### PR TITLE
fix: address Gemini review feedback in stats-functions.sh (GH#5667)

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -1267,22 +1267,22 @@ _quality_sweep_for_repo() {
 			local sc_summary=""
 			local sc_details=""
 
-			# timeout_sec (from shared-constants.sh) handles macOS + Linux portably.
-			# It always provides a timeout mechanism (background + kill fallback on
-			# bare macOS), so we no longer need to skip ShellCheck when no timeout
-			# utility is installed.
+			# timeout_sec (from shared-constants.sh) handles macOS + Linux portably,
+			# providing a background + kill fallback on bare macOS so we no longer
+			# need to skip ShellCheck when no timeout utility is installed.
+			# GH#5663: git ls-files returns relative paths — resolve to absolute
+			# before running ShellCheck, and guard against tracked-but-deleted files
+			# (index vs working tree mismatch) by skipping missing paths with a log
+			# entry rather than passing a non-existent path to ShellCheck.
 
 			while IFS= read -r shfile; do
 				[[ -z "$shfile" ]] && continue
-				# GH#5663: git ls-files returns relative paths — resolve to absolute.
-				if [[ "$shfile" != /* ]]; then
+				if [[ ! "$shfile" =~ ^/ ]]; then
 					shfile="${repo_path}/${shfile}"
 				fi
-				# GH#5663: Guard against tracked-but-deleted files (index vs working
-				# tree mismatch). Skip with a log entry rather than running ShellCheck
-				# on a path that does not exist.
 				if [[ ! -f "$shfile" ]]; then
-					echo "[stats] ShellCheck: skipping missing file: ${shfile}" >>"$LOGFILE"
+					printf '%s [stats] ShellCheck: skipping missing file: %s\n' \
+						"$(date '+%Y-%m-%d %H:%M:%S')" "${shfile}" >>"$LOGFILE"
 					continue
 				fi
 				local result


### PR DESCRIPTION
## Summary

Addresses the 3 medium-severity findings from Gemini's review of PR #5664 on `.agents/scripts/stats-functions.sh`.

### Changes

**Finding 1 — Consolidate comment block (line 1274)**
The two separate comment blocks (one for `timeout_sec`, one for GH#5663 path handling) were merged into a single cohesive block above the `while` loop, improving readability without changing behaviour.

**Finding 2 — Regex for absolute path check (line 1279)**
Changed `[[ "$shfile" != /* ]]` to `[[ ! "$shfile" =~ ^/ ]]`. The regex form is more explicit and handles edge cases (e.g. paths starting with multiple slashes) more reliably.

**Finding 3 — `printf` with timestamp for log entry (line 1285)**
Replaced `echo "[stats] ShellCheck: skipping missing file: ..."` with `printf '%s [stats] ShellCheck: skipping missing file: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${shfile}"`. This:
- Avoids backslash-escape ambiguity in `echo`
- Adds a timestamp for better traceability in log files
- Uses `date '+%Y-%m-%d %H:%M:%S'` (portable, bash 3.2 compatible) rather than the bash 4.2+ `%(%Y-%m-%d %H:%M:%S)T` format specifier suggested by Gemini

### Verification

- ShellCheck: zero violations on the modified file

Closes #5667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell script path resolution to use pattern-based detection for more reliable accuracy.
  * Enhanced error logging for missing shell files with timestamp information for better tracking.

* **Chores**
  * Updated documentation comments to reflect path resolution and error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->