### PR TITLE
refactor: reduce function complexity by extracting sub-functions (#5766 #5765 #5764 #5763)

### DIFF
--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -251,10 +251,11 @@ _print_candidates_text() {
 }
 
 #######################################
-# Find graduation candidates
-# Criteria: high confidence OR frequently accessed, not yet graduated
+# Parse arguments for cmd_candidates
+# Usage: _candidates_parse_args "$@"
+# Outputs: newline-separated KEY=VALUE pairs
 #######################################
-cmd_candidates() {
+_candidates_parse_args() {
 	local limit=$DEFAULT_LIMIT
 	local min_access=$DEFAULT_MIN_ACCESS
 	local format="text"
@@ -276,6 +277,30 @@ cmd_candidates() {
 		*) shift ;;
 		esac
 	done
+
+	printf '%s\n' \
+		"limit=${limit}" \
+		"min_access=${min_access}" \
+		"format=${format}"
+	return 0
+}
+
+#######################################
+# Find graduation candidates
+# Criteria: high confidence OR frequently accessed, not yet graduated
+#######################################
+cmd_candidates() {
+	local parsed
+	parsed=$(_candidates_parse_args "$@")
+
+	local limit min_access format
+	while IFS='=' read -r key val; do
+		case "$key" in
+		limit) limit="$val" ;;
+		min_access) min_access="$val" ;;
+		format) format="$val" ;;
+		esac
+	done <<<"$parsed"
 
 	ensure_schema || return 1
 
@@ -468,9 +493,11 @@ HEADER
 }
 
 #######################################
-# Graduate memories into shared docs
+# Parse arguments for cmd_graduate
+# Usage: _graduate_parse_args "$@"
+# Outputs: newline-separated KEY=VALUE pairs
 #######################################
-cmd_graduate() {
+_graduate_parse_args() {
 	local dry_run=false
 	local limit=$DEFAULT_LIMIT
 	local min_access=$DEFAULT_MIN_ACCESS
@@ -493,6 +520,84 @@ cmd_graduate() {
 		esac
 	done
 
+	printf '%s\n' \
+		"dry_run=${dry_run}" \
+		"limit=${limit}" \
+		"min_access=${min_access}"
+	return 0
+}
+
+#######################################
+# Collect entries from results into tmp_dir and read back counts/ids
+# Args: results tmp_dir
+# Outputs: sets graduated_count, skipped_count, graduated_ids[] in caller scope
+# (caller must declare these variables before calling)
+#######################################
+_graduate_collect_and_read() {
+	local results="$1"
+	local tmp_dir="$2"
+
+	_collect_entries "$results" "$tmp_dir"
+
+	graduated_count=$(cat "$tmp_dir/count_graduated" 2>/dev/null || echo "0")
+	skipped_count=$(cat "$tmp_dir/count_skipped" 2>/dev/null || echo "0")
+
+	graduated_ids=()
+	if [[ -f "$tmp_dir/ids" ]]; then
+		while IFS= read -r id; do
+			graduated_ids+=("$id")
+		done <"$tmp_dir/ids"
+	fi
+	return 0
+}
+
+#######################################
+# Write graduated content to file and mark memories in DB
+# Args: tmp_dir target_file graduated_count skipped_count graduated_ids...
+#######################################
+_graduate_write_and_mark() {
+	local tmp_dir="$1"
+	local target_file="$2"
+	local graduated_count="$3"
+	local skipped_count="$4"
+	shift 4
+	local graduated_ids=("$@")
+
+	local new_content
+	new_content=$(_build_graduation_content "$tmp_dir")
+
+	_ensure_graduated_file "$target_file"
+
+	# Append graduated content
+	echo "$new_content" >>"$target_file"
+
+	# Mark memories as graduated in the DB
+	if [[ ${#graduated_ids[@]} -gt 0 ]]; then
+		mark_graduated "${graduated_ids[@]}"
+	fi
+
+	log_success "Graduated $graduated_count memories ($skipped_count skipped as metadata)"
+	log_info "Updated: $target_file"
+	log_info "Remember to commit and push the changes."
+	return 0
+}
+
+#######################################
+# Graduate memories into shared docs
+#######################################
+cmd_graduate() {
+	local parsed
+	parsed=$(_graduate_parse_args "$@")
+
+	local dry_run limit min_access
+	while IFS='=' read -r key val; do
+		case "$key" in
+		dry_run) dry_run="$val" ;;
+		limit) limit="$val" ;;
+		min_access) min_access="$val" ;;
+		esac
+	done <<<"$parsed"
+
 	ensure_schema || return 1
 
 	local target_file
@@ -514,19 +619,9 @@ cmd_graduate() {
 	# shellcheck disable=SC2064
 	trap "rm -rf '$tmp_dir'" EXIT
 
-	_collect_entries "$results" "$tmp_dir"
-
 	local graduated_count skipped_count
-	graduated_count=$(cat "$tmp_dir/count_graduated" 2>/dev/null || echo "0")
-	skipped_count=$(cat "$tmp_dir/count_skipped" 2>/dev/null || echo "0")
-
-	# Read collected ids into array
 	local graduated_ids=()
-	if [[ -f "$tmp_dir/ids" ]]; then
-		while IFS= read -r id; do
-			graduated_ids+=("$id")
-		done <"$tmp_dir/ids"
-	fi
+	_graduate_collect_and_read "$results" "$tmp_dir"
 
 	if [[ "$graduated_count" -eq 0 ]]; then
 		log_info "No actionable memories to graduate ($skipped_count skipped as metadata)."
@@ -542,21 +637,8 @@ cmd_graduate() {
 		return 0
 	fi
 
-	local new_content
-	new_content=$(_build_graduation_content "$tmp_dir")
-
-	_ensure_graduated_file "$target_file"
-
-	# Append graduated content
-	echo "$new_content" >>"$target_file"
-
-	# Mark memories as graduated in the DB
-	mark_graduated "${graduated_ids[@]}"
-
-	log_success "Graduated $graduated_count memories ($skipped_count skipped as metadata)"
-	log_info "Updated: $target_file"
-	log_info "Remember to commit and push the changes."
-
+	_graduate_write_and_mark "$tmp_dir" "$target_file" \
+		"$graduated_count" "$skipped_count" "${graduated_ids[@]+"${graduated_ids[@]}"}"
 	return 0
 }
 

--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -666,6 +666,23 @@ _act_on_findings() {
 	return 0
 }
 
+# Iterate over monitored processes, accumulate RSS/count, run per-process checks.
+# Modifies caller-scope total_rss_mb and process_count (must be declared before call).
+# Also populates _check_findings[], _check_has_critical, _check_has_warning via
+# _check_process_rss_and_runtime().
+_do_check_per_process() {
+	local processes
+	processes=$(_collect_monitored_processes)
+
+	while IFS='|' read -r pid rss_mb runtime cmd_name full_cmd; do
+		[[ -z "$pid" ]] && continue
+		process_count=$((process_count + 1))
+		total_rss_mb=$((total_rss_mb + rss_mb))
+		_check_process_rss_and_runtime "$pid" "$rss_mb" "$runtime" "$cmd_name"
+	done <<<"$processes"
+	return 0
+}
+
 # Evaluate all monitored processes and generate alerts.
 # Returns: 0=ok, 1=warnings found, 2=critical findings
 do_check() {
@@ -680,15 +697,7 @@ do_check() {
 	local process_count=0
 
 	# Phase 1: Per-process checks
-	local processes
-	processes=$(_collect_monitored_processes)
-
-	while IFS='|' read -r pid rss_mb runtime cmd_name full_cmd; do
-		[[ -z "$pid" ]] && continue
-		process_count=$((process_count + 1))
-		total_rss_mb=$((total_rss_mb + rss_mb))
-		_check_process_rss_and_runtime "$pid" "$rss_mb" "$runtime" "$cmd_name"
-	done <<<"$processes"
+	_do_check_per_process
 
 	# Phases 2+3: Aggregate and OS checks
 	_check_aggregate_and_os "$total_rss_mb" "$process_count"

--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -450,24 +450,14 @@ _recall_output() {
 }
 
 #######################################
-# Recall learnings with search
+# Unpack parsed KEY=VALUE pairs into local variables for cmd_recall
+# Usage: _recall_unpack_args <parsed_string>
+# Sets: query limit type_filter max_age_days project_filter format
+#       recent_mode semantic_mode hybrid_mode shared_mode
+#       auto_only manual_only entity_filter
 #######################################
-cmd_recall() {
-	# Handle --stats early exit before argument parsing
-	local arg
-	for arg in "$@"; do
-		if [[ "$arg" == "--stats" ]]; then
-			cmd_stats
-			return $?
-		fi
-	done
-
-	# Parse arguments into KEY=VALUE pairs
-	local parsed
-	parsed=$(_recall_parse_args "$@") || return $?
-
-	local query limit type_filter max_age_days project_filter format
-	local recent_mode semantic_mode hybrid_mode shared_mode auto_only manual_only entity_filter
+_recall_unpack_args() {
+	local parsed="$1"
 	while IFS='=' read -r key val; do
 		case "$key" in
 		query) query="$val" ;;
@@ -485,6 +475,73 @@ cmd_recall() {
 		entity_filter) entity_filter="$val" ;;
 		esac
 	done <<<"$parsed"
+	return 0
+}
+
+#######################################
+# Execute FTS5 search: build query/filters, search DB, update access, shared search.
+# Caller must have: query limit type_filter max_age_days project_filter
+#                   auto_only manual_only entity_filter shared_mode MEMORY_DB
+# Outputs: sets results and shared_results in caller scope
+#######################################
+_recall_execute_fts() {
+	# Build FTS5 parameterised query
+	param_query=$(_recall_build_fts_param "$query")
+
+	# Build extra filters (validates type/age/project)
+	extra_filters=$(_recall_build_extra_filters "$type_filter" "$max_age_days" "$project_filter") || return $?
+
+	# Build auto-capture filter for FTS query (uses full table name, no alias)
+	auto_join_filter=""
+	if [[ "$auto_only" == true ]]; then
+		auto_join_filter="AND COALESCE(learning_access.auto_captured, 0) = 1"
+	elif [[ "$manual_only" == true ]]; then
+		auto_join_filter="AND COALESCE(learning_access.auto_captured, 0) = 0"
+	fi
+
+	# Build entity clauses for FTS5 (no alias support)
+	local entity_fts_clauses
+	entity_fts_clauses=$(_recall_build_entity_fts_clauses "$entity_filter")
+	entity_fts_join=$(printf '%s' "$entity_fts_clauses" | head -1)
+	entity_fts_where=$(printf '%s' "$entity_fts_clauses" | tail -1)
+
+	# Execute FTS5 search and update access tracking
+	results=$(_recall_search_db "$MEMORY_DB" "$param_query" \
+		"$entity_fts_join" "$entity_fts_where" \
+		"$extra_filters" "$auto_join_filter" "$limit")
+	_recall_update_access "$MEMORY_DB" "$results"
+
+	# Shared search: also query global DB when in a namespace with --shared
+	shared_results=""
+	if [[ "$shared_mode" == true && -n "$MEMORY_NAMESPACE" ]]; then
+		shared_results=$(_recall_shared_search "$param_query" \
+			"$entity_fts_join" "$entity_fts_where" \
+			"$extra_filters" "$auto_join_filter" "$limit")
+	fi
+	return 0
+}
+
+#######################################
+# Recall learnings with search
+#######################################
+cmd_recall() {
+	# Handle --stats early exit before argument parsing
+	local arg
+	for arg in "$@"; do
+		if [[ "$arg" == "--stats" ]]; then
+			cmd_stats
+			return $?
+		fi
+	done
+
+	# Parse arguments into KEY=VALUE pairs
+	local parsed
+	parsed=$(_recall_parse_args "$@") || return $?
+
+	local query="" limit="" type_filter="" max_age_days="" project_filter="" format=""
+	local recent_mode="" semantic_mode="" hybrid_mode="" shared_mode=""
+	local auto_only="" manual_only="" entity_filter=""
+	_recall_unpack_args "$parsed"
 
 	init_db
 
@@ -523,42 +580,11 @@ cmd_recall() {
 		return $?
 	fi
 
-	# Build FTS5 parameterised query
-	local param_query
-	param_query=$(_recall_build_fts_param "$query")
-
-	# Build extra filters (validates type/age/project)
-	local extra_filters
-	extra_filters=$(_recall_build_extra_filters "$type_filter" "$max_age_days" "$project_filter") || return $?
-
-	# Build auto-capture filter for FTS query (uses full table name, no alias)
-	local auto_join_filter=""
-	if [[ "$auto_only" == true ]]; then
-		auto_join_filter="AND COALESCE(learning_access.auto_captured, 0) = 1"
-	elif [[ "$manual_only" == true ]]; then
-		auto_join_filter="AND COALESCE(learning_access.auto_captured, 0) = 0"
-	fi
-
-	# Build entity clauses for FTS5 (no alias support)
-	local entity_fts_clauses entity_fts_join entity_fts_where
-	entity_fts_clauses=$(_recall_build_entity_fts_clauses "$entity_filter")
-	entity_fts_join=$(printf '%s' "$entity_fts_clauses" | head -1)
-	entity_fts_where=$(printf '%s' "$entity_fts_clauses" | tail -1)
-
-	# Execute FTS5 search and update access tracking
-	local results
-	results=$(_recall_search_db "$MEMORY_DB" "$param_query" \
-		"$entity_fts_join" "$entity_fts_where" \
-		"$extra_filters" "$auto_join_filter" "$limit")
-	_recall_update_access "$MEMORY_DB" "$results"
-
-	# Shared search: also query global DB when in a namespace with --shared
-	local shared_results=""
-	if [[ "$shared_mode" == true && -n "$MEMORY_NAMESPACE" ]]; then
-		shared_results=$(_recall_shared_search "$param_query" \
-			"$entity_fts_join" "$entity_fts_where" \
-			"$extra_filters" "$auto_join_filter" "$limit")
-	fi
+	# Execute FTS5 search (builds query, filters, entity clauses, shared search)
+	local param_query extra_filters auto_join_filter
+	local entity_fts_join="" entity_fts_where=""
+	local results="" shared_results=""
+	_recall_execute_fts || return $?
 
 	_recall_output "$format" "$query" "$entity_filter" "$results" "$shared_results" "$limit"
 	return 0

--- a/.agents/scripts/mission-dashboard-helper.sh
+++ b/.agents/scripts/mission-dashboard-helper.sh
@@ -495,7 +495,10 @@ _status_print_blockers() {
 # CLI Dashboard Command
 # =============================================================================
 
-cmd_status() {
+# Parse --mission and --verbose flags for cmd_status.
+# Usage: _status_parse_args "$@"
+# Outputs: newline-separated KEY=VALUE pairs
+_status_parse_args() {
 	local mission_filter="" verbose=false
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -510,6 +513,23 @@ cmd_status() {
 		*) shift ;;
 		esac
 	done
+	printf '%s\n' \
+		"mission_filter=${mission_filter}" \
+		"verbose=${verbose}"
+	return 0
+}
+
+cmd_status() {
+	local parsed
+	parsed=$(_status_parse_args "$@")
+
+	local mission_filter="" verbose=""
+	while IFS='=' read -r key val; do
+		case "$key" in
+		mission_filter) mission_filter="$val" ;;
+		verbose) verbose="$val" ;;
+		esac
+	done <<<"$parsed"
 
 	local -a mission_files=()
 	while IFS= read -r f; do
@@ -678,6 +698,29 @@ _json_build_mission() {
 # JSON Output Command
 # =============================================================================
 
+# Build the missions JSON array from a list of mission files.
+# Args: mission_filter mission_files...
+# Outputs: JSON array string to stdout
+_json_build_missions_array() {
+	local mission_filter="$1"
+	shift
+	local mission_files=("$@")
+
+	local missions_json="["
+	local first_mission=true
+	for mission_file in "${mission_files[@]}"; do
+		local mission_obj
+		mission_obj=$(_json_build_mission "$mission_file" "$mission_filter")
+		[[ -z "$mission_obj" ]] && continue
+		[[ "$first_mission" == "true" ]] || missions_json="${missions_json},"
+		first_mission=false
+		missions_json="${missions_json}${mission_obj}"
+	done
+	missions_json="${missions_json}]"
+	printf '%s' "$missions_json"
+	return 0
+}
+
 cmd_json() {
 	local mission_filter=""
 	while [[ $# -gt 0 ]]; do
@@ -706,17 +749,8 @@ cmd_json() {
 	burn_json=$(get_burn_rate_json)
 	cost_json=$(get_cost_status_json)
 
-	local missions_json="["
-	local first_mission=true
-	for mission_file in "${mission_files[@]}"; do
-		local mission_obj
-		mission_obj=$(_json_build_mission "$mission_file" "$mission_filter")
-		[[ -z "$mission_obj" ]] && continue
-		[[ "$first_mission" == "true" ]] || missions_json="${missions_json},"
-		first_mission=false
-		missions_json="${missions_json}${mission_obj}"
-	done
-	missions_json="${missions_json}]"
+	local missions_json
+	missions_json=$(_json_build_missions_array "$mission_filter" "${mission_files[@]+"${mission_files[@]}"}")
 
 	# Assemble full dashboard JSON.
 	# Note: bash ${var:-{}} is ambiguous — the first } closes the expansion.


### PR DESCRIPTION
## Summary

Extracts focused helper functions from oversized functions across 4 scripts to reduce complexity. No behavior changes.

## Changes

### memory-graduate-helper.sh (closes #5766)
- Extract `_candidates_parse_args()` from `cmd_candidates()` — arg parsing loop
- Extract `_graduate_parse_args()`, `_graduate_collect_and_read()`, `_graduate_write_and_mark()` from `cmd_graduate()`
- `cmd_graduate()`: 89 lines → 56 lines

### memory-pressure-monitor.sh (closes #5765)
- Extract `_do_check_per_process()` from `do_check()` — the process iteration loop
- `do_check()`: 35 lines → 27 lines

### memory/recall.sh (closes #5764)
- Extract `_recall_unpack_args()` — unpacks parsed KEY=VALUE pairs into local variables
- Extract `_recall_execute_fts()` — builds FTS5 query/filters, executes search, handles shared search
- `cmd_recall()`: 111 lines → 65 lines (the genuine >100 line violation)

### mission-dashboard-helper.sh (closes #5763)
- Extract `_status_parse_args()` from `cmd_status()` — flag parsing
- Extract `_json_build_missions_array()` from `cmd_json()` — mission JSON array construction
- `cmd_status()`: 42 lines → 38 lines; `cmd_json()`: 57 lines → 48 lines

## Verification

- `bash -n` syntax check: all 4 files pass
- `shellcheck`: no new violations (pre-existing SC1091 info-level warnings unchanged)
- All extracted functions are under 100 lines
- No logic changes — pure structural extraction

Closes #5766
Closes #5765
Closes #5764
Closes #5763