### PR TITLE
Issue #5852: Reduce function complexity in memory-helper.sh

### DIFF
--- a/.agents/scripts/memory-helper.sh
+++ b/.agents/scripts/memory-helper.sh
@@ -82,9 +82,9 @@ source "${SCRIPT_DIR}/memory/recall.sh"
 source "${SCRIPT_DIR}/memory/maintenance.sh"
 
 #######################################
-# Show help
+# Help: usage and commands section
 #######################################
-cmd_help() {
+_help_usage_commands() {
 	cat <<'EOF'
 memory-helper.sh - Lightweight memory system for aidevops
 
@@ -113,7 +113,15 @@ COMMANDS:
     graduate    Promote validated memories into shared docs (delegates to memory-graduate-helper.sh)
     namespaces  List all memory namespaces
     help        Show this help
+EOF
+	return 0
+}
 
+#######################################
+# Help: store and recall options
+#######################################
+_help_store_recall_options() {
+	cat <<'EOF'
 GLOBAL OPTIONS:
     --namespace <name>    Use isolated memory namespace (per-runner)
                           Creates DB at: memory/namespaces/<name>/memory.db
@@ -161,7 +169,15 @@ RECALL OPTIONS:
     --hybrid              Combine FTS5 keyword + semantic search using RRF
     --stats               Show memory statistics
     --json                Output as JSON
+EOF
+	return 0
+}
 
+#######################################
+# Help: prune and dedup options
+#######################################
+_help_prune_dedup_options() {
+	cat <<'EOF'
 PRUNE OPTIONS:
     --older-than-days <n> Age threshold (default: 90)
     --dry-run             Show what would be deleted
@@ -206,7 +222,15 @@ STALENESS PREVENTION:
     - Recall updates last_accessed_at (used = valuable)
     - Prune removes old entries that were never accessed
     - Validate warns about potentially stale entries
+EOF
+	return 0
+}
 
+#######################################
+# Help: examples section
+#######################################
+_help_examples() {
+	cat <<'EOF'
 EXAMPLES:
     # Store a learning
     memory-helper.sh store --content "Use FTS5 for fast search" --type WORKING_SOLUTION
@@ -259,7 +283,15 @@ EXAMPLES:
     memory-helper.sh dedup --dry-run
     memory-helper.sh dedup
     memory-helper.sh dedup --exact-only
+EOF
+	return 0
+}
 
+#######################################
+# Help: entity and namespace examples
+#######################################
+_help_entity_namespace_examples() {
+	cat <<'EOF'
 ENTITY EXAMPLES:
     # Store a learning linked to an entity
     memory-helper.sh store --content "Prefers concise responses" --entity ent_xxx --type USER_PREFERENCE
@@ -298,6 +330,18 @@ NAMESPACE EXAMPLES:
     memory-helper.sh namespaces migrate --from code-reviewer --to global
     memory-helper.sh namespaces migrate --from global --to seo-analyst --move
 EOF
+	return 0
+}
+
+#######################################
+# Show help (orchestrates sub-sections)
+#######################################
+cmd_help() {
+	_help_usage_commands
+	_help_store_recall_options
+	_help_prune_dedup_options
+	_help_examples
+	_help_entity_namespace_examples
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Reduces function complexity in `.agents/scripts/memory-helper.sh` by extracting sub-functions from `cmd_help()`, which was 215 lines (a single large heredoc).

## Changes

`cmd_help()` is now an 8-line orchestrator that delegates to 5 focused helper functions:

| Function | Lines | Content |
|---|---|---|
| `_help_usage_commands()` | 32 | USAGE + COMMANDS section |
| `_help_store_recall_options()` | 52 | GLOBAL/STORE/RECALL options |
| `_help_prune_dedup_options()` | 49 | PRUNE/DEDUP options + feature notes |
| `_help_examples()` | 57 | Usage examples |
| `_help_entity_namespace_examples()` | 42 | Entity + namespace examples |

All functions are under 100 lines. No behavior changes.

## Verification

- `bash -n` syntax check: passes
- `shellcheck`: no new violations (pre-existing SC1091 info-level warnings for sourced files unchanged)
- `diff` of `memory-helper.sh help` output: only 4 cosmetic trailing blank lines removed (were between heredoc sections in the original single block)

Closes #5852