### PR TITLE
GH#5668: fix(quality-feedback): filter human APPROVED merge/CI-status comments

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1099,17 +1099,30 @@ _scan_single_pr() {
 
 		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not)) as $actionable |
 
+		# Detect merge/CI-status comments: supervisor or bot merge announcements
+		# (e.g. "Pulse supervisor: all CI checks green... Merging.") are not
+		# actionable review feedback -- they are operational status messages.
+		# These slip through the $approval_only filter because they do not match
+		# the short approval phrase patterns (GH#5668, incident: issue #5668).
+		($body | test(
+			"\\bmerging\\.?$|\\bmerge (this|the) pr\\b|" +
+			"\\bci (checks? )?(green|pass(ed)?|ok)\\b|" +
+			"\\ball (checks?|tests?) (green|pass(ed)?|ok)\\b|" +
+			"\\breview.bot.gate (pass|ok)\\b|" +
+			"\\bpulse supervisor\\b"; "i")) as $merge_status_only |
+
 		# Skip purely approving reviews unless --include-positive is set.
 		# Explicit "no suggestions" statements are always non-actionable and should
 		# be skipped even though they contain the token "suggest", which would
 		# otherwise trip the actionable heuristic.
 		# Other approval/sentiment patterns are skipped only when no actionable
 		# critique appears in the body.
-		select($include_positive or (((($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not))) | not)) |
+		select($include_positive or (((($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $merge_status_only) and ($actionable | not))) | not)) |
 
 		select(
 			if $include_positive then true
-			elif $reviewer == "human" then true
+			elif .state == "CHANGES_REQUESTED" then true
+			elif $reviewer == "human" then $actionable
 			elif .state == "APPROVED" then $actionable
 			else
 				($actionable and ($body | test(

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -574,9 +574,17 @@ _test_approval_filter() {
 
 		($actionable_raw and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not)) as $actionable |
 
+		# GH#5668: merge/CI-status comments are not actionable review feedback
+		($body | test(
+			"\\bmerging\\.?$|\\bmerge (this|the) pr\\b|" +
+			"\\bci (checks? )?(green|pass(ed)?|ok)\\b|" +
+			"\\ball (checks?|tests?) (green|pass(ed)?|ok)\\b|" +
+			"\\breview.bot.gate (pass|ok)\\b|" +
+			"\\bpulse supervisor\\b"; "i")) as $merge_status_only |
+
 		# skip = approval-only/no-recommendation/no-suggestions/no-actionable sentiment
-		# or summary praise with no actionable critique
-		if (($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) then "skip"
+		# or summary praise with no actionable critique, or merge/CI-status comment
+		if (($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $merge_status_only) and ($actionable | not)) then "skip"
 		else "keep"
 		end
 	')
@@ -1585,6 +1593,108 @@ test_scan_single_pr_filters_issue3145_pr3077_review_body() {
 	return 0
 }
 
+# Regression test for GH#5668: pulse supervisor merge comment filed as quality-debt.
+# The exact review body from PR #5637 (marcusquinn, APPROVED, human reviewer).
+# "Pulse supervisor: all CI checks green, review-bot-gate PASS, CodeRabbit approved. Merging."
+# This is an operational status message, not actionable review feedback.
+# Before the fix: human APPROVED reviews bypassed all filters (elif $reviewer == "human" then true).
+# After the fix: human APPROVED reviews require $actionable content, and $merge_status_only
+# is added to the non-actionable filter set.
+test_skips_pr5637_pulse_supervisor_merge_comment() {
+	local result
+	result=$(_test_approval_filter "Pulse supervisor: all CI checks green, review-bot-gate PASS, CodeRabbit approved. Merging." "APPROVED" "marcusquinn")
+	if [[ "$result" == "skip" ]]; then
+		print_result "GH#5668: pulse supervisor merge comment filtered (human APPROVED)" 0
+	else
+		print_result "GH#5668: pulse supervisor merge comment filtered (human APPROVED)" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
+# Counterpart: human CHANGES_REQUESTED review must always pass through (GH#5668).
+# The fix preserves CHANGES_REQUESTED as always-actionable.
+test_keeps_human_changes_requested_review_gh5668() {
+	local result
+	result=$(_test_approval_filter "This function has a bug: the return value is not checked. Please fix before merging." "CHANGES_REQUESTED" "marcusquinn")
+	if [[ "$result" == "keep" ]]; then
+		print_result "GH#5668: human CHANGES_REQUESTED review kept (not filtered)" 0
+	else
+		print_result "GH#5668: human CHANGES_REQUESTED review kept (not filtered)" 1 "expected keep, got ${result}"
+	fi
+	return 0
+}
+
+# Integration test: _scan_single_pr with the exact PR #5637 review must return 0 findings.
+test_scan_single_pr_filters_pr5637_merge_comment() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					echo "[]"
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					# Exact review from PR #5637 that caused issue #5668
+					echo '[{"id":3996148895,"user":{"login":"marcusquinn"},"state":"APPROVED","body":"Pulse supervisor: all CI checks green, review-bot-gate PASS, CodeRabbit approved. Merging.","submitted_at":"2026-03-24T04:24:00Z","html_url":"https://github.com/marcusquinn/aidevops/pull/5637#pullrequestreview-3996148895"}]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '{"tree":[]}'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			echo "[]"
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		echo "[]"
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "5637" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "GH#5668: PR #5637 pulse supervisor merge comment produces 0 findings" 0
+	else
+		print_result "GH#5668: PR #5637 pulse supervisor merge comment produces 0 findings" 1 "expected 0 findings, got ${count} — would have filed false-positive issue"
+	fi
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			_mock_gh_api "$@"
+			return $?
+			;;
+		label) return 0 ;;
+		issue)
+			_mock_gh_issue "$@"
+			return $?
+			;;
+		esac
+		echo "unexpected gh call: ${command}" >&2
+		return 1
+	}
+	return 0
+}
+
 main() {
 	source "$HELPER"
 
@@ -1643,6 +1753,12 @@ main() {
 	echo "Running positive-review filter regression tests (GH#4814)"
 	test_scan_single_pr_filters_issue4814_pr2166_exact_body
 	test_scan_single_pr_positive_body_with_inline_comments_not_summary_only
+
+	echo ""
+	echo "Running merge/CI-status comment filter tests (GH#5668)"
+	test_skips_pr5637_pulse_supervisor_merge_comment
+	test_keeps_human_changes_requested_review_gh5668
+	test_scan_single_pr_filters_pr5637_merge_comment
 
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes two root causes that caused the pulse supervisor's merge approval comment to be filed as a quality-debt issue (incident: issue #5668, PR #5637).

- **Root cause 1**: Human `APPROVED` reviews bypassed all positive-review filters. The `select()` block had `elif $reviewer == "human" then true` which unconditionally passed all human reviews regardless of content. Fix: human `APPROVED` reviews now require `$actionable` content (same as bots). `CHANGES_REQUESTED` reviews remain always-actionable via a new first branch.

- **Root cause 2**: Merge/CI-status comments (e.g. `"Pulse supervisor: all CI checks green, review-bot-gate PASS, CodeRabbit approved. Merging."`) were not matched by any existing filter. The `$approval_only` pattern requires the entire body to be a short approval phrase — these operational messages are not. Fix: new `$merge_status_only` filter matches `"Merging."`, `"CI checks green"`, `"review-bot-gate PASS"`, `"Pulse supervisor"`, etc.

## Changes

- `.agents/scripts/quality-feedback-helper.sh`: Two-part fix in `_scan_single_pr` review body processing
  - Added `$merge_status_only` jq variable with patterns for merge/CI-status comments
  - Changed `elif $reviewer == "human" then true` → `elif .state == "CHANGES_REQUESTED" then true` + `elif $reviewer == "human" then $actionable`
- `.agents/scripts/tests/test-quality-feedback-main-verification.sh`: 3 new regression tests
  - `test_skips_pr5637_pulse_supervisor_merge_comment` — exact body from the incident
  - `test_keeps_human_changes_requested_review_gh5668` — CHANGES_REQUESTED still passes
  - `test_scan_single_pr_filters_pr5637_merge_comment` — integration test via `_scan_single_pr`

## Verification

- `shellcheck .agents/scripts/quality-feedback-helper.sh` — 0 violations
- `shellcheck .agents/scripts/tests/test-quality-feedback-main-verification.sh` — 0 violations
- Test suite: **45/45 passed, 0 failed** (was 42/42 before; 3 new tests added)

Closes #5668