### PR TITLE
GH#6704: Fix zsh IFS tab compatibility in agent-generated inline commands

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -466,12 +466,14 @@ Git is the primary audit trail for all work. Every change should be discoverable
 #
 # Critical difference: IFS=$'\t' on while-read loops
 # In bash: `IFS=$'\t'` on the `while` line is scoped to the `read` command only.
-# In zsh: `IFS=$'\t'` LEAKS into the loop body's subshells, corrupting PATH-based
-# command resolution. ALL $() command substitutions inside the loop fail with
-# "command not found" — even for standard utilities (sed, grep, cut, basename).
+# In zsh: `IFS=$'\t'` LEAKS into the loop body's subshells, causing $() command
+# substitutions and external commands to fail with "command not found" — even for
+# standard utilities (sed, grep, cut, basename). The exact mechanism may vary by
+# zsh version, but the observed behaviour is consistent: commands that work
+# outside the loop fail inside it when IFS is set to tab on the while-read line.
 #
 # BROKEN in zsh (agent-generated inline commands):
-#   echo -e "100\ttest.md" | while IFS=$'\t' read -r size path; do
+#   printf '100\ttest.md\n' | while IFS=$'\t' read -r size path; do
 #     base=$(echo "$path" | sed 's|\.md$||')   # FAILS: sed not found
 #     if echo "$x" | grep -qi "$base"; then     # FAILS: grep not found
 #       continue
@@ -487,8 +489,8 @@ Git is the primary audit trail for all work. Every change should be discoverable
   - `${path##*/}` instead of `$(basename "$path")`
   - `${path%.md}` instead of `$(echo "$path" | sed 's|\.md$||')`
   - `${line%%$'\t'*}` and `${line#*$'\t'}` instead of `$(echo "$line" | cut -f1)` / `cut -f2`
-- If subshell commands are unavoidable inside the loop, save and restore IFS:
-  - `while IFS=$'\t' read -r a b; do old_ifs="$IFS"; IFS=' '; result=$(cmd); IFS=$'\t'; done`
+- If subshell commands are unavoidable inside the loop, save and restore IFS correctly:
+  - `while IFS=$'\t' read -r a b; do old_ifs="$IFS"; IFS=' '; result=$(cmd); IFS="$old_ifs"; done`
 - Or avoid `IFS=$'\t'` entirely — parse tabs without setting IFS:
   - `while read -r line; do field1="${line%%$'\t'*}"; field2="${line#*$'\t'}"; done`
 - Framework .sh scripts with bash shebangs are NOT affected when invoked via `/bin/bash script.sh`

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -458,6 +458,44 @@ Git is the primary audit trail for all work. Every change should be discoverable
 - ShellCheck does NOT catch most bash version incompatibilities — manual review required
 - ShellCheck does NOT catch `"\t"` vs `$'\t'` — both are valid bash, just different semantics
 
+# zsh Compatibility (MCP Bash tool runs in user's default shell)
+# The MCP Bash tool (used by Claude Code, OpenCode, etc.) executes commands in
+# the user's default shell — typically zsh on macOS. Framework .sh scripts with
+# #!/usr/bin/env bash shebangs are safe when invoked directly. But agent-generated
+# INLINE shell commands run in zsh, where IFS scoping differs from bash.
+#
+# Critical difference: IFS=$'\t' on while-read loops
+# In bash: `IFS=$'\t'` on the `while` line is scoped to the `read` command only.
+# In zsh: `IFS=$'\t'` LEAKS into the loop body's subshells, corrupting PATH-based
+# command resolution. ALL $() command substitutions inside the loop fail with
+# "command not found" — even for standard utilities (sed, grep, cut, basename).
+#
+# BROKEN in zsh (agent-generated inline commands):
+#   echo -e "100\ttest.md" | while IFS=$'\t' read -r size path; do
+#     base=$(echo "$path" | sed 's|\.md$||')   # FAILS: sed not found
+#     if echo "$x" | grep -qi "$base"; then     # FAILS: grep not found
+#       continue
+#     fi
+#   done
+#
+# This caused GH#6696: pulse dedup logic silently failed — sed/grep returned
+# "command not found" inside while-read loops, so dedup never filtered anything,
+# causing 4+ duplicate dispatches per cycle.
+#
+# Safe alternatives for inline commands:
+- Inside `while IFS=$'\t' read` loops, use parameter expansion instead of subshell commands:
+  - `${path##*/}` instead of `$(basename "$path")`
+  - `${path%.md}` instead of `$(echo "$path" | sed 's|\.md$||')`
+  - `${line%%$'\t'*}` and `${line#*$'\t'}` instead of `$(echo "$line" | cut -f1)` / `cut -f2`
+- If subshell commands are unavoidable inside the loop, save and restore IFS:
+  - `while IFS=$'\t' read -r a b; do old_ifs="$IFS"; IFS=' '; result=$(cmd); IFS=$'\t'; done`
+- Or avoid `IFS=$'\t'` entirely — parse tabs without setting IFS:
+  - `while read -r line; do field1="${line%%$'\t'*}"; field2="${line#*$'\t'}"; done`
+- Framework .sh scripts with bash shebangs are NOT affected when invoked via `/bin/bash script.sh`
+  or `./script.sh`. Only inline commands pasted into the MCP Bash tool are affected.
+- When generating inline shell for the MCP Bash tool, prefer invoking a helper script over
+  inlining complex tab-parsing logic. The script runs in bash; the inline command runs in zsh.
+
 # Write-Time Quality Enforcement
 # Inspired by Plankton (github.com/alexfazio/plankton) — adapted for runtime-agnostic use.
 # When PostToolUse hooks are available, linting runs automatically on every edit.


### PR DESCRIPTION
## Summary

- Add zsh compatibility guidance to `build.txt` documenting the `IFS=$'\t'` scoping difference between bash and zsh that breaks `$()` command substitutions inside while-read loops
- Provide safe alternatives: parameter expansion, IFS save/restore, tab-free parsing patterns
- Recommend helper script invocation over inline tab-parsing logic for the MCP Bash tool

Closes #6704

## Root Cause

zsh (macOS default shell, used by the MCP Bash tool) leaks `IFS=$'\t'` from `while ... read` lines into the loop body's subshells. This corrupts PATH-based command resolution — all `$()` substitutions fail with "command not found" for standard utilities (sed, grep, cut, basename). Bash scopes IFS to the `read` command only, so this is a zsh-specific behavioral difference.

## Scope

- **74 instances** of `IFS=$'\t' read` exist across framework `.sh` scripts — all have `#!/usr/bin/env bash` shebangs and are **unaffected** when invoked directly
- The problem only manifests in **agent-generated inline commands** that run through the MCP Bash tool (which uses the user's default shell, typically zsh on macOS)
- This is a **framework guidance issue**, not a code bug — agents need to know about this pitfall

## Changes

| File | Change |
|------|--------|
| `.agents/prompts/build.txt` | New "zsh Compatibility" section (38 lines) after existing "Bash 3.2 Compatibility" section |

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low — documentation/guidance only, no code logic changes
- **Rationale**: This adds agent prompt guidance. No executable code is modified. The 74 existing script instances are confirmed safe (all have bash shebangs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on shell compatibility considerations for users working with the MCP Bash tool, including recommendations for handling inline commands in alternative shell environments and best practices for shell script invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->