### PR TITLE
GH#11261: tighten opencode-server.md (318→259 lines, -19%)

### DIFF
--- a/.agents/tools/ai-assistants/opencode-server.md
+++ b/.agents/tools/ai-assistants/opencode-server.md
@@ -27,67 +27,50 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-OpenCode server mode (`opencode serve`) exposes an HTTP API for programmatic interaction with AI sessions. This enables parallel agent orchestration, voice dispatch, automated testing, and custom integrations.
-
 ## Architecture
 
 ```text
-┌─────────────────────────────────────────────────────────────┐
-│                    OpenCode Server                          │
-│                   (opencode serve)                          │
-├─────────────────────────────────────────────────────────────┤
-│  HTTP API (OpenAPI 3.1)                                     │
-│  ├── /session          - Session management                 │
-│  ├── /session/:id/message - Sync prompts (wait for reply)   │
-│  ├── /session/:id/prompt_async - Async prompts (fire+forget)│
-│  ├── /event            - SSE stream for real-time events    │
-│  └── /tui/*            - TUI control (if running)           │
-├─────────────────────────────────────────────────────────────┤
-│  Clients                                                    │
-│  ├── TUI (opencode)    - Default terminal interface         │
-│  ├── SDK               - @opencode-ai/sdk (TypeScript)      │
-│  ├── curl/HTTP         - Direct API calls                   │
-│  └── Custom apps       - Voice, chat bots, CI/CD            │
-└─────────────────────────────────────────────────────────────┘
+OpenCode Server (opencode serve)
+├── HTTP API (OpenAPI 3.1)
+│   ├── /session              Session management
+│   ├── /session/:id/message  Sync prompts (wait for reply)
+│   ├── /session/:id/prompt_async  Async prompts (fire+forget)
+│   ├── /event                SSE stream for real-time events
+│   └── /tui/*                TUI control (if running)
+└── Clients: TUI, SDK (@opencode-ai/sdk), curl/HTTP, custom apps
 ```
 
 ## Starting the Server
 
 ```bash
-opencode serve                                                    # default (port 4096, localhost)
-opencode serve --port 8080 --hostname 0.0.0.0                    # custom port/hostname
-opencode serve --mdns                                             # mDNS discovery
-opencode serve --cors http://localhost:5173                       # CORS for browser clients
-OPENCODE_SERVER_PASSWORD=secret opencode serve                   # with auth
+opencode serve                                    # default (port 4096, localhost)
+opencode serve --port 8080 --hostname 0.0.0.0     # custom port/hostname
+opencode serve --mdns                              # mDNS discovery
+opencode serve --cors http://localhost:5173        # CORS for browser clients
+OPENCODE_SERVER_PASSWORD=secret opencode serve    # with auth
 OPENCODE_SERVER_USERNAME=admin OPENCODE_SERVER_PASSWORD=secret opencode serve
-opencode --port 4096 --hostname 127.0.0.1                        # alongside TUI (fixed port)
+opencode --port 4096 --hostname 127.0.0.1         # alongside TUI (fixed port)
 ```
 
-## TypeScript SDK
-
-```bash
-npm install @opencode-ai/sdk
-```
+## TypeScript SDK (`npm install @opencode-ai/sdk`)
 
 ```typescript
 import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk"
 
-// Option 1: Start server + client together
+// Option A: Start server + client together
 const { client, server } = await createOpencode({
-  port: 4096,
-  hostname: "127.0.0.1",
+  port: 4096, hostname: "127.0.0.1",
   config: { model: "anthropic/claude-sonnet-4-6" },
 })
-
-// Option 2: Connect to existing server
+// Option B: Connect to existing server
 const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
 
-// Session management
+// Session lifecycle
 const session = await client.session.create({ body: { title: "My automated task" } })
-const sessions = await client.session.list()
+await client.session.list()
 await client.session.delete({ path: { id: session.data.id } })
 
-// Synchronous prompt (waits for full response)
+// Sync prompt (waits for response)
 const result = await client.session.prompt({
   path: { id: session.data.id },
   body: {
@@ -95,32 +78,31 @@ const result = await client.session.prompt({
     parts: [{ type: "text", text: "Explain this codebase structure" }],
   },
 })
-console.log(result.data.parts)
 
-// Asynchronous prompt (fire and forget — returns 204, monitor via SSE)
+// Async prompt (fire+forget — returns 204, monitor via SSE)
 await client.session.promptAsync({
   path: { id: session.data.id },
   body: { parts: [{ type: "text", text: "Run the test suite" }] },
 })
 
-// Context injection (no AI response triggered)
-await client.session.prompt({
-  path: { id: session.data.id },
-  body: {
-    noReply: true,
-    parts: [{ type: "text", text: "Context: This project uses TypeScript and Bun runtime." }],
-  },
+// Context injection (noReply: true — no AI response triggered)
+await client.session.prompt({ path: { id: session.data.id },
+  body: { noReply: true, parts: [{ type: "text", text: "Context: TypeScript + Bun runtime." }] },
 })
 
-// Real-time events (SSE)
-const events = await client.event.subscribe()
-for await (const event of events.stream) {
-  switch (event.type) {
-    case "session.message": console.log("New message:", event.properties); break
-    case "session.status":  console.log("Status change:", event.properties); break
-    case "tool.call":       console.log("Tool invoked:", event.properties); break
-  }
+// SSE events
+for await (const event of (await client.event.subscribe()).stream) {
+  // event.type: "session.message" | "session.status" | "tool.call"
+  console.log(event.type, event.properties)
 }
+
+// Slash commands, shell, pre-edit check (aidevops integration)
+await client.session.command({ path: { id: session.data.id },
+  body: { command: "remember", arguments: "WORKING_SOLUTION: Use --no-verify for hotfixes" } })
+await client.session.command({ path: { id: session.data.id },
+  body: { command: "recall", arguments: "--type WORKING_SOLUTION --recent 10" } })
+await client.session.shell({ path: { id: session.data.id },
+  body: { agent: "default", command: "~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode" } })
 ```
 
 ## Direct HTTP API
@@ -141,163 +123,122 @@ curl -X POST http://localhost:4096/session/{session_id}/prompt_async \
   -H "Content-Type: application/json" \
   -d '{"parts":[{"type":"text","text":"Run tests in background"}]}'
 
-# Subscribe to events (SSE)
+# Subscribe to events (SSE) | Execute slash command | Run shell command
 curl -N http://localhost:4096/event
-
-# Execute slash command
 curl -X POST http://localhost:4096/session/{session_id}/command \
   -H "Content-Type: application/json" \
   -d '{"command":"remember","arguments":"This pattern worked for async processing"}'
-
-# Run shell command
 curl -X POST http://localhost:4096/session/{session_id}/shell \
   -H "Content-Type: application/json" \
   -d '{"agent":"default","command":"npm test"}'
 ```
 
-## Use Cases for aidevops
+## Use Cases
 
-### 1. Parallel Agent Orchestration
+### Parallel Agent Orchestration
+
+Create multiple sessions, dispatch async prompts concurrently via `Promise.all`:
 
 ```typescript
 const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
-
-const [codeReview, docGen, testGen] = await Promise.all([
+const [review, docs, tests] = await Promise.all([
   client.session.create({ body: { title: "Code Review" } }),
   client.session.create({ body: { title: "Documentation" } }),
   client.session.create({ body: { title: "Test Generation" } }),
 ])
-
 await Promise.all([
-  client.session.promptAsync({ path: { id: codeReview.data.id },
+  client.session.promptAsync({ path: { id: review.data.id },
     body: { parts: [{ type: "text", text: "Review src/auth.ts for security issues" }] } }),
-  client.session.promptAsync({ path: { id: docGen.data.id },
-    body: { parts: [{ type: "text", text: "Generate API documentation for src/api/" }] } }),
-  client.session.promptAsync({ path: { id: testGen.data.id },
+  client.session.promptAsync({ path: { id: docs.data.id },
+    body: { parts: [{ type: "text", text: "Generate API docs for src/api/" }] } }),
+  client.session.promptAsync({ path: { id: tests.data.id },
     body: { parts: [{ type: "text", text: "Generate unit tests for src/utils/" }] } }),
 ])
 ```
 
-### 2. Voice Dispatch (VoiceInk/iOS Shortcut)
+### Voice Dispatch (VoiceInk/iOS Shortcut)
 
 ```bash
 #!/bin/bash
 # voice-dispatch.sh - Called by VoiceInk or iOS Shortcut
-TRANSCRIPTION="$1"
-SESSION_ID="${OPENCODE_SESSION_ID:-default}"
-curl -X POST "http://localhost:4096/session/$SESSION_ID/prompt_async" \
+curl -X POST "http://localhost:4096/session/${OPENCODE_SESSION_ID:-default}/prompt_async" \
   -H "Content-Type: application/json" \
-  -d "{\"parts\": [{\"type\": \"text\", \"text\": \"$TRANSCRIPTION\"}]}"
+  -d "{\"parts\": [{\"type\": \"text\", \"text\": \"$1\"}]}"
 ```
 
-### 3. Automated Agent Testing
+### Automated Agent Testing
 
 ```typescript
-async function testAgentChange(testPrompt: string, expectedPattern: RegExp) {
+async function testAgentChange(prompt: string, expected: RegExp) {
   const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
   const session = await client.session.create({ body: { title: `Test: ${Date.now()}` } })
   try {
     const result = await client.session.prompt({
       path: { id: session.data.id },
-      body: { parts: [{ type: "text", text: testPrompt }] },
+      body: { parts: [{ type: "text", text: prompt }] },
     })
-    const responseText = result.data.parts.filter((p) => p.type === "text").map((p) => p.text).join("\n")
-    return { passed: expectedPattern.test(responseText), response: responseText }
-  } finally {
-    await client.session.delete({ path: { id: session.data.id } })
-  }
+    const text = result.data.parts.filter((p) => p.type === "text").map((p) => p.text).join("\n")
+    return { passed: expected.test(text), response: text }
+  } finally { await client.session.delete({ path: { id: session.data.id } }) }
 }
 ```
 
-### 4. Self-Improving Agent Loop
+### Self-Improving Agent Loop
 
-Pattern: Review phase (analyze memory for failure patterns) → Refine phase (generate improvements in isolated session) → Test phase (validate against test prompts) → PR phase (create PR if tests pass, with privacy filter). Use `client.session.command` with `/recall` and `/remember` for memory access.
+Pattern: Review (analyze memory for failure patterns) → Refine (generate improvements in isolated session) → Test (validate against test prompts) → PR (create if tests pass, with privacy filter). Use `client.session.command` with `/recall` and `/remember`.
 
-### 5. CI/CD Integration
+### CI/CD Integration (GitHub Actions)
 
 ```bash
-# In GitHub Actions: start server, create session, send review prompt, post comment
 opencode serve --port 4096 &
 sleep 5
 SESSION=$(curl -s -X POST http://localhost:4096/session \
   -H "Content-Type: application/json" -d '{"title":"PR Review"}' | jq -r '.id')
 curl -X POST "http://localhost:4096/session/$SESSION/message" \
   -H "Content-Type: application/json" \
-  -d '{"parts":[{"type":"text","text":"Review the changes in this PR for security issues. Output as markdown."}]}' \
+  -d '{"parts":[{"type":"text","text":"Review this PR for security issues. Output as markdown."}]}' \
   | jq -r '.parts[0].text' > review.md
-# Then post review.md as a PR comment via actions/github-script
+# Post review.md as PR comment via actions/github-script
 ```
 
 ## API Reference
 
-### Session Endpoints
+Full spec at `http://localhost:4096/doc`. Key endpoints:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/session` | List all sessions |
-| `POST` | `/session` | Create new session |
-| `GET` | `/session/:id` | Get session details |
-| `DELETE` | `/session/:id` | Delete session |
-| `PATCH` | `/session/:id` | Update session (title) |
+| `GET/POST` | `/session` | List / create sessions |
+| `GET/DELETE/PATCH` | `/session/:id` | Get / delete / update session |
 | `POST` | `/session/:id/message` | Send prompt (sync) |
 | `POST` | `/session/:id/prompt_async` | Send prompt (async) |
 | `POST` | `/session/:id/command` | Execute slash command |
 | `POST` | `/session/:id/shell` | Run shell command |
 | `POST` | `/session/:id/abort` | Abort running session |
 | `POST` | `/session/:id/fork` | Fork session at message |
-| `GET` | `/session/:id/diff` | Get session file changes |
-| `GET` | `/session/:id/todo` | Get session todo list |
-
-### Global / File Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/global/health` | Server health check |
+| `GET` | `/session/:id/diff` | Session file changes |
+| `GET` | `/session/:id/todo` | Session todo list |
+| `GET` | `/global/health` | Health check |
 | `GET` | `/event` | SSE event stream |
 | `GET` | `/doc` | OpenAPI 3.1 spec |
 | `GET` | `/find?pattern=<pat>` | Search text in files |
 | `GET` | `/find/file?query=<q>` | Find files by name |
 | `GET` | `/file/content?path=<p>` | Read file content |
+| `POST` | `/tui/*` | TUI control: `append-prompt`, `submit-prompt`, `clear-prompt`, `execute-command`, `show-toast` |
 
-### TUI Control (when TUI is running)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/tui/append-prompt` | Add text to prompt |
-| `POST` | `/tui/submit-prompt` | Submit current prompt |
-| `POST` | `/tui/clear-prompt` | Clear prompt |
-| `POST` | `/tui/execute-command` | Run command |
-| `POST` | `/tui/show-toast` | Show notification |
-
-## Integration with aidevops
-
-```typescript
-// Store/recall memories via slash command
-await client.session.command({ path: { id: sessionId },
-  body: { command: "remember", arguments: "WORKING_SOLUTION: Use --no-verify for emergency hotfixes" } })
-await client.session.command({ path: { id: sessionId },
-  body: { command: "recall", arguments: "--type WORKING_SOLUTION --recent 10" } })
-```
+## Mailbox Dispatch
 
 ```bash
-# Mailbox dispatch to parallel agents
 mail-helper.sh send --to "code-reviewer" --type "task_dispatch" \
   --subject "Review PR #123" --body "Review security implications of auth changes"
 ```
 
-```typescript
-// Pre-edit check before file modifications in automated sessions
-const preCheck = await client.session.shell({ path: { id: sessionId },
-  body: { agent: "default", command: "~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode" } })
-```
+## Security
 
-## Security Considerations
-
-1. **Network exposure**: Use `--hostname 127.0.0.1` (default) for local-only access
-2. **Authentication**: Always set `OPENCODE_SERVER_PASSWORD` when exposing to network
+1. **Network**: `--hostname 127.0.0.1` (default) for local-only access
+2. **Auth**: Always set `OPENCODE_SERVER_PASSWORD` when exposing to network
 3. **CORS**: Only allow trusted origins with `--cors`
 4. **Credentials**: Never pass secrets in prompts — use environment variables
-5. **Session cleanup**: Delete sessions after use to prevent data leakage
+5. **Cleanup**: Delete sessions after use to prevent data leakage
 
 ## Troubleshooting
 
@@ -307,12 +248,12 @@ pkill -f "opencode serve"              # kill existing process
 curl http://localhost:4096/global/health  # verify server is running
 ```
 
-SDK timeout: pass `timeout: 30000` to `createOpencode({ timeout: 30000 })`.
+SDK timeout: `createOpencode({ timeout: 30000 })`.
 
-## Related Documentation
+## Related
 
-- `tools/ai-assistants/overview.md` - AI assistant comparison
-- `workflows/git-workflow.md` - Git workflow integration
-- `reference/memory.md` - Memory system documentation
-- OpenCode SDK docs: `https://opencode.ai/docs/sdk/`
-- OpenCode Server docs: `https://opencode.ai/docs/server/`
+- `tools/ai-assistants/overview.md` — AI assistant comparison
+- `workflows/git-workflow.md` — Git workflow integration
+- `reference/memory.md` — Memory system documentation
+- OpenCode SDK: `https://opencode.ai/docs/sdk/`
+- OpenCode Server: `https://opencode.ai/docs/server/`


### PR DESCRIPTION
## Summary

- Tightens `.agents/tools/ai-assistants/opencode-server.md` from 318 to 259 lines (-19%)
- Removes redundancy while preserving all actionable content, code blocks, URLs, and API endpoints
- Merges "Integration with aidevops" section into the SDK example to eliminate duplicate code patterns

## Changes

- **Removed** redundant intro paragraph (duplicated Quick Reference content)
- **Compacted** architecture diagram from box-drawing to tree format (same information, fewer lines)
- **Merged** 3 separate "Integration with aidevops" code blocks into the main SDK example
- **Consolidated** 3 API reference tables (Session, Global/File, TUI) into 1 unified table
- **Tightened** voice dispatch, agent testing, and CI/CD use case examples
- **Inlined** `npm install` command into section heading

## Verification

- All code blocks preserved (server start, SDK, curl, all 5 use cases)
- All URLs preserved (`localhost:4096/doc`, `opencode.ai/docs/sdk/`, `opencode.ai/docs/server/`)
- All API endpoints preserved (13 session + 6 global/file + 5 TUI)
- All commands preserved (`opencode serve`, `mail-helper.sh`, `pre-edit-check.sh`, troubleshooting)
- Zero markdownlint violations

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompt only — no code, no runtime behaviour change)

Closes #11261