### PR TITLE
fix: always clean stale files during agent deployment

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -286,16 +286,17 @@ deploy_aidevops_agents() {
 	# Create target directory
 	mkdir -p "$target_dir"
 
-	# If clean mode, remove stale files first (preserving user and plugin directories)
-	if [[ "$CLEAN_MODE" == "true" ]]; then
-		local -a preserved_dirs=("custom" "draft")
-		if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
-			for pns in "${plugin_namespaces[@]}"; do
-				preserved_dirs+=("$pns")
-			done
-		fi
-		_deploy_agents_clean_mode "$target_dir" "${preserved_dirs[@]}" || return 1
+	# Always clean stale files from previous deployments. Files that were
+	# moved or deleted in the source repo would otherwise persist in the
+	# deployed directory indefinitely (rsync without --delete is additive).
+	# Preserves user directories (custom/, draft/) and plugin namespaces.
+	local -a preserved_dirs=("custom" "draft")
+	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
+		for pns in "${plugin_namespaces[@]}"; do
+			preserved_dirs+=("$pns")
+		done
 	fi
+	_deploy_agents_clean_mode "$target_dir" "${preserved_dirs[@]}" || return 1
 
 	# Copy all agent files and folders, excluding:
 	# - loop-state/ (local runtime state, not agents)


### PR DESCRIPTION
## Summary

- Always prune stale files from `~/.aidevops/agents/` before deploying, not just when `--clean` is passed
- Prevents moved/deleted files from persisting indefinitely after reorganisations
- Preserves `custom/`, `draft/`, and plugin namespace directories (unchanged behaviour)

## Context

After the v3.2.0 `.agents/` reorganisation (PR #11127), stale directories like `tools/marketing/`, `tools/social-media/`, `tools/accounts/` persisted in the deployed location because `rsync` without `--delete` is additive. The `_deploy_agents_clean_mode` function already existed and correctly preserves user content — it just wasn't being called by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Agent deployment process now consistently applies clean mode deployment without conditional checks, ensuring uniform behavior across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->