### PR TITLE
t11173: tighten coolify-cli.md 388→158 lines

### DIFF
--- a/.agents/tools/deployment/coolify-cli.md
+++ b/.agents/tools/deployment/coolify-cli.md
@@ -34,161 +34,38 @@ tools:
 **Local Dev** (no Coolify): `./.agents/scripts/coolify-cli-helper.sh dev local ./app 3000`
 <!-- AI-CONTEXT-END -->
 
-Comprehensive self-hosted deployment and management using the Coolify CLI through the AI DevOps Framework.
-
-## Overview
-
-The Coolify CLI helper provides complete automation for:
-
-- **Local Development**: Works without Coolify setup for immediate development
-- Self-hosted application deployment and management
-- Server provisioning and management
-- Database creation and backup management
-- Multi-environment deployment workflows
-- Docker container orchestration
-
-### 🚀 **Local Development First**
-
-The integration is designed to work **immediately** for local development without requiring Coolify setup:
-
-- **Node.js Projects**: Automatically detects and runs `npm run dev` or `npm run start`
-- **Docker Projects**: Supports Dockerfile and docker-compose.yml
-- **Static HTML**: Serves static files using Python HTTP server
-- **Universal Build**: Runs local build scripts without cloud dependencies
-
 ## Prerequisites
 
-### Install Coolify CLI
+Install Coolify CLI:
 
 ```bash
-# Using install script (recommended)
 curl -fsSL https://raw.githubusercontent.com/coollabsio/coolify-cli/main/scripts/install.sh | bash
-
-# Using Go
-go install github.com/coollabsio/coolify-cli/coolify@latest
+# or: go install github.com/coollabsio/coolify-cli/coolify@latest
 ```
 
-### Dependencies
-
-- **Coolify CLI**: Latest version
-- **jq**: JSON processor for configuration management
-- **Docker**: For Docker-based projects (optional)
-- **Node.js**: For Node.js projects (optional)
+Dependencies: `jq` (required), `docker` (optional), `node` (optional).
 
 ## Configuration
 
-### Setup Configuration File
-
 ```bash
-# Copy template
+# Copy template and edit
 cp configs/coolify-cli-config.json.txt configs/coolify-cli-config.json
 
-# Edit configuration
-nano configs/coolify-cli-config.json
-```
-
-### Add Coolify Context
-
-```bash
-# Add production context
+# Add contexts
 ./.agents/scripts/coolify-cli-helper.sh add-context production https://coolify.example.com your-api-token true
-
-# Add staging context
 ./.agents/scripts/coolify-cli-helper.sh add-context staging https://staging.coolify.example.com staging-token
-
-# List contexts
 ./.agents/scripts/coolify-cli-helper.sh list-contexts
 ```
 
-## Usage Examples
-
-### Local Development (No Coolify Required)
-
-```bash
-# Start development server (works immediately)
-./.agents/scripts/coolify-cli-helper.sh dev local ./my-app 3000
-
-# Build project locally
-./.agents/scripts/coolify-cli-helper.sh build local ./my-app
-
-# Works with any project type:
-# - Node.js projects with package.json
-# - Docker projects with Dockerfile or docker-compose.yml
-# - Static HTML files
-# - Any framework with npm scripts
-```
-
-### Application Management
-
-```bash
-# List applications
-./.agents/scripts/coolify-cli-helper.sh list-apps production
-
-# Deploy application by name
-./.agents/scripts/coolify-cli-helper.sh deploy production my-app
-
-# Force deploy
-./.agents/scripts/coolify-cli-helper.sh deploy production my-app true
-
-# Get application details
-./.agents/scripts/coolify-cli-helper.sh get-app production app-uuid-here
-```
-
-### Server Management
-
-```bash
-# List servers
-./.agents/scripts/coolify-cli-helper.sh list-servers production
-
-# Add new server
-./.agents/scripts/coolify-cli-helper.sh add-server production myserver 192.168.1.100 key-uuid 22 root true
-
-# Parameters: context name ip key-uuid port user validate
-```
-
-### Database Management
-
-```bash
-# List databases
-./.agents/scripts/coolify-cli-helper.sh list-databases production
-
-# Create PostgreSQL database
-./.agents/scripts/coolify-cli-helper.sh create-db production postgresql server-uuid project-uuid main mydb true
-
-# Parameters: context type server-uuid project-uuid environment name instant-deploy
-```
-
-## Advanced Features
-
-### Multi-Context Management
-
-Configure multiple Coolify instances:
+Multi-context config (`configs/coolify-cli-config.json`):
 
 ```json
 {
   "contexts": {
-    "local": {
-      "url": "http://localhost:8000",
-      "description": "Local development"
-    },
-    "staging": {
-      "url": "https://staging.coolify.example.com",
-      "description": "Staging environment"
-    },
-    "production": {
-      "url": "https://coolify.example.com",
-      "description": "Production environment"
-    }
-  }
-}
-```
-
-### Project Configuration
-
-Define project-specific settings:
-
-```json
-{
+    "local":      { "url": "http://localhost:8000" },
+    "staging":    { "url": "https://staging.coolify.example.com" },
+    "production": { "url": "https://coolify.example.com" }
+  },
   "projects": {
     "web-app": {
       "context": "production",
@@ -202,187 +79,80 @@ Define project-specific settings:
 }
 ```
 
-### Docker Support
+## Usage
 
-Full Docker integration:
+### Local Development (no Coolify required)
+
+Auto-detects project type (Node.js `package.json`, Dockerfile/docker-compose, static HTML):
 
 ```bash
-# Docker Compose projects
-./.agents/scripts/coolify-cli-helper.sh dev local ./docker-app 3000
-
-# Dockerfile projects
-./.agents/scripts/coolify-cli-helper.sh build local ./docker-app
+./.agents/scripts/coolify-cli-helper.sh dev local ./my-app 3000
+./.agents/scripts/coolify-cli-helper.sh build local ./my-app
 ```
 
-## Integration with CI/CD
+### Application Management
 
-### GitHub Actions Integration
+```bash
+./.agents/scripts/coolify-cli-helper.sh list-apps production
+./.agents/scripts/coolify-cli-helper.sh deploy production my-app          # deploy
+./.agents/scripts/coolify-cli-helper.sh deploy production my-app true     # force deploy
+./.agents/scripts/coolify-cli-helper.sh get-app production app-uuid-here
+```
+
+### Server Management
+
+```bash
+./.agents/scripts/coolify-cli-helper.sh list-servers production
+# add-server: context name ip key-uuid port user validate
+./.agents/scripts/coolify-cli-helper.sh add-server production myserver 192.168.1.100 key-uuid 22 root true
+```
+
+### Database Management
+
+```bash
+./.agents/scripts/coolify-cli-helper.sh list-databases production
+# create-db: context type server-uuid project-uuid environment name instant-deploy
+./.agents/scripts/coolify-cli-helper.sh create-db production postgresql server-uuid project-uuid main mydb true
+./.agents/scripts/coolify-cli-helper.sh create-db production redis       server-uuid project-uuid main redis-cache true
+./.agents/scripts/coolify-cli-helper.sh create-db production mongodb     server-uuid project-uuid main mongo-db true
+```
+
+## CI/CD Integration
 
 ```yaml
 name: Deploy to Coolify
 on:
   push:
     branches: [main]
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Deploy to Coolify
-        run: |
-          ./.agents/scripts/coolify-cli-helper.sh deploy production my-app true
+      - run: ./.agents/scripts/coolify-cli-helper.sh deploy production my-app true
         env:
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
 ```
 
-### Multi-Environment Deployments
+## Monitoring
 
 ```bash
-# Development
-./.agents/scripts/coolify-cli-helper.sh dev local ./app 3000
-
-# Staging deployment
-./.agents/scripts/coolify-cli-helper.sh deploy staging my-app
-
-# Production deployment
-./.agents/scripts/coolify-cli-helper.sh deploy production my-app
-```
-
-## Database Management
-
-### Supported Database Types
-
-- **PostgreSQL**: Full-featured relational database
-- **MySQL/MariaDB**: Popular relational databases
-- **MongoDB**: Document database
-- **Redis**: In-memory data store
-- **ClickHouse**: Columnar database
-- **KeyDB**: Redis-compatible database
-
-### Database Operations
-
-```bash
-# Create databases
-./.agents/scripts/coolify-cli-helper.sh create-db production postgresql server-uuid project-uuid main postgres-db true
-./.agents/scripts/coolify-cli-helper.sh create-db production redis server-uuid project-uuid main redis-cache true
-./.agents/scripts/coolify-cli-helper.sh create-db production mongodb server-uuid project-uuid main mongo-db true
-```
-
-## Security Best Practices
-
-### API Token Management
-
-- Store Coolify tokens securely in environment variables
-- Use context-specific tokens for different environments
-- Rotate tokens regularly for security
-
-### Server Security
-
-- Use SSH key authentication for server access
-- Configure proper firewall rules
-- Enable SSL/TLS for all applications
-- Regular security updates
-
-### Network Security
-
-- Use private networks for database connections
-- Configure proper port mappings
-- Enable IP whitelisting when needed
-
-## Troubleshooting
-
-### Common Issues
-
-1. **CLI Not Found**
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/coollabsio/coolify-cli/main/scripts/install.sh | bash
-   ```
-
-2. **Context Issues**
-
-   ```bash
-   ./.agents/scripts/coolify-cli-helper.sh list-contexts
-   ./.agents/scripts/coolify-cli-helper.sh add-context production https://coolify.example.com token
-   ```
-
-3. **Local Development Issues**
-   - Check if Node.js/Docker is installed
-   - Verify project structure (package.json, Dockerfile, etc.)
-   - Check port availability
-
-4. **Deployment Failures**
-   - Verify server connectivity
-   - Check application logs
-   - Validate environment variables
-
-### Debug Mode
-
-Enable verbose logging:
-
-```bash
-# Set debug environment variable
-export DEBUG=1
-./.agents/scripts/coolify-cli-helper.sh deploy production my-app
-```
-
-## Framework Support
-
-Coolify CLI helper supports all major frameworks and deployment types:
-
-- **Node.js**: Express, Next.js, Nuxt.js, NestJS
-- **PHP**: Laravel, Symfony, WordPress
-- **Python**: Django, Flask, FastAPI
-- **Docker**: Any containerized application
-- **Static Sites**: HTML, CSS, JavaScript
-- **Databases**: PostgreSQL, MySQL, MongoDB, Redis
-
-## Performance Optimization
-
-### Build Optimization
-
-- Use appropriate base images
-- Configure build caching
-- Optimize container layers
-- Enable compression
-
-### Deployment Speed
-
-- Use incremental deployments
-- Configure proper health checks
-- Optimize resource allocation
-
-## Monitoring and Logging
-
-### Built-in Monitoring
-
-- Application health checks
-- Resource usage monitoring
-- Log aggregation
-- Uptime monitoring
-
-### Custom Monitoring
-
-```bash
-# View application logs
 coolify app logs app-uuid
-
-# Monitor deployments
 coolify deploy list
-
-# Check server resources
 coolify server get server-uuid --resources
 ```
 
-## API Integration
+API docs: https://coolify.io/docs/api
 
-The helper script integrates with Coolify's REST API for advanced operations:
+## Troubleshooting
 
-- Application lifecycle management
-- Server provisioning and management
-- Database operations
-- Backup management
-- Team and user management
+| Issue | Fix |
+|-------|-----|
+| CLI not found | Re-run install script above |
+| Context issues | `list-contexts` then `add-context` |
+| Local dev fails | Check Node.js/Docker installed; verify `package.json`/`Dockerfile` present; check port availability |
+| Deployment fails | Verify server connectivity; check app logs; validate env vars |
 
-For direct API access, see the [Coolify API documentation](https://coolify.io/docs/api).
+Debug mode: `export DEBUG=1` before any command.
+
+**Security**: Store tokens in env vars or `aidevops secret`. Use context-specific tokens per environment.


### PR DESCRIPTION
## Summary

- Reduced `.agents/tools/deployment/coolify-cli.md` from 388 → 158 lines (59% reduction, well past the ~30% target)
- Removed: duplicate Overview/Local Dev First sections, redundant Docker Support and Multi-Environment examples, duplicate Database Management section, generic Framework Support list, vague Performance Optimization and Monitoring boilerplate, thin API Integration section
- Consolidated: multi-context config JSON merged with project config into one block; database create examples consolidated; troubleshooting converted to table
- Preserved: all commands, all URLs, all code blocks, install script, GitHub Actions CI/CD example, debug mode, security note, API docs link

## Runtime Testing

- Testing level: `self-assessed`
- Risk classification: Low (docs-only change, no code modified)
- Markdown lint: 0 errors (`npx markdownlint-cli2`)

## Files Changed

- `.agents/tools/deployment/coolify-cli.md` — tightened from 388 to 158 lines; all actionable guidance preserved

Closes #11173