### PR TITLE
t9604: tighten agent doc Unstract - Document Processing

### DIFF
--- a/.agents/services/document-processing/unstract.md
+++ b/.agents/services/document-processing/unstract.md
@@ -26,19 +26,10 @@ mcp:
 - **Credentials**: `UNSTRACT_API_KEY` + `API_BASE_URL` in `~/.config/aidevops/credentials.sh` (chmod 600)
 - **Docs**: https://docs.unstract.com/unstract/unstract_platform/mcp/unstract_platform_mcp_server/
 - **GitHub**: https://github.com/Zipstack/unstract
-
-**On-demand loading**: This MCP is disabled globally and enabled per-agent when document extraction is needed.
+- **On-demand loading**: MCP disabled globally; enabled per-agent when document extraction is needed
+- **Trigger keywords**: document, extract, parse, invoice, statement, PDF, OCR, unstructured
 
 <!-- AI-CONTEXT-END -->
-
-## What is Unstract?
-
-Unstract is a no-code LLM platform that structures unstructured documents. It provides:
-
-- **Prompt Studio**: Visual environment to define extraction schemas
-- **API Deployments**: Turn any document into JSON via REST API
-- **ETL Pipelines**: Batch process documents into databases
-- **MCP Server**: Integrate extraction into AI agent workflows
 
 ## Supported File Types
 
@@ -64,54 +55,46 @@ Submits a file to the Unstract API, polls for completion, and returns structured
 
 ## Setup
 
-The MCP server is a thin client that connects to any Unstract API endpoint - cloud or self-hosted.
-
 ### Option A: Cloud (Quick Start)
 
 1. Sign up at https://unstract.com/start-for-free/ (14-day free trial)
-2. Create a Prompt Studio project and define your extraction schema
-3. Deploy as an API endpoint
-4. Copy the API key and deployment URL
+2. Create a Prompt Studio project, define extraction schema, deploy as API endpoint
+3. Add credentials to `~/.config/aidevops/credentials.sh` (chmod 600):
 
 ```bash
-# Add to ~/.config/aidevops/credentials.sh:
 export UNSTRACT_API_KEY="your_api_key_here"
 export API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
-chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### Option B: Self-Hosted (Local) - Recommended
 
-Install and run the full Unstract platform locally (requires Docker, 8GB RAM):
+Requires Docker, 8GB RAM. Full data privacy — no documents leave your machine.
 
 ```bash
-# One-command install via aidevops helper:
 ~/.aidevops/agents/scripts/unstract-helper.sh install
-
-# Or via the MCP integrations setup:
-~/.aidevops/agents/scripts/setup-mcp-integrations.sh unstract
+# Or: ~/.aidevops/agents/scripts/setup-mcp-integrations.sh unstract
 ```
 
-This clones Unstract to `~/.aidevops/unstract/`, disables analytics, starts Docker Compose, and configures the MCP to point at your local instance.
+Clones to `~/.aidevops/unstract/`, disables analytics, starts Docker Compose. Visit http://frontend.unstract.localhost (login: unstract/unstract)
 
-Visit http://frontend.unstract.localhost (login: unstract/unstract)
-
-**Management commands:**
+**Management:**
 
 ```bash
-unstract-helper.sh start          # Start containers
-unstract-helper.sh stop           # Stop containers
-unstract-helper.sh status         # Check status
-unstract-helper.sh logs           # View logs
-unstract-helper.sh configure-llm  # Help adding LLM adapters
-unstract-helper.sh uninstall      # Remove everything
+unstract-helper.sh start|stop|status|logs|configure-llm|uninstall
 ```
 
-Self-hosted gives full data privacy - no documents leave your machine.
+Set credentials pointing at local instance:
 
-### Using Your Existing LLM API Keys
+```bash
+export UNSTRACT_API_KEY="your_api_key_here"
+export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
+```
 
-Unstract uses "Adapters" to connect to LLM providers. Your existing API keys from `~/.config/aidevops/credentials.sh` work directly - just add them as adapters in the Unstract UI (Settings > Adapters):
+**Note**: The MCP expects `API_BASE_URL` (not prefixed). This matches the official Unstract spec.
+
+### LLM Adapters (Self-Hosted)
+
+Add existing API keys as adapters in Unstract UI (Settings > Adapters). Run `unstract-helper.sh configure-llm` to see configured keys.
 
 | Your Key | Unstract Adapter |
 |----------|-----------------|
@@ -122,43 +105,21 @@ Unstract uses "Adapters" to connect to LLM providers. Your existing API keys fro
 | AWS credentials | AWS Bedrock |
 | Ollama (local, no key) | Ollama (http://host.docker.internal:11434) |
 
-Run `unstract-helper.sh configure-llm` to see which keys you already have configured.
+For fully local/offline operation, use **Ollama** — no cloud API keys needed.
 
-For fully local/offline operation, use **Ollama** as the LLM adapter - no cloud API keys needed.
+### OpenCode / Claude Desktop Configuration
 
-### 2. Store Credentials
-
-Whichever option you chose, ensure credentials are in `~/.config/aidevops/credentials.sh`:
-
-```bash
-export UNSTRACT_API_KEY="your_api_key_here"
-export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
-chmod 600 ~/.config/aidevops/credentials.sh
-```
-
-**Note**: The MCP expects `API_BASE_URL` (not prefixed). This matches the official Unstract spec.
-
-### 3. OpenCode Configuration (On-Demand)
-
-The MCP is configured in OpenCode but disabled globally. It loads on-demand when this subagent is invoked.
-
-See `configs/mcp-templates/unstract.json` for the configuration template.
-
-### 4. Claude Desktop Configuration (Docker)
+- **OpenCode**: See `configs/mcp-templates/unstract.json` (on-demand, disabled globally)
+- **Claude Desktop** (Docker):
 
 ```json
 {
   "mcpServers": {
     "unstract_tool": {
       "command": "/usr/local/bin/docker",
-      "args": [
-        "run", "-i", "--rm",
-        "-v", "/tmp:/tmp",
-        "-e", "UNSTRACT_API_KEY",
-        "-e", "API_BASE_URL",
-        "unstract/mcp-server",
-        "unstract"
-      ],
+      "args": ["run", "-i", "--rm", "-v", "/tmp:/tmp",
+               "-e", "UNSTRACT_API_KEY", "-e", "API_BASE_URL",
+               "unstract/mcp-server", "unstract"],
       "env": {
         "UNSTRACT_API_KEY": "",
         "API_BASE_URL": "https://us-central.unstract.com/deployment/api/.../"
@@ -170,30 +131,15 @@ See `configs/mcp-templates/unstract.json` for the configuration template.
 
 ## Use Cases
 
-- **Invoice processing**: Extract line items, totals, vendor info from invoices
-- **Bank statement parsing**: Structure transaction data from varied bank formats
+- **Invoice processing**: Extract line items, totals, vendor info
+- **Bank statement parsing**: Structure transaction data from varied formats
 - **Insurance claims**: Extract claim details from forms and supporting documents
 - **KYC/onboarding**: Parse identity documents and application forms
 - **Contract analysis**: Extract key terms, dates, parties from legal documents
 
 ## Analytics / Telemetry
 
-The MCP server itself (`unstract/mcp-server` Docker image) contains **no analytics or telemetry code** - it is a clean API client that submits files and returns results.
-
-For **self-hosted** Unstract deployments, disable frontend analytics:
-
-```bash
-# In frontend/.env of your self-hosted Unstract instance:
-REACT_APP_ENABLE_POSTHOG=false
-```
-
-The **cloud API** (`us-central.unstract.com`) may collect server-side usage metrics as part of their platform. Use self-hosted if this is a concern.
-
-## Integration with aidevops
-
-This subagent is referenced by agents that need document extraction capabilities. The MCP loads only when document processing tasks are detected.
-
-**Trigger keywords**: document, extract, parse, invoice, statement, PDF, OCR, unstructured
+The `unstract/mcp-server` Docker image has no telemetry. For self-hosted, disable frontend analytics: set `REACT_APP_ENABLE_POSTHOG=false` in `frontend/.env`. The cloud API may collect server-side usage metrics — use self-hosted if this is a concern.
 
 ## Related
 

--- a/.agents/services/document-processing/unstract.md
+++ b/.agents/services/document-processing/unstract.md
@@ -59,7 +59,7 @@ Submits a file to the Unstract API, polls for completion, and returns structured
 
 1. Sign up at https://unstract.com/start-for-free/ (14-day free trial)
 2. Create a Prompt Studio project, define extraction schema, deploy as API endpoint
-3. Add credentials to `~/.config/aidevops/credentials.sh` (chmod 600):
+3. Store credentials (preferred: `~/.aidevops/agents/scripts/setup-local-api-keys.sh`; or manually in `~/.config/aidevops/credentials.sh` chmod 600):
 
 ```bash
 export UNSTRACT_API_KEY="your_api_key_here"
@@ -80,10 +80,10 @@ Clones to `~/.aidevops/unstract/`, disables analytics, starts Docker Compose. Vi
 **Management:**
 
 ```bash
-unstract-helper.sh start|stop|status|logs|configure-llm|uninstall
+~/.aidevops/agents/scripts/unstract-helper.sh start|stop|status|logs|configure-llm|uninstall
 ```
 
-Set credentials pointing at local instance:
+Set credentials pointing at local instance (preferred: `~/.aidevops/agents/scripts/setup-local-api-keys.sh`; or manually):
 
 ```bash
 export UNSTRACT_API_KEY="your_api_key_here"
@@ -94,7 +94,7 @@ export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
 
 ### LLM Adapters (Self-Hosted)
 
-Add existing API keys as adapters in Unstract UI (Settings > Adapters). Run `unstract-helper.sh configure-llm` to see configured keys.
+Add existing API keys as adapters in Unstract UI (Settings > Adapters). Run `~/.aidevops/agents/scripts/unstract-helper.sh configure-llm` to see configured keys.
 
 | Your Key | Unstract Adapter |
 |----------|-----------------|


### PR DESCRIPTION
## Summary

- Reduces `.agents/services/document-processing/unstract.md` from 202 to 148 lines (27% reduction)
- Removes redundant "What is Unstract?" section (duplicated Quick Reference content)
- Folds "Integration with aidevops" trigger keywords into Quick Reference
- Condenses "Store Credentials" duplicate block (already shown in Option A/B)
- Compresses "Analytics/Telemetry" from 12 lines to 2
- Collapses management commands to single-line format
- Merges OpenCode + Claude Desktop config into one section

## Content Preservation

All commands, URLs, config blocks, file references, and supported formats preserved. Verified with `rg` across all key identifiers.

## Runtime Testing

- **Risk**: Low (docs/agent prompt only — no code changes)
- **Level**: self-assessed
- **Verification**: `wc -l` confirms 148 lines; `rg` confirms all key references present

## Files Changed

- `.agents/services/document-processing/unstract.md` — tightened prose, removed redundancy, preserved all actionable content

Closes #9604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP on-demand guidance to indicate global disable / per-agent enable
  * Moved trigger keywords to Quick Reference and removed the “What is Unstract?” section
  * Rewrote Setup: tightened cloud quick-start, streamlined self-hosted flow, added local frontend login URL and management command examples
  * Consolidated credential export guidance (note about API_BASE_URL)
  * Condensed analytics/telemetry guidance and how to disable frontend analytics
  * Streamlined OpenCode/Claude Desktop Docker args and headings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->