### PR TITLE
fix: exclude OPENCODE_PID from worker sandbox passthrough (GH#6668)

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -88,6 +88,15 @@ build_sandbox_passthrough_csv() {
 	while IFS='=' read -r name _; do
 		case "$name" in
 		AIDEVOPS_* | PULSE_* | GH_* | GITHUB_* | OPENAI_* | ANTHROPIC_* | GOOGLE_* | OPENCODE_* | CLAUDE_* | XDG_* | REAL_HOME | TMPDIR | TMP | TEMP | RTK_* | VERIFY_*)
+			# Exclude session-attachment vars that are only meaningful for the
+			# dispatching process (pulse/supervisor). Workers inheriting these
+			# attach to the parent's session instead of creating independent ones.
+			# GH#6668: OPENCODE_PID caused all workers to share the pulse session.
+			case "$name" in
+			OPENCODE_PID | OPENCODE_SESSION_ID)
+				continue
+				;;
+			esac
 			if [[ "$seen_names" == *" ${name} "* ]]; then
 				continue
 			fi
@@ -1219,4 +1228,7 @@ main() {
 	esac
 }
 
-main "$@"
+# Allow sourcing for unit tests without executing main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -418,6 +418,50 @@ else
 fi
 rm -f "$LOCK_DIR/issue-other.pid"
 
+# ── GH#6668: OPENCODE_PID must not be passed through to workers ──────────────
+# Workers inheriting OPENCODE_PID attach to the pulse's session instead of
+# creating independent sessions, causing all workers to share one session and
+# exit immediately with 0 commits / 0 PRs.
+section "Sandbox passthrough exclusions (GH#6668)"
+
+# Source the helper in a subshell so we can call build_sandbox_passthrough_csv
+# directly without polluting the test environment.
+passthrough_csv=$(
+	export OPENCODE_PID="12345"
+	export OPENCODE_SESSION_ID="ses_pulse_session"
+	export OPENCODE_BIN="$TEST_TMP_DIR/opencode-stub.sh"
+	export ANTHROPIC_API_KEY="test-key"
+	# shellcheck source=/dev/null
+	. "$HELPER" 2>/dev/null || true
+	build_sandbox_passthrough_csv 2>/dev/null || true
+)
+
+if echo "$passthrough_csv" | grep -qw "OPENCODE_PID"; then
+	fail "OPENCODE_PID excluded from worker passthrough" "found in: $passthrough_csv"
+else
+	pass "OPENCODE_PID excluded from worker passthrough"
+fi
+
+if echo "$passthrough_csv" | grep -qw "OPENCODE_SESSION_ID"; then
+	fail "OPENCODE_SESSION_ID excluded from worker passthrough" "found in: $passthrough_csv"
+else
+	pass "OPENCODE_SESSION_ID excluded from worker passthrough"
+fi
+
+# Other OPENCODE_* vars (e.g. OPENCODE_BIN) should still pass through
+if echo "$passthrough_csv" | grep -qw "OPENCODE_BIN"; then
+	pass "other OPENCODE_* vars still pass through"
+else
+	fail "other OPENCODE_* vars still pass through" "OPENCODE_BIN missing from: $passthrough_csv"
+fi
+
+# ANTHROPIC_API_KEY should still pass through
+if echo "$passthrough_csv" | grep -qw "ANTHROPIC_API_KEY"; then
+	pass "ANTHROPIC_API_KEY still passes through"
+else
+	fail "ANTHROPIC_API_KEY still passes through" "missing from: $passthrough_csv"
+fi
+
 echo ""
 printf "Total: %d, Passed: %d, Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
 


### PR DESCRIPTION
## Summary

- `build_sandbox_passthrough_csv()` passed all `OPENCODE_*` env vars to workers, including `OPENCODE_PID` — the pulse's own process PID
- OpenCode uses `OPENCODE_PID` to attach to an existing session; workers inherited it and joined the pulse's session instead of creating independent ones
- All workers exited immediately with 0 commits / 0 PRs (confirmed: 5 workers in pulse cycle 2026-03-26T10:14 all received session `ses_2d67d2936ffe6oi0NUc6hIsJSo`)

## Fix

Add an explicit exclusion for `OPENCODE_PID` and `OPENCODE_SESSION_ID` inside the `OPENCODE_*` match arm of `build_sandbox_passthrough_csv()`. These vars are only meaningful for the dispatching process's own session management and must not propagate to workers.

Also adds a `BASH_SOURCE` guard so the helper can be sourced for unit testing, and 4 new tests covering the exclusion behaviour.

## Testing

```
=== Sandbox passthrough exclusions (GH#6668) ===
  PASS OPENCODE_PID excluded from worker passthrough
  PASS OPENCODE_SESSION_ID excluded from worker passthrough
  PASS other OPENCODE_* vars still pass through
  PASS ANTHROPIC_API_KEY still passes through

Total: 28, Passed: 28, Failed: 0
```

## Files Changed

- `.agents/scripts/headless-runtime-helper.sh` — exclusion in `build_sandbox_passthrough_csv()` + `BASH_SOURCE` guard
- `tests/test-headless-runtime-helper.sh` — 4 new tests for GH#6668

Closes #6668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed worker process session attachment to properly use parent session instead of inheriting dispatch-only values.

* **Tests**
  * Added test coverage for worker process sandbox configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->