### PR TITLE
t1680.2: Move Self-Improvement to on-demand subagent doc

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -71,56 +71,7 @@ For setup workflow, safety gates, and scheduling patterns, use `/routine` or rea
 
 ## Self-Improvement
 
-Every agent session — interactive, worker, or supervisor — should improve the system, not just complete its task. This is a universal principle, not specific to any one command.
-
-**Observe outcomes from existing state.** TODO.md, PLANS.md, and GitHub issues/PRs are the state database. Never duplicate this state into separate files, databases, or logs.
-
-**Signals that something needs fixing** (check via `gh` CLI, not custom state):
-- A PR has been open for 6+ hours with no progress
-- The same issue/PR appears in consecutive supervisor pulses with no state change
-- A PR was closed (not merged) — a worker failed
-- Multiple PRs fail CI with the same error pattern
-- A worker creates a PR that duplicates an existing one
-
-**Response: create a GitHub issue, not a workaround.** When you observe a systemic problem, file a GitHub issue describing the pattern, root cause hypothesis, and proposed fix. This enters the existing task queue and gets picked up by the next available worker. Never patch around a broken process — fix the process.
-
-**Route to the correct repo.** Not every improvement belongs in the current project. Before creating a self-improvement task, determine whether the problem is project-specific or framework-level:
-
-- **Framework-level** — route to the aidevops repo. Indicators: the observation references files under `~/.aidevops/`, framework scripts (`ai-actions.sh`, `ai-lifecycle.sh`, `supervisor/`, `dispatch.sh`, `pre-edit-check.sh`, helper scripts), agent prompt behaviour, supervisor/pulse logic, or cross-repo orchestration. **Use `framework-issue-helper.sh log` — not `claim-task-id.sh` — to file the issue directly on `marcusquinn/aidevops`.** The fix belongs in the framework, not in the project that happened to trigger it.
-- **Project-specific** — route to the current repo. Indicators: the observation is about this project's CI, code patterns, dependencies, or domain logic.
-
-If uncertain, ask: "Would this fix apply to every repo the framework manages, or only this one?" Framework-wide problems go to aidevops; project-specific problems stay local. Never create framework tasks in a project repo — they become invisible to framework maintainers and pollute the project's task namespace.
-
-**How to file a framework issue (GH#5149):** When you detect a framework-level problem, use the dedicated helper — not `claim-task-id.sh` in the current repo:
-
-```bash
-# Detect if a problem is framework-level (exit 0 = framework, exit 1 = project)
-~/.aidevops/agents/scripts/framework-issue-helper.sh detect "description of the problem"
-
-# File a framework issue directly on marcusquinn/aidevops (deduplicates automatically)
-~/.aidevops/agents/scripts/framework-issue-helper.sh log \
-  --title "Bug: supervisor pipeline fails when stdin is consumed" \
-  --body "Observed in ai-lifecycle.sh phase 3: ..." \
-  --label "bug"
-```
-
-This is the correct action path for framework issues. Do NOT use `claim-task-id.sh` in the project repo for framework-level observations — that pollutes the project's task namespace and makes the issue invisible to framework maintainers.
-
-**Scope boundary for code changes (t1405, GH#2928).** Separate "observe and report" from "observe and fix". When dispatched by the pulse, the `PULSE_SCOPE_REPOS` env var lists the repo slugs where you may create worktrees and PRs. Filing issues is always allowed on any repo — cross-repo bug reports are valuable. But code changes (worktrees, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop. The issue enters that repo's queue for their maintainers (or their own pulse) to handle. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies.
-
-**What counts as self-improvement:**
-- Filing issues for repeated failure patterns
-- Improving agent prompts when workers consistently misunderstand instructions
-- Identifying missing automation (e.g., a manual step that could be a `gh` command)
-- Flagging stale tasks that are blocked but not marked as such
-- Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
-- **Filing issues for information gaps (t1416):** When you cannot determine what happened on a task because comments lack model tier, branch name, failure diagnosis, or other audit-critical fields, file a self-improvement issue. Information gaps cause cascading waste — without knowing what was tried, the next attempt repeats the same failure. The issue/PR comment timeline is the primary audit trail; if the information isn't there, it's invisible.
-
-**Issue quality filter (GH#6508):** Before filing any enhancement or architectural change — whether via `/log-issue-aidevops`, `framework-issue-helper.sh`, or direct `gh issue create` — apply the framework's own principles to the proposal. Ask: (1) Is this addressing an observed failure, or is it preemptive? Preemptive rules for unobserved failure modes are prompt bloat. (2) Does this add a deterministic mechanism where model judgment would work better? (3) If this comes from comparing aidevops to another framework, is the "gap" actually a deliberate architectural choice? The bar for adding guidance is: **observed failure first, then minimal guidance**. Bug reports with clear reproduction steps are exempt — bugs are observed failures by definition.
-
-**Intelligence over determinism:** The harness gives you goals, tools, and boundaries — not scripts for every scenario. Deterministic rules are for things with exactly one correct answer (CLI syntax, file paths, security). Everything else — prioritisation, triage, stuck detection, what to work on — is a judgment call. If a rule says "if X then Y" but there are cases where X is true and Y is wrong, it's guidance not a rule. Use the cheapest model that can handle the decision (haiku for triage, sonnet for implementation, opus for strategy) — but never use a regex where a model call would handle outliers better. See `prompts/build.txt` "Intelligence Over Determinism" for the full principle.
-
-**Autonomous operation:** When the user says "continue", "monitor", or "keep going" — enter autonomous mode: use sleep/wait loops, maintain a perpetual todo to survive compaction, only interrupt for blocking errors that require user input.
+Every session should improve the system, not just complete its task. Full guidance: `reference/self-improvement.md`
 
 ---
 
@@ -279,18 +230,18 @@ Full domain-to-subagent lookup table (30+ domains): `reference/domain-index.md`.
 
 ## Capabilities
 
-Key capabilities — details in `reference/orchestration.md`, `reference/services.md`, `reference/session.md`:
+Key capabilities (details in `reference/orchestration.md`, `reference/services.md`, `reference/session.md`):
 
 - **Model routing**: local→haiku→flash→sonnet→pro→opus (cost-aware). See `tools/context/model-routing.md`.
-- **Bundle presets**: project-type defaults for model tiers, quality gates, agent routing. See `bundles/` and `scripts/bundle-helper.sh`.
+- **Bundle presets**: Project-type-aware defaults for model tiers, quality gates, and agent routing. Auto-detected from marker files or explicit in repos.json. See `bundles/` and `scripts/bundle-helper.sh`.
 - **Memory**: cross-session SQLite FTS5 (`/remember`, `/recall`)
 - **Orchestration**: supervisor dispatch, pulse scheduler, auto-pickup, cross-repo issue/PR/TODO visibility
-- **Contribution watch**: monitors external issues/PRs for new activity. See `scripts/contribution-watch-helper.sh help`.
-- **Upstream watch**: monitors inspiration repos for new releases. See `reference/services.md` "Auto-Update".
+- **Contribution watch**: monitors external issues/PRs for new activity needing reply using the GitHub Notifications API. `contribution-watch-helper.sh seed|scan|status|install|uninstall` (optional `scan --backfill` for low-frequency safety-net sweeps of tracked threads). Managed repos (`pulse: true` in repos.json) are excluded to suppress internal automation noise. Prompt-injection-safe — automated scans are deterministic metadata checks (no LLM), comment bodies only shown in interactive sessions after `prompt-guard-helper.sh scan`.
+- **Upstream watch**: monitors external repos we've borrowed ideas/code from for new releases. `upstream-watch-helper.sh add|remove|check|ack|status`. Shows release diffs and changelogs between our last-seen version and latest. Distinct from skill imports (code we pulled in) and contribution watch (repos we filed issues on) — this tracks "inspiration repos" for passive monitoring. Config: `.agents/configs/upstream-watch.json`.
 - **Skills**: `aidevops skills`, `/skills`
-- **Auto-update**: daily freshness checks via `auto-update-helper.sh`. See `reference/services.md` "Auto-Update".
+- **Auto-update**: GitHub poll + daily skill/upstream watch/OpenClaw/tool freshness checks (via `auto-update-helper.sh`). Repo sync runs separately via `aidevops repo-sync` scheduler.
 - **Browser**: Playwright, dev-browser (persistent login)
-- **Quality**: write-time linting → `linters-local.sh` → `/pr review` → `/postflight`. See `prompts/build.txt`.
+- **Quality**: Write-time per-edit linting → `linters-local.sh` → `/pr review` → `/postflight`. Fix violations at edit time, not commit time. See `prompts/build.txt` "Write-Time Quality Enforcement". Bundle `skip_gates` filter irrelevant checks per project type.
 - **Sessions**: `/session-review`, `/checkpoint`, compaction resilience
 - **Auth recovery**: if model is broken or "Key Missing" → read `tools/credentials/auth-troubleshooting.md`
 

--- a/.agents/reference/domain-index.md
+++ b/.agents/reference/domain-index.md
@@ -37,6 +37,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Upstream watch | `scripts/upstream-watch-helper.sh`, `.agents/configs/upstream-watch.json` |
 | Testing | `scripts/commands/testing-setup.md`, `tools/build-agent/agent-testing.md`, `scripts/testing-setup-helper.sh` |
 | Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md`, `tools/mcp-toolkit/mcporter.md` |
+| Self-Improvement | `reference/self-improvement.md` |
 | Framework | `aidevops/architecture.md`, `scripts/commands/skills.md` |
 
 **Creating agents**: When a user asks to create, build, or design an agent — regardless of which primary agent is active — always read `tools/build-agent/build-agent.md` first. It contains the tier prompt (draft/custom/shared), design checklist, and lifecycle rules.

--- a/.agents/reference/self-improvement.md
+++ b/.agents/reference/self-improvement.md
@@ -1,0 +1,77 @@
+---
+description: Self-improvement principles and routing for all agent sessions
+mode: subagent
+---
+
+# Self-Improvement
+
+Every agent session — interactive, worker, or supervisor — should improve the system, not just complete its task. This is a universal principle, not specific to any one command.
+
+**Observe outcomes from existing state.** TODO.md, PLANS.md, and GitHub issues/PRs are the state database. Never duplicate this state into separate files, databases, or logs.
+
+**Signals that something needs fixing** (check via `gh` CLI, not custom state):
+
+- A PR has been open for 6+ hours with no progress
+- The same issue/PR appears in consecutive supervisor pulses with no state change
+- A PR was closed (not merged) — a worker failed
+- Multiple PRs fail CI with the same error pattern
+- A worker creates a PR that duplicates an existing one
+
+**Response: create a GitHub issue, not a workaround.** When you observe a systemic problem, file a GitHub issue describing the pattern, root cause hypothesis, and proposed fix. This enters the existing task queue and gets picked up by the next available worker. Never patch around a broken process — fix the process.
+
+## Routing
+
+**Route to the correct repo.** Not every improvement belongs in the current project. Before creating a self-improvement task, determine whether the problem is project-specific or framework-level:
+
+- **Framework-level** — route to the aidevops repo. Indicators: the observation references files under `~/.aidevops/`, framework scripts (`ai-actions.sh`, `ai-lifecycle.sh`, `supervisor/`, `dispatch.sh`, `pre-edit-check.sh`, helper scripts), agent prompt behaviour, supervisor/pulse logic, or cross-repo orchestration. **Use `framework-issue-helper.sh log` — not `claim-task-id.sh` — to file the issue directly on `marcusquinn/aidevops`.** The fix belongs in the framework, not in the project that happened to trigger it.
+- **Project-specific** — route to the current repo. Indicators: the observation is about this project's CI, code patterns, dependencies, or domain logic.
+
+If uncertain, ask: "Would this fix apply to every repo the framework manages, or only this one?" Framework-wide problems go to aidevops; project-specific problems stay local. Never create framework tasks in a project repo — they become invisible to framework maintainers and pollute the project's task namespace.
+
+## Filing a Framework Issue
+
+**How to file a framework issue (GH#5149):** When you detect a framework-level problem, use the dedicated helper — not `claim-task-id.sh` in the current repo:
+
+```bash
+# Detect if a problem is framework-level (exit 0 = framework, exit 1 = project)
+~/.aidevops/agents/scripts/framework-issue-helper.sh detect "description of the problem"
+
+# File a framework issue directly on marcusquinn/aidevops (deduplicates automatically)
+~/.aidevops/agents/scripts/framework-issue-helper.sh log \
+  --title "Bug: supervisor pipeline fails when stdin is consumed" \
+  --body "Observed in ai-lifecycle.sh phase 3: ..." \
+  --label "bug"
+```
+
+This is the correct action path for framework issues. Do NOT use `claim-task-id.sh` in the project repo for framework-level observations — that pollutes the project's task namespace and makes the issue invisible to framework maintainers.
+
+## Scope Boundary
+
+**Scope boundary for code changes (t1405, GH#2928).** Separate "observe and report" from "observe and fix". When dispatched by the pulse, the `PULSE_SCOPE_REPOS` env var lists the repo slugs where you may create worktrees and PRs. Filing issues is always allowed on any repo — cross-repo bug reports are valuable. But code changes (worktrees, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop. The issue enters that repo's queue for their maintainers (or their own pulse) to handle. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies.
+
+## What Counts as Self-Improvement
+
+- Filing issues for repeated failure patterns
+- Improving agent prompts when workers consistently misunderstand instructions
+- Identifying missing automation (e.g., a manual step that could be a `gh` command)
+- Flagging stale tasks that are blocked but not marked as such
+- Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
+- **Filing issues for information gaps (t1416):** When you cannot determine what happened on a task because comments lack model tier, branch name, failure diagnosis, or other audit-critical fields, file a self-improvement issue. Information gaps cause cascading waste — without knowing what was tried, the next attempt repeats the same failure. The issue/PR comment timeline is the primary audit trail; if the information isn't there, it's invisible.
+
+## Issue Quality Filter
+
+**Issue quality filter (GH#6508):** Before filing any enhancement or architectural change — whether via `/log-issue-aidevops`, `framework-issue-helper.sh`, or direct `gh issue create` — apply the framework's own principles to the proposal. Ask: (1) Is this addressing an observed failure, or is it preemptive? Preemptive rules for unobserved failure modes are prompt bloat. (2) Does this add a deterministic mechanism where model judgment would work better? (3) If this comes from comparing aidevops to another framework, is the "gap" actually a deliberate architectural choice? The bar for adding guidance is: **observed failure first, then minimal guidance**. Bug reports with clear reproduction steps are exempt — bugs are observed failures by definition.
+
+## Intelligence Over Determinism
+
+**Intelligence over determinism:** The harness gives you goals, tools, and boundaries — not scripts for every scenario. Deterministic rules are for things with exactly one correct answer (CLI syntax, file paths, security). Everything else — prioritisation, triage, stuck detection, what to work on — is a judgment call. If a rule says "if X then Y" but there are cases where X is true and Y is wrong, it's guidance not a rule. Use the cheapest model that can handle the decision (haiku for triage, sonnet for implementation, opus for strategy) — but never use a regex where a model call would handle outliers better. See `prompts/build.txt` "Intelligence Over Determinism" for the full principle.
+
+## Autonomous Operation
+
+**Autonomous operation:** When the user says "continue", "monitor", or "keep going" — enter autonomous mode: use sleep/wait loops, maintain a perpetual todo to survive compaction, only interrupt for blocking errors that require user input.
+
+## Related
+
+- `aidevops/self-improving-agents.md` — archived script context and observation/response patterns
+- `scripts/commands/pulse.md` — supervisor outcome observation (Step 2a)
+- `reference/session.md` — cross-session memory system


### PR DESCRIPTION
## Summary

- Extract the full Self-Improvement section (~54 lines) from `.agents/AGENTS.md` into a new on-demand subagent doc at `reference/self-improvement.md`
- Replace the section in AGENTS.md with a single pointer line: `Full guidance: reference/self-improvement.md`
- Add Self-Improvement entry to the Domain Index table for discoverability

## Motivation

The Self-Improvement section was one of the largest sections in AGENTS.md, loaded into every session's context regardless of whether self-improvement guidance was needed. Moving it to an on-demand subagent doc reduces the root AGENTS.md instruction budget and follows the progressive disclosure pattern used throughout the framework.

## Files Changed

- `.agents/AGENTS.md` — section replaced with 1-line pointer; Domain Index updated
- `.agents/reference/self-improvement.md` — new subagent doc with full content, YAML frontmatter, and structured headings

## Runtime Testing

- **Risk classification:** Low (docs/agent prompts only, no code logic)
- **Testing level:** self-assessed
- **Verification:** Content preserved verbatim; pointer and Domain Index entry confirmed correct

Closes #6804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Consolidated self-improvement guidance into a dedicated reference document for improved discoverability and maintainability.
  * Updated capability descriptions with clearer automation behavior specifications and configuration detection details.
  * Expanded domain index to improve internal documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->