### PR TITLE
fix: propagate error returns in add-skill-helper.sh (Augment review fixes for #6206)

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -1231,7 +1231,7 @@ cmd_add() {
 	# Handle conflicts (may update skill_name/target_path in caller scope)
 	if ! _apply_conflict_resolution "$target_path" "$force" "$description" "$source_dir"; then
 		rm -rf "$TEMP_DIR"
-		return 0
+		return 1
 	fi
 
 	if [[ "$dry_run" == true ]]; then
@@ -1422,7 +1422,7 @@ cmd_add_url() {
 	# Handle conflicts (may update skill_name/target_path in caller scope)
 	if ! _apply_conflict_resolution "$target_path" "$force" "$description" "$fetch_dir"; then
 		rm -rf "$fetch_dir"
-		return 0
+		return 1
 	fi
 
 	if [[ "$dry_run" == true ]]; then
@@ -1437,7 +1437,10 @@ cmd_add_url() {
 
 	# Convert URL content to aidevops format
 	local target_file=".agents/${target_path}.md"
-	_convert_url_to_skill "$fetch_file" "$target_file" "$skill_name" "$description" "$url"
+	if ! _convert_url_to_skill "$fetch_file" "$target_file" "$skill_name" "$description" "$url"; then
+		rm -rf "$fetch_dir"
+		return 1
+	fi
 
 	# Finalize: security scan, register, cleanup
 	if ! _finalize_import "$fetch_dir" "$skill_name" "$skip_security" \
@@ -1510,7 +1513,7 @@ cmd_add_clawdhub() {
 
 	# Handle conflicts (may update skill_name/target_path in caller scope)
 	if ! _apply_conflict_resolution "$target_path" "$force" "$summary" "."; then
-		return 0
+		return 1
 	fi
 
 	if [[ "$dry_run" == true ]]; then


### PR DESCRIPTION
## Summary

Addresses the two Augment Code review suggestions on PR #6206 before merge.

### Issue 1: `_apply_conflict_resolution` failure not propagated (3 call sites)

`_handle_conflicts` returns non-zero when a conflict is detected in non-interactive mode (or when the user chooses "Skip"). All three callers were turning that into `return 0`, making automation believe the import succeeded when it was actually blocked/cancelled.

Fixed in:
- `cmd_add` (GitHub source) — line 1234
- `cmd_add_url` — line 1425
- `cmd_add_clawdhub` — line 1513

### Issue 2: `_convert_url_to_skill` return value ignored

A write/conversion failure in `_convert_url_to_skill` could fall through to `_finalize_import`, which would then register a skill whose target file was never created — a false "import succeeded" outcome.

Fixed in `cmd_add_url` — now checks the return value and aborts with temp-dir cleanup on failure.

## Verification

- `bash -n`: passes
- `shellcheck`: zero violations (SC1091 info-level only — same as before)
- Line count: 1747 (original 1744 + 3 lines for the new `if !` block)

## Relation to PR #6206

This PR targets the `simplify/qd-6019` branch so the fixes land in PR #6206 before it merges to main.