### PR TITLE
issue-5784: reduce function complexity in content-fanout-helper.sh

### DIFF
--- a/.agents/scripts/content-fanout-helper.sh
+++ b/.agents/scripts/content-fanout-helper.sh
@@ -863,10 +863,10 @@ channel_estimate_values() {
 }
 
 # Print the per-channel estimate table rows.
-# Args: channels (space-separated)
-# Side effect: appends "tokens minutes" per channel to $_est_totals_file.
+# Args: channels (space-separated), totals_file (path to accumulate "tokens minutes" per channel)
 _print_estimate_rows() {
 	local channels="$1"
+	local totals_file="$2"
 
 	for ch in $channels; do
 		local est tokens minutes outputs
@@ -875,7 +875,7 @@ _print_estimate_rows() {
 		minutes="${est##* }"
 		outputs=$(channel_outputs "$ch" 2>/dev/null || echo "Channel-specific content")
 		printf "  %-18s %-8s %-8s %s\n" "$ch" "~${tokens}" "~${minutes}" "$outputs"
-		echo "${tokens} ${minutes}" >>"$_est_totals_file"
+		echo "${tokens} ${minutes}" >>"$totals_file"
 	done
 	return 0
 }
@@ -917,10 +917,11 @@ cmd_estimate() {
 	printf "  %-18s %-8s %-8s %s\n" "CHANNEL" "TOKENS" "MINUTES" "OUTPUTS"
 	printf "  %-18s %-8s %-8s %s\n" "-------" "------" "-------" "-------"
 
-	_est_totals_file=$(mktemp)
-	_print_estimate_rows "$channels"
-	_print_estimate_summary "$_est_totals_file"
-	rm -f "$_est_totals_file"
+	local est_totals_file
+	est_totals_file=$(mktemp)
+	_print_estimate_rows "$channels" "$est_totals_file"
+	_print_estimate_summary "$est_totals_file"
+	rm -f "$est_totals_file"
 
 	return 0
 }

--- a/.agents/scripts/content-fanout-helper.sh
+++ b/.agents/scripts/content-fanout-helper.sh
@@ -301,6 +301,8 @@ write_plan_file() {
 	local total_outputs=0
 	local formats_file
 	formats_file=$(mktemp)
+	# shellcheck disable=SC2064
+	trap "rm -f '$formats_file'" RETURN
 
 	{
 		_emit_plan_header
@@ -321,7 +323,6 @@ write_plan_file() {
 		echo "estimated_tokens: $((total_outputs * 2000))"
 	} >"$plan_file"
 
-	rm -f "$formats_file"
 	return 0
 }
 

--- a/.agents/scripts/content-fanout-helper.sh
+++ b/.agents/scripts/content-fanout-helper.sh
@@ -218,77 +218,110 @@ parse_channels() {
 
 # ─── Plan/run helper functions ────────────────────────────────────────
 
+# Emit the plan file header with brief metadata.
+# Reads BRIEF_* globals and plan_id from caller scope.
+_emit_plan_header() {
+	echo "# Content Fan-Out Plan"
+	echo "# Generated: $(timestamp)"
+	echo "# Version: ${FANOUT_VERSION}"
+	echo ""
+	echo "id: ${plan_id}"
+	echo "topic: ${BRIEF_TOPIC}"
+	echo "angle: ${BRIEF_ANGLE}"
+	echo "audience: ${BRIEF_AUDIENCE}"
+	echo "tone: ${BRIEF_TONE}"
+	echo "cta: ${BRIEF_CTA:-}"
+	echo "notes: ${BRIEF_NOTES:-}"
+	echo "status: planned"
+	echo ""
+	echo "# --- Channel Outputs ---"
+	echo ""
+	return 0
+}
+
+# Emit a single channel entry and collect its formats into a temp file.
+# Args: ch formats_file
+_emit_channel_entry() {
+	local ch="$1"
+	local formats_file="$2"
+
+	local formats outputs subagent
+	formats=$(channel_formats "$ch")
+	outputs=$(channel_outputs "$ch")
+	subagent=$(channel_subagent "$ch")
+
+	echo "channel: ${ch}"
+	echo "  subagent: ${subagent}"
+	echo "  formats: ${formats}"
+	echo "  outputs: ${outputs}"
+	echo "  status: pending"
+	echo ""
+
+	# Append comma-separated formats for dedup by caller
+	echo "$formats" >>"$formats_file"
+	return 0
+}
+
+# Count unique formats from a file of comma-separated format lines.
+# Args: formats_file
+# Outputs: "count format1 format2 ..."
+_count_unique_formats() {
+	local formats_file="$1"
+	local all_formats="" format_count=0
+
+	local line fmt _saved_ifs
+	while IFS= read -r line; do
+		_saved_ifs="$IFS"
+		IFS=','
+		for fmt in $line; do
+			case " ${all_formats} " in
+			*" ${fmt} "*) ;;
+			*) all_formats="${all_formats} ${fmt}" ;;
+			esac
+		done
+		IFS="$_saved_ifs"
+	done <"$formats_file"
+
+	for _fmt in $all_formats; do
+		format_count=$((format_count + 1))
+	done
+
+	echo "${format_count} (${all_formats})"
+	return 0
+}
+
 # Write the plan file content for cmd_plan.
 # Args: plan_file channels channel_count
 # Reads BRIEF_* globals set by parse_brief.
-# Outputs: all_formats (space-separated) and total_outputs via stdout side-channel
-#          (caller re-counts from the written file to avoid subshell variable loss).
 write_plan_file() {
 	local plan_file="$1"
 	local channels="$2"
 	local channel_count="$3"
 
 	local total_outputs=0
-	local all_formats=""
+	local formats_file
+	formats_file=$(mktemp)
 
 	{
-		echo "# Content Fan-Out Plan"
-		echo "# Generated: $(timestamp)"
-		echo "# Version: ${FANOUT_VERSION}"
-		echo ""
-		echo "id: ${plan_id}"
-		echo "topic: ${BRIEF_TOPIC}"
-		echo "angle: ${BRIEF_ANGLE}"
-		echo "audience: ${BRIEF_AUDIENCE}"
-		echo "tone: ${BRIEF_TONE}"
-		echo "cta: ${BRIEF_CTA:-}"
-		echo "notes: ${BRIEF_NOTES:-}"
-		echo "status: planned"
-		echo ""
-		echo "# --- Channel Outputs ---"
-		echo ""
+		_emit_plan_header
 
 		for ch in $channels; do
-			local formats
-			formats=$(channel_formats "$ch")
-			local outputs
-			outputs=$(channel_outputs "$ch")
-			local subagent
-			subagent=$(channel_subagent "$ch")
-
-			echo "channel: ${ch}"
-			echo "  subagent: ${subagent}"
-			echo "  formats: ${formats}"
-			echo "  outputs: ${outputs}"
-			echo "  status: pending"
-			echo ""
-
+			_emit_channel_entry "$ch" "$formats_file"
 			total_outputs=$((total_outputs + 1))
-
-			local fmt _saved_ifs2="$IFS"
-			IFS=','
-			for fmt in $formats; do
-				case " ${all_formats} " in
-				*" ${fmt} "*) ;;
-				*) all_formats="${all_formats} ${fmt}" ;;
-				esac
-			done
-			IFS="$_saved_ifs2"
 		done
 
-		local format_count=0
-		for _fmt in $all_formats; do
-			format_count=$((format_count + 1))
-		done
+		local unique_formats
+		unique_formats=$(_count_unique_formats "$formats_file")
 
 		echo "# --- Summary ---"
 		echo ""
 		echo "total_channels: ${channel_count}"
 		echo "total_outputs: ${total_outputs}"
-		echo "unique_formats: ${format_count} (${all_formats})"
+		echo "unique_formats: ${unique_formats}"
 		echo "estimated_tokens: $((total_outputs * 2000))"
 	} >"$plan_file"
 
+	rm -f "$formats_file"
 	return 0
 }
 
@@ -362,33 +395,37 @@ write_channel_prompt() {
 	return 0
 }
 
-# Emit the channel-specific instruction lines (no file redirection — caller handles it).
-# Args: ch
-write_channel_instructions() {
-	local ch="$1"
+# Emit channel-specific instruction lines for YouTube.
+_instructions_youtube() {
+	echo "Generate a complete YouTube video package:"
+	echo "1. Long-form script (scene-by-scene with B-roll directions, 8-12 min target)"
+	echo "2. Title (3 variants using hook formulas: Bold Claim, Question, Curiosity Gap)"
+	echo "3. Description (SEO-optimized, timestamps, links, keywords)"
+	echo "4. Tags (15-20 relevant tags)"
+	echo "5. Thumbnail brief (text overlay, emotion, color scheme, 3 variants)"
+	echo "6. End screen CTA script"
+	echo ""
+	echo "Reference: content/distribution/youtube/ for YouTube-specific conventions."
+	return 0
+}
 
+# Emit channel-specific instruction lines for short-form video.
+_instructions_short_form() {
+	echo "Generate vertical short-form video content:"
+	echo "1. 60-second script (hook in first 1-3 seconds, fast cuts every 1-3s)"
+	echo "2. Caption/subtitle text (for 80%+ silent viewers)"
+	echo "3. Trending sound suggestion (describe mood/genre, not specific track)"
+	echo "4. 3 hook variants (pattern interrupt openers)"
+	echo ""
+	echo "Format: 9:16 vertical. Platforms: TikTok, Reels, Shorts."
+	echo "Reference: content/distribution/short-form.md"
+	return 0
+}
+
+# Emit channel-specific instruction lines for social platforms.
+_instructions_social() {
+	local ch="$1"
 	case "$ch" in
-	youtube)
-		echo "Generate a complete YouTube video package:"
-		echo "1. Long-form script (scene-by-scene with B-roll directions, 8-12 min target)"
-		echo "2. Title (3 variants using hook formulas: Bold Claim, Question, Curiosity Gap)"
-		echo "3. Description (SEO-optimized, timestamps, links, keywords)"
-		echo "4. Tags (15-20 relevant tags)"
-		echo "5. Thumbnail brief (text overlay, emotion, color scheme, 3 variants)"
-		echo "6. End screen CTA script"
-		echo ""
-		echo "Reference: content/distribution/youtube/ for YouTube-specific conventions."
-		;;
-	short-form)
-		echo "Generate vertical short-form video content:"
-		echo "1. 60-second script (hook in first 1-3 seconds, fast cuts every 1-3s)"
-		echo "2. Caption/subtitle text (for 80%+ silent viewers)"
-		echo "3. Trending sound suggestion (describe mood/genre, not specific track)"
-		echo "4. 3 hook variants (pattern interrupt openers)"
-		echo ""
-		echo "Format: 9:16 vertical. Platforms: TikTok, Reels, Shorts."
-		echo "Reference: content/distribution/short-form.md"
-		;;
 	social-x)
 		echo "Generate X (Twitter) content:"
 		echo "1. Thread version (5-8 posts, hook-first, each post standalone value)"
@@ -396,7 +433,6 @@ write_channel_instructions() {
 		echo "3. Quote-post version (for sharing related content)"
 		echo ""
 		echo "Voice: Concise, opinionated, personality-forward."
-		echo "Reference: content/distribution/social.md"
 		;;
 	social-linkedin)
 		echo "Generate LinkedIn content:"
@@ -405,7 +441,6 @@ write_channel_instructions() {
 		echo "3. Article outline (if topic warrants deeper treatment)"
 		echo ""
 		echo "Voice: Professional, insight-driven, no sales pitch."
-		echo "Reference: content/distribution/social.md"
 		;;
 	social-reddit)
 		echo "Generate Reddit content:"
@@ -415,8 +450,17 @@ write_channel_instructions() {
 		echo "4. Comment engagement strategy"
 		echo ""
 		echo "Voice: Authentic, helpful, never salesy."
-		echo "Reference: content/distribution/social.md"
 		;;
+	*) return 1 ;;
+	esac
+	echo "Reference: content/distribution/social.md"
+	return 0
+}
+
+# Emit channel-specific instruction lines for text-based channels.
+_instructions_text_channel() {
+	local ch="$1"
+	case "$ch" in
 	blog)
 		echo "Generate SEO-optimized blog content:"
 		echo "1. Article outline (H2/H3 structure, 1500-2500 words target)"
@@ -447,6 +491,21 @@ write_channel_instructions() {
 		echo ""
 		echo "Reference: content/distribution/podcast.md"
 		;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+# Emit the channel-specific instruction lines (no file redirection — caller handles it).
+# Args: ch
+write_channel_instructions() {
+	local ch="$1"
+
+	case "$ch" in
+	youtube) _instructions_youtube ;;
+	short-form) _instructions_short_form ;;
+	social-x | social-linkedin | social-reddit) _instructions_social "$ch" ;;
+	blog | email | podcast) _instructions_text_channel "$ch" ;;
 	*)
 		echo "Generate content adapted for: ${ch}"
 		echo "Follow the conventions in the relevant distribution subagent."
@@ -529,6 +588,52 @@ cmd_plan() {
 	return 0
 }
 
+# Extract channel names from a plan file as a space-separated string.
+# Args: plan_file
+_extract_plan_channels() {
+	local plan_file="$1"
+	local channels=""
+
+	while IFS= read -r line; do
+		local ch="${line#channel: }"
+		if [[ -n "$channels" ]]; then
+			channels="${channels} ${ch}"
+		else
+			channels="$ch"
+		fi
+	done < <(grep '^channel:' "$plan_file")
+
+	echo "$channels"
+	return 0
+}
+
+# Generate prompts for each channel in the plan.
+# Args: channels output_dir
+# Reads PLAN_* globals. Returns completed count via stdout.
+_generate_channel_prompts() {
+	local channels="$1"
+	local output_dir="$2"
+	local completed=0
+
+	for ch in $channels; do
+		local ch_dir="${output_dir}/${ch}"
+		mkdir -p "$ch_dir"
+
+		print_info "Generating: ${ch}..."
+
+		write_channel_prompt \
+			"$ch" "$PLAN_TOPIC" "$PLAN_ANGLE" "$PLAN_AUDIENCE" \
+			"$PLAN_TONE" "$PLAN_CTA" "$PLAN_NOTES" \
+			"${ch_dir}/prompt.md"
+
+		echo "pending" >"${ch_dir}/.status"
+		completed=$((completed + 1))
+	done
+
+	echo "$completed"
+	return 0
+}
+
 cmd_run() {
 	local plan_file="$1"
 	ensure_dirs
@@ -546,33 +651,11 @@ cmd_run() {
 	print_info "Executing fan-out: ${PLAN_ID}"
 	print_info "Output directory: ${output_dir}"
 
-	local channels=""
-	while IFS= read -r line; do
-		local ch="${line#channel: }"
-		if [[ -n "$channels" ]]; then
-			channels="${channels} ${ch}"
-		else
-			channels="$ch"
-		fi
-	done < <(grep '^channel:' "$plan_file")
+	local channels
+	channels=$(_extract_plan_channels "$plan_file")
 
-	local completed=0
-	local failed=0
-
-	for ch in $channels; do
-		local ch_dir="${output_dir}/${ch}"
-		mkdir -p "$ch_dir"
-
-		print_info "Generating: ${ch}..."
-
-		write_channel_prompt \
-			"$ch" "$PLAN_TOPIC" "$PLAN_ANGLE" "$PLAN_AUDIENCE" \
-			"$PLAN_TONE" "$PLAN_CTA" "$PLAN_NOTES" \
-			"${ch_dir}/prompt.md"
-
-		echo "pending" >"${ch_dir}/.status"
-		completed=$((completed + 1))
-	done
+	local completed failed=0
+	completed=$(_generate_channel_prompts "$channels" "$output_dir")
 
 	write_run_summary "$output_dir" "$plan_file" "$completed" "$failed"
 
@@ -627,6 +710,40 @@ cmd_formats() {
 	return 0
 }
 
+# Print channel status rows and write counts to a totals file.
+# Args: output_dir totals_file
+_print_channel_statuses() {
+	local output_dir="$1"
+	local totals_file="$2"
+	local total=0 pending=0 complete=0
+
+	for ch_dir in "${output_dir}"/*/; do
+		[[ -d "$ch_dir" ]] || continue
+		local ch status="unknown"
+		ch=$(basename "$ch_dir")
+
+		if [[ -f "${ch_dir}/.status" ]]; then
+			status=$(cat "${ch_dir}/.status")
+		fi
+
+		total=$((total + 1))
+		case "$status" in
+		pending)
+			pending=$((pending + 1))
+			printf "  [ ] %s\n" "$ch"
+			;;
+		complete)
+			complete=$((complete + 1))
+			printf "  [x] %s\n" "$ch"
+			;;
+		*) printf "  [?] %s (%s)\n" "$ch" "$status" ;;
+		esac
+	done
+
+	echo "${total} ${complete} ${pending}" >"$totals_file"
+	return 0
+}
+
 cmd_status() {
 	local plan_file="$1"
 
@@ -648,37 +765,67 @@ cmd_status() {
 	echo "Fan-out status: ${plan_id}"
 	echo ""
 
-	local total=0
-	local pending=0
-	local complete=0
+	local totals_file
+	totals_file=$(mktemp)
+	_print_channel_statuses "$output_dir" "$totals_file"
 
-	for ch_dir in "${output_dir}"/*/; do
-		[[ -d "$ch_dir" ]] || continue
-		local ch
-		ch=$(basename "$ch_dir")
-		local status="unknown"
-
-		if [[ -f "${ch_dir}/.status" ]]; then
-			status=$(cat "${ch_dir}/.status")
-		fi
-
-		total=$((total + 1))
-		case "$status" in
-		pending)
-			pending=$((pending + 1))
-			printf "  [ ] %s\n" "$ch"
-			;;
-		complete)
-			complete=$((complete + 1))
-			printf "  [x] %s\n" "$ch"
-			;;
-		*) printf "  [?] %s (%s)\n" "$ch" "$status" ;;
-		esac
-	done
+	local total complete pending
+	read -r total complete pending <"$totals_file"
+	rm -f "$totals_file"
 
 	echo ""
 	echo "  Total: ${total} | Complete: ${complete} | Pending: ${pending}"
 
+	return 0
+}
+
+# Emit a story brief with the given field values.
+# Args: title angle channels tone notes
+_emit_brief_fields() {
+	local title="$1" angle="$2" channels="$3" tone="$4" notes="$5"
+	echo "# ${title}"
+	echo ""
+	echo "topic: "
+	echo "angle: ${angle}"
+	echo "audience: "
+	echo "channels: ${channels}"
+	echo "tone: ${tone}"
+	echo "cta: "
+	echo "notes: ${notes}"
+	return 0
+}
+
+# Emit a story brief template to stdout.
+# Args: template_type (default|video|blog|social)
+_emit_brief_template() {
+	local template_type="$1"
+	case "$template_type" in
+	default)
+		_emit_brief_fields "Story Brief" "contrarian" \
+			"youtube, short-form, social-x, social-linkedin, social-reddit, blog, email, podcast" \
+			"direct, conversational, data-backed" ""
+		;;
+	video)
+		_emit_brief_fields "Story Brief (Video-First)" "contrarian" \
+			"youtube, short-form" "energetic, visual, fast-paced" \
+			"Include B-roll directions and visual cues"
+		;;
+	blog)
+		_emit_brief_fields "Story Brief (Blog/SEO)" "educational" \
+			"blog, email, social-linkedin" "authoritative, helpful, SEO-aware" \
+			"Target keyword: [keyword]. Include internal link opportunities."
+		;;
+	social)
+		_emit_brief_fields "Story Brief (Social-First)" "hot-take" \
+			"social-x, social-linkedin, social-reddit, short-form" \
+			"punchy, opinionated, shareable" "Optimise for engagement and shares"
+		;;
+	*)
+		print_error "Unknown template type: $template_type"
+		print_info "Available: default, video, blog, social"
+		return 1
+		;;
+	esac
 	return 0
 }
 
@@ -688,70 +835,71 @@ cmd_template() {
 
 	local template_file="${TEMPLATES_DIR}/brief-${template_type}.md"
 
-	case "$template_type" in
-	default)
-		{
-			echo "# Story Brief"
-			echo ""
-			echo "topic: "
-			echo "angle: contrarian"
-			echo "audience: "
-			echo "channels: youtube, short-form, social-x, social-linkedin, social-reddit, blog, email, podcast"
-			echo "tone: direct, conversational, data-backed"
-			echo "cta: "
-			echo "notes: "
-		} >"$template_file"
-		;;
-	video)
-		{
-			echo "# Story Brief (Video-First)"
-			echo ""
-			echo "topic: "
-			echo "angle: contrarian"
-			echo "audience: "
-			echo "channels: youtube, short-form"
-			echo "tone: energetic, visual, fast-paced"
-			echo "cta: "
-			echo "notes: Include B-roll directions and visual cues"
-		} >"$template_file"
-		;;
-	blog)
-		{
-			echo "# Story Brief (Blog/SEO)"
-			echo ""
-			echo "topic: "
-			echo "angle: educational"
-			echo "audience: "
-			echo "channels: blog, email, social-linkedin"
-			echo "tone: authoritative, helpful, SEO-aware"
-			echo "cta: "
-			echo "notes: Target keyword: [keyword]. Include internal link opportunities."
-		} >"$template_file"
-		;;
-	social)
-		{
-			echo "# Story Brief (Social-First)"
-			echo ""
-			echo "topic: "
-			echo "angle: hot-take"
-			echo "audience: "
-			echo "channels: social-x, social-linkedin, social-reddit, short-form"
-			echo "tone: punchy, opinionated, shareable"
-			echo "cta: "
-			echo "notes: Optimise for engagement and shares"
-		} >"$template_file"
-		;;
-	*)
-		print_error "Unknown template type: $template_type"
-		print_info "Available: default, video, blog, social"
-		return 1
-		;;
-	esac
+	_emit_brief_template "$template_type" >"$template_file" || return 1
 
 	print_success "Template written: ${template_file}"
 	echo ""
 	cat "$template_file"
 
+	return 0
+}
+
+# Return estimated tokens and minutes for a channel as "tokens minutes".
+# Args: ch
+channel_estimate_values() {
+	local ch="$1"
+	case "$ch" in
+	youtube) echo "4000 8" ;;
+	short-form) echo "1500 3" ;;
+	social-x) echo "1000 2" ;;
+	social-linkedin) echo "1200 3" ;;
+	social-reddit) echo "800 2" ;;
+	blog) echo "3000 6" ;;
+	email) echo "1500 3" ;;
+	podcast) echo "2500 5" ;;
+	*) echo "1500 3" ;;
+	esac
+	return 0
+}
+
+# Print the per-channel estimate table rows.
+# Args: channels (space-separated)
+# Side effect: appends "tokens minutes" per channel to $_est_totals_file.
+_print_estimate_rows() {
+	local channels="$1"
+
+	for ch in $channels; do
+		local est tokens minutes outputs
+		est=$(channel_estimate_values "$ch")
+		tokens="${est%% *}"
+		minutes="${est##* }"
+		outputs=$(channel_outputs "$ch" 2>/dev/null || echo "Channel-specific content")
+		printf "  %-18s %-8s %-8s %s\n" "$ch" "~${tokens}" "~${minutes}" "$outputs"
+		echo "${tokens} ${minutes}" >>"$_est_totals_file"
+	done
+	return 0
+}
+
+# Print the estimate summary from accumulated totals.
+# Args: totals_file
+_print_estimate_summary() {
+	local totals_file="$1"
+	local total_tokens=0 total_minutes=0 channel_count=0
+	local t m
+
+	while read -r t m; do
+		total_tokens=$((total_tokens + t))
+		total_minutes=$((total_minutes + m))
+		channel_count=$((channel_count + 1))
+	done <"$totals_file"
+
+	echo ""
+	echo "  Total estimated tokens:  ~${total_tokens}"
+	echo "  Total estimated time:    ~${total_minutes} minutes (sequential)"
+	echo "  Parallel time (3 slots): ~$(((total_minutes + 2) / 3)) minutes"
+	echo ""
+	echo "  Channels: ${channel_count}"
+	echo "  Story research (one-time): ~30 minutes"
 	return 0
 }
 
@@ -766,72 +914,13 @@ cmd_estimate() {
 	echo "Fan-out estimate for: ${BRIEF_TOPIC}"
 	echo ""
 
-	local total_tokens=0
-	local total_minutes=0
-	local channel_count=0
-
 	printf "  %-18s %-8s %-8s %s\n" "CHANNEL" "TOKENS" "MINUTES" "OUTPUTS"
 	printf "  %-18s %-8s %-8s %s\n" "-------" "------" "-------" "-------"
 
-	for ch in $channels; do
-		local tokens=0
-		local minutes=0
-
-		# Estimates based on typical output sizes
-		case "$ch" in
-		youtube)
-			tokens=4000
-			minutes=8
-			;;
-		short-form)
-			tokens=1500
-			minutes=3
-			;;
-		social-x)
-			tokens=1000
-			minutes=2
-			;;
-		social-linkedin)
-			tokens=1200
-			minutes=3
-			;;
-		social-reddit)
-			tokens=800
-			minutes=2
-			;;
-		blog)
-			tokens=3000
-			minutes=6
-			;;
-		email)
-			tokens=1500
-			minutes=3
-			;;
-		podcast)
-			tokens=2500
-			minutes=5
-			;;
-		*)
-			tokens=1500
-			minutes=3
-			;;
-		esac
-
-		local outputs
-		outputs=$(channel_outputs "$ch" 2>/dev/null || echo "Channel-specific content")
-		printf "  %-18s %-8s %-8s %s\n" "$ch" "~${tokens}" "~${minutes}" "$outputs"
-		total_tokens=$((total_tokens + tokens))
-		total_minutes=$((total_minutes + minutes))
-		channel_count=$((channel_count + 1))
-	done
-
-	echo ""
-	echo "  Total estimated tokens:  ~${total_tokens}"
-	echo "  Total estimated time:    ~${total_minutes} minutes (sequential)"
-	echo "  Parallel time (3 slots): ~$(((total_minutes + 2) / 3)) minutes"
-	echo ""
-	echo "  Channels: ${channel_count}"
-	echo "  Story research (one-time): ~30 minutes"
+	_est_totals_file=$(mktemp)
+	_print_estimate_rows "$channels"
+	_print_estimate_summary "$_est_totals_file"
+	rm -f "$_est_totals_file"
 
 	return 0
 }
@@ -878,51 +967,45 @@ cmd_help() {
 
 # ─── Main ─────────────────────────────────────────────────────────────
 
+# Validate that a required argument is present.
+# Args: arg_count command_name arg_label
+_require_arg() {
+	local arg_count="$1"
+	local cmd_name="$2"
+	local arg_label="$3"
+
+	if [[ "$arg_count" -lt 1 ]]; then
+		print_error "Usage: content-fanout-helper.sh ${cmd_name} <${arg_label}>"
+		return 1
+	fi
+	return 0
+}
+
 main() {
 	local command="${1:-help}"
 	shift || true
 
 	case "$command" in
 	plan)
-		[[ $# -lt 1 ]] && {
-			print_error "Usage: content-fanout-helper.sh plan <brief-file>"
-			return 1
-		}
+		_require_arg $# "plan" "brief-file" || return 1
 		cmd_plan "$1"
 		;;
 	run)
-		[[ $# -lt 1 ]] && {
-			print_error "Usage: content-fanout-helper.sh run <plan-file>"
-			return 1
-		}
+		_require_arg $# "run" "plan-file" || return 1
 		cmd_run "$1"
 		;;
-	channels)
-		cmd_channels
-		;;
-	formats)
-		cmd_formats
-		;;
+	channels) cmd_channels ;;
+	formats) cmd_formats ;;
 	status)
-		[[ $# -lt 1 ]] && {
-			print_error "Usage: content-fanout-helper.sh status <plan-file>"
-			return 1
-		}
+		_require_arg $# "status" "plan-file" || return 1
 		cmd_status "$1"
 		;;
-	template)
-		cmd_template "${1:-default}"
-		;;
+	template) cmd_template "${1:-default}" ;;
 	estimate)
-		[[ $# -lt 1 ]] && {
-			print_error "Usage: content-fanout-helper.sh estimate <brief-file>"
-			return 1
-		}
+		_require_arg $# "estimate" "brief-file" || return 1
 		cmd_estimate "$1"
 		;;
-	help | --help | -h)
-		cmd_help
-		;;
+	help | --help | -h) cmd_help ;;
 	*)
 		print_error "${ERROR_UNKNOWN_COMMAND}: $command"
 		cmd_help


### PR DESCRIPTION
## Summary

- Extracted 14 focused helper functions from 7 functions that exceeded 50 lines in `.agents/scripts/content-fanout-helper.sh`
- All 40 functions now under 50 lines (max: 48 lines)
- No functionality changes — pure structural refactoring

## Functions decomposed

| Function | Before | After | Extracted helpers |
|----------|--------|-------|-------------------|
| `write_channel_instructions()` | 91 | 16 | `_instructions_youtube`, `_instructions_short_form`, `_instructions_social`, `_instructions_text_channel` |
| `cmd_estimate()` | 80 | 21 | `channel_estimate_values`, `_print_estimate_rows`, `_print_estimate_summary` |
| `cmd_template()` | 72 | 14 | `_emit_brief_fields`, `_emit_brief_template` |
| `write_plan_file()` | 68 | 31 | `_emit_plan_header`, `_emit_channel_entry`, `_count_unique_formats` |
| `cmd_run()` | 57 | 35 | `_extract_plan_channels`, `_generate_channel_prompts` |
| `cmd_status()` | 54 | 34 | `_print_channel_statuses` |
| `main()` | 52 | 32 | `_require_arg` |

## Verification

- `bash -n` syntax check: pass
- `shellcheck`: clean (only SC1091 info, globally disabled)
- All functions under 50 lines confirmed

Closes #5784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal helper functions for improved code organization and maintainability
  * Reorganized channel instruction generation logic
  * Streamlined command execution flow for better clarity
  * Improved status reporting code structure
  * Refactored template and estimate command implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->