### PR TITLE
t8887: tighten playwright-emulation.md (288→183 lines, 36% reduction)

### DIFF
--- a/.agents/tools/browser/playwright-emulation.md
+++ b/.agents/tools/browser/playwright-emulation.md
@@ -18,190 +18,109 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Mobile, tablet, and responsive testing via Playwright device emulation
 - **Docs**: https://playwright.dev/docs/emulation
 - **Device registry**: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/deviceDescriptorsSource.json
-- **Requires**: `npm install playwright` (or `@playwright/test` for test runner)
-
-**Capabilities**: Device presets (iPhone, iPad, Pixel, Galaxy, desktop), custom viewport/screen size, user agent override, touch events (`hasTouch`, `isMobile`), geolocation, locale/timezone, permissions (notifications, geolocation, camera, microphone), color scheme, reduced motion, forced colors, offline mode, JavaScript disabled, device scale factor (HiDPI/Retina).
-
-**When to use**: Testing responsive layouts, mobile-specific behavior, touch interactions, geolocation features, locale-dependent content, dark mode, or any scenario requiring browser environment emulation. Complements native mobile testing (Maestro, iOS Simulator MCP) for web-based mobile testing.
+- **Install**: `npm install playwright` or `@playwright/test`
+- **Capabilities**: device presets, viewport/screen, user agent, touch (`hasTouch`, `isMobile`), geolocation, locale/timezone, permissions, color scheme, reduced motion, forced colors, offline, JS disabled, HiDPI/Retina
+- **When to use**: responsive layouts, mobile behavior, touch, geolocation, locale, dark mode. Complements Maestro (t096) / iOS Simulator MCP (t097) for web-based mobile testing.
 
 <!-- AI-CONTEXT-END -->
 
 ## Device Presets
 
-Playwright ships with 100+ device descriptors. Each preset includes `viewport`, `userAgent`, `deviceScaleFactor`, `isMobile`, and `hasTouch`.
-
-### Common Devices
-
-| Device | Viewport | Scale | Mobile |
-|--------|----------|-------|--------|
-| `Desktop Chrome/Firefox/Safari/Edge` | 1280x720 | 1 | No |
-| `iPhone 13/14/15` | 390x844 | 3 | Yes |
-| `iPhone 13 Pro Max / 14 Pro Max / 15 Pro Max` | 428-430x926-932 | 3 | Yes |
-| `iPad (gen 7)` | 810x1080 | 2 | Yes |
-| `iPad Mini` | 768x1024 | 2 | Yes |
-| `iPad Pro 11` | 834x1194 | 2 | Yes |
-| `Pixel 5` | 393x851 | 2.75 | Yes |
-| `Pixel 7` | 412x915 | 2.625 | Yes |
-| `Galaxy S8` | 360x740 | 3 | Yes |
-| `Galaxy S9+` | 320x658 | 4.5 | Yes |
-| `Galaxy Tab S4` | 712x1138 | 2.25 | Yes |
+100+ built-in descriptors. Each includes `viewport`, `userAgent`, `deviceScaleFactor`, `isMobile`, `hasTouch`. Landscape variants: `devices['iPhone 13 landscape']`.
 
 ```bash
-# List all available devices
 node -e "const { devices } = require('playwright'); console.log(Object.keys(devices).join('\n'))"
 ```
 
-Most mobile devices have landscape variants: `devices['iPhone 13 landscape']`
+| Device | Viewport | Scale | Mobile |
+|--------|----------|-------|--------|
+| Desktop Chrome/Firefox/Safari/Edge | 1280×720 | 1 | No |
+| iPhone 13/14/15 | 390×844 | 3 | Yes |
+| iPhone 13/14/15 Pro Max | 428–430×926–932 | 3 | Yes |
+| iPad gen7 / Mini / Pro 11 | 810×1080 / 768×1024 / 834×1194 | 2 | Yes |
+| Pixel 5 / Pixel 7 | 393×851 / 412×915 | 2.75 / 2.625 | Yes |
+| Galaxy S8 / S9+ / Tab S4 | 360×740 / 320×658 / 712×1138 | 3 / 4.5 / 2.25 | Yes |
 
 ## Configuration
 
-### Test Runner (playwright.config.ts)
+### Test Runner (`playwright.config.ts`)
 
 ```typescript
 import { defineConfig, devices } from '@playwright/test';
-
 export default defineConfig({
   projects: [
     { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } },
-    { name: 'Mobile Safari', use: { ...devices['iPhone 13'] } },
-    { name: 'Mobile Chrome', use: { ...devices['Pixel 7'] } },
-    { name: 'Tablet', use: { ...devices['iPad Pro 11'] } },
+    { name: 'Mobile Safari',  use: { ...devices['iPhone 13'] } },
+    { name: 'Mobile Chrome',  use: { ...devices['Pixel 7'] } },
+    { name: 'Tablet',         use: { ...devices['iPad Pro 11'] } },
   ],
 });
 ```
 
-### Library API (Direct Usage)
+### Library API
 
 ```javascript
 const { chromium, devices } = require('playwright');
-const browser = await chromium.launch();
-const context = await browser.newContext({ ...devices['iPhone 13'] });
-const page = await context.newPage();
-await page.goto('https://example.com');
+const ctx = await (await chromium.launch()).newContext({ ...devices['iPhone 13'] });
+await (await ctx.newPage()).goto('https://example.com');
 ```
 
-## Viewport Emulation
+## Emulation Options
 
 ```typescript
-// Per-test override
+// Viewport
 test.use({ viewport: { width: 1600, height: 1200 } });
-
-// Dynamic resize
 await page.setViewportSize({ width: 375, height: 667 });
+await browser.newContext({ viewport: { width: 2560, height: 1440 }, deviceScaleFactor: 2 }); // HiDPI
 
-// HiDPI / Retina
-const context = await browser.newContext({
-  viewport: { width: 2560, height: 1440 },
-  deviceScaleFactor: 2,
-});
-```
-
-## Geolocation
-
-```typescript
-// Config-level
-export default defineConfig({
-  use: {
-    geolocation: { longitude: -122.4194, latitude: 37.7749 },
-    permissions: ['geolocation'],
-  },
-});
-
-// Dynamic change
+// Geolocation
+use: { geolocation: { longitude: -122.4194, latitude: 37.7749 }, permissions: ['geolocation'] }
 await context.setGeolocation({ longitude: 48.8584, latitude: 2.2945 });
+
+// Locale / Timezone
+use: { locale: 'en-GB', timezoneId: 'Europe/London' }
+
+// Color scheme / media
+await page.emulateMedia({ colorScheme: 'dark' | 'light', reducedMotion: 'reduce', forcedColors: 'active', media: 'print' });
+
+// Permissions
+use: { permissions: ['notifications'] }
+await context.grantPermissions(['geolocation'], { origin: 'https://example.com' });
+await context.grantPermissions(['notifications', 'camera', 'microphone']);
+await context.clearPermissions();
+
+// Offline / JS / User Agent
+await context.setOffline(true);
+test.use({ javaScriptEnabled: false, userAgent: 'Custom Bot/1.0' });
 ```
 
-## Locale and Timezone
-
-```typescript
-// Config-level
-export default defineConfig({
-  use: { locale: 'en-GB', timezoneId: 'Europe/London' },
-});
-```
+**Permission values**: `geolocation`, `midi`, `midi-sysex`, `notifications`, `camera`, `microphone`, `background-sync`, `ambient-light-sensor`, `accelerometer`, `gyroscope`, `magnetometer`, `accessibility-events`, `clipboard-read`, `clipboard-write`, `payment-handler`
 
 ### Common Locale/Timezone Combinations
 
 | Market | Locale | Timezone |
 |--------|--------|----------|
-| US West | `en-US` | `America/Los_Angeles` |
-| US East | `en-US` | `America/New_York` |
-| UK | `en-GB` | `Europe/London` |
-| Germany | `de-DE` | `Europe/Berlin` |
-| France | `fr-FR` | `Europe/Paris` |
-| Japan | `ja-JP` | `Asia/Tokyo` |
-| China | `zh-CN` | `Asia/Shanghai` |
-| India | `hi-IN` | `Asia/Kolkata` |
-| Brazil | `pt-BR` | `America/Sao_Paulo` |
-| Australia | `en-AU` | `Australia/Sydney` |
-
-## Color Scheme and Media
-
-```typescript
-// Dark mode (config, per-test, or dynamic)
-test.use({ colorScheme: 'dark' });
-await page.emulateMedia({ colorScheme: 'dark' });
-
-// Reduced motion / forced colors / print
-await page.emulateMedia({ reducedMotion: 'reduce' });
-await page.emulateMedia({ forcedColors: 'active' });
-await page.emulateMedia({ media: 'print' });
-```
-
-## Permissions
-
-```typescript
-// Config-level
-export default defineConfig({ use: { permissions: ['notifications'] } });
-
-// Per-context (domain-specific)
-await context.grantPermissions(['geolocation'], { origin: 'https://example.com' });
-await context.grantPermissions(['notifications', 'camera', 'microphone']);
-await context.clearPermissions();
-```
-
-**Available permissions**: `geolocation`, `midi`, `midi-sysex`, `notifications`, `camera`, `microphone`, `background-sync`, `ambient-light-sensor`, `accelerometer`, `gyroscope`, `magnetometer`, `accessibility-events`, `clipboard-read`, `clipboard-write`, `payment-handler`
-
-## Offline Mode and JavaScript Disabled
-
-```typescript
-// Offline
-await context.setOffline(true);
-
-// No JS
-test.use({ javaScriptEnabled: false });
-```
-
-## User Agent Override
-
-```typescript
-test.use({ userAgent: 'Custom Bot/1.0' });
-```
+| US West / East | `en-US` | `America/Los_Angeles` / `America/New_York` |
+| UK / Germany / France | `en-GB` / `de-DE` / `fr-FR` | `Europe/London` / `Europe/Berlin` / `Europe/Paris` |
+| Japan / China / India | `ja-JP` / `zh-CN` / `hi-IN` | `Asia/Tokyo` / `Asia/Shanghai` / `Asia/Kolkata` |
+| Brazil / Australia | `pt-BR` / `en-AU` | `America/Sao_Paulo` / `Australia/Sydney` |
 
 ## Recipes
 
 ### Responsive Breakpoint Testing
 
-```typescript
-const breakpoints = [
-  { name: 'mobile-sm', width: 320, height: 568 },
-  { name: 'mobile-md', width: 375, height: 667 },
-  { name: 'tablet', width: 768, height: 1024 },
-  { name: 'laptop', width: 1024, height: 768 },
-  { name: 'desktop', width: 1280, height: 800 },
-  { name: 'desktop-lg', width: 1920, height: 1080 },
-];
+Standard breakpoints: `mobile-sm` 320×568, `mobile-md` 375×667, `tablet` 768×1024, `laptop` 1024×768, `desktop` 1280×800, `desktop-lg` 1920×1080.
 
+```typescript
 for (const bp of breakpoints) {
   test(`layout at ${bp.name}`, async ({ browser }) => {
-    const context = await browser.newContext({ viewport: { width: bp.width, height: bp.height } });
-    const page = await context.newPage();
+    const ctx = await browser.newContext({ viewport: { width: bp.width, height: bp.height } });
+    const page = await ctx.newPage();
     await page.goto('https://example.com');
     await expect(page).toHaveScreenshot(`${bp.name}.png`);
-    await context.close();
+    await ctx.close();
   });
 }
 ```
@@ -209,13 +128,6 @@ for (const bp of breakpoints) {
 ### Multi-Device Parallel Testing
 
 ```typescript
-const testDevices = [
-  { name: 'iPhone 13', device: devices['iPhone 13'] },
-  { name: 'Pixel 7', device: devices['Pixel 7'] },
-  { name: 'iPad Pro 11', device: devices['iPad Pro 11'] },
-  { name: 'Desktop', device: { viewport: { width: 1280, height: 720 } } },
-];
-
 for (const { name, device } of testDevices) {
   test.describe(name, () => {
     test.use({ ...device });
@@ -225,64 +137,47 @@ for (const { name, device } of testDevices) {
     });
   });
 }
+// testDevices: [{ name, device }] where device = devices['iPhone 13'] | devices['Pixel 7'] | { viewport: {...} }
 ```
 
-### Touch Gesture Testing
-
-```javascript
-const context = await browser.newContext({ ...devices['iPhone 13'], hasTouch: true });
-const page = await context.newPage();
-await page.goto('https://example.com');
-await page.tap('.button');
-await page.touchscreen.tap(200, 300);
-```
-
-### Network Condition Emulation (Chromium only, via CDP)
-
-```javascript
-const cdpSession = await page.context().newCDPSession(page);
-
-// Slow 3G
-await cdpSession.send('Network.emulateNetworkConditions', {
-  offline: false,
-  downloadThroughput: (500 * 1024) / 8,
-  uploadThroughput: (500 * 1024) / 8,
-  latency: 400,
-});
-```
-
-### Dark Mode Visual Regression
+### Touch / Network / Dark Mode
 
 ```typescript
+// Touch gestures
+const ctx = await browser.newContext({ ...devices['iPhone 13'], hasTouch: true });
+await (await ctx.newPage()).tap('.button');
+await page.touchscreen.tap(200, 300);
+
+// Network throttling (Chromium/CDP only — Slow 3G)
+const cdp = await page.context().newCDPSession(page);
+await cdp.send('Network.emulateNetworkConditions', {
+  offline: false, downloadThroughput: (500 * 1024) / 8,
+  uploadThroughput: (500 * 1024) / 8, latency: 400,
+});
+
+// Dark mode visual regression
 for (const scheme of ['light', 'dark'] as const) {
   test(`visual regression (${scheme})`, async ({ browser }) => {
-    const context = await browser.newContext({ colorScheme: scheme, viewport: { width: 1280, height: 720 } });
-    const page = await context.newPage();
+    const ctx = await browser.newContext({ colorScheme: scheme, viewport: { width: 1280, height: 720 } });
+    const page = await ctx.newPage();
     await page.goto('https://example.com');
     await expect(page).toHaveScreenshot(`homepage-${scheme}.png`);
-    await context.close();
+    await ctx.close();
   });
 }
 ```
 
 ## Integration with aidevops Tools
 
-**With Chrome DevTools MCP**: Combine device emulation with performance auditing — navigate in mobile emulation, then connect `npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222` for Lighthouse mobile audit.
-
-**With Stagehand (Natural Language + Device)**:
-
-```javascript
-const stagehand = new Stagehand({ env: 'LOCAL', browserOptions: { ...devices['iPhone 13'] } });
-await stagehand.init();
-await stagehand.act('tap the hamburger menu');
-```
+- **Chrome DevTools MCP**: navigate in mobile emulation → `npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222` for Lighthouse mobile audit.
+- **Stagehand**: `new Stagehand({ env: 'LOCAL', browserOptions: { ...devices['iPhone 13'] } })` → `stagehand.act('tap the hamburger menu')`.
 
 ## Related
 
-- `playwright.md` - Core Playwright automation (cross-browser, forms, security, API testing)
-- `playwright-cli.md` - CLI-first Playwright for AI agents
-- `browser-automation.md` - Tool selection decision tree
-- `browser-benchmark.md` - Performance benchmarks across all browser tools
-- `pagespeed.md` - PageSpeed Insights integration
-- Maestro (t096) - Native mobile E2E testing
-- iOS Simulator MCP (t097) - iOS simulator interaction
+- `playwright.md` — core automation (cross-browser, forms, security, API testing)
+- `playwright-cli.md` — CLI-first Playwright for AI agents
+- `browser-automation.md` — tool selection decision tree
+- `browser-benchmark.md` — performance benchmarks
+- `pagespeed.md` — PageSpeed Insights integration
+- Maestro (t096) — native mobile E2E testing
+- iOS Simulator MCP (t097) — iOS simulator interaction


### PR DESCRIPTION
## Summary

- Converts verbose prose to tables/bullets throughout
- Consolidates 6 separate emulation sections (viewport, geolocation, locale, color scheme, permissions, offline/JS/UA) into a single `## Emulation Options` code block with inline comments
- Compresses device table from 11 rows → 6 rows (merging iPad/Pixel/Galaxy variants)
- Compresses locale/timezone table from 10 rows → 4 rows (grouping by region)
- Merges 5 recipe sections into 3 (touch + network + dark mode combined)
- Converts breakpoint array to inline prose + shorter loop snippet

## Metrics

- **Before**: 288 lines
- **After**: 183 lines
- **Reduction**: 36.5% (105 lines removed)
- **All operational content preserved**: device presets, emulation APIs, permission values, all 5 recipe patterns, integration notes, related links

## Note on target

Issue requested ~50% reduction. The remaining lines are code blocks containing operational API examples — compressing further would lose information. 36.5% represents the actual redundancy (prose, blank lines, repeated patterns).

Closes #8887