### PR TITLE
simplification: reduce function complexity in task-brief-helper.sh

### DIFF
--- a/.agents/scripts/task-brief-helper.sh
+++ b/.agents/scripts/task-brief-helper.sh
@@ -177,6 +177,91 @@ db.close()
 
 # --- Step 3: Extract conversation context ---
 
+# Python helper: scan user messages in a session and find the diff that added task_id.
+# Prints the task block lines bracketed by TASK_BLOCK_START/END and a MESSAGE_TITLE= line.
+# Called via env vars to prevent injection.
+_python_extract_task_block() {
+	python3 -c "
+import sqlite3, json, re, os
+
+def _peek_next_indent(lines, i, task_indent):
+    '''Return True if the next non-blank line after index i is more indented than task_indent.'''
+    for j in range(i + 1, min(i + 3, len(lines))):
+        if lines[j].strip():
+            next_indent = len(lines[j]) - len(lines[j].lstrip())
+            return next_indent > task_indent
+    return False
+
+def _extract_block_from_diff(after, task_id):
+    '''Extract the task block lines from a diff's after-text.'''
+    lines = after.split('\n')
+    capturing = False
+    task_block = []
+    task_indent = -1
+    for i, line in enumerate(lines):
+        if re.search(rf'- \[.\] {re.escape(task_id)} ', line):
+            capturing = True
+            task_indent = len(line) - len(line.lstrip())
+            task_block.append(line)
+            continue
+        if capturing:
+            current_indent = len(line) - len(line.lstrip())
+            if line.strip() == '':
+                if _peek_next_indent(lines, i, task_indent):
+                    task_block.append(line)
+                else:
+                    break
+            elif current_indent > task_indent:
+                task_block.append(line)
+            else:
+                break
+    result = []
+    if task_block:
+        result.append('TASK_BLOCK_START')
+        result.extend(task_block)
+        result.append('TASK_BLOCK_END')
+    return result
+
+db_path = os.environ['BRIEF_OPENCODE_DB']
+session_id = os.environ['BRIEF_SESSION_ID']
+task_id = os.environ['BRIEF_TASK_ID']
+
+db = sqlite3.connect(db_path)
+db.execute('PRAGMA journal_mode=WAL')
+db.execute('PRAGMA busy_timeout=5000')
+cursor = db.cursor()
+
+cursor.execute('''
+    SELECT m.data, m.time_created
+    FROM message m
+    WHERE m.session_id = ?
+    AND json_extract(m.data, '\$.role') = 'user'
+    ORDER BY m.time_created
+''', (session_id,))
+
+context_parts = []
+for row in cursor.fetchall():
+    try:
+        data = json.loads(row[0])
+        summary = data.get('summary', {})
+        title = summary.get('title', '')
+        diffs = summary.get('diffs', [])
+        for diff in diffs:
+            after = diff.get('after', '')
+            before = diff.get('before', '')
+            if task_id in after and task_id not in before:
+                context_parts.extend(_extract_block_from_diff(after, task_id))
+                context_parts.append(f'MESSAGE_TITLE={title}')
+                break
+    except (json.JSONDecodeError, KeyError):
+        continue
+
+db.close()
+print('\n'.join(context_parts) if context_parts else 'NO_CONTEXT_FOUND')
+" 2>/dev/null || echo "NO_CONTEXT_FOUND"
+	return 0
+}
+
 extract_session_context() {
 	local session_id
 	local task_id
@@ -188,97 +273,8 @@ extract_session_context() {
 	fi
 
 	# Pass all parameters via environment variables to prevent injection
-	BRIEF_SESSION_ID="$session_id" BRIEF_TASK_ID="$task_id" BRIEF_OPENCODE_DB="$OPENCODE_DB" python3 -c "
-import sqlite3, json, sys, re, os
-
-db_path = os.environ['BRIEF_OPENCODE_DB']
-session_id = os.environ['BRIEF_SESSION_ID']
-task_id = os.environ['BRIEF_TASK_ID']
-
-db = sqlite3.connect(db_path)
-db.execute('PRAGMA journal_mode=WAL')
-db.execute('PRAGMA busy_timeout=5000')
-cursor = db.cursor()
-
-# Get all user messages from this session — parameterized query
-cursor.execute('''
-    SELECT m.data, m.time_created
-    FROM message m
-    WHERE m.session_id = ?
-    AND json_extract(m.data, '\$.role') = 'user'
-    ORDER BY m.time_created
-''', (session_id,))
-
-context_parts = []
-
-for row in cursor.fetchall():
-    try:
-        data = json.loads(row[0])
-        summary = data.get('summary', {})
-        title = summary.get('title', '')
-        diffs = summary.get('diffs', [])
-
-        # Check if this message's diff added the task
-        for diff in diffs:
-            after = diff.get('after', '')
-            before = diff.get('before', '')
-            if task_id in after and task_id not in before:
-                # This message created the task — extract the full block
-                lines = after.split('\n')
-                capturing = False
-                task_block = []
-                # Find the task line and determine its indent level
-                task_indent = -1
-                for i, line in enumerate(lines):
-                    # Match the task line (with or without checkbox)
-                    if re.search(rf'- \[.\] {re.escape(task_id)} ', line):
-                        capturing = True
-                        task_indent = len(line) - len(line.lstrip())
-                        task_block.append(line)
-                        continue
-                    if capturing:
-                        stripped = line.lstrip()
-                        current_indent = len(line) - len(stripped)
-                        # Continue capturing if:
-                        # - line is blank (preserve structure)
-                        # - line is more indented than the task line
-                        if line.strip() == '':
-                            # Blank line: peek ahead to see if next non-blank
-                            # line is still part of this block
-                            still_in_block = False
-                            for j in range(i + 1, min(i + 3, len(lines))):
-                                if lines[j].strip():
-                                    next_indent = len(lines[j]) - len(lines[j].lstrip())
-                                    if next_indent > task_indent:
-                                        still_in_block = True
-                                    break
-                            if still_in_block:
-                                task_block.append(line)
-                            else:
-                                break
-                        elif current_indent > task_indent:
-                            task_block.append(line)
-                        else:
-                            # Same or less indent = new task or section
-                            break
-
-                if task_block:
-                    context_parts.append('TASK_BLOCK_START')
-                    context_parts.extend(task_block)
-                    context_parts.append('TASK_BLOCK_END')
-
-                context_parts.append(f'MESSAGE_TITLE={title}')
-                break
-    except (json.JSONDecodeError, KeyError):
-        continue
-
-db.close()
-
-if context_parts:
-    print('\n'.join(context_parts))
-else:
-    print('NO_CONTEXT_FOUND')
-" 2>/dev/null || echo "NO_CONTEXT_FOUND"
+	BRIEF_SESSION_ID="$session_id" BRIEF_TASK_ID="$task_id" BRIEF_OPENCODE_DB="$OPENCODE_DB" \
+		_python_extract_task_block
 	return 0
 }
 
@@ -310,21 +306,15 @@ db.close()
 	return 0
 }
 
-# --- Step 5: Generate brief ---
+# --- Step 5: Generate brief (decomposed) ---
 
-generate_brief() {
+# Resolve commit fields into named variables written to stdout as KEY=VALUE lines.
+_resolve_commit_info() {
 	local task_id
 	local project_root
-	local output_file
 	task_id="$1"
 	project_root="$2"
-	output_file="$project_root/todo/tasks/${task_id}-brief.md"
 
-	validate_task_id "$task_id" || return 1
-
-	mkdir -p "$project_root/todo/tasks"
-
-	# Find creation commit
 	local commit
 	commit=$(find_creation_commit "$task_id" "$project_root")
 	if [[ -z "$commit" ]]; then
@@ -332,35 +322,28 @@ generate_brief() {
 		return 1
 	fi
 
-	# Get commit info — separate declaration from assignment per style guide
-	local commit_date
-	local commit_author
-	local commit_msg
+	echo "COMMIT=$commit"
+	get_commit_info "$commit" "$project_root"
+	return 0
+}
+
+# Resolve session info given a project_id and commit epoch.
+# Outputs: SESSION_ID, SESSION_TITLE, PARENT_SESSION (pipe-delimited raw), SEARCH_SESSION
+_resolve_session_info() {
+	local task_id
+	local project_root
 	local commit_epoch
-	commit_date=""
-	commit_author=""
-	commit_msg=""
-	commit_epoch=""
-	while IFS='=' read -r key value; do
-		case "$key" in
-		COMMIT_DATE) commit_date="$value" ;;
-		COMMIT_AUTHOR) commit_author="$value" ;;
-		COMMIT_MSG) commit_msg="$value" ;;
-		COMMIT_EPOCH) commit_epoch="$value" ;;
-		esac
-	done <<<"$(get_commit_info "$commit" "$project_root")"
+	task_id="$1"
+	project_root="$2"
+	commit_epoch="$3"
 
-	log_info "$task_id: commit $commit ($commit_date) by $commit_author"
-
-	# Find OpenCode session
-	local session_id
-	local session_title
-	local parent_session
 	local project_id
-	session_id=""
-	session_title=""
-	parent_session=""
 	project_id=$(find_opencode_project_id "$project_root") || true
+
+	local session_id=""
+	local session_title=""
+	local parent_session=""
+	local search_session=""
 
 	if [[ -n "$project_id" && -n "$commit_epoch" ]]; then
 		local session_info
@@ -379,13 +362,8 @@ generate_brief() {
 		fi
 	fi
 
-	# Extract conversation context
-	local context
-	local search_session
-	context="NO_CONTEXT_FOUND"
-	search_session="${session_id}"
-
-	# If this was a subagent commit session, search the parent
+	# If this was a subagent commit session, search the parent instead
+	search_session="$session_id"
 	if [[ "$session_title" == *"subagent"* && -n "$parent_session" ]]; then
 		search_session=$(echo "$parent_session" | cut -d'|' -f1)
 		local p_title
@@ -393,28 +371,22 @@ generate_brief() {
 		log_info "$task_id: searching parent session '$p_title'"
 	fi
 
-	if [[ -n "$search_session" ]]; then
-		context=$(extract_session_context "$search_session" "$task_id") || true
-	fi
+	echo "SESSION_ID=$session_id"
+	echo "SESSION_TITLE=$session_title"
+	echo "PARENT_SESSION=$parent_session"
+	echo "SEARCH_SESSION=$search_session"
+	return 0
+}
 
-	# Check supervisor DB
-	local supervisor_info
-	supervisor_info=""
-	supervisor_info=$(find_supervisor_context "$task_id") || true
+# Extract the indented block for task_id from a TODO.md file.
+# Writes block content to stdout (multi-line safe).
+_extract_todo_block() {
+	local task_id
+	local todo_file
+	task_id="$1"
+	todo_file="$2"
 
-	# Extract task description from TODO.md
-	local task_line
-	task_line=""
-	task_line=$(grep -E "^\s*- \[.\] ${task_id} " "$project_root/TODO.md" 2>/dev/null | head -1) || true
-	local task_title
-	task_title=""
-	task_title=$(echo "$task_line" | sed -E 's/^.*\] t[0-9]+(\.[0-9]+)* //' | sed -E 's/ #.*//' | sed -E 's/ ~//')
-
-	# Extract task block (subtasks/notes) from TODO.md
-	# Captures the task line and all lines more indented than it
-	local task_block
-	task_block=""
-	task_block=$(BRIEF_TASK_ID="$task_id" BRIEF_TODO_FILE="$project_root/TODO.md" python3 -c "
+	BRIEF_TASK_ID="$task_id" BRIEF_TODO_FILE="$todo_file" python3 -c "
 import re, os
 task_id = os.environ['BRIEF_TASK_ID']
 todo_file = os.environ['BRIEF_TODO_FILE']
@@ -431,7 +403,6 @@ for i, line in enumerate(lines):
         continue
     if capturing:
         if rline.strip() == '':
-            # Blank line: check if next non-blank is still indented
             still_in = False
             for j in range(i + 1, min(i + 3, len(lines))):
                 nxt = lines[j].rstrip('\n')
@@ -448,20 +419,60 @@ for i, line in enumerate(lines):
         else:
             break
 print('\n'.join(block))
-" 2>/dev/null) || true
+" 2>/dev/null
+	return 0
+}
 
-	# Extract REBASE comment
-	local rebase_note
-	rebase_note=""
+# Extract task metadata from TODO.md: task line, task block, rebase note.
+# Outputs simple KEY=VALUE lines; TASK_BLOCK written to a temp file (path in TASK_BLOCK_FILE).
+_resolve_task_metadata() {
+	local task_id
+	local project_root
+	task_id="$1"
+	project_root="$2"
+
+	local task_line=""
+	task_line=$(grep -E "^\s*- \[.\] ${task_id} " "$project_root/TODO.md" 2>/dev/null | head -1) || true
+
+	local task_title=""
+	task_title=$(echo "$task_line" | sed -E 's/^.*\] t[0-9]+(\.[0-9]+)* //' | sed -E 's/ #.*//' | sed -E 's/ ~//')
+
+	local rebase_note=""
 	rebase_note=$(echo "$task_line" | grep -oE '<!-- REBASE:[^>]+-->' | sed 's/<!-- REBASE: //;s/ -->//' || true)
 
-	# Determine session origin string
-	local session_origin
-	session_origin="unknown"
+	# Write multi-line task_block to a temp file to avoid sentinel parsing in callers
+	local block_file
+	block_file=$(mktemp)
+	_extract_todo_block "$task_id" "$project_root/TODO.md" >"$block_file" 2>/dev/null || true
+
+	printf 'TASK_TITLE=%s\n' "$task_title"
+	printf 'REBASE_NOTE=%s\n' "$rebase_note"
+	printf 'TASK_LINE=%s\n' "$task_line"
+	printf 'TASK_BLOCK_FILE=%s\n' "$block_file"
+	return 0
+}
+
+# Derive session_origin and created_by strings from resolved session/commit/supervisor data.
+# Args: session_id session_title parent_session supervisor_info commit_author task_id
+# Outputs: SESSION_ORIGIN=... CREATED_BY=... SUP_ID=...
+_derive_attribution() {
+	local session_id session_title parent_session supervisor_info commit_author task_id
+	session_id="$1"
+	session_title="$2"
+	parent_session="$3"
+	supervisor_info="$4"
+	commit_author="$5"
+	task_id="$6"
+
+	local session_origin="unknown"
+	local sup_id=""
+	if [[ -n "$supervisor_info" ]]; then
+		sup_id=$(echo "$supervisor_info" | cut -d'|' -f1)
+	fi
+
 	if [[ -n "$session_id" ]]; then
 		if [[ -n "$parent_session" ]]; then
-			local p_id
-			local p_title
+			local p_id p_title
 			p_id=$(echo "$parent_session" | cut -d'|' -f1)
 			p_title=$(echo "$parent_session" | cut -d'|' -f2)
 			session_origin="opencode:${p_id} '${p_title}' (committed via subagent ${session_id})"
@@ -476,48 +487,40 @@ print('\n'.join(block))
 		session_origin="external contributor ($commit_author)"
 	fi
 
-	# Determine created_by — supervisor match must be exact (id field only)
-	local created_by
-	local sup_id
-	created_by="ai-interactive"
-	sup_id=""
-	if [[ -n "$supervisor_info" ]]; then
-		sup_id=$(echo "$supervisor_info" | cut -d'|' -f1)
-	fi
+	local created_by="ai-interactive"
 	if [[ -n "$sup_id" && "$sup_id" == "$task_id" ]]; then
 		created_by="ai-supervisor"
 	elif [[ "$commit_author" != "marcusquinn" && "$commit_author" != "GitHub Actions" ]]; then
 		created_by="human ($commit_author)"
 	fi
 
-	# Check for parent task
-	local parent_task
-	parent_task=""
-	if echo "$task_id" | grep -qE '\.'; then
-		parent_task=$(echo "$task_id" | sed -E 's/\.[0-9]+$//')
-	fi
+	printf 'SESSION_ORIGIN=%s\n' "$session_origin"
+	printf 'CREATED_BY=%s\n' "$created_by"
+	printf 'SUP_ID=%s\n' "$sup_id"
+	return 0
+}
 
-	# Extract context block from session data
-	local context_block
-	context_block=""
-	if [[ "$context" != "NO_CONTEXT_FOUND" ]]; then
-		local msg_title
-		msg_title=$(echo "$context" | grep '^MESSAGE_TITLE=' | head -1 | sed 's/MESSAGE_TITLE=//')
-		local task_content
-		task_content=$(echo "$context" | sed -n '/^TASK_BLOCK_START$/,/^TASK_BLOCK_END$/p' | grep -v 'TASK_BLOCK_')
-		if [[ -n "$task_content" ]]; then
-			context_block="$task_content"
-		fi
-		if [[ -n "$msg_title" ]]; then
-			session_origin="${session_origin} — message: '${msg_title}'"
-		fi
-	fi
+# Write the brief markdown file given all resolved metadata.
+_write_brief_file() {
+	local output_file task_id task_title commit commit_date commit_msg
+	local session_origin created_by parent_task
+	local best_block context_block task_block rebase_note supervisor_info sup_id
+	output_file="$1"
+	task_id="$2"
+	task_title="$3"
+	commit="$4"
+	commit_date="$5"
+	commit_msg="$6"
+	session_origin="$7"
+	created_by="$8"
+	parent_task="$9"
+	best_block="${10}"
+	context_block="${11}"
+	task_block="${12}"
+	rebase_note="${13}"
+	supervisor_info="${14}"
+	sup_id="${15}"
 
-	# Prefer session context block over TODO.md extraction (session has original rich content)
-	local best_block
-	best_block="${context_block:-${task_block:-${task_line}}}"
-
-	# Write the brief
 	cat >"$output_file" <<BRIEF
 ---
 mode: subagent
@@ -568,6 +571,130 @@ ${supervisor_info}
 
 <!-- TODO: Add relevant file paths after codebase analysis -->
 BRIEF
+
+	return 0
+}
+
+# Extract context_block from session context output and optionally enrich session_origin.
+# Args: context session_origin
+# Outputs: CONTEXT_BLOCK=... SESSION_ORIGIN=...
+_enrich_context() {
+	local context
+	local session_origin
+	context="$1"
+	session_origin="$2"
+
+	local context_block=""
+	if [[ "$context" != "NO_CONTEXT_FOUND" ]]; then
+		local msg_title
+		msg_title=$(echo "$context" | grep '^MESSAGE_TITLE=' | head -1 | sed 's/MESSAGE_TITLE=//')
+		context_block=$(echo "$context" | sed -n '/^TASK_BLOCK_START$/,/^TASK_BLOCK_END$/p' | grep -v 'TASK_BLOCK_')
+		if [[ -n "$msg_title" ]]; then
+			session_origin="${session_origin} — message: '${msg_title}'"
+		fi
+	fi
+
+	printf 'SESSION_ORIGIN=%s\n' "$session_origin"
+	printf 'CONTEXT_BLOCK_START\n%s\nCONTEXT_BLOCK_END\n' "$context_block"
+	return 0
+}
+
+generate_brief() {
+	local task_id
+	local project_root
+	local output_file
+	task_id="$1"
+	project_root="$2"
+	output_file="$project_root/todo/tasks/${task_id}-brief.md"
+
+	validate_task_id "$task_id" || return 1
+	mkdir -p "$project_root/todo/tasks"
+
+	# Step 1: Resolve commit
+	local commit="" commit_date="" commit_author="" commit_msg="" commit_epoch=""
+	while IFS='=' read -r key value; do
+		case "$key" in
+		COMMIT) commit="$value" ;;
+		COMMIT_DATE) commit_date="$value" ;;
+		COMMIT_AUTHOR) commit_author="$value" ;;
+		COMMIT_MSG) commit_msg="$value" ;;
+		COMMIT_EPOCH) commit_epoch="$value" ;;
+		esac
+	done <<<"$(_resolve_commit_info "$task_id" "$project_root")" || return 1
+
+	log_info "$task_id: commit $commit ($commit_date) by $commit_author"
+
+	# Step 2: Resolve session
+	local session_id="" session_title="" parent_session="" search_session=""
+	while IFS='=' read -r key value; do
+		case "$key" in
+		SESSION_ID) session_id="$value" ;;
+		SESSION_TITLE) session_title="$value" ;;
+		PARENT_SESSION) parent_session="$value" ;;
+		SEARCH_SESSION) search_session="$value" ;;
+		esac
+	done <<<"$(_resolve_session_info "$task_id" "$project_root" "$commit_epoch")"
+
+	# Step 3: Extract conversation context
+	local context="NO_CONTEXT_FOUND"
+	if [[ -n "$search_session" ]]; then
+		context=$(extract_session_context "$search_session" "$task_id") || true
+	fi
+
+	# Step 4: Supervisor DB
+	local supervisor_info=""
+	supervisor_info=$(find_supervisor_context "$task_id") || true
+
+	# Step 5: Task metadata from TODO.md
+	local task_title="" rebase_note="" task_line="" task_block_file=""
+	while IFS='=' read -r key value; do
+		case "$key" in
+		TASK_TITLE) task_title="$value" ;;
+		REBASE_NOTE) rebase_note="$value" ;;
+		TASK_LINE) task_line="$value" ;;
+		TASK_BLOCK_FILE) task_block_file="$value" ;;
+		esac
+	done <<<"$(_resolve_task_metadata "$task_id" "$project_root")"
+	local task_block=""
+	[[ -f "$task_block_file" ]] && task_block=$(cat "$task_block_file") && rm -f "$task_block_file"
+
+	# Step 6: Derive session_origin and created_by
+	local session_origin="" created_by="" sup_id=""
+	while IFS='=' read -r key value; do
+		case "$key" in
+		SESSION_ORIGIN) session_origin="$value" ;;
+		CREATED_BY) created_by="$value" ;;
+		SUP_ID) sup_id="$value" ;;
+		esac
+	done <<<"$(_derive_attribution "$session_id" "$session_title" "$parent_session" \
+		"$supervisor_info" "$commit_author" "$task_id")"
+
+	# Step 7: Extract context block and enrich session_origin
+	local context_block="" _in_ctx=0
+	while IFS= read -r line; do
+		case "$line" in
+		SESSION_ORIGIN=*) session_origin="${line#SESSION_ORIGIN=}" ;;
+		CONTEXT_BLOCK_START) _in_ctx=1 ;;
+		CONTEXT_BLOCK_END) _in_ctx=0 ;;
+		*)
+			if [[ "$_in_ctx" -eq 1 ]]; then
+				context_block="${context_block:+${context_block}$'\n'}${line}"
+			fi
+			;;
+		esac
+	done <<<"$(_enrich_context "$context" "$session_origin")"
+
+	local parent_task=""
+	if echo "$task_id" | grep -qE '\.'; then
+		parent_task=$(echo "$task_id" | sed -E 's/\.[0-9]+$//')
+	fi
+
+	local best_block="${context_block:-${task_block:-${task_line}}}"
+
+	_write_brief_file "$output_file" "$task_id" "$task_title" "$commit" "$commit_date" \
+		"$commit_msg" "$session_origin" "$created_by" "$parent_task" \
+		"$best_block" "$context_block" "$task_block" "$rebase_note" \
+		"$supervisor_info" "$sup_id"
 
 	log_info "$task_id: brief written to $output_file"
 	return 0


### PR DESCRIPTION
## Summary

Closes #6027

Reduces function complexity in `.agents/scripts/task-brief-helper.sh` by decomposing the two oversized functions into focused single-responsibility helpers.

## Changes

**Before:**
- `extract_session_context()`: 103 lines (inline Python with forward-referenced helper functions)
- `generate_brief()`: 259 lines (monolithic orchestrator doing everything inline)

**After — all functions ≤100 lines:**

| Function | Lines | Role |
|---|---|---|
| `generate_brief()` | 100 | Orchestrator — calls helpers, no inline logic |
| `_write_brief_file()` | 73 | Writes the markdown brief file |
| `_resolve_session_info()` | 48 | Finds OpenCode session by timestamp |
| `_derive_attribution()` | 44 | Derives session_origin + created_by strings |
| `_extract_todo_block()` | 42 | Extracts indented task block from TODO.md |
| `_python_extract_task_block()` | 81 | Python: scans session messages for task diff |
| `_enrich_context()` | 20 | Extracts context_block, enriches session_origin |
| `_resolve_task_metadata()` | 26 | Reads task line/title/rebase from TODO.md |
| `_resolve_commit_info()` | 17 | Finds creation commit + parses fields |
| `extract_session_context()` | 15 | Thin bash wrapper around Python helper |

**Bug fix included:** Python helper functions `_extract_block_from_diff` and `_peek_next_indent` were defined after their call site in the original refactor — moved to before use to fix the forward-reference `NameError`.

**Multi-line value passing:** `_resolve_task_metadata` now writes `task_block` to a temp file (path returned as `TASK_BLOCK_FILE=`) instead of using sentinel-delimited output, eliminating a 20-line parsing loop from `generate_brief`.

## Verification

- `bash -n .agents/scripts/task-brief-helper.sh` — SYNTAX OK
- `shellcheck .agents/scripts/task-brief-helper.sh` — zero violations
- All functions ≤100 lines (0 over threshold, down from 2)