### PR TITLE
GH#10269: tighten video-ugc.md agent doc by ~38%

### DIFF
--- a/.agents/tools/marketing/ad-creative/video-ugc.md
+++ b/.agents/tools/marketing/ad-creative/video-ugc.md
@@ -1,243 +1,150 @@
 ## Video Ad Hooks: The Critical First 3 Seconds
 
-Users scroll 400+ posts/hour. Decision to watch happens in <1 second. Every hook needs: visual pattern interrupt, immediate relevance signal, curiosity gap, emotional trigger, clear value promise.
+Users scroll 400+ posts/hour. Hook decision in <1 second. Every hook needs: visual pattern interrupt, immediate relevance, curiosity gap, emotional trigger, clear value promise. **Target:** 3-second view rate >50%.
 
-**Performance targets:** 3-second view rate >50%, strong hook-through and ThruPlay rates.
+### Question Hooks (1-20)
 
-**Common mistakes:** Too slow, too generic, no visual interrupt, unclear relevance, weak promise.
+| # | Name | Template |
+|---|------|----------|
+| 1 | Problem-Focused | "Still [doing painful thing]?" |
+| 2 | Identification | "Are you a [type] who [struggles with X]?" |
+| 3 | Yes-Set | "Want to [desired outcome]?" |
+| 4 | Challenging | "What if everything you know about [topic] is wrong?" |
+| 5 | Curiosity | "Want to know the secret [people] use to [result]?" |
+| 6 | Direct Pain | "Tired of [specific frustration]?" |
+| 7 | Future-Pacing | "What would [timeframe] look like with [outcome]?" |
+| 8 | Comparison | "Why do [successful group] [action] while you [other]?" |
+| 9 | Verification | "Did you know [surprising fact]?" |
+| 10 | Personal | "How much money are you leaving on the table with [bad strategy]?" |
+| 11 | Achievement | "Ready to [milestone]?" |
+| 12 | Objection | "What if you could [goal] without [objection]?" |
+| 13 | Timeline | "How long will you keep [negative behavior]?" |
+| 14 | Awareness | "Do you know what's killing your [outcome]?" |
+| 15 | Diagnostic | "Which of these [N] mistakes are you making?" |
+| 16 | Qualifier | "If you're [criteria], watch this" |
+| 17 | Rhetorical | "Who else wants [desired outcome]?" |
+| 18 | Negative Assumption | "Struggling with [problem]? You're not alone" |
+| 19 | Alternative | "What if there's a better way to [goal]?" |
+| 20 | Direct Challenge | "Think [common belief]? Think again" |
 
-### Category 1: Question Hooks (20 formulas)
+### Statement Hooks (21-40)
 
-Format: `# | Name | Template | Example`
+| # | Name | Template |
+|---|------|----------|
+| 21 | Bold Claim | "[Result] in [timeframe]" |
+| 22 | Shocking Statistic | "[N]% of [people] are [doing wrong thing]" |
+| 23 | Negative Callout | "Stop [common behavior]" |
+| 24 | Contrarian | "[Common advice] is killing your [outcome]" |
+| 25 | Personal Testimony | "[Timeframe] ago I [negative]. Now I [positive]" |
+| 26 | Revelation | "I just discovered why [problem occurs]" |
+| 27 | Story Beginning | "This is the story of how [outcome]" |
+| 28 | Single Solution | "One [thing] changed everything" |
+| 29 | Warning | "If you're [doing action], you need to see this" |
+| 30 | Mistake ID | "This is the #1 mistake [type] make" |
+| 31 | Secret Reveal | "[Type of people] don't want you to know this" |
+| 32 | Current Event | "[Recent change] changes everything for [people]" |
+| 33 | Urgency | "You have [timeframe] to [action] before [consequence]" |
+| 34 | Diagnosis | "Here's why your [thing] isn't working" |
+| 35 | Permission | "It's okay to [non-traditional action]" |
+| 36 | Attention Grab | "Attention [type of person]" |
+| 37 | Achievement | "We just [impressive feat]" |
+| 38 | Controversial | "[Popular thing] is overrated. Here's what works" |
+| 39 | Direct Address | "If you [qualifier], this is for you" |
+| 40 | Negative Consequence | "Every day you [inaction] costs you [loss]" |
 
-| # | Name | Template | Example |
-|---|------|----------|---------|
-| 1 | Problem-Focused | "Still [doing painful thing]?" | "Still manually scheduling your social posts?" |
-| 2 | Identification | "Are you a [type] who [struggles with X]?" | "Are you a small business owner struggling to get noticed online?" |
-| 3 | Yes-Set | "Want to [desired outcome]?" | "Want to double your Instagram followers in 30 days?" |
-| 4 | Challenging | "What if everything you know about [topic] is wrong?" | "What if everything you know about weight loss is wrong?" |
-| 5 | Curiosity | "Want to know the secret [people] use to [result]?" | "Want to know the secret top podcasters use to grow fast?" |
-| 6 | Direct Pain | "Tired of [specific frustration]?" | "Tired of ads that waste your money?" |
-| 7 | Future-Pacing | "What would [timeframe] look like with [outcome]?" | "What would your business look like with 100 qualified leads per month?" |
-| 8 | Comparison | "Why do [successful group] [action] while you [other]?" | "Why do top brands use video ads while you're still using images?" |
-| 9 | Verification | "Did you know [surprising fact]?" | "Did you know 70% of Facebook ads fail in the first 3 days?" |
-| 10 | Personal | "How much money are you leaving on the table with [bad strategy]?" | "How much money are you leaving on the table with poor ad creative?" |
-| 11 | Achievement | "Ready to [milestone]?" | "Ready to hit your first $10K month?" |
-| 12 | Objection | "What if you could [goal] without [objection]?" | "What if you could build muscle without spending hours at the gym?" |
-| 13 | Timeline | "How long will you keep [negative behavior]?" | "How long will you keep paying for software you don't use?" |
-| 14 | Awareness | "Do you know what's killing your [outcome]?" | "Do you know what's killing your conversion rate?" |
-| 15 | Diagnostic | "Which of these [N] mistakes are you making?" | "Which of these 5 Instagram mistakes are you making?" |
-| 16 | Qualifier | "If you're [criteria], watch this" | "If you're spending $5K+/month on ads, watch this" |
-| 17 | Rhetorical | "Who else wants [desired outcome]?" | "Who else wants passive income while they sleep?" |
-| 18 | Negative Assumption | "Struggling with [problem]? You're not alone" | "Struggling with engagement? You're not alone" |
-| 19 | Alternative | "What if there's a better way to [goal]?" | "What if there's a better way to find customers?" |
-| 20 | Direct Challenge | "Think [common belief]? Think again" | "Think you need a huge budget for video ads? Think again" |
-
-### Category 2: Statement Hooks (20 formulas)
-
-| # | Name | Template | Example |
-|---|------|----------|---------|
-| 21 | Bold Claim | "[Result] in [timeframe]" | "$40K in sales in 30 days from this strategy" |
-| 22 | Shocking Statistic | "[N]% of [people] are [doing wrong thing]" | "87% of Facebook ads fail because of this one mistake" |
-| 23 | Negative Callout | "Stop [common behavior]" | "Stop wasting money on bad ads" |
-| 24 | Contrarian | "[Common advice] is killing your [outcome]" | "Posting more content is killing your engagement" |
-| 25 | Personal Testimony | "[Timeframe] ago I [negative]. Now I [positive]" | "6 months ago I had 0 clients. Now I have a waitlist" |
-| 26 | Revelation | "I just discovered why [problem occurs]" | "I just discovered why your landing pages don't convert" |
-| 27 | Story Beginning | "This is the story of how [outcome]" | "This is the story of how we 10x'd our revenue" |
-| 28 | Single Solution | "One [thing] changed everything" | "One tweak to our ad copy doubled our ROI" |
-| 29 | Warning | "If you're [doing action], you need to see this" | "If you're running Facebook ads, you need to see this" |
-| 30 | Mistake ID | "This is the #1 mistake [type] make" | "This is the #1 mistake new e-com stores make" |
-| 31 | Secret Reveal | "[Type of people] don't want you to know this" | "Ad agencies don't want you to know this" |
-| 32 | Current Event | "[Recent change] changes everything for [people]" | "iOS 14 changes everything for advertisers" |
-| 33 | Urgency | "You have [timeframe] to [action] before [consequence]" | "You have 30 days to fix your ad account before Q4" |
-| 34 | Diagnosis | "Here's why your [thing] isn't working" | "Here's why your email campaigns aren't converting" |
-| 35 | Permission | "It's okay to [non-traditional action]" | "It's okay to spend less on ads and get better results" |
-| 36 | Attention Grab | "Attention [type of person]" | "Attention e-commerce store owners" |
-| 37 | Achievement | "We just [impressive feat]" | "We just scaled a client from $5K to $100K/month" |
-| 38 | Controversial | "[Popular thing] is overrated. Here's what works" | "Influencer marketing is overrated. Here's what works" |
-| 39 | Direct Address | "If you [qualifier], this is for you" | "If you spend $10K+/month on ads, this is for you" |
-| 40 | Negative Consequence | "Every day you [inaction] costs you [loss]" | "Every day you don't optimize costs you $500" |
-
-### Category 3: Visual Pattern Interrupts (15 formulas)
+### Visual Pattern Interrupts (41-55)
 
 | # | Name | Technique |
 |---|------|-----------|
-| 41 | Text Slap | Bold text appears suddenly ("WAIT", "STOP SCROLLING") — large, contrasting overlay |
-| 42 | Unexpected Perspective | Unusual camera angle/POV (e.g., over-shoulder of shocking dashboard metrics) |
-| 43 | Fast Motion | Quick action in frame — money thrown, product appearing suddenly |
-| 44 | Face Close-Up | Extreme close-up with strong expression (shock, excitement, concern) |
-| 45 | Contrast Shock | Sudden shift dark→bright or vice versa (black screen to bright dashboard) |
-| 46 | Text On/Off | Key phrases flashing rapidly — kinetic typography |
-| 47 | Split Screen | Before/after or old way/new way shown simultaneously |
-| 48 | Object Drop | Product/object drops into frame with physics-based motion |
-| 49 | Color Flash | Bright brand color fills screen then reveals content |
-| 50 | Zoom Effect | Rapid zoom in/out (e.g., into specific metric on dashboard) |
-| 51 | Hand-Held Shake | Intentionally shaky cam for UGC authenticity |
-| 52 | Emoji/Sticker Pop | Animated emoji or "NEW" sticker appears |
-| 53 | Graph/Data Viz | Striking chart or upward-trending graph animation |
+| 41 | Text Slap | Bold text suddenly ("WAIT", "STOP SCROLLING") — large, contrasting |
+| 42 | Unexpected Perspective | Unusual camera angle/POV |
+| 43 | Fast Motion | Quick action — money thrown, product appearing |
+| 44 | Face Close-Up | Extreme close-up, strong expression |
+| 45 | Contrast Shock | Sudden dark-to-bright or vice versa |
+| 46 | Text On/Off | Key phrases flashing — kinetic typography |
+| 47 | Split Screen | Before/after or old/new way simultaneously |
+| 48 | Object Drop | Product drops into frame with physics motion |
+| 49 | Color Flash | Brand color fills screen then reveals content |
+| 50 | Zoom Effect | Rapid zoom in/out on specific element |
+| 51 | Hand-Held Shake | Shaky cam for UGC authenticity |
+| 52 | Emoji/Sticker Pop | Animated emoji or "NEW" sticker |
+| 53 | Graph/Data Viz | Striking chart or upward-trending animation |
 | 54 | Product Showcase | Product appears dramatically (spinning, unboxing) |
-| 55 | Scene Jump | Quick cut between contrasting scenes (messy desk → organized desk) |
+| 55 | Scene Jump | Quick cut between contrasting scenes |
 
-### Category 4: Combination Hooks (10 formulas)
+### Combination Hooks (56-65)
 
-| # | Name | Template | Example |
-|---|------|----------|---------|
-| 56 | Question + Statistic | "Did you know [X]% of [people] [fact]?" | "Did you know 73% of your website visitors leave without buying?" |
-| 57 | Statement + Question | "[Bold claim]. Want to know how?" | "I 5x'd my revenue in 60 days. Want to know how?" |
-| 58 | Visual + Text Slap | Striking visual with bold text overlay | Money visual + "YOU'RE LEAVING MONEY ON THE TABLE" |
-| 59 | Personal Story + Result | "[Timeframe] ago: [struggle]. Today: [success]" | "30 days ago: $0 in sales. Today: $15K" |
-| 60 | Warning + Question | "If you're [doing X], are you [consequence]?" | "If you're running ads, are you losing money?" |
-| 61 | Negative + Positive | "Stop [bad]. Start [good]" | "Stop chasing followers. Start building community" |
-| 62 | Identify + Promise | "[Type]? Here's how to [goal]" | "E-comm owner? Here's how to scale to $100K/month" |
-| 63 | Shock + Explanation | "[Shocking fact]. Here's why it matters" | "Your best ad is shown to the wrong people. Here's why it matters" |
-| 64 | Challenge + Invitation | "Think you can't [goal]? Watch this" | "Think you can't afford video ads? Watch this" |
-| 65 | Pain + Solution | "Struggling with [problem]? I found the fix" | "Struggling with high CPAs? I found the fix" |
+| # | Name | Template |
+|---|------|----------|
+| 56 | Question + Statistic | "Did you know [X]% of [people] [fact]?" |
+| 57 | Statement + Question | "[Bold claim]. Want to know how?" |
+| 58 | Visual + Text Slap | Striking visual + bold text overlay |
+| 59 | Personal Story + Result | "[Timeframe] ago: [struggle]. Today: [success]" |
+| 60 | Warning + Question | "If you're [doing X], are you [consequence]?" |
+| 61 | Negative + Positive | "Stop [bad]. Start [good]" |
+| 62 | Identify + Promise | "[Type]? Here's how to [goal]" |
+| 63 | Shock + Explanation | "[Shocking fact]. Here's why it matters" |
+| 64 | Challenge + Invitation | "Think you can't [goal]? Watch this" |
+| 65 | Pain + Solution | "Struggling with [problem]? I found the fix" |
 
-### Hook Testing Framework
+### Hook Testing
 
-**Test variables:** Hook type (question/statement/visual), specificity, emotion (fear/desire/curiosity), length (1s vs 3s), visual (with/without person).
-
-**Winning characteristics:** Immediately signals relevance, creates open loop, stands out visually, speaks to avatar, promises specific value.
+**Variables:** Hook type (question/statement/visual), specificity, emotion (fear/desire/curiosity), length (1s vs 3s), visual (with/without person). **Winners:** Immediately signals relevance, creates open loop, stands out visually, speaks to avatar, promises specific value.
 
 ---
 
 ## UGC-Style Ad Creation
 
-**Definition:** Content that looks like it was created by a real customer — smartphone-shot, casual setting, authentic delivery.
+Content that looks customer-created — smartphone-shot, casual setting, authentic delivery. Works because: native to platform, higher trust, lower cost, better engagement, algorithm-favored.
 
-**Why UGC works:** Native to platform (doesn't look like an ad), higher trust (peer vs brand), lower production friction, better engagement, algorithm favorability.
-
-| Traditional Brand Ads | UGC-Style Ads |
-|-----------------------|---------------|
-| Professional production | Smartphone filmed |
-| Studio setting | Home/casual environment |
+| Traditional | UGC-Style |
+|-------------|-----------|
+| Professional/studio | Smartphone/casual |
 | Scripted, polished | Conversational, natural |
 | Product-focused | Person-focused with product |
 | High cost, slow iteration | Low cost, fast testing |
 
-### UGC Creation Process
+### Creation Process
 
-**Step 1: Source Creators**
+**Sourcing:** Hire (Fiverr/Billo/Insense: $100-500, 3-7 days) | Customer testimonials (incentive) | Internal team (free, fastest).
 
-| Source | Cost | Turnaround | Best For |
-|--------|------|------------|----------|
-| Hire (Fiverr, Billo, Insense) | $100-500/video | 3-7 days | Scaling production |
-| Customer testimonials | Incentive (discount/free product) | Varies | Genuine authenticity |
-| Internal team | Free (salary) | Fastest | Testing concepts quickly |
-
-**Step 2: Brief Creation**
+**Brief template:**
 
 ```text
-CREATOR: [Name/Type]
-PRODUCT: [What they're promoting]
-OBJECTIVE: [What the video should accomplish]
-
-TARGET AUDIENCE:
-- [Demographics, pain points, desires]
-
-KEY MESSAGES:
-1. [Main benefit]  2. [Differentiator]  3. [Social proof element]
-
-SCRIPT STRUCTURE:
-0-3s: [Hook]  |  3-10s: [Story/problem]  |  10-20s: [Solution/product]
-20-30s: [Benefits/results]  |  30-40s: [Social proof]  |  40-45s: [CTA]
-
-FILMING: Vertical 9:16, smartphone, natural lighting, casual setting, include captions
-TALKING POINTS (not a script): [Point 1] [Point 2] [Point 3]
-
-DON'T: Sound like an ad, use marketing jargon, be overly promotional, use "perfect" delivery
-DELIVERABLES: 1x 30-45s vertical video, raw footage, usage rights for paid advertising
+CREATOR: [Name/Type] | PRODUCT: [What] | OBJECTIVE: [Goal]
+TARGET: [Demographics, pain points, desires]
+MESSAGES: 1. [Main benefit] 2. [Differentiator] 3. [Social proof]
+SCRIPT: 0-3s [Hook] | 3-10s [Problem] | 10-20s [Solution] | 20-30s [Benefits] | 30-40s [Proof] | 40-45s [CTA]
+FILMING: Vertical 9:16, smartphone, natural light, casual setting, captions
+DON'T: Sound like an ad, use jargon, be overly promotional
+DELIVERABLES: 1x 30-45s vertical, raw footage, paid ad usage rights
 ```
 
-**Step 3: Filming Best Practices**
+**Filming:** Vertical 9:16, natural light (face window/golden hour), person fills 60-70% at eye level, speak TO camera like FaceTiming a friend, 3-5 takes varying hooks/energy, capture B-roll.
 
-- **Technical:** Smartphone, vertical 9:16, natural light (face window/golden hour), stable hand-hold or tripod, quiet environment
-- **Framing:** Person fills 60-70% of frame, eye level, simple background, product visible but not dominating
-- **Delivery:** Speak TO camera like FaceTiming a friend, casual pace, okay to pause/"um", don't sound scripted
-- **Takes:** Film 3-5 full takes, vary hooks and energy levels, capture B-roll, get vertical + square versions
+**Editing:** Minimal (raw feel), jump cuts for energy. Captions required (85% watch muted) — large font, high contrast, synced. Tools: CapCut, InShot, Canva, Premiere Rush, VEED.io.
 
-**Step 4: Editing**
+### Script Frameworks
 
-- **Style:** Minimal editing (maintain raw feel), jump cuts for energy, simple transitions, no fancy effects
-- **Captions (required — 85% watch without sound):** Large readable font, high contrast (white text/black outline), center or lower third, synced to speech
-- **Audio:** Keep original, optional subtle background music, ensure voice is clear
-- **B-Roll:** Brief product shots, results/before-after, screenshots of reviews — person stays primary focus
-- **Tools:** CapCut (free), InShot, Canva, Adobe Premiere Rush, VEED.io (auto-captions)
+**1. Problem-Discovery-Solution:** Hook: "I used to struggle with [pain]" → Tried everything, nothing worked → Discovery [timeframe] ago → Results: "Within [time], [result]" → CTA: "Link in bio" / "Use code [CODE]"
 
-### UGC Script Frameworks
+**2. Transformation Story:** Hook: "[Time] ago I [negative state]" → Daily struggles/emotions → Turning point: discovered product → Journey: early result → bigger result → now → "The difference is [mechanism]"
 
-**Framework 1: Problem-Discovery-Solution**
+**3. Comparison/Alternative:** Hook: "I switched from [popular] to [product]" → Old problems → What's better: [1], [2], [3] → Results since switching → "Make the switch"
 
-```text
-[0-3s] HOOK: "I used to struggle with [specific pain point]"
-[3-10s] TRIED EVERYTHING: "I tried [solution 1], [solution 2], [solution 3]... nothing worked"
-[10-20s] DISCOVERY: "Then [timeframe] ago, [how you found product]"
-[20-35s] RESULTS: "Within [timeframe], I noticed [specific result]. Now [current state]"
-[35-45s] RECOMMENDATION: "If you're dealing with [problem], honestly try this. [Specific reason]"
-[CTA]: "Link in bio" or "Use code [CODE]"
-```
+**4. Unexpected Benefit:** Hook: "I bought [product] for [reason] but [surprise]" → Original intent → Unexpected benefit → Why it matters more → Recommend for the surprise benefit
 
-**Example — Skincare:**
+**5. Direct Recommendation:** Hook: "If you [qualifier], you need this" → Why it's perfect for [audience] → Features + benefits → Personal results over [timeframe] → Where/price/guarantee
 
-> "I've struggled with acne scars for years. Tried expensive creams, laser treatments, dermatologists... spent thousands with barely any improvement. Then 3 months ago, my esthetician recommended this serum. I was super skeptical. But within 2 weeks, I could see my scars fading. Now, 3 months later — my skin hasn't looked this clear since high school. If you have scarring or texture issues, please try this. Link below."
+### Performance Optimization
 
-**Framework 2: Transformation Story**
+**Test variables:** Creators (age/gender, personality, expert vs everyday) | Settings (location, indoor/outdoor, framing) | Hooks (question vs statement, problem vs result) | Angle (transformation, review, comparison, tutorial, unboxing) | Length (15s/30s/45-60s).
 
-```text
-[0-3s] HOOK: "[Timeframe] ago I [negative state]"
-[3-10s] STRUGGLE: "Every day was [struggles]. I felt [emotions]"
-[10-20s] TURNING POINT: "Everything changed when [discovered product]"
-[20-35s] JOURNEY: "First [short timeframe]: [early result] → After [longer]: [bigger result] → Now: [current state]"
-[35-45s] WHY IT WORKED: "The difference is [unique mechanism]"
-```
-
-**Framework 3: Comparison/Alternative**
-
-```text
-[0-3s] HOOK: "I switched from [popular solution] to [product]"
-[3-10s] WHY: "[Popular solution] was [problems]"
-[10-25s] WHAT'S BETTER: "[Product] is different because [1], [2], [3]"
-[25-40s] RESULTS: "Since switching: [specific improvements]"
-[40-45s] RECOMMENDATION: "If you're using [old], make the switch"
-```
-
-**Framework 4: Unexpected Benefit**
-
-```text
-[0-3s] HOOK: "I bought [product] for [reason] but [unexpected benefit]"
-[3-10s] ORIGINAL INTENT: "I got this because [main selling point]"
-[10-25s] SURPRISE: "What I didn't expect was [surprising benefit]"
-[25-40s] WHY IT MATTERS: "This matters more than [original] because [reasoning]"
-[40-45s] RECOMMENDATION: "Even if you just want [main benefit], get it for [unexpected benefit]"
-```
-
-**Framework 5: Direct Recommendation**
-
-```text
-[0-3s] HOOK: "If you [qualifier], you need this"
-[3-10s] WHY FOR THEM: "Here's why it's perfect for [audience]: [reasons]"
-[10-25s] FEATURES: "[Feature 1 + benefit], [Feature 2 + benefit], [Feature 3 + benefit]"
-[25-35s] PROOF: "I've used it for [timeframe] and [specific results]"
-[35-45s] HOW TO GET IT: "[Where], [price/offer], [guarantee]"
-```
-
-### UGC Performance Optimization
-
-**Testing variables:**
-
-1. **Creators:** Age/gender diversity, personality (energetic vs calm), expert vs everyday, new vs long-time user
-2. **Settings:** Home/car/coffee shop/office, indoor/outdoor, close-up vs full body
-3. **Hooks:** Question vs statement, problem vs result, personal story vs direct recommendation
-4. **Content angle:** Transformation, review, comparison, tutorial, unboxing, day-in-the-life
-5. **Length:** 15s (mobile-optimized), 30s (story + conversion balance), 45-60s (full story)
-
-**Iteration process:** Launch 5-10 variations → run 3-7 days (min 50 purchases/creative) → identify top 20% → analyze common elements → create variations of winners → retire bottom 50% → repeat weekly.
-
-**Scaling phases:**
+**Iteration:** 5-10 variations → 3-7 days (min 50 purchases/creative) → top 20% get variations → retire bottom 50% → repeat weekly.
 
 | Phase | Timeline | Actions |
 |-------|----------|---------|
-| Validation | Weeks 1-2 | 5 UGC concepts, small budget, identify winning angle |
-| Variation | Weeks 3-4 | 10 variations of winner, different creators same message, test hooks/lengths |
-| Scale | Weeks 5+ | 5-10 creators/month, 2-3 videos each, 20+ ads in rotation, continuously retire/promote |
-| Systematization | Ongoing | Build creator roster, template briefs, streamline approval, content calendar |
+| Validation | Weeks 1-2 | 5 concepts, small budget, find winning angle |
+| Variation | Weeks 3-4 | 10 variations of winner, different creators, test hooks/lengths |
+| Scale | Weeks 5+ | 5-10 creators/month, 20+ ads in rotation, retire/promote |
+| Systematization | Ongoing | Creator roster, template briefs, approval flow, content calendar |


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/marketing/ad-creative/video-ugc.md` from 243 to 150 lines (~38% reduction)
- Compress prose while preserving all 65 hook formulas, 5 UGC script frameworks, 4 scaling phases, and tool references
- Remove redundant inline examples where the template bracket syntax is self-explanatory

## What changed

| Technique | Lines saved |
|-----------|-------------|
| Remove duplicate examples from hook tables (template already shows pattern) | ~30 |
| Consolidate 5 script frameworks from code blocks to inline summaries | ~35 |
| Tighten UGC creation process prose | ~15 |
| Compress visual pattern interrupt descriptions | ~10 |
| Merge section headers and reduce whitespace | ~3 |

## Content preservation verification

- All 65 hook formulas: verified (`rg -c '^\| [0-9]'` = 65)
- All 5 script frameworks: verified
- All 4 scaling phases: verified
- Tool/platform references (CapCut, Fiverr, Billo, Insense, VEED.io): verified
- Zero markdownlint errors

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** Low (docs-only change, no code)
- **Verification:** Line count, formula count, lint check

Closes #10269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined video UGC marketing guide with condensed hook formulas, visual pattern interrupts, and creation process steps
  * Simplified UGC comparison guidance and script framework descriptions
  * Updated performance optimization recommendations for improved clarity and faster reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->