### PR TITLE
t1675: clarify pulse model pinning vs worker OpenAI rotation

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -158,10 +158,17 @@ kill PID
 
 ### Model round-robin
 
-The headless runtime helper alternates between configured providers:
-`AIDEVOPS_HEADLESS_MODELS=anthropic/claude-sonnet-4-6`
+The headless runtime helper alternates between configured providers in
+`AIDEVOPS_HEADLESS_MODELS`.
 
-> **Note**: The pulse supervisor requires Anthropic (sonnet). OpenAI models are unreliable for orchestration — they exit immediately without producing model activity, wasting every other pulse cycle. Workers can use any provider via the rotation, but the pulse itself should be sonnet-only. Set in `~/.config/aidevops/credentials.sh`.
+Recommended split config (pulse pinned, workers rotated):
+
+```bash
+export PULSE_MODEL="anthropic/claude-sonnet-4-6"
+export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex"
+```
+
+> **Note**: The pulse supervisor requires Anthropic (sonnet). OpenAI models are unreliable for orchestration — they exit immediately without producing model activity, wasting every other pulse cycle. Workers can use any provider via `AIDEVOPS_HEADLESS_MODELS`, but the pulse itself should be pinned with `PULSE_MODEL`.
 
 ### Backoff handling
 

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -184,6 +184,8 @@ export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-code
 
 `AIDEVOPS_HEADLESS_MODELS` is a rotation pool with backoff handling, not a strict tier escalation chain. If you need guaranteed tiered escalation, use task-tier labels (`tier:thinking`) so the supervisor dispatches at a higher tier directly.
 
+For this split config, keep `openai/gpt-5.4` out of default worker rotation and use it as an explicit escalation target for high-thinking dispatches (for example via `tier:thinking` or explicit `--model openai/gpt-5.4`).
+
 ## Integration with Task Tool
 
 When using the Task tool to dispatch subagents, the `model:` field in the subagent's frontmatter serves as a recommendation. The orchestrating agent can override based on task complexity.

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -168,9 +168,21 @@ Cross-provider reviewers: `models/gemini-reviewer.md`, `models/gpt-reviewer.md`
 
 The pulse supervisor and headless workers have different model requirements:
 
-- **Pulse supervisor**: Anthropic sonnet only. OpenAI models are unreliable for orchestration — they exit immediately without producing model activity, wasting the entire pulse cycle. This is a proven failure mode, not a preference. Set via `AIDEVOPS_HEADLESS_MODELS=anthropic/claude-sonnet-4-6` in `~/.config/aidevops/credentials.sh`.
-- **Workers**: Can use any configured provider. The headless runtime helper rotates between providers in `AIDEVOPS_HEADLESS_MODELS`. For worker-only multi-provider rotation, configure the env var with multiple models but ensure the pulse plist only has anthropic.
+- **Pulse supervisor**: Anthropic sonnet only. OpenAI models are unreliable for orchestration — they exit immediately without producing model activity, wasting the entire pulse cycle. This is a proven failure mode, not a preference. Pin with `PULSE_MODEL=anthropic/claude-sonnet-4-6` in `~/.config/aidevops/credentials.sh`.
+- **Workers**: Can use any configured provider. The headless runtime helper rotates models from `AIDEVOPS_HEADLESS_MODELS`. For worker-only OpenAI usage, keep pulse pinned with `PULSE_MODEL` and set workers separately.
 - **Default** (no env var set): `anthropic/claude-sonnet-4-6` (single provider, no rotation).
+
+Recommended split configuration:
+
+```bash
+# Pulse orchestration model (stable)
+export PULSE_MODEL="anthropic/claude-sonnet-4-6"
+
+# Worker rotation pool
+export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex"
+```
+
+`AIDEVOPS_HEADLESS_MODELS` is a rotation pool with backoff handling, not a strict tier escalation chain. If you need guaranteed tiered escalation, use task-tier labels (`tier:thinking`) so the supervisor dispatches at a higher tier directly.
 
 ## Integration with Task Tool
 


### PR DESCRIPTION
## Summary
- Clarify that pulse should be pinned with `PULSE_MODEL`, while worker rotation uses `AIDEVOPS_HEADLESS_MODELS`.
- Add a recommended split configuration snippet for stable pulse orchestration with OpenAI-enabled workers.
- Document that `AIDEVOPS_HEADLESS_MODELS` is a rotation/backoff pool, not a strict tier escalation chain.

## Verification
- `markdown-formatter check .agents/tools/context/model-routing.md`
- `markdown-formatter check .agents/automate.md`

Closes #6578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified model routing guidance: recommend pinning the supervisor model while using a separate rotation pool for workers.
  * Added a “recommended split” configuration example showing supervisor pinning and worker rotation.
  * Explained that worker rotation uses a backoff-style pool (not tier escalation) and that tiered escalation should use task-tier labels; noted keeping high-tier models out of default rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->