### PR TITLE
fix: prevent double-dispatch — session-key worker detection + backfill grace wait (GH#6453)

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2974,25 +2974,47 @@ has_worker_for_repo_issue() {
 
 	local repo_path
 	repo_path=$(get_repo_path_by_slug "$repo_slug")
-	if [[ -z "$repo_path" ]]; then
-		return 1
+
+	local worker_lines
+	worker_lines=$(list_active_worker_processes) || worker_lines=""
+
+	# Primary match: repo path + issue number in command line.
+	# Requires get_repo_path_by_slug to return a non-empty path.
+	if [[ -n "$repo_path" ]]; then
+		local matches
+		matches=$(printf '%s\n' "$worker_lines" | awk -v issue="$issue_number" -v path="$repo_path" '
+			BEGIN {
+				esc = path
+				gsub(/[][(){}.^$*+?|\\]/, "\\\\&", esc)
+			}
+			$0 ~ ("--dir[[:space:]]+" esc "([[:space:]]|$)") &&
+			($0 ~ ("issue-" issue "([^0-9]|$)") || $0 ~ ("Issue #" issue "([^0-9]|$)")) { count++ }
+			END { print count + 0 }
+		') || matches=0
+		[[ "$matches" =~ ^[0-9]+$ ]] || matches=0
+		if [[ "$matches" -gt 0 ]]; then
+			return 0
+		fi
 	fi
 
-	local matches
-	matches=$(list_active_worker_processes | awk -v issue="$issue_number" -v path="$repo_path" '
-		BEGIN {
-			esc = path
-			gsub(/[][(){}.^$*+?|\\]/, "\\\\&", esc)
-		}
-		$0 ~ ("--dir[[:space:]]+" esc "([[:space:]]|$)") &&
-		($0 ~ ("issue-" issue "([^0-9]|$)") || $0 ~ ("Issue #" issue "([^0-9]|$)")) { count++ }
+	# Fallback: match by session-key alone (GH#6453).
+	# When get_repo_path_by_slug returns empty (slug not in repos.json,
+	# path mismatch, or repos.json unavailable), the primary match above
+	# always returns 0 matches — a false-negative that causes the backfill
+	# cycle to re-dispatch already-running workers.
+	# The session-key "issue-<number>" is always present in the command line
+	# of workers dispatched via headless-runtime-helper.sh run --session-key.
+	# This fallback catches those workers regardless of path resolution.
+	local sk_matches
+	sk_matches=$(printf '%s\n' "$worker_lines" | awk -v issue="$issue_number" '
+		$0 ~ ("--session-key[[:space:]]+issue-" issue "([^0-9]|$)") { count++ }
 		END { print count + 0 }
-	') || matches=0
-	[[ "$matches" =~ ^[0-9]+$ ]] || matches=0
-
-	if [[ "$matches" -gt 0 ]]; then
+	') || sk_matches=0
+	[[ "$sk_matches" =~ ^[0-9]+$ ]] || sk_matches=0
+	if [[ "$sk_matches" -gt 0 ]]; then
 		return 0
 	fi
+
 	return 1
 }
 
@@ -3755,6 +3777,14 @@ _compute_initial_underfill() {
 # If the LLM exited quickly (<5 min) and the pool is still underfilled
 # with runnable work, restart the pulse. Capped at PULSE_BACKFILL_MAX_ATTEMPTS.
 #
+# GH#6453: A grace-period wait is inserted before re-counting workers.
+# Workers dispatched by the LLM pulse take several seconds to appear in
+# list_active_worker_processes (sandbox-exec + opencode startup latency).
+# Without this wait, count_active_workers() returns the pre-dispatch count,
+# making the pool appear underfilled and triggering a second LLM pass that
+# re-dispatches the same issues — doubling compute cost and causing branch
+# conflicts. The wait duration is PULSE_LAUNCH_GRACE_SECONDS (default 20s).
+#
 # Arguments:
 #   $1 - initial pulse_duration in seconds
 #######################################
@@ -3771,6 +3801,18 @@ _run_early_exit_recycle_loop() {
 		if [[ -f "$STOP_FLAG" ]]; then
 			echo "[pulse-wrapper] Stop flag set — skipping early-exit recycle" >>"$LOGFILE"
 			break
+		fi
+
+		# GH#6453: Wait for newly-dispatched workers to appear in the process list
+		# before re-counting. Workers dispatched by the LLM pulse take
+		# PULSE_LAUNCH_GRACE_SECONDS to start (sandbox-exec + opencode startup).
+		# Counting immediately after the LLM exits produces a false-negative
+		# (workers running but not yet visible) that triggers duplicate dispatch.
+		local grace_wait="$PULSE_LAUNCH_GRACE_SECONDS"
+		[[ "$grace_wait" =~ ^[0-9]+$ ]] || grace_wait=20
+		if [[ "$grace_wait" -gt 0 ]]; then
+			echo "[pulse-wrapper] Early-exit recycle: waiting ${grace_wait}s for dispatched workers to appear (GH#6453)" >>"$LOGFILE"
+			sleep "$grace_wait"
 		fi
 
 		# Re-check worker state

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -253,6 +253,48 @@ test_excludes_zombie_and_stopped_processes() {
 	return 0
 }
 
+test_has_worker_for_repo_issue_session_key_fallback() {
+	# GH#6453: When get_repo_path_by_slug returns empty (slug not in repos.json),
+	# has_worker_for_repo_issue must fall back to matching by --session-key.
+	# This prevents false-negatives that cause the backfill cycle to re-dispatch
+	# already-running workers.
+	local original_repos_json="$REPOS_JSON"
+
+	# Use a repos.json that does NOT contain the slug being tested
+	cat >"${REPOS_JSON}" <<'JSON'
+{
+  "initialized_repos": [
+    {
+      "slug": "marcusquinn/other-repo",
+      "path": "/tmp/other-repo"
+    }
+  ]
+}
+JSON
+
+	# Worker process with --session-key issue-6426 but slug not in repos.json
+	set_ps_fixture "500 S 00:15 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- opencode run \"/full-loop Implement issue #6426\" --dir /tmp/aidevops --session-key issue-6426 --title Issue #6426"
+
+	# Should detect the worker via session-key fallback even though slug is not in repos.json
+	if ! has_worker_for_repo_issue "6426" "marcusquinn/aidevops"; then
+		REPOS_JSON="$original_repos_json"
+		print_result "has_worker_for_repo_issue session-key fallback detects worker when slug not in repos.json" 1 "Expected worker match via session-key fallback"
+		return 0
+	fi
+
+	# Should not match a different issue number
+	if has_worker_for_repo_issue "9999" "marcusquinn/aidevops"; then
+		REPOS_JSON="$original_repos_json"
+		print_result "has_worker_for_repo_issue session-key fallback rejects wrong issue number" 1 "Expected no match for issue 9999"
+		return 0
+	fi
+
+	REPOS_JSON="$original_repos_json"
+	print_result "has_worker_for_repo_issue session-key fallback detects worker when slug not in repos.json" 0
+	print_result "has_worker_for_repo_issue session-key fallback rejects wrong issue number" 0
+	return 0
+}
+
 test_check_dispatch_dedup_treats_merged_pr_as_duplicate() {
 	local original_script_dir="$SCRIPT_DIR"
 	SCRIPT_DIR="$TEST_ROOT"
@@ -282,6 +324,7 @@ main() {
 	test_deduplicates_multiple_workers_with_process_chains
 	test_repo_issue_detection_uses_filtered_worker_list
 	test_excludes_zombie_and_stopped_processes
+	test_has_worker_for_repo_issue_session_key_fallback
 	test_check_dispatch_dedup_treats_merged_pr_as_duplicate
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Fixes two root causes for `headless-runtime-helper.sh` spawning 2 processes per dispatch (GH#6453).

## Root Causes

### 1. `has_worker_for_repo_issue` false-negative

The primary match requires BOTH `--dir <repo_path>` AND `issue-<number>` in the process command line. When `get_repo_path_by_slug` returns empty (slug not in `repos.json`, path mismatch, or `repos.json` unavailable), the awk match always returns 0 — a false-negative that makes `check_worker_launch` report INVALID even when the worker is running.

**Fix:** Added a session-key fallback that matches `--session-key issue-<number>` in the process command line. This is always present for workers dispatched via `headless-runtime-helper.sh run --session-key`. The primary path+issue match is preserved as the preferred path; session-key is the fallback when path resolution fails.

### 2. Backfill cycle re-dispatches before workers appear

`_run_early_exit_recycle_loop` immediately re-counts workers after the LLM pulse exits. Workers dispatched by the LLM take `PULSE_LAUNCH_GRACE_SECONDS` (default 20s) to appear in `list_active_worker_processes` (sandbox-exec + opencode startup latency). Counting before they appear produces a false-negative that triggers a second LLM pass re-dispatching the same issues — doubling compute cost and causing branch conflicts.

**Fix:** Added a grace-period sleep (`PULSE_LAUNCH_GRACE_SECONDS`) before the re-count in `_run_early_exit_recycle_loop`. This gives just-dispatched workers time to appear in the process list before the backfill decides to re-dispatch.

## Changes

- `.agents/scripts/pulse-wrapper.sh`: `has_worker_for_repo_issue` — session-key fallback + backfill grace wait
- `.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`: new test `test_has_worker_for_repo_issue_session_key_fallback`

## Verification

All 10 tests pass:

```
PASS count_active_workers excludes supervisor /pulse but counts worker with /pulse in args
PASS count_active_workers deduplicates 3-process chain to 1 logical worker
PASS count_active_workers counts 2 logical workers from 6 process-chain entries
PASS has_worker_for_repo_issue matches scoped worker process
PASS has_worker_for_repo_issue rejects unrelated issues
PASS has_worker_for_repo_issue does not match prefix-sibling repo path
PASS count_active_workers excludes zombie and stopped processes
PASS has_worker_for_repo_issue session-key fallback detects worker when slug not in repos.json
PASS has_worker_for_repo_issue session-key fallback rejects wrong issue number
PASS check_dispatch_dedup skips dispatch when merged PR exists

Ran 10 tests, 0 failed.
```

ShellCheck: zero violations on both modified files.

Closes #6453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced worker detection with fallback matching logic and configurable grace period to prevent false resource readings.

* **Tests**
  * Added test coverage for session-key fallback detection in worker identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->