### PR TITLE
t1685: Disable all MCPs by default, activate on-demand via subagents

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -10,6 +10,8 @@ subagents:
   - plans
   # Context tools
   - toon
+  # macOS automation (AppleScript/JXA)
+  - macos-automator
   # Built-in
   - general
   - explore

--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -37,9 +37,12 @@ subagents:
   - github-cli
   - gitlab-cli
   - github-actions
+  # UI components
+  - shadcn
   # Deployment
   - coolify
   - vercel
+  - cloudflare-mcp
   # Monitoring
   - sentry
   - socket

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -1200,9 +1200,9 @@ _generate_mcp_for_runtime() {
 		print_warning "Skipping auggie-mcp: binary found but not logged in (run: auggie login)"
 	fi
 
-	# context7 (library docs)
+	# context7 (library docs — remote endpoint, zero install)
 	register_mcp_for_runtime "$runtime_id" "context7" \
-		'{"command":"npx","args":["-y","@upstash/context7-mcp@latest"]}'
+		'{"url":"https://mcp.context7.com/mcp"}'
 	mcp_count=$((mcp_count + 1))
 
 	# Playwright MCP (correct package: @playwright/mcp, not @anthropic-ai/mcp-server-playwright)

--- a/.agents/scripts/mcp-config-adapter.sh
+++ b/.agents/scripts/mcp-config-adapter.sh
@@ -204,13 +204,15 @@ _register_mcp_opencode() {
 	local url
 	url=$(echo "$mcp_json" | jq -r '.url // empty')
 
+	# Default: disabled. MCPs activate on-demand via subagents.
+	# Pass "enabled":true in mcp_json to override for always-on MCPs.
 	local opencode_entry
 	if [[ -n "$url" ]]; then
 		# Remote MCP: use type "remote" with url field
 		opencode_entry=$(echo "$mcp_json" | jq -c '{
             type: "remote",
             url: .url,
-            enabled: (.enabled // true)
+            enabled: (.enabled // false)
         }')
 	else
 		# Local MCP: merge command + args into a single "command" array
@@ -219,7 +221,7 @@ _register_mcp_opencode() {
             type: "local",
             command: ([.command] + (.args // [])),
             environment: (.env // {}),
-            enabled: (.enabled // true)
+            enabled: (.enabled // false)
         }')
 	fi
 

--- a/.agents/tools/browser/playwright.md
+++ b/.agents/tools/browser/playwright.md
@@ -10,6 +10,9 @@ tools:
   grep: true
   webfetch: true
   task: true
+  playwright_*: true
+mcp:
+  - playwright
 ---
 
 # Playwright MCP

--- a/.agents/tools/context/augment-context-engine.md
+++ b/.agents/tools/context/augment-context-engine.md
@@ -10,7 +10,10 @@ tools:
   grep: true
   webfetch: false
   task: true
+  auggie-mcp_*: true
+  augment-context-engine_*: true
 mcp:
+  - auggie-mcp
   - augment-context-engine
 ---
 

--- a/.agents/tools/context/context7.md
+++ b/.agents/tools/context/context7.md
@@ -10,6 +10,9 @@ tools:
   grep: true
   webfetch: true
   task: true
+  context7_*: true
+mcp:
+  - context7
 ---
 
 # Context7 MCP Setup Guide

--- a/.agents/tools/ui/shadcn.md
+++ b/.agents/tools/ui/shadcn.md
@@ -10,6 +10,9 @@ tools:
   grep: true
   webfetch: true
   task: true
+  shadcn_*: true
+mcp:
+  - shadcn
 ---
 
 # shadcn/ui MCP Server

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -686,17 +686,22 @@ disable_ondemand_mcps() {
 		return 0
 	fi
 
-	# MCPs to disable globally (these have subagent alternatives or are unused)
+	# All MCPs disabled by default — activate on-demand via subagents.
+	# This reduces idle process/connection overhead to zero.
 	# Note: use exact MCP key names from opencode.json
 	local -a ondemand_mcps=(
-		"playwriter"
-		"playwright"
+		"auggie-mcp"
 		"augment-context-engine"
+		"cloudflare-api"
+		"context7"
 		"gh_grep"
 		"google-analytics-mcp"
 		"grep_app"
+		"playwright"
+		"playwriter"
+		"shadcn"
+		"macos-automator"
 		"websearch"
-		# KEEP ENABLED: context7 (library docs), auggie-mcp (semantic search)
 	)
 
 	local disabled=0
@@ -733,15 +738,8 @@ disable_ondemand_mcps() {
 		fi
 	done
 
-	# Re-enable MCPs that were accidentally disabled (v2.100.16-17 bug)
-	local -a keep_enabled=("context7")
-	for mcp in "${keep_enabled[@]}"; do
-		if jq -e ".mcp[\"$mcp\"].enabled == false" "$tmp_config" >/dev/null 2>&1; then
-			jq ".mcp[\"$mcp\"].enabled = true" "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-			print_info "Re-enabled $mcp MCP"
-			changed=1
-		fi
-	done
+	# Note: the v2.100.16-17 context7 re-enable migration was removed in v3.1.312.
+	# All MCPs are now disabled by default — subagents enable them on-demand.
 
 	if [[ $disabled -gt 0 || $changed -gt 0 ]]; then
 		create_backup_with_rotation "$opencode_config" "opencode"


### PR DESCRIPTION
## Summary

- All MCPs now `enabled: false` by default — zero idle process/connection overhead
- Each MCP activates only when its subagent is invoked
- Audited every MCP → subagent → agent chain to ensure no gaps

## Changes

### Adapter default (`mcp-config-adapter.sh`)
- Changed `enabled` default from `true` to `false` for new OpenCode MCP entries

### Migration (`migrations.sh`)
- Expanded disable list to cover ALL MCPs (catches existing users on update)
- Removed context7 re-enable migration (no longer special-cased)

### context7 (`generate-runtime-config.sh`)
- Switched from `npx @upstash/context7-mcp@latest` to remote URL `https://mcp.context7.com/mcp` (zero install, consistent with cloudflare-api)

### Subagent MCP declarations (4 files)
Added `mcp:` and tool wildcard declarations so subagents can activate their MCPs:

| Subagent | Added |
|----------|-------|
| `context7.md` | `mcp: [context7]`, `context7_*: true` |
| `playwright.md` | `mcp: [playwright]`, `playwright_*: true` |
| `shadcn.md` | `mcp: [shadcn]`, `shadcn_*: true` |
| `augment-context-engine.md` | `mcp: [auggie-mcp]`, `auggie-mcp_*: true` (alongside existing key) |

### Agent routing (2 files)
Added missing subagent permissions:

| Agent | Added subagents |
|-------|----------------|
| Build+ | `shadcn`, `cloudflare-mcp` |
| Automate | `macos-automator` |

## Audit Matrix

| MCP | Subagent | Agent(s) with access |
|-----|----------|---------------------|
| `context7` | `tools/context/context7.md` | Build+, Legal, Research, Video |
| `auggie-mcp` | `tools/context/augment-context-engine.md` | Build+, Research |
| `playwright` | `tools/browser/playwright.md` | Build+ |
| `cloudflare-api` | `tools/api/cloudflare-mcp.md` | Build+ (new) |
| `shadcn` | `tools/ui/shadcn.md` | Build+ (new) |
| `macos-automator` | `tools/automation/macos-automator.md` | Automate (new) |

## Testing

- **Level**: self-assessed (config/routing changes — low runtime risk)
- **ShellCheck**: zero new violations
- **Verified**: existing opencode.json already working with all MCPs disabled

Closes #6870