### PR TITLE
GH#6684: Fix full-loop-helper.sh unbound variable crashes in background/status paths

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -15,6 +15,7 @@ readonly DEFAULT_MAX_TASK_ITERATIONS=50 DEFAULT_MAX_PREFLIGHT_ITERATIONS=5 DEFAU
 readonly BOLD='\033[1m'
 
 HEADLESS="${FULL_LOOP_HEADLESS:-false}"
+_FG_PID_FILE=""
 
 is_headless() { [[ "$HEADLESS" == "true" ]]; }
 
@@ -56,7 +57,8 @@ load_state() {
 		_val="${_line#*=}"
 		# Allowlist: only set known state variables
 		case "$_key" in
-		PHASE | ACTIVE | ITERATION | MAX_TASK_ITERATIONS | MAX_PREFLIGHT_ITERATIONS | \
+		PHASE | ACTIVE | ITERATION | STARTED_AT | UPDATED_AT | \
+			MAX_TASK_ITERATIONS | MAX_PREFLIGHT_ITERATIONS | \
 			MAX_PR_ITERATIONS | SKIP_PREFLIGHT | SKIP_POSTFLIGHT | SKIP_RUNTIME_TESTING | \
 			NO_AUTO_PR | NO_AUTO_DEPLOY | HEADLESS | PR_NUMBER)
 			printf -v "$_key" '%s' "$_val"
@@ -67,6 +69,8 @@ load_state() {
 		print toupper(k) "=" $2
 	}' "$STATE_FILE")
 	CURRENT_PHASE="${PHASE:-}"
+	STARTED_AT="${STARTED_AT:-unknown}"
+	UPDATED_AT="${UPDATED_AT:-}"
 	HEADLESS="${HEADLESS:-false}"
 	SAVED_PROMPT=$(sed -n '/^---$/,/^---$/d; p' "$STATE_FILE")
 	return 0
@@ -139,6 +143,17 @@ cmd_start() {
 	local prompt="$1"
 	shift
 	local background=false
+	# Initialize option variables with defaults so set -u doesn't crash on
+	# export (line ~220) when flags are not passed.
+	MAX_TASK_ITERATIONS="${MAX_TASK_ITERATIONS:-$DEFAULT_MAX_TASK_ITERATIONS}"
+	MAX_PREFLIGHT_ITERATIONS="${MAX_PREFLIGHT_ITERATIONS:-$DEFAULT_MAX_PREFLIGHT_ITERATIONS}"
+	MAX_PR_ITERATIONS="${MAX_PR_ITERATIONS:-$DEFAULT_MAX_PR_ITERATIONS}"
+	SKIP_PREFLIGHT="${SKIP_PREFLIGHT:-false}"
+	SKIP_POSTFLIGHT="${SKIP_POSTFLIGHT:-false}"
+	SKIP_RUNTIME_TESTING="${SKIP_RUNTIME_TESTING:-false}"
+	NO_AUTO_PR="${NO_AUTO_PR:-false}"
+	NO_AUTO_DEPLOY="${NO_AUTO_DEPLOY:-false}"
+	DRY_RUN="${DRY_RUN:-false}"
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--max-task-iterations)
@@ -329,10 +344,11 @@ EOF
 
 _run_foreground() {
 	local prompt="$1"
-	local pid_file="${STATE_DIR}/full-loop.pid"
-	# On exit (normal or error), clear the PID file so status/logs don't report
-	# a background loop that is no longer running.
-	trap 'rm -f "$pid_file"' EXIT
+	# Use a global for the trap — local variables are out of scope when the
+	# EXIT trap fires after the function returns (causes unbound variable
+	# crash under set -u).
+	_FG_PID_FILE="${STATE_DIR}/full-loop.pid"
+	trap 'rm -f "$_FG_PID_FILE"' EXIT
 	emit_task_phase "$prompt"
 	return 0
 }


### PR DESCRIPTION
## Summary

- Fix three `set -u` unbound variable crashes in `full-loop-helper.sh` that prevented background mode and status checking from working
- Add `STARTED_AT`/`UPDATED_AT` to `load_state()` allowlist so they're populated from state file
- Replace local `pid_file` in `_run_foreground` trap with global `_FG_PID_FILE` to survive function scope exit
- Initialize all option variables with defaults at `cmd_start` entry before export

## Root Causes

1. **`STARTED_AT` unbound (line 267/257):** `load_state()` parsed `started_at` from YAML frontmatter via awk into `STARTED_AT=value`, but the allowlist in the `case` statement didn't include `STARTED_AT` — so `printf -v` never set it. Both `cmd_status` and `cmd_resume` then referenced `$STARTED_AT` without a default.

2. **`pid_file` unbound in trap (line 356):** `_run_foreground()` declared `local pid_file=...` and set `trap 'rm -f "$pid_file"' EXIT`. When the EXIT trap fires after the function returns, the local variable is out of scope — crash under `set -u`.

3. **Option variables unbound on export (line 220-221):** `cmd_start()` exported `MAX_TASK_ITERATIONS`, `SKIP_PREFLIGHT`, etc. for the background subprocess, but these were only set if the corresponding `--flag` was passed. Without flags, `export` of unset variables crashes under `set -u`.

## Testing

- `shellcheck` — zero violations (only SC1091 info for external source)
- `bash -n` — syntax OK
- Risk: **low** — bugfix to shell script, no behaviour change for working paths

Closes #6684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added process lifecycle timestamp tracking (started and updated times).

* **Bug Fixes**
  * Improved initialization of configuration variables to prevent runtime failures.
  * Fixed variable scoping issues in process management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->