### PR TITLE
7986: simplification: tighten FLOWCHARTS.md (431→217 lines)

### DIFF
--- a/.agents/tools/diagrams/mermaid-diagrams-skill/references/FLOWCHARTS.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/references/FLOWCHARTS.md
@@ -2,8 +2,6 @@
 
 Flowcharts visualize processes, algorithms, and decision flows using nodes and edges.
 
----
-
 ## Basic Syntax
 
 ```mermaid
@@ -13,8 +11,6 @@ flowchart LR
     B -->|No| D[End]
 ```
 
----
-
 ## Direction
 
 | Declaration | Direction |
@@ -23,13 +19,6 @@ flowchart LR
 | `BT` | Bottom to Top |
 | `LR` | Left to Right |
 | `RL` | Right to Left |
-
-```mermaid
-flowchart TB
-    A --> B --> C
-```
-
----
 
 ## Node Shapes
 
@@ -53,7 +42,25 @@ M(((Double Circle))) Double circle
 
 ### Extended Shapes (v11.3+)
 
-New syntax using `@{ shape: name }`:
+Syntax: `node@{ shape: name, label: "Text" }`
+
+| Shape | Description | Shape | Description |
+|-------|-------------|-------|-------------|
+| `rect` | Rectangle | `rounded` | Rounded rectangle |
+| `stadium` | Pill | `subroutine` | Subroutine box |
+| `cyl` | Cylinder (DB) | `circle` | Circle |
+| `dbl-circ` | Double circle | `diamond` | Diamond |
+| `hex` | Hexagon | `lean-r` / `lean-l` | Parallelogram |
+| `trap-b` / `trap-t` | Trapezoid | `doc` | Document |
+| `bolt` | Lightning bolt | `tri` | Triangle |
+| `fork` | Fork | `hourglass` | Hourglass |
+| `flag` | Flag | `comment` | Comment |
+| `f-circ` | Filled circle | `lin-cyl` | Lined cylinder |
+| `brace` / `brace-r` / `braces` | Curly brace(s) | `win-pane` | Window pane |
+| `notch-rect` | Notched rect | `bow-rect` | Bow tie rect |
+| `div-rect` | Divided rect | `odd` | Odd shape |
+| `lin-doc` | Lined document | `tag-doc` / `tag-rect` | Tagged shapes |
+| `half-rounded-rect` | Half rounded | `curv-trap` | Curved trapezoid |
 
 ```mermaid
 flowchart LR
@@ -63,51 +70,7 @@ flowchart LR
     dec@{ shape: diamond, label: "Decision" }
 ```
 
-**Available extended shapes:**
-
-| Shape | Description |
-|-------|-------------|
-| `rect` | Rectangle |
-| `rounded` | Rounded rectangle |
-| `stadium` | Stadium/pill |
-| `subroutine` | Subroutine box |
-| `cyl` | Cylinder (database) |
-| `circle` | Circle |
-| `dbl-circ` | Double circle |
-| `diamond` | Diamond/rhombus |
-| `hex` | Hexagon |
-| `lean-r` | Lean right (parallelogram) |
-| `lean-l` | Lean left |
-| `trap-b` | Trapezoid bottom |
-| `trap-t` | Trapezoid top |
-| `doc` | Document |
-| `notch-rect` | Notched rectangle |
-| `brace` | Curly brace left |
-| `brace-r` | Curly brace right |
-| `braces` | Double braces |
-| `comment` | Comment |
-| `bolt` | Lightning bolt |
-| `lin-cyl` | Lined cylinder |
-| `bow-rect` | Bow tie rectangle |
-| `div-rect` | Divided rectangle |
-| `odd` | Odd shape |
-| `win-pane` | Window pane |
-| `f-circ` | Filled circle |
-| `lin-doc` | Lined document |
-| `tri` | Triangle |
-| `fork` | Fork |
-| `hourglass` | Hourglass |
-| `flag` | Flag |
-| `tag-doc` | Tagged document |
-| `tag-rect` | Tagged rectangle |
-| `half-rounded-rect` | Half rounded rectangle |
-| `curv-trap` | Curved trapezoid |
-
----
-
 ## Edge Types
-
-### Basic Edges
 
 ```
 A --> B       Solid arrow
@@ -116,11 +79,6 @@ A -.-> B      Dotted arrow
 A -.- B       Dotted line
 A ==> B       Thick arrow
 A === B       Thick line
-```
-
-### Arrow Ends
-
-```
 A --o B       Circle end
 A --x B       Cross end
 A o--o B      Circle both ends
@@ -128,7 +86,9 @@ A x--x B      Cross both ends
 A <--> B      Arrows both ends
 ```
 
-### Edge Labels
+**Edge length** — extra dashes extend: `A --> B` (normal), `A ---> B` (longer), `A ----> B` (even longer)
+
+**Labels:**
 
 ```mermaid
 flowchart LR
@@ -137,93 +97,26 @@ flowchart LR
     E -->|"multi word"| F
 ```
 
-### Edge Length
-
-Control edge length with extra dashes:
-
-```
-A --> B        Normal
-A ---> B       Longer
-A ----> B      Even longer
-```
-
-### Edge IDs and Animation (v11+)
-
-```mermaid
-flowchart LR
-    A e1@--> B e2@--> C
-    e1@{ animate: true }
-    e2@{ animate: true, animation-duration: "0.5s" }
-```
-
----
+**Animation (v11+):** `A e1@--> B` then `e1@{ animate: true, animation-duration: "0.5s" }`
 
 ## Subgraphs
-
-Group related nodes:
 
 ```mermaid
 flowchart TB
     subgraph Frontend
         UI[React App]
-        State[Redux Store]
     end
-
     subgraph Backend
         API[REST API]
         WS[WebSocket]
     end
-
-    subgraph Data
-        DB[(PostgreSQL)]
-        Cache[(Redis)]
-    end
-
     UI --> API
     UI --> WS
-    API --> DB
-    API --> Cache
 ```
 
-### Nested Subgraphs
-
-```mermaid
-flowchart TB
-    subgraph Cloud
-        subgraph VPC
-            subgraph Public
-                LB[Load Balancer]
-            end
-            subgraph Private
-                App[App Server]
-                DB[(Database)]
-            end
-        end
-    end
-
-    LB --> App --> DB
-```
-
-### Subgraph Direction
-
-```mermaid
-flowchart LR
-    subgraph TOP
-        direction TB
-        A --> B
-    end
-    subgraph BOTTOM
-        direction TB
-        C --> D
-    end
-    TOP --> BOTTOM
-```
-
----
+**Nested subgraphs** — subgraphs can contain subgraphs. **Per-subgraph direction** — add `direction TB` inside a subgraph to override flow direction locally.
 
 ## Multi-Target Edges
-
-Connect multiple nodes:
 
 ```mermaid
 flowchart LR
@@ -231,11 +124,7 @@ flowchart LR
     E & F --> G
 ```
 
----
-
 ## Markdown in Labels
-
-Use backticks for markdown:
 
 ```mermaid
 flowchart LR
@@ -246,84 +135,45 @@ flowchart LR
     A --> B
 ```
 
----
-
 ## Icons
-
-FontAwesome icons (when enabled):
 
 ```mermaid
 flowchart LR
     A[fa:fa-user User] --> B[fa:fa-database Database]
-    B --> C[fa:fa-cog Settings]
 ```
 
----
-
 ## Click Events
-
-### Links
 
 ```mermaid
 flowchart LR
     A[GitHub] --> B[Docs]
     click A href "https://github.com" _blank
-    click B href "https://docs.example.com"
+    click B call callback()
 ```
-
-### Callbacks
-
-```mermaid
-flowchart LR
-    A[Click Me] --> B
-    click A call callback()
-```
-
----
 
 ## Styling
-
-### Inline Styles
 
 ```mermaid
 flowchart LR
     A[Start]:::green --> B[Process]:::blue --> C[End]:::green
-
     classDef green fill:#10b981,stroke:#059669,color:white
     classDef blue fill:#3b82f6,stroke:#2563eb,color:white
 ```
 
-### Individual Node Style
+**Individual node and link styles:**
 
 ```mermaid
 flowchart LR
     A --> B --> C
     style A fill:#f9f,stroke:#333,stroke-width:2px
-    style B fill:#bbf,stroke:#333
-```
-
-### Link Styles
-
-```mermaid
-flowchart LR
-    A --> B --> C
     linkStyle 0 stroke:red,stroke-width:2px
-    linkStyle 1 stroke:blue,stroke-width:2px,stroke-dasharray:5
-```
-
-### Default Styles
-
-```mermaid
-flowchart LR
-    A --> B --> C
+    linkStyle 1 stroke:blue,stroke-dasharray:5
     linkStyle default stroke:gray,stroke-width:1px
 ```
 
----
-
 ## Layout Engine
 
-Use ELK for complex diagrams (v9.4+):
+ELK for complex diagrams (v9.4+):
 
 ```mermaid
 %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
@@ -332,74 +182,7 @@ flowchart TB
     B & C & D --> E
 ```
 
----
-
 ## Examples
-
-### Microservices Architecture
-
-```mermaid
-flowchart LR
-    subgraph Client
-        Web[Web App]
-        Mobile[Mobile App]
-    end
-
-    subgraph Gateway
-        Kong[API Gateway]
-        Auth[Auth Service]
-    end
-
-    subgraph Services
-        Users[Users Service]
-        Orders[Orders Service]
-        Products[Products Service]
-        Payments[Payments Service]
-    end
-
-    subgraph Data
-        UsersDB[(Users DB)]
-        OrdersDB[(Orders DB)]
-        ProductsDB[(Products DB)]
-        MQ[Message Queue]
-    end
-
-    Web & Mobile --> Kong
-    Kong --> Auth
-    Auth --> Users
-    Kong --> Orders & Products & Payments
-    Users --> UsersDB
-    Orders --> OrdersDB
-    Products --> ProductsDB
-    Orders --> MQ
-    Payments --> MQ
-```
-
-### CI/CD Pipeline
-
-```mermaid
-flowchart LR
-    subgraph Source
-        Git[Git Push]
-    end
-
-    subgraph Build
-        Lint[Lint]
-        Test[Test]
-        Build[Build]
-    end
-
-    subgraph Deploy
-        Staging[Staging]
-        Prod[Production]
-    end
-
-    Git --> Lint --> Test --> Build
-    Build --> Staging
-    Staging -->|approved| Prod
-
-    style Prod fill:#10b981
-```
 
 ### Decision Tree
 
@@ -411,21 +194,24 @@ flowchart TD
     Perm -->|Yes| Process[Process Request]
     Perm -->|No| Denied[403 Forbidden]
     Process --> Success[200 OK]
-
     style Success fill:#10b981
     style Denied fill:#ef4444
     style Login fill:#f59e0b
 ```
 
-### Data Flow
+### CI/CD Pipeline
 
 ```mermaid
 flowchart LR
-    Input[(Raw Data)] --> Transform[ETL Process]
-    Transform --> Validate{Valid?}
-    Validate -->|Yes| Store[(Data Warehouse)]
-    Validate -->|No| Error[Error Queue]
-    Store --> Analytics[Analytics Engine]
-    Analytics --> Dashboard[Dashboard]
-    Analytics --> Reports[Reports]
+    subgraph Build
+        Lint[Lint] --> Test[Test] --> Compile[Build]
+    end
+    subgraph Deploy
+        Staging[Staging]
+        Prod[Production]
+    end
+    Git[Git Push] --> Lint
+    Compile --> Staging
+    Staging -->|approved| Prod
+    style Prod fill:#10b981
 ```


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/diagrams/mermaid-diagrams-skill/references/FLOWCHARTS.md` from 431 to 217 lines (50% reduction)
- Converted verbose prose and single-column extended shapes table to compact 2-column table layout
- Preserved all syntax reference content: node shapes, edge types, labels, animation, subgraphs, styling, layout engine
- Retained 2 illustrative examples (Decision Tree, CI/CD Pipeline) — most instructionally distinct
- Removed redundant `---` section separators, collapsed animation syntax to inline, merged nested subgraph prose

## Changes

| File | Before | After | Change |
|------|--------|-------|--------|
| `FLOWCHARTS.md` | 431 lines | 217 lines | −214 lines (−50%) |

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** low (docs-only change, no code)
- **Behaviour verified:** all mermaid syntax blocks preserved and valid; no broken references

Closes #7986