### PR TITLE
GH#11236: Tighten smartlead.md from 333 to 230 lines

### DIFF
--- a/.agents/services/outreach/smartlead.md
+++ b/.agents/services/outreach/smartlead.md
@@ -15,27 +15,14 @@ tools:
 
 - **Helper**: `scripts/smartlead-helper.sh <command> <subcommand> [options]`
 - **API base**: `https://server.smartlead.ai/api/v1`
-- **Auth**: API key as query parameter (`?api_key=...`)
-- **Rate limit**: 10 requests per 2 seconds (built-in 0.2s delay)
-- **Credential**: `aidevops secret set smartlead-api-key` or `SMARTLEAD_API_KEY` env var
+- **Auth**: API key as query parameter (`?api_key=...`). Get from Smartlead dashboard > Settings > API Keys. Store: `aidevops secret set smartlead-api-key` or `export SMARTLEAD_API_KEY="your-key-here"` (run in terminal, not AI chat)
+- **Rate limit**: 10 req/2s (built-in 0.2s delay; override with `SMARTLEAD_RATE_LIMIT_DELAY`)
 - **Config template**: `configs/smartlead-config.json.txt`
-- **Strategy doc**: `services/outreach/cold-outreach.md`
-
-## Authentication
-
-Smartlead uses API key authentication via query parameter. The key is available in the Smartlead dashboard under Settings > API Keys.
-
-```bash
-# Store API key securely (run in your terminal, not in AI chat)
-aidevops secret set smartlead-api-key
-
-# Or set as environment variable
-export SMARTLEAD_API_KEY="your-key-here"
-```
+- **Strategy**: `services/outreach/cold-outreach.md` (warmup schedules, compliance, platform comparison)
 
 ## Campaign Lifecycle
 
-Typical campaign setup flow via the helper:
+Setup flow via the helper:
 
 ```text
 1. Create campaign         → campaigns create "Name"
@@ -62,35 +49,21 @@ Typical campaign setup flow via the helper:
 ### Campaigns
 
 ```bash
-# List all campaigns
 smartlead-helper.sh campaigns list
 smartlead-helper.sh campaigns list --client-id 5
-
-# Get campaign details
 smartlead-helper.sh campaigns get 123
-
-# Create a new campaign
 smartlead-helper.sh campaigns create "Q1 Outreach 2026"
 smartlead-helper.sh campaigns create "Client Campaign" --client-id 5
-
-# Update campaign status
 smartlead-helper.sh campaigns status 123 START
 smartlead-helper.sh campaigns status 123 PAUSED
-
-# Update campaign settings
 smartlead-helper.sh campaigns settings 123 --json '{"max_leads_per_day": 50, "track_settings": {"track_open": true, "track_click": true}}'
-
-# Set campaign schedule
 smartlead-helper.sh campaigns schedule 123 --json '{"timezone": "America/New_York", "days": [1,2,3,4,5], "start_hour": "09:00", "end_hour": "17:00"}'
-
-# Delete campaign (permanent)
-smartlead-helper.sh campaigns delete 123
+smartlead-helper.sh campaigns delete 123  # permanent
 ```
 
 ### Sequences
 
 ```bash
-# Get sequences for a campaign
 smartlead-helper.sh sequences get 123
 
 # Save sequences (with A/B variants)
@@ -118,44 +91,21 @@ smartlead-helper.sh sequences save 123 --json '{
 ### Leads
 
 ```bash
-# Add leads from JSON file (auto-batches at 400 per request)
-smartlead-helper.sh leads add 123 --file leads.json
-
-# Add leads with import settings
+smartlead-helper.sh leads add 123 --file leads.json  # auto-batches at 400/request
 smartlead-helper.sh leads add 123 --file leads.json --settings '{"ignore_global_block_list": false, "ignore_duplicate_leads_in_other_campaign": true}'
-
-# List campaign leads
 smartlead-helper.sh leads list 123
-
-# Get specific lead
 smartlead-helper.sh leads get 123 789
-
-# Search lead by email (global)
-smartlead-helper.sh leads search "contact@example.com"
-
-# Update lead details
+smartlead-helper.sh leads search "contact@example.com"  # global search
 smartlead-helper.sh leads update 123 789 --json '{"first_name": "Jane", "custom_fields": {"job_title": "CTO"}}'
-
-# Pause/resume lead
 smartlead-helper.sh leads pause 123 789
 smartlead-helper.sh leads resume 123 789
 smartlead-helper.sh leads resume 123 789 --delay-days 7
-
-# Delete lead from campaign
 smartlead-helper.sh leads delete 123 789
-
-# Unsubscribe (campaign-level)
-smartlead-helper.sh leads unsubscribe 123 789
-
-# Unsubscribe (global — permanent, all campaigns)
-smartlead-helper.sh leads unsubscribe-global 789
-
-# Export leads as CSV
+smartlead-helper.sh leads unsubscribe 123 789          # campaign-level
+smartlead-helper.sh leads unsubscribe-global 789       # permanent, all campaigns
 smartlead-helper.sh leads export 123
 smartlead-helper.sh leads export 123 --output campaign-leads.csv
-
-# View lead message history
-smartlead-helper.sh leads history 123 789
+smartlead-helper.sh leads history 123 789              # message history
 ```
 
 **Lead file format** (`leads.json`):
@@ -177,16 +127,13 @@ smartlead-helper.sh leads history 123 789
 }
 ```
 
-Maximum 400 leads per batch. The helper auto-splits larger files into batches.
+Max 400 leads per batch (helper auto-splits larger files).
 
 ### Email Accounts
 
 ```bash
-# List all email accounts
 smartlead-helper.sh accounts list
 smartlead-helper.sh accounts list --offset 0 --limit 50
-
-# Get account details
 smartlead-helper.sh accounts get 456
 
 # Create SMTP email account
@@ -203,26 +150,16 @@ smartlead-helper.sh accounts create --json '{
   "max_email_per_day": 100
 }'
 
-# Update account settings
 smartlead-helper.sh accounts update 456 --json '{"max_email_per_day": 80, "from_name": "Jane S."}'
-
-# Delete account
 smartlead-helper.sh accounts delete 456
-
-# Add accounts to campaign
 smartlead-helper.sh accounts add-to-campaign 123 --ids 456,457,458
-
-# List campaign email accounts
 smartlead-helper.sh accounts campaign-list 123
-
-# Remove accounts from campaign
 smartlead-helper.sh accounts remove-from-campaign 123 --ids 456,457
 ```
 
 ### Warmup
 
 ```bash
-# Configure warmup for an email account
 smartlead-helper.sh warmup configure 456 --json '{
   "warmup_enabled": true,
   "total_warmup_per_day": 15,
@@ -230,8 +167,7 @@ smartlead-helper.sh warmup configure 456 --json '{
   "reply_rate_percentage": 30
 }'
 
-# Get warmup statistics (last 7 days)
-smartlead-helper.sh warmup stats 456
+smartlead-helper.sh warmup stats 456  # last 7 days
 ```
 
 Follow the warmup ramp schedule in `services/outreach/cold-outreach.md` — start at 5-8/day, scale to 20/day over 4 weeks.
@@ -239,16 +175,9 @@ Follow the warmup ramp schedule in `services/outreach/cold-outreach.md` — star
 ### Analytics
 
 ```bash
-# Campaign-level analytics (top-level)
-smartlead-helper.sh analytics campaign 123
-
-# Campaign statistics (email-level detail)
-smartlead-helper.sh analytics campaign-stats 123
-
-# Analytics by date range
+smartlead-helper.sh analytics campaign 123          # top-level
+smartlead-helper.sh analytics campaign-stats 123    # email-level detail
 smartlead-helper.sh analytics date-range 123 --start 2026-01-01 --end 2026-03-31
-
-# Global overview (all campaigns)
 smartlead-helper.sh analytics overview
 smartlead-helper.sh analytics overview --start 2026-01-01 --end 2026-03-31
 ```
@@ -256,17 +185,13 @@ smartlead-helper.sh analytics overview --start 2026-01-01 --end 2026-03-31
 ### Webhooks
 
 ```bash
-# Create campaign webhook
+# Campaign webhooks
 smartlead-helper.sh webhooks create 123 --json '{
   "name": "Reply Notification",
   "webhook_url": "https://example.com/hooks/smartlead",
   "event_types": ["LEAD_REPLIED", "LEAD_BOUNCED"]
 }'
-
-# List campaign webhooks
 smartlead-helper.sh webhooks list 123
-
-# Delete campaign webhook
 smartlead-helper.sh webhooks delete 123 456
 
 # Global webhooks (user-level, all campaigns)
@@ -276,38 +201,22 @@ smartlead-helper.sh webhooks global-create --json '{
   "name": "All Events",
   "event_type_map": {"SENT": true, "OPENED": true, "CLICKED": true, "REPLIED": true, "BOUNCED": true}
 }'
-
 smartlead-helper.sh webhooks global-get 789
 smartlead-helper.sh webhooks global-update 789 --json '{"name": "Updated Hook"}'
 smartlead-helper.sh webhooks global-delete 789
 ```
 
-**Webhook event types**: `LEAD_REPLIED`, `LEAD_OPENED`, `LEAD_CLICKED`, `LEAD_BOUNCED`, `LEAD_UNSUBSCRIBED` (campaign-level). Global webhooks use: `SENT`, `OPENED`, `CLICKED`, `REPLIED`, `BOUNCED`, `UNSUBSCRIBED`.
+**Webhook event types**: Campaign-level: `LEAD_REPLIED`, `LEAD_OPENED`, `LEAD_CLICKED`, `LEAD_BOUNCED`, `LEAD_UNSUBSCRIBED`. Global: `SENT`, `OPENED`, `CLICKED`, `REPLIED`, `BOUNCED`, `UNSUBSCRIBED`.
 
 ### Block List
 
 ```bash
-# Block domains globally (no future emails to these domains)
 smartlead-helper.sh blocklist add-domains --json '{"domains": ["spam.com", "invalid.org"], "source": "manual"}'
-
-# List blocked domains
 smartlead-helper.sh blocklist list-domains
-
-# List blocked email addresses
 smartlead-helper.sh blocklist list-emails
 ```
 
 Block list sources: `manual`, `bounce`, `complaint`, `invalid`.
-
-## Rate Limiting
-
-Smartlead enforces 10 requests per 2 seconds. The helper includes a built-in 0.2-second delay between requests. For batch operations (large lead imports), the delay is applied per API call.
-
-Adjust the delay if needed:
-
-```bash
-export SMARTLEAD_RATE_LIMIT_DELAY=0.3  # More conservative
-```
 
 ## Environment Variables
 
@@ -318,16 +227,4 @@ export SMARTLEAD_RATE_LIMIT_DELAY=0.3  # More conservative
 | `SMARTLEAD_TIMEOUT` | `30` | Request timeout (seconds) |
 | `SMARTLEAD_RATE_LIMIT_DELAY` | `0.2` | Delay between requests (seconds) |
 
-## Integration with Cold Outreach Strategy
-
-This helper implements the technical layer for the strategy defined in `services/outreach/cold-outreach.md`. Key alignment points:
-
-- **Warmup ramp**: Use `warmup configure` to match the 4-week ramp schedule (5 → 20/day)
-- **Daily limits**: Set `max_email_per_day` to 100 or below per account via `accounts update`
-- **Multi-mailbox rotation**: Add multiple accounts to campaigns via `accounts add-to-campaign`
-- **Compliance**: Use `blocklist add-domains` for suppression; `leads unsubscribe` for opt-outs
-- **Reply detection**: Configure webhooks for `LEAD_REPLIED` events to trigger handoff workflows
-
 <!-- AI-CONTEXT-END -->
-
-For strategy guidance (warmup schedules, compliance, platform comparison), see `services/outreach/cold-outreach.md`.


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/outreach/smartlead.md` from 333 → 230 lines (-31%, net -103 lines)
- Removed 3 redundant sections (Authentication, Rate Limiting, Integration with Cold Outreach Strategy) by consolidating into Quick Reference and inline comments
- Converted verbose per-command comments to inline `# comment` format where section headers already provide context

## What was removed and where it went

| Removed section | Destination |
|---|---|
| Authentication (11 lines) | Merged into Quick Reference `Auth` bullet |
| Rate Limiting (8 lines + code block) | Already in Quick Reference + env vars table; override var mentioned in QR |
| Integration with Cold Outreach Strategy (9 lines) | Strategy ref in QR; warmup ramp in Warmup section; other points self-evident from commands |
| Final strategy ref line | Duplicate of QR strategy ref |
| 50+ inline comment lines | Moved to inline `# comment` or removed (section headers suffice) |

## Content preservation verification

- All 54 `smartlead-helper.sh` command references preserved (verified via `rg` diff)
- All 4 environment variables preserved in table
- All webhook event types, personalization variables, JSON examples, lead file format preserved
- All URLs and file references preserved
- Zero unique technical content removed

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/agent prompt only, no code changes)
- **Verification**: markdownlint — 0 errors; `rg` command diff — zero unique commands lost

Closes #11236