### PR TITLE
t10993: simplify semrush.md from 219 to 130 lines

### DIFF
--- a/.agents/seo/semrush.md
+++ b/.agents/seo/semrush.md
@@ -11,138 +11,57 @@ tools:
 
 # Semrush SEO Integration
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
-- **Purpose**: Domain analytics, keyword research, backlinks, competitor research, position tracking, site audit
 - **API**: `https://api.semrush.com/` (Analytics v3) | `https://api.semrush.com/management/v1/` (Projects)
-- **Auth**: `key=` query param — key in `~/.config/aidevops/credentials.sh` as `SEMRUSH_API_KEY`; load with `source ~/.config/aidevops/credentials.sh`
-- **Response**: CSV (semicolon-delimited) for Analytics v3
-- **Docs**: https://developer.semrush.com/api/
-- **No MCP required** — uses curl directly (official MCP server also available)
-- **Setup**: Get key from Semrush account > Subscription Info > API Units tab; add `export SEMRUSH_API_KEY="your_key_here"` to credentials.sh
+- **Auth**: `key=` query param — `SEMRUSH_API_KEY` in `~/.config/aidevops/credentials.sh`; `source ~/.config/aidevops/credentials.sh`
+- **Response**: CSV (semicolon-delimited). Docs: https://developer.semrush.com/api/ — no MCP required (curl direct; official MCP also available)
+- **Setup**: Semrush account > Subscription Info > API Units tab; `export SEMRUSH_API_KEY="your_key_here"`
+- **Pricing**: Pro 10k units/$139.95 | Guru 30k/$249.95 | Business 50k/$499.95 per month. Additional units purchasable.
+- **Unit balance**: `curl -s "https://api.semrush.com/management/v1/projects?key=$SEMRUSH_API_KEY" -H "Accept: application/json"`
 
-## Pricing (unit-based)
+Use `display_limit` to control unit consumption per request.
 
-| Plan | API Units/Month | Price |
-|------|----------------|-------|
-| Pro | 10,000 | $139.95/mo |
-| Guru | 30,000 | $249.95/mo |
-| Business | 50,000 | $499.95/mo |
+## Endpoints
 
-Use `display_limit` to control unit consumption. Additional units purchasable.
+All Analytics v3 endpoints return CSV (semicolon-delimited). Use `export_columns` to select fields.
 
-<!-- AI-CONTEXT-END -->
-
-## API Unit Balance
-
-```bash
-curl -s "https://api.semrush.com/management/v1/projects?key=$SEMRUSH_API_KEY" \
-  -H "Accept: application/json"
-```
-
-## Analytics API v3 Endpoints
-
-All Analytics v3 endpoints return CSV (semicolon-delimited). Use `export_columns` to select fields and `display_limit` to limit rows (saves API units).
-
-### Domain Overview (All Databases)
+### Domain Reports
 
 ```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_ranks&export_columns=Db,Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain=example.com"
-```
-
-### Domain Overview (One Database)
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_rank&export_columns=Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain=example.com&database=us"
-```
-
-### Domain Organic Keywords
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_organic&export_columns=Ph,Po,Pp,Pd,Nq,Cp,Ur,Tr,Tc,Co,Kd&domain=example.com&database=us&display_limit=50"
-```
-
-### Domain Paid Keywords
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_adwords&export_columns=Ph,Po,Nq,Cp,Tr,Tc,Co,Ur,Ds&domain=example.com&database=us&display_limit=50"
-```
-
-### Competitors in Organic Search
-
-```bash
+curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_organic_unique&export_columns=Ur,Pc,Tg&domain=example.com&database=us&display_limit=50"
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_organic_organic&export_columns=Dn,Cr,Np,Or,Ot,Oc,Ad&domain=example.com&database=us&display_limit=20"
-```
-
-### Domain vs Domain
-
-Compare up to 5 domains for keyword overlap:
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_domains&export_columns=Ph,Nq,Cp,Co,Kd,P0,P1,P2&domains=example.com%7Cor%7C*%7Ccompetitor1.com%7Cor%7C*%7Ccompetitor2.com%7Cor%7C*&database=us&display_limit=50"
 ```
 
-### Backlinks Overview
+`domain_ranks`=all DBs overview, `domain_rank`=one DB, `domain_organic`=organic keywords, `domain_adwords`=paid keywords, `domain_organic_unique`=organic pages, `domain_organic_organic`=competitors, `domain_domains`=domain vs domain (up to 5).
 
-```bash
-curl -s "https://api.semrush.com/analytics/v1/?key=$SEMRUSH_API_KEY&type=backlinks_overview&target=example.com&target_type=root_domain&export_columns=total,domains_num,urls_num,ips_num,follows_num,nofollows_num,texts_num,images_num"
-```
-
-### Backlinks List
-
-```bash
-curl -s "https://api.semrush.com/analytics/v1/?key=$SEMRUSH_API_KEY&type=backlinks&target=example.com&target_type=root_domain&export_columns=source_url,source_title,target_url,anchor,external_num,internal_num&display_limit=50"
-```
-
-### Referring Domains
-
-```bash
-curl -s "https://api.semrush.com/analytics/v1/?key=$SEMRUSH_API_KEY&type=backlinks_refdomains&target=example.com&target_type=root_domain&export_columns=domain,domain_score,backlinks_num,first_seen,last_seen&display_limit=50"
-```
-
-### Keyword Overview (One Database)
+### Keyword Reports
 
 ```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=phrase_this&export_columns=Ph,Nq,Cp,Co,Nr,Td,Kd,In&phrase=seo+tools&database=us"
-```
-
-### Keyword Overview (All Databases)
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=phrase_all&export_columns=Db,Ph,Nq,Cp,Co,Nr&phrase=seo+tools"
-```
-
-### Related Keywords
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=phrase_related&export_columns=Ph,Nq,Cp,Co,Nr,Td,Kd,Rr&phrase=seo+tools&database=us&display_limit=50"
-```
-
-### Broad Match Keywords
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=phrase_fullsearch&export_columns=Ph,Nq,Cp,Co,Nr,Td,Kd&phrase=seo+tools&database=us&display_limit=50"
-```
-
-### Keyword Difficulty
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=phrase_kdi&export_columns=Ph,Kd&phrase=seo+tools&database=us"
-```
-
-### Organic Results for Keyword
-
-```bash
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=phrase_organic&export_columns=Dn,Ur,Fk,Fp,Po&phrase=seo+tools&database=us&display_limit=20"
 ```
 
-### Domain Organic Pages
+`phrase_this`=one DB overview, `phrase_all`=all DBs, `phrase_related`=related keywords, `phrase_fullsearch`=broad match, `phrase_kdi`=difficulty, `phrase_organic`=organic results for keyword.
+
+### Backlink Reports
 
 ```bash
-curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_organic_unique&export_columns=Ur,Pc,Tg&domain=example.com&database=us&display_limit=50"
+curl -s "https://api.semrush.com/analytics/v1/?key=$SEMRUSH_API_KEY&type=backlinks_overview&target=example.com&target_type=root_domain&export_columns=total,domains_num,urls_num,ips_num,follows_num,nofollows_num,texts_num,images_num"
+curl -s "https://api.semrush.com/analytics/v1/?key=$SEMRUSH_API_KEY&type=backlinks&target=example.com&target_type=root_domain&export_columns=source_url,source_title,target_url,anchor,external_num,internal_num&display_limit=50"
+curl -s "https://api.semrush.com/analytics/v1/?key=$SEMRUSH_API_KEY&type=backlinks_refdomains&target=example.com&target_type=root_domain&export_columns=domain,domain_score,backlinks_num,first_seen,last_seen&display_limit=50"
 ```
+
+`backlinks_overview`=summary, `backlinks`=full list, `backlinks_refdomains`=referring domains.
 
 ## Parameters
 
@@ -190,19 +109,11 @@ curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_organic_uniqu
 
 Format: `column|condition|value`. Join multiple with `|or|` or `|and|`. URL-encode the filter string.
 
-| Condition | Meaning |
-|-----------|---------|
-| `Gt` | Greater than |
-| `Lt` | Less than |
-| `Eq` | Equal to |
-| `Co` | Contains |
-| `Bw` | Begins with |
-| `Ew` | Ends with |
+Conditions: `Gt` (greater than), `Lt` (less than), `Eq` (equal), `Co` (contains), `Bw` (begins with), `Ew` (ends with).
 
-Example — keywords with volume > 1000:
+Example — keywords with volume > 1000 (`Nq|Gt|1000`):
 
 ```bash
-# Filter: Nq|Gt|1000
 curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_organic&export_columns=Ph,Po,Nq,Cp,Kd&domain=example.com&database=us&display_limit=50&display_filter=%2B%7CNq%7CGt%7C1000"
 ```
 


### PR DESCRIPTION
## Summary

- Consolidates 14 individual endpoint sections into 3 grouped code blocks (domain/keyword/backlink), eliminating per-section headings and blank lines
- Merges Pricing table and API Unit Balance command into Quick Reference as compact inline entries
- Replaces 6-row filter conditions table with a single inline list
- Removes `<!-- AI-CONTEXT-START/END -->` markers (not needed in subagent doc)

## Verification

- All 16 `type=` API values present before and after
- All 17 curl examples preserved (7 domain + 6 keyword + 3 backlink + 1 filter)
- All 20 column codes preserved
- All 12 parameters preserved
- Line count: 219 → 130 (40.6% reduction, ~59% of original)

## Runtime Testing

- Testing level: self-assessed
- Risk classification: low (docs-only change, no code)
- No runtime verification required

Closes #10993