### PR TITLE
t1679.1: Extract Conversational Memory Lookup to reference/memory-lookup.md

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -527,66 +527,9 @@ Git is the primary audit trail for all work. Every change should be discoverable
 - MCP tools loaded on-demand per subagent (reduces context overhead)
 
 # Conversational Memory Lookup
-# When the user references past work — "remember when we...", "that thing we built",
-# "last week we did...", "the session where...", "we already solved this" — they are
-# recalling something from a previous session. The current session has no memory of it
-# unless you actively search. This is a judgment call, not a keyword trigger.
-#
-# Progressive discovery — same principle as agent context loading. Search from
-# short-term/local (instant, free) through long-term/remote (API calls, expensive).
-# Stop as soon as you have enough context to respond. Don't search all sources for
-# every vague reference — match the source to the question.
-#
-# Tier 1 — Local cached (instant, zero cost):
-# 1. Cross-session memory: `memory-helper.sh recall "keywords"` (CLI) or
-#    `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have
-#    the answer. Solutions, decisions, preferences, patterns.
-# 2. TODO.md + completed tasks: `rg "keyword" TODO.md` — task IDs, PR numbers,
-#    completion dates, brief descriptions of all past work.
-#
-# Tier 2 — Local indexed (fast, local I/O):
-# 3. Git history: `git log --all --oneline --grep="keyword"` — commits, branches,
-#    PRs, code changes. High volume but precise when the keyword is specific.
-# 4. Session transcripts (Claude Code): `~/.claude/transcripts/*.jsonl` — full
-#    JSONL conversation logs. `rg "keyword" ~/.claude/transcripts/`. Recovers
-#    exact conversation context, what was discussed, tool calls made.
-#    For structured field searches, pipe through jq:
-#    `rg -l "keyword" ~/.claude/transcripts/ | xargs -I{} jq 'select(.type=="assistant") | .message.content' {}`
-# 5. Session database: runtime-specific — see AGENTS.md for paths per runtime.
-# 6. Observability metrics: `~/.aidevops/.agent-workspace/observability/metrics.jsonl`
-#    — JSONL log of LLM request metadata, costs, models, tokens per session.
-#    Fields per record: provider, model, session_id, request_id, project,
-#    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-#    cost_input, cost_output, cost_total, stop_reason, git_branch, recorded_at.
-#    Example: jq -s '[.[] | select(.project=="aidevops")] | group_by(.model)
-#    | map({model:.[0].model, total_cost:([.[].cost_total] | add),
-#    requests:length})' ~/.aidevops/.agent-workspace/observability/metrics.jsonl
-#
-# Tier 3 — Remote targeted (API calls, need a specific number):
-# 7. GitHub issue/PR comments: `gh issue view {num} --comments --repo {slug}`,
-#    `gh pr view {num} --comments --repo {slug}`, or the API equivalents
-#    `gh api repos/{slug}/issues/{num}/comments` and
-#    `gh api repos/{slug}/pulls/{num}/comments` (for inline review comments).
-#    Discussion, review feedback, decisions made in threads — context that never
-#    reaches git or memory. Get the issue/PR number from TODO.md first.
-#
-# Tier 4 — Remote broad (expensive, last resort):
-# 8. GitHub search: `gh search issues "keyword" --repo {slug}` (issues),
-#    `gh search prs "keyword" --repo {slug}` (PRs),
-#    `gh search code "keyword" --repo {slug}` (code). Broad search when you
-#    don't know the issue/PR number.
-# 9. GitHub discussions: `gh api repos/{slug}/discussions` (if enabled).
-#    Long-form design discussions, RFCs, community Q&A.
-# 10. GitHub wiki: `gh api repos/{slug}/pages` or clone the wiki repo
-#    (`git clone https://github.com/{slug}.wiki.git`). Persistent documentation that may contain
-#    architectural decisions, onboarding guides, or historical context.
-#
-# Examples:
-# "Remember that auth fix?" → memory recall + git log.
-# "What did we discuss about the database schema?" → memory recall + transcripts.
-# "How much did last week's batch run cost?" → observability metrics.
-# "What did the reviewer say about that PR?" → TODO.md (get PR#) + PR comments.
-# "Was there a discussion about the migration?" → GitHub discussions/wiki.
+# When user references past work ("remember when...", "that thing we built"), search
+# progressively: memory recall → TODO.md → git log → transcripts → GitHub API.
+# Full 4-tier lookup guide: `reference/memory-lookup.md`
 
 # Intelligence Over Determinism (CORE PRINCIPLE)
 You are an LLM. You can read an issue body, understand context, assess whether something is blocked, stuck, duplicated, or ready — and act on that understanding. No regex, state machine, or if/then ruleset can do this. The framework exists to give you goals, tools, and boundaries — not to script your decisions.

--- a/.agents/reference/memory-lookup.md
+++ b/.agents/reference/memory-lookup.md
@@ -1,0 +1,65 @@
+# Conversational Memory Lookup
+
+When the user references past work — "remember when we...", "that thing we built",
+"last week we did...", "the session where...", "we already solved this" — they are
+recalling something from a previous session. The current session has no memory of it
+unless you actively search. This is a judgment call, not a keyword trigger.
+
+Progressive discovery — same principle as agent context loading. Search from
+short-term/local (instant, free) through long-term/remote (API calls, expensive).
+Stop as soon as you have enough context to respond. Don't search all sources for
+every vague reference — match the source to the question.
+
+## Tier 1 — Local cached (instant, zero cost)
+
+1. **Cross-session memory**: `memory-helper.sh recall "keywords"` (CLI) or
+   `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have
+   the answer. Solutions, decisions, preferences, patterns.
+2. **TODO.md + completed tasks**: `rg "keyword" TODO.md` — task IDs, PR numbers,
+   completion dates, brief descriptions of all past work.
+
+## Tier 2 — Local indexed (fast, local I/O)
+
+3. **Git history**: `git log --all --oneline --grep="keyword"` — commits, branches,
+   PRs, code changes. High volume but precise when the keyword is specific.
+4. **Session transcripts (Claude Code)**: `~/.claude/projects/` — per-project session
+   transcripts in JSONL. `rg "keyword" ~/.claude/projects/`. Recovers exact
+   conversation context, what was discussed, tool calls made.
+   For structured field searches, pipe through jq:
+   `rg -l "keyword" ~/.claude/projects/ | xargs -I{} jq 'select(.type=="assistant") | .message.content' {}`
+5. **Session database**: runtime-specific — see AGENTS.md for paths per runtime.
+6. **Observability metrics**: `~/.aidevops/.agent-workspace/observability/metrics.jsonl`
+   — JSONL log of LLM request metadata, costs, models, tokens per session.
+   Fields per record: provider, model, session_id, request_id, project,
+   input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+   cost_input, cost_output, cost_total, stop_reason, git_branch, recorded_at.
+   Example: `jq -s '[.[] | select(.project=="aidevops")] | group_by(.model) | map({model:.[0].model, total_cost:([.[].cost_total] | add), requests:length})' ~/.aidevops/.agent-workspace/observability/metrics.jsonl`
+
+## Tier 3 — Remote targeted (API calls, need a specific number)
+
+7. **GitHub issue/PR comments**: `gh issue view {num} --comments --repo {slug}`,
+   `gh pr view {num} --comments --repo {slug}`, or the API equivalents
+   `gh api repos/{slug}/issues/{num}/comments` and
+   `gh api repos/{slug}/pulls/{num}/comments` (for inline review comments).
+   Discussion, review feedback, decisions made in threads — context that never
+   reaches git or memory. Get the issue/PR number from TODO.md first.
+
+## Tier 4 — Remote broad (expensive, last resort)
+
+8. **GitHub search**: `gh search issues "keyword" --repo {slug}` (issues),
+   `gh search prs "keyword" --repo {slug}` (PRs),
+   `gh search code "keyword" --repo {slug}` (code). Broad search when you
+   don't know the issue/PR number.
+9. **GitHub discussions**: `gh api repos/{slug}/discussions` (if enabled).
+   Long-form design discussions, RFCs, community Q&A.
+10. **GitHub wiki**: `gh api repos/{slug}/pages` or clone the wiki repo
+    (`git clone https://github.com/{slug}.wiki.git`). Persistent documentation that may contain
+    architectural decisions, onboarding guides, or historical context.
+
+## Examples
+
+- "Remember that auth fix?" → memory recall + git log.
+- "What did we discuss about the database schema?" → memory recall + transcripts.
+- "How much did last week's batch run cost?" → observability metrics.
+- "What did the reviewer say about that PR?" → TODO.md (get PR#) + PR comments.
+- "Was there a discussion about the migration?" → GitHub discussions/wiki.


### PR DESCRIPTION
## Summary

- Extracts the 57-line Conversational Memory Lookup section from `.agents/prompts/build.txt` into a new dedicated reference file `.agents/reference/memory-lookup.md`
- Replaces the inline block with a 4-line pointer: `Full 4-tier lookup guide: \`reference/memory-lookup.md\``
- Reduces build.txt from 650 to 593 lines (progressive disclosure pattern)

## Changes

- `.agents/prompts/build.txt` — section replaced with 1-line pointer (+ 3 lines of context)
- `.agents/reference/memory-lookup.md` — new file with full 4-tier lookup guide in proper markdown format

## Runtime Testing

- **Risk classification**: Low — docs/agent prompt only, no code logic changed
- **Testing level**: self-assessed
- **Verification**: `grep -n "Conversational Memory" .agents/prompts/build.txt` confirms pointer present; `ls .agents/reference/memory-lookup.md` confirms file created

Closes #6796