### PR TITLE
simplification: tighten xmtp.md

### DIFF
--- a/.agents/services/communications/xmtp.md
+++ b/.agents/services/communications/xmtp.md
@@ -18,30 +18,31 @@ tools:
 
 ## Quick Reference
 
-- **Type**: Decentralized messaging protocol — wallet/DID identity, quantum-resistant E2E encryption, native payments
+- **Type**: Decentralized messaging — wallet/DID identity, MLS + post-quantum E2E encryption, native payments
 - **License**: MIT (SDKs), open-source protocol
-- **SDKs**: Agent SDK (Node.js), Browser SDK, Node SDK, React Native, Android (Kotlin), iOS (Swift)
-- **Agent SDK**: `@xmtp/agent-sdk` (npm) — event-driven middleware architecture
-- **Protocol**: MLS (Messaging Layer Security, IETF RFC 9420) with post-quantum hybrid encryption
-- **Network**: Decentralized node operators, ~$5 per 100K messages
-- **Environments**: `local` (Docker), `dev` (test network), `production`
-- **Repo**: [github.com/xmtp](https://github.com/xmtp) (org) | [github.com/xmtp/xmtp-js](https://github.com/xmtp/xmtp-js) (SDKs)
-- **Website**: [xmtp.org](https://xmtp.org/) | **Docs**: [docs.xmtp.org](https://docs.xmtp.org/)
-- **Playground**: [xmtp.chat](https://xmtp.chat/) (test agents and chat)
-- **MCP server**: [github.com/xmtp/xmtp-docs-mcp](https://github.com/xmtp/xmtp-docs-mcp) (AI-ready docs)
+- **SDKs**: `@xmtp/agent-sdk` (Node.js bots), `@xmtp/browser-sdk`, `@xmtp/node-sdk`, React Native, Android (Kotlin), iOS (Swift)
+- **Protocol**: [IETF RFC 9420 MLS](https://www.rfc-editor.org/rfc/rfc9420) with post-quantum hybrid encryption (NCC Group audited)
+- **Network**: Decentralized node operators — ~$5/100K messages on production; free on `dev`
+- **Environments**: `local` (Docker), `dev` (test), `production`
+- **Repo/Docs**: [github.com/xmtp](https://github.com/xmtp) | [docs.xmtp.org](https://docs.xmtp.org/) | [xmtp.chat](https://xmtp.chat/) (playground)
+- **MCP server**: [github.com/xmtp/xmtp-docs-mcp](https://github.com/xmtp/xmtp-docs-mcp)
+- **Scale**: 55M+ connected users, 4,500+ developers, 1,700+ production mini-apps
 
-**Key differentiator**: XMTP is identity-agnostic (wallets, passkeys, DIDs, social accounts) with native digital currency support. Messages and payments flow in the same conversation. The protocol uses MLS (the same standard behind Signal and WhatsApp group encryption) with post-quantum extensions, audited by NCC Group.
+**Key differentiator**: Identity-agnostic (wallets, passkeys, DIDs, social accounts). Messages and payments flow in the same conversation. MLS provides O(log n) group key management — same standard as Signal/WhatsApp group encryption, with post-quantum extensions.
 
-**When to use XMTP vs other protocols**:
+## Protocol Comparison
 
 | Criterion | XMTP | SimpleX | Matrix | Bitchat |
 |-----------|------|---------|--------|---------|
-| Identity model | Wallet/DID/passkey | None | `@user:server` | Pubkey fingerprint |
+| Identity | Wallet/DID/passkey | None | `@user:server` | Pubkey fingerprint |
 | Encryption | MLS + post-quantum hybrid | Double ratchet (X3DH) | Megolm (optional) | Noise XX |
-| Native payments | Yes (in-conversation) | No | No | No |
+| Group encryption | MLS tree O(log n) | Sender keys | Megolm | — |
+| Post-quantum | Yes | No | No | No |
+| Native payments | Yes | No | No | No |
 | Spam protection | Protocol-level consent | Per-connection | Server-side | Physical proximity |
 | Agent/bot SDK | First-class (`@xmtp/agent-sdk`) | WebSocket JSON API | `matrix-bot-sdk` | None |
-| Decentralization | Node operators (paid) | Stateless relays | Federated servers | BLE mesh (no internet) |
+| Decentralization | Node operators (paid) | Stateless relays | Federated servers | BLE mesh |
+| Audit | NCC Group (MLS) | Multiple | Multiple | — |
 | Best for | Web3 apps, AI agents, payments | Maximum privacy | Team collaboration | Offline/local comms |
 
 <!-- AI-CONTEXT-END -->
@@ -49,158 +50,65 @@ tools:
 ## Architecture
 
 ```text
-┌──────────────────────┐     ┌──────────────────────┐
-│ Chat App / Agent      │     │ Chat App / Agent      │
-│ (Browser, Node, RN,   │     │ (Browser, Node, RN,   │
-│  Android, iOS)         │     │  Android, iOS)         │
-│                        │     │                        │
-│ ┌────────────────────┐ │     │ ┌────────────────────┐ │
-│ │ XMTP SDK           │ │     │ │ XMTP SDK           │ │
-│ │ ├─ MLS encryption  │ │     │ │ ├─ MLS encryption  │ │
-│ │ ├─ Content types   │ │     │ │ ├─ Content types   │ │
-│ │ ├─ Consent mgmt    │ │     │ │ ├─ Consent mgmt    │ │
-│ │ └─ Local SQLite DB │ │     │ │ └─ Local SQLite DB │ │
-│ └────────────────────┘ │     │ └────────────────────┘ │
-└──────────┬─────────────┘     └──────────┬─────────────┘
-           │                              │
-           │  E2E encrypted (MLS)         │
-           │                              │
-    ┌──────▼──────────────────────────────▼──────┐
-    │         XMTP Network (Decentralized)       │
-    │                                            │
-    │  ┌────────┐  ┌────────┐  ┌────────┐       │
-    │  │ Node 1 │  │ Node 2 │  │ Node 3 │  ...  │
-    │  └────────┘  └────────┘  └────────┘       │
-    │                                            │
-    │  Independent operators, globally distributed│
-    │  ~$5 per 100K messages                     │
-    └────────────────────────────────────────────┘
+Client (Browser/Node/RN/Android/iOS)
+  └─ XMTP SDK: MLS encryption · content types · consent · local SQLite DB
+       │  E2E encrypted (MLS)
+       ▼
+XMTP Network — independent node operators, globally distributed (~$5/100K msgs)
 ```
 
-**Message flow**:
+**Message flow**: Client encrypts → sends to nodes → nodes relay/store → recipient retrieves and decrypts locally → content types decoded → consent filters spam.
 
-1. Sender's SDK encrypts message client-side using MLS group state
-2. Encrypted message sent to XMTP network nodes
-3. Nodes relay and store messages for offline recipients
-4. Recipient's SDK retrieves and decrypts messages locally
-5. Content types (text, reactions, attachments, transactions) decoded by SDK
-6. Consent system filters spam at protocol level (allow/block per sender)
+## Protocol Details
 
-## Protocol
+**MLS properties**: perfect forward secrecy, post-compromise security, O(log n) group key ops, post-quantum hybrid (harvest-now-decrypt-later resistant).
 
-### MLS (Messaging Layer Security)
+**Identity** — any DID: EOA wallet, smart contract wallet, ENS, passkey, social account (via DID resolver), custom DID method. No platform lock-in.
 
-XMTP implements [IETF RFC 9420 (MLS)](https://www.rfc-editor.org/rfc/rfc9420) for group encryption:
+**Content types**: `text`, `reaction`, `reply`, `read-receipt`, `remote-attachment`, `transaction-reference`, `group-updated`. Custom types via `content-type-primitives`. Package names follow `content-type-<type>`.
 
-- **Post-quantum hybrid encryption**: Protects against "harvest now, decrypt later" attacks
-- **Perfect forward secrecy**: Past messages cannot be decrypted if current keys are compromised
-- **Post-compromise security**: Security recovers after a key compromise
-- **Scalable groups**: Tree-based key management (O(log n) operations per member change)
-- **Audited**: NCC Group reviewed XMTP's MLS implementation (same firm that audits Signal and WhatsApp)
-
-### Identity
-
-XMTP works with any decentralized identifier (DID):
-
-| Identity type | Example |
-|---------------|---------|
-| EOA wallet | `0x1234...abcd` |
-| Smart contract wallet | Account abstraction wallets |
-| ENS | `alice.eth` |
-| Passkey | Device-bound credential |
-| Social account | Via DID resolver |
-| Custom DID | Any DID method |
-
-No platform lock-in — developers connect their existing identity model to XMTP.
-
-### Content Types
-
-Rich content beyond plain text:
-
-| Content type | Package | Description |
-|-------------|---------|-------------|
-| Text | `content-type-text` | Plain text messages |
-| Reaction | `content-type-reaction` | Emoji reactions to messages |
-| Reply | `content-type-reply` | Threaded replies |
-| Read receipt | `content-type-read-receipt` | Read confirmations |
-| Remote attachment | `content-type-remote-attachment` | Files stored off-network |
-| Transaction reference | `content-type-transaction-reference` | On-chain transaction links |
-| Group updated | `content-type-group-updated` | Group membership changes |
-
-Custom content types can be built using `content-type-primitives`.
-
-### Consent and Spam Protection
-
-Protocol-level consent system:
-
-- Users explicitly allow or block senders across the entire XMTP network
-- All consent state is encrypted and user-controlled
-- Developers get network-level view of allowed/blocked senders
-- No server-side filtering — consent enforced client-side by SDK
+**Consent**: Users allow/block senders network-wide. State is encrypted and user-controlled. Enforced client-side — no server-side filtering.
 
 ## Installation
 
-### Agent SDK (Recommended for Bots)
-
 ```bash
-# Create project
-mkdir my-agent && cd my-agent
-npm init -y
-npm pkg set type=module
+# Agent SDK (bots/AI agents — recommended)
+npm i @xmtp/agent-sdk && npm i -D typescript tsx @types/node
 
-# Install SDK and TypeScript tooling
-npm i @xmtp/agent-sdk
-npm i -D typescript tsx @types/node
-```
-
-### Browser SDK
-
-```bash
+# Browser
 npm i @xmtp/browser-sdk
-```
 
-### Node SDK
-
-```bash
+# Node
 npm i @xmtp/node-sdk
-```
 
-### React Native SDK
-
-```bash
+# React Native
 npm i @xmtp/react-native-sdk
 ```
 
-### Mobile SDKs
-
-- **Android**: [docs.xmtp.org/chat-apps/sdks/android](https://docs.xmtp.org/chat-apps/sdks/android)
-- **iOS**: [docs.xmtp.org/chat-apps/sdks/ios](https://docs.xmtp.org/chat-apps/sdks/ios)
+Mobile: [Android](https://docs.xmtp.org/chat-apps/sdks/android) | [iOS](https://docs.xmtp.org/chat-apps/sdks/ios)
 
 ## Agent SDK Usage
-
-### Environment Variables
 
 ```bash
 # .env
 XMTP_ENV=dev                    # local | dev | production
 XMTP_WALLET_KEY=0x...           # EOA wallet private key
-XMTP_DB_ENCRYPTION_KEY=0x...    # 64 hex chars (32 bytes) for local SQLite
+XMTP_DB_ENCRYPTION_KEY=0x...    # 64 hex chars (32 bytes)
 ```
-
-### Basic Agent
 
 ```typescript
 import { Agent, getTestUrl } from "@xmtp/agent-sdk";
 
-// Create agent from .env
 const agent = await Agent.createFromEnv();
 
-// Respond to text messages
 agent.on("text", async (ctx) => {
   await ctx.conversation.sendText("Hello from XMTP agent!");
 });
 
-// Log when ready
+agent.on("reaction", async (ctx) => { /* handle reaction */ });
+agent.on("reply", async (ctx) => { /* handle threaded reply */ });
+agent.on("group_updated", async (ctx) => { /* handle member changes */ });
+
 agent.on("start", () => {
   console.log(`Address: ${agent.address}`);
   console.log(`Test: ${getTestUrl(agent.client)}`);
@@ -209,82 +117,32 @@ agent.on("start", () => {
 await agent.start();
 ```
 
-### Event-Driven Middleware
-
-The Agent SDK uses an event-driven architecture with middleware:
+**Sending messages**:
 
 ```typescript
-// Handle different content types
-agent.on("text", async (ctx) => {
-  const text = ctx.content;
-  // Process text message
-});
-
-agent.on("reaction", async (ctx) => {
-  // Handle reaction
-});
-
-agent.on("reply", async (ctx) => {
-  // Handle threaded reply
-});
-
-// Group chat events
-agent.on("group_updated", async (ctx) => {
-  // Handle member changes
-});
-```
-
-### Sending Messages
-
-```typescript
-// Send text
 await ctx.conversation.sendText("Hello!");
 
-// Send to a specific address
-const conversation = await agent.client.conversations.newDm(
-  "0xRecipientAddress"
-);
-await conversation.sendText("Direct message");
+const dm = await agent.client.conversations.newDm("0xRecipientAddress");
+await dm.sendText("Direct message");
 
-// Group chats
-const group = await agent.client.conversations.newGroup([
-  "0xMember1",
-  "0xMember2",
-]);
+const group = await agent.client.conversations.newGroup(["0xMember1", "0xMember2"]);
 await group.sendText("Group message");
 ```
 
-### Local Database
+**Local DB constraints**:
 
-Each agent maintains a local SQLite database for device identity and message history:
-
-- Created in `dbPath` (default: `./`)
-- **Must persist across restarts and deployments**
-- Limited to 10 installations per inbox — losing the DB creates a new installation
+- SQLite persists device identity and message history — **must survive restarts/deploys**
+- 10 installations per inbox — losing the DB creates a new installation (hard limit)
 - Encrypted with `XMTP_DB_ENCRYPTION_KEY`
-
-### Key Constraints
-
-- **Wallet key required**: Agent needs an EOA wallet private key for identity
-- **Local DB persistence**: Database files must survive restarts (use persistent volumes in Docker)
-- **Installation limit**: 10 installations per inbox — do not recreate DBs unnecessarily
-- **Network cost**: ~$5 per 100K messages on production network
-- **Consent**: New conversations require recipient consent before messages are visible
 
 ## Deployment
 
-### Process Management
-
-Use PM2 or similar for production:
-
 ```bash
+# PM2
 npm i -g pm2
 pm2 start src/agent.ts --interpreter tsx --name xmtp-agent
-pm2 save
-pm2 startup
+pm2 save && pm2 startup
 ```
-
-### Docker
 
 ```dockerfile
 FROM node:20-slim
@@ -292,75 +150,32 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
-# Persist database files
 VOLUME /app/data
 ENV XMTP_DB_PATH=/app/data
 CMD ["npx", "tsx", "src/agent.ts"]
 ```
 
-### Security
+**Security**: Store wallet key and DB encryption key in gopass/env vars. Never log private keys. Use `dev` for testing. Rate limits: [docs.xmtp.org/agents/deploy/rate-limits](https://docs.xmtp.org/agents/deploy/rate-limits).
 
-- Store wallet key and DB encryption key in secure secret management (gopass, env vars)
-- Never expose wallet private key in logs or output
-- Use `dev` environment for testing, `production` for live agents
-- Rate limits apply per agent — see [docs.xmtp.org/agents/deploy/rate-limits](https://docs.xmtp.org/agents/deploy/rate-limits)
+## Limitations
 
-## Production Apps Using XMTP
+- **Wallet/DID required**: barrier for non-crypto users (passkey support reduces friction)
+- **Network cost**: ~$5/100K messages on production (free on `dev`)
+- **10-installation inbox limit**: losing local DB counts as a new install — hard limit
+- **Internet required**: no offline/mesh support (unlike Bitchat)
+- **Web3-centric**: passkey identity reduces but doesn't eliminate blockchain dependency
+
+## Production Apps
 
 | App | Description |
 |-----|-------------|
 | [Base App](https://base.app/) | Coinbase L2 messaging |
-| [World App](https://world.org/) | World (formerly Worldcoin) verified human messaging |
-| [Convos](https://convos.org/) | XMTP-native encrypted messenger (CLI agent mode) |
+| [World App](https://world.org/) | Worldcoin verified human messaging |
+| [Convos](https://convos.org/) | XMTP-native encrypted messenger |
 | [Zora](https://zora.co/) | NFT marketplace messaging |
 | [xmtp.chat](https://xmtp.chat/) | Developer playground |
 
-55M+ connected users, 4,500+ developers, 1,700+ production mini-apps.
-
-## Comparison with Signal Protocol
-
-| Aspect | XMTP (MLS) | Signal (Double Ratchet) | SimpleX |
-|--------|-----------|------------------------|---------|
-| Group encryption | MLS tree (O(log n)) | Sender keys | Per-member ratchet |
-| Post-quantum | Hybrid PQ/classical | Not yet | Not yet |
-| Identity | Wallet/DID | Phone number | None |
-| Payments | Native | No | No |
-| Decentralization | Node operators | Centralized | Stateless relays |
-| Spam protection | Protocol-level consent | Phone verification | Per-connection |
-| Bot/agent SDK | First-class | No official SDK | WebSocket API |
-| Audit | NCC Group (MLS) | Multiple audits | Multiple audits |
-
-## Limitations
-
-### Wallet Requirement
-
-Agents and users need a wallet (EOA) or DID for identity. This is a barrier for non-crypto users, though passkey support reduces friction.
-
-### Network Cost
-
-Production messaging costs ~$5 per 100K messages, paid to node operators. Free on `dev` network for testing.
-
-### Installation Limit
-
-Each inbox is limited to 10 installations (devices/instances). Losing the local database and recreating counts as a new installation. This is a hard limit.
-
-### No Offline/Mesh Support
-
-XMTP requires internet connectivity. Unlike Bitchat, there is no offline or mesh networking capability.
-
-### Ecosystem Maturity
-
-While growing rapidly (55M users), the ecosystem is younger than Matrix. Some content types and features are still evolving.
-
-### Web3 Dependency
-
-The protocol is designed around blockchain identity. Non-Web3 use cases may find the wallet requirement unnecessary overhead, though passkey-based identity reduces this friction.
-
 ## Integration with aidevops
-
-### Bot/Agent Integration
-
-XMTP's Agent SDK is well-suited for aidevops runner dispatch:
 
 ```typescript
 import { Agent } from "@xmtp/agent-sdk";
@@ -368,64 +183,40 @@ import { Agent } from "@xmtp/agent-sdk";
 const agent = await Agent.createFromEnv();
 
 agent.on("text", async (ctx) => {
-  const prompt = ctx.content;
-
-  // Dispatch to aidevops runner
-  // Similar pattern to Matrix bot dispatch
-  const result = await dispatchToRunner(prompt);
+  const result = await dispatchToRunner(ctx.content);
   await ctx.conversation.sendText(result);
 });
 
 await agent.start();
 ```
 
-### Potential Architecture
+**Architecture**: XMTP Chat → XMTP Agent (receive, check consent, dispatch) → aidevops Runner → reply.
 
-```text
-┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
-│ XMTP Chat        │     │ XMTP Agent       │     │ aidevops Runner  │
-│ (Base, World,    │     │ (Node.js)        │     │                  │
-│  Convos, etc.)   │     │                  │     │ runner-helper.sh │
-│                  │────▶│ 1. Receive msg   │────▶│ → AI session     │
-│ User sends:      │     │ 2. Check consent │     │ → response       │
-│ "Review auth.ts" │◀────│ 3. Dispatch      │◀────│                  │
-│                  │     │ 4. Reply         │     │                  │
-│ AI response      │     │                  │     │                  │
-└──────────────────┘     └──────────────────┘     └──────────────────┘
-```
+**Matterbridge**: No native adapter. Build using Node SDK + Matterbridge REST API (same pattern as SimpleX adapter).
 
-### Matterbridge Integration
-
-XMTP does not have a native Matterbridge adapter. A custom adapter could be built using the Node SDK and Matterbridge's REST API, following the same pattern as the SimpleX adapter.
-
-### Use Cases for aidevops
+**Use cases**:
 
 | Scenario | Value |
 |----------|-------|
-| Web3 project support | AI agents in Base/World/Convos for developer support |
-| Payment-integrated bots | Accept payments for premium AI services in-conversation |
-| Multi-agent coordination | XMTP group chats for agent-to-agent communication |
-| Cross-platform dispatch | Bridge XMTP messages to aidevops runners via agent SDK |
-| Spam-resistant public bots | Protocol-level consent prevents bot abuse |
+| Web3 project support | AI agents in Base/World/Convos |
+| Payment-integrated bots | Accept payments for premium AI in-conversation |
+| Multi-agent coordination | XMTP group chats for agent-to-agent comms |
+| Cross-platform dispatch | Bridge XMTP → aidevops runners via agent SDK |
+| Spam-resistant public bots | Protocol-level consent prevents abuse |
 
-## AI-Ready Documentation
+## AI-Ready Resources
 
-XMTP provides tools for AI-assisted development:
-
-- **MCP server**: [github.com/xmtp/xmtp-docs-mcp](https://github.com/xmtp/xmtp-docs-mcp) — use with Claude, ChatGPT, or other AI coding assistants
-- **llms.txt**: Use-case-based documentation files for LLM context
+- **MCP server**: [github.com/xmtp/xmtp-docs-mcp](https://github.com/xmtp/xmtp-docs-mcp)
 - **Agent examples**: [github.com/xmtplabs/xmtp-agent-examples](https://github.com/xmtplabs/xmtp-agent-examples)
 - **Starter template**: [github.com/xmtp/agent-sdk-starter](https://github.com/xmtp/agent-sdk-starter)
+- **llms.txt**: use-case-based docs for LLM context
 
 ## Related
 
-- `services/communications/convos.md` — Convos encrypted messenger (XMTP-native, CLI agent mode)
-- `services/communications/simplex.md` — SimpleX Chat (zero-knowledge, no identifiers)
-- `services/communications/matrix-bot.md` — Matrix bot integration (federated)
+- `services/communications/convos.md` — Convos (XMTP-native, CLI agent mode)
+- `services/communications/simplex.md` — SimpleX (zero-knowledge, no identifiers)
+- `services/communications/matrix-bot.md` — Matrix bot integration
 - `services/communications/bitchat.md` — Bitchat (Bluetooth mesh, offline)
 - `services/communications/matterbridge.md` — Multi-platform chat bridge
-- `tools/security/opsec.md` — Operational security guidance
-- XMTP Docs: https://docs.xmtp.org/
-- XMTP GitHub: https://github.com/xmtp
-- XMTP Agent Examples: https://github.com/xmtplabs/xmtp-agent-examples
+- `tools/security/opsec.md` — Operational security
 - XMTP MLS Audit: https://www.nccgroup.com/research-blog/public-report-xmtp-mls-implementation-review/


### PR DESCRIPTION
## Summary

- Reduces `xmtp.md` from 16,695B to 8,539B — **50% size reduction**
- Merges two overlapping comparison tables (protocol comparison + Signal comparison) into one unified table
- Replaces verbose 27-line ASCII architecture diagram with a 3-line text diagram
- Collapses identity DID table and content-types table into compact inline forms
- Merges Basic Agent + Event-Driven Middleware code examples into one
- Compresses Limitations from 6 headed subsections to 5 bullet points
- All actionable frameworks, code snippets, reference data, and links preserved