### PR TITLE
GH#6453: Fix headless-runtime-helper.sh spawning 2 processes per dispatch

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1380,6 +1380,36 @@ list_active_worker_processes() {
 	return 0
 }
 
+#######################################
+# List headless-runtime-helper.sh processes that are launching workers (GH#6453)
+#
+# Catches workers in their startup phase — after headless-runtime-helper.sh
+# has been invoked but before the opencode process has spawned. During this
+# window (model selection, auth check, sandbox setup), the worker is invisible
+# to list_active_worker_processes() because no opencode process exists yet.
+#
+# This causes has_worker_for_repo_issue() to return false-negative, allowing
+# the early-exit recycle loop or a recycled pulse to re-dispatch the same issue.
+#
+# Output format: pid etime command (same as list_active_worker_processes)
+# Filters: must contain headless-runtime-helper AND --role worker AND --session-key
+# Excludes: zombie/stopped processes
+#######################################
+list_launching_worker_processes() {
+	ps axo pid,stat,etime,command | awk '
+		/headless-runtime-helper/ &&
+		/--role[[:space:]]+worker/ &&
+		/--session-key/ {
+			stat = $2
+			if (stat ~ /^[ZT]/) next
+			printf "%s %s", $1, $3
+			for (i = 4; i <= NF; i++) printf " %s", $i
+			printf "\n"
+		}
+	'
+	return 0
+}
+
 prefetch_active_workers() {
 	local worker_lines
 	worker_lines=$(list_active_worker_processes || true)
@@ -2924,12 +2954,56 @@ prefetch_gh_failure_notifications() {
 
 #######################################
 # Count active worker processes
+#
+# GH#6453: Also counts headless-runtime-helper.sh processes in startup
+# phase (before opencode spawns). These are deduplicated against active
+# workers by session-key to avoid double-counting workers that have both
+# a headless-runtime-helper parent and an opencode child running.
+#
 # Returns: count via stdout
 #######################################
 count_active_workers() {
-	local count
-	count=$(list_active_worker_processes | wc -l | tr -d ' ') || count=0
-	echo "$count"
+	local active_count launching_count
+	active_count=$(list_active_worker_processes | wc -l | tr -d ' ') || active_count=0
+	[[ "$active_count" =~ ^[0-9]+$ ]] || active_count=0
+
+	# GH#6453: Count launching workers not yet visible as opencode processes.
+	# A launching worker's headless-runtime-helper.sh process contains
+	# --session-key issue-NNN. If an active opencode worker already exists
+	# for the same issue-NNN, the launching process is the parent — don't
+	# double-count. We use a simple heuristic: count launching processes
+	# whose session-key does NOT appear in the active worker process list.
+	local active_lines launching_lines
+	active_lines=$(list_active_worker_processes) || active_lines=""
+	launching_lines=$(list_launching_worker_processes) || launching_lines=""
+	launching_count=0
+
+	if [[ -n "$launching_lines" ]]; then
+		while IFS= read -r launch_line; do
+			[[ -z "$launch_line" ]] && continue
+			# Extract session-key value (e.g., "issue-6426")
+			local skey=""
+			if [[ "$launch_line" =~ --session-key[[:space:]]+([^[:space:]]+) ]]; then
+				skey="${BASH_REMATCH[1]}"
+			fi
+			if [[ -z "$skey" ]]; then
+				# Can't extract session-key — count conservatively
+				launching_count=$((launching_count + 1))
+				continue
+			fi
+			# Check if an active opencode worker already has this session-key
+			# (the session-key appears in the opencode command line as part of
+			# the issue reference, e.g., "issue-6426" in --session-key or prompt)
+			if [[ -n "$active_lines" ]] && echo "$active_lines" | grep -qF "$skey"; then
+				# Already counted as an active worker — skip
+				continue
+			fi
+			launching_count=$((launching_count + 1))
+		done <<<"$launching_lines"
+	fi
+
+	local total=$((active_count + launching_count))
+	echo "$total"
 	return 0
 }
 
@@ -2978,6 +3052,7 @@ has_worker_for_repo_issue() {
 		return 1
 	fi
 
+	# Check active opencode worker processes (fully started)
 	local matches
 	matches=$(list_active_worker_processes | awk -v issue="$issue_number" -v path="$repo_path" '
 		BEGIN {
@@ -2993,6 +3068,30 @@ has_worker_for_repo_issue() {
 	if [[ "$matches" -gt 0 ]]; then
 		return 0
 	fi
+
+	# GH#6453: Also check headless-runtime-helper.sh processes in startup phase.
+	# Workers are invisible to list_active_worker_processes() during the window
+	# between headless-runtime-helper.sh invocation and opencode process spawn
+	# (model selection, auth check, sandbox setup — typically 5-15s). Without
+	# this check, the early-exit recycle loop re-dispatches the same issue,
+	# creating 2 workers per dispatch.
+	local launching_matches
+	launching_matches=$(list_launching_worker_processes | awk -v issue="$issue_number" -v path="$repo_path" '
+		BEGIN {
+			esc = path
+			gsub(/[][(){}.^$*+?|\\]/, "\\\\&", esc)
+		}
+		($0 ~ ("--dir[[:space:]]+" esc "([[:space:]]|$)") &&
+		 ($0 ~ ("issue-" issue "([^0-9]|$)") || $0 ~ ("Issue #" issue "([^0-9]|$)"))) ||
+		($0 ~ ("--session-key[[:space:]]+issue-" issue "([^0-9]|$)")) { count++ }
+		END { print count + 0 }
+	') || launching_matches=0
+	[[ "$launching_matches" =~ ^[0-9]+$ ]] || launching_matches=0
+
+	if [[ "$launching_matches" -gt 0 ]]; then
+		return 0
+	fi
+
 	return 1
 }
 
@@ -3773,7 +3872,18 @@ _run_early_exit_recycle_loop() {
 			break
 		fi
 
-		# Re-check worker state
+		# GH#6453: Grace period before re-evaluating worker counts.
+		# Workers dispatched by the just-completed pulse are still in their
+		# startup phase (headless-runtime-helper.sh → model selection → auth
+		# check → sandbox setup → opencode spawn). Without this delay, the
+		# recycle loop sees an underfilled pool and re-dispatches the same
+		# issues, creating 2 workers per dispatch.
+		# PULSE_LAUNCH_GRACE_SECONDS (default 20s) matches the grace window
+		# used by check_worker_launch() for the same reason.
+		echo "[pulse-wrapper] Early-exit recycle: waiting ${PULSE_LAUNCH_GRACE_SECONDS}s for recently-dispatched workers to start" >>"$LOGFILE"
+		sleep "$PULSE_LAUNCH_GRACE_SECONDS"
+
+		# Re-check worker state (now includes launching workers via GH#6453)
 		local post_max post_active post_runnable post_queued
 		post_max=$(get_max_workers_target)
 		post_active=$(count_active_workers)

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -271,6 +271,87 @@ test_check_dispatch_dedup_treats_merged_pr_as_duplicate() {
 	return 0
 }
 
+test_launching_worker_detected_by_has_worker_for_repo_issue() {
+	# GH#6453: A headless-runtime-helper.sh process in startup phase (before
+	# opencode spawns) must be detected by has_worker_for_repo_issue() to
+	# prevent duplicate dispatch.
+	set_ps_fixture "500 S 00:03 bash /home/user/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-6426 --dir /tmp/aidevops --title Issue #6426: Fix auth --prompt /full-loop Implement issue #6426"
+
+	if ! has_worker_for_repo_issue "6426" "marcusquinn/aidevops"; then
+		print_result "has_worker_for_repo_issue detects launching worker (GH#6453)" 1 "Expected match for launching headless-runtime-helper process"
+		return 0
+	fi
+
+	# Should NOT match a different issue number
+	if has_worker_for_repo_issue "9999" "marcusquinn/aidevops"; then
+		print_result "has_worker_for_repo_issue rejects unrelated issue for launching worker" 1 "Expected no match for issue 9999"
+		return 0
+	fi
+
+	print_result "has_worker_for_repo_issue detects launching worker (GH#6453)" 0
+	print_result "has_worker_for_repo_issue rejects unrelated issue for launching worker" 0
+	return 0
+}
+
+test_count_active_workers_includes_launching_workers() {
+	# GH#6453: count_active_workers must include launching workers that
+	# don't yet have an opencode process, to prevent the early-exit recycle
+	# loop from seeing an underfilled pool and re-dispatching.
+	set_ps_fixture "600 S 00:30 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #6001\" --dir /tmp/aidevops --title Issue #6001
+601 S 00:03 bash /home/user/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-6002 --dir /tmp/aidevops --title Issue #6002: New feature --prompt /full-loop Implement issue #6002"
+
+	local count
+	count=$(count_active_workers)
+	# Line 600: active opencode worker (counted by list_active_worker_processes)
+	# Line 601: launching worker (counted by list_launching_worker_processes, no overlap)
+	if [[ "$count" != "2" ]]; then
+		print_result "count_active_workers includes launching workers (GH#6453)" 1 "Expected 2, got ${count}"
+		return 0
+	fi
+
+	print_result "count_active_workers includes launching workers (GH#6453)" 0
+	return 0
+}
+
+test_count_active_workers_deduplicates_launching_and_active() {
+	# GH#6453: When a worker has both a headless-runtime-helper parent AND
+	# an opencode child running, count it only once (not double-counted).
+	# The session-key "issue-6003" appears in both the launching process
+	# and the active opencode process command line.
+	set_ps_fixture "700 S 00:10 bash /home/user/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-6003 --dir /tmp/aidevops --title Issue #6003: Fix bug --prompt /full-loop Implement issue #6003
+701 S 00:08 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #6003\" --dir /tmp/aidevops --session-key issue-6003 --title Issue #6003"
+
+	local count
+	count=$(count_active_workers)
+	# Line 701 is the active opencode worker (counted by list_active_worker_processes)
+	# Line 700 is the launching parent — its session-key "issue-6003" appears in
+	# the active worker list, so it should be deduplicated (not double-counted)
+	if [[ "$count" != "1" ]]; then
+		print_result "count_active_workers deduplicates launching+active for same session-key (GH#6453)" 1 "Expected 1, got ${count}"
+		return 0
+	fi
+
+	print_result "count_active_workers deduplicates launching+active for same session-key (GH#6453)" 0
+	return 0
+}
+
+test_list_launching_worker_processes_excludes_pulse() {
+	# GH#6453: list_launching_worker_processes must only match --role worker,
+	# not --role pulse (the supervisor pulse is not a worker).
+	set_ps_fixture "800 S 00:03 bash /home/user/.aidevops/agents/scripts/headless-runtime-helper.sh run --role pulse --session-key supervisor-pulse --dir /tmp/workspace --title Supervisor Pulse
+801 S 00:03 bash /home/user/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-6004 --dir /tmp/aidevops --title Issue #6004: Fix --prompt /full-loop"
+
+	local launching_count
+	launching_count=$(list_launching_worker_processes | wc -l | tr -d ' ')
+	if [[ "$launching_count" != "1" ]]; then
+		print_result "list_launching_worker_processes excludes pulse role (GH#6453)" 1 "Expected 1, got ${launching_count}"
+		return 0
+	fi
+
+	print_result "list_launching_worker_processes excludes pulse role (GH#6453)" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -283,6 +364,11 @@ main() {
 	test_repo_issue_detection_uses_filtered_worker_list
 	test_excludes_zombie_and_stopped_processes
 	test_check_dispatch_dedup_treats_merged_pr_as_duplicate
+	# GH#6453: Launching worker detection tests
+	test_launching_worker_detected_by_has_worker_for_repo_issue
+	test_count_active_workers_includes_launching_workers
+	test_count_active_workers_deduplicates_launching_and_active
+	test_list_launching_worker_processes_excludes_pulse
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes #6453

Workers dispatched by the pulse are invisible to `has_worker_for_repo_issue()` during their startup phase (headless-runtime-helper.sh → model selection → auth check → sandbox setup → opencode spawn, typically 5-15s). The early-exit recycle loop re-evaluates the pool during this window, sees underfilled slots, and re-dispatches the same issues — creating 2 workers per dispatch.

## Root Cause

The `list_active_worker_processes()` function matches processes containing both `/full-loop` AND `opencode`. During the startup window, only `headless-runtime-helper.sh` is running — `opencode` hasn't spawned yet. This makes the worker invisible to all dedup checks (`has_worker_for_repo_issue`, `count_active_workers`, `check_dispatch_dedup`).

## Fix (three-part)

1. **`list_launching_worker_processes()`** — new function that detects `headless-runtime-helper.sh` processes with `--role worker` before opencode spawns
2. **`has_worker_for_repo_issue()`** — also checks launching workers by session-key and `--dir` path, closing the false-negative window
3. **`count_active_workers()`** — includes launching workers in the count (deduplicated by session-key to avoid double-counting workers that have both a headless-runtime-helper parent and an opencode child)
4. **`_run_early_exit_recycle_loop()`** — adds `PULSE_LAUNCH_GRACE_SECONDS` delay before re-evaluating worker counts, giving dispatched workers time to start

## Testing

- All 8 existing worker detection tests pass unchanged
- Added 5 new tests:
  - `has_worker_for_repo_issue` detects launching worker (GH#6453)
  - `has_worker_for_repo_issue` rejects unrelated issue for launching worker
  - `count_active_workers` includes launching workers (GH#6453)
  - `count_active_workers` deduplicates launching+active for same session-key (GH#6453)
  - `list_launching_worker_processes` excludes pulse role (GH#6453)

## Impact

- Eliminates doubled compute cost per task
- Prevents struggle_ratio inflation from competing workers on the same worktree
- Prevents branch conflicts from concurrent workers on the same issue

## Files Changed

- `.agents/scripts/pulse-wrapper.sh` — core fix (new function + modified dedup logic + grace period)
- `.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh` — 5 new tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of worker processes during initialization phases, capturing processes not previously visible
  * Enhanced worker availability checking to prevent missing workers when matching to specific repos and issues
  * Optimized worker recycling with better grace period management during startup windows

* **Tests**
  * Added comprehensive test coverage for worker process detection, counting, and deduplication logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->