### PR TITLE
GH#6754: Fix quality-debt from PR #6742 review feedback in daytona.md

### DIFF
--- a/.agents/tools/deployment/daytona.md
+++ b/.agents/tools/deployment/daytona.md
@@ -304,19 +304,23 @@ all_sandboxes = daytona.list()
 ### Python (Async)
 
 ```python
+import asyncio
 from daytona import AsyncDaytona, CreateSandboxFromImageParams, Resources, Image
 
-daytona = AsyncDaytona()
+async def main():
+    daytona = AsyncDaytona()
 
-image = Image.base("alpine:3.18").pip_install(["numpy"])
-sandbox = await daytona.create(CreateSandboxFromImageParams(
-    image=image,
-    language="python",
-    resources=Resources(cpu=2, memory=4),
-), timeout=120, on_snapshot_create_logs=lambda chunk: print(chunk, end=""))
+    image = Image.base("alpine:3.18").pip_install(["numpy"])
+    sandbox = await daytona.create(CreateSandboxFromImageParams(
+        image=image,
+        language="python",
+        resources=Resources(cpu=2, memory=4),
+    ), timeout=120, on_snapshot_create_logs=lambda chunk: print(chunk, end=""))
 
-result = await sandbox.process.code_run('import numpy; print(numpy.__version__)')
-await daytona.delete(sandbox)
+    result = await sandbox.process.code_run('import numpy; print(numpy.__version__)')
+    await daytona.delete(sandbox)
+
+asyncio.run(main())
 ```
 
 ### TypeScript
@@ -356,16 +360,16 @@ Base URL: `https://app.daytona.io/api` — `Authorization: Bearer $DAYTONA_API_K
 
 ```bash
 AUTH="Authorization: Bearer $DAYTONA_API_KEY"
-curl -H "$AUTH" https://app.daytona.io/api/sandboxes                                          # list
+curl -H "$AUTH" https://app.daytona.io/api/sandbox                                            # list
 curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
-  -d '{"template":"python-3.11","resources":{"cpus":2,"memory":4,"disk":10}}' \
-  https://app.daytona.io/api/sandboxes                                                        # create
-curl -X POST -H "$AUTH" https://app.daytona.io/api/sandboxes/<id>/start                      # start
-curl -X POST -H "$AUTH" https://app.daytona.io/api/sandboxes/<id>/stop                       # stop
-curl -X DELETE -H "$AUTH" https://app.daytona.io/api/sandboxes/<id>                          # delete
+  -d '{"image":"python:3.11-slim","cpu":2,"memory":4,"disk":10}' \
+  https://app.daytona.io/api/sandbox                                                          # create
+curl -X POST -H "$AUTH" https://app.daytona.io/api/sandbox/<id>/start                        # start
+curl -X POST -H "$AUTH" https://app.daytona.io/api/sandbox/<id>/stop                         # stop
+curl -X DELETE -H "$AUTH" https://app.daytona.io/api/sandbox/<id>                            # delete
 curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"command":"python script.py","timeout":60}' \
-  https://app.daytona.io/api/sandboxes/<id>/exec                                              # exec
+  https://app.daytona.io/api/sandbox/<id>/exec                                                # exec
 ```
 
 ## Comparison
@@ -394,7 +398,7 @@ daytona-helper.sh status <sandbox-id>
 daytona logs <sandbox-id>
 # Causes: resource limits exceeded, template not found, API key expired
 
-# Command timeout — increase or use background + poll
+# Command timeout — increase the timeout parameter
 result = sandbox.process.exec("long-running-command", timeout=300)
 
 # Port not accessible — verify listening, then re-expose


### PR DESCRIPTION
## Summary

Fixes three quality-debt findings from the PR #6742 code review in `.agents/tools/deployment/daytona.md`:

1. **REST API fields** (lines 360-362): Replaced nested `resources.cpus` with flat top-level `cpu`/`memory`/`disk` fields and corrected endpoint path from `/api/sandboxes` to `/api/sandbox` — verified against current [Daytona SDK docs](https://docs.daytona.io/api)
2. **Async Python example** (lines 306-320): Wrapped bare top-level `await` calls in `async def main()` + `asyncio.run(main())` so the example is valid runnable Python
3. **Troubleshooting guidance** (line 397): Removed stale "background + poll" reference that described a removed flow; simplified to "increase the timeout parameter"

## Verification

- All three findings verified against current Daytona SDK documentation via Context7 before applying fixes
- REST API field names (`cpu`, `memory`, `disk` as flat top-level fields) confirmed from official Daytona getting-started and sandbox docs
- Endpoint path `/api/sandbox` (singular) confirmed from official REST API examples
- Markdown lint: clean (formatter false-positive on `__version__` inside code block — expected)

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (documentation-only changes — no code, no runtime behaviour)
- **Rationale**: Agent prompt/doc changes with no executable code paths

## Files Changed

- `.agents/tools/deployment/daytona.md` — fixed REST API example, async Python wrapper, troubleshooting text

Closes #6754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated REST API endpoint paths and sandbox creation payload format with image-based configuration
  * Improved command timeout troubleshooting guidance

* **Examples**
  * Refactored Python async example for better structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->