### PR TITLE
fix: platform-aware brew updates and PEP 668-safe pip installs in tool-version-check.sh

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -86,7 +86,10 @@ _brew_pkg_upgrade_cmd() {
 	local sys_pkg="${2:-$1}"
 	# Emit a self-contained shell snippet that detects the package manager at
 	# update time (not at script load time) so the string stays portable.
-	printf 'if command -v brew >/dev/null 2>&1; then brew upgrade %s; elif command -v apt-get >/dev/null 2>&1; then sudo apt-get install -y --only-upgrade %s; elif command -v dnf >/dev/null 2>&1; then sudo dnf upgrade -y %s; else echo "No supported package manager found (brew/apt-get/dnf)" >&2; exit 1; fi' \
+	# sudo -n is used for apt/dnf paths: if sudo requires a password (non-TTY
+	# or container context), we emit a clear message instead of hanging on a
+	# password prompt or burning the 120s update timeout.
+	printf 'if command -v brew >/dev/null 2>&1; then brew upgrade %s; elif command -v apt-get >/dev/null 2>&1; then if sudo -n true 2>/dev/null; then sudo apt-get install -y --only-upgrade %s; else echo "sudo requires a password — rerun with elevated privileges or as root" >&2; exit 1; fi; elif command -v dnf >/dev/null 2>&1; then if sudo -n true 2>/dev/null; then sudo dnf upgrade -y %s; else echo "sudo requires a password — rerun with elevated privileges or as root" >&2; exit 1; fi; else echo "No supported package manager found (brew/apt-get/dnf)" >&2; exit 1; fi' \
 		"$brew_pkg" "$sys_pkg" "$sys_pkg"
 }
 
@@ -121,9 +124,9 @@ BREW_TOOLS=(
 )
 
 PIP_TOOLS=(
-	"pip|Beads Viewer|beads_viewer|--version|beads-viewer|pip install --user --upgrade beads-viewer"
-	"pip|DSPy|dspy|--version|dspy-ai|pip install --user --upgrade dspy-ai"
-	"pip|Crawl4AI|crawl4ai|--version|crawl4ai|pip install --user --upgrade crawl4ai"
+	"pip|Beads Viewer|beads_viewer|--version|beads-viewer|if command -v pipx >/dev/null 2>&1; then pipx install beads-viewer --force; elif command -v uv >/dev/null 2>&1; then uv tool install beads-viewer --force; else echo 'Install pipx or uv to upgrade beads-viewer on externally-managed Python' >&2; exit 1; fi"
+	"pip|DSPy|dspy|--version|dspy-ai|if command -v pipx >/dev/null 2>&1; then pipx install dspy-ai --force; elif command -v uv >/dev/null 2>&1; then uv tool install dspy-ai --force; else echo 'Install pipx or uv to upgrade dspy-ai on externally-managed Python' >&2; exit 1; fi"
+	"pip|Crawl4AI|crawl4ai|--version|crawl4ai|if command -v pipx >/dev/null 2>&1; then pipx install crawl4ai --force; elif command -v uv >/dev/null 2>&1; then uv tool install crawl4ai --force; else echo 'Install pipx or uv to upgrade crawl4ai on externally-managed Python' >&2; exit 1; fi"
 	"pip|Analytics MCP|analytics-mcp|--version|analytics-mcp|pipx upgrade analytics-mcp"
 	"pip|Outscraper MCP|outscraper-mcp-server|--version|outscraper-mcp-server|uv tool upgrade outscraper-mcp-server"
 )
@@ -292,17 +295,40 @@ get_npm_latest() {
 	return 0
 }
 
-# Get latest brew version
+# Map brew formula names to GitHub owner/repo for non-brew latest-version lookup.
+# Returns empty string if no mapping is known.
+_brew_pkg_github_repo() {
+	local pkg="$1"
+	case "$pkg" in
+	gh) echo "cli/cli" ;;
+	glab) echo "gitlab-org/cli" ;;
+	max-sixty/worktrunk/wt) echo "max-sixty/worktrunk" ;;
+	jq) echo "jqlang/jq" ;;
+	shellcheck) echo "koalaman/shellcheck" ;;
+	*) echo "" ;;
+	esac
+	return 0
+}
+
+# Get latest brew version.
+# On brew hosts: query brew info (works for all formulae including taps).
+# On non-brew hosts: fall back to GitHub Releases API for known packages.
+# Returns "unknown" if neither path resolves a version.
 get_brew_latest() {
 	local pkg="$1"
 	local brew_bin=""
 	brew_bin=$(command -v brew 2>/dev/null || true)
 	if [[ -n "$brew_bin" && -x "$brew_bin" ]]; then
 		timeout_sec "$PKG_QUERY_TIMEOUT" "$brew_bin" info "$pkg" 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"
-	elif [[ "$pkg" == "gh" ]]; then
-		get_public_release_tag "cli/cli"
 	else
-		echo "unknown"
+		# Non-brew host: resolve via GitHub Releases API for known packages.
+		local gh_repo
+		gh_repo=$(_brew_pkg_github_repo "$pkg")
+		if [[ -n "$gh_repo" ]]; then
+			get_public_release_tag "$gh_repo"
+		else
+			echo "unknown"
+		fi
 	fi
 	return 0
 }
@@ -467,7 +493,10 @@ _check_all_categories() {
 		if [[ ${#NPM_TOOLS[@]} -gt 0 ]]; then
 			check_category "NPM" "${NPM_TOOLS[@]}"
 		fi
-		if command -v brew &>/dev/null && [[ ${#BREW_TOOLS[@]} -gt 0 ]]; then
+		# Run brew-category tools on all platforms: brew hosts use brew upgrade,
+		# apt/dnf hosts use the distro-aware commands in _brew_pkg_upgrade_cmd,
+		# and get_brew_latest falls back to GitHub Releases API on non-brew hosts.
+		if [[ ${#BREW_TOOLS[@]} -gt 0 ]]; then
 			check_category "Homebrew" "${BREW_TOOLS[@]}"
 		fi
 		if command -v pip &>/dev/null && [[ ${#PIP_TOOLS[@]} -gt 0 ]]; then

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -72,6 +72,24 @@ done
 # shellcheck disable=SC2016  # Single quotes intentional: string is a bash -c payload, must not expand at assignment time
 _oc_upgrade_cmd='if r=$(command -v opencode 2>/dev/null); [[ "$r" == *bun* ]]; then bun install -g opencode-ai@latest; else npm install -g opencode-ai@latest; fi'
 
+# Build a platform-aware upgrade command for a brew-category package.
+# On macOS (or any system with brew): brew upgrade <pkg>
+# On Debian/Ubuntu (apt): sudo apt-get install -y --only-upgrade <pkg>
+# On Fedora/RHEL (dnf): sudo dnf upgrade -y <pkg>
+# Falls back to brew upgrade if no system package manager is detected.
+# The returned string is executed via `bash -c` so it must be self-contained.
+# $1 = brew formula name (used for brew upgrade)
+# $2 = apt/dnf package name (may differ, e.g. "gh" vs "gh" — usually the same)
+# shellcheck disable=SC2016  # Single quotes intentional: bash -c payload
+_brew_pkg_upgrade_cmd() {
+	local brew_pkg="$1"
+	local sys_pkg="${2:-$1}"
+	# Emit a self-contained shell snippet that detects the package manager at
+	# update time (not at script load time) so the string stays portable.
+	printf 'if command -v brew >/dev/null 2>&1; then brew upgrade %s; elif command -v apt-get >/dev/null 2>&1; then sudo apt-get install -y --only-upgrade %s; elif command -v dnf >/dev/null 2>&1; then sudo dnf upgrade -y %s; else echo "No supported package manager found (brew/apt-get/dnf)" >&2; exit 1; fi' \
+		"$brew_pkg" "$sys_pkg" "$sys_pkg"
+}
+
 # Tool definitions
 # Format: category|display_name|cli_command|version_flag|package_name|update_command
 
@@ -94,18 +112,18 @@ NPM_TOOLS=(
 )
 
 BREW_TOOLS=(
-	"brew|GitHub CLI|gh|--version|gh|brew upgrade gh"
-	"brew|GitLab CLI|glab|--version|glab|brew upgrade glab"
-	"brew|Worktrunk|wt|--version|max-sixty/worktrunk/wt|brew upgrade max-sixty/worktrunk/wt"
-	"brew|Beads CLI|bd|version|steveyegge/beads/bd|brew upgrade steveyegge/beads/bd"
-	"brew|jq|jq|--version|jq|brew upgrade jq"
-	"brew|ShellCheck|shellcheck|--version|shellcheck|brew upgrade shellcheck"
+	"brew|GitHub CLI|gh|--version|gh|$(_brew_pkg_upgrade_cmd gh gh)"
+	"brew|GitLab CLI|glab|--version|glab|$(_brew_pkg_upgrade_cmd glab glab)"
+	"brew|Worktrunk|wt|--version|max-sixty/worktrunk/wt|$(_brew_pkg_upgrade_cmd max-sixty/worktrunk/wt wt)"
+	"brew|Beads CLI|bd|version|steveyegge/beads/bd|$(_brew_pkg_upgrade_cmd steveyegge/beads/bd bd)"
+	"brew|jq|jq|--version|jq|$(_brew_pkg_upgrade_cmd jq jq)"
+	"brew|ShellCheck|shellcheck|--version|shellcheck|$(_brew_pkg_upgrade_cmd shellcheck shellcheck)"
 )
 
 PIP_TOOLS=(
-	"pip|Beads Viewer|beads_viewer|--version|beads-viewer|pip install --upgrade beads-viewer"
-	"pip|DSPy|dspy|--version|dspy-ai|pip install --upgrade dspy-ai"
-	"pip|Crawl4AI|crawl4ai|--version|crawl4ai|pip install --upgrade crawl4ai"
+	"pip|Beads Viewer|beads_viewer|--version|beads-viewer|pip install --user --upgrade beads-viewer"
+	"pip|DSPy|dspy|--version|dspy-ai|pip install --user --upgrade dspy-ai"
+	"pip|Crawl4AI|crawl4ai|--version|crawl4ai|pip install --user --upgrade crawl4ai"
 	"pip|Analytics MCP|analytics-mcp|--version|analytics-mcp|pipx upgrade analytics-mcp"
 	"pip|Outscraper MCP|outscraper-mcp-server|--version|outscraper-mcp-server|uv tool upgrade outscraper-mcp-server"
 )

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -89,8 +89,29 @@ _brew_pkg_upgrade_cmd() {
 	# sudo -n is used for apt/dnf paths: if sudo requires a password (non-TTY
 	# or container context), we emit a clear message instead of hanging on a
 	# password prompt or burning the 120s update timeout.
-	printf 'if command -v brew >/dev/null 2>&1; then brew upgrade %s; elif command -v apt-get >/dev/null 2>&1; then if sudo -n true 2>/dev/null; then sudo apt-get install -y --only-upgrade %s; else echo "sudo requires a password — rerun with elevated privileges or as root" >&2; exit 1; fi; elif command -v dnf >/dev/null 2>&1; then if sudo -n true 2>/dev/null; then sudo dnf upgrade -y %s; else echo "sudo requires a password — rerun with elevated privileges or as root" >&2; exit 1; fi; else echo "No supported package manager found (brew/apt-get/dnf)" >&2; exit 1; fi' \
-		"$brew_pkg" "$sys_pkg" "$sys_pkg"
+	local _sudo_check='if sudo -n true 2>/dev/null; then'
+	local _sudo_fail='else echo "sudo requires a password — rerun with elevated privileges or as root" >&2; exit 1; fi'
+	local _no_pm='echo "No supported package manager found (brew/apt-get/dnf)" >&2; exit 1'
+	printf 'if command -v brew >/dev/null 2>&1; then brew upgrade %s; elif command -v apt-get >/dev/null 2>&1; then %s sudo apt-get install -y --only-upgrade %s; %s; elif command -v dnf >/dev/null 2>&1; then %s sudo dnf upgrade -y %s; %s; else %s; fi' \
+		"$brew_pkg" \
+		"$_sudo_check" "$sys_pkg" "$_sudo_fail" \
+		"$_sudo_check" "$sys_pkg" "$_sudo_fail" \
+		"$_no_pm"
+	return 0
+}
+
+# Build a PEP 668-safe upgrade command for a pip-category package.
+# Prefers pipx (isolated environments), falls back to uv tool install,
+# and emits a clear error if neither is available.
+# The returned string is executed via `bash -c` so it must be self-contained.
+# $1 = pip package name (e.g. "beads-viewer", "dspy-ai", "crawl4ai")
+# shellcheck disable=SC2016  # Single quotes intentional: bash -c payload
+_pip_pkg_upgrade_cmd() {
+	local pip_pkg="$1"
+	local _no_tool="echo 'Install pipx or uv to upgrade ${pip_pkg} on externally-managed Python' >&2; exit 1"
+	printf 'if command -v pipx >/dev/null 2>&1; then pipx install %s --force; elif command -v uv >/dev/null 2>&1; then uv tool install %s --force; else %s; fi' \
+		"$pip_pkg" "$pip_pkg" "$_no_tool"
+	return 0
 }
 
 # Tool definitions
@@ -124,9 +145,9 @@ BREW_TOOLS=(
 )
 
 PIP_TOOLS=(
-	"pip|Beads Viewer|beads_viewer|--version|beads-viewer|if command -v pipx >/dev/null 2>&1; then pipx install beads-viewer --force; elif command -v uv >/dev/null 2>&1; then uv tool install beads-viewer --force; else echo 'Install pipx or uv to upgrade beads-viewer on externally-managed Python' >&2; exit 1; fi"
-	"pip|DSPy|dspy|--version|dspy-ai|if command -v pipx >/dev/null 2>&1; then pipx install dspy-ai --force; elif command -v uv >/dev/null 2>&1; then uv tool install dspy-ai --force; else echo 'Install pipx or uv to upgrade dspy-ai on externally-managed Python' >&2; exit 1; fi"
-	"pip|Crawl4AI|crawl4ai|--version|crawl4ai|if command -v pipx >/dev/null 2>&1; then pipx install crawl4ai --force; elif command -v uv >/dev/null 2>&1; then uv tool install crawl4ai --force; else echo 'Install pipx or uv to upgrade crawl4ai on externally-managed Python' >&2; exit 1; fi"
+	"pip|Beads Viewer|beads_viewer|--version|beads-viewer|$(_pip_pkg_upgrade_cmd beads-viewer)"
+	"pip|DSPy|dspy|--version|dspy-ai|$(_pip_pkg_upgrade_cmd dspy-ai)"
+	"pip|Crawl4AI|crawl4ai|--version|crawl4ai|$(_pip_pkg_upgrade_cmd crawl4ai)"
 	"pip|Analytics MCP|analytics-mcp|--version|analytics-mcp|pipx upgrade analytics-mcp"
 	"pip|Outscraper MCP|outscraper-mcp-server|--version|outscraper-mcp-server|uv tool upgrade outscraper-mcp-server"
 )


### PR DESCRIPTION
## Summary

Address 3 CodeRabbit CHANGES_REQUESTED issues in `tool-version-check.sh`:

**CRITICAL (PEP 668):** Replace `pip install --user --upgrade` with a `_pip_pkg_upgrade_cmd()` helper that prefers `pipx install --force`, falls back to `uv tool install --force`, and emits a clear error if neither is available. Fixes externally-managed Python environments (Ubuntu 24.04+, Fedora 38+).

**MAJOR (sudo in non-TTY):** Add `sudo -n` preflight check in `_brew_pkg_upgrade_cmd()` for apt/dnf paths. Non-TTY and container contexts now get a clear "rerun with elevated privileges" message instead of hanging on a password prompt or burning the 120s timeout.

**MAJOR (Linux update unreachable):** Relax the `brew` existence gate in `_check_all_categories` so `BREW_TOOLS` are checked on all platforms. Add `_brew_pkg_github_repo()` helper and extend `get_brew_latest()` to resolve versions via GitHub Releases API on non-brew hosts for `gh`, `glab`, `wt`, `jq`, `shellcheck` — `OUTDATED_PACKAGES` is now populated correctly on Linux without Homebrew.

## Changes

- `.agents/scripts/tool-version-check.sh` — add `_pip_pkg_upgrade_cmd()`, `_brew_pkg_github_repo()`, extend `get_brew_latest()`, add `sudo -n` preflight, relax brew gate in `_check_all_categories`

## Testing

- ShellCheck: zero violations (`/opt/homebrew/Cellar/shellcheck/0.11.0/bin/shellcheck`)
- Codacy: pass (all CI checks green)
- Runtime smoke test: brew path confirmed working on macOS; apt/dnf and GitHub API paths verified by code review

## Runtime Testing

- **Risk classification**: Low — shell script update commands, no auth/payment/data paths
- **Testing level**: self-assessed + partial runtime-verified (brew path confirmed on macOS)
- **Dev environment**: macOS with brew

Closes #6762