### PR TITLE
t1679.4: Extract Bash 3.2 Compatibility to reference/bash-compat.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -282,6 +282,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Business | `business.md`, `business/company-runners.md` |
 | Planning | `workflows/plans.md`, `scripts/commands/define.md`, `tools/task-management/beads.md` |
 | Code quality | `tools/code-review/code-standards.md` |
+| Shell/Bash compat | `reference/bash-compat.md` |
 | Git/PRs/Releases | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `workflows/release.md` |
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -418,45 +418,15 @@ Git is the primary audit trail for all work. Every change should be discoverable
 # Bash 4.0+ features silently crash or produce wrong results on 3.2 — no
 # error message, just broken behaviour. This has caused repeated production
 # failures (pulse dispatch, worktree cleanup, dataset helpers, routine scheduler).
+# Full reference: `reference/bash-compat.md`
 #
-# Forbidden features (bash 4.0+):
-- `declare -A` / `local -A` (associative arrays) — use parallel indexed arrays or grep-based lookup
-- `mapfile` / `readarray` — use `while IFS= read -r line; do arr+=("$line"); done < <(cmd)`
-- `${var,,}` / `${var^^}` (case conversion) — use `tr '[:upper:]' '[:lower:]'` or `tr '[:lower:]' '[:upper:]'`
-- `${var:offset:length}` negative offsets — use `${var: -N}` (space before minus) or string manipulation
-- `|&` (pipe stderr) — use `2>&1 |`
-- `&>>` (append both) — use `>> file 2>&1`
-- `declare -n` / `local -n` (namerefs) — use eval or indirect expansion `${!var}`
-- `[[ $var =~ regex ]]` with stored regex in variables works differently — test on 3.2
-#
-# Subshell and command substitution traps:
-- `$()` captures ALL stdout — never mix `tee` or command output with exit code capture in `$()`. Write exit codes to a temp file instead: `printf '%s' "$?" > "$exit_code_file"`
-- `local -a arr=()` inside `$()` subshells — `local` in a subshell not inside a function is undefined in 3.2
-- `PIPESTATUS` — available in 3.2 but only for the immediately preceding pipeline in the current shell. Inside `$()` it reflects the subshell's pipeline, not the parent's. Capture it immediately: `cmd1 | cmd2; local ps=("${PIPESTATUS[@]}")`
-#
-# Array passing across process boundaries:
-- Arrays cannot cross subshell, `$()`, or pipe boundaries as arrays. They flatten to strings.
-- To pass an array to a subprocess: pass elements as separate positional arguments (`"${arr[@]}"`), never as a single escaped string (`printf -v str '%q ' "${arr[@]}"` then `"$str"` — the subprocess receives one argument, not many)
-- To receive array results from a subprocess: write to a temp file (one element per line), then read back with `while read` loop
-#
-# Escape sequence quoting (recurring production-breaking bug):
-# Bash double quotes do NOT interpret \t \n \r as whitespace. They are literal
-# two-character sequences (backslash + letter). This is unlike C, Python, JS,
-# and most other languages. Agents repeatedly write `"\t"` expecting a tab —
-# this produces broken XML/plist/JSON/YAML and is invisible until runtime.
+# Critical rules (full list in reference):
+- NEVER use `declare -A` / `mapfile` / `${var,,}` / `|&` / `&>>` / `declare -n` — all bash 4.0+
 - `"\t"` → literal backslash-t (TWO characters). Use `$'\t'` for actual tab.
 - `"\n"` → literal backslash-n (TWO characters). Use `$'\n'` for actual newline.
-- For string concatenation with variables: `var+=$'\t'"${value}"` (ANSI-C quote for the tab, then double-quote for the variable expansion)
-- Inside heredocs (`<<EOF`), tabs are literal tab characters (typed or pasted) — `\t` is NOT interpreted. This is correct and safe.
-- `echo -e "\t"` interprets escapes but is non-portable. Prefer `printf '\t'`.
-- `printf '%s\t%s' "$a" "$b"` is the safest portable way to embed tabs.
-- When building XML/plist/JSON via string concatenation, ALWAYS use `$'\t'` for indentation — never `"\t"`. A single `"\t"` in a plist makes it unparseable and silently kills launchd jobs.
-#
-# Safe patterns:
+- When building XML/plist/JSON via string concatenation, ALWAYS use `$'\t'` — never `"\t"`. A single `"\t"` in a plist makes it unparseable and silently kills launchd jobs.
 - Test scripts with `/bin/bash` (not `/opt/homebrew/bin/bash`) to catch 4.0+ usage
-- When in doubt, check: `bash --version` on macOS gives 3.2.57
 - ShellCheck does NOT catch most bash version incompatibilities — manual review required
-- ShellCheck does NOT catch `"\t"` vs `$'\t'` — both are valid bash, just different semantics
 
 # Write-Time Quality Enforcement
 # Inspired by Plankton (github.com/alexfazio/plankton) — adapted for runtime-agnostic use.

--- a/.agents/reference/bash-compat.md
+++ b/.agents/reference/bash-compat.md
@@ -1,0 +1,71 @@
+# Bash 3.2 Compatibility — Detail Reference
+
+Loaded on-demand when writing or reviewing shell scripts.
+Core pointer is in `prompts/build.txt` "Bash 3.2 Compatibility".
+
+macOS ships bash 3.2.57. All shell scripts MUST work on this version.
+Bash 4.0+ features silently crash or produce wrong results on 3.2 — no
+error message, just broken behaviour. This has caused repeated production
+failures (pulse dispatch, worktree cleanup, dataset helpers, routine scheduler).
+
+## Forbidden Features (bash 4.0+)
+
+| Feature | Replacement |
+|---------|-------------|
+| `declare -A` / `local -A` (associative arrays) | Parallel indexed arrays or grep-based lookup |
+| `mapfile` / `readarray` | `while IFS= read -r line; do arr+=("$line"); done < <(cmd)` |
+| `${var,,}` / `${var^^}` (case conversion) | `tr '[:upper:]' '[:lower:]'` or `tr '[:lower:]' '[:upper:]'` |
+| `${var:offset:length}` negative offsets | `${var: -N}` (space before minus) or string manipulation |
+| `\|&` (pipe stderr) | `2>&1 \|` |
+| `&>>` (append both) | `>> file 2>&1` |
+| `declare -n` / `local -n` (namerefs) | eval or indirect expansion `${!var}` |
+| `[[ $var =~ regex ]]` with stored regex in variables | Test directly on 3.2 — behaviour differs |
+
+## Subshell and Command Substitution Traps
+
+- `$()` captures ALL stdout — never mix `tee` or command output with exit code capture in `$()`. Write exit codes to a temp file instead:
+
+  ```bash
+  printf '%s' "$?" > "$exit_code_file"
+  ```
+
+- `local -a arr=()` inside `$()` subshells — `local` in a subshell not inside a function is undefined in 3.2.
+- `PIPESTATUS` — available in 3.2 but only for the immediately preceding pipeline in the current shell. Inside `$()` it reflects the subshell's pipeline, not the parent's. Capture it immediately:
+
+  ```bash
+  cmd1 | cmd2; local ps=("${PIPESTATUS[@]}")
+  ```
+
+## Array Passing Across Process Boundaries
+
+Arrays cannot cross subshell, `$()`, or pipe boundaries as arrays. They flatten to strings.
+
+- **To pass an array to a subprocess**: pass elements as separate positional arguments (`"${arr[@]}"`), never as a single escaped string (`printf -v str '%q ' "${arr[@]}"` then `"$str"` — the subprocess receives one argument, not many).
+- **To receive array results from a subprocess**: write to a temp file (one element per line), then read back with `while read` loop.
+
+## Escape Sequence Quoting (recurring production-breaking bug)
+
+Bash double quotes do NOT interpret `\t` `\n` `\r` as whitespace. They are literal
+two-character sequences (backslash + letter). This is unlike C, Python, JS,
+and most other languages. Agents repeatedly write `"\t"` expecting a tab —
+this produces broken XML/plist/JSON/YAML and is invisible until runtime.
+
+| Expression | Result | Use for |
+|------------|--------|---------|
+| `"\t"` | Literal backslash-t (TWO characters) | Nothing — avoid |
+| `$'\t'` | Actual tab character | Tab in strings |
+| `"\n"` | Literal backslash-n (TWO characters) | Nothing — avoid |
+| `$'\n'` | Actual newline character | Newline in strings |
+
+- For string concatenation with variables: `var+=$'\t'"${value}"` (ANSI-C quote for the tab, then double-quote for the variable expansion).
+- Inside heredocs (`<<EOF`), tabs are literal tab characters (typed or pasted) — `\t` is NOT interpreted. This is correct and safe.
+- `echo -e "\t"` interprets escapes but is non-portable. Prefer `printf '\t'`.
+- `printf '%s\t%s' "$a" "$b"` is the safest portable way to embed tabs.
+- When building XML/plist/JSON via string concatenation, ALWAYS use `$'\t'` for indentation — never `"\t"`. A single `"\t"` in a plist makes it unparseable and silently kills launchd jobs.
+
+## Safe Patterns
+
+- Test scripts with `/bin/bash` (not `/opt/homebrew/bin/bash`) to catch 4.0+ usage.
+- When in doubt, check: `bash --version` on macOS gives 3.2.57.
+- ShellCheck does NOT catch most bash version incompatibilities — manual review required.
+- ShellCheck does NOT catch `"\t"` vs `$'\t'` — both are valid bash, just different semantics.


### PR DESCRIPTION
## Summary

- Extracts the full Bash 3.2 compatibility section from `prompts/build.txt` into a new `reference/bash-compat.md` reference file
- Replaces the 44-line inline block in `build.txt` with a condensed 6-line pointer + critical rules summary
- Adds `Shell/Bash compat` entry to the AGENTS.md domain index for on-demand loading

## Files Changed

- `.agents/reference/bash-compat.md` — new file with full Bash 3.2 compatibility reference (forbidden features, subshell traps, array passing, escape sequence quoting, safe patterns)
- `.agents/prompts/build.txt` — replaced 44-line inline section with 6-line condensed pointer
- `.agents/AGENTS.md` — added `Shell/Bash compat | reference/bash-compat.md` to domain index

## Runtime Testing

- Testing level: `self-assessed`
- Risk classification: Low (docs/reference only — no code changes)
- No runtime environment required

## Motivation

Part of the t1679 series extracting verbose reference sections from `build.txt` into dedicated `reference/` files. Follows the same pattern as t1679.1 (memory-lookup.md) and t1679.2 (screenshot-limits.md). Reduces system prompt token load while preserving full detail on-demand.

Closes #6799