### PR TITLE
simplification: reduce function complexity in .agents/scripts/ai-cli-config.sh

### DIFF
--- a/.agents/scripts/ai-cli-config.sh
+++ b/.agents/scripts/ai-cli-config.sh
@@ -120,16 +120,11 @@ PYEOF
 # Source: https://github.com/janwilmake/openapi-mcp-server
 # URL:    https://openapi-mcp.openapisearch.com/mcp
 # =============================================================================
-configure_openapi_search_mcp() {
-	local mcp_name="openapi-search"
-	local mcp_url="https://openapi-mcp.openapisearch.com/mcp"
 
-	print_info "Configuring OpenAPI Search MCP for AI assistants..."
-	print_info "Remote URL: $mcp_url (no prerequisites required)"
-
-	# -------------------------------------------------------------------------
-	# OpenCode — ~/.config/opencode/opencode.json
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for OpenCode (~/.config/opencode/opencode.json).
+_configure_openapi_opencode() {
+	local mcp_name="$1"
+	local mcp_url="$2"
 	local opencode_config="$HOME/.config/opencode/opencode.json"
 	if [[ -d "$HOME/.config/opencode" ]] || command -v opencode >/dev/null 2>&1; then
 		mkdir -p "$HOME/.config/opencode"
@@ -141,10 +136,13 @@ configure_openapi_search_mcp() {
 		print_warning "OpenCode not detected - skipping"
 		print_info "Run setup.sh to create OpenCode config, then re-run this script"
 	fi
+	return 0
+}
 
-	# -------------------------------------------------------------------------
-	# Claude Code CLI — claude mcp add --transport http
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for Claude Code CLI (claude mcp add).
+_configure_openapi_claude_code() {
+	local mcp_name="$1"
+	local mcp_url="$2"
 	if command -v claude >/dev/null 2>&1; then
 		print_info "Configuring OpenAPI Search for Claude Code..."
 		if claude mcp add --scope user "$mcp_name" --transport http "$mcp_url"; then
@@ -158,10 +156,13 @@ configure_openapi_search_mcp() {
 	else
 		print_info "Claude Code CLI not found - skipping (install: https://claude.ai/download)"
 	fi
+	return 0
+}
 
-	# -------------------------------------------------------------------------
-	# Cursor — ~/.cursor/mcp.json
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for Cursor (~/.cursor/mcp.json).
+_configure_openapi_cursor() {
+	local mcp_name="$1"
+	local mcp_url="$2"
 	local cursor_config="$HOME/.cursor/mcp.json"
 	if [[ -d "$HOME/.cursor" ]] || command -v cursor >/dev/null 2>&1; then
 		print_info "Configuring OpenAPI Search for Cursor..."
@@ -172,10 +173,13 @@ configure_openapi_search_mcp() {
 	else
 		print_info "Cursor not detected - skipping"
 	fi
+	return 0
+}
 
-	# -------------------------------------------------------------------------
-	# Windsurf — ~/.codeium/windsurf/mcp_config.json
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for Windsurf (~/.codeium/windsurf/mcp_config.json).
+_configure_openapi_windsurf() {
+	local mcp_name="$1"
+	local mcp_url="$2"
 	local windsurf_config="$HOME/.codeium/windsurf/mcp_config.json"
 	if [[ -d "$HOME/.codeium/windsurf" ]] || command -v windsurf >/dev/null 2>&1; then
 		print_info "Configuring OpenAPI Search for Windsurf..."
@@ -186,10 +190,13 @@ configure_openapi_search_mcp() {
 	else
 		print_info "Windsurf not detected - skipping"
 	fi
+	return 0
+}
 
-	# -------------------------------------------------------------------------
-	# Gemini CLI — ~/.gemini/settings.json
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for Gemini CLI (~/.gemini/settings.json).
+_configure_openapi_gemini() {
+	local mcp_name="$1"
+	local mcp_url="$2"
 	local gemini_config="$HOME/.gemini/settings.json"
 	if [[ -d "$HOME/.gemini" ]] || command -v gemini >/dev/null 2>&1; then
 		print_info "Configuring OpenAPI Search for Gemini CLI..."
@@ -200,10 +207,13 @@ configure_openapi_search_mcp() {
 	else
 		print_info "Gemini CLI not detected - skipping"
 	fi
+	return 0
+}
 
-	# -------------------------------------------------------------------------
-	# Continue.dev — ~/.continue/config.json (array-based mcpServers)
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for Continue.dev (~/.continue/config.json, array-based).
+_configure_openapi_continue() {
+	local mcp_name="$1"
+	local mcp_url="$2"
 	local continue_config="$HOME/.continue/config.json"
 	# Note: 'continue' is a bash builtin, so 'command -v continue' always succeeds.
 	# Use 'type -P' to search only the filesystem PATH for a real Continue.dev binary.
@@ -217,14 +227,17 @@ configure_openapi_search_mcp() {
 	else
 		print_info "Continue.dev not detected - skipping"
 	fi
+	return 0
+}
 
-	# -------------------------------------------------------------------------
-	# Kilo Code / Kiro — ~/.kilo/mcp.json and ~/.kiro/mcp.json
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for Kilo Code / Kiro (~/.kilo/mcp.json, ~/.kiro/mcp.json).
+_configure_openapi_kilo_kiro() {
+	local mcp_name="$1"
+	local mcp_url="$2"
+	local kilo_dir kilo_config kilo_name
 	for kilo_dir in "$HOME/.kilo" "$HOME/.kiro"; do
 		if [[ -d "$kilo_dir" ]]; then
-			local kilo_config="$kilo_dir/mcp.json"
-			local kilo_name
+			kilo_config="$kilo_dir/mcp.json"
 			kilo_name="$(basename "$kilo_dir")"
 			print_info "Configuring OpenAPI Search for ${kilo_name}..."
 			json_set_nested "$kilo_config" "mcpServers" "$mcp_name" \
@@ -232,10 +245,13 @@ configure_openapi_search_mcp() {
 			print_success "${kilo_name} configured for OpenAPI Search"
 		fi
 	done
+	return 0
+}
 
-	# -------------------------------------------------------------------------
-	# Droid (Factory.AI) — droid mcp add CLI
-	# -------------------------------------------------------------------------
+# Configure OpenAPI Search MCP for Droid (Factory.AI) via droid CLI.
+_configure_openapi_droid() {
+	local mcp_name="$1"
+	local mcp_url="$2"
 	if command -v droid >/dev/null 2>&1; then
 		print_info "Configuring OpenAPI Search for Droid (Factory.AI)..."
 		droid mcp add "$mcp_name" --url "$mcp_url" || true
@@ -243,6 +259,24 @@ configure_openapi_search_mcp() {
 	else
 		print_info "Droid (Factory.AI) not detected - skipping"
 	fi
+	return 0
+}
+
+configure_openapi_search_mcp() {
+	local mcp_name="openapi-search"
+	local mcp_url="https://openapi-mcp.openapisearch.com/mcp"
+
+	print_info "Configuring OpenAPI Search MCP for AI assistants..."
+	print_info "Remote URL: $mcp_url (no prerequisites required)"
+
+	_configure_openapi_opencode "$mcp_name" "$mcp_url"
+	_configure_openapi_claude_code "$mcp_name" "$mcp_url"
+	_configure_openapi_cursor "$mcp_name" "$mcp_url"
+	_configure_openapi_windsurf "$mcp_name" "$mcp_url"
+	_configure_openapi_gemini "$mcp_name" "$mcp_url"
+	_configure_openapi_continue "$mcp_name" "$mcp_url"
+	_configure_openapi_kilo_kiro "$mcp_name" "$mcp_url"
+	_configure_openapi_droid "$mcp_name" "$mcp_url"
 
 	print_success "OpenAPI Search MCP configured for all detected AI assistants"
 	print_info "Docs: https://github.com/janwilmake/openapi-mcp-server"


### PR DESCRIPTION
## Summary

- `configure_openapi_search_mcp()` was 129 lines, exceeding the 100-line threshold flagged in issue #5890
- Extracted 8 focused per-assistant helper functions (`_configure_openapi_<assistant>`), each 12–18 lines
- Orchestrator `configure_openapi_search_mcp()` reduced to 22 lines — calls helpers in sequence
- No behavior changes; all logic is identical, just reorganised

## Function sizes after refactor

| Function | Lines |
|---|---|
| `_configure_openapi_opencode` | 16 |
| `_configure_openapi_claude_code` | 18 |
| `_configure_openapi_cursor` | 15 |
| `_configure_openapi_windsurf` | 15 |
| `_configure_openapi_gemini` | 15 |
| `_configure_openapi_continue` | 18 |
| `_configure_openapi_kilo_kiro` | 16 |
| `_configure_openapi_droid` | 12 |
| `configure_openapi_search_mcp` (orchestrator) | 22 |

## Verification

- `bash -n .agents/scripts/ai-cli-config.sh` — syntax OK
- `shellcheck .agents/scripts/ai-cli-config.sh` — zero new violations (pre-existing SC1091 info on sourced file)

Closes #5890