### PR TITLE
GH#11289: tighten email sequence templates (423→304 lines)

### DIFF
--- a/.agents/marketing/direct-response-copy-templates-email-sequences.md
+++ b/.agents/marketing/direct-response-copy-templates-email-sequences.md
@@ -3,6 +3,7 @@
 ## Shared Conventions
 
 **Defaults for all templates** (don't repeat in each email):
+
 - Greeting: `Hey [First Name],` or `[First Name],`
 - Sign-off: `[Your Name]` (solo brand) or `— [Your Name/Team]` (SaaS/company)
 - Every email ends with a reply invitation ("Just reply", "Hit reply", etc.)
@@ -16,18 +17,12 @@ Archetypes referenced by name across sequences. Sequence-specific customisations
 
 ```
 I want to introduce you to [Customer Name].
-
 Before: [Their situation before]
 Challenge: [What was holding them back]
-
 Then they [took specific action with your help].
-
 After: [Specific results — use numbers]
-
 "[Testimonial quote]"
-
 The key insight? [What made the difference]
-
 [CTA — soft or hard depending on sequence stage]
 ```
 
@@ -35,18 +30,10 @@ The key insight? [What made the difference]
 
 ```
 Here are the questions most people have:
-
-"Is it really worth the price?"
-→ [Brief value statement]
-
-"Will it work for my situation?"
-→ [Address common use cases]
-
-"What if I don't like it?"
-→ [Guarantee reminder]
-
+"Is it really worth the price?" → [Brief value statement]
+"Will it work for my situation?" → [Address common use cases]
+"What if I don't like it?" → [Guarantee reminder]
 [Additional product-specific Qs as needed]
-
 [CTA]
 ```
 
@@ -54,14 +41,9 @@ Here are the questions most people have:
 
 ```
 [What's ending] disappear in [timeframe].
-
 After [deadline]:
-❌ [Loss 1]
-❌ [Loss 2]
-❌ [Price increase]
-
+❌ [Loss 1]  ❌ [Loss 2]  ❌ [Price increase]
 If you've been on the fence, now's the time.
-
 [CTA]
 ```
 
@@ -75,19 +57,11 @@ If you've been on the fence, now's the time.
 
 ```
 Welcome! I'm [Your Name], and I'm glad you're here.
-
-As promised, here's your [Resource Name]:
-[Download Link]
-
+As promised, here's your [Resource Name]: [Download Link]
 I created [Resource] because [connect to their problem].
-
 Over the next few days, I'll share:
-• [What email 2 covers]
-• [What email 3 covers]
-• [What email 4 covers]
-
+• [What email 2 covers]  • [What email 3 covers]  • [What email 4 covers]
 For now, grab your [resource] and let me know if you have questions.
-
 P.S. The [specific section/page] is my favorite part—start there.
 ```
 
@@ -97,14 +71,9 @@ P.S. The [specific section/page] is my favorite part—start there.
 
 ```
 Yesterday I sent you [Resource]. Did you grab it?
-
 Here's a quick win you can use right now:
-
 [Actionable tip in 3-5 sentences]
-
-Why it works:
-[Brief explanation]
-
+Why it works: [Brief explanation]
 Try it today. Tomorrow, I'll share [preview of next email].
 ```
 
@@ -114,54 +83,29 @@ Try it today. Tomorrow, I'll share [preview of next email].
 
 ```
 Let me tell you a quick story.
-
 [Timeframe] ago, I was [in their situation].
-
-I tried [what didn't work].
-I spent [money/time] on [failed solutions].
-I was about to [give up].
-
-Then [discovery moment].
-
-[Brief description of what changed]
-
+I tried [what didn't work]. I spent [money/time] on [failed solutions]. I was about to [give up].
+Then [discovery moment]. [Brief description of what changed]
 The lesson? [Key takeaway they can apply]
-
-If you're in a similar spot, here's what I'd do:
-[Specific action step]
+If you're in a similar spot, here's what I'd do: [Specific action step]
 ```
 
 ### Email 4: Social Proof (Day 5)
 
 **Subject:** How [Customer Name] [achieved specific result]
 
-Uses **Social Proof pattern** above. Soft CTA: preview tomorrow's offer.
+Uses **Social Proof pattern**. Soft CTA: preview tomorrow's offer.
 
 ### Email 5: Offer (Day 7)
 
 **Subject:** Ready to [achieve their desired outcome]?
 
 ```
-Over the past week, I've shared:
-• [Value point 1]
-• [Value point 2]
-• [Value point 3]
-
-Now I have something for you: [Product Name].
-
-[One-sentence description]
-
-Here's what you get:
-• [Benefit 1]
-• [Benefit 2]
-• [Benefit 3]
-
-Plus these bonuses:
-• [Bonus 1]
-• [Bonus 2]
-
+Over the past week, I've shared: • [Value 1] • [Value 2] • [Value 3]
+Now I have something for you: [Product Name]. [One-sentence description]
+Here's what you get: • [Benefit 1] • [Benefit 2] • [Benefit 3]
+Plus these bonuses: • [Bonus 1] • [Bonus 2]
 [CTA Button: Get [Product Name] →]
-
 P.S. [Urgency element—deadline, limited spots, etc.]
 ```
 
@@ -175,10 +119,7 @@ P.S. [Urgency element—deadline, limited spots, etc.]
 
 ```
 I noticed you started checking out but didn't finish.
-
-No worries—these things happen. Your cart is still saved:
-[Link to Cart]
-
+No worries—these things happen. Your cart is still saved: [Link to Cart]
 If you ran into any issues, just hit reply.
 ```
 
@@ -186,7 +127,7 @@ If you ran into any issues, just hit reply.
 
 **Subject:** Quick question about your [Product] order
 
-Uses **Objection Handling pattern** above. Include cart link after Q&A block.
+Uses **Objection Handling pattern**. Include cart link after Q&A block.
 
 ### Email 3: Final Push + Incentive (48 Hours)
 
@@ -194,13 +135,8 @@ Uses **Objection Handling pattern** above. Include cart link after Q&A block.
 
 ```
 I wanted to check in one more time about [Product].
-
 Use code [CODE] at checkout for [discount/bonus] off your order.
-
-[Link to Cart]
-
-This code expires in 24 hours.
-
+[Link to Cart] — This code expires in 24 hours.
 P.S. [Guarantee reminder]
 ```
 
@@ -213,23 +149,12 @@ P.S. [Guarantee reminder]
 **Subject:** Welcome to [Product]! Here's how to start
 
 ```
-You're in! 🎉
-
-Here's the fastest way to get value from [Product]:
-
-1. [First action] — [What it does for them]
-   [Link directly to feature]
-
-2. [Second action] — [What it does for them]
-   [Link]
-
-3. [Third action - the "aha moment"] — [What it does for them]
-   [Link]
-
+You're in! Here's the fastest way to get value from [Product]:
+1. [First action] — [What it does for them] [Link]
+2. [Second action] — [What it does for them] [Link]
+3. [Third action - the "aha moment"] — [What it does for them] [Link]
 ⏱️ Most users finish setup in under [X] minutes.
-
 [Log in to [Product] →]
-
 P.S. Your trial lasts [X] days. Let's make them count!
 ```
 
@@ -239,13 +164,9 @@ P.S. Your trial lasts [X] days. Let's make them count!
 
 ```
 Most [Product] users say [Feature Name] is what hooked them.
-
 [2-3 sentences explaining the feature and its benefit]
-
 [Screenshot or GIF]
-
 Try it now: [Link directly to feature]
-
 Not sure how? Here's a 2-minute tutorial: [Video link]
 ```
 
@@ -253,7 +174,7 @@ Not sure how? Here's a 2-minute tutorial: [Video link]
 
 **Subject:** "[Result achieved]" — How [Customer] uses [Product]
 
-Uses **Social Proof pattern** above. Add product feature attribution: "They did it by [specific action in the product]." Hard CTA to relevant feature link.
+Uses **Social Proof pattern**. Add product feature attribution: "They did it by [specific action in the product]." Hard CTA to relevant feature link.
 
 ### Email 4: Check-in (Day 7)
 
@@ -261,15 +182,9 @@ Uses **Social Proof pattern** above. Add product feature attribution: "They did 
 
 ```
 You're halfway through your trial—how's it going?
-
-- Have you [completed key action]?
-- Need help with anything?
-
+- Have you [completed key action]?  - Need help with anything?
 A few things you might not have discovered yet:
-• [Feature/tip they might have missed]
-• [Another underutilized feature]
-• [Pro tip]
-
+• [Feature/tip they might have missed]  • [Another underutilized feature]  • [Pro tip]
 [Log in to [Product] →]
 ```
 
@@ -277,16 +192,13 @@ A few things you might not have discovered yet:
 
 **Subject:** The [Feature] trick most users miss
 
-Same structure as Email 2 above. Focus on a power-user feature most people overlook. Include step-by-step how-to (3-4 steps) + screenshot.
+Same structure as Email 2. Focus on a power-user feature most people overlook. Include step-by-step how-to (3-4 steps) + screenshot.
 
 ### Email 6: Trial Ending Soon (Day 12)
 
 **Subject:** Your trial ends in 2 days
 
-Uses **Urgency pattern** above, adapted for trial context:
-- Losses: access to key features, data/work they've created
-- CTA: `[Upgrade Now →]`
-- Offer extension: "If you need more time, just reply."
+Uses **Urgency pattern**, adapted for trial context. Losses: access to key features, data/work they've created. CTA: `[Upgrade Now →]`. Offer extension: "If you need more time, just reply."
 
 ### Email 7: Last Day (Day 14)
 
@@ -294,14 +206,8 @@ Uses **Urgency pattern** above, adapted for trial context:
 
 ```
 Your [Product] trial ends at midnight tonight.
-
-Upgrade now to keep:
-✓ [Feature/benefit 1]
-✓ [Feature/benefit 2]
-✓ [Work/data they've created]
-
+Upgrade now to keep: ✓ [Feature/benefit 1] ✓ [Feature/benefit 2] ✓ [Work/data they've created]
 [Upgrade Now →]
-
 As a thank you, use code [CODE] for [discount] off your first [month/year].
 ```
 
@@ -315,15 +221,10 @@ As a thank you, use code [CODE] for [discount] off your first [month/year].
 
 ```
 I've been working on something for [timeframe].
-
 On [Date], I'm finally ready to share it.
-
 [1-2 sentence teaser—what it is without full details]
-
 It's designed for [who it's for] who want to [achieve outcome].
-
 Mark your calendar: [Date]
-
 P.S. [Optional: early access or waitlist CTA]
 ```
 
@@ -333,41 +234,26 @@ P.S. [Optional: early access or waitlist CTA]
 
 ```
 Tomorrow is the big day. But first, let's talk about [the problem].
-
 [Describe the problem in detail]
-
 Most people try to solve this by:
 • [Common approach 1] — but [why it fails]
 • [Common approach 2] — but [why it fails]
-
 The real issue? [Key insight about why the problem persists]
-
 Tomorrow, I'll show you a different approach.
 ```
 
 ### Email 3: Launch Day (Day 0)
 
-**Subject:** It's here: [Product Name] is LIVE 🚀
+**Subject:** It's here: [Product Name] is LIVE
 
 ```
-Introducing [Product Name]:
-[Link to Sales Page]
-
+Introducing [Product Name]: [Link to Sales Page]
 [Product Name] helps you [achieve outcome] without [objection].
-
-Here's what you get:
-• [Benefit 1]
-• [Benefit 2]
-• [Benefit 3]
-
+Here's what you get: • [Benefit 1] • [Benefit 2] • [Benefit 3]
 Plus, for launch week only:
-• [Bonus 1] ($[X] value)
-• [Bonus 2] ($[X] value)
-
+• [Bonus 1] ($[X] value)  • [Bonus 2] ($[X] value)
 [Launch Price: $X (Regular: $Y)]
-
 [Get [Product Name] Now →]
-
 P.S. [Scarcity/urgency element]
 ```
 
@@ -375,13 +261,14 @@ P.S. [Scarcity/urgency element]
 
 **Subject:** "I can't believe this actually worked" — [Customer Name]
 
-Uses **Social Proof pattern** above. Frame as launch momentum: "The response to [Product Name] has been incredible." Hard CTA.
+Uses **Social Proof pattern**. Frame as launch momentum: "The response to [Product Name] has been incredible." Hard CTA.
 
 ### Email 5: FAQ/Objections (Day 4)
 
 **Subject:** Your [Product] questions, answered
 
-Uses **Objection Handling pattern** above. Add product-specific Qs:
+Uses **Objection Handling pattern**. Add product-specific Qs:
+
 - "How long does it take to see results?" → [Answer]
 - "What's included exactly?" → [Brief summary]
 
@@ -389,7 +276,7 @@ Uses **Objection Handling pattern** above. Add product-specific Qs:
 
 **Subject:** 48 hours left for [bonus/price]
 
-Uses **Urgency pattern** above. Losses = launch bonuses + price increase.
+Uses **Urgency pattern**. Losses = launch bonuses + price increase.
 
 ### Email 7: Final Hours (Day 7)
 
@@ -397,16 +284,10 @@ Uses **Urgency pattern** above. Losses = launch bonuses + price increase.
 
 ```
 This is it. At midnight tonight:
-• [Bonus/price change 1]
-• [Bonus/price change 2]
-
+• [Bonus/price change 1]  • [Bonus/price change 2]
 [Get [Product Name] Before Midnight →]
-
-Here's what you'll get:
-[Quick summary of offer]
-
+Here's what you'll get: [Quick summary of offer]
 [Get [Product Name] Now →]
-
 P.S. Last-minute question? Reply now—I'll get back to you before midnight.
 ```
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing/direct-response-copy-templates-email-sequences.md` from 423 to 304 lines (28% reduction)
- Compressed verbose template code blocks by collapsing multi-line placeholder lists into single lines
- Removed redundant whitespace and unnecessary line breaks within code blocks
- All 22 emails, 3 reusable patterns, 5 subject line categories, and 17 code blocks preserved

## Verification

| Element | Before | After |
|---------|--------|-------|
| Lines | 423 | 304 |
| Major sections | 7 | 7 |
| Email templates | 22 | 22 |
| Reusable patterns | 3 | 3 |
| Code blocks | 17 | 17 |
| Subject line table categories | 5 | 5 |

## Runtime Testing

- **Testing level:** `self-assessed`
- **Risk classification:** Low (docs/agent prompts only)
- **Rationale:** No code changes — markdown template file tightening only

Closes #11289