### PR TITLE
fix: update label-protection-notice to say write/maintain/admin

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -214,7 +214,7 @@ jobs:
             gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "<!-- label-protection-notice -->
           The \`needs-maintainer-review\` label was re-applied automatically.
 
-          Only repository maintainers (admin/maintain permission) can remove triage labels from external issues. This prevents the development pipeline from picking up unreviewed external contributions.
+          Only repository collaborators with write access or higher (write/maintain/admin permission) can remove triage labels from external issues. This prevents the development pipeline from picking up unreviewed external contributions.
 
           If you believe this issue is ready for development, please ask a maintainer to review and approve it."
           fi


### PR DESCRIPTION
## Summary

- Updates the `label-protection-notice` comment message in `.github/workflows/maintainer-gate.yml` (line 217) to say "write/maintain/admin permission" instead of "admin/maintain permission"
- Aligns the user-facing message with the actual permission check logic which already permits `write` access

## Changes

Single-line text change in the `gh issue comment` body inside the `protect-labels` job.

Closes #5681