### PR TITLE
t8471: simplify offer-optimization.md — 229→126 lines

### DIFF
--- a/.agents/tools/marketing/direct-response-copy/checklists/offer-optimization.md
+++ b/.agents/tools/marketing/direct-response-copy/checklists/offer-optimization.md
@@ -1,150 +1,68 @@
 # Offer Optimization Checklist
 
-Use this checklist to ensure your offer is irresistible before launch.
+---
+
+## Core Offer & Value Stack
+
+| Area | Checklist |
+|------|-----------|
+| **Core** | Defined in one sentence · Primary benefit obvious · Solves a real problem · Delivers transformation (before→after) · Matches audience awareness level |
+| **Main product** | Clearly described · Value assigned and justified · Components listed (modules, features, deliverables) |
+| **Bonuses** | Relevant to core offer · Help succeed with main offer · Specific deliverables · Believable values · Named (not "Bonus 1") · 2–3 minimum |
+| **Value math** | Total value 5–10× price · Calculation shown · Each component value listed · Final price feels like a bargain |
 
 ---
 
-## Core Offer ✓
+## Pricing
 
-- [ ] The core product/service is CLEARLY defined
-- [ ] I can describe what they get in ONE sentence
-- [ ] The PRIMARY benefit is obvious
-- [ ] It solves a REAL problem my audience has
-- [ ] It delivers a TRANSFORMATION (before → after)
-- [ ] The offer matches the AWARENESS level of my audience
-
----
-
-## Value Stack ✓
-
-**Core Offer:**
-- [ ] Main product is clearly described
-- [ ] Value is assigned and justified
-- [ ] Components are listed (modules, features, deliverables)
-
-**Bonuses:**
-- [ ] Each bonus is RELEVANT to the core offer
-- [ ] Each bonus helps them SUCCEED with the main offer
-- [ ] Each bonus has SPECIFIC deliverables (not vague)
-- [ ] Bonus values are BELIEVABLE
-- [ ] Bonuses are NAMED (not just "Bonus 1")
-- [ ] At least 2-3 bonuses included
-
-**Value Math:**
-- [ ] Total value is 5-10x the price
-- [ ] Value calculation is shown (not hidden)
-- [ ] Each component value is listed
-- [ ] Final price feels like a BARGAIN in comparison
+| Area | Checklist |
+|------|-----------|
+| **Structure** | Clear and simple · Most popular tier highlighted · Tiers easy to compare · Budget tier present · Power tier if applicable |
+| **Psychology** | Anchor high value before price · Charm pricing ($97/$297/$497) · Payment plan for $200+ offers · Annual discount for subscriptions · Compare to alternatives ("$5k agency vs $79/mo") |
+| **10× rule** | Customer gets 10× value · ROI clear (pay $500 → expect $5k+ value) · ROI communicated in copy |
 
 ---
 
-## Pricing ✓
+## Guarantee
 
-**Structure:**
-- [ ] Pricing is CLEAR and simple
-- [ ] Most popular tier is HIGHLIGHTED (if multiple tiers)
-- [ ] Features per tier are EASY to compare
-- [ ] There's a tier for BUDGET-conscious buyers
-- [ ] There's a tier for POWER users (if applicable)
-
-**Psychology:**
-- [ ] Price ANCHORING is used (show high value first)
-- [ ] Charm pricing applied ($97, $297, $497 vs. round numbers)
-- [ ] Payment plan option for $200+ offers
-- [ ] Annual discount incentivizes commitment (if subscription)
-- [ ] Price is COMPARED to alternatives ("$5,000 agency vs. $79/mo")
-
-**10x Rule:**
-- [ ] Customer will get 10x the value of what they pay
-- [ ] ROI is clear (if $500, they should expect $5,000+ value)
-- [ ] ROI is communicated in the copy
+| Area | Checklist |
+|------|-----------|
+| **Clarity** | Prominent (not buried) · Terms clear · Timeframe specific (30/60 days) · Refund process simple |
+| **Strength** | Removes primary fear · Feels fair · Shows confidence · Has a name |
+| **Types** | Money-back · Results-based · Free trial (no CC) · Risk-free trial (CC, cancel anytime) |
 
 ---
 
-## Guarantee ✓
+## Urgency & Scarcity
 
-**Clarity:**
-- [ ] Guarantee is PROMINENT (not buried)
-- [ ] Guarantee terms are CLEAR
-- [ ] Timeframe is SPECIFIC (30 days, 60 days, etc.)
-- [ ] Refund process is SIMPLE (not lots of hoops)
-
-**Strength:**
-- [ ] Guarantee removes their PRIMARY fear
-- [ ] Guarantee feels FAIR (not one-sided)
-- [ ] Guarantee shows CONFIDENCE in product
-- [ ] Guarantee has a NAME (adds legitimacy)
-
-**Types (choose one or combine):**
-- [ ] Money-back guarantee
-- [ ] Results-based guarantee
-- [ ] Free trial (no CC)
-- [ ] Risk-free trial (with CC, cancel anytime)
+| Area | Checklist |
+|------|-----------|
+| **Legitimacy** | Real (not fake) · Specific deadline (date/time) · Consequences of waiting clear · Deadline will be honoured (no extending) |
+| **Types** | Limited time · Limited quantity (spots/copies) · Rising price (early bird) · Bonus expiration · Cart expiration |
+| **Copy** | What they lose is clear (bonuses, price, access) · Why the limit exists is explained |
 
 ---
 
-## Urgency & Scarcity ✓
+## Call to Action
 
-**Legitimacy:**
-- [ ] Urgency/scarcity is REAL (not fake)
-- [ ] Deadline is SPECIFIC (date/time)
-- [ ] Consequences of waiting are CLEAR
-- [ ] We WILL honor the deadline (no extending)
-
-**Types (use when appropriate):**
-- [ ] Limited time offer (deadline)
-- [ ] Limited quantity (spots, copies)
-- [ ] Rising price (early bird)
-- [ ] Bonus expiration
-- [ ] Cart expiration (for abandoners)
-
-**Copy:**
-- [ ] What they LOSE is clear (bonuses, price, access)
-- [ ] Why the limit EXISTS is explained (if not obvious)
+- Action-oriented ("Start My Trial" not "Submit") · Benefit-focused when possible ("Get More Leads")
+- Appears multiple times on long pages · Stands out visually · Explains what happens next
+- Friction minimised (fewest fields possible)
 
 ---
 
-## Call to Action ✓
+## Objection Handling
 
-- [ ] CTA is ACTION-ORIENTED ("Start My Trial" vs "Submit")
-- [ ] CTA is BENEFIT-focused when possible ("Get More Leads")
-- [ ] CTA appears MULTIPLE times on long pages
-- [ ] CTA STANDS OUT visually
-- [ ] CTA explains what happens NEXT
-- [ ] FRICTION is minimized (fewest fields possible)
-
----
-
-## Objection Handling ✓
-
-Ensure your offer addresses these common objections:
-
-**Price objection:**
-- [ ] Value is clear before price
-- [ ] Price is compared to alternatives
-- [ ] ROI is communicated
-- [ ] Payment plans reduce friction
-
-**Trust objection:**
-- [ ] Guarantee removes risk
-- [ ] Social proof backs claims
-- [ ] Credibility is established
-
-**Time objection:**
-- [ ] Time to results is clear
-- [ ] Time investment is reasonable
-- [ ] Quick wins are highlighted
-
-**"Not for me" objection:**
-- [ ] Target audience is clear
-- [ ] Different use cases shown
-- [ ] FAQ addresses edge cases
+| Objection | Must address |
+|-----------|-------------|
+| **Price** | Value shown before price · Compared to alternatives · ROI communicated · Payment plan available |
+| **Trust** | Guarantee removes risk · Social proof backs claims · Credibility established |
+| **Time** | Time to results clear · Time investment reasonable · Quick wins highlighted |
+| **Not for me** | Target audience clear · Use cases shown · FAQ covers edge cases |
 
 ---
 
 ## Offer Comparison
-
-Before finalizing, compare your offer:
 
 | Factor | Your Offer | Competitor A | Competitor B |
 |--------|------------|--------------|--------------|
@@ -155,41 +73,31 @@ Before finalizing, compare your offer:
 | Support | | | |
 | Unique advantage | | | |
 
-Your offer should win on at least 2-3 factors.
+Your offer should win on at least 2–3 factors.
 
 ---
 
-## Offer Testing Priorities
-
-Test these elements in order of impact:
+## Testing Priorities (in order of impact)
 
 1. **Price point** — $97 vs $197 vs $297
 2. **Guarantee** — 30-day vs 60-day vs results-based
-3. **Bonuses** — Which bonuses increase conversion?
-4. **Payment options** — One-time vs. payment plan
-5. **Urgency type** — Deadline vs. quantity vs. price increase
+3. **Bonuses** — which increase conversion?
+4. **Payment options** — one-time vs payment plan
+5. **Urgency type** — deadline vs quantity vs price increase
 
 ---
 
 ## Pre-Launch Verification
 
-Before launching the offer:
-
-- [ ] Offer is documented clearly
-- [ ] Team knows the offer details
-- [ ] Checkout process works
-- [ ] Payment processing tested
-- [ ] Fulfillment ready (instant access, onboarding, etc.)
-- [ ] Support prepared for questions
-- [ ] Tracking set up (pixels, analytics)
+- [ ] Offer documented and team briefed
+- [ ] Checkout process tested · Payment processing confirmed
+- [ ] Fulfillment ready (instant access, onboarding)
+- [ ] Support prepared · Tracking set up (pixels, analytics)
 
 ---
 
 ## Offer Math Worksheet
 
-Fill this out to verify your offer makes sense:
-
-**Value Calculation:**
 ```
 Core Product Value: $______
 + Bonus 1 Value:    $______
@@ -197,33 +105,22 @@ Core Product Value: $______
 + Bonus 3 Value:    $______
 ─────────────────────────────
 Total Value:        $______
-
 Your Price:         $______
+Value Multiple:     ____x  (target: 5–10×)
 
-Value Multiple:     ____x (should be 5-10x)
-```
-
-**ROI Calculation:**
-```
 If customer pays:   $______
-They should get:    $______ in value (10x minimum)
-
-How do they get that value?
-- [Outcome 1]: $______
-- [Outcome 2]: $______
-- [Outcome 3]: $______
+They should get:    $______ in value (10× minimum)
+- [Outcome 1]:      $______
+- [Outcome 2]:      $______
+- [Outcome 3]:      $______
 ```
 
 ---
 
-## Quick Offer Check
+## Quick Check (all must be yes before launch)
 
-Before you publish, ask:
-
-1. ✓ Would I buy this at this price?
-2. ✓ Is the value obviously greater than the price?
-3. ✓ Is there a clear reason to buy NOW?
-4. ✓ Is the risk removed (guarantee)?
-5. ✓ Is the action clear?
-
-If all five are "yes," your offer is ready.
+1. Would I buy this at this price?
+2. Is the value obviously greater than the price?
+3. Is there a clear reason to buy NOW?
+4. Is the risk removed (guarantee)?
+5. Is the action clear?


### PR DESCRIPTION
## Summary

- Convert verbose prose checklist sections to compact tables (Core Offer & Value Stack, Pricing, Guarantee, Urgency & Scarcity, Objection Handling)
- Merge overlapping "Core Offer" and "Value Stack" sections into one table
- All checklist items, comparison table, math worksheets, testing priorities, and quick check preserved
- 229 → 126 lines (45% reduction)

Closes #8471