### PR TITLE
t1685: Fix 3 broken MCP configs and add remote URL support to adapters

### DIFF
--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -510,17 +510,19 @@ if command -v claude &>/dev/null; then
 		return 0
 	}
 
-	# --- Augment Context Engine ---
-	if command -v auggie &>/dev/null; then
+	# --- Augment Context Engine (requires binary AND active auth session) ---
+	if command -v auggie &>/dev/null && [[ -f "$HOME/.augment/session.json" ]]; then
 		local_auggie=$(command -v auggie)
 		register_mcp "auggie-mcp" "{\"type\":\"stdio\",\"command\":\"$local_auggie\",\"args\":[\"--mcp\"]}"
+	elif command -v auggie &>/dev/null; then
+		echo -e "  ${YELLOW}[SKIP]${NC} auggie-mcp: binary found but not logged in (run: auggie login)"
 	fi
 
 	# --- context7 (library docs) ---
 	register_mcp "context7" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@upstash/context7-mcp@latest\"]}"
 
-	# --- Playwright MCP ---
-	register_mcp "playwright" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@anthropic-ai/mcp-server-playwright@latest\"]}"
+	# --- Playwright MCP (correct package: @playwright/mcp) ---
+	register_mcp "playwright" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@playwright/mcp@latest\"]}"
 
 	# --- shadcn UI ---
 	register_mcp "shadcn" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"shadcn@latest\",\"mcp\"]}"

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -1189,13 +1189,15 @@ _generate_mcp_for_runtime() {
 	# Shared MCP definitions — defined once, registered for each runtime
 	# Format: register_mcp_for_runtime <runtime_id> <name> '<json>'
 
-	# Augment Context Engine
+	# Augment Context Engine (requires auggie binary AND active auth session)
 	local auggie_path
 	auggie_path=$(command -v auggie 2>/dev/null || echo "")
-	if [[ -n "$auggie_path" ]]; then
+	if [[ -n "$auggie_path" && -f "$HOME/.augment/session.json" ]]; then
 		register_mcp_for_runtime "$runtime_id" "auggie-mcp" \
 			"{\"command\":\"$auggie_path\",\"args\":[\"--mcp\"]}"
 		mcp_count=$((mcp_count + 1))
+	elif [[ -n "$auggie_path" ]]; then
+		print_warning "Skipping auggie-mcp: binary found but not logged in (run: auggie login)"
 	fi
 
 	# context7 (library docs)
@@ -1203,9 +1205,9 @@ _generate_mcp_for_runtime() {
 		'{"command":"npx","args":["-y","@upstash/context7-mcp@latest"]}'
 	mcp_count=$((mcp_count + 1))
 
-	# Playwright MCP
+	# Playwright MCP (correct package: @playwright/mcp, not @anthropic-ai/mcp-server-playwright)
 	register_mcp_for_runtime "$runtime_id" "playwright" \
-		'{"command":"npx","args":["-y","@anthropic-ai/mcp-server-playwright@latest"]}'
+		'{"command":"npx","args":["-y","@playwright/mcp@latest"]}'
 	mcp_count=$((mcp_count + 1))
 
 	# shadcn UI
@@ -1228,9 +1230,9 @@ _generate_mcp_for_runtime() {
 		mcp_count=$((mcp_count + 1))
 	fi
 
-	# Cloudflare API (remote)
+	# Cloudflare API (remote MCP endpoint — no local install needed)
 	register_mcp_for_runtime "$runtime_id" "cloudflare-api" \
-		'{"command":"npx","args":["-y","@cloudflare/mcp-server-cloudflare"]}'
+		'{"url":"https://mcp.cloudflare.com/mcp"}'
 	mcp_count=$((mcp_count + 1))
 
 	print_success "$display_name: $mcp_count MCP servers processed"

--- a/.agents/scripts/mcp-config-adapter.sh
+++ b/.agents/scripts/mcp-config-adapter.sh
@@ -152,9 +152,16 @@ validate_mcp_command() {
 		return 0
 	fi
 
+	# URL-based (remote) MCPs have no command to validate
+	local url
+	url=$(echo "$mcp_json" | jq -r '.url // empty')
+	if [[ -n "$url" ]]; then
+		return 0
+	fi
+
 	cmd=$(echo "$mcp_json" | jq -r '.command // empty')
 	if [[ -z "$cmd" ]]; then
-		print_warning "No command specified in MCP definition"
+		print_warning "No command or url specified in MCP definition"
 		return 1
 	fi
 
@@ -193,17 +200,28 @@ _register_mcp_opencode() {
 		return 0
 	fi
 
-	# Transform universal format → OpenCode format:
-	# - Merge command + args into a single "command" array
-	# - Rename "env" → "environment"
-	# - Add type: "local", enabled: true (unless overridden)
+	# Detect remote (URL-based) vs local (command-based) MCP
+	local url
+	url=$(echo "$mcp_json" | jq -r '.url // empty')
+
 	local opencode_entry
-	opencode_entry=$(echo "$mcp_json" | jq -c '{
-        type: "local",
-        command: ([.command] + (.args // [])),
-        environment: (.env // {}),
-        enabled: (.enabled // true)
-    }')
+	if [[ -n "$url" ]]; then
+		# Remote MCP: use type "remote" with url field
+		opencode_entry=$(echo "$mcp_json" | jq -c '{
+            type: "remote",
+            url: .url,
+            enabled: (.enabled // true)
+        }')
+	else
+		# Local MCP: merge command + args into a single "command" array
+		# Rename "env" → "environment"
+		opencode_entry=$(echo "$mcp_json" | jq -c '{
+            type: "local",
+            command: ([.command] + (.args // [])),
+            environment: (.env // {}),
+            enabled: (.enabled // true)
+        }')
+	fi
 
 	json_set_nested "$opencode_config" "mcp" "$mcp_name" "$opencode_entry"
 	return 0
@@ -233,16 +251,26 @@ _register_mcp_claude() {
 		return 0
 	fi
 
-	# Transform universal format → Claude format:
-	# - type: "stdio" (default)
-	# - command, args, env stay as-is
+	# Detect remote (URL-based) vs local (command-based) MCP
+	local url
+	url=$(echo "$mcp_json" | jq -r '.url // empty')
+
 	local claude_entry
-	claude_entry=$(echo "$mcp_json" | jq -c '{
-        type: (.transport // "stdio"),
-        command: .command,
-        args: (.args // []),
-        env: (.env // {})
-    }')
+	if [[ -n "$url" ]]; then
+		# Remote MCP: use SSE transport with url
+		claude_entry=$(echo "$mcp_json" | jq -c '{
+            type: "sse",
+            url: .url
+        }')
+	else
+		# Local MCP: stdio transport with command + args
+		claude_entry=$(echo "$mcp_json" | jq -c '{
+            type: (.transport // "stdio"),
+            command: .command,
+            args: (.args // []),
+            env: (.env // {})
+        }')
+	fi
 
 	if claude mcp add-json "$mcp_name" --scope user "$claude_entry" 2>/dev/null; then
 		print_success "Registered $mcp_name in Claude Code"
@@ -354,13 +382,24 @@ _register_mcp_mcpservers() {
 		;;
 	esac
 
-	# Common entry format for all mcpServers-style runtimes
+	# Detect remote (URL-based) vs local (command-based) MCP
+	local url
+	url=$(echo "$mcp_json" | jq -r '.url // empty')
+
 	local entry
-	entry=$(echo "$mcp_json" | jq -c '{
-		command: .command,
-		args: (.args // []),
-		env: (.env // {})
-	}')
+	if [[ -n "$url" ]]; then
+		# Remote MCP: use url field (mcpServers format supports this)
+		entry=$(echo "$mcp_json" | jq -c '{
+			url: .url
+		}')
+	else
+		# Local MCP: command + args + env
+		entry=$(echo "$mcp_json" | jq -c '{
+			command: .command,
+			args: (.args // []),
+			env: (.env // {})
+		}')
+	fi
 
 	json_set_nested "$config_path" "mcpServers" "$mcp_name" "$entry"
 	return 0


### PR DESCRIPTION
## Summary

- **playwright MCP**: Fix package name from nonexistent `@anthropic-ai/mcp-server-playwright` to correct `@playwright/mcp` — the old package returns npm 404, causing "Connection closed" in OpenCode
- **cloudflare-api MCP**: Switch from broken local `npx @cloudflare/mcp-server-cloudflare` to remote URL endpoint `https://mcp.cloudflare.com/mcp` — the local package requires interactive `init`/`run` subcommands and auth setup
- **auggie-mcp**: Gate registration on `~/.augment/session.json` existence, not just binary presence — missing auth causes immediate exit and "Connection closed"
- **mcp-config-adapter**: Add remote URL handling to all 4 adapter functions (OpenCode, Claude Code, mcpServers, validate) — previously all adapters assumed local command-based MCPs only

## Root Cause

The `generate-runtime-config.sh` and `generate-claude-agents.sh` scripts had stale/wrong MCP package names that diverged from upstream reality. The `mcp-config-adapter.sh` had no concept of remote/URL-based MCPs, forcing all entries through the local command path. These broken configs were deployed on every `setup.sh` / `aidevops update` run.

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/generate-runtime-config.sh` | Fix playwright pkg, cloudflare URL, auggie auth gate |
| `.agents/scripts/generate-claude-agents.sh` | Fix playwright pkg, auggie auth gate |
| `.agents/scripts/mcp-config-adapter.sh` | Add remote URL support to `validate_mcp_command`, `_register_mcp_opencode`, `_register_mcp_claude`, `_register_mcp_mcpservers` |

## Testing

- **Level**: self-assessed (config generation scripts — low runtime risk)
- **ShellCheck**: zero new violations on all 3 files
- **Verification**: npm confirms `@playwright/mcp` exists (v0.0.68), `@anthropic-ai/mcp-server-playwright` returns 404

Closes #6870