### PR TITLE
refactor: reduce complexity in observability-helper.sh (#5848)

### DIFF
--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -397,65 +397,42 @@ check_rate_limit_risk() {
 	return 0
 }
 
-cmd_rate_limits() {
-	local json_flag=false provider_filter="" window_minutes=""
-	while [[ $# -gt 0 ]]; do
-		case "$1" in --json)
-			json_flag=true
-			shift
-			;;
-		--provider)
-			provider_filter="${2:-}"
-			shift 2
-			;;
-		--window)
-			window_minutes="${2:-}"
-			shift 2
-			;;
-		*) shift ;; esac
-	done
-	cmd_ingest --quiet >/dev/null 2>&1 || true
-
-	local config_file
-	config_file=$(_get_rate_limits_config) || config_file=""
-	local ew="${window_minutes:-$(_get_config_val "window_minutes" "$DEFAULT_WINDOW_MINUTES")}"
-	local wp
-	wp=$(_get_config_val "warn_pct" "$DEFAULT_WARN_PCT")
-	[[ "$ew" =~ ^[0-9]+$ && "$ew" -gt 0 ]] || {
-		print_error "--window must be a positive integer"
-		return 1
-	}
-	[[ "$wp" =~ ^[0-9]+$ ]] || wp="$DEFAULT_WARN_PCT"
-
-	# Collect providers
-	local -a providers=()
+# Collect unique provider names from config and metrics JSONL.
+# Prints one provider name per line to stdout.
+# Usage: _rl_collect_providers config_file provider_filter
+_rl_collect_providers() {
+	local config_file="$1" provider_filter="$2"
 	if [[ -n "$provider_filter" ]]; then
-		providers=("$provider_filter")
-	else
-		local seen=""
-		if [[ -n "$config_file" ]] && command -v jq &>/dev/null; then
-			while IFS= read -r p; do
-				[[ -z "$p" || "$seen" == *"|${p}|"* ]] && continue
-				providers+=("$p")
-				seen="${seen}|${p}|"
-			done < <(jq -r '.providers | keys[]' "$config_file" 2>/dev/null)
-		fi
-		if [[ -f "$OBS_METRICS" ]] && command -v jq &>/dev/null; then
-			while IFS= read -r p; do
-				[[ -z "$p" || "$seen" == *"|${p}|"* ]] && continue
-				providers+=("$p")
-				seen="${seen}|${p}|"
-			done < <(jq -r '.provider' "$OBS_METRICS" 2>/dev/null | sort -u)
-		fi
-	fi
-	[[ ${#providers[@]} -eq 0 ]] && {
-		[[ "$json_flag" == "true" ]] && echo "[]" || print_info "No provider data. Run 'ingest' first."
+		echo "$provider_filter"
 		return 0
-	}
+	fi
+	local seen=""
+	if [[ -n "$config_file" ]] && command -v jq &>/dev/null; then
+		while IFS= read -r p; do
+			[[ -z "$p" || "$seen" == *"|${p}|"* ]] && continue
+			echo "$p"
+			seen="${seen}|${p}|"
+		done < <(jq -r '.providers | keys[]' "$config_file" 2>/dev/null)
+	fi
+	if [[ -f "$OBS_METRICS" ]] && command -v jq &>/dev/null; then
+		while IFS= read -r p; do
+			[[ -z "$p" || "$seen" == *"|${p}|"* ]] && continue
+			echo "$p"
+			seen="${seen}|${p}|"
+		done < <(jq -r '.provider' "$OBS_METRICS" 2>/dev/null | sort -u)
+	fi
+	return 0
+}
 
-	# Build rows
-	local -a rows=()
-	for prov in "${providers[@]}"; do
+# Build pipe-delimited usage rows for each provider.
+# Each row: provider|req_used|req_limit|req_pct|tok_used|tok_limit|tok_pct|status|billing_type
+# Prints one row per line to stdout.
+# Usage: _rl_build_rows eff_window warn_pct provider [provider ...]
+_rl_build_rows() {
+	local ew="$1" wp="$2"
+	shift 2
+	local prov
+	for prov in "$@"; do
 		[[ -z "$prov" ]] && continue
 		local rl tl bt usage ar at rp=0 tp=0
 		rl=$(_get_rl_field "$prov" "requests_per_min")
@@ -472,25 +449,34 @@ cmd_rate_limits() {
 		mp=$(awk "BEGIN { print ($rp > $tp) ? $rp : $tp }")
 		[[ "$mp" -ge 95 ]] && st="critical"
 		[[ "$mp" -lt 95 && "$mp" -ge "$wp" ]] && st="warn"
-		rows+=("${prov}|${ar}|${rl}|${rp}|${at}|${tl}|${tp}|${st}|${bt}")
+		echo "${prov}|${ar}|${rl}|${rp}|${at}|${tl}|${tp}|${st}|${bt}"
 	done
+	return 0
+}
 
-	if [[ "$json_flag" == "true" ]]; then
-		local json_arr="[" first=true
-		for row in "${rows[@]}"; do
-			IFS='|' read -r pv a r rp2 t l tp2 s _ <<<"$row"
-			[[ "$first" == "true" ]] || json_arr="${json_arr},"
-			first=false
-			json_arr="${json_arr}{\"provider\":\"$pv\",\"requests_used\":${a:-0},\"requests_limit\":${r:-0},\"requests_pct\":${rp2:-0},\"tokens_used\":${t:-0},\"tokens_limit\":${l:-0},\"tokens_pct\":${tp2:-0},\"status\":\"$s\",\"window_minutes\":${ew:-1}}"
-		done
-		echo "${json_arr}]"
-		return 0
-	fi
+# Emit JSON array from pipe-delimited rows on stdin. Usage: _rl_output_json eff_window
+_rl_output_json() {
+	local ew="$1"
+	local json_arr="[" first=true row
+	while IFS= read -r row; do
+		IFS='|' read -r pv a r rp2 t l tp2 s _ <<<"$row"
+		[[ "$first" == "true" ]] || json_arr="${json_arr},"
+		first=false
+		json_arr="${json_arr}{\"provider\":\"$pv\",\"requests_used\":${a:-0},\"requests_limit\":${r:-0},\"requests_pct\":${rp2:-0},\"tokens_used\":${t:-0},\"tokens_limit\":${l:-0},\"tokens_pct\":${tp2:-0},\"status\":\"$s\",\"window_minutes\":${ew:-1}}"
+	done
+	echo "${json_arr}]"
+	return 0
+}
 
+# Emit human-readable table from pipe-delimited rows on stdin.
+# Usage: _rl_output_table eff_window warn_pct config_file
+_rl_output_table() {
+	local ew="$1" wp="$2" config_file="$3"
 	printf "\nRate Limit Utilisation (%smin window, warn at %s%%)\n" "$ew" "$wp"
 	[[ -z "$config_file" ]] && print_warning "No rate-limits.json found"
 	printf "  %-12s %6s %10s %5s %8s %10s %5s %s\n" "Provider" "Reqs" "Limit" "Pct" "Tokens" "Limit" "Pct" "Status"
-	for row in "${rows[@]}"; do
+	local row
+	while IFS= read -r row; do
 		IFS='|' read -r pv a r rp2 t l tp2 s _ <<<"$row"
 		local sd="$s"
 		[[ "$s" == "critical" ]] && sd="${RED}CRITICAL${NC}"
@@ -499,6 +485,59 @@ cmd_rate_limits() {
 		printf "  %-12s %6s %10s %4s%% %8s %10s %4s%% %b\n" "$pv" "$a" "${r:-n/a}" "$rp2" "$t" "${l:-n/a}" "$tp2" "$sd"
 	done
 	echo ""
+	return 0
+}
+
+cmd_rate_limits() {
+	local json_flag=false provider_filter="" window_minutes=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		--provider)
+			provider_filter="${2:-}"
+			shift 2
+			;;
+		--window)
+			window_minutes="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+	cmd_ingest --quiet >/dev/null 2>&1 || true
+
+	local config_file
+	config_file=$(_get_rate_limits_config) || config_file=""
+	local ew="${window_minutes:-$(_get_config_val "window_minutes" "$DEFAULT_WINDOW_MINUTES")}"
+	local wp
+	wp=$(_get_config_val "warn_pct" "$DEFAULT_WARN_PCT")
+	[[ "$ew" =~ ^[0-9]+$ && "$ew" -gt 0 ]] || {
+		print_error "--window must be a positive integer"
+		return 1
+	}
+	[[ "$wp" =~ ^[0-9]+$ ]] || wp="$DEFAULT_WARN_PCT"
+
+	local providers_out
+	providers_out=$(_rl_collect_providers "$config_file" "$provider_filter")
+	[[ -z "$providers_out" ]] && {
+		[[ "$json_flag" == "true" ]] && echo "[]" || print_info "No provider data. Run 'ingest' first."
+		return 0
+	}
+
+	local rows_out
+	rows_out=$(while IFS= read -r prov; do
+		_rl_build_rows "$ew" "$wp" "$prov"
+	done <<<"$providers_out")
+
+	if [[ "$json_flag" == "true" ]]; then
+		_rl_output_json "$ew" <<<"$rows_out"
+	else
+		_rl_output_table "$ew" "$wp" "$config_file" <<<"$rows_out"
+	fi
+	return 0
 }
 
 cmd_help() {


### PR DESCRIPTION
## Summary

Extracts four focused helper functions from `cmd_rate_limits()` in `.agents/scripts/observability-helper.sh`, reducing it from 102 lines to 51 lines. No behaviour changes.

## Functions extracted

| Function | Lines | Purpose |
|---|---|---|
| `_rl_collect_providers()` | 23 | Gather unique provider names from config/metrics |
| `_rl_build_rows()` | 25 | Compute per-provider usage rows (pipe-delimited) |
| `_rl_output_json()` | 12 | Emit JSON array from rows on stdin |
| `_rl_output_table()` | 17 | Emit human-readable table from rows on stdin |

`cmd_rate_limits()` becomes a 51-line orchestrator that calls these helpers.

## Verification

- `bash -n` passes (syntax OK)
- `shellcheck` passes (zero new violations — only pre-existing SC1091 info for `source`)
- No behaviour changes: same logic, same output format, same CLI flags

Closes #5848