### PR TITLE
t1688: fix quality sweep off-peak window and add failure miner to setup.sh

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -765,7 +765,16 @@ build_routine_prompt() {
 parse_launchd_options() {
 	ROUTINE_NAME="$DEFAULT_ROUTINE_NAME"
 	ROUTINE_SCHEDULE="$DEFAULT_ROUTINE_SCHEDULE"
-	ROUTINE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+	# Resolve to canonical (main) worktree, not a linked worktree.
+	# Worktree paths like ~/Git/repo.branch-name get cleaned up, so the plist
+	# must point at the main worktree (~/Git/repo) to survive worktree removal.
+	local raw_dir
+	raw_dir=$(cd "${SCRIPT_DIR}/../.." && pwd)
+	ROUTINE_DIR=$(git -C "$raw_dir" worktree list --porcelain 2>/dev/null |
+		awk '/^worktree / {print substr($0, 10); exit}') || ROUTINE_DIR=""
+	if [[ -z "$ROUTINE_DIR" || ! -d "$ROUTINE_DIR" ]]; then
+		ROUTINE_DIR="$raw_dir"
+	fi
 	ROUTINE_TITLE="$DEFAULT_ROUTINE_TITLE"
 	LAUNCHD_SINCE_HOURS="$DEFAULT_SINCE_HOURS"
 	LAUNCHD_SYSTEMIC_THRESHOLD="$DEFAULT_SYSTEMIC_THRESHOLD"

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -1355,15 +1355,19 @@ update_health_issues() {
 # actionable GitHub issues for findings that warrant fixes.
 #######################################
 run_daily_quality_sweep() {
-	# Time-of-day gate — only run during off-peak hours (18:00-23:59 local).
+	# Time-of-day gate — only run during off-peak hours (18:00-05:59 local).
 	# Anthropic doubles token allowance during off-peak (6 PM-12 AM UK time),
 	# and model demand is lower. Quality sweep findings trigger LLM worker
 	# dispatch via the pulse, so landing findings in this window means the
-	# resulting workers also run at 2x rates. Override: QUALITY_SWEEP_OFFPEAK=0
+	# resulting workers also run at 2x rates. The window includes overnight
+	# hours (00:00-05:59) which are the quietest period for both API load
+	# and user activity. Override: QUALITY_SWEEP_OFFPEAK=0
 	local current_hour
 	current_hour=$(date +%H)
-	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]] && ((10#$current_hour < 18)); then
-		echo "[stats] Quality sweep deferred: hour ${current_hour} is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
+	# Off-peak = 18:00-05:59 (hours 18,19,20,21,22,23,0,1,2,3,4,5)
+	# Peak = 06:00-17:59 (hours 6-17). Defer during peak only.
+	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]] && ((10#$current_hour >= 6 && 10#$current_hour < 18)); then
+		echo "[stats] Quality sweep deferred: hour ${current_hour} is outside off-peak window (18:00-05:59)" >>"$LOGFILE"
 		return 0
 	fi
 

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -437,6 +437,112 @@ PLIST
 	return 0
 }
 
+# Setup failure miner — mines GitHub CI failure notifications for systemic patterns
+# and auto-files root-cause issues. Runs as a pure bash script (no LLM needed).
+# Installed when pulse is enabled and the helper script exists.
+# macOS: launchd plist (hourly at :15) | Linux: cron (hourly at :15)
+setup_failure_miner() {
+	local _pulse_lower="$1"
+	local _pulse_effective="${PULSE_ENABLED:-$_pulse_lower}"
+	local miner_script="$HOME/.aidevops/agents/scripts/gh-failure-miner-helper.sh"
+	local miner_label="sh.aidevops.routine-gh-failure-miner"
+	if [[ ! -x "$miner_script" ]] || [[ "$_pulse_effective" != "true" ]]; then
+		# Remove scheduler if pulse is disabled or script missing
+		if [[ "$(uname -s)" == "Darwin" ]]; then
+			local miner_plist="$HOME/Library/LaunchAgents/${miner_label}.plist"
+			if _launchd_has_agent "$miner_label"; then
+				launchctl unload "$miner_plist" 2>/dev/null || true
+				rm -f "$miner_plist"
+				print_info "Failure miner disabled (pulse is off or script missing)"
+			fi
+		else
+			if crontab -l 2>/dev/null | grep -qF "aidevops: gh-failure-miner"; then
+				crontab -l 2>/dev/null | grep -v 'aidevops: gh-failure-miner' | crontab - || true
+				print_info "Failure miner disabled (cron entry removed)"
+			fi
+		fi
+		return 0
+	fi
+
+	mkdir -p "$HOME/.aidevops/logs"
+
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		local miner_plist="$HOME/Library/LaunchAgents/${miner_label}.plist"
+
+		local _xml_miner_script _xml_miner_home _xml_miner_path _xml_miner_log
+		_xml_miner_script=$(_xml_escape "$miner_script")
+		_xml_miner_home=$(_xml_escape "$HOME")
+		_xml_miner_path=$(_xml_escape "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")
+		_xml_miner_log=$(_xml_escape "${HOME}/.aidevops/logs/routine-gh-failure-miner.log")
+
+		local miner_plist_content
+		miner_plist_content=$(
+			cat <<MINER_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${miner_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>${_xml_miner_script}</string>
+		<string>create-issues</string>
+		<string>--since-hours</string>
+		<string>24</string>
+		<string>--pulse-repos</string>
+		<string>--systemic-threshold</string>
+		<string>2</string>
+		<string>--max-issues</string>
+		<string>3</string>
+		<string>--label</string>
+		<string>auto-dispatch</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>${_xml_miner_home}</string>
+		<key>PATH</key>
+		<string>${_xml_miner_path}</string>
+	</dict>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Minute</key>
+			<integer>15</integer>
+		</dict>
+	</array>
+	<key>StandardOutPath</key>
+	<string>${_xml_miner_log}</string>
+	<key>StandardErrorPath</key>
+	<string>${_xml_miner_log}</string>
+	<key>RunAtLoad</key>
+	<false/>
+</dict>
+</plist>
+MINER_PLIST
+		)
+
+		if _launchd_install_if_changed "$miner_label" "$miner_plist" "$miner_plist_content"; then
+			print_info "Failure miner enabled (launchd, hourly at :15)"
+		else
+			print_warning "Failed to load failure miner LaunchAgent"
+		fi
+	else
+		local _cron_miner_script
+		_cron_miner_script=$(_cron_escape "$miner_script")
+		(
+			crontab -l 2>/dev/null | grep -v 'aidevops: gh-failure-miner' || true
+			echo "15 * * * * /bin/bash ${_cron_miner_script} create-issues --since-hours 24 --pulse-repos --systemic-threshold 2 --max-issues 3 --label auto-dispatch >> \"\$HOME/.aidevops/logs/routine-gh-failure-miner.log\" 2>&1 # aidevops: gh-failure-miner"
+		) | crontab - || true
+		if crontab -l 2>/dev/null | grep -qF "aidevops: gh-failure-miner"; then
+			print_info "Failure miner enabled (cron, hourly at :15)"
+		fi
+	fi
+	return 0
+}
+
 # Setup process guard — kills runaway AI processes (ShellCheck bloat, stuck workers)
 # before they exhaust memory and cause kernel panics. Always installed when the
 # script exists; no consent needed (safety net, not autonomous action).

--- a/setup.sh
+++ b/setup.sh
@@ -877,6 +877,7 @@ _setup_post_setup_steps() {
 	setup_auto_update
 	setup_supervisor_pulse "$os"
 	setup_stats_wrapper "${PULSE_ENABLED:-}"
+	setup_failure_miner "${PULSE_ENABLED:-}"
 	setup_repo_sync
 	setup_process_guard
 	setup_memory_pressure_monitor


### PR DESCRIPTION
## Summary

- **Quality sweep off-peak window widened** from `18:00-23:59` to `18:00-05:59` — the overnight hours (midnight to 6 AM) are the quietest period for both API load and user activity, and were being wasted
- **Failure miner `ROUTINE_DIR` fixed** to resolve to canonical (main) worktree via `git worktree list --porcelain`, preventing breakage when linked worktrees are cleaned up
- **Failure miner added to `setup.sh`** via new `setup_failure_miner()` in `schedulers.sh` — runs the bash script directly (no LLM wrapper), hourly at `:15`, with proper cleanup when pulse is disabled. All users now get this on update.

## Root Causes

1. `stats-functions.sh:run_daily_quality_sweep()` gate condition `((10#$current_hour < 18))` deferred at hours 0-17, but should only defer at 6-17 (peak hours)
2. `gh-failure-miner-helper.sh:parse_launchd_options()` set `ROUTINE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)` which resolves to the worktree path when run from a worktree — the generated plist then hardcodes that ephemeral path
3. `setup.sh` never called `setup_failure_miner` — the routine was only installed if a user manually ran `gh-failure-miner-helper.sh install-launchd-routine`

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Medium (scheduler config, no data path changes)
- **Verification**: ShellCheck passes on all 4 modified files. Logic change is a simple hour-range comparison. Plist generation follows existing patterns from `setup_process_guard` and `setup_stats_wrapper`.

Closes #6885