### PR TITLE
t11152: tighten browser-benchmark-scripts.md (shell quality + prose trim)

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts.md
+++ b/.agents/tools/browser/browser-benchmark-scripts.md
@@ -124,6 +124,7 @@ bench_navigate() {
   end=$(python3 -c 'import time; print(time.time())')
   python3 -c "print(f'{$end - $start:.2f}')"
   agent-browser close
+  return 0
 }
 
 bench_formFill() {
@@ -138,6 +139,7 @@ bench_formFill() {
   end=$(python3 -c 'import time; print(time.time())')
   python3 -c "print(f'{$end - $start:.2f}')"
   agent-browser close
+  return 0
 }
 
 bench_extract() {
@@ -148,6 +150,7 @@ bench_extract() {
   end=$(python3 -c 'import time; print(time.time())')
   python3 -c "print(f'{$end - $start:.2f}')"
   agent-browser close
+  return 0
 }
 
 bench_multiStep() {
@@ -160,6 +163,7 @@ bench_multiStep() {
   end=$(python3 -c 'import time; print(time.time())')
   python3 -c "print(f'{$end - $start:.2f}')"
   agent-browser close
+  return 0
 }
 
 echo "=== agent-browser Benchmark ==="
@@ -403,6 +407,6 @@ async function benchVisual() {
 benchVisual();
 ```
 
-**Visual verification workflow**: Navigate → viewport screenshot (no `fullPage: true`) → ARIA snapshot → AI analyses both → decide next action.
+**Workflow**: Navigate → viewport screenshot (no `fullPage: true`) → ARIA snapshot → AI analyses both → decide next action.
 
 **Key metrics**: screenshot file size (token cost), ARIA node count, time to screenshot-ready, whether ARIA alone suffices vs needing vision.


### PR DESCRIPTION
## Summary

- Added explicit `return 0` to all 4 shell functions in the agent-browser benchmark (required by shell quality rules — SonarCloud S7682)
- Trimmed redundant label: "Visual verification workflow" → "Workflow"

## Assessment

This file is a reference corpus of runnable benchmark scripts. The code blocks are the content — they cannot be compressed without losing functionality. The prose was already minimal (3-line intro, 2-line footer). The automated scan flagged it at "medium confidence" which was appropriate — the file is already well-structured.

Net change: +4 lines (quality improvements outweigh the 1-line prose trim). The shell `return 0` additions are the substantive improvement.

Closes #11152