### PR TITLE
refactor: extract sub-functions to reduce complexity in 4 scripts

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -865,6 +865,113 @@ _validate_run_args() {
 	return 0
 }
 
+# _build_run_cmd: build the opencode command array for a run attempt.
+# Args: selected_model work_dir prompt title agent_name persisted_session
+#       extra_args (remaining positional args)
+# Outputs: space-separated command (caller must eval or use array assignment).
+# Returns: 0 always.
+_build_run_cmd() {
+	local selected_model="$1"
+	local work_dir="$2"
+	local prompt="$3"
+	local title="$4"
+	local agent_name="$5"
+	local persisted_session="$6"
+	shift 6
+
+	# Emit base command args as null-delimited tokens (bash 3.2 compat: no local -a in subshell)
+	printf '%s\0' "$OPENCODE_BIN_DEFAULT" run "$prompt" --dir "$work_dir" -m "$selected_model" --title "$title" --format json
+	if [[ -n "$agent_name" ]]; then
+		printf '%s\0' --agent "$agent_name"
+	fi
+	if [[ -n "$persisted_session" ]]; then
+		printf '%s\0' --session "$persisted_session" --continue
+	fi
+	# Emit any extra args passed as positional parameters
+	while [[ $# -gt 0 ]]; do
+		printf '%s\0' "$1"
+		shift
+	done
+	return 0
+}
+
+# _invoke_opencode: run the opencode command (with or without sandbox) and capture output.
+# Args: output_file exit_code_file cmd_args (null-delimited, read from stdin via process sub)
+# Caller passes the cmd array elements as positional args after the two file args.
+# Returns: 0 always (exit code written to exit_code_file).
+_invoke_opencode() {
+	local output_file="$1"
+	local exit_code_file="$2"
+	shift 2
+	local -a cmd=("$@")
+
+	# Run in subshell to avoid fragile set +e/set -e toggling (GH#4225).
+	# Subshell localises errexit so main shell state is never modified.
+	# Exit code is written to a temp file — NOT captured via $() — because
+	# tee stdout would contaminate the $() capture (bash 3.2 has no clean
+	# way to separate tee output from the exit code in a single $()).
+	(
+		set +e
+		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
+			# Pass cmd array elements as separate arguments after --.
+			# Previous code used printf -v to build a single escaped string,
+			# which the sandbox received as one argument and passed to env as
+			# a single executable path — causing "No such file or directory".
+			# Bash 3.2 compat: no local -a in subshells, no printf -v tricks.
+			local passthrough_csv
+			passthrough_csv="$(build_sandbox_passthrough_csv)"
+			if [[ -n "$passthrough_csv" ]]; then
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+			else
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
+			fi
+			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
+		else
+			"${cmd[@]}" 2>&1 | tee "$output_file"
+			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
+		fi
+	) || true
+	return 0
+}
+
+# _handle_run_result: process output_file after opencode exits.
+# Args: exit_code output_file role provider session_key selected_model
+# Sets caller variable _run_failure_reason on failure.
+# Returns: 0 success, 75 no-activity backoff, non-zero on failure.
+_handle_run_result() {
+	local exit_code="$1"
+	local output_file="$2"
+	local role="$3"
+	local provider="$4"
+	local session_key="$5"
+	local selected_model="$6"
+
+	local discovered_session activity_detected
+	discovered_session=$(extract_session_id_from_output "$output_file")
+	activity_detected=$(output_has_activity "$output_file")
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		if [[ "$activity_detected" != "1" ]]; then
+			record_provider_backoff "$provider" "provider_error" "$output_file" "$selected_model"
+			rm -f "$output_file"
+			print_warning "$selected_model returned exit 0 without any model activity; backing off model"
+			return 75
+		fi
+		if [[ "$role" != "pulse" && -n "$discovered_session" ]]; then
+			store_session_id "$provider" "$session_key" "$discovered_session" "$selected_model"
+		fi
+		rm -f "$output_file"
+		return 0
+	fi
+
+	local failure_reason
+	failure_reason=$(classify_failure_reason "$output_file")
+	record_provider_backoff "$provider" "$failure_reason" "$output_file" "$selected_model"
+	rm -f "$output_file"
+	_run_failure_reason="$failure_reason"
+	return "$exit_code"
+}
+
 # _execute_run_attempt: run one opencode invocation and handle the result.
 # Args: role session_key work_dir title prompt selected_model agent_name model_override
 #       extra_args (array passed as remaining positional args after the named ones)
@@ -895,74 +1002,23 @@ _execute_run_attempt() {
 		persisted_session=$(get_session_id "$provider" "$session_key")
 	fi
 
-	local -a cmd=("$OPENCODE_BIN_DEFAULT" run "$prompt" --dir "$work_dir" -m "$selected_model" --title "$title" --format json)
-	if [[ -n "$agent_name" ]]; then
-		cmd+=(--agent "$agent_name")
-	fi
-	if [[ -n "$persisted_session" ]]; then
-		cmd+=(--session "$persisted_session" --continue)
-	fi
-	if [[ ${#extra_args[@]} -gt 0 ]]; then
-		cmd+=("${extra_args[@]}")
-	fi
+	local -a cmd=()
+	while IFS= read -r -d '' arg; do
+		cmd+=("$arg")
+	done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
+		"$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
 
 	local output_file exit_code_file exit_code
 	output_file=$(mktemp)
 	exit_code_file=$(mktemp)
 	exit_code=0
-	# Run in subshell to avoid fragile set +e/set -e toggling (GH#4225).
-	# Subshell localises errexit so main shell state is never modified.
-	# Exit code is written to a temp file — NOT captured via $() — because
-	# tee stdout would contaminate the $() capture (bash 3.2 has no clean
-	# way to separate tee output from the exit code in a single $()).
-	(
-		set +e
-		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
-			# Pass cmd array elements as separate arguments after --.
-			# Previous code used printf -v to build a single escaped string,
-			# which the sandbox received as one argument and passed to env as
-			# a single executable path — causing "No such file or directory".
-			# Bash 3.2 compat: no local -a in subshells, no printf -v tricks.
-			local passthrough_csv
-			passthrough_csv="$(build_sandbox_passthrough_csv)"
-			if [[ -n "$passthrough_csv" ]]; then
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
-			else
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
-			fi
-			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
-		else
-			"${cmd[@]}" 2>&1 | tee "$output_file"
-			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
-		fi
-	) || true
+
+	_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
 	exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
 	rm -f "$exit_code_file"
 
-	local discovered_session activity_detected
-	discovered_session=$(extract_session_id_from_output "$output_file")
-	activity_detected=$(output_has_activity "$output_file")
-
-	if [[ "$exit_code" -eq 0 ]]; then
-		if [[ "$activity_detected" != "1" ]]; then
-			record_provider_backoff "$provider" "provider_error" "$output_file" "$selected_model"
-			rm -f "$output_file"
-			print_warning "$selected_model returned exit 0 without any model activity; backing off model"
-			return 75
-		fi
-		if [[ "$role" != "pulse" && -n "$discovered_session" ]]; then
-			store_session_id "$provider" "$session_key" "$discovered_session" "$selected_model"
-		fi
-		rm -f "$output_file"
-		return 0
-	fi
-
-	local failure_reason
-	failure_reason=$(classify_failure_reason "$output_file")
-	record_provider_backoff "$provider" "$failure_reason" "$output_file" "$selected_model"
-	rm -f "$output_file"
-	_run_failure_reason="$failure_reason"
-	return "$exit_code"
+	_handle_run_result "$exit_code" "$output_file" "$role" "$provider" "$session_key" "$selected_model"
+	return $?
 }
 
 cmd_run() {

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -1203,6 +1203,58 @@ check_secret_policy() {
 # results — no error message, just broken behaviour. ShellCheck does NOT catch
 # most version incompatibilities, so this is a dedicated scanner.
 
+# _scan_bash32_file: scan a single file for bash 4.0+ incompatibilities.
+# Appends findings to tmp_file. Args: $1=file $2=tmp_file
+# Returns: 0 always.
+_scan_bash32_file() {
+	local file="$1"
+	local tmp_file="$2"
+
+	# declare -A / local -A (associative arrays — bash 4.0+)
+	grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-A[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+		printf '%s:%s [associative array — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+	done
+
+	# mapfile / readarray (bash 4.0+)
+	grep -nE '^[[:space:]]*(mapfile|readarray)[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+		printf '%s:%s [mapfile/readarray — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+	done
+
+	# ${var,,} / ${var^^} case conversion (bash 4.0+)
+	# Exclude comments — grep -n prefixes "NNN:" so comments appear as "NNN:\s*#"
+	grep -n ',,}' "$file" 2>/dev/null | grep '\${' | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
+		printf '%s:%s [case conversion ,,} — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+	done
+	grep -n '^^}' "$file" 2>/dev/null | grep '\${' | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
+		printf '%s:%s [case conversion ^^} — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+	done
+
+	# declare -n / local -n namerefs (bash 4.3+)
+	grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+		printf '%s:%s [nameref — bash 4.3+]\n' "$file" "$line" >>"$tmp_file"
+	done
+
+	# coproc (bash 4.0+)
+	grep -nE '^[[:space:]]*coproc[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+		printf '%s:%s [coproc — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+	done
+
+	# &>> append-both (bash 4.0+)
+	grep -n '&>>' "$file" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
+		printf '%s:%s [&>> append — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+	done
+
+	# "\t" or "\n" in string concatenation (likely wants $'\t' or $'\n')
+	# Only flag += or = assignments, not awk/sed/printf/echo -e/python contexts
+	grep -nE '\+="\\[tn]|="\\[tn]' "$file" 2>/dev/null |
+		grep -vE '^[0-9]+:[[:space:]]*#' |
+		grep -vE 'awk|sed|printf|echo.*-e|python|f\.write|gsub|join|split|print |replace|coords|excerpt|delimiter|regex|pattern' |
+		while IFS= read -r line; do
+			printf '%s:%s ["\t"/"\n" — use $'"'"'\\t'"'"' or $'"'"'\\n'"'"' for actual whitespace]\n' "$file" "$line" >>"$tmp_file"
+		done
+	return 0
+}
+
 check_bash32_compat() {
 	echo -e "${BLUE}Checking Bash 3.2 Compatibility...${NC}"
 
@@ -1222,49 +1274,7 @@ check_bash32_compat() {
 	for file in "${ALL_SH_FILES[@]}"; do
 		[[ -f "$file" ]] || continue
 		[[ "$(basename "$file")" == "$self_basename" ]] && continue
-
-		# declare -A / local -A (associative arrays — bash 4.0+)
-		grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-A[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
-			printf '%s:%s [associative array — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
-		done
-
-		# mapfile / readarray (bash 4.0+)
-		grep -nE '^[[:space:]]*(mapfile|readarray)[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
-			printf '%s:%s [mapfile/readarray — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
-		done
-
-		# ${var,,} / ${var^^} case conversion (bash 4.0+)
-		# Exclude comments — grep -n prefixes "NNN:" so comments appear as "NNN:\s*#"
-		grep -n ',,}' "$file" 2>/dev/null | grep '\${' | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
-			printf '%s:%s [case conversion ,,} — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
-		done
-		grep -n '^^}' "$file" 2>/dev/null | grep '\${' | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
-			printf '%s:%s [case conversion ^^} — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
-		done
-
-		# declare -n / local -n namerefs (bash 4.3+)
-		grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
-			printf '%s:%s [nameref — bash 4.3+]\n' "$file" "$line" >>"$tmp_file"
-		done
-
-		# coproc (bash 4.0+)
-		grep -nE '^[[:space:]]*coproc[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
-			printf '%s:%s [coproc — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
-		done
-
-		# &>> append-both (bash 4.0+)
-		grep -n '&>>' "$file" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
-			printf '%s:%s [&>> append — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
-		done
-
-		# "\t" or "\n" in string concatenation (likely wants $'\t' or $'\n')
-		# Only flag += or = assignments, not awk/sed/printf/echo -e/python contexts
-		grep -nE '\+="\\[tn]|="\\[tn]' "$file" 2>/dev/null |
-			grep -vE '^[0-9]+:[[:space:]]*#' |
-			grep -vE 'awk|sed|printf|echo.*-e|python|f\.write|gsub|join|split|print |replace|coords|excerpt|delimiter|regex|pattern' |
-			while IFS= read -r line; do
-				printf '%s:%s ["\t"/"\n" — use $'"'"'\\t'"'"' or $'"'"'\\n'"'"' for actual whitespace]\n' "$file" "$line" >>"$tmp_file"
-			done
+		_scan_bash32_file "$file" "$tmp_file"
 	done
 
 	if [[ -s "$tmp_file" ]]; then
@@ -1343,10 +1353,9 @@ should_skip_gate() {
 	return 1
 }
 
-# Run all gate checks in order, respecting bundle skip_gates.
-# Writes to the exit_code variable in the caller's scope via a temp file.
-# Returns: 0 if all gates passed, 1 if any gate failed.
-_run_gate_checks() {
+# _run_gate_checks_static: run static analysis gates (sonarcloud through secret-policy).
+# Returns: 0 if all passed, 1 if any failed.
+_run_gate_checks_static() {
 	local exit_code=0
 
 	if ! should_skip_gate "sonarcloud"; then
@@ -1409,6 +1418,14 @@ _run_gate_checks() {
 		echo ""
 	fi
 
+	return $exit_code
+}
+
+# _run_gate_checks_complexity: run complexity and compatibility gates (bash32 through python).
+# Returns: 0 if all passed, 1 if any failed.
+_run_gate_checks_complexity() {
+	local exit_code=0
+
 	if ! should_skip_gate "bash32-compat"; then
 		check_bash32_compat || exit_code=1
 		echo ""
@@ -1433,6 +1450,17 @@ _run_gate_checks() {
 		check_python_complexity || exit_code=1
 		echo ""
 	fi
+
+	return $exit_code
+}
+
+# Run all gate checks in order, respecting bundle skip_gates.
+# Returns: 0 if all gates passed, 1 if any gate failed.
+_run_gate_checks() {
+	local exit_code=0
+
+	_run_gate_checks_static || exit_code=1
+	_run_gate_checks_complexity || exit_code=1
 
 	return $exit_code
 }

--- a/.agents/scripts/list-todo-helper.sh
+++ b/.agents/scripts/list-todo-helper.sh
@@ -752,9 +752,9 @@ require_arg() {
 	fi
 }
 
-# Main
-main() {
-	# Parse command line
+# Parse command-line arguments and set global option variables.
+# Returns: 0 on success, exits on error or --help.
+_parse_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--priority | -p) SORT_BY="priority" ;;
@@ -813,6 +813,12 @@ main() {
 		esac
 		shift
 	done
+	return 0
+}
+
+# Main
+main() {
+	_parse_args "$@"
 
 	# Disable colors if requested or not a terminal
 	# shellcheck disable=SC2034

--- a/.agents/scripts/list-verify-helper.sh
+++ b/.agents/scripts/list-verify-helper.sh
@@ -195,6 +195,56 @@ _count_entries() {
 	return 0
 }
 
+# _print_section_header: print the markdown table header for a section.
+# Args: $1 = section name (failed|pending|passed)
+# Returns: 0 always.
+_print_section_header() {
+	local section="$1"
+	case "$section" in
+	failed)
+		echo "| # | Verify | Task | Description | PR | Merged | Reason |"
+		echo "|---|--------|------|-------------|-----|--------|--------|"
+		;;
+	pending)
+		echo "| # | Verify | Task | Description | PR | Merged | Checks |"
+		echo "|---|--------|------|-------------|-----|--------|--------|"
+		;;
+	passed)
+		echo "| # | Verify | Task | Description | PR | Merged | Verified |"
+		echo "|---|--------|------|-------------|-----|--------|----------|"
+		;;
+	esac
+	return 0
+}
+
+# _print_section_rows: print table rows for a section from entries_file.
+# Args: $1 = section name, $2 = entries_file
+# Returns: 0 always.
+_print_section_rows() {
+	local section="$1"
+	local entries_file="$2"
+	local num=0
+
+	while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
+		[[ "$status" != "$section" ]] && continue
+		((++num))
+		case "$section" in
+		failed)
+			echo "| $num | $vid | $tid | $desc | $pr | $merged | ${failed_reason:--} |"
+			;;
+		pending)
+			local check_count=0
+			[[ -n "$checks" ]] && check_count=$(echo "$checks" | tr ';' '\n' | wc -l | tr -d ' ')
+			echo "| $num | $vid | $tid | $desc | $pr | $merged | ${check_count} checks |"
+			;;
+		passed)
+			echo "| $num | $vid | $tid | $desc | $pr | $merged | ${verified:--} |"
+			;;
+		esac
+	done <"$entries_file"
+	return 0
+}
+
 # Render one status section (failed / pending / passed) in markdown
 # Args: $1 = section name, $2 = count, $3 = entries_file, $4 = color code
 _output_markdown_section() {
@@ -225,38 +275,8 @@ _output_markdown_section() {
 			esac
 		done <"$entries_file"
 	else
-		case "$section" in
-		failed)
-			echo "| # | Verify | Task | Description | PR | Merged | Reason |"
-			echo "|---|--------|------|-------------|-----|--------|--------|"
-			;;
-		pending)
-			echo "| # | Verify | Task | Description | PR | Merged | Checks |"
-			echo "|---|--------|------|-------------|-----|--------|--------|"
-			;;
-		passed)
-			echo "| # | Verify | Task | Description | PR | Merged | Verified |"
-			echo "|---|--------|------|-------------|-----|--------|----------|"
-			;;
-		esac
-		local num=0
-		while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
-			[[ "$status" != "$section" ]] && continue
-			((++num))
-			case "$section" in
-			failed)
-				echo "| $num | $vid | $tid | $desc | $pr | $merged | ${failed_reason:--} |"
-				;;
-			pending)
-				local check_count=0
-				[[ -n "$checks" ]] && check_count=$(echo "$checks" | tr ';' '\n' | wc -l | tr -d ' ')
-				echo "| $num | $vid | $tid | $desc | $pr | $merged | ${check_count} checks |"
-				;;
-			passed)
-				echo "| $num | $vid | $tid | $desc | $pr | $merged | ${verified:--} |"
-				;;
-			esac
-		done <"$entries_file"
+		_print_section_header "$section"
+		_print_section_rows "$section" "$entries_file"
 	fi
 	echo ""
 	echo "---"


### PR DESCRIPTION
## Summary

Reduces function complexity in 4 scripts by extracting sub-functions from functions exceeding 100 lines. No behavior changes.

Closes #5774
Closes #5773
Closes #5772
Closes #5771

## Changes

### headless-runtime-helper.sh (#5774)

`_execute_run_attempt()` (92 lines) decomposed into 3 focused helpers:
- `_build_run_cmd()` — constructs the opencode command array (null-delimited output for bash 3.2 compat)
- `_invoke_opencode()` — runs the command via sandbox or direct execution
- `_handle_run_result()` — processes output file, records backoff, stores session ID
- `_execute_run_attempt()` reduced to ~30 lines (orchestration only)

### linters-local.sh (#5773)

`check_bash32_compat()` (84 lines) and `_run_gate_checks()` (89 lines) decomposed:
- `_scan_bash32_file()` — per-file grep loops for bash 4.0+ patterns (extracted from `check_bash32_compat`)
- `_run_gate_checks_static()` — sonarcloud through secret-policy gates
- `_run_gate_checks_complexity()` — bash32-compat through python-complexity gates
- `_run_gate_checks()` reduced to 8 lines (calls the two halves)

### list-todo-helper.sh (#5772)

`main()` (72 lines) decomposed:
- `_parse_args()` — CLI argument parsing loop (60 lines)
- `main()` reduced to ~20 lines (calls `_parse_args`, finds project, runs output)

### list-verify-helper.sh (#5771)

`_output_markdown_section()` (65 lines) decomposed:
- `_print_section_header()` — emits the markdown table header for a section
- `_print_section_rows()` — iterates entries and emits table rows
- `_output_markdown_section()` reduced to ~30 lines

## Verification

- `bash -n` syntax check: all 4 files pass
- `shellcheck --severity=warning`: zero violations on all 4 files
- No behavior changes: all extracted functions are pure refactors with identical logic