### PR TITLE
qd-6018: Reduce function complexity in browser-qa-helper.sh

### DIFF
--- a/.agents/scripts/browser-qa-helper.sh
+++ b/.agents/scripts/browser-qa-helper.sh
@@ -194,6 +194,45 @@ enforce_screenshot_size_guardrails() {
 }
 
 # =============================================================================
+# Shared JS Array Builders
+# =============================================================================
+
+# Build a JS array literal of viewport objects from a comma-separated viewport string.
+# Args: $1 = comma-separated viewport names (e.g. "desktop,mobile")
+# Output: JS array fragment like "{ name: 'desktop', width: 1440, height: 900 },"
+_build_viewports_js_array() {
+	local viewports="$1"
+	local result=""
+	IFS=',' read -ra vp_list <<<"$viewports"
+	for vp in "${vp_list[@]}"; do
+		local dims
+		dims=$(get_viewport_dimensions "$vp")
+		local width="${dims%%x*}"
+		local height="${dims##*x}"
+		local safe_vp
+		safe_vp=$(js_escape_string "$vp")
+		result="${result}{ name: '${safe_vp}', width: ${width}, height: ${height} },"
+	done
+	printf '%s' "$result"
+	return 0
+}
+
+# Build a JS array literal of page path strings from a space-separated page list.
+# Args: $1 = space-separated page paths (e.g. "/ /about /dashboard")
+# Output: JS array fragment like "'/','/about','/dashboard',"
+_build_pages_js_array() {
+	local pages="$1"
+	local result=""
+	for page in $pages; do
+		local safe_page
+		safe_page=$(js_escape_string "$page")
+		result="${result}'${safe_page}',"
+	done
+	printf '%s' "$result"
+	return 0
+}
+
+# =============================================================================
 # Prerequisite Checks
 # =============================================================================
 
@@ -235,6 +274,67 @@ wait_for_url() {
 # =============================================================================
 # Screenshot Capture
 # =============================================================================
+
+# Generate the Playwright screenshot script file.
+# Args: $1=script_file $2=safe_url $3=viewport_array $4=pages_array $5=safe_output_dir $6=timeout $7=full_page
+_generate_screenshot_script() {
+	local script_file="$1"
+	local safe_url="$2"
+	local viewport_array="$3"
+	local pages_array="$4"
+	local safe_output_dir="$5"
+	local timeout="$6"
+	local full_page="$7"
+
+	cat >"$script_file" <<SCRIPT
+import { chromium } from 'playwright';
+
+const baseUrl = '${safe_url}'.replace(/\/\$/, '');
+const viewports = [${viewport_array}];
+const pages = [${pages_array}];
+const outputDir = '${safe_output_dir}';
+const timeout = ${timeout};
+const fullPage = ${full_page};
+
+async function run() {
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+
+  for (const vp of viewports) {
+    const context = await browser.newContext({
+      viewport: { width: vp.width, height: vp.height },
+    });
+    const page = await context.newPage();
+
+    for (const pagePath of pages) {
+      const url = baseUrl + pagePath;
+      const safeName = pagePath.replace(/\\//g, '_').replace(/^_/, '') || 'index';
+      const filename = \`\${safeName}-\${vp.name}-\${vp.width}x\${vp.height}.png\`;
+      const filepath = \`\${outputDir}/\${filename}\`;
+
+      try {
+        await page.goto(url, { waitUntil: 'networkidle', timeout });
+        await page.screenshot({ path: filepath, fullPage });
+        results.push({ page: pagePath, viewport: vp.name, file: filepath, status: 'ok' });
+      } catch (err) {
+        results.push({ page: pagePath, viewport: vp.name, file: filepath, status: 'error', error: err.message });
+      }
+    }
+
+    await context.close();
+  }
+
+  await browser.close();
+  console.log(JSON.stringify(results, null, 2));
+}
+
+run().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});
+SCRIPT
+	return 0
+}
 
 # Capture screenshots of pages at specified viewports using Playwright.
 # Args: --url URL --pages "/ /about /dashboard" --viewports "desktop,mobile" --output-dir DIR
@@ -291,83 +391,20 @@ cmd_screenshot() {
 	fi
 
 	max_dim=$(resolve_max_image_dim "$max_dim")
-
 	mkdir -p "$output_dir"
 
-	# Generate Playwright script for screenshots
 	local script_file
 	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-screenshot-XXXXXX.mjs")
 
-	local viewport_array=""
-	IFS=',' read -ra vp_list <<<"$viewports"
-	for vp in "${vp_list[@]}"; do
-		local dims
-		dims=$(get_viewport_dimensions "$vp")
-		local width="${dims%%x*}"
-		local height="${dims##*x}"
-		local safe_vp
-		safe_vp=$(js_escape_string "$vp")
-		viewport_array="${viewport_array}{ name: '${safe_vp}', width: ${width}, height: ${height} },"
-	done
-
-	local pages_array=""
-	for page in $pages; do
-		local safe_page
-		safe_page=$(js_escape_string "$page")
-		pages_array="${pages_array}'${safe_page}',"
-	done
-
+	local viewport_array
+	viewport_array=$(_build_viewports_js_array "$viewports")
+	local pages_array
+	pages_array=$(_build_pages_js_array "$pages")
 	local safe_url safe_output_dir
 	safe_url=$(js_escape_string "$url")
 	safe_output_dir=$(js_escape_string "$output_dir")
 
-	cat >"$script_file" <<SCRIPT
-import { chromium } from 'playwright';
-
-const baseUrl = '${safe_url}'.replace(/\/\$/, '');
-const viewports = [${viewport_array}];
-const pages = [${pages_array}];
-const outputDir = '${safe_output_dir}';
-const timeout = ${timeout};
-const fullPage = ${full_page};
-
-async function run() {
-  const browser = await chromium.launch({ headless: true });
-  const results = [];
-
-  for (const vp of viewports) {
-    const context = await browser.newContext({
-      viewport: { width: vp.width, height: vp.height },
-    });
-    const page = await context.newPage();
-
-    for (const pagePath of pages) {
-      const url = baseUrl + pagePath;
-      const safeName = pagePath.replace(/\\//g, '_').replace(/^_/, '') || 'index';
-      const filename = \`\${safeName}-\${vp.name}-\${vp.width}x\${vp.height}.png\`;
-      const filepath = \`\${outputDir}/\${filename}\`;
-
-      try {
-        await page.goto(url, { waitUntil: 'networkidle', timeout });
-        await page.screenshot({ path: filepath, fullPage });
-        results.push({ page: pagePath, viewport: vp.name, file: filepath, status: 'ok' });
-      } catch (err) {
-        results.push({ page: pagePath, viewport: vp.name, file: filepath, status: 'error', error: err.message });
-      }
-    }
-
-    await context.close();
-  }
-
-  await browser.close();
-  console.log(JSON.stringify(results, null, 2));
-}
-
-run().catch(err => {
-  console.error('Fatal error:', err.message);
-  process.exit(1);
-});
-SCRIPT
+	_generate_screenshot_script "$script_file" "$safe_url" "$viewport_array" "$pages_array" "$safe_output_dir" "$timeout" "$full_page"
 
 	log_info "Capturing screenshots for ${pages} at viewports: ${viewports}"
 	local exit_code=0
@@ -502,41 +539,13 @@ SCRIPT
 # Accessibility Checks
 # =============================================================================
 
-# Run accessibility checks on pages using Playwright.
-# Delegates to playwright-contrast.mjs for contrast, adds ARIA and structure checks.
-# Args: --url URL --pages "/ /about" --level AA|AAA
-# Output: JSON accessibility report
-cmd_a11y() {
-	local url=""
-	local pages="/"
-	local level="AA"
-
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-		--url)
-			url="$2"
-			shift 2
-			;;
-		--pages)
-			pages="$2"
-			shift 2
-			;;
-		--level)
-			level="$2"
-			shift 2
-			;;
-		*)
-			log_error "Unknown option: $1"
-			return 1
-			;;
-		esac
-	done
-
-	if [[ -z "$url" ]]; then
-		log_error "URL is required. Use --url http://localhost:3000"
-		return 1
-	fi
-
+# Run contrast checks for each page using playwright-contrast.mjs.
+# Args: $1=url $2=pages $3=level
+# Output: JSON array of contrast results (stdout)
+_run_contrast_checks() {
+	local url="$1"
+	local pages="$2"
+	local level="$3"
 	local contrast_script="${SCRIPT_DIR}/accessibility/playwright-contrast.mjs"
 	local contrast_json='[]'
 
@@ -544,7 +553,6 @@ cmd_a11y() {
 		local full_url="${url%/}${page_path}"
 		log_info "Running accessibility check on ${full_url} (level: ${level})"
 
-		# Run contrast check if script exists
 		if [[ -f "$contrast_script" ]]; then
 			local contrast_result
 			contrast_result=$(node "$contrast_script" "$full_url" --format json --level "$level" 2>/dev/null) || contrast_result='{"error": "contrast check failed"}'
@@ -560,19 +568,16 @@ cmd_a11y() {
 		fi
 	done
 
-	# Run ARIA and structure checks via Playwright
-	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-a11y-XXXXXX.mjs")
+	printf '%s' "$contrast_json"
+	return 0
+}
 
-	local pages_array=""
-	for page_path in $pages; do
-		local safe_page
-		safe_page=$(js_escape_string "$page_path")
-		pages_array="${pages_array}'${safe_page}',"
-	done
-
-	local safe_url
-	safe_url=$(js_escape_string "$url")
+# Generate the Playwright a11y ARIA/structure check script file.
+# Args: $1=script_file $2=safe_url $3=pages_array
+_generate_a11y_script() {
+	local script_file="$1"
+	local safe_url="$2"
+	local pages_array="$3"
 
 	cat >"$script_file" <<SCRIPT
 import { chromium } from 'playwright';
@@ -720,26 +725,17 @@ run().catch(err => {
   process.exit(1);
 });
 SCRIPT
-
-	# Pass contrast results as JSON via process.argv[2]
-	local exit_code=0
-	node "$script_file" "$contrast_json" || exit_code=$?
-	rm -f "$script_file"
-	return $exit_code
+	return 0
 }
 
-# =============================================================================
-# Smoke Test (Console Errors + Basic Rendering)
-# =============================================================================
-
-# Navigate to pages and check for console errors, failed network requests, and basic rendering.
-# Args: --url URL --pages "/ /about" --format json|markdown
-# Output: JSON or markdown report of console errors and rendering issues
-cmd_smoke() {
+# Run accessibility checks on pages using Playwright.
+# Delegates to playwright-contrast.mjs for contrast, adds ARIA and structure checks.
+# Args: --url URL --pages "/ /about" --level AA|AAA
+# Output: JSON accessibility report
+cmd_a11y() {
 	local url=""
 	local pages="/"
-	local format="json"
-	local timeout="$BROWSER_QA_DEFAULT_TIMEOUT"
+	local level="AA"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -751,12 +747,8 @@ cmd_smoke() {
 			pages="$2"
 			shift 2
 			;;
-		--format)
-			format="$2"
-			shift 2
-			;;
-		--timeout)
-			timeout="$2"
+		--level)
+			level="$2"
 			shift 2
 			;;
 		*)
@@ -771,18 +763,36 @@ cmd_smoke() {
 		return 1
 	fi
 
+	local contrast_json
+	contrast_json=$(_run_contrast_checks "$url" "$pages" "$level")
+
 	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-smoke-XXXXXX.mjs")
+	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-a11y-XXXXXX.mjs")
 
-	local pages_array=""
-	for page_path in $pages; do
-		local safe_page
-		safe_page=$(js_escape_string "$page_path")
-		pages_array="${pages_array}'${safe_page}',"
-	done
-
+	local pages_array
+	pages_array=$(_build_pages_js_array "$pages")
 	local safe_url
 	safe_url=$(js_escape_string "$url")
+
+	_generate_a11y_script "$script_file" "$safe_url" "$pages_array"
+
+	local exit_code=0
+	node "$script_file" "$contrast_json" || exit_code=$?
+	rm -f "$script_file"
+	return $exit_code
+}
+
+# =============================================================================
+# Smoke Test (Console Errors + Basic Rendering)
+# =============================================================================
+
+# Generate the Playwright smoke test script file.
+# Args: $1=script_file $2=safe_url $3=pages_array $4=timeout
+_generate_smoke_script() {
+	local script_file="$1"
+	local safe_url="$2"
+	local pages_array="$3"
+	local timeout="$4"
 
 	cat >"$script_file" <<SCRIPT
 import { chromium } from 'playwright';
@@ -873,6 +883,57 @@ run().catch(err => {
   process.exit(1);
 });
 SCRIPT
+	return 0
+}
+
+# Navigate to pages and check for console errors, failed network requests, and basic rendering.
+# Args: --url URL --pages "/ /about" --format json|markdown
+# Output: JSON or markdown report of console errors and rendering issues
+cmd_smoke() {
+	local url=""
+	local pages="/"
+	local format="json"
+	local timeout="$BROWSER_QA_DEFAULT_TIMEOUT"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--url)
+			url="$2"
+			shift 2
+			;;
+		--pages)
+			pages="$2"
+			shift 2
+			;;
+		--format)
+			format="$2"
+			shift 2
+			;;
+		--timeout)
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$url" ]]; then
+		log_error "URL is required. Use --url http://localhost:3000"
+		return 1
+	fi
+
+	local script_file
+	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-smoke-XXXXXX.mjs")
+
+	local pages_array
+	pages_array=$(_build_pages_js_array "$pages")
+	local safe_url
+	safe_url=$(js_escape_string "$url")
+
+	_generate_smoke_script "$script_file" "$safe_url" "$pages_array" "$timeout"
 
 	log_info "Running smoke test on ${url} for pages: ${pages}"
 	local exit_code=0


### PR DESCRIPTION
## Summary

- Extract sub-functions from 3 functions exceeding 100-line complexity threshold in `.agents/scripts/browser-qa-helper.sh`
- All existing behavior preserved — pure structural refactor

### Changes

| Function | Before | After | Extracted helpers |
|----------|--------|-------|-------------------|
| `cmd_screenshot` | 122 lines | 83 lines | `_generate_screenshot_script` |
| `cmd_a11y` | 207 lines | 49 lines | `_run_contrast_checks`, `_generate_a11y_script` |
| `cmd_smoke` | 131 lines | 52 lines | `_generate_smoke_script` |

Shared helpers added: `_build_viewports_js_array`, `_build_pages_js_array` (replace duplicated viewport/page array building across all 3 functions).

### Verification

- `bash -n` syntax check: PASS
- `shellcheck`: PASS (only pre-existing SC1091 info for external source)
- All 3 target functions now under 100 lines

Closes #6018