### PR TITLE
t11224: tighten speech-to-speech.md (336→202 lines)

### DIFF
--- a/.agents/tools/voice/speech-to-speech.md
+++ b/.agents/tools/voice/speech-to-speech.md
@@ -26,13 +26,13 @@ tools:
 - **Install dir**: `~/.aidevops/.agent-workspace/work/speech-to-speech/`
 - **Languages**: English, French, Spanish, Chinese, Japanese, Korean (auto-detect or fixed)
 
-**When to Use**: Read this when setting up voice interfaces, transcription pipelines, voice-driven DevOps, or phone-based AI assistants (pairs with Twilio).
+**When to Use**: Voice interfaces, transcription pipelines, voice-driven DevOps, phone-based AI assistants (pairs with Twilio).
 
 <!-- AI-CONTEXT-END -->
 
 ## Architecture
 
-Four-stage cascaded pipeline connected via thread-safe queues:
+Four-stage cascaded pipeline via thread-safe queues:
 
 ```text
 Microphone/Socket -> [VAD] -> [STT] -> [LLM] -> [TTS] -> Speaker/Socket
@@ -47,21 +47,17 @@ Microphone/Socket -> [VAD] -> [STT] -> [LLM] -> [TTS] -> Speaker/Socket
 
 Each stage runs in its own thread. Audio streams via socket (server/client) or local audio device.
 
-## Component Options
+## Components
 
-### VAD (Voice Activity Detection)
+### VAD — Silero VAD v5 (default, production-grade)
 
-| Implementation | Notes |
-|---------------|-------|
-| Silero VAD v5 | Default, production-grade |
+Key params: `--thresh` (sensitivity), `--min_speech_ms`, `--min_silence_ms`
 
-Key parameters: `--thresh` (trigger sensitivity), `--min_speech_ms`, `--min_silence_ms`
-
-### STT (Speech to Text)
+### STT
 
 | Implementation | Flag | Best For |
 |---------------|------|----------|
-| Whisper (Transformers) | `--stt whisper` | CUDA, general purpose |
+| Whisper (Transformers) | `--stt whisper` | CUDA, general |
 | Faster Whisper | `--stt faster-whisper` | CUDA, lower latency |
 | Lightning Whisper MLX | `--stt whisper-mlx` | macOS Apple Silicon |
 | MLX Audio Whisper | `--stt mlx-audio-whisper` | macOS, newer models |
@@ -69,9 +65,9 @@ Key parameters: `--thresh` (trigger sensitivity), `--min_speech_ms`, `--min_sile
 | Parakeet TDT | `--stt parakeet-tdt` | CUDA, NVIDIA NeMo |
 | Moonshine | `--stt moonshine` | Lightweight |
 
-Model selection: `--stt_model_name <model>` (any Whisper checkpoint on HF Hub)
+Model: `--stt_model_name <model>` (any Whisper checkpoint on HF Hub)
 
-### LLM (Language Model)
+### LLM
 
 | Implementation | Flag | Best For |
 |---------------|------|----------|
@@ -79,22 +75,15 @@ Model selection: `--stt_model_name <model>` (any Whisper checkpoint on HF Hub)
 | MLX-LM | `--llm mlx-lm` | macOS Apple Silicon |
 | OpenAI API | `--llm open_api` | Cloud, lowest latency |
 
-Model selection: `--lm_model_name <model>` or `--mlx_lm_model_name <model>`
+Model: `--lm_model_name <model>` or `--mlx_lm_model_name <model>`
 
-> **Security:** When using `--llm open_api`, store `OPENAI_API_KEY` with
-> `aidevops secret set OPENAI_API_KEY` (gopass encrypted, preferred). Use
-> `~/.config/aidevops/credentials.sh` only as a 600-permission plaintext fallback.
->
-> Never hardcode API keys in scripts or config files; if a key is committed or
-> shared in logs/transcripts, treat it as compromised and rotate it immediately.
->
-> See `tools/credentials/api-key-setup.md` for setup.
+> **Security:** Store `OPENAI_API_KEY` with `aidevops secret set OPENAI_API_KEY` (gopass preferred) or `~/.config/aidevops/credentials.sh` (600 perms). Never hardcode keys; treat any committed/logged key as compromised and rotate immediately. See `tools/credentials/api-key-setup.md`.
 
-### TTS (Text to Speech)
+### TTS
 
 | Implementation | Flag | Best For |
 |---------------|------|----------|
-| Parler-TTS | `--tts parler` | CUDA, streaming output |
+| Parler-TTS | `--tts parler` | CUDA, streaming |
 | MeloTTS | `--tts melo` | Multi-language (6 langs) |
 | ChatTTS | `--tts chatTTS` | Natural conversational |
 | Kokoro | `--tts kokoro` | macOS default, quality |
@@ -102,191 +91,75 @@ Model selection: `--lm_model_name <model>` or `--mlx_lm_model_name <model>`
 | Pocket TTS | `--tts pocket` | Lightweight |
 | Qwen3-TTS | `--tts qwen3-tts` | 10 langs, voice cloning, 97ms latency |
 
-## Deployment Modes
-
-### Local (macOS with Apple Silicon)
-
-Optimal for development and personal use. Uses MPS acceleration:
+## Deployment
 
 ```bash
-# One-liner with optimal Mac settings
+# macOS Apple Silicon (MPS)
 speech-to-speech-helper.sh start --local-mac
+# Equivalent: python s2s_pipeline.py --local_mac_optimal_settings --device mps \
+#   --stt parakeet-tdt --llm mlx-lm --tts kokoro \
+#   --mlx_lm_model_name mlx-community/Meta-Llama-3.1-8B-Instruct-4bit
 
-# Equivalent to:
-python s2s_pipeline.py \
-    --local_mac_optimal_settings \
-    --device mps \
-    --stt parakeet-tdt \
-    --llm mlx-lm \
-    --tts kokoro \
-    --mlx_lm_model_name mlx-community/Meta-Llama-3.1-8B-Instruct-4bit
-```
-
-### Local (CUDA GPU)
-
-For workstations with NVIDIA GPU:
-
-```bash
-# Start with torch compile optimizations
+# CUDA GPU (torch compile optimizations)
 speech-to-speech-helper.sh start --cuda
+# Equivalent: python s2s_pipeline.py --recv_host 0.0.0.0 --send_host 0.0.0.0 \
+#   --lm_model_name microsoft/Phi-3-mini-4k-instruct \
+#   --stt_compile_mode reduce-overhead --tts_compile_mode default
 
-# Equivalent to:
-python s2s_pipeline.py \
-    --recv_host 0.0.0.0 --send_host 0.0.0.0 \
-    --lm_model_name microsoft/Phi-3-mini-4k-instruct \
-    --stt_compile_mode reduce-overhead \
-    --tts_compile_mode default
-```
+# Server/client (remote GPU — RunPod, Vast.ai, Lambda, NVIDIA Cloud)
+speech-to-speech-helper.sh start --server          # on GPU server
+speech-to-speech-helper.sh client --host <ip>      # on local machine
+# Or: python listen_and_play.py --host <server-ip>
 
-### Server/Client (Remote GPU)
-
-For cloud GPU instances (NVIDIA Cloud, Vast.ai, RunPod, Lambda):
-
-```bash
-# On GPU server
-speech-to-speech-helper.sh start --server
-
-# On local machine (audio I/O)
-speech-to-speech-helper.sh client --host <server-ip>
-
-# Or directly:
-python listen_and_play.py --host <server-ip>
-```
-
-### Docker (CUDA)
-
-```bash
-# Start with docker compose
+# Docker (pytorch 2.4.0-cuda12.1-cudnn9-devel, ports 12345/12346, GPU device 0)
 speech-to-speech-helper.sh start --docker
-
-# Uses: pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel
-# Ports: 12345 (recv), 12346 (send)
-# GPU: nvidia device 0
 ```
+
+GPU sizing: 4GB VRAM minimum, 8–16GB recommended. See `tools/infrastructure/cloud-gpu.md` for provider comparison, SSH setup, model caching, cost optimization.
 
 ## Setup
 
 ```bash
-# Install via helper (clones repo, installs deps)
 speech-to-speech-helper.sh setup
-
 # Or manually:
-git clone https://github.com/huggingface/speech-to-speech.git
-cd speech-to-speech
-
-# CUDA/Linux
-uv pip install -r requirements.txt
-
-# macOS
-uv pip install -r requirements_mac.txt
-
-# For MeloTTS (optional)
-python -m unidic download
+git clone https://github.com/huggingface/speech-to-speech.git && cd speech-to-speech
+uv pip install -r requirements.txt          # CUDA/Linux
+uv pip install -r requirements_mac.txt      # macOS
+python -m unidic download                   # MeloTTS only
 ```
 
-### Requirements
-
-- Python 3.10+
-- PyTorch 2.4+ (CUDA and macOS)
-- `uv` package manager (recommended)
-- CUDA 12.1+ (for GPU) or Apple Silicon (for MPS)
-- `sounddevice` for local audio I/O
-- ~4GB VRAM minimum (varies by model selection)
+**Requirements:** Python 3.10+, PyTorch 2.4+, `uv`, CUDA 12.1+ or Apple Silicon, `sounddevice`, ~4GB VRAM minimum.
 
 ## Multi-Language
 
 ```bash
-# Auto-detect language per utterance
-speech-to-speech-helper.sh start --local-mac --language auto
-
-# Fixed language (e.g., Chinese)
-speech-to-speech-helper.sh start --local-mac --language zh
+speech-to-speech-helper.sh start --local-mac --language auto   # auto-detect per utterance
+speech-to-speech-helper.sh start --local-mac --language zh     # fixed language
 ```
 
-Requires compatible STT model (e.g., `--stt_model_name large-v3`) and multilingual TTS (MeloTTS or ChatTTS - Parler-TTS is English-only currently).
+Requires multilingual STT model (e.g., `--stt_model_name large-v3`) and multilingual TTS (MeloTTS or ChatTTS — Parler-TTS is English-only).
 
 ## CLI Parameters
 
-All parameters use prefix convention: `--stt_*`, `--lm_*`, `--tts_*`, `--melo_*`, etc.
+All params use prefix convention: `--stt_*`, `--lm_*`, `--tts_*`, `--melo_*`. Generation params use `_gen_` infix: `--stt_gen_max_new_tokens 128`.
 
-Generation parameters use `_gen_` infix: `--stt_gen_max_new_tokens 128`
-
-Full reference: `python s2s_pipeline.py -h` or see [arguments_classes/](https://github.com/huggingface/speech-to-speech/tree/main/arguments_classes)
-
-## Integration with aidevops
-
-### Voice-Driven DevOps (Conceptual)
-
-The pipeline can be paired with the LLM stage to create voice-controlled DevOps. This is an integration pattern, not a built-in command:
-
-1. STT captures voice command
-2. LLM interprets as DevOps action (via system prompt)
-3. TTS confirms action and reports result
-
-For a ready-to-use voice interface, see the Voice Bridge section below.
-
-### Transcription
-
-For standalone transcription (meeting notes, podcasts), use Whisper directly instead of the full S2S pipeline. See `tools/voice/transcription.md` for model options and cloud APIs.
-
-To use the S2S pipeline for transcription, run with `--llm open_api` and a system prompt that outputs transcription only, or use the STT components directly via Python.
-
-### Phone Integration (Twilio)
-
-Combine with `services/communications/twilio.md` for phone-based AI:
-
-1. Twilio receives call, streams audio via WebSocket
-2. S2S pipeline processes speech in real-time
-3. TTS response streamed back to caller
-
-### Video Narration
-
-Pair with `tools/video/remotion.md` for generated voiceover:
-
-1. Generate script with LLM
-2. TTS produces audio track
-3. Remotion composites with video
-
-## Cloud GPU Providers
-
-For server/client deployment when local GPU is insufficient, see the shared **[Cloud GPU Deployment Guide](../infrastructure/cloud-gpu.md)** for:
-
-- Provider comparison (RunPod, Vast.ai, Lambda, NVIDIA Cloud)
-- GPU selection by VRAM requirements
-- SSH setup, Docker deployment, model caching
-- Cost optimization strategies
-
-Quick reference for voice pipeline GPU needs: 4GB VRAM minimum (low-VRAM config), 8-16GB recommended (full S2S pipeline). See the guide's VRAM requirements table for details.
+Full reference: `python s2s_pipeline.py -h` or [arguments_classes/](https://github.com/huggingface/speech-to-speech/tree/main/arguments_classes)
 
 ## Recommended Configurations
 
-### Low Latency (CUDA)
+| Use Case | Flags |
+|----------|-------|
+| Low latency (CUDA) | `--stt faster-whisper --llm open_api --tts parler --stt_compile_mode reduce-overhead --tts_compile_mode default` |
+| Low VRAM (~4GB) | `--stt moonshine --llm open_api --tts pocket` |
+| Best quality (CUDA 24GB+) | `--stt whisper --stt_model_name openai/whisper-large-v3 --llm transformers --lm_model_name microsoft/Phi-3-mini-4k-instruct --tts parler` |
+| macOS optimal | `--local_mac_optimal_settings --device mps --mlx_lm_model_name mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` |
 
-```bash
---stt faster-whisper --llm open_api --tts parler \
---stt_compile_mode reduce-overhead --tts_compile_mode default
-```
+## Integrations
 
-### Low VRAM (~4GB)
-
-```bash
---stt moonshine --llm open_api --tts pocket
-```
-
-### Best Quality (CUDA, 24GB+)
-
-```bash
---stt whisper --stt_model_name openai/whisper-large-v3 \
---llm transformers --lm_model_name microsoft/Phi-3-mini-4k-instruct \
---tts parler
-```
-
-### macOS Optimal
-
-```bash
---local_mac_optimal_settings --device mps \
---mlx_lm_model_name mlx-community/Meta-Llama-3.1-8B-Instruct-4bit
-```
+- **Transcription**: Use Whisper directly for standalone transcription. See `tools/voice/transcription.md`. For S2S-based transcription, use `--llm open_api` with a transcription-only system prompt.
+- **Phone (Twilio)**: Twilio streams audio via WebSocket → S2S processes in real-time → TTS response streamed back. See `services/communications/twilio.md`.
+- **Video narration**: LLM generates script → TTS produces audio → Remotion composites. See `tools/video/remotion.md`.
+- **Voice-driven DevOps**: STT captures command → LLM interprets via system prompt → TTS confirms. Integration pattern, not a built-in command.
 
 ## Troubleshooting
 
@@ -298,39 +171,32 @@ Quick reference for voice pipeline GPU needs: 4GB VRAM minimum (low-VRAM config)
 | Audio crackling | Increase `--min_silence_ms` or check sample rate |
 | OOM on GPU | Use smaller models or `--llm open_api` to offload LLM |
 
-## Voice Bridge (Recommended)
+## Voice Bridge (Recommended for Agent Use)
 
-For talking directly to your AI coding agent, use the **voice bridge** instead of the full S2S pipeline. It's simpler, faster to start, and integrates with OpenCode:
+For talking directly to your AI coding agent, use the voice bridge — simpler, faster, integrates with OpenCode:
 
 ```bash
-voice-helper.sh talk              # Start voice conversation (defaults)
-voice-helper.sh talk whisper-mlx edge-tts  # Explicit engines
-voice-helper.sh talk whisper-mlx macos-say # Offline mode
-voice-helper.sh devices           # List audio devices
-voice-helper.sh voices            # List available TTS voices
-voice-helper.sh benchmark         # Test component speeds
+voice-helper.sh talk                              # start voice conversation
+voice-helper.sh talk whisper-mlx edge-tts         # explicit engines
+voice-helper.sh talk whisper-mlx macos-say        # offline mode
+voice-helper.sh devices | voices | benchmark
 ```
 
 **Architecture:** `Mic -> Silero VAD -> Whisper MLX (1.4s) -> OpenCode run --attach (~4-6s) -> Edge TTS (0.4s) -> Speaker`
 
-**Round-trip:** ~6-8s conversational, longer for tool execution.
+**Round-trip:** ~6–8s conversational, longer for tool execution.
 
-**Features:**
-- Swappable STT (whisper-mlx, faster-whisper) and TTS (edge-tts, macos-say, facebookMMS)
-- Voice exit phrases ("that's all", "goodbye", "all for now")
-- STT sanity checking (corrects transcription errors before acting)
-- Session handback (transcript output on exit for calling agent)
-- Esc key interrupt in terminal, graceful degradation in TUI subprocess
+**Features:** Swappable STT/TTS engines; voice exit phrases ("that's all", "goodbye"); STT sanity checking; session handback (transcript on exit); Esc interrupt; graceful TUI degradation.
 
-The full S2S pipeline above is for advanced use cases (custom LLMs, server/client deployment, multi-language, phone integration).
+The full S2S pipeline is for advanced use cases: custom LLMs, server/client deployment, multi-language, phone integration.
 
 ## See Also
 
-- `tools/voice/cloud-voice-agents.md` - Cloud voice agents (GPT-4o Realtime, MiniCPM-o, NVIDIA Nemotron Speech)
-- `tools/voice/voice-ai-models.md` - Complete model comparison (TTS, STT, S2S)
-- `tools/voice/pipecat-opencode.md` - Pipecat real-time voice pipeline
-- `tools/voice/qwen3-tts.md` - Qwen3-TTS setup and usage (voice cloning, voice design, multi-language)
-- `tools/infrastructure/cloud-gpu.md` - Cloud GPU deployment guide (provider comparison, setup, cost optimization)
-- `services/communications/twilio.md` - Phone integration
-- `tools/video/remotion.md` - Video narration
-- `content/heygen-skill/rules-voices.md` - AI voice cloning
+- `tools/voice/cloud-voice-agents.md` — Cloud voice agents (GPT-4o Realtime, MiniCPM-o, NVIDIA Nemotron Speech)
+- `tools/voice/voice-ai-models.md` — Complete model comparison (TTS, STT, S2S)
+- `tools/voice/pipecat-opencode.md` — Pipecat real-time voice pipeline
+- `tools/voice/qwen3-tts.md` — Qwen3-TTS setup, voice cloning, multi-language
+- `tools/infrastructure/cloud-gpu.md` — Cloud GPU deployment (provider comparison, setup, cost optimization)
+- `services/communications/twilio.md` — Phone integration
+- `tools/video/remotion.md` — Video narration
+- `content/heygen-skill/rules-voices.md` — AI voice cloning


### PR DESCRIPTION
## Summary

- Reduces `.agents/tools/voice/speech-to-speech.md` from 336 to 202 lines (40% reduction)
- Consolidates 4 separate deployment mode sections into a single `## Deployment` block with inline comments for equivalents
- Merges 4 integration subsections (Voice-Driven DevOps, Transcription, Phone, Video) into a compact bullet list
- Collapses 4 recommended config code blocks into a single table
- Compresses setup requirements bullet list into a single inline sentence
- Removes redundant prose throughout (section intros, repeated context)
- All flags, models, commands, URLs, and technical content preserved (verified: 30 grep matches)

Closes #11224