### PR TITLE
t11204: tighten seo.md by 35% (366 → 239 lines)

### DIFF
--- a/.agents/seo.md
+++ b/.agents/seo.md
@@ -48,91 +48,66 @@ subagents:
 
 - **Purpose**: SEO optimization and analysis
 - **Tools**: Google Search Console, Ahrefs, Semrush, DataForSEO, Serper, PageSpeed Insights, Google Analytics, Context7
-- **MCP**: GSC, DataForSEO, Serper, Google Analytics, Context7 for comprehensive SEO data and library docs
+- **MCP**: GSC, DataForSEO, Serper, Google Analytics, Context7
 - **Commands**: `/keyword-research`, `/autocomplete-research`, `/keyword-research-extended`, `/seo-export`, `/seo-analyze`, `/seo-opportunities`, `/seo-write`, `/seo-optimize`, `/seo-analyze-content`, `/seo-fanout`, `/seo-geo`, `/seo-sro`, `/seo-hallucination-defense`, `/seo-agent-discovery`, `/seo-ai-readiness`, `/seo-ai-baseline`
 
 **Subagents** (`seo/` and `services/analytics/`):
 
 | Subagent | Purpose |
 |----------|---------|
-| `keyword-research.md` | Comprehensive keyword research with SERP weakness detection |
-| `google-search-console.md` | GSC queries and search performance |
+| `keyword-research.md` | Keyword research with SERP weakness detection (17 types, KeywordScore 0-100) |
+| `google-search-console.md` | GSC queries, search performance, index coverage |
 | `gsc-sitemaps.md` | Sitemap submission via Playwright browser automation |
-| `dataforseo.md` | Comprehensive SEO data APIs (SERP, keywords, backlinks) |
+| `dataforseo.md` | SERP data, keywords, backlinks, on-page (REST API) |
 | `serper.md` | Google Search API (web, images, news, places) |
-| `site-crawler.md` | SEO site auditing (Screaming Frog-like capabilities) |
+| `ahrefs.md` | Backlinks, organic keywords, domain rating (REST API v3) |
+| `semrush.md` | Domain analytics, keywords, backlinks, competitor research |
+| `site-crawler.md` | Site auditing — links, meta, redirects (Screaming Frog-like) |
 | `screaming-frog.md` | Screaming Frog SEO Spider CLI integration |
-| `eeat-score.md` | E-E-A-T content quality scoring and analysis |
-| `google-analytics.md` | GA4 reporting, traffic analysis, and user behavior (see `services/analytics/`) |
-| `data-export.md` | Export SEO data from GSC, Bing, Ahrefs, DataForSEO to TOON format |
-| `semrush.md` | Semrush API - domain analytics, keyword research, competitor analysis |
-| `contentking.md` | Conductor Monitoring (ContentKing) real-time SEO monitoring |
-| `ranking-opportunities.md` | Analyze data for quick wins, striking distance, cannibalization |
-| `analytics-tracking.md` | GA4 setup, event tracking, conversions, UTM parameters, attribution |
-| `rich-results.md` | Google Rich Results Test via browser automation (API deprecated) |
-| `debug-opengraph.md` | Validate Open Graph meta tags for social sharing |
+| `eeat-score.md` | E-E-A-T content quality scoring (7 criteria, 1-10) |
+| `contentking.md` | Real-time SEO monitoring and change tracking |
+| `ranking-opportunities.md` | Quick wins, striking distance, cannibalization analysis |
+| `analytics-tracking.md` | GA4 setup, event tracking, conversions, UTM, attribution |
+| `rich-results.md` | Google Rich Results Test via browser automation |
+| `debug-opengraph.md` | Validate Open Graph meta tags |
 | `debug-favicon.md` | Validate favicon setup across platforms |
-| `programmatic-seo.md` | Build SEO pages at scale with templates and keyword clustering |
-| `image-seo.md` | AI-powered image SEO: filename, alt text, tag generation |
-| `moondream.md` | Moondream AI vision model for image analysis and captioning |
-| `upscale.md` | Image upscaling services (Real-ESRGAN, Replicate, Cloudflare) |
-| `content-analyzer.md` | Comprehensive content analysis (readability, keywords, SEO quality) |
+| `programmatic-seo.md` | SEO pages at scale with templates and keyword clustering |
+| `image-seo.md` | AI-powered alt text, filenames, tags (Moondream); upscaling via `upscale.md` |
+| `content-analyzer.md` | Content analysis (readability, keywords, SEO quality) |
 | `seo-optimizer.md` | On-page SEO audit with prioritized recommendations |
 | `keyword-mapper.md` | Keyword placement, density, and distribution analysis |
-| `geo-strategy.md` | AI search visibility strategy using criteria extraction and retrieval-first optimization |
-| `sro-grounding.md` | Selection Rate Optimization for grounding snippet coverage and citation readiness |
-| `query-fanout-research.md` | Query decomposition and thematic fan-out modeling for content planning |
-| `ai-hallucination-defense.md` | Detect and reduce brand hallucination risk with consistency and claim-evidence audits |
-| `ai-agent-discovery.md` | Evaluate whether autonomous agents can discover key site information over multi-turn exploration |
-| `ai-search-readiness.md` | End-to-end orchestration playbook chaining fan-out, GEO, SRO, consistency, and discoverability |
+| `geo-strategy.md` | AI search visibility — criteria extraction, retrieval-first optimization |
+| `sro-grounding.md` | Selection Rate Optimization for grounding snippet coverage |
+| `query-fanout-research.md` | Query decomposition and thematic fan-out for content planning |
+| `ai-hallucination-defense.md` | Detect brand hallucination risk, consistency and claim-evidence audits |
+| `ai-agent-discovery.md` | Validate autonomous agents can discover key site information |
+| `ai-search-readiness.md` | End-to-end orchestration: fan-out → GEO → SRO → consistency → discoverability |
+| `google-analytics.md` | GA4 reporting, traffic analysis, user behavior |
+| `data-export.md` | Export SEO data from GSC, Bing, Ahrefs, DataForSEO to TOON format |
+
+Each subagent has curl examples. Load the relevant one when needed.
 
 **Content Analysis** (adapted from [SEO Machine](https://github.com/TheCraigHewitt/seomachine)):
 
 ```bash
-# Full content analysis with keyword
 python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py analyze article.md --keyword "target keyword"
-
-# Individual analyses
 python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py readability article.md
 python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py keywords article.md --keyword "keyword"
 python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py quality article.md
 python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py intent "search query"
 ```
 
-**Key Operations**:
-- Keyword research with weakness detection (`/keyword-research-extended`)
-- Autocomplete long-tail expansion (`/autocomplete-research`)
-- Competitor keyword analysis (`--competitor`)
-- Keyword gap analysis (`--gap`)
-- Search performance analysis (GSC)
-- SERP analysis (DataForSEO, Serper)
-- Backlink analysis (Ahrefs, DataForSEO)
-- Page speed optimization (PageSpeed)
-- **Image SEO**: AI-powered alt text, filename, and tag generation (`image-seo.md`)
-- **Data export and analysis** (`/seo-opportunities`)
-
 **Commands**:
 
 ```bash
-# Basic keyword research
 /keyword-research "best seo tools, keyword research"
-
-# Long-tail autocomplete expansion
 /autocomplete-research "how to lose weight"
-
-# Full SERP analysis with weakness detection
 /keyword-research-extended "dog training tips"
-
-# Competitor research
 /keyword-research-extended --competitor petco.com
-
-# Keyword gap analysis
 /keyword-research-extended --gap mysite.com,competitor.com
-
-# Export and analyze ranking data
 /seo-opportunities example.com --days 90
 
-# AI search readiness commands
+# AI search readiness
 /seo-fanout "best personal injury lawyer chicago"
 /seo-geo example.com
 /seo-sro example.com
@@ -141,19 +116,6 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py intent "search query"
 /seo-ai-readiness example.com
 /seo-ai-baseline example.com
 ```
-
-**API Access** (via curl in subagents, no MCP needed):
-
-| Subagent | API | What it provides |
-|----------|-----|-----------------|
-| `google-search-console` | Google Search Console API | Search analytics, indexing, sitemaps |
-| `dataforseo` | DataForSEO REST API | SERP data, keywords, backlinks, on-page |
-| `serper` | Serper.dev API | Google search results (web, images, news, places) |
-| `ahrefs` | Ahrefs REST API v3 | Backlinks, organic keywords, domain rating |
-| `semrush` | Semrush Analytics API v3 | Domain analytics, keywords, backlinks, competitor research |
-| `contentking` | Conductor Monitoring API v2 | Real-time SEO monitoring, change tracking, issues |
-
-Each subagent has curl examples. Load the relevant one when needed.
 
 **Testing**: Use OpenCode CLI to test SEO commands without restarting TUI:
 
@@ -167,88 +129,49 @@ See `tools/opencode/opencode.md` for CLI testing patterns.
 
 ## SEO Workflow
 
-### Keyword Research (Primary)
-
-Use `/keyword-research` commands for comprehensive keyword analysis:
+### Keyword Research
 
 ```bash
-# Discovery workflow
 /keyword-research "seed keywords"           # Expand seed keywords
 /autocomplete-research "question phrase"    # Long-tail discovery
-/keyword-research-extended "top keywords"   # Full SERP analysis
+/keyword-research-extended "top keywords"   # Full SERP analysis with weakness detection
 ```
 
-See `seo/keyword-research.md` for complete documentation including:
-- 17 SERP weakness types
-- KeywordScore algorithm (0-100)
-- Domain/Competitor/Gap research modes
-- Provider configuration (DataForSEO, Serper, Ahrefs)
+See `seo/keyword-research.md` for Domain/Competitor/Gap research modes and provider configuration.
 
 ### Search Performance
 
-Use Google Search Console MCP for:
-- Query performance data
-- Click-through rates
-- Position tracking
-- Index coverage
-
-See `seo/google-search-console.md` for query patterns.
+Use Google Search Console MCP for query performance, CTR, position tracking, and index coverage. See `seo/google-search-console.md`.
 
 ### AI Search Optimization (GEO and SRO)
 
-Use a retrieval-first workflow for AI search surfaces:
+Retrieval-first workflow for AI search surfaces:
 
-0. Run `/seo-ai-baseline example.com` to capture grounding eligibility, coverage, selection, integrity, and discoverability baselines
-1. Run `/seo-fanout "target query"` (`seo/query-fanout-research.md`) to model thematic sub-queries for target intents
-2. Run `/seo-geo example.com` (`seo/geo-strategy.md`) to extract decision criteria and map coverage gaps
-3. Run `/seo-sro example.com` (`seo/sro-grounding.md`) to improve snippet selection likelihood and grounding density
-4. Run `/seo-hallucination-defense example.com` (`seo/ai-hallucination-defense.md`) to remove contradictions and unsupported claims
-5. Run `/seo-agent-discovery example.com` (`seo/ai-agent-discovery.md`) to validate that autonomous agents can actually find key information
+0. `/seo-ai-baseline example.com` — capture grounding eligibility, coverage, selection, integrity, discoverability baselines
+1. `/seo-fanout "target query"` — model thematic sub-queries (`seo/query-fanout-research.md`)
+2. `/seo-geo example.com` — extract decision criteria, map coverage gaps (`seo/geo-strategy.md`)
+3. `/seo-sro example.com` — improve snippet selection and grounding density (`seo/sro-grounding.md`)
+4. `/seo-hallucination-defense example.com` — remove contradictions and unsupported claims (`seo/ai-hallucination-defense.md`)
+5. `/seo-agent-discovery example.com` — validate autonomous agents can find key information (`seo/ai-agent-discovery.md`)
 
-This keeps focus on deterministic retrieval signals (content clarity, structure, consistency, discoverability) instead of volatile prompt-rank tracking.
+Focus: deterministic retrieval signals (content clarity, structure, consistency, discoverability). Full scorecard: `seo/ai-search-readiness.md`.
 
-For full execution order and scorecard guidance, use `seo/ai-search-readiness.md`.
+### SERP and Backlink Analysis
 
-### SERP Analysis
-
-Use DataForSEO or Serper for real-time SERP data:
-- **DataForSEO**: Comprehensive SERP data with keyword metrics
-- **Serper**: Quick Google searches (web, images, news, places)
-
-See `seo/dataforseo.md` and `seo/serper.md` for usage.
-
-### Keyword Research (Legacy)
-
-Combine tools:
-- GSC for existing performance
-- DataForSEO for keyword data (volume, CPC, difficulty)
-- Ahrefs for competitor analysis
-- Content gap identification
-
-### Backlink Analysis
-
-- **DataForSEO**: Backlink data, referring domains, anchor text
-- **Ahrefs**: Comprehensive backlink profiles
+- **SERP**: DataForSEO (comprehensive + keyword metrics) or Serper (quick searches). See `seo/dataforseo.md`, `seo/serper.md`.
+- **Backlinks**: DataForSEO (referring domains, anchor text) or Ahrefs (full profiles). See `seo/ahrefs.md`.
 
 ### Technical SEO
 
-- PageSpeed optimization (see `tools/browser/pagespeed.md`)
-- Core Web Vitals monitoring
-- Mobile usability
-- Structured data validation
-- On-page analysis (DataForSEO)
-- **Site crawling**: Use `site-crawler.md` for comprehensive audits
-- **Real-time monitoring**: Use `contentking.md` for 24/7 SEO monitoring and change tracking
+- PageSpeed / Core Web Vitals (`tools/browser/pagespeed.md`)
+- Mobile usability, structured data validation, on-page analysis (DataForSEO)
+- Site crawling: `seo/site-crawler.md`
+- Real-time monitoring: `seo/contentking.md`
 
 ### Site Auditing
 
-Use `seo/site-crawler.md` for Screaming Frog-like capabilities:
-
 ```bash
-# Full site crawl
 site-crawler-helper.sh crawl https://example.com
-
-# Specific audits
 site-crawler-helper.sh audit-links https://example.com
 site-crawler-helper.sh audit-meta https://example.com
 site-crawler-helper.sh audit-redirects https://example.com
@@ -258,97 +181,47 @@ Output: `~/Downloads/{domain}/{datestamp}/` with CSV/XLSX reports.
 
 ### E-E-A-T Content Quality
 
-Use `seo/eeat-score.md` for content quality analysis:
-
 ```bash
-# Analyze crawled pages
 eeat-score-helper.sh analyze ~/Downloads/example.com/_latest/crawl-data.json
-
-# Score single URL
 eeat-score-helper.sh score https://example.com/article
 ```
 
 Scores 7 criteria (1-10): Authorship, Citation, Effort, Originality, Intent, Subjective Quality, Writing.
-Output: `{domain}-eeat-score-{date}.xlsx` with scores and reasoning.
+Output: `{domain}-eeat-score-{date}.xlsx`.
 
 ### Sitemap Submission
 
-Use `seo/gsc-sitemaps.md` for automated sitemap submissions:
-
 ```bash
-# Submit sitemap for single domain
 ~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit example.com
-
-# Submit for multiple domains
 ~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit example.com example.net example.org
-
-# Submit from file
 ~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit --file domains.txt
-
-# Check status
 ~/.aidevops/agents/scripts/gsc-sitemap-helper.sh status example.com
 ```
 
-Uses Playwright browser automation with persistent Chrome profile. First-time setup requires `~/.aidevops/agents/scripts/gsc-sitemap-helper.sh login` to authenticate.
+Uses Playwright with persistent Chrome profile. First-time: `gsc-sitemap-helper.sh login`.
 
 ### Data Export & Opportunity Analysis
 
-Export ranking data from multiple platforms and analyze for opportunities:
-
 ```bash
-# Export from all platforms (GSC, Bing, Ahrefs, DataForSEO)
-/seo-export all example.com --days 90
-
-# Run full analysis
-/seo-analyze example.com
-
-# Or combine both in one step
-/seo-opportunities example.com --days 90
+/seo-export all example.com --days 90   # Export from GSC, Bing, Ahrefs, DataForSEO
+/seo-analyze example.com                # Analyze for opportunities
+/seo-opportunities example.com --days 90  # Both in one step
 ```
 
-**Analysis types**:
-- **Quick Wins**: Position 4-20, high impressions (easy improvements)
-- **Striking Distance**: Position 11-30, high volume (page 2 to page 1)
-- **Low CTR**: High impressions, low clicks (title/meta optimization)
-- **Cannibalization**: Same query ranking with multiple URLs
-
-Output: `~/.aidevops/.agent-workspace/work/seo-data/{domain}/`
-
-See `seo/data-export.md` and `seo/ranking-opportunities.md` for details.
+**Analysis types**: Quick Wins (pos 4-20), Striking Distance (pos 11-30), Low CTR, Cannibalization.
+Output: `~/.aidevops/.agent-workspace/work/seo-data/{domain}/`. See `seo/data-export.md`, `seo/ranking-opportunities.md`.
 
 ### Image SEO
 
-Use `seo/image-seo.md` for AI-powered image optimization:
-
-- **Alt text generation**: WCAG-compliant descriptions via Moondream vision AI
-- **SEO filenames**: Descriptive, hyphenated filenames from image content
-- **Tag extraction**: Keyword tags for metadata and categorization
-- **Quality upscaling**: Ensure minimum dimensions for social sharing
-
-See `seo/image-seo.md` for the full workflow, `seo/moondream.md` for the vision API, and `seo/upscale.md` for upscaling options.
+AI-powered via `seo/image-seo.md`: alt text (WCAG-compliant, Moondream), SEO filenames, keyword tags, quality upscaling. See `seo/moondream.md`, `seo/upscale.md`.
 
 ### Content Optimization
 
-Integrate with `content.md` for:
-- Content calendar planning and gap analysis (`content/content-calendar.md`)
-- SEO-optimized content writing (`content/seo-writer.md`)
-- Meta title/description generation (`content/meta-creator.md`)
-- Internal linking strategy (`content/internal-linker.md`)
-- Human voice editing (`content/editor.md`)
+Integrate with `content.md`: content calendar (`content/content-calendar.md`), SEO writing (`content/seo-writer.md`), meta generation (`content/meta-creator.md`), internal linking (`content/internal-linker.md`), editing (`content/editor.md`).
 
-**Content analysis workflow** (from SEO Machine integration):
+Workflow: Plan → Research (`/keyword-research`) → Write → Analyze (`seo-content-analyzer.py`) → Optimize (`seo/seo-optimizer.md`) → Edit → Publish.
 
-1. **Plan**: Use `content/content-calendar.md` for gap analysis and scheduling
-2. **Research**: `/keyword-research` + `/autocomplete-research`
-3. **Write**: Use `content/seo-writer.md` with keyword targets
-4. **Analyze**: `seo-content-analyzer.py analyze` for quality score
-5. **Optimize**: Address issues from `seo/seo-optimizer.md`
-6. **Edit**: `content/editor.md` for human voice
-7. **Publish**: Via WordPress or CMS
-
-**Context templates** for per-project SEO configuration:
-
-See `content/context-templates.md` for brand voice, style guide, target keywords, internal links map, competitor analysis, and SEO guidelines templates. Create a `context/` directory in your project and populate from those templates.
+Per-project SEO config: see `content/context-templates.md` for brand voice, style guide, keyword, and competitor templates.
 
 ## Tool Comparison
 


### PR DESCRIPTION
## Summary

- Reduced `.agents/seo.md` from 366 to 239 lines (34.7% reduction, target ~30%)
- Removed redundant content without losing any actionable guidance

## Changes

- **Subagent table**: Condensed descriptions, merged `moondream`/`upscale` into `image-seo` row, removed `ahrefs` duplicate row (was missing from original table but in YAML — added back)
- **Key Operations list** (lines 102–112): Removed — fully covered by the Commands block immediately below it
- **API Access table** (lines 145–156): Removed — Tool Comparison table at bottom covers tool capabilities; curl note moved inline to subagent table
- **Keyword Research (Legacy)** section: Removed — redundant with Primary section above it
- **Workflow prose**: Collapsed verbose multi-bullet sections (Search Performance, SERP Analysis, Backlink Analysis) to single-line pointers
- **Content Optimization**: Collapsed 7-step workflow to one-line summary; context templates to one-line pointer
- **Commands block**: Removed inline comments (self-evident from command names)

## Preserved

All subagent references, all slash commands, all technical terminology (KeywordScore, 17 SERP weakness types, E-E-A-T 7 criteria, GEO/SRO workflow steps, Quick Wins/Striking Distance/Cannibalization analysis types, retrieval-first workflow, grounding baselines).

## Runtime Testing

- **Risk**: Low (docs/agent prompt only — no code changes)
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 239 lines; `rg` confirms all subagent names and key technical terms present

Closes #11204