### PR TITLE
GH#8758: Tighten Email Delivery Testing doc (225→124 lines)

### DIFF
--- a/.agents/services/email/email-delivery-testing.md
+++ b/.agents/services/email/email-delivery-testing.md
@@ -19,127 +19,27 @@ tools:
 
 - **Purpose**: Spam content analysis, provider-specific deliverability, inbox placement testing
 - **Script**: `email-delivery-test-helper.sh [command] [options]`
-- **Checks**: Spam triggers, Gmail/Outlook/Yahoo deliverability, seed-list placement, warm-up
 - **Tools**: dig, openssl, curl, nc (required); swaks, spamassassin (optional)
 - **Related**: `email-health-check-helper.sh` (DNS auth), `email-test-suite-helper.sh` (design rendering)
 
-**Quick commands:**
-
 ```bash
-# Spam content analysis
-email-delivery-test-helper.sh spam-check newsletter.html
-
-# Provider-specific deliverability
-email-delivery-test-helper.sh gmail example.com
-email-delivery-test-helper.sh outlook example.com
-email-delivery-test-helper.sh providers example.com
-
-# Inbox placement
-email-delivery-test-helper.sh seed-test example.com
-email-delivery-test-helper.sh send-test me@example.com test@gmail.com smtp.example.com
-
-# Warm-up guidance
-email-delivery-test-helper.sh warmup example.com
-
-# Full report
-email-delivery-test-helper.sh report example.com
+email-delivery-test-helper.sh spam-check newsletter.html       # Spam content analysis
+email-delivery-test-helper.sh spamassassin newsletter.html      # SpamAssassin (if installed)
+email-delivery-test-helper.sh providers example.com             # All provider checks
+email-delivery-test-helper.sh gmail example.com                 # Gmail-specific
+email-delivery-test-helper.sh outlook example.com               # Outlook-specific
+email-delivery-test-helper.sh yahoo example.com                 # Yahoo-specific
+email-delivery-test-helper.sh seed-test example.com             # Seed-list testing guide
+email-delivery-test-helper.sh send-test me@example.com test@gmail.com smtp.example.com 587
+email-delivery-test-helper.sh warmup example.com                # Warm-up schedule
+email-delivery-test-helper.sh report example.com                # Full deliverability report
 ```
 
 <!-- AI-CONTEXT-END -->
 
-## Overview
+## Spam Content Analysis
 
-The email delivery test helper focuses on three areas that complement the existing email tools:
-
-### 1. Spam Content Analysis
-
-Analyses email HTML/text for content-level spam signals:
-
-- **Subject line** - ALL CAPS, excessive punctuation, financial/prize language
-- **High-risk phrases** - "act now", "buy now", "click here", "free gift", etc.
-- **Medium-risk phrases** - "bargain", "discount", "exclusive deal", etc.
-- **Structural signals** - Image-to-text ratio, URL count, shortened URLs, hidden text, JavaScript, form elements
-- **Compliance** - Unsubscribe link, physical address (CAN-SPAM)
-
-Produces a spam score (0-100) with risk rating: CLEAN, LOW RISK, MEDIUM RISK, HIGH RISK, CRITICAL.
-
-### 2. Provider-Specific Deliverability
-
-Checks deliverability requirements for each major email provider:
-
-**Gmail** (8-point score):
-
-- SPF, DKIM, DMARC enforcement
-- One-click unsubscribe (Feb 2024 requirement)
-- PTR records, Google Postmaster Tools, ARC headers
-
-**Outlook** (7-point score):
-
-- SPF, DKIM, DMARC
-- MTA-STS support
-- Blacklist status, Microsoft SNDS
-
-**Yahoo/AOL** (5-point score):
-
-- SPF, DKIM, DMARC enforcement
-- One-click unsubscribe (Feb 2024 requirement)
-
-### 3. Inbox Placement & Warm-Up
-
-- **Seed-list testing** - Guide for manual and automated inbox placement testing
-- **SMTP send test** - Send test emails via swaks or openssl
-- **Warm-up schedule** - Day-by-day volume ramp-up for new IPs/domains
-- **Monitoring services** - Links to Google Postmaster, Microsoft SNDS, etc.
-
-## Usage
-
-### Spam Content Analysis
-
-```bash
-# Analyze email HTML for spam triggers
-email-delivery-test-helper.sh spam-check newsletter.html
-
-# Use SpamAssassin if installed
-email-delivery-test-helper.sh spamassassin newsletter.html
-```
-
-### Provider Deliverability
-
-```bash
-# Check all providers
-email-delivery-test-helper.sh providers example.com
-
-# Individual providers
-email-delivery-test-helper.sh gmail example.com
-email-delivery-test-helper.sh outlook example.com
-email-delivery-test-helper.sh yahoo example.com
-```
-
-### Inbox Placement
-
-```bash
-# Seed-list testing guide
-email-delivery-test-helper.sh seed-test example.com
-
-# Send test email via SMTP
-email-delivery-test-helper.sh send-test me@example.com test@gmail.com smtp.example.com 587
-```
-
-### Warm-Up
-
-```bash
-# View warm-up schedule and guidance
-email-delivery-test-helper.sh warmup example.com
-```
-
-### Full Report
-
-```bash
-# Comprehensive deliverability report
-email-delivery-test-helper.sh report example.com
-```
-
-## Spam Score Interpretation
+Analyses email HTML/text for content-level spam signals. Produces a score (0-100):
 
 | Score | Rating | Meaning |
 |-------|--------|---------|
@@ -149,9 +49,23 @@ email-delivery-test-helper.sh report example.com
 | 51-75 | HIGH RISK | Likely to be flagged as spam |
 | 76-100 | CRITICAL | Will almost certainly be flagged |
 
-## Feb 2024 Bulk Sender Requirements
+**What it checks:**
 
-Gmail and Yahoo introduced strict requirements for bulk senders (>5000 emails/day):
+- **Subject line** — ALL CAPS, excessive punctuation, financial/prize language
+- **High-risk phrases** — "act now", "buy now", "click here", "free gift", etc.
+- **Medium-risk phrases** — "bargain", "discount", "exclusive deal", etc.
+- **Structural signals** — Image-to-text ratio, URL count, shortened URLs, hidden text, JavaScript, form elements
+- **Compliance** — Unsubscribe link, physical address (CAN-SPAM)
+
+## Provider-Specific Deliverability
+
+| Provider | Score | Key checks |
+|----------|-------|------------|
+| **Gmail** | /8 | SPF, DKIM, DMARC, one-click unsubscribe (Feb 2024), PTR, Google Postmaster Tools, ARC headers |
+| **Outlook** | /7 | SPF, DKIM, DMARC, MTA-STS, blacklist status, Microsoft SNDS |
+| **Yahoo/AOL** | /5 | SPF, DKIM, DMARC, one-click unsubscribe (Feb 2024) |
+
+### Feb 2024 Bulk Sender Requirements (>5000 emails/day)
 
 | Requirement | Gmail | Yahoo |
 |-------------|-------|-------|
@@ -162,9 +76,11 @@ Gmail and Yahoo introduced strict requirements for bulk senders (>5000 emails/da
 | Spam rate < 0.3% | Required | Required |
 | PTR records | Required | Recommended |
 
-## Warm-Up Schedule
+## Inbox Placement & Warm-Up
 
-For new IPs/domains, follow this gradual volume increase:
+Seed-list testing, SMTP send tests (via swaks or openssl), and warm-up scheduling for new IPs/domains.
+
+### Warm-Up Schedule
 
 | Day | Daily Volume | Notes |
 |-----|-------------|-------|
@@ -186,24 +102,7 @@ For new IPs/domains, follow this gradual volume increase:
 | `email-test-suite-helper.sh` | Design rendering + delivery infrastructure |
 | `email-delivery-test-helper.sh` | Spam content + provider deliverability + inbox placement |
 
-**Recommended workflow:**
-
-```bash
-# 1. Check DNS authentication
-email-health-check-helper.sh check example.com
-
-# 2. Analyze content for spam triggers
-email-delivery-test-helper.sh spam-check newsletter.html
-
-# 3. Check provider-specific deliverability
-email-delivery-test-helper.sh providers example.com
-
-# 4. Test design rendering
-email-test-suite-helper.sh test-design newsletter.html
-
-# 5. Send test emails
-email-delivery-test-helper.sh send-test me@example.com test@gmail.com
-```
+**Recommended workflow:** DNS auth check → spam content analysis → provider deliverability → design rendering → send test emails.
 
 ## External Services
 


### PR DESCRIPTION
## Summary

- Removed redundant Usage section (100% duplicated Quick Reference commands — ~40 lines)
- Compressed Overview prose into compact provider table (3 rows vs 30+ lines of prose)
- Consolidated Integration workflow code block into one-liner description
- All actionable content preserved: 10 commands, 7 external URLs, 4 related doc links, Feb 2024 requirements, warm-up schedule, spam score table, CAN-SPAM compliance checks

**Before:** 225 lines | **After:** 124 lines (45% reduction)

## Verification

- All commands present: `spam-check`, `spamassassin`, `providers`, `gmail`, `outlook`, `yahoo`, `seed-test`, `send-test`, `warmup`, `report`
- All external URLs preserved (Google Postmaster, Microsoft SNDS, mail-tester.com, GlockApps, Mailtrap, Mailreach, InboxAlly)
- All related doc references intact
- All key terms preserved: CAN-SPAM, Feb 2024, one-click unsubscribe, MTA-STS, ARC headers, PTR, SpamAssassin, swaks, openssl
- Zero markdownlint errors

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** Low (docs-only change, no code)
- **Behaviour verified:** Content preservation confirmed via automated grep of all commands, URLs, references, and key terms

Closes #8758