### PR TITLE
t1680.2: Move Self-Improvement section to on-demand subagent doc

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -71,56 +71,7 @@ For setup workflow, safety gates, and scheduling patterns, use `/routine` or rea
 
 ## Self-Improvement
 
-Every agent session — interactive, worker, or supervisor — should improve the system, not just complete its task. This is a universal principle, not specific to any one command.
-
-**Observe outcomes from existing state.** TODO.md, PLANS.md, and GitHub issues/PRs are the state database. Never duplicate this state into separate files, databases, or logs.
-
-**Signals that something needs fixing** (check via `gh` CLI, not custom state):
-- A PR has been open for 6+ hours with no progress
-- The same issue/PR appears in consecutive supervisor pulses with no state change
-- A PR was closed (not merged) — a worker failed
-- Multiple PRs fail CI with the same error pattern
-- A worker creates a PR that duplicates an existing one
-
-**Response: create a GitHub issue, not a workaround.** When you observe a systemic problem, file a GitHub issue describing the pattern, root cause hypothesis, and proposed fix. This enters the existing task queue and gets picked up by the next available worker. Never patch around a broken process — fix the process.
-
-**Route to the correct repo.** Not every improvement belongs in the current project. Before creating a self-improvement task, determine whether the problem is project-specific or framework-level:
-
-- **Framework-level** — route to the aidevops repo. Indicators: the observation references files under `~/.aidevops/`, framework scripts (`ai-actions.sh`, `ai-lifecycle.sh`, `supervisor/`, `dispatch.sh`, `pre-edit-check.sh`, helper scripts), agent prompt behaviour, supervisor/pulse logic, or cross-repo orchestration. **Use `framework-issue-helper.sh log` — not `claim-task-id.sh` — to file the issue directly on `marcusquinn/aidevops`.** The fix belongs in the framework, not in the project that happened to trigger it.
-- **Project-specific** — route to the current repo. Indicators: the observation is about this project's CI, code patterns, dependencies, or domain logic.
-
-If uncertain, ask: "Would this fix apply to every repo the framework manages, or only this one?" Framework-wide problems go to aidevops; project-specific problems stay local. Never create framework tasks in a project repo — they become invisible to framework maintainers and pollute the project's task namespace.
-
-**How to file a framework issue (GH#5149):** When you detect a framework-level problem, use the dedicated helper — not `claim-task-id.sh` in the current repo:
-
-```bash
-# Detect if a problem is framework-level (exit 0 = framework, exit 1 = project)
-~/.aidevops/agents/scripts/framework-issue-helper.sh detect "description of the problem"
-
-# File a framework issue directly on marcusquinn/aidevops (deduplicates automatically)
-~/.aidevops/agents/scripts/framework-issue-helper.sh log \
-  --title "Bug: supervisor pipeline fails when stdin is consumed" \
-  --body "Observed in ai-lifecycle.sh phase 3: ..." \
-  --label "bug"
-```
-
-This is the correct action path for framework issues. Do NOT use `claim-task-id.sh` in the project repo for framework-level observations — that pollutes the project's task namespace and makes the issue invisible to framework maintainers.
-
-**Scope boundary for code changes (t1405, GH#2928).** Separate "observe and report" from "observe and fix". When dispatched by the pulse, the `PULSE_SCOPE_REPOS` env var lists the repo slugs where you may create worktrees and PRs. Filing issues is always allowed on any repo — cross-repo bug reports are valuable. But code changes (worktrees, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop. The issue enters that repo's queue for their maintainers (or their own pulse) to handle. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies.
-
-**What counts as self-improvement:**
-- Filing issues for repeated failure patterns
-- Improving agent prompts when workers consistently misunderstand instructions
-- Identifying missing automation (e.g., a manual step that could be a `gh` command)
-- Flagging stale tasks that are blocked but not marked as such
-- Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
-- **Filing issues for information gaps (t1416):** When you cannot determine what happened on a task because comments lack model tier, branch name, failure diagnosis, or other audit-critical fields, file a self-improvement issue. Information gaps cause cascading waste — without knowing what was tried, the next attempt repeats the same failure. The issue/PR comment timeline is the primary audit trail; if the information isn't there, it's invisible.
-
-**Issue quality filter (GH#6508):** Before filing any enhancement or architectural change — whether via `/log-issue-aidevops`, `framework-issue-helper.sh`, or direct `gh issue create` — apply the framework's own principles to the proposal. Ask: (1) Is this addressing an observed failure, or is it preemptive? Preemptive rules for unobserved failure modes are prompt bloat. (2) Does this add a deterministic mechanism where model judgment would work better? (3) If this comes from comparing aidevops to another framework, is the "gap" actually a deliberate architectural choice? The bar for adding guidance is: **observed failure first, then minimal guidance**. Bug reports with clear reproduction steps are exempt — bugs are observed failures by definition.
-
-**Intelligence over determinism:** The harness gives you goals, tools, and boundaries — not scripts for every scenario. Deterministic rules are for things with exactly one correct answer (CLI syntax, file paths, security). Everything else — prioritisation, triage, stuck detection, what to work on — is a judgment call. If a rule says "if X then Y" but there are cases where X is true and Y is wrong, it's guidance not a rule. Use the cheapest model that can handle the decision (haiku for triage, sonnet for implementation, opus for strategy) — but never use a regex where a model call would handle outliers better. See `prompts/build.txt` "Intelligence Over Determinism" for the full principle.
-
-**Autonomous operation:** When the user says "continue", "monitor", or "keep going" — enter autonomous mode: use sleep/wait loops, maintain a perpetual todo to survive compaction, only interrupt for blocking errors that require user input.
+Read `workflows/self-improvement.md` for the full self-improvement guide (signals, repo routing, issue quality filter, scope boundaries).
 
 ---
 

--- a/.agents/workflows/self-improvement.md
+++ b/.agents/workflows/self-improvement.md
@@ -1,0 +1,94 @@
+---
+description: Self-improvement guidance — read when observing systemic problems, filing framework issues, or improving agent behaviour
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Self-Improvement
+
+Every agent session — interactive, worker, or supervisor — should improve the system, not just complete its task. This is a universal principle, not specific to any one command.
+
+**Observe outcomes from existing state.** TODO.md, PLANS.md, and GitHub issues/PRs are the state database. Never duplicate this state into separate files, databases, or logs.
+
+## Signals That Something Needs Fixing
+
+Check via `gh` CLI, not custom state:
+
+- A PR has been open for 6+ hours with no progress
+- The same issue/PR appears in consecutive supervisor pulses with no state change
+- A PR was closed (not merged) — a worker failed
+- Multiple PRs fail CI with the same error pattern
+- A worker creates a PR that duplicates an existing one
+
+**Response: create a GitHub issue, not a workaround.** When you observe a systemic problem, file a GitHub issue describing the pattern, root cause hypothesis, and proposed fix. This enters the existing task queue and gets picked up by the next available worker. Never patch around a broken process — fix the process.
+
+## Route to the Correct Repo
+
+Not every improvement belongs in the current project. Before creating a self-improvement task, determine whether the problem is project-specific or framework-level:
+
+- **Framework-level** — route to the aidevops repo. Indicators: the observation references files under `~/.aidevops/`, framework scripts (`ai-actions.sh`, `ai-lifecycle.sh`, `supervisor/`, `dispatch.sh`, `pre-edit-check.sh`, helper scripts), agent prompt behaviour, supervisor/pulse logic, or cross-repo orchestration. **Use `framework-issue-helper.sh log` — not `claim-task-id.sh` — to file the issue directly on `marcusquinn/aidevops`.** The fix belongs in the framework, not in the project that happened to trigger it.
+- **Project-specific** — route to the current repo. Indicators: the observation is about this project's CI, code patterns, dependencies, or domain logic.
+
+If uncertain, ask: "Would this fix apply to every repo the framework manages, or only this one?" Framework-wide problems go to aidevops; project-specific problems stay local. Never create framework tasks in a project repo — they become invisible to framework maintainers and pollute the project's task namespace.
+
+## How to File a Framework Issue (GH#5149)
+
+When you detect a framework-level problem, use the dedicated helper — not `claim-task-id.sh` in the current repo:
+
+```bash
+# Detect if a problem is framework-level (exit 0 = framework, exit 1 = project)
+~/.aidevops/agents/scripts/framework-issue-helper.sh detect "description of the problem"
+
+# File a framework issue directly on marcusquinn/aidevops (deduplicates automatically)
+~/.aidevops/agents/scripts/framework-issue-helper.sh log \
+  --title "Bug: supervisor pipeline fails when stdin is consumed" \
+  --body "Observed in ai-lifecycle.sh phase 3: ..." \
+  --label "bug"
+```
+
+This is the correct action path for framework issues. Do NOT use `claim-task-id.sh` in the project repo for framework-level observations — that pollutes the project's task namespace and makes the issue invisible to framework maintainers.
+
+## Scope Boundary for Code Changes (t1405, GH#2928)
+
+Separate "observe and report" from "observe and fix". When dispatched by the pulse, the `PULSE_SCOPE_REPOS` env var lists the repo slugs where you may create worktrees and PRs. Filing issues is always allowed on any repo — cross-repo bug reports are valuable. But code changes (worktrees, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop. The issue enters that repo's queue for their maintainers (or their own pulse) to handle. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies.
+
+## What Counts as Self-Improvement
+
+- Filing issues for repeated failure patterns
+- Improving agent prompts when workers consistently misunderstand instructions
+- Identifying missing automation (e.g., a manual step that could be a `gh` command)
+- Flagging stale tasks that are blocked but not marked as such
+- Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
+- **Filing issues for information gaps (t1416):** When you cannot determine what happened on a task because comments lack model tier, branch name, failure diagnosis, or other audit-critical fields, file a self-improvement issue. Information gaps cause cascading waste — without knowing what was tried, the next attempt repeats the same failure. The issue/PR comment timeline is the primary audit trail; if the information isn't there, it's invisible.
+
+## Issue Quality Filter (GH#6508)
+
+Before filing any enhancement or architectural change — whether via `/log-issue-aidevops`, `framework-issue-helper.sh`, or direct `gh issue create` — apply the framework's own principles to the proposal. Ask:
+
+1. Is this addressing an observed failure, or is it preemptive? Preemptive rules for unobserved failure modes are prompt bloat.
+2. Does this add a deterministic mechanism where model judgment would work better?
+3. If this comes from comparing aidevops to another framework, is the "gap" actually a deliberate architectural choice?
+
+The bar for adding guidance is: **observed failure first, then minimal guidance**. Bug reports with clear reproduction steps are exempt — bugs are observed failures by definition.
+
+## Intelligence Over Determinism
+
+The harness gives you goals, tools, and boundaries — not scripts for every scenario. Deterministic rules are for things with exactly one correct answer (CLI syntax, file paths, security). Everything else — prioritisation, triage, stuck detection, what to work on — is a judgment call. If a rule says "if X then Y" but there are cases where X is true and Y is wrong, it's guidance not a rule. Use the cheapest model that can handle the decision (haiku for triage, sonnet for implementation, opus for strategy) — but never use a regex where a model call would handle outliers better. See `prompts/build.txt` "Intelligence Over Determinism" for the full principle.
+
+## Autonomous Operation
+
+When the user says "continue", "monitor", or "keep going" — enter autonomous mode: use sleep/wait loops, maintain a perpetual todo to survive compaction, only interrupt for blocking errors that require user input.
+
+## Related
+
+- `aidevops/self-improving-agents.md` — technical background on the self-improvement mechanism
+- `scripts/commands/pulse.md` — supervisor outcome observation (Step 2a)
+- `memory/README.md` — cross-session memory system


### PR DESCRIPTION
## Summary

- Extracts the `## Self-Improvement` section from `.agents/AGENTS.md` into a new on-demand subagent doc at `.agents/workflows/self-improvement.md`
- Replaces the 52-line inline section with a 1-line pointer: `Read \`workflows/self-improvement.md\` for the full self-improvement guide`
- No content removed — all guidance preserved in the subagent doc with proper frontmatter

## Part of t1680 Progressive-Load Refactor

Parent task: t1680 (GH#11089) — refactor AGENTS.md for progressive loading.
Sibling tasks: t1680.1 (Domain Index), t1680.3 (Agent Routing).

## Files Changed

- `.agents/AGENTS.md` — Self-Improvement section replaced with 1-line pointer (−50 lines)
- `.agents/workflows/self-improvement.md` — new on-demand subagent doc with full content (+95 lines)

## Runtime Testing

- **Risk classification:** Low — docs/agent prompts only, no code logic
- **Testing level:** self-assessed
- **Verification:** Content diff confirms all guidance preserved; pointer path matches new file location

Closes #11091