### PR TITLE
feat: add ai-training=false to .gitattributes on aidevops init

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Opt out of AI model training
+* ai-training=false

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1656,6 +1656,30 @@ SOPSEOF
 		fi
 	fi
 
+	# Ensure .gitattributes has ai-training=false (opt out of AI model training)
+	# GitHub and other platforms respect this attribute to exclude repo content
+	# from AI/ML training datasets. Idempotent — only adds if not already present.
+	local gitattributes="$project_root/.gitattributes"
+	if [[ -f "$gitattributes" ]]; then
+		if ! grep -q "ai-training=false" "$gitattributes" 2>/dev/null; then
+			ensure_trailing_newline "$gitattributes"
+			{
+				echo ""
+				echo "# Opt out of AI model training"
+				echo "* ai-training=false"
+			} >>"$gitattributes"
+			print_success "Added ai-training=false to .gitattributes"
+		else
+			print_info ".gitattributes already has ai-training=false"
+		fi
+	else
+		cat >"$gitattributes" <<'GITATTRSEOF'
+# Opt out of AI model training
+* ai-training=false
+GITATTRSEOF
+		print_success "Created .gitattributes with ai-training=false"
+	fi
+
 	# Add aidevops runtime artifacts to .gitignore
 	# Note: .agents/ itself is NOT ignored — it contains committed project-specific agents.
 	# Only runtime artifacts (loop state, tmp, memory) are ignored.
@@ -1793,6 +1817,7 @@ SOPSEOF
 	# Auto-commit initialized files so they don't linger as mystery unstaged
 	# changes (#2570 bug 2). Collect all files that cmd_init creates/modifies.
 	local init_files=()
+	[[ -f "$project_root/.gitattributes" ]] && init_files+=(".gitattributes")
 	[[ -f "$project_root/.gitignore" ]] && init_files+=(".gitignore")
 	[[ -d "$project_root/.agents" ]] && init_files+=(".agents/")
 	[[ -f "$project_root/AGENTS.md" ]] && init_files+=("AGENTS.md")

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1661,7 +1661,7 @@ SOPSEOF
 	# from AI/ML training datasets. Idempotent — only adds if not already present.
 	local gitattributes="$project_root/.gitattributes"
 	if [[ -f "$gitattributes" ]]; then
-		if ! grep -q "ai-training=false" "$gitattributes" 2>/dev/null; then
+		if ! grep -qE '^\*[[:space:]]+ai-training=false' "$gitattributes" 2>/dev/null; then
 			ensure_trailing_newline "$gitattributes"
 			{
 				echo ""


### PR DESCRIPTION
## Summary

- `aidevops init` now ensures every repo has `* ai-training=false` in `.gitattributes`, opting out of AI model training datasets (GitHub, etc.)
- Idempotent: creates the file if missing, appends the rule if file exists without it, skips if already present
- Added `.gitattributes` to the auto-commit file list so it's included in the init commit
- Also applied the change to all 21 existing managed repos (committed + pushed separately)

## Changes

- `aidevops.sh` — Added `.gitattributes` section to `cmd_init()` (before the `.gitignore` block), and added `.gitattributes` to the `init_files` array for auto-commit
- `.gitattributes` — New file for the aidevops repo itself

## Testing

- ShellCheck passes clean on `aidevops.sh`
- Verified idempotent behavior: new file creation, append to existing, skip when present
- Tested across 21 repos: 15 new files created, 4 appended to existing, 2 skipped (missing dirs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `.gitattributes` configuration file to the project.
  * Updated initialization script to automatically create and manage `.gitattributes` during project setup, with safeguards to prevent duplicate entries and maintain proper file formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->