### PR TITLE
t11179: tighten script-writer.md by 41% (384→225 lines)

### DIFF
--- a/.agents/content/distribution-youtube-script-writer.md
+++ b/.agents/content/distribution-youtube-script-writer.md
@@ -26,44 +26,16 @@ Before writing a video script, work through:
 3. What does the viewer already know — where does this video meet them?
 4. What would make this indistinguishable from the last 10 videos on this topic — and how do we avoid that?
 
-## When to Use
-
-Read this subagent when the user wants to:
-
-- Write a YouTube video script from a topic/outline
-- Generate hooks for the first 30 seconds
-- Create a script outline with retention curve awareness
-- Remix a competitor's video into a unique script
-- Apply storytelling frameworks (AIDA, Hero's Journey, etc.)
-- Optimize an existing script for better retention
-
 ## Script Structure
 
 Every YouTube script follows this retention-optimized structure:
 
 ```text
-HOOK (0-30 seconds)
-  Pattern interrupt + promise + credibility
-  Goal: Stop the scroll, prevent click-away
-
-INTRO (30-60 seconds)
-  Context + roadmap + stakes
-  Goal: Commit viewer to watching the full video
-
-BODY (bulk of video)
-  Section 1: [Topic point] + pattern interrupt
-  Section 2: [Topic point] + pattern interrupt
-  Section 3: [Topic point] + pattern interrupt
-  ...
-  Goal: Deliver value while maintaining curiosity
-
-CLIMAX (near end)
-  Payoff the hook's promise
-  Goal: Satisfy the viewer's initial curiosity
-
-CTA (final 30 seconds)
-  Subscribe + next video + comment prompt
-  Goal: Convert viewer into subscriber
+HOOK (0-30s)   — Pattern interrupt + promise + credibility. Goal: stop the scroll.
+INTRO (30-60s) — Context + roadmap + stakes. Goal: commit viewer to full video.
+BODY           — Sections with pattern interrupts every 2-3 min. Goal: deliver value.
+CLIMAX         — Payoff the hook's promise. Goal: satisfy initial curiosity.
+CTA (final 30s)— Subscribe + next video + comment prompt. Goal: convert to subscriber.
 ```
 
 ### Pattern Interrupts
@@ -72,277 +44,150 @@ Insert every 2-3 minutes to reset attention:
 
 | Type | Example |
 |------|---------|
-| **Curiosity gap** | "But here's where it gets weird..." |
-| **Story pivot** | "That's what I thought too, until..." |
-| **Direct address** | "Now you might be thinking..." |
-| **Visual change** | "[B-roll / graphic / screen change]" |
-| **Tease ahead** | "And the third one is the one nobody expects..." |
-| **Reframe** | "But forget everything I just said, because..." |
+| Curiosity gap | "But here's where it gets weird..." |
+| Story pivot | "That's what I thought too, until..." |
+| Direct address | "Now you might be thinking..." |
+| Visual change | "[B-roll / graphic / screen change]" |
+| Tease ahead | "And the third one is the one nobody expects..." |
+| Reframe | "But forget everything I just said, because..." |
 
 ## Hook Formulas
 
 The hook is the most critical part. Use these proven formulas:
 
-### 1. Bold Claim
-
-> "[Surprising statement that challenges assumptions]"
-> Example: "This $5 tool outperforms every $500 alternative I've tested."
-
-### 2. Question Hook
-
-> "[Question that the viewer desperately wants answered]"
-> Example: "Why do 90% of YouTube channels never reach 1,000 subscribers?"
-
-### 3. Story Hook
-
-> "[Drop into the middle of a compelling story]"
-> Example: "Three months ago, I made a video that got 47 views. Last week, it hit 2 million."
-
-### 4. Contrarian Hook
-
-> "[Statement that goes against popular belief]"
-> Example: "Everything you've been told about YouTube SEO is wrong."
-
-### 5. Result Hook
-
-> "[Show the end result, then explain how]"
-> Example: "This channel went from 0 to 100K subscribers in 6 months. Here's exactly how."
-
-### 6. Problem-Agitate Hook
-
-> "[Name a pain point, then make it worse]"
-> Example: "Your YouTube thumbnails are costing you views. And the fix isn't what you think."
-
-### 7. Curiosity Gap Hook
-
-> "[Reveal partial information that demands completion]"
-> Example: "There's one setting in YouTube Studio that 95% of creators never touch. It changed everything for me."
+| Formula | Pattern | Example |
+|---------|---------|---------|
+| **Bold Claim** | Surprising statement that challenges assumptions | "This $5 tool outperforms every $500 alternative I've tested." |
+| **Question** | Question the viewer desperately wants answered | "Why do 90% of YouTube channels never reach 1,000 subscribers?" |
+| **Story** | Drop into the middle of a compelling story | "Three months ago, I made a video that got 47 views. Last week, it hit 2 million." |
+| **Contrarian** | Statement that goes against popular belief | "Everything you've been told about YouTube SEO is wrong." |
+| **Result** | Show the end result, then explain how | "This channel went from 0 to 100K subscribers in 6 months. Here's exactly how." |
+| **Problem-Agitate** | Name a pain point, then make it worse | "Your YouTube thumbnails are costing you views. And the fix isn't what you think." |
+| **Curiosity Gap** | Reveal partial information that demands completion | "There's one setting in YouTube Studio that 95% of creators never touch. It changed everything for me." |
 
 ## Storytelling Frameworks
 
-Choose based on content type:
-
-### AIDA (Best for: product reviews, tutorials)
-
-1. **Attention**: Hook with the problem or result
-2. **Interest**: Why this matters to the viewer
-3. **Desire**: Show the solution working
-4. **Action**: CTA (subscribe, try it, comment)
-
-### Three-Act Structure (Best for: documentaries, deep dives)
-
-1. **Setup**: Introduce the topic, establish stakes
-2. **Confrontation**: Present the conflict/challenge/mystery
-3. **Resolution**: Deliver the answer/solution/revelation
-
-### Hero's Journey (Best for: personal stories, transformations)
-
-1. **Ordinary world**: Where you/subject started
-2. **Call to adventure**: The challenge that appeared
-3. **Trials**: What was tried, what failed
-4. **Transformation**: The breakthrough moment
-5. **Return**: What was learned, how it applies to viewer
-
-### Problem-Solution-Result (Best for: how-to, educational)
-
-1. **Problem**: What's broken/missing/painful
-2. **Failed approaches**: What doesn't work (and why)
-3. **Solution**: The method that works
-4. **Proof**: Evidence it works (data, examples, demos)
-5. **Implementation**: Step-by-step for the viewer
-
-### Listicle with Stakes (Best for: "Top X" videos)
-
-1. **Hook**: Why this list matters
-2. **Items N through 2**: Build anticipation (save best for last)
-3. **Item 1**: The most impactful/surprising entry
-4. **Synthesis**: What the list reveals about the bigger picture
+| Framework | Best for | Structure |
+|-----------|----------|-----------|
+| **AIDA** | Product reviews, tutorials | Attention → Interest → Desire → Action |
+| **Three-Act** | Documentaries, deep dives | Setup → Confrontation → Resolution |
+| **Hero's Journey** | Personal stories, transformations | Ordinary world → Call → Trials → Transformation → Return |
+| **Problem-Solution-Result** | How-to, educational | Problem → Failed approaches → Solution → Proof → Implementation |
+| **Listicle with Stakes** | "Top X" videos | Hook why list matters → Items N–2 → Item 1 (best last) → Synthesis |
+| **Inverted Pyramid** | News, updates | Most important first, context after |
+| **Side-by-side** | Comparisons | Feature-by-feature with verdict |
 
 ## Workflow: Generate a Script
 
 ### Step 1: Gather Context
 
 ```bash
-# Recall channel voice and audience from memory
 memory-helper.sh recall --namespace youtube "channel voice"
 memory-helper.sh recall --namespace youtube "audience"
-
-# Get topic research
 memory-helper.sh recall --namespace youtube-topics "[topic]"
-
-# Get competitor scripts on this topic (transcripts)
 youtube-helper.sh transcript COMPETITOR_VIDEO_ID
 ```
 
-### Step 2: Choose Framework
+### Step 2: Generate the Script
 
-Match the framework to the content type:
+**Prompt pattern**:
 
-| Content Type | Best Framework |
-|-------------|---------------|
-| Product review | AIDA |
-| Tutorial / how-to | Problem-Solution-Result |
-| Documentary / explainer | Three-Act Structure |
-| Personal story | Hero's Journey |
-| List / roundup | Listicle with Stakes |
-| News / update | Inverted Pyramid (most important first) |
-| Comparison | Side-by-side with verdict |
-
-### Step 3: Generate the Script
-
-**Prompt pattern for script generation**:
-
-> Write a YouTube video script for the topic: [topic]
+> Write a YouTube video script for: [topic]
 >
 > **Channel voice**: [from memory — formal/casual, humor style, expertise level]
-> **Target audience**: [from memory — who they are, what they care about]
-> **Framework**: [chosen framework]
+> **Target audience**: [from memory]
+> **Framework**: [chosen from table above]
 > **Target length**: [X minutes / Y words]
 > **Primary keyword**: [from topic research]
 >
 > Requirements:
-> 1. Hook must use [formula type] format
-> 2. Include pattern interrupts every 2-3 minutes
-> 3. Include [VISUAL CUE] markers for B-roll/graphics
-> 4. Include [TIMESTAMP] markers for YouTube chapters
-> 5. End with a specific CTA that relates to the content
+> 1. Hook: [formula type] format
+> 2. Pattern interrupts every 2-3 minutes
+> 3. [VISUAL CUE] markers for B-roll/graphics
+> 4. [TIMESTAMP] markers for YouTube chapters
+> 5. CTA specific to the content (not generic)
 >
-> Competitor angles to AVOID (already covered):
-> - [angle 1 from topic research]
-> - [angle 2 from topic research]
->
+> Competitor angles to AVOID: [from topic research]
 > Our unique angle: [from topic research]
 
-### Step 4: Review and Refine
+### Step 3: Review Against Retention Signals
 
-Check the script against these retention signals:
-
-| Checkpoint | What to Verify |
-|-----------|---------------|
-| First 5 seconds | Does it stop the scroll? |
-| First 30 seconds | Is the hook complete with promise + credibility? |
-| 60-second mark | Does the viewer know what they'll get? |
-| Every 2-3 minutes | Is there a pattern interrupt? |
-| Midpoint | Is there a "but wait" moment to re-engage? |
-| Before CTA | Was the hook's promise fulfilled? |
-| CTA | Is it specific and content-related (not generic)? |
+| Checkpoint | Verify |
+|-----------|--------|
+| First 5 seconds | Stops the scroll? |
+| First 30 seconds | Hook complete with promise + credibility? |
+| 60-second mark | Viewer knows what they'll get? |
+| Every 2-3 minutes | Pattern interrupt present? |
+| Midpoint | "But wait" moment to re-engage? |
+| Before CTA | Hook's promise fulfilled? |
+| CTA | Specific and content-related (not generic)? |
 
 ## Workflow: Remix Mode
 
 Transform a competitor's successful video into a unique script with your voice and angle.
 
-### Step 1: Extract the Source Structure
+### Step 1: Extract Source Structure
 
 ```bash
-# Get the full transcript
 youtube-helper.sh transcript VIDEO_ID > /tmp/source_transcript.txt
-
-# Get video metadata
 youtube-helper.sh video VIDEO_ID
 ```
 
-### Step 2: Analyze the Structure
+### Step 2: Analyze and Remix
 
-**Prompt pattern**:
-> Analyze this transcript and extract:
-> 1. The hook formula used (first 30 seconds)
-> 2. The storytelling framework
-> 3. Key points covered (in order)
-> 4. Pattern interrupts used
-> 5. The CTA approach
-> 6. What made this video successful (based on [X views])
->
-> [paste transcript]
+**Analyze prompt**: Extract hook formula, storytelling framework, key points, pattern interrupts, CTA approach, and what drove success.
 
-### Step 3: Remix with New Angle
-
-**Prompt pattern**:
-> Using the structure extracted above, write a NEW script that:
-> 1. Covers the SAME topic but from [new angle]
-> 2. Uses MY channel voice: [description]
-> 3. Adds [new information/perspective] not in the original
-> 4. Keeps the structural elements that made the original successful
-> 5. Is clearly distinct — no copied phrases or examples
->
-> The goal is to learn from what worked, not to copy.
+**Remix prompt**: Write a NEW script covering the SAME topic from [new angle], using MY channel voice, adding [new information/perspective], keeping structural elements that worked. No copied phrases or examples.
 
 ### Remix Modes
 
 | Mode | Description |
 |------|-------------|
-| **Same topic, new angle** | Cover the same subject from a different perspective |
-| **Same structure, new topic** | Apply the successful format to a different subject |
-| **Update** | Take an older video's topic and cover what's changed |
-| **Response** | Create a response/reaction that adds your expertise |
-| **Deep dive** | Take one point from a broad video and go deeper |
+| Same topic, new angle | Different perspective on same subject |
+| Same structure, new topic | Apply successful format to different subject |
+| Update | Cover what's changed since the original |
+| Response | Add your expertise to an existing video |
+| Deep dive | Expand one point from a broad video |
 
 ## Script Output Format
 
 ```markdown
 ## [Video Title]
 
-**Target length**: [X minutes / Y words]
-**Framework**: [framework name]
-**Primary keyword**: [keyword]
+**Target length**: [X min / Y words] | **Framework**: [name] | **Primary keyword**: [keyword]
 
 ---
 
 ### [00:00] HOOK
-
 [Script text with delivery notes]
-
-[VISUAL: description of what's on screen]
-
----
+[VISUAL: description]
 
 ### [00:30] INTRO
-
 [Script text]
-
 [VISUAL: description]
-
----
 
 ### [01:00] Section 1: [Title]
-
 [Script text]
-
 [PATTERN INTERRUPT: type and text]
-
 [VISUAL: description]
 
----
-
 ### [03:00] Section 2: [Title]
-
 [Script text]
-
 [PATTERN INTERRUPT: type and text]
-
----
 
 [... continue sections ...]
 
----
-
 ### [XX:XX] CTA
-
 [Script text — specific to content, not generic]
 
 ---
 
 ## Metadata
 
-**Suggested titles** (3 options):
-1. [Title option 1]
-2. [Title option 2]
-3. [Title option 3]
+**Suggested titles**: [Option 1] / [Option 2] / [Option 3]
 
 **Chapter timestamps**:
-00:00 - [Hook/Intro]
-00:30 - [Section 1]
-03:00 - [Section 2]
-...
+00:00 - Hook/Intro | 00:30 - Section 1 | 03:00 - Section 2 | ...
 
 **Tags**: [tag1], [tag2], [tag3], ...
 ```
@@ -350,17 +195,13 @@ youtube-helper.sh video VIDEO_ID
 ## Memory Integration
 
 ```bash
-# Store a successful script pattern
+# Store successful script pattern
 memory-helper.sh store --type SUCCESS_PATTERN --namespace youtube-scripts \
-  "Script for [topic] using [framework] with [hook type] hook. \
-   [X] minutes, [Y] sections. Audience response: [feedback if available]."
+  "Script for [topic] using [framework] with [hook type] hook. [X] min, [Y] sections. Response: [feedback]."
 
-# Store channel voice profile
+# Store/recall channel voice
 memory-helper.sh store --type WORKING_SOLUTION --namespace youtube \
-  "Channel voice: [casual/formal], [humor level], [expertise positioning]. \
-   Signature phrases: [list]. Avoid: [list]."
-
-# Recall voice for new scripts
+  "Channel voice: [casual/formal], [humor level], [expertise positioning]. Phrases: [list]. Avoid: [list]."
 memory-helper.sh recall --namespace youtube "channel voice"
 ```
 
@@ -368,17 +209,17 @@ memory-helper.sh recall --namespace youtube "channel voice"
 
 | Tool | Integration |
 |------|-------------|
-| `content/seo-writer.md` | SEO-optimize the script for search |
-| `content/humanise.md` | Remove AI writing patterns from generated scripts |
+| `content/seo-writer.md` | SEO-optimize the script |
+| `content/humanise.md` | Remove AI writing patterns |
 | `content/platform-personas.md` | YouTube-specific voice guidelines |
-| `optimizer.md` | Generate titles, tags, descriptions from the script |
+| `optimizer.md` | Generate titles, tags, descriptions from script |
 | `topic-research.md` | Feed validated topics into script generation |
 | `tools/voice/transcription.md` | Transcribe your own videos for voice analysis |
 
 ## Related
 
-- `youtube.md` — Main YouTube orchestrator (this directory)
+- `youtube.md` — Main YouTube orchestrator
 - `topic-research.md` — Topic validation before scripting
 - `optimizer.md` — Title/tag/description from completed scripts
 - `content.md` — General content writing workflows
-- `tools/video/video-prompt-design.md` — If generating AI video from the script
+- `tools/video/video-prompt-design.md` — AI video generation from script


### PR DESCRIPTION
## Summary

- Consolidate 7 hook formulas (7×3-line blockquotes) into a single table
- Consolidate 5 storytelling frameworks (verbose numbered lists) into a single table
- Compress script structure block from 20 lines to 5 inline lines
- Remove redundant "When to Use" section (duplicated description frontmatter)
- Merge "Step 2: Choose Framework" table into framework section (was duplicate)
- Trim workflow steps: remove inline comments from bash blocks, merge analyze+remix prompts
- Compress output template: remove redundant `---` separators, inline metadata
- Tighten memory integration: merge store/recall into fewer commands

All actionable guidance, examples, command patterns, and tool references preserved.

## Runtime Testing

- **Risk classification**: Low (docs/agent prompt only — no code changes)
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 384→225 lines (41% reduction, exceeds ~30% target)

## Files Changed

- `.agents/content/distribution-youtube-script-writer.md` — tightened from 384 to 225 lines

Closes #11179