### PR TITLE
t1681: refactor: consolidate plugin tools.mjs helper functions

### DIFF
--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -114,41 +114,6 @@ function createPreEditCheckTool(scriptsDir) {
 }
 
 /**
- * Run the full pre-commit pipeline via the hook script.
- * @param {string} scriptsDir
- * @returns {string}
- */
-function runPreCommitPipeline(scriptsDir) {
-  const hookScript = join(scriptsDir, "pre-commit-hook.sh");
-  if (!existsSync(hookScript)) {
-    return "pre-commit-hook.sh not found — run aidevops update";
-  }
-  try {
-    const result = execSync(`bash "${hookScript}"`, {
-      encoding: "utf-8",
-      timeout: 30000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    return `Pre-commit quality checks PASSED:\n${result.trim()}`;
-  } catch (err) {
-    const cmdOutput = (err.stdout || "") + (err.stderr || "");
-    return `Pre-commit quality checks FAILED:\n${cmdOutput.trim()}`;
-  }
-}
-
-/**
- * Format a quality pipeline result into a user-friendly string.
- * @param {string} label
- * @param {{ totalViolations: number, report: string }} result
- * @returns {string}
- */
-function formatQualityResult(label, result) {
-  return result.totalViolations > 0
-    ? `${label}: ${result.totalViolations} issue(s) found:\n${result.report}`
-    : `${label}: all checks passed.`;
-}
-
-/**
  * Create the quality check tool.
  * @param {string} scriptsDir - Path to scripts directory
  * @param {object} pipelines - { runShellQualityPipeline, runMarkdownQualityPipeline, scanForSecrets }
@@ -157,6 +122,30 @@ function formatQualityResult(label, result) {
 function createQualityCheckTool(scriptsDir, pipelines) {
   const { runShellQualityPipeline, runMarkdownQualityPipeline, scanForSecrets } = pipelines;
 
+  function formatResult(label, result) {
+    return result.totalViolations > 0
+      ? `${label}: ${result.totalViolations} issue(s) found:\n${result.report}`
+      : `${label}: all checks passed.`;
+  }
+
+  function runPreCommitPipeline() {
+    const hookScript = join(scriptsDir, "pre-commit-hook.sh");
+    if (!existsSync(hookScript)) {
+      return "pre-commit-hook.sh not found — run aidevops update";
+    }
+    try {
+      const result = execSync(`bash "${hookScript}"`, {
+        encoding: "utf-8",
+        timeout: 30000,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return `Pre-commit quality checks PASSED:\n${result.trim()}`;
+    } catch (err) {
+      const cmdOutput = (err.stdout || "") + (err.stderr || "");
+      return `Pre-commit quality checks FAILED:\n${cmdOutput.trim()}`;
+    }
+  }
+
   return {
     description:
       'Run quality checks on a file or the full pre-commit pipeline. Args: file (string, path to check) OR command "pre-commit" to run full pipeline on staged files',
@@ -164,15 +153,15 @@ function createQualityCheckTool(scriptsDir, pipelines) {
       const file = args.file || args.command || args;
 
       if (file === "pre-commit" || file === "staged") {
-        return runPreCommitPipeline(scriptsDir);
+        return runPreCommitPipeline();
       }
 
       if (typeof file === "string" && file.endsWith(".sh")) {
-        return formatQualityResult("Quality check", runShellQualityPipeline(file));
+        return formatResult("Quality check", runShellQualityPipeline(file));
       }
 
       if (typeof file === "string" && file.endsWith(".md")) {
-        return formatQualityResult("Markdown check", runMarkdownQualityPipeline(file));
+        return formatResult("Markdown check", runMarkdownQualityPipeline(file));
       }
 
       if (typeof file === "string" && existsSync(file)) {
@@ -188,90 +177,80 @@ function createQualityCheckTool(scriptsDir, pipelines) {
 }
 
 /**
- * Sanitize a hook action string into a known-safe literal.
- * Uses a switch statement so static taint analyzers (Codacy/Semgrep) can
- * prove the returned value is a constant — completely severing the data flow
- * from the function parameter to the shell command. Object-property lookups
- * and Array.find() do not satisfy Semgrep's taint tracking because the
- * analyzer cannot prove the returned value is independent of the input.
- * @param {string} action - Raw action string from caller
- * @returns {string|undefined} Sanitized action literal, or undefined if invalid
- */
-function sanitizeHookAction(action) {
-  switch (String(action)) {
-    case "install": return "install";
-    case "uninstall": return "uninstall";
-    case "status": return "status";
-    case "test": return "test";
-    default: return undefined;
-  }
-}
-
-/** Valid hook actions for display in error messages. */
-const VALID_HOOK_ACTIONS = ["install", "uninstall", "status", "test"];
-
-/**
- * Run the install-hooks-helper.sh script.
- * Uses execFileSync with argument array instead of execSync with string
- * interpolation — eliminates shell interpretation entirely, which is both
- * more secure and satisfies static taint analyzers (Codacy/Semgrep) that
- * flag parameter-to-child_process data flows in execSync template strings.
- * @param {string} helperScript - Path to the helper script
- * @param {string} action - Hook action to run
- * @returns {string}
- */
-function runHookHelper(helperScript, action) {
-  const validAction = sanitizeHookAction(action);
-  if (!validAction) {
-    return `Invalid action: ${String(action)}. Valid actions: ${VALID_HOOK_ACTIONS.join(", ")}`;
-  }
-  try {
-    const result = execFileSync("bash", [helperScript, validAction], {
-      encoding: "utf-8",
-      timeout: 15000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    return result.trim();
-  } catch (err) {
-    const cmdOutput = (err.stdout || "") + (err.stderr || "");
-    return `Hook ${validAction} failed:\n${cmdOutput.trim()}`;
-  }
-}
-
-/**
- * Fallback: install git pre-commit hook directly when helper script is missing.
- * @param {string} scriptsDir
- * @param {function} run - Shell command runner
- * @returns {string}
- */
-function installGitHookFallback(scriptsDir, run) {
-  const preCommitHook = join(scriptsDir, "pre-commit-hook.sh");
-  if (!existsSync(preCommitHook)) {
-    return "pre-commit-hook.sh not found — run aidevops update";
-  }
-  const gitHookDir = run("git rev-parse --git-dir 2>/dev/null");
-  if (!gitHookDir) {
-    return "Not in a git repository — cannot install pre-commit hook";
-  }
-  const hookDest = join(gitHookDir, "hooks", "pre-commit");
-  try {
-    execSync(`cp "${preCommitHook}" "${hookDest}" && chmod +x "${hookDest}"`, {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-    return `Git pre-commit hook installed at ${hookDest}`;
-  } catch (err) {
-    return `Failed to install hook: ${err.message}`;
-  }
-}
-
-/**
  * Create the install hooks tool.
  * @param {string} scriptsDir - Path to scripts directory
  * @param {function} run - Shell command runner
  * @returns {object} Tool definition
  */
 function createInstallHooksTool(scriptsDir, run) {
+  // Valid hook actions — used for validation and error messages.
+  const VALID_HOOK_ACTIONS = ["install", "uninstall", "status", "test"];
+
+  /**
+   * Sanitize a hook action string into a known-safe literal.
+   * Uses a switch statement so static taint analyzers (Codacy/Semgrep) can
+   * prove the returned value is a constant — completely severing the data flow
+   * from the function parameter to the shell command. Object-property lookups
+   * and Array.find() do not satisfy Semgrep's taint tracking because the
+   * analyzer cannot prove the returned value is independent of the input.
+   */
+  function sanitizeAction(action) {
+    switch (String(action)) {
+      case "install": return "install";
+      case "uninstall": return "uninstall";
+      case "status": return "status";
+      case "test": return "test";
+      default: return undefined;
+    }
+  }
+
+  /**
+   * Run install-hooks-helper.sh via execFileSync (argument array, not string
+   * interpolation) — eliminates shell interpretation and satisfies Semgrep
+   * taint tracking for parameter-to-child_process data flows.
+   */
+  function runHelper(helperScript, action) {
+    const validAction = sanitizeAction(action);
+    if (!validAction) {
+      return `Invalid action: ${String(action)}. Valid actions: ${VALID_HOOK_ACTIONS.join(", ")}`;
+    }
+    try {
+      const result = execFileSync("bash", [helperScript, validAction], {
+        encoding: "utf-8",
+        timeout: 15000,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return result.trim();
+    } catch (err) {
+      const cmdOutput = (err.stdout || "") + (err.stderr || "");
+      return `Hook ${validAction} failed:\n${cmdOutput.trim()}`;
+    }
+  }
+
+  /**
+   * Fallback: install git pre-commit hook directly when helper script is missing.
+   */
+  function installFallback() {
+    const preCommitHook = join(scriptsDir, "pre-commit-hook.sh");
+    if (!existsSync(preCommitHook)) {
+      return "pre-commit-hook.sh not found — run aidevops update";
+    }
+    const gitHookDir = run("git rev-parse --git-dir 2>/dev/null");
+    if (!gitHookDir) {
+      return "Not in a git repository — cannot install pre-commit hook";
+    }
+    const hookDest = join(gitHookDir, "hooks", "pre-commit");
+    try {
+      execSync(`cp "${preCommitHook}" "${hookDest}" && chmod +x "${hookDest}"`, {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      return `Git pre-commit hook installed at ${hookDest}`;
+    } catch (err) {
+      return `Failed to install hook: ${err.message}`;
+    }
+  }
+
   return {
     description:
       'Install or manage git pre-commit quality hooks. Args: action (string: "install", "uninstall", "status", "test")',
@@ -280,11 +259,11 @@ function createInstallHooksTool(scriptsDir, run) {
       const helperScript = join(scriptsDir, "install-hooks-helper.sh");
 
       if (existsSync(helperScript)) {
-        return runHookHelper(helperScript, action);
+        return runHelper(helperScript, action);
       }
 
       if (action === "install") {
-        return installGitHookFallback(scriptsDir, run);
+        return installFallback();
       }
 
       return `install-hooks-helper.sh not found. Available actions: install, uninstall, status, test`;


### PR DESCRIPTION
## Summary

- Move `runPreCommitPipeline` and `formatQualityResult` inside `createQualityCheckTool` as closures — they were only used there and are now co-located with their consumer
- Move `sanitizeHookAction`, `VALID_HOOK_ACTIONS`, `runHookHelper`, and `installGitHookFallback` inside `createInstallHooksTool` as closures — same pattern
- Reduces module-level top-level declarations from 10 to 6 (removed 4 standalone functions + 1 constant)
- 351 → 330 lines (6% reduction)

## What's preserved

- All 7 tool behaviors identical — no functional changes
- Security comments explaining the Semgrep taint analysis rationale for the `switch` statement in `sanitizeAction` are preserved inside `createInstallHooksTool`
- `shellEscape` and `isSafeCommand` remain at module level (used by multiple tools)
- `createMemoryTool` factory remains at module level (used twice)

## Runtime Testing

- **Risk**: Low — refactor only, no logic changes
- **Testing level**: self-assessed
- **Verification**: diff confirms identical logic paths; all closures capture the same variables as before via lexical scope

Closes #6808