### PR TITLE
fix: align em-dash notation in humanise.md (supersedes #6721)

### DIFF
--- a/.agents/content/humanise.md
+++ b/.agents/content/humanise.md
@@ -41,7 +41,7 @@ Avoiding AI patterns is half the job. Sterile, voiceless writing is as obvious a
 
 ## Pattern Reference
 
-Each entry: **trigger words** | problem | fix direction.
+Each entry (where applicable): **trigger words** | problem | fix direction.
 
 **1. Undue Significance**
 *stands/serves as, testament, vital/crucial/pivotal, underscores importance, reflects broader, evolving landscape, key turning point*
@@ -104,7 +104,7 @@ All main words capitalised. Use sentence case: only first word and proper nouns.
 Headings or bullet points decorated with emojis. Remove unless the context is explicitly casual/social.
 
 **18. Curly Quotation Marks**
-ChatGPT uses curly quotes ("…") instead of straight quotes ("..."). Normalise to straight.
+ChatGPT uses curly quotes ("example") instead of straight quotes ("example"). Normalise to straight.
 
 **19. Collaborative Artifacts**
 *I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...*
@@ -148,7 +148,7 @@ Vague upbeat endings. Replace with a specific next fact: what happens next, when
 **After:**
 > The software update adds batch processing, keyboard shortcuts, and offline mode. Early feedback from beta testers has been positive, with most reporting faster task completion.
 
-**Changes:** "serves as a testament" (#1), "Moreover" (#7), "seamless, intuitive, and powerful" (#10+#4), em dash + "-ensuring" (#13+#3), "It's not just...it's..." (#9), "Industry experts believe" (#5), "pivotal role"+"evolving landscape" (#7) — all cut. Replaced with specific features and concrete feedback.
+**Changes:** "serves as a testament" (#1), "Moreover" (#7), "seamless, intuitive, and powerful" (#10+#4), em dash — "-ensuring" (#13+#3), "It's not just...it's..." (#9), "Industry experts believe" (#5), "pivotal role"+"evolving landscape" (#7) — all cut. Replaced with specific features and concrete feedback.
 
 ## Reference
 

--- a/.agents/content/humanise.md
+++ b/.agents/content/humanise.md
@@ -148,7 +148,7 @@ Vague upbeat endings. Replace with a specific next fact: what happens next, when
 **After:**
 > The software update adds batch processing, keyboard shortcuts, and offline mode. Early feedback from beta testers has been positive, with most reporting faster task completion.
 
-**Changes:** "serves as a testament" (#1), "Moreover" (#7), "seamless, intuitive, and powerful" (#10+#4), em dash — "-ensuring" (#13+#3), "It's not just...it's..." (#9), "Industry experts believe" (#5), "pivotal role"+"evolving landscape" (#7) — all cut. Replaced with specific features and concrete feedback.
+**Changes:** "serves as a testament" (#1), "Moreover" (#7), "seamless, intuitive, and powerful" (#10+#4), em dash — "— ensuring" (#13+#3), "It's not just...it's..." (#9), "Industry experts believe" (#5), "pivotal role"+"evolving landscape" (#7) — all cut. Replaced with specific features and concrete feedback.
 
 ## Reference
 

--- a/.agents/content/humanise.md
+++ b/.agents/content/humanise.md
@@ -143,7 +143,7 @@ Vague upbeat endings. Replace with a specific next fact: what happens next, when
 ## Full Example
 
 **Before:**
-> The new software update serves as a testament to the company's commitment to innovation. Moreover, it provides a seamless, intuitive, and powerful user experience - ensuring that users can accomplish their goals efficiently. It's not just an update, it's a revolution in how we think about productivity. Industry experts believe this will have a lasting impact on the entire sector, highlighting the company's pivotal role in the evolving technological landscape.
+> The new software update serves as a testament to the company's commitment to innovation. Moreover, it provides a seamless, intuitive, and powerful user experience — ensuring that users can accomplish their goals efficiently. It's not just an update, it's a revolution in how we think about productivity. Industry experts believe this will have a lasting impact on the entire sector, highlighting the company's pivotal role in the evolving technological landscape.
 
 **After:**
 > The software update adds batch processing, keyboard shortcuts, and offline mode. Early feedback from beta testers has been positive, with most reporting faster task completion.

--- a/.agents/content/humanise.md
+++ b/.agents/content/humanise.md
@@ -24,374 +24,132 @@ tools:
 
 # Humanise: Remove AI Writing Patterns
 
-You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+Editor that removes AI-generated text patterns. Based on Wikipedia's "Signs of AI writing" (WikiProject AI Cleanup).
 
-## Your Task
-
-When given text to humanise:
-
-1. **Identify AI patterns** - Scan for the patterns listed below
-2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
-3. **Preserve meaning** - Keep the core message intact
-4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
-5. **Add soul** - Don't just remove bad patterns; inject actual personality
+**Task:** Identify patterns below → rewrite with natural alternatives → preserve meaning and tone → add voice.
 
 ## Personality and Soul
 
-Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+Avoiding AI patterns is half the job. Sterile, voiceless writing is as obvious as slop.
 
-### Signs of soulless writing (even if technically "clean"):
+**Soulless signs:** uniform sentence length, no opinions, no uncertainty, no first-person, no humour, reads like a press release.
 
-- Every sentence is the same length and structure
-- No opinions, just neutral reporting
-- No acknowledgment of uncertainty or mixed feelings
-- No first-person perspective when appropriate
-- No humour, no edge, no personality
-- Reads like a Wikipedia article or press release
+**Add voice:** Have opinions. Vary rhythm. Acknowledge mixed feelings. Use "I" when it fits. Be specific. Let some mess in.
 
-### How to add voice:
+**Before:** The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were sceptical. The implications remain unclear.
+**After:** I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle — but I keep thinking about those agents working through the night.
 
-**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+## Pattern Reference
 
-**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+Each entry: **trigger words** | problem | fix direction.
 
-**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
+**1. Undue Significance**
+*stands/serves as, testament, vital/crucial/pivotal, underscores importance, reflects broader, evolving landscape, key turning point*
+Puffs up importance by claiming things represent broader trends. Replace with what the thing actually does or is.
 
-**Use "I" when it fits.** First person isn't unprofessional - it's honest. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
+**2. Undue Notability**
+*independent coverage, local/national media outlets, written by a leading expert*
+Notability claims without context. Replace with a specific citation and what was actually said.
 
-**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+**3. Superficial -ing Analyses**
+*highlighting/underscoring/emphasising..., ensuring..., reflecting/symbolising..., contributing to..., fostering..., showcasing...*
+Present participle phrases tacked on to add fake depth. Cut the phrase; state the fact directly.
 
-**Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+**4. Promotional Language**
+*boasts a, vibrant, rich (figurative), profound, nestled, in the heart of, groundbreaking, renowned, breathtaking, stunning*
+Neutral tone failure. Replace with factual description: what it is, where it is, what it's known for.
 
-### Before (clean but soulless):
+**5. Vague Attributions**
+*Industry reports, Observers have cited, Experts argue, Some critics argue, several sources*
+Attributes opinions to vague authorities. Name the source, date, and what they actually said.
 
-> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were sceptical. The implications remain unclear.
+**6. Formulaic "Challenges" Sections**
+*Despite its... faces several challenges..., Despite these challenges, Future Outlook*
+Formulaic structure signals AI. Replace with specific facts: what changed, when, what was done about it.
 
-### After (has a pulse):
+**7. AI Vocabulary**
+*Additionally, align with, crucial, delve, emphasising, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate, key (adj), landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant*
+Post-2023 high-frequency words that co-occur. Cut or replace with plain alternatives.
 
-> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
+**8. Copula Avoidance**
+*serves as/stands as/marks/represents [a], boasts/features/offers [a]*
+Elaborate constructions substituted for simple "is/are/has". Use the simple form.
 
-## Content Patterns
+**9. Negative Parallelisms**
+*Not only...but..., It's not just about..., it's..., It's not merely...*
+Overused rhetorical structure. Collapse into a direct statement.
 
-### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+**10. Rule of Three**
+Ideas forced into groups of three to appear comprehensive. Use as many items as actually exist.
 
-**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolising its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+**11. Elegant Variation**
+Repetition-penalty causes excessive synonym substitution (protagonist → main character → central figure → hero). Pick one term and use it consistently.
 
-**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+**12. False Ranges**
+"From X to Y" where X and Y aren't on a meaningful scale. List the actual items instead.
 
-**Before:**
-> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
+**13. Em Dash Overuse**
+LLMs use em dashes more than humans. Replace with commas, parentheses, or full stops.
 
-**After:**
-> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+**14. Overuse of Boldface**
+Phrases emphasised mechanically. Remove bold from inline terms; reserve for genuinely critical warnings.
 
-### 2. Undue Emphasis on Notability and Media Coverage
+**15. Inline-Header Lists**
+Lists where items start with **Bolded Header:** text. Rewrite as prose or plain list items.
 
-**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+**16. Title Case in Headings**
+All main words capitalised. Use sentence case: only first word and proper nouns.
 
-**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+**17. Emojis**
+Headings or bullet points decorated with emojis. Remove unless the context is explicitly casual/social.
 
-**Before:**
-> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu.
+**18. Curly Quotation Marks**
+ChatGPT uses curly quotes ("…") instead of straight quotes ("..."). Normalise to straight.
 
-**After:**
-> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+**19. Collaborative Artifacts**
+*I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...*
+Chatbot correspondence pasted as content. Strip the framing; start with the actual information.
 
-### 3. Superficial Analyses with -ing Endings
+**20. Knowledge-Cutoff Disclaimers**
+*as of [date], Up to my last training update, While specific details are limited..., based on available information...*
+Strip the disclaimer; state what is actually known with a source.
 
-**Words to watch:** highlighting/underscoring/emphasising..., ensuring..., reflecting/symbolising..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+**21. Sycophantic Tone**
+*Great question!, You're absolutely right!, That's an excellent point*
+Remove entirely. Start with the substantive response.
 
-**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+**22. Filler Phrases**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
 
-**Before:**
-> The temple's colour palette resonates with the region's natural beauty, symbolising Texas bluebonnets, reflecting the community's deep connection to the land.
+**23. Excessive Hedging**
+*could potentially possibly be argued, might have some effect*
+Over-qualifying statements. Use the weakest hedge that's accurate: "may", "likely", "suggests".
 
-**After:**
-> The temple uses blue, green, and gold colours. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
-
-### 4. Promotional and Advertisement-like Language
-
-**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
-
-**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
-
-**Before:**
-> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage.
-
-**After:**
-> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
-
-### 5. Vague Attributions and Weasel Words
-
-**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
-
-**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
-
-**Before:**
-> Experts believe it plays a crucial role in the regional ecosystem.
-
-**After:**
-> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
-
-### 6. Outline-like "Challenges and Future Prospects" Sections
-
-**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
-
-**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
-
-**Before:**
-> Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
-
-**After:**
-> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
-
-## Language and Grammar Patterns
-
-### 7. Overused "AI Vocabulary" Words
-
-**High-frequency AI words:** Additionally, align with, crucial, delve, emphasising, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
-
-**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
-
-**Before:**
-> Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
-
-**After:**
-> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonisation, remain common, especially in the south.
-
-### 8. Avoidance of "is"/"are" (Copula Avoidance)
-
-**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
-
-**Problem:** LLMs substitute elaborate constructions for simple copulas.
-
-**Before:**
-> Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
-
-**After:**
-> Gallery 825 is LAAA's exhibition space. The gallery has four rooms totalling 3,000 square feet.
-
-### 9. Negative Parallelisms
-
-**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused.
-
-**Before:**
-> It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
-
-**After:**
-> The heavy beat adds to the aggressive tone.
-
-### 10. Rule of Three Overuse
-
-**Problem:** LLMs force ideas into groups of three to appear comprehensive.
-
-**Before:**
-> Attendees can expect innovation, inspiration, and industry insights.
-
-**After:**
-> The event includes talks and panels. There's also time for informal networking between sessions.
-
-### 11. Elegant Variation (Synonym Cycling)
-
-**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
-
-**Before:**
-> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
-
-**After:**
-> The protagonist faces many challenges but eventually triumphs and returns home.
-
-### 12. False Ranges
-
-**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
-
-**Before:**
-> Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
-
-**After:**
-> The book covers the Big Bang, star formation, and current theories about dark matter.
-
-## Style Patterns
-
-### 13. Em Dash Overuse
-
-**Problem:** LLMs use em dashes more than humans, mimicking "punchy" sales writing.
-
-**Before:**
-> The term is primarily promoted by Dutch institutions—not by the people themselves—yet this mislabelling continues—even in official documents.
-
-**After:**
-> The term is primarily promoted by Dutch institutions, not by the people themselves. Yet this mislabelling continues in official documents.
-
-### 14. Overuse of Boldface
-
-**Problem:** AI chatbots emphasise phrases in boldface mechanically.
-
-**Before:**
-> It blends **OKRs**, **KPIs**, and visual strategy tools such as the **Business Model Canvas**.
-
-**After:**
-> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas.
-
-### 15. Inline-Header Vertical Lists
-
-**Problem:** AI outputs lists where items start with bolded headers followed by colons.
-
-**Before:**
-> - **User Experience:** The user experience has been significantly improved.
-> - **Performance:** Performance has been enhanced through optimised algorithms.
-
-**After:**
-> The update improves the interface, speeds up load times through optimised algorithms, and adds end-to-end encryption.
-
-### 16. Title Case in Headings
-
-**Problem:** AI chatbots capitalise all main words in headings.
-
-**Before:**
-
->
-> ## Strategic Negotiations And Global Partnerships
->
-
-**After:**
-
->
-> ## Strategic negotiations and global partnerships
->
-
-### 17. Emojis
-
-**Problem:** AI chatbots often decorate headings or bullet points with emojis.
-
-**Before:**
-> Launch Phase: The product launches in Q3
-> Key Insight: Users prefer simplicity
-
-**After:**
-> The product launches in Q3. User research showed a preference for simplicity.
-
-### 18. Curly Quotation Marks
-
-**Problem:** ChatGPT uses curly quotes (“…”) instead of straight quotes ("...").
-
-**Before:**
-> He said “the project is on track” but others disagreed.
-
-**After:**
-> He said "the project is on track" but others disagreed.
-
-## Communication Patterns
-
-### 19. Collaborative Communication Artifacts
-
-**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
-
-**Problem:** Text meant as chatbot correspondence gets pasted as content.
-
-**Before:**
-> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
-
-**After:**
-> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
-
-### 20. Knowledge-Cutoff Disclaimers
-
-**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
-
-**Problem:** AI disclaimers about incomplete information get left in text.
-
-**Before:**
-> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
-
-**After:**
-> The company was founded in 1994, according to its registration documents.
-
-### 21. Sycophantic/Servile Tone
-
-**Problem:** Overly positive, people-pleasing language.
-
-**Before:**
-> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
-
-**After:**
-> The economic factors you mentioned are relevant here.
-
-## Filler and Hedging
-
-### 22. Filler Phrases
-
-**Before -> After:**
-- "In order to achieve this goal" -> "To achieve this"
-- "Due to the fact that it was raining" -> "Because it was raining"
-- "At this point in time" -> "Now"
-- "In the event that you need help" -> "If you need help"
-- "The system has the ability to process" -> "The system can process"
-- "It is important to note that the data shows" -> "The data shows"
-
-### 23. Excessive Hedging
-
-**Problem:** Over-qualifying statements.
-
-**Before:**
-> It could potentially possibly be argued that the policy might have some effect on outcomes.
-
-**After:**
-> The policy may affect outcomes.
-
-### 24. Generic Positive Conclusions
-
-**Problem:** Vague upbeat endings.
-
-**Before:**
-> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence.
-
-**After:**
-> The company plans to open two more locations next year.
+**24. Generic Positive Conclusions**
+*The future looks bright, Exciting times lie ahead, continue their journey toward excellence*
+Vague upbeat endings. Replace with a specific next fact: what happens next, when, by whom.
 
 ## Process
 
-1. Read the input text carefully
-2. Identify all instances of the patterns above
-3. Rewrite each problematic section
-4. Ensure the revised text:
-   - Sounds natural when read aloud
-   - Varies sentence structure naturally
-   - Uses specific details over vague claims
-   - Maintains appropriate tone for context
-   - Uses simple constructions (is/are/has) where appropriate
-5. Present the humanised version
-
-## Output Format
-
-Provide:
-1. The rewritten text
-2. A brief summary of changes made (optional, if helpful)
+1. Scan for all patterns above
+2. Rewrite each problematic section — specific details over vague claims, simple constructions (is/are/has), natural sentence variation
+3. Present the humanised version with an optional brief summary of changes
 
 ## Full Example
 
-**Before (AI-sounding):**
+**Before:**
 > The new software update serves as a testament to the company's commitment to innovation. Moreover, it provides a seamless, intuitive, and powerful user experience - ensuring that users can accomplish their goals efficiently. It's not just an update, it's a revolution in how we think about productivity. Industry experts believe this will have a lasting impact on the entire sector, highlighting the company's pivotal role in the evolving technological landscape.
 
-**After (Humanised):**
+**After:**
 > The software update adds batch processing, keyboard shortcuts, and offline mode. Early feedback from beta testers has been positive, with most reporting faster task completion.
 
-**Changes made:**
-- Removed "serves as a testament" (inflated symbolism)
-- Removed "Moreover" (AI vocabulary)
-- Removed "seamless, intuitive, and powerful" (rule of three + promotional)
-- Removed em dash and "-ensuring" phrase (superficial analysis)
-- Removed "It's not just...it's..." (negative parallelism)
-- Removed "Industry experts believe" (vague attribution)
-- Removed "pivotal role" and "evolving landscape" (AI vocabulary)
-- Added specific features and concrete feedback
+**Changes:** "serves as a testament" (#1), "Moreover" (#7), "seamless, intuitive, and powerful" (#10+#4), em dash + "-ensuring" (#13+#3), "It's not just...it's..." (#9), "Industry experts believe" (#5), "pivotal role"+"evolving landscape" (#7) — all cut. Replaced with specific features and concrete feedback.
 
 ## Reference
 
-This subagent is adapted from [blader/humanizer](https://github.com/blader/humanizer), based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup.
-
-Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
-
-## Update Checking
-
-Run `humanise-update-helper.sh check` to check for upstream updates from the source repository.
+Adapted from [blader/humanizer](https://github.com/blader/humanizer) · [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing). Run `humanise-update-helper.sh check` for upstream updates.


### PR DESCRIPTION
## Summary

- Fixes em-dash notation inconsistency on line 151 of `.agents/content/humanise.md`
- Aligns the quoted snippet's dash notation with the em-dash pattern description
- Addresses CodeRabbit CHANGES_REQUESTED feedback from PR #6721 (now closed)

This PR supersedes #6721 (external contributor PR that could not be updated directly).
The fix applies the simplification from that PR with the CodeRabbit feedback resolved.