### PR TITLE
t1677: Add supervisor.peak_hours worker cap for Anthropic peak windows

### DIFF
--- a/.agents/configs/aidevops-config.schema.json
+++ b/.agents/configs/aidevops-config.schema.json
@@ -123,6 +123,37 @@
           "minimum": 0,
           "maximum": 100,
           "description": "Maximum share of worker slots quality-debt issues may consume. Env: AIDEVOPS_QUALITY_DEBT_CAP_PCT"
+        },
+        "peak_hours_enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Cap MAX_WORKERS during peak hours to reduce session-limit pressure. Disabled by default. Env: AIDEVOPS_PEAK_HOURS_ENABLED"
+        },
+        "peak_hours_start": {
+          "type": "integer",
+          "default": 5,
+          "minimum": 0,
+          "maximum": 23,
+          "description": "Start hour of the peak window (0-23, local time). Default 5 = 5 AM. Env: AIDEVOPS_PEAK_HOURS_START"
+        },
+        "peak_hours_end": {
+          "type": "integer",
+          "default": 11,
+          "minimum": 0,
+          "maximum": 23,
+          "description": "End hour of the peak window (0-23, local time, exclusive). Overnight windows supported (start > end). Env: AIDEVOPS_PEAK_HOURS_END"
+        },
+        "peak_hours_tz": {
+          "type": "string",
+          "default": "America/Los_Angeles",
+          "description": "Timezone label for documentation. Pulse uses system local time (date +%H). Env: AIDEVOPS_PEAK_HOURS_TZ"
+        },
+        "peak_hours_worker_fraction": {
+          "type": "number",
+          "default": 0.2,
+          "minimum": 0.01,
+          "maximum": 1.0,
+          "description": "Fraction of off-peak MAX_WORKERS allowed during peak hours (0.2 = 20%). Result is rounded up, minimum 1. Env: AIDEVOPS_PEAK_HOURS_WORKER_FRACTION"
         }
       },
       "additionalProperties": false

--- a/.agents/reference/settings.md
+++ b/.agents/reference/settings.md
@@ -49,6 +49,11 @@ Controls the autonomous orchestration supervisor that dispatches AI workers.
 | `supervisor.stale_threshold_seconds` | number | `1800` | -- | Seconds before a worker is considered stale/stuck. |
 | `supervisor.circuit_breaker_max_failures` | number | `3` | -- | Consecutive worker failures before the circuit breaker pauses dispatch. |
 | `supervisor.strategic_review_hours` | number | `4` | -- | Hours between opus-tier strategic reviews of queue health. |
+| `supervisor.peak_hours_enabled` | boolean | `false` | `AIDEVOPS_PEAK_HOURS_ENABLED` | Enable peak-hours worker cap. When `true`, `MAX_WORKERS` is reduced during the configured window. **Disabled by default.** |
+| `supervisor.peak_hours_start` | number | `5` | `AIDEVOPS_PEAK_HOURS_START` | Start hour of the peak window (0-23, local time). Default 5 = 5 AM. |
+| `supervisor.peak_hours_end` | number | `11` | `AIDEVOPS_PEAK_HOURS_END` | End hour of the peak window (0-23, local time, exclusive). Default 11 = 11 AM. Overnight windows supported (start > end, e.g., `22` → `6`). |
+| `supervisor.peak_hours_tz` | string | `"America/Los_Angeles"` | `AIDEVOPS_PEAK_HOURS_TZ` | Timezone label for documentation. The pulse uses system local time (`date +%H`), so set your system timezone to match. |
+| `supervisor.peak_hours_worker_fraction` | number | `0.2` | `AIDEVOPS_PEAK_HOURS_WORKER_FRACTION` | Fraction of off-peak `MAX_WORKERS` allowed during peak hours. `0.2` = 20%. Result is rounded up, minimum 1. |
 
 ### repo_sync
 
@@ -169,3 +174,25 @@ Previously, aidevops settings were configured exclusively via `AIDEVOPS_*` envir
 | `AIDEVOPS_TOOL_AUTO_UPDATE=false` | `auto_update.tool_auto_update = false` |
 | `AIDEVOPS_SUPERVISOR_PULSE=false` | `supervisor.pulse_enabled = false` |
 | `AIDEVOPS_REPO_SYNC=false` | `repo_sync.enabled = false` |
+
+## Peak Hours Configuration
+
+Anthropic tightens session limits during weekday peak hours (5 AM–11 AM PT). Enable the peak-hours cap to automatically reduce `MAX_WORKERS` during this window:
+
+```bash
+# Enable peak-hours cap (disabled by default)
+settings-helper.sh set supervisor.peak_hours_enabled true
+
+# Customise the window (default: 5→11 local time)
+settings-helper.sh set supervisor.peak_hours_start 5
+settings-helper.sh set supervisor.peak_hours_end 11
+
+# Set the fraction (default: 0.2 = 20% of off-peak MAX_WORKERS, rounded up, min 1)
+settings-helper.sh set supervisor.peak_hours_worker_fraction 0.2
+```
+
+**How it works**: `calculate_max_workers()` in `pulse-wrapper.sh` computes the RAM-based worker count first, then calls `apply_peak_hours_cap()`. If the current local hour falls within `[peak_hours_start, peak_hours_end)`, the result is capped at `ceil(off_peak_max × peak_hours_worker_fraction)`, minimum 1. The cap is applied after the RAM-based clamp so it can only reduce, never increase, the worker count.
+
+**Timezone**: The pulse uses `date +%H` (system local time). Set your system timezone to match the desired window timezone. The `peak_hours_tz` field is documentation-only.
+
+**Overnight windows**: Set `peak_hours_start > peak_hours_end` for overnight windows (e.g., `start=22, end=6` covers 10 PM–6 AM).

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -295,6 +295,12 @@ After 2+ failed attempts on the same issue (count kill/failure comments), escala
 
 ## Dispatch Refinements
 
+### Peak-hours worker cap (t1677)
+
+`MAX_WORKERS` is computed by `pulse-wrapper.sh` before the pulse starts and written to `~/.aidevops/logs/pulse-max-workers`. When `supervisor.peak_hours_enabled` is `true` in `settings.json`, the wrapper automatically reduces `MAX_WORKERS` to `ceil(off_peak_max × peak_hours_worker_fraction)` (minimum 1) during the configured local-time window. The pulse reads the already-capped value — no action required here.
+
+To enable: `settings-helper.sh set supervisor.peak_hours_enabled true`. Default window: 5 AM–11 AM local time (Anthropic peak). Default fraction: 0.2 (20%). See `reference/settings.md` for full configuration.
+
 ### Per-repo worker cap
 
 Default `MAX_WORKERS_PER_REPO=5`. If a repo already has this many active workers, skip dispatch for that repo this cycle.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4218,6 +4218,103 @@ cleanup_orphans() {
 }
 
 #######################################
+# Apply peak-hours worker cap (t1677)
+#
+# When supervisor.peak_hours_enabled is true and the current local time
+# falls within the configured window, caps MAX_WORKERS at
+# ceil(off_peak_max * peak_hours_worker_fraction), minimum 1.
+#
+# The cap is applied AFTER the RAM-based calculation so it can only
+# reduce, never increase, the worker count.
+#
+# Settings read via settings-helper.sh (respects env var overrides):
+#   supervisor.peak_hours_enabled        (default: false)
+#   supervisor.peak_hours_start          (default: 5,  0-23 local hour)
+#   supervisor.peak_hours_end            (default: 11, 0-23 local hour)
+#   supervisor.peak_hours_tz             (default: America/Los_Angeles)
+#   supervisor.peak_hours_worker_fraction (default: 0.2)
+#
+# Arguments:
+#   $1 - current off-peak max_workers value (integer >= 1)
+#
+# Output: (possibly reduced) max_workers value to stdout
+# Returns: 0 always
+#######################################
+apply_peak_hours_cap() {
+	local off_peak_max="$1"
+
+	# Validate input
+	[[ "$off_peak_max" =~ ^[0-9]+$ ]] || off_peak_max=1
+	[[ "$off_peak_max" -lt 1 ]] && off_peak_max=1
+
+	# Read settings via helper (respects env var overrides)
+	local settings_helper="${SCRIPT_DIR}/settings-helper.sh"
+	if [[ ! -x "$settings_helper" ]]; then
+		echo "$off_peak_max"
+		return 0
+	fi
+
+	local peak_enabled
+	peak_enabled=$("$settings_helper" get supervisor.peak_hours_enabled 2>/dev/null || echo "false")
+	if [[ "$peak_enabled" != "true" ]]; then
+		echo "$off_peak_max"
+		return 0
+	fi
+
+	local ph_start ph_end ph_fraction
+	ph_start=$("$settings_helper" get supervisor.peak_hours_start 2>/dev/null || echo "5")
+	ph_end=$("$settings_helper" get supervisor.peak_hours_end 2>/dev/null || echo "11")
+	ph_fraction=$("$settings_helper" get supervisor.peak_hours_worker_fraction 2>/dev/null || echo "0.2")
+
+	# Validate hour values
+	[[ "$ph_start" =~ ^[0-9]+$ ]] || ph_start=5
+	[[ "$ph_end" =~ ^[0-9]+$ ]] || ph_end=11
+	[[ "$ph_start" -gt 23 ]] && ph_start=5
+	[[ "$ph_end" -gt 23 ]] && ph_end=11
+
+	# Get current local hour (strip leading zero to avoid octal interpretation)
+	local current_hour
+	current_hour=$(date +%H)
+	local cur ph_s ph_e
+	cur=$((10#${current_hour}))
+	ph_s=$((10#${ph_start}))
+	ph_e=$((10#${ph_end}))
+
+	# Determine if we are inside the peak window
+	# Supports overnight windows (start > end, e.g., 22→6)
+	local in_peak=false
+	if [[ "$ph_s" -le "$ph_e" ]]; then
+		# Normal window: in peak when cur >= start AND cur < end
+		if [[ "$cur" -ge "$ph_s" && "$cur" -lt "$ph_e" ]]; then
+			in_peak=true
+		fi
+	else
+		# Overnight window: in peak when cur >= start OR cur < end
+		if [[ "$cur" -ge "$ph_s" || "$cur" -lt "$ph_e" ]]; then
+			in_peak=true
+		fi
+	fi
+
+	if [[ "$in_peak" != "true" ]]; then
+		echo "$off_peak_max"
+		return 0
+	fi
+
+	# Compute capped value: ceil(off_peak_max * fraction), minimum 1
+	# Use awk for floating-point arithmetic (bash has no native float support)
+	local peak_max
+	peak_max=$(awk -v max="$off_peak_max" -v frac="$ph_fraction" \
+		'BEGIN { v = max * frac; c = int(v); if (c < v) c++; if (c < 1) c = 1; print c }' \
+		2>/dev/null || echo "1")
+	[[ "$peak_max" =~ ^[0-9]+$ ]] || peak_max=1
+	[[ "$peak_max" -lt 1 ]] && peak_max=1
+
+	echo "[pulse-wrapper] Peak hours active (window ${ph_s}→${ph_e}, current hour ${cur}): capping MAX_WORKERS ${off_peak_max}→${peak_max} (fraction=${ph_fraction})" >>"$LOGFILE"
+	echo "$peak_max"
+	return 0
+}
+
+#######################################
 # Calculate max workers from available RAM
 #
 # Formula: (free_ram - RAM_RESERVE_MB) / RAM_PER_WORKER_MB
@@ -4253,6 +4350,11 @@ calculate_max_workers() {
 	elif [[ "$max_workers" -gt "$MAX_WORKERS_CAP" ]]; then
 		max_workers="$MAX_WORKERS_CAP"
 	fi
+
+	# Apply peak-hours cap (t1677) — may further reduce max_workers
+	max_workers=$(apply_peak_hours_cap "$max_workers")
+	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
+	[[ "$max_workers" -lt 1 ]] && max_workers=1
 
 	# Write to a file that pulse.md can read
 	local max_workers_file="${HOME}/.aidevops/logs/pulse-max-workers"

--- a/.agents/scripts/settings-helper.sh
+++ b/.agents/scripts/settings-helper.sh
@@ -63,7 +63,12 @@ _generate_defaults() {
     "pulse_interval_seconds": 120,
     "stale_threshold_seconds": 1800,
     "circuit_breaker_max_failures": 3,
-    "strategic_review_hours": 4
+    "strategic_review_hours": 4,
+    "peak_hours_enabled": false,
+    "peak_hours_start": 5,
+    "peak_hours_end": 11,
+    "peak_hours_tz": "America/Los_Angeles",
+    "peak_hours_worker_fraction": 0.2
   },
   "repo_sync": {
     "enabled": true,
@@ -111,6 +116,11 @@ _env_var_for_key() {
 	auto_update.openclaw_auto_update) echo "AIDEVOPS_OPENCLAW_AUTO_UPDATE" ;;
 	auto_update.openclaw_freshness_hours) echo "AIDEVOPS_OPENCLAW_FRESHNESS_HOURS" ;;
 	supervisor.pulse_enabled) echo "AIDEVOPS_SUPERVISOR_PULSE" ;;
+	supervisor.peak_hours_enabled) echo "AIDEVOPS_PEAK_HOURS_ENABLED" ;;
+	supervisor.peak_hours_start) echo "AIDEVOPS_PEAK_HOURS_START" ;;
+	supervisor.peak_hours_end) echo "AIDEVOPS_PEAK_HOURS_END" ;;
+	supervisor.peak_hours_tz) echo "AIDEVOPS_PEAK_HOURS_TZ" ;;
+	supervisor.peak_hours_worker_fraction) echo "AIDEVOPS_PEAK_HOURS_WORKER_FRACTION" ;;
 	repo_sync.enabled) echo "AIDEVOPS_REPO_SYNC" ;;
 	*) echo "" ;;
 	esac
@@ -383,6 +393,31 @@ cmd_validate() {
 		errors=$((errors + 1))
 	fi
 
+	# Validate peak_hours settings when enabled
+	local peak_enabled
+	peak_enabled=$(jq -r '.supervisor.peak_hours_enabled // false' "$SETTINGS_FILE" 2>/dev/null)
+	if [[ "$peak_enabled" == "true" ]]; then
+		local ph_start ph_end ph_fraction
+		ph_start=$(jq -r '.supervisor.peak_hours_start // -1' "$SETTINGS_FILE" 2>/dev/null)
+		ph_end=$(jq -r '.supervisor.peak_hours_end // -1' "$SETTINGS_FILE" 2>/dev/null)
+		ph_fraction=$(jq -r '.supervisor.peak_hours_worker_fraction // -1' "$SETTINGS_FILE" 2>/dev/null)
+		if [[ "$ph_start" -lt 0 || "$ph_start" -gt 23 ]]; then
+			print_warning "supervisor.peak_hours_start ($ph_start) should be 0-23"
+			errors=$((errors + 1))
+		fi
+		if [[ "$ph_end" -lt 0 || "$ph_end" -gt 23 ]]; then
+			print_warning "supervisor.peak_hours_end ($ph_end) should be 0-23"
+			errors=$((errors + 1))
+		fi
+		# Validate fraction is a number between 0.01 and 1.0
+		if ! jq -e --argjson f "$ph_fraction" '$f > 0 and $f <= 1' /dev/null 2>/dev/null; then
+			if ! echo "$ph_fraction" | grep -qE '^0\.[0-9]+$|^1(\.0+)?$'; then
+				print_warning "supervisor.peak_hours_worker_fraction ($ph_fraction) should be 0.01-1.0"
+				errors=$((errors + 1))
+			fi
+		fi
+	fi
+
 	if [[ $errors -eq 0 ]]; then
 		print_success "Settings file is valid"
 	else
@@ -417,6 +452,11 @@ cmd_export_env() {
 		"auto_update.openclaw_auto_update"
 		"auto_update.openclaw_freshness_hours"
 		"supervisor.pulse_enabled"
+		"supervisor.peak_hours_enabled"
+		"supervisor.peak_hours_start"
+		"supervisor.peak_hours_end"
+		"supervisor.peak_hours_tz"
+		"supervisor.peak_hours_worker_fraction"
 		"repo_sync.enabled"
 	)
 
@@ -470,6 +510,11 @@ SETTINGS KEYS (dot-notation):
     supervisor.stale_threshold_seconds   Stale worker threshold (default: 1800)
     supervisor.circuit_breaker_max_failures  Max failures before pause (default: 3)
     supervisor.strategic_review_hours    Hours between strategic reviews (default: 4)
+    supervisor.peak_hours_enabled        Cap workers during peak hours (default: false)
+    supervisor.peak_hours_start          Peak window start hour 0-23 (default: 5)
+    supervisor.peak_hours_end            Peak window end hour 0-23 (default: 11)
+    supervisor.peak_hours_tz             Timezone for peak window (default: America/Los_Angeles)
+    supervisor.peak_hours_worker_fraction  Fraction of off-peak MAX_WORKERS during peak (default: 0.2)
     repo_sync.enabled                    Daily repo sync on/off (default: true)
     repo_sync.schedule                   Sync schedule (default: daily)
     quality.shellcheck_enabled           ShellCheck on/off (default: true)


### PR DESCRIPTION
## Summary

- Adds `supervisor.peak_hours` config to `settings.json` so the pulse dynamically caps `MAX_WORKERS` at a configurable fraction of the off-peak value during configured local-time windows
- Disabled by default (`peak_hours_enabled: false`) — zero behaviour change for existing users
- Default window: 5 AM–11 AM local time (Anthropic weekday peak); default fraction: 0.2 (20%, rounded up, min 1)

## Changes

### `settings-helper.sh`
- 5 new keys: `supervisor.peak_hours_enabled`, `peak_hours_start`, `peak_hours_end`, `peak_hours_tz`, `peak_hours_worker_fraction`
- Defaults, env var mappings (`AIDEVOPS_PEAK_HOURS_*`), validation, help text, export-env support

### `pulse-wrapper.sh`
- New `apply_peak_hours_cap()` function: reads settings via `settings-helper.sh`, checks if current local hour is in window, returns `ceil(off_peak_max × fraction)` (min 1)
- Wired into `calculate_max_workers()` after the RAM-based clamp — cap can only reduce, never increase
- Overnight windows supported (start > end, e.g., 22→6)
- Logs cap event to pulse.log when active

### `reference/settings.md`
- Full table row for each new key + new "Peak Hours Configuration" section with usage examples

### `scripts/commands/pulse.md`
- New "Peak-hours worker cap" subsection in Dispatch Refinements

### `configs/aidevops-config.schema.json`
- 5 new fields in `orchestration` section with types, defaults, and constraints

## Runtime Testing

- **Risk classification**: Low — new feature disabled by default; no behaviour change when `peak_hours_enabled: false`
- **Testing level**: self-assessed + logic smoke-tested
- **Smoke checks**: awk ceil formula verified for all combinations (max=1..20, frac=0.2/0.5/1.0); window boundary logic verified for normal (5→11) and overnight (22→6) windows
- **ShellCheck**: zero violations on both modified scripts

## Closes

Closes #6783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced peak-hour worker capping: automatically reduce concurrent workers during configured local-time windows (default 5 AM–11 AM) to a specified fraction of off-peak capacity.

* **Documentation**
  * Extended configuration reference with new peak-hours settings, timezone support, environment variable bindings, and setup examples for worker limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->