### PR TITLE
t10569: tighten email-sequences.md prose headers

### DIFF
--- a/.agents/tools/marketing/direct-response-copy/templates/email-sequences.md
+++ b/.agents/tools/marketing/direct-response-copy/templates/email-sequences.md
@@ -2,7 +2,7 @@
 
 ## Shared Conventions
 
-**All templates below use these defaults** (don't repeat in each email):
+**Defaults for all templates** (don't repeat in each email):
 - Greeting: `Hey [First Name],` or `[First Name],`
 - Sign-off: `[Your Name]` (solo brand) or `— [Your Name/Team]` (SaaS/company)
 - Every email ends with a reply invitation ("Just reply", "Hit reply", etc.)
@@ -10,7 +10,7 @@
 
 ## Reusable Patterns
 
-These archetypes appear across multiple sequences. Each sequence email references which pattern it uses, with sequence-specific customisations noted inline.
+Archetypes referenced by name across sequences. Sequence-specific customisations noted inline.
 
 ### Pattern: Social Proof
 


### PR DESCRIPTION
## Summary

- Removes two verbose meta-description sentences that restate what section headings already convey
- Template bodies, pattern blocks, subject line tables, and all sequence content preserved intact
- File classified as reference corpus — content compression would lose value; only prose overhead removed

## Changes

- `## Shared Conventions` intro: "All templates below use these defaults" → "Defaults for all templates"
- `## Reusable Patterns` intro: 2-sentence verbose explanation → 1 concise sentence

## Runtime Testing

- **Risk classification:** Low (docs/agent prompts only)
- **Testing level:** self-assessed
- **Verification:** Content preservation confirmed — all code blocks, template bodies, pattern references, and subject line templates present before and after

Closes #10569