### PR TITLE
t1679.2: Extract Screenshot Size Limits to reference/screenshot-limits.md

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -129,20 +129,11 @@ When referencing specific functions or code include the pattern `file_path:line_
 - For remote repos: fetch README first, check size with `gh api`, use `includePatterns`
 
 # Screenshot Size Limits (CRITICAL — session-crashing)
-# Anthropic hard-rejects images >8000px on any dimension. This crashes the session
-# because the oversized image is already in message history — every subsequent
-# API call fails with the same error. There is no recovery except starting a new
-# session and losing all conversation context.
-# GH#4213 added guardrails to browser-qa-helper.sh but agents take screenshots
-# through at least 5 other paths that bypass those guardrails entirely.
+# Full rules, resize commands, and path risk table: `reference/screenshot-limits.md`
 - NEVER use `fullPage: true` for screenshots intended for AI vision review. Use viewport-sized screenshots instead (`fullPage: false` or omit the option).
-- When full-page capture is genuinely needed (human review, visual regression, saving to disk for later), save to file and resize before including in conversation context:
-  `sips --resampleHeightWidthMax 1568 screenshot.png --out screenshot-resized.png` (macOS)
-  `magick screenshot.png -resize "1568x1568>" screenshot-resized.png` (ImageMagick, cross-platform)
-- For AI vision review: target max 1568px on the longest side. Images above this are auto-downscaled by the API, adding latency with no quality benefit.
-- Anthropic hard limit: 8000px on any single dimension. Images at or above this are rejected outright.
-- The Playwright MCP `browser_screenshot` tool returns base64 images directly into conversation context with NO resize hook. There is no way to intercept or resize these images after the tool returns. Prefer `browser-qa-helper.sh screenshot` which has built-in guardrails, or use viewport-sized screenshots via Playwright direct.
-- The `browser-qa-helper.sh screenshot` command is the ONLY screenshot path with automatic size guardrails (post-capture resize to `--max-dim`, default 4000px). All other paths — Playwright MCP, Playwriter MCP, dev-browser scripts, raw Playwright code — have zero size protection.
+- Anthropic hard limit: 8000px on any single dimension — session crashes with no recovery.
+- For AI vision review: target max 1568px. Resize with `sips --resampleHeightWidthMax 1568` (macOS) or `magick -resize "1568x1568>"` (cross-platform).
+- The Playwright MCP `browser_screenshot` tool has NO resize hook — prefer `browser-qa-helper.sh screenshot` (only path with automatic guardrails).
 
 # Error Prevention (top recurring patterns from session mining)
 #

--- a/.agents/reference/screenshot-limits.md
+++ b/.agents/reference/screenshot-limits.md
@@ -1,0 +1,48 @@
+# Screenshot Size Limits (CRITICAL — session-crashing)
+
+Anthropic hard-rejects images >8000px on any dimension. This crashes the session
+because the oversized image is already in message history — every subsequent
+API call fails with the same error. There is no recovery except starting a new
+session and losing all conversation context.
+
+GH#4213 added guardrails to `browser-qa-helper.sh` but agents take screenshots
+through at least 5 other paths that bypass those guardrails entirely.
+
+## Rules
+
+- NEVER use `fullPage: true` for screenshots intended for AI vision review. Use viewport-sized screenshots instead (`fullPage: false` or omit the option).
+- When full-page capture is genuinely needed (human review, visual regression, saving to disk for later), save to file and resize before including in conversation context:
+  - macOS: `sips --resampleHeightWidthMax 1568 screenshot.png --out screenshot-resized.png`
+  - Cross-platform: `magick screenshot.png -resize "1568x1568>" screenshot-resized.png`
+- For AI vision review: target max 1568px on the longest side. Images above this are auto-downscaled by the API, adding latency with no quality benefit.
+- Anthropic hard limit: 8000px on any single dimension. Images at or above this are rejected outright.
+- The Playwright MCP `browser_screenshot` tool returns base64 images directly into conversation context with NO resize hook. There is no way to intercept or resize these images after the tool returns. Prefer `browser-qa-helper.sh screenshot` which has built-in guardrails, or use viewport-sized screenshots via Playwright direct.
+- The `browser-qa-helper.sh screenshot` command is the ONLY screenshot path with automatic size guardrails (post-capture resize to `--max-dim`, default 4000px). All other paths — Playwright MCP, Playwriter MCP, dev-browser scripts, raw Playwright code — have zero size protection.
+
+## Screenshot Paths and Risk
+
+| Path | Guardrails | Risk |
+|------|-----------|------|
+| `browser-qa-helper.sh screenshot` | Auto-resize to `--max-dim` (default 4000px) | Low |
+| Playwright MCP `browser_screenshot` | None — base64 direct to context | **High** |
+| Playwriter MCP | None | **High** |
+| dev-browser scripts | None | **High** |
+| Raw Playwright code | None | **High** |
+
+## Resize Commands
+
+```bash
+# macOS (sips — built-in, no install required)
+sips --resampleHeightWidthMax 1568 screenshot.png --out screenshot-resized.png
+
+# Cross-platform (ImageMagick)
+magick screenshot.png -resize "1568x1568>" screenshot-resized.png
+```
+
+## Size Targets
+
+| Use case | Max dimension | Notes |
+|----------|--------------|-------|
+| AI vision review | 1568px | API auto-downscales above this — no quality benefit |
+| `browser-qa-helper.sh` default | 4000px | Safe for most uses; resize further for AI review |
+| Anthropic hard limit | 8000px | Rejected outright — session crashes, no recovery |


### PR DESCRIPTION
## Summary

- Extracts the verbose Screenshot Size Limits section from `build.txt` into a dedicated reference file at `.agents/reference/screenshot-limits.md`
- `build.txt` now has 4 concise bullet points + a pointer to the reference file (down from 14 lines), reducing prompt token overhead
- Reference file adds a structured path risk table, resize command examples, and size target table for quick lookup

## Changes

- `.agents/prompts/build.txt` — replaced 14-line section with 4-line summary + pointer
- `.agents/reference/screenshot-limits.md` — new file with full detail: rules, path risk table, resize commands, size targets

## Runtime Testing

- **Risk classification**: Low (docs/reference only — no code, scripts, or logic changed)
- **Testing level**: self-assessed
- **Verification**: Confirmed build.txt section is concise and pointer is correct; reference file contains all original content plus structured tables

Closes #6797