### PR TITLE
docs: tighten agent docs to remove redundant content (#6085 #6084 #6083 #6082)

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -50,131 +50,70 @@ tools:
 **Security**: MCP servers are a trust boundary -- they access conversation context, credentials, and network. Verify source, scan dependencies (`npx @socketsecurity/cli npm info <pkg>`), and scan source (`skill-scanner scan /path`) before installing. See `tools/mcp-toolkit/mcporter.md` "Security Considerations".
 <!-- AI-CONTEXT-END -->
 
-This document provides comprehensive setup and usage instructions for advanced Model Context Protocol (MCP) integrations that dramatically expand our AI development capabilities.
+## Setup Commands
 
-## 📋 **Available MCP Integrations**
-
-### **🌐 Web & Browser Automation**
-
-- **Chrome DevTools MCP**: Browser automation, debugging, performance analysis
-- **Playwright MCP**: Cross-browser testing and automation
-- **Cloudflare Browser Rendering**: Server-side web scraping and rendering
-
-### **🔍 SEO & Research Tools**
-
-- **Ahrefs MCP**: SEO analysis, backlink research, keyword data
-- **Perplexity MCP**: AI-powered web search and research
-- **Google Search Console MCP**: Search performance data and insights
-
-### **📱 Mobile Testing**
-
-- **iOS Simulator MCP**: AI-driven iOS simulator interaction (tap, swipe, type, screenshot, accessibility)
-
-### **⚡ Development Tools**
-
-- **Claude Code MCP**: Run Claude Code as an MCP server for automation
-- **Next.js DevTools MCP**: Next.js development and debugging assistance
-- **Cloudflare Code Mode MCP**: Deploy Workers, query D1, manage KV/R2/Pages, AI Gateway — OAuth-authenticated remote server
-- **MCPorter**: TypeScript runtime, CLI, and code-generation toolkit — discover, call, compose, and generate CLIs/typed clients for any MCP server
-- **OpenAPI Search MCP**: Search and explore any OpenAPI specification — semantic search across 3000+ public APIs, zero install, no auth required
-
-### **📄 Document Processing**
-
-- **Unstract MCP**: LLM-powered structured data extraction from unstructured documents (PDF, images, DOCX)
-
-### **📧 CRM & Marketing**
-
-- **FluentCRM MCP**: WordPress CRM with contacts, campaigns, automations, and email marketing
-
-### **📚 Legacy MCP Servers (from MCP-SERVERS.md)**
-
-- **Context7 MCP**: Real-time documentation access for development libraries
-- **LocalWP MCP**: Direct WordPress database access for local development
-
-## 🎯 **Quick Setup Commands**
-
-### **Chrome DevTools MCP**
+### Chrome DevTools MCP
 
 ```bash
-# Add to Claude Desktop
 claude mcp add chrome-devtools npx chrome-devtools-mcp@latest
-
-# Add to VS Code Copilot
-code --add-mcp '{"name":"chrome-devtools","command":"npx","args":["chrome-devtools-mcp@latest"]}'
-
-# Manual configuration
-npx chrome-devtools-mcp@latest --channel=canary --headless=true
+# VS Code: code --add-mcp '{"name":"chrome-devtools","command":"npx","args":["chrome-devtools-mcp@latest"]}'
 ```
 
-### **Playwright MCP**
+### Playwright MCP
 
 ```bash
-# Install Playwright MCP
 npm install -g playwright-mcp
 playwright-mcp --install-browsers
-
-# Add to MCP client
 claude mcp add playwright npx playwright-mcp@latest
 ```
 
-### **iOS Simulator MCP**
+### iOS Simulator MCP
 
 ```bash
 # Prerequisites: macOS, Xcode with iOS simulators, Facebook IDB
 brew tap facebook/fb && brew install idb-companion
-
-# Add to Claude Code
 claude mcp add ios-simulator npx ios-simulator-mcp
 ```
 
 **Tools**: `ui_tap`, `ui_swipe`, `ui_type`, `ui_view`, `screenshot`, `record_video`, `ui_describe_all`, `install_app`, `launch_app`, `get_booted_sim_id`.
 
-**Env vars**: `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` (output dir), `IOS_SIMULATOR_MCP_FILTERED_TOOLS` (disable tools), `IOS_SIMULATOR_MCP_IDB_PATH` (custom IDB path).
+**Env vars**: `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR`, `IOS_SIMULATOR_MCP_FILTERED_TOOLS`, `IOS_SIMULATOR_MCP_IDB_PATH`.
 
-**Per-Agent Enablement**: The `tools/mobile/ios-simulator-mcp.md` subagent has `ios-simulator_*: true` in its tools section. Disabled globally, enabled on-demand.
+Per-agent enablement: `tools/mobile/ios-simulator-mcp.md` (disabled globally, enabled on-demand).
 
-See `tools/mobile/ios-simulator-mcp.md` for detailed documentation.
-
-### **Claude Code MCP (Fork)**
+### Claude Code MCP (Fork)
 
 ```bash
-# Add forked MCP server via Claude Code
 claude mcp add claude-code-mcp "npx -y github:marcusquinn/claude-code-mcp"
 ```
 
 **One-time setup**: run `claude --dangerously-skip-permissions` and accept prompts.
 **Upstream**: https://github.com/steipete/claude-code-mcp (revert if merged).
-**Local dev (optional)**: clone the fork and swap the command to `./start.sh` for instant iteration.
 
-### **MCPorter**
+### MCPorter
 
 ```bash
-# Zero-install (npx)
-npx mcporter list
-
-# Project dependency
-pnpm add mcporter
-
-# Homebrew
+npx mcporter list          # Zero-install
+pnpm add mcporter          # Project dependency
 brew tap steipete/tap && brew install steipete/tap/mcporter
 ```
 
-**Core commands**: `mcporter list` (discover servers/tools), `mcporter call` (invoke tools), `mcporter generate-cli` (mint standalone CLIs), `mcporter emit-ts` (typed client wrappers), `mcporter auth` (OAuth login), `mcporter daemon` (keep stateful servers warm).
+**Core commands**: `list` (discover), `call` (invoke), `generate-cli` (mint CLIs), `emit-ts` (typed clients), `auth` (OAuth), `daemon` (keep warm).
 
-**Auto-imports**: Merges configs from Claude Code, Claude Desktop, Cursor, Codex, Windsurf, OpenCode, VS Code automatically.
+Auto-imports configs from Claude Code, Claude Desktop, Cursor, Codex, Windsurf, OpenCode, VS Code.
 
 See `tools/mcp-toolkit/mcporter.md` for full documentation.
 
-### **OpenAPI Search MCP**
+### OpenAPI Search MCP
 
-No installation required — this is a remote Cloudflare Worker with no authentication needed.
+No installation — remote Cloudflare Worker, no auth required.
 
 ```bash
-# Claude Code (recommended)
+# Claude Code
 claude mcp add --scope user openapi-search --transport http https://openapi-mcp.openapisearch.com/mcp
 ```
 
-**For OpenCode** (`~/.config/opencode/opencode.json`):
+**OpenCode** (`~/.config/opencode/opencode.json`):
 
 ```json
 {
@@ -188,11 +127,7 @@ claude mcp add --scope user openapi-search --transport http https://openapi-mcp.
 }
 ```
 
-**For Claude Desktop** (config path by OS):
-
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+**Claude Desktop** config paths: macOS `~/Library/Application Support/Claude/claude_desktop_config.json`, Windows `%APPDATA%\Claude\claude_desktop_config.json`, Linux `~/.config/Claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -205,45 +140,21 @@ claude mcp add --scope user openapi-search --transport http https://openapi-mcp.
 }
 ```
 
-**Available Tools**: `searchAPIs` (semantic search across 3000+ public APIs), `getAPIOverview` (endpoint summary), `getOperationDetails` (full request/response schema).
+**Tools**: `searchAPIs` (3000+ public APIs), `getAPIOverview`, `getOperationDetails`. Workflow: search → overview → details (minimal context usage).
 
-**Workflow**: `searchAPIs` → `getAPIOverview` → `getOperationDetails` — keeps context usage minimal by loading only what you need.
+Per-agent enablement: `tools/context/openapi-search.md` (disabled globally, enabled on-demand).
 
-**Per-Agent Enablement**: The `tools/context/openapi-search.md` subagent has `openapi-search_*: true` in its tools section. Disabled globally, enabled on-demand for API exploration tasks.
+### Cloudflare Code Mode MCP
 
-See `tools/context/openapi-search.md` for full documentation.
-
-### **Cloudflare Code Mode MCP**
-
-No installation required — this is a remote MCP server authenticated via OAuth.
+No installation — remote server, OAuth-authenticated.
 
 ```json
-{
-  "cloudflare-api": {
-    "url": "https://mcp.cloudflare.com/mcp"
-  }
-}
+{ "cloudflare-api": { "url": "https://mcp.cloudflare.com/mcp" } }
 ```
 
-On first connection, your MCP client opens a browser OAuth flow to `dash.cloudflare.com`. After authorizing, the token is stored automatically — no manual API key setup needed.
+First connection opens browser OAuth flow to `dash.cloudflare.com`. Token stored automatically.
 
-**For Claude Desktop** (config path by OS):
-
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-- **Linux**: `~/.config/Claude/claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "cloudflare-api": {
-      "url": "https://mcp.cloudflare.com/mcp"
-    }
-  }
-}
-```
-
-**For OpenCode** (`~/.config/opencode/config.json`):
+**OpenCode** (`~/.config/opencode/config.json`):
 
 ```json
 {
@@ -256,26 +167,19 @@ On first connection, your MCP client opens a browser OAuth flow to `dash.cloudfl
 }
 ```
 
-**Available Tools**: Workers (deploy/update/tail), D1 (SQL queries/schema), KV (get/put/delete/list), R2 (objects/buckets), Pages (projects/deployments), AI Gateway (logs/analytics), DNS records, zone analytics.
+**Tools**: Workers (deploy/update/tail), D1 (SQL), KV (get/put/delete/list), R2 (objects/buckets), Pages (projects/deployments), AI Gateway (logs/analytics), DNS, zone analytics.
 
-**Per-Agent Enablement**: The `tools/api/cloudflare-mcp.md` subagent has `cloudflare-api_*: true` in its tools section. Disabled globally, enabled on-demand for Cloudflare platform work.
+Per-agent enablement: `tools/api/cloudflare-mcp.md` (disabled globally, enabled on-demand).
 
-See `tools/api/cloudflare-mcp.md` for detailed documentation.
-
-### **Ahrefs MCP**
+### Ahrefs MCP
 
 ```bash
-# Get your standard 40-char API key (NOT JWT tokens) from https://ahrefs.com/api
 # Store in ~/.config/aidevops/credentials.sh:
 export AHREFS_API_KEY="your_40_char_api_key"
-
-# For Claude Desktop:
 claude mcp add ahrefs npx @ahrefs/mcp@latest
 ```
 
-**Important**: The `@ahrefs/mcp` package expects `API_KEY` environment variable, not `AHREFS_API_KEY`.
-
-**For OpenCode** - use bash wrapper pattern (environment blocks don't expand variables):
+**Important**: Package expects `API_KEY` env var, not `AHREFS_API_KEY`. Use bash wrapper for OpenCode (env blocks don't expand variables):
 
 ```json
 {
@@ -287,42 +191,37 @@ claude mcp add ahrefs npx @ahrefs/mcp@latest
 }
 ```
 
-### **Perplexity MCP**
+### Perplexity MCP
 
 ```bash
-# Setup Perplexity integration
 export PERPLEXITY_API_KEY="your_api_key_here"
 claude mcp add perplexity npx perplexity-mcp@latest
 ```
 
-### **Google Search Console MCP**
+### Google Search Console MCP
 
 ```bash
-# Setup Google Search Console integration
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account-key.json"
 claude mcp add google-search-console npx mcp-server-gsc@latest
 ```
 
-### **FluentCRM MCP**
+### FluentCRM MCP
 
-**Note**: The FluentCRM MCP server is not published to npm. It requires cloning and building locally.
+Not published to npm — requires local build:
 
 ```bash
-# 1. Clone and build the MCP server
 mkdir -p ~/.local/share/mcp-servers
 cd ~/.local/share/mcp-servers
 git clone https://github.com/netflyapp/fluentcrm-mcp-server.git
-cd fluentcrm-mcp-server
-npm install
-npm run build
+cd fluentcrm-mcp-server && npm install && npm run build
 
-# 2. Store credentials in ~/.config/aidevops/credentials.sh:
+# Store in ~/.config/aidevops/credentials.sh:
 export FLUENTCRM_API_URL="https://your-domain.com/wp-json/fluent-crm/v2"
 export FLUENTCRM_API_USERNAME="your_username"
 export FLUENTCRM_API_PASSWORD="your_application_password"
 ```
 
-**For OpenCode** - use bash wrapper pattern (disabled globally, enabled per-agent):
+**OpenCode** (bash wrapper, disabled globally):
 
 ```json
 {
@@ -334,45 +233,19 @@ export FLUENTCRM_API_PASSWORD="your_application_password"
 }
 ```
 
-**For Claude Desktop**:
+Per-agent enablement: `services/crm/fluentcrm.md`. Tools: Contacts, Tags, Lists, Campaigns, Email Templates, Automations, Webhooks, Smart Links, Dashboard Stats.
 
-```json
-{
-  "mcpServers": {
-    "fluentcrm": {
-      "command": "node",
-      "args": ["~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"],
-      "env": {
-        "FLUENTCRM_API_URL": "https://your-domain.com/wp-json/fluent-crm/v2",
-        "FLUENTCRM_API_USERNAME": "your_username",
-        "FLUENTCRM_API_PASSWORD": "your_application_password"
-      }
-    }
-  }
-}
-```
-
-**Per-Agent Enablement**: The `services/crm/fluentcrm.md` subagent has `fluentcrm_*: true` in its tools section. Main agents (`sales.md`, `marketing.md`) reference this subagent for CRM operations.
-
-**Available Tools**: Contacts, Tags, Lists, Campaigns, Email Templates, Automations, Webhooks, Smart Links, Dashboard Stats.
-
-See `services/crm/fluentcrm.md` for detailed documentation.
-
-### **Unstract MCP**
+### Unstract MCP
 
 ```bash
-# 1. Self-hosted (recommended): unstract-helper.sh install
-# 2. Or cloud: Sign up at https://unstract.com/start-for-free/
-# 3. Create a Prompt Studio project, define schema, deploy as API
-# 4. Store credentials in ~/.config/aidevops/credentials.sh:
+# Self-hosted (recommended): unstract-helper.sh install
+# Or cloud: https://unstract.com/start-for-free/
+# Store in ~/.config/aidevops/credentials.sh:
 export UNSTRACT_API_KEY="your_api_key_here"
 export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
-chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
-**Note**: The MCP expects `API_BASE_URL` (not prefixed) - this matches the official Unstract spec.
-
-**For OpenCode** - Docker-based, disabled globally, enabled on-demand:
+**OpenCode** (Docker, disabled globally):
 
 ```json
 {
@@ -384,209 +257,62 @@ chmod 600 ~/.config/aidevops/credentials.sh
 }
 ```
 
-**For Claude Desktop** (Docker):
+**Tool**: `unstract_tool` — submits files, polls for completion, returns structured JSON. Set `UNSTRACT_IMAGE_TAG` to pin version.
 
-```json
-{
-  "mcpServers": {
-    "unstract_tool": {
-      "command": "/usr/local/bin/docker",
-      "args": [
-        "run", "-i", "--rm",
-        "-v", "/tmp:/tmp",
-        "-e", "UNSTRACT_API_KEY",
-        "-e", "API_BASE_URL",
-        "-e", "DISABLE_TELEMETRY=true",
-        "unstract/mcp-server", "unstract"
-      ],
-      "env": {
-        "UNSTRACT_API_KEY": "your_api_key",
-        "API_BASE_URL": "http://backend.unstract.localhost/deployment/api/.../"
-      }
-    }
-  }
-}
-```
+Per-agent enablement: `services/document-processing/unstract.md`.
 
-**Per-Agent Enablement**: The `services/document-processing/unstract.md` subagent has `unstract_tool: true` in its tools section. Agents needing document extraction reference this subagent.
+## Advanced Configurations
 
-**Available Tools**: `unstract_tool` - submits files, polls for completion, returns structured JSON. Supports optional metadata and metrics.
-
-**Image Pinning**: Set `UNSTRACT_IMAGE_TAG` env var to pin a specific version for reproducibility.
-
-See `services/document-processing/unstract.md` for detailed documentation.
-
-## 🔧 **Configuration Examples**
-
-### **Advanced Chrome DevTools Configuration**
+### Chrome DevTools (full options)
 
 ```json
 {
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": [
-        "chrome-devtools-mcp@latest",
-        "--channel=canary",
-        "--headless=true",
-        "--isolated=true",
-        "--viewport=1920x1080",
-        "--logFile=/tmp/chrome-mcp.log"
-      ]
+      "args": ["chrome-devtools-mcp@latest", "--channel=canary", "--headless=true", "--isolated=true", "--viewport=1920x1080", "--logFile=/tmp/chrome-mcp.log"]
     }
   }
 }
 ```
 
-### **Cloudflare Browser Rendering Configuration**
+### Cloudflare Browser Rendering
 
 ```json
 {
   "mcpServers": {
     "cloudflare-browser": {
       "command": "npx",
-      "args": [
-        "cloudflare-browser-rendering-mcp@latest",
-        "--account-id=your_account_id",
-        "--api-token=your_api_token"
-      ]
+      "args": ["cloudflare-browser-rendering-mcp@latest", "--account-id=your_account_id", "--api-token=your_api_token"]
     }
   }
 }
 ```
 
-## 📊 **Use Cases & Examples**
-
-### **Web Scraping & Analysis**
-
-- Extract data from websites using Chrome DevTools or Cloudflare Browser Rendering
-- Perform SEO analysis with Ahrefs integration
-- Research topics and gather information with Perplexity
-
-### **Automated Testing**
-
-- Cross-browser testing with Playwright
-- Performance analysis with Chrome DevTools
-- Visual regression testing and debugging
-
-### **Development Assistance**
-
-- Next.js development debugging and optimization
-- Real-time browser inspection and manipulation
-- API testing and validation
-
-## 🔐 **Security & API Keys**
-
-### **MCP Server Security Warning**
-
-**Every MCP server you install is a trust decision.** MCP servers run as persistent processes with access to your conversation context, credentials passed via environment variables, and network connectivity. A malicious or compromised MCP server can:
-
-- **Inject prompt instructions** via tool responses to manipulate your AI agent
-- **Exfiltrate credentials** passed in `env` blocks or inherited from your shell
-- **Log conversation context** including code, file contents, and sensitive data
-- **Introduce supply chain risks** via compromised npm/pip dependencies
-
-**Before installing any MCP server:**
-
-1. Verify the source repository and maintainer reputation
-2. Scan dependencies with Socket.dev: `npx @socketsecurity/cli npm info <package>`
-3. Scan source code with Cisco Skill Scanner: `skill-scanner scan /path/to/mcp-source`
-4. Use scoped API keys with minimal permissions -- never pass full-access tokens
-5. Pin package versions in your config -- avoid `@latest` in production
-
-See `tools/mcp-toolkit/mcporter.md` "Security Considerations" for the full risk model and mitigation checklist.
-
-### **Required API Keys**
-
-- **Ahrefs**: Get standard 40-char key from [Ahrefs API Dashboard](https://ahrefs.com/api) (JWT tokens don't work)
-- **Perplexity**: Get from [Perplexity API](https://docs.perplexity.ai/)
-- **Cloudflare**: Account ID and API token from Cloudflare dashboard
-
-### **Environment Variables**
+## Environment Variables
 
 ```bash
-# Ahrefs - store as AHREFS_API_KEY, MCP receives it as API_KEY via bash wrapper
-export AHREFS_API_KEY="your_40_char_ahrefs_key"
+export AHREFS_API_KEY="your_40_char_ahrefs_key"   # MCP receives as API_KEY via bash wrapper
 export PERPLEXITY_API_KEY="your_perplexity_key"
 export CLOUDFLARE_ACCOUNT_ID="your_account_id"
 export CLOUDFLARE_API_TOKEN="your_api_token"
-
-# Unstract - document processing (see services/document-processing/unstract.md)
 export UNSTRACT_API_KEY="your_unstract_api_key"
 export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
-# Optional: pin image version for reproducibility
-export UNSTRACT_IMAGE_TAG="latest"
+export UNSTRACT_IMAGE_TAG="latest"                 # Optional: pin image version
 ```
 
-## 🚀 **Getting Started**
-
-### **Quick Setup (All Integrations)**
-
-```bash
-# Install all MCP integrations
-bash .agents/scripts/setup-mcp-integrations.sh all
-
-# Validate setup
-bash .agents/scripts/validate-mcp-integrations.sh
-```
-
-### **Individual Integration Setup**
-
-```bash
-# Install specific integration
-bash .agents/scripts/setup-mcp-integrations.sh chrome-devtools
-bash .agents/scripts/setup-mcp-integrations.sh playwright
-bash .agents/scripts/setup-mcp-integrations.sh ahrefs
-```
-
-### **Configuration Steps**
-
-1. **Choose your MCP integrations** based on your needs
-2. **Run the setup script** for your selected integrations
-3. **Configure API keys** using the provided templates
-4. **Test integrations** with the validation script
-5. **Start using** advanced AI-assisted development capabilities!
-
-## 🎯 **Real-World Use Cases**
-
-### **Web Development Workflow**
-
-- **Chrome DevTools**: Debug performance issues, analyze Core Web Vitals
-- **Playwright**: Automated cross-browser testing and E2E validation
-- **Next.js DevTools**: Real-time development assistance and optimization
-
-### **SEO & Content Strategy**
-
-- **Ahrefs**: Keyword research, backlink analysis, competitor insights
-- **Perplexity**: AI-powered research and content ideation
-- **Cloudflare Browser Rendering**: Server-side content analysis
-
-### **Quality Assurance**
-
-- **Playwright**: Comprehensive test automation across browsers
-- **Chrome DevTools**: Performance monitoring and debugging
-- **Visual regression testing** with screenshot comparisons
-
-## 📊 **Integration Status Dashboard**
-
-Run the validation script to see your current setup status:
+## Validation
 
 ```bash
 bash .agents/scripts/validate-mcp-integrations.sh
+# Expected: ✅ Overall status: EXCELLENT (100% success rate)
 ```
 
-Expected output for fully configured setup:
+## Resources
 
-```text
-✅ Overall status: EXCELLENT (100% success rate)
-✅ All MCP integrations are ready to use!
-```
-
-## 📚 **Additional Resources**
-
-- [MCP Integration Setup Script](.agents/scripts/setup-mcp-integrations.sh)
-- [MCP Validation Script](.agents/scripts/validate-mcp-integrations.sh)
-- [MCP Configuration Templates](configs/mcp-templates/)
+- [Setup Script](.agents/scripts/setup-mcp-integrations.sh)
+- [Validation Script](.agents/scripts/validate-mcp-integrations.sh)
+- [Config Templates](configs/mcp-templates/)
 - [Chrome DevTools Guide](.agents/tools/browser/chrome-devtools.md)
-- [Playwright Automation Guide](.agents/tools/browser/playwright.md)
-- [Troubleshooting Guide](.agents/aidevops/mcp-troubleshooting.md)
+- [Playwright Guide](.agents/tools/browser/playwright.md)
+- [Troubleshooting](.agents/aidevops/mcp-troubleshooting.md)

--- a/.agents/content/production/audio.md
+++ b/.agents/content/production/audio.md
@@ -42,48 +42,28 @@ AI Video Output → CapCut AI Voice Cleanup → ElevenLabs Transformation → Fi
 
 **Why this matters:**
 
-1. **CapCut AI Voice Cleanup** (FIRST):
-   - Normalizes accents and artifacts from raw AI output
-   - Removes robotic patterns and unnatural cadence
-   - Cleans background noise and audio artifacts
-   - Standardizes volume and tone
+1. **CapCut AI Voice Cleanup** (FIRST): Normalizes accents/artifacts, removes robotic patterns, cleans background noise, standardizes volume and tone.
+2. **ElevenLabs Transformation** (SECOND): Voice cloning, emotional delivery, character consistency, professional quality.
 
-2. **ElevenLabs Transformation** (SECOND):
-   - Voice cloning for consistent channel narration
-   - Emotional delivery and natural speech patterns
-   - Character voice consistency across videos
-   - Professional voice quality
-
-**Common mistake**: Feeding raw AI video audio directly to ElevenLabs produces poor results because the artifacts and unnatural patterns get amplified during transformation.
+**Common mistake**: Feeding raw AI video audio directly to ElevenLabs amplifies artifacts during transformation.
 
 ### Voice Cloning Workflow
 
-For consistent channel narration across multiple videos:
-
 ```bash
-# 1. Record or extract clean voice sample (10-30 seconds minimum for instant clone)
-# 2. Upload to ElevenLabs voice library (or MiniMax with 10s clip)
-# 3. Use cloned voice for all channel content
-
 # Voice bridge for interactive voice (development/testing)
 voice-helper.sh talk              # Start voice conversation
 voice-helper.sh voices            # List available TTS voices
 ```
 
-**Critical: NEVER use pre-made ElevenLabs voices for realistic content.** Pre-made voices are widely recognised and immediately signal "AI-generated" to audiences. Instead:
+**Critical: NEVER use pre-made ElevenLabs voices for realistic content.** Pre-made voices are widely recognised and signal "AI-generated". Instead:
 
-- **Voice Design**: Create a unique voice from a natural language description (e.g., "warm female voice, mid-30s, slight British accent, confident and approachable")
-- **Instant Voice Clone**: Upload a 10-30 second clean audio clip of the target voice
+- **Voice Design**: Create from natural language description (e.g., "warm female voice, mid-30s, slight British accent")
+- **Instant Voice Clone**: Upload a 10-30 second clean audio clip
 - **Professional Voice Clone**: Upload 3-5 minutes for highest fidelity (recommended for AI influencer personas)
 
-**Voice cloning source quality rules:**
+**Voice cloning source quality rules**: Single speaker, quiet environment, clear pronunciation. If cloning from existing content, run through CapCut cleanup first.
 
-- Single speaker, no overlapping voices
-- Quiet environment, no background music or noise
-- Clear pronunciation, natural speaking pace
-- If cloning from existing content (YouTube, podcast), run through CapCut cleanup first (see Critical 2-Step Voice Workflow above)
-
-**Alternative: MiniMax TTS** — For talking-head content where ElevenLabs is overkill, MiniMax offers good default quality at $5/month for 120 minutes. Voice clone works with just a 10-second clip. See `tools/voice/voice-models.md` for full comparison.
+**Alternative: MiniMax TTS** — For talking-head content where ElevenLabs is overkill. Good default quality at $5/month for 120 minutes; voice clone works with a 10-second clip. See `tools/voice/voice-models.md`.
 
 **Voice consistency checklist:**
 
@@ -96,7 +76,7 @@ voice-helper.sh voices            # List available TTS voices
 
 ### Emotional Block Cues
 
-Per-word emotion tagging for natural AI speech delivery. This technique dramatically improves the naturalness of AI-generated speech by giving the TTS model explicit emotional context.
+Per-word emotion tagging for natural AI speech delivery. Dramatically improves naturalness by giving TTS explicit emotional context.
 
 **Format:**
 
@@ -106,123 +86,55 @@ Per-word emotion tagging for natural AI speech delivery. This technique dramatic
 
 **Available emotion tags:**
 
-| Tag | Use Case | Example |
-|-----|----------|---------|
-| `[neutral]` | Default, informational | "Here's how it works." |
-| `[excited]` | Hooks, reveals, wins | "This changed everything!" |
-| `[serious]` | Problems, warnings, data | "95% of creators fail here." |
-| `[curious]` | Questions, exploration | "What if we tried this?" |
-| `[confident]` | Authority, expertise | "I've tested this 100 times." |
-| `[empathetic]` | Pain points, struggles | "I know how frustrating this is." |
-| `[urgent]` | CTAs, time-sensitive | "Don't miss this opportunity." |
+| Tag | Use Case |
+|-----|----------|
+| `[neutral]` | Default, informational |
+| `[excited]` | Hooks, reveals, wins |
+| `[serious]` | Problems, warnings, data |
+| `[curious]` | Questions, exploration |
+| `[confident]` | Authority, expertise |
+| `[empathetic]` | Pain points, struggles |
+| `[urgent]` | CTAs, time-sensitive |
 
 **Emotional pacing rules:**
 
-1. **Hook (0-3s)**: Start with `[excited]` or `[curious]` to grab attention
-2. **Problem (3-10s)**: Shift to `[serious]` or `[empathetic]` to establish pain
-3. **Solution (10s+)**: Use `[confident]` to deliver value
-4. **CTA (final 5s)**: End with `[urgent]` or `[excited]` for action
+1. **Hook (0-3s)**: `[excited]` or `[curious]`
+2. **Problem (3-10s)**: `[serious]` or `[empathetic]`
+3. **Solution (10s+)**: `[confident]`
+4. **CTA (final 5s)**: `[urgent]` or `[excited]`
 
-**Example script with emotional blocks:**
-
-```text
-[excited]What if I told you there's a way to 10x your content output?[/excited]
-[serious]Most creators spend 40 hours per video.[/serious]
-[empathetic]I was stuck in that cycle for months.[/empathetic]
-[confident]Then I discovered this AI pipeline.[/confident]
-[excited]Now I produce 10 videos in the same time.[/excited]
-[urgent]Let me show you exactly how.[/urgent]
-```
-
-**Integration with script writing:**
-
-- Scripts from `content/production/writing.md` should include emotional block markup
-- Voice actors (human or AI) use these as delivery cues
-- TTS engines with emotion support (ElevenLabs, ChatTTS) parse these directly
+Scripts from `content/production/writing.md` should include emotional block markup. TTS engines with emotion support (ElevenLabs, ChatTTS) parse these directly.
 
 ## 4-Layer Audio Design
 
-Professional audio is built in layers, not as a single track. This approach gives you mixing flexibility and professional polish.
+### Layer 1: Dialogue (Primary) — Target: -15 LUFS
 
-### Layer 1: Dialogue (Primary)
+Processing chain: `Raw Voice → Noise Reduction → EQ → Compression → De-esser → Limiter → -15 LUFS`
 
-**Target LUFS**: -15 (dialogue clarity)
-
-- Voice narration or on-camera speech
-- Highest priority in the mix
 - Always centered (mono or center channel)
 - EQ: High-pass filter at 80Hz, presence boost at 3-5kHz
+- Tools: CapCut (AI cleanup), ElevenLabs (transformation), Audacity/Audition (manual), `voice-helper.sh`
 
-**Processing chain:**
+### Layer 2: Ambient Noise (Background) — Target: -25 LUFS
 
-```text
-Raw Voice → Noise Reduction → EQ → Compression → De-esser → Limiter → -15 LUFS
-```
+- Stereo width for immersion; low-pass filter to avoid competing with dialogue
 
-**Tools:**
+| Content Type | Ambient Style |
+|--------------|---------------|
+| UGC/Vlog | Diegetic only (room tone, keyboard clicks) |
+| Tutorial | Minimal/none |
+| Documentary | Rich environmental |
+| Commercial | Designed ambience |
 
-- CapCut: AI voice cleanup, noise reduction
-- ElevenLabs: Voice transformation, cloning
-- Audacity/Audition: Manual cleanup, EQ, compression
-- `voice-helper.sh`: Local voice processing
+Sources: Freesound.org (CC0/CC-BY), Epidemic Sound, custom recording, AI-generated (AudioCraft, Stable Audio).
 
-### Layer 2: Ambient Noise (Background)
+### Layer 3: SFX (Sound Effects) — Target: -10 to -20 LUFS
 
-**Target LUFS**: -25 (subtle presence)
+Categories: Whooshes/Swooshes, Impacts, UI Sounds, Foley, Risers/Drops.
 
-- Environmental sound (office, street, nature)
-- Establishes scene context
-- Stereo width for immersion
-- Low-pass filter to avoid competing with dialogue
+**Timing rules**: SFX should land 1-2 frames BEFORE the visual event. Layer multiple SFX for bigger impacts. Use reverb to place SFX in the same "space" as dialogue.
 
-**Content type ambient rules:**
-
-| Content Type | Ambient Style | Example |
-|--------------|---------------|---------|
-| UGC/Vlog | Diegetic only | Room tone, keyboard clicks |
-| Tutorial | Minimal/none | Silence or soft room tone |
-| Documentary | Rich environmental | Location-specific ambience |
-| Commercial | Designed ambience | Branded sonic environment |
-
-**Where to source:**
-
-- Freesound.org (CC0 and CC-BY)
-- Epidemic Sound (subscription)
-- Record custom ambience on location
-- AI-generated ambience (AudioCraft, Stable Audio)
-
-### Layer 3: SFX (Sound Effects)
-
-**Target LUFS**: Varies by effect (-10 to -20)
-
-- Punctuation for visual events
-- Transitions between scenes
-- UI sounds for motion graphics
-- Impact sounds for reveals
-
-**SFX categories:**
-
-1. **Whooshes/Swooshes**: Scene transitions, motion graphics
-2. **Impacts**: Reveals, text appearance, logo hits
-3. **UI Sounds**: Button clicks, notifications, tech interfaces
-4. **Foley**: Footsteps, object handling, physical actions
-5. **Risers/Drops**: Build tension, release energy
-
-**Timing rules:**
-
-- SFX should land 1-2 frames BEFORE the visual event (anticipation)
-- Layer multiple SFX for bigger impacts (e.g., whoosh + impact + reverb tail)
-- Use reverb to place SFX in the same "space" as dialogue
-
-### Layer 4: Music (Score)
-
-**Target LUFS**: -18 to -20 (supporting role)
-
-- Emotional tone and pacing
-- Fills silence without competing with dialogue
-- Ducking (auto-volume reduction) when dialogue plays
-
-**Music selection by content type:**
+### Layer 4: Music (Score) — Target: -18 to -20 LUFS
 
 | Content Type | Music Style | Ducking |
 |--------------|-------------|---------|
@@ -232,79 +144,13 @@ Raw Voice → Noise Reduction → EQ → Compression → De-esser → Limiter �
 | Documentary | Cinematic score | -4dB during speech |
 | YouTube | Upbeat, royalty-free | -6dB during speech |
 
-**Music sources:**
+Sources: Epidemic Sound, Artlist, Uppbeat (free tier), AudioJungle, AI-generated (Suno, Udio, Stable Audio).
 
-- Epidemic Sound (subscription, YouTube-safe)
-- Artlist (subscription, unlimited license)
-- Uppbeat (free tier, attribution)
-- AudioJungle (pay-per-track)
-- AI-generated (Suno, Udio, Stable Audio) - check platform policies
+**Ducking automation**: Set dialogue track as sidechain input, music as target. Threshold -20dB, ratio 4:1, attack 10ms, release 200ms.
 
-**Ducking automation:**
+## LUFS Reference
 
-Most NLEs (Premiere, DaVinci, Final Cut) support sidechain compression for automatic ducking. Set dialogue track as sidechain input, music track as target, threshold -20dB, ratio 4:1, attack 10ms, release 200ms.
-
-## Platform Audio Rules
-
-Different platforms and content types have different audio expectations. Violating these conventions makes content feel "off" even if technically correct.
-
-### UGC (User-Generated Content)
-
-**Rule**: All diegetic audio (sounds that exist in the scene)
-
-- No background music unless it's playing in the scene
-- Natural room tone and ambient noise
-- Authentic, unpolished feel
-- Dialogue can be slightly rough (adds authenticity)
-
-**Why**: UGC audiences expect raw, authentic audio. Overly polished audio signals "produced content" and breaks trust.
-
-**Examples**: TikTok vlogs, Instagram Stories, YouTube Shorts (personal)
-
-### Commercial/Branded
-
-**Rule**: Mixed diegetic + score
-
-- Professional voice (ElevenLabs or pro voice actor)
-- Designed ambience (not raw location audio)
-- Music score for emotional tone
-- Polished, clean mix
-
-**Why**: Branded content needs to signal quality and professionalism. Audiences expect production value.
-
-**Examples**: Product demos, brand videos, ads, sponsored content
-
-### Tutorial/Educational
-
-**Rule**: Dialogue-first, minimal music
-
-- Clear, intelligible voice (no competing sounds)
-- Music only in intro/outro or silent sections
-- SFX for UI interactions and transitions
-- Consistent volume throughout
-
-**Why**: Educational content prioritizes information transfer. Any audio that competes with dialogue reduces comprehension.
-
-**Examples**: How-to videos, courses, explainers
-
-### Documentary/Cinematic
-
-**Rule**: Rich soundscape, cinematic score
-
-- Layered ambience for immersion
-- Music score for emotional arc
-- Foley for physical actions
-- Dynamic range (quiet moments and loud moments)
-
-**Why**: Documentary audiences expect immersive, cinematic audio that enhances storytelling.
-
-**Examples**: Long-form YouTube documentaries, narrative content
-
-## LUFS Levels Reference
-
-LUFS (Loudness Units Full Scale) is the broadcast standard for measuring perceived loudness. Different content types and platforms have different target LUFS.
-
-### Target LUFS by Content Type
+### Platform Targets
 
 | Content Type | Target LUFS | Notes |
 |--------------|-------------|-------|
@@ -315,38 +161,37 @@ LUFS (Loudness Units Full Scale) is the broadcast standard for measuring perceiv
 | Streaming (Netflix) | -27 | Wide dynamic range |
 | Audiobook | -18 to -23 | Consistent, comfortable |
 
-### Layer LUFS Targets
+### Layer Targets
 
-| Layer | Target LUFS | Relative Level |
-|-------|-------------|----------------|
-| Dialogue | -15 | 0dB (reference) |
-| Ambient | -25 | -10dB |
-| SFX | -10 to -20 | Varies by effect |
-| Music | -18 to -20 | -3 to -5dB |
+| Layer | Target LUFS |
+|-------|-------------|
+| Dialogue | -15 (reference) |
+| Ambient | -25 |
+| SFX | -10 to -20 |
+| Music | -18 to -20 |
 
 **Measuring LUFS:**
 
 ```bash
-# ffmpeg (integrated LUFS)
 ffmpeg -i input.mp4 -af loudnorm=print_format=json -f null -
-
 # Audacity: Analyze > Loudness Normalization (preview mode)
 # DaVinci Resolve: Fairlight > Loudness Meter
-# Adobe Audition: Effects > Amplitude and Compression > Match Loudness
 ```
 
-**Normalization workflow:**
+**Normalization workflow**: Mix layers → measure integrated LUFS → apply normalization → limiter (true peak -1dB).
 
-1. Mix all layers to target relative levels
-2. Measure integrated LUFS of final mix
-3. Apply loudness normalization to hit platform target
-4. Use limiter to prevent clipping (true peak -1dB)
+## Platform Audio Rules
+
+| Platform | Rule | Why |
+|----------|------|-----|
+| UGC (TikTok, Shorts) | All diegetic, no score | Raw/authentic feel; polished audio breaks trust |
+| Commercial/Branded | Mixed diegetic + score, professional voice | Signals quality and production value |
+| Tutorial/Educational | Dialogue-first, minimal music | Competing audio reduces comprehension |
+| Documentary/Cinematic | Rich soundscape, cinematic score | Immersive storytelling |
 
 ## Voice Tools Reference
 
 ### Local Voice Processing
-
-**voice-helper.sh** - Interactive voice bridge for AI coding agent:
 
 ```bash
 voice-helper.sh talk              # Start voice conversation (defaults)
@@ -363,230 +208,21 @@ voice-helper.sh benchmark         # Test component speeds
 
 ### Cloud Voice Services
 
-**ElevenLabs** (voice cloning, transformation):
+**ElevenLabs**: Voice cloning from 3-5 min samples, 29 languages, 100+ stock voices, emotional control. API: `voice-pipeline-helper.sh [transform|tts|voices|clone]`
 
-- Voice cloning from 3-5 minute samples
-- 29 languages, 100+ stock voices
-- Emotional control and speaking style
-- API: `voice-pipeline-helper.sh [transform|tts|voices|clone]`
+**CapCut-equivalent cleanup** (local ffmpeg): Noise reduction, high-pass filter, de-essing, loudness normalization. CLI: `voice-pipeline-helper.sh cleanup <audio> [output] [target-lufs]`
 
-**CapCut-equivalent cleanup** (local ffmpeg processing):
+**Edge TTS** (Microsoft, free): 400+ voices, 100+ languages, fast, no API key. Used by voice-helper.sh.
 
-- Noise reduction, high-pass filter, de-essing
-- Loudness normalization to target LUFS
-- Compression and presence boost for voice clarity
-- CLI: `voice-pipeline-helper.sh cleanup <audio> [output] [target-lufs]`
-- Full pipeline: `voice-pipeline-helper.sh pipeline <file> [voice-id]`
-
-**CapCut** (web-based AI voice cleanup):
-
-- Accent normalization
-- Artifact removal
-- Background noise reduction
-- Web-based, no API (manual workflow — use `voice-pipeline-helper.sh cleanup` for automated equivalent)
-
-**Edge TTS** (Microsoft, free):
-
-- 400+ voices, 100+ languages
-- Fast, low-latency
-- No API key required
-- Used by voice-helper.sh
-
-### Speech-to-Speech Pipeline
-
-For advanced use cases (custom LLMs, server/client deployment, multi-language, phone integration), see `tools/voice/speech-to-speech.md`.
-
-**Pipeline**: `VAD → STT → LLM → TTS`
-
-**Deployment modes**:
-
-- Local (macOS with Apple Silicon)
-- Local (CUDA GPU)
-- Server/Client (Remote GPU)
-- Docker (CUDA)
-
-**Use cases**:
-
-- Voice-driven DevOps
-- Phone integration (Twilio)
-- Video narration
-- Multi-language support (6+ languages)
-
-## Audio Production Workflow
-
-### 1. Script Preparation
-
-From `content/production/writing.md`:
-
-- Long-form: Scene-by-scene with B-roll directions
-- Short-form: Hook-first, 60s constraint
-- Include emotional block cues for voice delivery
-- Mark dialogue pacing (8-second chunks for AI video)
-
-### 2. Voice Recording/Generation
-
-**Option A: AI Voice (ElevenLabs)**
-
-1. Generate voice from script with emotional blocks
-2. Export as WAV (48kHz, 24-bit)
-3. If from AI video: CapCut cleanup FIRST, then ElevenLabs
-
-**Option B: Human Voice Actor**
-
-1. Record in treated space (minimal reverb)
-2. Use pop filter and quality mic
-3. Record at -12dB to -18dB (leave headroom)
-4. Provide emotional block cues as delivery notes
-
-**Option C: Voice Cloning (Consistent Channel)**
-
-1. Record or source 3-5 minute clean voice sample
-2. Upload to ElevenLabs voice library
-3. Use cloned voice for all channel content
-4. Update voice sample quarterly for quality
-
-### 3. Voice Cleanup (Layer 1)
-
-```text
-Raw Voice → Noise Reduction → EQ → Compression → De-esser → Limiter → -15 LUFS
-```
-
-**Tools**: CapCut (AI cleanup), Audacity (manual), Adobe Audition (pro)
-
-### 4. Sound Design (Layers 2-4)
-
-**Ambient (Layer 2)**:
-
-- Source from Freesound, Epidemic Sound, or record custom
-- Low-pass filter to avoid dialogue competition
-- Target -25 LUFS
-
-**SFX (Layer 3)**:
-
-- Add whooshes for transitions
-- Add impacts for reveals
-- Time 1-2 frames before visual event
-- Layer multiple SFX for bigger impacts
-
-**Music (Layer 4)**:
-
-- Select music matching content type and emotional tone
-- Apply ducking (sidechain compression) to reduce volume during dialogue
-- Target -18 to -20 LUFS
-
-### 5. Mixing
-
-**Balance**:
-
-- Dialogue: 0dB (reference)
-- Ambient: -10dB
-- Music: -3 to -5dB
-- SFX: Varies by effect
-
-**Panning**:
-
-- Dialogue: Center (mono)
-- Ambient: Stereo width
-- Music: Stereo
-- SFX: Positioned to match visual
-
-**EQ**:
-
-- High-pass filter on all tracks (80Hz) to remove rumble
-- Presence boost on dialogue (3-5kHz)
-- Low-pass filter on ambient (8kHz) to avoid dialogue competition
-
-### 6. Mastering
-
-**Loudness normalization**:
-
-1. Measure integrated LUFS of final mix
-2. Apply loudness normalization to hit platform target
-3. Use limiter to prevent clipping (true peak -1dB)
-
-**Final export**:
-
-- Format: WAV or AAC
-- Sample rate: 48kHz (video standard)
-- Bit depth: 24-bit (WAV) or 320kbps (AAC)
-- Channels: Stereo (or mono for dialogue-only)
-
-## Content Type Audio Presets
-
-Quick-start presets for common content types:
-
-### YouTube Long-Form
-
-- **Dialogue**: -15 LUFS, centered, EQ for clarity
-- **Music**: Upbeat royalty-free, -18 LUFS, ducking -6dB
-- **SFX**: Transitions and reveals
-- **Ambient**: Minimal or none
-
-### TikTok/Shorts (UGC)
-
-- **Dialogue**: -12 LUFS (louder for mobile), authentic/raw
-- **Music**: Trending sounds (diegetic), no score
-- **SFX**: Minimal, only for emphasis
-- **Ambient**: Natural room tone
-
-### Commercial/Product Demo
-
-- **Dialogue**: -15 LUFS, professional voice (ElevenLabs)
-- **Music**: Branded score, -20 LUFS, ducking -8dB
-- **SFX**: UI sounds, product interactions
-- **Ambient**: Designed ambience (not raw location)
-
-### Podcast
-
-- **Dialogue**: -16 to -19 LUFS, consistent volume
-- **Music**: Intro/outro only, -18 LUFS
-- **SFX**: Minimal, transitions only
-- **Ambient**: None (studio environment)
-
-### Documentary/Cinematic
-
-- **Dialogue**: -15 LUFS, natural delivery
-- **Music**: Cinematic score, -18 LUFS, ducking -4dB
-- **SFX**: Rich foley, environmental sounds
-- **Ambient**: Layered, immersive, -25 LUFS
-
-## Integration with Content Pipeline
-
-Audio production fits into the broader content creation pipeline:
-
-```text
-Research (content/research.md)
-    ↓
-Story (content/story.md)
-    ↓
-Script (content/production/writing.md)
-    ↓
-Voice Production (THIS FILE)
-    ↓
-Video Production (content/production/video.md)
-    ↓
-Final Mix & Master
-    ↓
-Distribution (content/distribution/)
-```
-
-**Cross-references**:
-
-- **Script writing**: `content/production/writing.md` - Dialogue pacing, emotional cues
-- **Video production**: `content/production/video.md` - Audio sync, dialogue timing, longform talking-head pipeline
-- **Voice models**: `tools/voice/voice-models.md` - TTS model comparison (ElevenLabs, MiniMax, Qwen3-TTS)
-- **Voice pipeline**: `voice-pipeline-helper.sh` - CapCut cleanup + ElevenLabs transformation chain
-- **Voice tools**: `tools/voice/speech-to-speech.md` - Advanced voice pipeline
-- **Voice helper**: `voice-helper.sh` - Local voice processing
+For advanced use cases (custom LLMs, server/client deployment, phone integration), see `tools/voice/speech-to-speech.md`.
 
 ## See Also
 
-- `tools/voice/speech-to-speech.md` - Advanced voice pipeline (VAD, STT, LLM, TTS)
-- `tools/voice/cloud-voice-agents.md` - Cloud voice agents (GPT-4o Realtime, MiniCPM-o)
-- `tools/voice/voice-ai-models.md` - Complete model comparison (TTS, STT, S2S)
-- `tools/voice/pipecat-opencode.md` - Pipecat real-time voice pipeline
-- `tools/video/remotion.md` - Video narration and compositing
-- `tools/video/heygen-skill/rules/voices.md` - AI voice cloning
-- `content/production/writing.md` - Script structure and dialogue pacing
-- `content/production/video.md` - Video production and audio sync
-- `content/optimization.md` - A/B testing audio variants
+- `tools/voice/speech-to-speech.md` — Advanced voice pipeline (VAD, STT, LLM, TTS)
+- `tools/voice/cloud-voice-agents.md` — Cloud voice agents (GPT-4o Realtime, MiniCPM-o)
+- `tools/voice/voice-ai-models.md` — Complete model comparison (TTS, STT, S2S)
+- `tools/voice/voice-models.md` — TTS model comparison (ElevenLabs, MiniMax, Qwen3-TTS)
+- `tools/voice/pipecat-opencode.md` — Pipecat real-time voice pipeline
+- `content/production/writing.md` — Script structure, dialogue pacing, emotional cues
+- `content/production/video.md` — Video production and audio sync
+- `content/optimization.md` — A/B testing audio variants

--- a/.agents/tools/code-review/secretlint.md
+++ b/.agents/tools/code-review/secretlint.md
@@ -31,61 +31,21 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-Secretlint is a pluggable linting tool designed to prevent committing credentials and secrets to repositories. It provides an opt-in approach with comprehensive documentation for each detection rule.
-
-## Overview
-
-| Feature | Description |
-|---------|-------------|
-| **Secret Scanner** | Finds credentials in projects and reports them |
-| **Project-Friendly** | Easy setup per-project with CI service integration |
-| **Pre-Commit Hooks** | Prevents committing credential files |
-| **Pluggable** | Custom rules and flexible configuration |
-| **Documentation** | Each rule describes why it detects something as secret |
-
 ## Quick Start
 
-### Installation Options
-
 ```bash
-# Option 1: Local installation (recommended for projects)
-./.agents/scripts/secretlint-helper.sh install
+./.agents/scripts/secretlint-helper.sh install   # Local install (recommended)
+./.agents/scripts/secretlint-helper.sh quick     # Quick scan without installation
+./.agents/scripts/secretlint-helper.sh docker    # Docker (no Node.js required)
+./.agents/scripts/secretlint-helper.sh install global  # Global installation
 
-# Option 2: Quick scan without installation
-./.agents/scripts/secretlint-helper.sh quick
-
-# Option 3: Docker (no Node.js required)
-./.agents/scripts/secretlint-helper.sh docker
-
-# Option 4: Global installation
-./.agents/scripts/secretlint-helper.sh install global
-```
-
-### Basic Usage
-
-```bash
-# Check installation status
-./.agents/scripts/secretlint-helper.sh status
-
-# Initialize configuration
-./.agents/scripts/secretlint-helper.sh init
-
-# Scan all files
-./.agents/scripts/secretlint-helper.sh scan
-
-# Scan specific directory
-./.agents/scripts/secretlint-helper.sh scan "src/**/*"
-
-# Quick scan (no installation needed)
-./.agents/scripts/secretlint-helper.sh quick
-
-# Scan via Docker
-./.agents/scripts/secretlint-helper.sh docker
+./.agents/scripts/secretlint-helper.sh status    # Check installation status
+./.agents/scripts/secretlint-helper.sh init      # Initialize configuration
+./.agents/scripts/secretlint-helper.sh scan      # Scan all files
+./.agents/scripts/secretlint-helper.sh scan "src/**/*"  # Scan specific directory
 ```
 
 ## Detected Secret Types
-
-Secretlint's recommended preset detects:
 
 | Secret Type | Rule |
 |-------------|------|
@@ -104,32 +64,21 @@ Secretlint's recommended preset detects:
 | 1Password Service Account Tokens | `@secretlint/secretlint-rule-1password` |
 | Database Connection Strings | `@secretlint/secretlint-rule-database-connection-string` |
 
-### Additional Rules
-
-| Rule | Description |
-|------|-------------|
-| `@secretlint/secretlint-rule-pattern` | Custom regex patterns |
-| `@secretlint/secretlint-rule-secp256k1-privatekey` | Cryptocurrency private keys |
-| `@secretlint/secretlint-rule-no-k8s-kind-secret` | Kubernetes Secret manifests |
-| `@secretlint/secretlint-rule-no-homedir` | Home directory paths |
-| `@secretlint/secretlint-rule-no-dotenv` | .env file detection |
-| `@secretlint/secretlint-rule-filter-comments` | Comment-based ignoring |
+**Additional rules**: `@secretlint/secretlint-rule-pattern` (custom regex), `secretlint-rule-secp256k1-privatekey` (crypto keys), `secretlint-rule-no-k8s-kind-secret` (Kubernetes), `secretlint-rule-no-homedir`, `secretlint-rule-no-dotenv`, `secretlint-rule-filter-comments`.
 
 ## Configuration
 
-### Basic Configuration (.secretlintrc.json)
+### Basic (.secretlintrc.json)
 
 ```json
 {
   "rules": [
-    {
-      "id": "@secretlint/secretlint-rule-preset-recommend"
-    }
+    { "id": "@secretlint/secretlint-rule-preset-recommend" }
   ]
 }
 ```
 
-### Advanced Configuration
+### Advanced
 
 ```json
 {
@@ -139,26 +88,15 @@ Secretlint's recommended preset detects:
       "rules": [
         {
           "id": "@secretlint/secretlint-rule-aws",
-          "options": {
-            "allows": ["/test-key-/i", "AKIAIOSFODNN7EXAMPLE"]
-          },
+          "options": { "allows": ["/test-key-/i", "AKIAIOSFODNN7EXAMPLE"] },
           "allowMessageIds": ["AWSAccountID"]
-        },
-        {
-          "id": "@secretlint/secretlint-rule-github",
-          "disabled": false
         }
       ]
     },
     {
       "id": "@secretlint/secretlint-rule-pattern",
       "options": {
-        "patterns": [
-          {
-            "name": "custom-api-key",
-            "patterns": ["/MY_CUSTOM_KEY=[A-Za-z0-9]{32}/"]
-          }
-        ]
+        "patterns": [{ "name": "custom-api-key", "patterns": ["/MY_CUSTOM_KEY=[A-Za-z0-9]{32}/"] }]
       }
     }
   ]
@@ -177,26 +115,15 @@ Secretlint's recommended preset detects:
 
 ### Ignore File (.secretlintignore)
 
-Uses `.gitignore` syntax:
-
 ```text
-# Dependencies
 **/node_modules/**
 **/vendor/**
-
-# Build outputs
 **/dist/**
 **/build/**
-
-# Test fixtures (may contain fake secrets)
 **/test/fixtures/**
 **/testdata/**
-
-# Generated files
 **/package-lock.json
 **/pnpm-lock.yaml
-
-# Binary files
 **/*.png
 **/*.jpg
 **/*.pdf
@@ -204,22 +131,14 @@ Uses `.gitignore` syntax:
 
 ## Ignoring by Comments
 
-Use inline comments to ignore specific lines:
-
 ```javascript
 // secretlint-disable-next-line
 const API_KEY = "sk-test-12345";
 
-const config = {
-  key: "secret-value" // secretlint-disable-line
-};
+const config = { key: "secret-value" }; // secretlint-disable-line
 
 // secretlint-disable
-// Block of code with test secrets
-const TEST_KEYS = {
-  aws: "AKIAIOSFODNN7EXAMPLE",
-  github: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-};
+const TEST_KEYS = { aws: "AKIAIOSFODNN7EXAMPLE" };
 // secretlint-enable
 
 /* secretlint-disable @secretlint/secretlint-rule-github -- test credentials */
@@ -229,72 +148,33 @@ const testToken = "ghs_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
 ## Output Formats
 
-### Stylish (default)
-
 ```bash
-secretlint "**/*"
-```
+secretlint "**/*"                                          # Stylish (default)
+secretlint "**/*" --format json                            # JSON
+./.agents/scripts/secretlint-helper.sh scan . json        # JSON via helper
 
-### JSON
-
-```bash
-secretlint "**/*" --format json
-# or
-./.agents/scripts/secretlint-helper.sh scan . json
-```
-
-### SARIF (for CI/CD)
-
-```bash
-# Install SARIF formatter
+# SARIF (for CI/CD security dashboards)
 npm install @secretlint/secretlint-formatter-sarif --save-dev
-
-# Generate SARIF
 secretlint "**/*" --format @secretlint/secretlint-formatter-sarif > results.sarif
-# or
-./.agents/scripts/secretlint-helper.sh sarif
-```
+./.agents/scripts/secretlint-helper.sh sarif              # Via helper
 
-### Mask Result (fix secrets)
-
-```bash
-# Mask secrets in a file and overwrite
+# Mask secrets in a file
 secretlint .zsh_history --format=mask-result --output=.zsh_history
-# or
-./.agents/scripts/secretlint-helper.sh mask .env.example
+./.agents/scripts/secretlint-helper.sh mask .env.example  # Via helper
 ```
 
 ## Pre-commit Integration
 
-### Option 1: Native Git Hook
-
 ```bash
-# Setup via helper
+# Option 1: Native git hook
 ./.agents/scripts/secretlint-helper.sh hook
-```
 
-### Option 2: Husky + lint-staged (Node.js projects)
-
-```bash
-# Setup via helper
+# Option 2: Husky + lint-staged (Node.js projects)
 ./.agents/scripts/secretlint-helper.sh husky
-```
-
-Or manually:
-
-```bash
-# Install
+# Or manually:
 npx husky-init && npm install lint-staged --save-dev
-
-# Configure lint-staged in package.json
-{
-  "lint-staged": {
-    "*": ["secretlint"]
-  }
-}
-
-# Add hook
-npx husky add .husky/pre-commit "npx --no-install lint-staged"
+# Add to package.json: "lint-staged": { "*": ["secretlint"] }
+# npx husky add .husky/pre-commit "npx --no-install lint-staged"
 ```
 
 ### Option 3: pre-commit Framework (Docker)
@@ -324,8 +204,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+        with: { node-version: 20 }
       - run: npm ci
       - run: npx secretlint "**/*"
 ```
@@ -340,13 +219,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        with: { fetch-depth: 0 }
       - uses: tj-actions/changed-files@v44
         id: changed-files
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+        with: { node-version: 20 }
       - if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           npm ci
@@ -358,57 +235,24 @@ jobs:
 ```yaml
 secretlint:
   image: secretlint/secretlint:latest
-  script:
-    - secretlint "**/*"
+  script: secretlint "**/*"
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
-### Generic CI Script
-
-```bash
-#!/bin/bash
-set -e
-
-# Install
-npm ci
-
-# Run secretlint
-npx secretlint "**/*" --format json > secretlint-results.json || true
-
-# Check for issues
-if jq -e '.messages | length > 0' secretlint-results.json > /dev/null; then
-    echo "Secrets detected!"
-    jq '.messages[] | "\(.filePath):\(.line):\(.column) \(.ruleId): \(.message)"' secretlint-results.json
-    exit 1
-fi
-
-echo "No secrets found"
-```
-
 ## Docker Usage
 
-### Quick Scan
-
 ```bash
+# Quick scan
 docker run -v "$(pwd)":"$(pwd)" -w "$(pwd)" --rm -it secretlint/secretlint secretlint "**/*"
-```
 
-### With Custom Config
-
-```bash
+# With custom config
 docker run -v "$(pwd)":"$(pwd)" -w "$(pwd)" --rm -it \
-  secretlint/secretlint secretlint "**/*" \
-  --secretlintrc .secretlintrc.json
+  secretlint/secretlint secretlint "**/*" --secretlintrc .secretlintrc.json
 ```
 
-### Built-in Docker Packages
-
-The Docker image includes:
-- `@secretlint/secretlint-rule-preset-recommend`
-- `@secretlint/secretlint-rule-pattern`
-- `@secretlint/secretlint-formatter-sarif`
+Docker image includes: `secretlint-rule-preset-recommend`, `secretlint-rule-pattern`, `secretlint-formatter-sarif`.
 
 ## Comparison with Other Tools
 
@@ -416,115 +260,16 @@ The Docker image includes:
 |---------|------------|-------------|----------------|----------|
 | Approach | Opt-in | Opt-out | Opt-out | Opt-out |
 | Custom Rules | npm packages | Shell patterns | Python plugins | TOML config |
-| Pre-commit | Yes | Yes | Yes | Yes |
-| CI/CD | Yes | Yes | Yes | Yes |
 | Documentation | Per-rule docs | Limited | Limited | Limited |
 | Node.js Required | Yes (or Docker) | No | Python | No |
 | False Positives | Lower (opt-in) | Higher | Medium | Medium |
 
-## Best Practices
-
-### For Development Teams
-
-1. **Install locally** in each project for consistent behavior
-2. **Initialize configuration** early in project setup
-3. **Use pre-commit hooks** to catch secrets before they're committed
-4. **Configure allowlists** for known safe patterns (test credentials)
-5. **Document exceptions** with `secretlint-disable` comments
-
-### For CI/CD
-
-1. **Fail builds** when secrets are detected
-2. **Generate SARIF** for security dashboard integration
-3. **Scan diff only** in PRs for performance
-4. **Use Docker** for consistent, dependency-free scanning
-
-### Handling False Positives
-
-1. **Allow specific patterns** in rule options:
-
-   ```json
-   {
-     "options": {
-       "allows": ["/test-/i", "example-key"]
-     }
-   }
-   ```
-
-2. **Suppress specific message IDs**:
-
-   ```json
-   {
-     "allowMessageIds": ["AWSAccountID"]
-   }
-   ```
-
-3. **Use inline comments** for one-off exceptions:
-
-   ```javascript
-   const key = "test-key"; // secretlint-disable-line
-   ```
-
-4. **Add to ignore file** for entire files/directories
-
-## Integration with AI DevOps Framework
-
-### Helper Script Commands
-
-```bash
-# Installation
-./.agents/scripts/secretlint-helper.sh install         # Local install
-./.agents/scripts/secretlint-helper.sh install global  # Global install
-./.agents/scripts/secretlint-helper.sh install-rules all  # Additional rules
-
-# Configuration
-./.agents/scripts/secretlint-helper.sh init            # Initialize config
-./.agents/scripts/secretlint-helper.sh status          # Check status
-
-# Scanning
-./.agents/scripts/secretlint-helper.sh scan            # Scan all files
-./.agents/scripts/secretlint-helper.sh scan "src/**/*" # Scan specific
-./.agents/scripts/secretlint-helper.sh quick           # Quick scan (npx)
-./.agents/scripts/secretlint-helper.sh docker          # Docker scan
-
-# Output
-./.agents/scripts/secretlint-helper.sh scan . json     # JSON output
-./.agents/scripts/secretlint-helper.sh sarif           # SARIF output
-./.agents/scripts/secretlint-helper.sh mask file.txt   # Mask secrets
-
-# Hooks
-./.agents/scripts/secretlint-helper.sh hook            # Git hook
-./.agents/scripts/secretlint-helper.sh husky           # Husky setup
-```
-
-### Quality Pipeline Integration
-
-Secretlint integrates with the framework's quality pipeline:
-
-```bash
-# Run as part of quality checks
-./.agents/scripts/linters-local.sh  # Includes secretlint
-
-# Pre-commit validation
-./.agents/scripts/pre-commit-hook.sh  # Includes secretlint
-```
-
 ## Troubleshooting
-
-### Common Issues
 
 **"Failed to load rule module: @secretlint/secretlint-rule-preset-recommend is not found"**
 
-This error means secretlint is installed but the required rule preset is missing. The config file references rules that aren't installed.
-
 ```bash
-# Fix: Install the preset alongside secretlint
 npm install --save-dev secretlint @secretlint/secretlint-rule-preset-recommend
-
-# Or globally
-npm install -g secretlint @secretlint/secretlint-rule-preset-recommend
-
-# Verify installation
 ./.agents/scripts/secretlint-helper.sh status
 ```
 
@@ -537,39 +282,27 @@ npm install -g secretlint @secretlint/secretlint-rule-preset-recommend
 **"secretlint command not found"**
 
 ```bash
-# Use npx
 npx secretlint "**/*"
-# Or install globally (include the preset!)
-npm install -g secretlint @secretlint/secretlint-rule-preset-recommend
+# Or: npm install -g secretlint @secretlint/secretlint-rule-preset-recommend
 ```
 
-**Scan fails with exit code 2**
-
-Exit code 2 indicates a configuration or installation error (not secrets found). Check:
+**Exit code 2** (configuration/installation error, not secrets found):
 
 ```bash
-# Diagnose the issue
 ./.agents/scripts/secretlint-helper.sh status
-
-# Common fixes:
-# 1. Missing rules - reinstall
-./.agents/scripts/secretlint-helper.sh install
-
-# 2. Invalid config - reinitialize
-rm .secretlintrc.json
-./.agents/scripts/secretlint-helper.sh init
+./.agents/scripts/secretlint-helper.sh install   # Missing rules
+rm .secretlintrc.json && ./.agents/scripts/secretlint-helper.sh init  # Invalid config
 ```
 
-**Performance issues with large repos**
+**Performance issues with large repos** — add to `.secretlintignore`:
 
-```bash
-# Configure .secretlintignore to exclude:
+```text
 **/node_modules/**
 **/dist/**
 **/*.lock
 ```
 
-**False positives**
+**False positives** — allow specific patterns in rule options:
 
 ```json
 {
@@ -577,21 +310,25 @@ rm .secretlintrc.json
     "id": "@secretlint/secretlint-rule-preset-recommend",
     "rules": [{
       "id": "@secretlint/secretlint-rule-<rule-name>",
-      "options": {
-        "allows": ["/pattern-to-allow/i"]
-      }
+      "options": { "allows": ["/pattern-to-allow/i"] },
+      "allowMessageIds": ["AWSAccountID"]
     }]
   }]
 }
 ```
 
+Or use inline comments: `const key = "test-key"; // secretlint-disable-line`
+
+## Quality Pipeline Integration
+
+```bash
+./.agents/scripts/linters-local.sh      # Includes secretlint
+./.agents/scripts/pre-commit-hook.sh    # Includes secretlint
+```
+
 ## Resources
 
-- **GitHub**: [https://github.com/secretlint/secretlint](https://github.com/secretlint/secretlint)
-- **npm**: [https://www.npmjs.com/package/secretlint](https://www.npmjs.com/package/secretlint)
-- **Docker Hub**: [https://hub.docker.com/r/secretlint/secretlint](https://hub.docker.com/r/secretlint/secretlint)
-- **Demo**: [https://secretlint.github.io/](https://secretlint.github.io/)
-
----
-
-**Secretlint provides a secure, developer-friendly approach to preventing credential leaks with its opt-in rule system and comprehensive documentation.**
+- **GitHub**: https://github.com/secretlint/secretlint
+- **npm**: https://www.npmjs.com/package/secretlint
+- **Docker Hub**: https://hub.docker.com/r/secretlint/secretlint
+- **Demo**: https://secretlint.github.io/

--- a/.agents/tools/voice/transcription.md
+++ b/.agents/tools/voice/transcription.md
@@ -17,19 +17,10 @@ tools:
 - **Default local model**: Whisper Large v3 Turbo (best speed/accuracy tradeoff)
 - **Dependencies**: `yt-dlp` (YouTube), `ffmpeg` (audio extraction), `faster-whisper` or `whisper.cpp` (local)
 
-**Quick Commands**:
-
 ```bash
-# Transcribe YouTube video (local Whisper)
-transcription-helper.sh transcribe "https://youtu.be/dQw4w9WgXcQ"
-
-# Transcribe local file
-transcription-helper.sh transcribe recording.mp3
-
-# Transcribe with specific model
+transcription-helper.sh transcribe "https://youtu.be/dQw4w9WgXcQ"  # YouTube
+transcription-helper.sh transcribe recording.mp3                    # Local file
 transcription-helper.sh transcribe recording.mp3 --model large-v3-turbo
-
-# List available models
 transcription-helper.sh models
 ```
 
@@ -37,29 +28,23 @@ transcription-helper.sh models
 
 ## Decision Matrix
 
-Use this to pick the right tool before starting.
-
 | Criterion | Whisper (local) | Buzz (GUI) | AssemblyAI | Deepgram |
 |-----------|----------------|------------|------------|----------|
-| **Privacy** | Full (no data leaves device) | Full (offline) | Cloud (data sent) | Cloud (data sent) |
-| **Cost** | Free | Free | $0.15/hr (Universal-2) – $0.45/hr (U3 Pro streaming) | $0.0077/min (Nova-3) |
+| **Privacy** | Full (offline) | Full (offline) | Cloud | Cloud |
+| **Cost** | Free | Free | $0.15/hr (U2) – $0.45/hr (U3 Pro) | $0.0077/min (Nova-3) |
 | **Setup** | pip + ffmpeg | brew install | API key only | API key only |
-| **Accuracy** | 9.0–9.8 (model-dependent) | 9.0–9.8 | 9.6 (Universal-2) | 9.5 (Nova-3) |
-| **Speed** | Slow–medium (CPU/GPU) | Medium (GUI) | Fast (async) | Real-time capable |
-| **Speaker diarization** | No (base Whisper) | No | Yes | Yes |
-| **Timestamps** | Word-level (JSON) | Yes | Word-level | Word-level |
-| **Batch/async** | Yes (CLI loop) | No | Yes (webhooks) | Yes |
+| **Accuracy** | 9.0–9.8 | 9.0–9.8 | 9.6 (U2) | 9.5 (Nova-3) |
+| **Speaker diarization** | No | No | Yes | Yes |
 | **Real-time streaming** | No | No | Yes (WebSocket) | Yes (WebSocket) |
-| **Language detection** | Auto (99 languages) | Auto | Auto (99 languages) | Auto (45+ languages) |
 | **Best for** | Private/offline, long files | macOS GUI users | Speaker ID, meetings | Real-time, low latency |
 
 **Decision flow**:
 
-1. **Privacy required or no internet** → Whisper local or Buzz
-2. **Need speaker diarization** → AssemblyAI or Deepgram
-3. **Real-time streaming** → Deepgram
-4. **Highest accuracy, cloud OK** → AssemblyAI Universal-3 Pro
-5. **Free, good enough** → Whisper medium or large-v3-turbo locally
+1. Privacy required or no internet → Whisper or Buzz
+2. Need speaker diarization → AssemblyAI or Deepgram
+3. Real-time streaming → Deepgram
+4. Highest accuracy, cloud OK → AssemblyAI Universal-3 Pro
+5. Free, good enough → Whisper turbo locally
 
 ---
 
@@ -76,35 +61,18 @@ Use this to pick the right tool before starting.
 
 ## Whisper (Local — OpenAI Original)
 
-The original OpenAI Whisper model. Runs locally via Python. Good baseline; `faster-whisper` is faster for the same models.
-
-### Installation
+Runs locally via Python. `faster-whisper` is faster for the same models.
 
 ```bash
 pip install openai-whisper
-brew install ffmpeg   # required dependency
-```
+brew install ffmpeg
 
-### CLI Usage
-
-```bash
-# Basic transcription (auto-detects language)
-whisper audio.mp3
-
-# Specify model and language
+whisper audio.mp3                                          # Basic (auto-detects language)
 whisper audio.mp3 --model medium --language en
-
-# Output as SRT subtitles
-whisper audio.mp3 --model medium --output_format srt
-
-# Transcribe video (extracts audio automatically)
+whisper audio.mp3 --model medium --output_format srt      # SRT subtitles
 whisper video.mp4 --model large --language en --output_format txt
-
-# Translate non-English audio to English
-whisper french-audio.mp3 --task translate --model medium
-
-# Word-level timestamps (JSON output)
-whisper audio.mp3 --model medium --output_format json
+whisper french-audio.mp3 --task translate --model medium  # Translate to English
+whisper audio.mp3 --model medium --output_format json     # Word-level timestamps
 ```
 
 ### Model Selection
@@ -115,13 +83,14 @@ whisper audio.mp3 --model medium --output_format json
 | `base` | 142MB | Fast | 7.3/10 | Quick transcription |
 | `small` | 461MB | Medium | 8.5/10 | Good balance, multilingual |
 | `medium` | 1.5GB | Slow | 9.0/10 | Solid quality, recommended default |
-| `large` | 2.9GB | Slowest | 9.8/10 | Best quality |
-| `large-v3` | 2.9GB | Slowest | 9.8/10 | Latest, best multilingual |
-| `turbo` | 1.5GB | Fast | 9.7/10 | Large-v3 quality at medium speed |
+| `large-v3` | 2.9GB | Slowest | 9.8/10 | Best quality, best multilingual |
+| **`turbo`** | **1.5GB** | **Fast** | **9.7/10** | **Large-v3 quality at medium speed** |
+| NVIDIA Parakeet V2 | 474MB | Fastest | 9.4/10 | English-only |
+| Apple Speech | Built-in | Fast | 9.0/10 | macOS 26+, on-device |
 
 **Recommendation**: `medium` for most use cases; `turbo` when speed matters; `large-v3` for accuracy-critical work.
 
-### via faster-whisper (Recommended for Performance)
+### faster-whisper (Recommended for Performance)
 
 CTranslate2-based, 4x faster than original Whisper with identical accuracy.
 
@@ -131,14 +100,13 @@ pip install faster-whisper
 
 ```python
 from faster_whisper import WhisperModel
-
 model = WhisperModel("medium", device="cpu", compute_type="int8")
 segments, info = model.transcribe("audio.mp3", language="en")
 for segment in segments:
     print(f"[{segment.start:.2f}s] {segment.text}")
 ```
 
-### via whisper.cpp (C++ Native, Apple Silicon Optimised)
+### whisper.cpp (C++ Native, Apple Silicon Optimised)
 
 ```bash
 git clone https://github.com/ggml-org/whisper.cpp
@@ -151,114 +119,56 @@ cd whisper.cpp && make
 
 ## Buzz (macOS GUI for Whisper)
 
-Desktop app wrapping Whisper models. No cloud, no API key. Best for users who prefer a GUI over CLI.
-
-### Installation
+Desktop app wrapping Whisper models. No cloud, no API key.
 
 ```bash
-# macOS GUI app (recommended)
-brew install --cask buzz
-
-# CLI / Python
-pip install buzz-captions
+brew install --cask buzz    # macOS GUI (recommended)
+pip install buzz-captions   # CLI / Python
+# Or: https://buzzcaptions.com
 ```
 
-Or download from https://buzzcaptions.com
-
-### GUI Workflow
-
-1. Open Buzz → File → Open
-2. Select audio or video file
-3. Choose model (medium recommended) and language
-4. Click Transcribe
-5. Export as TXT, SRT, or VTT
-
-### CLI Usage
+**GUI**: File → Open → choose model (medium recommended) → Transcribe → Export (TXT/SRT/VTT).
 
 ```bash
-# Transcribe with timestamps
 buzz transcribe audio.mp3 --model medium --output-format srt
-
-# Translate to English
 buzz transcribe foreign.mp3 --task translate --language auto
-
-# Use faster-whisper backend (faster, lower memory)
 buzz transcribe audio.mp3 --model-type faster-whisper --model large-v3
 ```
 
-### Supported Formats
-
-- **Audio**: MP3, WAV, FLAC, OGG, M4A, WMA
-- **Video**: MP4, MKV, AVI, MOV, WebM (extracts audio automatically)
-- **Output**: TXT, SRT, VTT, JSON
+**Supported formats**: Audio (MP3, WAV, FLAC, OGG, M4A, WMA), Video (MP4, MKV, AVI, MOV, WebM), Output (TXT, SRT, VTT, JSON).
 
 ---
 
 ## AssemblyAI (Cloud — Speaker Diarization, High Accuracy)
 
-Cloud API with speaker diarization, sentiment analysis, and auto-chapters. Best for meeting transcription where you need to identify who said what.
-
-### Installation
+Best for meeting transcription where you need to identify who said what.
 
 ```bash
 pip install assemblyai
+# Store API key: aidevops secret set ASSEMBLYAI_API_KEY
 ```
 
-Store API key: `aidevops secret set ASSEMBLYAI_API_KEY`
-
-### Basic Transcription
-
 ```python
-import assemblyai as aai
-import os
-
+import assemblyai as aai, os
 aai.settings.api_key = os.environ["ASSEMBLYAI_API_KEY"]
 transcriber = aai.Transcriber()
 
-# From local file
+# Basic
 transcript = transcriber.transcribe("audio.mp3")
 print(transcript.text)
 
-# From URL
-transcript = transcriber.transcribe("https://example.com/audio.mp3")
-print(transcript.text)
-```
-
-### Speaker Diarization (Meeting Transcription)
-
-```python
-config = aai.TranscriptionConfig(
-    speaker_labels=True,
-    speakers_expected=3,   # optional hint
-    language_code="en"
-)
+# Speaker diarization
+config = aai.TranscriptionConfig(speaker_labels=True, speakers_expected=3)
 transcript = transcriber.transcribe("meeting.mp3", config=config)
-
 for utterance in transcript.utterances:
     print(f"Speaker {utterance.speaker}: {utterance.text}")
-```
 
-### Advanced Features
-
-```python
+# Advanced features
 config = aai.TranscriptionConfig(
-    speaker_labels=True,
-    auto_chapters=True,        # topic segmentation
-    sentiment_analysis=True,   # per-sentence sentiment
-    entity_detection=True,     # names, places, orgs
-    auto_highlights=True,      # key phrases
-    language_detection=True,   # auto-detect language
-    punctuate=True,
-    format_text=True
+    speaker_labels=True, auto_chapters=True, sentiment_analysis=True,
+    entity_detection=True, auto_highlights=True, language_detection=True,
+    punctuate=True, format_text=True
 )
-```
-
-### Async / Webhook
-
-```python
-# Submit and poll
-transcript = transcriber.transcribe("long-audio.mp3")
-# Blocks until complete; use submit() + poll() for non-blocking
 
 # Webhook (production)
 config = aai.TranscriptionConfig(webhook_url="https://yourapp.com/webhook")
@@ -274,7 +184,7 @@ print(transcript.id)  # poll later
 | Universal-2 | $0.15/hr | — | 99 languages, general-purpose |
 | Universal-Streaming | — | $0.15/hr | English-only, fastest |
 | Universal-Streaming Multilingual | — | $0.15/hr | 6 languages |
-| Whisper-Streaming | — | $0.30/hr | 99+ languages, open-source model |
+| Whisper-Streaming | — | $0.30/hr | 99+ languages |
 
 > Last verified: March 2026 — [assemblyai.com/pricing](https://www.assemblyai.com/pricing)
 
@@ -282,17 +192,12 @@ print(transcript.id)  # poll later
 
 ## Deepgram (Cloud — Real-Time, Low Latency)
 
-Cloud API optimised for real-time streaming and batch. Best for live transcription, call centres, and latency-sensitive applications.
-
-### Installation
+Best for live transcription, call centres, and latency-sensitive applications.
 
 ```bash
 pip install deepgram-sdk
+# Store API key: aidevops secret set DEEPGRAM_API_KEY
 ```
-
-Store API key: `aidevops secret set DEEPGRAM_API_KEY`
-
-### Batch Transcription
 
 ```python
 from deepgram import DeepgramClient, PrerecordedOptions
@@ -300,32 +205,26 @@ import os
 
 deepgram = DeepgramClient(os.environ["DEEPGRAM_API_KEY"])
 
-# From local file
+# Batch from file
 with open("audio.mp3", "rb") as f:
-    payload = {"buffer": f}
-    options = PrerecordedOptions(
-        model="nova-3",
-        language="en",
-        punctuate=True,
-        diarize=True,
-        smart_format=True
-    )
-    response = deepgram.listen.rest.v("1").transcribe_file(payload, options)
+    options = PrerecordedOptions(model="nova-3", language="en", punctuate=True, diarize=True, smart_format=True)
+    response = deepgram.listen.rest.v("1").transcribe_file({"buffer": f}, options)
     print(response.results.channels[0].alternatives[0].transcript)
 
-# From URL
-options = PrerecordedOptions(model="nova-3", diarize=True)
-response = deepgram.listen.rest.v("1").transcribe_url(
-    {"url": "https://example.com/audio.mp3"}, options
-)
+# Batch from URL
+response = deepgram.listen.rest.v("1").transcribe_url({"url": "https://example.com/audio.mp3"}, PrerecordedOptions(model="nova-3", diarize=True))
+
+# Speaker diarization
+words = response.results.channels[0].alternatives[0].words
+for word in words:
+    print(f"[Speaker {word.speaker}] {word.word}")
 ```
 
 ### Real-Time Streaming
 
 ```python
 from deepgram import DeepgramClient, LiveTranscriptionEvents, LiveOptions
-import asyncio
-import os
+import asyncio, os
 
 async def stream_microphone():
     dg = DeepgramClient(os.environ["DEEPGRAM_API_KEY"])
@@ -342,38 +241,14 @@ async def stream_microphone():
     # feed audio chunks via connection.send(audio_chunk)
 ```
 
-### Speaker Diarization
+### Models & Pricing
 
-```python
-options = PrerecordedOptions(
-    model="nova-3",
-    diarize=True,
-    punctuate=True
-)
-response = deepgram.listen.rest.v("1").transcribe_url({"url": "https://example.com/audio.mp3"}, options)
-words = response.results.channels[0].alternatives[0].words
-for word in words:
-    print(f"[Speaker {word.speaker}] {word.word}")
-```
-
-### Models
-
-| Model | Accuracy | Speed | Notes |
-|-------|----------|-------|-------|
-| `nova-3` | 9.5/10 | Fast | General purpose, 36 languages |
-| `nova-3-medical` | 9.6/10 | Fast | Clinical vocabulary, English only |
-| `nova-2` | 9.3/10 | Fast | Previous gen, wider language support |
-| `enhanced` | 9.0/10 | Medium | Legacy |
-| `base` | 8.5/10 | Fastest | Lowest cost |
-
-### Pricing
-
-| Model | Cost (pay-as-you-go) | Notes |
-|-------|---------------------|-------|
-| Flux | $0.0077/min | Voice agent optimised |
-| Nova-3 (Monolingual) | $0.0077/min | Highest accuracy |
-| Nova-3 (Multilingual) | $0.0092/min | 45+ languages |
-| Nova-1 & 2 | $0.0058/min | Non-English recommended |
+| Model | Accuracy | Cost | Notes |
+|-------|----------|------|-------|
+| `nova-3` | 9.5/10 | $0.0077/min | General purpose, 36 languages |
+| `nova-3-medical` | 9.6/10 | $0.0077/min | Clinical vocabulary, English only |
+| `nova-3` (Multilingual) | 9.5/10 | $0.0092/min | 45+ languages |
+| `nova-2` | 9.3/10 | $0.0058/min | Previous gen, wider language support |
 
 > Last verified: March 2026 — [deepgram.com/pricing](https://deepgram.com/pricing)
 
@@ -381,22 +256,19 @@ for word in words:
 
 ## Cloud APIs (Extended)
 
-| Provider | Model | Accuracy | Speed | Cost | Notes |
-|----------|-------|----------|-------|------|-------|
-| **Groq** | Whisper Large v3 Turbo | 9.6/10 | Lightning | Free tier | OpenAI-compatible API |
-| **ElevenLabs** | Scribe v2 | 9.9/10 | Fast | Pay/min | Highest accuracy |
-| **Mistral** | Voxtral Mini | 9.7/10 | Fast | Pay/token | Multilingual |
-| **OpenAI** | Whisper API | 9.5/10 | Fast | $0.006/min | Reference implementation |
-| **Google** | Gemini 2.5 Pro | 9.7/10 | Fast | Pay/token | Multimodal input |
-| **Soniox** | stt-async-v3 | 9.6/10 | Async | Batch | Batch processing |
-
-> Rates for Groq, ElevenLabs, Mistral, Google, and Soniox vary by plan — check provider pricing pages for current rates.
+| Provider | Model | Accuracy | Cost | Notes |
+|----------|-------|----------|------|-------|
+| **Groq** | Whisper Large v3 Turbo | 9.6/10 | Free tier | OpenAI-compatible API |
+| **ElevenLabs** | Scribe v2 | 9.9/10 | Pay/min | Highest accuracy |
+| **Mistral** | Voxtral Mini | 9.7/10 | Pay/token | Multilingual |
+| **OpenAI** | Whisper API | 9.5/10 | $0.006/min | Reference implementation |
+| **Google** | Gemini 2.5 Pro | 9.7/10 | Pay/token | Multimodal input |
+| **Soniox** | stt-async-v3 | 9.6/10 | Batch | Batch processing |
 
 Store API keys: `aidevops secret set <PROVIDER>_API_KEY`
 
-Example (Groq — OpenAI-compatible):
-
 ```bash
+# Groq (OpenAI-compatible)
 curl https://api.groq.com/openai/v1/audio/transcriptions \
   -H "Authorization: Bearer ${GROQ_API_KEY}" \
   -F "file=@audio.wav" \
@@ -411,8 +283,7 @@ curl https://api.groq.com/openai/v1/audio/transcriptions \
 ### Meeting Transcription with Speaker Labels
 
 ```bash
-# 1. Record meeting (Zoom/Teams/Google Meet → export MP4)
-# 2. Transcribe with speaker diarization (AssemblyAI)
+# AssemblyAI (with speaker diarization)
 python3 - <<'EOF'
 import assemblyai as aai, os
 aai.settings.api_key = os.environ["ASSEMBLYAI_API_KEY"]
@@ -422,21 +293,17 @@ for u in t.utterances:
     print(f"[Speaker {u.speaker}] {u.text}")
 EOF
 
-# 3. Or use local Whisper (no speaker labels, but private)
+# Local Whisper (no speaker labels, but private)
 whisper meeting.mp4 --model medium --language en --output_format txt
 ```
 
 ### Video Subtitles (SRT/VTT)
 
 ```bash
-# Local Whisper → SRT
+# Local Whisper
 whisper video.mp4 --model medium --output_format srt
-# Output: video.srt (ready for YouTube, VLC, Premiere)
 
-# Buzz GUI → SRT
-buzz transcribe video.mp4 --model large-v3 --output-format srt
-
-# AssemblyAI → SRT (cloud, higher accuracy)
+# AssemblyAI (cloud, higher accuracy)
 python3 - <<'EOF'
 import assemblyai as aai, os
 aai.settings.api_key = os.environ["ASSEMBLYAI_API_KEY"]
@@ -449,11 +316,8 @@ EOF
 ### Podcast Notes / Show Notes
 
 ```bash
-# Transcribe episode
 whisper episode.mp3 --model turbo --language en --output_format txt
-
-# Then pipe to LLM for summary (example with Claude CLI)
-cat episode.txt | claude "Summarise this podcast transcript into: 
+cat episode.txt | claude "Summarise this podcast transcript into:
 1. Key topics (bullet points)
 2. Notable quotes (3-5)
 3. Action items mentioned
@@ -463,20 +327,18 @@ cat episode.txt | claude "Summarise this podcast transcript into:
 ### Batch Transcription
 
 ```bash
-# Batch with local Whisper
+# Local Whisper
 for f in recordings/*.mp3; do
   whisper "$f" --model medium --output_format txt --output_dir transcripts/
 done
 
-# Batch with Deepgram (parallel, faster)
+# Deepgram (parallel, faster)
 python3 - <<'EOF'
 import os, glob
 from deepgram import DeepgramClient, PrerecordedOptions
-
 dg = DeepgramClient(os.environ["DEEPGRAM_API_KEY"])
 options = PrerecordedOptions(model="nova-3", punctuate=True, smart_format=True)
 os.makedirs("transcripts", exist_ok=True)
-
 for path in glob.glob("recordings/*.mp3"):
     with open(path, "rb") as f:
         resp = dg.listen.rest.v("1").transcribe_file({"buffer": f}, options)
@@ -490,11 +352,9 @@ EOF
 ### YouTube Video Transcription
 
 ```bash
-# Download audio then transcribe
 yt-dlp -x --audio-format mp3 -o "youtube_video.%(ext)s" "https://youtu.be/VIDEO_ID"
 whisper "youtube_video.mp3" --model medium --language en --output_format txt
-
-# Or use the helper (handles download + transcription)
+# Or use the helper (handles download + transcription):
 transcription-helper.sh transcribe "https://youtu.be/VIDEO_ID"
 ```
 
@@ -502,9 +362,7 @@ transcription-helper.sh transcribe "https://youtu.be/VIDEO_ID"
 
 ## Language Support
 
-### Whisper (OpenAI) — 99 Languages
-
-Auto-detects language by default (when `--language` is omitted). Specify for accuracy:
+Whisper auto-detects language by default (omit `--language`). Specify for accuracy:
 
 ```bash
 whisper audio.mp3 --language fr   # French
@@ -512,38 +370,11 @@ whisper audio.mp3 --language zh   # Chinese (Mandarin)
 whisper audio.mp3 --language es   # Spanish
 ```
 
-| Language | Code | Notes |
-|----------|------|-------|
-| English | `en` | Best accuracy |
-| Spanish | `es` | Strong support |
-| French | `fr` | Strong support |
-| German | `de` | Strong support |
-| Chinese | `zh` | Mandarin, good |
-| Japanese | `ja` | Good |
-| Portuguese | `pt` | Good |
-| Russian | `ru` | Good |
-| Arabic | `ar` | Moderate |
-| Hindi | `hi` | Moderate |
-| Korean | `ko` | Good |
-| Italian | `it` | Good |
-| Dutch | `nl` | Good |
-| Polish | `pl` | Good |
-| Turkish | `tr` | Good |
+Whisper supports 99 languages. Full list: https://github.com/openai/whisper#available-models-and-languages
 
-Full list: https://github.com/openai/whisper#available-models-and-languages
+AssemblyAI: 99 languages — `aai.TranscriptionConfig(language_code="fr")` or `language_detection=True`
 
-### AssemblyAI — 99 Languages
-
-```python
-config = aai.TranscriptionConfig(language_code="fr")  # or language_detection=True
-```
-
-### Deepgram — 36 Languages (Nova-3)
-
-```python
-options = PrerecordedOptions(model="nova-3", language="fr")
-# Use nova-2 for broader language coverage (100+ languages)
-```
+Deepgram Nova-3: 36 languages — `PrerecordedOptions(model="nova-3", language="fr")`. Use `nova-2` for broader coverage (100+ languages).
 
 ---
 
@@ -555,21 +386,6 @@ options = PrerecordedOptions(model="nova-3", language="fr")
 | `.srt` | Video subtitles (most compatible) | Whisper, Buzz, AssemblyAI |
 | `.vtt` | Web video subtitles | Whisper, Buzz, AssemblyAI |
 | `.json` | Programmatic access, word timestamps | All tools |
-
----
-
-## Local Model Comparison
-
-| Model | Size | Speed | Accuracy | Best for |
-|-------|------|-------|----------|----------|
-| Tiny | 75MB | 9.5/10 | 6.0/10 | Draft/preview only |
-| Base | 142MB | 8.5/10 | 7.3/10 | Quick transcription |
-| Small | 461MB | 7.0/10 | 8.5/10 | Good balance, multilingual |
-| Medium | 1.5GB | 5.0/10 | 9.0/10 | Solid quality |
-| Large v3 | 2.9GB | 3.0/10 | 9.8/10 | Best quality |
-| **Turbo** | **1.5GB** | **7.5/10** | **9.7/10** | **Recommended default** |
-| NVIDIA Parakeet V2 | 474MB | 9.9/10 | 9.4/10 | English-only, fastest |
-| Apple Speech | Built-in | 9.0/10 | 9.0/10 | macOS 26+, on-device |
 
 ---
 


### PR DESCRIPTION
## Summary

Tighten four agent docs by removing redundant content, consolidating repetitive sections, and reducing line count while preserving all essential information. No behaviour changes.

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| `.agents/aidevops/mcp-integrations.md` | 592 lines | 318 lines | -46% |
| `.agents/content/production/audio.md` | 592 lines | 228 lines | -61% |
| `.agents/tools/voice/transcription.md` | 595 lines | 411 lines | -31% |
| `.agents/tools/code-review/secretlint.md` | 597 lines | 334 lines | -44% |

## What was removed

- **mcp-integrations.md**: Duplicate integration listing section (same content as Quick Reference + setup sections), redundant "Use Cases & Examples" and "Real-World Use Cases" sections, repeated "Getting Started" commands
- **audio.md**: "Audio Production Workflow" steps 1-6 (duplicated the 4-layer design section), "Content Type Audio Presets" (duplicated platform rules table), merged two cross-reference sections into one "See Also"
- **transcription.md**: Duplicate "Local Model Comparison" table at end (already present in Whisper section), condensed language support from a 15-row table to prose
- **secretlint.md**: "Integration with AI DevOps Framework" section (duplicated Quick Reference commands), "Best Practices" section (generic advice already implied), condensed troubleshooting prose

Closes #6085
Closes #6084
Closes #6083
Closes #6082