### PR TITLE
GH#11307: Tighten es2022-es2023.md (387 → 236 lines, 39% reduction)

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/es2022-es2023.md
+++ b/.agents/tools/programming/modern-javascript-skill/es2022-es2023.md
@@ -6,64 +6,34 @@
 
 ### Array.prototype.at()
 
-Access elements from the end with negative indices.
+Access elements from the end with negative indices. Works on arrays, strings, and TypedArrays.
 
 ```javascript
 const arr = ['a', 'b', 'c', 'd', 'e'];
-
-// Positive indices (same as bracket notation)
-arr.at(0);   // 'a'
-arr.at(2);   // 'c'
-
-// Negative indices (from end)
-arr.at(-1);  // 'e' (last element)
-arr.at(-2);  // 'd' (second to last)
-
-// Works on strings too
+arr.at(-1);   // 'e' (last element)
+arr.at(-2);   // 'd'
 'hello'.at(-1);  // 'o'
-
-// Works on TypedArrays
 new Uint8Array([1, 2, 3]).at(-1);  // 3
-```
 
-**Migration pattern:**
-
-```javascript
-// ❌ Before
-const last = arr[arr.length - 1];
-const secondLast = arr[arr.length - 2];
-
-// ✅ After
-const last = arr.at(-1);
-const secondLast = arr.at(-2);
+// Migration: arr[arr.length - 1] → arr.at(-1)
 ```
 
 ### Object.hasOwn()
 
-Safe alternative to `hasOwnProperty`.
+Safe alternative to `hasOwnProperty` — works on null-prototype objects and can't be overridden.
 
 ```javascript
 const obj = { name: 'Alice' };
-
-// ✅ Safe and concise
 Object.hasOwn(obj, 'name');      // true
 Object.hasOwn(obj, 'toString');  // false (inherited)
 
-// Works with objects that don't have hasOwnProperty
+// Safe with null-prototype objects (hasOwnProperty would throw TypeError)
 const nullProto = Object.create(null);
 nullProto.key = 'value';
 Object.hasOwn(nullProto, 'key');  // true
-// nullProto.hasOwnProperty('key')  // TypeError!
-```
 
-**Why not hasOwnProperty:**
-
-```javascript
-// hasOwnProperty can be overwritten
-const malicious = {
-  hasOwnProperty: () => false,
-  secret: 'data'
-};
+// Can't be spoofed (unlike obj.hasOwnProperty which can be overwritten)
+const malicious = { hasOwnProperty: () => false, secret: 'data' };
 malicious.hasOwnProperty('secret');  // false (wrong!)
 Object.hasOwn(malicious, 'secret');  // true (correct!)
 ```
@@ -73,23 +43,17 @@ Object.hasOwn(malicious, 'secret');  // true (correct!)
 Use `await` at module top level without async wrapper.
 
 ```javascript
-// config.js
+// config.js — loading configuration
 const response = await fetch('/api/config');
 export const config = await response.json();
 
-// db.js
+// db.js — initializing connections
 import { config } from './config.js';
 export const db = await connectDatabase(config.dbUrl);
 
-// app.js
+// app.js — modules wait for dependencies automatically
 import { db } from './db.js';  // Waits for db to be ready
 ```
-
-**Use cases:**
-- Loading configuration
-- Initializing database connections
-- Dynamic module loading
-- Conditional imports
 
 ### Class Private Fields and Methods
 
@@ -97,43 +61,33 @@ True encapsulation with `#` prefix.
 
 ```javascript
 class BankAccount {
-  #balance = 0;  // Private field
-  #transactionHistory = [];
+  #balance = 0;
+  #history = [];
 
-  constructor(initial) {
-    this.#balance = initial;
+  constructor(initial) { this.#balance = initial; }
+
+  #log(type, amount) {
+    this.#history.push({ type, amount, date: new Date() });
   }
 
-  // Private method
-  #logTransaction(type, amount) {
-    this.#transactionHistory.push({ type, amount, date: new Date() });
-  }
-
-  deposit(amount) {
-    this.#balance += amount;
-    this.#logTransaction('deposit', amount);
-  }
+  deposit(amount) { this.#balance += amount; this.#log('deposit', amount); }
 
   withdraw(amount) {
     if (amount > this.#balance) throw new Error('Insufficient funds');
     this.#balance -= amount;
-    this.#logTransaction('withdrawal', amount);
+    this.#log('withdrawal', amount);
   }
 
-  get balance() {
-    return this.#balance;
-  }
+  get balance() { return this.#balance; }
 
-  // Private field check
-  static isAccount(obj) {
-    return #balance in obj;
-  }
+  // Private field existence check via `in`
+  static isAccount(obj) { return #balance in obj; }
 }
 
 const account = new BankAccount(100);
 account.deposit(50);
-// account.#balance  // SyntaxError: Private field
-// account.#logTransaction()  // SyntaxError: Private method
+// account.#balance       // SyntaxError: Private field
+// account.#log()         // SyntaxError: Private method
 ```
 
 ### Static Class Fields and Blocks
@@ -144,20 +98,16 @@ class Config {
   static version = '1.0.0';
   static features = [];
 
-  // Static initialization block
+  // Static initialization block — runs once when class is evaluated
   static {
-    console.log('Initializing Config class');
     this.features = ['auth', 'logging'];
-
     if (process.env.NODE_ENV === 'development') {
       this.features.push('debug');
     }
   }
 
   static getInstance() {
-    if (!this.#instance) {
-      this.#instance = new Config();
-    }
+    if (!this.#instance) this.#instance = new Config();
     return this.#instance;
   }
 }
@@ -165,7 +115,7 @@ class Config {
 
 ### Error Cause
 
-Chain errors with context.
+Chain errors with context using the `cause` option.
 
 ```javascript
 async function fetchUserData(userId) {
@@ -185,9 +135,9 @@ async function fetchUserData(userId) {
 try {
   await fetchUserData(123);
 } catch (error) {
-  console.error(error.message);        // 'User data unavailable'
-  console.error(error.cause.message);  // 'Failed to fetch user'
-  console.error(error.cause.cause);    // { status: 404, userId: 123 }
+  error.message;        // 'User data unavailable'
+  error.cause.message;  // 'Failed to fetch user'
+  error.cause.cause;    // { status: 404, userId: 123 }
 }
 ```
 
@@ -196,16 +146,9 @@ try {
 Get start/end positions with `/d` flag.
 
 ```javascript
-const str = 'Hello World';
-const regex = /(?<greeting>Hello) (?<subject>World)/d;
-const match = str.match(regex);
-
-console.log(match.indices);
-// [[0, 11], [0, 5], [6, 11]]
-// [fullMatch, greeting, subject]
-
-console.log(match.indices.groups);
-// { greeting: [0, 5], subject: [6, 11] }
+const match = 'Hello World'.match(/(?<greeting>Hello) (?<subject>World)/d);
+match.indices;         // [[0, 11], [0, 5], [6, 11]]
+match.indices.groups;  // { greeting: [0, 5], subject: [6, 11] }
 ```
 
 ---
@@ -214,77 +157,38 @@ console.log(match.indices.groups);
 
 ### Array Change-by-Copy Methods
 
-New methods that return modified copies without mutating the original.
-
-#### toSorted()
+New methods return modified copies without mutating the original. Replaces the clone-then-mutate pattern.
 
 ```javascript
-const numbers = [3, 1, 4, 1, 5];
-
-// ❌ Mutates original
-const sorted = numbers.sort((a, b) => a - b);
-console.log(numbers);  // [1, 1, 3, 4, 5] - mutated!
-
-// ✅ Returns new array
-const numbers2 = [3, 1, 4, 1, 5];
-const sorted2 = numbers2.toSorted((a, b) => a - b);
-console.log(numbers2);  // [3, 1, 4, 1, 5] - unchanged
-console.log(sorted2);   // [1, 1, 3, 4, 5] - new array
-```
-
-#### toReversed()
-
-```javascript
-const arr = [1, 2, 3, 4, 5];
-
-// ❌ Mutates original
-const reversed = arr.reverse();
-
-// ✅ Returns new array
-const arr2 = [1, 2, 3, 4, 5];
-const reversed2 = arr2.toReversed();
-console.log(arr2);       // [1, 2, 3, 4, 5] - unchanged
-console.log(reversed2);  // [5, 4, 3, 2, 1] - new array
-```
-
-#### toSpliced()
-
-```javascript
+const nums = [3, 1, 4, 1, 5];
 const months = ['Jan', 'Mar', 'Apr'];
-
-// ❌ Mutates original
-months.splice(1, 0, 'Feb');
-
-// ✅ Returns new array
-const months2 = ['Jan', 'Mar', 'Apr'];
-const withFeb = months2.toSpliced(1, 0, 'Feb');
-console.log(months2);  // ['Jan', 'Mar', 'Apr'] - unchanged
-console.log(withFeb);  // ['Jan', 'Feb', 'Mar', 'Apr'] - new array
-
-// Remove elements
-const withoutMar = months2.toSpliced(1, 1);
-// ['Jan', 'Apr']
-```
-
-#### with()
-
-Replace element at index.
-
-```javascript
 const colors = ['red', 'green', 'blue'];
 
-// ❌ Mutates original
-colors[1] = 'yellow';
+// toSorted() — immutable sort
+const sorted = nums.toSorted((a, b) => a - b);  // [1, 1, 3, 4, 5]
+console.log(nums);  // [3, 1, 4, 1, 5] — unchanged
 
-// ✅ Returns new array
-const colors2 = ['red', 'green', 'blue'];
-const updated = colors2.with(1, 'yellow');
-console.log(colors2);  // ['red', 'green', 'blue'] - unchanged
-console.log(updated);  // ['red', 'yellow', 'blue'] - new array
+// toReversed() — immutable reverse
+const reversed = nums.toReversed();  // [5, 1, 4, 1, 3]
 
-// Supports negative indices
-const last = colors2.with(-1, 'purple');
-// ['red', 'green', 'purple']
+// toSpliced() — immutable splice (insert/remove)
+const withFeb = months.toSpliced(1, 0, 'Feb');  // ['Jan', 'Feb', 'Mar', 'Apr']
+const withoutMar = months.toSpliced(1, 1);       // ['Jan', 'Apr']
+
+// with() — immutable index replacement (supports negative indices)
+const updated = colors.with(1, 'yellow');  // ['red', 'yellow', 'blue']
+const last = colors.with(-1, 'purple');    // ['red', 'green', 'purple']
+```
+
+**Migration patterns:**
+
+```javascript
+// Sorting: [...arr].sort(fn) → arr.toSorted(fn)
+const sortedUsers = users.toSorted((a, b) => a.name.localeCompare(b.name));
+
+// State updates (React/Redux): spread-copy-mutate → .with()
+// Before: const copy = [...items]; copy[index] = newValue; return copy;
+const updateItem = (items, index, val) => items.with(index, val);
 ```
 
 ### findLast() and findLastIndex()
@@ -292,13 +196,6 @@ const last = colors2.with(-1, 'purple');
 Search from the end of the array.
 
 ```javascript
-const numbers = [1, 2, 3, 2, 1];
-
-// Find last occurrence
-const lastTwo = numbers.findLast(n => n === 2);      // 2
-const lastTwoIdx = numbers.findLastIndex(n => n === 2);  // 3
-
-// Practical example
 const transactions = [
   { id: 1, type: 'credit' },
   { id: 2, type: 'debit' },
@@ -311,15 +208,17 @@ const lastCredit = transactions.findLast(t => t.type === 'credit');
 
 const lastCreditIdx = transactions.findLastIndex(t => t.type === 'credit');
 // 2
+
+// Migration: manual reverse loop → .findLast()
+const lastError = logs.findLast(entry => entry.level === 'error');
 ```
 
 ### Hashbang Grammar
 
-Executable scripts with shebang.
+Executable scripts with shebang — now valid JavaScript syntax.
 
 ```javascript
 #!/usr/bin/env node
-// This is now valid JavaScript syntax
 console.log('Hello from CLI!');
 ```
 
@@ -330,58 +229,8 @@ Use symbols (except registered) as WeakMap keys.
 ```javascript
 const privateData = new WeakMap();
 const key = Symbol('private');
-
-const obj = {};
 privateData.set(key, { secret: 'data' });
+privateData.get(key);  // { secret: 'data' }
 
-console.log(privateData.get(key));  // { secret: 'data' }
-
-// Registered symbols still not allowed
-const registered = Symbol.for('global');
-// privateData.set(registered, 'value');  // TypeError
-```
-
-## Practical Migrations
-
-### Sorting Collections
-
-```javascript
-// Before: Clone then sort
-const sortedUsers = [...users].sort((a, b) => a.name.localeCompare(b.name));
-
-// After: Single method
-const sortedUsers = users.toSorted((a, b) => a.name.localeCompare(b.name));
-```
-
-### State Updates (React/Redux style)
-
-```javascript
-// Before
-function updateItem(items, index, newValue) {
-  const copy = [...items];
-  copy[index] = newValue;
-  return copy;
-}
-
-// After
-function updateItem(items, index, newValue) {
-  return items.with(index, newValue);
-}
-```
-
-### Finding Last Match
-
-```javascript
-// Before
-const logs = getLogEntries();
-let lastError = null;
-for (let i = logs.length - 1; i >= 0; i--) {
-  if (logs[i].level === 'error') {
-    lastError = logs[i];
-    break;
-  }
-}
-
-// After
-const lastError = logs.findLast(entry => entry.level === 'error');
+// Registered symbols (Symbol.for()) still not allowed as WeakMap keys
 ```


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/programming/modern-javascript-skill/es2022-es2023.md` from 387 to 236 lines (39% reduction)
- Consolidated 4 separate change-by-copy method sections (`toSorted`, `toReversed`, `toSpliced`, `with`) into a single combined code block
- Merged the redundant "Practical Migrations" section (sorting, state updates, findLast) into their respective feature sections
- Trimmed obvious comments (positive-index examples for `.at()`, redundant use-case bullet lists)

## Content Preservation

All 15 ES2022/ES2023 features preserved with full technical detail:

| Feature | Status |
|---------|--------|
| `.at()` indexing (arrays, strings, TypedArrays) | Preserved |
| `Object.hasOwn()` (null-proto, spoofing defense) | Preserved |
| Top-level await (config, DB, dependency chain) | Preserved |
| Private class fields/methods (`#`, `in` check) | Preserved |
| Static class fields and blocks | Preserved |
| Error cause (nested chain) | Preserved |
| RegExp match indices (`/d` flag) | Preserved |
| `toSorted()` / `toReversed()` / `toSpliced()` / `with()` | Preserved |
| `findLast()` / `findLastIndex()` | Preserved |
| Hashbang grammar | Preserved |
| Symbols as WeakMap keys | Preserved |
| Migration patterns (sorting, state updates, findLast) | Merged inline |

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/reference content only, no code execution paths)
- **Verification**: markdownlint-cli2 — 0 errors. Manual content audit against original.

Closes #11307