### PR TITLE
refactor: reduce function complexity in 4 scripts (GH#5721-5724)

### DIFF
--- a/.agents/scripts/muapi-helper.sh
+++ b/.agents/scripts/muapi-helper.sh
@@ -319,6 +319,7 @@ cmd_flux() {
 	submit_and_poll "flux-dev-image" "${payload}" \
 		"${_flux_poll_interval}" "${_flux_timeout}" \
 		"${_flux_output_file}" "${_flux_webhook}"
+	return $?
 }
 
 # Parse arguments for cmd_effects — sets _effects_* globals
@@ -438,6 +439,7 @@ cmd_effects() {
 	submit_and_poll "generate_wan_ai_effects" "${payload}" \
 		"${_effects_poll_interval}" "${_effects_timeout}" \
 		"${_effects_output_file}" "${_effects_webhook}"
+	return $?
 }
 
 # Music generation (Suno)
@@ -522,6 +524,7 @@ cmd_music() {
 	fi
 
 	submit_and_poll "${endpoint}" "${payload}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Lip-sync
@@ -598,6 +601,7 @@ cmd_lipsync() {
 		'{video_url: $video, audio_url: $audio}')
 
 	submit_and_poll "${endpoint}" "${payload}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Agent operations

--- a/.agents/scripts/real-video-enhancer-helper.sh
+++ b/.agents/scripts/real-video-enhancer-helper.sh
@@ -294,37 +294,36 @@ cmd_install() {
 # Enhancement Commands
 # =============================================================================
 
-cmd_upscale() {
-	check_installation || return 1
-
-	local input=""
-	local output=""
-	local scale="${DEFAULT_SCALE}"
-	local model="${DEFAULT_UPSCALE_MODEL}"
-	local backend="${DEFAULT_BACKEND}"
-	local tile_size="${DEFAULT_TILE_SIZE}"
-	local verbose=false
+# Parse arguments for cmd_upscale; sets _UPSCALE_* globals
+_upscale_parse_args() {
+	_UPSCALE_INPUT=""
+	_UPSCALE_OUTPUT=""
+	_UPSCALE_SCALE="${DEFAULT_SCALE}"
+	_UPSCALE_MODEL="${DEFAULT_UPSCALE_MODEL}"
+	_UPSCALE_BACKEND="${DEFAULT_BACKEND}"
+	_UPSCALE_TILE_SIZE="${DEFAULT_TILE_SIZE}"
+	_UPSCALE_VERBOSE=false
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--scale | -s)
-			scale="$2"
+			_UPSCALE_SCALE="$2"
 			shift 2
 			;;
 		--model | -m)
-			model="$2"
+			_UPSCALE_MODEL="$2"
 			shift 2
 			;;
 		--backend | -b)
-			backend="$2"
+			_UPSCALE_BACKEND="$2"
 			shift 2
 			;;
 		--tile-size | -t)
-			tile_size="$2"
+			_UPSCALE_TILE_SIZE="$2"
 			shift 2
 			;;
 		--verbose | -v)
-			verbose=true
+			_UPSCALE_VERBOSE=true
 			shift
 			;;
 		-*)
@@ -332,10 +331,10 @@ cmd_upscale() {
 			return 1
 			;;
 		*)
-			if [[ -z "$input" ]]; then
-				input="$1"
-			elif [[ -z "$output" ]]; then
-				output="$1"
+			if [[ -z "${_UPSCALE_INPUT}" ]]; then
+				_UPSCALE_INPUT="$1"
+			elif [[ -z "${_UPSCALE_OUTPUT}" ]]; then
+				_UPSCALE_OUTPUT="$1"
 			else
 				print_error "Unexpected argument: $1"
 				return 1
@@ -344,6 +343,14 @@ cmd_upscale() {
 			;;
 		esac
 	done
+
+	return 0
+}
+
+# Validate upscale inputs and print usage on failure
+_upscale_validate() {
+	local input="$1"
+	local output="$2"
 
 	if [[ -z "$input" ]] || [[ -z "$output" ]]; then
 		print_error "Usage: real-video-enhancer-helper.sh upscale <input> <output> [options]"
@@ -360,6 +367,23 @@ cmd_upscale() {
 		print_error "Input file not found: $input"
 		return 1
 	fi
+
+	return 0
+}
+
+cmd_upscale() {
+	check_installation || return 1
+
+	_upscale_parse_args "$@" || return 1
+	local input="${_UPSCALE_INPUT}"
+	local output="${_UPSCALE_OUTPUT}"
+	local scale="${_UPSCALE_SCALE}"
+	local model="${_UPSCALE_MODEL}"
+	local backend="${_UPSCALE_BACKEND}"
+	local tile_size="${_UPSCALE_TILE_SIZE}"
+	local verbose="${_UPSCALE_VERBOSE}"
+
+	_upscale_validate "$input" "$output" || return 1
 
 	# Auto-detect backend if needed
 	if [[ "$backend" == "auto" ]]; then
@@ -393,34 +417,34 @@ cmd_upscale() {
 	fi
 
 	print_success "Upscaling complete: $output"
+	return 0
 }
 
-cmd_interpolate() {
-	check_installation || return 1
-
-	local input=""
-	local output=""
-	local fps="${DEFAULT_FPS}"
-	local model="${DEFAULT_INTERPOLATE_MODEL}"
-	local backend="${DEFAULT_BACKEND}"
-	local verbose=false
+# Parse arguments for cmd_interpolate; sets _INTERPOLATE_* globals
+_interpolate_parse_args() {
+	_INTERPOLATE_INPUT=""
+	_INTERPOLATE_OUTPUT=""
+	_INTERPOLATE_FPS="${DEFAULT_FPS}"
+	_INTERPOLATE_MODEL="${DEFAULT_INTERPOLATE_MODEL}"
+	_INTERPOLATE_BACKEND="${DEFAULT_BACKEND}"
+	_INTERPOLATE_VERBOSE=false
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--fps | -f)
-			fps="$2"
+			_INTERPOLATE_FPS="$2"
 			shift 2
 			;;
 		--model | -m)
-			model="$2"
+			_INTERPOLATE_MODEL="$2"
 			shift 2
 			;;
 		--backend | -b)
-			backend="$2"
+			_INTERPOLATE_BACKEND="$2"
 			shift 2
 			;;
 		--verbose | -v)
-			verbose=true
+			_INTERPOLATE_VERBOSE=true
 			shift
 			;;
 		-*)
@@ -428,10 +452,10 @@ cmd_interpolate() {
 			return 1
 			;;
 		*)
-			if [[ -z "$input" ]]; then
-				input="$1"
-			elif [[ -z "$output" ]]; then
-				output="$1"
+			if [[ -z "${_INTERPOLATE_INPUT}" ]]; then
+				_INTERPOLATE_INPUT="$1"
+			elif [[ -z "${_INTERPOLATE_OUTPUT}" ]]; then
+				_INTERPOLATE_OUTPUT="$1"
 			else
 				print_error "Unexpected argument: $1"
 				return 1
@@ -440,6 +464,14 @@ cmd_interpolate() {
 			;;
 		esac
 	done
+
+	return 0
+}
+
+# Validate interpolate inputs and print usage on failure
+_interpolate_validate() {
+	local input="$1"
+	local output="$2"
 
 	if [[ -z "$input" ]] || [[ -z "$output" ]]; then
 		print_error "Usage: real-video-enhancer-helper.sh interpolate <input> <output> [options]"
@@ -455,6 +487,22 @@ cmd_interpolate() {
 		print_error "Input file not found: $input"
 		return 1
 	fi
+
+	return 0
+}
+
+cmd_interpolate() {
+	check_installation || return 1
+
+	_interpolate_parse_args "$@" || return 1
+	local input="${_INTERPOLATE_INPUT}"
+	local output="${_INTERPOLATE_OUTPUT}"
+	local fps="${_INTERPOLATE_FPS}"
+	local model="${_INTERPOLATE_MODEL}"
+	local backend="${_INTERPOLATE_BACKEND}"
+	local verbose="${_INTERPOLATE_VERBOSE}"
+
+	_interpolate_validate "$input" "$output" || return 1
 
 	# Auto-detect backend if needed
 	if [[ "$backend" == "auto" ]]; then
@@ -487,29 +535,29 @@ cmd_interpolate() {
 	fi
 
 	print_success "Interpolation complete: $output"
+	return 0
 }
 
-cmd_denoise() {
-	check_installation || return 1
-
-	local input=""
-	local output=""
-	local model="${DEFAULT_DENOISE_MODEL}"
-	local backend="${DEFAULT_BACKEND}"
-	local verbose=false
+# Parse arguments for cmd_denoise; sets _DENOISE_* globals
+_denoise_parse_args() {
+	_DENOISE_INPUT=""
+	_DENOISE_OUTPUT=""
+	_DENOISE_MODEL="${DEFAULT_DENOISE_MODEL}"
+	_DENOISE_BACKEND="${DEFAULT_BACKEND}"
+	_DENOISE_VERBOSE=false
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--model | -m)
-			model="$2"
+			_DENOISE_MODEL="$2"
 			shift 2
 			;;
 		--backend | -b)
-			backend="$2"
+			_DENOISE_BACKEND="$2"
 			shift 2
 			;;
 		--verbose | -v)
-			verbose=true
+			_DENOISE_VERBOSE=true
 			shift
 			;;
 		-*)
@@ -517,10 +565,10 @@ cmd_denoise() {
 			return 1
 			;;
 		*)
-			if [[ -z "$input" ]]; then
-				input="$1"
-			elif [[ -z "$output" ]]; then
-				output="$1"
+			if [[ -z "${_DENOISE_INPUT}" ]]; then
+				_DENOISE_INPUT="$1"
+			elif [[ -z "${_DENOISE_OUTPUT}" ]]; then
+				_DENOISE_OUTPUT="$1"
 			else
 				print_error "Unexpected argument: $1"
 				return 1
@@ -529,6 +577,14 @@ cmd_denoise() {
 			;;
 		esac
 	done
+
+	return 0
+}
+
+# Validate denoise inputs and print usage on failure
+_denoise_validate() {
+	local input="$1"
+	local output="$2"
 
 	if [[ -z "$input" ]] || [[ -z "$output" ]]; then
 		print_error "Usage: real-video-enhancer-helper.sh denoise <input> <output> [options]"
@@ -543,6 +599,21 @@ cmd_denoise() {
 		print_error "Input file not found: $input"
 		return 1
 	fi
+
+	return 0
+}
+
+cmd_denoise() {
+	check_installation || return 1
+
+	_denoise_parse_args "$@" || return 1
+	local input="${_DENOISE_INPUT}"
+	local output="${_DENOISE_OUTPUT}"
+	local model="${_DENOISE_MODEL}"
+	local backend="${_DENOISE_BACKEND}"
+	local verbose="${_DENOISE_VERBOSE}"
+
+	_denoise_validate "$input" "$output" || return 1
 
 	# Auto-detect backend if needed
 	if [[ "$backend" == "auto" ]]; then
@@ -574,6 +645,7 @@ cmd_denoise() {
 	fi
 
 	print_success "Denoising complete: $output"
+	return 0
 }
 
 # Parse arguments for cmd_enhance; sets _ENHANCE_* globals

--- a/.agents/scripts/test-task-id-collision.sh
+++ b/.agents/scripts/test-task-id-collision.sh
@@ -906,15 +906,11 @@ EOF
 # =============================================================================
 # Test 11: .task-counter file validation
 # =============================================================================
-test_counter_validation() {
-	echo ""
-	echo "=== Test 11: .task-counter file validation ==="
-	info "Testing invalid counter file handling"
+# Helper: initialise a git repo without .task-counter for validation tests
+_counter_validation_setup() {
+	local test_repo="$1"
 
-	local test_repo="$TEST_DIR/test-repo-validate"
 	mkdir -p "$test_repo"
-
-	# Test with missing .task-counter
 	(
 		cd "$test_repo"
 		git init -q
@@ -927,6 +923,12 @@ EOF
 		git add TODO.md
 		git commit -q -m "init"
 	)
+	return 0
+}
+
+# Helper: verify missing .task-counter produces an error
+_counter_validation_check_missing() {
+	local test_repo="$1"
 
 	local output
 	output=$("$SCRIPT_DIR/claim-task-id.sh" --title "No counter test" --offline --no-issue --repo-path "$test_repo" 2>&1) || true
@@ -936,9 +938,16 @@ EOF
 	else
 		fail "Missing .task-counter did not produce expected error"
 	fi
+	return 0
+}
+
+# Helper: verify non-numeric and valid .task-counter values
+_counter_validation_check_values() {
+	local test_repo="$1"
 
 	# Test with non-numeric .task-counter
 	echo "abc" >"$test_repo/.task-counter"
+	local output
 	output=$("$SCRIPT_DIR/claim-task-id.sh" --title "Bad counter test" --offline --no-issue --repo-path "$test_repo" 2>&1) || true
 
 	if echo "$output" | grep -qi "invalid\|error"; then
@@ -959,6 +968,19 @@ EOF
 	else
 		fail "Expected t142, got '$task_id'"
 	fi
+	return 0
+}
+
+test_counter_validation() {
+	echo ""
+	echo "=== Test 11: .task-counter file validation ==="
+	info "Testing invalid counter file handling"
+
+	local test_repo="$TEST_DIR/test-repo-validate"
+
+	_counter_validation_setup "$test_repo"
+	_counter_validation_check_missing "$test_repo"
+	_counter_validation_check_values "$test_repo"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Reduces function complexity in four scripts by extracting sub-functions from commands that exceeded 100 lines. No behaviour changes.

## Changes

### `real-video-enhancer-helper.sh` (issue #5723 — primary violation)

`cmd_upscale` exceeded 100 lines. Extracted arg-parsing and validation following the existing pattern already used for `cmd_enhance` and `cmd_batch`:

- `_upscale_parse_args()` — parses CLI flags into `_UPSCALE_*` globals
- `_upscale_validate()` — validates input/output paths and prints usage

Applied the same pattern to `cmd_interpolate` and `cmd_denoise` (at 94 and 88 lines respectively) for consistency and to prevent future violations:

- `_interpolate_parse_args()` + `_interpolate_validate()`
- `_denoise_parse_args()` + `_denoise_validate()`

### `test-task-id-collision.sh` (issue #5721)

`test_counter_validation` exceeded 100 lines. Extracted three focused helpers:

- `_counter_validation_setup()` — initialises the test git repo
- `_counter_validation_check_missing()` — verifies missing counter produces error
- `_counter_validation_check_values()` — verifies non-numeric and valid counter values

### `muapi-helper.sh` (issue #5724)

Functions were already decomposed (parsers extracted in prior work). Added explicit `return $?` to `cmd_flux`, `cmd_effects`, `cmd_music`, and `cmd_lipsync` which were missing explicit returns.

### `test-ocr-extraction-pipeline.sh` (issue #5722)

Functions were already fully decomposed in prior work. No changes needed — all functions confirmed under 100 lines.

## Verification

- `bash -n` syntax check: all 4 files pass
- `shellcheck -S warning`: zero violations on all 4 files
- Function span check (start-to-next-function): no function exceeds 100 lines

Closes #5721
Closes #5722
Closes #5723
Closes #5724