### PR TITLE
t1679: improve md scan qualification gate (follow-up to #6879)

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -228,12 +228,14 @@ COMPLEXITY_SCAN_LAST_RUN="${HOME}/.aidevops/logs/complexity-scan-last-run"
 COMPLEXITY_SCAN_INTERVAL="${COMPLEXITY_SCAN_INTERVAL:-86400}"                   # 1 day in seconds (was 7 days)
 COMPLEXITY_FUNC_LINE_THRESHOLD="${COMPLEXITY_FUNC_LINE_THRESHOLD:-100}"         # Functions longer than this are violations
 COMPLEXITY_FILE_VIOLATION_THRESHOLD="${COMPLEXITY_FILE_VIOLATION_THRESHOLD:-1}" # Files with >= this many violations get an issue (was 5)
+COMPLEXITY_MD_MIN_LINES="${COMPLEXITY_MD_MIN_LINES:-50}"                        # Agent docs shorter than this are not actionable for simplification
 WORKER_WATCHDOG_HELPER="${SCRIPT_DIR}/worker-watchdog.sh"
 
 # Validate complexity scan configuration (defined above, validated here)
 COMPLEXITY_SCAN_INTERVAL=$(_validate_int COMPLEXITY_SCAN_INTERVAL "$COMPLEXITY_SCAN_INTERVAL" 86400 3600)
 COMPLEXITY_FUNC_LINE_THRESHOLD=$(_validate_int COMPLEXITY_FUNC_LINE_THRESHOLD "$COMPLEXITY_FUNC_LINE_THRESHOLD" 100 50)
 COMPLEXITY_FILE_VIOLATION_THRESHOLD=$(_validate_int COMPLEXITY_FILE_VIOLATION_THRESHOLD "$COMPLEXITY_FILE_VIOLATION_THRESHOLD" 1 1)
+COMPLEXITY_MD_MIN_LINES=$(_validate_int COMPLEXITY_MD_MIN_LINES "$COMPLEXITY_MD_MIN_LINES" 50 10)
 
 if [[ ! -x "$HEADLESS_RUNTIME_HELPER" ]]; then
 	printf '[pulse-wrapper] ERROR: headless runtime helper is missing or not executable: %s (SCRIPT_DIR=%s)\n' "$HEADLESS_RUNTIME_HELPER" "$SCRIPT_DIR" >&2
@@ -2720,9 +2722,45 @@ _complexity_scan_collect_violations() {
 	return 0
 }
 
-# Collect all agent docs (.md files in .agents/) for simplification analysis.
-# No file size gate — classification (instruction doc vs reference corpus)
+# Determine whether an agent doc qualifies for a simplification issue.
+# Not every .agents/*.md file is actionable — very short files, empty stubs,
+# and YAML-only frontmatter files are not candidates. This gate prevents
+# flooding the issue tracker with non-actionable entries (CodeRabbit GH#6879).
+# Arguments: $1 - full_path, $2 - line_count
+# Returns: 0 if the file should get an issue, 1 if it should be skipped
+_complexity_scan_should_open_md_issue() {
+	local full_path="$1"
+	local line_count="$2"
+
+	# Skip files below the minimum actionable size
+	if [[ "$line_count" -lt "$COMPLEXITY_MD_MIN_LINES" ]]; then
+		return 1
+	fi
+
+	# Skip files that are mostly YAML frontmatter (e.g., stub agent definitions).
+	# If >60% of lines are inside the frontmatter block, there's no prose to simplify.
+	local frontmatter_end=0
+	if head -1 "$full_path" 2>/dev/null | grep -q '^---$'; then
+		frontmatter_end=$(awk 'NR==1 && /^---$/ { in_fm=1; next } in_fm && /^---$/ { print NR; exit }' "$full_path" 2>/dev/null)
+		frontmatter_end=${frontmatter_end:-0}
+	fi
+	if [[ "$frontmatter_end" -gt 0 ]]; then
+		local content_lines=$((line_count - frontmatter_end))
+		# If content after frontmatter is less than 40% of total, skip
+		local threshold=$(((line_count * 40) / 100))
+		if [[ "$content_lines" -lt "$threshold" ]]; then
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
+# Collect agent docs (.md files in .agents/) for simplification analysis.
+# No hard file size gate — classification (instruction doc vs reference corpus)
 # determines the action, not line count (t1679, code-simplifier.md).
+# Files must pass _complexity_scan_should_open_md_issue to be included —
+# this filters out stubs, short files, and frontmatter-only definitions.
 # Protected files (build.txt, AGENTS.md, pulse.md) are excluded — these are
 # core infrastructure that must be simplified manually with a maintainer present.
 # Results are sorted longest-first so biggest wins come early.
@@ -2741,11 +2779,6 @@ _complexity_scan_collect_md_violations() {
 		return 1
 	fi
 
-	# Minimum line count to qualify for simplification analysis.
-	# Files below this threshold are unlikely to benefit from restructuring
-	# and would flood issues for trivially small stubs or index files.
-	local md_min_lines=50
-
 	local scan_results=""
 	local file_count=0
 	local skipped_count=0
@@ -2755,18 +2788,18 @@ _complexity_scan_collect_md_violations() {
 		[[ -f "$full_path" ]] || continue
 		local lc
 		lc=$(wc -l <"$full_path" 2>/dev/null | tr -d ' ')
-		if [[ "$lc" -lt "$md_min_lines" ]]; then
+		if _complexity_scan_should_open_md_issue "$full_path" "$lc"; then
+			scan_results="${scan_results}${file}|${lc}"$'\n'
+			file_count=$((file_count + 1))
+		else
 			skipped_count=$((skipped_count + 1))
-			continue
 		fi
-		scan_results="${scan_results}${file}|${lc}"$'\n'
-		file_count=$((file_count + 1))
 	done <<<"$md_files"
 
 	# Sort longest-first (descending by line count after the pipe)
 	scan_results=$(printf '%s' "$scan_results" | sort -t'|' -k2 -rn)
 
-	echo "[pulse-wrapper] Complexity scan (.md): ${file_count} agent doc files collected (${skipped_count} skipped below ${md_min_lines}-line threshold)" >>"$LOGFILE"
+	echo "[pulse-wrapper] Complexity scan (.md): ${file_count} agent docs qualified, ${skipped_count} skipped (below ${COMPLEXITY_MD_MIN_LINES}-line threshold or stub)" >>"$LOGFILE"
 	printf '%s' "$scan_results"
 	return 0
 }
@@ -2826,7 +2859,7 @@ _complexity_scan_has_existing_issue() {
 	return 1
 }
 
-# Build the GitHub issue body for an oversized agent doc.
+# Build the GitHub issue body for an agent doc flagged for simplification review.
 # Arguments:
 #   $1 - file_path (repo-relative)
 #   $2 - line_count
@@ -2876,7 +2909,7 @@ Tighten and restructure this agent doc. Follow \`tools/build-agent/build-agent.m
 
 ### Confidence: medium
 
-Automated scan flagged this file via the \`simplification-debt\` topic label. The best simplification strategy requires human judgment — some large files are appropriately large. Reference corpora (SKILL.md, domain knowledge bases) need restructuring into chapters, not content reduction.
+Automated scan flagged this file for maintainer review. The best simplification strategy requires human judgment — some files are appropriately structured already. Reference corpora (SKILL.md, domain knowledge bases) need restructuring into chapters, not content reduction.
 
 ---
 **To approve or decline**, comment on this issue:
@@ -2886,7 +2919,7 @@ ISSUE_BODY_EOF
 	return 0
 }
 
-# Create GitHub issues for oversized agent docs.
+# Create GitHub issues for agent docs flagged for simplification review.
 # Uses tier:thinking label (opus) because doc simplification requires deep
 # reasoning to distinguish noise from institutional knowledge.
 # Arguments: $1 - scan_results (pipe-delimited: file_path|line_count), $2 - repos_json, $3 - aidevops_slug

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -431,9 +431,9 @@ Code simplification analysis fits into the quality workflow via two input paths:
 
 ### 1. Automated daily scan (GH#5628)
 
-`pulse-wrapper.sh` runs a daily complexity scan that uses the same awk-based function complexity check as CI. It creates `simplification-debt` issues for files exceeding the per-file violation threshold (default: 1+ function >100 lines). Issues are deduplicated against existing open issues by repo-relative file path.
+`pulse-wrapper.sh` runs a daily complexity scan that uses the same awk-based function complexity check as CI. It creates `simplification-debt` issues for files exceeding the per-file violation threshold (default: 1+ functions >100 lines). Issues are deduplicated against existing open issues by repo-relative file path.
 
-**No file size gate.** Agent docs of any size are eligible for simplification analysis. The previous 500-line threshold was removed (t1679) — smaller files can be equally verbose. The classification (instruction doc vs reference corpus) determines the action, not the line count.
+**No file size gate.** Agent docs of any size are eligible for simplification analysis. The previous 500-line threshold was removed (t1679) — smaller files can be equally verbose. A qualification gate (`_complexity_scan_should_open_md_issue`) filters out stubs and very short files (default: <50 lines) so only actionable candidates reach issue creation. The classification (instruction doc vs reference corpus) determines the action, not the line count.
 
 ```text
 pulse-wrapper.sh (daily) --> awk complexity scan
@@ -445,7 +445,7 @@ pulse-wrapper.sh (daily) --> awk complexity scan
                               Create issues (simplification-debt + needs-maintainer-review)
 ```
 
-Configuration: `COMPLEXITY_SCAN_INTERVAL` (default 1 day), `COMPLEXITY_FILE_VIOLATION_THRESHOLD` (default 1).
+Configuration: `COMPLEXITY_SCAN_INTERVAL` (default 1 day), `COMPLEXITY_FILE_VIOLATION_THRESHOLD` (default 1), `COMPLEXITY_MD_MIN_LINES` (default 50).
 
 ### 2. Manual analysis
 


### PR DESCRIPTION
## Summary

Follow-up to #6879 addressing remaining CodeRabbit review feedback with a more robust implementation:

- Extract `_complexity_scan_should_open_md_issue()` gate function that checks both minimum line count AND frontmatter ratio (files that are mostly YAML frontmatter are not simplification candidates)
- Promote `md_min_lines` from hardcoded local variable to configurable `COMPLEXITY_MD_MIN_LINES` env var (default 50) with `_validate_int` validation
- Update issue template: "flagged for maintainer review" (was "flagged via simplification-debt topic label")
- Update `code-simplifier.md` to document the gate function and new config variable
- Remove remaining "oversized" language from function comments

## Why

The merged fix (#6879) used a simple inline line-count check with a hardcoded local variable. This follow-up:
1. Makes the threshold configurable via environment variable (consistent with other `COMPLEXITY_*` vars)
2. Adds frontmatter ratio detection — stub agent definitions with large YAML frontmatter but minimal content won't get issues
3. Documents the gate function in code-simplifier.md so the scan pipeline diagram stays accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Complexity scanning now runs daily instead of weekly.
  * Introduced a configurable minimum Markdown length to avoid flagging short/frontmatter-heavy files.
  * Simplified violation trigger from 5+ to 1+ to surface simplification opportunities earlier.
  * Issue wording updated: documents are now "flagged for maintainer review" rather than labeled as oversized.

* **Documentation**
  * Updated workflow docs to reflect the daily scan cadence and new gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->