### PR TITLE
GH#6428: reduce function complexity in worker-lifecycle-common.sh

### DIFF
--- a/.agents/scripts/session_tail_query.py
+++ b/.agents/scripts/session_tail_query.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Query OpenCode session DB and classify the session tail.
+
+Extracted from the inline heredoc in worker-lifecycle-common.sh
+(_run_session_tail_python) to reduce function complexity and enable
+independent testing.
+
+Reads env vars:
+    SESSION_TAIL_DB_PATH   - path to the OpenCode SQLite database
+    SESSION_TAIL_TITLE     - session title fragment to match
+    SESSION_TAIL_TIMEOUT   - recent-activity window in seconds
+    SESSION_TAIL_LIMIT     - max number of 'part' rows to inspect
+
+Prints: "classification|summary" to stdout.
+"""
+
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+
+PROVIDER_MARKERS = (
+    "rate limit",
+    "rate-limit",
+    "429",
+    "backoff",
+    "retrying",
+    "retry after",
+    "overloaded",
+    "temporarily unavailable",
+    "connection reset",
+    "timed out",
+    "timeout",
+    "econnreset",
+    "etimedout",
+    "service unavailable",
+)
+
+
+def collapse(value, limit=120):
+    """Collapse whitespace and truncate a string for log-safe display."""
+    value = re.sub(r"\s+", " ", value or "").strip()
+    if len(value) > limit:
+        value = value[: limit - 3] + "..."
+    return value.replace("|", "/")
+
+
+def find_session(cursor, session_title):
+    """Find the most recent session matching *session_title*.
+
+    Returns (session_id, resolved_title) or None.
+    """
+    cursor.execute(
+        """
+        SELECT id, title
+        FROM session
+        WHERE title LIKE ?
+        ORDER BY time_created DESC
+        LIMIT 1
+        """,
+        (f"%{session_title}%",),
+    )
+    return cursor.fetchone()
+
+
+def count_recent_messages(cursor, session_id, timeout_seconds):
+    """Count messages created within the recent-activity window."""
+    cursor.execute(
+        """
+        SELECT COUNT(*)
+        FROM message
+        WHERE session_id = ?
+          AND (CASE WHEN time_created > 20000000000
+               THEN time_created / 1000
+               ELSE time_created END)
+              > strftime('%s', 'now') - ?
+        """,
+        (session_id, timeout_seconds),
+    )
+    return int(cursor.fetchone()[0] or 0)
+
+
+def fetch_recent_parts(cursor, session_id, part_limit):
+    """Fetch the most recent *part_limit* parts, oldest-first."""
+    cursor.execute(
+        """
+        SELECT data, time_created
+        FROM part
+        WHERE session_id = ?
+        ORDER BY time_created DESC
+        LIMIT ?
+        """,
+        (session_id, part_limit),
+    )
+    return list(reversed(cursor.fetchall()))
+
+
+def parse_parts(part_rows):
+    """Parse raw part rows into display entries and a search blob.
+
+    Returns (entries, search_blob, newest_part_time).
+    """
+    entries = []
+    search_blob = []
+    newest_part_time = 0
+
+    for raw_data, part_time in part_rows:
+        newest_part_time = max(newest_part_time, int(part_time or 0))
+        data = json.loads(raw_data)
+        part_type = data.get("type", "unknown")
+
+        if part_type == "text":
+            preview = collapse(data.get("text", ""))
+            if preview:
+                entries.append(f'text:"{preview}"')
+                search_blob.append(preview.lower())
+        elif part_type == "tool":
+            state = data.get("state", {})
+            status = collapse(str(state.get("status", "unknown")), 24)
+            description = collapse(
+                str(state.get("input", {}).get("description", ""))
+            )
+            tool_name = collapse(str(data.get("tool", "tool")), 32)
+            if description:
+                entries.append(f'tool:{tool_name}({status}) "{description}"')
+                search_blob.append(description.lower())
+            else:
+                entries.append(f"tool:{tool_name}({status})")
+        elif part_type == "step-finish":
+            reason = collapse(str(data.get("reason", "done")), 32)
+            entries.append(f"step-finish:{reason}")
+        elif part_type == "step-start":
+            entries.append("step-start")
+        elif part_type == "reasoning":
+            entries.append("reasoning")
+        else:
+            entries.append(collapse(part_type, 32))
+
+    if not entries:
+        entries.append("no-parts")
+
+    return entries, search_blob, newest_part_time
+
+
+def classify_session(recent_count, search_blob):
+    """Classify session state as active, provider-waiting, or stalled."""
+    joined_blob = " ".join(search_blob)
+    if recent_count > 0:
+        return "active"
+    if any(marker in joined_blob for marker in PROVIDER_MARKERS):
+        return "provider-waiting"
+    return "stalled"
+
+
+def format_summary(classification, resolved_title, recent_count,
+                   newest_part_time, entries):
+    """Build the final 'classification|summary' output line."""
+    age_seconds = (
+        max(0, int(time.time()) - newest_part_time)
+        if newest_part_time
+        else -1
+    )
+    tail_summary = " > ".join(entries[-5:])
+    summary = (
+        f'session="{collapse(resolved_title, 80)}"; '
+        f"recent_messages={recent_count}; "
+        f"newest_part_age={age_seconds}s; "
+        f"tail={tail_summary}"
+    )
+    return f"{classification}|{summary}"
+
+
+def main():
+    """Entry point: read env vars, query DB, print classification."""
+    db_path = os.environ["SESSION_TAIL_DB_PATH"]
+    session_title = os.environ["SESSION_TAIL_TITLE"]
+    timeout_seconds = int(os.environ["SESSION_TAIL_TIMEOUT"])
+    part_limit = int(os.environ["SESSION_TAIL_LIMIT"])
+
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA busy_timeout=5000")
+        cursor = conn.cursor()
+
+        session_row = find_session(cursor, session_title)
+        if not session_row:
+            print("none|No OpenCode session found")
+            return
+
+        session_id, resolved_title = session_row
+        recent_count = count_recent_messages(
+            cursor, session_id, timeout_seconds
+        )
+        part_rows = fetch_recent_parts(cursor, session_id, part_limit)
+    except sqlite3.Error as exc:
+        print(
+            f"none|Session evidence query failed: "
+            f"{collapse(str(exc), 120)}"
+        )
+        return
+
+    entries, search_blob, newest_part_time = parse_parts(part_rows)
+    classification = classify_session(recent_count, search_blob)
+    print(
+        format_summary(
+            classification, resolved_title, recent_count,
+            newest_part_time, entries,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -20,6 +20,10 @@
 #   _compute_struggle_ratio() Compute messages/commits ratio for a worker
 #   _format_duration()        Format seconds into human-readable duration
 #
+# Companion files:
+#   session_tail_query.py     Extracted Python logic for session tail
+#                             classification (GH#6428)
+#
 # Usage: source worker-lifecycle-common.sh
 #
 # Include guard prevents double-loading (readonly errors, function redefinition).
@@ -113,144 +117,22 @@ _get_session_tail_preconditions() {
 # Reads env vars: SESSION_TAIL_DB_PATH, SESSION_TAIL_TITLE,
 #   SESSION_TAIL_TIMEOUT, SESSION_TAIL_LIMIT
 # Returns: "classification|summary" via stdout
+#
+# Logic extracted to session_tail_query.py for testability and to
+# keep this function under the 100-line complexity threshold (GH#6428).
 #######################################
 _run_session_tail_python() {
-	python3 - <<'PY'
-import json
-import os
-import re
-import sqlite3
-import time
+	local script_dir
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local py_script="${script_dir}/session_tail_query.py"
 
-db_path = os.environ["SESSION_TAIL_DB_PATH"]
-session_title = os.environ["SESSION_TAIL_TITLE"]
-timeout_seconds = int(os.environ["SESSION_TAIL_TIMEOUT"])
-part_limit = int(os.environ["SESSION_TAIL_LIMIT"])
+	if [[ ! -f "$py_script" ]]; then
+		echo "none|session_tail_query.py not found at ${py_script}" >&2
+		printf '%s' "none|session_tail_query.py missing"
+		return 1
+	fi
 
-provider_markers = (
-    "rate limit",
-    "rate-limit",
-    "429",
-    "backoff",
-    "retrying",
-    "retry after",
-    "overloaded",
-    "temporarily unavailable",
-    "connection reset",
-    "timed out",
-    "timeout",
-    "econnreset",
-    "etimedout",
-    "service unavailable",
-)
-
-def collapse(value: str, limit: int = 120) -> str:
-    value = re.sub(r"\s+", " ", value or "").strip()
-    if len(value) > limit:
-        value = value[: limit - 3] + "..."
-    return value.replace("|", "/")
-
-try:
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA busy_timeout=5000")
-    cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT id, title
-        FROM session
-        WHERE title LIKE ?
-        ORDER BY time_created DESC
-        LIMIT 1
-        """,
-        (f"%{session_title}%",),
-    )
-    session_row = cursor.fetchone()
-    if not session_row:
-        print("none|No OpenCode session found")
-        raise SystemExit(0)
-
-    session_id, resolved_title = session_row
-    cursor.execute(
-        """
-        SELECT COUNT(*)
-        FROM message
-        WHERE session_id = ?
-          AND (CASE WHEN time_created > 20000000000 THEN time_created / 1000 ELSE time_created END) > strftime('%s', 'now') - ?
-        """,
-        (session_id, timeout_seconds),
-    )
-    recent_count = int(cursor.fetchone()[0] or 0)
-
-    cursor.execute(
-        """
-        SELECT data, time_created
-        FROM part
-        WHERE session_id = ?
-        ORDER BY time_created DESC
-        LIMIT ?
-        """,
-        (session_id, part_limit),
-    )
-    part_rows = list(reversed(cursor.fetchall()))
-except sqlite3.Error as exc:
-    print(f"none|Session evidence query failed: {collapse(str(exc), 120)}")
-    raise SystemExit(0)
-
-entries = []
-search_blob = []
-newest_part_time = 0
-
-for raw_data, part_time in part_rows:
-    newest_part_time = max(newest_part_time, int(part_time or 0))
-    data = json.loads(raw_data)
-    part_type = data.get("type", "unknown")
-
-    if part_type == "text":
-        preview = collapse(data.get("text", ""))
-        if preview:
-            entries.append(f'text:"{preview}"')
-            search_blob.append(preview.lower())
-    elif part_type == "tool":
-        state = data.get("state", {})
-        status = collapse(str(state.get("status", "unknown")), 24)
-        description = collapse(str(state.get("input", {}).get("description", "")))
-        tool_name = collapse(str(data.get("tool", "tool")), 32)
-        if description:
-            entries.append(f'tool:{tool_name}({status}) "{description}"')
-            search_blob.append(description.lower())
-        else:
-            entries.append(f"tool:{tool_name}({status})")
-    elif part_type == "step-finish":
-        reason = collapse(str(data.get("reason", "done")), 32)
-        entries.append(f"step-finish:{reason}")
-    elif part_type == "step-start":
-        entries.append("step-start")
-    elif part_type == "reasoning":
-        entries.append("reasoning")
-    else:
-        entries.append(collapse(part_type, 32))
-
-if not entries:
-    entries.append("no-parts")
-
-joined_blob = " ".join(search_blob)
-if recent_count > 0:
-    classification = "active"
-elif any(marker in joined_blob for marker in provider_markers):
-    classification = "provider-waiting"
-else:
-    classification = "stalled"
-
-age_seconds = max(0, int(time.time()) - newest_part_time) if newest_part_time else -1
-tail_summary = " > ".join(entries[-5:])
-summary = (
-    f'session="{collapse(resolved_title, 80)}"; '
-    f"recent_messages={recent_count}; "
-    f"newest_part_age={age_seconds}s; "
-    f"tail={tail_summary}"
-)
-print(f"{classification}|{summary}")
-PY
+	python3 "$py_script"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Extracted the 138-line `_run_session_tail_python()` inline Python heredoc into a standalone `session_tail_query.py` module with 8 focused functions
- The bash wrapper is now 14 lines — calls the external script via `python3` with the same env var interface
- No functional changes: identical input (env vars) and output format (`classification|summary`)

## Details

The original function embedded a ~130-line Python script as a heredoc inside a bash function. This made it:
- Impossible to lint/test the Python independently
- Hard to read (no syntax highlighting in most editors for heredoc content)
- The sole function exceeding the 100-line complexity threshold

**Extracted Python functions:**

| Function | Lines | Purpose |
|----------|-------|---------|
| `collapse()` | 6 | Whitespace normalization and truncation |
| `find_session()` | 16 | DB lookup for matching session |
| `count_recent_messages()` | 15 | Count messages in activity window |
| `fetch_recent_parts()` | 13 | Fetch recent session parts |
| `parse_parts()` | 45 | Parse raw parts into display entries |
| `classify_session()` | 8 | Determine active/provider-waiting/stalled |
| `format_summary()` | 16 | Build output string |
| `main()` | 37 | Orchestrate the pipeline |

## Verification

- `bash -n worker-lifecycle-common.sh` — PASS
- `shellcheck worker-lifecycle-common.sh` — PASS (zero violations)
- `python3 -m py_compile session_tail_query.py` — PASS
- `source worker-lifecycle-common.sh && type _run_session_tail_python` — PASS
- Files touched: 2 (under 5-file cap)

Closes #6428