### PR TITLE
docs: add Python packaging guidance for workers in worktree-based workflow

### DIFF
--- a/.agents/templates/plans-template.md
+++ b/.agents/templates/plans-template.md
@@ -80,6 +80,18 @@ Based on [Loom's spec-as-lookup-table pattern](https://ghuntley.com/ralph/), eac
 
 Brief description of why this work matters.
 
+#### Development Environment
+
+<!-- Required for Python, Node.js, and any project with non-trivial setup.
+     Workers read this section to avoid broken installs in worktrees. -->
+
+| Item | Value |
+|------|-------|
+| Language/runtime | e.g. Python 3.12, Node 20 |
+| Venv/install | e.g. `python3 -m venv .venv && pip install -e ".[dev]"` |
+| Tests | e.g. `source .venv/bin/activate && pytest` |
+| Do NOT | e.g. install globally; run `pip install -e` from worktree using canonical venv |
+
 #### Linkage (The Pin)
 
 | Concept | Files | Lines | Synonyms |

--- a/.agents/tools/code-review/code-standards.md
+++ b/.agents/tools/code-review/code-standards.md
@@ -397,6 +397,90 @@ npx markdownlint-cli2 "**/*.md" --ignore node_modules
 - **Codacy**: Enterprise-grade compliance
 - **Critical Issues**: S7679 & S1481 = 0 (RESOLVED)
 
+## Python Projects
+
+Rules for Python projects using the worktree-based workflow. Workers encounter these regularly — the worktree model creates specific failure modes that differ from single-checkout development.
+
+### Worktrees and Virtual Environments
+
+**Gitignored artifacts do not transfer between worktrees.** `.venv/`, `__pycache__/`, build dirs, and compiled extensions are gitignored and exist only in the directory where they were created. A worker operating in a worktree cannot assume the canonical repo's `.venv/` is usable from that worktree path.
+
+| Situation | Correct action |
+|-----------|----------------|
+| Project has `.venv/` in canonical repo | Create a fresh `.venv/` inside the worktree, or activate the canonical venv by absolute path and do NOT run `pip install -e` from the worktree |
+| Project has `pyproject.toml` but no `.venv/` | Create `.venv/` inside the worktree: `python3 -m venv .venv && pip install -e ".[dev]"` |
+| Verifying that a package installs correctly | Create a throwaway venv inside the worktree — never modify the canonical repo's venv from a worktree context |
+
+### Editable Installs in Worktrees
+
+**`pip install -e` writes the worktree's absolute path into a `.pth` file.** When the worktree is removed after PR merge, that path no longer exists. Any code that imports the package via the editable install will fail silently.
+
+```bash
+# UNSAFE — from inside a worktree, using the canonical repo's venv
+pip install -e shared/project/  # Writes worktree path into canonical venv's .pth
+
+# SAFE — create a throwaway venv inside the worktree
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e shared/project/  # .pth path is inside the worktree, removed with it
+```
+
+**Rule**: Never run `pip install -e` from a worktree using a venv that lives outside the worktree.
+
+### Installation Scope
+
+**Never install packages to user-local or system scope.** If a project has a `.venv/`, use it. If it doesn't, create one. Never let `pip install` fall through to `~/.local/lib/` or system Python.
+
+```bash
+# UNSAFE — no venv active, packages go to ~/.local/lib/python3.x/
+pip install crawl4ai
+
+# SAFE — activate venv first
+source .venv/bin/activate
+pip install crawl4ai
+
+# SAFE — explicit venv pip
+.venv/bin/pip install crawl4ai
+```
+
+Verify scope before installing: `pip --version` should show a path inside the project's `.venv/`, not `~/.local/` or `/usr/`.
+
+### Requirements File Discipline
+
+Every Python project must have a reproducible dependency declaration. Workers must not create venvs and install packages without updating the dependency file.
+
+| File | When to use |
+|------|-------------|
+| `pyproject.toml` (preferred) | New projects, PEP 517/518 compliant |
+| `requirements.txt` | Legacy projects or simple scripts |
+| `requirements-dev.txt` | Dev-only deps (pytest, mypy, ruff) |
+
+After installing any package:
+
+```bash
+# pyproject.toml projects
+pip install -e ".[dev]"  # installs from declared deps — no manual update needed
+
+# requirements.txt projects
+pip freeze > requirements.txt  # or pin manually — never leave venv unreproducible
+```
+
+**A venv that cannot be recreated from committed files is a defect.** Workers must not leave venvs in a state where `git clone` + `pip install -r requirements.txt` would produce a different environment.
+
+### Project AGENTS.md / Plan: Development Environment Section
+
+When working on a Python project that lacks a "Development Environment" section in its `AGENTS.md` or plan, add one. This prevents the next worker from repeating the same discovery. Minimum content:
+
+```markdown
+## Development Environment
+
+- **Python**: 3.x (specify version)
+- **Venv**: `python3 -m venv .venv && source .venv/bin/activate`
+- **Install**: `pip install -e ".[dev]"` (or `pip install -r requirements.txt`)
+- **Tests**: `pytest` (or project-specific command)
+- **Do NOT**: install globally, run `pip install -e` from a worktree using the canonical venv
+```
+
 ## Related Documentation
 
 - **Local linting**: `scripts/linters-local.sh`

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -64,6 +64,17 @@ ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh list
 
 If the main repo is left on a feature branch, the next session inherits that state, causing "local changes would be overwritten" errors and breaking parallel workflows. See `workflows/worktree.md` for full worktree workflow.
 
+**Non-git artifacts do not transfer between worktrees.** Gitignored directories — `.venv/`, `node_modules/`, `dist/`, `build/`, compiled extensions — exist only in the directory where they were created. A worktree starts with only git-tracked files.
+
+| Artifact | Worktree behaviour | Correct action |
+|----------|--------------------|----------------|
+| `.venv/` (Python) | Not present | Create fresh venv inside worktree; never run `pip install -e` from worktree using canonical venv (creates broken absolute `.pth` path) |
+| `node_modules/` | Not present | Run `npm install` / `pnpm install` inside worktree |
+| `dist/`, `build/` | Not present | Run build command inside worktree |
+| `.env` (gitignored) | Not present | Copy from canonical repo or recreate from `.env.example` |
+
+See `tools/code-review/code-standards.md` "Python Projects" for detailed Python packaging rules.
+
 **Session-Branch Tracking**:
 
 | Tool/Command | Purpose |


### PR DESCRIPTION
## Summary

- Adds a **Python Projects** section to `code-standards.md` covering the four failure modes documented in GH#6765: broken editable installs, user-local package accumulation, undeclared venvs, and stale references
- Adds a **non-git artifacts table** to `git-workflow.md` Quick Reference so workers know `.venv/`, `node_modules/`, `.env` etc. don't transfer between worktrees
- Adds a **Development Environment** section to `plans-template.md` so plan authors document venv setup, install commands, and anti-patterns — preventing the next worker from repeating the same discovery

## What changed

| File | Change |
|------|--------|
| `.agents/tools/code-review/code-standards.md` | New "Python Projects" section (84 lines): worktree/venv isolation, editable install `.pth` caveat, installation scope rules, requirements file discipline, guidance to add Dev Env section to project AGENTS.md |
| `.agents/workflows/git-workflow.md` | Non-git artifacts table in Quick Reference: `.venv/`, `node_modules/`, `dist/`, `build/`, `.env` — each with worktree behaviour and correct action |
| `.agents/templates/plans-template.md` | "Development Environment" section added to plan template with language/runtime, venv/install, tests, and Do NOT rows |

## Root cause addressed

The editable install + worktree interaction (GH#6765 root cause): `pip install -e` writes the worktree's absolute path into a `.pth` file in the venv. When the worktree is removed after PR merge, the `.pth` points to a nonexistent directory. Importing the package fails silently. The new guidance explicitly names this mechanism and provides the safe alternative (throwaway venv inside the worktree).

## Runtime Testing

- **Risk classification**: Low — documentation-only changes, no executable code
- **Testing level**: self-assessed
- **Verification**: `npx markdownlint-cli2` — 0 errors across all 3 modified files

Closes #6765