### PR TITLE
t5717: Reduce function complexity in setup-modules/shell-env.sh

### DIFF
--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -92,6 +92,50 @@ get_all_shell_rcs() {
 	return 0
 }
 
+# Offer to change the default shell to zsh after Oh My Zsh is installed.
+_omz_offer_shell_change() {
+	local default_shell="$1"
+
+	if [[ "$default_shell" == "zsh" ]]; then
+		return 0
+	fi
+
+	echo ""
+	read -r -p "Change default shell to zsh? [y/N]: " change_shell
+	if [[ "$change_shell" =~ ^[Yy]$ ]]; then
+		if chsh -s "$(command -v zsh)"; then
+			print_success "Default shell changed to zsh"
+			print_info "Restart your terminal for the change to take effect"
+		else
+			print_warning "Failed to change shell - run manually: chsh -s $(command -v zsh)"
+		fi
+	fi
+
+	return 0
+}
+
+# Run the Oh My Zsh installer and handle post-install steps.
+_omz_run_install() {
+	local default_shell="$1"
+
+	print_info "Installing Oh My Zsh..."
+	# Use verified download + --unattended to avoid changing the shell or starting zsh
+	# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
+	VERIFIED_INSTALL_SHELL="sh"
+	if verified_install "Oh My Zsh" "https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" --unattended; then
+		print_success "Oh My Zsh installed"
+		if [[ ! -f "$HOME/.zshrc" ]]; then
+			print_warning ".zshrc not created - Oh My Zsh may not have installed correctly"
+		fi
+		_omz_offer_shell_change "$default_shell"
+	else
+		print_warning "Oh My Zsh installation failed"
+		print_info "Install manually: curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o /tmp/omz-install.sh && sh /tmp/omz-install.sh"
+	fi
+
+	return 0
+}
+
 # Offer to install Oh My Zsh if zsh is the default shell and OMZ is not present
 setup_oh_my_zsh() {
 	# Check prerequisites before announcing setup (GH#5240)
@@ -124,35 +168,7 @@ setup_oh_my_zsh() {
 	read -r -p "Install Oh My Zsh? [y/N]: " install_omz
 
 	if [[ "$install_omz" =~ ^[Yy]$ ]]; then
-		print_info "Installing Oh My Zsh..."
-		# Use verified download + --unattended to avoid changing the shell or starting zsh
-		# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
-		VERIFIED_INSTALL_SHELL="sh"
-		if verified_install "Oh My Zsh" "https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" --unattended; then
-			print_success "Oh My Zsh installed"
-
-			# Ensure .zshrc exists (Oh My Zsh creates it, but verify)
-			if [[ ! -f "$HOME/.zshrc" ]]; then
-				print_warning ".zshrc not created - Oh My Zsh may not have installed correctly"
-			fi
-
-			# If the user's default shell isn't zsh, offer to change it
-			if [[ "$default_shell" != "zsh" ]]; then
-				echo ""
-				read -r -p "Change default shell to zsh? [y/N]: " change_shell
-				if [[ "$change_shell" =~ ^[Yy]$ ]]; then
-					if chsh -s "$(command -v zsh)"; then
-						print_success "Default shell changed to zsh"
-						print_info "Restart your terminal for the change to take effect"
-					else
-						print_warning "Failed to change shell - run manually: chsh -s $(command -v zsh)"
-					fi
-				fi
-			fi
-		else
-			print_warning "Oh My Zsh installation failed"
-			print_info "Install manually: curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o /tmp/omz-install.sh && sh /tmp/omz-install.sh"
-		fi
+		_omz_run_install "$default_shell"
 	else
 		print_info "Skipped Oh My Zsh installation"
 		print_info "Install later: curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o /tmp/omz-install.sh && sh /tmp/omz-install.sh"
@@ -229,12 +245,49 @@ _shell_compat_count_customizations() {
 	return 0
 }
 
-# Extract portable customizations from bash config files into the shared profile.
-# Returns the count of extracted lines.
-_shell_compat_extract_to_shared_profile() {
+# Return 0 if the line is bash-specific and should NOT be extracted to shared profile.
+_shell_compat_is_bash_specific() {
+	local line="$1"
+	case "$line" in
+	*shopt*) return 0 ;;
+	*PROMPT_COMMAND*) return 0 ;;
+	*PS1=*) return 0 ;;
+	*PS2=*) return 0 ;;
+	*bash_completion*) return 0 ;;
+	*"complete "*) return 0 ;;
+	*"bind "*) return 0 ;;
+	*HISTCONTROL*) return 0 ;;
+	*HISTFILESIZE*) return 0 ;;
+	*HISTSIZE*) return 0 ;;
+	*"source /etc/bash"*) return 0 ;;
+	*". /etc/bash"*) return 0 ;;
+	*"source /etc/profile"*) return 0 ;;
+	*". /etc/profile"*) return 0 ;;
+	# Skip lines that source .bashrc from .bash_profile (circular)
+	*".bashrc"*) return 0 ;;
+	# Skip lines that source .shell_common (we'll add this ourselves)
+	*"shell_common"*) return 0 ;;
+	esac
+	return 1
+}
+
+# Return 0 if the line is a portable shell customization (exports, aliases, PATH, etc.).
+_shell_compat_is_portable() {
+	local line="$1"
+	case "$line" in
+	export\ [A-Z]* | export\ PATH*) return 0 ;;
+	alias\ *) return 0 ;;
+	eval\ *) return 0 ;;
+	*PATH=*) return 0 ;;
+	# Also match 'source' and '. ' commands (tool integrations like nvm, rvm, pyenv)
+	source\ * | .\ /* | .\ \$* | .\ \~*) return 0 ;;
+	esac
+	return 1
+}
+
+# Write the header block for the shared profile file.
+_shell_compat_write_profile_header() {
 	local shared_profile="$1"
-	shift
-	# remaining args are bash_files
 
 	{
 		echo "# Shared shell profile - sourced by both bash and zsh"
@@ -244,84 +297,86 @@ _shell_compat_extract_to_shared_profile() {
 		echo ""
 	} >"$shared_profile"
 
-	# Track lines we've already written to avoid duplicates
-	# (common on Linux where .bash_profile sources .bashrc)
+	return 0
+}
+
+# Extract portable lines from one source file into the shared profile.
+# Skips duplicates (tracked via seen_lines nameref-style via global).
+# Prints the number of lines extracted from this file.
+# Args: shared_profile src_file [seen_line1 seen_line2 ...]
+# Returns extracted count via stdout; seen lines via stdout after count (newline-separated).
+_shell_compat_extract_one_file() {
+	local shared_profile="$1"
+	local src_file="$2"
+	shift 2
+	# remaining args are already-seen lines
+
+	local src_basename
+	src_basename=$(basename "$src_file")
+	local added_header=false
+	local extracted=0
+
+	# Build a local seen set from passed args
+	local -a seen_lines=("$@")
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		[[ -z "$line" ]] && continue
+		[[ "$line" =~ ^[[:space:]]*# ]] && continue
+		_shell_compat_is_bash_specific "$line" && continue
+		_shell_compat_is_portable "$line" || continue
+
+		# Deduplicate
+		local is_dup=false
+		local seen
+		for seen in "${seen_lines[@]+"${seen_lines[@]}"}"; do
+			if [[ "$seen" == "$line" ]]; then
+				is_dup=true
+				break
+			fi
+		done
+		[[ "$is_dup" == "true" ]] && continue
+
+		if [[ "$added_header" == "false" ]]; then
+			echo "" >>"$shared_profile"
+			echo "# From $src_basename" >>"$shared_profile"
+			added_header=true
+		fi
+		echo "$line" >>"$shared_profile"
+		seen_lines+=("$line")
+		((++extracted))
+	done <"$src_file"
+
+	# Output: count on first line, then new seen lines (for caller to accumulate)
+	echo "$extracted"
+	printf '%s\n' "${seen_lines[@]+"${seen_lines[@]}"}"
+	return 0
+}
+
+# Extract portable customizations from bash config files into the shared profile.
+# Returns the count of extracted lines.
+_shell_compat_extract_to_shared_profile() {
+	local shared_profile="$1"
+	shift
+	# remaining args are bash_files
+
+	_shell_compat_write_profile_header "$shared_profile"
+
 	local -a seen_lines=()
 	local extracted=0
 
 	local src_file
 	for src_file in "$@"; do
-		local src_basename
-		src_basename=$(basename "$src_file")
-		local added_header=false
-
-		while IFS= read -r line || [[ -n "$line" ]]; do
-			# Skip empty lines
-			[[ -z "$line" ]] && continue
-			# Skip pure comment lines
-			[[ "$line" =~ ^[[:space:]]*# ]] && continue
-
-			# Skip bash-specific settings that don't work in zsh
-			case "$line" in
-			*shopt*) continue ;;
-			*PROMPT_COMMAND*) continue ;;
-			*PS1=*) continue ;;
-			*PS2=*) continue ;;
-			*bash_completion*) continue ;;
-			*"complete "*) continue ;;
-			*"bind "*) continue ;;
-			*HISTCONTROL*) continue ;;
-			*HISTFILESIZE*) continue ;;
-			*HISTSIZE*) continue ;;
-			*"source /etc/bash"*) continue ;;
-			*". /etc/bash"*) continue ;;
-			*"source /etc/profile"*) continue ;;
-			*". /etc/profile"*) continue ;;
-			# Skip lines that source .bashrc from .bash_profile (circular)
-			*".bashrc"*) continue ;;
-			# Skip lines that source .shell_common (we'll add this ourselves)
-			*"shell_common"*) continue ;;
-			esac
-
-			# Match portable lines: exports, aliases, PATH, eval, source/dot-source
-			local is_portable=false
-			case "$line" in
-			export\ [A-Z]* | export\ PATH*) is_portable=true ;;
-			alias\ *) is_portable=true ;;
-			eval\ *) is_portable=true ;;
-			*PATH=*) is_portable=true ;;
-			esac
-			# Also match 'source' and '. ' commands (tool integrations like nvm, rvm, pyenv)
-			if [[ "$is_portable" == "false" ]]; then
-				case "$line" in
-				source\ * | .\ /* | .\ \$* | .\ \~*) is_portable=true ;;
-				esac
-			fi
-
-			if [[ "$is_portable" == "true" ]]; then
-				# Deduplicate: skip if we've already seen this exact line
-				local is_dup=false
-				local seen
-				for seen in "${seen_lines[@]}"; do
-					if [[ "$seen" == "$line" ]]; then
-						is_dup=true
-						break
-					fi
-				done
-				if [[ "$is_dup" == "true" ]]; then
-					continue
-				fi
-
-				if [[ "$added_header" == "false" ]]; then
-					echo "" >>"$shared_profile"
-					echo "# From $src_basename" >>"$shared_profile"
-					added_header=true
-				fi
-				echo "$line" >>"$shared_profile"
-				seen_lines+=("$line")
-				((++extracted))
-			fi
-		done <"$src_file"
+		local file_out
+		file_out=$(_shell_compat_extract_one_file "$shared_profile" "$src_file" "${seen_lines[@]+"${seen_lines[@]}"}")
+		local file_count
+		file_count=$(printf '%s\n' "$file_out" | head -1)
+		extracted=$((extracted + file_count))
+		# Rebuild seen_lines from output (skip first line = count)
+		local -a new_seen=()
+		while IFS= read -r seen_line; do
+			[[ -n "$seen_line" ]] && new_seen+=("$seen_line")
+		done < <(printf '%s\n' "$file_out" | tail -n +2)
+		seen_lines=("${new_seen[@]+"${new_seen[@]}"}")
 	done
 
 	echo "$extracted"
@@ -365,6 +420,70 @@ _shell_compat_add_sourcing() {
 	return 0
 }
 
+# Print detected customization counts and prompt the user.
+# Returns 1 if the user declines (caller should return 0).
+_shell_compat_prompt_user() {
+	local file_count="$1"
+	local total_exports="$2"
+	local total_aliases="$3"
+	local total_paths="$4"
+
+	print_info "Detected bash customizations across ${file_count} file(s):"
+	echo "  Exports: $total_exports, Aliases: $total_aliases, PATH entries: $total_paths"
+	echo ""
+	print_info "Best practice: create a shared profile (~/.shell_common) sourced by"
+	print_info "both bash and zsh, so your customizations work in either shell."
+	echo ""
+
+	local setup_compat="Y"
+	if [[ "$NON_INTERACTIVE" != "true" ]]; then
+		read -r -p "Create shared shell profile for cross-shell compatibility? [Y/n]: " setup_compat
+	fi
+
+	if [[ ! "$setup_compat" =~ ^[Yy]?$ ]]; then
+		print_info "Skipped cross-shell compatibility setup"
+		print_info "Set up later by creating ~/.shell_common and sourcing it from both shells"
+		return 1
+	fi
+
+	return 0
+}
+
+# Do the extraction and sourcing steps, then print the success summary.
+_shell_compat_do_extract() {
+	local shared_profile="$1"
+	local zsh_rc="$2"
+	shift 2
+	# remaining args are bash_files
+
+	# We extract: exports, PATH modifications, aliases, eval statements, source commands
+	# We skip: bash-specific syntax (shopt, PROMPT_COMMAND, PS1, completion, bind, etc.)
+	# We deduplicate lines that appear in multiple files (e.g. .bash_profile sources .bashrc)
+	print_info "Creating shared profile: $shared_profile"
+
+	local extracted
+	extracted=$(_shell_compat_extract_to_shared_profile "$shared_profile" "$@")
+
+	if [[ $extracted -eq 0 ]]; then
+		rm -f "$shared_profile"
+		print_info "No portable customizations found to extract"
+		return 0
+	fi
+
+	chmod 644 "$shared_profile"
+	print_success "Extracted $extracted unique customization(s) to $shared_profile"
+	_shell_compat_add_sourcing "$zsh_rc" "$@"
+
+	echo ""
+	print_success "Cross-shell compatibility configured"
+	print_info "Your customizations are now in: $shared_profile"
+	print_info "Both bash and zsh will source this file automatically."
+	print_info "Edit ~/.shell_common for settings you want in both shells."
+	print_info "Use ~/.bashrc or ~/.zshrc for shell-specific settings only."
+
+	return 0
+}
+
 # Extract portable customizations from bash configs into a shared profile for cross-shell use
 setup_shell_compatibility() {
 	print_info "Setting up cross-shell compatibility..."
@@ -391,50 +510,8 @@ setup_shell_compatibility() {
 		return 0
 	fi
 
-	print_info "Detected bash customizations across ${#bash_files[@]} file(s):"
-	echo "  Exports: $total_exports, Aliases: $total_aliases, PATH entries: $total_paths"
-	echo ""
-	print_info "Best practice: create a shared profile (~/.shell_common) sourced by"
-	print_info "both bash and zsh, so your customizations work in either shell."
-	echo ""
-
-	local setup_compat="Y"
-	if [[ "$NON_INTERACTIVE" != "true" ]]; then
-		read -r -p "Create shared shell profile for cross-shell compatibility? [Y/n]: " setup_compat
-	fi
-
-	if [[ ! "$setup_compat" =~ ^[Yy]?$ ]]; then
-		print_info "Skipped cross-shell compatibility setup"
-		print_info "Set up later by creating ~/.shell_common and sourcing it from both shells"
-		return 0
-	fi
-
-	# Extract portable customizations from bash config into shared profile
-	# We extract: exports, PATH modifications, aliases, eval statements, source commands
-	# We skip: bash-specific syntax (shopt, PROMPT_COMMAND, PS1, completion, bind, etc.)
-	# We deduplicate lines that appear in multiple files (e.g. .bash_profile sources .bashrc)
-	print_info "Creating shared profile: $shared_profile"
-
-	local extracted
-	extracted=$(_shell_compat_extract_to_shared_profile "$shared_profile" "${bash_files[@]}")
-
-	if [[ $extracted -eq 0 ]]; then
-		rm -f "$shared_profile"
-		print_info "No portable customizations found to extract"
-		return 0
-	fi
-
-	chmod 644 "$shared_profile"
-	print_success "Extracted $extracted unique customization(s) to $shared_profile"
-
-	_shell_compat_add_sourcing "$zsh_rc" "${bash_files[@]}"
-
-	echo ""
-	print_success "Cross-shell compatibility configured"
-	print_info "Your customizations are now in: $shared_profile"
-	print_info "Both bash and zsh will source this file automatically."
-	print_info "Edit ~/.shell_common for settings you want in both shells."
-	print_info "Use ~/.bashrc or ~/.zshrc for shell-specific settings only."
+	_shell_compat_prompt_user "${#bash_files[@]}" "$total_exports" "$total_aliases" "$total_paths" || return 0
+	_shell_compat_do_extract "$shared_profile" "$zsh_rc" "${bash_files[@]}"
 
 	return 0
 }
@@ -478,37 +555,39 @@ check_optional_deps() {
 	return 0
 }
 
-# Add ~/.local/bin to PATH in all shell rc files for the aidevops CLI
-add_local_bin_to_path() {
-	# shellcheck disable=SC2016 # path_line is written to rc files; must expand at shell startup, not now
-	local path_line='export PATH="$HOME/.local/bin:$PATH"'
-	local added_to=""
-	local already_in=""
+# Update a single rc file to include ~/.local/bin on PATH.
+# Prints "added:<file>" or "already:<file>" to stdout.
+_local_bin_update_rc_file() {
+	local rc_file="$1"
+	local path_line="$2"
 
-	local rc_file
-	while IFS= read -r rc_file; do
-		[[ -z "$rc_file" ]] && continue
+	# Create the rc file if it doesn't exist (ensure parent dir exists for fish etc.)
+	if [[ ! -f "$rc_file" ]]; then
+		mkdir -p "$(dirname "$rc_file")"
+		touch "$rc_file"
+	fi
 
-		# Create the rc file if it doesn't exist (ensure parent dir exists for fish etc.)
-		if [[ ! -f "$rc_file" ]]; then
-			mkdir -p "$(dirname "$rc_file")"
-			touch "$rc_file"
-		fi
+	# Check if already added (file created above if it didn't exist)
+	if grep -q '\.local/bin' "$rc_file"; then
+		echo "already:$rc_file"
+		return 0
+	fi
 
-		# Check if already added (file created above if it didn't exist)
-		if grep -q '\.local/bin' "$rc_file"; then
-			already_in="${already_in:+$already_in, }$rc_file"
-			continue
-		fi
+	# Add to shell config
+	{
+		echo ""
+		echo "# Added by aidevops setup"
+		echo "$path_line"
+	} >>"$rc_file"
+	echo "added:$rc_file"
+	return 0
+}
 
-		# Add to shell config
-		{
-			echo ""
-			echo "# Added by aidevops setup"
-			echo "$path_line"
-		} >>"$rc_file"
-		added_to="${added_to:+$added_to, }$rc_file"
-	done < <(get_all_shell_rcs)
+# Print result messages for add_local_bin_to_path.
+_local_bin_report_results() {
+	local added_to="$1"
+	local already_in="$2"
+	local path_line="$3"
 
 	if [[ -n "$added_to" ]]; then
 		print_success "Added $HOME/.local/bin to PATH in: $added_to"
@@ -523,6 +602,29 @@ add_local_bin_to_path() {
 		print_warning "Could not detect shell config file"
 		print_info "Add this to your shell config: $path_line"
 	fi
+
+	return 0
+}
+
+# Add ~/.local/bin to PATH in all shell rc files for the aidevops CLI
+add_local_bin_to_path() {
+	# shellcheck disable=SC2016 # path_line is written to rc files; must expand at shell startup, not now
+	local path_line='export PATH="$HOME/.local/bin:$PATH"'
+	local added_to=""
+	local already_in=""
+
+	local rc_file
+	while IFS= read -r rc_file; do
+		[[ -z "$rc_file" ]] && continue
+		local result
+		result=$(_local_bin_update_rc_file "$rc_file" "$path_line")
+		case "$result" in
+		added:*) added_to="${added_to:+$added_to, }${result#added:}" ;;
+		already:*) already_in="${already_in:+$already_in, }${result#already:}" ;;
+		esac
+	done < <(get_all_shell_rcs)
+
+	_local_bin_report_results "$added_to" "$already_in" "$path_line"
 
 	# Also export for current session
 	export PATH="$HOME/.local/bin:$PATH"
@@ -697,6 +799,81 @@ _shellcheck_wrapper_setup_zshenv() {
 	return 0
 }
 
+# Remove stale old-form PATH entries for the aidevops shim from an rc file.
+# Handles both bash/zsh case-guard form and fish 'contains' form.
+_shellcheck_wrapper_remove_stale_path() {
+	local rc_file="$1"
+	local is_fish_rc="$2"
+
+	# Remove stale old-form entries (case guard that only checked presence,
+	# not position — left the shim at the end of PATH on upgrades)
+	# shellcheck disable=SC2016 # Matching literal $PATH text in rc files, not expanding
+	if grep -q 'case ":$PATH:" in.*\.aidevops/bin' "$rc_file"; then
+		# shellcheck disable=SC2016
+		sed -i.bak '/case ":$PATH:" in.*\.aidevops\/bin/d' "$rc_file"
+		rm -f "${rc_file}.bak"
+	fi
+	# For fish: also remove old 'contains' form that only checked presence
+	if [[ "$is_fish_rc" == "true" ]] && grep -q 'contains.*\.aidevops/bin' "$rc_file"; then
+		sed -i.bak '/contains.*\.aidevops\/bin/d' "$rc_file"
+		rm -f "${rc_file}.bak"
+	fi
+
+	return 0
+}
+
+# Configure SHELLCHECK_PATH and PATH shim in a single rc file.
+# Prints "added:<file>" or "already:<file>" to stdout.
+_shellcheck_wrapper_setup_one_rc() {
+	local rc_file="$1"
+	local env_line="$2"
+	local path_line="$3"
+	local env_line_fish="$4"
+	local path_line_fish="$5"
+
+	if [[ ! -f "$rc_file" ]]; then
+		mkdir -p "$(dirname "$rc_file")"
+		touch "$rc_file"
+	fi
+
+	# Detect fish config — uses set -gx syntax, not export
+	local is_fish_rc=false
+	[[ "$rc_file" == *"/fish/config.fish" ]] && is_fish_rc=true
+
+	# Select the correct syntax for this shell
+	local rc_env_line="$env_line"
+	local rc_path_line="$path_line"
+	if [[ "$is_fish_rc" == "true" ]]; then
+		rc_env_line="$env_line_fish"
+		rc_path_line="$path_line_fish"
+	fi
+
+	# SHELLCHECK_PATH env var
+	if grep -q 'SHELLCHECK_PATH' "$rc_file"; then
+		echo "already:$rc_file"
+	else
+		{
+			echo ""
+			echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)"
+			echo "$rc_env_line"
+		} >>"$rc_file"
+		echo "added:$rc_file"
+	fi
+
+	# PATH prepend for ~/.aidevops/bin (GH#2993)
+	_shellcheck_wrapper_remove_stale_path "$rc_file" "$is_fish_rc"
+	# Check for the new sanitize-and-prepend form (uses _aidevops_shim variable)
+	if ! grep -Fq '_aidevops_shim' "$rc_file"; then
+		{
+			echo ""
+			echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)"
+			echo "$rc_path_line"
+		} >>"$rc_file"
+	fi
+
+	return 0
+}
+
 # Layer 3: Configure SHELLCHECK_PATH and PATH shim in interactive shell rc files.
 _shellcheck_wrapper_setup_rc_files() {
 	local env_line="$1"
@@ -709,63 +886,53 @@ _shellcheck_wrapper_setup_rc_files() {
 	local rc_file
 	while IFS= read -r rc_file; do
 		[[ -z "$rc_file" ]] && continue
-
-		if [[ ! -f "$rc_file" ]]; then
-			mkdir -p "$(dirname "$rc_file")"
-			touch "$rc_file"
-		fi
-
-		# Detect fish config — uses set -gx syntax, not export
-		local is_fish_rc=false
-		if [[ "$rc_file" == *"/fish/config.fish" ]]; then
-			is_fish_rc=true
-		fi
-
-		# Select the correct syntax for this shell
-		local rc_env_line="$env_line"
-		local rc_path_line="$path_line"
-		if [[ "$is_fish_rc" == "true" ]]; then
-			rc_env_line="$env_line_fish"
-			rc_path_line="$path_line_fish"
-		fi
-
-		# SHELLCHECK_PATH env var
-		if grep -q 'SHELLCHECK_PATH' "$rc_file"; then
-			already_in_out="${already_in_out:+$already_in_out, }$rc_file"
-		else
-			{
-				echo ""
-				echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)"
-				echo "$rc_env_line"
-			} >>"$rc_file"
-			added_to_out="${added_to_out:+$added_to_out, }$rc_file"
-		fi
-
-		# PATH prepend for ~/.aidevops/bin (GH#2993)
-		# Remove stale old-form entries (case guard that only checked presence,
-		# not position — left the shim at the end of PATH on upgrades)
-		# shellcheck disable=SC2016 # Matching literal $PATH text in rc files, not expanding
-		if grep -q 'case ":$PATH:" in.*\.aidevops/bin' "$rc_file"; then
-			# shellcheck disable=SC2016
-			sed -i.bak '/case ":$PATH:" in.*\.aidevops\/bin/d' "$rc_file"
-			rm -f "${rc_file}.bak"
-		fi
-		# For fish: also remove old 'contains' form that only checked presence
-		if [[ "$is_fish_rc" == "true" ]] && grep -q 'contains.*\.aidevops/bin' "$rc_file"; then
-			sed -i.bak '/contains.*\.aidevops\/bin/d' "$rc_file"
-			rm -f "${rc_file}.bak"
-		fi
-		# Check for the new sanitize-and-prepend form (uses _aidevops_shim variable)
-		if ! grep -Fq '_aidevops_shim' "$rc_file"; then
-			{
-				echo ""
-				echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)"
-				echo "$rc_path_line"
-			} >>"$rc_file"
-		fi
+		local result
+		result=$(_shellcheck_wrapper_setup_one_rc "$rc_file" "$env_line" "$path_line" "$env_line_fish" "$path_line_fish")
+		case "$result" in
+		added:*) added_to_out="${added_to_out:+$added_to_out, }${result#added:}" ;;
+		already:*) already_in_out="${already_in_out:+$already_in_out, }${result#already:}" ;;
+		esac
 	done < <(get_all_shell_rcs)
 
 	echo "$added_to_out|$already_in_out"
+	return 0
+}
+
+# Merge results from zshenv and rc-file layers and print status messages.
+_shellcheck_wrapper_report_results() {
+	local env_line="$1"
+	local zshenv_result="$2"
+	local rc_result="$3"
+
+	local zshenv_added zshenv_already
+	zshenv_added="${zshenv_result%% *}"
+	zshenv_already="${zshenv_result##* }"
+
+	local rc_added rc_already
+	rc_added="${rc_result%%|*}"
+	rc_already="${rc_result##*|}"
+
+	# Merge results from layers 2 and 3
+	local added_to=""
+	local already_in=""
+	[[ -n "$zshenv_added" && "$zshenv_added" != " " ]] && added_to="${zshenv_added}"
+	[[ -n "$rc_added" ]] && added_to="${added_to:+$added_to, }${rc_added}"
+	[[ -n "$zshenv_already" && "$zshenv_already" != " " ]] && already_in="${zshenv_already}"
+	[[ -n "$rc_already" ]] && already_in="${already_in:+$already_in, }${rc_already}"
+
+	if [[ -n "$added_to" ]]; then
+		print_success "Configured SHELLCHECK_PATH wrapper in: $added_to"
+	fi
+
+	if [[ -n "$already_in" ]]; then
+		print_info "SHELLCHECK_PATH already configured in: $already_in"
+	fi
+
+	if [[ -z "$added_to" && -z "$already_in" && "$PLATFORM_MACOS" != "true" ]]; then
+		print_warning "Could not configure SHELLCHECK_PATH automatically"
+		print_info "Add this to your shell config: $env_line"
+	fi
+
 	return 0
 }
 
@@ -794,55 +961,21 @@ setup_shellcheck_wrapper() {
 	# Layer 0: PATH shim (GH#2993)
 	_shellcheck_wrapper_setup_shim "$wrapper_path"
 
-	# Layer 1: launchctl setenv (macOS) — affects all GUI-launched processes
-	# Set both SHELLCHECK_PATH (for tools that honour it) and PATH (for tools
-	# that resolve shellcheck via PATH lookup, like bash-language-server).
-	# CRITICAL: Always prepend shim_dir even if it's already in PATH — it may
-	# be at the END (e.g., appended by a previous setup run), which means the
-	# real shellcheck at /opt/homebrew/bin is found first. We strip any existing
-	# occurrence and prepend to guarantee first position.
+	# Layer 1: launchctl setenv (macOS) — GUI-launched processes
 	if [[ "$PLATFORM_MACOS" == "true" ]]; then
 		_shellcheck_wrapper_setup_launchctl "$wrapper_path" "$shim_dir"
 	fi
 
-	# Layer 2: .zshenv — affects ALL zsh processes (interactive AND non-interactive)
-	# This is critical because opencode spawns bash-language-server as a
-	# non-interactive child process. .zshrc is NOT sourced for non-interactive
-	# shells, so SHELLCHECK_PATH set only in .zshrc is invisible to the LSP.
-	# GH#2993: Also prepend ~/.aidevops/bin to PATH here so the shim is found.
+	# Layer 2: .zshenv — ALL zsh processes (interactive AND non-interactive)
 	local zshenv_result
 	zshenv_result=$(_shellcheck_wrapper_setup_zshenv "$env_line" "$path_line" "$shim_dir")
-	local zshenv_added zshenv_already
-	zshenv_added="${zshenv_result%% *}"
-	zshenv_already="${zshenv_result##* }"
 
-	# Layer 3: Shell rc files — affects interactive terminal sessions
+	# Layer 3: Shell rc files — interactive terminal sessions
 	local rc_result
 	rc_result=$(_shellcheck_wrapper_setup_rc_files "$env_line" "$path_line" "$env_line_fish" "$path_line_fish")
-	local rc_added rc_already
-	rc_added="${rc_result%%|*}"
-	rc_already="${rc_result##*|}"
 
-	# Merge results from layers 2 and 3
-	local added_to=""
-	local already_in=""
-	[[ -n "$zshenv_added" && "$zshenv_added" != " " ]] && added_to="${zshenv_added}"
-	[[ -n "$rc_added" ]] && added_to="${added_to:+$added_to, }${rc_added}"
-	[[ -n "$zshenv_already" && "$zshenv_already" != " " ]] && already_in="${zshenv_already}"
-	[[ -n "$rc_already" ]] && already_in="${already_in:+$already_in, }${rc_already}"
-
-	if [[ -n "$added_to" ]]; then
-		print_success "Configured SHELLCHECK_PATH wrapper in: $added_to"
-	fi
-
-	if [[ -n "$already_in" ]]; then
-		print_info "SHELLCHECK_PATH already configured in: $already_in"
-	fi
-
-	if [[ -z "$added_to" && -z "$already_in" && "$PLATFORM_MACOS" != "true" ]]; then
-		print_warning "Could not configure SHELLCHECK_PATH automatically"
-		print_info "Add this to your shell config: $env_line"
-	fi
+	# Report merged results from layers 2 and 3
+	_shellcheck_wrapper_report_results "$env_line" "$zshenv_result" "$rc_result"
 
 	# Also export for current session
 	export SHELLCHECK_PATH="$wrapper_path"
@@ -871,6 +1004,76 @@ _aliases_check_configured() {
 	return 1
 }
 
+# Write alias blocks to fish or bash/zsh rc files.
+# Prints the list of files aliases were added to (comma-separated).
+_aliases_write_to_rc_files() {
+	local is_fish="$1"
+	local alias_block_bash="$2"
+	local alias_block_fish="$3"
+	local added_to=""
+
+	# Handle fish separately
+	if [[ "$is_fish" == "true" ]]; then
+		local fish_rc="$HOME/.config/fish/config.fish"
+		mkdir -p "$HOME/.config/fish"
+		echo "$alias_block_fish" >>"$fish_rc"
+		added_to="$fish_rc"
+	else
+		# Add to all bash/zsh rc files
+		local rc_file
+		while IFS= read -r rc_file; do
+			[[ -z "$rc_file" ]] && continue
+
+			# Create if it doesn't exist
+			if [[ ! -f "$rc_file" ]]; then
+				touch "$rc_file"
+			fi
+
+			# Skip if already has aliases (file created above if it didn't exist)
+			if grep -q "# AI Assistant Server Access" "$rc_file"; then
+				continue
+			fi
+
+			echo "$alias_block_bash" >>"$rc_file"
+			added_to="${added_to:+$added_to, }$rc_file"
+		done < <(get_all_shell_rcs)
+	fi
+
+	echo "$added_to"
+	return 0
+}
+
+# Build the bash/zsh and fish alias blocks for server access.
+# Prints two lines: "bash:<block>" and "fish:<block>" — callers split on newline.
+# Since blocks are multi-line, we use process substitution via temp files.
+# Outputs bash block to stdout, fish block to fd3 (caller must set up fd3).
+_aliases_build_blocks() {
+	cat <<'ALIASES'
+
+# AI Assistant Server Access Framework
+alias servers='./.agents/scripts/servers-helper.sh'
+alias servers-list='./.agents/scripts/servers-helper.sh list'
+alias hostinger='./.agents/scripts/hostinger-helper.sh'
+alias hetzner='./.agents/scripts/hetzner-helper.sh'
+alias aws-helper='./.agents/scripts/aws-helper.sh'
+ALIASES
+	return 0
+}
+
+# Build the fish-syntax alias block for server access.
+_aliases_build_fish_block() {
+	cat <<'ALIASES'
+
+# AI Assistant Server Access Framework
+alias servers './.agents/scripts/servers-helper.sh'
+alias servers-list './.agents/scripts/servers-helper.sh list'
+alias hostinger './.agents/scripts/hostinger-helper.sh'
+alias hetzner './.agents/scripts/hetzner-helper.sh'
+alias aws-helper './.agents/scripts/aws-helper.sh'
+ALIASES
+	return 0
+}
+
 # Add server access aliases to shell rc files (bash/zsh/fish)
 setup_aliases() {
 	print_info "Setting up shell aliases..."
@@ -880,35 +1083,13 @@ setup_aliases() {
 
 	# Fish shell uses different alias syntax
 	local is_fish=false
-	if [[ "$default_shell" == "fish" ]]; then
-		is_fish=true
-	fi
+	[[ "$default_shell" == "fish" ]] && is_fish=true
 
 	local alias_block_bash
-	alias_block_bash=$(
-		cat <<'ALIASES'
-
-# AI Assistant Server Access Framework
-alias servers='./.agents/scripts/servers-helper.sh'
-alias servers-list='./.agents/scripts/servers-helper.sh list'
-alias hostinger='./.agents/scripts/hostinger-helper.sh'
-alias hetzner='./.agents/scripts/hetzner-helper.sh'
-alias aws-helper='./.agents/scripts/aws-helper.sh'
-ALIASES
-	)
+	alias_block_bash=$(_aliases_build_blocks)
 
 	local alias_block_fish
-	alias_block_fish=$(
-		cat <<'ALIASES'
-
-# AI Assistant Server Access Framework
-alias servers './.agents/scripts/servers-helper.sh'
-alias servers-list './.agents/scripts/servers-helper.sh list'
-alias hostinger './.agents/scripts/hostinger-helper.sh'
-alias hetzner './.agents/scripts/hetzner-helper.sh'
-alias aws-helper './.agents/scripts/aws-helper.sh'
-ALIASES
-	)
+	alias_block_fish=$(_aliases_build_fish_block)
 
 	if _aliases_check_configured; then
 		print_info "Server Access aliases already configured - Skipping"
@@ -919,34 +1100,8 @@ ALIASES
 	read -r -p "Add shell aliases? [Y/n]: " add_aliases
 
 	if [[ "$add_aliases" =~ ^[Yy]?$ ]]; then
-		local added_to=""
-
-		# Handle fish separately
-		if [[ "$is_fish" == "true" ]]; then
-			local fish_rc="$HOME/.config/fish/config.fish"
-			mkdir -p "$HOME/.config/fish"
-			echo "$alias_block_fish" >>"$fish_rc"
-			added_to="$fish_rc"
-		else
-			# Add to all bash/zsh rc files
-			local rc_file
-			while IFS= read -r rc_file; do
-				[[ -z "$rc_file" ]] && continue
-
-				# Create if it doesn't exist
-				if [[ ! -f "$rc_file" ]]; then
-					touch "$rc_file"
-				fi
-
-				# Skip if already has aliases (file created above if it didn't exist)
-				if grep -q "# AI Assistant Server Access" "$rc_file"; then
-					continue
-				fi
-
-				echo "$alias_block_bash" >>"$rc_file"
-				added_to="${added_to:+$added_to, }$rc_file"
-			done < <(get_all_shell_rcs)
-		fi
+		local added_to
+		added_to=$(_aliases_write_to_rc_files "$is_fish" "$alias_block_bash" "$alias_block_fish")
 
 		if [[ -n "$added_to" ]]; then
 			print_success "Aliases added to: $added_to"
@@ -958,45 +1113,27 @@ ALIASES
 	return 0
 }
 
-# Install terminal title integration that syncs tab titles with git repo/branch
-setup_terminal_title() {
-	# Check prerequisites before announcing setup (GH#5240)
-	local setup_script=".agents/scripts/terminal-title-setup.sh"
-
-	if [[ ! -f "$setup_script" ]]; then
-		print_skip "Terminal title" "setup script not found" "Deploy agents first (setup.sh), then re-run"
-		setup_track_skipped "Terminal title" "setup script not found"
-		return 0
-	fi
-
-	# Check if already installed (check all rc files)
-	local title_configured=false
+# Check if terminal title integration is already configured in any rc file.
+# Returns 0 if configured, 1 if not.
+_terminal_title_is_configured() {
 	local rc_file
 	while IFS= read -r rc_file; do
 		[[ -z "$rc_file" ]] && continue
 		if [[ -f "$rc_file" ]] && grep -q "aidevops terminal-title" "$rc_file"; then
-			title_configured=true
-			break
+			return 0
 		fi
 	done < <(get_all_shell_rcs)
+	return 1
+}
 
-	if [[ "$title_configured" == "true" ]]; then
-		print_success "Terminal title integration already configured"
-		setup_track_configured "Terminal title"
-		return 0
-	fi
-
-	# Prerequisites met — proceed with setup
-	print_info "Setting up terminal title integration..."
-
-	# Show current status before asking
+# Print current shell and Tabby status for terminal title setup.
+_terminal_title_show_status() {
 	echo ""
 	print_info "Terminal title integration syncs your terminal tab with git repo/branch"
 	print_info "Example: Tab shows 'aidevops/feature/xyz' when in that branch"
 	echo ""
 	echo "Current status:"
 
-	# Shell info
 	local shell_name
 	shell_name=$(detect_default_shell)
 	local shell_info="$shell_name"
@@ -1005,7 +1142,6 @@ setup_terminal_title() {
 	fi
 	echo "  Shell: $shell_info"
 
-	# Tabby info
 	local tabby_config="$HOME/Library/Application Support/tabby/config.yaml"
 	if [[ -f "$tabby_config" ]]; then
 		local disabled_count
@@ -1017,6 +1153,13 @@ setup_terminal_title() {
 			echo "  Tabby: detected, dynamic titles enabled"
 		fi
 	fi
+
+	return 0
+}
+
+# Prompt the user and run the terminal title installer.
+_terminal_title_prompt_and_install() {
+	local setup_script="$1"
 
 	echo ""
 	read -r -p "Install terminal title integration? [Y/n]: " install_title
@@ -1031,6 +1174,31 @@ setup_terminal_title() {
 		print_info "Skipped terminal title setup by user request"
 		print_info "You can install later with: ~/.aidevops/agents/scripts/terminal-title-setup.sh install"
 	fi
+
+	return 0
+}
+
+# Install terminal title integration that syncs tab titles with git repo/branch
+setup_terminal_title() {
+	# Check prerequisites before announcing setup (GH#5240)
+	local setup_script=".agents/scripts/terminal-title-setup.sh"
+
+	if [[ ! -f "$setup_script" ]]; then
+		print_skip "Terminal title" "setup script not found" "Deploy agents first (setup.sh), then re-run"
+		setup_track_skipped "Terminal title" "setup script not found"
+		return 0
+	fi
+
+	if _terminal_title_is_configured; then
+		print_success "Terminal title integration already configured"
+		setup_track_configured "Terminal title"
+		return 0
+	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Setting up terminal title integration..."
+	_terminal_title_show_status
+	_terminal_title_prompt_and_install "$setup_script"
 
 	return 0
 }


### PR DESCRIPTION
## Summary

- Extracted sub-functions from all functions that exceeded 50 lines in `setup-modules/shell-env.sh`
- All 40 functions now have bodies ≤50 lines (max: 50 lines for `_shellcheck_wrapper_setup_zshenv`)
- ShellCheck passes with zero violations
- All existing functionality is fully preserved

## Extracted functions

| New function | Extracted from |
|---|---|
| `_omz_offer_shell_change` | `setup_oh_my_zsh` |
| `_omz_run_install` | `setup_oh_my_zsh` |
| `_shell_compat_write_profile_header` | `_shell_compat_extract_to_shared_profile` |
| `_shell_compat_extract_one_file` | `_shell_compat_extract_to_shared_profile` |
| `_shell_compat_prompt_user` | `setup_shell_compatibility` |
| `_shell_compat_do_extract` | `setup_shell_compatibility` |
| `_local_bin_update_rc_file` | `add_local_bin_to_path` |
| `_local_bin_report_results` | `add_local_bin_to_path` |
| `_shellcheck_wrapper_remove_stale_path` | `_shellcheck_wrapper_setup_rc_files` |
| `_shellcheck_wrapper_setup_one_rc` | `_shellcheck_wrapper_setup_rc_files` |
| `_terminal_title_is_configured` | `setup_terminal_title` |
| `_terminal_title_show_status` | `setup_terminal_title` |
| `_terminal_title_prompt_and_install` | `setup_terminal_title` |
| `_aliases_build_blocks` | `setup_aliases` |
| `_aliases_build_fish_block` | `setup_aliases` |

## Verification

```
shellcheck setup-modules/shell-env.sh  # exits 0
# All 40 functions: max body size = 50 lines
```

Closes #5717