### PR TITLE
docs: add AI inference hosting comparison and provider agents (Fireworks, NEAR AI)

### DIFF
--- a/.agents/tools/deployment/hosting-comparison.md
+++ b/.agents/tools/deployment/hosting-comparison.md
@@ -209,7 +209,7 @@ Edge Functions: ~$0.60/million invocations. Serverless Functions: ~$0.18/GB-hour
 
 ## AI Model Inference Hosting
 
-For AI model inference, fine-tuning, and custom model hosting, see the dedicated infrastructure agents. Managed platforms (Fireworks, Together AI, Cloudflare Workers AI, NEAR AI Cloud) expose OpenAI-compatible APIs — change `base_url` only. Cloud GPU (raw providers) depends on the inference server you deploy: vLLM and TGI expose OpenAI-compatible APIs; other stacks may not.
+For AI model inference, fine-tuning, and custom model hosting, see the dedicated infrastructure agents. Managed platforms (Fireworks, Together AI, Cloudflare Workers AI, NEAR AI Cloud) expose OpenAI-compatible APIs -- change `base_url` only. Cloud GPU (raw providers) depends on the inference server you deploy: vLLM and TGI expose OpenAI-compatible APIs; other stacks may not -- verify your runtime's API compatibility and auth behaviour before integrating.
 
 ### Platform Comparison
 

--- a/.agents/tools/deployment/hosting-comparison.md
+++ b/.agents/tools/deployment/hosting-comparison.md
@@ -204,3 +204,49 @@ Edge Functions: ~$0.60/million invocations. Serverless Functions: ~$0.18/GB-hour
 | Data sovereignty required | Coolify | Cloudron | Fly.io, Daytona, Vercel |
 
 **Self-hosted vs managed rule of thumb**: Coolify/Cloudron wins on cost and control for single-region, always-on workloads. Fly.io/Vercel wins on global distribution, auto-scaling, and zero-ops.
+
+---
+
+## AI Model Inference Hosting
+
+For AI model inference, fine-tuning, and custom model hosting, see the dedicated infrastructure agents. All platforms below are OpenAI SDK compatible (change `base_url` only).
+
+### Platform Comparison
+
+| Platform | Type | Models | Fine-tuning | Custom uploads | Dedicated GPUs | CLI | Docs |
+|----------|------|--------|-------------|----------------|----------------|-----|------|
+| **Fireworks AI** | Managed inference + training | 100+ open-source | SFT, DPO, RFT, Training SDK | Yes (HF, S3, Azure) | A100/H100/H200/B200 | `firectl` | `tools/infrastructure/fireworks.md` |
+| **Together AI** | Managed inference + training | 100+ open-source | SFT, DPO, RL | Yes | H100/H200/B200/GB200 | REST API | `tools/infrastructure/together.md` |
+| **Cloudflare Workers AI** | Edge serverless inference | ~30 open-source | No | No (custom via form) | No (serverless GPUs) | `wrangler` | `tools/infrastructure/cloudflare-ai.md` |
+| **NVIDIA Cloud** | Cloud API + self-host runtime | 100+ (build.nvidia.com) | NeMo (separate) | Self-host any NIM container | Self-host or DGX Cloud | REST API | `tools/infrastructure/nvidia-cloud.md` |
+| **NEAR AI Cloud** | TEE-backed private inference | ~10 (open + closed proxy) | No | No | No | REST API only | `tools/infrastructure/nearai.md` |
+| **Cloud GPU** | Raw GPU providers | Any (self-managed) | Any (self-managed) | N/A | RunPod/Vast.ai/Lambda | Provider CLIs | `tools/infrastructure/cloud-gpu.md` |
+
+### Pricing Comparison (common models, $/M tokens, March 2026)
+
+| Model | Fireworks | Together AI | Cloudflare | NEAR AI | Notes |
+|-------|-----------|-------------|------------|---------|-------|
+| GPT-OSS 120B (in/out) | $0.15 / $0.60 | $0.15 / $0.60 | $0.35 / $0.75 | $0.15 / $0.55 | CF ~2x more expensive |
+| DeepSeek V3 (in/out) | $0.56 / $1.68 | $0.60 / $1.70 | N/A | $1.05 / $3.10 | NEAR ~2x (TEE premium) |
+| Llama 3.3 70B (in/out) | $0.90 / $0.90 | $0.88 / $0.88 | $0.29 / $2.25 | N/A | CF cheap input, expensive output |
+| Qwen3 30B A3B (in/out) | $0.15 / $0.60 | $0.15 / $1.50 | $0.05 / $0.34 | $0.15 / $0.55 | CF cheapest for this model |
+| GLM-5 (in/out) | $1.00 / $3.20 | $1.00 / $3.20 | N/A | $0.85 / $3.30 | Parity across platforms |
+| Kimi K2.5 (in/out) | $0.60 / $3.00 | $0.50 / $2.80 | $0.60 / $3.00 | N/A | Together slightly cheaper |
+| Batch discount | 50% off | 50% off | N/A | N/A | Fireworks and Together both offer batch |
+
+NVIDIA Cloud (build.nvidia.com): Free cloud endpoints for prototyping (1000 API credits). Production via self-hosted NIM containers (free with NVIDIA AI Enterprise license or DGX). No published per-token serverless pricing — the cloud API is for prototyping, production runs on your own GPUs via NIM.
+
+### Decision Guide
+
+| Requirement | Recommended | Alternative |
+|-------------|-------------|-------------|
+| Production inference, lowest cost | Fireworks or Together AI | Cloudflare (small models) |
+| Fine-tuning (SFT/DPO/RFT) | Fireworks | Together AI |
+| Custom model training loops | Fireworks (Training SDK) | Cloud GPU (full control) |
+| Edge/global inference, Cloudflare stack | Cloudflare Workers AI | Fireworks (multi-region) |
+| Privacy-critical (TEE, regulated data) | NEAR AI Cloud | Self-hosted NIM in TEE |
+| Self-hosted optimized inference | NVIDIA Cloud (NIM) | vLLM/TGI on Cloud GPU |
+| Anonymized closed-model access | NEAR AI Cloud | Direct provider APIs |
+| Batch processing at scale | Fireworks or Together AI (50% off) | Cloud GPU |
+| GPU clusters for training | Together AI (GPU Clusters) | Cloud GPU providers |
+| Cheapest experimentation | Cloudflare (10K free neurons/day) | NVIDIA Cloud (free credits) |

--- a/.agents/tools/deployment/hosting-comparison.md
+++ b/.agents/tools/deployment/hosting-comparison.md
@@ -209,7 +209,7 @@ Edge Functions: ~$0.60/million invocations. Serverless Functions: ~$0.18/GB-hour
 
 ## AI Model Inference Hosting
 
-For AI model inference, fine-tuning, and custom model hosting, see the dedicated infrastructure agents. All platforms below are OpenAI SDK compatible (change `base_url` only).
+For AI model inference, fine-tuning, and custom model hosting, see the dedicated infrastructure agents. Managed platforms (Fireworks, Together AI, Cloudflare Workers AI, NEAR AI Cloud) expose OpenAI-compatible APIs — change `base_url` only. Cloud GPU (raw providers) depends on the inference server you deploy: vLLM and TGI expose OpenAI-compatible APIs; other stacks may not.
 
 ### Platform Comparison
 

--- a/.agents/tools/infrastructure/cloud-gpu.md
+++ b/.agents/tools/infrastructure/cloud-gpu.md
@@ -140,6 +140,8 @@ Never expose model APIs without auth -- use SSH tunnels or VPN. Store keys: `aid
 
 ## See Also
 
+- `tools/infrastructure/fireworks.md` -- managed inference, fine-tuning, and model hosting (Fireworks AI)
+- `tools/infrastructure/nearai.md` -- TEE-backed private inference (NEAR AI Cloud)
 - `tools/voice/speech-to-speech.md` -- voice pipeline with cloud GPU
 - `services/hosting/hetzner.md` -- dedicated servers (CPU-only alternative)
 - `tools/ai-orchestration/overview.md` -- AI orchestration for model serving

--- a/.agents/tools/infrastructure/cloudflare-ai.md
+++ b/.agents/tools/infrastructure/cloudflare-ai.md
@@ -1,0 +1,85 @@
+---
+description: "Cloudflare Workers AI — edge serverless inference, ~30 open-source models, global PoPs, wrangler CLI"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: false
+---
+
+# Cloudflare Workers AI
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **API base**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/{model}` (REST) | Workers binding (in-Worker)
+- **Auth**: Cloudflare API token with `Workers AI` permission | `Authorization: Bearer <token>` header
+- **Creds**: `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` env vars
+- **CLI**: `wrangler` — `npm install -g wrangler` | `wrangler ai models list`
+- **Docs**: [Quickstart](https://developers.cloudflare.com/workers-ai/get-started/) | [Models](https://developers.cloudflare.com/workers-ai/models/) | [Pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)
+- **Dashboard**: [dash.cloudflare.com](https://dash.cloudflare.com) → AI → Workers AI
+
+<!-- AI-CONTEXT-END -->
+
+Edge serverless inference on Cloudflare's global network (300+ PoPs). Models run close to users with no cold starts. OpenAI-compatible REST API available; native Workers binding for in-Worker use.
+
+**Best for**: edge inference integrated with Cloudflare Workers/Pages, low-latency global inference for small-to-mid models, Cloudflare-stack applications.
+**Not for**: fine-tuning, custom model uploads (custom models via waitlist only), large models (>70B), privacy-critical TEE workloads (see `nearai.md`), batch inference.
+
+## Pricing (March 2026)
+
+- **Free tier**: 10,000 neurons/day (shared across all models)
+- **Paid**: $0.011 per 1,000 neurons (neurons = compute units, not tokens — varies by model)
+- No per-token pricing published; see [pricing docs](https://developers.cloudflare.com/workers-ai/platform/pricing/) for neuron costs per model
+
+## Models
+
+~30 open-source models across text generation, embeddings, image classification, speech recognition, and image generation. Key models: Llama 3.3 70B, Mistral 7B, Qwen 2.5, Gemma, Whisper, FLUX. Full catalog: https://developers.cloudflare.com/workers-ai/models/
+
+## Usage
+
+### REST API
+
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+### Workers Binding (in-Worker)
+
+```javascript
+// wrangler.toml: [ai] binding = "AI"
+export default {
+  async fetch(request, env) {
+    const response = await env.AI.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    return Response.json(response);
+  },
+};
+```
+
+### OpenAI-Compatible Endpoint
+
+Cloudflare provides an OpenAI-compatible endpoint for supported models. See [OpenAI compat docs](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) for supported models and limitations — not all Workers AI models support this interface.
+
+## Security
+
+- Store credentials: `aidevops secret set CLOUDFLARE_API_TOKEN` and `aidevops secret set CLOUDFLARE_ACCOUNT_ID`
+- Never expose tokens in logs or output
+- Use scoped API tokens (Workers AI permission only) for CI/CD
+
+## See Also
+
+- `tools/infrastructure/fireworks.md` — managed inference + fine-tuning (more models, fine-tuning support)
+- `tools/infrastructure/nearai.md` — TEE-backed private inference
+- `tools/infrastructure/cloud-gpu.md` — raw GPU providers for self-managed inference
+- `tools/deployment/hosting-comparison.md` — platform comparison including inference hosting

--- a/.agents/tools/infrastructure/cloudflare-ai.md
+++ b/.agents/tools/infrastructure/cloudflare-ai.md
@@ -1,5 +1,5 @@
 ---
-description: "Cloudflare Workers AI — edge serverless inference, ~30 open-source models, global PoPs, wrangler CLI"
+description: "Cloudflare Workers AI — edge serverless inference on Cloudflare's global GPU network, pay-per-neuron pricing, Wrangler CLI"
 mode: subagent
 tools:
   read: true
@@ -18,68 +18,155 @@ tools:
 
 ## Quick Reference
 
-- **API base**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/{model}` (REST) | Workers binding (in-Worker)
-- **Auth**: Cloudflare API token with `Workers AI` permission | `Authorization: Bearer <token>` header
-- **Creds**: `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` env vars
-- **CLI**: `wrangler` — `npm install -g wrangler` | `wrangler ai models list`
-- **Docs**: [Quickstart](https://developers.cloudflare.com/workers-ai/get-started/) | [Models](https://developers.cloudflare.com/workers-ai/models/) | [Pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)
-- **Dashboard**: [dash.cloudflare.com](https://dash.cloudflare.com) → AI → Workers AI
+- **CLI**: `wrangler` — `npm install -g wrangler` | `wrangler ai models` (list models)
+- **API base**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/{model}`
+- **Auth**: Cloudflare API token or `wrangler login`
+- **Creds**: `CLOUDFLARE_API_TOKEN` env var | `CLOUDFLARE_ACCOUNT_ID`
+- **Docs**: [developers.cloudflare.com/workers-ai](https://developers.cloudflare.com/workers-ai/) | [Pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/) | [Models](https://developers.cloudflare.com/workers-ai/models/)
+- **Dashboard**: [dash.cloudflare.com](https://dash.cloudflare.com/?to=/:account/ai/workers-ai)
+- **Free tier**: 10,000 Neurons/day (both Free and Paid Workers plans)
 
 <!-- AI-CONTEXT-END -->
 
-Edge serverless inference on Cloudflare's global network (300+ PoPs). Models run close to users with no cold starts. OpenAI-compatible REST API available; native Workers binding for in-Worker use.
+Serverless AI inference on Cloudflare's global GPU network. Models run at the edge, close to users. Part of the Cloudflare developer platform (Workers, Pages, KV, D1, R2, Vectorize, AI Gateway).
 
-**Best for**: edge inference integrated with Cloudflare Workers/Pages, low-latency global inference for small-to-mid models, Cloudflare-stack applications.
-**Not for**: fine-tuning, custom model uploads (custom models via waitlist only), large models (>70B), privacy-critical TEE workloads (see `nearai.md`), batch inference.
+**Best for**: edge inference with low latency, Cloudflare-native apps (Workers/Pages), small-to-medium models, free experimentation (10K neurons/day), integrated AI Gateway (caching, rate limiting, fallback).
+**Not for**: fine-tuning, custom model uploads (requires custom form), large model hosting (no DeepSeek V3, no GLM-5), dedicated GPUs, batch inference, self-hosted.
 
 ## Pricing (March 2026)
 
-- **Free tier**: 10,000 neurons/day (shared across all models)
-- **Paid**: $0.011 per 1,000 neurons (neurons = compute units, not tokens — varies by model)
-- No per-token pricing published; see [pricing docs](https://developers.cloudflare.com/workers-ai/platform/pricing/) for neuron costs per model
+Billed in Neurons ($0.011 per 1,000 Neurons). Free allocation: 10,000 Neurons/day on both Free and Paid Workers plans.
 
-## Models
+### LLM Pricing (selected models)
 
-~30 open-source models across text generation, embeddings, image classification, speech recognition, and image generation. Key models: Llama 3.3 70B, Mistral 7B, Qwen 2.5, Gemma, Whisper, FLUX. Full catalog: https://developers.cloudflare.com/workers-ai/models/
+| Model | $/M input | $/M output |
+|-------|-----------|------------|
+| Llama 3.2 1B | $0.027 | $0.201 |
+| Llama 3.2 3B | $0.051 | $0.335 |
+| Llama 3.1 8B FP8 Fast | $0.045 | $0.384 |
+| Llama 3.3 70B FP8 Fast | $0.293 | $2.253 |
+| Llama 4 Scout 17B | $0.270 | $0.850 |
+| DeepSeek R1 Distill Qwen 32B | $0.497 | $4.881 |
+| Qwen3 30B A3B FP8 | $0.051 | $0.335 |
+| GPT-OSS 120B | $0.350 | $0.750 |
+| GPT-OSS 20B | $0.200 | $0.300 |
+| Kimi K2.5 | $0.600 | $3.000 |
+| Nemotron 3 120B A12B | $0.500 | $1.500 |
+| Mistral 7B | $0.110 | $0.190 |
+| Mistral Small 3.1 24B | $0.351 | $0.555 |
+
+### Other Modalities
+
+| Type | Model | Price |
+|------|-------|-------|
+| Embeddings | BGE Small/Base/Large | $0.008-$0.204/M tokens |
+| Image | FLUX.1 Schnell | $0.00035/step |
+| Image | FLUX.2 Klein 4B | $0.000059/input tile |
+| Audio STT | Whisper Large v3 Turbo | $0.0005/min |
+| Audio TTS | MeloTTS | $0.0002/min |
+| Audio TTS | Deepgram Aura 2 | $0.030/1K chars |
+| Reranking | BGE Reranker Base | $0.003/M tokens |
+
+### Price Comparison vs Fireworks/Together
+
+Cloudflare is generally **more expensive for large models** but **competitive or cheaper for small models**:
+
+| Model | Cloudflare | Fireworks | Together |
+|-------|------------|-----------|---------|
+| GPT-OSS 120B (in/out) | $0.35/$0.75 | $0.15/$0.60 | $0.15/$0.60 |
+| Llama 3.3 70B (in/out) | $0.29/$2.25 | $0.90/$0.90 | $0.88/$0.88 |
+| Qwen3 30B A3B (in/out) | $0.05/$0.34 | $0.15/$0.60 | $0.15/$1.50 |
+| Mistral 7B (in/out) | $0.11/$0.19 | $0.20/$0.20 | $0.20/$0.20 |
+
+Pattern: CF has cheap input but expensive output for large models. Best value for small models (<16B).
 
 ## Usage
+
+### From Workers (recommended)
+
+```javascript
+// In a Cloudflare Worker
+export default {
+  async fetch(request, env) {
+    const response = await env.AI.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+      messages: [{ role: "user", content: "Hello" }]
+    });
+    return Response.json(response);
+  }
+};
+```
 
 ### REST API
 
 ```bash
-curl "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast" \
+curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  -H "Content-Type: application/json" \
   -d '{"messages": [{"role": "user", "content": "Hello"}]}'
-```
-
-### Workers Binding (in-Worker)
-
-```javascript
-// wrangler.toml: [ai] binding = "AI"
-export default {
-  async fetch(request, env) {
-    const response = await env.AI.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
-      messages: [{ role: "user", content: "Hello" }],
-    });
-    return Response.json(response);
-  },
-};
 ```
 
 ### OpenAI-Compatible Endpoint
 
-Cloudflare provides an OpenAI-compatible endpoint for supported models. See [OpenAI compat docs](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) for supported models and limitations — not all Workers AI models support this interface.
+Cloudflare provides an OpenAI-compatible endpoint for supported models. See [OpenAI compat docs](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) for supported models and limitations.
+
+## Capabilities and Limitations
+
+### Available
+
+- ~30 LLM models (Llama, Qwen, Mistral, DeepSeek distills, GPT-OSS, Gemma)
+- Image generation (FLUX, Leonardo, Stable Diffusion)
+- Speech-to-text (Whisper, Deepgram Nova)
+- Text-to-speech (MeloTTS, Deepgram Aura)
+- Embeddings (BGE family, Qwen3)
+- Reranking (BGE Reranker)
+- Classification, translation, object detection
+- AI Gateway (caching, rate limiting, retries, model fallback, analytics)
+- Vectorize (vector database for RAG)
+- Streaming responses
+
+### Not available
+
+- Fine-tuning -- use Fireworks or Together
+- Custom model uploads -- requires [custom requirements form](https://forms.gle/axnnpGDb6xrmR31T6)
+- Dedicated GPUs -- serverless only
+- Batch inference -- no batch API
+- Large frontier models (DeepSeek V3 full, GLM-5) -- only distilled versions
+- Self-hosted option -- Cloudflare network only
+- Anthropic SDK compatibility -- Cloudflare API or OpenAI-compat only
+
+### Cloudflare Platform Integration
+
+Workers AI is most valuable when combined with the Cloudflare platform:
+
+- **AI Gateway**: Caching (reduce costs), rate limiting, request retries, model fallback, observability
+- **Vectorize**: Vector database for RAG pipelines
+- **Workers**: Serverless compute for pre/post-processing
+- **KV/D1/R2**: Storage for context, conversation history, assets
+- **Pages**: Frontend hosting for AI apps
+
+## When to Use Cloudflare Workers AI
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Cloudflare-native app needing AI | Strong fit -- native integration |
+| Edge inference, low latency globally | Strong fit -- runs on CF network |
+| Small model inference (<16B) | Good value -- competitive pricing |
+| Free experimentation | Good fit -- 10K neurons/day free |
+| Large model production inference | Use Fireworks or Together instead |
+| Fine-tuning or custom models | Use Fireworks or Together instead |
+| Batch processing at scale | Use Fireworks or Together instead |
+| Privacy-critical workloads | Use NEAR AI instead |
 
 ## Security
 
 - Store credentials: `aidevops secret set CLOUDFLARE_API_TOKEN` and `aidevops secret set CLOUDFLARE_ACCOUNT_ID`
 - Never expose tokens in logs or output
-- Use scoped API tokens (Workers AI permission only) for CI/CD
+- Use Workers bindings (`env.AI`) instead of raw API calls when possible
+- AI Gateway provides rate limiting and abuse protection
 
 ## See Also
 
-- `tools/infrastructure/fireworks.md` — managed inference + fine-tuning (more models, fine-tuning support)
-- `tools/infrastructure/nearai.md` — TEE-backed private inference
-- `tools/infrastructure/cloud-gpu.md` — raw GPU providers for self-managed inference
-- `tools/deployment/hosting-comparison.md` — platform comparison including inference hosting
+- `tools/infrastructure/fireworks.md` -- managed inference + fine-tuning (more models, cheaper for large)
+- `tools/infrastructure/together.md` -- managed inference + GPU clusters
+- `tools/infrastructure/nearai.md` -- TEE-backed private inference
+- `tools/deployment/hosting-comparison.md` -- full platform comparison
+- Cloudflare platform skill: load with `/skill cloudflare-platform`

--- a/.agents/tools/infrastructure/fireworks.md
+++ b/.agents/tools/infrastructure/fireworks.md
@@ -89,6 +89,7 @@ curl https://api.fireworks.ai/inference/v1/chat/completions \
   -d '{"model": "accounts/fireworks/models/deepseek-v3p1", "messages": [{"role": "user", "content": "Hello"}]}'
 
 # OpenAI SDK (Python) — just change base_url
+import os
 from openai import OpenAI
 client = OpenAI(api_key=os.environ["FIREWORKS_API_KEY"], base_url="https://api.fireworks.ai/inference/v1")
 response = client.chat.completions.create(model="accounts/fireworks/models/deepseek-v3p1", messages=[...])
@@ -138,13 +139,13 @@ curl https://api.fireworks.ai/inference/v1/chat/completions \
 # Upload from local files
 firectl model create <MODEL_ID> /path/to/files/
 
-# Upload from S3 (use env vars or IAM role — never pass credentials as CLI flags)
+# Upload from S3 (use env vars or IAM role -- never pass credentials as CLI flags)
 # Option A: environment variables (preferred)
 export AWS_ACCESS_KEY_ID="<KEY>"
 export AWS_SECRET_ACCESS_KEY="<SECRET>"
 firectl model create <MODEL_ID> s3://<BUCKET>/<PATH>/
-# Option B: IAM role (recommended for EC2/ECS — no credentials needed)
-# Attach an IAM role with S3 read access to the instance; firectl picks it up automatically
+# Option B: IAM role/profile (recommended for EC2/ECS -- no credentials needed)
+AWS_PROFILE=<PROFILE> firectl model create <MODEL_ID> s3://<BUCKET>/<PATH>/
 
 # Upload LoRA adapter
 firectl model create <MODEL_ID> /path/to/adapter/ \

--- a/.agents/tools/infrastructure/fireworks.md
+++ b/.agents/tools/infrastructure/fireworks.md
@@ -1,0 +1,278 @@
+---
+description: "Fireworks AI — fast inference, dedicated GPU deployments, fine-tuning (SFT/DPO/RFT), custom model hosting for open-source models"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: false
+---
+
+# Fireworks AI
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **CLI**: `firectl` — `brew tap fw-ai/firectl && brew install firectl` or [manual install](https://docs.fireworks.ai/tools-sdks/firectl/firectl)
+- **Auth**: `firectl signin` (browser OAuth) | `firectl set-api-key <key>` (headless) | `firectl whoami`
+- **Creds**: `~/.fireworks/auth.ini` (firectl) | `FIREWORKS_API_KEY` env var (API)
+- **API base**: `https://api.fireworks.ai/inference/v1` (OpenAI-compat) | `https://api.fireworks.ai/inference` (Anthropic-compat)
+- **Docs**: [Getting started](https://docs.fireworks.ai/getting-started/introduction) | [API ref](https://docs.fireworks.ai/api-reference/introduction) | [firectl](https://docs.fireworks.ai/tools-sdks/firectl/firectl) | [Pricing](https://fireworks.ai/pricing)
+- **Resource naming**: `accounts/{account_id}/models/{name}`, `accounts/{account_id}/deployments/{id}`
+
+<!-- AI-CONTEXT-END -->
+
+Fast inference and fine-tuning platform for open-source models. OpenAI/Anthropic SDK compatible. 100+ models serverless, or deploy on dedicated GPUs with autoscaling.
+
+**Best for**: production inference (serverless or dedicated), custom model training (SFT/DPO/RFT), LoRA deployment, batch inference at scale.
+**Not for**: closed-model hosting (Claude/GPT/Gemini), privacy-critical workloads requiring TEE (see `nearai.md`), static site hosting.
+
+## Pricing (March 2026)
+
+### Serverless (pay-per-token)
+
+| Tier | $/1M tokens |
+|------|-------------|
+| <4B params | $0.10 |
+| 4-16B params | $0.20 |
+| >16B params | $0.90 |
+| MoE 0-56B (Mixtral 8x7B) | $0.50 |
+| MoE 56-176B (DBRX, 8x22B) | $1.20 |
+| DeepSeek V3 family | $0.56 in / $1.68 out |
+| Kimi K2 Instruct | $0.60 in / $2.50 out |
+| GPT-OSS 120B | $0.15 in / $0.60 out |
+| GPT-OSS 20B | $0.07 in / $0.30 out |
+| GLM-5 | $1.00 in / $3.20 out |
+
+Cached input: 50% of input price. Batch inference: 50% of serverless price.
+
+### Dedicated GPUs (pay-per-second)
+
+| GPU | $/hour |
+|-----|--------|
+| A100 80GB | $2.90 |
+| H100 80GB | $6.00 |
+| H200 141GB | $6.00 |
+| B200 180GB | $9.00 |
+
+### Fine-tuning (per 1M training tokens)
+
+| Base model size | SFT | DPO |
+|----------------|-----|-----|
+| Up to 16B | $0.50 | $1.00 |
+| 16-80B | $3.00 | $6.00 |
+| 80-300B | $6.00 | $12.00 |
+| >300B | $10.00 | $20.00 |
+
+RFT: same as on-demand GPU rates. Embeddings: $0.008-$0.10/M tokens.
+
+### Cost comparison
+
+Fireworks serverless is competitive with direct API providers. Dedicated GPUs become cheaper than serverless at sustained high utilization. Batch inference (50% off) is the cheapest option for non-latency-sensitive workloads.
+
+## Models
+
+100+ models across text, vision, audio, image, and embeddings. Key architectures: DeepSeek V1-V3, Qwen family, Llama 1-4, Mistral/Mixtral, Gemma, Phi, GPT-OSS. Full catalog: https://fireworks.ai/models
+
+## Serverless Inference
+
+```bash
+# curl
+curl https://api.fireworks.ai/inference/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $FIREWORKS_API_KEY" \
+  -d '{"model": "accounts/fireworks/models/deepseek-v3p1", "messages": [{"role": "user", "content": "Hello"}]}'
+
+# OpenAI SDK (Python) — just change base_url
+from openai import OpenAI
+client = OpenAI(api_key=os.environ["FIREWORKS_API_KEY"], base_url="https://api.fireworks.ai/inference/v1")
+response = client.chat.completions.create(model="accounts/fireworks/models/deepseek-v3p1", messages=[...])
+```
+
+Features: streaming, function calling, structured outputs (JSON schema), reasoning, vision, speech-to-text, embeddings, reranking.
+
+Rate limits: 10 RPM without payment method, up to 6,000 RPM with payment method. Serverless models may be deprecated with 2+ weeks notice.
+
+## Dedicated Deployments
+
+```bash
+# Create deployment with shape (fast/throughput/cost)
+firectl deployment create accounts/fireworks/models/gpt-oss-120b \
+  --deployment-shape fast \
+  --min-replica-count 0 --max-replica-count 4 \
+  --scale-up-window 30s --scale-down-window 5m --scale-to-zero-window 5m \
+  --wait
+
+# Autoscale by RPS or concurrent requests
+firectl deployment create accounts/fireworks/models/gpt-oss-120b \
+  --deployment-shape fast --max-replica-count 4 \
+  --load-targets requests_per_second=5 --wait
+
+# Management
+firectl deployment list
+firectl deployment get <DEPLOYMENT_ID>
+firectl deployment scale <DEPLOYMENT_ID> --replica-count 2
+firectl deployment delete <DEPLOYMENT_ID>
+firectl deployment undelete <DEPLOYMENT_ID>
+
+# Query deployment (same API, different model string)
+curl https://api.fireworks.ai/inference/v1/chat/completions \
+  -H "Authorization: Bearer $FIREWORKS_API_KEY" \
+  -d '{"model": "accounts/<ACCOUNT_ID>/deployments/<DEPLOYMENT_ID>", "messages": [...]}'
+```
+
+**Deployment shapes**: `fast` (low latency), `throughput` (high volume), `cost` (cheapest). List available: `firectl deployment-shape-version list --base-model <model-id>`.
+
+**GPU types**: `--accelerator-type NVIDIA_A100_80GB|NVIDIA_H100_80GB|NVIDIA_H200_141GB`. Multi-GPU: `--accelerator-count 2`.
+
+**Autoscaling**: min/max replicas, scale-up/down/to-zero windows, load targets. Deployments scale to zero after 1h idle by default; auto-deleted after 7 days of no traffic if min replicas = 0.
+
+## Custom Models
+
+```bash
+# Upload from local files
+firectl model create <MODEL_ID> /path/to/files/
+
+# Upload from S3
+firectl model create <MODEL_ID> s3://<BUCKET>/<PATH>/ \
+  --aws-access-key-id <KEY> --aws-secret-access-key <SECRET>
+
+# Upload LoRA adapter
+firectl model create <MODEL_ID> /path/to/adapter/ \
+  --base-model "accounts/fireworks/models/<BASE_MODEL_ID>"
+
+# Verify upload
+firectl model get accounts/<ACCOUNT_ID>/models/<MODEL_NAME>  # State: READY
+
+# Deploy custom model
+firectl deployment create accounts/<ACCOUNT_ID>/models/<MODEL_NAME> --wait
+
+# Publish/unpublish
+firectl model update <MODEL_ID> --public
+firectl model update <MODEL_ID> --public=false
+
+# Model management
+firectl model list
+firectl model get <MODEL_ID>
+firectl model delete <MODEL_ID>
+firectl model prepare <MODEL_ID>  # prepare for different precisions
+```
+
+Supported architectures: DeepSeek V1-V3, Qwen/Qwen2/Qwen2.5/Qwen3, Llama 1-4, Mistral/Mixtral, Gemma, Phi, GPT-OSS, and more. Required files: `config.json`, weights (`.safetensors`/`.bin`), tokenizer files.
+
+LoRA adapters: rank 4-64, target modules `q_proj`, `k_proj`, `v_proj`, `o_proj`, `up_proj`, `down_proj`, `gate_proj`. Customize defaults via `fireworks.json`.
+
+## Fine-Tuning
+
+### Supervised Fine-Tuning (SFT)
+
+```bash
+# Upload dataset
+firectl dataset create <DATASET_ID> /path/to/data.jsonl
+
+# Launch SFT job
+firectl supervised-fine-tuning-job create \
+  --model accounts/fireworks/models/<BASE_MODEL> \
+  --dataset accounts/<ACCOUNT_ID>/datasets/<DATASET_ID>
+
+# Monitor
+firectl supervised-fine-tuning-job get <JOB_ID>
+firectl supervised-fine-tuning-job list
+
+# Cancel/delete
+firectl supervised-fine-tuning-job cancel <JOB_ID>
+firectl supervised-fine-tuning-job delete <JOB_ID>
+```
+
+### Direct Preference Optimization (DPO)
+
+```bash
+firectl dpo-job create --model <MODEL> --dataset <DATASET_ID>
+firectl dpo-job get <JOB_ID>
+firectl dpo-job list
+firectl dpo-job cancel <JOB_ID>
+firectl dpo-job resume <JOB_ID>
+```
+
+### Reinforcement Fine-Tuning (RFT)
+
+```bash
+firectl reinforcement-fine-tuning-job create --model <MODEL> --evaluator <EVALUATOR_ID>
+firectl reinforcement-fine-tuning-job get <JOB_ID>
+firectl reinforcement-fine-tuning-job list
+firectl reinforcement-fine-tuning-job resume <JOB_ID>
+```
+
+RFT uses evaluator/reward functions to iteratively improve model outputs. Best for: small datasets (<1000 examples), no ground-truth labels, multi-step reasoning tasks.
+
+### Training SDK
+
+For custom training loops with full Python control over objectives. Install: `pip install --pre fireworks-ai`. Supports custom loss functions, full-parameter tuning, inference-in-the-loop evaluation, per-step control.
+
+### When to use which
+
+- **SFT**: 1000+ labeled examples, straightforward tasks (classification, extraction)
+- **DPO**: Preference data (chosen/rejected pairs), alignment tuning
+- **RFT**: <1000 examples, no ground truth, verifiable tasks, multi-step reasoning
+- **Training SDK**: Custom loss functions, full-parameter tuning, research
+
+## Batch Inference
+
+```bash
+firectl batch-inference-job create --model <MODEL> --input-file /path/to/input.jsonl
+firectl batch-inference-job get <JOB_ID>
+firectl batch-inference-job list
+firectl batch-inference-job delete <JOB_ID>
+```
+
+50% cheaper than serverless. Async processing for non-latency-sensitive workloads.
+
+## Datasets
+
+```bash
+firectl dataset create <DATASET_ID> /path/to/data.jsonl
+firectl dataset get <DATASET_ID>
+firectl dataset list
+firectl dataset download <DATASET_ID> /local/path/
+firectl dataset update <DATASET_ID> --display-name "New Name"
+firectl dataset delete <DATASET_ID>
+```
+
+## Account Management
+
+```bash
+firectl whoami
+firectl account get
+firectl account list
+firectl api-key create
+firectl api-key list
+firectl api-key delete <KEY_ID>
+firectl billing export-metrics
+firectl billing list-invoices
+firectl user list
+firectl user create --email <EMAIL>
+firectl secret create --name <NAME> --value <VALUE>
+firectl secret list
+firectl quota list
+firectl quota get <QUOTA_ID>
+```
+
+## Security
+
+- Store API key: `aidevops secret set FIREWORKS_API_KEY`
+- Never expose keys in logs or output
+- firectl stores auth at `~/.fireworks/auth.ini` — ensure 600 permissions
+- Use service accounts for CI/CD: `firectl user create` + `firectl api-key create`
+- Secrets management: `firectl secret create` for values used in evaluators/training
+
+## See Also
+
+- `tools/infrastructure/cloud-gpu.md` — raw GPU providers (RunPod, Vast.ai, Lambda)
+- `tools/infrastructure/nearai.md` — TEE-backed private inference
+- `tools/local-models/local-models.md` — local model serving
+- `tools/deployment/hosting-comparison.md` — app hosting platforms

--- a/.agents/tools/infrastructure/fireworks.md
+++ b/.agents/tools/infrastructure/fireworks.md
@@ -138,9 +138,13 @@ curl https://api.fireworks.ai/inference/v1/chat/completions \
 # Upload from local files
 firectl model create <MODEL_ID> /path/to/files/
 
-# Upload from S3
-firectl model create <MODEL_ID> s3://<BUCKET>/<PATH>/ \
-  --aws-access-key-id <KEY> --aws-secret-access-key <SECRET>
+# Upload from S3 (use env vars or IAM role — never pass credentials as CLI flags)
+# Option A: environment variables (preferred)
+export AWS_ACCESS_KEY_ID="<KEY>"
+export AWS_SECRET_ACCESS_KEY="<SECRET>"
+firectl model create <MODEL_ID> s3://<BUCKET>/<PATH>/
+# Option B: IAM role (recommended for EC2/ECS — no credentials needed)
+# Attach an IAM role with S3 read access to the instance; firectl picks it up automatically
 
 # Upload LoRA adapter
 firectl model create <MODEL_ID> /path/to/adapter/ \

--- a/.agents/tools/infrastructure/nearai.md
+++ b/.agents/tools/infrastructure/nearai.md
@@ -78,6 +78,7 @@ curl https://cloud-api.near.ai/v1/chat/completions \
 ```
 
 ```python
+import os
 import openai
 client = openai.OpenAI(base_url="https://cloud-api.near.ai/v1", api_key=os.environ["NEARAI_API_KEY"])
 response = client.chat.completions.create(
@@ -107,7 +108,7 @@ Use HuggingFace-style IDs: `deepseek-ai/DeepSeek-V3.1`, `openai/gpt-oss-120b`, `
 
 - **TEE isolation**: Open-source models run inside hardware-enforced Trusted Execution Environments (Intel TDX / AMD SEV-SNP)
 - **Cryptographic attestation**: Every inference generates verifiable proof that code and data were not tampered with
-- **No data access** (TEE-protected open-source models only): For open-source models running in TEEs, model providers, cloud providers, and NEAR AI cannot access prompts or responses. Closed-model proxy requests (Claude, GPT-5.2, Gemini) are anonymized but still forwarded to the upstream provider — the upstream provider processes the request and the "no data access" guarantee does not apply.
+- **No data access (TEE-protected open-source models only)**: For open-source models running in TEEs, model providers, cloud providers, and NEAR AI cannot access prompts or responses. Closed-model proxy requests (Claude, GPT-5.2, Gemini) are anonymized but still forwarded to the upstream provider -- the upstream provider processes the request content and the "no data access" guarantee does not apply (see below).
 - **TLS in enclave**: Direct completions endpoints terminate TLS inside the TEE — no intermediate can intercept
 - **E2EE chat**: End-to-end encrypted chat completions available (see [guide](https://docs.near.ai/cloud/guides/e2ee-chat-completions))
 - **Verification**: Clients can verify attestation reports. See [verification docs](https://docs.near.ai/cloud/verification)
@@ -115,7 +116,7 @@ Use HuggingFace-style IDs: `deepseek-ai/DeepSeek-V3.1`, `openai/gpt-oss-120b`, `
 ### Anonymized vs TEE-protected
 
 - **TEE-protected** (open-source models): Full hardware isolation, cryptographic attestation, no data access by anyone
-- **Anonymized** (Claude, GPT-5.2, Gemini): Requests proxied through NEAR AI with identifying information stripped. Provider sees the request but not your identity. Weaker guarantee than TEE.
+- **Anonymized** (Claude, GPT-5.2, Gemini): Requests proxied through NEAR AI with identifying information stripped. The upstream provider sees the full request content but not your identity. This is a weaker guarantee than TEE -- the provider can read prompts and responses, only your identity is hidden.
 
 ## Capabilities and Limitations
 

--- a/.agents/tools/infrastructure/nearai.md
+++ b/.agents/tools/infrastructure/nearai.md
@@ -107,7 +107,7 @@ Use HuggingFace-style IDs: `deepseek-ai/DeepSeek-V3.1`, `openai/gpt-oss-120b`, `
 
 - **TEE isolation**: Open-source models run inside hardware-enforced Trusted Execution Environments (Intel TDX / AMD SEV-SNP)
 - **Cryptographic attestation**: Every inference generates verifiable proof that code and data were not tampered with
-- **No data access**: Model providers, cloud providers, and NEAR AI cannot access prompts or responses
+- **No data access** (TEE-protected open-source models only): For open-source models running in TEEs, model providers, cloud providers, and NEAR AI cannot access prompts or responses. Closed-model proxy requests (Claude, GPT-5.2, Gemini) are anonymized but still forwarded to the upstream provider — the upstream provider processes the request and the "no data access" guarantee does not apply.
 - **TLS in enclave**: Direct completions endpoints terminate TLS inside the TEE — no intermediate can intercept
 - **E2EE chat**: End-to-end encrypted chat completions available (see [guide](https://docs.near.ai/cloud/guides/e2ee-chat-completions))
 - **Verification**: Clients can verify attestation reports. See [verification docs](https://docs.near.ai/cloud/verification)

--- a/.agents/tools/infrastructure/nearai.md
+++ b/.agents/tools/infrastructure/nearai.md
@@ -1,0 +1,170 @@
+---
+description: "NEAR AI Cloud — TEE-backed private inference, cryptographic verification, OpenAI-compatible API for privacy-sensitive workloads"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: false
+---
+
+# NEAR AI Cloud
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **API base**: `https://cloud-api.near.ai/v1` (gateway, OpenAI-compat) | `https://{slug}.completions.near.ai/v1` (direct to TEE)
+- **Auth**: API key from [cloud.near.ai/dashboard/keys](https://cloud.near.ai/dashboard/keys)
+- **Creds**: `NEARAI_API_KEY` env var | `Authorization: Bearer <key>` header
+- **Docs**: [Quickstart](https://docs.near.ai/cloud/quickstart) | [Models](https://docs.near.ai/cloud/models/overview) | [API ref](https://cloud-api.near.ai/docs) | [Private inference](https://docs.near.ai/cloud/private-inference)
+- **Dashboard**: [cloud.near.ai](https://cloud.near.ai)
+- **Status**: Beta (as of March 2026)
+
+<!-- AI-CONTEXT-END -->
+
+TEE-backed private inference platform. All requests execute inside hardware-enforced Trusted Execution Environments with cryptographic attestation. OpenAI SDK compatible — change `base_url` only.
+
+**Best for**: privacy-sensitive workloads (regulated data, PII, healthcare, government), verifiable inference (cryptographic proof of integrity), applications requiring data sovereignty guarantees.
+**Not for**: fine-tuning, custom model uploads, dedicated deployments, batch inference, embeddings, image generation at scale (see `fireworks.md`).
+
+## Pricing (March 2026)
+
+| Model | Context | $/M input | $/M output |
+|-------|---------|-----------|------------|
+| Claude Opus 4.6 * | 200K | $5.00 | $25.00 |
+| Claude Sonnet 4.5 * | 200K | $3.00 | $15.50 |
+| Gemini 3 Pro Preview * | 1000K | $1.25 | $15.00 |
+| OpenAI GPT-5.2 * | 400K | $1.80 | $15.50 |
+| DeepSeek V3.1 | 128K | $1.05 | $3.10 |
+| GPT OSS 120B | 131K | $0.15 | $0.55 |
+| Qwen3 30B A3B | 262K | $0.15 | $0.55 |
+| Qwen3.5 122B A10B | 131K | $0.40 | $3.20 |
+| GLM 5 | 203K | $0.85 | $3.30 |
+| FLUX.2-klein-4B (image) | 128K | $1.00 | $1.00 |
+
+\* Marked "anonymized, not TEE-protected" — proxied to original providers with anonymization layer, not full TEE isolation. Open-source models (DeepSeek, GPT-OSS, Qwen, GLM) run in actual TEEs.
+
+### Price comparison vs Fireworks (same open-source models)
+
+| Model | Fireworks (in/out) | NEAR AI (in/out) | Notes |
+|-------|-------------------|-------------------|-------|
+| GPT-OSS 120B | $0.15 / $0.60 | $0.15 / $0.55 | ~same |
+| DeepSeek V3 | $0.56 / $1.68 | $1.05 / $3.10 | NEAR ~1.9x more (TEE premium) |
+| Qwen3 30B A3B | $0.15 / $0.60 | $0.15 / $0.55 | ~same |
+| GLM-5 | $1.00 / $3.20 | $0.85 / $3.30 | ~same |
+
+NEAR AI's premium on some models reflects the TEE overhead. For non-privacy-sensitive workloads, Fireworks is cheaper and has more features.
+
+### Unique value: closed-model access
+
+NEAR AI offers Claude, GPT-5.2, and Gemini via anonymized proxy — useful when you need frontier model quality with an anonymization layer between your app and the provider. Not available on Fireworks (open-source only).
+
+## Usage
+
+### Gateway (recommended)
+
+Routes to the appropriate model TEE automatically.
+
+```bash
+curl https://cloud-api.near.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NEARAI_API_KEY" \
+  -d '{"model": "deepseek-ai/DeepSeek-V3.1", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+```python
+import openai
+client = openai.OpenAI(base_url="https://cloud-api.near.ai/v1", api_key=os.environ["NEARAI_API_KEY"])
+response = client.chat.completions.create(
+    model="deepseek-ai/DeepSeek-V3.1",
+    messages=[{"role": "user", "content": "Hello, NEAR AI!"}]
+)
+```
+
+### Direct completions (TLS terminates inside TEE)
+
+Each model has its own subdomain — no gateway hop, TLS terminates directly in the model enclave.
+
+```bash
+curl https://qwen35-122b.completions.near.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NEARAI_API_KEY" \
+  -d '{"model": "Qwen/Qwen3.5-122B-A10B", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+Available direct endpoints: `qwen35-122b.completions.near.ai`, `qwen3-30b.completions.near.ai`, `gpt-oss-120b.completions.near.ai`, and more. Full list: https://completions.near.ai/endpoints
+
+### Model IDs
+
+Use HuggingFace-style IDs: `deepseek-ai/DeepSeek-V3.1`, `openai/gpt-oss-120b`, `Qwen/Qwen3-30B-A3B-Instruct-2507`, `Qwen/Qwen3.5-122B-A10B`, `zai-org/GLM-5-FP8`, `anthropic/claude-opus-4-6`, `openai/gpt-5.2`, `google/gemini-3-pro`.
+
+## Privacy Architecture
+
+- **TEE isolation**: Open-source models run inside hardware-enforced Trusted Execution Environments (Intel TDX / AMD SEV-SNP)
+- **Cryptographic attestation**: Every inference generates verifiable proof that code and data were not tampered with
+- **No data access**: Model providers, cloud providers, and NEAR AI cannot access prompts or responses
+- **TLS in enclave**: Direct completions endpoints terminate TLS inside the TEE — no intermediate can intercept
+- **E2EE chat**: End-to-end encrypted chat completions available (see [guide](https://docs.near.ai/cloud/guides/e2ee-chat-completions))
+- **Verification**: Clients can verify attestation reports. See [verification docs](https://docs.near.ai/cloud/verification)
+
+### Anonymized vs TEE-protected
+
+- **TEE-protected** (open-source models): Full hardware isolation, cryptographic attestation, no data access by anyone
+- **Anonymized** (Claude, GPT-5.2, Gemini): Requests proxied through NEAR AI with identifying information stripped. Provider sees the request but not your identity. Weaker guarantee than TEE.
+
+## Capabilities and Limitations
+
+### Available
+
+- Chat completions (OpenAI-compatible)
+- Streaming responses
+- Direct completions (TLS-in-TEE)
+- E2EE chat completions
+- Cryptographic verification/attestation
+- Files API and Conversations API (via OpenAI compatibility)
+
+### Not available
+
+- Fine-tuning (SFT, DPO, RFT) — use Fireworks
+- Custom model uploads — use Fireworks
+- Dedicated GPU deployments — use Fireworks
+- Batch inference — use Fireworks
+- Embeddings — use Fireworks
+- Speech-to-text — use Fireworks
+- CLI tool — API only
+- Function calling — not documented
+- Structured outputs — not documented
+
+## When to Use NEAR AI vs Fireworks
+
+| Requirement | Use |
+|-------------|-----|
+| Privacy-critical inference (PII, healthcare, legal) | NEAR AI |
+| Regulatory compliance requiring TEE attestation | NEAR AI |
+| Anonymized access to Claude/GPT-5.2/Gemini | NEAR AI |
+| Fine-tuning custom models | Fireworks |
+| Dedicated GPU deployments with autoscaling | Fireworks |
+| Batch inference at scale | Fireworks |
+| Custom model uploads from HuggingFace | Fireworks |
+| Lowest cost for non-sensitive workloads | Fireworks |
+| LoRA adapter deployment | Fireworks |
+| Embeddings, reranking, speech-to-text | Fireworks |
+
+## Security
+
+- Store API key: `aidevops secret set NEARAI_API_KEY`
+- Never expose keys in logs or output
+- For maximum privacy, use direct completions endpoints (TLS terminates in TEE)
+- Verify attestation reports for high-security workloads
+- Credits are prepaid — purchase at [cloud.near.ai](https://cloud.near.ai) dashboard
+
+## See Also
+
+- `tools/infrastructure/fireworks.md` — inference + fine-tuning + custom model hosting
+- `tools/infrastructure/cloud-gpu.md` — raw GPU providers (RunPod, Vast.ai, Lambda)
+- `tools/local-models/local-models.md` — local model serving

--- a/.agents/tools/infrastructure/nvidia-cloud.md
+++ b/.agents/tools/infrastructure/nvidia-cloud.md
@@ -1,5 +1,5 @@
 ---
-description: "NVIDIA Cloud — NIM inference microservices, build.nvidia.com API, DGX Cloud, self-hosted NIM containers"
+description: "NVIDIA Cloud — build.nvidia.com API, NIM containers for self-hosted inference, NeMo for training, DGX Cloud"
 mode: subagent
 tools:
   read: true
@@ -12,57 +12,78 @@ tools:
   task: false
 ---
 
-# NVIDIA Cloud (NIM / build.nvidia.com)
+# NVIDIA Cloud
 
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
-- **Cloud API**: `https://integrate.api.nvidia.com/v1` (build.nvidia.com, OpenAI-compat)
-- **Auth**: NVIDIA API key from [build.nvidia.com](https://build.nvidia.com) | `Authorization: Bearer <key>` header
-- **Creds**: `NVIDIA_API_KEY` env var
-- **Self-hosted NIM**: Docker containers from `nvcr.io/nim/` — requires NVIDIA AI Enterprise license or NGC account
-- **Docs**: [NIM overview](https://docs.nvidia.com/nim/) | [build.nvidia.com](https://build.nvidia.com) | [NIM containers](https://catalog.ngc.nvidia.com/orgs/nim/teams/meta)
-- **Dashboard**: [build.nvidia.com](https://build.nvidia.com)
+- **Cloud API**: `https://integrate.api.nvidia.com/v1` (OpenAI-compat, prototyping)
+- **Auth**: API key from [build.nvidia.com](https://build.nvidia.com/) (free, 1000 credits)
+- **Creds**: `NVIDIA_API_KEY` env var | `Authorization: Bearer <key>` header
+- **Self-host**: NIM containers via `docker pull nvcr.io/nim/<model>` (requires NGC API key)
+- **Docs**: [docs.api.nvidia.com](https://docs.api.nvidia.com/) | [NIM docs](https://docs.nvidia.com/nim/) | [build.nvidia.com](https://build.nvidia.com/explore/discover)
+- **Licensing**: Cloud API free (credit-based). NIM self-host free with AI Enterprise license or DGX.
 
 <!-- AI-CONTEXT-END -->
 
-NVIDIA's inference platform: cloud API for prototyping (build.nvidia.com) and self-hosted NIM containers for production. NIM (NVIDIA Inference Microservices) are optimized Docker containers for running models on NVIDIA GPUs with TensorRT-LLM acceleration.
+NVIDIA's AI inference platform with two modes: (1) free cloud API for prototyping at build.nvidia.com, (2) self-hosted NIM containers for production on your own GPUs. OpenAI SDK compatible.
 
-**Best for**: self-hosted optimized inference on NVIDIA GPUs (NIM containers), prototyping with frontier models (build.nvidia.com free credits), organizations with NVIDIA AI Enterprise licenses.
-**Not for**: managed serverless inference at scale (use Fireworks/Together), fine-tuning (use NeMo separately), privacy-critical TEE workloads (see `nearai.md`).
+**Best for**: prototyping with free credits, self-hosted production inference (NIM containers are highly optimized), NVIDIA GPU owners (DGX, HGX), healthcare/biology/simulation models, enterprise with AI Enterprise licenses.
+**Not for**: pay-per-token production serverless (no published pricing), fine-tuning via API (use NeMo separately), budget-conscious serverless (use Fireworks/Together), edge inference (use Cloudflare).
 
-## Pricing (March 2026)
+## Pricing Model
 
-- **build.nvidia.com (cloud API)**: Free tier — 1,000 API credits for prototyping. No published per-token serverless pricing for production; cloud API is intended for evaluation only.
-- **Self-hosted NIM**: Free with NVIDIA AI Enterprise license (included with DGX systems, available separately). NGC personal accounts get limited free access.
-- **DGX Cloud**: Enterprise GPU clusters — contact NVIDIA for pricing.
+NVIDIA Cloud has a fundamentally different pricing model from Fireworks/Together/Cloudflare:
 
-## Models
+| Mode | Cost | Use case |
+|------|------|----------|
+| **Cloud API** (build.nvidia.com) | Free (1000 API credits, replenishable) | Prototyping, evaluation, development |
+| **Self-hosted NIM** | Free with AI Enterprise license or DGX purchase | Production inference on your GPUs |
+| **DGX Cloud** | GPU rental (contact sales) | Production without owning hardware |
 
-100+ models on build.nvidia.com: Llama, Mistral, Gemma, Phi, DeepSeek, Qwen, Nemotron, multimodal (vision, speech), and NVIDIA-optimized variants. Full catalog: https://build.nvidia.com/explore/discover
+No published per-token serverless pricing. The cloud API is explicitly for prototyping -- production workloads run on self-hosted NIM or DGX Cloud.
 
-## Cloud API (build.nvidia.com)
+## Models (100+)
+
+### LLMs
+
+DeepSeek V3.1/V3.2, Llama 2/3/3.1/3.2/3.3/4, Mistral/Mixtral family, Qwen 2/2.5/3/3.5, GPT-OSS 20B/120B, Nemotron family (NVIDIA's own), Kimi K2, MiniMax M2.5, GLM-4.7/5, Phi-3/4, Gemma 2/3/3n, Granite, and many more.
+
+### Specialized
+
+- **Retrieval**: Embeddings (NV-Embed, BGE, Arctic), reranking (NV-Rerank, BGE)
+- **Vision**: FLUX image gen, Stable Diffusion, object detection, document parsing
+- **Healthcare**: AlphaFold2, ESMFold, protein design (RFDiffusion, ProteinMPNN), molecular docking
+- **Simulation**: Weather prediction (FourCastNet), climate (CorrDiff)
+- **Safety**: NemoGuard (jailbreak detection, content safety, topic control), Llama Guard
+- **Code**: StarCoder2, Codestral, CodeGemma
+
+## Usage
+
+### Cloud API (prototyping)
 
 ```bash
-# OpenAI-compatible REST
 curl https://integrate.api.nvidia.com/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $NVIDIA_API_KEY" \
   -d '{"model": "meta/llama-3.3-70b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
-
-# OpenAI SDK (Python)
-from openai import OpenAI
-client = OpenAI(api_key=os.environ["NVIDIA_API_KEY"], base_url="https://integrate.api.nvidia.com/v1")
-response = client.chat.completions.create(model="meta/llama-3.3-70b-instruct", messages=[...])
 ```
 
-## Self-Hosted NIM Containers
+```python
+# OpenAI SDK (change base_url only)
+from openai import OpenAI
+client = OpenAI(api_key=os.environ["NVIDIA_API_KEY"], base_url="https://integrate.api.nvidia.com/v1")
+response = client.chat.completions.create(
+    model="meta/llama-3.3-70b-instruct",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
 
-NIM containers package model weights + TensorRT-LLM optimizations + OpenAI-compatible API server into a single Docker image.
+### Self-hosted NIM (production)
 
 ```bash
-# Pull and run a NIM container (requires NGC API key and NVIDIA GPU)
+# Pull and run NIM container (requires NGC API key and NVIDIA GPU)
 export NGC_API_KEY="<your-ngc-api-key>"
 docker login nvcr.io --username '$oauthtoken' --password "$NGC_API_KEY"
 
@@ -71,23 +92,86 @@ docker run --gpus all \
   -p 8000:8000 \
   nvcr.io/nim/meta/llama-3.3-70b-instruct:latest
 
-# Query the local NIM (OpenAI-compatible)
+# Query (same OpenAI-compatible API)
 curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "meta/llama-3.3-70b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
-NIM containers expose an OpenAI-compatible API at `/v1/chat/completions`. Deploy on any NVIDIA GPU server (cloud or on-prem).
+NIM containers include NVIDIA's inference optimizations (TensorRT-LLM, quantization, batching). Generally faster than vLLM/TGI for NVIDIA GPUs.
+
+## Cloud API vs Self-Hosted NIM
+
+| Dimension | Cloud API | Self-hosted NIM |
+|-----------|-----------|-----------------|
+| Cost | Free (credit-based) | GPU cost only (NIM license free with AI Enterprise) |
+| Rate limits | Credit-based, limited | Unlimited (your hardware) |
+| Latency | Variable (shared infra) | Predictable (dedicated) |
+| Models | 100+ | Any NIM-packaged model |
+| Custom models | No | Yes (custom NIM containers) |
+| Data privacy | NVIDIA sees requests | Full control |
+| Setup | API key only | Docker + NVIDIA GPU + NGC key |
+| Use case | Prototyping, evaluation | Production |
+
+## Capabilities and Limitations
+
+### Available
+
+- 100+ models across LLM, vision, retrieval, healthcare, simulation
+- OpenAI-compatible chat completions API
+- Streaming responses
+- Embeddings and reranking
+- Image generation (FLUX, Stable Diffusion)
+- Specialized models (healthcare, weather, safety) not available elsewhere
+- Self-hosted NIM with TensorRT-LLM optimizations
+- Attestation API (for NIM container verification)
+
+### Not available (via cloud API)
+
+- Fine-tuning -- use NeMo (separate product) or Fireworks/Together
+- Batch inference API -- use Fireworks/Together
+- Dedicated cloud deployments with autoscaling -- use Fireworks/Together or DGX Cloud
+- Published per-token pricing -- credit-based only
+- CLI tool -- REST API and Docker only
+- Audio/speech models -- limited (use Fireworks/Together/Cloudflare)
+
+## When to Use NVIDIA Cloud
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Prototyping with many models | Strong fit -- free credits, 100+ models |
+| Production on own NVIDIA GPUs | Strong fit -- NIM containers are fastest |
+| Healthcare/biology models | Unique -- AlphaFold, ESMFold, molecular docking |
+| Enterprise with AI Enterprise license | Strong fit -- NIM is free |
+| Pay-per-token serverless production | Use Fireworks or Together instead |
+| Fine-tuning via API | Use Fireworks or Together instead |
+| Edge/global inference | Use Cloudflare instead |
+| Privacy-critical with TEE | Use NEAR AI instead |
+| Budget-conscious, no NVIDIA GPUs | Use Fireworks or Together instead |
+
+## NeMo (Training)
+
+NVIDIA NeMo is a separate product for model training and customization:
+
+- **NeMo Customizer**: Fine-tuning (SFT, PEFT, DPO)
+- **NeMo Evaluator**: Model evaluation
+- **NeMo Data Designer**: Synthetic dataset generation
+- **NeMo Guardrails**: Safety and alignment
+
+NeMo is self-hosted or available via DGX Cloud. Not accessible through the build.nvidia.com API.
 
 ## Security
 
-- Store credentials: `aidevops secret set NVIDIA_API_KEY`
+- Store API key: `aidevops secret set NVIDIA_API_KEY`
+- NGC API key (for NIM pulls): `aidevops secret set NGC_API_KEY`
 - Never expose keys in logs or output
-- Self-hosted NIM: run behind a reverse proxy with auth (nginx/caddy) — NIM containers have no built-in auth
+- Self-hosted NIM: full data sovereignty, but run behind reverse proxy with auth (NIM has no built-in auth)
+- Cloud API: NVIDIA processes requests (no TEE guarantees)
 
 ## See Also
 
-- `tools/infrastructure/fireworks.md` — managed inference + fine-tuning (no GPU required)
-- `tools/infrastructure/cloud-gpu.md` — raw GPU providers for running NIM or other inference servers
-- `tools/infrastructure/nearai.md` — TEE-backed private inference
-- `tools/deployment/hosting-comparison.md` — platform comparison including inference hosting
+- `tools/infrastructure/fireworks.md` -- managed serverless inference + fine-tuning
+- `tools/infrastructure/together.md` -- managed inference + GPU clusters
+- `tools/infrastructure/nearai.md` -- TEE-backed private inference
+- `tools/infrastructure/cloud-gpu.md` -- raw GPU providers for self-hosting NIM
+- `tools/deployment/hosting-comparison.md` -- full platform comparison

--- a/.agents/tools/infrastructure/nvidia-cloud.md
+++ b/.agents/tools/infrastructure/nvidia-cloud.md
@@ -1,0 +1,93 @@
+---
+description: "NVIDIA Cloud — NIM inference microservices, build.nvidia.com API, DGX Cloud, self-hosted NIM containers"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: false
+---
+
+# NVIDIA Cloud (NIM / build.nvidia.com)
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Cloud API**: `https://integrate.api.nvidia.com/v1` (build.nvidia.com, OpenAI-compat)
+- **Auth**: NVIDIA API key from [build.nvidia.com](https://build.nvidia.com) | `Authorization: Bearer <key>` header
+- **Creds**: `NVIDIA_API_KEY` env var
+- **Self-hosted NIM**: Docker containers from `nvcr.io/nim/` — requires NVIDIA AI Enterprise license or NGC account
+- **Docs**: [NIM overview](https://docs.nvidia.com/nim/) | [build.nvidia.com](https://build.nvidia.com) | [NIM containers](https://catalog.ngc.nvidia.com/orgs/nim/teams/meta)
+- **Dashboard**: [build.nvidia.com](https://build.nvidia.com)
+
+<!-- AI-CONTEXT-END -->
+
+NVIDIA's inference platform: cloud API for prototyping (build.nvidia.com) and self-hosted NIM containers for production. NIM (NVIDIA Inference Microservices) are optimized Docker containers for running models on NVIDIA GPUs with TensorRT-LLM acceleration.
+
+**Best for**: self-hosted optimized inference on NVIDIA GPUs (NIM containers), prototyping with frontier models (build.nvidia.com free credits), organizations with NVIDIA AI Enterprise licenses.
+**Not for**: managed serverless inference at scale (use Fireworks/Together), fine-tuning (use NeMo separately), privacy-critical TEE workloads (see `nearai.md`).
+
+## Pricing (March 2026)
+
+- **build.nvidia.com (cloud API)**: Free tier — 1,000 API credits for prototyping. No published per-token serverless pricing for production; cloud API is intended for evaluation only.
+- **Self-hosted NIM**: Free with NVIDIA AI Enterprise license (included with DGX systems, available separately). NGC personal accounts get limited free access.
+- **DGX Cloud**: Enterprise GPU clusters — contact NVIDIA for pricing.
+
+## Models
+
+100+ models on build.nvidia.com: Llama, Mistral, Gemma, Phi, DeepSeek, Qwen, Nemotron, multimodal (vision, speech), and NVIDIA-optimized variants. Full catalog: https://build.nvidia.com/explore/discover
+
+## Cloud API (build.nvidia.com)
+
+```bash
+# OpenAI-compatible REST
+curl https://integrate.api.nvidia.com/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NVIDIA_API_KEY" \
+  -d '{"model": "meta/llama-3.3-70b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
+
+# OpenAI SDK (Python)
+from openai import OpenAI
+client = OpenAI(api_key=os.environ["NVIDIA_API_KEY"], base_url="https://integrate.api.nvidia.com/v1")
+response = client.chat.completions.create(model="meta/llama-3.3-70b-instruct", messages=[...])
+```
+
+## Self-Hosted NIM Containers
+
+NIM containers package model weights + TensorRT-LLM optimizations + OpenAI-compatible API server into a single Docker image.
+
+```bash
+# Pull and run a NIM container (requires NGC API key and NVIDIA GPU)
+export NGC_API_KEY="<your-ngc-api-key>"
+docker login nvcr.io --username '$oauthtoken' --password "$NGC_API_KEY"
+
+docker run --gpus all \
+  -e NGC_API_KEY="$NGC_API_KEY" \
+  -p 8000:8000 \
+  nvcr.io/nim/meta/llama-3.3-70b-instruct:latest
+
+# Query the local NIM (OpenAI-compatible)
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "meta/llama-3.3-70b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+NIM containers expose an OpenAI-compatible API at `/v1/chat/completions`. Deploy on any NVIDIA GPU server (cloud or on-prem).
+
+## Security
+
+- Store credentials: `aidevops secret set NVIDIA_API_KEY`
+- Never expose keys in logs or output
+- Self-hosted NIM: run behind a reverse proxy with auth (nginx/caddy) — NIM containers have no built-in auth
+
+## See Also
+
+- `tools/infrastructure/fireworks.md` — managed inference + fine-tuning (no GPU required)
+- `tools/infrastructure/cloud-gpu.md` — raw GPU providers for running NIM or other inference servers
+- `tools/infrastructure/nearai.md` — TEE-backed private inference
+- `tools/deployment/hosting-comparison.md` — platform comparison including inference hosting

--- a/.agents/tools/infrastructure/together.md
+++ b/.agents/tools/infrastructure/together.md
@@ -1,5 +1,5 @@
 ---
-description: "Together AI — managed inference, fine-tuning (SFT/DPO/RL), GPU clusters, 100+ open-source models"
+description: "Together AI — serverless and dedicated inference, fine-tuning (SFT/DPO/RL), GPU clusters (H100-GB300), batch inference, image/video/audio generation"
 mode: subagent
 tools:
   read: true
@@ -19,60 +19,145 @@ tools:
 ## Quick Reference
 
 - **API base**: `https://api.together.xyz/v1` (OpenAI-compat)
-- **Auth**: API key from [api.together.ai/settings/api-keys](https://api.together.ai/settings/api-keys)
-- **Creds**: `TOGETHER_API_KEY` env var | `Authorization: Bearer <key>` header
-- **Docs**: [Quickstart](https://docs.together.ai/docs/quickstart) | [Models](https://docs.together.ai/docs/inference-models) | [API ref](https://docs.together.ai/reference) | [Pricing](https://www.together.ai/pricing)
-- **Dashboard**: [api.together.ai](https://api.together.ai)
+- **Auth**: API key from [api.together.ai](https://api.together.ai/) dashboard
+- **Creds**: `TOGETHER_API_KEY` env var
+- **Docs**: [docs.together.ai](https://docs.together.ai/) | [Pricing](https://www.together.ai/pricing) | [Models](https://www.together.ai/models)
+- **SDK**: `pip install together` (Python) | `npm install together-ai` (JS)
+- **Dashboard**: [api.together.ai](https://api.together.ai/)
 
 <!-- AI-CONTEXT-END -->
 
-Managed inference and fine-tuning platform for open-source models. OpenAI SDK compatible — change `base_url` only. 100+ models serverless, plus dedicated GPU clusters for training.
+Managed inference and training platform for open-source models. OpenAI SDK compatible. Strong research team (FlashAttention, ThunderKittens). GPU clusters available for large-scale training.
 
-**Best for**: production inference (serverless), fine-tuning (SFT/DPO/RL), GPU cluster training, batch inference at scale.
-**Not for**: closed-model hosting (Claude/GPT/Gemini), privacy-critical workloads requiring TEE (see `nearai.md`), static site hosting.
+**Best for**: production inference (serverless or dedicated), fine-tuning (SFT/DPO), GPU cluster rental (H100 through GB300), image/video generation, batch inference.
+**Not for**: closed-model hosting, privacy-critical TEE workloads (see `nearai.md`), edge/CDN inference (see `cloudflare-ai.md`).
 
 ## Pricing (March 2026)
 
-Pricing varies by model — see [together.ai/pricing](https://www.together.ai/pricing) for current rates. Batch inference: 50% off serverless price.
+### Serverless Inference (pay-per-token, selected models)
 
-## Models
+| Model | $/M input | $/M output |
+|-------|-----------|------------|
+| Llama 4 Maverick | $0.27 | $0.85 |
+| MiniMax M2.5 | $0.30 ($0.06 cached) | $1.20 |
+| Kimi K2.5 | $0.50 | $2.80 |
+| GLM-5 | $1.00 | $3.20 |
+| DeepSeek V3.1 | $0.60 | $1.70 |
+| DeepSeek R1-0528 | $3.00 | $7.00 |
+| GPT-OSS 120B | $0.15 | $0.60 |
+| Llama 3.3 70B | $0.88 | $0.88 |
+| Llama 3 8B Lite | $0.10 | $0.10 |
+| Mistral Small 3 | $0.10 | $0.30 |
+| Gemma 3n E4B | $0.02 | $0.04 |
 
-100+ models across text, vision, code, and embeddings. Key families: Llama 1-4, Mistral/Mixtral, DeepSeek, Qwen, Gemma, Phi, DBRX. Full catalog: https://docs.together.ai/docs/inference-models
+Batch inference: 50% off for most models.
 
-## Serverless Inference
+### Dedicated Inference
+
+Custom hardware allocation for consistent performance. Contact sales for pricing. Supports H100, H200, B200, GB200 GPUs.
+
+### GPU Clusters
+
+| GPU | Use case |
+|-----|----------|
+| H100 | Training and inference |
+| H200 | Large model training |
+| B200 | Next-gen training |
+| GB200 NVL72 | Frontier-scale training |
+| GB300 NVL72 | Latest generation |
+
+Self-service GPU clusters. Pricing varies by GPU type and commitment.
+
+### Fine-Tuning
+
+SFT and DPO available. Pricing per training token, varies by model size. See [together.ai/pricing](https://www.together.ai/pricing) for current rates.
+
+### Other Modalities
+
+- **Image generation**: FLUX family ($0.0014-$0.08/image), Stable Diffusion, HiDream, Ideogram, Google Imagen
+- **Video generation**: Veo 2/3, Kling, MiniMax, Wan, Sora 2 ($0.14-$3.20/video)
+- **Audio**: Cartesia Sonic TTS ($65/M chars), Whisper STT ($0.0015/min)
+- **Embeddings**: $0.02/M tokens
+- **Reranking**: Available
+
+## Usage
 
 ```bash
-# curl
+# curl (OpenAI-compatible)
 curl https://api.together.xyz/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOGETHER_API_KEY" \
   -d '{"model": "meta-llama/Llama-3.3-70B-Instruct-Turbo", "messages": [{"role": "user", "content": "Hello"}]}'
-
-# OpenAI SDK (Python) — just change base_url
-from openai import OpenAI
-client = OpenAI(api_key=os.environ["TOGETHER_API_KEY"], base_url="https://api.together.xyz/v1")
-response = client.chat.completions.create(model="meta-llama/Llama-3.3-70B-Instruct-Turbo", messages=[...])
 ```
 
-Features: streaming, function calling, structured outputs (JSON schema), vision, embeddings, reranking.
+```python
+# OpenAI SDK (change base_url only)
+from openai import OpenAI
+client = OpenAI(api_key=os.environ["TOGETHER_API_KEY"], base_url="https://api.together.xyz/v1")
+response = client.chat.completions.create(
+    model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
 
-## Fine-Tuning
+```python
+# Together SDK
+from together import Together
+client = Together()
+response = client.chat.completions.create(
+    model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
 
-Together AI supports SFT, DPO, and RL fine-tuning jobs via the API. See [fine-tuning docs](https://docs.together.ai/docs/fine-tuning-overview) for dataset format, job creation, and monitoring.
+Features: streaming, function calling, structured outputs (JSON mode), vision, image generation, video generation, audio (TTS/STT), embeddings, reranking, moderation.
 
-## GPU Clusters
+## Capabilities
 
-Together AI offers dedicated GPU clusters (H100, H200, B200, GB200) for large-scale training. See [GPU Clusters](https://www.together.ai/products/clusters) for availability and pricing.
+| Feature | Status |
+|---------|--------|
+| Serverless inference | 100+ models |
+| Dedicated inference | Custom hardware |
+| Batch inference | 50% discount |
+| Fine-tuning (SFT) | Yes |
+| Fine-tuning (DPO) | Yes |
+| GPU clusters | H100 through GB300 |
+| Custom model upload | Yes (dedicated containers) |
+| Image generation | FLUX, SD, Imagen, Ideogram |
+| Video generation | Veo, Kling, MiniMax, Sora |
+| Audio (TTS/STT) | Cartesia, Whisper |
+| Embeddings | Yes |
+| Reranking | Yes |
+| Sandbox (dev envs) | Yes |
+| Managed storage | Yes |
+| OpenAI SDK compat | Yes |
+
+## Fireworks vs Together
+
+Both are strong competitors with similar offerings. Key differences:
+
+| Dimension | Fireworks | Together |
+|-----------|-----------|---------|
+| CLI tool | `firectl` (full CRUD) | No CLI (REST API only) |
+| Fine-tuning methods | SFT, DPO, RFT, Training SDK | SFT, DPO |
+| GPU clusters | No | Yes (H100-GB300, self-service) |
+| Video generation | No | Yes (Veo, Kling, Sora, etc.) |
+| LoRA hot-loading | Yes | Not documented |
+| Anthropic SDK compat | Yes | Not documented |
+| Deployment shapes | fast/throughput/cost presets | Custom hardware configs |
+| Research output | Production-focused | FlashAttention, ThunderKittens |
+
+**Rule of thumb**: Fireworks for `firectl` CLI automation and RFT/Training SDK. Together for GPU clusters and multimodal generation (video/image).
 
 ## Security
 
 - Store API key: `aidevops secret set TOGETHER_API_KEY`
 - Never expose keys in logs or output
-- Use service accounts for CI/CD
+- Use environment variables, not hardcoded keys
 
 ## See Also
 
-- `tools/infrastructure/fireworks.md` — inference + fine-tuning + custom model hosting (Fireworks AI)
-- `tools/infrastructure/nearai.md` — TEE-backed private inference
-- `tools/infrastructure/cloud-gpu.md` — raw GPU providers (RunPod, Vast.ai, Lambda)
-- `tools/deployment/hosting-comparison.md` — platform comparison including inference hosting
+- `tools/infrastructure/fireworks.md` -- primary competitor (inference + fine-tuning + CLI)
+- `tools/infrastructure/nearai.md` -- TEE-backed private inference
+- `tools/infrastructure/cloud-gpu.md` -- raw GPU providers
+- `tools/deployment/hosting-comparison.md` -- full platform comparison

--- a/.agents/tools/infrastructure/together.md
+++ b/.agents/tools/infrastructure/together.md
@@ -1,0 +1,78 @@
+---
+description: "Together AI — managed inference, fine-tuning (SFT/DPO/RL), GPU clusters, 100+ open-source models"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: false
+---
+
+# Together AI
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **API base**: `https://api.together.xyz/v1` (OpenAI-compat)
+- **Auth**: API key from [api.together.ai/settings/api-keys](https://api.together.ai/settings/api-keys)
+- **Creds**: `TOGETHER_API_KEY` env var | `Authorization: Bearer <key>` header
+- **Docs**: [Quickstart](https://docs.together.ai/docs/quickstart) | [Models](https://docs.together.ai/docs/inference-models) | [API ref](https://docs.together.ai/reference) | [Pricing](https://www.together.ai/pricing)
+- **Dashboard**: [api.together.ai](https://api.together.ai)
+
+<!-- AI-CONTEXT-END -->
+
+Managed inference and fine-tuning platform for open-source models. OpenAI SDK compatible — change `base_url` only. 100+ models serverless, plus dedicated GPU clusters for training.
+
+**Best for**: production inference (serverless), fine-tuning (SFT/DPO/RL), GPU cluster training, batch inference at scale.
+**Not for**: closed-model hosting (Claude/GPT/Gemini), privacy-critical workloads requiring TEE (see `nearai.md`), static site hosting.
+
+## Pricing (March 2026)
+
+Pricing varies by model — see [together.ai/pricing](https://www.together.ai/pricing) for current rates. Batch inference: 50% off serverless price.
+
+## Models
+
+100+ models across text, vision, code, and embeddings. Key families: Llama 1-4, Mistral/Mixtral, DeepSeek, Qwen, Gemma, Phi, DBRX. Full catalog: https://docs.together.ai/docs/inference-models
+
+## Serverless Inference
+
+```bash
+# curl
+curl https://api.together.xyz/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  -d '{"model": "meta-llama/Llama-3.3-70B-Instruct-Turbo", "messages": [{"role": "user", "content": "Hello"}]}'
+
+# OpenAI SDK (Python) — just change base_url
+from openai import OpenAI
+client = OpenAI(api_key=os.environ["TOGETHER_API_KEY"], base_url="https://api.together.xyz/v1")
+response = client.chat.completions.create(model="meta-llama/Llama-3.3-70B-Instruct-Turbo", messages=[...])
+```
+
+Features: streaming, function calling, structured outputs (JSON schema), vision, embeddings, reranking.
+
+## Fine-Tuning
+
+Together AI supports SFT, DPO, and RL fine-tuning jobs via the API. See [fine-tuning docs](https://docs.together.ai/docs/fine-tuning-overview) for dataset format, job creation, and monitoring.
+
+## GPU Clusters
+
+Together AI offers dedicated GPU clusters (H100, H200, B200, GB200) for large-scale training. See [GPU Clusters](https://www.together.ai/products/clusters) for availability and pricing.
+
+## Security
+
+- Store API key: `aidevops secret set TOGETHER_API_KEY`
+- Never expose keys in logs or output
+- Use service accounts for CI/CD
+
+## See Also
+
+- `tools/infrastructure/fireworks.md` — inference + fine-tuning + custom model hosting (Fireworks AI)
+- `tools/infrastructure/nearai.md` — TEE-backed private inference
+- `tools/infrastructure/cloud-gpu.md` — raw GPU providers (RunPod, Vast.ai, Lambda)
+- `tools/deployment/hosting-comparison.md` — platform comparison including inference hosting


### PR DESCRIPTION
## Summary

Commits orphaned work from the `feature/inference-hosting-agents` worktree that was never committed or PRed after the parent task t1663 closed.

- `.agents/tools/deployment/hosting-comparison.md` — new 'AI Model Inference Hosting' section with platform comparison table, pricing table (March 2026), and decision guide
- `.agents/tools/infrastructure/fireworks.md` — new agent doc for Fireworks AI (inference/fine-tuning)
- `.agents/tools/infrastructure/nearai.md` — new agent doc for NEAR AI Cloud (TEE-backed inference)
- `.agents/tools/infrastructure/cloud-gpu.md` — minor additions

No new research was done — content was already written and ready to commit.

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** low (docs-only changes, no code)
- **Dev environment:** N/A
- **Behaviour verified:** content reviewed as-is; no functional changes

Closes #11122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive AI Model Inference Hosting guide with platform comparisons, decision guidance, and pricing reference
  * Added Fireworks AI docs for managed inference, fine-tuning, deployments, and lifecycle operations
  * Added NEAR AI Cloud docs for TEE-backed private inference and verification guidance
  * Added Cloudflare Workers AI, NVIDIA Cloud, and Together AI platform guides with usage patterns, capabilities, and pricing
  * Expanded cross-references between infrastructure guides and cloud GPU provider guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->