### PR TITLE
GH#11577: tighten document-creation.md agent doc

### DIFF
--- a/.agents/tools/document/document-creation.md
+++ b/.agents/tools/document/document-creation.md
@@ -66,7 +66,7 @@ document-creation-helper.sh template draft --type letter --format odt
 Unifies document format operations into a single decision tree. Routes to specialist agents (MinerU, DocStrange, LibPDF) when appropriate, handles everything else.
 
 ```text
-Input → [Detect format] → [Select tool (preferred → fallback)] → [Convert/Create] → [Validate] → Output
+Input → [Detect format] → [Select tool (preferred → fallback)] → [Convert/Create] → [Validate (exists, non-empty, valid format)] → Output
 ```
 
 ## Tool Selection Matrix
@@ -198,7 +198,7 @@ Use programmatic creation (odfpy/python-docx) when: document structure is data-d
 | Tier | Install | Tools |
 |------|---------|-------|
 | 1: Minimal | `pandoc poppler` | pandoc (md/docx/odt/html/epub/rst/latex/pptx/xlsx/csv/tsv/rtf), poppler (pdftotext/pdfimages/pdfinfo/pdftohtml) |
-| 2: Standard | + Python libs | odfpy (ODT/ODS/ODP), python-docx (DOCX), openpyxl (XLSX) |
+| 2: Standard | + Python libs | odfpy (programmatic ODT/ODS/ODP), python-docx (programmatic DOCX), openpyxl (programmatic XLSX) |
 | 3: Full | + LibreOffice | `soffice --headless --convert-to <format>` — highest fidelity for office conversions |
 
 ### Specialist Tools (routed to, not owned)

--- a/.agents/tools/document/document-creation.md
+++ b/.agents/tools/document/document-creation.md
@@ -39,31 +39,39 @@ document-creation-helper.sh template draft --type letter --format odt
 
 <!-- AI-CONTEXT-END -->
 
-## Architecture
-
-This agent unifies document format operations into a single decision tree. It does
-not replace the specialist agents (MinerU for layout-aware PDF parsing, DocStrange
-for structured data extraction, LibPDF for PDF form filling) -- it routes to them
-when appropriate and handles everything else.
+## Decision Tree
 
 ```text
-Input (any format)
-     |
-  [Detect format]
-     |
-  [Select tool] -- preferred tool for this format pair
-     |            \-- fallback if preferred unavailable or fails
-  [Convert / Create]
-     |
-  [Validate output] -- file exists, non-empty, format-valid
-     |
-  Output (target format)
+1. What is the task?
+   |
+    +-- Convert format A to format B
+    |   +-- Structured data extraction? → document-extraction.md or docstrange.md
+    |   +-- PDF form filling or signing? → tools/pdf/overview.md (LibPDF)
+    |   +-- PDF with complex layout to markdown? → tools/conversion/mineru.md
+    |   +-- Scanned PDF or image with text? → OCR pipeline (auto-detect provider)
+    |   +-- Otherwise: use tool selection matrix below
+    |
+    +-- Create document from template
+    |   +-- Template supplied? → replace placeholders, save
+    |   +-- No template? → offer to generate draft template
+    |   +-- Complex/data-driven? → odfpy/python-docx programmatically
+    |
+    +-- Generate draft template
+        +-- Collect: format, fields, header/footer, logo
+        +-- Generate with odfpy/python-docx → user refines in editor
+```
+
+## Architecture
+
+Unifies document format operations into a single decision tree. Routes to specialist agents (MinerU, DocStrange, LibPDF) when appropriate, handles everything else.
+
+```text
+Input → [Detect format] → [Select tool (preferred → fallback)] → [Convert/Create] → [Validate] → Output
 ```
 
 ## Tool Selection Matrix
 
-Each format pair has a preferred tool and fallback. The helper script checks
-availability at runtime and selects automatically.
+Format pairs with preferred tool and fallback. The helper checks availability at runtime.
 
 ### Text/Document Formats
 
@@ -76,7 +84,7 @@ availability at runtime and selects automatically.
 | MD | EPUB | pandoc | -- | Native strength |
 | MD | PPTX | pandoc | -- | Slide-per-heading |
 | ODT | MD | pandoc | odfpy (extract XML) | Good quality |
-| ODT | DOCX | pandoc | LibreOffice headless | pandoc is lossless for text; LO better for complex layout |
+| ODT | DOCX | pandoc | LibreOffice headless | pandoc lossless for text; LO better for complex layout |
 | ODT | PDF | LibreOffice headless | pandoc + LaTeX | LO preserves headers/footers/images faithfully |
 | ODT | HTML | pandoc | LibreOffice headless | |
 | DOCX | MD | pandoc | -- | Excellent quality |
@@ -94,10 +102,10 @@ availability at runtime and selects automatically.
 
 | From | To | Preferred | Fallback | Notes |
 |------|----|-----------|----------|-------|
-| EML | MD | email-to-markdown.py | -- | Parses MIME structure, converts HTML body to markdown, extracts attachments |
-| MSG | MD | email-to-markdown.py | -- | Uses extract-msg library, converts HTML body to markdown, extracts attachments |
+| EML | MD | email-to-markdown.py | -- | Parses MIME, converts HTML body, extracts attachments |
+| MSG | MD | email-to-markdown.py | -- | Uses extract-msg, converts HTML body, extracts attachments |
 
-**Email conversion**: Parses MIME/MSG structure, converts HTML body to markdown, extracts attachments to `{filename}_attachments/`, preserves metadata (From, To, Subject, Date) in frontmatter. Dependencies: Python stdlib for `.eml`; `extract-msg` (auto-installed) for `.msg`.
+Attachments extracted to `{filename}_attachments/`. Metadata (From, To, Subject, Date) in frontmatter. Dependencies: Python stdlib for `.eml`; `extract-msg` (auto-installed) for `.msg`.
 
 **Thread reconstruction** (t1054.8):
 
@@ -107,9 +115,9 @@ email-batch-convert-helper.sh convert ./emails    # convert only
 email-batch-convert-helper.sh threads ./emails    # reconstruct only
 ```
 
-Thread metadata added to frontmatter: `thread_id`, `thread_position`, `thread_length`. Output includes `thread-index.md` listing all emails grouped by thread with reply hierarchy.
+Thread metadata in frontmatter: `thread_id`, `thread_position`, `thread_length`. Output includes `thread-index.md` with emails grouped by thread and reply hierarchy.
 
-### PDF Extraction (PDF as source)
+### PDF Extraction
 
 | From | To | Preferred | Fallback | Notes |
 |------|----|-----------|----------|-------|
@@ -142,43 +150,26 @@ Thread metadata added to frontmatter: `thread_id`, `thread_position`, `thread_le
 | ODP | PDF | LibreOffice headless | -- | |
 | MD | PPTX | pandoc | -- | Heading-per-slide |
 
-## Tool Reference
+## OCR Support
 
-### Tier 1: Minimal (pandoc + poppler)
+**Auto-detection**: `pdftotext` returns empty or `pdffonts` shows no embedded fonts → trigger OCR.
 
-- **pandoc**: Reads/writes md, docx, odt, html, epub, rst, latex, pptx, xlsx, csv, tsv, rtf
-- **poppler** (pdftotext, pdfimages, pdfinfo, pdftohtml): PDF text/image extraction, metadata
+| Provider | Install | Speed | Quality | Best For |
+|----------|---------|-------|---------|----------|
+| Tesseract | `brew install tesseract` | Fast | Good (printed text) | Batch processing, simple documents |
+| EasyOCR | `pip install easyocr` | Medium | Good (80+ languages) | Multi-language documents |
+| GLM-OCR | `ollama pull glm-ocr` | Slow | Very good | Privacy-sensitive, complex layouts |
+| Vision LLM | API key required | Medium | Excellent | Photos, receipts, handwriting |
 
-### Tier 2: Standard (+ Python libraries)
+**Selection order** (auto mode): Tesseract → EasyOCR → GLM-OCR → Vision LLM
 
-- **odfpy**: Create/edit ODT, ODS, ODP programmatically
-- **python-docx**: Create/edit DOCX programmatically
-- **openpyxl**: Create/edit XLSX programmatically
+For screenshot/image input: keep as image, extract text (OCR), or both (image + text caption).
 
-### Tier 3: Full (+ LibreOffice headless)
-
-- **LibreOffice headless**: `soffice --headless --convert-to <format> <input>`. Highest fidelity for office format conversions.
-
-### Specialist Tools (routed to, not owned)
-
-| Tool | Agent | When to route |
-|------|-------|---------------|
-| MinerU | `tools/conversion/mineru.md` | PDF with complex layout, tables, formulas, OCR |
-| DocStrange | `tools/document/docstrange.md` | Structured data extraction from documents |
-| Docling+ExtractThinker | `tools/document/document-extraction.md` | Schema-based extraction with PII redaction |
-| LibPDF | `tools/pdf/overview.md` | PDF form filling, digital signatures |
-
-### Advanced Conversion Providers
-
-| Provider | Model | Install | Best For |
-|----------|-------|---------|----------|
-| Reader-LM | Jina, 1.5B | `ollama pull reader-lm` | HTML to markdown with table preservation |
-| RolmOCR | Reducto, 7B | vLLM server with RolmOCR model | PDF page images to markdown with table preservation (GPU-accelerated) |
+**Related OCR agents**: `tools/ocr/glm-ocr.md`, `tools/ocr/ocr-research.md`, `tools/document/document-extraction.md`, `tools/conversion/mineru.md`
 
 ## Document Creation from Templates
 
 **Placeholder syntax**: `{{field_name}}`
-
 **Template storage**: `~/.aidevops/.agent-workspace/templates/` (documents/, spreadsheets/, presentations/)
 
 ```bash
@@ -201,6 +192,30 @@ document-creation-helper.sh create --script generate-report.py \
 ```
 
 Use programmatic creation (odfpy/python-docx) when: document structure is data-driven, no visual template exists, or batch generation with different structures.
+
+## Tool Tiers and Routing
+
+| Tier | Install | Tools |
+|------|---------|-------|
+| 1: Minimal | `pandoc poppler` | pandoc (md/docx/odt/html/epub/rst/latex/pptx/xlsx/csv/tsv/rtf), poppler (pdftotext/pdfimages/pdfinfo/pdftohtml) |
+| 2: Standard | + Python libs | odfpy (ODT/ODS/ODP), python-docx (DOCX), openpyxl (XLSX) |
+| 3: Full | + LibreOffice | `soffice --headless --convert-to <format>` — highest fidelity for office conversions |
+
+### Specialist Tools (routed to, not owned)
+
+| Tool | Agent | When to route |
+|------|-------|---------------|
+| MinerU | `tools/conversion/mineru.md` | PDF with complex layout, tables, formulas, OCR |
+| DocStrange | `tools/document/docstrange.md` | Structured data extraction from documents |
+| Docling+ExtractThinker | `tools/document/document-extraction.md` | Schema-based extraction with PII redaction |
+| LibPDF | `tools/pdf/overview.md` | PDF form filling, digital signatures |
+
+### Advanced Conversion Providers
+
+| Provider | Model | Install | Best For |
+|----------|-------|---------|----------|
+| Reader-LM | Jina, 1.5B | `ollama pull reader-lm` | HTML to markdown with table preservation |
+| RolmOCR | Reducto, 7B | vLLM server with RolmOCR model | PDF page images to markdown with table preservation (GPU-accelerated) |
 
 ## Installation
 
@@ -244,50 +259,10 @@ document-creation-helper.sh convert scanned.pdf --to odt --ocr tesseract
 document-creation-helper.sh convert screenshot.png --to md --ocr auto
 ```
 
-## Decision Tree
-
-```text
-1. What is the task?
-   |
-    +-- Convert format A to format B
-    |   |
-    |   +-- Structured data extraction? → document-extraction.md or docstrange.md
-    |   +-- PDF form filling or signing? → tools/pdf/overview.md (LibPDF)
-    |   +-- PDF with complex layout to markdown? → tools/conversion/mineru.md
-    |   +-- Scanned PDF or image with text? → OCR pipeline (auto-detect provider)
-    |   +-- Otherwise: use tool selection matrix above
-    |
-    +-- Create document from template
-    |   +-- Template supplied? → replace placeholders, save
-    |   +-- No template? → offer to generate draft template
-    |   +-- Complex/data-driven? → odfpy/python-docx programmatically
-    |
-    +-- Generate draft template
-        +-- Collect: format, fields, header/footer, logo
-        +-- Generate with odfpy/python-docx → user refines in editor
-```
-
-## OCR Support
-
-**Auto-detection**: `pdftotext` returns empty → pages are images; `pdffonts` shows no embedded fonts → trigger OCR.
-
-| Provider | Install | Speed | Quality | Best For |
-|----------|---------|-------|---------|----------|
-| Tesseract | `brew install tesseract` | Fast | Good (printed text) | Batch processing, simple documents |
-| EasyOCR | `pip install easyocr` | Medium | Good (80+ languages) | Multi-language documents |
-| GLM-OCR | `ollama pull glm-ocr` | Slow | Very good | Privacy-sensitive, complex layouts |
-| Vision LLM | API key required | Medium | Excellent | Photos, receipts, handwriting |
-
-**Selection order** (auto mode): Tesseract → EasyOCR → GLM-OCR → Vision LLM
-
-For screenshot/image input, options: keep as image, extract text (OCR), or both (image + text caption).
-
-**Related OCR agents**: `tools/ocr/glm-ocr.md`, `tools/ocr/ocr-research.md`, `tools/document/document-extraction.md`, `tools/conversion/mineru.md`
-
 ## Limitations
 
 - **PDF to editable formats**: inherently lossy — text/images transfer well, exact positioning does not
-- **Spreadsheet formulas**: may not survive format conversion; values preserved, formulas need verification
+- **Spreadsheet formulas**: may not survive conversion; values preserved, formulas need verification
 - **Presentation animations/transitions**: lost in most conversions
 - **Embedded fonts**: may not transfer; output uses fallback fonts if original unavailable
 - **LibreOffice headless**: highest fidelity but large install (~500MB); pandoc used as fallback


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/document/document-creation.md` from 303 → 278 lines (~8% reduction) while preserving all institutional knowledge.

Closes #11577

## Changes

- **Reorder by importance**: Decision Tree moved immediately after Quick Reference (primary routing use case — LLMs weight earlier context more heavily)
- **Compress Architecture**: 13-line ASCII diagram → single-line flow notation
- **Merge Tool Reference**: Three tier subsections with bullet lists → compact summary table ("Tool Tiers and Routing")
- **Tighten prose**: Removed redundant section intros, compressed email conversion notes, shortened table cell text
- **Reorder OCR**: Moved OCR Support before Templates (more commonly needed)

## Content Preservation

- All task IDs: `t1054.8` ✓
- All code blocks: 14 (7 pairs) ✓
- All helper commands: 23 references to `document-creation-helper.sh` ✓
- All specialist tools: MinerU, DocStrange, Docling+ExtractThinker, LibPDF ✓
- All OCR providers: Tesseract, EasyOCR, GLM-OCR, Vision LLM, RolmOCR, Reader-LM ✓
- All Related links: 7 cross-references ✓
- Email batch convert commands: 3 ✓

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (agent prompt doc, no code logic)
- **Verification**: markdownlint-cli2 — 0 errors