### PR TITLE
docs: tighten wp-dev.md from 567→465 lines (36% reduction from original 724)

### DIFF
--- a/.agents/tools/wordpress/wp-dev.md
+++ b/.agents/tools/wordpress/wp-dev.md
@@ -21,54 +21,18 @@ tools:
 
 ## Quick Reference
 
-- **Plugin/Theme Dev**: `~/Git/wordpress/{slug}` for analysis, `{slug}-fix` for patches
-- **MCP Adapter Repo**: `~/Git/wordpress/mcp-adapter`
-- **Local Sites**: `~/Local Sites/`
-- **Sites Config**: `~/.config/aidevops/wordpress-sites.json`
-- **Working Dir**: `~/.aidevops/.agent-workspace/work/wordpress/`
-- **Preferred Plugins**: See `wp-preferred.md` for curated recommendations
+| Path | Purpose |
+|------|---------|
+| `~/Git/wordpress/{slug}` | Plugin/theme analysis; `{slug}-fix` for patches |
+| `~/Git/wordpress/mcp-adapter` | MCP Adapter repo |
+| `~/Local Sites/` | LocalWP sites |
+| `~/.config/aidevops/wordpress-sites.json` | Sites config |
+| `~/.aidevops/.agent-workspace/work/wordpress/` | Working dir |
+| `wp-preferred.md` | Curated plugin recommendations |
 
-**Plugin/Theme Workflow**:
-- Clone to `~/Git/wordpress/{slug}/` for analysis
-- Fork + PR for open-source contributions
-- Create `{slug}-fix/` or `{slug}-addon/` for pro plugin patches (survives updates)
+**Prerequisites**: `php -v` (>= 7.4), `composer -V`, `wp --version`, `node -v` (>= 18)
 
-**Dependency Checks** (run first):
-
-```bash
-php -v          # >= 7.4
-composer -V     # Package manager
-wp --version    # WP-CLI
-node -v         # >= 18 (for HTTP transport, wp-env, Playground)
-```
-
-**WordPress MCP Adapter**:
-- STDIO: `wp mcp-adapter serve --server=mcp-adapter-default-server --user=admin`
-- HTTP: `npx @automattic/mcp-wordpress-remote`
-- Requires: WordPress Abilities API plugin
-
-**Testing Environments**:
-
-| Environment | Best For | Command |
-|-------------|----------|---------|
-| WordPress Playground | Quick testing | `npx @wp-playground/cli server` |
-| LocalWP | Full development | Open Local.app |
-| wp-env | CI/CD, PHPUnit | `wp-env start` |
-
-**Related Subagents**:
-- `@localwp` - Database inspection during debugging
-- `@wp-admin` - Content/maintenance tasks (hand off)
-- `@browser-automation` - E2E testing with Playwright
-- `@code-standards` - PHP/JS code quality checks
-
-**Related Workflows** (in .agents/workflows/):
-- `bug-fixing.md` - Systematic debugging approach
-- `code-review.md` - Code review checklist
-- `git-workflow.md` - Branching for features/fixes
-- `release-process.md` - Plugin/theme releases
-- `error-checking-feedback-loops.md` - CI/CD error resolution
-
-**Always use Context7** for latest WordPress/WP-CLI/PHP documentation.
+**Subagents**: `@localwp` (DB), `@wp-admin` (content), `@browser-automation` (E2E), `@code-standards` (quality). **Always use Context7** for latest WP/WP-CLI/PHP docs.
 
 <!-- AI-CONTEXT-END -->
 
@@ -80,33 +44,19 @@ brew install php@8.2 composer wp-cli node
 
 ## Composer-Based WordPress (Bedrock)
 
-For projects that manage WordPress as a Composer project (e.g., [Bedrock](https://roots.io/bedrock/)), use [WP Composer](https://wp-composer.com/) as the Composer repository for plugins and themes. It is the preferred alternative to WPackagist (which was acquired by WP Engine in March 2024).
-
-**Setup:**
+For Bedrock-style projects, use [WP Composer](https://wp-composer.com/) as the Composer repository (preferred over WPackagist, acquired by WP Engine March 2024). Package naming: `wp-plugin/{slug}`, `wp-theme/{slug}`. Not applicable to traditional WP-CLI/admin-managed installations.
 
 ```bash
 composer config repositories.wp-composer composer https://repo.wp-composer.com
 ```
 
-**Package naming:** `wp-plugin/{slug}` for plugins, `wp-theme/{slug}` for themes.
-
-**When to use:** Bedrock-style projects where `wp-content` is managed via `composer.json` and the entire site is version-controlled. Not applicable to traditional WordPress installations where plugins are managed via WP-CLI or the admin dashboard (e.g., Closte-hosted sites).
-
-**Migration from WPackagist:** See [migration guide](https://wp-composer.com/wp-composer-vs-wpackagist) or use the [migration script](https://github.com/roots/wp-composer/blob/main/scripts/migrate-from-wpackagist.sh).
+Migration: [guide](https://wp-composer.com/wp-composer-vs-wpackagist) | [script](https://github.com/roots/wp-composer/blob/main/scripts/migrate-from-wpackagist.sh)
 
 ## WordPress MCP Adapter
 
-The official WordPress MCP Adapter enables AI interaction with WordPress sites.
+Official AI interaction with WordPress sites. Requires WordPress Abilities API plugin. Repo: `~/git/wordpress/mcp-adapter` (update: `cd ~/git/wordpress/mcp-adapter && git pull`).
 
-```bash
-# Clone location (already cloned)
-~/git/wordpress/mcp-adapter
-
-# Update to latest
-cd ~/git/wordpress/mcp-adapter && git pull
-```
-
-### STDIO Transport (Local Development)
+**STDIO** (local):
 
 ```bash
 cd /path/to/wordpress
@@ -115,7 +65,7 @@ wp plugin activate mcp-adapter
 wp mcp-adapter serve --server=mcp-adapter-default-server --user=admin
 ```
 
-### HTTP Transport (Remote Sites)
+**HTTP** (remote):
 
 ```bash
 npx @automattic/mcp-wordpress-remote
@@ -125,26 +75,29 @@ export WP_API_USERNAME="your-username"
 export WP_API_PASSWORD="your-application-password"
 ```
 
-### Application Passwords
-
-For HTTP transport, create an Application Password:
-
-1. WordPress Admin → Users → Your Profile
-2. Scroll to "Application Passwords"
-3. Enter name: `mcp-adapter-dev`
-4. Click "Add New Application Password"
-5. Store securely: `setup-local-api-keys.sh set wp-app-password-sitename "xxxx xxxx xxxx xxxx"`
+**Application Passwords** (for HTTP): WordPress Admin > Users > Profile > "Application Passwords" > name `mcp-adapter-dev` > store via `setup-local-api-keys.sh set wp-app-password-sitename "xxxx xxxx xxxx xxxx"`
 
 ## Testing Environments
 
-### WordPress Playground (Quick Testing)
+| Feature | Playground | LocalWP | wp-env |
+|---------|------------|---------|--------|
+| Setup Time | Instant | 5-10 min | 2-5 min |
+| Persistence | None | Full | Partial |
+| PHP Versions | Limited | Many | Configurable |
+| Database | In-memory | MySQL | MySQL |
+| Docker Required | No | No | Yes |
+| GitHub Actions | Works* | N/A | Works |
+| Best For | Quick testing | Full dev | CI/Testing |
+
+*Playground may be flaky in CI environments
+
+### WordPress Playground
 
 ```bash
-npm install -g @wp-playground/cli
 npx @wp-playground/cli server --port=8888 --blueprint=blueprint.json
 ```
 
-**Blueprint Example** (`blueprint.json`):
+**Blueprint** (`blueprint.json`):
 
 ```json
 {
@@ -192,45 +145,19 @@ npx @wp-playground/cli server --port=8888 --blueprint=blueprint.json
 }
 ```
 
-### LocalWP (Full Development)
+### LocalWP
+
+Sites: `~/Local Sites/`. WP-CLI path: `/Applications/Local.app/Contents/Resources/extraResources/bin/wp-cli.phar`
 
 ```bash
-# Default sites location
-~/Local Sites/
-
-# WP-CLI with LocalWP
 cd "~/Local Sites/site-name/app/public"
 wp plugin list
-wp option get siteurl
-
-# LocalWP's WP-CLI path
-/Applications/Local.app/Contents/Resources/extraResources/bin/wp-cli.phar
-```
-
-**Plugin Sync Script** (`bin/localwp-sync.sh`):
-
-```bash
-#!/bin/bash
-PLUGIN_SLUG="your-plugin-slug"
-SITE_NAME="project-name"
-PLUGIN_DIR="$HOME/Local Sites/$SITE_NAME/app/public/wp-content/plugins/$PLUGIN_SLUG"
-
-rsync -av --delete \
-  --exclude='node_modules' \
-  --exclude='vendor' \
-  --exclude='tests' \
-  --exclude='.git' \
-  ./ "$PLUGIN_DIR/"
-
-echo "Plugin synced to LocalWP"
 ```
 
 ### wp-env (Docker/CI)
 
 ```bash
-npm install -g @wordpress/env
-wp-env start
-wp-env stop
+wp-env start                          # npm install -g @wordpress/env
 wp-env run cli wp plugin list
 wp-env run tests-cli phpunit
 ```
@@ -242,60 +169,36 @@ wp-env run tests-cli phpunit
   "core": "WordPress/WordPress#6.4",
   "phpVersion": "8.1",
   "plugins": [".", "https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip"],
-  "config": {
-    "WP_DEBUG": true,
-    "WP_DEBUG_LOG": true,
-    "SCRIPT_DEBUG": true
-  }
+  "config": { "WP_DEBUG": true, "WP_DEBUG_LOG": true, "SCRIPT_DEBUG": true }
 }
 ```
 
-**Multisite** (`.wp-env.json`):
+**Multisite** — add to `config`:
 
 ```json
 {
-  "core": "WordPress/WordPress#6.4",
-  "phpVersion": "8.1",
-  "plugins": ["."],
-  "config": {
-    "WP_DEBUG": true,
-    "WP_ALLOW_MULTISITE": true,
-    "MULTISITE": true,
-    "SUBDOMAIN_INSTALL": false,
-    "DOMAIN_CURRENT_SITE": "localhost",
-    "PATH_CURRENT_SITE": "/",
-    "SITE_ID_CURRENT_SITE": 1,
-    "BLOG_ID_CURRENT_SITE": 1
-  }
+  "WP_ALLOW_MULTISITE": true,
+  "MULTISITE": true,
+  "SUBDOMAIN_INSTALL": false,
+  "DOMAIN_CURRENT_SITE": "localhost",
+  "PATH_CURRENT_SITE": "/",
+  "SITE_ID_CURRENT_SITE": 1,
+  "BLOG_ID_CURRENT_SITE": 1
 }
 ```
 
 ## Theme Development
 
-### Theme Structure (Block Theme)
+### Block Theme Structure (FSE)
 
 ```text
 theme-name/
 ├── style.css              # Theme metadata
 ├── theme.json             # Global settings
 ├── functions.php          # Theme functions
-├── templates/             # Block templates
-│   ├── index.html
-│   ├── single.html
-│   ├── page.html
-│   └── archive.html
-├── parts/                 # Template parts
-│   ├── header.html
-│   └── footer.html
+├── templates/             # Block templates (index, single, page, archive)
+├── parts/                 # Template parts (header, footer)
 └── patterns/              # Block patterns
-    └── hero.php
-```
-
-### Theme Scaffolding
-
-```bash
-wp scaffold theme theme-name --theme_name="Theme Name" --activate
-wp scaffold child-theme kadence-child --parent_theme=kadence --activate
 ```
 
 ### Template Hierarchy
@@ -312,29 +215,17 @@ is_404()         → 404.html → index.html
 
 ## Plugin Development
 
-### Plugin Scaffolding
-
-```bash
-wp scaffold plugin my-plugin --plugin_name="My Plugin" --activate
-wp scaffold post-type book --plugin=my-plugin
-wp scaffold block my-block --plugin=my-plugin
-```
-
 ### Plugin Header
 
 ```php
 <?php
 /**
  * Plugin Name: My Plugin
- * Plugin URI: https://example.com/my-plugin
  * Description: Plugin description
  * Version: 1.0.0
  * Author: Your Name
- * Author URI: https://example.com
  * License: GPL-2.0+
- * License URI: https://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain: my-plugin
- * Domain Path: /languages
  * Requires at least: 6.0
  * Requires PHP: 7.4
  */
@@ -359,60 +250,31 @@ $value = apply_filters('my_plugin_value', $default);
 
 ## Plugin & Theme Analysis Workflow
 
-### Local Development Directory
+All plugin/theme work lives under `~/Git/wordpress/`:
 
-```text
-~/Git/wordpress/
-├── {plugin-slug}/              # Cloned plugin for analysis/patching
-├── {plugin-slug}-addon/        # Custom addon for pro/closed plugins
-├── {plugin-slug}-fix/          # Patches that survive updates
-├── {theme-slug}/               # Cloned theme
-└── {theme-slug}-child/         # Child theme customizations
-```
+| Suffix | Purpose | Example |
+|--------|---------|---------|
+| `{slug}` | Clone for analysis or open-source fork | `readabler`, `flavor` |
+| `{slug}-addon` | Custom addon for pro/closed plugins | `kadence-blocks-addon` |
+| `{slug}-fix` | Patches that survive updates | `media-file-renamer-fix` |
+| `{slug}-child` | Child theme customizations | `kadence-child` |
 
-### Naming Conventions
-
-| Scenario | Folder Name | Example |
-|----------|-------------|---------|
-| Cloned for analysis | `{slug}` | `readabler` |
-| Open source fork | `{slug}` | `flavor` (your fork) |
-| Addon for pro plugin | `{slug}-addon` | `kadence-blocks-addon` |
-| Fix/patch plugin | `{slug}-fix` | `media-file-renamer-fix` |
-| Child theme | `{slug}-child` | `kadence-child` |
-
-### Workflow: Analyzing a Plugin/Theme
+### Analyzing a Plugin/Theme
 
 ```bash
 cd ~/Git/wordpress
 git clone https://github.com/developer/plugin-slug.git
-
-# Or extract from zip (for pro plugins)
+# Or extract from zip (for pro plugins):
 unzip ~/Downloads/plugin-name.zip -d ~/Git/wordpress/
-cd ~/Git/wordpress/plugin-slug
-git init && git add . && git commit -m "Initial import of plugin-slug v1.0.0"
+cd ~/Git/wordpress/plugin-slug && git init && git add . && git commit -m "Initial import v1.0.0"
 
-# Analyze
 rg "add_action|add_filter" --type php .
 
-# Test in LocalWP
+# Symlink into LocalWP for testing
 ln -s ~/Git/wordpress/plugin-slug "~/Local Sites/test-site/app/public/wp-content/plugins/"
 ```
 
-### Workflow: Contributing to Open Source
-
-```bash
-cd ~/Git/wordpress
-git clone git@github.com:marcusquinn/plugin-slug.git
-cd plugin-slug
-git remote add upstream https://github.com/original/plugin-slug.git
-git checkout -b fix/issue-description
-# make changes
-git add . && git commit -m "fix: description of the fix"
-git push origin fix/issue-description
-# Create PR on GitHub
-```
-
-### Workflow: Patching Pro/Closed Plugins
+### Patching Pro/Closed Plugins
 
 Create a companion plugin that survives updates:
 
@@ -420,7 +282,7 @@ Create a companion plugin that survives updates:
 <?php
 /**
  * Plugin Name: Plugin Slug Fix
- * Description: Patches and fixes for Plugin Slug that survive updates
+ * Description: Patches for Plugin Slug that survive updates
  * Version: 1.0.0
  * Requires Plugins: plugin-slug
  */
@@ -428,68 +290,26 @@ Create a companion plugin that survives updates:
 add_action('plugins_loaded', 'plugin_slug_fix_init', 20);
 
 function plugin_slug_fix_init() {
-    if (!class_exists('Original_Plugin_Class')) {
-        return;
-    }
-
-    // Remove problematic hook
+    if (!class_exists('Original_Plugin_Class')) { return; }
     remove_action('init', 'original_problematic_function');
-
-    // Add fixed version
     add_action('init', 'fixed_function');
 }
 
-function fixed_function() {
-    // Your fixed implementation
-}
-```
+function fixed_function() { /* fixed implementation */ }
 
-For filter overrides:
-
-```php
 // Override a filter with higher priority
 add_filter('original_filter', 'my_fixed_filter', 999);
-
-function my_fixed_filter($value) {
-    // Your fixed logic
-    return $modified_value;
-}
+function my_fixed_filter($value) { return $modified_value; }
 ```
 
-### Best Practices for Fix Plugins
-
-1. **Always check if original plugin exists**: `if (!function_exists('original_function')) { return; }`
-2. **Use appropriate hook priority**: Lower = runs earlier, higher = runs later (default 10)
-3. **Document what you're fixing** with issue URL and affected versions
-4. **Version compatibility checks**: `version_compare(ORIGINAL_PLUGIN_VERSION, '2.4.0', '<')`
-5. **Keep fixes minimal**: One fix per function/hook, use hooks/filters when possible
+**Best practices**: (1) Guard with `class_exists`/`function_exists`. (2) Use priority > 10 to run after original. (3) Document the issue URL and affected versions. (4) Version-gate if needed: `version_compare(ORIGINAL_PLUGIN_VERSION, '2.4.0', '<')`.
 
 ### Syncing with LocalWP
 
 ```bash
-cat > ~/Git/wordpress/sync-to-local.sh << 'EOF'
-#!/bin/bash
-PLUGIN_SLUG="$1"
-SITE_NAME="${2:-test-site}"
-
-if [ -z "$PLUGIN_SLUG" ]; then
-    echo "Usage: sync-to-local.sh plugin-slug [site-name]"
-    exit 1
-fi
-
-rsync -av --delete \
-    --exclude='.git' \
-    --exclude='node_modules' \
-    --exclude='vendor' \
-    "$HOME/Git/wordpress/$PLUGIN_SLUG/" \
-    "$HOME/Local Sites/$SITE_NAME/app/public/wp-content/plugins/$PLUGIN_SLUG/"
-
-echo "Synced $PLUGIN_SLUG to $SITE_NAME"
-EOF
-chmod +x ~/Git/wordpress/sync-to-local.sh
-
-# Usage:
-~/Git/wordpress/sync-to-local.sh readabler-fix my-test-site
+rsync -av --delete --exclude='.git' --exclude='node_modules' --exclude='vendor' \
+    ~/Git/wordpress/plugin-slug/ \
+    "~/Local Sites/site-name/app/public/wp-content/plugins/plugin-slug/"
 ```
 
 ## Debugging
@@ -505,31 +325,19 @@ define('SCRIPT_DEBUG', true);      // Use non-minified scripts
 define('SAVEQUERIES', true);       // Log database queries
 ```
 
-### Debug Log Location
-
-```bash
-tail -f ~/Local\ Sites/site-name/app/public/wp-content/debug.log
-wp-env run cli tail -f /var/www/html/wp-content/debug.log
-```
+**Log locations**: `~/Local Sites/site-name/app/public/wp-content/debug.log` (LocalWP) or `wp-env run cli tail -f /var/www/html/wp-content/debug.log` (wp-env)
 
 ### Query Monitor
 
-Essential debugging plugin:
+Essential debugging plugin — shows DB queries, PHP errors, HTTP requests, hooks, template hierarchy, memory:
 
 ```bash
 wp plugin install query-monitor --activate
 ```
 
-Shows: database queries, PHP errors/warnings, HTTP requests, hooks and actions, template hierarchy, memory usage.
-
 ### OpenCode PHP LSP (Intelephense + WordPress)
 
-If WordPress symbols are unresolved in OpenCode (e.g., `add_action`, `WP_Query`, globals):
-
-1. Configure `~/.config/opencode/config.json` with an explicit Intelephense server and WordPress stubs.
-2. Ensure the `command` path points to the actual Intelephense binary installed for OpenCode.
-3. Restart the OpenCode session/LSP process after saving config changes.
-4. If diagnostics persist, clear/rebuild Intelephense cache and reindex the workspace.
+If WordPress symbols are unresolved in OpenCode (`add_action`, `WP_Query`, globals), configure `~/.config/opencode/config.json` with Intelephense + WordPress stubs, then restart the LSP process:
 
 ```json
 {
@@ -550,63 +358,41 @@ If WordPress symbols are unresolved in OpenCode (e.g., `add_action`, `WP_Query`,
 }
 ```
 
-Notes:
-- Use your local Intelephense path; do not assume `/home/USER/...` exists.
-- In OpenCode sessions, do not suggest Claude-specific commands such as `/lsp-restart`.
+Use your local Intelephense path (not `/home/USER/...`). If diagnostics persist, clear/rebuild cache. Do not suggest Claude-specific commands (e.g., `/lsp-restart`) in OpenCode sessions.
 
 ### Error Diagnosis Workflow
 
-1. **Enable debugging**: Set `WP_DEBUG` constants
-2. **Check debug.log**: Look for PHP errors/warnings
-3. **Use Query Monitor**: Check admin bar for issues
-4. **Inspect database**: Use `@localwp` for SQL access
-5. **Check hooks**: Use `wp hook list` or Query Monitor
-6. **Profile performance**: Use `wp profile` or Code Profiler Pro
+1. Enable `WP_DEBUG` constants → check `debug.log` → use Query Monitor
+2. Inspect database via `@localwp` → check hooks with `wp hook list`
+3. Profile performance with `wp profile` or Code Profiler Pro
 
-## WP-CLI Development Commands
-
-### Scaffold Commands
+## WP-CLI Commands
 
 ```bash
-wp scaffold theme theme-name
-wp scaffold child-theme child-name --parent_theme=parent-name
+# Scaffold
+wp scaffold theme theme-name --theme_name="Theme Name" --activate
+wp scaffold child-theme child-name --parent_theme=parent-name --activate
 wp scaffold plugin plugin-name
 wp scaffold post-type cpt-name --plugin=plugin-name
-wp scaffold taxonomy tax-name --post_types=cpt-name --plugin=plugin-name
 wp scaffold block block-name --plugin=plugin-name
-```
 
-### Database Commands
-
-```bash
-wp db export backup.sql
-wp db import backup.sql
-wp db query "SELECT * FROM wp_posts LIMIT 5"
+# Database
+wp db export backup.sql && wp db import backup.sql
 wp search-replace 'old.domain.com' 'new.domain.com' --dry-run
-wp search-replace 'old.domain.com' 'new.domain.com'
-wp db optimize
-wp db check
-```
+wp db optimize && wp db check
 
-### Development Commands
-
-```bash
+# Development
 wp shell                          # Interactive PHP
 wp eval 'echo get_option("siteurl");'
-wp post generate --count=10
-wp user generate --count=5
-wp cache flush
-wp transient delete --all
+wp post generate --count=10 && wp user generate --count=5
+wp cache flush && wp transient delete --all
 ```
 
 ## PHPUnit Testing
 
 ```bash
-# With wp-env
-wp-env run tests-cli phpunit
-
-# With Composer
-composer require --dev phpunit/phpunit wp-phpunit/wp-phpunit
+wp-env run tests-cli phpunit                                    # wp-env
+composer require --dev phpunit/phpunit wp-phpunit/wp-phpunit    # Composer
 vendor/bin/phpunit
 ```
 
@@ -616,20 +402,11 @@ vendor/bin/phpunit
 <?php
 class Test_My_Plugin extends WP_UnitTestCase {
 
-    public function setUp(): void {
-        parent::setUp();
-    }
-
-    public function tearDown(): void {
-        parent::tearDown();
-    }
-
     public function test_post_creation() {
         $post_id = $this->factory->post->create([
-            'post_title' => 'Test Post',
-            'post_status' => 'publish'
+            'post_title'  => 'Test Post',
+            'post_status' => 'publish',
         ]);
-
         $this->assertIsInt($post_id);
         $this->assertEquals('Test Post', get_the_title($post_id));
     }
@@ -640,14 +417,7 @@ class Test_My_Plugin extends WP_UnitTestCase {
 
 ```xml
 <?xml version="1.0"?>
-<phpunit
-    bootstrap="tests/bootstrap.php"
-    backupGlobals="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
->
+<phpunit bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true">
     <testsuites>
         <testsuite name="My Plugin Test Suite">
             <directory suffix=".php">./tests/</directory>
@@ -656,69 +426,40 @@ class Test_My_Plugin extends WP_UnitTestCase {
 </phpunit>
 ```
 
-## E2E Testing
+## E2E & Security
 
 ```bash
 # Playwright
-npm install -D @playwright/test
-npx playwright test
+npx playwright test              # npm install -D @playwright/test
 npx playwright test --ui
 
 # Cypress
-npm install -D cypress
-npx cypress run
+npx cypress run                  # npm install -D cypress
 npx cypress open
-```
 
-## Security Scanning
-
-```bash
+# Security scanning
 ./.agents/scripts/secretlint-helper.sh scan
 grep -r "password\|api_key\|secret" --include="*.php" .
 ```
-
-## Environment Comparison
-
-| Feature | Playground | LocalWP | wp-env |
-|---------|------------|---------|--------|
-| Setup Time | Instant | 5-10 min | 2-5 min |
-| Persistence | None | Full | Partial |
-| PHP Versions | Limited | Many | Configurable |
-| Database | In-memory | MySQL | MySQL |
-| WP-CLI | Yes | Yes | Yes |
-| Multisite | Yes | Yes | Yes |
-| Docker Required | No | No | Yes |
-| GitHub Actions | Works* | N/A | Works |
-| Best For | Quick testing | Full dev | CI/Testing |
-
-*Playground may be flaky in CI environments
 
 ## Testing Checklist
 
 Before releasing a plugin/theme:
 
-- [ ] Tested on single site
-- [ ] Tested on multisite
-- [ ] Tested with minimum PHP version
-- [ ] Tested with minimum WordPress version
-- [ ] Tested with latest WordPress version
-- [ ] PHPUnit tests passing
-- [ ] E2E tests passing
-- [ ] No PHP errors/warnings in debug log
-- [ ] No JavaScript console errors
-- [ ] Tested activation/deactivation
-- [ ] Tested uninstall process
+- [ ] Tested on single site and multisite
+- [ ] Tested with minimum and latest PHP/WordPress versions
+- [ ] PHPUnit and E2E tests passing
+- [ ] No PHP errors/warnings in debug log, no JS console errors
+- [ ] Tested activation/deactivation/uninstall
 - [ ] Security scan completed
 - [ ] Code quality checks passed
 
 ## Resources
 
-- [WordPress Playground](https://wordpress.github.io/wordpress-playground/)
-- [WordPress Playground Blueprints](https://wordpress.github.io/wordpress-playground/blueprints)
+- [WordPress Playground](https://wordpress.github.io/wordpress-playground/) + [Blueprints](https://wordpress.github.io/wordpress-playground/blueprints)
 - [LocalWP Documentation](https://localwp.com/help-docs/)
 - [@wordpress/env Documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)
 - [PHPUnit for WordPress](https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/)
 - [WordPress MCP Adapter](https://github.com/WordPress/mcp-adapter)
 - [WP-CLI Commands](https://developer.wordpress.org/cli/commands/)
-- [WP Composer](https://wp-composer.com/) (preferred Composer repository for WP plugins/themes)
-- [Bedrock](https://roots.io/bedrock/) (Composer-based WordPress boilerplate by Roots)
+- [WP Composer](https://wp-composer.com/) (preferred Composer repository) | [Bedrock](https://roots.io/bedrock/)


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/wordpress/wp-dev.md` from 567 lines to 465 lines — a 36% reduction from the original 724 lines (issue target: 20-40%).

## What was removed

| Section | Before | After | Saving |
|---------|--------|-------|--------|
| `sync-to-local.sh` inline script | 27 lines | 3-line rsync command | 24 lines |
| Contributing to Open Source | 13 lines | removed (generic git, not WP-specific) | 13 lines |
| `wp-env` multisite config | full repeat | diff-only keys | 12 lines |
| Block theme directory listing | named files | inline comments | 6 lines |
| PHPUnit `setUp`/`tearDown` boilerplate | present | removed (standard PHPUnit) | 8 lines |
| `phpunit.xml` verbose attributes | 4 attrs | essential only | 4 lines |
| Plugin header optional fields | URI, Author URI, Domain Path | removed | 3 lines |
| Resources section | 9 lines | 7 lines (merged pairs) | 2 lines |
| Trivial `wp db query SELECT` example | present | removed | 1 line |

## What was preserved

All unique, WP-specific content is intact:
- MCP Adapter STDIO + HTTP config (all env vars, application password setup)
- Blueprint JSON (standard + multisite)
- Template hierarchy (all 7 conditions)
- Fix plugin companion pattern (with `class_exists` guard, priority, version-compare)
- Debug constants (`WP_DEBUG`, `WP_DEBUG_LOG`, `WP_DEBUG_DISPLAY`, `SCRIPT_DEBUG`, `SAVEQUERIES`)
- Intelephense + WordPress stubs config (full JSON)
- WP Composer guidance (preferred over WPackagist, migration links)
- All URLs (19 unique URLs verified present)
- All WP-CLI scaffold, database, and development commands

Closes #6436