### PR TITLE
t1665.1: Create runtime-registry.sh — central data source for all runtime properties

### DIFF
--- a/.agents/scripts/runtime-registry.sh
+++ b/.agents/scripts/runtime-registry.sh
@@ -1,0 +1,537 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+# =============================================================================
+# Runtime Registry — Central data source for all supported AI CLI runtimes
+# =============================================================================
+# Single source of truth for runtime properties: binary names, config paths,
+# config formats, MCP root keys, command directories, prompt mechanisms,
+# session databases, and process patterns.
+#
+# Bash 3.2 compatible: uses parallel indexed arrays (no associative arrays).
+#
+# Usage:
+#   source runtime-registry.sh
+#   # Look up a property by runtime ID:
+#   local config_path
+#   config_path=$(rt_config_path "claude-code")
+#   # List all runtime IDs:
+#   rt_list_ids
+#   # Detect which runtimes are installed:
+#   rt_detect_installed
+#
+# Sourced from shared-constants.sh so all scripts inherit it.
+#
+# Design: t1665.1 — registry data source only, no adapters or migration.
+# =============================================================================
+
+# Include guard
+[[ -n "${_RUNTIME_REGISTRY_LOADED:-}" ]] && return 0
+_RUNTIME_REGISTRY_LOADED=1
+
+# =============================================================================
+# Runtime ID Index
+# =============================================================================
+# Each runtime has a stable string ID used as the lookup key.
+# The index position in _RT_IDS corresponds to the same index in all
+# parallel property arrays below.
+#
+# To add a new runtime: append to _RT_IDS and to every _RT_* array below,
+# keeping the same index position. Run tests/test-runtime-registry.sh to
+# verify alignment.
+
+_RT_IDS=(
+	"opencode"    # 0
+	"claude-code" # 1
+	"codex"       # 2
+	"cursor"      # 3
+	"droid"       # 4
+	"gemini-cli"  # 5
+	"windsurf"    # 6
+	"continue"    # 7
+	"kilo"        # 8
+	"kiro"        # 9
+	"aider"       # 10
+	"amp"         # 11
+)
+
+# Total count — used for alignment validation
+_RT_COUNT=${#_RT_IDS[@]}
+
+# =============================================================================
+# Property Arrays (parallel to _RT_IDS)
+# =============================================================================
+# IMPORTANT: Every array MUST have exactly _RT_COUNT elements. Use "" for
+# unknown/not-applicable values. The test suite validates alignment.
+
+# --- Binary names (what to pass to `command -v`) ---
+_RT_BINARY=(
+	"opencode" # opencode
+	"claude"   # claude-code
+	"codex"    # codex
+	"cursor"   # cursor
+	"droid"    # droid
+	"gemini"   # gemini-cli
+	"windsurf" # windsurf
+	"continue" # continue
+	"kilo"     # kilo
+	"kiro"     # kiro
+	"aider"    # aider
+	"amp"      # amp
+)
+
+# --- Display names (human-readable) ---
+_RT_DISPLAY_NAME=(
+	"OpenCode"    # opencode
+	"Claude Code" # claude-code
+	"Codex CLI"   # codex
+	"Cursor"      # cursor
+	"Droid"       # droid
+	"Gemini CLI"  # gemini-cli
+	"Windsurf"    # windsurf
+	"Continue"    # continue
+	"Kilo Code"   # kilo
+	"Kiro"        # kiro
+	"Aider"       # aider
+	"Amp"         # amp
+)
+
+# --- MCP config file paths (~ expanded at lookup time) ---
+# Use $HOME explicitly; ~ is not expanded inside double quotes.
+_RT_CONFIG_PATH=(
+	"\$HOME/.config/opencode/config.jsonc"             # opencode
+	"\$HOME/.config/Claude/claude_desktop_config.json" # claude-code
+	"\$HOME/.codex/config.json"                        # codex
+	"\$HOME/.cursor/mcp.json"                          # cursor
+	"\$HOME/.config/droid/mcp.json"                    # droid
+	"\$HOME/.gemini/settings.json"                     # gemini-cli
+	"\$HOME/.codeium/windsurf/mcp_config.json"         # windsurf
+	"\$HOME/.continue/config.json"                     # continue
+	"\$HOME/.kilo/mcp.json"                            # kilo
+	"\$HOME/.kiro/settings/mcp.json"                   # kiro
+	""                                                 # aider (no MCP config)
+	"\$HOME/.amp/settings.json"                        # amp
+)
+
+# --- Config file formats ---
+_RT_CONFIG_FORMAT=(
+	"jsonc" # opencode
+	"json"  # claude-code
+	"json"  # codex
+	"json"  # cursor
+	"json"  # droid
+	"json"  # gemini-cli
+	"json"  # windsurf
+	"json"  # continue
+	"json"  # kilo
+	"json"  # kiro
+	""      # aider
+	"json"  # amp
+)
+
+# --- MCP root key (the JSON key under which MCP servers are defined) ---
+_RT_MCP_ROOT_KEY=(
+	"mcpServers" # opencode — inside config.jsonc
+	"mcpServers" # claude-code
+	"mcpServers" # codex
+	"mcpServers" # cursor
+	"mcpServers" # droid
+	"mcpServers" # gemini-cli
+	"mcpServers" # windsurf
+	"mcpServers" # continue
+	"mcpServers" # kilo
+	"mcpServers" # kiro
+	""           # aider
+	"mcpServers" # amp
+)
+
+# --- Slash command directories (where /command files live) ---
+_RT_COMMAND_DIR=(
+	"\$HOME/.config/opencode/command" # opencode
+	"\$HOME/.claude/commands"         # claude-code
+	""                                # codex
+	""                                # cursor
+	""                                # droid
+	""                                # gemini-cli
+	""                                # windsurf
+	""                                # continue
+	""                                # kilo
+	""                                # kiro
+	""                                # aider
+	""                                # amp
+)
+
+# --- Prompt mechanism (how the runtime loads system instructions) ---
+# Values: "AGENTS.md" (file-based), "system-prompt" (API param),
+#         "config" (in config file), "" (unknown/none)
+_RT_PROMPT_MECHANISM=(
+	"AGENTS.md"     # opencode
+	"AGENTS.md"     # claude-code
+	"system-prompt" # codex
+	"config"        # cursor (.cursorrules)
+	"AGENTS.md"     # droid
+	"system-prompt" # gemini-cli
+	"config"        # windsurf (.windsurfrules)
+	"config"        # continue (.continuerules)
+	"system-prompt" # kilo
+	"AGENTS.md"     # kiro
+	"config"        # aider (.aider.conf.yml)
+	"AGENTS.md"     # amp
+)
+
+# --- Session database paths ---
+# Where the runtime stores session/conversation history.
+# Use $HOME; expanded at lookup time.
+_RT_SESSION_DB=(
+	"\$HOME/.local/share/opencode/opencode.db" # opencode (SQLite)
+	"\$HOME/.claude/projects"                  # claude-code (JSONL dir)
+	""                                         # codex
+	"\$HOME/.cursor/state.vscdb"               # cursor (SQLite)
+	""                                         # droid
+	""                                         # gemini-cli
+	""                                         # windsurf
+	""                                         # continue
+	""                                         # kilo
+	""                                         # kiro
+	""                                         # aider
+	""                                         # amp
+)
+
+# --- Session DB format ---
+_RT_SESSION_DB_FORMAT=(
+	"sqlite"    # opencode
+	"jsonl-dir" # claude-code
+	""          # codex
+	"sqlite"    # cursor
+	""          # droid
+	""          # gemini-cli
+	""          # windsurf
+	""          # continue
+	""          # kilo
+	""          # kiro
+	""          # aider
+	""          # amp
+)
+
+# --- Process patterns (for pgrep/ps detection of running instances) ---
+_RT_PROCESS_PATTERN=(
+	"opencode" # opencode
+	"claude"   # claude-code
+	"codex"    # codex
+	"cursor"   # cursor (Electron app name)
+	"droid"    # droid
+	"gemini"   # gemini-cli
+	"windsurf" # windsurf (Electron app name)
+	"continue" # continue
+	"kilo"     # kilo
+	"kiro"     # kiro
+	"aider"    # aider (Python process)
+	"amp"      # amp
+)
+
+# --- Headless support (can the runtime run without a UI?) ---
+# "yes" = has a headless/CLI mode, "no" = GUI/editor only, "" = unknown
+_RT_HEADLESS_SUPPORT=(
+	"yes" # opencode
+	"yes" # claude-code
+	"yes" # codex
+	"no"  # cursor (editor-only)
+	"yes" # droid
+	"yes" # gemini-cli
+	"no"  # windsurf (editor-only)
+	"no"  # continue (editor extension)
+	"yes" # kilo
+	"no"  # kiro (editor-only)
+	"yes" # aider
+	"yes" # amp
+)
+
+# =============================================================================
+# Internal: Index Lookup
+# =============================================================================
+# Returns the array index for a given runtime ID, or 1 if not found.
+# This is the core lookup used by all rt_* functions.
+
+_rt_index() {
+	local id="$1"
+	local i=0
+	while [[ $i -lt $_RT_COUNT ]]; do
+		if [[ "${_RT_IDS[$i]}" == "$id" ]]; then
+			echo "$i"
+			return 0
+		fi
+		i=$((i + 1))
+	done
+	return 1
+}
+
+# Expand $HOME in a path string.
+# Handles the "\$HOME" literal stored in arrays (to avoid premature expansion).
+_rt_expand_path() {
+	local path="$1"
+	# Replace literal $HOME or \$HOME with actual HOME value
+	path="${path//\\\$HOME/$HOME}"
+	path="${path//\$HOME/$HOME}"
+	echo "$path"
+	return 0
+}
+
+# =============================================================================
+# Public API: Property Lookups
+# =============================================================================
+# All functions take a runtime ID as $1 and print the value to stdout.
+# Return 0 on success, 1 if the runtime ID is unknown.
+# Empty string output means "not applicable" for that runtime.
+
+rt_binary() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_BINARY[$idx]}"
+	return 0
+}
+
+rt_display_name() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_DISPLAY_NAME[$idx]}"
+	return 0
+}
+
+rt_config_path() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	_rt_expand_path "${_RT_CONFIG_PATH[$idx]}"
+	return 0
+}
+
+rt_config_format() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_CONFIG_FORMAT[$idx]}"
+	return 0
+}
+
+rt_mcp_root_key() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_MCP_ROOT_KEY[$idx]}"
+	return 0
+}
+
+rt_command_dir() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	_rt_expand_path "${_RT_COMMAND_DIR[$idx]}"
+	return 0
+}
+
+rt_prompt_mechanism() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_PROMPT_MECHANISM[$idx]}"
+	return 0
+}
+
+rt_session_db() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	_rt_expand_path "${_RT_SESSION_DB[$idx]}"
+	return 0
+}
+
+rt_session_db_format() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_SESSION_DB_FORMAT[$idx]}"
+	return 0
+}
+
+rt_process_pattern() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_PROCESS_PATTERN[$idx]}"
+	return 0
+}
+
+rt_headless_support() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_HEADLESS_SUPPORT[$idx]}"
+	return 0
+}
+
+# =============================================================================
+# Public API: Enumeration and Detection
+# =============================================================================
+
+# Print all runtime IDs, one per line.
+rt_list_ids() {
+	local i=0
+	while [[ $i -lt $_RT_COUNT ]]; do
+		echo "${_RT_IDS[$i]}"
+		i=$((i + 1))
+	done
+	return 0
+}
+
+# Print the total number of registered runtimes.
+rt_count() {
+	echo "$_RT_COUNT"
+	return 0
+}
+
+# Detect which runtimes are installed (binary found in PATH).
+# Prints installed runtime IDs, one per line.
+# Returns 0 if at least one found, 1 if none.
+rt_detect_installed() {
+	local found=0
+	local i=0
+	local bin
+	while [[ $i -lt $_RT_COUNT ]]; do
+		bin="${_RT_BINARY[$i]}"
+		if [[ -n "$bin" ]] && command -v "$bin" >/dev/null 2>&1; then
+			echo "${_RT_IDS[$i]}"
+			found=1
+		fi
+		i=$((i + 1))
+	done
+	if [[ $found -eq 1 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# Detect which runtimes have MCP config files present.
+# Prints runtime IDs with existing config files, one per line.
+rt_detect_configured() {
+	local found=0
+	local i=0
+	local path
+	while [[ $i -lt $_RT_COUNT ]]; do
+		path="${_RT_CONFIG_PATH[$i]}"
+		if [[ -n "$path" ]]; then
+			path=$(_rt_expand_path "$path")
+			if [[ -f "$path" ]]; then
+				echo "${_RT_IDS[$i]}"
+				found=1
+			fi
+		fi
+		i=$((i + 1))
+	done
+	if [[ $found -eq 1 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# Detect which runtimes have running processes.
+# Prints runtime IDs with detected processes, one per line.
+rt_detect_running() {
+	local found=0
+	local i=0
+	local pattern
+	while [[ $i -lt $_RT_COUNT ]]; do
+		pattern="${_RT_PROCESS_PATTERN[$i]}"
+		if [[ -n "$pattern" ]] && pgrep -x "$pattern" >/dev/null 2>&1; then
+			echo "${_RT_IDS[$i]}"
+			found=1
+		fi
+		i=$((i + 1))
+	done
+	if [[ $found -eq 1 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# Look up a runtime ID by its binary name.
+# Useful for reverse lookups (e.g., "which runtime is 'claude'?").
+# Returns 0 and prints the ID, or 1 if not found.
+rt_id_from_binary() {
+	local bin="$1"
+	local i=0
+	while [[ $i -lt $_RT_COUNT ]]; do
+		if [[ "${_RT_BINARY[$i]}" == "$bin" ]]; then
+			echo "${_RT_IDS[$i]}"
+			return 0
+		fi
+		i=$((i + 1))
+	done
+	return 1
+}
+
+# List runtimes that support headless operation.
+# Prints runtime IDs, one per line.
+rt_list_headless() {
+	local i=0
+	while [[ $i -lt $_RT_COUNT ]]; do
+		if [[ "${_RT_HEADLESS_SUPPORT[$i]}" == "yes" ]]; then
+			echo "${_RT_IDS[$i]}"
+		fi
+		i=$((i + 1))
+	done
+	return 0
+}
+
+# List runtimes that have slash command directories.
+# Prints runtime IDs, one per line.
+rt_list_with_commands() {
+	local i=0
+	while [[ $i -lt $_RT_COUNT ]]; do
+		if [[ -n "${_RT_COMMAND_DIR[$i]}" ]]; then
+			echo "${_RT_IDS[$i]}"
+		fi
+		i=$((i + 1))
+	done
+	return 0
+}
+
+# =============================================================================
+# Validation (called by test suite, safe to call at source time)
+# =============================================================================
+# Verifies all parallel arrays have the same length as _RT_IDS.
+# Returns 0 if valid, 1 if misaligned (prints which array is wrong).
+
+rt_validate_registry() {
+	local errors=0
+	local arrays=(
+		"_RT_BINARY"
+		"_RT_DISPLAY_NAME"
+		"_RT_CONFIG_PATH"
+		"_RT_CONFIG_FORMAT"
+		"_RT_MCP_ROOT_KEY"
+		"_RT_COMMAND_DIR"
+		"_RT_PROMPT_MECHANISM"
+		"_RT_SESSION_DB"
+		"_RT_SESSION_DB_FORMAT"
+		"_RT_PROCESS_PATTERN"
+		"_RT_HEADLESS_SUPPORT"
+	)
+
+	local arr_name
+	for arr_name in "${arrays[@]}"; do
+		local count_cmd="${arr_name}[@]"
+		local arr_vals=("${!count_cmd}")
+		local arr_len=${#arr_vals[@]}
+		if [[ $arr_len -ne $_RT_COUNT ]]; then
+			echo "MISALIGNED: $arr_name has $arr_len elements, expected $_RT_COUNT" >&2
+			errors=$((errors + 1))
+		fi
+	done
+
+	if [[ $errors -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1540,6 +1540,13 @@ if [[ -r "$_CONFIG_HELPER" ]]; then
 	source "$_CONFIG_HELPER"
 fi
 
+# Source runtime registry (t1665.1) — central data source for all AI CLI runtimes
+_RUNTIME_REGISTRY="${_SC_SELF%/*}/runtime-registry.sh"
+if [[ -r "$_RUNTIME_REGISTRY" ]]; then
+	# shellcheck source=/dev/null
+	source "$_RUNTIME_REGISTRY"
+fi
+
 # Legacy paths (kept for backward compatibility and migration)
 FEATURE_TOGGLES_DEFAULTS="${HOME}/.aidevops/agents/configs/feature-toggles.conf.defaults"
 FEATURE_TOGGLES_USER="${HOME}/.config/aidevops/feature-toggles.conf"

--- a/tests/test-runtime-registry.sh
+++ b/tests/test-runtime-registry.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+
+# =============================================================================
+# Tests for runtime-registry.sh
+# =============================================================================
+# Validates: array alignment, lookup functions, enumeration, detection,
+# reverse lookups, and path expansion.
+#
+# Usage: bash tests/test-runtime-registry.sh [--verbose]
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGISTRY="$REPO_DIR/.agents/scripts/runtime-registry.sh"
+VERBOSE="${1:-}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TOTAL_COUNT=0
+
+pass() {
+	local message="$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	if [[ "$VERBOSE" == "--verbose" ]]; then
+		printf "  PASS %s\n" "$message"
+	fi
+	return 0
+}
+
+fail() {
+	local message="$1"
+	local detail="${2:-}"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  FAIL %s\n" "$message"
+	if [[ -n "$detail" ]]; then
+		printf "       %s\n" "$detail"
+	fi
+	return 0
+}
+
+section() {
+	local title="$1"
+	echo ""
+	printf "=== %s ===\n" "$title"
+	return 0
+}
+
+# Source the registry
+# shellcheck source=../.agents/scripts/runtime-registry.sh
+source "$REGISTRY"
+
+# =============================================================================
+section "Registry Validation"
+# =============================================================================
+
+if rt_validate_registry; then
+	pass "All parallel arrays are aligned"
+else
+	fail "Parallel array alignment check failed"
+fi
+
+# Verify count is reasonable (at least 10 runtimes defined)
+count=$(rt_count)
+if [[ "$count" -ge 10 ]]; then
+	pass "Registry has $count runtimes (>= 10)"
+else
+	fail "Registry has only $count runtimes (expected >= 10)"
+fi
+
+# =============================================================================
+section "Property Lookups — Known Runtimes"
+# =============================================================================
+
+# --- opencode ---
+result=$(rt_binary "opencode")
+if [[ "$result" == "opencode" ]]; then
+	pass "rt_binary opencode = opencode"
+else
+	fail "rt_binary opencode" "expected 'opencode', got '$result'"
+fi
+
+result=$(rt_display_name "opencode")
+if [[ "$result" == "OpenCode" ]]; then
+	pass "rt_display_name opencode = OpenCode"
+else
+	fail "rt_display_name opencode" "expected 'OpenCode', got '$result'"
+fi
+
+result=$(rt_config_format "opencode")
+if [[ "$result" == "jsonc" ]]; then
+	pass "rt_config_format opencode = jsonc"
+else
+	fail "rt_config_format opencode" "expected 'jsonc', got '$result'"
+fi
+
+result=$(rt_mcp_root_key "opencode")
+if [[ "$result" == "mcpServers" ]]; then
+	pass "rt_mcp_root_key opencode = mcpServers"
+else
+	fail "rt_mcp_root_key opencode" "expected 'mcpServers', got '$result'"
+fi
+
+result=$(rt_prompt_mechanism "opencode")
+if [[ "$result" == "AGENTS.md" ]]; then
+	pass "rt_prompt_mechanism opencode = AGENTS.md"
+else
+	fail "rt_prompt_mechanism opencode" "expected 'AGENTS.md', got '$result'"
+fi
+
+result=$(rt_session_db_format "opencode")
+if [[ "$result" == "sqlite" ]]; then
+	pass "rt_session_db_format opencode = sqlite"
+else
+	fail "rt_session_db_format opencode" "expected 'sqlite', got '$result'"
+fi
+
+result=$(rt_headless_support "opencode")
+if [[ "$result" == "yes" ]]; then
+	pass "rt_headless_support opencode = yes"
+else
+	fail "rt_headless_support opencode" "expected 'yes', got '$result'"
+fi
+
+# --- claude-code ---
+result=$(rt_binary "claude-code")
+if [[ "$result" == "claude" ]]; then
+	pass "rt_binary claude-code = claude"
+else
+	fail "rt_binary claude-code" "expected 'claude', got '$result'"
+fi
+
+result=$(rt_display_name "claude-code")
+if [[ "$result" == "Claude Code" ]]; then
+	pass "rt_display_name claude-code = Claude Code"
+else
+	fail "rt_display_name claude-code" "expected 'Claude Code', got '$result'"
+fi
+
+result=$(rt_config_format "claude-code")
+if [[ "$result" == "json" ]]; then
+	pass "rt_config_format claude-code = json"
+else
+	fail "rt_config_format claude-code" "expected 'json', got '$result'"
+fi
+
+result=$(rt_session_db_format "claude-code")
+if [[ "$result" == "jsonl-dir" ]]; then
+	pass "rt_session_db_format claude-code = jsonl-dir"
+else
+	fail "rt_session_db_format claude-code" "expected 'jsonl-dir', got '$result'"
+fi
+
+# --- cursor ---
+result=$(rt_headless_support "cursor")
+if [[ "$result" == "no" ]]; then
+	pass "rt_headless_support cursor = no (editor-only)"
+else
+	fail "rt_headless_support cursor" "expected 'no', got '$result'"
+fi
+
+# --- aider ---
+result=$(rt_config_path "aider")
+if [[ "$result" == "" ]]; then
+	pass "rt_config_path aider = '' (no MCP config)"
+else
+	fail "rt_config_path aider" "expected empty, got '$result'"
+fi
+
+result=$(rt_mcp_root_key "aider")
+if [[ "$result" == "" ]]; then
+	pass "rt_mcp_root_key aider = '' (no MCP)"
+else
+	fail "rt_mcp_root_key aider" "expected empty, got '$result'"
+fi
+
+# =============================================================================
+section "Path Expansion"
+# =============================================================================
+
+result=$(rt_config_path "opencode")
+expected="$HOME/.config/opencode/config.jsonc"
+if [[ "$result" == "$expected" ]]; then
+	pass "rt_config_path opencode expands \$HOME correctly"
+else
+	fail "rt_config_path opencode expansion" "expected '$expected', got '$result'"
+fi
+
+result=$(rt_session_db "opencode")
+expected="$HOME/.local/share/opencode/opencode.db"
+if [[ "$result" == "$expected" ]]; then
+	pass "rt_session_db opencode expands \$HOME correctly"
+else
+	fail "rt_session_db opencode expansion" "expected '$expected', got '$result'"
+fi
+
+result=$(rt_command_dir "claude-code")
+expected="$HOME/.claude/commands"
+if [[ "$result" == "$expected" ]]; then
+	pass "rt_command_dir claude-code expands \$HOME correctly"
+else
+	fail "rt_command_dir claude-code expansion" "expected '$expected', got '$result'"
+fi
+
+# =============================================================================
+section "Unknown Runtime Handling"
+# =============================================================================
+
+if ! rt_binary "nonexistent-runtime" 2>/dev/null; then
+	pass "rt_binary returns 1 for unknown runtime"
+else
+	fail "rt_binary should return 1 for unknown runtime"
+fi
+
+if ! rt_config_path "nonexistent-runtime" 2>/dev/null; then
+	pass "rt_config_path returns 1 for unknown runtime"
+else
+	fail "rt_config_path should return 1 for unknown runtime"
+fi
+
+# =============================================================================
+section "Enumeration Functions"
+# =============================================================================
+
+# rt_list_ids should include known runtimes
+ids=$(rt_list_ids)
+if echo "$ids" | grep -q "opencode"; then
+	pass "rt_list_ids includes opencode"
+else
+	fail "rt_list_ids missing opencode"
+fi
+
+if echo "$ids" | grep -q "claude-code"; then
+	pass "rt_list_ids includes claude-code"
+else
+	fail "rt_list_ids missing claude-code"
+fi
+
+if echo "$ids" | grep -q "aider"; then
+	pass "rt_list_ids includes aider"
+else
+	fail "rt_list_ids missing aider"
+fi
+
+# rt_list_headless should include opencode and claude-code but not cursor
+headless=$(rt_list_headless)
+if echo "$headless" | grep -q "opencode"; then
+	pass "rt_list_headless includes opencode"
+else
+	fail "rt_list_headless missing opencode"
+fi
+
+if echo "$headless" | grep -q "claude-code"; then
+	pass "rt_list_headless includes claude-code"
+else
+	fail "rt_list_headless missing claude-code"
+fi
+
+if ! echo "$headless" | grep -q "cursor"; then
+	pass "rt_list_headless excludes cursor (editor-only)"
+else
+	fail "rt_list_headless should exclude cursor"
+fi
+
+# rt_list_with_commands should include opencode and claude-code
+with_cmds=$(rt_list_with_commands)
+if echo "$with_cmds" | grep -q "opencode"; then
+	pass "rt_list_with_commands includes opencode"
+else
+	fail "rt_list_with_commands missing opencode"
+fi
+
+if echo "$with_cmds" | grep -q "claude-code"; then
+	pass "rt_list_with_commands includes claude-code"
+else
+	fail "rt_list_with_commands missing claude-code"
+fi
+
+# =============================================================================
+section "Reverse Lookup"
+# =============================================================================
+
+result=$(rt_id_from_binary "claude")
+if [[ "$result" == "claude-code" ]]; then
+	pass "rt_id_from_binary claude = claude-code"
+else
+	fail "rt_id_from_binary claude" "expected 'claude-code', got '$result'"
+fi
+
+result=$(rt_id_from_binary "opencode")
+if [[ "$result" == "opencode" ]]; then
+	pass "rt_id_from_binary opencode = opencode"
+else
+	fail "rt_id_from_binary opencode" "expected 'opencode', got '$result'"
+fi
+
+result=$(rt_id_from_binary "aider")
+if [[ "$result" == "aider" ]]; then
+	pass "rt_id_from_binary aider = aider"
+else
+	fail "rt_id_from_binary aider" "expected 'aider', got '$result'"
+fi
+
+if ! rt_id_from_binary "nonexistent-binary" 2>/dev/null; then
+	pass "rt_id_from_binary returns 1 for unknown binary"
+else
+	fail "rt_id_from_binary should return 1 for unknown binary"
+fi
+
+# =============================================================================
+section "All Properties for Each Runtime"
+# =============================================================================
+# Verify every runtime has non-empty binary and display name (minimum requirement)
+
+all_ids=$(rt_list_ids)
+while IFS= read -r rid; do
+	bin=$(rt_binary "$rid")
+	if [[ -n "$bin" ]]; then
+		pass "rt_binary $rid is non-empty ($bin)"
+	else
+		fail "rt_binary $rid is empty (every runtime needs a binary name)"
+	fi
+
+	name=$(rt_display_name "$rid")
+	if [[ -n "$name" ]]; then
+		pass "rt_display_name $rid is non-empty ($name)"
+	else
+		fail "rt_display_name $rid is empty (every runtime needs a display name)"
+	fi
+done <<<"$all_ids"
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo ""
+echo "=== Results ==="
+printf "Total: %d  Passed: %d  Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Add `runtime-registry.sh` as the single source of truth for all supported AI CLI runtime properties (12 runtimes: OpenCode, Claude Code, Codex, Cursor, Droid, Gemini CLI, Windsurf, Continue, Kilo, Kiro, Aider, Amp)
- Bash 3.2 compatible: parallel indexed arrays with lookup functions for binary names, config paths, config formats, MCP root keys, command dirs, prompt mechanisms, session DBs, process patterns, and headless support
- Source from `shared-constants.sh` so all 70+ scripts inherit the registry automatically

## What Changed

| File | Change |
|------|--------|
| `.agents/scripts/runtime-registry.sh` | **New** — 12 parallel property arrays, 11 lookup functions, 7 enumeration/detection functions, 1 validation function |
| `.agents/scripts/shared-constants.sh` | Source `runtime-registry.sh` after `config-helper.sh` |
| `tests/test-runtime-registry.sh` | **New** — 57 tests covering alignment, lookups, path expansion, unknown runtime handling, enumeration, and reverse lookups |

## Task Lineage

- **Parent:** t1665 (Runtime abstraction layer)
- **This task:** t1665.1 — registry data source only (no adapters or migration)
- **Siblings:** t1665.2 (runtime adapter functions), t1665.3 (MCP config adapter), t1665.4 (command generation adapter), t1665.5 (session/memory adapter), t1665.6 (migration of hardcoded paths)

## Cross-task stubs

None required — this is the foundational data layer. Sibling tasks will `source runtime-registry.sh` and call `rt_*` functions.

## Testing

```
$ bash tests/test-runtime-registry.sh --verbose
Total: 57  Passed: 57  Failed: 0
```

ShellCheck: zero violations on all 3 files.

Closes #6532