### PR TITLE
refactor: simplify email-sequences.md framework doc (542 → 159 lines)

### DIFF
--- a/.agents/tools/marketing/direct-response-copy/frameworks/email-sequences.md
+++ b/.agents/tools/marketing/direct-response-copy/frameworks/email-sequences.md
@@ -4,6 +4,8 @@
 
 Email converts at 2-5x the rate of social media, you own the list, and it delivers ~$36 ROI per $1 spent. Works for acquisition, nurturing, and retention.
 
+**For copy-paste templates**: See [Email Sequence Templates](../templates/email-sequences.md).
+
 ---
 
 ## Anatomy of a High-Converting Email
@@ -33,7 +35,7 @@ Email converts at 2-5x the rate of social media, you own the list, and it delive
 
 ### The PAS Template
 
-```
+```text
 Subject: [Problem-focused subject line]
 
 [Name],
@@ -59,119 +61,17 @@ But here's the thing...
 
 ### 1. Welcome Sequence (5-7 Emails Over 2 Weeks)
 
-**Email 1: Welcome (Day 0)**
-```
-Subject: Welcome to [Brand] + Your [Promised Resource]
+**Purpose**: Deliver lead magnet, build trust, introduce brand, make first offer.
 
-Hey [Name],
+| Email | Timing | Goal | Key Element |
+|-------|--------|------|-------------|
+| 1 — Welcome | Day 0 | Deliver resource, set expectations | Origin story teaser, social link |
+| 2 — Origin Story | Day 1-2 | Build connection through vulnerability | Relatable struggle, reply prompt |
+| 3 — Quick Win | Day 3-4 | Prove value with immediate result | Actionable 3-step tip |
+| 4 — Social Proof | Day 5-7 | Build trust through results | Before/after case study |
+| 5 — The Pitch | Day 7-10 | Convert to customer | Offer + incentive + guarantee |
 
-Welcome to [Brand]! I'm [Your Name], and I'm pumped you're here.
-
-As promised, here's your [Resource]: [Link]
-
-Quick backstory: I started [Brand] because [relatable origin story - 2 sentences].
-
-Over the coming days, I'll share [what to expect]:
-• [Value point 1]
-• [Value point 2]
-• [Value point 3]
-
-For now, grab your [resource] and hit reply if you have any questions.
-
-[Name]
-
-P.S. Follow us on [Social] for daily tips.
-```
-
-**Email 2: Origin Story (Day 1-2)**
-```
-Subject: Why I started [Brand] (hint: it was personal)
-
-[Name],
-
-Before [Brand] existed, I was exactly where you are...
-
-[Share relatable struggle - be specific and vulnerable]
-
-I tried [common solutions] but nothing worked because [reason].
-
-That's when I discovered [insight that led to your product/approach].
-
-Fast forward to today: [result you've achieved or helped others achieve]
-
-Tomorrow, I'll share [preview of next email].
-
-[Name]
-
-P.S. Hit reply and tell me your biggest challenge with [topic].
-```
-
-**Email 3: Quick Win (Day 3-4)**
-```
-Subject: Do this in 5 minutes to [get result]
-
-[Name],
-
-Today I'm giving you something you can use immediately.
-
-[Tactical tip or mini-guide]
-
-1. [Step 1]
-2. [Step 2]
-3. [Step 3]
-
-[Why this works] I've seen people [result] just from this one change.
-
-Try it today and let me know how it goes.
-
-[Name]
-```
-
-**Email 4: Social Proof (Day 5-7)**
-```
-Subject: How [Customer Name] got [Result]
-
-[Name],
-
-[Before]: [Their situation before]
-[Challenge]: [What was holding them back]
-[After]: [Result they achieved]
-
-"[Testimonial quote]"
-
-What made the difference? [Key insight]
-
-If you're ready for similar results, [CTA].
-
-[Name]
-```
-
-**Email 5: The Pitch (Day 7-10)**
-```
-Subject: Ready to [achieve outcome]?
-
-[Name],
-
-Over the past week, I've shared: [Quick summary of value provided]
-
-Now, if you want to take things further:
-
-[Product Name] helps you [primary benefit] without [primary objection].
-
-• [Feature/benefit 1]
-• [Feature/benefit 2]
-• [Feature/benefit 3]
-
-Right now, [offer/incentive].
-
-[CTA Button: Start Your Trial / Get Access]
-
-[Name]
-
-P.S. [Guarantee or scarcity element]
-```
-
-### 2. Nurture Sequence (Ongoing - Weekly/Bi-Weekly)
+### 2. Nurture Sequence (Ongoing — Weekly/Bi-Weekly)
 
 **Content Mix**: 80% value (tips, insights, stories) / 20% promotion (soft sells, offers)
 
@@ -186,325 +86,42 @@ P.S. [Guarantee or scarcity element]
 
 ### 3. Launch Sequence (7-10 Emails Over 7-14 Days)
 
-**Email 1: Announcement (Day 0)**
-```
-Subject: Something big is coming...
+**Purpose**: Build anticipation, reveal product, handle objections, close with urgency.
 
-[Name],
-
-I've been working on something for the past [timeframe].
-
-On [Date], I'm finally revealing it.
-
-[Brief teaser - don't give everything away]
-
-Mark your calendar.
-
-[Name]
-
-P.S. [Optional: Early access or waitlist CTA]
-```
-
-**Email 2: The Problem (Day 2)**
-```
-Subject: The real reason [problem] happens
-
-[Name],
-
-Let's talk about [problem your product solves].
-
-[Describe the problem in detail]
-
-Most people try [common approaches]. But here's the issue: [why those approaches fail]
-
-[Preview that your solution is different]
-
-More tomorrow...
-
-[Name]
-```
-
-**Email 3: The Solution (Day 4)**
-```
-Subject: What if [desired outcome] was actually possible?
-
-[Name],
-
-Yesterday I talked about why [problem] is so hard.
-
-Today, I want to show you what's possible when you [approach differently].
-
-[Story of success - yours or customer's]
-
-The key is [your unique mechanism].
-
-Tomorrow, I'll reveal exactly how you can do this too.
-
-[Name]
-```
-
-**Email 4: The Reveal (Day 5 - Launch Day)**
-```
-Subject: [Product Name] is LIVE 🚀
-
-[Name],
-
-Introducing [Product Name]: [One-line description]
-
-[Link to sales page]
-
-• [Benefit 1]
-• [Benefit 2]
-• [Benefit 3]
-
-Plus, for the next [timeframe]: [Bonus 1] + [Bonus 2]
-
-[Price point and/or discount]
-
-[CTA: Get [Product Name] Now]
-
-[Name]
-
-P.S. [Scarcity or urgency element]
-```
-
-**Email 5: FAQ/Objection Handling (Day 6)**
-```
-Subject: Quick answers about [Product Name]
-
-[Name],
-
-Q: [Question 1] A: [Answer]
-Q: [Question 2] A: [Answer]
-Q: [Question 3] A: [Answer]
-
-Still on the fence? [Guarantee reminder]
-
-[CTA]
-
-[Name]
-```
-
-**Email 6: Social Proof (Day 7)**
-```
-Subject: "[Quote from customer about results]"
-
-[Name],
-
-The results are already coming in:
-
-[Screenshot or quote from customer 1]
-[Screenshot or quote from customer 2]
-
-[Brief commentary on what made the difference]
-
-You could be next. [CTA]
-
-[Name]
-```
-
-**Email 7: Urgency (Day 9)**
-```
-Subject: 48 hours left for [bonus/discount]
-
-[Name],
-
-The [bonus/discount] for [Product Name] disappears in 48 hours.
-
-After that:
-• [What they'll miss - bonus 1]
-• [Price will be $X instead of $Y]
-
-[CTA]
-
-[Name]
-```
-
-**Email 8: Last Chance (Day 10)**
-```
-Subject: [FINAL] Doors close at midnight
-
-[Name],
-
-At midnight tonight, [Product Name] [closes/price increases/bonus goes away].
-
-[Quick summary of offer] vs [What they miss out on]
-
-Don't regret it later.
-
-[CTA]
-
-[Name]
-
-P.S. Questions before you decide? Reply now — I'll get back to you before midnight.
-```
+| Email | Timing | Goal | Key Element |
+|-------|--------|------|-------------|
+| 1 — Announcement | Day 0 | Tease launch, build anticipation | Calendar date, waitlist CTA |
+| 2 — The Problem | Day 2 | Agitate pain, show why existing solutions fail | Problem deep-dive |
+| 3 — The Solution | Day 4 | Show what's possible, preview approach | Success story |
+| 4 — The Reveal | Day 5 | Launch — present full offer | Benefits, bonuses, price, CTA |
+| 5 — FAQ | Day 6 | Handle objections | Q&A format, guarantee reminder |
+| 6 — Social Proof | Day 7 | Reinforce with results | Customer screenshots/quotes |
+| 7 — Urgency | Day 9 | Create deadline pressure | 48-hour countdown |
+| 8 — Last Chance | Day 10 | Final close | Midnight deadline, reply offer |
 
 ### 4. Cart Abandonment Sequence (3 Emails)
 
-**Email 1: Reminder (1 hour after)**
-```
-Subject: Did something go wrong?
+**Purpose**: Recover lost sales with escalating incentives.
 
-Hey [Name],
-
-I noticed you started checking out but didn't finish.
-
-Your cart is still saved: [Link to cart]
-
-If you ran into any issues or have questions, just hit reply.
-
-[Name]
-```
-
-**Email 2: Objection Handling (24 hours)**
-```
-Subject: Quick question about your [Product] order
-
-[Name],
-
-A lot of people who pause at checkout have one of these concerns:
-
-1. "Is it really worth the price?" [Brief value reminder]
-2. "Will it work for my situation?" [Address this objection]
-3. "What if I don't like it?" [Guarantee reminder]
-
-Your cart is still waiting: [Link]
-
-[Name]
-```
-
-**Email 3: Final + Incentive (48 hours)**
-```
-Subject: Here's a little something to help you decide
-
-[Name],
-
-Use code [CODE] for [discount/bonus] when you complete your order.
-
-[Link to cart] — This expires in 24 hours.
-
-[Name]
-
-P.S. [Guarantee reminder]
-```
+| Email | Timing | Goal | Key Element |
+|-------|--------|------|-------------|
+| 1 — Reminder | 1 hour | Gentle nudge, offer help | Cart link, reply prompt |
+| 2 — Objection Handling | 24 hours | Address common concerns | FAQ format, guarantee |
+| 3 — Final + Incentive | 48 hours | Last push with discount | Coupon code, 24h expiry |
 
 ### 5. SaaS Trial Sequence (7 Emails Over 14 Days)
 
-**Email 1: Welcome + Quick Start (Day 0)**
-```
-Subject: Welcome! Here's how to get started in 5 minutes
+**Purpose**: Drive activation, demonstrate value, convert to paid.
 
-Hey [Name],
-
-Step 1: [First action they should take]
-Step 2: [Second action]
-Step 3: [Third action - the "aha moment"]
-
-Click here to get started: [App link]
-
-[Name/Team]
-
-P.S. Your trial lasts [X] days. Make the most of it!
-```
-
-**Email 2: Feature Highlight #1 (Day 2)**
-```
-Subject: Have you tried [Feature] yet?
-
-Hey [Name],
-
-Most users who love [Product] say [Feature] changed everything.
-
-[Brief explanation of feature + benefit]
-
-Try it now: [Link directly to feature]
-
-[Name/Team]
-```
-
-**Email 3: Social Proof (Day 4)**
-```
-Subject: "This saved us 10 hours per week" - [Customer]
-
-Hey [Name],
-
-[Customer quote with specific result]
-
-They used [Product] to:
-• [Action they took]
-• [Result they got]
-
-You can do the same. Just [specific action].
-
-[Name/Team]
-```
-
-**Email 4: Check-In (Day 7 - Mid-Trial)**
-```
-Subject: How's your trial going?
-
-Hey [Name],
-
-You're halfway through your trial — how's it going?
-
-A few things you might want to try:
-• [Feature/action they haven't tried]
-• [Pro tip]
-
-[Name/Team]
-
-P.S. Need a call? [Book a time with our team]
-```
-
-**Email 5: Feature Highlight #2 (Day 9)**
-```
-Subject: The [Feature] most users miss
-
-Hey [Name],
-
-Did you know [Product] can [capability]?
-
-[Brief how-to]
-
-Try it here: [Link]
-
-[Name/Team]
-```
-
-**Email 6: Trial Ending Soon (Day 12)**
-```
-Subject: Your trial ends in 2 days
-
-Hey [Name],
-
-Your [Product] trial ends in 2 days.
-
-• [What they'll lose access to]
-• [How to upgrade]
-
-[CTA: Upgrade Now]
-
-[Name/Team]
-```
-
-**Email 7: Last Day + Incentive (Day 14)**
-```
-Subject: Your trial ends today
-
-Hey [Name],
-
-Your [Product] trial expires at midnight.
-
-Upgrade now to keep:
-• [Feature access]
-• [Data/work they've done]
-
-[CTA: Upgrade Now]
-
-Use code [CODE] for [discount] off your first [month/year].
-
-[Name/Team]
-```
+| Email | Timing | Goal | Key Element |
+|-------|--------|------|-------------|
+| 1 — Welcome + Quick Start | Day 0 | Get to "aha moment" fast | 3-step setup, app link |
+| 2 — Feature Highlight #1 | Day 2 | Show key differentiator | Direct link to feature |
+| 3 — Social Proof | Day 4 | Build confidence with results | Customer quote + specific numbers |
+| 4 — Check-In | Day 7 | Re-engage, surface blockers | Reply prompt, call booking |
+| 5 — Feature Highlight #2 | Day 9 | Show hidden value | Underutilized feature |
+| 6 — Trial Ending Soon | Day 12 | Create urgency | Loss aversion (what they'll lose) |
+| 7 — Last Day + Incentive | Day 14 | Final conversion push | Discount code, guarantee |
 
 ---
 


### PR DESCRIPTION
## Summary

- Simplify `.agents/tools/marketing/direct-response-copy/frameworks/email-sequences.md` from 542 to 159 lines (71% reduction)
- Remove full email body templates that duplicated `templates/email-sequences.md` (629 lines of the same content already exists there)
- Replace verbose per-email template blocks with structured summary tables showing timing, goal, and key elements for each sequence
- Retain all strategy content: subject line formulas, Star-Chain-Hook structure, PAS template, 80/20 nurture mix, best practices, testing checklist
- Add prominent cross-reference to templates file at top of doc

## What changed

The frameworks file's role is **strategy and structure** — when to send, what each email should accomplish, content mix ratios. The templates file's role is **copy-paste templates** — actual email bodies to fill in. The original frameworks file contained full email body templates for all 5 sequence types (Welcome, Nurture, Launch, Cart Abandonment, SaaS Trial), duplicating content that already existed in `templates/email-sequences.md`.

## Content preservation

All cross-references, subject line formulas (10), nurture content types (6), best practices, send time table, and the 7-item testing checklist are preserved. No task IDs, incident references, or institutional knowledge existed in this file.

Closes #6443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured email sequence templates with condensed summary tables (Email/Timing/Goal/Key Element) for Welcome, Launch, Cart Abandonment, and SaaS Trial sequences.
  * Added cross-references to copy-paste email templates.
  * Normalized formatting in sequence headers for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->