### PR TITLE
feat: distinguish reference corpora from instruction docs in simplification pipeline

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2690,7 +2690,14 @@ _complexity_scan_create_md_issues() {
 **File:** \`${file_path}\`
 **Current size:** ${line_count} lines (threshold: ${COMPLEXITY_MD_LINE_THRESHOLD})
 
-### Proposed action
+### Classify before acting
+
+**First, determine the file type** — the correct action depends on whether this is an instruction doc or a reference corpus:
+
+- **Instruction doc** (agent rules, workflows, decision trees, operational procedures): Tighten prose, reorder by importance, split if multiple concerns. Follow guidance below.
+- **Reference corpus** (SKILL.md, domain knowledge base, textbook-style content with self-contained sections): Do NOT compress content. Instead, split into chapter files with a slim index. See \`tools/code-review/code-simplifier.md\` \"Reference corpora\" classification (GH#6432).
+
+### For instruction docs — proposed action
 
 Tighten and restructure this agent doc. Follow \`tools/build-agent/build-agent.md\` guidance. Key principles:
 
@@ -2699,15 +2706,23 @@ Tighten and restructure this agent doc. Follow \`tools/build-agent/build-agent.m
 3. **Split if needed** — if the file covers multiple distinct concerns, extract sub-docs with a parent index. Use progressive disclosure (pointers, not inline content).
 4. **Use search patterns, not line numbers** — any \`file:line_number\` references to other files go stale on every edit. Use \`rg \"pattern\"\` or section heading references instead.
 
+### For reference corpora — proposed action
+
+1. **Extract each major section** into its own file (e.g., \`01-introduction.md\`, \`02-fundamentals.md\`)
+2. **Replace the original with a slim index** (~100-200 lines) — table of contents with one-line descriptions and file pointers
+3. **Zero content loss** — every line moves to a chapter file, nothing is deleted or compressed
+4. **Reconcile existing chapter files** — if partial splits already exist, deduplicate and keep the most complete version
+
 ### Verification
 
 - Content preservation: all code blocks, URLs, task ID references (\`tNNN\`, \`GH#NNN\`), and command examples must be present before and after
 - No broken internal links or references
 - Agent behaviour unchanged (test with a representative query if possible)
+- For reference corpora: \`wc -l\` total of chapter files >= original line count minus index overhead
 
 ### Confidence: medium
 
-Automated scan identified this file by size. The best simplification strategy requires human judgment — some large files are appropriately large.
+Automated scan identified this file by size. The best simplification strategy requires human judgment — some large files are appropriately large. Reference corpora (SKILL.md, domain knowledge bases) need restructuring into chapters, not content reduction.
 
 ---
 **To approve or decline**, comment on this issue:

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -134,6 +134,27 @@ Workers that skip verification or mark a PR ready without running the specified 
 - Abstractions that add indirection without clear benefit
 - Consolidating similar sections that address different audiences or contexts
 
+### Reference corpora — restructure, do not compress (GH#6432)
+
+Some large `.md` files are **knowledge bases** (skill docs, domain reference material, textbooks) rather than agent instruction docs. Their size comes from breadth of domain knowledge, not verbosity — the content is already as dense as it should be.
+
+**How to identify:** The file is a SKILL.md or similar reference doc where sections are self-contained domain knowledge (e.g., "Landing Page Optimization", "Checkout Flow Psychology") rather than operational rules, workflows, or decision trees. The content reads like a textbook chapter, not like agent instructions.
+
+**Correct action: split into chapter files with a slim index.** Do NOT compress, summarise, or remove domain knowledge. Instead:
+
+1. Extract each major section (`## N. Section`) into its own file (e.g., `01-introduction.md`, `02-fundamentals.md`)
+2. Replace the original file with a slim index (~100-200 lines) — table of contents with one-line descriptions and file pointers to each chapter
+3. Verify zero content loss: `wc -l` total of all chapter files >= original line count minus index overhead
+4. This enables progressive disclosure — agents load only the chapter they need, not the entire corpus
+
+**What NOT to do with reference corpora:**
+
+- Do not "tighten prose" — reference material is already dense
+- Do not merge small sections to reduce file count — each section is a distinct domain concern
+- Do not remove sections that seem to overlap — domain topics overlap by nature (e.g., social proof appears in landing pages AND checkout flows)
+
+**Issue template guidance:** When creating `simplification-debt` issues for oversized files, classify the file first. If it's a reference corpus, the issue title should say "restructure" not "tighten", and the body should recommend chapter splitting, not prose compression.
+
 ### Almost never simplify (flag but do not recommend)
 
 - Comments containing task IDs, incident numbers, or error pattern data (e.g., `t1345`, `GH#2928`, `46.8% failure rate`) -- these are institutional memory


### PR DESCRIPTION
## Summary

- Add "Reference corpora" classification to `code-simplifier.md` — teaches workers to split knowledge-base files into chapter files with a slim index, rather than compressing domain content
- Update `pulse-wrapper.sh` issue template with a "classify before acting" step that distinguishes instruction docs (tighten prose) from reference corpora (split into chapters)

## Context

GH#6432 flagged `.agents/tools/marketing/cro/SKILL.md` (18,308 lines) for simplification. The file is a CRO domain knowledge base — its size comes from breadth of domain knowledge, not verbosity. The automated scan and worker instructions didn't distinguish between "verbose instruction doc" and "appropriately large reference corpus", risking content loss if a worker compressed the prose.

## Changes

| File | Change |
|------|--------|
| `.agents/tools/code-review/code-simplifier.md` | New classification section: "Reference corpora — restructure, do not compress" with identification criteria, correct action (chapter split), and anti-patterns |
| `.agents/scripts/pulse-wrapper.sh` | Issue template now includes classify-before-acting step with separate guidance paths for instruction docs vs reference corpora |

## Verification

- `bash -n` syntax check: passed
- `shellcheck`: zero violations
- Content preservation: all existing classifications, examples, and institutional knowledge retained
- No functional change to scan logic — only the issue body template is updated

Closes #6432