### PR TITLE
t1665.5: Migrate 6 coupled scripts to use runtime-registry.sh

### DIFF
--- a/.agents/scripts/mcp-index-helper.sh
+++ b/.agents/scripts/mcp-index-helper.sh
@@ -6,7 +6,7 @@
 # on-demand discovery instead of loading all tool definitions upfront.
 #
 # Usage:
-#   mcp-index-helper.sh sync              # Sync MCP descriptions from opencode.json
+#   mcp-index-helper.sh sync              # Sync MCP descriptions from all runtime configs
 #   mcp-index-helper.sh search "query"    # Search for tools matching query
 #   mcp-index-helper.sh list [mcp-name]   # List tools for an MCP server
 #   mcp-index-helper.sh status            # Show index status
@@ -27,7 +27,6 @@ set -euo pipefail
 # Configuration
 readonly INDEX_DIR="${AIDEVOPS_MCP_INDEX_DIR:-$HOME/.aidevops/.agent-workspace/mcp-index}"
 readonly INDEX_DB="$INDEX_DIR/mcp-tools.db"
-readonly OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
 # shellcheck disable=SC2034  # Used for future cache invalidation
 readonly CACHE_TTL_HOURS=24
 
@@ -100,7 +99,8 @@ EOF
 }
 
 #######################################
-# Check if index needs refresh
+# Check if index needs refresh (t1665.5)
+# Checks all runtime config files, not just opencode.json.
 #######################################
 needs_refresh() {
 	if [[ ! -f "$INDEX_DB" ]]; then
@@ -114,49 +114,60 @@ needs_refresh() {
 		return 0
 	fi
 
-	# Check if opencode.json is newer than last sync
-	if [[ -f "$OPENCODE_CONFIG" ]]; then
-		local config_mtime
-		config_mtime=$(stat -c %Y "$OPENCODE_CONFIG" 2>/dev/null || stat -f %m "$OPENCODE_CONFIG" 2>/dev/null || echo "0")
-		local sync_epoch
-		sync_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$last_sync" +%s 2>/dev/null || date -d "$last_sync" +%s 2>/dev/null || echo "0")
+	local sync_epoch
+	sync_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$last_sync" +%s 2>/dev/null || date -d "$last_sync" +%s 2>/dev/null || echo "0")
 
+	# Check if any runtime config file is newer than last sync
+	local rt_id config_path config_mtime
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		config_path=$(rt_config_path "$rt_id") || continue
+		[[ -z "$config_path" || ! -f "$config_path" ]] && continue
+
+		config_mtime=$(stat -c %Y "$config_path" 2>/dev/null || stat -f %m "$config_path" 2>/dev/null || echo "0")
 		if [[ "$config_mtime" -gt "$sync_epoch" ]]; then
 			return 0
 		fi
-	fi
+	done < <(rt_detect_configured)
 
 	return 1
 }
 
 #######################################
-# Insert MCP tools into the index database
-# Reads opencode.json, iterates enabled MCP servers,
-# classifies tools by category, and upserts rows.
+# Insert MCP tools into the index database (t1665.5)
+# Reads MCP config from all configured runtimes via registry.
+# Each runtime may use a different MCP root key (e.g., "mcp" vs "mcpServers").
 # Prints "tool_count mcp_count" to stdout on success.
 # Uses Python for reliable JSON parsing.
 #######################################
 _sync_insert_tools() {
-	python3 - "$INDEX_DB" "$OPENCODE_CONFIG" <<'PYEOF'
+	# Build config_path:mcp_root_key pairs for all configured runtimes
+	local config_args=""
+	local rt_id config_path mcp_key
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		config_path=$(rt_config_path "$rt_id") || continue
+		[[ -z "$config_path" || ! -f "$config_path" ]] && continue
+		mcp_key=$(rt_mcp_root_key "$rt_id") || continue
+		[[ -z "$mcp_key" ]] && continue
+		config_args="${config_args}${config_path}:${mcp_key}"$'\n'
+	done < <(rt_detect_configured)
+
+	[[ -z "$config_args" ]] && {
+		echo "0 0"
+		return 0
+	}
+
+	python3 - "$INDEX_DB" "$config_args" <<'PYEOF'
 import json
 import sqlite3
 import sys
 
-db_path, config_path = sys.argv[1], sys.argv[2]
-
-try:
-    with open(config_path, 'r') as f:
-        config = json.load(f)
-except Exception as e:
-    print(f"Error reading config: {e}", file=sys.stderr)
-    sys.exit(1)
+db_path = sys.argv[1]
+config_specs = sys.argv[2].strip().split('\n')
 
 conn = sqlite3.connect(db_path)
 cursor = conn.cursor()
-
-# Get MCP servers from config
-mcp_servers = config.get('mcp', {})
-global_tools = config.get('tools', {})
 
 tool_count = 0
 mcp_count = 0
@@ -166,7 +177,6 @@ tool_categories = {
     'context7': ['query-docs', 'resolve-library-id'],
     'augment-context-engine': ['codebase-retrieval'],
     'dataforseo': ['serp', 'keywords', 'backlinks', 'domain-analytics'],
-    # serper - REMOVED: Uses curl subagent (.agents/seo/serper.md)
     'gsc': ['query', 'sitemaps', 'inspect'],
     'shadcn': ['browse', 'search', 'install'],
     'playwriter': ['navigate', 'click', 'type', 'screenshot'],
@@ -177,7 +187,6 @@ tool_categories = {
     'claude-code-mcp': ['run_claude_code'],
 }
 
-# More specific descriptions for known tools
 tool_descriptions = {
     'query-docs': 'Query documentation for a library using Context7',
     'resolve-library-id': 'Resolve a library name to Context7 ID',
@@ -190,65 +199,84 @@ tool_descriptions = {
     'run_claude_code': 'Run Claude Code as a one-shot subprocess',
 }
 
-for mcp_name, mcp_config in mcp_servers.items():
-    if not isinstance(mcp_config, dict):
+# Track seen MCP names to avoid duplicates across runtimes
+seen_mcps = set()
+
+for spec in config_specs:
+    if ':' not in spec:
+        continue
+    # Split on last colon to handle paths with colons (unlikely but safe)
+    parts = spec.rsplit(':', 1)
+    if len(parts) != 2:
+        continue
+    config_path, mcp_root_key = parts
+
+    try:
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+    except Exception as e:
+        print(f"Warning: Failed to read {config_path}: {e}", file=sys.stderr)
         continue
 
-    # Skip disabled MCPs
-    if not mcp_config.get('enabled', True):
-        continue
+    # Get MCP servers using the runtime-specific root key
+    mcp_servers = config.get(mcp_root_key, {})
+    global_tools = config.get('tools', {})
 
-    mcp_count += 1
+    for mcp_name, mcp_config in mcp_servers.items():
+        if not isinstance(mcp_config, dict):
+            continue
+        if not mcp_config.get('enabled', True):
+            continue
+        if mcp_name in seen_mcps:
+            continue  # Already indexed from another runtime
+        seen_mcps.add(mcp_name)
 
-    # Check if this MCP's tools are globally enabled
-    tool_pattern = f"{mcp_name}_*"
-    globally_enabled = 1 if global_tools.get(tool_pattern, False) else 0
+        mcp_count += 1
 
-    # Classify category and resolve known tools for this MCP
-    category = 'general'
-    known_tools = []
+        tool_pattern = f"{mcp_name}_*"
+        globally_enabled = 1 if global_tools.get(tool_pattern, False) else 0
 
-    for pattern, tools in tool_categories.items():
-        if pattern in mcp_name.lower():
-            known_tools = tools
-            # Derive category from MCP name
-            if 'seo' in mcp_name.lower() or pattern in ['dataforseo', 'gsc']:
-                category = 'seo'
-            elif pattern in ['context7', 'augment-context-engine']:
-                category = 'context'
-            elif pattern in ['shadcn', 'playwriter']:
-                category = 'browser'
-            elif pattern == 'macos-automator':
-                category = 'automation'
-            elif pattern == 'outscraper':
-                category = 'data-extraction'
-            elif pattern == 'quickfile':
-                category = 'accounting'
-            elif pattern == 'localwp':
-                category = 'wordpress'
-            elif pattern == 'claude-code-mcp':
-                category = 'ai-assistant'
-            break
+        category = 'general'
+        known_tools = []
 
-    # If no known tools, create a generic placeholder entry
-    if not known_tools:
-        known_tools = ['*']
+        for pattern, tools in tool_categories.items():
+            if pattern in mcp_name.lower():
+                known_tools = tools
+                if 'seo' in mcp_name.lower() or pattern in ['dataforseo', 'gsc']:
+                    category = 'seo'
+                elif pattern in ['context7', 'augment-context-engine']:
+                    category = 'context'
+                elif pattern in ['shadcn', 'playwriter']:
+                    category = 'browser'
+                elif pattern == 'macos-automator':
+                    category = 'automation'
+                elif pattern == 'outscraper':
+                    category = 'data-extraction'
+                elif pattern == 'quickfile':
+                    category = 'accounting'
+                elif pattern == 'localwp':
+                    category = 'wordpress'
+                elif pattern == 'claude-code-mcp':
+                    category = 'ai-assistant'
+                break
 
-    for tool in known_tools:
-        tool_name = f"{mcp_name}_{tool}" if tool != '*' else f"{mcp_name}_*"
-        description = tool_descriptions.get(tool, f"Tool from {mcp_name} MCP server")
+        if not known_tools:
+            known_tools = ['*']
 
-        cursor.execute('''
-            INSERT OR REPLACE INTO mcp_tools
-            (mcp_name, tool_name, description, category, enabled_globally, indexed_at)
-            VALUES (?, ?, ?, ?, ?, datetime('now'))
-        ''', (mcp_name, tool_name, description, category, globally_enabled))
-        tool_count += 1
+        for tool in known_tools:
+            tool_name = f"{mcp_name}_{tool}" if tool != '*' else f"{mcp_name}_*"
+            description = tool_descriptions.get(tool, f"Tool from {mcp_name} MCP server")
+
+            cursor.execute('''
+                INSERT OR REPLACE INTO mcp_tools
+                (mcp_name, tool_name, description, category, enabled_globally, indexed_at)
+                VALUES (?, ?, ?, ?, ?, datetime('now'))
+            ''', (mcp_name, tool_name, description, category, globally_enabled))
+            tool_count += 1
 
 conn.commit()
 conn.close()
 
-# Print counts for the caller to capture and store in metadata
 print(f"{tool_count} {mcp_count}")
 PYEOF
 	return 0

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -129,14 +129,14 @@ check_jq() {
 }
 
 #######################################
-# Detect available AI CLI backend (t1160.3, t1160)
-# Sets AIDEVOPS_DISPATCH_BACKEND to "opencode" or "claude"
+# Detect available AI CLI backend (t1160.3, t1160, t1665.5)
+# Sets AIDEVOPS_DISPATCH_BACKEND to a binary name (e.g., "opencode", "claude")
 #
 # Priority (aligned with supervisor/dispatch.sh resolve_ai_cli):
 #   1. AIDEVOPS_DISPATCH_BACKEND env var (explicit override)
 #   2. SUPERVISOR_CLI env var (supervisor-level override)
-#   3. opencode (primary — handles all providers including Anthropic OAuth)
-#   4. claude (first-class fallback — Anthropic-only, OAuth subscription billing)
+#   3. First headless-capable runtime found via registry (preference order:
+#      opencode first, then others by registry order)
 #
 # Returns 1 if no backend is available
 #######################################
@@ -148,8 +148,9 @@ detect_dispatch_backend() {
 
 	# Honour SUPERVISOR_CLI if set (supervisor-level override)
 	if [[ -n "${SUPERVISOR_CLI:-}" ]]; then
-		if [[ "$SUPERVISOR_CLI" != "opencode" && "$SUPERVISOR_CLI" != "claude" ]]; then
-			log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' is not a supported CLI (opencode|claude)"
+		# Validate it's a known runtime binary
+		if ! rt_id_from_binary "$SUPERVISOR_CLI" >/dev/null 2>&1; then
+			log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' is not a registered runtime binary"
 			return 1
 		fi
 		if command -v "$SUPERVISOR_CLI" &>/dev/null; then
@@ -161,17 +162,40 @@ detect_dispatch_backend() {
 		return 1
 	fi
 
-	if command -v opencode &>/dev/null; then
-		AIDEVOPS_DISPATCH_BACKEND="opencode"
-	elif command -v claude &>/dev/null; then
-		AIDEVOPS_DISPATCH_BACKEND="claude"
-	else
-		log_error "No AI CLI backend available. Install opencode (https://opencode.ai) or Claude Code CLI (https://docs.anthropic.com/en/docs/claude-cli)"
-		return 1
+	# Use registry to find first available headless-capable runtime.
+	# Preference: opencode first (handles all providers), then others.
+	local rt_id bin
+	# Check opencode first (primary preference)
+	bin=$(rt_binary "opencode") || bin=""
+	if [[ -n "$bin" ]] && command -v "$bin" &>/dev/null; then
+		AIDEVOPS_DISPATCH_BACKEND="$bin"
+		log_info "Using dispatch backend: $AIDEVOPS_DISPATCH_BACKEND"
+		return 0
 	fi
+	# Check claude-code second (first-class fallback)
+	bin=$(rt_binary "claude-code") || bin=""
+	if [[ -n "$bin" ]] && command -v "$bin" &>/dev/null; then
+		AIDEVOPS_DISPATCH_BACKEND="$bin"
+		log_info "Using dispatch backend: $AIDEVOPS_DISPATCH_BACKEND"
+		return 0
+	fi
+	# Fall through to any other headless-capable runtime
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		[[ "$rt_id" == "opencode" || "$rt_id" == "claude-code" ]] && continue # already checked
+		local headless
+		headless=$(rt_headless_support "$rt_id") || headless=""
+		[[ "$headless" != "yes" ]] && continue
+		bin=$(rt_binary "$rt_id") || continue
+		if [[ -n "$bin" ]] && command -v "$bin" &>/dev/null; then
+			AIDEVOPS_DISPATCH_BACKEND="$bin"
+			log_info "Using dispatch backend: $AIDEVOPS_DISPATCH_BACKEND"
+			return 0
+		fi
+	done < <(rt_list_ids)
 
-	log_info "Using dispatch backend: $AIDEVOPS_DISPATCH_BACKEND"
-	return 0
+	log_error "No AI CLI backend available. Install a supported runtime: https://aidevops.sh/runtimes"
+	return 1
 }
 
 #######################################

--- a/.agents/scripts/secret-hygiene-helper.sh
+++ b/.agents/scripts/secret-hygiene-helper.sh
@@ -458,8 +458,12 @@ scan_mcp_configs() {
 
 	local found_risk=0
 
-	for config in "$HOME/.config/Claude/claude_desktop_config.json" "$HOME/.cursor/mcp.json"; do
-		[[ -f "$config" ]] || continue
+	# Scan all runtime config files via registry (t1665.5)
+	local rt_id config
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		config=$(rt_config_path "$rt_id") || continue
+		[[ -z "$config" || ! -f "$config" ]] && continue
 
 		local uvx_count=0 npx_count=0
 		uvx_count=$(grep -c '"uvx"' "$config" 2>/dev/null) || uvx_count=0
@@ -478,7 +482,7 @@ scan_mcp_configs() {
 				"Pin versions or use locally installed packages"
 			found_risk=1
 		fi
-	done
+	done < <(rt_detect_configured)
 
 	if [[ "$found_risk" -eq 0 ]]; then
 		echo -e "  ${GREEN}[OK]${NC} No auto-downloading MCP server configurations found"

--- a/.agents/scripts/session-count-helper.sh
+++ b/.agents/scripts/session-count-helper.sh
@@ -38,14 +38,9 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # Detects interactive AI coding sessions by examining running processes.
 # Distinguishes interactive (TUI) sessions from headless workers.
 #
-# Known AI coding assistants and their process signatures:
-#   opencode (interactive): .opencode (no "run" argument in cmdline)
-#   opencode (headless):    .opencode run ... (has "run" in cmdline)
-#   claude (interactive):   claude (no "-p" or "--print" in cmdline)
-#   claude (headless):      claude -p ... or claude --print ...
-#   cursor:                 Cursor process
-#   windsurf:               Windsurf process
-#   aider:                  aider (Python process)
+# Uses runtime-registry.sh (t1665.1) for runtime detection. Headless
+# exclusion patterns are maintained per-runtime in _rt_headless_pattern().
+# Adding a new runtime to the registry automatically makes it visible here.
 
 # Get system RAM in GB (used as default session threshold).
 # Each session uses ~100-400 MB, so RAM in GB is a reasonable max.
@@ -110,111 +105,163 @@ _get_pid_cmdline() {
 	return 0
 }
 
-# Count interactive OpenCode sessions.
-# Excludes headless workers (.opencode run ...), language servers, and node wrappers.
-# Outputs the count on stdout.
-_count_opencode_sessions() {
-	local count=0
-	local opencode_pids=""
-	opencode_pids=$(pgrep -f '\.opencode' || true)
+# =============================================================================
+# Runtime-aware session counting (t1665.5)
+# =============================================================================
+# Uses runtime-registry.sh to detect all installed runtimes and count their
+# interactive sessions. Headless exclusion patterns are per-runtime.
 
-	if [[ -n "$opencode_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
-
-			# Skip headless workers
-			if echo "$cmdline" | grep -qE '\.opencode run '; then
-				continue
-			fi
-			# Skip language servers spawned by opencode
-			if echo "$cmdline" | grep -qE '(typescript-language-server|eslintServer|vscode-)'; then
-				continue
-			fi
-			# Skip node wrapper processes (the actual .opencode binary is what matters)
-			if echo "$cmdline" | grep -qE '^node .*/bin/opencode'; then
-				continue
-			fi
-			count=$((count + 1))
-		done <<<"$opencode_pids"
-	fi
-
-	echo "$count"
+# Headless exclusion patterns per runtime ID.
+# Returns a grep -E pattern that matches headless/worker command lines.
+# Empty return means "no headless mode" — all PIDs are interactive.
+_rt_headless_pattern() {
+	local rt_id="$1"
+	case "$rt_id" in
+	opencode)
+		echo '\.opencode run '
+		;;
+	claude-code)
+		echo 'claude (-p|--print|run) '
+		;;
+	codex)
+		echo 'codex (--quiet|-q) '
+		;;
+	*)
+		# No known headless pattern — treat all PIDs as interactive
+		echo ""
+		;;
+	esac
 	return 0
 }
 
-# Count interactive Claude Code sessions.
-# Excludes headless modes (-p, --print, run).
-# Outputs the count on stdout.
-_count_claude_sessions() {
-	local count=0
-	local claude_pids=""
-	claude_pids=$(pgrep -x claude || true)
-
-	if [[ -n "$claude_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
-
-			# Skip headless modes
-			if echo "$cmdline" | grep -qE 'claude (-p|--print|run) '; then
-				continue
-			fi
-			count=$((count + 1))
-		done <<<"$claude_pids"
-	fi
-
-	echo "$count"
+# Noise exclusion patterns per runtime ID.
+# Returns a grep -E pattern that matches non-session processes (LSPs, wrappers).
+# Empty return means "no noise to filter".
+_rt_noise_pattern() {
+	local rt_id="$1"
+	case "$rt_id" in
+	opencode)
+		echo '(typescript-language-server|eslintServer|vscode-)|^node .*/bin/opencode'
+		;;
+	*)
+		echo ""
+		;;
+	esac
 	return 0
 }
 
-# Count interactive sessions for a simple app (Cursor, Windsurf, Aider).
-# These apps have no headless mode to filter — all matching PIDs are interactive.
-# Args: $1 = pgrep pattern
+# pgrep strategy per runtime ID.
+# Returns "exact" for pgrep -x (exact binary match) or "fuzzy" for pgrep -f.
+_rt_pgrep_strategy() {
+	local rt_id="$1"
+	case "$rt_id" in
+	opencode)
+		# opencode binary appears as .opencode in process list
+		echo "fuzzy"
+		;;
+	cursor)
+		echo "fuzzy"
+		;;
+	windsurf)
+		echo "fuzzy"
+		;;
+	*)
+		echo "exact"
+		;;
+	esac
+	return 0
+}
+
+# pgrep pattern per runtime ID (overrides binary name when needed).
+_rt_pgrep_pattern() {
+	local rt_id="$1"
+	local bin="$2"
+	case "$rt_id" in
+	opencode)
+		echo '\.opencode'
+		;;
+	cursor)
+		echo 'Cursor\.app'
+		;;
+	windsurf)
+		echo 'Windsurf'
+		;;
+	*)
+		echo "$bin"
+		;;
+	esac
+	return 0
+}
+
+# Count interactive sessions for a single runtime.
+# Args: $1 = runtime ID
 # Outputs the count on stdout.
-_count_simple_sessions() {
-	local pattern="$1"
-	local pids=""
-	pids=$(pgrep -f "$pattern" || true)
-	if [[ -n "$pids" ]]; then
-		echo "$pids" | wc -l | tr -d ' '
-	else
+_count_runtime_sessions() {
+	local rt_id="$1"
+	local bin
+	bin=$(rt_binary "$rt_id") || bin=""
+	[[ -z "$bin" ]] && {
 		echo "0"
+		return 0
+	}
+
+	local strategy pgrep_pat headless_pat noise_pat
+	strategy=$(_rt_pgrep_strategy "$rt_id")
+	pgrep_pat=$(_rt_pgrep_pattern "$rt_id" "$bin")
+	headless_pat=$(_rt_headless_pattern "$rt_id")
+	noise_pat=$(_rt_noise_pattern "$rt_id")
+
+	local pids=""
+	if [[ "$strategy" == "fuzzy" ]]; then
+		pids=$(pgrep -f "$pgrep_pat" || true)
+	else
+		pids=$(pgrep -x "$bin" || true)
 	fi
+
+	if [[ -z "$pids" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	# If no filtering needed, just count PIDs
+	if [[ -z "$headless_pat" && -z "$noise_pat" ]]; then
+		echo "$pids" | wc -l | tr -d ' '
+		return 0
+	fi
+
+	# Filter out headless and noise processes
+	local count=0
+	local pid
+	while IFS= read -r pid; do
+		[[ -z "$pid" ]] && continue
+		local cmdline
+		cmdline=$(_get_pid_cmdline "$pid")
+
+		if [[ -n "$headless_pat" ]] && echo "$cmdline" | grep -qE "$headless_pat"; then
+			continue
+		fi
+		if [[ -n "$noise_pat" ]] && echo "$cmdline" | grep -qE "$noise_pat"; then
+			continue
+		fi
+		count=$((count + 1))
+	done <<<"$pids"
+
+	echo "$count"
 	return 0
 }
 
-# Count interactive AI sessions.
+# Count interactive AI sessions across all installed runtimes.
 # Returns the count on stdout.
-# Uses pgrep + /proc/cmdline (Linux) or ps (macOS) to distinguish
-# interactive from headless sessions.
+# Uses runtime-registry.sh for detection (t1665.5).
 count_interactive_sessions() {
 	local count=0
-	local n
+	local rt_id n
 
-	n=$(_count_opencode_sessions)
-	count=$((count + n))
-
-	n=$(_count_claude_sessions)
-	count=$((count + n))
-
-	# --- Cursor sessions ---
-	# Note: pgrep -c is Linux-only; use pgrep | wc -l for cross-platform.
-	# Guard with -n check to avoid counting empty output as 1.
-	n=$(_count_simple_sessions 'Cursor\.app')
-	count=$((count + n))
-
-	# --- Windsurf sessions ---
-	n=$(_count_simple_sessions 'Windsurf')
-	count=$((count + n))
-
-	# --- Aider sessions ---
-	n=$(_count_simple_sessions 'aider')
-	count=$((count + n))
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		n=$(_count_runtime_sessions "$rt_id")
+		count=$((count + n))
+	done < <(rt_detect_installed)
 
 	echo "$count"
 	return 0
@@ -235,116 +282,65 @@ _print_session_detail() {
 	return 0
 }
 
-# List interactive OpenCode sessions with details.
-# Excludes headless workers, language servers, and node wrappers.
-# Increments the found counter via stdout (caller adds to its own count).
-# Args: none. Outputs detail lines; returns number of sessions found.
-_list_opencode_sessions() {
-	local found=0
-	local opencode_pids=""
-	opencode_pids=$(pgrep -f '\.opencode' || true)
-
-	if [[ -n "$opencode_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
-
-			# Skip headless, language servers, node wrappers
-			if echo "$cmdline" | grep -qE '\.opencode run '; then
-				continue
-			fi
-			if echo "$cmdline" | grep -qE '(typescript-language-server|eslintServer|vscode-)'; then
-				continue
-			fi
-			if echo "$cmdline" | grep -qE '^node .*/bin/opencode'; then
-				continue
-			fi
-
-			_print_session_detail "$pid" "OpenCode"
-			found=$((found + 1))
-		done <<<"$opencode_pids"
-	fi
-
-	return "$found"
-}
-
-# List interactive Claude Code sessions with details.
-# Excludes headless modes (-p, --print, run).
+# List interactive sessions for a single runtime with details.
+# Args: $1 = runtime ID
 # Returns number of sessions found via exit code.
-_list_claude_sessions() {
-	local found=0
-	local claude_pids=""
-	claude_pids=$(pgrep -x claude || true)
+_list_runtime_sessions() {
+	local rt_id="$1"
+	local bin display_name
+	bin=$(rt_binary "$rt_id") || bin=""
+	[[ -z "$bin" ]] && return 0
+	display_name=$(rt_display_name "$rt_id") || display_name="$rt_id"
 
-	if [[ -n "$claude_pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			local cmdline
-			cmdline=$(_get_pid_cmdline "$pid")
+	local strategy pgrep_pat headless_pat noise_pat
+	strategy=$(_rt_pgrep_strategy "$rt_id")
+	pgrep_pat=$(_rt_pgrep_pattern "$rt_id" "$bin")
+	headless_pat=$(_rt_headless_pattern "$rt_id")
+	noise_pat=$(_rt_noise_pattern "$rt_id")
 
-			if echo "$cmdline" | grep -qE 'claude (-p|--print|run) '; then
-				continue
-			fi
-
-			_print_session_detail "$pid" "Claude Code"
-			found=$((found + 1))
-		done <<<"$claude_pids"
-	fi
-
-	return "$found"
-}
-
-# List interactive sessions for a simple app (Cursor, Windsurf, Aider).
-# All matching PIDs are treated as interactive (no headless mode to filter).
-# Args: $1 = pgrep pattern, $2 = display name
-# Returns number of sessions found via exit code.
-_list_simple_app_sessions() {
-	local pattern="$1"
-	local display_name="$2"
-	local found=0
 	local pids=""
-	pids=$(pgrep -f "$pattern" || true)
-
-	if [[ -n "$pids" ]]; then
-		local pid
-		while IFS= read -r pid; do
-			[[ -z "$pid" ]] && continue
-			_print_session_detail "$pid" "$display_name"
-			found=$((found + 1))
-		done <<<"$pids"
+	if [[ "$strategy" == "fuzzy" ]]; then
+		pids=$(pgrep -f "$pgrep_pat" || true)
+	else
+		pids=$(pgrep -x "$bin" || true)
 	fi
+
+	[[ -z "$pids" ]] && return 0
+
+	local found=0
+	local pid
+	while IFS= read -r pid; do
+		[[ -z "$pid" ]] && continue
+		local cmdline
+		cmdline=$(_get_pid_cmdline "$pid")
+
+		if [[ -n "$headless_pat" ]] && echo "$cmdline" | grep -qE "$headless_pat"; then
+			continue
+		fi
+		if [[ -n "$noise_pat" ]] && echo "$cmdline" | grep -qE "$noise_pat"; then
+			continue
+		fi
+
+		_print_session_detail "$pid" "$display_name"
+		found=$((found + 1))
+	done <<<"$pids"
 
 	return "$found"
 }
 
-# List detected interactive sessions with details.
+# List detected interactive sessions with details (t1665.5).
 # Output format: PID | APP | RSS_MB | UPTIME
+# Uses runtime-registry.sh for detection.
 list_sessions() {
 	local found=0
 	local n=0
+	local rt_id
 
-	# --- OpenCode sessions ---
-	_list_opencode_sessions || n=$?
-	found=$((found + n))
-
-	# --- Claude Code sessions ---
-	_list_claude_sessions || n=$?
-	found=$((found + n))
-
-	# --- Cursor sessions ---
-	_list_simple_app_sessions 'Cursor\.app' "Cursor" || n=$?
-	found=$((found + n))
-
-	# --- Windsurf sessions ---
-	_list_simple_app_sessions 'Windsurf' "Windsurf" || n=$?
-	found=$((found + n))
-
-	# --- Aider sessions ---
-	_list_simple_app_sessions 'aider' "Aider" || n=$?
-	found=$((found + n))
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		_list_runtime_sessions "$rt_id" || n=$?
+		found=$((found + n))
+	done < <(rt_detect_installed)
 
 	if [[ "$found" -eq 0 ]]; then
 		echo "  No interactive AI sessions detected"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1377,20 +1377,26 @@ resolve_model_tier() {
 }
 
 #######################################
-# Detect available AI CLI backends (t132.7)
-# Returns a newline-separated list of available backends.
-# Checks: opencode, claude
+# Detect available AI CLI backends (t132.7, t1665.5)
+# Returns a newline-separated list of available backend binary names.
+# Delegates to runtime-registry.sh rt_detect_installed() for detection,
+# then maps runtime IDs back to binary names for backward compatibility.
 #######################################
 detect_ai_backends() {
 	local -a backends=()
+	local rt_id bin
 
-	if command -v opencode &>/dev/null; then
-		backends+=("opencode")
-	fi
-
-	if command -v claude &>/dev/null; then
-		backends+=("claude")
-	fi
+	# runtime-registry.sh is sourced above in this file
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		bin=$(rt_binary "$rt_id") || continue
+		[[ -z "$bin" ]] && continue
+		# Only include runtimes with headless support (dispatchable backends)
+		local headless
+		headless=$(rt_headless_support "$rt_id") || headless=""
+		[[ "$headless" != "yes" ]] && continue
+		backends+=("$bin")
+	done < <(rt_detect_installed)
 
 	if [[ ${#backends[@]} -eq 0 ]]; then
 		echo "none"

--- a/.agents/scripts/worker-sandbox-helper.sh
+++ b/.agents/scripts/worker-sandbox-helper.sh
@@ -142,33 +142,35 @@ create_worker_sandbox() {
 		ln -sf "$agents_source" "$sandbox_dir/.aidevops"
 	fi
 
-	# --- Claude Code / OpenCode config ---
-	# Workers need their tool configs. Copy only the specific config files needed,
-	# not the entire .config directory (which may contain credentials).
+	# --- Runtime config files (t1665.5) ---
+	# Workers need MCP/tool configs. Copy only the specific config files needed
+	# for each installed runtime, not entire directories (which may contain credentials).
+	# Uses runtime-registry.sh for detection and path lookup.
 	local config_dir="$sandbox_dir/.config"
 	mkdir -p "$config_dir"
 
-	# OpenCode config (if exists) — needed for MCP server definitions
-	local opencode_src="${REAL_HOME}/.config/opencode"
-	if [[ -d "$opencode_src" ]]; then
-		mkdir -p "$config_dir/opencode"
-		# Copy only opencode.json (MCP config), not auth files
-		if [[ -f "$opencode_src/opencode.json" ]]; then
-			cp "$opencode_src/opencode.json" "$config_dir/opencode/"
-		fi
-	fi
+	local rt_id rt_config_file rt_config_dir dst_dir
+	while IFS= read -r rt_id; do
+		[[ -z "$rt_id" ]] && continue
+		rt_config_file=$(rt_config_path "$rt_id") || continue
+		# Resolve against REAL_HOME (sandbox uses the real user's configs)
+		rt_config_file="${rt_config_file/$HOME/$REAL_HOME}"
+		[[ -z "$rt_config_file" || ! -f "$rt_config_file" ]] && continue
 
-	# Claude Code settings (if exists) — needed for MCP server definitions
-	local claude_dir_src="${REAL_HOME}/.claude"
-	if [[ -d "$claude_dir_src" ]]; then
-		local claude_dir_dst="$sandbox_dir/.claude"
-		mkdir -p "$claude_dir_dst"
-		# Copy settings.json (MCP config, preferences) but NOT credentials
-		if [[ -f "$claude_dir_src/settings.json" ]]; then
-			cp "$claude_dir_src/settings.json" "$claude_dir_dst/"
-		fi
-		# Do NOT copy: credentials.json, .credentials, auth tokens
-	fi
+		rt_config_dir=$(dirname "$rt_config_file")
+
+		# Determine sandbox destination based on config path structure
+		# Config paths under ~/.config/ go to $sandbox_dir/.config/
+		# Config paths under ~/.claude/ go to $sandbox_dir/.claude/
+		# Config paths under ~/.<name>/ go to $sandbox_dir/.<name>/
+		local rel_to_home="${rt_config_file#"$REAL_HOME"/}"
+		dst_dir="$sandbox_dir/$(dirname "$rel_to_home")"
+		mkdir -p "$dst_dir"
+
+		# Copy only the config file (MCP definitions), NOT credentials
+		cp "$rt_config_file" "$dst_dir/"
+	done < <(rt_detect_configured)
+	# Do NOT copy: credentials.json, .credentials, auth tokens, OAuth files
 
 	# --- XDG directories for tool state ---
 	# Tools like npm, bun, etc. need writable cache/data dirs


### PR DESCRIPTION
## Summary

Migrates the 6 highest-impact accidentally-coupled scripts to use `runtime-registry.sh` (t1665.1) instead of hardcoded runtime references. After this PR, adding a new runtime to the registry automatically makes it visible to session counting, backend detection, MCP indexing, secret scanning, and sandbox provisioning.

Closes #6536

## Scripts Migrated

| Script | What Changed |
|--------|-------------|
| `shared-constants.sh` | `detect_ai_backends()` delegates to `rt_detect_installed()` + `rt_binary()` instead of hardcoded `command -v opencode/claude` |
| `session-count-helper.sh` | Unified `_count_runtime_sessions()` replaces per-runtime `_count_opencode_sessions()` / `_count_claude_sessions()` / `_count_simple_sessions()`. Headless exclusion patterns maintained via `_rt_headless_pattern()` lookup table |
| `runner-helper.sh` | `detect_dispatch_backend()` uses registry for runtime discovery with preference ordering (opencode > claude > any headless-capable) |
| `mcp-index-helper.sh` | Reads MCP config from all configured runtimes via `rt_detect_configured()` + `rt_config_path()` + `rt_mcp_root_key()` instead of only `opencode.json` |
| `secret-hygiene-helper.sh` | `scan_mcp_configs()` scans all runtime config files via registry instead of hardcoded Claude Desktop / Cursor paths |
| `worker-sandbox-helper.sh` | Copies config files for all installed runtimes into sandbox instead of only opencode + claude |

## Design Decisions

- **Headless exclusion patterns stay as a case statement** (`_rt_headless_pattern()`): These patterns are inherently runtime-specific (opencode filters `.opencode run`, claude filters `-p`/`--print`/`run`). Putting them in the registry would add complexity without benefit — they change rarely and are only used by session counting.
- **pgrep strategy per runtime**: Some runtimes need `pgrep -f` (fuzzy, for opencode/cursor/windsurf), others need `pgrep -x` (exact binary match). This is encoded in `_rt_pgrep_strategy()`.
- **MCP index deduplication**: When the same MCP server is configured in multiple runtimes, only the first occurrence is indexed (via `seen_mcps` set in Python).
- **Backward compatibility**: `detect_ai_backends()` still returns binary names (not runtime IDs) so callers don't need changes.

## Remaining Work

~15 files still have hardcoded `command -v opencode|claude` references. These are lower-priority (Category 4-6 from the issue brief: dispatch orchestration, feature flags, documentation). They should be migrated in follow-up PRs to stay within blast radius limits.

## Runtime Testing
- **Testing level:** self-assessed
- **Risk classification:** medium (refactoring internal detection logic, no user-facing behavior change)
- **Verification:** All 6 files pass shellcheck. Registry functions (`rt_detect_installed`, `rt_config_path`, etc.) are tested by `tests/test-runtime-registry.sh`. The migration preserves existing behavior — same runtimes detected, same session counts, same config paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multi-runtime support: System now dynamically discovers and manages MCP tools and configurations across all installed AI runtimes instead of hardcoded defaults.
  * Improved backend detection using a registry-driven approach for greater flexibility.

* **Bug Fixes**
  * Graceful error handling during configuration loading; system continues processing if individual runtime configs fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->