### PR TITLE
GH#8515: decompose oversized main() in progressive-load-check.sh

### DIFF
--- a/.agents/scripts/progressive-load-check.sh
+++ b/.agents/scripts/progressive-load-check.sh
@@ -92,23 +92,7 @@ check_inline_only() {
 	return 0
 }
 
-main() {
-	if [[ ! -f "$BUILD_TXT" ]]; then
-		printf "ERROR: build.txt not found at %s\n" "$BUILD_TXT" >&2
-		return 2
-	fi
-
-	if [[ ! -f "$AGENTS_MD" ]]; then
-		printf "ERROR: AGENTS.md not found at %s\n" "$AGENTS_MD" >&2
-		return 2
-	fi
-
-	[[ "$QUIET" != "--quiet" ]] && printf "Progressive Load Safety Check\n"
-	[[ "$QUIET" != "--quiet" ]] && printf "Source: %s\n" "$AGENTS_DIR"
-
-	# -------------------------------------------------------------------------
-	# build.txt extractions
-	# -------------------------------------------------------------------------
+check_build_txt_extractions() {
 	[[ "$QUIET" != "--quiet" ]] && printf "\n--- build.txt extractions ---"
 
 	check_extraction \
@@ -157,9 +141,10 @@ main() {
 		"$BUILD_TXT" \
 		"review-bot-gate-helper\.sh"
 
-	# -------------------------------------------------------------------------
-	# AGENTS.md extractions
-	# -------------------------------------------------------------------------
+	return 0
+}
+
+check_agents_md_extractions() {
 	[[ "$QUIET" != "--quiet" ]] && printf "\n--- AGENTS.md extractions ---"
 
 	check_extraction \
@@ -194,9 +179,10 @@ main() {
 		log_info "not yet extracted (open PR #6832) — still inline in AGENTS.md"
 	fi
 
-	# -------------------------------------------------------------------------
-	# Summary
-	# -------------------------------------------------------------------------
+	return 0
+}
+
+print_summary() {
 	printf "\n"
 	if [[ "$FAIL" -eq 0 ]]; then
 		printf "RESULT: PASS (%d checks passed, 0 failures)\n" "$PASS"
@@ -205,6 +191,25 @@ main() {
 		printf "RESULT: FAIL (%d passed, %d failed)\n" "$PASS" "$FAIL"
 		return 1
 	fi
+}
+
+main() {
+	if [[ ! -f "$BUILD_TXT" ]]; then
+		printf "ERROR: build.txt not found at %s\n" "$BUILD_TXT" >&2
+		return 2
+	fi
+
+	if [[ ! -f "$AGENTS_MD" ]]; then
+		printf "ERROR: AGENTS.md not found at %s\n" "$AGENTS_MD" >&2
+		return 2
+	fi
+
+	[[ "$QUIET" != "--quiet" ]] && printf "Progressive Load Safety Check\n"
+	[[ "$QUIET" != "--quiet" ]] && printf "Source: %s\n" "$AGENTS_DIR"
+
+	check_build_txt_extractions
+	check_agents_md_extractions
+	print_summary
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Breaks down the 113-line `main()` function in `.agents/scripts/progressive-load-check.sh` into three focused helper functions
- `main()` reduced from 113 lines to 18 lines; all functions now under 100 lines
- Pure refactor — no behaviour change, output is byte-identical

## Changes

| Function | Lines | Purpose |
|----------|-------|---------|
| `check_build_txt_extractions()` | 51 | All build.txt extraction + inline-only checks |
| `check_agents_md_extractions()` | 37 | All AGENTS.md extraction checks (domain index, self-improvement, agent routing) |
| `print_summary()` | 10 | Pass/fail result reporting |
| `main()` | 18 | Validation + header + orchestrates the three helpers |

## Verification

- `shellcheck` — clean (exit 0)
- `bash -n` — syntax OK
- Functional output — identical to pre-refactor baseline (10 pass, 4 fail — pre-existing)
- `--quiet` mode — works correctly
- Bash 3.2 compatible — no 4.0+ features used

## Runtime Testing

- **Testing level:** `self-assessed`
- **Risk classification:** Low (pure refactor, docs/script restructuring only)
- **Smoke check:** Script runs identically before and after

Closes #8515