### PR TITLE
fix: export agent_dir to xargs subshells in _generate_subagents_opencode

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -828,6 +828,7 @@ _generate_subagents_opencode() {
 
 	export -f generate_subagent_stub 2>/dev/null || true
 	export AGENTS_DIR
+	export agent_dir
 
 	local _ncpu
 	_ncpu=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)


### PR DESCRIPTION
## Summary

- `$agent_dir` was a `local` variable inside `_generate_subagents_opencode()` but was never exported to the environment before `xargs` spawned bash subshells via `export -f generate_subagent_stub`
- In the subshells, `$agent_dir` was empty, so the redirect `>"$agent_dir/$name.md"` became `>"/$name.md"` — a root filesystem write attempt
- This produced hundreds of `environment: /name.md: Permission denied` errors (bash 5.x labels `export -f` function errors with `environment:` prefix) and left `~/.config/opencode/agent/` empty
- Fix: add `export agent_dir` alongside `export AGENTS_DIR` on line 831. `local` and `export` coexist in bash 3.2+ — the value propagates correctly to xargs subshells

## Testing Evidence

- **Testing level**: `runtime-verified`
- **Standalone reproduction** (from issue body) confirmed the bug before fix and the fix after:
  ```bash
  # Before (bug): writes to /out.md → Permission denied
  # After (fix): writes to /tmp/test-6676/out.md → success
  ```
- ShellCheck: zero new violations (only pre-existing SC1091 info notices from source directives)
- Bash 3.2 compatible: `local` + `export` on the same variable is valid in bash 3.2+

## Files Changed

- `.agents/scripts/generate-runtime-config.sh` — add `export agent_dir` after `export AGENTS_DIR` (line 831)

## Runtime Testing

- Risk classification: **Low** (shell script fix, no runtime app involved)
- Verified with standalone bash reproduction matching the exact pattern from the issue
- No dev environment required — pure bash behaviour

Closes #6676