### PR TITLE
t9344: tighten code-simplifier.md 278→197 lines

### DIFF
--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -19,75 +19,46 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Analyse code and agent docs for simplification opportunities
-- **Mode**: Analysis-only -- produces suggestions, never applies changes directly
-- **Model**: `opus` tier minimum (deep reasoning needed to distinguish noise from knowledge)
+- **Mode**: Analysis-only — suggestions only, never applies changes directly
+- **Model**: `opus` minimum (NEVER sonnet/haiku/flash — knowledge-loss risk; if unavailable, wait)
 - **Trigger**: `/code-simplifier`
-- **Priority**: Clarity over brevity -- explicit code beats compact code
-- **Rule**: Never lose functionality, knowledge, capability, or decision rationale
-
-**Key Principles**: Analysis-only output as TODO items and GitHub issues. Human approves each suggestion before work begins. Preserve functionality, institutional knowledge, and decision rationale. Apply project standards from AGENTS.md. Reduce complexity/nesting. Eliminate genuine redundancy (not intentional repetition). Remove decorative emojis and comments that restate what code does -- never comments explaining why.
+- **Rule**: Never lose functionality, knowledge, capability, or decision rationale. Human approves every suggestion before work begins.
 
 <!-- AI-CONTEXT-END -->
 
-## Why Analysis-Only
-
-Simplification is a judgment call. Non-thinking models (sonnet, haiku, flash) confidently remove things they don't understand. Even thinking models get it wrong. The human gate catches what the model misses. This agent has `write: false` and `edit: false` -- implementation happens in a separate session after human review, via the normal worktree + PR workflow.
-
-## Model Tier Restriction
-
-MUST run on the highest available reasoning tier: Anthropic `opus`, Google `pro`, OpenAI `o3`, or equivalent. NEVER run on non-thinking or mid-tier models (sonnet, haiku, flash, grok-fast). The risk of knowledge loss from pattern-matching "this looks redundant" without understanding *why* it exists is too high. If the highest tier is unavailable, wait.
-
 ## Protected Files
 
-Excluded from automated simplification entirely -- interactive maintainer sessions only:
+Excluded from automated simplification — interactive maintainer sessions only:
 
-- `prompts/build.txt` -- root system prompt; a single removed sentence can silently re-introduce failures across hundreds of sessions
-- `AGENTS.md` (both `~/Git/aidevops/AGENTS.md` and `.agents/AGENTS.md`) -- framework operating model
-- `.agents/scripts/commands/pulse.md` -- supervisor pulse instructions
+- `prompts/build.txt` — root system prompt
+- `AGENTS.md` (both `~/Git/aidevops/AGENTS.md` and `.agents/AGENTS.md`) — framework operating model
+- `.agents/scripts/commands/pulse.md` — supervisor pulse instructions
 
-If scope includes these files, skip silently and note: "Protected files excluded from analysis: [list]. These require interactive maintainer review." Workers dispatched for `simplification-debt` issues MUST NOT modify these files -- skip and comment on the issue explaining why.
-
-## Analysis Process
-
-1. **Identify** target code sections (recently modified, or specified scope)
-2. **Analyse** for genuine simplification opportunities
-3. **Classify** each finding (see Classification below)
-4. **Verify** no knowledge, capability, or decision rationale would be lost
-5. **Output** findings as structured list for human review
-6. **Wait** for human approval before any implementation begins
+Workers MUST NOT modify these files — skip and comment on the issue explaining why.
 
 ## Output Format
-
-For each finding:
 
 ```text
 ### [file:line_range] Category: Brief description
 
-**Current**: What exists now (quote the relevant code/text)
+**Current**: What exists now
 **Proposed**: What it would become
 **Preserved**: What knowledge/capability is explicitly retained
-**Risk**: What could go wrong if this suggestion is wrong
-**Verification**: How to prove the simplification didn't break anything
+**Risk**: What could go wrong
+**Verification**: How to prove nothing broke
 **Confidence**: high/medium/low
 ```
 
-Low-confidence findings: flag as "worth discussing" rather than "should change."
-
-After analysis, create GitHub issues with `simplification-debt` + `needs-maintainer-review` labels, grouped by file or logical area. Each issue must include preservation notes and verification method.
+Low-confidence findings: flag as "worth discussing" not "should change." Create GitHub issues with `simplification-debt` + `needs-maintainer-review` labels, grouped by file.
 
 ## Regression Verification
 
-Every `simplification-debt` issue must specify a verification method. The implementing worker MUST run verification before marking the PR ready.
-
 | File type | Minimum verification |
 |-----------|---------------------|
-| Shell scripts (`.sh`) | `bash -n` (syntax) + `shellcheck` + existing tests |
-| Agent docs (`.md`) | Content preservation: all code blocks, URLs, task ID references (`tNNN`, `GH#NNN`), command examples present before and after |
+| Shell scripts (`.sh`) | `bash -n` + `shellcheck` + existing tests |
+| Agent docs (`.md`) | All code blocks, URLs, task ID refs (`tNNN`, `GH#NNN`), command examples present before and after |
 | TypeScript/JavaScript | `tsc --noEmit` + existing tests |
 | Configuration files | Schema validation or dry-run the consuming tool |
-
-For substantive refactors (consolidating functions, removing abstractions, restructuring logic): also run a smoke test demonstrating identical output for at least one representative input. Workers that skip verification are failing the task -- the PR should not be merged.
 
 ## Classification
 
@@ -98,61 +69,45 @@ For substantive refactors (consolidating functions, removing abstractions, restr
 - Duplicated structure where one instance can reference the other
 - Dead/unreachable code with no explanatory value
 - Redundant formatting (excessive bold, unnecessary headers for single-line content)
-- Format inconsistency with project convention -- e.g., `### **EMOJI ALL CAPS**` when 91% of codebase uses plain `### Section Name`. Heading level already conveys hierarchy; bold/caps/emoji on top is redundant.
+- Format inconsistency — e.g., `### **EMOJI ALL CAPS**` when 91% of codebase uses plain `### Section Name`
 - Stale references to files/tools that no longer exist
 
 ### Prose tightening for agent docs (high confidence)
 
-Agent instruction docs (NOT reference corpora) often contain verbose prose. LLMs follow terse instructions equally well. Tighten by:
+Tighten by removing filler, redundant explanations, and narrative context that doesn't change agent behaviour.
 
-- Removing filler ("In order to" -> "To", "It is important to note that" -> drop)
-- Removing redundant explanations when the rule is self-evident
-- Compressing multi-sentence descriptions into single sentences
-- Converting verbose bullets into terse equivalents
-- Removing narrative context that doesn't change agent behaviour (keep task ID and rule, drop the story)
+**Preservation rules**: KEEP all task IDs (`tNNN`), issue refs (`GH#NNN`), incident identifiers, rules/constraints (compress wording not the rule), file paths, command examples, code blocks, safety-critical detail.
 
-**Preservation rules**: KEEP all task IDs (`tNNN`), issue refs (`GH#NNN`), incident identifiers, rules/constraints (compress wording not the rule), file paths, command examples, code blocks, safety-critical detail. Test: can the tightened version produce the same agent behaviour? If uncertain, keep original.
-
-**Evidence (t1679):** Terse pass on `build.txt` achieved 63% byte reduction (45k->17k) with zero rule loss. `AGENTS.md` achieved 48% (22k->12k). All 25 critical patterns verified present.
+**Evidence (t1679):** `build.txt` 63% byte reduction (45k→17k), zero rule loss. `AGENTS.md` 48% (22k→12k). All 25 critical patterns verified present.
 
 ### Requires careful judgment (medium confidence)
 
 - Verbose code that could be shorter without losing readability
 - Abstractions adding indirection without clear benefit
-- Consolidating similar sections addressing different audiences or contexts
+- Consolidating similar sections addressing different audiences
 
-### Reference corpora -- restructure, do not compress (GH#6432)
+### Reference corpora — restructure, do not compress (GH#6432)
 
-Some large `.md` files are knowledge bases (skill docs, domain reference) rather than agent instructions. Their size comes from breadth of domain knowledge, not verbosity.
+Knowledge bases (skill docs, domain reference) whose size comes from breadth, not verbosity. **How to identify:** reads like a textbook chapter, not agent instructions.
 
-**How to identify:** SKILL.md or similar where sections are self-contained domain knowledge (e.g., "Landing Page Optimization") rather than operational rules. Reads like a textbook chapter, not agent instructions.
-
-**Correct action: split into chapter files with a slim index.** Do NOT compress or remove domain knowledge. Extract each major section into its own file, replace original with a slim index (~100-200 lines) with one-line descriptions and file pointers. Verify zero content loss: `wc -l` total of chapters >= original minus index overhead.
-
-**What NOT to do:** Don't "tighten prose" on reference material. Don't merge small sections to reduce file count. Don't remove seemingly overlapping sections -- domain topics overlap by nature.
-
-**Issue template:** For oversized reference corpora, title should say "restructure" not "tighten", and body should recommend chapter splitting.
+**Action:** Split into chapter files with a slim index (~100-200 lines). Verify zero content loss: `wc -l` total of chapters >= original minus index overhead. Issue title: "restructure" not "tighten".
 
 ### Almost never simplify (flag but do not recommend)
 
-- Comments with task IDs, incident numbers, or error pattern data (`t1345`, `GH#2928`, `46.8% failure rate`) -- institutional memory
-- Comments explaining *why* something is disabled, with bug/PR references (e.g., `DISABLED:` blocks)
+- Comments with task IDs, incident numbers, or error pattern data (`t1345`, `GH#2928`, `46.8% failure rate`)
+- Comments explaining *why* something is disabled, with bug/PR references (`DISABLED:` blocks)
 - Agent prompt rules encoding specific observed failure patterns
 - Shell script quality standards (`local var="$1"`, explicit `return 0`)
 - Intentional repetition across agent docs serving different audiences
-- Error-prevention rules with supporting data justifying the rule's existence
+- Error-prevention rules with supporting data
 
 ## Core Principles
 
-1. **Preserve everything with purpose.** The bar for "redundant": does removing this lose information someone would need in the future? If uncertain, it stays. Decision-recording comments, institutional memory (task IDs, error stats, incident descriptions), agent prompt specificity, quality standard patterns, and disabled code with rationale are all protected.
-
-2. **Remove decorative noise.** Emojis in code/scripts/agent docs that add no information beyond surrounding text. Examples: `print_success "All quality gates passed"` (function name conveys success), `echo "Running analysis..."` (emoji before "Running" adds nothing), emoji bullets in markdown where plain text suffices. Exception: emojis serving genuine UI/UX purpose (status indicators in dashboards).
-
-3. **Apply project standards** -- but standards themselves are not simplification targets. Follow ES modules, `function` keyword, explicit return types, React Props types, proper error handling. Shell: `local var="$1"`, explicit returns, constants for 3+ occurrences, SC2155 compliance.
-
-4. **Enhance clarity without losing depth.** Reduce nesting, eliminate genuinely redundant code, improve naming, consolidate related logic, remove "what" comments (not "why"), prefer switch/if-else over nested ternaries.
-
-5. **Maintain balance.** Avoid over-simplification that reduces clarity, creates clever-but-opaque solutions, combines too many concerns, removes helpful abstractions, prioritizes fewer lines over readability, or loses edge-case handling.
+1. **Preserve everything with purpose.** If uncertain whether removing loses needed information, it stays.
+2. **Remove decorative noise.** Emojis/formatting that add no information. Exception: genuine UI/UX purpose.
+3. **Apply project standards** — but standards themselves are not simplification targets.
+4. **Enhance clarity without losing depth.** Reduce nesting, improve naming, remove "what" comments (not "why").
+5. **Maintain balance.** Avoid over-simplification that removes helpful abstractions or loses edge-case handling.
 
 ## Usage
 
@@ -162,13 +117,9 @@ Some large `.md` files are knowledge bases (skill docs, domain reference) rather
 /code-simplifier --all        # Analyse entire codebase (use sparingly)
 ```
 
-**Scope detection** (no target specified): `git diff --name-only HEAD~1` and `git diff --name-only --staged`. With target: analyse directory, file, or `--all`.
+Scope detection (no target): `git diff --name-only HEAD~1` and `git diff --name-only --staged`. Workflow: analyse → human reviews → approved items become issues → worker implements in worktree + PR.
 
-**Workflow**: `/code-simplifier` (analyse) -> human reviews -> approved items become issues -> dispatched via normal workflow -> worker implements in worktree + PR. Deliberately slower than direct editing -- the cost of accidentally removing institutional knowledge far exceeds a human review step.
-
-## Examples
-
-### NOT a simplification target
+## Example: NOT a simplification target
 
 ```bash
 # DISABLED: qlty fmt introduces invalid shell syntax (adds "|| exit" after
@@ -176,30 +127,17 @@ Some large `.md` files are knowledge bases (skill docs, domain reference) rather
 # See: https://github.com/marcusquinn/aidevops/issues/333
 ```
 
-This encodes critical knowledge: what was tried, why it failed, where to find details. Removing it risks re-enabling a known-broken approach.
-
-### Structural simplification
-
-Nested ternary `isLoading ? 'loading' : hasError ? 'error' : isComplete ? 'complete' : 'idle'` -> extract to a function with early returns. Same logic, clearer structure, zero risk.
-
-Dense chain `.filter().map().reduce().slice()` -> named intermediate variables with `join()`. Same behaviour, clearer intent.
-
 ## Human Gate Workflow
 
-Every finding must pass through a maintainer before work begins, enforced through GitHub labels, assignment, and dashboard visibility.
+### Issue creation
 
-### Issue creation (by code-simplifier agent)
-
-1. **Dedup check FIRST (GH#10783)** -- before creating any issue, search for existing open issues targeting the same file. Without this, each scan run creates duplicates.
-2. Add labels: `simplification-debt` + `needs-maintainer-review`
-3. Assign to repo maintainer (from `repos.json` `maintainer` field, fall back to slug owner)
-4. Include structured finding format (Current/Proposed/Preserved/Risk/Verification/Confidence)
+1. **Dedup check FIRST (GH#10783)** — search for existing open issues targeting the same file.
+2. Add labels `simplification-debt` + `needs-maintainer-review`, assign to repo maintainer (`repos.json` `maintainer` field, fall back to slug owner).
 
 ```bash
 MAINTAINER=$(jq -r '.initialized_repos[] | select(.slug == "<slug>") | .maintainer // empty' ~/.config/aidevops/repos.json)
 [[ -z "$MAINTAINER" ]] && MAINTAINER=$(echo "<slug>" | cut -d/ -f1)
 
-# Dedup: check for existing open issue targeting this file (GH#10783)
 EXISTING=$(gh issue list --repo <slug> \
   --label "simplification-debt" --state open \
   --search "\"<file_path>\" in:title" \
@@ -220,16 +158,13 @@ else
 fi
 ```
 
-The `needs-maintainer-review` label prevents pulse dispatch. GitHub notifies the assignee on creation.
-
 ### Maintainer review
 
-Review via GitHub notifications, label filter (`gh issue list --label simplification-debt --label needs-maintainer-review`), or `/dashboard --pending-review`.
+`gh issue list --label simplification-debt --label needs-maintainer-review`
 
-- **Approve**: comment `approved` (case-insensitive). Pulse removes `needs-maintainer-review`, adds `auto-dispatch`, issue enters dispatch queue.
-- **Decline**: comment `declined: <reason>`. Pulse closes the issue with reason preserved.
-- **Defer**: no comment needed -- stays in `needs-maintainer-review`.
-- **Label fallback**: maintainers can also directly manipulate labels (`--remove-label "needs-maintainer-review" --add-label "auto-dispatch"` or `gh issue close -c "Declined: <reason>"`).
+- **Approve**: comment `approved` → pulse removes `needs-maintainer-review`, adds `auto-dispatch`.
+- **Decline**: comment `declined: <reason>` → pulse closes the issue.
+- **Defer**: no comment — stays gated.
 
 ### Label lifecycle
 
@@ -242,31 +177,15 @@ Issue created [simplification-debt + needs-maintainer-review] + assigned
 
 ## Integration with Quality Workflow
 
-### 1. Automated daily scan (GH#5628)
+**Automated daily scan (GH#5628):** `pulse-wrapper.sh` creates `simplification-debt` issues for files exceeding per-file violation threshold (default: 1+ functions >100 lines). Deduplicated by repo-relative file path. No file size gate (t1679) — classification determines action. Config: `COMPLEXITY_SCAN_INTERVAL` (default 1 day), `COMPLEXITY_FILE_VIOLATION_THRESHOLD` (default 1), `COMPLEXITY_MD_MIN_LINES` (default 50).
 
-`pulse-wrapper.sh` runs daily complexity scan (same awk-based check as CI). Creates `simplification-debt` issues for files exceeding the per-file violation threshold (default: 1+ functions >100 lines). Deduplicated by repo-relative file path.
-
-**No file size gate** (t1679). Agent docs of any size are eligible. A qualification gate (`_complexity_scan_should_open_md_issue`) filters stubs/very short files (default: <50 lines). Classification (instruction doc vs reference corpus) determines the action, not line count.
-
-Config: `COMPLEXITY_SCAN_INTERVAL` (default 1 day), `COMPLEXITY_FILE_VIOLATION_THRESHOLD` (default 1), `COMPLEXITY_MD_MIN_LINES` (default 50).
-
-### 2. Manual analysis
-
-`/code-simplifier` (analyse) -> issues created with `needs-maintainer-review`.
-
-### Common pipeline
-
-Both paths -> maintainer approves/declines -> approved items dispatched (priority 8) -> worker implements in worktree + PR -> CI threshold ratchets down.
-
-**CI threshold ratchet (GH#5628):** Thresholds stored in `.agents/configs/complexity-thresholds.conf` (not hardcoded). After simplification PRs merge, lower thresholds in a chore commit. Contains `FUNCTION_COMPLEXITY_THRESHOLD`, `NESTING_DEPTH_THRESHOLD`, `FILE_SIZE_THRESHOLD`.
+**CI threshold ratchet (GH#5628):** Thresholds in `.agents/configs/complexity-thresholds.conf` (`FUNCTION_COMPLEXITY_THRESHOLD`, `NESTING_DEPTH_THRESHOLD`, `FILE_SIZE_THRESHOLD`). Lower after simplification PRs merge.
 
 ## Pulse and Supervisor Integration
 
-Approved `simplification-debt` issues enter the dispatch queue at **priority 8** (below quality-debt, above oldest-issues). Post-deployment maintainability work -- dispatched only when no higher-priority work exists.
+Approved issues enter dispatch at **priority 8** (below quality-debt, above oldest-issues). Concurrency cap: 10% of worker slots, 30% combined cap with quality-debt. See `scripts/commands/pulse.md`.
 
-**Concurrency cap:** At most 10% of worker slots, sharing a combined 30% cap with quality-debt. See `scripts/commands/pulse.md`.
-
-**Codacy maintainability signal:** When Codacy reports grade B or below, simplification-debt issues for that repo get temporary priority boost to 7 (same as quality-debt). Workers fix issues -> grade recovers -> priority returns to normal. The daily quality sweep (in `pulse-wrapper.sh`) posts Codacy findings on the persistent quality-review issue; the pulse reads these for priority adjustment.
+**Codacy signal (GH#5628):** Grade B or below → temporary priority boost to 7. Workers fix issues → grade recovers → priority returns to normal.
 
 ## Related Agents
 


### PR DESCRIPTION
## Summary

- Tightens `.agents/tools/code-review/code-simplifier.md` from 278 lines to 197 lines (29% reduction, 39% of original 501-line baseline)
- Removes verbose prose, redundant explanations, and narrative context that doesn't change agent behaviour
- All task IDs (`t1345`, `t1679`), GH refs (`GH#6432`, `GH#2928`, `GH#10783`, `GH#5628`), code blocks (5 fenced blocks), and command examples preserved

## What was cut

- "Why Analysis-Only" section (prose restating frontmatter `write: false`)
- "Analysis Process" numbered list (generic steps, self-evident from output format)
- Verbose prose in Classification subsections compressed to single sentences
- Core Principles compressed from multi-sentence paragraphs to single lines
- Structural simplification examples (generic, not institutional knowledge)
- Redundant intro/outro prose around code blocks

## Verification

- All task IDs present before and after: `t1345`, `t1679`
- All GH refs present before and after: `GH#6432`, `GH#2928`, `GH#10783`, `GH#5628`
- 5 fenced code blocks preserved (output format, bash issue creation, label lifecycle, usage, DISABLED example)
- Agent behaviour unchanged: analysis-only mode, opus requirement, protected files, human gate workflow all intact

Closes #9344