### PR TITLE
fix: use pip show for pip tool version detection (GH#6675)

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -132,6 +132,21 @@ declare -a JSON_RESULTS=()
 # slow interpreters (Python, Ruby) while still catching hung MCP servers.
 readonly VERSION_TIMEOUT=10
 
+# Get installed version for pip packages using pip show.
+# pip-only libraries (e.g. crawl4ai, dspy) have no CLI binary, so
+# command -v always fails. pip show is fast and works for any installed package.
+get_pip_installed_version() {
+	local pkg="$1"
+	local version
+	version=$(pip show "$pkg" 2>/dev/null | grep -i '^Version:' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+	if [[ -n "$version" ]]; then
+		echo "$version"
+	else
+		echo "not installed"
+	fi
+	return 0
+}
+
 # Get installed version from npm global package.json
 # Fallback for tools where --version starts a server instead of printing a version
 get_npm_pkg_version() {
@@ -283,8 +298,13 @@ check_tool() {
 	local update_cmd="$6"
 
 	local installed
-	# Pass package name for npm tools so fallback to package.json works
-	if [[ "$category" == "npm" ]]; then
+	# pip tools: use pip show for version detection — pip-only libraries (e.g.
+	# crawl4ai, dspy) have no CLI binary so command -v always fails.
+	# npm tools: pass package name so fallback to package.json works.
+	# All other categories: standard CLI binary detection.
+	if [[ "$category" == "pip" ]]; then
+		installed=$(get_pip_installed_version "$pkg")
+	elif [[ "$category" == "npm" ]]; then
 		installed=$(get_installed_version "$cmd" "$ver_flag" "$pkg")
 	else
 		installed=$(get_installed_version "$cmd" "$ver_flag")

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -132,18 +132,41 @@ declare -a JSON_RESULTS=()
 # slow interpreters (Python, Ruby) while still catching hung MCP servers.
 readonly VERSION_TIMEOUT=10
 
-# Get installed version for pip packages using pip show.
-# pip-only libraries (e.g. crawl4ai, dspy) have no CLI binary, so
-# command -v always fails. pip show is fast and works for any installed package.
+# Get installed version for Python packages.
+# Tries pip show first (standard pip installs), then pipx list (pipx-isolated
+# tools like analytics-mcp), then uv tool list (uv-isolated tools like
+# outscraper-mcp-server). pip-only libraries (e.g. crawl4ai, dspy) have no
+# CLI binary so command -v always fails — this function handles all three cases.
 get_pip_installed_version() {
 	local pkg="$1"
 	local version
+
+	# 1. Try pip show (standard pip installs and library packages)
 	version=$(pip show "$pkg" 2>/dev/null | grep -i '^Version:' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
 	if [[ -n "$version" ]]; then
 		echo "$version"
-	else
-		echo "not installed"
+		return 0
 	fi
+
+	# 2. Try pipx list (packages installed in isolated pipx environments)
+	if command -v pipx &>/dev/null; then
+		version=$(pipx list --short 2>/dev/null | grep -i "^${pkg}" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+		if [[ -n "$version" ]]; then
+			echo "$version"
+			return 0
+		fi
+	fi
+
+	# 3. Try uv tool list (packages installed via uv tool install)
+	if command -v uv &>/dev/null; then
+		version=$(uv tool list 2>/dev/null | grep -i "^${pkg}" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+		if [[ -n "$version" ]]; then
+			echo "$version"
+			return 0
+		fi
+	fi
+
+	echo "not installed"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- `crawl4ai`, `dspy`, and other pip-only libraries have no CLI binary — `command -v crawl4ai` always fails even when the package is installed via pip
- Add `get_pip_installed_version()` which uses `pip show <pkg>` to detect installed version — works for any pip package regardless of whether it installs a CLI binary
- Update `check_tool()` to use this function for all `pip` category tools instead of the CLI-binary-based `get_installed_version()`

## Root Cause

`get_installed_version()` at line 157 gates on `command -v "$cmd"`. For pip-only libraries, `$cmd` is the package name (e.g. `crawl4ai`) but no binary is installed to `PATH`. The function returns `"not installed"` unconditionally.

## Fix

```bash
get_pip_installed_version() {
    local pkg="$1"
    local version
    version=$(pip show "$pkg" 2>/dev/null | grep -i '^Version:' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
    if [[ -n "$version" ]]; then
        echo "$version"
    else
        echo "not installed"
    fi
    return 0
}
```

`pip show` is fast (no subprocess spawn, no import), works for all pip packages, and returns the exact installed version from pip's metadata.

## Runtime Testing

- **Risk**: Low — shell script change, no runtime environment required
- **Testing level**: self-assessed
- **ShellCheck**: zero violations

## Files Changed

- `.agents/scripts/tool-version-check.sh` — add `get_pip_installed_version()`, update `check_tool()` pip branch

Closes #6675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved version detection for pip-installed tools in the version checker: now more reliably detects pip-installed packages by checking pip, pipx and the tool list before reporting "not installed", resulting in fewer false "not installed" reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->