### PR TITLE
fix: address remaining CodeRabbit findings in best-practices.md (GH#6611)

### DIFF
--- a/.agents/tools/code-review/best-practices.md
+++ b/.agents/tools/code-review/best-practices.md
@@ -23,12 +23,12 @@ tools:
 - **S1192**: `readonly CONSTANT` for strings used 3+ times
 - **S1481**: Remove unused variables or enhance functionality
 - **Explicit returns**: Every function must end with `return 0` or error code
-- **Pre/post**: Run `linters-local.sh` before and after changes
+- **Pre/post**: Run `.agents/scripts/linters-local.sh` before and after changes
 - **Targets**: SonarCloud <50 issues, 0 critical violations, 100% feature preservation
 
 <!-- AI-CONTEXT-END -->
 
-> **IMPORTANT**: Supplementary to [AGENTS.md](../../../AGENTS.md). For conflicts, AGENTS.md takes precedence.
+> **IMPORTANT**: Supplementary to [AGENTS.md](../../AGENTS.md). For conflicts, AGENTS.md takes precedence.
 
 ## Shell Script Standards (MANDATORY)
 
@@ -67,7 +67,7 @@ fi
 
 ## Quality Tools
 
-- `linters-local.sh` — run before and after changes
+- `.agents/scripts/linters-local.sh` — run before and after changes
 - `fix-content-type.sh`, `fix-auth-headers.sh`, `fix-error-messages.sh` — targeted fixers
 - `coderabbit-cli.sh review`, `codacy-cli.sh analyze`, `sonarscanner-cli.sh analyze`
 
@@ -218,14 +218,14 @@ Use for long-running polls to avoid hammering APIs:
 
 ```bash
 poll_with_backoff() {
-    local check_cmd="$1"
+    local check_fn="$1"
     local max_wait="${2:-300}"
     local interval="${3:-2}"
     local max_interval="${4:-30}"
     local elapsed=0
 
     while [[ "$elapsed" -lt "$max_wait" ]]; do
-        if $check_cmd; then return 0; fi
+        if "$check_fn"; then return 0; fi
         sleep "$interval"
         elapsed=$(( elapsed + interval ))
         interval=$(( interval * 2 ))


### PR DESCRIPTION
## Summary

Three CodeRabbit findings from PR #6636 were not included in the merge (PR was merged before the fixes landed on the branch). This PR addresses them.

## Changes

- **AGENTS.md link** (line 31): `../../../AGENTS.md` → `../../AGENTS.md`
  From `.agents/tools/code-review/`, `../../` resolves to `.agents/AGENTS.md` (user/operational guide). `../../../` would resolve to root `AGENTS.md` (developer guide) — incorrect for operational precedence. alex-solovyev confirmed this in the PR thread.

- **`poll_with_backoff`** (line ~221): rename `check_cmd` → `check_fn`, invoke as tokenized command (`"$check_fn"`) instead of unquoted string expansion (`$check_cmd`). Unquoted string expansion is fragile and potentially unsafe per CodeRabbit's major finding.

- **`linters-local.sh` references** (lines 26, 70): use explicit path `.agents/scripts/linters-local.sh` for reproducible execution in automation/docs consumers (CodeRabbit nitpick).

Closes #6611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated script paths and references for accuracy.
  * Improved code examples for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->