### PR TITLE
t11526: tighten Better Auth agent doc

### DIFF
--- a/.agents/tools/api/better-auth.md
+++ b/.agents/tools/api/better-auth.md
@@ -22,12 +22,8 @@ tools:
 - **Purpose**: Full-featured authentication for Next.js applications
 - **Packages**: `better-auth`, `@better-auth/expo`, `@better-auth/passkey`
 - **Docs**: Use Context7 MCP for current documentation
-
-**Key Features**:
-- Email/password, OAuth, magic links, passkeys
-- Session management with database storage
-- Built-in Drizzle adapter
-- React hooks for client-side auth
+- **Features**: Email/password, OAuth, magic links, passkeys, session management (DB-backed), Drizzle adapter, React hooks
+- **Imports**: `@workspace/auth/server` (server), `@workspace/auth/client/react` (client) — never mix
 
 **Server Setup**:
 
@@ -37,7 +33,6 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@workspace/db";
 
-// Validate required environment variables
 const requiredEnvVars = ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'BETTER_AUTH_SECRET'] as const;
 for (const envVar of requiredEnvVars) {
   if (!process.env[envVar]) {
@@ -45,9 +40,8 @@ for (const envVar of requiredEnvVars) {
   }
 }
 
-// Server-side password validation — enforced on every signUp.email() call.
-// Client-side checks (e.g. Zod passwordSchema) are UX only; this is the
-// security boundary. Callers that bypass the client still hit this validator.
+// Server-side password validation — security boundary.
+// Client-side Zod checks are UX only; this enforces on every signUp.email() call.
 const validatePassword = (password: string) => {
   if (password.length < 8) return false;
   if (!/[A-Z]/.test(password)) return false;
@@ -57,14 +51,10 @@ const validatePassword = (password: string) => {
 };
 
 export const auth = betterAuth({
-  database: drizzleAdapter(db, {
-    provider: "pg",
-  }),
+  database: drizzleAdapter(db, { provider: "pg" }),
   emailAndPassword: {
     enabled: true,
-    password: {
-      validate: validatePassword,
-    },
+    password: { validate: validatePassword },
   },
   socialProviders: {
     google: {
@@ -75,7 +65,7 @@ export const auth = betterAuth({
 });
 ```
 
-**Client Hooks**:
+**Client Setup**:
 
 ```tsx
 // packages/auth/src/client/react.ts
@@ -88,34 +78,14 @@ export const authClient = createAuthClient({
 export const { useSession, signIn, signOut, signUp } = authClient;
 ```
 
-**Usage in Components**:
+**API Route Handler**:
 
 ```tsx
-"use client";
-import { useSession, signIn, signOut } from "@workspace/auth/client/react";
+// app/api/auth/[...all]/route.ts
+import { auth } from "@workspace/auth/server";
+import { toNextJsHandler } from "better-auth/next-js";
 
-function AuthButton() {
-  const { data: session, isPending } = useSession();
-
-  if (isPending) return <div>Loading...</div>;
-
-  if (session) {
-    return (
-      <div>
-        <span>{session.user.email}</span>
-        <button onClick={() => signOut()}>Sign Out</button>
-      </div>
-    );
-  }
-
-  return (
-    // Get from form state
-    const { email, password } = formData;
-    <button onClick={() => signIn.email({ email, password })}>
-      Sign In
-    </button>
-  );
-}
+export const { GET, POST } = toNextJsHandler(auth);
 ```
 
 **Protected Routes**:
@@ -132,22 +102,37 @@ export default auth.middleware({
 
 <!-- AI-CONTEXT-END -->
 
-## Detailed Patterns
+## Usage Patterns
+
+### Component Auth (Client)
+
+```tsx
+"use client";
+import { useSession, signIn, signOut } from "@workspace/auth/client/react";
+
+function AuthButton() {
+  const { data: session, isPending } = useSession();
+  if (isPending) return <div>Loading...</div>;
+  if (session) {
+    return (
+      <div>
+        <span>{session.user.email}</span>
+        <button onClick={() => signOut()}>Sign Out</button>
+      </div>
+    );
+  }
+  return <button onClick={() => signIn.email({ email, password })}>Sign In</button>;
+}
+```
 
 ### OAuth Sign In
 
 ```tsx
 import { signIn } from "@workspace/auth/client/react";
 
-// Google OAuth
-<button onClick={() => signIn.social({ provider: "google" })}>
-  Sign in with Google
-</button>
-
-// GitHub OAuth
-<button onClick={() => signIn.social({ provider: "github" })}>
-  Sign in with GitHub
-</button>
+// Google / GitHub OAuth
+<button onClick={() => signIn.social({ provider: "google" })}>Sign in with Google</button>
+<button onClick={() => signIn.social({ provider: "github" })}>Sign in with GitHub</button>
 ```
 
 ### Email/Password Sign Up
@@ -156,11 +141,8 @@ import { signIn } from "@workspace/auth/client/react";
 import { signUp } from "@workspace/auth/client/react";
 import { z } from "zod";
 
-// Client-side password validation — UX only, NOT a security boundary.
-// Callers can bypass this and call signUp.email() directly.
-// The server enforces the same rules via emailAndPassword.password.validate
-// in packages/auth/src/server.ts — signUp.email() returns an error if the
-// password fails server-side validation, regardless of client-side checks.
+// Client-side validation — UX only, not a security boundary.
+// Server enforces via emailAndPassword.password.validate (see server setup).
 const passwordSchema = z.string()
   .min(8, "Password must be at least 8 characters")
   .regex(/[A-Z]/, "Must contain an uppercase letter")
@@ -168,15 +150,12 @@ const passwordSchema = z.string()
   .regex(/[0-9]/, "Must contain a number");
 
 const handleSignUp = async (data: { email: string; password: string; name: string }) => {
-  // Early UX feedback — mirrors the server-side validatePassword function.
   const passwordCheck = passwordSchema.safeParse(data.password);
   if (!passwordCheck.success) {
     console.error("Weak password:", passwordCheck.error.flatten().formErrors);
     return;
   }
 
-  // Server enforces password strength via emailAndPassword.password.validate.
-  // If validation fails server-side, result.error is set and no account is created.
   const result = await signUp.email({
     email: data.email,
     password: data.password,
@@ -184,13 +163,10 @@ const handleSignUp = async (data: { email: string; password: string; name: strin
   });
 
   if (result.error) {
-    // Handles both server-side password validation failures and other errors
-    // (e.g., duplicate email). result.error.message contains the reason.
+    // Server-side validation failures, duplicate email, etc.
     console.error("Sign-up failed:", result.error.message);
     return;
   }
-
-  // User created and signed in
   router.push("/dashboard");
 };
 ```
@@ -198,27 +174,17 @@ const handleSignUp = async (data: { email: string; password: string; name: strin
 ### Server-Side Session
 
 ```tsx
-// In server component or API route
 import { auth } from "@workspace/auth/server";
 import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 
 export async function getServerSession() {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-  return session;
+  return auth.api.getSession({ headers: await headers() }); // headers() is async in Next.js 15+
 }
-
-// Usage in page
-import { redirect } from "next/navigation";
 
 export default async function DashboardPage() {
   const session = await getServerSession();
-  
-  if (!session) {
-    redirect("/login");
-  }
-
+  if (!session) redirect("/login");
   return <div>Welcome, {session.user.name}</div>;
 }
 ```
@@ -226,41 +192,27 @@ export default async function DashboardPage() {
 ### Passkey Authentication
 
 ```tsx
-// Server config
+// Server: add plugin
 import { passkey } from "@better-auth/passkey";
+export const auth = betterAuth({ plugins: [passkey()], /* ... */ });
 
-export const auth = betterAuth({
-  plugins: [passkey()],
-  // ... other config
-});
-
-// Client usage
+// Client
 import { signIn } from "@workspace/auth/client/react";
-
-<button onClick={() => signIn.passkey()}>
-  Sign in with Passkey
-</button>
+<button onClick={() => signIn.passkey()}>Sign in with Passkey</button>
 ```
 
 ### Custom Session Data
 
 ```tsx
-// Extend session with custom fields
 export const auth = betterAuth({
   session: {
     expiresIn: 60 * 60 * 24 * 7, // 7 days
-    updateAge: 60 * 60 * 24, // Update session every 24 hours
-    cookieCache: {
-      enabled: true,
-      maxAge: 60 * 5, // 5 minutes
-    },
+    updateAge: 60 * 60 * 24,      // refresh every 24h
+    cookieCache: { enabled: true, maxAge: 60 * 5 }, // 5 min cache
   },
   user: {
     additionalFields: {
-      role: {
-        type: "string",
-        defaultValue: "user",
-      },
+      role: { type: "string", defaultValue: "user" },
     },
   },
 });
@@ -269,42 +221,19 @@ export const auth = betterAuth({
 ### Database Schema Generation
 
 ```bash
-# Generate auth schema for Drizzle
+# Generate/update auth schema for Drizzle (creates packages/db/src/schema/auth.ts)
 pnpm --filter auth db:generate
-
-# This creates/updates packages/db/src/schema/auth.ts
-```
-
-### API Route Handler
-
-```tsx
-// app/api/auth/[...all]/route.ts
-import { auth } from "@workspace/auth/server";
-import { toNextJsHandler } from "better-auth/next-js";
-
-export const { GET, POST } = toNextJsHandler(auth);
 ```
 
 ## Common Mistakes
 
-1. **Missing environment variables**
-   - `BETTER_AUTH_SECRET` required
-   - OAuth credentials for each provider
-
-2. **Not generating schema**
-   - Run `db:generate` after auth config changes
-   - Auth tables must exist in database
-
-3. **Forgetting to await headers()**
-   - `headers()` is async in Next.js 15+
-   - Always `await headers()` before passing to auth
-
-4. **Client/server import confusion**
-   - Use `@workspace/auth/server` on server
-   - Use `@workspace/auth/client/react` on client
+1. **Missing env vars** — `BETTER_AUTH_SECRET` required; OAuth credentials per provider
+2. **Schema not generated** — run `db:generate` after auth config changes; auth tables must exist
+3. **Not awaiting `headers()`** — async in Next.js 15+; always `await headers()` before passing to auth
+4. **Import confusion** — `@workspace/auth/server` on server, `@workspace/auth/client/react` on client
 
 ## Related
 
-- `tools/api/drizzle.md` - Database adapter
-- `tools/ui/nextjs-layouts.md` - Protected layouts
+- `tools/api/drizzle.md` — Database adapter
+- `tools/ui/nextjs-layouts.md` — Protected layouts
 - Context7 MCP for Better Auth documentation


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/api/better-auth.md` from 310→239 lines (23% reduction), 7542→6479 bytes (14%)
- Fix broken JSX in component example (`const` declaration inside JSX return statement)
- Compress redundant client/server validation boundary comments (explained 3 times → 1)
- Promote API route handler into Quick Reference (AI-CONTEXT block) for faster agent access
- Merge "Detailed Patterns" into flat "Usage Patterns" section
- Compact common mistakes to single-line format

## Content Preservation Verification

| Element | Count | Status |
|---------|-------|--------|
| Code blocks | 11 | All preserved |
| Package paths | 8 | All preserved |
| Import statements | 15 | All preserved |
| Key API patterns | 18 | All preserved |
| Environment variables | 5 | All preserved |
| Common mistakes | 4 | All preserved |

## Bug Fix

The original "Usage in Components" example had invalid JSX — a `const` variable declaration inside a JSX return expression (lines 111-117). This was syntactically broken and would confuse any agent using it as a template. Fixed to valid JSX.

## Runtime Testing

- Testing level: `self-assessed`
- Risk classification: Low (agent doc prose tightening, no runtime code)
- Verification: markdownlint-cli2 — 0 errors; all 18 key API patterns verified present via `rg`

Closes #11526