### PR TITLE
t1683: fix Claude Code MCP registration duplicate check pattern

### DIFF
--- a/.agents/scripts/mcp-config-adapter.sh
+++ b/.agents/scripts/mcp-config-adapter.sh
@@ -225,9 +225,10 @@ _register_mcp_claude() {
 	fi
 
 	# Check if already registered
+	# Output format: "name: command - status" (colon after name, not space)
 	local existing
 	existing=$(claude mcp list 2>/dev/null || echo "")
-	if echo "$existing" | grep -q "^${mcp_name}[[:space:]]" 2>/dev/null; then
+	if echo "$existing" | grep -q "^${mcp_name}:" 2>/dev/null; then
 		print_info "$mcp_name already registered in Claude Code — skipping"
 		return 0
 	fi


### PR DESCRIPTION
## Summary

- Fix grep pattern in `_register_mcp_claude()` that caused all MCP servers to show "Failed to register" on every setup run despite being already registered
- `claude mcp list` outputs `name: command - status` format; old pattern `^name[[:space:]]` never matched, so the duplicate check always fell through to re-registration (which then failed)
- New pattern `^name:` correctly matches the colon-separated output format

## Root Cause

`mcp-config-adapter.sh:230` used `grep -q "^${mcp_name}[[:space:]]"` but `claude mcp list` outputs lines like:

```
context7: npx -y @upstash/context7-mcp@latest - ✓ Connected
```

The name is followed by `:`, not a space. The pattern never matched, so every setup run attempted re-registration for all 7 servers, producing spurious "Failed to register" warnings.

## Fix

Changed pattern from `^${mcp_name}[[:space:]]` to `^${mcp_name}:` to match actual CLI output format.

## Testing

- Verified `claude mcp list` output format locally: `name: command - status`
- ShellCheck: zero violations (only pre-existing SC1091 info notices for sourced files)
- Risk classification: **Low** (single-line grep pattern fix, no logic change, no runtime state affected)
- Testing level: `self-assessed`

## Runtime Testing

- **Risk**: Low — grep pattern fix in idempotency check only
- **Testing level**: self-assessed
- **Behaviour verified**: `claude mcp list` output format confirmed matches new pattern

Closes #6848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Model Context Protocol registration detection to properly align with updated CLI output format, preventing duplicate registrations and ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->