### PR TITLE
t1661.3: Update cross-references and indexes for Fly.io

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -301,7 +301,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Database/Local-first | `tools/database/pglite-local-first.md`, `services/database/postgres-drizzle-skill.md` |
 | Vector Search | `tools/database/vector-search.md`, `tools/database/vector-search/zvec.md` |
 | Local Development | `services/hosting/local-hosting.md` |
-| Hosting/Deployment | `tools/deployment/fly-io.md`, `tools/deployment/coolify.md`, `tools/deployment/vercel.md`, `tools/deployment/uncloud.md`, `tools/deployment/daytona.md` |
+| Hosting/Deployment | `tools/deployment/hosting-comparison.md`, `tools/deployment/fly-io.md`, `tools/deployment/coolify.md`, `tools/deployment/vercel.md`, `tools/deployment/uncloud.md`, `tools/deployment/daytona.md` |
 | Infrastructure | `tools/infrastructure/cloud-gpu.md`, `tools/containers/orbstack.md`, `tools/containers/remote-dispatch.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md` |
 | OpenAPI exploration | `tools/context/openapi-search.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -60,7 +60,7 @@ tools/vision/,Vision AI - image generation understanding and editing with local 
 tools/voice/,Voice AI - TTS/STT/S2S model catalog voice bridge Pipecat pipeline cloud voice agents and audio transcription (Whisper Buzz AssemblyAI Deepgram),voice-models|voice-ai-models|speech-to-speech|cloud-voice-agents|voice-bridge|hyprwhspr|pipecat-opencode|transcription|buzz|qwen3-tts
 tools/research/,Website research - tech stack detection and analysis providers,providers/crft-lookup
 tools/data-extraction/,Data extraction - scraping business data,outscraper
-tools/deployment/,Deployment automation - self-hosted PaaS cloud platforms sandbox hosting and orchestration,coolify|coolify-cli|vercel|fly-io|daytona|cloudron-app-packaging|cloudron-app-packaging-skill|cloudron-app-publishing-skill|cloudron-server-ops-skill|uncloud
+tools/deployment/,Deployment automation - self-hosted PaaS cloud platforms sandbox hosting and orchestration,hosting-comparison|coolify|coolify-cli|vercel|fly-io|daytona|cloudron-app-packaging|cloudron-app-packaging-skill|cloudron-app-publishing-skill|cloudron-server-ops-skill|uncloud
 tools/git/,Git operations - GitHub/GitLab/Gitea CLIs and diff tools,github-cli|gitlab-cli|gitea-cli|github-actions|worktrunk|lumen|jujutsu|conflict-resolution
 tools/credentials/,Secret management - API keys vaults and encryption stack,api-key-setup|api-key-management|vaultwarden|gopass|psst|multi-tenant|list-keys|sops|gocryptfs|encryption-stack
 tools/security/,Security tools - terminal guards privacy filtering IP reputation scanning prompt injection defense and opsec,tirith|shannon|cdn-origin-ip|privacy-filter|ip-reputation|opsec|prompt-injection-defender

--- a/.agents/tools/deployment/fly-io.md
+++ b/.agents/tools/deployment/fly-io.md
@@ -279,6 +279,11 @@ fly config validate --app my-app
 ./.agents/scripts/fly-io-helper.sh apps
 ```
 
+## Related
+
+- **Hosting comparison**: `tools/deployment/hosting-comparison.md` — Fly.io vs Daytona vs Coolify vs Cloudron vs Vercel decision guide
+- **Helper script**: `.agents/scripts/fly-io-helper.sh`
+
 ## References
 
 - **Docs**: https://fly.io/docs/


### PR DESCRIPTION
## Summary

- Add `hosting-comparison.md` to AGENTS.md domain index (Hosting/Deployment row) as the first entry — it's the decision guide entry point
- Add `hosting-comparison` to `subagent-index.toon` `tools/deployment/` key_files
- Add a Related section in `fly-io.md` cross-referencing the hosting comparison guide

## Context

The hosting comparison doc (`tools/deployment/hosting-comparison.md`, from t1663) and Fly.io subagent doc (`tools/deployment/fly-io.md`, from t1661.1) both exist but were not cross-referenced from the framework's discovery indexes. This makes them harder to find via the domain index and subagent lookup.

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/index changes only — no code, no runtime behaviour)
- **Files changed**: 3 (AGENTS.md, subagent-index.toon, fly-io.md)
- **Verification**: markdownlint-cli2 reports 0 errors on modified files

Closes #6724