### PR TITLE
t11290: tighten cro-chapter-03.md (414 → 174 lines)

### DIFF
--- a/.agents/marketing/cro-chapter-03.md
+++ b/.agents/marketing/cro-chapter-03.md
@@ -2,53 +2,17 @@
 
 With limited resources and countless potential optimizations, prioritization is essential. CRO frameworks help systematically evaluate and prioritize testing opportunities.
 
-### The PIE Framework
+## The PIE Framework
 
-PIE (Potential, Importance, Ease) is one of the most popular prioritization frameworks, developed by Chris Goward at WiderFunnel.
+PIE (Potential, Importance, Ease) was developed by Chris Goward at WiderFunnel. Each component scored 0-10.
 
-#### PIE Components
+**Potential** — How much improvement is possible? Low-performing pages with obvious issues score higher. Already performing well = 1-2; significant room with multiple issues = 9-10.
 
-**Potential (0-10)**: How much improvement is possible?
-- Consider current performance: low-performing pages have higher potential
-- Evaluate existing issues: more obvious problems mean higher potential
-- Review benchmark data: if you're far below benchmarks, potential is higher
+**Importance** — How valuable is this page? Consider traffic volume, revenue impact, strategic alignment. Minimal business impact = 1-2; critical pages (checkout, key landing pages) = 9-10.
 
-Scoring Guide:
-- 9-10: Significant room for improvement, multiple obvious issues
-- 7-8: Clear improvement opportunities
-- 5-6: Moderate improvement possible
-- 3-4: Limited improvement likely
-- 1-2: Already performing well, minimal potential
-
-**Importance (0-10)**: How valuable is this page or element to your business?
-- Traffic volume: higher traffic = higher importance
-- Revenue impact: pages closer to conversion = higher importance
-- Strategic value: alignment with business goals
-
-Scoring Guide:
-- 9-10: Critical page (checkout, key landing pages)
-- 7-8: Important page (product pages, category pages)
-- 5-6: Supporting page (blog posts, informational pages)
-- 3-4: Low-traffic page
-- 1-2: Minimal business impact
-
-**Ease (0-10)**: How difficult is the test to implement?
-- Technical complexity: simple copy change vs. major rebuild
-- Resources required: designer, developer, copywriter time
-- Political considerations: stakeholder buy-in needed
-
-Scoring Guide:
-- 9-10: Simple change, minimal resources (headline, button text)
-- 7-8: Moderate effort (new section, image changes)
-- 5-6: Significant effort (redesign, new functionality)
-- 3-4: Major effort (substantial development work)
-- 1-2: Extremely difficult (platform migration, major rebuild)
-
-#### PIE Calculation and Prioritization
+**Ease** — How difficult to implement? Factor technical complexity, resources required, stakeholder buy-in. Major rebuild = 1-2; simple copy/button change = 9-10.
 
 **PIE Score = (Potential + Importance + Ease) / 3**
-
-Example:
 
 | Test Idea | Potential | Importance | Ease | PIE Score | Priority |
 |-----------|-----------|------------|------|-----------|----------|
@@ -58,55 +22,18 @@ Example:
 | Improve product image quality | 6 | 8 | 7 | 7.0 | 4 |
 | Create new landing page template | 7 | 6 | 4 | 5.7 | 5 |
 
-Based on these scores, you would prioritize:
-1. Simplifying checkout form (highest impact, high feasibility)
-2. Adding testimonials to product page (strong all-around)
-3. Improving product image quality (balanced opportunity)
-4. Redesigning homepage (lower despite high potential due to difficulty)
-5. Creating new landing page template (lowest overall score)
+**Advantages**: Simple, intuitive, balances multiple factors, encourages team discussion.
+**Limitations**: Subjective scoring, equal weighting may not fit all situations, doesn't account for learning value or resource availability.
 
-#### PIE Framework Advantages and Limitations
+## The ICE Framework
 
-**Advantages**:
-- Simple and intuitive
-- Balances multiple factors
-- Quick to apply
-- Encourages team discussion
+ICE (Impact, Confidence, Ease) was popularized by Sean Ellis (GrowthHackers). Replaces PIE's Potential/Importance with Impact/Confidence.
 
-**Limitations**:
-- Subjective scoring
-- Equal weighting of factors may not fit all situations
-- Doesn't account for learning value
-- No consideration of resource availability
+- **Impact (1-10)**: Expected conversion lift and number of users affected
+- **Confidence (1-10)**: Evidence quality — research, data, user feedback, precedent from similar tests
+- **Ease (1-10)**: Time, resources, technical complexity
 
-### The ICE Framework
-
-ICE (Impact, Confidence, Ease) was popularized by Sean Ellis, founder of GrowthHackers.
-
-#### ICE Components
-
-**Impact (1-10)**: How much will this improve the conversion rate if successful?
-- Consider the expected lift
-- Evaluate how many users it will affect
-- Assess the value of those conversions
-
-**Confidence (1-10)**: How confident are you that this will improve conversions?
-- Based on research quality
-- Supported by data and user feedback
-- Precedent from similar tests or case studies
-
-**Ease (1-10)**: How easy is this to implement?
-- Time required
-- Resources needed
-- Technical complexity
-
-#### ICE Calculation
-
-**ICE Score = (Impact × Confidence × Ease) / 100**
-
-Or alternatively: **ICE Score = Impact + Confidence + Ease**
-
-Example using addition method:
+**ICE Score = Impact + Confidence + Ease** (or multiplicative: Impact x Confidence x Ease / 100)
 
 | Test Idea | Impact | Confidence | Ease | ICE Score | Priority |
 |-----------|--------|------------|------|-----------|----------|
@@ -115,300 +42,133 @@ Example using addition method:
 | Implement exit-intent popup | 6 | 7 | 8 | 21 | 3 |
 | Rebuild product configurator | 9 | 8 | 2 | 19 | 4 |
 
-#### ICE vs. PIE
+**ICE vs PIE**: Use ICE when you have strong research (confidence matters) and want quick wins. Use PIE when page importance/traffic varies significantly and you need to balance long-term vs short-term.
 
-**Use ICE when**:
-- You have strong research supporting hypotheses (confidence is key)
-- Speed of implementation is critical
-- You want to focus on quick wins
+## The RICE Framework
 
-**Use PIE when**:
-- You want to consider the current state (potential)
-- Page importance and traffic vary significantly
-- You need to balance long-term and short-term opportunities
+RICE (Reach, Impact, Confidence, Effort) adds quantitative nuance, particularly for product development contexts.
 
-### The RICE Framework
+- **Reach**: Users/sessions impacted per time period (actual numbers, not 1-10)
+- **Impact**: Per-user effect on a fixed scale: 3 (massive), 2 (high), 1 (medium), 0.5 (low), 0.25 (minimal)
+- **Confidence**: Percentage — 100% (high), 80% (medium), 50% (low)
+- **Effort**: Person-months/days total (design + dev + testing + deployment)
 
-RICE (Reach, Impact, Confidence, Effort) adds more nuance, particularly for product development contexts.
+**RICE Score = (Reach x Impact x Confidence) / Effort**
 
-#### RICE Components
-
-**Reach**: How many users will this impact in a given time period?
-- Number of users/sessions per month, quarter, etc.
-- Percentage of user base affected
-
-**Impact (0.25, 0.5, 1, 2, 3)**: How much will this impact each user?
-- 3 = Massive impact
-- 2 = High impact
-- 1 = Medium impact
-- 0.5 = Low impact
-- 0.25 = Minimal impact
-
-**Confidence (percentage)**: How confident are you in your estimates?
-- 100% = High confidence
-- 80% = Medium confidence
-- 50% = Low confidence
-
-**Effort (person-months)**: How much time will this take?
-- Total team time required
-- Includes design, development, testing, and deployment
-
-#### RICE Calculation
-
-**RICE Score = (Reach × Impact × Confidence) / Effort**
-
-Example:
-
-| Test Idea | Reach (monthly users) | Impact | Confidence | Effort (person-days) | RICE Score |
-|-----------|----------------------|--------|------------|---------------------|------------|
+| Test Idea | Reach (monthly) | Impact | Confidence | Effort (person-days) | RICE Score |
+|-----------|-----------------|--------|------------|---------------------|------------|
 | Optimize mobile checkout | 15,000 | 3 | 80% | 10 | 3,600 |
 | Add live chat | 30,000 | 1 | 90% | 15 | 1,800 |
 | Redesign product pages | 25,000 | 2 | 70% | 20 | 1,750 |
 | Improve search functionality | 10,000 | 2 | 60% | 15 | 800 |
 
-The highest RICE score indicates the best opportunity considering reach, impact, confidence, and effort.
+## The PXL Framework
 
-### The PXL Framework
+PXL (Predict, Explore, Learn), created by CXL, uses binary yes/no scoring to remove subjectivity.
 
-The PXL (Predict, Explore, Learn) framework, created by CXL, uses a binary yes/no approach to remove subjectivity.
+**Evidence-Based** (must have at least 1 Yes):
+- Based on qualitative research/data?
+- Based on quantitative research/data?
+- Based on best practices (industry research)?
+- Solves a problem from user testing / analytics / heuristic analysis?
 
-#### PXL Criteria
+**Value Potential**: High-traffic page? Major conversion funnel? Significant expected impact? Aligns with business goals?
 
-Questions are answered with Yes (1 point) or No (0 points):
+**Implementation**: Buildable in <2 weeks? Technically feasible? Resources available?
 
-**Evidence-Based (must have at least 1 Yes)**:
-- Is it based on qualitative research/data?
-- Is it based on quantitative research/data?
-- Is it based on best practices (industry research)?
-- Does it solve a problem noticed in user testing?
-- Does it solve a problem noticed in analytics?
-- Does it solve a problem noticed in heuristic analysis?
+Tests require at least one Evidence-Based "Yes" and a strong overall score (typically 7+).
 
-**Value Potential**:
-- Will it address a high-traffic page?
-- Will it affect a major conversion funnel?
-- Is the expected impact significant?
-- Does it align with business goals?
+## The TIR Framework
 
-**Implementation**:
-- Can it be built in less than 2 weeks?
-- Is it technically feasible without major issues?
-- Do you have the necessary resources?
+TIR (Traffic, Impact, Resources) — a simpler alternative. Each scored 1-10 (Resources: 10 = very easy).
 
-Tests are only pursued if they have:
-1. At least one "Yes" in Evidence-Based category
-2. A strong overall score (typically 7+ out of available points)
+**TIR Score = Traffic x Impact x Resources**
 
-### The TIR Framework (Traffic, Impact, Resources)
+## The Value vs Complexity Matrix
 
-TIR provides a simpler alternative:
+Plot ideas on two axes — Value/Impact (Y) vs Complexity/Effort (X):
 
-**Traffic (1-10)**: How much traffic does this page receive?
-**Impact (1-10)**: What's the potential conversion lift?
-**Resources (1-10)**: How easy is implementation? (10 = very easy)
+| Quadrant | Value | Complexity | Action |
+|----------|-------|------------|--------|
+| Upper Left | High | Low | **Quick Wins — do first** |
+| Upper Right | High | High | Major Projects — plan and resource |
+| Lower Left | Low | Low | Maybe — if time permits |
+| Lower Right | Low | High | Don't Do — avoid |
 
-**TIR Score = Traffic × Impact × Resources**
+## Hybrid Approaches
 
-Higher scores get priority.
+Custom frameworks combine elements from multiple systems. Example:
 
-### The Value vs. Complexity Matrix
-
-A visual prioritization method that plots ideas on two axes:
-
-**Y-Axis**: Value/Impact (Low to High)
-**X-Axis**: Complexity/Effort (Low to High)
-
-This creates four quadrants:
-
-1. **High Value, Low Complexity** (Upper Left): Quick Wins - DO THESE FIRST
-2. **High Value, High Complexity** (Upper Right): Major Projects - plan and resource
-3. **Low Value, Low Complexity** (Lower Left): Maybe - if time permits
-4. **Low Value, High Complexity** (Lower Right): Don't Do - avoid these
-
-### Hybrid Approaches
-
-Many successful CRO teams develop custom frameworks combining elements from multiple systems:
-
-**Example Custom Framework**:
-- Business Impact (0-10): Revenue potential
+- Business Impact (0-10, **2x weight**): Revenue potential
 - User Impact (0-10): UX improvement
 - Confidence (0-10): Evidence quality
-- Effort (0-10): Resources required (inverted, so 10 = easy)
-- Strategic Fit (0-10): Alignment with company goals
+- Effort (0-10, inverted — 10 = easy): Resources required
+- Strategic Fit (0-10): Company goal alignment
 
-**Custom Score = (Business Impact × 2) + User Impact + Confidence + Effort + Strategic Fit**
+**Score = (Business Impact x 2) + User Impact + Confidence + Effort + Strategic Fit**
 
-The 2× multiplier on Business Impact reflects that company's prioritization of revenue-generating tests.
+The multiplier reflects prioritization of revenue-generating tests.
 
-### Practical Prioritization Considerations
+## Practical Prioritization Considerations
 
-Beyond frameworks, consider these factors:
+1. **Traffic requirements**: Tests need adequate traffic for statistical significance. Prioritize high-traffic pages or plan longer test durations.
+2. **Learning value**: "Risky" tests with uncertain outcomes may open new optimization avenues. Factor learning potential in.
+3. **Seasonality**: Prioritize tests that run during peak periods for maximum value.
+4. **Technical dependencies**: Be realistic about platform constraints and implementation feasibility.
+5. **Team bandwidth**: Don't commit to more tests than designers, developers, and copywriters can handle.
+6. **Testing velocity**: Balance large slow tests with quick wins to maintain momentum and stakeholder enthusiasm.
+7. **Risk tolerance**: Radical redesigns carry more risk but higher potential reward. Balance your portfolio.
 
-**1. Traffic Requirements for Testing**
-Tests require adequate traffic for statistical significance. Prioritize high-traffic pages when possible, or be prepared to run tests longer on low-traffic pages.
+## Building Your CRO Roadmap
 
-**2. Learning Value**
-Sometimes a "risky" test with uncertain outcome has high learning value. If successful, it could open new optimization avenues. Factor learning potential into prioritization.
+Example quarterly structure:
 
-**3. Seasonality**
-Seasonal businesses should prioritize tests that can run during peak periods and deliver value when it matters most.
+- **Weeks 1-2**: Quick wins (3 small tests) — trust badges, headline tests, mobile form optimization
+- **Weeks 3-6**: Medium test (1) — product page template redesign
+- **Weeks 7-12**: Major test (1, alongside smaller tests) — new checkout flow
+- **Ongoing**: Research pipeline — user surveys, session recordings, competitor research, next-quarter ideation
 
-**4. Technical Dependencies**
-Some tests may be blocked by technical limitations or platform constraints. Be realistic about implementation feasibility.
+This ensures quick wins maintain momentum, major opportunities aren't neglected, research feeds the pipeline, and team capacity isn't overwhelmed.
 
-**5. Team Bandwidth**
-Consider available resources—designers, developers, copywriters. Don't commit to more tests than your team can handle.
+## Prioritization Meeting Structure
 
-**6. Testing Velocity**
-Balance large, slow tests with quick wins. A steady stream of quick wins maintains momentum and stakeholder enthusiasm while major tests run.
+**Monthly CRO Prioritization Meeting** (~90 min):
 
-**7. Risk Tolerance**
-Radical redesigns carry more risk but potentially higher reward. Conservative changes are safer but may yield incremental improvements. Balance your portfolio.
+1. **Review previous month** (15 min) — completed test results, ongoing test status, implemented winners impact
+2. **Present new ideas** (30 min) — supporting research, hypotheses, expected outcomes, dependencies
+3. **Score ideas** (20 min) — apply chosen framework, discuss scoring differences, reach consensus
+4. **Prioritize and plan** (15 min) — rank by score, check resources, assign to test slots and owners
+5. **Set research priorities** (10 min) — identify research needs, assign tasks, set deadlines
+6. **Review roadmap** (10 min) — confirm next month, preview quarter, adjust as needed
 
-### Building Your CRO Roadmap
+## Common Prioritization Mistakes
 
-Once you've prioritized ideas, build a roadmap:
+| Mistake | Remedy |
+|---------|--------|
+| **HiPPO** (Highest Paid Person's Opinion) | Involve leadership in framework creation, not test selection |
+| **Shiny Object Syndrome** | Stick to your framework and roadmap |
+| **Ignoring Quick Wins** | Quick wins build momentum and stakeholder support |
+| **Analysis Paralysis** | Don't spend more time debating than testing |
+| **Neglecting Research** | Frameworks are only as good as the research feeding them |
+| **Forgetting Learning Value** | Learning what doesn't work is valuable too |
+| **Resource Mismatches** | Don't prioritize tests you can't implement |
 
-**Quarter 1 Example**:
-- **Weeks 1-2**: Quick wins (3 small tests)
-  - Add trust badges to checkout
-  - Test new headline on primary landing page
-  - Optimize mobile form fields
+## Calculating ROI of CRO Tests
 
-- **Weeks 3-6**: Medium test (1 test)
-  - Redesign product page template
-
-- **Weeks 7-12**: Major test (1 test, running alongside smaller tests)
-  - New checkout flow
-
-- **Ongoing**: Research and ideation
-  - User surveys
-  - Session recording analysis
-  - Competitor research
-  - Preparing Q2 test ideas
-
-This balanced approach ensures:
-- Quick wins maintain momentum
-- Major opportunities aren't neglected
-- Research continues to feed the pipeline
-- Team capacity isn't overwhelmed
-
-### Prioritization Meeting Structure
-
-Effective CRO teams hold regular prioritization meetings:
-
-**Monthly CRO Prioritization Meeting Agenda**:
-
-1. **Review Previous Month** (15 minutes)
-   - Completed tests and results
-   - Ongoing tests status
-   - Implemented winners impact
-
-2. **Present New Ideas** (30 minutes)
-   - Team members present ideas with supporting research
-   - Discuss hypotheses and expected outcomes
-   - Identify any concerns or dependencies
-
-3. **Score Ideas** (20 minutes)
-   - Apply chosen framework (PIE, ICE, etc.)
-   - Discuss scoring differences
-   - Reach consensus on scores
-
-4. **Prioritize and Plan** (15 minutes)
-   - Rank ideas by score
-   - Check against available resources
-   - Assign to upcoming test slots
-   - Identify who owns each test
-
-5. **Set Research Priorities** (10 minutes)
-   - Identify research needed for future tests
-   - Assign research tasks
-   - Set deadlines
-
-6. **Review Roadmap** (10 minutes)
-   - Confirm next month's tests
-   - Preview upcoming quarter
-   - Adjust if necessary
-
-Total: 90 minutes
-
-### Common Prioritization Mistakes
-
-**1. HiPPO (Highest Paid Person's Opinion)**
-Don't let seniority override data-driven prioritization. Involve leadership in framework creation, not test selection.
-
-**2. Shiny Object Syndrome**
-Resist chasing every new tactic or trend. Stick to your prioritization framework and roadmap.
-
-**3. Ignoring Quick Wins**
-Don't only pursue complex, long-term tests. Quick wins build momentum and stakeholder support.
-
-**4. Analysis Paralysis**
-Don't spend more time debating prioritization than actually testing. Frameworks provide structure, not perfection.
-
-**5. Neglecting Research**
-Prioritization frameworks are only as good as the research feeding them. Invest in ongoing research.
-
-**6. Forgetting Learning Value**
-Not every test needs to be a guaranteed winner. Learning what doesn't work is valuable too.
-
-**7. Resource Mismatches**
-Don't prioritize tests you can't actually implement with available resources.
-
-### Calculating ROI of CRO Tests
-
-To further inform prioritization, estimate ROI:
-
-**Expected Value Calculation**:
-
-```text
-Expected Value = (Probability of Success × Expected Lift × Revenue Impacted) - Cost of Implementation
-```
+**Expected Value = (Probability of Success x Expected Lift x Revenue Impacted) - Cost of Implementation**
 
 Example:
-- Probability of Success: 60% (based on research quality)
-- Expected Lift: 15% conversion rate increase
-- Current Conversion Rate: 2%
-- New Conversion Rate: 2.3%
-- Monthly Revenue from this page: $100,000
-- Additional Monthly Revenue: $15,000
-- Annual Additional Revenue: $180,000
-- Cost of Implementation: $10,000
+- Probability: 60% | Expected lift: 15% | Current CVR: 2% -> 2.3%
+- Monthly revenue from page: $100,000 | Additional monthly: $15,000 | Annual: $180,000
+- Cost: $10,000
+- **Expected Value = (0.60 x $180,000) - $10,000 = $98,000** — strong ROI, prioritize
 
-Expected Value = (0.60 × $180,000) - $10,000 = $98,000
+Counter-example:
+- Probability: 40% | Lift: 5% | Monthly revenue: $50,000 | Annual additional: $30,000 | Cost: $15,000
+- **Expected Value = (0.40 x $30,000) - $15,000 = -$3,000** — negative EV, deprioritize or redesign
 
-This test has a strong expected ROI and should be prioritized.
+## Documentation and Knowledge Management
 
-Compare this to another test:
-- Probability of Success: 40%
-- Expected Lift: 5%
-- Monthly Revenue: $50,000
-- Additional Monthly Revenue: $2,500
-- Annual Additional Revenue: $30,000
-- Cost: $15,000
-
-Expected Value = (0.40 × $30,000) - $15,000 = -$3,000
-
-This test has negative expected value and should be deprioritized or redesigned.
-
-### Documentation and Knowledge Management
-
-Maintain a prioritization database/spreadsheet tracking:
-- Test idea and hypothesis
-- Supporting research
-- Framework scores
-- Priority ranking
-- Status (backlog, planned, in-progress, completed)
-- Owner
-- Expected completion date
-- Actual results (once tested)
-- Learning and next steps
-
-This becomes an invaluable knowledge repository showing:
-- What you've tested
-- What worked and didn't work
-- Why decisions were made
-- Patterns in successful tests
-- Research supporting future tests
+Maintain a prioritization database tracking: test idea/hypothesis, supporting research, framework scores, priority ranking, status (backlog/planned/in-progress/completed), owner, expected completion, actual results, and learnings/next steps. This repository reveals what you've tested, what worked, why decisions were made, patterns in successful tests, and research supporting future tests.
 
 ---


### PR DESCRIPTION
## Summary

- Tighten `.agents/marketing/cro-chapter-03.md` from 414 to 174 lines (58% reduction)
- Compress prose while preserving all 8 CRO frameworks, formulas, example tables, attributions, and practical guidance
- Convert verbose scoring rubrics to inline descriptions, common mistakes list to compact table, merge redundant sections

Closes #11290

## What changed

| Technique | Lines saved | Detail |
|-----------|-------------|--------|
| PIE scoring rubrics → inline descriptions | ~25 | 3 separate 5-tier rubrics consolidated |
| Redundant priority list removed | ~6 | Duplicated the table's Priority column |
| ICE components compressed | ~10 | Parallel structure to PIE, less repetition |
| Common mistakes → table | ~15 | 7 items from heading+paragraph to table rows |
| Meeting agenda compressed | ~15 | Sub-bullets merged into single-line descriptions |
| Documentation section merged | ~10 | Two lists saying the same thing → one paragraph |
| General prose tightening | ~160 | Throughout |

## Content preservation verification

- All 8 frameworks: PIE, ICE, RICE, PXL, TIR, Value vs Complexity, Hybrid, ROI
- All 5 formulas with exact calculations
- All 4 example tables with original data
- All attributions: Chris Goward/WiderFunnel, Sean Ellis/GrowthHackers, CXL
- All 7 practical considerations
- All 7 common mistakes
- Both ROI worked examples (positive $98K and negative -$3K EV)
- Meeting structure with time allocations
- Quarterly roadmap example

## Runtime Testing

- **Testing level**: self-assessed
- **Risk classification**: Low (docs/reference content only, no code)
- **Verification**: Content audit via grep confirmed all frameworks, formulas, key terms, and examples present