### PR TITLE
fix: address CodeRabbit CHANGES_REQUESTED on PR #8493 (GH#7265)

### DIFF
--- a/.agents/content/production/video.md
+++ b/.agents/content/production/video.md
@@ -77,6 +77,6 @@ seed-bracket-helper.sh generate --type product --prompt "Product rotating on whi
 video-gen-helper.sh generate sora "A cat reading a book" sora-2-pro 8 1280x720
 video-gen-helper.sh generate veo "Cinematic mountain sunset" veo-3.1-generate-001 16:9
 
-# Post-production
-real-video-enhancer-helper.sh enhance input.mp4 output.mp4 --scale 2 --fps 60 --denoise
+# Post-production (use --fps 60 for action footage; keep cinematic/non-action closer to source fps)
+real-video-enhancer-helper.sh enhance input.mp4 output.mp4 --scale 2 --fps 30 --denoise
 ```

--- a/.agents/content/production/video/01-model-selection.md
+++ b/.agents/content/production/video/01-model-selection.md
@@ -33,3 +33,5 @@ Content Type?
 | Commercial | 16:9 | 15-30s | Gimbal | Veo 3.1 | 4000-4999 (product) / 1000-1999 (people) |
 | Cinematic | 2.39:1 | 10-30s | Dolly/crane | Veo 3.1 | 3000-3999 / 1000-1999 |
 | Documentary | 16:9 | 15-60s | Tripod/handheld | Sora 2 Pro or Veo 3.1 | 2000-2999 / 3000-3999 |
+
+> See Quick Reference above for full seed range breakdown (people/action/landscape/product/YouTube).

--- a/.agents/content/production/video/04-seed-bracketing.md
+++ b/.agents/content/production/video/04-seed-bracketing.md
@@ -9,10 +9,14 @@ Increases success rate from 15% to 70%+ by systematically testing seed ranges.
 ```bash
 #!/bin/bash
 set -euo pipefail
+HF_API_KEY="${HF_API_KEY:?Set HF_API_KEY}"
+HF_SECRET="${HF_SECRET:?Set HF_SECRET}"
+: > seed_bracket_results.csv
+echo "seed,job_id" >> seed_bracket_results.csv
 for seed in {4000..4010}; do
   result=$(curl --fail --show-error --silent -X POST \
     'https://platform.higgsfield.ai/v1/image2video/dop' \
-    --header 'hf-api-key: {api-key}' --header 'hf-secret: {secret}' \
+    --header "hf-api-key: ${HF_API_KEY}" --header "hf-secret: ${HF_SECRET}" \
     --data "{\"params\":{\"prompt\":\"[your prompt]\",\"seed\":$seed,\"model\":\"dop-turbo\"}}") \
     || { echo "ERROR: API call failed for seed $seed" >&2; continue; }
   job_id=$(echo "$result" | jq -r '.jobs[0].id // empty' || true)

--- a/.agents/content/production/video/06-two-track-production.md
+++ b/.agents/content/production/video/06-two-track-production.md
@@ -11,9 +11,9 @@ Upload Midjourney output as ingredient, apply VEO framework for animation.
 **Track 2 (Characters & People)**: Freepik → Seedream 4 → Veo 3.1
 
 ```bash
-# Refine to 4K via Higgsfield API
+# Refine to 4K via Higgsfield Seedream upscale API (different endpoint from character upload)
 curl -X POST 'https://platform.higgsfield.ai/bytedance/seedream/v4/upscale' \
-  --header 'Authorization: Key {api_key}:{api_secret}' \
+  --header 'hf-api-key: {api-key}' --header 'hf-secret: {secret}' \
   --data '{"image_url": "https://freepik-output.jpg", "target_resolution": "4K"}'
 ```
 

--- a/.agents/content/production/video/09-tools-resources.md
+++ b/.agents/content/production/video/09-tools-resources.md
@@ -20,7 +20,9 @@
 ```bash
 # Seed bracketing
 seed-bracket-helper.sh generate --type product --prompt "Product rotating on white background"
+seed-bracket-helper.sh status  # Check progress of latest run
 seed-bracket-helper.sh score 4005 8 9 7 8 9 && seed-bracket-helper.sh report
+seed-bracket-helper.sh list    # Show all bracket runs
 
 # Unified video generation CLI (Sora 2, Veo 3.1, Nanobanana Pro)
 video-gen-helper.sh generate sora "A cat reading a book" sora-2-pro 8 1280x720


### PR DESCRIPTION
## Summary

Addresses all CodeRabbit CHANGES_REQUESTED comments on PR #8493.

## Changes

- **video.md**: Fix `--fps 60` example conflicting with the frame-rate rule; use `--fps 30` as safe default with action-only qualifier in comment
- **04-seed-bracketing.md**: Add CSV init + header before loop to prevent run contamination; use `HF_API_KEY`/`HF_SECRET` env vars instead of inline credential placeholders
- **06-two-track-production.md**: Standardize Higgsfield auth headers to `hf-api-key`/`hf-secret` format (consistent with `03-veo-workflow.md`); note this is the upscale endpoint (different from character upload)
- **09-tools-resources.md**: Add `status` and `list` commands to `seed-bracket-helper.sh` examples for complete command reference
- **01-model-selection.md**: Add note pointing to Quick Reference for full seed range breakdown to reduce duplication

## Runtime Testing

- **Testing level**: self-assessed
- **Risk classification**: Low (docs-only changes)
- **Behaviour verified**: All changes are documentation fixes addressing CodeRabbit review feedback

Closes #7265