### PR TITLE
fix: update safety-policy-check.sh for compressed build.txt (#6818 followup)

### DIFF
--- a/.agents/scripts/safety-policy-check.sh
+++ b/.agents/scripts/safety-policy-check.sh
@@ -78,15 +78,37 @@ PY
 check_policy_markers() {
 	local build_prompt="${SCRIPT_DIR}/../prompts/build.txt"
 	local sandbox_helper="${SCRIPT_DIR}/sandbox-exec-helper.sh"
+	local secret_handling_ref="${SCRIPT_DIR}/../reference/secret-handling.md"
 
-	if ! pattern_exists "Session transcript exposure model" "$build_prompt"; then
+	# build.txt must reference transcript exposure policy (inline or via pointer)
+	if ! pattern_exists "transcript exposure" "$build_prompt"; then
 		echo "FAIL: transcript exposure policy missing from build prompt" >&2
 		return 1
 	fi
 
-	if ! pattern_exists "Never paste secret values into AI chat" "$build_prompt"; then
-		echo "FAIL: mandatory warning guidance missing from build prompt" >&2
+	# build.txt must contain the transcript-visible rule
+	if ! pattern_exists "transcript-visible" "$build_prompt"; then
+		echo "FAIL: transcript-visible rule missing from build prompt" >&2
 		return 1
+	fi
+
+	# Detailed secret handling rules must exist (either inline in build.txt
+	# or in the extracted reference file)
+	if [[ -f "$secret_handling_ref" ]]; then
+		if ! pattern_exists "Never paste secret values into AI chat" "$secret_handling_ref"; then
+			echo "FAIL: mandatory warning guidance missing from secret-handling reference" >&2
+			return 1
+		fi
+		if ! pattern_exists "Session Transcript Exposure" "$secret_handling_ref"; then
+			echo "FAIL: transcript exposure section missing from secret-handling reference" >&2
+			return 1
+		fi
+	else
+		# Fallback: if reference file doesn't exist, check build.txt directly
+		if ! pattern_exists "Never paste secret values into AI chat" "$build_prompt"; then
+			echo "FAIL: mandatory warning guidance missing from build prompt" >&2
+			return 1
+		fi
 	fi
 
 	if ! pattern_exists "_sandbox_emit_redacted_output" "$sandbox_helper"; then

--- a/.agents/scripts/safety-policy-check.sh
+++ b/.agents/scripts/safety-policy-check.sh
@@ -9,11 +9,11 @@ pattern_exists() {
 	local file_path="$2"
 
 	if command -v rg >/dev/null 2>&1; then
-		rg -q --fixed-strings "$pattern" "$file_path"
+		rg -qi --fixed-strings "$pattern" "$file_path"
 		return $?
 	fi
 
-	grep -qF "$pattern" "$file_path"
+	grep -qiF "$pattern" "$file_path"
 	return $?
 }
 


### PR DESCRIPTION
## Summary

PR #6818 compressed `build.txt` sections 8.1-8.4 to pointer-style references, but `safety-policy-check.sh` still checked for the old inline markers (`Session transcript exposure model`, `Never paste secret values into AI chat`).

This fix updates the checks to verify:
- `build.txt` has `transcript exposure` pointer and `transcript-visible` rule (both present after #6818)
- `reference/secret-handling.md` exists with detailed policy content (added by #6818)

## Changes

- `safety-policy-check.sh`: replace exact-string checks for old verbose markers with checks for the compressed pointer-style references and the extracted reference file

Closes #6795