### PR TITLE
t11267: tighten discord.md from 315 to 307 lines

### DIFF
--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -1,15 +1,7 @@
 ---
 description: Discord bot integration — discord.js (TypeScript), bot setup (Developer Portal, intents, OAuth2), DM/guild/thread messaging, slash commands, interactive components v2, role-based routing, access control, privacy/security assessment, aidevops runner dispatch, Matterbridge bridging
 mode: subagent
-tools:
-  read: true
-  write: false
-  edit: false
-  bash: true
-  glob: false
-  grep: false
-  webfetch: false
-  task: false
+tools: { read: true, write: false, edit: false, bash: true, glob: false, grep: false, webfetch: false, task: false }
 ---
 
 # Discord Bot Integration


### PR DESCRIPTION
## Summary

- Collapse verbose YAML frontmatter tools block (9 lines → 1 line inline object)
- Preserve all functional content: code blocks, URLs, command examples, security notes

## Changes

- `.agents/services/communications/discord.md`: 315 → 307 lines (2.5% reduction)

## Notes

This file is already lean — the bulk of content is functional code blocks (TypeScript, bash, TOML, JSON) that cannot be compressed without losing operational value. The frontmatter was the only structural redundancy.

## Runtime Testing

- **Risk classification**: Low (docs-only change)
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 307 lines; diff confirms no code block content removed

Closes #11267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Discord service documentation formatting for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->