### PR TITLE
9138: tighten aeo-geo-patterns.md from 405 lines

### DIFF
--- a/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
@@ -2,186 +2,116 @@
 
 Reusable content block patterns optimized for answer engines and AI citation.
 
----
-
 ## Answer Engine Optimization (AEO) Patterns
 
-These patterns help content appear in featured snippets, AI Overviews, voice search results, and answer boxes.
+Patterns for featured snippets, AI Overviews, voice search, and answer boxes.
 
 ### Definition Block
 
-Use for "What is [X]?" queries.
+For "What is [X]?" queries. Lead with 1-sentence definition, expand with characteristics, close with why it matters.
 
 ```markdown
 ## What is [Term]?
 
-[Term] is [concise 1-sentence definition]. [Expanded 1-2 sentence explanation with key characteristics]. [Brief context on why it matters or how it's used].
-```
-
-**Example:**
-
-```markdown
-## What is Answer Engine Optimization?
-
-Answer Engine Optimization (AEO) is the practice of structuring content so AI-powered systems can easily extract and present it as direct answers to user queries. Unlike traditional SEO that focuses on ranking in search results, AEO optimizes for featured snippets, AI Overviews, and voice assistant responses. This approach has become essential as over 60% of Google searches now end without a click.
+[Term] is [1-sentence definition]. [Key characteristics]. [Why it matters].
 ```
 
 ### Step-by-Step Block
 
-Use for "How to [X]" queries. Optimal for list snippets.
+For "How to [X]" queries. Optimal for list snippets.
 
 ```markdown
 ## How to [Action/Goal]
 
-[1-sentence overview of the process]
+[1-sentence overview]
 
-1. **[Step Name]**: [Clear action description in 1-2 sentences]
-2. **[Step Name]**: [Clear action description in 1-2 sentences]
-3. **[Step Name]**: [Clear action description in 1-2 sentences]
-4. **[Step Name]**: [Clear action description in 1-2 sentences]
-5. **[Step Name]**: [Clear action description in 1-2 sentences]
-
-[Optional: Brief note on expected outcome or time estimate]
-```
-
-**Example:**
-
-```markdown
-## How to Optimize Content for Featured Snippets
-
-Earning featured snippets requires strategic formatting and direct answers to search queries.
-
-1. **Identify snippet opportunities**: Use tools like Semrush or Ahrefs to find keywords where competitors have snippets you could capture.
-2. **Match the snippet format**: Analyze whether the current snippet is a paragraph, list, or table, and format your content accordingly.
-3. **Answer the question directly**: Provide a clear, concise answer (40-60 words for paragraph snippets) immediately after the question heading.
-4. **Add supporting context**: Expand on your answer with examples, data, and expert insights in the following paragraphs.
-5. **Use proper heading structure**: Place your target question as an H2 or H3, with the answer immediately following.
-
-Most featured snippets appear within 2-4 weeks of publishing well-optimized content.
+1. **[Step]**: [Action in 1-2 sentences]
+2. **[Step]**: [Action in 1-2 sentences]
+3. **[Step]**: [Action in 1-2 sentences]
 ```
 
 ### Comparison Table Block
 
-Use for "[X] vs [Y]" queries. Optimal for table snippets.
+For "[X] vs [Y]" queries. Optimal for table snippets.
 
 ```markdown
-## [Option A] vs [Option B]: [Brief Descriptor]
+## [Option A] vs [Option B]: [Descriptor]
 
 | Feature | [Option A] | [Option B] |
 |---------|------------|------------|
-| [Criteria 1] | [Value/Description] | [Value/Description] |
-| [Criteria 2] | [Value/Description] | [Value/Description] |
-| [Criteria 3] | [Value/Description] | [Value/Description] |
-| [Criteria 4] | [Value/Description] | [Value/Description] |
+| [Criteria] | [Value] | [Value] |
 | Best For | [Use case] | [Use case] |
 
-**Bottom line**: [1-2 sentence recommendation based on different needs]
+**Bottom line**: [1-2 sentence recommendation]
 ```
 
 ### Pros and Cons Block
 
-Use for evaluation queries: "Is [X] worth it?", "Should I [X]?"
+For evaluation queries: "Is [X] worth it?", "Should I [X]?"
 
 ```markdown
 ## Advantages and Disadvantages of [Topic]
 
-[1-sentence overview of the evaluation context]
-
 ### Pros
-
-- **[Benefit category]**: [Specific explanation]
-- **[Benefit category]**: [Specific explanation]
-- **[Benefit category]**: [Specific explanation]
+- **[Benefit]**: [Explanation]
 
 ### Cons
+- **[Drawback]**: [Explanation]
 
-- **[Drawback category]**: [Specific explanation]
-- **[Drawback category]**: [Specific explanation]
-- **[Drawback category]**: [Specific explanation]
-
-**Verdict**: [1-2 sentence balanced conclusion with recommendation]
+**Verdict**: [Balanced conclusion with recommendation]
 ```
 
 ### FAQ Block
 
-Use for topic pages with multiple common questions. Essential for FAQ schema.
+For topic pages with multiple common questions. Essential for FAQ schema.
 
 ```markdown
-## Frequently Asked Questions
+### [Question phrased as users search]?
 
-### [Question phrased exactly as users search]?
-
-[Direct answer in first sentence]. [Supporting context in 2-3 additional sentences].
-
-### [Question phrased exactly as users search]?
-
-[Direct answer in first sentence]. [Supporting context in 2-3 additional sentences].
-
-### [Question phrased exactly as users search]?
-
-[Direct answer in first sentence]. [Supporting context in 2-3 additional sentences].
+[Direct answer first sentence]. [Supporting context in 2-3 sentences].
 ```
 
-**Tips for FAQ questions:**
-- Use natural question phrasing ("How do I..." not "How does one...")
-- Include question words: what, how, why, when, where, who, which
-- Match "People Also Ask" queries from search results
-- Keep answers between 50-100 words
+Use natural phrasing ("How do I..." not "How does one..."). Match "People Also Ask" queries. Keep answers 50-100 words.
 
 ### Listicle Block
 
-Use for "Best [X]", "Top [X]", "[Number] ways to [X]" queries.
+For "Best [X]", "Top [X]", "[Number] ways to [X]" queries.
 
 ```markdown
 ## [Number] Best [Items] for [Goal/Purpose]
 
-[1-2 sentence intro establishing context and selection criteria]
+[1-2 sentence intro with selection criteria]
 
 ### 1. [Item Name]
-
-[Why it's included in 2-3 sentences with specific benefits]
-
-### 2. [Item Name]
-
-[Why it's included in 2-3 sentences with specific benefits]
-
-### 3. [Item Name]
-
-[Why it's included in 2-3 sentences with specific benefits]
+[Why included -- 2-3 sentences with specific benefits]
 ```
+
+### Voice Search Patterns
+
+Voice queries are conversational. Common formats: "What is...", "How do I...", "Where can I find...", "Why does...", "When should I..."
+
+Lead with direct answer (under 30 words). Use natural language. Avoid jargon unless targeting experts. Include local context where relevant.
 
 ---
 
 ## Generative Engine Optimization (GEO) Patterns
 
-These patterns optimize content for citation by AI assistants like ChatGPT, Claude, Perplexity, and Gemini.
+Patterns for citation by AI assistants (ChatGPT, Claude, Perplexity, Gemini).
 
 ### Statistic Citation Block
 
 Statistics increase AI citation rates by 15-30%. Always include sources.
 
 ```markdown
-[Claim statement]. According to [Source/Organization], [specific statistic with number and timeframe]. [Context for why this matters].
-```
-
-**Example:**
-
-```markdown
-Mobile optimization is no longer optional for SEO success. According to Google's 2024 Core Web Vitals report, 70% of web traffic now comes from mobile devices, and pages failing mobile usability standards see 24% higher bounce rates. This makes mobile-first indexing a critical ranking factor.
+[Claim]. According to [Source], [statistic with number and timeframe]. [Why this matters].
 ```
 
 ### Expert Quote Block
 
-Named expert attribution adds credibility and increases citation likelihood.
+Named attribution adds credibility and increases citation likelihood.
 
 ```markdown
-"[Direct quote from expert]," says [Expert Name], [Title/Role] at [Organization]. [1 sentence of context or interpretation].
-```
-
-**Example:**
-
-```markdown
-"The shift from keyword-driven search to intent-driven discovery represents the most significant change in SEO since mobile-first indexing," says Rand Fishkin, Co-founder of SparkToro. This perspective highlights why content strategies must evolve beyond traditional keyword optimization.
+"[Quote]," says [Name], [Title] at [Org]. [1 sentence context].
 ```
 
 ### Authoritative Claim Block
@@ -189,217 +119,106 @@ Named expert attribution adds credibility and increases citation likelihood.
 Structure claims for easy AI extraction with clear attribution.
 
 ```markdown
-[Topic] [verb: is/has/requires/involves] [clear, specific claim]. [Source] [confirms/reports/found] that [supporting evidence]. This [explains/means/suggests] [implication or action].
-```
-
-**Example:**
-
-```markdown
-E-E-A-T is the cornerstone of Google's content quality evaluation. Google's Search Quality Rater Guidelines confirm that trust is the most critical factor, stating that "untrustworthy pages have low E-E-A-T no matter how experienced, expert, or authoritative they may seem." This means content creators must prioritize transparency and accuracy above all other optimization tactics.
+[Topic] [verb] [specific claim]. [Source] [confirms/found] [evidence]. This [means/suggests] [action].
 ```
 
 ### Self-Contained Answer Block
 
-Create quotable, standalone statements that AI can extract directly.
+Quotable, standalone statements AI can extract directly.
 
 ```markdown
-**[Topic/Question]**: [Complete, self-contained answer that makes sense without additional context. Include specific details, numbers, or examples in 2-3 sentences.]
-```
-
-**Example:**
-
-```markdown
-**Ideal blog post length for SEO**: The optimal length for SEO blog posts is 1,500-2,500 words for competitive topics. This range allows comprehensive topic coverage while maintaining reader engagement. HubSpot research shows long-form content earns 77% more backlinks than short articles, directly impacting search rankings.
+**[Topic/Question]**: [Complete, self-contained answer with details/numbers in 2-3 sentences.]
 ```
 
 ### Evidence Sandwich Block
 
-Structure claims with evidence for maximum credibility.
+Claims bracketed by evidence for maximum credibility.
 
 ```markdown
-[Opening claim statement].
+[Opening claim].
 
-Evidence supporting this includes:
-- [Data point 1 with source]
-- [Data point 2 with source]
-- [Data point 3 with source]
+Evidence:
+- [Data point with source]
+- [Data point with source]
+- [Data point with source]
 
-[Concluding statement connecting evidence to actionable insight].
+[Conclusion connecting evidence to actionable insight].
 ```
 
 ### GEO Product Block
 
-Use when AI systems are likely to run domain-scoped retrieval such as
-`site:yourdomain.com [category] features [year]`.
+For domain-scoped AI retrieval (`site:yourdomain.com [category] features [year]`).
 
 ```markdown
 ## [Product/Category] Features for [Audience] ([Year])
 
 **Best for**: [ICP or use case]
-**Pricing model**: [starting point / packaging logic]
-**Integrations**: [top integrations users ask about]
+**Pricing**: [starting point / packaging]
+**Integrations**: [top integrations]
 **Compliance**: [SOC 2, GDPR, HIPAA, etc.]
-**Time-to-value**: [implementation timeline]
+**Time-to-value**: [timeline]
 
 ### Key capabilities
-
-- **[Capability 1]**: [Specific and testable description]
-- **[Capability 2]**: [Specific and testable description]
-- **[Capability 3]**: [Specific and testable description]
+- **[Capability]**: [Specific, testable description]
 
 ### Validation sources
-
 - G2: [profile URL with UTM]
 - Capterra: [profile URL with UTM]
-- TrustRadius: [profile URL with UTM]
 ```
 
-**Implementation notes:**
-
-- Mirror the same canonical facts on the product page and third-party profiles
-  (pricing anchor, feature limits, support model)
-- Keep `title`, `H1`, and first section paragraph aligned to likely
-  domain-scoped query modifiers
-- Use consistent UTM parameters across profile and comparison links for
-  citation attribution (for example: `utm_source=g2`,
-  `utm_medium=referral`, `utm_campaign=ai_citation`)
-- Review profile freshness monthly to prevent stale third-party facts from
-  outranking first-party updates
+**Implementation:** Mirror canonical facts on product page and third-party profiles. Align `title`/`H1`/first paragraph to domain-scoped query modifiers. Use consistent UTM: `utm_source=g2`, `utm_medium=referral`, `utm_campaign=ai_citation`. Review profile freshness monthly.
 
 ---
 
-## Domain-Specific GEO Tactics
+## Domain-Specific GEO Authority Signals
 
-Different content domains benefit from different authority signals.
-
-### Technology Content
-
-- Emphasize technical precision and correct terminology
-- Include version numbers and dates for software/tools
-- Reference official documentation
-- Add code examples where relevant
-
-### Health/Medical Content
-
-- Cite peer-reviewed studies with publication details
-- Include expert credentials (MD, RN, etc.)
-- Note study limitations and context
-- Add "last reviewed" dates
-
-### Financial Content
-
-- Reference regulatory bodies (SEC, FTC, etc.)
-- Include specific numbers with timeframes
-- Note that information is educational, not advice
-- Cite recognized financial institutions
-
-### Legal Content
-
-- Cite specific laws, statutes, and regulations
-- Reference jurisdiction clearly
-- Include professional disclaimers
-- Note when professional consultation is advised
-
-### Business/Marketing Content
-
-- Include case studies with measurable results
-- Reference industry research and reports
-- Add percentage changes and timeframes
-- Quote recognized thought leaders
+| Domain | Key signals |
+|--------|-------------|
+| **Technology** | Technical precision, version numbers, dates, official docs, code examples |
+| **Health/Medical** | Peer-reviewed studies, expert credentials (MD, RN), study limitations, "last reviewed" dates |
+| **Financial** | Regulatory bodies (SEC, FTC), numbers with timeframes, "educational not advice" disclaimers |
+| **Legal** | Specific laws/statutes, jurisdiction, professional disclaimers, "consult a professional" |
+| **Business/Marketing** | Case studies with results, industry research, percentage changes, thought leader quotes |
 
 ---
 
 ## Site-Searchable Content Patterns
 
-These patterns optimize content for domain-scoped AI retrieval — when a model runs `site:yourdomain.com` queries to extract detail from your site specifically.
+Optimized for domain-scoped AI retrieval (`site:yourdomain.com` queries).
 
 ### Site-Searchable Product Block
-
-Structured content block optimized for domain-scoped AI retrieval. When a model searches `site:yourdomain.com [category] features`, this block ensures the page matches and the key facts are extractable.
 
 ```markdown
 ## [Product Name]: [Category] [Type] for [Audience]
 
-[Product Name] is a [category term] that [core value proposition in one sentence]. [Key differentiator in one sentence].
+[Product Name] is a [category term] that [value proposition]. [Differentiator].
 
 ### Key Features
-
-- **[Feature category]**: [Specific capability with measurable detail]
-- **[Feature category]**: [Specific capability with measurable detail]
-- **[Feature category]**: [Specific capability with measurable detail]
-- **[Feature category]**: [Specific capability with measurable detail]
+- **[Feature]**: [Capability with measurable detail]
 
 ### Pricing
-
-[Pricing model] starting at [price point] per [unit/period]. [Brief tier summary]. [Link to detailed pricing page].
+[Model] starting at [price] per [unit]. [Tier summary]. [Pricing link].
 
 ### Integrations
-
-Connects with [number] tools including [top 3-5 integration names]. [Link to full integration directory].
+Connects with [number] tools including [top 3-5]. [Directory link].
 
 *Last updated: [YYYY-MM]*
 ```
 
-**Why this works for `site:` retrieval:**
+**Why this works:** H2 contains category terms matching `site:` queries. Opening sentence extractable as standalone claim. Feature list uses category vocabulary, not jargon. Sections addressable via heading anchors. Date signals freshness.
 
-- H2 contains category terms that match `site:` query patterns (not just brand name)
-- Opening sentence is a self-contained definition extractable as a standalone claim
-- Feature list uses category vocabulary, not internal product jargon
-- Pricing and integration sections are individually addressable via heading anchors
-- Last-updated date signals freshness to the retrieval system
+### UTM Citation Attribution
 
-### UTM Citation Attribution Tracking
-
-Track which AI-cited pages drive traffic using UTM parameters. AI models that cite sources often include UTM-tagged links, enabling attribution of AI-driven visits.
-
-**Implementation pattern:**
+Track AI-cited page traffic using UTM parameters.
 
 ```markdown
-<!-- Canonical URL (clean, no tracking params) -->
+<!-- Canonical (clean) -->
 https://yourdomain.com/product-features/
 
-<!-- Distributed/cited link variant with UTM attribution -->
+<!-- Cited variant -->
 https://yourdomain.com/product-features/?utm_source=ai&utm_medium=citation&utm_campaign=[model-name]
 ```
 
-> **Note:** The canonical URL must always be clean — tracking parameters belong
-> only in distributed or cited link variants, never in the canonical itself.
+Canonical URL must always be clean -- tracking parameters only in distributed/cited variants.
 
-**Attribution strategy:**
-
-- Monitor `utm_source=ai` or `utm_source=chatgpt` (and similar) traffic in analytics to measure AI citation volume
-- Track which pages receive AI-attributed visits — these are the pages models are actually citing
-- Compare cited pages against your priority page list to identify gaps (high-priority pages not being cited)
-- Use referrer analysis alongside UTM data: AI platforms often send identifiable referrer headers
-- Set up conversion tracking on AI-attributed visits to measure revenue impact, not just traffic
-- Monitor UTM coverage ratio: of all pages cited by AI models, what percentage have proper attribution tracking?
-
-**Key metrics:**
-
-- AI citation traffic volume (visits with AI-attributed UTM or referrer)
-- Citation-to-conversion rate (do AI-referred visitors convert differently?)
-- Page citation distribution (which pages get cited most/least?)
-- UTM coverage (percent of AI-cited pages with attribution tracking)
-
----
-
-## Voice Search Optimization
-
-Voice queries are conversational and question-based. Optimize for these patterns:
-
-### Question Formats for Voice
-
-- "What is..."
-- "How do I..."
-- "Where can I find..."
-- "Why does..."
-- "When should I..."
-- "Who is..."
-
-### Voice-Optimized Answer Structure
-
-- Lead with direct answer (under 30 words ideal)
-- Use natural, conversational language
-- Avoid jargon unless targeting expert audience
-- Include local context where relevant
-- Structure for single spoken response
+**Key metrics:** AI citation traffic volume, citation-to-conversion rate, page citation distribution, UTM coverage (% of cited pages with tracking).

--- a/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
@@ -100,7 +100,7 @@ Patterns for citation by AI assistants (ChatGPT, Claude, Perplexity, Gemini).
 
 ### Statistic Citation Block
 
-Statistics increase AI citation rates by 15-30%. Always include sources.
+Statistics can increase AI citation rates. Always include sources.
 
 ```markdown
 [Claim]. According to [Source], [statistic with number and timeframe]. [Why this matters].


### PR DESCRIPTION
## Summary

- Reduced `.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md` from 405 to 224 lines (45% reduction)
- All 16 original content patterns preserved with templates and implementation guidance
- Zero markdownlint violations

## What changed

- Removed redundant full examples — templates are self-explanatory with inline annotations
- Compressed domain-specific GEO tactics (5 bullet-list sections) into a single table
- Eliminated overlap between Site-Searchable Product Block and GEO Product Block
- Folded Voice Search section into AEO patterns as a subsection
- Tightened UTM attribution section — removed verbose strategy bullets, kept key metrics
- Removed unnecessary horizontal rules and blank lines within code blocks

## Content preservation

All 16 patterns verified present: Definition, Step-by-Step, Comparison Table, Pros/Cons, FAQ, Listicle, Voice Search, Statistic Citation, Expert Quote, Authoritative Claim, Self-Contained Answer, Evidence Sandwich, GEO Product, Domain-Specific GEO (5 domains), Site-Searchable Product, UTM Citation Attribution.

## Runtime Testing

- **Testing level**: self-assessed
- **Risk classification**: Low (docs-only change)
- **Verification**: markdownlint-cli2 — 0 errors; content pattern grep — 16/16 present

Closes #9138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized SEO audit guidance: condensed AEO and GEO sections with simplified templates, shorter step instructions, consolidated comparison tables, and streamlined pros/cons and FAQs for quicker reading.
  * Replaced detailed domain tactics with a compact domain-to-signal table, shortened site-searchable and UTM guidance, and merged voice-search content into a shorter patterns subsection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->