### PR TITLE
fix: resolve MD005 blockquote list indentation in models-pool-check.md

### DIFF
--- a/.agents/scripts/commands/models-pool-check.md
+++ b/.agents/scripts/commands/models-pool-check.md
@@ -41,7 +41,7 @@ If Claude CLI is not installed or not logged in, fall back to the standard inter
 >
 > You'll need a paid subscription to one of these:
 >
- > - **Claude Pro or Max** ($20-100/mo from anthropic.com) — for Claude models
+> - **Claude Pro or Max** ($20-100/mo from anthropic.com) — for Claude models
 > - **ChatGPT Plus or Pro** ($20-200/mo from openai.com) — for GPT/o-series models
 > - **Cursor Pro** ($20/mo from cursor.com) — for models via Cursor's proxy
 > - **Google AI Pro or Ultra** ($25-65/mo from one.google.com) — for Gemini models via Gemini CLI


### PR DESCRIPTION
## Summary

Fixes inconsistent blockquote list indentation (MD005) in `.agents/scripts/commands/models-pool-check.md` as flagged by CodeRabbit in PR #5618.

## Change

Line 44 had a leading space before `>` (` > - **Claude Pro or Max**...`) while lines 45-47 used `> - ` without a leading space. Removed the errant leading space so all four provider list items are consistently formatted as `> - `.

## Verification

`markdownlint-cli2` no longer reports MD005 warnings on this file. The only remaining lint issue (MD040, fenced code block without language on line 32) is pre-existing and out of scope for this issue.

Closes #5671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting consistency in setup requirements documentation to ensure proper alignment and readability of list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->