### PR TITLE
refactor: reduce function complexity in contest-helper.sh

### DIFF
--- a/.agents/scripts/contest-helper.sh
+++ b/.agents/scripts/contest-helper.sh
@@ -298,13 +298,14 @@ select_contest_models() {
 }
 
 #######################################
-# Create a contest for a task (t1011)
-# Dispatches the same task to top-3 models in parallel
+# Parse arguments for cmd_create
+# Sets task_id, explicit_models, batch_id in caller scope via stdout
+# Usage: _parse_create_args "$@"
+# Outputs: task_id<TAB>explicit_models<TAB>batch_id
 #######################################
-cmd_create() {
+_parse_create_args() {
 	local task_id="" explicit_models="" batch_id=""
 
-	# Parse args
 	if [[ $# -gt 0 && ! "$1" =~ ^-- ]]; then
 		task_id="$1"
 		shift
@@ -334,6 +335,54 @@ cmd_create() {
 			;;
 		esac
 	done
+
+	printf '%s\t%s\t%s' "$task_id" "$explicit_models" "$batch_id"
+	return 0
+}
+
+#######################################
+# Create contest entries for each model
+# Usage: _create_contest_entries <contest_id> <task_id> <models_csv>
+#######################################
+_create_contest_entries() {
+	local contest_id="$1"
+	local task_id="$2"
+	local models="$3"
+
+	local model_index=0
+	local IFS=','
+	for model in $models; do
+		model_index=$((model_index + 1))
+		local entry_id="${contest_id}-entry-${model_index}"
+		local entry_task_id="${task_id}-contest-${model_index}"
+
+		db "$SUPERVISOR_DB" "
+			INSERT INTO contest_entries (id, contest_id, model, task_id, status)
+			VALUES (
+				'$(sql_escape "$entry_id")',
+				'$(sql_escape "$contest_id")',
+				'$(sql_escape "$model")',
+				'$(sql_escape "$entry_task_id")',
+				'pending'
+			);
+		"
+
+		log_info "Created entry $entry_id for model $model (task: $entry_task_id)"
+	done
+	unset IFS
+
+	echo "$model_index"
+	return 0
+}
+
+#######################################
+# Create a contest for a task (t1011)
+# Dispatches the same task to top-3 models in parallel
+#######################################
+cmd_create() {
+	local parsed_args task_id explicit_models batch_id
+	parsed_args=$(_parse_create_args "$@") || return 1
+	IFS=$'\t' read -r task_id explicit_models batch_id <<<"$parsed_args"
 
 	if [[ -z "$task_id" ]]; then
 		log_error "Usage: contest-helper.sh create <task_id> [--models 'model1,model2,model3']"
@@ -396,30 +445,81 @@ cmd_create() {
 	"
 
 	# Create contest entries for each model
-	local model_index=0
-	local IFS=','
-	for model in $models; do
-		model_index=$((model_index + 1))
-		local entry_id="${contest_id}-entry-${model_index}"
-		local entry_task_id="${task_id}-contest-${model_index}"
+	local model_count
+	model_count=$(_create_contest_entries "$contest_id" "$task_id" "$models")
 
-		db "$SUPERVISOR_DB" "
-			INSERT INTO contest_entries (id, contest_id, model, task_id, status)
-			VALUES (
-				'$(sql_escape "$entry_id")',
-				'$(sql_escape "$contest_id")',
-				'$(sql_escape "$model")',
-				'$(sql_escape "$entry_task_id")',
-				'pending'
-			);
-		"
-
-		log_info "Created entry $entry_id for model $model (task: $entry_task_id)"
-	done
-	unset IFS
-
-	log_success "Contest created: $contest_id with ${model_index} entries"
+	log_success "Contest created: $contest_id with ${model_count} entries"
 	echo "$contest_id"
+	return 0
+}
+
+#######################################
+# Dispatch a single contest entry as a worker subtask
+# Usage: _dispatch_single_entry <entry_id> <entry_model> <entry_task_id>
+#                               <ctask_id> <cdesc> <crepo> <cbatch_id>
+# Returns 0 on success, 1 on failure
+#######################################
+_dispatch_single_entry() {
+	local entry_id="$1"
+	local entry_model="$2"
+	local entry_task_id="$3"
+	local ctask_id="$4"
+	local cdesc="$5"
+	local crepo="$6"
+	local cbatch_id="$7"
+
+	local supervisor_helper="${SCRIPT_DIR}/supervisor-helper.sh"
+
+	log_info "Dispatching contest entry: $entry_id (model: $entry_model)"
+
+	# Add subtask to supervisor DB with the specific model
+	if ! "$supervisor_helper" add "$entry_task_id" \
+		--repo "${crepo:-.}" \
+		--description "Contest entry for $ctask_id: $cdesc" \
+		--model "$entry_model" 2>/dev/null; then
+		log_error "Failed to add subtask $entry_task_id for entry $entry_id"
+		db "$SUPERVISOR_DB" "
+			UPDATE contest_entries SET status = 'failed'
+			WHERE id = '$(sql_escape "$entry_id")';
+		"
+		return 1
+	fi
+
+	# Add to batch if one exists
+	if [[ -n "$cbatch_id" ]]; then
+		"$supervisor_helper" db "
+			INSERT OR IGNORE INTO batch_tasks (batch_id, task_id)
+			VALUES ('$(sql_escape "$cbatch_id")', '$(sql_escape "$entry_task_id")');
+		" 2>/dev/null || true
+	fi
+
+	# Dispatch the subtask
+	if ! "$supervisor_helper" dispatch "$entry_task_id" ${cbatch_id:+--batch "$cbatch_id"} 2>/dev/null; then
+		log_warn "Failed to dispatch entry $entry_id"
+		db "$SUPERVISOR_DB" "
+			UPDATE contest_entries SET status = 'failed'
+			WHERE id = '$(sql_escape "$entry_id")';
+		"
+		return 1
+	fi
+
+	# Update entry with dispatch info
+	local subtask_info
+	subtask_info=$(db -separator $'\t' "$SUPERVISOR_DB" "
+		SELECT worktree, branch, log_file
+		FROM tasks WHERE id = '$(sql_escape "$entry_task_id")';
+	")
+	local ewt ebranch elog
+	IFS=$'\t' read -r ewt ebranch elog <<<"$subtask_info"
+
+	db "$SUPERVISOR_DB" "
+		UPDATE contest_entries SET
+			status = 'dispatched',
+			worktree = '$(sql_escape "${ewt:-}")',
+			branch = '$(sql_escape "${ebranch:-}")',
+			log_file = '$(sql_escape "${elog:-}")'
+		WHERE id = '$(sql_escape "$entry_id")';
+	"
 	return 0
 }
 
@@ -473,61 +573,15 @@ cmd_dispatch_contest() {
 		return 0
 	fi
 
-	local supervisor_helper="${SCRIPT_DIR}/supervisor-helper.sh"
 	local dispatched_count=0
 
 	while IFS=$'\t' read -r entry_id entry_model entry_task_id; do
 		[[ -z "$entry_id" ]] && continue
 
-		log_info "Dispatching contest entry: $entry_id (model: $entry_model)"
-
-		# Add subtask to supervisor DB with the specific model
-		if "$supervisor_helper" add "$entry_task_id" \
-			--repo "${crepo:-.}" \
-			--description "Contest entry for $ctask_id: $cdesc" \
-			--model "$entry_model" 2>/dev/null; then
-
-			# Add to batch if one exists
-			if [[ -n "$cbatch_id" ]]; then
-				"$supervisor_helper" db "
-					INSERT OR IGNORE INTO batch_tasks (batch_id, task_id)
-					VALUES ('$(sql_escape "$cbatch_id")', '$(sql_escape "$entry_task_id")');
-				" 2>/dev/null || true
-			fi
-
-			# Dispatch the subtask
-			if "$supervisor_helper" dispatch "$entry_task_id" ${cbatch_id:+--batch "$cbatch_id"} 2>/dev/null; then
-				# Update entry with dispatch info
-				local subtask_info
-				subtask_info=$(db -separator $'\t' "$SUPERVISOR_DB" "
-					SELECT worktree, branch, log_file
-					FROM tasks WHERE id = '$(sql_escape "$entry_task_id")';
-				")
-				local ewt ebranch elog
-				IFS=$'\t' read -r ewt ebranch elog <<<"$subtask_info"
-
-				db "$SUPERVISOR_DB" "
-					UPDATE contest_entries SET
-						status = 'dispatched',
-						worktree = '$(sql_escape "${ewt:-}")',
-						branch = '$(sql_escape "${ebranch:-}")',
-						log_file = '$(sql_escape "${elog:-}")'
-					WHERE id = '$(sql_escape "$entry_id")';
-				"
-				dispatched_count=$((dispatched_count + 1))
-			else
-				log_warn "Failed to dispatch entry $entry_id"
-				db "$SUPERVISOR_DB" "
-					UPDATE contest_entries SET status = 'failed'
-					WHERE id = '$(sql_escape "$entry_id")';
-				"
-			fi
-		else
-			log_error "Failed to add subtask $entry_task_id for entry $entry_id"
-			db "$SUPERVISOR_DB" "
-				UPDATE contest_entries SET status = 'failed'
-				WHERE id = '$(sql_escape "$entry_id")';
-			"
+		if _dispatch_single_entry \
+			"$entry_id" "$entry_model" "$entry_task_id" \
+			"$ctask_id" "$cdesc" "$crepo" "$cbatch_id"; then
+			dispatched_count=$((dispatched_count + 1))
 		fi
 	done <<<"$entries"
 
@@ -616,6 +670,255 @@ cmd_status() {
 }
 
 #######################################
+# Collect output summaries from completed contest entries
+# Usage: _collect_entry_summaries <escaped_cid>
+# Populates entry_ids, entry_models, entry_summaries arrays in caller scope
+# via a temp file (one line per entry: id<TAB>model<TAB>summary_b64)
+# Outputs the temp file path; caller must rm it
+#######################################
+_collect_entry_summaries() {
+	local escaped_cid="$1"
+
+	local entries_data
+	entries_data=$(db -separator $'\t' "$SUPERVISOR_DB" "
+		SELECT id, model, task_id, worktree, branch, log_file, pr_url
+		FROM contest_entries
+		WHERE contest_id = '$escaped_cid' AND status = 'complete'
+		ORDER BY id;
+	")
+
+	local tmpfile
+	tmpfile=$(mktemp "${TMPDIR:-/tmp}/contest-summaries-XXXXXX")
+
+	while IFS=$'\t' read -r eid emodel _etask ewt _ebranch elog _epr; do
+		[[ -z "$eid" ]] && continue
+
+		local summary=""
+		if [[ -n "$ewt" && -d "$ewt" ]]; then
+			summary=$(git -C "$ewt" diff --stat "main..HEAD" 2>/dev/null || echo "No diff available")
+			local full_diff
+			full_diff=$(git -C "$ewt" diff "main..HEAD" 2>/dev/null | head -500 || echo "")
+			summary="${summary}
+
+--- Code Changes ---
+${full_diff}"
+		elif [[ -n "$elog" && -f "$elog" ]]; then
+			summary=$(tail -100 "$elog" 2>/dev/null || echo "No log available")
+		fi
+
+		# Store summary in entry
+		db "$SUPERVISOR_DB" "
+			UPDATE contest_entries SET output_summary = '$(sql_escape "$summary")'
+			WHERE id = '$(sql_escape "$eid")';
+		"
+
+		# Write to temp file: id<TAB>model<TAB>summary (summary may contain newlines — base64 encode)
+		local summary_b64
+		summary_b64=$(printf '%s' "$summary" | base64 | tr -d '\n')
+		printf '%s\t%s\t%s\n' "$eid" "$emodel" "$summary_b64" >>"$tmpfile"
+	done <<<"$entries_data"
+
+	echo "$tmpfile"
+	return 0
+}
+
+#######################################
+# Build the cross-ranking prompt for judges
+# Usage: _build_ranking_prompt <num_entries> <labels_csv> <summaries_csv_b64>
+# Reads summaries from a temp file (one line: label<TAB>summary_b64)
+# Outputs the prompt text
+#######################################
+_build_ranking_prompt() {
+	local num_entries="$1"
+	local summaries_file="$2"
+
+	local ranking_prompt="You are evaluating ${num_entries} different implementations of the same task. Each implementation is labelled with a letter (A, B, C, etc.). You do NOT know which model produced which output.
+
+Score each implementation on these criteria (1-5 scale):
+- Correctness (30%): Does it correctly solve the task? Any bugs or errors?
+- Completeness (25%): Does it cover all requirements including edge cases?
+- Code Quality (25%): Is it clean, idiomatic, well-structured with error handling?
+- Clarity (20%): Is it well-organized and easy to understand?
+
+For each implementation, output EXACTLY this JSON format (one per line):
+{\"label\": \"A\", \"correctness\": N, \"completeness\": N, \"code_quality\": N, \"clarity\": N}
+
+Here are the implementations:
+"
+
+	local labels=("A" "B" "C" "D" "E")
+	local idx=0
+	while IFS=$'\t' read -r _eid _emodel summary_b64; do
+		[[ -z "$_eid" ]] && continue
+		local label="${labels[$idx]:-$(printf '%c' $((65 + idx)))}"
+		local summary
+		summary=$(printf '%s' "$summary_b64" | base64 --decode 2>/dev/null || echo "")
+		ranking_prompt="${ranking_prompt}
+=== Implementation ${label} ===
+${summary}
+=== End Implementation ${label} ===
+"
+		idx=$((idx + 1))
+	done <"$summaries_file"
+
+	ranking_prompt="${ranking_prompt}
+
+Now score each implementation. Output ONLY the JSON lines, nothing else."
+
+	printf '%s' "$ranking_prompt"
+	return 0
+}
+
+#######################################
+# Run all judge models and collect raw scores
+# Usage: _run_judges <judge_models_newline_sep> <ranking_prompt>
+# Outputs raw score lines: judge:<model>|<json_score>
+#######################################
+_run_judges() {
+	local judges_file="$1"
+	local ranking_prompt="$2"
+
+	local judge_count=0
+	local total_judges
+	total_judges=$(wc -l <"$judges_file" | tr -d ' ')
+
+	while IFS= read -r judge_model; do
+		[[ -z "$judge_model" ]] && continue
+		judge_count=$((judge_count + 1))
+		log_info "Judge $judge_count/${total_judges}: $judge_model scoring all entries..."
+
+		local score_tmpfile
+		score_tmpfile=$(mktemp "${TMPDIR:-/tmp}/contest-score-XXXXXX")
+		local score_output=""
+
+		if run_ai_scoring "$judge_model" "$ranking_prompt" "$score_tmpfile"; then
+			score_output=$(cat "$score_tmpfile" 2>/dev/null || echo "")
+		fi
+
+		if [[ -n "$score_output" ]]; then
+			local json_scores
+			json_scores=$(echo "$score_output" | grep -oE '\{[^}]*"label"[^}]*\}' || true)
+			if [[ -n "$json_scores" ]]; then
+				while IFS= read -r score_line; do
+					[[ -z "$score_line" ]] && continue
+					printf 'judge:%s|%s\n' "$judge_model" "$score_line"
+				done <<<"$json_scores"
+			else
+				log_warn "Judge $judge_model returned no parseable scores"
+			fi
+		else
+			log_warn "Judge $judge_model returned empty output"
+		fi
+
+		rm -f "$score_tmpfile"
+	done <"$judges_file"
+
+	return 0
+}
+
+#######################################
+# Aggregate judge scores for a single entry label
+# Usage: _aggregate_entry_scores <label> <all_scores_file>
+# Outputs: correctness<TAB>completeness<TAB>quality<TAB>clarity<TAB>weighted<TAB>score_count
+#######################################
+_aggregate_entry_scores() {
+	local label="$1"
+	local all_scores_file="$2"
+
+	local total_correctness=0 total_completeness=0 total_quality=0 total_clarity=0
+	local score_count=0
+
+	while IFS= read -r score_entry; do
+		[[ -z "$score_entry" ]] && continue
+		local score_json="${score_entry#*|}"
+		local score_label
+		score_label=$(echo "$score_json" | sed -n 's/.*"label"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || echo "")
+
+		if [[ "$score_label" == "$label" ]]; then
+			local s_correct s_complete s_quality s_clarity
+			s_correct=$(echo "$score_json" | sed -n 's/.*"correctness"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
+			s_complete=$(echo "$score_json" | sed -n 's/.*"completeness"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
+			s_quality=$(echo "$score_json" | sed -n 's/.*"code_quality"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
+			s_clarity=$(echo "$score_json" | sed -n 's/.*"clarity"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
+
+			total_correctness=$((total_correctness + s_correct))
+			total_completeness=$((total_completeness + s_complete))
+			total_quality=$((total_quality + s_quality))
+			total_clarity=$((total_clarity + s_clarity))
+			score_count=$((score_count + 1))
+		fi
+	done <"$all_scores_file"
+
+	if [[ "$score_count" -gt 0 ]]; then
+		local avg_correct avg_complete avg_quality avg_clarity weighted
+		avg_correct=$(awk "BEGIN {printf \"%.2f\", $total_correctness / $score_count}")
+		avg_complete=$(awk "BEGIN {printf \"%.2f\", $total_completeness / $score_count}")
+		avg_quality=$(awk "BEGIN {printf \"%.2f\", $total_quality / $score_count}")
+		avg_clarity=$(awk "BEGIN {printf \"%.2f\", $total_clarity / $score_count}")
+		weighted=$(awk "BEGIN {printf \"%.2f\", ($avg_correct * $WEIGHT_CORRECTNESS + $avg_complete * $WEIGHT_COMPLETENESS + $avg_quality * $WEIGHT_CODE_QUALITY + $avg_clarity * $WEIGHT_CLARITY) / 100}")
+		printf '%s\t%s\t%s\t%s\t%s\t%d' \
+			"$avg_correct" "$avg_complete" "$avg_quality" "$avg_clarity" "$weighted" "$score_count"
+	else
+		printf '0\t0\t0\t0\t0\t0'
+	fi
+	return 0
+}
+
+#######################################
+# Store aggregated scores for all entries and determine winner
+# Usage: _store_scores_and_find_winner <escaped_cid> <summaries_file> <all_scores_file>
+# Outputs: winner_id<TAB>winner_model<TAB>winner_score  (or empty on failure)
+#######################################
+_store_scores_and_find_winner() {
+	local escaped_cid="$1"
+	local summaries_file="$2"
+	local all_scores_file="$3"
+
+	local labels=("A" "B" "C" "D" "E")
+	local idx=0
+
+	while IFS=$'\t' read -r eid emodel _summary_b64; do
+		[[ -z "$eid" ]] && continue
+		local label="${labels[$idx]:-$(printf '%c' $((65 + idx)))}"
+
+		local score_row
+		score_row=$(_aggregate_entry_scores "$label" "$all_scores_file")
+		local avg_correct avg_complete avg_quality avg_clarity weighted score_count
+		IFS=$'\t' read -r avg_correct avg_complete avg_quality avg_clarity weighted score_count <<<"$score_row"
+
+		if [[ "$score_count" -gt 0 ]]; then
+			local raw_scores
+			raw_scores=$(tr '\n' ' ' <"$all_scores_file")
+			db "$SUPERVISOR_DB" "
+				UPDATE contest_entries SET
+					score_correctness = $avg_correct,
+					score_completeness = $avg_complete,
+					score_code_quality = $avg_quality,
+					score_clarity = $avg_clarity,
+					weighted_score = $weighted,
+					cross_rank_scores = '$(sql_escape "judges:$score_count,raw:$raw_scores")'
+				WHERE id = '$(sql_escape "$eid")';
+			"
+			log_info "Entry $label ($emodel): correctness=$avg_correct completeness=$avg_complete quality=$avg_quality clarity=$avg_clarity weighted=$weighted"
+		else
+			log_warn "No scores collected for entry $label ($eid)"
+		fi
+
+		idx=$((idx + 1))
+	done <"$summaries_file"
+
+	# Return winner row
+	db -separator $'\t' "$SUPERVISOR_DB" "
+		SELECT id, model, weighted_score
+		FROM contest_entries
+		WHERE contest_id = '$escaped_cid' AND status = 'complete'
+		ORDER BY weighted_score DESC
+		LIMIT 1;
+	"
+	return 0
+}
+
+#######################################
 # Evaluate contest — cross-rank outputs from all completed entries
 # Each model scores all outputs (including its own) blindly as A/B/C
 # Then aggregate scores and pick winner
@@ -672,203 +975,64 @@ cmd_evaluate() {
 
 	# Transition to evaluating
 	db "$SUPERVISOR_DB" "UPDATE contests SET status = 'evaluating' WHERE id = '$escaped_cid';"
-
 	log_info "Evaluating contest $contest_id with $complete_count entries..."
 
-	# Collect output summaries from each entry's worktree
-	local entries_data
-	entries_data=$(db -separator $'\t' "$SUPERVISOR_DB" "
-		SELECT id, model, task_id, worktree, branch, log_file, pr_url
-		FROM contest_entries
-		WHERE contest_id = '$escaped_cid' AND status = 'complete'
-		ORDER BY id;
-	")
+	# Collect output summaries
+	local summaries_file
+	summaries_file=$(_collect_entry_summaries "$escaped_cid")
 
-	# Build anonymised output summaries (A, B, C, ...)
-	local -a entry_ids=()
-	local -a entry_models=()
-	local -a entry_summaries=()
-	local label_index=0
-	local labels=("A" "B" "C" "D" "E")
+	local num_entries
+	num_entries=$(wc -l <"$summaries_file" | tr -d ' ')
 
-	while IFS=$'\t' read -r eid emodel _etask ewt _ebranch elog _epr; do
-		[[ -z "$eid" ]] && continue
-		entry_ids+=("$eid")
-		entry_models+=("$emodel")
-
-		# Extract output summary from worktree diff
-		local summary=""
-		if [[ -n "$ewt" && -d "$ewt" ]]; then
-			# Get the diff as the "output"
-			summary=$(git -C "$ewt" diff --stat "main..HEAD" 2>/dev/null || echo "No diff available")
-			local full_diff
-			full_diff=$(git -C "$ewt" diff "main..HEAD" 2>/dev/null | head -500 || echo "")
-			summary="${summary}
-
---- Code Changes ---
-${full_diff}"
-		elif [[ -n "$elog" && -f "$elog" ]]; then
-			# Fallback: extract key output from log
-			summary=$(tail -100 "$elog" 2>/dev/null || echo "No log available")
-		fi
-
-		# Store summary in entry
-		db "$SUPERVISOR_DB" "
-			UPDATE contest_entries SET output_summary = '$(sql_escape "$summary")'
-			WHERE id = '$(sql_escape "$eid")';
-		"
-
-		entry_summaries+=("$summary")
-		label_index=$((label_index + 1))
-	done <<<"$entries_data"
-
-	local num_entries=${#entry_ids[@]}
 	if [[ "$num_entries" -lt 2 ]]; then
 		log_error "Not enough entries to evaluate"
+		rm -f "$summaries_file"
 		return 1
 	fi
 
-	# Build the cross-ranking prompt
-	local ranking_prompt="You are evaluating ${num_entries} different implementations of the same task. Each implementation is labelled with a letter (A, B, C, etc.). You do NOT know which model produced which output.
-
-Score each implementation on these criteria (1-5 scale):
-- Correctness (30%): Does it correctly solve the task? Any bugs or errors?
-- Completeness (25%): Does it cover all requirements including edge cases?
-- Code Quality (25%): Is it clean, idiomatic, well-structured with error handling?
-- Clarity (20%): Is it well-organized and easy to understand?
-
-For each implementation, output EXACTLY this JSON format (one per line):
-{\"label\": \"A\", \"correctness\": N, \"completeness\": N, \"code_quality\": N, \"clarity\": N}
-
-Here are the implementations:
-"
-
-	for i in $(seq 0 $((num_entries - 1))); do
-		local label="${labels[$i]:-$(printf '%c' $((65 + i)))}"
-		ranking_prompt="${ranking_prompt}
-=== Implementation ${label} ===
-${entry_summaries[$i]}
-=== End Implementation ${label} ===
-"
-	done
-
-	ranking_prompt="${ranking_prompt}
-
-Now score each implementation. Output ONLY the JSON lines, nothing else."
+	# Build ranking prompt
+	local ranking_prompt
+	ranking_prompt=$(_build_ranking_prompt "$num_entries" "$summaries_file")
 
 	# Transition to scoring
 	db "$SUPERVISOR_DB" "UPDATE contests SET status = 'scoring' WHERE id = '$escaped_cid';"
 
-	# Cross-rank: have each model score all outputs
-	# Use multiple judges for robustness — each contest model scores all entries
-	local -a judges=()
-	for model in "${entry_models[@]}"; do
-		judges+=("$model")
-	done
+	# Build judges list from entry models
+	local judges_file
+	judges_file=$(mktemp "${TMPDIR:-/tmp}/contest-judges-XXXXXX")
+	while IFS=$'\t' read -r _eid emodel _summary_b64; do
+		[[ -z "$emodel" ]] && continue
+		echo "$emodel" >>"$judges_file"
+	done <"$summaries_file"
 
-	# Score collection: each judge scores all entries
-	local -a all_scores=()
-	local judge_count=0
+	# Run judges and collect all scores
+	local all_scores_file
+	all_scores_file=$(mktemp "${TMPDIR:-/tmp}/contest-allscores-XXXXXX")
+	_run_judges "$judges_file" "$ranking_prompt" >"$all_scores_file"
+	rm -f "$judges_file"
 
-	for judge_model in "${judges[@]}"; do
-		judge_count=$((judge_count + 1))
-		log_info "Judge $judge_count/${#judges[@]}: $judge_model scoring all entries..."
+	local judge_count
+	judge_count=$(wc -l <"$all_scores_file" | tr -d ' ')
+	log_info "Aggregating scores from ${judge_count} score lines..."
 
-		# Dispatch scoring via resolved AI CLI (t1160.4)
-		local score_output=""
-		local score_tmpfile
-		score_tmpfile=$(mktemp "${TMPDIR:-/tmp}/contest-score-XXXXXX")
-
-		if run_ai_scoring "$judge_model" "$ranking_prompt" "$score_tmpfile"; then
-			score_output=$(cat "$score_tmpfile" 2>/dev/null || echo "")
-		fi
-
-		# Parse JSON scores from output
-		if [[ -n "$score_output" ]]; then
-			# Extract JSON lines from the output
-			local json_scores
-			json_scores=$(echo "$score_output" | grep -oE '\{[^}]*"label"[^}]*\}' || true)
-
-			if [[ -n "$json_scores" ]]; then
-				while IFS= read -r score_line; do
-					[[ -z "$score_line" ]] && continue
-					all_scores+=("judge:${judge_model}|${score_line}")
-				done <<<"$json_scores"
-			else
-				log_warn "Judge $judge_model returned no parseable scores"
-			fi
-		else
-			log_warn "Judge $judge_model returned empty output"
-		fi
-
-		rm -f "$score_tmpfile"
-	done
-
-	# Aggregate scores across all judges
-	log_info "Aggregating scores from ${judge_count} judges..."
-
-	for i in $(seq 0 $((num_entries - 1))); do
-		local label="${labels[$i]:-$(printf '%c' $((65 + i)))}"
-		local eid="${entry_ids[$i]}"
-		local total_correctness=0 total_completeness=0 total_quality=0 total_clarity=0
-		local score_count=0
-
-		for score_entry in "${all_scores[@]}"; do
-			local score_json="${score_entry#*|}"
-			local score_label
-			score_label=$(echo "$score_json" | sed -n 's/.*"label"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || echo "")
-
-			if [[ "$score_label" == "$label" ]]; then
-				local s_correct s_complete s_quality s_clarity
-				s_correct=$(echo "$score_json" | sed -n 's/.*"correctness"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
-				s_complete=$(echo "$score_json" | sed -n 's/.*"completeness"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
-				s_quality=$(echo "$score_json" | sed -n 's/.*"code_quality"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
-				s_clarity=$(echo "$score_json" | sed -n 's/.*"clarity"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' || echo "0")
-
-				total_correctness=$((total_correctness + s_correct))
-				total_completeness=$((total_completeness + s_complete))
-				total_quality=$((total_quality + s_quality))
-				total_clarity=$((total_clarity + s_clarity))
-				score_count=$((score_count + 1))
-			fi
-		done
-
-		if [[ "$score_count" -gt 0 ]]; then
-			# Average scores across judges
-			local avg_correct avg_complete avg_quality avg_clarity weighted
-			avg_correct=$(awk "BEGIN {printf \"%.2f\", $total_correctness / $score_count}")
-			avg_complete=$(awk "BEGIN {printf \"%.2f\", $total_completeness / $score_count}")
-			avg_quality=$(awk "BEGIN {printf \"%.2f\", $total_quality / $score_count}")
-			avg_clarity=$(awk "BEGIN {printf \"%.2f\", $total_clarity / $score_count}")
-			weighted=$(awk "BEGIN {printf \"%.2f\", ($avg_correct * $WEIGHT_CORRECTNESS + $avg_complete * $WEIGHT_COMPLETENESS + $avg_quality * $WEIGHT_CODE_QUALITY + $avg_clarity * $WEIGHT_CLARITY) / 100}")
-
-			# Store scores
-			db "$SUPERVISOR_DB" "
-				UPDATE contest_entries SET
-					score_correctness = $avg_correct,
-					score_completeness = $avg_complete,
-					score_code_quality = $avg_quality,
-					score_clarity = $avg_clarity,
-					weighted_score = $weighted,
-					cross_rank_scores = '$(sql_escape "judges:$score_count,raw:${all_scores[*]}")'
-				WHERE id = '$(sql_escape "$eid")';
-			"
-
-			log_info "Entry $label (${entry_models[$i]}): correctness=$avg_correct completeness=$avg_complete quality=$avg_quality clarity=$avg_clarity weighted=$weighted"
-		else
-			log_warn "No scores collected for entry $label ($eid)"
-		fi
-	done
-
-	# Determine winner
+	# Store scores and find winner
 	local winner_row
-	winner_row=$(db -separator $'\t' "$SUPERVISOR_DB" "
-		SELECT id, model, weighted_score
-		FROM contest_entries
-		WHERE contest_id = '$escaped_cid' AND status = 'complete'
-		ORDER BY weighted_score DESC
-		LIMIT 1;
-	")
+	winner_row=$(_store_scores_and_find_winner "$escaped_cid" "$summaries_file" "$all_scores_file")
+	rm -f "$summaries_file" "$all_scores_file"
+
+	_finalize_contest_winner "$contest_id" "$escaped_cid" "$winner_row"
+	return $?
+}
+
+#######################################
+# Persist winner, record patterns/scores, or mark contest failed
+# Usage: _finalize_contest_winner <contest_id> <escaped_cid> <winner_row>
+# winner_row format: id<TAB>model<TAB>score  (empty = no winner)
+#######################################
+_finalize_contest_winner() {
+	local contest_id="$1"
+	local escaped_cid="$2"
+	local winner_row="$3"
 
 	if [[ -n "$winner_row" ]]; then
 		local winner_id winner_model winner_score


### PR DESCRIPTION
## Summary

Closes #6016

Extracts sub-functions from the 3 functions in `.agents/scripts/contest-helper.sh` that exceeded 100 lines. No behaviour changes.

## Functions refactored

| Function | Before | After | Extracted into |
|---|---|---|---|
| `cmd_create` | 120 lines | 72 lines | `_parse_create_args`, `_create_contest_entries` |
| `cmd_dispatch_contest` | 122 lines | 76 lines | `_dispatch_single_entry` |
| `cmd_evaluate` | 282 lines | 99 lines | `_collect_entry_summaries`, `_build_ranking_prompt`, `_run_judges`, `_aggregate_entry_scores`, `_store_scores_and_find_winner`, `_finalize_contest_winner` |

All functions are now under 100 lines. Largest is `cmd_evaluate` at 99 lines.

## Verification

- `bash -n .agents/scripts/contest-helper.sh` — syntax OK
- `shellcheck .agents/scripts/contest-helper.sh` — SC1091 info only (pre-existing, sourced file not available to shellcheck)