### PR TITLE
t1660.5: Add --testing-level flag to task-complete-helper.sh

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -8,6 +8,7 @@
 # Options:
 #   --pr <number>              PR number (e.g., 123)
 #   --verified <date>          Verified date (YYYY-MM-DD, defaults to today)
+#   --testing-level <level>    Testing level: runtime-verified | self-assessed | untested
 #   --verify                   Run verify-brief.sh on task brief before completing
 #   --repo-path <path>         Path to git repository (default: current directory)
 #   --gh-repo <owner/repo>     GitHub repo slug for PR lookup (default: auto-detect from git remote)
@@ -21,6 +22,14 @@
 #   task-complete-helper.sh t125 --verified  # Uses today's date
 #   task-complete-helper.sh t126 --pr 789 --verify  # Verify brief before completing
 #   task-complete-helper.sh t127 --pr 101 --gh-repo owner/repo  # Cross-repo PR lookup
+#   task-complete-helper.sh t128 --pr 102 --testing-level runtime-verified
+#   task-complete-helper.sh t129 --verified --testing-level self-assessed
+#   task-complete-helper.sh t130 --verified --testing-level untested
+#
+# Testing levels:
+#   runtime-verified  Dev environment started, Playwright/smoke tests ran and passed
+#   self-assessed     Code reviewed by AI, no runtime execution (default for most tasks)
+#   untested          No testing performed (docs, config, or blocked by environment)
 #
 # Exit codes:
 #   0 - Success (task marked complete, committed, and pushed)
@@ -31,11 +40,13 @@
 #   - When --pr is given, verifies the PR is actually MERGED before proceeding
 #   - Marks task [x] in TODO.md
 #   - Adds pr:#NNN or verified:YYYY-MM-DD to the task line
+#   - Adds testing:LEVEL to the task line when --testing-level is specified
 #   - Adds completed:YYYY-MM-DD timestamp
 #   - Commits and pushes the change
 #
 # This closes the interactive AI enforcement gap (t317).
 # PR merge verification closes the premature-completion bug (GH#466 on Ultimate-Multisite/ai-agent).
+# Testing level recording closes the observability gap (t1660.5).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
@@ -46,11 +57,15 @@ set -euo pipefail
 TASK_ID=""
 PR_NUMBER=""
 VERIFIED_DATE=""
+TESTING_LEVEL=""
 REPO_PATH="$PWD"
 GH_REPO=""
 NO_PUSH=false
 VERIFY_BRIEF=false
 SKIP_MERGE_CHECK=false
+
+# Valid testing levels (t1660.5)
+VALID_TESTING_LEVELS="runtime-verified self-assessed untested"
 
 # Logging: uses shared log_* from shared-constants.sh
 
@@ -86,6 +101,23 @@ _validate_args() {
 	if [[ -n "$VERIFIED_DATE" ]] && ! echo "$VERIFIED_DATE" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
 		log_error "Invalid verified date: $VERIFIED_DATE (expected: YYYY-MM-DD)"
 		return 1
+	fi
+
+	# Validate testing level if provided (t1660.5)
+	if [[ -n "$TESTING_LEVEL" ]]; then
+		local valid_level=""
+		local level=""
+		for level in $VALID_TESTING_LEVELS; do
+			if [[ "$TESTING_LEVEL" == "$level" ]]; then
+				valid_level="$level"
+				break
+			fi
+		done
+		if [[ -z "$valid_level" ]]; then
+			log_error "Invalid testing level: $TESTING_LEVEL"
+			log_error "Valid values: $VALID_TESTING_LEVELS"
+			return 1
+		fi
 	fi
 
 	return 0
@@ -144,6 +176,15 @@ parse_args() {
 				exit 1
 			fi
 			GH_REPO="$val"
+			shift 2
+			;;
+		--testing-level)
+			val="${2:-}"
+			if [[ -z "$val" || "$val" == --* ]]; then
+				echo "Error: --testing-level requires a value (runtime-verified|self-assessed|untested)" >&2
+				exit 1
+			fi
+			TESTING_LEVEL="$val"
 			shift 2
 			;;
 		--skip-merge-check)
@@ -578,6 +619,12 @@ main() {
 	else
 		proof_log="verified:${VERIFIED_DATE}"
 		log_info "Proof-log: verified ${VERIFIED_DATE}"
+	fi
+
+	# Append testing level to proof-log when provided (t1660.5)
+	if [[ -n "$TESTING_LEVEL" ]]; then
+		proof_log="${proof_log} testing:${TESTING_LEVEL}"
+		log_info "Testing level: ${TESTING_LEVEL}"
 	fi
 
 	# Mark task complete

--- a/tests/test-proof-log-enforcement.sh
+++ b/tests/test-proof-log-enforcement.sh
@@ -128,6 +128,145 @@ test_pre_commit_script_enforces_proof_log() {
 	return 0
 }
 
+# t1660.5: Tests for --testing-level flag
+test_testing_level_runtime_verified() {
+	echo "Test: --testing-level runtime-verified appended to proof-log"
+
+	local temp_repo
+	temp_repo=$(mktemp -d)
+
+	git init "$temp_repo" >/dev/null 2>&1
+	git -C "$temp_repo" config user.name "AI DevOps Test"
+	git -C "$temp_repo" config user.email "aidevops-test@example.com"
+
+	cat >"${temp_repo}/TODO.md" <<'EOF'
+- [ ] t200 Test runtime-verified testing level #test
+EOF
+
+	git -C "$temp_repo" add TODO.md
+	git -C "$temp_repo" commit -m "test: seed todo" >/dev/null 2>&1
+
+	local rc=0
+	"$TASK_COMPLETE_HELPER" t200 --verified 2026-03-14 \
+		--testing-level runtime-verified \
+		--repo-path "$temp_repo" --no-push >/dev/null 2>&1 || rc=$?
+	assert_exit_code 0 "$rc" "helper succeeds with testing-level runtime-verified"
+
+	assert_file_contains "${temp_repo}/TODO.md" "testing:runtime-verified" "testing:runtime-verified appended to proof-log"
+	assert_file_contains "${temp_repo}/TODO.md" "verified:2026-03-14" "verified proof-log still present"
+
+	rm -rf "$temp_repo"
+	return 0
+}
+
+test_testing_level_self_assessed() {
+	echo "Test: --testing-level self-assessed appended to proof-log"
+
+	local temp_repo
+	temp_repo=$(mktemp -d)
+
+	git init "$temp_repo" >/dev/null 2>&1
+	git -C "$temp_repo" config user.name "AI DevOps Test"
+	git -C "$temp_repo" config user.email "aidevops-test@example.com"
+
+	cat >"${temp_repo}/TODO.md" <<'EOF'
+- [ ] t201 Test self-assessed testing level #test
+EOF
+
+	git -C "$temp_repo" add TODO.md
+	git -C "$temp_repo" commit -m "test: seed todo" >/dev/null 2>&1
+
+	local rc=0
+	"$TASK_COMPLETE_HELPER" t201 --verified 2026-03-14 \
+		--testing-level self-assessed \
+		--repo-path "$temp_repo" --no-push >/dev/null 2>&1 || rc=$?
+	assert_exit_code 0 "$rc" "helper succeeds with testing-level self-assessed"
+
+	assert_file_contains "${temp_repo}/TODO.md" "testing:self-assessed" "testing:self-assessed appended to proof-log"
+
+	rm -rf "$temp_repo"
+	return 0
+}
+
+test_testing_level_untested() {
+	echo "Test: --testing-level untested appended to proof-log"
+
+	local temp_repo
+	temp_repo=$(mktemp -d)
+
+	git init "$temp_repo" >/dev/null 2>&1
+	git -C "$temp_repo" config user.name "AI DevOps Test"
+	git -C "$temp_repo" config user.email "aidevops-test@example.com"
+
+	cat >"${temp_repo}/TODO.md" <<'EOF'
+- [ ] t202 Test untested testing level #test
+EOF
+
+	git -C "$temp_repo" add TODO.md
+	git -C "$temp_repo" commit -m "test: seed todo" >/dev/null 2>&1
+
+	local rc=0
+	"$TASK_COMPLETE_HELPER" t202 --verified 2026-03-14 \
+		--testing-level untested \
+		--repo-path "$temp_repo" --no-push >/dev/null 2>&1 || rc=$?
+	assert_exit_code 0 "$rc" "helper succeeds with testing-level untested"
+
+	assert_file_contains "${temp_repo}/TODO.md" "testing:untested" "testing:untested appended to proof-log"
+
+	rm -rf "$temp_repo"
+	return 0
+}
+
+test_testing_level_invalid_rejected() {
+	echo "Test: --testing-level with invalid value is rejected"
+
+	local output=""
+	local rc=0
+	output=$("$TASK_COMPLETE_HELPER" t999 --verified 2026-03-14 \
+		--testing-level bad-value \
+		--repo-path "$REPO_DIR" --no-push 2>&1) || rc=$?
+
+	assert_exit_code 1 "$rc" "helper exits non-zero with invalid testing-level"
+	if echo "$output" | grep -q "Invalid testing level"; then
+		pass "invalid testing-level error message shown"
+	else
+		fail "invalid testing-level error message not shown (got: $output)"
+	fi
+	return 0
+}
+
+test_testing_level_omitted_no_change() {
+	echo "Test: omitting --testing-level produces no testing: field"
+
+	local temp_repo
+	temp_repo=$(mktemp -d)
+
+	git init "$temp_repo" >/dev/null 2>&1
+	git -C "$temp_repo" config user.name "AI DevOps Test"
+	git -C "$temp_repo" config user.email "aidevops-test@example.com"
+
+	cat >"${temp_repo}/TODO.md" <<'EOF'
+- [ ] t203 Test omitted testing level #test
+EOF
+
+	git -C "$temp_repo" add TODO.md
+	git -C "$temp_repo" commit -m "test: seed todo" >/dev/null 2>&1
+
+	local rc=0
+	"$TASK_COMPLETE_HELPER" t203 --verified 2026-03-14 \
+		--repo-path "$temp_repo" --no-push >/dev/null 2>&1 || rc=$?
+	assert_exit_code 0 "$rc" "helper succeeds without --testing-level"
+
+	if grep -qE "testing:" "${temp_repo}/TODO.md"; then
+		fail "testing: field present when --testing-level was omitted"
+	else
+		pass "no testing: field when --testing-level omitted (backward compatible)"
+	fi
+
+	rm -rf "$temp_repo"
+	return 0
+}
+
 main() {
 	echo "============================================"
 	echo "Proof-Log Enforcement - Test Suite"
@@ -141,6 +280,16 @@ main() {
 	test_verified_completion_updates_todo
 	echo ""
 	test_pre_commit_script_enforces_proof_log
+	echo ""
+	test_testing_level_runtime_verified
+	echo ""
+	test_testing_level_self_assessed
+	echo ""
+	test_testing_level_untested
+	echo ""
+	test_testing_level_invalid_rejected
+	echo ""
+	test_testing_level_omitted_no_change
 	echo ""
 
 	echo "============================================"


### PR DESCRIPTION
## Summary

Adds `--testing-level <level>` flag to `task-complete-helper.sh` that records the testing method used in the proof-log entry in `TODO.md`.

## What

- New optional flag `--testing-level` with three valid values:
  - `runtime-verified` — dev environment started, Playwright/smoke tests ran and passed
  - `self-assessed` — code reviewed by AI, no runtime execution (most common)
  - `untested` — no testing performed (docs, config, or blocked by environment)
- When provided, appends `testing:LEVEL` to the proof-log field alongside `pr:#NNN` or `verified:YYYY-MM-DD`
- Flag is **optional** — omitting it preserves existing behavior (no `testing:` field written, fully backward compatible)
- Invalid values are rejected with a clear error message listing valid options

## Example output in TODO.md

```
- [x] t128 Some task pr:#456 testing:runtime-verified completed:2026-03-26
- [x] t129 Another task verified:2026-03-26 testing:self-assessed completed:2026-03-26
- [x] t130 Docs task verified:2026-03-26 completed:2026-03-26  # no testing: field (omitted)
```

## Tests

Added 5 new tests to `tests/test-proof-log-enforcement.sh`:
- `test_testing_level_runtime_verified` — verifies `testing:runtime-verified` appended
- `test_testing_level_self_assessed` — verifies `testing:self-assessed` appended
- `test_testing_level_untested` — verifies `testing:untested` appended
- `test_testing_level_invalid_rejected` — verifies invalid values exit 1 with clear error
- `test_testing_level_omitted_no_change` — verifies backward compatibility (no field when omitted)

All 22 tests pass (17 pre-existing + 5 new).

## Task Lineage

This task is part of the t1660 Runtime Testing Setup parent:
- **Parent:** t1660 — Runtime testing setup
- **This task:** t1660.5 — task-complete-helper.sh --testing-level flag
- **Related:** t1660.6 (PR template), t1660.7 (full-loop gate), t1660.9 (audit-log event type), t1660.10 (issue closing comment)

Closes #6490