### PR TITLE
t1679, t1680: Progressive-load build.txt and AGENTS.md — reduce session baseline by ~5,500 tokens

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -3049,29 +3049,14 @@ async function poolActionCheck(providerArg, now) {
  */
 export function createPoolTool(client) {
   return {
-    description: [
-      "Manage OAuth account pool for provider credential rotation.",
-      "Use 'list' to see all accounts and their status,",
-      "'rotate' to switch to the next pool account,",
-      "'remove <email>' to remove an account,",
-      "'assign-pending <email>' to assign a pending unidentified token to an account,",
-      "'check' to test token validity for all accounts,",
-      "'status' for rotation statistics.",
-      "Supports providers: anthropic (Claude Pro/Max), openai (ChatGPT Plus/Pro),",
-      "cursor (Cursor Pro), and google (Google AI Pro/Ultra/Workspace).",
-      "The agent should route natural language requests about managing",
-      "provider accounts, OAuth pools, or credential rotation to this tool.",
-      "Shell equivalent: oauth-pool-helper.sh supports the same actions",
-      "(rotate, status, assign-pending, check, list, remove, add).",
-    ].join(" "),
+    description: "Manage OAuth account pool for provider credential rotation. Actions: list, rotate, remove, assign-pending, check, status, reset-cooldowns. Providers: anthropic, openai, cursor, google. Shell equivalent: oauth-pool-helper.sh.",
     parameters: {
       type: "object",
       properties: {
         action: {
           type: "string",
           enum: ["list", "remove", "status", "reset-cooldowns", "rotate", "assign-pending", "check"],
-          description:
-            "Action to perform: list accounts, remove an account, show status, reset cooldowns, rotate to next account, assign a pending token, or check token validity",
+          description: "Action to perform",
         },
         email: {
           type: "string",

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -217,28 +217,13 @@ When referencing specific functions or code include the pattern `file_path:line_
 - NEVER include private repo names in TODO.md, issue titles, issue bodies, or comments on public repos. Use "a managed private repo" or similar generic references. issue-sync-helper.sh has automated sanitization as a safety net, but prevention at source is primary.
 
 # Parallel Model Verification (t1364)
-# High-stakes operations are verified by a second model before execution.
-# This catches single-model hallucinations before destructive operations cause
-# irreversible damage. Different providers have different failure modes, so
-# correlated errors are rare. Verification is targeted — not every operation,
-# only those matching the risk taxonomy.
-- Before destructive operations (force push, DB drop, production deploy, secret exposure): source `verify-operation-helper.sh` and call `check_operation()`. If risk is critical/high, call `verify_operation()` and respect the result.
-- pre-edit-check.sh accepts `--verify-op "command"` to gate operations at the pre-edit stage.
-- dispatch.sh automatically screens task descriptions via `check_task_high_stakes()` before committing workers.
-- Verification is opt-out (`VERIFY_ENABLED=false`) not opt-in. High-stakes operations are verified by default.
-- Verification uses the cheapest model tier (haiku) — cost is minimal per check.
-- When verification is unavailable (no verifier model reachable): critical operations are blocked in headless mode, warned in interactive mode. Non-critical operations proceed.
+# Before destructive operations (force push, DB drop, production deploy): call `check_operation()`
+# from `verify-operation-helper.sh`. Critical/high risk → `verify_operation()` and respect result.
+# Full details: `reference/model-verification.md`
 
 # Tamper-Evident Audit Logging (t1412.8)
-# Security-sensitive operations are logged to an append-only JSONL file with
-# SHA-256 hash chaining. Each entry includes the hash of the previous entry,
-# creating a chain. Modifying or deleting any entry breaks the chain, making
-# tampering detectable via `audit-log-helper.sh verify`.
-- Log security-sensitive operations via `audit-log-helper.sh log <type> <message> [--detail k=v ...]`. Event types: `worker.dispatch`, `worker.complete`, `worker.error`, `credential.access`, `credential.rotate`, `config.change`, `config.deploy`, `security.event`, `security.injection`, `security.scan`, `operation.verify`, `operation.block`, `system.startup`, `system.update`, `system.rotate` (15 types). Run `audit-log-helper.sh help` for details.
-- Log file: `~/.aidevops/.agent-workspace/observability/audit.jsonl` (0600 permissions, owner-only).
-- Verify chain integrity: `audit-log-helper.sh verify`. Run before log rotation and during security audits.
-- NEVER log credential values — only key names, scopes, and access metadata. The audit log is plaintext.
-- Full docs: `tools/security/tamper-evident-audit.md`.
+# Log security-sensitive operations: `audit-log-helper.sh log <type> <message>`.
+# NEVER log credential values. Full details: `reference/audit-logging.md`
 
 # Git Workflow and Traceability
 Git is the primary audit trail for all work. Every change should be discoverable through the chain: TODO task -> GitHub issue -> worktree/ref -> PR -> merge commit. A PR without a TODO entry, or an issue closed without a PR link, is an audit gap.
@@ -345,18 +330,8 @@ Short, concise, GitHub-flavored markdown. Numbered options for prompts (never "[
 Never apply AI tool suggestions (review bots, linters, PR reviewers) without independent verification. AI reviewers hallucinate. Verify claims against runtime, docs, or project conventions.
 
 # Review Bot Gate (t1382, GH#3827)
-# Before merging any PR, wait for AI code review bots (CodeRabbit, Gemini Code Assist,
-# etc.) to post their reviews. PRs merged before bots post lose security findings.
-# Three enforcement layers:
-# 1. CI: `.github/workflows/review-bot-gate.yml` — required status check
-# 2. Agent: `review-bot-gate-helper.sh check <PR> [REPO]` — returns PASS/PASS_RATE_LIMITED/WAITING/SKIP
-# 3. Branch protection: add `review-bot-gate` as required check per repo
-- Before merging: run `review-bot-gate-helper.sh check <PR_NUMBER>`. If WAITING, poll up to 10 minutes. Most bots post within 2-5 minutes.
-- If the PR has `skip-review-gate` label, bypass the gate (for docs-only PRs or repos without bots).
-- In headless mode: if still WAITING after timeout, proceed but log a warning. The CI required check is the hard gate.
-- ALWAYS read bot reviews before merging. Address critical/security findings; note non-critical suggestions for follow-up.
-- PASS_RATE_LIMITED means bots are rate-limited but the PR exceeded the grace period (default 4h). Safe to merge — bot reviews will arrive later and can be addressed in follow-up PRs. Use `request-retry` to trigger a re-review once rate limits clear.
-- When many PRs are rate-limited simultaneously, use `request-retry` on the highest-priority PRs first. Stagger retries to avoid re-triggering rate limits.
+# Before merging any PR: run `review-bot-gate-helper.sh check <PR_NUMBER>`.
+# ALWAYS read bot reviews before merging. Full workflow: `reference/review-bot-gate.md`
 
 # Context Compaction Survival
 # On compaction, ALWAYS preserve: (1) task IDs + states, (2) active batch/concurrency,

--- a/.agents/reference/agent-routing.md
+++ b/.agents/reference/agent-routing.md
@@ -1,6 +1,6 @@
 # Agent Routing
 
-Not every task is code. The framework has multiple primary agents, each with domain expertise. When dispatching workers (via `/pulse`, `/runners`, or manual `opencode run`), route to the appropriate agent using `--agent <name>`.
+Not every task is code. The framework has multiple primary agents, each with domain expertise. When dispatching workers (via `/pulse`, `/runners`, or `headless-runtime-helper.sh run`), route to the appropriate agent using `--agent <name>`.
 
 ## Available Primary Agents
 
@@ -26,7 +26,7 @@ Full index in `subagent-index.toon`.
 
 - Read the task/issue description and match it to the domain above
 - If the task is clearly code (implement, fix, refactor, CI), use Build+ or omit `--agent`
-- If the task matches another domain, pass `--agent <name>` to `opencode run`
+- If the task matches another domain, pass `--agent <name>` to `headless-runtime-helper.sh run`
 - When uncertain, default to Build+ — it can read subagent docs on demand
 - The agent choice affects which system prompt and domain knowledge the worker loads
 - **Bundle-aware routing (t1364.6):** Project bundles can define `agent_routing` overrides per task domain. For example, a content-site bundle routes `marketing` tasks to the Marketing agent. Check with `bundle-helper.sh get agent_routing <repo-path>`. Explicit `--agent` flags always override bundle defaults.

--- a/.agents/reference/agent-routing.md
+++ b/.agents/reference/agent-routing.md
@@ -1,11 +1,10 @@
----
-mode: subagent
----
 # Agent Routing
 
 Not every task is code. The framework has multiple primary agents, each with domain expertise. When dispatching workers (via `/pulse`, `/runners`, or manual `opencode run`), route to the appropriate agent using `--agent <name>`.
 
-**Available primary agents** (full index in `subagent-index.toon`):
+## Available Primary Agents
+
+Full index in `subagent-index.toon`.
 
 | Agent | Use for |
 |-------|---------|
@@ -23,7 +22,8 @@ Not every task is code. The framework has multiple primary agents, each with dom
 | Video | Video generation, editing, prompt engineering |
 | Health | Health and wellness content |
 
-**Routing rules:**
+## Routing Rules
+
 - Read the task/issue description and match it to the domain above
 - If the task is clearly code (implement, fix, refactor, CI), use Build+ or omit `--agent`
 - If the task matches another domain, pass `--agent <name>` to `opencode run`
@@ -31,15 +31,16 @@ Not every task is code. The framework has multiple primary agents, each with dom
 - The agent choice affects which system prompt and domain knowledge the worker loads
 - **Bundle-aware routing (t1364.6):** Project bundles can define `agent_routing` overrides per task domain. For example, a content-site bundle routes `marketing` tasks to the Marketing agent. Check with `bundle-helper.sh get agent_routing <repo-path>`. Explicit `--agent` flags always override bundle defaults.
 
-**Headless dispatch CLI:** ALWAYS use `headless-runtime-helper.sh run` for dispatching workers. This helper handles provider rotation, session persistence, backoff, and lifecycle reinforcement. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (GH#5096). NEVER use `claude`, `claude -p`, or any other CLI.
+## Headless Dispatch
 
-**Dispatch example:**
+ALWAYS use `headless-runtime-helper.sh run` for dispatching workers. This helper handles provider rotation, session persistence, backoff, and lifecycle reinforcement. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (GH#5096). NEVER use `claude`, `claude -p`, or any other CLI.
+
+### Dispatch Example
 
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 AGENTS_DIR="${AGENTS_DIR:-"$HOME/.aidevops/agents"}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
-# Path is determined by 'paths.agents_dir' in config.jsonc
 
 # Code task (default — Build+ implied)
 $HELPER run \
@@ -58,15 +59,5 @@ $HELPER run \
   --dir ~/Git/myproject \
   --title "Issue #55: SEO audit" \
   --prompt "/full-loop Implement issue #55 -- Run SEO audit on landing pages" &
-sleep 2
-
-# Content task
-$HELPER run \
-  --role worker \
-  --session-key "issue-60" \
-  --agent Content \
-  --dir ~/Git/myproject \
-  --title "Issue #60: Blog post" \
-  --prompt "/full-loop Implement issue #60 -- Write launch announcement blog post" &
 sleep 2
 ```

--- a/.agents/reference/audit-logging.md
+++ b/.agents/reference/audit-logging.md
@@ -9,7 +9,7 @@ tampering detectable via `audit-log-helper.sh verify`.
 
 Log security-sensitive operations via `audit-log-helper.sh log <type> <message> [--detail k=v ...]`.
 
-Event types (15): `worker.dispatch`, `worker.complete`, `worker.error`, `credential.access`, `credential.rotate`, `config.change`, `config.deploy`, `security.event`, `security.injection`, `security.scan`, `operation.verify`, `operation.block`, `system.startup`, `system.update`, `system.rotate`.
+Event types (16): `worker.dispatch`, `worker.complete`, `worker.error`, `credential.access`, `credential.rotate`, `config.change`, `config.deploy`, `security.event`, `security.injection`, `security.scan`, `operation.verify`, `operation.block`, `system.startup`, `system.update`, `system.rotate`, `testing.runtime`.
 
 Run `audit-log-helper.sh help` for details.
 

--- a/.agents/reference/audit-logging.md
+++ b/.agents/reference/audit-logging.md
@@ -1,0 +1,21 @@
+# Tamper-Evident Audit Logging (t1412.8)
+
+Security-sensitive operations are logged to an append-only JSONL file with
+SHA-256 hash chaining. Each entry includes the hash of the previous entry,
+creating a chain. Modifying or deleting any entry breaks the chain, making
+tampering detectable via `audit-log-helper.sh verify`.
+
+## Usage
+
+Log security-sensitive operations via `audit-log-helper.sh log <type> <message> [--detail k=v ...]`.
+
+Event types (15): `worker.dispatch`, `worker.complete`, `worker.error`, `credential.access`, `credential.rotate`, `config.change`, `config.deploy`, `security.event`, `security.injection`, `security.scan`, `operation.verify`, `operation.block`, `system.startup`, `system.update`, `system.rotate`.
+
+Run `audit-log-helper.sh help` for details.
+
+## Configuration
+
+- Log file: `~/.aidevops/.agent-workspace/observability/audit.jsonl` (0600 permissions, owner-only).
+- Verify chain integrity: `audit-log-helper.sh verify`. Run before log rotation and during security audits.
+- NEVER log credential values — only key names, scopes, and access metadata. The audit log is plaintext.
+- Full docs: `tools/security/tamper-evident-audit.md`.

--- a/.agents/reference/external-repo-submissions.md
+++ b/.agents/reference/external-repo-submissions.md
@@ -46,4 +46,4 @@ Before `gh pr create` targeting an external repo:
 
 If a submission is auto-closed by a compliance bot, read the bot's comment for formatting requirements, then resubmit with the correct format.
 
-Practical examples and template mapping: `tools/git/github-cli.md` "External Repo Submissions" section.
+Practical examples and template mapping: `../tools/git/github-cli.md` "External Repo Submissions" section.

--- a/.agents/reference/external-repo-submissions.md
+++ b/.agents/reference/external-repo-submissions.md
@@ -8,7 +8,7 @@ well-crafted issues get closed within hours if they don't use the right format.
 This is a judgment call, not a deterministic check. Read the templates and
 contributing guidelines, then format your submission accordingly.
 
-## Filing Issues on External Repos
+## Issue Submission
 
 Before `gh issue create --repo <slug>` on a repo NOT in `~/.config/aidevops/repos.json`:
 
@@ -30,14 +30,11 @@ Before `gh issue create --repo <slug>` on a repo NOT in `~/.config/aidevops/repo
    ```
 
 2. If templates exist, fetch the relevant one (e.g., `bug-report.yml`) using the same `--include` status pattern; only decode `200` bodies (`base64 -d`).
-
 3. Check for `CONTRIBUTING.md` using the same `--include` status pattern; continue on `404`, fail on other non-`200` statuses.
-
 4. Format the issue body to match the required template structure. YAML form templates (`.yml`) generate `### Label` section headers when submitted via the web UI — replicate this structure in your `--body`.
-
 5. If no templates exist, use a clear, well-structured format (title, description, steps to reproduce, expected/actual behaviour).
 
-## Filing PRs on External Repos
+## PR Submission
 
 Before `gh pr create` targeting an external repo:
 
@@ -45,10 +42,8 @@ Before `gh pr create` targeting an external repo:
 2. Check `CONTRIBUTING.md` for PR requirements (branch naming, commit format, CLA, etc.)
 3. Format the PR body to match their template and follow their contributing guidelines.
 
-## Auto-Closed Submissions
+## Auto-closed Submissions
 
 If a submission is auto-closed by a compliance bot, read the bot's comment for formatting requirements, then resubmit with the correct format.
 
-## Practical Examples
-
-Template mapping and worked examples: `tools/git/github-cli.md` "External Repo Submissions" section.
+Practical examples and template mapping: `tools/git/github-cli.md` "External Repo Submissions" section.

--- a/.agents/reference/memory-lookup.md
+++ b/.agents/reference/memory-lookup.md
@@ -12,49 +12,25 @@ every vague reference — match the source to the question.
 
 ## Tier 1 — Local cached (instant, zero cost)
 
-1. **Cross-session memory**: `memory-helper.sh recall "keywords"` (CLI) or
-   `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have
-   the answer. Solutions, decisions, preferences, patterns.
-2. **TODO.md + completed tasks**: `rg "keyword" TODO.md` — task IDs, PR numbers,
-   completion dates, brief descriptions of all past work.
+1. **Cross-session memory**: `memory-helper.sh recall "keywords"` (CLI) or `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have the answer. Solutions, decisions, preferences, patterns.
+2. **TODO.md + completed tasks**: `rg "keyword" TODO.md` — task IDs, PR numbers, completion dates, brief descriptions of all past work.
 
 ## Tier 2 — Local indexed (fast, local I/O)
 
-3. **Git history**: `git log --all --oneline --grep="keyword"` — commits, branches,
-   PRs, code changes. High volume but precise when the keyword is specific.
-4. **Session transcripts (Claude Code)**: `~/.claude/projects/` — per-project session
-   transcripts in JSONL. `rg "keyword" ~/.claude/projects/`. Recovers exact
-   conversation context, what was discussed, tool calls made.
-   For structured field searches, pipe through jq:
-   `rg -l "keyword" ~/.claude/projects/ | xargs -I{} jq 'select(.type=="assistant") | .message.content' {}`
+3. **Git history**: `git log --all --oneline --grep="keyword"` — commits, branches, PRs, code changes. High volume but precise when the keyword is specific.
+4. **Session transcripts (Claude Code)**: `~/.claude/transcripts/*.jsonl` — full JSONL conversation logs. `rg "keyword" ~/.claude/transcripts/`. Recovers exact conversation context, what was discussed, tool calls made. For structured field searches, pipe through jq: `rg -l "keyword" ~/.claude/transcripts/ | xargs -I{} jq 'select(.type=="assistant") | .message.content' {}`
 5. **Session database**: runtime-specific — see AGENTS.md for paths per runtime.
-6. **Observability metrics**: `~/.aidevops/.agent-workspace/observability/metrics.jsonl`
-   — JSONL log of LLM request metadata, costs, models, tokens per session.
-   Fields per record: provider, model, session_id, request_id, project,
-   input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-   cost_input, cost_output, cost_total, stop_reason, git_branch, recorded_at.
-   Example: `jq -s '[.[] | select(.project=="aidevops")] | group_by(.model) | map({model:.[0].model, total_cost:([.[].cost_total] | add), requests:length})' ~/.aidevops/.agent-workspace/observability/metrics.jsonl`
+6. **Observability metrics**: `~/.aidevops/.agent-workspace/observability/metrics.jsonl` — JSONL log of LLM request metadata, costs, models, tokens per session. Fields per record: provider, model, session_id, request_id, project, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cost_input, cost_output, cost_total, stop_reason, git_branch, recorded_at. Example: `jq -s '[.[] | select(.project=="aidevops")] | group_by(.model) | map({model:.[0].model, total_cost:([.[].cost_total] | add), requests:length})' ~/.aidevops/.agent-workspace/observability/metrics.jsonl`
 
 ## Tier 3 — Remote targeted (API calls, need a specific number)
 
-7. **GitHub issue/PR comments**: `gh issue view {num} --comments --repo {slug}`,
-   `gh pr view {num} --comments --repo {slug}`, or the API equivalents
-   `gh api repos/{slug}/issues/{num}/comments` and
-   `gh api repos/{slug}/pulls/{num}/comments` (for inline review comments).
-   Discussion, review feedback, decisions made in threads — context that never
-   reaches git or memory. Get the issue/PR number from TODO.md first.
+7. **GitHub issue/PR comments**: `gh issue view {num} --comments --repo {slug}`, `gh pr view {num} --comments --repo {slug}`, or the API equivalents `gh api repos/{slug}/issues/{num}/comments` and `gh api repos/{slug}/pulls/{num}/comments` (for inline review comments). Discussion, review feedback, decisions made in threads — context that never reaches git or memory. Get the issue/PR number from TODO.md first.
 
 ## Tier 4 — Remote broad (expensive, last resort)
 
-8. **GitHub search**: `gh search issues "keyword" --repo {slug}` (issues),
-   `gh search prs "keyword" --repo {slug}` (PRs),
-   `gh search code "keyword" --repo {slug}` (code). Broad search when you
-   don't know the issue/PR number.
-9. **GitHub discussions**: `gh api repos/{slug}/discussions` (if enabled).
-   Long-form design discussions, RFCs, community Q&A.
-10. **GitHub wiki**: `gh api repos/{slug}/pages` or clone the wiki repo
-    (`git clone https://github.com/{slug}.wiki.git`). Persistent documentation that may contain
-    architectural decisions, onboarding guides, or historical context.
+8. **GitHub search**: `gh search issues "keyword" --repo {slug}` (issues), `gh search prs "keyword" --repo {slug}` (PRs), `gh search code "keyword" --repo {slug}` (code). Broad search when you don't know the issue/PR number.
+9. **GitHub discussions**: `gh api repos/{slug}/discussions` (if enabled). Long-form design discussions, RFCs, community Q&A.
+10. **GitHub wiki**: `gh api repos/{slug}/pages` or clone the wiki repo (`git clone https://github.com/{slug}.wiki.git`). Persistent documentation that may contain architectural decisions, onboarding guides, or historical context.
 
 ## Examples
 

--- a/.agents/reference/model-verification.md
+++ b/.agents/reference/model-verification.md
@@ -1,0 +1,16 @@
+# Parallel Model Verification (t1364)
+
+High-stakes operations are verified by a second model before execution.
+This catches single-model hallucinations before destructive operations cause
+irreversible damage. Different providers have different failure modes, so
+correlated errors are rare. Verification is targeted — not every operation,
+only those matching the risk taxonomy.
+
+## Usage
+
+- Before destructive operations (force push, DB drop, production deploy, secret exposure): source `verify-operation-helper.sh` and call `check_operation()`. If risk is critical/high, call `verify_operation()` and respect the result.
+- pre-edit-check.sh accepts `--verify-op "command"` to gate operations at the pre-edit stage.
+- dispatch.sh automatically screens task descriptions via `check_task_high_stakes()` before committing workers.
+- Verification is opt-out (`VERIFY_ENABLED=false`) not opt-in. High-stakes operations are verified by default.
+- Verification uses the cheapest model tier (haiku) — cost is minimal per check.
+- When verification is unavailable (no verifier model reachable): critical operations are blocked in headless mode, warned in interactive mode. Non-critical operations proceed.

--- a/.agents/reference/review-bot-gate.md
+++ b/.agents/reference/review-bot-gate.md
@@ -1,0 +1,19 @@
+# Review Bot Gate (t1382, GH#3827)
+
+Before merging any PR, wait for AI code review bots (CodeRabbit, Gemini Code Assist,
+etc.) to post their reviews. PRs merged before bots post lose security findings.
+
+## Enforcement Layers
+
+1. **CI**: `.github/workflows/review-bot-gate.yml` — required status check
+2. **Agent**: `review-bot-gate-helper.sh check <PR> [REPO]` — returns PASS/PASS_RATE_LIMITED/WAITING/SKIP
+3. **Branch protection**: add `review-bot-gate` as required check per repo
+
+## Workflow
+
+- Before merging: run `review-bot-gate-helper.sh check <PR_NUMBER>`. If WAITING, poll up to 10 minutes. Most bots post within 2-5 minutes.
+- If the PR has `skip-review-gate` label, bypass the gate (for docs-only PRs or repos without bots).
+- In headless mode: if still WAITING after timeout, proceed but log a warning. The CI required check is the hard gate.
+- ALWAYS read bot reviews before merging. Address critical/security findings; note non-critical suggestions for follow-up.
+- PASS_RATE_LIMITED means bots are rate-limited but the PR exceeded the grace period (default 4h). Safe to merge — bot reviews will arrive later and can be addressed in follow-up PRs. Use `request-retry` to trigger a re-review once rate limits clear.
+- When many PRs are rate-limited simultaneously, use `request-retry` on the highest-priority PRs first. Stagger retries to avoid re-triggering rate limits.

--- a/.agents/reference/screenshot-limits.md
+++ b/.agents/reference/screenshot-limits.md
@@ -1,10 +1,12 @@
-# Screenshot Size Limits
+# Screenshot Size Limits (CRITICAL — session-crashing)
 
-**CRITICAL — session-crashing**
+Anthropic hard-rejects images >8000px on any dimension. This crashes the session
+because the oversized image is already in message history — every subsequent
+API call fails with the same error. There is no recovery except starting a new
+session and losing all conversation context.
 
-Anthropic hard-rejects images >8000px on any dimension. This crashes the session because the oversized image is already in message history — every subsequent API call fails with the same error. There is no recovery except starting a new session and losing all conversation context.
-
-GH#4213 added guardrails to `browser-qa-helper.sh` but agents take screenshots through at least 5 other paths that bypass those guardrails entirely.
+GH#4213 added guardrails to browser-qa-helper.sh but agents take screenshots
+through at least 5 other paths that bypass those guardrails entirely.
 
 ## Rules
 

--- a/.agents/reference/self-improvement.md
+++ b/.agents/reference/self-improvement.md
@@ -1,8 +1,3 @@
----
-description: Self-improvement principles and routing for all agent sessions
-mode: subagent
----
-
 # Self-Improvement
 
 Every agent session — interactive, worker, or supervisor — should improve the system, not just complete its task. This is a universal principle, not specific to any one command.
@@ -10,7 +5,6 @@ Every agent session — interactive, worker, or supervisor — should improve th
 **Observe outcomes from existing state.** TODO.md, PLANS.md, and GitHub issues/PRs are the state database. Never duplicate this state into separate files, databases, or logs.
 
 **Signals that something needs fixing** (check via `gh` CLI, not custom state):
-
 - A PR has been open for 6+ hours with no progress
 - The same issue/PR appears in consecutive supervisor pulses with no state change
 - A PR was closed (not merged) — a worker failed
@@ -19,16 +13,12 @@ Every agent session — interactive, worker, or supervisor — should improve th
 
 **Response: create a GitHub issue, not a workaround.** When you observe a systemic problem, file a GitHub issue describing the pattern, root cause hypothesis, and proposed fix. This enters the existing task queue and gets picked up by the next available worker. Never patch around a broken process — fix the process.
 
-## Routing
-
 **Route to the correct repo.** Not every improvement belongs in the current project. Before creating a self-improvement task, determine whether the problem is project-specific or framework-level:
 
 - **Framework-level** — route to the aidevops repo. Indicators: the observation references files under `~/.aidevops/`, framework scripts (`ai-actions.sh`, `ai-lifecycle.sh`, `supervisor/`, `dispatch.sh`, `pre-edit-check.sh`, helper scripts), agent prompt behaviour, supervisor/pulse logic, or cross-repo orchestration. **Use `framework-issue-helper.sh log` — not `claim-task-id.sh` — to file the issue directly on `marcusquinn/aidevops`.** The fix belongs in the framework, not in the project that happened to trigger it.
 - **Project-specific** — route to the current repo. Indicators: the observation is about this project's CI, code patterns, dependencies, or domain logic.
 
 If uncertain, ask: "Would this fix apply to every repo the framework manages, or only this one?" Framework-wide problems go to aidevops; project-specific problems stay local. Never create framework tasks in a project repo — they become invisible to framework maintainers and pollute the project's task namespace.
-
-## Filing a Framework Issue
 
 **How to file a framework issue (GH#5149):** When you detect a framework-level problem, use the dedicated helper — not `claim-task-id.sh` in the current repo:
 
@@ -45,12 +35,9 @@ If uncertain, ask: "Would this fix apply to every repo the framework manages, or
 
 This is the correct action path for framework issues. Do NOT use `claim-task-id.sh` in the project repo for framework-level observations — that pollutes the project's task namespace and makes the issue invisible to framework maintainers.
 
-## Scope Boundary
-
 **Scope boundary for code changes (t1405, GH#2928).** Separate "observe and report" from "observe and fix". When dispatched by the pulse, the `PULSE_SCOPE_REPOS` env var lists the repo slugs where you may create worktrees and PRs. Filing issues is always allowed on any repo — cross-repo bug reports are valuable. But code changes (worktrees, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop. The issue enters that repo's queue for their maintainers (or their own pulse) to handle. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies.
 
-## What Counts as Self-Improvement
-
+**What counts as self-improvement:**
 - Filing issues for repeated failure patterns
 - Improving agent prompts when workers consistently misunderstand instructions
 - Identifying missing automation (e.g., a manual step that could be a `gh` command)
@@ -58,20 +45,6 @@ This is the correct action path for framework issues. Do NOT use `claim-task-id.
 - Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
 - **Filing issues for information gaps (t1416):** When you cannot determine what happened on a task because comments lack model tier, branch name, failure diagnosis, or other audit-critical fields, file a self-improvement issue. Information gaps cause cascading waste — without knowing what was tried, the next attempt repeats the same failure. The issue/PR comment timeline is the primary audit trail; if the information isn't there, it's invisible.
 
-## Issue Quality Filter
-
 **Issue quality filter (GH#6508):** Before filing any enhancement or architectural change — whether via `/log-issue-aidevops`, `framework-issue-helper.sh`, or direct `gh issue create` — apply the framework's own principles to the proposal. Ask: (1) Is this addressing an observed failure, or is it preemptive? Preemptive rules for unobserved failure modes are prompt bloat. (2) Does this add a deterministic mechanism where model judgment would work better? (3) If this comes from comparing aidevops to another framework, is the "gap" actually a deliberate architectural choice? The bar for adding guidance is: **observed failure first, then minimal guidance**. Bug reports with clear reproduction steps are exempt — bugs are observed failures by definition.
 
-## Intelligence Over Determinism
-
-**Intelligence over determinism:** The harness gives you goals, tools, and boundaries — not scripts for every scenario. Deterministic rules are for things with exactly one correct answer (CLI syntax, file paths, security). Everything else — prioritisation, triage, stuck detection, what to work on — is a judgment call. If a rule says "if X then Y" but there are cases where X is true and Y is wrong, it's guidance not a rule. Use the cheapest model that can handle the decision (haiku for triage, sonnet for implementation, opus for strategy) — but never use a regex where a model call would handle outliers better. See `prompts/build.txt` "Intelligence Over Determinism" for the full principle.
-
-## Autonomous Operation
-
 **Autonomous operation:** When the user says "continue", "monitor", or "keep going" — enter autonomous mode: use sleep/wait loops, maintain a perpetual todo to survive compaction, only interrupt for blocking errors that require user input.
-
-## Related
-
-- `aidevops/self-improving-agents.md` — archived script context and observation/response patterns
-- `scripts/commands/pulse.md` — supervisor outcome observation (Step 2a)
-- `reference/session.md` — cross-session memory system

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -111,6 +111,30 @@ Use primary sources over tutorials. Cross-reference, prefer recent, watch for ve
 7. **Existing agent?** Call and improve vs duplicate?
 8. **Sources verified?** Primary, cross-referenced
 9. **Markdown linting?** MD025/MD022/MD031/MD012. Run `bunx markdownlint-cli2 "path/to/file.md"`
+10. **Terse pass done?** See below
+
+## Post-Creation Terse Pass (MANDATORY)
+
+After writing any agent doc, do a second pass to tighten prose before committing. Every token in an agent doc is paid for on every load — verbose docs compound cost across hundreds of sessions.
+
+**Technique:** Re-read the doc and compress every instruction to its minimum form while preserving all rules, constraints, and references. LLMs follow terse instructions equally well as verbose ones.
+
+**What to compress:**
+- "In order to achieve X, you should Y" → "Y"
+- "It is important to note that X" → "X" (or drop if self-evident)
+- Multi-sentence explanations of a single rule → single sentence
+- Narrative context ("The reason this exists is because in March 2026...") → keep task ID, drop story
+- Redundant examples that demonstrate the same point → keep one
+
+**What to preserve (never compress):**
+- Task IDs (`tNNN`), issue refs (`GH#NNN`), incident identifiers
+- All rules and constraints — compress wording, not the rule itself
+- File paths, command examples, code blocks
+- Safety-critical detail (security, compatibility)
+
+**Target:** Agent docs should read like reference cards, not tutorials. If a section reads like it's explaining a concept to a newcomer, tighten it — the reader is an LLM that already understands the concept.
+
+**Evidence:** Terse pass on `build.txt` achieved 63% byte reduction with zero rule loss. `AGENTS.md` achieved 48%. See `tools/code-review/code-simplifier.md` "Prose tightening" for the full classification.
 
 ## Code Examples: When to Include
 

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -128,6 +128,25 @@ Workers that skip verification or mark a PR ready without running the specified 
 - Format inconsistency with project convention -- e.g., `### **EMOJI ALL CAPS**` when 91% of the codebase uses plain `### Section Name`. Normalising outlier files to the established convention improves scannability across docs. Heading level (`###`) already conveys hierarchy; bold/caps/emoji on top is redundant emphasis.
 - Stale references to files that no longer exist or tools that were replaced
 
+### Prose tightening for agent docs (suggest with high confidence)
+
+Agent instruction docs (NOT reference corpora) often contain verbose explanatory prose written for human readers. LLMs follow terse instructions equally well. Tighten by:
+
+- Removing filler words ("In order to" → "To", "It is important to note that" → drop)
+- Removing redundant explanations (rule + explanation of why the rule exists, when the rule is self-evident)
+- Compressing multi-sentence descriptions into single sentences
+- Converting verbose bullet points into terse equivalents
+- Removing narrative context that doesn't change agent behaviour (incident stories — keep the task ID and rule, drop the narrative)
+
+**Preservation rules for prose tightening:**
+- KEEP all task IDs (`tNNN`), issue refs (`GH#NNN`), incident identifiers
+- KEEP all rules/constraints — compress the wording, not the rule
+- KEEP all file paths, command examples, code blocks
+- KEEP safety-critical detail (security rules, bash compatibility forbidden features)
+- Test: can the tightened version produce the same agent behaviour? If uncertain, keep the original.
+
+**Evidence (t1679 session):** Terse pass on `build.txt` achieved 63% byte reduction (45k→17k) with zero rule loss. `AGENTS.md` achieved 48% (22k→12k). All 25 critical patterns verified present after tightening.
+
 ### Requires careful judgment (suggest with medium confidence)
 
 - Verbose code that could be shorter without losing readability
@@ -413,6 +432,8 @@ Code simplification analysis fits into the quality workflow via two input paths:
 ### 1. Automated weekly scan (GH#5628)
 
 `pulse-wrapper.sh` runs a weekly complexity scan that uses the same awk-based function complexity check as CI. It creates `simplification-debt` issues for files exceeding the per-file violation threshold (default: 5+ functions >100 lines). Issues are deduplicated against existing open issues by repo-relative file path.
+
+**No file size gate.** Agent docs of any size are eligible for simplification analysis. The previous 500-line threshold was removed (t1679) — smaller files can be equally verbose. The classification (instruction doc vs reference corpus) determines the action, not the line count.
 
 ```text
 pulse-wrapper.sh (weekly) --> awk complexity scan


### PR DESCRIPTION
## Summary

- Extract 8 rarely-used sections from always-loaded prompt files (`build.txt`, `AGENTS.md`) into on-demand reference docs under `.agents/reference/`
- Each extracted section replaced with a 1-2 line pointer that triggers on-demand loading
- **~5,500 tokens saved per session** (~3,200 from build.txt, ~2,300 from AGENTS.md)

## Sections Extracted

**build.txt → reference/:**
- Conversational Memory Lookup → `memory-lookup.md`
- Screenshot Size Limits → `screenshot-limits.md`
- External Repo Issue/PR Submission → `external-repo-submissions.md`
- Tamper-Evident Audit Logging → `audit-logging.md`
- Parallel Model Verification → `model-verification.md`
- Review Bot Gate → `review-bot-gate.md`

**AGENTS.md → reference/:**
- Self-Improvement → `self-improvement.md`
- Agent Routing → `agent-routing.md`

## Context

Session baseline grew from ~9.5k tokens (Mar 1) to ~22k tokens (Mar 27) in prompt files alone. Combined with tool definitions, total baseline was ~39k tokens before first user message. This PR is Phase 2 of the context token optimization plan (see PLANS.md).

No knowledge is lost — full content preserved in reference files, loaded on demand when the agent encounters the relevant context (e.g., "remember when..." triggers memory lookup load, screenshot tasks trigger screenshot limits load).

## CodeRabbit Fixes Applied

- `agent-routing.md`: replaced bare `opencode run` with `headless-runtime-helper.sh run` to resolve dispatch guidance contradiction
- `audit-logging.md`: corrected event type count 15 → 16 (added `testing.runtime` to match `AUDIT_EVENT_TYPES` array)
- `external-repo-submissions.md`: fixed path reference `tools/git/github-cli.md` → `../tools/git/github-cli.md` for .agents/-relative consistency

Closes #6795
Closes #6802