### PR TITLE
GH#11554: tighten Pricing Page Psychology agent doc

### DIFF
--- a/.agents/marketing-sales/cro-chapter-09.md
+++ b/.agents/marketing-sales/cro-chapter-09.md
@@ -4,19 +4,20 @@ Pricing pages are the most scrutinized pages on any site. Presentation psycholog
 
 ## Anchoring
 
-**Anchoring**: the first price seen sets expectations for all subsequent prices.
+First price seen sets expectations for all subsequent prices.
 
-**Descending order wins** — anchor to the highest price, making middle tiers feel reasonable:
+**Descending order wins** — anchor to highest price, making middle tiers feel reasonable:
 
-```
+```text
 Enterprise: $299/mo → Professional: $99/mo → Basic: $29/mo
 ```
 
-Ascending order anchors to $29; $99 feels 3.4× more. Descending anchors to $299; $99 feels like a 67% discount. Optimizely test: descending order increased Professional signups 37%.
+Ascending anchors to $29; $99 feels 3.4x more. Descending anchors to $299; $99 feels like 67% discount. Optimizely test: descending order increased Professional signups 37%.
 
-**Strikethrough anchors**: only use genuine previous prices or MSRP. Competitive anchoring ("Competitors charge $299, we charge $149") must be truthful.
+**Strikethrough anchors**: only genuine previous prices or MSRP. Competitive anchoring ("Competitors charge $299, we charge $149") must be truthful.
 
 **Annual vs. monthly display**:
+
 - Maximize monthly signups → show monthly price prominently
 - Maximize annual conversions → show annual as monthly equivalent ("$79/mo billed annually")
 - Maximize revenue → test both; annual often wins on transaction value despite fewer conversions
@@ -26,8 +27,9 @@ Ascending order anchors to $29; $99 feels 3.4× more. Descending anchors to $299
 A third option designed to make the target option obviously better by comparison.
 
 **Classic example** (Dan Ariely / The Economist):
+
 - Online Only: $59 | Print Only: $125 (decoy) | Online + Print: $125
-- With decoy: 84% chose Online+Print. Without: 32% chose it. Revenue per customer: $80 → $114 (+43%).
+- With decoy: 84% chose Online+Print. Without: 32%. Revenue per customer: $80 → $114 (+43%).
 
 **Decoy rules**: must be (1) inferior to target, (2) similar in price, (3) clearly worse value.
 
@@ -36,14 +38,14 @@ A third option designed to make the target option obviously better by comparison
 | Plan | Price | Limits |
 |------|-------|--------|
 | Starter | $29/mo | 10 users, 50GB, email support |
-| **Pro** ← TARGET | **$99/mo** | 50 users, 500GB, phone support, analytics |
-| Team ← DECOY | $89/mo | 30 users, 100GB, email support |
+| **Pro** <- TARGET | **$99/mo** | 50 users, 500GB, phone support, analytics |
+| Team <- DECOY | $89/mo | 30 users, 100GB, email support |
 
 Team is $10 cheaper than Pro but offers far less — Pro becomes the obvious value choice.
 
 ## Charm Pricing (Left-Digit Effect)
 
-Prices ending in 9/99/95. People process left-to-right and weight the leftmost digit: $3.99 reads as "three-something."
+Prices ending in 9/99/95. Left-to-right processing weights the leftmost digit: $3.99 reads as "three-something."
 
 **MIT/UChicago (2003)**: Identical clothing at $34 (16 sales), $39 (21 sales, +31%), $44 (17 sales). Charm price outperformed both lower and higher.
 
@@ -62,13 +64,15 @@ Real examples: Apple ($999/$1,999) — premium + charm at threshold. McKinsey ($
 ## Price Framing
 
 **Time-based**: Break large sums into daily costs.
+
 - $365/yr = "Just $1/day"
 - $10,000/yr = "Just $27/day — less than 30 min of an employee's time"
 
 **Unit economics**: $499/mo for 25 users = "Less than $20/user/month"
 
 **Comparative framing** — against alternatives:
-- Professional Photography: $2,000 vs DIY ($800 + time + quality) vs Competitors ($3,000–$5,000)
+
+- Professional Photography: $2,000 vs DIY ($800 + time + quality) vs Competitors ($3,000-$5,000)
 - Website Security: $99/mo vs Data breach ($4.24M avg, IBM) vs Legal fees ($100K+)
 
 **Loss vs. gain framing**:
@@ -78,27 +82,28 @@ Real examples: Apple ($999/$1,999) — premium + charm at threshold. McKinsey ($
 | "Don't waste $10K/year on inefficient processes" | "Save $10K/year with automation" |
 | "Stop losing 20% of leads" | "Capture 20% more leads" |
 
-Use loss framing for known pain points, security, prevention. Use gain framing for new opportunities, aspirational products. Test both — audiences differ.
+Use loss framing for known pain points, security, prevention. Gain framing for new opportunities, aspirational products. Test both — audiences differ.
 
 ## Tiered Pricing
 
-**Optimal tier count**: 3. Too few (1–2) = no segmentation. Too many (5+) = analysis paralysis.
+**Optimal tier count**: 3. Too few (1-2) = no segmentation. Too many (5+) = analysis paralysis.
 
 **Tier naming**:
 
 | Type | Examples | Perceived value |
 |------|----------|----------------|
-| Generic | Basic/Standard/Premium | Low–Medium |
+| Generic | Basic/Standard/Premium | Low-Medium |
 | Aspirational | Silver/Gold/Platinum, Essential/Plus/Ultimate | Higher |
 | Niche-specific | Individual/Team/Organization | Highest relevance |
 
 **Highlight the middle tier** (larger card, "Most Popular" badge, different color). Decoy effect makes it the obvious choice; pushes users off lowest tier; leaves Enterprise as upsell path. Highlight highest tier instead when targeting enterprise or anchoring high.
 
-**Feature differentiation mistakes**: too similar (no justification for price jump), too different (gap too large), feature stuffing (30+ features overwhelms).
+**Feature differentiation mistakes**: too similar (no price-jump justification), too different (gap too large), feature stuffing (30+ features overwhelms).
 
 **Effective value ladder**:
+
 - Starter ($29/mo): 10 users, 50GB, email support, core features
-- **Pro ($99/mo) ← MOST POPULAR**: 50 users, 500GB, phone support, analytics, API
+- **Pro ($99/mo) <- MOST POPULAR**: 50 users, 500GB, phone support, analytics, API
 - Enterprise ($299/mo): Unlimited, dedicated AM, SSO, SLA, custom integrations
 
 **Pricing model comparison**:
@@ -109,7 +114,7 @@ Use loss framing for known pain points, security, prevention. Use gain framing f
 | Usage-based | Scales with growth, feels fair | Unpredictable revenue, overage anxiety |
 | Hybrid | Best of both | More complex to communicate |
 
-**Annual discount sweet spot**: 15–25%. Below 10% = not compelling. Above 30% = signals desperation. Most successful SaaS clusters at 15–20% (Basecamp ~16%, ConvertKit 20%, HubSpot ~17%).
+**Annual discount sweet spot**: 15-25%. Below 10% = not compelling. Above 30% = signals desperation. Most successful SaaS: 15-20% (Basecamp ~16%, ConvertKit 20%, HubSpot ~17%).
 
 **Annual/monthly toggle**: use when annual billing is a key revenue goal. Show savings badge prominently ("Save 20%"). Default to monthly; let users switch to annual.
 
@@ -123,16 +128,17 @@ Use loss framing for known pain points, security, prevention. Use gain framing f
 
 | Scenario | Visible price | Contact Sales |
 |----------|--------------|---------------|
-| SaaS ($499/mo) | 47 trial clicks, avg $6K/yr → $282K potential | 12 clicks, avg $8.5K/yr → $102K potential |
+| SaaS ($499/mo) | 47 trial clicks, avg $6K/yr -> $282K potential | 12 clicks, avg $8.5K/yr -> $102K potential |
 | Enterprise software ($25K/yr+) | 8 contacts, avg $32K | 23 contacts, avg $67K |
 
-Showing pricing won for the mid-market SaaS; Contact Sales won for enterprise (qualified out small prospects, enabled larger deals).
+Visible pricing won for mid-market SaaS; Contact Sales won for enterprise (qualified out small prospects, enabled larger deals).
 
 **Hybrid "Starting at X"**: sets anchor, signals flexibility, reduces sticker shock, qualifies out low-budget prospects.
 
 ## Free Trial vs. Freemium
 
 **Free trial** — full/partial access for limited time (7/14/30 days):
+
 - Strengths: urgency, full product experience, predictable conversion window
 - Weaknesses: acquisition friction, may not be enough time for complex products
 - Use when: quick time-to-value, short sales cycle
@@ -141,16 +147,17 @@ Showing pricing won for the mid-market SaaS; Contact Sales won for enterprise (q
 
 | Metric | CC required | No CC |
 |--------|------------|-------|
-| Trial signups | 60–80% fewer | Higher volume |
-| Conversion to paid | 40–60% | 10–15% |
+| Trial signups | 60-80% fewer | Higher volume |
+| Conversion to paid | 40-60% | 10-15% |
 | Net revenue | Varies | Often higher due to volume |
 
 **Freemium** — free tier with limited features/usage:
+
 - Strengths: low friction, viral growth, habit formation
-- Weaknesses: no urgency, support costs, 2–5% avg conversion rate
+- Weaknesses: no urgency, support costs, 2-5% avg conversion rate
 - Use when: network effects matter, viral growth critical, low marginal cost per user
 
-**Hybrid (trial of premium + freemium fallback)**: 14-day premium trial → upgrade or downgrade to free. Best of both: urgency + safety net. Used by Canva (30-day Pro trial → generous Free tier).
+**Hybrid (trial of premium + freemium fallback)**: 14-day premium trial -> upgrade or downgrade to free. Best of both: urgency + safety net. Used by Canva (30-day Pro trial -> generous Free tier).
 
 ## Money-Back Guarantees
 
@@ -163,9 +170,10 @@ Showing pricing won for the mid-market SaaS; Contact Sales won for enterprise (q
 | Satisfaction | "Love it or return it — for any reason, at any time" |
 | Lifetime | "If it ever fails, we'll replace it free" |
 
-**Placement** (highest to lowest impact): pricing page → checkout → product pages → exit-intent popups.
+**Placement** (highest to lowest impact): pricing page -> checkout -> product pages -> exit-intent popups.
 
 **Framing strength**:
+
 - Weak: "We offer refunds"
 - Medium: "30-day money-back guarantee"
 - Strong: "Love It or Your Money Back — Guaranteed"
@@ -177,9 +185,9 @@ Adding "no questions asked" to a 30-day guarantee: +18% conversions, +2% refund 
 
 | Length | Effect | Best for |
 |--------|--------|----------|
-| 7–14 days | Creates urgency | Digital products |
+| 7-14 days | Creates urgency | Digital products |
 | 30 days | Balanced, most common | Most products |
-| 60–90 days | Powerful risk reversal | Complex products |
+| 60-90 days | Powerful risk reversal | Complex products |
 | 365 days / Lifetime | Maximum confidence | Durable goods (Zappos: core brand identity) |
 
 Combine multiple trust signals near CTA: secure checkout badge + guarantee seal + shipping policy + review score.
@@ -208,7 +216,7 @@ Combine multiple trust signals near CTA: secure checkout badge + guarantee seal 
 | # | Company | Works | Fix |
 |---|---------|-------|-----|
 | 11 | **Dollar Shave Club** | 3 tiers as product cards, "Most popular", free trial | Subscription cost structure confusing; total monthly cost hidden |
-| 12 | **HelloFresh** | Plan selector (people × meals), price per serving | Total cost unclear; first-box discounts feel like bait-and-switch |
+| 12 | **HelloFresh** | Plan selector (people x meals), price per serving | Total cost unclear; first-box discounts feel like bait-and-switch |
 | 13 | **Spotify** | 4 plans by user count, student discount, free trial | No annual plan; Duo not well-known |
 | 14 | **Netflix** | 3 simple tiers, clear differentiation (resolution + screens) | No annual discount; Basic 720p feels deliberately crippled |
 | 15 | **Peloton** | Financing prominent, premium positioning, testimonials | Total cost of ownership unclear; no budget tier |
@@ -219,20 +227,20 @@ Combine multiple trust signals near CTA: secure checkout badge + guarantee seal 
 | # | Company | Works | Fix |
 |---|---------|-------|-----|
 | 17 | **Fiverr** | Service packages, ratings visible, delivery time shown | Hidden service fees; race-to-bottom pricing |
-| 18 | **99designs** | Contest vs 1-to-1 differentiated, money-back guarantee | Contest model confusing; $299–$1,299 swing |
+| 18 | **99designs** | Contest vs 1-to-1 differentiated, money-back guarantee | Contest model confusing; $299-$1,299 swing |
 | 19 | **Upwork** | Transparent sliding fee structure, volume discounts | Confusing fee tiers; Plus membership value unclear |
 | 20 | **Freshbooks** | Client-count pricing, "Most popular" on Plus, trust signals | Client limits feel arbitrary; Select "custom pricing" adds friction |
 | 21 | **Salesforce** | 4 editions, per-user, "Most popular", free trial | Overwhelming for SMBs; add-on/implementation costs hidden |
 | 22 | **Zendesk** | Product-based pricing, suite bundles, free trial | Multiple products confusing; too many options |
 | 23 | **Adobe CC** | Individual app vs All Apps, student discount (60%) | Monthly vs annual commitment rates confusing |
-| 24 | **Hootsuite** | 4 tiers, social account limits, "Most popular", free trial | Team→Business jump steep ($129→$599); Enterprise opaque |
+| 24 | **Hootsuite** | 4 tiers, social account limits, "Most popular", free trial | Team->Business jump steep ($129->$599); Enterprise opaque |
 | 25 | **SEMrush** | 3 tiers, toggle, project/keyword limits clear, 7-day trial | High starting price ($119.95/mo); annual discount not compelling (16%) |
 
 ### E-Learning
 
 | # | Company | Works | Fix |
 |---|---------|-------|-----|
-| 26 | **Udemy** | Pay-once ownership, anchoring (original + sale), 30-day guarantee | Constant sales reduce trust; race to bottom ($10–15) |
+| 26 | **Udemy** | Pay-once ownership, anchoring (original + sale), 30-day guarantee | Constant sales reduce trust; race to bottom ($10-15) |
 | 27 | **Coursera** | Coursera Plus ($399/yr unlimited), free audit, financial aid | Confusing model (audit vs certificate vs subscription) |
 | 28 | **MasterClass** | Simple 3-plan all-access, 30-day guarantee, gift option | No monthly option; can't buy individual classes |
 | 29 | **LinkedIn Learning** | Monthly/annual, 35% annual discount, 1-month trial, certificates | Only individual and team; team pricing opaque |
@@ -259,7 +267,7 @@ Combine multiple trust signals near CTA: secure checkout badge + guarantee seal 
 
 | # | Company | Works | Fix |
 |---|---------|-------|-----|
-| 38 | **Airbnb** | Clear per-night pricing, fees itemized, dynamic host pricing | Fees add 20–30%; price changes on date adjustment |
+| 38 | **Airbnb** | Clear per-night pricing, fees itemized, dynamic host pricing | Fees add 20-30%; price changes on date adjustment |
 | 39 | **Canva** | Generous free tier, 30-day Pro trial, education/nonprofit discounts | Pro features overwhelming; Teams vs Pro not clearly differentiated |
 | 40 | **Zoom** | 4 tiers, clear differentiation, 40-min free limit creates upgrade pressure | Business minimum 10 licenses; add-on costs pile up |
 | 41 | **Loom** | 3 tiers, per-creator pricing, free tier with 25-video limit | Business minimum 5 creators; integrations locked behind Business |
@@ -268,7 +276,7 @@ Combine multiple trust signals near CTA: secure checkout badge + guarantee seal 
 | 45 | **ClickUp** | Generous forever-free, "Most popular" badge, clear differentiation | 5 tiers overwhelming; features list too long |
 | 46 | **Miro** | 4 tiers, free good for individuals, board limits clear | Starter minimum 2 users; collaboration features locked behind paid |
 | 47 | **Figma** | 3 tiers, generous free (3 projects), viewers free, education free | Organization minimum 2 editors; version history limited on Starter |
-| 48 | **Intercom** | Product-based pricing, calculator on page | Extremely complex (products × seats × contacts); expensive for SMBs |
+| 48 | **Intercom** | Product-based pricing, calculator on page | Extremely complex (products x seats x contacts); expensive for SMBs |
 | 49 | **Drift** | 3 editions, free tools available | No pricing shown (all "Contact Sales"); massive friction |
 | 50 | **ConvertKit** | Simple 3-tier, subscriber-based scaling, free to 1K, migration service | Gets expensive at scale; Creator Pro benefits not compelling |
 
@@ -277,9 +285,10 @@ Combine multiple trust signals near CTA: secure checkout badge + guarantee seal 
 ## Key Takeaways
 
 **What works (universal)**:
-1. 3–4 tiers optimal
+
+1. 3-4 tiers optimal
 2. "Most Popular" badge on middle tier
-3. 15–25% annual discounts
+3. 15-25% annual discounts
 4. Free trials reduce friction
 5. Money-back guarantees prominently displayed
 6. Feature comparison tables for self-selection
@@ -287,6 +296,7 @@ Combine multiple trust signals near CTA: secure checkout badge + guarantee seal 
 8. Generous free tiers when network effects matter
 
 **What doesn't work**:
+
 1. "Contact Sales" without price anchor — massive friction
 2. Hidden costs revealed late — destroys trust
 3. 5+ tiers — analysis paralysis
@@ -296,6 +306,7 @@ Combine multiple trust signals near CTA: secure checkout badge + guarantee seal 
 7. No social proof on pricing pages
 
 **Emerging trends**:
+
 1. Pricing calculators (adjust variables, see price live)
 2. Personalization ("teams like yours choose...")
 3. Multi-product bundling increases AOV


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/marketing-sales/cro-chapter-09.md` (Pricing Page Psychology chapter) while preserving all institutional knowledge
- Normalize Unicode characters (arrows, dashes, multiplication signs) to ASCII for cross-system compatibility
- Fix markdown compliance issues (MD032 blank lines before lists, MD040 code block language)

## Classification

**File type**: Reference corpus (CRO skill chapter 9 of 25) — not an instruction doc. Already split into chapter files. Prose tightening applied to instructional framing; teardown reference data preserved verbatim.

## Changes

- Compressed verbose phrasing to direct statements (~111 bytes reduced)
- Replaced `×` → `x`, `←` → `<-`, `→` → `->`, `–` → `-` (ASCII normalization)
- Added blank lines before list items after bold text (MD032)
- Added `text` language specifier to fenced code block (MD040)

## Content Preservation Verification

- All 50 company teardowns: intact (same company names, data, Works/Fix columns)
- All research citations: MIT/UChicago 2003, Dan Ariely/Economist, Optimizely, IBM $4.24M
- All percentages and data points: 37%, 84%, 43%, 18%, +2%, 15-25%, etc.
- All code blocks, tables, pricing examples ($29/$99/$299)
- Key Takeaways section: complete
- Zero knowledge loss

## Runtime Testing

- Testing level: `self-assessed`
- Risk classification: Low (docs/agent prompts only)
- Markdown linting: 0 errors after fix

Closes #11554