### PR TITLE
GH#6538: Fix headless-runtime-helper.sh spawning duplicate worker processes

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -22,6 +22,63 @@ readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"
 readonly SANDBOX_EXEC_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
 readonly HEADLESS_SANDBOX_TIMEOUT_DEFAULT="${AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT:-3600}"
 readonly OPENCODE_AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
+readonly LOCK_DIR="${STATE_DIR}/locks"
+
+# _acquire_session_lock: prevent duplicate workers for the same session-key (GH#6538).
+#
+# Creates a PID lock file at $LOCK_DIR/<session_key>.pid. If a lock file
+# already exists with a live PID, returns 1 (duplicate — caller should exit).
+# If the PID is dead, cleans up the stale lock and acquires a new one.
+#
+# Args: $1 = session_key
+# Returns: 0 = lock acquired, 1 = duplicate detected (live process exists)
+_acquire_session_lock() {
+	local lock_session_key="$1"
+	mkdir -p "$LOCK_DIR" 2>/dev/null || true
+
+	# Sanitise session key for use as filename (replace / and spaces)
+	local safe_key
+	safe_key=$(printf '%s' "$lock_session_key" | tr '/ ' '__')
+	local lock_file="${LOCK_DIR}/${safe_key}.pid"
+
+	if [[ -f "$lock_file" ]]; then
+		local existing_pid
+		existing_pid=$(cat "$lock_file" 2>/dev/null) || existing_pid=""
+		if [[ -n "$existing_pid" ]] && [[ "$existing_pid" =~ ^[0-9]+$ ]]; then
+			if kill -0 "$existing_pid" 2>/dev/null; then
+				# Live process exists — duplicate dispatch
+				print_warning "Duplicate dispatch blocked: session-key '${lock_session_key}' already has active worker PID ${existing_pid} (GH#6538)"
+				return 1
+			fi
+			# PID is dead — stale lock, clean up and proceed
+		fi
+		rm -f "$lock_file"
+	fi
+
+	# Write our PID to the lock file
+	printf '%s' "$$" >"$lock_file"
+	return 0
+}
+
+# _release_session_lock: remove the PID lock file for a session-key.
+# Only removes if the lock file contains our own PID (safety against races).
+#
+# Args: $1 = session_key
+_release_session_lock() {
+	local lock_session_key="$1"
+	local safe_key
+	safe_key=$(printf '%s' "$lock_session_key" | tr '/ ' '__')
+	local lock_file="${LOCK_DIR}/${safe_key}.pid"
+
+	if [[ -f "$lock_file" ]]; then
+		local stored_pid
+		stored_pid=$(cat "$lock_file" 2>/dev/null) || stored_pid=""
+		if [[ "$stored_pid" == "$$" ]]; then
+			rm -f "$lock_file"
+		fi
+	fi
+	return 0
+}
 
 build_sandbox_passthrough_csv() {
 	local names=()
@@ -1035,12 +1092,29 @@ cmd_run() {
 	_parse_run_args "$@" || return 1
 	_validate_run_args || return 1
 
+	# GH#6538: Acquire a session-key lock to prevent duplicate workers.
+	# The pulse (or any caller) may dispatch the same session-key twice in
+	# rapid succession — before the first worker appears in process lists.
+	# The lock file acts as an immediate dedup guard: the second invocation
+	# sees the first's PID and exits without spawning a sandbox process.
+	if ! _acquire_session_lock "$session_key"; then
+		return 0
+	fi
+	# shellcheck disable=SC2064
+	trap "_release_session_lock '$session_key'" EXIT
+
 	local selected_model
-	selected_model=$(choose_model "$role" "$model_override") || return $?
+	selected_model=$(choose_model "$role" "$model_override") || {
+		local choose_exit=$?
+		_release_session_lock "$session_key"
+		trap - EXIT
+		return "$choose_exit"
+	}
 
 	local attempt=1
 	local max_attempts=2
 	local _run_failure_reason=""
+	local run_exit=1
 	while [[ "$attempt" -le "$max_attempts" ]]; do
 		_run_failure_reason=""
 		_execute_run_attempt \
@@ -1049,17 +1123,27 @@ cmd_run() {
 			"${extra_args[@]+"${extra_args[@]}"}"
 		local attempt_exit=$?
 
-		[[ "$attempt_exit" -eq 0 ]] && return 0
+		if [[ "$attempt_exit" -eq 0 ]]; then
+			_release_session_lock "$session_key"
+			trap - EXIT
+			return 0
+		fi
 
 		# Only retry on auth errors when no explicit model was requested
 		# and we have attempts remaining.
 		if [[ -n "$model_override" || "$_run_failure_reason" != "auth_error" || "$attempt" -ge "$max_attempts" ]]; then
+			_release_session_lock "$session_key"
+			trap - EXIT
 			return "$attempt_exit"
 		fi
 
 		local provider next_model
 		provider=$(extract_provider "$selected_model")
-		next_model=$(choose_model "$role" "") || return "$attempt_exit"
+		next_model=$(choose_model "$role" "") || {
+			_release_session_lock "$session_key"
+			trap - EXIT
+			return "$attempt_exit"
+		}
 		print_warning "$provider auth failure detected at startup; retrying once with alternate provider model $next_model"
 		selected_model="$next_model"
 		attempt=$((attempt + 1))
@@ -1067,6 +1151,8 @@ cmd_run() {
 
 	# Unreachable: loop always executes (attempt starts at 1, max_attempts=2)
 	# and every path inside returns explicitly. Kept as defensive fallback.
+	_release_session_lock "$session_key"
+	trap - EXIT
 	return 1
 }
 
@@ -1085,6 +1171,12 @@ Backoff granularity:
   Rate limits and provider errors are recorded per model (e.g. anthropic/claude-sonnet-4-6).
   Auth errors are recorded per provider (e.g. anthropic) since credentials are shared.
   This allows fallback from sonnet to opus when only sonnet is rate-limited.
+
+Dedup guard (GH#6538):
+  Each 'run' invocation acquires a PID lock file keyed by --session-key.
+  If a live process already holds the lock, the second invocation exits
+  immediately (exit 0) without spawning a worker. Stale locks (dead PIDs)
+  are cleaned up automatically. Lock files: $STATE_DIR/locks/<key>.pid
 
 Defaults:
   AIDEVOPS_HEADLESS_MODELS defaults to anthropic/claude-sonnet-4-6,openai/gpt-4o

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -357,6 +357,67 @@ else
 	fail "explicit --model opencode/* is accepted" "got: $explicit_gateway"
 fi
 
+section "Session-Key Dedup Guard (GH#6538)"
+# Test 1: A second run with the same session-key while the first is "running"
+# should be blocked. Simulate by writing a lock file with our own PID (which
+# is alive), then attempting a run with the same session-key.
+LOCK_DIR="$TEST_TMP_DIR/runtime/locks"
+mkdir -p "$LOCK_DIR"
+echo "$$" >"$LOCK_DIR/issue-dedup-test.pid"
+rm -f "$STUB_LOG_FILE"
+AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=anthropic bash "$HELPER" run \
+	--role worker \
+	--session-key "issue-dedup-test" \
+	--dir "$REPO_DIR" \
+	--title "Issue #999: Dedup test" \
+	--prompt "Reply with exactly OK" >/dev/null 2>&1 || true
+if [[ -f "$STUB_LOG_FILE" ]]; then
+	fail "dedup guard blocks second dispatch with same session-key" "stub was invoked (opencode ran)"
+else
+	pass "dedup guard blocks second dispatch with same session-key"
+fi
+rm -f "$LOCK_DIR/issue-dedup-test.pid"
+
+# Test 2: A stale lock (dead PID) should be cleaned up and the run should proceed.
+echo "99999999" >"$LOCK_DIR/issue-stale-test.pid"
+rm -f "$STUB_LOG_FILE"
+export STUB_SESSION_ID="ses_stale_lock"
+AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=anthropic bash "$HELPER" run \
+	--role worker \
+	--session-key "issue-stale-test" \
+	--dir "$REPO_DIR" \
+	--title "Issue #998: Stale lock test" \
+	--prompt "Reply with exactly OK" >/dev/null 2>&1
+if [[ -f "$STUB_LOG_FILE" ]] && grep -q 'Reply with exactly OK' "$STUB_LOG_FILE"; then
+	pass "stale lock (dead PID) is cleaned up and run proceeds"
+else
+	fail "stale lock (dead PID) is cleaned up and run proceeds" "stub log: $(cat "$STUB_LOG_FILE" 2>/dev/null || echo 'missing')"
+fi
+
+# Test 3: Lock file should be cleaned up after a successful run.
+if [[ -f "$LOCK_DIR/issue-stale-test.pid" ]]; then
+	fail "lock file cleaned up after successful run" "lock file still exists"
+else
+	pass "lock file cleaned up after successful run"
+fi
+
+# Test 4: Different session-keys should not block each other.
+echo "$$" >"$LOCK_DIR/issue-other.pid"
+rm -f "$STUB_LOG_FILE"
+export STUB_SESSION_ID="ses_different_key"
+AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=anthropic bash "$HELPER" run \
+	--role worker \
+	--session-key "issue-different" \
+	--dir "$REPO_DIR" \
+	--title "Issue #997: Different key" \
+	--prompt "Reply with exactly OK" >/dev/null 2>&1
+if [[ -f "$STUB_LOG_FILE" ]] && grep -q 'Reply with exactly OK' "$STUB_LOG_FILE"; then
+	pass "different session-keys do not block each other"
+else
+	fail "different session-keys do not block each other" "stub log: $(cat "$STUB_LOG_FILE" 2>/dev/null || echo 'missing')"
+fi
+rm -f "$LOCK_DIR/issue-other.pid"
+
 echo ""
 printf "Total: %d, Passed: %d, Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
 


### PR DESCRIPTION
## Summary

- Adds a session-key-based PID lock mechanism to `headless-runtime-helper.sh` `cmd_run` that prevents duplicate worker processes for the same dispatch
- Lock files at `$STATE_DIR/locks/<session-key>.pid` are acquired before spawning sandbox/opencode and released on all exit paths
- Stale locks (dead PIDs) are detected and cleaned up automatically

## Problem

During pulse dispatch, every `headless-runtime-helper.sh run` call could spawn two `sandbox-exec-helper.sh` processes with identical arguments. This was observed for issues #6528, #6532, and PR #1933 CI fix. Root cause: the pulse (or its early-exit recycle loop) dispatches the same session-key twice in rapid succession — before the first worker appears in process lists used by dedup checks (`has_worker_for_repo_issue`, `dispatch-dedup-helper.sh`).

## Fix

The new dedup guard operates at the `headless-runtime-helper.sh` layer itself — the last line of defense before a sandbox process is spawned. When `cmd_run` is called:

1. `_acquire_session_lock` checks for an existing lock file for the session-key
2. If a live PID holds the lock → exits immediately (return 0, no worker spawned)
3. If the PID is dead → cleans up stale lock, acquires new one
4. On exit (success, failure, or trap) → `_release_session_lock` removes the lock file (only if it contains our own PID)

## Testing

- 4 new tests added to `tests/test-headless-runtime-helper.sh`:
  - Dedup guard blocks second dispatch with same session-key
  - Stale lock (dead PID) is cleaned up and run proceeds
  - Lock file cleaned up after successful run
  - Different session-keys do not block each other
- All 24 tests pass (20 existing + 4 new)
- ShellCheck clean (only pre-existing SC1091)

## Files changed

- `.agents/scripts/headless-runtime-helper.sh` — added `_acquire_session_lock`, `_release_session_lock`, lock integration in `cmd_run`, help text update
- `tests/test-headless-runtime-helper.sh` — 4 new dedup guard tests

Closes #6538