### PR TITLE
t1682: fix errored MCP server config paths for Claude Code runtime

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -79,7 +79,7 @@ Use TodoWrite frequently. Break complex tasks into steps. Mark todos completed i
 - When a tool call returns "MCP error -32000", "Connection closed", "spawn ENOENT", or similar startup errors, mark that MCP server as unavailable for the rest of the session. Do NOT retry tools from that server.
 - If you see tools in the tool list from a server that has previously errored, skip them entirely — do not attempt to call them.
 - To identify and fix errored MCP servers: `~/.aidevops/agents/scripts/mcp-diagnose.sh check-all`. This scans all enabled MCP servers and reports which ones are unavailable, with remediation steps.
-- To disable a persistently errored server: set `"enabled": false` in `~/.config/opencode/opencode.json` for that server entry. This removes its tool schemas from context entirely.
+- To disable a persistently errored server: set `"enabled": false` in your runtime's MCP config for that server entry. This removes its tool schemas from context entirely. Claude Code CLI: `~/.config/Claude/Claude.json`; Claude Desktop (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`.
 
 # File Discovery (MANDATORY)
 - NEVER use Glob when Bash is available

--- a/.agents/scripts/mcp-diagnose.sh
+++ b/.agents/scripts/mcp-diagnose.sh
@@ -41,20 +41,50 @@ fi
 # =============================================================================
 
 # Resolve the MCP config file path.
-# Tries the runtime registry first, then falls back to the default location.
+# Tries the runtime registry first (for all detected runtimes), then falls back
+# to platform-aware candidate paths in priority order:
+#   1. Claude Code CLI:     ~/.config/Claude/Claude.json
+#   2. Claude Desktop macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
+#   3. OpenCode:            ~/.config/opencode/opencode.json
 # Echoes the resolved path on stdout.
 # Returns: 0 if a valid config file was found, 1 otherwise.
 _resolve_mcp_config() {
 	local config_file=""
-	if type rt_config_path &>/dev/null; then
-		config_file=$(rt_config_path "opencode" 2>/dev/null) || config_file=""
-	fi
-	if [[ -z "$config_file" || ! -f "$config_file" ]]; then
-		config_file="$HOME/.config/opencode/opencode.json"
+
+	# Try runtime registry for all detected runtimes (preferred — registry-driven)
+	if type rt_detect_configured &>/dev/null; then
+		local _rt_id
+		while IFS= read -r _rt_id; do
+			local _cfg
+			_cfg=$(rt_config_path "$_rt_id" 2>/dev/null) || continue
+			if [[ -n "$_cfg" && -f "$_cfg" ]]; then
+				config_file="$_cfg"
+				break
+			fi
+		done < <(rt_detect_configured 2>/dev/null)
 	fi
 
-	if [[ ! -f "$config_file" ]]; then
-		echo -e "${RED}✗ No MCP config file found at: $config_file${NC}" >&2
+	# Fallback: platform-aware candidate paths in priority order
+	if [[ -z "$config_file" || ! -f "$config_file" ]]; then
+		local _candidates=(
+			"$HOME/.config/Claude/Claude.json"
+			"$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+			"$HOME/.config/opencode/opencode.json"
+		)
+		local _c
+		for _c in "${_candidates[@]}"; do
+			if [[ -f "$_c" ]]; then
+				config_file="$_c"
+				break
+			fi
+		done
+	fi
+
+	if [[ -z "$config_file" || ! -f "$config_file" ]]; then
+		echo -e "${RED}✗ No MCP config file found. Checked:${NC}" >&2
+		echo -e "${RED}  ~/.config/Claude/Claude.json${NC}" >&2
+		echo -e "${RED}  ~/Library/Application Support/Claude/claude_desktop_config.json${NC}" >&2
+		echo -e "${RED}  ~/.config/opencode/opencode.json${NC}" >&2
 		return 1
 	fi
 
@@ -274,10 +304,22 @@ if type rt_detect_configured &>/dev/null; then
 		[[ -n "$_cfg" && -f "$_cfg" ]] && _MCP_DIAG_CONFIGS+=("$_rt_id:$_cfg")
 	done < <(rt_detect_configured)
 fi
-# Fallback if registry not loaded or no configs found
+# Fallback if registry not loaded or no configs found — check platform-aware candidates
 if [[ ${#_MCP_DIAG_CONFIGS[@]} -eq 0 ]]; then
-	_fallback_cfg="$HOME/.config/opencode/opencode.json"
-	[[ -f "$_fallback_cfg" ]] && _MCP_DIAG_CONFIGS+=("opencode:$_fallback_cfg")
+	declare -a _fallback_candidates
+	_fallback_candidates=(
+		"claude-code:$HOME/.config/Claude/Claude.json"
+		"claude-code:$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+		"opencode:$HOME/.config/opencode/opencode.json"
+	)
+	_fc=""
+	_fc_rt=""
+	_fc_path=""
+	for _fc in "${_fallback_candidates[@]}"; do
+		_fc_rt="${_fc%%:*}"
+		_fc_path="${_fc#*:}"
+		[[ -f "$_fc_path" ]] && _MCP_DIAG_CONFIGS+=("${_fc_rt}:${_fc_path}")
+	done
 fi
 
 _mcp_found_in_any=0

--- a/.agents/scripts/runtime-registry.sh
+++ b/.agents/scripts/runtime-registry.sh
@@ -377,7 +377,27 @@ rt_config_path() {
 	local id="$1"
 	local idx
 	idx=$(_rt_index "$id") || return 1
-	_rt_expand_path "${_RT_CONFIG_PATH[$idx]}"
+	local path
+	path=$(_rt_expand_path "${_RT_CONFIG_PATH[$idx]}")
+
+	# Platform-aware override for claude-code: on macOS the Desktop app stores
+	# its config in ~/Library/Application Support/Claude/ rather than ~/.config/Claude/.
+	# Check both locations and return the one that exists (Desktop path takes priority
+	# since it's the primary MCP config on macOS).
+	if [[ "$id" == "claude-code" ]]; then
+		local macos_path="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+		local linux_path="$HOME/.config/Claude/Claude.json"
+		if [[ -f "$macos_path" ]]; then
+			echo "$macos_path"
+			return 0
+		elif [[ -f "$linux_path" ]]; then
+			echo "$linux_path"
+			return 0
+		fi
+		# Neither exists — fall through to return the registry default (may not exist)
+	fi
+
+	echo "$path"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- **build.txt**: Replace stale `~/.config/opencode/opencode.json` path in the Errored MCP Server Guard with runtime-aware guidance covering both Claude Code CLI (`~/.config/Claude/Claude.json`) and Claude Desktop on macOS (`~/Library/Application Support/Claude/claude_desktop_config.json`)
- **mcp-diagnose.sh**: `_resolve_mcp_config()` now iterates all detected runtimes via the registry, then falls back to platform-aware candidate paths (Claude Code CLI → Claude Desktop macOS → OpenCode) instead of hardcoding opencode only
- **mcp-diagnose.sh**: Single-server diagnosis fallback also updated to check Claude Code paths before opencode
- **runtime-registry.sh**: `rt_config_path()` for `claude-code` now resolves the correct platform-aware path at call time (macOS `~/Library/Application Support/Claude/` vs Linux `~/.config/Claude/`)

## Root Cause

The Errored MCP Server Guard (t1682) was added when OpenCode was the primary runtime. After migrating to Claude Code, the config path reference in `build.txt` and the hardcoded fallback in `mcp-diagnose.sh` were not updated. The runtime registry also had the `claude-code` config path pointing to `~/.config/Claude/claude_desktop_config.json` which doesn't exist on macOS (actual path: `~/Library/Application Support/Claude/claude_desktop_config.json`). This caused `mcp-diagnose.sh check-all` to silently fall back to opencode config even when Claude Code was the active runtime.

## Testing

- `shellcheck` passes on both modified scripts (only pre-existing SC1091 info)
- `mcp-diagnose.sh check-all` correctly resolves config via registry-driven path
- `rt_config_path "claude-code"` now returns the macOS Library path when present

## Runtime Testing

- **Risk**: Low — prompt/config path guidance and diagnostic script only, no runtime logic changes
- **Level**: self-assessed

Closes #11096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP configuration file discovery to check multiple platform-specific locations across different runtimes
  * Enhanced config path resolution with improved fallback behavior for macOS and Linux systems
  * Updated MCP server disablement guidance with runtime-specific configuration file paths
  * Improved diagnostic error reporting to display all checked configuration file locations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->