### PR TITLE
t11164: tighten supervisor-module-map.md by ~28%

### DIFF
--- a/.agents/aidevops/supervisor-module-map.md
+++ b/.agents/aidevops/supervisor-module-map.md
@@ -1,319 +1,217 @@
 # Supervisor Module Map
 
-Audit of `supervisor-helper.sh` — 155 functions across 14,644 lines.
-Produced by t311.1. Use this map to guide modularisation (t311).
-
-## Domain Groups
-
-### 1. Core Infrastructure (core)
-
-Foundation utilities used by nearly every other domain.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `log_info` | 236 | Info-level logging |
-| 2 | `log_success` | 237 | Success-level logging |
-| 3 | `log_warn` | 238 | Warning-level logging |
-| 4 | `log_error` | 239 | Error-level logging |
-| 5 | `log_verbose` | 240 | Verbose debug logging |
-| 6 | `log_cmd` | 448 | Log stderr from a command to supervisor log |
-| 7 | `sql_escape` | 1134 | Escape single quotes for SQL |
-| 8 | `db` | 1143 | SQLite wrapper with busy_timeout |
-| 9 | `find_project_root` | 1097 | Find directory containing TODO.md |
-| 10 | `detect_repo_slug` | 1116 | Detect GitHub owner/repo from git remote |
-| 11 | `check_gh_auth` | 398 | Check GitHub CLI authentication |
-| 12 | `get_cpu_cores` | 557 | Get CPU core count |
-| 13 | `show_usage` | 14268 | Show CLI help text |
-| 14 | `main` | 14593 | CLI dispatch entry point |
-
-**Dependants**: Every other domain depends on core.
-
-### 2. Database (database)
-
-Schema management, backup/restore, migration.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `backup_db` | 1152 | Backup supervisor database |
-| 2 | `safe_migrate` | 1190 | Schema migration with backup and rollback |
-| 3 | `restore_db` | 1231 | Restore database from backup |
-| 4 | `ensure_db` | 1280 | Ensure DB directory and file exist |
-| 5 | `init_db` | 1653 | Initialize SQLite schema |
-| 6 | `validate_transition` | 1770 | Validate state machine transitions |
-| 7 | `cmd_init` | 1787 | CLI: `init` |
-| 8 | `cmd_backup` | 1803 | CLI: `backup` |
-| 9 | `cmd_restore` | 1811 | CLI: `restore` |
-| 10 | `cmd_db` | 3361 | CLI: `db` (direct SQLite access) |
-
-**Depends on**: core
-
-### 3. Task Management (task)
-
-CRUD operations for tasks and batches, state transitions, querying.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `cmd_add` | 1819 | CLI: `add` — register a task |
-| 2 | `cmd_batch` | 1938 | CLI: `batch` — create/manage batches |
-| 3 | `cmd_transition` | 2037 | CLI: `transition` — state machine transitions |
-| 4 | `check_batch_completion` | 2345 | Check if all tasks in a batch are done |
-| 5 | `cmd_status` | 2417 | CLI: `status` — show task/batch status |
-| 6 | `cmd_list` | 2624 | CLI: `list` — list tasks with filters |
-| 7 | `cmd_reset` | 2710 | CLI: `reset` — reset task to queued |
-| 8 | `cmd_cancel` | 2780 | CLI: `cancel` — cancel task or batch |
-| 9 | `cmd_next` | 3408 | CLI: `next` — get next dispatchable tasks |
-| 10 | `cmd_running_count` | 3377 | CLI: `running-count` — count active tasks |
-| 11 | `check_task_already_done` | 3190 | Pre-dispatch: verify task not already complete |
-
-**Depends on**: core, database
-
-### 4. Task Claiming (claiming)
-
-Ownership assignment via TODO.md `assignee:` field and GitHub Issue sync.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `get_aidevops_identity` | 2925 | Get identity string for claiming |
-| 2 | `get_task_assignee` | 2957 | Read assignee: from TODO.md task line |
-| 3 | `cmd_claim` | 2986 | CLI: `claim` — claim a task |
-| 4 | `cmd_unclaim` | 3101 | CLI: `unclaim` — release a claimed task |
-| 5 | `check_task_claimed` | 3272 | Check if task is claimed by another agent |
-| 6 | `sync_claim_to_github` | 3319 | Sync claim to GitHub Issue assignee |
-| 7 | `ensure_status_labels` | 2874 | Ensure GitHub status labels exist |
-| 8 | `find_task_issue_number` | 2894 | Find GitHub issue # from TODO.md |
-
-**Depends on**: core, database, todo-sync (commit_and_push_todo)
-
-### 5. Dispatch (dispatch)
-
-Worker dispatch: model resolution, CLI resolution, command building, worktree creation.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `detect_dispatch_mode` | 3445 | Detect terminal environment |
-| 2 | `resolve_ai_cli` | 3468 | Resolve AI CLI tool for dispatch |
-| 3 | `resolve_model` | 3497 | Resolve best model for a tier |
-| 4 | `resolve_model_from_frontmatter` | 3571 | Read model: from subagent YAML |
-| 5 | `classify_task_complexity` | 3630 | Classify task for model routing |
-| 6 | `resolve_task_model` | 3798 | Resolve model for a specific task |
-| 7 | `get_next_tier` | 3905 | Get next higher model tier for escalation |
-| 8 | `check_output_quality` | 3953 | Check worker output quality |
-| 9 | `run_quality_gate` | 4058 | Quality gate with auto-escalation |
-| 10 | `check_model_health` | 4154 | Pre-dispatch model health probe |
-| 11 | `generate_worker_mcp_config` | 4354 | Generate worker MCP config |
-| 12 | `build_dispatch_cmd` | 4404 | Build the full dispatch command |
-| 13 | `create_task_worktree` | 4635 | Create git worktree for a task |
-| 14 | `cmd_dispatch` | 5140 | CLI: `dispatch` — dispatch a single task |
-| 15 | `dispatch_decomposition_worker` | 12903 | Dispatch a #plan decomposition worker |
-
-**Depends on**: core, database, task, claiming
-
-### 6. Worker Lifecycle (lifecycle)
-
-Worker monitoring, evaluation, reprompting, process management.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `cmd_worker_status` | 5538 | CLI: `worker-status` — check worker process |
-| 2 | `extract_log_tail` | 5628 | Extract last N lines from worker log |
-| 3 | `extract_log_metadata` | 5645 | Extract structured outcome from log |
-| 4 | `evaluate_worker` | 6261 | Evaluate worker outcome from logs |
-| 5 | `_meta_get` | 6356 | Helper: extract key=value from metadata |
-| 6 | `evaluate_with_ai` | 6636 | AI-assisted evaluation of ambiguous outcomes |
-| 7 | `cmd_reprompt` | 6726 | CLI: `reprompt` — re-prompt a worker |
-| 8 | `cmd_evaluate` | 7024 | CLI: `evaluate` — manually evaluate a task |
-| 9 | `cleanup_task_worktree` | 4830 | Clean up worktree for completed task |
-| 10 | `cleanup_worker_processes` | 4885 | Kill worker process tree |
-| 11 | `_kill_descendants` | 4924 | Recursively kill descendant processes |
-| 12 | `_list_descendants` | 4943 | List all descendant PIDs |
-| 13 | `cmd_kill_workers` | 4960 | CLI: `kill-workers` — emergency cleanup |
-| 14 | `cmd_cleanup` | 10334 | CLI: `cleanup` — clean completed worktrees |
-
-**Depends on**: core, database, dispatch (resolve_ai_cli, resolve_model)
-
-### 7. PR Management (pr)
-
-PR discovery, linking, status checking, review triage, merge, rebase.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `validate_pr_belongs_to_task` | 5790 | Validate PR title/branch matches task |
-| 2 | `parse_pr_url` | 5860 | Parse PR URL into slug + number |
-| 3 | `discover_pr_by_branch` | 5900 | Find PR via branch name lookup |
-| 4 | `auto_create_pr_for_task` | 5963 | Auto-create PR for orphaned branch |
-| 5 | `link_pr_to_task` | 6086 | Link PR to task (single source of truth) |
-| 6 | `check_review_threads` | 7091 | Fetch unresolved review threads (GraphQL) |
-| 7 | `triage_review_feedback` | 7179 | Triage review feedback by severity |
-| 8 | `dispatch_review_fix_worker` | 7262 | Dispatch worker to fix review feedback |
-| 9 | `dismiss_bot_reviews` | 7492 | Dismiss blocking bot reviews |
-| 10 | `check_pr_status` | 7550 | Check PR CI and review status |
-| 11 | `scan_orphaned_prs` | 7785 | Scan for PRs supervisor missed |
-| 12 | `scan_orphaned_pr_for_task` | 7936 | Eager orphan PR scan for one task |
-| 13 | `cmd_pr_check` | 8019 | CLI: `pr-check` |
-| 14 | `get_sibling_tasks` | 8062 | Get sibling subtasks |
-| 15 | `rebase_sibling_pr` | 8105 | Rebase a sibling PR onto main |
-| 16 | `rebase_sibling_prs_after_merge` | 8198 | Rebase all sibling PRs after merge |
-| 17 | `merge_task_pr` | 8252 | Squash-merge a task's PR |
-| 18 | `cmd_pr_merge` | 8357 | CLI: `pr-merge` |
-| 19 | `run_postflight_for_task` | 8395 | Run postflight checks after merge |
-| 20 | `run_deploy_for_task` | 8424 | Run deploy for aidevops repos |
-| 21 | `cleanup_after_merge` | 8538 | Clean up worktree after merge |
-| 22 | `record_lifecycle_timing` | 8608 | Record PR lifecycle timing metrics |
-| 23 | `cmd_pr_lifecycle` | 8664 | CLI: `pr-lifecycle` — full post-PR lifecycle |
-| 24 | `extract_parent_id` | 9278 | Extract parent from subtask ID |
-| 25 | `process_post_pr_lifecycle` | 9299 | Process post-PR lifecycle for all eligible |
-
-**Depends on**: core, database, task, dispatch (for review-fix workers), lifecycle (cleanup)
-
-### 8. Pulse Orchestration (pulse)
-
-The central autonomous loop that drives all other domains.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `acquire_pulse_lock` | 481 | Acquire exclusive pulse lock |
-| 2 | `release_pulse_lock` | 542 | Release pulse lock |
-| 3 | `check_system_load` | 587 | Check CPU/memory/load pressure |
-| 4 | `calculate_adaptive_concurrency` | 1037 | Dynamic worker count from load |
-| 5 | `cmd_pulse` | 9390 | CLI: `pulse` — the main orchestration loop |
-| 6 | `cmd_auto_pickup` | 13100 | CLI: `auto-pickup` — scan TODO.md for tasks |
-| 7 | `cmd_cron` | 13356 | CLI: `cron` — manage cron scheduling |
-| 8 | `cmd_watch` | 13473 | CLI: `watch` — fswatch TODO.md |
-
-**Depends on**: ALL other domains. `cmd_pulse` calls 42 functions across every domain.
-
-### 9. TODO Sync (todo-sync)
-
-Synchronising task state with TODO.md and GitHub Issues.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `create_github_issue` | 10448 | Create GitHub issue for a task |
-| 2 | `commit_and_push_todo` | 10535 | Commit and push TODO.md with retry |
-| 3 | `verify_task_deliverables` | 10597 | Verify task has real deliverables |
-| 4 | `update_todo_on_complete` | 11192 | Mark task done in TODO.md |
-| 5 | `post_blocked_comment_to_github` | 11526 | Post blocked comment to GH issue |
-| 6 | `update_todo_on_blocked` | 11603 | Update TODO.md for blocked/failed task |
-| 7 | `cmd_update_todo` | 12710 | CLI: `update-todo` |
-| 8 | `cmd_reconcile_todo` | 12764 | CLI: `reconcile-todo` — bulk fix stale entries |
-
-**Depends on**: core, database, pr (for deliverable verification)
-
-### 10. Verification (verify)
-
-Post-merge verification via VERIFY.md queue.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `populate_verify_queue` | 10701 | Populate VERIFY.md after PR merge |
-| 2 | `run_verify_checks` | 10852 | Run verification checks for a task |
-| 3 | `mark_verify_entry` | 11011 | Mark verify entry passed/failed |
-| 4 | `process_verify_queue` | 11037 | Process verification queue (t180.3) |
-| 5 | `cmd_verify` | 11103 | CLI: `verify` |
-| 6 | `commit_verify_changes` | 11164 | Commit and push VERIFY.md |
-| 7 | `generate_verify_entry` | 11305 | Generate VERIFY.md entry for a task |
-| 8 | `process_verify_queue` | 11440 | Process pending verifications (t180.4, shadows t180.3) |
-
-**Note**: `process_verify_queue` is defined twice (lines 11037 and 11440). The second definition shadows the first at runtime. This is a bug — the t180.4 version at line 11440 is the active one.
-
-**Depends on**: core, database, todo-sync (commit_and_push_todo), pr (parse_pr_url)
-
-### 11. Recovery & Self-Healing (recovery)
-
-Diagnostic subtask creation, self-healing for failed tasks.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `is_self_heal_eligible` | 12017 | Check if task qualifies for self-heal |
-| 2 | `create_diagnostic_subtask` | 12066 | Create diagnostic subtask in DB |
-| 3 | `attempt_self_heal` | 12166 | Attempt self-heal for failed task |
-| 4 | `handle_diagnostic_completion` | 12202 | Re-queue parent after diagnostic completes |
-| 5 | `cmd_self_heal` | 12248 | CLI: `self-heal` |
-
-**Depends on**: core, database, task (cmd_reset)
-
-### 12. Release & Retrospective (release)
-
-Batch release triggering, retrospectives, session review.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `trigger_batch_release` | 2198 | Trigger release via version-manager.sh |
-| 2 | `run_batch_retrospective` | 12306 | Run retrospective after batch completion |
-| 3 | `run_session_review` | 12426 | Session review and distillation |
-| 4 | `cmd_release` | 12520 | CLI: `release` |
-| 5 | `cmd_retrospective` | 12640 | CLI: `retrospective` |
-
-**Depends on**: core, database, task (check_batch_completion triggers release)
-
-### 13. Memory & Patterns (memory)
-
-Cross-session memory recall and pattern tracking.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `recall_task_memories` | 11788 | Recall relevant memories before dispatch |
-| 2 | `store_failure_pattern` | 11838 | Store failure pattern after evaluation |
-| 3 | `store_success_pattern` | 11926 | Store success pattern after completion |
-| 4 | `cmd_recall` | 12670 | CLI: `recall` |
-
-**Depends on**: core, database
-
-### 14. Notifications (notify)
-
-macOS notifications and inter-agent mail.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `send_task_notification` | 11672 | Send notification about state change |
-| 2 | `notify_batch_progress` | 11751 | macOS notification for batch milestones |
-| 3 | `cmd_notify` | 12858 | CLI: `notify` |
-
-**Depends on**: core, database
-
-### 15. Proof Log & Audit (audit)
-
-Structured audit trail for task lifecycle.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `write_proof_log` | 269 | Write structured proof-log entry |
-| 2 | `_proof_log_stage_duration` | 346 | Calculate stage duration |
-| 3 | `cmd_proof_log` | 14052 | CLI: `proof-log` — query/export proof-logs |
-
-**Depends on**: core, database
-
-### 16. System Resources (system)
-
-Memory monitoring, respawn management, system load.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `get_process_footprint_mb` | 721 | Get physical memory footprint |
-| 2 | `check_supervisor_memory` | 802 | Check if supervisor should respawn |
-| 3 | `log_respawn_event` | 869 | Log respawn to persistent history |
-| 4 | `attempt_respawn_after_batch` | 898 | Check/trigger respawn after batch wave |
-| 5 | `cmd_respawn_history` | 989 | CLI: `respawn-history` |
-| 6 | `cmd_mem_check` | 5056 | CLI: `mem-check` |
-
-**Depends on**: core, database
-
-### 17. Dashboard (dashboard)
-
-Terminal UI for monitoring.
-
-| # | Function | Line | Description |
-|---|----------|------|-------------|
-| 1 | `cmd_dashboard` | 13531 | CLI: `dashboard` — live TUI |
-| 2 | `_dashboard_cleanup` | 13562 | Cleanup on exit (nested) |
-| 3 | `_fmt_elapsed` | 13582 | Format elapsed time (nested) |
-| 4 | `_render_bar` | 13597 | Render progress bar (nested) |
-| 5 | `_status_color` | 13617 | Status colour code (nested) |
-| 6 | `_status_icon` | 13633 | Status icon (nested) |
-| 7 | `_trunc` | 13659 | Truncate string (nested) |
-| 8 | `_render_frame` | 13669 | Render one dashboard frame (nested) |
-
-**Depends on**: core, database, system (check_system_load)
+Audit of `supervisor-helper.sh` — 155 functions, 14,644 lines. Produced by t311.1 to guide modularisation (t311).
+
+### 1. Core Infrastructure (core) — dependant: every domain
+| Function | Line | Description |
+|----------|------|-------------|
+| `log_info` | 236 | Info-level logging |
+| `log_success` | 237 | Success-level logging |
+| `log_warn` | 238 | Warning-level logging |
+| `log_error` | 239 | Error-level logging |
+| `log_verbose` | 240 | Verbose debug logging |
+| `log_cmd` | 448 | Log stderr from a command to supervisor log |
+| `sql_escape` | 1134 | Escape single quotes for SQL |
+| `db` | 1143 | SQLite wrapper with busy_timeout |
+| `find_project_root` | 1097 | Find directory containing TODO.md |
+| `detect_repo_slug` | 1116 | Detect GitHub owner/repo from git remote |
+| `check_gh_auth` | 398 | Check GitHub CLI authentication |
+| `get_cpu_cores` | 557 | Get CPU core count |
+| `show_usage` | 14268 | Show CLI help text |
+| `main` | 14593 | CLI dispatch entry point |
+### 2. Database (database) — depends on: core
+| Function | Line | Description |
+|----------|------|-------------|
+| `backup_db` | 1152 | Backup supervisor database |
+| `safe_migrate` | 1190 | Schema migration with backup and rollback |
+| `restore_db` | 1231 | Restore database from backup |
+| `ensure_db` | 1280 | Ensure DB directory and file exist |
+| `init_db` | 1653 | Initialize SQLite schema |
+| `validate_transition` | 1770 | Validate state machine transitions |
+| `cmd_init` | 1787 | CLI: `init` |
+| `cmd_backup` | 1803 | CLI: `backup` |
+| `cmd_restore` | 1811 | CLI: `restore` |
+| `cmd_db` | 3361 | CLI: `db` (direct SQLite access) |
+### 3. Task Management (task) — depends on: core, database
+| Function | Line | Description |
+|----------|------|-------------|
+| `cmd_add` | 1819 | CLI: `add` — register a task |
+| `cmd_batch` | 1938 | CLI: `batch` — create/manage batches |
+| `cmd_transition` | 2037 | CLI: `transition` — state machine transitions |
+| `check_batch_completion` | 2345 | Check if all tasks in a batch are done |
+| `cmd_status` | 2417 | CLI: `status` — show task/batch status |
+| `cmd_list` | 2624 | CLI: `list` — list tasks with filters |
+| `cmd_reset` | 2710 | CLI: `reset` — reset task to queued |
+| `cmd_cancel` | 2780 | CLI: `cancel` — cancel task or batch |
+| `cmd_next` | 3408 | CLI: `next` — get next dispatchable tasks |
+| `cmd_running_count` | 3377 | CLI: `running-count` — count active tasks |
+| `check_task_already_done` | 3190 | Pre-dispatch: verify task not already complete |
+### 4. Task Claiming (claiming) — depends on: core, database, todo-sync
+| Function | Line | Description |
+|----------|------|-------------|
+| `get_aidevops_identity` | 2925 | Get identity string for claiming |
+| `get_task_assignee` | 2957 | Read assignee: from TODO.md task line |
+| `cmd_claim` | 2986 | CLI: `claim` — claim a task |
+| `cmd_unclaim` | 3101 | CLI: `unclaim` — release a claimed task |
+| `check_task_claimed` | 3272 | Check if task is claimed by another agent |
+| `sync_claim_to_github` | 3319 | Sync claim to GitHub Issue assignee |
+| `ensure_status_labels` | 2874 | Ensure GitHub status labels exist |
+| `find_task_issue_number` | 2894 | Find GitHub issue # from TODO.md |
+### 5. Dispatch (dispatch) — depends on: core, database, task, claiming
+| Function | Line | Description |
+|----------|------|-------------|
+| `detect_dispatch_mode` | 3445 | Detect terminal environment |
+| `resolve_ai_cli` | 3468 | Resolve AI CLI tool for dispatch |
+| `resolve_model` | 3497 | Resolve best model for a tier |
+| `resolve_model_from_frontmatter` | 3571 | Read model: from subagent YAML |
+| `classify_task_complexity` | 3630 | Classify task for model routing |
+| `resolve_task_model` | 3798 | Resolve model for a specific task |
+| `get_next_tier` | 3905 | Get next higher model tier for escalation |
+| `check_output_quality` | 3953 | Check worker output quality |
+| `run_quality_gate` | 4058 | Quality gate with auto-escalation |
+| `check_model_health` | 4154 | Pre-dispatch model health probe |
+| `generate_worker_mcp_config` | 4354 | Generate worker MCP config |
+| `build_dispatch_cmd` | 4404 | Build the full dispatch command |
+| `create_task_worktree` | 4635 | Create git worktree for a task |
+| `cmd_dispatch` | 5140 | CLI: `dispatch` — dispatch a single task |
+| `dispatch_decomposition_worker` | 12903 | Dispatch a #plan decomposition worker |
+### 6. Worker Lifecycle (lifecycle) — depends on: core, database, dispatch
+| Function | Line | Description |
+|----------|------|-------------|
+| `cmd_worker_status` | 5538 | CLI: `worker-status` — check worker process |
+| `extract_log_tail` | 5628 | Extract last N lines from worker log |
+| `extract_log_metadata` | 5645 | Extract structured outcome from log |
+| `evaluate_worker` | 6261 | Evaluate worker outcome from logs |
+| `_meta_get` | 6356 | Helper: extract key=value from metadata (nested) |
+| `evaluate_with_ai` | 6636 | AI-assisted evaluation of ambiguous outcomes |
+| `cmd_reprompt` | 6726 | CLI: `reprompt` — re-prompt a worker |
+| `cmd_evaluate` | 7024 | CLI: `evaluate` — manually evaluate a task |
+| `cleanup_task_worktree` | 4830 | Clean up worktree for completed task |
+| `cleanup_worker_processes` | 4885 | Kill worker process tree |
+| `_kill_descendants` | 4924 | Recursively kill descendant processes |
+| `_list_descendants` | 4943 | List all descendant PIDs |
+| `cmd_kill_workers` | 4960 | CLI: `kill-workers` — emergency cleanup |
+| `cmd_cleanup` | 10334 | CLI: `cleanup` — clean completed worktrees |
+### 7. PR Management (pr) — depends on: core, database, task, dispatch, lifecycle
+| Function | Line | Description |
+|----------|------|-------------|
+| `validate_pr_belongs_to_task` | 5790 | Validate PR title/branch matches task |
+| `parse_pr_url` | 5860 | Parse PR URL into slug + number |
+| `discover_pr_by_branch` | 5900 | Find PR via branch name lookup |
+| `auto_create_pr_for_task` | 5963 | Auto-create PR for orphaned branch |
+| `link_pr_to_task` | 6086 | Link PR to task (single source of truth) |
+| `check_review_threads` | 7091 | Fetch unresolved review threads (GraphQL) |
+| `triage_review_feedback` | 7179 | Triage review feedback by severity |
+| `dispatch_review_fix_worker` | 7262 | Dispatch worker to fix review feedback |
+| `dismiss_bot_reviews` | 7492 | Dismiss blocking bot reviews |
+| `check_pr_status` | 7550 | Check PR CI and review status |
+| `scan_orphaned_prs` | 7785 | Scan for PRs supervisor missed |
+| `scan_orphaned_pr_for_task` | 7936 | Eager orphan PR scan for one task |
+| `cmd_pr_check` | 8019 | CLI: `pr-check` |
+| `get_sibling_tasks` | 8062 | Get sibling subtasks |
+| `rebase_sibling_pr` | 8105 | Rebase a sibling PR onto main |
+| `rebase_sibling_prs_after_merge` | 8198 | Rebase all sibling PRs after merge |
+| `merge_task_pr` | 8252 | Squash-merge a task's PR |
+| `cmd_pr_merge` | 8357 | CLI: `pr-merge` |
+| `run_postflight_for_task` | 8395 | Run postflight checks after merge |
+| `run_deploy_for_task` | 8424 | Run deploy for aidevops repos |
+| `cleanup_after_merge` | 8538 | Clean up worktree after merge |
+| `record_lifecycle_timing` | 8608 | Record PR lifecycle timing metrics |
+| `cmd_pr_lifecycle` | 8664 | CLI: `pr-lifecycle` — full post-PR lifecycle |
+| `extract_parent_id` | 9278 | Extract parent from subtask ID |
+| `process_post_pr_lifecycle` | 9299 | Process post-PR lifecycle for all eligible |
+### 8. Pulse Orchestration (pulse) — depends on: ALL domains
+| Function | Line | Description |
+|----------|------|-------------|
+| `acquire_pulse_lock` | 481 | Acquire exclusive pulse lock |
+| `release_pulse_lock` | 542 | Release pulse lock |
+| `check_system_load` | 587 | Check CPU/memory/load pressure |
+| `calculate_adaptive_concurrency` | 1037 | Dynamic worker count from load |
+| `cmd_pulse` | 9390 | CLI: `pulse` — the main orchestration loop |
+| `cmd_auto_pickup` | 13100 | CLI: `auto-pickup` — scan TODO.md for tasks |
+| `cmd_cron` | 13356 | CLI: `cron` — manage cron scheduling |
+| `cmd_watch` | 13473 | CLI: `watch` — fswatch TODO.md |
+
+`cmd_pulse` calls 42 functions across all 17 domains.
+### 9. TODO Sync (todo-sync) — depends on: core, database, pr
+| Function | Line | Description |
+|----------|------|-------------|
+| `create_github_issue` | 10448 | Create GitHub issue for a task |
+| `commit_and_push_todo` | 10535 | Commit and push TODO.md with retry |
+| `verify_task_deliverables` | 10597 | Verify task has real deliverables |
+| `update_todo_on_complete` | 11192 | Mark task done in TODO.md |
+| `post_blocked_comment_to_github` | 11526 | Post blocked comment to GH issue |
+| `update_todo_on_blocked` | 11603 | Update TODO.md for blocked/failed task |
+| `cmd_update_todo` | 12710 | CLI: `update-todo` |
+| `cmd_reconcile_todo` | 12764 | CLI: `reconcile-todo` — bulk fix stale entries |
+### 10. Verification (verify) — depends on: core, database, todo-sync, pr
+| Function | Line | Description |
+|----------|------|-------------|
+| `populate_verify_queue` | 10701 | Populate VERIFY.md after PR merge |
+| `run_verify_checks` | 10852 | Run verification checks for a task |
+| `mark_verify_entry` | 11011 | Mark verify entry passed/failed |
+| `process_verify_queue` | 11037 | Process verification queue (t180.3) |
+| `cmd_verify` | 11103 | CLI: `verify` |
+| `commit_verify_changes` | 11164 | Commit and push VERIFY.md |
+| `generate_verify_entry` | 11305 | Generate VERIFY.md entry for a task |
+| `process_verify_queue` | 11440 | Process pending verifications (t180.4 — active, shadows t180.3) |
+
+**Bug**: `process_verify_queue` defined twice (lines 11037 and 11440). Deduplicate before splitting — keep t180.4 version.
+### 11. Recovery & Self-Healing (recovery) — depends on: core, database, task
+| Function | Line | Description |
+|----------|------|-------------|
+| `is_self_heal_eligible` | 12017 | Check if task qualifies for self-heal |
+| `create_diagnostic_subtask` | 12066 | Create diagnostic subtask in DB |
+| `attempt_self_heal` | 12166 | Attempt self-heal for failed task |
+| `handle_diagnostic_completion` | 12202 | Re-queue parent after diagnostic completes |
+| `cmd_self_heal` | 12248 | CLI: `self-heal` |
+### 12. Release & Retrospective (release) — depends on: core, database, task
+| Function | Line | Description |
+|----------|------|-------------|
+| `trigger_batch_release` | 2198 | Trigger release via version-manager.sh |
+| `run_batch_retrospective` | 12306 | Run retrospective after batch completion |
+| `run_session_review` | 12426 | Session review and distillation |
+| `cmd_release` | 12520 | CLI: `release` |
+| `cmd_retrospective` | 12640 | CLI: `retrospective` |
+### 13. Memory & Patterns (memory) — depends on: core, database
+| Function | Line | Description |
+|----------|------|-------------|
+| `recall_task_memories` | 11788 | Recall relevant memories before dispatch |
+| `store_failure_pattern` | 11838 | Store failure pattern after evaluation |
+| `store_success_pattern` | 11926 | Store success pattern after completion |
+| `cmd_recall` | 12670 | CLI: `recall` |
+### 14. Notifications (notify) — depends on: core, database
+| Function | Line | Description |
+|----------|------|-------------|
+| `send_task_notification` | 11672 | Send notification about state change |
+| `notify_batch_progress` | 11751 | macOS notification for batch milestones |
+| `cmd_notify` | 12858 | CLI: `notify` |
+### 15. Proof Log & Audit (audit) — depends on: core, database
+| Function | Line | Description |
+|----------|------|-------------|
+| `write_proof_log` | 269 | Write structured proof-log entry |
+| `_proof_log_stage_duration` | 346 | Calculate stage duration |
+| `cmd_proof_log` | 14052 | CLI: `proof-log` — query/export proof-logs |
+### 16. System Resources (system) — depends on: core, database
+| Function | Line | Description |
+|----------|------|-------------|
+| `get_process_footprint_mb` | 721 | Get physical memory footprint |
+| `check_supervisor_memory` | 802 | Check if supervisor should respawn |
+| `log_respawn_event` | 869 | Log respawn to persistent history |
+| `attempt_respawn_after_batch` | 898 | Check/trigger respawn after batch wave |
+| `cmd_respawn_history` | 989 | CLI: `respawn-history` |
+| `cmd_mem_check` | 5056 | CLI: `mem-check` |
+### 17. Dashboard (dashboard) — depends on: core, database, system
+| Function | Line | Description |
+|----------|------|-------------|
+| `cmd_dashboard` | 13531 | CLI: `dashboard` — live TUI |
+| `_dashboard_cleanup` | 13562 | Cleanup on exit (nested) |
+| `_fmt_elapsed` | 13582 | Format elapsed time (nested) |
+| `_render_bar` | 13597 | Render progress bar (nested) |
+| `_status_color` | 13617 | Status colour code (nested) |
+| `_status_icon` | 13633 | Status icon (nested) |
+| `_trunc` | 13659 | Truncate string (nested) |
+| `_render_frame` | 13669 | Render one dashboard frame (nested) |
 
 ## Cross-Domain Dependency Matrix
 
@@ -339,9 +237,7 @@ Rows depend on columns. `X` = direct function calls exist between domains.
 | **system** | X | X | | | | | | | | | | | | | | - | |
 | **dashboard** | X | X | | | | | | | | | | | | | | X | - |
 
-## Module Assignment Table
-
-Proposed file names for modularisation. Each module is a sourceable shell library.
+## Module Assignment
 
 | Module File | Domain | Functions | Lines (est.) | CLI Commands |
 |-------------|--------|-----------|-------------|--------------|
@@ -366,21 +262,15 @@ Proposed file names for modularisation. Each module is a sourceable shell librar
 
 ## Key Observations
 
-1. **`cmd_pulse` is the god function** — 943 lines, calls 42 internal functions across all 17 domains. It is the primary candidate for decomposition into phase-based sub-functions.
+1. **`cmd_pulse` is the god function** — 943 lines, calls 42 functions across all 17 domains. Primary candidate for decomposition into phase-based sub-functions.
+2. **`cmd_pr_lifecycle` is the second-largest orchestrator** — 613 lines, 27 internal calls.
+3. **Duplicate `process_verify_queue`** — defined at lines 11037 (t180.3) and 11440 (t180.4). Second shadows first. Deduplicate before splitting.
+4. **Recursive `main()` re-entry** — 11 functions call `main()` to re-invoke CLI commands. Replace with direct function calls during modularisation.
+5. **Core utilities called everywhere** — `db` (77 callers), `sql_escape` (67), `log_info` (64), `log_warn` (55), `ensure_db` (54), `log_error` (52). Must be sourced first.
+6. **`cmd_transition` serves dual purpose** — called from CLI and by 11 other functions; the state machine backbone.
+7. **Nested functions** — `_meta_get` inside `evaluate_worker`; 7 `_dashboard_*` inside `cmd_dashboard`. Stay with parent modules.
+8. **Source order** — core → database → task → claiming → dispatch → lifecycle → pr → todo-sync → verify → recovery → release → memory → notify → audit → system → dashboard → pulse (last).
 
-2. **`cmd_pr_lifecycle` is the second-largest orchestrator** — 613 lines, 27 internal calls. Manages the complete PR lifecycle from status check through merge, deploy, and postflight.
-
-3. **Duplicate function**: `process_verify_queue` is defined at both line 11037 (t180.3) and line 11440 (t180.4). The second shadows the first. Should be deduplicated.
-
-4. **Recursive `main()` re-entry**: 11 functions call `main()` to re-invoke CLI commands. This pattern creates tight coupling — modularisation should replace these with direct function calls.
-
-5. **Core utilities are called everywhere**: `db` (77 callers), `sql_escape` (67), `log_info` (64), `log_warn` (55), `ensure_db` (54), `log_error` (52). These must be in a shared core module sourced first.
-
-6. **`cmd_transition` serves dual purpose**: Called from CLI and by 11 other functions. It is the state machine backbone — any module that changes task state depends on it.
-
-7. **Nested functions**: `_meta_get` inside `evaluate_worker`, and 7 `_dashboard_*` functions inside `cmd_dashboard`. These stay with their parent modules.
-
-8. **Source order matters**: Modules must be sourced in dependency order: core -> database -> task -> claiming -> dispatch -> lifecycle -> pr -> todo-sync -> verify -> recovery -> release -> memory -> notify -> audit -> system -> dashboard -> pulse (last, since it depends on everything).
 
 ## Modularisation Risk Assessment
 


### PR DESCRIPTION
## Summary

- Reduced `.agents/aidevops/supervisor-module-map.md` from 393 to 283 lines (-28%)
- Removed redundant prose intro sentences from each domain section
- Merged `**Depends on**` dependency info into section headings (e.g. `### 2. Database (database) — depends on: core`)
- Removed `## Domain Groups` wrapper heading
- Dropped `#` index column from all 17 function tables
- Removed blank lines between section headings and their tables
- Condensed Key Observations to remove verbose phrasing
- Condensed duplicate-function note in section 10 to a single **Bug** line

All commands, function names, line numbers, CLI commands, dependency rules, cross-domain matrix, module assignment table, and risk assessment preserved intact.

Closes #11164