### PR TITLE
5885: Reduce function complexity in autogen-helper.sh

### DIFF
--- a/.agents/scripts/autogen-helper.sh
+++ b/.agents/scripts/autogen-helper.sh
@@ -31,131 +31,131 @@ LOCALHOST_HELPER="$SCRIPTS_DIR/localhost-helper.sh"
 # Port management integration with localhost-helper.sh
 # Returns available port (original if free, or next available)
 get_available_port() {
-    local desired_port="$1"
-    
-    # Use localhost-helper.sh if available
-    if [[ -x "$LOCALHOST_HELPER" ]]; then
-        if "$LOCALHOST_HELPER" check-port "$desired_port" >/dev/null 2>&1; then
-            echo "$desired_port"
-            return 0
-        else
-            # Port in use, find alternative
-            local suggested
-            suggested=$("$LOCALHOST_HELPER" find-port "$((desired_port + 1))" 2>/dev/null)
-            if [[ -n "$suggested" ]]; then
-                print_warning "Port $desired_port in use, using $suggested instead"
-                echo "$suggested"
-                return 0
-            fi
-        fi
-    fi
-    
-    # Fallback: basic port check using lsof
-    if ! lsof -i :"$desired_port" >/dev/null 2>&1; then
-        echo "$desired_port"
-        return 0
-    fi
-    
-    # Find next available port
-    local port="$desired_port"
-    while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
-        ((++port))
-    done
-    
-    if [[ $port -lt 65535 ]]; then
-        print_warning "Port $desired_port in use, using $port instead"
-        echo "$port"
-        return 0
-    fi
-    
-    print_error "No available ports found"
-    return 1
+	local desired_port="$1"
+
+	# Use localhost-helper.sh if available
+	if [[ -x "$LOCALHOST_HELPER" ]]; then
+		if "$LOCALHOST_HELPER" check-port "$desired_port" >/dev/null 2>&1; then
+			echo "$desired_port"
+			return 0
+		else
+			# Port in use, find alternative
+			local suggested
+			suggested=$("$LOCALHOST_HELPER" find-port "$((desired_port + 1))" 2>/dev/null)
+			if [[ -n "$suggested" ]]; then
+				print_warning "Port $desired_port in use, using $suggested instead"
+				echo "$suggested"
+				return 0
+			fi
+		fi
+	fi
+
+	# Fallback: basic port check using lsof
+	if ! lsof -i :"$desired_port" >/dev/null 2>&1; then
+		echo "$desired_port"
+		return 0
+	fi
+
+	# Find next available port
+	local port="$desired_port"
+	while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
+		((++port))
+	done
+
+	if [[ $port -lt 65535 ]]; then
+		print_warning "Port $desired_port in use, using $port instead"
+		echo "$port"
+		return 0
+	fi
+
+	print_error "No available ports found"
+	return 1
 }
 
 # Check prerequisites
 check_prerequisites() {
-    local missing=0
-    
-    print_info "Checking prerequisites..."
-    
-    # Check Python
-    if command -v python3 &> /dev/null; then
-        local python_version
-        python_version=$(python3 --version 2>&1 | cut -d' ' -f2)
-        local major minor
-        major=$(echo "$python_version" | cut -d. -f1)
-        minor=$(echo "$python_version" | cut -d. -f2)
-        
-        if [[ $major -ge 3 ]] && [[ $minor -ge 10 ]]; then
-            print_success "Python $python_version found (3.10+ required)"
-        else
-            print_error "Python 3.10+ required, found $python_version"
-            missing=1
-        fi
-    else
-        print_error "Python 3 not found"
-        missing=1
-    fi
-    
-    # Check pip
-    if command -v pip3 &> /dev/null || python3 -m pip --version &> /dev/null; then
-        print_success "pip found"
-    else
-        print_error "pip not found"
-        missing=1
-    fi
-    
-    # Check for uv (preferred)
-    if command -v uv &> /dev/null; then
-        print_success "uv found (preferred package manager)"
-    else
-        print_warning "uv not found, will use pip"
-    fi
-    
-    if [[ $missing -eq 1 ]]; then
-        print_error "Missing prerequisites. Please install them first."
-        return 1
-    fi
-    
-    print_success "All prerequisites met"
-    return 0
+	local missing=0
+
+	print_info "Checking prerequisites..."
+
+	# Check Python
+	if command -v python3 &>/dev/null; then
+		local python_version
+		python_version=$(python3 --version 2>&1 | cut -d' ' -f2)
+		local major minor
+		major=$(echo "$python_version" | cut -d. -f1)
+		minor=$(echo "$python_version" | cut -d. -f2)
+
+		if [[ $major -ge 3 ]] && [[ $minor -ge 10 ]]; then
+			print_success "Python $python_version found (3.10+ required)"
+		else
+			print_error "Python 3.10+ required, found $python_version"
+			missing=1
+		fi
+	else
+		print_error "Python 3 not found"
+		missing=1
+	fi
+
+	# Check pip
+	if command -v pip3 &>/dev/null || python3 -m pip --version &>/dev/null; then
+		print_success "pip found"
+	else
+		print_error "pip not found"
+		missing=1
+	fi
+
+	# Check for uv (preferred)
+	if command -v uv &>/dev/null; then
+		print_success "uv found (preferred package manager)"
+	else
+		print_warning "uv not found, will use pip"
+	fi
+
+	if [[ $missing -eq 1 ]]; then
+		print_error "Missing prerequisites. Please install them first."
+		return 1
+	fi
+
+	print_success "All prerequisites met"
+	return 0
 }
 
 # Setup AutoGen
 setup_autogen() {
-    print_info "Setting up AutoGen..."
-    
-    # Create directories
-    mkdir -p "$AUTOGEN_DIR"
-    mkdir -p "$SCRIPTS_DIR"
-    
-    cd "$AUTOGEN_DIR" || exit 1
-    
-    # Create virtual environment
-    if [[ ! -d "venv" ]]; then
-        print_info "Creating virtual environment..."
-        python3 -m venv venv
-    fi
-    
-    # Activate venv
-    # shellcheck source=/dev/null
-    source venv/bin/activate
-    
-    # Install AutoGen
-    print_info "Installing AutoGen..."
-    if command -v uv &> /dev/null; then
-        uv pip install autogen-agentchat -U
-        uv pip install 'autogen-ext[openai]' -U
-        uv pip install autogenstudio -U
-    else
-        pip install autogen-agentchat -U
-        pip install 'autogen-ext[openai]' -U
-        pip install autogenstudio -U
-    fi
-    
-    # Create environment template
-    if [[ ! -f ".env.example" ]]; then
-        cat > .env.example << 'EOF'
+	print_info "Setting up AutoGen..."
+
+	# Create directories
+	mkdir -p "$AUTOGEN_DIR"
+	mkdir -p "$SCRIPTS_DIR"
+
+	cd "$AUTOGEN_DIR" || exit 1
+
+	# Create virtual environment
+	if [[ ! -d "venv" ]]; then
+		print_info "Creating virtual environment..."
+		python3 -m venv venv
+	fi
+
+	# Activate venv
+	# shellcheck source=/dev/null
+	source venv/bin/activate
+
+	# Install AutoGen
+	print_info "Installing AutoGen..."
+	if command -v uv &>/dev/null; then
+		uv pip install autogen-agentchat -U
+		uv pip install 'autogen-ext[openai]' -U
+		uv pip install autogenstudio -U
+	else
+		pip install autogen-agentchat -U
+		pip install 'autogen-ext[openai]' -U
+		pip install autogenstudio -U
+	fi
+
+	# Create environment template
+	if [[ ! -f ".env.example" ]]; then
+		cat >.env.example <<'EOF'
 # AutoGen Configuration for AI DevOps Framework
 # Copy this file to .env and configure your API keys
 
@@ -182,32 +182,32 @@ AUTOGEN_STUDIO_APPDIR=./studio-data
 # Security Note: All processing runs locally
 # No data is sent to external services unless you configure external LLMs
 EOF
-        print_success "Created environment template"
-    fi
-    
-    # Copy template to .env if not exists
-    if [[ ! -f ".env" ]]; then
-        cp .env.example .env
-        print_info "Created .env file - please configure your API keys"
-    fi
-    
-    # Create example script
-    create_example_script
-    
-    # Create management scripts
-    create_management_scripts
-    
-    print_success "AutoGen setup complete"
-    print_info "Directory: $AUTOGEN_DIR"
-    print_info "Configure your API keys in .env file"
-    return 0
+		print_success "Created environment template"
+	fi
+
+	# Copy template to .env if not exists
+	if [[ ! -f ".env" ]]; then
+		cp .env.example .env
+		print_info "Created .env file - please configure your API keys"
+	fi
+
+	# Create example script
+	create_example_script
+
+	# Create management scripts
+	create_management_scripts
+
+	print_success "AutoGen setup complete"
+	print_info "Directory: $AUTOGEN_DIR"
+	print_info "Configure your API keys in .env file"
+	return 0
 }
 
 # Create example script
 create_example_script() {
-    print_info "Creating example script..."
-    
-    cat > "$AUTOGEN_DIR/hello_autogen.py" << 'EXAMPLEEOF'
+	print_info "Creating example script..."
+
+	cat >"$AUTOGEN_DIR/hello_autogen.py" <<'EXAMPLEEOF'
 """
 AutoGen Hello World Example
 AI DevOps Framework Integration
@@ -244,19 +244,14 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 EXAMPLEEOF
-    
-    print_success "Created example script: hello_autogen.py"
-    return 0
+
+	print_success "Created example script: hello_autogen.py"
+	return 0
 }
 
-# Create management scripts
-create_management_scripts() {
-    print_info "Creating management scripts..."
-    
-    mkdir -p "$SCRIPTS_DIR"
-    
-    # Create start script
-    cat > "$SCRIPTS_DIR/start-autogen-studio.sh" << 'EOF'
+# Write the AutoGen Studio start script to disk
+_write_start_script() {
+	cat >"$SCRIPTS_DIR/start-autogen-studio.sh" <<'EOF'
 #!/bin/bash
 # AI DevOps Framework - AutoGen Studio Startup Script
 
@@ -291,28 +286,28 @@ fi
 
 if [[ -d "$AUTOGEN_DIR/venv" ]]; then
     cd "$AUTOGEN_DIR" || exit 1
-    
+
     # Activate venv
     source venv/bin/activate
-    
+
     # Load environment
     if [[ -f .env ]]; then
         set -a
         source .env
         set +a
     fi
-    
+
     # Create app directory
     mkdir -p "$APPDIR"
-    
+
     # Start AutoGen Studio with available port
     autogenstudio ui --port "$DESIRED_PORT" --appdir "$APPDIR" &
     STUDIO_PID=$!
     echo "$STUDIO_PID" > /tmp/autogen_studio_pid
     echo "$DESIRED_PORT" > /tmp/autogen_studio_port
-    
+
     sleep 5
-    
+
     echo ""
     echo "AutoGen Studio started!"
     echo "URL: http://localhost:$DESIRED_PORT"
@@ -324,10 +319,13 @@ else
     exit 1
 fi
 EOF
-    chmod +x "$SCRIPTS_DIR/start-autogen-studio.sh"
-    
-    # Create stop script
-    cat > "$SCRIPTS_DIR/stop-autogen-studio.sh" << 'EOF'
+	chmod +x "$SCRIPTS_DIR/start-autogen-studio.sh"
+	return 0
+}
+
+# Write the AutoGen Studio stop script to disk
+_write_stop_script() {
+	cat >"$SCRIPTS_DIR/stop-autogen-studio.sh" <<'EOF'
 #!/bin/bash
 # AI DevOps Framework - AutoGen Studio Stop Script
 
@@ -347,10 +345,13 @@ pkill -f "autogenstudio" 2>/dev/null || true
 
 echo "AutoGen Studio stopped"
 EOF
-    chmod +x "$SCRIPTS_DIR/stop-autogen-studio.sh"
-    
-    # Create status script
-    cat > "$SCRIPTS_DIR/autogen-status.sh" << 'EOF'
+	chmod +x "$SCRIPTS_DIR/stop-autogen-studio.sh"
+	return 0
+}
+
+# Write the AutoGen status script to disk
+_write_status_script() {
+	cat >"$SCRIPTS_DIR/autogen-status.sh" <<'EOF'
 #!/bin/bash
 # AI DevOps Framework - AutoGen Status Script
 
@@ -387,106 +388,119 @@ else
     echo "AutoGen venv not found"
 fi
 EOF
-    chmod +x "$SCRIPTS_DIR/autogen-status.sh"
-    
-    print_success "Management scripts created in $SCRIPTS_DIR"
-    return 0
+	chmod +x "$SCRIPTS_DIR/autogen-status.sh"
+	return 0
+}
+
+# Create management scripts
+create_management_scripts() {
+	print_info "Creating management scripts..."
+
+	mkdir -p "$SCRIPTS_DIR"
+
+	# Create start, stop, and status scripts
+	_write_start_script
+	_write_stop_script
+	_write_status_script
+
+	print_success "Management scripts created in $SCRIPTS_DIR"
+	return 0
 }
 
 # Start AutoGen Studio
 start_studio() {
-    if [[ -f "$SCRIPTS_DIR/start-autogen-studio.sh" ]]; then
-        "$SCRIPTS_DIR/start-autogen-studio.sh"
-    else
-        print_error "AutoGen not set up. Run 'setup' first."
-        return 1
-    fi
-    return 0
+	if [[ -f "$SCRIPTS_DIR/start-autogen-studio.sh" ]]; then
+		"$SCRIPTS_DIR/start-autogen-studio.sh"
+	else
+		print_error "AutoGen not set up. Run 'setup' first."
+		return 1
+	fi
+	return 0
 }
 
 # Stop AutoGen Studio
 stop_studio() {
-    if [[ -f "$SCRIPTS_DIR/stop-autogen-studio.sh" ]]; then
-        "$SCRIPTS_DIR/stop-autogen-studio.sh"
-    else
-        pkill -f "autogenstudio" 2>/dev/null || true
-    fi
-    return 0
+	if [[ -f "$SCRIPTS_DIR/stop-autogen-studio.sh" ]]; then
+		"$SCRIPTS_DIR/stop-autogen-studio.sh"
+	else
+		pkill -f "autogenstudio" 2>/dev/null || true
+	fi
+	return 0
 }
 
 # Check status
 check_status() {
-    if [[ -f "$SCRIPTS_DIR/autogen-status.sh" ]]; then
-        "$SCRIPTS_DIR/autogen-status.sh"
-    else
-        if curl -s "http://localhost:$AUTOGEN_STUDIO_PORT" >/dev/null 2>&1; then
-            print_success "AutoGen Studio is running at http://localhost:$AUTOGEN_STUDIO_PORT"
-        else
-            print_warning "AutoGen Studio is not running"
-        fi
-    fi
-    return 0
+	if [[ -f "$SCRIPTS_DIR/autogen-status.sh" ]]; then
+		"$SCRIPTS_DIR/autogen-status.sh"
+	else
+		if curl -s "http://localhost:$AUTOGEN_STUDIO_PORT" >/dev/null 2>&1; then
+			print_success "AutoGen Studio is running at http://localhost:$AUTOGEN_STUDIO_PORT"
+		else
+			print_warning "AutoGen Studio is not running"
+		fi
+	fi
+	return 0
 }
 
 # Show usage
 show_usage() {
-    echo "AI DevOps Framework - AutoGen Helper"
-    echo ""
-    echo "Usage: $0 [action]"
-    echo ""
-    echo "Actions:"
-    echo "  setup     Complete setup of AutoGen"
-    echo "  start     Start AutoGen Studio"
-    echo "  stop      Stop AutoGen Studio"
-    echo "  status    Check AutoGen status"
-    echo "  check     Check prerequisites"
-    echo "  help      Show this help message"
-    echo ""
-    echo "Examples:"
-    echo "  $0 setup    # Full setup"
-    echo "  $0 start    # Start Studio"
-    echo "  $0 status   # Check status"
-    echo ""
-    echo "URLs (after start):"
-    echo "  AutoGen Studio: http://localhost:8081"
-    return 0
+	echo "AI DevOps Framework - AutoGen Helper"
+	echo ""
+	echo "Usage: $0 [action]"
+	echo ""
+	echo "Actions:"
+	echo "  setup     Complete setup of AutoGen"
+	echo "  start     Start AutoGen Studio"
+	echo "  stop      Stop AutoGen Studio"
+	echo "  status    Check AutoGen status"
+	echo "  check     Check prerequisites"
+	echo "  help      Show this help message"
+	echo ""
+	echo "Examples:"
+	echo "  $0 setup    # Full setup"
+	echo "  $0 start    # Start Studio"
+	echo "  $0 status   # Check status"
+	echo ""
+	echo "URLs (after start):"
+	echo "  AutoGen Studio: http://localhost:8081"
+	return 0
 }
 
 # Main function
 main() {
-    local action="${1:-help}"
-    shift || true
-    
-    case "$action" in
-        "setup")
-            if check_prerequisites; then
-                setup_autogen
-                echo ""
-                print_success "AutoGen setup complete!"
-                echo ""
-                echo "Next Steps:"
-                echo "1. Configure API keys in $AUTOGEN_DIR/.env"
-                echo "2. Start AutoGen Studio: $SCRIPTS_DIR/start-autogen-studio.sh"
-                echo "3. Or run example: cd $AUTOGEN_DIR && source venv/bin/activate && python hello_autogen.py"
-            fi
-            ;;
-        "start")
-            start_studio
-            ;;
-        "stop")
-            stop_studio
-            ;;
-        "status")
-            check_status
-            ;;
-        "check")
-            check_prerequisites
-            ;;
-        "help"|*)
-            show_usage
-            ;;
-    esac
-    return 0
+	local action="${1:-help}"
+	shift || true
+
+	case "$action" in
+	"setup")
+		if check_prerequisites; then
+			setup_autogen
+			echo ""
+			print_success "AutoGen setup complete!"
+			echo ""
+			echo "Next Steps:"
+			echo "1. Configure API keys in $AUTOGEN_DIR/.env"
+			echo "2. Start AutoGen Studio: $SCRIPTS_DIR/start-autogen-studio.sh"
+			echo "3. Or run example: cd $AUTOGEN_DIR && source venv/bin/activate && python hello_autogen.py"
+		fi
+		;;
+	"start")
+		start_studio
+		;;
+	"stop")
+		stop_studio
+		;;
+	"status")
+		check_status
+		;;
+	"check")
+		check_prerequisites
+		;;
+	"help" | *)
+		show_usage
+		;;
+	esac
+	return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Extracts three heredoc-writing blocks from `create_management_scripts()` into dedicated sub-functions, reducing it from 141 lines to 13 lines.

### Changes

- `_write_start_script()` — writes `start-autogen-studio.sh` (72 lines)
- `_write_stop_script()` — writes `stop-autogen-studio.sh` (24 lines)
- `_write_status_script()` — writes `autogen-status.sh` (41 lines)
- `create_management_scripts()` — now 13 lines, calls the three sub-functions

All functions are under 100 lines. No behavior changes.

### Verification

- `bash -n` syntax check: PASS
- `shellcheck`: no new violations (pre-existing SC1091 info on `source` of external file)

Closes #5885