### PR TITLE
GH#5857: Reduce function complexity in linter-manager.sh

### DIFF
--- a/.agents/scripts/linter-manager.sh
+++ b/.agents/scripts/linter-manager.sh
@@ -31,8 +31,8 @@ install_npm_global() {
 	fi
 }
 
-# Detect project languages and frameworks
-detect_project_languages() {
+# Detect scripted/interpreted languages (Python, JS, CSS, Shell, Docker, YAML, PHP, Ruby)
+_detect_scripted_languages() {
 	local languages=()
 
 	# Python
@@ -65,11 +65,6 @@ detect_project_languages() {
 		languages+=("yaml")
 	fi
 
-	# Go
-	if [[ -f "go.mod" || -f "go.sum" ]]; then
-		languages+=("go")
-	fi
-
 	# PHP
 	if [[ -f "composer.json" ]] || find . -name "*.php" | head -1 | grep -q .; then
 		languages+=("php")
@@ -78,6 +73,19 @@ detect_project_languages() {
 	# Ruby
 	if [[ -f "Gemfile" || -f "Rakefile" ]] || find . -name "*.rb" | head -1 | grep -q .; then
 		languages+=("ruby")
+	fi
+
+	printf '%s\n' "${languages[@]}"
+	return 0
+}
+
+# Detect compiled/typed languages (Go, Java, C#, Swift, Kotlin, Dart, R, C/C++, Haskell, Groovy, PowerShell)
+_detect_compiled_languages() {
+	local languages=()
+
+	# Go
+	if [[ -f "go.mod" || -f "go.sum" ]]; then
+		languages+=("go")
 	fi
 
 	# Java
@@ -130,10 +138,24 @@ detect_project_languages() {
 		languages+=("powershell")
 	fi
 
-	# Security scanning (always relevant)
-	languages+=("security")
-
 	printf '%s\n' "${languages[@]}"
+	return 0
+}
+
+# Detect project languages and frameworks
+detect_project_languages() {
+	local scripted compiled
+
+	scripted=$(_detect_scripted_languages)
+	compiled=$(_detect_compiled_languages)
+
+	# Combine results, filter empty lines, append security (always relevant)
+	{
+		printf '%s\n' "$scripted"
+		printf '%s\n' "$compiled"
+		printf '%s\n' "security"
+	} | grep -v '^$'
+
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Splits the 103-line `detect_project_languages()` function in `.agents/scripts/linter-manager.sh` into three focused sub-functions, each under 100 lines. No behavior changes.

## Changes

- `_detect_scripted_languages()` — 48 lines: detects Python, JavaScript, CSS, Shell, Docker, YAML, PHP, Ruby
- `_detect_compiled_languages()` — 63 lines: detects Go, Java, C#, Swift, Kotlin, Dart, R, C/C++, Haskell, Groovy, PowerShell
- `detect_project_languages()` — 17 lines: orchestrates the two helpers, appends "security" (always relevant), filters blank lines

Also fixes SC2086 (unquoted variable in `printf` call) that was introduced during the refactor.

## Verification

- `bash -n linter-manager.sh` — syntax OK
- `shellcheck linter-manager.sh` — no new violations (SC1091 is pre-existing, sourced file not available to shellcheck)
- Functional test: `detect_project_languages` correctly returns detected languages + "security" in the aidevops repo

Closes #5857