### PR TITLE
Fix maintainer-gate.yml: surface API failures instead of masking them

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -47,6 +47,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAINTAINER_GATE_DEBUG: ${{ vars.MAINTAINER_GATE_DEBUG || 'false' }}
         run: |
           # Collect linked issue numbers from PR body
           LINKED_ISSUES=""
@@ -57,10 +58,16 @@ jobs:
           # Also check PR title for task ID and find matching issue
           TASK_ID=$(echo "$PR_TITLE" | grep -oE '^t[0-9]+(\.[0-9]+)*' || true)
           if [[ -n "$TASK_ID" && -z "$LINKED_ISSUES" ]]; then
-            FOUND=$(gh issue list --repo "$REPO" --state all --search "${TASK_ID}:" --json number,title --limit 5 \
-              | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
-            if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
-              LINKED_ISSUES="$FOUND"
+            ISSUE_SEARCH_OUTPUT=$(gh issue list --repo "$REPO" --state all --search "${TASK_ID}:" --json number,title --limit 5 2>&1) || {
+              echo "::warning::Title-based issue lookup failed for task ID '$TASK_ID': $ISSUE_SEARCH_OUTPUT"
+              ISSUE_SEARCH_OUTPUT=""
+            }
+            if [[ -n "$ISSUE_SEARCH_OUTPUT" ]]; then
+              FOUND=$(echo "$ISSUE_SEARCH_OUTPUT" \
+                | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
+              if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
+                LINKED_ISSUES="$FOUND"
+              fi
             fi
           fi
 
@@ -87,11 +94,13 @@ jobs:
               continue
             }
 
-            # Debug: log raw assignees and labels arrays for troubleshooting
-            echo "DEBUG: Raw assignees for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.assignees[]?.login]')"
-            echo "DEBUG: Raw labels for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.labels[]?.name]')"
+            # Debug: log raw assignees and labels arrays for troubleshooting (opt-in via workflow_dispatch or re-run)
+            if [[ "${MAINTAINER_GATE_DEBUG:-false}" == "true" ]]; then
+              echo "DEBUG: Raw assignees for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.assignees[]?.login]')"
+              echo "DEBUG: Raw labels for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.labels[]?.name]')"
+            fi
 
-            # Parse fields from raw JSON — use //empty to handle null safely
+            # Parse fields from raw JSON — use []? to handle empty arrays safely
             ISSUE_DATA=$(echo "$RAW_ISSUE_DATA" | jq '{labels: [.labels[]?.name], assignees: [.assignees[]?.login], state: .state, author_association: .author_association}') || {
               echo "::error::jq parsing failed for issue #$ISSUE_NUM"
               echo "DEBUG: First 500 chars of raw response: ${RAW_ISSUE_DATA:0:500}"
@@ -104,7 +113,9 @@ jobs:
             ASSIGNEES=$(echo "$ISSUE_DATA" | jq -r '.assignees[]' 2>/dev/null || true)
             STATE=$(echo "$ISSUE_DATA" | jq -r '.state' 2>/dev/null || echo "unknown")
 
-            echo "DEBUG: Parsed LABELS='$LABELS' ASSIGNEES='$ASSIGNEES' STATE='$STATE'"
+            if [[ "${MAINTAINER_GATE_DEBUG:-false}" == "true" ]]; then
+              echo "DEBUG: Parsed LABELS='$LABELS' ASSIGNEES='$ASSIGNEES' STATE='$STATE'"
+            fi
 
             # Skip closed issues — they've already been reviewed
             if [[ "$STATE" == "closed" ]]; then
@@ -268,6 +279,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAINTAINER_GATE_DEBUG: ${{ vars.MAINTAINER_GATE_DEBUG || 'false' }}
         run: |
           echo "Issue #$ISSUE_NUMBER labels changed — checking for linked PRs"
 
@@ -313,10 +325,16 @@ jobs:
             # Also check PR title for task ID and find matching issue
             TASK_ID=$(echo "$PR_TITLE" | grep -oE '^t[0-9]+(\.[0-9]+)*' || true)
             if [[ -n "$TASK_ID" && -z "$LINKED_ISSUES" ]]; then
-              FOUND=$(gh issue list --repo "$REPO" --state all --search "${TASK_ID}:" --json number,title --limit 5 \
-                | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
-              if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
-                LINKED_ISSUES="$FOUND"
+              ISSUE_SEARCH_OUTPUT=$(gh issue list --repo "$REPO" --state all --search "${TASK_ID}:" --json number,title --limit 5 2>&1) || {
+                echo "::warning::Title-based issue lookup failed for task ID '$TASK_ID': $ISSUE_SEARCH_OUTPUT"
+                ISSUE_SEARCH_OUTPUT=""
+              }
+              if [[ -n "$ISSUE_SEARCH_OUTPUT" ]]; then
+                FOUND=$(echo "$ISSUE_SEARCH_OUTPUT" \
+                  | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
+                if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
+                  LINKED_ISSUES="$FOUND"
+                fi
               fi
             fi
 
@@ -348,9 +366,11 @@ jobs:
                 continue
               }
 
-              # Debug: log raw assignees and labels arrays for troubleshooting
-              echo "DEBUG: Raw assignees for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.assignees[]?.login]')"
-              echo "DEBUG: Raw labels for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.labels[]?.name]')"
+              # Debug: log raw assignees and labels arrays for troubleshooting (opt-in)
+              if [[ "${MAINTAINER_GATE_DEBUG:-false}" == "true" ]]; then
+                echo "DEBUG: Raw assignees for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.assignees[]?.login]')"
+                echo "DEBUG: Raw labels for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.labels[]?.name]')"
+              fi
 
               # Parse fields from raw JSON
               ISSUE_DATA=$(echo "$RAW_ISSUE_DATA" | jq '{labels: [.labels[]?.name], assignees: [.assignees[]?.login], state: .state}') || {
@@ -365,7 +385,9 @@ jobs:
               ASSIGNEES=$(echo "$ISSUE_DATA" | jq -r '.assignees[]' 2>/dev/null || true)
               STATE=$(echo "$ISSUE_DATA" | jq -r '.state' 2>/dev/null || echo "unknown")
 
-              echo "DEBUG: Parsed LABELS='$LABELS' ASSIGNEES='$ASSIGNEES' STATE='$STATE'"
+              if [[ "${MAINTAINER_GATE_DEBUG:-false}" == "true" ]]; then
+                echo "DEBUG: Parsed LABELS='$LABELS' ASSIGNEES='$ASSIGNEES' STATE='$STATE'"
+              fi
 
               # Skip closed issues — they've already been reviewed
               if [[ "$STATE" == "closed" ]]; then

--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -79,13 +79,32 @@ jobs:
           for ISSUE_NUM in $LINKED_ISSUES; do
             echo "--- Checking issue #$ISSUE_NUM ---"
 
-            # Get issue labels and assignees
-            ISSUE_DATA=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
-              --jq '{labels: [.labels[].name], assignees: [.assignees[].login], state: .state, author_association: .author_association}' 2>/dev/null || echo '{}')
+            # Fetch raw issue JSON first, then parse — never silence API errors (GH#11063)
+            RAW_ISSUE_DATA=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" 2>&1) || {
+              echo "::error::gh api failed for issue #$ISSUE_NUM: $RAW_ISSUE_DATA"
+              BLOCKED=true
+              REASONS="${REASONS}Issue #${ISSUE_NUM}: API call failed — cannot verify assignee/labels.\n"
+              continue
+            }
+
+            # Debug: log raw assignees and labels arrays for troubleshooting
+            echo "DEBUG: Raw assignees for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.assignees[]?.login]')"
+            echo "DEBUG: Raw labels for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.labels[]?.name]')"
+
+            # Parse fields from raw JSON — use //empty to handle null safely
+            ISSUE_DATA=$(echo "$RAW_ISSUE_DATA" | jq '{labels: [.labels[]?.name], assignees: [.assignees[]?.login], state: .state, author_association: .author_association}') || {
+              echo "::error::jq parsing failed for issue #$ISSUE_NUM"
+              echo "DEBUG: First 500 chars of raw response: ${RAW_ISSUE_DATA:0:500}"
+              BLOCKED=true
+              REASONS="${REASONS}Issue #${ISSUE_NUM}: Failed to parse API response.\n"
+              continue
+            }
 
             LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[]' 2>/dev/null || true)
             ASSIGNEES=$(echo "$ISSUE_DATA" | jq -r '.assignees[]' 2>/dev/null || true)
             STATE=$(echo "$ISSUE_DATA" | jq -r '.state' 2>/dev/null || echo "unknown")
+
+            echo "DEBUG: Parsed LABELS='$LABELS' ASSIGNEES='$ASSIGNEES' STATE='$STATE'"
 
             # Skip closed issues — they've already been reviewed
             if [[ "$STATE" == "closed" ]]; then
@@ -321,12 +340,32 @@ jobs:
             for ISSUE_NUM in $LINKED_ISSUES; do
               echo "--- Checking issue #$ISSUE_NUM ---"
 
-              ISSUE_DATA=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
-                --jq '{labels: [.labels[].name], assignees: [.assignees[].login], state: .state}' 2>/dev/null || echo '{}')
+              # Fetch raw issue JSON first, then parse — never silence API errors (GH#11063)
+              RAW_ISSUE_DATA=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" 2>&1) || {
+                echo "::error::gh api failed for issue #$ISSUE_NUM: $RAW_ISSUE_DATA"
+                BLOCKED=true
+                DESCRIPTION="Issue #${ISSUE_NUM}: API call failed"
+                continue
+              }
+
+              # Debug: log raw assignees and labels arrays for troubleshooting
+              echo "DEBUG: Raw assignees for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.assignees[]?.login]')"
+              echo "DEBUG: Raw labels for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.labels[]?.name]')"
+
+              # Parse fields from raw JSON
+              ISSUE_DATA=$(echo "$RAW_ISSUE_DATA" | jq '{labels: [.labels[]?.name], assignees: [.assignees[]?.login], state: .state}') || {
+                echo "::error::jq parsing failed for issue #$ISSUE_NUM"
+                echo "DEBUG: First 500 chars of raw response: ${RAW_ISSUE_DATA:0:500}"
+                BLOCKED=true
+                DESCRIPTION="Issue #${ISSUE_NUM}: Failed to parse API response"
+                continue
+              }
 
               LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[]' 2>/dev/null || true)
               ASSIGNEES=$(echo "$ISSUE_DATA" | jq -r '.assignees[]' 2>/dev/null || true)
               STATE=$(echo "$ISSUE_DATA" | jq -r '.state' 2>/dev/null || echo "unknown")
+
+              echo "DEBUG: Parsed LABELS='$LABELS' ASSIGNEES='$ASSIGNEES' STATE='$STATE'"
 
               # Skip closed issues — they've already been reviewed
               if [[ "$STATE" == "closed" ]]; then

--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -64,11 +64,24 @@ jobs:
             }
             if [[ -n "$ISSUE_SEARCH_OUTPUT" ]]; then
               FOUND=$(echo "$ISSUE_SEARCH_OUTPUT" \
-                | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
+                | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>&1) || {
+                echo "::error::jq parsing failed during title-based issue lookup for task ID '$TASK_ID': $FOUND"
+                FOUND=""
+                TITLE_LOOKUP_FAILED=true
+              }
               if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
                 LINKED_ISSUES="$FOUND"
               fi
             fi
+          fi
+
+          # If title-based lookup was attempted but failed, block — don't pass the gate on API errors
+          if [[ -z "$LINKED_ISSUES" && "${TITLE_LOOKUP_FAILED:-false}" == "true" ]]; then
+            echo "::error::Title-based issue lookup failed — cannot verify linked issues. Blocking to be safe."
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            printf 'Title-based issue lookup for task ID %s failed — cannot verify linked issues.\n' "$TASK_ID" > /tmp/gate-reasons.txt
+            echo "has_reasons=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           if [[ -z "$LINKED_ISSUES" ]]; then
@@ -331,11 +344,27 @@ jobs:
               }
               if [[ -n "$ISSUE_SEARCH_OUTPUT" ]]; then
                 FOUND=$(echo "$ISSUE_SEARCH_OUTPUT" \
-                  | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
+                  | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>&1) || {
+                  echo "::error::jq parsing failed during title-based issue lookup for task ID '$TASK_ID': $FOUND"
+                  FOUND=""
+                  TITLE_LOOKUP_FAILED=true
+                }
                 if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
                   LINKED_ISSUES="$FOUND"
                 fi
               fi
+            fi
+
+            # If title-based lookup was attempted but failed, block — don't pass the gate on API errors
+            if [[ -z "$LINKED_ISSUES" && "${TITLE_LOOKUP_FAILED:-false}" == "true" ]]; then
+              echo "::error::Title-based issue lookup failed for PR #$PR_NUM — blocking to be safe"
+              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+                --method POST \
+                -f state=failure \
+                -f context="maintainer-gate" \
+                -f description="Title-based issue lookup failed — cannot verify linked issues" \
+                2>/dev/null || echo "::warning::Could not post failure status on PR #$PR_NUM"
+              continue
             fi
 
             if [[ -z "$LINKED_ISSUES" ]]; then


### PR DESCRIPTION
## Summary

Fixes the maintainer-gate workflow falsely reporting "no assignee" on issues that have assignees set (e.g., issue #7633 blocking PR #11060).

Closes #11063

## Root Cause

The `gh api` call used `--jq` with `2>/dev/null || echo '{}'` which silently masked API failures. When the API call failed (e.g., permission edge case with `pull_request_target` token), the fallback produced an empty JSON object `{}`, causing `ASSIGNEES` to be empty and triggering the "no assignee" block — even though the issue had assignees.

## Changes

- **Fetch raw JSON first, then parse** — separates API call from jq transformation so failures at each stage are visible
- **Add DEBUG logging** — echoes raw assignees/labels arrays before jq parsing, and logs parsed values after
- **Replace silent fallback with explicit error handling** — API failures now log `::error::` annotations and block the PR (fail-closed) instead of silently producing wrong results
- **Use jq optional operator (`[]?`)** — safely handles empty arrays without failing the jq expression
- **Applied to both Job 1 (check-pr) and Job 3 (retrigger-pr-checks)** — both had the identical pattern

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Medium (CI workflow, no runtime app)
- **Rationale**: GitHub Actions workflow — cannot be tested locally. The fix is structurally sound: separating API fetch from jq parse, adding debug output, and replacing silent fallback with explicit error handling. The next PR that triggers this workflow will validate the fix via CI logs.

## Files Changed

- `.github/workflows/maintainer-gate.yml` — fixed API error handling in both issue-checking loops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gate checks now fail fast and explicitly block when external API or response-parsing errors occur, preventing silent error masking and ensuring failures surface.

* **Chores**
  * Added clearer failure reporting (including commit-status updates for retrigger flows) and an opt-in debug mode that emits richer raw/parsed diagnostic output for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->