### PR TITLE
fix: add TZ=UTC to macOS date conversion in backoff_active_for_key

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -455,7 +455,7 @@ backoff_active_for_key() {
 	if [[ -n "$stored_retry_after" ]]; then
 		local now_epoch retry_epoch
 		now_epoch=$(date -u '+%s')
-		retry_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$stored_retry_after" '+%s' 2>/dev/null || date -u -d "$stored_retry_after" '+%s' 2>/dev/null || printf '%s' "0")
+		retry_epoch=$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$stored_retry_after" '+%s' 2>/dev/null || date -u -d "$stored_retry_after" '+%s' 2>/dev/null || printf '%s' "0")
 		if [[ "$retry_epoch" -le "$now_epoch" ]]; then
 			clear_provider_backoff "$key"
 			return 1

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -297,6 +297,39 @@ fi
 # Clean up
 bash "$HELPER" backoff clear anthropic >/dev/null 2>&1 || true
 
+section "Backoff Expiry UTC Timezone (GH#6549)"
+# Regression test: backoff_active_for_key() must treat stored retry_after as UTC.
+# On macOS, date -j -f without TZ=UTC interprets the timestamp as local time,
+# causing an expired backoff to appear still active when the local timezone is
+# behind UTC (e.g. UTC-5 adds 18000 seconds to the epoch).
+#
+# Strategy: write a retry_after timestamp 1 second in the past (UTC), then
+# verify that backoff is NOT active (i.e. the expiry check correctly sees it
+# as expired). If the timezone bug is present, the epoch will be inflated by
+# the local UTC offset and the backoff will appear active.
+bash "$HELPER" backoff clear anthropic >/dev/null 2>&1 || true
+PAST_UTC=$(date -u -v-1S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '1 second ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)
+if [[ -n "$PAST_UTC" ]]; then
+	# Directly insert a row with an already-expired retry_after into the DB
+	RUNTIME_DB="$TEST_TMP_DIR/runtime/runtime.db"
+	mkdir -p "$(dirname "$RUNTIME_DB")"
+	sqlite3 "$RUNTIME_DB" "CREATE TABLE IF NOT EXISTS provider_backoff (provider TEXT PRIMARY KEY, reason TEXT DEFAULT '', retry_after TEXT DEFAULT '', auth_signature TEXT DEFAULT '', details TEXT DEFAULT '', updated_at TEXT DEFAULT '');" 2>/dev/null || true
+	sqlite3 "$RUNTIME_DB" "INSERT OR REPLACE INTO provider_backoff (provider, reason, retry_after, auth_signature, details, updated_at) VALUES ('anthropic', 'rate_limit', '$(printf '%s' "$PAST_UTC")', '', '', '$(date -u '+%Y-%m-%dT%H:%M:%SZ')');" 2>/dev/null || true
+	# Now select a model — if backoff is correctly expired, anthropic should be available
+	expired_backoff_model=$(
+		AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6" \
+			bash "$HELPER" select --role worker 2>/dev/null || true
+	)
+	if [[ "$expired_backoff_model" == "anthropic/claude-sonnet-4-6" ]]; then
+		pass "expired UTC backoff is correctly treated as inactive (GH#6549)"
+	else
+		fail "expired UTC backoff is correctly treated as inactive (GH#6549)" "got: '$expired_backoff_model' — timezone offset bug may still be present"
+	fi
+	bash "$HELPER" backoff clear anthropic >/dev/null 2>&1 || true
+else
+	pass "expired UTC backoff test skipped (date command unavailable)"
+fi
+
 section "OpenCode Gateway Models"
 # opencode/* models should be selectable when configured and auth file exists
 # Create a fake auth file so provider_auth_available("opencode") returns true


### PR DESCRIPTION
## Summary

- Fixes a timezone offset bug in `backoff_active_for_key()` where `date -j -f '%Y-%m-%dT%H:%M:%SZ'` on macOS interprets the UTC ISO 8601 timestamp as local time, inflating the epoch by the local UTC offset (e.g. UTC-5 adds 18000 seconds)
- An expired backoff appeared still active, causing all workers to exit with EX_TEMPFAIL (75) and the pulse to silently fail to dispatch
- Fix: prefix the macOS `date -j` call with `TZ=UTC` so the timestamp is correctly parsed as UTC; the Linux `date -u -d` fallback was already correct and is unchanged
- Adds a regression test that writes an already-expired UTC `retry_after` directly into the DB and verifies the model is selectable again (25/25 tests pass)

## Root cause

`date -j -f '%Y-%m-%dT%H:%M:%SZ'` on macOS does not honour the trailing `Z` as a UTC indicator — the format string strips the literal `Z` but does not apply a UTC offset. The fix uses `TZ=UTC date -j -f ...` to force UTC interpretation.

## Testing

- All 25 existing tests pass
- New regression test `Backoff Expiry UTC Timezone (GH#6549)` passes
- Manually verified: without fix, a UTC-5 system inflates epoch by 18000s (backoff appears active); with fix, epoch is correct (backoff correctly expired)

## Files changed

- `.agents/scripts/headless-runtime-helper.sh` — one-character fix: add `TZ=UTC ` prefix to macOS date call (line 458)
- `tests/test-headless-runtime-helper.sh` — regression test for the UTC timezone expiry check

Closes #6549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UTC timezone handling in retry backoff logic to ensure consistent and accurate retry timing calculations.

* **Tests**
  * Added regression test for backoff expiry UTC timezone handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->