### PR TITLE
fix: json_set_nested() now updates existing MCP entries instead of skipping

### DIFF
--- a/.agents/scripts/ai-cli-config.sh
+++ b/.agents/scripts/ai-cli-config.sh
@@ -47,13 +47,14 @@ except (FileNotFoundError, json.JSONDecodeError):
 if outer_key not in config or not isinstance(config[outer_key], dict):
     config[outer_key] = {}
 
-if inner_key in config[outer_key]:
-    print(f"{inner_key} already configured in {file_path} - skipping")
+existed = inner_key in config[outer_key]
+config[outer_key][inner_key] = json.loads(value_json)
+with open(file_path, 'w') as f:
+    json.dump(config, f, indent=2)
+    f.write('\n')
+if existed:
+    print(f"Updated {inner_key} in {file_path}")
 else:
-    config[outer_key][inner_key] = json.loads(value_json)
-    with open(file_path, 'w') as f:
-        json.dump(config, f, indent=2)
-        f.write('\n')
     print(f"Added {inner_key} to {file_path}")
 PYEOF
 	return 0


### PR DESCRIPTION
## Summary

- `json_set_nested()` in `.agents/scripts/ai-cli-config.sh` previously skipped writing if the inner key already existed, preventing `setup.sh` / `aidevops update` from fixing stale MCP entries
- Now always overwrites the entry (generator script is the source of truth) and prints `Updated` vs `Added` to distinguish the two cases
- Fixes the root cause of "Connection closed" errors seen in GH#6870 where stale entries couldn't be corrected by re-running setup

## Changes

- `.agents/scripts/ai-cli-config.sh:50-58` — replace skip-if-exists guard with unconditional write + conditional log message

## Runtime Testing

- **Testing level**: self-assessed
- **Risk classification**: low (shell script helper, no auth/payment/state-machine paths)
- **Behaviour verified**: logic reviewed — `existed` flag captured before overwrite, file written unconditionally, message reflects add vs update

## Actionable Findings

- actionable_findings_total=0
- fixed_in_pr=1
- deferred_tasks_created=0
- coverage=100%

Closes #6872