### PR TITLE
GH#6891: Add assignee guard to deterministic dedup and version to dispatch comments

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -199,6 +199,7 @@ comments to understand what happened — if the information isn't there, it's in
 
 ```text
 Dispatching worker.
+- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v3.x.x
 - **Model**: sonnet (anthropic/claude-sonnet-4-6)
 - **Branch**: bugfix/qd-4472-speech-to-speech
 - **Scope**: Address critical review feedback on speech-to-speech.md
@@ -206,10 +207,15 @@ Dispatching worker.
 - **Direction**: Focus on the specific review comments from PR #4397
 ```
 
+The version is read from `~/.aidevops/agents/VERSION` (or `$AIDEVOPS_VERSION` if set).
+The `[aidevops.sh](https://github.com/marcusquinn/aidevops)` link provides quick navigation
+to the framework repo for anyone reading the comment.
+
 ### Kill/failure comment template
 
 ```text
 Worker killed after 2h15m with 0 commits (struggle_ratio: 45).
+- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v3.x.x
 - **Model**: sonnet
 - **Branch**: feature/t748-migration
 - **Reason**: thrashing — repeated identical errors, no progress
@@ -221,6 +227,7 @@ Worker killed after 2h15m with 0 commits (struggle_ratio: 45).
 
 ```text
 Completed via PR #4501.
+- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v3.x.x
 - **Model**: sonnet (first attempt)
 - **Attempts**: 1
 - **Duration**: 23 minutes

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -60,19 +60,17 @@ Check external contributor gate before ANY merge (see Pre-merge checks below).
 For each unassigned, non-blocked issue with no open PR, no active worker, and **no `needs-maintainer-review` label**:
 
 ```bash
-# Dedup guard (MANDATORY — all four checks required)
+# Dedup guard (MANDATORY — all checks via deterministic guard + claim lock)
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
 
-# 1. Local process dedup (same machine only)
-if has_worker_for_repo_issue NUMBER SLUG; then continue; fi
-if ~/.aidevops/agents/scripts/dispatch-dedup-helper.sh is-duplicate "Issue #NUMBER: TITLE"; then continue; fi
+# 1. Deterministic dedup (ledger, process, title, merged-PR, assignee — GH#6891)
+# The assignee check is now inside check_dispatch_dedup (Layer 5), so passing
+# $RUNNER_USER as the 5th arg is required. This prevents the bug where an LLM
+# pulse skipped the is_assigned step and dispatched for another runner's issue.
+if check_dispatch_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER_USER"; then continue; fi
 
-# 2. Cross-machine assignee dedup (checks GitHub — visible to ALL runners)
-# If another runner already assigned themselves, skip this issue.
-if ~/.aidevops/agents/scripts/dispatch-dedup-helper.sh is-assigned NUMBER SLUG "$RUNNER_USER"; then continue; fi
-
-# 3. Cross-machine claim lock (t1686 — prevents race in assign-then-dispatch)
+# 2. Cross-machine claim lock (t1686 — prevents race in assign-then-dispatch)
 # Posts an HTML comment claim, waits consensus window, checks who was first.
 # Exit 0 = won (proceed), exit 1 = lost (skip), exit 2 = error (proceed, fail-open).
 CLAIM_EXIT=0
@@ -541,8 +539,11 @@ Every comment the supervisor posts on an issue or PR must be **sufficient for a 
 
 When dispatching a worker, comment on the issue with:
 
+Read the aidevops version: `AIDEVOPS_VERSION=$(cat ~/.aidevops/agents/VERSION 2>/dev/null || echo "unknown")`.
+
 ```bash
 gh issue comment <number> --repo <slug> --body "Dispatching worker.
+- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v${AIDEVOPS_VERSION}
 - **Model**: <tier and full model ID, e.g., sonnet (anthropic/claude-sonnet-4-6)>
 - **Branch**: <branch name, e.g., fix/t748-ai-migration>
 - **Scope**: <1-line description of what the worker should do>
@@ -556,6 +557,7 @@ When killing a worker or closing a failed PR, comment with:
 
 ```bash
 gh issue comment <number> --repo <slug> --body "Worker killed after <duration> with <N> commits (struggle_ratio: <ratio>).
+- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v${AIDEVOPS_VERSION}
 - **Model**: <tier used>
 - **Branch**: <branch name>
 - **Reason**: <why it was killed — thrashing, timeout, CI loop, etc.>
@@ -569,6 +571,7 @@ When merging a PR or closing an issue as done:
 
 ```bash
 gh issue comment <number> --repo <slug> --body "Completed via PR #<N>.
+- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v${AIDEVOPS_VERSION}
 - **Model**: <tier that succeeded>
 - **Attempts**: <total attempts including failures>
 - **Duration**: <wall-clock from first dispatch to merge>"
@@ -719,16 +722,16 @@ Closing as duplicate of #<kept_number>. Identified during pulse triage — these
 # Source once per pulse run (provides has_worker_for_repo_issue, has_merged_pr_for_issue, and check_dispatch_dedup)
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 
-# Single dedup guard: checks active worker, title variants, and merged-PR evidence
-if check_dispatch_dedup <number> <slug> "Issue #<number>: <title>" "<task-id>: <title>"; then
+# Single dedup guard: checks active worker, title variants, merged-PR evidence, and assignee
+if check_dispatch_dedup <number> <slug> "Issue #<number>: <title>" "<task-id>: <title>" "$RUNNER_USER"; then
   echo "Dedup guard blocked dispatch for #<number> in <slug> — skipping"
   # Leave a trace in GitHub so the catch is visible to all runners and to the dedup health check
-  gh issue comment <number> --repo <slug> --body "Dispatch skipped — deterministic dedup guard detected overlap (active worker or merged PR evidence). See check_dispatch_dedup in pulse-wrapper.sh." 2>/dev/null || true
+  gh issue comment <number> --repo <slug> --body "Dispatch skipped — deterministic dedup guard detected overlap (active worker, merged PR evidence, or assigned to another runner). See check_dispatch_dedup in pulse-wrapper.sh." 2>/dev/null || true
   continue
 fi
 ```
 
-`check_dispatch_dedup` runs all three checks in sequence: (1) exact repo+issue process overlap, (2) title variants via dispatch-dedup-helper (e.g., `issue-3502` vs `Issue #3502: description`), and (3) merged-PR evidence via close keywords and task-ID fallback. Skipping this guard caused both the 26-worker thrashing incident (GH#4400) and the awardsapp duplicate-PR pattern (GH#4527).
+`check_dispatch_dedup` runs all five checks in sequence: (1) in-flight dispatch ledger, (2) exact repo+issue process overlap, (3) title variants via dispatch-dedup-helper (e.g., `issue-3502` vs `Issue #3502: description`), (4) merged-PR evidence via close keywords and task-ID fallback, and (5) cross-machine assignee guard (GH#6891) — prevents dispatching for issues already assigned to another runner. Skipping this guard caused both the 26-worker thrashing incident (GH#4400) and the awardsapp duplicate-PR pattern (GH#4527). The assignee guard was added after GH#6891 where a runner dispatched a worker for an issue assigned to a different user.
 
 The deterministic guard is the safety net, not the primary layer. Over time, as the intelligence scan catches more duplicates earlier, the deterministic guard should fire less often. See "Dedup health monitoring" below for how to track this.
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3286,6 +3286,7 @@ has_worker_for_repo_issue() {
 #   $2 - repo slug (owner/repo)
 #   $3 - dispatch title (e.g., "Issue #42: Fix auth")
 #   $4 - issue title (optional; used for merged-PR task-id fallback)
+#   $5 - self login (optional; runner's GitHub login for assignee check)
 # Exit codes:
 #   0 - duplicate detected (do NOT dispatch)
 #   1 - no duplicate (safe to dispatch)
@@ -3295,6 +3296,7 @@ check_dispatch_dedup() {
 	local repo_slug="$2"
 	local title="$3"
 	local issue_title="${4:-}"
+	local self_login="${5:-}"
 
 	# Layer 1 (GH#6696): in-flight dispatch ledger — catches workers between
 	# dispatch and PR creation (the 10-15 min gap that caused duplicate dispatches)
@@ -3330,6 +3332,19 @@ check_dispatch_dedup() {
 			else
 				echo "[pulse-wrapper] Dedup: merged PR evidence already exists for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 			fi
+			return 0
+		fi
+	fi
+
+	# Layer 5 (GH#6891): cross-machine assignee guard — prevents runners from
+	# dispatching workers for issues already assigned to another runner. This was
+	# previously an LLM-only instruction in pulse.md; moving it here makes it
+	# deterministic. The incident: johnwaldo's pulse dispatched a worker for an
+	# issue assigned to marcusquinn because the LLM skipped the is_assigned step.
+	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+		local assigned_output=""
+		if assigned_output=$("$dedup_helper" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE"); then
+			echo "[pulse-wrapper] Dedup: #${issue_number} in ${repo_slug} already assigned to another runner — ${assigned_output}" >>"$LOGFILE"
 			return 0
 		fi
 	fi


### PR DESCRIPTION
## Summary

- **Bug fix**: Add `is_assigned` as Layer 5 in `check_dispatch_dedup()` (`pulse-wrapper.sh`), making the cross-machine assignee check deterministic instead of relying on LLM pulse agents to follow instructions
- **Bug fix**: Consolidate initial dispatch dedup in `pulse.md` to use `check_dispatch_dedup` with `$RUNNER_USER` as 5th arg, eliminating separate manual steps the LLM can skip
- **Enhancement**: Add `[aidevops.sh](https://github.com/marcusquinn/aidevops)` version line to all dispatch comment templates (dispatch, kill/failure, completion)

## Root Cause (GH#6891)

`johnwaldo`'s pulse dispatched a worker for issue #6891 which was assigned to `marcusquinn`. The `is_assigned` check was only an LLM instruction in `pulse.md` (line 73), not enforced by the deterministic `check_dispatch_dedup()` guard. The LLM skipped it. The nonce/claim comment also wasn't posted (same root cause).

Moving the assignee check into the deterministic shell function prevents this class of bug entirely — it runs regardless of whether the LLM follows the instruction.

## Changes

| File | What | Why |
|------|------|-----|
| `.agents/scripts/pulse-wrapper.sh` | Add Layer 5 (assignee guard) to `check_dispatch_dedup()` | Deterministic enforcement of cross-machine assignee check |
| `.agents/scripts/commands/pulse.md` | Pass `$RUNNER_USER` as 5th arg, consolidate dedup steps, update descriptions | Align docs with new function signature |
| `.agents/automate.md` | Add `aidevops.sh` version line to all comment templates | Version traceability in issue comments |

## Runtime Testing

- **Level**: self-assessed
- **Risk**: low (docs + shell function guard addition, no behaviour change for existing callers — 5th arg is optional)
- ShellCheck: clean
- markdownlint: clean

Closes #6891