### PR TITLE
t11544: tighten class-er.md reference doc structure

### DIFF
--- a/.agents/tools/diagrams/mermaid-diagrams-skill/class-er.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/class-er.md
@@ -2,9 +2,11 @@
 
 Class diagrams model object-oriented structures. ER diagrams model database schemas and data relationships.
 
-# Class Diagrams
+## Class Diagrams
 
-## Class Definition
+### Definition & Members
+
+Visibility: `+` public, `-` private, `#` protected, `~` package/internal.
 
 ```mermaid
 classDiagram
@@ -17,21 +19,6 @@ classDiagram
         #validatePassword(pwd) bool
         -hashPassword(pwd) String
     }
-```
-
-### Visibility Modifiers
-
-| Symbol | Visibility |
-|--------|------------|
-| `+` | Public |
-| `-` | Private |
-| `#` | Protected |
-| `~` | Package/Internal |
-
-### Return Types
-
-```mermaid
-classDiagram
     class Repository {
         +findById(id) Entity
         +findAll() List~Entity~
@@ -40,7 +27,7 @@ classDiagram
     }
 ```
 
-## Relationships
+### Relationships
 
 | Syntax | Relationship |
 |--------|--------------|
@@ -65,13 +52,6 @@ classDiagram
 
 ### Cardinality
 
-```mermaid
-classDiagram
-    Customer "1" --> "*" Order : places
-    Order "1" --> "1..*" LineItem : contains
-    Order "0..1" --> "1" ShippingAddress : ships to
-```
-
 | Notation | Meaning |
 |----------|---------|
 | `1` | Exactly one |
@@ -81,7 +61,14 @@ classDiagram
 | `n` | Specific number |
 | `0..n` | Zero to n |
 
-## Annotations
+```mermaid
+classDiagram
+    Customer "1" --> "*" Order : places
+    Order "1" --> "1..*" LineItem : contains
+    Order "0..1" --> "1" ShippingAddress : ships to
+```
+
+### Annotations
 
 ```mermaid
 classDiagram
@@ -107,7 +94,7 @@ classDiagram
     }
 ```
 
-## Generic Types
+### Generic Types
 
 ```mermaid
 classDiagram
@@ -122,7 +109,7 @@ classDiagram
     Repository~User~ <|-- UserRepository
 ```
 
-## Namespaces
+### Namespaces
 
 ```mermaid
 classDiagram
@@ -139,7 +126,7 @@ classDiagram
     UserRepository ..|> IUserRepository
 ```
 
-## Notes & Styling
+### Notes & Styling
 
 ```mermaid
 classDiagram
@@ -147,16 +134,12 @@ classDiagram
     note for Order "Aggregate root for order management"
     class OrderItem
     note for OrderItem "Value object - immutable"
-```
-
-```mermaid
-classDiagram
     class Important
     class Normal
     style Important fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-## Example: Domain Model
+### Example: Domain Model
 
 ```mermaid
 classDiagram
@@ -206,11 +189,9 @@ classDiagram
     OrderItem --> Money : unitPrice
 ```
 
-# Entity Relationship Diagrams
+## Entity Relationship Diagrams
 
-## Relationship Notation (Crow's Foot)
-
-### Cardinality Symbols
+### Cardinality (Crow's Foot)
 
 | Left | Right | Meaning |
 |------|-------|---------|
@@ -221,8 +202,6 @@ classDiagram
 
 Line types: `--` (identifying/strong), `..` (non-identifying/weak).
 
-### Common Patterns
-
 ```mermaid
 erDiagram
     A ||--|| B : "one to one"
@@ -231,7 +210,9 @@ erDiagram
     G }|--|{ H : "many to many (required)"
 ```
 
-## Entity Attributes
+### Entity Attributes
+
+Modifiers: `PK` (primary key), `FK` (foreign key), `UK` (unique key).
 
 ```mermaid
 erDiagram
@@ -250,13 +231,7 @@ erDiagram
     USER ||--o{ ORDER : places
 ```
 
-| Modifier | Meaning |
-|----------|---------|
-| `PK` | Primary Key |
-| `FK` | Foreign Key |
-| `UK` | Unique Key |
-
-## Example: E-Commerce Schema
+### Example: E-Commerce Schema
 
 ```mermaid
 erDiagram
@@ -282,7 +257,7 @@ erDiagram
     SHIPPING { uuid id PK; uuid order_id FK UK; string carrier; string tracking_number; string status; timestamp shipped_at; timestamp delivered_at }
 ```
 
-## Example: Multi-Tenant SaaS
+### Example: Multi-Tenant SaaS
 
 ```mermaid
 erDiagram


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/diagrams/mermaid-diagrams-skill/class-er.md` (305 → 280 lines, 8% reduction)
- Classified as **reference corpus** per GH#6432 — structural tightening, not content compression
- Zero content loss: all Mermaid syntax, code blocks, tables, and worked examples preserved

## Changes

| Change | Effect |
|--------|--------|
| Fix heading hierarchy | H1 was duplicated; sections now properly H2/H3 |
| Merge Return Types into Definition & Members | 2 code blocks → 1 |
| Inline Visibility Modifiers table | 10-line table → 1-line prose |
| Inline ER Attribute Modifier table | 5-line table → 1-line prose |
| Merge Notes & Styling code blocks | 2 blocks → 1 |
| Flatten ER section headers | 3 heading levels → 2 |
| Reorder Cardinality section | Table before example (reference first) |

## Verification

- All 12 Mermaid code blocks present (14 → 12 via intentional merges)
- All syntax patterns verified: `<|--`, `*--`, `o--`, `-->`, `..>`, `..|>`, `||--||`, `||--o{`, `}o--o{`, `}|--|{`, `PK`, `FK`, `UK`, `<<interface>>`, `<<enumeration>>`, `<<abstract>>`, `<<service>>`, `Repository~T~`, `namespace`, `note for`, `style Important`
- Markdown lint: 0 errors
- Both worked examples (E-Commerce Schema, Multi-Tenant SaaS) unchanged

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/reference only, no code changes)
- **Verification**: Content preservation verified via grep counts on all key syntax patterns

Closes #11544