### PR TITLE
t9539: tighten opencode-gitlab.md agent doc (252→144 lines)

### DIFF
--- a/.agents/tools/git/opencode-gitlab.md
+++ b/.agents/tools/git/opencode-gitlab.md
@@ -19,10 +19,8 @@ tools:
 ## Quick Reference
 
 - **Trigger**: `@opencode` in any issue/MR comment
-- **Runs on**: Your GitLab CI runners (secure)
-- **Docs**: https://opencode.ai/docs/gitlab/
-
-**What It Does**:
+- **Runs on**: Your GitLab CI runners (code never leaves your environment)
+- **Docs**: <https://opencode.ai/docs/gitlab/>
 
 | Command | Result |
 |---------|--------|
@@ -30,47 +28,19 @@ tools:
 | `@opencode fix this` | Creates branch, implements fix, opens MR |
 | `@opencode review this MR` | Reviews code, suggests improvements |
 
-**Requirements**:
-- GitLab CI/CD pipeline configured
-- CI/CD Variables: `ANTHROPIC_API_KEY`, `GITLAB_TOKEN_OPENCODE`, `GITLAB_HOST`
-- Service account for git operations
+**Requirements**: GitLab CI/CD enabled, CI/CD variables (`ANTHROPIC_API_KEY`, `GITLAB_TOKEN_OPENCODE`, `GITLAB_HOST`), service account with `api` + `read_repository` + `write_repository` scopes.
 
 <!-- AI-CONTEXT-END -->
 
-## Overview
-
-OpenCode's GitLab integration enables AI-powered automation directly from GitLab issues and merge requests. When you comment `@opencode fix this` on an issue, OpenCode:
-
-1. Analyzes the issue context
-2. Creates a new branch
-3. Implements the fix
-4. Opens a merge request with the changes
-
-All execution happens securely on YOUR GitLab CI runners.
-
 ## Installation
-
-### Prerequisites
-
-1. GitLab repository with CI/CD enabled
-2. AI provider API key (Anthropic, OpenAI, etc.)
-3. GitLab access token for the service account
-4. `glab` CLI available in your CI image
 
 ### Step 1: Create Service Account
 
-Create a GitLab user or use a project access token for OpenCode operations.
-
-Required scopes:
-- `api` - Full API access
-- `read_repository` - Read repository
-- `write_repository` - Write repository
+Create a GitLab user or project access token with scopes: `api`, `read_repository`, `write_repository`.
 
 ### Step 2: Configure CI/CD Variables
 
-Go to: Settings → CI/CD → Variables
-
-Add these variables:
+Settings > CI/CD > Variables:
 
 | Variable | Value | Protected | Masked |
 |----------|-------|-----------|--------|
@@ -80,7 +50,7 @@ Add these variables:
 
 ### Step 3: Create CI/CD Pipeline
 
-Create `.gitlab-ci.yml` or add to existing:
+Add to `.gitlab-ci.yml`:
 
 ```yaml
 stages:
@@ -90,7 +60,6 @@ opencode:
   stage: opencode
   image: node:22-slim
   rules:
-    # Trigger on issue/MR comments containing @opencode
     - if: '$CI_PIPELINE_SOURCE == "trigger"'
       when: always
   before_script:
@@ -103,16 +72,18 @@ opencode:
     # Configure git
     - git config --global user.email "opencode@gitlab.com"
     - git config --global user.name "OpenCode"
-    # Setup OpenCode auth
+    # Setup OpenCode auth (supports multiple providers)
     - mkdir -p ~/.local/share/opencode
     - |
       cat > ~/.local/share/opencode/auth.json << EOF
-      { "anthropic": { "apiKey": "$ANTHROPIC_API_KEY" } }
+      {
+        "anthropic": { "apiKey": "$ANTHROPIC_API_KEY" },
+        "openai": { "apiKey": "$OPENAI_API_KEY" }
+      }
       EOF
   script:
-    # Run OpenCode with the trigger context
+    # Specify model with --model (e.g., anthropic/claude-sonnet-4-6)
     - opencode run "$AI_FLOW_INPUT"
-    # Commit and push any changes
     - |
       if [ -n "$(git status --porcelain)" ]; then
         git add -A
@@ -126,115 +97,36 @@ opencode:
 
 ### Step 4: Configure Webhook (Optional)
 
-For automatic triggering on comments, configure a webhook:
-
-1. Go to: Settings → Webhooks
-2. URL: Your pipeline trigger URL
-3. Trigger: Note events (issues and MRs)
-
-## Usage
-
-### In Issues
-
-Comment on any issue:
-
-```text
-@opencode explain this issue
-```
-
-OpenCode reads the issue and replies with an explanation.
-
-```text
-@opencode fix this
-```
-
-OpenCode creates a branch, implements a fix, and opens an MR.
-
-### In Merge Requests
-
-Comment on an MR:
-
-```text
-@opencode review this merge request
-```
-
-OpenCode analyzes the changes and provides feedback.
+For automatic triggering on comments: Settings > Webhooks > set URL to your pipeline trigger URL, trigger on Note events (issues and MRs).
 
 ## Configuration
 
-### Using Different AI Providers
+**Self-hosted GitLab**: Set `GITLAB_HOST` to your instance URL in CI/CD variables (e.g., `gitlab.company.com`).
 
-Update the auth.json creation in your pipeline:
+**Custom model**: Pass `--model` flag in the script section (e.g., `opencode run --model anthropic/claude-sonnet-4-6 "$AI_FLOW_INPUT"`).
 
-```yaml
-# For OpenAI
-- |
-  cat > ~/.local/share/opencode/auth.json << EOF
-  { "openai": { "apiKey": "$OPENAI_API_KEY" } }
-  EOF
-
-# For multiple providers
-- |
-  cat > ~/.local/share/opencode/auth.json << EOF
-  {
-    "anthropic": { "apiKey": "$ANTHROPIC_API_KEY" },
-    "openai": { "apiKey": "$OPENAI_API_KEY" }
-  }
-  EOF
-```
-
-### Custom Model
-
-Specify model in the opencode run command:
-
-```yaml
-script:
-  - opencode run --model anthropic/claude-sonnet-4-6 "$AI_FLOW_INPUT"
-```
-
-### Self-Hosted GitLab
-
-Set `GITLAB_HOST` to your instance URL:
-
-```yaml
-variables:
-  GITLAB_HOST: gitlab.company.com
-```
+**Provider selection**: Include only the providers you use in `auth.json`. Remove unused entries from the template above.
 
 ## Security
 
-- **Runs on YOUR runners**: Code never leaves your GitLab CI environment
-- **Secrets in CI/CD Variables**: API keys stored securely
-- **Service account isolation**: Dedicated account for OpenCode operations
-- **Audit trail**: All pipeline runs visible in CI/CD → Pipelines
+- **Runs on YOUR runners** -- code never leaves your GitLab CI environment
+- **Secrets in CI/CD Variables** -- API keys stored securely, masked in logs
+- **Service account isolation** -- dedicated account for OpenCode operations
+- **Audit trail** -- all pipeline runs visible in CI/CD > Pipelines
 
 ## Troubleshooting
 
-### Pipeline Not Triggering
-
-1. Check webhook configuration
-2. Verify trigger rules in `.gitlab-ci.yml`
-3. Check CI/CD is enabled for the project
-
-### Authentication Errors
-
-1. Verify `GITLAB_TOKEN_OPENCODE` has correct scopes
-2. Check token hasn't expired
-3. Verify `GITLAB_HOST` is correct
-
-### OpenCode Errors
-
-1. Check `ANTHROPIC_API_KEY` is set correctly
-2. Verify auth.json is created properly
-3. Check pipeline logs for specific errors
+| Problem | Checks |
+|---------|--------|
+| Pipeline not triggering | Webhook config, trigger rules in `.gitlab-ci.yml`, CI/CD enabled for project |
+| Authentication errors | `GITLAB_TOKEN_OPENCODE` scopes, token expiry, `GITLAB_HOST` value |
+| OpenCode errors | `ANTHROPIC_API_KEY` set correctly, `auth.json` created properly, pipeline logs |
 
 ## Integration with aidevops
 
-When using aidevops workflows:
-
-1. **Branch naming**: Configure OpenCode to use aidevops conventions
-2. **MR format**: Use custom prompts for aidevops-style MR descriptions
-3. **Quality checks**: OpenCode MRs trigger your existing CI pipelines
+- **Branch naming**: Configure OpenCode to use aidevops conventions (`feature/`, `bugfix/`, etc.)
+- **MR format**: Use custom prompts for aidevops-style MR descriptions
+- **Quality checks**: OpenCode MRs trigger your existing CI pipelines automatically
 
 ## Comparison with GitHub Integration
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/git/opencode-gitlab.md` from 252 lines to 144 lines (43% reduction)
- Removed redundant Overview section that duplicated the Quick Reference table
- Removed duplicate Usage examples (commands already shown in Quick Reference)
- Consolidated three separate provider auth YAML blocks into one annotated template
- Converted troubleshooting numbered lists into a single diagnostic table
- Inlined self-hosted GitLab and custom model config (were separate sections with minimal content)
- Preserved all actionable information: CI/CD pipeline YAML, webhook setup, security model, comparison table, all URLs and command references

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/agent prompt only)
- **Verification**: markdownlint — 0 errors. All URLs, code blocks, CLI commands, and cross-references verified present in output.

Closes #9539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined GitLab integration guide with condensed instructions and clearer setup steps
  * Enhanced CI pipeline configuration to support both Anthropic and OpenAI API providers
  * Reorganized troubleshooting section for improved reference and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->