### PR TITLE
t11165: tighten code-standards.md 392→271 lines (-31%)

### DIFF
--- a/.agents/tools/code-review/code-standards.md
+++ b/.agents/tools/code-review/code-standards.md
@@ -35,35 +35,23 @@ tools:
 **Validation Commands**:
 
 ```bash
-# Run all local quality checks
-~/.aidevops/agents/scripts/linters-local.sh
-
-# Check specific rules
-grep -L "return [01]" .agents/scripts/*.sh          # S7682
-grep -n '\$[1-9]' .agents/scripts/*.sh | grep -v 'local.*=.*\$[1-9]'  # S7679
-find .agents/scripts/ -name "*.sh" -exec shellcheck {} \;  # ShellCheck
-npx markdownlint-cli2 "**/*.md" --ignore node_modules      # Markdown
-~/.aidevops/agents/scripts/secretlint-helper.sh scan       # Secrets
+~/.aidevops/agents/scripts/linters-local.sh                              # all checks
+grep -L "return [01]" .agents/scripts/*.sh                               # S7682
+grep -n '\$[1-9]' .agents/scripts/*.sh | grep -v 'local.*=.*\$[1-9]'   # S7679
+find .agents/scripts/ -name "*.sh" -exec shellcheck {} \;               # ShellCheck
+npx markdownlint-cli2 "**/*.md" --ignore node_modules                   # Markdown
+~/.aidevops/agents/scripts/secretlint-helper.sh scan                    # Secrets
 ```
 
 **Workflow Position**: Reference during development, validated by `/linters-local`
 
 <!-- AI-CONTEXT-END -->
 
-## Purpose
-
-Authoritative code quality standards for the aidevops framework.
-
-**Related commands**:
-- `/linters-local` — validates these standards locally
-- `/code-audit-remote` — validates via external services
-- `/pr` — orchestrates all checks
-
 ## Critical Standards (Zero Tolerance)
 
 ### S7682 - Return Statements
 
-Every function MUST have an explicit `return 0` or `return 1`.
+Every function MUST end with `return 0` or `return 1`.
 
 ```bash
 # Correct
@@ -72,17 +60,11 @@ function_name() {
     # logic
     return 0
 }
-
-# Violation — missing return
-function_name() {
-    local param="$1"
-    # logic
-}
 ```
 
 ### S7679 - Positional Parameters
 
-Never use positional parameters directly. Always assign to local variables first.
+Always assign positional params to locals first — never use `$1`/`$2` directly.
 
 ```bash
 # Correct
@@ -95,28 +77,15 @@ main() {
     esac
     return 0
 }
-
-# Violation — direct $1/$2 usage
-main() {
-    case "$1" in
-        "list") list_items "$2" ;;
-    esac
-}
 ```
 
 ### S1192 - String Literals
 
-Define constants for strings used 3 or more times.
+Define constants for strings used 3+ times.
 
 ```bash
-# Correct — constants at file top
 readonly ERROR_ACCOUNT_REQUIRED="Account name is required"
-readonly ERROR_CONFIG_NOT_FOUND="Configuration file not found"
-
 print_error "$ERROR_ACCOUNT_REQUIRED"
-
-# Violation — repeated string literals
-print_error "Account name is required"  # repeated 3+ times
 ```
 
 **Validation**:
@@ -132,26 +101,7 @@ done
 
 Only declare variables that are actually used.
 
-```bash
-# Correct
-function_name() {
-    local used_param="$1"
-    echo "$used_param"
-    return 0
-}
-
-# Violation — unused_param declared but never referenced
-function_name() {
-    local used_param="$1"
-    local unused_param="$2"
-    echo "$used_param"
-    return 0
-}
-```
-
 ### ShellCheck Compliance
-
-All shell scripts must pass ShellCheck with zero violations.
 
 ```bash
 find .agents/scripts/ -name "*.sh" -exec shellcheck {} \;
@@ -160,21 +110,16 @@ shellcheck script.sh  # single file
 
 ## Security Hotspots (Acceptable Patterns)
 
-SonarCloud flags these patterns as security hotspots. They are acceptable when properly documented.
+SonarCloud flags these patterns. They are acceptable when documented with `# SONAR:` comments.
 
 ### HTTP String Detection (S5332)
 
-When checking for insecure URLs, not using them:
-
 ```bash
-# Correct — comment documents intent
 # SONAR: Detecting insecure URLs for security audit, not using them
 non_https=$(echo "$data" | jq '[.items[] | select(.url | startswith("http://"))] | length')
 ```
 
 ### Localhost HTTP Output (S5332)
-
-Local development environments often lack SSL:
 
 ```bash
 if [[ "$ssl" == "true" ]]; then
@@ -187,17 +132,12 @@ fi
 
 ### Curl Pipe to Bash (S4423)
 
-For official installers from verified sources:
-
 ```bash
-# Correct — documented official installer
 # SONAR: Official Bun installer from verified HTTPS source
 curl -fsSL https://bun.sh/install | bash
 
-# Better for new/unknown sources — download and inspect first
-curl -fsSL https://example.com/install.sh -o /tmp/install.sh
-less /tmp/install.sh
-bash /tmp/install.sh
+# Better for unknown sources — download and inspect first
+curl -fsSL https://example.com/install.sh -o /tmp/install.sh && less /tmp/install.sh && bash /tmp/install.sh
 ```
 
 **When to suppress vs fix:**
@@ -207,82 +147,29 @@ bash /tmp/install.sh
 
 ## Platform Targets
 
-### SonarCloud
-
-| Metric | Target |
-|--------|--------|
-| Quality Gate | Passed |
-| Bugs | 0 |
-| Vulnerabilities | 0 |
-| Code Smells | <50 |
-| Technical Debt | <400 minutes |
-| Security Rating | A |
-| Reliability Rating | A |
-| Maintainability Rating | A |
-
-### CodeFactor
-
-| Metric | Target |
-|--------|--------|
-| Overall Grade | A |
-| A-grade Files | >85% |
-| Critical Issues | 0 |
-
-### Codacy
-
-| Metric | Target |
-|--------|--------|
-| Grade | A |
-| Security Issues | 0 |
-| Error Prone | 0 |
+| Platform | Metric | Target |
+|----------|--------|--------|
+| SonarCloud | Quality Gate | Passed |
+| SonarCloud | Bugs / Vulnerabilities | 0 |
+| SonarCloud | Code Smells | <50 |
+| SonarCloud | Technical Debt | <400 min |
+| SonarCloud | Security / Reliability / Maintainability | A |
+| CodeFactor | Overall Grade | A |
+| CodeFactor | A-grade Files | >85% |
+| CodeFactor | Critical Issues | 0 |
+| Codacy | Grade | A |
+| Codacy | Security / Error Prone | 0 |
 
 ## Markdown Standards
 
 All markdown files must pass markdownlint with zero violations.
 
-### MD022 - Headings Surrounded by Blank Lines
-
-```markdown
-<!-- Correct -->
-Some content.
-
-### Heading Title
-
-Content after heading.
-
-<!-- Violation — missing blank line after heading -->
-### Heading Title
-Content after heading.
-```
-
-### MD025 - Single Top-Level Heading
-
-Each document should have only ONE H1 (`#`) heading.
-
-### MD012 - No Multiple Blank Lines
-
-Use only single blank lines between elements.
-
-### MD031 - Fenced Code Blocks Surrounded by Blank Lines
-
-Code blocks MUST have blank lines before AND after them.
-
-````markdown
-<!-- Correct -->
-Some text.
-
-```bash
-echo "hello"
-```
-
-More text.
-
-<!-- Violation — missing blank line before code block -->
-Some text.
-```bash
-echo "hello"
-```
-````
+| Rule | Requirement |
+|------|-------------|
+| MD022 | Blank lines before and after headings |
+| MD025 | Single H1 per document |
+| MD012 | No multiple consecutive blank lines |
+| MD031 | Blank lines before and after fenced code blocks |
 
 **Auto-fix**:
 
@@ -301,77 +188,69 @@ npx markdownlint-cli2 "**/*.md" --fix
 
 ## Python Projects
 
-Rules for Python projects using the worktree-based workflow. Workers encounter these regularly — the worktree model creates specific failure modes that differ from single-checkout development.
+Worktree-specific failure modes differ from single-checkout development.
 
 ### Worktrees and Virtual Environments
 
-**Gitignored artifacts do not transfer between worktrees.** `.venv/`, `__pycache__/`, build dirs, and compiled extensions are gitignored and exist only in the directory where they were created. A worker operating in a worktree cannot assume the canonical repo's `.venv/` is usable from that worktree path.
+Gitignored artifacts (`.venv/`, `__pycache__/`, build dirs) exist only where created — they do not transfer between worktrees.
 
 | Situation | Correct action |
 |-----------|----------------|
-| Project has `.venv/` in canonical repo | Create a fresh `.venv/` inside the worktree, or activate the canonical venv by absolute path and do NOT run `pip install -e` from the worktree |
-| Project has `pyproject.toml` but no `.venv/` | Create `.venv/` inside the worktree: `python3 -m venv .venv && pip install -e ".[dev]"` |
-| Verifying that a package installs correctly | Create a throwaway venv inside the worktree — never modify the canonical repo's venv from a worktree context |
+| Project has `.venv/` in canonical repo | Create fresh `.venv/` inside the worktree, or activate canonical venv by absolute path without running `pip install -e` from the worktree |
+| Project has `pyproject.toml` but no `.venv/` | `python3 -m venv .venv && pip install -e ".[dev]"` inside the worktree |
+| Verifying package install | Throwaway venv inside the worktree — never modify canonical repo's venv from a worktree |
 
 ### Editable Installs in Worktrees
 
-**`pip install -e` writes the worktree's absolute path into a `.pth` file.** When the worktree is removed after PR merge, that path no longer exists. Any code that imports the package via the editable install will fail silently.
+`pip install -e` writes the worktree's absolute path into a `.pth` file. When the worktree is removed, that path breaks any code importing via the editable install.
 
 ```bash
-# Unsafe — from inside a worktree, using the canonical repo's venv
-pip install -e shared/project/  # Writes worktree path into canonical venv's .pth
+# Unsafe — writes worktree path into canonical venv's .pth
+pip install -e shared/project/
 
-# Safe — create a throwaway venv inside the worktree
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -e shared/project/  # .pth path is inside the worktree, removed with it
+# Safe — throwaway venv inside the worktree
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e shared/project/
 ```
 
-**Rule**: Never run `pip install -e` from a worktree using a venv that lives outside the worktree.
+**Rule**: Never run `pip install -e` from a worktree using a venv outside the worktree.
 
 ### Installation Scope
 
-**Never install packages to user-local or system scope.** If a project has a `.venv/`, use it. If it doesn't, create one. Never let `pip install` fall through to `~/.local/lib/` or system Python.
+Never install to user-local or system scope. Always use a project `.venv/`.
 
 ```bash
-# Unsafe — no venv active, packages go to ~/.local/lib/python3.x/
+# Unsafe — packages go to ~/.local/lib/python3.x/
 pip install crawl4ai
 
-# Safe — activate venv first
-source .venv/bin/activate
-pip install crawl4ai
-
-# Safe — explicit venv pip
+# Safe
+source .venv/bin/activate && pip install crawl4ai
+# or
 .venv/bin/pip install crawl4ai
 ```
 
-Verify scope before installing: `pip --version` should show a path inside the project's `.venv/`, not `~/.local/` or `/usr/`.
+Verify scope: `pip --version` must show a path inside the project's `.venv/`.
 
 ### Requirements File Discipline
 
-Every Python project must have a reproducible dependency declaration. Workers must not create venvs and install packages without updating the dependency file.
-
 | File | When to use |
 |------|-------------|
-| `pyproject.toml` (preferred) | New projects, PEP 517/518 compliant |
+| `pyproject.toml` (preferred) | New projects, PEP 517/518 |
 | `requirements.txt` | Legacy projects or simple scripts |
 | `requirements-dev.txt` | Dev-only deps (pytest, mypy, ruff) |
 
 After installing any package:
 
 ```bash
-# pyproject.toml projects
-pip install -e ".[dev]"  # installs from declared deps — no manual update needed
-
-# requirements.txt projects
-pip freeze > requirements.txt  # or pin manually — never leave venv unreproducible
+pip install -e ".[dev]"          # pyproject.toml — no manual update needed
+pip freeze > requirements.txt    # requirements.txt — pin manually
 ```
 
-**A venv that cannot be recreated from committed files is a defect.** Workers must not leave venvs in a state where `git clone` + `pip install -r requirements.txt` would produce a different environment.
+**A venv that cannot be recreated from committed files is a defect.**
 
-### Project AGENTS.md / Plan: Development Environment Section
+### Project AGENTS.md — Development Environment Section
 
-When working on a Python project that lacks a "Development Environment" section in its `AGENTS.md` or plan, add one. This prevents the next worker from repeating the same discovery. Minimum content:
+When a Python project lacks a "Development Environment" section, add one:
 
 ```markdown
 ## Development Environment


### PR DESCRIPTION
## Summary

- Reduced `.agents/tools/code-review/code-standards.md` from 392 to 271 lines (−31%)
- Removed redundant prose intros, duplicate violation examples, and verbose section descriptions
- Collapsed three separate platform tables (SonarCloud/CodeFactor/Codacy) into one unified table
- Condensed MD022/MD025/MD012/MD031 markdown rules from prose+examples into a single reference table
- All rule IDs (S7682, S7679, S1192, S1481, S4423, S5332, ShellCheck, MD*), commands, SONAR suppression patterns, decision tables, and Python worktree rules fully preserved

## Runtime Testing

- **Risk**: Low — docs-only change, no code modified
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 271 lines; grep confirms all rule IDs, commands, and decision tables present

Closes #11165