### PR TITLE
t9743: tighten debug-favicon.md by 41% (357→211 lines)

### DIFF
--- a/.agents/seo/debug-favicon.md
+++ b/.agents/seo/debug-favicon.md
@@ -62,10 +62,10 @@ curl -sI "https://example.com/favicon.ico" | head -1 | cut -d' ' -f2
 
 | Size | Purpose |
 |------|---------|
-| 48x48 | Android notification |
-| 72x72 | Android home screen |
-| 96x96 | Android home screen |
-| 144x144 | Android home screen |
+| 48x48 | Android notification (optional) |
+| 72x72 | Android home screen (optional) |
+| 96x96 | Android home screen (optional) |
+| 144x144 | Android home screen (optional) |
 | 192x192 | **Required** - PWA install |
 | 512x512 | **Required** - PWA splash screen |
 
@@ -131,7 +131,7 @@ curl -sI "https://example.com/favicon.ico" | head -1 | cut -d' ' -f2
 | 2 | Wrong Content-Type | ICO: `image/x-icon`, PNG: `image/png`, SVG: `image/svg+xml` |
 | 3 | Missing Apple Touch Icon | Add `<link rel="apple-touch-icon" href="/apple-touch-icon.png">` |
 | 4 | PWA install fails | Ensure manifest has 192x192 and 512x512 icons |
-| 5 | Icon URL resolution in manifest | Use absolute paths (e.g., `/icons/icon-192x192.png`) or relative paths (resolved relative to manifest location) |
+| 5 | Icon URL resolution in manifest | Absolute (`/icons/icon-192.png`) or relative (`icon-192.png` — resolved relative to manifest location) |
 | 6 | Cache issues | Add version query string: `href="/favicon.ico?v=2"` |
 
 ## Full Audit Script

--- a/.agents/seo/debug-favicon.md
+++ b/.agents/seo/debug-favicon.md
@@ -26,91 +26,16 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Quick Validation
-
-### Extract All Favicon/Icon Links
+## Quick Checks
 
 ```bash
-curl -sL "https://example.com" | grep -oE '<link[^>]+(rel="(icon|shortcut icon|apple-touch-icon|manifest)"|rel="(icon|shortcut icon|apple-touch-icon|manifest)"[^>]*)[^>]*>' | head -20
-```
+# Extract all favicon/icon links (case-insensitive, handles single/double quotes)
+curl -sL "https://example.com" \
+  | grep -ioE "<link[^>]*rel=['\"](icon|shortcut icon|apple-touch-icon|manifest)['\"][^>]*>" \
+  | head -20
 
-### Full Icon Extraction with Details
-
-```bash
-url="https://example.com"
-html=$(curl -sL "$url")
-
-echo "=== Favicon & Icon Links ==="
-echo "$html" | grep -oE '<link[^>]+rel="[^"]*icon[^"]*"[^>]*>' | while read -r line; do
-  rel=$(echo "$line" | grep -oE 'rel="[^"]*"' | cut -d'"' -f2)
-  href=$(echo "$line" | grep -oE 'href="[^"]*"' | cut -d'"' -f2)
-  sizes=$(echo "$line" | grep -oE 'sizes="[^"]*"' | cut -d'"' -f2)
-  type=$(echo "$line" | grep -oE 'type="[^"]*"' | cut -d'"' -f2)
-  printf "%-20s %-12s %-15s %s\n" "$rel" "${sizes:-n/a}" "${type:-n/a}" "$href"
-done
-
-echo ""
-echo "=== Apple Touch Icons ==="
-echo "$html" | grep -oE '<link[^>]+rel="apple-touch-icon[^"]*"[^>]*>' | while read -r line; do
-  href=$(echo "$line" | grep -oE 'href="[^"]*"' | cut -d'"' -f2)
-  sizes=$(echo "$line" | grep -oE 'sizes="[^"]*"' | cut -d'"' -f2)
-  printf "%-12s %s\n" "${sizes:-default}" "$href"
-done
-
-echo ""
-echo "=== Manifest Link ==="
-manifest=$(echo "$html" | grep -oE '<link[^>]+rel="manifest"[^>]+href="[^"]*"' | grep -oE 'href="[^"]*"' | cut -d'"' -f2)
-echo "Manifest: ${manifest:-[NOT FOUND]}"
-```
-
-### Check favicon.ico Directly
-
-```bash
-url="https://example.com"
-status=$(curl -sI "$url/favicon.ico" | head -1 | cut -d' ' -f2)
-echo "favicon.ico status: $status"
-
-# Check content type
-curl -sI "$url/favicon.ico" | grep -i "content-type"
-```
-
-## Manifest Validation
-
-### Extract and Validate manifest.json
-
-```bash
-url="https://example.com"
-html=$(curl -sL "$url")
-
-# Find manifest URL
-manifest_href=$(echo "$html" | grep -oE '<link[^>]+rel="manifest"[^>]+href="[^"]*"' | grep -oE 'href="[^"]*"' | cut -d'"' -f2)
-
-if [ -n "$manifest_href" ]; then
-  # Handle relative URLs
-  if [[ "$manifest_href" != http* ]]; then
-    base_url=$(echo "$url" | grep -oE 'https?://[^/]+')
-    manifest_href="${base_url}${manifest_href}"
-  fi
-  
-  echo "Manifest URL: $manifest_href"
-  echo ""
-  
-  # Fetch and parse manifest
-  manifest=$(curl -sL "$manifest_href")
-  
-  echo "=== Manifest Icons ==="
-  echo "$manifest" | jq -r '.icons[]? | "\(.sizes)\t\(.type // "n/a")\t\(.src)"' 2>/dev/null || echo "Failed to parse manifest JSON"
-  
-  echo ""
-  echo "=== PWA Requirements Check ==="
-  has_192=$(echo "$manifest" | jq -r '.icons[]? | select(.sizes == "192x192") | .src' 2>/dev/null)
-  has_512=$(echo "$manifest" | jq -r '.icons[]? | select(.sizes == "512x512") | .src' 2>/dev/null)
-  
-  [ -n "$has_192" ] && echo "[OK] 192x192 icon found" || echo "[MISSING] 192x192 icon (required for PWA)"
-  [ -n "$has_512" ] && echo "[OK] 512x512 icon found" || echo "[MISSING] 512x512 icon (required for PWA)"
-else
-  echo "[MISSING] No manifest.json link found"
-fi
+# Check favicon.ico status
+curl -sI "https://example.com/favicon.ico" | head -1 | cut -d' ' -f2
 ```
 
 ## Platform Requirements
@@ -170,21 +95,15 @@ fi
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-
 <!-- Apple Touch Icons -->
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
 <link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167x167.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
-
-<!-- PWA Manifest -->
+<!-- PWA / Windows -->
 <link rel="manifest" href="/manifest.json">
-
-<!-- Windows -->
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-config" content="/browserconfig.xml">
-
-<!-- Theme color -->
 <meta name="theme-color" content="#ffffff">
 ```
 
@@ -195,10 +114,6 @@ fi
   "name": "My App",
   "short_name": "App",
   "icons": [
-    { "src": "/icons/icon-48x48.png", "sizes": "48x48", "type": "image/png" },
-    { "src": "/icons/icon-72x72.png", "sizes": "72x72", "type": "image/png" },
-    { "src": "/icons/icon-96x96.png", "sizes": "96x96", "type": "image/png" },
-    { "src": "/icons/icon-144x144.png", "sizes": "144x144", "type": "image/png" },
     { "src": "/icons/icon-192x192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
     { "src": "/icons/icon-512x512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
   ],
@@ -210,86 +125,30 @@ fi
 
 ## Common Issues
 
-### 1. Missing favicon.ico
-
-**Problem**: No favicon.ico at root
-**Solution**: Always include `/favicon.ico` - browsers request it automatically
-
-```bash
-# Check if favicon.ico exists
-curl -sI "https://example.com/favicon.ico" | head -1
-```
-
-### 2. Wrong Content-Type
-
-**Problem**: Server returns wrong MIME type
-**Solution**: Configure server to return correct types
-
-| Format | MIME Type |
-|--------|-----------|
-| ICO | `image/x-icon` or `image/vnd.microsoft.icon` |
-| PNG | `image/png` |
-| SVG | `image/svg+xml` |
-
-### 3. Missing Apple Touch Icon
-
-**Problem**: iOS shows screenshot instead of icon
-**Solution**: Add apple-touch-icon link
-
-```html
-<link rel="apple-touch-icon" href="/apple-touch-icon.png">
-```
-
-### 4. PWA Install Fails
-
-**Problem**: "Add to Home Screen" not available
-**Solution**: Ensure manifest has 192x192 and 512x512 icons
-
-### 5. Relative URLs in Manifest
-
-**Problem**: Icons don't load from manifest
-**Solution**: Use absolute paths or paths relative to manifest location
-
-```json
-{
-  "icons": [
-    { "src": "/icons/icon-192x192.png", "sizes": "192x192" }
-  ]
-}
-```
-
-### 6. Cache Issues
-
-Browsers cache favicons aggressively. Force refresh:
-
-```bash
-# Add version query string
-<link rel="icon" href="/favicon.ico?v=2">
-
-# Or use different filename
-<link rel="icon" href="/favicon-v2.ico">
-```
+| # | Problem | Solution |
+|---|---------|----------|
+| 1 | Missing `favicon.ico` | Always serve `/favicon.ico` — browsers request it automatically |
+| 2 | Wrong Content-Type | ICO: `image/x-icon`, PNG: `image/png`, SVG: `image/svg+xml` |
+| 3 | Missing Apple Touch Icon | Add `<link rel="apple-touch-icon" href="/apple-touch-icon.png">` |
+| 4 | PWA install fails | Ensure manifest has 192x192 and 512x512 icons |
+| 5 | Icon URL resolution in manifest | Use absolute paths (e.g., `/icons/icon-192x192.png`) or relative paths (resolved relative to manifest location) |
+| 6 | Cache issues | Add version query string: `href="/favicon.ico?v=2"` |
 
 ## Full Audit Script
 
 ```bash
 #!/bin/bash
 # favicon-audit.sh - Full favicon audit
-
 url="${1:-https://example.com}"
 base_url=$(echo "$url" | grep -oE 'https?://[^/]+')
 
 echo "=== Favicon Audit: $url ==="
-echo ""
-
 html=$(curl -sL "$url")
 
-# Check favicon.ico
 echo "## Direct favicon.ico Check"
 status=$(curl -sI "$base_url/favicon.ico" 2>/dev/null | head -1 | cut -d' ' -f2)
 printf "  /favicon.ico: %s\n" "${status:-unreachable}"
 
-# Check HTML link tags
 echo ""
 echo "## HTML Icon Links"
 echo "$html" | grep -oE '<link[^>]+rel="[^"]*icon[^"]*"[^>]*>' | while read -r line; do
@@ -299,7 +158,6 @@ echo "$html" | grep -oE '<link[^>]+rel="[^"]*icon[^"]*"[^>]*>' | while read -r l
   printf "  %-20s %-12s %s\n" "$rel" "${sizes:-n/a}" "$href"
 done
 
-# Check apple-touch-icon
 echo ""
 echo "## Apple Touch Icons"
 apple_icons=$(echo "$html" | grep -c 'apple-touch-icon')
@@ -313,19 +171,16 @@ else
   echo "  [MISSING] No apple-touch-icon found"
 fi
 
-# Check manifest
 echo ""
 echo "## PWA Manifest"
 manifest_href=$(echo "$html" | grep -oE '<link[^>]+rel="manifest"[^>]+href="[^"]*"' | grep -oE 'href="[^"]*"' | cut -d'"' -f2)
 if [ -n "$manifest_href" ]; then
   [[ "$manifest_href" != http* ]] && manifest_href="${base_url}${manifest_href}"
   echo "  URL: $manifest_href"
-  
   manifest=$(curl -sL "$manifest_href" 2>/dev/null)
   if [ -n "$manifest" ]; then
     echo "  Icons:"
     echo "$manifest" | jq -r '.icons[]? | "    \(.sizes)\t\(.src)"' 2>/dev/null || echo "    [Failed to parse]"
-    
     has_192=$(echo "$manifest" | jq -r '.icons[]? | select(.sizes == "192x192") | .src' 2>/dev/null)
     has_512=$(echo "$manifest" | jq -r '.icons[]? | select(.sizes == "512x512") | .src' 2>/dev/null)
     echo ""
@@ -337,7 +192,6 @@ else
   echo "  [MISSING] No manifest.json link found"
 fi
 
-# Theme color
 echo ""
 echo "## Theme Color"
 theme=$(echo "$html" | grep -oE '<meta[^>]+name="theme-color"[^>]+content="[^"]*"' | grep -oE 'content="[^"]*"' | cut -d'"' -f2)


### PR DESCRIPTION
## Summary

- Tighten `.agents/seo/debug-favicon.md` from 357 to 211 lines (41% reduction)
- Address both CodeRabbit CHANGES_REQUESTED review comments from PR #9815:
  1. **Harden favicon extraction regex**: add `-i` flag for case-insensitive matching and `['"]` to handle both single and double-quoted `rel` attributes
  2. **Fix manifest icon `src` guidance**: relative URLs are valid per the Web App Manifest spec (MDN/W3C) — updated from "Use absolute paths" to "Use absolute or relative paths (resolved relative to manifest location)"

## Changes

- Collapsed verbose multi-section Quick Validation / Manifest Validation into single Quick Checks block
- Collapsed 6 individual Common Issues subsections into a single table
- Removed redundant manifest.json icons (kept only required 192x192 and 512x512)
- Removed redundant HTML comments and blank lines in code examples

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs-only change — agent prompt markdown)
- No runtime behaviour affected

Closes #9743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the favicon debugging guide with condensed validation checks and simplified examples.
  * Reorganized troubleshooting issues into a quick-reference table format for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->