### PR TITLE
GH#11422: Tighten Audio/Video Transcription doc

### DIFF
--- a/.agents/tools/voice/transcription.md
+++ b/.agents/tools/voice/transcription.md
@@ -87,6 +87,7 @@ Desktop Whisper wrapper. No cloud/API key. Audio: MP3/WAV/FLAC/OGG/M4A/WMA. Vide
 
 ```bash
 brew install --cask buzz                                         # GUI: File → Open → Transcribe → Export
+pip install buzz-captions                                        # CLI package
 buzz transcribe audio.mp3 --model medium --output-format srt     # CLI
 buzz transcribe foreign.mp3 --task translate --language auto
 buzz transcribe audio.mp3 --model-type faster-whisper --model large-v3
@@ -137,6 +138,7 @@ for word in alt.words: print(f"[Speaker {word.speaker}] {word.word}")
 
 ```python
 from deepgram import DeepgramClient, LiveTranscriptionEvents, LiveOptions
+import os
 dg = DeepgramClient(os.environ["DEEPGRAM_API_KEY"])
 conn = dg.listen.asyncwebsocket.v("1")
 conn.on(LiveTranscriptionEvents.Transcript, lambda r, **kw: print(r.channel.alternatives[0].transcript) or None)

--- a/.agents/tools/voice/transcription.md
+++ b/.agents/tools/voice/transcription.md
@@ -18,7 +18,7 @@ tools:
 
 ```bash
 transcription-helper.sh transcribe "https://youtu.be/VIDEO_ID"  # YouTube
-transcription-helper.sh transcribe recording.mp3 --model large-v3-turbo
+transcription-helper.sh transcribe recording.mp3 --model large-v3-turbo  # helper model name; native whisper uses --model turbo
 brew install yt-dlp ffmpeg && brew install --cask buzz           # macOS deps
 pip install openai-whisper faster-whisper assemblyai deepgram-sdk
 ```
@@ -37,7 +37,7 @@ pip install openai-whisper faster-whisper assemblyai deepgram-sdk
 | **Streaming** | No | No | Yes | Yes |
 | **Best for** | Private/offline | macOS GUI | Speaker ID, meetings | Real-time |
 
-**Decision flow**: Privacy/offline → Whisper/Buzz. Speaker diarization → AssemblyAI/Deepgram. Real-time → Deepgram. Highest accuracy → AssemblyAI U3 Pro. Free → Whisper turbo.
+**Decision flow**: Privacy/offline → Whisper/Buzz. Speaker diarization → AssemblyAI/Deepgram. Real-time → Deepgram. Highest accuracy (primary) → AssemblyAI U3 Pro; (extended) → ElevenLabs Scribe v2. Free → Whisper turbo.
 
 **Input sources**: YouTube (`yt-dlp -x --audio-format wav`), URL (`curl` + `ffmpeg`), local audio (`.wav .mp3 .flac .ogg .m4a`), local video (`ffmpeg -i input -vn -acodec pcm_s16le output.wav`).
 

--- a/.agents/tools/voice/transcription.md
+++ b/.agents/tools/voice/transcription.md
@@ -18,7 +18,6 @@ tools:
 
 ```bash
 transcription-helper.sh transcribe "https://youtu.be/VIDEO_ID"  # YouTube
-transcription-helper.sh transcribe recording.mp3                # Local file
 transcription-helper.sh transcribe recording.mp3 --model large-v3-turbo
 brew install yt-dlp ffmpeg && brew install --cask buzz           # macOS deps
 pip install openai-whisper faster-whisper assemblyai deepgram-sdk
@@ -31,55 +30,52 @@ pip install openai-whisper faster-whisper assemblyai deepgram-sdk
 | Criterion | Whisper (local) | Buzz (GUI) | AssemblyAI | Deepgram |
 |-----------|----------------|------------|------------|----------|
 | **Privacy** | Full (offline) | Full (offline) | Cloud | Cloud |
-| **Cost** | Free | Free | $0.15/hr (U2) – $0.45/hr (U3 Pro) | $0.0077/min (Nova-3) |
-| **Setup** | pip + ffmpeg | brew install | API key only | API key only |
-| **Accuracy** | 9.0–9.8 | 9.0–9.8 | 9.6 (U2) | 9.5 (Nova-3) |
-| **Speaker diarization** | No | No | Yes | Yes |
-| **Real-time streaming** | No | No | Yes (WebSocket) | Yes (WebSocket) |
-| **Best for** | Private/offline, long files | macOS GUI users | Speaker ID, meetings | Real-time, low latency |
+| **Cost** | Free | Free | $0.15-$0.45/hr | $0.0077/min |
+| **Setup** | pip + ffmpeg | brew install | API key | API key |
+| **Accuracy** | 9.0-9.8 | 9.0-9.8 | 9.6 | 9.5 |
+| **Diarization** | No | No | Yes | Yes |
+| **Streaming** | No | No | Yes | Yes |
+| **Best for** | Private/offline | macOS GUI | Speaker ID, meetings | Real-time |
 
-**Decision flow**: (1) Privacy/offline → Whisper or Buzz. (2) Speaker diarization → AssemblyAI or Deepgram. (3) Real-time → Deepgram. (4) Highest accuracy, cloud OK → AssemblyAI Universal-3 Pro. (5) Free, good enough → Whisper turbo locally.
+**Decision flow**: Privacy/offline → Whisper/Buzz. Speaker diarization → AssemblyAI/Deepgram. Real-time → Deepgram. Highest accuracy → AssemblyAI U3 Pro. Free → Whisper turbo.
 
-**Input sources**: YouTube (`yt-dlp -x --audio-format wav`), direct URL (`curl` + `ffmpeg`), local audio (`.wav .mp3 .flac .ogg .m4a`), local video (`ffmpeg -i input -vn -acodec pcm_s16le output.wav`).
+**Input sources**: YouTube (`yt-dlp -x --audio-format wav`), URL (`curl` + `ffmpeg`), local audio (`.wav .mp3 .flac .ogg .m4a`), local video (`ffmpeg -i input -vn -acodec pcm_s16le output.wav`).
 
-## Whisper (Local — OpenAI Original)
+## Whisper (Local)
 
-`faster-whisper` (CTranslate2-based) is 2–4x faster with comparable accuracy.
+`faster-whisper` (CTranslate2) is 2-4x faster with comparable accuracy.
 
 ```bash
-whisper audio.mp3 --model medium --language en
-whisper audio.mp3 --model medium --output_format srt      # SRT subtitles
-whisper audio.mp3 --model medium --output_format json     # word-level timestamps
-whisper french-audio.mp3 --task translate --model medium  # translate to English
+whisper audio.mp3 --model medium --language en                   # basic
+whisper audio.mp3 --model medium --output_format srt             # subtitles
+whisper audio.mp3 --model medium --output_format json            # word timestamps
+whisper foreign.mp3 --task translate --model medium              # translate to English
+for f in recordings/*.mp3; do whisper "$f" --model medium --output_format txt --output_dir transcripts/; done
 ```
 
-### Model Selection
+### Models
 
 | Model | Size | Speed | Accuracy | Use case |
 |-------|------|-------|----------|----------|
-| `tiny` | 75MB | Fastest | 6.0/10 | Draft/preview only |
-| `base` | 142MB | Fast | 7.3/10 | Quick transcription |
+| `tiny`/`base` | 75-142MB | Fastest | 6-7/10 | Draft/preview |
 | `small` | 461MB | Medium | 8.5/10 | Good balance, multilingual |
-| `medium` | 1.5GB | Slow | 9.0/10 | Recommended default |
-| `large-v3` | 2.9GB | Slowest | 9.8/10 | Best quality, best multilingual |
-| **`turbo`** | **1.5GB** | **Fast** | **9.7/10** | **Large-v3 quality at medium speed** |
-| NVIDIA Parakeet V2 | 474MB | Fastest | 9.4/10 | English-only |
+| `medium` | 1.5GB | Slow | 9.0/10 | **Recommended default** |
+| `large-v3` | 2.9GB | Slowest | 9.8/10 | Best quality/multilingual |
+| **`turbo`** | **1.5GB** | **Fast** | **9.7/10** | **Large-v3 quality, medium speed** |
+| Parakeet V2 | 474MB | Fastest | 9.4/10 | English-only (NVIDIA) |
 | Apple Speech | Built-in | Fast | 9.0/10 | macOS 26+, on-device |
-
-**Recommendation**: `medium` for most; `turbo` when speed matters; `large-v3` for accuracy-critical work.
 
 ### faster-whisper / whisper.cpp
 
 ```python
-# faster-whisper (pip install faster-whisper)
-from faster_whisper import WhisperModel
+from faster_whisper import WhisperModel  # pip install faster-whisper
 model = WhisperModel("medium", device="cpu", compute_type="int8")
 for seg, _ in model.transcribe("audio.mp3", language="en"):
     print(f"[{seg.start:.2f}s] {seg.text}")
 ```
 
 ```bash
-# whisper.cpp — Apple Silicon optimised (https://github.com/ggml-org/whisper.cpp)
+# whisper.cpp — Apple Silicon optimised
 git clone https://github.com/ggml-org/whisper.cpp && cd whisper.cpp && make
 ./models/download-ggml-model.sh medium
 ./build/bin/whisper-cli -m models/ggml-medium.bin -f audio.wav -otxt -osrt
@@ -87,72 +83,60 @@ git clone https://github.com/ggml-org/whisper.cpp && cd whisper.cpp && make
 
 ## Buzz (macOS GUI for Whisper)
 
-Desktop app wrapping Whisper models. No cloud, no API key. Supports audio (MP3, WAV, FLAC, OGG, M4A, WMA), video (MP4, MKV, AVI, MOV, WebM), output (TXT, SRT, VTT, JSON).
+Desktop Whisper wrapper. No cloud/API key. Audio: MP3/WAV/FLAC/OGG/M4A/WMA. Video: MP4/MKV/AVI/MOV/WebM. Output: TXT/SRT/VTT/JSON.
 
 ```bash
-brew install --cask buzz    # GUI — File → Open → model → Transcribe → Export
-pip install buzz-captions   # CLI / Python
-buzz transcribe audio.mp3 --model medium --output-format srt
+brew install --cask buzz                                         # GUI: File → Open → Transcribe → Export
+buzz transcribe audio.mp3 --model medium --output-format srt     # CLI
 buzz transcribe foreign.mp3 --task translate --language auto
 buzz transcribe audio.mp3 --model-type faster-whisper --model large-v3
 ```
 
-## AssemblyAI (Cloud — Speaker Diarization, High Accuracy)
+## AssemblyAI (Cloud — Speaker Diarization)
 
-Best for meeting transcription with speaker identification. `aidevops secret set ASSEMBLYAI_API_KEY`
+Best for meetings with speaker identification. `aidevops secret set ASSEMBLYAI_API_KEY`
 
 ```python
 import assemblyai as aai, os
 aai.settings.api_key = os.environ["ASSEMBLYAI_API_KEY"]
-
-# Speaker diarization
-config = aai.TranscriptionConfig(speaker_labels=True, speakers_expected=3)
+config = aai.TranscriptionConfig(speaker_labels=True, speakers_expected=3, auto_chapters=True)
 transcript = aai.Transcriber().transcribe("meeting.mp3", config=config)
-for utterance in transcript.utterances:
-    print(f"Speaker {utterance.speaker}: {utterance.text}")
-
-# Async webhook (production)
-transcript = aai.Transcriber().submit("audio.mp3", aai.TranscriptionConfig(webhook_url="https://yourapp.com/webhook"))
-print(transcript.id)  # poll later
+for u in transcript.utterances: print(f"Speaker {u.speaker}: {u.text}")
+# Subtitles: transcript.export_subtitles_srt()
+# Async: aai.Transcriber().submit("audio.mp3", aai.TranscriptionConfig(webhook_url="https://..."))
 ```
 
-Additional `TranscriptionConfig` options: `auto_chapters`, `sentiment_analysis`, `entity_detection`, `auto_highlights`, `language_detection`, `punctuate`, `format_text`.
-
-### Pricing
+Config options: `sentiment_analysis`, `entity_detection`, `auto_highlights`, `language_detection`, `punctuate`, `format_text`.
 
 | Model | Batch | Streaming | Notes |
 |-------|-------|-----------|-------|
 | Universal-3 Pro | $0.21/hr | $0.45/hr | Promptable, 6 languages |
-| Universal-2 | $0.15/hr | — | 99 languages, general-purpose |
-| Universal-Streaming | — | $0.15/hr | English-only, fastest |
-| Universal-Streaming Multilingual | — | $0.15/hr | 6 languages |
+| Universal-2 | $0.15/hr | — | 99 languages |
+| Universal-Streaming | — | $0.15/hr | English-only / 6-lang multilingual |
 | Whisper-Streaming | — | $0.30/hr | 99+ languages |
 
 > Last verified: March 2026 — [assemblyai.com/pricing](https://www.assemblyai.com/pricing)
 
 ## Deepgram (Cloud — Real-Time, Low Latency)
 
-Best for live transcription, call centres, and latency-sensitive applications. `aidevops secret set DEEPGRAM_API_KEY`
+Best for live transcription and latency-sensitive apps. `aidevops secret set DEEPGRAM_API_KEY`
 
 ```python
 from deepgram import DeepgramClient, PrerecordedOptions
 import os
-
 dg = DeepgramClient(os.environ["DEEPGRAM_API_KEY"])
 opts = PrerecordedOptions(model="nova-3", language="en", punctuate=True, diarize=True, smart_format=True)
 with open("audio.mp3", "rb") as f:
     resp = dg.listen.rest.v("1").transcribe_file({"buffer": f}, opts)
 alt = resp.results.channels[0].alternatives[0]
 print(alt.transcript)
-for word in alt.words: print(f"[Speaker {word.speaker}] {word.word}")  # diarization
+for word in alt.words: print(f"[Speaker {word.speaker}] {word.word}")
 ```
 
-### Real-Time Streaming
+### Streaming
 
 ```python
 from deepgram import DeepgramClient, LiveTranscriptionEvents, LiveOptions
-import asyncio, os
-
 dg = DeepgramClient(os.environ["DEEPGRAM_API_KEY"])
 conn = dg.listen.asyncwebsocket.v("1")
 conn.on(LiveTranscriptionEvents.Transcript, lambda r, **kw: print(r.channel.alternatives[0].transcript) or None)
@@ -160,13 +144,11 @@ await conn.start(LiveOptions(model="nova-3", language="en-US", smart_format=True
 # feed audio chunks via conn.send(audio_chunk)
 ```
 
-### Models & Pricing
-
 | Model | Accuracy | Cost | Notes |
 |-------|----------|------|-------|
 | `nova-3` | 9.5/10 | $0.0077/min | General purpose, 36 languages |
 | `nova-3-medical` | 9.6/10 | $0.0077/min | Clinical vocabulary, English only |
-| `nova-3` (Multilingual) | 9.5/10 | $0.0092/min | 45+ languages |
+| `nova-3` Multilingual | 9.5/10 | $0.0092/min | 45+ languages |
 | `nova-2` | 9.3/10 | $0.0058/min | Previous gen, wider language support |
 
 > Last verified: March 2026 — [deepgram.com/pricing](https://deepgram.com/pricing)
@@ -175,69 +157,24 @@ await conn.start(LiveOptions(model="nova-3", language="en-US", smart_format=True
 
 | Provider | Model | Accuracy | Cost | Notes |
 |----------|-------|----------|------|-------|
-| **Groq** | Whisper Large v3 Turbo | 9.6/10 | Free tier | OpenAI-compatible API |
+| **Groq** | Whisper Large v3 Turbo | 9.6/10 | Free tier | OpenAI-compatible |
 | **ElevenLabs** | Scribe v2 | 9.9/10 | Pay/min | Highest accuracy |
 | **Mistral** | Voxtral Mini | 9.7/10 | Pay/token | Multilingual |
-| **OpenAI** | Whisper API | 9.5/10 | $0.006/min | Reference implementation |
+| **OpenAI** | Whisper API | 9.5/10 | $0.006/min | Reference impl |
 | **Google** | Gemini 2.5 Pro | 9.7/10 | Pay/token | Multimodal input |
 | **Soniox** | stt-async-v3 | 9.6/10 | Batch | Batch processing |
 
-Store API keys: `aidevops secret set <PROVIDER>_API_KEY`
+Store keys: `aidevops secret set <PROVIDER>_API_KEY`
 
 ```bash
-# Groq (OpenAI-compatible)
 curl https://api.groq.com/openai/v1/audio/transcriptions \
   -H "Authorization: Bearer ${GROQ_API_KEY}" \
   -F "file=@audio.wav" -F "model=whisper-large-v3" -F "response_format=verbose_json"
 ```
 
-## Common Workflows
+## Language & Output
 
-```bash
-# Meeting — AssemblyAI speaker diarization
-python3 -c "
-import assemblyai as aai, os; aai.settings.api_key = os.environ['ASSEMBLYAI_API_KEY']
-t = aai.Transcriber().transcribe('meeting.mp4', aai.TranscriptionConfig(speaker_labels=True, auto_chapters=True))
-for u in t.utterances: print(f'[Speaker {u.speaker}] {u.text}')
-"
-
-# Meeting — local Whisper (private, no speaker labels)
-whisper meeting.mp4 --model medium --output_format txt
-
-# Video subtitles — local
-whisper video.mp4 --model medium --output_format srt
-
-# Video subtitles — AssemblyAI (cloud, higher accuracy)
-python3 -c "
-import assemblyai as aai, os; aai.settings.api_key = os.environ['ASSEMBLYAI_API_KEY']
-t = aai.Transcriber().transcribe('video.mp4')
-open('subtitles.srt', 'w').write(t.export_subtitles_srt())
-"
-
-# Podcast — transcribe then summarise
-whisper episode.mp3 --model turbo --output_format txt
-cat episode.txt | claude "Summarise: key topics, notable quotes, action items, guest names"
-
-# Batch — local Whisper
-for f in recordings/*.mp3; do whisper "$f" --model medium --output_format txt --output_dir transcripts/; done
-
-# Batch — Deepgram (faster, parallel)
-python3 -c "
-import os, glob; from deepgram import DeepgramClient, PrerecordedOptions
-dg = DeepgramClient(os.environ['DEEPGRAM_API_KEY'])
-opts = PrerecordedOptions(model='nova-3', punctuate=True, smart_format=True)
-os.makedirs('transcripts', exist_ok=True)
-for p in glob.glob('recordings/*.mp3'):
-    r = dg.listen.rest.v('1').transcribe_file({'buffer': open(p,'rb')}, opts)
-    open(p.replace('recordings/','transcripts/').replace('.mp3','.txt'),'w').write(r.results.channels[0].alternatives[0].transcript)
-"
-```
-
-## Language & Output Reference
-
-**Languages** — Whisper: 99 (`--language fr/zh/es`; full list: https://github.com/openai/whisper#available-models-and-languages). AssemblyAI: 99 (`language_code="fr"` or `language_detection=True`). Deepgram Nova-3: 36 (`language="fr"`); `nova-2` for 100+.
-
-**Output formats**: `.txt` (all tools), `.srt`/`.vtt` subtitles (Whisper, Buzz, AssemblyAI), `.json` word timestamps (all tools).
+**Languages** — Whisper: 99 (`--language fr/zh/es`). AssemblyAI: 99 (`language_code="fr"` or `language_detection=True`). Deepgram Nova-3: 36; `nova-2` for 100+. **Formats**: `.txt` (all), `.srt`/`.vtt` (Whisper, Buzz, AssemblyAI), `.json` word timestamps (all).
 
 ---
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/voice/transcription.md` from 250 to 187 lines (25.2% reduction)
- Remove redundant Common Workflows section (all examples already shown in provider sections)
- Consolidate model table rows (tiny/base merged), AssemblyAI streaming rows, decision matrix cells
- Fold batch processing into Whisper CLI block, inline subtitle/async patterns as comments
- All functional content preserved: decision matrix, all 4 provider sections, code examples, pricing tables, language/output reference

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs-only change — no code, no config, no runtime behaviour)
- **Verification**: Line count confirmed (250 → 187), diff reviewed for content preservation

Closes #11422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and simplified voice transcription documentation including updated examples for local and cloud transcription services (Whisper, Buzz, AssemblyAI, Deepgram), streamlined pricing information, and consolidated language and output format guidance in a single reference section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->