### PR TITLE
GH#5683: Fix recall.sh apostrophe escaping and shared mode filter bypass

### DIFF
--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -204,7 +204,15 @@ cmd_recall() {
 		fi
 	done
 	set +f # Re-enable globbing
-	local escaped_query="$tokenised_query"
+	# Escape tokenised_query for use in `.param set :query "${param_query}"`.
+	# sqlite3 `.param set` with a double-quoted VALUE treats it as a string
+	# literal. Apostrophes pass through double quotes safely (O'Reilly works).
+	# We must escape: (1) backslashes, (2) double quotes — because the FTS5
+	# token quoting uses double quotes ("word") which would otherwise be
+	# consumed by the heredoc's double-quote expansion.
+	# Ref: https://sqlite.org/cli.html (.param set), GH#5683
+	local param_query="${tokenised_query//\\/\\\\}"
+	param_query="${param_query//\"/\\\"}"
 
 	# Build filters with validation
 	local extra_filters=""
@@ -259,7 +267,7 @@ cmd_recall() {
 	local results
 	results=$(
 		db -json "$MEMORY_DB" <<EOF
-.param set :query "$escaped_query"
+.param set :query "${param_query}"
 SELECT 
     learnings.id,
     learnings.content,
@@ -316,6 +324,7 @@ EOF
 		if [[ -f "$global_db" ]]; then
 			shared_results=$(
 				db -json "$global_db" <<EOF
+.param set :query "${param_query}"
 SELECT 
     learnings.id,
     learnings.content,
@@ -328,7 +337,8 @@ SELECT
     bm25(learnings) as score
 FROM learnings
 LEFT JOIN learning_access ON learnings.id = learning_access.id
-WHERE learnings MATCH '$escaped_query' $extra_filters
+$entity_fts_join
+WHERE learnings MATCH :query $extra_filters $auto_join_filter $entity_fts_where
 ORDER BY score
 LIMIT $limit;
 EOF


### PR DESCRIPTION
## Summary

- Fix `.param set` double-quote escaping so FTS5 queries with apostrophes (e.g., `O'Reilly guide`) work correctly
- Add missing `--auto-only`/`--manual-only` and `--entity` filters to `--shared` mode global DB query
- Switch shared query from direct string interpolation to parameterized `.param set` binding

## Root Cause

Two bugs identified by CodeRabbit review on PR #5678 (post-merge findings):

### 1. Apostrophe/single-quote in queries breaks `.param set`

`.param set :query "$escaped_query"` in a heredoc (`<<EOF`) — the FTS5 token double quotes (`"word"`) were consumed by the heredoc's double-quote expansion, leaving sqlite3 with malformed input. For queries containing apostrophes like `O'Reilly`, this produced FTS5 syntax errors.

**Fix:** Escape backslashes and double quotes in `tokenised_query` before interpolation. sqlite3 `.param set` with a double-quoted VALUE treats apostrophes as literal characters, so `O'Reilly` passes through safely.

### 2. `--shared` mode bypassed filters

The shared/global DB query only applied `$extra_filters` but omitted:
- `$auto_join_filter` (`--auto-only` / `--manual-only`)
- `$entity_fts_join` and `$entity_fts_where` (`--entity` filtering)
- Used direct string interpolation (`'$escaped_query'`) instead of `.param set` binding

**Fix:** Added all missing filter variables and switched to parameterized binding, consistent with the namespace query.

## Verification

Tested with sqlite3 FTS5 against 7 query patterns:
- `O'Reilly guide` (apostrophe) — previously failed, now returns correct result
- `it's wonderful` (multiple apostrophes) — works
- `custom water` (simple multi-word) — works (no regression)
- `bottled` (single word) — works (no regression)
- `shellcheck memory` (no special chars) — works
- `shellcheck` (single word) — works
- `nonexistent` (no match) — returns empty (correct)

Closes #5683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search parameter handling for more reliable query processing.
  * Enhanced search filtering to better incorporate all relevant entity-scoped criteria in recall and global searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->