### PR TITLE
t1660.7: Add Step 3 runtime testing gate to full-loop.md

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -214,7 +214,8 @@ Iterate until emitting `<promise>TASK_COMPLETE</promise>`.
 6. Conventional commits used
 7. Headless rules observed (see below)
 8. **Actionable finding coverage** — every deferred finding from audit/review/scan has a tracked task+issue
-9. **Commit+PR gate (GH#5317 — MANDATORY):**
+9. **Runtime testing gate (t1660.7)** — risk-appropriate runtime verification (see below)
+10. **Commit+PR gate (GH#5317 — MANDATORY):**
 
    ```bash
    UNCOMMITTED=$(git status --porcelain | wc -l | tr -d ' ')
@@ -240,6 +241,154 @@ For multi-finding reports (audit/review/scan): build `severity|title|details` li
 ```
 
 Include in PR body: `actionable_findings_total=N`, `fixed_in_pr=N`, `deferred_tasks_created=N`, `coverage=100%`.
+
+### Runtime Testing Gate (t1660.7 — MANDATORY)
+
+Before emitting `TASK_COMPLETE`, classify the risk level of your changes and perform the appropriate level of runtime verification. This is a judgment call — the agent reads the diff, identifies risk patterns, and escalates testing accordingly. Static analysis (lint, typecheck) catches syntax; runtime testing catches behaviour.
+
+#### Step 1: Diff Risk Classification
+
+Analyse `git diff origin/main` for high-risk patterns. Each pattern detected raises the required testing level.
+
+**Risk taxonomy:**
+
+| Risk Level | Patterns in Diff | Required Testing |
+|------------|-----------------|------------------|
+| **Critical** | Payment/billing logic, auth/session handling, data deletion/migration, cryptographic operations, credential flows | `runtime-verified` |
+| **High** | Polling/interval loops (`setInterval`, `setTimeout` chains, `while` polling), page reload triggers (`location.reload`, `router.refresh`), WebSocket/SSE connections, state machine transitions, form submission handlers, API endpoint changes | `runtime-verified` |
+| **Medium** | UI component changes, CSS/layout modifications, new routes/pages, configuration changes, environment variable usage, database queries | `runtime-verified` when dev env available; `self-assessed` with justification otherwise |
+| **Low** | Documentation, comments, type-only changes, test files only, linter config, CI config, agent prompts, markdown | `self-assessed` (no runtime testing needed) |
+
+**Detection approach — intelligence, not regex:**
+
+Read the diff holistically. A one-line CSS change is low risk. A one-line change to a payment webhook URL is critical. The pattern table above is guidance — use judgment for edge cases. When uncertain, escalate.
+
+```bash
+# Quick diff summary for risk assessment
+git diff --stat origin/main
+git diff origin/main -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.py' '*.php' '*.rb' '*.go' '*.rs'
+```
+
+#### Step 2: Determine Testing Level
+
+Three testing levels, in ascending order of rigour:
+
+| Level | What It Means | When to Use |
+|-------|--------------|-------------|
+| `self-assessed` | Worker reviewed the code, ran static checks, assessed correctness by reading | Low-risk changes; no dev environment available and risk is medium or below |
+| `unit-tested` | Automated test suite passes (`npm test`, `pytest`, `cargo test`, etc.) | Any project with an existing test suite; medium-risk changes |
+| `runtime-verified` | Application started, behaviour confirmed in a running environment (browser, API call, CLI execution) | High/critical risk; any change touching user-facing behaviour in a project with a dev environment |
+
+**Escalation is one-way:** If the diff contains ANY critical-risk pattern, the entire PR requires `runtime-verified` regardless of other low-risk changes in the same diff.
+
+**Testing config integration (t1660.2):** If `.aidevops/testing.json` exists in the project root, read it for the project's dev environment setup, test commands, and smoke-test URLs. This file is created by `/testing-setup` (t1660.1). When the file doesn't exist, fall back to conventional detection:
+
+```bash
+# Detect available test infrastructure
+TESTING_CONFIG="$(git rev-parse --show-toplevel)/.aidevops/testing.json"
+if [[ -f "$TESTING_CONFIG" ]]; then
+  # Use project-specific testing config (t1660.2)
+  TEST_CMD=$(jq -r '.test_command // empty' "$TESTING_CONFIG")
+  DEV_CMD=$(jq -r '.dev_command // empty' "$TESTING_CONFIG")
+  SMOKE_URLS=$(jq -r '.smoke_urls[]? // empty' "$TESTING_CONFIG")
+else
+  # Conventional detection fallback
+  [[ -f "package.json" ]] && TEST_CMD="npm test"
+  [[ -f "pytest.ini" || -f "pyproject.toml" ]] && TEST_CMD="pytest"
+  [[ -f "Cargo.toml" ]] && TEST_CMD="cargo test"
+  [[ -f "go.mod" ]] && TEST_CMD="go test ./..."
+fi
+```
+
+#### Step 3: Execute Testing
+
+**For `self-assessed`:** Document in the commit message or PR body what you reviewed and why runtime testing was not required. Example: "Self-assessed: docs-only change, no runtime behaviour affected."
+
+**For `unit-tested`:** Run the test suite and confirm it passes:
+
+```bash
+if [[ -n "${TEST_CMD:-}" ]]; then
+  eval "$TEST_CMD" || {
+    echo "[t1660.7] Unit tests failed — fix before TASK_COMPLETE"
+    # Do NOT proceed to TASK_COMPLETE
+  }
+fi
+```
+
+**For `runtime-verified`:** Start the dev environment, verify behaviour, and record evidence:
+
+1. **Start dev server** (if not already running):
+
+   ```bash
+   # Use testing.json dev_command, or detect conventionally
+   if [[ -n "${DEV_CMD:-}" ]]; then
+     eval "$DEV_CMD" &
+     DEV_PID=$!
+     sleep 5  # Allow startup
+   fi
+   ```
+
+2. **Run smoke checks** — verify the application loads and key pages respond:
+
+   ```bash
+   # browser-qa-helper.sh stability (t1660.3) when available
+   STABILITY_HELPER="$HOME/.aidevops/agents/scripts/browser-qa-helper.sh"
+   if [[ -x "$STABILITY_HELPER" ]] && "$STABILITY_HELPER" help 2>&1 | grep -q 'stability'; then
+     "$STABILITY_HELPER" stability --url "${SMOKE_URLS:-http://localhost:3000}" --timeout 30
+   else
+     # Fallback: basic HTTP check
+     curl -sf "${SMOKE_URLS:-http://localhost:3000}" >/dev/null 2>&1 || {
+       echo "[t1660.7] Smoke check failed — application not responding"
+     }
+   fi
+   ```
+
+3. **Verify changed behaviour** — for UI changes, load the affected page; for API changes, call the affected endpoint; for CLI changes, run the affected command. This is the agent's judgment call — there is no script for "verify the thing you changed works."
+
+4. **Record evidence** in the PR body (see Step 4.7 structured format, t1660.10):
+
+   ```markdown
+   ## Runtime Testing
+   - **Testing level:** runtime-verified
+   - **Risk classification:** high (polling loop in useDataSync hook)
+   - **Dev environment:** npm run dev (Next.js 14, localhost:3000)
+   - **Smoke check:** homepage loads, /dashboard renders, /api/health returns 200
+   - **Behaviour verified:** polling interval respects backoff, stops on unmount
+   ```
+
+#### Step 4: Gate Enforcement
+
+**Before `TASK_COMPLETE`**, verify the testing level matches the risk:
+
+| Situation | Action |
+|-----------|--------|
+| Critical/high risk + no runtime verification | **BLOCK** — do not emit `TASK_COMPLETE`. Start the dev env and verify, or exit `BLOCKED: runtime testing required but dev environment unavailable` |
+| Medium risk + no dev env available | **WARN** — proceed with `self-assessed` but document the gap in PR body: "Medium-risk change, runtime testing recommended but dev environment not configured. Run `/testing-setup` to enable." |
+| Low risk + self-assessed | **PASS** — proceed normally |
+| Any risk + `testing.json` specifies `required_level` | **ENFORCE** — the project config overrides the default risk mapping. If `testing.json` says `runtime-verified` is required for all PRs, comply regardless of diff risk. |
+
+**Headless mode behaviour:** In headless dispatch, if runtime testing is required but the dev environment fails to start (missing dependencies, port conflict, Docker not running), exit with a structured message:
+
+```text
+BLOCKED: Runtime testing required (risk: high — auth flow changes in src/auth/handler.ts)
+but dev environment failed to start: npm run dev exited with code 1 (missing NEXT_PUBLIC_API_URL).
+Recommend: configure .aidevops/testing.json via /testing-setup, or add env vars to .env.local.
+```
+
+**`--skip-runtime-testing` flag:** For emergency hotfixes, pass `--skip-runtime-testing` to `/full-loop`. This bypasses the gate but logs a warning in the PR body: "Runtime testing skipped (emergency override). Manual verification recommended before merge." The flag is intentionally verbose to discourage casual use.
+
+#### Integration with Sibling Tasks
+
+This gate is designed to work standalone (using conventional detection and agent judgment) and to improve as sibling tasks land:
+
+| Task | What It Adds | Gate Behaviour Without It |
+|------|-------------|--------------------------|
+| t1660.1 `/testing-setup` | Interactive per-repo config | Agent uses conventional detection |
+| t1660.2 `testing.json` | Structured project config | Agent detects test/dev commands from package.json etc. |
+| t1660.3 `browser-qa stability` | Playwright quiescence detection | Agent uses `curl` smoke checks |
+| t1660.4 `verify-brief.sh` runtime | Brief-driven runtime verification | Agent runs tests directly |
+| t1660.5 `--testing-level` flag | Proof-log recording | Agent documents level in PR body only |
+| t1660.6 PR template section | Structured PR testing section | Agent writes free-form testing section |
 
 ### Key Rules
 
@@ -436,6 +585,7 @@ Verify release health. Deploy: `setup.sh --non-interactive` (aidevops repos only
 | `--skip-postflight` | Skip postflight monitoring |
 | `--no-auto-pr` | Pause for manual PR creation |
 | `--no-auto-deploy` | Don't auto-run setup.sh |
+| `--skip-runtime-testing` | Skip runtime testing gate (emergency hotfixes only) |
 
 ## Related
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -37,6 +37,7 @@ max_preflight_iterations: ${MAX_PREFLIGHT_ITERATIONS:-$DEFAULT_MAX_PREFLIGHT_ITE
 max_pr_iterations: ${MAX_PR_ITERATIONS:-$DEFAULT_MAX_PR_ITERATIONS}
 skip_preflight: ${SKIP_PREFLIGHT:-false}
 skip_postflight: ${SKIP_POSTFLIGHT:-false}
+skip_runtime_testing: ${SKIP_RUNTIME_TESTING:-false}
 no_auto_pr: ${NO_AUTO_PR:-false}
 no_auto_deploy: ${NO_AUTO_DEPLOY:-false}
 headless: ${HEADLESS:-false}
@@ -56,8 +57,8 @@ load_state() {
 		# Allowlist: only set known state variables
 		case "$_key" in
 		PHASE | ACTIVE | ITERATION | MAX_TASK_ITERATIONS | MAX_PREFLIGHT_ITERATIONS | \
-			MAX_PR_ITERATIONS | SKIP_PREFLIGHT | SKIP_POSTFLIGHT | NO_AUTO_PR | \
-			NO_AUTO_DEPLOY | HEADLESS | PR_NUMBER)
+			MAX_PR_ITERATIONS | SKIP_PREFLIGHT | SKIP_POSTFLIGHT | SKIP_RUNTIME_TESTING | \
+			NO_AUTO_PR | NO_AUTO_DEPLOY | HEADLESS | PR_NUMBER)
 			printf -v "$_key" '%s' "$_val"
 			;;
 		esac
@@ -160,6 +161,10 @@ cmd_start() {
 			SKIP_POSTFLIGHT=true
 			shift
 			;;
+		--skip-runtime-testing)
+			SKIP_RUNTIME_TESTING=true
+			shift
+			;;
 		--no-auto-pr)
 			NO_AUTO_PR=true
 			shift
@@ -213,7 +218,7 @@ cmd_start() {
 	if [[ "$background" == "true" ]]; then
 		mkdir -p "$STATE_DIR"
 		export MAX_TASK_ITERATIONS MAX_PREFLIGHT_ITERATIONS MAX_PR_ITERATIONS
-		export SKIP_PREFLIGHT SKIP_POSTFLIGHT NO_AUTO_PR NO_AUTO_DEPLOY FULL_LOOP_HEADLESS="$HEADLESS"
+		export SKIP_PREFLIGHT SKIP_POSTFLIGHT SKIP_RUNTIME_TESTING NO_AUTO_PR NO_AUTO_DEPLOY FULL_LOOP_HEADLESS="$HEADLESS"
 		nohup "$0" _run_foreground "$prompt" >"${STATE_DIR}/full-loop.log" 2>&1 &
 		echo "$!" >"${STATE_DIR}/full-loop.pid"
 		print_success "Background loop started (PID: $!). Use 'status' or 'logs' to monitor."
@@ -316,7 +321,8 @@ Usage: full-loop-helper.sh <command> [options]
 Commands: start "<prompt>" | resume | status | cancel | logs [N] | help
 Options: --max-task-iterations N (50) | --max-preflight-iterations N (5)
   --max-pr-iterations N (20) | --skip-preflight | --skip-postflight
-  --no-auto-pr | --no-auto-deploy | --headless | --dry-run | --background
+  --skip-runtime-testing | --no-auto-pr | --no-auto-deploy
+  --headless | --dry-run | --background
 Phases: task -> preflight -> pr-create -> pr-review -> postflight -> deploy
 EOF
 }


### PR DESCRIPTION
## Summary

- Adds a risk-based runtime testing gate as Step 3 completion criterion #9 in `full-loop.md`, requiring workers to classify diff risk and perform appropriate runtime verification before emitting `TASK_COMPLETE`
- Defines a 4-level risk taxonomy (critical/high/medium/low) with pattern guidance for payment, auth, polling, reload, state machine, and UI changes
- Adds `--skip-runtime-testing` flag to `full-loop-helper.sh` for emergency hotfixes

## Runtime Testing Gate Design

**Risk taxonomy** — the agent reads the diff holistically and classifies risk:

| Risk Level | Example Patterns | Required Testing |
|------------|-----------------|------------------|
| Critical | Payment/billing, auth/session, data deletion, crypto | `runtime-verified` |
| High | Polling loops, page reload, WebSocket, state machines, form handlers | `runtime-verified` |
| Medium | UI components, CSS, routes, config, DB queries | `runtime-verified` or `self-assessed` |
| Low | Docs, comments, types, tests, linter config, agent prompts | `self-assessed` |

**Three testing levels:**
- `self-assessed` — code review + static checks only
- `unit-tested` — automated test suite passes
- `runtime-verified` — application started, behaviour confirmed in running environment

**Forward-compatible** — references sibling tasks (t1660.1-t1660.6) with graceful fallback:
- Uses `testing.json` (t1660.2) when available, conventional detection otherwise
- Uses `browser-qa-helper.sh stability` (t1660.3) when available, `curl` smoke checks otherwise
- Documents testing level in PR body (structured format ready for t1660.6 PR template)

**Intelligence over determinism** — the gate is guidance-driven, not a regex script. The agent reads the diff, understands context, and makes a judgment call about risk level.

## Files Changed

- `.agents/scripts/commands/full-loop.md` — new "Runtime Testing Gate" subsection in Step 3, new completion criterion #9, new `--skip-runtime-testing` option
- `.agents/scripts/full-loop-helper.sh` — `--skip-runtime-testing` flag in CLI parsing, state save/load, background export, help text

## How It Was Tested

- **Testing level:** self-assessed
- **Risk classification:** low (agent prompt/docs change — no runtime behaviour affected)
- ShellCheck: zero new violations on `full-loop-helper.sh`
- Markdown formatter: no formatting issues on `full-loop.md`
- Verified state variable allowlist includes `SKIP_RUNTIME_TESTING`
- Verified flag is parsed, saved, loaded, and exported consistently

Closes #6492