### PR TITLE
refactor: reduce function complexity in ip-reputation-helper.sh

### DIFF
--- a/.agents/scripts/ip-reputation-helper.sh
+++ b/.agents/scripts/ip-reputation-helper.sh
@@ -557,9 +557,105 @@ get_available_providers() {
 # Provider Execution
 # =============================================================================
 
-# Run a single provider and write JSON result to stdout
-# Checks rate limits and SQLite cache first; falls back to live query on miss/expiry
-# Detects HTTP 429 (rate_limited error) and retries with exponential backoff
+# Execute a single provider attempt; handle rate-limit 429 and cache writes.
+# Outputs JSON result to stdout. Returns 0 always (errors encoded in JSON).
+# Called by _run_provider_with_retry inside the retry loop.
+_run_provider_attempt() {
+	local provider="$1"
+	local ip="$2"
+	local script_path="$3"
+	local timeout_secs="$4"
+	local use_cache="$5"
+	local attempt="$6"
+	local max_retries="$7"
+	local backoff="$8"
+
+	local result
+	local run_cmd=(timeout_sec "$timeout_secs" "$script_path" check "$ip")
+
+	if result=$("${run_cmd[@]}" 2>/dev/null); then
+		if echo "$result" | jq empty 2>/dev/null; then
+			local error_type
+			error_type=$(echo "$result" | jq -r '.error // empty')
+			if [[ "$error_type" == "rate_limited" || "$error_type" == *"429"* || "$error_type" == *"rate limit"* ]]; then
+				local retry_after
+				retry_after=$(echo "$result" | jq -r '.retry_after // 60')
+				rate_limit_record "$provider" "$retry_after"
+				if [[ "$attempt" -lt "$max_retries" ]]; then
+					local jitter=$((RANDOM % backoff))
+					local backoff_with_jitter=$((backoff + jitter))
+					log_warn "Provider '${provider}' returned 429 — retry $((attempt + 1))/${max_retries} in ${backoff_with_jitter}s"
+					sleep "$backoff_with_jitter" 2>/dev/null || true
+					# Signal caller to retry: print sentinel + new backoff
+					echo "__RETRY__ $((backoff * 2))"
+					return 0
+				fi
+				echo "$result"
+				return 0
+			fi
+			# Only cache successful (non-error) results
+			if [[ -z "$error_type" && "$use_cache" == "true" ]]; then
+				local ttl
+				ttl=$(provider_cache_ttl "$provider")
+				cache_put "$ip" "$provider" "$result" "$ttl"
+			fi
+			echo "$result"
+		else
+			jq -n \
+				--arg provider "$provider" \
+				--arg ip "$ip" \
+				'{provider: $provider, ip: $ip, error: "invalid_json_response", is_listed: false, score: 0, risk_level: "unknown"}'
+		fi
+		return 0
+	else
+		local exit_code=$?
+		local err_msg
+		if [[ $exit_code -eq 124 ]]; then
+			err_msg="timeout after ${timeout_secs}s"
+		else
+			err_msg="provider failed (exit ${exit_code})"
+		fi
+		jq -n \
+			--arg provider "$provider" \
+			--arg ip "$ip" \
+			--arg error "$err_msg" \
+			'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+		return 0
+	fi
+}
+
+# Retry loop with exponential backoff for rate limit (429) responses.
+# Outputs JSON result to stdout. Returns 0 always.
+_run_provider_with_retry() {
+	local provider="$1"
+	local ip="$2"
+	local script_path="$3"
+	local timeout_secs="$4"
+	local use_cache="$5"
+
+	local max_retries=2
+	local attempt=0
+	local backoff=2
+
+	while [[ "$attempt" -le "$max_retries" ]]; do
+		local attempt_out
+		attempt_out=$(_run_provider_attempt \
+			"$provider" "$ip" "$script_path" "$timeout_secs" "$use_cache" \
+			"$attempt" "$max_retries" "$backoff")
+		if [[ "$attempt_out" == __RETRY__* ]]; then
+			backoff="${attempt_out#__RETRY__ }"
+			attempt=$((attempt + 1))
+			continue
+		fi
+		echo "$attempt_out"
+		return 0
+	done
+	return 0
+}
+
+# Run a single provider and write JSON result to stdout.
+# Checks script availability, rate limits, and SQLite cache first;
+# falls back to live query on miss/expiry with exponential backoff on 429.
 run_provider() {
 	local provider="$1"
 	local ip="$2"
@@ -592,73 +688,12 @@ run_provider() {
 		local cached
 		cached=$(cache_get "$ip" "$provider")
 		if [[ -n "$cached" ]]; then
-			# Annotate cached result
 			echo "$cached" | jq '. + {cached: true}'
 			return 0
 		fi
 	fi
 
-	# Retry loop with exponential backoff for rate limit (429) responses
-	local max_retries=2
-	local attempt=0
-	local backoff=2
-
-	while [[ "$attempt" -le "$max_retries" ]]; do
-		local result
-		local run_cmd=(timeout_sec "$timeout_secs" "$script_path" check "$ip")
-
-		if result=$("${run_cmd[@]}" 2>/dev/null); then
-			if echo "$result" | jq empty 2>/dev/null; then
-				# Check for rate_limited error from provider script
-				local error_type
-				error_type=$(echo "$result" | jq -r '.error // empty')
-				if [[ "$error_type" == "rate_limited" || "$error_type" == *"429"* || "$error_type" == *"rate limit"* ]]; then
-					local retry_after
-					retry_after=$(echo "$result" | jq -r '.retry_after // 60')
-					rate_limit_record "$provider" "$retry_after"
-					if [[ "$attempt" -lt "$max_retries" ]]; then
-						attempt=$((attempt + 1))
-						local jitter=$((RANDOM % backoff))
-						local backoff_with_jitter=$((backoff + jitter))
-						log_warn "Provider '${provider}' returned 429 — retry ${attempt}/${max_retries} in ${backoff_with_jitter}s"
-						sleep "$backoff_with_jitter" 2>/dev/null || true
-						backoff=$((backoff * 2))
-						continue
-					fi
-					echo "$result"
-					return 0
-				fi
-
-				# Only cache successful (non-error) results
-				if [[ -z "$error_type" && "$use_cache" == "true" ]]; then
-					local ttl
-					ttl=$(provider_cache_ttl "$provider")
-					cache_put "$ip" "$provider" "$result" "$ttl"
-				fi
-				echo "$result"
-			else
-				jq -n \
-					--arg provider "$provider" \
-					--arg ip "$ip" \
-					'{provider: $provider, ip: $ip, error: "invalid_json_response", is_listed: false, score: 0, risk_level: "unknown"}'
-			fi
-			return 0
-		else
-			local exit_code=$?
-			local err_msg
-			if [[ $exit_code -eq 124 ]]; then
-				err_msg="timeout after ${timeout_secs}s"
-			else
-				err_msg="provider failed (exit ${exit_code})"
-			fi
-			jq -n \
-				--arg provider "$provider" \
-				--arg ip "$ip" \
-				--arg error "$err_msg" \
-				'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
-			return 0
-		fi
-	done
+	_run_provider_with_retry "$provider" "$ip" "$script_path" "$timeout_secs" "$use_cache"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Extracts `_run_provider_attempt()` and `_run_provider_with_retry()` from `run_provider()` in `.agents/scripts/ip-reputation-helper.sh`
- `run_provider()` was 101 lines — the only remaining violation across all 4 scanned scripts
- The other 3 scripts (`email-delivery-test-helper.sh`, `email-sieve-helper.sh`, `enhancor-helper.sh`) were already compliant from prior refactoring sessions

## What changed

`run_provider()` split into three focused functions:

| Function | Lines | Responsibility |
|----------|-------|----------------|
| `_run_provider_attempt()` | ~55 | Single execution attempt: run script, detect 429, cache write |
| `_run_provider_with_retry()` | ~20 | Retry loop with exponential backoff |
| `run_provider()` | ~30 | Preflight (availability, rate limit, cache hit) + delegate |

## Verification

- `bash -n`: syntax OK
- `shellcheck`: zero violations
- All functions <= 100 lines (verified with Python brace-depth counter)
- No behaviour changes — pure structural refactor

Closes #5729
Closes #5730
Closes #5731
Closes #5732