### PR TITLE
GH#7633: Fix CodeRabbit review findings from PR #7906 (opus model prefix + test + docs)

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -106,8 +106,10 @@ is_known_provider() {
 
 # Tier to primary/fallback model mapping
 # Format: primary_provider/model|fallback_provider/model
-# When OpenCode is available, prefer opencode/* model IDs (routed through
-# OpenCode's gateway, no direct API keys needed for these).
+# When OpenCode is available, Anthropic models are routed through OpenCode's
+# gateway using the anthropic/ provider prefix (not opencode/). OpenCode uses
+# anthropic/ as the provider prefix for all Anthropic models — using opencode/
+# causes ProviderModelNotFoundError at dispatch time (GH#7633).
 get_tier_models() {
 	local tier="$1"
 
@@ -115,14 +117,14 @@ get_tier_models() {
 	if _is_opencode_available; then
 		case "$tier" in
 		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
-		haiku) echo "opencode/claude-haiku-4-5|opencode/gemini-3-flash" ;;
+		haiku) echo "anthropic/claude-haiku-4-5|opencode/gemini-3-flash" ;;
 		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
-		sonnet) echo "opencode/claude-sonnet-4-6|openai/gpt-5.3-codex|anthropic/claude-sonnet-4-6" ;;
+		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.3-codex" ;;
 		pro) echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;
-		opus) echo "opencode/claude-opus-4-6|openai/gpt-5.4|anthropic/claude-opus-4-6" ;;
-		health) echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		eval) echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		coding) echo "opencode/claude-opus-4-6|openai/gpt-5.4|anthropic/claude-opus-4-6" ;;
+		opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
+		health) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+		eval) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+		coding) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
 		*) return 1 ;;
 		esac
 	else

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -178,8 +178,11 @@ fi
 # OpenCode uses anthropic/ as the provider prefix — opencode/claude-* causes
 # ProviderModelNotFoundError at dispatch time.
 for tier in opus coding haiku sonnet health eval; do
-	tier_output=$(run_with_timeout 5 bash "$HELPER" resolve "$tier" --quiet 2>&1) || true
-	if [[ -n "$tier_output" && "$tier_output" == opencode/claude-* ]]; then
+	tier_exit=0
+	tier_output=$(run_with_timeout 5 bash "$HELPER" resolve "$tier" --quiet 2>&1) || tier_exit=$?
+	if [[ "$tier_exit" -ne 0 || -z "$tier_output" ]]; then
+		skip "resolve $tier: unable to resolve in this environment (cannot validate GH#7633)"
+	elif [[ "$tier_output" == opencode/claude-* ]]; then
 		fail "resolve $tier: must not return opencode/claude-* prefix (GH#7633)" \
 			"Got: $tier_output — OpenCode uses anthropic/ prefix for Anthropic models"
 	else

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -19,20 +19,20 @@ VERBOSE="${1:-}"
 # Portable timeout: gtimeout (macOS homebrew) > timeout (Linux) > none
 TIMEOUT_CMD=""
 if command -v gtimeout &>/dev/null; then
-    TIMEOUT_CMD="gtimeout"
+	TIMEOUT_CMD="gtimeout"
 elif command -v timeout &>/dev/null; then
-    TIMEOUT_CMD="timeout"
+	TIMEOUT_CMD="timeout"
 fi
 
 # Run a command with optional timeout
 run_with_timeout() {
-    local secs="$1"
-    shift
-    if [[ -n "$TIMEOUT_CMD" ]]; then
-        "$TIMEOUT_CMD" "$secs" "$@"
-    else
-        "$@"
-    fi
+	local secs="$1"
+	shift
+	if [[ -n "$TIMEOUT_CMD" ]]; then
+		"$TIMEOUT_CMD" "$secs" "$@"
+	else
+		"$@"
+	fi
 }
 
 # --- Test Framework ---
@@ -42,36 +42,36 @@ SKIP_COUNT=0
 TOTAL_COUNT=0
 
 pass() {
-    PASS_COUNT=$((PASS_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    if [[ "$VERBOSE" == "--verbose" ]]; then
-        printf "  \033[0;32mPASS\033[0m %s\n" "$1"
-    fi
-    return 0
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	if [[ "$VERBOSE" == "--verbose" ]]; then
+		printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	fi
+	return 0
 }
 
 fail() {
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
-    if [[ -n "${2:-}" ]]; then
-        printf "       %s\n" "$2"
-    fi
-    return 0
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
+	return 0
 }
 
 skip() {
-    SKIP_COUNT=$((SKIP_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    if [[ "$VERBOSE" == "--verbose" ]]; then
-        printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
-    fi
-    return 0
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	if [[ "$VERBOSE" == "--verbose" ]]; then
+		printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	fi
+	return 0
 }
 
 section() {
-    echo ""
-    printf "\033[1m=== %s ===\033[0m\n" "$1"
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
 }
 
 # Use a temp DB for testing to avoid polluting real cache
@@ -86,55 +86,55 @@ section "Basic Validation"
 
 # Syntax check
 if bash -n "$HELPER" 2>/dev/null; then
-    pass "bash -n syntax check"
+	pass "bash -n syntax check"
 else
-    fail "bash -n syntax check" "Script has syntax errors"
+	fail "bash -n syntax check" "Script has syntax errors"
 fi
 
 # ShellCheck
 if command -v shellcheck &>/dev/null; then
-    sc_output=$(shellcheck "$HELPER" 2>&1 || true)
-    sc_errors=$(echo "$sc_output" | grep -c "error" 2>/dev/null || true)
-    if [[ "$sc_errors" -eq 0 ]]; then
-        pass "shellcheck (0 errors)"
-    else
-        fail "shellcheck ($sc_errors errors)" "$(echo "$sc_output" | head -5)"
-    fi
+	sc_output=$(shellcheck "$HELPER" 2>&1 || true)
+	sc_errors=$(echo "$sc_output" | grep -c "error" 2>/dev/null || true)
+	if [[ "$sc_errors" -eq 0 ]]; then
+		pass "shellcheck (0 errors)"
+	else
+		fail "shellcheck ($sc_errors errors)" "$(echo "$sc_output" | head -5)"
+	fi
 else
-    skip "shellcheck not installed"
+	skip "shellcheck not installed"
 fi
 
 # Help command
 help_output=$(run_with_timeout 5 bash "$HELPER" help 2>&1) || true
 if [[ -n "$help_output" ]]; then
-    pass "help command produces output"
+	pass "help command produces output"
 else
-    fail "help command produces output" "No output"
+	fail "help command produces output" "No output"
 fi
 
 # Help mentions key commands
 if echo "$help_output" | grep -qi "check"; then
-    pass "help mentions 'check' command"
+	pass "help mentions 'check' command"
 else
-    fail "help mentions 'check' command"
+	fail "help mentions 'check' command"
 fi
 
 if echo "$help_output" | grep -qi "probe"; then
-    pass "help mentions 'probe' command"
+	pass "help mentions 'probe' command"
 else
-    fail "help mentions 'probe' command"
+	fail "help mentions 'probe' command"
 fi
 
 if echo "$help_output" | grep -qi "resolve"; then
-    pass "help mentions 'resolve' command"
+	pass "help mentions 'resolve' command"
 else
-    fail "help mentions 'resolve' command"
+	fail "help mentions 'resolve' command"
 fi
 
 if echo "$help_output" | grep -qi "rate-limits"; then
-    pass "help mentions 'rate-limits' command"
+	pass "help mentions 'rate-limits' command"
 else
-    fail "help mentions 'rate-limits' command"
+	fail "help mentions 'rate-limits' command"
 fi
 
 # ============================================================
@@ -144,9 +144,9 @@ section "Status Command (Empty State)"
 
 status_output=$(run_with_timeout 5 bash "$HELPER" status 2>&1) || true
 if [[ -n "$status_output" ]]; then
-    pass "status command runs without error"
+	pass "status command runs without error"
 else
-    fail "status command runs without error" "No output or error"
+	fail "status command runs without error" "No output or error"
 fi
 
 # ============================================================
@@ -156,23 +156,36 @@ section "Tier Resolution"
 
 # Test that resolve returns a model spec for known tiers
 for tier in haiku flash sonnet pro opus health eval coding; do
-    resolve_output=$(run_with_timeout 15 bash "$HELPER" resolve "$tier" --quiet 2>&1) || true
-    # Even without API keys, resolve should return the primary model
-    # (it falls through to the primary when no probe is possible)
-    if [[ -n "$resolve_output" && "$resolve_output" == *"/"* ]]; then
-        pass "resolve $tier -> $resolve_output"
-    else
-        # May fail if no API keys configured - that's OK for CI
-        skip "resolve $tier (no API keys or provider unavailable)"
-    fi
+	resolve_output=$(run_with_timeout 15 bash "$HELPER" resolve "$tier" --quiet 2>&1) || true
+	# Even without API keys, resolve should return the primary model
+	# (it falls through to the primary when no probe is possible)
+	if [[ -n "$resolve_output" && "$resolve_output" == *"/"* ]]; then
+		pass "resolve $tier -> $resolve_output"
+	else
+		# May fail if no API keys configured - that's OK for CI
+		skip "resolve $tier (no API keys or provider unavailable)"
+	fi
 done
 
 # Test unknown tier (use || true to prevent set -e from aborting on expected failure)
 if run_with_timeout 5 bash "$HELPER" resolve "nonexistent" --quiet >/dev/null 2>&1; then
-    fail "resolve unknown tier returns error" "Expected non-zero exit"
+	fail "resolve unknown tier returns error" "Expected non-zero exit"
 else
-    pass "resolve unknown tier returns error"
+	pass "resolve unknown tier returns error"
 fi
+
+# GH#7633: Verify opus/coding tiers never return opencode/ prefix for Anthropic models.
+# OpenCode uses anthropic/ as the provider prefix — opencode/claude-* causes
+# ProviderModelNotFoundError at dispatch time.
+for tier in opus coding haiku sonnet health eval; do
+	tier_output=$(run_with_timeout 5 bash "$HELPER" resolve "$tier" --quiet 2>&1) || true
+	if [[ -n "$tier_output" && "$tier_output" == opencode/claude-* ]]; then
+		fail "resolve $tier: must not return opencode/claude-* prefix (GH#7633)" \
+			"Got: $tier_output — OpenCode uses anthropic/ prefix for Anthropic models"
+	else
+		pass "resolve $tier: no opencode/claude-* prefix (GH#7633)"
+	fi
+done
 
 # ============================================================
 # SECTION 4: Check command
@@ -181,23 +194,23 @@ section "Check Command"
 
 # Check with unknown provider (use if to prevent set -e from aborting on expected failure)
 if run_with_timeout 5 bash "$HELPER" check "nonexistent_provider_xyz" --quiet >/dev/null 2>&1; then
-    fail "check unknown target returns error" "Expected non-zero exit, got 0"
+	fail "check unknown target returns error" "Expected non-zero exit, got 0"
 else
-    pass "check unknown target returns error"
+	pass "check unknown target returns error"
 fi
 
 # Check with known provider (may succeed or fail depending on keys)
 # Use || true to prevent set -e from aborting on non-zero exit
 for provider in anthropic openai google opencode; do
-    check_exit=0
-    run_with_timeout 15 bash "$HELPER" check "$provider" --quiet >/dev/null 2>&1 || check_exit=$?
-    case "$check_exit" in
-        0) pass "check $provider: healthy" ;;
-        1) pass "check $provider: unhealthy (expected without key or CLI)" ;;
-        2) pass "check $provider: rate limited" ;;
-        3) pass "check $provider: no key (expected in CI)" ;;
-        *) fail "check $provider: unexpected exit code $check_exit" ;;
-    esac
+	check_exit=0
+	run_with_timeout 15 bash "$HELPER" check "$provider" --quiet >/dev/null 2>&1 || check_exit=$?
+	case "$check_exit" in
+	0) pass "check $provider: healthy" ;;
+	1) pass "check $provider: unhealthy (expected without key or CLI)" ;;
+	2) pass "check $provider: rate limited" ;;
+	3) pass "check $provider: no key (expected in CI)" ;;
+	*) fail "check $provider: unexpected exit code $check_exit" ;;
+	esac
 done
 
 # ============================================================
@@ -208,17 +221,17 @@ section "Cache Invalidation"
 run_with_timeout 5 bash "$HELPER" invalidate >/dev/null 2>&1
 invalidate_exit=$?
 if [[ $invalidate_exit -eq 0 ]]; then
-    pass "invalidate all caches"
+	pass "invalidate all caches"
 else
-    fail "invalidate all caches" "Exit code: $invalidate_exit"
+	fail "invalidate all caches" "Exit code: $invalidate_exit"
 fi
 
 run_with_timeout 5 bash "$HELPER" invalidate anthropic >/dev/null 2>&1
 invalidate_prov_exit=$?
 if [[ $invalidate_prov_exit -eq 0 ]]; then
-    pass "invalidate specific provider cache"
+	pass "invalidate specific provider cache"
 else
-    fail "invalidate specific provider cache" "Exit code: $invalidate_prov_exit"
+	fail "invalidate specific provider cache" "Exit code: $invalidate_prov_exit"
 fi
 
 # ============================================================
@@ -228,30 +241,30 @@ section "Supervisor Integration"
 
 # Verify supervisor references the availability helper
 if grep -q "model-availability-helper.sh" "$SUPERVISOR"; then
-    pass "supervisor references model-availability-helper.sh"
+	pass "supervisor references model-availability-helper.sh"
 else
-    fail "supervisor references model-availability-helper.sh"
+	fail "supervisor references model-availability-helper.sh"
 fi
 
 # Verify resolve_model() has availability helper fast path
 if grep -q "availability_helper.*resolve" "$SUPERVISOR"; then
-    pass "resolve_model() uses availability helper"
+	pass "resolve_model() uses availability helper"
 else
-    fail "resolve_model() uses availability helper"
+	fail "resolve_model() uses availability helper"
 fi
 
 # Verify check_model_health() has availability helper fast path
 if grep -q "availability_helper.*check" "$SUPERVISOR"; then
-    pass "check_model_health() uses availability helper fast path"
+	pass "check_model_health() uses availability helper fast path"
 else
-    fail "check_model_health() uses availability helper fast path"
+	fail "check_model_health() uses availability helper fast path"
 fi
 
 # Verify check_model_health() still has CLI fallback
 if grep -q 'health-check' "$SUPERVISOR"; then
-    pass "check_model_health() retains CLI fallback (slow path)"
+	pass "check_model_health() retains CLI fallback (slow path)"
 else
-    fail "check_model_health() retains CLI fallback (slow path)"
+	fail "check_model_health() retains CLI fallback (slow path)"
 fi
 
 # ============================================================
@@ -261,31 +274,31 @@ section "OpenCode Integration"
 
 # Verify opencode is a known provider
 if bash "$HELPER" help 2>&1 | grep -q "opencode"; then
-    pass "help mentions opencode provider"
+	pass "help mentions opencode provider"
 else
-    fail "help mentions opencode provider"
+	fail "help mentions opencode provider"
 fi
 
 # Check opencode provider (should succeed if CLI installed, fail gracefully otherwise)
 check_oc_exit=0
 run_with_timeout 10 bash "$HELPER" check opencode --quiet >/dev/null 2>&1 || check_oc_exit=$?
 case "$check_oc_exit" in
-    0) pass "check opencode: healthy (CLI and cache available)" ;;
-    1) pass "check opencode: unhealthy (CLI or cache not available)" ;;
-    *) fail "check opencode: unexpected exit code $check_oc_exit" ;;
+0) pass "check opencode: healthy (CLI and cache available)" ;;
+1) pass "check opencode: unhealthy (CLI or cache not available)" ;;
+*) fail "check opencode: unexpected exit code $check_oc_exit" ;;
 esac
 
 # Verify opencode model check (if opencode is available)
 if command -v opencode &>/dev/null && [[ -f "$HOME/.cache/opencode/models.json" ]]; then
-    oc_model_exit=0
-    run_with_timeout 10 bash "$HELPER" check "opencode/claude-sonnet-4" --quiet >/dev/null 2>&1 || oc_model_exit=$?
-    case "$oc_model_exit" in
-        0) pass "check opencode/claude-sonnet-4: available" ;;
-        1) pass "check opencode/claude-sonnet-4: not available (provider unhealthy)" ;;
-        *) fail "check opencode/claude-sonnet-4: unexpected exit code $oc_model_exit" ;;
-    esac
+	oc_model_exit=0
+	run_with_timeout 10 bash "$HELPER" check "opencode/claude-sonnet-4" --quiet >/dev/null 2>&1 || oc_model_exit=$?
+	case "$oc_model_exit" in
+	0) pass "check opencode/claude-sonnet-4: available" ;;
+	1) pass "check opencode/claude-sonnet-4: not available (provider unhealthy)" ;;
+	*) fail "check opencode/claude-sonnet-4: unexpected exit code $oc_model_exit" ;;
+	esac
 else
-    skip "opencode model check (opencode CLI not installed)"
+	skip "opencode model check (opencode CLI not installed)"
 fi
 
 # ============================================================
@@ -296,17 +309,17 @@ section "JSON Output"
 # Status --json
 json_status=$(run_with_timeout 5 bash "$HELPER" status --json 2>&1) || true
 if echo "$json_status" | grep -q "{" 2>/dev/null; then
-    pass "status --json produces JSON"
+	pass "status --json produces JSON"
 else
-    skip "status --json (no data to format)"
+	skip "status --json (no data to format)"
 fi
 
 # Resolve --json
 json_resolve=$(run_with_timeout 15 bash "$HELPER" resolve sonnet --json --quiet 2>&1) || true
 if echo "$json_resolve" | grep -q "tier" 2>/dev/null; then
-    pass "resolve --json produces JSON with tier field"
+	pass "resolve --json produces JSON with tier field"
 else
-    skip "resolve --json (provider may be unavailable)"
+	skip "resolve --json (provider may be unavailable)"
 fi
 
 # ============================================================
@@ -315,15 +328,15 @@ fi
 echo ""
 echo "========================================"
 printf "  \033[1mResults: %d total, \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m, \033[0;33m%d skipped\033[0m\n" \
-    "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+	"$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
 echo "========================================"
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
-    echo ""
-    printf "\033[0;31mFAILURES DETECTED - review output above\033[0m\n"
-    exit 1
+	echo ""
+	printf "\033[0;31mFAILURES DETECTED - review output above\033[0m\n"
+	exit 1
 else
-    echo ""
-    printf "\033[0;32mAll tests passed.\033[0m\n"
-    exit 0
+	echo ""
+	printf "\033[0;32mAll tests passed.\033[0m\n"
+	exit 0
 fi


### PR DESCRIPTION
## Summary

Addresses all 3 CodeRabbit findings from PR #7906 (which fixed `model-availability-helper.sh resolve opus` returning `opencode/claude-opus-4-6` instead of `anthropic/claude-opus-4-6`).

This PR includes the original fix from PR #7906 plus the CodeRabbit corrections:

### Changes

**`.agents/scripts/model-availability-helper.sh`** (from PR #7906):
- Replace `opencode/claude-*` → `anthropic/claude-*` in the OpenCode branch of `get_tier_models()` for all affected tiers: haiku, sonnet, opus, coding, health, eval
- Non-Anthropic models (`gemini-*`, `gpt-*`) retain their `opencode/` prefix

**`tests/test-model-availability.sh`** (CodeRabbit fix 1):
- Remove `|| true` from GH#7633 regression test block
- Capture exit status in `tier_exit`; use `skip` when resolver fails or returns empty (no API keys in environment)
- `fail` only when output matches `opencode/claude-*` prefix — prevents false-positive PASS masking the regression

**`.agents/scripts/commands/email-inbox.md`** (CodeRabbit fix 2):
- Split ambiguous `triage [--limit N]` row into two accurate rows matching actual `email-triage-helper.sh` subcommands:
  - `triage` → `email-triage-helper.sh triage --message-file <message.json>` (single message)
  - `triage --limit N` → `email-triage-helper.sh batch --input <file> --limit N` (batch)
- Verified against `email-triage-helper.sh help` output

**Line 76 quarantine doc** (CodeRabbit fix 3): Already accurate in current main (updated by PR #10292 — "The digest displays truncated content previews (max 200 chars) for review; full message bodies are not rendered"). No change needed.

## Runtime Testing

- **Risk**: Low — config change + test logic fix + doc correction
- **Level**: self-assessed
- `bash -n tests/test-model-availability.sh`: PASS (syntax OK)
- `shellcheck tests/test-model-availability.sh`: PASS (0 errors)
- `email-triage-helper.sh help` confirmed: `triage` and `batch` are valid subcommands; `run` is not

## Actionable Findings

- `actionable_findings_total=3`
- `fixed_in_pr=3`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #7633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model routing logic for Haiku, Sonnet, Opus, Health, Eval, and Coding service tiers to adjust primary and fallback model assignments.

* **Tests**
  * Enhanced tier resolution validation tests to verify correct model routing across all affected tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->