### PR TITLE
fix: address remaining CodeRabbit CR on PR #6884 — conditional race window wording in full-loop.md

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -92,7 +92,7 @@ fi
 
 **Label lifecycle:** `available` → `queued` → `in-progress` → `in-review` → `done`. Always remove prior labels. Stale recovery: 3+ hours with no PR → pulse relabels `status:available`.
 
-**Idempotent with claim-on-create (t1687):** If `/new-task` already assigned the user and set `status:in-progress` (option 2 — "claim for this session"), this step is a no-op. The `gh issue edit` calls are idempotent — adding an already-present assignee or label succeeds silently. This closes the race window between interactive task creation and `/full-loop` startup where the pulse could dispatch a worker for the same issue.
+**Idempotent with claim-on-create (t1687):** If `/new-task` already assigned the user and set `status:in-progress` (option 2 — "claim for this session"), this step is a no-op. The `gh issue edit` calls are idempotent — adding an already-present assignee or label succeeds silently. The race window is closed when claim-on-create succeeds — if the `/new-task` claim failed silently (e.g. no network), this step re-applies it before the pulse can dispatch.
 
 ### Step 0.7: Label Dispatch Model — `dispatched:{model}`
 

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -92,6 +92,8 @@ fi
 
 **Label lifecycle:** `available` → `queued` → `in-progress` → `in-review` → `done`. Always remove prior labels. Stale recovery: 3+ hours with no PR → pulse relabels `status:available`.
 
+**Idempotent with claim-on-create (t1687):** If `/new-task` already assigned the user and set `status:in-progress` (option 2 — "claim for this session"), this step is a no-op. The `gh issue edit` calls are idempotent — adding an already-present assignee or label succeeds silently. This closes the race window between interactive task creation and `/full-loop` startup where the pulse could dispatch a worker for the same issue.
+
 ### Step 0.7: Label Dispatch Model — `dispatched:{model}`
 
 Tag issue with model. Detect from `$ANTHROPIC_MODEL`/`$CLAUDE_MODEL` or system prompt. Map: `*opus*`→`dispatched:opus`, `*sonnet*`→`dispatched:sonnet`, `*haiku*`→`dispatched:haiku`. Remove stale labels first.

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -73,10 +73,36 @@ ID: {task_id}
 Ref: ref:{task_ref}
 
 Options:
-1. Add to TODO.md with brief (recommended)
-2. Customize estimate, tags, and dependencies
-3. Just show the ID (don't add to TODO.md)
+1. Add to TODO.md with brief (recommended — queued for pulse dispatch)
+2. Add to TODO.md with brief AND claim for this session (prevents pulse pickup)
+3. Customize estimate, tags, and dependencies
+4. Just show the ID (don't add to TODO.md)
 ```
+
+**Option 2 — Claim on create (t1687):** When the user intends to work on the task
+interactively in the current session (or shortly after), claiming the issue at
+creation time prevents the pulse from dispatching a worker for the same issue
+during the gap between `/new-task` and `/full-loop`. This assigns the current
+user and applies `status:in-progress` on the GitHub issue immediately:
+
+```bash
+if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
+  ISSUE_NUM="${task_ref#GH#}"
+  WORKER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
+  gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" \
+    --add-assignee "$WORKER_USER" \
+    --add-label "status:in-progress" 2>/dev/null || true
+fi
+```
+
+The pulse skips issues with an assignee (dedup check #2) and issues with
+`status:in-progress` (stale recovery only after 3+ hours), so this closes the
+race window completely. When `/full-loop` runs later, Step 0.6 is idempotent —
+it re-applies the same assignee and label with no side effects.
+
+**When NOT to claim:** If the user is queuing work for later or for pulse
+workers to pick up, use option 1 (no claim). This is the default and preserves
+the existing behaviour.
 
 ### Step 5: Create Task Brief (MANDATORY)
 
@@ -260,9 +286,10 @@ AI: Allocated: t325 (ref:GH#1260)
     - How: Add ExportButton to DataTable toolbar, use papaparse for CSV generation
     - Acceptance: Button visible in toolbar, exports current filter, handles 10k+ rows
 
-    1. Confirm and add to TODO.md
-    2. Edit brief first
-    3. Cancel
+    1. Add to TODO.md (queued for pulse dispatch)
+    2. Add to TODO.md and claim for this session
+    3. Edit brief first
+    4. Cancel
 User: 1
 AI: Added:
     - todo/tasks/t325-brief.md (brief)
@@ -287,7 +314,13 @@ AI: Brief: todo/tasks/t326-brief.md
       for iOS Safari cookie persistence. File: packages/auth/src/config.ts
     - Acceptance: iOS Safari session persists 24h, no regression on other browsers
 
-    1. Confirm  2. Edit  3. Cancel
+    1. Add to TODO.md (queued)  2. Claim for this session  3. Edit  4. Cancel
+User: 2
+AI: Added and claimed:
+    - todo/tasks/t326-brief.md (brief)
+    - TODO.md: - [ ] t326 Fix login timeout on mobile #bugfix ~2h ref:GH#1261 logged:2026-02-12
+    - Issue #1261: assigned to you + status:in-progress
+    Pulse workers will skip this issue until you release it or 3h stale recovery kicks in.
 ```
 
 ## CRITICAL: Supervisor Subtask Creation

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -83,9 +83,16 @@ Options:
 interactively in the current session (or shortly after), claiming the issue at
 creation time prevents the pulse from dispatching a worker for the same issue
 during the gap between `/new-task` and `/full-loop`. This assigns the current
-user and applies `status:in-progress` on the GitHub issue immediately:
+user and applies `status:in-progress` on the GitHub issue immediately.
+
+Resolve `REPO_SLUG` the same way as Step 6.5 (via `gh repo view`). The claim
+runs after the issue is created (Step 2), so `task_ref` is always available.
+If `gh issue edit` fails (silenced by `|| true`), the assignee and label are
+not applied and the issue remains dispatchable — `/full-loop` Step 0.6 will
+re-apply the same claim as a fallback when the worker starts:
 
 ```bash
+REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
 if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
   ISSUE_NUM="${task_ref#GH#}"
   WORKER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
@@ -95,10 +102,10 @@ if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
 fi
 ```
 
-The pulse skips issues with an assignee (dedup check #2) and issues with
-`status:in-progress` (stale recovery only after 3+ hours), so this closes the
-race window completely. When `/full-loop` runs later, Step 0.6 is idempotent —
-it re-applies the same assignee and label with no side effects.
+When successful, the pulse skips the issue via two independent checks: assignee
+presence (dedup check #2) and `status:in-progress` label (stale recovery only
+after 3+ hours). When `/full-loop` runs later, Step 0.6 is idempotent — it
+re-applies the same assignee and label with no side effects.
 
 **When NOT to claim:** If the user is queuing work for later or for pulse
 workers to pick up, use option 1 (no claim). This is the default and preserves

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -249,7 +249,7 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **`status:blocked` but blockers resolved** → remove `status:blocked`, add `status:available`, comment what unblocked it. Dispatchable this cycle. Note: issues blocked by terminal blockers (GH#5141 — e.g., missing token scopes) are auto-detected during dispatch; the user must resolve the blocker and remove the label manually.
 - **Duplicate issues for same task ID** → keep the one referenced by `ref:GH#` in TODO.md, close others with a comment.
 - **Too large for one worker** → classify with `task-decompose-helper.sh classify`. If composite, decompose into subtask issues, label parent `status:blocked`. Child tasks enter the normal dispatch queue.
-- **`status:queued` or `status:in-progress`** → check `updatedAt`. If updated within 3 hours, skip. If 3+ hours with no PR and no worker, relabel `status:available`, unassign, comment the recovery.
+- **`status:queued` or `status:in-progress`** → check `updatedAt`. If updated within 3 hours, skip. If 3+ hours with no PR and no worker, relabel `status:available`, unassign, comment the recovery. Note: issues claimed at creation via `/new-task` option 2 (t1687) will have `status:in-progress` + assignee set immediately, so the pulse correctly skips them during the interactive work window.
 - **`needs-maintainer-review`** → SKIP. Awaiting maintainer review. Do NOT dispatch.
 - **`status:available` or no status (without `needs-maintainer-review`)** → dispatch a worker.
 

--- a/todo/tasks/t1687-brief.md
+++ b/todo/tasks/t1687-brief.md
@@ -1,0 +1,52 @@
+# t1687: Add interactive claim-on-create option to /new-task to prevent pulse dispatch races
+
+## Origin
+
+- **Created:** 2026-03-27
+- **Session:** claude-code:t1687-interactive-claim
+- **Created by:** human + ai-interactive
+- **Conversation context:** User identified a race window where interactively created issues could be picked up by pulse workers before the user starts `/full-loop`. The nonce mechanism (t1686) solves runner-to-runner races but not the interactive-to-pulse gap.
+
+## What
+
+Add a "claim for this session" option to `/new-task` that assigns the current user and sets `status:in-progress` on the GitHub issue at creation time, preventing pulse workers from dispatching for the same issue during the gap between task creation and `/full-loop` startup.
+
+## Why
+
+When a user creates a task via `/new-task` and intends to work on it interactively, there is a window (minutes to hours) where the issue has no assignee and no status label. The pulse sees it as "unassigned, open, no PR" and may dispatch a worker, duplicating work. The existing nonce claim (t1686) solves sub-second races between automated runners but not this wider interactive gap.
+
+## How (Approach)
+
+1. Add option 2 ("claim for this session") to `/new-task` Step 4 presentation — runs `gh issue edit` to set assignee + `status:in-progress` immediately
+2. Document idempotency in `/full-loop` Step 0.6 — the same assignee/label calls are no-ops when already set
+3. Add a note in `pulse.md` issue triage explaining that claimed-on-create issues are correctly skipped
+4. No changes to `dispatch-claim-helper.sh` or `dispatch-dedup-helper.sh` — the existing `is_assigned` check already handles this
+
+Key files:
+
+- `.agents/scripts/commands/new-task.md:64-79` — Step 4 options
+- `.agents/scripts/commands/full-loop.md:73-93` — Step 0.6 label update
+- `.agents/scripts/commands/pulse.md:252` — status:in-progress skip logic
+
+## Acceptance Criteria
+
+- [ ] `/new-task` Step 4 offers "claim for this session" option with `gh issue edit` assignee + label logic
+- [ ] `/full-loop` Step 0.6 documents idempotency with claim-on-create
+- [ ] `pulse.md` documents that claimed-on-create issues are correctly skipped
+- [ ] Examples updated to show both "queue for dispatch" and "claim for session" flows
+- [ ] Default option (1) preserves existing behaviour — no claim, pulse can pick up
+- [ ] Lint clean (markdownlint)
+
+## Context & Decisions
+
+- **Rejected: nonce mechanism for interactive sessions** — the nonce (t1686) is designed for sub-second races between automated runners. Interactive gaps are minutes to hours; assignee + label is the right mechanism.
+- **Rejected: always claim on create** — sometimes users create tasks to queue for pulse workers. The default must remain "no claim" to preserve this workflow.
+- **No script changes needed** — this is purely agent instruction changes. The `gh issue edit` calls are standard GitHub API operations already used in `/full-loop`.
+
+## Relevant Files
+
+- `.agents/scripts/commands/new-task.md` — primary change: Step 4 options + claim logic
+- `.agents/scripts/commands/full-loop.md` — idempotency documentation
+- `.agents/scripts/commands/pulse.md` — skip logic documentation
+- `.agents/scripts/dispatch-dedup-helper.sh:378-425` — `is_assigned()` already handles this
+- `.agents/scripts/dispatch-claim-helper.sh` — no changes needed


### PR DESCRIPTION
## Summary

- Changes "This closes the race window" to conditional wording "The race window is closed when claim-on-create succeeds" in `full-loop.md` line 95
- Acknowledges that a silent `gh issue edit` failure (via `|| true`) leaves the issue dispatchable until `/full-loop` Step 0.6 re-applies the claim

## CodeRabbit CHANGES_REQUESTED

This addresses the remaining CodeRabbit review finding from PR #6884:

> **full-loop.md lines 95-96**: Prefer conditional wording over absolute guarantee. To avoid overclaiming, phrase this as "race window is closed when claim-on-create succeeds" rather than unconditional closure.

The `new-task.md` finding (REPO_SLUG origin + silent failure documentation) was already addressed in commit `d509b4d28` which landed on main after the PR merge.

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/commands/full-loop.md` | Change absolute "closes the race window" to conditional "race window is closed when claim-on-create succeeds" |

Closes #6883 (follow-up CR fixes)