### PR TITLE
Fix missing getProducts import in FSD Next.js guide (PR #11437 follow-up)

### DIFF
--- a/.agents/tools/architecture/feature-slicing-skill/nextjs.md
+++ b/.agents/tools/architecture/feature-slicing-skill/nextjs.md
@@ -113,7 +113,7 @@ When a route needs server-side data, the `src/app/` file fetches and passes prop
 ```typescript
 // src/app/products/[id]/page.tsx
 import { ProductDetailPage } from '@/pages/product-detail';
-import { getProductById } from '@/entities/product';
+import { getProductById, getProducts } from '@/entities/product';
 
 export default async function Page({ params }: { params: { id: string } }) {
   const product = await getProductById(params.id);


### PR DESCRIPTION
## Summary

- Add missing `getProducts` import to the App Router code example in `.agents/tools/architecture/feature-slicing-skill/nextjs.md`
- `generateStaticParams()` calls `getProducts()` but only `getProductById` was imported, causing a compile error for users copying the example

## Context

CodeRabbit flagged this as a Major issue in PR #11437 review. The fix was marked as addressed but did not make it into the final squash merge.

## What changed

| File | Change |
|------|--------|
| `.agents/tools/architecture/feature-slicing-skill/nextjs.md:116` | `import { getProductById }` → `import { getProductById, getProducts }` |

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** Low (docs-only, no runtime code)
- **Rationale:** Documentation example fix -- no executable code affected

Ref: PR #11437 CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated product data access layer for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->