### PR TITLE
GH#10290: Tighten aeo-geo-patterns.md by 38% (224 → 139 lines)

### DIFF
--- a/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
@@ -1,174 +1,119 @@
 # AEO and GEO Content Patterns
 
-Reusable content block patterns optimized for answer engines and AI citation.
+Reusable content block patterns for answer engines and AI citation.
 
-## Answer Engine Optimization (AEO) Patterns
+## AEO Patterns — featured snippets, AI Overviews, voice search, answer boxes
 
-Patterns for featured snippets, AI Overviews, voice search, and answer boxes.
-
-### Definition Block
-
-For "What is [X]?" queries. Lead with 1-sentence definition, expand with characteristics, close with why it matters.
+### Definition Block — "What is [X]?"
 
 ```markdown
 ## What is [Term]?
-
 [Term] is [1-sentence definition]. [Key characteristics]. [Why it matters].
 ```
 
-### Step-by-Step Block
-
-For "How to [X]" queries. Optimal for list snippets.
+### Step-by-Step Block — "How to [X]" (list snippets)
 
 ```markdown
 ## How to [Action/Goal]
-
 [1-sentence overview]
-
 1. **[Step]**: [Action in 1-2 sentences]
 2. **[Step]**: [Action in 1-2 sentences]
 3. **[Step]**: [Action in 1-2 sentences]
 ```
 
-### Comparison Table Block
-
-For "[X] vs [Y]" queries. Optimal for table snippets.
+### Comparison Table — "[X] vs [Y]" (table snippets)
 
 ```markdown
 ## [Option A] vs [Option B]: [Descriptor]
-
 | Feature | [Option A] | [Option B] |
 |---------|------------|------------|
 | [Criteria] | [Value] | [Value] |
 | Best For | [Use case] | [Use case] |
-
 **Bottom line**: [1-2 sentence recommendation]
 ```
 
-### Pros and Cons Block
-
-For evaluation queries: "Is [X] worth it?", "Should I [X]?"
+### Pros/Cons Block — "Is [X] worth it?", "Should I [X]?"
 
 ```markdown
 ## Advantages and Disadvantages of [Topic]
-
-### Pros
-- **[Benefit]**: [Explanation]
-
-### Cons
-- **[Drawback]**: [Explanation]
-
+**Pros**: **[Benefit]**: [Explanation]
+**Cons**: **[Drawback]**: [Explanation]
 **Verdict**: [Balanced conclusion with recommendation]
 ```
 
-### FAQ Block
+### FAQ Block — common questions (FAQ schema)
 
-For topic pages with multiple common questions. Essential for FAQ schema.
+Natural phrasing ("How do I..." not "How does one..."). Match "People Also Ask". 50-100 word answers.
 
 ```markdown
 ### [Question phrased as users search]?
-
 [Direct answer first sentence]. [Supporting context in 2-3 sentences].
 ```
 
-Use natural phrasing ("How do I..." not "How does one..."). Match "People Also Ask" queries. Keep answers 50-100 words.
-
-### Listicle Block
-
-For "Best [X]", "Top [X]", "[Number] ways to [X]" queries.
+### Listicle Block — "Best [X]", "Top [X]", "[N] ways to [X]"
 
 ```markdown
 ## [Number] Best [Items] for [Goal/Purpose]
-
 [1-2 sentence intro with selection criteria]
-
 ### 1. [Item Name]
 [Why included -- 2-3 sentences with specific benefits]
 ```
 
-### Voice Search Patterns
+### Voice Search
 
-Voice queries are conversational. Common formats: "What is...", "How do I...", "Where can I find...", "Why does...", "When should I..."
+Conversational queries ("What is...", "How do I...", "Where can I find...", "Why does...", "When should I..."). Direct answer under 30 words, natural language, avoid jargon unless targeting experts, include local context where relevant.
 
-Lead with direct answer (under 30 words). Use natural language. Avoid jargon unless targeting experts. Include local context where relevant.
+## GEO Patterns
 
----
+For citation by AI assistants (ChatGPT, Claude, Perplexity, Gemini).
 
-## Generative Engine Optimization (GEO) Patterns
+### Single-Line Citation Patterns
 
-Patterns for citation by AI assistants (ChatGPT, Claude, Perplexity, Gemini).
+| Pattern | Template |
+|---------|----------|
+| **Statistic** | `[Claim]. According to [Source], [statistic with number and timeframe]. [Why this matters].` |
+| **Expert Quote** | `"[Quote]," says [Name], [Title] at [Org]. [1 sentence context].` |
+| **Authoritative Claim** | `[Topic] [verb] [specific claim]. [Source] [confirms/found] [evidence]. This [means/suggests] [action].` |
+| **Self-Contained Answer** | `**[Topic/Question]**: [Complete, self-contained answer with details/numbers in 2-3 sentences.]` |
 
-### Statistic Citation Block
-
-Statistics can increase AI citation rates. Always include sources.
-
-```markdown
-[Claim]. According to [Source], [statistic with number and timeframe]. [Why this matters].
-```
-
-### Expert Quote Block
-
-Named attribution adds credibility and increases citation likelihood.
-
-```markdown
-"[Quote]," says [Name], [Title] at [Org]. [1 sentence context].
-```
-
-### Authoritative Claim Block
-
-Structure claims for easy AI extraction with clear attribution.
-
-```markdown
-[Topic] [verb] [specific claim]. [Source] [confirms/found] [evidence]. This [means/suggests] [action].
-```
-
-### Self-Contained Answer Block
-
-Quotable, standalone statements AI can extract directly.
-
-```markdown
-**[Topic/Question]**: [Complete, self-contained answer with details/numbers in 2-3 sentences.]
-```
-
-### Evidence Sandwich Block
-
-Claims bracketed by evidence for maximum credibility.
+### Evidence Sandwich — claims bracketed by evidence
 
 ```markdown
 [Opening claim].
-
 Evidence:
 - [Data point with source]
 - [Data point with source]
 - [Data point with source]
-
 [Conclusion connecting evidence to actionable insight].
 ```
 
-### GEO Product Block
+### Product Block — domain-scoped AI retrieval
 
-For domain-scoped AI retrieval (`site:yourdomain.com [category] features [year]`).
+For `site:yourdomain.com [category] features [year]` queries. Align `title`/`H1`/first paragraph to domain-scoped query modifiers.
 
 ```markdown
 ## [Product/Category] Features for [Audience] ([Year])
-
-**Best for**: [ICP or use case]
-**Pricing**: [starting point / packaging]
-**Integrations**: [top integrations]
-**Compliance**: [SOC 2, GDPR, HIPAA, etc.]
+**Best for**: [ICP or use case]  |  **Pricing**: [starting point / packaging]
+**Integrations**: [top integrations]  |  **Compliance**: [SOC 2, GDPR, HIPAA, etc.]
 **Time-to-value**: [timeline]
-
 ### Key capabilities
 - **[Capability]**: [Specific, testable description]
-
 ### Validation sources
-- G2: [profile URL with UTM]
-- Capterra: [profile URL with UTM]
+- G2: [profile URL with UTM]  |  Capterra: [profile URL with UTM]
 ```
 
-**Implementation:** Mirror canonical facts on product page and third-party profiles. Align `title`/`H1`/first paragraph to domain-scoped query modifiers. Use consistent UTM: `utm_source=g2`, `utm_medium=referral`, `utm_campaign=ai_citation`. Review profile freshness monthly.
+Mirror canonical facts on product page and third-party profiles. UTM: `utm_source=g2`, `utm_medium=referral`, `utm_campaign=ai_citation`. Review freshness monthly.
 
----
+**Site-searchable variant** — H2 with category terms for `site:` queries, standalone opening sentence, date freshness:
+
+```markdown
+## [Product Name]: [Category] [Type] for [Audience]
+[Product Name] is a [category term] that [value proposition]. [Differentiator].
+- **Key Features**: [Capability with measurable detail]
+- **Pricing**: [Model] starting at [price] per [unit]. [Tier summary]. [Link].
+- **Integrations**: Connects with [number] tools including [top 3-5]. [Link].
+*Last updated: [YYYY-MM]*
+```
 
 ## Domain-Specific GEO Authority Signals
 
@@ -180,45 +125,15 @@ For domain-scoped AI retrieval (`site:yourdomain.com [category] features [year]`
 | **Legal** | Specific laws/statutes, jurisdiction, professional disclaimers, "consult a professional" |
 | **Business/Marketing** | Case studies with results, industry research, percentage changes, thought leader quotes |
 
----
+## UTM Citation Attribution
 
-## Site-Searchable Content Patterns
-
-Optimized for domain-scoped AI retrieval (`site:yourdomain.com` queries).
-
-### Site-Searchable Product Block
+Canonical URL always clean — tracking parameters only in cited variants.
 
 ```markdown
-## [Product Name]: [Category] [Type] for [Audience]
-
-[Product Name] is a [category term] that [value proposition]. [Differentiator].
-
-### Key Features
-- **[Feature]**: [Capability with measurable detail]
-
-### Pricing
-[Model] starting at [price] per [unit]. [Tier summary]. [Pricing link].
-
-### Integrations
-Connects with [number] tools including [top 3-5]. [Directory link].
-
-*Last updated: [YYYY-MM]*
-```
-
-**Why this works:** H2 contains category terms matching `site:` queries. Opening sentence extractable as standalone claim. Feature list uses category vocabulary, not jargon. Sections addressable via heading anchors. Date signals freshness.
-
-### UTM Citation Attribution
-
-Track AI-cited page traffic using UTM parameters.
-
-```markdown
-<!-- Canonical (clean) -->
+<!-- Canonical -->
 https://yourdomain.com/product-features/
-
 <!-- Cited variant -->
 https://yourdomain.com/product-features/?utm_source=ai&utm_medium=citation&utm_campaign=[model-name]
 ```
 
-Canonical URL must always be clean -- tracking parameters only in distributed/cited variants.
-
-**Key metrics:** AI citation traffic volume, citation-to-conversion rate, page citation distribution, UTM coverage (% of cited pages with tracking).
+**Key metrics:** citation traffic volume, citation-to-conversion rate, page citation distribution, UTM coverage.


### PR DESCRIPTION
## Summary

- Tighten `.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md` from 224 → 139 lines (38% reduction)
- Consolidate 4 single-line GEO citation patterns (Statistic, Expert Quote, Authoritative Claim, Self-Contained Answer) into a compact table
- Compress code block templates by removing non-structural blank lines
- Merge prose descriptions into section headings

Closes #10290

## What changed

| Technique | Lines saved |
|-----------|-------------|
| Consolidate 4 GEO patterns into table | ~20 |
| Remove internal blank lines in code blocks | ~25 |
| Merge descriptions into headings | ~15 |
| Compress implementation notes | ~25 |

## Content preservation

All 13 pattern blocks preserved: Definition, Step-by-Step, Comparison Table, Pros/Cons, FAQ, Listicle, Voice Search, Statistic Citation, Expert Quote, Authoritative Claim, Self-Contained Answer, Evidence Sandwich, Product Block (both variants). Domain authority signals table, all URLs, and UTM examples intact.

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** Low (docs-only change — agent prompt reference file)
- **Verification:** markdownlint-cli2: 0 errors. Content audit: all 13 patterns, domain signals table, URLs, UTM examples confirmed present.