### PR TITLE
t9349: tighten objection-handling.md from 489 to 130 lines

### DIFF
--- a/.agents/tools/marketing/direct-response-copy/frameworks/objection-handling.md
+++ b/.agents/tools/marketing/direct-response-copy/frameworks/objection-handling.md
@@ -2,488 +2,129 @@
 
 > "Every sale has five basic obstacles: no need, no money, no hurry, no desire, no trust." — Zig Ziglar
 
-## Why Objection Handling Matters
+## The 5 Core Objections
 
-Every prospect has reasons NOT to buy. Your copy must address these before they click away.
-
-**The 5 Core Objections:**
-1. **No Need:** "I don't have this problem"
-2. **No Trust:** "I don't believe you can solve it"
-3. **No Money:** "It's too expensive"
-4. **No Hurry:** "I'll do this later"
-5. **No Fit:** "This won't work for my situation"
-
-Great copy handles all five—often without the reader consciously noticing.
+| # | Objection | Root Cause |
+|---|-----------|------------|
+| 1 | **No Need** — "I don't have this problem" | Unrecognised pain; normalised symptoms |
+| 2 | **No Trust** — "I don't believe you" | Too good to be true; burned before; stranger |
+| 3 | **No Money** — "It's too expensive" | Price > perceived value; real budget limits |
+| 4 | **No Hurry** — "I'll do this later" | No immediate pain; competing priorities |
+| 5 | **No Fit** — "This won't work for me" | Unique situation; tried similar; can't self-identify |
 
 ---
 
-## The 5 Core Objections (Deep Dive)
+## Overcoming Each Objection
 
-### 1. "I Don't Have This Problem" (No Need)
+### 1. No Need
 
-**Why they think this:**
-- They don't recognize the problem yet
-- They've normalized the pain
-- They're unaware of what's possible
+- **Paint the problem vividly** — describe the gap between current state and what's possible
+- **Quantify the cost** — calculate what the unresolved problem costs per month/year
+- **Show symptoms** — checklist of recognisable pain points ("If you nodded at any of these...")
 
-**How to overcome:**
+### 2. No Trust
 
-**A. Paint the problem vividly**
-```
-You check Google Analytics. Traffic is up. 
-But revenue? Flat.
+- **Social proof with specifics** — named testimonials with company, role, and measurable result
+- **Show the mechanism** — explain *why* it works, not just that it works
+- **Third-party validation** — ratings, press mentions, user counts
+- **Demonstrate expertise** — years in domain, volume processed, track record
 
-You've published 50 blog posts this quarter.
-Spent hundreds of hours creating content.
-But half your pages aren't even indexed.
+### 3. No Money
 
-They're invisible. And every day they stay invisible,
-you're losing traffic to competitors who showed up first.
-```
+- **Compare to alternatives** — agency/in-house/DIY costs vs. your price
+- **Calculate ROI** — traffic/revenue uplift vs. monthly cost; show the multiple
+- **Break down daily cost** — "$49/month = $1.63/day"
+- **Reframe as investment** — cost of *not* solving vs. cost of solving
+- **Payment plan** — reduce friction with instalments if price is a real barrier
 
-**B. Quantify the cost of the problem**
-```
-Let's do the math:
+### 4. No Hurry
 
-If just 10% of your unindexed pages were indexed,
-and each page brought in 100 visitors/month at $0.50 per visitor...
+- **Quantify cost of waiting** — what accumulates each day/week without action
+- **Create real urgency** — time-limited price, expiring bonus, closing window (must be genuine)
+- **Make starting easy** — 3-step onboarding, "you could be live by tonight"
+- **FOMO** — show others acting now; competitors already using it
 
-That's $500/month you're leaving on the table.
-$6,000 per year. From content you've already created.
-```
+### 5. No Fit
 
-**C. Show they already feel the symptoms**
-```
-Do any of these sound familiar?
-
-✓ You hit "Request Indexing" but nothing happens
-✓ Your content takes weeks to show up in search
-✓ Competitors with worse content outrank you
-✓ You've tried everything but can't figure out why
-
-If you nodded at any of these, you have an indexing problem.
-```
-
-### 2. "I Don't Believe You" (No Trust)
-
-**Why they think this:**
-- Too good to be true
-- They've been burned before
-- You're a stranger
-
-**How to overcome:**
-
-**A. Social proof with specifics**
-```
-Don't take our word for it:
-
-"We went from 23% indexed to 94% in just 14 days.
- BrowserBlast literally saved our content strategy."
- — Sarah Chen, SEO Director, GrowthAgency
-
-"I was skeptical. I'd tried 5 other tools. But BrowserBlast 
- actually works. 847 of our 900 pages are now indexed."
- — Marcus Thompson, Founder, TechStartup
-```
-
-**B. Show the mechanism**
-```
-Here's WHY BrowserBlast works when others don't:
-
-Most tools just ping Google and hope.
-We use a proprietary indexing protocol that:
-
-1. Signals high-quality content to Google's crawlers
-2. Prioritizes your pages in the indexing queue
-3. Monitors and re-submits until indexed
-
-It's not magic. It's methodology.
-```
-
-**C. Third-party validation**
-```
-• Rated 4.9/5 on G2 (200+ reviews)
-• Featured in Search Engine Journal
-• Used by 10,000+ SEO professionals
-• Recommended by [Industry Expert]
-```
-
-**D. Demonstrate expertise**
-```
-Our team has worked with indexing since 2018.
-We've processed over 5 million URL submissions.
-We've seen what works and what doesn't.
-
-BrowserBlast is the result of 6 years of learning.
-```
-
-### 3. "It's Too Expensive" (No Money)
-
-**Why they think this:**
-- Price is higher than expected
-- They don't see the value
-- Budget constraints are real
-
-**How to overcome:**
-
-**A. Compare to alternatives**
-```
-Let's look at your options:
-
-❌ Hire an agency: $2,000-5,000/month
-❌ Hire in-house: $60,000+/year
-❌ DIY with free tools: 10+ hours/week (at $50/hour = $2,000/month of your time)
-
-✓ BrowserBlast: $49/month
-
-The choice is clear.
-```
-
-**B. Calculate ROI**
-```
-Here's the math:
-
-BrowserBlast Pro: $49/month
-
-Average results:
-• 40% more pages indexed
-• 2-3x faster indexing time
-• 15% more organic traffic (from pages that were invisible)
-
-If that traffic is worth just $500/month to you,
-that's a 10x return on your investment.
-```
-
-**C. Break down the daily cost**
-```
-$49/month = $1.63/day
-
-Less than a cup of coffee.
-
-For unlimited indexing of your entire site.
-```
-
-**D. Reframe as investment**
-```
-This isn't an expense. It's an investment.
-
-Every day your content sits unindexed,
-you're losing potential customers.
-
-$49/month to fix that isn't a cost—it's a bargain.
-```
-
-**E. Payment plan option**
-```
-Too much all at once?
-
-Split it into 3 easy payments of $177.
-Same full access. Same results. Easier on your budget.
-```
-
-### 4. "I'll Do This Later" (No Hurry)
-
-**Why they think this:**
-- No immediate pain
-- Competing priorities
-- Procrastination
-
-**How to overcome:**
-
-**A. Quantify the cost of waiting**
-```
-Every day you wait:
-
-• More content sits unindexed (losing potential traffic)
-• Competitors get indexed first (winning your keywords)
-• Your existing content ages without ranking
-
-In 30 days of "later," you could have indexed 
-your entire content library.
-
-The question isn't "should I do this?"
-It's "why haven't I done this already?"
-```
-
-**B. Create real urgency**
-```
-This offer is only available until Friday.
-
-After that:
-• Price returns to $97/month
-• The bonus templates disappear
-• The onboarding call offer expires
-
-You can wait—but you'll pay more and get less.
-```
-
-**C. Make starting easy**
-```
-Getting started takes 5 minutes:
-
-1. Sign up (30 seconds)
-2. Connect your Search Console (2 minutes)
-3. Add URLs (2 minutes)
-
-You could be indexed by tonight.
-```
-
-**D. Fear of missing out**
-```
-While you're thinking about it:
-
-• 47 people signed up today
-• 1,200 pages were indexed this hour
-• Your competitors are probably already using this
-
-Don't let "later" turn into "too late."
-```
-
-### 5. "This Won't Work For Me" (No Fit)
-
-**Why they think this:**
-- Their situation feels unique
-- They've tried similar things
-- They don't see themselves in your examples
-
-**How to overcome:**
-
-**A. Address specific situations**
-```
-BrowserBlast works for:
-
-✓ New websites (get crawled faster)
-✓ Large content sites (bulk indexing)
-✓ E-commerce (index product pages)
-✓ News/media (time-sensitive content)
-✓ Agencies (manage multiple clients)
-
-If you have a website and want it indexed, we've got you.
-```
-
-**B. "But what if..." FAQ**
-```
-Q: What if I have thousands of pages?
-A: Perfect. Our bulk upload handles 10,000 URLs at once.
-
-Q: What if I'm not technical?
-A: You don't need to be. Point-and-click interface.
-
-Q: What if I'm using [specific platform]?
-A: We integrate with WordPress, Shopify, Webflow, 
-   and any site that uses Google Search Console.
-
-Q: What if I've tried other indexing tools?
-A: Most tools just ping Google. We use a different 
-   approach that actually works. Try it risk-free.
-```
-
-**C. Show diverse case studies**
-```
-It works for businesses like yours:
-
-• E-commerce: "Indexed 2,000 product pages in 2 weeks"
-• SaaS blog: "Cut indexing time from 3 weeks to 3 days"
-• Local business: "All 15 location pages now ranking"
-• Agency: "Managing 50 client sites in one dashboard"
-```
-
-**D. Personal relevance**
-```
-If you're reading this, you probably:
-
-• Create content that deserves to be found
-• Understand that indexing is the first step to ranking
-• Want a solution that actually works
-
-Sound like you? Then BrowserBlast is for you.
-```
+- **Address specific use cases** — list verticals/scenarios explicitly covered
+- **"But what if…" FAQ** — pre-empt the most common edge cases
+- **Diverse case studies** — one example per major segment (e-commerce, SaaS, agency, local)
+- **Personal relevance close** — "If you're reading this, you probably… Sound like you?"
 
 ---
 
-## Where to Handle Objections in Your Copy
+## Where to Handle Objections
 
-### In the Body Copy (Woven In)
-
-Address objections naturally as you present benefits:
-
-```
-"You might be thinking this sounds too good to be true.
- 
- I get it. I was skeptical too until I saw [proof point].
- 
- The difference is [unique mechanism that explains why it works]."
-```
-
-### In a Dedicated Section
-
-```
-STILL ON THE FENCE?
-
-Let me address the questions you might have:
-
-[Question 1]
-[Answer]
-
-[Question 2]
-[Answer]
-
-[etc.]
-```
-
-### In the FAQ
-
-```
-FREQUENTLY ASKED QUESTIONS
-
-Q: How is this different from [competitor/alternative]?
-A: Unlike [X], we [unique value prop].
-
-Q: What if it doesn't work for me?
-A: You're protected by our [guarantee].
-
-Q: How long does it take to see results?
-A: Most customers see [result] within [timeframe].
-```
-
-### In Testimonials
-
-Let customers handle objections for you:
-
-```
-"I was worried it wouldn't work for my small site, 
- but it worked even better than expected."
-
-"At first I thought $49/month was a lot, 
- but it paid for itself in the first week."
-
-"I'd tried three other tools before this one. 
- BrowserBlast is the only one that actually delivered."
-```
+| Placement | Format | Best for |
+|-----------|--------|----------|
+| **Body copy (woven in)** | "You might be thinking… I get it. The difference is…" | Trust, fit |
+| **Dedicated section** | "Still on the fence? Let me address…" | Money, hurry |
+| **FAQ** | Q&A format | Fit, trust, money |
+| **Testimonials** | Let customers voice the objection and resolve it | All five |
 
 ---
 
-## Objection Handling by Business Type
+## By Business Type
 
-### SaaS (BrowserBlast, LocalRank)
+### SaaS
 
 | Objection | Handle With |
 |-----------|-------------|
-| "I can do this manually" | Calculate time cost; show scale benefits |
-| "I already use [competitor]" | Differentiate on specific features; offer migration help |
-| "What about data security?" | Security certifications; privacy policy; GDPR compliance |
-| "Will it integrate with my stack?" | List integrations; API availability |
-| "What if I need to cancel?" | No lock-in; easy cancellation; data export |
+| "I can do this manually" | Time cost; scale benefits |
+| "I already use [competitor]" | Specific differentiators; migration help |
+| "Data security?" | Certifications; privacy policy; GDPR |
+| "Will it integrate?" | Integration list; API availability |
+| "What if I cancel?" | No lock-in; easy cancellation; data export |
 
-### Courses/Info Products
+### Courses / Info Products
 
 | Objection | Handle With |
 |-----------|-------------|
-| "I've bought courses before that didn't work" | What makes this different; implementation support |
-| "I can learn this for free online" | Time cost; curation value; support access |
-| "I don't have time to go through a course" | Flexible pacing; bite-sized modules; quick wins |
-| "What if I'm a beginner/advanced?" | Show curriculum covers multiple levels; personalization |
+| "Courses never work for me" | What makes this different; implementation support |
+| "I can learn this free online" | Time cost; curation; support access |
+| "No time for a course" | Flexible pacing; bite-sized modules; quick wins |
+| "Wrong level for me" | Curriculum covers multiple levels; personalisation |
 
-### Services/Agencies (Indexsy)
+### Services / Agencies
 
 | Objection | Handle With |
 |-----------|-------------|
 | "Why not hire in-house?" | Cost comparison; expertise breadth; flexibility |
-| "I've had bad experiences with agencies" | Specific differentiators; guarantee; testimonials |
+| "Bad agency experiences" | Specific differentiators; guarantee; testimonials |
 | "How do I know you'll deliver?" | Case studies; references; milestone-based pricing |
-| "What about communication?" | Process overview; reporting cadence; single point of contact |
+| "Communication concerns" | Process overview; reporting cadence; single POC |
 
 ---
 
-## The Objection Handling Checklist
+## Pre-Publish Checklist
 
-Before publishing, verify your copy addresses:
+**Need:** problem defined · reader sees themselves · cost of inaction clear
 
-**Need:**
-- [ ] Problem is clearly defined
-- [ ] Reader can see themselves in the problem
-- [ ] Cost of not solving is clear
+**Trust:** specific social proof (names/numbers) · mechanism explained · third-party validation present
 
-**Trust:**
-- [ ] Social proof is specific (names, companies, numbers)
-- [ ] Mechanism is explained (why it works)
-- [ ] Third-party validation is present
+**Money:** value shown before price · compared to alternatives · ROI calculated · payment options available
 
-**Money:**
-- [ ] Value is clear before price is shown
-- [ ] Price is compared to alternatives
-- [ ] ROI is calculated or implied
-- [ ] Payment options reduce friction
+**Hurry:** urgency present and genuine · cost of waiting clear · low-friction start
 
-**Hurry:**
-- [ ] Urgency is present (and real)
-- [ ] Cost of waiting is clear
-- [ ] Starting is easy (low friction)
-
-**Fit:**
-- [ ] Target audience is clear
-- [ ] Different use cases are addressed
-- [ ] "But what if..." questions are answered
-- [ ] FAQ covers edge cases
+**Fit:** target audience named · use cases listed · FAQ covers edge cases
 
 ---
 
-## Scripts for Common Objections
+## Reusable Scripts
 
-### "I need to think about it"
+**"I need to think about it"**
+> "Every [day/week] you wait, [cost of waiting]. With our [guarantee], you can try risk-free — if it doesn't work, you get your money back. The only risk is missing out."
 
-```
-"I totally understand—this is a decision worth thinking about.
+**"It's too expensive"**
+> "What's the cost of *not* solving this? If [problem] costs you [amount]/month and [product] fixes it for [price], that's a [X]x return — plus a full refund if it doesn't deliver."
 
-Here's what I'd consider:
-
-Every [day/week/month] you wait, [cost of waiting].
-
-And with our [guarantee], you can try it risk-free.
-
-If it doesn't work, you get your money back.
-If it does work, you [benefit].
-
-The only risk is missing out."
-```
-
-### "It's too expensive"
-
-```
-"I hear you on the price.
-
-Let me ask: what's the cost of NOT solving this?
-
-If [problem] is costing you [amount] per month,
-and [product] fixes that for just [price]...
-
-That's not an expense—that's an investment with [X]x returns.
-
-Plus, with our [guarantee], if it doesn't deliver,
-you get every penny back."
-```
-
-### "I've tried something like this before"
-
-```
-"I understand—and I'm sorry that didn't work out.
-
-Here's what makes [product] different:
-
-[Unique mechanism/approach]
-
-Unlike [what they tried], we [key differentiator].
-
-That's why [social proof—results others have gotten].
-
-And with our [guarantee], if it doesn't work better than
-what you tried before, you get a full refund."
-```
+**"I've tried something like this before"**
+> "Here's what makes [product] different: [unique mechanism]. Unlike [what they tried], we [key differentiator]. That's why [social proof]. And if it doesn't work better than what you tried, full refund."
 
 ---
 
 ## Further Reading
 
-- See [Landing Page Structure](landing-page-structure.md) for where to place objection handling
-- See [Email Sequences](email-sequences.md) for objection-handling emails
-- See [Offer Construction](offer-construction.md) for guarantee types
+- [Landing Page Structure](landing-page-structure.md) — where to place objection handling
+- [Email Sequences](email-sequences.md) — objection-handling email flows
+- [Offer Construction](offer-construction.md) — guarantee types


### PR DESCRIPTION
Reduces objection-handling.md from 489 to 130 lines (73% reduction). Removes verbose prose and product-specific code block examples. Preserves all structural reference content: 5-objection table, technique lists, placement guide, business-type tables, checklist, and script templates.

Closes #9349