### PR TITLE
t1679.3: Extract External Repo Issue/PR Submission to reference/external-repo-submissions.md

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -362,39 +362,8 @@ Git is the primary audit trail for all work. Every change should be discoverable
 **Pulse scope boundary (t1405, GH#2928):** When dispatched by the pulse, `PULSE_SCOPE_REPOS` (comma-separated repo slugs) defines which repos you may create branches and PRs on. Filing issues is always allowed on any repo. Code changes (branches, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop — do not implement the fix. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies. This prevents pulse-dispatched workers from creating PRs on repos outside the user's managed scope.
 
 # External Repo Issue/PR Submission (t1407)
-# When filing issues or PRs on repos we don't maintain, template compliance bots
-# (e.g., GitHub Actions that check issue format) will auto-close submissions that
-# don't match the repo's required templates. Many popular repos enforce this —
-# well-crafted issues get closed within hours if they don't use the right format.
-#
-# This is a judgment call, not a deterministic check. Read the templates and
-# contributing guidelines, then format your submission accordingly.
-- Before `gh issue create --repo <slug>` on a repo NOT in `~/.config/aidevops/repos.json`:
-  1. Check for issue templates with explicit status handling (`404` means "missing", anything else fails):
-     ```bash
-     endpoint="repos/{slug}/contents/.github/ISSUE_TEMPLATE/"
-     resp=$(gh api --include "$endpoint") || { echo "gh api failed: $endpoint" >&2; exit 1; }
-     status=$(printf '%s\n' "$resp" | awk 'NR==1 {print $2}')
-     if [[ "$status" == "404" ]]; then
-       templates="[]"
-     elif [[ "$status" != "200" ]]; then
-       echo "gh api error $status: $endpoint" >&2
-       exit 1
-     else
-       body=$(printf '%s\n' "$resp" | sed '1,/^\r$/d')
-       templates=$(printf '%s\n' "$body" | jq -r '.[].name')
-     fi
-     ```
-  2. If templates exist, fetch the relevant one (e.g., `bug-report.yml`) using the same `--include` status pattern; only decode `200` bodies (`base64 -d`).
-  3. Check for `CONTRIBUTING.md` using the same `--include` status pattern; continue on `404`, fail on other non-`200` statuses.
-  4. Format the issue body to match the required template structure. YAML form templates (`.yml`) generate `### Label` section headers when submitted via the web UI — replicate this structure in your `--body`.
-  5. If no templates exist, use a clear, well-structured format (title, description, steps to reproduce, expected/actual behaviour).
-- Before `gh pr create` targeting an external repo:
-  1. Check for PR templates with the same `gh api --include` status parsing (`404` allowed, other non-`200` statuses fail).
-  2. Check `CONTRIBUTING.md` for PR requirements (branch naming, commit format, CLA, etc.)
-  3. Format the PR body to match their template and follow their contributing guidelines.
-- If a submission is auto-closed by a compliance bot, read the bot's comment for formatting requirements, then resubmit with the correct format.
-- Practical examples and template mapping: `tools/git/github-cli.md` "External Repo Submissions" section.
+# When filing issues/PRs on external repos, check their templates and CONTRIBUTING.md first.
+# Compliance bots auto-close non-conforming submissions. Read `reference/external-repo-submissions.md`.
 
 **Git-readiness check:** When working in a project directory that is NOT a git repo, or is a git repo without `TODO.md` / aidevops initialisation, flag this to the user: "This project has no git tracking / no aidevops task management. Work here won't be traceable. Consider `git init` + `aidevops init` to enable the full workflow." Use judgment — a throwaway script directory doesn't need this, but any project with ongoing development does.
 

--- a/.agents/reference/external-repo-submissions.md
+++ b/.agents/reference/external-repo-submissions.md
@@ -1,0 +1,54 @@
+# External Repo Issue/PR Submission (t1407)
+
+When filing issues or PRs on repos we don't maintain, template compliance bots
+(e.g., GitHub Actions that check issue format) will auto-close submissions that
+don't match the repo's required templates. Many popular repos enforce this —
+well-crafted issues get closed within hours if they don't use the right format.
+
+This is a judgment call, not a deterministic check. Read the templates and
+contributing guidelines, then format your submission accordingly.
+
+## Filing Issues on External Repos
+
+Before `gh issue create --repo <slug>` on a repo NOT in `~/.config/aidevops/repos.json`:
+
+1. Check for issue templates with explicit status handling (`404` means "missing", anything else fails):
+
+   ```bash
+   endpoint="repos/{slug}/contents/.github/ISSUE_TEMPLATE/"
+   resp=$(gh api --include "$endpoint") || { echo "gh api failed: $endpoint" >&2; exit 1; }
+   status=$(printf '%s\n' "$resp" | awk 'NR==1 {print $2}')
+   if [[ "$status" == "404" ]]; then
+     templates="[]"
+   elif [[ "$status" != "200" ]]; then
+     echo "gh api error $status: $endpoint" >&2
+     exit 1
+   else
+     body=$(printf '%s\n' "$resp" | sed '1,/^\r$/d')
+     templates=$(printf '%s\n' "$body" | jq -r '.[].name')
+   fi
+   ```
+
+2. If templates exist, fetch the relevant one (e.g., `bug-report.yml`) using the same `--include` status pattern; only decode `200` bodies (`base64 -d`).
+
+3. Check for `CONTRIBUTING.md` using the same `--include` status pattern; continue on `404`, fail on other non-`200` statuses.
+
+4. Format the issue body to match the required template structure. YAML form templates (`.yml`) generate `### Label` section headers when submitted via the web UI — replicate this structure in your `--body`.
+
+5. If no templates exist, use a clear, well-structured format (title, description, steps to reproduce, expected/actual behaviour).
+
+## Filing PRs on External Repos
+
+Before `gh pr create` targeting an external repo:
+
+1. Check for PR templates with the same `gh api --include` status parsing (`404` allowed, other non-`200` statuses fail).
+2. Check `CONTRIBUTING.md` for PR requirements (branch naming, commit format, CLA, etc.)
+3. Format the PR body to match their template and follow their contributing guidelines.
+
+## Auto-Closed Submissions
+
+If a submission is auto-closed by a compliance bot, read the bot's comment for formatting requirements, then resubmit with the correct format.
+
+## Practical Examples
+
+Template mapping and worked examples: `tools/git/github-cli.md` "External Repo Submissions" section.


### PR DESCRIPTION
## Summary

- Extracts the ~500-token External Repo Issue/PR Submission section from `prompts/build.txt` into a new on-demand reference file `reference/external-repo-submissions.md`
- Replaces the inline block with a 3-line pointer comment in `build.txt`
- Part of the t1679 progressive-load refactor to reduce build.txt from ~14k to ~10k tokens

## Files Changed

- `.agents/prompts/build.txt` — section replaced with 1-line pointer (saves ~500 tokens)
- `.agents/reference/external-repo-submissions.md` — new file with full extracted content

## Runtime Testing

- **Risk classification:** Low (docs/agent prompts only — no code logic changed)
- **Testing level:** self-assessed
- **Verification:** confirmed pointer text matches the new file path; full content preserved in reference file

Closes #6798