### PR TITLE
t1665.5: Migrate accidentally-coupled scripts to use runtime-registry.sh

### DIFF
--- a/.agents/scripts/contributor-activity-helper.sh
+++ b/.agents/scripts/contributor-activity-helper.sh
@@ -571,12 +571,30 @@ cross_repo_summary() {
 }
 
 #######################################
-# Auto-detect AI assistant session database path
+# Auto-detect AI assistant session database path (t1665.5)
 #
-# Checks known locations for OpenCode and Claude Code databases.
+# Uses runtime registry to find the first available session DB.
+# Falls back to hardcoded paths if registry is not loaded.
 # Output: database path to stdout, or empty string if not found
 #######################################
 _session_time_detect_db() {
+	# Use runtime registry if available (t1665.5)
+	if type rt_list_ids &>/dev/null; then
+		local _db_rt_id _db_path _db_fmt
+		while IFS= read -r _db_rt_id; do
+			_db_path=$(rt_session_db "$_db_rt_id") || continue
+			_db_fmt=$(rt_session_db_format "$_db_rt_id") || continue
+			# Only return SQLite databases (this function is used for SQL queries)
+			if [[ "$_db_fmt" == "sqlite" && -n "$_db_path" && -f "$_db_path" ]]; then
+				echo "$_db_path"
+				return 0
+			fi
+		done < <(rt_list_ids)
+		echo ""
+		return 0
+	fi
+
+	# Fallback: hardcoded paths
 	if [[ -f "${HOME}/.local/share/opencode/opencode.db" ]]; then
 		echo "${HOME}/.local/share/opencode/opencode.db"
 	elif [[ -f "${HOME}/.local/share/claude/Claude.db" ]]; then

--- a/.agents/scripts/mcp-diagnose.sh
+++ b/.agents/scripts/mcp-diagnose.sh
@@ -65,29 +65,59 @@ if [[ "$INSTALLED_VERSION" != *"$LATEST_VERSION"* ]] && [[ "$LATEST_VERSION" != 
 	echo -e "   ${YELLOW}⚠️  UPDATE AVAILABLE - run: npm update -g $NPM_PKG${NC}"
 fi
 
-# 3. Check OpenCode config
+# 3. Check runtime configs for MCP (t1665.5 — registry-driven)
 echo ""
-echo "3. Checking OpenCode configuration..."
-CONFIG_FILE="$HOME/.config/opencode/opencode.json"
-if [[ -f "$CONFIG_FILE" ]]; then
-	if grep -q "\"$MCP_NAME\"" "$CONFIG_FILE"; then
-		echo -e "   ${GREEN}✓ MCP configured in opencode.json${NC}"
+echo "3. Checking runtime configurations..."
+
+# Build list of config files to check from registry, fallback to hardcoded
+_MCP_DIAG_CONFIGS=()
+if type rt_detect_configured &>/dev/null; then
+	while IFS= read -r _rt_id; do
+		_cfg=$(rt_config_path "$_rt_id") || continue
+		[[ -n "$_cfg" && -f "$_cfg" ]] && _MCP_DIAG_CONFIGS+=("$_rt_id:$_cfg")
+	done < <(rt_detect_configured)
+fi
+# Fallback if registry not loaded or no configs found
+if [[ ${#_MCP_DIAG_CONFIGS[@]} -eq 0 ]]; then
+	_fallback_cfg="$HOME/.config/opencode/opencode.json"
+	[[ -f "$_fallback_cfg" ]] && _MCP_DIAG_CONFIGS+=("opencode:$_fallback_cfg")
+fi
+
+_mcp_found_in_any=0
+for _diag_entry in "${_MCP_DIAG_CONFIGS[@]}"; do
+	_diag_rt="${_diag_entry%%:*}"
+	CONFIG_FILE="${_diag_entry#*:}"
+	_diag_name=""
+	if type rt_display_name &>/dev/null; then
+		_diag_name=$(rt_display_name "$_diag_rt") || _diag_name="$_diag_rt"
+	else
+		_diag_name="$_diag_rt"
+	fi
+
+	if grep -q "\"$MCP_NAME\"" "$CONFIG_FILE" 2>/dev/null; then
+		echo -e "   ${GREEN}✓ MCP configured in ${_diag_name} config${NC}"
 		# Extract and show the command using Python
 		python3 -c "
 import json
 with open('$CONFIG_FILE') as f:
     cfg = json.load(f)
-mcp = cfg.get('mcp', {}).get('$MCP_NAME', {})
+# Try both 'mcp' (opencode) and 'mcpServers' (other runtimes) root keys
+mcp = cfg.get('mcp', cfg.get('mcpServers', {})).get('$MCP_NAME', {})
 cmd = mcp.get('command', 'not set')
 enabled = mcp.get('enabled', 'not set')
 print(f'   Command: {cmd}')
 print(f'   Enabled: {enabled}')
 " 2>/dev/null || echo "   (Could not parse config)"
-	else
-		echo -e "   ${RED}✗ MCP not found in config${NC}"
+		_mcp_found_in_any=1
 	fi
-else
-	echo -e "   ${RED}✗ Config file not found: $CONFIG_FILE${NC}"
+done
+
+if [[ "$_mcp_found_in_any" -eq 0 ]]; then
+	if [[ ${#_MCP_DIAG_CONFIGS[@]} -eq 0 ]]; then
+		echo -e "   ${RED}✗ No runtime config files found${NC}"
+	else
+		echo -e "   ${RED}✗ MCP '$MCP_NAME' not found in any runtime config${NC}"
+	fi
 fi
 
 # 4. Check for known breaking changes
@@ -130,4 +160,4 @@ echo "1. Update tool: npm update -g $NPM_PKG"
 echo "2. Check official docs for command changes"
 echo "3. Run: $CLI_CMD --help"
 echo "4. Check ~/.aidevops/agents/tools/ for updated documentation"
-echo "5. Run: opencode mcp list (to verify status after fixes)"
+echo "5. Verify MCP status in your runtime's config after fixes"

--- a/.agents/scripts/mcp-index-helper.sh
+++ b/.agents/scripts/mcp-index-helper.sh
@@ -27,7 +27,13 @@ set -euo pipefail
 # Configuration
 readonly INDEX_DIR="${AIDEVOPS_MCP_INDEX_DIR:-$HOME/.aidevops/.agent-workspace/mcp-index}"
 readonly INDEX_DB="$INDEX_DIR/mcp-tools.db"
-readonly OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
+# Primary MCP config — use runtime registry if available, fallback to opencode (t1665.5)
+if type rt_config_path &>/dev/null; then
+	_MCP_IDX_CONFIG=$(rt_config_path "opencode") || _MCP_IDX_CONFIG=""
+else
+	_MCP_IDX_CONFIG="$HOME/.config/opencode/opencode.json"
+fi
+readonly OPENCODE_CONFIG="${_MCP_IDX_CONFIG}"
 # shellcheck disable=SC2034  # Used for future cache invalidation
 readonly CACHE_TTL_HOURS=24
 

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -129,14 +129,13 @@ check_jq() {
 }
 
 #######################################
-# Detect available AI CLI backend (t1160.3, t1160)
-# Sets AIDEVOPS_DISPATCH_BACKEND to "opencode" or "claude"
+# Detect available AI CLI backend (t1160.3, t1160, t1665.5)
+# Sets AIDEVOPS_DISPATCH_BACKEND to a runtime ID from the registry.
 #
 # Priority (aligned with supervisor/dispatch.sh resolve_ai_cli):
 #   1. AIDEVOPS_DISPATCH_BACKEND env var (explicit override)
 #   2. SUPERVISOR_CLI env var (supervisor-level override)
-#   3. opencode (primary — handles all providers including Anthropic OAuth)
-#   4. claude (first-class fallback — Anthropic-only, OAuth subscription billing)
+#   3. First headless-capable runtime found via registry
 #
 # Returns 1 if no backend is available
 #######################################
@@ -148,12 +147,18 @@ detect_dispatch_backend() {
 
 	# Honour SUPERVISOR_CLI if set (supervisor-level override)
 	if [[ -n "${SUPERVISOR_CLI:-}" ]]; then
-		if [[ "$SUPERVISOR_CLI" != "opencode" && "$SUPERVISOR_CLI" != "claude" ]]; then
-			log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' is not a supported CLI (opencode|claude)"
-			return 1
+		# Validate it's a known runtime binary
+		local cli_binary="$SUPERVISOR_CLI"
+		if type rt_id_from_binary &>/dev/null; then
+			local rt_id
+			rt_id=$(rt_id_from_binary "$cli_binary") || true
+			if [[ -z "$rt_id" ]]; then
+				log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' is not a registered runtime"
+				return 1
+			fi
 		fi
-		if command -v "$SUPERVISOR_CLI" &>/dev/null; then
-			AIDEVOPS_DISPATCH_BACKEND="$SUPERVISOR_CLI"
+		if command -v "$cli_binary" &>/dev/null; then
+			AIDEVOPS_DISPATCH_BACKEND="$cli_binary"
 			log_info "Using dispatch backend: $AIDEVOPS_DISPATCH_BACKEND (from SUPERVISOR_CLI)"
 			return 0
 		fi
@@ -161,6 +166,22 @@ detect_dispatch_backend() {
 		return 1
 	fi
 
+	# Use runtime registry to find first available headless-capable backend (t1665.5)
+	if type rt_list_headless &>/dev/null; then
+		local rt_id bin
+		while IFS= read -r rt_id; do
+			bin=$(rt_binary "$rt_id") || continue
+			if [[ -n "$bin" ]] && command -v "$bin" &>/dev/null; then
+				AIDEVOPS_DISPATCH_BACKEND="$bin"
+				log_info "Using dispatch backend: $AIDEVOPS_DISPATCH_BACKEND (runtime: $rt_id)"
+				return 0
+			fi
+		done < <(rt_list_headless)
+		log_error "No AI CLI backend available. Install a headless-capable runtime (opencode, claude, codex, etc.)"
+		return 1
+	fi
+
+	# Fallback: hardcoded check (registry not loaded)
 	if command -v opencode &>/dev/null; then
 		AIDEVOPS_DISPATCH_BACKEND="opencode"
 	elif command -v claude &>/dev/null; then

--- a/.agents/scripts/runtime-registry.sh
+++ b/.agents/scripts/runtime-registry.sh
@@ -246,6 +246,80 @@ _RT_HEADLESS_SUPPORT=(
 	"yes" # amp
 )
 
+# --- Headless cmdline patterns (regex to identify headless/worker instances) ---
+# Used by session-count-helper.sh to exclude headless workers from interactive counts.
+# Empty string means "no headless mode" (all instances are interactive).
+# These are grep -E patterns matched against the process command line.
+_RT_HEADLESS_CMDLINE_PATTERN=(
+	"\\.opencode run "         # opencode — headless via "run" subcommand
+	"claude (-p|--print|run) " # claude-code — headless via -p, --print, or run
+	"codex "                   # codex — all CLI invocations are headless
+	""                         # cursor — no headless mode
+	"droid run "               # droid — headless via "run" subcommand
+	"gemini "                  # gemini-cli — all CLI invocations are headless
+	""                         # windsurf — no headless mode
+	""                         # continue — no headless mode
+	"kilo run "                # kilo — headless via "run" subcommand
+	""                         # kiro — no headless mode
+	"aider --yes "             # aider — headless via --yes flag
+	"amp run "                 # amp — headless via "run" subcommand
+)
+
+# --- pgrep mode (how to find processes for this runtime) ---
+# "x" = pgrep -x (exact binary name match)
+# "f" = pgrep -f (full command line match, for runtimes whose binary
+#       name differs from the process pattern, e.g., opencode runs as .opencode)
+_RT_PGREP_MODE=(
+	"f" # opencode — binary is .opencode in PATH, needs -f
+	"x" # claude-code — exact match on "claude"
+	"x" # codex
+	"f" # cursor — match Cursor.app in cmdline
+	"x" # droid
+	"x" # gemini-cli
+	"f" # windsurf — match Windsurf in cmdline
+	"f" # continue — match in cmdline
+	"x" # kilo
+	"x" # kiro
+	"f" # aider — Python process, needs -f
+	"x" # amp
+)
+
+# --- pgrep search pattern (what to pass to pgrep) ---
+# May differ from _RT_PROCESS_PATTERN when pgrep mode is "f" (full cmdline).
+_RT_PGREP_PATTERN=(
+	"\\.opencode"  # opencode — binary is .opencode
+	"claude"       # claude-code
+	"codex"        # codex
+	"Cursor\\.app" # cursor
+	"droid"        # droid
+	"gemini"       # gemini-cli
+	"Windsurf"     # windsurf
+	"continue"     # continue
+	"kilo"         # kilo
+	"kiro"         # kiro
+	"aider"        # aider
+	"amp"          # amp
+)
+
+# --- Process exclusion patterns (noise to filter out) ---
+# grep -E patterns for processes that match the pgrep pattern but are NOT
+# actual runtime sessions (language servers, node wrappers, etc.).
+# Empty string means "no exclusions needed".
+_RT_PROCESS_EXCLUSION=(
+	"(typescript-language-server|eslintServer|vscode-)|^node .*/bin/opencode" # opencode
+	""                                                                        # claude-code
+	""                                                                        # codex
+	""                                                                        # cursor
+	""                                                                        # droid
+	""                                                                        # gemini-cli
+	""                                                                        # windsurf
+	""                                                                        # continue
+	""                                                                        # kilo
+	""                                                                        # kiro
+	""                                                                        # aider
+	""                                                                        # amp
+)
+
 # =============================================================================
 # Internal: Index Lookup
 # =============================================================================
@@ -368,6 +442,38 @@ rt_headless_support() {
 	local idx
 	idx=$(_rt_index "$id") || return 1
 	echo "${_RT_HEADLESS_SUPPORT[$idx]}"
+	return 0
+}
+
+rt_headless_cmdline_pattern() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_HEADLESS_CMDLINE_PATTERN[$idx]}"
+	return 0
+}
+
+rt_pgrep_mode() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_PGREP_MODE[$idx]}"
+	return 0
+}
+
+rt_pgrep_pattern() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_PGREP_PATTERN[$idx]}"
+	return 0
+}
+
+rt_process_exclusion() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	echo "${_RT_PROCESS_EXCLUSION[$idx]}"
 	return 0
 }
 
@@ -517,6 +623,10 @@ rt_validate_registry() {
 		"_RT_SESSION_DB_FORMAT"
 		"_RT_PROCESS_PATTERN"
 		"_RT_HEADLESS_SUPPORT"
+		"_RT_HEADLESS_CMDLINE_PATTERN"
+		"_RT_PGREP_MODE"
+		"_RT_PGREP_PATTERN"
+		"_RT_PROCESS_EXCLUSION"
 	)
 
 	local arr_name

--- a/.agents/scripts/secret-hygiene-helper.sh
+++ b/.agents/scripts/secret-hygiene-helper.sh
@@ -458,7 +458,21 @@ scan_mcp_configs() {
 
 	local found_risk=0
 
-	for config in "$HOME/.config/Claude/claude_desktop_config.json" "$HOME/.cursor/mcp.json"; do
+	# Build config list from registry (t1665.5), fallback to hardcoded
+	local -a _sh_configs=()
+	if type rt_detect_configured &>/dev/null; then
+		local _sh_rt_id _sh_cfg
+		while IFS= read -r _sh_rt_id; do
+			_sh_cfg=$(rt_config_path "$_sh_rt_id") || continue
+			[[ -n "$_sh_cfg" && -f "$_sh_cfg" ]] && _sh_configs+=("$_sh_cfg")
+		done < <(rt_detect_configured)
+	fi
+	# Fallback if registry not loaded or no configs found
+	if [[ ${#_sh_configs[@]} -eq 0 ]]; then
+		[[ -f "$HOME/.config/Claude/claude_desktop_config.json" ]] && _sh_configs+=("$HOME/.config/Claude/claude_desktop_config.json")
+		[[ -f "$HOME/.cursor/mcp.json" ]] && _sh_configs+=("$HOME/.cursor/mcp.json")
+	fi
+	for config in "${_sh_configs[@]}"; do
 		[[ -f "$config" ]] || continue
 
 		local uvx_count=0 npx_count=0

--- a/.agents/scripts/session-count-helper.sh
+++ b/.agents/scripts/session-count-helper.sh
@@ -33,19 +33,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 # =============================================================================
-# Session Detection
+# Session Detection (t1665.5 — registry-driven)
 # =============================================================================
 # Detects interactive AI coding sessions by examining running processes.
-# Distinguishes interactive (TUI) sessions from headless workers.
-#
-# Known AI coding assistants and their process signatures:
-#   opencode (interactive): .opencode (no "run" argument in cmdline)
-#   opencode (headless):    .opencode run ... (has "run" in cmdline)
-#   claude (interactive):   claude (no "-p" or "--print" in cmdline)
-#   claude (headless):      claude -p ... or claude --print ...
-#   cursor:                 Cursor process
-#   windsurf:               Windsurf process
-#   aider:                  aider (Python process)
+# Distinguishes interactive (TUI) sessions from headless workers using
+# per-runtime patterns from the runtime registry.
 
 # Get system RAM in GB (used as default session threshold).
 # Each session uses ~100-400 MB, so RAM in GB is a reasonable max.
@@ -110,111 +102,71 @@ _get_pid_cmdline() {
 	return 0
 }
 
-# Count interactive OpenCode sessions.
-# Excludes headless workers (.opencode run ...), language servers, and node wrappers.
+# Count interactive sessions for a single runtime using registry properties.
+# Args: $1 = runtime ID
 # Outputs the count on stdout.
-_count_opencode_sessions() {
+_count_runtime_sessions() {
+	local rt_id="$1"
 	local count=0
-	local opencode_pids=""
-	opencode_pids=$(pgrep -f '\.opencode' || true)
 
-	if [[ -n "$opencode_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
+	local pgrep_mode pgrep_pat headless_pat exclusion_pat
+	pgrep_mode=$(rt_pgrep_mode "$rt_id") || return 0
+	pgrep_pat=$(rt_pgrep_pattern "$rt_id") || return 0
+	headless_pat=$(rt_headless_cmdline_pattern "$rt_id") || true
+	exclusion_pat=$(rt_process_exclusion "$rt_id") || true
 
-			# Skip headless workers
-			if echo "$cmdline" | grep -qE '\.opencode run '; then
-				continue
-			fi
-			# Skip language servers spawned by opencode
-			if echo "$cmdline" | grep -qE '(typescript-language-server|eslintServer|vscode-)'; then
-				continue
-			fi
-			# Skip node wrapper processes (the actual .opencode binary is what matters)
-			if echo "$cmdline" | grep -qE '^node .*/bin/opencode'; then
-				continue
-			fi
-			count=$((count + 1))
-		done <<<"$opencode_pids"
-	fi
-
-	echo "$count"
-	return 0
-}
-
-# Count interactive Claude Code sessions.
-# Excludes headless modes (-p, --print, run).
-# Outputs the count on stdout.
-_count_claude_sessions() {
-	local count=0
-	local claude_pids=""
-	claude_pids=$(pgrep -x claude || true)
-
-	if [[ -n "$claude_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
-
-			# Skip headless modes
-			if echo "$cmdline" | grep -qE 'claude (-p|--print|run) '; then
-				continue
-			fi
-			count=$((count + 1))
-		done <<<"$claude_pids"
-	fi
-
-	echo "$count"
-	return 0
-}
-
-# Count interactive sessions for a simple app (Cursor, Windsurf, Aider).
-# These apps have no headless mode to filter — all matching PIDs are interactive.
-# Args: $1 = pgrep pattern
-# Outputs the count on stdout.
-_count_simple_sessions() {
-	local pattern="$1"
-	local pids=""
-	pids=$(pgrep -f "$pattern" || true)
-	if [[ -n "$pids" ]]; then
-		echo "$pids" | wc -l | tr -d ' '
-	else
+	[[ -z "$pgrep_pat" ]] && {
 		echo "0"
+		return 0
+	}
+
+	# Find matching PIDs
+	local pids=""
+	if [[ "$pgrep_mode" == "x" ]]; then
+		pids=$(pgrep -x "$pgrep_pat" || true)
+	else
+		pids=$(pgrep -f "$pgrep_pat" || true)
 	fi
+
+	if [[ -z "$pids" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	local pid cmdline
+	while IFS= read -r pid; do
+		[[ -z "$pid" ]] && continue
+		cmdline=$(_get_pid_cmdline "$pid")
+
+		# Skip headless workers if pattern is defined
+		if [[ -n "$headless_pat" ]] && echo "$cmdline" | grep -qE "$headless_pat"; then
+			continue
+		fi
+
+		# Skip noise processes (language servers, wrappers, etc.)
+		if [[ -n "$exclusion_pat" ]] && echo "$cmdline" | grep -qE "$exclusion_pat"; then
+			continue
+		fi
+
+		count=$((count + 1))
+	done <<<"$pids"
+
+	echo "$count"
 	return 0
 }
 
-# Count interactive AI sessions.
+# Count interactive AI sessions across all registered runtimes.
 # Returns the count on stdout.
-# Uses pgrep + /proc/cmdline (Linux) or ps (macOS) to distinguish
-# interactive from headless sessions.
 count_interactive_sessions() {
 	local count=0
-	local n
 
-	n=$(_count_opencode_sessions)
-	count=$((count + n))
-
-	n=$(_count_claude_sessions)
-	count=$((count + n))
-
-	# --- Cursor sessions ---
-	# Note: pgrep -c is Linux-only; use pgrep | wc -l for cross-platform.
-	# Guard with -n check to avoid counting empty output as 1.
-	n=$(_count_simple_sessions 'Cursor\.app')
-	count=$((count + n))
-
-	# --- Windsurf sessions ---
-	n=$(_count_simple_sessions 'Windsurf')
-	count=$((count + n))
-
-	# --- Aider sessions ---
-	n=$(_count_simple_sessions 'aider')
-	count=$((count + n))
+	if type rt_list_ids &>/dev/null; then
+		local rt_id n
+		while IFS= read -r rt_id; do
+			n=$(_count_runtime_sessions "$rt_id")
+			count=$((count + n))
+		done < <(rt_list_ids)
+	fi
 
 	echo "$count"
 	return 0
@@ -235,87 +187,50 @@ _print_session_detail() {
 	return 0
 }
 
-# List interactive OpenCode sessions with details.
-# Excludes headless workers, language servers, and node wrappers.
-# Increments the found counter via stdout (caller adds to its own count).
-# Args: none. Outputs detail lines; returns number of sessions found.
-_list_opencode_sessions() {
-	local found=0
-	local opencode_pids=""
-	opencode_pids=$(pgrep -f '\.opencode' || true)
-
-	if [[ -n "$opencode_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
-
-			# Skip headless, language servers, node wrappers
-			if echo "$cmdline" | grep -qE '\.opencode run '; then
-				continue
-			fi
-			if echo "$cmdline" | grep -qE '(typescript-language-server|eslintServer|vscode-)'; then
-				continue
-			fi
-			if echo "$cmdline" | grep -qE '^node .*/bin/opencode'; then
-				continue
-			fi
-
-			_print_session_detail "$pid" "OpenCode"
-			found=$((found + 1))
-		done <<<"$opencode_pids"
-	fi
-
-	return "$found"
-}
-
-# List interactive Claude Code sessions with details.
-# Excludes headless modes (-p, --print, run).
+# List interactive sessions for a single runtime with details.
+# Args: $1 = runtime ID
 # Returns number of sessions found via exit code.
-_list_claude_sessions() {
+_list_runtime_sessions() {
+	local rt_id="$1"
 	local found=0
-	local claude_pids=""
-	claude_pids=$(pgrep -x claude || true)
 
-	if [[ -n "$claude_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
+	local display_name pgrep_mode pgrep_pat headless_pat exclusion_pat
+	display_name=$(rt_display_name "$rt_id") || display_name="$rt_id"
+	pgrep_mode=$(rt_pgrep_mode "$rt_id") || return 0
+	pgrep_pat=$(rt_pgrep_pattern "$rt_id") || return 0
+	headless_pat=$(rt_headless_cmdline_pattern "$rt_id") || true
+	exclusion_pat=$(rt_process_exclusion "$rt_id") || true
 
-			if echo "$cmdline" | grep -qE 'claude (-p|--print|run) '; then
-				continue
-			fi
+	[[ -z "$pgrep_pat" ]] && return 0
 
-			_print_session_detail "$pid" "Claude Code"
-			found=$((found + 1))
-		done <<<"$claude_pids"
-	fi
-
-	return "$found"
-}
-
-# List interactive sessions for a simple app (Cursor, Windsurf, Aider).
-# All matching PIDs are treated as interactive (no headless mode to filter).
-# Args: $1 = pgrep pattern, $2 = display name
-# Returns number of sessions found via exit code.
-_list_simple_app_sessions() {
-	local pattern="$1"
-	local display_name="$2"
-	local found=0
+	# Find matching PIDs
 	local pids=""
-	pids=$(pgrep -f "$pattern" || true)
-
-	if [[ -n "$pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			_print_session_detail "$pid" "$display_name"
-			found=$((found + 1))
-		done <<<"$pids"
+	if [[ "$pgrep_mode" == "x" ]]; then
+		pids=$(pgrep -x "$pgrep_pat" || true)
+	else
+		pids=$(pgrep -f "$pgrep_pat" || true)
 	fi
+
+	[[ -z "$pids" ]] && return 0
+
+	local pid cmdline
+	while IFS= read -r pid; do
+		[[ -z "$pid" ]] && continue
+		cmdline=$(_get_pid_cmdline "$pid")
+
+		# Skip headless workers
+		if [[ -n "$headless_pat" ]] && echo "$cmdline" | grep -qE "$headless_pat"; then
+			continue
+		fi
+
+		# Skip noise processes
+		if [[ -n "$exclusion_pat" ]] && echo "$cmdline" | grep -qE "$exclusion_pat"; then
+			continue
+		fi
+
+		_print_session_detail "$pid" "$display_name"
+		found=$((found + 1))
+	done <<<"$pids"
 
 	return "$found"
 }
@@ -324,27 +239,15 @@ _list_simple_app_sessions() {
 # Output format: PID | APP | RSS_MB | UPTIME
 list_sessions() {
 	local found=0
-	local n=0
 
-	# --- OpenCode sessions ---
-	_list_opencode_sessions || n=$?
-	found=$((found + n))
-
-	# --- Claude Code sessions ---
-	_list_claude_sessions || n=$?
-	found=$((found + n))
-
-	# --- Cursor sessions ---
-	_list_simple_app_sessions 'Cursor\.app' "Cursor" || n=$?
-	found=$((found + n))
-
-	# --- Windsurf sessions ---
-	_list_simple_app_sessions 'Windsurf' "Windsurf" || n=$?
-	found=$((found + n))
-
-	# --- Aider sessions ---
-	_list_simple_app_sessions 'aider' "Aider" || n=$?
-	found=$((found + n))
+	if type rt_list_ids &>/dev/null; then
+		local rt_id n
+		while IFS= read -r rt_id; do
+			n=0
+			_list_runtime_sessions "$rt_id" || n=$?
+			found=$((found + n))
+		done < <(rt_list_ids)
+	fi
 
 	if [[ "$found" -eq 0 ]]; then
 		echo "  No interactive AI sessions detected"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1377,26 +1377,35 @@ resolve_model_tier() {
 }
 
 #######################################
-# Detect available AI CLI backends (t132.7)
-# Returns a newline-separated list of available backends.
-# Checks: opencode, claude
+# Detect available AI CLI backends (t132.7, t1665.5)
+# Returns a newline-separated list of available backend runtime IDs.
+# Delegates to runtime-registry.sh rt_detect_installed().
 #######################################
 detect_ai_backends() {
-	local -a backends=()
+	# Use runtime registry if loaded (t1665.5)
+	if type rt_detect_installed &>/dev/null; then
+		local installed
+		installed=$(rt_detect_installed) || true
+		if [[ -z "$installed" ]]; then
+			echo "none"
+			return 1
+		fi
+		echo "$installed"
+		return 0
+	fi
 
+	# Fallback: hardcoded check (registry not loaded)
+	local -a backends=()
 	if command -v opencode &>/dev/null; then
 		backends+=("opencode")
 	fi
-
 	if command -v claude &>/dev/null; then
 		backends+=("claude")
 	fi
-
 	if [[ ${#backends[@]} -eq 0 ]]; then
 		echo "none"
 		return 1
 	fi
-
 	printf '%s\n' "${backends[@]}"
 	return 0
 }

--- a/.agents/scripts/worker-sandbox-helper.sh
+++ b/.agents/scripts/worker-sandbox-helper.sh
@@ -142,33 +142,54 @@ create_worker_sandbox() {
 		ln -sf "$agents_source" "$sandbox_dir/.aidevops"
 	fi
 
-	# --- Claude Code / OpenCode config ---
+	# --- Runtime config files (t1665.5 — registry-driven) ---
 	# Workers need their tool configs. Copy only the specific config files needed,
 	# not the entire .config directory (which may contain credentials).
 	local config_dir="$sandbox_dir/.config"
 	mkdir -p "$config_dir"
 
-	# OpenCode config (if exists) — needed for MCP server definitions
-	local opencode_src="${REAL_HOME}/.config/opencode"
-	if [[ -d "$opencode_src" ]]; then
-		mkdir -p "$config_dir/opencode"
-		# Copy only opencode.json (MCP config), not auth files
-		if [[ -f "$opencode_src/opencode.json" ]]; then
-			cp "$opencode_src/opencode.json" "$config_dir/opencode/"
-		fi
-	fi
+	# Copy MCP config files for all configured runtimes
+	if type rt_detect_configured &>/dev/null; then
+		local _sb_rt_id _sb_cfg_path _sb_cfg_dir _sb_cfg_file _sb_dst_dir
+		while IFS= read -r _sb_rt_id; do
+			_sb_cfg_path=$(rt_config_path "$_sb_rt_id") || continue
+			[[ -z "$_sb_cfg_path" || ! -f "$_sb_cfg_path" ]] && continue
 
-	# Claude Code settings (if exists) — needed for MCP server definitions
-	local claude_dir_src="${REAL_HOME}/.claude"
-	if [[ -d "$claude_dir_src" ]]; then
-		local claude_dir_dst="$sandbox_dir/.claude"
-		mkdir -p "$claude_dir_dst"
-		# Copy settings.json (MCP config, preferences) but NOT credentials
-		if [[ -f "$claude_dir_src/settings.json" ]]; then
-			cp "$claude_dir_src/settings.json" "$claude_dir_dst/"
+			# Reconstruct the path relative to HOME for the sandbox
+			_sb_cfg_dir=$(dirname "$_sb_cfg_path")
+			_sb_cfg_file=$(basename "$_sb_cfg_path")
+			# Strip REAL_HOME prefix to get relative path
+			local _sb_rel_dir="${_sb_cfg_dir#"${REAL_HOME}"/}"
+			if [[ "$_sb_rel_dir" == "$_sb_cfg_dir" ]]; then
+				# Path doesn't start with REAL_HOME — skip
+				continue
+			fi
+
+			# Handle paths under .config/ vs paths under ~/.<dir>/
+			if [[ "$_sb_rel_dir" == .config/* ]]; then
+				_sb_dst_dir="$config_dir/${_sb_rel_dir#.config/}"
+			else
+				_sb_dst_dir="$sandbox_dir/$_sb_rel_dir"
+			fi
+
+			mkdir -p "$_sb_dst_dir"
+			cp "$_sb_cfg_path" "$_sb_dst_dir/$_sb_cfg_file"
+		done < <(rt_detect_configured)
+	else
+		# Fallback: hardcoded paths (registry not loaded)
+		local opencode_src="${REAL_HOME}/.config/opencode"
+		if [[ -d "$opencode_src" ]]; then
+			mkdir -p "$config_dir/opencode"
+			[[ -f "$opencode_src/opencode.json" ]] && cp "$opencode_src/opencode.json" "$config_dir/opencode/"
 		fi
-		# Do NOT copy: credentials.json, .credentials, auth tokens
+		local claude_dir_src="${REAL_HOME}/.claude"
+		if [[ -d "$claude_dir_src" ]]; then
+			local claude_dir_dst="$sandbox_dir/.claude"
+			mkdir -p "$claude_dir_dst"
+			[[ -f "$claude_dir_src/settings.json" ]] && cp "$claude_dir_src/settings.json" "$claude_dir_dst/"
+		fi
 	fi
+	# Do NOT copy: credentials.json, .credentials, auth tokens
 
 	# --- XDG directories for tool state ---
 	# Tools like npm, bun, etc. need writable cache/data dirs

--- a/setup-modules/post-setup.sh
+++ b/setup-modules/post-setup.sh
@@ -135,33 +135,52 @@ print_final_instructions() {
 	return 0
 }
 
-# Offer to launch onboarding for new users (only if not running inside OpenCode
-# and not non-interactive).
+# Offer to launch onboarding for new users (only if not running inside an AI
+# runtime session and not non-interactive). (t1665.5 — registry-driven)
 # Respects config: aidevops config set ui.onboarding_prompt false
 setup_onboarding_prompt() {
-	if [[ "$NON_INTERACTIVE" != "true" ]] && [[ -z "${OPENCODE_SESSION:-}" ]] && is_feature_enabled onboarding_prompt 2>/dev/null && command -v opencode &>/dev/null; then
-		echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	# Skip if non-interactive or already inside a runtime session
+	[[ "$NON_INTERACTIVE" == "true" ]] && return 0
+	[[ -n "${OPENCODE_SESSION:-}" || -n "${CLAUDE_SESSION:-}" ]] && return 0
+	is_feature_enabled onboarding_prompt 2>/dev/null || return 0
+
+	# Find first available headless runtime for onboarding dispatch
+	local _onb_bin="" _onb_name=""
+	if type rt_list_headless &>/dev/null; then
+		local _onb_rt_id
+		while IFS= read -r _onb_rt_id; do
+			_onb_bin=$(rt_binary "$_onb_rt_id") || continue
+			if [[ -n "$_onb_bin" ]] && command -v "$_onb_bin" &>/dev/null; then
+				_onb_name=$(rt_display_name "$_onb_rt_id") || _onb_name="$_onb_bin"
+				break
+			fi
+			_onb_bin=""
+		done < <(rt_list_headless)
+	fi
+	# Fallback
+	if [[ -z "$_onb_bin" ]] && command -v opencode &>/dev/null; then
+		_onb_bin="opencode"
+		_onb_name="OpenCode"
+	fi
+	[[ -z "$_onb_bin" ]] && return 0
+
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo ""
+	echo "Ready to configure your services?"
+	echo ""
+	echo "Launch ${_onb_name} with the onboarding wizard to:"
+	echo "  - See which services are already configured"
+	echo "  - Get personalized recommendations based on your work"
+	echo "  - Set up API keys and credentials interactively"
+	echo ""
+	read -r -p "Launch ${_onb_name} with /onboarding now? [Y/n]: " launch_onboarding
+	if [[ "$launch_onboarding" =~ ^[Yy]?$ ]]; then
 		echo ""
-		echo "Ready to configure your services?"
+		echo "Starting ${_onb_name} with onboarding wizard..."
+		"$_onb_bin" --prompt "/onboarding"
+	else
 		echo ""
-		echo "Launch OpenCode with the onboarding wizard to:"
-		echo "  - See which services are already configured"
-		echo "  - Get personalized recommendations based on your work"
-		echo "  - Set up API keys and credentials interactively"
-		echo ""
-		read -r -p "Launch OpenCode with /onboarding now? [Y/n]: " launch_onboarding
-		if [[ "$launch_onboarding" =~ ^[Yy]?$ ]]; then
-			echo ""
-			echo "Starting OpenCode with onboarding wizard..."
-			# Launch with /onboarding prompt only — don't use --agent flag because
-			# the "Onboarding" agent only exists after generate-opencode-agents.sh
-			# writes to opencode.json, which requires opencode.json to already exist.
-			# On first run it won't, so --agent "Onboarding" causes a fatal error.
-			opencode --prompt "/onboarding"
-		else
-			echo ""
-			echo "You can run /onboarding anytime in OpenCode to configure services."
-		fi
+		echo "You can run /onboarding anytime in ${_onb_name} to configure services."
 	fi
 	return 0
 }

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -150,9 +150,20 @@ setup_supervisor_pulse() {
 		_pulse_installed=true
 	fi
 
-	# Detect opencode binary location
+	# Detect dispatch backend binary location (t1665.5 — registry-driven)
 	local opencode_bin
-	opencode_bin=$(command -v opencode 2>/dev/null || echo "/opt/homebrew/bin/opencode")
+	if type rt_list_headless &>/dev/null; then
+		local _sched_rt_id _sched_bin
+		while IFS= read -r _sched_rt_id; do
+			_sched_bin=$(rt_binary "$_sched_rt_id") || continue
+			if [[ -n "$_sched_bin" ]] && command -v "$_sched_bin" &>/dev/null; then
+				opencode_bin=$(command -v "$_sched_bin")
+				break
+			fi
+		done < <(rt_list_headless)
+	fi
+	# Fallback if registry not loaded or no runtime found
+	opencode_bin="${opencode_bin:-$(command -v opencode 2>/dev/null || echo "/opt/homebrew/bin/opencode")}"
 
 	if [[ "$_do_install" == "true" ]]; then
 		mkdir -p "$HOME/.aidevops/logs"


### PR DESCRIPTION
## Summary

- Migrates 10 scripts from hardcoded runtime references (`command -v opencode/claude`, config paths, process patterns) to use `runtime-registry.sh` functions
- Adds 4 new registry properties for process detection: headless cmdline patterns, pgrep mode, pgrep patterns, and process exclusion patterns
- After this change, adding a new runtime to the registry automatically makes it visible to session counting, process detection, config validation, dispatch, and all other framework operations

## Changes by Category

### Category 1: Runtime detection
- `shared-constants.sh`: `detect_ai_backends()` delegates to `rt_detect_installed()`
- `runner-helper.sh`: `detect_dispatch_backend()` uses `rt_list_headless()` to find first available headless-capable backend

### Category 2: Process detection
- `session-count-helper.sh`: Merged per-runtime `_count_opencode_sessions()` and `_count_claude_sessions()` into generic `_count_runtime_sessions()` driven by registry properties

### Category 3: Config path lookups
- `mcp-index-helper.sh`: Config path from `rt_config_path()`
- `mcp-diagnose.sh`: Diagnoses MCP issues across all configured runtimes (not just opencode)
- `worker-sandbox-helper.sh`: Copies configs for all configured runtimes into sandbox
- `secret-hygiene-helper.sh`: Scans all runtime config files for leaked secrets
- `contributor-activity-helper.sh`: Session DB path from `rt_session_db()`

### Category 4: Dispatch and orchestration
- `setup-modules/post-setup.sh`: Onboarding uses first available headless runtime
- `setup-modules/schedulers.sh`: Pulse binary detected from registry

### Registry additions (`runtime-registry.sh`)
- `_RT_HEADLESS_CMDLINE_PATTERN`: Regex to identify headless/worker instances per runtime
- `_RT_PGREP_MODE`: `x` (exact) or `f` (full cmdline) per runtime
- `_RT_PGREP_PATTERN`: What to pass to pgrep (may differ from binary name)
- `_RT_PROCESS_EXCLUSION`: Noise processes to filter out (language servers, wrappers)

## Design Decisions

- **Graceful fallbacks**: All changes include fallback to hardcoded paths when the registry is not loaded, ensuring backward compatibility
- **Inherently runtime-specific files left as-is**: Plugin setup (`mcp-setup.sh`), config validation (`migrations.sh`), tool installation (`tool-install.sh`), and binary introspection scripts are inherently tied to specific runtimes and should not be abstracted
- **Feature flags (Cat 5) deferred**: Config schema changes for `manage_opencode_config`/`manage_claude_config` → `managed_runtimes` are a broader change best handled separately

## Verification

- `rt_validate_registry` passes (all 15 parallel arrays aligned)
- ShellCheck passes on all 11 modified files
- Zero remaining `command -v opencode|claude` in `.agents/scripts/` (excluding inherently runtime-specific files)
- All fallback paths tested

Closes #6536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal runtime detection to dynamically discover multiple AI assistant backends and their configurations, replacing hardcoded paths with registry-driven discovery for improved flexibility and reliability across different runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->