### PR TITLE
t11501: tighten script-writer.md from 384 to 255 lines

### DIFF
--- a/.agents/content/distribution/youtube/script-writer.md
+++ b/.agents/content/distribution/youtube/script-writer.md
@@ -17,185 +17,72 @@ tools:
 
 Generate YouTube video scripts optimized for audience retention. Supports structured outlines, full scripts with pattern interrupts, hook generation, and remix mode (transform competitor videos into unique content).
 
-## Pre-flight Questions
-
-Before writing a video script, work through:
-
-1. What is the single takeaway — and does every section of the script serve it?
-2. Why would someone watch past 30 seconds — what tension or promise holds them?
-3. What does the viewer already know — where does this video meet them?
-4. What would make this indistinguishable from the last 10 videos on this topic — and how do we avoid that?
-
-## When to Use
-
-Read this subagent when the user wants to:
-
-- Write a YouTube video script from a topic/outline
-- Generate hooks for the first 30 seconds
-- Create a script outline with retention curve awareness
-- Remix a competitor's video into a unique script
-- Apply storytelling frameworks (AIDA, Hero's Journey, etc.)
-- Optimize an existing script for better retention
+Before writing, answer: (1) What is the single takeaway? (2) What tension holds viewers past 30 seconds? (3) What does the viewer already know? (4) What makes this distinct from the last 10 videos on this topic?
 
 ## Script Structure
 
-Every YouTube script follows this retention-optimized structure:
-
 ```text
-HOOK (0-30 seconds)
-  Pattern interrupt + promise + credibility
-  Goal: Stop the scroll, prevent click-away
-
-INTRO (30-60 seconds)
-  Context + roadmap + stakes
-  Goal: Commit viewer to watching the full video
-
-BODY (bulk of video)
-  Section 1: [Topic point] + pattern interrupt
-  Section 2: [Topic point] + pattern interrupt
-  Section 3: [Topic point] + pattern interrupt
-  ...
-  Goal: Deliver value while maintaining curiosity
-
-CLIMAX (near end)
-  Payoff the hook's promise
-  Goal: Satisfy the viewer's initial curiosity
-
-CTA (final 30 seconds)
-  Subscribe + next video + comment prompt
-  Goal: Convert viewer into subscriber
+HOOK (0-30s)    — Pattern interrupt + promise + credibility. Stop the scroll.
+INTRO (30-60s)  — Context + roadmap + stakes. Commit viewer to full watch.
+BODY            — Sections with pattern interrupts every 2-3 min. Deliver value + curiosity.
+CLIMAX          — Payoff the hook's promise.
+CTA (final 30s) — Subscribe + next video + comment prompt.
 ```
 
-### Pattern Interrupts
-
-Insert every 2-3 minutes to reset attention:
+### Pattern Interrupts (every 2-3 min)
 
 | Type | Example |
 |------|---------|
-| **Curiosity gap** | "But here's where it gets weird..." |
-| **Story pivot** | "That's what I thought too, until..." |
-| **Direct address** | "Now you might be thinking..." |
-| **Visual change** | "[B-roll / graphic / screen change]" |
-| **Tease ahead** | "And the third one is the one nobody expects..." |
-| **Reframe** | "But forget everything I just said, because..." |
+| Curiosity gap | "But here's where it gets weird..." |
+| Story pivot | "That's what I thought too, until..." |
+| Direct address | "Now you might be thinking..." |
+| Visual change | `[B-roll / graphic / screen change]` |
+| Tease ahead | "And the third one is the one nobody expects..." |
+| Reframe | "But forget everything I just said, because..." |
 
 ## Hook Formulas
 
-The hook is the most critical part. Use these proven formulas:
-
-### 1. Bold Claim
-
-> "[Surprising statement that challenges assumptions]"
-> Example: "This $5 tool outperforms every $500 alternative I've tested."
-
-### 2. Question Hook
-
-> "[Question that the viewer desperately wants answered]"
-> Example: "Why do 90% of YouTube channels never reach 1,000 subscribers?"
-
-### 3. Story Hook
-
-> "[Drop into the middle of a compelling story]"
-> Example: "Three months ago, I made a video that got 47 views. Last week, it hit 2 million."
-
-### 4. Contrarian Hook
-
-> "[Statement that goes against popular belief]"
-> Example: "Everything you've been told about YouTube SEO is wrong."
-
-### 5. Result Hook
-
-> "[Show the end result, then explain how]"
-> Example: "This channel went from 0 to 100K subscribers in 6 months. Here's exactly how."
-
-### 6. Problem-Agitate Hook
-
-> "[Name a pain point, then make it worse]"
-> Example: "Your YouTube thumbnails are costing you views. And the fix isn't what you think."
-
-### 7. Curiosity Gap Hook
-
-> "[Reveal partial information that demands completion]"
-> Example: "There's one setting in YouTube Studio that 95% of creators never touch. It changed everything for me."
+| Formula | Pattern | Example |
+|---------|---------|---------|
+| Bold claim | Surprising statement | "This $5 tool outperforms every $500 alternative I've tested." |
+| Question | Viewer desperately wants answered | "Why do 90% of YouTube channels never reach 1,000 subscribers?" |
+| Story | Drop into the middle | "Three months ago, I made a video that got 47 views. Last week, it hit 2 million." |
+| Contrarian | Against popular belief | "Everything you've been told about YouTube SEO is wrong." |
+| Result | Show end result, then explain | "This channel went from 0 to 100K in 6 months. Here's exactly how." |
+| Problem-agitate | Name pain, make it worse | "Your thumbnails are costing you views. And the fix isn't what you think." |
+| Curiosity gap | Partial info that demands completion | "There's one setting in YouTube Studio that 95% of creators never touch." |
 
 ## Storytelling Frameworks
 
-Choose based on content type:
-
-### AIDA (Best for: product reviews, tutorials)
-
-1. **Attention**: Hook with the problem or result
-2. **Interest**: Why this matters to the viewer
-3. **Desire**: Show the solution working
-4. **Action**: CTA (subscribe, try it, comment)
-
-### Three-Act Structure (Best for: documentaries, deep dives)
-
-1. **Setup**: Introduce the topic, establish stakes
-2. **Confrontation**: Present the conflict/challenge/mystery
-3. **Resolution**: Deliver the answer/solution/revelation
-
-### Hero's Journey (Best for: personal stories, transformations)
-
-1. **Ordinary world**: Where you/subject started
-2. **Call to adventure**: The challenge that appeared
-3. **Trials**: What was tried, what failed
-4. **Transformation**: The breakthrough moment
-5. **Return**: What was learned, how it applies to viewer
-
-### Problem-Solution-Result (Best for: how-to, educational)
-
-1. **Problem**: What's broken/missing/painful
-2. **Failed approaches**: What doesn't work (and why)
-3. **Solution**: The method that works
-4. **Proof**: Evidence it works (data, examples, demos)
-5. **Implementation**: Step-by-step for the viewer
-
-### Listicle with Stakes (Best for: "Top X" videos)
-
-1. **Hook**: Why this list matters
-2. **Items N through 2**: Build anticipation (save best for last)
-3. **Item 1**: The most impactful/surprising entry
-4. **Synthesis**: What the list reveals about the bigger picture
+| Framework | Best for | Structure |
+|-----------|----------|-----------|
+| AIDA | Product reviews, tutorials | Attention → Interest → Desire → Action |
+| Three-Act | Documentaries, deep dives | Setup → Confrontation → Resolution |
+| Hero's Journey | Personal stories, transformations | Ordinary world → Challenge → Trials → Transformation → Return |
+| Problem-Solution-Result | How-to, educational | Problem → Failed approaches → Solution → Proof → Implementation |
+| Listicle with Stakes | "Top X" videos | Hook → Items N–2 (build anticipation) → Item 1 → Synthesis |
 
 ## Workflow: Generate a Script
 
 ### Step 1: Gather Context
 
 ```bash
-# Recall channel voice and audience from memory
 memory-helper.sh recall --namespace youtube "channel voice"
 memory-helper.sh recall --namespace youtube "audience"
-
-# Get topic research
 memory-helper.sh recall --namespace youtube-topics "[topic]"
-
-# Get competitor scripts on this topic (transcripts)
 youtube-helper.sh transcript COMPETITOR_VIDEO_ID
 ```
 
 ### Step 2: Choose Framework
 
-Match the framework to the content type:
-
-| Content Type | Best Framework |
-|-------------|---------------|
-| Product review | AIDA |
-| Tutorial / how-to | Problem-Solution-Result |
-| Documentary / explainer | Three-Act Structure |
-| Personal story | Hero's Journey |
-| List / roundup | Listicle with Stakes |
-| News / update | Inverted Pyramid (most important first) |
-| Comparison | Side-by-side with verdict |
+Match content type to framework using the table above. For news/updates use Inverted Pyramid (most important first); for comparisons use Side-by-side with verdict.
 
 ### Step 3: Generate the Script
 
-**Prompt pattern for script generation**:
-
-> Write a YouTube video script for the topic: [topic]
+> Write a YouTube video script for: [topic]
 >
-> **Channel voice**: [from memory — formal/casual, humor style, expertise level]
-> **Target audience**: [from memory — who they are, what they care about]
+> **Channel voice**: [from memory]
+> **Target audience**: [from memory]
 > **Framework**: [chosen framework]
 > **Target length**: [X minutes / Y words]
 > **Primary keyword**: [from topic research]
@@ -203,78 +90,66 @@ Match the framework to the content type:
 > Requirements:
 > 1. Hook must use [formula type] format
 > 2. Include pattern interrupts every 2-3 minutes
-> 3. Include [VISUAL CUE] markers for B-roll/graphics
-> 4. Include [TIMESTAMP] markers for YouTube chapters
+> 3. Include `[VISUAL CUE]` markers for B-roll/graphics
+> 4. Include `[TIMESTAMP]` markers for YouTube chapters
 > 5. End with a specific CTA that relates to the content
 >
-> Competitor angles to AVOID (already covered):
-> - [angle 1 from topic research]
-> - [angle 2 from topic research]
->
+> Competitor angles to AVOID: [from topic research]
 > Our unique angle: [from topic research]
 
-### Step 4: Review and Refine
+### Step 4: Review Against Retention Signals
 
-Check the script against these retention signals:
-
-| Checkpoint | What to Verify |
-|-----------|---------------|
-| First 5 seconds | Does it stop the scroll? |
-| First 30 seconds | Is the hook complete with promise + credibility? |
-| 60-second mark | Does the viewer know what they'll get? |
-| Every 2-3 minutes | Is there a pattern interrupt? |
-| Midpoint | Is there a "but wait" moment to re-engage? |
-| Before CTA | Was the hook's promise fulfilled? |
-| CTA | Is it specific and content-related (not generic)? |
+| Checkpoint | Verify |
+|-----------|--------|
+| First 5 seconds | Stops the scroll? |
+| First 30 seconds | Hook complete with promise + credibility? |
+| 60-second mark | Viewer knows what they'll get? |
+| Every 2-3 minutes | Pattern interrupt present? |
+| Midpoint | "But wait" moment to re-engage? |
+| Before CTA | Hook's promise fulfilled? |
+| CTA | Specific and content-related (not generic)? |
 
 ## Workflow: Remix Mode
 
 Transform a competitor's successful video into a unique script with your voice and angle.
 
-### Step 1: Extract the Source Structure
+### Step 1: Extract Source
 
 ```bash
-# Get the full transcript
 youtube-helper.sh transcript VIDEO_ID > /tmp/source_transcript.txt
-
-# Get video metadata
 youtube-helper.sh video VIDEO_ID
 ```
 
-### Step 2: Analyze the Structure
+### Step 2: Analyze Structure
 
-**Prompt pattern**:
 > Analyze this transcript and extract:
-> 1. The hook formula used (first 30 seconds)
-> 2. The storytelling framework
-> 3. Key points covered (in order)
+> 1. Hook formula (first 30 seconds)
+> 2. Storytelling framework
+> 3. Key points (in order)
 > 4. Pattern interrupts used
-> 5. The CTA approach
-> 6. What made this video successful (based on [X views])
+> 5. CTA approach
+> 6. What made this successful (based on [X views])
 >
 > [paste transcript]
 
 ### Step 3: Remix with New Angle
 
-**Prompt pattern**:
-> Using the structure extracted above, write a NEW script that:
-> 1. Covers the SAME topic but from [new angle]
+> Using the structure above, write a NEW script that:
+> 1. Covers the SAME topic from [new angle]
 > 2. Uses MY channel voice: [description]
 > 3. Adds [new information/perspective] not in the original
-> 4. Keeps the structural elements that made the original successful
+> 4. Keeps structural elements that made the original successful
 > 5. Is clearly distinct — no copied phrases or examples
->
-> The goal is to learn from what worked, not to copy.
 
 ### Remix Modes
 
 | Mode | Description |
 |------|-------------|
-| **Same topic, new angle** | Cover the same subject from a different perspective |
-| **Same structure, new topic** | Apply the successful format to a different subject |
-| **Update** | Take an older video's topic and cover what's changed |
-| **Response** | Create a response/reaction that adds your expertise |
-| **Deep dive** | Take one point from a broad video and go deeper |
+| Same topic, new angle | Different perspective on same subject |
+| Same structure, new topic | Apply successful format to different subject |
+| Update | Cover what's changed since an older video |
+| Response | Add your expertise to an existing video |
+| Deep dive | Expand one point from a broad video |
 
 ## Script Output Format
 
@@ -291,7 +166,7 @@ youtube-helper.sh video VIDEO_ID
 
 [Script text with delivery notes]
 
-[VISUAL: description of what's on screen]
+[VISUAL: description]
 
 ---
 
@@ -350,17 +225,13 @@ youtube-helper.sh video VIDEO_ID
 ## Memory Integration
 
 ```bash
-# Store a successful script pattern
+# Store successful script pattern
 memory-helper.sh store --type SUCCESS_PATTERN --namespace youtube-scripts \
-  "Script for [topic] using [framework] with [hook type] hook. \
-   [X] minutes, [Y] sections. Audience response: [feedback if available]."
+  "Script for [topic] using [framework] with [hook type] hook. [X] min, [Y] sections."
 
-# Store channel voice profile
+# Store/recall channel voice
 memory-helper.sh store --type WORKING_SOLUTION --namespace youtube \
-  "Channel voice: [casual/formal], [humor level], [expertise positioning]. \
-   Signature phrases: [list]. Avoid: [list]."
-
-# Recall voice for new scripts
+  "Channel voice: [casual/formal], [humor level], [expertise positioning]. Avoid: [list]."
 memory-helper.sh recall --namespace youtube "channel voice"
 ```
 
@@ -369,7 +240,7 @@ memory-helper.sh recall --namespace youtube "channel voice"
 | Tool | Integration |
 |------|-------------|
 | `content/seo-writer.md` | SEO-optimize the script for search |
-| `content/humanise.md` | Remove AI writing patterns from generated scripts |
+| `content/humanise.md` | Remove AI writing patterns |
 | `content/platform-personas.md` | YouTube-specific voice guidelines |
 | `optimizer.md` | Generate titles, tags, descriptions from the script |
 | `topic-research.md` | Feed validated topics into script generation |
@@ -377,7 +248,7 @@ memory-helper.sh recall --namespace youtube "channel voice"
 
 ## Related
 
-- `youtube.md` — Main YouTube orchestrator (this directory)
+- `youtube.md` — Main YouTube orchestrator
 - `topic-research.md` — Topic validation before scripting
 - `optimizer.md` — Title/tag/description from completed scripts
 - `content.md` — General content writing workflows


### PR DESCRIPTION
## Summary

- Reduced `.agents/content/distribution/youtube/script-writer.md` from 384 → 255 lines (−34%)
- Collapsed 7 verbose hook formula subsections into a single table
- Collapsed 5 storytelling framework subsections into a single table
- Removed redundant "When to Use" section (duplicated frontmatter description)
- Condensed pre-flight questions from a numbered list to a single inline paragraph
- Removed Step 2 framework-selection table in Generate workflow (duplicated frameworks section)
- All script templates, workflow steps, bash commands, and memory integration patterns preserved

## Runtime Testing

- **Risk classification**: Low (docs/agent prompt only — no code changes)
- **Testing level**: self-assessed
- **Lint**: `markdownlint-cli2` — 0 errors

Closes #11501