### PR TITLE
GH#10915: Tighten direct-response-copy SKILL.md (284 lines)

### DIFF
--- a/.agents/tools/marketing/direct-response-copy/SKILL.md
+++ b/.agents/tools/marketing/direct-response-copy/SKILL.md
@@ -1,284 +1,154 @@
 # Direct Response Copywriting Skill
 
-> "On the average, five times as many people read the headline as read the body copy." — David Ogilvy
-
-## When to Use
-
 Copy that drives **immediate, measurable action**: landing pages, email sequences, ad copy, sales pages/VSLs, cold outreach, pricing pages, trial/demo flows, onboarding sequences.
 
 **NOT for:** Brand awareness, content marketing, PR, or general visibility goals.
 
 ---
 
-## The Legends: Mental Models That Generate Sales
+## Mental Models (The Legends)
 
-### Claude Hopkins — Scientific Advertising
-- Every ad makes a proposition: "Buy this, get this specific benefit"
-- Specificity sells: "Our beer bottles are washed with live steam" (not "clean")
-- Track everything; what can't be measured can't be improved
+| Legend | Core Insight |
+|--------|-------------|
+| **Hopkins** — Scientific Advertising | Every ad = proposition ("Buy this, get this benefit"). Specificity sells. Track everything. |
+| **Ogilvy** — Research + Respect | Research before writing. Headlines with news perform better. Long copy outsells short (when reader is interested). Every campaign needs one "Big Idea." |
+| **Halbert** — The A-Pile Test | List > copy (hungry crowd beats everything). Write like talking to a friend. First sentence's job = get them to read the second. |
+| **Schwartz** — Awareness Levels | You don't create desire — channel the strongest existing desire toward your product. |
+| **Kennedy** — No B.S. ROI | Message-Market-Media Match. One clear CTA. "Whoever can spend the most to acquire a customer, wins." |
 
-### David Ogilvy — Research + Respect
-- Research obsessively before writing a single word
-- Headlines with news ("New," "Now," "Introducing") perform better
-- Long copy sells more than short copy (when the reader is interested)
-- The "Big Idea" — every campaign needs one instantly-understood concept
+### Schwartz's Five Awareness Levels
 
-Famous headline: *"At 60 miles an hour the loudest noise in this new Rolls-Royce comes from the electric clock."*
-
-### Gary Halbert — The A-Pile Test
-- Your list is more important than your copy (a hungry crowd beats everything)
-- Write like you're talking to a friend
-- The first sentence's job is to get them to read the second sentence
-- "Motion beats meditation" — write first, edit later
-
-### Eugene Schwartz — Five Levels of Awareness
-
-| Level | Description | Copy Approach |
-|-------|-------------|---------------|
-| **Most Aware** | Knows your product, just needs the deal | Lead with the offer |
-| **Product Aware** | Knows your product, not convinced | Lead with differentiation |
-| **Solution Aware** | Knows solutions exist, not yours | Lead with your unique mechanism |
-| **Problem Aware** | Knows the problem, not solutions | Lead with the problem and agitate |
-| **Unaware** | Doesn't know they have a problem | Lead with identity or curiosity |
-
-**Mass desire equation:** You don't create desire — you find the strongest existing desire and channel it toward your product.
-
-### Dan Kennedy — No B.S. ROI
-- "Message-Market-Media Match" — right message to right market through right channel
-- Every piece of copy should have one clear call to action
-- "Whoever can spend the most to acquire a customer, wins"
+| Level | Copy Approach |
+|-------|---------------|
+| **Most Aware** (knows product, needs deal) | Lead with the offer |
+| **Product Aware** (knows product, unconvinced) | Lead with differentiation |
+| **Solution Aware** (knows solutions, not yours) | Lead with your unique mechanism |
+| **Problem Aware** (knows problem, not solutions) | Lead with problem + agitate |
+| **Unaware** (doesn't know the problem) | Lead with identity or curiosity |
 
 ---
 
 ## Core Principles
 
 1. **Copy is salesmanship in print** — one job: generate a measurable response
-2. **Specificity beats vagueness** — "Cut email response time from 4.2 hours to 11 minutes" beats "Save time"
+2. **Specificity beats vagueness** — "Cut response time from 4.2 hours to 11 minutes" beats "Save time"
 3. **Features → Benefits → Outcomes** — features are proof; benefits are reasons; outcomes are what people buy
 4. **The reader is the hero** — your product is Obi-Wan; the prospect is Luke Skywalker
 5. **One Big Idea per piece** — multiple ideas = confusion = no action
 6. **Proof converts skeptics** — specific testimonials, case studies, third-party validation, guarantees
-7. **Write first, edit later** — perfectionism is the enemy of production
 
 ---
 
 ## Core Frameworks
 
-### AIDA (Attention → Interest → Desire → Action)
-- **Attention**: Stop the scroll — headlines with news, curiosity gaps, specific numbers, pain callouts
-- **Interest**: Connect to their world — relate to their situation, acknowledge what they've tried
-- **Desire**: Build want — paint the after picture, stack value, show social proof, handle objections
-- **Action**: One clear CTA, reason to act now, reduce friction
+**AIDA** (Attention → Interest → Desire → Action): Stop the scroll (headline) → Connect to their world → Build want (after picture, value stack, social proof, objection handling) → One clear CTA with urgency and low friction.
 
-### PAS (Problem → Agitate → Solve)
-Best for short-form copy (ads, emails, social).
+**PAS** (Problem → Agitate → Solve): Best for short-form (ads, emails, social). State problem → amplify pain → present solution.
 
-> **Problem**: "You're getting traffic but nobody's converting."
-> **Agitate**: "Every visitor that bounces is money walking out the door. How much are you losing each month?"
-> **Solve**: "Our conversion audit reveals exactly where visitors are dropping off—and what to fix."
+**PASTOR** (Problem, Amplify, Story, Transformation, Offer, Response): Best for longer sales pages and VSLs.
 
-### PASTOR (Problem, Amplify, Story, Transformation, Offer, Response)
-Best for longer sales pages and VSLs.
+**4 U's** (Headlines): **Useful** (benefit?) · **Ultra-specific** ("7 ways" > "several") · **Urgent** (why now?) · **Unique** (what's different?)
 
-### The 4 U's (Headlines)
-Every headline should be: **Useful** (what's in it for them?), **Ultra-specific** ("7 ways" beats "several"), **Urgent** (why now?), **Unique** (what makes this different?).
-
-### Star-Chain-Hook (Emails)
-**Star**: Attention-grabbing opening (fact, story, question) → **Chain**: Connected facts, benefits, reasons → **Hook**: Call to action
+**Star-Chain-Hook** (Emails): Attention-grabbing opening → Connected facts/benefits/reasons → Call to action.
 
 ---
 
 ## Step-by-Step Process
 
-### Step 1: Research (50% of Your Time)
+### 1. Research (50% of Your Time)
 
-**Know your audience:**
-- Demographics + psychographics (fears, desires, beliefs, objections)
-- What have they tried before that didn't work?
-- What language do they use to describe their problem?
+**Know your audience:** Demographics + psychographics (fears, desires, beliefs, objections). What they've tried before. Language they use to describe their problem.
 
-**Research sources:** Customer interviews (gold), competitor product reviews (mine the complaints), Reddit/forums, Amazon reviews of related books, support tickets, surveys.
+**Sources:** Customer interviews (gold), competitor reviews (mine complaints), Reddit/forums, Amazon reviews of related books, support tickets, surveys.
 
-**Research document template:**
-```markdown
-## Target Audience Profile
-- Who they are:
-- Their #1 problem related to this product:
-- What they've tried before + why those solutions failed:
-- Their dream outcome:
-- Objections they'll have:
-- Language they use:
+**Document:** Target audience profile (who, #1 problem, failed solutions, dream outcome, objections, language) + Product analysis (core promise, features→benefits→outcomes, unique mechanism, proof points, competitor weaknesses).
 
-## Product Analysis
-- Core promise:
-- Key features → benefits → outcomes:
-- Unique mechanism (why it works):
-- Proof points:
-- Common competitor weaknesses:
-```
-
-### Step 2: Determine Awareness Level
+### 2. Determine Awareness Level
 
 | Traffic Source | Likely Awareness | Copy Length |
 |----------------|------------------|-------------|
-| Direct (typing URL) | Most Aware | Short, direct to offer |
-| Brand search | Product Aware | Medium |
+| Direct / Brand search | Most/Product Aware | Short-Medium |
 | Referral | Solution Aware | Medium-long |
-| Paid ads (interest) | Problem/Solution Aware | Long |
-| Paid ads (lookalike) | Problem Aware | Long |
+| Paid ads (interest/lookalike) | Problem/Solution Aware | Long |
 | Cold outreach | Unaware/Problem Aware | Longest |
 
-### Step 3: Write the Headline (First, Revise Last)
+### 3. Write the Headline (First, Revise Last)
 
-The headline is 80% of your ad. Write 25+ variations.
+The headline is 80% of your ad. Write 25+ variations using templates: "How to [Outcome]" · "[Number] Ways to [Benefit]" · "Why [Common Belief] is Wrong" · "[Do This] Without [Objection]" · "[Specific Result] in [Specific Time]" · "Are You Making These [Topic] Mistakes?"
 
-```
-1. "How to [Desired Outcome]"
-2. "[Number] Ways to [Benefit]"
-3. "The [Adjective] Guide to [Topic]"
-4. "Why [Common Belief] is Wrong"
-5. "[Do This] Without [Objection]"
-6. "Who Else Wants [Desired Outcome]?"
-7. "The Secret of [Desired Group]"
-8. "Warning: [Negative Outcome]"
-9. "[Specific Result] in [Specific Time]"
-10. "Are You Making These [Topic] Mistakes?"
-```
+### 4. Write the Lead
 
-### Step 4: Write the Lead
+First 200-300 words determine if they keep reading. Types: Story, Problem, Curiosity, Offer (Most Aware), Social Proof.
 
-First 200-300 words determine if they keep reading. Lead types: Story, Problem, Curiosity, Offer (Most Aware), Social Proof.
+### 5. Build the Body
 
-### Step 5: Build the Body
+**Landing page structure:** Headline + subheadline → Hero (problem + value prop) → Social proof bar → Problem (agitate) → Solution (unique approach) → Features→Benefits→Outcomes → Case study/testimonials → How it works (3 steps) → FAQ (objection handling) → Risk reversal (guarantee) → Final CTA.
 
-**Landing page structure:**
-1. Headline + Subheadline
-2. Hero section (problem statement + value prop)
-3. Social proof bar (logos, stats)
-4. Problem section (agitate)
-5. Solution section (unique approach)
-6. Features → Benefits → Outcomes
-7. Case study/testimonials
-8. How it works (3 steps)
-9. Objection handling (FAQ)
-10. Risk reversal (guarantee)
-11. Final CTA
+**Tips:** Short paragraphs (2-3 sentences), subheads for skimming, bullets for features/benefits, bold key phrases, "you/your" tone.
 
-**Body copy tips:** Short paragraphs (2-3 sentences), subheads for skimming, bullets for features/benefits, bold key phrases, conversational "you/your" tone.
+### 6. Craft the Offer
 
-### Step 6: Craft the Offer
+Stack value: Core Product ($X) + Bonus 1 ($Y) + Bonus 2 ($Z) = Total Value ($BIG) → Your Price ($MUCH SMALLER).
 
-```
-Core Product: $X value
-+ Bonus 1: $Y value
-+ Bonus 2: $Z value
-= Total Value: $BIG NUMBER
-Your Price Today: $MUCH SMALLER
-```
+### 7. Write the CTA
 
-### Step 7: Write the CTA
+One clear action, repeated multiple times: "Start Your Free Trial" / "Get [Benefit] Now" / "Yes, I Want [Outcome]"
 
-One clear action, repeated multiple times: "Start Your Free Trial" / "Get [Benefit] Now" / "Yes, I Want [Outcome]" / "Claim Your [Thing]"
+### 8. Add Urgency (Ethically)
 
-### Step 8: Add Urgency (Ethically)
+Legitimate only: real deadlines, true limited quantity, actual rising price, seasonal relevance. **Never fake urgency.**
 
-Legitimate urgency: limited time offers (real deadline), limited quantity (if true), rising price (if true), seasonal relevance. **Never fake urgency** — it destroys trust.
+### 9. Edit Ruthlessly
 
-### Step 9: Edit Ruthlessly
-
-Read out loud. Cut everything that doesn't move the story forward, build desire, handle objections, or push toward action. Fix: passive → active voice, jargon → plain language, "we" → "you", vague claims → specific proof, long sentences → short.
+Read aloud. Cut anything that doesn't build desire, handle objections, or push toward action. Fix: passive→active, jargon→plain, "we"→"you", vague→specific, long→short.
 
 ---
 
 ## Psychology of Persuasion
 
-### Cialdini's 6 Principles
-1. **Reciprocity** — Give value first (free guides, trials)
-2. **Commitment/Consistency** — Small yeses lead to big yeses
-3. **Social Proof** — "5,000+ companies use us"
-4. **Authority** — Expert endorsements, credentials
-5. **Liking** — Relatable stories, shared values
-6. **Scarcity** — Limited time, limited quantity
+**Cialdini's 6 Principles:** Reciprocity (give value first) · Commitment/Consistency (small yeses → big yeses) · Social Proof ("5,000+ companies") · Authority (expert endorsements) · Liking (relatable stories) · Scarcity (limited time/quantity).
 
-### Primary Buying Emotions
-People buy emotionally, justify rationally: **Fear** (loss, FOMO, looking foolish), **Greed** (more money/success/status), **Guilt** (not providing, not living up to potential), **Pride** (recognition, accomplishment), **Love** (protection, connection, belonging).
+**Buying Emotions:** Fear (loss, FOMO) · Greed (money/success/status) · Guilt (not living up to potential) · Pride (recognition) · Love (connection/belonging). People buy emotionally, justify rationally.
 
-### Before/After/Bridge
-**Before** (current painful state) → **After** (desired future state) → **Bridge** (your product/service)
+**Before/After/Bridge:** Current painful state → Desired future state → Your product.
 
 ---
 
 ## SaaS & B2B Copy
 
-### Key Differences from B2C
-- Longer sales cycles — nurture sequences matter more
-- Multiple decision makers — copy must work for users AND buyers
-- Logic plays bigger role — ROI, integrations, security
-- Social proof from peers — G2 reviews, case studies
+**Key differences from B2C:** Longer sales cycles (nurture sequences matter) · Multiple decision makers (copy for users AND buyers) · Logic plays bigger role (ROI, integrations, security) · Peer social proof (G2, case studies).
 
-### SaaS Homepage Formula
+**SaaS Homepage Formula:** Hero (value prop + who it's for + CTA + logos) → Problem (pain + why existing solutions fail) → Solution (unique approach, 3 steps) → Features (3-5, each tied to benefit) → Social Proof (case studies with numbers, G2/Capterra) → Pricing (clear tiers, popular highlighted) → FAQ (objections, integrations, security) → Final CTA (restate value prop + risk reversal).
 
-```
-HERO: Clear value prop headline + who it's for + CTA + social proof logos
-PROBLEM: Pain point + why existing solutions fail
-SOLUTION: Unique approach + how it works (3 steps)
-FEATURES: 3-5 key features, each tied to a benefit
-SOCIAL PROOF: Case studies with numbers, testimonials, G2/Capterra ratings
-PRICING: Clear tiers, most popular highlighted, feature comparison
-FAQ: Objection handling, integrations, security/compliance
-FINAL CTA: Restate value prop + clear action + risk reversal
-```
-
-### Trial Welcome Sequence (7 emails / 14 days)
-1. Welcome + quick start guide
-2. Day 2: Feature highlight #1
-3. Day 4: Case study (similar company)
-4. Day 7: Feature highlight #2
-5. Day 10: "How's it going?" + support offer
-6. Day 12: Urgency (trial ending soon)
-7. Day 14: Final push + special offer
-
-**Onboarding goal:** Get to "activation point" — the action that predicts retention.
+**Trial Welcome Sequence (7 emails / 14 days):** Welcome + quick start → Day 2: Feature #1 → Day 4: Case study → Day 7: Feature #2 → Day 10: Check-in + support → Day 12: Trial ending → Day 14: Final push + offer. **Goal:** Get to activation point (action that predicts retention).
 
 ---
 
 ## Testing & Optimization
 
-**Test in order of impact:**
-1. Offer (what you're selling, price, guarantee)
-2. Headline
-3. CTA (text, placement, color)
-4. Lead (first 100 words)
-5. Social proof (type and placement)
-6. Price presentation (anchoring, payment plans)
-
-A/B test one element at a time. Run until statistical significance. Document everything. Build a swipe file of winners.
+**Test in order of impact:** Offer → Headline → CTA → Lead → Social proof → Price presentation. A/B test one element at a time. Run until statistical significance. Build a swipe file of winners.
 
 ---
 
-## Copywriting Checklist
+## Checklist
 
-**Research:** Know exactly who you're writing to · Understand their awareness level · Know top 3 objections · Have proof points ready
-
-**Headline:** Promises a clear benefit · Creates curiosity or urgency · Speaks to target audience specifically · Written 10+ variations
-
-**Body:** Opens with problem or hook · Benefits outnumber features 3:1 · Includes social proof · Handles major objections · Easy to skim
-
-**Offer:** Clear value proposition · Price is justified · Risk reversal included · Urgency is present (and real)
-
-**CTA:** One clear action · Action-oriented button text · Appears multiple times · Friction minimized
+- **Research:** Know audience · Understand awareness level · Know top 3 objections · Proof points ready
+- **Headline:** Clear benefit · Curiosity or urgency · Speaks to target · 10+ variations written
+- **Body:** Opens with problem/hook · Benefits outnumber features 3:1 · Social proof · Handles objections · Skimmable
+- **Offer:** Clear value prop · Price justified · Risk reversal · Real urgency
+- **CTA:** One clear action · Action-oriented text · Appears multiple times · Friction minimized
 
 ---
 
 ## Essential Reading
 
-1. **Breakthrough Advertising** — Eugene Schwartz (the bible)
-2. **The Boron Letters** — Gary Halbert (fundamentals)
-3. **Ogilvy on Advertising** — David Ogilvy (principles)
-4. **Influence** — Robert Cialdini (psychology)
-5. **Scientific Advertising** — Claude Hopkins (foundations)
+1. **Breakthrough Advertising** — Eugene Schwartz
+2. **The Boron Letters** — Gary Halbert
+3. **Ogilvy on Advertising** — David Ogilvy
+4. **Influence** — Robert Cialdini
+5. **Scientific Advertising** — Claude Hopkins
 6. **The Adweek Copywriting Handbook** — Joseph Sugarman
 7. **Ca$hvertising** — Drew Eric Whitman
 8. **The Ultimate Sales Letter** — Dan Kennedy
 
-Websites: Copyblogger.com · Copyhackers.com · Swiped.co (swipe file) · Really Good Emails
+Websites: Copyblogger.com · Copyhackers.com · Swiped.co · Really Good Emails


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/marketing/direct-response-copy/SKILL.md` from 284 → 154 lines (**45.8% reduction**)
- Converted verbose subsections (Legends, Frameworks, Process steps) into compact tables and inline paragraphs
- Preserved all actionable content: all 5 legends, all 5 frameworks, all 9 process steps, psychology section, SaaS/B2B section, checklist, and reading list

## What changed

- **Legends section**: Individual H3 subsections with bullet lists → single summary table + compact awareness-level table
- **Core Frameworks**: Expanded subsections with examples → inline paragraph per framework
- **Step-by-Step Process**: Removed code block templates (research doc, headline templates, offer stack), replaced with inline descriptions preserving the same information
- **Awareness/Traffic table**: Merged similar rows (Direct+Brand search, interest+lookalike ads)
- **Psychology, SaaS, Testing, Checklist**: Converted numbered/bulleted lists to compact inline format
- **Removed**: Ogilvy quote (decorative), PAS example blockquote (redundant with framework description), "Write first, edit later" principle (duplicated in Step 9)

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs-only change, no code)
- **Verification**: `markdownlint-cli2` — 0 errors. All key terms verified present via `rg`.

Closes #10915