### PR TITLE
simplification: reduce function complexity in setup-modules/tool-install.sh

### DIFF
--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -95,6 +95,81 @@ setup_git_clis() {
 	return 0
 }
 
+_print_file_discovery_manual_install() {
+	echo ""
+	echo "  Manual installation:"
+	echo "    macOS:        brew install fd ripgrep ripgrep-all"
+	echo "    Ubuntu/Debian: sudo apt install fd-find ripgrep  # rga: cargo install ripgrep_all"
+	echo "    Fedora:       sudo dnf install fd-find ripgrep   # rga: cargo install ripgrep_all"
+	echo "    Arch:         sudo pacman -S fd ripgrep ripgrep-all"
+	return 0
+}
+
+# Add fd=fdfind alias to shell rc files on Debian/Ubuntu after apt install.
+_add_fd_alias_debian() {
+	local rc_files=("$HOME/.bashrc" "$HOME/.zshrc")
+	local added_to=""
+	local rc_file
+
+	for rc_file in "${rc_files[@]}"; do
+		[[ ! -f "$rc_file" ]] && continue
+
+		if ! grep -q 'alias fd="fdfind"' "$rc_file" 2>/dev/null; then
+			if { echo '' >>"$rc_file" &&
+				echo '# fd-find alias for Debian/Ubuntu (added by aidevops)' >>"$rc_file" &&
+				echo 'alias fd="fdfind"' >>"$rc_file"; }; then
+				added_to="${added_to:+$added_to, }$rc_file"
+			fi
+		fi
+	done
+
+	if [[ -n "$added_to" ]]; then
+		print_success "Added alias fd=fdfind to: $added_to"
+		echo "  Restart your shell to activate"
+	else
+		print_success "fd alias already configured"
+	fi
+	return 0
+}
+
+# Resolve apt package names (fd→fd-find on Debian/Ubuntu) and install.
+_install_file_discovery_packages() {
+	local pkg_manager="$1"
+	shift
+	local missing_packages=("$@")
+
+	print_info "Installing ${missing_packages[*]}..."
+
+	local actual_packages=()
+	local pkg
+	for pkg in "${missing_packages[@]}"; do
+		case "$pkg_manager" in
+		apt)
+			# Debian/Ubuntu uses fd-find instead of fd
+			if [[ "$pkg" == "fd" ]]; then
+				actual_packages+=("fd-find")
+			else
+				actual_packages+=("$pkg")
+			fi
+			;;
+		*)
+			actual_packages+=("$pkg")
+			;;
+		esac
+	done
+
+	if install_packages "$pkg_manager" "${actual_packages[@]}"; then
+		print_success "File discovery tools installed"
+		# On Debian/Ubuntu, fd is installed as fdfind — create alias in shell rc files
+		if [[ "$pkg_manager" == "apt" ]] && command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1; then
+			_add_fd_alias_debian
+		fi
+	else
+		print_warning "Failed to install some file discovery tools (non-critical)"
+	fi
+	return 0
+}
+
 setup_file_discovery_tools() {
 	print_info "Setting up file discovery tools..."
 
@@ -160,72 +235,13 @@ setup_file_discovery_tools() {
 			fi
 
 			if [[ "$install_fd_tools" =~ ^[Yy]?$ ]]; then
-				print_info "Installing ${missing_packages[*]}..."
-
-				# Handle package name differences across package managers
-				local actual_packages=()
-				for pkg in "${missing_packages[@]}"; do
-					case "$pkg_manager" in
-					apt)
-						# Debian/Ubuntu uses fd-find instead of fd
-						if [[ "$pkg" == "fd" ]]; then
-							actual_packages+=("fd-find")
-						else
-							actual_packages+=("$pkg")
-						fi
-						;;
-					*)
-						actual_packages+=("$pkg")
-						;;
-					esac
-				done
-
-				if install_packages "$pkg_manager" "${actual_packages[@]}"; then
-					print_success "File discovery tools installed"
-
-					# On Debian/Ubuntu, fd is installed as fdfind - create alias in all existing shell rc files
-					if [[ "$pkg_manager" == "apt" ]] && command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1; then
-						local rc_files=("$HOME/.bashrc" "$HOME/.zshrc")
-						local added_to=""
-
-						for rc_file in "${rc_files[@]}"; do
-							[[ ! -f "$rc_file" ]] && continue
-
-							if ! grep -q 'alias fd="fdfind"' "$rc_file" 2>/dev/null; then
-								if { echo '' >>"$rc_file" &&
-									echo '# fd-find alias for Debian/Ubuntu (added by aidevops)' >>"$rc_file" &&
-									echo 'alias fd="fdfind"' >>"$rc_file"; }; then
-									added_to="${added_to:+$added_to, }$rc_file"
-								fi
-							fi
-						done
-
-						if [[ -n "$added_to" ]]; then
-							print_success "Added alias fd=fdfind to: $added_to"
-							echo "  Restart your shell to activate"
-						else
-							print_success "fd alias already configured"
-						fi
-					fi
-				else
-					print_warning "Failed to install some file discovery tools (non-critical)"
-				fi
+				_install_file_discovery_packages "$pkg_manager" "${missing_packages[@]}"
 			else
 				print_info "Skipped file discovery tools installation"
-				echo ""
-				echo "  Manual installation:"
-				echo "    macOS:        brew install fd ripgrep ripgrep-all"
-				echo "    Ubuntu/Debian: sudo apt install fd-find ripgrep  # rga: cargo install ripgrep_all"
-				echo "    Fedora:       sudo dnf install fd-find ripgrep   # rga: cargo install ripgrep_all"
-				echo "    Arch:         sudo pacman -S fd ripgrep ripgrep-all"
+				_print_file_discovery_manual_install
 			fi
 		else
-			echo ""
-			echo "  Manual installation:"
-			echo "    macOS:        brew install fd ripgrep ripgrep-all"
-			echo "    Ubuntu/Debian: sudo apt install fd-find ripgrep  # rga: cargo install ripgrep_all"
-			echo "    Fedora:       sudo dnf install fd-find ripgrep   # rga: cargo install ripgrep_all"
-			echo "    Arch:         sudo pacman -S fd ripgrep ripgrep-all"
+			_print_file_discovery_manual_install
 		fi
 	else
 		print_success "All file discovery tools installed!"
@@ -569,6 +585,87 @@ setup_rosetta_audit() {
 	return 0
 }
 
+# Install Worktrunk shell integration (enables 'wt switch' to change directories).
+_setup_worktrunk_shell_integration() {
+	print_info "Installing shell integration..."
+	if wt config shell install; then
+		print_success "Shell integration installed"
+		print_info "Restart your terminal or source your shell config"
+	else
+		print_warning "Shell integration failed - run manually: wt config shell install"
+	fi
+	return 0
+}
+
+# Check and optionally install Worktrunk shell integration when wt is already present.
+_check_worktrunk_shell_integration() {
+	local wt_integrated=false
+	local rc_file
+	while IFS= read -r rc_file; do
+		[[ -z "$rc_file" ]] && continue
+		if [[ -f "$rc_file" ]] && grep -q "worktrunk" "$rc_file" 2>/dev/null; then
+			wt_integrated=true
+			break
+		fi
+	done < <(get_all_shell_rcs)
+
+	if [[ "$wt_integrated" == "false" ]]; then
+		print_info "Shell integration not detected"
+		local install_shell
+		read -r -p "Install Worktrunk shell integration (enables 'wt switch' to change directories)? [Y/n]: " install_shell
+		if [[ "$install_shell" =~ ^[Yy]?$ ]]; then
+			_setup_worktrunk_shell_integration
+		fi
+	else
+		print_success "Shell integration already configured"
+	fi
+	return 0
+}
+
+# Install Worktrunk via Homebrew and set up shell integration.
+_install_worktrunk_brew() {
+	local install_wt
+	read -r -p "Install Worktrunk via Homebrew? [Y/n]: " install_wt
+
+	if [[ "$install_wt" =~ ^[Yy]?$ ]]; then
+		if run_with_spinner "Installing Worktrunk via Homebrew" brew install max-sixty/worktrunk/wt; then
+			_setup_worktrunk_shell_integration
+			echo ""
+			print_info "Quick start:"
+			echo "  wt switch feature/my-feature  # Create/switch to worktree"
+			echo "  wt list                       # List all worktrees"
+			echo "  wt merge                      # Merge and cleanup"
+			echo ""
+			print_info "Documentation: ~/.aidevops/agents/tools/git/worktrunk.md"
+		else
+			print_warning "Homebrew installation failed"
+			echo "  Try: cargo install worktrunk && wt config shell install"
+		fi
+	else
+		print_info "Skipped Worktrunk installation"
+		print_info "Install later: brew install max-sixty/worktrunk/wt"
+		print_info "Fallback available: ~/.aidevops/agents/scripts/worktree-helper.sh"
+	fi
+	return 0
+}
+
+# Install Worktrunk via Cargo and set up shell integration.
+_install_worktrunk_cargo() {
+	local install_wt
+	read -r -p "Install Worktrunk via Cargo? [Y/n]: " install_wt
+
+	if [[ "$install_wt" =~ ^[Yy]?$ ]]; then
+		if run_with_spinner "Installing Worktrunk via Cargo" cargo install worktrunk; then
+			_setup_worktrunk_shell_integration
+		else
+			print_warning "Cargo installation failed"
+		fi
+	else
+		print_info "Skipped Worktrunk installation"
+	fi
+	return 0
+}
+
 setup_worktrunk() {
 	print_info "Setting up Worktrunk (git worktree management)..."
 
@@ -577,33 +674,7 @@ setup_worktrunk() {
 		local wt_version
 		wt_version=$(wt --version 2>/dev/null | head -1 || echo "unknown")
 		print_success "Worktrunk already installed: $wt_version"
-
-		# Check if shell integration is installed (check all rc files)
-		local wt_integrated=false
-		local rc_file
-		while IFS= read -r rc_file; do
-			[[ -z "$rc_file" ]] && continue
-			if [[ -f "$rc_file" ]] && grep -q "worktrunk" "$rc_file" 2>/dev/null; then
-				wt_integrated=true
-				break
-			fi
-		done < <(get_all_shell_rcs)
-
-		if [[ "$wt_integrated" == "false" ]]; then
-			print_info "Shell integration not detected"
-			read -r -p "Install Worktrunk shell integration (enables 'wt switch' to change directories)? [Y/n]: " install_shell
-			if [[ "$install_shell" =~ ^[Yy]?$ ]]; then
-				print_info "Installing shell integration..."
-				if wt config shell install; then
-					print_success "Shell integration installed"
-					print_info "Restart your terminal for the change to take effect"
-				else
-					print_warning "Shell integration failed - run manually: wt config shell install"
-				fi
-			fi
-		else
-			print_success "Shell integration already configured"
-		fi
+		_check_worktrunk_shell_integration
 		return 0
 	fi
 
@@ -621,54 +692,9 @@ setup_worktrunk() {
 	pkg_manager=$(detect_package_manager)
 
 	if [[ "$pkg_manager" == "brew" ]]; then
-		read -r -p "Install Worktrunk via Homebrew? [Y/n]: " install_wt
-
-		if [[ "$install_wt" =~ ^[Yy]?$ ]]; then
-			if run_with_spinner "Installing Worktrunk via Homebrew" brew install max-sixty/worktrunk/wt; then
-				# Install shell integration (don't use spinner - command is fast and may need interaction)
-				print_info "Installing shell integration..."
-				if wt config shell install; then
-					print_success "Shell integration installed"
-					print_info "Restart your terminal or source your shell config"
-				else
-					print_warning "Shell integration failed - run manually: wt config shell install"
-				fi
-
-				echo ""
-				print_info "Quick start:"
-				echo "  wt switch feature/my-feature  # Create/switch to worktree"
-				echo "  wt list                       # List all worktrees"
-				echo "  wt merge                      # Merge and cleanup"
-				echo ""
-				print_info "Documentation: ~/.aidevops/agents/tools/git/worktrunk.md"
-			else
-				print_warning "Homebrew installation failed"
-				echo "  Try: cargo install worktrunk && wt config shell install"
-			fi
-		else
-			print_info "Skipped Worktrunk installation"
-			print_info "Install later: brew install max-sixty/worktrunk/wt"
-			print_info "Fallback available: ~/.aidevops/agents/scripts/worktree-helper.sh"
-		fi
+		_install_worktrunk_brew
 	elif command -v cargo >/dev/null 2>&1; then
-		read -r -p "Install Worktrunk via Cargo? [Y/n]: " install_wt
-
-		if [[ "$install_wt" =~ ^[Yy]?$ ]]; then
-			if run_with_spinner "Installing Worktrunk via Cargo" cargo install worktrunk; then
-				# Install shell integration (don't use spinner - command is fast and may need interaction)
-				print_info "Installing shell integration..."
-				if wt config shell install; then
-					print_success "Shell integration installed"
-					print_info "Restart your terminal or source your shell config"
-				else
-					print_warning "Shell integration failed - run manually: wt config shell install"
-				fi
-			else
-				print_warning "Cargo installation failed"
-			fi
-		else
-			print_info "Skipped Worktrunk installation"
-		fi
+		_install_worktrunk_cargo
 	else
 		print_warning "Worktrunk not installed"
 		echo ""
@@ -682,6 +708,167 @@ setup_worktrunk() {
 		print_info "Fallback available: ~/.aidevops/agents/scripts/worktree-helper.sh"
 	fi
 
+	return 0
+}
+
+# Trigger OpenCode extension install in Zed via the zed:// URI scheme.
+_install_opencode_ext_for_zed() {
+	local install_opencode_ext
+	read -r -p "Install OpenCode extension for Zed? [Y/n]: " install_opencode_ext
+	if [[ "$install_opencode_ext" =~ ^[Yy]?$ ]]; then
+		print_info "Installing OpenCode extension..."
+		if [[ "$(uname)" == "Darwin" ]]; then
+			open "zed://extension/opencode" 2>/dev/null
+			print_success "OpenCode extension install triggered"
+			print_info "Zed will open and prompt to install the extension"
+		elif [[ "$(uname)" == "Linux" ]]; then
+			xdg-open "zed://extension/opencode" 2>/dev/null ||
+				print_info "Open Zed and install 'opencode' from Extensions (Cmd+Shift+X)"
+		fi
+	fi
+	return 0
+}
+
+# Install Tabby terminal on Linux (x86_64 only via packagecloud; ARM64 manual).
+_install_tabby_linux() {
+	local arch
+	arch=$(uname -m)
+	# Tabby packagecloud repo only has x86_64 packages
+	# ARM64 (aarch64) must use .deb from GitHub releases or skip
+	if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+		# Clean up stale Tabby packagecloud repo if it exists from a previous run
+		# (it causes apt-get update failures on ARM64)
+		if [[ -f /etc/apt/sources.list.d/eugeny_tabby.list ]]; then
+			print_info "Removing stale Tabby packagecloud repo (not available for ARM64)..."
+			sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.list
+			sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.sources
+			sudo apt-get update -qq 2>/dev/null || true
+		fi
+		print_warning "Tabby packages are not available for ARM64 Linux via package manager"
+		echo "  Download ARM64 .deb from: https://github.com/Eugeny/tabby/releases/latest"
+		echo "  Or skip Tabby - it's optional (a modern terminal emulator)"
+		return 0
+	fi
+
+	local pkg_manager
+	pkg_manager=$(detect_package_manager)
+	case "$pkg_manager" in
+	apt)
+		# Add packagecloud repo for Tabby (verified download, not piped to sudo)
+		# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
+		VERIFIED_INSTALL_SUDO="true"
+		if verified_install "Tabby repository (apt)" "https://packagecloud.io/install/repositories/eugeny/tabby/script.deb.sh"; then
+			if ! sudo apt-get install -y tabby-terminal; then
+				print_warning "Tabby package not found for this architecture"
+				echo "  Download from: https://github.com/Eugeny/tabby/releases/latest"
+			fi
+		fi
+		;;
+	dnf | yum)
+		# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
+		VERIFIED_INSTALL_SUDO="true"
+		if verified_install "Tabby repository (rpm)" "https://packagecloud.io/install/repositories/eugeny/tabby/script.rpm.sh"; then
+			if ! sudo "$pkg_manager" install -y tabby-terminal; then
+				print_warning "Tabby package not found for this architecture"
+				echo "  Download from: https://github.com/Eugeny/tabby/releases/latest"
+			fi
+		fi
+		;;
+	pacman)
+		# AUR package
+		print_info "Tabby available in AUR as 'tabby-bin'"
+		echo "  Install with: yay -S tabby-bin"
+		;;
+	*)
+		echo "  Download manually: https://github.com/Eugeny/tabby/releases/latest"
+		;;
+	esac
+	return 0
+}
+
+# Offer and perform Tabby terminal installation.
+_install_tabby() {
+	local install_tabby
+	read -r -p "Install Tabby terminal? [Y/n]: " install_tabby
+
+	if [[ "$install_tabby" =~ ^[Yy]?$ ]]; then
+		if [[ "$(uname)" == "Darwin" ]]; then
+			if command -v brew >/dev/null 2>&1; then
+				if run_with_spinner "Installing Tabby" brew install --cask tabby; then
+					: # Success message handled by spinner
+				else
+					print_warning "Failed to install Tabby via Homebrew"
+					echo "  Download manually: https://github.com/Eugeny/tabby/releases/latest"
+				fi
+			else
+				print_warning "Homebrew not found"
+				echo "  Download manually: https://github.com/Eugeny/tabby/releases/latest"
+			fi
+		elif [[ "$(uname)" == "Linux" ]]; then
+			_install_tabby_linux
+		fi
+	else
+		print_info "Skipped Tabby installation"
+	fi
+	return 0
+}
+
+# Offer and perform Zed editor installation, then optionally install OpenCode extension.
+_install_zed_and_opencode_ext() {
+	local install_zed
+	read -r -p "Install Zed editor? [Y/n]: " install_zed
+
+	if [[ "$install_zed" =~ ^[Yy]?$ ]]; then
+		local zed_installed=false
+		if [[ "$(uname)" == "Darwin" ]]; then
+			if command -v brew >/dev/null 2>&1; then
+				if run_with_spinner "Installing Zed" brew install --cask zed; then
+					zed_installed=true
+				else
+					print_warning "Failed to install Zed via Homebrew"
+					echo "  Download manually: https://zed.dev/download"
+				fi
+			else
+				print_warning "Homebrew not found"
+				echo "  Download manually: https://zed.dev/download"
+			fi
+		elif [[ "$(uname)" == "Linux" ]]; then
+			# Zed provides an install script for Linux (verified download)
+			# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
+			VERIFIED_INSTALL_SHELL="sh"
+			if verified_install "Zed" "https://zed.dev/install.sh"; then
+				zed_installed=true
+			else
+				print_warning "Failed to install Zed"
+				echo "  See: https://zed.dev/docs/linux"
+			fi
+		fi
+
+		if [[ "$zed_installed" == "true" ]]; then
+			_install_opencode_ext_for_zed
+		fi
+	else
+		print_info "Skipped Zed installation"
+	fi
+	return 0
+}
+
+# Check for OpenCode extension in an existing Zed installation and offer to install.
+_check_opencode_ext_existing_zed() {
+	local zed_extensions_dir=""
+	if [[ "$(uname)" == "Darwin" ]]; then
+		zed_extensions_dir="$HOME/Library/Application Support/Zed/extensions/installed"
+	elif [[ "$(uname)" == "Linux" ]]; then
+		zed_extensions_dir="$HOME/.local/share/zed/extensions/installed"
+	fi
+
+	if [[ -d "$zed_extensions_dir" ]]; then
+		if [[ ! -d "$zed_extensions_dir/opencode" ]]; then
+			_install_opencode_ext_for_zed
+		else
+			print_success "OpenCode extension already installed in Zed"
+		fi
+	fi
 	return 0
 }
 
@@ -734,31 +921,7 @@ setup_recommended_tools() {
 
 	# Check for OpenCode extension in existing Zed installation
 	if [[ "$zed_exists" == "true" ]]; then
-		local zed_extensions_dir=""
-		if [[ "$(uname)" == "Darwin" ]]; then
-			zed_extensions_dir="$HOME/Library/Application Support/Zed/extensions/installed"
-		elif [[ "$(uname)" == "Linux" ]]; then
-			zed_extensions_dir="$HOME/.local/share/zed/extensions/installed"
-		fi
-
-		if [[ -d "$zed_extensions_dir" ]]; then
-			if [[ ! -d "$zed_extensions_dir/opencode" ]]; then
-				read -r -p "Install OpenCode extension for Zed? [Y/n]: " install_opencode_ext
-				if [[ "$install_opencode_ext" =~ ^[Yy]?$ ]]; then
-					print_info "Installing OpenCode extension..."
-					if [[ "$(uname)" == "Darwin" ]]; then
-						open "zed://extension/opencode" 2>/dev/null
-						print_success "OpenCode extension install triggered"
-						print_info "Zed will open and prompt to install the extension"
-					elif [[ "$(uname)" == "Linux" ]]; then
-						xdg-open "zed://extension/opencode" 2>/dev/null ||
-							print_info "Open Zed and install 'opencode' from Extensions"
-					fi
-				fi
-			else
-				print_success "OpenCode extension already installed in Zed"
-			fi
-		fi
+		_check_opencode_ext_existing_zed
 	fi
 
 	# Offer to install missing tools
@@ -770,127 +933,12 @@ setup_recommended_tools() {
 
 		# Install Tabby if missing
 		if [[ " ${missing_tools[*]} " =~ " tabby " ]]; then
-			read -r -p "Install Tabby terminal? [Y/n]: " install_tabby
-
-			if [[ "$install_tabby" =~ ^[Yy]?$ ]]; then
-				if [[ "$(uname)" == "Darwin" ]]; then
-					if command -v brew >/dev/null 2>&1; then
-						if run_with_spinner "Installing Tabby" brew install --cask tabby; then
-							: # Success message handled by spinner
-						else
-							print_warning "Failed to install Tabby via Homebrew"
-							echo "  Download manually: https://github.com/Eugeny/tabby/releases/latest"
-						fi
-					else
-						print_warning "Homebrew not found"
-						echo "  Download manually: https://github.com/Eugeny/tabby/releases/latest"
-					fi
-				elif [[ "$(uname)" == "Linux" ]]; then
-					local arch
-					arch=$(uname -m)
-					# Tabby packagecloud repo only has x86_64 packages
-					# ARM64 (aarch64) must use .deb from GitHub releases or skip
-					if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
-						# Clean up stale Tabby packagecloud repo if it exists from a previous run
-						# (it causes apt-get update failures on ARM64)
-						if [[ -f /etc/apt/sources.list.d/eugeny_tabby.list ]]; then
-							print_info "Removing stale Tabby packagecloud repo (not available for ARM64)..."
-							sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.list
-							sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.sources
-							sudo apt-get update -qq 2>/dev/null || true
-						fi
-						print_warning "Tabby packages are not available for ARM64 Linux via package manager"
-						echo "  Download ARM64 .deb from: https://github.com/Eugeny/tabby/releases/latest"
-						echo "  Or skip Tabby - it's optional (a modern terminal emulator)"
-					else
-						local pkg_manager
-						pkg_manager=$(detect_package_manager)
-						case "$pkg_manager" in
-						apt)
-							# Add packagecloud repo for Tabby (verified download, not piped to sudo)
-							# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
-							VERIFIED_INSTALL_SUDO="true"
-							if verified_install "Tabby repository (apt)" "https://packagecloud.io/install/repositories/eugeny/tabby/script.deb.sh"; then
-								if ! sudo apt-get install -y tabby-terminal; then
-									print_warning "Tabby package not found for this architecture"
-									echo "  Download from: https://github.com/Eugeny/tabby/releases/latest"
-								fi
-							fi
-							;;
-						dnf | yum)
-							# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
-							VERIFIED_INSTALL_SUDO="true"
-							if verified_install "Tabby repository (rpm)" "https://packagecloud.io/install/repositories/eugeny/tabby/script.rpm.sh"; then
-								if ! sudo "$pkg_manager" install -y tabby-terminal; then
-									print_warning "Tabby package not found for this architecture"
-									echo "  Download from: https://github.com/Eugeny/tabby/releases/latest"
-								fi
-							fi
-							;;
-						pacman)
-							# AUR package
-							print_info "Tabby available in AUR as 'tabby-bin'"
-							echo "  Install with: yay -S tabby-bin"
-							;;
-						*)
-							echo "  Download manually: https://github.com/Eugeny/tabby/releases/latest"
-							;;
-						esac
-					fi
-				fi
-			else
-				print_info "Skipped Tabby installation"
-			fi
+			_install_tabby
 		fi
 
 		# Install Zed if missing
 		if [[ " ${missing_tools[*]} " =~ " zed " ]]; then
-			read -r -p "Install Zed editor? [Y/n]: " install_zed
-
-			if [[ "$install_zed" =~ ^[Yy]?$ ]]; then
-				local zed_installed=false
-				if [[ "$(uname)" == "Darwin" ]]; then
-					if command -v brew >/dev/null 2>&1; then
-						if run_with_spinner "Installing Zed" brew install --cask zed; then
-							zed_installed=true
-						else
-							print_warning "Failed to install Zed via Homebrew"
-							echo "  Download manually: https://zed.dev/download"
-						fi
-					else
-						print_warning "Homebrew not found"
-						echo "  Download manually: https://zed.dev/download"
-					fi
-				elif [[ "$(uname)" == "Linux" ]]; then
-					# Zed provides an install script for Linux (verified download)
-					# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
-					VERIFIED_INSTALL_SHELL="sh"
-					if verified_install "Zed" "https://zed.dev/install.sh"; then
-						zed_installed=true
-					else
-						print_warning "Failed to install Zed"
-						echo "  See: https://zed.dev/docs/linux"
-					fi
-				fi
-
-				# Install OpenCode extension for Zed
-				if [[ "$zed_installed" == "true" ]]; then
-					read -r -p "Install OpenCode extension for Zed? [Y/n]: " install_opencode_ext
-					if [[ "$install_opencode_ext" =~ ^[Yy]?$ ]]; then
-						print_info "Installing OpenCode extension..."
-						if [[ "$(uname)" == "Darwin" ]]; then
-							open "zed://extension/opencode" 2>/dev/null
-							print_success "OpenCode extension install triggered"
-							print_info "Zed will open and prompt to install the extension"
-						elif [[ "$(uname)" == "Linux" ]]; then
-							xdg-open "zed://extension/opencode" 2>/dev/null ||
-								print_info "Open Zed and install 'opencode' from Extensions (Cmd+Shift+X)"
-						fi
-					fi
-				fi
-			else
-				print_info "Skipped Zed installation"
-			fi
+			_install_zed_and_opencode_ext
 		fi
 	else
 		print_success "All recommended tools installed!"
@@ -1294,24 +1342,76 @@ setup_nodejs_env() {
 	fi
 }
 
+# Install Node.js via apt, preferring NodeSource LTS over the distro package.
+_install_nodejs_apt() {
+	# Clean up stale Tabby packagecloud repo if present (causes apt-get update failures)
+	if [[ -f /etc/apt/sources.list.d/eugeny_tabby.list ]]; then
+		local arch
+		arch=$(uname -m)
+		if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+			print_info "Removing stale Tabby repo (not available for ARM64)..."
+			sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.list
+			sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.sources
+		fi
+	fi
+
+	# Use NodeSource for a recent version (apt default may be old)
+	print_info "Installing Node.js (via NodeSource for latest LTS)..."
+	if command -v curl >/dev/null 2>&1; then
+		# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
+		VERIFIED_INSTALL_SUDO="true"
+		if verified_install "NodeSource repository" "https://deb.nodesource.com/setup_22.x"; then
+			# Install nodejs (NodeSource bundles npm, but distro fallback may not)
+			# Include npm explicitly in case NodeSource setup failed silently
+			# and apt falls back to the distro nodejs package (which lacks npm)
+			if sudo apt-get install -y nodejs npm 2>/dev/null || sudo apt-get install -y nodejs; then
+				print_success "Node.js installed: $(node --version)"
+			else
+				print_warning "Node.js installation failed"
+			fi
+		else
+			# Fallback to distro package
+			print_info "Falling back to distro Node.js package..."
+			if sudo apt-get install -y nodejs npm; then
+				print_success "Node.js installed: $(node --version)"
+			else
+				print_warning "Node.js installation failed"
+			fi
+		fi
+	else
+		if sudo apt-get install -y nodejs npm; then
+			print_success "Node.js installed: $(node --version)"
+		else
+			print_warning "Node.js installation failed"
+		fi
+	fi
+	return 0
+}
+
+# Ensure npm is present when Node.js is already installed (distro packages may omit it).
+_ensure_npm_installed() {
+	if command -v npm >/dev/null 2>&1; then
+		return 0
+	fi
+	print_info "npm not found (distro nodejs package may omit it) — installing..."
+	local pkg_manager
+	pkg_manager=$(detect_package_manager)
+	case "$pkg_manager" in
+	apt) sudo apt-get install -y npm 2>/dev/null || print_warning "Failed to install npm via apt" ;;
+	dnf | yum) sudo "$pkg_manager" install -y npm 2>/dev/null || print_warning "Failed to install npm via $pkg_manager" ;;
+	brew) brew install npm 2>/dev/null || print_warning "Failed to install npm via brew" ;;
+	*) print_warning "Cannot auto-install npm — install manually" ;;
+	esac
+	return 0
+}
+
 setup_nodejs() {
 	# Check if Node.js is already installed
 	if command -v node >/dev/null 2>&1; then
 		local node_version
 		node_version=$(node --version 2>/dev/null || echo "unknown")
 		print_success "Node.js already installed: $node_version"
-		# Distro nodejs package may not include npm — install it if missing
-		if ! command -v npm >/dev/null 2>&1; then
-			print_info "npm not found (distro nodejs package may omit it) — installing..."
-			local pkg_manager
-			pkg_manager=$(detect_package_manager)
-			case "$pkg_manager" in
-			apt) sudo apt-get install -y npm 2>/dev/null || print_warning "Failed to install npm via apt" ;;
-			dnf | yum) sudo "$pkg_manager" install -y npm 2>/dev/null || print_warning "Failed to install npm via $pkg_manager" ;;
-			brew) brew install npm 2>/dev/null || print_warning "Failed to install npm via brew" ;;
-			*) print_warning "Cannot auto-install npm — install manually" ;;
-			esac
-		fi
+		_ensure_npm_installed
 		return 0
 	fi
 
@@ -1322,6 +1422,7 @@ setup_nodejs() {
 
 	case "$pkg_manager" in
 	brew)
+		local install_node
 		read -r -p "Install Node.js via Homebrew? [Y/n]: " install_node
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if run_with_spinner "Installing Node.js" brew install node; then
@@ -1332,51 +1433,14 @@ setup_nodejs() {
 		fi
 		;;
 	apt)
+		local install_node
 		read -r -p "Install Node.js via apt? [Y/n]: " install_node
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
-			# Clean up stale Tabby packagecloud repo if present (causes apt-get update failures)
-			if [[ -f /etc/apt/sources.list.d/eugeny_tabby.list ]]; then
-				local arch
-				arch=$(uname -m)
-				if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
-					print_info "Removing stale Tabby repo (not available for ARM64)..."
-					sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.list
-					sudo rm -f /etc/apt/sources.list.d/eugeny_tabby.sources
-				fi
-			fi
-			# Use NodeSource for a recent version (apt default may be old)
-			print_info "Installing Node.js (via NodeSource for latest LTS)..."
-			if command -v curl >/dev/null 2>&1; then
-				# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
-				VERIFIED_INSTALL_SUDO="true"
-				if verified_install "NodeSource repository" "https://deb.nodesource.com/setup_22.x"; then
-					# Install nodejs (NodeSource bundles npm, but distro fallback may not)
-					# Include npm explicitly in case NodeSource setup failed silently
-					# and apt falls back to the distro nodejs package (which lacks npm)
-					if sudo apt-get install -y nodejs npm 2>/dev/null || sudo apt-get install -y nodejs; then
-						print_success "Node.js installed: $(node --version)"
-					else
-						print_warning "Node.js installation failed"
-					fi
-				else
-					# Fallback to distro package
-					print_info "Falling back to distro Node.js package..."
-					if sudo apt-get install -y nodejs npm; then
-						print_success "Node.js installed: $(node --version)"
-					else
-						print_warning "Node.js installation failed"
-					fi
-				fi
-			else
-				if sudo apt-get install -y nodejs npm; then
-					print_success "Node.js installed: $(node --version)"
-				else
-					print_warning "Node.js installation failed"
-				fi
-			fi
+			_install_nodejs_apt
 		fi
 		;;
 	dnf | yum)
+		local install_node
 		read -r -p "Install Node.js via $pkg_manager? [Y/n]: " install_node
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if sudo "$pkg_manager" install -y nodejs npm; then
@@ -1387,6 +1451,7 @@ setup_nodejs() {
 		fi
 		;;
 	pacman)
+		local install_node
 		read -r -p "Install Node.js via pacman? [Y/n]: " install_node
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if sudo pacman -S --noconfirm nodejs npm; then
@@ -1397,6 +1462,7 @@ setup_nodejs() {
 		fi
 		;;
 	apk)
+		local install_node
 		read -r -p "Install Node.js via apk? [Y/n]: " install_node
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if sudo apk add nodejs npm; then


### PR DESCRIPTION
## Summary

- Extracts sub-functions from 4 functions that exceeded 100 lines in `setup-modules/tool-install.sh`
- No behaviour changes — pure structural refactor
- All extracted helpers use `_` prefix to signal internal use

## Functions refactored

| Function | Before | After | Extracted helpers |
|---|---|---|---|
| `setup_file_discovery_tools` | 138 | 79 | `_print_file_discovery_manual_install`, `_add_fd_alias_debian`, `_install_file_discovery_packages` |
| `setup_worktrunk` | 115 | 44 | `_setup_worktrunk_shell_integration`, `_check_worktrunk_shell_integration`, `_install_worktrunk_brew`, `_install_worktrunk_cargo` |
| `setup_recommended_tools` | 217 | 78 | `_install_opencode_ext_for_zed`, `_install_tabby_linux`, `_install_tabby`, `_install_zed_and_opencode_ext`, `_check_opencode_ext_existing_zed` |
| `setup_nodejs` | 120 | 75 | `_install_nodejs_apt`, `_ensure_npm_installed` |

## Verification

- `bash -n setup-modules/tool-install.sh` — PASS
- `shellcheck setup-modules/tool-install.sh` — PASS (zero violations)
- Largest function is now 85 lines (`setup_git_clis`, unchanged)

Closes #5981