### PR TITLE
t1679.3: Extract External Repo Issue/PR Submission to reference/external-repo-submission.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -283,6 +283,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Planning | `workflows/plans.md`, `scripts/commands/define.md`, `tools/task-management/beads.md` |
 | Code quality | `tools/code-review/code-standards.md` |
 | Git/PRs/Releases | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `workflows/release.md` |
+| External repo submissions | `reference/external-repo-submission.md` |
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Product (shared) | `product/validation.md`, `product/onboarding.md`, `product/monetisation.md`, `product/growth.md`, `product/ui-design.md`, `product/analytics.md` |

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -363,38 +363,9 @@ Git is the primary audit trail for all work. Every change should be discoverable
 
 # External Repo Issue/PR Submission (t1407)
 # When filing issues or PRs on repos we don't maintain, template compliance bots
-# (e.g., GitHub Actions that check issue format) will auto-close submissions that
-# don't match the repo's required templates. Many popular repos enforce this —
-# well-crafted issues get closed within hours if they don't use the right format.
-#
-# This is a judgment call, not a deterministic check. Read the templates and
-# contributing guidelines, then format your submission accordingly.
-- Before `gh issue create --repo <slug>` on a repo NOT in `~/.config/aidevops/repos.json`:
-  1. Check for issue templates with explicit status handling (`404` means "missing", anything else fails):
-     ```bash
-     endpoint="repos/{slug}/contents/.github/ISSUE_TEMPLATE/"
-     resp=$(gh api --include "$endpoint") || { echo "gh api failed: $endpoint" >&2; exit 1; }
-     status=$(printf '%s\n' "$resp" | awk 'NR==1 {print $2}')
-     if [[ "$status" == "404" ]]; then
-       templates="[]"
-     elif [[ "$status" != "200" ]]; then
-       echo "gh api error $status: $endpoint" >&2
-       exit 1
-     else
-       body=$(printf '%s\n' "$resp" | sed '1,/^\r$/d')
-       templates=$(printf '%s\n' "$body" | jq -r '.[].name')
-     fi
-     ```
-  2. If templates exist, fetch the relevant one (e.g., `bug-report.yml`) using the same `--include` status pattern; only decode `200` bodies (`base64 -d`).
-  3. Check for `CONTRIBUTING.md` using the same `--include` status pattern; continue on `404`, fail on other non-`200` statuses.
-  4. Format the issue body to match the required template structure. YAML form templates (`.yml`) generate `### Label` section headers when submitted via the web UI — replicate this structure in your `--body`.
-  5. If no templates exist, use a clear, well-structured format (title, description, steps to reproduce, expected/actual behaviour).
-- Before `gh pr create` targeting an external repo:
-  1. Check for PR templates with the same `gh api --include` status parsing (`404` allowed, other non-`200` statuses fail).
-  2. Check `CONTRIBUTING.md` for PR requirements (branch naming, commit format, CLA, etc.)
-  3. Format the PR body to match their template and follow their contributing guidelines.
-- If a submission is auto-closed by a compliance bot, read the bot's comment for formatting requirements, then resubmit with the correct format.
-- Practical examples and template mapping: `tools/git/github-cli.md` "External Repo Submissions" section.
+# will auto-close submissions that don't match required templates.
+# Full workflow, code snippets, and examples: `reference/external-repo-submission.md`
+- Before filing issues or PRs on external repos: read `reference/external-repo-submission.md` for the full workflow (template discovery, status handling, CONTRIBUTING.md checks, auto-close recovery).
 
 **Git-readiness check:** When working in a project directory that is NOT a git repo, or is a git repo without `TODO.md` / aidevops initialisation, flag this to the user: "This project has no git tracking / no aidevops task management. Work here won't be traceable. Consider `git init` + `aidevops init` to enable the full workflow." Use judgment — a throwaway script directory doesn't need this, but any project with ongoing development does.
 

--- a/.agents/reference/external-repo-submission.md
+++ b/.agents/reference/external-repo-submission.md
@@ -1,0 +1,54 @@
+# External Repo Issue/PR Submission — Detail Reference
+
+Loaded on-demand when filing issues or PRs on repos we don't maintain.
+Core pointer is in `prompts/build.txt` "External Repo Issue/PR Submission (t1407)".
+
+When filing issues or PRs on repos we don't maintain, template compliance bots
+(e.g., GitHub Actions that check issue format) will auto-close submissions that
+don't match the repo's required templates. Many popular repos enforce this —
+well-crafted issues get closed within hours if they don't use the right format.
+
+This is a judgment call, not a deterministic check. Read the templates and
+contributing guidelines, then format your submission accordingly.
+
+## Filing Issues on External Repos
+
+Before `gh issue create --repo <slug>` on a repo NOT in `~/.config/aidevops/repos.json`:
+
+1. Check for issue templates with explicit status handling (`404` means "missing", anything else fails):
+
+   ```bash
+   endpoint="repos/{slug}/contents/.github/ISSUE_TEMPLATE/"
+   resp=$(gh api --include "$endpoint") || { echo "gh api failed: $endpoint" >&2; exit 1; }
+   status=$(printf '%s\n' "$resp" | awk 'NR==1 {print $2}')
+   if [[ "$status" == "404" ]]; then
+     templates="[]"
+   elif [[ "$status" != "200" ]]; then
+     echo "gh api error $status: $endpoint" >&2
+     exit 1
+   else
+     body=$(printf '%s\n' "$resp" | sed '1,/^\r$/d')
+     templates=$(printf '%s\n' "$body" | jq -r '.[].name')
+   fi
+   ```
+
+2. If templates exist, fetch the relevant one (e.g., `bug-report.yml`) using the same `--include` status pattern; only decode `200` bodies (`base64 -d`).
+3. Check for `CONTRIBUTING.md` using the same `--include` status pattern; continue on `404`, fail on other non-`200` statuses.
+4. Format the issue body to match the required template structure. YAML form templates (`.yml`) generate `### Label` section headers when submitted via the web UI — replicate this structure in your `--body`.
+5. If no templates exist, use a clear, well-structured format (title, description, steps to reproduce, expected/actual behaviour).
+
+## Filing PRs on External Repos
+
+Before `gh pr create` targeting an external repo:
+
+1. Check for PR templates with the same `gh api --include` status parsing (`404` allowed, other non-`200` statuses fail).
+2. Check `CONTRIBUTING.md` for PR requirements (branch naming, commit format, CLA, etc.)
+3. Format the PR body to match their template and follow their contributing guidelines.
+
+## Handling Auto-Closed Submissions
+
+If a submission is auto-closed by a compliance bot, read the bot's comment for formatting requirements, then resubmit with the correct format.
+
+## Practical Examples
+
+See `tools/git/github-cli.md` "External Repo Submissions" section for template mapping examples.


### PR DESCRIPTION
## Summary

- Extracts the 35-line External Repo Issue/PR Submission section from `prompts/build.txt` into a dedicated reference file at `.agents/reference/external-repo-submission.md`
- Replaces the inline block with a 2-line pointer (section header + single bullet) in `build.txt`
- Adds `External repo submissions` entry to the domain index in `AGENTS.md` for discoverability

## Changes

- `.agents/reference/external-repo-submission.md` — new file with full workflow, code snippets, and examples
- `.agents/prompts/build.txt` — inline section replaced with pointer (`reference/external-repo-submission.md`)
- `.agents/AGENTS.md` — domain index entry added

## Runtime Testing

- **Risk**: Low (docs/agent prompts only, no code changes)
- **Testing level**: self-assessed
- **Verification**: file exists at expected path, pointer in build.txt references correct path, domain index entry present

Closes #6798