### PR TITLE
t8768: simplify monetisation.md from 221 to 148 lines

### DIFF
--- a/.agents/product/monetisation.md
+++ b/.agents/product/monetisation.md
@@ -26,20 +26,11 @@ tools:
 **Revenue model decision tree**:
 
 ```text
-Product solves a daily recurring problem?
-  -> Subscription (weekly/monthly/annual)
-
-Product provides one-time value (tool, utility)?
-  -> One-time purchase or lifetime unlock
-
-Product has broad appeal but low willingness to pay?
-  -> Freemium with premium tier, or ad-supported
-
-Product drives users to another product/service?
-  -> Free (sales funnel / audience builder)
-
-Product can recommend relevant products?
-  -> Affiliate links + optional premium tier
+Product solves a daily recurring problem?      -> Subscription (weekly/monthly/annual)
+Product provides one-time value (tool/utility)? -> One-time purchase or lifetime unlock
+Broad appeal but low willingness to pay?        -> Freemium + premium tier, or ad-supported
+Product drives users to another offering?       -> Free (sales funnel / audience builder)
+Product can recommend relevant products?        -> Affiliate links + optional premium tier
 ```
 
 **Platform payment tools**:
@@ -55,39 +46,11 @@ Product can recommend relevant products?
 
 ## Subscription Management
 
-### RevenueCat (Mobile)
-
-RevenueCat is the recommended subscription management platform for mobile apps. It handles:
-
-- Cross-platform subscription state (iOS + Android)
-- Receipt validation and entitlement management
-- Analytics and cohort analysis
-- A/B testing paywalls (via Superwall or RevenueCat Paywalls)
-- Webhook integrations for backend sync
-
-See `services/payments/revenuecat.md` for detailed setup and SDK integration.
-
-### Stripe (Web, Desktop, Extensions)
-
-Stripe is the recommended payment platform for non-mobile products:
-
-- Subscription billing with Stripe Billing
-- One-time payments with Checkout
-- Customer portal for self-service management
-- Webhook integrations for entitlement sync
-
-See `services/payments/stripe.md` for detailed setup.
-
-### Superwall (Paywall A/B Testing)
-
-Superwall provides remote paywall configuration and A/B testing:
-
-- Change paywall design without app updates
-- Test different pricing, layouts, and copy
-- Trigger paywalls based on user behaviour
-- Works alongside RevenueCat or Stripe
-
-See `services/payments/superwall.md` for setup.
+| Provider | Use for | Details |
+|----------|---------|---------|
+| **RevenueCat** | Mobile (iOS + Android) | Cross-platform state, receipt validation, entitlements, A/B testing, webhooks. See `services/payments/revenuecat.md` |
+| **Stripe** | Web, desktop, extensions | Billing, Checkout, customer portal, webhook entitlement sync. See `services/payments/stripe.md` |
+| **Superwall** | Paywall A/B testing (any) | Remote paywall config, price/layout/copy testing, behaviour triggers. See `services/payments/superwall.md` |
 
 ## Entitlements Model
 
@@ -99,123 +62,87 @@ Products (what users buy)     -> Entitlements (what users get access to)
 └── Pro Add-on ($2.99/mo)     -> "pro" entitlement
 ```
 
-This model is platform-agnostic — whether you use RevenueCat, Stripe, or another provider, the entitlement concept is the same: users buy products, products grant entitlements, features check entitlements.
+Platform-agnostic: users buy products → products grant entitlements → features check entitlements.
 
 ## Paywall Design
 
-### Principles
-
-- Show paywall at the moment of highest intent (after user tries a premium feature)
-- Display clear value proposition (what they get, not what they pay)
+**Principles:**
+- Show at moment of highest intent (after user tries a premium feature)
+- Display value proposition (what they get, not what they pay)
 - Offer 3 tiers: weekly (highest per-unit), monthly (default), annual (best value)
-- Highlight the "best value" option visually
-- Include free trial option (3 or 7 days)
-- Show social proof (user count, ratings)
+- Highlight "best value" visually; include 3 or 7-day free trial; show social proof
 - "Restore Purchases" button must be accessible (mobile)
 
-### Paywall Placement
+**Placement by conversion rate:**
 
-| Trigger | Conversion Rate | Notes |
-|---------|----------------|-------|
-| After onboarding (hard paywall) | Medium-high | User hasn't experienced value but onboarding built intent |
+| Trigger | Conversion | Notes |
+|---------|-----------|-------|
 | Feature gate | High | User wants the feature NOW |
 | Usage limit | High | User has experienced value, wants more |
-| Settings/upgrade | Low | Only motivated users find it |
+| After onboarding (hard paywall) | Medium-high | Onboarding built intent |
 | Time-delayed | Medium | After N days of free use |
+| Settings/upgrade | Low | Only motivated users find it |
 
-See `product/onboarding.md` for the hard paywall pattern and when to use it.
+See `product/onboarding.md` for the hard paywall pattern.
 
-### Free Trial Strategy
-
-- 3-day trial: Higher conversion, lower retention
-- 7-day trial: Lower conversion, higher retention
-- No trial: Highest friction, but attracts committed users
-- Recommendation: 7-day trial for subscription products, no trial for one-time purchases
+**Free trial:**
+- 3-day: higher conversion, lower retention
+- 7-day: lower conversion, higher retention (recommended for subscriptions)
+- No trial: highest friction, attracts committed users; recommended for one-time purchases
 
 ## Alternative Revenue Models
 
-### Ad-Supported
-
-- **AdMob** (Google): Banner, interstitial, rewarded ads (mobile)
-- **Unity Ads**: Rewarded video (good for games)
-- **Carbon Ads**: Developer/tech audience (web, extensions)
-- Best for: High-volume, low willingness-to-pay products
-- Combine with premium tier to remove ads
-
-### Freemium
-
-- Core functionality free, premium features gated
-- Works well when free tier provides genuine value
-- Premium tier should feel like an upgrade, not a ransom
-
-### Affiliate
-
-- Recommend relevant products/services within the product
-- Use affiliate links for revenue share
-- Must be transparent about affiliate relationships
-- Works well for recommendation/review products
-
-### Sales Funnel
-
-- Product is free, drives users to paid service/product
-- Product builds audience and trust
-- Revenue comes from the external offering
-- Works well for consultants, coaches, SaaS products
+| Model | Best for | Notes |
+|-------|---------|-------|
+| **Ad-supported** | High-volume, low WTP | AdMob (mobile), Unity Ads (games), Carbon Ads (dev/tech web). Combine with premium tier to remove ads |
+| **Freemium** | Products with genuine free-tier value | Premium should feel like upgrade, not ransom |
+| **Affiliate** | Recommendation/review products | Transparent disclosure required; revenue share via affiliate links |
+| **Sales funnel** | Consultants, coaches, SaaS | Product is free; revenue from external offering it drives users toward |
 
 ## Pricing Strategy
 
-### Research-Based Pricing
-
+**Research process:**
 1. Check competitor pricing in relevant stores
 2. Survey target users on willingness to pay
-3. Start with competitive pricing, adjust based on data
-4. Annual plans should offer 15-40% discount vs monthly
+3. Start competitive, adjust based on data
+4. Annual plans: 15–40% discount vs monthly
 
-### Common Price Points
+**Common price points:**
 
 | Model | Typical Range |
 |-------|--------------|
-| Weekly | $2.99-$7.99 |
-| Monthly | $4.99-$14.99 |
-| Annual | $29.99-$79.99 |
-| Lifetime | $49.99-$149.99 |
-| One-time (extension/desktop) | $9.99-$49.99 |
+| Weekly | $2.99–$7.99 |
+| Monthly | $4.99–$14.99 |
+| Annual | $29.99–$79.99 |
+| Lifetime | $49.99–$149.99 |
+| One-time (extension/desktop) | $9.99–$49.99 |
 
-### A/B Testing
+**A/B testing:** Use RevenueCat Experiments, Superwall, or Stripe test mode to test price points, paywall designs, trial lengths, and feature gates.
 
-Use RevenueCat Experiments, Superwall, or Stripe's test mode to test:
+## Recurring Revenue Mental Model
 
-- Different price points
-- Different paywall designs
-- Different trial lengths
-- Different feature gates
-
-## The Recurring Revenue Mental Model
-
-Think of products as digital properties and users as tenants:
-
-- **Build once, sell forever** — unlike services, products don't require per-customer delivery
+- **Build once, sell forever** — unlike services, no per-customer delivery cost
 - **Subscription = recurring rent** — predictable monthly revenue that compounds
 - **Churn = vacancy** — reducing churn is as important as acquiring new users
-- **LTV > CAC** — lifetime value must exceed customer acquisition cost for sustainability
+- **LTV > CAC** — lifetime value must exceed customer acquisition cost
 
-This mental model applies across all product types. A browser extension with 10,000 subscribers at $3/month generates $30k/month with near-zero marginal cost per user.
+Example: 10,000 subscribers × $3/month = $30k/month with near-zero marginal cost per user.
 
 ## Legal Requirements
 
-- Clearly display subscription terms before purchase
+- Display subscription terms clearly before purchase
 - Show renewal price and frequency
 - Provide easy cancellation instructions
 - Include "Restore Purchases" for returning users (mobile)
 - Privacy policy must cover payment data handling
 - EULA required for subscription apps (mobile)
-- Comply with platform-specific payment rules (Apple's 3.1.1, Google's billing policy)
+- Comply with platform payment rules (Apple 3.1.1, Google billing policy)
 
 ## Related
 
-- `services/payments/revenuecat.md` - RevenueCat setup (mobile)
-- `services/payments/superwall.md` - Paywall A/B testing
-- `services/payments/stripe.md` - Stripe payments (web, desktop, extensions)
-- `product/onboarding.md` - Paywall placement in onboarding
-- `product/analytics.md` - Revenue analytics and optimisation
-- `product/growth.md` - User acquisition to feed the revenue funnel
+- `services/payments/revenuecat.md` — RevenueCat setup (mobile)
+- `services/payments/superwall.md` — Paywall A/B testing
+- `services/payments/stripe.md` — Stripe payments (web, desktop, extensions)
+- `product/onboarding.md` — Paywall placement in onboarding
+- `product/analytics.md` — Revenue analytics and optimisation
+- `product/growth.md` — User acquisition to feed the revenue funnel


### PR DESCRIPTION
## Summary

- Converted verbose prose sections to tables and bullets throughout
- Collapsed three separate provider prose sections (RevenueCat, Stripe, Superwall) into a single comparison table
- Merged four alternative revenue model sections into one table
- Preserved all decision trees, price point tables, paywall placement table, entitlements code block, legal requirements, and related links
- 221 → 148 lines (33% reduction)

## Runtime Testing

- **Risk**: Low (docs-only change)
- **Testing level**: self-assessed
- **Behaviour verified**: all code blocks, decision trees, tables, and cross-references present before and after

Closes #8768