### PR TITLE
t1680.1: Move Domain Index section to on-demand reference with 1-line pointer

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -210,6 +210,7 @@ Rules: `prompts/build.txt`.
 - **Scripts**: `~/.aidevops/agents/scripts/[service]-helper.sh [command] [account] [target]`
 - **Secrets**: `aidevops secret` (gopass preferred) or `~/.config/aidevops/credentials.sh` (600 perms)
 - **Subagent Index**: `subagent-index.toon`
+- **Domain Index**: `reference/domain-index.md` (30+ domain-to-subagent mappings; read on demand)
 - **Rules**: `prompts/build.txt` (file ops, security, discovery, quality). MD031: blank lines around code blocks.
 
 ## Planning & Tasks
@@ -272,10 +273,6 @@ When a user invokes a slash command (`/runners`, `/full-loop`, `/routine`, etc.)
 This also applies when the agent itself needs to perform an action that has a corresponding command (e.g., logging a framework issue → `/log-issue-aidevops`). Prefer the slash command workflow as the operator interface; the command doc enforces quality steps (diagnostics, duplicate checks, user confirmation) that direct helper invocation may skip.
 
 If unsure which command maps to the user's intent, list available commands: `ls ~/.aidevops/agents/scripts/commands/`.
-
-## Domain Index
-
-Full domain-to-subagent lookup table (30+ domains): `reference/domain-index.md`. When a user asks to create, build, or design an agent, always read `tools/build-agent/build-agent.md` first.
 
 ## Capabilities
 


### PR DESCRIPTION
## Summary

- Removes the standalone `## Domain Index` section from `AGENTS.md` (4 lines including blank lines)
- Adds a single `- **Domain Index**: \`reference/domain-index.md\`` bullet in the Quick Reference section
- No content lost: the full 30+ domain table and agent-creation note already live in `reference/domain-index.md`

## Motivation

The `## Domain Index` section was prompt budget overhead — a section heading with a pointer to a file that already contains all the content. Collapsing it to a Quick Reference bullet reduces AGENTS.md by 4 lines while preserving discoverability.

## Runtime Testing

- **Risk**: Low (docs/agent prompt only, no code changes)
- **Testing level**: self-assessed
- **Verification**: `git diff` confirms correct removal and pointer addition; `reference/domain-index.md` unchanged and contains full table + agent-creation note

## Files Changed

- `.agents/AGENTS.md` — removed `## Domain Index` section, added 1-line pointer in Quick Reference

Closes #11090