### PR TITLE
t7683: Fix qwen3-tts.md CodeRabbit review comments (PR #7695 follow-up)

### DIFF
--- a/.agents/tools/voice/qwen3-tts.md
+++ b/.agents/tools/voice/qwen3-tts.md
@@ -21,107 +21,59 @@ tools:
 
 - **Source**: [QwenLM/Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS) (Apache-2.0)
 - **Purpose**: Multi-language TTS with voice cloning, voice design, and ultra-low latency
-- **Languages**: 10 languages (zh/en/ja/ko/de/fr/ru/pt/es/it)
-- **Latency**: 97ms streaming latency (first chunk)
-- **Models**: 1.7B and 0.6B variants (CustomVoice, VoiceDesign, Base)
-- **Install**: `pip install qwen-tts` or vLLM-Omni
-- **Helper**: `voice-helper.sh talk whisper-mlx qwen3-tts` (integration with voice bridge)
+- **Languages**: zh, en, ja, ko, de, fr, ru, pt, es, it (auto-detected)
+- **Latency**: 97ms streaming (first chunk)
+- **Models**: 1.7B (~4GB VRAM) and 0.6B (~2GB) in Base, CustomVoice, VoiceDesign variants
+- **Install**: `pip install qwen-tts` or `pip install vllm-omni` (production serving)
+- **Helper**: `voice-helper.sh talk whisper-mlx qwen3-tts` (voice bridge integration)
 
-**When to Use**: Read this when you need multi-language TTS with voice cloning (3s reference), custom voice control (9 speakers + instruction), or voice design (natural language persona description). Ideal for production voice agents, content creation, and accessibility applications.
+**When to Use**: Multi-language TTS with voice cloning (3s reference), custom voice control (9 speakers + instruction), or voice design (natural language persona). Ideal for voice agents, content creation, and accessibility.
 
 <!-- AI-CONTEXT-END -->
 
-## Architecture
+## Models
 
-Qwen3-TTS is a discrete multi-codebook language model TTS system:
+Three variants, each in 1.7B (quality) and 0.6B (lightweight):
 
-```text
-Text Input -> [Text Encoder] -> [Multi-Codebook LM] -> [Vocoder] -> Audio Output
-                                        |
-                                   [Voice Prompt]
-                                   (3s reference OR
-                                    speaker ID OR
-                                    persona description)
-```
+| Variant | Capability |
+|---------|-----------|
+| **Base** | 9 preset speakers, standard TTS |
+| **CustomVoice** | Voice cloning from 3s reference + instruction control |
+| **VoiceDesign** | Voice generation from natural language persona description |
 
-Three model variants:
-
-1. **Base**: Standard TTS with 9 preset speakers
-2. **CustomVoice**: Voice cloning from 3-second reference audio + instruction control
-3. **VoiceDesign**: Voice generation from natural language persona description
-
-## Model Selection
-
-| Model | Size | Use Case | VRAM |
-|-------|------|----------|------|
-| Qwen3-TTS-1.7B-Base | 1.7B | High quality, 9 preset speakers | ~4GB |
-| Qwen3-TTS-0.6B-Base | 0.6B | Lightweight, 9 preset speakers | ~2GB |
-| Qwen3-TTS-1.7B-CustomVoice | 1.7B | Voice cloning + instruction control | ~4GB |
-| Qwen3-TTS-0.6B-CustomVoice | 0.6B | Lightweight voice cloning | ~2GB |
-| Qwen3-TTS-1.7B-VoiceDesign | 1.7B | Persona-based voice generation | ~4GB |
-| Qwen3-TTS-0.6B-VoiceDesign | 0.6B | Lightweight voice design | ~2GB |
-
-**Recommendation**: Start with 0.6B-CustomVoice for development (lower VRAM), upgrade to 1.7B for production quality.
+**Start with 0.6B-CustomVoice** for development; upgrade to 1.7B for production.
 
 ## Setup
 
-### Via Python Package (Recommended)
-
 ```bash
-# Install qwen-tts package
+# Python package (recommended)
 pip install qwen-tts
 
-# Or with uv (faster)
-uv pip install qwen-tts
-```
-
-### Via vLLM-Omni (For Production Serving)
-
-```bash
-# Install vLLM-Omni
+# Production server (vLLM-Omni)
 pip install vllm-omni
-
-# Start server
-vllm serve Qwen/Qwen3-TTS-1.7B-CustomVoice \
-    --task tts \
-    --dtype auto \
-    --max-model-len 2048
+vllm serve Qwen/Qwen3-TTS-1.7B-CustomVoice --task tts --dtype auto --max-model-len 2048
 ```
 
 ## Usage
 
-### Base Model (Preset Speakers)
+### Base (Preset Speakers)
 
 ```python
 from qwen_tts import QwenTTS
 
-# Initialize model
 tts = QwenTTS(model="Qwen/Qwen3-TTS-1.7B-Base")
-
-# Generate speech with speaker ID (0-8)
-audio = tts.synthesize(
-    text="Hello, I am your AI DevOps assistant.",
-    speaker_id=0,  # 0-8 for different voices
-    language="en"
-)
-
-# Save to file
+audio = tts.synthesize(text="Hello, I am your AI DevOps assistant.", speaker_id=0, language="en")
 tts.save_audio(audio, "output.wav")
 ```
 
 ### CustomVoice (Voice Cloning)
 
 ```python
-from qwen_tts import QwenTTS
-
-# Initialize CustomVoice model
 tts = QwenTTS(model="Qwen/Qwen3-TTS-1.7B-CustomVoice")
-
-# Clone voice from 3-second reference
 audio = tts.synthesize(
     text="This is a cloned voice speaking.",
-    reference_audio="path/to/reference.wav",  # 3s+ reference
-    instruction="Speak in a calm, professional tone",  # Optional control
+    reference_audio="path/to/reference.wav",  # 3s+ clean speech, single speaker, 16kHz+
+    instruction="Speak in a calm, professional tone",
     language="en"
 )
 ```
@@ -129,12 +81,7 @@ audio = tts.synthesize(
 ### VoiceDesign (Persona-Based)
 
 ```python
-from qwen_tts import QwenTTS
-
-# Initialize VoiceDesign model
 tts = QwenTTS(model="Qwen/Qwen3-TTS-1.7B-VoiceDesign")
-
-# Generate voice from persona description
 audio = tts.synthesize(
     text="Welcome to the AI DevOps framework.",
     persona="A friendly female voice, mid-30s, British accent, warm and professional",
@@ -142,184 +89,72 @@ audio = tts.synthesize(
 )
 ```
 
-### Streaming (Low Latency)
+### Streaming
 
 ```python
-from qwen_tts import QwenTTS
-
 tts = QwenTTS(model="Qwen/Qwen3-TTS-0.6B-CustomVoice", streaming=True)
-
-# Stream audio chunks (97ms first chunk latency)
-for chunk in tts.synthesize_stream(
-    text="This is a streaming example with ultra-low latency.",
-    speaker_id=0,
-    language="en"
-):
-    # Play chunk immediately (e.g., via sounddevice)
+for chunk in tts.synthesize_stream(text="Streaming with 97ms first-chunk latency.", speaker_id=0, language="en"):
     play_audio(chunk)
 ```
 
-## Multi-Language Support
-
-Qwen3-TTS supports 10 languages with automatic language detection:
-
-| Language | Code | Notes |
-|----------|------|-------|
-| Chinese | `zh` | Mandarin |
-| English | `en` | US/UK |
-| Japanese | `ja` | |
-| Korean | `ko` | |
-| German | `de` | |
-| French | `fr` | |
-| Russian | `ru` | |
-| Portuguese | `pt` | BR/PT |
-| Spanish | `es` | ES/LATAM |
-| Italian | `it` | |
-
-```python
-# Auto-detect language
-audio = tts.synthesize(text="Bonjour, je suis votre assistant IA.")
-
-# Or specify explicitly
-audio = tts.synthesize(text="Bonjour, je suis votre assistant IA.", language="fr")
-```
-
-## Integration with Voice Bridge
-
-Add Qwen3-TTS to the aidevops voice bridge:
+## Voice Bridge Integration
 
 ```bash
-# Use Qwen3-TTS as TTS engine
-voice-helper.sh talk whisper-mlx qwen3-tts
-
-# With custom voice (positional: stt tts voice)
-voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav
-
-# With custom voice and model (positional: stt tts voice model)
-voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav opencode/claude-sonnet-4-6
+voice-helper.sh talk whisper-mlx qwen3-tts                              # Default
+voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav        # Custom voice
+voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav opencode/claude-sonnet-4-6  # Custom voice + model
 ```
 
-> **Note**: `voice-helper.sh talk` uses positional arguments (`stt tts voice model`). Named flags like
-> `--voice-ref` and `--persona` are not supported. Voice design (persona descriptions) must be
-> configured via the Qwen3-TTS Python API directly — see the Voice Design section above.
+> Positional args: `stt tts voice model`. Named flags (`--voice-ref`, `--persona`) not supported.
+> Voice design (persona descriptions) must use the Python API directly.
 
-See `voice-helper.sh` for full integration details.
-
-## Performance Optimization
-
-### GPU Acceleration
+## Performance
 
 ```python
-# Use CUDA for faster inference
-tts = QwenTTS(model="Qwen/Qwen3-TTS-1.7B-CustomVoice", device="cuda")
+tts = QwenTTS(model="Qwen/Qwen3-TTS-1.7B-CustomVoice", device="cuda")  # GPU acceleration
+tts = QwenTTS(model="...", cache_dir="~/.cache/qwen-tts")               # Model caching
+
+# Batch processing
+audios = tts.batch_synthesize(["First.", "Second.", "Third."], speaker_id=0, language="en")
 ```
 
-### Batch Processing
+## Voice Cloning Tips
 
-```python
-# Process multiple texts in parallel
-texts = ["First sentence.", "Second sentence.", "Third sentence."]
-audios = tts.batch_synthesize(texts, speaker_id=0, language="en")
-```
+- **Reference audio**: 3+ seconds clean speech, single speaker, no background noise, 16kHz+
+- **Instruction control**: natural language — "Speak slowly", "Sound excited", "British accent"
+- **Persona design**: be specific — age, gender, accent, personality (e.g., "A cheerful young woman in her 20s, American accent, enthusiastic")
 
-### Model Caching
-
-```python
-# Cache model for faster subsequent loads
-tts = QwenTTS(
-    model="Qwen/Qwen3-TTS-1.7B-CustomVoice",
-    cache_dir="~/.cache/qwen-tts"
-)
-```
-
-## Voice Cloning Best Practices
-
-1. **Reference Audio Quality**:
-   - 3+ seconds of clean speech
-   - Single speaker, no background noise
-   - Clear pronunciation
-   - Sample rate: 16kHz or higher
-
-2. **Instruction Control**:
-   - Use natural language: "Speak slowly and clearly"
-   - Emotion: "Sound excited and energetic"
-   - Tone: "Use a professional, calm tone"
-   - Accent: "British accent" or "American accent"
-
-3. **Persona Design**:
-   - Be specific: age, gender, accent, personality
-   - Example: "A cheerful young woman in her 20s, American accent, enthusiastic and friendly"
-
-## Deployment Modes
-
-### Local (Development)
+## Production Deployment
 
 ```bash
-# Run locally with Python
-python your_tts_script.py
-```
+# vLLM-Omni server
+vllm serve Qwen/Qwen3-TTS-1.7B-CustomVoice --task tts --host 0.0.0.0 --port 8000 --dtype auto
 
-### Server (Production)
-
-```bash
-# Start vLLM-Omni server
-vllm serve Qwen/Qwen3-TTS-1.7B-CustomVoice \
-    --task tts \
-    --host 0.0.0.0 \
-    --port 8000 \
-    --dtype auto
-
-# Client request
+# Client
 curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
-    -d '{
-        "text": "Hello world",
-        "speaker_id": 0,
-        "language": "en"
-    }' \
+    -d '{"text": "Hello world", "speaker_id": 0, "language": "en"}' \
     --output output.wav
 ```
 
-### Docker
-
-```dockerfile
-FROM python:3.10-slim
-
-RUN pip install qwen-tts
-
-COPY your_script.py /app/
-WORKDIR /app
-
-CMD ["python", "your_script.py"]
-```
-
-## Cloud GPU Providers
-
-For production deployment when local GPU is insufficient, see the shared **[Cloud GPU Deployment Guide](../infrastructure/cloud-gpu.md)** for:
-
-- Provider comparison (RunPod, Vast.ai, Lambda, NVIDIA Cloud)
-- GPU selection by VRAM requirements
-- SSH setup, Docker deployment, model caching
-- Cost optimization strategies
-
-Quick reference for Qwen3-TTS GPU needs: 2GB VRAM minimum (0.6B models), 4GB recommended (1.7B models). See the guide's VRAM requirements table for details.
+For cloud GPU deployment (RunPod, Vast.ai, Lambda, NVIDIA Cloud), see **[Cloud GPU Guide](../infrastructure/cloud-gpu.md)**. VRAM: 2GB min (0.6B), 4GB recommended (1.7B).
 
 ## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
-| `ModuleNotFoundError: qwen_tts` | Run `pip install qwen-tts` |
-| High latency | Use streaming mode: `streaming=True` |
-| OOM on GPU | Use 0.6B model or CPU: `device="cpu"` |
-| Poor voice clone quality | Ensure 3+ seconds of clean reference audio |
-| Accent not matching | Use instruction control: `instruction="British accent"` |
+| `ModuleNotFoundError: qwen_tts` | `pip install qwen-tts` |
+| High latency | Use streaming: `streaming=True` |
+| OOM on GPU | Use 0.6B model or `device="cpu"` |
+| Poor voice clone quality | Ensure 3+ seconds clean reference audio |
+| Accent not matching | Use instruction: `instruction="British accent"` |
 
 ## See Also
 
-- `tools/voice/speech-to-speech.md` - Full S2S pipeline (VAD, STT, LLM, TTS)
-- `tools/voice/voice-ai-models.md` - Complete model comparison (TTS, STT, S2S)
-- `tools/voice/cloud-voice-agents.md` - Cloud voice agents (GPT-4o Realtime, MiniCPM-o)
-- `tools/voice/pipecat-opencode.md` - Pipecat real-time voice pipeline
-- `tools/infrastructure/cloud-gpu.md` - Cloud GPU deployment guide
-- `services/communications/twilio.md` - Phone integration
-- `tools/video/remotion.md` - Video narration
+- `tools/voice/speech-to-speech.md` — Full S2S pipeline (VAD, STT, LLM, TTS)
+- `tools/voice/voice-ai-models.md` — Complete model comparison (TTS, STT, S2S)
+- `tools/voice/cloud-voice-agents.md` — Cloud voice agents (GPT-4o Realtime, MiniCPM-o)
+- `tools/voice/pipecat-opencode.md` — Pipecat real-time voice pipeline
+- `tools/infrastructure/cloud-gpu.md` — Cloud GPU deployment guide
+- `services/communications/twilio.md` — Phone integration
+- `tools/video/remotion.md` — Video narration

--- a/.agents/tools/voice/qwen3-tts.md
+++ b/.agents/tools/voice/qwen3-tts.md
@@ -25,7 +25,7 @@ tools:
 - **Latency**: 97ms streaming (first chunk)
 - **Models**: 1.7B (~4GB VRAM) and 0.6B (~2GB) in Base, CustomVoice, VoiceDesign variants
 - **Install**: `pip install qwen-tts` or `pip install vllm-omni` (production serving)
-- **Helper**: `voice-helper.sh talk whisper-mlx qwen3-tts` (voice bridge integration)
+- **Note**: Not supported by voice-bridge.py — use the Python API directly
 
 **When to Use**: Multi-language TTS with voice cloning (3s reference), custom voice control (9 speakers + instruction), or voice design (natural language persona). Ideal for voice agents, content creation, and accessibility.
 
@@ -97,16 +97,7 @@ for chunk in tts.synthesize_stream(text="Streaming with 97ms first-chunk latency
     play_audio(chunk)
 ```
 
-## Voice Bridge Integration
-
-```bash
-voice-helper.sh talk whisper-mlx qwen3-tts                              # Default
-voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav        # Custom voice
-voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav opencode/claude-sonnet-4-6  # Custom voice + model
-```
-
-> Positional args: `stt tts voice model`. Named flags (`--voice-ref`, `--persona`) not supported.
-> Voice design (persona descriptions) must use the Python API directly.
+> **Note:** qwen3-tts is not supported by voice-bridge.py. Use the Python API directly for all synthesis tasks.
 
 ## Performance
 

--- a/.agents/tools/voice/qwen3-tts.md
+++ b/.agents/tools/voice/qwen3-tts.md
@@ -144,7 +144,7 @@ For cloud GPU deployment (RunPod, Vast.ai, Lambda, NVIDIA Cloud), see **[Cloud G
 | Issue | Solution |
 |-------|----------|
 | `ModuleNotFoundError: qwen_tts` | `pip install qwen-tts` |
-| High latency | Use streaming: `streaming=True` |
+| High latency | Enable streaming mode: `streaming=True` |
 | OOM on GPU | Use 0.6B model or `device="cpu"` |
 | Poor voice clone quality | Ensure 3+ seconds clean reference audio |
 | Accent not matching | Use instruction: `instruction="British accent"` |


### PR DESCRIPTION
## Summary

- Fix CodeRabbit actionable comment on `qwen3-tts.md` from PR #7695
- Remove broken Voice Bridge Integration section (qwen3-tts not supported by voice-bridge.py)
- Clarify troubleshooting table wording: "Enable streaming mode: `streaming=True`"
- Add explicit note in Quick Reference that qwen3-tts is not supported by voice-bridge.py

## CodeRabbit Comments Addressed

**Critical (PR #7695, line ~109):** Remove Voice Bridge Integration block — `voice-bridge.py` only supports `edge-tts`, `macos-say`, and `facebookMMS` in its defaults dict; passing `qwen3-tts` triggers `sys.exit(1)`. Replaced with a note directing users to the Python API examples.

**Nitpick (PR #7695, line 147):** Updated "Use streaming: `streaming=True`" → "Enable streaming mode: `streaming=True`" for clarity and consistency.

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs only, no code behaviour change)
- **Verification**: `wc -l` confirms 151 lines; all code patterns and cross-references present

## References

- Addresses CodeRabbit review on PR #7695
- Closes #7683