### PR TITLE
GH#6427: fix duplicate setup_shellcheck_wrapper call in interactive path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -830,7 +830,6 @@ main() {
 		confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift
 		confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && deploy_aidevops_agents
 		confirm_step "Sync agents from private repositories" && sync_agent_sources
-		setup_shellcheck_wrapper
 		confirm_step "Install Claude Code safety hooks (block destructive commands)" && setup_safety_hooks
 		confirm_step "Initialize settings.json (canonical config file)" && init_settings_json
 		confirm_step "Setup multi-tenant credential storage" && setup_multi_tenant_credentials


### PR DESCRIPTION
## Summary

- Removes the duplicate `setup_shellcheck_wrapper` call at line 833 in `_setup_run_interactive()`
- The interactive path called the function twice: once at line 808 (correct, after `setup_shell_linting_tools`) and again at line 833 (redundant, between `sync_agent_sources` and `setup_safety_hooks`)
- The non-interactive path only calls it once — this fix aligns the interactive path to match

## Verification

- `bash -n setup.sh` — syntax OK
- `shellcheck -S warning setup.sh` — zero violations
- 1 file changed, 1 deletion

## Context

This addresses the CodeRabbit finding on PR #6450 (which was a larger refactor of `main()` into helper functions). That PR introduced the duplicate as a side-effect of the decomposition. This focused fix resolves the finding cleanly with a single-line deletion.

Closes #6427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup script to remove shellcheck wrapper initialization from interactive mode workflows. Non-interactive mode continues to include this step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->