### PR TITLE
t10284: tighten tech-stack.md agent doc (236→112 lines)

### DIFF
--- a/.agents/scripts/commands/tech-stack.md
+++ b/.agents/scripts/commands/tech-stack.md
@@ -4,7 +4,7 @@ agent: Build+
 mode: subagent
 ---
 
-Detect the full tech stack of a URL or find sites using specific technologies. Orchestrates multiple open-source detection tools (Wappalyzer, httpx, nuclei) and optional BuiltWith API.
+Detect the full tech stack of a URL or find sites using specific technologies. Orchestrates Wappalyzer, httpx, nuclei, and optional BuiltWith API.
 
 Arguments: $ARGUMENTS
 
@@ -12,14 +12,14 @@ Arguments: $ARGUMENTS
 
 ### Step 1: Determine Operation Mode
 
-Parse `$ARGUMENTS` to determine what to run:
+Parse `$ARGUMENTS`:
 
-- If argument is a URL: run single-site tech stack lookup
-- If argument starts with "reverse": run reverse lookup to find sites using a technology
-- If argument is "cache-stats" or "cache-clear": run cache management
-- If argument is "help" or empty: show available commands
+- URL → single-site tech stack lookup
+- Starts with `reverse` → reverse lookup (find sites using a technology)
+- `cache-stats` or `cache-clear` → cache management
+- `help` or empty → show available commands
 
-### Step 2: Run Appropriate Command
+### Step 2: Run Command
 
 **Single-site lookup:**
 
@@ -27,10 +27,7 @@ Parse `$ARGUMENTS` to determine what to run:
 ~/.aidevops/agents/scripts/tech-stack-helper.sh lookup "$ARGUMENTS"
 ```
 
-**Reverse lookup:**
-
-Parse the technology name and optional filters from arguments using portable shell patterns
-(no `eval`, no `grep -P`/PCRE — safe for all POSIX-compatible shells):
+**Reverse lookup** — parse technology name and optional filters (portable shell, no `eval`/PCRE):
 
 ```bash
 # Parse: tech-stack reverse <tech> [--region X] [--industry Y] [--traffic Z]
@@ -58,179 +55,58 @@ cmd_array=(~/.aidevops/agents/scripts/tech-stack-helper.sh reverse "$tech_name")
 
 ### Step 3: Present Results
 
-Format the output as a clear report with:
+Format output by operation type:
 
-- **Single-site lookup**: Technologies grouped by category (Frontend, Backend, Analytics, CDN, etc.) with confidence scores and provider counts
-- **Reverse lookup**: List of sites using the technology with traffic tier, industry, and related technologies
-- **Cache stats**: Total entries, cache size, hit rate, top cached domains
+- **Single-site**: technologies grouped by category (Frontend, Backend, Analytics, CDN, etc.) with confidence scores and provider counts
+- **Reverse**: sites using the technology with traffic tier, industry, and related technologies
+- **Cache stats**: total entries, cache size, hit rate, top cached domains
 
-### Step 4: Offer Follow-up Actions
+### Step 4: Follow-up Actions
 
-```text
-Actions:
-1. Export results to JSON/CSV
-2. Run reverse lookup for detected technologies
-3. Compare with competitor sites
-4. Schedule periodic monitoring
-5. View detailed provider reports
-```
+Offer: export to JSON/CSV, reverse lookup for detected technologies, competitor comparison, periodic monitoring, detailed provider reports.
 
-## Options
+## Usage
 
 | Command | Purpose |
 |---------|---------|
 | `/tech-stack https://vercel.com` | Detect tech stack for URL |
-| `/tech-stack vercel.com --format json` | Get JSON output |
-| `/tech-stack reverse "Next.js" --traffic high` | Find high-traffic sites using Next.js |
-| `/tech-stack reverse "React" --region us --industry ecommerce` | Find US ecommerce sites using React |
+| `/tech-stack vercel.com --format json` | JSON output |
+| `/tech-stack reverse "Next.js" --traffic high` | Find high-traffic Next.js sites |
+| `/tech-stack reverse "React" --region us --industry ecommerce` | Find US ecommerce React sites |
 | `/tech-stack cache-stats` | Show cache statistics |
 | `/tech-stack cache-clear --older-than 7` | Clear cache older than 7 days |
 
-## Examples
-
-**Single-site lookup:**
-
-```text
-User: /tech-stack https://vercel.com
-AI: Analyzing tech stack for https://vercel.com...
-
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    
-    Frontend Frameworks
-      React 18.2.0                    ████████████████████ 100% (4 sources)
-      Next.js 13.4.1                  ████████████████████ 100% (3 sources)
-    
-    UI Libraries
-      Tailwind CSS 3.3.0              ████████████████████ 100% (4 sources)
-      Radix UI 1.0.0                  ███████████████░░░░░  75% (3 sources)
-    
-    Analytics
-      Google Analytics 4              ████████████████████ 100% (4 sources)
-      Vercel Analytics                ███████████████░░░░░  75% (3 sources)
-    
-    CDN & Hosting
-      Vercel                          ████████████████████ 100% (4 sources)
-      Cloudflare                      ████████████████████ 100% (4 sources)
-    
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    Total: 15 technologies detected
-    Cache: Stored for 24h
-    
-    Actions:
-    1. Export to JSON: /tech-stack vercel.com --format json
-    2. Find similar sites: /tech-stack reverse "Next.js"
-    3. Compare with competitor
-```
-
-**Reverse lookup:**
-
-```text
-User: /tech-stack reverse "Next.js" --traffic high
-AI: Finding high-traffic sites using Next.js...
-
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    
-    Sites using Next.js (filtered: traffic=high)
-    
-    1. vercel.com
-       Traffic: Very High (10M+ monthly)
-       Industry: Developer Tools
-       Also uses: React, Tailwind CSS, Vercel Analytics
-    
-    2. hulu.com
-       Traffic: Very High (100M+ monthly)
-       Industry: Streaming Media
-       Also uses: React, GraphQL, AWS
-    
-    3. nike.com
-       Traffic: Very High (500M+ monthly)
-       Industry: E-commerce
-       Also uses: React, Redux, Cloudflare
-    
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    Total: 1,247 sites found (showing top 3)
-    
-    Top industries: E-commerce (23%), SaaS (18%), Media (15%)
-    Top regions: US (45%), EU (28%), Asia (20%)
-```
-
-**JSON output:**
-
-```text
-User: /tech-stack vercel.com --format json
-AI: {
-      "url": "https://vercel.com",
-      "technologies": [
-        {
-          "name": "React",
-          "version": "18.2.0",
-          "category": "Frontend Framework",
-          "confidence": 100,
-          "providers": 4
-        },
-        {
-          "name": "Next.js",
-          "version": "13.4.1",
-          "category": "Frontend Framework",
-          "confidence": 100,
-          "providers": 3
-        }
-      ],
-      "cached": false,
-      "timestamp": "2026-02-16T20:30:00Z"
-    }
-```
-
-**Cache stats:**
-
-```text
-User: /tech-stack cache-stats
-AI: Cache statistics:
-
-    Total entries: 342
-    Cache size: 2.4 MB
-    Oldest entry: 14 days ago
-    Newest entry: 2 hours ago
-    
-    Top cached domains:
-    1. github.com (15 lookups)
-    2. vercel.com (12 lookups)
-    3. netlify.com (8 lookups)
-```
-
 ## Provider Configuration
 
-### Wappalyzer (Free, Open Source)
+### Wappalyzer (free, open source)
 
-No API key needed. Install via npm:
+No API key needed.
 
 ```bash
 npm install -g wappalyzer
 ```
 
-### httpx + nuclei (Free, Open Source)
+### httpx + nuclei (free, open source)
 
-No API key needed. Install via go:
+No API key needed.
 
 ```bash
 go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
 go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest
 ```
 
-### BuiltWith API (Commercial, Optional)
+### BuiltWith API (commercial, optional)
 
-For reverse lookup and historical data:
+For reverse lookup and historical data. $295/month API access; free tier: 100 lookups/month.
 
 ```bash
 aidevops secret set BUILTWITH_API_KEY
 ```
 
-Pricing: $295/month for API access. Free tier: 100 lookups/month.
-
 ## Related
 
-- `tools/research/tech-stack-lookup.md` - Full agent documentation
-- `tools/research/wappalyzer.md` - Wappalyzer CLI integration (t1064)
-- `tools/research/whatruns.md` - WhatRuns browser automation (t1065)
-- `tools/research/builtwith.md` - BuiltWith API integration (t1066)
-- `tools/research/httpx-nuclei.md` - HTTP fingerprinting (t1067)
+- `tools/research/tech-stack-lookup.md` — full agent documentation
+- `tools/research/wappalyzer.md` — Wappalyzer CLI integration (t1064)
+- `tools/research/whatruns.md` — WhatRuns browser automation (t1065)
+- `tools/research/builtwith.md` — BuiltWith API integration (t1066)
+- `tools/research/httpx-nuclei.md` — HTTP fingerprinting (t1067)


### PR DESCRIPTION
## Summary

- Tightened `.agents/scripts/commands/tech-stack.md` from 236 → 112 lines (**52.5% reduction**, exceeding the ~40% target)
- Removed 4 verbose mock output examples (109 lines of ASCII art, fake data, illustrative formatting) that duplicated what `tech-stack-helper.sh` already produces
- Preserved all actionable content: workflow steps, code blocks, shell commands, usage table, provider configuration, task ID references (t1064–t1067), and related links

## Classification

**Instruction doc** — slash command workflow with steps, code blocks, and options. Tightened prose per `build-agent.md` guidance; no content split needed.

## What was removed

The Examples section contained 4 large mock output blocks showing ASCII bar charts, formatted tables, JSON samples, and cache stats. These were decorative — the helper script produces its own output, and the Usage table already covers all command patterns.

## Content preservation checklist

- [x] All code blocks (lookup, reverse parse, cache commands, install commands)
- [x] All URLs and paths (`tech-stack-helper.sh`, `tools/research/*.md`)
- [x] All task ID references (t1064, t1065, t1066, t1067)
- [x] All 6 usage examples in table
- [x] Provider configuration (Wappalyzer, httpx/nuclei, BuiltWith + pricing)
- [x] Frontmatter unchanged
- [x] Zero markdownlint violations

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** Low (docs-only change — agent prompt file, no code)
- **Verification:** markdownlint-cli2 passes with 0 errors; all actionable content verified present

Closes #10284