### PR TITLE
9594: simplify stealth-patches.md (219→158 lines)

### DIFF
--- a/.agents/tools/browser/stealth-patches.md
+++ b/.agents/tools/browser/stealth-patches.md
@@ -10,10 +10,6 @@ tools:
 
 # Stealth Patches (Chromium/Playwright)
 
-<!-- AI-CONTEXT-START -->
-
-## Overview
-
 Patches for Playwright/Chromium to remove automation detection signals. Uses `rebrowser-patches` (1.2k stars, MIT) as the primary solution, with `playwright-stealth` as a lightweight alternative.
 
 ## Tool Selection
@@ -26,67 +22,40 @@ Patches for Playwright/Chromium to remove automation detection signals. Uses `re
 
 ## rebrowser-patches
 
-### What It Fixes
-
-1. **Runtime.enable leak** - Anti-bots detect CDP `Runtime.enable` calls that Playwright makes
-2. **navigator.webdriver** - Removes the `webdriver` flag
-3. **CDP leak prevention** - Hides Chrome DevTools Protocol artifacts
-4. **Headless detection** - Patches headless mode indicators
-5. **sourceURL leak** - Removes `//# sourceURL=` from injected scripts
+Fixes: Runtime.enable CDP leak, `navigator.webdriver` flag, CDP artifacts, headless indicators, `//# sourceURL=` leaks.
 
 ### Installation
 
 ```bash
-# Patch existing Playwright installation (Node.js)
-npx rebrowser-patches@latest patch
-
-# Or use drop-in replacement package
-npm install rebrowser-playwright
-# Then: import { chromium } from 'rebrowser-playwright';
-
-# Python drop-in replacement
-pip install rebrowser-playwright
-# Then: from rebrowser_playwright.sync_api import sync_playwright
-
-# Unpatch (restore original)
-npx rebrowser-patches@latest unpatch
+npx rebrowser-patches@latest patch        # Patch existing Playwright (Node.js)
+npm install rebrowser-playwright          # Drop-in replacement (Node.js)
+pip install rebrowser-playwright          # Drop-in replacement (Python)
+npx rebrowser-patches@latest unpatch     # Restore original
 ```
 
-### Usage (Node.js)
+### Usage
+
+**Node.js** — use patched playwright or drop-in:
 
 ```javascript
-// Option 1: Patched Playwright (after npx rebrowser-patches patch)
-import { chromium } from 'playwright';
-
-// Option 2: Drop-in replacement (no patching needed)
-import { chromium } from 'rebrowser-playwright';
+import { chromium } from 'rebrowser-playwright';  // or 'playwright' after patching
 
 const browser = await chromium.launch({
   headless: true,
-  args: [
-    '--disable-blink-features=AutomationControlled',
-  ]
+  args: ['--disable-blink-features=AutomationControlled'],
 });
-
 const context = await browser.newContext({
-  // Realistic viewport
   viewport: { width: 1920, height: 1080 },
-  // Realistic user agent
   userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
 });
-
 const page = await context.newPage();
 await page.goto('https://www.browserscan.net/bot-detection');
 ```
 
-### Usage (Python)
+**Python** — same options:
 
 ```python
-# Option 1: Drop-in replacement
-from rebrowser_playwright.sync_api import sync_playwright
-
-# Option 2: Standard playwright (after patching)
-from playwright.sync_api import sync_playwright
+from rebrowser_playwright.sync_api import sync_playwright  # or playwright after patching
 
 with sync_playwright() as p:
     browser = p.chromium.launch(
@@ -103,15 +72,11 @@ with sync_playwright() as p:
 
 ## playwright-stealth (Python)
 
-Lightweight alternative for Python scripts. Applies JS-level evasions.
-
-### Installation
+JS-level evasions. Patches: `navigator.webdriver`, plugins, languages, `chrome.runtime`, `window.chrome`, Permissions API, iframe detection, WebGL strings, `hardwareConcurrency`.
 
 ```bash
 pip install playwright-stealth
 ```
-
-### Usage
 
 ```python
 from playwright.sync_api import sync_playwright
@@ -120,25 +85,11 @@ from playwright_stealth import stealth_sync
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)
     page = browser.new_page()
-    stealth_sync(page)  # Apply stealth evasions
+    stealth_sync(page)
     page.goto('https://bot.sannysoft.com')
 ```
 
-### What It Patches (JS-level)
-
-- `navigator.webdriver` → undefined
-- `navigator.plugins` → realistic plugin list
-- `navigator.languages` → matches Accept-Language
-- `chrome.runtime` → realistic object
-- `window.chrome` → present
-- `Permissions.query` → realistic responses
-- `iframe.contentWindow` → no blank detection
-- `WebGL vendor/renderer` → realistic strings
-- `navigator.hardwareConcurrency` → realistic value
-
 ## Manual Stealth Args (Minimal)
-
-For basic stealth without additional packages:
 
 ```javascript
 const browser = await chromium.launch({
@@ -163,26 +114,18 @@ const browser = await chromium.launch({
 
 ## Integration with aidevops
 
-### With anti-detect-helper.sh
-
 ```bash
-# Setup rebrowser-patches
 ~/.aidevops/agents/scripts/anti-detect-helper.sh setup --engine chromium
-
-# Launch with stealth (auto-applies patches)
 ~/.aidevops/agents/scripts/anti-detect-helper.sh launch --engine chromium --profile "my-profile"
 ```
 
-### With Existing Playwright Scripts
-
 ```javascript
-// Add to any existing Playwright script for stealth
 import { createStealthContext } from '~/.aidevops/agents/scripts/stealth-context.mjs';
 
 const { browser, context, page } = await createStealthContext({
   headless: true,
   proxy: { server: 'socks5://127.0.0.1:1080' },  // Optional
-  profile: 'my-profile',  // Optional: load saved state
+  profile: 'my-profile',                           // Optional: load saved state
 });
 ```
 
@@ -197,14 +140,12 @@ const { browser, context, page } = await createStealthContext({
 | **Pixelscan** | Fingerprint consistency | https://pixelscan.net |
 | **Incolumitas** | Bot detection suite | https://bot.incolumitas.com |
 
-## Limitations
+## Limitations & Comparison
 
 - **rebrowser-patches**: Chromium only, needs re-patching after Playwright updates
 - **playwright-stealth**: JS-level only, detectable by sophisticated anti-bots
-- **Neither**: Handles fingerprint rotation, WebRTC spoofing, or font spoofing
+- **Neither**: handles fingerprint rotation, WebRTC spoofing, or font spoofing
 - **For full anti-detect**: Use Camoufox (see `fingerprint-profiles.md`)
-
-## Comparison: rebrowser-patches vs Camoufox
 
 | Aspect | rebrowser-patches | Camoufox |
 |--------|------------------|----------|
@@ -215,5 +156,3 @@ const { browser, context, page } = await createStealthContext({
 | **Maintenance** | Re-patch on updates | pip upgrade |
 | **Language** | Node.js / Python | Python |
 | **Best for** | Quick stealth on existing code | Full anti-detect profiles |
-
-<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

- Merged duplicate Node.js/Python usage sections into unified blocks with inline language labels
- Consolidated `rebrowser-patches` "What It Fixes" numbered list into a single prose line
- Removed `<!-- AI-CONTEXT-START/END -->` wrapper (subagent doc, not main agent)
- Removed redundant inline code comments that restate the obvious (e.g., `// Realistic viewport`)
- Merged separate Limitations + Comparison sections into one
- All commands, URLs, code examples, and technical content preserved

**Line count:** 219 → 158 (28% reduction)

## Runtime Testing

- **Risk classification:** Low (docs-only change, no code)
- **Testing level:** self-assessed
- **Verification:** `wc -l` confirms 158 lines; all code blocks, URLs, and commands present

Closes #9594