### PR TITLE
t11228: tighten api-integrations.md 335→115 lines

### DIFF
--- a/.agents/aidevops/api-integrations.md
+++ b/.agents/aidevops/api-integrations.md
@@ -11,325 +11,105 @@ tools:
   webfetch: true
 ---
 
-# Comprehensive API Integration Guide
+# API Integration Guide
 
 <!-- AI-CONTEXT-START -->
 
-## Quick Reference
-
 **Total APIs**: 28+ integrated services
-
-**By Category**:
-- **Hosting**: Hostinger, Hetzner, Closte, Coolify
-- **DNS/Domains**: Cloudflare, Spaceship, 101domains, Route53, Namecheap
-- **Git**: GitHub, GitLab, Gitea
-- **Code Quality**: CodeRabbit, Codacy, SonarCloud, CodeFactor
-- **SEO**: Ahrefs, Google Search Console, Perplexity
-- **Security**: Vaultwarden
-- **Email**: Amazon SES
-- **Dev Tools**: Context7, LocalWP, Pandoc, Agno, Playwright/Selenium
 
 **Pattern**: `configs/[service]-config.json` + `.agents/scripts/[service]-helper.sh`
 
-**API Key Setup**: `bash .agents/scripts/setup-local-api-keys.sh set [service]-api-key YOUR_KEY`
-**Test All APIs**: `bash .agents/scripts/test-all-apis.sh`
-<!-- AI-CONTEXT-END -->
-
-This document provides detailed information about all 28+ API integrations supported by the AI DevOps framework.
-
-## 📊 **API Integration Overview**
-
-Our framework provides standardized access to APIs across all major infrastructure categories, enabling seamless automation and management through consistent interfaces.
-
-## 🏗️ **Infrastructure & Hosting APIs**
-
-### **Hostinger API**
-
-- **Purpose**: Server management, domain operations, hosting control
-- **Authentication**: API Token
-- **Configuration**: `configs/hostinger-config.json`
-- **Helper Script**: `.agents/scripts/hostinger-helper.sh`
-- **Key Features**: VPS management, domain registration, hosting plans
-
-### **Hetzner Cloud API**
-
-- **Purpose**: VPS management, networking, load balancers
-- **Authentication**: API Token
-- **Configuration**: `configs/hetzner-config.json`
-- **Helper Script**: `.agents/scripts/hetzner-helper.sh`
-- **Key Features**: Server creation, networking, snapshots, load balancers
-
-### **Closte API**
-
-- **Purpose**: Managed hosting, application deployment
-- **Authentication**: API Key
-- **Configuration**: `configs/closte-config.json`
-- **Helper Script**: `.agents/scripts/closte-helper.sh`
-- **Key Features**: Application management, deployment automation
-
-### **Coolify API**
-
-- **Purpose**: Self-hosted PaaS, application management
-- **Authentication**: API Token
-- **Configuration**: `configs/coolify-config.json`
-- **Helper Script**: `.agents/scripts/coolify-helper.sh`
-- **Key Features**: Docker deployment, service management, monitoring
-
-## 🌐 **Domain & DNS APIs**
-
-### **Cloudflare API**
-
-- **Purpose**: DNS management, security, performance optimization
-- **Authentication**: API Token (scoped permissions)
-- **Configuration**: `configs/cloudflare-dns-config.json`
-- **Helper Script**: `.agents/scripts/dns-helper.sh`
-- **Key Features**: DNS records, security rules, analytics, caching
-
-### **Spaceship API**
-
-- **Purpose**: Domain registration, management, transfers
-- **Authentication**: API Key
-- **Configuration**: `configs/spaceship-config.json`
-- **Helper Script**: `.agents/scripts/spaceship-helper.sh`
-- **Key Features**: Domain search, registration, WHOIS, transfers
-
-### **101domains API**
-
-- **Purpose**: Domain purchasing, bulk operations, WHOIS
-- **Authentication**: API Credentials
-- **Configuration**: `configs/101domains-config.json`
-- **Helper Script**: `.agents/scripts/101domains-helper.sh`
-- **Key Features**: Bulk domain operations, pricing, availability
-
-### **AWS Route 53 API**
-
-- **Purpose**: DNS management, health checks
-- **Authentication**: AWS Access Keys
-- **Configuration**: `configs/route53-dns-config.json`
-- **Helper Script**: `.agents/scripts/dns-helper.sh`
-- **Key Features**: DNS hosting, health checks, traffic routing
-
-### **Namecheap API**
-
-- **Purpose**: Domain registration, DNS management
-- **Authentication**: API Key + Username
-- **Configuration**: `configs/namecheap-dns-config.json`
-- **Helper Script**: `.agents/scripts/dns-helper.sh`
-- **Key Features**: Domain management, DNS hosting, SSL certificates
-
-## 📧 **Communication APIs**
-
-### **Amazon SES API**
-
-- **Purpose**: Email delivery, bounce handling, analytics
-- **Authentication**: AWS Access Keys
-- **Configuration**: `configs/ses-config.json`
-- **Helper Script**: `.agents/scripts/ses-helper.sh`
-- **Key Features**: Email sending, bounce tracking, reputation monitoring
-
-### **Twilio API**
-
-- **Purpose**: SMS, voice calls, WhatsApp, phone verification, call recording
-- **Authentication**: Account SID + Auth Token
-- **Configuration**: `configs/twilio-config.json`
-- **Helper Script**: `.agents/scripts/twilio-helper.sh`
-- **Key Features**: SMS/MMS, voice calls, WhatsApp Business, Verify (2FA), Lookup, recordings, transcriptions
-- **AUP Compliance**: Must follow Twilio Acceptable Use Policy
-- **Recommended Client**: Telfon app for end-user interface (https://mytelfon.com/)
-
-### **MainWP API**
-
-- **Purpose**: WordPress site management, updates, monitoring
-- **Authentication**: API Key
-- **Configuration**: `configs/mainwp-config.json`
-- **Helper Script**: `.agents/scripts/mainwp-helper.sh`
-- **Key Features**: Site management, updates, backups, monitoring
-
-## 🔐 **Security & Code Quality APIs**
-
-### **Vaultwarden API**
-
-- **Purpose**: Password management, secure credential storage
-- **Authentication**: API Token
-- **Configuration**: `configs/vaultwarden-config.json`
-- **Helper Script**: `.agents/scripts/vaultwarden-helper.sh`
-- **Key Features**: Credential storage, secure sharing, audit logs
-
-### **CodeRabbit API**
-
-- **Purpose**: AI-powered code review, security analysis
-- **Authentication**: API Key
-- **Setup Script**: `.agents/scripts/coderabbit-cli.sh`
-- **Key Features**: Automated code review, security scanning, suggestions
-
-### **Codacy API**
-
-- **Purpose**: Code quality analysis, technical debt tracking
-- **Authentication**: API Token
-- **Setup Script**: `.agents/scripts/codacy-cli.sh`
-- **Key Features**: Quality metrics, security analysis, coverage tracking
-
-### **SonarCloud API**
-
-- **Purpose**: Security scanning, maintainability metrics
-- **Authentication**: API Token
-- **Integration**: GitHub Actions workflow
-- **Key Features**: Security hotspots, code smells, coverage analysis
-
-### **CodeFactor API**
-
-- **Purpose**: Automated code quality grading
-- **Authentication**: GitHub integration
-- **Setup**: Automatic via GitHub
-- **Key Features**: Quality scoring, trend analysis, file-level metrics
-
-## 🔍 **SEO & Analytics APIs**
-
-### **Ahrefs API**
-
-- **Purpose**: SEO analysis, backlink research, keyword tracking
-- **Authentication**: API Key
-- **MCP Integration**: `mcp-server-ahrefs`
-- **Key Features**: Backlink analysis, keyword research, competitor analysis
-
-### **Google Search Console API**
-
-- **Purpose**: Search performance, indexing status
-- **Authentication**: Service Account (Google Cloud)
-- **MCP Integration**: `mcp-server-gsc`
-- **Key Features**: Search analytics, Core Web Vitals, index coverage
-
-### **Perplexity API**
-
-- **Purpose**: AI-powered research and content generation
-- **Authentication**: API Key
-- **MCP Integration**: `perplexity-mcp`
-- **Key Features**: Research queries, content generation, fact-checking
-
-## ⚡ **Development & Git APIs**
-
-### **GitHub API**
-
-- **Purpose**: Repository management, actions, security
-- **Authentication**: Personal Access Token
-- **Helper Script**: `.agents/scripts/git-platforms-helper.sh`
-- **Key Features**: Repository operations, workflow management, security scanning
-
-### **GitLab API**
-
-- **Purpose**: Project management, CI/CD, security scanning
-- **Authentication**: Personal Access Token
-- **Helper Script**: `.agents/scripts/git-platforms-helper.sh`
-- **Key Features**: Project management, pipeline automation, security features
-
-### **Gitea API**
-
-- **Purpose**: Self-hosted Git operations, user management
-- **Authentication**: API Token
-- **Helper Script**: `.agents/scripts/git-platforms-helper.sh`
-- **Key Features**: Repository management, user administration, webhooks
-
-### **Context7 API**
-
-- **Purpose**: Real-time documentation access
-- **Authentication**: API Key
-- **MCP Integration**: `@context7/mcp-server`
-- **Key Features**: Library documentation, code examples, API references
-
-### **LocalWP API**
-
-- **Purpose**: WordPress database operations, site management
-- **Authentication**: Local access
-- **MCP Integration**: Custom MCP server
-- **Key Features**: Database queries, site management, development tools
-
-### **Pandoc Document Conversion**
-
-- **Purpose**: Convert various document formats to markdown for AI processing
-- **Authentication**: Local tool (no API key required)
-- **Helper Script**: `.agents/scripts/pandoc-helper.sh`
-- **Key Features**: Multi-format conversion, batch processing, AI-optimized output
-- **Supported Formats**: Word, PDF, HTML, EPUB, LaTeX, and 20+ other formats
-
-### **Agno AgentOS**
-
-- **Purpose**: Local AI agent operating system for DevOps automation
-- **Authentication**: API keys for LLM providers (OpenAI, Anthropic, etc.)
-- **Setup Script**: `.agents/scripts/agno-setup.sh`
-- **Key Features**: Multi-agent framework, production runtime, complete privacy
-- **Agents**: DevOps Assistant, Code Review Agent, Documentation Agent
-- **Interface**: Agent-UI web interface and REST API
-
-### **Local Browser Automation (Playwright/Selenium)**
-
-- **Purpose**: LOCAL web automation and browser-based task automation (privacy-first)
-- **Authentication**: Website credentials (stored securely in local environment only)
-- **Setup Script**: Included in `.agents/scripts/agno-setup.sh`
-- **Key Features**: LOCAL LinkedIn automation, web scraping, form filling, social media management
-- **Privacy**: Complete local operation - no cloud services or external browsers
-- **Agents**: LinkedIn Automation Assistant (local), Web Automation Assistant (local)
-- **Tools**: LOCAL Playwright, LOCAL Selenium, BeautifulSoup, ethical automation guidelines
-- **Security**: Enterprise-grade privacy with local-only browser instances
-
-## 🔧 **API Integration Features**
-
-### **Standardized Authentication**
-
-- Consistent token management across all APIs
-- Secure credential storage in separate config files
-- Environment variable support for CI/CD
-
-### **Rate Limiting & Error Handling**
-
-- Built-in respect for API limits and quotas
-- Comprehensive error messages and retry logic
-- Graceful degradation when APIs are unavailable
-
-### **Security & Compliance**
-
-- Secure credential storage with proper file permissions
-- Minimal permission scoping for all API keys
-- Complete audit trail of all API operations
-
-### **Monitoring & Logging**
-
-- Comprehensive logging of all API interactions
-- Performance monitoring and analytics
-- Error tracking and alerting
-
-## 🚀 **Getting Started**
-
-### **Quick Setup**
-
 ```bash
-# Setup all API integrations
-bash setup.sh
-
-# Configure specific API
-cp configs/[service]-config.json.txt configs/[service]-config.json
-# Edit with your API credentials
-
-# Test API connection
-./.agents/scripts/[service]-helper.sh test-connection
-```
-
-### **API Key Management**
-
-```bash
-# Secure API key setup
-bash .agents/scripts/setup-local-api-keys.sh set [service]-api-key YOUR_API_KEY
-
-# List configured APIs
+# Setup
+bash .agents/scripts/setup-local-api-keys.sh set [service]-api-key YOUR_KEY
 bash .agents/scripts/setup-local-api-keys.sh list
-
-# Test all API connections
 bash .agents/scripts/test-all-apis.sh
 ```
 
-## 📚 **Additional Resources**
+<!-- AI-CONTEXT-END -->
+
+## Service Catalog
+
+### Infrastructure & Hosting
+
+| Service | Auth | Config | Helper | Notes |
+|---------|------|--------|--------|-------|
+| Hostinger | API Token | `configs/hostinger-config.json` | `hostinger-helper.sh` | VPS, domains, hosting plans |
+| Hetzner Cloud | API Token | `configs/hetzner-config.json` | `hetzner-helper.sh` | Servers, networking, snapshots, load balancers |
+| Closte | API Key | `configs/closte-config.json` | `closte-helper.sh` | Managed hosting, app deployment |
+| Coolify | API Token | `configs/coolify-config.json` | `coolify-helper.sh` | Self-hosted PaaS, Docker, service management |
+
+### Domain & DNS
+
+| Service | Auth | Config | Helper | Notes |
+|---------|------|--------|--------|-------|
+| Cloudflare | API Token (scoped) | `configs/cloudflare-dns-config.json` | `dns-helper.sh` | DNS, security rules, analytics, caching |
+| Spaceship | API Key | `configs/spaceship-config.json` | `spaceship-helper.sh` | Registration, WHOIS, transfers |
+| 101domains | API Credentials | `configs/101domains-config.json` | `101domains-helper.sh` | Bulk operations, pricing, availability |
+| AWS Route 53 | AWS Access Keys | `configs/route53-dns-config.json` | `dns-helper.sh` | DNS hosting, health checks, traffic routing |
+| Namecheap | API Key + Username | `configs/namecheap-dns-config.json` | `dns-helper.sh` | Domain management, DNS, SSL certificates |
+
+### Communication
+
+| Service | Auth | Config | Helper | Notes |
+|---------|------|--------|--------|-------|
+| Amazon SES | AWS Access Keys | `configs/ses-config.json` | `ses-helper.sh` | Email delivery, bounce tracking, reputation |
+| Twilio | Account SID + Auth Token | `configs/twilio-config.json` | `twilio-helper.sh` | SMS/MMS, voice, WhatsApp Business, Verify (2FA), Lookup, recordings. AUP compliance required. Telfon app for end-user UI (https://mytelfon.com/) |
+| MainWP | API Key | `configs/mainwp-config.json` | `mainwp-helper.sh` | WordPress site management, updates, backups |
+
+### Security & Code Quality
+
+| Service | Auth | Config/Setup | Notes |
+|---------|------|--------------|-------|
+| Vaultwarden | API Token | `configs/vaultwarden-config.json` / `vaultwarden-helper.sh` | Credential storage, secure sharing, audit logs |
+| CodeRabbit | API Key | `coderabbit-cli.sh` | AI code review, security scanning |
+| Codacy | API Token | `codacy-cli.sh` | Quality metrics, coverage tracking |
+| SonarCloud | API Token | GitHub Actions workflow | Security hotspots, code smells, coverage |
+| CodeFactor | GitHub integration | Automatic via GitHub | Quality scoring, trend analysis |
+
+### SEO & Analytics
+
+| Service | Auth | Integration | Notes |
+|---------|------|-------------|-------|
+| Ahrefs | API Key | `mcp-server-ahrefs` | Backlink analysis, keyword research, competitor analysis |
+| Google Search Console | Service Account (GCP) | `mcp-server-gsc` | Search analytics, Core Web Vitals, index coverage |
+| Perplexity | API Key | `perplexity-mcp` | Research queries, content generation, fact-checking |
+
+### Git Platforms
+
+All three share `git-platforms-helper.sh`.
+
+| Service | Auth | Notes |
+|---------|------|-------|
+| GitHub | Personal Access Token | Repos, Actions, security scanning |
+| GitLab | Personal Access Token | Projects, CI/CD pipelines, security features |
+| Gitea | API Token | Self-hosted repos, user admin, webhooks |
+
+### Development Tools
+
+| Service | Auth | Integration | Notes |
+|---------|------|-------------|-------|
+| Context7 | API Key | `@context7/mcp-server` | Real-time library docs, code examples, API references |
+| LocalWP | Local access | Custom MCP server | WordPress DB queries, site management, dev tools |
+| Pandoc | None (local) | `pandoc-helper.sh` | Multi-format → markdown conversion (Word, PDF, HTML, EPUB, LaTeX, 20+ formats) |
+| Agno AgentOS | LLM provider keys | `agno-setup.sh` | Multi-agent framework, production runtime, Agent-UI web interface |
+| Playwright/Selenium | Site credentials (local only) | Included in `agno-setup.sh` | Local browser automation — LinkedIn, web scraping, form filling. No cloud services. |
+
+## Setup
+
+```bash
+# Full setup
+bash setup.sh
+
+# Single service
+cp configs/[service]-config.json.txt configs/[service]-config.json
+# Edit with credentials, then:
+./.agents/scripts/[service]-helper.sh test-connection
+```
+
+## References
 
 - [MCP Integration Guide](MCP-INTEGRATIONS.md)
 - [Security Best Practices](.agents/aidevops/security.md)
 - [Configuration Templates](../configs/)
 - [Helper Scripts](../.agents/scripts/)
-- [API Testing Scripts](.agents/scripts/)


### PR DESCRIPTION
## Summary

- Converted 28 per-service prose blocks into compact tables (Infrastructure, DNS, Communication, Security/Quality, SEO, Git, Dev Tools)
- Removed boilerplate: generic intro paragraph, "API Integration Features" section (standardized auth/rate-limiting/security/monitoring prose), duplicate Getting Started content already in Quick Reference
- All unique technical content preserved: Twilio AUP compliance note + Telfon URL, Playwright local-only privacy note, Pandoc 20+ format list, Agno Agent-UI reference

## Stats

| Metric | Before | After |
|--------|--------|-------|
| Lines | 335 | 115 |
| Reduction | — | 66% |
| Services | 28 | 28 |

## Runtime Testing

- **Risk**: Low (docs-only change, no code)
- **Level**: self-assessed
- **Verification**: `rg` count confirms all 28 service names present; all code blocks, URLs, and unique notes preserved

Closes #11228