### PR TITLE
refactor: tighten 4 agent docs, remove redundant content

### DIFF
--- a/.agents/content/optimization.md
+++ b/.agents/content/optimization.md
@@ -36,11 +36,7 @@ Data-driven content improvement through systematic testing, variant generation, 
 
 ## A/B Testing Discipline
 
-Systematic testing methodology to identify winning content patterns before scaling production.
-
 ### Testing Rules
-
-**Minimum viable test**:
 
 | Metric | Threshold | Action |
 |--------|-----------|--------|
@@ -50,7 +46,7 @@ Systematic testing methodology to identify winning content patterns before scali
 | Performance threshold | 2-3% | Scale — produce more of this type |
 | Performance threshold | >3% | Go aggressive — this is a winner |
 
-**Sample size requirements by platform**:
+**Sample size by platform**:
 
 | Platform | Metric | Minimum Sample | Confidence Threshold |
 |----------|--------|----------------|---------------------|
@@ -60,16 +56,9 @@ Systematic testing methodology to identify winning content patterns before scali
 | Email | Open rate | 250 sends | 20% open rate |
 | Thumbnail | CTR | 1000 impressions | 5% CTR |
 
-**Statistical significance**:
+**Statistical significance**: 95% confidence minimum; run 7+ days to account for day-of-week variance; 14+ days for audiences <1000.
 
-- Use A/B testing tools with built-in significance calculators (Google Optimize, VWO, Optimizely)
-- Minimum 95% confidence level before declaring a winner
-- Run tests for at least 7 days to account for day-of-week variance
-- For small audiences (<1000), extend test duration to 14+ days
-
-### What to Test
-
-**Priority order** (highest impact first):
+### What to Test (priority order)
 
 1. **Hooks** (first 3 seconds, headline, thumbnail) — 80% of performance variance
 2. **Angles** (pain vs aspiration, contrarian vs consensus, before/after)
@@ -79,117 +68,38 @@ Systematic testing methodology to identify winning content patterns before scali
 6. **Length** (word count, video duration, scene count)
 7. **Publishing time** (day of week, time of day)
 
-**Hook testing framework**:
+**Hook types to test** (generate 5-10 per topic):
+- Bold Claim: "95% of AI influencers fail — here's why"
+- Question: "Why do most AI videos get ignored?"
+- Story: "I spent $10K on AI video tools — here's what actually worked"
+- Contrarian: "Stop using Sora for UGC content"
+- Result: "From 0 to 100K views in 30 days with AI video"
+- Problem-Agitate: "Your AI videos look fake — and everyone can tell"
+- Curiosity Gap: "The one AI video trick nobody talks about"
 
-Generate 5-10 hook variants per topic before committing to production. Test across:
-
-- **Bold Claim**: "95% of AI influencers fail — here's why"
-- **Question**: "Why do most AI videos get ignored?"
-- **Story**: "I spent $10K on AI video tools — here's what actually worked"
-- **Contrarian**: "Stop using Sora for UGC content"
-- **Result**: "From 0 to 100K views in 30 days with AI video"
-- **Problem-Agitate**: "Your AI videos look fake — and everyone can tell"
-- **Curiosity Gap**: "The one AI video trick nobody talks about"
-
-**Thumbnail testing**:
-
-- Generate 5-10 thumbnail variants using style library templates (see `content/production/image.md`)
-- Use `thumbnail-helper.sh` for automated variant generation, scoring, and A/B test setup
-- Test via YouTube's built-in A/B testing or manual rotation
-- Score on: text readability, face prominence, contrast, emotion (automated via scoring rubric)
-- Winning thumbnail style becomes template for next 10 videos
-
-**Automated thumbnail pipeline** (via `thumbnail-helper.sh`):
+**Thumbnail pipeline** (via `thumbnail-helper.sh`):
 
 ```bash
-# Generate 10 thumbnail variants
 thumbnail-helper.sh generate "Your Video Topic" --count 10 --template high-contrast-face
-
-# Score all variants (interactive rubric)
 thumbnail-helper.sh batch-score ~/.cache/aidevops/thumbnails/[output_dir]/
-
-# Upload passing thumbnails for A/B testing
 thumbnail-helper.sh ab-test VIDEO_ID ~/.cache/aidevops/thumbnails/[output_dir]/
-
-# Analyze performance after 1000+ impressions
 thumbnail-helper.sh analyze VIDEO_ID
 ```
 
-### Test Execution
+### Test Execution Workflow
 
-**Rapid testing workflow**:
-
-1. **Generate variants**: Use `content/production/` agents to create 10+ versions
-   - Hook variants: `content/story.md` frameworks
-   - Thumbnail variants: `content/production/image.md` style library
-   - Script variants: `content/production/writing.md` structure templates
-   - Video variants: `content/production/video.md` seed bracketing
-
-2. **Deploy test**: Platform-specific deployment
-   - **YouTube**: Upload with different thumbnails, rotate via YouTube Studio A/B test
-   - **TikTok/Reels**: Post variants as separate videos, measure completion rate
-   - **Blog**: Use Google Optimize or VWO for headline/intro A/B tests
-   - **Email**: Split list into segments, test subject lines
-
-3. **Collect data**: Minimum 250 samples per variant
-   - YouTube: CTR, retention curve, watch time
-   - TikTok: Completion rate, shares, saves
-   - Blog: Time on page, scroll depth, bounce rate
-   - Email: Open rate, click rate, conversion rate
-
-4. **Analyze results**: Compare against baseline and thresholds
-   - Calculate lift: `(variant - baseline) / baseline * 100`
-   - Check statistical significance (95% confidence)
-   - Identify winning patterns (not just winning variants)
-
-5. **Scale winners**: Produce more content using winning patterns
-   - Extract the pattern (e.g., "question hooks outperform bold claims 2:1")
-   - Store pattern in memory: `/remember "Hook pattern: question format gets 2x CTR vs bold claims for [niche]"`
-   - Apply pattern to next 10 pieces of content
-
-**Batch testing for efficiency**:
-
-Instead of testing one piece at a time, batch test 10 variants simultaneously:
-
-- **Week 1**: Produce 10 hook variants, deploy all
-- **Week 2**: Collect data (250+ samples each)
-- **Week 3**: Analyze, kill bottom 7, scale top 3
-- **Week 4**: Produce 10 new variants using top 3 patterns
-
-This approach finds winners 10x faster than sequential testing.
+1. **Generate variants**: 10+ versions using `content/production/` agents
+2. **Deploy**: Platform-specific (YouTube A/B test, TikTok separate videos, Google Optimize for blog, email list split)
+3. **Collect**: 250+ samples per variant (CTR, retention, completion rate, time on page)
+4. **Analyze**: Calculate lift `(variant - baseline) / baseline * 100`; check 95% significance
+5. **Scale winners**: Extract the pattern, store in memory (`/remember "Hook pattern: ..."`), apply to next 10 pieces
+6. **Batch test**: Deploy 10 variants simultaneously (Week 1: produce, Week 2: collect, Week 3: analyze+kill bottom 7, Week 4: produce from top 3 patterns)
 
 ## Variant Generation
 
-Systematic creation of test variants across all content dimensions.
+### Hook Variants
 
-### Hook Variant Generation
-
-**Process**:
-
-1. Start with core topic: "AI video generation for content creators"
-2. Generate 10 hook variants using 7 hook types (see `content/story.md`)
-3. Constraint: 6-12 words maximum
-4. Test all 10, measure CTR/retention
-5. Scale top 3 patterns
-
-**Example hook variants for "AI video generation"**:
-
-| Type | Hook | Word Count |
-|------|------|------------|
-| Bold Claim | "AI video will replace 90% of editors" | 8 |
-| Question | "Why do AI videos still look fake?" | 7 |
-| Story | "I spent $10K testing every AI video tool" | 8 |
-| Contrarian | "Stop using Sora for social media content" | 7 |
-| Result | "0 to 100K views with AI video in 30 days" | 10 |
-| Problem-Agitate | "Your AI videos scream 'AI' — here's why" | 8 |
-| Curiosity Gap | "The AI video secret nobody shares" | 6 |
-| Bold Claim 2 | "Veo 3.1 just killed the video production industry" | 8 |
-| Question 2 | "Can AI video actually look cinematic?" | 6 |
-| Result 2 | "From amateur to 100K subscribers with AI" | 7 |
-
-**Automation**:
-
-Use `content/story.md` agent with prompt:
+Generate 10 hooks per topic using all 7 types, 6-12 words each:
 
 ```text
 Generate 10 hook variants for topic: [topic]
@@ -199,114 +109,33 @@ Output as table: Type | Hook | Word Count
 
 ### Seed Bracketing for Video
 
-**Purpose**: Systematically test seed ranges to find high-quality outputs before committing to full production.
+Systematically test seed ranges before committing to full production (see `content/production/video.md` for full details):
 
-**Method** (see `content/production/video.md` for full details):
-
-1. **Define seed range** by content type:
-   - People: 1000-1999
-   - Action: 2000-2999
-   - Landscape: 3000-3999
-   - Product: 4000-4999
-   - YouTube-optimized: 2000-3000
-
-2. **Test bracket**: Generate 10 outputs with seeds 2000-2010
-3. **Score outputs**: Use vision model to rate on:
-   - Composition (rule of thirds, framing)
-   - Quality (sharpness, artifacts, lighting)
-   - Style consistency (matches brand aesthetic)
-   - Subject accuracy (prompt adherence)
-
-4. **Pick winners**: Top 3 seeds become production seeds
-5. **Iterate**: If no winners, shift range (2010-2020) and repeat
-
-**Scoring rubric**:
-
-| Dimension | Weight | 1 (Poor) | 3 (Good) | 5 (Excellent) |
-|-----------|--------|----------|----------|---------------|
-| Composition | 30% | Off-center, poor framing | Decent framing | Rule of thirds, cinematic |
-| Quality | 30% | Artifacts, blurry | Clean, sharp | Pristine, 4K-ready |
-| Style | 20% | Generic, off-brand | Matches style | Perfect brand fit |
-| Accuracy | 20% | Wrong subject | Close to prompt | Exact prompt match |
-
-**Total score**: Weighted average. Threshold: 4.0+ = winner, 3.0-3.9 = maybe, <3.0 = reject.
-
-**Efficiency gain**: Seed bracketing cuts AI video costs by ~60% (success rate 15% → 70%+).
+- **Seed ranges by content type**: People 1000-1999, Action 2000-2999, Landscape 3000-3999, Product 4000-4999
+- **Test bracket**: Generate 10 outputs with seeds 2000-2010; score on Composition (30%), Quality (30%), Style (20%), Accuracy (20%)
+- **Threshold**: 4.0+ = winner, 3.0-3.9 = maybe, <3.0 = reject
+- **Efficiency gain**: Cuts AI video costs ~60% (success rate 15% → 70%+)
 
 ### Scene-Level Variant Testing
 
-**Purpose**: Identify which specific moments in a video cause retention drop-off.
-
-**Process**:
-
-1. **Publish video** with analytics enabled (YouTube Studio retention curve)
-2. **Analyze retention curve**: Identify drop-off points (>10% drop in 5 seconds)
-3. **Isolate scenes**: Which scene caused the drop? (B-roll, talking head, transition)
-4. **Generate variants**: Re-render that scene with 3-5 different approaches
-   - Different B-roll footage
-   - Different pacing (faster cuts)
-   - Different music/SFX
-   - Different camera angle
-5. **Re-upload as new video**: Test variant, compare retention curve
-6. **Scale winner**: Use winning scene pattern in next 10 videos
-
-**Example**:
-
-- Original video: Retention drops 15% at 0:45 (during product demo scene)
-- Hypothesis: Demo is too slow, viewers lose interest
-- Variants:
-  - A: Same demo, 2x speed
-  - B: Same demo, add text overlays with key points
-  - C: Replace demo with before/after comparison
-- Test: Upload 3 new videos with variants A, B, C
-- Result: Variant C (before/after) retains 12% better
-- Action: Use before/after format for all future product demos
+1. Publish video → analyze YouTube Studio retention curve
+2. Identify drop-off points (>10% drop in 5 seconds) → isolate scene
+3. Generate 3-5 variants (different B-roll, pacing, music, angle)
+4. Re-upload as new video → compare retention → scale winner
 
 ### Thumbnail Variant Factory
 
-**Purpose**: Generate consistent, on-brand thumbnail variants at scale.
+Style template (Nanobanana Pro JSON): define color palette, font, composition, lighting. Swap subject/concept, keep style constant. Test 10 thumbnails across 10 videos; measure CTR at 1000+ impressions.
 
-**Process** (see `content/production/image.md` for full details):
-
-1. **Define style template**: Nanobanana Pro JSON with brand constants
-   - Color palette: `["#FF6B35", "#004E89", "#FFFFFF"]`
-   - Font: `"Montserrat Bold"`
-   - Composition: `"Rule of thirds, subject left, text right"`
-   - Lighting: `"High contrast, dramatic shadows"`
-
-2. **Generate variants**: Swap subject/concept, keep style constant
-   - Template: `{"style": "editorial", "subject": "[VARIABLE]", "composition": "rule_of_thirds", "colors": ["#FF6B35", "#004E89"]}`
-   - Variant 1: `subject = "shocked face"`
-   - Variant 2: `subject = "before/after split"`
-   - Variant 3: `subject = "product close-up"`
-
-3. **Test batch**: Upload 10 videos with 10 different thumbnails
-4. **Measure CTR**: YouTube Studio analytics, 1000+ impressions per thumbnail
-5. **Scale winner**: Winning subject type becomes default for next batch
-
-**Thumbnail scoring criteria**:
-
-| Criterion | Weight | Measurement |
-|-----------|--------|-------------|
-| CTR | 50% | YouTube Studio analytics |
-| Text readability | 20% | Can you read text in 0.5 seconds? |
-| Face prominence | 15% | Is face >30% of frame? |
-| Contrast | 10% | Does it stand out in feed? |
-| Emotion | 5% | Does face show clear emotion? |
-
-**Automation**:
-
-```bash
-# Generate 10 thumbnail variants
-for i in {1..10}; do
-  # Use Nanobanana Pro JSON template with different subjects
-  # See content/production/image.md for JSON schema
-done
-```
+| Criterion | Weight |
+|-----------|--------|
+| CTR | 50% |
+| Text readability | 20% |
+| Face prominence | 15% |
+| Contrast | 10% |
+| Emotion | 5% |
 
 ## Analytics Loops
-
-Continuous feedback from performance data into content strategy and production.
 
 ### Platform-Specific Metrics
 
@@ -320,22 +149,15 @@ Continuous feedback from performance data into content strategy and production.
 | Retention | <30% | Hook failed — test new hooks |
 | Retention | 30-50% | Decent — optimize pacing |
 | Retention | >50% | Great — this format works |
-| Watch time | <2min | Too long or boring — cut length |
-| Watch time | 2-5min | Good for short-form |
-| Watch time | >5min | Great for long-form |
 
 **TikTok/Reels/Shorts**:
 
 | Metric | Threshold | Action |
 |--------|-----------|--------|
-| Completion rate | <50% | Hook failed — test new hooks |
+| Completion rate | <50% | Hook failed |
 | Completion rate | 50-70% | Decent — optimize pacing |
 | Completion rate | >70% | Winner — replicate format |
-| Shares | <1% | Not shareable — add value/emotion |
-| Shares | 1-3% | Good — scale this type |
 | Shares | >3% | Viral potential — go aggressive |
-| Saves | <2% | Not useful — add actionable tips |
-| Saves | 2-5% | Good — educational content works |
 | Saves | >5% | High value — make more like this |
 
 **Blog/SEO**:
@@ -343,280 +165,82 @@ Continuous feedback from performance data into content strategy and production.
 | Metric | Threshold | Action |
 |--------|-----------|--------|
 | Time on page | <1min | Content too thin or wrong audience |
-| Time on page | 1-3min | Decent — optimize for engagement |
 | Time on page | >3min | Great — this topic resonates |
 | Scroll depth | <50% | Hook failed or content too long |
-| Scroll depth | 50-75% | Good — optimize lower sections |
-| Scroll depth | >75% | Excellent — readers engaged |
 | Bounce rate | >70% | Wrong audience or poor hook |
-| Bounce rate | 40-70% | Normal — optimize CTAs |
-| Bounce rate | <40% | Great — readers exploring site |
 
 **Email**:
 
 | Metric | Threshold | Action |
 |--------|-----------|--------|
 | Open rate | <15% | Test new subject lines |
-| Open rate | 15-25% | Good — scale this format |
 | Open rate | >25% | Excellent — replicate pattern |
-| Click rate | <2% | CTA failed — test new CTAs |
-| Click rate | 2-5% | Good — optimize landing page |
+| Click rate | <2% | CTA failed |
 | Click rate | >5% | Great — this offer works |
 
 ### Retention Analysis Workflow
 
-**Purpose**: Identify exactly which moments in a video retain vs cause drop-off.
-
-**Process**:
-
-1. **Export retention curve**: YouTube Studio → Analytics → Retention → Export CSV
-2. **Identify drop-off points**: >10% drop in <5 seconds
-3. **Map to timeline**: Which scene/moment caused the drop?
-4. **Categorize drop-offs**:
-   - **Hook failure**: Drop in first 10 seconds (0:00-0:10)
-   - **Pacing issue**: Gradual decline (slow content, no payoff)
-   - **Scene failure**: Sharp drop at specific moment (boring B-roll, long explanation)
-   - **Natural exit**: Gradual decline at end (viewers got value, left satisfied)
-
-5. **Generate hypotheses**: Why did viewers leave?
-   - Hook: Not compelling enough, didn't deliver on promise
-   - Pacing: Too slow, too fast, repetitive
-   - Scene: Boring visuals, confusing explanation, off-topic tangent
-
-6. **Test fixes**: Create variant with improved scene, re-upload, compare retention
-
-**Example retention analysis**:
-
-```text
-Video: "How to Use AI Video for Content Creation"
-Total views: 5,000
-Average retention: 42%
-
-Drop-off points:
-- 0:03 (15% drop): Hook didn't grab attention
-- 0:45 (12% drop): Slow product demo scene
-- 2:30 (10% drop): Long technical explanation
-
-Actions:
-- Test 5 new hook variants (see Hook Variant Generation)
-- Replace demo with before/after comparison (see Scene-Level Variant Testing)
-- Cut technical explanation from 60s to 20s, add visual examples
-```
+1. Export retention curve: YouTube Studio → Analytics → Retention → Export CSV
+2. Identify drop-off points (>10% drop in <5 seconds)
+3. Categorize: Hook failure (0:00-0:10), Pacing issue (gradual), Scene failure (sharp drop), Natural exit (gradual at end)
+4. Generate hypotheses → test fixes → compare retention
 
 ### Content Calendar Integration
 
-**Purpose**: Use analytics feedback to inform next cycle's topic selection and production priorities.
-
-**Helper**: `content-calendar-helper.sh` — SQLite-backed calendar with cadence tracking, gap analysis, and lifecycle management. See `tools/content/content-calendar.md` for full documentation.
-
-**Weekly review workflow**:
-
 ```bash
-content-calendar-helper.sh cadence --weeks 1    # How did last week go?
-content-calendar-helper.sh gaps --days 7        # What's missing next week?
-content-calendar-helper.sh due --days 7         # What's coming up?
-content-calendar-helper.sh stats                # Overall health check
+content-calendar-helper.sh cadence --weeks 1    # last week performance
+content-calendar-helper.sh gaps --days 7        # missing next week
+content-calendar-helper.sh due --days 7         # upcoming
+content-calendar-helper.sh stats                # overall health
 ```
 
-**Workflow**:
-
-1. **Weekly review**: Analyze performance of all published content from past 7 days
-2. **Identify patterns**: Which topics/formats/angles performed best?
-3. **Update content calendar**: Prioritize more of what works, deprioritize what doesn't
-4. **Store patterns in memory**: `/remember "Pattern: [niche] + [format] gets [X]% better retention than baseline"`
-5. **Feed into research cycle**: Use winning topics as seeds for next research phase (see `content/research.md`)
-
-**Content calendar template**:
-
-| Week | Topic | Format | Platform | Status | Performance | Next Action |
-|------|-------|--------|----------|--------|-------------|-------------|
-| W1 | AI video tools | Long-form | YouTube | Published | 3.2% CTR, 48% retention | Scale — make 3 more |
-| W1 | Sora 2 tutorial | Short-form | TikTok | Published | 65% completion | Good — test new hook |
-| W2 | Veo 3.1 review | Long-form | YouTube | Planned | - | Use winning hook pattern |
-| W2 | AI video mistakes | Short-form | Reels | Planned | - | Use before/after format |
-
-**Posting cadence recommendations**:
+**Posting cadence**:
 
 | Platform | Frequency | Rationale |
 |----------|-----------|-----------|
-| YouTube | 2-3/week | Algorithm favors consistency, not volume |
+| YouTube | 2-3/week | Algorithm favors consistency |
 | Shorts/TikTok/Reels | Daily | High volume needed to find viral hits |
 | Blog | 1-2/week | SEO favors depth over frequency |
 | Email | 1/week | Avoid list fatigue |
 | Social (X, LinkedIn) | Daily | Engagement requires presence |
 
-**Q4 seasonality awareness**:
-
-- **Q4 (Oct-Dec)**: Highest buying intent — prioritize monetization-focused content
-  - Product reviews, comparisons, "best of" lists
-  - Affiliate content, info product launches
-  - Holiday gift guides, year-end roundups
-
-- **Q1 (Jan-Mar)**: New Year motivation — prioritize educational content
-  - "How to get started" guides, beginner tutorials
-  - Goal-setting, planning, strategy content
-
-- **Q2-Q3 (Apr-Sep)**: Maintenance mode — test new formats, build backlog
-  - Experiment with new topics, formats, platforms
-  - Build content backlog for Q4 push
+**Seasonality**: Q4 (Oct-Dec) = highest buying intent → product reviews, comparisons, affiliate content. Q1 = educational/how-to. Q2-Q3 = experiment with new formats, build backlog.
 
 ### Analytics Feedback Loop
 
-**Purpose**: Close the loop from performance data back to research and strategy.
-
-**Process**:
-
-1. **Publish content** → 2. **Collect analytics** → 3. **Analyze performance** → 4. **Extract patterns** → 5. **Store in memory** → 6. **Feed into next research cycle** → 7. **Inform next content plan** → (repeat)
-
-**Example loop**:
-
-```text
-Cycle 1:
-- Research: "AI video generation" niche (see content/research.md)
-- Produce: 10 videos on AI video tools
-- Publish: YouTube, TikTok, Blog
-- Analyze: "Sora 2 tutorial" got 2x CTR vs others
-- Pattern: "Tool-specific tutorials outperform general overviews"
-- Store: /remember "Pattern: [AI video niche] tool-specific tutorials get 2x CTR vs general content"
-
-Cycle 2:
-- Research: Recall pattern, research more tool-specific topics
-- Produce: 10 videos on specific tools (Veo 3.1, Nanobanana, Higgsfield)
-- Publish: YouTube, TikTok, Blog
-- Analyze: "Veo 3.1 cinematic prompts" got 3x CTR
-- Pattern: "Advanced technique tutorials outperform basic tutorials"
-- Store: /remember "Pattern: [AI video niche] advanced techniques get 3x CTR vs basic tutorials"
-
-Cycle 3:
-- Research: Recall patterns, research advanced technique topics
-- Produce: 10 videos on advanced techniques (seed bracketing, style libraries, prompt engineering)
-- (continue loop)
-```
-
-**Automation**:
-
-```bash
-# Weekly analytics review script
-# 1. Pull analytics from all platforms
-# 2. Compare against baseline and thresholds
-# 3. Generate performance report
-# 4. Store winning patterns in memory
-# 5. Update content calendar with next cycle's priorities
-```
+Publish → Collect analytics → Analyze → Extract patterns → Store in memory (`/remember "Pattern: ..."`) → Feed into research cycle → Inform next content plan → repeat.
 
 ## Proven First, Original Second
 
-**Philosophy**: Iterate on proven winners, not on losers.
+1. **Find proven content**: Top 10 YouTube videos, viral TikToks, high-traffic blog posts (Ahrefs/SEMrush)
+2. **Replicate structure**: Copy format, not content (same hook type, different topic)
+3. **Add 3% twist**: Different personality, visual style, examples, or contrarian take
+4. **Test 10 variants** with different twists → scale the winner
 
-**Strategy**:
-
-1. **Find proven content**: Research what already works in your niche
-   - Top 10 videos on YouTube for your topic
-   - Viral TikToks in your niche
-   - High-traffic blog posts (via Ahrefs, SEMrush)
-
-2. **Replicate structure**: Copy the format, not the content
-   - Same hook type, different topic
-   - Same video structure, different examples
-   - Same blog outline, different angle
-
-3. **Add 3% twist**: Make it yours with a small unique element
-   - Different personality/voice
-   - Different visual style
-   - Different examples/case studies
-   - Contrarian take on same topic
-
-4. **Test variants**: Generate 10 versions with different twists
-5. **Scale winners**: Once you find your twist that works, produce 10 more
-
-**Example**:
-
-- **Proven**: "I spent $10K testing every AI video tool — here's what works" (1M views)
-- **Replicate**: "I spent [X] testing every [category] — here's what works" structure
-- **3% twist**: Your unique angle
-  - "I spent 100 hours testing AI video tools — here's the free ones that beat the paid ones"
-  - "I spent $10K on AI video tools — here's why I refunded 90% of them"
-  - "I spent 6 months testing AI video tools — here's the only 3 you need"
-
-**Why this works**:
-
-- Proven content has already validated the market (demand exists)
-- Proven content has already validated the format (structure works)
-- Your twist differentiates you without reinventing the wheel
-- Testing 10 twists finds your unique voice faster than starting from scratch
-
-## Rapid Testing Framework
-
-**Purpose**: Iterate faster by testing multiple variants in parallel.
-
-**Components**:
-
-1. **B-roll library**: Pre-generated stock footage, animations, transitions
-2. **Voice clone**: Consistent narration voice across all variants
-3. **Script variants**: 10 different scripts for same topic
-4. **Thumbnail variants**: 10 different thumbnails for same video
-
-**Workflow**:
-
-1. **Week 1: Generate variants**
-   - Write 10 script variants (see `content/production/writing.md`)
-   - Generate 10 thumbnail variants (see `content/production/image.md`)
-   - Record 10 voiceovers using voice clone (see `content/production/audio.md`)
-   - Assemble 10 videos using B-roll library (see `content/production/video.md`)
-
-2. **Week 2: Deploy and collect data**
-   - Upload all 10 videos to YouTube (or TikTok, or blog)
-   - Wait for 250+ impressions per variant
-   - Collect CTR, retention, watch time data
-
-3. **Week 3: Analyze and scale**
-   - Identify top 3 performers
-   - Extract winning patterns (hook type, thumbnail style, script structure)
-   - Kill bottom 7 variants (unlist or delete)
-
-4. **Week 4: Produce next batch**
-   - Generate 10 new variants using top 3 patterns
-   - Repeat cycle
-
-**Efficiency gain**: This approach finds winners 4x faster than sequential testing (10 variants in 4 weeks vs 10 weeks).
-
-## Integration
-
-- **Feeds into**: `content/research.md` (analytics inform next research cycle), `content/production/` (winning patterns inform next production batch)
-- **Uses data from**: `content/distribution/` (platform-specific analytics), `content/production/` (variant generation)
-- **Related**: `tools/task-management/beads.md` (task tracking for test execution), `memory/README.md` (pattern storage)
+Example: "I spent $10K testing every AI video tool" (1M views) → replicate structure → twist: "here's the free ones that beat the paid ones" / "here's why I refunded 90%"
 
 ## Tools and Automation
 
-**Analytics tools**:
+**Analytics**: YouTube Studio, TikTok Analytics, Google Analytics, Google Search Console (`seo/google-search-console.md`), DataForSEO (`seo/dataforseo.md`)
 
-- **YouTube Studio**: Retention curves, CTR, watch time
-- **TikTok Analytics**: Completion rate, shares, saves
-- **Google Analytics**: Time on page, scroll depth, bounce rate
-- **Google Search Console**: Click-through rate, impressions, rankings (see `seo/google-search-console.md`)
-- **DataForSEO**: Keyword rankings, competitor analysis (see `seo/dataforseo.md`)
-
-**A/B testing tools**:
-
-- **YouTube Studio**: Built-in thumbnail A/B testing
-- **Google Optimize**: Website headline/intro A/B testing
-- **VWO**: Full-stack A/B testing platform
-- **Optimizely**: Enterprise A/B testing
+**A/B testing**: YouTube Studio (thumbnails), Google Optimize (website), VWO, Optimizely
 
 **Automation scripts**:
+- `content-calendar-helper.sh`: calendar, cadence tracking, gap analysis (t208)
+- `analytics-helper.sh`: pull analytics from all platforms, generate report
+- `variant-generator-helper.sh`: generate 10 variants of a piece of content
+- `seed-bracket-helper.sh`: automate seed testing for AI video generation
+- `thumbnail-factory-helper.sh`: generate thumbnail variants using style library (t207)
 
-- `content-calendar-helper.sh`: Content calendar, cadence tracking, gap analysis, lifecycle management (see t208)
-- `analytics-helper.sh`: Pull analytics from all platforms, generate performance report
-- `variant-generator-helper.sh`: Generate 10 variants of a given piece of content
-- `seed-bracket-helper.sh`: Automate seed testing for AI video generation (generate, score, report)
-- `thumbnail-factory-helper.sh`: Generate thumbnail variants using style library (see t207)
+## Integration
+
+- **Feeds into**: `content/research.md` (analytics inform next research cycle), `content/production/` (winning patterns inform next batch)
+- **Uses data from**: `content/distribution/` (platform analytics), `content/production/` (variant generation)
+- **Related**: `tools/task-management/beads.md` (task tracking), `memory/README.md` (pattern storage)
 
 ## Next Steps
 
-After optimizing content:
-
-1. **Store winning patterns**: `/remember "Pattern: [description]"`
-2. **Update content calendar**: Prioritize more of what works
-3. **Feed into research cycle**: Use winning topics as seeds for next research phase
-4. **Scale production**: Produce 10 more pieces using winning patterns
-5. **Repeat loop**: Continuous optimization cycle
+1. Store winning patterns: `/remember "Pattern: [description]"`
+2. Update content calendar: prioritize more of what works
+3. Feed into research cycle: use winning topics as seeds
+4. Scale production: produce 10 more pieces using winning patterns

--- a/.agents/tools/ai-assistants/opencode-server.md
+++ b/.agents/tools/ai-assistants/opencode-server.md
@@ -53,49 +53,21 @@ OpenCode server mode (`opencode serve`) exposes an HTTP API for programmatic int
 
 ## Starting the Server
 
-### Standalone Server
-
 ```bash
-# Default (port 4096, localhost only)
-opencode serve
-
-# Custom port and hostname
-opencode serve --port 8080 --hostname 0.0.0.0
-
-# With mDNS discovery (for local network)
-opencode serve --mdns
-
-# With CORS for browser clients
-opencode serve --cors http://localhost:5173 --cors https://app.example.com
-```
-
-### With Authentication
-
-```bash
-# Basic auth (recommended for network exposure)
-OPENCODE_SERVER_PASSWORD=your-secure-password opencode serve
-
-# Custom username
+opencode serve                                                    # default (port 4096, localhost)
+opencode serve --port 8080 --hostname 0.0.0.0                    # custom port/hostname
+opencode serve --mdns                                             # mDNS discovery
+opencode serve --cors http://localhost:5173                       # CORS for browser clients
+OPENCODE_SERVER_PASSWORD=secret opencode serve                   # with auth
 OPENCODE_SERVER_USERNAME=admin OPENCODE_SERVER_PASSWORD=secret opencode serve
-```
-
-### Alongside TUI
-
-When you run `opencode` (TUI), it automatically starts a server on a random port. You can specify a fixed port:
-
-```bash
-opencode --port 4096 --hostname 127.0.0.1
+opencode --port 4096 --hostname 127.0.0.1                        # alongside TUI (fixed port)
 ```
 
 ## TypeScript SDK
 
-### Installation
-
 ```bash
 npm install @opencode-ai/sdk
 ```
-
-### Creating a Client
 
 ```typescript
 import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk"
@@ -104,255 +76,134 @@ import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk"
 const { client, server } = await createOpencode({
   port: 4096,
   hostname: "127.0.0.1",
-  config: {
-    model: "anthropic/claude-sonnet-4-6",
-  },
+  config: { model: "anthropic/claude-sonnet-4-6" },
 })
 
 // Option 2: Connect to existing server
-const client = createOpencodeClient({
-  baseUrl: "http://localhost:4096",
-})
-```
+const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
 
-### Session Management
-
-```typescript
-// Create a new session
-const session = await client.session.create({
-  body: { title: "My automated task" },
-})
-
-// List all sessions
+// Session management
+const session = await client.session.create({ body: { title: "My automated task" } })
 const sessions = await client.session.list()
+await client.session.delete({ path: { id: session.data.id } })
 
-// Get session details
-const details = await client.session.get({
-  path: { id: session.data.id },
-})
-
-// Delete a session
-await client.session.delete({
-  path: { id: session.data.id },
-})
-```
-
-### Sending Prompts
-
-```typescript
 // Synchronous prompt (waits for full response)
 const result = await client.session.prompt({
   path: { id: session.data.id },
   body: {
-    model: {
-      providerID: "anthropic",
-      modelID: "claude-sonnet-4-6",
-    },
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
     parts: [{ type: "text", text: "Explain this codebase structure" }],
   },
 })
+console.log(result.data.parts)
 
-console.log(result.data.parts) // AI response parts
-
-// Asynchronous prompt (fire and forget)
+// Asynchronous prompt (fire and forget — returns 204, monitor via SSE)
 await client.session.promptAsync({
   path: { id: session.data.id },
-  body: {
-    parts: [{ type: "text", text: "Run the test suite" }],
-  },
+  body: { parts: [{ type: "text", text: "Run the test suite" }] },
 })
-// Returns 204 No Content immediately
-// Monitor via SSE events
-```
 
-### Context Injection (No Reply)
-
-```typescript
-// Inject context without triggering AI response
+// Context injection (no AI response triggered)
 await client.session.prompt({
   path: { id: session.data.id },
   body: {
     noReply: true,
-    parts: [
-      {
-        type: "text",
-        text: "Context: This project uses TypeScript and Bun runtime.",
-      },
-    ],
+    parts: [{ type: "text", text: "Context: This project uses TypeScript and Bun runtime." }],
   },
 })
-```
 
-### Real-Time Events (SSE)
-
-```typescript
-// Subscribe to server events
+// Real-time events (SSE)
 const events = await client.event.subscribe()
-
 for await (const event of events.stream) {
   switch (event.type) {
-    case "session.message":
-      console.log("New message:", event.properties)
-      break
-    case "session.status":
-      console.log("Status change:", event.properties)
-      break
-    case "tool.call":
-      console.log("Tool invoked:", event.properties)
-      break
+    case "session.message": console.log("New message:", event.properties); break
+    case "session.status":  console.log("Status change:", event.properties); break
+    case "tool.call":       console.log("Tool invoked:", event.properties); break
   }
 }
 ```
 
 ## Direct HTTP API
 
-### Create Session
-
 ```bash
+# Create session
 curl -X POST http://localhost:4096/session \
   -H "Content-Type: application/json" \
   -d '{"title": "API Test Session"}'
-```
 
-### Send Prompt (Sync)
-
-```bash
+# Send prompt (sync)
 curl -X POST http://localhost:4096/session/{session_id}/message \
   -H "Content-Type: application/json" \
-  -d '{
-    "model": {
-      "providerID": "anthropic",
-      "modelID": "claude-sonnet-4-6"
-    },
-    "parts": [{"type": "text", "text": "Hello!"}]
-  }'
-```
+  -d '{"model":{"providerID":"anthropic","modelID":"claude-sonnet-4-6"},"parts":[{"type":"text","text":"Hello!"}]}'
 
-### Send Prompt (Async)
-
-```bash
+# Send prompt (async — returns 204 immediately)
 curl -X POST http://localhost:4096/session/{session_id}/prompt_async \
   -H "Content-Type: application/json" \
-  -d '{
-    "parts": [{"type": "text", "text": "Run tests in background"}]
-  }'
-# Returns 204 immediately
-```
+  -d '{"parts":[{"type":"text","text":"Run tests in background"}]}'
 
-### Subscribe to Events
-
-```bash
+# Subscribe to events (SSE)
 curl -N http://localhost:4096/event
-# SSE stream - first event is server.connected
-```
 
-### Execute Slash Command
-
-```bash
+# Execute slash command
 curl -X POST http://localhost:4096/session/{session_id}/command \
   -H "Content-Type: application/json" \
-  -d '{
-    "command": "remember",
-    "arguments": "This pattern worked for async processing"
-  }'
-```
+  -d '{"command":"remember","arguments":"This pattern worked for async processing"}'
 
-### Run Shell Command
-
-```bash
+# Run shell command
 curl -X POST http://localhost:4096/session/{session_id}/shell \
   -H "Content-Type: application/json" \
-  -d '{
-    "agent": "default",
-    "command": "npm test"
-  }'
+  -d '{"agent":"default","command":"npm test"}'
 ```
 
 ## Use Cases for aidevops
 
 ### 1. Parallel Agent Orchestration
 
-Run multiple AI sessions concurrently for different tasks:
-
 ```typescript
-import { createOpencodeClient } from "@opencode-ai/sdk"
-
 const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
 
-// Create parallel sessions for different tasks
 const [codeReview, docGen, testGen] = await Promise.all([
   client.session.create({ body: { title: "Code Review" } }),
   client.session.create({ body: { title: "Documentation" } }),
   client.session.create({ body: { title: "Test Generation" } }),
 ])
 
-// Dispatch tasks in parallel
 await Promise.all([
-  client.session.promptAsync({
-    path: { id: codeReview.data.id },
-    body: { parts: [{ type: "text", text: "Review src/auth.ts for security issues" }] },
-  }),
-  client.session.promptAsync({
-    path: { id: docGen.data.id },
-    body: { parts: [{ type: "text", text: "Generate API documentation for src/api/" }] },
-  }),
-  client.session.promptAsync({
-    path: { id: testGen.data.id },
-    body: { parts: [{ type: "text", text: "Generate unit tests for src/utils/" }] },
-  }),
+  client.session.promptAsync({ path: { id: codeReview.data.id },
+    body: { parts: [{ type: "text", text: "Review src/auth.ts for security issues" }] } }),
+  client.session.promptAsync({ path: { id: docGen.data.id },
+    body: { parts: [{ type: "text", text: "Generate API documentation for src/api/" }] } }),
+  client.session.promptAsync({ path: { id: testGen.data.id },
+    body: { parts: [{ type: "text", text: "Generate unit tests for src/utils/" }] } }),
 ])
 ```
 
 ### 2. Voice Dispatch (VoiceInk/iOS Shortcut)
 
-Send voice transcriptions to OpenCode:
-
 ```bash
 #!/bin/bash
 # voice-dispatch.sh - Called by VoiceInk or iOS Shortcut
-
 TRANSCRIPTION="$1"
 SESSION_ID="${OPENCODE_SESSION_ID:-default}"
-SERVER="http://localhost:4096"
-
-curl -X POST "$SERVER/session/$SESSION_ID/prompt_async" \
+curl -X POST "http://localhost:4096/session/$SESSION_ID/prompt_async" \
   -H "Content-Type: application/json" \
   -d "{\"parts\": [{\"type\": \"text\", \"text\": \"$TRANSCRIPTION\"}]}"
 ```
 
 ### 3. Automated Agent Testing
 
-Test agent changes in isolated sessions:
-
 ```typescript
 async function testAgentChange(testPrompt: string, expectedPattern: RegExp) {
   const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
-
-  // Create isolated test session
-  const session = await client.session.create({
-    body: { title: `Test: ${Date.now()}` },
-  })
-
+  const session = await client.session.create({ body: { title: `Test: ${Date.now()}` } })
   try {
-    // Send test prompt
     const result = await client.session.prompt({
       path: { id: session.data.id },
-      body: {
-        parts: [{ type: "text", text: testPrompt }],
-      },
+      body: { parts: [{ type: "text", text: testPrompt }] },
     })
-
-    // Extract text from response
-    const responseText = result.data.parts
-      .filter((p) => p.type === "text")
-      .map((p) => p.text)
-      .join("\n")
-
-    // Validate response
-    const passed = expectedPattern.test(responseText)
-    return { passed, response: responseText }
+    const responseText = result.data.parts.filter((p) => p.type === "text").map((p) => p.text).join("\n")
+    return { passed: expectedPattern.test(responseText), response: responseText }
   } finally {
-    // Cleanup
     await client.session.delete({ path: { id: session.data.id } })
   }
 }
@@ -360,115 +211,21 @@ async function testAgentChange(testPrompt: string, expectedPattern: RegExp) {
 
 ### 4. Self-Improving Agent Loop
 
-Query memory, generate improvements, test in isolated session:
-
-```typescript
-async function selfImproveLoop() {
-  const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
-
-  // 1. Review phase - analyze memory for patterns
-  const reviewSession = await client.session.create({
-    body: { title: "Self-Improve: Review" },
-  })
-
-  const analysis = await client.session.prompt({
-    path: { id: reviewSession.data.id },
-    body: {
-      parts: [
-        {
-          type: "text",
-          text: `Analyze recent memory entries for failure patterns:
-          
-/recall --type FAILURE --recent 20
-
-Identify gaps where we failed but don't have solutions.
-Output as JSON: { gaps: [{ pattern, frequency, suggestion }] }`,
-        },
-      ],
-    },
-  })
-
-  // 2. Refine phase - generate improvements
-  const refineSession = await client.session.create({
-    body: { title: "Self-Improve: Refine" },
-  })
-
-  const improvements = await client.session.prompt({
-    path: { id: refineSession.data.id },
-    body: {
-      parts: [
-        {
-          type: "text",
-          text: `Based on these gaps, propose agent improvements:
-${JSON.stringify(analysis.data)}
-
-Generate specific edits to agent files. Use worktree isolation.`,
-        },
-      ],
-    },
-  })
-
-  // 3. Test phase - validate in isolated session
-  const testSession = await client.session.create({
-    body: { title: "Self-Improve: Test" },
-  })
-
-  // Run test prompts against improved agents...
-
-  // 4. PR phase - create PR if tests pass (with privacy filter)
-}
-```
+Pattern: Review phase (analyze memory for failure patterns) → Refine phase (generate improvements in isolated session) → Test phase (validate against test prompts) → PR phase (create PR if tests pass, with privacy filter). Use `client.session.command` with `/recall` and `/remember` for memory access.
 
 ### 5. CI/CD Integration
 
-Trigger AI analysis from GitHub Actions:
-
-```yaml
-# .github/workflows/ai-review.yml
-name: AI Code Review
-
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-jobs:
-  ai-review:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Start OpenCode Server
-        run: |
-          opencode serve --port 4096 &
-          sleep 5
-
-      - name: Run AI Review
-        run: |
-          SESSION=$(curl -s -X POST http://localhost:4096/session \
-            -H "Content-Type: application/json" \
-            -d '{"title": "PR Review"}' | jq -r '.id')
-
-          curl -X POST "http://localhost:4096/session/$SESSION/message" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "parts": [{
-                "type": "text",
-                "text": "Review the changes in this PR for security issues and code quality. Output as markdown."
-              }]
-            }' | jq -r '.parts[0].text' > review.md
-
-      - name: Post Review Comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs')
-            const review = fs.readFileSync('review.md', 'utf8')
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: review
-            })
+```bash
+# In GitHub Actions: start server, create session, send review prompt, post comment
+opencode serve --port 4096 &
+sleep 5
+SESSION=$(curl -s -X POST http://localhost:4096/session \
+  -H "Content-Type: application/json" -d '{"title":"PR Review"}' | jq -r '.id')
+curl -X POST "http://localhost:4096/session/$SESSION/message" \
+  -H "Content-Type: application/json" \
+  -d '{"parts":[{"type":"text","text":"Review the changes in this PR for security issues. Output as markdown."}]}' \
+  | jq -r '.parts[0].text' > review.md
+# Then post review.md as a PR comment via actions/github-script
 ```
 
 ## API Reference
@@ -491,18 +248,13 @@ jobs:
 | `GET` | `/session/:id/diff` | Get session file changes |
 | `GET` | `/session/:id/todo` | Get session todo list |
 
-### Global Endpoints
+### Global / File Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/global/health` | Server health check |
 | `GET` | `/event` | SSE event stream |
 | `GET` | `/doc` | OpenAPI 3.1 spec |
-
-### File Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
 | `GET` | `/find?pattern=<pat>` | Search text in files |
 | `GET` | `/find/file?query=<q>` | Find files by name |
 | `GET` | `/file/content?path=<p>` | Read file content |
@@ -519,56 +271,24 @@ jobs:
 
 ## Integration with aidevops
 
-### Memory System
-
-Use the server API to store/recall memories programmatically:
-
 ```typescript
-// Store a memory via slash command
-await client.session.command({
-  path: { id: sessionId },
-  body: {
-    command: "remember",
-    arguments: "WORKING_SOLUTION: Use --no-verify for emergency hotfixes",
-  },
-})
-
-// Recall memories
-await client.session.command({
-  path: { id: sessionId },
-  body: {
-    command: "recall",
-    arguments: "--type WORKING_SOLUTION --recent 10",
-  },
-})
+// Store/recall memories via slash command
+await client.session.command({ path: { id: sessionId },
+  body: { command: "remember", arguments: "WORKING_SOLUTION: Use --no-verify for emergency hotfixes" } })
+await client.session.command({ path: { id: sessionId },
+  body: { command: "recall", arguments: "--type WORKING_SOLUTION --recent 10" } })
 ```
-
-### Mailbox System
-
-Dispatch tasks to parallel agents via mailbox:
 
 ```bash
-# Send task to another agent session
-mail-helper.sh send \
-  --to "code-reviewer" \
-  --type "task_dispatch" \
-  --subject "Review PR #123" \
-  --body "Review security implications of auth changes"
+# Mailbox dispatch to parallel agents
+mail-helper.sh send --to "code-reviewer" --type "task_dispatch" \
+  --subject "Review PR #123" --body "Review security implications of auth changes"
 ```
 
-### Pre-Edit Check
-
-Always run pre-edit check before file modifications:
-
 ```typescript
-// Before any file edits in automated sessions
-const preCheck = await client.session.shell({
-  path: { id: sessionId },
-  body: {
-    agent: "default",
-    command: "~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode",
-  },
-})
+// Pre-edit check before file modifications in automated sessions
+const preCheck = await client.session.shell({ path: { id: sessionId },
+  body: { agent: "default", command: "~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode" } })
 ```
 
 ## Security Considerations
@@ -576,45 +296,23 @@ const preCheck = await client.session.shell({
 1. **Network exposure**: Use `--hostname 127.0.0.1` (default) for local-only access
 2. **Authentication**: Always set `OPENCODE_SERVER_PASSWORD` when exposing to network
 3. **CORS**: Only allow trusted origins with `--cors`
-4. **Credentials**: Never pass secrets in prompts - use environment variables
+4. **Credentials**: Never pass secrets in prompts — use environment variables
 5. **Session cleanup**: Delete sessions after use to prevent data leakage
 
 ## Troubleshooting
 
-### Server won't start
-
 ```bash
-# Check if port is in use
-lsof -i :4096
-
-# Kill existing process
-pkill -f "opencode serve"
+lsof -i :4096                          # check if port is in use
+pkill -f "opencode serve"              # kill existing process
+curl http://localhost:4096/global/health  # verify server is running
 ```
 
-### Connection refused
-
-```bash
-# Verify server is running
-curl http://localhost:4096/global/health
-
-# Check firewall (macOS)
-sudo pfctl -s rules | grep 4096
-```
-
-### SDK timeout
-
-```typescript
-// Increase timeout for long operations
-const { client } = await createOpencode({
-  timeout: 30000, // 30 seconds
-})
-```
+SDK timeout: pass `timeout: 30000` to `createOpencode({ timeout: 30000 })`.
 
 ## Related Documentation
 
-- [OpenCode CLI](/docs/cli/) - Command-line interface
-- [OpenCode SDK](https://opencode.ai/docs/sdk/) - Official SDK documentation
-- [OpenCode Server](https://opencode.ai/docs/server/) - Full API reference
 - `tools/ai-assistants/overview.md` - AI assistant comparison
 - `workflows/git-workflow.md` - Git workflow integration
 - `memory/README.md` - Memory system documentation
+- OpenCode SDK docs: `https://opencode.ai/docs/sdk/`
+- OpenCode Server docs: `https://opencode.ai/docs/server/`

--- a/.agents/tools/architecture/feature-slicing-skill/references/IMPLEMENTATION.md
+++ b/.agents/tools/architecture/feature-slicing-skill/references/IMPLEMENTATION.md
@@ -1,14 +1,8 @@
 # FSD Implementation Patterns
 
-> **Sources:** [Tutorial](https://feature-sliced.design/docs/get-started/tutorial) | [Examples](https://github.com/feature-sliced/examples) | [Awesome FSD](https://github.com/feature-sliced/awesome)
+Code patterns for Feature-Sliced Design architecture. Sources: [Tutorial](https://feature-sliced.design/docs/get-started/tutorial) | [Examples](https://github.com/feature-sliced/examples) | [Awesome FSD](https://github.com/feature-sliced/awesome)
 
-Code patterns for Feature-Sliced Design architecture.
-
----
-
-## Entity Pattern
-
-### Complete Entity: User
+## Entity Pattern: User
 
 **Model Layer** (`entities/user/model/`):
 
@@ -180,11 +174,7 @@ export { mapUserDTO } from './model/mapper';
 export { userSchema, type UserFormData } from './model/schema';
 ```
 
----
-
-## Feature Pattern
-
-### Complete Feature: Authentication
+## Feature Pattern: Authentication
 
 **Model Layer** (`features/auth/model/`):
 
@@ -368,11 +358,7 @@ export type { LoginCredentials, AuthTokens } from './model/types';
 export { loginSchema, registerSchema } from './model/schema';
 ```
 
----
-
-## Widget Pattern
-
-### Header Widget
+## Widget Pattern: Header
 
 ```tsx
 // widgets/header/ui/Header.tsx
@@ -409,11 +395,7 @@ export function Header() {
 export { Header } from './ui/Header';
 ```
 
----
-
-## Page Pattern
-
-### Product Detail Page
+## Page Pattern: Product Detail
 
 ```typescript
 // pages/product-detail/api/loader.ts
@@ -452,11 +434,7 @@ export { ProductDetailPage } from './ui/ProductDetailPage';
 export { productDetailLoader } from './api/loader';
 ```
 
----
-
 ## Shared Layer Pattern
-
-### API Client
 
 ```typescript
 // shared/api/client.ts
@@ -554,11 +532,7 @@ export { Button } from './Button';
 export { Input } from './Input';
 ```
 
----
-
 ## App Layer Pattern
-
-### Providers Setup
 
 ```tsx
 // app/providers/index.tsx
@@ -601,8 +575,6 @@ export const router = createBrowserRouter([
   { path: '/login', element: <LoginPage /> },
 ]);
 ```
-
----
 
 ## TypeScript Configuration
 

--- a/.agents/tools/document/document-creation.md
+++ b/.agents/tools/document/document-creation.md
@@ -25,29 +25,14 @@ tools:
 - **OCR**: Auto-detects scanned PDFs; supports Tesseract, EasyOCR, GLM-OCR, Vision LLM
 - **Formats**: ODT, DOCX, PDF, MD, HTML, EPUB, PPTX, ODP, XLSX, ODS, RTF, CSV, TSV
 
-**Quick start**:
-
 ```bash
-# Check available tools
-document-creation-helper.sh status
-
-# Install dependencies (choose tier)
-document-creation-helper.sh install --minimal   # pandoc + poppler
-document-creation-helper.sh install --standard   # + odfpy, python-docx, openpyxl
-document-creation-helper.sh install --full       # + LibreOffice headless
-
-# Convert between formats
-document-creation-helper.sh convert report.pdf --to odt
-document-creation-helper.sh convert letter.odt --to pdf
-document-creation-helper.sh convert notes.md --to docx
-
-# Create from template
+document-creation-helper.sh status                                    # check tools
+document-creation-helper.sh install --minimal                         # pandoc + poppler
+document-creation-helper.sh install --standard                        # + odfpy, python-docx, openpyxl
+document-creation-helper.sh install --full                            # + LibreOffice headless
+document-creation-helper.sh convert report.pdf --to odt               # convert
 document-creation-helper.sh create template.odt --data fields.json --output letter.odt
-
-# List supported conversions
-document-creation-helper.sh formats
-
-# Manage templates
+document-creation-helper.sh formats                                   # list supported conversions
 document-creation-helper.sh template list
 document-creation-helper.sh template draft --type letter --format odt
 ```
@@ -112,74 +97,17 @@ availability at runtime and selects automatically.
 | EML | MD | email-to-markdown.py | -- | Parses MIME structure, converts HTML body to markdown, extracts attachments |
 | MSG | MD | email-to-markdown.py | -- | Uses extract-msg library, converts HTML body to markdown, extracts attachments |
 
-**Email conversion features**:
-- Parses MIME structure using Python's email library (.eml) or extract-msg (.msg)
-- Converts HTML email body to markdown using html2text
-- Extracts all attachments to a subfolder (`{filename}_attachments/`)
-- Preserves email metadata (From, To, Subject, Date) in markdown frontmatter
-- Outputs: `email.md` + `email_attachments/` folder
-
-**Converting extracted attachments**:
-After extracting attachments from an email, you can convert them to markdown using the same tool:
-
-```bash
-# Extract email and attachments
-document-creation-helper.sh convert email.eml --to md
-
-# Convert PDF attachment to markdown
-document-creation-helper.sh convert email_attachments/report.pdf --to md
-
-# Convert DOCX attachment to markdown
-document-creation-helper.sh convert email_attachments/document.docx --to md
-
-# OCR image attachment to markdown
-document-creation-helper.sh convert email_attachments/scan.jpg --to md --ocr auto
-```
-
-**Dependencies**:
-- `.eml` files: Python stdlib (email module) + html2text
-- `.msg` files: extract-msg library (auto-installed on first use)
+**Email conversion**: Parses MIME/MSG structure, converts HTML body to markdown, extracts attachments to `{filename}_attachments/`, preserves metadata (From, To, Subject, Date) in frontmatter. Dependencies: Python stdlib for `.eml`; `extract-msg` (auto-installed) for `.msg`.
 
 **Thread reconstruction** (t1054.8):
 
-After converting multiple emails to markdown, reconstruct conversation threads from `message_id` and `in_reply_to` headers:
-
 ```bash
-# Batch convert emails and reconstruct threads
-email-batch-convert-helper.sh batch ./emails
-
-# Or run steps separately:
-# 1. Convert emails
-email-batch-convert-helper.sh convert ./emails
-
-# 2. Reconstruct threads
-email-batch-convert-helper.sh threads ./emails
-
-# Or use Python scripts directly:
-python3 email-thread-reconstruction.py ./emails
+email-batch-convert-helper.sh batch ./emails      # convert + reconstruct threads
+email-batch-convert-helper.sh convert ./emails    # convert only
+email-batch-convert-helper.sh threads ./emails    # reconstruct only
 ```
 
-**Thread metadata added to frontmatter**:
-- `thread_id`: Root message-id of the conversation thread
-- `thread_position`: Position in thread (0 = root, 1+ = replies)
-- `thread_length`: Total messages in thread
-
-**Thread index file** (`thread-index.md`):
-- Lists all emails grouped by thread
-- Chronological ordering within each thread
-- Indented to show reply hierarchy
-- Links to individual email markdown files
-
-Example thread index output:
-```markdown
-## Thread: Project kickoff meeting (4 messages)
-Thread ID: `<msg-001@example.com>`
-
-1. [Project kickoff meeting](email1.md) - alice@example.com - 2026-02-10T09:00:00+0000
-  2. [Re: Project kickoff meeting](email2.md) - bob@example.com - 2026-02-10T10:30:00+0000
-  3. [Re: Project kickoff meeting](email3.md) - charlie@example.com - 2026-02-10T11:00:00+0000
-    4. [Re: Project kickoff meeting](email4.md) - alice@example.com - 2026-02-10T12:00:00+0000
-```
+Thread metadata added to frontmatter: `thread_id`, `thread_position`, `thread_length`. Output includes `thread-index.md` listing all emails grouped by thread with reply hierarchy.
 
 ### PDF Extraction (PDF as source)
 
@@ -218,28 +146,20 @@ Thread ID: `<msg-001@example.com>`
 
 ### Tier 1: Minimal (pandoc + poppler)
 
-Always available after `install --minimal`. Handles most text-based conversions.
-
-- **pandoc**: Swiss-army knife. Reads: md, docx, odt, html, epub, rst, latex, pptx, xlsx, csv, tsv, rtf. Writes: md, docx, odt, html, epub, pdf (with engine), pptx, rst, latex.
-- **poppler** (pdftotext, pdfimages, pdfinfo, pdftohtml): PDF text/image extraction, metadata.
+- **pandoc**: Reads/writes md, docx, odt, html, epub, rst, latex, pptx, xlsx, csv, tsv, rtf
+- **poppler** (pdftotext, pdfimages, pdfinfo, pdftohtml): PDF text/image extraction, metadata
 
 ### Tier 2: Standard (+ Python libraries)
 
-Adds programmatic document creation and manipulation.
-
-- **odfpy**: Create/edit ODT, ODS, ODP programmatically. Full control over styles, headers, footers, images, tables.
-- **python-docx**: Create/edit DOCX programmatically. Paragraphs, tables, images, styles, headers/footers.
-- **openpyxl**: Create/edit XLSX programmatically. Cells, formulas, charts, styles.
+- **odfpy**: Create/edit ODT, ODS, ODP programmatically
+- **python-docx**: Create/edit DOCX programmatically
+- **openpyxl**: Create/edit XLSX programmatically
 
 ### Tier 3: Full (+ LibreOffice headless)
 
-Highest fidelity for office format conversions. LibreOffice headless runs without GUI.
-
-- **LibreOffice headless**: `soffice --headless --convert-to <format> <input>`. Handles complex layouts, embedded objects, macros. Faithful ODT/DOCX/XLSX/PPTX to PDF conversion.
+- **LibreOffice headless**: `soffice --headless --convert-to <format> <input>`. Highest fidelity for office format conversions.
 
 ### Specialist Tools (routed to, not owned)
-
-These have their own agents. This agent routes to them when the task matches.
 
 | Tool | Agent | When to route |
 |------|-------|---------------|
@@ -250,293 +170,106 @@ These have their own agents. This agent routes to them when the task matches.
 
 ### Advanced Conversion Providers
 
-AI-powered conversion tools for enhanced quality and table preservation.
-
 | Provider | Model | Install | Best For |
 |----------|-------|---------|----------|
 | Reader-LM | Jina, 1.5B | `ollama pull reader-lm` | HTML to markdown with table preservation |
 | RolmOCR | Reducto, 7B | vLLM server with RolmOCR model | PDF page images to markdown with table preservation (GPU-accelerated) |
 
-**Reader-LM** (Jina AI, 1.5B parameters):
-- Runs locally via Ollama
-- Converts HTML to markdown while preserving complex table structures
-- Replaces pandoc for HTML->md when available
-- Usage: `document-creation-helper.sh convert page.html --to md`
-
-**RolmOCR** (Reducto, 7B parameters):
-- Runs via vLLM server (requires GPU)
-- Converts PDF page images to markdown with table preservation
-- Replaces pdftotext for PDF->md when GPU available
-- Requires vLLM server running on port 8000 with RolmOCR model
-- Usage: `document-creation-helper.sh convert document.pdf --to md`
-
 ## Document Creation from Templates
-
-### Template System
-
-Templates are regular documents (ODT, DOCX, etc.) with placeholder markers.
-The agent replaces markers with supplied data to produce finished documents.
 
 **Placeholder syntax**: `{{field_name}}`
 
-Example template fields:
-
-```text
-{{property_name}}       -- "The Bakehouse"
-{{property_address}}    -- "Rue de la Vallee, St Mary, JE3 3DL"
-{{date}}                -- "10th October 2025"
-{{author}}              -- "Marcus Quinn"
-{{listing_reference}}   -- "MY0128"
-```
-
-### Template Sources
-
-1. **User-supplied** (preferred): Place templates in your project or provide a path.
-   The agent uses them as-is, replacing only the placeholder fields.
-
-2. **Draft templates**: When no template exists, the agent can generate a draft
-   ODT/DOCX with placeholder fields, basic styles, headers/footers, and logo
-   placement. The user then refines the layout in their preferred editor
-   (LibreOffice, Affinity Publisher, Word) and saves it as the canonical template.
-
-### Template Storage
-
-```text
-~/.aidevops/.agent-workspace/templates/
-  documents/          # Document templates (ODT, DOCX)
-  spreadsheets/       # Spreadsheet templates (ODS, XLSX)
-  presentations/      # Presentation templates (ODP, PPTX)
-```
-
-Project-specific templates can live anywhere -- pass the path to the helper.
-
-### Creating Documents from Templates
+**Template storage**: `~/.aidevops/.agent-workspace/templates/` (documents/, spreadsheets/, presentations/)
 
 ```bash
-# From a template with JSON data
+# From template with JSON data
 document-creation-helper.sh create template.odt \
   --data '{"property_name": "The Bakehouse", "date": "10th October 2025"}' \
   --output letter.odt
 
-# From a template with a JSON file
-document-creation-helper.sh create template.odt \
-  --data fields.json \
-  --output letter.odt
+# From template with data file
+document-creation-helper.sh create template.odt --data fields.json --output letter.odt
 
 # Generate a draft template
 document-creation-helper.sh template draft \
-  --type letter \
-  --format odt \
+  --type letter --format odt \
   --fields "property_name,property_address,date,author,listing_reference"
-```
 
-### Programmatic Creation (no template)
-
-For fully programmatic document generation (e.g., reports from data), the agent
-uses odfpy/python-docx directly. This is appropriate when:
-
-- The document structure is data-driven (variable number of sections, images)
-- No visual template exists yet
-- Batch generation of many documents with different structures
-
-```bash
-# The helper delegates to a Python script for complex creation
+# Programmatic creation (data-driven structure, no template)
 document-creation-helper.sh create --script generate-report.py \
-  --data project-data.json \
-  --output report.odt
+  --data project-data.json --output report.odt
 ```
+
+Use programmatic creation (odfpy/python-docx) when: document structure is data-driven, no visual template exists, or batch generation with different structures.
 
 ## Installation
 
 ```bash
-# Check what's installed
-document-creation-helper.sh status
-
-# Minimal: pandoc + poppler (covers most text conversions)
-document-creation-helper.sh install --minimal
-
-# Standard: + odfpy, python-docx, openpyxl (programmatic creation)
-document-creation-helper.sh install --standard
-
-# Full: + LibreOffice headless (highest fidelity office conversions)
-document-creation-helper.sh install --full
-
-# Individual tools
-document-creation-helper.sh install --tool pandoc
-document-creation-helper.sh install --tool libreoffice
-document-creation-helper.sh install --tool odfpy
-document-creation-helper.sh install --tool python-docx
-document-creation-helper.sh install --tool openpyxl
-```
-
-### Installation Details
-
-**Tier 1 - Minimal**:
-
-```bash
 # macOS
-brew install pandoc poppler
+brew install pandoc poppler                                           # Tier 1
+brew install --cask libreoffice                                       # Tier 3
 
 # Ubuntu/Debian
-sudo apt install pandoc poppler-utils
+sudo apt install pandoc poppler-utils                                 # Tier 1
+sudo apt install libreoffice-core libreoffice-writer libreoffice-calc libreoffice-impress  # Tier 3
 
-# Windows
-choco install pandoc
-```
-
-**Tier 2 - Standard** (Python venv at `~/.aidevops/.agent-workspace/python-env/document-creation/`):
-
-```bash
+# Tier 2 (Python venv at ~/.aidevops/.agent-workspace/python-env/document-creation/)
 python3 -m venv ~/.aidevops/.agent-workspace/python-env/document-creation
 source ~/.aidevops/.agent-workspace/python-env/document-creation/bin/activate
 pip install odfpy python-docx openpyxl
-```
 
-**Tier 3 - Full**:
-
-```bash
-# macOS
-brew install --cask libreoffice
-
-# Ubuntu/Debian
-sudo apt install libreoffice-core libreoffice-writer libreoffice-calc libreoffice-impress
-
-# Verify headless mode
-soffice --headless --version
+# Via helper (handles venv automatically)
+document-creation-helper.sh install --tool easyocr
+ollama pull glm-ocr                                                   # GLM-OCR
 ```
 
 ## Usage Examples
 
-### Format Conversion
-
 ```bash
-# Simple conversions
-document-creation-helper.sh convert report.md --to docx
-document-creation-helper.sh convert letter.odt --to pdf
-document-creation-helper.sh convert slides.pptx --to pdf
-document-creation-helper.sh convert data.xlsx --to csv
-
-# Email conversions (extracts attachments automatically)
-document-creation-helper.sh convert email.eml --to md
-document-creation-helper.sh convert message.msg --to md
-
-# With options
-document-creation-helper.sh convert report.md --to pdf --engine xelatex
-document-creation-helper.sh convert letter.odt --to pdf --tool libreoffice
-document-creation-helper.sh convert complex.pdf --to md --tool mineru
-
-# Batch conversion (use a for loop — the script processes one file at a time)
+# Batch conversion
 for f in ./documents/*.docx; do document-creation-helper.sh convert "$f" --to pdf; done
-for f in ./reports/*.md; do document-creation-helper.sh convert "$f" --to odt; done
 
 # Force a specific tool
-document-creation-helper.sh convert file.odt --to pdf --tool pandoc
 document-creation-helper.sh convert file.odt --to pdf --tool libreoffice
-```
 
-### PDF to ODT (layout-preserving)
+# Email (extracts attachments automatically)
+document-creation-helper.sh convert email.eml --to md
 
-This is a multi-step process handled automatically:
-
-1. Extract text with `pdftotext -layout`
-2. Extract images with `pdfimages`
-3. Detect document structure (headings, paragraphs, captions)
-4. Build ODT with odfpy (styles, headers/footers, embedded images)
-
-```bash
-# Automatic (uses best available tools)
+# PDF to ODT (multi-step: extract text+images, detect structure, build ODT)
 document-creation-helper.sh convert report.pdf --to odt
-
-# With a template (applies extracted content to template layout)
 document-creation-helper.sh convert report.pdf --to odt --template company-template.odt
-```
 
-### Document Creation
-
-```bash
-# From template with inline data
-document-creation-helper.sh create letter-template.odt \
-  --data '{"recipient": "Planning Department", "date": "2025-10-11"}' \
-  --output cover-letter.odt
-
-# From template with data file
-document-creation-helper.sh create invoice-template.xlsx \
-  --data invoice-data.json \
-  --output "Invoice-2025-001.xlsx"
-
-# Generate a draft template for a new document type
-document-creation-helper.sh template draft \
-  --type report \
-  --format odt \
-  --fields "title,author,date,summary" \
-  --header-logo logo.png \
-  --footer-text "Company Name | confidential"
+# OCR
+document-creation-helper.sh convert scanned.pdf --to odt --ocr tesseract
+document-creation-helper.sh convert screenshot.png --to md --ocr auto
 ```
 
 ## Decision Tree
-
-When asked to convert or create a document, follow this tree:
 
 ```text
 1. What is the task?
    |
     +-- Convert format A to format B
     |   |
-    |   +-- Is it structured data extraction? (invoice fields, receipt OCR)
-    |   |   YES -> Route to document-extraction.md or docstrange.md
-    |   |
-    |   +-- Is it PDF form filling or signing?
-    |   |   YES -> Route to tools/pdf/overview.md (LibPDF)
-    |   |
-    |   +-- Is it PDF with complex layout to markdown?
-    |   |   YES -> Route to tools/conversion/mineru.md
-    |   |
-    |   +-- Is it a scanned PDF or image with text?
-    |   |   YES -> OCR pipeline (auto-detect provider, extract text, then convert)
-    |   |
-    |   +-- Otherwise: use this agent's tool selection matrix
-    |       Check preferred tool -> available? -> use it
-    |       Not available? -> try fallback
-    |       No fallback? -> suggest installation
-   |
-   +-- Create document from template
-   |   |
-   |   +-- Template supplied?
-   |   |   YES -> Load template, replace placeholders, save
-   |   |   NO  -> Offer to generate draft template
-   |   |
-   |   +-- Complex/data-driven structure?
-   |       YES -> Use odfpy/python-docx programmatically
-   |       NO  -> Template + placeholder replacement
-   |
-   +-- Generate draft template
-       |
-       +-- Collect: format, fields, header/footer, logo
-       +-- Generate with odfpy/python-docx
-       +-- Save to templates directory or specified path
-       +-- User refines in their preferred editor
+    |   +-- Structured data extraction? → document-extraction.md or docstrange.md
+    |   +-- PDF form filling or signing? → tools/pdf/overview.md (LibPDF)
+    |   +-- PDF with complex layout to markdown? → tools/conversion/mineru.md
+    |   +-- Scanned PDF or image with text? → OCR pipeline (auto-detect provider)
+    |   +-- Otherwise: use tool selection matrix above
+    |
+    +-- Create document from template
+    |   +-- Template supplied? → replace placeholders, save
+    |   +-- No template? → offer to generate draft template
+    |   +-- Complex/data-driven? → odfpy/python-docx programmatically
+    |
+    +-- Generate draft template
+        +-- Collect: format, fields, header/footer, logo
+        +-- Generate with odfpy/python-docx → user refines in editor
 ```
 
 ## OCR Support
 
-For scanned PDFs and images containing text, OCR extracts the text content before
-document creation or conversion can proceed.
-
-### When OCR Is Needed
-
-- **Scanned PDFs**: Pages are images, not selectable text. `pdftotext` returns empty output.
-- **Photos of documents**: Camera captures of letters, forms, signs.
-- **Screenshots with text**: UI captures where text needs extracting.
-
-### Auto-Detection
-
-The helper script detects scanned PDFs automatically:
-
-1. Run `pdftotext` on the input -- if output is empty or near-empty, pages are likely scanned images
-2. Run `pdffonts` -- if no fonts are embedded, the PDF contains only images
-3. If both checks indicate image-only content, trigger OCR pipeline
-
-### OCR Provider Routing
+**Auto-detection**: `pdftotext` returns empty → pages are images; `pdffonts` shows no embedded fonts → trigger OCR.
 
 | Provider | Install | Speed | Quality | Best For |
 |----------|---------|-------|---------|----------|
@@ -545,71 +278,19 @@ The helper script detects scanned PDFs automatically:
 | GLM-OCR | `ollama pull glm-ocr` | Slow | Very good | Privacy-sensitive, complex layouts |
 | Vision LLM | API key required | Medium | Excellent | Photos, receipts, handwriting |
 
-**Selection order** (auto mode): Tesseract -> EasyOCR -> GLM-OCR -> Vision LLM
+**Selection order** (auto mode): Tesseract → EasyOCR → GLM-OCR → Vision LLM
 
-The helper picks the first available provider. Use `--ocr <provider>` to force a specific one.
+For screenshot/image input, options: keep as image, extract text (OCR), or both (image + text caption).
 
-### Usage
-
-```bash
-# Auto-detect and OCR if needed
-document-creation-helper.sh convert scanned-report.pdf --to odt
-
-# Force OCR with specific provider
-document-creation-helper.sh convert scanned.pdf --to odt --ocr tesseract
-document-creation-helper.sh convert photo.jpg --to odt --ocr glm-ocr
-
-# OCR a screenshot -- extract text as quoted block
-document-creation-helper.sh convert screenshot.png --to md --ocr auto
-
-# Check OCR tool availability
-document-creation-helper.sh status
-```
-
-### Screenshot Text Extraction
-
-When the input is a screenshot or image (PNG, JPG, TIFF), the agent offers three options:
-
-1. **Keep as image** -- embed the screenshot in the output document as-is
-2. **Extract text** -- OCR the image and insert the text content
-3. **Both** -- embed the image with the extracted text as a caption or adjacent paragraph
-
-### OCR Installation
-
-```bash
-# Tesseract (recommended first install -- fast, reliable for printed text)
-brew install tesseract                    # macOS
-sudo apt install tesseract-ocr            # Ubuntu/Debian
-
-# EasyOCR (Python, 80+ languages)
-document-creation-helper.sh install --tool easyocr
-
-# GLM-OCR (local AI via Ollama, no API keys)
-ollama pull glm-ocr
-
-# All OCR tools at once
-document-creation-helper.sh install --ocr
-```
-
-### Related OCR Agents
-
-- `tools/ocr/glm-ocr.md` -- Local OCR via Ollama
-- `tools/ocr/ocr-research.md` -- OCR approach comparison and research
-- `tools/document/document-extraction.md` -- Structured data extraction (Docling + ExtractThinker)
-- `tools/conversion/mineru.md` -- MinerU (layout-aware PDF parsing with built-in OCR)
+**Related OCR agents**: `tools/ocr/glm-ocr.md`, `tools/ocr/ocr-research.md`, `tools/document/document-extraction.md`, `tools/conversion/mineru.md`
 
 ## Limitations
 
-- **PDF to editable formats** is inherently lossy. PDFs use absolute positioning;
-  flow-based formats (ODT, DOCX) use relative layout. Text content and images
-  transfer well; exact positioning does not.
-- **Spreadsheet formulas** may not survive format conversion (XLSX to ODS and back).
-  Values are preserved; formulas may need manual verification.
-- **Presentation animations and transitions** are lost in most conversions.
-- **Embedded fonts** may not transfer between formats. The output may use
-  fallback fonts if the original font is unavailable.
-- **LibreOffice headless** produces the highest fidelity but is a large install (~500MB).
-  The helper script works without it, using pandoc as fallback.
+- **PDF to editable formats**: inherently lossy — text/images transfer well, exact positioning does not
+- **Spreadsheet formulas**: may not survive format conversion; values preserved, formulas need verification
+- **Presentation animations/transitions**: lost in most conversions
+- **Embedded fonts**: may not transfer; output uses fallback fonts if original unavailable
+- **LibreOffice headless**: highest fidelity but large install (~500MB); pandoc used as fallback
 
 ## Related
 


### PR DESCRIPTION
## Summary

- `document-creation.md`: 622 → 303 lines (51% reduction) — merged duplicate install sections, collapsed usage examples, condensed OCR install
- `content/optimization.md`: 622 → 246 lines (60% reduction) — removed repeated test execution workflow, condensed analytics tables, trimmed verbose examples
- `opencode-server.md`: 620 → 318 lines (49% reduction) — collapsed duplicate HTTP/SDK examples, condensed CI/CD workflow, tightened self-improve pattern
- `IMPLEMENTATION.md`: 618 → 590 lines — code-dense reference, removed dividers and redundant section headers

No behavior changes. All code blocks, task IDs, command examples, and URLs preserved.

Closes #6074
Closes #6075
Closes #6076
Closes #6077