### PR TITLE
GH#10521: Fix dispatch-dedup is-assigned to distinguish maintainer from runner

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -29,6 +29,11 @@
 #     task-id fallback) and should be skipped by pulse dispatch.
 #     Exit 0 = PR evidence exists (do NOT dispatch), exit 1 = no evidence.
 #
+#   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
+#     Check if issue is assigned to another runner (not self, owner, or maintainer).
+#     GH#10521: Ignores repo owner (from slug) and maintainer (from repos.json).
+#     Exit 0 = assigned to another runner (do NOT dispatch), exit 1 = safe to dispatch.
+#
 #   dispatch-dedup-helper.sh list-running-keys
 #     List dedup keys for all currently running workers.
 #
@@ -359,21 +364,49 @@ is_duplicate() {
 }
 
 #######################################
-# Check if a GitHub issue is already assigned to someone else.
+# Look up the repo maintainer from repos.json.
+# The maintainer is the repo owner/admin — not a runner account.
+# Args: $1 = repo slug (owner/repo)
+# Returns: maintainer login on stdout (empty if not found)
+#######################################
+_get_repo_maintainer() {
+	local repo_slug="$1"
+	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+
+	if [[ ! -f "$repos_json" ]]; then
+		return 0
+	fi
+
+	local maintainer=""
+	maintainer=$(jq -r --arg slug "$repo_slug" \
+		'.initialized_repos[] | select(.slug == $slug) | .maintainer // empty' \
+		"$repos_json" 2>/dev/null) || maintainer=""
+
+	printf '%s' "$maintainer"
+	return 0
+}
+
+#######################################
+# Check if a GitHub issue is already assigned to another runner.
 #
 # This is the primary cross-machine dedup guard. Process-based checks
 # (is_duplicate, has_worker_for_repo_issue) only see local processes —
 # they miss workers running on other machines. The GitHub assignee is
 # the single source of truth visible to all runners.
 #
+# GH#10521: Distinguishes maintainer/owner assignment from runner
+# assignment. Issues assigned to the repo maintainer (from repos.json)
+# or the repo owner (from slug) are NOT blocked — only issues assigned
+# to other known runner accounts trigger the dedup guard.
+#
 # Args:
 #   $1 = issue number
 #   $2 = repo slug (owner/repo)
 #   $3 = (optional) current runner login — if assigned to self, not a dup
 # Returns:
-#   exit 0 if assigned to someone else (do NOT dispatch)
-#   exit 1 if unassigned or assigned to self (safe to dispatch)
-# Outputs: assignee info on stdout if assigned
+#   exit 0 if assigned to another runner (do NOT dispatch)
+#   exit 1 if unassigned, assigned to self, or assigned to maintainer/owner (safe to dispatch)
+# Outputs: assignee info on stdout if assigned to another runner
 #######################################
 is_assigned() {
 	local issue_number="$1"
@@ -400,27 +433,62 @@ is_assigned() {
 		return 1
 	fi
 
-	# If assigned to self, not a duplicate
+	# Build the set of non-runner logins to exclude from the dedup check:
+	# 1. Current runner (self_login)
+	# 2. Repo maintainer from repos.json
+	# 3. Repo owner from slug (owner/repo → owner)
+	local -a non_runner_logins=()
 	if [[ -n "$self_login" ]]; then
-		# Check if ALL assignees are self (could be multiple)
-		local dominated_by_self=true
-		local -a assignee_array=()
-		local saved_ifs="${IFS:-}"
-		IFS=',' read -ra assignee_array <<<"$assignees"
-		IFS="$saved_ifs"
-		local assignee
-		for assignee in "${assignee_array[@]}"; do
-			if [[ "$assignee" != "$self_login" ]]; then
-				dominated_by_self=false
+		non_runner_logins+=("$self_login")
+	fi
+
+	# Repo owner from slug (the part before /)
+	local repo_owner=""
+	repo_owner="${repo_slug%%/*}"
+	if [[ -n "$repo_owner" ]]; then
+		non_runner_logins+=("$repo_owner")
+	fi
+
+	# Repo maintainer from repos.json
+	local repo_maintainer=""
+	repo_maintainer=$(_get_repo_maintainer "$repo_slug")
+	if [[ -n "$repo_maintainer" ]]; then
+		non_runner_logins+=("$repo_maintainer")
+	fi
+
+	# Check if ALL assignees are non-runner logins (self, maintainer, or owner)
+	local has_runner_assignee=false
+	local runner_assignees=""
+	local -a assignee_array=()
+	local saved_ifs="${IFS:-}"
+	IFS=',' read -ra assignee_array <<<"$assignees"
+	IFS="$saved_ifs"
+	local assignee
+	for assignee in "${assignee_array[@]}"; do
+		local is_non_runner=false
+		local non_runner
+		for non_runner in "${non_runner_logins[@]}"; do
+			if [[ "$assignee" == "$non_runner" ]]; then
+				is_non_runner=true
 				break
 			fi
 		done
-		if [[ "$dominated_by_self" == "true" ]]; then
-			return 1
+		if [[ "$is_non_runner" == "false" ]]; then
+			has_runner_assignee=true
+			if [[ -n "$runner_assignees" ]]; then
+				runner_assignees="${runner_assignees},${assignee}"
+			else
+				runner_assignees="$assignee"
+			fi
 		fi
+	done
+
+	if [[ "$has_runner_assignee" == "false" ]]; then
+		# All assignees are self, maintainer, or repo owner — safe to dispatch
+		return 1
 	fi
 
-	printf 'ASSIGNED: issue #%s in %s is assigned to %s\n' "$issue_number" "$repo_slug" "$assignees"
+	printf 'ASSIGNED: issue #%s in %s is assigned to runner(s) %s\n' "$issue_number" "$repo_slug" "$runner_assignees"
 	return 0
 }
 
@@ -502,7 +570,8 @@ Usage:
   dispatch-dedup-helper.sh has-open-pr <issue> <slug> [issue-title]
                                                     Check merged PR evidence (exit 0=evidence, 1=none)
   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
-                                                     Check if issue is assigned (exit 0=assigned, 1=free)
+                                                      Check if assigned to another runner (exit 0=blocked, 1=free)
+                                                      Ignores repo owner (from slug) and maintainer (from repos.json)
   dispatch-dedup-helper.sh claim <issue> <slug> [runner-login]
                                                      Cross-machine claim lock (exit 0=won, 1=lost, 2=error)
   dispatch-dedup-helper.sh release <issue> <slug> [runner-login]
@@ -524,11 +593,12 @@ Examples:
     echo "Safe to dispatch"
   fi
 
-  # Check before dispatching (cross-machine assignee dedup)
+  # Check before dispatching (cross-machine assignee dedup — GH#10521)
+  # Only blocks for runner accounts, not repo owner/maintainer
   if dispatch-dedup-helper.sh is-assigned 2300 owner/repo mylogin; then
-    echo "Assigned to someone else — skip dispatch"
+    echo "Assigned to another runner — skip dispatch"
   else
-    echo "Unassigned or assigned to self — safe to dispatch"
+    echo "Unassigned, assigned to self, or assigned to owner/maintainer — safe"
   fi
 
   # Check before dispatching (merged PR dedup)

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Test dispatch-dedup-helper.sh is-assigned (GH#10521)
+#
+# Verifies that is_assigned() distinguishes between:
+# - Repo maintainer/owner assignment (should NOT block dispatch)
+# - Runner account assignment (SHOULD block dispatch)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../dispatch-dedup-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+
+	mkdir -p "${TEST_ROOT}/bin"
+	mkdir -p "${TEST_ROOT}/config/aidevops"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+
+	# Create a repos.json with a known maintainer
+	cat >"${TEST_ROOT}/config/aidevops/repos.json" <<'EOF'
+{
+  "initialized_repos": [
+    {
+      "path": "/home/user/Git/aidevops",
+      "slug": "marcusquinn/aidevops",
+      "pulse": true,
+      "maintainer": "marcusquinn-bot"
+    },
+    {
+      "path": "/home/user/Git/other",
+      "slug": "orgname/other-repo",
+      "pulse": true,
+      "maintainer": "orgadmin"
+    }
+  ]
+}
+EOF
+
+	# Point the helper to our test repos.json
+	export REPOS_JSON="${TEST_ROOT}/config/aidevops/repos.json"
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Create a gh stub that returns specific assignees for a given issue
+create_gh_stub() {
+	local assignees_csv="$1"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+	# Return the configured assignees
+	printf '%s\n' "${assignees_csv}"
+	exit 0
+fi
+
+printf 'unsupported gh invocation in test stub\n' >&2
+exit 1
+GHEOF
+
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Test: unassigned issue → safe to dispatch (exit 1)
+test_unassigned_issue() {
+	create_gh_stub ""
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "unassigned issue allows dispatch" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "unassigned issue allows dispatch" 0
+	return 0
+}
+
+# Test: assigned to self → safe to dispatch (exit 1)
+test_assigned_to_self() {
+	create_gh_stub "runner1"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "assigned to self allows dispatch" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "assigned to self allows dispatch" 0
+	return 0
+}
+
+# Test: assigned to repo owner (from slug) → safe to dispatch (exit 1)
+# GH#10521: marcusquinn is the owner in marcusquinn/aidevops
+test_assigned_to_repo_owner() {
+	create_gh_stub "marcusquinn"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "assigned to repo owner allows dispatch (GH#10521)" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "assigned to repo owner allows dispatch (GH#10521)" 0
+	return 0
+}
+
+# Test: assigned to repo maintainer (from repos.json) → safe to dispatch (exit 1)
+# GH#10521: maintainer from repos.json should not block
+test_assigned_to_maintainer() {
+	create_gh_stub "marcusquinn-bot"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "assigned to maintainer allows dispatch (GH#10521)" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "assigned to maintainer allows dispatch (GH#10521)" 0
+	return 0
+}
+
+# Test: assigned to another runner → block dispatch (exit 0)
+test_assigned_to_another_runner() {
+	create_gh_stub "other-runner"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'other-runner'*)
+			print_result "assigned to another runner blocks dispatch" 0
+			return 0
+			;;
+		esac
+		print_result "assigned to another runner blocks dispatch" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "assigned to another runner blocks dispatch" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+# Test: assigned to both maintainer AND another runner → block dispatch (exit 0)
+test_mixed_assignees_with_runner() {
+	create_gh_stub "marcusquinn,other-runner"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'other-runner'*)
+			print_result "mixed assignees with runner blocks dispatch" 0
+			return 0
+			;;
+		esac
+		print_result "mixed assignees with runner blocks dispatch" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "mixed assignees with runner blocks dispatch" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+# Test: assigned to both maintainer AND self → safe to dispatch (exit 1)
+test_mixed_assignees_maintainer_and_self() {
+	create_gh_stub "marcusquinn,runner1"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "maintainer + self allows dispatch" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "maintainer + self allows dispatch" 0
+	return 0
+}
+
+# Test: different repo — maintainer from repos.json for orgname/other-repo
+test_different_repo_maintainer() {
+	create_gh_stub "orgadmin"
+
+	if "$HELPER_SCRIPT" is-assigned 200 orgname/other-repo runner1 >/dev/null 2>&1; then
+		print_result "different repo maintainer allows dispatch" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "different repo maintainer allows dispatch" 0
+	return 0
+}
+
+# Test: no self_login provided, assigned to owner → safe (exit 1)
+test_no_self_login_owner_assigned() {
+	create_gh_stub "marcusquinn"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops >/dev/null 2>&1; then
+		print_result "no self_login + owner assigned allows dispatch" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "no self_login + owner assigned allows dispatch" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	test_unassigned_issue
+	test_assigned_to_self
+	test_assigned_to_repo_owner
+	test_assigned_to_maintainer
+	test_assigned_to_another_runner
+	test_mixed_assignees_with_runner
+	test_mixed_assignees_maintainer_and_self
+	test_different_repo_maintainer
+	test_no_self_login_owner_assigned
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Fix `is_assigned()` in `dispatch-dedup-helper.sh` to distinguish repo maintainer/owner assignment from runner assignment (GH#10521)
- Add `_get_repo_maintainer()` helper that looks up the maintainer from `repos.json`
- Add 9-case test suite covering all assignment scenarios

## Problem

The `is-assigned` dedup check treated ANY assignee other than `self_login` as "assigned to another runner". When all 1003 issues were batch-assigned to `marcusquinn` (the repo maintainer), the pulse blocked dispatch for every single issue — zero workers dispatched despite 3 available slots.

## Fix

Build a non-runner exclusion set from three sources:
1. `self_login` (existing — the current runner)
2. Repo owner from slug (`marcusquinn/aidevops` → `marcusquinn`)
3. Repo maintainer from `repos.json` `maintainer` field

Only assignees NOT in this exclusion set trigger the dedup block. This means issues assigned to the repo owner or maintainer are treated as "unassigned for dispatch purposes" — they don't block runners from picking up work.

## Runtime Testing

- **Testing level**: `unit-tested`
- **Risk classification**: Medium (dispatch logic, no data mutation)
- **Tests**: 9 test cases all passing — unassigned, self, owner, maintainer, other-runner, mixed assignees (runner+maintainer), maintainer+self, different repo maintainer, no-self-login
- **ShellCheck**: Clean on both files

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/dispatch-dedup-helper.sh` | Add `_get_repo_maintainer()`, rewrite `is_assigned()` to exclude owner/maintainer |
| `.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh` | New 9-case test suite |

Closes #10521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dispatch blocking logic to treat assignments to repository owners and maintainers as non-blocking. The system now only prevents execution when an issue is assigned to another runner.

* **Tests**
  * Added comprehensive test coverage for dispatch assignment behavior, validating correct handling across various assignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->