### PR TITLE
t8478: tighten docstrange.md — 227 to 162 lines, prose to tables/bullets

### DIFF
--- a/.agents/tools/document/docstrange.md
+++ b/.agents/tools/document/docstrange.md
@@ -19,164 +19,100 @@ mcp:
 
 ## Quick Reference
 
-- **Purpose**: Convert documents to Markdown/JSON/CSV/HTML with structured data extraction
-- **Install**: `pip install docstrange`
-- **Formats**: PDF, DOCX, PPTX, XLSX, images (PNG/JPG/TIFF/BMP), HTML, URLs
-- **Modes**: Cloud (free, 10k docs/month) or local GPU (100% private, CUDA required)
-- **MCP**: Built-in server for Claude Desktop (clone repo, not in PyPI)
-- **License**: MIT
-- **GitHub**: https://github.com/NanoNets/docstrange (1.3k stars)
-- **Docs**: https://docstrange.nanonets.com/
+| | |
+|---|---|
+| **Install** | `pip install docstrange` |
+| **Formats** | PDF, DOCX, PPTX, XLSX, PNG/JPG/TIFF/BMP, HTML, URLs |
+| **Modes** | Cloud (free, 10k/month) or local GPU (CUDA, 100% private) |
+| **MCP** | Built-in server — clone repo (not in PyPI) |
+| **GitHub** | https://github.com/NanoNets/docstrange |
+| **Docs** | https://docstrange.nanonets.com/ |
 
-**On-demand loading**: This MCP is disabled globally and enabled per-agent when document extraction is needed.
+**Purpose**: Single `pip install` replaces Docling+ExtractThinker+Presidio for most extraction tasks. 7B model for OCR and layout detection; produces LLM-optimized Markdown and structured JSON.
+
+**On-demand loading**: MCP disabled globally; enabled per-agent when document extraction is needed.
 
 <!-- AI-CONTEXT-END -->
 
-## What is DocStrange?
-
-NanoNets DocStrange is a Python library for converting documents into clean, structured output. It uses an upgraded 7B model for OCR and layout detection, producing LLM-optimized Markdown and structured JSON. Key differentiator: single `pip install` replaces the multi-tool Docling+ExtractThinker+Presidio stack for most extraction tasks.
-
 ## Processing Modes
 
-| Mode | Privacy | Speed | Setup | Limit |
-|------|---------|-------|-------|-------|
-| **Cloud (anonymous)** | Low | Fast | None | Rate-limited |
-| **Cloud (authenticated)** | Low | Fast | `docstrange login` | 10k docs/month |
-| **Cloud (API key)** | Low | Fast | API key | 10k docs/month |
-| **Local GPU** | Full | Medium | CUDA required | Unlimited |
+| Mode | Privacy | Setup | Limit |
+|------|---------|-------|-------|
+| Cloud (anonymous) | Low | None | Rate-limited |
+| Cloud (authenticated) | Low | `docstrange login` | 10k docs/month |
+| Cloud (API key) | Low | API key | 10k docs/month |
+| Local GPU | Full | CUDA required | Unlimited |
 
 ## Installation
 
 ```bash
-# Core library
-pip install docstrange
-
-# With web UI (local drag-and-drop interface)
-pip install "docstrange[web]"
-
-# Local GPU mode requires CUDA
-# Models download automatically on first run
+pip install docstrange                 # core
+pip install "docstrange[web]"          # + local web UI
+# Local GPU: CUDA required; models download on first run (~4GB)
 ```
 
-## Usage
-
-### Convert to Markdown
+## Python API
 
 ```python
 from docstrange import DocumentExtractor
-
 extractor = DocumentExtractor()
+
+# Markdown
 result = extractor.extract("document.pdf")
 print(result.extract_markdown())
-```
 
-### Extract Structured JSON
-
-```python
-result = extractor.extract("invoice.pdf")
+# Structured JSON
 json_data = result.extract_data()
-print(json_data)
-```
 
-### Extract Specific Fields
-
-```python
-result = extractor.extract("invoice.pdf")
+# Specific fields
 fields = result.extract_data(specified_fields=[
     "invoice_number", "total_amount", "vendor_name", "due_date"
 ])
-```
 
-### Extract with JSON Schema
-
-```python
-schema = {
-    "contract_number": "string",
-    "parties": ["string"],
-    "total_value": "number",
-    "start_date": "string",
-    "terms": ["string"]
-}
+# JSON schema
+schema = {"contract_number": "string", "parties": ["string"], "total_value": "number"}
 structured = result.extract_data(json_schema=schema)
-```
 
-### Local GPU Processing
-
-```python
+# Local GPU (private)
 extractor = DocumentExtractor(gpu=True)
-result = extractor.extract("sensitive-document.pdf")
 ```
 
-### CLI
+## CLI
 
 ```bash
-# Basic conversion
-docstrange document.pdf
-
-# JSON output with specific fields
+docstrange document.pdf                                                    # Markdown
 docstrange invoice.pdf --output json --extract-fields invoice_number total_amount
-
-# JSON schema extraction
 docstrange contract.pdf --output json --json-schema schema.json
-
-# Local GPU mode
-docstrange document.pdf --gpu-mode
-
-# Multiple files
-docstrange *.pdf --output markdown
-
-# Save to file
+docstrange document.pdf --gpu-mode                                         # local GPU
+docstrange *.pdf --output markdown                                         # batch
 docstrange document.pdf --output-file result.md
-```
-
-### Authentication
-
-```bash
-# Google login (10k docs/month)
-docstrange login
-
-# Or use API key
+docstrange login                                                           # auth (10k/month)
 docstrange document.pdf --api-key YOUR_API_KEY
-
-# Logout
 docstrange --logout
-```
-
-## Output Formats
-
-| Method | Output | Use Case |
-|--------|--------|----------|
-| `extract_markdown()` | Clean Markdown | LLM/RAG pipelines |
-| `extract_data()` | Structured JSON | Data extraction |
-| `extract_data(specified_fields=[...])` | Targeted JSON | Specific field extraction |
-| `extract_data(json_schema={...})` | Schema-conforming JSON | Structured pipelines |
-| `extract_html()` | Formatted HTML | Web display |
-| `extract_csv()` | CSV | Table/spreadsheet data |
-| `extract_text()` | Plain text | Simple text extraction |
-
-## Local Web UI
-
-```bash
-# Start local web interface
-docstrange web
-
-# Custom port
+docstrange web                                                             # UI at :8000
 docstrange web --port 8080
 ```
 
-Provides drag-and-drop document conversion at `http://localhost:8000`. Supports cloud and local GPU modes.
+## Output Methods
+
+| Method | Output | Use Case |
+|--------|--------|----------|
+| `extract_markdown()` | Markdown | LLM/RAG pipelines |
+| `extract_data()` | JSON | General extraction |
+| `extract_data(specified_fields=[...])` | Targeted JSON | Known fields |
+| `extract_data(json_schema={...})` | Schema JSON | Structured pipelines |
+| `extract_html()` | HTML | Web display |
+| `extract_csv()` | CSV | Tables/spreadsheets |
+| `extract_text()` | Plain text | Simple extraction |
 
 ## MCP Server (Claude Desktop)
 
-The MCP server is in the repo but not in the PyPI package. Clone to use:
-
 ```bash
 git clone https://github.com/nanonets/docstrange.git
-cd docstrange
-pip install -e ".[dev]"
+cd docstrange && pip install -e ".[dev]"
 ```
 
-Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -189,39 +125,38 @@ Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_deskt
 }
 ```
 
-MCP features: smart token counting, hierarchical document navigation, intelligent chunking, document search.
+MCP features: smart token counting, hierarchical navigation, intelligent chunking, document search.
 
-## When to Use (vs Alternatives)
+## When to Use
 
-| Feature | DocStrange | Docling+ExtractThinker | Unstract |
-|---------|-----------|----------------------|----------|
-| **Setup** | `pip install docstrange` | 3 separate installs | Docker/server |
-| **Schema extraction** | JSON schema or field list | Pydantic models | Pre-built extractors |
+| | DocStrange | Docling+ExtractThinker | Unstract |
+|---|---|---|---|
+| **Setup** | `pip install` | 3 installs | Docker/server |
+| **Schema extraction** | JSON schema / field list | Pydantic models | Pre-built extractors |
 | **PII redaction** | Not built-in | Via Presidio | Manual |
-| **Local processing** | GPU mode (CUDA) | Ollama (CPU/GPU) | Self-hosted Docker |
-| **MCP server** | Built-in (repo only) | None | Docker-based |
-| **Cloud API** | Free 10k/month | N/A (bring your LLM) | Cloud or self-hosted |
-| **OCR quality** | 7B model, strong on scans | EasyOCR/Tesseract | Depends on LLM |
-| **Best for** | Quick extraction, scans | Custom pipelines, PII | Enterprise workflows |
+| **Local processing** | GPU (CUDA only) | Ollama (CPU/GPU) | Self-hosted Docker |
+| **MCP server** | Repo only | None | Docker-based |
+| **Cloud API** | Free 10k/month | N/A | Cloud or self-hosted |
+| **OCR quality** | 7B model, strong on scans | EasyOCR/Tesseract | LLM-dependent |
+| **Best for** | Fast setup, scans, free API | PII, custom pipelines | Enterprise ETL |
 
-**Choose DocStrange when**: You need fast setup, good OCR on scans/photos, schema-based extraction, or a free cloud API. Single tool, no orchestration needed.
-
-**Choose Docling+ExtractThinker when**: You need PII redaction (Presidio), custom Pydantic schemas, fully local CPU processing (no CUDA), or fine-grained pipeline control.
-
-**Choose Unstract when**: You need a visual schema builder, enterprise ETL pipelines, or pre-built extractors without code.
+**Decision rules:**
+- **DocStrange**: fast setup, scan/photo OCR, schema extraction, free cloud API — single tool, no orchestration
+- **Docling+ExtractThinker**: PII redaction (Presidio), Pydantic schemas, CPU-only local, fine-grained control
+- **Unstract**: visual schema builder, enterprise ETL, pre-built extractors without code
 
 ## Limitations
 
-- Local GPU mode requires CUDA (no Apple Silicon/MLX support)
-- No built-in PII detection/redaction (use Presidio separately if needed)
+- Local GPU requires CUDA — no Apple Silicon/MLX support
+- No built-in PII detection/redaction (use Presidio separately)
 - Cloud mode sends documents to NanoNets servers
-- MCP server not included in PyPI package (must clone repo)
+- MCP server not in PyPI — must clone repo
 - 7B model downloads on first local run (~4GB)
 
 ## Related
 
-- `tools/document/document-extraction.md` - Docling+ExtractThinker+Presidio stack (alternative)
-- `tools/ocr/glm-ocr.md` - Local OCR via Ollama
-- `services/document-processing/unstract.md` - Enterprise document processing
-- `tools/conversion/pandoc.md` - Document format conversion
-- `todo/tasks/prd-document-extraction.md` - Full document extraction PRD
+- `tools/document/document-extraction.md` — Docling+ExtractThinker+Presidio stack
+- `tools/ocr/glm-ocr.md` — local OCR via Ollama
+- `services/document-processing/unstract.md` — enterprise document processing
+- `tools/conversion/pandoc.md` — document format conversion
+- `todo/tasks/prd-document-extraction.md` — full document extraction PRD


### PR DESCRIPTION
Converts verbose prose to tables/bullets. Preserves all CLI commands, Python API examples, MCP server config JSON, output methods table, tool comparison table, decision rules, and limitations. 227 to 162 lines (29% reduction). Closes #8478