### PR TITLE
GH#5832: Reduce cmd_help() complexity in runway-helper.sh

### DIFF
--- a/.agents/scripts/runway-helper.sh
+++ b/.agents/scripts/runway-helper.sh
@@ -777,10 +777,8 @@ cmd_usage() {
 	return 0
 }
 
-cmd_help() {
-	cat <<'HELP'
-runway-helper.sh - Runway API CLI for video, image, and audio generation
-
+_help_commands() {
+	cat <<'COMMANDS'
 COMMANDS:
   video     Generate video from image, text, or video
   image     Generate image from text with optional references
@@ -795,7 +793,12 @@ COMMANDS:
   credits   Check credit balance
   usage     Query credit usage history
   help      Show this help
+COMMANDS
+	return 0
+}
 
+_help_options() {
+	cat <<'OPTIONS'
 VIDEO OPTIONS:
   --image, -i URL     Source image URL (image-to-video)
   --video, -v URL     Source video URL (video-to-video, uses gen4_aleph)
@@ -850,7 +853,12 @@ ISOLATE OPTIONS:
 USAGE OPTIONS:
   --start DATE        Start date (YYYY-MM-DD)
   --end DATE          End date (YYYY-MM-DD)
+OPTIONS
+	return 0
+}
 
+_help_examples() {
+	cat <<'EXAMPLES'
 EXAMPLES:
   # Image-to-video with Gen-4 Turbo
   runway-helper.sh video -i https://example.com/photo.jpg \
@@ -901,7 +909,18 @@ VOICE PRESETS:
 DUBBING LANGUAGES:
   en, hi, pt, zh, es, fr, de, ja, ar, ru, ko, id, it, nl, tr, pl, sv,
   fil, ms, ro, uk, el, cs, da, fi, bg, hr, sk, ta
-HELP
+EXAMPLES
+	return 0
+}
+
+cmd_help() {
+	echo "runway-helper.sh - Runway API CLI for video, image, and audio generation"
+	echo ""
+	_help_commands
+	echo ""
+	_help_options
+	echo ""
+	_help_examples
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Extracts three focused sub-functions from `cmd_help()` in `.agents/scripts/runway-helper.sh`, which was 126 lines — exceeding the 100-line threshold flagged in GH#5832.

## Changes

- `_help_commands()` (18 lines) — COMMANDS section
- `_help_options()` (58 lines) — all per-command OPTIONS sections
- `_help_examples()` (54 lines) — EXAMPLES, ENVIRONMENT, VOICE PRESETS, DUBBING LANGUAGES
- `cmd_help()` reduced to 9 lines — prints header and delegates to the three helpers

**No behaviour change.** The `help` command output is byte-for-byte identical.

## Verification

- `bash -n .agents/scripts/runway-helper.sh` — syntax OK
- `shellcheck .agents/scripts/runway-helper.sh` — zero violations
- `runway-helper.sh help` output verified (header, commands, options, examples, env, voice presets, dubbing languages all present)
- All functions now under 100 lines (largest: `cmd_video` and `cmd_image` at 95 lines each)

Closes #5832