### PR TITLE
t1673: fix OpenAI pool add for Codex device auth

### DIFF
--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -5,7 +5,7 @@
 # accounts when the OpenCode TUI auth hooks are unavailable.
 #
 # Usage:
-#   oauth-pool-helper.sh add [anthropic|openai|cursor|google]           # Add account via OAuth
+#   oauth-pool-helper.sh add [anthropic|openai|cursor|google]           # Add account via OAuth/device flow
 #   oauth-pool-helper.sh check [anthropic|openai|cursor|google|all]     # Health check all accounts
 #   oauth-pool-helper.sh list [anthropic|openai|cursor|google|all]      # List accounts
 #   oauth-pool-helper.sh remove <provider> <email>                      # Remove an account
@@ -160,9 +160,10 @@ pool_upsert_account() {
 	local refresh_token="$4"
 	local expires_ms="$5"
 	local now_iso="$6"
+	local account_id="${7:-}"
 	PROVIDER="$provider" EMAIL="$email" \
 		ACCESS="$access_token" REFRESH="$refresh_token" \
-		EXPIRES="$expires_ms" NOW_ISO="$now_iso" \
+		EXPIRES="$expires_ms" NOW_ISO="$now_iso" ACCOUNT_ID="$account_id" \
 		python3 -c "
 import sys, json, os
 pool = json.load(sys.stdin)
@@ -172,6 +173,7 @@ access = os.environ['ACCESS']
 refresh = os.environ['REFRESH']
 expires = int(os.environ['EXPIRES'])
 now_iso = os.environ['NOW_ISO']
+account_id = os.environ.get('ACCOUNT_ID', '')
 
 if provider not in pool:
     pool[provider] = []
@@ -185,11 +187,13 @@ for account in pool[provider]:
         account['lastUsed'] = now_iso
         account['status'] = 'active'
         account['cooldownUntil'] = None
+        if account_id:
+            account['accountId'] = account_id
         found = True
         break
 
 if not found:
-    pool[provider].append({
+    entry = {
         'email': email,
         'access': access,
         'refresh': refresh,
@@ -198,7 +202,10 @@ if not found:
         'lastUsed': now_iso,
         'status': 'active',
         'cooldownUntil': None,
-    })
+    }
+    if account_id:
+        entry['accountId'] = account_id
+    pool[provider].append(entry)
 
 json.dump(pool, sys.stdout, indent=2)
 "
@@ -328,13 +335,93 @@ _add_save_to_pool() {
 	local refresh_token="$4"
 	local expires_ms="$5"
 	local now_iso="$6"
+	local account_id="${7:-}"
 	local pool count
 	pool=$(load_pool)
 	pool=$(printf '%s' "$pool" | pool_upsert_account "$provider" "$email" \
-		"$access_token" "$refresh_token" "$expires_ms" "$now_iso")
+		"$access_token" "$refresh_token" "$expires_ms" "$now_iso" "$account_id")
 	save_pool "$pool"
 	count=$(printf '%s' "$pool" | count_provider_accounts "$provider")
 	print_success "Added ${email} to ${provider} pool (${count} account(s) total)"
+	return 0
+}
+
+# Read OpenCode OpenAI auth fields (access, refresh, expires, accountId).
+# Prints four lines in that order.
+_openai_read_opencode_auth_fields() {
+	local auth_path="$OPENCODE_AUTH_FILE"
+	if [[ ! -f "$auth_path" ]]; then
+		print_error "OpenCode auth file not found: ${auth_path}"
+		return 1
+	fi
+	python3 -c "
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        auth = json.load(f)
+except Exception:
+    print('')
+    print('')
+    print('')
+    print('')
+    sys.exit(0)
+
+entry = auth.get('openai', {}) if isinstance(auth, dict) else {}
+print(entry.get('access', ''))
+print(entry.get('refresh', ''))
+print(entry.get('expires', ''))
+print(entry.get('accountId', ''))
+" "$auth_path" 2>/dev/null
+	return 0
+}
+
+# Add OpenAI account via OpenCode's headless Codex device flow.
+# Falls back to callback mode in cmd_add() when this returns non-zero.
+_cmd_add_openai_device() {
+	local prefill_email="$1"
+	local email
+	email=$(_add_prompt_email "$prefill_email") || return 1
+
+	if ! command -v opencode &>/dev/null; then
+		print_error "OpenCode CLI not found. Cannot run OpenAI device login flow."
+		return 1
+	fi
+
+	print_info "Starting OpenAI device login (Codex) via OpenCode..."
+	print_info "Follow the browser/device prompts, then return to this terminal."
+	if ! opencode providers login -p OpenAI -m "ChatGPT Pro/Plus (headless)"; then
+		print_error "OpenAI device login failed"
+		return 1
+	fi
+
+	local auth_fields access_token refresh_token expires_raw account_id
+	auth_fields=$(_openai_read_opencode_auth_fields) || return 1
+	access_token=$(printf '%s\n' "$auth_fields" | sed -n '1p')
+	refresh_token=$(printf '%s\n' "$auth_fields" | sed -n '2p')
+	expires_raw=$(printf '%s\n' "$auth_fields" | sed -n '3p')
+	account_id=$(printf '%s\n' "$auth_fields" | sed -n '4p')
+
+	if [[ -z "$access_token" ]]; then
+		print_error "OpenCode login completed but no OpenAI access token was found"
+		return 1
+	fi
+
+	local now_ms expires_ms now_iso
+	now_ms=$(get_now_ms)
+	if [[ "$expires_raw" =~ ^[0-9]+$ ]]; then
+		if [[ "$expires_raw" -gt 1000000000000 ]]; then
+			expires_ms="$expires_raw"
+		else
+			expires_ms=$((expires_raw * 1000))
+		fi
+	else
+		expires_ms=$((now_ms + 3600 * 1000))
+	fi
+	now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	_add_save_to_pool "openai" "$email" "$access_token" "$refresh_token" "$expires_ms" "$now_iso" "$account_id"
+	print_info "OpenAI account added via device flow. Restart OpenCode to use the pool token."
 	return 0
 }
 
@@ -442,6 +529,26 @@ cmd_add() {
 	if [[ "$provider" == "google" ]]; then
 		cmd_add_google "$prefill_email"
 		return $?
+	fi
+
+	# OpenAI default path: headless device auth (Codex). Callback flow remains fallback.
+	if [[ "$provider" == "openai" ]]; then
+		local openai_add_mode="${AIDEVOPS_OPENAI_ADD_MODE:-device}"
+		case "$openai_add_mode" in
+		device)
+			if _cmd_add_openai_device "$prefill_email"; then
+				return 0
+			fi
+			print_warning "OpenAI device login failed — falling back to callback URL flow"
+			;;
+		callback)
+			print_info "Using callback URL flow for OpenAI (AIDEVOPS_OPENAI_ADD_MODE=callback)"
+			;;
+		*)
+			print_error "Invalid AIDEVOPS_OPENAI_ADD_MODE: ${openai_add_mode} (valid: device, callback)"
+			return 1
+			;;
+		esac
 	fi
 
 	local email
@@ -1041,7 +1148,7 @@ cmd_check() {
 		echo ""
 		echo "To add an account:"
 		echo "  oauth-pool-helper.sh add anthropic    # Claude Pro/Max"
-		echo "  oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro"
+		echo "  oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro (device flow default)"
 		echo "  oauth-pool-helper.sh add cursor       # Cursor Pro (reads from IDE)"
 		echo "  oauth-pool-helper.sh add google       # Google AI Pro/Ultra/Workspace"
 	fi
@@ -1261,12 +1368,17 @@ try:
     if next_account.get('expires', 0) <= now_ms and next_account.get('refresh'):
         _try_refresh(next_account, provider, now_ms)
 
-    auth[provider] = {
+    auth_entry = {
         'type':    current_auth.get('type', 'oauth'),
         'refresh': next_account.get('refresh', ''),
         'access':  next_account.get('access', ''),
         'expires': next_account.get('expires', 0),
     }
+    if provider == 'openai':
+        account_id = next_account.get('accountId', current_auth.get('accountId', ''))
+        if account_id:
+            auth_entry['accountId'] = account_id
+    auth[provider] = auth_entry
     _atomic_write_json(auth_path, auth)
 
     now_iso = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -1508,12 +1620,17 @@ try:
                     # and check if auth still has the expired token)
                     auth_expires = auth.get(provider, {}).get('expires', 0)
                     if auth_expires and auth_expires <= now_ms:
-                        auth[provider] = {
+                        auth_entry = {
                             'type': 'oauth',
                             'refresh': acct.get('refresh', ''),
                             'access': acct.get('access', ''),
                             'expires': acct.get('expires', 0),
                         }
+                        if provider == 'openai':
+                            account_id = acct.get('accountId', auth.get(provider, {}).get('accountId', ''))
+                            if account_id:
+                                auth_entry['accountId'] = account_id
+                        auth[provider] = auth_entry
                         auth_dir = os.path.dirname(auth_path)
                         fd2, tmp2 = tempfile.mkstemp(dir=auth_dir, prefix='.auth-', suffix='.tmp')
                         try:
@@ -1640,7 +1757,7 @@ print(f'  Auth errors:    {auth_error}')
 		echo ""
 		echo "To add an account:"
 		echo "  oauth-pool-helper.sh add anthropic    # Claude Pro/Max"
-		echo "  oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro"
+		echo "  oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro (device flow default)"
 		echo "  oauth-pool-helper.sh add cursor       # Cursor Pro (reads from IDE)"
 		echo "  oauth-pool-helper.sh add google       # Google AI Pro/Ultra/Workspace"
 	fi
@@ -1867,7 +1984,7 @@ if available == 0 and total > 0:
 		echo ""
 		echo "Add an account:"
 		echo "  aidevops model-accounts-pool add anthropic    # Claude Pro/Max"
-		echo "  aidevops model-accounts-pool add openai       # ChatGPT Plus/Pro"
+		echo "  aidevops model-accounts-pool add openai       # ChatGPT Plus/Pro (device flow default)"
 		echo "  aidevops model-accounts-pool add cursor       # Cursor Pro"
 		echo "  aidevops model-accounts-pool add google       # Google AI Pro/Ultra/Workspace"
 		echo "  aidevops model-accounts-pool import claude-cli"
@@ -2084,7 +2201,7 @@ Preferred CLI (same commands, no path needed):
   aidevops model-accounts-pool <command>
 
 Commands:
-  add [anthropic|openai|cursor|google]            Add an account (browser OAuth flow)
+  add [anthropic|openai|cursor|google]            Add an account (OAuth; OpenAI defaults to device flow)
   check [anthropic|openai|cursor|google|all]      Health check: token expiry + live validity
   list [anthropic|openai|cursor|google|all]       List accounts with per-account status
   status [anthropic|openai|cursor|google|all]     Pool aggregate stats (counts, availability)
@@ -2104,7 +2221,7 @@ Quickstart (if you see "Key Missing" or auth errors):
 
 Examples:
   oauth-pool-helper.sh add anthropic                      # Claude Pro/Max (browser OAuth)
-  oauth-pool-helper.sh add openai                         # ChatGPT Plus/Pro (browser OAuth)
+  oauth-pool-helper.sh add openai                         # ChatGPT Plus/Pro (device flow default)
   oauth-pool-helper.sh add cursor                         # Cursor Pro (reads from IDE)
   oauth-pool-helper.sh add google                         # Google AI Pro/Ultra/Workspace (browser OAuth)
   oauth-pool-helper.sh import claude-cli                  # Import from Claude CLI auth

--- a/.agents/tools/opencode/opencode-openai-auth.md
+++ b/.agents/tools/opencode/opencode-openai-auth.md
@@ -25,16 +25,14 @@ Uses the same token injection architecture as the Anthropic pool.
 
 ```bash
 # Add your first ChatGPT Plus/Pro account to the pool
-opencode auth login
-# Select: OpenAI Pool
-# Enter your ChatGPT account email
-# Complete OAuth flow in browser (redirects to localhost:1455)
-# Copy the "code" parameter from the redirect URL
-# Paste into the OpenCode prompt
+aidevops model-accounts-pool add openai
+# Default flow: OpenAI Codex device auth (recommended)
+# You will see:
+#   Go to: https://auth.openai.com/codex/device
+#   Enter code: XXXX-XXXXX
 
-# Optionally add more accounts for automatic rotation
-opencode auth login
-# Select: OpenAI Pool → enter second account email
+# Optional fallback (callback URL flow)
+AIDEVOPS_OPENAI_ADD_MODE=callback aidevops model-accounts-pool add openai
 
 # Manage accounts
 # /model-accounts-pool list provider=openai
@@ -60,22 +58,24 @@ The OpenAI pool uses the same token injection architecture as the Anthropic pool
 |--------|-----------|--------|
 | Token endpoint | `platform.claude.com/v1/oauth/token` | `auth.openai.com/oauth/token` |
 | Body format | JSON | `application/x-www-form-urlencoded` |
-| Redirect URI | `console.anthropic.com/oauth/code/callback` | `localhost:1455/auth/callback` |
+| Primary auth UX | Browser callback | Codex device auth (`auth.openai.com/codex/device`) |
+| Callback fallback | N/A | `localhost:1455/auth/callback` (optional via `AIDEVOPS_OPENAI_ADD_MODE=callback`) |
 | Scopes | `org:create_api_key user:profile ...` | `openid profile email offline_access` |
 | Account ID | N/A | `chatgpt_account_id` (from JWT claims) |
 | Auth.json fields | `type, refresh, access, expires` | `type, refresh, access, expires, accountId` |
 
 ## OAuth Flow
 
-OpenAI uses a local redirect server (port 1455) for its built-in OAuth flow.
-The pool's add-account flow uses the same redirect URI with a code-paste UX:
+The pool helper uses a **device-auth-first** flow for OpenAI:
 
-1. Browser opens to `https://auth.openai.com/oauth/authorize`
-2. User signs in with their ChatGPT Plus/Pro account
-3. Browser redirects to `http://localhost:1455/auth/callback?code=...`
-4. User copies the `code` parameter from the URL
-5. User pastes the code into the OpenCode terminal prompt
-6. Pool exchanges the code for tokens and stores them
+1. Run `aidevops model-accounts-pool add openai`
+2. Terminal prompts OpenCode headless login flow
+3. Browser opens to `https://auth.openai.com/codex/device`
+4. User enters the device code shown in terminal
+5. OpenCode stores OAuth tokens in `~/.local/share/opencode/auth.json`
+6. Pool helper reads those tokens and stores them in `~/.aidevops/oauth-pool.json`
+
+If device auth is unavailable in your environment, set `AIDEVOPS_OPENAI_ADD_MODE=callback` to use the legacy callback URL flow.
 
 ## Managing the Pool
 
@@ -93,7 +93,7 @@ Or inspect the pool file directly (key names only):
 
 ```bash
 # List account emails (never expose token values)
-cat ~/.aidevops/oauth-pool.json | jq -r '.openai[].email'
+jq -r '.openai[].email' ~/.aidevops/oauth-pool.json
 ```
 
 ## Pool File Structure
@@ -121,7 +121,7 @@ cat ~/.aidevops/oauth-pool.json | jq -r '.openai[].email'
 - Pool file has 0600 permissions (owner-only read/write)
 - Tokens are stored locally, never transmitted to third parties
 - Do not commit `~/.aidevops/oauth-pool.json` to version control
-- Rotate tokens by re-running `opencode auth login` → OpenAI Pool
+- Rotate tokens by re-running `aidevops model-accounts-pool add openai`
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary
- Make `model-accounts-pool add openai` device-auth-first by invoking OpenCode headless login (`https://auth.openai.com/codex/device`) and importing tokens from `~/.local/share/opencode/auth.json` into the pool.
- Keep callback URL OAuth flow as fallback (`AIDEVOPS_OPENAI_ADD_MODE=callback`) so legacy environments remain supported.
- Preserve OpenAI `accountId` in pool entries and when writing back to OpenCode auth during rotation/refresh.
- Update OpenAI auth docs and helper command text to match the new default flow.

## Verification
- `shellcheck .agents/scripts/oauth-pool-helper.sh`
- `markdown-formatter check .agents/tools/opencode/opencode-openai-auth.md`
- `AIDEVOPS_OPENAI_ADD_MODE=invalid .agents/scripts/oauth-pool-helper.sh add openai test@example.com` (mode guard)
- `printf 'dummy-code\n' | AIDEVOPS_OPENAI_ADD_MODE=callback .agents/scripts/oauth-pool-helper.sh add openai test@example.com` (callback fallback path reachable)
- `AIDEVOPS_OPENAI_ADD_MODE=device .agents/scripts/oauth-pool-helper.sh add openai test@example.com` (device path shows `auth.openai.com/codex/device` and waits for authorization)

Closes #6553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenAI device-flow authentication, enabling users to authenticate via terminal device codes instead of browser-based OAuth.
  * Implemented fallback to callback flow when device authentication is unavailable.

* **Documentation**
  * Updated OpenAI account setup and token rotation instructions to reflect the new device-flow-first authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->