### PR TITLE
t1557: Replace default GitHub template even when markers already exist

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -1761,10 +1761,9 @@ _update_inject_markers_if_needed() {
 	local profile_repo="$1"
 	local readme_path="$2"
 
-	if grep -q '<!-- STATS-START -->' "$readme_path" && grep -q '<!-- STATS-END -->' "$readme_path"; then
-		return 0
-	fi
-
+	# Even if markers exist, check if the content outside them is the default
+	# GitHub template. This handles the case where v3.1.87 injected markers into
+	# the default template but didn't replace the template content itself.
 	if _is_default_github_template "$readme_path"; then
 		echo "Default GitHub template detected — replacing with rich profile README..."
 		local gh_user
@@ -1775,10 +1774,17 @@ _update_inject_markers_if_needed() {
 			echo "Could not resolve username — injecting markers only..."
 			_inject_markers_into_readme "$readme_path"
 		fi
-	else
-		echo "Markers missing from README — injecting them..."
-		_inject_markers_into_readme "$readme_path"
+		git -C "$profile_repo" add README.md
+		git -C "$profile_repo" commit -m "feat: replace default GitHub template with rich profile README" --no-verify 2>/dev/null || true
+		return 0
 	fi
+
+	if grep -q '<!-- STATS-START -->' "$readme_path" && grep -q '<!-- STATS-END -->' "$readme_path"; then
+		return 0
+	fi
+
+	echo "Markers missing from README — injecting them..."
+	_inject_markers_into_readme "$readme_path"
 	git -C "$profile_repo" add README.md
 	git -C "$profile_repo" commit -m "feat: initialize profile README with aidevops stat markers" --no-verify 2>/dev/null || true
 	return 0

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -463,6 +463,110 @@ EOF
 	return 0
 }
 
+test_default_template_with_existing_markers_replaced() {
+	local test_name="default template with existing markers gets replaced"
+
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	local helper_dir="${TEST_DIR}/helper"
+	local helper_path="${helper_dir}/profile-readme-helper.sh"
+
+	mkdir -p "${helper_dir}" "${fixture_home}/.config/aidevops"
+	mkdir -p "${fixture_home}/.aidevops/.agent-workspace/observability"
+	mkdir -p "${fixture_home}/.aidevops/cache"
+	cp "${SOURCE_HELPER}" "${helper_path}"
+	chmod +x "${helper_path}"
+	write_stub_dependencies "${helper_dir}"
+
+	git init --bare --initial-branch=main "${fixture_remote}" >/dev/null
+	git init -b main "${fixture_repo}" >/dev/null
+	git -C "${fixture_repo}" config user.name "Fixture"
+	git -C "${fixture_repo}" config user.email "fixture@example.com"
+	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
+
+	# Simulate Alex's exact case: default GitHub template with markers already
+	# injected at the bottom (by v3.1.87 _inject_markers_into_readme)
+	cat >"${fixture_repo}/README.md" <<'EOF'
+## Hi there 👋
+
+<!--
+**fixture/fixture** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+
+Here are some ideas to get you started:
+
+- 🔭 I'm currently working on ...
+- 🌱 I'm currently learning ...
+-->
+
+<!-- STATS-START -->
+Old stats content
+<!-- STATS-END -->
+
+<!-- CONTRIBUTIONS-START -->
+<!-- CONTRIBUTIONS-END -->
+
+---
+
+<!-- UPDATED-START -->
+<!-- UPDATED-END -->
+EOF
+
+	git -C "${fixture_repo}" add README.md
+	git -C "${fixture_repo}" commit -m "feat: markers injected into default template" >/dev/null
+	git -C "${fixture_repo}" push -u origin main >/dev/null
+
+	cat >"${fixture_home}/.config/aidevops/repos.json" <<EOF
+{
+  "initialized_repos": [
+    {
+      "path": "${fixture_repo}",
+      "slug": "fixture/fixture",
+      "priority": "profile",
+      "pulse": false,
+      "maintainer": "fixture"
+    }
+  ]
+}
+EOF
+
+	# Run update — should detect default template despite markers and replace it
+	if ! HOME="${fixture_home}" bash "${helper_path}" update >/dev/null 2>&1; then
+		print_result "${test_name}" 1 "helper update command failed"
+		return 0
+	fi
+
+	local readme="${fixture_repo}/README.md"
+
+	# Verify the default template is gone
+	if grep -q 'is a.*special.*repository' "$readme" 2>/dev/null; then
+		print_result "${test_name}" 1 "default GitHub template still present after update"
+		return 0
+	fi
+
+	# Verify the "Hi there" heading is gone (replaced with rich profile heading)
+	if grep -q 'Hi there' "$readme" 2>/dev/null; then
+		print_result "${test_name}" 1 "'Hi there' heading still present — template not replaced"
+		return 0
+	fi
+
+	# Verify markers still exist
+	if ! grep -q '<!-- STATS-START -->' "$readme"; then
+		print_result "${test_name}" 1 "STATS-START marker missing after replacement"
+		return 0
+	fi
+
+	# Verify it's a rich README
+	if ! grep -q 'aidevops' "$readme"; then
+		print_result "${test_name}" 1 "aidevops reference not found — not a rich README"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
 main() {
 	if [[ ! -x "${SOURCE_HELPER}" ]]; then
 		echo "Helper script not found or not executable: ${SOURCE_HELPER}" >&2
@@ -476,6 +580,8 @@ main() {
 	test_diverged_history_recovery
 	teardown
 	test_default_template_replaced_with_rich_readme
+	teardown
+	test_default_template_with_existing_markers_replaced
 	teardown
 
 	echo ""


### PR DESCRIPTION
## Summary

- Fix `cmd_update` to replace the default GitHub template with the full rich profile even when stat markers already exist
- This is the final fix for the Alex scenario: v3.1.87 injected markers into the default template, v3.1.90 added template detection but only when markers were missing

Closes #5610

## What was done

**Problem:** Alex's profile shows stats (markers work) but still has the "Hi there" default template at the top — missing name, bio, and language badges. The v3.1.90 template detection only fires when markers are absent, but his README already has markers (injected by v3.1.87).

**Fix:** In `_update_inject_markers_if_needed()`, moved the `_is_default_github_template()` check BEFORE the marker-existence check. If the template is detected, the full rich README is regenerated regardless of whether markers exist.

## Files changed

- `.agents/scripts/profile-readme-helper.sh` — reordered checks in `_update_inject_markers_if_needed()`
- `.agents/scripts/tests/test-profile-readme-boundary.sh` — new test reproducing Alex's exact scenario (default template + existing markers)