### PR TITLE
GH#10783: Fix simplification scanner duplicate issue creation

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2837,8 +2837,14 @@ _complexity_scan_extract_md_topic_label() {
 }
 
 # Check if an open simplification-debt issue already exists for a given file.
+#
+# Uses GitHub search API via `gh issue list --search` to query server-side,
+# avoiding the --limit 200 cap that caused duplicate issues (GH#10783).
+# Previous approach fetched 200 issues locally and checked with jq, but with
+# 3000+ open simplification-debt issues, most were invisible to the dedup check.
+#
 # Arguments:
-#   $1 - existing_issues (JSON array from gh issue list)
+#   $1 - repo_slug (owner/repo for gh commands)
 #   $2 - issue_key (repo-relative file path used as dedup key)
 # Exit codes:
 #   0 - existing issue found (skip creation)
@@ -2857,6 +2863,18 @@ _complexity_scan_has_existing_issue() {
 	if [[ "${match_count:-0}" -gt 0 ]]; then
 		return 0
 	fi
+
+	# Fallback: search in issue body for the structured **File:** field.
+	# This catches issues where the title format differs (e.g., Qlty issues).
+	match_count=$(gh issue list --repo "$repo_slug" \
+		--label "simplification-debt" --state open \
+		--search "\"$issue_key\" in:body" \
+		--json number --jq 'length' 2>/dev/null) || match_count="0"
+
+	if [[ "$match_count" -gt 0 ]]; then
+		return 0
+	fi
+
 	return 1
 }
 

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -190,24 +190,34 @@ Every finding must pass through a maintainer before work begins, enforced throug
 
 ### Issue creation (by code-simplifier agent)
 
-1. Add labels: `simplification-debt` + `needs-maintainer-review`
-2. Assign to repo maintainer (from `repos.json` `maintainer` field, fall back to slug owner)
-3. Include structured finding format (Current/Proposed/Preserved/Risk/Verification/Confidence)
+1. **Dedup check FIRST (GH#10783)** -- before creating any issue, search for existing open issues targeting the same file. Without this, each scan run creates duplicates.
+2. Add labels: `simplification-debt` + `needs-maintainer-review`
+3. Assign to repo maintainer (from `repos.json` `maintainer` field, fall back to slug owner)
+4. Include structured finding format (Current/Proposed/Preserved/Risk/Verification/Confidence)
 
 ```bash
 MAINTAINER=$(jq -r '.initialized_repos[] | select(.slug == "<slug>") | .maintainer // empty' ~/.config/aidevops/repos.json)
 [[ -z "$MAINTAINER" ]] && MAINTAINER=$(echo "<slug>" | cut -d/ -f1)
 
-gh issue create --repo <slug> \
-  --title "simplification: <brief description>" \
-  --label "simplification-debt" --label "needs-maintainer-review" \
-  --assignee "$MAINTAINER" \
-  --body "<structured finding>
+# Dedup: check for existing open issue targeting this file (GH#10783)
+EXISTING=$(gh issue list --repo <slug> \
+  --label "simplification-debt" --state open \
+  --search "\"<file_path>\" in:title" \
+  --json number --jq 'length' 2>/dev/null) || EXISTING="0"
+if [[ "$EXISTING" -gt 0 ]]; then
+  echo "Skipping <file_path> — existing open simplification-debt issue found"
+else
+  gh issue create --repo <slug> \
+    --title "simplification: <brief description>" \
+    --label "simplification-debt" --label "needs-maintainer-review" \
+    --assignee "$MAINTAINER" \
+    --body "<structured finding>
 
 ---
 **To approve or decline**, comment on this issue:
 - \`approved\` — removes the review gate and queues for automated dispatch
 - \`declined: <reason>\` — closes this issue"
+fi
 ```
 
 The `needs-maintainer-review` label prevents pulse dispatch. GitHub notifies the assignee on creation.


### PR DESCRIPTION
## Summary

- Replace bulk-fetch dedup (`--limit 200` + local jq) with per-file `gh issue list --search` queries in `_complexity_scan_has_existing_issue`
- Add dedup check guidance to `code-simplifier.md` interactive agent issue creation instructions

Closes #10783

## Root Cause

The `_complexity_scan_has_existing_issue` function fetched 200 issues via `gh issue list --limit 200` and checked locally with `jq`. With **3,323 open `simplification-debt` issues**, the dedup only saw 6% of existing issues. Every daily scan created fresh duplicates for files whose issues fell outside the first 200 results.

## Fix

Changed `_complexity_scan_has_existing_issue` to accept `repo_slug` instead of a pre-fetched JSON array, and query GitHub's search API directly:

```bash
gh issue list --repo "$repo_slug" \
  --label "simplification-debt" --state open \
  --search "\"$issue_key\" in:title" \
  --json number --jq 'length'
```

This delegates filtering to GitHub's search index, which handles any number of issues. Falls back to body search for issues with non-standard title formats (e.g., Qlty issues).

**Trade-off**: More API calls (one per candidate file) vs. one bulk call. The scan runs daily with ~50-200 candidates — well within rate limits. The alternative (fetching 3000+ issues) would be slower and more memory-intensive.

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/pulse-wrapper.sh` | Rewrote `_complexity_scan_has_existing_issue` to use search API; updated both callers to pass `repo_slug` instead of `existing_issues` JSON |
| `.agents/tools/code-review/code-simplifier.md` | Added dedup check step to interactive issue creation instructions |

## Runtime Testing

- **Level**: `self-assessed` (low risk — agent prompt + shell script logic change)
- **Risk**: Low — changes only affect issue creation dedup, not core pulse logic
- **Verification**: `bash -n` + `shellcheck` pass clean; tested search queries against live data confirming correct match/no-match behaviour
- Verified `animejs.md` returns 14 matches (correctly blocks creation)
- Verified nonexistent file returns 0 matches (correctly allows creation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate issue detection to prevent creating duplicate GitHub issues when scanning code complexity.
  * Enhanced issue matching with a multi-phase server-side search approach for improved accuracy and reliability over previous local caching methods.

* **Documentation**
  * Updated issue creation workflow documentation to include and clarify deduplication checks that occur before any new issue is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->