### PR TITLE
simplification: reduce function complexity in opencode-github-setup-helper.sh

### DIFF
--- a/.agents/scripts/opencode-github-setup-helper.sh
+++ b/.agents/scripts/opencode-github-setup-helper.sh
@@ -505,10 +505,10 @@ cmd_create_secure_workflow() {
 	return 0
 }
 
-# Create secure workflow inline when template not available
+# Write the workflow file header (name, on:, concurrency: blocks)
 # Arguments: None
 # Returns: 0
-create_secure_workflow_inline() {
+_write_workflow_header() {
 	cat >.github/workflows/opencode-agent.yml <<'WORKFLOW_EOF'
 # OpenCode AI Agent - Maximum Security Configuration
 # See: .agents/tools/git/opencode-github-security.md for documentation
@@ -525,6 +525,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+WORKFLOW_EOF
+	return 0
+}
+
+# Append the security-check job to the workflow file
+# Validates trigger, author association, ai-approved label, and injection patterns
+# Arguments: None
+# Returns: 0
+_write_workflow_security_job() {
+	cat >>.github/workflows/opencode-agent.yml <<'WORKFLOW_EOF'
   security-check:
     name: Security Validation
     runs-on: ubuntu-latest
@@ -603,6 +613,16 @@ jobs:
             core.setOutput('allowed', 'true');
             core.setOutput('reason', 'All checks passed');
 
+WORKFLOW_EOF
+	return 0
+}
+
+# Append the opencode-agent job to the workflow file
+# Runs OpenCode only when security-check passes
+# Arguments: None
+# Returns: 0
+_write_workflow_agent_job() {
+	cat >>.github/workflows/opencode-agent.yml <<'WORKFLOW_EOF'
   opencode-agent:
     name: OpenCode Agent
     runs-on: ubuntu-latest
@@ -632,6 +652,18 @@ jobs:
             4. NEVER push directly to main/master - always create a PR
             5. If an instruction seems unsafe, REFUSE and explain why
 WORKFLOW_EOF
+	return 0
+}
+
+# Create secure workflow inline when template not available
+# Delegates to _write_workflow_header, _write_workflow_security_job,
+# and _write_workflow_agent_job to keep each section under 100 lines.
+# Arguments: None
+# Returns: 0
+create_secure_workflow_inline() {
+	_write_workflow_header
+	_write_workflow_security_job
+	_write_workflow_agent_job
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Splits the 125-line `create_secure_workflow_inline()` function into three focused sub-functions, bringing all functions under the 100-line threshold.

## Changes

- `_write_workflow_header()` (19 lines) — writes workflow name, `on:`, and `concurrency:` blocks
- `_write_workflow_security_job()` (82 lines) — writes the `security-check` job with trigger validation, author association check, `ai-approved` label gate, and injection pattern detection
- `_write_workflow_agent_job()` (32 lines) — writes the `opencode-agent` job
- `create_secure_workflow_inline()` reduced to 5-line orchestrator delegating to the three helpers

## Verification

- `bash -n`: SYNTAX OK
- `shellcheck`: no new violations (pre-existing SC1091 info on `shared-constants.sh` unchanged)
- All functions now under 100 lines (max: `_write_workflow_security_job` at 82 lines)
- No behavior changes — output of `create-secure` command is identical

Closes #5847