### PR TITLE
fix: use conditional wording for race window closure in full-loop.md (CodeRabbit CR #6884)

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -92,7 +92,7 @@ fi
 
 **Label lifecycle:** `available` → `queued` → `in-progress` → `in-review` → `done`. Always remove prior labels. Stale recovery: 3+ hours with no PR → pulse relabels `status:available`.
 
-**Idempotent with claim-on-create (t1687):** If `/new-task` already assigned the user and set `status:in-progress` (option 2 — "claim for this session"), this step is a no-op. The `gh issue edit` calls are idempotent — adding an already-present assignee or label succeeds silently. This closes the race window between interactive task creation and `/full-loop` startup where the pulse could dispatch a worker for the same issue.
+**Idempotent with claim-on-create (t1687):** If `/new-task` already assigned the user and set `status:in-progress` (option 2 — "claim for this session"), this step is a no-op. The `gh issue edit` calls are idempotent — adding an already-present assignee or label succeeds silently. The race window is closed when claim-on-create succeeds — if the `/new-task` claim failed silently (e.g. no network), this step re-applies it before the pulse can dispatch.
 
 ### Step 0.7: Label Dispatch Model — `dispatched:{model}`
 


### PR DESCRIPTION
## Summary

- Changes "This closes the race window" to conditional wording "The race window is closed when claim-on-create succeeds" in `full-loop.md`
- Addresses the remaining CodeRabbit CHANGES_REQUESTED from PR #6884

## Problem

CodeRabbit flagged that the original wording overclaimed — the race window is only closed when `gh issue edit` succeeds. The `|| true` means silent failures leave the issue dispatchable until `/full-loop` Step 0.6 re-applies the claim.

## Changes

- `.agents/scripts/commands/full-loop.md`: Conditional wording for race window closure

Closes #6883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `/full-loop` command documentation with clarified behavior for Step 0.6, including details on race window closure and recovery scenarios when claim operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->