### PR TITLE
docs: exempt pinned monitoring issues from title verbosity guidance

### DIFF
--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -134,6 +134,8 @@ Use `templates/brief-template.md`. The brief captures: origin (session ID, date,
 
 Task descriptions in TODO.md become GitHub issue titles. Write them so that a reader scanning a list of 50 issues can immediately tell whether two issues describe the same work. This is the primary input to the pulse's intelligence-first duplicate detection.
 
+Exception: persistent/pinned monitoring issues (for example daily review, dashboard, or long-lived watcher threads) keep their existing concise title style for continuity. Apply the verbosity guidance to normal task-generated issues, not pinned monitoring threads.
+
 **Good descriptions** — specific enough to distinguish from similar work:
 - `Add WooCommerce tax fallback when no tax class matches product category`
 - `Fix infinite redirect loop on /login when session cookie is expired`


### PR DESCRIPTION
## Summary
- Add an explicit exception in `plans.md` so pinned/persistent monitoring issues keep their existing concise title style
- Keep verbose what/where/why title guidance for normal task-generated issues

## Why
The broad verbosity guidance was too aggressive for long-lived monitoring threads (for example issue #2632), where title continuity is more valuable than descriptive expansion.

Refs #2632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidelines to clarify title conventions for persistent monitoring items, allowing them to maintain their existing concise format while normal task-generated items follow updated verbosity standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->