### PR TITLE
simplification: reduce function complexity in compare-models-helper.sh

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -761,6 +761,120 @@ _clamp_score() {
 	return 0
 }
 
+# Return the scoring instructions block appended to judge prompts.
+_judge_scoring_instructions() {
+	cat <<'INSTRUCTIONS'
+
+SCORING INSTRUCTIONS:
+Score each model on these criteria (1-10 scale):
+- correctness: Factual accuracy and technical correctness
+- completeness: Coverage of all requirements and edge cases
+- quality: Code quality, best practices, maintainability
+- clarity: Clear explanation, good formatting, readability
+- adherence: Following the original prompt instructions precisely
+
+Respond with ONLY a valid JSON object in this exact format (no markdown, no explanation):
+{
+  "task_type": "general",
+  "winner": "<model_tier_of_best_response>",
+  "reasoning": "<one sentence explaining the winner>",
+  "scores": {
+    "<model_tier>": {
+      "correctness": <1-10>,
+      "completeness": <1-10>,
+      "quality": <1-10>,
+      "clarity": <1-10>,
+      "adherence": <1-10>
+    }
+  }
+}
+INSTRUCTIONS
+	return 0
+}
+
+# Parse winner, task_type, and reasoning from judge JSON.
+# Outputs three lines: winner, task_type, reasoning.
+# Args: $1=judge_json $2=err_log
+_judge_parse_json_fields() {
+	local judge_json="$1"
+	local err_log="$2"
+	echo "$judge_json" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+r = d.get('reasoning', '')[:500]
+r = ''.join(c for c in r if c.isprintable() or c in (' ', '\t'))
+print(d.get('winner', ''))
+print(d.get('task_type', 'general'))
+print(r)
+" 2>>"$err_log" || true
+	return 0
+}
+
+# Sanitize task_type against known allowlist; echoes validated value.
+# Args: $1=task_type
+_judge_validate_task_type() {
+	local task_type="$1"
+	local -a valid_task_types=(general code review analysis debug refactor test docs security)
+	local vt
+	for vt in "${valid_task_types[@]}"; do
+		if [[ "$task_type" == "$vt" ]]; then
+			echo "$task_type"
+			return 0
+		fi
+	done
+	echo "general"
+	return 0
+}
+
+# Sanitize winner against models_with_output list; echoes validated value or empty.
+# Args: $1=winner $2+=models_with_output
+_judge_validate_winner() {
+	local winner="$1"
+	shift
+	local -a models_with_output=("$@")
+	if [[ -z "$winner" ]]; then
+		return 0
+	fi
+	local m
+	for m in "${models_with_output[@]}"; do
+		if [[ "$winner" == "$m" ]]; then
+			echo "$winner"
+			return 0
+		fi
+	done
+	print_warning "Judge returned unknown winner '${winner}' — ignoring"
+	return 0
+}
+
+# Append per-model score args to score_args array from judge JSON.
+# Args: $1=judge_json $2=err_log $3+=models_with_output
+# Outputs one line per model: "--model M --correctness C ..."
+_judge_build_score_args() {
+	local judge_json="$1"
+	local err_log="$2"
+	shift 2
+	local -a models_with_output=("$@")
+	local model_tier
+	for model_tier in "${models_with_output[@]}"; do
+		local scores_line
+		scores_line=$(echo "$judge_json" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+s = d.get('scores', {}).get('${model_tier}', {})
+print(s.get('correctness', 0), s.get('completeness', 0), s.get('quality', 0), s.get('clarity', 0), s.get('adherence', 0))
+" 2>>"$err_log" || echo "0 0 0 0 0")
+		local corr comp qual clar adhr
+		read -r corr comp qual clar adhr <<<"$scores_line"
+		corr=$(_clamp_score "$corr")
+		comp=$(_clamp_score "$comp")
+		qual=$(_clamp_score "$qual")
+		clar=$(_clamp_score "$clar")
+		adhr=$(_clamp_score "$adhr")
+		echo "--model ${model_tier} --correctness ${corr} --completeness ${comp} --quality ${qual} --clarity ${clar} --adherence ${adhr}"
+	done
+	return 0
+}
+
 # Judge scoring for cross-review (t1329)
 # Dispatches all model outputs to a judge model, parses structured JSON scores,
 # records results via cmd_score, and feeds into the pattern tracker.
@@ -774,145 +888,21 @@ _clamp_score() {
 #   $5 - prompt_version (may be empty)
 #   $6 - prompt_file (may be empty)
 #   $7+ - model_names array
-_cross_review_judge_score() {
-	local original_prompt="$1"
-	local models_str="$2"
-	local output_dir="$3"
-	local judge_model="$4"
-	local prompt_version="$5"
-	local prompt_file="$6"
-	shift 6
-	local -a model_names=("$@")
+# Record judge scores: parse JSON, build score_args, call cmd_score.
+# Args: $1=judge_json $2=judge_err_log $3=original_prompt $4=task_type $5=winner
+#       $6=judge_model $7=prompt_version $8=prompt_file $9+=models_with_output
+_judge_record_scores() {
+	local judge_json="$1"
+	local judge_err_log="$2"
+	local original_prompt="$3"
+	local task_type="$4"
+	local winner="$5"
+	local judge_model="$6"
+	local prompt_version="$7"
+	local prompt_file="$8"
+	shift 8
+	local -a models_with_output=("$@")
 
-	# Validate judge_model identifier (used in filenames and runner names)
-	if [[ ! "$judge_model" =~ ^[A-Za-z0-9._-]+$ ]]; then
-		print_error "Invalid judge model identifier: $judge_model"
-		return 1
-	fi
-
-	local runner_helper="${SCRIPT_DIR}/runner-helper.sh"
-	if [[ ! -x "$runner_helper" ]]; then
-		print_warning "runner-helper.sh not found — skipping judge scoring"
-		return 0
-	fi
-
-	echo "=== JUDGE SCORING (${judge_model}) ==="
-	echo ""
-
-	# Build judge prompt: include original prompt + all model responses
-	local max_chars_per_model=20000
-	local judge_prompt
-	judge_prompt=$(_judge_build_prompt "$output_dir" "$max_chars_per_model" "$original_prompt" "${model_names[@]}")
-
-	# Extract models_with_output from the prompt (models that had output files)
-	local -a models_with_output=()
-	for model_tier in "${model_names[@]}"; do
-		local result_file="${output_dir}/${model_tier}.txt"
-		if [[ -f "$result_file" && -s "$result_file" ]]; then
-			models_with_output+=("$model_tier")
-		fi
-	done
-
-	if [[ ${#models_with_output[@]} -lt 2 ]]; then
-		print_warning "Not enough model outputs for judge scoring (need 2+)"
-		return 0
-	fi
-
-	judge_prompt+="
-SCORING INSTRUCTIONS:
-Score each model on these criteria (1-10 scale):
-- correctness: Factual accuracy and technical correctness
-- completeness: Coverage of all requirements and edge cases
-- quality: Code quality, best practices, maintainability
-- clarity: Clear explanation, good formatting, readability
-- adherence: Following the original prompt instructions precisely
-
-Respond with ONLY a valid JSON object in this exact format (no markdown, no explanation):
-{
-  \"task_type\": \"general\",
-  \"winner\": \"<model_tier_of_best_response>\",
-  \"reasoning\": \"<one sentence explaining the winner>\",
-  \"scores\": {
-    \"<model_tier>\": {
-      \"correctness\": <1-10>,
-      \"completeness\": <1-10>,
-      \"quality\": <1-10>,
-      \"clarity\": <1-10>,
-      \"adherence\": <1-10>
-    }
-  }
-}"
-
-	# Sanitize judge_model before using in filenames/runner names
-	if [[ ! "$judge_model" =~ ^[A-Za-z0-9._-]+$ ]]; then
-		print_warning "Invalid judge model identifier: $judge_model — skipping scoring"
-		return 0
-	fi
-
-	# Dispatch to judge model and extract JSON
-	local judge_json
-	judge_json=$(_judge_dispatch "$judge_model" "$judge_prompt" "$output_dir") || {
-		print_warning "Could not parse judge JSON output. Check ${output_dir}/judge-errors.log"
-		return 0
-	}
-
-	# Parse winner, task_type, and reasoning in a single Python call
-	local parsed_fields
-	parsed_fields=$(echo "$judge_json" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-# Truncate reasoning to 500 chars and strip control characters
-r = d.get('reasoning', '')[:500]
-r = ''.join(c for c in r if c.isprintable() or c in (' ', '\t'))
-print(d.get('winner', ''))
-print(d.get('task_type', 'general'))
-print(r)
-" 2>>"$judge_err_log" || true)
-
-	local winner task_type reasoning
-	if [[ -n "$parsed_fields" ]]; then
-		winner=$(echo "$parsed_fields" | head -1)
-		task_type=$(echo "$parsed_fields" | sed -n '2p')
-		reasoning=$(echo "$parsed_fields" | sed -n '3p')
-	else
-		winner=""
-		task_type="general"
-		reasoning=""
-	fi
-
-	# Sanitize task_type: restrict to known allowlist
-	local -a valid_task_types=(general code review analysis debug refactor test docs security)
-	local task_type_valid=false
-	for vt in "${valid_task_types[@]}"; do
-		if [[ "$task_type" == "$vt" ]]; then
-			task_type_valid=true
-			break
-		fi
-	done
-	if [[ "$task_type_valid" != "true" ]]; then
-		task_type="general"
-	fi
-
-	# Sanitize winner: must be one of the models with output
-	local winner_valid=false
-	if [[ -n "$winner" ]]; then
-		for m in "${models_with_output[@]}"; do
-			if [[ "$winner" == "$m" ]]; then
-				winner_valid=true
-				break
-			fi
-		done
-		if [[ "$winner_valid" != "true" ]]; then
-			print_warning "Judge returned unknown winner '${winner}' — ignoring"
-			winner=""
-		fi
-	fi
-
-	echo "  Judge winner: ${winner:-unknown}"
-	[[ -n "$reasoning" ]] && echo "  Reasoning: ${reasoning}"
-	echo ""
-
-	# Build cmd_score arguments from judge JSON
 	local -a score_args=(
 		--task "$original_prompt"
 		--type "$task_type"
@@ -922,41 +912,89 @@ print(r)
 	[[ -n "$prompt_version" ]] && score_args+=(--prompt-version "$prompt_version")
 	[[ -n "$prompt_file" ]] && score_args+=(--prompt-file "$prompt_file")
 
-	for model_tier in "${models_with_output[@]}"; do
-		# Extract all scores in a single Python call (avoids 5 subprocesses per model)
-		local scores_line
-		scores_line=$(echo "$judge_json" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-s = d.get('scores', {}).get('${model_tier}', {})
-print(s.get('correctness', 0), s.get('completeness', 0), s.get('quality', 0), s.get('clarity', 0), s.get('adherence', 0))
-" 2>>"$judge_err_log" || echo "0 0 0 0 0")
-		local corr comp qual clar adhr
-		read -r corr comp qual clar adhr <<<"$scores_line"
+	local score_line
+	while IFS= read -r score_line; do
+		[[ -z "$score_line" ]] && continue
+		# shellcheck disable=SC2206
+		local -a line_args=($score_line)
+		score_args+=("${line_args[@]}")
+	done < <(_judge_build_score_args "$judge_json" "$judge_err_log" "${models_with_output[@]}")
 
-		# Clamp all scores to valid integer range 0-10
-		corr=$(_clamp_score "$corr")
-		comp=$(_clamp_score "$comp")
-		qual=$(_clamp_score "$qual")
-		clar=$(_clamp_score "$clar")
-		adhr=$(_clamp_score "$adhr")
-
-		score_args+=(
-			--model "$model_tier"
-			--correctness "$corr"
-			--completeness "$comp"
-			--quality "$qual"
-			--clarity "$clar"
-			--adherence "$adhr"
-		)
-	done
-
-	# Record scores via cmd_score (also syncs to pattern tracker)
 	cmd_score "${score_args[@]}"
+	return 0
+}
+
+_cross_review_judge_score() {
+	local original_prompt="$1"
+	local models_str="$2"
+	local output_dir="$3"
+	local judge_model="$4"
+	local prompt_version="$5"
+	local prompt_file="$6"
+	shift 6
+	local -a model_names=("$@")
+	local judge_err_log="${output_dir}/judge-errors.log"
+	local judge_output_file="${output_dir}/judge-${judge_model}.json"
+
+	if [[ ! "$judge_model" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		print_error "Invalid judge model identifier: $judge_model"
+		return 1
+	fi
+	if [[ ! -x "${SCRIPT_DIR}/runner-helper.sh" ]]; then
+		print_warning "runner-helper.sh not found — skipping judge scoring"
+		return 0
+	fi
+
+	echo "=== JUDGE SCORING (${judge_model}) ==="
+	echo ""
+
+	# Build judge prompt from model outputs
+	local judge_prompt
+	judge_prompt=$(_judge_build_prompt "$output_dir" "20000" "$original_prompt" "${model_names[@]}")
+
+	# Collect models that produced output
+	local -a models_with_output=()
+	local model_tier
+	for model_tier in "${model_names[@]}"; do
+		[[ -f "${output_dir}/${model_tier}.txt" && -s "${output_dir}/${model_tier}.txt" ]] &&
+			models_with_output+=("$model_tier")
+	done
+	if [[ ${#models_with_output[@]} -lt 2 ]]; then
+		print_warning "Not enough model outputs for judge scoring (need 2+)"
+		return 0
+	fi
+
+	judge_prompt+=$(_judge_scoring_instructions)
+
+	local judge_json
+	judge_json=$(_judge_dispatch "$judge_model" "$judge_prompt" "$output_dir") || {
+		print_warning "Could not parse judge JSON output. Check ${output_dir}/judge-errors.log"
+		return 0
+	}
+
+	# Parse and sanitize winner/task_type/reasoning
+	local parsed_fields winner task_type reasoning
+	parsed_fields=$(_judge_parse_json_fields "$judge_json" "$judge_err_log")
+	if [[ -n "$parsed_fields" ]]; then
+		winner=$(echo "$parsed_fields" | head -1)
+		task_type=$(echo "$parsed_fields" | sed -n '2p')
+		reasoning=$(echo "$parsed_fields" | sed -n '3p')
+	else
+		winner="" task_type="general" reasoning=""
+	fi
+	task_type=$(_judge_validate_task_type "$task_type")
+	winner=$(_judge_validate_winner "$winner" "${models_with_output[@]}")
+
+	echo "  Judge winner: ${winner:-unknown}"
+	[[ -n "$reasoning" ]] && echo "  Reasoning: ${reasoning}"
+	echo ""
+
+	_judge_record_scores "$judge_json" "$judge_err_log" "$original_prompt" \
+		"$task_type" "$winner" "$judge_model" "$prompt_version" "$prompt_file" \
+		"${models_with_output[@]}"
 
 	echo "Judge scores recorded. Judge output: $judge_output_file"
 	echo ""
-
 	return 0
 }
 
@@ -1103,6 +1141,67 @@ _cross_review_show_diff() {
 	return 0
 }
 
+# Dispatch one model in a subshell for cross-review; writes result to output_dir.
+# Args: $1=runner_helper $2=runner_name $3=model_tier $4=prompt $5=review_timeout $6=workdir $7=output_dir
+_cross_review_dispatch_one() {
+	local runner_helper="$1"
+	local runner_name="$2"
+	local model_tier="$3"
+	local prompt="$4"
+	local review_timeout="$5"
+	local workdir="$6"
+	local output_dir="$7"
+	local model_err_log="${output_dir}/${model_tier}-errors.log"
+	local result_file="${output_dir}/${model_tier}.txt"
+	local model_failed=0
+
+	"$runner_helper" create "$runner_name" \
+		--model "$model_tier" \
+		--description "Cross-review: $model_tier" \
+		--workdir "$workdir" 2>>"$model_err_log" || model_failed=1
+
+	"$runner_helper" run "$runner_name" "$prompt" \
+		--model "$model_tier" \
+		--timeout "$review_timeout" \
+		--format json 2>>"$model_err_log" >"${output_dir}/${model_tier}.json" || model_failed=1
+
+	# Extract text response from JSON
+	if [[ -f "${output_dir}/${model_tier}.json" ]]; then
+		jq -r '.parts[]? | select(.type == "text") | .text' \
+			"${output_dir}/${model_tier}.json" 2>>"$model_err_log" >"$result_file" || model_failed=1
+	fi
+
+	# Clean up runner (always attempt cleanup, even on failure)
+	"$runner_helper" destroy "$runner_name" --force 2>>"$model_err_log" || true
+
+	# Fail if no usable output was produced
+	[[ -s "$result_file" ]] || model_failed=1
+	return "$model_failed"
+}
+
+# Wait for parallel pids and report per-model status.
+# Args: $1=output_dir; remaining args alternate: pid model_name ...
+# Outputs count of failures to stdout as last line "failed=N".
+_cross_review_wait_results() {
+	local output_dir="$1"
+	shift
+	local failed=0
+	while [[ $# -ge 2 ]]; do
+		local pid="$1"
+		local model_name="$2"
+		shift 2
+		if ! wait "$pid" 2>/dev/null; then
+			local err_log="${output_dir}/${model_name}-errors.log"
+			echo "  ${model_name}: failed (see ${err_log})"
+			failed=$((failed + 1))
+		else
+			echo "  ${model_name}: done"
+		fi
+	done
+	echo "failed=${failed}"
+	return 0
+}
+
 cmd_cross_review() {
 	local prompt="" models_str="" workdir="" review_timeout="600" output_dir=""
 	local score_flag=false judge_model="opus"
@@ -1118,20 +1217,12 @@ cmd_cross_review() {
 	fi
 
 	# Default models: sonnet + opus (Anthropic second opinion)
-	if [[ -z "$models_str" ]]; then
-		models_str="sonnet,opus"
-	fi
+	[[ -z "$models_str" ]] && models_str="sonnet,opus"
 
-	# Set up output directory
-	if [[ -z "$output_dir" ]]; then
-		output_dir="${HOME}/.aidevops/.agent-workspace/tmp/cross-review-$(date +%Y%m%d%H%M%S)"
-	fi
+	# Set up output directory and workdir
+	[[ -z "$output_dir" ]] && output_dir="${HOME}/.aidevops/.agent-workspace/tmp/cross-review-$(date +%Y%m%d%H%M%S)"
 	mkdir -p "$output_dir"
-
-	# Set workdir
-	if [[ -z "$workdir" ]]; then
-		workdir="$(pwd)"
-	fi
+	[[ -z "$workdir" ]] && workdir="$(pwd)"
 
 	local runner_helper="${SCRIPT_DIR}/runner-helper.sh"
 	if [[ ! -x "$runner_helper" ]]; then
@@ -1139,10 +1230,9 @@ cmd_cross_review() {
 		return 1
 	fi
 
-	# Parse models list
+	# Parse and validate models list
 	local -a model_array=()
 	IFS=',' read -ra model_array <<<"$models_str"
-
 	if [[ ${#model_array[@]} -lt 2 ]]; then
 		print_error "At least 2 models required for cross-review (got ${#model_array[@]})"
 		return 1
@@ -1156,81 +1246,14 @@ cmd_cross_review() {
 	echo "Timeout: ${review_timeout}s per model"
 	echo ""
 
-	# Create temporary runners for each model and dispatch in parallel
-	local -a pids=()
-	local -a runner_names=()
+	# Dispatch all models in parallel and wait
 	local -a model_names=()
-
-	for model_tier in "${model_array[@]}"; do
-		model_tier="${model_tier// /}"
-		[[ -z "$model_tier" ]] && continue
-
-		# Sanitize model identifier to prevent path traversal (reject chars outside safe set)
-		if [[ ! "$model_tier" =~ ^[A-Za-z0-9._-]+$ ]]; then
-			print_warning "Skipping invalid model identifier: $model_tier"
-			continue
-		fi
-
-		local runner_name="cross-review-${model_tier}-$$"
-		runner_names+=("$runner_name")
-		model_names+=("$model_tier")
-
-		# Resolve tier to full model string for display
-		local resolved_model
-		resolved_model=$(resolve_model_tier "$model_tier")
-
-		echo "  Dispatching to ${model_tier} (${resolved_model})..."
-
-		# Create runner, dispatch, capture output (errors logged per-model for debugging)
-		local model_err_log="${output_dir}/${model_tier}-errors.log"
-		(
-			local model_failed=0
-
-			"$runner_helper" create "$runner_name" \
-				--model "$model_tier" \
-				--description "Cross-review: $model_tier" \
-				--workdir "$workdir" 2>>"$model_err_log" || model_failed=1
-
-			local result_file="${output_dir}/${model_tier}.txt"
-			"$runner_helper" run "$runner_name" "$prompt" \
-				--model "$model_tier" \
-				--timeout "$review_timeout" \
-				--format json 2>>"$model_err_log" >"${output_dir}/${model_tier}.json" || model_failed=1
-
-			# Extract text response from JSON
-			if [[ -f "${output_dir}/${model_tier}.json" ]]; then
-				jq -r '.parts[]? | select(.type == "text") | .text' \
-					"${output_dir}/${model_tier}.json" 2>>"$model_err_log" >"$result_file" || model_failed=1
-			fi
-
-			# Clean up runner (always attempt cleanup, even on failure)
-			"$runner_helper" destroy "$runner_name" --force 2>>"$model_err_log" || true
-
-			# Fail if no usable output was produced
-			[[ -s "$result_file" ]] || model_failed=1
-			exit "$model_failed"
-		) &
-		pids+=($!)
-	done
-
-	# Wait for all dispatches to complete
-	echo ""
-	echo "Waiting for ${#pids[@]} models to respond..."
-	local failed=0
-	for i in "${!pids[@]}"; do
-		if ! wait "${pids[$i]}" 2>/dev/null; then
-			local err_log="${output_dir}/${model_names[$i]}-errors.log"
-			echo "  ${model_names[$i]}: failed (see ${err_log})"
-			failed=$((failed + 1))
-		else
-			echo "  ${model_names[$i]}: done"
-		fi
-	done
-
-	echo ""
+	_cross_review_dispatch_all "$runner_helper" "$prompt" "$review_timeout" \
+		"$workdir" "$output_dir" model_names "${model_array[@]}"
 
 	# Collect and display results
 	local results_found=0
+	local model_tier
 	for model_tier in "${model_names[@]}"; do
 		local result_file="${output_dir}/${model_tier}.txt"
 		if [[ -f "$result_file" && -s "$result_file" ]]; then
@@ -1250,26 +1273,69 @@ cmd_cross_review() {
 		return 1
 	fi
 
-	# Generate diff summary if we have 2+ results
+	# Generate diff summary
 	echo "=== DIFF SUMMARY ==="
 	echo ""
 	echo "Models compared: ${models_str}"
 	echo "Results: ${results_found}/${#model_names[@]} successful"
 	echo ""
-
 	_cross_review_show_diff "$output_dir" "${model_names[@]}"
-
 	echo "Full results saved to: $output_dir"
 	echo ""
 
 	# Judge scoring pipeline (t1329)
-	# When --score is set, dispatch all outputs to a judge model for structured scoring.
 	if [[ "$score_flag" == "true" ]]; then
 		_cross_review_judge_score \
 			"$prompt" "$models_str" "$output_dir" "$judge_model" \
 			"$prompt_version" "$prompt_file" "${model_names[@]}"
 	fi
 
+	return 0
+}
+
+# Dispatch all models in parallel and wait for completion.
+# Populates the nameref array with validated model names.
+# Args: $1=runner_helper $2=prompt $3=timeout $4=workdir $5=output_dir $6=nameref_array $7+=model_array
+_cross_review_dispatch_all() {
+	local runner_helper="$1"
+	local prompt="$2"
+	local review_timeout="$3"
+	local workdir="$4"
+	local output_dir="$5"
+	local -n _da_model_names="$6"
+	shift 6
+	local -a model_array=("$@")
+
+	local -a pids=()
+	local model_tier
+	for model_tier in "${model_array[@]}"; do
+		model_tier="${model_tier// /}"
+		[[ -z "$model_tier" ]] && continue
+		if [[ ! "$model_tier" =~ ^[A-Za-z0-9._-]+$ ]]; then
+			print_warning "Skipping invalid model identifier: $model_tier"
+			continue
+		fi
+		local runner_name="cross-review-${model_tier}-$$"
+		_da_model_names+=("$model_tier")
+		local resolved_model
+		resolved_model=$(resolve_model_tier "$model_tier")
+		echo "  Dispatching to ${model_tier} (${resolved_model})..."
+		_cross_review_dispatch_one "$runner_helper" "$runner_name" "$model_tier" \
+			"$prompt" "$review_timeout" "$workdir" "$output_dir" &
+		pids+=($!)
+	done
+
+	echo ""
+	echo "Waiting for ${#pids[@]} models to respond..."
+	local wait_args=()
+	local i
+	for i in "${!pids[@]}"; do
+		wait_args+=("${pids[$i]}" "${_da_model_names[$i]}")
+	done
+	local wait_output
+	wait_output=$(_cross_review_wait_results "$output_dir" "${wait_args[@]}")
+	echo "$wait_output" | grep -v '^failed='
+	echo ""
 	return 0
 }
 
@@ -1639,10 +1705,82 @@ _discover_check_provider() {
 	return 1
 }
 
+# Scan all providers and print/collect status.
+# Args: $1=probe_flag $2=list_flag $3=json_flag
+# Outputs: "total|available|models" on last line for caller to parse.
+_discover_scan_providers() {
+	local probe_flag="$1"
+	local list_flag="$2"
+	local json_flag="$3"
+
+	local total_providers=0
+	local available_providers=0
+	local available_models=0
+	local -a json_entries=()
+
+	while IFS= read -r line; do
+		local provider
+		provider=$(echo "$line" | cut -d'|' -f1)
+		total_providers=$((total_providers + 1))
+		local found=false source="" active_key=""
+		_discover_check_provider "$provider" found source active_key
+
+		if [[ "$found" == "true" ]]; then
+			available_providers=$((available_providers + 1))
+			local status="configured" status_icon="Y"
+			if [[ "$probe_flag" == "true" ]]; then
+				if probe_provider "$provider" "$active_key"; then
+					status="verified"
+					status_icon="V"
+				else
+					status="key-invalid"
+					status_icon="!"
+				fi
+			fi
+			local model_count
+			model_count=$(echo "$MODEL_DATA" | grep -c "|${provider}|" || true)
+			available_models=$((available_models + model_count))
+			if [[ "$json_flag" == "true" ]]; then
+				json_entries+=("{\"provider\":\"${provider}\",\"status\":\"${status}\",\"source\":\"${source}\",\"models\":${model_count}}")
+			else
+				printf "  %s %-12s  %-12s  (source: %s, %d tracked models)\n" \
+					"$status_icon" "$provider" "$status" "$source" "$model_count"
+			fi
+			if [[ "$list_flag" == "true" && "$status" == "verified" ]]; then
+				local live_models
+				live_models=$(list_provider_models "$provider" "$active_key" 2>/dev/null)
+				if [[ -n "$live_models" ]]; then
+					local live_count
+					live_count=$(echo "$live_models" | wc -l | tr -d ' ')
+					echo "    Live models ($live_count):"
+					echo "$live_models" | head -20 | while IFS= read -r m; do
+						echo "      - $m"
+					done
+					local remaining=$((live_count - 20))
+					[[ "$remaining" -gt 0 ]] && echo "      ... and $remaining more"
+				fi
+			fi
+		else
+			if [[ "$json_flag" == "true" ]]; then
+				json_entries+=("{\"provider\":\"${provider}\",\"status\":\"not-configured\",\"source\":null,\"models\":0}")
+			else
+				printf "  - %-12s  not configured\n" "$provider"
+			fi
+		fi
+	done <<<"$PROVIDER_ENV_KEYS"
+
+	if [[ "$json_flag" == "true" ]]; then
+		echo "[$(
+			IFS=,
+			echo "${json_entries[*]}"
+		)]"
+	fi
+	echo "counts=${total_providers}|${available_providers}|${available_models}"
+	return 0
+}
+
 cmd_discover() {
-	local probe_flag=false
-	local list_flag=false
-	local json_flag=false
+	local probe_flag=false list_flag=false json_flag=false
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -1668,141 +1806,76 @@ cmd_discover() {
 	echo "========================"
 	echo ""
 
-	local total_providers=0
-	local available_providers=0
-	local available_models=0
-	local json_entries=()
+	local scan_output counts_line
+	scan_output=$(_discover_scan_providers "$probe_flag" "$list_flag" "$json_flag")
+	counts_line=$(echo "$scan_output" | grep '^counts=')
+	echo "$scan_output" | grep -v '^counts='
 
-	while IFS= read -r line; do
-		local provider
-		provider=$(echo "$line" | cut -d'|' -f1)
-
-		total_providers=$((total_providers + 1))
-		local found=false source="" active_key=""
-
-		# Check if provider is available
-		_discover_check_provider "$provider" found source active_key
-
-		if [[ "$found" == "true" ]]; then
-			available_providers=$((available_providers + 1))
-			local status="configured"
-			local status_icon="Y"
-
-			# Optionally probe the API
-			if [[ "$probe_flag" == "true" ]]; then
-				if probe_provider "$provider" "$active_key"; then
-					status="verified"
-					status_icon="V"
-				else
-					status="key-invalid"
-					status_icon="!"
-				fi
-			fi
-
-			# Count models from embedded database for this provider
-			local model_count
-			model_count=$(echo "$MODEL_DATA" | grep -c "|${provider}|" || true)
-			available_models=$((available_models + model_count))
-
-			if [[ "$json_flag" == "true" ]]; then
-				json_entries+=("{\"provider\":\"${provider}\",\"status\":\"${status}\",\"source\":\"${source}\",\"models\":${model_count}}")
-			else
-				printf "  %s %-12s  %-12s  (source: %s, %d tracked models)\n" \
-					"$status_icon" "$provider" "$status" "$source" "$model_count"
-			fi
-
-			# Optionally list live models from API
-			if [[ "$list_flag" == "true" && "$status" == "verified" ]]; then
-				local live_models
-				live_models=$(list_provider_models "$provider" "$active_key" 2>/dev/null)
-				if [[ -n "$live_models" ]]; then
-					local live_count
-					live_count=$(echo "$live_models" | wc -l | tr -d ' ')
-					echo "    Live models ($live_count):"
-					echo "$live_models" | head -20 | while IFS= read -r m; do
-						echo "      - $m"
-					done
-					local remaining=$((live_count - 20))
-					if [[ "$remaining" -gt 0 ]]; then
-						echo "      ... and $remaining more"
-					fi
-				fi
-			fi
-		else
-			if [[ "$json_flag" == "true" ]]; then
-				json_entries+=("{\"provider\":\"${provider}\",\"status\":\"not-configured\",\"source\":null,\"models\":0}")
-			else
-				printf "  - %-12s  not configured\n" "$provider"
-			fi
-		fi
-	done <<<"$PROVIDER_ENV_KEYS"
-
-	if [[ "$json_flag" == "true" ]]; then
-		echo "[$(
-			IFS=,
-			echo "${json_entries[*]}"
-		)]"
-	else
+	if [[ "$json_flag" != "true" ]]; then
+		local total_providers available_providers available_models
+		IFS='|' read -r total_providers available_providers available_models \
+			<<<"${counts_line#counts=}"
 		echo ""
 		echo "Summary: $available_providers/$total_providers providers configured, $available_models tracked models available"
 		echo ""
-
 		if [[ "$probe_flag" != "true" ]]; then
 			echo "Tip: Use --probe to verify API keys are valid"
 			echo "     Use --list-models to enumerate live models from each provider"
 		fi
-
-		# Show models grouped by availability
-		echo ""
-		echo "Available Models (from configured providers):"
-		echo ""
-		printf "  %-22s %-10s %-8s %-12s %-12s %-7s\n" \
-			"Model" "Provider" "Context" "Input/1M" "Output/1M" "Tier"
-		printf "  %-22s %-10s %-8s %-12s %-12s %-7s\n" \
-			"-----" "--------" "-------" "--------" "---------" "----"
-
-		echo "$MODEL_DATA" | while IFS= read -r model_line; do
-			local model_provider
-			model_provider=$(get_field "$model_line" 2)
-
-			# Check if this provider is available
-			local provider_available=false dummy1 dummy2
-			_discover_check_provider "$model_provider" provider_available dummy1 dummy2
-
-			if [[ "$provider_available" == "true" ]]; then
-				local mid mctx minput moutput mtier
-				mid=$(get_field "$model_line" 1)
-				mctx=$(get_field "$model_line" 4)
-				minput=$(get_field "$model_line" 5)
-				moutput=$(get_field "$model_line" 6)
-				mtier=$(get_field "$model_line" 7)
-				local ctx_fmt
-				ctx_fmt=$(format_context "$mctx")
-				printf "  %-22s %-10s %-8s %-12s %-12s %-7s\n" \
-					"$mid" "$model_provider" "$ctx_fmt" "\$$minput" "\$$moutput" "$mtier"
-			fi
-		done
-
-		echo ""
-		echo "Unavailable Models (provider not configured):"
-		echo ""
-
-		echo "$MODEL_DATA" | while IFS= read -r model_line; do
-			local model_provider
-			model_provider=$(get_field "$model_line" 2)
-
-			local provider_available=false dummy1 dummy2
-			_discover_check_provider "$model_provider" provider_available dummy1 dummy2
-
-			if [[ "$provider_available" != "true" ]]; then
-				local mid
-				mid=$(get_field "$model_line" 1)
-				echo "  - $mid ($model_provider)"
-			fi
-		done
+		_discover_print_available_models
+		_discover_print_unavailable_models
 	fi
 
 	echo ""
+	return 0
+}
+
+# Print table of models from configured providers.
+_discover_print_available_models() {
+	echo ""
+	echo "Available Models (from configured providers):"
+	echo ""
+	printf "  %-22s %-10s %-8s %-12s %-12s %-7s\n" \
+		"Model" "Provider" "Context" "Input/1M" "Output/1M" "Tier"
+	printf "  %-22s %-10s %-8s %-12s %-12s %-7s\n" \
+		"-----" "--------" "-------" "--------" "---------" "----"
+
+	echo "$MODEL_DATA" | while IFS= read -r model_line; do
+		local model_provider
+		model_provider=$(get_field "$model_line" 2)
+		local provider_available=false dummy1 dummy2
+		_discover_check_provider "$model_provider" provider_available dummy1 dummy2
+		if [[ "$provider_available" == "true" ]]; then
+			local mid mctx minput moutput mtier ctx_fmt
+			mid=$(get_field "$model_line" 1)
+			mctx=$(get_field "$model_line" 4)
+			minput=$(get_field "$model_line" 5)
+			moutput=$(get_field "$model_line" 6)
+			mtier=$(get_field "$model_line" 7)
+			ctx_fmt=$(format_context "$mctx")
+			printf "  %-22s %-10s %-8s %-12s %-12s %-7s\n" \
+				"$mid" "$model_provider" "$ctx_fmt" "\$$minput" "\$$moutput" "$mtier"
+		fi
+	done
+	return 0
+}
+
+# Print list of models from unconfigured providers.
+_discover_print_unavailable_models() {
+	echo ""
+	echo "Unavailable Models (provider not configured):"
+	echo ""
+	echo "$MODEL_DATA" | while IFS= read -r model_line; do
+		local model_provider
+		model_provider=$(get_field "$model_line" 2)
+		local provider_available=false dummy1 dummy2
+		_discover_check_provider "$model_provider" provider_available dummy1 dummy2
+		if [[ "$provider_available" != "true" ]]; then
+			local mid
+			mid=$(get_field "$model_line" 1)
+			echo "  - $mid ($model_provider)"
+		fi
+	done
 	return 0
 }
 
@@ -2054,21 +2127,50 @@ cmd_score() {
 		prompt_version=$(git log -1 --format='%h' -- "$prompt_file" 2>/dev/null) || prompt_version=""
 	fi
 
-	# Insert comparison record (escape all string values for SQL safety)
-	local comp_id safe_task safe_type safe_eval safe_winner safe_pv safe_pf
+	# Insert comparison + scores into DB
+	local comp_id
+	comp_id=$(_score_insert_comparison "$task" "$task_type" "$evaluator" "$winner" \
+		"$prompt_version" "$prompt_file" "${model_entries[@]}") || return 1
+
+	print_success "Comparison #$comp_id recorded ($task_type: ${#model_entries[@]} models scored)"
+
+	# Display summary table
+	_score_display_table "$winner" "${model_entries[@]}"
+
+	# Sync to unified pattern tracker backbone (t1094)
+	_score_sync_pattern_tracker "$task_type" "${model_entries[@]}"
+
+	return 0
+}
+
+# Insert a comparison record and its per-model scores into RESULTS_DB.
+# Echoes the new comparison ID on success.
+# Args: $1=task $2=task_type $3=evaluator $4=winner $5=prompt_version $6=prompt_file $7+=model_entries
+_score_insert_comparison() {
+	local task="$1"
+	local task_type="$2"
+	local evaluator="$3"
+	local winner="$4"
+	local prompt_version="$5"
+	local prompt_file="$6"
+	shift 6
+	local -a model_entries=("$@")
+
+	local safe_task safe_type safe_eval safe_winner safe_pv safe_pf
 	safe_task="${task//\'/\'\'}"
 	safe_type="${task_type//\'/\'\'}"
 	safe_eval="${evaluator//\'/\'\'}"
 	safe_winner="${winner//\'/\'\'}"
 	safe_pv="${prompt_version//\'/\'\'}"
 	safe_pf="${prompt_file//\'/\'\'}"
+	local comp_id
 	comp_id=$(sqlite3 "$RESULTS_DB" "INSERT INTO comparisons (task_description, task_type, evaluator_model, winner_model, prompt_version, prompt_file) VALUES ('${safe_task}', '${safe_type}', '${safe_eval}', '${safe_winner}', '${safe_pv}', '${safe_pf}'); SELECT last_insert_rowid();")
 
-	# Insert scores for each model (escape strings, validate numerics)
+	local entry
 	for entry in "${model_entries[@]}"; do
 		IFS='|' read -r m_id m_cor m_com m_qua m_cla m_adh m_ove m_lat m_tok m_str m_wea m_res <<<"$entry"
-
 		# Validate all numeric fields — reject non-integer values to prevent SQL injection
+		local n
 		for n in m_cor m_com m_qua m_cla m_adh m_ove m_lat m_tok; do
 			if ! [[ "${!n}" =~ ^[0-9]+$ ]]; then
 				print_error "Invalid numeric value for ${n}: ${!n}"
@@ -2076,12 +2178,12 @@ cmd_score() {
 			fi
 		done
 		# Clamp score fields to valid 0-10 range
+		local s
 		for s in m_cor m_com m_qua m_cla m_adh m_ove; do
 			if ((${!s} > 10)); then
 				printf -v "$s" "10"
 			fi
 		done
-
 		local safe_id="${m_id//\'/\'\'}"
 		local safe_str="${m_str//\'/\'\'}"
 		local safe_wea="${m_wea//\'/\'\'}"
@@ -2089,15 +2191,24 @@ cmd_score() {
 		sqlite3 "$RESULTS_DB" "INSERT INTO comparison_scores (comparison_id, model_id, correctness, completeness, code_quality, clarity, adherence, overall, latency_ms, tokens_used, strengths, weaknesses, response_file) VALUES ($comp_id, '${safe_id}', $m_cor, $m_com, $m_qua, $m_cla, $m_adh, $m_ove, $m_lat, $m_tok, '${safe_str}', '${safe_wea}', '${safe_res}');"
 	done
 
-	print_success "Comparison #$comp_id recorded ($task_type: ${#model_entries[@]} models scored)"
+	echo "$comp_id"
+	return 0
+}
 
-	# Display summary table
+# Display a formatted score summary table for model_entries.
+# Args: $1=winner $2+=model_entries
+_score_display_table() {
+	local winner="$1"
+	shift
+	local -a model_entries=("$@")
+
 	echo ""
 	printf "%-22s %5s %5s %5s %5s %5s %7s %8s %6s\n" \
 		"Model" "Corr" "Comp" "Qual" "Clar" "Adhr" "Overall" "Latency" "Tokens"
 	printf "%-22s %5s %5s %5s %5s %5s %7s %8s %6s\n" \
 		"-----" "----" "----" "----" "----" "----" "-------" "-------" "------"
 
+	local entry
 	for entry in "${model_entries[@]}"; do
 		IFS='|' read -r m_id m_cor m_com m_qua m_cla m_adh m_ove m_lat m_tok _ _ _ <<<"$entry"
 		local lat_fmt="${m_lat}ms"
@@ -2112,10 +2223,6 @@ cmd_score() {
 		echo "  Winner: $winner"
 	fi
 	echo ""
-
-	# Sync to unified pattern tracker backbone (t1094)
-	_score_sync_pattern_tracker "$task_type" "${model_entries[@]}"
-
 	return 0
 }
 
@@ -3043,91 +3150,99 @@ cmd_bench() {
 	echo ""
 
 	local prompt_idx=0
+	local p
 	for p in "${prompts[@]}"; do
 		prompt_idx=$((prompt_idx + 1))
 		local prompt_label="Prompt"
-		if [[ ${#prompts[@]} -gt 1 ]]; then
-			prompt_label="Prompt ${prompt_idx}/${#prompts[@]}"
-		fi
-
-		# Truncate prompt for display
-		local display_prompt="${p:0:80}"
-		[[ ${#p} -gt 80 ]] && display_prompt="${display_prompt}..."
-		echo "${prompt_label}: ${display_prompt}"
-		echo ""
-
-		# Create temp directory for this prompt's results
-		local bench_dir
-		bench_dir=$(mktemp -d "${TMPDIR:-/tmp}/bench-XXXXXX")
-
-		# Run models in parallel
-		local -a pids=()
-		for m in "${valid_models[@]}"; do
-			echo "  Calling ${m}..."
-			_bench_call_model "$m" "$p" "$max_tokens" "$bench_dir" &
-			pids+=($!)
-		done
-
-		# Wait for all
-		for pid in "${pids[@]}"; do
-			wait "$pid" 2>/dev/null || true
-		done
-
-		# Collect judge scores if enabled
-		local judge_models=()
-		local judge_scores_vals=()
-		if [[ "$judge_flag" == true ]]; then
-			echo "  Scoring with judge (haiku)..."
-			local judge_output
-			judge_output=$(_bench_judge_score "$p" "$bench_dir")
-			while IFS='|' read -r jm js; do
-				[[ -z "$jm" ]] && continue
-				judge_models+=("$jm")
-				judge_scores_vals+=("$js")
-			done <<<"$judge_output"
-		fi
-
-		# Build and display results table
-		echo ""
-		_bench_display_results "$bench_dir" "$judge_flag" "${valid_models[@]}"
-
-		for m in "${valid_models[@]}"; do
-			local result_file="${bench_dir}/${m}.json"
-			[[ ! -f "$result_file" ]] && continue
-
-			local latency tokens_in tokens_out error_msg
-			latency=$(jq -r '.latency_ms // 0' "$result_file" 2>/dev/null || echo "0")
-			tokens_in=$(jq -r '.tokens_in // 0' "$result_file" 2>/dev/null || echo "0")
-			tokens_out=$(jq -r '.tokens_out // 0' "$result_file" 2>/dev/null || echo "0")
-			error_msg=$(jq -r '.error // ""' "$result_file" 2>/dev/null || echo "")
-
-			[[ -n "$error_msg" ]] && continue
-
-			local cost
-			cost=$(_calc_bench_cost "$m" "$tokens_in" "$tokens_out")
-
-			# Look up judge score from parallel arrays
-			local judge_score=""
-			for i in "${!judge_models[@]}"; do
-				if [[ "${judge_models[$i]}" == "$m" ]]; then
-					judge_score="${judge_scores_vals[$i]}"
-					break
-				fi
-			done
-
-			# Store result
-			_store_bench_result "$m" "$p" "$latency" "$tokens_in" "$tokens_out" "$cost" \
-				"$judge_score" "$prompt_version"
-		done
-
-		echo ""
-
-		# Clean up temp dir
-		rm -rf "$bench_dir"
+		[[ ${#prompts[@]} -gt 1 ]] && prompt_label="Prompt ${prompt_idx}/${#prompts[@]}"
+		_bench_run_prompt "$p" "$prompt_label" "$max_tokens" "$judge_flag" "$prompt_version" "${valid_models[@]}"
 	done
 
 	echo "Results stored: $BENCH_RESULTS_FILE"
 	echo ""
+	return 0
+}
+
+# Run one prompt across all models, display results, and store them.
+# Args: $1=prompt $2=prompt_label $3=max_tokens $4=judge_flag $5=prompt_version $6+=valid_models
+_bench_run_prompt() {
+	local p="$1"
+	local prompt_label="$2"
+	local max_tokens="$3"
+	local judge_flag="$4"
+	local prompt_version="$5"
+	shift 5
+	local -a valid_models=("$@")
+
+	# Truncate prompt for display
+	local display_prompt="${p:0:80}"
+	[[ ${#p} -gt 80 ]] && display_prompt="${display_prompt}..."
+	echo "${prompt_label}: ${display_prompt}"
+	echo ""
+
+	# Create temp directory for this prompt's results
+	local bench_dir
+	bench_dir=$(mktemp -d "${TMPDIR:-/tmp}/bench-XXXXXX")
+
+	# Run models in parallel
+	local -a pids=()
+	local m
+	for m in "${valid_models[@]}"; do
+		echo "  Calling ${m}..."
+		_bench_call_model "$m" "$p" "$max_tokens" "$bench_dir" &
+		pids+=($!)
+	done
+	local pid
+	for pid in "${pids[@]}"; do
+		wait "$pid" 2>/dev/null || true
+	done
+
+	# Collect judge scores if enabled
+	local -a judge_models=()
+	local -a judge_scores_vals=()
+	if [[ "$judge_flag" == true ]]; then
+		echo "  Scoring with judge (haiku)..."
+		local judge_output
+		judge_output=$(_bench_judge_score "$p" "$bench_dir")
+		local jm js
+		while IFS='|' read -r jm js; do
+			[[ -z "$jm" ]] && continue
+			judge_models+=("$jm")
+			judge_scores_vals+=("$js")
+		done <<<"$judge_output"
+	fi
+
+	# Display results table
+	echo ""
+	_bench_display_results "$bench_dir" "$judge_flag" "${valid_models[@]}"
+
+	# Store results for each model
+	for m in "${valid_models[@]}"; do
+		local result_file="${bench_dir}/${m}.json"
+		[[ ! -f "$result_file" ]] && continue
+		local latency tokens_in tokens_out error_msg
+		latency=$(jq -r '.latency_ms // 0' "$result_file" 2>/dev/null || echo "0")
+		tokens_in=$(jq -r '.tokens_in // 0' "$result_file" 2>/dev/null || echo "0")
+		tokens_out=$(jq -r '.tokens_out // 0' "$result_file" 2>/dev/null || echo "0")
+		error_msg=$(jq -r '.error // ""' "$result_file" 2>/dev/null || echo "")
+		[[ -n "$error_msg" ]] && continue
+		local cost
+		cost=$(_calc_bench_cost "$m" "$tokens_in" "$tokens_out")
+		# Look up judge score from parallel arrays
+		local judge_score=""
+		local i
+		for i in "${!judge_models[@]}"; do
+			if [[ "${judge_models[$i]}" == "$m" ]]; then
+				judge_score="${judge_scores_vals[$i]}"
+				break
+			fi
+		done
+		_store_bench_result "$m" "$p" "$latency" "$tokens_in" "$tokens_out" "$cost" \
+			"$judge_score" "$prompt_version"
+	done
+
+	echo ""
+	rm -rf "$bench_dir"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Closes #5639

Splits 5 functions exceeding 100 lines in `.agents/scripts/compare-models-helper.sh` into smaller, focused helpers. No behaviour changes — pure structural decomposition.

## Functions refactored

| Function | Before | After | Helpers extracted |
|---|---|---|---|
| `_cross_review_judge_score` | 184 lines | ~90 lines | `_judge_scoring_instructions`, `_judge_parse_json_fields`, `_judge_validate_task_type`, `_judge_validate_winner`, `_judge_build_score_args`, `_judge_record_scores` |
| `cmd_cross_review` | 168 lines | ~50 lines | `_cross_review_dispatch_one`, `_cross_review_wait_results`, `_cross_review_dispatch_all` |
| `cmd_discover` | 165 lines | ~30 lines | `_discover_scan_providers`, `_discover_print_available_models`, `_discover_print_unavailable_models` |
| `cmd_score` | 107 lines | ~25 lines | `_score_insert_comparison`, `_score_display_table` |
| `cmd_bench` | 124 lines | ~20 lines | `_bench_run_prompt` |

## Verification

- `bash -n`: pass (syntax clean)
- `shellcheck`: no new violations (pre-existing SC1091 info finding unchanged)
- All functions now under 100 lines
- 1 file changed (within max 5 files constraint)

Also fixed a pre-existing bug: `judge_err_log` and `judge_output_file` were referenced in `_cross_review_judge_score` but only defined in the called `_judge_dispatch` function (locals don't leak across function calls). Both are now correctly defined in `_cross_review_judge_score`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal command handling and helper functions across judge scoring, model dispatch, provider discovery, and benchmark execution pipelines. No changes to user-facing functionality or public command signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->