### PR TITLE
t1682: fix: guard against dead tool schemas from errored MCP servers

### DIFF
--- a/.agents/aidevops/mcp-troubleshooting.md
+++ b/.agents/aidevops/mcp-troubleshooting.md
@@ -41,9 +41,45 @@ If you see `Unrecognized key: "xxx"`, OpenCode doesn't support that config key.
 
 **Fix**: Edit `~/.config/opencode/opencode.json` and remove the unsupported key.
 
+## Errored Servers — Dead Tool Schemas (t1682)
+
+When an MCP server fails to start, its tool schemas may still appear in the tool
+list. The agent sees the tools but every call returns "MCP error -32000: Connection
+closed". This wastes context tokens on tools that can never execute.
+
+**Detect errored servers:**
+
+```bash
+~/.aidevops/agents/scripts/mcp-diagnose.sh check-all
+```
+
+This scans all enabled MCP servers, reports which commands are unreachable, and
+prints remediation steps (fix, disable, or remove).
+
+**Disable a persistently errored server** (removes its schemas from context):
+
+```json
+{
+  "playwright": {
+    "enabled": false
+  }
+}
+```
+
+Edit `~/.config/opencode/opencode.json` and set `"enabled": false` for the server.
+Restart your AI runtime to reload the tool list.
+
+**Agent behaviour with errored servers:** When a tool call returns
+"MCP error -32000" or "Connection closed", treat that server as unavailable for
+the rest of the session. Do not retry tools from that server. See `prompts/build.txt`
+"Errored MCP Server Guard" for the full rule.
+
 ## Diagnostic Commands
 
 ```bash
+# Scan all enabled MCP servers for connection errors (t1682)
+~/.aidevops/agents/scripts/mcp-diagnose.sh check-all
+
 # Full diagnosis for specific MCP
 ~/.aidevops/agents/scripts/mcp-diagnose.sh <mcp-name>
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -72,6 +72,15 @@ Use TodoWrite frequently. Break complex tasks into steps. Mark todos completed i
 - NEVER use bash echo to communicate — output text directly.
 - Slash commands: read `scripts/commands/<command>.md` first.
 
+# Errored MCP Server Guard (t1682)
+# MCP servers that fail to start (e.g., "MCP error -32000: Connection closed",
+# "spawn ENOENT", "ECONNREFUSED") may still have their tool schemas present in
+# the tool list. Calling these tools wastes tokens and always fails.
+- When a tool call returns "MCP error -32000", "Connection closed", "spawn ENOENT", or similar startup errors, mark that MCP server as unavailable for the rest of the session. Do NOT retry tools from that server.
+- If you see tools in the tool list from a server that has previously errored, skip them entirely — do not attempt to call them.
+- To identify and fix errored MCP servers: `~/.aidevops/agents/scripts/mcp-diagnose.sh check-all`. This scans all enabled MCP servers and reports which ones are unavailable, with remediation steps.
+- To disable a persistently errored server: set `"enabled": false` in `~/.config/opencode/opencode.json` for that server entry. This removes its tool schemas from context entirely.
+
 # File Discovery (MANDATORY)
 - NEVER use Glob when Bash is available
 - `git ls-files '<pattern>'` for tracked files; `fd -e <ext>` for untracked

--- a/.agents/scripts/mcp-diagnose.sh
+++ b/.agents/scripts/mcp-diagnose.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # MCP Connection Failure Diagnostics
 # Usage: mcp-diagnose.sh <mcp-name>
+#        mcp-diagnose.sh check-all
 #
 # Diagnoses common MCP connection issues:
 # - Command availability
 # - Version mismatches
 # - Configuration errors
 # - Known breaking changes
+#
+# check-all: scans all enabled MCP servers and reports which are unavailable,
+# helping identify dead tool schemas that waste context tokens (t1682).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
@@ -17,10 +21,160 @@ MCP_NAME="${1:-}"
 
 if [[ -z "$MCP_NAME" ]]; then
 	echo "Usage: mcp-diagnose.sh <mcp-name>"
+	echo "       mcp-diagnose.sh check-all"
 	echo ""
 	echo "Examples:"
 	echo "  mcp-diagnose.sh augment-context-engine"
+	echo "  mcp-diagnose.sh check-all"
 	exit 1
+fi
+
+# =============================================================================
+# check-all: scan all enabled MCP servers for connection errors (t1682)
+# Identifies servers whose tool schemas are in context but can't execute.
+# =============================================================================
+_check_all_mcps() {
+	echo -e "${BLUE}=== MCP Server Health Check (t1682) ===${NC}"
+	echo ""
+	echo "Scanning all enabled MCP servers for connection errors..."
+	echo "Errored servers inject dead tool schemas into context, wasting tokens."
+	echo ""
+
+	# Resolve config file — registry-driven with opencode fallback
+	local config_file=""
+	if type rt_config_path &>/dev/null; then
+		config_file=$(rt_config_path "opencode" 2>/dev/null) || config_file=""
+	fi
+	if [[ -z "$config_file" || ! -f "$config_file" ]]; then
+		config_file="$HOME/.config/opencode/opencode.json"
+	fi
+
+	if [[ ! -f "$config_file" ]]; then
+		echo -e "${RED}✗ No MCP config file found at: $config_file${NC}"
+		return 1
+	fi
+
+	echo "Config: $config_file"
+	echo ""
+
+	# Extract enabled MCP server names and their commands using Python
+	local server_list
+	server_list=$(
+		python3 - "$config_file" <<'PYEOF'
+import json, sys
+
+config_file = sys.argv[1]
+with open(config_file) as f:
+    cfg = json.load(f)
+
+# Support both 'mcp' (opencode) and 'mcpServers' (Claude Code / other runtimes)
+mcp_section = cfg.get('mcp', cfg.get('mcpServers', {}))
+
+for name, server in mcp_section.items():
+    enabled = server.get('enabled', True)
+    if not enabled:
+        continue
+    server_type = server.get('type', 'local')
+    if server_type == 'remote':
+        # Remote MCPs: just print name with remote marker
+        print(f"{name}\tremote\t")
+        continue
+    cmd = server.get('command', [])
+    if isinstance(cmd, list) and len(cmd) > 0:
+        print(f"{name}\tlocal\t{cmd[0]}")
+    elif isinstance(cmd, str):
+        print(f"{name}\tlocal\t{cmd}")
+    else:
+        print(f"{name}\tlocal\t")
+PYEOF
+	) || {
+		echo -e "${RED}✗ Failed to parse config file${NC}"
+		return 1
+	}
+
+	if [[ -z "$server_list" ]]; then
+		echo -e "${YELLOW}No enabled MCP servers found in config.${NC}"
+		return 0
+	fi
+
+	local ok_count=0
+	local error_count=0
+	local skip_count=0
+	local errored_names=()
+
+	while IFS=$'\t' read -r name server_type cmd_path; do
+		[[ -z "$name" ]] && continue
+
+		if [[ "$server_type" == "remote" ]]; then
+			echo -e "  ${CYAN}[remote]${NC} $name — skipping connectivity check (remote MCP)"
+			((++skip_count))
+			continue
+		fi
+
+		# For local MCPs: check if the command binary exists
+		# cmd_path may be a full path (e.g. /home/user/.nvm/.../npx) or a bare name
+		local cmd_ok=false
+		if [[ -n "$cmd_path" ]]; then
+			if [[ -x "$cmd_path" ]]; then
+				cmd_ok=true
+			elif command -v "$cmd_path" &>/dev/null; then
+				cmd_ok=true
+			fi
+		fi
+
+		if [[ "$cmd_ok" == "true" ]]; then
+			echo -e "  ${GREEN}[ok]${NC}     $name"
+			((++ok_count))
+		else
+			echo -e "  ${RED}[error]${NC}  $name — command not found: ${cmd_path:-<none>}"
+			errored_names+=("$name")
+			((++error_count))
+		fi
+	done <<<"$server_list"
+
+	echo ""
+	echo "Summary: ${ok_count} ok, ${error_count} errored, ${skip_count} skipped (remote)"
+
+	if [[ ${#errored_names[@]} -gt 0 ]]; then
+		echo ""
+		echo -e "${YELLOW}=== Errored Servers — Dead Tool Schemas in Context ===${NC}"
+		echo ""
+		echo "These servers have tool schemas registered but cannot execute."
+		echo "Each errored server wastes context tokens on unusable tools."
+		echo ""
+		echo "Remediation options:"
+		echo ""
+		echo "  Option A — Fix the connection (preferred):"
+		for name in "${errored_names[@]}"; do
+			echo "    mcp-diagnose.sh $name"
+		done
+		echo ""
+		echo "  Option B — Disable until fixed (removes schemas from context):"
+		echo "    Edit $config_file"
+		for name in "${errored_names[@]}"; do
+			echo "    Set \"$name\": { ..., \"enabled\": false }"
+		done
+		echo ""
+		echo "  Option C — Remove registration entirely:"
+		for name in "${errored_names[@]}"; do
+			echo "    Delete the \"$name\" entry from $config_file"
+		done
+		echo ""
+		echo -e "${BLUE}Tip:${NC} After fixing, restart your AI runtime to reload tool schemas."
+		return 1
+	fi
+
+	echo ""
+	echo -e "${GREEN}All enabled local MCP servers have reachable commands.${NC}"
+	return 0
+}
+
+# =============================================================================
+# Single-server diagnosis (original behaviour)
+# =============================================================================
+if [[ "$MCP_NAME" == "check-all" ]]; then
+	_check_all_mcps
+	exit $?
 fi
 
 echo -e "${BLUE}=== MCP Diagnosis: $MCP_NAME ===${NC}"


### PR DESCRIPTION
## Summary

- Adds an **Errored MCP Server Guard** rule to `build.txt`: when a tool call returns `MCP error -32000: Connection closed` or similar startup errors, the agent marks that server unavailable for the session and skips its tools entirely — no retries
- Adds a **`check-all` command** to `mcp-diagnose.sh`: scans all enabled MCP servers, checks whether their command binaries are reachable, and prints remediation steps (fix connection, disable server, or remove registration)
- Updates **`mcp-troubleshooting.md`** with a new "Errored Servers — Dead Tool Schemas" section explaining the problem, the detection command, and the `"enabled": false` disable pattern

## Problem

MCP servers that fail to start (e.g., `playwright`, `cloudflare-api` with "MCP error -32000: Connection closed") may still have their tool schemas registered in the agent's tool list. The agent sees the tools, attempts to call them, and always gets a connection error — wasting context tokens on tools that can never execute.

## Solution

Three layers:
1. **Agent prompt rule** (`build.txt`) — instructs the agent to treat the first connection error as a permanent unavailability signal for that server in the session
2. **Detection script** (`mcp-diagnose.sh check-all`) — lets users proactively identify errored servers before a session starts
3. **Documentation** (`mcp-troubleshooting.md`) — explains the problem and remediation options

## Testing

```bash
# Verify check-all works
~/.aidevops/agents/scripts/mcp-diagnose.sh check-all

# Verify usage message updated
~/.aidevops/agents/scripts/mcp-diagnose.sh

# ShellCheck passes (SC1091 info only — expected for sourced files)
shellcheck .agents/scripts/mcp-diagnose.sh
```

## Runtime Testing

Risk: **Low** — agent prompt guidance + shell script + documentation only. No application logic changed.
Testing level: `self-assessed`

Closes #6809