### PR TITLE
t11362: simplify ES2018 & ES2019 reference doc (372→240 lines)

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/es2018-es2019.md
+++ b/.agents/tools/programming/modern-javascript-skill/es2018-es2019.md
@@ -15,8 +15,7 @@ const settings = { ...defaults, ...userPrefs };
 
 // Object rest (destructuring)
 const { name, ...rest } = { name: 'Alice', age: 30, city: 'NYC' };
-// name = 'Alice'
-// rest = { age: 30, city: 'NYC' }
+// name = 'Alice', rest = { age: 30, city: 'NYC' }
 
 // Function parameters
 function update({ id, ...changes }) {
@@ -43,20 +42,6 @@ async function* fetchPages(url) {
 for await (const page of fetchPages('/api/items')) {
   processPage(page);
 }
-
-// Async iterables
-const asyncIterable = {
-  [Symbol.asyncIterator]() {
-    let i = 0;
-    return {
-      async next() {
-        if (i >= 3) return { done: true };
-        await delay(100);
-        return { value: i++, done: false };
-      }
-    };
-  }
-};
 ```
 
 ### Promise.prototype.finally()
@@ -70,38 +55,15 @@ fetch('/api/data')
   .then(res => res.json())
   .then(data => process(data))
   .catch(err => showError(err))
-  .finally(() => {
-    hideSpinner();  // Always runs
-  });
-
-// With async/await
-async function fetchData() {
-  showSpinner();
-  try {
-    const res = await fetch('/api/data');
-    return await res.json();
-  } catch (err) {
-    showError(err);
-  } finally {
-    hideSpinner();  // Always runs
-  }
-}
+  .finally(() => hideSpinner());  // Always runs
 ```
 
 ### RegExp Named Capture Groups
 
 ```javascript
-// ❌ Before: numbered groups
-const dateRegex = /(\d{4})-(\d{2})-(\d{2})/;
-const match = '2024-03-15'.match(dateRegex);
-const year = match[1];   // Which is which?
-const month = match[2];
-const day = match[3];
-
-// ✅ Named groups
+// Named groups — self-documenting
 const dateRegex = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/;
-const match = '2024-03-15'.match(dateRegex);
-const { year, month, day } = match.groups;
+const { year, month, day } = '2024-03-15'.match(dateRegex).groups;
 // year = '2024', month = '03', day = '15'
 
 // In replace()
@@ -124,9 +86,7 @@ const priceRegex = /(?<=\$)\d+(\.\d{2})?/;
 '€19.99'.match(priceRegex);  // null
 
 // Negative lookbehind: match if NOT preceded by pattern
-const notEuroRegex = /(?<!€)\d+(\.\d{2})?/;
-'€19.99'.match(notEuroRegex);  // null
-'$19.99'.match(notEuroRegex);  // ['19.99']
+/(?<!€)\d+(\.\d{2})?/.test('€19.99');  // false
 ```
 
 ### RegExp dotAll Flag (s)
@@ -134,14 +94,8 @@ const notEuroRegex = /(?<!€)\d+(\.\d{2})?/;
 Make `.` match newlines too.
 
 ```javascript
-// ❌ Before: dot doesn't match newlines
-/foo.bar/.test('foo\nbar');  // false
-
-// ✅ With s flag
+/foo.bar/.test('foo\nbar');   // false
 /foo.bar/s.test('foo\nbar');  // true
-
-// Check flag
-/foo.bar/s.dotAll;  // true
 ```
 
 ### RegExp Unicode Property Escapes
@@ -149,36 +103,11 @@ Make `.` match newlines too.
 Match characters by Unicode property.
 
 ```javascript
-// Match Greek letters
-/\p{Script=Greek}/u.test('π');  // true
-/\p{Script=Greek}/u.test('p');  // false
-
-// Match any letter
-/\p{Letter}/u.test('Ω');  // true
-/\p{Letter}/u.test('5');  // false
-
-// Match emoji
-/\p{Emoji}/u.test('😀');  // true
-
-// General category properties
-/\p{Lowercase}/u;           // Lowercase letters
-/\p{Uppercase}/u;           // Uppercase letters
-/\p{Alphabetic}/u;          // Alphabetic characters
-/\p{Number}/u;              // Any number (Nd, Nl, No)
-/\p{Decimal_Number}/u;      // Decimal digits (0-9 in any script)
-/\p{Punctuation}/u;         // Punctuation marks
-/\p{White_Space}/u;         // Whitespace characters
-/\p{Math}/u;                // Mathematical symbols
-
-// Script properties
-/\p{Script=Latin}/u;        // Latin script
-/\p{Script=Greek}/u;        // Greek script
-/\p{Script=Cyrillic}/u;     // Cyrillic script
-/\p{Script=Han}/u;          // Chinese characters
-/\p{Script=Hiragana}/u;     // Japanese Hiragana
-/\p{Script=Katakana}/u;     // Japanese Katakana
-/\p{Script=Arabic}/u;       // Arabic script
-/\p{Script=Hebrew}/u;       // Hebrew script
+/\p{Script=Greek}/u.test('π');   // true
+/\p{Letter}/u.test('Ω');         // true
+/\p{Emoji}/u.test('😀');          // true
+/\p{Decimal_Number}/u;            // digits 0-9 in any script
+/\p{Script=Han}/u;                // Chinese characters
 ```
 
 ### Template Literal Revision
@@ -186,18 +115,11 @@ Match characters by Unicode property.
 Allow invalid escape sequences in tagged templates.
 
 ```javascript
-// Before ES2018, this would throw SyntaxError
-function latex(strings) {
-  return strings.raw[0];
-}
-latex`\unicode`;  // Now works, returns '\\unicode'
-
-// Cooked value is undefined for invalid escapes
 function tag(strings) {
-  console.log(strings[0]);      // undefined
+  console.log(strings[0]);      // undefined (invalid escape → cooked is undefined)
   console.log(strings.raw[0]);  // '\\unicode'
 }
-tag`\unicode`;
+tag`\unicode`;  // No longer throws SyntaxError
 ```
 
 ---
@@ -209,38 +131,27 @@ tag`\unicode`;
 Flatten nested arrays.
 
 ```javascript
-// Default: flatten one level
-[1, [2, [3, [4]]]].flat();     // [1, 2, [3, [4]]]
-
-// Specify depth
-[1, [2, [3, [4]]]].flat(2);    // [1, 2, 3, [4]]
-
-// Flatten completely
-[1, [2, [3, [4]]]].flat(Infinity);  // [1, 2, 3, 4]
-
-// Removes holes
-[1, , 3, , 5].flat();  // [1, 3, 5]
+[1, [2, [3, [4]]]].flat();           // [1, 2, [3, [4]]]  (default: 1 level)
+[1, [2, [3, [4]]]].flat(2);          // [1, 2, 3, [4]]
+[1, [2, [3, [4]]]].flat(Infinity);   // [1, 2, 3, 4]
+[1, , 3, , 5].flat();                // [1, 3, 5]  (removes holes)
 ```
 
 ### Array.prototype.flatMap()
 
-Map then flatten (one level).
+Map then flatten one level.
 
 ```javascript
-// Equivalent to .map().flat()
 const sentences = ['Hello world', 'How are you'];
 
-// ❌ map returns nested arrays
 sentences.map(s => s.split(' '));
 // [['Hello', 'world'], ['How', 'are', 'you']]
 
-// ✅ flatMap flattens
 sentences.flatMap(s => s.split(' '));
 // ['Hello', 'world', 'How', 'are', 'you']
 
-// Can also filter by returning empty array
-const nums = [1, 2, 3, 4];
-nums.flatMap(n => n % 2 ? [n] : []);  // [1, 3]
+// Filter by returning empty array
+[1, 2, 3, 4].flatMap(n => n % 2 ? [n] : []);  // [1, 3]
 ```
 
 ### Object.fromEntries()
@@ -249,44 +160,28 @@ Create object from key-value pairs (inverse of Object.entries).
 
 ```javascript
 // From entries array
-Object.fromEntries([['a', 1], ['b', 2]]);
-// { a: 1, b: 2 }
+Object.fromEntries([['a', 1], ['b', 2]]);  // { a: 1, b: 2 }
 
 // From Map
 const map = new Map([['name', 'Alice'], ['age', 30]]);
-Object.fromEntries(map);
-// { name: 'Alice', age: 30 }
+Object.fromEntries(map);  // { name: 'Alice', age: 30 }
 
-// Transform object
+// Transform object values
 const prices = { apple: 1, banana: 2 };
-const doubled = Object.fromEntries(
-  Object.entries(prices).map(([k, v]) => [k, v * 2])
-);
+Object.fromEntries(Object.entries(prices).map(([k, v]) => [k, v * 2]));
 // { apple: 2, banana: 4 }
 
-// Filter object
-const filtered = Object.fromEntries(
-  Object.entries(obj).filter(([k, v]) => v > 0)
-);
-
-// URL search params to object
-const params = new URLSearchParams('name=Alice&age=30');
-Object.fromEntries(params);
-// { name: 'Alice', age: '30' }
+// Filter object entries
+Object.fromEntries(Object.entries(obj).filter(([, v]) => v > 0));
 ```
 
 ### String.prototype.trimStart() and trimEnd()
 
 ```javascript
 const str = '  Hello World  ';
-
 str.trimStart();  // 'Hello World  '
 str.trimEnd();    // '  Hello World'
 str.trim();       // 'Hello World'
-
-// Aliases (for compatibility)
-str.trimLeft();   // Same as trimStart()
-str.trimRight();  // Same as trimEnd()
 ```
 
 ### Optional Catch Binding
@@ -294,41 +189,25 @@ str.trimRight();  // Same as trimEnd()
 Omit the error parameter if not needed.
 
 ```javascript
-// ❌ Before: always needed parameter
-try {
-  JSON.parse(input);
-} catch (e) {  // 'e' is unused
-  return null;
-}
+// Before: always needed parameter
+try { JSON.parse(input); } catch (e) { return null; }
 
-// ✅ Now optional
-try {
-  JSON.parse(input);
-} catch {
-  return null;
-}
+// Now optional
+try { JSON.parse(input); } catch { return null; }
 ```
 
 ### Symbol.prototype.description
 
-Access symbol description directly.
-
 ```javascript
 const sym = Symbol('mySymbol');
-
-// ❌ Before: had to parse toString()
-sym.toString();  // 'Symbol(mySymbol)'
-
-// ✅ Now: direct access
-sym.description;  // 'mySymbol'
-
-Symbol().description;  // undefined
-Symbol('').description;  // ''
+sym.toString();    // 'Symbol(mySymbol)'
+sym.description;   // 'mySymbol'  (direct access, ES2019+)
+Symbol().description;   // undefined
 ```
 
 ### Stable Array.prototype.sort()
 
-Sort is now guaranteed to be stable (equal elements maintain order).
+Sort is now guaranteed stable — equal elements maintain relative order.
 
 ```javascript
 const items = [
@@ -337,14 +216,10 @@ const items = [
   { name: 'Charlie', age: 25 },
 ];
 
-// Sort by age - Alice and Bob maintain relative order
+// Alice and Bob maintain relative order after sort by age
 // Note: Use .toSorted() in ES2023+ to avoid mutation
-const sorted = items.toSorted((a, b) => a.age - b.age);
-// [
-//   { name: 'Charlie', age: 25 },
-//   { name: 'Alice', age: 30 },    <- Alice before Bob (stable)
-//   { name: 'Bob', age: 30 },
-// ]
+items.toSorted((a, b) => a.age - b.age);
+// [{ Charlie, 25 }, { Alice, 30 }, { Bob, 30 }]
 ```
 
 ### Well-formed JSON.stringify()
@@ -352,11 +227,7 @@ const sorted = items.toSorted((a, b) => a.age - b.age);
 Properly encode lone surrogates as escape sequences.
 
 ```javascript
-// Before: could produce invalid Unicode
-JSON.stringify('\uD800');  // '"\uD800"' (invalid)
-
-// After: escape sequences for lone surrogates
-JSON.stringify('\uD800');  // '"\\ud800"' (valid)
+JSON.stringify('\uD800');  // '"\\ud800"' (valid — was invalid before)
 ```
 
 ### Function.prototype.toString() Revision
@@ -365,8 +236,5 @@ Returns exact source code including whitespace and comments.
 
 ```javascript
 function /* comment */ foo() { }
-
-foo.toString();
-// 'function /* comment */ foo() { }'
-// (Before, comments/whitespace might be stripped)
+foo.toString();  // 'function /* comment */ foo() { }'
 ```


### PR DESCRIPTION
## Summary

- Reduced `.agents/tools/programming/modern-javascript-skill/es2018-es2019.md` from 372 → 240 lines (35% reduction, target was ~30%)
- All 17 feature sections preserved; zero content loss on actionable guidance
- Removed: duplicate async iterable manual implementation (generator example sufficient), redundant `Promise.finally()` async/await duplicate, `❌ Before` numbered-groups contrast block, negative lookbehind redundant example, Unicode property escapes catalogue trimmed to 5 representative entries, `trimStart/trimEnd` aliases, `Object.fromEntries` URL params example

Closes #11362