### PR TITLE
fix: discover shell scripts via git ls-files in quality sweep (GH#5663)

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -1251,7 +1251,15 @@ _quality_sweep_for_repo() {
 	local shellcheck_section=""
 	if command -v shellcheck &>/dev/null; then
 		local sh_files
-		sh_files=$(find "$repo_path" -name "*.sh" -not -path "*/archived/*" -not -path "*/node_modules/*" -not -path "*/.git/*" -type f 2>/dev/null | head -100)
+		# GH#5663: Use git ls-files to discover only tracked shell scripts.
+		# find can return deleted files still on disk, stale worktree paths, or
+		# build artifacts — causing false ShellCheck findings on non-existent files.
+		if git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
+			sh_files=$(git -C "$repo_path" ls-files '*.sh' 2>/dev/null | head -100)
+		else
+			# Fallback for non-git directories (should not occur for pulse repos)
+			sh_files=$(find "$repo_path" -name "*.sh" -not -path "*/archived/*" -not -path "*/node_modules/*" -not -path "*/.git/*" -type f 2>/dev/null | head -100)
+		fi
 
 		if [[ -n "$sh_files" ]]; then
 			local sc_errors=0
@@ -1266,6 +1274,17 @@ _quality_sweep_for_repo() {
 
 			while IFS= read -r shfile; do
 				[[ -z "$shfile" ]] && continue
+				# GH#5663: git ls-files returns relative paths — resolve to absolute.
+				if [[ "$shfile" != /* ]]; then
+					shfile="${repo_path}/${shfile}"
+				fi
+				# GH#5663: Guard against tracked-but-deleted files (index vs working
+				# tree mismatch). Skip with a log entry rather than running ShellCheck
+				# on a path that does not exist.
+				if [[ ! -f "$shfile" ]]; then
+					echo "[stats] ShellCheck: skipping missing file: ${shfile}" >>"$LOGFILE"
+					continue
+				fi
 				local result
 				# t1398.2: hardened invocation — no -x, --norc, per-file timeout,
 				# ulimit -v in subshell to cap RSS per shellcheck process.


### PR DESCRIPTION
## Summary

- Replace `find` with `git ls-files '*.sh'` in `_quality_sweep_for_repo` ShellCheck section to avoid false findings on untracked/deleted files
- Add fallback to `find` for non-git directories (should not occur for pulse repos but handles edge cases)
- Resolve relative paths returned by `git ls-files` to absolute paths before passing to ShellCheck
- Add file-existence guard: skip tracked-but-deleted files (index vs working tree mismatch) with a log entry

## Problem

`find` scans the filesystem and returns paths not tracked by git — deleted scripts still on disk, stale worktree paths, build artifacts. This caused false ShellCheck findings and spurious quality-debt issues (evidence: GH#650 in a managed repo reported SC2086 on two files that `git ls-files` showed did not exist).

## Changes

`stats-functions.sh` lines ~1251-1287 (ShellCheck section of `_quality_sweep_for_repo`):

```bash
# Before
sh_files=$(find "$repo_path" -name "*.sh" ... | head -100)

# After
if git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
    sh_files=$(git -C "$repo_path" ls-files '*.sh' 2>/dev/null | head -100)
else
    sh_files=$(find "$repo_path" -name "*.sh" ... | head -100)  # fallback
fi
# + relative→absolute path resolution
# + [[ ! -f "$shfile" ]] guard before ShellCheck invocation
```

## Verification

- ShellCheck on modified file: **0 violations** (unchanged from baseline)
- 1 file changed, 20 insertions(+), 1 deletion(-)

Closes #5663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell script quality checks by enhancing file discovery logic to reduce false positives from missing or stale paths
  * Strengthened support for both git and non-git repositories with better path handling and pre-validation of files before analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->