### PR TITLE
t1665.6: Add Codex, Cursor, Droid runtime entries + fix Codex Docker MCP

### DIFF
--- a/.agents/scripts/ai-cli-config.sh
+++ b/.agents/scripts/ai-cli-config.sh
@@ -248,6 +248,33 @@ _configure_openapi_kilo_kiro() {
 	return 0
 }
 
+# Configure OpenAPI Search MCP for Codex (OpenAI) via config.toml.
+# Codex uses TOML config at ~/.codex/config.toml with [mcp_servers.NAME] sections.
+_configure_openapi_codex() {
+	local mcp_name="$1"
+	local mcp_url="$2"
+	local codex_config="$HOME/.codex/config.toml"
+	if [[ -d "$HOME/.codex" ]] || command -v codex >/dev/null 2>&1; then
+		print_info "Configuring OpenAPI Search for Codex..."
+		mkdir -p "$HOME/.codex"
+		# Codex uses TOML — append section if not already present
+		if grep -q "\\[mcp_servers\\.${mcp_name}\\]" "$codex_config" 2>/dev/null; then
+			print_info "$mcp_name already configured in $codex_config - skipping"
+		else
+			{
+				echo ""
+				echo "[mcp_servers.${mcp_name}]"
+				echo "type = 'url'"
+				echo "url = '${mcp_url}'"
+			} >>"$codex_config"
+			print_success "Codex configured for OpenAPI Search"
+		fi
+	else
+		print_info "Codex not detected - skipping"
+	fi
+	return 0
+}
+
 # Configure OpenAPI Search MCP for Droid (Factory.AI) via droid CLI.
 _configure_openapi_droid() {
 	local mcp_name="$1"
@@ -271,6 +298,7 @@ configure_openapi_search_mcp() {
 
 	_configure_openapi_opencode "$mcp_name" "$mcp_url"
 	_configure_openapi_claude_code "$mcp_name" "$mcp_url"
+	_configure_openapi_codex "$mcp_name" "$mcp_url"
 	_configure_openapi_cursor "$mcp_name" "$mcp_url"
 	_configure_openapi_windsurf "$mcp_name" "$mcp_url"
 	_configure_openapi_gemini "$mcp_name" "$mcp_url"

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -78,6 +78,7 @@ _oc_upgrade_cmd='if r=$(command -v opencode 2>/dev/null); [[ "$r" == *bun* ]]; t
 NPM_TOOLS=(
 	"npm|OpenCode|opencode|--version|opencode-ai|${_oc_upgrade_cmd}"
 	"npm|Claude Code CLI|claude|--version|@anthropic-ai/claude-code|npm install -g @anthropic-ai/claude-code@latest"
+	"npm|Codex CLI|codex|--version|@openai/codex|npm install -g @openai/codex@latest"
 	"npm|Augment CLI|auggie|--version|@augmentcode/auggie@prerelease|npm install -g @augmentcode/auggie@prerelease"
 	"npm|Repomix|repomix|--version|repomix|npm install -g repomix@latest"
 	"npm|DSPyGround|dspyground|--version|dspyground|npm install -g dspyground@latest"
@@ -114,6 +115,7 @@ PIP_TOOLS=(
 # which skips latest-version lookup and just reports installed version
 CUSTOM_TOOLS=(
 	"self|Cursor CLI|agent|--version|cursor-agent|agent update"
+	"self|Droid CLI|droid|--version|droid|curl -fsSL https://app.factory.ai/install.sh | bash"
 )
 
 # Counters

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -398,6 +398,113 @@ inject_agents_reference() {
 		fi
 	fi
 
+	# Deploy Codex instructions.md (Codex reads ~/.codex/instructions.md as system prompt)
+	_deploy_codex_instructions
+
+	# Deploy Cursor AGENTS.md (Cursor reads ~/.cursor/rules/*.md as context)
+	_deploy_cursor_agents_reference
+
+	# Deploy Droid AGENTS.md (Droid reads ~/.factory/skills/*.md as context)
+	_deploy_droid_agents_reference
+
+	return 0
+}
+
+# Deploy instructions.md to Codex config directory.
+# Codex reads ~/.codex/instructions.md as its system-level instructions.
+_deploy_codex_instructions() {
+	local codex_dir="$HOME/.codex"
+	local instructions_file="$codex_dir/instructions.md"
+
+	# Only deploy if Codex is installed or config dir exists
+	if [[ ! -d "$codex_dir" ]] && ! command -v codex >/dev/null 2>&1; then
+		return 0
+	fi
+
+	mkdir -p "$codex_dir"
+
+	local reference_content
+	reference_content="Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities."
+
+	if [[ -f "$instructions_file" ]]; then
+		# Check if our reference is already present
+		# shellcheck disable=SC2088  # Tilde is a literal grep pattern, not a path
+		if grep -q '~/.aidevops/agents/AGENTS.md' "$instructions_file" 2>/dev/null; then
+			print_info "Codex instructions.md already has aidevops reference"
+			return 0
+		fi
+		# Prepend reference to existing instructions
+		local temp_file
+		temp_file=$(mktemp)
+		echo "$reference_content" >"$temp_file"
+		echo "" >>"$temp_file"
+		cat "$instructions_file" >>"$temp_file"
+		mv "$temp_file" "$instructions_file"
+		print_success "Added aidevops reference to $instructions_file"
+	else
+		echo "$reference_content" >"$instructions_file"
+		print_success "Created $instructions_file with aidevops reference"
+	fi
+	return 0
+}
+
+# Deploy AGENTS.md reference to Cursor rules directory.
+# Cursor reads ~/.cursor/rules/*.md files as additional context.
+_deploy_cursor_agents_reference() {
+	local cursor_dir="$HOME/.cursor"
+	local rules_dir="$cursor_dir/rules"
+	local agents_file="$rules_dir/aidevops.md"
+
+	# Only deploy if Cursor is installed or config dir exists
+	if [[ ! -d "$cursor_dir" ]] && ! command -v cursor >/dev/null 2>&1 && ! command -v agent >/dev/null 2>&1; then
+		return 0
+	fi
+
+	mkdir -p "$rules_dir"
+
+	local reference_content
+	reference_content="Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities."
+
+	if [[ -f "$agents_file" ]]; then
+		# shellcheck disable=SC2088  # Tilde is a literal grep pattern, not a path
+		if grep -q '~/.aidevops/agents/AGENTS.md' "$agents_file" 2>/dev/null; then
+			print_info "Cursor rules/aidevops.md already has aidevops reference"
+			return 0
+		fi
+	fi
+
+	echo "$reference_content" >"$agents_file"
+	print_success "Deployed aidevops reference to $agents_file"
+	return 0
+}
+
+# Deploy AGENTS.md reference to Droid skills directory.
+# Droid reads ~/.factory/skills/*.md files as additional context.
+_deploy_droid_agents_reference() {
+	local factory_dir="$HOME/.factory"
+	local skills_dir="$factory_dir/skills"
+	local agents_file="$skills_dir/aidevops.md"
+
+	# Only deploy if Droid is installed or config dir exists
+	if [[ ! -d "$factory_dir" ]] && ! command -v droid >/dev/null 2>&1; then
+		return 0
+	fi
+
+	mkdir -p "$skills_dir"
+
+	local reference_content
+	reference_content="Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities."
+
+	if [[ -f "$agents_file" ]]; then
+		# shellcheck disable=SC2088  # Tilde is a literal grep pattern, not a path
+		if grep -q '~/.aidevops/agents/AGENTS.md' "$agents_file" 2>/dev/null; then
+			print_info "Droid skills/aidevops.md already has aidevops reference"
+			return 0
+		fi
+	fi
+
+	echo "$reference_content" >"$agents_file"
+	print_success "Deployed aidevops reference to $agents_file"
 	return 0
 }
 

--- a/setup-modules/config.sh
+++ b/setup-modules/config.sh
@@ -163,3 +163,179 @@ update_claude_config() {
 
 	return 0
 }
+
+update_codex_config() {
+	# Only run if Codex is installed or config dir exists
+	if [[ ! -d "$HOME/.codex" ]] && ! command -v codex >/dev/null 2>&1; then
+		return 0
+	fi
+
+	print_info "Updating Codex configuration..."
+
+	# Fix broken MCP_DOCKER entry (P0 — OrbStack/Colima don't support docker mcp)
+	if type _fix_codex_docker_mcp &>/dev/null; then
+		_fix_codex_docker_mcp
+	fi
+
+	# Deploy aidevops MCP servers to Codex config.toml
+	_deploy_codex_mcps
+
+	print_success "Codex configuration updated"
+	return 0
+}
+
+# Deploy standard aidevops MCP servers to ~/.codex/config.toml
+# Codex uses TOML format: [mcp_servers.NAME] sections
+_deploy_codex_mcps() {
+	local config="$HOME/.codex/config.toml"
+	mkdir -p "$HOME/.codex"
+
+	# Touch config if it doesn't exist
+	[[ -f "$config" ]] || touch "$config"
+
+	local mcp_count=0
+
+	# Helper: add a TOML MCP section if not already present
+	# Args: $1=name, $2=type (stdio|url), $3=command_or_url, $4=args (optional, comma-separated)
+	_add_codex_mcp() {
+		local name="$1"
+		local mcp_type="$2"
+		local cmd_or_url="$3"
+		local args="${4:-}"
+
+		if grep -q "\\[mcp_servers\\.${name}\\]" "$config" 2>/dev/null; then
+			echo -e "  ${BLUE:-}=${NC:-} $name (already configured)"
+			return 0
+		fi
+
+		{
+			echo ""
+			echo "[mcp_servers.${name}]"
+			if [[ "$mcp_type" == "stdio" ]]; then
+				echo "command = '${cmd_or_url}'"
+				if [[ -n "$args" ]]; then
+					echo "args = [${args}]"
+				fi
+			else
+				echo "type = 'url'"
+				echo "url = '${cmd_or_url}'"
+			fi
+		} >>"$config"
+		((++mcp_count))
+		echo -e "  ${GREEN:-}+${NC:-} $name"
+		return 0
+	}
+
+	# --- context7 (library docs) ---
+	_add_codex_mcp "context7" "stdio" "npx" "'-y', '@upstash/context7-mcp@latest'"
+
+	# --- Playwright MCP ---
+	_add_codex_mcp "playwright" "stdio" "npx" "'-y', '@anthropic-ai/mcp-server-playwright@latest'"
+
+	# --- shadcn UI ---
+	_add_codex_mcp "shadcn" "stdio" "npx" "'shadcn@latest', 'mcp'"
+
+	# --- OpenAPI Search (remote, zero install) ---
+	_add_codex_mcp "openapi-search" "url" "https://openapi-mcp.openapisearch.com/mcp"
+
+	# --- Cloudflare API (remote) ---
+	_add_codex_mcp "cloudflare-api" "url" "https://mcp.cloudflare.com/mcp"
+
+	echo -e "  ${GREEN:-}Done${NC:-} -- $mcp_count new MCP servers added to Codex config"
+	return 0
+}
+
+update_cursor_config() {
+	# Only run if Cursor is installed or config dir exists
+	if [[ ! -d "$HOME/.cursor" ]] && ! command -v cursor >/dev/null 2>&1 && ! command -v agent >/dev/null 2>&1; then
+		return 0
+	fi
+
+	print_info "Updating Cursor configuration..."
+
+	# Deploy aidevops MCP servers to Cursor mcp.json
+	_deploy_cursor_mcps
+
+	print_success "Cursor configuration updated"
+	return 0
+}
+
+# Deploy standard aidevops MCP servers to ~/.cursor/mcp.json
+# Cursor uses JSON format: { "mcpServers": { "name": { ... } } }
+_deploy_cursor_mcps() {
+	local config="$HOME/.cursor/mcp.json"
+	mkdir -p "$HOME/.cursor"
+
+	# Ensure config file exists with valid JSON
+	if [[ ! -f "$config" ]]; then
+		echo '{}' >"$config"
+	fi
+
+	# Use the json_set_nested helper from ai-cli-config.sh if available,
+	# otherwise use python3 directly
+	local mcp_count=0
+
+	# Helper: add a JSON MCP entry if not already present
+	# Increments mcp_count only when a new entry is actually added.
+	_add_cursor_mcp() {
+		local name="$1"
+		local json_value="$2"
+
+		if ! command -v python3 >/dev/null 2>&1; then
+			print_warning "python3 not found - cannot update Cursor config"
+			return 0
+		fi
+
+		local py_output
+		py_output=$(
+			python3 - "$config" "$name" "$json_value" <<'PYEOF'
+import json, sys
+
+file_path = sys.argv[1]
+name = sys.argv[2]
+value_json = sys.argv[3]
+
+try:
+    with open(file_path, 'r') as f:
+        cfg = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    cfg = {}
+
+if "mcpServers" not in cfg or not isinstance(cfg["mcpServers"], dict):
+    cfg["mcpServers"] = {}
+
+if name in cfg["mcpServers"]:
+    print(f"SKIP  = {name} (already configured)")
+else:
+    cfg["mcpServers"][name] = json.loads(value_json)
+    with open(file_path, 'w') as f:
+        json.dump(cfg, f, indent=2)
+        f.write('\n')
+    print(f"ADDED + {name}")
+PYEOF
+		) || true
+		echo "  ${py_output#* }"
+		if [[ "$py_output" == ADDED* ]]; then
+			((++mcp_count))
+		fi
+		return 0
+	}
+
+	# --- context7 (library docs) ---
+	_add_cursor_mcp "context7" '{"command":"npx","args":["-y","@upstash/context7-mcp@latest"]}'
+
+	# --- Playwright MCP ---
+	_add_cursor_mcp "playwright" '{"command":"npx","args":["-y","@anthropic-ai/mcp-server-playwright@latest"]}'
+
+	# --- shadcn UI ---
+	_add_cursor_mcp "shadcn" '{"command":"npx","args":["shadcn@latest","mcp"]}'
+
+	# --- OpenAPI Search (remote, zero install) ---
+	_add_cursor_mcp "openapi-search" '{"url":"https://openapi-mcp.openapisearch.com/mcp"}'
+
+	# --- Cloudflare API (remote) ---
+	_add_cursor_mcp "cloudflare-api" '{"url":"https://mcp.cloudflare.com/mcp"}'
+
+	echo "  Done -- $mcp_count new MCP servers added to Cursor config"
+	return 0
+}

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1535,6 +1535,150 @@ setup_opencode_cli() {
 	return 0
 }
 
+setup_codex_cli() {
+	print_info "Setting up OpenAI Codex CLI..."
+
+	# Check if Codex is already installed
+	if command -v codex >/dev/null 2>&1; then
+		local codex_version
+		codex_version=$(codex --version 2>/dev/null | head -1 || echo "unknown")
+		print_success "Codex already installed: $codex_version"
+		# Fix broken MCP_DOCKER if present
+		_fix_codex_docker_mcp
+		return 0
+	fi
+
+	# Need either bun or npm to install
+	local installer=""
+	local install_pkg="@openai/codex@latest"
+
+	if command -v bun >/dev/null 2>&1; then
+		installer="bun"
+	elif command -v npm >/dev/null 2>&1; then
+		installer="npm"
+	else
+		print_warning "Neither bun nor npm found - cannot install Codex"
+		print_info "Install Node.js first, then re-run setup"
+		return 0
+	fi
+
+	print_info "Codex is OpenAI's AI coding CLI (terminal-based, agentic)"
+	echo "  It provides an AI-powered terminal interface using OpenAI models."
+	echo ""
+
+	local install_codex="Y"
+	if [[ "${NON_INTERACTIVE:-}" != "true" ]]; then
+		read -r -p "Install Codex via $installer? [Y/n]: " install_codex || install_codex="Y"
+	fi
+	if [[ "$install_codex" =~ ^[Yy]?$ ]]; then
+		if run_with_spinner "Installing Codex" npm_global_install "$install_pkg"; then
+			print_success "Codex installed"
+			echo ""
+			print_info "Codex needs OpenAI authentication."
+			print_info "Run 'codex' and follow the auth prompts."
+			echo ""
+			# Fix broken MCP_DOCKER if Codex created a default config
+			_fix_codex_docker_mcp
+		else
+			print_warning "Codex installation failed"
+			print_info "Try manually: npm install -g $install_pkg"
+		fi
+	else
+		print_info "Skipped Codex installation"
+		print_info "Install later: $installer install -g $install_pkg"
+	fi
+
+	return 0
+}
+
+# P0 fix: Remove broken MCP_DOCKER from Codex config.toml
+# Docker Desktop 4.40+ with MCP Toolkit extension is required for `docker mcp`.
+# OrbStack, Colima, Rancher Desktop do not support it.
+_fix_codex_docker_mcp() {
+	local config="$HOME/.codex/config.toml"
+	[[ -f "$config" ]] || return 0
+
+	# Check if MCP_DOCKER section exists
+	if ! grep -q '^\[mcp_servers\.MCP_DOCKER\]' "$config" 2>/dev/null; then
+		return 0
+	fi
+
+	# Check if `docker mcp` subcommand is actually available
+	if docker mcp --help >/dev/null 2>&1; then
+		return 0
+	fi
+
+	# Comment out the MCP_DOCKER section (from header to next section or EOF)
+	# Use sed to comment out lines from [mcp_servers.MCP_DOCKER] to the next
+	# section header or end of file. Portable sed (no -i on macOS without ext).
+	local tmp_config
+	tmp_config=$(mktemp)
+	local in_mcp_docker=false
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == "[mcp_servers.MCP_DOCKER]" ]]; then
+			in_mcp_docker=true
+			printf '# %s  # Disabled by aidevops: docker mcp not available\n' "$line" >>"$tmp_config"
+			continue
+		fi
+		# If we hit another section header, stop commenting
+		if [[ "$in_mcp_docker" == "true" ]] && [[ "$line" == "["* ]]; then
+			in_mcp_docker=false
+		fi
+		if [[ "$in_mcp_docker" == "true" ]]; then
+			printf '# %s\n' "$line" >>"$tmp_config"
+		else
+			printf '%s\n' "$line" >>"$tmp_config"
+		fi
+	done <"$config"
+	mv "$tmp_config" "$config"
+	print_info "Disabled MCP_DOCKER in Codex config (docker mcp not available on this system)"
+	return 0
+}
+
+setup_droid_cli() {
+	print_info "Setting up Factory.AI Droid CLI..."
+
+	# Check if Droid is already installed
+	if command -v droid >/dev/null 2>&1; then
+		local droid_version
+		droid_version=$(droid --version 2>/dev/null | head -1 || echo "unknown")
+		print_success "Droid already installed: $droid_version"
+		return 0
+	fi
+
+	# Droid uses its own installer — not available via npm/brew
+	print_info "Droid (Factory.AI) is an AI coding agent CLI"
+	echo "  It provides autonomous coding capabilities with Factory.AI models."
+	echo ""
+
+	local install_droid="Y"
+	if [[ "${NON_INTERACTIVE:-}" != "true" ]]; then
+		read -r -p "Install Droid CLI? [Y/n]: " install_droid || install_droid="Y"
+	fi
+	if [[ "$install_droid" =~ ^[Yy]?$ ]]; then
+		print_info "Installing Droid CLI..."
+		if command -v curl >/dev/null 2>&1; then
+			if curl -fsSL https://app.factory.ai/install.sh | bash 2>/dev/null; then
+				print_success "Droid installed"
+				echo ""
+				print_info "Run 'droid auth login' to authenticate with Factory.AI."
+				echo ""
+			else
+				print_warning "Droid installation failed"
+				print_info "Install manually from: https://docs.factory.ai/cli/installation"
+			fi
+		else
+			print_warning "curl not found - cannot install Droid"
+			print_info "Install manually from: https://docs.factory.ai/cli/installation"
+		fi
+	else
+		print_info "Skipped Droid installation"
+		print_info "Install later: curl -fsSL https://app.factory.ai/install.sh | bash"
+	fi
+
+	return 0
+}
+
 setup_google_workspace_cli() {
 	print_info "Setting up Google Workspace CLI (gws)..."
 

--- a/setup.sh
+++ b/setup.sh
@@ -776,6 +776,8 @@ main() {
 		else
 			print_info "Claude config management disabled via config (integrations.manage_claude_config)"
 		fi
+		update_codex_config
+		update_cursor_config
 		disable_ondemand_mcps
 	else
 		# Required steps (always run)
@@ -852,10 +854,15 @@ main() {
 		confirm_step "Setup Google Workspace CLI (Gmail, Calendar, Drive)" && setup_google_workspace_cli
 		confirm_step "Setup OpenCode CLI (AI coding tool)" && setup_opencode_cli
 		confirm_step "Setup OpenCode plugins" && setup_opencode_plugins
-		# Run AFTER OpenCode CLI install so opencode.json may exist for agent config
+		confirm_step "Setup Codex CLI (OpenAI AI coding tool)" && setup_codex_cli
+		confirm_step "Setup Droid CLI (Factory.AI coding tool)" && setup_droid_cli
+		# Run AFTER CLI installs so config dirs may exist for agent config
 		confirm_step "Update OpenCode configuration" && update_opencode_config
 		# Run AFTER OpenCode config so Claude Code gets equivalent setup
 		confirm_step "Update Claude Code configuration (slash commands, MCPs, settings)" && update_claude_config
+		# Run AFTER Claude Code config so Codex/Cursor get equivalent setup
+		confirm_step "Update Codex configuration (MCPs, instructions)" && update_codex_config
+		confirm_step "Update Cursor configuration (MCPs)" && update_cursor_config
 		# Run AFTER all MCP setup functions to ensure disabled state persists
 		confirm_step "Disable on-demand MCPs globally" && disable_ondemand_mcps
 	fi


### PR DESCRIPTION
## Summary

- **P0 fix**: Comments out broken `MCP_DOCKER` in `~/.codex/config.toml` when `docker mcp` is unavailable (OrbStack, Colima, Rancher Desktop)
- Adds `setup_codex_cli()` and `setup_droid_cli()` CLI installation functions
- Deploys aidevops MCP servers (context7, playwright, shadcn, openapi-search, cloudflare-api) to Codex TOML and Cursor JSON configs
- Deploys AGENTS.md references to Codex (`instructions.md`), Cursor (`rules/aidevops.md`), and Droid (`skills/aidevops.md`)
- Wires everything into `setup.sh` interactive and non-interactive flows

Closes #6537

## Task Lineage

- **Parent:** t1665 (Runtime abstraction layer)
- **This task:** t1665.6 — runtime entries and MCP config fixes
- **Scope:** CLI install functions, MCP deployment, system prompt deployment, setup.sh wiring

## Changes

### P0: Fix Codex Docker MCP (`setup-modules/tool-install.sh`)
- `_fix_codex_docker_mcp()` — reads `~/.codex/config.toml`, detects `[mcp_servers.MCP_DOCKER]`, checks if `docker mcp --help` works, comments out the section if not
- Called during `setup_codex_cli()` and `update_codex_config()`

### CLI Installation (`setup-modules/tool-install.sh`)
- `setup_codex_cli()` — installs `@openai/codex@latest` via npm/bun, follows `setup_opencode_cli()` pattern
- `setup_droid_cli()` — installs via `curl -fsSL https://app.factory.ai/install.sh | bash`

### MCP Deployment (`setup-modules/config.sh`)
- `update_codex_config()` + `_deploy_codex_mcps()` — writes TOML `[mcp_servers.NAME]` sections to `~/.codex/config.toml`
- `update_cursor_config()` + `_deploy_cursor_mcps()` — writes JSON `mcpServers` entries to `~/.cursor/mcp.json`

### System Prompt Deployment (`setup-modules/agent-deploy.sh`)
- `_deploy_codex_instructions()` — creates/updates `~/.codex/instructions.md` with AGENTS.md reference
- `_deploy_cursor_agents_reference()` — creates `~/.cursor/rules/aidevops.md`
- `_deploy_droid_agents_reference()` — creates `~/.factory/skills/aidevops.md`

### OpenAPI Search MCP (`.agents/scripts/ai-cli-config.sh`)
- `_configure_openapi_codex()` — adds OpenAPI Search to Codex TOML config

### Version Tracking (`.agents/scripts/tool-version-check.sh`)
- Added Codex (npm category) and Droid (custom/self category)

### Setup.sh Wiring (`setup.sh`)
- Interactive: `confirm_step` entries for Codex CLI, Droid CLI, Codex config, Cursor config
- Non-interactive: direct calls to `update_codex_config`, `update_cursor_config`

## Testing

- All modified files pass `shellcheck` with zero violations
- No Bash 4.0+ features used (3.2 compatible)
- Idempotent: all functions check for existing config before writing
- Graceful degradation: skips if runtime not installed