### PR TITLE
GH#5833: Reduce parse_args complexity in quickfile-helper.sh

### DIFF
--- a/.agents/scripts/quickfile-helper.sh
+++ b/.agents/scripts/quickfile-helper.sh
@@ -576,12 +576,11 @@ cmd_help() {
 	return 0
 }
 
-# Parse command-line arguments
-parse_args() {
-	local command="${1:-help}"
-	shift || true
-
-	# Parse named options
+# Parse named options from argument list; sets variables in caller scope via echo
+# Usage: eval "$(_parse_options "$@")"
+# Outputs: shell assignments for file, dry_run, nominal_override, supplier_id,
+#          auto_supplier, currency_override; remaining args are consumed.
+_parse_options() {
 	local file=""
 	local dry_run="false"
 	local nominal_override=""
@@ -589,7 +588,7 @@ parse_args() {
 	local auto_supplier="false"
 	local currency_override=""
 
-	# First positional arg after command is the file/dir/name
+	# First positional arg (if not a flag) is the file/dir/name
 	if [[ $# -gt 0 ]] && [[ ! "$1" =~ ^-- ]]; then
 		file="$1"
 		shift || true
@@ -639,6 +638,26 @@ parse_args() {
 		esac
 	done
 
+	printf '%s\n' \
+		"file=$(printf '%q' "$file")" \
+		"dry_run=$(printf '%q' "$dry_run")" \
+		"nominal_override=$(printf '%q' "$nominal_override")" \
+		"supplier_id=$(printf '%q' "$supplier_id")" \
+		"auto_supplier=$(printf '%q' "$auto_supplier")" \
+		"currency_override=$(printf '%q' "$currency_override")"
+	return 0
+}
+
+# Dispatch a parsed command to the appropriate cmd_* function
+_dispatch_command() {
+	local command="$1"
+	local file="$2"
+	local dry_run="$3"
+	local nominal_override="$4"
+	local supplier_id="$5"
+	local auto_supplier="$6"
+	local currency_override="$7"
+
 	case "$command" in
 	record-purchase | rp)
 		if [[ -z "$file" ]]; then
@@ -687,6 +706,28 @@ parse_args() {
 		return 1
 		;;
 	esac
+	return $?
+}
+
+# Parse command-line arguments and dispatch to the appropriate command
+parse_args() {
+	local command="${1:-help}"
+	shift || true
+
+	local file=""
+	local dry_run="false"
+	local nominal_override=""
+	local supplier_id=""
+	local auto_supplier="false"
+	local currency_override=""
+
+	local opts
+	opts="$(_parse_options "$@")" || return 1
+	eval "$opts"
+
+	_dispatch_command "$command" "$file" "$dry_run" "$nominal_override" \
+		"$supplier_id" "$auto_supplier" "$currency_override"
+	return $?
 }
 
 # Main entry point


### PR DESCRIPTION
## Summary

Reduces function complexity in `.agents/scripts/quickfile-helper.sh` by extracting two sub-functions from `parse_args()`, which exceeded 100 lines.

### Changes

- Extracted `_parse_options()` (71 lines) — handles the named-option parsing loop (`--dry-run`, `--nominal`, `--supplier-id`, `--auto-supplier`, `--currency`)
- Extracted `_dispatch_command()` (60 lines) — handles the `case` dispatch to `cmd_*` functions
- `parse_args()` reduced from 110 lines to 20 lines; calls the two helpers and passes results through

### No behavior changes

All command routing, option validation, and error messages are identical. The only structural change is the extraction into named sub-functions.

### Verification

- `bash -n`: syntax OK
- `shellcheck`: only pre-existing SC1091 info notice (external source file, not a violation)
- Function line counts: `_parse_options` 71, `_dispatch_command` 60, `parse_args` 20 — all under 100

Closes #5833