### PR TITLE
docs: codify .agents/ architecture conventions for scalability

### DIFF
--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -131,3 +131,35 @@ Full extension guide: `.agents/aidevops/extension.md`
 ### Security Standards
 
 All services must implement: API token validation, rate limiting awareness, secure credential storage, input validation, error message sanitization, audit logging, confirmation prompts for destructive operations.
+
+## Knowledge Organization Model
+
+The `.agents/` directory organizes knowledge along two axes: **strategy** (what to do) and **execution** (how to do it). Full conventions in `tools/build-agent/build-agent.md` "Folder Organization".
+
+### Strategy: Main Agent Directories
+
+Main agents at root (e.g., `marketing.md`, `seo.md`) own domain strategy — methodology, audience knowledge, campaign planning. Their matching directories (`marketing/`, `seo/`) contain extended strategy knowledge loaded on demand.
+
+### Execution: Cross-Domain Directories
+
+| Directory | Contains | Used by |
+|-----------|----------|---------|
+| `tools/` | Capabilities — browser, git, database, code review, deployment | Any agent |
+| `services/` | Integrations — hosting, payments, communications, email providers | Any agent |
+| `workflows/` | Processes — git flow, release, PR review | Any agent |
+| `reference/` | Operating rules — planning, sessions, security | Any agent |
+
+### Scripts: Flat and Cross-Domain
+
+All scripts live flat in `scripts/` — intentionally not grouped into domain folders. Scripts are shared utilities callable by any agent. The prefix naming convention (`email-*`, `seo-*`, `browser-*`) provides grouping via filesystem sort and glob patterns without imposing ownership.
+
+- `*-helper.sh` suffix = agent-callable utilities (distinguishes from framework infrastructure scripts)
+- Discovery: `ls scripts/email-*`, `rg --files -g "scripts/seo-*"`
+
+### Flat Files Over Nested Folders
+
+Inside any directory, prefer flat files with descriptive prefix-based names over nested subdirectories. File names provide sorting, grouping, and keyword discoverability. `ls {dir}/` should show everything at a glance. Max depth from `.agents/` should be 2 levels for agent knowledge. See `tools/build-agent/build-agent.md` for examples.
+
+### Ingested Skills
+
+External skills retain the `-skill` suffix as a provenance marker enabling automated upstream update checks. On ingestion, upstream structure (nested `references/`, `rules/`, `SKILL.md` entry points) is transposed to match our flat `{name}-skill.md` + `{name}-skill/` convention. See `tools/build-agent/add-skill.md`.

--- a/.agents/tools/build-agent/add-skill.md
+++ b/.agents/tools/build-agent/add-skill.md
@@ -156,7 +156,7 @@ Already in aidevops format.
 
 Plain markdown without frontmatter.
 
-**Transposition:** Wrap in markdown with generated frontmatter:
+**Transposition:** Wrap in Markdown with generated frontmatter:
 
 ```markdown
 ---

--- a/.agents/tools/build-agent/add-skill.md
+++ b/.agents/tools/build-agent/add-skill.md
@@ -5,7 +5,7 @@ mode: subagent
 
 # Add Skill - External Skill Import System
 
-Import skills from external sources (GitHub repos, ClawdHub registry) and convert them to aidevops format while preserving knowledge and handling conflicts intelligently.
+Ingest skills from external sources (GitHub repos, ClawdHub registry) and transpose them to aidevops format while preserving all knowledge and handling conflicts intelligently.
 
 ## Quick Reference
 
@@ -36,7 +36,7 @@ External Skill (GitHub or ClawdHub)
         ↓
     Present Merge Options (if conflicts)
         ↓
-    Convert to aidevops Format
+    Transpose to aidevops Format (see below)
         ↓
     Register in skill-sources.json
         ↓
@@ -46,6 +46,75 @@ External Skill (GitHub or ClawdHub)
     - ~/.claude/skills/
     - ~/.config/amp/tools/
 ```
+
+## Transposition Rules
+
+Ingested skills retain the `-skill` suffix as a provenance marker — this enables `skill-update-helper.sh` to identify and check all ingested skills for upstream changes. The internal structure is flattened to match our `{name}.md` + `{name}/` convention with flat, descriptively-named files.
+
+### Entry Point Rename
+
+Upstream `SKILL.md` → `{name}-skill.md` (named entry point at the target category level).
+
+### Flatten Nested Directories
+
+Upstream nested structure is flattened using prefix-based naming:
+
+| Upstream path | Transposed path |
+|---------------|-----------------|
+| `SKILL.md` | `{name}-skill.md` |
+| `references/SCHEMA.md` | `{name}-skill/schema.md` |
+| `references/QUERIES.md` | `{name}-skill/queries.md` |
+| `references/CHEATSHEET/01-schema.md` | `{name}-skill/cheatsheet-schema.md` |
+| `references/CHEATSHEET/02-relations.md` | `{name}-skill/cheatsheet-relations.md` |
+| `rules/authentication.md` | `{name}-skill/rules-authentication.md` |
+| `rules/avatars.md` | `{name}-skill/rules-avatars.md` |
+
+### Example: Upstream vs Transposed
+
+```text
+# Upstream (postgres-drizzle skill)
+SKILL.md
+references/
+├── SCHEMA.md
+├── QUERIES.md
+├── MIGRATIONS.md
+├── PERFORMANCE.md
+├── RELATIONS.md
+├── POSTGRES.md
+├── CHEATSHEET.md
+└── CHEATSHEET/
+    ├── 01-schema.md
+    ├── 02-relations.md
+    ├── 03-queries.md
+    ├── 04-mutations.md
+    ├── 05-config.md
+    └── 06-reference.md
+
+# Transposed (aidevops format)
+postgres-drizzle-skill.md                    # Entry point (was SKILL.md)
+postgres-drizzle-skill/                      # Flat reference files
+├── schema.md
+├── queries.md
+├── migrations.md
+├── performance.md
+├── relations.md
+├── postgres.md
+├── cheatsheet.md
+├── cheatsheet-schema.md
+├── cheatsheet-relations.md
+├── cheatsheet-queries.md
+├── cheatsheet-mutations.md
+├── cheatsheet-config.md
+└── cheatsheet-reference.md
+```
+
+### Benefits
+
+- `ls {name}-skill/` shows all reference material at a glance
+- `ls {name}-skill/cheatsheet*` groups all cheatsheet files
+- Entry point is discoverable by filename alongside sibling agents
+- `-skill` suffix enables automated upstream update detection
+- Max depth is 2 levels from parent directory
 
 ## Supported Input Formats
 
@@ -75,19 +144,19 @@ Instructions for the AI agent...
 command examples
 ```
 
-**Conversion:** Preserve frontmatter, add `mode: subagent` and `imported_from: external`.
+**Transposition:** Preserve frontmatter, add `mode: subagent` and `imported_from: external`. Rename `SKILL.md` → `{name}-skill.md`. Flatten nested directories per transposition rules above.
 
 ### AGENTS.md (aidevops/Windsurf)
 
 Already in aidevops format.
 
-**Conversion:** Direct copy, ensure `mode: subagent` is set.
+**Transposition:** Direct copy, ensure `mode: subagent` is set.
 
 ### .cursorrules (Cursor)
 
 Plain markdown without frontmatter.
 
-**Conversion:** Wrap in markdown with generated frontmatter:
+**Transposition:** Wrap in markdown with generated frontmatter:
 
 ```markdown
 ---
@@ -104,7 +173,7 @@ imported_from: cursorrules
 
 Any markdown file (README.md, etc.).
 
-**Conversion:** Copy as-is, add frontmatter if missing.
+**Transposition:** Copy as-is, add frontmatter if missing. Rename to `{name}-skill.md`.
 
 ## Conflict Resolution
 

--- a/.agents/tools/build-agent/add-skill.md
+++ b/.agents/tools/build-agent/add-skill.md
@@ -38,14 +38,12 @@ External Skill (GitHub or ClawdHub)
         ↓
     Transpose to aidevops Format (see below)
         ↓
-    Register in skill-sources.json
+    Place in .agents/ using category detection
         ↓
-    setup.sh creates symlinks to:
-    - ~/.config/opencode/skills/
-    - ~/.codex/skills/
-    - ~/.claude/skills/
-    - ~/.config/amp/tools/
+    Register in skill-sources.json
 ```
+
+Ingested skills live in `.agents/` alongside all other knowledge — same naming, same discovery, same progressive disclosure. No symlinks to external runtime skill directories. Runtimes that support `.agents/` (or AGENTS.md-based discovery) find ingested skills through the same mechanisms as native agents. The `.agents/` convention replaces the isolated `SKILL.md`-per-directory pattern used by other runtimes.
 
 ## Transposition Rules
 
@@ -284,35 +282,18 @@ Default: `tools/{skill-name}/`
 # Up to date: vercel-deploy
 ```
 
-## Integration with setup.sh
+## Why Not Symlinks to Runtime Skill Directories
 
-After importing skills, `setup.sh` creates symlinks:
+Other runtimes (Claude Code, Codex, Amp) have their own skill directories (`~/.claude/skills/`, `~/.codex/skills/`, etc.) using a `SKILL.md`-per-directory convention. We previously created symlinks from `.agents/` into these directories.
 
-```bash
-# In setup.sh
-create_skill_symlinks() {
-    local skill_sources="$AGENTS_DIR/configs/skill-sources.json"
-    
-    if [[ -f "$skill_sources" ]] && command -v jq &>/dev/null; then
-        # Create symlinks to various AI assistant skill directories
-        jq -r '.skills[] | .local_path' "$skill_sources" | while read -r path; do
-            local skill_name=$(basename "$path" .md)
-            
-            # OpenCode
-            ln -sf "$AGENTS_DIR/$path" "$HOME/.config/opencode/skills/$skill_name/SKILL.md"
-            
-            # Codex
-            ln -sf "$AGENTS_DIR/$path" "$HOME/.codex/skills/$skill_name/SKILL.md"
-            
-            # Claude Code
-            ln -sf "$AGENTS_DIR/$path" "$HOME/.claude/skills/$skill_name/SKILL.md"
-            
-            # Amp
-            ln -sf "$AGENTS_DIR/$path" "$HOME/.config/amp/tools/$skill_name.md"
-        done
-    fi
-}
-```
+**This is no longer the approach.** Reasons:
+
+- **Isolated discovery**: Each runtime's skill directory is a silo. Skills can't cross-reference each other or link to tools/services/workflows.
+- **Flat structure**: One `SKILL.md` per directory with no naming convention — doesn't scale, can't sort/group/search by prefix.
+- **Duplicate paths**: Symlinks create a parallel discovery path that diverges from `.agents/` — agents find different content depending on which path they follow.
+- **No progressive disclosure**: The `SKILL.md` pattern is all-or-nothing. Our `{name}-skill.md` + `{name}-skill/` convention loads the entry point first, extended knowledge on demand.
+
+Runtimes that support `.agents/` or `AGENTS.md`-based discovery find ingested skills through the same mechanisms as native agents. For runtimes that only support their own skill directories, the `generate-skills.sh` script can produce compatible output as a build step — but `.agents/` is the source of truth.
 
 ## Popular Skills to Import
 
@@ -377,5 +358,5 @@ It does NOT check for semantic duplicates. Use `/add-skill list` to review.
 - `scripts/add-skill-helper.sh` - Main implementation
 - `scripts/clawdhub-helper.sh` - ClawdHub browser-based fetcher
 - `scripts/skill-update-helper.sh` - Automated update checking
-- `scripts/generate-skills.sh` - SKILL.md generation for aidevops agents
-- `build-agent.md` - Agent design patterns
+- `scripts/generate-skills.sh` - Compatibility output for runtimes that only support SKILL.md directories
+- `build-agent.md` - Agent design patterns (see "Folder Organization" for naming conventions)

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -191,6 +191,7 @@ The `-skill` suffix distinguishes ingested knowledge from native agents. See `ad
 - **Files**: lowercase with hyphens (`kebab-case`). ALLCAPS only for entry points (`AGENTS.md`).
 - **Scripts**: `[domain]-[function]-helper.sh` for agent-callable, plain `[name].sh` for framework infra.
 - **Python scripts**: `snake_case` (Python convention) — exception to kebab-case rule.
+- **Subagent discovery**: Tooling uses `find -mindepth 2` to discover subagents (skips root-level main agents).
 - **File structure** — main agents: `# Name` → `<!-- AI-CONTEXT-START -->` Quick Reference `<!-- AI-CONTEXT-END -->` → Detailed docs. Subagents: YAML frontmatter + content.
 - **Slash commands**: NEVER define inline in main agents. Generic → `scripts/commands/{command}.md`. Domain-specific → `{domain}/{subagent}.md`.
 

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -68,15 +68,129 @@ tools:
 ```text
 .agents/
 ├── AGENTS.md           # Entry point (ALLCAPS)
-├── {domain}.md         # Main agents at root (lowercase)
-├── {domain}/           # Subagents for that domain
-├── tools/              # Cross-domain utilities
-├── services/           # External integrations
-├── workflows/          # Process guides
-└── scripts/commands/   # Slash command definitions
+├── {agent}.md          # Main agents at root (lowercase, strategy/what)
+├── {agent}/            # Extended knowledge for that agent (flat files)
+├── tools/              # Cross-domain capabilities (how to do it)
+├── services/           # External integrations (how to connect)
+├── workflows/          # Process guides (how to process)
+├── reference/          # Operating rules (how to operate)
+├── scripts/            # Shared helper scripts (flat, cross-domain)
+├── scripts/commands/   # Slash command definitions
+├── configs/            # Configuration templates and schemas
+├── bundles/            # Project-type presets
+├── templates/          # Reusable templates
+├── rules/              # Enforced constraints
+├── tests/              # Agent test suites
+├── custom/             # User's private agents (survives updates)
+└── draft/              # R&D experimental (survives updates)
 ```
 
-- Naming: lowercase with hyphens; ALLCAPS only for entry points. Tooling uses `find -mindepth 2` for subagent discovery.
+### Strategy vs Execution Split
+
+Main agent directories contain **strategy** knowledge — what needs doing and why. Cross-domain directories contain **execution** knowledge — how to do it with specific tools and services.
+
+| Location | Contains | Nature |
+|----------|----------|--------|
+| `{agent}.md` + `{agent}/` | Domain strategy, methodology, audience knowledge | **What** to do |
+| `tools/` | Browser, git, database, code review, deployment tools | **How** to do it |
+| `services/` | Hosting, payments, communications, email providers | **How** to connect |
+| `workflows/` | Git flow, release, PR review, pre-edit checks | **How** to process |
+
+**Placement test:** "Would another agent use this independently without going through the owning agent?" Yes → `tools/` or `services/`. No → `{agent}/`.
+
+### The `{name}.md` + `{name}/` Convention
+
+Every agent or knowledge area follows the same pattern:
+
+- **Single-file agent**: `{name}.md` at the appropriate level. No directory needed.
+- **Multi-file agent**: `{name}.md` (entry point, always loaded) + `{name}/` (extended knowledge, loaded on demand).
+
+The `.md` file is the entry point — it contains the agent persona, capabilities overview, and pointers to extended knowledge. The directory contains deeper reference material that's only loaded when a specific sub-topic is needed.
+
+```text
+# Single-file agent (fits in one file)
+sales.md
+
+# Multi-file agent (needs extended knowledge)
+marketing.md                              # Entry point — strategy, capabilities
+marketing/                                # Extended knowledge — loaded on demand
+├── meta-ads.md                           # Meta Ads strategy and methodology
+├── meta-ads-audiences.md                 # Audience targeting reference
+├── meta-ads-campaigns.md                 # Campaign structure reference
+├── direct-response-copy.md               # DR copy methodology
+├── direct-response-copy-swipe-emails.md  # Email swipe file
+├── cro.md                                # Conversion rate optimization
+└── ad-creative.md                        # Ad creative methodology
+```
+
+### Flat Files with Descriptive Names (Prefer Over Nesting)
+
+Inside agent directories, prefer flat files with prefix-based naming over nested subdirectories. File names provide sorting, grouping, hierarchy, and keyword discoverability.
+
+```text
+# Good: flat, discoverable, sortable
+marketing/
+├── meta-ads.md
+├── meta-ads-audiences.md
+├── meta-ads-campaigns.md
+├── meta-ads-creative.md
+├── meta-ads-optimization.md
+├── direct-response-copy.md
+├── direct-response-copy-swipe-emails.md
+└── direct-response-copy-templates.md
+
+# Avoid: nested folders that hide content
+marketing/
+├── meta-ads/
+│   ├── audiences/
+│   │   └── targeting.md
+│   └── campaigns/
+│       └── structure.md
+└── direct-response-copy/
+    └── swipe-file/
+        └── emails/
+            └── welcome.md
+```
+
+**Benefits of flat naming:**
+- `ls marketing/` shows everything at a glance
+- `ls marketing/meta-ads*` groups all Meta Ads knowledge
+- `ls marketing/*swipe*` finds all swipe files across sub-topics
+- `rg --files -g "marketing/meta-ads*"` loads all Meta Ads context
+- Max depth is 2 levels from `.agents/` — never 5+
+
+**When to use a subdirectory:** Only when a single prefix group exceeds ~20 files of reference material. Even then, one level max.
+
+### Scripts: Flat by Design
+
+Scripts live flat in `scripts/` because they're cross-domain — any agent can call any script. The prefix naming convention (`email-*`, `seo-*`, `browser-*`) provides grouping via filesystem sort and glob patterns.
+
+- `*-helper.sh` = agent-callable utilities (agents run these)
+- Other `.sh` = framework infrastructure (setup, deployment, CI)
+- `scripts/commands/` = slash command documentation
+
+Discovery: `ls scripts/email-*`, `rg --files -g "scripts/seo-*"`.
+
+### Ingested Skills
+
+Skills imported from external sources (GitHub, ClawdHub) retain the `-skill` suffix as a provenance marker. This enables `skill-update-helper.sh` to identify and check all ingested skills for upstream changes.
+
+**Transposition on ingestion:** External skill structure is flattened to match our convention:
+
+| Upstream format | aidevops format |
+|-----------------|-----------------|
+| `SKILL.md` (entry point) | `{name}-skill.md` (named entry point) |
+| `{name}-skill/references/*.md` | `{name}-skill/{topic}.md` (flat) |
+| `{name}-skill/rules/*.md` | `{name}-skill/rules-{topic}.md` (flat) |
+| Nested `references/CHEATSHEET/*.md` | `{name}-skill/cheatsheet-{topic}.md` (flat) |
+
+The `-skill` suffix distinguishes ingested knowledge from native agents. See `add-skill.md` for full ingestion workflow.
+
+### Naming Conventions
+
+- **Files**: lowercase with hyphens (`kebab-case`). ALLCAPS only for entry points (`AGENTS.md`).
+- **Scripts**: `[domain]-[function]-helper.sh` for agent-callable, plain `[name].sh` for framework infra.
+- **Python scripts**: `snake_case` (Python convention) — exception to kebab-case rule.
 - **File structure** — main agents: `# Name` → `<!-- AI-CONTEXT-START -->` Quick Reference `<!-- AI-CONTEXT-END -->` → Detailed docs. Subagents: YAML frontmatter + content.
 - **Slash commands**: NEVER define inline in main agents. Generic → `scripts/commands/{command}.md`. Domain-specific → `{domain}/{subagent}.md`.
 

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -96,7 +96,7 @@ Main agent directories contain **strategy** knowledge — what needs doing and w
 | `services/` | Hosting, payments, communications, email providers | **How** to connect |
 | `workflows/` | Git flow, release, PR review, pre-edit checks | **How** to process |
 
-**Placement test:** "Would another agent use this independently without going through the owning agent?" Yes → `tools/` or `services/`. No → `{agent}/`.
+**Placement test:** "Would another agent use this independently without going through the owning agent?" Yes → `tools/`, `services/`, or `workflows/` (and `reference/` for operating rules). No → `{agent}/`.
 
 ### The `{name}.md` + `{name}/` Convention
 


### PR DESCRIPTION
## Summary

- Codifies the strategy-vs-execution split (`{agent}.md` + `{agent}/` = what to do; `tools/`, `services/`, `workflows/` = how to do it)
- Documents the `{name}.md` + `{name}/` convention explicitly with examples
- Adds flat-files-with-prefixes guidance (prefer over nested folders for discoverability)
- Documents scripts-flat-by-design rationale (cross-domain, prefix-named, `-helper` suffix meaning)
- Adds skill ingestion transposition rules (`SKILL.md` → `{name}-skill.md`, nested dirs → flat prefix-named files, `-skill` suffix as provenance marker)
- Updates `build-agent.md`, `architecture.md`, and `add-skill.md`

## Context

Audit of `.agents/` structure identified that conventions existed implicitly but weren't documented. As the framework scales toward potentially thousands of agents, these patterns need to be codified so new agents and skills follow consistent structure. This PR documents the guidance; subsequent PRs will migrate existing files to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined knowledge-base organization into separate "strategy" (agent entry docs) and "execution" (shared cross-agent resources) axes
  * Introduced new top-level directories and explicit responsibilities for tools, services, workflows, reference, configs, templates, bundles, rules, tests, custom, and drafts
  * Standardized entry-point vs extended-doc conventions and a preference for flat, prefix-based file naming with depth guidance
  * Clarified skill ingestion/transposition rules for imported content
  * Defined script placement and naming conventions, including agent-callable helper suffixes and discovery guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->