### PR TITLE
fix(queries): tx.rollback is a property access, not a callable method

### DIFF
--- a/.agents/services/database/postgres-drizzle-skill/queries.md
+++ b/.agents/services/database/postgres-drizzle-skill/queries.md
@@ -215,7 +215,7 @@ await db.transaction(async (tx) => {
 // Manual rollback
 await db.transaction(async (tx) => {
   const [user] = await tx.insert(users).values({ ... }).returning();
-  if ((await checkBalance(user.id)) < 0) tx.rollback();
+  if ((await checkBalance(user.id)) < 0) tx.rollback;
   await tx.insert(orders).values({ userId: user.id, ... });
 });
 


### PR DESCRIPTION
## Summary

- Fixes CodeRabbit review suggestion from PR #11416 that was merged before the fix could be included
- Changes `tx.rollback()` → `tx.rollback` at line 218 of `.agents/services/database/postgres-drizzle-skill/queries.md`

## Context

Drizzle ORM's `tx.rollback` throws `TransactionRollbackError` when accessed as a **property** — it is not a callable method. Calling `tx.rollback()` is incorrect and would not trigger the expected rollback behaviour.

PR #11416 was merged with the original simplification commit before this fix could be pushed to the branch. This PR applies the single-line correction to `main`.

Closes the open CodeRabbit suggestion from #11416.