### PR TITLE
fix(dispatch): prevent double-worker dispatch when owner is also a runner (GH#11141)

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -67,15 +67,14 @@ Check external contributor gate before ANY approve/merge (see Pre-merge checks b
 For each unassigned, non-blocked issue with no open PR, no active worker, and **no `needs-maintainer-review` label**:
 
 ```bash
-# Dedup guard (MANDATORY — all 6 layers run deterministically inside check_dispatch_dedup)
+# Dedup guard (MANDATORY — all 7 layers run deterministically inside check_dispatch_dedup)
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
 
-# All dedup layers including cross-machine claim lock (GH#11086) are inside
-# check_dispatch_dedup. Layer 6 posts an HTML comment claim, sleeps the
-# consensus window, and checks who was first. Do NOT add a separate claim
-# step — it's already deterministic. Passing $RUNNER_USER as the 5th arg
-# is required for the assignee guard (Layer 5) and claim lock (Layer 6).
+# All dedup layers including dispatch comment check (GH#11141), assignee guard,
+# and cross-machine claim lock are inside check_dispatch_dedup. Passing
+# $RUNNER_USER as the 5th arg is required for the assignee guard (Layer 6),
+# dispatch comment check (Layer 5), and claim lock (Layer 7).
 if check_dispatch_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER_USER"; then continue; fi
 
 # Assign and dispatch
@@ -741,7 +740,7 @@ fi
 release_dispatch_claim <number> <slug> "$RUNNER_USER"
 ```
 
-`check_dispatch_dedup` runs all six checks in sequence: (1) in-flight dispatch ledger, (2) exact repo+issue process overlap, (3) title variants via dispatch-dedup-helper (e.g., `issue-3502` vs `Issue #3502: description`), (4) merged-PR evidence via close keywords and task-ID fallback, (5) cross-machine assignee guard (GH#6891) — prevents dispatching for issues already assigned to another runner, and (6) cross-machine optimistic claim lock (GH#11086) — posts an HTML comment claim, sleeps the consensus window, and checks who was first. Only the oldest claimant proceeds; others back off. This was previously an LLM-instructed step that runners could skip — the GH#11086 incident showed two runners dispatching on the same issue 45 seconds apart.
+`check_dispatch_dedup` runs all seven checks in sequence: (1) in-flight dispatch ledger, (2) exact repo+issue process overlap, (3) title variants via dispatch-dedup-helper (e.g., `issue-3502` vs `Issue #3502: description`), (4) merged-PR evidence via close keywords and task-ID fallback, (5) cross-machine dispatch comment check (GH#11141) — detects "Dispatching worker" comments posted by other runners, the persistent cross-machine signal that survives beyond the claim lock's 8-second window, (6) cross-machine assignee guard — blocks if assigned to any login other than self (GH#11141 fix: repo owner/maintainer are no longer excluded since they may also be runners), and (7) cross-machine optimistic claim lock (GH#11086) — posts an HTML comment claim, sleeps the consensus window, and checks who was first. Only the oldest claimant proceeds; others back off.
 
 The deterministic guard is the safety net, not the primary layer. Over time, as the intelligence scan catches more duplicates earlier, the deterministic guard should fire less often. See "Dedup health monitoring" below for how to track this.
 

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -394,19 +394,21 @@ _get_repo_maintainer() {
 # they miss workers running on other machines. The GitHub assignee is
 # the single source of truth visible to all runners.
 #
-# GH#10521: Distinguishes maintainer/owner assignment from runner
-# assignment. Issues assigned to the repo maintainer (from repos.json)
-# or the repo owner (from slug) are NOT blocked — only issues assigned
-# to other known runner accounts trigger the dedup guard.
+# GH#11141: Only self_login is excluded from the dedup check. The repo
+# owner and maintainer are NOT excluded — they may also be runners, and
+# excluding them caused double-dispatch when the owner's pulse assigned
+# an issue and another runner's pulse ignored the assignment (the
+# GH#10521 exclusion). The pulse already handles owner-assigned-but-
+# not-dispatched issues via status labels and staleness checks.
 #
 # Args:
 #   $1 = issue number
 #   $2 = repo slug (owner/repo)
 #   $3 = (optional) current runner login — if assigned to self, not a dup
 # Returns:
-#   exit 0 if assigned to another runner (do NOT dispatch)
-#   exit 1 if unassigned, assigned to self, or assigned to maintainer/owner (safe to dispatch)
-# Outputs: assignee info on stdout if assigned to another runner
+#   exit 0 if assigned to another login (do NOT dispatch)
+#   exit 1 if unassigned or assigned only to self (safe to dispatch)
+# Outputs: assignee info on stdout if assigned to another login
 #######################################
 is_assigned() {
 	local issue_number="$1"
@@ -433,62 +435,33 @@ is_assigned() {
 		return 1
 	fi
 
-	# Build the set of non-runner logins to exclude from the dedup check:
-	# 1. Current runner (self_login)
-	# 2. Repo maintainer from repos.json
-	# 3. Repo owner from slug (owner/repo → owner)
-	local -a non_runner_logins=()
-	if [[ -n "$self_login" ]]; then
-		non_runner_logins+=("$self_login")
-	fi
-
-	# Repo owner from slug (the part before /)
-	local repo_owner=""
-	repo_owner="${repo_slug%%/*}"
-	if [[ -n "$repo_owner" ]]; then
-		non_runner_logins+=("$repo_owner")
-	fi
-
-	# Repo maintainer from repos.json
-	local repo_maintainer=""
-	repo_maintainer=$(_get_repo_maintainer "$repo_slug")
-	if [[ -n "$repo_maintainer" ]]; then
-		non_runner_logins+=("$repo_maintainer")
-	fi
-
-	# Check if ALL assignees are non-runner logins (self, maintainer, or owner)
-	local has_runner_assignee=false
-	local runner_assignees=""
+	# Only exclude self_login. Any other assignee — including repo owner
+	# and maintainer — means the issue is claimed. This prevents double-
+	# dispatch when the owner is also a runner (GH#11141).
 	local -a assignee_array=()
 	local saved_ifs="${IFS:-}"
 	IFS=',' read -ra assignee_array <<<"$assignees"
 	IFS="$saved_ifs"
+
+	local other_assignees=""
 	local assignee
 	for assignee in "${assignee_array[@]}"; do
-		local is_non_runner=false
-		local non_runner
-		for non_runner in "${non_runner_logins[@]}"; do
-			if [[ "$assignee" == "$non_runner" ]]; then
-				is_non_runner=true
-				break
-			fi
-		done
-		if [[ "$is_non_runner" == "false" ]]; then
-			has_runner_assignee=true
-			if [[ -n "$runner_assignees" ]]; then
-				runner_assignees="${runner_assignees},${assignee}"
-			else
-				runner_assignees="$assignee"
-			fi
+		if [[ -n "$self_login" && "$assignee" == "$self_login" ]]; then
+			continue
+		fi
+		if [[ -n "$other_assignees" ]]; then
+			other_assignees="${other_assignees},${assignee}"
+		else
+			other_assignees="$assignee"
 		fi
 	done
 
-	if [[ "$has_runner_assignee" == "false" ]]; then
-		# All assignees are self, maintainer, or repo owner — safe to dispatch
+	if [[ -z "$other_assignees" ]]; then
+		# Only assignee is self (or no assignees) — safe to dispatch
 		return 1
 	fi
 
-	printf 'ASSIGNED: issue #%s in %s is assigned to runner(s) %s\n' "$issue_number" "$repo_slug" "$runner_assignees"
+	printf 'ASSIGNED: issue #%s in %s is assigned to %s\n' "$issue_number" "$repo_slug" "$other_assignees"
 	return 0
 }
 
@@ -558,6 +531,87 @@ has_open_pr() {
 }
 
 #######################################
+# Check whether an issue has a recent "Dispatching worker" comment
+# from another runner (GH#11141).
+#
+# The pulse agent posts a "Dispatching worker." comment on every issue
+# it dispatches. This is a persistent, cross-machine signal that a
+# worker is in-flight — unlike the dispatch ledger (local-only) or
+# the claim lock (8-second window). Checking for this comment catches
+# the gap between dispatch and PR creation across machines.
+#
+# A comment is considered active if it was posted within the last
+# DISPATCH_COMMENT_MAX_AGE seconds (default 4 hours — generous to
+# cover long-running workers). Only comments from other logins are
+# considered; self-posted comments are ignored.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug (owner/repo)
+#   $3 = self login (optional; comments from self are ignored)
+# Returns:
+#   exit 0 if a recent dispatch comment from another runner exists (do NOT dispatch)
+#   exit 1 if no recent dispatch comment (safe to dispatch)
+# Outputs:
+#   single-line reason when evidence is found
+#######################################
+has_dispatch_comment() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="${3:-}"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	local max_age="${DISPATCH_COMMENT_MAX_AGE:-14400}" # 4 hours
+
+	local now_epoch
+	now_epoch=$(date -u '+%s')
+
+	# Fetch recent comments and look for "Dispatching worker" from non-self authors
+	local comments_json
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--jq '[.[] | select(.body | startswith("Dispatching worker")) | {author: .user.login, created_at: .created_at}]' \
+		2>/dev/null) || comments_json="[]"
+
+	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
+		return 1
+	fi
+
+	# Check each dispatch comment
+	local count
+	count=$(printf '%s' "$comments_json" | jq 'length' 2>/dev/null) || count=0
+
+	local i
+	for i in $(seq 0 $((count - 1))); do
+		local author created_at
+		author=$(printf '%s' "$comments_json" | jq -r ".[$i].author // \"\"" 2>/dev/null) || author=""
+		created_at=$(printf '%s' "$comments_json" | jq -r ".[$i].created_at // \"\"" 2>/dev/null) || created_at=""
+
+		# Skip self-posted comments
+		if [[ -n "$self_login" && "$author" == "$self_login" ]]; then
+			continue
+		fi
+
+		# Check age
+		if [[ -n "$created_at" ]]; then
+			local comment_epoch
+			comment_epoch=$(date -u -d "$created_at" '+%s' 2>/dev/null ||
+				TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$created_at" '+%s' 2>/dev/null ||
+				printf '%s' "0")
+			local age=$((now_epoch - comment_epoch))
+			if [[ "$age" -lt "$max_age" ]]; then
+				printf 'dispatch comment by %s posted %ds ago on issue #%s\n' "$author" "$age" "$issue_number"
+				return 0
+			fi
+		fi
+	done
+
+	return 1
+}
+
+#######################################
 # Show help
 #######################################
 show_help() {
@@ -569,9 +623,10 @@ Usage:
   dispatch-dedup-helper.sh is-duplicate <title>     Check if already running (exit 0=dup, 1=safe)
   dispatch-dedup-helper.sh has-open-pr <issue> <slug> [issue-title]
                                                     Check merged PR evidence (exit 0=evidence, 1=none)
+  dispatch-dedup-helper.sh has-dispatch-comment <issue> <slug> [self-login]
+                                                     Check for recent "Dispatching worker" comment (exit 0=found, 1=none)
   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
-                                                      Check if assigned to another runner (exit 0=blocked, 1=free)
-                                                      Ignores repo owner (from slug) and maintainer (from repos.json)
+                                                       Check if assigned to another login (exit 0=blocked, 1=free)
   dispatch-dedup-helper.sh claim <issue> <slug> [runner-login]
                                                      Cross-machine claim lock (exit 0=won, 1=lost, 2=error)
   dispatch-dedup-helper.sh release <issue> <slug> [runner-login]
@@ -593,12 +648,19 @@ Examples:
     echo "Safe to dispatch"
   fi
 
-  # Check before dispatching (cross-machine assignee dedup — GH#10521)
-  # Only blocks for runner accounts, not repo owner/maintainer
+  # Check before dispatching (cross-machine assignee dedup — GH#11141)
+  # Blocks if assigned to any login other than self
   if dispatch-dedup-helper.sh is-assigned 2300 owner/repo mylogin; then
-    echo "Assigned to another runner — skip dispatch"
+    echo "Assigned to another login — skip dispatch"
   else
-    echo "Unassigned, assigned to self, or assigned to owner/maintainer — safe"
+    echo "Unassigned or assigned to self — safe"
+  fi
+
+  # Check before dispatching (dispatch comment dedup — GH#11141)
+  if dispatch-dedup-helper.sh has-dispatch-comment 2300 owner/repo mylogin; then
+    echo "Another runner already dispatched — skip"
+  else
+    echo "No recent dispatch comment — safe"
   fi
 
   # Check before dispatching (merged PR dedup)
@@ -648,6 +710,13 @@ main() {
 			return 1
 		}
 		is_assigned "$1" "$2" "${3:-}"
+		;;
+	has-dispatch-comment)
+		[[ $# -lt 2 ]] && {
+			echo "Error: has-dispatch-comment requires <issue-number> <repo-slug> [self-login]" >&2
+			return 1
+		}
+		has_dispatch_comment "$1" "$2" "${3:-}"
 		;;
 	has-open-pr)
 		[[ $# -lt 2 ]] && {

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3863,20 +3863,35 @@ check_dispatch_dedup() {
 		fi
 	fi
 
-	# Layer 5 (GH#6891): cross-machine assignee guard — prevents runners from
-	# dispatching workers for issues already assigned to another runner. This was
-	# previously an LLM-only instruction in pulse.md; moving it here makes it
-	# deterministic. The incident: johnwaldo's pulse dispatched a worker for an
-	# issue assigned to marcusquinn because the LLM skipped the is_assigned step.
+	# Layer 5 (GH#11141): cross-machine dispatch comment check — detects
+	# "Dispatching worker" comments posted by other runners. This is the
+	# persistent cross-machine signal that survives beyond the claim lock's
+	# 8-second window. The GH#11141 incident: marcusquinn dispatched at
+	# 02:36, johnwaldo dispatched at 03:18 (42 min later). The claim lock
+	# had long expired, the ledger is local-only, and the assignee guard
+	# excluded the repo owner. But the "Dispatching worker" comment was
+	# sitting right there on the issue — visible to all runners.
 	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
-		local assigned_output=""
-		if assigned_output=$("$dedup_helper" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE"); then
-			echo "[pulse-wrapper] Dedup: #${issue_number} in ${repo_slug} already assigned to another runner — ${assigned_output}" >>"$LOGFILE"
+		local dispatch_comment_output=""
+		if dispatch_comment_output=$("$dedup_helper" has-dispatch-comment "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE"); then
+			echo "[pulse-wrapper] Dedup: #${issue_number} in ${repo_slug} has active dispatch comment — ${dispatch_comment_output}" >>"$LOGFILE"
 			return 0
 		fi
 	fi
 
-	# Layer 6 (GH#11086): cross-machine optimistic claim lock — the final safety
+	# Layer 6 (GH#6891): cross-machine assignee guard — prevents runners from
+	# dispatching workers for issues already assigned to another login. Only
+	# self_login is excluded; repo owner and maintainer are NOT excluded since
+	# they may also be runners (GH#11141 fix — reverts the GH#10521 exclusion).
+	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+		local assigned_output=""
+		if assigned_output=$("$dedup_helper" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE"); then
+			echo "[pulse-wrapper] Dedup: #${issue_number} in ${repo_slug} already assigned — ${assigned_output}" >>"$LOGFILE"
+			return 0
+		fi
+	fi
+
+	# Layer 7 (GH#11086): cross-machine optimistic claim lock — the final safety
 	# net for multi-runner environments. Posts an HTML comment claim on the issue,
 	# sleeps the consensus window (default 8s), then checks if this runner's claim
 	# is the oldest. Only the first claimant proceeds; others back off.


### PR DESCRIPTION
## Summary

Fixes the double-worker dispatch bug where two runners dispatched workers for the same issue 42 minutes apart (GH#11141). Root cause: the assignee dedup guard excluded the repo owner, and no layer checked for existing "Dispatching worker" comments.

Closes #11141

## Changes

### 1. `dispatch-dedup-helper.sh` — `is_assigned()` fix
- **Removed** repo owner and maintainer exclusion from the assignee dedup check (reverts GH#10521)
- **Only** `self_login` is excluded now — any other assignee blocks dispatch
- The owner IS a runner; excluding them let other runners ignore the assignment

### 2. `dispatch-dedup-helper.sh` — New `has_dispatch_comment()`
- Checks for recent "Dispatching worker" comments from other runners (4-hour window)
- Persistent cross-machine signal that survives beyond the claim lock's 8-second window
- Covers the gap between dispatch and PR creation across machines

### 3. `pulse-wrapper.sh` — New Layer 5 in `check_dispatch_dedup`
- Wired `has_dispatch_comment` as Layer 5 (before assignee guard)
- Renumbered: assignee → Layer 6, claim lock → Layer 7
- Updated Layer 6 comment to reflect GH#11141 fix

### 4. `pulse.md` — Documentation
- Updated layer count (6→7) and descriptions

## Why each dedup layer failed in GH#11141

| Layer | Check | Why it missed |
|---|---|---|
| 1. Ledger | Local JSONL | Local-only — invisible to other machines |
| 2. Process | Local `ps` | Can't see remote processes |
| 3. Title | Local `pgrep` | Same |
| 4. Merged PR | `gh pr list` | No PR existed yet (42-min gap) |
| 5. Assignee | `gh issue view` | **BUG**: Excluded repo owner (GH#10521) |
| 6. Claim lock | HTML comment | 8s window expired; claim released after dispatch |

## Testing Evidence

- Risk: Medium (dispatch infrastructure, no user-facing code)
- Level: self-assessed
- Existing tests pass: `test-dispatch-dedup-helper-has-open-pr.sh` (3/3), `test-dispatch-claim-helper.sh` (12/12)
- ShellCheck: clean on all modified files
- New `has_dispatch_comment` function is testable offline with a mock `gh` stub

## Files Changed

- `.agents/scripts/dispatch-dedup-helper.sh` — `is_assigned()` simplified, `has_dispatch_comment()` added
- `.agents/scripts/pulse-wrapper.sh` — Layer 5 added to `check_dispatch_dedup`
- `.agents/scripts/commands/pulse.md` — Layer count and descriptions updated