### PR TITLE
t11551: tighten agent doc Scaling Playbook

### DIFF
--- a/.agents/marketing-sales/meta-ads-optimization-scaling.md
+++ b/.agents/marketing-sales/meta-ads-optimization-scaling.md
@@ -2,178 +2,25 @@
 
 > How to spend more while maintaining profitability.
 
----
+This is an index into the Meta Ads scaling knowledge base. Detailed methods, checklists, and diagnostics live in dedicated files to avoid duplication.
 
-## Scaling Prerequisites
+## Scaling Methods
 
-### Before You Scale, Confirm:
+For vertical scaling (budget increases), horizontal scaling (duplication), and creative scaling methods, see `meta-ads-campaigns-scaling-cbo.md` — covers conservative through aggressive approaches, timing, duplication strategies, and the recommended scaling sequence.
 
-- [ ] **CPA at or below target** for 5+ consecutive days
-- [ ] **50+ conversions** with statistical confidence
-- [ ] **CTR stable** (not declining)
-- [ ] **Frequency under control** (<3 for prospecting)
-- [ ] **Creative not fatigued** (still fresh)
-- [ ] **Landing page stable** (no changes, good CVR)
-- [ ] **Tracking working** (all events firing)
+## Scaling Checklists
 
----
+For pre-scale requirements, scaling decision tree, execution checklists, post-scale monitoring, and warning signs, see `meta-ads-checklists-scaling-checklist.md`.
 
-## Vertical Scaling (Budget Increases)
+## Troubleshooting During Scale
 
-### Conservative Scaling
-
-**When to Use:**
-- CPA is close to target
-- You're unsure how campaign will respond
-- Learning phase just ended
-
-**Method:**
-```
-Increase by 10-20% every 2-3 days
-
-Day 1: $100
-Day 3: $120 (+20%)
-Day 5: $144 (+20%)
-Day 7: $173 (+20%)
-Day 10: $207 (+20%)
-```
-
-**Monitor:**
-- CPA after each increase
-- If CPA rises >20%, pause increases
-
-### Moderate Scaling
-
-**When to Use:**
-- CPA is 20-30% below target
-- Campaign has been stable for 1+ weeks
-- Good conversion volume
-
-**Method:**
-```
-Increase by 20-30% every 2-3 days
-
-Day 1: $100
-Day 3: $130 (+30%)
-Day 5: $169 (+30%)
-Day 7: $220 (+30%)
-```
-
-### Aggressive Scaling
-
-**When to Use:**
-- CPA is 50%+ below target
-- You need to capture opportunity quickly
-- Strong creative performing consistently
-
-**Method:**
-```
-Increase by 50-100% if performance holds
-
-Day 1: $100 (CPA: $15, target: $30)
-Day 2: $200 (+100%)
-Day 3: Monitor (still good?)
-Day 4: $350 (+75%)
-Day 5: Monitor
-```
-
-### Budget Increase Timing
-
-**Best Time to Increase:**
-- Early morning (12:00 AM - 2:00 AM your time)
-- This is start of new day for the algorithm
-- Budget for full day ahead
-
-**Avoid:**
-- Mid-day increases (disrupts pacing)
-- Evening increases (partial day impact)
+For CPA diagnosis, algorithm resets, delivery issues, and performance recovery, see `meta-ads-optimization-troubleshooting.md`.
 
 ---
 
-## Horizontal Scaling (Duplication)
+## Creative Velocity at Scale
 
-### When to Duplicate
-
-**Duplicate Instead of Budget Increase When:**
-- Vertical scaling hitting diminishing returns
-- CPA rises with budget increases
-- You want to test audience variations
-- Diversify risk across ad sets
-
-### How to Duplicate
-
-**Step 1: Choose What to Duplicate**
-```
-Best: Entire ad set (preserves learning)
-Alternative: Just the ads
-```
-
-**Step 2: What to Change**
-```
-Change ONE thing:
-- Different age range
-- Different geography
-- Different lookalike %
-- Different placement focus
-```
-
-**Step 3: Budget**
-```
-Start duplicate at same budget as original
-Let them compete
-```
-
-### Duplication Strategies
-
-**Age Splits:**
-```
-Original: Broad 25-65
-Duplicate 1: 25-40
-Duplicate 2: 40-55
-Duplicate 3: 55-65
-```
-
-**Geo Splits:**
-```
-Original: US All
-Duplicate 1: US - CA, NY, TX
-Duplicate 2: US - Other States
-Duplicate 3: CA, UK, AU
-```
-
-**Lookalike Stacks:**
-```
-Original: 1% Customer LAL
-Duplicate 1: 1% High-LTV LAL
-Duplicate 2: 2% Customer LAL
-Duplicate 3: Broad
-```
-
-### Managing Duplicates
-
-**Watch for:**
-- Audience overlap (competing with yourself)
-- One duplicate dominating
-- Combined frequency getting too high
-
-**Pause duplicates when:**
-- CPA is 50%+ above original
-- CTR is significantly lower
-- Clear underperformance after 5 days
-
----
-
-## Creative Scaling
-
-### Scale Winners, Not Just Budget
-
-**Don't just increase budget** — also:
-1. Create iterations of winning creative
-2. Test new hooks with winning body
-3. Test winning hook with new body
-4. Test winning concept in new formats
-
-### Creative Velocity at Scale
+Scale creative output proportionally to spend. Relying on one winner is fragile.
 
 | Monthly Spend | New Creative/Week |
 |---------------|-------------------|
@@ -182,10 +29,9 @@ Duplicate 3: Broad
 | $100K | 25-40 |
 | $200K+ | 40+ |
 
-### Diversifying Creative
+**Healthy spend distribution:**
 
-**Don't rely on one winner:**
-```
+```text
 Unhealthy: 80% of spend on 1 ad
 Healthy: No ad >30% of spend
 Best: 4-5 ads each at 15-25%
@@ -193,70 +39,18 @@ Best: 4-5 ads each at 15-25%
 
 ---
 
-## Handling Scale Challenges
-
-### CPA Rising During Scale
-
-**Diagnosis:**
-1. Is it gradual or sudden?
-2. Is frequency rising?
-3. Is CPM rising?
-4. Is CTR falling?
-
-**Solutions by Cause:**
-
-| Cause | Solution |
-|-------|----------|
-| Creative fatigue | Add new creative |
-| Audience saturation | Expand targeting |
-| Competition | Accept higher CPA or pause |
-| Quality decline | Improve creative |
-
-### Algorithm Resets
-
-**Signs of Reset:**
-- "Learning" status reappeared
-- Wild performance swings
-- CPA significantly different
-
-**What Triggers Resets:**
-- Budget change >20% (sometimes)
-- Targeting change (always)
-- Creative change (if all ads changed)
-- Pause >7 days (always)
-
-**Recovery:**
-- Wait 3-5 days
-- Don't make more changes
-- Let algorithm re-learn
-
-### Diminishing Returns
-
-**Signs:**
-- Each budget increase yields smaller CPA improvement
-- Eventually CPA starts rising
-- Frequency increasing despite larger audience
-
-**Response:**
-1. Stop vertical scaling
-2. Try horizontal scaling (duplicates)
-3. Look for new winning creative
-4. Accept current scale as efficient maximum
-
----
-
-## Scale Planning
+## Scale Planning Templates
 
 ### Weekly Scale Review
 
-```
+```text
 1. What's current spend?
 2. What's current CPA vs target?
 3. Is there room to scale (CPA below target)?
 4. What's limiting scale?
-   - Budget → Increase budget
-   - Creative → Need more creative
-   - Audience → Need to expand
+   - Budget -> Increase budget
+   - Creative -> Need more creative
+   - Audience -> Need to expand
 5. What's the plan for next week?
 ```
 
@@ -271,7 +65,8 @@ Best: 4-5 ads each at 15-25%
 
 ### Scale Limits
 
-**Know Your Ceiling:**
+Know your ceiling before scaling:
+
 - What's your total addressable market?
 - At what CPA do you become unprofitable?
 - What's your inventory/fulfillment capacity?
@@ -279,27 +74,4 @@ Best: 4-5 ads each at 15-25%
 
 ---
 
-## Scale Checklist
-
-### Before Scaling
-- [ ] CPA below target for 5+ days
-- [ ] Creative has room to run
-- [ ] Frequency under control
-- [ ] Landing page stable
-- [ ] Business can handle volume
-
-### During Scale
-- [ ] Increase budget gradually
-- [ ] Monitor CPA after each increase
-- [ ] Watch for learning resets
-- [ ] Have new creative ready
-
-### If Scale Stalls
-- [ ] Check creative fatigue
-- [ ] Consider horizontal scaling
-- [ ] Expand audiences
-- [ ] Accept current efficient level
-
----
-
-*Next: [Troubleshooting](troubleshooting.md)*
+*Next: [Troubleshooting](meta-ads-optimization-troubleshooting.md)*

--- a/.agents/marketing-sales/meta-ads-optimization-troubleshooting.md
+++ b/.agents/marketing-sales/meta-ads-optimization-troubleshooting.md
@@ -33,6 +33,10 @@
 
 **Was great, now terrible**: Gradual decline = fatigue (add new creative, pause fatigued ads). Sudden overnight = algorithm reset or external factor (check edits, seasonal competition, LP changes). Recovery: revert edits if sudden, duplicate fresh ad set, adjust expectations.
 
+**Algorithm Reset Triggers**: Budget change >20% (sometimes), targeting change (always), all creative changed at once (always), pause >7 days (always). Recovery: wait 3-5 days, don't make more changes, let algorithm re-learn.
+
+**Diminishing Returns at Scale**: Each budget increase yields smaller CPA improvement, eventually CPA starts rising, frequency increasing despite larger audience. Response: (1) stop vertical scaling, (2) try horizontal scaling (duplicates), (3) look for new winning creative, (4) accept current scale as efficient maximum.
+
 **High CPM** — Causes: Q4/holiday competition, narrow audience, low ad quality, poor engagement. Fixes: broaden audience, improve creative, test placements, adjust timing.
 
 **Low CTR** — Benchmark: <0.8% concerning, <0.5% needs action. Causes: hook not compelling, wrong audience, creative fatigue, poor visuals, unclear value prop. Fixes: test new hooks, review audience fit, refresh creative, clarify message.

--- a/.agents/marketing-sales/meta-ads-optimization-troubleshooting.md
+++ b/.agents/marketing-sales/meta-ads-optimization-troubleshooting.md
@@ -33,7 +33,7 @@
 
 **Was great, now terrible**: Gradual decline = fatigue (add new creative, pause fatigued ads). Sudden overnight = algorithm reset or external factor (check edits, seasonal competition, LP changes). Recovery: revert edits if sudden, duplicate fresh ad set, adjust expectations.
 
-**Algorithm Reset Triggers**: Budget change >20% (sometimes), targeting change (always), all creative changed at once (always), pause >7 days (always). Recovery: wait 3-5 days, don't make more changes, let algorithm re-learn.
+**Algorithm Reset** — Signs: "Learning" status reappeared, wild performance swings, CPA significantly different from baseline. Triggers: budget change >20% (sometimes), targeting change (always), all creative changed at once (always), pause >7 days (always). Recovery: wait 3-5 days, don't make more changes, let algorithm re-learn.
 
 **Diminishing Returns at Scale**: Each budget increase yields smaller CPA improvement, eventually CPA starts rising, frequency increasing despite larger audience. Response: (1) stop vertical scaling, (2) try horizontal scaling (duplicates), (3) look for new winning creative, (4) accept current scale as efficient maximum.
 


### PR DESCRIPTION
## Summary

- Replaces 305-line scaling playbook with 77-line slim index (75% reduction) by deduplicating content into authoritative sibling files
- Migrates algorithm reset triggers and diminishing returns knowledge to troubleshooting file where they belong
- Fixes broken footer link (`troubleshooting.md` → `meta-ads-optimization-troubleshooting.md`)

## What changed

**`meta-ads-optimization-scaling.md`** (305 → 77 lines): Duplicated sections replaced with pointers to:
- `meta-ads-campaigns-scaling-cbo.md` — vertical, horizontal, creative scaling methods
- `meta-ads-checklists-scaling-checklist.md` — pre/during/post-scale checklists
- `meta-ads-optimization-troubleshooting.md` — CPA diagnosis, algorithm resets, recovery

Unique content preserved inline: creative velocity table, healthy spend distribution metrics, weekly/monthly planning templates, scale limits.

**`meta-ads-optimization-troubleshooting.md`** (+4 lines): Added algorithm reset triggers (budget >20%, targeting change, all creative changed, pause >7 days) and diminishing returns response strategy — knowledge that was only in the scaling playbook.

## Content preservation verification

Every section from the original mapped to either the new index file or an existing sibling:

| Original Section | New Location |
|---|---|
| Scaling Prerequisites | `meta-ads-checklists-scaling-checklist.md` (more comprehensive) |
| Vertical/Horizontal/Creative Scaling | `meta-ads-campaigns-scaling-cbo.md` |
| Budget Increase Timing | `meta-ads-campaigns-scaling-cbo.md` line 64 |
| CPA Rising / Algorithm Resets / Diminishing Returns | `meta-ads-optimization-troubleshooting.md` |
| Creative Velocity + Diversification | Preserved inline |
| Weekly/Monthly Planning + Scale Limits | Preserved inline |
| Scale Checklist | `meta-ads-checklists-scaling-checklist.md` (more comprehensive) |

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/agent prompts only, no code changes)
- **Verification**: markdownlint passes with 0 errors on both files

Closes #11551