### PR TITLE
fix: address review bugs in add-skill-helper.sh (#6019)

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -659,360 +659,177 @@ log_skill_scan_result() {
 }
 
 # =============================================================================
-# Commands
+# Shared Import Helpers (used by cmd_add, cmd_add_url, cmd_add_clawdhub)
 # =============================================================================
 
-cmd_add() {
-	local url="$1"
-	shift
+# Handle conflict resolution for all import paths.
+# Sets skill_name and target_path in the caller's scope if the user renames.
+# Args: target_path force description source_dir
+# Returns: 0 = proceed, 1 = cancelled or non-interactive block
+_handle_conflicts() {
+	local target_path_arg="$1"
+	local force="$2"
+	local description="$3"
+	local source_dir="$4"
 
-	local custom_name=""
-	local force=false
-	local dry_run=false
-	local skip_security=false
-
-	# Parse options using named variable for clarity (S7679)
-	local opt
-	while [[ $# -gt 0 ]]; do
-		opt="$1"
-		case "$opt" in
-		--name)
-			custom_name="$2"
-			shift 2
-			;;
-		--force)
-			force=true
-			shift
-			;;
-		--skip-security)
-			skip_security=true
-			shift
-			;;
-		--dry-run)
-			dry_run=true
-			shift
-			;;
-		*)
-			log_error "Unknown option: $opt"
-			return 1
-			;;
-		esac
-	done
-
-	log_info "Parsing source: $url"
-
-	# Detect ClawdHub source (clawdhub:slug or clawdhub.com URL)
-	local is_clawdhub=false
-	local clawdhub_slug=""
-
-	if [[ "$url" == clawdhub:* ]]; then
-		is_clawdhub=true
-		clawdhub_slug="${url#clawdhub:}"
-	elif [[ "$url" == *clawdhub.com* ]]; then
-		is_clawdhub=true
-		# Strip URL prefix and extract slug (last path segment)
-		clawdhub_slug="${url#*clawdhub.com/}"
-		clawdhub_slug="${clawdhub_slug#/}"
-		clawdhub_slug="${clawdhub_slug%/}"
-		# If format is owner/slug, take just the slug
-		if [[ "$clawdhub_slug" == */* ]]; then
-			clawdhub_slug="${clawdhub_slug##*/}"
-		fi
-	fi
-
-	if [[ "$is_clawdhub" == true ]]; then
-		cmd_add_clawdhub "$clawdhub_slug" "$custom_name" "$force" "$dry_run" "$skip_security"
-		return $?
-	fi
-
-	# Detect raw URL source (not GitHub, not ClawdHub — a direct URL to a .md file)
-	# Matches: https://example.com/skill.md, https://convos.org/SKILL.md, etc.
-	# Also matches URLs without .md extension if they start with http(s)://
-	# and are not github.com URLs (those go through the GitHub clone path)
-	local is_raw_url=false
-	if [[ "$url" =~ ^https?:// && "$url" != *github.com* && "$url" != *clawdhub.com* ]]; then
-		is_raw_url=true
-	fi
-
-	if [[ "$is_raw_url" == true ]]; then
-		cmd_add_url "$url" "$custom_name" "$force" "$dry_run" "$skip_security"
-		return $?
-	fi
-
-	# Parse GitHub URL
-	local parsed owner repo subpath
-	parsed=$(parse_github_url "$url")
-	IFS='|' read -r owner repo subpath <<<"$parsed"
-
-	if [[ -z "$owner" || -z "$repo" ]]; then
-		log_error "Could not parse source URL: $url"
-		log_info "Expected: owner/repo, https://github.com/owner/repo, clawdhub:slug, or a raw URL"
-		return 1
-	fi
-
-	log_info "Owner: $owner, Repo: $repo, Subpath: ${subpath:-<root>}"
-
-	# Create temp directory
-	rm -rf "$TEMP_DIR"
-	mkdir -p "$TEMP_DIR"
-
-	# Try to use openskills if available
-	if command -v openskills &>/dev/null; then
-		log_info "Using openskills to fetch skill..."
-		if openskills install "$owner/$repo${subpath:+/$subpath}" --yes --universal 2>/dev/null; then
-			log_success "Skill installed via openskills"
-			# openskills handles everything, just register it
-			local skill_name="${custom_name:-$(basename "${subpath:-$repo}")}"
-			skill_name=$(to_kebab_case "$skill_name")
-			# openskills installs to ~/.config/opencode/skills/<name>/SKILL.md
-			# Register with -skill suffix for consistency with direct imports
-			register_skill "$skill_name" "https://github.com/$owner/$repo" ".agents/skills/${skill_name}-skill.md" "skill-md" "" "openskills" "Installed via openskills CLI"
-			return 0
-		fi
-		log_warning "openskills failed, falling back to direct fetch"
-	fi
-
-	# Clone repository
-	log_info "Cloning repository..."
-	local clone_url="https://github.com/$owner/$repo.git"
-
-	if ! git clone --depth 1 "$clone_url" "$TEMP_DIR/repo" 2>/dev/null; then
-		log_error "Failed to clone repository: $clone_url"
-		return 1
-	fi
-
-	# Navigate to subpath if specified
-	local source_dir="$TEMP_DIR/repo"
-	if [[ -n "$subpath" ]]; then
-		source_dir="$TEMP_DIR/repo/$subpath"
-		if [[ ! -d "$source_dir" ]]; then
-			log_error "Subpath not found: $subpath"
-			return 1
-		fi
-	fi
-
-	# Detect format (returns format|skill_subdir)
-	local format_result skill_subdir format
-	format_result=$(detect_format "$source_dir")
-	IFS='|' read -r format skill_subdir <<<"$format_result"
-	log_info "Detected format: $format"
-
-	# For nested skills, update source_dir to point to the skill directory
-	local skill_source_dir="$source_dir"
-	if [[ "$format" == "skill-md-nested" && -n "$skill_subdir" ]]; then
-		skill_source_dir="$source_dir/$skill_subdir"
-		log_info "Found nested skill at: $skill_subdir"
-	fi
-
-	# Determine skill name
-	local skill_name=""
-	if [[ -n "$custom_name" ]]; then
-		skill_name=$(to_kebab_case "$custom_name")
-	elif [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
-		skill_name=$(extract_skill_name "$skill_source_dir/SKILL.md")
-		skill_name=$(to_kebab_case "${skill_name:-$(basename "${subpath:-$repo}")}")
-	else
-		skill_name=$(to_kebab_case "$(basename "${subpath:-$repo}")")
-	fi
-
-	log_info "Skill name: $skill_name"
-
-	# Get description
-	local description=""
-	if [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
-		description=$(extract_skill_description "$skill_source_dir/SKILL.md")
-	fi
-
-	# Determine target path
-	local target_path
-	target_path=$(determine_target_path "$skill_name" "$description" "$skill_source_dir")
-	log_info "Target path: .agents/$target_path"
-
-	# Check for conflicts (check_conflicts returns 1 when conflicts exist)
 	local conflicts
-	conflicts=$(check_conflicts "$target_path" ".agent") || true
-	if [[ -n "$conflicts" ]]; then
-		# Filter out INFO lines (informational, not blocking)
-		local blocking_conflicts
-		blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
-		local info_lines
-		info_lines=$(echo "$conflicts" | grep "^INFO:" || true)
-
-		# Show info lines (native subagent coexistence)
-		if [[ -n "$info_lines" ]]; then
-			echo "$info_lines" | while read -r info; do
-				log_info "${info#INFO: }"
-			done
-		fi
-
-		# Handle blocking conflicts
-		if [[ -n "$blocking_conflicts" && "$force" != true ]]; then
-			# Determine conflict type for better messaging
-			if echo "$blocking_conflicts" | grep -q "^NATIVE:"; then
-				log_warning "Conflicts with native aidevops subagent(s):"
-				echo "$blocking_conflicts" | while read -r conflict; do
-					echo "  - ${conflict#NATIVE: }"
-				done
-				echo ""
-				echo "The -skill suffix should prevent this. If you see this,"
-				echo "the imported skill has the same name as a native subagent."
-				echo ""
-			elif echo "$blocking_conflicts" | grep -q "^IMPORTED:"; then
-				log_warning "Conflicts with previously imported skill(s):"
-				echo "$blocking_conflicts" | while read -r conflict; do
-					echo "  - ${conflict#IMPORTED: }"
-				done
-				echo ""
-			else
-				log_warning "Conflicts detected:"
-				echo "$blocking_conflicts" | while read -r conflict; do
-					echo "  - $conflict"
-				done
-				echo ""
-			fi
-
-			echo "Options:"
-			echo "  1. Replace (overwrite existing)"
-			echo "  2. Separate (use different name)"
-			echo "  3. Skip (cancel import)"
-			echo ""
-			read -rp "Choose option [1-3]: " choice
-
-			local new_name
-			case "$choice" in
-			1)
-				log_info "Replacing existing..."
-				;;
-			2)
-				read -rp "Enter new name: " new_name
-				skill_name=$(to_kebab_case "$new_name")
-				target_path=$(determine_target_path "$skill_name" "$description" "$source_dir")
-				;;
-			3 | *)
-				log_info "Import cancelled"
-				return 0
-				;;
-			esac
-		fi
-	fi
-
-	if [[ "$dry_run" == true ]]; then
-		log_info "DRY RUN - Would create:"
-		echo "  .agents/${target_path}.md"
-		if [[ -d "$skill_source_dir/scripts" || -d "$skill_source_dir/references" ]]; then
-			echo "  .agents/${target_path}/"
-		fi
+	conflicts=$(check_conflicts "$target_path_arg" ".agent") || true
+	if [[ -z "$conflicts" ]]; then
 		return 0
 	fi
 
-	# Create target directory
-	local target_dir
-	target_dir=".agents/$(dirname "$target_path")"
-	mkdir -p "$target_dir"
+	local blocking_conflicts
+	blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
+	local info_lines
+	info_lines=$(echo "$conflicts" | grep "^INFO:" || true)
 
-	# Convert and copy files
-	local target_file=".agents/${target_path}.md"
+	# Show info lines (native subagent coexistence)
+	if [[ -n "$info_lines" ]]; then
+		echo "$info_lines" | while read -r info; do
+			log_info "${info#INFO: }"
+		done
+	fi
 
-	case "$format" in
-	skill-md | skill-md-nested)
-		convert_skill_md "$skill_source_dir/SKILL.md" "$target_file" "$skill_name"
-		;;
-	agents-md)
-		cp "$source_dir/AGENTS.md" "$target_file"
-		;;
-	cursorrules)
-		# Convert .cursorrules to markdown
-		{
-			echo "---"
-			echo "description: Imported from .cursorrules"
-			echo "mode: subagent"
-			echo "imported_from: cursorrules"
-			echo "---"
-			echo "# $skill_name"
-			echo ""
-			cat "$source_dir/.cursorrules"
-		} >"$target_file"
-		;;
-	*)
-		# Copy first markdown file found
-		local md_file
-		md_file=$(find "$source_dir" -maxdepth 1 -name "*.md" -type f | head -1)
-		if [[ -n "$md_file" ]]; then
-			cp "$md_file" "$target_file"
-		else
-			log_error "No suitable files found to import"
-			return 1
-		fi
-		;;
-	esac
+	# No blocking conflicts — proceed (reset rename vars)
+	if [[ -z "$blocking_conflicts" || "$force" == true ]]; then
+		_conflict_new_skill_name=""
+		_conflict_new_target_path=""
+		return 0
+	fi
 
-	log_success "Created: $target_file"
+	# Determine conflict type for better messaging
+	if echo "$blocking_conflicts" | grep -q "^NATIVE:"; then
+		log_warning "Conflicts with native aidevops subagent(s):"
+		echo "$blocking_conflicts" | while read -r conflict; do
+			echo "  - ${conflict#NATIVE: }"
+		done
+		echo ""
+		echo "The -skill suffix should prevent this. If you see this,"
+		echo "the imported skill has the same name as a native subagent."
+		echo ""
+	elif echo "$blocking_conflicts" | grep -q "^IMPORTED:"; then
+		log_warning "Conflicts with previously imported skill(s):"
+		echo "$blocking_conflicts" | while read -r conflict; do
+			echo "  - ${conflict#IMPORTED: }"
+		done
+		echo ""
+	else
+		log_warning "Conflicts detected:"
+		echo "$blocking_conflicts" | while read -r conflict; do
+			echo "  - ${conflict#*: }"
+		done
+		echo ""
+	fi
 
-	# Copy additional resources (scripts, references, assets)
-	for resource_dir in scripts references assets; do
-		if [[ -d "$skill_source_dir/$resource_dir" ]]; then
-			local target_resource_dir=".agents/${target_path}/$resource_dir"
-			mkdir -p "$target_resource_dir"
-			cp -r "$skill_source_dir/$resource_dir/"* "$target_resource_dir/" 2>/dev/null || true
-			log_success "Copied: $resource_dir/"
-		fi
-	done
-
-	# Security scan before registration (scan the source directory which has full context)
-	if ! scan_skill_security "$skill_source_dir" "$skill_name" "$skip_security"; then
-		# Clean up the partially imported files
-		rm -f "$target_file"
-		local skill_resource_dir=".agents/${target_path}"
-		[[ -d "$skill_resource_dir" ]] && rm -rf "$skill_resource_dir"
-		rm -rf "$TEMP_DIR"
+	# In non-interactive mode, block
+	if [[ ! -t 0 ]]; then
+		log_error "Conflicts detected in non-interactive mode (use --force to override)"
 		return 1
 	fi
 
-	# VirusTotal scan (advisory, non-blocking -- runs after Cisco scanner gate)
-	scan_skill_virustotal "$skill_source_dir" "$skill_name" "$skip_security"
-
-	# Get commit hash for tracking
-	local commit_hash=""
-	if [[ -d "$TEMP_DIR/repo/.git" ]]; then
-		commit_hash=$(git -C "$TEMP_DIR/repo" rev-parse HEAD 2>/dev/null || echo "")
-	fi
-
-	# Register in skill-sources.json
-	register_skill "$skill_name" "https://github.com/$owner/$repo${subpath:+/$subpath}" ".agents/${target_path}.md" "$format" "$commit_hash" "added" ""
-
-	log_success "Skill '$skill_name' imported successfully"
-
-	# Cleanup
-	rm -rf "$TEMP_DIR"
-
-	# Remind about setup.sh
+	echo "Options:"
+	echo "  1. Replace (overwrite existing)"
+	echo "  2. Separate (use different name)"
+	echo "  3. Skip (cancel import)"
 	echo ""
-	log_info "Run './setup.sh' to create symlinks for other AI assistants"
+	read -rp "Choose option [1-3]: " choice
+
+	local new_name
+	case "$choice" in
+	1) log_info "Replacing existing..." ;;
+	2)
+		read -rp "Enter new name: " new_name
+		# Update caller's variables via nameref-free pattern (bash 3.2 compat)
+		_conflict_new_skill_name=$(to_kebab_case "$new_name")
+		_conflict_new_target_path=$(determine_target_path "$_conflict_new_skill_name" "$description" "$source_dir")
+		;;
+	3 | *)
+		log_info "Import cancelled"
+		return 1
+		;;
+	esac
 
 	return 0
 }
 
-# Import a skill from a raw URL (not GitHub, not ClawdHub)
-# Fetches with curl, computes SHA-256 content hash, registers with format_detected: "url"
-cmd_add_url() {
+# Handle conflicts and apply any rename. Updates skill_name and target_path in caller scope.
+# Args: target_path force description source_dir
+# Returns: 0 = proceed, 1 = cancelled
+_apply_conflict_resolution() {
+	local target_path_arg="$1"
+	local force="$2"
+	local description="$3"
+	local source_dir="$4"
+
+	_conflict_new_skill_name=""
+	_conflict_new_target_path=""
+	if ! _handle_conflicts "$target_path_arg" "$force" "$description" "$source_dir"; then
+		return 1
+	fi
+	# Apply rename if user chose option 2
+	if [[ -n "$_conflict_new_skill_name" ]]; then
+		skill_name="$_conflict_new_skill_name"
+		target_path="$_conflict_new_target_path"
+	fi
+	return 0
+}
+
+# Run security scans, register skill, and clean up temp directory.
+# Args: scan_dir skill_name skip_security target_file target_path
+#       upstream_url local_path format commit merge_strategy notes
+#       [upstream_hash] [upstream_etag] [upstream_last_modified] [cleanup_dir]
+_finalize_import() {
+	local scan_dir="$1"
+	local skill_name="$2"
+	local skip_security="$3"
+	local target_file="$4"
+	local target_path="$5"
+	local upstream_url="$6"
+	local local_path="$7"
+	local format="$8"
+	local commit="${9:-}"
+	local merge_strategy="${10:-added}"
+	local notes="${11:-}"
+	local upstream_hash="${12:-}"
+	local upstream_etag="${13:-}"
+	local upstream_last_modified="${14:-}"
+	local cleanup_dir="${15:-}"
+
+	# Security scan before registration
+	if ! scan_skill_security "$scan_dir" "$skill_name" "$skip_security"; then
+		rm -f "$target_file"
+		local skill_resource_dir=".agents/${target_path}"
+		[[ -d "$skill_resource_dir" ]] && rm -rf "$skill_resource_dir"
+		[[ -n "$cleanup_dir" ]] && rm -rf "$cleanup_dir"
+		return 1
+	fi
+
+	# VirusTotal scan (advisory, non-blocking)
+	scan_skill_virustotal "$scan_dir" "$skill_name" "$skip_security"
+
+	# Register in skill-sources.json
+	register_skill "$skill_name" "$upstream_url" "$local_path" "$format" \
+		"$commit" "$merge_strategy" "$notes" \
+		"$upstream_hash" "$upstream_etag" "$upstream_last_modified"
+
+	# Cleanup temp directory
+	[[ -n "$cleanup_dir" ]] && rm -rf "$cleanup_dir"
+
+	return 0
+}
+
+# Fetch content from a URL with validation.
+# Sets in caller scope: fetch_file, header_file, resp_etag, resp_last_modified, content_hash
+# Args: url fetch_dir
+# Returns: 0 = success, 1 = failure (fetch_dir cleaned up on failure)
+_fetch_url_content() {
 	local url="$1"
-	local custom_name="$2"
-	local force="$3"
-	local dry_run="$4"
-	local skip_security="${5:-false}"
+	local fetch_dir="$2"
 
-	log_info "Importing from URL: $url"
+	fetch_file="$fetch_dir/fetched-skill.md"
+	header_file="$fetch_dir/response-headers.txt"
 
-	# Create temp directory for fetched content
-	local fetch_dir="${TMPDIR:-/tmp}/aidevops-url-fetch"
-	rm -rf "$fetch_dir"
-	mkdir -p "$fetch_dir"
-
-	# Fetch the content with curl, capturing response headers for ETag/Last-Modified (t1415.3)
 	local http_code=""
-	local fetch_file="$fetch_dir/fetched-skill.md"
-	local header_file="$fetch_dir/response-headers.txt"
-
 	http_code=$(curl -sS -L --connect-timeout 15 --max-time 60 \
 		-o "$fetch_file" -D "$header_file" -w "%{http_code}" \
 		-H "User-Agent: aidevops-skill-importer/1.0" \
@@ -1037,7 +854,8 @@ cmd_add_url() {
 	fi
 
 	# Extract ETag and Last-Modified from response headers for caching (t1415.3)
-	local resp_etag="" resp_last_modified=""
+	resp_etag=""
+	resp_last_modified=""
 	if [[ -f "$header_file" ]]; then
 		resp_etag=$(grep -i '^etag:' "$header_file" | tail -1 | sed 's/^[Ee][Tt][Aa][Gg]: *//; s/\r$//')
 		resp_last_modified=$(grep -i '^last-modified:' "$header_file" | tail -1 | sed 's/^[Ll][Aa][Ss][Tt]-[Mm][Oo][Dd][Ii][Ff][Ii][Ee][Dd]: *//; s/\r$//')
@@ -1054,7 +872,7 @@ cmd_add_url() {
 	fi
 
 	# Compute SHA-256 content hash
-	local content_hash=""
+	content_hash=""
 	if command -v shasum &>/dev/null; then
 		content_hash=$(shasum -a 256 "$fetch_file" | cut -d' ' -f1)
 	elif command -v sha256sum &>/dev/null; then
@@ -1065,119 +883,407 @@ cmd_add_url() {
 
 	log_info "Content hash (SHA-256): ${content_hash:0:16}..."
 
-	# Determine skill name
-	local skill_name=""
+	return 0
+}
+
+# Resolve skill name from custom name, frontmatter, or URL/repo fallback.
+# Args: custom_name source_file fallback_name [url_for_domain_fallback]
+# Prints: resolved kebab-case skill name
+_resolve_skill_name() {
+	local custom_name="$1"
+	local source_file="$2"
+	local fallback_name="$3"
+	local url_for_domain="${4:-}"
+
 	if [[ -n "$custom_name" ]]; then
-		skill_name=$(to_kebab_case "$custom_name")
-	else
-		# Try to extract name from SKILL.md frontmatter
-		local extracted_name
-		extracted_name=$(extract_skill_name "$fetch_file")
-		if [[ -n "$extracted_name" ]]; then
-			skill_name=$(to_kebab_case "$extracted_name")
-		else
-			# Derive from URL filename (strip .md extension)
-			local url_basename
-			url_basename=$(basename "$url")
-			url_basename="${url_basename%.md}"
-			# If the basename is generic (skill, SKILL, index), use the domain instead
-			if [[ "$url_basename" =~ ^(skill|SKILL|index|README|readme)$ ]]; then
-				# Extract domain name and use it
-				local domain
-				domain=$(echo "$url" | sed -E 's|^https?://([^/]+).*|\1|' | sed 's/^www\.//')
-				# Use first part of domain (e.g., "convos" from "convos.org")
-				skill_name=$(to_kebab_case "${domain%%.*}")
-			else
-				skill_name=$(to_kebab_case "$url_basename")
-			fi
-		fi
-	fi
-
-	log_info "Skill name: $skill_name"
-
-	# Extract description from frontmatter if available
-	local description=""
-	description=$(extract_skill_description "$fetch_file")
-
-	# For URL imports, determine_target_path needs a directory with the file
-	# Copy the fetched file as SKILL.md for format detection compatibility
-	cp "$fetch_file" "$fetch_dir/SKILL.md" 2>/dev/null || true
-
-	# Determine target path
-	local target_path
-	target_path=$(determine_target_path "$skill_name" "$description" "$fetch_dir")
-	log_info "Target path: .agents/$target_path"
-
-	# Check for conflicts
-	local conflicts
-	conflicts=$(check_conflicts "$target_path" ".agent") || true
-	if [[ -n "$conflicts" ]]; then
-		local blocking_conflicts
-		blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
-		local info_lines
-		info_lines=$(echo "$conflicts" | grep "^INFO:" || true)
-
-		# Show info lines
-		if [[ -n "$info_lines" ]]; then
-			echo "$info_lines" | while read -r info; do
-				log_info "${info#INFO: }"
-			done
-		fi
-
-		if [[ -n "$blocking_conflicts" && "$force" != true ]]; then
-			log_warning "Conflicts detected:"
-			echo "$blocking_conflicts" | while read -r conflict; do
-				echo "  - ${conflict#*: }"
-			done
-			echo ""
-			echo "Options:"
-			echo "  1. Replace (overwrite existing)"
-			echo "  2. Separate (use different name)"
-			echo "  3. Skip (cancel import)"
-			echo ""
-
-			if [[ ! -t 0 ]]; then
-				log_error "Conflicts detected in non-interactive mode (use --force to override)"
-				rm -rf "$fetch_dir"
-				return 1
-			fi
-
-			read -rp "Choose option [1-3]: " choice
-
-			local new_name
-			case "$choice" in
-			1) log_info "Replacing existing..." ;;
-			2)
-				read -rp "Enter new name: " new_name
-				skill_name=$(to_kebab_case "$new_name")
-				target_path=$(determine_target_path "$skill_name" "$description" "$fetch_dir")
-				;;
-			3 | *)
-				log_info "Import cancelled"
-				rm -rf "$fetch_dir"
-				return 0
-				;;
-			esac
-		fi
-	fi
-
-	if [[ "$dry_run" == true ]]; then
-		log_info "DRY RUN - Would create:"
-		echo "  .agents/${target_path}.md"
-		echo "  Source: $url"
-		echo "  Format: url"
-		echo "  Content hash: ${content_hash:-<unavailable>}"
-		rm -rf "$fetch_dir"
+		to_kebab_case "$custom_name"
 		return 0
 	fi
+
+	# Try to extract name from frontmatter
+	local extracted_name=""
+	if [[ -f "$source_file" ]]; then
+		extracted_name=$(extract_skill_name "$source_file")
+	fi
+
+	if [[ -n "$extracted_name" ]]; then
+		to_kebab_case "$extracted_name"
+		return 0
+	fi
+
+	# URL domain fallback: if basename is generic, use domain name
+	if [[ -n "$url_for_domain" ]]; then
+		local url_basename
+		url_basename=$(basename "$url_for_domain")
+		url_basename="${url_basename%.md}"
+		if [[ "$url_basename" =~ ^(skill|SKILL|index|README|readme)$ ]]; then
+			local domain
+			domain=$(echo "$url_for_domain" | sed -E 's|^https?://([^/]+).*|\1|' | sed 's/^www\.//')
+			to_kebab_case "${domain%%.*}"
+			return 0
+		fi
+		to_kebab_case "$url_basename"
+		return 0
+	fi
+
+	to_kebab_case "$fallback_name"
+	return 0
+}
+
+# Convert source files to aidevops format and copy to target location.
+# Args: format source_dir skill_source_dir target_file skill_name target_path
+_convert_and_install_files() {
+	local format="$1"
+	local source_dir="$2"
+	local skill_source_dir="$3"
+	local target_file="$4"
+	local skill_name="$5"
+	local target_path="$6"
 
 	# Create target directory
 	local target_dir
 	target_dir=".agents/$(dirname "$target_path")"
 	mkdir -p "$target_dir"
 
-	# Convert to aidevops format
+	case "$format" in
+	skill-md | skill-md-nested)
+		convert_skill_md "$skill_source_dir/SKILL.md" "$target_file" "$skill_name"
+		;;
+	agents-md)
+		cp "$source_dir/AGENTS.md" "$target_file"
+		;;
+	cursorrules)
+		{
+			echo "---"
+			echo "description: Imported from .cursorrules"
+			echo "mode: subagent"
+			echo "imported_from: cursorrules"
+			echo "---"
+			echo "# $skill_name"
+			echo ""
+			cat "$source_dir/.cursorrules"
+		} >"$target_file"
+		;;
+	*)
+		local md_file
+		md_file=$(find "$source_dir" -maxdepth 1 -name "*.md" -type f | head -1)
+		if [[ -n "$md_file" ]]; then
+			cp "$md_file" "$target_file"
+		else
+			log_error "No suitable files found to import"
+			return 1
+		fi
+		;;
+	esac
+
+	log_success "Created: $target_file"
+
+	# Copy additional resources (scripts, references, assets)
+	local resource_dir
+	for resource_dir in scripts references assets; do
+		if [[ -d "$skill_source_dir/$resource_dir" ]]; then
+			local target_resource_dir=".agents/${target_path}/$resource_dir"
+			mkdir -p "$target_resource_dir"
+			cp -r "$skill_source_dir/$resource_dir/"* "$target_resource_dir/" 2>/dev/null || true
+			log_success "Copied: $resource_dir/"
+		fi
+	done
+
+	return 0
+}
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+# Try to install via openskills CLI. Returns 0 if installed, 1 if not available/failed.
+# Args: owner repo subpath custom_name
+_try_openskills_install() {
+	local owner="$1"
+	local repo="$2"
+	local subpath="$3"
+	local custom_name="$4"
+
+	if ! command -v openskills &>/dev/null; then
+		return 1
+	fi
+
+	log_info "Using openskills to fetch skill..."
+	if openskills install "$owner/$repo${subpath:+/$subpath}" --yes --universal 2>/dev/null; then
+		log_success "Skill installed via openskills"
+		local skill_name="${custom_name:-$(basename "${subpath:-$repo}")}"
+		skill_name=$(to_kebab_case "$skill_name")
+		register_skill "$skill_name" "https://github.com/$owner/$repo" ".agents/skills/${skill_name}-skill.md" "skill-md" "" "openskills" "Installed via openskills CLI"
+		return 0
+	fi
+
+	log_warning "openskills failed, falling back to direct fetch"
+	return 1
+}
+
+# Parse cmd_add options. Sets caller variables: custom_name, force, dry_run, skip_security
+_parse_add_options() {
+	local opt
+	while [[ $# -gt 0 ]]; do
+		opt="$1"
+		case "$opt" in
+		--name)
+			_add_custom_name="$2"
+			shift 2
+			;;
+		--force)
+			_add_force=true
+			shift
+			;;
+		--skip-security)
+			_add_skip_security=true
+			shift
+			;;
+		--dry-run)
+			_add_dry_run=true
+			shift
+			;;
+		*)
+			log_error "Unknown option: $opt"
+			return 1
+			;;
+		esac
+	done
+	return 0
+}
+
+# Detect source type and route to appropriate handler.
+# Returns: 0 if delegated (caller should return), 1 if GitHub (caller continues)
+_detect_and_route_source() {
+	local url="$1"
+	local custom_name="$2"
+	local force="$3"
+	local dry_run="$4"
+	local skip_security="$5"
+
+	# Detect ClawdHub source (clawdhub:slug or clawdhub.com URL)
+	local clawdhub_slug=""
+
+	if [[ "$url" == clawdhub:* ]]; then
+		clawdhub_slug="${url#clawdhub:}"
+	elif [[ "$url" == *clawdhub.com* ]]; then
+		clawdhub_slug="${url#*clawdhub.com/}"
+		clawdhub_slug="${clawdhub_slug#/}"
+		clawdhub_slug="${clawdhub_slug%/}"
+		if [[ "$clawdhub_slug" == */* ]]; then
+			clawdhub_slug="${clawdhub_slug##*/}"
+		fi
+	fi
+
+	if [[ -n "$clawdhub_slug" ]]; then
+		cmd_add_clawdhub "$clawdhub_slug" "$custom_name" "$force" "$dry_run" "$skip_security"
+		_route_exit_code=$?
+		return 0
+	fi
+
+	# Detect raw URL source (not GitHub, not ClawdHub)
+	if [[ "$url" =~ ^https?:// && "$url" != *github.com* && "$url" != *clawdhub.com* ]]; then
+		cmd_add_url "$url" "$custom_name" "$force" "$dry_run" "$skip_security"
+		_route_exit_code=$?
+		return 0
+	fi
+
+	# Not delegated — caller handles as GitHub
+	return 1
+}
+
+# Clone a GitHub repo and detect skill format/metadata.
+# Sets in caller scope: source_dir, skill_source_dir, format, skill_subdir
+# Args: owner repo subpath
+_clone_and_prepare_github() {
+	local owner="$1"
+	local repo="$2"
+	local subpath="$3"
+
+	# Clone repository
+	log_info "Cloning repository..."
+	local clone_url="https://github.com/$owner/$repo.git"
+
+	if ! git clone --depth 1 "$clone_url" "$TEMP_DIR/repo" 2>/dev/null; then
+		log_error "Failed to clone repository: $clone_url"
+		return 1
+	fi
+
+	# Navigate to subpath if specified
+	source_dir="$TEMP_DIR/repo"
+	if [[ -n "$subpath" ]]; then
+		source_dir="$TEMP_DIR/repo/$subpath"
+		if [[ ! -d "$source_dir" ]]; then
+			log_error "Subpath not found: $subpath"
+			return 1
+		fi
+	fi
+
+	# Detect format (returns format|skill_subdir)
+	local format_result
+	format_result=$(detect_format "$source_dir")
+	IFS='|' read -r format skill_subdir <<<"$format_result"
+	log_info "Detected format: $format"
+
+	# For nested skills, update source_dir to point to the skill directory
+	skill_source_dir="$source_dir"
+	if [[ "$format" == "skill-md-nested" && -n "$skill_subdir" ]]; then
+		skill_source_dir="$source_dir/$skill_subdir"
+		log_info "Found nested skill at: $skill_subdir"
+	fi
+
+	return 0
+}
+
+# Resolve skill name, description, and target path for a GitHub import.
+# Sets in caller scope: skill_name, description, target_path
+# Args: custom_name format skill_source_dir subpath repo
+_resolve_github_skill_metadata() {
+	local custom_name="$1"
+	local format="$2"
+	local skill_source_dir="$3"
+	local subpath="$4"
+	local repo="$5"
+
+	# Determine skill name
+	skill_name=""
+	if [[ -n "$custom_name" ]]; then
+		skill_name=$(to_kebab_case "$custom_name")
+	elif [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
+		skill_name=$(extract_skill_name "$skill_source_dir/SKILL.md")
+		skill_name=$(to_kebab_case "${skill_name:-$(basename "${subpath:-$repo}")}")
+	else
+		skill_name=$(to_kebab_case "$(basename "${subpath:-$repo}")")
+	fi
+
+	log_info "Skill name: $skill_name"
+
+	# Get description
+	description=""
+	if [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
+		description=$(extract_skill_description "$skill_source_dir/SKILL.md")
+	fi
+
+	# Determine target path
+	target_path=$(determine_target_path "$skill_name" "$description" "$skill_source_dir")
+	log_info "Target path: .agents/$target_path"
+
+	return 0
+}
+
+cmd_add() {
+	local url="$1"
+	shift
+
+	# Parse options (sets _add_* globals)
+	_add_custom_name=""
+	_add_force=false
+	_add_skip_security=false
+	_add_dry_run=false
+	if ! _parse_add_options "$@"; then
+		return 1
+	fi
+	local custom_name="$_add_custom_name"
+	local force="$_add_force"
+	local dry_run="$_add_dry_run"
+	local skip_security="$_add_skip_security"
+
+	log_info "Parsing source: $url"
+
+	# Route to ClawdHub or URL handler if applicable
+	_route_exit_code=0
+	if _detect_and_route_source "$url" "$custom_name" "$force" "$dry_run" "$skip_security"; then
+		return "$_route_exit_code"
+	fi
+
+	# Parse GitHub URL
+	local parsed owner repo subpath
+	parsed=$(parse_github_url "$url")
+	IFS='|' read -r owner repo subpath <<<"$parsed"
+
+	if [[ -z "$owner" || -z "$repo" ]]; then
+		log_error "Could not parse source URL: $url"
+		log_info "Expected: owner/repo, https://github.com/owner/repo, clawdhub:slug, or a raw URL"
+		return 1
+	fi
+
+	log_info "Owner: $owner, Repo: $repo, Subpath: ${subpath:-<root>}"
+
+	# Create temp directory
+	rm -rf "$TEMP_DIR"
+	mkdir -p "$TEMP_DIR"
+
+	# Try openskills first (returns 0 if installed successfully)
+	if _try_openskills_install "$owner" "$repo" "$subpath" "$custom_name"; then
+		return 0
+	fi
+
+	# Clone and detect format (sets source_dir, skill_source_dir, format, skill_subdir)
+	local source_dir="" skill_source_dir="" format="" skill_subdir=""
+	if ! _clone_and_prepare_github "$owner" "$repo" "$subpath"; then
+		return 1
+	fi
+
+	# Resolve metadata (sets skill_name, description, target_path)
+	local skill_name="" description="" target_path=""
+	_resolve_github_skill_metadata "$custom_name" "$format" "$skill_source_dir" "$subpath" "$repo"
+
+	# Handle conflicts (may update skill_name/target_path in caller scope)
+	if ! _apply_conflict_resolution "$target_path" "$force" "$description" "$source_dir"; then
+		rm -rf "$TEMP_DIR"
+		return 0
+	fi
+
+	if [[ "$dry_run" == true ]]; then
+		log_info "DRY RUN - Would create:"
+		echo "  .agents/${target_path}.md"
+		if [[ -d "$skill_source_dir/scripts" || -d "$skill_source_dir/references" ]]; then
+			echo "  .agents/${target_path}/"
+		fi
+		return 0
+	fi
+
+	# Convert and install files
 	local target_file=".agents/${target_path}.md"
+	if ! _convert_and_install_files "$format" "$source_dir" "$skill_source_dir" "$target_file" "$skill_name" "$target_path"; then
+		return 1
+	fi
+
+	# Get commit hash for tracking
+	local commit_hash=""
+	if [[ -d "$TEMP_DIR/repo/.git" ]]; then
+		commit_hash=$(git -C "$TEMP_DIR/repo" rev-parse HEAD 2>/dev/null || echo "")
+	fi
+
+	# Finalize: security scan, register, cleanup
+	if ! _finalize_import "$skill_source_dir" "$skill_name" "$skip_security" \
+		"$target_file" "$target_path" \
+		"https://github.com/$owner/$repo${subpath:+/$subpath}" \
+		".agents/${target_path}.md" "$format" "$commit_hash" \
+		"added" "" "" "" "" "$TEMP_DIR"; then
+		return 1
+	fi
+
+	log_success "Skill '$skill_name' imported successfully"
+	echo ""
+	log_info "Run './setup.sh' to create symlinks for other AI assistants"
+
+	return 0
+}
+
+# Convert fetched URL content to aidevops format.
+# Args: fetch_file target_file skill_name description url
+_convert_url_to_skill() {
+	local fetch_file="$1"
+	local target_file="$2"
+	local skill_name="$3"
+	local description="$4"
+	local url="$5"
+
+	# Create target directory
+	local target_dir
+	target_dir=".agents/$(dirname "${target_file#.agents/}")"
+	mkdir -p "$target_dir"
 
 	# Check if the fetched file has SKILL.md frontmatter
 	local has_frontmatter=false
@@ -1186,10 +1292,8 @@ cmd_add_url() {
 	fi
 
 	if [[ "$has_frontmatter" == true ]]; then
-		# Convert SKILL.md format to aidevops format
 		convert_skill_md "$fetch_file" "$target_file" "$skill_name"
 	else
-		# Wrap raw markdown with aidevops frontmatter
 		local safe_description
 		safe_description=$(printf '%s' "${description:-Imported from URL}" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
@@ -1207,23 +1311,142 @@ EOF
 	fi
 
 	log_success "Created: $target_file"
+	return 0
+}
 
-	# Security scan before registration
-	if ! scan_skill_security "$fetch_dir" "$skill_name" "$skip_security"; then
-		# Clean up the partially imported files
-		rm -f "$target_file"
-		rm -rf "$fetch_dir"
+# Fetch SKILL.md from ClawdHub and convert to aidevops format.
+# Args: slug fetch_dir target_file display_name skill_name summary version
+_fetch_and_convert_clawdhub() {
+	local slug="$1"
+	local fetch_dir="$2"
+	local target_file="$3"
+	local display_name="$4"
+	local skill_name="$5"
+	local summary="$6"
+	local version="$7"
+
+	# Fetch SKILL.md content using clawdhub-helper.sh (Playwright-based)
+	local helper_script
+	helper_script="$(dirname "$0")/clawdhub-helper.sh"
+
+	rm -rf "$fetch_dir"
+
+	if [[ -x "$helper_script" ]]; then
+		if ! "$helper_script" fetch "$slug" --output "$fetch_dir"; then
+			log_error "Failed to fetch SKILL.md from ClawdHub"
+			return 1
+		fi
+	else
+		log_error "clawdhub-helper.sh not found at: $helper_script"
 		return 1
 	fi
 
-	# VirusTotal scan (advisory, non-blocking)
-	scan_skill_virustotal "$fetch_dir" "$skill_name" "$skip_security"
+	# Verify SKILL.md was fetched
+	if [[ ! -f "$fetch_dir/SKILL.md" || ! -s "$fetch_dir/SKILL.md" ]]; then
+		log_error "SKILL.md not found or empty after fetch"
+		return 1
+	fi
 
-	# Register in skill-sources.json with upstream_hash and cache headers for update detection (t1415.2, t1415.3)
-	register_skill "$skill_name" "$url" ".agents/${target_path}.md" "url" "" "added" "Imported from URL" "$content_hash" "$resp_etag" "$resp_last_modified"
+	# Create target directory and convert to aidevops format
+	local target_dir
+	target_dir=".agents/$(dirname "${target_file#.agents/}")"
+	mkdir -p "$target_dir"
 
-	# Cleanup
+	local safe_summary
+	safe_summary=$(printf '%s' "${summary:-Imported from ClawdHub}" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+	cat >"$target_file" <<EOF
+---
+description: "${safe_summary}"
+mode: subagent
+imported_from: clawdhub
+clawdhub_slug: "${slug}"
+clawdhub_version: "${version}"
+---
+# ${display_name:-$skill_name}
+
+EOF
+
+	# Append the fetched SKILL.md content (skip any existing frontmatter)
+	awk '
+        BEGIN { in_frontmatter = 0; after_frontmatter = 0; has_frontmatter = 0 }
+        NR == 1 && /^---$/ { in_frontmatter = 1; has_frontmatter = 1; next }
+        in_frontmatter && /^---$/ { in_frontmatter = 0; after_frontmatter = 1; next }
+        in_frontmatter { next }
+        !has_frontmatter || after_frontmatter { print }
+    ' "$fetch_dir/SKILL.md" >>"$target_file"
+
+	log_success "Created: $target_file"
+	return 0
+}
+
+# Import a skill from a raw URL (not GitHub, not ClawdHub)
+# Fetches with curl, computes SHA-256 content hash, registers with format_detected: "url"
+cmd_add_url() {
+	local url="$1"
+	local custom_name="$2"
+	local force="$3"
+	local dry_run="$4"
+	local skip_security="${5:-false}"
+
+	log_info "Importing from URL: $url"
+
+	# Create temp directory for fetched content
+	local fetch_dir="${TMPDIR:-/tmp}/aidevops-url-fetch"
 	rm -rf "$fetch_dir"
+	mkdir -p "$fetch_dir"
+
+	# Fetch and validate URL content (sets fetch_file, resp_etag, resp_last_modified, content_hash)
+	local fetch_file="" resp_etag="" resp_last_modified="" content_hash="" header_file=""
+	if ! _fetch_url_content "$url" "$fetch_dir"; then
+		return 1
+	fi
+
+	# Determine skill name
+	local skill_name
+	skill_name=$(_resolve_skill_name "$custom_name" "$fetch_file" "$(basename "${url%.md}")" "$url")
+	log_info "Skill name: $skill_name"
+
+	# Extract description from frontmatter if available
+	local description=""
+	description=$(extract_skill_description "$fetch_file")
+
+	# Copy fetched file as SKILL.md for format detection compatibility
+	cp "$fetch_file" "$fetch_dir/SKILL.md" 2>/dev/null || true
+
+	# Determine target path
+	local target_path
+	target_path=$(determine_target_path "$skill_name" "$description" "$fetch_dir")
+	log_info "Target path: .agents/$target_path"
+
+	# Handle conflicts (may update skill_name/target_path in caller scope)
+	if ! _apply_conflict_resolution "$target_path" "$force" "$description" "$fetch_dir"; then
+		rm -rf "$fetch_dir"
+		return 0
+	fi
+
+	if [[ "$dry_run" == true ]]; then
+		log_info "DRY RUN - Would create:"
+		echo "  .agents/${target_path}.md"
+		echo "  Source: $url"
+		echo "  Format: url"
+		echo "  Content hash: ${content_hash:-<unavailable>}"
+		rm -rf "$fetch_dir"
+		return 0
+	fi
+
+	# Convert URL content to aidevops format
+	local target_file=".agents/${target_path}.md"
+	_convert_url_to_skill "$fetch_file" "$target_file" "$skill_name" "$description" "$url"
+
+	# Finalize: security scan, register, cleanup
+	if ! _finalize_import "$fetch_dir" "$skill_name" "$skip_security" \
+		"$target_file" "$target_path" \
+		"$url" ".agents/${target_path}.md" "url" "" \
+		"added" "Imported from URL" \
+		"$content_hash" "$resp_etag" "$resp_last_modified" "$fetch_dir"; then
+		return 1
+	fi
 
 	log_success "Skill '$skill_name' imported from URL successfully"
 	echo ""
@@ -1285,40 +1508,9 @@ cmd_add_clawdhub() {
 	target_path=$(determine_target_path "$skill_name" "$summary" ".")
 	log_info "Target path: .agents/$target_path"
 
-	# Check for conflicts
-	local conflicts
-	conflicts=$(check_conflicts "$target_path" ".agent") || true
-	if [[ -n "$conflicts" ]]; then
-		local blocking_conflicts
-		blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
-
-		if [[ -n "$blocking_conflicts" && "$force" != true ]]; then
-			log_warning "Conflicts detected:"
-			echo "$blocking_conflicts" | while read -r conflict; do
-				echo "  - ${conflict#*: }"
-			done
-			echo ""
-			echo "Options:"
-			echo "  1. Replace (overwrite existing)"
-			echo "  2. Separate (use different name)"
-			echo "  3. Skip (cancel import)"
-			echo ""
-			read -rp "Choose option [1-3]: " choice
-
-			local new_name
-			case "$choice" in
-			1) log_info "Replacing existing..." ;;
-			2)
-				read -rp "Enter new name: " new_name
-				skill_name=$(to_kebab_case "$new_name")
-				target_path=$(determine_target_path "$skill_name" "$summary" ".")
-				;;
-			3 | *)
-				log_info "Import cancelled"
-				return 0
-				;;
-			esac
-		fi
+	# Handle conflicts (may update skill_name/target_path in caller scope)
+	if ! _apply_conflict_resolution "$target_path" "$force" "$summary" "."; then
+		return 0
 	fi
 
 	if [[ "$dry_run" == true ]]; then
@@ -1327,81 +1519,22 @@ cmd_add_clawdhub() {
 		return 0
 	fi
 
-	# Fetch SKILL.md content using clawdhub-helper.sh (Playwright-based)
-	local helper_script
-	helper_script="$(dirname "$0")/clawdhub-helper.sh"
+	# Fetch and convert ClawdHub content
 	local fetch_dir="${TMPDIR:-/tmp}/clawdhub-fetch/${slug}"
-
-	rm -rf "$fetch_dir"
-
-	if [[ -x "$helper_script" ]]; then
-		if ! "$helper_script" fetch "$slug" --output "$fetch_dir"; then
-			log_error "Failed to fetch SKILL.md from ClawdHub"
-			return 1
-		fi
-	else
-		log_error "clawdhub-helper.sh not found at: $helper_script"
-		return 1
-	fi
-
-	# Verify SKILL.md was fetched
-	if [[ ! -f "$fetch_dir/SKILL.md" || ! -s "$fetch_dir/SKILL.md" ]]; then
-		log_error "SKILL.md not found or empty after fetch"
-		return 1
-	fi
-
-	# Create target directory
-	local target_dir
-	target_dir=".agents/$(dirname "$target_path")"
-	mkdir -p "$target_dir"
-
-	# Convert to aidevops format
 	local target_file=".agents/${target_path}.md"
-
-	# Write aidevops-style header
-	local safe_summary
-	safe_summary=$(printf '%s' "${summary:-Imported from ClawdHub}" | sed 's/\\/\\\\/g; s/"/\\"/g')
-
-	cat >"$target_file" <<EOF
----
-description: "${safe_summary}"
-mode: subagent
-imported_from: clawdhub
-clawdhub_slug: "${slug}"
-clawdhub_version: "${version}"
----
-# ${display_name:-$skill_name}
-
-EOF
-
-	# Append the fetched SKILL.md content (skip any existing frontmatter)
-	awk '
-        BEGIN { in_frontmatter = 0; after_frontmatter = 0; has_frontmatter = 0 }
-        NR == 1 && /^---$/ { in_frontmatter = 1; has_frontmatter = 1; next }
-        in_frontmatter && /^---$/ { in_frontmatter = 0; after_frontmatter = 1; next }
-        in_frontmatter { next }
-        !has_frontmatter || after_frontmatter { print }
-    ' "$fetch_dir/SKILL.md" >>"$target_file"
-
-	log_success "Created: $target_file"
-
-	# Security scan before registration
-	if ! scan_skill_security "$fetch_dir" "$skill_name" "$skip_security"; then
-		# Clean up the partially imported files
-		rm -f "$target_file"
-		rm -rf "$fetch_dir"
+	if ! _fetch_and_convert_clawdhub "$slug" "$fetch_dir" "$target_file" "$display_name" "$skill_name" "$summary" "$version"; then
 		return 1
 	fi
 
-	# VirusTotal scan (advisory, non-blocking)
-	scan_skill_virustotal "$fetch_dir" "$skill_name" "$skip_security"
-
-	# Register in skill-sources.json
+	# Finalize: security scan, register, cleanup
 	local upstream_url="https://clawdhub.com/${owner_handle}/${slug}"
-	register_skill "$skill_name" "$upstream_url" ".agents/${target_path}.md" "clawdhub" "$version" "added" "ClawdHub v${version} by @${owner_handle}"
-
-	# Cleanup
-	rm -rf "$fetch_dir"
+	if ! _finalize_import "$fetch_dir" "$skill_name" "$skip_security" \
+		"$target_file" "$target_path" \
+		"$upstream_url" ".agents/${target_path}.md" "clawdhub" "$version" \
+		"added" "ClawdHub v${version} by @${owner_handle}" \
+		"" "" "" "$fetch_dir"; then
+		return 1
+	fi
 
 	log_success "Skill '$skill_name' imported from ClawdHub successfully"
 	echo ""

--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -1221,6 +1221,7 @@ cmd_add() {
 	# Clone and detect format (sets source_dir, skill_source_dir, format, skill_subdir)
 	local source_dir="" skill_source_dir="" format="" skill_subdir=""
 	if ! _clone_and_prepare_github "$owner" "$repo" "$subpath"; then
+		rm -rf "$TEMP_DIR"
 		return 1
 	fi
 
@@ -1231,7 +1232,7 @@ cmd_add() {
 	# Handle conflicts (may update skill_name/target_path in caller scope)
 	if ! _apply_conflict_resolution "$target_path" "$force" "$description" "$source_dir"; then
 		rm -rf "$TEMP_DIR"
-		return 0
+		return 1
 	fi
 
 	if [[ "$dry_run" == true ]]; then
@@ -1240,12 +1241,14 @@ cmd_add() {
 		if [[ -d "$skill_source_dir/scripts" || -d "$skill_source_dir/references" ]]; then
 			echo "  .agents/${target_path}/"
 		fi
+		rm -rf "$TEMP_DIR"
 		return 0
 	fi
 
 	# Convert and install files
 	local target_file=".agents/${target_path}.md"
 	if ! _convert_and_install_files "$format" "$source_dir" "$skill_source_dir" "$target_file" "$skill_name" "$target_path"; then
+		rm -rf "$TEMP_DIR"
 		return 1
 	fi
 
@@ -1422,7 +1425,7 @@ cmd_add_url() {
 	# Handle conflicts (may update skill_name/target_path in caller scope)
 	if ! _apply_conflict_resolution "$target_path" "$force" "$description" "$fetch_dir"; then
 		rm -rf "$fetch_dir"
-		return 0
+		return 1
 	fi
 
 	if [[ "$dry_run" == true ]]; then
@@ -1437,7 +1440,11 @@ cmd_add_url() {
 
 	# Convert URL content to aidevops format
 	local target_file=".agents/${target_path}.md"
-	_convert_url_to_skill "$fetch_file" "$target_file" "$skill_name" "$description" "$url"
+	if ! _convert_url_to_skill "$fetch_file" "$target_file" "$skill_name" "$description" "$url"; then
+		log_error "Failed to convert URL content to skill format"
+		rm -rf "$fetch_dir"
+		return 1
+	fi
 
 	# Finalize: security scan, register, cleanup
 	if ! _finalize_import "$fetch_dir" "$skill_name" "$skip_security" \
@@ -1469,6 +1476,18 @@ cmd_add_clawdhub() {
 
 	if [[ -z "$slug" ]]; then
 		log_error "ClawdHub slug required"
+		return 1
+	fi
+
+	# Sanitize slug to prevent path traversal (reject ../ and absolute paths)
+	if [[ "$slug" == *..* || "$slug" == /* ]]; then
+		log_error "Invalid slug (path traversal detected): $slug"
+		return 1
+	fi
+	# Strip any remaining path-unsafe characters (allow alphanumeric, hyphen, underscore)
+	slug=$(printf '%s' "$slug" | tr -cd 'a-zA-Z0-9_-')
+	if [[ -z "$slug" ]]; then
+		log_error "Slug is empty after sanitization"
 		return 1
 	fi
 
@@ -1510,7 +1529,7 @@ cmd_add_clawdhub() {
 
 	# Handle conflicts (may update skill_name/target_path in caller scope)
 	if ! _apply_conflict_resolution "$target_path" "$force" "$summary" "."; then
-		return 0
+		return 1
 	fi
 
 	if [[ "$dry_run" == true ]]; then


### PR DESCRIPTION
## Summary

Fixes 4 bugs identified by Augment code review on PR #6206:

1. **Conflict return swallowed** (medium): _handle_conflicts returns non-zero for non-interactive conflicts, but cmd_add, cmd_add_url, and cmd_add_clawdhub all turned that into return 0 -- making automation think the import succeeded. Now propagates return 1.

2. **Unchecked conversion** (medium): _convert_url_to_skill return value was ignored in cmd_add_url, so write/conversion failures fell through to _finalize_import and could register a skill whose target file was not created. Now checked with cleanup on failure.

3. **Path traversal in slug** (high): ClawdHub slug was used to build fetch_dir and passed to rm -rf without sanitization. A slug containing ../ could escape the /tmp/clawdhub-fetch/ sandbox. Now rejects ../ and absolute paths, strips non-alphanumeric characters.

4. **TEMP_DIR leak** (low): cmd_add returned 1 on _clone_and_prepare_github and _convert_and_install_files failure without cleaning up TEMP_DIR. Added cleanup on all early-exit error paths including dry-run.

**Bug 5 (false positive)**: Augment claimed _finalize_import receives TEMP_DIR as 16th argument with cleanup_dir empty. Verified the call passes exactly 15 arguments with TEMP_DIR correctly at position 15 (cleanup_dir). No change needed.

## Verification

- bash -n: passes
- shellcheck -S warning: zero violations

Closes #6019