### PR TITLE
GH#6413: Fix sandbox-exec-helper.sh timeout enforcement with secondary watchdog

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1353,14 +1353,28 @@ list_active_worker_processes() {
 	#      (sandbox-disabled path and test fixtures)
 	# Exclude: lines starting with "node " (node child) or whose command
 	# starts with a path ending in "/.opencode " (binary grandchild).
-	ps axo pid,etime,command | awk '
+	#
+	# GH#6413: Process state filtering — exclude zombie (Z) and stopped (T)
+	# processes. These are dead/stuck processes that hold no useful work but
+	# appear as "active" in worker counts, inflating struggle ratios and
+	# preventing the pulse from dispatching replacements. The stat column is
+	# used for filtering only; output format remains pid,etime,command for
+	# backward compatibility with all consumers.
+	ps axo pid,stat,etime,command | awk '
 		/\/full-loop/ &&
 		$0 !~ /(^|[[:space:]])\/pulse([[:space:]]|$)/ &&
 		$0 !~ /Supervisor Pulse/ &&
 		$0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ &&
 		$0 !~ /[[:space:]]node[[:space:]].*\/opencode/ &&
 		$0 !~ /\/bin\/\.opencode[[:space:]]/ {
-			print
+			# $2 is the stat column (e.g., S, SN, Ss, Z, Zs, T, TN)
+			stat = $2
+			# Exclude zombies (Z*) and stopped processes (T*)
+			if (stat ~ /^[ZT]/) next
+			# Print pid, etime, command (skip stat to preserve output format)
+			printf "%s %s", $1, $3
+			for (i = 4; i <= NF; i++) printf " %s", $i
+			printf "\n"
 		}
 	'
 	return 0

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -434,6 +434,7 @@ _sandbox_exec_with_pgkill() {
 	shift 3
 	local child_pid=""
 	local child_pgid=""
+	local child_start_token=""
 	local t_exit_code=0
 	local watchdog_pid=""
 
@@ -495,6 +496,13 @@ _sandbox_exec_with_pgkill() {
 		child_pgid=""
 	fi
 
+	# PID recycling safety: capture a stable identity token at spawn time.
+	# On macOS, use 'ps -o lstart=' which returns the absolute start timestamp
+	# of the process. This is stable for the lifetime of the process and changes
+	# when the PID is recycled. If ps fails (child already exited), token is
+	# empty — the watchdog will skip signal delivery (safe: child already gone).
+	child_start_token="$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ')" || true
+
 	# Secondary watchdog (GH#6413): independent wall-clock timeout enforcement.
 	# Spawned as a background subshell that sleeps for the timeout duration,
 	# then checks if the child is still alive and kills it. This catches cases
@@ -502,7 +510,8 @@ _sandbox_exec_with_pgkill() {
 	# The watchdog uses date(1) for wall-clock verification rather than relying
 	# solely on sleep duration, which can drift under system load.
 	# 10% grace period avoids racing with the primary loop's normal timeout.
-	_sandbox_spawn_watchdog "$t_secs" "$child_pid" "$child_pgid" &
+	# child_start_token is passed for PID recycling safety (see _sandbox_spawn_watchdog).
+	_sandbox_spawn_watchdog "$t_secs" "$child_pid" "$child_pgid" "$child_start_token" &
 	watchdog_pid=$!
 
 	# Poll until the child exits or the deadline is reached.
@@ -522,6 +531,18 @@ _sandbox_exec_with_pgkill() {
 
 	wait "$child_pid" 2>/dev/null
 	t_exit_code=$?
+
+	# Watchdog exit status override: if the secondary watchdog killed the child,
+	# it will have left a marker file at /tmp/.sandbox_timeout_${child_pid}.
+	# Override the exit code to 124 (standard timeout) so callers can distinguish
+	# a watchdog-killed process from a normal non-zero exit.
+	local wd_marker="/tmp/.sandbox_timeout_${child_pid}"
+	if [[ -f "$wd_marker" ]]; then
+		log_sandbox "WARN" "Secondary watchdog marker detected for PID ${child_pid} — overriding exit code to 124"
+		t_exit_code=124
+		rm -f "$wd_marker" 2>/dev/null || true
+	fi
+
 	# Explicitly clean up any remaining descendants in the process group.
 	# The EXIT trap is cleared below, so cleanup must be called explicitly
 	# here — the trap does not fire on a normal function return.
@@ -537,14 +558,27 @@ _sandbox_exec_with_pgkill() {
 # polling loop in _sandbox_exec_with_pgkill fails (parent crash, OOM, sleep
 # drift), this watchdog independently enforces the timeout.
 #
+# Exit status override: before sending TERM/KILL, the watchdog touches a marker
+# file at /tmp/.sandbox_timeout_${child_pid}. The parent checks for this marker
+# after 'wait "$child_pid"' returns and overrides the exit code to 124 (standard
+# timeout exit code) so callers can distinguish watchdog-killed from normal exit.
+#
+# PID recycling safety: $4 (child_start_token) is the output of
+# 'ps -o lstart= -p $child_pid' captured at spawn time. Before sending any
+# signal, the watchdog re-reads the process start time and compares it to the
+# stored token. If they differ, the PID has been recycled — the watchdog logs
+# and exits cleanly without sending signals.
+#
 # Arguments:
 #   $1 - timeout_secs (original timeout)
 #   $2 - child_pid (PID to monitor)
 #   $3 - child_pgid (process group ID, may be empty)
+#   $4 - child_start_token (ps -o lstart= output captured at spawn time, may be empty)
 _sandbox_spawn_watchdog() {
 	local wd_timeout="$1"
 	local wd_pid="$2"
 	local wd_pgid="$3"
+	local wd_start_token="$4"
 	local wd_start
 	wd_start="$(date +%s)"
 
@@ -586,9 +620,35 @@ _sandbox_spawn_watchdog() {
 		return 0
 	fi
 
-	# Child is still alive past the deadline — kill it
+	# Child is still alive past the deadline — verify PID identity before killing.
 	if kill -0 "$wd_pid" 2>/dev/null; then
+		# PID recycling safety: re-read the process start time and compare to
+		# the token captured at spawn. If the PID has been recycled (new process
+		# with the same PID), the start times will differ — skip signal delivery.
+		if [[ -n "$wd_start_token" ]]; then
+			local wd_current_token
+			wd_current_token="$(ps -o lstart= -p "$wd_pid" 2>/dev/null | tr -s ' ')" || true
+			if [[ -z "$wd_current_token" ]]; then
+				# ps returned nothing — process already exited between kill -0 and now
+				return 0
+			fi
+			if [[ "$wd_current_token" != "$wd_start_token" ]]; then
+				log_sandbox "WARN" "Secondary watchdog: PID ${wd_pid} start time changed (token mismatch) — PID recycled, skipping kill"
+				return 0
+			fi
+		fi
+
 		log_sandbox "WARN" "Secondary watchdog: child PID ${wd_pid} still alive after ${wd_elapsed}s (timeout=${wd_timeout}s) — killing"
+
+		# Touch marker file before sending signals so the parent can detect
+		# that this watchdog (not a normal exit) caused the child's termination.
+		# The parent checks for this file after 'wait "$child_pid"' and overrides
+		# the exit code to 124. Use a temp-then-move pattern to make the create
+		# atomic — avoids a partial file being read by the parent.
+		local wd_marker="/tmp/.sandbox_timeout_${wd_pid}"
+		local wd_marker_tmp="${wd_marker}.tmp$$"
+		printf '%s\n' "$wd_elapsed" >"$wd_marker_tmp" 2>/dev/null &&
+			mv -f "$wd_marker_tmp" "$wd_marker" 2>/dev/null || true
 
 		if [[ -n "$wd_pgid" ]]; then
 			kill -- "-${wd_pgid}" 2>/dev/null || true

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -419,6 +419,14 @@ _sandbox_check_dns_exfil() {
 # command in a new process group via `setsid`, then kill the entire group
 # (kill -- -PGID) on timeout or exit. _pgkill_cleanup is called explicitly
 # on all exit paths — the EXIT trap is a safety net for unexpected exits only.
+#
+# Secondary watchdog (GH#6413):
+# The primary polling loop uses sleep 0.5 + counter decrement. If the parent
+# process crashes, gets OOM-killed, or the sleep drifts, the child (in its
+# own session via setsid) survives indefinitely. Fix: spawn a background
+# watchdog process that independently tracks wall-clock time via date(1) and
+# kills the child process group if the deadline is exceeded. The watchdog is
+# killed on normal exit to avoid orphaned watchers.
 _sandbox_exec_with_pgkill() {
 	local t_secs="$1"
 	local t_stdout_file="$2"
@@ -427,11 +435,20 @@ _sandbox_exec_with_pgkill() {
 	local child_pid=""
 	local child_pgid=""
 	local t_exit_code=0
+	local watchdog_pid=""
 
 	# Kill the child process group on any exit from this function.
 	# Uses kill -- -PGID to send SIGTERM to every process in the group,
 	# followed by SIGKILL after a short grace period.
+	# Also kills the secondary watchdog if still running.
 	_pgkill_cleanup() {
+		# Kill the secondary watchdog first to prevent it from firing
+		# after we've already cleaned up the child.
+		if [[ -n "$watchdog_pid" ]]; then
+			kill "$watchdog_pid" 2>/dev/null || true
+			wait "$watchdog_pid" 2>/dev/null || true
+			watchdog_pid=""
+		fi
 		if [[ -n "$child_pgid" ]]; then
 			# SIGTERM first — allow graceful shutdown
 			kill -- "-${child_pgid}" 2>/dev/null || true
@@ -478,6 +495,16 @@ _sandbox_exec_with_pgkill() {
 		child_pgid=""
 	fi
 
+	# Secondary watchdog (GH#6413): independent wall-clock timeout enforcement.
+	# Spawned as a background subshell that sleeps for the timeout duration,
+	# then checks if the child is still alive and kills it. This catches cases
+	# where the primary polling loop fails (parent crash, sleep drift, etc.).
+	# The watchdog uses date(1) for wall-clock verification rather than relying
+	# solely on sleep duration, which can drift under system load.
+	# 10% grace period avoids racing with the primary loop's normal timeout.
+	_sandbox_spawn_watchdog "$t_secs" "$child_pid" "$child_pgid" &
+	watchdog_pid=$!
+
 	# Poll until the child exits or the deadline is reached.
 	local half_secs_remaining=$((t_secs * 2))
 	while kill -0 "$child_pid" 2>/dev/null; do
@@ -501,6 +528,82 @@ _sandbox_exec_with_pgkill() {
 	_pgkill_cleanup
 	trap - EXIT
 	return "$t_exit_code"
+}
+
+# Secondary watchdog for _sandbox_exec_with_pgkill (GH#6413).
+# Runs as a background process. Sleeps for timeout + 10% grace, then verifies
+# wall-clock elapsed time via date(1) and kills the child process group if
+# the deadline has been exceeded. This is defense-in-depth: if the primary
+# polling loop in _sandbox_exec_with_pgkill fails (parent crash, OOM, sleep
+# drift), this watchdog independently enforces the timeout.
+#
+# Arguments:
+#   $1 - timeout_secs (original timeout)
+#   $2 - child_pid (PID to monitor)
+#   $3 - child_pgid (process group ID, may be empty)
+_sandbox_spawn_watchdog() {
+	local wd_timeout="$1"
+	local wd_pid="$2"
+	local wd_pgid="$3"
+	local wd_start
+	wd_start="$(date +%s)"
+
+	# Grace period: 10% of timeout, minimum 5s, maximum 60s.
+	# This avoids racing with the primary loop which fires at exactly t_secs.
+	local wd_grace=$((wd_timeout / 10))
+	if ((wd_grace < 5)); then
+		wd_grace=5
+	fi
+	if ((wd_grace > 60)); then
+		wd_grace=60
+	fi
+	local wd_deadline=$((wd_timeout + wd_grace))
+
+	# Sleep in chunks (30s) so we can exit promptly if the child finishes
+	# and our parent kills us. A single long sleep would delay cleanup.
+	local wd_slept=0
+	while ((wd_slept < wd_deadline)); do
+		local wd_chunk=30
+		if ((wd_slept + wd_chunk > wd_deadline)); then
+			wd_chunk=$((wd_deadline - wd_slept))
+		fi
+		sleep "$wd_chunk" 2>/dev/null || return 0
+		wd_slept=$((wd_slept + wd_chunk))
+
+		# Check if child is still alive — if not, our job is done
+		if ! kill -0 "$wd_pid" 2>/dev/null; then
+			return 0
+		fi
+	done
+
+	# Verify wall-clock elapsed time to guard against sleep drift
+	local wd_now
+	wd_now="$(date +%s)"
+	local wd_elapsed=$((wd_now - wd_start))
+
+	if ((wd_elapsed < wd_timeout)); then
+		# Sleep returned early (spurious wakeup) — not actually timed out
+		return 0
+	fi
+
+	# Child is still alive past the deadline — kill it
+	if kill -0 "$wd_pid" 2>/dev/null; then
+		log_sandbox "WARN" "Secondary watchdog: child PID ${wd_pid} still alive after ${wd_elapsed}s (timeout=${wd_timeout}s) — killing"
+
+		if [[ -n "$wd_pgid" ]]; then
+			kill -- "-${wd_pgid}" 2>/dev/null || true
+			sleep 1
+			kill -0 -- "-${wd_pgid}" 2>/dev/null &&
+				kill -9 -- "-${wd_pgid}" 2>/dev/null || true
+		else
+			kill "$wd_pid" 2>/dev/null || true
+			sleep 1
+			kill -0 "$wd_pid" 2>/dev/null &&
+				kill -9 "$wd_pid" 2>/dev/null || true
+		fi
+	fi
+
+	return 0
 }
 
 # Build the env -i argument list for sandboxed execution.

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -497,11 +497,17 @@ _sandbox_exec_with_pgkill() {
 	fi
 
 	# PID recycling safety: capture a stable identity token at spawn time.
-	# On macOS, use 'ps -o lstart=' which returns the absolute start timestamp
-	# of the process. This is stable for the lifetime of the process and changes
-	# when the PID is recycled. If ps fails (child already exited), token is
-	# empty — the watchdog will skip signal delivery (safe: child already gone).
-	child_start_token="$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ')" || true
+	# On Linux, use /proc/<pid>/stat field 22 (starttime in clock ticks since
+	# boot) — more reliable than ps and avoids fork overhead. On macOS/other,
+	# use 'ps -o lstart=' which returns the absolute start timestamp.
+	# If the lookup fails (child already exited), token is empty — the watchdog
+	# will skip signal delivery (safe: child already gone).
+	child_start_token="$(_sandbox_get_proc_starttime "$child_pid")"
+
+	# Marker file for watchdog-initiated kills (GH#6414, CodeRabbit review).
+	# Derived from t_stderr_file path to avoid collisions across concurrent
+	# sandbox invocations (unlike a global /tmp/ path with PID suffix).
+	local t_watchdog_marker="${t_stderr_file}.watchdog_timeout"
 
 	# Secondary watchdog (GH#6413): independent wall-clock timeout enforcement.
 	# Spawned as a background subshell that sleeps for the timeout duration,
@@ -511,7 +517,7 @@ _sandbox_exec_with_pgkill() {
 	# solely on sleep duration, which can drift under system load.
 	# 10% grace period avoids racing with the primary loop's normal timeout.
 	# child_start_token is passed for PID recycling safety (see _sandbox_spawn_watchdog).
-	_sandbox_spawn_watchdog "$t_secs" "$child_pid" "$child_pgid" "$child_start_token" &
+	_sandbox_spawn_watchdog "$t_secs" "$child_pid" "$child_pgid" "$child_start_token" "$t_watchdog_marker" &
 	watchdog_pid=$!
 
 	# Poll until the child exits or the deadline is reached.
@@ -532,15 +538,15 @@ _sandbox_exec_with_pgkill() {
 	wait "$child_pid" 2>/dev/null
 	t_exit_code=$?
 
-	# Watchdog exit status override: if the secondary watchdog killed the child,
-	# it will have left a marker file at /tmp/.sandbox_timeout_${child_pid}.
-	# Override the exit code to 124 (standard timeout) so callers can distinguish
-	# a watchdog-killed process from a normal non-zero exit.
-	local wd_marker="/tmp/.sandbox_timeout_${child_pid}"
-	if [[ -f "$wd_marker" ]]; then
+	# Watchdog exit status override (GH#6414, CodeRabbit review): if the
+	# secondary watchdog killed the child, it will have touched the marker
+	# file derived from t_stderr_file. Override the exit code to 124
+	# (standard timeout) so callers can distinguish a watchdog-killed
+	# process from a normal non-zero exit.
+	if [[ -f "$t_watchdog_marker" ]]; then
 		log_sandbox "WARN" "Secondary watchdog marker detected for PID ${child_pid} — overriding exit code to 124"
 		t_exit_code=124
-		rm -f "$wd_marker" 2>/dev/null || true
+		rm -f "$t_watchdog_marker" 2>/dev/null || true
 	fi
 
 	# Explicitly clean up any remaining descendants in the process group.
@@ -551,6 +557,46 @@ _sandbox_exec_with_pgkill() {
 	return "$t_exit_code"
 }
 
+# Get the start time of a process for PID recycling detection (GH#6414).
+# On Linux, reads /proc/<pid>/stat field 22 (starttime in clock ticks since
+# boot) — this is the most reliable identity token: monotonic, kernel-sourced,
+# and avoids forking ps. On macOS/other, uses ps -o lstart= which returns the
+# process start date/time string. Returns empty string if the process doesn't
+# exist or the start time can't be determined (non-fatal — the watchdog
+# proceeds without the recycling guard in that case).
+# Arguments: $1 - PID
+_sandbox_get_proc_starttime() {
+	local gps_pid="$1"
+	local gps_starttime=""
+
+	if [[ -f "/proc/${gps_pid}/stat" ]]; then
+		# Linux: field 22 of /proc/<pid>/stat is starttime (clock ticks since boot).
+		# Fields are space-separated but field 2 (comm) can contain spaces and
+		# parentheses, so we strip it first: remove everything from the first
+		# '(' to the last ')' to get clean space-separated fields, then pick
+		# field 20 (which is original field 22 after removing the 2-field comm).
+		local gps_stat_content=""
+		gps_stat_content="$(cat "/proc/${gps_pid}/stat" 2>/dev/null)" || true
+		if [[ -n "$gps_stat_content" ]]; then
+			# Remove comm field: everything from first '(' to last ')'
+			local gps_after_comm=""
+			gps_after_comm="${gps_stat_content##*) }"
+			# Field 20 in the remaining string = original field 22 (starttime)
+			gps_starttime="$(printf '%s' "$gps_after_comm" | awk '{print $20}')" || true
+		fi
+	else
+		# macOS / other: use ps -o lstart= for process start time string.
+		# Example output: "Wed Mar 25 14:30:00 2026"
+		gps_starttime="$(ps -o lstart= -p "$gps_pid" 2>/dev/null | tr -s ' ')" || true
+		# Trim leading/trailing whitespace
+		gps_starttime="${gps_starttime#"${gps_starttime%%[![:space:]]*}"}"
+		gps_starttime="${gps_starttime%"${gps_starttime##*[![:space:]]}"}"
+	fi
+
+	printf '%s' "$gps_starttime"
+	return 0
+}
+
 # Secondary watchdog for _sandbox_exec_with_pgkill (GH#6413).
 # Runs as a background process. Sleeps for timeout + 10% grace, then verifies
 # wall-clock elapsed time via date(1) and kills the child process group if
@@ -558,27 +604,31 @@ _sandbox_exec_with_pgkill() {
 # polling loop in _sandbox_exec_with_pgkill fails (parent crash, OOM, sleep
 # drift), this watchdog independently enforces the timeout.
 #
-# Exit status override: before sending TERM/KILL, the watchdog touches a marker
-# file at /tmp/.sandbox_timeout_${child_pid}. The parent checks for this marker
-# after 'wait "$child_pid"' returns and overrides the exit code to 124 (standard
-# timeout exit code) so callers can distinguish watchdog-killed from normal exit.
+# Exit status override (GH#6414): before sending TERM/KILL, the watchdog
+# touches the marker file passed as $5. The parent checks for this marker
+# after 'wait "$child_pid"' returns and overrides the exit code to 124
+# (standard timeout exit code) so callers can distinguish watchdog-killed
+# from normal exit. The marker path is derived from t_stderr_file to avoid
+# collisions across concurrent sandbox invocations.
 #
-# PID recycling safety: $4 (child_start_token) is the output of
-# 'ps -o lstart= -p $child_pid' captured at spawn time. Before sending any
-# signal, the watchdog re-reads the process start time and compares it to the
-# stored token. If they differ, the PID has been recycled — the watchdog logs
-# and exits cleanly without sending signals.
+# PID recycling safety (GH#6414): $4 (child_start_token) is the process
+# start time captured at spawn via _sandbox_get_proc_starttime (Linux:
+# /proc/<pid>/stat field 22, macOS: ps -o lstart=). Before sending any
+# signal, the watchdog re-reads the start time and compares. If they differ,
+# the PID has been recycled — the watchdog logs and exits without signalling.
 #
 # Arguments:
 #   $1 - timeout_secs (original timeout)
 #   $2 - child_pid (PID to monitor)
 #   $3 - child_pgid (process group ID, may be empty)
-#   $4 - child_start_token (ps -o lstart= output captured at spawn time, may be empty)
+#   $4 - child_start_token (process start time captured at spawn, may be empty)
+#   $5 - marker_file (touched before kill to signal timeout to parent)
 _sandbox_spawn_watchdog() {
 	local wd_timeout="$1"
 	local wd_pid="$2"
 	local wd_pgid="$3"
 	local wd_start_token="$4"
+	local wd_marker="$5"
 	local wd_start
 	wd_start="$(date +%s)"
 
@@ -622,14 +672,14 @@ _sandbox_spawn_watchdog() {
 
 	# Child is still alive past the deadline — verify PID identity before killing.
 	if kill -0 "$wd_pid" 2>/dev/null; then
-		# PID recycling safety: re-read the process start time and compare to
-		# the token captured at spawn. If the PID has been recycled (new process
-		# with the same PID), the start times will differ — skip signal delivery.
+		# PID recycling safety: re-read the process start time via the same
+		# platform-aware helper used at spawn. If the PID has been recycled
+		# (new process with the same PID), the start times will differ.
 		if [[ -n "$wd_start_token" ]]; then
-			local wd_current_token
-			wd_current_token="$(ps -o lstart= -p "$wd_pid" 2>/dev/null | tr -s ' ')" || true
+			local wd_current_token=""
+			wd_current_token="$(_sandbox_get_proc_starttime "$wd_pid")"
 			if [[ -z "$wd_current_token" ]]; then
-				# ps returned nothing — process already exited between kill -0 and now
+				# Lookup returned nothing — process already exited between kill -0 and now
 				return 0
 			fi
 			if [[ "$wd_current_token" != "$wd_start_token" ]]; then
@@ -643,12 +693,8 @@ _sandbox_spawn_watchdog() {
 		# Touch marker file before sending signals so the parent can detect
 		# that this watchdog (not a normal exit) caused the child's termination.
 		# The parent checks for this file after 'wait "$child_pid"' and overrides
-		# the exit code to 124. Use a temp-then-move pattern to make the create
-		# atomic — avoids a partial file being read by the parent.
-		local wd_marker="/tmp/.sandbox_timeout_${wd_pid}"
-		local wd_marker_tmp="${wd_marker}.tmp$$"
-		printf '%s\n' "$wd_elapsed" >"$wd_marker_tmp" 2>/dev/null &&
-			mv -f "$wd_marker_tmp" "$wd_marker" 2>/dev/null || true
+		# the exit code to 124.
+		touch "$wd_marker" 2>/dev/null || true
 
 		if [[ -n "$wd_pgid" ]]; then
 			kill -- "-${wd_pgid}" 2>/dev/null || true

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -69,6 +69,11 @@ set_ps_fixture() {
 }
 
 ps() {
+	if [[ "${1:-}" == "axo" && "${2:-}" == "pid,stat,etime,command" ]]; then
+		cat "$PS_FIXTURE_FILE"
+		return 0
+	fi
+	# Backward compat: also intercept old format for any tests not yet updated
 	if [[ "${1:-}" == "axo" && "${2:-}" == "pid,etime,command" ]]; then
 		cat "$PS_FIXTURE_FILE"
 		return 0
@@ -113,10 +118,10 @@ EOF
 test_counts_plain_and_dot_prefixed_opencode_workers() {
 	# Line 125: supervisor /pulse — excluded by standalone /pulse filter
 	# Line 126: worker whose session-key contains /pulse-related (not standalone) — must be counted
-	set_ps_fixture "123 00:10 opencode run --dir /tmp/aidevops --title Issue #4342 \"/full-loop Implement issue #4342\"
-124 00:11 /Users/test/.opencode/bin/opencode run --dir /tmp/aidevops --title Issue #4343 \"/full-loop Implement issue #4343\"
-125 00:20 opencode run --dir /tmp/aidevops --title Supervisor Pulse \"/pulse\"
-126 00:05 opencode run --dir /tmp/aidevops --session-key issue-4344 --title Issue #4344 \"/full-loop Implement issue #4344 -- fix /pulse-related bug\""
+	set_ps_fixture "123 S 00:10 opencode run --dir /tmp/aidevops --title Issue #4342 \"/full-loop Implement issue #4342\"
+124 S 00:11 /Users/test/.opencode/bin/opencode run --dir /tmp/aidevops --title Issue #4343 \"/full-loop Implement issue #4343\"
+125 S 00:20 opencode run --dir /tmp/aidevops --title Supervisor Pulse \"/pulse\"
+126 S 00:05 opencode run --dir /tmp/aidevops --session-key issue-4344 --title Issue #4344 \"/full-loop Implement issue #4344 -- fix /pulse-related bug\""
 
 	local count
 	count=$(count_active_workers)
@@ -136,9 +141,9 @@ test_deduplicates_process_chain_to_one_logical_worker() {
 	#   node /opt/homebrew/bin/opencode run ...                  (node child)
 	#   /path/to/.opencode run ...                               (binary grandchild)
 	# All three contain /full-loop and opencode — only the launcher must be counted.
-	set_ps_fixture "200 00:30 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072
-201 00:30 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072
-202 00:30 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072"
+	set_ps_fixture "200 S 00:30 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072
+201 S 00:30 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072
+202 S 00:30 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072"
 
 	local count
 	count=$(count_active_workers)
@@ -155,12 +160,12 @@ test_deduplicates_process_chain_to_one_logical_worker() {
 test_deduplicates_multiple_workers_with_process_chains() {
 	# t5072: Two logical workers, each spawning a 3-process chain = 6 OS processes.
 	# count_active_workers must return 2, not 6.
-	set_ps_fixture "300 01:00 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
-301 01:00 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
-302 01:00 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
-310 00:20 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002
-311 00:20 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002
-312 00:20 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002"
+	set_ps_fixture "300 S 01:00 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
+301 S 01:00 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
+302 S 01:00 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
+310 S 00:20 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002
+311 S 00:20 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002
+312 S 00:20 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002"
 
 	local count
 	count=$(count_active_workers)
@@ -174,10 +179,10 @@ test_deduplicates_multiple_workers_with_process_chains() {
 }
 
 test_repo_issue_detection_uses_filtered_worker_list() {
-	set_ps_fixture "211 00:31 opencode run --dir /tmp/aidevops --session-key issue-4342 --title Issue #4342: fix \"/full-loop Implement issue #4342\"
-212 00:31 opencode run --dir /tmp/other --session-key issue-4342 --title Issue #4342: other \"/full-loop Implement issue #4342\"
-213 00:05 opencode run --dir /tmp/aidevops --title Supervisor Pulse \"/pulse\"
-214 00:12 opencode run --dir /tmp/aidevops-tools --session-key issue-4342 --title Issue #4342: tools \"/full-loop Implement issue #4342\""
+	set_ps_fixture "211 S 00:31 opencode run --dir /tmp/aidevops --session-key issue-4342 --title Issue #4342: fix \"/full-loop Implement issue #4342\"
+212 S 00:31 opencode run --dir /tmp/other --session-key issue-4342 --title Issue #4342: other \"/full-loop Implement issue #4342\"
+213 S 00:05 opencode run --dir /tmp/aidevops --title Supervisor Pulse \"/pulse\"
+214 S 00:12 opencode run --dir /tmp/aidevops-tools --session-key issue-4342 --title Issue #4342: tools \"/full-loop Implement issue #4342\""
 
 	if ! has_worker_for_repo_issue "4342" "marcusquinn/aidevops"; then
 		print_result "has_worker_for_repo_issue matches scoped worker process" 1 "Expected worker match for repo issue"
@@ -223,6 +228,31 @@ JSON
 	return 0
 }
 
+test_excludes_zombie_and_stopped_processes() {
+	# GH#6413: Zombie (Z) and stopped (T) processes must be excluded from
+	# active worker counts. SN (sleeping, low priority) processes that are
+	# NOT zombie/stopped should still be counted — SN is a valid running state.
+	set_ps_fixture "400 S 00:10 opencode run --dir /tmp/aidevops --title Issue #4400 \"/full-loop Implement issue #4400\"
+401 Z 00:30 opencode run --dir /tmp/aidevops --title Issue #4401 \"/full-loop Implement issue #4401\"
+402 SN 00:45 opencode run --dir /tmp/aidevops --title Issue #4402 \"/full-loop Implement issue #4402\"
+403 T 01:00 opencode run --dir /tmp/aidevops --title Issue #4403 \"/full-loop Implement issue #4403\"
+404 Ss 00:05 opencode run --dir /tmp/aidevops --title Issue #4404 \"/full-loop Implement issue #4404\"
+405 Zs 00:15 opencode run --dir /tmp/aidevops --title Issue #4405 \"/full-loop Implement issue #4405\"
+406 TN 00:20 opencode run --dir /tmp/aidevops --title Issue #4406 \"/full-loop Implement issue #4406\""
+
+	local count
+	count=$(count_active_workers)
+	# Lines 400 (S), 402 (SN), 404 (Ss) are valid running states — counted
+	# Lines 401 (Z), 403 (T), 405 (Zs), 406 (TN) are zombie/stopped — excluded
+	if [[ "$count" != "3" ]]; then
+		print_result "count_active_workers excludes zombie and stopped processes" 1 "Expected 3, got ${count}"
+		return 0
+	fi
+
+	print_result "count_active_workers excludes zombie and stopped processes" 0
+	return 0
+}
+
 test_check_dispatch_dedup_treats_merged_pr_as_duplicate() {
 	local original_script_dir="$SCRIPT_DIR"
 	SCRIPT_DIR="$TEST_ROOT"
@@ -251,6 +281,7 @@ main() {
 	test_deduplicates_process_chain_to_one_logical_worker
 	test_deduplicates_multiple_workers_with_process_chains
 	test_repo_issue_detection_uses_filtered_worker_list
+	test_excludes_zombie_and_stopped_processes
 	test_check_dispatch_dedup_treats_merged_pr_as_duplicate
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

- Add secondary watchdog to `_sandbox_exec_with_pgkill` that independently tracks wall-clock time via `date(1)` and kills the child process group if the deadline is exceeded — defense-in-depth against parent crash, OOM, or sleep drift
- Add process state filtering in `list_active_worker_processes` to exclude zombie (`Z`) and stopped (`T`) processes from active worker counts, preventing inflated struggle ratios and stale worker detection
- Update test fixtures and add new test for zombie/stopped process filtering (all 8 tests pass)

## Details

**Root cause**: When the sandbox wrapper process crashes or gets OOM-killed, the child process (running in its own session via `setsid`) survives indefinitely. The primary polling loop dies with the parent, so no timeout enforcement occurs. Observed: PID 88026 ran 18+ hours despite `--timeout 3600`.

**Secondary watchdog design**:
- Spawned as a background subshell alongside the primary polling loop
- Sleeps in 30s chunks (responsive to parent kill signals)
- Uses `date(1)` wall-clock verification, not just sleep duration
- 10% grace period (min 5s, max 60s) avoids racing with the primary loop
- Killed on normal exit via `_pgkill_cleanup` to prevent orphaned watchers

**Process state filtering**:
- `ps axo pid,stat,etime,command` now includes the `stat` column
- awk filters exclude processes starting with `Z` (zombie) or `T` (stopped)
- Output format preserved as `pid etime command` for backward compatibility
- `SN` (sleeping, low priority) processes are NOT excluded — they are valid running states

Closes #6413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system process monitoring by filtering out zombie and stopped processes for accurate counts
  * Enhanced sandbox timeout enforcement with a dedicated watchdog mechanism

* **Tests**
  * Extended test coverage for zombie and stopped process filtering scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->