### PR TITLE
GH#5677: Preserve apostrophes in FTS5 .param set quoting

### DIFF
--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -192,14 +192,10 @@ cmd_recall() {
 	# Quote each token individually to handle special chars (hyphens = NOT in FTS5)
 	# "foo-bar baz" → "\"foo-bar\" \"baz\"" (each token quoted, joined by implicit AND)
 	#
-	# Apostrophes and backslashes are replaced with spaces before tokenization.
-	# Apostrophes inside FTS5 double-quoted tokens cannot be SQL-escaped (doubling
-	# them to '' produces invalid FTS5 syntax). Backslashes are not valid FTS5 query
-	# syntax and cause a parse error. Replacing both with spaces splits e.g.
-	# "O'Reilly" into "O" and "Reilly", which still matches stored content because
-	# FTS5 tokenizes stored content the same way (GH#5678).
-	local query_clean="${query//"'"/" "}"
-	query_clean="${query_clean//\\/  }"
+	# Backslashes are stripped before tokenization — they are not valid FTS5 query
+	# syntax and cause a parse error. Apostrophes are preserved through proper
+	# quoting (see param_query construction below).
+	local query_clean="${query//\\/  }"
 	local tokenised_query=""
 	local token
 	set -f # Disable globbing during tokenization (SC2086)
@@ -215,9 +211,20 @@ cmd_recall() {
 	set +f # Re-enable globbing
 	# Build an SQL single-quoted literal for .param set, then escape it for the
 	# sqlite3 dot-command's outer double-quoted argument (GH#5678).
-	# tokenised_query contains no apostrophes or backslashes (stripped above), so
-	# the SQL literal needs no internal single-quote escaping. The FTS5 double-quote
-	# tokens are escaped as \" for the outer double-quoted dot-command argument.
+	#
+	# The sqlite3 dot-command parser has its own quoting rules separate from SQL:
+	# - Single-quoted args: the parser does NOT support '' escaping, so embedded
+	#   apostrophes (e.g., O'Reilly) break the argument boundary.
+	# - Double-quoted args: the parser supports \" for literal double quotes.
+	#
+	# Strategy: build an SQL single-quoted literal (with '' for apostrophes),
+	# then escape backslashes and double quotes for the outer double-quoted
+	# dot-command argument. The result is passed as: .param set :query "VALUE"
+	# where VALUE is the SQL expression (e.g., '\"O''Reilly\" \"guide\"').
+	#
+	# Step 1: Double single quotes for SQL literal (sed avoids bash quoting issues)
+	# Step 2: Wrap in SQL single quotes via printf
+	# Step 3: Escape \ and " for dot-command double-quoted argument (sed)
 	#
 	# Security note: the heredoc uses <<EOF (not <<'EOF'), so ${param_query} is
 	# expanded by the shell. This is safe because shell variable expansion is NOT
@@ -225,8 +232,8 @@ cmd_recall() {
 	# command-substitution syntax ($(…), `…`) or variable references inside the
 	# value are NOT re-evaluated. The :query parameter binding then isolates the
 	# value from SQL execution, preventing injection at the SQLite layer.
-	local param_query="'${tokenised_query}'"
-	param_query="${param_query//\"/\\\"}"
+	local param_query
+	param_query=$(printf "'%s'" "$(printf '%s' "$tokenised_query" | sed "s/'/''/g")" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
 	# Build filters with validation
 	local extra_filters=""


### PR DESCRIPTION
## Summary

- Replace lossy apostrophe-stripping workaround with proper SQL literal escaping for sqlite3's `.param set` dot-command
- Queries like `O'Reilly` now preserve the apostrophe instead of being split into `O Reilly`
- Uses SQL single-quoted literal wrapped in double-quoted dot-command argument per sqlite3 CLI docs

## Problem

PR #5678 merged with a workaround that stripped apostrophes from queries before tokenization (`O'Reilly` → `O Reilly`). While functionally correct for FTS5 matching (the tokenizer splits on apostrophes anyway), this was lossy and didn't address the root cause identified by CodeRabbit and Gemini reviewers.

**Root cause**: sqlite3's dot-command parser does NOT support `''` escaping inside single-quoted arguments. The dot-command parser is separate from the SQL parser. So `.param set :query '"O''Reilly"'` breaks at the first embedded `'`.

## Fix

Build the `.param set` value as an SQL single-quoted literal, then escape it for the dot-command's double-quoted argument context:

```
.param set :query "'\"O''Reilly\" \"guide\"'"
```

- Outer `"..."`: dot-command argument boundary (supports `\"` escaping)
- Inner `'...'`: SQL text literal delimiters
- `''`: SQL-escaped apostrophe (evaluated by SQL parser, not dot-command parser)
- `\"`: dot-command-escaped double quote (preserves FTS5 token quoting)

Uses `sed` for the escaping pipeline to avoid bash quoting conflicts between parameter expansion and heredoc contexts.

## Verification

All 10 test cases pass:
- Simple multi-word, single word, hyphenated tokens
- **O'Reilly**, **can't**, **it's O'Reilly's book** (apostrophe cases)
- Backslash stripping, JSON output mode
- ShellCheck: zero violations

## Review Comments Addressed

Addresses all 5 unresolved review comments from PR #5678:
1. **CodeRabbit (line 262)**: `.param set` quoting — now uses SQL literal in double-quoted dot-command arg
2. **CodeRabbit (line 332)**: shared-mode filter propagation — already fixed in #5678, preserved
3. **Gemini critical (line 262)**: FTS5 syntax correctness — preserved and improved
4. **Gemini security-high (line 319)**: parameterized binding for shared query — preserved
5. **Gemini security-high (line 332)**: `:query` parameter vs interpolation — preserved

Closes #5677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search functionality to correctly process queries containing special characters such as apostrophes and backslashes. Previously, these characters could cause unexpected behavior; now they are properly handled throughout the search pipeline, ensuring users receive accurate results regardless of special characters in their input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->