### PR TITLE
t1660.10: Add structured testing evidence to full-loop Step 4.7 issue closing comment

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -366,13 +366,21 @@ fi
 
 ### 4.7 Issue Closing Comment (MANDATORY)
 
-After merge, post on every linked issue:
+After merge, post on every linked issue. The **Testing Evidence** section replaces free-text with structured fields so future workers can assess stability at a glance.
 
 ```markdown
 ## Completed via PR #<PR_NUMBER>
 
 **What was done:** <bullet list>
-**How it was tested:** <tests/verification>
+
+**Testing Evidence:**
+- **Testing level:** `runtime-verified` | `self-assessed` | `untested`
+  - `runtime-verified` — dev server started, Playwright/curl smoke checks passed
+  - `self-assessed` — manual review of diff, no runtime execution
+  - `untested` — docs/config only, no executable code changed
+- **Stability results:** <pass/fail counts, error messages, or "N/A — docs only">
+- **Smoke pages/endpoints checked:** <URLs or commands verified, or "N/A">
+
 **Key decisions:** <non-obvious choices and why>
 **Files changed:** `path/to/file` — <what and why>
 **Blockers encountered:** <issues hit and resolution, or "None">
@@ -380,7 +388,13 @@ After merge, post on every linked issue:
 **Released in:** v<VERSION> — run `aidevops update` to get this fix.
 ```
 
-Rules: every section needs ≥1 bullet ("None" if empty), be specific, include file paths, include release version (aidevops repo only). This is a gate — no `FULL_LOOP_COMPLETE` until comments posted.
+**Rules:**
+- Every section needs ≥1 bullet ("None" / "N/A" if nothing to report)
+- **Testing level is required** — never omit it. If you did not start a dev server or run any automated check, use `self-assessed`. If the change is docs/config only with no executable code, use `untested`.
+- Be specific — "fixed the bug" is useless; "fixed race condition in worktree creation by adding `sleep 2` between dispatches" is useful
+- Include file paths with brief descriptions so future workers can find the changes
+- Include release version (aidevops repo only). For non-aidevops repos, omit the "Released in" line.
+- This is a gate — no `FULL_LOOP_COMPLETE` until closing comments are posted
 
 ### 4.8 Worktree Cleanup
 


### PR DESCRIPTION
## Summary

Replaces the free-text `**How it was tested:**` field in the Step 4.7 issue closing comment template with three structured fields that give future workers at-a-glance stability signal.

## Changes

- `.agents/scripts/commands/full-loop.md` — Step 4.7 issue closing comment template updated

### New Testing Evidence structure

```markdown
**Testing Evidence:**
- **Testing level:** `runtime-verified` | `self-assessed` | `untested`
  - `runtime-verified` — dev server started, Playwright/curl smoke checks passed
  - `self-assessed` — manual review of diff, no runtime execution
  - `untested` — docs/config only, no executable code changed
- **Stability results:** <pass/fail counts, error messages, or "N/A — docs only">
- **Smoke pages/endpoints checked:** <URLs or commands verified, or "N/A">
```

Testing level is now **required** — workers must declare which tier applies. This prevents the pattern where "How it was tested: reviewed the code" provides no actionable signal.

## Testing Evidence

- **Testing level:** `untested`
- **Stability results:** N/A — docs/config change only, no executable code modified
- **Smoke pages/endpoints checked:** N/A

## Part of t1660 Runtime Testing Setup

This is subtask t1660.10 of the t1660 parent task (Runtime testing setup — per-repo dev environment config, testing level enforcement, and proof-log integration).

Closes #6495