### PR TITLE
t1679.1: Extract Conversational Memory Lookup to reference/memory-lookup.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -310,6 +310,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Model routing | `tools/context/model-routing.md`, `reference/orchestration.md` |
 | Orchestration | `reference/orchestration.md`, `tools/ai-assistants/headless-dispatch.md`, `scripts/commands/pulse.md`, `scripts/commands/dashboard.md` |
 | Upstream watch | `scripts/upstream-watch-helper.sh`, `.agents/configs/upstream-watch.json` |
+| Memory/Session lookup | `reference/memory-lookup.md`, `reference/session.md` |
 | Testing | `scripts/commands/testing-setup.md`, `tools/build-agent/agent-testing.md`, `scripts/testing-setup-helper.sh` |
 | Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md`, `tools/mcp-toolkit/mcporter.md` |
 | Framework | `aidevops/architecture.md`, `scripts/commands/skills.md` |
@@ -322,7 +323,7 @@ Key capabilities (details in `reference/orchestration.md`, `reference/services.m
 
 - **Model routing**: local→haiku→flash→sonnet→pro→opus (cost-aware). See `tools/context/model-routing.md`.
 - **Bundle presets**: Project-type-aware defaults for model tiers, quality gates, and agent routing. Auto-detected from marker files or explicit in repos.json. See `bundles/` and `scripts/bundle-helper.sh`.
-- **Memory**: cross-session SQLite FTS5 (`/remember`, `/recall`)
+- **Memory**: cross-session SQLite FTS5 (`/remember`, `/recall`). Conversational lookup: `reference/memory-lookup.md`
 - **Orchestration**: supervisor dispatch, pulse scheduler, auto-pickup, cross-repo issue/PR/TODO visibility
 - **Contribution watch**: monitors external issues/PRs for new activity needing reply using the GitHub Notifications API. `contribution-watch-helper.sh seed|scan|status|install|uninstall` (optional `scan --backfill` for low-frequency safety-net sweeps of tracked threads). Managed repos (`pulse: true` in repos.json) are excluded to suppress internal automation noise. Prompt-injection-safe — automated scans are deterministic metadata checks (no LLM), comment bodies only shown in interactive sessions after `prompt-guard-helper.sh scan`.
 - **Upstream watch**: monitors external repos we've borrowed ideas/code from for new releases. `upstream-watch-helper.sh add|remove|check|ack|status`. Shows release diffs and changelogs between our last-seen version and latest. Distinct from skill imports (code we pulled in) and contribution watch (repos we filed issues on) — this tracks "inspiration repos" for passive monitoring. Config: `.agents/configs/upstream-watch.json`.

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -481,66 +481,10 @@ Git is the primary audit trail for all work. Every change should be discoverable
 - MCP tools loaded on-demand per subagent (reduces context overhead)
 
 # Conversational Memory Lookup
-# When the user references past work — "remember when we...", "that thing we built",
-# "last week we did...", "the session where...", "we already solved this" — they are
-# recalling something from a previous session. The current session has no memory of it
-# unless you actively search. This is a judgment call, not a keyword trigger.
-#
-# Progressive discovery — same principle as agent context loading. Search from
-# short-term/local (instant, free) through long-term/remote (API calls, expensive).
-# Stop as soon as you have enough context to respond. Don't search all sources for
-# every vague reference — match the source to the question.
-#
-# Tier 1 — Local cached (instant, zero cost):
-# 1. Cross-session memory: `memory-helper.sh recall "keywords"` (CLI) or
-#    `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have
-#    the answer. Solutions, decisions, preferences, patterns.
-# 2. TODO.md + completed tasks: `rg "keyword" TODO.md` — task IDs, PR numbers,
-#    completion dates, brief descriptions of all past work.
-#
-# Tier 2 — Local indexed (fast, local I/O):
-# 3. Git history: `git log --all --oneline --grep="keyword"` — commits, branches,
-#    PRs, code changes. High volume but precise when the keyword is specific.
-# 4. Session transcripts (Claude Code): `~/.claude/transcripts/*.jsonl` — full
-#    JSONL conversation logs. `rg "keyword" ~/.claude/transcripts/`. Recovers
-#    exact conversation context, what was discussed, tool calls made.
-#    For structured field searches, pipe through jq:
-#    `rg -l "keyword" ~/.claude/transcripts/ | xargs -I{} jq 'select(.type=="assistant") | .message.content' {}`
-# 5. Session database: runtime-specific — see AGENTS.md for paths per runtime.
-# 6. Observability metrics: `~/.aidevops/.agent-workspace/observability/metrics.jsonl`
-#    — JSONL log of LLM request metadata, costs, models, tokens per session.
-#    Fields per record: provider, model, session_id, request_id, project,
-#    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-#    cost_input, cost_output, cost_total, stop_reason, git_branch, recorded_at.
-#    Example: jq -s '[.[] | select(.project=="aidevops")] | group_by(.model)
-#    | map({model:.[0].model, total_cost:([.[].cost_total] | add),
-#    requests:length})' ~/.aidevops/.agent-workspace/observability/metrics.jsonl
-#
-# Tier 3 — Remote targeted (API calls, need a specific number):
-# 7. GitHub issue/PR comments: `gh issue view {num} --comments --repo {slug}`,
-#    `gh pr view {num} --comments --repo {slug}`, or the API equivalents
-#    `gh api repos/{slug}/issues/{num}/comments` and
-#    `gh api repos/{slug}/pulls/{num}/comments` (for inline review comments).
-#    Discussion, review feedback, decisions made in threads — context that never
-#    reaches git or memory. Get the issue/PR number from TODO.md first.
-#
-# Tier 4 — Remote broad (expensive, last resort):
-# 8. GitHub search: `gh search issues "keyword" --repo {slug}` (issues),
-#    `gh search prs "keyword" --repo {slug}` (PRs),
-#    `gh search code "keyword" --repo {slug}` (code). Broad search when you
-#    don't know the issue/PR number.
-# 9. GitHub discussions: `gh api repos/{slug}/discussions` (if enabled).
-#    Long-form design discussions, RFCs, community Q&A.
-# 10. GitHub wiki: `gh api repos/{slug}/pages` or clone the wiki repo
-#    (`git clone https://github.com/{slug}.wiki.git`). Persistent documentation that may contain
-#    architectural decisions, onboarding guides, or historical context.
-#
-# Examples:
-# "Remember that auth fix?" → memory recall + git log.
-# "What did we discuss about the database schema?" → memory recall + transcripts.
-# "How much did last week's batch run cost?" → observability metrics.
-# "What did the reviewer say about that PR?" → TODO.md (get PR#) + PR comments.
-# "Was there a discussion about the migration?" → GitHub discussions/wiki.
+# When the user references past work from a previous session, search progressively
+# from local/cached (instant, free) through remote/broad (API calls, expensive).
+# Stop as soon as you have enough context. This is a judgment call, not a keyword trigger.
+# Full tier breakdown and examples: `reference/memory-lookup.md`
 
 # Intelligence Over Determinism (CORE PRINCIPLE)
 You are an LLM. You can read an issue body, understand context, assess whether something is blocked, stuck, duplicated, or ready — and act on that understanding. No regex, state machine, or if/then ruleset can do this. The framework exists to give you goals, tools, and boundaries — not to script your decisions.

--- a/.agents/reference/memory-lookup.md
+++ b/.agents/reference/memory-lookup.md
@@ -1,0 +1,75 @@
+# Conversational Memory Lookup — Detail Reference
+
+Loaded on-demand when the user references past work from a previous session.
+Core pointer is in `prompts/build.txt` "Conversational Memory Lookup".
+
+When the user references past work — "remember when we...", "that thing we built",
+"last week we did...", "the session where...", "we already solved this" — they are
+recalling something from a previous session. The current session has no memory of it
+unless you actively search. This is a judgment call, not a keyword trigger.
+
+Progressive discovery — same principle as agent context loading. Search from
+short-term/local (instant, free) through long-term/remote (API calls, expensive).
+Stop as soon as you have enough context to respond. Don't search all sources for
+every vague reference — match the source to the question.
+
+## Tier 1 — Local Cached (instant, zero cost)
+
+1. **Cross-session memory**: `memory-helper.sh recall "keywords"` (CLI) or
+   `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have
+   the answer. Solutions, decisions, preferences, patterns.
+2. **TODO.md + completed tasks**: `rg "keyword" TODO.md` — task IDs, PR numbers,
+   completion dates, brief descriptions of all past work.
+
+## Tier 2 — Local Indexed (fast, local I/O)
+
+3. **Git history**: `git log --all --oneline --grep="keyword"` — commits, branches,
+   PRs, code changes. High volume but precise when the keyword is specific.
+4. **Session transcripts (Claude Code)**: `~/.claude/transcripts/*.jsonl` — full
+   JSONL conversation logs. `rg "keyword" ~/.claude/transcripts/`. Recovers
+   exact conversation context, what was discussed, tool calls made.
+   For structured field searches, pipe through jq:
+   `rg -l "keyword" ~/.claude/transcripts/ | xargs -I{} jq 'select(.type=="assistant") | .message.content' {}`
+5. **Session database**: runtime-specific — see `AGENTS.md` for paths per runtime.
+6. **Observability metrics**: `~/.aidevops/.agent-workspace/observability/metrics.jsonl`
+   — JSONL log of LLM request metadata, costs, models, tokens per session.
+   Fields per record: provider, model, session_id, request_id, project,
+   input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+   cost_input, cost_output, cost_total, stop_reason, git_branch, recorded_at.
+
+   ```bash
+   jq -s '[.[] | select(.project=="aidevops")] | group_by(.model)
+   | map({model:.[0].model, total_cost:([.[].cost_total] | add),
+   requests:length})' ~/.aidevops/.agent-workspace/observability/metrics.jsonl
+   ```
+
+## Tier 3 — Remote Targeted (API calls, need a specific number)
+
+7. **GitHub issue/PR comments**: `gh issue view {num} --comments --repo {slug}`,
+   `gh pr view {num} --comments --repo {slug}`, or the API equivalents
+   `gh api repos/{slug}/issues/{num}/comments` and
+   `gh api repos/{slug}/pulls/{num}/comments` (for inline review comments).
+   Discussion, review feedback, decisions made in threads — context that never
+   reaches git or memory. Get the issue/PR number from TODO.md first.
+
+## Tier 4 — Remote Broad (expensive, last resort)
+
+8. **GitHub search**: `gh search issues "keyword" --repo {slug}` (issues),
+   `gh search prs "keyword" --repo {slug}` (PRs),
+   `gh search code "keyword" --repo {slug}` (code). Broad search when you
+   don't know the issue/PR number.
+9. **GitHub discussions**: `gh api repos/{slug}/discussions` (if enabled).
+   Long-form design discussions, RFCs, community Q&A.
+10. **GitHub wiki**: `gh api repos/{slug}/pages` or clone the wiki repo
+    (`git clone https://github.com/{slug}.wiki.git`). Persistent documentation that may contain
+    architectural decisions, onboarding guides, or historical context.
+
+## Examples
+
+| Query | Sources |
+|-------|---------|
+| "Remember that auth fix?" | memory recall + git log |
+| "What did we discuss about the database schema?" | memory recall + transcripts |
+| "How much did last week's batch run cost?" | observability metrics |
+| "What did the reviewer say about that PR?" | TODO.md (get PR#) + PR comments |
+| "Was there a discussion about the migration?" | GitHub discussions/wiki |


### PR DESCRIPTION
## Summary

- Extracts the 60-line Conversational Memory Lookup tier guide from `prompts/build.txt` into a dedicated reference file at `.agents/reference/memory-lookup.md`
- Replaces the inline block in `build.txt` with a 4-line pointer (progressive discovery summary + link)
- Adds `Memory/Session lookup` row to the AGENTS.md domain index table
- Updates the `Memory` capability bullet in AGENTS.md to link the new file

## Changes

- `.agents/reference/memory-lookup.md` — new file, full tier breakdown (Tier 1–4) with examples table
- `.agents/prompts/build.txt` — 60 lines → 4 lines (pointer only)
- `.agents/AGENTS.md` — domain index + capability bullet updated

## Runtime Testing

- **Risk classification**: Low (docs/agent prompts only, no code)
- **Testing level**: self-assessed
- **Verification**: content preserved verbatim, pointer links correct path

Closes #6796