### PR TITLE
fix(claim-task-id): auto-bootstrap .task-counter when missing (GH#6569)

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -55,7 +55,15 @@
 #
 # Offline fallback:
 #   - Reads local .task-counter + 100 offset to avoid collisions
+#   - If local .task-counter is missing, bootstraps from TODO.md highest ID
 #   - Reconciliation required when back online
+#
+# Auto-bootstrap (GH#6569 — repo-agnostic):
+#   - If .task-counter is missing on remote, bootstrap_remote_counter() seeds it
+#   - Seed precedence: highest task ID in TODO.md + 1, otherwise 1
+#   - Bootstrap uses the same CAS git plumbing — safe from any branch
+#   - Emits BOOTSTRAP_COUNTER_OK / BOOTSTRAP_COUNTER_FAILED for observability
+#   - Concurrent bootstrap: if another session wins the push, we retry read
 #
 # Migration from TODO.md scanning:
 #   - If .task-counter doesn't exist, initialize from TODO.md highest ID
@@ -286,6 +294,101 @@ get_highest_task_id() {
 	echo "$highest"
 }
 
+# Compute seed value for .task-counter bootstrap from TODO.md (or default 1).
+# Reads TODO.md from the repo root; falls back to 1 if not found or empty.
+# Returns the seed value (highest task ID + 1, minimum 1).
+_compute_counter_seed() {
+	local repo_path="$1"
+	local todo_file="${repo_path}/TODO.md"
+	local seed=1
+
+	if [[ -f "$todo_file" ]]; then
+		local todo_content
+		todo_content=$(cat "$todo_file" 2>/dev/null || true)
+		if [[ -n "$todo_content" ]]; then
+			local highest
+			highest=$(get_highest_task_id "$todo_content")
+			if [[ "$highest" =~ ^[0-9]+$ ]] && [[ "$highest" -gt 0 ]]; then
+				seed=$((highest + 1))
+			fi
+		fi
+	fi
+
+	echo "$seed"
+	return 0
+}
+
+# Bootstrap .task-counter on <remote>/<counter_branch> when it is missing.
+# Seeds from TODO.md highest task ID (or 1 for fresh repos).
+# Uses the same git plumbing as allocate_counter_cas to stay branch-safe.
+# Returns 0 on success (counter now exists on remote), 1 on failure.
+bootstrap_remote_counter() {
+	local repo_path="$1"
+
+	cd "$repo_path" || return 1
+
+	log_info "BOOTSTRAP_COUNTER: .task-counter missing on ${REMOTE_NAME}/${COUNTER_BRANCH} — bootstrapping"
+
+	local seed
+	seed=$(_compute_counter_seed "$repo_path")
+	log_info "BOOTSTRAP_COUNTER: seeding from TODO.md → counter=${seed}"
+
+	# Create a blob with the seed value
+	local blob_sha
+	blob_sha=$(echo "$seed" | git hash-object -w --stdin 2>/dev/null) || {
+		log_warn "BOOTSTRAP_COUNTER: failed to create blob"
+		return 1
+	}
+
+	# Check whether .task-counter already exists in the remote tree
+	local existing_tree
+	existing_tree=$(git ls-tree "${REMOTE_NAME}/${COUNTER_BRANCH}" 2>/dev/null || true)
+
+	local tree_sha
+	if echo "$existing_tree" | grep -q "${COUNTER_FILE}$"; then
+		# Replace existing (invalid) entry
+		tree_sha=$(echo "$existing_tree" | sed "s|[0-9a-f]\{40,64\}	${COUNTER_FILE}$|${blob_sha}	${COUNTER_FILE}|" | git mktree 2>/dev/null) || {
+			log_warn "BOOTSTRAP_COUNTER: failed to create tree (replace)"
+			return 1
+		}
+	else
+		# Add new entry to existing tree
+		tree_sha=$(
+			{
+				echo "$existing_tree"
+				printf '100644 blob %s\t%s\n' "$blob_sha" "$COUNTER_FILE"
+			} | git mktree 2>/dev/null
+		) || {
+			log_warn "BOOTSTRAP_COUNTER: failed to create tree (add)"
+			return 1
+		}
+	fi
+
+	local parent_sha
+	parent_sha=$(git rev-parse "${REMOTE_NAME}/${COUNTER_BRANCH}" 2>/dev/null) || {
+		log_warn "BOOTSTRAP_COUNTER: failed to resolve ${REMOTE_NAME}/${COUNTER_BRANCH}"
+		return 1
+	}
+
+	local commit_sha
+	commit_sha=$(git commit-tree "$tree_sha" -p "$parent_sha" -m "chore: bootstrap .task-counter (seed=${seed})" 2>/dev/null) || {
+		log_warn "BOOTSTRAP_COUNTER: failed to create commit"
+		return 1
+	}
+
+	if ! git push "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" 2>/dev/null; then
+		log_warn "BOOTSTRAP_COUNTER: push failed (conflict — another session may have bootstrapped)"
+		git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+		# Not a hard failure — the remote may now have a valid counter from the other session
+		return 1
+	fi
+
+	git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+	log_info "BOOTSTRAP_COUNTER_OK: counter initialized to ${seed} on ${REMOTE_NAME}/${COUNTER_BRANCH}"
+	echo "BOOTSTRAP_COUNTER_OK"
+	return 0
+}
+
 # Read .task-counter from <remote>/<counter_branch> (fetches first)
 read_remote_counter() {
 	local repo_path="$1"
@@ -339,10 +442,19 @@ allocate_counter_cas() {
 
 	cd "$repo_path" || return 1
 
-	# Step 1: Read current counter from <remote>/<counter_branch>
+	# Step 1: Read current counter from <remote>/<counter_branch>.
+	# If missing/invalid, auto-bootstrap from TODO.md (GH#6569).
 	local current_value
 	if ! current_value=$(read_remote_counter "$repo_path"); then
-		return 1
+		log_info "Counter missing — attempting auto-bootstrap (GH#6569)"
+		local bootstrap_result
+		bootstrap_result=$(bootstrap_remote_counter "$repo_path") || true
+		# After bootstrap attempt, retry reading the counter.
+		# If another session bootstrapped concurrently, we still get a valid value.
+		if ! current_value=$(read_remote_counter "$repo_path"); then
+			log_error "BOOTSTRAP_COUNTER_FAILED: counter unavailable after bootstrap attempt"
+			return 1
+		fi
 	fi
 
 	local first_id="$current_value"
@@ -452,6 +564,7 @@ allocate_online() {
 }
 
 # Offline allocation (with safety offset)
+# Falls back to TODO.md seed when local .task-counter is missing (GH#6569).
 allocate_offline() {
 	local repo_path="$1"
 	local count="$2"
@@ -460,8 +573,14 @@ allocate_offline() {
 
 	local current_value
 	if ! current_value=$(read_local_counter "$repo_path"); then
-		log_error "Cannot read local ${COUNTER_FILE}"
-		return 1
+		# Auto-bootstrap local counter from TODO.md (GH#6569)
+		log_warn "Local ${COUNTER_FILE} missing — bootstrapping from TODO.md for offline use"
+		local seed
+		seed=$(_compute_counter_seed "$repo_path")
+		log_info "BOOTSTRAP_COUNTER: offline seed from TODO.md → ${seed}"
+		echo "$seed" >"${repo_path}/${COUNTER_FILE}"
+		current_value="$seed"
+		log_info "BOOTSTRAP_COUNTER_OK: local counter initialized to ${seed}"
 	fi
 
 	local first_id=$((current_value + OFFLINE_OFFSET))

--- a/.agents/scripts/test-task-id-collision.sh
+++ b/.agents/scripts/test-task-id-collision.sh
@@ -926,41 +926,64 @@ EOF
 	return 0
 }
 
-# Helper: verify missing .task-counter produces an error
+# Helper: verify missing .task-counter auto-bootstraps from TODO.md (GH#6569)
 _counter_validation_check_missing() {
 	local test_repo="$1"
+
+	# Remove any existing counter to simulate missing state
+	rm -f "$test_repo/.task-counter"
 
 	local output
 	output=$("$SCRIPT_DIR/claim-task-id.sh" --title "No counter test" --offline --no-issue --repo-path "$test_repo" 2>&1) || true
 
-	if echo "$output" | grep -qi "not found\|invalid\|missing\|error"; then
-		pass "Missing .task-counter correctly produces error"
+	local task_id
+	task_id=$(echo "$output" | grep "^task_id=" | cut -d= -f2 || echo "")
+
+	# TODO.md has t1, so seed=2, offline offset=100 → t102
+	if [[ -n "$task_id" ]] && [[ "$task_id" =~ ^t[0-9]+$ ]]; then
+		pass "Missing .task-counter auto-bootstraps from TODO.md (got $task_id)"
 	else
-		fail "Missing .task-counter did not produce expected error"
+		fail "Missing .task-counter should auto-bootstrap, got: $task_id (output: $output)"
+	fi
+
+	# Verify BOOTSTRAP_COUNTER_OK marker was emitted
+	if echo "$output" | grep -q "BOOTSTRAP_COUNTER_OK"; then
+		pass "BOOTSTRAP_COUNTER_OK marker emitted for observability"
+	else
+		fail "BOOTSTRAP_COUNTER_OK marker not found in output"
+	fi
+
+	# Verify .task-counter was created locally
+	if [[ -f "$test_repo/.task-counter" ]]; then
+		pass ".task-counter file created after bootstrap"
+	else
+		fail ".task-counter file not created after bootstrap"
 	fi
 	return 0
 }
 
-# Helper: verify non-numeric and valid .task-counter values
+# Helper: verify non-numeric .task-counter auto-bootstraps, and valid counter works
 _counter_validation_check_values() {
 	local test_repo="$1"
 
-	# Test with non-numeric .task-counter
+	# Test with non-numeric .task-counter — should auto-bootstrap from TODO.md
 	echo "abc" >"$test_repo/.task-counter"
 	local output
 	output=$("$SCRIPT_DIR/claim-task-id.sh" --title "Bad counter test" --offline --no-issue --repo-path "$test_repo" 2>&1) || true
 
-	if echo "$output" | grep -qi "invalid\|error"; then
-		pass "Non-numeric .task-counter correctly produces error"
+	local task_id
+	task_id=$(echo "$output" | grep "^task_id=" | cut -d= -f2 || echo "")
+
+	if [[ -n "$task_id" ]] && [[ "$task_id" =~ ^t[0-9]+$ ]]; then
+		pass "Non-numeric .task-counter auto-bootstraps from TODO.md (got $task_id)"
 	else
-		fail "Non-numeric .task-counter did not produce expected error"
+		fail "Non-numeric .task-counter should auto-bootstrap, got: $task_id"
 	fi
 
 	# Test with valid .task-counter
 	echo "42" >"$test_repo/.task-counter"
 	output=$("$SCRIPT_DIR/claim-task-id.sh" --title "Valid counter test" --offline --no-issue --repo-path "$test_repo" 2>/dev/null) || true
 
-	local task_id
 	task_id=$(echo "$output" | grep "^task_id=" | cut -d= -f2 || echo "")
 
 	if [[ "$task_id" == "t142" ]]; then
@@ -973,14 +996,57 @@ _counter_validation_check_values() {
 
 test_counter_validation() {
 	echo ""
-	echo "=== Test 11: .task-counter file validation ==="
-	info "Testing invalid counter file handling"
+	echo "=== Test 11: .task-counter file validation (GH#6569 auto-bootstrap) ==="
+	info "Testing auto-bootstrap when .task-counter is missing or invalid"
 
 	local test_repo="$TEST_DIR/test-repo-validate"
 
 	_counter_validation_setup "$test_repo"
 	_counter_validation_check_missing "$test_repo"
 	_counter_validation_check_values "$test_repo"
+	return 0
+}
+
+# =============================================================================
+# Test 12: Fresh repo bootstrap (no TODO.md, no .task-counter) — GH#6569
+# =============================================================================
+test_fresh_repo_bootstrap() {
+	echo ""
+	echo "=== Test 12: Fresh repo bootstrap (no TODO.md, no .task-counter) ==="
+	info "Testing auto-bootstrap seeds counter at 1 when no TODO.md exists"
+
+	local test_repo="$TEST_DIR/test-repo-fresh"
+	mkdir -p "$test_repo"
+	(
+		cd "$test_repo"
+		git init -q
+		git config user.email "test@test.com"
+		git config user.name "Test"
+		# No TODO.md, no .task-counter — truly fresh repo
+		touch README.md
+		git add README.md
+		git commit -q -m "init"
+	)
+
+	local output
+	output=$("$SCRIPT_DIR/claim-task-id.sh" --title "Fresh repo test" --offline --no-issue --repo-path "$test_repo" 2>&1) || true
+
+	local task_id
+	task_id=$(echo "$output" | grep "^task_id=" | cut -d= -f2 || echo "")
+
+	# Seed=1 (no TODO.md), offline offset=100 → t101
+	if [[ "$task_id" == "t101" ]]; then
+		pass "Fresh repo (no TODO.md) bootstraps at seed=1, allocates t101"
+	else
+		fail "Expected t101 for fresh repo, got '$task_id'"
+	fi
+
+	# Verify .task-counter was created
+	if [[ -f "$test_repo/.task-counter" ]]; then
+		pass ".task-counter created in fresh repo after bootstrap"
+	else
+		fail ".task-counter not created in fresh repo"
+	fi
 	return 0
 }
 
@@ -1007,6 +1073,7 @@ test_highest_task_id
 test_edge_cases
 test_batch_allocation
 test_counter_validation
+test_fresh_repo_bootstrap
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

- Auto-bootstrap `.task-counter` file when it is missing in any repo, making the full-loop task lifecycle repo-agnostic
- Fixes the bug where `claim-task-id.sh` would fail with an error when `.task-counter` didn't exist in the target repo

Closes #6569