### PR TITLE
fix: add libnss3-tools to apt branch in ensure_mkcert

### DIFF
--- a/.agents/scripts/localdev-helper.sh
+++ b/.agents/scripts/localdev-helper.sh
@@ -105,6 +105,10 @@ ensure_mkcert() {
 		if sudo apt-get update -qq && sudo apt-get install -y -qq mkcert libnss3-tools 2>/dev/null; then
 			installed=true
 		fi
+	elif command -v apt >/dev/null 2>&1; then
+		if sudo apt update -qq && sudo apt install -y -qq mkcert libnss3-tools 2>/dev/null; then
+			installed=true
+		fi
 	elif command -v dnf >/dev/null 2>&1; then
 		if sudo dnf install -y mkcert 2>/dev/null; then
 			installed=true


### PR DESCRIPTION
## Summary

- Restores the `apt` fallback branch in `ensure_mkcert()` with `libnss3-tools` included
- The `apt-get` branch already had `libnss3-tools` (added in PR #6416), but the `apt` branch was dropped rather than fixed
- On systems where only `apt` is available (not `apt-get`), `mkcert -install` would fail to seed the NSS/browser trust store without `libnss3-tools`

## Root Cause

PR #6416 addressed the CodeRabbit finding for the `apt-get` branch but removed the `apt` branch entirely instead of fixing it. The intermediate commit `756f4ac` had both branches missing `libnss3-tools`; the final merged commit fixed `apt-get` but dropped `apt`.

## Testing

- Systems with `apt-get` (standard Ubuntu/Debian): unchanged behaviour — `apt-get` branch runs first
- Systems with only `apt` (some minimal containers, older Debian variants): now installs `libnss3-tools` alongside `mkcert`, enabling `mkcert -install` to trust certs in Firefox/Chromium

Closes #6474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved local development setup compatibility with additional Linux systems by expanding package manager support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->