### PR TITLE
GH#6676: Fix $agent_dir not exported to xargs subshells

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -828,6 +828,7 @@ _generate_subagents_opencode() {
 
 	export -f generate_subagent_stub 2>/dev/null || true
 	export AGENTS_DIR
+	export agent_dir
 
 	local _ncpu
 	_ncpu=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)


### PR DESCRIPTION
## Summary

- Fix `_generate_subagents_opencode()` in `generate-runtime-config.sh` where `$agent_dir` was not exported to xargs subshells, causing all ~2,837 subagent stub writes to fail with `Permission denied`

## Root Cause

`agent_dir` is declared as `local` on line 739 and used inside `generate_subagent_stub()` on line 825. The function is exported via `export -f` for parallel execution by `xargs`, but `agent_dir` itself was never exported. In xargs subshells, `$agent_dir` resolves to empty string, making the redirect target `>/$name.md` (root filesystem) instead of `>$agent_dir/$name.md`.

## Fix

Add `export agent_dir` on line 831 alongside the existing `export AGENTS_DIR`. `local` and `export` coexist in bash — the value propagates correctly to xargs subshells.

## Testing Evidence

- **Testing level:** `self-assessed`
- **Risk classification:** medium (shell variable scoping fix, no logic change)
- **Verification:** Standalone reproduction script confirms `local` + `export` propagates to xargs subshells correctly
- **ShellCheck:** Zero violations (only pre-existing SC1091 info-level for external sources)
- **Diff:** 1 file, 1 line added

## Impact

- Restores generation of ~2,837 subagent markdown stubs in `~/.config/opencode/agent/`
- Fixes all `@subagent` routing in OpenCode (domain-specific agents like `@wordpress`, `@dataforseo`, etc.)
- Affects Linux/bash 5.x users and macOS users with homebrew bash 5.x

Closes #6676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal environment configuration handling for agent script generation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->