### PR TITLE
qd-6056: Reduce function complexity in email-signature-parser-helper.sh

### DIFF
--- a/.agents/scripts/email-signature-parser-helper.sh
+++ b/.agents/scripts/email-signature-parser-helper.sh
@@ -384,6 +384,89 @@ contact:
 TOON
 }
 
+# Extract existing field values from a TOON contact file in a single pass.
+# Sets caller variables: existing_name, existing_title, existing_company,
+# existing_phone, existing_website, existing_address.
+# Args: toon_content (string)
+_extract_existing_fields() {
+	local content="$1"
+
+	existing_name=""
+	existing_title=""
+	existing_company=""
+	existing_phone=""
+	existing_website=""
+	existing_address=""
+
+	local _line
+	while IFS= read -r _line; do
+		case "$_line" in
+		"  name: "*) existing_name="${_line#  name: }" ;;
+		"  title: "*) existing_title="${_line#  title: }" ;;
+		"  company: "*) existing_company="${_line#  company: }" ;;
+		"  phone: "*) existing_phone="${_line#  phone: }" ;;
+		"  website: "*) existing_website="${_line#  website: }" ;;
+		"  address: "*) existing_address="${_line#  address: }" ;;
+		esac
+	done <<<"$content"
+	return 0
+}
+
+# Check a single field for changes and update the existing record.
+# If the new value differs from the old, appends a history entry and updates
+# the field in-place. If the old value is empty, fills it.
+# Reads/writes caller variables: existing, history_entries.
+# Args: field_name new_val old_val now source
+_check_and_update_field() {
+	local field_name="$1"
+	local new_val="$2"
+	local old_val="$3"
+	local now="$4"
+	local source="$5"
+
+	# Skip if new value is empty
+	[[ -z "$new_val" ]] && return 0
+
+	# Detect change: new value differs from old value and old value is not empty
+	if [[ -n "$old_val" && "$new_val" != "$old_val" ]]; then
+		# Append to history
+		history_entries="${history_entries}    - date: ${now}
+      field: ${field_name}
+      old: ${old_val}
+      new: ${new_val}
+      source: ${source}
+"
+		# Update the field in the existing record
+		existing=$(sed "s|^  ${field_name}: .*|  ${field_name}: ${new_val}|" <<<"$existing")
+	elif [[ -z "$old_val" ]]; then
+		# Fill empty field
+		existing=$(sed "s|^  ${field_name}: $|  ${field_name}: ${new_val}|" <<<"$existing")
+	fi
+	return 0
+}
+
+# Append accumulated history entries to the existing TOON record.
+# Reads/writes caller variable: existing.
+# Args: history_entries (string, may be empty)
+_append_history_entries() {
+	local history_entries="$1"
+
+	[[ -z "$history_entries" ]] && return 0
+
+	# Check if history section exists
+	if ! echo "$existing" | grep -q "^  history:"; then
+		# Add history section
+		existing="${existing}
+  history:
+${history_entries}"
+	else
+		# Append to existing history section
+		existing="${existing}
+${history_entries}"
+	fi
+	return 0
+}
+
 # t1044.4: Enhanced merge with field change detection and history tracking
 # Merge a new contact record into an existing TOON file.
 # If the file exists:
@@ -417,77 +500,27 @@ merge_toon_contact() {
 	local existing
 	existing=$(cat "$toon_file")
 
-	# Extract existing field values in a single pass (avoids repeated grep per field)
+	# Extract existing field values
 	local existing_name existing_title existing_company existing_phone existing_website existing_address
-	while IFS= read -r _line; do
-		case "$_line" in
-		"  name: "*) existing_name="${_line#  name: }" ;;
-		"  title: "*) existing_title="${_line#  title: }" ;;
-		"  company: "*) existing_company="${_line#  company: }" ;;
-		"  phone: "*) existing_phone="${_line#  phone: }" ;;
-		"  website: "*) existing_website="${_line#  website: }" ;;
-		"  address: "*) existing_address="${_line#  address: }" ;;
-		esac
-	done <<<"$existing"
+	_extract_existing_fields "$existing"
 
-	# Update last_seen (here-string: line-anchored replacement in multiline string)
+	# Update last_seen
 	existing=$(sed "s/^  last_seen: .*/  last_seen: ${now}/" <<<"$existing")
 
 	# Detect field changes and build history entries
 	local history_entries=""
-
-	# Helper function to check and update a field
-	check_and_update_field() {
-		local field_name="$1"
-		local new_val="$2"
-		local old_val="$3"
-
-		# Skip if new value is empty
-		[[ -z "$new_val" ]] && return 0
-
-		# Detect change: new value differs from old value and old value is not empty
-		if [[ -n "$old_val" && "$new_val" != "$old_val" ]]; then
-			# Append to history
-			history_entries="${history_entries}    - date: ${now}
-      field: ${field_name}
-      old: ${old_val}
-      new: ${new_val}
-      source: ${source}
-"
-			# Update the field in the existing record (here-string: line-anchored multiline replacement)
-			existing=$(sed "s|^  ${field_name}: .*|  ${field_name}: ${new_val}|" <<<"$existing")
-		elif [[ -z "$old_val" ]]; then
-			# Fill empty field (here-string: line-anchored multiline replacement)
-			existing=$(sed "s|^  ${field_name}: $|  ${field_name}: ${new_val}|" <<<"$existing")
-		fi
-		return 0
-	}
-
-	# Check each field for changes
-	check_and_update_field "name" "$name" "$existing_name"
-	check_and_update_field "title" "$title" "$existing_title"
-	check_and_update_field "company" "$company" "$existing_company"
-	check_and_update_field "phone" "$phone" "$existing_phone"
-	check_and_update_field "website" "$website" "$existing_website"
-	check_and_update_field "address" "$address" "$existing_address"
+	_check_and_update_field "name" "$name" "$existing_name" "$now" "$source"
+	_check_and_update_field "title" "$title" "$existing_title" "$now" "$source"
+	_check_and_update_field "company" "$company" "$existing_company" "$now" "$source"
+	_check_and_update_field "phone" "$phone" "$existing_phone" "$now" "$source"
+	_check_and_update_field "website" "$website" "$existing_website" "$now" "$source"
+	_check_and_update_field "address" "$address" "$existing_address" "$now" "$source"
 
 	# Append history entries if any changes detected
-	if [[ -n "$history_entries" ]]; then
-		# Check if history section exists
-		if ! echo "$existing" | grep -q "^  history:"; then
-			# Add history section
-			existing="${existing}
-  history:
-${history_entries}"
-		else
-			# Append to existing history section
-			existing="${existing}
-${history_entries}"
-		fi
-	fi
+	_append_history_entries "$history_entries"
 
 	# Upgrade confidence if new is higher
-	local existing_conf
+	local existing_conf _field_line
 	_field_line=$(echo "$existing" | grep -E "^  confidence: " || true)
 	existing_conf="${_field_line#  confidence: }"
 	if [[ "$confidence" == "high" && "$existing_conf" != "high" ]]; then
@@ -745,6 +778,140 @@ parse_llm_output() {
 }
 
 # =============================================================================
+# Main Parsing Logic — Sub-functions
+# =============================================================================
+
+# Calculate confidence level from the number of extracted fields.
+# Prints: "high", "medium", or "low".
+# Args: name title company phone website address
+_calculate_confidence() {
+	local name="$1"
+	local title="$2"
+	local company="$3"
+	local phone="$4"
+	local website="$5"
+	local address="$6"
+
+	local field_count=0
+	[[ -n "$name" ]] && field_count=$((field_count + 1))
+	[[ -n "$title" ]] && field_count=$((field_count + 1))
+	[[ -n "$company" ]] && field_count=$((field_count + 1))
+	[[ -n "$phone" ]] && field_count=$((field_count + 1))
+	[[ -n "$website" ]] && field_count=$((field_count + 1))
+	[[ -n "$address" ]] && field_count=$((field_count + 1))
+
+	if [[ "$field_count" -le 1 ]]; then
+		echo "low"
+	elif [[ "$field_count" -le 3 ]]; then
+		echo "medium"
+	else
+		echo "high"
+	fi
+	return 0
+}
+
+# Attempt LLM fallback extraction and merge results into caller variables.
+# Reads/writes caller variables: name, title, company, phone, website, address,
+# emails_raw, confidence, used_llm.
+# Args: sig_block
+_apply_llm_fallback() {
+	local sig_block="$1"
+
+	print_info "Low confidence from regex — attempting LLM extraction..."
+	local llm_output
+	if llm_output=$(llm_extract_signature "$sig_block"); then
+		parse_llm_output "$llm_output"
+		used_llm=true
+
+		# Fill in missing fields from LLM
+		[[ -z "$name" && -n "$LLM_NAME" ]] && name="$LLM_NAME"
+		[[ -z "$title" && -n "$LLM_TITLE" ]] && title="$LLM_TITLE"
+		[[ -z "$company" && -n "$LLM_COMPANY" ]] && company="$LLM_COMPANY"
+		[[ -z "$phone" && -n "$LLM_PHONE" ]] && phone="$LLM_PHONE"
+		[[ -z "$website" && -n "$LLM_WEBSITE" ]] && website="$LLM_WEBSITE"
+		[[ -z "$address" && -n "$LLM_ADDRESS" ]] && address="$LLM_ADDRESS"
+
+		# Add LLM-discovered emails
+		if [[ -n "$LLM_EMAIL" ]]; then
+			emails_raw=$(printf '%s\n%s' "$emails_raw" "$LLM_EMAIL" | sort -uf | grep -v '^$' || true)
+		fi
+
+		# Recalculate confidence, downgraded since LLM was needed
+		confidence=$(_calculate_confidence "$name" "$title" "$company" "$phone" "$website" "$address")
+		if [[ "$confidence" == "high" ]]; then
+			confidence="medium"
+		fi
+	fi
+	return 0
+}
+
+# Save contact to TOON file and cross-reference additional emails.
+# Args: contacts_dir emails_raw name title company phone website address source_label confidence
+# Prints: toon_file path on stdout.
+_save_contact_and_crossref() {
+	local contacts_dir="$1"
+	local emails_raw="$2"
+	local name="$3"
+	local title="$4"
+	local company="$5"
+	local phone="$6"
+	local website="$7"
+	local address="$8"
+	local source_label="$9"
+	local confidence="${10}"
+
+	# Resolve contact filename (handle name collisions)
+	local primary_email
+	primary_email=$(echo "$emails_raw" | head -1)
+	local toon_file
+	toon_file=$(resolve_contact_filename "$contacts_dir" "$primary_email" "$name")
+
+	# Merge contact with field change detection and history tracking
+	merge_toon_contact "$toon_file" "$primary_email" "$name" "$title" "$company" "$phone" "$website" "$address" "$source_label" "$confidence"
+
+	# Cross-reference additional emails
+	local email_count
+	email_count=$(echo "$emails_raw" | wc -l | tr -d ' ')
+	if [[ "$email_count" -gt 1 ]]; then
+		local additional_email
+		while IFS= read -r additional_email; do
+			[[ "$additional_email" == "$primary_email" ]] && continue
+			add_email_cross_reference "$toon_file" "$additional_email"
+		done <<<"$emails_raw"
+	fi
+
+	echo "$toon_file"
+	return 0
+}
+
+# Print a summary of the extracted contact fields.
+# Args: toon_file name title company primary_email phone website address confidence used_llm
+_print_contact_summary() {
+	local toon_file="$1"
+	local name="$2"
+	local title="$3"
+	local company="$4"
+	local primary_email="$5"
+	local phone="$6"
+	local website="$7"
+	local address="$8"
+	local confidence="$9"
+	local used_llm="${10}"
+
+	print_success "Contact saved: ${toon_file}"
+	print_info "  Name: ${name:-<not found>}"
+	print_info "  Title: ${title:-<not found>}"
+	print_info "  Company: ${company:-<not found>}"
+	print_info "  Email: ${primary_email}"
+	print_info "  Phone: ${phone:-<not found>}"
+	print_info "  Website: ${website:-<not found>}"
+	print_info "  Address: ${address:-<not found>}"
+	print_info "  Confidence: ${confidence}"
+	[[ "$used_llm" == true ]] && print_info "  LLM fallback: yes"
+	return 0
+}
+
+# =============================================================================
 # Main Parsing Logic
 # =============================================================================
 
@@ -802,66 +969,14 @@ parse_email_signature() {
 		company=$(extract_company "$sig_block" "$name" "$title" 2>/dev/null) || true
 	fi
 
-	# Determine confidence based on how many fields we extracted
-	local field_count=0
-	[[ -n "$name" ]] && field_count=$((field_count + 1))
-	[[ -n "$title" ]] && field_count=$((field_count + 1))
-	[[ -n "$company" ]] && field_count=$((field_count + 1))
-	[[ -n "$phone" ]] && field_count=$((field_count + 1))
-	[[ -n "$website" ]] && field_count=$((field_count + 1))
-	[[ -n "$address" ]] && field_count=$((field_count + 1))
-
-	local confidence="high"
-	if [[ "$field_count" -le 1 ]]; then
-		confidence="low"
-	elif [[ "$field_count" -le 3 ]]; then
-		confidence="medium"
-	fi
+	# Determine confidence
+	local confidence
+	confidence=$(_calculate_confidence "$name" "$title" "$company" "$phone" "$website" "$address")
 
 	# LLM fallback if regex extraction was poor
 	local used_llm=false
 	if [[ "$confidence" == "low" || -z "$emails_raw" ]]; then
-		print_info "Low confidence from regex — attempting LLM extraction..."
-		local llm_output
-		if llm_output=$(llm_extract_signature "$sig_block"); then
-			parse_llm_output "$llm_output"
-			used_llm=true
-
-			# Fill in missing fields from LLM
-			[[ -z "$name" && -n "$LLM_NAME" ]] && name="$LLM_NAME"
-			[[ -z "$title" && -n "$LLM_TITLE" ]] && title="$LLM_TITLE"
-			[[ -z "$company" && -n "$LLM_COMPANY" ]] && company="$LLM_COMPANY"
-			[[ -z "$phone" && -n "$LLM_PHONE" ]] && phone="$LLM_PHONE"
-			[[ -z "$website" && -n "$LLM_WEBSITE" ]] && website="$LLM_WEBSITE"
-			[[ -z "$address" && -n "$LLM_ADDRESS" ]] && address="$LLM_ADDRESS"
-
-			# Add LLM-discovered emails
-			if [[ -n "$LLM_EMAIL" ]]; then
-				emails_raw=$(printf '%s\n%s' "$emails_raw" "$LLM_EMAIL" | sort -uf | grep -v '^$' || true)
-			fi
-
-			# Recalculate confidence
-			field_count=0
-			[[ -n "$name" ]] && field_count=$((field_count + 1))
-			[[ -n "$title" ]] && field_count=$((field_count + 1))
-			[[ -n "$company" ]] && field_count=$((field_count + 1))
-			[[ -n "$phone" ]] && field_count=$((field_count + 1))
-			[[ -n "$website" ]] && field_count=$((field_count + 1))
-			[[ -n "$address" ]] && field_count=$((field_count + 1))
-
-			if [[ "$field_count" -le 1 ]]; then
-				confidence="low"
-			elif [[ "$field_count" -le 3 ]]; then
-				confidence="medium"
-			else
-				confidence="high"
-			fi
-
-			# Downgrade slightly since LLM was needed
-			if [[ "$confidence" == "high" ]]; then
-				confidence="medium"
-			fi
-		fi
+		_apply_llm_fallback "$sig_block"
 	fi
 
 	# Check we have at least one email
@@ -875,36 +990,13 @@ parse_email_signature() {
 		source_label="${source_label}+llm"
 	fi
 
-	# t1044.4: Resolve contact filename (handle name collisions)
-	local primary_email
+	# t1044.4: Save contact and cross-reference additional emails
+	local primary_email toon_file
 	primary_email=$(echo "$emails_raw" | head -1)
-	local toon_file
-	toon_file=$(resolve_contact_filename "$contacts_dir" "$primary_email" "$name")
+	toon_file=$(_save_contact_and_crossref "$contacts_dir" "$emails_raw" "$name" "$title" "$company" "$phone" "$website" "$address" "$source_label" "$confidence")
 
-	# t1044.4: Merge contact with field change detection and history tracking
-	merge_toon_contact "$toon_file" "$primary_email" "$name" "$title" "$company" "$phone" "$website" "$address" "$source_label" "$confidence"
-
-	# t1044.4: Cross-reference additional emails
-	local email_count
-	email_count=$(echo "$emails_raw" | wc -l | tr -d ' ')
-	if [[ "$email_count" -gt 1 ]]; then
-		local additional_email
-		while IFS= read -r additional_email; do
-			[[ "$additional_email" == "$primary_email" ]] && continue
-			add_email_cross_reference "$toon_file" "$additional_email"
-		done <<<"$emails_raw"
-	fi
-
-	print_success "Contact saved: ${toon_file}"
-	print_info "  Name: ${name:-<not found>}"
-	print_info "  Title: ${title:-<not found>}"
-	print_info "  Company: ${company:-<not found>}"
-	print_info "  Email: ${primary_email}"
-	print_info "  Phone: ${phone:-<not found>}"
-	print_info "  Website: ${website:-<not found>}"
-	print_info "  Address: ${address:-<not found>}"
-	print_info "  Confidence: ${confidence}"
-	[[ "$used_llm" == true ]] && print_info "  LLM fallback: yes"
+	# Print summary
+	_print_contact_summary "$toon_file" "$name" "$title" "$company" "$primary_email" "$phone" "$website" "$address" "$confidence" "$used_llm"
 
 	echo "$toon_file"
 	return 0


### PR DESCRIPTION
## Summary

- Extract 7 sub-functions from `merge_toon_contact()` (104 → 55 lines) and `parse_email_signature()` (157 → 83 lines) to bring both under the 100-line threshold
- All existing behavior preserved — pure structural refactor with no logic changes
- `bash -n` syntax check and `shellcheck` pass clean (only SC1091 info for external source)

### Extracted helpers

**From `merge_toon_contact()`:**
- `_extract_existing_fields()` — single-pass TOON field extraction
- `_check_and_update_field()` — per-field change detection (was nested function, now top-level with explicit args)
- `_append_history_entries()` — history section append logic

**From `parse_email_signature()`:**
- `_calculate_confidence()` — field count → confidence level (eliminates duplication)
- `_apply_llm_fallback()` — LLM extraction and field merge
- `_save_contact_and_crossref()` — file resolution, merge, cross-reference
- `_print_contact_summary()` — output formatting

Closes #6056