### PR TITLE
t1679.2: Extract Screenshot Size Limits to reference/screenshot-limits.md

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -109,10 +109,7 @@ Reference code as `file_path:line_number` for easy navigation.
 - Before deleting/rewriting: verify no accumulated knowledge will be lost.
 - Never consume >100K tokens on single operation.
 
-# Screenshot Size Limits (CRITICAL — session-crashing)
-# Images >8000px crash session irrecoverably. NEVER `fullPage: true` for AI review.
-# Max 1568px longest side. Use `browser-qa-helper.sh screenshot` (only guarded path).
-# Full rules: `reference/screenshot-limits.md`
+# Screenshot Size Limits (CRITICAL — session-crashing): Images >8000px crash sessions irrecoverably. Full rules: `reference/screenshot-limits.md`
 
 # Error Prevention (top recurring patterns)
 #


### PR DESCRIPTION
## Summary

- Condenses the 4-line Screenshot Size Limits block in `build.txt` (lines 131-134) to a single 1-line pointer
- Full rules already exist in `.agents/reference/screenshot-limits.md` (18 lines, complete content)
- Saves 3 lines of prompt budget while preserving the CRITICAL signal and reference path

## Changes

- `.agents/prompts/build.txt` — 4-line block → 1-line pointer (`reference/screenshot-limits.md`)

## Task Lineage

Part of t1679 (GH#11082) — refactoring build.txt for progressive loading.
Sibling tasks t1679.1, t1679.3–t1679.6 handle other sections.

Closes #11084

## Runtime Testing

- **Risk classification:** Low (docs/prompt refactor only — no code logic changed)
- **Testing level:** self-assessed
- **Verification:** `reference/screenshot-limits.md` confirmed present with full 18-line content; build.txt pointer confirmed correct path