### PR TITLE
refactor: reduce function complexity in 4 helper scripts

### DIFF
--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -698,6 +698,55 @@ _run_audit_services() {
 	return 0
 }
 
+# Auto-detect PR number if not already set (0 means unset).
+# Outputs the resolved PR number to stdout.
+_audit_detect_pr() {
+	local pr_number="$1"
+
+	if [[ "$pr_number" -ne 0 ]]; then
+		echo "$pr_number"
+		return 0
+	fi
+
+	local detected
+	detected=$(gh pr view --json number -q .number 2>/dev/null || echo "0")
+	if ! [[ "$detected" =~ ^[0-9]+$ ]]; then
+		log_warn "Could not auto-detect PR number, defaulting to 0"
+		detected=0
+	fi
+	echo "$detected"
+	return 0
+}
+
+# Create an audit run record and return its ID.
+_audit_create_run() {
+	local repo="$1"
+	local pr_number="$2"
+	local head_sha="$3"
+
+	db "$AUDIT_DB" "
+        INSERT INTO audit_runs (repo, pr_number, head_sha)
+        VALUES ('$(sql_escape "$repo")', $pr_number, '$(sql_escape "$head_sha")');
+        SELECT last_insert_rowid();
+    "
+	return 0
+}
+
+# Mark an audit run as complete with services_run metadata.
+_audit_finalize_run() {
+	local run_id="$1"
+	local services_run="$2"
+
+	db "$AUDIT_DB" "
+        UPDATE audit_runs
+        SET completed_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'),
+            services_run = '$(sql_escape "$services_run")',
+            status = 'complete'
+        WHERE id = $run_id;
+    "
+	return 0
+}
+
 cmd_audit() {
 	local repo=""
 	local pr_number=0
@@ -711,21 +760,8 @@ cmd_audit() {
 
 	_resolve_audit_context repo pr_number || return 1
 
-	# Auto-detect repo if not specified
-	if [[ -z "$repo" ]]; then
-		repo=$(get_repo)
-	fi
-
-	# Auto-detect PR if not specified
-	if [[ "$pr_number" -eq 0 ]]; then
-		local _detected_pr
-		_detected_pr=$(gh pr view --json number -q .number 2>/dev/null || echo "0")
-		if ! [[ "$_detected_pr" =~ ^[0-9]+$ ]]; then
-			log_warn "Could not auto-detect PR number, defaulting to 0"
-			_detected_pr=0
-		fi
-		pr_number="$_detected_pr"
-	fi
+	[[ -z "$repo" ]] && repo=$(get_repo)
+	pr_number=$(_audit_detect_pr "$pr_number")
 
 	local head_sha
 	head_sha=$(get_head_sha)
@@ -735,17 +771,10 @@ cmd_audit() {
 	log_info "Starting unified code audit for ${repo}"
 	[[ "$pr_number" -gt 0 ]] && log_info "PR: #${pr_number} (SHA: ${head_sha})"
 
-	# Create audit run
 	local run_id
-	run_id=$(db "$AUDIT_DB" "
-        INSERT INTO audit_runs (repo, pr_number, head_sha)
-        VALUES ('$(sql_escape "$repo")', $pr_number, '$(sql_escape "$head_sha")');
-        SELECT last_insert_rowid();
-    ")
-
+	run_id=$(_audit_create_run "$repo" "$pr_number" "$head_sha")
 	log_info "Audit run #${run_id} started"
 
-	# Determine which services to run
 	local services
 	if [[ -n "$services_filter" ]]; then
 		services="$services_filter"
@@ -753,24 +782,13 @@ cmd_audit() {
 		services=$(get_configured_services)
 	fi
 
-	# Collect findings from all services
 	local result services_run total_findings
 	result=$(_run_audit_services "$run_id" "$repo" "$pr_number" "$services")
 	IFS='|' read -r services_run total_findings <<<"$result"
 
-	# Deduplicate cross-service findings
 	deduplicate_findings "$run_id"
+	_audit_finalize_run "$run_id" "$services_run"
 
-	# Update audit run as completed
-	db "$AUDIT_DB" "
-        UPDATE audit_runs
-        SET completed_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'),
-            services_run = '$(sql_escape "$services_run")',
-            status = 'complete'
-        WHERE id = $run_id;
-    "
-
-	# Output summary
 	echo ""
 	print_summary "$run_id"
 
@@ -880,12 +898,10 @@ print_dedup_stats() {
 	return 0
 }
 
-print_summary() {
+# Print findings grouped by source (excluding duplicates).
+print_findings_by_source() {
 	local run_id="$1"
 
-	print_summary_header "$run_id"
-
-	# Findings by source (excluding duplicates)
 	echo "  Findings by Source:"
 	db "$AUDIT_DB" -separator '|' "
         SELECT source, COUNT(*) as cnt
@@ -898,10 +914,13 @@ print_summary() {
 	done
 
 	echo ""
+	return 0
+}
 
-	print_findings_by_severity "$run_id"
+# Print findings grouped by category (excluding duplicates).
+print_findings_by_category() {
+	local run_id="$1"
 
-	# Findings by category (excluding duplicates)
 	echo "  Findings by Category:"
 	db "$AUDIT_DB" -separator '|' "
         SELECT category, COUNT(*) as cnt
@@ -914,7 +933,16 @@ print_summary() {
 	done
 
 	echo ""
+	return 0
+}
 
+print_summary() {
+	local run_id="$1"
+
+	print_summary_header "$run_id"
+	print_findings_by_source "$run_id"
+	print_findings_by_severity "$run_id"
+	print_findings_by_category "$run_id"
 	print_most_affected_files "$run_id"
 	print_dedup_stats "$run_id"
 
@@ -1076,15 +1104,13 @@ report_text() {
 	return 0
 }
 
-cmd_report() {
-	parse_report_args "$@" || return 1
+# Validate report inputs (run_id, limit) and resolve the latest run_id if unset.
+# Sets _RPT_RUN_ID in caller scope via the global (already set by parse_report_args).
+# Returns 1 on validation failure.
+_report_validate_and_resolve() {
+	local run_id="$1"
+	local limit="$2"
 
-	local format="$_RPT_FORMAT"
-	local severity="$_RPT_SEVERITY"
-	local run_id="$_RPT_RUN_ID"
-	local limit="$_RPT_LIMIT"
-
-	# Validate numeric inputs to prevent SQL injection
 	if [[ -n "$run_id" ]] && ! [[ "$run_id" =~ ^[0-9]+$ ]]; then
 		log_error "Invalid run ID: $run_id"
 		return 1
@@ -1094,22 +1120,24 @@ cmd_report() {
 		return 1
 	fi
 
-	ensure_db
-
-	# Default to latest run
 	if [[ -z "$run_id" ]]; then
 		run_id=$(db "$AUDIT_DB" "SELECT id FROM audit_runs ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo "")
 		if [[ -z "$run_id" ]]; then
 			log_error "No audit runs found. Run 'code-audit-helper.sh audit' first."
 			return 1
 		fi
+		_RPT_RUN_ID="$run_id"
 	fi
 
-	# Build WHERE clause
-	local where="WHERE run_id = $run_id AND is_duplicate = 0"
-	if [[ -n "$severity" ]]; then
-		where="${where} AND severity = '$(sql_escape "$severity")'"
-	fi
+	return 0
+}
+
+# Dispatch report output to the correct format handler.
+_report_dispatch_format() {
+	local format="$1"
+	local run_id="$2"
+	local where="$3"
+	local limit="$4"
 
 	local severity_order="
                 ORDER BY
@@ -1147,6 +1175,28 @@ cmd_report() {
 		report_text "$run_id" "$where" "$limit"
 		;;
 	esac
+
+	return 0
+}
+
+cmd_report() {
+	parse_report_args "$@" || return 1
+
+	local format="$_RPT_FORMAT"
+	local severity="$_RPT_SEVERITY"
+	local run_id="$_RPT_RUN_ID"
+	local limit="$_RPT_LIMIT"
+
+	ensure_db
+	_report_validate_and_resolve "$run_id" "$limit" || return 1
+	run_id="$_RPT_RUN_ID"
+
+	local where="WHERE run_id = $run_id AND is_duplicate = 0"
+	if [[ -n "$severity" ]]; then
+		where="${where} AND severity = '$(sql_escape "$severity")'"
+	fi
+
+	_report_dispatch_format "$format" "$run_id" "$where" "$limit"
 
 	return 0
 }

--- a/.agents/scripts/contest-helper.sh
+++ b/.agents/scripts/contest-helper.sh
@@ -376,6 +376,73 @@ _create_contest_entries() {
 }
 
 #######################################
+# Verify task exists in supervisor DB and return its fields.
+# Usage: _create_verify_task <escaped_id>
+# Outputs: repo<TAB>description  (empty = not found)
+#######################################
+_create_verify_task() {
+	local escaped_id="$1"
+
+	db -separator $'\t' "$SUPERVISOR_DB" "
+		SELECT repo, description
+		FROM tasks WHERE id = '$escaped_id';
+	"
+	return 0
+}
+
+#######################################
+# Check for an existing active contest for a task.
+# Usage: _create_check_existing <escaped_id>
+# Outputs: existing contest ID (empty = none)
+#######################################
+_create_check_existing() {
+	local escaped_id="$1"
+
+	db "$SUPERVISOR_DB" "
+		SELECT id FROM contests
+		WHERE task_id = '$escaped_id'
+		AND status NOT IN ('complete','failed','cancelled');
+	"
+	return 0
+}
+
+#######################################
+# Insert a contest record and its entries; outputs contest_id.
+# Usage: _create_insert_contest <task_id> <escaped_id> <tdesc> <trepo> <models> <batch_id>
+#######################################
+_create_insert_contest() {
+	local task_id="$1"
+	local escaped_id="$2"
+	local tdesc="$3"
+	local trepo="$4"
+	local models="$5"
+	local batch_id="$6"
+
+	local contest_id
+	contest_id="contest-${task_id}-$(date +%Y%m%d%H%M%S)"
+
+	db "$SUPERVISOR_DB" "
+		INSERT INTO contests (id, task_id, description, status, models, batch_id, repo)
+		VALUES (
+			'$(sql_escape "$contest_id")',
+			'$escaped_id',
+			'$(sql_escape "$tdesc")',
+			'pending',
+			'$(sql_escape "$models")',
+			'$(sql_escape "${batch_id:-}")',
+			'$(sql_escape "${trepo:-.}")'
+		);
+	"
+
+	local model_count
+	model_count=$(_create_contest_entries "$contest_id" "$task_id" "$models")
+
+	log_success "Contest created: $contest_id with ${model_count} entries"
+	echo "$contest_id"
+	return 0
+}
+
+#######################################
 # Create a contest for a task (t1011)
 # Dispatches the same task to top-3 models in parallel
 #######################################
@@ -391,65 +458,32 @@ cmd_create() {
 
 	ensure_contest_tables || return 1
 
-	# Verify task exists in supervisor DB
 	local escaped_id
 	escaped_id=$(sql_escape "$task_id")
-	local task_row
-	task_row=$(db -separator $'\t' "$SUPERVISOR_DB" "
-		SELECT id, repo, description, status
-		FROM tasks WHERE id = '$escaped_id';
-	")
 
+	local task_row
+	task_row=$(_create_verify_task "$escaped_id")
 	if [[ -z "$task_row" ]]; then
 		log_error "Task not found in supervisor DB: $task_id"
 		return 1
 	fi
 
-	local _tid trepo tdesc _tstatus
-	IFS=$'\t' read -r _tid trepo tdesc _tstatus <<<"$task_row"
+	local trepo tdesc
+	IFS=$'\t' read -r trepo tdesc <<<"$task_row"
 
-	# Check for existing active contest
 	local existing_contest
-	existing_contest=$(db "$SUPERVISOR_DB" "
-		SELECT id FROM contests
-		WHERE task_id = '$escaped_id'
-		AND status NOT IN ('complete','failed','cancelled');
-	")
+	existing_contest=$(_create_check_existing "$escaped_id")
 	if [[ -n "$existing_contest" ]]; then
 		log_warn "Active contest already exists for $task_id: $existing_contest"
 		echo "$existing_contest"
 		return 0
 	fi
 
-	# Select models
 	local models
 	models=$(select_contest_models "$explicit_models")
 	log_info "Contest models: $models"
 
-	# Generate contest ID
-	local contest_id
-	contest_id="contest-${task_id}-$(date +%Y%m%d%H%M%S)"
-
-	# Create contest record
-	db "$SUPERVISOR_DB" "
-		INSERT INTO contests (id, task_id, description, status, models, batch_id, repo)
-		VALUES (
-			'$(sql_escape "$contest_id")',
-			'$escaped_id',
-			'$(sql_escape "$tdesc")',
-			'pending',
-			'$(sql_escape "$models")',
-			'$(sql_escape "${batch_id:-}")',
-			'$(sql_escape "${trepo:-.}")'
-		);
-	"
-
-	# Create contest entries for each model
-	local model_count
-	model_count=$(_create_contest_entries "$contest_id" "$task_id" "$models")
-
-	log_success "Contest created: $contest_id with ${model_count} entries"
-	echo "$contest_id"
+	_create_insert_contest "$task_id" "$escaped_id" "$tdesc" "$trepo" "$models" "$batch_id"
 	return 0
 }
 
@@ -524,6 +558,56 @@ _dispatch_single_entry() {
 }
 
 #######################################
+# Load contest details from DB; outputs task_id<TAB>desc<TAB>repo<TAB>batch_id
+# Returns 1 if not found.
+#######################################
+_dispatch_load_contest() {
+	local escaped_cid="$1"
+
+	local row
+	row=$(db -separator $'\t' "$SUPERVISOR_DB" "
+		SELECT task_id, description, repo, batch_id
+		FROM contests WHERE id = '$escaped_cid';
+	")
+	if [[ -z "$row" ]]; then
+		return 1
+	fi
+	printf '%s' "$row"
+	return 0
+}
+
+#######################################
+# Dispatch all pending entries for a contest; outputs dispatched_count.
+#######################################
+_dispatch_run_entries() {
+	local escaped_cid="$1"
+	local ctask_id="$2"
+	local cdesc="$3"
+	local crepo="$4"
+	local cbatch_id="$5"
+
+	local entries
+	entries=$(db -separator $'\t' "$SUPERVISOR_DB" "
+		SELECT id, model, task_id
+		FROM contest_entries
+		WHERE contest_id = '$escaped_cid' AND status = 'pending';
+	")
+
+	local dispatched_count=0
+	while IFS=$'\t' read -r entry_id entry_model entry_task_id; do
+		[[ -z "$entry_id" ]] && continue
+		if _dispatch_single_entry \
+			"$entry_id" "$entry_model" "$entry_task_id" \
+			"$ctask_id" "$cdesc" "$crepo" "$cbatch_id"; then
+			dispatched_count=$((dispatched_count + 1))
+		fi
+	done <<<"$entries"
+
+	echo "$dispatched_count"
+	return 0
+}
+
+#######################################
 # Dispatch contest entries as parallel workers
 # Creates subtasks in supervisor DB and dispatches them
 #######################################
@@ -539,53 +623,34 @@ cmd_dispatch_contest() {
 	local escaped_cid
 	escaped_cid=$(sql_escape "$contest_id")
 
-	# Get contest details
 	local contest_row
-	contest_row=$(db -separator $'\t' "$SUPERVISOR_DB" "
-		SELECT task_id, description, repo, batch_id
-		FROM contests WHERE id = '$escaped_cid';
-	")
-
-	if [[ -z "$contest_row" ]]; then
+	contest_row=$(_dispatch_load_contest "$escaped_cid") || {
 		log_error "Contest not found: $contest_id"
 		return 1
-	fi
+	}
 
 	local ctask_id cdesc crepo cbatch_id
 	IFS=$'\t' read -r ctask_id cdesc crepo cbatch_id <<<"$contest_row"
 
-	# Transition contest to dispatching
 	db "$SUPERVISOR_DB" "
 		UPDATE contests SET status = 'dispatching', metadata = 'dispatch_started:$(date -u +%Y-%m-%dT%H:%M:%SZ)'
 		WHERE id = '$escaped_cid';
 	"
 
-	# Get pending entries
 	local entries
 	entries=$(db -separator $'\t' "$SUPERVISOR_DB" "
 		SELECT id, model, task_id
 		FROM contest_entries
 		WHERE contest_id = '$escaped_cid' AND status = 'pending';
 	")
-
 	if [[ -z "$entries" ]]; then
 		log_warn "No pending entries for contest $contest_id"
 		return 0
 	fi
 
-	local dispatched_count=0
+	local dispatched_count
+	dispatched_count=$(_dispatch_run_entries "$escaped_cid" "$ctask_id" "$cdesc" "$crepo" "$cbatch_id")
 
-	while IFS=$'\t' read -r entry_id entry_model entry_task_id; do
-		[[ -z "$entry_id" ]] && continue
-
-		if _dispatch_single_entry \
-			"$entry_id" "$entry_model" "$entry_task_id" \
-			"$ctask_id" "$cdesc" "$crepo" "$cbatch_id"; then
-			dispatched_count=$((dispatched_count + 1))
-		fi
-	done <<<"$entries"
-
-	# Update contest status
 	if [[ "$dispatched_count" -gt 0 ]]; then
 		db "$SUPERVISOR_DB" "
 			UPDATE contests SET status = 'running'
@@ -919,6 +984,100 @@ _store_scores_and_find_winner() {
 }
 
 #######################################
+# Check that a contest is ready for evaluation.
+# Returns 0 (ready), 1 (error/not ready), 2 (still running).
+# On success, outputs complete_count to stdout.
+#######################################
+_evaluate_check_readiness() {
+	local contest_id="$1"
+	local escaped_cid="$2"
+
+	local contest_status
+	contest_status=$(db "$SUPERVISOR_DB" "SELECT status FROM contests WHERE id = '$escaped_cid';")
+	if [[ "$contest_status" != "running" ]]; then
+		log_error "Contest $contest_id is in '$contest_status' state, must be 'running' to evaluate"
+		return 1
+	fi
+
+	local pending_count
+	pending_count=$(db "$SUPERVISOR_DB" "
+		SELECT count(*) FROM contest_entries
+		WHERE contest_id = '$escaped_cid'
+		AND status NOT IN ('complete','failed','cancelled');
+	")
+	if [[ "$pending_count" -gt 0 ]]; then
+		log_info "Contest $contest_id has $pending_count entries still running — not ready for evaluation"
+		return 2
+	fi
+
+	local complete_count
+	complete_count=$(db "$SUPERVISOR_DB" "
+		SELECT count(*) FROM contest_entries
+		WHERE contest_id = '$escaped_cid' AND status = 'complete';
+	")
+	if [[ "$complete_count" -lt 2 ]]; then
+		log_error "Contest $contest_id has fewer than 2 completed entries ($complete_count) — cannot cross-rank"
+		db "$SUPERVISOR_DB" "
+			UPDATE contests SET status = 'failed',
+				metadata = COALESCE(metadata,'') || ' eval_failed:insufficient_entries'
+			WHERE id = '$escaped_cid';
+		"
+		return 1
+	fi
+
+	echo "$complete_count"
+	return 0
+}
+
+#######################################
+# Collect summaries, build ranking prompt, run judges, aggregate scores.
+# Outputs winner_row (id<TAB>model<TAB>score) or empty on failure.
+#######################################
+_evaluate_run_pipeline() {
+	local contest_id="$1"
+	local escaped_cid="$2"
+
+	local summaries_file
+	summaries_file=$(_collect_entry_summaries "$escaped_cid")
+
+	local num_entries
+	num_entries=$(wc -l <"$summaries_file" | tr -d ' ')
+	if [[ "$num_entries" -lt 2 ]]; then
+		log_error "Not enough entries to evaluate"
+		rm -f "$summaries_file"
+		return 1
+	fi
+
+	local ranking_prompt
+	ranking_prompt=$(_build_ranking_prompt "$num_entries" "$summaries_file")
+
+	db "$SUPERVISOR_DB" "UPDATE contests SET status = 'scoring' WHERE id = '$escaped_cid';"
+
+	local judges_file
+	judges_file=$(mktemp "${TMPDIR:-/tmp}/contest-judges-XXXXXX")
+	while IFS=$'\t' read -r _eid emodel _summary_b64; do
+		[[ -z "$emodel" ]] && continue
+		echo "$emodel" >>"$judges_file"
+	done <"$summaries_file"
+
+	local all_scores_file
+	all_scores_file=$(mktemp "${TMPDIR:-/tmp}/contest-allscores-XXXXXX")
+	_run_judges "$judges_file" "$ranking_prompt" >"$all_scores_file"
+	rm -f "$judges_file"
+
+	local judge_count
+	judge_count=$(wc -l <"$all_scores_file" | tr -d ' ')
+	log_info "Aggregating scores from ${judge_count} score lines..."
+
+	local winner_row
+	winner_row=$(_store_scores_and_find_winner "$escaped_cid" "$summaries_file" "$all_scores_file")
+	rm -f "$summaries_file" "$all_scores_file"
+
+	printf '%s' "$winner_row"
+	return 0
+}
+
+#######################################
 # Evaluate contest — cross-rank outputs from all completed entries
 # Each model scores all outputs (including its own) blindly as A/B/C
 # Then aggregate scores and pick winner
@@ -935,90 +1094,18 @@ cmd_evaluate() {
 	local escaped_cid
 	escaped_cid=$(sql_escape "$contest_id")
 
-	# Verify contest is in evaluatable state
-	local contest_status
-	contest_status=$(db "$SUPERVISOR_DB" "SELECT status FROM contests WHERE id = '$escaped_cid';")
-	if [[ "$contest_status" != "running" ]]; then
-		log_error "Contest $contest_id is in '$contest_status' state, must be 'running' to evaluate"
-		return 1
-	fi
-
-	# Check all entries are complete (or failed)
-	local pending_count
-	pending_count=$(db "$SUPERVISOR_DB" "
-		SELECT count(*) FROM contest_entries
-		WHERE contest_id = '$escaped_cid'
-		AND status NOT IN ('complete','failed','cancelled');
-	")
-
-	if [[ "$pending_count" -gt 0 ]]; then
-		log_info "Contest $contest_id has $pending_count entries still running — not ready for evaluation"
-		return 2
-	fi
-
-	# Get completed entries
 	local complete_count
-	complete_count=$(db "$SUPERVISOR_DB" "
-		SELECT count(*) FROM contest_entries
-		WHERE contest_id = '$escaped_cid' AND status = 'complete';
-	")
-
-	if [[ "$complete_count" -lt 2 ]]; then
-		log_error "Contest $contest_id has fewer than 2 completed entries ($complete_count) — cannot cross-rank"
-		db "$SUPERVISOR_DB" "
-			UPDATE contests SET status = 'failed',
-				metadata = COALESCE(metadata,'') || ' eval_failed:insufficient_entries'
-			WHERE id = '$escaped_cid';
-		"
-		return 1
+	complete_count=$(_evaluate_check_readiness "$contest_id" "$escaped_cid")
+	local readiness_rc=$?
+	if [[ "$readiness_rc" -ne 0 ]]; then
+		return "$readiness_rc"
 	fi
 
-	# Transition to evaluating
 	db "$SUPERVISOR_DB" "UPDATE contests SET status = 'evaluating' WHERE id = '$escaped_cid';"
 	log_info "Evaluating contest $contest_id with $complete_count entries..."
 
-	# Collect output summaries
-	local summaries_file
-	summaries_file=$(_collect_entry_summaries "$escaped_cid")
-
-	local num_entries
-	num_entries=$(wc -l <"$summaries_file" | tr -d ' ')
-
-	if [[ "$num_entries" -lt 2 ]]; then
-		log_error "Not enough entries to evaluate"
-		rm -f "$summaries_file"
-		return 1
-	fi
-
-	# Build ranking prompt
-	local ranking_prompt
-	ranking_prompt=$(_build_ranking_prompt "$num_entries" "$summaries_file")
-
-	# Transition to scoring
-	db "$SUPERVISOR_DB" "UPDATE contests SET status = 'scoring' WHERE id = '$escaped_cid';"
-
-	# Build judges list from entry models
-	local judges_file
-	judges_file=$(mktemp "${TMPDIR:-/tmp}/contest-judges-XXXXXX")
-	while IFS=$'\t' read -r _eid emodel _summary_b64; do
-		[[ -z "$emodel" ]] && continue
-		echo "$emodel" >>"$judges_file"
-	done <"$summaries_file"
-
-	# Run judges and collect all scores
-	local all_scores_file
-	all_scores_file=$(mktemp "${TMPDIR:-/tmp}/contest-allscores-XXXXXX")
-	_run_judges "$judges_file" "$ranking_prompt" >"$all_scores_file"
-	rm -f "$judges_file"
-
-	local judge_count
-	judge_count=$(wc -l <"$all_scores_file" | tr -d ' ')
-	log_info "Aggregating scores from ${judge_count} score lines..."
-
-	# Store scores and find winner
 	local winner_row
-	winner_row=$(_store_scores_and_find_winner "$escaped_cid" "$summaries_file" "$all_scores_file")
-	rm -f "$summaries_file" "$all_scores_file"
+	winner_row=$(_evaluate_run_pipeline "$contest_id" "$escaped_cid") || return 1
 
 	_finalize_contest_winner "$contest_id" "$escaped_cid" "$winner_row"
 	return $?

--- a/.agents/scripts/dataset-helper.sh
+++ b/.agents/scripts/dataset-helper.sh
@@ -421,31 +421,93 @@ cmd_create() {
 	return 0
 }
 
-# Validate a JSONL dataset file
-cmd_validate() {
-	local file_path=""
-	local strict=false
+# Parse validate command arguments.
+# Sets _VAL_FILE and _VAL_STRICT in caller scope.
+# Returns 0 on success, 1 on error.
+_validate_parse_args() {
+	_VAL_FILE=""
+	_VAL_STRICT=false
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--strict)
-			strict=true
+			_VAL_STRICT=true
 			shift
 			;;
 		--help | -h)
 			_validate_help
-			return 0
+			return 2
 			;;
 		-*)
 			print_error "Unknown option: $1"
 			return 1
 			;;
 		*)
-			file_path="$1"
+			_VAL_FILE="$1"
 			shift
 			;;
 		esac
 	done
+	return 0
+}
+
+# Iterate lines of a JSONL file, validate each, and return error count.
+# Outputs final line_num to stdout as "LINES:<n>".
+_validate_process_file() {
+	local file_path="$1"
+	local strict="$2"
+
+	local errors=0
+	local line_num=0
+	local seen_ids=""
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		line_num=$((line_num + 1))
+		[[ -z "$line" ]] && continue
+
+		if ! _validate_line_json "$line" "$line_num"; then
+			errors=$((errors + 1))
+			continue
+		fi
+
+		local entry_id
+		entry_id=$(_validate_line_fields "$line" "$line_num") || {
+			local field_err_count=$?
+			errors=$((errors + field_err_count))
+			entry_id=""
+		}
+
+		if [[ -n "$entry_id" ]]; then
+			if printf '%s' "$seen_ids" | grep -qxF -- "$entry_id"; then
+				print_error "Line $line_num: Duplicate ID '$entry_id'"
+				errors=$((errors + 1))
+			else
+				seen_ids="${seen_ids}${entry_id}
+"
+			fi
+		fi
+
+		if [[ "$strict" == "true" ]]; then
+			_validate_line_strict "$line" "$line_num" || {
+				local strict_err_count=$?
+				errors=$((errors + strict_err_count))
+			}
+		fi
+	done <"$file_path"
+
+	echo "LINES:${line_num}"
+	return "$errors"
+}
+
+# Validate a JSONL dataset file
+cmd_validate() {
+	_validate_parse_args "$@"
+	local parse_rc=$?
+	[[ "$parse_rc" -eq 2 ]] && return 0
+	[[ "$parse_rc" -ne 0 ]] && return 1
+
+	local file_path="$_VAL_FILE"
+	local strict="$_VAL_STRICT"
 
 	if [[ -z "$file_path" ]]; then
 		print_error "File path is required"
@@ -460,7 +522,6 @@ cmd_validate() {
 		return 1
 	fi
 
-	# Empty file is valid (newly created dataset)
 	local line_count
 	line_count=$(wc -l <"$file_path" | tr -d ' ')
 	if [[ "$line_count" -eq 0 ]]; then
@@ -468,49 +529,11 @@ cmd_validate() {
 		return 0
 	fi
 
-	local errors=0
-	local line_num=0
-	local seen_ids=""
-
-	while IFS= read -r line || [[ -n "$line" ]]; do
-		line_num=$((line_num + 1))
-
-		# Skip empty lines
-		[[ -z "$line" ]] && continue
-
-		# Check valid JSON
-		if ! _validate_line_json "$line" "$line_num"; then
-			errors=$((errors + 1))
-			continue
-		fi
-
-		# Check required fields; capture the entry id from stdout
-		local entry_id
-		entry_id=$(_validate_line_fields "$line" "$line_num") || {
-			local field_err_count=$?
-			errors=$((errors + field_err_count))
-			entry_id=""
-		}
-
-		# Check for duplicate IDs (newline-separated list, bash 3.2 compatible)
-		if [[ -n "$entry_id" ]]; then
-			if printf '%s' "$seen_ids" | grep -qxF -- "$entry_id"; then
-				print_error "Line $line_num: Duplicate ID '$entry_id'"
-				errors=$((errors + 1))
-			else
-				seen_ids="${seen_ids}${entry_id}
-"
-			fi
-		fi
-
-		# Strict mode: validate optional field types
-		if [[ "$strict" == "true" ]]; then
-			_validate_line_strict "$line" "$line_num" || {
-				local strict_err_count=$?
-				errors=$((errors + strict_err_count))
-			}
-		fi
-	done <"$file_path"
+	local process_output
+	process_output=$(_validate_process_file "$file_path" "$strict")
+	local errors=$?
+	local line_num
+	line_num=$(printf '%s' "$process_output" | sed -n 's/^LINES://p')
 
 	if [[ "$errors" -gt 0 ]]; then
 		print_error "Validation failed: $errors error(s) in $file_path"
@@ -521,16 +544,19 @@ cmd_validate() {
 	return 0
 }
 
-# Add an entry to a dataset
-cmd_add() {
-	local file_path=""
-	local input_text=""
-	local expected_text=""
-	local context_text=""
-	local tags_csv=""
-	local source_text="manual"
-	local entry_id=""
-	local metadata_json=""
+# Parse add command arguments.
+# Sets _ADD_FILE, _ADD_INPUT, _ADD_EXPECTED, _ADD_CONTEXT, _ADD_TAGS,
+#      _ADD_SOURCE, _ADD_ID, _ADD_METADATA in caller scope.
+# Returns 0 on success, 1 on error, 2 on --help.
+_add_parse_args() {
+	_ADD_FILE=""
+	_ADD_INPUT=""
+	_ADD_EXPECTED=""
+	_ADD_CONTEXT=""
+	_ADD_TAGS=""
+	_ADD_SOURCE="manual"
+	_ADD_ID=""
+	_ADD_METADATA=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -539,7 +565,7 @@ cmd_add() {
 				print_error "--input requires a value"
 				return 1
 			}
-			input_text="$2"
+			_ADD_INPUT="$2"
 			shift 2
 			;;
 		--expected)
@@ -547,7 +573,7 @@ cmd_add() {
 				print_error "--expected requires a value"
 				return 1
 			}
-			expected_text="$2"
+			_ADD_EXPECTED="$2"
 			shift 2
 			;;
 		--context)
@@ -555,7 +581,7 @@ cmd_add() {
 				print_error "--context requires a value"
 				return 1
 			}
-			context_text="$2"
+			_ADD_CONTEXT="$2"
 			shift 2
 			;;
 		--tags)
@@ -563,7 +589,7 @@ cmd_add() {
 				print_error "--tags requires a value"
 				return 1
 			}
-			tags_csv="$2"
+			_ADD_TAGS="$2"
 			shift 2
 			;;
 		--source)
@@ -571,7 +597,7 @@ cmd_add() {
 				print_error "--source requires a value"
 				return 1
 			}
-			source_text="$2"
+			_ADD_SOURCE="$2"
 			shift 2
 			;;
 		--id)
@@ -579,7 +605,7 @@ cmd_add() {
 				print_error "--id requires a value"
 				return 1
 			}
-			entry_id="$2"
+			_ADD_ID="$2"
 			shift 2
 			;;
 		--metadata)
@@ -587,20 +613,20 @@ cmd_add() {
 				print_error "--metadata requires a value"
 				return 1
 			}
-			metadata_json="$2"
+			_ADD_METADATA="$2"
 			shift 2
 			;;
 		--help | -h)
 			_add_help
-			return 0
+			return 2
 			;;
 		-*)
 			print_error "Unknown option: $1"
 			return 1
 			;;
 		*)
-			if [[ -z "$file_path" ]]; then
-				file_path="$1"
+			if [[ -z "$_ADD_FILE" ]]; then
+				_ADD_FILE="$1"
 			else
 				print_error "Unexpected argument: $1"
 				return 1
@@ -609,6 +635,24 @@ cmd_add() {
 			;;
 		esac
 	done
+	return 0
+}
+
+# Add an entry to a dataset
+cmd_add() {
+	_add_parse_args "$@"
+	local parse_rc=$?
+	[[ "$parse_rc" -eq 2 ]] && return 0
+	[[ "$parse_rc" -ne 0 ]] && return 1
+
+	local file_path="$_ADD_FILE"
+	local input_text="$_ADD_INPUT"
+	local expected_text="$_ADD_EXPECTED"
+	local context_text="$_ADD_CONTEXT"
+	local tags_csv="$_ADD_TAGS"
+	local source_text="$_ADD_SOURCE"
+	local entry_id="$_ADD_ID"
+	local metadata_json="$_ADD_METADATA"
 
 	entry_id=$(_add_validate_inputs "$file_path" "$input_text" "$entry_id") || return 1
 
@@ -792,11 +836,13 @@ cmd_stats() {
 	return 0
 }
 
-# Promote an observability trace to a dataset entry
-cmd_promote() {
-	local trace_id=""
-	local output_file=""
-	local tags_csv=""
+# Parse promote command arguments.
+# Sets _PROMO_TRACE_ID, _PROMO_OUTPUT, _PROMO_TAGS in caller scope.
+# Returns 0 on success, 1 on error, 2 on --help.
+_promote_parse_args() {
+	_PROMO_TRACE_ID=""
+	_PROMO_OUTPUT=""
+	_PROMO_TAGS=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -805,7 +851,7 @@ cmd_promote() {
 				print_error "--trace-id requires a value"
 				return 1
 			}
-			trace_id="$2"
+			_PROMO_TRACE_ID="$2"
 			shift 2
 			;;
 		--output | -o)
@@ -813,7 +859,7 @@ cmd_promote() {
 				print_error "-o/--output requires a value"
 				return 1
 			}
-			output_file="$2"
+			_PROMO_OUTPUT="$2"
 			shift 2
 			;;
 		--tags)
@@ -821,7 +867,7 @@ cmd_promote() {
 				print_error "--tags requires a value"
 				return 1
 			}
-			tags_csv="$2"
+			_PROMO_TAGS="$2"
 			shift 2
 			;;
 		--help | -h)
@@ -835,7 +881,7 @@ cmd_promote() {
 			echo "  --tags \"a,b\"      Additional tags for the entry"
 			echo ""
 			echo "The trace's model, project, and cost are stored in metadata."
-			return 0
+			return 2
 			;;
 		-*)
 			print_error "Unknown option: $1"
@@ -847,6 +893,39 @@ cmd_promote() {
 			;;
 		esac
 	done
+	return 0
+}
+
+# Resolve the output file for promote, creating it if needed.
+# Outputs the resolved path to stdout; returns 1 on error.
+_promote_resolve_output() {
+	local output_file="$1"
+
+	if [[ -z "$output_file" ]]; then
+		_ensure_dir "$GLOBAL_DATASETS_DIR"
+		output_file="${GLOBAL_DATASETS_DIR}/promoted.jsonl"
+		[[ -f "$output_file" ]] || touch "$output_file"
+	fi
+
+	if [[ ! -f "$output_file" ]]; then
+		print_error "Output dataset not found: $output_file"
+		return 1
+	fi
+
+	echo "$output_file"
+	return 0
+}
+
+# Promote an observability trace to a dataset entry
+cmd_promote() {
+	_promote_parse_args "$@"
+	local parse_rc=$?
+	[[ "$parse_rc" -eq 2 ]] && return 0
+	[[ "$parse_rc" -ne 0 ]] && return 1
+
+	local trace_id="$_PROMO_TRACE_ID"
+	local output_file="$_PROMO_OUTPUT"
+	local tags_csv="$_PROMO_TAGS"
 
 	if [[ -z "$trace_id" ]]; then
 		print_error "--trace-id is required"
@@ -862,7 +941,6 @@ cmd_promote() {
 		return 1
 	fi
 
-	# Find the trace in metrics
 	local trace_data
 	if ! trace_data=$(_promote_find_trace "$trace_id" "$OBS_METRICS"); then
 		print_error "Trace not found: $trace_id"
@@ -870,19 +948,8 @@ cmd_promote() {
 		return 1
 	fi
 
-	# Default output file
-	if [[ -z "$output_file" ]]; then
-		_ensure_dir "$GLOBAL_DATASETS_DIR"
-		output_file="${GLOBAL_DATASETS_DIR}/promoted.jsonl"
-		[[ -f "$output_file" ]] || touch "$output_file"
-	fi
+	output_file=$(_promote_resolve_output "$output_file") || return 1
 
-	if [[ ! -f "$output_file" ]]; then
-		print_error "Output dataset not found: $output_file"
-		return 1
-	fi
-
-	# Build and append the entry
 	local entry entry_id
 	entry=$(_promote_build_entry "$trace_data" "$trace_id" "$tags_csv")
 	entry_id=$(echo "$entry" | jq -r '.id')

--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -2009,60 +2009,71 @@ PYEOF
 	return 0
 }
 
-cmd_create() {
-	local template=""
-	local data=""
-	local output=""
-	local script=""
+# Parse create command arguments.
+# Sets _CREATE_TEMPLATE, _CREATE_DATA, _CREATE_OUTPUT, _CREATE_SCRIPT in caller scope.
+_create_cmd_parse_args() {
+	_CREATE_TEMPLATE=""
+	_CREATE_DATA=""
+	_CREATE_OUTPUT=""
+	_CREATE_SCRIPT=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--data)
-			data="$2"
+			_CREATE_DATA="$2"
 			shift 2
 			;;
 		--output | -o)
-			output="$2"
+			_CREATE_OUTPUT="$2"
 			shift 2
 			;;
 		--script)
-			script="$2"
+			_CREATE_SCRIPT="$2"
 			shift 2
 			;;
 		--*) shift ;;
 		*)
-			if [[ -z "${template}" ]]; then
-				template="$1"
-			fi
+			[[ -z "${_CREATE_TEMPLATE}" ]] && _CREATE_TEMPLATE="$1"
 			shift
 			;;
 		esac
 	done
+	return 0
+}
 
-	# Script mode: delegate to a Python script
-	if [[ -n "${script}" ]]; then
-		_create_run_script "${script}" "${data}" "${output}"
-		return $?
-	fi
+# Validate template inputs and resolve output path.
+# Returns 1 on validation failure.
+_create_validate_template() {
+	local template="$1"
+	local data="$2"
+	local output_ref="$3"
 
-	# Template mode
 	if [[ -z "${template}" ]]; then
 		die "Usage: create <template-file> --data <json|file> --output <file>"
 	fi
-
 	if [[ ! -f "${template}" ]]; then
 		die "Template not found: ${template}"
 	fi
-
 	if [[ -z "${data}" ]]; then
 		die "Data required. Use --data '{\"field\": \"value\"}' or --data fields.json"
 	fi
 
-	if [[ -z "${output}" ]]; then
+	local _output="${!output_ref}"
+	if [[ -z "${_output}" ]]; then
 		local ext
 		ext=$(get_ext "$template")
-		output="${template%.*}-filled.${ext}"
+		_output="${template%.*}-filled.${ext}"
+		printf -v "${output_ref}" '%s' "${_output}"
 	fi
+
+	return 0
+}
+
+# Fill a template file with data, dispatching by extension.
+_create_fill_template() {
+	local template="$1"
+	local data="$2"
+	local output="$3"
 
 	local ext
 	ext=$(get_ext "$template")
@@ -2091,6 +2102,25 @@ cmd_create() {
 		die "Unsupported template format: ${ext}. Use odt or docx."
 		;;
 	esac
+
+	return 0
+}
+
+cmd_create() {
+	_create_cmd_parse_args "$@"
+
+	local template="${_CREATE_TEMPLATE}"
+	local data="${_CREATE_DATA}"
+	local output="${_CREATE_OUTPUT}"
+	local script="${_CREATE_SCRIPT}"
+
+	if [[ -n "${script}" ]]; then
+		_create_run_script "${script}" "${data}" "${output}"
+		return $?
+	fi
+
+	_create_validate_template "${template}" "${data}" output || return 1
+	_create_fill_template "${template}" "${data}" "${output}"
 
 	return 0
 }


### PR DESCRIPTION
## Summary

Extracts sub-functions from functions exceeding 100 lines across 4 scripts. No behaviour changes — pure structural refactoring.

## Changes

### code-audit-helper.sh (Closes #5736)
- `print_summary`: extracted `print_findings_by_source` and `print_findings_by_category`
- `cmd_audit`: extracted `_audit_detect_pr`, `_audit_create_run`, `_audit_finalize_run`
- `cmd_report`: extracted `_report_validate_and_resolve`, `_report_dispatch_format`

### contest-helper.sh (Closes #5735)
- `cmd_create`: extracted `_create_verify_task`, `_create_check_existing`, `_create_insert_contest`
- `cmd_dispatch_contest`: extracted `_dispatch_load_contest`, `_dispatch_run_entries`
- `cmd_evaluate`: extracted `_evaluate_check_readiness`, `_evaluate_run_pipeline`

### dataset-helper.sh (Closes #5734)
- `cmd_validate`: extracted `_validate_parse_args`, `_validate_process_file`
- `cmd_add`: extracted `_add_parse_args`
- `cmd_promote`: extracted `_promote_parse_args`, `_promote_resolve_output`

### document-creation-helper.sh (Closes #5733)
- `cmd_create`: extracted `_create_cmd_parse_args`, `_create_validate_template`, `_create_fill_template`
- Note: `convert_eml_to_md` and `extract_contact_from_email` are already short bash functions (20 and 8 lines respectively); the scanner counted adjacent Python heredoc helpers

## Verification

- `bash -n` passes on all 4 files
- `shellcheck` shows only pre-existing SC1091 info-level warnings (sourced files), no new violations