### PR TITLE
t1672: update OpenAI tier equivalents for sonnet and opus routing

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -100,7 +100,9 @@ model_id_to_tier() {
 	*sonnet*) echo "sonnet" ;;
 	*haiku*) echo "haiku" ;;
 	*flash* | gemini-2.0*) echo "flash" ;;
-	*pro* | gpt-4.1 | o3) echo "pro" ;;
+	*pro* | gpt-4.1 | o3 | gpt-5.2) echo "pro" ;;
+	gpt-5.4 | gpt-5.4-*) echo "opus" ;;
+	gpt-5.3-codex | gpt-5.3-codex-*) echo "sonnet" ;;
 	o4-mini | gpt-4.1-mini | gpt-4o-mini | deepseek* | llama* | gpt-4.1-nano) echo "haiku" ;;
 	gpt-4o) echo "sonnet" ;;
 	*) echo "" ;;
@@ -180,18 +182,18 @@ opus|claude-opus-4-6|Architecture decisions, complex multi-step reasoning"
 # Task-to-Model Recommendations
 # =============================================================================
 
-readonly TASK_RECOMMENDATIONS="code review|claude-sonnet-4-6|o4-mini|gemini-2.5-flash
-code implementation|claude-sonnet-4-6|gpt-4.1|gemini-2.5-pro
+readonly TASK_RECOMMENDATIONS="code review|claude-sonnet-4-6|gpt-5.3-codex|gemini-2.5-flash
+code implementation|claude-sonnet-4-6|gpt-5.3-codex|gemini-2.5-pro
 architecture design|claude-opus-4-6|o3|gemini-2.5-pro
-bug fixing|claude-sonnet-4-6|gpt-4.1|o4-mini
-refactoring|claude-sonnet-4-6|gpt-4.1|gemini-2.5-pro
+bug fixing|claude-sonnet-4-6|gpt-5.3-codex|o4-mini
+refactoring|claude-sonnet-4-6|gpt-5.3-codex|gemini-2.5-pro
 documentation|claude-sonnet-4-6|gpt-4o|gemini-2.5-flash
-testing|claude-sonnet-4-6|gpt-4.1|o4-mini
+testing|claude-sonnet-4-6|gpt-5.3-codex|o4-mini
 classification|claude-haiku-4-5|gpt-4.1-nano|gemini-2.5-flash
 summarization|gemini-2.5-flash|gpt-4o-mini|claude-haiku-4-5
-large codebase analysis|gemini-2.5-pro|gpt-4.1|claude-sonnet-4-6
-math reasoning|o3|deepseek-r1|gemini-2.5-pro
-security audit|claude-opus-4-6|o3|claude-sonnet-4-6
+large codebase analysis|gemini-2.5-pro|gpt-5.3-codex|claude-sonnet-4-6
+math reasoning|gpt-5.4|deepseek-r1|gemini-2.5-pro
+security audit|claude-opus-4-6|gpt-5.4|claude-sonnet-4-6
 data extraction|gemini-2.5-flash|gpt-4o-mini|claude-haiku-4-5
 commit messages|claude-haiku-4-5|gpt-4.1-nano|gemini-2.5-flash
 pr description|claude-sonnet-4-6|gpt-4o|gemini-2.5-flash"
@@ -481,10 +483,10 @@ cmd_recommend() {
 	if [[ "$found" != "true" ]]; then
 		echo "No exact task match. Showing general recommendations:"
 		echo ""
-		echo "  High capability: claude-opus-4-6 or o3"
-		echo "  Balanced:        claude-sonnet-4-6 or gpt-4.1"
+		echo "  High capability: claude-opus-4-6 or gpt-5.4"
+		echo "  Balanced:        claude-sonnet-4-6 or gpt-5.3-codex"
 		echo "  Budget:          gemini-2.5-flash or gpt-4.1-nano"
-		echo "  Large context:   gemini-2.5-pro or gpt-4.1 (1M tokens)"
+		echo "  Large context:   gemini-2.5-pro or gpt-5.3-codex"
 		echo ""
 		echo "Available task types:"
 		echo "$TASK_RECOMMENDATIONS" | cut -d'|' -f1 | while IFS= read -r t; do
@@ -1478,7 +1480,7 @@ cmd_help() {
 	echo "Scoring examples:"
 	echo "  compare-models-helper.sh score --task 'fix React bug' --type code \\"
 	echo "    --model claude-sonnet-4-6 --correctness 9 --completeness 8 --quality 8 --clarity 9 --adherence 9 \\"
-	echo "    --model gpt-4.1 --correctness 8 --completeness 7 --quality 7 --clarity 8 --adherence 8 \\"
+	echo "    --model gpt-5.3-codex --correctness 8 --completeness 7 --quality 7 --clarity 8 --adherence 8 \\"
 	echo "    --winner claude-sonnet-4-6"
 	echo "  compare-models-helper.sh score --task 'review code' --prompt-file prompts/build.txt \\"
 	echo "    --model sonnet --correctness 9 --completeness 8 --quality 8 --clarity 9 --adherence 9"
@@ -1510,7 +1512,7 @@ cmd_help() {
 	echo ""
 	echo "Bench examples (t1393):"
 	echo "  compare-models-helper.sh bench 'What is 2+2?' claude-sonnet-4-6 gpt-4o"
-	echo "  compare-models-helper.sh bench 'Explain quicksort' claude-sonnet-4-6 gpt-4.1 gemini-2.5-pro --judge"
+	echo "  compare-models-helper.sh bench 'Explain quicksort' claude-sonnet-4-6 gpt-5.3-codex gemini-2.5-pro --judge"
 	echo "  compare-models-helper.sh bench --dataset prompts.jsonl claude-sonnet-4-6 gpt-4o --judge"
 	echo "  compare-models-helper.sh bench 'What is 2+2?' claude-sonnet-4-6 --dry-run"
 	echo "  compare-models-helper.sh bench --history --limit 10"

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -117,12 +117,12 @@ get_tier_models() {
 		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 		haiku) echo "opencode/claude-haiku-4-5|opencode/gemini-3-flash" ;;
 		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
-		sonnet) echo "opencode/claude-sonnet-4-6|anthropic/claude-sonnet-4-6" ;;
+		sonnet) echo "opencode/claude-sonnet-4-6|openai/gpt-5.3-codex|anthropic/claude-sonnet-4-6" ;;
 		pro) echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;
-		opus) echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
+		opus) echo "opencode/claude-opus-4-6|openai/gpt-5.4|anthropic/claude-opus-4-6" ;;
 		health) echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
 		eval) echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		coding) echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
+		coding) echo "opencode/claude-opus-4-6|openai/gpt-5.4|anthropic/claude-opus-4-6" ;;
 		*) return 1 ;;
 		esac
 	else
@@ -130,12 +130,12 @@ get_tier_models() {
 		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 		haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
 		flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
-		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-4.1" ;;
+		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.3-codex" ;;
 		pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
-		opus) echo "anthropic/claude-opus-4-6|openai/o3" ;;
+		opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
 		health) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
 		eval) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		coding) echo "anthropic/claude-opus-4-6|openai/o3" ;;
+		coding) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
 		*) return 1 ;;
 		esac
 	fi

--- a/.agents/tools/ai-assistants/models/README.md
+++ b/.agents/tools/ai-assistants/models/README.md
@@ -8,10 +8,10 @@ Model-specific subagents enable cross-provider model routing. Instead of passing
 |------|----------|---------------|----------|
 | `haiku` | `models/haiku.md` | claude-haiku-4-5-20251001 | gemini-2.5-flash-preview-05-20 |
 | `flash` | `models/flash.md` | gemini-2.5-flash-preview-05-20 | gpt-4.1-mini |
-| `sonnet` | `models/sonnet.md` | claude-sonnet-4-6 | gpt-4.1 |
+| `sonnet` | `models/sonnet.md` | claude-sonnet-4-6 | gpt-5.3-codex |
 | `composer2` | `models/composer2.md` | cursor/composer-2 | claude-sonnet-4-6 |
 | `pro` | `models/pro.md` | gemini-2.5-pro | claude-sonnet-4-6 |
-| `opus` | `models/opus.md` | claude-opus-4-6 | o3 |
+| `opus` | `models/opus.md` | claude-opus-4-6 | gpt-5.4 |
 
 ## How It Works
 
@@ -51,7 +51,7 @@ Add `fallback-chain:` to any model tier's YAML frontmatter for per-agent overrid
 ```yaml
 fallback-chain:
   - anthropic/claude-sonnet-4-6
-  - openai/gpt-4.1
+  - openai/gpt-5.3-codex
   - google/gemini-2.5-pro
   - openrouter/anthropic/claude-sonnet-4-6
 ```

--- a/.agents/tools/ai-assistants/models/composer2.md
+++ b/.agents/tools/ai-assistants/models/composer2.md
@@ -7,7 +7,7 @@ model-fallback: anthropic/claude-sonnet-4-6
 fallback-chain:
   - cursor/composer-2
   - anthropic/claude-sonnet-4-6
-  - openai/gpt-4.1
+  - openai/gpt-5.3-codex
 tools:
   read: true
   write: true

--- a/.agents/tools/ai-assistants/models/opus.md
+++ b/.agents/tools/ai-assistants/models/opus.md
@@ -3,10 +3,10 @@ description: Highest-capability model for architecture decisions, novel problems
 mode: subagent
 model: anthropic/claude-opus-4-6
 model-tier: opus
-model-fallback: openai/o3
+model-fallback: openai/gpt-5.4
 fallback-chain:
   - anthropic/claude-opus-4-6
-  - openai/o3
+  - openai/gpt-5.4
   - anthropic/claude-sonnet-4-6
   - openrouter/anthropic/claude-opus-4-6
 tools:

--- a/.agents/tools/ai-assistants/models/sonnet.md
+++ b/.agents/tools/ai-assistants/models/sonnet.md
@@ -3,10 +3,10 @@ description: Balanced model for code implementation, review, and most developmen
 mode: subagent
 model: anthropic/claude-sonnet-4-6
 model-tier: sonnet
-model-fallback: openai/gpt-4.1
+model-fallback: openai/gpt-5.3-codex
 fallback-chain:
   - anthropic/claude-sonnet-4-6
-  - openai/gpt-4.1
+  - openai/gpt-5.3-codex
   - google/gemini-2.5-pro
   - openrouter/anthropic/claude-sonnet-4-6
 tools:

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -158,9 +158,9 @@ Concrete model subagents are defined across these paths (`tools/ai-assistants/mo
 | `flash` | `models/flash.md` | gemini-2.5-flash-preview-05-20 | gpt-4.1-mini |
 | `haiku` | `models/haiku.md` | claude-haiku-4-5-20251001 | gemini-2.5-flash-preview-05-20 |
 | `composer2` | `models/composer2.md` | cursor/composer-2 | claude-sonnet-4-6 |
-| `sonnet` | `models/sonnet.md` | claude-sonnet-4-6 | gpt-4.1 |
+| `sonnet` | `models/sonnet.md` | claude-sonnet-4-6 | gpt-5.3-codex |
 | `pro` | `models/pro.md` | gemini-2.5-pro | claude-sonnet-4-6 |
-| `opus` | `models/opus.md` | claude-opus-4-6 | o3 |
+| `opus` | `models/opus.md` | claude-opus-4-6 | gpt-5.4 |
 
 Cross-provider reviewers: `models/gemini-reviewer.md`, `models/gpt-reviewer.md`
 
@@ -218,9 +218,9 @@ Each tier defines a primary model and a fallback from a different provider. When
 | `flash` | gemini-2.5-flash-preview-05-20 | gpt-4.1-mini | No Google key |
 | `haiku` | claude-haiku-4-5-20251001 | gemini-2.5-flash-preview-05-20 | No Anthropic key |
 | `composer2` | cursor/composer-2 | claude-sonnet-4-6 | No Cursor OAuth pool configured (t1549) or pool exhausted |
-| `sonnet` | claude-sonnet-4-6 | gpt-4.1 | No Anthropic key |
+| `sonnet` | claude-sonnet-4-6 | gpt-5.3-codex | No Anthropic key |
 | `pro` | gemini-2.5-pro | claude-sonnet-4-6 | No Google key |
-| `opus` | claude-opus-4-6 | o3 | No Anthropic key |
+| `opus` | claude-opus-4-6 | gpt-5.4 | No Anthropic key |
 
 The supervisor resolves fallbacks automatically during headless dispatch. For interactive sessions, the orchestrating agent should run `compare-models-helper.sh discover` to check availability before selecting a model.
 


### PR DESCRIPTION
## Summary
- Update sonnet-tier OpenAI fallback mapping from `gpt-4.1` to `gpt-5.3-codex` across model routing docs and model subagent frontmatter.
- Update opus-tier OpenAI fallback mapping from `o3` to `gpt-5.4` across model routing docs and model subagent frontmatter.
- Update runtime resolver logic in `model-availability-helper.sh` and recommendation/tier mapping logic in `compare-models-helper.sh` to align with current OpenCode model availability.

## Verification
- `opencode models openai` (shows `openai/gpt-5.3-codex` and `openai/gpt-5.4` available)
- `.agents/scripts/compare-models-helper.sh recommend \"code implementation\"`
- `.agents/scripts/model-availability-helper.sh resolve sonnet`
- `.agents/scripts/model-availability-helper.sh resolve opus`
- `markdown-formatter check` on updated markdown files (all clean)
- `shellcheck` on updated scripts (SC1091 info only for sourced shared constants)

Closes #6546