### PR TITLE
simplification: tighten opencode.md (631 → 462 lines)

### DIFF
--- a/.agents/tools/opencode/opencode.md
+++ b/.agents/tools/opencode/opencode.md
@@ -17,12 +17,12 @@ tools:
 
 ## Quick Reference
 
-- **Primary Agent**: `aidevops` - Full framework access
+- **Primary Agent**: `aidevops` — full framework access
 - **Subagents**: hostinger, hetzner, wordpress, seo, code-quality, browser-automation, etc.
 - **Setup**: `./setup.sh` (from aidevops repo)
-- **MCPs disabled globally** - enabled per-agent to save context tokens
+- **MCPs disabled globally** — enabled per-agent to save context tokens
 
-**Critical Paths** (AI assistants often need these):
+**Critical Paths:**
 
 | Purpose | Path |
 |---------|------|
@@ -32,45 +32,32 @@ tools:
 | aidevops agents | `~/.aidevops/agents/` (after setup.sh) |
 | Credentials | `~/.config/aidevops/credentials.sh` |
 
-**Key Commands**:
+**Key Commands:**
 
 ```bash
-# Install agents
+# Install/update agents
 .agents/scripts/generate-opencode-agents.sh
 
-# Check status
-.agents/scripts/generate-opencode-agents.sh
-
-# Authenticate (OAuth plugins)
+# Authenticate (built-in OAuth, v1.1.36+)
 opencode auth login
-# - Anthropic → Claude Pro/Max (direct Claude access)
-# - Anthropic → Claude Pro/Max (direct Claude access)
+# Select: Anthropic → Claude Pro/Max (or Create an API Key)
 
 # In OpenCode:
 # - Tab to switch primary agents
 # - @agent-name to invoke subagents
-```text
+```
 
 <!-- AI-CONTEXT-END -->
 
-## Overview
-
-OpenCode is a CLI AI assistant that supports specialized agents and MCP (Model Context Protocol) servers. This integration configures OpenCode with aidevops-specific agents and MCPs.
-
 ## Anthropic OAuth (Built-in)
 
-OpenCode v1.1.36+ includes Anthropic OAuth authentication natively. No external plugin is needed.
-
-**Authenticate after setup:**
+OpenCode v1.1.36+ includes Anthropic OAuth natively. No external plugin needed.
 
 ```bash
 opencode auth login
 # Select: Anthropic → Claude Pro/Max (or Create an API Key)
-# Complete OAuth flow in browser
-# Paste authorization code when prompted
+# Complete OAuth flow in browser, paste authorization code when prompted
 ```
-
-**Authentication methods:**
 
 | Method | Use Case | Cost |
 |--------|----------|------|
@@ -78,45 +65,32 @@ opencode auth login
 | **Create API Key** | OAuth-based key creation | Standard API rates |
 | **Manual API Key** | Existing API keys | Standard API rates |
 
-**Benefits of OAuth:**
-- Automatic token refresh (no re-authentication)
-- Beta features auto-enabled (extended thinking, etc.)
-- Zero cost for Pro/Max subscribers
-- No manual API key management
+OAuth benefits: automatic token refresh, beta features auto-enabled, zero cost for Pro/Max subscribers, no manual key management.
 
-> **Note:** The external `opencode-anthropic-auth` plugin is no longer needed and should be removed from `opencode.json` plugins if present. Adding it alongside the built-in version causes a TypeError due to double-loading.
+> **Note:** The external `opencode-anthropic-auth` plugin is no longer needed. Remove it from `opencode.json` plugins if present — adding it alongside the built-in version causes a TypeError due to double-loading.
 
 ## Installation
 
 ### Prerequisites
 
-1. **OpenCode CLI** installed - https://opencode.ai
+1. **OpenCode CLI** installed — https://opencode.ai
 2. **aidevops framework** cloned to `~/Git/aidevops/`
 3. **MCP servers** installed (optional, per-service)
 
 ### Quick Setup
 
 ```bash
-# Run the setup script
 cd ~/Git/aidevops
 .agents/scripts/generate-opencode-agents.sh
-```text
+```
 
-This creates:
-- `~/.config/opencode/agent/` directory
-- Agent markdown files for each service
-- Updates `opencode.json` with agent configurations
+This creates `~/.config/opencode/agent/` with agent markdown files and updates `opencode.json` with agent configurations.
 
 ## Agent Architecture
 
 ### Primary Agent: aidevops
 
-The main agent with full framework access. Use `Tab` to switch to it.
-
-**Capabilities**:
-- All built-in tools (write, edit, bash, read, glob, grep, webfetch, task)
-- Access to all helper scripts
-- Full documentation access
+The main agent with full framework access. Use `Tab` to switch to it. Has all built-in tools (write, edit, bash, read, glob, grep, webfetch, task) plus access to all helper scripts and documentation.
 
 ### Subagents
 
@@ -147,7 +121,7 @@ Specialized agents invoked with `@agent-name`. MCPs are enabled only for relevan
   "mcp": {
     "hostinger-api": {
       "type": "local",
-      "command": [...],
+      "command": ["..."],
       "enabled": false
     }
   },
@@ -164,18 +138,13 @@ Specialized agents invoked with `@agent-name`. MCPs are enabled only for relevan
     }
   }
 }
-```text
+```
 
-**Key Design**:
-- MCPs are defined but `enabled: false` (not started at launch)
-- Tools are disabled globally with `"mcp_*": false`
-- Each subagent enables its specific tools with `"mcp_*": true`
-
-This saves context tokens by only loading MCP tools when the relevant subagent is invoked.
+**Design pattern:** MCPs are defined but `enabled: false` globally. Tools are disabled with `"mcp_*": false`. Each subagent enables its specific tools with `"mcp_*": true` — this saves context tokens by only loading MCP tools when the relevant subagent is invoked.
 
 ### Agent Markdown Format
 
-Agents can be defined as markdown files in `~/.config/opencode/agent/`:
+Agents are defined as markdown files in `~/.config/opencode/agent/`:
 
 ```markdown
 ---
@@ -190,57 +159,23 @@ tools:
 # Agent Name
 
 Detailed instructions for the agent...
-```text
+```
 
 ## Usage
 
 ### Switching Agents
 
 - **Tab**: Cycle through primary agents
-- **@agent-name**: Invoke a subagent
+- **@agent-name**: Invoke a subagent (one `@mention` per message)
 
-### Agent Invocation Order
+### Recommended Workflow Order
 
-OpenCode doesn't have built-in workflow orchestration, but agents should be invoked in logical order based on dependencies:
-
-#### Recommended Workflow Order
-
-```text
-┌─────────────────────────────────────────────────────────────────┐
-│                    DEVELOPMENT WORKFLOW                         │
-├─────────────────────────────────────────────────────────────────┤
-│  1. PLAN/RESEARCH (parallel)                                    │
-│     @context7-mcp-setup  - Get documentation                    │
-│     @seo                 - Research keywords/competitors        │
-│     @browser-automation  - Scrape/test existing sites           │
-│                                                                 │
-│  2. INFRASTRUCTURE (sequential)                                 │
-│     @dns-providers       - Configure DNS first                  │
-│     @hetzner             - Provision servers                    │
-│     @hostinger           - Setup hosting/WordPress              │
-│                                                                 │
-│  3. DEVELOPMENT (parallel)                                      │
-│     @wordpress           - Local development                    │
-│     @git-platforms       - Repository management                │
-│     @crawl4ai-usage      - Data extraction                      │
-│                                                                 │
-│  4. QUALITY (sequential)                                        │
-│     @code-standards        - Run checks, apply fixes              │
-│     @agent-review        - Session analysis + PR                │
-└─────────────────────────────────────────────────────────────────┘
-```text
-
-#### Parallel vs Sequential
-
-| Type | Agents | When to Use |
-|------|--------|-------------|
-| **Parallel** | Research agents (seo, context7, browser) | No dependencies between tasks |
-| **Sequential** | Infrastructure (dns → server → hosting) | Output of one is input to next |
-| **Always Last** | code-quality, agent-review | Requires completed work to review |
-
-#### Invoking Multiple Agents
-
-OpenCode processes one `@mention` per message. For parallel work, send separate messages:
+| Phase | Agents | Execution |
+|-------|--------|-----------|
+| 1. Plan/Research | @context7-mcp-setup, @seo, @browser-automation | Parallel (no dependencies) |
+| 2. Infrastructure | @dns-providers → @hetzner → @hostinger | Sequential (output chains) |
+| 3. Development | @wordpress, @git-platforms, @crawl4ai-usage | Parallel |
+| 4. Quality | @code-standards → @agent-review | Sequential (always last) |
 
 ```bash
 # Parallel research (send in quick succession)
@@ -254,20 +189,28 @@ OpenCode processes one `@mention` per message. For parallel work, send separate 
 > @hetzner create server app-server in brandlight
 # Wait for server...
 > @hostinger deploy WordPress to app.example.com
+```
+
+### End-of-Session Pattern (MANDATORY)
+
+Always end sessions with these agents in order:
+
+1. **@code-standards** — fix any quality issues introduced
+2. **@agent-review** — analyze session, suggest improvements, optionally create PR
+
+The review agent identifies which agents were used, evaluates missing/incorrect/excessive information, generates ready-to-apply edits, and can compose a PR to contribute improvements back to aidevops.
+
 ```text
-
-#### End-of-Session Pattern (MANDATORY)
-
-**Always end sessions with these agents in order:**
-
-1. **@code-standards** - Fix any quality issues introduced
-2. **@agent-review** - Analyze session, suggest improvements, optionally create PR
+Session → @agent-review → Improvements → Better Agents → Better Sessions
+                ↓
+         PR to aidevops repo (optional)
+```
 
 ```bash
-> @code-standards check and fix any issues in today's changes
-# Wait for fixes...
-> @agent-review analyze this session
-```text
+> @agent-review create a PR for improvement #2
+```
+
+The agent has restricted bash permissions — only `git *` and `gh pr *` commands are allowed (with confirmation).
 
 ### Example Workflows
 
@@ -276,30 +219,16 @@ OpenCode processes one `@mention` per message. For parallel work, send separate 
 opencode
 > What services are available?
 
-# Invoke Hostinger subagent
+# Invoke subagents
 > @hostinger list all websites
-
-# Invoke Hetzner subagent
 > @hetzner list servers in brandlight account
-
-# Invoke SEO subagent
 > @seo get top queries for example.com last 30 days
-
-# Invoke code quality
 > @code-standards run ShellCheck on all scripts
-```text
+```
 
 ## CLI Testing Mode
 
-The OpenCode TUI requires a restart to pick up configuration changes (new MCPs, agents, slash commands). Use the CLI for quick testing without restarting.
-
-### When to Use CLI Testing
-
-- **New MCP servers** added to `opencode.json`
-- **Agent configuration changes** (tools, permissions)
-- **Slash commands** added or modified
-- **Quick one-off commands** with specific agents
-- **Debugging MCP connection issues**
+The OpenCode TUI requires a restart for config changes (new MCPs, agents, slash commands). Use the CLI for quick testing without restarting.
 
 ### Basic CLI Testing
 
@@ -315,7 +244,7 @@ opencode run "Quick test" --agent Build+ --model anthropic/claude-sonnet-4-6
 
 # Capture errors for debugging
 opencode run "Test the serper MCP" --agent SEO 2>&1
-```text
+```
 
 ### Persistent Server Mode (Faster Iteration)
 
@@ -330,7 +259,7 @@ opencode run --attach http://localhost:4096 "Test query" --agent SEO
 opencode run --attach http://localhost:4096 "Another test" --agent SEO
 
 # After config changes: Ctrl+C in Terminal 1, restart server
-```text
+```
 
 ### Testing Scenarios
 
@@ -344,8 +273,6 @@ opencode run --attach http://localhost:4096 "Another test" --agent SEO
 
 ### Helper Script
 
-Use the helper script for common testing tasks:
-
 ```bash
 # Test if MCP is accessible
 ~/.aidevops/agents/scripts/opencode-test-helper.sh test-mcp dataforseo SEO
@@ -358,11 +285,11 @@ Use the helper script for common testing tasks:
 
 # Start persistent server
 ~/.aidevops/agents/scripts/opencode-test-helper.sh serve 4096
-```text
+```
 
 ### Workflow: Adding New MCP
 
-1. Edit `~/.config/opencode/opencode.json` - add MCP config
+1. Edit `~/.config/opencode/opencode.json` — add MCP config
 2. Test with CLI: `opencode run "Test [mcp]" --agent [agent] 2>&1`
 3. If errors, check stderr output and fix config
 4. If working, restart TUI to use interactively
@@ -387,7 +314,7 @@ export HCLOUD_TOKEN_STORAGEBOX="your-token"
 # Google Search Console
 # Requires service account JSON file at:
 # ~/.config/aidevops/gsc-credentials.json
-```text
+```
 
 ### Installing MCP Servers
 
@@ -402,13 +329,11 @@ brew install mcp-hetzner
 brew install mcp-local-wp
 
 # Chrome DevTools MCP (auto-installed via npx)
-```text
+```
 
 ### OpenCode MCP Environment Variable Limitation
 
-**Important**: OpenCode's MCP `environment` blocks do NOT expand shell variables like `${VAR}` - they are treated as literal strings.
-
-**Solution**: Use bash wrapper pattern to expand variables at runtime:
+OpenCode's MCP `environment` blocks do NOT expand shell variables like `${VAR}` — they are treated as literal strings. Use the bash wrapper pattern to expand variables at runtime:
 
 ```json
 {
@@ -433,99 +358,51 @@ brew install mcp-local-wp
     }
   }
 }
-```text
-
-This pattern:
-1. Uses `/bin/bash -c` to run a shell command
-2. Sets the required env var by reading from your shell environment
-3. Then executes the MCP server with that variable set
+```
 
 ## Troubleshooting
 
-### MCPs Not Loading
+| Problem | Steps |
+|---------|-------|
+| **MCPs not loading** | 1. Check MCP `enabled` in opencode.json 2. Verify env vars set 3. Test MCP command manually |
+| **Agent not found** | 1. Check file exists in `~/.config/opencode/agent/` 2. Verify frontmatter YAML valid 3. Restart OpenCode |
+| **Tools not available** | 1. Check tools enabled in agent config 2. Verify glob patterns match MCP tool names 3. Check MCP server responding |
 
-1. Check MCP is enabled in opencode.json
-2. Verify environment variables are set
-3. Test MCP command manually
+### File Locations
 
-### Agent Not Found
-
-1. Check file exists in `~/.config/opencode/agent/`
-2. Verify frontmatter YAML is valid
-3. Restart OpenCode
-
-### Tools Not Available
-
-1. Check tools enabled in agent config
-2. Verify glob patterns match MCP tool names
-3. Check MCP server is responding
-
-## File Locations
-
-**OpenCode Configuration:**
-
-| Path | Purpose | Notes |
-|------|---------|-------|
-| `~/.config/opencode/opencode.json` | Main configuration | MCP servers, agents, tools |
-| `~/.config/opencode/agent/*.md` | Agent markdown files | Per-agent instructions |
-| `~/.opencode/` | Alternative location | Some installations use this |
-| `~/.opencode/agent/` | Alternative agent location | Check if ~/.config not working |
-
-**aidevops Integration:**
-
-| Path | Purpose | Notes |
-|------|---------|-------|
-| `~/.aidevops/agents/` | Deployed aidevops agents | Created by setup.sh |
-| `~/.config/aidevops/credentials.sh` | API credentials | 600 permissions |
-| `~/Git/aidevops/.agents/` | Source agents | Development repo |
-| `~/Git/aidevops/setup.sh` | Deployment script | Copies to ~/.aidevops/ |
-
-**Troubleshooting Path Issues:**
+| Path | Purpose |
+|------|---------|
+| `~/.config/opencode/opencode.json` | Main config (MCP servers, agents, tools) |
+| `~/.config/opencode/agent/*.md` | Agent markdown files |
+| `~/.opencode/` | Alternative config location (some installations) |
+| `~/.opencode/agent/` | Alternative agent location |
+| `~/.aidevops/agents/` | Deployed aidevops agents (created by setup.sh) |
+| `~/.config/aidevops/credentials.sh` | API credentials (600 permissions) |
+| `~/Git/aidevops/.agents/` | Source agents (development repo) |
+| `~/Git/aidevops/setup.sh` | Deployment script (copies to ~/.aidevops/) |
 
 ```bash
-# Check which OpenCode config is active
+# Verify paths
 ls -la ~/.config/opencode/ ~/.opencode/ 2>/dev/null
-
-# Verify agent deployment
 ls -la ~/.aidevops/agents/ 2>/dev/null
-
-# Check if aidevops agents are referenced
 grep -l "aidevops" ~/.config/opencode/agent/*.md 2>/dev/null
-```text
+```
 
 ## Permission Model Limitations
 
-### Critical: Subagent Permission Inheritance
+### Subagent Permission Inheritance
 
-**OpenCode subagents do NOT inherit parent agent permission restrictions.**
+**OpenCode subagents do NOT inherit parent agent permission restrictions.** When a parent agent uses the `task` tool to spawn a subagent, the subagent runs with its OWN tool permissions — parent's `write: false` or `bash: deny` are NOT enforced.
 
-When a parent agent uses the `task` tool to spawn a subagent:
-- The subagent runs with its OWN tool permissions
-- Parent's `write: false` is NOT enforced on the subagent
-- Parent's `bash: deny` is NOT enforced on the subagent
+| Configuration | Actually Read-Only? |
+|---------------|---------------------|
+| `write: false, edit: false, task: true` | **NO** — subagents can write |
+| `write: false, edit: false, bash: true` | **NO** — bash can write files |
+| `write: false, edit: false, bash: false, task: false` | **YES** — truly read-only |
 
-**Implications for Read-Only Agents:**
-
-| Configuration | Is Actually Read-Only? |
-|---------------|----------------------|
-| `write: false, edit: false, task: true` | NO - subagents can write |
-| `write: false, edit: false, bash: true` | NO - bash can write files |
-| `write: false, edit: false, bash: false, task: false` | YES - truly read-only |
-
-**Example**: A read-only agent (like @plan-plus) with `task: true` could call a subagent that creates files, defeating its read-only purpose.
-
-### Bash Escapes All Restrictions
-
-When `bash: true`, the agent can execute ANY shell command, including:
-- `echo "content" > file.txt` - creates files
-- `sed -i 's/old/new/' file.txt` - modifies files
-- `rm file.txt` - deletes files
-
-**For true read-only behavior**: Set both `bash: false` AND `task: false`
+**For true read-only behavior**: set both `bash: false` AND `task: false`.
 
 ### @plan-plus Read-Only Configuration
-
-The @plan-plus subagent is configured as strictly read-only:
 
 ```json
 "@plan-plus": {
@@ -545,63 +422,21 @@ The @plan-plus subagent is configured as strictly read-only:
     "webfetch": true
   }
 }
-```text
+```
 
 Use Build+ (Tab) for any operations requiring file changes.
 
-## Continuous Improvement with @agent-review
-
-**End every session by calling `@agent-review`** to analyze the conversation and improve agents:
-
-```text
-@agent-review analyze this session and suggest improvements to the agents used
-```text
-
-The review agent will:
-1. Identify which agents were used
-2. Evaluate missing, incorrect, or excessive information
-3. Suggest specific improvements to agent files
-4. Generate ready-to-apply edits
-5. **Optionally compose a PR** to contribute improvements back to aidevops
-
-**Feedback Loop:**
-
-```text
-Session → @agent-review → Improvements → Better Agents → Better Sessions
-                ↓
-         PR to aidevops repo (optional)
-```text
-
-**Contributing back:**
-
-```text
-@agent-review create a PR for improvement #2
-```text
-
-This creates a branch, applies changes, and submits a PR to `marcusquinn/aidevops`. The agent has restricted bash permissions - only `git *` and `gh pr *` commands are allowed (with confirmation).
-
 ## Code Quality Learning Loop
 
-The `@code-standards` agent doesn't just fix issues - it learns from them:
+The `@code-standards` agent learns from issues it fixes:
 
 ```text
 Quality Issue → Fix Applied → Pattern Identified → Framework Updated → Issue Prevented
-```text
+```
 
-After fixing violations from SonarCloud, Codacy, ShellCheck, etc.:
-
-1. **Categorize the issue** - Shell scripting, security, style, architecture
-2. **Analyze root cause** - Why didn't the framework prevent this?
-3. **Update framework** - Add guidance, examples, or checklist items
-4. **Submit PR** - Contribute the prevention back to aidevops
-
-Example: Finding 15 SC2162 violations (read without -r) leads to adding clear examples in AGENTS.md's shell best practices section.
+After fixing violations (SonarCloud, Codacy, ShellCheck, etc.): categorize the issue, analyze root cause, update framework guidance, and submit a PR to contribute the prevention back to aidevops.
 
 ## Spawning Parallel Sessions
-
-OpenCode supports multiple session patterns for parallel work.
-
-### Quick Reference
 
 ```bash
 # Non-interactive execution
@@ -618,11 +453,7 @@ opencode run --attach http://localhost:4097 "Task" --agent Build+
 ~/.aidevops/agents/scripts/worktree-helper.sh add feature/parallel-task
 ```
 
-See `workflows/session-manager.md` for full session lifecycle guidance including:
-- Terminal tab spawning (macOS, Linux)
-- Session handoff patterns
-- Worktree integration
-- Loop completion detection
+See `workflows/session-manager.md` for full session lifecycle guidance including terminal tab spawning, session handoff patterns, worktree integration, and loop completion detection.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Reduces `.agents/tools/opencode/opencode.md` from 631 to 462 lines (27% reduction, now under the 500-line threshold)
- Fixes 19 broken code fences (`\`\`\`text` incorrectly used as closing fences throughout the file)
- Consolidates redundant sections while preserving all unique technical content

## Changes

| What | Detail |
|------|--------|
| Broken code fences | Fixed 19 instances of `\`\`\`text` used where `\`\`\`` should close blocks |
| ASCII workflow diagram | Replaced 24-line box-drawing diagram with compact table |
| End-of-Session + @agent-review | Merged two overlapping sections into one |
| File Locations | Consolidated two separate tables into one |
| Troubleshooting | Converted 3 subsections (9 numbered steps) into single table |
| Quick Reference | Removed duplicate "Install agents"/"Check status" commands and duplicate auth line |
| Explanatory prose | Compressed paragraphs that restated adjacent code/JSON examples |

## Content Preservation Verification

- All URLs present (5 external links)
- All key technical terms verified: `opencode.json`, `generate-opencode-agents.sh`, `opencode-test-helper.sh`, `credentials.sh`, `opencode auth login`, `opencode run`, `opencode serve`, `worktree-helper.sh`, `session-manager.md`, `context7`, `hostinger-api`, `hetzner`, `plan-plus`, `code-standards`, `agent-review`, `HCLOUD_TOKEN`, `HOSTINGER_API_TOKEN`, `gsc-credentials.json`, `ahrefs`, `TypeError`, `v1.1.36`
- All code fences properly paired (38 markers, all matched)
- Markdown lint: clean (no violations)

Closes #5972