### PR TITLE
simplify: reduce function complexity in test-task-id-collision.sh

### DIFF
--- a/.agents/scripts/test-task-id-collision.sh
+++ b/.agents/scripts/test-task-id-collision.sh
@@ -209,14 +209,11 @@ EOF
 # =============================================================================
 # Test 3: Supervisor dedup Phase 0.5 (DB-level)
 # =============================================================================
-test_supervisor_dedup_db() {
-	echo ""
-	echo "=== Test 3: Supervisor dedup Phase 0.5 (DB-level) ==="
-	info "Injecting duplicate task IDs into supervisor DB, verifying dedup"
 
-	local test_db="$TEST_DIR/test-supervisor.db"
+# Helper: create supervisor DB and inject duplicate task IDs
+_dedup_db_setup() {
+	local test_db="$1"
 
-	# Create a minimal supervisor DB with duplicate task IDs
 	sqlite3 "$test_db" <<'SQL'
 CREATE TABLE IF NOT EXISTS tasks (
     id TEXT NOT NULL,
@@ -239,7 +236,6 @@ INSERT INTO tasks (id, status, description, created_at) VALUES ('t202', 'queued'
 INSERT INTO tasks (id, status, description, created_at) VALUES ('t202', 'queued', 'Triple t202', '2026-02-12T10:05:00Z');
 SQL
 
-	# Verify duplicates exist
 	local dup_count
 	dup_count=$(sqlite3 "$test_db" "SELECT COUNT(*) FROM (SELECT id FROM tasks GROUP BY id HAVING COUNT(*) > 1);")
 
@@ -248,8 +244,13 @@ SQL
 	else
 		fail "Expected 2 duplicate IDs, found $dup_count"
 	fi
+	return 0
+}
 
-	# Simulate Phase 0.5 dedup logic (extracted from supervisor-helper.sh)
+# Helper: run Phase 0.5 dedup logic against the DB
+_dedup_db_run_dedup() {
+	local test_db="$1"
+
 	local duplicate_ids
 	duplicate_ids=$(sqlite3 "$test_db" "
 		SELECT id, COUNT(*) as cnt
@@ -287,8 +288,13 @@ SQL
 			done <<<"$all_instances"
 		done <<<"$duplicate_ids"
 	fi
+	return 0
+}
 
-	# Verify: no more duplicates in non-cancelled tasks
+# Helper: verify dedup results in the DB
+_dedup_db_verify() {
+	local test_db="$1"
+
 	local remaining_dups
 	remaining_dups=$(sqlite3 "$test_db" "
 		SELECT COUNT(*) FROM (
@@ -302,7 +308,6 @@ SQL
 		fail "Still $remaining_dups duplicate IDs after dedup"
 	fi
 
-	# Verify cancelled tasks have correct error message
 	local cancelled_count
 	cancelled_count=$(sqlite3 "$test_db" "SELECT COUNT(*) FROM tasks WHERE status = 'cancelled' AND error LIKE '%Phase 0.5 dedup%';")
 
@@ -312,7 +317,6 @@ SQL
 		fail "Expected 3 cancelled tasks, got $cancelled_count"
 	fi
 
-	# Verify originals are still queued
 	local queued_count
 	queued_count=$(sqlite3 "$test_db" "SELECT COUNT(*) FROM tasks WHERE status = 'queued';")
 
@@ -324,18 +328,28 @@ SQL
 	return 0
 }
 
+test_supervisor_dedup_db() {
+	echo ""
+	echo "=== Test 3: Supervisor dedup Phase 0.5 (DB-level) ==="
+	info "Injecting duplicate task IDs into supervisor DB, verifying dedup"
+
+	local test_db="$TEST_DIR/test-supervisor.db"
+
+	_dedup_db_setup "$test_db"
+	_dedup_db_run_dedup "$test_db"
+	_dedup_db_verify "$test_db"
+	return 0
+}
+
 # =============================================================================
 # Test 4: Supervisor dedup Phase 0.5b (TODO.md level)
 # =============================================================================
-test_supervisor_dedup_todo() {
-	echo ""
-	echo "=== Test 4: Supervisor dedup Phase 0.5b (TODO.md level) ==="
-	info "Injecting duplicate task IDs into TODO.md, verifying dedup"
 
-	local test_repo="$TEST_DIR/test-repo-dedup"
+# Helper: create TODO.md with intentional duplicate task IDs
+_dedup_todo_setup() {
+	local test_repo="$1"
+
 	mkdir -p "$test_repo"
-
-	# Create TODO.md with intentional duplicates
 	cat >"$test_repo/TODO.md" <<'EOF'
 # TODO
 
@@ -353,8 +367,14 @@ test_supervisor_dedup_todo() {
 
 - [ ] t303 Backlog task
 EOF
+	return 0
+}
 
-	# Extract open task IDs and find duplicates (simulating Phase 0.5b logic)
+# Helper: detect duplicates and rename them; writes changes_made count to $2 (temp file)
+_dedup_todo_run_dedup() {
+	local test_repo="$1"
+	local count_file="$2"
+
 	local task_lines
 	task_lines=$(grep -nE '^[[:space:]]*- \[ \] t[0-9]+' "$test_repo/TODO.md" | while IFS=: read -r lnum line_content; do
 		if [[ "$line_content" =~ ^[[:space:]]*-[[:space:]]\[[[:space:]]\][[:space:]](t[0-9]+(\.[0-9]+)*) ]]; then
@@ -369,10 +389,10 @@ EOF
 		pass "Detected duplicate task IDs in TODO.md: $(echo "$dup_ids" | tr '\n' ' ')"
 	else
 		fail "Failed to detect duplicate task IDs in TODO.md"
-		return
+		printf '%s\n' "0" >"$count_file"
+		return 0
 	fi
 
-	# Find highest task number for renaming
 	local max_num
 	max_num=$(grep -oE '(^|[[:space:]])t([0-9]+)' "$test_repo/TODO.md" | grep -oE '[0-9]+' | sort -n | tail -1 || echo "0")
 	max_num=$((10#${max_num}))
@@ -412,8 +432,15 @@ EOF
 	done <<<"$dup_ids"
 
 	info "Renamed $changes_made duplicate task IDs"
+	printf '%s\n' "$changes_made" >"$count_file"
+	return 0
+}
 
-	# Verify no more duplicates
+# Helper: verify no duplicates remain and rename count is correct
+_dedup_todo_verify() {
+	local test_repo="$1"
+	local changes_made="$2"
+
 	local post_task_ids
 	post_task_ids=$(grep -E '^[[:space:]]*- \[ \] t[0-9]+' "$test_repo/TODO.md" |
 		sed -E 's/^[[:space:]]*- \[ \] (t[0-9]+(\.[0-9]+)*).*/\1/')
@@ -427,7 +454,6 @@ EOF
 		fail "Still have duplicates after dedup: $post_dups"
 	fi
 
-	# Verify the renamed IDs are sequential
 	local renamed_ids
 	renamed_ids=$(echo "$post_task_ids" | sort -t't' -k1 -n | tail -"$changes_made")
 	info "Renamed tasks now have IDs: $(echo "$renamed_ids" | tr '\n' ' ')"
@@ -440,18 +466,33 @@ EOF
 	return 0
 }
 
+test_supervisor_dedup_todo() {
+	echo ""
+	echo "=== Test 4: Supervisor dedup Phase 0.5b (TODO.md level) ==="
+	info "Injecting duplicate task IDs into TODO.md, verifying dedup"
+
+	local test_repo="$TEST_DIR/test-repo-dedup"
+	local count_file="$TEST_DIR/dedup-todo-count.txt"
+
+	_dedup_todo_setup "$test_repo"
+	_dedup_todo_run_dedup "$test_repo" "$count_file"
+
+	local changes_made
+	changes_made=$(tr -d '[:space:]' <"$count_file")
+
+	_dedup_todo_verify "$test_repo" "$changes_made"
+	return 0
+}
+
 # =============================================================================
 # Test 5: Pre-commit hook rejects duplicate task IDs
 # =============================================================================
-test_precommit_duplicate_rejection() {
-	echo ""
-	echo "=== Test 5: Pre-commit hook rejects duplicate task IDs ==="
-	info "Simulating staged TODO.md with duplicates"
 
-	local test_repo="$TEST_DIR/test-repo-precommit"
+# Helper: initialise a git repo with a clean TODO.md baseline
+_precommit_setup() {
+	local test_repo="$1"
+
 	mkdir -p "$test_repo"
-
-	# Initialize git repo
 	(
 		cd "$test_repo"
 		git init -q
@@ -466,8 +507,13 @@ EOF
 		git add TODO.md
 		git commit -q -m "init"
 	)
+	return 0
+}
 
-	# Now create a TODO.md with duplicates and stage it
+# Helper: stage a TODO.md with duplicates and verify the hook detects them
+_precommit_check_duplicates() {
+	local test_repo="$1"
+
 	cat >"$test_repo/TODO.md" <<'EOF'
 # TODO
 
@@ -496,22 +542,18 @@ EOF
 		fail "Pre-commit logic failed to detect duplicate task IDs"
 	fi
 
-	# Verify the specific duplicate
 	if echo "$duplicates" | grep -q "t400"; then
 		pass "Correctly identified t400 as the duplicate"
 	else
 		fail "Expected t400 as duplicate, got: $duplicates"
 	fi
 
-	# Verify non-duplicates are not flagged
 	if ! echo "$duplicates" | grep -q "t401"; then
 		pass "t401 correctly not flagged as duplicate"
 	else
 		fail "t401 incorrectly flagged as duplicate"
 	fi
 
-	# Test that the hook would reject (non-zero exit)
-	# Simulate the validate_duplicate_task_ids return value
 	local dup_count
 	dup_count=$(echo "$duplicates" | grep -c "." || echo "0")
 
@@ -520,8 +562,13 @@ EOF
 	else
 		fail "Pre-commit hook would incorrectly allow commit"
 	fi
+	return 0
+}
 
-	# Test with clean TODO.md (no duplicates)
+# Helper: stage a clean TODO.md and verify the hook allows it
+_precommit_check_clean() {
+	local test_repo="$1"
+
 	cat >"$test_repo/TODO.md" <<'EOF'
 # TODO
 
@@ -546,6 +593,19 @@ EOF
 	else
 		fail "Pre-commit logic incorrectly flags clean TODO.md"
 	fi
+	return 0
+}
+
+test_precommit_duplicate_rejection() {
+	echo ""
+	echo "=== Test 5: Pre-commit hook rejects duplicate task IDs ==="
+	info "Simulating staged TODO.md with duplicates"
+
+	local test_repo="$TEST_DIR/test-repo-precommit"
+
+	_precommit_setup "$test_repo"
+	_precommit_check_duplicates "$test_repo"
+	_precommit_check_clean "$test_repo"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Closes #6002

Extracts sub-functions from 3 functions that exceeded 100 lines in `.agents/scripts/test-task-id-collision.sh`. No behaviour changes — pure structural refactor.

## Changes

| Original function | Lines before | Lines after | Extracted helpers |
|---|---|---|---|
| `test_supervisor_dedup_db` | 113 | 17 | `_dedup_db_setup`, `_dedup_db_run_dedup`, `_dedup_db_verify` |
| `test_supervisor_dedup_todo` | 111 | 20 | `_dedup_todo_setup`, `_dedup_todo_run_dedup`, `_dedup_todo_verify` |
| `test_precommit_duplicate_rejection` | 104 | 15 | `_precommit_setup`, `_precommit_check_duplicates`, `_precommit_check_clean` |

## Verification

- `bash -n`: SYNTAX OK
- `shellcheck`: zero violations
- Test suite: 34 PASS, 0 FAIL, 1 SKIP (unchanged from pre-refactor)

## Notes

`_dedup_todo_run_dedup` uses a temp file to return the `changes_made` count rather than stdout capture, avoiding ANSI escape code contamination from `pass`/`fail`/`info` helpers that write coloured output to stdout.