### PR TITLE
9595: tighten agent doc llm-tldr — 218→86 lines

### DIFF
--- a/.agents/tools/context/llm-tldr.md
+++ b/.agents/tools/context/llm-tldr.md
@@ -14,7 +14,7 @@ tools:
 
 # llm-tldr - Semantic Code Analysis
 
-TLDR extracts code structure and semantics, saving ~95% tokens compared to raw code.
+TLDR extracts code structure and semantics, saving ~95% tokens vs raw code.
 
 **Source**: [parcadei/llm-tldr](https://github.com/parcadei/llm-tldr)
 
@@ -26,8 +26,6 @@ pip install llm-tldr
 
 ## MCP Server (OpenCode)
 
-Add to your MCP config:
-
 ```json
 {
   "llm-tldr": {
@@ -37,102 +35,25 @@ Add to your MCP config:
 }
 ```
 
-Or use the template: `configs/mcp-templates/llm-tldr.json`
+Template: `configs/mcp-templates/llm-tldr.json`
 
 ## CLI Commands
 
-### Tree - File Structure
-
-```bash
-tldr tree /path/to/project
-```
-
-Shows file tree with line counts.
-
-### Structure - Code Skeleton
-
-```bash
-tldr structure /path/to/file.py
-```
-
-Extracts classes, functions, imports without implementation details.
-
-### Context - Full Analysis
-
-```bash
-tldr context /path/to/file.py
-```
-
-Comprehensive analysis including:
-- Imports and dependencies
-- Class/function signatures
-- Docstrings
-- Type hints
-- Call relationships
-
-### CFG - Control Flow Graph
-
-```bash
-tldr cfg /path/to/file.py function_name
-```
-
-Shows control flow for a specific function.
-
-### DFG - Data Flow Graph
-
-```bash
-tldr dfg /path/to/file.py function_name
-```
-
-Shows data dependencies and variable flow.
-
-### Semantic Search
-
-```bash
-tldr search "authentication logic" /path/to/project
-```
-
-Uses bge-large-en-v1.5 embeddings (1024-dim) for semantic code search.
-
-### Impact Analysis
-
-```bash
-tldr impact /path/to/file.py function_name
-```
-
-Shows what would be affected by changing a function.
-
-### Dead Code Detection
-
-```bash
-tldr dead /path/to/project
-```
-
-Finds unused functions and classes.
-
-### Slice - Code Slice
-
-```bash
-tldr slice /path/to/file.py variable_name
-```
-
-Extracts code slice affecting a variable.
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `tree` | `tldr tree /path/to/project` | File structure with line counts |
+| `structure` | `tldr structure /path/to/file.py` | Classes, functions, imports (no impl) |
+| `context` | `tldr context /path/to/file.py` | Full analysis: imports, signatures, docstrings, types, call graph |
+| `cfg` | `tldr cfg /path/to/file.py fn_name` | Control flow graph for a function |
+| `dfg` | `tldr dfg /path/to/file.py fn_name` | Data flow / variable dependencies |
+| `search` | `tldr search "auth logic" /path` | Semantic search (bge-large-en-v1.5, 1024-dim) |
+| `impact` | `tldr impact /path/to/file.py fn_name` | What would break if this function changes |
+| `dead` | `tldr dead /path/to/project` | Unused functions and classes |
+| `slice` | `tldr slice /path/to/file.py var_name` | Code slice affecting a variable |
 
 ## MCP Tools (via tldr-mcp)
 
-When running as MCP server, provides these tools:
-
-| Tool | Purpose |
-|------|---------|
-| `tldr_tree` | Get project file structure |
-| `tldr_structure` | Extract code skeleton |
-| `tldr_context` | Full semantic analysis |
-| `tldr_cfg` | Control flow graph |
-| `tldr_dfg` | Data flow graph |
-| `tldr_search` | Semantic code search |
-| `tldr_impact` | Impact analysis |
-| `tldr_dead` | Dead code detection |
-| `tldr_slice` | Code slicing |
+Same commands as CLI, prefixed `tldr_`: `tldr_tree`, `tldr_structure`, `tldr_context`, `tldr_cfg`, `tldr_dfg`, `tldr_search`, `tldr_impact`, `tldr_dead`, `tldr_slice`.
 
 ## Token Savings
 
@@ -142,54 +63,17 @@ When running as MCP server, provides these tools:
 | Class definition | ~500 | ~50 | 90% |
 | Function body | ~200 | ~20 | 90% |
 
-## Use Cases
+## When to Use
 
-### Before Editing Code
+- **Before editing**: `tldr context` + `tldr impact` to understand scope
+- **Codebase exploration**: `tldr search` for concepts, `tldr tree` for overview
+- **Code review**: `tldr dead` for unused code, `tldr dfg` for data flow
 
-```bash
-# Get structure before making changes
-tldr context src/auth/handler.py
-
-# Check what would be affected
-tldr impact src/auth/handler.py validate_token
-```
-
-### Understanding Codebase
-
-```bash
-# Find authentication logic
-tldr search "where do we validate JWT tokens" ./src
-
-# Get project overview
-tldr tree ./src
-```
-
-### Code Review
-
-```bash
-# Check for dead code
-tldr dead ./src
-
-# Understand data flow
-tldr dfg src/payment/processor.py process_payment
-```
-
-## Comparison with Other Tools
-
-| Tool | Purpose | Token Efficiency |
-|------|---------|------------------|
-| llm-tldr | Semantic extraction | 95% savings |
-| Augment | Codebase retrieval | Good for context |
-| repomix | Full packing | No savings |
-
-**Recommendation**: Use llm-tldr for understanding code structure, rg/Augment for finding code, repomix for full context when needed.
+**vs other tools**: llm-tldr for structure/semantics; rg/Augment for finding code; repomix for full context.
 
 ## Integration with Memory System
 
-After using TLDR to understand code:
-
 ```bash
-# Remember the pattern you discovered
 ~/.aidevops/agents/scripts/memory-helper.sh store "CODEBASE_PATTERN" \
   "Auth flow: validate_token -> check_permissions -> authorize" \
   "auth,flow,pattern" "myproject"
@@ -197,22 +81,6 @@ After using TLDR to understand code:
 
 ## Troubleshooting
 
-### Embedding Model Download
-
-First run downloads bge-large-en-v1.5 (~1.3GB). Be patient.
-
-### Unsupported Language
-
-TLDR supports: Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Ruby, PHP, C#, Kotlin, Scala, Lua, Elixir.
-
-For other languages, use `tldr tree` and `tldr context` (basic parsing).
-
-### MCP Connection Issues
-
-```bash
-# Test MCP server directly
-tldr-mcp --project /path/to/project
-
-# Check if running
-ps aux | grep tldr-mcp
-```
+- **First run**: downloads bge-large-en-v1.5 (~1.3GB)
+- **Unsupported language**: supports Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Ruby, PHP, C#, Kotlin, Scala, Lua, Elixir. Others: use `tldr tree` + `tldr context` (basic parsing)
+- **MCP issues**: `tldr-mcp --project /path/to/project` to test; `ps aux | grep tldr-mcp` to check running


### PR DESCRIPTION
## Summary

- Collapsed 9 verbose per-command sections into a single reference table
- Merged Use Cases into a concise When-to-Use section (3 bullets)
- Consolidated Troubleshooting into inline bullets
- Zero content loss: all commands, MCP config, token savings table, memory integration, and troubleshooting preserved

## Runtime Testing

- **Risk**: Low (docs/agent prompts only)
- **Level**: self-assessed
- **Verification**: `wc -l` confirms 218→86 lines; all CLI commands, MCP tools, token savings table, and troubleshooting present in output

## Files Changed

- `.agents/tools/context/llm-tldr.md` — tightened from 218 to 86 lines (61% reduction)

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #9595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Streamlined documentation for improved readability and clarity
  * Updated token efficiency messaging
  * Converted detailed command references into a concise tabular format
  * Simplified configuration guidance with clearer examples
  * Condensed redundant sections for better user navigation
  * Enhanced quick-reference layout for CLI and tool commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->