### PR TITLE
t11203: tighten transports.md from 366 to 233 lines

### DIFF
--- a/.agents/tools/build-mcp/transports.md
+++ b/.agents/tools/build-mcp/transports.md
@@ -17,9 +17,6 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Configure MCP server transports for different deployment scenarios
-- **Recommended**: stdio for local, StreamableHTTP for production
-
 | Transport | Protocol | Use Case |
 |-----------|----------|----------|
 | `StdioServerTransport` | stdio | Local dev, spawned by AI assistants |
@@ -30,64 +27,39 @@ tools:
 
 ## Stdio Transport
 
-Best for local development and when AI assistants spawn the MCP server as a subprocess.
-
-### Basic Setup
+Best for local development and AI assistants that spawn the MCP server as a subprocess.
 
 ```typescript
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 
-const server = new McpServer({
-  name: 'my-mcp',
-  version: '1.0.0',
-});
+const server = new McpServer({ name: 'my-mcp', version: '1.0.0' });
 
-// Register tools
 server.tool(
   'hello',
   { name: z.string() },
-  async (args) => ({
-    content: [{ type: 'text', text: `Hello, ${args.name}!` }],
-  })
+  async (args) => ({ content: [{ type: 'text', text: `Hello, ${args.name}!` }] })
 );
 
-// Connect via stdio
 const transport = new StdioServerTransport();
 await server.connect(transport);
 ```
 
-### OpenCode Configuration
+**Logging:** stdout is reserved for MCP protocol — use `console.error(...)` for debug output.
+
+### Client Configuration
+
+**OpenCode:**
 
 ```json
-{
-  "mcp": {
-    "my-mcp": {
-      "type": "local",
-      "command": ["bun", "run", "/path/to/my-mcp/src/index.ts"],
-      "enabled": true
-    }
-  }
-}
+{ "mcp": { "my-mcp": { "type": "local", "command": ["bun", "run", "/path/to/my-mcp/src/index.ts"], "enabled": true } } }
 ```
 
-### Claude Code Configuration
+**Claude Code:**
 
 ```bash
 claude mcp add my-mcp bun run /path/to/my-mcp/src/index.ts
-```
-
-### Logging with Stdio
-
-Since stdout is used for MCP communication, use stderr for logging:
-
-```typescript
-// Good - logs to stderr
-console.error('[DEBUG] Processing request');
-
-// Bad - interferes with MCP protocol
-console.log('[DEBUG] Processing request');
 ```
 
 ## Streamable HTTP Transport
@@ -102,11 +74,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import express from 'express';
 import { randomUUID } from 'crypto';
 
-const server = new McpServer({
-  name: 'my-mcp',
-  version: '1.0.0',
-});
-
+const server = new McpServer({ name: 'my-mcp', version: '1.0.0' });
 // Register tools...
 
 const app = express();
@@ -117,15 +85,21 @@ app.post('/mcp', async (req, res) => {
     sessionIdGenerator: () => randomUUID(),
     enableJsonResponse: true,
   });
-  
   res.on('close', () => transport.close());
   await server.connect(transport);
   await transport.handleRequest(req, res, req.body);
 });
 
-app.listen(3000, () => {
-  console.log('MCP Server running on http://localhost:3000/mcp');
-});
+app.listen(3000);
+```
+
+`transport.sessionId` exposes the UUID for the current session.
+
+**DNS rebinding protection** is auto-enabled when binding to `127.0.0.1`; disabled for `0.0.0.0`:
+
+```typescript
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
+const app = createMcpExpressApp({ host: '127.0.0.1' }); // protected
 ```
 
 ### With ElysiaJS (Recommended)
@@ -136,93 +110,43 @@ import { mcp } from 'elysia-mcp';
 import { z } from 'zod';
 
 const app = new Elysia()
-  .use(
-    mcp({
-      serverInfo: { name: 'my-mcp', version: '1.0.0' },
-      capabilities: { tools: {} },
-      setupServer: async (server) => {
-        server.tool(
-          'hello',
-          { name: z.string() },
-          async (args) => ({
-            content: [{ type: 'text', text: `Hello, ${args.name}!` }],
-          })
-        );
-      },
-    })
-  )
+  .use(mcp({
+    serverInfo: { name: 'my-mcp', version: '1.0.0' },
+    capabilities: { tools: {} },
+    setupServer: async (server) => {
+      server.tool(
+        'hello',
+        { name: z.string() },
+        async (args) => ({ content: [{ type: 'text', text: `Hello, ${args.name}!` }] })
+      );
+    },
+  }))
   .listen(3000);
-```
-
-### DNS Rebinding Protection
-
-For localhost servers, enable DNS rebinding protection:
-
-```typescript
-import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
-
-// Protection auto-enabled for localhost
-const app = createMcpExpressApp({ host: '127.0.0.1' });
-
-// No protection when binding to all interfaces
-const app = createMcpExpressApp({ host: '0.0.0.0' });
-```
-
-### Session Management
-
-```typescript
-const transport = new StreamableHTTPServerTransport({
-  sessionIdGenerator: () => randomUUID(),
-  enableJsonResponse: true,
-});
-
-// Access session ID
-transport.sessionId; // UUID string
 ```
 
 ## SSE Transport (Legacy)
 
-For backwards compatibility with older clients using protocol version 2024-11-05.
-
-### Basic SSE Server
+For backwards compatibility with clients using protocol version 2024-11-05.
 
 ```typescript
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import express from 'express';
 
-const server = new McpServer({
-  name: 'my-mcp',
-  version: '1.0.0',
-});
-
+const server = new McpServer({ name: 'my-mcp', version: '1.0.0' });
 const app = express();
 const transports = new Map<string, SSEServerTransport>();
 
-// SSE endpoint for streaming
 app.get('/sse', (req, res) => {
   const transport = new SSEServerTransport('/messages', res);
-  const sessionId = transport.sessionId;
-  transports.set(sessionId, transport);
-  
-  res.on('close', () => {
-    transports.delete(sessionId);
-    transport.close();
-  });
-  
+  transports.set(transport.sessionId, transport);
+  res.on('close', () => { transports.delete(transport.sessionId); transport.close(); });
   server.connect(transport);
 });
 
-// Message endpoint
 app.post('/messages', express.json(), (req, res) => {
-  const sessionId = req.query.sessionId as string;
-  const transport = transports.get(sessionId);
-  
-  if (!transport) {
-    res.status(404).json({ error: 'Session not found' });
-    return;
-  }
-  
+  const transport = transports.get(req.query.sessionId as string);
+  if (!transport) { res.status(404).json({ error: 'Session not found' }); return; }
   transport.handlePostMessage(req, res, req.body);
 });
 
@@ -231,7 +155,7 @@ app.listen(3000);
 
 ## Backwards Compatible Server
 
-Support both Streamable HTTP and SSE transports:
+Support both Streamable HTTP and SSE on the same Express app:
 
 ```typescript
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -240,127 +164,70 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import express from 'express';
 import { randomUUID } from 'crypto';
 
-const server = new McpServer({
-  name: 'my-mcp',
-  version: '1.0.0',
-});
-
+const server = new McpServer({ name: 'my-mcp', version: '1.0.0' });
 const app = express();
 app.use(express.json());
-
 const sseTransports = new Map<string, SSEServerTransport>();
 
-// Streamable HTTP (new protocol)
+// Streamable HTTP (2025-03-26)
 app.post('/mcp', async (req, res) => {
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-  });
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
   res.on('close', () => transport.close());
   await server.connect(transport);
   await transport.handleRequest(req, res, req.body);
 });
 
-// SSE (legacy protocol)
+// SSE (2024-11-05 legacy)
 app.get('/sse', (req, res) => {
   const transport = new SSEServerTransport('/messages', res);
   sseTransports.set(transport.sessionId, transport);
-  res.on('close', () => {
-    sseTransports.delete(transport.sessionId);
-    transport.close();
-  });
+  res.on('close', () => { sseTransports.delete(transport.sessionId); transport.close(); });
   server.connect(transport);
 });
 
 app.post('/messages', (req, res) => {
-  const sessionId = req.query.sessionId as string;
-  const transport = sseTransports.get(sessionId);
-  if (transport) {
-    transport.handlePostMessage(req, res, req.body);
-  } else {
-    res.status(404).json({ error: 'Session not found' });
-  }
+  const transport = sseTransports.get(req.query.sessionId as string);
+  transport ? transport.handlePostMessage(req, res, req.body) : res.status(404).json({ error: 'Session not found' });
 });
 
-app.listen(3000, () => {
-  console.log('MCP Server running:');
-  console.log('  Streamable HTTP: http://localhost:3000/mcp');
-  console.log('  SSE (legacy): http://localhost:3000/sse');
-});
+app.listen(3000);
 ```
 
 ## Remote HTTP Configuration
 
-For AI assistants connecting to remote MCP servers:
-
-### OpenCode
+**OpenCode:**
 
 ```json
-{
-  "mcp": {
-    "my-mcp": {
-      "type": "remote",
-      "url": "https://my-mcp.example.com/mcp",
-      "enabled": true
-    }
-  }
-}
+{ "mcp": { "my-mcp": { "type": "remote", "url": "https://my-mcp.example.com/mcp", "enabled": true } } }
 ```
 
-### Claude Desktop (via proxy)
+**Claude Desktop (via proxy):**
 
 ```json
-{
-  "mcpServers": {
-    "my-mcp": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote-client", "https://my-mcp.example.com/mcp"]
-    }
-  }
-}
+{ "mcpServers": { "my-mcp": { "command": "npx", "args": ["-y", "mcp-remote-client", "https://my-mcp.example.com/mcp"] } } }
 ```
 
-## Transport Selection Guide
+## Transport Selection
 
-| Scenario | Transport | Why |
-|----------|-----------|-----|
-| Local development | stdio | Simple, no server needed |
-| AI assistant spawns process | stdio | Direct communication |
-| Web deployment | StreamableHTTP | Standard HTTP, scalable |
-| Multiple clients | StreamableHTTP | Session management |
-| Legacy clients | SSE | Backwards compatibility |
-| Both new and old clients | Both | Maximum compatibility |
+| Scenario | Transport |
+|----------|-----------|
+| Local dev / AI spawns process | stdio |
+| Web deployment / multiple clients | StreamableHTTP |
+| Legacy clients | SSE |
+| New + old clients | Both (backwards compatible) |
 
-## Testing Transports
-
-### Test stdio
+## Testing
 
 ```bash
-# Run server
-bun run src/index.ts
-
-# Server reads from stdin, writes to stdout
+# stdio
 echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | bun run src/index.ts
-```
 
-### Test HTTP
-
-```bash
-# Start server
-bun run src/index.ts
-
-# Test with curl
+# HTTP
 curl -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
-```
 
-### Test with MCP Inspector
-
-```bash
+# MCP Inspector
 npx @modelcontextprotocol/inspector
-
-# Connect to:
-# - stdio: Run command directly
-# - HTTP: http://localhost:3000/mcp
-# - SSE: http://localhost:3000/sse
+# Connect: stdio (run command), HTTP (localhost:3000/mcp), SSE (localhost:3000/sse)
 ```


### PR DESCRIPTION
## Summary

- Reduces `.agents/tools/build-mcp/transports.md` from 366 lines to 233 lines (~36% reduction)
- Removes redundant prose intro sentences before code blocks
- Collapses "Session Management" subsection (content folded into inline note)
- Collapses "DNS Rebinding Protection" subsection (folded into one-liner note)
- Compacts code blocks: removes duplicate `McpServer` boilerplate, trims obvious comments
- Merges OpenCode/Claude Code client config into a single "Client Configuration" subsection
- Collapses Testing section: three separate subsections → one fenced block
- All transport specs (stdio, StreamableHTTP, SSE, backwards-compatible, remote) preserved
- All code examples preserved

## Runtime Testing

- **Risk**: Low (docs-only change, no code)
- **Level**: self-assessed
- **Verification**: line count confirmed at 233 via `wc -l`

Closes #11203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Simplified and condensed MCP transport documentation with clearer guidance on reserving stdout for the MCP protocol and directing debug output to `console.error()`.
* Streamlined code examples across Stdio, HTTP, ElysiaJS, and SSE configurations for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->