### PR TITLE
Security advisory system, secret hygiene scanner, and unified security CLI

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -293,7 +293,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Outreach | `services/outreach/cold-outreach.md`, `services/outreach/smartlead.md`, `services/outreach/instantly.md`, `services/outreach/manyreach.md` |
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md`, `services/payments/procurement.md` |
 | Auth troubleshooting | `tools/credentials/auth-troubleshooting.md` |
-| Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/security/prompt-injection-defender.md`, `tools/security/tamper-evident-audit.md`, `tools/credentials/encryption-stack.md` |
+| Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/security/prompt-injection-defender.md`, `tools/security/tamper-evident-audit.md`, `tools/credentials/encryption-stack.md`, `scripts/secret-hygiene-helper.sh` |
 | Database/Local-first | `tools/database/pglite-local-first.md`, `services/database/postgres-drizzle-skill.md` |
 | Vector Search | `tools/database/vector-search.md`, `tools/database/vector-search/zvec.md` |
 | Local Development | `services/hosting/local-hosting.md` |
@@ -330,6 +330,13 @@ Key capabilities (details in `reference/orchestration.md`, `reference/services.m
 ## Security
 
 Rules: `prompts/build.txt`. Secrets: `gopass` preferred; `credentials.sh` plaintext fallback (600 perms). Config templates: `configs/*.json.txt` (committed), working: `configs/*.json` (gitignored). Full docs: `tools/credentials/gopass.md`.
+
+**Secret hygiene & supply chain protection:**
+- `aidevops security scan` — scans for plaintext secrets (AWS, GCP, Azure, k8s, Docker, npm, PyPI, SSH), Python `.pth` supply chain IoCs, unpinned dependencies, and MCP auto-download risks. Never exposes secret values.
+- `aidevops security scan-pth` — Python `.pth` file audit (the attack vector used in the LiteLLM March 2026 supply chain compromise).
+- `aidevops security dismiss <id>` — dismiss a security advisory after taking action.
+- Security advisories are delivered via `aidevops update` and shown in the session greeting until dismissed. Advisory files: `~/.aidevops/advisories/*.advisory`.
+- All remediation commands must be run in a **separate terminal**, never inside AI chat sessions.
 
 **Cross-repo privacy:** NEVER include private repo names in TODO.md task descriptions, issue titles, or comments on public repos. Use generic references like "a managed private repo" or "cross-repo project". The issue-sync-helper.sh has automated sanitization, but prevention at the source is the primary defense.
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -331,9 +331,11 @@ Key capabilities (details in `reference/orchestration.md`, `reference/services.m
 
 Rules: `prompts/build.txt`. Secrets: `gopass` preferred; `credentials.sh` plaintext fallback (600 perms). Config templates: `configs/*.json.txt` (committed), working: `configs/*.json` (gitignored). Full docs: `tools/credentials/gopass.md`.
 
-**Secret hygiene & supply chain protection:**
-- `aidevops security scan` — scans for plaintext secrets (AWS, GCP, Azure, k8s, Docker, npm, PyPI, SSH), Python `.pth` supply chain IoCs, unpinned dependencies, and MCP auto-download risks. Never exposes secret values.
-- `aidevops security scan-pth` — Python `.pth` file audit (the attack vector used in the LiteLLM March 2026 supply chain compromise).
+**Unified security command:** `aidevops security` (no args) runs all checks — user posture, plaintext secret hygiene, supply chain IoCs, and active advisories. Subcommands for targeted use:
+- `aidevops security` — run everything (recommended)
+- `aidevops security posture` — interactive security posture setup (gopass, gh auth, SSH, secretlint)
+- `aidevops security scan` — secret hygiene & supply chain scan (plaintext secrets, `.pth` IoCs, unpinned deps, MCP auto-download risks). Never exposes secret values.
+- `aidevops security check` — per-repo posture assessment (workflows, branch protection, review bot gate)
 - `aidevops security dismiss <id>` — dismiss a security advisory after taking action.
 - Security advisories are delivered via `aidevops update` and shown in the session greeting until dismissed. Advisory files: `~/.aidevops/advisories/*.advisory`.
 - All remediation commands must be run in a **separate terminal**, never inside AI chat sessions.

--- a/.agents/advisories/litellm-2026-03.advisory
+++ b/.agents/advisories/litellm-2026-03.advisory
@@ -1,0 +1,26 @@
+[SECURITY ADVISORY] LiteLLM PyPI Supply Chain Attack (March 24, 2026)
+
+  Compromised versions: litellm v1.82.7 and v1.82.8
+  Attack window: March 24, 2026, 10:39-16:00 UTC
+  Impact: Credential stealer harvesting env vars, SSH keys, cloud creds, k8s tokens
+  Also affects: DSPy users (dspy depends on litellm>=1.64.0)
+
+  The malware installs litellm_init.pth which executes on EVERY Python startup,
+  not just when litellm is imported. A bug in the malware caused a fork bomb,
+  which is how it was discovered — without that bug it would have been silent.
+
+  Check now — run these commands in a SEPARATE TERMINAL (not in AI chat):
+
+    # Check for the malware indicator file
+    secret-hygiene-helper.sh scan-pth
+
+    # Check your installed litellm version
+    pip show litellm 2>/dev/null | grep Version
+
+    # Full scan for plaintext secrets and IoCs
+    secret-hygiene-helper.sh scan
+
+  If affected: rotate ALL credentials immediately. Details:
+    https://docs.litellm.ai/blog/security-update-march-2026
+
+  aidevops requirements.txt has been pinned to litellm==1.79.3 (safe).

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -268,6 +268,40 @@ main() {
 		echo "$security_posture"
 	fi
 
+	# Secret hygiene & supply chain IoC check
+	local secret_hygiene=""
+	if [[ -x "${script_dir}/secret-hygiene-helper.sh" ]]; then
+		secret_hygiene="$("${script_dir}/secret-hygiene-helper.sh" startup-check || true)"
+	fi
+	if [[ -n "$secret_hygiene" ]]; then
+		echo "$secret_hygiene"
+	fi
+
+	# Active security advisories (delivered via aidevops updates, dismissed by user)
+	local advisories_output=""
+	local advisories_dir="$HOME/.aidevops/advisories"
+	local dismissed_file="$advisories_dir/dismissed.txt"
+	if [[ -d "$advisories_dir" ]]; then
+		for advisory_file in "$advisories_dir"/*.advisory; do
+			[[ -f "$advisory_file" ]] || continue
+			local adv_id
+			adv_id=$(basename "$advisory_file" .advisory)
+			# Skip dismissed advisories
+			if [[ -f "$dismissed_file" ]] && grep -qxF "$adv_id" "$dismissed_file" 2>/dev/null; then
+				continue
+			fi
+			local first_line
+			first_line=$(head -1 "$advisory_file" | sed 's/^[[:space:]]*//')
+			if [[ -n "$first_line" ]]; then
+				advisories_output="${advisories_output:+${advisories_output}
+}${first_line} Run in your terminal: secret-hygiene-helper.sh scan | Dismiss: secret-hygiene-helper.sh dismiss ${adv_id}"
+			fi
+		done
+	fi
+	if [[ -n "$advisories_output" ]]; then
+		echo "$advisories_output"
+	fi
+
 	# Contribution watch: surface items needing reply (t1419)
 	# Reads cached state file — no API calls, no LLM, no comment bodies.
 	local contribution_watch=""
@@ -301,6 +335,8 @@ main() {
 		[[ -n "$nudge_output" ]] && echo "$nudge_output"
 		[[ -n "$session_warning" ]] && echo "$session_warning"
 		[[ -n "$security_posture" ]] && echo "$security_posture"
+		[[ -n "$secret_hygiene" ]] && echo "$secret_hygiene"
+		[[ -n "$advisories_output" ]] && echo "$advisories_output"
 		[[ -n "$contribution_watch" ]] && echo "$contribution_watch"
 	} >"$cache_dir/session-greeting.txt"
 

--- a/.agents/scripts/commands/security-scan.md
+++ b/.agents/scripts/commands/security-scan.md
@@ -44,7 +44,16 @@ Target: $ARGUMENTS
    ./.agents/scripts/mcp-audit-helper.sh scan
    ```
 
-5. **Report findings** with severity and location
+5. **Secret hygiene & supply chain scan** for plaintext credentials and IoCs:
+
+   ```bash
+   # Scan for plaintext secrets, .pth supply chain IoCs, unpinned deps
+   aidevops security scan
+   # Or directly:
+   secret-hygiene-helper.sh scan
+   ```
+
+6. **Report findings** with severity and location
 
 ## What It Checks
 
@@ -56,6 +65,10 @@ Target: $ARGUMENTS
 | AI Configs | Ferret | Prompt injection, jailbreaks |
 | MCP Descriptions | MCP Audit | Injection in MCP tool descriptions |
 | Obvious Vulns | Security Helper | Command injection, SQL injection |
+| Plaintext Secrets | Secret Hygiene | AWS, GCP, Azure, k8s, Docker, npm, PyPI, SSH |
+| Supply Chain IoCs | Secret Hygiene | Python .pth files, compromised package versions |
+| Unpinned Deps | Secret Hygiene | >= in requirements.txt, ^ in package.json |
+| MCP Auto-Download | Secret Hygiene | uvx/npx in MCP configs (transitive dep risk) |
 
 ## Output
 
@@ -84,3 +97,17 @@ Use `/security-analysis` for comprehensive scanning with:
 - Full taint analysis
 - Git history scanning
 - Detailed remediation guidance
+
+## Related CLI Commands
+
+```bash
+aidevops security              # Security posture setup wizard
+aidevops security scan         # Full secret hygiene & supply chain scan
+aidevops security scan-pth     # Python .pth file audit only
+aidevops security scan-secrets # Plaintext secret locations only
+aidevops security scan-deps    # Unpinned dependency check only
+aidevops security dismiss <id> # Dismiss a security advisory after action
+aidevops security hygiene      # Alias for 'aidevops security scan'
+aidevops security setup        # Interactive security posture setup
+aidevops security status       # Detailed security posture report
+```

--- a/.agents/scripts/commands/security-scan.md
+++ b/.agents/scripts/commands/security-scan.md
@@ -110,5 +110,4 @@ aidevops security scan-secrets # Plaintext secret locations only
 aidevops security scan-deps    # Unpinned dependency check only
 aidevops security check        # Per-repo security posture assessment
 aidevops security dismiss <id> # Dismiss a security advisory after action
-aidevops security status       # Detailed security posture report
 ```

--- a/.agents/scripts/commands/security-scan.md
+++ b/.agents/scripts/commands/security-scan.md
@@ -101,13 +101,14 @@ Use `/security-analysis` for comprehensive scanning with:
 ## Related CLI Commands
 
 ```bash
-aidevops security              # Security posture setup wizard
-aidevops security scan         # Full secret hygiene & supply chain scan
+aidevops security              # Run ALL checks (posture + hygiene + supply chain)
+aidevops security posture      # Interactive security posture setup (gopass, gh, SSH)
+aidevops security status       # Combined posture + hygiene summary
+aidevops security scan         # Secret hygiene & supply chain scan only
 aidevops security scan-pth     # Python .pth file audit only
 aidevops security scan-secrets # Plaintext secret locations only
 aidevops security scan-deps    # Unpinned dependency check only
+aidevops security check        # Per-repo security posture assessment
 aidevops security dismiss <id> # Dismiss a security advisory after action
-aidevops security hygiene      # Alias for 'aidevops security scan'
-aidevops security setup        # Interactive security posture setup
 aidevops security status       # Detailed security posture report
 ```

--- a/.agents/scripts/secret-hygiene-helper.sh
+++ b/.agents/scripts/secret-hygiene-helper.sh
@@ -1,0 +1,658 @@
+#!/usr/bin/env bash
+# secret-hygiene-helper.sh — Scan for plaintext secrets and supply chain IoCs
+#
+# Scans common locations where credentials are stored in plaintext on macOS/Linux,
+# checks for Python supply chain attack indicators (.pth files), and reports
+# findings with remediation guidance.
+#
+# CRITICAL: This script NEVER reads, prints, or exposes secret VALUES.
+#           It only reports file existence, permissions, and key NAMES.
+#           All remediation commands must be run in a SEPARATE TERMINAL,
+#           never inside an AI chat session.
+#
+# Usage:
+#   secret-hygiene-helper.sh scan           # Full scan, text output
+#   secret-hygiene-helper.sh scan-secrets   # Plaintext secret locations only
+#   secret-hygiene-helper.sh scan-pth       # Python .pth file audit only
+#   secret-hygiene-helper.sh scan-deps      # Unpinned dependency check only
+#   secret-hygiene-helper.sh startup-check  # One-line summary for greeting
+#   secret-hygiene-helper.sh dismiss <id>   # Dismiss an advisory
+#   secret-hygiene-helper.sh help           # Show usage
+#
+# Exit codes:
+#   0 — No findings
+#   1 — Findings detected (action needed)
+#   2 — Error
+#
+# Related: security-posture-helper.sh (user-level security config)
+#          security-audit-sweep.sh (per-repo security audit)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+readonly SCRIPT_DIR
+readonly ADVISORIES_DIR="$HOME/.aidevops/advisories"
+readonly DISMISSED_FILE="$ADVISORIES_DIR/dismissed.txt"
+readonly VERSION="1.0.0"
+
+# Colours
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Counters
+FINDINGS_HIGH=0
+FINDINGS_MEDIUM=0
+FINDINGS_LOW=0
+FINDINGS_TOTAL=0
+
+# ============================================================
+# ADVISORY MANAGEMENT
+# ============================================================
+
+ensure_advisories_dir() {
+	mkdir -p "$ADVISORIES_DIR"
+	[[ -f "$DISMISSED_FILE" ]] || touch "$DISMISSED_FILE"
+	return 0
+}
+
+is_dismissed() {
+	local advisory_id="$1"
+	ensure_advisories_dir
+	grep -qxF "$advisory_id" "$DISMISSED_FILE" 2>/dev/null
+}
+
+dismiss_advisory() {
+	local advisory_id="$1"
+	ensure_advisories_dir
+	if is_dismissed "$advisory_id"; then
+		echo "Advisory '$advisory_id' already dismissed."
+		return 0
+	fi
+	echo "$advisory_id" >>"$DISMISSED_FILE"
+	echo "Advisory '$advisory_id' dismissed."
+	return 0
+}
+
+# ============================================================
+# PLAINTEXT SECRET SCANNING
+# ============================================================
+
+report_finding() {
+	local severity="$1"
+	local location="$2"
+	local description="$3"
+	local remediation="$4"
+
+	case "$severity" in
+	high) FINDINGS_HIGH=$((FINDINGS_HIGH + 1)) ;;
+	medium) FINDINGS_MEDIUM=$((FINDINGS_MEDIUM + 1)) ;;
+	low) FINDINGS_LOW=$((FINDINGS_LOW + 1)) ;;
+	esac
+	FINDINGS_TOTAL=$((FINDINGS_TOTAL + 1))
+
+	local color="$NC"
+	# Bash 3.2 compat: no ${var^^} — use tr for uppercase
+	local severity_upper
+	severity_upper=$(printf '%s' "$severity" | tr '[:lower:]' '[:upper:]')
+	case "$severity" in
+	high) color="$RED" ;;
+	medium) color="$YELLOW" ;;
+	low) color="$BLUE" ;;
+	esac
+
+	echo -e "  ${color}[${severity_upper}]${NC} ${BOLD}${location}${NC}"
+	echo -e "    ${description}"
+	echo -e "    Fix (run in separate terminal): ${remediation}"
+	echo ""
+	return 0
+}
+
+get_perms() {
+	local file="$1"
+	if [[ "$(uname)" == "Darwin" ]]; then
+		stat -f %Lp "$file" 2>/dev/null || echo "000"
+	else
+		stat -c %a "$file" 2>/dev/null || echo "000"
+	fi
+}
+
+scan_plaintext_secrets() {
+	echo -e "${BOLD}Plaintext Secret Locations${NC}"
+	echo "=========================="
+	echo ""
+	echo "WARNING: Never paste secret values into AI chat sessions."
+	echo "Run all remediation commands in a SEPARATE TERMINAL."
+	echo ""
+
+	# 1. aidevops credentials.sh
+	local creds="$HOME/.config/aidevops/credentials.sh"
+	if [[ -f "$creds" ]]; then
+		local perms
+		perms=$(get_perms "$creds")
+		if [[ "$perms" != "600" ]]; then
+			report_finding "high" "$creds" \
+				"Plaintext credentials with insecure permissions ($perms)" \
+				"chmod 600 $creds && migrate to gopass: aidevops secret init"
+		else
+			report_finding "medium" "$creds" \
+				"Plaintext credentials file (600 perms — OK but still plaintext on disk)" \
+				"Migrate to gopass: aidevops secret init"
+		fi
+	fi
+
+	# 2. AWS credentials
+	local aws_creds="$HOME/.aws/credentials"
+	if [[ -f "$aws_creds" ]]; then
+		local perms
+		perms=$(get_perms "$aws_creds")
+		local key_count
+		key_count=$(grep -c "aws_access_key_id\|aws_secret_access_key\|aws_session_token" "$aws_creds" 2>/dev/null) || key_count=0
+		report_finding "high" "$aws_creds" \
+			"AWS credentials in plaintext ($key_count key entries, perms: $perms)" \
+			"Use IAM Identity Center or SSO instead of long-lived keys"
+	fi
+
+	# 3. GCP application default credentials
+	local gcp_creds="$HOME/.config/gcloud/application_default_credentials.json"
+	if [[ -f "$gcp_creds" ]]; then
+		report_finding "high" "$gcp_creds" \
+			"GCP application default credentials in plaintext" \
+			"gcloud auth application-default revoke && gcloud auth application-default login"
+	fi
+
+	# 4. Azure tokens
+	local azure_tokens="$HOME/.azure/accessTokens.json"
+	if [[ -f "$azure_tokens" ]]; then
+		report_finding "high" "$azure_tokens" \
+			"Azure access tokens in plaintext" \
+			"az account clear && az login"
+	fi
+
+	# 5. Kubernetes config
+	local kube_config="$HOME/.kube/config"
+	if [[ -f "$kube_config" ]]; then
+		local perms
+		perms=$(get_perms "$kube_config")
+		local has_tokens
+		has_tokens=$(grep -c "token:\|password:\|client-certificate-data:\|client-key-data:" "$kube_config" 2>/dev/null) || has_tokens=0
+		if [[ "$has_tokens" -gt 0 ]]; then
+			report_finding "high" "$kube_config" \
+				"Kubernetes config with $has_tokens embedded credential entries (perms: $perms)" \
+				"Use exec-based auth plugins or rotate tokens"
+		fi
+	fi
+
+	# 6. Docker config (may contain registry auth)
+	local docker_config="$HOME/.docker/config.json"
+	if [[ -f "$docker_config" ]]; then
+		local has_auth=0
+		has_auth=$(grep -c '"auth"' "$docker_config" 2>/dev/null) || has_auth=0
+		if [[ "$has_auth" -gt 0 ]]; then
+			local perms
+			perms=$(get_perms "$docker_config")
+			report_finding "medium" "$docker_config" \
+				"Docker config with $has_auth registry auth entries (perms: $perms)" \
+				"docker logout && docker login (uses credential helper)"
+		fi
+	fi
+
+	# 7. NPM token
+	local npmrc="$HOME/.npmrc"
+	if [[ -f "$npmrc" ]]; then
+		local has_token
+		has_token=$(grep -c "_authToken\|_auth\|//registry" "$npmrc" 2>/dev/null) || has_token=0
+		if [[ "$has_token" -gt 0 ]]; then
+			report_finding "medium" "$npmrc" \
+				"NPM config with $has_token auth token entries" \
+				"npm token revoke <token> && npm login"
+		fi
+	fi
+
+	# 8. PyPI credentials (this is how litellm maintainer was compromised)
+	local pypirc="$HOME/.pypirc"
+	if [[ -f "$pypirc" ]]; then
+		report_finding "high" "$pypirc" \
+			"PyPI credentials in plaintext (PyPI account compromise was the LiteLLM attack vector)" \
+			"rm ~/.pypirc && use trusted publishers or API tokens with limited scope"
+	fi
+
+	# 9. Netrc
+	local netrc="$HOME/.netrc"
+	if [[ -f "$netrc" ]]; then
+		local perms
+		perms=$(get_perms "$netrc")
+		local entry_count
+		entry_count=$(grep -c "^machine\|^login\|^password" "$netrc" 2>/dev/null) || entry_count=0
+		report_finding "medium" "$netrc" \
+			"Netrc with $entry_count entries (perms: $perms)" \
+			"Review and remove unused entries; chmod 600 ~/.netrc"
+	fi
+
+	# 10. GitHub CLI hosts
+	local gh_hosts="$HOME/.config/gh/hosts.yml"
+	if [[ -f "$gh_hosts" ]]; then
+		local perms
+		perms=$(get_perms "$gh_hosts")
+		if [[ "$perms" != "600" ]]; then
+			report_finding "medium" "$gh_hosts" \
+				"GitHub CLI token file with insecure permissions ($perms)" \
+				"chmod 600 $gh_hosts"
+		fi
+	fi
+
+	# 11. SSH keys without passphrase
+	local ssh_dir="$HOME/.ssh"
+	if [[ -d "$ssh_dir" ]]; then
+		local unprotected=0
+		for key in "$ssh_dir"/id_*; do
+			[[ -f "$key" ]] || continue
+			[[ "$key" == *.pub ]] && continue
+			# Check if key has a passphrase — ssh-keygen -y -P "" succeeds only
+			# if the key has no passphrase. The if guards against set -e.
+			if ssh-keygen -y -f "$key" -P "" >/dev/null 2>&1; then
+				unprotected=$((unprotected + 1))
+			fi
+		done
+		if [[ "$unprotected" -gt 0 ]]; then
+			report_finding "high" "$ssh_dir/id_*" \
+				"$unprotected SSH private key(s) without passphrase protection" \
+				"ssh-keygen -p -f <key_file> (adds passphrase to existing key)"
+		fi
+	fi
+
+	# 12. .env files in Git repos
+	local env_count=0
+	if command -v fd &>/dev/null; then
+		env_count=$(fd -g ".env" "$HOME/Git/" --max-depth 3 --type f 2>/dev/null | wc -l | tr -d ' ') || env_count=0
+	fi
+	if [[ "${env_count:-0}" -gt 0 ]]; then
+		report_finding "medium" "$HOME/Git/**/.env" \
+			"$env_count .env file(s) found in Git project directories" \
+			"Ensure .env is in .gitignore; migrate secrets to gopass: aidevops secret set NAME"
+	fi
+
+	# 13. Stripe CLI config
+	local stripe_config="$HOME/.config/stripe"
+	if [[ -d "$stripe_config" ]]; then
+		report_finding "medium" "$stripe_config" \
+			"Stripe CLI config directory (may contain API keys)" \
+			"stripe login (refreshes token via browser)"
+	fi
+
+	return 0
+}
+
+# ============================================================
+# PYTHON .PTH FILE AUDIT (supply chain IoC detection)
+# ============================================================
+
+scan_pth_files() {
+	echo -e "${BOLD}Python .pth File Audit${NC}"
+	echo "======================"
+	echo ""
+	echo "(.pth files execute on EVERY Python startup — primary supply chain attack vector)"
+	echo ""
+
+	local found_suspicious=0
+
+	# Find all Python site-packages directories
+	for py in /opt/homebrew/opt/python@*/bin/python3.* /usr/local/bin/python3.*; do
+		[[ -x "$py" ]] || continue
+		local sp
+		sp=$("$py" -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) || continue
+		[[ -d "$sp" ]] || continue
+
+		for pth in "$sp"/*.pth; do
+			[[ -f "$pth" ]] || continue
+			local basename_pth
+			basename_pth=$(basename "$pth")
+
+			# Known-safe .pth files
+			case "$basename_pth" in
+			distutils-precedence.pth | easy-install.pth | setuptools.pth | pip.pth)
+				continue
+				;;
+			esac
+
+			# Specific IoC: litellm_init.pth
+			if [[ "$basename_pth" == "litellm_init.pth" ]]; then
+				report_finding "high" "$pth" \
+					"KNOWN MALWARE: litellm_init.pth (LiteLLM supply chain attack IoC)" \
+					"IMMEDIATELY: rm '$pth' && rotate ALL credentials on this machine"
+				found_suspicious=1
+				continue
+			fi
+
+			# Check for suspicious content (NEVER print the actual content)
+			if grep -qE "subprocess|exec\(|base64|urllib|requests\.|socket\.|http" "$pth" 2>/dev/null; then
+				report_finding "high" "$pth" \
+					"Suspicious .pth file with code execution patterns" \
+					"Investigate: review the file content manually in your terminal"
+				found_suspicious=1
+			else
+				report_finding "low" "$pth" \
+					"Non-standard .pth file (review recommended)" \
+					"Check if this file is expected for your Python environment"
+			fi
+		done
+	done
+
+	# Check uv/pipx caches for compromised versions
+	for cache_dir in "$HOME/.cache/uv" "$HOME/.local/share/uv" "$HOME/Library/Caches/uv"; do
+		[[ -d "$cache_dir" ]] || continue
+		local malicious_versions
+		malicious_versions=$(find "$cache_dir" -path "*litellm*1.82.7*" -o -path "*litellm*1.82.8*" 2>/dev/null | head -5)
+		if [[ -n "$malicious_versions" ]]; then
+			report_finding "high" "$cache_dir" \
+				"Compromised LiteLLM version (1.82.7 or 1.82.8) found in uv cache" \
+				"IMMEDIATELY: uv cache clean && rotate ALL credentials"
+		fi
+	done
+
+	# Check for malicious domain references
+	if grep -rq "models.litellm.cloud" /etc/hosts "$HOME/.zshrc" "$HOME/.bashrc" 2>/dev/null; then
+		report_finding "high" "DNS/config" \
+			"Reference to malicious domain models.litellm.cloud found" \
+			"Investigate immediately — this machine may be compromised"
+	fi
+
+	if [[ "$found_suspicious" -eq 0 && "$FINDINGS_HIGH" -eq 0 ]]; then
+		echo -e "  ${GREEN}[OK]${NC} No suspicious .pth files found"
+		echo ""
+	fi
+
+	return 0
+}
+
+# ============================================================
+# UNPINNED DEPENDENCY CHECK
+# ============================================================
+
+scan_unpinned_deps() {
+	echo -e "${BOLD}Dependency Pinning Check${NC}"
+	echo "========================"
+	echo ""
+
+	local repo_root
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+	if [[ -z "$repo_root" ]]; then
+		echo "  Not in a git repository — skipping dependency check"
+		echo ""
+		return 0
+	fi
+
+	# Check requirements.txt for unpinned deps
+	local req_file="$repo_root/requirements.txt"
+	if [[ -f "$req_file" ]]; then
+		local unpinned=0
+		while IFS= read -r line; do
+			[[ "$line" =~ ^[[:space:]]*# ]] && continue
+			[[ -z "$line" ]] && continue
+			if echo "$line" | grep -qE '>=' && ! echo "$line" | grep -qE '=='; then
+				unpinned=$((unpinned + 1))
+			fi
+		done <"$req_file"
+
+		if [[ "$unpinned" -gt 0 ]]; then
+			report_finding "high" "$req_file" \
+				"$unpinned dependencies with unpinned upper bounds (>=)" \
+				"Pin to exact versions (==) to prevent supply chain attacks"
+		else
+			echo -e "  ${GREEN}[OK]${NC} All Python dependencies pinned to exact versions"
+		fi
+	fi
+
+	# Check package.json for unpinned deps
+	local pkg_file="$repo_root/package.json"
+	if [[ -f "$pkg_file" ]] && command -v jq &>/dev/null; then
+		local unpinned_npm=0
+		unpinned_npm=$(jq -r '(.dependencies // {}) + (.devDependencies // {}) | to_entries[] | select(.value | test("^[\\^~]")) | .key' "$pkg_file" 2>/dev/null | wc -l | tr -d ' ')
+		if [[ "${unpinned_npm:-0}" -gt 0 ]]; then
+			report_finding "medium" "$pkg_file" \
+				"$unpinned_npm npm dependencies with ^ or ~ version ranges" \
+				"Consider pinning exact versions or using npm shrinkwrap / package-lock.json"
+		fi
+	fi
+
+	echo ""
+	return 0
+}
+
+# ============================================================
+# MCP SERVER DEPENDENCY AUDIT
+# ============================================================
+
+scan_mcp_configs() {
+	echo -e "${BOLD}MCP Server Dependency Audit${NC}"
+	echo "==========================="
+	echo ""
+
+	local found_risk=0
+
+	for config in "$HOME/.config/Claude/claude_desktop_config.json" "$HOME/.cursor/mcp.json"; do
+		[[ -f "$config" ]] || continue
+
+		local uvx_count=0 npx_count=0
+		uvx_count=$(grep -c '"uvx"' "$config" 2>/dev/null) || uvx_count=0
+		npx_count=$(grep -c '"npx"' "$config" 2>/dev/null) || npx_count=0
+
+		if [[ "${uvx_count:-0}" -gt 0 ]]; then
+			report_finding "medium" "$config" \
+				"$uvx_count MCP server(s) using uvx (auto-downloads latest Python packages)" \
+				"Pin versions in MCP config or switch to local installs"
+			found_risk=1
+		fi
+
+		if [[ "${npx_count:-0}" -gt 0 ]]; then
+			report_finding "low" "$config" \
+				"$npx_count MCP server(s) using npx (auto-downloads latest npm packages)" \
+				"Pin versions or use locally installed packages"
+			found_risk=1
+		fi
+	done
+
+	if [[ "$found_risk" -eq 0 ]]; then
+		echo -e "  ${GREEN}[OK]${NC} No auto-downloading MCP server configurations found"
+	fi
+
+	echo ""
+	return 0
+}
+
+# ============================================================
+# STARTUP CHECK (one-line for greeting)
+# ============================================================
+
+cmd_startup_check() {
+	local findings=0
+
+	# Quick .pth check (most critical — active malware indicator)
+	for py in /opt/homebrew/opt/python@*/bin/python3.* /usr/local/bin/python3.*; do
+		[[ -x "$py" ]] || continue
+		local sp
+		sp=$("$py" -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) || continue
+		[[ -d "$sp" ]] || continue
+		if [[ -f "$sp/litellm_init.pth" ]]; then
+			echo "CRITICAL: LiteLLM supply chain malware detected! Run in your terminal: secret-hygiene-helper.sh scan"
+			return 1
+		fi
+		for pth in "$sp"/*.pth; do
+			[[ -f "$pth" ]] || continue
+			local bn
+			bn=$(basename "$pth")
+			case "$bn" in
+			distutils-precedence.pth | easy-install.pth | setuptools.pth | pip.pth) continue ;;
+			esac
+			if grep -qE "subprocess|exec\(|base64" "$pth" 2>/dev/null; then
+				findings=$((findings + 1))
+			fi
+		done
+	done
+
+	# Quick plaintext secret check (count locations, not values)
+	local plaintext_count=0
+	[[ -f "$HOME/.aws/credentials" ]] && plaintext_count=$((plaintext_count + 1))
+	[[ -f "$HOME/.pypirc" ]] && plaintext_count=$((plaintext_count + 1))
+	[[ -f "$HOME/.config/gcloud/application_default_credentials.json" ]] && plaintext_count=$((plaintext_count + 1))
+	[[ -f "$HOME/.azure/accessTokens.json" ]] && plaintext_count=$((plaintext_count + 1))
+
+	if [[ "$findings" -gt 0 ]]; then
+		echo "WARNING: $findings suspicious .pth file(s) found. Run in your terminal: secret-hygiene-helper.sh scan"
+		return 1
+	fi
+
+	if [[ "$plaintext_count" -gt 0 ]]; then
+		echo "Secret hygiene: $plaintext_count high-risk plaintext credential location(s). Run in your terminal: secret-hygiene-helper.sh scan"
+		return 1
+	fi
+
+	# All clear — no output (keeps greeting clean)
+	return 0
+}
+
+# ============================================================
+# FULL SCAN
+# ============================================================
+
+cmd_scan() {
+	echo -e "${BOLD}${BLUE}Secret Hygiene & Supply Chain Scan${NC}"
+	echo "==================================="
+	echo ""
+	echo "WARNING: Never paste secret values into AI chat sessions."
+	echo "Run ALL remediation commands in a SEPARATE TERMINAL."
+	echo ""
+
+	scan_plaintext_secrets
+	scan_pth_files
+	scan_unpinned_deps
+	scan_mcp_configs
+
+	# Show active advisories
+	local has_advisories=0
+	ensure_advisories_dir
+	for advisory in "$ADVISORIES_DIR"/*.advisory; do
+		[[ -f "$advisory" ]] || continue
+		local advisory_id
+		advisory_id=$(basename "$advisory" .advisory)
+		if is_dismissed "$advisory_id"; then
+			continue
+		fi
+		if [[ "$has_advisories" -eq 0 ]]; then
+			echo -e "${BOLD}${RED}Active Security Advisories${NC}"
+			echo "=========================="
+			echo ""
+			has_advisories=1
+		fi
+		cat "$advisory"
+		echo ""
+		echo -e "  Dismiss after taking action: $(basename "$0") dismiss $advisory_id"
+		echo ""
+	done
+
+	# Summary
+	echo -e "${BOLD}Summary${NC}"
+	echo "======="
+	if [[ "$FINDINGS_TOTAL" -eq 0 ]]; then
+		echo -e "  ${GREEN}All clear — no findings.${NC}"
+	else
+		[[ "$FINDINGS_HIGH" -gt 0 ]] && echo -e "  ${RED}High: $FINDINGS_HIGH${NC}"
+		[[ "$FINDINGS_MEDIUM" -gt 0 ]] && echo -e "  ${YELLOW}Medium: $FINDINGS_MEDIUM${NC}"
+		[[ "$FINDINGS_LOW" -gt 0 ]] && echo -e "  ${BLUE}Low: $FINDINGS_LOW${NC}"
+		echo ""
+		echo "Run remediation commands in a SEPARATE TERMINAL — not in AI chat."
+		echo "After rotating credentials, dismiss advisories:"
+		echo "  secret-hygiene-helper.sh dismiss <advisory-id>"
+	fi
+
+	if [[ "$FINDINGS_HIGH" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# ============================================================
+# HELP
+# ============================================================
+
+print_usage() {
+	cat <<'EOF'
+Usage: secret-hygiene-helper.sh <command> [options]
+
+Secret hygiene scanner and supply chain IoC detector.
+NEVER exposes secret values — only reports locations and key names.
+Run ALL remediation commands in a SEPARATE TERMINAL, not in AI chat.
+
+Commands:
+  scan              Full scan (secrets, .pth files, deps, MCP configs)
+  scan-secrets      Plaintext secret locations only
+  scan-pth          Python .pth file audit only (supply chain IoC)
+  scan-deps         Unpinned dependency check only
+  startup-check     One-line summary for session greeting
+  dismiss <id>      Dismiss a security advisory after taking action
+  help              Show this help
+
+Advisory System:
+  Advisories are delivered via aidevops updates as files in:
+    ~/.aidevops/advisories/<id>.advisory
+
+  They appear in the session greeting until dismissed.
+  Dismiss after taking action: secret-hygiene-helper.sh dismiss <id>
+
+Examples:
+  secret-hygiene-helper.sh scan                    # Full scan
+  secret-hygiene-helper.sh scan-pth               # Check for .pth malware
+  secret-hygiene-helper.sh startup-check          # Quick check for greeting
+  secret-hygiene-helper.sh dismiss litellm-2026-03  # Dismiss after rotating creds
+EOF
+	return 0
+}
+
+# ============================================================
+# MAIN
+# ============================================================
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	scan)
+		cmd_scan "$@"
+		;;
+	scan-secrets)
+		scan_plaintext_secrets "$@"
+		;;
+	scan-pth)
+		scan_pth_files "$@"
+		;;
+	scan-deps)
+		scan_unpinned_deps "$@"
+		;;
+	startup-check)
+		cmd_startup_check "$@"
+		;;
+	dismiss)
+		local advisory_id="${1:-}"
+		if [[ -z "$advisory_id" ]]; then
+			echo "Usage: $(basename "$0") dismiss <advisory-id>"
+			return 2
+		fi
+		dismiss_advisory "$advisory_id"
+		;;
+	help | --help | -h)
+		print_usage
+		;;
+	*)
+		echo "Unknown command: $cmd"
+		print_usage
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/secret-hygiene-helper.sh
+++ b/.agents/scripts/secret-hygiene-helper.sh
@@ -569,7 +569,7 @@ cmd_scan() {
 		echo "  secret-hygiene-helper.sh dismiss <advisory-id>"
 	fi
 
-	if [[ "$FINDINGS_HIGH" -gt 0 ]]; then
+	if [[ "$FINDINGS_TOTAL" -gt 0 ]]; then
 		return 1
 	fi
 	return 0

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ authorized_keys
 # Exception for credential/secret management scripts (not actual credentials)
 !.agents/scripts/credential-helper.sh
 !.agents/scripts/secret-helper.sh
+!.agents/scripts/secret-hygiene-helper.sh
 !.agents/scripts/tests/test-secret-helper.sh
 
 # Environment files

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The result: an AI operations platform that manages projects across every busines
 - `aidevops update` - Update framework
 - `aidevops auto-update` - Automatic update polling (enable/disable/status)
 - `aidevops secret` - Manage secrets (gopass encrypted, AI-safe)
+- `aidevops security scan` - Secret hygiene & supply chain scan
 - `/onboarding` - Interactive setup wizard (in AI assistant)
 
 ### Agent Structure
@@ -122,6 +123,22 @@ The result: an AI operations platform that manages projects across every busines
 
 **Capabilities:** Execute commands, access credentials, modify infrastructure, interact with APIs
 **Your responsibility:** Use trusted AI providers, rotate credentials regularly, monitor activity
+
+### Security Commands
+
+```bash
+aidevops security              # Interactive security posture setup
+aidevops security scan         # Scan for plaintext secrets, supply chain IoCs, unpinned deps
+aidevops security scan-pth     # Python .pth file audit (supply chain attack vector)
+aidevops security scan-secrets # Plaintext credential locations only
+aidevops security scan-deps    # Unpinned dependency check
+aidevops security dismiss <id> # Dismiss a security advisory after taking action
+aidevops security status       # Detailed security posture report
+```
+
+**Security advisories** are delivered via `aidevops update` and shown in the session greeting until dismissed. The scanner never exposes secret values — only file locations and key names. All remediation commands should be run in a separate terminal, not inside AI chat sessions.
+
+**Supply chain hardening:** All Python dependencies are pinned to exact versions (`==`) to prevent malicious package upgrades. The `.pth` file auditor detects known supply chain attack indicators (e.g., the LiteLLM March 2026 PyPI compromise).
 
 ## **Quick Start**
 

--- a/README.md
+++ b/README.md
@@ -127,14 +127,18 @@ The result: an AI operations platform that manages projects across every busines
 ### Security Commands
 
 ```bash
-aidevops security              # Interactive security posture setup
-aidevops security scan         # Scan for plaintext secrets, supply chain IoCs, unpinned deps
+aidevops security              # Run ALL checks (posture + hygiene + supply chain)
+aidevops security posture      # Interactive security posture setup (gopass, gh auth, SSH)
+aidevops security status       # Combined posture + hygiene summary
+aidevops security scan         # Secret hygiene & supply chain scan only
 aidevops security scan-pth     # Python .pth file audit (supply chain attack vector)
 aidevops security scan-secrets # Plaintext credential locations only
 aidevops security scan-deps    # Unpinned dependency check
+aidevops security check        # Per-repo security posture assessment
 aidevops security dismiss <id> # Dismiss a security advisory after taking action
-aidevops security status       # Detailed security posture report
 ```
+
+Running `aidevops security` with no arguments is the single command that covers everything — user security posture, plaintext secret detection, supply chain IoC scanning, and active advisories.
 
 **Security advisories** are delivered via `aidevops update` and shown in the session greeting until dismissed. The scanner never exposes secret values — only file locations and key names. All remediation commands should be run in a separate terminal, not inside AI chat sessions.
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3072,7 +3072,7 @@ _help_commands() {
 	echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
 	echo "  model-accounts-pool OAuth account pool (list/check/add/rotate/reset-cooldowns)"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
-	echo "  security <cmd>     Security posture, secret hygiene, supply chain scanning"
+	echo "  security [cmd]     Full security assessment (posture + hygiene + supply chain)"
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
@@ -3086,15 +3086,14 @@ _help_commands() {
 
 _help_detailed_sections() {
 	echo "Security:"
-	echo "  aidevops security check      # Run per-repo security posture assessment"
-	echo "  aidevops security audit      # Alias for check"
-	echo "  aidevops security summary    # One-line per-repo security status"
-	echo "  aidevops security setup      # Interactive guided user security setup"
-	echo "  aidevops security status     # Detailed user security posture report"
+	echo "  aidevops security            # Run ALL checks (posture + hygiene + supply chain)"
+	echo "  aidevops security posture    # Interactive security posture setup (gopass, gh, SSH)"
+	echo "  aidevops security status     # Combined posture + hygiene summary"
 	echo "  aidevops security scan       # Secret hygiene & supply chain scan"
 	echo "  aidevops security scan-pth   # Python .pth file audit (supply chain IoC)"
 	echo "  aidevops security scan-secrets # Plaintext credential locations"
 	echo "  aidevops security scan-deps  # Unpinned dependency check"
+	echo "  aidevops security check      # Per-repo security posture assessment"
 	echo "  aidevops security dismiss <id> # Dismiss a security advisory"
 	echo ""
 	echo "IP Reputation:"
@@ -3326,6 +3325,16 @@ main() {
 	pulse) _dispatch_helper "pulse-session-helper.sh" "pulse-session-helper.sh" "$@" ;;
 	security)
 		case "${1:-}" in
+		"")
+			# No args: run ALL security checks (posture + hygiene + advisories)
+			echo ""
+			echo "Running full security assessment..."
+			echo "==================================="
+			echo ""
+			_dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" status || true
+			echo ""
+			_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" scan || true
+			;;
 		scan | scan-secrets | scan-pth | scan-deps | dismiss)
 			_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" "$@"
 			;;
@@ -3333,8 +3342,18 @@ main() {
 			shift
 			_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" "${@:-scan}"
 			;;
+		posture | setup)
+			shift || true
+			_dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" "${@:-setup}"
+			;;
+		status)
+			# Status shows both posture and hygiene summary
+			_dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" status || true
+			echo ""
+			_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" startup-check || true
+			;;
 		*)
-			[[ $# -eq 0 ]] && _dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" setup || _dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" "$@"
+			_dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" "$@"
 			;;
 		esac
 		;;

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3072,7 +3072,7 @@ _help_commands() {
 	echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
 	echo "  model-accounts-pool OAuth account pool (list/check/add/rotate/reset-cooldowns)"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
-	echo "  security <cmd>     Security posture (check/audit/setup/status/summary)"
+	echo "  security <cmd>     Security posture, secret hygiene, supply chain scanning"
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
@@ -3091,6 +3091,11 @@ _help_detailed_sections() {
 	echo "  aidevops security summary    # One-line per-repo security status"
 	echo "  aidevops security setup      # Interactive guided user security setup"
 	echo "  aidevops security status     # Detailed user security posture report"
+	echo "  aidevops security scan       # Secret hygiene & supply chain scan"
+	echo "  aidevops security scan-pth   # Python .pth file audit (supply chain IoC)"
+	echo "  aidevops security scan-secrets # Plaintext credential locations"
+	echo "  aidevops security scan-deps  # Unpinned dependency check"
+	echo "  aidevops security dismiss <id> # Dismiss a security advisory"
 	echo ""
 	echo "IP Reputation:"
 	echo "  aidevops ip-check check <ip> # Check IP reputation across providers"
@@ -3319,7 +3324,20 @@ main() {
 	sources | agent-sources) _dispatch_helper "agent-sources-helper.sh" "agent-sources-helper.sh" "$@" ;;
 	plugin | plugins) cmd_plugin "$@" ;;
 	pulse) _dispatch_helper "pulse-session-helper.sh" "pulse-session-helper.sh" "$@" ;;
-	security) [[ $# -eq 0 ]] && _dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" setup || _dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" "$@" ;;
+	security)
+		case "${1:-}" in
+		scan | scan-secrets | scan-pth | scan-deps | dismiss)
+			_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" "$@"
+			;;
+		hygiene)
+			shift
+			_dispatch_helper "secret-hygiene-helper.sh" "secret-hygiene-helper.sh" "${@:-scan}"
+			;;
+		*)
+			[[ $# -eq 0 ]] && _dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" setup || _dispatch_helper "security-posture-helper.sh" "security-posture-helper.sh" "$@"
+			;;
+		esac
+		;;
 	doctor | doc) _dispatch_helper "doctor-helper.sh" "doctor-helper.sh" "$@" ;;
 	detect | scan) cmd_detect ;;
 	ip-check | ip_check) _dispatch_helper "ip-reputation-helper.sh" "ip-reputation-helper.sh" "$@" ;;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,36 @@
 # AI DevOps Framework - Python Dependencies
 # DSPy and DSPyGround integration requirements
+#
+# SECURITY: All versions pinned to exact versions (==) to prevent supply chain
+# attacks via malicious PyPI uploads. See: LiteLLM supply chain incident
+# (March 2026) where compromised v1.82.7/v1.82.8 contained credential stealers.
+# Update versions deliberately via requirements-lock.txt, not automatically.
 
 # Core DSPy packages
-dspy-ai>=2.6.27
-dspy>=2.6.27
+dspy-ai==2.6.27
+dspy==2.6.27
 
 # Core dependencies for AI/ML workflows
-openai>=2.8.0
-litellm>=1.79.3
-pandas>=2.3.3
-numpy>=2.0.2
-requests>=2.32.5
+openai==2.8.0
+litellm==1.79.3
+pandas==2.3.3
+numpy==2.0.2
+requests==2.32.5
 
 # Data processing and storage
-datasets>=4.4.1
-diskcache>=5.6.3
-joblib>=1.5.2
+datasets==4.4.1
+diskcache==5.6.3
+joblib==1.5.2
 
 # Optimization and experimentation
-optuna>=4.6.0
-tenacity>=9.1.2
+optuna==4.6.0
+tenacity==9.1.2
 
 # Utilities
-rich>=14.2.0
-tqdm>=4.67.1
-python-dotenv>=1.2.1
-pydantic>=2.12.4
+rich==14.2.0
+tqdm==4.67.1
+python-dotenv==1.2.1
+pydantic==2.12.4
 
 # Optional: Browser automation (for Agno integration)
 # playwright>=1.40.0

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -207,6 +207,22 @@ deploy_aidevops_agents() {
 			print_warning "VERSION file not found in repo root"
 		fi
 
+		# Deploy security advisories (shown in session greeting until dismissed)
+		local advisories_source="$source_dir/advisories"
+		local advisories_target="$HOME/.aidevops/advisories"
+		if [[ -d "$advisories_source" ]]; then
+			mkdir -p "$advisories_target"
+			local adv_count=0
+			for adv_file in "$advisories_source"/*.advisory; do
+				[[ -f "$adv_file" ]] || continue
+				cp "$adv_file" "$advisories_target/"
+				adv_count=$((adv_count + 1))
+			done
+			if [[ "$adv_count" -gt 0 ]]; then
+				print_info "Deployed $adv_count security advisory/advisories"
+			fi
+		fi
+
 		# Inject extracted OpenCode plan-reminder into Plan+ if available
 		local plan_reminder="$HOME/.aidevops/cache/opencode-prompts/plan-reminder.txt"
 		local plan_plus="$target_dir/plan-plus.md"


### PR DESCRIPTION
## Summary

- Add **secret-hygiene-helper.sh**: scans for plaintext secrets (13 locations: AWS, GCP, Azure, k8s, Docker, npm, PyPI, SSH, .env, etc.), Python `.pth` supply chain IoCs, unpinned dependencies, and MCP auto-download risks. Never exposes secret values — all remediation directed to separate terminal sessions.
- Add **security advisory system**: `.agents/advisories/*.advisory` files deployed via `aidevops update`, shown in session greeting until user dismisses with `secret-hygiene-helper.sh dismiss <id>`. First advisory: LiteLLM PyPI supply chain attack (March 24, 2026).
- **Pin all Python deps** in `requirements.txt` to exact versions (`==`) to prevent supply chain attacks.
- **Consolidate `aidevops security`** into a single unified command: `aidevops security` (no args) runs ALL checks — user posture + secret hygiene + supply chain + advisories. Subcommands preserved for targeted use.

## What changed

| File | Change |
|------|--------|
| `.agents/scripts/secret-hygiene-helper.sh` | New: 660-line scanner (bash 3.2 compatible, ShellCheck clean) |
| `.agents/advisories/litellm-2026-03.advisory` | New: first security advisory |
| `.agents/scripts/aidevops-update-check.sh` | Greeting integration: secret hygiene startup check + advisory display |
| `setup-modules/agent-deploy.sh` | Deploy advisories to `~/.aidevops/advisories/` |
| `aidevops.sh` | Consolidated security CLI routing + help text |
| `requirements.txt` | All deps pinned `>=` → `==` |
| `.gitignore` | Exception for `secret-hygiene-helper.sh` |
| `README.md` | Security Commands section, Key Commands update |
| `.agents/AGENTS.md` | Security section docs, Domain Index update |
| `.agents/scripts/commands/security-scan.md` | Updated with hygiene checks + CLI reference |

## CLI commands

```
aidevops security              # Run ALL checks (posture + hygiene + supply chain)
aidevops security posture      # Interactive security posture setup
aidevops security scan         # Secret hygiene & supply chain scan only
aidevops security check        # Per-repo posture assessment
aidevops security status       # Combined posture + hygiene summary
aidevops security dismiss <id> # Dismiss a security advisory
```

## Context

LiteLLM v1.82.7/v1.82.8 (March 24, 2026) contained credential stealers via compromised PyPI maintainer account. DSPy depends on `litellm>=1.64.0` (unpinned), amplifying the attack surface. The malware used Python `.pth` files which execute on every Python startup regardless of imports.

This machine was NOT affected (pinned to `litellm==1.79.3`, no `.pth` IoCs found). The advisory system ensures all aidevops users are notified on next session start.

## Testing

- `secret-hygiene-helper.sh scan` — runs clean, finds expected plaintext locations
- `secret-hygiene-helper.sh startup-check` — silent when clean, reports when findings exist
- Advisory deploy → greeting display → dismiss cycle verified
- ShellCheck clean on all modified scripts
- Bash 3.2 compatible (fixed `${var^^}`, `grep -c || echo` patterns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `aidevops security` command with subcommands for posture assessment, secret hygiene scanning, and supply chain vulnerability detection
  * New security advisory system that delivers active security alerts at startup with support for dismissing advisories

* **Documentation**
  * Updated security command documentation in README with guidance on new scanning capabilities

* **Chores**
  * Pinned all project dependencies to exact versions for improved supply chain security resilience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->