### PR TITLE
9600: simplification: tighten agent doc Extension Testing - Cross-Browser QA

### DIFF
--- a/.agents/tools/browser/extension-dev/testing.md
+++ b/.agents/tools/browser/extension-dev/testing.md
@@ -20,50 +20,31 @@ tools:
 
 - **Purpose**: Test browser extensions across Chromium browsers and Firefox
 - **Tools**: Playwright (E2E), Chrome DevTools, browser-specific debugging
-- **Levels**: Unit -> Integration -> E2E -> Cross-browser -> Performance
+- **Levels**: Unit → Integration → E2E → Cross-browser → Performance
 
 **Testing tool decision tree**:
 
 ```text
-Need E2E testing with extension loaded?
-  -> Playwright (supports loading extensions in Chromium)
-
-Need to debug service worker?
-  -> chrome://extensions -> Inspect service worker
-
-Need to debug content scripts?
-  -> Browser DevTools -> Sources -> Content scripts
-
-Need cross-browser verification?
-  -> Test in Chrome + Firefox + Edge manually or via CI
+E2E with extension loaded?   → Playwright (Chromium only)
+Debug service worker?        → chrome://extensions → Inspect service worker
+Debug content scripts?       → DevTools → Sources → Content scripts
+Cross-browser verification?  → Chrome + Firefox + Edge (manual or CI)
 ```
 
 <!-- AI-CONTEXT-END -->
 
-## Testing Strategy
+## Unit Tests
 
-### Unit Tests
-
-Test business logic in isolation:
+Test business logic in isolation (message parsing, storage, data transforms, API clients):
 
 ```bash
-# Using Vitest (recommended with WXT)
-npm run test
-
-# Or Jest
-npx jest
+npm run test   # Vitest (recommended with WXT)
+npx jest       # Jest alternative
 ```
 
-Cover:
+## E2E Testing with Playwright
 
-- Message parsing and handling
-- Storage read/write logic
-- Data transformations
-- API client functions
-
-### E2E Testing with Playwright
-
-Playwright can load unpacked extensions in Chromium:
+Playwright loads unpacked extensions in Chromium only (not Firefox):
 
 ```typescript
 import { test, chromium } from '@playwright/test';
@@ -71,7 +52,6 @@ import path from 'path';
 
 test('extension popup works', async () => {
   const pathToExtension = path.resolve('.output/chrome-mv3');
-
   const context = await chromium.launchPersistentContext('', {
     headless: false, // Extensions require headed mode
     args: [
@@ -80,7 +60,6 @@ test('extension popup works', async () => {
     ],
   });
 
-  // Get extension ID from service worker
   let extensionId: string;
   const serviceWorkers = context.serviceWorkers();
   if (serviceWorkers.length > 0) {
@@ -90,23 +69,18 @@ test('extension popup works', async () => {
     extensionId = sw.url().split('/')[2];
   }
 
-  // Open popup
   const popup = await context.newPage();
   await popup.goto(`chrome-extension://${extensionId}/popup.html`);
-
-  // Test popup UI
   await popup.click('button#action');
   await popup.waitForSelector('#result');
-
   await context.close();
 });
 ```
 
-### Manual Testing Checklist
+## Manual Testing Checklist
 
-**Chrome/Chromium**:
+**Chrome/Chromium** (load from `.output/chrome-mv3/`):
 
-- [ ] Load unpacked extension from `.output/chrome-mv3/`
 - [ ] Popup opens and functions correctly
 - [ ] Content scripts inject on target pages
 - [ ] Service worker handles events
@@ -115,56 +89,36 @@ test('extension popup works', async () => {
 - [ ] Side panel works (if applicable)
 - [ ] Permissions requested correctly
 
-**Firefox**:
+**Firefox** (load temporary add-on from `.output/firefox-mv2/` or MV3):
 
-- [ ] Load temporary add-on from `.output/firefox-mv2/` (or MV3)
 - [ ] All features work as in Chrome
 - [ ] Firefox-specific APIs handled
 - [ ] No console errors
 
-**Edge**:
+**Edge** (load from `.output/chrome-mv3/` — same build):
 
-- [ ] Load unpacked from `.output/chrome-mv3/` (same build)
 - [ ] Edge-specific features work (if any)
 
-### Debugging
+## Debugging
 
-**Service Worker**:
+**Service Worker**: `chrome://extensions` → find extension → "Inspect views: service worker"
 
-1. Navigate to `chrome://extensions`
-2. Find your extension
-3. Click "Inspect views: service worker"
-4. Use DevTools Console and Sources
+**Content Scripts**: DevTools (F12) → Sources → Content scripts → set breakpoints
 
-**Content Scripts**:
+**Popup**: Right-click extension icon → "Inspect popup"
 
-1. Open target web page
-2. Open DevTools (F12)
-3. Go to Sources -> Content scripts
-4. Set breakpoints and debug
-
-**Popup**:
-
-1. Right-click extension icon
-2. Select "Inspect popup"
-3. DevTools opens for popup context
-
-**Storage**:
+**Storage** (DevTools console in any extension context):
 
 ```javascript
-// In DevTools console (any extension context)
 chrome.storage.local.get(null, console.log);
 chrome.storage.sync.get(null, console.log);
 ```
 
 ## Cross-Browser CI
 
-### GitHub Actions
-
 ```yaml
 name: Extension Tests
 on: [push, pull_request]
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -180,8 +134,6 @@ jobs:
 ```
 
 ## Pre-Submission Checklist
-
-Before submitting to stores:
 
 - [ ] All unit tests pass
 - [ ] E2E tests pass in Chrome


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/browser/extension-dev/testing.md` per simplification-debt scan (GH#9600).

**Changes:**
- Collapse decision tree to single-line format (saves 8 lines)
- Remove redundant `## Testing Strategy` / `### GitHub Actions` headings
- Merge unit test prose + bullet list into one compact block
- Remove obvious inline code comments in Playwright example
- Collapse numbered debugging steps to single-line format
- Remove "Before submitting to stores:" prose before checklist

**Result:** 202 → 154 lines (−24%). All content preserved — no code blocks, URLs, or references removed.

## Runtime Testing

- **Risk**: Low (docs/agent prompt only — no code execution path)
- **Testing level**: self-assessed
- **Verification**: `wc -l` before (202) and after (154); content diff reviewed

Closes #9600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and simplified testing documentation with improved formatting and readability.
  * Updated manual testing checklist with specific browser load paths for Chrome/Chromium, Firefox, and Edge.
  * Streamlined debugging section with simplified navigation steps.
  * Refined E2E testing guidance to clarify platform-specific support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->