### PR TITLE
fix(gh-failure-miner): unbound variable extra_labels and labels API slug guard

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -607,6 +607,11 @@ build_issue_body() {
 ensure_repo_labels() {
 	local clusters_json="$1"
 	printf '%s\n' "$clusters_json" | jq -r '.[].repo' | sort -u | while IFS= read -r repo_entry; do
+		# Skip empty or malformed slugs (must be owner/repo format)
+		if [[ -z "$repo_entry" ]] || [[ "$repo_entry" != *"/"* ]]; then
+			echo "ensure_repo_labels: skipping invalid repo slug: '${repo_entry}'" >&2
+			continue
+		fi
 		gh label create "source:ci-failure-miner" --repo "$repo_entry" \
 			--description "Auto-created by gh-failure-miner-helper.sh" --color "C2E0C6" --force || true
 	done
@@ -705,7 +710,7 @@ create_systemic_issues() {
 			continue
 		fi
 
-		create_or_preview_issue "$cluster_json" "$pattern_id" "$systemic_threshold" "$dry_run" "${extra_labels[@]}"
+		create_or_preview_issue "$cluster_json" "$pattern_id" "$systemic_threshold" "$dry_run" "${extra_labels[@]+"${extra_labels[@]}"}"
 
 		created=$((created + 1))
 		idx=$((idx + 1))


### PR DESCRIPTION
## Summary

- Fix `extra_labels[@]: unbound variable` crash in `create-issues` path under `set -euo pipefail` when no `--label` flags are passed
- Fix HTTP 404 on labels API by guarding against empty/malformed repo slugs in `ensure_repo_labels()`

## Root Cause

**Bug 1 — Unbound variable:** `create_systemic_issues()` declares `local extra_labels=("$@")` and passes it as `"${extra_labels[@]}"` at line 708. With `set -u` (nounset), bash 3.2 treats an empty array expansion as unbound. The fix uses the bash 3.2-safe conditional expansion `"${extra_labels[@]+"${extra_labels[@]}"}"` which expands to nothing when the array is empty.

**Bug 2 — Labels API 404:** `ensure_repo_labels()` iterates over `.repo` values from the clusters JSON and calls `gh label create --repo "$repo_entry"`. If `repo_entry` is empty or malformed (missing `owner/repo` format), `gh` falls back to the current repo or constructs a bad API URL. The fix adds an explicit format guard that skips and logs any invalid slug.

## Testing

- ShellCheck: zero violations
- Bash 3.2 (`/bin/bash`) empty array expansion: verified `${arr[@]+"${arr[@]}"}` returns empty string without error
- Non-empty array: verified values pass through correctly

## Runtime Testing

- Risk classification: **Low** — shell script bugfix, no runtime environment required
- Testing level: `self-assessed` (ShellCheck + manual bash expansion verification)
- No dev environment needed; the fix is a pure shell correctness change

## Files Changed

- `.agents/scripts/gh-failure-miner-helper.sh` — two targeted fixes, +6/-1 lines

Closes #6894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of repository configuration entries in CI failure mining helper script to skip invalid formats and continue processing.
  * Enhanced handling of optional label parameters to ensure proper argument construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->