### PR TITLE
t11212: tighten voice-models.md by 20% (343→273 lines)

### DIFF
--- a/.agents/tools/voice/voice-models.md
+++ b/.agents/tools/voice/voice-models.md
@@ -34,64 +34,35 @@ tools:
 
 The voice bridge (`voice-bridge.py`) implements three TTS engines:
 
-#### EdgeTTS (Default)
-
-Microsoft Edge TTS via `edge-tts` package. See `voice-bridge.py:133-179`.
-
-- Free, no API key needed
-- 300+ voices across 70+ languages
-- Streaming support, adjustable rate
-- Default voice: `en-GB-SoniaNeural`
+| Engine | Notes | Code ref |
+|--------|-------|----------|
+| **EdgeTTS** (default) | Free, 300+ voices/70+ langs, streaming, default `en-GB-SoniaNeural` | `voice-bridge.py:133-179` |
+| **macOS Say** | Built-in, zero deps, default `Samantha`, macOS only | `voice-bridge.py:182-205` |
+| **FacebookMMS** | 1,100+ languages, requires `transformers`, CPU-friendly | `voice-bridge.py:208-238` |
 
 ```bash
-# Use via voice bridge
-voice-helper.sh talk
+voice-helper.sh talk  # Use via voice bridge
 ```
-
-#### macOS Say
-
-Native macOS speech synthesis. See `voice-bridge.py:182-205`.
-
-- Built-in, zero dependencies
-- Default voice: `Samantha`
-- macOS only
-
-#### FacebookMMS TTS
-
-Meta's Massively Multilingual Speech. See `voice-bridge.py:208-238`.
-
-- 1,100+ languages
-- Requires `transformers` package
-- CPU-friendly
 
 ### Local Open-Weight Models
 
-Models available for local inference. Not integrated into the voice bridge but usable standalone.
-
 #### Qwen3-TTS (Recommended for Quality + Multilingual)
 
-Alibaba's open-weight TTS series. 7.1k stars, Apache-2.0.
+Alibaba's open-weight TTS series. 7.1k stars, Apache-2.0. Sizes: 0.6B and 1.7B.
 
-- **Sizes**: 0.6B and 1.7B parameters
 - **Languages**: Chinese, English, Japanese, Korean, German, French, Russian, Portuguese, Spanish, Italian
-- **Features**: Voice cloning (3-second reference), voice design (natural language description), custom voices (9 built-in speakers), instruction-controlled emotion/prosody, streaming generation (97ms first-packet latency)
-- **Architecture**: Discrete multi-codebook LM with Qwen3-TTS-Tokenizer-12Hz, dual-track hybrid streaming
-- **Models**: CustomVoice (built-in speakers + instruction control), VoiceDesign (create voices from text descriptions), Base (voice cloning + fine-tuning)
-- **Requires**: CUDA GPU, Python 3.12, PyTorch 2.4+, FlashAttention 2 recommended
+- **Features**: Voice cloning (3s reference), voice design (text description), 9 built-in speakers, emotion/prosody control, streaming (97ms first-packet)
+- **Requires**: CUDA GPU, Python 3.12, PyTorch 2.4+; vLLM day-0 support
 - **Install**: `pip install qwen-tts`
-- **vLLM**: Day-0 support via vLLM-Omni for production deployment
 
 ```python
 from qwen_tts import Qwen3TTSModel
 import torch, soundfile as sf
 
-model = Qwen3TTSModel.from_pretrained(
-    "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-    device_map="cuda:0", dtype=torch.bfloat16,
-)
-wavs, sr = model.generate_custom_voice(
-    text="Hello, this is a test.", language="English", speaker="Ryan",
-)
+model = Qwen3TTSModel.from_pretrained("Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    device_map="cuda:0", dtype=torch.bfloat16)
+wavs, sr = model.generate_custom_voice(text="Hello, this is a test.",
+    language="English", speaker="Ryan")
 sf.write("output.wav", wavs[0], sr)
 ```
 
@@ -101,20 +72,16 @@ Docs: https://github.com/QwenLM/Qwen3-TTS
 
 82M parameter open-weight TTS. 5.6k stars, Apache-2.0.
 
-- **Size**: 82M parameters (extremely lightweight)
-- **Languages**: American English, British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin Chinese
-- **Features**: Comparable quality to larger models, very fast inference, multiple voice presets, MPS acceleration on Apple Silicon
-- **Architecture**: StyleTTS 2 based with misaki G2P
-- **Requires**: `espeak-ng`, Python 3.9+
-- **Install**: `pip install kokoro`
+- **Languages**: American/British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin
+- **Features**: Fast inference, multiple voice presets, MPS (Apple Silicon)
+- **Requires**: `espeak-ng`, Python 3.9+ — **Install**: `pip install kokoro`
 
 ```python
 from kokoro import KPipeline
+import soundfile as sf
 
 pipeline = KPipeline(lang_code='a')  # 'a' = American English
-generator = pipeline("Hello world!", voice='af_heart')
-for i, (gs, ps, audio) in enumerate(generator):
-    import soundfile as sf
+for i, (gs, ps, audio) in enumerate(pipeline("Hello world!", voice='af_heart')):
     sf.write(f'{i}.wav', audio, 24000)
 ```
 
@@ -122,16 +89,11 @@ Docs: https://github.com/hexgrad/kokoro
 
 #### Dia (Recommended for Dialogue)
 
-1.6B parameter dialogue TTS by Nari Labs. 19.1k stars, Apache-2.0.
+1.6B parameter dialogue TTS by Nari Labs. 19.1k stars, Apache-2.0. English only (~4.4GB VRAM).
 
-- **Size**: 1.6B parameters (~4.4GB VRAM in bf16)
-- **Languages**: English only
-- **Features**: Multi-speaker dialogue in one pass (`[S1]`/`[S2]` tags), non-verbal sounds (laughs, coughs, sighs), voice cloning via audio prompt, emotion/tone conditioning
-- **Architecture**: Based on SoundStorm + Descript Audio Codec
-- **Requires**: CUDA GPU, PyTorch 2.0+
-- **Install**: `pip install git+https://github.com/nari-labs/dia.git`
-- **Dia2**: Newer version available at https://github.com/nari-labs/dia2
-- **HF Transformers**: Supported via `DiaForConditionalGeneration`
+- **Features**: Multi-speaker in one pass (`[S1]`/`[S2]` tags), non-verbal sounds (laughs, coughs, sighs), voice cloning via audio prompt
+- **Requires**: CUDA GPU, PyTorch 2.0+ — **Install**: `pip install git+https://github.com/nari-labs/dia.git`
+- **Dia2**: https://github.com/nari-labs/dia2
 
 ```python
 from dia.model import Dia
@@ -148,11 +110,9 @@ Docs: https://github.com/nari-labs/dia
 
 Flow-matching TTS with zero-shot voice cloning. 14.1k stars, MIT (code), CC-BY-NC (weights).
 
-- **Languages**: Chinese, English (base model), extensible via fine-tuning
-- **Features**: Zero-shot voice cloning from short reference audio, sway sampling for quality, multi-speaker generation, Gradio UI, CLI, Docker, TensorRT-LLM runtime
-- **Architecture**: Diffusion Transformer with ConvNeXt V2, flow matching
-- **Requires**: CUDA/ROCm/XPU/MPS, Python 3.10+
-- **Install**: `pip install f5-tts`
+- **Languages**: Chinese, English (base), extensible via fine-tuning
+- **Features**: Zero-shot cloning from short reference audio, sway sampling, multi-speaker, Gradio UI, CLI, Docker, TensorRT-LLM
+- **Requires**: CUDA/ROCm/XPU/MPS, Python 3.10+ — **Install**: `pip install f5-tts`
 
 ```bash
 f5-tts_infer-cli \
@@ -166,32 +126,30 @@ Docs: https://github.com/SWivid/F5-TTS
 
 #### Bark (Suno)
 
-Transformer-based TTS with non-speech generation. 39k+ stars, MIT. **Note**: No active development since 2023.
+Transformer-based TTS with non-speech generation. 39k+ stars, MIT. **No active development since 2023.**
 
-- **Languages**: English, Chinese, French, German, Hindi, Italian, Japanese, Korean, Polish, Portuguese, Russian, Spanish, Turkish
-- **Features**: Non-speech sounds (music, laughter, background noise), speaker presets, multilingual
-- **Requires**: GPU recommended, CPU possible but slow
+- **Languages**: 13 languages including English, Chinese, French, German, Hindi, Japanese, Spanish
+- **Features**: Non-speech sounds (music, laughter, background noise), speaker presets
 - **Install**: `pip install git+https://github.com/suno-ai/bark.git`
 
 Docs: https://github.com/suno-ai/bark
 
 #### Coqui TTS
 
-Multi-model TTS toolkit with voice cloning. 44k+ stars, MPL-2.0. **Note**: Coqui company shut down late 2023; repo is community-maintained.
+Multi-model TTS toolkit. 44k+ stars, MPL-2.0. **Company shut down late 2023; community-maintained.**
 
-- **Features**: 20+ TTS models (Tacotron2, VITS, YourTTS, Bark, etc.), voice cloning, multi-speaker, training support
+- **Features**: 20+ models (Tacotron2, VITS, YourTTS, Bark, etc.), voice cloning, multi-speaker, training
 - **Install**: `pip install TTS`
 
 Docs: https://github.com/coqui-ai/TTS
 
 #### Piper TTS (Archived)
 
-Fast local neural TTS. 10.5k stars, MIT. **Archived Oct 2025** — development moved to https://github.com/OHF-Voice/piper1-gpl (GPL license).
+Fast local neural TTS. 10.5k stars, MIT. **Archived Oct 2025** — active fork: https://github.com/OHF-Voice/piper1-gpl (GPL).
 
-- **Features**: Lightweight C++ binary, 100+ voices, CPU-friendly, VITS-based
-- **Best for**: Embedded/IoT, Home Assistant, offline-only environments
+- **Features**: Lightweight C++ binary, 100+ voices, CPU-friendly; best for embedded/IoT, Home Assistant
 
-Docs: https://github.com/rhasspy/piper (archived), https://github.com/OHF-Voice/piper1-gpl (active)
+Docs: https://github.com/rhasspy/piper (archived)
 
 ### Cloud TTS APIs
 
@@ -216,35 +174,18 @@ curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/21m00Tcm4TlvDq8ikWAM" 
 
 #### MiniMax / Hailuo (Best Value for Talking-Head Content)
 
-MiniMax offers the best quality-to-cost ratio for talking-head video voiceovers. Default output is already natural-sounding with minimal configuration.
-
-- **Cost**: $5/month for 120 minutes of generation
-- **Voice clone**: Works well with just a 10-second reference clip
-- **Default quality**: High out of the box — less tuning needed than ElevenLabs
-- **Access**: Via Higgsfield platform (web UI) or direct MiniMax API
-- **Best for**: Talking-head videos, AI influencer content, organic social
+$5/month for 120 minutes. Voice clone from 10s clip. High default quality, less tuning than ElevenLabs. Best for talking-head videos when cost > peak quality.
 
 ```bash
-# Via MiniMax API
 curl -X POST "https://api.minimax.chat/v1/t2a_v2" \
   -H "Authorization: Bearer ${MINIMAX_API_KEY}" \
   -H "Content-Type: application/json" \
-  -d '{
-    "model": "speech-02-hd",
-    "text": "Hello world",
-    "voice_setting": {"voice_id": "your-cloned-voice-id"}
-  }'
+  -d '{"model": "speech-02-hd", "text": "Hello world", "voice_setting": {"voice_id": "your-cloned-voice-id"}}'
 ```
 
-**Voice cloning workflow**:
-
-1. Record or source a 10-30 second clean audio clip (single speaker, no background noise)
-2. Upload via MiniMax voice clone API or Higgsfield web UI
-3. Use the cloned voice ID in subsequent TTS requests
-
-**When to choose MiniMax over ElevenLabs**: When you need good-enough quality at lower cost and simpler setup. ElevenLabs remains higher quality for premium content, but MiniMax closes the gap for most talking-head use cases.
-
 #### OpenAI TTS
+
+Models: `tts-1` (fast), `tts-1-hd` (higher quality). Voices: alloy, echo, fable, onyx, nova, shimmer.
 
 ```bash
 curl https://api.openai.com/v1/audio/speech \
@@ -253,13 +194,9 @@ curl https://api.openai.com/v1/audio/speech \
   -d '{"model": "tts-1-hd", "input": "Hello world", "voice": "alloy"}'
 ```
 
-Models: `tts-1` (fast, lower quality), `tts-1-hd` (higher quality). Voices: alloy, echo, fable, onyx, nova, shimmer.
-
 ## Speech-to-Text (STT) Models
 
-For comprehensive STT coverage including model comparisons, cloud APIs, and the transcription pipeline, see `tools/voice/transcription.md`.
-
-### Summary of STT Options
+Full STT coverage (model comparisons, cloud APIs, transcription pipeline): `tools/voice/transcription.md`.
 
 | Category | Recommended | Notes |
 |----------|-------------|-------|
@@ -272,9 +209,7 @@ For comprehensive STT coverage including model comparisons, cloud APIs, and the 
 | **macOS native** | Apple Speech (macOS 26+) | On-device, multilingual |
 | **GUI app** | Buzz | Offline, Whisper-based — see `tools/voice/buzz.md` |
 
-### Local STT Implementations
-
-The voice bridge (`voice-bridge.py:99-115`) implements `FasterWhisperSTT`. The speech-to-speech pipeline (`speech-to-speech.md`) supports 7 STT backends: Whisper, Faster Whisper, Lightning Whisper MLX, MLX Audio Whisper, Paraformer, Parakeet TDT, and Moonshine.
+Voice bridge (`voice-bridge.py:99-115`) implements `FasterWhisperSTT`. Speech-to-speech pipeline (`speech-to-speech.md`) supports 7 backends: Whisper, Faster Whisper, Lightning Whisper MLX, MLX Audio Whisper, Paraformer, Parakeet TDT, Moonshine.
 
 ## Model Selection Guide
 
@@ -311,26 +246,21 @@ The voice bridge (`voice-bridge.py:99-115`) implements `FasterWhisperSTT`. The s
 ## Installation Quick Reference
 
 ```bash
-# Implemented (voice bridge)
-pip install edge-tts                    # EdgeTTS
-pip install transformers                # FacebookMMS
+# Voice bridge engines
+pip install edge-tts transformers
 
 # Local TTS models
-pip install qwen-tts                    # Qwen3-TTS (CUDA required)
-pip install kokoro                      # Kokoro 82M
-pip install f5-tts                      # F5-TTS
-pip install git+https://github.com/nari-labs/dia.git  # Dia
-pip install TTS                         # Coqui TTS
-pip install git+https://github.com/suno-ai/bark.git   # Bark
+pip install qwen-tts kokoro f5-tts TTS
+pip install git+https://github.com/nari-labs/dia.git
+pip install git+https://github.com/suno-ai/bark.git
 
-# Local STT models
-pip install faster-whisper              # Faster Whisper (recommended)
+# Local STT
+pip install faster-whisper
 # whisper.cpp: build from source (see transcription.md)
 
-# System dependencies
-brew install espeak-ng                  # Required by Kokoro (macOS)
-apt install espeak-ng                   # Required by Kokoro (Linux)
-brew install ffmpeg yt-dlp              # Required for transcription pipeline
+# System dependencies (macOS)
+brew install espeak-ng ffmpeg yt-dlp
+# Linux: apt install espeak-ng ffmpeg
 ```
 
 ## Related


### PR DESCRIPTION
## Summary

- Reduced `.agents/tools/voice/voice-models.md` from 343 → 273 lines (70 lines removed, ~20%)
- Collapsed 3 implemented-engine sub-sections into a compact table
- Inlined Install/Requires into single bullets per model (Kokoro, Dia, F5-TTS)
- Condensed MiniMax description and curl example to single-line JSON
- Compressed Qwen3-TTS Python example (12 → 9 lines)
- Trimmed Bark language list from 13 explicit entries to summary
- Tightened Coqui/Piper prose
- Consolidated STT intro sentence

## Preservation check

- All model names, docs URLs, and code examples present
- All cross-references preserved (`voice-bridge.py`, `transcription.md`, `speech-to-speech.md`, `buzz.md`, `heygen-skill`)
- All selection tables (use case, resource constraints, STT summary, cloud TTS) intact
- No task IDs or incident references removed (none were present)

## Runtime Testing

- **Risk**: Low (docs-only change, no code)
- **Level**: self-assessed
- **Verification**: `wc -l` confirms 273 lines; `rg` confirms all model names and cross-references present

Closes #11212