### PR TITLE
fix: restore session-rename.ts as enabled OpenCode tool

### DIFF
--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -46,6 +46,20 @@ Key integrations:
 - **Commands**: 41 slash commands deployed to `~/.config/opencode/commands/`
 - **Plugins**: Compaction plugin at `.agents/plugins/opencode-aidevops/`
 - **Prompts**: Custom system prompt at `.agents/prompts/build.txt`
+- **OpenCode tools**: `.opencode/tool/*.ts` — native OpenCode plugin tools (loaded by the Bun runtime)
+
+### OpenCode Native Tools (`.opencode/tool/`)
+
+Files in `.opencode/tool/` are **OpenCode plugin tools** — TypeScript modules loaded by the Bun runtime that extend the agent's tool palette. They are NOT shell-script wrappers.
+
+**Classification rule:** Before deleting or disabling any `.opencode/tool/*.ts` file, check whether it contains unique logic (DB access, API calls, state management) or is a thin wrapper that shells out to a helper script. Only wrappers are redundant; tools with native logic (like `bun:sqlite` access) have no shell equivalent.
+
+| File | Type | Purpose |
+|------|------|---------|
+| `ai-research.ts` | Native logic | Spawns research queries via Anthropic API |
+| `session-rename.ts` | Native logic | Renames sessions via direct SQLite write to `~/.local/share/opencode/opencode.db` — no HTTP API exists for this |
+
+**Why this matters:** `session-rename.ts` was previously deleted by a cleanup task that treated all `.opencode/tool/` files as redundant wrappers. The tool contains unique logic — OpenCode CLI sessions don't expose an HTTP API; `Session.setTitle()` is a Drizzle ORM write to the local SQLite DB. There is no shell-script equivalent.
 
 ## Intelligence Over Scripts (Core Principle)
 

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -1,0 +1,102 @@
+import { tool } from "@opencode-ai/plugin"
+import { Database } from "bun:sqlite"
+import { homedir } from "os"
+import { join } from "path"
+
+/**
+ * Resolve the OpenCode SQLite database path.
+ * OpenCode stores sessions in ~/.local/share/opencode/opencode.db (Drizzle ORM).
+ * The OPENCODE_DB env var overrides the default path.
+ */
+function getDbPath(): string {
+  if (process.env.OPENCODE_DB) {
+    return process.env.OPENCODE_DB
+  }
+  return join(homedir(), ".local", "share", "opencode", "opencode.db")
+}
+
+/**
+ * Rename a session by updating the title directly in the SQLite database.
+ *
+ * OpenCode CLI sessions do not expose an HTTP API — Session.setTitle() is a
+ * Drizzle ORM call that writes to the local SQLite DB. The TUI reads from the
+ * same DB and picks up changes immediately (verified empirically).
+ */
+function renameSession(sessionID: string, title: string): { success: boolean; message: string } {
+  const dbPath = getDbPath()
+
+  try {
+    const db = new Database(dbPath)
+    try {
+      const nowMs = Date.now()
+      const result = db.run(
+        "UPDATE session SET title = ?, time_updated = ? WHERE id = ?",
+        [title, nowMs, sessionID],
+      )
+
+      if (result.changes === 0) {
+        return { success: false, message: `Session ${sessionID} not found in database` }
+      }
+
+      return { success: true, message: title }
+    } finally {
+      db.close()
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export default tool({
+  description:
+    "Rename the current session to a new title. Use this after creating a git branch to sync the session name with the branch name.",
+  args: {
+    title: tool.schema
+      .string()
+      .describe("New title for the session (e.g., branch name like 'feature/my-feature')"),
+  },
+  async execute(args, context) {
+    const { sessionID } = context
+    const { title } = args
+
+    const result = renameSession(sessionID, title)
+
+    if (result.success) {
+      return `Session renamed to: ${result.message}`
+    }
+    return `Failed to rename session: ${result.message}`
+  },
+})
+
+// Also export a tool that syncs with the current git branch
+export const sync_branch = tool({
+  description:
+    "Rename the current session to match the current git branch name. Call this after creating or switching branches.",
+  args: {},
+  async execute(_args, context) {
+    const { sessionID } = context
+
+    // Get current branch name
+    let branch: string
+    try {
+      const branchResult = await Bun.$`git branch --show-current`.text()
+      branch = branchResult.trim()
+    } catch {
+      return "Not in a git repository or git command failed"
+    }
+
+    if (!branch) {
+      return "No branch checked out (detached HEAD state or not a git repository)"
+    }
+
+    const result = renameSession(sessionID, branch)
+
+    if (result.success) {
+      return `Session synced with branch: ${result.message}`
+    }
+    return `Failed to sync session with branch: ${result.message}`
+  },
+})


### PR DESCRIPTION
## Summary
- Restores `.opencode/tool/session-rename.ts` as an **enabled** tool (not `.disabled`).
- Adds classification guidance to `.agents/aidevops/architecture.md` so workers distinguish native-logic tools from shell wrappers before deleting.

## Why
PR #6833 (t1678.4) deleted all `.opencode/tool/*.disabled` files as "redundant wrappers". Most were — but `session-rename.ts` contains unique native logic (`bun:sqlite` direct DB write to `~/.local/share/opencode/opencode.db`). There is no shell-script equivalent. The deletion undid the fix from PR #6812.

## Testing
- **Testing level:** `runtime-verified`
- **Risk classification:** medium (restoring previously-verified tool + docs)
- **Verification:** the SQLite rename was empirically verified earlier in this session — title update was visible immediately in the OpenCode TUI sidebar
- **Architecture doc:** `markdown-formatter lint` passed clean

Closes #6684