### PR TITLE
GH#6696: Fix pulse dispatch loop creating duplicate workers — add in-flight dispatch ledger

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -195,8 +195,15 @@ cmd_register() {
 		mv "$tmp_file" "$LEDGER_FILE"
 	fi
 
-	# Append new entry
-	printf '%s\n' "{\"session_key\":\"${session_key}\",\"issue_number\":\"${issue_number}\",\"repo_slug\":\"${repo_slug}\",\"pid\":${dispatch_pid},\"dispatched_at\":\"${now}\",\"status\":\"in-flight\",\"updated_at\":\"${now}\"}" >>"$LEDGER_FILE"
+	# Append new entry — use jq for safe JSON construction (handles special chars)
+	jq -cn \
+		--arg sk "$session_key" \
+		--arg inum "$issue_number" \
+		--arg slug "$repo_slug" \
+		--argjson pid "$dispatch_pid" \
+		--arg ts "$now" \
+		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: "in-flight", updated_at: $ts}' \
+		>>"$LEDGER_FILE"
 
 	_release_lock
 	return 0

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -1,0 +1,759 @@
+#!/usr/bin/env bash
+# dispatch-ledger-helper.sh — In-flight dispatch tracking ledger (GH#6696)
+#
+# Tracks workers between dispatch and PR creation to prevent duplicate
+# dispatches. The pulse checks GitHub for open PRs to detect "already
+# handled" targets, but workers take 10-15 minutes between dispatch and
+# PR creation. During this window, the target appears unhandled and gets
+# re-dispatched every pulse cycle.
+#
+# This ledger fills that gap: each dispatch registers an entry, and the
+# pulse checks the ledger before dispatching. Entries expire after a
+# configurable TTL (default 60 min) or are marked completed/failed by
+# the worker on exit.
+#
+# Storage: JSONL file at ~/.aidevops/.agent-workspace/tmp/dispatch-ledger.jsonl
+# Each line is a JSON object with fields:
+#   session_key  - unique worker session key (e.g., "issue-42")
+#   issue_number - GitHub issue number (string, may be empty)
+#   repo_slug    - owner/repo (may be empty for non-repo dispatches)
+#   pid          - PID of the dispatching process
+#   dispatched_at - ISO 8601 UTC timestamp
+#   status       - "in-flight" | "completed" | "failed"
+#   updated_at   - ISO 8601 UTC timestamp of last status change
+#
+# Concurrency: file-level flock for atomic reads/writes. Safe for
+# concurrent pulse + worker access. Falls back to no-lock on systems
+# without flock (macOS without util-linux) — acceptable because the
+# pulse is single-instance (mkdir lock) and workers update sequentially.
+#
+# Usage:
+#   dispatch-ledger-helper.sh register --session-key KEY [--issue NUM] [--repo SLUG] [--pid PID]
+#   dispatch-ledger-helper.sh check --session-key KEY
+#   dispatch-ledger-helper.sh check-issue --issue NUM [--repo SLUG]
+#   dispatch-ledger-helper.sh complete --session-key KEY
+#   dispatch-ledger-helper.sh fail --session-key KEY
+#   dispatch-ledger-helper.sh expire [--ttl SECONDS]
+#   dispatch-ledger-helper.sh count
+#   dispatch-ledger-helper.sh status
+#   dispatch-ledger-helper.sh help
+
+set -euo pipefail
+
+LEDGER_DIR="${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+LEDGER_FILE="${LEDGER_DIR}/dispatch-ledger.jsonl"
+LEDGER_LOCK="${LEDGER_DIR}/dispatch-ledger.lock"
+DEFAULT_TTL="${AIDEVOPS_DISPATCH_LEDGER_TTL:-3600}" # 60 minutes
+
+#######################################
+# Ensure ledger directory and file exist
+#######################################
+_ensure_ledger() {
+	mkdir -p "$LEDGER_DIR" 2>/dev/null || true
+	if [[ ! -f "$LEDGER_FILE" ]]; then
+		touch "$LEDGER_FILE"
+	fi
+	return 0
+}
+
+#######################################
+# Acquire file lock (best-effort — flock may not be available on macOS)
+# Args: $1 = lock FD number
+# Returns: 0 always (proceeds without lock if flock unavailable)
+#######################################
+_acquire_lock() {
+	if command -v flock &>/dev/null; then
+		exec 8>"$LEDGER_LOCK"
+		flock -w 5 8 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# Release file lock
+#######################################
+_release_lock() {
+	if command -v flock &>/dev/null; then
+		flock -u 8 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# Get current UTC timestamp in ISO 8601 format
+#######################################
+_now_utc() {
+	date -u '+%Y-%m-%dT%H:%M:%SZ'
+	return 0
+}
+
+#######################################
+# Get current epoch seconds
+#######################################
+_now_epoch() {
+	date -u '+%s'
+	return 0
+}
+
+#######################################
+# Parse ISO 8601 timestamp to epoch seconds
+# Args: $1 = ISO timestamp
+# Returns: epoch seconds via stdout
+#######################################
+_iso_to_epoch() {
+	local ts="$1"
+	# Try GNU date first (Linux), then BSD date (macOS)
+	date -u -d "$ts" '+%s' 2>/dev/null ||
+		TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" '+%s' 2>/dev/null ||
+		printf '%s' "0"
+	return 0
+}
+
+#######################################
+# Register a new dispatch in the ledger
+#
+# Args (named):
+#   --session-key KEY    (required) Unique session key
+#   --issue NUM          (optional) GitHub issue number
+#   --repo SLUG          (optional) owner/repo
+#   --pid PID            (optional) PID of dispatch process, defaults to $$
+#
+# Exit codes:
+#   0 - registered successfully
+#   1 - missing required args
+#######################################
+cmd_register() {
+	local session_key=""
+	local issue_number=""
+	local repo_slug=""
+	local dispatch_pid="$$"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-key)
+			session_key="${2:-}"
+			shift 2
+			;;
+		--issue)
+			issue_number="${2:-}"
+			shift 2
+			;;
+		--repo)
+			repo_slug="${2:-}"
+			shift 2
+			;;
+		--pid)
+			dispatch_pid="${2:-$$}"
+			shift 2
+			;;
+		*)
+			echo "Error: Unknown option for register: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$session_key" ]]; then
+		echo "Error: register requires --session-key" >&2
+		return 1
+	fi
+
+	_ensure_ledger
+	_acquire_lock
+
+	local now
+	now=$(_now_utc)
+
+	# Remove any existing entry for this session_key (idempotent re-register)
+	if [[ -s "$LEDGER_FILE" ]]; then
+		local tmp_file
+		tmp_file=$(mktemp)
+		jq -c --arg sk "$session_key" 'select(.session_key != $sk)' "$LEDGER_FILE" >"$tmp_file" 2>/dev/null || true
+		mv "$tmp_file" "$LEDGER_FILE"
+	fi
+
+	# Append new entry
+	printf '%s\n' "{\"session_key\":\"${session_key}\",\"issue_number\":\"${issue_number}\",\"repo_slug\":\"${repo_slug}\",\"pid\":${dispatch_pid},\"dispatched_at\":\"${now}\",\"status\":\"in-flight\",\"updated_at\":\"${now}\"}" >>"$LEDGER_FILE"
+
+	_release_lock
+	return 0
+}
+
+#######################################
+# Check if a session key has an in-flight entry
+#
+# Args:
+#   --session-key KEY    (required)
+#
+# Exit codes:
+#   0 - in-flight entry exists (do NOT dispatch)
+#   1 - no in-flight entry (safe to dispatch)
+# Output: entry JSON on stdout if found
+#######################################
+cmd_check() {
+	local session_key=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-key)
+			session_key="${2:-}"
+			shift 2
+			;;
+		*)
+			echo "Error: Unknown option for check: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$session_key" ]]; then
+		echo "Error: check requires --session-key" >&2
+		return 1
+	fi
+
+	_ensure_ledger
+
+	if [[ ! -s "$LEDGER_FILE" ]]; then
+		return 1
+	fi
+
+	local match
+	match=$(jq -c --arg sk "$session_key" 'select(.session_key == $sk and .status == "in-flight")' "$LEDGER_FILE" 2>/dev/null | head -1) || match=""
+
+	if [[ -z "$match" ]]; then
+		return 1
+	fi
+
+	# Verify PID is still alive (stale entry detection)
+	local entry_pid
+	entry_pid=$(printf '%s' "$match" | jq -r '.pid // 0') || entry_pid=0
+	if [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
+		if ! kill -0 "$entry_pid" 2>/dev/null; then
+			# PID is dead — mark as failed and return "safe to dispatch"
+			cmd_fail --session-key "$session_key" 2>/dev/null || true
+			return 1
+		fi
+	fi
+
+	printf '%s\n' "$match"
+	return 0
+}
+
+#######################################
+# Check if an issue number has an in-flight entry
+#
+# Args:
+#   --issue NUM          (required)
+#   --repo SLUG          (optional) restrict to specific repo
+#
+# Exit codes:
+#   0 - in-flight entry exists for this issue (do NOT dispatch)
+#   1 - no in-flight entry (safe to dispatch)
+# Output: entry JSON on stdout if found
+#######################################
+cmd_check_issue() {
+	local issue_number=""
+	local repo_slug=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--issue)
+			issue_number="${2:-}"
+			shift 2
+			;;
+		--repo)
+			repo_slug="${2:-}"
+			shift 2
+			;;
+		*)
+			echo "Error: Unknown option for check-issue: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$issue_number" ]]; then
+		echo "Error: check-issue requires --issue" >&2
+		return 1
+	fi
+
+	_ensure_ledger
+
+	if [[ ! -s "$LEDGER_FILE" ]]; then
+		return 1
+	fi
+
+	local match
+	if [[ -n "$repo_slug" ]]; then
+		match=$(jq -c --arg inum "$issue_number" --arg slug "$repo_slug" \
+			'select(.issue_number == $inum and .repo_slug == $slug and .status == "in-flight")' \
+			"$LEDGER_FILE" 2>/dev/null | head -1) || match=""
+	else
+		match=$(jq -c --arg inum "$issue_number" \
+			'select(.issue_number == $inum and .status == "in-flight")' \
+			"$LEDGER_FILE" 2>/dev/null | head -1) || match=""
+	fi
+
+	if [[ -z "$match" ]]; then
+		return 1
+	fi
+
+	# Verify PID is still alive
+	local entry_pid
+	entry_pid=$(printf '%s' "$match" | jq -r '.pid // 0') || entry_pid=0
+	if [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
+		if ! kill -0 "$entry_pid" 2>/dev/null; then
+			local sk
+			sk=$(printf '%s' "$match" | jq -r '.session_key // ""') || sk=""
+			if [[ -n "$sk" ]]; then
+				cmd_fail --session-key "$sk" 2>/dev/null || true
+			fi
+			return 1
+		fi
+	fi
+
+	printf '%s\n' "$match"
+	return 0
+}
+
+#######################################
+# Mark a session key as completed
+#
+# Args:
+#   --session-key KEY    (required)
+#
+# Exit codes:
+#   0 - marked completed (or entry not found — idempotent)
+#######################################
+cmd_complete() {
+	local session_key=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-key)
+			session_key="${2:-}"
+			shift 2
+			;;
+		*)
+			echo "Error: Unknown option for complete: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$session_key" ]]; then
+		echo "Error: complete requires --session-key" >&2
+		return 1
+	fi
+
+	_update_status "$session_key" "completed"
+	return 0
+}
+
+#######################################
+# Mark a session key as failed
+#
+# Args:
+#   --session-key KEY    (required)
+#
+# Exit codes:
+#   0 - marked failed (or entry not found — idempotent)
+#######################################
+cmd_fail() {
+	local session_key=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-key)
+			session_key="${2:-}"
+			shift 2
+			;;
+		*)
+			echo "Error: Unknown option for fail: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$session_key" ]]; then
+		echo "Error: fail requires --session-key" >&2
+		return 1
+	fi
+
+	_update_status "$session_key" "failed"
+	return 0
+}
+
+#######################################
+# Update the status of a ledger entry
+# Args: $1 = session_key, $2 = new status
+#######################################
+_update_status() {
+	local session_key="$1"
+	local new_status="$2"
+
+	_ensure_ledger
+	_acquire_lock
+
+	if [[ ! -s "$LEDGER_FILE" ]]; then
+		_release_lock
+		return 0
+	fi
+
+	local now
+	now=$(_now_utc)
+	local tmp_file
+	tmp_file=$(mktemp)
+
+	jq -c --arg sk "$session_key" --arg st "$new_status" --arg ts "$now" \
+		'if .session_key == $sk then .status = $st | .updated_at = $ts else . end' \
+		"$LEDGER_FILE" >"$tmp_file" 2>/dev/null || cp "$LEDGER_FILE" "$tmp_file"
+
+	mv "$tmp_file" "$LEDGER_FILE"
+	_release_lock
+	return 0
+}
+
+#######################################
+# Expire old in-flight entries
+#
+# Entries older than TTL seconds are marked "failed" (assumed dead).
+# Entries with dead PIDs are also marked "failed" regardless of age.
+#
+# Args:
+#   --ttl SECONDS    (optional, default: $DEFAULT_TTL)
+#
+# Exit codes:
+#   0 - always (best-effort cleanup)
+# Output: count of expired entries
+#######################################
+cmd_expire() {
+	local ttl="$DEFAULT_TTL"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--ttl)
+			ttl="${2:-$DEFAULT_TTL}"
+			shift 2
+			;;
+		*)
+			echo "Error: Unknown option for expire: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl="$DEFAULT_TTL"
+
+	_ensure_ledger
+	_acquire_lock
+
+	if [[ ! -s "$LEDGER_FILE" ]]; then
+		_release_lock
+		printf '%s\n' "0"
+		return 0
+	fi
+
+	local now_epoch
+	now_epoch=$(_now_epoch)
+	local now_ts
+	now_ts=$(_now_utc)
+	local expired_count=0
+	local tmp_file
+	tmp_file=$(mktemp)
+
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local status
+		status=$(printf '%s' "$line" | jq -r '.status // ""' 2>/dev/null) || status=""
+
+		if [[ "$status" != "in-flight" ]]; then
+			printf '%s\n' "$line" >>"$tmp_file"
+			continue
+		fi
+
+		local should_expire=false
+
+		# Check TTL expiry
+		local dispatched_at
+		dispatched_at=$(printf '%s' "$line" | jq -r '.dispatched_at // ""' 2>/dev/null) || dispatched_at=""
+		if [[ -n "$dispatched_at" ]]; then
+			local dispatch_epoch
+			dispatch_epoch=$(_iso_to_epoch "$dispatched_at")
+			local age=$((now_epoch - dispatch_epoch))
+			if [[ "$age" -gt "$ttl" ]]; then
+				should_expire=true
+			fi
+		fi
+
+		# Check PID liveness
+		if [[ "$should_expire" != "true" ]]; then
+			local entry_pid
+			entry_pid=$(printf '%s' "$line" | jq -r '.pid // 0' 2>/dev/null) || entry_pid=0
+			if [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
+				if ! kill -0 "$entry_pid" 2>/dev/null; then
+					should_expire=true
+				fi
+			fi
+		fi
+
+		if [[ "$should_expire" == "true" ]]; then
+			printf '%s\n' "$line" | jq -c --arg ts "$now_ts" '.status = "failed" | .updated_at = $ts' >>"$tmp_file" 2>/dev/null || printf '%s\n' "$line" >>"$tmp_file"
+			expired_count=$((expired_count + 1))
+		else
+			printf '%s\n' "$line" >>"$tmp_file"
+		fi
+	done <"$LEDGER_FILE"
+
+	mv "$tmp_file" "$LEDGER_FILE"
+	_release_lock
+
+	printf '%s\n' "$expired_count"
+	return 0
+}
+
+#######################################
+# Count in-flight entries (with PID liveness check)
+#
+# Exit codes: 0 always
+# Output: count of live in-flight entries
+#######################################
+cmd_count() {
+	_ensure_ledger
+
+	if [[ ! -s "$LEDGER_FILE" ]]; then
+		printf '%s\n' "0"
+		return 0
+	fi
+
+	local count=0
+	local inflight_lines
+	inflight_lines=$(jq -c 'select(.status == "in-flight")' "$LEDGER_FILE" 2>/dev/null) || inflight_lines=""
+
+	if [[ -z "$inflight_lines" ]]; then
+		printf '%s\n' "0"
+		return 0
+	fi
+
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local entry_pid
+		entry_pid=$(printf '%s' "$line" | jq -r '.pid // 0' 2>/dev/null) || entry_pid=0
+		if [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
+			if kill -0 "$entry_pid" 2>/dev/null; then
+				count=$((count + 1))
+			fi
+		else
+			# No valid PID — count it (conservative; expire will clean up)
+			count=$((count + 1))
+		fi
+	done <<<"$inflight_lines"
+
+	printf '%s\n' "$count"
+	return 0
+}
+
+#######################################
+# Show ledger status (all entries, human-readable)
+#
+# Exit codes: 0 always
+# Output: formatted status table
+#######################################
+cmd_status() {
+	_ensure_ledger
+
+	if [[ ! -s "$LEDGER_FILE" ]]; then
+		echo "Dispatch ledger is empty"
+		return 0
+	fi
+
+	local total inflight completed failed
+	total=$(wc -l <"$LEDGER_FILE" | tr -d ' ')
+	inflight=$(jq -c 'select(.status == "in-flight")' "$LEDGER_FILE" 2>/dev/null | wc -l | tr -d ' ') || inflight=0
+	completed=$(jq -c 'select(.status == "completed")' "$LEDGER_FILE" 2>/dev/null | wc -l | tr -d ' ') || completed=0
+	failed=$(jq -c 'select(.status == "failed")' "$LEDGER_FILE" 2>/dev/null | wc -l | tr -d ' ') || failed=0
+
+	echo "Dispatch Ledger Status"
+	echo "  Total entries: ${total}"
+	echo "  In-flight:     ${inflight}"
+	echo "  Completed:     ${completed}"
+	echo "  Failed:        ${failed}"
+	echo ""
+
+	if [[ "$inflight" -gt 0 ]]; then
+		echo "In-flight entries:"
+		jq -r 'select(.status == "in-flight") | "  \(.session_key) | issue=\(.issue_number) | repo=\(.repo_slug) | pid=\(.pid) | since=\(.dispatched_at)"' "$LEDGER_FILE" 2>/dev/null || true
+	fi
+
+	return 0
+}
+
+#######################################
+# Prune completed/failed entries older than 24h
+# Keeps the ledger file from growing indefinitely.
+#
+# Exit codes: 0 always
+# Output: count of pruned entries
+#######################################
+cmd_prune() {
+	_ensure_ledger
+	_acquire_lock
+
+	if [[ ! -s "$LEDGER_FILE" ]]; then
+		_release_lock
+		printf '%s\n' "0"
+		return 0
+	fi
+
+	local now_epoch prune_threshold pruned_count
+	now_epoch=$(_now_epoch)
+	prune_threshold=86400 # 24 hours
+	pruned_count=0
+	local tmp_file
+	tmp_file=$(mktemp)
+
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local status
+		status=$(printf '%s' "$line" | jq -r '.status // ""' 2>/dev/null) || status=""
+
+		# Keep in-flight entries always
+		if [[ "$status" == "in-flight" ]]; then
+			printf '%s\n' "$line" >>"$tmp_file"
+			continue
+		fi
+
+		# Prune completed/failed entries older than threshold
+		local updated_at
+		updated_at=$(printf '%s' "$line" | jq -r '.updated_at // ""' 2>/dev/null) || updated_at=""
+		if [[ -n "$updated_at" ]]; then
+			local update_epoch
+			update_epoch=$(_iso_to_epoch "$updated_at")
+			local age=$((now_epoch - update_epoch))
+			if [[ "$age" -gt "$prune_threshold" ]]; then
+				pruned_count=$((pruned_count + 1))
+				continue
+			fi
+		fi
+
+		printf '%s\n' "$line" >>"$tmp_file"
+	done <"$LEDGER_FILE"
+
+	mv "$tmp_file" "$LEDGER_FILE"
+	_release_lock
+
+	printf '%s\n' "$pruned_count"
+	return 0
+}
+
+#######################################
+# Show help
+#######################################
+show_help() {
+	cat <<'HELP'
+dispatch-ledger-helper.sh — In-flight dispatch tracking ledger (GH#6696)
+
+Tracks workers between dispatch and PR creation to prevent duplicate
+dispatches during the 10-15 minute window before a worker creates its PR.
+
+Usage:
+  dispatch-ledger-helper.sh register --session-key KEY [--issue NUM] [--repo SLUG] [--pid PID]
+    Register a new dispatch. Idempotent — re-registering overwrites.
+
+  dispatch-ledger-helper.sh check --session-key KEY
+    Check if session key has an in-flight entry. Exit 0=in-flight, 1=safe.
+
+  dispatch-ledger-helper.sh check-issue --issue NUM [--repo SLUG]
+    Check if issue has an in-flight entry. Exit 0=in-flight, 1=safe.
+
+  dispatch-ledger-helper.sh complete --session-key KEY
+    Mark dispatch as completed (worker finished successfully).
+
+  dispatch-ledger-helper.sh fail --session-key KEY
+    Mark dispatch as failed (worker errored or timed out).
+
+  dispatch-ledger-helper.sh expire [--ttl SECONDS]
+    Expire stale in-flight entries (default TTL: 3600s / 60 min).
+    Also expires entries with dead PIDs regardless of age.
+
+  dispatch-ledger-helper.sh count
+    Count live in-flight entries (with PID liveness check).
+
+  dispatch-ledger-helper.sh status
+    Show human-readable ledger status.
+
+  dispatch-ledger-helper.sh prune
+    Remove completed/failed entries older than 24h.
+
+  dispatch-ledger-helper.sh help
+    Show this help.
+
+Environment:
+  AIDEVOPS_DISPATCH_LEDGER_DIR   Override ledger directory
+  AIDEVOPS_DISPATCH_LEDGER_TTL   Override default TTL in seconds (default: 3600)
+
+Examples:
+  # Register before dispatching a worker
+  dispatch-ledger-helper.sh register --session-key "issue-42" --issue 42 --repo owner/repo --pid $!
+
+  # Check before dispatching (in pulse dedup)
+  if dispatch-ledger-helper.sh check-issue --issue 42 --repo owner/repo; then
+    echo "Already in-flight — skip dispatch"
+  fi
+
+  # Worker marks completion on exit
+  dispatch-ledger-helper.sh complete --session-key "issue-42"
+
+  # Pulse runs expire at start of each cycle
+  dispatch-ledger-helper.sh expire --ttl 3600
+HELP
+	return 0
+}
+
+#######################################
+# Main
+#######################################
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	register)
+		cmd_register "$@"
+		;;
+	check)
+		cmd_check "$@"
+		;;
+	check-issue)
+		cmd_check_issue "$@"
+		;;
+	complete)
+		cmd_complete "$@"
+		;;
+	fail)
+		cmd_fail "$@"
+		;;
+	expire)
+		cmd_expire "$@"
+		;;
+	count)
+		cmd_count
+		;;
+	status)
+		cmd_status
+		;;
+	prune)
+		cmd_prune
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		echo "Error: Unknown command: $command" >&2
+		show_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -417,7 +417,8 @@ _update_status() {
 
 	_ensure_ledger
 	if ! _acquire_lock; then
-		return 0 # Silently skip — status update is best-effort
+		echo "Error: _update_status aborted — could not acquire lock for session_key=${session_key}" >&2
+		return 1
 	fi
 
 	if [[ ! -s "$LEDGER_FILE" ]]; then

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -23,9 +23,9 @@
 #   updated_at   - ISO 8601 UTC timestamp of last status change
 #
 # Concurrency: file-level flock for atomic reads/writes. Safe for
-# concurrent pulse + worker access. Falls back to no-lock on systems
-# without flock (macOS without util-linux) — acceptable because the
-# pulse is single-instance (mkdir lock) and workers update sequentially.
+# concurrent pulse + worker access. Falls back to mkdir-based lock on
+# systems without flock (macOS without util-linux). Lock acquisition
+# fails closed — write operations abort if the lock cannot be obtained.
 #
 # Usage:
 #   dispatch-ledger-helper.sh register --session-key KEY [--issue NUM] [--repo SLUG] [--pid PID]
@@ -57,14 +57,30 @@ _ensure_ledger() {
 }
 
 #######################################
-# Acquire file lock (best-effort — flock may not be available on macOS)
-# Args: $1 = lock FD number
-# Returns: 0 always (proceeds without lock if flock unavailable)
+# Acquire file lock (fail-closed — aborts if lock cannot be obtained)
+# Uses flock when available, falls back to mkdir-based lock.
+# Returns: 0 on success, 1 on failure (caller must abort write)
 #######################################
 _acquire_lock() {
 	if command -v flock &>/dev/null; then
 		exec 8>"$LEDGER_LOCK"
-		flock -w 5 8 2>/dev/null || true
+		if ! flock -w 5 8 2>/dev/null; then
+			echo "Error: could not acquire ledger lock: $LEDGER_LOCK" >&2
+			return 1
+		fi
+	else
+		# Portable fallback: mkdir is atomic on all POSIX systems
+		local lock_dir="${LEDGER_LOCK}.d"
+		local attempts=0
+		local max_attempts=50 # 50 × 0.1s = 5s timeout
+		while ! mkdir "$lock_dir" 2>/dev/null; do
+			attempts=$((attempts + 1))
+			if [[ "$attempts" -ge "$max_attempts" ]]; then
+				echo "Error: could not acquire ledger lock (mkdir): $lock_dir" >&2
+				return 1
+			fi
+			sleep 0.1
+		done
 	fi
 	return 0
 }
@@ -75,6 +91,10 @@ _acquire_lock() {
 _release_lock() {
 	if command -v flock &>/dev/null; then
 		flock -u 8 2>/dev/null || true
+	else
+		# Remove mkdir-based lock
+		local lock_dir="${LEDGER_LOCK}.d"
+		rmdir "$lock_dir" 2>/dev/null || true
 	fi
 	return 0
 }
@@ -159,7 +179,10 @@ cmd_register() {
 	fi
 
 	_ensure_ledger
-	_acquire_lock
+	if ! _acquire_lock; then
+		echo "Error: register aborted — could not acquire lock" >&2
+		return 1
+	fi
 
 	local now
 	now=$(_now_utc)
@@ -167,7 +190,7 @@ cmd_register() {
 	# Remove any existing entry for this session_key (idempotent re-register)
 	if [[ -s "$LEDGER_FILE" ]]; then
 		local tmp_file
-		tmp_file=$(mktemp)
+		tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX")
 		jq -c --arg sk "$session_key" 'select(.session_key != $sk)' "$LEDGER_FILE" >"$tmp_file" 2>/dev/null || true
 		mv "$tmp_file" "$LEDGER_FILE"
 	fi
@@ -393,7 +416,9 @@ _update_status() {
 	local new_status="$2"
 
 	_ensure_ledger
-	_acquire_lock
+	if ! _acquire_lock; then
+		return 0 # Silently skip — status update is best-effort
+	fi
 
 	if [[ ! -s "$LEDGER_FILE" ]]; then
 		_release_lock
@@ -403,10 +428,16 @@ _update_status() {
 	local now
 	now=$(_now_utc)
 	local tmp_file
-	tmp_file=$(mktemp)
+	tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX")
 
+	# Only transition entries that are still "in-flight" — terminal statuses
+	# ("completed", "failed") are immutable. A late fail from dead-PID cleanup
+	# must not overwrite a genuinely completed dispatch.
 	jq -c --arg sk "$session_key" --arg st "$new_status" --arg ts "$now" \
-		'if .session_key == $sk then .status = $st | .updated_at = $ts else . end' \
+		'if .session_key == $sk and .status == "in-flight"
+			then .status = $st | .updated_at = $ts
+			else .
+		end' \
 		"$LEDGER_FILE" >"$tmp_file" 2>/dev/null || cp "$LEDGER_FILE" "$tmp_file"
 
 	mv "$tmp_file" "$LEDGER_FILE"
@@ -446,7 +477,10 @@ cmd_expire() {
 	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl="$DEFAULT_TTL"
 
 	_ensure_ledger
-	_acquire_lock
+	if ! _acquire_lock; then
+		printf '%s\n' "0"
+		return 0 # Best-effort cleanup
+	fi
 
 	if [[ ! -s "$LEDGER_FILE" ]]; then
 		_release_lock
@@ -460,7 +494,7 @@ cmd_expire() {
 	now_ts=$(_now_utc)
 	local expired_count=0
 	local tmp_file
-	tmp_file=$(mktemp)
+	tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX")
 
 	while IFS= read -r line; do
 		[[ -z "$line" ]] && continue
@@ -597,7 +631,10 @@ cmd_status() {
 #######################################
 cmd_prune() {
 	_ensure_ledger
-	_acquire_lock
+	if ! _acquire_lock; then
+		printf '%s\n' "0"
+		return 0 # Best-effort cleanup — skip if locked
+	fi
 
 	if [[ ! -s "$LEDGER_FILE" ]]; then
 		_release_lock
@@ -610,7 +647,7 @@ cmd_prune() {
 	prune_threshold=86400 # 24 hours
 	pruned_count=0
 	local tmp_file
-	tmp_file=$(mktemp)
+	tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX")
 
 	while IFS= read -r line; do
 		[[ -z "$line" ]] && continue

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -20,9 +20,54 @@ readonly STATE_DIR="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-wo
 readonly STATE_DB="${STATE_DIR}/state.db"
 readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"
 readonly SANDBOX_EXEC_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
+readonly DISPATCH_LEDGER_HELPER="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 readonly HEADLESS_SANDBOX_TIMEOUT_DEFAULT="${AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT:-3600}"
 readonly OPENCODE_AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
 readonly LOCK_DIR="${STATE_DIR}/locks"
+
+# _register_dispatch_ledger: register this dispatch in the in-flight ledger (GH#6696).
+# Extracts issue number from session_key (pattern: "issue-NNN") and registers
+# the dispatch so the pulse can detect in-flight workers before they create PRs.
+#
+# Args: $1 = session_key, $2 = work_dir (used to resolve repo slug)
+_register_dispatch_ledger() {
+	local ledger_session_key="$1"
+	local ledger_work_dir="$2"
+
+	[[ -x "$DISPATCH_LEDGER_HELPER" ]] || return 0
+
+	local ledger_issue=""
+	local ledger_repo=""
+
+	# Extract issue number from session key (e.g., "issue-42" -> "42")
+	if [[ "$ledger_session_key" =~ ^issue-([0-9]+)$ ]]; then
+		ledger_issue="${BASH_REMATCH[1]}"
+	fi
+
+	# Resolve repo slug from work_dir via git remote
+	if [[ -n "$ledger_work_dir" && -d "$ledger_work_dir" ]]; then
+		ledger_repo=$(git -C "$ledger_work_dir" remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || true)
+	fi
+
+	local ledger_args=(register --session-key "$ledger_session_key" --pid "$$")
+	[[ -n "$ledger_issue" ]] && ledger_args+=(--issue "$ledger_issue")
+	[[ -n "$ledger_repo" ]] && ledger_args+=(--repo "$ledger_repo")
+
+	"$DISPATCH_LEDGER_HELPER" "${ledger_args[@]}" 2>/dev/null || true
+	return 0
+}
+
+# _update_dispatch_ledger: mark a dispatch as completed or failed (GH#6696).
+# Args: $1 = session_key, $2 = status ("completed" or "failed")
+_update_dispatch_ledger() {
+	local ledger_session_key="$1"
+	local ledger_status="$2"
+
+	[[ -x "$DISPATCH_LEDGER_HELPER" ]] || return 0
+
+	"$DISPATCH_LEDGER_HELPER" "$ledger_status" --session-key "$ledger_session_key" 2>/dev/null || true
+	return 0
+}
 
 # _acquire_session_lock: prevent duplicate workers for the same session-key (GH#6538).
 #
@@ -1105,11 +1150,17 @@ cmd_run() {
 		return 0
 	fi
 	# shellcheck disable=SC2064
-	trap "_release_session_lock '$session_key'" EXIT
+	trap "_release_session_lock '$session_key'; _update_dispatch_ledger '$session_key' 'fail'" EXIT
+
+	# GH#6696: Register this dispatch in the in-flight ledger so the pulse
+	# can detect workers that haven't created PRs yet. The ledger bridges
+	# the 10-15 minute gap between dispatch and PR creation.
+	_register_dispatch_ledger "$session_key" "$work_dir"
 
 	local selected_model
 	selected_model=$(choose_model "$role" "$model_override") || {
 		local choose_exit=$?
+		_update_dispatch_ledger "$session_key" "fail"
 		_release_session_lock "$session_key"
 		trap - EXIT
 		return "$choose_exit"
@@ -1128,6 +1179,7 @@ cmd_run() {
 		local attempt_exit=$?
 
 		if [[ "$attempt_exit" -eq 0 ]]; then
+			_update_dispatch_ledger "$session_key" "complete"
 			_release_session_lock "$session_key"
 			trap - EXIT
 			return 0
@@ -1136,6 +1188,7 @@ cmd_run() {
 		# Only retry on auth errors when no explicit model was requested
 		# and we have attempts remaining.
 		if [[ -n "$model_override" || "$_run_failure_reason" != "auth_error" || "$attempt" -ge "$max_attempts" ]]; then
+			_update_dispatch_ledger "$session_key" "fail"
 			_release_session_lock "$session_key"
 			trap - EXIT
 			return "$attempt_exit"
@@ -1144,6 +1197,7 @@ cmd_run() {
 		local provider next_model
 		provider=$(extract_provider "$selected_model")
 		next_model=$(choose_model "$role" "") || {
+			_update_dispatch_ledger "$session_key" "fail"
 			_release_session_lock "$session_key"
 			trap - EXIT
 			return "$attempt_exit"
@@ -1155,6 +1209,7 @@ cmd_run() {
 
 	# Unreachable: loop always executes (attempt starts at 1, max_attempts=2)
 	# and every path inside returns explicitly. Kept as defensive fallback.
+	_update_dispatch_ledger "$session_key" "fail"
 	_release_session_lock "$session_key"
 	trap - EXIT
 	return 1

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3227,12 +3227,18 @@ has_worker_for_repo_issue() {
 }
 
 #######################################
-# Check if dispatching a worker would be a duplicate (GH#4400, GH#5210)
+# Check if dispatching a worker would be a duplicate (GH#4400, GH#5210, GH#6696)
 #
-# Four-layer dedup:
-#   1. has_worker_for_repo_issue() — exact repo+issue process match
-#   2. dispatch-dedup-helper.sh is-duplicate — normalized title key match
-#   3. dispatch-dedup-helper.sh has-open-pr — merged PR evidence for issue/task
+# Five-layer dedup:
+#   1. dispatch-ledger-helper.sh check-issue — in-flight ledger (GH#6696)
+#   2. has_worker_for_repo_issue() — exact repo+issue process match
+#   3. dispatch-dedup-helper.sh is-duplicate — normalized title key match
+#   4. dispatch-dedup-helper.sh has-open-pr — merged PR evidence for issue/task
+#
+# Layer 1 (ledger) is checked first because it's the fastest (local file
+# read, no process scanning or GitHub API calls) and catches the primary
+# failure mode: workers dispatched but not yet visible in process lists
+# or GitHub PRs (the 10-15 minute gap between dispatch and PR creation).
 #
 # Arguments:
 #   $1 - issue number
@@ -3249,13 +3255,23 @@ check_dispatch_dedup() {
 	local title="$3"
 	local issue_title="${4:-}"
 
-	# Layer 1: exact repo+issue process match
+	# Layer 1 (GH#6696): in-flight dispatch ledger — catches workers between
+	# dispatch and PR creation (the 10-15 min gap that caused duplicate dispatches)
+	local ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+	if [[ -x "$ledger_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+		if "$ledger_helper" check-issue --issue "$issue_number" --repo "$repo_slug" >/dev/null 2>&1; then
+			echo "[pulse-wrapper] Dedup: in-flight ledger entry for #${issue_number} in ${repo_slug} (GH#6696)" >>"$LOGFILE"
+			return 0
+		fi
+	fi
+
+	# Layer 2: exact repo+issue process match
 	if has_worker_for_repo_issue "$issue_number" "$repo_slug"; then
 		echo "[pulse-wrapper] Dedup: worker already running for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 		return 0
 	fi
 
-	# Layer 2: normalized title key match via dispatch-dedup-helper
+	# Layer 3: normalized title key match via dispatch-dedup-helper
 	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
 	if [[ -x "$dedup_helper" ]] && [[ -n "$title" ]]; then
 		if "$dedup_helper" is-duplicate "$title" >/dev/null 2>&1; then
@@ -3264,7 +3280,7 @@ check_dispatch_dedup() {
 		fi
 	fi
 
-	# Layer 3: merged PR evidence for this issue/task
+	# Layer 4: merged PR evidence for this issue/task
 	local dedup_helper_output=""
 	if [[ -x "$dedup_helper" ]]; then
 		if dedup_helper_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>>"$LOGFILE"); then
@@ -3903,6 +3919,19 @@ _run_preflight_stages() {
 	run_stage_with_timeout "cleanup_orphans" "$PRE_RUN_STAGE_TIMEOUT" cleanup_orphans || true
 	run_stage_with_timeout "cleanup_worktrees" "$PRE_RUN_STAGE_TIMEOUT" cleanup_worktrees || true
 	run_stage_with_timeout "cleanup_stashes" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stashes || true
+
+	# GH#6696: Expire stale in-flight ledger entries and prune old completed/failed ones.
+	# This runs before worker counting so count_active_workers sees accurate ledger state.
+	local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+	if [[ -x "$_ledger_helper" ]]; then
+		local expired_count
+		expired_count=$("$_ledger_helper" expire 2>/dev/null) || expired_count=0
+		"$_ledger_helper" prune >/dev/null 2>&1 || true
+		if [[ "${expired_count:-0}" -gt 0 ]]; then
+			echo "[pulse-wrapper] Dispatch ledger: expired ${expired_count} stale in-flight entries (GH#6696)" >>"$LOGFILE"
+		fi
+	fi
+
 	calculate_max_workers
 	calculate_priority_allocations
 	check_session_count >/dev/null

--- a/.agents/scripts/safety-policy-check.sh
+++ b/.agents/scripts/safety-policy-check.sh
@@ -80,6 +80,18 @@ check_policy_markers() {
 	local sandbox_helper="${SCRIPT_DIR}/sandbox-exec-helper.sh"
 	local secret_handling_ref="${SCRIPT_DIR}/../reference/secret-handling.md"
 
+	# Explicit readability checks before marker checks — avoids misleading
+	# "marker missing" errors when the file itself is absent or unreadable.
+	if [[ ! -r "$build_prompt" ]]; then
+		echo "FAIL: build prompt not readable: $build_prompt" >&2
+		return 1
+	fi
+
+	if [[ ! -r "$sandbox_helper" ]]; then
+		echo "FAIL: sandbox helper not readable: $sandbox_helper" >&2
+		return 1
+	fi
+
 	# build.txt must reference transcript exposure policy (inline or via pointer)
 	if ! pattern_exists "transcript exposure" "$build_prompt"; then
 		echo "FAIL: transcript exposure policy missing from build prompt" >&2
@@ -95,6 +107,10 @@ check_policy_markers() {
 	# Detailed secret handling rules must exist (either inline in build.txt
 	# or in the extracted reference file)
 	if [[ -f "$secret_handling_ref" ]]; then
+		if [[ ! -r "$secret_handling_ref" ]]; then
+			echo "FAIL: secret-handling reference not readable: $secret_handling_ref" >&2
+			return 1
+		fi
 		if ! pattern_exists "Never paste secret values into AI chat" "$secret_handling_ref"; then
 			echo "FAIL: mandatory warning guidance missing from secret-handling reference" >&2
 			return 1

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -163,20 +163,23 @@ test_complete_marks_entry() {
 	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
 	"$LEDGER_HELPER" complete --session-key "issue-42"
 
-	# check should now return 1 (no in-flight entry)
+	# A late fail (e.g., from dead-PID cleanup) must NOT overwrite completed status
+	"$LEDGER_HELPER" fail --session-key "issue-42"
+
+	# check should still return 1 (no in-flight entry)
 	local result=0
 	if "$LEDGER_HELPER" check --session-key "issue-42" >/dev/null 2>&1; then
 		result=1
 	fi
 
-	# Verify status in file
+	# Verify status is still "completed" — not downgraded to "failed"
 	local status
 	status=$(jq -r '.status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
 	if [[ "$status" != "completed" ]]; then
 		result=1
 	fi
 
-	print_result "complete marks entry as completed" "$result" "status=${status}"
+	print_result "complete marks entry as completed (terminal state immutable)" "$result" "status=${status}"
 	teardown_test_env
 	return 0
 }
@@ -199,6 +202,42 @@ test_fail_marks_entry() {
 	fi
 
 	print_result "fail marks entry as failed" "$result" "status=${status}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: terminal status immutability — fail cannot overwrite completed,
+# complete cannot overwrite failed (regression for CodeRabbit review)
+#######################################
+test_terminal_state_immutability() {
+	setup_test_env
+
+	local result=0
+
+	# Case 1: fail must not overwrite completed
+	"$LEDGER_HELPER" register --session-key "issue-77" --issue 77 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" complete --session-key "issue-77"
+	"$LEDGER_HELPER" fail --session-key "issue-77"
+
+	local status1
+	status1=$(jq -r 'select(.session_key == "issue-77") | .status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+	if [[ "$status1" != "completed" ]]; then
+		result=1
+	fi
+
+	# Case 2: complete must not overwrite failed
+	"$LEDGER_HELPER" register --session-key "issue-78" --issue 78 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" fail --session-key "issue-78"
+	"$LEDGER_HELPER" complete --session-key "issue-78"
+
+	local status2
+	status2=$(jq -r 'select(.session_key == "issue-78") | .status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+	if [[ "$status2" != "failed" ]]; then
+		result=1
+	fi
+
+	print_result "terminal status immutability (completed/failed are final)" "$result" "completed_after_fail=${status1}, failed_after_complete=${status2}"
 	teardown_test_env
 	return 0
 }
@@ -444,6 +483,7 @@ main() {
 	test_check_issue_detects_inflight
 	test_check_issue_different_repo
 	test_complete_marks_entry
+	test_terminal_state_immutability
 	test_fail_marks_entry
 	test_register_idempotent
 	test_count_inflight

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -15,6 +15,19 @@ TESTS_FAILED=0
 
 TEST_ROOT=""
 
+#######################################
+# Run a helper command without triggering set -e on failure.
+# Captures exit status so test bodies can check it explicitly.
+# Usage: run_helper [args...]; LAST_EXIT=$?
+#######################################
+run_helper() {
+	set +e
+	"$@"
+	LAST_EXIT=$?
+	set -e
+	return 0
+}
+
 print_result() {
 	local test_name="$1"
 	local passed="$2"
@@ -54,7 +67,7 @@ teardown_test_env() {
 test_register_creates_entry() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
 
 	local entry_count
 	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
@@ -88,7 +101,7 @@ test_register_creates_entry() {
 test_check_detects_inflight() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-99" --issue 99 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-99" --issue 99 --repo "owner/repo" --pid $$
 
 	local result=1
 	if "$LEDGER_HELPER" check --session-key "issue-99" >/dev/null 2>&1; then
@@ -106,7 +119,7 @@ test_check_detects_inflight() {
 test_check_returns_1_for_unknown() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
 
 	local result=0
 	if "$LEDGER_HELPER" check --session-key "issue-999" >/dev/null 2>&1; then
@@ -124,7 +137,7 @@ test_check_returns_1_for_unknown() {
 test_check_issue_detects_inflight() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-55" --issue 55 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-55" --issue 55 --repo "owner/repo" --pid $$
 
 	local result=1
 	if "$LEDGER_HELPER" check-issue --issue 55 --repo "owner/repo" >/dev/null 2>&1; then
@@ -142,7 +155,7 @@ test_check_issue_detects_inflight() {
 test_check_issue_different_repo() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-55" --issue 55 --repo "owner/repo-a" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-55" --issue 55 --repo "owner/repo-a" --pid $$
 
 	local result=0
 	if "$LEDGER_HELPER" check-issue --issue 55 --repo "owner/repo-b" >/dev/null 2>&1; then
@@ -160,11 +173,11 @@ test_check_issue_different_repo() {
 test_complete_marks_entry() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" complete --session-key "issue-42"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" complete --session-key "issue-42"
 
 	# A late fail (e.g., from dead-PID cleanup) must NOT overwrite completed status
-	"$LEDGER_HELPER" fail --session-key "issue-42"
+	run_helper "$LEDGER_HELPER" fail --session-key "issue-42"
 
 	# check should still return 1 (no in-flight entry)
 	local result=0
@@ -190,8 +203,8 @@ test_complete_marks_entry() {
 test_fail_marks_entry() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" fail --session-key "issue-42"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" fail --session-key "issue-42"
 
 	local status
 	status=$(jq -r '.status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
@@ -216,9 +229,9 @@ test_terminal_state_immutability() {
 	local result=0
 
 	# Case 1: fail must not overwrite completed
-	"$LEDGER_HELPER" register --session-key "issue-77" --issue 77 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" complete --session-key "issue-77"
-	"$LEDGER_HELPER" fail --session-key "issue-77"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-77" --issue 77 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" complete --session-key "issue-77"
+	run_helper "$LEDGER_HELPER" fail --session-key "issue-77"
 
 	local status1
 	status1=$(jq -r 'select(.session_key == "issue-77") | .status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
@@ -227,9 +240,9 @@ test_terminal_state_immutability() {
 	fi
 
 	# Case 2: complete must not overwrite failed
-	"$LEDGER_HELPER" register --session-key "issue-78" --issue 78 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" fail --session-key "issue-78"
-	"$LEDGER_HELPER" complete --session-key "issue-78"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-78" --issue 78 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" fail --session-key "issue-78"
+	run_helper "$LEDGER_HELPER" complete --session-key "issue-78"
 
 	local status2
 	status2=$(jq -r 'select(.session_key == "issue-78") | .status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
@@ -248,8 +261,8 @@ test_terminal_state_immutability() {
 test_register_idempotent() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
 
 	local entry_count
 	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
@@ -270,10 +283,10 @@ test_register_idempotent() {
 test_count_inflight() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-1" --issue 1 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" register --session-key "issue-2" --issue 2 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" register --session-key "issue-3" --issue 3 --repo "owner/repo" --pid $$
-	"$LEDGER_HELPER" complete --session-key "issue-2"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-1" --issue 1 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-2" --issue 2 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-3" --issue 3 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" complete --session-key "issue-2"
 
 	local count
 	count=$("$LEDGER_HELPER" count)
@@ -410,7 +423,7 @@ test_prune_old_entries() {
 test_status_runs() {
 	setup_test_env
 
-	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
 
 	local output
 	output=$("$LEDGER_HELPER" status 2>&1)

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# test-dispatch-ledger-helper.sh — Tests for dispatch-ledger-helper.sh (GH#6696)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+LEDGER_HELPER="${SCRIPT_DIR}/../dispatch-ledger-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export AIDEVOPS_DISPATCH_LEDGER_DIR="${TEST_ROOT}/ledger"
+	mkdir -p "${TEST_ROOT}/ledger"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+#######################################
+# Test: register creates a ledger entry
+#######################################
+test_register_creates_entry() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+
+	local entry_count
+	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
+
+	local result=0
+	if [[ "$entry_count" -ne 1 ]]; then
+		result=1
+	fi
+
+	# Verify fields
+	local status
+	status=$(jq -r '.status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+	if [[ "$status" != "in-flight" ]]; then
+		result=1
+	fi
+
+	local session_key
+	session_key=$(jq -r '.session_key' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+	if [[ "$session_key" != "issue-42" ]]; then
+		result=1
+	fi
+
+	print_result "register creates a ledger entry with correct fields" "$result" "count=${entry_count}, status=${status}, key=${session_key}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: check detects in-flight entry
+#######################################
+test_check_detects_inflight() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-99" --issue 99 --repo "owner/repo" --pid $$
+
+	local result=1
+	if "$LEDGER_HELPER" check --session-key "issue-99" >/dev/null 2>&1; then
+		result=0
+	fi
+
+	print_result "check detects in-flight entry" "$result"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: check returns 1 for unknown session key
+#######################################
+test_check_returns_1_for_unknown() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+
+	local result=0
+	if "$LEDGER_HELPER" check --session-key "issue-999" >/dev/null 2>&1; then
+		result=1
+	fi
+
+	print_result "check returns 1 for unknown session key" "$result"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: check-issue detects in-flight by issue number
+#######################################
+test_check_issue_detects_inflight() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-55" --issue 55 --repo "owner/repo" --pid $$
+
+	local result=1
+	if "$LEDGER_HELPER" check-issue --issue 55 --repo "owner/repo" >/dev/null 2>&1; then
+		result=0
+	fi
+
+	print_result "check-issue detects in-flight by issue number" "$result"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: check-issue returns 1 for different repo
+#######################################
+test_check_issue_different_repo() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-55" --issue 55 --repo "owner/repo-a" --pid $$
+
+	local result=0
+	if "$LEDGER_HELPER" check-issue --issue 55 --repo "owner/repo-b" >/dev/null 2>&1; then
+		result=1
+	fi
+
+	print_result "check-issue returns 1 for different repo" "$result"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: complete marks entry as completed
+#######################################
+test_complete_marks_entry() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" complete --session-key "issue-42"
+
+	# check should now return 1 (no in-flight entry)
+	local result=0
+	if "$LEDGER_HELPER" check --session-key "issue-42" >/dev/null 2>&1; then
+		result=1
+	fi
+
+	# Verify status in file
+	local status
+	status=$(jq -r '.status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+	if [[ "$status" != "completed" ]]; then
+		result=1
+	fi
+
+	print_result "complete marks entry as completed" "$result" "status=${status}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: fail marks entry as failed
+#######################################
+test_fail_marks_entry() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" fail --session-key "issue-42"
+
+	local status
+	status=$(jq -r '.status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+
+	local result=0
+	if [[ "$status" != "failed" ]]; then
+		result=1
+	fi
+
+	print_result "fail marks entry as failed" "$result" "status=${status}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: register is idempotent (re-register overwrites)
+#######################################
+test_register_idempotent() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+
+	local entry_count
+	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
+
+	local result=0
+	if [[ "$entry_count" -ne 1 ]]; then
+		result=1
+	fi
+
+	print_result "register is idempotent (re-register overwrites)" "$result" "count=${entry_count}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: count returns correct number of in-flight entries
+#######################################
+test_count_inflight() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-1" --issue 1 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" register --session-key "issue-2" --issue 2 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" register --session-key "issue-3" --issue 3 --repo "owner/repo" --pid $$
+	"$LEDGER_HELPER" complete --session-key "issue-2"
+
+	local count
+	count=$("$LEDGER_HELPER" count)
+
+	local result=0
+	if [[ "$count" -ne 2 ]]; then
+		result=1
+	fi
+
+	print_result "count returns correct number of in-flight entries" "$result" "count=${count} (expected 2)"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: expire removes stale entries by TTL
+#######################################
+test_expire_by_ttl() {
+	setup_test_env
+
+	# Create an entry with a timestamp 2 hours ago
+	local old_ts
+	old_ts=$(date -u -d '2 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-2H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "2020-01-01T00:00:00Z")
+
+	printf '{"session_key":"issue-old","issue_number":"100","repo_slug":"owner/repo","pid":99999999,"dispatched_at":"%s","status":"in-flight","updated_at":"%s"}\n' "$old_ts" "$old_ts" >"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl"
+
+	local expired_count
+	expired_count=$("$LEDGER_HELPER" expire --ttl 60)
+
+	local result=0
+	if [[ "$expired_count" -ne 1 ]]; then
+		result=1
+	fi
+
+	# Verify status changed to failed
+	local status
+	status=$(jq -r '.status' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" 2>/dev/null | head -1)
+	if [[ "$status" != "failed" ]]; then
+		result=1
+	fi
+
+	print_result "expire removes stale entries by TTL" "$result" "expired=${expired_count}, status=${status}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: expire detects dead PIDs
+#######################################
+test_expire_dead_pid() {
+	setup_test_env
+
+	local now_ts
+	now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+	# Use a PID that definitely doesn't exist (99999999)
+	printf '{"session_key":"issue-dead","issue_number":"200","repo_slug":"owner/repo","pid":99999999,"dispatched_at":"%s","status":"in-flight","updated_at":"%s"}\n' "$now_ts" "$now_ts" >"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl"
+
+	local expired_count
+	expired_count=$("$LEDGER_HELPER" expire --ttl 99999)
+
+	local result=0
+	if [[ "$expired_count" -ne 1 ]]; then
+		result=1
+	fi
+
+	print_result "expire detects dead PIDs" "$result" "expired=${expired_count}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: check detects dead PID and marks as failed
+#######################################
+test_check_dead_pid_marks_failed() {
+	setup_test_env
+
+	local now_ts
+	now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+	# Register with a dead PID
+	printf '{"session_key":"issue-dead","issue_number":"300","repo_slug":"owner/repo","pid":99999999,"dispatched_at":"%s","status":"in-flight","updated_at":"%s"}\n' "$now_ts" "$now_ts" >"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl"
+
+	# check should return 1 (safe to dispatch) because PID is dead
+	local result=0
+	if "$LEDGER_HELPER" check --session-key "issue-dead" >/dev/null 2>&1; then
+		result=1
+	fi
+
+	print_result "check detects dead PID and returns safe-to-dispatch" "$result"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: prune removes old completed/failed entries
+#######################################
+test_prune_old_entries() {
+	setup_test_env
+
+	local old_ts
+	old_ts=$(date -u -d '48 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-48H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "2020-01-01T00:00:00Z")
+	local now_ts
+	now_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+	# One old completed entry, one recent in-flight entry
+	{
+		printf '{"session_key":"issue-old","issue_number":"100","repo_slug":"owner/repo","pid":1,"dispatched_at":"%s","status":"completed","updated_at":"%s"}\n' "$old_ts" "$old_ts"
+		printf '{"session_key":"issue-new","issue_number":"200","repo_slug":"owner/repo","pid":%d,"dispatched_at":"%s","status":"in-flight","updated_at":"%s"}\n' "$$" "$now_ts" "$now_ts"
+	} >"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl"
+
+	local pruned_count
+	pruned_count=$("$LEDGER_HELPER" prune)
+
+	local remaining
+	remaining=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
+
+	local result=0
+	if [[ "$pruned_count" -ne 1 ]]; then
+		result=1
+	fi
+	if [[ "$remaining" -ne 1 ]]; then
+		result=1
+	fi
+
+	print_result "prune removes old completed/failed entries" "$result" "pruned=${pruned_count}, remaining=${remaining}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: status command runs without error
+#######################################
+test_status_runs() {
+	setup_test_env
+
+	"$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
+
+	local output
+	output=$("$LEDGER_HELPER" status 2>&1)
+	local exit_code=$?
+
+	local result=0
+	if [[ "$exit_code" -ne 0 ]]; then
+		result=1
+	fi
+
+	print_result "status command runs without error" "$result"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Test: empty ledger operations don't fail
+#######################################
+test_empty_ledger_operations() {
+	setup_test_env
+
+	local result=0
+
+	# All operations should succeed on empty ledger
+	if "$LEDGER_HELPER" check --session-key "nonexistent" >/dev/null 2>&1; then
+		result=1 # Should return 1 (not found)
+	fi
+
+	local count
+	count=$("$LEDGER_HELPER" count)
+	if [[ "$count" -ne 0 ]]; then
+		result=1
+	fi
+
+	local expired
+	expired=$("$LEDGER_HELPER" expire)
+	if [[ "$expired" -ne 0 ]]; then
+		result=1
+	fi
+
+	"$LEDGER_HELPER" status >/dev/null 2>&1 || result=1
+
+	print_result "empty ledger operations don't fail" "$result" "count=${count}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# Run all tests
+#######################################
+main() {
+	echo "=== dispatch-ledger-helper.sh tests (GH#6696) ==="
+	echo ""
+
+	# Verify helper exists
+	if [[ ! -x "$LEDGER_HELPER" ]]; then
+		echo "ERROR: dispatch-ledger-helper.sh not found at $LEDGER_HELPER"
+		exit 1
+	fi
+
+	# Verify jq is available
+	if ! command -v jq &>/dev/null; then
+		echo "ERROR: jq is required for tests"
+		exit 1
+	fi
+
+	test_register_creates_entry
+	test_check_detects_inflight
+	test_check_returns_1_for_unknown
+	test_check_issue_detects_inflight
+	test_check_issue_different_repo
+	test_complete_marks_entry
+	test_fail_marks_entry
+	test_register_idempotent
+	test_count_inflight
+	test_expire_by_ttl
+	test_expire_dead_pid
+	test_check_dead_pid_marks_failed
+	test_prune_old_entries
+	test_status_runs
+	test_empty_ledger_operations
+
+	echo ""
+	echo "=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ==="
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `dispatch-ledger-helper.sh` — a lightweight JSONL-based ledger that tracks workers between dispatch and PR creation, closing the 10-15 minute dedup gap that caused duplicate dispatches
- Integrates ledger into `headless-runtime-helper.sh` (register on dispatch, complete/fail on exit) and `pulse-wrapper.sh` (Layer 1 dedup check + preflight expire/prune)
- Includes 15 unit tests covering all ledger operations

## Problem

When the pulse dispatches workers in a continuous loop, it re-dispatches the same target because there's no tracking of in-flight workers between dispatch and PR creation. Workers take 10-15 minutes to create a worktree, implement, push, and open a PR. During that window, the pulse's dedup check (`gh pr list --state open`) finds nothing and re-dispatches. This was observed causing 4x duplicate dispatches per file, 47 orphaned worktrees, and significant token waste.

## Solution

**Dispatch ledger** (`dispatch-ledger-helper.sh`):
- JSONL file at `~/.aidevops/.agent-workspace/tmp/dispatch-ledger.jsonl`
- Commands: `register`, `check`, `check-issue`, `complete`, `fail`, `expire`, `count`, `prune`, `status`
- Entries include PID for liveness checks — dead PIDs are auto-detected and marked failed
- Configurable TTL (default 60 min) with automatic expiry of stale entries
- File-level flock for concurrent access safety

**Integration points:**
- `headless-runtime-helper.sh`: registers dispatch after session lock acquired, marks complete/fail on all exit paths (including EXIT trap)
- `pulse-wrapper.sh`: 
  - `check_dispatch_dedup()` — ledger check added as **Layer 1** (fastest, no process scanning or API calls)
  - `_run_preflight_stages()` — runs `expire` + `prune` before worker counting

## Runtime Testing

- **Testing level**: `unit-tested`
- **Risk classification**: Medium (dispatch infrastructure, no data deletion)
- 15 unit tests all passing — covers register, check, check-issue, complete, fail, idempotent re-register, count, expire by TTL, expire dead PIDs, check dead PID detection, prune, status, empty ledger operations
- ShellCheck clean on all files (zero violations)

## Files Changed

| File | What / Why |
|------|-----------|
| `.agents/scripts/dispatch-ledger-helper.sh` | **New** — in-flight dispatch tracking ledger |
| `.agents/scripts/headless-runtime-helper.sh` | Register/complete/fail ledger entries on worker lifecycle |
| `.agents/scripts/pulse-wrapper.sh` | Layer 1 dedup check + preflight expire/prune |
| `.agents/scripts/tests/test-dispatch-ledger-helper.sh` | **New** — 15 unit tests for ledger operations |

Closes #6696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent dispatch ledger to prevent duplicate in-flight dispatches and integrated ledger checks into preflight/dedup flows; ledger maintenance (expire/prune) runs automatically.

* **Bug Fixes**
  * Deduplication now treats dead or stale dispatches as safe to retry and avoids overwriting terminal statuses.

* **Tests**
  * Added a comprehensive end-to-end test suite validating ledger commands and lifecycle behaviors.

* **Chores**
  * Tightened safety policy marker validations in CI helper scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->