### PR TITLE
chore: raise simplification scan rate from 5 to 200 issues per run

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3242,7 +3242,7 @@ _complexity_scan_create_md_issues() {
 	local scan_results="$1"
 	local repos_json="$2"
 	local aidevops_slug="$3"
-	local max_issues_per_run=5
+	local max_issues_per_run=200
 	local issues_created=0
 	local issues_skipped=0
 
@@ -3293,7 +3293,7 @@ _complexity_scan_create_issues() {
 	local scan_results="$1"
 	local repos_json="$2"
 	local aidevops_slug="$3"
-	local max_issues_per_run=5
+	local max_issues_per_run=200
 	local issues_created=0
 	local issues_skipped=0
 


### PR DESCRIPTION
## Summary

- Raises `max_issues_per_run` from 5 to 200 in both `.sh` and `.md` complexity scan issue creators
- The open-issue cap (100) remains as the real safety valve — the per-run cap was the bottleneck preventing the scan from covering 824 eligible files
- At 5/day it would take ~165 days; now the open cap governs throughput naturally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the throttling limit for complexity scan issue creation, allowing more simplification-debt opportunities to be identified per scan run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->