### PR TITLE
t11140: tighten playwright.md 439→183 lines

### DIFF
--- a/.agents/tools/browser/playwright.md
+++ b/.agents/tools/browser/playwright.md
@@ -52,13 +52,13 @@ This is the underlying engine used by dev-browser, agent-browser, and Stagehand.
 **Chrome DevTools MCP**: Connect via `npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222` for Lighthouse, network monitoring, CSS coverage alongside Playwright automation.
 
 **Test types**:
-- Cross-browser: `runTest()`, `testBrowserFeatures()`
-- User flows: `automateFlow()`, `testFormValidation()`
-- Mobile: `testOnDevice()`, `testOrientations()`
-- Performance: `measurePerformance()`, `testWithNetwork()`
-- Visual: `visualRegressionSuite()`, `screenshotComponents()`
-- Security: `testXSS()`, `testAuthentication()`
-- API: `testAPIIntegration()`, `testRealTimeFeatures()`
+- Cross-browser: iterate over `['chromium', 'firefox', 'webkit']`
+- User flows: `page.click()`, `page.fill()`, `page.goto()`
+- Mobile: `devices['iPhone 12']` preset via `browser.newContext({ ...devices['iPhone 12'] })`
+- Performance: `page.evaluate(() => performance.getEntriesByType('navigation'))`
+- Visual: `page.screenshot()`, `expect(page).toHaveScreenshot()`
+- Security: XSS payloads via `page.fill()`, auth flow assertions
+- API: `page.route()` intercept + `page.waitForResponse()`
 
 <!-- AI-CONTEXT-END -->
 
@@ -95,48 +95,38 @@ npx --no-install playwright --version
 
 ## Custom Browser Engine (Brave, Edge, Chrome)
 
-Use `executablePath` to launch Brave, Edge, or Chrome instead of Playwright's bundled Chromium. This gives you access to browser-specific features like Brave Shields (ad blocking) or Edge enterprise SSO.
-
-### Launch with Custom Browser
-
-**Brave** - built-in ad/tracker blocking via Shields:
+Use `executablePath` to launch Brave, Edge, or Chrome instead of Playwright's bundled Chromium. This gives access to browser-specific features like Brave Shields (ad blocking) or Edge enterprise SSO.
 
 ```javascript
 import { chromium } from 'playwright';
 
+// Brave — built-in ad/tracker blocking via Shields
 const browser = await chromium.launch({
   executablePath: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
   headless: true,
 });
+
+// Microsoft Edge — enterprise SSO, Azure AD
+// executablePath: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
+
+// Google Chrome — widest extension compatibility
+// executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
 ```
 
-**Microsoft Edge** - enterprise SSO, Azure AD:
+### Browser Executable Paths
 
-```javascript
-import { chromium } from 'playwright';
+> Paths below are default install locations and may vary by distribution or package manager.
 
-const browser = await chromium.launch({
-  executablePath: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-  headless: true,
-});
-```
+| Browser | macOS | Linux | Windows |
+|---------|-------|-------|---------|
+| **Brave** | `/Applications/Brave Browser.app/Contents/MacOS/Brave Browser` | `/usr/bin/brave-browser` | `C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe` |
+| **Edge** | `/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge` | `/usr/bin/microsoft-edge` | `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe` |
+| **Chrome** | `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` | `/usr/bin/google-chrome` | `C:\Program Files\Google\Chrome\Application\chrome.exe` |
+| **Chromium** (bundled) | Auto-detected by Playwright | Auto-detected | Auto-detected |
 
-**Google Chrome** - widest extension compatibility:
+### Persistent Context + Extensions
 
-```javascript
-import { chromium } from 'playwright';
-
-const browser = await chromium.launch({
-  executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-  headless: true,
-});
-```
-
-### Custom Browser with Persistent Context + Extensions
-
-Combine a custom browser engine with extensions (e.g., uBlock Origin):
-
-**Brave + uBlock Origin** (Brave Shields may make uBlock redundant):
+Combine a custom browser with extensions. Extensions require `headless: false` on older Chromium; new headless (`--headless=new`) supports them.
 
 ```javascript
 import { chromium } from 'playwright';
@@ -145,24 +135,6 @@ const context = await chromium.launchPersistentContext(
   '/tmp/brave-profile',
   {
     executablePath: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
-    headless: false,  // Extensions may require headed mode in older Chromium; new headless (--headless=new) supports extensions
-    args: [
-      '--load-extension=/path/to/ublock-origin-unpacked',
-      '--disable-extensions-except=/path/to/ublock-origin-unpacked',
-    ],
-  }
-);
-```
-
-**Edge + uBlock Origin**:
-
-```javascript
-import { chromium } from 'playwright';
-
-const context = await chromium.launchPersistentContext(
-  '/tmp/edge-profile',
-  {
-    executablePath: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
     headless: false,
     args: [
       '--load-extension=/path/to/ublock-origin-unpacked',
@@ -172,268 +144,40 @@ const context = await chromium.launchPersistentContext(
 );
 ```
 
-### Browser Executable Paths
+> Note: Brave Shields may make uBlock Origin redundant. Same pattern works for Edge + uBlock.
 
-> **Note**: Paths below are default install locations and may vary by distribution, package manager, or custom install directory.
-
-| Browser | macOS | Linux | Windows |
-|---------|-------|-------|---------|
-| **Brave** | `/Applications/Brave Browser.app/Contents/MacOS/Brave Browser` | `/usr/bin/brave-browser` | `C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe` |
-| **Edge** | `/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge` | `/usr/bin/microsoft-edge` | `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe` |
-| **Chrome** | `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` | `/usr/bin/google-chrome` | `C:\Program Files\Google\Chrome\Application\chrome.exe` |
-| **Chromium** (bundled) | Auto-detected by Playwright | Auto-detected | Auto-detected |
-
-### Parallel Instances with Custom Browser
+### Parallel Instances
 
 ```javascript
 import { chromium } from 'playwright';
 
 const executablePath = '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser';
 
-// 3 parallel persistent contexts with Brave + extensions
+// 3 parallel persistent contexts — each fully isolated
 const contexts = await Promise.all([
   chromium.launchPersistentContext('/tmp/profile-1', { executablePath, headless: false }),
   chromium.launchPersistentContext('/tmp/profile-2', { executablePath, headless: false }),
   chromium.launchPersistentContext('/tmp/profile-3', { executablePath, headless: false }),
 ]);
 
-// Each context is fully isolated with its own profile
 for (const ctx of contexts) {
   const page = ctx.pages()[0] || await ctx.newPage();
   await page.goto('https://example.com');
 }
 ```
 
-## Cross-Browser Testing
+## Testing Patterns
 
-### **Multi-Browser Test Suite**
+For comprehensive device emulation (presets, viewport/HiDPI, geolocation, locale/timezone, permissions, color scheme, offline, responsive breakpoints), see `playwright-emulation.md`.
 
-```javascript
-// Test across different browsers
-const browsers = ['chromium', 'firefox', 'webkit'];
+**Cross-browser**: Iterate `['chromium', 'firefox', 'webkit']` and call `playwright[browserName].launch()`.
 
-for (const browserName of browsers) {
-  await playwright.runTest({
-    browser: browserName,
-    url: "https://your-website.com",
-    test: "login-flow"
-  });
-}
-```
+**Mobile**: Use `devices['iPhone 12']` preset — `browser.newContext({ ...devices['iPhone 12'] })`.
 
-### **Browser-Specific Feature Testing**
+**Performance**: `page.evaluate(() => performance.getEntriesByType('navigation')[0])` for Core Web Vitals. Use CDP `Network.emulateNetworkConditions` for throttling.
 
-```javascript
-// Test browser-specific features
-await playwright.testBrowserFeatures({
-  url: "https://your-website.com",
-  features: ["webgl", "webrtc", "geolocation", "notifications"],
-  browsers: ["chromium", "firefox", "webkit"]
-});
-```
+**Visual regression**: `expect(page).toHaveScreenshot('name.png', { threshold: 0.2 })` across viewports `[1920, 1366, 375]`.
 
-## 🔄 **Automated User Flows**
+**Security**: Inject XSS payloads via `page.fill()`, assert no alert dialogs fire. Test auth flows with valid/invalid credentials and assert redirect targets.
 
-### **E-commerce Checkout Flow**
-
-```javascript
-// Automate complete checkout process
-await playwright.automateFlow({
-  url: "https://your-ecommerce.com",
-  steps: [
-    { action: "click", selector: ".product-card:first-child" },
-    { action: "click", selector: ".add-to-cart" },
-    { action: "click", selector: ".cart-icon" },
-    { action: "fill", selector: "#email", value: "test@example.com" },
-    { action: "fill", selector: "#password", value: "testpass123" },
-    { action: "click", selector: ".checkout-button" }
-  ]
-});
-```
-
-### **Form Validation Testing**
-
-```javascript
-// Test form validation scenarios
-await playwright.testFormValidation({
-  url: "https://your-website.com/contact",
-  form: "#contact-form",
-  scenarios: [
-    { field: "email", value: "invalid-email", expectError: true },
-    { field: "phone", value: "123", expectError: true },
-    { field: "message", value: "", expectError: true }
-  ]
-});
-```
-
-## 📱 **Mobile & Responsive Testing**
-
-> **Detailed guide**: See `playwright-emulation.md` for comprehensive device emulation including device presets, viewport/HiDPI, geolocation, locale/timezone, permissions, color scheme, offline mode, and responsive breakpoint recipes.
-
-### **Device-Specific Testing**
-
-```javascript
-// Test on various mobile devices
-const devices = [
-  'iPhone 12',
-  'iPhone 12 Pro Max',
-  'Samsung Galaxy S21',
-  'iPad Pro'
-];
-
-for (const device of devices) {
-  await playwright.testOnDevice({
-    device: device,
-    url: "https://your-website.com",
-    tests: ["navigation", "forms", "media-queries"]
-  });
-}
-```
-
-### **Orientation Testing**
-
-```javascript
-// Test portrait and landscape orientations
-await playwright.testOrientations({
-  url: "https://your-website.com",
-  device: "iPhone 12",
-  orientations: ["portrait", "landscape"],
-  captureScreenshots: true
-});
-```
-
-## 🎯 **Performance Testing**
-
-### **Load Time Analysis**
-
-```javascript
-// Measure page load performance
-await playwright.measurePerformance({
-  url: "https://your-website.com",
-  metrics: [
-    "domContentLoaded",
-    "load",
-    "firstContentfulPaint",
-    "largestContentfulPaint"
-  ],
-  iterations: 5
-});
-```
-
-### **Network Throttling Tests**
-
-```javascript
-// Test under different network conditions
-const networkConditions = [
-  { name: "Fast 3G", downloadThroughput: 1.5 * 1024 * 1024 / 8 },
-  { name: "Slow 3G", downloadThroughput: 500 * 1024 / 8 },
-  { name: "Offline", offline: true }
-];
-
-for (const condition of networkConditions) {
-  await playwright.testWithNetwork({
-    url: "https://your-website.com",
-    networkCondition: condition,
-    timeout: 30000
-  });
-}
-```
-
-## 🔍 **Visual Testing & Screenshots**
-
-### **Visual Regression Suite**
-
-```javascript
-// Comprehensive visual regression testing
-await playwright.visualRegressionSuite({
-  baseUrl: "https://your-website.com",
-  pages: ["/", "/about", "/products", "/contact"],
-  viewports: [
-    { width: 1920, height: 1080 },
-    { width: 1366, height: 768 },
-    { width: 375, height: 667 }
-  ],
-  threshold: 0.2
-});
-```
-
-### **Component Screenshot Testing**
-
-```javascript
-// Test individual components
-await playwright.screenshotComponents({
-  url: "https://your-website.com",
-  components: [
-    { selector: ".header", name: "header" },
-    { selector: ".navigation", name: "nav" },
-    { selector: ".hero-section", name: "hero" },
-    { selector: ".footer", name: "footer" }
-  ]
-});
-```
-
-## 🛡️ **Security Testing**
-
-### **XSS Vulnerability Testing**
-
-```javascript
-// Test for XSS vulnerabilities
-await playwright.testXSS({
-  url: "https://your-website.com",
-  forms: ["#search-form", "#contact-form", "#login-form"],
-  payloads: [
-    "<script>alert('XSS')</script>",
-    "javascript:alert('XSS')",
-    "<img src=x onerror=alert('XSS')>"
-  ]
-});
-```
-
-### **Authentication Testing**
-
-```javascript
-// Test authentication flows
-await playwright.testAuthentication({
-  loginUrl: "https://your-website.com/login",
-  credentials: {
-    valid: { username: "testuser", password: "testpass" },
-    invalid: { username: "invalid", password: "wrong" }
-  },
-  protectedUrls: ["/dashboard", "/profile", "/settings"]
-});
-```
-
-## 📊 **API Testing Integration**
-
-### **API Response Validation**
-
-```javascript
-// Test API endpoints through UI interactions
-await playwright.testAPIIntegration({
-  url: "https://your-website.com",
-  interactions: [
-    {
-      action: "click",
-      selector: ".load-more",
-      expectAPI: {
-        url: "/api/posts",
-        method: "GET",
-        status: 200
-      }
-    }
-  ]
-});
-```
-
-### **Real-time Data Testing**
-
-```javascript
-// Test real-time features
-await playwright.testRealTimeFeatures({
-  url: "https://your-chat-app.com",
-  scenarios: [
-    { action: "sendMessage", text: "Hello World" },
-    { action: "expectMessage", text: "Hello World", timeout: 5000 }
-  ]
-});
-```
+**API interception**: `page.route('/api/**', route => route.fulfill({ json: mockData }))` or `page.waitForResponse(r => r.url().includes('/api/posts'))`.


### PR DESCRIPTION
## Summary

- Reduces `.agents/tools/browser/playwright.md` from 439 to 183 lines (58% reduction, 1 file changed)
- Replaces illustrative fictional API wrappers (`playwright.runTest()`, `playwright.automateFlow()`, etc.) with real Playwright patterns (`page.click()`, `page.fill()`, `expect(page).toHaveScreenshot()`)
- Preserves all operational content: installation, MCP config, custom browser engine, all executable paths (Brave/Edge/Chrome on macOS/Linux/Windows), persistent context + extensions, parallel instances, and pointer to `playwright-emulation.md`
- Compresses 7 verbose test-type sections into a single compact "Testing Patterns" section

## Runtime Testing

- **Risk**: Low (docs/agent prompt only — no code execution paths changed)
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 183 lines; `rg` confirms all key technical terms, browser paths, and cross-references preserved

## Files Changed

- `.agents/tools/browser/playwright.md` — tightened per simplification-debt guidelines

Closes #11140