### PR TITLE
t1676: fix(full-loop-helper): pre-initialize state vars before awk parse loop

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -50,7 +50,26 @@ EOF
 
 load_state() {
 	[[ -f "$STATE_FILE" ]] || return 1
-	# Single-pass parse of YAML frontmatter — safe variable assignment via declare
+	# Pre-initialize all state variables with safe defaults so that set -u does
+	# not abort when the state file is incomplete (missing fields are never set
+	# by the awk parse loop, leaving variables unbound).
+	PHASE=""
+	ACTIVE=""
+	ITERATION=""
+	STARTED_AT="unknown"
+	UPDATED_AT=""
+	PR_NUMBER=""
+	MAX_TASK_ITERATIONS="$DEFAULT_MAX_TASK_ITERATIONS"
+	MAX_PREFLIGHT_ITERATIONS="$DEFAULT_MAX_PREFLIGHT_ITERATIONS"
+	MAX_PR_ITERATIONS="$DEFAULT_MAX_PR_ITERATIONS"
+	SKIP_PREFLIGHT="false"
+	SKIP_POSTFLIGHT="false"
+	SKIP_RUNTIME_TESTING="false"
+	NO_AUTO_PR="false"
+	NO_AUTO_DEPLOY="false"
+	HEADLESS="${FULL_LOOP_HEADLESS:-false}"
+	SAVED_PROMPT=""
+	# Single-pass parse of YAML frontmatter — safe variable assignment via printf -v
 	local _key _val _line
 	while IFS= read -r _line; do
 		_key="${_line%%=*}"
@@ -69,9 +88,6 @@ load_state() {
 		print toupper(k) "=" $2
 	}' "$STATE_FILE")
 	CURRENT_PHASE="${PHASE:-}"
-	STARTED_AT="${STARTED_AT:-unknown}"
-	UPDATED_AT="${UPDATED_AT:-}"
-	HEADLESS="${HEADLESS:-false}"
 	SAVED_PROMPT=$(sed -n '/^---$/,/^---$/d; p' "$STATE_FILE")
 	return 0
 }


### PR DESCRIPTION
## Summary

- Pre-initialize all state variables with safe defaults at the top of `load_state()` before the awk parse loop runs
- Fixes `set -u` crashes when the state file is incomplete (missing fields leave variables unbound)
- Variables initialized: `PHASE`, `ACTIVE`, `ITERATION`, `STARTED_AT`, `UPDATED_AT`, `PR_NUMBER`, `MAX_TASK_ITERATIONS`, `MAX_PREFLIGHT_ITERATIONS`, `MAX_PR_ITERATIONS`, `SKIP_PREFLIGHT`, `SKIP_POSTFLIGHT`, `SKIP_RUNTIME_TESTING`, `NO_AUTO_PR`, `NO_AUTO_DEPLOY`, `HEADLESS`, `SAVED_PROMPT`

## Root Cause

`load_state()` used `printf -v "$_key"` to set variables from the YAML frontmatter parse loop. Under `set -u`, any field absent from the state file was never set, leaving the variable unbound. The first reference to such a variable after `load_state` returned caused an immediate abort. The post-loop defaults (lines 71-74 in the original) only covered `CURRENT_PHASE`, `STARTED_AT`, `UPDATED_AT`, and `HEADLESS` — leaving `PR_NUMBER`, all `MAX_*_ITERATIONS`, all `SKIP_*`, `NO_AUTO_*`, and `SAVED_PROMPT` unguarded.

## Fix

Initialize every allowlisted state variable with a safe default before the parse loop. The loop then overwrites only the fields present in the file; missing fields retain their defaults. Removed the now-redundant post-loop defaults for `STARTED_AT`, `UPDATED_AT`, and `HEADLESS` (they are set in the pre-init block).

## Testing

- ShellCheck: zero violations (SC1091 info pre-existing, not a violation)
- Risk: low — shell script, no runtime environment required
- Self-assessed: logic change is additive (pre-init only), no behavioral change when state file is complete

## Runtime Testing

- Testing level: `self-assessed`
- Risk classification: low (shell script state management, no external services)
- Behavior verified: pre-init block sets safe defaults; awk loop overwrites present fields; missing fields retain defaults

Closes #6720