### PR TITLE
simplification: tighten email-providers.md 165 → 123 lines (#8474)

### DIFF
--- a/.agents/scripts/commands/email-inbox.md
+++ b/.agents/scripts/commands/email-inbox.md
@@ -8,283 +8,74 @@ Interactive email inbox management — check inbox, triage messages, compose rep
 
 Arguments: $ARGUMENTS
 
-## Workflow
+## Operations
 
-### Step 1: Determine Operation
+Parse `$ARGUMENTS` to select an operation. Default is `check` (inbox summary).
 
-Parse `$ARGUMENTS` to determine which operation to run:
+| Command | Helper call | Purpose |
+|---------|-------------|---------|
+| *(empty)* / `check` | `email-mailbox-helper.sh inbox --summary` | Inbox summary (unread, flagged, pending triage) |
+| `triage [--limit N]` | `email-triage-helper.sh run --limit 50` | AI triage of unread messages (classify, prioritize, flag) |
+| `compose [--reply <id>]` | `email-compose-helper.sh` workflow | Compose new email or reply |
+| `search "<query>"` | `email-mailbox-helper.sh search "$QUERY"` | Full-text search |
+| `search --from <addr>` | `email-mailbox-helper.sh search --from "$ADDR"` | Search by sender |
+| `search --flag <flag>` | `email-mailbox-helper.sh search --flag "$FLAG"` | Search by flag |
+| `search --since <period>` | `email-mailbox-helper.sh search --since "$PERIOD"` | Search by date range |
+| `organize [--apply]` | `email-mailbox-helper.sh organize --dry-run` | Preview/apply category sorting |
+| `folders` | `email-mailbox-helper.sh folders` | List folders with message counts |
+| `thread <id>` | `email-mailbox-helper.sh thread "$MESSAGE_ID"` | Show full email thread |
+| `flag <id> <flag>` | `email-mailbox-helper.sh flag "$MESSAGE_ID" "$FLAG"` | Apply flag to message |
+| `archive <id>` | `email-mailbox-helper.sh archive "$MESSAGE_ID"` | Archive a message |
 
-- **Empty or `check`**: Show inbox summary (unread count, flagged, pending triage)
-- **`triage`**: Run AI triage on unread messages (classify, prioritize, flag)
-- **`compose`**: Compose a new email or reply to a message
-- **`search <query>`**: Search mailbox by keyword, sender, date, or flag
-- **`organize`**: Apply category sorting and archiving rules
-- **`folders`**: List folder structure and message counts
-- **`thread <id>`**: Show a full email thread
-- **`flag <id> <flag>`**: Apply a flag to a message
-- **`archive <id>`**: Archive a message
-- **`help`**: Show available commands
+All helper scripts are under `~/.aidevops/agents/scripts/`.
 
-### Step 2: Run Appropriate Operation
+## Output Format
 
-**Check inbox (default):**
-
-```bash
-~/.aidevops/agents/scripts/email-mailbox-helper.sh inbox --summary
-```
-
-**Triage unread messages:**
-
-```bash
-~/.aidevops/agents/scripts/email-triage-helper.sh run --limit 50
-```
-
-**Search mailbox:**
-
-```bash
-~/.aidevops/agents/scripts/email-mailbox-helper.sh search "$QUERY"
-```
-
-**Organize (apply category rules):**
-
-```bash
-~/.aidevops/agents/scripts/email-mailbox-helper.sh organize --dry-run
-```
-
-**List folders:**
-
-```bash
-~/.aidevops/agents/scripts/email-mailbox-helper.sh folders
-```
-
-**Show thread:**
-
-```bash
-~/.aidevops/agents/scripts/email-mailbox-helper.sh thread "$MESSAGE_ID"
-```
-
-**Flag a message:**
-
-```bash
-~/.aidevops/agents/scripts/email-mailbox-helper.sh flag "$MESSAGE_ID" "$FLAG"
-```
-
-**Archive a message:**
-
-```bash
-~/.aidevops/agents/scripts/email-mailbox-helper.sh archive "$MESSAGE_ID"
-```
-
-### Step 3: Present Results
-
-Format output as a clear, scannable report. For inbox check:
+Format results as scannable reports. Example inbox summary:
 
 ```text
 Inbox: {account}
 Updated: {timestamp}
 
-Unread:    {count}  ({primary} primary, {updates} updates, {promotions} promotions)
-Flagged:   {count}  ({tasks} tasks, {reminders} reminders, {review} review)
-Triage:    {count} messages need triage
+Unread:  {count}  ({primary} primary, {updates} updates, {promotions} promotions)
+Flagged: {count}  ({tasks} tasks, {reminders} reminders, {review} review)
+Triage:  {count} messages need triage
 
 Recent Primary (last 24h):
   {sender} — {subject} ({time})
-  {sender} — {subject} ({time})
-
-Actions:
-1. Triage unread messages
-2. Search inbox
-3. Compose new email
-4. Organize folders
-5. Show flagged messages
 ```
 
-For triage results:
+Triage results group by category: **Primary** (with urgency), **Transactions** (receipts/invoices), **Updates** (notifications), **Promotions** (newsletters), **Phishing suspects** (quarantined). Include flagged-for-action summary and receipt forwarding count.
 
-```text
-Triage Complete: {count} messages processed
+Search results show date, sender, subject per match with thread/flag/archive actions.
 
-Primary ({n}):
-  [{urgency}] {sender} — {subject}
-  [{urgency}] {sender} — {subject}
+## Follow-up Actions
 
-Transactions ({n}):
-  [receipt] {sender} — {subject}
+After each operation, offer contextual next steps:
 
-Updates ({n}):
-  [notification] {sender} — {subject}
-
-Promotions ({n}):
-  [newsletter] {sender} — {subject}
-
-Flagged for action:
-  [task]     {sender} — {subject}
-  [reminder] {sender} — {subject}
-
-Phishing suspects ({n}):
-  [QUARANTINE] {sender} — {subject}
-```
-
-For search results:
-
-```text
-Search: "{query}"
-Found: {count} messages
-
-  {date} {sender} — {subject}
-  {date} {sender} — {subject}
-
-Actions:
-1. Open thread
-2. Flag message
-3. Archive message
-4. Refine search
-```
-
-### Step 4: Offer Follow-up Actions
-
-After each operation, offer contextual next steps based on what was found:
-
-- If unread messages exist: offer triage
-- If flagged tasks exist: offer to show task list
-- If triage found phishing suspects: offer to review quarantine
-- If triage found receipts: offer to forward to accounts@
-- If compose requested: load `email-compose-helper.sh` workflow
-
-## Options
-
-| Command | Purpose |
-|---------|---------|
-| `/email-inbox` | Inbox summary (unread, flagged, pending triage) |
-| `/email-inbox check` | Same as above |
-| `/email-inbox triage` | AI triage of unread messages |
-| `/email-inbox triage --limit 20` | Triage up to 20 messages |
-| `/email-inbox compose` | Compose new email |
-| `/email-inbox compose --reply <id>` | Reply to a specific message |
-| `/email-inbox search "project proposal"` | Full-text search |
-| `/email-inbox search --from alice@example.com` | Search by sender |
-| `/email-inbox search --flag task` | Show all task-flagged messages |
-| `/email-inbox search --since 7d` | Messages from last 7 days |
-| `/email-inbox organize` | Preview category sorting (dry run) |
-| `/email-inbox organize --apply` | Apply category sorting |
-| `/email-inbox folders` | List folders with message counts |
-| `/email-inbox thread <id>` | Show full thread for a message |
-| `/email-inbox flag <id> task` | Flag message as task |
-| `/email-inbox flag <id> reminder` | Flag message as reminder |
-| `/email-inbox archive <id>` | Archive a message |
+- Unread messages exist → offer triage
+- Flagged tasks exist → offer task list
+- Phishing suspects found → offer quarantine review
+- Receipts found → offer forwarding to accounts@
+- Compose requested → load `email-compose-helper.sh` workflow
 
 ## Flag Reference
 
 | Flag | Meaning | Use when |
 |------|---------|---------|
-| `task` | Requires a concrete action | Message asks you to do something |
-| `reminder` | Time-sensitive | Message has a deadline or due date |
+| `task` | Requires action | Message asks you to do something |
+| `reminder` | Time-sensitive | Has a deadline or due date |
 | `review` | Needs careful reading | Contract, proposal, legal document |
-| `filing` | Archive to specific folder | Belongs in a project or client folder |
+| `filing` | Archive to folder | Belongs in a project/client folder |
 | `idea` | Future reference | Inspiration or interesting link |
 | `contact` | Save contact details | New person to add to contacts |
 
-## Examples
-
-**Inbox check:**
-
-```text
-User: /email-inbox
-AI: Checking inbox...
-
-    Inbox: hello@example.com
-    Updated: Mon 16 Mar 2026 09:14
-
-    Unread:    12  (5 primary, 4 updates, 3 promotions)
-    Flagged:    3  (2 tasks, 1 reminder)
-    Triage:     8 messages need triage
-
-    Recent Primary (last 24h):
-      Alice Chen — Re: Project proposal (08:42)
-      Bob Smith — Invoice #1042 attached (07:15)
-
-    Actions:
-    1. Triage 8 unread messages
-    2. Show 2 flagged tasks
-    3. Compose new email
-    4. Search inbox
-```
-
-**Triage run:**
-
-```text
-User: /email-inbox triage
-AI: Running triage on 8 unread messages...
-
-    Triage Complete: 8 messages processed
-
-    Primary (3):
-      [high]   Alice Chen — Re: Project proposal
-      [medium] Bob Smith — Invoice #1042 attached
-      [low]    Carol Jones — Catch-up call?
-
-    Transactions (2):
-      [receipt] Stripe — Payment received $299.00
-      [invoice] Xero — Invoice #1042 from Bob Smith Ltd
-
-    Updates (2):
-      [ci-alert] GitHub — Build failed: main branch
-      [security] Google — New sign-in from Chrome on Mac
-
-    Promotions (1):
-      [newsletter] ProductHunt — Top products this week
-
-    Flagged for action:
-      [task]     Alice Chen — Re: Project proposal (reply needed)
-      [task]     Bob Smith — Invoice #1042 attached (approve payment)
-      [reminder] Carol Jones — Catch-up call? (respond by Friday)
-
-    Receipts forwarded to accounts@: 2
-
-    Actions:
-    1. Reply to Alice Chen
-    2. Review invoice from Bob Smith
-    3. Approve CI failure notification
-```
-
-**Search:**
-
-```text
-User: /email-inbox search "project proposal"
-AI: Searching for "project proposal"...
-
-    Found: 4 messages
-
-      15 Mar  Alice Chen — Re: Project proposal (latest)
-      12 Mar  Alice Chen — Project proposal v2 attached
-      08 Mar  You — Project proposal — initial draft
-      01 Mar  Alice Chen — Project proposal request
-
-    Actions:
-    1. Open latest thread (Alice Chen)
-    2. Flag thread as task
-    3. Archive older messages
-```
-
-**Compose:**
-
-```text
-User: /email-inbox compose --reply abc123
-AI: Loading thread for message abc123...
-
-    Replying to: Alice Chen <alice@example.com>
-    Subject: Re: Project proposal
-
-    Loading email-compose-helper.sh workflow...
-    [Drafts reply using voice profile and templates]
-```
-
 ## Security
 
-- Prompt injection scanning is mandatory before displaying message bodies. All message content passes through `prompt-guard-helper.sh scan-stdin` before rendering.
-- Phishing suspects are quarantined automatically by the triage engine. Never display quarantined message bodies without explicit user confirmation.
-- Transaction emails forwarded to accounts@ require phishing verification (SPF/DKIM/DMARC pass) before forwarding. See `services/email/email-mailbox.md` "Transaction Receipt and Invoice Forwarding".
-- Message IDs passed to helper scripts are validated to prevent command injection.
+- **Prompt injection**: mandatory before displaying message bodies — all content passes through `prompt-guard-helper.sh scan-stdin` before rendering.
+- **Phishing quarantine**: triage engine quarantines suspects automatically. Never display quarantined bodies without explicit user confirmation.
+- **Transaction forwarding**: emails forwarded to accounts@ require phishing verification (SPF/DKIM/DMARC pass) before forwarding. See `services/email/email-mailbox.md` "Transaction Receipt and Invoice Forwarding".
+- **Command injection**: message IDs passed to helper scripts are validated.
 
 ## Dependencies
 

--- a/.agents/services/email/email-providers.md
+++ b/.agents/services/email/email-providers.md
@@ -38,38 +38,17 @@ cp configs/email-providers.json.txt configs/email-providers.json
 
 ## Provider Selection
 
-### By Privacy Rating
+| Rating | Providers | Auth |
+|--------|-----------|------|
+| **A+** Proton Mail, Tuta, Cloudron | E2EE/self-hosted, zero-knowledge | Bridge password / regular |
+| **A** Fastmail, mailbox.org, StartMail, Disroot, ChatMail | No data mining, privacy-focused | App passwords / regular |
+| **B** Zoho, IONOS, Namecheap, iCloud | No ads, less privacy-focused jurisdiction | OAuth2 / app passwords |
+| **C** Google Workspace, Microsoft 365, GMX, mail.com | No ad targeting, telemetry active | OAuth2 / service account |
+| **D** Gmail, Outlook/Hotmail, Yahoo | Ad-supported, content scanning | OAuth2 / app passwords |
 
-| Rating | Providers | Key Characteristics |
-|--------|-----------|-------------------|
-| A+ | Proton Mail, Tuta, Cloudron | E2EE built-in or self-hosted, zero-knowledge, open-source |
-| A | Fastmail, mailbox.org, StartMail, Disroot, ChatMail | No data mining, privacy-focused business model |
-| B | Zoho, IONOS, Namecheap, iCloud | No ads/mining, but less privacy-focused jurisdiction or practices |
-| C | Google Workspace, Microsoft 365, GMX, mail.com | Business plans with no ad targeting, but telemetry active |
-| D | Gmail, Outlook/Hotmail, Yahoo | Ad-supported, content scanning, broad data usage policies |
+**Protocol exceptions**: Tuta — no IMAP/SMTP/POP3 (proprietary only). Proton Mail — IMAP/SMTP via local Bridge. Fastmail — JMAP available. Outlook/365 — Graph API. All others: IMAP + SMTP + POP3.
 
-### By Protocol Support
-
-| Protocol | Providers |
-|----------|-----------|
-| IMAP + SMTP | All except Tuta |
-| JMAP | Fastmail only |
-| POP3 | Gmail, Google Workspace, Outlook, Microsoft 365, Yahoo, Zoho, GMX, IONOS, Namecheap, mail.com, Fastmail, mailbox.org, Disroot, Cloudron |
-| Graph API | Outlook, Microsoft 365 |
-| Bridge required | Proton Mail (local IMAP/SMTP via Proton Bridge) |
-| No standard protocols | Tuta (proprietary client only) |
-
-### By Auth Method
-
-| Method | Providers |
-|--------|-----------|
-| OAuth2 | Gmail, Google Workspace, Outlook, Microsoft 365, Zoho |
-| App passwords | Gmail, Fastmail, Yahoo, StartMail, iCloud |
-| Regular password | Cloudron, mailbox.org, GMX, IONOS, Namecheap, mail.com, Disroot, ChatMail, Zoho |
-| Bridge password | Proton Mail |
-| Service account | Google Workspace, Microsoft 365 |
-
-## POP vs IMAP Decision Tree
+## POP vs IMAP
 
 ```text
 Need email access?
@@ -95,42 +74,21 @@ Need email access?
 | Spam/Junk | `[Gmail]/Spam` | `Junk` / `Junk Email` | `Bulk Mail` | `Junk` | `Junk` or `Spam` |
 | Archive | `[Gmail]/All Mail` | `Archive` | `Archive` | `Archive` | `Archive` |
 
-- **Gmail**: uses labels, not folders — a message can appear in multiple IMAP "folders". Deleting from a label removes the label only; true deletion requires moving to Trash.
-- **Outlook/365**: free Outlook.com uses `Sent`/`Deleted`; Microsoft 365 business uses `Sent Items`/`Deleted Items`.
+- **Gmail**: labels not folders — message can appear in multiple IMAP "folders". Deleting a label removes the label only; true deletion requires moving to Trash.
+- **Outlook/365**: free uses `Sent`/`Deleted`; Microsoft 365 business uses `Sent Items`/`Deleted Items`.
 
 ## Shared Mailbox Patterns
 
-| Address | Purpose | Typical Protocol |
-|---------|---------|-----------------|
-| `info@` | General enquiries | POP or IMAP shared |
-| `support@` | Customer support | IMAP + helpdesk tool |
-| `sales@` | Sales enquiries | IMAP + CRM |
-| `enquiries@` | General enquiries (UK) | POP or IMAP shared |
-| `accounts@` | Financial / billing | IMAP (restricted) |
-| `marketing@` | Marketing team | IMAP shared |
-| `admin@` | Administrative | IMAP (restricted) |
-| `webmaster@` | Website issues | IMAP |
-| `buyers@` | Procurement | IMAP |
-| `dataprotection@` | GDPR / privacy | IMAP (restricted) |
-| `legal@` | Legal matters | IMAP (restricted) |
-| `billing@` | Payment / invoicing | IMAP (restricted) |
-| `noreply@` | Outbound only | SMTP only |
-| `hello@` | Friendly general contact | POP or IMAP shared |
-| `contact@` | General contact | POP or IMAP shared |
-| `hr@` | Human resources | IMAP (restricted) |
-| `careers@` | Job applications | IMAP |
-| `press@` | Media enquiries | IMAP |
-| `abuse@` | Abuse reports (RFC 2142) | IMAP |
-| `postmaster@` | Mail server issues (RFC 2142) | IMAP |
-| `security@` | Security reports | IMAP (restricted) |
+| Address | Protocol | Notes |
+|---------|----------|-------|
+| `info@`, `enquiries@`, `hello@`, `contact@` | POP or IMAP shared | POP if all users need same copy |
+| `support@` | IMAP + helpdesk tool | Assign/claim workflow |
+| `sales@` | IMAP + CRM | |
+| `noreply@` | SMTP only | No inbox needed |
+| `abuse@`, `postmaster@` | IMAP | RFC 2142 required addresses |
+| `security@`, `dataprotection@`, `legal@`, `billing@`, `accounts@` | IMAP (restricted) | Limit access |
 
-**Provider shared mailbox support:**
-- **Microsoft 365**: Best-in-class — dedicated shared mailbox, no extra license, auto-mapping, send-as/on-behalf.
-- **Google Workspace**: Collaborative inboxes via Google Groups; delegated access for individual mailboxes.
-- **Zoho Mail**: Group mailboxes in paid plans; shared folders and delegated access.
-- **Cloudron**: Separate mailbox accounts or aliases via admin panel / CLI.
-- **Proton Mail**: Business plans support multi-user access and catch-all.
-- **Others**: Most free/personal providers have no shared mailbox support.
+**Shared mailbox provider support**: Microsoft 365 (best — dedicated shared mailbox, no extra license, send-as/on-behalf) > Google Workspace (Groups + delegated access) > Zoho Mail (paid plans) > Cloudron (aliases via CLI) > Proton Mail (business plans). Most free/personal providers: none.
 
 ## Cloudron Mail Management
 


### PR DESCRIPTION
## Summary

- Merge 3 provider selection subsections (Privacy Rating, Protocol Support, Auth Method) into one unified table with auth column + protocol exceptions note
- Collapse 21-row shared mailbox table to 6 grouped rows — remove self-evident IMAP-only rows (`webmaster@`, `buyers@`, `marketing@`, `admin@`, `hr@`, `careers@`, `press@`, etc.)
- All actionable content preserved: RFC 2142 addresses, restricted-access groups, `noreply@` SMTP-only, provider shared mailbox ranking, all Cloudron CLI commands, all provider-specific notes

**165 → 123 lines (25% further reduction, 46% total from original 229)**

## Runtime Testing

- **Risk**: Low (docs-only change)
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 123 lines; content review confirms all actionable content preserved

Closes #8474