### PR TITLE
GH#8229: Fix CodeFactor violation — centralise spending limit detection in shared-constants.sh

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -610,12 +610,7 @@ PY
 	fi
 	# Spending/billing limit detection (GH#8229): must check BEFORE auth_error
 	# because spending limits often return 401 but with a distinct error body.
-	# MonthlyLimitError, spending limit, billing limit, quota exceeded, etc.
-	if [[ "$lowered" == *"monthlylimiterror"* ]] || [[ "$lowered" == *"spending limit"* ]] ||
-		[[ "$lowered" == *"monthly spending limit"* ]] || [[ "$lowered" == *"monthly limit"* ]] ||
-		[[ "$lowered" == *"billing limit"* ]] || [[ "$lowered" == *"budget exceeded"* ]] ||
-		[[ "$lowered" == *"quota exceeded"* ]] || [[ "$lowered" == *"usage limit"* ]] ||
-		[[ "$lowered" == *"credits exhausted"* ]]; then
+	if is_spending_limit_error "$lowered"; then
 		printf '%s' "spending_limit"
 		return 0
 	fi

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -207,27 +207,14 @@ _opencode_model_exists() {
 # because all models under the same account share the spending cap.
 
 # Check if an HTTP response body contains a spending/billing limit error.
+# Delegates to is_spending_limit_error() in shared-constants.sh.
 # Returns 0 if spending limit detected, 1 otherwise.
 _is_spending_limit_error() {
 	local body="$1"
 	local lowered
 	lowered=$(printf '%s' "$body" | tr '[:upper:]' '[:lower:]')
-
-	# Match known billing error patterns:
-	# - OpenCode: MonthlyLimitError / "monthly spending limit"
-	# - Generic: "spending limit", "billing limit", "quota exceeded", "budget exceeded"
-	case "$lowered" in
-	*monthlylimiterror* | *"monthly spending limit"* | *"monthly limit"*)
-		return 0
-		;;
-	*"spending limit"* | *"billing limit"* | *"budget exceeded"*)
-		return 0
-		;;
-	*"quota exceeded"* | *"usage limit"* | *"credits exhausted"*)
-		return 0
-		;;
-	esac
-	return 1
+	is_spending_limit_error "$lowered"
+	return $?
 }
 
 # =============================================================================

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -61,6 +61,32 @@ readonly ERROR_API_KEY_MISSING="API key is missing or invalid"
 readonly ERROR_INVALID_CREDENTIALS="Invalid credentials"
 
 # =============================================================================
+# Spending / Billing Limit Detection (GH#8229)
+# =============================================================================
+# Shared function used by model-availability-helper.sh and headless-runtime-helper.sh
+# to detect spending/billing limit errors in API response bodies.
+# Centralised here to avoid duplication between the two scripts.
+
+# Check if a (lowercased) string contains a spending/billing limit error pattern.
+# Caller must lowercase the input before passing it.
+# Returns 0 if spending limit detected, 1 otherwise.
+is_spending_limit_error() {
+	local lowered="$1"
+	case "$lowered" in
+	*monthlylimiterror* | *"monthly spending limit"* | *"monthly limit"*)
+		return 0
+		;;
+	*"spending limit"* | *"billing limit"* | *"budget exceeded"*)
+		return 0
+		;;
+	*"quota exceeded"* | *"usage limit"* | *"credits exhausted"*)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+# =============================================================================
 # Success Messages
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Fixes CodeFactor FAIL on PR #8566 caused by duplicate spending limit detection logic
- Centralises `is_spending_limit_error()` in `shared-constants.sh` (already sourced by both scripts)
- Both `_is_spending_limit_error()` in `model-availability-helper.sh` and `classify_failure_reason()` in `headless-runtime-helper.sh` now delegate to the shared function

## Root Cause

CodeFactor flagged the same 9-pattern list duplicated in two scripts:
- `_is_spending_limit_error()` in `model-availability-helper.sh`
- `classify_failure_reason()` in `headless-runtime-helper.sh`

## Fix

Added `is_spending_limit_error()` to `shared-constants.sh` with the canonical pattern list. Both callers delegate to it, eliminating the duplication.

## Runtime Testing

- **Testing level:** `self-assessed`
- **Risk classification:** Low (refactor only — no logic change, same patterns)
- ShellCheck: 0 errors on all 3 modified files (only pre-existing SC1091 info notices about source paths)
- Behaviour unchanged: same 9 patterns, same return codes

Closes #8229