### PR TITLE
GH#6740: Add mandatory worker self-cleanup to full-loop lifecycle

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -290,9 +290,44 @@ After merge, post structured comment on every linked issue with: **What was done
 
 Every section needs ≥1 bullet ("None"/"N/A" if nothing). Testing level required — never omit. Gate — no `FULL_LOOP_COMPLETE` until posted.
 
-### 4.8 Worktree Cleanup
+### 4.8 Worktree Cleanup (GH#6740 — MANDATORY)
 
-See [`worktree-cleanup.md`](worktree-cleanup.md). Key: never pass `--delete-branch` to `gh pr merge` from inside a worktree.
+Workers MUST clean up their worktree after successful merge. Without this, worktrees accumulate indefinitely during batch dispatch and eventually block new workers from creating worktrees.
+
+```bash
+# After merge (Step 4.5) succeeds:
+WORKTREE_PATH="$(pwd)"
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CANONICAL_DIR="${REPO_ROOT%%.*}"  # ~/Git/repo from ~/Git/repo.branch-name
+
+# 1. Return to canonical repo directory (on main)
+cd "$CANONICAL_DIR" || cd "$HOME"
+
+# 2. Pull merged changes
+git pull origin main 2>/dev/null || true
+
+# 3. Remove the worktree
+HELPER="$HOME/.aidevops/agents/scripts/worktree-helper.sh"
+if [[ -x "$HELPER" ]]; then
+  WORKTREE_FORCE_REMOVE=true "$HELPER" remove "$BRANCH_NAME" --force 2>/dev/null || true
+else
+  git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+fi
+
+# 4. Delete the remote branch (GitHub may auto-delete, but be explicit)
+git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+git branch -D "$BRANCH_NAME" 2>/dev/null || true
+```
+
+**Key rules:**
+- Never pass `--delete-branch` to `gh pr merge` from inside a worktree — it fails because the branch is checked out
+- Always `cd` out of the worktree before removing it
+- Use `--force` because the worktree is clean (all changes merged)
+- Failures are non-fatal (`|| true`) — the PR is already merged, cleanup is best-effort
+
+See [`worktree-cleanup.md`](worktree-cleanup.md) for the full procedure.
 
 ### 4.9 Postflight + Deploy
 

--- a/.agents/scripts/commands/worktree-cleanup.md
+++ b/.agents/scripts/commands/worktree-cleanup.md
@@ -2,7 +2,35 @@
 
 After a PR is merged, clean up the linked worktree and return the canonical repo to a clean state.
 
-## Commands
+## Automated Cleanup (workers — GH#6740)
+
+Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (Step 4.8). This prevents worktree accumulation during batch dispatch.
+
+```bash
+# After gh pr merge --squash succeeds:
+WORKTREE_PATH="$(pwd)"
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+CANONICAL_DIR="${WORKTREE_PATH%%.*}"
+
+# Return to canonical repo, pull, remove worktree
+cd "$CANONICAL_DIR" || cd "$HOME"
+git pull origin main 2>/dev/null || true
+
+HELPER="$HOME/.aidevops/agents/scripts/worktree-helper.sh"
+if [[ -x "$HELPER" ]]; then
+  WORKTREE_FORCE_REMOVE=true "$HELPER" remove "$BRANCH_NAME" --force 2>/dev/null || true
+else
+  git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+fi
+
+git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+git branch -D "$BRANCH_NAME" 2>/dev/null || true
+```
+
+Cleanup failures are non-fatal — the PR is already merged. The pulse `cleanup_worktrees()` stage acts as a safety net for any worktrees workers fail to clean up.
+
+## Manual Cleanup (interactive sessions)
 
 ```bash
 # Merge the PR without --delete-branch (required when working from a worktree)
@@ -23,8 +51,10 @@ wt prune
 - **Do not use `--delete-branch`** with `gh pr merge` when running from inside a worktree — it will fail because the branch is checked out in the worktree, not the canonical repo.
 - `wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run it from the canonical repo directory (on `main`), not from inside the worktree.
 - If `wt prune` is unavailable, use `git worktree prune` to remove stale worktree entries, then manually delete the worktree directory.
+- The pulse runs `cleanup_worktrees()` every cycle as a safety net, but workers should not rely on it — self-cleanup prevents accumulation during batch operations.
 
 ## See Also
 
 - `workflows/git-workflow.md` — full worktree lifecycle
 - `reference/session.md` — session and worktree conventions
+- `full-loop.md` Step 4.8 — worker self-cleanup specification

--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -98,8 +98,12 @@ worktree-helper.sh status
 worktree-helper.sh remove feature/auth   # Removes directory, NOT the branch
 git branch -d feature/auth               # Delete branch separately if needed
 
-# Batch cleanup (merged branches)
+# Batch cleanup (merged branches — interactive only)
 worktree-helper.sh clean                 # Prompts before removing; runs git fetch --prune
+
+# Worker self-cleanup (automated — after PR merge in /full-loop)
+# Workers remove their own worktree after merge (GH#6740).
+# See full-loop.md Step 4.8 for the full procedure.
 ```
 
 ## Integration with aidevops
@@ -142,6 +146,10 @@ worktree-helper.sh remove feature/branch --force  # Override ownership (use with
 ```
 
 Registry: `~/.aidevops/.agent-workspace/worktree-registry.db`
+
+### Worker Self-Cleanup (GH#6740)
+
+Workers dispatched via `/full-loop` must remove their worktree after successful PR merge. Without this, batch dispatches (50+ workers) accumulate worktrees faster than the pulse cleanup cycle can remove them, eventually blocking new workers. See `full-loop.md` Step 4.8 and `commands/worktree-cleanup.md`.
 
 ### Squash Merge Detection
 


### PR DESCRIPTION
## Summary

- Workers dispatched via `/full-loop` now must remove their worktree after successful PR merge (Step 4.8)
- Without this, batch dispatches (50+ workers) accumulate worktrees faster than the pulse cleanup cycle can remove them, eventually blocking new workers
- Pulse `cleanup_worktrees()` remains as a safety net for any worktrees workers fail to clean up

## Changes

- **`full-loop.md` Step 4.8**: Expanded from a one-liner reference to explicit cleanup commands using `worktree-helper.sh remove --force`, with fallback to raw `git worktree remove`
- **`worktree-cleanup.md`**: Added "Automated Cleanup" section for workers, separated from manual interactive cleanup
- **`worktree.md`**: Added "Worker Self-Cleanup" best practice note

## Context

GH#6482 researched the worktree cleanup architecture and found the pulse auto-cleanup is inverted ("delete by default, guess what to keep"). This fix addresses the complementary problem from GH#6740: workers never clean up after themselves, so batch operations overwhelm the pulse cleanup cycle.

Closes #6740