### PR TITLE
GH#6675: Fix pip package detection in tool-version-check.sh

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -148,11 +148,26 @@ get_npm_pkg_version() {
 	return 1
 }
 
+# Get installed version from pip show
+# Fallback for pip packages that have no CLI binary (e.g., crawl4ai, dspy)
+get_pip_pkg_version() {
+	local pkg="$1"
+	local ver
+	ver=$(pip show "$pkg" 2>/dev/null | grep -i '^Version:' | grep -oE '[0-9]+\.[0-9]+[0-9.]*' | head -1)
+	if [[ -n "$ver" ]]; then
+		echo "$ver"
+		return 0
+	fi
+	return 1
+}
+
 # Get installed version
+# Args: cmd ver_flag [pkg] [category]
 get_installed_version() {
 	local cmd="$1"
 	local ver_flag="$2"
 	local pkg="${3:-}"
+	local category="${4:-}"
 
 	if command -v "$cmd" &>/dev/null; then
 		local version
@@ -194,10 +209,14 @@ get_installed_version() {
 			version=$(echo "$ver_output" | grep -oE '[0-9]+\.[0-9]+' | head -1)
 		fi
 
-		# If --version produced no parseable version, try npm package.json fallback
+		# If --version produced no parseable version, try package manager fallback
 		if [[ -z "$version" ]] && [[ -n "$pkg" ]]; then
-			local pkg_version
-			pkg_version=$(get_npm_pkg_version "$pkg")
+			local pkg_version=""
+			if [[ "$category" == "pip" ]]; then
+				pkg_version=$(get_pip_pkg_version "$pkg")
+			else
+				pkg_version=$(get_npm_pkg_version "$pkg")
+			fi
 			if [[ -n "$pkg_version" ]]; then
 				echo "$pkg_version"
 				return 0
@@ -206,6 +225,16 @@ get_installed_version() {
 
 		echo "${version:-unknown}"
 	else
+		# No CLI binary found — for pip packages, try pip show as fallback
+		# Many pip packages are libraries without CLI entry points
+		if [[ "$category" == "pip" && -n "$pkg" ]]; then
+			local pip_version
+			pip_version=$(get_pip_pkg_version "$pkg")
+			if [[ -n "$pip_version" ]]; then
+				echo "$pip_version"
+				return 0
+			fi
+		fi
 		echo "not installed"
 	fi
 	return 0
@@ -283,9 +312,10 @@ check_tool() {
 	local update_cmd="$6"
 
 	local installed
-	# Pass package name for npm tools so fallback to package.json works
-	if [[ "$category" == "npm" ]]; then
-		installed=$(get_installed_version "$cmd" "$ver_flag" "$pkg")
+	# Pass package name and category so fallback detection works
+	# npm: falls back to package.json; pip: falls back to pip show
+	if [[ "$category" == "npm" || "$category" == "pip" ]]; then
+		installed=$(get_installed_version "$cmd" "$ver_flag" "$pkg" "$category")
 	else
 		installed=$(get_installed_version "$cmd" "$ver_flag")
 	fi


### PR DESCRIPTION
## Summary

- Add `get_pip_pkg_version()` fallback that uses `pip show` to detect installed pip packages that have no CLI binary
- Pass `category` parameter through `check_tool()` → `get_installed_version()` so pip tools use the pip-specific fallback
- When `command -v` fails for a pip tool, try `pip show <pkg>` before reporting "not installed"

## Root Cause

`get_installed_version()` used `command -v` to check if a tool exists. Pip packages like `crawl4ai` and `dspy` are Python libraries with no CLI entry point — `command -v crawl4ai` always fails even when the package is installed via pip.

## Changes

- **`get_pip_pkg_version()`** (new) — extracts version from `pip show <pkg>` output
- **`get_installed_version()`** — accepts optional `category` param; for `pip` category, falls back to `pip show` both when `--version` produces no output AND when `command -v` fails entirely
- **`check_tool()`** — passes `$pkg` and `$category` for pip tools (previously only passed for npm)

## Runtime Testing

- **Level:** `self-assessed`
- **Risk:** Low (version detection utility, no side effects)
- Ran `tool-version-check.sh --category pip` — correctly reports "not installed" for packages not on this machine
- ShellCheck: zero violations
- `pip show` version extraction verified working (tested with `pip show pip`)
- Existing tools with CLI binaries (e.g., `analytics-mcp`) unaffected — `command -v` path still takes priority

Closes #6675