### PR TITLE
refactor: reduce function complexity by extracting sub-functions in 4 scripts

### DIFF
--- a/.agents/scripts/keyword-research-helper.sh
+++ b/.agents/scripts/keyword-research-helper.sh
@@ -1751,6 +1751,41 @@ show_help() {
 # Main
 # =============================================================================
 
+# Parse a single filter option (--min-volume, --max-volume, etc.) into _OPT_FILTERS.
+# Arguments: $1=flag_name $2=value
+# Returns 1 if the flag is not a filter option (caller should handle it).
+_parse_filter_option() {
+	local flag="$1"
+	local value="$2"
+	case "$flag" in
+	--min-volume)
+		_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}min-volume:$value"
+		;;
+	--max-volume)
+		_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}max-volume:$value"
+		;;
+	--min-difficulty)
+		_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}min-difficulty:$value"
+		;;
+	--max-difficulty)
+		_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}max-difficulty:$value"
+		;;
+	--intent)
+		_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}intent:$value"
+		;;
+	--contains)
+		_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}contains:$value"
+		;;
+	--excludes)
+		_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}excludes:$value"
+		;;
+	*)
+		return 1
+		;;
+	esac
+	return 0
+}
+
 # Parse CLI options into global variables for main() dispatch
 # Sets: _OPT_KEYWORDS, _OPT_PROVIDER, _OPT_LOCALE, _OPT_LIMIT, _OPT_DAYS,
 #       _OPT_CSV, _OPT_QUICK, _OPT_AHREFS, _OPT_ENRICH, _OPT_MODE,
@@ -1818,32 +1853,8 @@ _parse_options() {
 			_OPT_TARGET="$2"
 			shift 2
 			;;
-		--min-volume)
-			_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}min-volume:$2"
-			shift 2
-			;;
-		--max-volume)
-			_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}max-volume:$2"
-			shift 2
-			;;
-		--min-difficulty)
-			_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}min-difficulty:$2"
-			shift 2
-			;;
-		--max-difficulty)
-			_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}max-difficulty:$2"
-			shift 2
-			;;
-		--intent)
-			_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}intent:$2"
-			shift 2
-			;;
-		--contains)
-			_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}contains:$2"
-			shift 2
-			;;
-		--excludes)
-			_OPT_FILTERS="${_OPT_FILTERS:+$_OPT_FILTERS,}excludes:$2"
+		--min-volume | --max-volume | --min-difficulty | --max-difficulty | --intent | --contains | --excludes)
+			_parse_filter_option "$1" "$2"
 			shift 2
 			;;
 		-*)

--- a/.agents/scripts/milestone-validation-worker.sh
+++ b/.agents/scripts/milestone-validation-worker.sh
@@ -265,25 +265,10 @@ validate_parsed_inputs() {
 	return 0
 }
 
-parse_args() {
-	# Check for --help before positional arg validation
-	for arg in "$@"; do
-		if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-			show_help
-			exit 0
-		fi
-	done
-
-	if [[ $# -lt 2 ]]; then
-		log_error "Missing required arguments: mission-file and milestone-number"
-		show_help
-		return 2
-	fi
-
-	MISSION_FILE="$1"
-	MILESTONE_NUM="$2"
-	shift 2
-
+# Parse the optional flags after positional arguments.
+# Modifies global config variables (REPO_PATH, BROWSER_TESTS, etc.).
+# Returns 2 on invalid option or missing value.
+_parse_args_options() {
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
@@ -350,6 +335,29 @@ parse_args() {
 			;;
 		esac
 	done
+	return 0
+}
+
+parse_args() {
+	# Check for --help before positional arg validation
+	for arg in "$@"; do
+		if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+			show_help
+			exit 0
+		fi
+	done
+
+	if [[ $# -lt 2 ]]; then
+		log_error "Missing required arguments: mission-file and milestone-number"
+		show_help
+		return 2
+	fi
+
+	MISSION_FILE="$1"
+	MILESTONE_NUM="$2"
+	shift 2
+
+	_parse_args_options "$@" || return $?
 
 	validate_parsed_inputs
 }

--- a/.agents/scripts/mission-email-helper.sh
+++ b/.agents/scripts/mission-email-helper.sh
@@ -377,20 +377,10 @@ _record_sent_message() {
 }
 
 #######################################
-# Send a templated email via SES
-#######################################
-cmd_send() {
-	# Parse arguments
-	local parsed_args
-	if ! parsed_args=$(_parse_send_args "$@"); then
-		return 1
-	fi
-
-	local SEND_ACCOUNT SEND_FROM SEND_TO SEND_SUBJECT SEND_TEMPLATE SEND_BODY
-	local SEND_THREAD_ID SEND_REGION SEND_TEMPLATE_VARS
-	eval "$parsed_args"
-
-	# Validate required fields
+# Validate required send fields (account, from, to, subject, body/template).
+# Expects SEND_* variables to be set in the caller's scope.
+# Returns 1 if any required field is missing.
+_validate_send_fields() {
 	if [[ -z "$SEND_ACCOUNT" ]]; then
 		log_error "Missing --account"
 		return 1
@@ -411,6 +401,48 @@ cmd_send() {
 		log_error "Either --template or --body is required"
 		return 1
 	fi
+	return 0
+}
+
+#######################################
+# Build the In-Reply-To header value for an existing thread.
+# Arguments: thread_id
+# Prints the header line (e.g. "In-Reply-To: <id>") or nothing if not found.
+_build_reply_to_header() {
+	local thread_id="$1"
+	if [[ -z "$thread_id" ]]; then
+		return 0
+	fi
+	ensure_db
+	local last_ses_id
+	last_ses_id=$(db "$EMAIL_DB" "
+		SELECT ses_message_id FROM messages
+		WHERE thread_id = '$(sql_escape "$thread_id")'
+		AND ses_message_id != ''
+		ORDER BY received_at DESC LIMIT 1;
+	")
+	if [[ -n "$last_ses_id" ]]; then
+		echo "In-Reply-To: <${last_ses_id}>"
+	fi
+	return 0
+}
+
+#######################################
+# Send a templated email via SES
+#######################################
+cmd_send() {
+	# Parse arguments
+	local parsed_args
+	if ! parsed_args=$(_parse_send_args "$@"); then
+		return 1
+	fi
+
+	local SEND_ACCOUNT SEND_FROM SEND_TO SEND_SUBJECT SEND_TEMPLATE SEND_BODY
+	local SEND_THREAD_ID SEND_REGION SEND_TEMPLATE_VARS
+	eval "$parsed_args"
+
+	# Validate required fields
+	_validate_send_fields || return 1
 
 	# Render template if specified
 	if [[ -n "$SEND_TEMPLATE" ]]; then
@@ -431,20 +463,8 @@ cmd_send() {
 	fi
 
 	# Build In-Reply-To header for threading
-	local extra_headers=""
-	if [[ -n "$SEND_THREAD_ID" ]]; then
-		ensure_db
-		local last_ses_id
-		last_ses_id=$(db "$EMAIL_DB" "
-			SELECT ses_message_id FROM messages
-			WHERE thread_id = '$(sql_escape "$SEND_THREAD_ID")'
-			AND ses_message_id != ''
-			ORDER BY received_at DESC LIMIT 1;
-		")
-		if [[ -n "$last_ses_id" ]]; then
-			extra_headers="In-Reply-To: <${last_ses_id}>"
-		fi
-	fi
+	local extra_headers
+	extra_headers=$(_build_reply_to_header "$SEND_THREAD_ID")
 
 	# Send via SES using raw email for header control
 	local raw_message

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -164,6 +164,98 @@ db_query_json() {
 # Sync: Subagent Frontmatter
 # =============================================================================
 
+# Parse model frontmatter fields from a single markdown file.
+# Outputs: model_full, model_tier, model_fallback (one per line as key=value).
+# Returns 1 if the file has no valid model frontmatter.
+_parse_subagent_frontmatter() {
+	local md_file="$1"
+	local model_full="" model_tier="" model_fallback=""
+	local in_frontmatter=false
+	local line_num=0
+
+	while IFS= read -r line; do
+		line_num=$((line_num + 1))
+		if [[ $line_num -eq 1 && "$line" == "---" ]]; then
+			in_frontmatter=true
+			continue
+		fi
+		if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
+			break
+		fi
+		if [[ "$in_frontmatter" == "true" ]]; then
+			case "$line" in
+			model:*)
+				model_full="${line#model:}"
+				model_full="${model_full#"${model_full%%[![:space:]]*}"}"
+				;;
+			model-tier:*)
+				model_tier="${line#model-tier:}"
+				model_tier="${model_tier#"${model_tier%%[![:space:]]*}"}"
+				;;
+			model-fallback:*)
+				model_fallback="${line#model-fallback:}"
+				model_fallback="${model_fallback#"${model_fallback%%[![:space:]]*}"}"
+				;;
+			esac
+		fi
+	done <"$md_file"
+
+	if [[ -z "$model_tier" || -z "$model_full" ]]; then
+		return 1
+	fi
+
+	printf 'model_full=%s\nmodel_tier=%s\nmodel_fallback=%s\n' \
+		"$model_full" "$model_tier" "$model_fallback"
+	return 0
+}
+
+# Upsert a single subagent model file into the subagent_models table.
+# Arguments: md_file basename_file updated_ref
+# Increments the named counter variable via eval on success.
+_sync_subagent_file() {
+	local md_file="$1"
+	local basename_file="$2"
+	local updated_ref="$3"
+
+	local frontmatter
+	frontmatter=$(_parse_subagent_frontmatter "$md_file") || return 0
+
+	local model_full model_tier model_fallback
+	model_full=$(echo "$frontmatter" | grep '^model_full=' | cut -d= -f2-)
+	model_tier=$(echo "$frontmatter" | grep '^model_tier=' | cut -d= -f2-)
+	model_fallback=$(echo "$frontmatter" | grep '^model_fallback=' | cut -d= -f2-)
+
+	# Extract short model_id from full ID (e.g., anthropic/claude-sonnet-4-6 -> claude-sonnet-4-6)
+	local model_short
+	model_short="${model_full#*/}"
+	# Strip trailing date suffix (e.g., -20250514)
+	model_short="${model_short%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
+
+	local norm_name
+	norm_name=$(normalize_model_name "$model_full")
+
+	db_query "
+        INSERT INTO subagent_models (tier, model_id, model_full_id, normalized_name, fallback_id, subagent_file, last_synced)
+        VALUES (
+            '$(sql_escape "$model_tier")',
+            '$(sql_escape "$model_short")',
+            '$(sql_escape "$model_full")',
+            '$(sql_escape "$norm_name")',
+            '$(sql_escape "$model_fallback")',
+            '$(sql_escape "$basename_file")',
+            strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+        )
+        ON CONFLICT(tier) DO UPDATE SET
+            model_id = excluded.model_id,
+            model_full_id = excluded.model_full_id,
+            normalized_name = excluded.normalized_name,
+            fallback_id = excluded.fallback_id,
+            subagent_file = excluded.subagent_file,
+            last_synced = excluded.last_synced;
+    " && eval "${updated_ref}=\$(( ${updated_ref} + 1 ))"
+	return 0
+}
+
 sync_subagents() {
 	local added=0
 	local updated=0
@@ -183,72 +275,7 @@ sync_subagents() {
 		[[ "$basename_file" == "README.md" ]] && continue
 		[[ "$basename_file" == *"-reviewer.md" ]] && continue
 
-		# Extract frontmatter fields
-		local model_full="" model_tier="" model_fallback=""
-		local in_frontmatter=false
-		local line_num=0
-
-		while IFS= read -r line; do
-			line_num=$((line_num + 1))
-			if [[ $line_num -eq 1 && "$line" == "---" ]]; then
-				in_frontmatter=true
-				continue
-			fi
-			if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
-				break
-			fi
-			if [[ "$in_frontmatter" == "true" ]]; then
-				case "$line" in
-				model:*)
-					model_full="${line#model:}"
-					model_full="${model_full#"${model_full%%[![:space:]]*}"}"
-					;;
-				model-tier:*)
-					model_tier="${line#model-tier:}"
-					model_tier="${model_tier#"${model_tier%%[![:space:]]*}"}"
-					;;
-				model-fallback:*)
-					model_fallback="${line#model-fallback:}"
-					model_fallback="${model_fallback#"${model_fallback%%[![:space:]]*}"}"
-					;;
-				esac
-			fi
-		done <"$md_file"
-
-		if [[ -z "$model_tier" || -z "$model_full" ]]; then
-			continue
-		fi
-
-		# Extract short model_id from full ID (e.g., anthropic/claude-sonnet-4-6 -> claude-sonnet-4-6)
-		local model_short
-		model_short="${model_full#*/}"
-		# Strip trailing date suffix (e.g., -20250514)
-		model_short="${model_short%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
-
-		# Compute normalized name for fuzzy matching
-		local norm_name
-		norm_name=$(normalize_model_name "$model_full")
-
-		# Upsert into subagent_models
-		db_query "
-            INSERT INTO subagent_models (tier, model_id, model_full_id, normalized_name, fallback_id, subagent_file, last_synced)
-            VALUES (
-                '$(sql_escape "$model_tier")',
-                '$(sql_escape "$model_short")',
-                '$(sql_escape "$model_full")',
-                '$(sql_escape "$norm_name")',
-                '$(sql_escape "$model_fallback")',
-                '$(sql_escape "$basename_file")',
-                strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
-            )
-            ON CONFLICT(tier) DO UPDATE SET
-                model_id = excluded.model_id,
-                model_full_id = excluded.model_full_id,
-                normalized_name = excluded.normalized_name,
-                fallback_id = excluded.fallback_id,
-                subagent_file = excluded.subagent_file,
-                last_synced = excluded.last_synced;
-        " && updated=$((updated + 1))
+		_sync_subagent_file "$md_file" "$basename_file" updated
 	done
 
 	# Log sync


### PR DESCRIPTION
## Summary

Extracts focused sub-functions from functions exceeding 100 lines across 4 scripts. No behavior changes — pure structural refactoring.

## Changes

### keyword-research-helper.sh (Closes #5728)
- Extract `_parse_filter_option()` from `_parse_options()`: 105 → 81 lines
- Filter-option parsing (`--min-volume`, `--max-volume`, etc.) moved to dedicated function

### milestone-validation-worker.sh (Closes #5727)
- Extract `_parse_args_options()` from `parse_args()`: 88 → 25 lines
- Option-parsing loop separated from positional argument handling

### mission-email-helper.sh (Closes #5726)
- Extract `_validate_send_fields()` from `cmd_send()`: 96 → 55 lines
- Extract `_build_reply_to_header()` from `cmd_send()`: In-Reply-To header lookup isolated

### model-registry-helper.sh (Closes #5725)
- Extract `_parse_subagent_frontmatter()` from `sync_subagents()`: 96 → 22 lines
- Extract `_sync_subagent_file()` from `sync_subagents()`: per-file upsert logic isolated

## Verification

- `bash -n` syntax check: all 4 files pass
- ShellCheck: no new violations (only pre-existing SC1091 info-level warnings)
- All functions now under 100 lines (verified by brace-matching line counter)