### PR TITLE
GH#11502: split extraction-schemas.md into chapter files with slim index

### DIFF
--- a/.agents/tools/document/extraction-schemas.md
+++ b/.agents/tools/document/extraction-schemas.md
@@ -14,9 +14,11 @@ tools:
 
 # Extraction Schemas
 
+<!-- AI-CONTEXT-START -->
+
 ## Quick Reference
 
-- **Pipeline**: Docling (parse) → ExtractThinker (extract) → QuickFile (record)
+- **Pipeline**: Docling (parse) -> ExtractThinker (extract) -> QuickFile (record)
 - **Helper**: `document-extraction-helper.sh extract file.pdf --schema <name>`
 
 | Document Type | Schema | QuickFile Target |
@@ -27,22 +29,30 @@ tools:
 | Credit note from supplier | `credit-note` | `quickfile_purchase_create` (negative) |
 | Generic receipt (non-accounting) | `receipt` | N/A |
 
-**Classification signals:**
+<!-- AI-CONTEXT-END -->
 
-```text
-"Invoice" / "Tax Invoice"  -> purchase-invoice (supplier) or invoice (you issued it)
-"Receipt" / "Till Receipt" -> expense-receipt
-"Credit Note" / "CN-"      -> credit-note
-"Estimate" / "Quote"       -> skip
-"Statement"                -> skip
+## Chapter Index
 
-Disambiguation:
-  Your company name in "From" field -> invoice (you issued it)
-  Your company name in "To" field   -> purchase-invoice (supplier issued it)
-  No invoice number + till format   -> expense-receipt
-```
+Full schema definitions, field mappings, and reference data in focused chapters:
 
-## Schemas
+| # | Chapter | Description |
+|---|---------|-------------|
+| 01 | [Design Principles](extraction-schemas/01-design-principles.md) | 8 schema design rules (field naming, types, VAT, confidence) |
+| 02 | [Purchase Invoice](extraction-schemas/02-purchase-invoice.md) | `PurchaseInvoice` + `VatRate` enum + `PurchaseLineItem` — full Pydantic models |
+| 03 | [Expense Receipt](extraction-schemas/03-expense-receipt.md) | `ExpenseReceipt` + `ExpenseCategory` enum + `ReceiptItem` — full Pydantic models |
+| 04 | [Credit Note](extraction-schemas/04-credit-note.md) | `CreditNote` model (reuses `PurchaseLineItem`) |
+| 05 | [Sales Invoice](extraction-schemas/05-sales-invoice.md) | `Invoice` + `SalesLineItem` — full Pydantic models |
+| 06 | [Generic Receipt](extraction-schemas/06-generic-receipt.md) | `Receipt` model (non-accounting, reuses `ReceiptItem`) |
+| 07 | [QuickFile Mapping](extraction-schemas/07-quickfile-mapping.md) | Field-to-parameter mapping tables for purchase and expense flows |
+| 08 | [VAT Handling](extraction-schemas/08-vat-handling.md) | UK VAT rate detection patterns + validation rules |
+| 09 | [Nominal Codes](extraction-schemas/09-nominal-codes.md) | Auto-categorisation table (merchant pattern -> nominal code) |
+| 10 | [Classification](extraction-schemas/10-classification.md) | Document type classification signals and disambiguation |
+| 11 | [Pipeline Integration](extraction-schemas/11-pipeline-integration.md) | CLI commands: single extract, batch, full pipeline (t012.4) |
+| 12 | [Validation](extraction-schemas/12-validation.md) | Confidence scoring and validation summary JSON format |
+
+## Compact Schema Reference
+
+All models in one block for quick inline reference. Full annotated versions in chapters 02-06.
 
 ```python
 from pydantic import BaseModel, Field
@@ -147,89 +157,6 @@ class Invoice(BaseModel):
     line_items: list[SalesLineItem] = Field(default_factory=list)
     payment_terms: Optional[str] = Field(default=None)
     document_type: str = Field(default="invoice")
-```
-
-## QuickFile Field Mapping
-
-`purchase-invoice` and `expense-receipt` both map to `quickfile_purchase_create`:
-
-| Extracted Field | QuickFile Parameter | purchase-invoice | expense-receipt |
-|----------------|---------------------|-----------------|-----------------|
-| `vendor_name` / `merchant_name` | Lookup → `supplierId` | Required | Required; create if not found |
-| `invoice_number` / `receipt_number` | `supplierRef` | Required | Optional |
-| `invoice_date` / `date` | `issueDate` | YYYY-MM-DD | YYYY-MM-DD |
-| `due_date` | `dueDate` | Or calc from `payment_terms` | — |
-| `currency` | `currency` | Default: GBP | Default: GBP |
-| `line_items[].description` / `items[].name` | `lines[].description` | Max 5000 chars | Single line from `total` if no items |
-| `line_items[].unit_price` / `items[].price` | `lines[].unitCost` | Per unit | qty=1 |
-| `line_items[].vat_rate` | `lines[].vatPercentage` | Default: 20 | Infer from `vat_amount` if missing |
-| `line_items[].nominal_code` / `expense_category` | `lines[].nominalCode` | Auto-categorise if missing | All lines same category |
-
-## VAT Handling
-
-| Receipt Pattern | Meaning | Rate |
-|----------------|---------|------|
-| `VAT @ 20%` | Standard rate | 20 |
-| `VAT @ 5%` | Reduced rate | 5 |
-| `VAT: 0.00` or `Zero rated` | Zero-rated | 0 |
-| `*` or `A` next to item | Standard rate (supermarket) | 20 |
-| `B` or no marker | Zero-rated (supermarket) | 0 |
-| `VAT Exempt` | Exempt | exempt |
-| `No VAT` or no VAT line | Out of scope | oos |
-| `Reverse Charge` | Reverse charge (B2B) | servrc |
-
-```text
-# VAT validation rules
-1. subtotal + vat_amount != total (>0.02 tolerance) -> flag for manual review
-2. vat_amount > 0 but no vendor_vat_number -> warning: VAT claimed without supplier VAT number
-3. line_items VAT sum != total vat_amount (>0.05 tolerance) -> recalculate from line items
-4. vat_rate not in [0, 5, 20, exempt, oos, servrc, cisrc, postgoods] -> flag as unusual
-```
-
-## Nominal Code Auto-Categorisation
-
-| Merchant/Item Pattern | Nominal Code | Category |
-|----------------------|-------------|----------|
-| Amazon, Staples, office supplies | 7504 | Stationery & Office Supplies |
-| Shell, BP, Esso, fuel, petrol, diesel | 7401 | Motor Expenses - Fuel |
-| Hotel, Airbnb, accommodation | 7403 | Hotel & Accommodation |
-| Restaurant, cafe, food, lunch | 7402 | Subsistence |
-| Train, bus, taxi, Uber, parking | 7400 | Travel & Subsistence |
-| Royal Mail, DHL, FedEx, postage | 7501 | Postage & Shipping |
-| BT, Vodafone, phone, broadband | 7502 | Telephone & Internet |
-| Adobe, Microsoft, SaaS, subscription | 7404 | Computer Software |
-| Google Ads, Facebook Ads, marketing | 6201 | Advertising & Marketing |
-| Accountant, solicitor, legal | 7600 | Professional Fees |
-| Plumber, electrician, repair | 7300 | Repairs & Maintenance |
-| *Default (no match)* | 5000 | General Purchases |
-
-## Extraction Pipeline
-
-```bash
-document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --privacy local
-document-extraction-helper.sh extract document.pdf --schema auto --privacy local
-document-extraction-helper.sh batch ./receipts/ --schema auto --privacy local
-
-# Full pipeline: extract -> review -> record
-document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --privacy local
-cat ~/.aidevops/.agent-workspace/work/document-extraction/invoice-extracted.json
-quickfile-helper.sh record-purchase invoice-extracted.json --auto-supplier
-quickfile-helper.sh batch-record ~/.aidevops/.agent-workspace/work/ocr-receipts/
-```
-
-## Confidence and Validation
-
-Fields with confidence < 0.7 are flagged for manual review.
-
-```json
-{
-  "extraction": { "...schema fields..." },
-  "validation": {
-    "vat_check": "pass", "total_check": "pass", "date_valid": true, "currency_detected": "GBP",
-    "confidence": { "vendor_name": 0.95, "total": 0.99, "vat_amount": 0.85, "line_items": 0.80 },
-    "warnings": [], "requires_review": false
-  }
-}
 ```
 
 ## Related

--- a/.agents/tools/document/extraction-schemas/01-design-principles.md
+++ b/.agents/tools/document/extraction-schemas/01-design-principles.md
@@ -1,0 +1,10 @@
+# Schema Design Principles
+
+1. **Field names match document terminology** - `vendor_name` not `SupplierID`
+2. **Optional fields have defaults** - extraction works even with partial data
+3. **Dates use ISO 8601** - `YYYY-MM-DD` for unambiguous parsing
+4. **Amounts are floats** - not strings, enabling arithmetic validation
+5. **VAT is explicit** - rate and amount separated for UK compliance
+6. **Currency is ISO 4217** - 3-letter codes (GBP, USD, EUR)
+7. **Line items are structured** - not free text, enabling per-line VAT
+8. **Confidence scores** - optional per-field confidence for QA workflows

--- a/.agents/tools/document/extraction-schemas/02-purchase-invoice.md
+++ b/.agents/tools/document/extraction-schemas/02-purchase-invoice.md
@@ -1,0 +1,124 @@
+# Purchase Invoice Schema (Supplier Invoice)
+
+Use for formal invoices received from suppliers with an invoice number.
+
+## Shared Types
+
+```python
+from pydantic import BaseModel, Field
+from typing import Optional
+from enum import Enum
+
+
+class VatRate(str, Enum):
+    """UK VAT rates and special codes."""
+    STANDARD = "20"
+    REDUCED = "5"
+    ZERO = "0"
+    EXEMPT = "exempt"
+    OUT_OF_SCOPE = "oos"
+    REVERSE_CHARGE = "servrc"
+    CIS_REVERSE = "cisrc"
+    PVA_GOODS = "postgoods"
+
+
+class PurchaseLineItem(BaseModel):
+    """A single line item on a purchase invoice."""
+    description: str = Field(
+        ..., description="Item or service description", max_length=5000
+    )
+    quantity: float = Field(
+        default=1.0, description="Number of units", ge=0
+    )
+    unit_price: float = Field(
+        ..., description="Price per unit excluding VAT"
+    )
+    amount: float = Field(
+        ..., description="Line total excluding VAT (quantity * unit_price)"
+    )
+    vat_rate: str = Field(
+        default="20", description="VAT rate percentage or special code"
+    )
+    vat_amount: Optional[float] = Field(
+        default=None, description="VAT amount for this line (calculated if omitted)"
+    )
+    nominal_code: Optional[str] = Field(
+        default=None,
+        description="Accounting nominal code (e.g., 5000=General Purchases, "
+        "7501=Postage, 7502=Telephone). Auto-categorised if omitted.",
+        min_length=2, max_length=5
+    )
+```
+
+## PurchaseInvoice Model
+
+```python
+class PurchaseInvoice(BaseModel):
+    """
+    Schema for supplier invoices received for goods/services purchased.
+
+    Maps to: quickfile_purchase_create
+    """
+    # Vendor identification
+    vendor_name: str = Field(
+        ..., description="Supplier/vendor company name"
+    )
+    vendor_address: Optional[str] = Field(
+        default=None, description="Supplier address (full or partial)"
+    )
+    vendor_vat_number: Optional[str] = Field(
+        default=None, description="Supplier VAT registration number"
+    )
+    vendor_company_number: Optional[str] = Field(
+        default=None, description="Supplier company registration number"
+    )
+
+    # Invoice identification
+    invoice_number: str = Field(
+        ..., description="Supplier's invoice reference number"
+    )
+    invoice_date: str = Field(
+        ..., description="Date invoice was issued (YYYY-MM-DD)"
+    )
+    due_date: Optional[str] = Field(
+        default=None, description="Payment due date (YYYY-MM-DD)"
+    )
+    purchase_order: Optional[str] = Field(
+        default=None, description="Purchase order number if referenced"
+    )
+
+    # Financial totals
+    subtotal: float = Field(
+        ..., description="Total before VAT"
+    )
+    vat_amount: float = Field(
+        default=0.0, description="Total VAT amount"
+    )
+    total: float = Field(
+        ..., description="Total including VAT"
+    )
+    currency: str = Field(
+        default="GBP", description="ISO 4217 currency code",
+        min_length=3, max_length=3
+    )
+
+    # Line items
+    line_items: list[PurchaseLineItem] = Field(
+        default_factory=list,
+        description="Individual line items (up to 500)"
+    )
+
+    # Payment info
+    payment_terms: Optional[str] = Field(
+        default=None, description="Payment terms (e.g., 'Net 30', '14 days')"
+    )
+    bank_details: Optional[str] = Field(
+        default=None, description="Supplier bank details for payment"
+    )
+
+    # Metadata
+    document_type: str = Field(
+        default="purchase_invoice",
+        description="Document classification"
+    )
+```

--- a/.agents/tools/document/extraction-schemas/03-expense-receipt.md
+++ b/.agents/tools/document/extraction-schemas/03-expense-receipt.md
@@ -1,0 +1,121 @@
+# Expense Receipt Schema (Till/Shop Receipt)
+
+Use for informal receipts from shops, restaurants, fuel stations, etc.
+
+## ExpenseCategory Enum
+
+```python
+class ExpenseCategory(str, Enum):
+    """Common expense categories with QuickFile nominal codes."""
+    OFFICE_SUPPLIES = "7504"       # Stationery & Office Supplies
+    TRAVEL = "7400"                # Travel & Subsistence
+    FUEL = "7401"                  # Motor Expenses - Fuel
+    MEALS = "7402"                 # Subsistence
+    ACCOMMODATION = "7403"         # Hotel & Accommodation
+    TELEPHONE = "7502"             # Telephone & Internet
+    POSTAGE = "7501"               # Postage & Shipping
+    SOFTWARE = "7404"              # Computer Software
+    EQUIPMENT = "0030"             # Office Equipment (asset)
+    GENERAL = "5000"               # General Purchases
+    ADVERTISING = "6201"           # Advertising & Marketing
+    PROFESSIONAL = "7600"          # Professional Fees
+    REPAIRS = "7300"               # Repairs & Maintenance
+    SUBSCRIPTIONS = "7900"         # Subscriptions
+```
+
+## ReceiptItem Model
+
+```python
+class ReceiptItem(BaseModel):
+    """A single item on a receipt."""
+    name: str = Field(
+        ..., description="Item name or description"
+    )
+    quantity: float = Field(
+        default=1.0, description="Number of units"
+    )
+    unit_price: Optional[float] = Field(
+        default=None, description="Price per unit"
+    )
+    price: float = Field(
+        ..., description="Total price for this item"
+    )
+    vat_rate: Optional[str] = Field(
+        default=None,
+        description="VAT rate if shown (e.g., '20', '0', 'A'=standard, 'B'=zero)"
+    )
+```
+
+## ExpenseReceipt Model
+
+```python
+class ExpenseReceipt(BaseModel):
+    """
+    Schema for informal receipts (shops, restaurants, fuel stations).
+
+    Maps to: quickfile_purchase_create (with auto-categorisation)
+    """
+    # Merchant identification
+    merchant_name: str = Field(
+        ..., description="Shop/restaurant/vendor name"
+    )
+    merchant_address: Optional[str] = Field(
+        default=None, description="Merchant address"
+    )
+    merchant_vat_number: Optional[str] = Field(
+        default=None, description="Merchant VAT number (if shown)"
+    )
+
+    # Receipt identification
+    receipt_number: Optional[str] = Field(
+        default=None, description="Receipt/transaction number"
+    )
+    date: str = Field(
+        ..., description="Transaction date (YYYY-MM-DD)"
+    )
+    time: Optional[str] = Field(
+        default=None, description="Transaction time (HH:MM)"
+    )
+
+    # Financial totals
+    subtotal: Optional[float] = Field(
+        default=None, description="Total before VAT (if shown separately)"
+    )
+    vat_amount: Optional[float] = Field(
+        default=None, description="VAT amount (if shown)"
+    )
+    total: float = Field(
+        ..., description="Total amount paid"
+    )
+    currency: str = Field(
+        default="GBP", description="ISO 4217 currency code",
+        min_length=3, max_length=3
+    )
+
+    # Items
+    items: list[ReceiptItem] = Field(
+        default_factory=list,
+        description="Individual items purchased"
+    )
+
+    # Payment
+    payment_method: Optional[str] = Field(
+        default=None,
+        description="Payment method (cash, card, contactless, etc.)"
+    )
+    card_last_four: Optional[str] = Field(
+        default=None, description="Last 4 digits of card used"
+    )
+
+    # Categorisation
+    expense_category: Optional[str] = Field(
+        default=None,
+        description="Expense category nominal code (auto-categorised if omitted)"
+    )
+
+    # Metadata
+    document_type: str = Field(
+        default="expense_receipt",
+        description="Document classification"
+    )
+```

--- a/.agents/tools/document/extraction-schemas/04-credit-note.md
+++ b/.agents/tools/document/extraction-schemas/04-credit-note.md
@@ -1,0 +1,53 @@
+# Credit Note Schema
+
+Use for credit notes received from suppliers (refunds, adjustments).
+
+Reuses `PurchaseLineItem` from [02-purchase-invoice.md](02-purchase-invoice.md).
+
+```python
+class CreditNote(BaseModel):
+    """
+    Schema for credit notes received from suppliers.
+
+    Maps to: quickfile_purchase_create (with negative amounts)
+    """
+    vendor_name: str = Field(
+        ..., description="Supplier/vendor company name"
+    )
+    credit_note_number: str = Field(
+        ..., description="Credit note reference number"
+    )
+    date: str = Field(
+        ..., description="Credit note date (YYYY-MM-DD)"
+    )
+    original_invoice: Optional[str] = Field(
+        default=None, description="Original invoice number being credited"
+    )
+
+    subtotal: float = Field(
+        ..., description="Credit amount before VAT (positive number)"
+    )
+    vat_amount: float = Field(
+        default=0.0, description="VAT credit amount"
+    )
+    total: float = Field(
+        ..., description="Total credit including VAT"
+    )
+    currency: str = Field(
+        default="GBP", description="ISO 4217 currency code",
+        min_length=3, max_length=3
+    )
+
+    reason: Optional[str] = Field(
+        default=None, description="Reason for credit"
+    )
+    line_items: list[PurchaseLineItem] = Field(
+        default_factory=list,
+        description="Credited line items"
+    )
+
+    document_type: str = Field(
+        default="credit_note",
+        description="Document classification"
+    )
+```

--- a/.agents/tools/document/extraction-schemas/05-sales-invoice.md
+++ b/.agents/tools/document/extraction-schemas/05-sales-invoice.md
@@ -1,0 +1,88 @@
+# Sales Invoice Schema (Issued by You)
+
+Use for invoices you have issued to clients (existing schema, enhanced).
+
+## SalesLineItem Model
+
+```python
+class SalesLineItem(BaseModel):
+    """A single line item on a sales invoice."""
+    description: str = Field(
+        ..., description="Service or product description", max_length=5000
+    )
+    quantity: float = Field(
+        default=1.0, description="Number of units or hours"
+    )
+    unit_price: float = Field(
+        ..., description="Price per unit excluding VAT"
+    )
+    amount: float = Field(
+        ..., description="Line total excluding VAT"
+    )
+    vat_rate: str = Field(
+        default="20", description="VAT rate percentage"
+    )
+    vat_amount: Optional[float] = Field(
+        default=None, description="VAT amount for this line"
+    )
+```
+
+## Invoice Model
+
+```python
+class Invoice(BaseModel):
+    """
+    Schema for sales invoices (issued by you to clients).
+
+    Maps to: quickfile_invoice_create
+    """
+    # Client identification
+    client_name: str = Field(
+        ..., description="Client/customer company or individual name"
+    )
+    client_address: Optional[str] = Field(
+        default=None, description="Client billing address"
+    )
+
+    # Invoice identification
+    invoice_number: str = Field(
+        ..., description="Your invoice number"
+    )
+    invoice_date: str = Field(
+        ..., description="Date invoice was issued (YYYY-MM-DD)"
+    )
+    due_date: Optional[str] = Field(
+        default=None, description="Payment due date (YYYY-MM-DD)"
+    )
+
+    # Financial totals
+    subtotal: float = Field(
+        ..., description="Total before VAT"
+    )
+    vat_amount: float = Field(
+        default=0.0, description="Total VAT amount"
+    )
+    total: float = Field(
+        ..., description="Total including VAT"
+    )
+    currency: str = Field(
+        default="GBP", description="ISO 4217 currency code",
+        min_length=3, max_length=3
+    )
+
+    # Line items
+    line_items: list[SalesLineItem] = Field(
+        default_factory=list,
+        description="Individual line items"
+    )
+
+    # Payment
+    payment_terms: Optional[str] = Field(
+        default=None, description="Payment terms"
+    )
+
+    document_type: str = Field(
+        default="invoice",
+        description="Document classification"
+    )
+```

--- a/.agents/tools/document/extraction-schemas/06-generic-receipt.md
+++ b/.agents/tools/document/extraction-schemas/06-generic-receipt.md
@@ -1,0 +1,38 @@
+# Generic Receipt Schema (Non-Accounting)
+
+Use for general-purpose receipt extraction without accounting integration.
+
+Reuses `ReceiptItem` from [03-expense-receipt.md](03-expense-receipt.md).
+
+```python
+class Receipt(BaseModel):
+    """
+    Schema for generic receipts (no accounting integration).
+
+    Use expense-receipt for accounting workflows instead.
+    """
+    merchant: str = Field(
+        ..., description="Merchant/vendor name"
+    )
+    date: str = Field(
+        ..., description="Transaction date (YYYY-MM-DD)"
+    )
+    total: float = Field(
+        ..., description="Total amount"
+    )
+    currency: str = Field(
+        default="GBP", description="ISO 4217 currency code"
+    )
+    payment_method: Optional[str] = Field(
+        default=None, description="Payment method"
+    )
+    items: list[ReceiptItem] = Field(
+        default_factory=list,
+        description="Items purchased"
+    )
+
+    document_type: str = Field(
+        default="receipt",
+        description="Document classification"
+    )
+```

--- a/.agents/tools/document/extraction-schemas/07-quickfile-mapping.md
+++ b/.agents/tools/document/extraction-schemas/07-quickfile-mapping.md
@@ -1,0 +1,36 @@
+# QuickFile Field Mapping
+
+## Purchase Invoice -> `quickfile_purchase_create`
+
+| Extracted Field | QuickFile Parameter | Notes |
+|----------------|--------------------|----|
+| `vendor_name` | Lookup via `quickfile_supplier_search` -> `supplierId` | Create supplier if not found |
+| `invoice_number` | `supplierRef` | Supplier's reference number |
+| `invoice_date` | `issueDate` | YYYY-MM-DD format |
+| `due_date` | `dueDate` | Or calculate from `payment_terms` |
+| `currency` | `currency` | Default: GBP |
+| `line_items[].description` | `lines[].description` | Max 5000 chars |
+| `line_items[].quantity` | `lines[].quantity` | |
+| `line_items[].unit_price` | `lines[].unitCost` | |
+| `line_items[].vat_rate` | `lines[].vatPercentage` | Default: 20 |
+| `line_items[].nominal_code` | `lines[].nominalCode` | Auto-categorise if missing |
+
+## Expense Receipt -> `quickfile_purchase_create`
+
+Expense receipts require additional processing before QuickFile submission:
+
+1. **Supplier resolution**: Search by `merchant_name`, create if not found
+2. **Date handling**: Use `date` as `issueDate`
+3. **Line item consolidation**: If no line items, create single line from `total`
+4. **VAT inference**: If `vat_amount` present but no per-item rates, calculate from total
+5. **Category mapping**: Use `expense_category` or auto-categorise from merchant/items
+
+| Extracted Field | QuickFile Parameter | Notes |
+|----------------|--------------------|----|
+| `merchant_name` | Lookup -> `supplierId` | Create supplier if not found |
+| `receipt_number` | `supplierRef` | Optional |
+| `date` | `issueDate` | |
+| `total` | Derived from lines | |
+| `items[].name` | `lines[].description` | |
+| `items[].price` | `lines[].unitCost` (qty=1) | |
+| `expense_category` | `lines[].nominalCode` | All lines same category |

--- a/.agents/tools/document/extraction-schemas/08-vat-handling.md
+++ b/.agents/tools/document/extraction-schemas/08-vat-handling.md
@@ -1,0 +1,32 @@
+# VAT Handling
+
+## UK VAT Rate Detection
+
+The extraction pipeline should detect VAT from these common patterns:
+
+| Receipt Pattern | Meaning | Rate |
+|----------------|---------|------|
+| `VAT @ 20%` | Standard rate | 20 |
+| `VAT @ 5%` | Reduced rate | 5 |
+| `VAT: 0.00` or `Zero rated` | Zero-rated | 0 |
+| `*` or `A` next to item | Standard rate (supermarket convention) | 20 |
+| `B` or no marker | Zero-rated (supermarket convention) | 0 |
+| `VAT Exempt` | Exempt | exempt |
+| `No VAT` or no VAT line | Out of scope or not VAT registered | oos |
+| `Reverse Charge` | Reverse charge (B2B services) | servrc |
+
+## VAT Validation Rules
+
+```text
+1. If subtotal + vat_amount != total (within 0.02 tolerance):
+   -> Flag for manual review
+
+2. If vat_amount > 0 but no vendor_vat_number:
+   -> Warning: VAT claimed without supplier VAT number
+
+3. If line_items VAT sum != total vat_amount (within 0.05 tolerance):
+   -> Recalculate from line items (line items take precedence)
+
+4. If vat_rate not in [0, 5, 20, exempt, oos, servrc, cisrc, postgoods]:
+   -> Flag as unusual rate for review
+```

--- a/.agents/tools/document/extraction-schemas/09-nominal-codes.md
+++ b/.agents/tools/document/extraction-schemas/09-nominal-codes.md
@@ -1,0 +1,18 @@
+# Nominal Code Auto-Categorisation
+
+When `nominal_code` is not extracted from the document, infer from context:
+
+| Merchant/Item Pattern | Nominal Code | Category |
+|----------------------|-------------|----------|
+| Amazon, Staples, office supplies | 7504 | Stationery & Office Supplies |
+| Shell, BP, Esso, fuel, petrol, diesel | 7401 | Motor Expenses - Fuel |
+| Hotel, Airbnb, accommodation | 7403 | Hotel & Accommodation |
+| Restaurant, cafe, food, lunch | 7402 | Subsistence |
+| Train, bus, taxi, Uber, parking | 7400 | Travel & Subsistence |
+| Royal Mail, DHL, FedEx, postage | 7501 | Postage & Shipping |
+| BT, Vodafone, phone, broadband | 7502 | Telephone & Internet |
+| Adobe, Microsoft, SaaS, subscription | 7404 | Computer Software |
+| Google Ads, Facebook Ads, marketing | 6201 | Advertising & Marketing |
+| Accountant, solicitor, legal | 7600 | Professional Fees |
+| Plumber, electrician, repair | 7300 | Repairs & Maintenance |
+| *Default (no match)* | 5000 | General Purchases |

--- a/.agents/tools/document/extraction-schemas/10-classification.md
+++ b/.agents/tools/document/extraction-schemas/10-classification.md
@@ -1,0 +1,18 @@
+# Document Classification
+
+Before extraction, classify the document to select the correct schema:
+
+```text
+Classification signals:
+  "Invoice" / "Tax Invoice"     -> purchase-invoice (if from supplier)
+                                -> invoice (if issued by you)
+  "Receipt" / "Till Receipt"    -> expense-receipt
+  "Credit Note" / "CN-"        -> credit-note
+  "Estimate" / "Quote"         -> Not an extraction target (skip)
+  "Statement"                  -> Not an extraction target (skip)
+
+Disambiguation:
+  - Your company name in "From" field -> invoice (you issued it)
+  - Your company name in "To" field   -> purchase-invoice (supplier issued it)
+  - No invoice number + till format   -> expense-receipt
+```

--- a/.agents/tools/document/extraction-schemas/11-pipeline-integration.md
+++ b/.agents/tools/document/extraction-schemas/11-pipeline-integration.md
@@ -1,0 +1,40 @@
+# Extraction Pipeline Integration
+
+## Single Document
+
+```bash
+# Extract with specific schema
+document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --privacy local
+
+# Auto-classify and extract
+document-extraction-helper.sh extract document.pdf --schema auto --privacy local
+```
+
+## Batch Processing
+
+```bash
+# Process folder of mixed documents
+document-extraction-helper.sh batch ./receipts/ --schema auto --privacy local
+
+# Process only invoices
+document-extraction-helper.sh batch ./invoices/ --schema purchase-invoice
+```
+
+## Full Pipeline (Extract -> Validate -> Record)
+
+```bash
+# 1. Extract
+document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --privacy local
+
+# 2. Review extracted JSON (human or AI validation)
+cat ~/.aidevops/.agent-workspace/work/document-extraction/invoice-extracted.json
+
+# 3. Record in QuickFile (t012.4)
+quickfile-helper.sh record-purchase invoice-extracted.json --auto-supplier
+
+# Or for expense receipts (auto-categorises nominal code):
+quickfile-helper.sh record-expense receipt-extracted.json --auto-supplier
+
+# Batch record all extracted files:
+quickfile-helper.sh batch-record ~/.aidevops/.agent-workspace/work/ocr-receipts/
+```

--- a/.agents/tools/document/extraction-schemas/12-validation.md
+++ b/.agents/tools/document/extraction-schemas/12-validation.md
@@ -1,0 +1,25 @@
+# Confidence and Validation
+
+Each extraction should include a validation summary:
+
+```json
+{
+  "extraction": { "...schema fields..." },
+  "validation": {
+    "vat_check": "pass",
+    "total_check": "pass",
+    "date_valid": true,
+    "currency_detected": "GBP",
+    "confidence": {
+      "vendor_name": 0.95,
+      "total": 0.99,
+      "vat_amount": 0.85,
+      "line_items": 0.80
+    },
+    "warnings": [],
+    "requires_review": false
+  }
+}
+```
+
+Fields with confidence below 0.7 should be flagged for manual review.


### PR DESCRIPTION
## Summary

- Restructured `.agents/tools/document/extraction-schemas.md` (reference corpus) from a 243-line monolithic file into a 170-line slim index + 12 focused chapter files (603 lines total)
- Each chapter contains full annotated Pydantic models, field mapping tables, or reference data (VAT rates, nominal codes, classification signals)
- Zero content loss: all code blocks, task IDs (`t012.4`), field mappings, and related links preserved

## Classification

**Reference corpus** (not instruction doc) — contains Pydantic schema definitions, field mapping tables, VAT reference data, and nominal code categorisation tables. Per issue guidance, split into chapter files with slim index rather than content compression.

## Chapter Structure

| # | Chapter | Content |
|---|---------|---------|
| 01 | Design Principles | 8 schema design rules |
| 02 | Purchase Invoice | `PurchaseInvoice` + `VatRate` + `PurchaseLineItem` |
| 03 | Expense Receipt | `ExpenseReceipt` + `ExpenseCategory` + `ReceiptItem` |
| 04 | Credit Note | `CreditNote` model |
| 05 | Sales Invoice | `Invoice` + `SalesLineItem` |
| 06 | Generic Receipt | `Receipt` model |
| 07 | QuickFile Mapping | Field-to-parameter mapping tables |
| 08 | VAT Handling | UK VAT rate detection + validation rules |
| 09 | Nominal Codes | Auto-categorisation table |
| 10 | Classification | Document type signals + disambiguation |
| 11 | Pipeline Integration | CLI commands (single, batch, full pipeline) |
| 12 | Validation | Confidence scoring + validation JSON |

## Verification

- `wc -l` total of chapter files (603) >= original (243) minus index overhead
- All code blocks, task IDs, and command examples present in chapters
- External references to `extraction-schemas.md` unchanged (file path stable)
- `markdownlint-cli2`: 0 errors across all 13 files
- No broken internal links

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/agent prompts only — no code logic changes)
- **Behaviour verified**: markdown lint passes, all external references resolve

Closes #11502