### PR TITLE
fix(sandbox): document source guard root cause and add regression tests (GH#6617)

### DIFF
--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -1226,6 +1226,15 @@ main() {
 	esac
 }
 
+# Source guard: only call main() when executed directly, not when sourced.
+# This prevents the secondary watchdog (_sandbox_spawn_watchdog_bg) from
+# triggering help output when it sources this script to load helper functions.
+# Without this guard, sourcing the script would call main() with the watchdog's
+# positional args (e.g., a numeric timeout), which falls through to the *)
+# case in main() → sandbox_help() → help text printed to the sandbox's stdout
+# pipe → contaminating the opencode output file → output_has_activity() returns
+# "0" → headless-runtime-helper.sh records a backoff and never launches the
+# worker. This was the root cause of GH#6617. (GH#6550)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 	main "$@"
 fi

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -435,6 +435,44 @@ else
 	fail "other OPENCODE_* vars still included in passthrough CSV" "got: $passthrough_csv2"
 fi
 
+section "Sandbox Source Guard (GH#6617)"
+# Regression test: sourcing sandbox-exec-helper.sh must NOT call main() and
+# must NOT produce any output. The secondary watchdog (_sandbox_spawn_watchdog_bg)
+# sources the sandbox script to load helper functions. Before the source guard
+# was added (GH#6550), sourcing the script called main() with the watchdog's
+# positional args, which fell through to the *) case → sandbox_help() → help
+# text printed to stdout → contaminating the opencode output file → workers
+# never launched (GH#6617).
+SANDBOX_HELPER="$REPO_DIR/.agents/scripts/sandbox-exec-helper.sh"
+source_output=$(bash -c "source '$SANDBOX_HELPER' 2>/dev/null; echo 'source_ok'" 2>/dev/null || true)
+if [[ "$source_output" == "source_ok" ]]; then
+	pass "sourcing sandbox-exec-helper.sh produces no output (source guard active)"
+else
+	fail "sourcing sandbox-exec-helper.sh produces no output (source guard active)" \
+		"got: $(printf '%s' "$source_output" | head -3)"
+fi
+
+# Verify that sourcing does NOT print help text (the specific symptom of GH#6617).
+source_help_check=$(bash -c "source '$SANDBOX_HELPER' 2>/dev/null; echo done" 2>/dev/null || true)
+if printf '%s' "$source_help_check" | grep -q "Commands:"; then
+	fail "sourcing sandbox-exec-helper.sh does not print help text (GH#6617 regression)" \
+		"help text found in source output"
+else
+	pass "sourcing sandbox-exec-helper.sh does not print help text (GH#6617 regression)"
+fi
+
+# Verify that sourcing with watchdog-style args (numeric timeout) does NOT call main().
+# This simulates what _sandbox_spawn_watchdog_bg does: source the script then call
+# _sandbox_spawn_watchdog. The numeric arg (3600) would previously trigger the *)
+# case in main() → help output.
+source_with_args=$(bash -c "source '$SANDBOX_HELPER' 3600 12345 12345 '' '/tmp/marker' 2>/dev/null; echo done" 2>/dev/null || true)
+if printf '%s' "$source_with_args" | grep -q "Commands:"; then
+	fail "sourcing sandbox-exec-helper.sh with watchdog args does not print help text (GH#6617)" \
+		"help text found when sourced with numeric args"
+else
+	pass "sourcing sandbox-exec-helper.sh with watchdog args does not print help text (GH#6617)"
+fi
+
 echo ""
 printf "Total: %d, Passed: %d, Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
 


### PR DESCRIPTION
## Summary

- Documents the root cause of GH#6617 in a comment on the source guard in `sandbox-exec-helper.sh`
- Adds 3 regression tests to `tests/test-headless-runtime-helper.sh` to prevent this from regressing

## Root Cause

The source guard added in GH#6550 (`if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then main "$@"; fi`) fixed the root cause of GH#6617, but the connection between the two was not documented.

**What was happening:**

1. `_sandbox_spawn_watchdog_bg` in `sandbox-exec-helper.sh` spawns a background watchdog via `exec bash -c 'source "$script"; _sandbox_spawn_watchdog "$@"'`
2. Before GH#6550, the script ended with unconditional `main "$@"`
3. When the watchdog sourced the script, `main()` was called with the watchdog's positional args (e.g., a numeric timeout like `3600`)
4. `3600` doesn't match `run|audit|config|help` → falls through to `*)` case → `sandbox_help()` → help text printed to stdout
5. The watchdog inherits the sandbox's stdout, which is piped to `tee "$output_file"`
6. Help text appears in `output_file` → `output_has_activity()` returns `"0"` (no JSON events found)
7. `_handle_run_result` records a provider backoff and returns 75 (no-activity)
8. `headless-runtime-helper.sh` never launches the worker

The workaround `AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1` bypassed the sandbox entirely, confirming the bug was in the sandbox invocation path.

## Changes

- `sandbox-exec-helper.sh`: Added explanatory comment to the source guard linking it to GH#6617
- `tests/test-headless-runtime-helper.sh`: Added 3 regression tests in a new "Sandbox Source Guard (GH#6617)" section

## Testing

All 29 tests pass (26 existing + 3 new):

```
=== Sandbox Source Guard (GH#6617) ===
  PASS sourcing sandbox-exec-helper.sh produces no output (source guard active)
  PASS sourcing sandbox-exec-helper.sh does not print help text (GH#6617 regression)
  PASS sourcing sandbox-exec-helper.sh with watchdog args does not print help text (GH#6617)

Total: 29, Passed: 29, Failed: 0
```

## Testing Evidence

- **Testing level:** `runtime-verified`
- **Risk classification:** low (comment + regression tests only, no logic changes)
- **Test command:** `/bin/bash tests/test-headless-runtime-helper.sh --verbose`
- **Stability results:** 29/29 pass, 0 fail
- **Behaviour verified:** sourcing sandbox-exec-helper.sh with watchdog-style args produces no output

Closes #6617