### PR TITLE
GH#6444: simplify browser-benchmark.md — split into guide + scripts reference

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts.md
+++ b/.agents/tools/browser/browser-benchmark-scripts.md
@@ -1,0 +1,408 @@
+# Browser Benchmark Scripts
+
+Reference scripts for `browser-benchmark.md`. Each follows the same pattern: navigate, formFill, extract, multiStep — 3 runs each, median reported.
+
+## Playwright
+
+```javascript
+// ~/.aidevops/.agent-workspace/work/browser-bench/bench-playwright.mjs
+import { chromium } from 'playwright';
+
+const TESTS = {
+  async navigate(page) {
+    await page.goto('https://the-internet.herokuapp.com/');
+    await page.screenshot({ path: '/tmp/bench-pw-nav.png' });
+  },
+  async formFill(page) {
+    await page.goto('https://the-internet.herokuapp.com/login');
+    await page.fill('#username', 'tomsmith');
+    await page.fill('#password', 'SuperSecretPassword!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL('**/secure');
+  },
+  async extract(page) {
+    await page.goto('https://the-internet.herokuapp.com/challenging_dom');
+    const rows = await page.$$eval('table tbody tr', trs => trs.slice(0, 5).map(tr => tr.textContent.trim()));
+    if (rows.length < 5) throw new Error('Expected 5+ rows');
+  },
+  async multiStep(page) {
+    await page.goto('https://the-internet.herokuapp.com/');
+    await page.click('a[href="/abtest"]');
+    await page.waitForURL('**/abtest');
+    const title = await page.title();
+    if (!title) throw new Error('No title on target page');
+  }
+};
+
+async function run() {
+  const browser = await chromium.launch({ headless: true });
+  const results = {};
+  for (const [name, fn] of Object.entries(TESTS)) {
+    const times = [];
+    for (let i = 0; i < 3; i++) {
+      const page = await browser.newPage();
+      const start = performance.now();
+      try { await fn(page); times.push(((performance.now() - start) / 1000).toFixed(2)); }
+      catch (e) { times.push(`ERR: ${e.message}`); }
+      await page.close();
+    }
+    results[name] = times;
+  }
+  await browser.close();
+  console.log(JSON.stringify(results, null, 2));
+}
+run();
+```
+
+## dev-browser
+
+```typescript
+// Run via: cd ~/.aidevops/dev-browser/skills/dev-browser && bun x tsx bench.ts
+import { connect, waitForPageLoad } from "@/client.js";
+import type { Page } from "playwright";
+
+const TESTS = {
+  async navigate(page: Page) {
+    await page.goto('https://the-internet.herokuapp.com/');
+    await waitForPageLoad(page);
+    await page.screenshot({ path: '/tmp/bench-dev-nav.png' });
+  },
+  async formFill(page: Page) {
+    await page.goto('https://the-internet.herokuapp.com/login');
+    await waitForPageLoad(page);
+    await page.fill('#username', 'tomsmith');
+    await page.fill('#password', 'SuperSecretPassword!');
+    await page.click('button[type="submit"]');
+    await page.waitForURL('**/secure');
+  },
+  async extract(page: Page) {
+    await page.goto('https://the-internet.herokuapp.com/challenging_dom');
+    await waitForPageLoad(page);
+    const rows = await page.$$eval('table tbody tr', (trs: Element[]) =>
+      trs.slice(0, 5).map(tr => tr.textContent?.trim() ?? ''));
+    if (rows.length < 5) throw new Error('Expected 5+ rows');
+  },
+  async multiStep(page: Page) {
+    await page.goto('https://the-internet.herokuapp.com/');
+    await waitForPageLoad(page);
+    await page.click('a[href="/abtest"]');
+    await page.waitForURL('**/abtest');
+  }
+};
+
+async function run() {
+  const client = await connect("http://localhost:9222");
+  const results: Record<string, string[]> = {};
+  for (const [name, fn] of Object.entries(TESTS)) {
+    const times: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const page = await client.page("bench");
+      const start = performance.now();
+      try { await fn(page); times.push(((performance.now() - start) / 1000).toFixed(2)); }
+      catch (e: any) { times.push(`ERR: ${e.message}`); }
+    }
+    results[name] = times;
+  }
+  await client.disconnect();
+  console.log(JSON.stringify(results, null, 2));
+}
+run();
+```
+
+## agent-browser
+
+```bash
+#!/bin/bash
+# bench-agent-browser.sh
+set -euo pipefail
+
+bench_navigate() {
+  local start end
+  start=$(python3 -c 'import time; print(time.time())')
+  agent-browser open "https://the-internet.herokuapp.com/"
+  agent-browser screenshot /tmp/bench-ab-nav.png
+  end=$(python3 -c 'import time; print(time.time())')
+  python3 -c "print(f'{$end - $start:.2f}')"
+  agent-browser close
+}
+
+bench_formFill() {
+  local start end
+  start=$(python3 -c 'import time; print(time.time())')
+  agent-browser open "https://the-internet.herokuapp.com/login"
+  agent-browser snapshot -i
+  agent-browser fill '@username' 'tomsmith'
+  agent-browser fill '@password' 'SuperSecretPassword!'
+  agent-browser click '@submit'
+  agent-browser wait --url '**/secure'
+  end=$(python3 -c 'import time; print(time.time())')
+  python3 -c "print(f'{$end - $start:.2f}')"
+  agent-browser close
+}
+
+bench_extract() {
+  local start end
+  start=$(python3 -c 'import time; print(time.time())')
+  agent-browser open "https://the-internet.herokuapp.com/challenging_dom"
+  agent-browser eval "JSON.stringify([...document.querySelectorAll('table tbody tr')].slice(0,5).map(r=>r.textContent.trim()))"
+  end=$(python3 -c 'import time; print(time.time())')
+  python3 -c "print(f'{$end - $start:.2f}')"
+  agent-browser close
+}
+
+bench_multiStep() {
+  local start end
+  start=$(python3 -c 'import time; print(time.time())')
+  agent-browser open "https://the-internet.herokuapp.com/"
+  agent-browser click 'a[href="/abtest"]'
+  agent-browser wait --url '**/abtest'
+  agent-browser get url
+  end=$(python3 -c 'import time; print(time.time())')
+  python3 -c "print(f'{$end - $start:.2f}')"
+  agent-browser close
+}
+
+echo "=== agent-browser Benchmark ==="
+for test in navigate formFill extract multiStep; do
+  echo -n "$test: "
+  for i in 1 2 3; do echo -n "$(bench_"$test")s "; done
+  echo ""
+done
+```
+
+## Crawl4AI
+
+```python
+# ~/.aidevops/.agent-workspace/work/browser-bench/bench-crawl4ai.py
+# Run: source ~/.aidevops/crawl4ai-venv/bin/activate && python bench-crawl4ai.py
+import asyncio, time, json
+from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
+from crawl4ai.extraction_strategy import JsonCssExtractionStrategy
+
+BROWSER_CONFIG = BrowserConfig(headless=True)
+
+async def bench_navigate():
+    async with AsyncWebCrawler(config=BROWSER_CONFIG) as crawler:
+        start = time.time()
+        result = await crawler.arun(url="https://the-internet.herokuapp.com/", config=CrawlerRunConfig(screenshot=True))
+        assert result.success, f"Failed: {result.error_message}"
+        return f"{time.time() - start:.2f}"
+
+async def bench_extract():
+    schema = {"name": "TableRows", "baseSelector": "table tbody tr",
+              "fields": [{"name": "text", "selector": "td:first-child", "type": "text"}]}
+    async with AsyncWebCrawler(config=BROWSER_CONFIG) as crawler:
+        start = time.time()
+        result = await crawler.arun(
+            url="https://the-internet.herokuapp.com/challenging_dom",
+            config=CrawlerRunConfig(extraction_strategy=JsonCssExtractionStrategy(schema)))
+        assert result.success
+        data = json.loads(result.extracted_content)
+        assert len(data) >= 5, f"Expected 5+ rows, got {len(data)}"
+        return f"{time.time() - start:.2f}"
+
+async def run():
+    results = {}
+    for name, fn in [("navigate", bench_navigate), ("extract", bench_extract)]:
+        times = [await fn() for _ in range(3)]
+        results[name] = times
+    print(json.dumps(results, indent=2))
+
+asyncio.run(run())
+```
+
+## Stagehand
+
+```javascript
+// ~/.aidevops/.agent-workspace/work/browser-bench/bench-stagehand.mjs
+import { Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod";
+
+const TESTS = {
+  async navigate(sh) {
+    const page = sh.ctx.pages()[0];
+    await page.goto('https://the-internet.herokuapp.com/');
+    await page.screenshot({ path: '/tmp/bench-sh-nav.png' });
+  },
+  async formFill(sh) {
+    const page = sh.ctx.pages()[0];
+    await page.goto('https://the-internet.herokuapp.com/login');
+    await sh.act("fill the username field with tomsmith");
+    await sh.act("fill the password field with SuperSecretPassword!");
+    await sh.act("click the Login button");
+  },
+  async extract(sh) {
+    const page = sh.ctx.pages()[0];
+    await page.goto('https://the-internet.herokuapp.com/challenging_dom');
+    const data = await sh.extract("extract the first 5 rows from the table",
+      z.object({ rows: z.array(z.object({ text: z.string() })) }));
+    if (data.rows.length < 5) throw new Error('Expected 5+ rows');
+  },
+  async multiStep(sh) {
+    const page = sh.ctx.pages()[0];
+    await page.goto('https://the-internet.herokuapp.com/');
+    await sh.act("click the A/B Testing link");
+    await page.waitForURL('**/abtest');
+  }
+};
+
+async function run() {
+  const results = {};
+  for (const [name, fn] of Object.entries(TESTS)) {
+    const times = [];
+    for (let i = 0; i < 3; i++) {
+      const sh = new Stagehand({ env: "LOCAL", headless: true, verbose: 0 });
+      await sh.init();
+      const start = performance.now();
+      try { await fn(sh); times.push(((performance.now() - start) / 1000).toFixed(2)); }
+      catch (e) { times.push(`ERR: ${e.message}`); }
+      await sh.close();
+    }
+    results[name] = times;
+  }
+  console.log(JSON.stringify(results, null, 2));
+}
+run();
+```
+
+## Parallel Instance Benchmarks
+
+### Playwright — multi-context, multi-browser, multi-page
+
+```javascript
+// bench-parallel.mjs
+import { chromium } from 'playwright';
+
+async function benchParallel() {
+  const results = {};
+
+  // Multiple contexts (same browser, cookie-isolated)
+  let start = performance.now();
+  const browser = await chromium.launch({ headless: true });
+  const contexts = await Promise.all(Array.from({ length: 5 }, () => browser.newContext()));
+  await Promise.all(contexts.map(async ctx => {
+    const page = await ctx.newPage();
+    await page.goto('https://the-internet.herokuapp.com/login');
+  }));
+  results.multiContext = `${((performance.now() - start) / 1000).toFixed(2)}s (5 contexts)`;
+  await browser.close();
+
+  // Multiple browsers (full OS-level isolation)
+  start = performance.now();
+  const browsers = await Promise.all(Array.from({ length: 3 }, () => chromium.launch({ headless: true })));
+  await Promise.all(browsers.map(async b => {
+    const page = await b.newPage();
+    await page.goto('https://the-internet.herokuapp.com/');
+  }));
+  results.multiBrowser = `${((performance.now() - start) / 1000).toFixed(2)}s (3 browsers)`;
+  await Promise.all(browsers.map(b => b.close()));
+
+  // 10 parallel pages (shared context)
+  start = performance.now();
+  const b2 = await chromium.launch({ headless: true });
+  const ctx = await b2.newContext();
+  await Promise.all(Array.from({ length: 10 }, async () => {
+    const p = await ctx.newPage();
+    await p.goto('https://the-internet.herokuapp.com/');
+  }));
+  results.multiPage = `${((performance.now() - start) / 1000).toFixed(2)}s (10 pages)`;
+  await b2.close();
+
+  console.log(JSON.stringify(results, null, 2));
+}
+benchParallel();
+```
+
+### agent-browser — parallel sessions
+
+```bash
+# bench-parallel-ab.sh — agent-browser parallel sessions
+set -euo pipefail
+start=$(python3 -c 'import time; print(time.time())')
+agent-browser --session s1 open "https://the-internet.herokuapp.com/login" &
+agent-browser --session s2 open "https://the-internet.herokuapp.com/checkboxes" &
+agent-browser --session s3 open "https://the-internet.herokuapp.com/dropdown" &
+wait
+end=$(python3 -c 'import time; print(time.time())')
+echo "3 parallel sessions: $(python3 -c "print(f'{$end - $start:.2f}')")s"
+echo "s1: $(agent-browser --session s1 get url)"
+echo "s2: $(agent-browser --session s2 get url)"
+echo "s3: $(agent-browser --session s3 get url)"
+agent-browser --session s1 close; agent-browser --session s2 close; agent-browser --session s3 close
+```
+
+### Crawl4AI — sequential vs parallel
+
+```python
+# bench-parallel-crawl4ai.py
+import asyncio, time
+from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
+
+URLS = [
+    "https://the-internet.herokuapp.com/login",
+    "https://the-internet.herokuapp.com/checkboxes",
+    "https://the-internet.herokuapp.com/dropdown",
+    "https://the-internet.herokuapp.com/tables",
+    "https://the-internet.herokuapp.com/frames",
+]
+
+async def run():
+    browser_config = BrowserConfig(headless=True)
+    run_config = CrawlerRunConfig(screenshot=True)
+    start = time.time()
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        for url in URLS: await crawler.arun(url=url, config=run_config)
+    seq = time.time() - start
+    start = time.time()
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        await crawler.arun_many(urls=URLS, config=run_config)
+    par = time.time() - start
+    print(f"Sequential: {seq:.2f}s | Parallel: {par:.2f}s | Speedup: {seq/par:.1f}x")
+
+asyncio.run(run())
+```
+
+## Visual Verification Benchmark
+
+```javascript
+// bench-visual.mjs — Screenshot + AI analysis workflow timing
+import { chromium } from 'playwright';
+import fs from 'fs';
+
+const PAGES = [
+  { url: 'https://the-internet.herokuapp.com/login', expect: 'login form' },
+  { url: 'https://the-internet.herokuapp.com/tables', expect: 'data table' },
+  { url: 'https://the-internet.herokuapp.com/checkboxes', expect: 'checkboxes' },
+];
+
+async function benchVisual() {
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  for (const { url, expect: expected } of PAGES) {
+    const page = await browser.newPage();
+    const start = performance.now();
+    await page.goto(url);
+    await page.waitForLoadState('networkidle');
+    // WARNING: Do NOT use fullPage: true for AI vision — full-page captures can exceed 8000px, crashing the session
+    const screenshotPath = `/tmp/bench-visual-${Date.now()}.png`;
+    await page.screenshot({ path: screenshotPath });
+    const ariaSnapshot = await page.accessibility.snapshot();
+    const textContent = await page.evaluate(() => document.body.innerText.substring(0, 500));
+    const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+    results.push({
+      url, expected, elapsed: `${elapsed}s`,
+      screenshotSize: `${(fs.statSync(screenshotPath).size / 1024).toFixed(0)}KB`,
+      ariaNodes: ariaSnapshot?.children?.length || 0,
+      textPreview: textContent.substring(0, 100),
+    });
+    await page.close();
+  }
+  await browser.close();
+  console.log(JSON.stringify(results, null, 2));
+}
+benchVisual();
+```
+
+**Visual verification workflow**: Navigate → viewport screenshot (no `fullPage: true`) → ARIA snapshot → AI analyses both → decide next action.
+
+**Key metrics**: screenshot file size (token cost), ARIA node count, time to screenshot-ready, whether ARIA alone suffices vs needing vision.

--- a/.agents/tools/browser/browser-benchmark.md
+++ b/.agents/tools/browser/browser-benchmark.md
@@ -24,19 +24,21 @@ Run standardised benchmarks across all browser automation tools and update docum
 /browser-benchmark --update-docs
 ```
 
-## Test Suite
+## Test Matrix
 
-Run each test 3 times per tool, report median. All tests use `https://the-internet.herokuapp.com`.
+All tests use `https://the-internet.herokuapp.com`. Run each test 3 times per tool, report median.
 
-| Test | Playwright | dev-browser | agent-browser | Crawl4AI | Playwriter | Stagehand |
-|------|-----------|-------------|---------------|----------|------------|-----------|
-| Navigate + Screenshot | `page.goto()` + `page.screenshot()` | TSX via bun | `open` + `screenshot` | `arun(screenshot=True)` | CDP + `page.screenshot()` | `page.goto()` + `page.screenshot()` |
-| Form Fill (4 fields) | `page.fill()` x2 + `page.click()` | TSX fill/click | `fill` + `click` | N/A | CDP fill/click | `stagehand.act("fill...")` |
-| Data Extraction (5 items) | `page.$$eval()` | TSX `$$eval()` | `eval` CLI | `JsonCssExtractionStrategy` | CDP `$$eval()` | `stagehand.extract()` |
-| Multi-step (click+nav) | `page.click()` + `waitForURL()` | TSX click+wait | `click`+`wait`+`get url` | N/A | CDP click+wait | `stagehand.act("click...")` |
-| Reliability (3 runs) | Same as Navigate x3 | Same x3 | Same x3 | Same x3 | Same x3 | Same x3 |
+| Test | What it measures |
+|------|-----------------|
+| Navigate + Screenshot | Cold page load + render capture |
+| Form Fill (4 fields) | Input interaction + submit + navigation |
+| Data Extraction (5 rows) | DOM query + structured data return |
+| Multi-step (click + nav) | Sequential interaction + URL change |
+| Reliability (3 runs) | Variance across repeated Navigate runs |
 
-## Prerequisites Check
+**Tool coverage:** Playwright (full), dev-browser (full), agent-browser (full), Crawl4AI (navigate + extract only), Stagehand (full, AI-dependent latency). Playwriter requires manual extension activation — may skip in automated runs.
+
+## Prerequisites
 
 ```bash
 #!/bin/bash
@@ -71,277 +73,12 @@ npx playwriter --version &>/dev/null 2>&1 && echo "[!!] Playwriter (needs extens
   echo "[--] Stagehand (run: mkdir -p ~/.aidevops/stagehand-bench && cd ~/.aidevops/stagehand-bench && npm init -y && npm i @browserbasehq/stagehand)"
 ```
 
-## Benchmark Scripts
+## Running Benchmarks
 
-### Playwright
-
-```javascript
-// ~/.aidevops/.agent-workspace/work/browser-bench/bench-playwright.mjs
-import { chromium } from 'playwright';
-
-const TESTS = {
-  async navigate(page) {
-    await page.goto('https://the-internet.herokuapp.com/');
-    await page.screenshot({ path: '/tmp/bench-pw-nav.png' });
-  },
-  async formFill(page) {
-    await page.goto('https://the-internet.herokuapp.com/login');
-    await page.fill('#username', 'tomsmith');
-    await page.fill('#password', 'SuperSecretPassword!');
-    await page.click('button[type="submit"]');
-    await page.waitForURL('**/secure');
-  },
-  async extract(page) {
-    await page.goto('https://the-internet.herokuapp.com/challenging_dom');
-    const rows = await page.$$eval('table tbody tr', trs => trs.slice(0, 5).map(tr => tr.textContent.trim()));
-    if (rows.length < 5) throw new Error('Expected 5+ rows');
-  },
-  async multiStep(page) {
-    await page.goto('https://the-internet.herokuapp.com/');
-    await page.click('a[href="/abtest"]');
-    await page.waitForURL('**/abtest');
-    const title = await page.title();
-    if (!title) throw new Error('No title on target page');
-  }
-};
-
-async function run() {
-  const browser = await chromium.launch({ headless: true });
-  const results = {};
-  for (const [name, fn] of Object.entries(TESTS)) {
-    const times = [];
-    for (let i = 0; i < 3; i++) {
-      const page = await browser.newPage();
-      const start = performance.now();
-      try { await fn(page); times.push(((performance.now() - start) / 1000).toFixed(2)); }
-      catch (e) { times.push(`ERR: ${e.message}`); }
-      await page.close();
-    }
-    results[name] = times;
-  }
-  await browser.close();
-  console.log(JSON.stringify(results, null, 2));
-}
-run();
-```
-
-### dev-browser
-
-```typescript
-// Run via: cd ~/.aidevops/dev-browser/skills/dev-browser && bun x tsx bench.ts
-import { connect, waitForPageLoad } from "@/client.js";
-import type { Page } from "playwright";
-
-const TESTS = {
-  async navigate(page: Page) {
-    await page.goto('https://the-internet.herokuapp.com/');
-    await waitForPageLoad(page);
-    await page.screenshot({ path: '/tmp/bench-dev-nav.png' });
-  },
-  async formFill(page: Page) {
-    await page.goto('https://the-internet.herokuapp.com/login');
-    await waitForPageLoad(page);
-    await page.fill('#username', 'tomsmith');
-    await page.fill('#password', 'SuperSecretPassword!');
-    await page.click('button[type="submit"]');
-    await page.waitForURL('**/secure');
-  },
-  async extract(page: Page) {
-    await page.goto('https://the-internet.herokuapp.com/challenging_dom');
-    await waitForPageLoad(page);
-    const rows = await page.$$eval('table tbody tr', (trs: Element[]) =>
-      trs.slice(0, 5).map(tr => tr.textContent?.trim() ?? ''));
-    if (rows.length < 5) throw new Error('Expected 5+ rows');
-  },
-  async multiStep(page: Page) {
-    await page.goto('https://the-internet.herokuapp.com/');
-    await waitForPageLoad(page);
-    await page.click('a[href="/abtest"]');
-    await page.waitForURL('**/abtest');
-  }
-};
-
-async function run() {
-  const client = await connect("http://localhost:9222");
-  const results: Record<string, string[]> = {};
-  for (const [name, fn] of Object.entries(TESTS)) {
-    const times: string[] = [];
-    for (let i = 0; i < 3; i++) {
-      const page = await client.page("bench");
-      const start = performance.now();
-      try { await fn(page); times.push(((performance.now() - start) / 1000).toFixed(2)); }
-      catch (e: any) { times.push(`ERR: ${e.message}`); }
-    }
-    results[name] = times;
-  }
-  await client.disconnect();
-  console.log(JSON.stringify(results, null, 2));
-}
-run();
-```
-
-### agent-browser
+Scripts live in `~/.aidevops/.agent-workspace/work/browser-bench/`. Full source: `browser-benchmark-scripts.md`.
 
 ```bash
-#!/bin/bash
-# bench-agent-browser.sh
-set -euo pipefail
-
-bench_navigate() {
-  local start end
-  start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/"
-  agent-browser screenshot /tmp/bench-ab-nav.png
-  end=$(python3 -c 'import time; print(time.time())')
-  python3 -c "print(f'{$end - $start:.2f}')"
-  agent-browser close
-}
-
-bench_formFill() {
-  local start end
-  start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/login"
-  agent-browser snapshot -i
-  agent-browser fill '@username' 'tomsmith'
-  agent-browser fill '@password' 'SuperSecretPassword!'
-  agent-browser click '@submit'
-  agent-browser wait --url '**/secure'
-  end=$(python3 -c 'import time; print(time.time())')
-  python3 -c "print(f'{$end - $start:.2f}')"
-  agent-browser close
-}
-
-bench_extract() {
-  local start end
-  start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/challenging_dom"
-  agent-browser eval "JSON.stringify([...document.querySelectorAll('table tbody tr')].slice(0,5).map(r=>r.textContent.trim()))"
-  end=$(python3 -c 'import time; print(time.time())')
-  python3 -c "print(f'{$end - $start:.2f}')"
-  agent-browser close
-}
-
-bench_multiStep() {
-  local start end
-  start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/"
-  agent-browser click 'a[href="/abtest"]'
-  agent-browser wait --url '**/abtest'
-  agent-browser get url
-  end=$(python3 -c 'import time; print(time.time())')
-  python3 -c "print(f'{$end - $start:.2f}')"
-  agent-browser close
-}
-
-echo "=== agent-browser Benchmark ==="
-for test in navigate formFill extract multiStep; do
-  echo -n "$test: "
-  for i in 1 2 3; do echo -n "$(bench_"$test")s "; done
-  echo ""
-done
-```
-
-### Crawl4AI
-
-```python
-# ~/.aidevops/.agent-workspace/work/browser-bench/bench-crawl4ai.py
-# Run: source ~/.aidevops/crawl4ai-venv/bin/activate && python bench-crawl4ai.py
-import asyncio, time, json
-from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
-from crawl4ai.extraction_strategy import JsonCssExtractionStrategy
-
-BROWSER_CONFIG = BrowserConfig(headless=True)
-
-async def bench_navigate():
-    async with AsyncWebCrawler(config=BROWSER_CONFIG) as crawler:
-        start = time.time()
-        result = await crawler.arun(url="https://the-internet.herokuapp.com/", config=CrawlerRunConfig(screenshot=True))
-        assert result.success, f"Failed: {result.error_message}"
-        return f"{time.time() - start:.2f}"
-
-async def bench_extract():
-    schema = {"name": "TableRows", "baseSelector": "table tbody tr",
-              "fields": [{"name": "text", "selector": "td:first-child", "type": "text"}]}
-    async with AsyncWebCrawler(config=BROWSER_CONFIG) as crawler:
-        start = time.time()
-        result = await crawler.arun(
-            url="https://the-internet.herokuapp.com/challenging_dom",
-            config=CrawlerRunConfig(extraction_strategy=JsonCssExtractionStrategy(schema)))
-        assert result.success
-        data = json.loads(result.extracted_content)
-        assert len(data) >= 5, f"Expected 5+ rows, got {len(data)}"
-        return f"{time.time() - start:.2f}"
-
-async def run():
-    results = {}
-    for name, fn in [("navigate", bench_navigate), ("extract", bench_extract)]:
-        times = [await fn() for _ in range(3)]
-        results[name] = times
-    print(json.dumps(results, indent=2))
-
-asyncio.run(run())
-```
-
-### Stagehand
-
-```javascript
-// ~/.aidevops/.agent-workspace/work/browser-bench/bench-stagehand.mjs
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
-
-const TESTS = {
-  async navigate(sh) {
-    const page = sh.ctx.pages()[0];
-    await page.goto('https://the-internet.herokuapp.com/');
-    await page.screenshot({ path: '/tmp/bench-sh-nav.png' });
-  },
-  async formFill(sh) {
-    const page = sh.ctx.pages()[0];
-    await page.goto('https://the-internet.herokuapp.com/login');
-    await sh.act("fill the username field with tomsmith");
-    await sh.act("fill the password field with SuperSecretPassword!");
-    await sh.act("click the Login button");
-  },
-  async extract(sh) {
-    const page = sh.ctx.pages()[0];
-    await page.goto('https://the-internet.herokuapp.com/challenging_dom');
-    const data = await sh.extract("extract the first 5 rows from the table",
-      z.object({ rows: z.array(z.object({ text: z.string() })) }));
-    if (data.rows.length < 5) throw new Error('Expected 5+ rows');
-  },
-  async multiStep(sh) {
-    const page = sh.ctx.pages()[0];
-    await page.goto('https://the-internet.herokuapp.com/');
-    await sh.act("click the A/B Testing link");
-    await page.waitForURL('**/abtest');
-  }
-};
-
-async function run() {
-  const results = {};
-  for (const [name, fn] of Object.entries(TESTS)) {
-    const times = [];
-    for (let i = 0; i < 3; i++) {
-      const sh = new Stagehand({ env: "LOCAL", headless: true, verbose: 0 });
-      await sh.init();
-      const start = performance.now();
-      try { await fn(sh); times.push(((performance.now() - start) / 1000).toFixed(2)); }
-      catch (e) { times.push(`ERR: ${e.message}`); }
-      await sh.close();
-    }
-    results[name] = times;
-  }
-  console.log(JSON.stringify(results, null, 2));
-}
-run();
-```
-
-## Running the Full Suite
-
-```bash
-# 1. Check prerequisites
-bash bench-prereqs.sh
-
+# 1. Check prerequisites (above)
 # 2. Run each tool
 cd ~/.aidevops/.agent-workspace/work/browser-bench/
 node bench-playwright.mjs | tee results-playwright.json
@@ -349,10 +86,16 @@ cd ~/.aidevops/dev-browser/skills/dev-browser && bun x tsx bench.ts | tee ~/resu
 bash bench-agent-browser.sh | tee results-agent-browser.txt
 source ~/.aidevops/crawl4ai-venv/bin/activate && python bench-crawl4ai.py | tee results-crawl4ai.json
 OPENAI_API_KEY=... node bench-stagehand.mjs | tee results-stagehand.json
-
-# 3. Compile results table
-echo "Done. Compare results and update browser-automation.md benchmarks table."
+# 3. Compile results and update browser-automation.md
 ```
+
+## Interpreting Results
+
+- **Cold start**: First agent-browser run is slower (daemon startup) — discard or note separately
+- **Network variance**: Times vary ~0.2-0.5s — use median of 3
+- **Stagehand API latency**: Depends on OpenAI/Anthropic response time — note model used
+- **Crawl4AI**: Cannot do form fill or multi-step (extraction only)
+- **Playwriter**: Requires manual extension activation — may skip in automated runs
 
 ## Updating Documentation
 
@@ -372,155 +115,11 @@ echo "Bun: $(bun --version 2>/dev/null || echo 'N/A')"
 echo "Python: $(python3 --version)"
 ```
 
-## Interpreting Results
-
-- **Cold start**: First agent-browser run is slower (daemon startup) — discard or note separately
-- **Network variance**: Times vary ~0.2-0.5s — use median of 3
-- **Stagehand API latency**: Depends on OpenAI/Anthropic response time — note model used
-- **Crawl4AI**: Cannot do form fill or multi-step (extraction only)
-- **Playwriter**: Requires manual extension activation — may skip in automated runs
-
-## Parallel Instance Benchmarks
-
-```javascript
-// bench-parallel.mjs
-import { chromium } from 'playwright';
-
-async function benchParallel() {
-  const results = {};
-
-  // Multiple contexts (same browser, cookie-isolated)
-  let start = performance.now();
-  const browser = await chromium.launch({ headless: true });
-  const contexts = await Promise.all(Array.from({ length: 5 }, () => browser.newContext()));
-  await Promise.all(contexts.map(async ctx => {
-    const page = await ctx.newPage();
-    await page.goto('https://the-internet.herokuapp.com/login');
-  }));
-  results.multiContext = `${((performance.now() - start) / 1000).toFixed(2)}s (5 contexts)`;
-  await browser.close();
-
-  // Multiple browsers (full OS-level isolation)
-  start = performance.now();
-  const browsers = await Promise.all(Array.from({ length: 3 }, () => chromium.launch({ headless: true })));
-  await Promise.all(browsers.map(async b => {
-    const page = await b.newPage();
-    await page.goto('https://the-internet.herokuapp.com/');
-  }));
-  results.multiBrowser = `${((performance.now() - start) / 1000).toFixed(2)}s (3 browsers)`;
-  await Promise.all(browsers.map(b => b.close()));
-
-  // 10 parallel pages (shared context)
-  start = performance.now();
-  const b2 = await chromium.launch({ headless: true });
-  const ctx = await b2.newContext();
-  await Promise.all(Array.from({ length: 10 }, async () => {
-    const p = await ctx.newPage();
-    await p.goto('https://the-internet.herokuapp.com/');
-  }));
-  results.multiPage = `${((performance.now() - start) / 1000).toFixed(2)}s (10 pages)`;
-  await b2.close();
-
-  console.log(JSON.stringify(results, null, 2));
-}
-benchParallel();
-```
-
-```bash
-# bench-parallel-ab.sh — agent-browser parallel sessions
-set -euo pipefail
-start=$(python3 -c 'import time; print(time.time())')
-agent-browser --session s1 open "https://the-internet.herokuapp.com/login" &
-agent-browser --session s2 open "https://the-internet.herokuapp.com/checkboxes" &
-agent-browser --session s3 open "https://the-internet.herokuapp.com/dropdown" &
-wait
-end=$(python3 -c 'import time; print(time.time())')
-echo "3 parallel sessions: $(python3 -c "print(f'{$end - $start:.2f}')")s"
-echo "s1: $(agent-browser --session s1 get url)"
-echo "s2: $(agent-browser --session s2 get url)"
-echo "s3: $(agent-browser --session s3 get url)"
-agent-browser --session s1 close; agent-browser --session s2 close; agent-browser --session s3 close
-```
-
-```python
-# bench-parallel-crawl4ai.py
-import asyncio, time
-from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
-
-URLS = [
-    "https://the-internet.herokuapp.com/login",
-    "https://the-internet.herokuapp.com/checkboxes",
-    "https://the-internet.herokuapp.com/dropdown",
-    "https://the-internet.herokuapp.com/tables",
-    "https://the-internet.herokuapp.com/frames",
-]
-
-async def run():
-    browser_config = BrowserConfig(headless=True)
-    run_config = CrawlerRunConfig(screenshot=True)
-    start = time.time()
-    async with AsyncWebCrawler(config=browser_config) as crawler:
-        for url in URLS: await crawler.arun(url=url, config=run_config)
-    seq = time.time() - start
-    start = time.time()
-    async with AsyncWebCrawler(config=browser_config) as crawler:
-        await crawler.arun_many(urls=URLS, config=run_config)
-    par = time.time() - start
-    print(f"Sequential: {seq:.2f}s | Parallel: {par:.2f}s | Speedup: {seq/par:.1f}x")
-
-asyncio.run(run())
-```
-
-## Visual Verification Benchmark
-
-```javascript
-// bench-visual.mjs — Screenshot + AI analysis workflow timing
-import { chromium } from 'playwright';
-import fs from 'fs';
-
-const PAGES = [
-  { url: 'https://the-internet.herokuapp.com/login', expect: 'login form' },
-  { url: 'https://the-internet.herokuapp.com/tables', expect: 'data table' },
-  { url: 'https://the-internet.herokuapp.com/checkboxes', expect: 'checkboxes' },
-];
-
-async function benchVisual() {
-  const browser = await chromium.launch({ headless: true });
-  const results = [];
-  for (const { url, expect: expected } of PAGES) {
-    const page = await browser.newPage();
-    const start = performance.now();
-    await page.goto(url);
-    await page.waitForLoadState('networkidle');
-    // WARNING: Do NOT use fullPage: true for AI vision — full-page captures can exceed 8000px, crashing the session
-    const screenshotPath = `/tmp/bench-visual-${Date.now()}.png`;
-    await page.screenshot({ path: screenshotPath });
-    const ariaSnapshot = await page.accessibility.snapshot();
-    const textContent = await page.evaluate(() => document.body.innerText.substring(0, 500));
-    const elapsed = ((performance.now() - start) / 1000).toFixed(2);
-    results.push({
-      url, expected, elapsed: `${elapsed}s`,
-      screenshotSize: `${(fs.statSync(screenshotPath).size / 1024).toFixed(0)}KB`,
-      ariaNodes: ariaSnapshot?.children?.length || 0,
-      textPreview: textContent.substring(0, 100),
-    });
-    await page.close();
-  }
-  await browser.close();
-  console.log(JSON.stringify(results, null, 2));
-}
-benchVisual();
-```
-
-**Visual verification workflow**: Navigate → viewport screenshot (no `fullPage: true`) → ARIA snapshot → AI analyses both → decide next action.
-
-**Key metrics**: screenshot file size (token cost), ARIA node count, time to screenshot-ready, whether ARIA alone suffices vs needing vision.
-
 ## Adding New Tools
 
-1. Add a benchmark script following the patterns above
-2. Add the tool to the prerequisites check
+1. Add a benchmark script following the patterns in `browser-benchmark-scripts.md`
+2. Add the tool to the prerequisites check (above)
 3. Run the full suite including the new tool
 4. Update `browser-automation.md` tables (Performance, Feature Matrix, Parallel, Extensions)
-5. Update this file's test methods table
+5. Update this file's test matrix
 6. Test parallel capabilities, extension support, and visual verification


### PR DESCRIPTION
## Summary

- Split `browser-benchmark.md` (526 lines) into a concise orchestration guide (125 lines, **76% reduction**) + a `browser-benchmark-scripts.md` sub-doc (408 lines) containing all benchmark scripts
- Parent file now focuses on: test matrix, prerequisites check, run instructions, result interpretation, and doc update workflow
- Scripts sub-doc preserves all code blocks verbatim: Playwright, dev-browser, agent-browser, Crawl4AI, Stagehand, parallel benchmarks, and visual verification

## What changed

| File | Before | After | Change |
|------|--------|-------|--------|
| `browser-benchmark.md` | 526 lines | 125 lines | -76% (orchestration guide) |
| `browser-benchmark-scripts.md` | — | 408 lines | New (extracted scripts) |

## Content preservation verified

- All 33 URLs preserved across both files
- All code blocks preserved verbatim (9 scripts)
- All external references valid (`browser-automation.md`, `playwright-emulation.md`, `crawl4ai.md` all reference `browser-benchmark.md` by unchanged path)
- `fullPage: true` warning preserved in visual benchmark script
- Zero markdownlint violations

## Design rationale

The original file was 90% code blocks (benchmark scripts) with thin orchestration prose between them. An agent reading this file to understand *how to run benchmarks* had to scan past ~400 lines of scripts to find the 5-line interpretation guide. Progressive disclosure (pointer from parent → scripts sub-doc) matches the `build-agent.md` guidance and improves signal density for the common read path.

Closes #6444