### PR TITLE
refactor: reduce function complexity in 4 scripts

### DIFF
--- a/.agents/scripts/transcription-helper.sh
+++ b/.agents/scripts/transcription-helper.sh
@@ -578,6 +578,145 @@ select_backend() {
 
 # ─── Main Commands ───────────────────────────────────────────────────
 
+# Prepare audio file from source (download/extract as needed)
+# Sets audio_file and cleanup_temp in caller scope via output vars
+# Arguments: source_type, input, cache_dir
+# Outputs: prints audio_file path on success
+_prepare_audio_file() {
+	local source_type="$1"
+	local input="$2"
+	local cache_dir="$3"
+
+	mkdir -p "$cache_dir"
+
+	case "$source_type" in
+	youtube)
+		local temp_audio="$cache_dir/yt-audio-$$.wav"
+		download_youtube_audio "$input" "$temp_audio" || return 1
+		# yt-dlp may add extension, find the actual file
+		if [[ ! -f "$temp_audio" ]]; then
+			temp_audio=$(find "$cache_dir" -name "yt-audio-$$.*" -type f | head -1)
+		fi
+		printf '%s' "$temp_audio"
+		;;
+	url)
+		local temp_audio="$cache_dir/url-audio-$$.wav"
+		download_url_audio "$input" "$temp_audio" || return 1
+		printf '%s' "$temp_audio"
+		;;
+	video)
+		local temp_audio="$cache_dir/extracted-audio-$$.wav"
+		extract_audio "$input" "$temp_audio" || return 1
+		printf '%s' "$temp_audio"
+		;;
+	audio)
+		printf '%s' "$input"
+		;;
+	*)
+		print_error "Unsupported source type: $source_type"
+		return 1
+		;;
+	esac
+	return 0
+}
+
+# Determine output file path for transcription
+# Arguments: source_type, input, output_override, output_dir_override, format
+# Outputs: prints resolved output file path
+_determine_output_path() {
+	local source_type="$1"
+	local input="$2"
+	local output_override="$3"
+	local output_dir_override="$4"
+	local format="$5"
+
+	if [[ -n "$output_override" ]]; then
+		printf '%s' "$output_override"
+		return 0
+	fi
+
+	local base_name=""
+	if [[ "$source_type" == "youtube" ]] || [[ "$source_type" == "url" ]]; then
+		base_name="transcription-$(date '+%Y%m%d-%H%M%S')"
+	else
+		base_name="$(basename "${input%.*}")"
+	fi
+	local out_dir="${output_dir_override:-$DEFAULT_OUTPUT_DIR}"
+	mkdir -p "$out_dir"
+	printf '%s' "$out_dir/${base_name}.${format}"
+	return 0
+}
+
+# Dispatch transcription to the selected backend
+# Arguments: backend, audio_file, model, language, format, output_file
+_run_transcription_backend() {
+	local backend="$1"
+	local audio_file="$2"
+	local model="$3"
+	local language="$4"
+	local format="$5"
+	local output_file="$6"
+
+	case "$backend" in
+	faster-whisper)
+		transcribe_faster_whisper "$audio_file" "$model" "$language" "$format" "$output_file"
+		;;
+	whisper-cpp)
+		transcribe_whisper_cpp "$audio_file" "$model" "$language" "$format" "$output_file"
+		;;
+	groq)
+		transcribe_groq "$audio_file" "$model" "$language" "$format" "$output_file"
+		;;
+	openai)
+		transcribe_openai "$audio_file" "$model" "$language" "$format" "$output_file"
+		;;
+	buzz)
+		print_info "Transcribing with Buzz CLI..."
+		local buzz_args=(transcribe "$audio_file" --model "$model")
+		if [[ "$language" != "auto" ]]; then
+			buzz_args+=(--language "$language")
+		fi
+		buzz_args+=(--output-format "$format")
+		buzz "${buzz_args[@]}" >"$output_file"
+		;;
+	*)
+		print_error "Unknown backend: $backend"
+		return 1
+		;;
+	esac
+	return $?
+}
+
+# Show transcription result summary and preview
+# Arguments: exit_code, output_file, format
+_show_transcription_result() {
+	local exit_code="$1"
+	local output_file="$2"
+	local format="$3"
+
+	if [[ $exit_code -eq 0 ]]; then
+		echo ""
+		print_success "Transcription saved to: $output_file"
+
+		if [[ -f "$output_file" ]]; then
+			local file_size
+			file_size=$(wc -c <"$output_file" | tr -d ' ')
+			local line_count
+			line_count=$(wc -l <"$output_file" | tr -d ' ')
+			print_info "Size: ${file_size} bytes, ${line_count} lines"
+
+			if [[ "$format" == "txt" ]] && [[ $line_count -gt 0 ]]; then
+				echo ""
+				print_info "Preview (first 5 lines):"
+				head -5 "$output_file"
+			fi
+		fi
+	else
+		print_error "Transcription failed (exit code: $exit_code)"
+	fi
+	return 0
+}
+
 # Parse transcription options
 parse_transcribe_options() {
 	TRANSCRIBE_INPUT=""
@@ -674,40 +813,11 @@ cmd_transcribe() {
 	local backend
 	backend=$(select_backend "$TRANSCRIBE_BACKEND") || return 1
 
-	# Prepare temp directory for intermediate files
-	mkdir -p "$CACHE_DIR"
-	local temp_audio=""
-	local cleanup_temp=false
-
 	# Prepare audio file based on source type
-	local audio_file=""
-	case "$source_type" in
-	youtube)
-		temp_audio="$CACHE_DIR/yt-audio-$$.wav"
-		download_youtube_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
-		# yt-dlp may add extension, find the actual file
-		if [[ ! -f "$temp_audio" ]]; then
-			temp_audio=$(find "$CACHE_DIR" -name "yt-audio-$$.*" -type f | head -1)
-		fi
-		audio_file="$temp_audio"
-		cleanup_temp=true
-		;;
-	url)
-		temp_audio="$CACHE_DIR/url-audio-$$.wav"
-		download_url_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
-		audio_file="$temp_audio"
-		cleanup_temp=true
-		;;
-	video)
-		temp_audio="$CACHE_DIR/extracted-audio-$$.wav"
-		extract_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
-		audio_file="$temp_audio"
-		cleanup_temp=true
-		;;
-	audio)
-		audio_file="$TRANSCRIBE_INPUT"
-		;;
-	esac
+	local audio_file
+	audio_file=$(_prepare_audio_file "$source_type" "$TRANSCRIBE_INPUT" "$CACHE_DIR") || return 1
+	local cleanup_temp=false
+	[[ "$source_type" != "audio" ]] && cleanup_temp=true
 
 	if [[ ! -f "$audio_file" ]]; then
 		print_error "Audio file not available after preparation."
@@ -715,18 +825,9 @@ cmd_transcribe() {
 	fi
 
 	# Determine output file path
-	local output_file="$TRANSCRIBE_OUTPUT"
-	if [[ -z "$output_file" ]]; then
-		local base_name=""
-		if [[ "$source_type" == "youtube" ]] || [[ "$source_type" == "url" ]]; then
-			base_name="transcription-$(date '+%Y%m%d-%H%M%S')"
-		else
-			base_name="$(basename "${TRANSCRIBE_INPUT%.*}")"
-		fi
-		local out_dir="${TRANSCRIBE_OUTPUT_DIR:-$DEFAULT_OUTPUT_DIR}"
-		mkdir -p "$out_dir"
-		output_file="$out_dir/${base_name}.${TRANSCRIBE_FORMAT}"
-	fi
+	local output_file
+	output_file=$(_determine_output_path "$source_type" "$TRANSCRIBE_INPUT" \
+		"$TRANSCRIBE_OUTPUT" "$TRANSCRIBE_OUTPUT_DIR" "$TRANSCRIBE_FORMAT")
 
 	print_header "Transcription"
 	print_info "Input:    $TRANSCRIBE_INPUT ($source_type)"
@@ -739,61 +840,15 @@ cmd_transcribe() {
 
 	# Run transcription
 	local exit_code=0
-	case "$backend" in
-	faster-whisper)
-		transcribe_faster_whisper "$audio_file" "$TRANSCRIBE_MODEL" \
-			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-		;;
-	whisper-cpp)
-		transcribe_whisper_cpp "$audio_file" "$TRANSCRIBE_MODEL" \
-			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-		;;
-	groq)
-		transcribe_groq "$audio_file" "$TRANSCRIBE_MODEL" \
-			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-		;;
-	openai)
-		transcribe_openai "$audio_file" "$TRANSCRIBE_MODEL" \
-			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-		;;
-	buzz)
-		print_info "Transcribing with Buzz CLI..."
-		local buzz_args=(transcribe "$audio_file" --model "$TRANSCRIBE_MODEL")
-		if [[ "$TRANSCRIBE_LANGUAGE" != "auto" ]]; then
-			buzz_args+=(--language "$TRANSCRIBE_LANGUAGE")
-		fi
-		buzz_args+=(--output-format "$TRANSCRIBE_FORMAT")
-		buzz "${buzz_args[@]}" >"$output_file" || exit_code=$?
-		;;
-	esac
+	_run_transcription_backend "$backend" "$audio_file" "$TRANSCRIBE_MODEL" \
+		"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
 
 	# Cleanup temp files
-	if [[ "$cleanup_temp" == true ]] && [[ -n "$temp_audio" ]]; then
-		rm -f "$temp_audio"
+	if [[ "$cleanup_temp" == true ]] && [[ -n "$audio_file" ]]; then
+		rm -f "$audio_file"
 	fi
 
-	if [[ $exit_code -eq 0 ]]; then
-		echo ""
-		print_success "Transcription saved to: $output_file"
-
-		# Show file size and preview
-		if [[ -f "$output_file" ]]; then
-			local file_size
-			file_size=$(wc -c <"$output_file" | tr -d ' ')
-			local line_count
-			line_count=$(wc -l <"$output_file" | tr -d ' ')
-			print_info "Size: ${file_size} bytes, ${line_count} lines"
-
-			if [[ "$TRANSCRIBE_FORMAT" == "txt" ]] && [[ $line_count -gt 0 ]]; then
-				echo ""
-				print_info "Preview (first 5 lines):"
-				head -5 "$output_file"
-			fi
-		fi
-	else
-		print_error "Transcription failed (exit code: $exit_code)"
-	fi
-
+	_show_transcription_result "$exit_code" "$output_file" "$TRANSCRIBE_FORMAT"
 	return $exit_code
 }
 

--- a/.agents/scripts/ttsr-rule-loader.sh
+++ b/.agents/scripts/ttsr-rule-loader.sh
@@ -542,15 +542,16 @@ cmd_show() {
 # Main
 # =============================================================================
 
-main() {
-	local command=""
-	local rules_dir="$DEFAULT_RULES_DIR"
-	local state_file="$DEFAULT_STATE_FILE"
-	local current_turn=1
-	local format="text"
-	local positional_args=()
+# Parse main() arguments into named variables
+# Sets: _rules_dir, _state_file, _current_turn, _format, _positional_args
+# Returns: 0 on success, non-zero on error (usage printed)
+_parse_main_args() {
+	_rules_dir="$DEFAULT_RULES_DIR"
+	_state_file="$DEFAULT_STATE_FILE"
+	_current_turn=1
+	_format="text"
+	_positional_args=()
 
-	# Parse arguments
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--rules-dir)
@@ -558,7 +559,7 @@ main() {
 				log_error "--rules-dir requires a value"
 				usage
 			}
-			rules_dir="$2"
+			_rules_dir="$2"
 			shift 2
 			;;
 		--state-file)
@@ -566,7 +567,7 @@ main() {
 				log_error "--state-file requires a value"
 				usage
 			}
-			state_file="$2"
+			_state_file="$2"
 			_STATE_FILE_IS_DEFAULT=false
 			shift 2
 			;;
@@ -579,7 +580,7 @@ main() {
 				log_error "--turn must be a positive integer"
 				usage
 			fi
-			current_turn="$2"
+			_current_turn="$2"
 			shift 2
 			;;
 		--format)
@@ -587,7 +588,7 @@ main() {
 				log_error "--format requires a value"
 				usage
 			}
-			format="$2"
+			_format="$2"
 			shift 2
 			;;
 		--help | -h)
@@ -596,7 +597,7 @@ main() {
 			;;
 		-)
 			# Stdin marker — treat as positional arg
-			positional_args+=("$1")
+			_positional_args+=("$1")
 			shift
 			;;
 		-*)
@@ -604,23 +605,30 @@ main() {
 			usage
 			;;
 		*)
-			positional_args+=("$1")
+			_positional_args+=("$1")
 			shift
 			;;
 		esac
 	done
 
 	# Resolve rules directory to absolute path
-	if [[ -d "$rules_dir" ]]; then
-		rules_dir="$(cd "$rules_dir" && pwd)"
+	if [[ -d "$_rules_dir" ]]; then
+		_rules_dir="$(cd "$_rules_dir" && pwd)"
 	fi
 
-	# Extract command
-	if [[ ${#positional_args[@]} -lt 1 ]]; then
-		log_error "No command specified"
-		usage
-	fi
-	command="${positional_args[0]}"
+	return 0
+}
+
+# Dispatch to the appropriate command handler
+# Arguments: command, rules_dir, state_file, current_turn, format, positional_args array
+_dispatch_command() {
+	local command="$1"
+	local rules_dir="$2"
+	local state_file="$3"
+	local current_turn="$4"
+	local format="$5"
+	shift 5
+	local positional_args=("$@")
 
 	case "$command" in
 	list)
@@ -653,6 +661,24 @@ main() {
 		usage
 		;;
 	esac
+	return $?
+}
+
+main() {
+	local _rules_dir _state_file _current_turn _format
+	local _positional_args=()
+
+	_parse_main_args "$@" || return $?
+
+	# Extract command
+	if [[ ${#_positional_args[@]} -lt 1 ]]; then
+		log_error "No command specified"
+		usage
+	fi
+	local command="${_positional_args[0]}"
+
+	_dispatch_command "$command" "$_rules_dir" "$_state_file" "$_current_turn" "$_format" "${_positional_args[@]}"
+	return $?
 }
 
 main "$@"

--- a/.agents/scripts/upstream-watch-helper.sh
+++ b/.agents/scripts/upstream-watch-helper.sh
@@ -385,6 +385,274 @@ cmd_remove() {
 }
 
 #######################################
+# Report update status for a single GitHub repo and update shared counters.
+# Arguments:
+#   $1 - slug
+#   $2 - relevance
+#   $3 - has_new_release (true/false)
+#   $4 - has_new_commits (true/false)
+#   $5 - last_release_seen
+#   $6 - last_commit_seen
+#   $7 - latest_release_tag
+#   $8 - latest_release_name
+#   $9 - latest_release_date
+#   $10 - latest_commit (full SHA)
+#   $11 - latest_commit_date
+#   $12 - verbose (true/false)
+# Side-effects: increments _check_updates_found
+#######################################
+_report_github_repo_update() {
+	local slug="$1"
+	local relevance="$2"
+	local has_new_release="$3"
+	local has_new_commits="$4"
+	local last_release_seen="$5"
+	local last_commit_seen="$6"
+	local latest_release_tag="$7"
+	local latest_release_name="$8"
+	local latest_release_date="$9"
+	local latest_commit="${10}"
+	local latest_commit_date="${11}"
+	local verbose="${12}"
+
+	if [[ "$has_new_release" == true ]]; then
+		_check_updates_found=$((_check_updates_found + 1))
+		echo ""
+		echo -e "${YELLOW}NEW RELEASE${NC}: ${slug}"
+		[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
+		echo "  Previous:  ${last_release_seen:-none}"
+		echo "  Latest:    ${latest_release_tag} (${latest_release_date:-unknown})"
+		[[ -n "$latest_release_name" && "$latest_release_name" != "$latest_release_tag" ]] &&
+			echo "  Name:      ${latest_release_name}"
+		_show_release_diff "$slug" "$last_release_seen" "$latest_release_tag"
+		if [[ "$verbose" == true ]]; then
+			_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
+		fi
+		echo "  Action:    Review changes, then run: upstream-watch-helper.sh ack ${slug}"
+	elif [[ "$has_new_commits" == true ]]; then
+		_check_updates_found=$((_check_updates_found + 1))
+		echo ""
+		echo -e "${BLUE}NEW COMMITS${NC}: ${slug} (no new release)"
+		[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
+		if [[ "$verbose" == true ]]; then
+			_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
+		else
+			echo "  Latest commit: ${latest_commit:0:7} (${latest_commit_date:-unknown})"
+			echo "  Action:        Review changes, then run: upstream-watch-helper.sh ack ${slug}"
+		fi
+	else
+		echo -e "${GREEN}Up to date${NC}: ${slug} (${latest_release_tag:-no releases})"
+	fi
+	return 0
+}
+
+#######################################
+# Check a single GitHub repo for new releases and commits.
+# Updates state in-place (passed by reference via global _check_state).
+# Arguments:
+#   $1 - Repository slug (owner/repo)
+#   $2 - Config JSON
+#   $3 - Current ISO timestamp
+#   $4 - Verbose flag (true/false)
+# Outputs: prints update report to stdout
+# Returns: 0 if up to date or updated, 1 if probe failed
+# Side-effects: sets _check_updates_found, _check_had_probe_failure globals
+#######################################
+_check_single_github_repo() {
+	local slug="$1"
+	local config="$2"
+	local now="$3"
+	local verbose="$4"
+
+	# Get relevance from config
+	local relevance
+	relevance=$(echo "$config" | jq -r --arg slug "$slug" '.repos[] | select(.slug == $slug) | .relevance // ""')
+
+	# Get last-seen state
+	local last_release_seen last_commit_seen
+	last_release_seen=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].last_release_seen // ""')
+	last_commit_seen=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].last_commit_seen // ""')
+
+	# --- Check releases ---
+	local latest_release_tag="" latest_release_name="" latest_release_date=""
+	local release_json=""
+	local probe_failed=false
+	local api_stderr
+	api_stderr=$(mktemp)
+	if release_json=$(gh api "repos/${slug}/releases/latest" 2>"$api_stderr"); then
+		: # success — release_json has the response
+	else
+		local release_err
+		release_err=$(<"$api_stderr")
+		# 404 = no releases (normal), anything else = real error
+		if [[ "$release_err" == *"Not Found"* || "$release_err" == *"404"* ]]; then
+			release_json=""
+		else
+			_log_warn "gh api releases failed for ${slug}: ${release_err}"
+			echo -e "${YELLOW}Warning${NC}: Could not fetch releases for ${slug}" >&2
+			release_json=""
+			probe_failed=true
+		fi
+	fi
+	rm -f "$api_stderr"
+
+	if [[ -n "$release_json" ]]; then
+		latest_release_tag=$(echo "$release_json" | jq -r '.tag_name // ""')
+		latest_release_name=$(echo "$release_json" | jq -r '.name // ""')
+		latest_release_date=$(echo "$release_json" | jq -r '.published_at // ""')
+	fi
+
+	local has_new_release=false
+	if [[ -n "$latest_release_tag" && "$latest_release_tag" != "$last_release_seen" ]]; then
+		has_new_release=true
+	fi
+
+	# --- Check commits (even if no new release) ---
+	local latest_commit="" latest_commit_date=""
+	local commit_json=""
+	api_stderr=$(mktemp)
+	if commit_json=$(gh api "repos/${slug}/commits?per_page=1" --jq '.[0]' 2>"$api_stderr"); then
+		: # success
+	else
+		local commit_err
+		commit_err=$(<"$api_stderr")
+		_log_warn "gh api commits failed for ${slug}: ${commit_err}"
+		echo -e "${YELLOW}Warning${NC}: Could not fetch commits for ${slug}" >&2
+		commit_json=""
+		probe_failed=true
+	fi
+	rm -f "$api_stderr"
+
+	if [[ -n "$commit_json" ]]; then
+		latest_commit=$(echo "$commit_json" | jq -r '.sha // ""')
+		latest_commit_date=$(echo "$commit_json" | jq -r '.commit.committer.date // ""')
+	fi
+
+	local has_new_commits=false
+	if [[ -n "$latest_commit" && "${latest_commit:0:7}" != "$last_commit_seen" ]]; then
+		has_new_commits=true
+	fi
+
+	# --- Report ---
+	_report_github_repo_update "$slug" "$relevance" \
+		"$has_new_release" "$has_new_commits" \
+		"$last_release_seen" "$last_commit_seen" \
+		"$latest_release_tag" "$latest_release_name" "$latest_release_date" \
+		"$latest_commit" "$latest_commit_date" "$verbose"
+
+	# Update last_checked and updates_pending (but NOT last_release_seen or last_commit_seen — those require explicit ack)
+	# Skip state update if probes failed to avoid masking errors as "up to date"
+	if [[ "$probe_failed" != true ]]; then
+		_check_state=$(echo "$_check_state" | jq --arg slug "$slug" --arg now "$now" \
+			--argjson pending "$([[ "$has_new_release" == true || "$has_new_commits" == true ]] && echo 1 || echo 0)" \
+			'.repos[$slug].last_checked = $now | .repos[$slug].updates_pending = $pending')
+	else
+		_check_had_probe_failure=true
+	fi
+	return 0
+}
+
+#######################################
+# Check all non-GitHub upstreams (Docker Hub, GitLab, Forgejo, etc.)
+# Updates _check_state in-place via global.
+# Arguments:
+#   $1 - Config JSON
+#   $2 - Target name (empty = all)
+#   $3 - Current ISO timestamp
+# Side-effects: sets _check_updates_found, _check_had_probe_failure globals
+#######################################
+_check_non_github_upstreams() {
+	local config="$1"
+	local target_name="$2"
+	local now="$3"
+
+	local non_github_names
+	if [[ -n "$target_name" ]]; then
+		non_github_names="$target_name"
+	else
+		non_github_names=$(echo "$config" | jq -r '.non_github_upstreams // [] | .[].name')
+	fi
+
+	while IFS= read -r entry_name; do
+		[[ -z "$entry_name" ]] && continue
+
+		local entry_json
+		entry_json=$(echo "$config" | jq --arg name "$entry_name" '.non_github_upstreams[] | select(.name == $name)')
+
+		local check_cmd source_type description relevance entry_url
+		check_cmd=$(echo "$entry_json" | jq -r '.check_command // ""')
+		source_type=$(echo "$entry_json" | jq -r '.source_type // "unknown"')
+		description=$(echo "$entry_json" | jq -r '.description // ""')
+		relevance=$(echo "$entry_json" | jq -r '.relevance // ""')
+		entry_url=$(echo "$entry_json" | jq -r '.url // ""')
+
+		if [[ -z "$check_cmd" ]]; then
+			echo -e "${YELLOW}Warning${NC}: No check_command for ${entry_name}, skipping" >&2
+			continue
+		fi
+
+		# Get last-seen state
+		local last_seen_value
+		last_seen_value=$(echo "$_check_state" | jq -r --arg name "$entry_name" '.non_github[$name].last_seen // ""')
+
+		# Run the check command (curl + jq) in a subshell for isolation
+		# Note: check_command comes from a committed config file, not user input
+		local current_value=""
+		local probe_failed=false
+		current_value=$(bash -c "$check_cmd" 2>/dev/null) || {
+			_log_warn "check_command failed for ${entry_name}"
+			echo -e "${YELLOW}Warning${NC}: Could not check ${entry_name} (${source_type})" >&2
+			probe_failed=true
+		}
+
+		# Trim whitespace
+		current_value=$(echo "$current_value" | tr -d '[:space:]')
+
+		local has_update=false
+		if [[ "$probe_failed" != true && -n "$current_value" && "$current_value" != "$last_seen_value" ]]; then
+			has_update=true
+		fi
+
+		if [[ "$has_update" == true ]]; then
+			_check_updates_found=$((_check_updates_found + 1))
+			echo ""
+			echo -e "${YELLOW}UPDATE DETECTED${NC}: ${entry_name} (${source_type})"
+			echo "  Description: ${description}"
+			[[ -n "$relevance" ]] && echo -e "  Relevance:   ${CYAN}${relevance}${NC}"
+			echo "  Previous:    ${last_seen_value:-none}"
+			echo "  Current:     ${current_value}"
+			[[ -n "$entry_url" ]] && echo "  URL:         ${entry_url}"
+
+			# Show affected files
+			local affects
+			affects=$(echo "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null)
+			if [[ -n "$affects" ]]; then
+				echo "  Affects:"
+				while IFS= read -r affected_file; do
+					[[ -n "$affected_file" ]] && echo "    - ${affected_file}"
+				done <<<"$affects"
+			fi
+
+			echo "  Action:      Review changes, then run: upstream-watch-helper.sh ack ${entry_name}"
+		elif [[ "$probe_failed" != true ]]; then
+			echo -e "${GREEN}Up to date${NC}: ${entry_name} (${source_type}: ${current_value:-unknown})"
+		fi
+
+		# Update state (but not last_seen — that requires explicit ack)
+		if [[ "$probe_failed" != true ]]; then
+			_check_state=$(echo "$_check_state" | jq --arg name "$entry_name" --arg now "$now" \
+				--arg current "$current_value" \
+				--argjson pending "$([[ "$has_update" == true ]] && echo 1 || echo 0)" \
+				'.non_github[$name].last_checked = $now | .non_github[$name].current_value = $current | .non_github[$name].updates_pending = $pending')
+		else
+			_check_had_probe_failure=true
+		fi
+
+	done <<<"$non_github_names"
+	return 0
+}
+
+#######################################
 # Check watched repos for new releases and commits
 # Compares current GitHub state against last-seen state. Reports new
 # releases with changelog diffs and new commits. Does NOT advance
@@ -404,8 +672,8 @@ cmd_check() {
 
 	local config
 	config=$(_read_config)
-	local state
-	state=$(_read_state)
+	# Use a global so sub-functions can update state in-place
+	_check_state=$(_read_state)
 
 	# Check if target is a non-GitHub upstream name
 	local target_is_non_github=false
@@ -439,236 +707,41 @@ cmd_check() {
 		return 0
 	fi
 
-	local updates_found=0
-	local had_probe_failure=false
+	# Shared counters updated by sub-functions
+	_check_updates_found=0
+	_check_had_probe_failure=false
 	local now
 	now=$(_now_iso)
 
+	# Check GitHub repos
 	while IFS= read -r slug; do
 		[[ -z "$slug" ]] && continue
-
-		# Get relevance from config
-		local relevance
-		relevance=$(echo "$config" | jq -r --arg slug "$slug" '.repos[] | select(.slug == $slug) | .relevance // ""')
-
-		# Get last-seen state
-		local last_release_seen last_commit_seen
-		last_release_seen=$(echo "$state" | jq -r --arg slug "$slug" '.repos[$slug].last_release_seen // ""')
-		last_commit_seen=$(echo "$state" | jq -r --arg slug "$slug" '.repos[$slug].last_commit_seen // ""')
-
-		# --- Check releases ---
-		local latest_release_tag="" latest_release_name="" latest_release_date=""
-		local release_json=""
-		local probe_failed=false
-		local api_stderr
-		api_stderr=$(mktemp)
-		if release_json=$(gh api "repos/${slug}/releases/latest" 2>"$api_stderr"); then
-			: # success — release_json has the response
-		else
-			local release_err
-			release_err=$(<"$api_stderr")
-			# 404 = no releases (normal), anything else = real error
-			if [[ "$release_err" == *"Not Found"* || "$release_err" == *"404"* ]]; then
-				release_json=""
-			else
-				_log_warn "gh api releases failed for ${slug}: ${release_err}"
-				echo -e "${YELLOW}Warning${NC}: Could not fetch releases for ${slug}" >&2
-				release_json=""
-				probe_failed=true
-			fi
-		fi
-		rm -f "$api_stderr"
-
-		if [[ -n "$release_json" ]]; then
-			latest_release_tag=$(echo "$release_json" | jq -r '.tag_name // ""')
-			latest_release_name=$(echo "$release_json" | jq -r '.name // ""')
-			latest_release_date=$(echo "$release_json" | jq -r '.published_at // ""')
-		fi
-
-		local has_new_release=false
-		if [[ -n "$latest_release_tag" && "$latest_release_tag" != "$last_release_seen" ]]; then
-			has_new_release=true
-		fi
-
-		# --- Check commits (even if no new release) ---
-		local latest_commit="" latest_commit_date=""
-		local commit_json=""
-		api_stderr=$(mktemp)
-		if commit_json=$(gh api "repos/${slug}/commits?per_page=1" --jq '.[0]' 2>"$api_stderr"); then
-			: # success
-		else
-			local commit_err
-			commit_err=$(<"$api_stderr")
-			_log_warn "gh api commits failed for ${slug}: ${commit_err}"
-			echo -e "${YELLOW}Warning${NC}: Could not fetch commits for ${slug}" >&2
-			commit_json=""
-			probe_failed=true
-		fi
-		rm -f "$api_stderr"
-
-		if [[ -n "$commit_json" ]]; then
-			latest_commit=$(echo "$commit_json" | jq -r '.sha // ""')
-			latest_commit_date=$(echo "$commit_json" | jq -r '.commit.committer.date // ""')
-		fi
-
-		local has_new_commits=false
-		if [[ -n "$latest_commit" && "${latest_commit:0:7}" != "$last_commit_seen" ]]; then
-			has_new_commits=true
-		fi
-
-		# --- Report ---
-		if [[ "$has_new_release" == true ]]; then
-			updates_found=$((updates_found + 1))
-			echo ""
-			echo -e "${YELLOW}NEW RELEASE${NC}: ${slug}"
-			[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
-			echo "  Previous:  ${last_release_seen:-none}"
-			echo "  Latest:    ${latest_release_tag} (${latest_release_date:-unknown})"
-			[[ -n "$latest_release_name" && "$latest_release_name" != "$latest_release_tag" ]] &&
-				echo "  Name:      ${latest_release_name}"
-
-			# Show releases between last-seen and latest
-			_show_release_diff "$slug" "$last_release_seen" "$latest_release_tag"
-
-			# Show commit summary if verbose
-			if [[ "$verbose" == true ]]; then
-				_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
-			fi
-
-			echo "  Action:    Review changes, then run: upstream-watch-helper.sh ack ${slug}"
-
-		elif [[ "$has_new_commits" == true ]]; then
-			updates_found=$((updates_found + 1))
-			echo ""
-			echo -e "${BLUE}NEW COMMITS${NC}: ${slug} (no new release)"
-			[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
-			if [[ "$verbose" == true ]]; then
-				_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
-			else
-				echo "  Latest commit: ${latest_commit:0:7} (${latest_commit_date:-unknown})"
-				echo "  Action:        Review changes, then run: upstream-watch-helper.sh ack ${slug}"
-			fi
-		else
-			echo -e "${GREEN}Up to date${NC}: ${slug} (${latest_release_tag:-no releases})"
-		fi
-
-		# Update last_checked and updates_pending (but NOT last_release_seen or last_commit_seen — those require explicit ack)
-		# Skip state update if probes failed to avoid masking errors as "up to date"
-		if [[ "$probe_failed" != true ]]; then
-			state=$(echo "$state" | jq --arg slug "$slug" --arg now "$now" \
-				--argjson pending "$([[ "$has_new_release" == true || "$has_new_commits" == true ]] && echo 1 || echo 0)" \
-				'.repos[$slug].last_checked = $now | .repos[$slug].updates_pending = $pending')
-		else
-			had_probe_failure=true
-		fi
-
+		_check_single_github_repo "$slug" "$config" "$now" "$verbose"
 	done <<<"$slugs"
 
-	# =========================================================================
-	# Non-GitHub upstreams (Docker Hub, GitLab, Forgejo, etc.)
-	# =========================================================================
+	# Check non-GitHub upstreams
 	if [[ "$has_non_github" == true ]]; then
-		local non_github_names
-		if [[ "$target_is_non_github" == true ]]; then
-			non_github_names="$target_slug"
-		else
-			non_github_names=$(echo "$config" | jq -r '.non_github_upstreams // [] | .[].name')
-		fi
-
-		while IFS= read -r entry_name; do
-			[[ -z "$entry_name" ]] && continue
-
-			local entry_json
-			entry_json=$(echo "$config" | jq --arg name "$entry_name" '.non_github_upstreams[] | select(.name == $name)')
-
-			local check_cmd source_type description relevance entry_url
-			check_cmd=$(echo "$entry_json" | jq -r '.check_command // ""')
-			source_type=$(echo "$entry_json" | jq -r '.source_type // "unknown"')
-			description=$(echo "$entry_json" | jq -r '.description // ""')
-			relevance=$(echo "$entry_json" | jq -r '.relevance // ""')
-			entry_url=$(echo "$entry_json" | jq -r '.url // ""')
-
-			if [[ -z "$check_cmd" ]]; then
-				echo -e "${YELLOW}Warning${NC}: No check_command for ${entry_name}, skipping" >&2
-				continue
-			fi
-
-			# Get last-seen state
-			local last_seen_value
-			last_seen_value=$(echo "$state" | jq -r --arg name "$entry_name" '.non_github[$name].last_seen // ""')
-
-			# Run the check command (curl + jq) in a subshell for isolation
-			# Note: check_command comes from a committed config file, not user input
-			local current_value=""
-			local probe_failed=false
-			current_value=$(bash -c "$check_cmd" 2>/dev/null) || {
-				_log_warn "check_command failed for ${entry_name}"
-				echo -e "${YELLOW}Warning${NC}: Could not check ${entry_name} (${source_type})" >&2
-				probe_failed=true
-			}
-
-			# Trim whitespace
-			current_value=$(echo "$current_value" | tr -d '[:space:]')
-
-			local has_update=false
-			if [[ "$probe_failed" != true && -n "$current_value" && "$current_value" != "$last_seen_value" ]]; then
-				has_update=true
-			fi
-
-			if [[ "$has_update" == true ]]; then
-				updates_found=$((updates_found + 1))
-				echo ""
-				echo -e "${YELLOW}UPDATE DETECTED${NC}: ${entry_name} (${source_type})"
-				echo "  Description: ${description}"
-				[[ -n "$relevance" ]] && echo -e "  Relevance:   ${CYAN}${relevance}${NC}"
-				echo "  Previous:    ${last_seen_value:-none}"
-				echo "  Current:     ${current_value}"
-				[[ -n "$entry_url" ]] && echo "  URL:         ${entry_url}"
-
-				# Show affected files
-				local affects
-				affects=$(echo "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null)
-				if [[ -n "$affects" ]]; then
-					echo "  Affects:"
-					while IFS= read -r affected_file; do
-						[[ -n "$affected_file" ]] && echo "    - ${affected_file}"
-					done <<<"$affects"
-				fi
-
-				echo "  Action:      Review changes, then run: upstream-watch-helper.sh ack ${entry_name}"
-			elif [[ "$probe_failed" != true ]]; then
-				echo -e "${GREEN}Up to date${NC}: ${entry_name} (${source_type}: ${current_value:-unknown})"
-			fi
-
-			# Update state (but not last_seen — that requires explicit ack)
-			if [[ "$probe_failed" != true ]]; then
-				state=$(echo "$state" | jq --arg name "$entry_name" --arg now "$now" \
-					--arg current "$current_value" \
-					--argjson pending "$([[ "$has_update" == true ]] && echo 1 || echo 0)" \
-					'.non_github[$name].last_checked = $now | .non_github[$name].current_value = $current | .non_github[$name].updates_pending = $pending')
-			else
-				had_probe_failure=true
-			fi
-
-		done <<<"$non_github_names"
+		local ng_target=""
+		[[ "$target_is_non_github" == true ]] && ng_target="$target_slug"
+		_check_non_github_upstreams "$config" "$ng_target" "$now"
 	fi
 
 	# Only advance global last_check if all probes succeeded — partial failures
 	# should not advance the 24h gate so the caller retries on the next cycle
-	if [[ "$had_probe_failure" != true ]]; then
-		state=$(echo "$state" | jq --arg now "$now" '.last_check = $now')
+	if [[ "$_check_had_probe_failure" != true ]]; then
+		_check_state=$(echo "$_check_state" | jq --arg now "$now" '.last_check = $now')
 	fi
-	_write_state "$state"
+	_write_state "$_check_state"
 
 	echo ""
-	if [[ "$updates_found" -gt 0 ]]; then
-		echo -e "${YELLOW}${updates_found} repo(s) have updates to review.${NC}"
+	if [[ "$_check_updates_found" -gt 0 ]]; then
+		echo -e "${YELLOW}${_check_updates_found} repo(s) have updates to review.${NC}"
 	else
 		echo -e "${GREEN}All watched repos are up to date.${NC}"
 	fi
 
-	_log_info "Check complete: ${updates_found} updates found"
-	[[ "$had_probe_failure" == true ]] && return 1
+	_log_info "Check complete: ${_check_updates_found} updates found"
+	[[ "$_check_had_probe_failure" == true ]] && return 1
 	return 0
 }
 

--- a/.agents/scripts/validate-version-consistency.sh
+++ b/.agents/scripts/validate-version-consistency.sh
@@ -25,155 +25,187 @@ get_current_version() {
 	return 0
 }
 
-# Function to validate version consistency across files
-validate_version_consistency() {
+# Check VERSION file consistency
+# Arguments: expected_version
+# Outputs: increments _vc_errors on mismatch
+_check_version_file() {
 	local expected_version="$1"
-	local errors=0
-	local warnings=0
-
-	print_info "🔍 Validating version consistency across files..."
-	print_info "Expected version: $expected_version"
-	echo ""
-
-	# Check VERSION file
 	if [[ -f "$VERSION_FILE" ]]; then
 		local version_file_content
 		version_file_content=$(cat "$VERSION_FILE")
 		if [[ "$version_file_content" != "$expected_version" ]]; then
 			print_error "VERSION file contains '$version_file_content', expected '$expected_version'"
-			errors=$((errors + 1))
+			_vc_errors=$((_vc_errors + 1))
 		else
 			print_success "VERSION file: $expected_version"
 		fi
 	else
 		print_error "VERSION file not found at $VERSION_FILE"
-		errors=$((errors + 1))
+		_vc_errors=$((_vc_errors + 1))
 	fi
+	return 0
+}
 
-	# Check README badge (optional - dynamic GitHub release badge is preferred)
-	# If using dynamic badge (github.io/v/release), skip hardcoded version check
-	if [[ -f "$REPO_ROOT/README.md" ]]; then
-		if grep -q "img.shields.io/github/v/release" "$REPO_ROOT/README.md"; then
+# Check README badge consistency
+# Arguments: expected_version, repo_root
+# Outputs: increments _vc_errors or _vc_warnings on mismatch
+_check_readme_badge() {
+	local expected_version="$1"
+	local repo_root="$2"
+	if [[ -f "$repo_root/README.md" ]]; then
+		if grep -q "img.shields.io/github/v/release" "$repo_root/README.md"; then
 			print_success "README.md uses dynamic GitHub release badge (recommended)"
-		elif grep -q "Version-$expected_version-blue" "$REPO_ROOT/README.md"; then
+		elif grep -q "Version-$expected_version-blue" "$repo_root/README.md"; then
 			print_success "README.md badge: $expected_version"
 		else
 			local current_badge
-			current_badge=$(grep -o "Version-[0-9]\+\.[0-9]\+\.[0-9]\+-blue" "$REPO_ROOT/README.md" || echo "not found")
+			current_badge=$(grep -o "Version-[0-9]\+\.[0-9]\+\.[0-9]\+-blue" "$repo_root/README.md" || echo "not found")
 			if [[ "$current_badge" == "not found" ]]; then
 				print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)"
-				warnings=$((warnings + 1))
+				_vc_warnings=$((_vc_warnings + 1))
 			else
 				print_error "README.md badge shows '$current_badge', expected 'Version-$expected_version-blue'"
-				errors=$((errors + 1))
+				_vc_errors=$((_vc_errors + 1))
 			fi
 		fi
 	else
 		print_warning "README.md not found"
-		warnings=$((warnings + 1))
+		_vc_warnings=$((_vc_warnings + 1))
 	fi
+	return 0
+}
+
+# Check config/build file version references (sonar, setup.sh, aidevops.sh, package.json, homebrew, marketplace)
+# Arguments: expected_version, repo_root
+# Outputs: increments _vc_errors or _vc_warnings on mismatch
+_check_config_files() {
+	local expected_version="$1"
+	local repo_root="$2"
 
 	# Check sonar-project.properties
-	if [[ -f "$REPO_ROOT/sonar-project.properties" ]]; then
-		if grep -q "sonar.projectVersion=$expected_version" "$REPO_ROOT/sonar-project.properties"; then
+	if [[ -f "$repo_root/sonar-project.properties" ]]; then
+		if grep -q "sonar.projectVersion=$expected_version" "$repo_root/sonar-project.properties"; then
 			print_success "sonar-project.properties: $expected_version"
 		else
 			local current_sonar
-			current_sonar=$(grep "sonar.projectVersion=" "$REPO_ROOT/sonar-project.properties" | cut -d'=' -f2 || echo "not found")
+			current_sonar=$(grep "sonar.projectVersion=" "$repo_root/sonar-project.properties" | cut -d'=' -f2 || echo "not found")
 			print_error "sonar-project.properties shows '$current_sonar', expected '$expected_version'"
-			errors=$((errors + 1))
+			_vc_errors=$((_vc_errors + 1))
 		fi
 	else
 		print_warning "sonar-project.properties not found"
-		warnings=$((warnings + 1))
+		_vc_warnings=$((_vc_warnings + 1))
 	fi
 
 	# Check setup.sh
-	if [[ -f "$REPO_ROOT/setup.sh" ]]; then
-		if grep -q "# Version: $expected_version" "$REPO_ROOT/setup.sh"; then
+	if [[ -f "$repo_root/setup.sh" ]]; then
+		if grep -q "# Version: $expected_version" "$repo_root/setup.sh"; then
 			print_success "setup.sh: $expected_version"
 		else
 			local current_setup
-			current_setup=$(grep "# Version:" "$REPO_ROOT/setup.sh" | cut -d':' -f2 | xargs || echo "not found")
+			current_setup=$(grep "# Version:" "$repo_root/setup.sh" | cut -d':' -f2 | xargs || echo "not found")
 			print_error "setup.sh shows '$current_setup', expected '$expected_version'"
-			errors=$((errors + 1))
+			_vc_errors=$((_vc_errors + 1))
 		fi
 	else
 		print_warning "setup.sh not found"
-		warnings=$((warnings + 1))
+		_vc_warnings=$((_vc_warnings + 1))
 	fi
 
 	# Check aidevops.sh
-	if [[ -f "$REPO_ROOT/aidevops.sh" ]]; then
-		if grep -q "# Version: $expected_version" "$REPO_ROOT/aidevops.sh"; then
+	if [[ -f "$repo_root/aidevops.sh" ]]; then
+		if grep -q "# Version: $expected_version" "$repo_root/aidevops.sh"; then
 			print_success "aidevops.sh: $expected_version"
 		else
 			local current_aidevops
-			current_aidevops=$(grep "# Version:" "$REPO_ROOT/aidevops.sh" | head -1 | cut -d':' -f2 | xargs || echo "not found")
+			current_aidevops=$(grep "# Version:" "$repo_root/aidevops.sh" | head -1 | cut -d':' -f2 | xargs || echo "not found")
 			print_error "aidevops.sh shows '$current_aidevops', expected '$expected_version'"
-			errors=$((errors + 1))
+			_vc_errors=$((_vc_errors + 1))
 		fi
 	else
 		print_warning "aidevops.sh not found"
-		warnings=$((warnings + 1))
+		_vc_warnings=$((_vc_warnings + 1))
 	fi
 
 	# Check package.json
-	if [[ -f "$REPO_ROOT/package.json" ]]; then
+	if [[ -f "$repo_root/package.json" ]]; then
 		local pkg_version
-		pkg_version=$(jq -r '.version // "not found"' "$REPO_ROOT/package.json" 2>/dev/null || echo "not found")
+		pkg_version=$(jq -r '.version // "not found"' "$repo_root/package.json" 2>/dev/null || echo "not found")
 		if [[ "$pkg_version" == "$expected_version" ]]; then
 			print_success "package.json: $expected_version"
 		else
 			print_error "package.json shows '$pkg_version', expected '$expected_version'"
-			errors=$((errors + 1))
+			_vc_errors=$((_vc_errors + 1))
 		fi
 	else
 		print_warning "package.json not found"
-		warnings=$((warnings + 1))
+		_vc_warnings=$((_vc_warnings + 1))
 	fi
 
 	# Check homebrew/aidevops.rb (version URL only - SHA256 is updated by CI)
-	if [[ -f "$REPO_ROOT/homebrew/aidevops.rb" ]]; then
-		if grep -q "v${expected_version}.tar.gz" "$REPO_ROOT/homebrew/aidevops.rb"; then
+	if [[ -f "$repo_root/homebrew/aidevops.rb" ]]; then
+		if grep -q "v${expected_version}.tar.gz" "$repo_root/homebrew/aidevops.rb"; then
 			print_success "homebrew/aidevops.rb: v$expected_version"
 		else
 			local current_formula_version
-			current_formula_version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz' "$REPO_ROOT/homebrew/aidevops.rb" | head -1 || echo "not found")
+			current_formula_version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz' "$repo_root/homebrew/aidevops.rb" | head -1 || echo "not found")
 			print_error "homebrew/aidevops.rb shows '$current_formula_version', expected 'v${expected_version}.tar.gz'"
-			errors=$((errors + 1))
+			_vc_errors=$((_vc_errors + 1))
 		fi
 	fi
 
 	# Check .claude-plugin/marketplace.json (optional - only for repos with Claude plugin)
-	if [[ -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
+	if [[ -f "$repo_root/.claude-plugin/marketplace.json" ]]; then
 		local marketplace_version
-		marketplace_version=$(jq -r '.version // .metadata.version // "not found"' "$REPO_ROOT/.claude-plugin/marketplace.json" 2>/dev/null || echo "not found")
+		marketplace_version=$(jq -r '.version // .metadata.version // "not found"' "$repo_root/.claude-plugin/marketplace.json" 2>/dev/null || echo "not found")
 		if [[ "$marketplace_version" == "$expected_version" ]]; then
 			print_success ".claude-plugin/marketplace.json: $expected_version"
 		else
 			print_error ".claude-plugin/marketplace.json shows '$marketplace_version', expected '$expected_version'"
-			errors=$((errors + 1))
+			_vc_errors=$((_vc_errors + 1))
 		fi
 	fi
+	return 0
+}
 
+# Print validation summary and return appropriate exit code
+# Arguments: expected_version
+# Reads: _vc_errors, _vc_warnings
+_print_validation_summary() {
+	local expected_version="$1"
 	echo ""
 	print_info "📊 Validation Summary:"
-
-	if [[ $errors -eq 0 ]]; then
+	if [[ $_vc_errors -eq 0 ]]; then
 		print_success "All version references are consistent: $expected_version"
-		if [[ $warnings -gt 0 ]]; then
-			print_warning "Found $warnings optional files missing (not critical)"
+		if [[ $_vc_warnings -gt 0 ]]; then
+			print_warning "Found $_vc_warnings optional files missing (not critical)"
 		fi
 		return 0
 	else
-		print_error "Found $errors version inconsistencies"
-		if [[ $warnings -gt 0 ]]; then
-			print_warning "Found $warnings optional files missing"
+		print_error "Found $_vc_errors version inconsistencies"
+		if [[ $_vc_warnings -gt 0 ]]; then
+			print_warning "Found $_vc_warnings optional files missing"
 		fi
 		return 1
 	fi
-	return 0
+}
+
+# Function to validate version consistency across files
+validate_version_consistency() {
+	local expected_version="$1"
+	# Shared counters used by sub-functions
+	_vc_errors=0
+	_vc_warnings=0
+
+	print_info "🔍 Validating version consistency across files..."
+	print_info "Expected version: $expected_version"
+	echo ""
+
+	_check_version_file "$expected_version"
+	_check_readme_badge "$expected_version" "$REPO_ROOT"
+	_check_config_files "$expected_version" "$REPO_ROOT"
+	_print_validation_summary "$expected_version"
+	return $?
 }
 
 # Main function


### PR DESCRIPTION
## Summary

Extracts sub-functions from four functions that exceeded 100 lines. No behaviour changes — pure structural refactoring.

### Changes

| File | Function | Before | After |
|------|----------|--------|-------|
| `transcription-helper.sh` | `cmd_transcribe` | 156 lines | 73 lines |
| `ttsr-rule-loader.sh` | `main` | 111 lines | 16 lines |
| `upstream-watch-helper.sh` | `cmd_check` | 274 lines | 80 lines |
| `validate-version-consistency.sh` | `validate_version_consistency` | 148 lines | 16 lines |

### Extracted functions

**transcription-helper.sh:**
- `_prepare_audio_file` — download/extract audio from source type
- `_determine_output_path` — resolve output file path
- `_run_transcription_backend` — dispatch to selected backend
- `_show_transcription_result` — display result summary and preview

**ttsr-rule-loader.sh:**
- `_parse_main_args` — argument parsing loop
- `_dispatch_command` — command dispatch

**upstream-watch-helper.sh:**
- `_check_single_github_repo` — probe a single GitHub repo for updates
- `_report_github_repo_update` — print update report for a repo
- `_check_non_github_upstreams` — check Docker Hub / GitLab / Forgejo entries

**validate-version-consistency.sh:**
- `_check_version_file` — check VERSION file
- `_check_readme_badge` — check README badge
- `_check_config_files` — check sonar/setup/aidevops/package.json/homebrew/marketplace
- `_print_validation_summary` — print summary and return exit code

### Verification

- `bash -n` passes on all four files
- `shellcheck` passes (only pre-existing SC1091 info warnings for `shared-constants.sh` sourcing)
- All extracted functions are under 100 lines
- All original target functions are now under 100 lines

Closes #5808
Closes #5807
Closes #5806
Closes #5805