### PR TITLE
fix: use npx --no-install for secretlint/markdownlint fallbacks in verify (#6566)

### DIFF
--- a/.agents/scripts/testing-setup-helper.sh
+++ b/.agents/scripts/testing-setup-helper.sh
@@ -797,8 +797,8 @@ cmd_verify() {
 					echo "  [fail] secretlint"
 					fail_count=$((fail_count + 1))
 				fi
-			elif command -v npx >/dev/null 2>&1; then
-				if (cd "$project_dir" && npx secretlint "**/*" 2>/dev/null); then
+			elif command -v npx >/dev/null 2>&1 && (cd "$project_dir" && npx --no-install secretlint --version >/dev/null 2>&1); then
+				if (cd "$project_dir" && npx --no-install secretlint "**/*" 2>/dev/null); then
 					echo "  [pass] secretlint"
 					pass_count=$((pass_count + 1))
 				else
@@ -819,8 +819,8 @@ cmd_verify() {
 					echo "  [fail] markdownlint"
 					fail_count=$((fail_count + 1))
 				fi
-			elif command -v npx >/dev/null 2>&1; then
-				if (cd "$project_dir" && npx markdownlint-cli2 "**/*.md" 2>/dev/null); then
+			elif command -v npx >/dev/null 2>&1 && (cd "$project_dir" && npx --no-install markdownlint-cli2 --version >/dev/null 2>&1); then
+				if (cd "$project_dir" && npx --no-install markdownlint-cli2 "**/*.md" 2>/dev/null); then
 					echo "  [pass] markdownlint"
 					pass_count=$((pass_count + 1))
 				else


### PR DESCRIPTION
## Summary

Addresses PR #6496 review feedback tracked in issue #6566.

The `verify` subcommand in `testing-setup-helper.sh` had two linter fallback blocks that used bare `npx secretlint` / `npx markdownlint-cli2` when the global binary wasn't found. This could auto-download packages on the fly, producing false-pass results and unexpected network calls.

## Changes

- **secretlint fallback**: now checks `npx --no-install secretlint --version` before running — only falls back to npx if the tool is locally installed. Skips cleanly otherwise.
- **markdownlint-cli2 fallback**: same pattern — `npx --no-install markdownlint-cli2 --version` check before execution.

Both linters follow the same priority: global binary → npx (locally installed only) → skip.

## Testing Evidence

- **Testing level:** `self-assessed`
- **Risk classification:** low (shell script logic change, no executable code path changes for users with global binaries installed)
- **Stability results:** N/A — no dev server
- **Smoke pages/endpoints checked:** N/A
- ShellCheck: only pre-existing SC1091 info (sourced file), no new violations

## Files Changed

- `.agents/scripts/testing-setup-helper.sh` — tighten npx fallback for secretlint and markdownlint-cli2 verify blocks

Closes #6566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing setup verification process with improved tool resolution checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->