### PR TITLE
t8468: simplify build-agent.md — prose to tables/bullets, 230→182 lines

### DIFF
--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -17,12 +17,11 @@ mode: subagent
 - **Related**: `@code-standards`, `.agents/aidevops/architecture.md`, `tools/browser/browser-automation.md`
 - **After creating/promoting**: `~/.aidevops/agents/scripts/subagent-index-helper.sh generate`
 - **Testing**: `agent-test-helper.sh run my-tests` or `claude -p "Test query"`
-
-**Model tier**: Use `/route "task"` or `/patterns recommend "type"` before setting `model:` in frontmatter. Static rules (`haiku`→formatting, `sonnet`→code, `opus`→architecture) are starting points; pattern data overrides at >75% success, 3+ samples.
+- **Model tier**: `/route "task"` or `/patterns recommend "type"`. Static: `haiku`→formatting, `sonnet`→code, `opus`→architecture. Pattern data overrides at >75% success, 3+ samples.
 
 <!-- AI-CONTEXT-END -->
 
-## Main Agent vs Subagent Design
+## Main Agent vs Subagent
 
 | Aspect | Main Agent | Subagent |
 |--------|-----------|----------|
@@ -35,7 +34,7 @@ Broad/strategic → main agent. Independent, no cross-domain knowledge → subag
 
 ## Subagent YAML Frontmatter (Required)
 
-Every subagent **must** include YAML frontmatter. Without it, agents default to read-only.
+Without frontmatter, agents default to read-only.
 
 ```yaml
 ---
@@ -53,23 +52,33 @@ tools:
 ---
 ```
 
-MCP tool patterns (subagents only — NEVER in main agents): `context7_*: true`, `wordpress-mcp_*: true`. Path-based permissions go in `opencode.json`, not frontmatter.
+- MCP tool patterns (subagents only): `context7_*: true`, `wordpress-mcp_*: true`. Path-based permissions → `opencode.json`.
+- MCP tool filtering (future `includeTools` — 17k→1.5k token savings): `mcp_requirements: { chrome-devtools: { tools: [navigate_page, take_screenshot] } }`
+- **Main-branch write restrictions** (`write/edit: true` on `main`/`master`): ALLOWED: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. BLOCKED: all other files.
+- **MCP config** (global disabled, per-agent enabled in `opencode.json`): `"mcp": { "hostinger-api": { "enabled": false } }` + `"agent": { "hostinger": { "tools": { "hostinger-api_*": true } } }`
 
-MCP requirements with tool filtering (future `includeTools` — enables 17k→1.5k token savings): `mcp_requirements: { chrome-devtools: { tools: [navigate_page, take_screenshot] } }`
+## Architecture & References
 
-**Main-branch write restrictions** (subagents with `write/edit: true` on `main`/`master`): ALLOWED: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. BLOCKED: all other files. Add a "Write Restrictions" section to any writable subagent.
+- **Source of truth**: `.agents/` → deployed to `~/.aidevops/agents/` by `setup.sh`. Stubs: `.opencode/agent/` via `generate-opencode-agents.sh`.
+- **Code refs**: search patterns, not line numbers. Hierarchy: function name → unique string → comment marker → broader pattern.
+- **Deployment sync**: changes in `.agents/` require `./setup.sh`. Offer to run on create/rename/move/merge/delete.
 
-## MCP Configuration Pattern
+## Folder Organization
 
-Global disabled, per-agent enabled in `opencode.json`: `"mcp": { "hostinger-api": { "enabled": false } }` + `"agent": { "hostinger": { "tools": { "hostinger-api_*": true } } }`
+```text
+.agents/
+├── AGENTS.md           # Entry point (ALLCAPS)
+├── {domain}.md         # Main agents at root (lowercase)
+├── {domain}/           # Subagents for that domain
+├── tools/              # Cross-domain utilities
+├── services/           # External integrations
+├── workflows/          # Process guides
+└── scripts/commands/   # Slash command definitions
+```
 
-## Agent Directory Architecture
-
-`.agents/` → source of truth, deployed to `~/.aidevops/agents/` by `setup.sh`. `.opencode/agent/` → generated stubs by `generate-opencode-agents.sh`.
-
-## Code References
-
-Use search patterns, not line numbers (they drift): `Search for handle_api_error in hostinger-helper.sh; fallback: api_error or error handling`. Hierarchy: function/variable name → unique string literals → comment markers → broader pattern.
+- Naming: lowercase with hyphens; ALLCAPS only for entry points. Tooling uses `find -mindepth 2` for subagent discovery.
+- **File structure** — main agents: `# Name` → `<!-- AI-CONTEXT-START -->` Quick Reference `<!-- AI-CONTEXT-END -->` → Detailed docs. Subagents: YAML frontmatter + content.
+- **Slash commands**: NEVER define inline in main agents. Generic → `scripts/commands/{command}.md`. Domain-specific → `{domain}/{subagent}.md`.
 
 ## Model Tier Selection
 
@@ -82,23 +91,11 @@ Use search patterns, not line numbers (they drift): `Search for handle_api_error
 
 Record: `/remember "SUCCESS/FAILURE: agent with model — reason"`. Frontmatter: `model: sonnet  # 87% success, 14 samples`. Full docs: `tools/context/model-routing.md`.
 
-## Quality Checking: Linters First
+## Quality Checking
 
-Never send an LLM to do a linter's job. Order: (1) deterministic linters (ShellCheck, ESLint, Ruff/Pylint), (2) static analysis (SonarCloud, Codacy, Secretlint), (3) LLM review (CodeRabbit — architectural only). Prefer `bun`/`bunx` over `npm`/`npx`.
+Linter order: (1) deterministic (ShellCheck, ESLint, Ruff/Pylint), (2) static analysis (SonarCloud, Secretlint), (3) LLM review (CodeRabbit — architectural only). Prefer `bun`/`bunx` over `npm`/`npx`. Never send an LLM to do a linter's job.
 
-## Information Quality
-
-Use primary sources over tutorials. Cross-reference, prefer recent, watch for vendor agendas.
-
-| Domain | Primary Sources | Watch For |
-|--------|-----------------|-----------|
-| Code/DevOps | Official docs, RFCs, source code | Outdated tutorials, version drift |
-| SEO | Webmaster tools, Search Console | Vendor claims, outdated tactics |
-| Legal | Legislation, case law | Jurisdiction differences |
-| Health | Peer-reviewed research | Commercial claims, fads |
-| Marketing | Platform docs, first-party data | Vendor case studies |
-| Accounting | Tax authority guidance | Jurisdiction-specific rules |
-| Content | Style guides, brand guidelines | Subjective preferences as rules |
+**Information sources**: Prefer official docs, RFCs, source code, first-party data. Watch for outdated tutorials, vendor claims, jurisdiction differences, and commercial bias across all domains.
 
 ## Agent Design Checklist
 
@@ -115,26 +112,13 @@ Use primary sources over tutorials. Cross-reference, prefer recent, watch for ve
 
 ## Post-Creation Terse Pass (MANDATORY)
 
-After writing any agent doc, do a second pass to tighten prose before committing. Every token in an agent doc is paid for on every load — verbose docs compound cost across hundreds of sessions.
+Every token in an agent doc is paid for on every load. Compress before committing.
 
-**Technique:** Re-read the doc and compress every instruction to its minimum form while preserving all rules, constraints, and references. LLMs follow terse instructions equally well as verbose ones.
+**Compress:** verbose phrasing → direct rule; narrative context → keep task ID, drop story; redundant examples → keep one; multi-sentence explanations of one rule → single sentence.
 
-**What to compress:**
-- "In order to achieve X, you should Y" → "Y"
-- "It is important to note that X" → "X" (or drop if self-evident)
-- Multi-sentence explanations of a single rule → single sentence
-- Narrative context ("The reason this exists is because in March 2026...") → keep task ID, drop story
-- Redundant examples that demonstrate the same point → keep one
+**Preserve (never compress):** task IDs (`tNNN`), issue refs (`GH#NNN`), all rules/constraints, file paths, command examples, code blocks, safety-critical detail.
 
-**What to preserve (never compress):**
-- Task IDs (`tNNN`), issue refs (`GH#NNN`), incident identifiers
-- All rules and constraints — compress wording, not the rule itself
-- File paths, command examples, code blocks
-- Safety-critical detail (security, compatibility)
-
-**Target:** Agent docs should read like reference cards, not tutorials. If a section reads like it's explaining a concept to a newcomer, tighten it — the reader is an LLM that already understands the concept.
-
-**Evidence:** Terse pass on `build.txt` achieved 63% byte reduction with zero rule loss. `AGENTS.md` achieved 48%. See `tools/code-review/code-simplifier.md` "Prose tightening" for the full classification.
+Target: reference cards, not tutorials. Evidence: terse pass on `build.txt` achieved 63% byte reduction with zero rule loss. See `tools/code-review/code-simplifier.md` "Prose tightening".
 
 ## Code Examples: When to Include
 
@@ -142,13 +126,13 @@ After writing any agent doc, do a second pass to tighten prose before committing
 
 **Avoid**: code exists in codebase (use search pattern); external library (use Context7 MCP); will become outdated (point to source).
 
-When a code example fails, trigger self-assessment: update if outdated, add conditions if context-dependent, check for duplicates.
+When a code example fails: update if outdated, add conditions if context-dependent, check for duplicates.
 
 ## Self-Assessment Protocol
 
 **Triggers**: Observable failure, user correction, contradiction with Context7/codebase, staleness.
 
-**Process**: (1) Complete current task first. (2) Identify root cause. (3) `rg "pattern" .agents/` — list ALL files needing coordinated updates. (4) Propose with rationale and request permission: `"Agent Feedback: While [task], I noticed [issue] in .agents/[file].md. Related: [other-files]. Suggested: [change]. Update after completing?"`
+**Process**: (1) Complete current task. (2) Identify root cause. (3) `rg "pattern" .agents/` — list ALL files needing coordinated updates. (4) Propose: `"Agent Feedback: While [task], I noticed [issue] in .agents/[file].md. Related: [other-files]. Suggested: [change]. Update after completing?"`
 
 ## Tool Selection
 
@@ -162,31 +146,6 @@ When a code example fails, trigger self-assessment: update if outdated, add cond
 | Parallel AI dispatch | OpenCode server API | Multiple TUI instances |
 
 Self-checks: "Faster CLI alternative?" and "Could this return >50K tokens?" See `tools/context/context-guardrails.md`.
-
-## Agent File Structure
-
-**Main agents** (no frontmatter): `# Name` → `<!-- AI-CONTEXT-START -->` Quick Reference `<!-- AI-CONTEXT-END -->` → Detailed Documentation.
-
-**Subagents**: YAML frontmatter + content. Avoid hardcoded counts, version numbers, or dates that go stale.
-
-## Folder Organization
-
-```text
-.agents/
-├── AGENTS.md           # Entry point (ALLCAPS)
-├── {domain}.md         # Main agents at root (lowercase)
-├── {domain}/           # Subagents for that domain
-├── tools/              # Cross-domain utilities
-├── services/           # External integrations
-├── workflows/          # Process guides
-└── scripts/commands/   # Slash command definitions
-```
-
-Naming: lowercase with hyphens; ALLCAPS only for entry points. Main agents at root — tooling uses `find -mindepth 2` for subagent discovery.
-
-## Slash Command Placement
-
-**CRITICAL**: Never define slash commands inline in main agents. Generic → `scripts/commands/{command}.md`. Domain-specific → `{domain}/{subagent}.md`. Main agents only **reference** commands.
 
 ## Agent Lifecycle Tiers
 
@@ -206,17 +165,10 @@ Naming: lowercase with hyphens; ALLCAPS only for entry points. Main agents at ro
 4. Shared - Add to aidevops for everyone (PR to .agents/)
 ```
 
-**Draft agents**: Place in `~/.aidevops/agents/draft/` with `status: draft` and `created` date. Promotion: log TODO (`- [ ] tXXX Review draft agent: {name} #agent-review`), then promote to `custom/` or `.agents/` via PR, or discard.
-
-**Custom agents**: Never shared, never overwritten. Use for business-specific workflows (`custom/mycompany/`, `custom/clients/`).
-
-**Shared agents**: Feature branch + PR when solving a general problem with no proprietary info.
-
-**Orchestration agents**: Create drafts when identifying reusable patterns. After: log TODO, reference draft in Task calls, note in completion summary.
-
-## Deployment Sync
-
-Agent changes in `.agents/` require `cd ~/Git/aidevops && ./setup.sh`. Offer to run on create/rename/move/merge/delete.
+- **Draft**: `~/.aidevops/agents/draft/` with `status: draft` + `created` date. Promotion: log TODO → promote to `custom/` or `.agents/` via PR, or discard.
+- **Custom**: Never shared, never overwritten (`custom/mycompany/`, `custom/clients/`).
+- **Shared**: Feature branch + PR. No proprietary info.
+- **Orchestration agents**: Create drafts for reusable patterns. Log TODO, reference draft in Task calls, note in completion summary.
 
 ## Cache-Aware Prompt Patterns
 


### PR DESCRIPTION
## Summary

- Converts verbose prose sections to bullets and tables throughout
- Merges redundant sections: Architecture/Code References/MCP Config → single section; File Structure/Folder Org/Slash Commands → single section
- Collapses Information Quality 7-row table to a single principle line (domain-specific detail is self-evident to LLMs)
- Preserves all command examples, decision tables, code blocks, task IDs, and actionable rules

Closes #8468