### PR TITLE
GH#8489: Fix BSD sed non-greedy quantifier in headless-runtime-helper.sh

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -46,7 +46,7 @@ _register_dispatch_ledger() {
 
 	# Resolve repo slug from work_dir via git remote
 	if [[ -n "$ledger_work_dir" && -d "$ledger_work_dir" ]]; then
-		ledger_repo=$(git -C "$ledger_work_dir" remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || true)
+		ledger_repo=$(git -C "$ledger_work_dir" remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|' || true)
 	fi
 
 	local ledger_args=(register --session-key "$ledger_session_key" --pid "$$")


### PR DESCRIPTION
## Summary

- Remove non-greedy quantifier `+?` from sed pattern on line 49 of `headless-runtime-helper.sh` — BSD sed (macOS default) does not support `+?` and throws `RE error: repetition-operator operand invalid`
- Replace `[^/]+?` with `[^/]+` (greedy) which is functionally equivalent since the character class already excludes `/`

Closes #8489

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** Low — single regex character removal in a sed pattern, no behavioral change
- **Rationale:** `[^/]+` and `[^/]+?` produce identical results here because `[^/]` cannot match `/`, so greediness vs non-greediness is irrelevant — the match stops at the same position either way. The `(\.git)?$` anchor handles the optional `.git` suffix correctly in both cases.
- **ShellCheck:** Clean (only pre-existing SC1091 info about external source)