### PR TITLE
GH#8229: Fix model-availability-helper to detect MonthlyLimitError spending cap

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -610,12 +610,7 @@ PY
 	fi
 	# Spending/billing limit detection (GH#8229): must check BEFORE auth_error
 	# because spending limits often return 401 but with a distinct error body.
-	# MonthlyLimitError, spending limit, billing limit, quota exceeded, etc.
-	if [[ "$lowered" == *"monthlylimiterror"* ]] || [[ "$lowered" == *"spending limit"* ]] ||
-		[[ "$lowered" == *"monthly spending limit"* ]] || [[ "$lowered" == *"monthly limit"* ]] ||
-		[[ "$lowered" == *"billing limit"* ]] || [[ "$lowered" == *"budget exceeded"* ]] ||
-		[[ "$lowered" == *"quota exceeded"* ]] || [[ "$lowered" == *"usage limit"* ]] ||
-		[[ "$lowered" == *"credits exhausted"* ]]; then
+	if is_spending_limit_error "$lowered"; then
 		printf '%s' "spending_limit"
 		return 0
 	fi

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -437,10 +437,10 @@ record_provider_backoff() {
 	local model="${4:-$provider}"
 	local details retry_seconds auth_signature retry_after backoff_key
 
-	# Auth errors back off at provider level (shared credentials).
+	# Auth and spending limit errors back off at provider level (shared credentials/budget).
 	# Rate limits and provider errors back off at model level so that
 	# other models from the same provider remain available as fallbacks.
-	if [[ "$reason" == "auth_error" ]]; then
+	if [[ "$reason" == "auth_error" || "$reason" == "spending_limit" ]]; then
 		backoff_key="$provider"
 	else
 		backoff_key="$model"
@@ -461,6 +461,7 @@ PY
 		case "$reason" in
 		rate_limit) retry_seconds=900 ;;
 		auth_error) retry_seconds=3600 ;;
+		spending_limit) retry_seconds=3600 ;;
 		*) retry_seconds=300 ;;
 		esac
 	fi
@@ -482,6 +483,17 @@ ON CONFLICT(provider) DO UPDATE SET
     details = excluded.details,
     updated_at = excluded.updated_at;
 " >/dev/null
+
+	# Cross-write spending limits to the model-availability cache (GH#8229).
+	# This ensures resolve_tier() in model-availability-helper.sh also skips
+	# this provider, preventing the pulse from dispatching new workers that
+	# will immediately fail with the same spending limit error.
+	if [[ "$reason" == "spending_limit" ]]; then
+		local avail_helper="${SCRIPT_DIR}/model-availability-helper.sh"
+		if [[ -x "$avail_helper" ]]; then
+			"$avail_helper" mark-unavailable "$provider" "spending_limit" --ttl "$retry_seconds" 2>/dev/null || true
+		fi
+	fi
 	return 0
 }
 
@@ -594,6 +606,17 @@ PY
 	)
 	if [[ "$lowered" == *"rate limit"* ]] || [[ "$lowered" == *"429"* ]] || [[ "$lowered" == *"too many requests"* ]]; then
 		printf '%s' "rate_limit"
+		return 0
+	fi
+	# Spending/billing limit detection (GH#8229): must check BEFORE auth_error
+	# because spending limits often return 401 but with a distinct error body.
+	# MonthlyLimitError, spending limit, billing limit, quota exceeded, etc.
+	if [[ "$lowered" == *"monthlylimiterror"* ]] || [[ "$lowered" == *"spending limit"* ]] ||
+		[[ "$lowered" == *"monthly spending limit"* ]] || [[ "$lowered" == *"monthly limit"* ]] ||
+		[[ "$lowered" == *"billing limit"* ]] || [[ "$lowered" == *"budget exceeded"* ]] ||
+		[[ "$lowered" == *"quota exceeded"* ]] || [[ "$lowered" == *"usage limit"* ]] ||
+		[[ "$lowered" == *"credits exhausted"* ]]; then
+		printf '%s' "spending_limit"
 		return 0
 	fi
 	if [[ "$lowered" =~ (unauthorized|401|invalid\ api\ key|authentication|token\ refresh\ failed|invalid_grant|invalid\ refresh\ token) ]] || [[ "$lowered" == *"auth"* && "$lowered" == *"failed"* ]]; then

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -207,27 +207,14 @@ _opencode_model_exists() {
 # because all models under the same account share the spending cap.
 
 # Check if an HTTP response body contains a spending/billing limit error.
+# Delegates to is_spending_limit_error() in shared-constants.sh.
 # Returns 0 if spending limit detected, 1 otherwise.
 _is_spending_limit_error() {
 	local body="$1"
 	local lowered
 	lowered=$(printf '%s' "$body" | tr '[:upper:]' '[:lower:]')
-
-	# Match known billing error patterns:
-	# - OpenCode: MonthlyLimitError / "monthly spending limit"
-	# - Generic: "spending limit", "billing limit", "quota exceeded", "budget exceeded"
-	case "$lowered" in
-	*monthlylimiterror* | *"monthly spending limit"* | *"monthly limit"*)
-		return 0
-		;;
-	*"spending limit"* | *"billing limit"* | *"budget exceeded"*)
-		return 0
-		;;
-	*"quota exceeded"* | *"usage limit"* | *"credits exhausted"*)
-		return 0
-		;;
-	esac
-	return 1
+	is_spending_limit_error "$lowered"
+	return $?
 }
 
 # =============================================================================

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -33,6 +33,7 @@
 #   1 - Provider/model unavailable or error
 #   2 - Rate limited (retry after delay)
 #   3 - API key invalid or missing
+#   4 - Spending/billing limit reached (provider-level backoff)
 #
 # Author: AI DevOps Framework
 # Version: 1.0.0
@@ -195,6 +196,38 @@ _opencode_model_exists() {
 			'[.[] | .models[$m] // empty] | length > 0' "$OPENCODE_MODELS_CACHE" >/dev/null 2>&1
 		return $?
 	fi
+}
+
+# =============================================================================
+# Spending / Billing Limit Detection (GH#8229)
+# =============================================================================
+# Detects MonthlyLimitError and similar billing cap errors from API responses.
+# These are distinct from auth errors: the key is valid but the account has
+# exhausted its spending budget. Requires provider-level backoff (not model-level)
+# because all models under the same account share the spending cap.
+
+# Check if an HTTP response body contains a spending/billing limit error.
+# Returns 0 if spending limit detected, 1 otherwise.
+_is_spending_limit_error() {
+	local body="$1"
+	local lowered
+	lowered=$(printf '%s' "$body" | tr '[:upper:]' '[:lower:]')
+
+	# Match known billing error patterns:
+	# - OpenCode: MonthlyLimitError / "monthly spending limit"
+	# - Generic: "spending limit", "billing limit", "quota exceeded", "budget exceeded"
+	case "$lowered" in
+	*monthlylimiterror* | *"monthly spending limit"* | *"monthly limit"*)
+		return 0
+		;;
+	*"spending limit"* | *"billing limit"* | *"budget exceeded"*)
+		return 0
+		;;
+	*"quota exceeded"* | *"usage limit"* | *"credits exhausted"*)
+		return 0
+		;;
+	esac
+	return 1
 }
 
 # =============================================================================
@@ -464,6 +497,10 @@ _probe_return_cached() {
 		[[ "$quiet" != "true" ]] && print_warning "$provider: cached key-invalid"
 		return 3
 		;;
+	spending_limit)
+		[[ "$quiet" != "true" ]] && print_warning "$provider: cached spending-limit"
+		return 4
+		;;
 	*)
 		[[ "$quiet" != "true" ]] && print_warning "$provider: cached unhealthy"
 		return 1
@@ -471,26 +508,69 @@ _probe_return_cached() {
 	esac
 }
 
-# Probe the OpenCode meta-provider via its local models cache (no API key needed).
-# Returns: 0=healthy, 1=unhealthy
+# Probe the OpenCode meta-provider.
+# Two-phase check (GH#8229):
+#   1. Local models cache — confirms CLI is installed and models are listed
+#   2. Live API probe — lightweight /models call to detect spending/billing limits
+# The cache check alone cannot detect account-level budget exhaustion because
+# the models list is static. A MonthlyLimitError only surfaces on actual API calls.
+# Returns: 0=healthy, 1=unhealthy, 4=spending-limit
 _probe_opencode() {
 	local quiet="${1:-false}"
 
-	if _is_opencode_available; then
-		local oc_models_count=0
-		oc_models_count=$(jq -r '.opencode.models | length' "$OPENCODE_MODELS_CACHE" 2>/dev/null || echo "0")
-		_record_health "opencode" "healthy" 200 0 "" "$oc_models_count"
-		[[ "$quiet" != "true" ]] && print_success "opencode: healthy ($oc_models_count models in cache)"
-		db_query "
-            INSERT INTO probe_log (provider, action, result, duration_ms, details)
-            VALUES ('opencode', 'cache_check', 'healthy', 0, '$oc_models_count models from cache');
-        " || true
-		return 0
+	if ! _is_opencode_available; then
+		_record_health "opencode" "unhealthy" 0 0 "OpenCode CLI or models cache not found" 0
+		[[ "$quiet" != "true" ]] && print_warning "opencode: CLI or models cache not available"
+		return 1
 	fi
 
-	_record_health "opencode" "unhealthy" 0 0 "OpenCode CLI or models cache not found" 0
-	[[ "$quiet" != "true" ]] && print_warning "opencode: CLI or models cache not available"
-	return 1
+	local oc_models_count=0
+	oc_models_count=$(jq -r '.opencode.models | length' "$OPENCODE_MODELS_CACHE" 2>/dev/null || echo "0")
+
+	# Phase 2: Live API probe to detect spending/billing limits.
+	# The /models endpoint is free and fast, but a spending-capped account
+	# will return 401 + MonthlyLimitError even on this endpoint.
+	local api_key
+	api_key=$(_get_key_value "opencode" 2>/dev/null) || api_key=""
+	if [[ -n "$api_key" ]]; then
+		local endpoint
+		endpoint=$(get_provider_endpoint "opencode" 2>/dev/null) || endpoint=""
+		if [[ -n "$endpoint" ]]; then
+			local live_response live_http_code live_body
+			live_response=$(curl -s -w $'\n%{http_code}' --max-time "$PROBE_TIMEOUT" \
+				-H "Authorization: Bearer ${api_key}" \
+				"$endpoint" 2>/dev/null) || true
+			live_http_code=$(printf '%s' "$live_response" | tail -1)
+			live_body=$(printf '%s' "$live_response" | sed '$d')
+
+			if [[ -n "$live_http_code" && "$live_http_code" != "200" ]]; then
+				# Check if the error is a spending/billing limit
+				if _is_spending_limit_error "$live_body"; then
+					_record_health "opencode" "spending_limit" "$live_http_code" 0 \
+						"Spending/billing limit reached" "$oc_models_count"
+					[[ "$quiet" != "true" ]] && print_error "opencode: spending limit reached (HTTP $live_http_code)"
+					db_query "
+						INSERT INTO probe_log (provider, action, result, duration_ms, details)
+						VALUES ('opencode', 'live_probe', 'spending_limit', 0,
+							'HTTP $live_http_code - spending limit detected');
+					" || true
+					return 4
+				fi
+				# Non-spending-limit errors on the live probe: log but don't fail
+				# the overall check — the models cache is still valid for listing
+				[[ "$quiet" != "true" ]] && print_warning "opencode: live probe returned HTTP $live_http_code (non-fatal)"
+			fi
+		fi
+	fi
+
+	# Models cache is valid and no spending limit detected
+	_record_health "opencode" "healthy" 200 0 "" "$oc_models_count"
+	[[ "$quiet" != "true" ]] && print_success "opencode: healthy ($oc_models_count models in cache)"
+	db_query "
+		INSERT INTO probe_log (provider, action, result, duration_ms, details)
+		VALUES ('opencode', 'cache_check', 'healthy', 0, '$oc_models_count models from cache');
+	" || true
+	return 0
 }
 
 # Build curl argument array and resolve the final endpoint URL for a provider.
@@ -549,10 +629,20 @@ _probe_parse_http_response() {
 		[[ "$quiet" != "true" ]] && print_success "$provider: healthy (${models_count} models)"
 		;;
 	401 | 403)
-		status="key_invalid"
-		error_msg="Authentication failed (HTTP $http_code)"
-		exit_code=3
-		[[ "$quiet" != "true" ]] && print_error "$provider: API key invalid (HTTP $http_code)"
+		# Distinguish spending/billing limits from auth errors (GH#8229).
+		# Spending limits often return 401 but with a body indicating budget exhaustion,
+		# not an invalid key. These require provider-level backoff, not key rotation.
+		if _is_spending_limit_error "$body"; then
+			status="spending_limit"
+			error_msg="Spending/billing limit reached (HTTP $http_code)"
+			exit_code=4
+			[[ "$quiet" != "true" ]] && print_error "$provider: spending limit reached (HTTP $http_code)"
+		else
+			status="key_invalid"
+			error_msg="Authentication failed (HTTP $http_code)"
+			exit_code=3
+			[[ "$quiet" != "true" ]] && print_error "$provider: API key invalid (HTTP $http_code)"
+		fi
 		;;
 	429)
 		status="rate_limited"
@@ -1253,6 +1343,7 @@ _status_print_providers() {
 		unhealthy | unreachable) status_display="${RED}$stat${NC}" ;;
 		rate_limited) status_display="${YELLOW}rate-ltd${NC}" ;;
 		key_invalid) status_display="${RED}bad-key${NC}" ;;
+		spending_limit) status_display="${RED}spend-cap${NC}" ;;
 		no_key) status_display="${YELLOW}no-key${NC}" ;;
 		esac
 
@@ -1509,6 +1600,80 @@ cmd_invalidate() {
 	return 0
 }
 
+# Mark a provider as unavailable with a specific reason (GH#8229).
+# Called by headless-runtime-helper.sh when a worker detects a spending limit
+# or other billing error at runtime. This writes directly to the availability
+# cache so subsequent resolve_tier() calls skip this provider.
+#
+# Usage: model-availability-helper.sh mark-unavailable <provider> <reason> [--ttl N]
+# Reasons: spending_limit, billing_error, quota_exceeded, key_invalid, unhealthy
+cmd_mark_unavailable() {
+	local provider="${1:-}"
+	local reason="${2:-unhealthy}"
+	local ttl_override=""
+	shift 2 || true
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--ttl)
+			ttl_override="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$provider" ]]; then
+		print_error "Usage: model-availability-helper.sh mark-unavailable <provider> <reason> [--ttl N]"
+		return 1
+	fi
+
+	local status="$reason"
+	local error_msg="Marked unavailable: $reason"
+	local ttl="${ttl_override:-$DEFAULT_HEALTH_TTL}"
+
+	# Spending limits get a longer TTL (1 hour) since they reset monthly
+	if [[ "$reason" == "spending_limit" && -z "$ttl_override" ]]; then
+		ttl=3600
+	fi
+
+	db_query "
+		INSERT INTO provider_health (provider, status, http_code, response_ms, error_message, models_count, checked_at, ttl_seconds)
+		VALUES (
+			'$(sql_escape "$provider")',
+			'$(sql_escape "$status")',
+			0,
+			0,
+			'$(sql_escape "$error_msg")',
+			0,
+			strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
+			$ttl
+		)
+		ON CONFLICT(provider) DO UPDATE SET
+			status = excluded.status,
+			http_code = excluded.http_code,
+			response_ms = excluded.response_ms,
+			error_message = excluded.error_message,
+			models_count = excluded.models_count,
+			checked_at = excluded.checked_at,
+			ttl_seconds = excluded.ttl_seconds;
+	" || true
+
+	db_query "
+		INSERT INTO probe_log (provider, action, result, duration_ms, details)
+		VALUES (
+			'$(sql_escape "$provider")',
+			'mark_unavailable',
+			'$(sql_escape "$status")',
+			0,
+			'$(sql_escape "$error_msg")'
+		);
+	" || true
+
+	print_info "$provider: marked as $status (TTL: ${ttl}s)"
+	return 0
+}
+
 # Resolve using the full fallback chain (t132.4).
 # Delegates to fallback-chain-helper.sh for extended chain resolution
 # including gateway providers and per-agent overrides.
@@ -1578,12 +1743,13 @@ cmd_help() {
 	echo "Usage: model-availability-helper.sh [command] [options]"
 	echo ""
 	echo "Commands:"
-	echo "  check <provider|model|tier>  Check availability (exit 0=yes, 1=no, 2=rate-limited, 3=bad-key)"
+	echo "  check <provider|model|tier>  Check availability (exit 0=yes, 1=no, 2=rate-limited, 3=bad-key, 4=spending-limit)"
 	echo "  probe [provider] [--all]     Probe providers (default: only those with keys)"
 	echo "  status                       Show cached availability status"
 	echo "  rate-limits                  Show rate limit data from cache"
 	echo "  resolve <tier>               Resolve best available model for tier (primary + fallback)"
 	echo "  resolve-chain <tier>         Resolve via full fallback chain (t132.4, includes gateways)"
+	echo "  mark-unavailable <prov> <reason>  Mark provider unavailable (GH#8229, called by headless-runtime)"
 	echo "  invalidate [provider]        Clear cache (all or specific provider)"
 	echo "  help                         Show this help"
 	echo ""
@@ -1639,6 +1805,7 @@ cmd_help() {
 	echo "  1 - Unavailable or error"
 	echo "  2 - Rate limited"
 	echo "  3 - API key invalid or missing"
+	echo "  4 - Spending/billing limit reached"
 	echo ""
 	echo "Cache: $AVAILABILITY_DB"
 	echo "OpenCode models: $OPENCODE_MODELS_CACHE"
@@ -1678,6 +1845,9 @@ main() {
 		;;
 	resolve-chain | resolve_chain)
 		cmd_resolve_chain "$@"
+		;;
+	mark-unavailable | mark_unavailable)
+		cmd_mark_unavailable "$@"
 		;;
 	invalidate | clear | flush)
 		cmd_invalidate "$@"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -61,6 +61,32 @@ readonly ERROR_API_KEY_MISSING="API key is missing or invalid"
 readonly ERROR_INVALID_CREDENTIALS="Invalid credentials"
 
 # =============================================================================
+# Spending / Billing Limit Detection (GH#8229)
+# =============================================================================
+# Shared function used by model-availability-helper.sh and headless-runtime-helper.sh
+# to detect spending/billing limit errors in API response bodies.
+# Centralised here to avoid duplication between the two scripts.
+
+# Check if a (lowercased) string contains a spending/billing limit error pattern.
+# Caller must lowercase the input before passing it.
+# Returns 0 if spending limit detected, 1 otherwise.
+is_spending_limit_error() {
+	local lowered="$1"
+	case "$lowered" in
+	*monthlylimiterror* | *"monthly spending limit"* | *"monthly limit"*)
+		return 0
+		;;
+	*"spending limit"* | *"billing limit"* | *"budget exceeded"*)
+		return 0
+		;;
+	*"quota exceeded"* | *"usage limit"* | *"credits exhausted"*)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+# =============================================================================
 # Success Messages
 # =============================================================================
 

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -480,6 +480,7 @@ section "Spending Limit Detection (GH#8229)"
 
 # Test classify_failure_reason detects MonthlyLimitError
 SPENDING_TMP=$(mktemp)
+# shellcheck disable=SC2016  # $300 is a literal dollar amount, not a variable
 printf '{"error":{"type":"MonthlyLimitError","message":"Your workspace has reached its monthly spending limit of $300"}}' >"$SPENDING_TMP"
 # Source the helper to get classify_failure_reason (need to avoid main execution)
 # Instead, call the helper's classify function indirectly via a subshell

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -473,6 +473,65 @@ else
 	pass "sourcing sandbox-exec-helper.sh with watchdog args does not print help text (GH#6617)"
 fi
 
+# ============================================================
+# Spending Limit Detection (GH#8229)
+# ============================================================
+section "Spending Limit Detection (GH#8229)"
+
+# Test classify_failure_reason detects MonthlyLimitError
+SPENDING_TMP=$(mktemp)
+printf '{"error":{"type":"MonthlyLimitError","message":"Your workspace has reached its monthly spending limit of $300"}}' >"$SPENDING_TMP"
+# Source the helper to get classify_failure_reason (need to avoid main execution)
+# Instead, call the helper's classify function indirectly via a subshell
+spending_reason=$(
+	bash -c '
+		source "'"$REPO_DIR"'/.agents/scripts/shared-constants.sh" 2>/dev/null || true
+		init_log_file 2>/dev/null || true
+		# Extract and source just the classify function
+		eval "$(sed -n "/^classify_failure_reason/,/^}/p" "'"$HELPER"'")"
+		classify_failure_reason "'"$SPENDING_TMP"'"
+	' 2>/dev/null
+) || spending_reason=""
+if [[ "$spending_reason" == "spending_limit" ]]; then
+	pass "classify_failure_reason detects MonthlyLimitError as spending_limit"
+else
+	fail "classify_failure_reason detects MonthlyLimitError as spending_limit" "Got: $spending_reason"
+fi
+
+# Test classify_failure_reason detects generic spending limit
+printf 'Error: Your account has reached its spending limit. Please upgrade your plan.' >"$SPENDING_TMP"
+spending_reason2=$(
+	bash -c '
+		source "'"$REPO_DIR"'/.agents/scripts/shared-constants.sh" 2>/dev/null || true
+		init_log_file 2>/dev/null || true
+		eval "$(sed -n "/^classify_failure_reason/,/^}/p" "'"$HELPER"'")"
+		classify_failure_reason "'"$SPENDING_TMP"'"
+	' 2>/dev/null
+) || spending_reason2=""
+if [[ "$spending_reason2" == "spending_limit" ]]; then
+	pass "classify_failure_reason detects generic 'spending limit' text"
+else
+	fail "classify_failure_reason detects generic 'spending limit' text" "Got: $spending_reason2"
+fi
+
+# Test that a regular 401 auth error is NOT classified as spending_limit
+printf '{"error":{"type":"authentication_error","message":"Invalid API key"}}' >"$SPENDING_TMP"
+auth_reason=$(
+	bash -c '
+		source "'"$REPO_DIR"'/.agents/scripts/shared-constants.sh" 2>/dev/null || true
+		init_log_file 2>/dev/null || true
+		eval "$(sed -n "/^classify_failure_reason/,/^}/p" "'"$HELPER"'")"
+		classify_failure_reason "'"$SPENDING_TMP"'"
+	' 2>/dev/null
+) || auth_reason=""
+if [[ "$auth_reason" == "auth_error" ]]; then
+	pass "classify_failure_reason correctly classifies auth_error (not spending_limit)"
+else
+	fail "classify_failure_reason correctly classifies auth_error (not spending_limit)" "Got: $auth_reason"
+fi
+
+rm -f "$SPENDING_TMP"
+
 echo ""
 printf "Total: %d, Passed: %d, Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
 

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -19,20 +19,20 @@ VERBOSE="${1:-}"
 # Portable timeout: gtimeout (macOS homebrew) > timeout (Linux) > none
 TIMEOUT_CMD=""
 if command -v gtimeout &>/dev/null; then
-    TIMEOUT_CMD="gtimeout"
+	TIMEOUT_CMD="gtimeout"
 elif command -v timeout &>/dev/null; then
-    TIMEOUT_CMD="timeout"
+	TIMEOUT_CMD="timeout"
 fi
 
 # Run a command with optional timeout
 run_with_timeout() {
-    local secs="$1"
-    shift
-    if [[ -n "$TIMEOUT_CMD" ]]; then
-        "$TIMEOUT_CMD" "$secs" "$@"
-    else
-        "$@"
-    fi
+	local secs="$1"
+	shift
+	if [[ -n "$TIMEOUT_CMD" ]]; then
+		"$TIMEOUT_CMD" "$secs" "$@"
+	else
+		"$@"
+	fi
 }
 
 # --- Test Framework ---
@@ -42,36 +42,36 @@ SKIP_COUNT=0
 TOTAL_COUNT=0
 
 pass() {
-    PASS_COUNT=$((PASS_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    if [[ "$VERBOSE" == "--verbose" ]]; then
-        printf "  \033[0;32mPASS\033[0m %s\n" "$1"
-    fi
-    return 0
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	if [[ "$VERBOSE" == "--verbose" ]]; then
+		printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	fi
+	return 0
 }
 
 fail() {
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
-    if [[ -n "${2:-}" ]]; then
-        printf "       %s\n" "$2"
-    fi
-    return 0
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
+	return 0
 }
 
 skip() {
-    SKIP_COUNT=$((SKIP_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    if [[ "$VERBOSE" == "--verbose" ]]; then
-        printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
-    fi
-    return 0
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	if [[ "$VERBOSE" == "--verbose" ]]; then
+		printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	fi
+	return 0
 }
 
 section() {
-    echo ""
-    printf "\033[1m=== %s ===\033[0m\n" "$1"
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
 }
 
 # Use a temp DB for testing to avoid polluting real cache
@@ -86,55 +86,55 @@ section "Basic Validation"
 
 # Syntax check
 if bash -n "$HELPER" 2>/dev/null; then
-    pass "bash -n syntax check"
+	pass "bash -n syntax check"
 else
-    fail "bash -n syntax check" "Script has syntax errors"
+	fail "bash -n syntax check" "Script has syntax errors"
 fi
 
 # ShellCheck
 if command -v shellcheck &>/dev/null; then
-    sc_output=$(shellcheck "$HELPER" 2>&1 || true)
-    sc_errors=$(echo "$sc_output" | grep -c "error" 2>/dev/null || true)
-    if [[ "$sc_errors" -eq 0 ]]; then
-        pass "shellcheck (0 errors)"
-    else
-        fail "shellcheck ($sc_errors errors)" "$(echo "$sc_output" | head -5)"
-    fi
+	sc_output=$(shellcheck "$HELPER" 2>&1 || true)
+	sc_errors=$(echo "$sc_output" | grep -c "error" 2>/dev/null || true)
+	if [[ "$sc_errors" -eq 0 ]]; then
+		pass "shellcheck (0 errors)"
+	else
+		fail "shellcheck ($sc_errors errors)" "$(echo "$sc_output" | head -5)"
+	fi
 else
-    skip "shellcheck not installed"
+	skip "shellcheck not installed"
 fi
 
 # Help command
 help_output=$(run_with_timeout 5 bash "$HELPER" help 2>&1) || true
 if [[ -n "$help_output" ]]; then
-    pass "help command produces output"
+	pass "help command produces output"
 else
-    fail "help command produces output" "No output"
+	fail "help command produces output" "No output"
 fi
 
 # Help mentions key commands
 if echo "$help_output" | grep -qi "check"; then
-    pass "help mentions 'check' command"
+	pass "help mentions 'check' command"
 else
-    fail "help mentions 'check' command"
+	fail "help mentions 'check' command"
 fi
 
 if echo "$help_output" | grep -qi "probe"; then
-    pass "help mentions 'probe' command"
+	pass "help mentions 'probe' command"
 else
-    fail "help mentions 'probe' command"
+	fail "help mentions 'probe' command"
 fi
 
 if echo "$help_output" | grep -qi "resolve"; then
-    pass "help mentions 'resolve' command"
+	pass "help mentions 'resolve' command"
 else
-    fail "help mentions 'resolve' command"
+	fail "help mentions 'resolve' command"
 fi
 
 if echo "$help_output" | grep -qi "rate-limits"; then
-    pass "help mentions 'rate-limits' command"
+	pass "help mentions 'rate-limits' command"
 else
-    fail "help mentions 'rate-limits' command"
+	fail "help mentions 'rate-limits' command"
 fi
 
 # ============================================================
@@ -144,9 +144,9 @@ section "Status Command (Empty State)"
 
 status_output=$(run_with_timeout 5 bash "$HELPER" status 2>&1) || true
 if [[ -n "$status_output" ]]; then
-    pass "status command runs without error"
+	pass "status command runs without error"
 else
-    fail "status command runs without error" "No output or error"
+	fail "status command runs without error" "No output or error"
 fi
 
 # ============================================================
@@ -156,22 +156,22 @@ section "Tier Resolution"
 
 # Test that resolve returns a model spec for known tiers
 for tier in haiku flash sonnet pro opus health eval coding; do
-    resolve_output=$(run_with_timeout 15 bash "$HELPER" resolve "$tier" --quiet 2>&1) || true
-    # Even without API keys, resolve should return the primary model
-    # (it falls through to the primary when no probe is possible)
-    if [[ -n "$resolve_output" && "$resolve_output" == *"/"* ]]; then
-        pass "resolve $tier -> $resolve_output"
-    else
-        # May fail if no API keys configured - that's OK for CI
-        skip "resolve $tier (no API keys or provider unavailable)"
-    fi
+	resolve_output=$(run_with_timeout 15 bash "$HELPER" resolve "$tier" --quiet 2>&1) || true
+	# Even without API keys, resolve should return the primary model
+	# (it falls through to the primary when no probe is possible)
+	if [[ -n "$resolve_output" && "$resolve_output" == *"/"* ]]; then
+		pass "resolve $tier -> $resolve_output"
+	else
+		# May fail if no API keys configured - that's OK for CI
+		skip "resolve $tier (no API keys or provider unavailable)"
+	fi
 done
 
 # Test unknown tier (use || true to prevent set -e from aborting on expected failure)
 if run_with_timeout 5 bash "$HELPER" resolve "nonexistent" --quiet >/dev/null 2>&1; then
-    fail "resolve unknown tier returns error" "Expected non-zero exit"
+	fail "resolve unknown tier returns error" "Expected non-zero exit"
 else
-    pass "resolve unknown tier returns error"
+	pass "resolve unknown tier returns error"
 fi
 
 # ============================================================
@@ -181,23 +181,23 @@ section "Check Command"
 
 # Check with unknown provider (use if to prevent set -e from aborting on expected failure)
 if run_with_timeout 5 bash "$HELPER" check "nonexistent_provider_xyz" --quiet >/dev/null 2>&1; then
-    fail "check unknown target returns error" "Expected non-zero exit, got 0"
+	fail "check unknown target returns error" "Expected non-zero exit, got 0"
 else
-    pass "check unknown target returns error"
+	pass "check unknown target returns error"
 fi
 
 # Check with known provider (may succeed or fail depending on keys)
 # Use || true to prevent set -e from aborting on non-zero exit
 for provider in anthropic openai google opencode; do
-    check_exit=0
-    run_with_timeout 15 bash "$HELPER" check "$provider" --quiet >/dev/null 2>&1 || check_exit=$?
-    case "$check_exit" in
-        0) pass "check $provider: healthy" ;;
-        1) pass "check $provider: unhealthy (expected without key or CLI)" ;;
-        2) pass "check $provider: rate limited" ;;
-        3) pass "check $provider: no key (expected in CI)" ;;
-        *) fail "check $provider: unexpected exit code $check_exit" ;;
-    esac
+	check_exit=0
+	run_with_timeout 15 bash "$HELPER" check "$provider" --quiet >/dev/null 2>&1 || check_exit=$?
+	case "$check_exit" in
+	0) pass "check $provider: healthy" ;;
+	1) pass "check $provider: unhealthy (expected without key or CLI)" ;;
+	2) pass "check $provider: rate limited" ;;
+	3) pass "check $provider: no key (expected in CI)" ;;
+	*) fail "check $provider: unexpected exit code $check_exit" ;;
+	esac
 done
 
 # ============================================================
@@ -208,17 +208,17 @@ section "Cache Invalidation"
 run_with_timeout 5 bash "$HELPER" invalidate >/dev/null 2>&1
 invalidate_exit=$?
 if [[ $invalidate_exit -eq 0 ]]; then
-    pass "invalidate all caches"
+	pass "invalidate all caches"
 else
-    fail "invalidate all caches" "Exit code: $invalidate_exit"
+	fail "invalidate all caches" "Exit code: $invalidate_exit"
 fi
 
 run_with_timeout 5 bash "$HELPER" invalidate anthropic >/dev/null 2>&1
 invalidate_prov_exit=$?
 if [[ $invalidate_prov_exit -eq 0 ]]; then
-    pass "invalidate specific provider cache"
+	pass "invalidate specific provider cache"
 else
-    fail "invalidate specific provider cache" "Exit code: $invalidate_prov_exit"
+	fail "invalidate specific provider cache" "Exit code: $invalidate_prov_exit"
 fi
 
 # ============================================================
@@ -228,30 +228,30 @@ section "Supervisor Integration"
 
 # Verify supervisor references the availability helper
 if grep -q "model-availability-helper.sh" "$SUPERVISOR"; then
-    pass "supervisor references model-availability-helper.sh"
+	pass "supervisor references model-availability-helper.sh"
 else
-    fail "supervisor references model-availability-helper.sh"
+	fail "supervisor references model-availability-helper.sh"
 fi
 
 # Verify resolve_model() has availability helper fast path
 if grep -q "availability_helper.*resolve" "$SUPERVISOR"; then
-    pass "resolve_model() uses availability helper"
+	pass "resolve_model() uses availability helper"
 else
-    fail "resolve_model() uses availability helper"
+	fail "resolve_model() uses availability helper"
 fi
 
 # Verify check_model_health() has availability helper fast path
 if grep -q "availability_helper.*check" "$SUPERVISOR"; then
-    pass "check_model_health() uses availability helper fast path"
+	pass "check_model_health() uses availability helper fast path"
 else
-    fail "check_model_health() uses availability helper fast path"
+	fail "check_model_health() uses availability helper fast path"
 fi
 
 # Verify check_model_health() still has CLI fallback
 if grep -q 'health-check' "$SUPERVISOR"; then
-    pass "check_model_health() retains CLI fallback (slow path)"
+	pass "check_model_health() retains CLI fallback (slow path)"
 else
-    fail "check_model_health() retains CLI fallback (slow path)"
+	fail "check_model_health() retains CLI fallback (slow path)"
 fi
 
 # ============================================================
@@ -261,52 +261,125 @@ section "OpenCode Integration"
 
 # Verify opencode is a known provider
 if bash "$HELPER" help 2>&1 | grep -q "opencode"; then
-    pass "help mentions opencode provider"
+	pass "help mentions opencode provider"
 else
-    fail "help mentions opencode provider"
+	fail "help mentions opencode provider"
 fi
 
 # Check opencode provider (should succeed if CLI installed, fail gracefully otherwise)
 check_oc_exit=0
 run_with_timeout 10 bash "$HELPER" check opencode --quiet >/dev/null 2>&1 || check_oc_exit=$?
 case "$check_oc_exit" in
-    0) pass "check opencode: healthy (CLI and cache available)" ;;
-    1) pass "check opencode: unhealthy (CLI or cache not available)" ;;
-    *) fail "check opencode: unexpected exit code $check_oc_exit" ;;
+0) pass "check opencode: healthy (CLI and cache available)" ;;
+1) pass "check opencode: unhealthy (CLI or cache not available)" ;;
+*) fail "check opencode: unexpected exit code $check_oc_exit" ;;
 esac
 
 # Verify opencode model check (if opencode is available)
 if command -v opencode &>/dev/null && [[ -f "$HOME/.cache/opencode/models.json" ]]; then
-    oc_model_exit=0
-    run_with_timeout 10 bash "$HELPER" check "opencode/claude-sonnet-4" --quiet >/dev/null 2>&1 || oc_model_exit=$?
-    case "$oc_model_exit" in
-        0) pass "check opencode/claude-sonnet-4: available" ;;
-        1) pass "check opencode/claude-sonnet-4: not available (provider unhealthy)" ;;
-        *) fail "check opencode/claude-sonnet-4: unexpected exit code $oc_model_exit" ;;
-    esac
+	oc_model_exit=0
+	run_with_timeout 10 bash "$HELPER" check "opencode/claude-sonnet-4" --quiet >/dev/null 2>&1 || oc_model_exit=$?
+	case "$oc_model_exit" in
+	0) pass "check opencode/claude-sonnet-4: available" ;;
+	1) pass "check opencode/claude-sonnet-4: not available (provider unhealthy)" ;;
+	*) fail "check opencode/claude-sonnet-4: unexpected exit code $oc_model_exit" ;;
+	esac
 else
-    skip "opencode model check (opencode CLI not installed)"
+	skip "opencode model check (opencode CLI not installed)"
 fi
 
 # ============================================================
-# SECTION 8: JSON output
+# SECTION 8: Spending Limit Detection (GH#8229)
+# ============================================================
+section "Spending Limit Detection (GH#8229)"
+
+# Test _is_spending_limit_error via mark-unavailable + check round-trip
+# Mark opencode as spending_limit, then verify check returns exit 4
+run_with_timeout 5 bash "$HELPER" mark-unavailable opencode spending_limit --ttl 60 >/dev/null 2>&1
+mark_exit=$?
+if [[ $mark_exit -eq 0 ]]; then
+	pass "mark-unavailable opencode spending_limit"
+else
+	fail "mark-unavailable opencode spending_limit" "Exit code: $mark_exit"
+fi
+
+# Check should now return exit 4 (spending_limit) from cache
+check_sl_exit=0
+run_with_timeout 5 bash "$HELPER" check opencode --quiet >/dev/null 2>&1 || check_sl_exit=$?
+if [[ $check_sl_exit -eq 4 ]]; then
+	pass "check opencode returns exit 4 after mark-unavailable spending_limit"
+else
+	fail "check opencode returns exit 4 after mark-unavailable spending_limit" "Got exit code: $check_sl_exit"
+fi
+
+# Invalidate and verify it clears
+run_with_timeout 5 bash "$HELPER" invalidate opencode >/dev/null 2>&1
+check_after_clear=0
+run_with_timeout 5 bash "$HELPER" check opencode --quiet >/dev/null 2>&1 || check_after_clear=$?
+if [[ $check_after_clear -ne 4 ]]; then
+	pass "invalidate clears spending_limit status"
+else
+	fail "invalidate clears spending_limit status" "Still returning exit 4 after invalidate"
+fi
+
+# Test mark-unavailable with no args returns error
+if run_with_timeout 5 bash "$HELPER" mark-unavailable 2>/dev/null; then
+	fail "mark-unavailable with no args returns error" "Expected non-zero exit"
+else
+	pass "mark-unavailable with no args returns error"
+fi
+
+# Test mark-unavailable with custom TTL
+run_with_timeout 5 bash "$HELPER" mark-unavailable anthropic spending_limit --ttl 120 >/dev/null 2>&1
+mark_ttl_exit=$?
+if [[ $mark_ttl_exit -eq 0 ]]; then
+	pass "mark-unavailable with custom TTL"
+else
+	fail "mark-unavailable with custom TTL" "Exit code: $mark_ttl_exit"
+fi
+# Clean up
+run_with_timeout 5 bash "$HELPER" invalidate anthropic >/dev/null 2>&1
+
+# Test help mentions spending limit
+if echo "$help_output" | grep -qi "spending"; then
+	pass "help mentions spending limit"
+else
+	fail "help mentions spending limit"
+fi
+
+# Test help mentions mark-unavailable
+if echo "$help_output" | grep -qi "mark-unavailable"; then
+	pass "help mentions mark-unavailable command"
+else
+	fail "help mentions mark-unavailable command"
+fi
+
+# Test exit code 4 is documented in help
+if echo "$help_output" | grep -q "4"; then
+	pass "help documents exit code 4"
+else
+	fail "help documents exit code 4"
+fi
+
+# ============================================================
+# SECTION 9: JSON output
 # ============================================================
 section "JSON Output"
 
 # Status --json
 json_status=$(run_with_timeout 5 bash "$HELPER" status --json 2>&1) || true
 if echo "$json_status" | grep -q "{" 2>/dev/null; then
-    pass "status --json produces JSON"
+	pass "status --json produces JSON"
 else
-    skip "status --json (no data to format)"
+	skip "status --json (no data to format)"
 fi
 
 # Resolve --json
 json_resolve=$(run_with_timeout 15 bash "$HELPER" resolve sonnet --json --quiet 2>&1) || true
 if echo "$json_resolve" | grep -q "tier" 2>/dev/null; then
-    pass "resolve --json produces JSON with tier field"
+	pass "resolve --json produces JSON with tier field"
 else
-    skip "resolve --json (provider may be unavailable)"
+	skip "resolve --json (provider may be unavailable)"
 fi
 
 # ============================================================
@@ -315,15 +388,15 @@ fi
 echo ""
 echo "========================================"
 printf "  \033[1mResults: %d total, \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m, \033[0;33m%d skipped\033[0m\n" \
-    "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+	"$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
 echo "========================================"
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
-    echo ""
-    printf "\033[0;31mFAILURES DETECTED - review output above\033[0m\n"
-    exit 1
+	echo ""
+	printf "\033[0;31mFAILURES DETECTED - review output above\033[0m\n"
+	exit 1
 else
-    echo ""
-    printf "\033[0;32mAll tests passed.\033[0m\n"
-    exit 0
+	echo ""
+	printf "\033[0;32mAll tests passed.\033[0m\n"
+	exit 0
 fi


### PR DESCRIPTION
## Summary

- Add spending/billing limit detection to `model-availability-helper.sh` and `headless-runtime-helper.sh` so the pulse stops dispatching workers to spending-capped providers
- The OpenCode availability check now makes a live API probe (in addition to the models cache check) to detect `MonthlyLimitError` and similar billing errors
- When a worker fails with a spending limit, the provider is marked unavailable in both the backoff table and the availability cache, causing `resolve_tier()` to fall back to the next provider

Closes #8229

## What Changed

### `model-availability-helper.sh`
- **`_is_spending_limit_error()`** — detects MonthlyLimitError, spending limit, billing limit, quota exceeded, credits exhausted in response bodies
- **`_probe_opencode()`** — now does a two-phase check: (1) local models cache, (2) live API probe to catch spending limits that the cache can't detect
- **`_probe_parse_http_response()`** — distinguishes spending limits from auth errors on 401 responses (spending limit = exit 4, auth error = exit 3)
- **`cmd_mark_unavailable`** — new command for external callers (headless-runtime) to mark a provider as unavailable with a reason and TTL
- **`_probe_return_cached()`** — handles `spending_limit` cached status (exit 4)
- **Status display** — shows `spend-cap` in red for spending-limited providers
- **Exit code 4** — new exit code for spending/billing limit reached

### `headless-runtime-helper.sh`
- **`classify_failure_reason()`** — detects `spending_limit` before `auth_error` (both return 401, but spending limits have distinct error bodies)
- **`record_provider_backoff()`** — spending limits back off at provider level (like auth errors) with 1-hour TTL; cross-writes to model-availability cache via `mark-unavailable`

### Tests
- 8 new tests in `test-model-availability.sh`: mark-unavailable round-trip, exit code 4 verification, cache invalidation, help text coverage
- 3 new tests in `test-headless-runtime-helper.sh`: MonthlyLimitError detection, generic spending limit detection, auth error distinction

## Runtime Testing

- **Testing level:** `unit-tested`
- **Risk classification:** Medium (billing detection logic, no data mutation)
- All 8 new model-availability tests pass (8/8)
- All 3 new headless-runtime tests pass (32/32 total)
- ShellCheck: 0 errors on all modified files
- Pre-existing test failures (4 supervisor-helper.sh, 1 help grep) unchanged