### PR TITLE
GH#6668: Fix workers inheriting pulse OPENCODE_PID causing session contamination

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -87,6 +87,10 @@ build_sandbox_passthrough_csv() {
 
 	while IFS='=' read -r name _; do
 		case "$name" in
+		# OPENCODE_PID is the pulse's own opencode process PID. Passing it to
+		# workers causes them to attach to the pulse's session instead of
+		# creating independent sessions (GH#6668). Exclude it explicitly.
+		OPENCODE_PID) ;;
 		AIDEVOPS_* | PULSE_* | GH_* | GITHUB_* | OPENAI_* | ANTHROPIC_* | GOOGLE_* | OPENCODE_* | CLAUDE_* | XDG_* | REAL_HOME | TMPDIR | TMP | TEMP | RTK_* | VERIFY_*)
 			if [[ "$seen_names" == *" ${name} "* ]]; then
 				continue
@@ -1206,6 +1210,12 @@ main() {
 	session)
 		cmd_session "$@"
 		return $?
+		;;
+	passthrough-csv)
+		# Print the sandbox passthrough CSV to stdout. Used by tests and
+		# diagnostics to verify which env vars are included/excluded.
+		build_sandbox_passthrough_csv
+		return 0
 		;;
 	help | --help | -h)
 		show_help

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -418,6 +418,23 @@ else
 fi
 rm -f "$LOCK_DIR/issue-other.pid"
 
+section "OPENCODE_PID Passthrough Exclusion (GH#6668)"
+# OPENCODE_PID must never appear in the sandbox passthrough CSV — workers that
+# inherit it attach to the pulse's session instead of creating independent ones.
+passthrough_csv=$(OPENCODE_PID="12345" bash "$HELPER" passthrough-csv 2>/dev/null || true)
+if [[ -z "$passthrough_csv" ]] || [[ "$passthrough_csv" != *"OPENCODE_PID"* ]]; then
+	pass "OPENCODE_PID excluded from sandbox passthrough CSV"
+else
+	fail "OPENCODE_PID excluded from sandbox passthrough CSV" "got: $passthrough_csv"
+fi
+# Other OPENCODE_* vars must still be passed through.
+passthrough_csv2=$(OPENCODE_THEME="dark" bash "$HELPER" passthrough-csv 2>/dev/null || true)
+if [[ "$passthrough_csv2" == *"OPENCODE_THEME"* ]]; then
+	pass "other OPENCODE_* vars still included in passthrough CSV"
+else
+	fail "other OPENCODE_* vars still included in passthrough CSV" "got: $passthrough_csv2"
+fi
+
 echo ""
 printf "Total: %d, Passed: %d, Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
 


### PR DESCRIPTION
## Summary

- Excludes `OPENCODE_PID` from the sandbox env passthrough in `build_sandbox_passthrough_csv()` so workers get independent OpenCode sessions instead of attaching to the pulse's session
- Adds a `passthrough-csv` subcommand to `headless-runtime-helper.sh` for testability
- Adds 2 tests: verifies `OPENCODE_PID` is excluded and other `OPENCODE_*` vars are still included

## Root Cause

`build_sandbox_passthrough_csv()` matched `OPENCODE_*` as a glob, which included `OPENCODE_PID`. OpenCode uses `OPENCODE_PID` to attach to an existing session. Workers inherited the pulse's PID, joined its session, and exited immediately with 0 commits and 0 PRs.

## Fix

Added an explicit `OPENCODE_PID)` no-op case before the `OPENCODE_*` wildcard in the `case` statement. In bash, the first matching case wins, so `OPENCODE_PID` is silently skipped while all other `OPENCODE_*` vars continue to pass through.

## Testing

```
=== OPENCODE_PID Passthrough Exclusion (GH#6668) ===
  PASS OPENCODE_PID excluded from sandbox passthrough CSV
  PASS other OPENCODE_* vars still included in passthrough CSV

Total: 26, Passed: 26, Failed: 0
```

Closes #6668