### PR TITLE
GH#5864: reduce cmd_create complexity in findings-to-tasks-helper.sh

### DIFF
--- a/.agents/scripts/findings-to-tasks-helper.sh
+++ b/.agents/scripts/findings-to-tasks-helper.sh
@@ -245,72 +245,12 @@ create_task_for_finding() {
 	return 0
 }
 
-cmd_create() {
-	local input_file=""
-	local repo_path_arg=""
-	local source="$DEFAULT_SOURCE"
-	local extra_labels=""
-	local extra_tags=""
-	local output_file=""
-	local offline_mode="false"
-	local no_issue_mode="false"
-	local dry_run_mode="false"
-	local allow_partial="false"
-
-	while [[ $# -gt 0 ]]; do
-		local arg="$1"
-		case "$arg" in
-		--input)
-			input_file="${2:-}"
-			shift 2
-			;;
-		--repo-path)
-			repo_path_arg="${2:-}"
-			shift 2
-			;;
-		--source)
-			source="${2:-$DEFAULT_SOURCE}"
-			shift 2
-			;;
-		--labels)
-			extra_labels="${2:-}"
-			shift 2
-			;;
-		--tags)
-			extra_tags="${2:-}"
-			shift 2
-			;;
-		--output)
-			output_file="${2:-}"
-			shift 2
-			;;
-		--offline)
-			offline_mode="true"
-			shift
-			;;
-		--no-issue)
-			no_issue_mode="true"
-			shift
-			;;
-		--dry-run)
-			dry_run_mode="true"
-			shift
-			;;
-		--allow-partial)
-			allow_partial="true"
-			shift
-			;;
-		help | --help | -h)
-			show_help
-			return 0
-			;;
-		*)
-			log_error "Unknown argument: $arg"
-			show_help
-			return 1
-			;;
-		esac
-	done
+# validate_cmd_create_inputs: check that required inputs exist and are accessible.
+# Arguments: input_file repo_path_arg
+# Outputs: resolved repo_path to stdout on success.
+validate_cmd_create_inputs() {
+	local input_file="${1:-}"
+	local repo_path_arg="${2:-}"
 
 	if [[ -z "$input_file" ]]; then
 		log_error "--input is required"
@@ -335,6 +275,24 @@ cmd_create() {
 
 	local repo_path=""
 	repo_path="$(resolve_repo_path "$repo_path_arg")" || return 1
+	printf '%s' "$repo_path"
+	return 0
+}
+
+# process_findings_file: iterate over findings and create tasks.
+# Arguments: input_file repo_path source extra_labels extra_tags output_file
+#            offline_mode no_issue_mode dry_run_mode allow_partial
+process_findings_file() {
+	local input_file="${1:-}"
+	local repo_path="${2:-}"
+	local source="${3:-$DEFAULT_SOURCE}"
+	local extra_labels="${4:-}"
+	local extra_tags="${5:-}"
+	local output_file="${6:-}"
+	local offline_mode="${7:-false}"
+	local no_issue_mode="${8:-false}"
+	local dry_run_mode="${9:-false}"
+	local allow_partial="${10:-false}"
 
 	local actionable_findings_total=0
 	local deferred_tasks_created=0
@@ -416,6 +374,90 @@ cmd_create() {
 	fi
 
 	return 0
+}
+
+cmd_create() {
+	local input_file=""
+	local repo_path_arg=""
+	local source="$DEFAULT_SOURCE"
+	local extra_labels=""
+	local extra_tags=""
+	local output_file=""
+	local offline_mode="false"
+	local no_issue_mode="false"
+	local dry_run_mode="false"
+	local allow_partial="false"
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--input)
+			input_file="${2:-}"
+			shift 2
+			;;
+		--repo-path)
+			repo_path_arg="${2:-}"
+			shift 2
+			;;
+		--source)
+			source="${2:-$DEFAULT_SOURCE}"
+			shift 2
+			;;
+		--labels)
+			extra_labels="${2:-}"
+			shift 2
+			;;
+		--tags)
+			extra_tags="${2:-}"
+			shift 2
+			;;
+		--output)
+			output_file="${2:-}"
+			shift 2
+			;;
+		--offline)
+			offline_mode="true"
+			shift
+			;;
+		--no-issue)
+			no_issue_mode="true"
+			shift
+			;;
+		--dry-run)
+			dry_run_mode="true"
+			shift
+			;;
+		--allow-partial)
+			allow_partial="true"
+			shift
+			;;
+		help | --help | -h)
+			show_help
+			return 0
+			;;
+		*)
+			log_error "Unknown argument: $arg"
+			show_help
+			return 1
+			;;
+		esac
+	done
+
+	local repo_path=""
+	repo_path="$(validate_cmd_create_inputs "$input_file" "$repo_path_arg")" || return 1
+
+	process_findings_file \
+		"$input_file" \
+		"$repo_path" \
+		"$source" \
+		"$extra_labels" \
+		"$extra_tags" \
+		"$output_file" \
+		"$offline_mode" \
+		"$no_issue_mode" \
+		"$dry_run_mode" \
+		"$allow_partial"
+	return $?
 }
 
 main() {


### PR DESCRIPTION
## Summary

Closes #5864

Extracts two sub-functions from `cmd_create()` in `.agents/scripts/findings-to-tasks-helper.sh`, which was 171 lines — the only function exceeding the 100-line threshold.

## Changes

- **`validate_cmd_create_inputs()`** (33 lines) — input file existence/readability checks and `claim-task-id.sh` prereq check; outputs resolved `repo_path` to stdout
- **`process_findings_file()`** (93 lines) — findings iteration loop, per-finding task creation, and coverage reporting
- **`cmd_create()`** reduced from 171 → 83 lines — arg parsing + delegation to the two new functions

## Verification

- `bash -n` syntax check: OK
- `shellcheck`: zero violations
- No behaviour changes — pure structural refactor, identical logic paths

## Function line counts (post-refactor)

| Function | Lines |
|---|---|
| `trim` | 7 |
| `is_valid_severity` | 12 |
| `normalize_tag_list` | 26 |
| `normalize_label_list` | 22 |
| `show_help` | 29 |
| `resolve_repo_path` | 18 |
| `parse_finding_line` | 35 |
| `create_task_for_finding` | 65 |
| `validate_cmd_create_inputs` | 33 |
| `process_findings_file` | 93 |
| `cmd_create` | 83 |
| `main` | 21 |

All functions under 100 lines.