### PR TITLE
fix: guard all unbound variables in full-loop-helper.sh background/status paths

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -14,7 +14,25 @@ readonly STATE_FILE="${STATE_DIR}/full-loop.local.state"
 readonly DEFAULT_MAX_TASK_ITERATIONS=50 DEFAULT_MAX_PREFLIGHT_ITERATIONS=5 DEFAULT_MAX_PR_ITERATIONS=20
 readonly BOLD='\033[1m'
 
+# Initialise all optional state variables with safe defaults so set -u never
+# fires on them, regardless of which flags were passed or whether load_state
+# was called.
 HEADLESS="${FULL_LOOP_HEADLESS:-false}"
+MAX_TASK_ITERATIONS="${MAX_TASK_ITERATIONS:-$DEFAULT_MAX_TASK_ITERATIONS}"
+MAX_PREFLIGHT_ITERATIONS="${MAX_PREFLIGHT_ITERATIONS:-$DEFAULT_MAX_PREFLIGHT_ITERATIONS}"
+MAX_PR_ITERATIONS="${MAX_PR_ITERATIONS:-$DEFAULT_MAX_PR_ITERATIONS}"
+SKIP_PREFLIGHT="${SKIP_PREFLIGHT:-false}"
+SKIP_POSTFLIGHT="${SKIP_POSTFLIGHT:-false}"
+SKIP_RUNTIME_TESTING="${SKIP_RUNTIME_TESTING:-false}"
+NO_AUTO_PR="${NO_AUTO_PR:-false}"
+NO_AUTO_DEPLOY="${NO_AUTO_DEPLOY:-false}"
+DRY_RUN="${DRY_RUN:-false}"
+# State variables populated by load_state; pre-initialised so cmd_status /
+# cmd_resume never hit unbound-variable errors even if load_state is skipped.
+CURRENT_PHASE=""
+STARTED_AT=""
+PR_NUMBER=""
+SAVED_PROMPT=""
 
 is_headless() { [[ "$HEADLESS" == "true" ]]; }
 
@@ -56,7 +74,7 @@ load_state() {
 		_val="${_line#*=}"
 		# Allowlist: only set known state variables
 		case "$_key" in
-		PHASE | ACTIVE | ITERATION | MAX_TASK_ITERATIONS | MAX_PREFLIGHT_ITERATIONS | \
+		PHASE | ACTIVE | ITERATION | STARTED_AT | MAX_TASK_ITERATIONS | MAX_PREFLIGHT_ITERATIONS | \
 			MAX_PR_ITERATIONS | SKIP_PREFLIGHT | SKIP_POSTFLIGHT | SKIP_RUNTIME_TESTING | \
 			NO_AUTO_PR | NO_AUTO_DEPLOY | HEADLESS | PR_NUMBER)
 			printf -v "$_key" '%s' "$_val"
@@ -329,10 +347,14 @@ EOF
 
 _run_foreground() {
 	local prompt="$1"
-	local pid_file="${STATE_DIR}/full-loop.pid"
+	# Use a non-local variable for the PID file path so the EXIT trap can
+	# reference it after the function's local scope is torn down.  Under
+	# set -u a local variable referenced inside a trap that fires post-return
+	# is unbound and crashes the script.
+	_RUN_FG_PID_FILE="${STATE_DIR}/full-loop.pid"
 	# On exit (normal or error), clear the PID file so status/logs don't report
 	# a background loop that is no longer running.
-	trap 'rm -f "$pid_file"' EXIT
+	trap 'rm -f "$_RUN_FG_PID_FILE"' EXIT
 	emit_task_phase "$prompt"
 	return 0
 }


### PR DESCRIPTION
## Summary

Fixes three classes of `unbound variable` crashes in `full-loop-helper.sh` under `set -u`, as reported in #6684.

## Root Causes Fixed

### 1. `STARTED_AT` missing from `load_state` allowlist (line 267 crash)

`load_state()` parses YAML frontmatter via an allowlist `case` statement. `STARTED_AT` was not in the allowlist, so it was never populated from the state file. `cmd_status` and `cmd_resume` then referenced `$STARTED_AT` on an unbound variable.

**Fix:** Added `STARTED_AT` to the allowlist in `load_state`.

### 2. Optional flag variables unbound on `export` (background path crash)

Variables like `MAX_TASK_ITERATIONS`, `SKIP_PREFLIGHT`, etc. were only assigned when the corresponding CLI flag was passed. The background path unconditionally `export`s all of them — under `set -u`, exporting an unset variable crashes.

**Fix:** Pre-initialise all optional flag variables at script level with safe defaults (matching the existing `DEFAULT_*` constants).

### 3. `pid_file` local variable referenced in EXIT trap (line 356 crash)

`_run_foreground` declared `local pid_file=...` then used it in `trap '... "$pid_file"' EXIT`. In bash, `local` variables are scoped to the function — when the EXIT trap fires after the function returns, `$pid_file` is unbound.

**Fix:** Replaced with a script-level variable `_RUN_FG_PID_FILE` that survives the function's scope.

### 4. State variables pre-initialised at script level

`CURRENT_PHASE`, `STARTED_AT`, `PR_NUMBER`, `SAVED_PROMPT` are now initialised to empty strings at the top of the script, so `cmd_status`/`cmd_resume` are safe even if `load_state` is skipped or returns early.

## Testing

- `shellcheck` passes (zero new violations; SC1091 is pre-existing info-level)
- Simulated the exact crash scenario from the issue: created a state file and ran `status` — output is correct, exit 0
- Script loads cleanly under `set -euo pipefail` with no flags set

Closes #6684