### PR TITLE
fix: add TZ=UTC to macOS date -j -f for UTC ISO8601 timestamp parsing

### DIFF
--- a/.agents/scripts/conversation-helper.sh
+++ b/.agents/scripts/conversation-helper.sh
@@ -1283,7 +1283,7 @@ EOF
 
 	# Calculate time since last activity (in seconds)
 	local last_epoch now_epoch elapsed_seconds
-	last_epoch=$(date -d "$last_activity" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_activity" +%s 2>/dev/null || echo "0")
+	last_epoch=$(date -d "$last_activity" +%s 2>/dev/null || TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_activity" +%s 2>/dev/null || echo "0")
 	now_epoch=$(date +%s)
 	elapsed_seconds=$((now_epoch - last_epoch))
 

--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -908,8 +908,8 @@ _check_approvals_safety_net() {
 		if [[ -n "$sa_created" && "$now_epoch" -gt 0 ]]; then
 			# Convert ISO8601 to epoch (macOS date -j -f)
 			local sa_created_epoch=0
-			if date -j -f "%Y-%m-%dT%H:%M:%SZ" "$sa_created" +%s &>/dev/null 2>&1; then
-				sa_created_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$sa_created" +%s 2>/dev/null) || sa_created_epoch=0
+			if TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$sa_created" +%s &>/dev/null 2>&1; then
+				sa_created_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$sa_created" +%s 2>/dev/null) || sa_created_epoch=0
 			elif date -d "$sa_created" +%s &>/dev/null 2>&1; then
 				# GNU date fallback (Linux)
 				sa_created_epoch=$(date -d "$sa_created" +%s 2>/dev/null) || sa_created_epoch=0

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -455,7 +455,7 @@ backoff_active_for_key() {
 	if [[ -n "$stored_retry_after" ]]; then
 		local now_epoch retry_epoch
 		now_epoch=$(date -u '+%s')
-		retry_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$stored_retry_after" '+%s' 2>/dev/null || date -u -d "$stored_retry_after" '+%s' 2>/dev/null || printf '%s' "0")
+		retry_epoch=$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$stored_retry_after" '+%s' 2>/dev/null || date -u -d "$stored_retry_after" '+%s' 2>/dev/null || printf '%s' "0")
 		if [[ "$retry_epoch" -le "$now_epoch" ]]; then
 			clear_provider_backoff "$key"
 			return 1

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -395,7 +395,7 @@ is_cache_valid() {
 
 	local checked_epoch now_epoch
 	if [[ "$(uname)" == "Darwin" ]]; then
-		checked_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked_at" "+%s" 2>/dev/null || echo "0")
+		checked_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked_at" "+%s" 2>/dev/null || echo "0")
 	else
 		checked_epoch=$(date -d "$checked_at" "+%s" 2>/dev/null || echo "0")
 	fi
@@ -1259,7 +1259,7 @@ _status_print_providers() {
 		local age_display="$checked"
 		local checked_epoch now_epoch
 		if [[ "$(uname)" == "Darwin" ]]; then
-			checked_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked" "+%s" 2>/dev/null || echo "0")
+			checked_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked" "+%s" 2>/dev/null || echo "0")
 		else
 			checked_epoch=$(date -d "$checked" "+%s" 2>/dev/null || echo "0")
 		fi

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -704,7 +704,7 @@ cmd_sync() {
 		if [[ -n "$last_sync" ]]; then
 			local last_epoch now_epoch
 			if [[ "$(uname)" == "Darwin" ]]; then
-				last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
+				last_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
 			else
 				last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
 			fi
@@ -870,7 +870,7 @@ cmd_status() {
 	if [[ -n "$last_sync" && "$last_sync" != "never" ]]; then
 		local last_epoch now_epoch
 		if [[ "$(uname)" == "Darwin" ]]; then
-			last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
+			last_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
 		else
 			last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
 		fi

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -107,7 +107,7 @@ get_pr_age_seconds() {
 
 	local created_epoch now_epoch
 	# macOS date vs GNU date
-	created_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$created_at" +%s 2>/dev/null ||
+	created_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$created_at" +%s 2>/dev/null ||
 		date -d "$created_at" +%s 2>/dev/null ||
 		echo "0")
 	now_epoch=$(date +%s)

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -2555,7 +2555,7 @@ _check_pr_bot_coverage() {
 			pr_created=$(echo "$pr_obj" | jq -r '.createdAt // empty')
 			if [[ -n "$pr_created" ]]; then
 				local pr_epoch
-				pr_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$pr_created" +%s 2>/dev/null || date -d "$pr_created" +%s 2>/dev/null || echo "0")
+				pr_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$pr_created" +%s 2>/dev/null || date -d "$pr_created" +%s 2>/dev/null || echo "0")
 				[[ "$pr_epoch" =~ ^[0-9]+$ ]] || pr_epoch=0
 				if [[ "$pr_epoch" -gt 0 ]]; then
 					local now_epoch


### PR DESCRIPTION
## Summary

- Fixes `backoff_active_for_key()` in `headless-runtime-helper.sh` where `date -j -f '%Y-%m-%dT%H:%M:%SZ'` on macOS interprets the input as local time instead of UTC, causing expired backoffs to appear still active for the duration of the local timezone offset (e.g. ~6 hours in UTC-6)
- Extends the same fix to 6 other active scripts with the identical pattern: `model-availability-helper.sh`, `model-registry-helper.sh`, `review-bot-gate-helper.sh`, `draft-response-helper.sh`, `stats-functions.sh`, `conversation-helper.sh`
- The Linux path (`date -u -d`) was already correct — only the macOS `date -j -f` path was broken

## Root Cause

`date -j -f '%Y-%m-%dT%H:%M:%SZ'` on macOS does not honour the trailing `Z` (UTC indicator). The format string strips the `Z` as a literal character but does not apply a UTC offset. The result is an epoch value offset by the local timezone.

## Fix

Prefix all macOS `date -j -f` calls that parse UTC ISO8601 timestamps with `TZ=UTC`:

```bash
# Before (broken on non-UTC machines)
retry_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$stored_retry_after" '+%s' 2>/dev/null || ...)

# After (correct)
retry_epoch=$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$stored_retry_after" '+%s' 2>/dev/null || ...)
```

## Impact

The critical failure was in `headless-runtime-helper.sh`: pulse workers exited with code 75 (`EX_TEMPFAIL`) because all models appeared backed off even after the retry window passed. Observed during pulse 2026-03-26T03:42Z.

## Testing Evidence

- **Testing level:** `self-assessed`
- **Stability results:** Verified via simulation — in UTC-6, broken path returns epoch +21600s, making an expired backoff appear active for ~6 more hours. Fixed path returns correct UTC epoch.
- **Smoke pages/endpoints checked:** N/A — shell script fix, no running service
- **ShellCheck:** Zero new warnings across all 7 modified files (only pre-existing SC1091 info-level `source` warnings)

## Files Changed

- `.agents/scripts/headless-runtime-helper.sh:458` — `backoff_active_for_key()` (critical path)
- `.agents/scripts/model-availability-helper.sh:398,1262` — staleness checks
- `.agents/scripts/model-registry-helper.sh:707,873` — sync staleness checks
- `.agents/scripts/review-bot-gate-helper.sh:110` — PR age calculation
- `.agents/scripts/draft-response-helper.sh:911,912` — advisory age check
- `.agents/scripts/stats-functions.sh:2558` — PR age calculation
- `.agents/scripts/conversation-helper.sh:1286` — last activity elapsed time

Closes #6549