### PR TITLE
t1684: fix(plugins): resolve uv tool install failures for cisco-ai-skill-scanner

### DIFF
--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -419,7 +419,17 @@ scan_imported_skills() {
 	# Pre-check: cisco-ai-skill-scanner requires Python >= 3.10
 	# Fallback chain: uv -> pipx -> venv+symlink -> pip3 --user (legacy)
 	# PEP 668 (Ubuntu 24.04+) blocks pip3 --user, so we try isolated methods first
-	if ! command -v skill-scanner &>/dev/null; then
+	#
+	# PATH note: uv installs to ~/.local/bin which may not be on PATH in all shells.
+	# Check both command -v and the known install path to avoid spurious reinstalls.
+	local skill_scanner_bin
+	skill_scanner_bin=$(command -v skill-scanner 2>/dev/null || echo "")
+	# Fallback: uv/pipx install to ~/.local/bin which may not be on PATH
+	if [[ -z "$skill_scanner_bin" && -x "$HOME/.local/bin/skill-scanner" ]]; then
+		skill_scanner_bin="$HOME/.local/bin/skill-scanner"
+	fi
+
+	if [[ -z "$skill_scanner_bin" ]]; then
 		# Verify Python >= 3.10 is available (or install it via uv)
 		if ! check_python_for_skill_scanner; then
 			print_warning "Skipping Cisco Skill Scanner install (Python >= 3.10 required)"
@@ -429,11 +439,23 @@ scan_imported_skills() {
 		local installed=false
 
 		# 1. uv tool install (preferred - fast, isolated, manages its own Python)
+		# Uses --force to handle two known failure modes:
+		#   a) Dangling/corrupted environment: uv detects "Invalid environment" and
+		#      exits 2. Detect via warning in `uv tool list` and uninstall first.
+		#   b) Executable conflict: skill-scanner already exists (e.g. from pipx).
+		#      --force overwrites the existing executable.
 		if [[ "$installed" == "false" ]] && command -v uv &>/dev/null && uv tool --help &>/dev/null; then
 			print_info "Installing Cisco Skill Scanner via uv..."
-			if run_with_spinner "Installing cisco-ai-skill-scanner" uv tool install cisco-ai-skill-scanner; then
+			# Detect and remove dangling uv environment before attempting install
+			if uv tool list 2>&1 | grep -q "Ignoring malformed tool.*cisco-ai-skill-scanner"; then
+				print_info "Removing dangling uv environment for cisco-ai-skill-scanner..."
+				uv tool uninstall cisco-ai-skill-scanner 2>/dev/null || true
+			fi
+			if run_with_spinner "Installing cisco-ai-skill-scanner" uv tool install --force cisco-ai-skill-scanner; then
 				print_success "Cisco Skill Scanner installed via uv"
 				installed=true
+				# uv installs to ~/.local/bin — update skill_scanner_bin for use below
+				skill_scanner_bin=$(command -v skill-scanner 2>/dev/null || echo "$HOME/.local/bin/skill-scanner")
 			fi
 		fi
 
@@ -443,6 +465,7 @@ scan_imported_skills() {
 			if run_with_spinner "Installing cisco-ai-skill-scanner" pipx install cisco-ai-skill-scanner; then
 				print_success "Cisco Skill Scanner installed via pipx"
 				installed=true
+				skill_scanner_bin=$(command -v skill-scanner 2>/dev/null || echo "$HOME/.local/bin/skill-scanner")
 			fi
 		fi
 
@@ -457,6 +480,7 @@ scan_imported_skills() {
 				ln -sf "$venv_dir/bin/skill-scanner" "$bin_dir/skill-scanner"
 				print_success "Cisco Skill Scanner installed via venv ($venv_dir)"
 				installed=true
+				skill_scanner_bin="$bin_dir/skill-scanner"
 			else
 				rm -rf "$venv_dir" 2>/dev/null || true
 			fi
@@ -468,6 +492,7 @@ scan_imported_skills() {
 			if run_with_spinner "Installing cisco-ai-skill-scanner" pip3 install --user cisco-ai-skill-scanner 2>/dev/null; then
 				print_success "Cisco Skill Scanner installed via pip3"
 				installed=true
+				skill_scanner_bin=$(command -v skill-scanner 2>/dev/null || echo "$HOME/.local/bin/skill-scanner")
 			fi
 		fi
 


### PR DESCRIPTION
## Summary

- **Root cause 1 — Dangling/corrupted uv environment**: When a previous `uv tool install` left a broken state (missing Python executable), `uv tool list` emits `warning: Ignoring malformed tool 'cisco-ai-skill-scanner'` and `uv tool install` exits 2 with `Invalid environment`. Fix: detect this warning and auto-run `uv tool uninstall` before retrying.
- **Root cause 2 — Executable conflict**: `uv tool install` exits 2 with `Executable already exists: skill-scanner` when `~/.local/bin/skill-scanner` already exists (e.g. from a prior pipx install). Fix: use `--force` flag so uv overwrites the existing binary.
- **Root cause 3 — PATH gap**: `~/.local/bin` is not on PATH in all shells (uv itself warns about this on install). `command -v skill-scanner` returns false even when the binary is installed, causing spurious reinstall attempts. Fix: check `~/.local/bin/skill-scanner` directly as a fallback.

## Changes

`setup-modules/plugins.sh` — `scan_imported_skills()`:
- Resolve `skill_scanner_bin` via `command -v` with `~/.local/bin` fallback before entering install block
- Detect dangling uv environment via `uv tool list` warning and auto-uninstall before retrying
- Add `--force` to `uv tool install` to handle executable conflicts
- Track `skill_scanner_bin` through all install paths for consistency

## Runtime Testing

- **Risk classification**: Low (shell script logic, no runtime app)
- **Testing level**: self-assessed
- **Verification**: ShellCheck zero violations; manually reproduced all three failure modes and confirmed fixes

Closes #6849