### PR TITLE
GH#6417: add shellcheck source hints to top 5 active scripts

### DIFF
--- a/.agents/scripts/ai-judgment-helper.sh
+++ b/.agents/scripts/ai-judgment-helper.sh
@@ -33,6 +33,7 @@
 #   2 - API unavailable (fallback used, still exits 0 for callers)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail

--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -16,6 +16,7 @@
 # Exit codes: 0=success (response on stdout), 1=error, 2=no API key
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail

--- a/.agents/scripts/ai-threshold-judge.sh
+++ b/.agents/scripts/ai-threshold-judge.sh
@@ -19,6 +19,7 @@
 # Exit codes: 0=success, 1=error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail

--- a/.agents/scripts/budget-analysis-helper.sh
+++ b/.agents/scripts/budget-analysis-helper.sh
@@ -15,6 +15,7 @@
 #   budget-analysis-helper.sh help
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 set -euo pipefail
 init_log_file


### PR DESCRIPTION
## Summary

Adds `# shellcheck source=shared-constants.sh` directives to the 4 active scripts that were missing them, reducing SC1091 noise in external scanners (CodeRabbit, Codacy) that run without the project's `.shellcheckrc`.

## Changes

- `ai-judgment-helper.sh` — added source hint above `source "${SCRIPT_DIR}/shared-constants.sh"`
- `ai-research-helper.sh` — added source hint above `source "${SCRIPT_DIR}/shared-constants.sh"`
- `ai-threshold-judge.sh` — added source hint above `source "${SCRIPT_DIR}/shared-constants.sh"`
- `budget-analysis-helper.sh` — added source hint above `source "${SCRIPT_DIR}/shared-constants.sh"`
- `audit-log-helper.sh` — already had the hint; no change needed
- `archived/` — already excluded from `lint-file-discovery.sh`; no change needed

## Why

The local linter disables SC1091 globally via `.shellcheckrc`. External scanners (CodeRabbit, Codacy) run shellcheck without the project config and report SC1091 warnings for every `source` line without a hint. The `# shellcheck source=` directive is the canonical way to tell shellcheck the intended path, suppressing the warning in all contexts.

## Verification

```bash
shellcheck --severity=warning .agents/scripts/ai-judgment-helper.sh \
  .agents/scripts/ai-research-helper.sh \
  .agents/scripts/ai-threshold-judge.sh \
  .agents/scripts/audit-log-helper.sh \
  .agents/scripts/budget-analysis-helper.sh
# exit: 0 — no warnings
```

Files changed: 4 (within blast radius cap of 5 per t1422)

Closes #6417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal build script quality assurance through static analysis directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->