### PR TITLE
t1679.6: Verify no safety regressions after build.txt progressive-load refactor

### DIFF
--- a/.agents/scripts/progressive-load-check.sh
+++ b/.agents/scripts/progressive-load-check.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Progressive Load Safety Check (t1679.6)
+# =============================================================================
+# Verifies that every section extracted from build.txt/AGENTS.md to a
+# reference/ file has:
+#   1. An inline trigger (pointer comment) in the source prompt file
+#   2. The reference file present in .agents/reference/
+#
+# Run after any progressive-load refactor to catch regressions before deploy.
+#
+# Usage: ./progressive-load-check.sh [--quiet]
+# Exit codes: 0 = all checks pass, 1 = regression detected, 2 = check error
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+AGENTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)" || exit 2
+BUILD_TXT="$AGENTS_DIR/prompts/build.txt"
+AGENTS_MD="$AGENTS_DIR/AGENTS.md"
+REFERENCE_DIR="$AGENTS_DIR/reference"
+
+QUIET="${1:-}"
+PASS=0
+FAIL=0
+
+log_pass() {
+	local msg="$1"
+	PASS=$((PASS + 1))
+	[[ "$QUIET" == "--quiet" ]] && return 0
+	printf "  PASS  %s\n" "$msg"
+	return 0
+}
+
+log_fail() {
+	local msg="$1"
+	FAIL=$((FAIL + 1))
+	printf "  FAIL  %s\n" "$msg"
+	return 0
+}
+
+log_info() {
+	local msg="$1"
+	[[ "$QUIET" == "--quiet" ]] && return 0
+	printf "  INFO  %s\n" "$msg"
+	return 0
+}
+
+check_extraction() {
+	local section="$1"
+	local source_file="$2"
+	local ref_file="$3"
+	local pointer_pattern="$4"
+
+	[[ "$QUIET" != "--quiet" ]] && printf "\n[%s]\n" "$section"
+
+	# Check 1: reference file exists
+	local ref_path="$REFERENCE_DIR/$ref_file"
+	if [[ -f "$ref_path" ]]; then
+		log_pass "reference file exists: reference/$ref_file"
+	else
+		log_fail "reference file MISSING: reference/$ref_file"
+		return 0
+	fi
+
+	# Check 2: inline trigger exists in source file
+	if grep -qE "$pointer_pattern" "$source_file" 2>/dev/null; then
+		log_pass "inline trigger found in $(basename "$source_file")"
+	else
+		log_fail "inline trigger MISSING in $(basename "$source_file") (pattern: $pointer_pattern)"
+	fi
+
+	return 0
+}
+
+check_inline_only() {
+	local section="$1"
+	local source_file="$2"
+	local inline_pattern="$3"
+
+	[[ "$QUIET" != "--quiet" ]] && printf "\n[%s]\n" "$section"
+
+	local match_count
+	match_count=$(grep -cE "$inline_pattern" "$source_file" 2>/dev/null || echo "0")
+	if [[ "$match_count" -gt 0 ]]; then
+		log_info "still inline ($match_count matching lines) — no extraction yet"
+	else
+		log_fail "section appears missing from $(basename "$source_file") (pattern: $inline_pattern)"
+	fi
+
+	return 0
+}
+
+main() {
+	if [[ ! -f "$BUILD_TXT" ]]; then
+		printf "ERROR: build.txt not found at %s\n" "$BUILD_TXT" >&2
+		return 2
+	fi
+
+	if [[ ! -f "$AGENTS_MD" ]]; then
+		printf "ERROR: AGENTS.md not found at %s\n" "$AGENTS_MD" >&2
+		return 2
+	fi
+
+	[[ "$QUIET" != "--quiet" ]] && printf "Progressive Load Safety Check\n"
+	[[ "$QUIET" != "--quiet" ]] && printf "Source: %s\n" "$AGENTS_DIR"
+
+	# -------------------------------------------------------------------------
+	# build.txt extractions
+	# -------------------------------------------------------------------------
+	[[ "$QUIET" != "--quiet" ]] && printf "\n--- build.txt extractions ---"
+
+	check_extraction \
+		"Screenshot Size Limits" \
+		"$BUILD_TXT" \
+		"screenshot-limits.md" \
+		"reference/screenshot-limits\.md"
+
+	check_extraction \
+		"Secret Handling (8.1-8.4)" \
+		"$BUILD_TXT" \
+		"secret-handling.md" \
+		"reference/secret-handling\.md"
+
+	check_extraction \
+		"External Repo Issue/PR Submission" \
+		"$BUILD_TXT" \
+		"external-repo-submissions.md" \
+		"reference/external-repo-submissions\.md"
+
+	check_extraction \
+		"Bash 3.2 Compatibility" \
+		"$BUILD_TXT" \
+		"bash-compat.md" \
+		"reference/bash-compat\.md"
+
+	check_extraction \
+		"Conversational Memory Lookup" \
+		"$BUILD_TXT" \
+		"memory-lookup.md" \
+		"reference/memory-lookup\.md"
+
+	# Sections still inline (not yet extracted) — verify they haven't been lost
+	check_inline_only \
+		"Parallel Model Verification (still inline)" \
+		"$BUILD_TXT" \
+		"verify-operation-helper\.sh|check_operation"
+
+	check_inline_only \
+		"Tamper-Evident Audit Logging (still inline)" \
+		"$BUILD_TXT" \
+		"audit-log-helper\.sh"
+
+	check_inline_only \
+		"Review Bot Gate (still inline)" \
+		"$BUILD_TXT" \
+		"review-bot-gate-helper\.sh"
+
+	# -------------------------------------------------------------------------
+	# AGENTS.md extractions
+	# -------------------------------------------------------------------------
+	[[ "$QUIET" != "--quiet" ]] && printf "\n--- AGENTS.md extractions ---"
+
+	check_extraction \
+		"Domain Index" \
+		"$AGENTS_MD" \
+		"domain-index.md" \
+		"reference/domain-index\.md"
+
+	# Self-Improvement and Agent Routing are in open PRs — check if extracted
+	local self_imp_ref="$REFERENCE_DIR/self-improvement.md"
+	local agent_routing_ref="$REFERENCE_DIR/agent-routing.md"
+
+	[[ "$QUIET" != "--quiet" ]] && printf "\n[Self-Improvement]\n"
+	if [[ -f "$self_imp_ref" ]]; then
+		if grep -qE "reference/self-improvement\.md" "$AGENTS_MD" 2>/dev/null; then
+			log_pass "extracted: reference file + inline trigger both present"
+		else
+			log_fail "reference file exists but inline trigger MISSING in AGENTS.md"
+		fi
+	else
+		log_info "not yet extracted (open PR #6837) — still inline in AGENTS.md"
+	fi
+
+	[[ "$QUIET" != "--quiet" ]] && printf "\n[Agent Routing]\n"
+	if [[ -f "$agent_routing_ref" ]]; then
+		if grep -qE "reference/agent-routing\.md" "$AGENTS_MD" 2>/dev/null; then
+			log_pass "extracted: reference file + inline trigger both present"
+		else
+			log_fail "reference file exists but inline trigger MISSING in AGENTS.md"
+		fi
+	else
+		log_info "not yet extracted (open PR #6832) — still inline in AGENTS.md"
+	fi
+
+	# -------------------------------------------------------------------------
+	# Summary
+	# -------------------------------------------------------------------------
+	printf "\n"
+	if [[ "$FAIL" -eq 0 ]]; then
+		printf "RESULT: PASS (%d checks passed, 0 failures)\n" "$PASS"
+		return 0
+	else
+		printf "RESULT: FAIL (%d passed, %d failed)\n" "$PASS" "$FAIL"
+		return 1
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `progressive-load-check.sh` — a verification script that checks every section extracted from `build.txt`/`AGENTS.md` to a `reference/` file has both an inline trigger and the reference file present
- Runs the verification and confirms all 12 checks pass — no safety regressions detected
- Provides a reusable tool for future progressive-load refactors

## Verification Results

All checks pass (12/12):

| Section | Status | Reference File |
|---------|--------|---------------|
| Screenshot Size Limits | PASS | `reference/screenshot-limits.md` ✓ |
| Secret Handling (8.1-8.4) | PASS | `reference/secret-handling.md` ✓ |
| External Repo Submission | PASS | `reference/external-repo-submissions.md` ✓ |
| Bash 3.2 Compatibility | PASS | `reference/bash-compat.md` ✓ |
| Conversational Memory Lookup | PASS | `reference/memory-lookup.md` ✓ |
| Domain Index | PASS | `reference/domain-index.md` ✓ |
| Parallel Model Verification | INFO | Still inline — not extracted yet |
| Tamper-Evident Audit Logging | INFO | Still inline — not extracted yet |
| Review Bot Gate | INFO | Still inline — not extracted yet |
| Self-Improvement | INFO | In open PR #6837 |
| Agent Routing | INFO | In open PR #6832 |

## Runtime Testing

- **Risk classification**: Low (docs/scripts only, no runtime behaviour change)
- **Testing level**: `self-assessed` + script execution verified
- **Verification**: Script runs successfully with exit 0 on current main

## Files Changed

- `.agents/scripts/progressive-load-check.sh` — new verification script (210 lines, ShellCheck clean, bash 3.2 compatible)

Closes #6801