### PR TITLE
GH#6752: Fix claim-task-id.sh to output zero-padded task IDs

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -101,6 +101,15 @@ _COUNTER_BRANCH_SET=false
 # Logging (all to stderr so stdout is machine-readable)
 # Logging: uses shared log_* from shared-constants.sh
 
+# Zero-pad a task ID number to minimum 3 digits (GH#6752).
+# Matches todo-template.md convention: t001, t002, ..., t999, t1000.
+# Usage: _pad_id 44 → "044"; _pad_id 1000 → "1000"
+_pad_id() {
+	local num="$1"
+	printf '%03d' "$num"
+	return 0
+}
+
 # Load project-level config from .aidevops.json in the repo root.
 # Populates REMOTE_NAME and COUNTER_BRANCH unless already set by CLI flags.
 # Requires: jq (optional — silently skipped if not installed).
@@ -461,7 +470,7 @@ allocate_counter_cas() {
 	local last_id=$((current_value + count - 1))
 	local new_counter=$((current_value + count))
 
-	log_info "Counter at ${current_value}, claiming t${first_id}..t${last_id}, new counter: ${new_counter}"
+	log_info "Counter at ${current_value}, claiming t$(_pad_id "$first_id")..t$(_pad_id "$last_id"), new counter: ${new_counter}"
 
 	# Step 2: Build a commit directly on <remote>/<counter_branch> using plumbing commands.
 	# This is safe from any branch — we never touch HEAD or the working tree index.
@@ -469,9 +478,9 @@ allocate_counter_cas() {
 
 	local commit_msg="chore: claim task ID"
 	if [[ "$count" -eq 1 ]]; then
-		commit_msg="chore: claim t${first_id}"
+		commit_msg="chore: claim t$(_pad_id "$first_id")"
 	else
-		commit_msg="chore: claim t${first_id}..t${last_id}"
+		commit_msg="chore: claim t$(_pad_id "$first_id")..t$(_pad_id "$last_id")"
 	fi
 
 	# Create a blob with the new counter value
@@ -544,7 +553,7 @@ allocate_online() {
 
 		case $cas_result in
 		0)
-			log_success "Claimed t${first_id} (attempt ${attempt})"
+			log_success "Claimed t$(_pad_id "$first_id") (attempt ${attempt})"
 			echo "$first_id"
 			return 0
 			;;
@@ -590,7 +599,7 @@ allocate_offline() {
 	# Update local counter (no push)
 	echo "$new_counter" >"${repo_path}/${COUNTER_FILE}"
 
-	log_warn "Allocated t${first_id} with offset (reconcile when back online)"
+	log_warn "Allocated t$(_pad_id "$first_id") with offset (reconcile when back online)"
 
 	echo "$first_id"
 	return 0
@@ -815,7 +824,7 @@ _main_resolve_allocation() {
 			local current
 			current=$(read_remote_counter "$REPO_PATH" 2>/dev/null || read_local_counter "$REPO_PATH" 2>/dev/null || echo "?")
 			if [[ "$current" =~ ^[0-9]+$ ]]; then
-				log_info "Would allocate t${current}..t$((current + ALLOC_COUNT - 1)) (counter at ${current})"
+				log_info "Would allocate t$(_pad_id "$current")..t$(_pad_id "$((current + ALLOC_COUNT - 1))") (counter at ${current})"
 			else
 				log_info "Would allocate task ID (counter unreadable: ${current})"
 			fi
@@ -825,7 +834,7 @@ _main_resolve_allocation() {
 		fi
 
 		if first_id_out=$(allocate_online "$REPO_PATH" "$ALLOC_COUNT"); then
-			log_success "Allocated task ID: t${first_id_out}"
+			log_success "Allocated task ID: t$(_pad_id "$first_id_out")"
 		else
 			log_warn "Online allocation failed, falling back to offline mode"
 			is_offline_out="true"
@@ -879,7 +888,8 @@ _main_create_issues() {
 		else
 			local i
 			for ((i = first_id; i <= last_id; i++)); do
-				local issue_title="t${i}: ${TASK_TITLE}"
+				local issue_title
+				issue_title="t$(_pad_id "$i"): ${TASK_TITLE}"
 				local issue_num=""
 
 				case "$platform" in
@@ -899,7 +909,7 @@ _main_create_issues() {
 						first_issue_num="$issue_num"
 					fi
 				else
-					log_warn "Issue creation failed for t${i} (non-fatal — ID is secured)"
+					log_warn "Issue creation failed for t$(_pad_id "$i") (non-fatal — ID is secured)"
 					issue_nums+=("")
 				fi
 			done
@@ -935,10 +945,10 @@ _main_output_results() {
 	local last_id=$((first_id + ALLOC_COUNT - 1))
 
 	if [[ "$ALLOC_COUNT" -eq 1 ]]; then
-		echo "task_id=t${first_id}"
+		echo "task_id=t$(_pad_id "$first_id")"
 	else
-		echo "task_id=t${first_id}"
-		echo "task_id_last=t${last_id}"
+		echo "task_id=t$(_pad_id "$first_id")"
+		echo "task_id_last=t$(_pad_id "$last_id")"
 		echo "task_count=${ALLOC_COUNT}"
 	fi
 
@@ -960,7 +970,7 @@ _main_output_results() {
 			for ((j = 0; j < ALLOC_COUNT; j++)); do
 				local tid=$((first_id + j))
 				if [[ -n "${issue_nums[$j]}" ]]; then
-					echo "ref_t${tid}=${ref_prefix}#${issue_nums[$j]}"
+					echo "ref_t$(_pad_id "$tid")=${ref_prefix}#${issue_nums[$j]}"
 				fi
 			done
 		fi


### PR DESCRIPTION
## Summary

- Add `_pad_id()` helper function using `printf '%03d'` to zero-pad task ID numbers to minimum 3 digits
- Apply padding to all 13 output points: machine-readable output (`task_id=`, `task_id_last=`, `ref_t*=`), log messages, git commit messages, GitHub/GitLab issue titles, and dry-run output
- Fix ShellCheck SC2155 warning introduced by the change (separate `local` declaration from assignment)

## Before/After

| Counter value | Before | After |
|---------------|--------|-------|
| 1 | `t1` | `t001` |
| 44 | `t44` | `t044` |
| 10 | `t10` | `t010` |
| 999 | `t999` | `t999` |
| 1000 | `t1000` | `t1000` |

Now matches `todo-template.md` convention (`t001`, `t002`, `t003`).

## Testing

- **Level**: `self-assessed`
- **Risk**: Low (formatting-only change, no logic change)
- ShellCheck: zero new violations (only pre-existing SC1091 for external source)
- `_pad_id()` uses `printf '%03d'` which is POSIX-standard and bash 3.2 compatible
- At t1000+, `%03d` naturally produces 4 digits — no truncation

Closes #6752