### PR TITLE
chore: raise simplification open-issue cap from 100 to 500

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3309,7 +3309,7 @@ _complexity_scan_create_md_issues() {
 	local issues_skipped=0
 
 	# Total-open cap: stop creating when backlog is already large
-	_complexity_scan_check_open_cap "$aidevops_slug" 100 "Complexity scan (.md)" || return 0
+	_complexity_scan_check_open_cap "$aidevops_slug" 500 "Complexity scan (.md)" || return 0
 
 	local maintainer
 	maintainer=$(jq -r --arg slug "$aidevops_slug" \
@@ -3360,7 +3360,7 @@ _complexity_scan_create_issues() {
 	local issues_skipped=0
 
 	# Total-open cap: stop creating when backlog is already large
-	_complexity_scan_check_open_cap "$aidevops_slug" 100 "Complexity scan" || return 0
+	_complexity_scan_check_open_cap "$aidevops_slug" 500 "Complexity scan" || return 0
 
 	local maintainer
 	maintainer=$(jq -r --arg slug "$aidevops_slug" \


### PR DESCRIPTION
## Summary

- Raises the open simplification-debt issue cap from 100 to 500
- With 843 eligible files, the previous cap of 100 meant the scan would stall after front-loading 100 issues and wait for workers to clear them
- Combined with the 15-min scan interval (5 issues/cycle), the full backlog can now be covered in ~2 days instead of being drip-fed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation thresholds in code quality monitoring to support tracking a higher volume of open issues before limiting new issue creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->