### PR TITLE
GH#11282: Simplify Offer Construction Framework (442→247 lines)

### DIFF
--- a/.agents/marketing/direct-response-copy-frameworks-offer-construction.md
+++ b/.agents/marketing/direct-response-copy-frameworks-offer-construction.md
@@ -24,13 +24,13 @@ An offer is **everything the customer gets when they say yes**—not just the pr
 
 Value stacking shows customers they're getting way more value than they're paying for.
 
-### The Basic Value Stack Structure
+### Structure
 
-```
+```text
 CORE OFFER: [Main Product] .................. $X,XXX Value
 
 BONUS 1: [Fast-Action Bonus] ................ $XXX Value
-BONUS 2: [Complementary Tool/Resource] ...... $XXX Value  
+BONUS 2: [Complementary Tool/Resource] ...... $XXX Value
 BONUS 3: [Access/Community] ................. $XXX Value
 BONUS 4: [Support/Implementation] ........... $XXX Value
 
@@ -48,56 +48,9 @@ GUARANTEE: [Risk Reversal]
 3. **Anchor with the total first** — Show the full value before revealing the price
 4. **Make bonuses tangible** — Specific deliverables, not vague promises
 
-### Example Value Stack (Course)
-
-```
-THE COPYWRITING ACCELERATOR
-
-CORE TRAINING
-Complete Copywriting Course (12 modules, 47 lessons) .... $997 Value
-  • Module 1: Direct Response Fundamentals
-  • Module 2: Research That Reveals Buyers
-  • Module 3: Headlines That Stop the Scroll
-  [etc.]
-
-BONUS 1: SWIPE FILE VAULT
-200+ Proven Templates & Examples ...................... $297 Value
-  • Headlines that converted
-  • Email sequences that sold
-  • Landing pages that worked
-
-BONUS 2: LIVE COPY CRITIQUES  
-4 Weekly Group Coaching Calls ......................... $500 Value
-  • Submit your copy for feedback
-  • Learn from others' work
-  • Direct access to instructor
-
-BONUS 3: PRIVATE COMMUNITY
-Lifetime Access to Student Network .................... $197 Value
-  • Connect with other copywriters
-  • Share wins and get feedback
-  • Exclusive job opportunities
-
-BONUS 4: QUICK-START GUIDE
-"Write Your First Sales Page in 48 Hours" ............ $97 Value
-  • Step-by-step framework
-  • Fill-in-the-blank templates
-  • Fast implementation
-
-─────────────────────────────────────────────────
-TOTAL VALUE: $2,088
-
-YOUR INVESTMENT TODAY: Just $497
-(or 3 payments of $177)
-
-GUARANTEE: 30-Day "Try It Risk-Free"
-If you don't love it, email us for a full refund.
-─────────────────────────────────────────────────
-```
-
 ### Example Value Stack (SaaS)
 
-```
+```text
 LOCALRANK PRO PLAN
 
 CORE PLATFORM
@@ -152,20 +105,13 @@ Show a higher price first to make your price feel reasonable.
 
 ### Charm Pricing
 
-Prices ending in 7, 9, or 95 feel more like deals.
-
-| Original | Charm Price |
-|----------|-------------|
-| $100 | $97 |
-| $50 | $47 |
-| $500 | $497 |
-| $1000 | $997 |
+Prices ending in 7, 9, or 95 feel more like deals (e.g., $97 instead of $100, $497 instead of $500).
 
 ### Payment Plans
 
 Reduce friction by breaking large amounts into smaller payments.
 
-```
+```text
 ONE-TIME PAYMENT: $497 (Best Value - Save $34)
 — or —
 3 MONTHLY PAYMENTS: $177/month
@@ -175,12 +121,7 @@ ONE-TIME PAYMENT: $497 (Best Value - Save $34)
 
 ### The 10x Rule
 
-Your offer should deliver **10x the value** of the price.
-
-- If you charge $500, customer should get $5,000+ in value
-- If you charge $5,000, customer should get $50,000+ in value
-
-This is the "no-brainer threshold"—when the value is so obviously greater than the price that saying no feels foolish.
+Your offer should deliver **10x the value** of the price. This is the "no-brainer threshold"—when the value is so obviously greater than the price that saying no feels foolish.
 
 ---
 
@@ -188,79 +129,22 @@ This is the "no-brainer threshold"—when the value is so obviously greater than
 
 A strong guarantee removes the fear of making a wrong decision.
 
-### 1. Money-Back Guarantee
-
-```
-100% MONEY-BACK GUARANTEE
-
-Try [Product] for 30 days. If you don't love it, 
-email us and we'll refund every penny. No questions asked.
-
-You have nothing to lose.
-```
-
-**When to use:** Most situations. Standard and expected.
-
-### 2. Results-Based Guarantee
-
-```
-THE "GET RESULTS OR GET YOUR MONEY BACK" GUARANTEE
-
-Use [Product] for 60 days. If you don't see [specific result],
-show us you implemented the system and we'll refund you in full.
-```
-
-**When to use:** When you're confident in results AND want to filter for serious buyers.
-
-### 3. Risk Reversal Guarantee
-
-```
-THE "[PRODUCT] PROMISE"
-
-If [Product] doesn't [deliver specific outcome] within [timeframe],
-we'll [give you more than a refund—specific action].
-
-Not only will we refund your investment, we'll also 
-[give you $X / pay you for your time / etc.]
-```
-
-**When to use:** When you want to make an ultra-bold statement.
-
-### 4. Free Trial
-
-```
-START YOUR FREE TRIAL
-
-Try [Product] free for 14 days. 
-No credit card required. Cancel anytime.
-
-If you love it, upgrade to keep all your work.
-If not, no hard feelings—we'll still send you free tips.
-```
-
-**When to use:** SaaS and subscription products.
-
-### 5. Double Your Money Back
-
-```
-DOUBLE YOUR MONEY BACK GUARANTEE
-
-If [Product] doesn't [result], we'll refund your purchase 
-AND pay you $100 for your trouble.
-
-That's how confident we are.
-```
-
-**When to use:** When you need to overcome extreme skepticism or compete in a crowded market.
+| Type | Template | When to Use |
+|------|----------|-------------|
+| **Money-Back** | "Try [Product] for 30 days. If you don't love it, full refund. No questions asked." | Most situations (standard) |
+| **Results-Based** | "Use [Product] for 60 days. If you don't see [specific result] after implementing, full refund." | Confident in results + filter serious buyers |
+| **Risk Reversal** | "If [Product] doesn't [outcome] within [timeframe], we'll refund you AND [extra compensation]." | Ultra-bold statement needed |
+| **Free Trial** | "Try free for 14 days. No credit card required. Cancel anytime." | SaaS and subscriptions |
+| **Double Money Back** | "If [Product] doesn't [result], we'll refund AND pay you $100 for your trouble." | Overcoming extreme skepticism |
 
 ### Guarantee Copy Formula
 
-```
+```text
 [GUARANTEE NAME]
 
-Try [Product] for [timeframe]. 
+Try [Product] for [timeframe].
 
-If [condition—what they need to experience], 
+If [condition—what they need to experience],
 just [action—email us / fill out form], and we'll [action—refund you].
 
 [Optional: No questions asked / No hassle / Simple process]
@@ -285,45 +169,23 @@ Urgency and scarcity work because of **loss aversion**—people fear missing out
 | **Seasonal** | "Black Friday pricing—this week only" | Holiday sales |
 | **Cart expiration** | "Your cart will expire in 24 hours" | Cart abandonment |
 
-### How to Write Urgency Copy
+### Urgency Copy Template
 
-```
-WHY YOU SHOULD ACT NOW:
-
-[Reason the deadline/limit exists]
-
-After [deadline]:
-❌ [What they'll lose - bonus 1]
-❌ [What they'll lose - bonus 2]
-❌ [Price increase / doors close]
-
-Don't wait. [CTA]
-```
-
-### Example Urgency Block
-
-```
+```text
 ⏰ THIS OFFER EXPIRES IN:
 [Countdown Timer]
 
-After the timer hits zero:
-• The $497 price goes back to $997
-• The bonus templates disappear
-• The early-bird coaching calls are gone
+After [deadline]:
+❌ [What they'll lose - bonus/price/access]
+❌ [What they'll lose - bonus/price/access]
+❌ [Price increase / doors close]
 
 This is the lowest price [Product] will ever be.
 
 [Get Instant Access Now →]
 ```
 
-### ⚠️ Warning: Never Fake Urgency
-
-Fake urgency destroys trust:
-- Countdown timers that reset
-- "Limited spots" that are never limited
-- "Sale ends today" that runs forever
-
-**Rule:** Only use urgency that's real. If you say it ends Friday, it ends Friday.
+**Warning:** Never fake urgency. Countdown timers that reset, "limited spots" that aren't limited, and "sale ends today" that runs forever destroy trust. Only use urgency that's real.
 
 ---
 
@@ -375,63 +237,6 @@ Before launching, verify:
 - [ ] Single, clear call to action
 - [ ] CTA button text is action-oriented
 - [ ] CTA appears multiple times on page
-
----
-
-## Example Offers for Jacky's Businesses
-
-### BrowserBlast Offer
-
-```
-BROWSERBLAST PRO
-
-CORE: Unlimited Indexing Requests .............. $149/mo Value
-  • Submit unlimited URLs
-  • Priority indexing queue
-  • Bulk upload (up to 10,000 URLs)
-
-BONUS 1: Indexing Dashboard .................... Included
-  • Real-time status tracking
-  • Historical reports
-  • API access
-
-BONUS 2: Indexing Strategy Guide ............... $97 Value
-  • Best practices for fast indexing
-  • What makes Google index faster
-  • Advanced techniques
-
-─────────────────────────────────────────────────
-TOTAL VALUE: $246/mo
-
-PRO PLAN: $49/mo
-(Annual: $39/mo — Save $120)
-
-GUARANTEE: 14-day free trial, no credit card required
-─────────────────────────────────────────────────
-```
-
-### LocalRank Agency Offer
-
-```
-LOCALRANK AGENCY PLAN
-
-For agencies managing multiple client locations.
-
-CORE: Full Platform (25 locations) ............. $299/mo Value
-BONUS 1: White-Label Reports ................... $99/mo Value  
-BONUS 2: Client Management Dashboard ........... $49/mo Value
-BONUS 3: Agency Training Certification ......... $297 Value
-BONUS 4: Priority Support ...................... $50/mo Value
-
-─────────────────────────────────────────────────
-TOTAL VALUE: $794+/mo
-
-AGENCY PLAN: $149/mo
-(Annual: $129/mo — Save $240)
-
-GUARANTEE: 30-day money back, no questions asked
-─────────────────────────────────────────────────
-```
 
 ---
 


### PR DESCRIPTION
## Summary

- Reduces `.agents/marketing/direct-response-copy-frameworks-offer-construction.md` from 442 to 247 lines (44% reduction)
- Removes redundant examples while preserving all frameworks, formulas, checklists, and cross-references
- Fixes 5 pre-existing MD040 lint violations (missing language specifiers on fenced code blocks)

Closes #11282

## What Changed

| Removed | Rationale |
|---------|-----------|
| Course value stack example (45 lines) | SaaS example already teaches the pattern |
| 5 individual guarantee copy blocks (84 lines) | Condensed into reference table + generic formula |
| Duplicate urgency copy block (16 lines) | Merged template + example into single template |
| Client-specific examples — BrowserBlast + LocalRank Agency (55 lines) | Pattern already taught by SaaS example above |
| Charm pricing table (8 lines) | Inlined as single sentence (pattern is obvious) |
| 10x rule expansion (4 lines) | Merged into single sentence |

## What's Preserved

- All 5 guarantee types (now in table format)
- Value stacking structure + rules + SaaS example
- All 4 pricing psychology techniques
- All 6 urgency/scarcity tactics
- Offer testing framework
- Complete offer checklist (value, price, risk reversal, urgency, CTA)
- All cross-references to related docs

## Runtime Testing

- **Testing level:** `self-assessed`
- **Risk classification:** Low (docs/agent prompts only — no code, no runtime behaviour)
- **Verification:** `markdownlint-cli2` — 0 errors (was 5 before fix)