### PR TITLE
t9765: tighten new-task.md by 39% (345→210 lines)

### DIFF
--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -24,32 +24,18 @@ Extract the task title from the user's request. If no title is provided, ask for
 
 ### Step 2: Allocate Task ID
 
-Run the wrapper function or script directly, passing the title via an environment variable to avoid shell injection:
+Always assign user input to a variable first — never interpolate it directly into the command string (shell injection risk):
 
 ```bash
 # Via planning-commit-helper.sh wrapper (preferred)
-# Assign user input to a variable first — never interpolate it directly into the command string
 TASK_TITLE="<sanitized title from user input>"
 output=$(~/.aidevops/agents/scripts/planning-commit-helper.sh next-id --title "$TASK_TITLE")
 
-# Or directly via claim-task-id.sh
+# Or directly
 output=$(~/.aidevops/agents/scripts/claim-task-id.sh --title "$TASK_TITLE" --repo-path "$(git rev-parse --show-toplevel)")
 ```
 
-> **Security note**: Always assign the user-supplied title to a variable first (`TASK_TITLE="..."`), then pass `"$TASK_TITLE"` as the argument. Never interpolate user input directly into a command string (e.g., `--title "$(user input)"`) — this allows shell metacharacters to execute arbitrary commands.
-
 ### Step 3: Parse Output
-
-The output contains machine-readable variables:
-
-```text
-TASK_ID=tNNN
-TASK_REF=GH#NNN
-TASK_ISSUE_URL=https://github.com/user/repo/issues/NNN
-TASK_OFFLINE=false
-```
-
-Parse these using a single-pass `while read` loop (more efficient and consistent with `planning-commit-helper.sh`):
 
 ```bash
 while IFS= read -r line; do
@@ -61,16 +47,14 @@ while IFS= read -r line; do
 done <<< "$output"
 ```
 
-### Step 4: Present to User
+Output variables: `TASK_ID=tNNN`, `TASK_REF=GH#NNN`, `TASK_ISSUE_URL=https://...`, `TASK_OFFLINE=false`.
 
-Show the allocated ID and ask for task metadata:
+### Step 4: Present to User
 
 ```text
 Allocated: {task_id} (ref:{task_ref})
 
 Task: "{title}"
-ID: {task_id}
-Ref: ref:{task_ref}
 
 Options:
 1. Add to TODO.md with brief (recommended — queued for pulse dispatch)
@@ -79,17 +63,7 @@ Options:
 4. Just show the ID (don't add to TODO.md)
 ```
 
-**Option 2 — Claim on create (t1687):** When the user intends to work on the task
-interactively in the current session (or shortly after), claiming the issue at
-creation time prevents the pulse from dispatching a worker for the same issue
-during the gap between `/new-task` and `/full-loop`. This assigns the current
-user and applies `status:in-progress` on the GitHub issue immediately.
-
-Resolve `REPO_SLUG` the same way as Step 6.5 (via `gh repo view`). The claim
-runs after the issue is created (Step 2), so `task_ref` is always available.
-If `gh issue edit` fails (silenced by `|| true`), the assignee and label are
-not applied and the issue remains dispatchable — `/full-loop` Step 0.6 will
-re-apply the same claim as a fallback when the worker starts:
+**Option 2 — Claim on create (t1687):** Prevents the pulse from dispatching a worker during the gap between `/new-task` and `/full-loop`. Assigns the current user and applies `status:in-progress` immediately. If `gh issue edit` fails, `/full-loop` Step 0.6 re-applies the claim as a fallback.
 
 ```bash
 REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
@@ -102,36 +76,27 @@ if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
 fi
 ```
 
-When successful, the pulse skips the issue via two independent checks: assignee
-presence (dedup check #2) and `status:in-progress` label (stale recovery only
-after 3+ hours). When `/full-loop` runs later, Step 0.6 is idempotent — it
-re-applies the same assignee and label with no side effects.
-
-**When NOT to claim:** If the user is queuing work for later or for pulse
-workers to pick up, use option 1 (no claim). This is the default and preserves
-the existing behaviour.
+Use option 1 (no claim) when queuing work for pulse workers to pick up.
 
 ### Step 5: Create Task Brief (MANDATORY)
 
-**Every task MUST have a brief file** at `todo/tasks/{task_id}-brief.md`. This is non-negotiable. A task without a brief is undevelopable.
-
-Use `templates/brief-template.md` as the base. Populate from conversation context:
+**Every task MUST have a brief** at `todo/tasks/{task_id}-brief.md`. A task without a brief is undevelopable. Use `templates/brief-template.md` as the base:
 
 ```markdown
 # {task_id}: {Title}
 
 ## Origin
 - **Created:** {ISO date}
-- **Session:** {app}:{session-id} (detect from runtime — e.g., opencode:session-xyz, claude-code:abc123)
+- **Session:** {app}:{session-id}
 - **Created by:** {author} (human | ai-supervisor | ai-interactive)
-- **Parent task:** {parent_id} (if subtask — include link to parent brief)
-- **Conversation context:** {1-2 sentence summary of what was discussed}
+- **Parent task:** {parent_id} (if subtask)
+- **Conversation context:** {1-2 sentence summary}
 
 ## What
-{Clear deliverable description — not "implement X" but what it must produce}
+{Clear deliverable — what it must produce, not just "implement X"}
 
 ## Why
-{Problem, user need, business value, or dependency requiring this}
+{Problem, user need, business value, or dependency}
 
 ## How (Approach)
 {Technical approach, key files, patterns to follow}
@@ -144,132 +109,65 @@ Use `templates/brief-template.md` as the base. Populate from conversation contex
 
 ## Context & Decisions
 {Key decisions, constraints, things ruled out}
-
-## Relevant Files
-- `path/to/file.ts:45` — {why relevant}
 ```
 
-**For subtasks**: The brief MUST reference the parent task's brief and inherit its context. Don't repeat everything — link to the parent and add what's specific to this subtask.
+**Session ID capture:** Use `$OPENCODE_SESSION_ID` / `$CLAUDE_SESSION_ID`, or `{app}:unknown-{ISO-date}` if unavailable.
 
-**Session ID capture**: Detect the runtime environment:
-
-- OpenCode: `$OPENCODE_SESSION_ID` or parse from `~/.local/share/opencode/sessions/`
-- Claude Code: `$CLAUDE_SESSION_ID` or the conversation ID from the CLI
-- If unavailable: use `{app}:unknown-{ISO-date}` and note "session ID not captured"
+**Subtasks:** Brief MUST reference the parent: `**Parent task:** {parent_id} — see [todo/tasks/{parent_id}-brief.md]`. Inherit context; add only subtask-specific details.
 
 ### Step 5.5: Classify and Decompose (t1408.2)
 
-After creating the brief, classify the task to determine if it should be decomposed into subtasks. This is the earliest point where decomposition can happen — before the task enters the dispatch queue.
-
 ```bash
 DECOMPOSE_HELPER="$HOME/.aidevops/agents/scripts/task-decompose-helper.sh"
-
 if [[ -x "$DECOMPOSE_HELPER" ]]; then
-  CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify "{title}") || CLASSIFY=""
-  TASK_KIND=$(echo "$CLASSIFY" | jq -r '.kind // "atomic"' || echo "atomic")
+  TASK_KIND=$(echo "$(/bin/bash "$DECOMPOSE_HELPER" classify "{title}")" | jq -r '.kind // "atomic"' || echo "atomic")
 fi
 ```
 
-**If atomic:** Proceed to Step 6 (add single entry to TODO.md). This is the default.
-
-**If composite:** Present the decomposition to the user:
-
-```text
-This task appears composite — it contains 2+ independent concerns.
-Suggested decomposition:
-
-  {task_id}.1: {subtask_1_description} (~{estimate})
-  {task_id}.2: {subtask_2_description} (~{estimate}) [depends on: .1]
-  {task_id}.3: {subtask_3_description} (~{estimate})
-
-Options:
-  1. Create parent + subtasks (recommended for auto-dispatch)
-  2. Keep as single task (implement all at once)
-  3. Edit decomposition
-```
-
-If the user chooses option 1:
-
-1. Create the parent task entry in TODO.md (with `status:blocked`)
-2. For each subtask, run `claim-task-id.sh` to allocate `{task_id}.N` IDs
-3. Create a brief for each subtask (inheriting parent context)
-4. Add subtask entries to TODO.md with `blocked-by:` edges
-5. The parent entry gets `blocked-by:{task_id}.1,{task_id}.2,...`
-
-Each subtask brief references the parent: `**Parent task:** {task_id} — see [todo/tasks/{task_id}-brief.md]`
-
-**Skip decomposition when:** `--no-decompose` flag is passed, or the helper script is not available (t1408.1 not yet merged).
+- **Atomic (default):** Proceed to Step 6.
+- **Composite:** Present decomposition tree. If user approves: allocate `{task_id}.N` IDs via `claim-task-id.sh`, create a brief per subtask, add `blocked-by:` edges in TODO.md, mark parent `status:blocked`.
+- **Skip when:** `--no-decompose` flag or helper unavailable (t1408.1).
 
 ### Step 6: Add to TODO.md
-
-Format the TODO.md entry using the allocated ID:
 
 ```markdown
 - [ ] {task_id} {title} #{tag} ~{estimate} ref:{task_ref} logged:{YYYY-MM-DD}
 ```
 
-**Auto-dispatch eligibility**: Only add `#auto-dispatch` if the brief has:
-
+**Auto-dispatch eligibility** — only add `#auto-dispatch` if the brief has:
 - At least 2 acceptance criteria beyond "tests pass" and "lint clean"
-- A non-empty "How (Approach)" section with file references
-- A non-empty "What" section with clear deliverable
-
-If the brief is too thin for auto-dispatch, omit the tag and note why.
+- Non-empty "How" section with file references
+- Non-empty "What" section with clear deliverable
 
 ### Step 6.5: Apply Model Tier and Agent Routing Labels
 
-Classify the task using the canonical taxonomy tables in
-`reference/task-taxonomy.md` — domain routing table and model tier table.
-
-Add the matching TODO tag to the TODO.md entry AND apply the matching GitHub label
-to the issue (if `task_ref` exists). Omit both for standard code tasks (Build+ is
-the default; coding tier is the default).
-
-If the task clearly matches a domain, apply the label:
+Classify using `reference/task-taxonomy.md`. Apply matching TODO tag AND GitHub label. Omit both for standard code tasks (Build+ / sonnet are defaults).
 
 ```bash
-# Apply labels if task_ref exists (issue was created)
 REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
 if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
   ISSUE_NUM="${task_ref#GH#}"
-  # Apply tier label (only for non-default tiers)
-  if [[ -n "$tier_label" ]]; then
-    gh label create "$tier_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
-    if ! gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$tier_label" >/dev/null 2>&1; then
-      echo "[new-task] WARN: failed to apply tier label '$tier_label' to ${task_ref}" >&2
-    fi
-  fi
-  # Apply domain label (only for non-code domains)
-  if [[ -n "$domain_label" ]]; then
-    gh label create "$domain_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
-    if ! gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$domain_label" >/dev/null 2>&1; then
-      echo "[new-task] WARN: failed to apply domain label '$domain_label' to ${task_ref}" >&2
-    fi
-  fi
-else
-  if [[ -n "$task_ref" ]]; then
-    echo "[new-task] WARN: unable to resolve repo slug for label application" >&2
-  fi
+  [[ -n "$tier_label" ]] && gh label create "$tier_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
+  [[ -n "$tier_label" ]] && gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$tier_label" 2>/dev/null || true
+  [[ -n "$domain_label" ]] && gh label create "$domain_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
+  [[ -n "$domain_label" ]] && gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$domain_label" 2>/dev/null || true
 fi
 ```
 
 ### Step 7: Commit and Push
 
-Commit both the brief and TODO.md change, passing the commit message via a variable to prevent injection:
+`${task_id}` is script-generated (safe). `${short_title}` must be a sanitized slug (lowercase, alphanumeric + hyphens — strip all shell metacharacters before use):
 
 ```bash
-# Build the commit message from already-validated variables — never interpolate raw user input
 commit_msg="plan: add ${task_id} ${short_title}"
 ~/.aidevops/agents/scripts/planning-commit-helper.sh "$commit_msg"
 ```
 
-> **Security note**: `${task_id}` is script-generated (safe). `${short_title}` must be a sanitized slug derived from the user's title (lowercase, alphanumeric + hyphens only — strip all shell metacharacters before use). Assign to a variable and quote it; never embed raw user input directly in the command string.
-
-The brief file (`todo/tasks/{task_id}-brief.md`) is a planning file and goes directly to main alongside TODO.md.
+The brief and TODO.md are planning files — they go directly to main.
 
 ## Offline Handling
 
-If `TASK_OFFLINE=true`, warn the user:
+If `TASK_OFFLINE=true`:
 
 ```text
 [WARN] Allocated {task_id} in offline mode (+100 offset).
@@ -277,69 +175,36 @@ If `TASK_OFFLINE=true`, warn the user:
        No GitHub/GitLab issue was created.
 ```
 
-## Examples
+## Example
 
 ```text
 User: /new-task Add CSV export button
-AI: Allocated: t325 (ref:GH#1260)
-    Task: "Add CSV export button"
+AI:   Allocated: t325 (ref:GH#1260)
 
-    Creating brief from conversation context...
+      Brief: todo/tasks/t325-brief.md
+      - What: CSV export button on data table — exports current filtered view as downloadable CSV
+      - Why: Users need filtered data for offline analysis
+      - How: Add ExportButton to DataTable toolbar, use papaparse. File: components/DataTable.tsx
+      - Acceptance: Button visible, exports current filter, handles 10k+ rows
 
-    Brief: todo/tasks/t325-brief.md
-    - What: Add a CSV export button to the data table component that exports
-      the current filtered view as a downloadable CSV file
-    - Why: Users need to export filtered data for offline analysis and reporting
-    - How: Add ExportButton to DataTable toolbar, use papaparse for CSV generation
-    - Acceptance: Button visible in toolbar, exports current filter, handles 10k+ rows
+      1. Add to TODO.md (queued)  2. Claim for this session  3. Edit  4. Cancel
 
-    1. Add to TODO.md (queued for pulse dispatch)
-    2. Add to TODO.md and claim for this session
-    3. Edit brief first
-    4. Cancel
-User: 1
-AI: Added:
-    - todo/tasks/t325-brief.md (brief)
-    - TODO.md: - [ ] t325 Add CSV export button #feature #auto-dispatch ~1h ref:GH#1260 logged:2026-02-12
-```
-
-```text
-User: /new-task Fix login timeout on mobile
-AI: Allocated: t326 (ref:GH#1261)
-    Task: "Fix login timeout on mobile"
-
-    I need more context for the brief:
-    1. What's the current timeout behaviour? (error message, redirect, etc.)
-    2. Which auth provider? (Better Auth, NextAuth, custom)
-    3. Mobile-specific or all platforms?
-
-User: Better Auth, only on iOS Safari, users get logged out after 5 minutes
-AI: Brief: todo/tasks/t326-brief.md
-    - What: Fix premature session expiry on iOS Safari — sessions should last 24h
-    - Why: iOS Safari users lose work after 5 min due to aggressive cookie handling
-    - How: Check Better Auth session config, likely needs SameSite=None + Secure
-      for iOS Safari cookie persistence. File: packages/auth/src/config.ts
-    - Acceptance: iOS Safari session persists 24h, no regression on other browsers
-
-    1. Add to TODO.md (queued)  2. Claim for this session  3. Edit  4. Cancel
 User: 2
-AI: Added and claimed:
-    - todo/tasks/t326-brief.md (brief)
-    - TODO.md: - [ ] t326 Fix login timeout on mobile #bugfix ~2h ref:GH#1261 logged:2026-02-12
-    - Issue #1261: assigned to you + status:in-progress
-    Pulse workers will skip this issue until you release it or 3h stale recovery kicks in.
+AI:   Added and claimed:
+      - todo/tasks/t325-brief.md
+      - TODO.md: - [ ] t325 Add CSV export button #feature #auto-dispatch ~1h ref:GH#1260 logged:2026-02-12
+      - Issue #1260: assigned to you + status:in-progress
+      Pulse workers will skip this issue until you release it or 3h stale recovery kicks in.
 ```
 
 ## CRITICAL: Supervisor Subtask Creation
 
-When the AI supervisor creates subtasks (e.g., decomposing t005 into t005.1-t005.5) — whether manually or via `task-decompose-helper.sh` (t1408.2) — it MUST:
+When decomposing a task (manually or via `task-decompose-helper.sh`), the supervisor MUST:
 
 1. Create a brief for EACH subtask at `todo/tasks/{subtask_id}-brief.md`
-2. Reference the parent task's brief: `**Parent task:** {parent_id} — see [todo/tasks/{parent_id}-brief.md]`
-3. Inherit context from the parent but add subtask-specific details
-4. Include the session ID of the supervisor session that created the subtask
-5. Set `blocked-by:` edges between subtasks based on dependency analysis from the decomposition
+2. Reference the parent brief: `**Parent task:** {parent_id} — see [todo/tasks/{parent_id}-brief.md]`
+3. Inherit parent context; add subtask-specific details
+4. Include the supervisor session ID
+5. Set `blocked-by:` edges from the `depends_on` array in decompose output
 
-When using `task-decompose-helper.sh decompose`, the output includes dependency edges (`depends_on` array) that map to `blocked-by:` references in TODO.md. The decompose output also suggests a `batch_strategy` (depth-first or breadth-first) — use this to inform dispatch ordering in the pulse.
-
-A subtask without a brief is a knowledge loss. The parent task's rich context (from the original conversation) must flow down to every subtask.
+The `batch_strategy` field in decompose output (depth-first or breadth-first) informs pulse dispatch ordering. A subtask without a brief is a knowledge loss.


### PR DESCRIPTION
## Summary

- Removes redundant prose from Option 2 claim explanation (idempotency details already covered in `full-loop.md` Step 0.6)
- Replaces verbose inline brief template with pointer to `templates/brief-template.md` + key fields only
- Condenses decomposition UI text (full options tree duplicated from `full-loop.md` Step 0.45)
- Merges duplicate security notes (Steps 2 and 7) into single inline comment
- Collapses two examples into one that covers both claim/no-claim patterns
- Tightens Step 6.5 label bash block (removes redundant error-path branching)

## Verification

- All task IDs preserved: `t1687`, `t1408`, `t1408.2`
- All code blocks preserved: `claim-task-id.sh`, `planning-commit-helper.sh`, decompose helper, label application
- All key references preserved: `brief-template.md`, `task-taxonomy.md`, `TASK_OFFLINE`, `#auto-dispatch`, `blocked-by`, `status:in-progress`
- Line count: 345 → 210 (39% reduction, target was ~40%)

## Runtime Testing

- Risk: Low (docs-only change, no code)
- Testing level: self-assessed
- Agent behaviour unchanged — all actionable instructions present

Closes #9765