### PR TITLE
t11492: tighten rules-text-overlays.md (318->192 lines, 40% reduction)

### DIFF
--- a/.agents/content/heygen-skill/rules-text-overlays.md
+++ b/.agents/content/heygen-skill/rules-text-overlays.md
@@ -7,49 +7,21 @@ metadata:
 
 # Text Overlays
 
-Add text overlays to your HeyGen videos for titles, captions, lower thirds, and other on-screen text elements.
+Text overlays for titles, captions, lower thirds, and on-screen text in HeyGen videos.
 
-## Basic Text Overlay
-
-```typescript
-const videoConfig = {
-  video_inputs: [
-    {
-      character: {
-        type: "avatar",
-        avatar_id: "josh_lite3_20230714",
-        avatar_style: "normal",
-      },
-      voice: {
-        type: "text",
-        input_text: "Welcome to our presentation!",
-        voice_id: "1bd001e7e50f421d891986aad5158bc8",
-      },
-      background: {
-        type: "color",
-        value: "#1a1a2e",
-      },
-    },
-  ],
-  // Text overlay configuration (if supported in your API tier)
-  // Note: Availability varies by plan
-};
-```
-
-## Text Overlay Configuration
-
-Text overlays typically support these properties:
+## Text Overlay Interface
 
 ```typescript
 interface TextOverlay {
   text: string;
   x: number;          // X position (pixels or percentage)
   y: number;          // Y position (pixels or percentage)
-  width?: number;     // Text box width
-  height?: number;    // Text box height
+  width?: number;
+  height?: number;
   font_family?: string;
   font_size?: number;
   font_color?: string;
+  font_weight?: string;
   background_color?: string;
   text_align?: "left" | "center" | "right";
   duration?: {
@@ -59,38 +31,34 @@ interface TextOverlay {
 }
 ```
 
-## Positioning Text
+Availability varies by API tier/plan.
 
-### Coordinate System
+## Positioning
 
-- **Origin**: Top-left corner (0, 0)
-- **X-axis**: Increases to the right
-- **Y-axis**: Increases downward
-- **Units**: Typically pixels or percentage of video dimensions
+**Coordinate system:** Origin top-left (0,0). X increases right, Y increases down. Units: pixels or percentage.
 
-### Common Positions
+### Common Positions (1920×1080)
 
-For a 1920x1080 video:
+| Position | X | Y |
+|----------|---|---|
+| Top-left | 50 | 50 |
+| Top-center | 960 | 50 |
+| Top-right | 1870 | 50 |
+| Center | 960 | 540 |
+| Bottom-left | 50 | 1030 |
+| Bottom-center | 960 | 1030 |
+| Bottom-right | 1870 | 1030 |
 
-| Position | X | Y | Description |
-|----------|---|---|-------------|
-| Top-left | 50 | 50 | Upper left corner |
-| Top-center | 960 | 50 | Top center |
-| Top-right | 1870 | 50 | Upper right corner |
-| Center | 960 | 540 | Dead center |
-| Bottom-left | 50 | 1030 | Lower third left |
-| Bottom-center | 960 | 1030 | Lower third center |
-
-### Position Helper Function
+### Position Helper
 
 ```typescript
-interface Position {
-  x: number;
-  y: number;
-}
+interface Position { x: number; y: number; }
+
+type Location = "top-left" | "top-center" | "top-right" | "center"
+  | "bottom-left" | "bottom-center" | "bottom-right";
 
 function getTextPosition(
-  location: "top-left" | "top-center" | "top-right" | "center" | "bottom-left" | "bottom-center" | "bottom-right",
+  location: Location,
   videoWidth: number,
   videoHeight: number,
   padding: number = 50
@@ -104,27 +72,11 @@ function getTextPosition(
     "bottom-center": { x: videoWidth / 2, y: videoHeight - padding },
     "bottom-right": { x: videoWidth - padding, y: videoHeight - padding },
   };
-
   return positions[location];
 }
 ```
 
 ## Font Styling
-
-### Available Font Properties
-
-```typescript
-const textStyle = {
-  font_family: "Arial",
-  font_size: 48,
-  font_color: "#FFFFFF",
-  font_weight: "bold",
-  background_color: "rgba(0, 0, 0, 0.5)",
-  text_align: "center",
-};
-```
-
-### Common Font Families
 
 | Font | Style | Use Case |
 |------|-------|----------|
@@ -135,64 +87,7 @@ const textStyle = {
 | Roboto | Sans-serif | Modern, digital |
 | Open Sans | Sans-serif | Friendly, accessible |
 
-## Common Text Overlay Patterns
-
-### Title Card
-
-```typescript
-const titleOverlay = {
-  text: "Product Demo",
-  x: 960,
-  y: 540,
-  font_family: "Arial",
-  font_size: 72,
-  font_color: "#FFFFFF",
-  text_align: "center",
-  duration: {
-    start: 0,
-    end: 3,
-  },
-};
-```
-
-### Lower Third (Name/Title)
-
-```typescript
-const lowerThirdOverlay = {
-  text: "John Smith\nCEO, Company Inc.",
-  x: 100,
-  y: 900,
-  font_family: "Arial",
-  font_size: 36,
-  font_color: "#FFFFFF",
-  background_color: "rgba(0, 102, 204, 0.9)",
-  text_align: "left",
-  duration: {
-    start: 2,
-    end: 8,
-  },
-};
-```
-
-### Call to Action
-
-```typescript
-const ctaOverlay = {
-  text: "Visit example.com",
-  x: 960,
-  y: 1000,
-  font_family: "Arial",
-  font_size: 42,
-  font_color: "#FFD700",
-  text_align: "center",
-  duration: {
-    start: 25,
-    end: 30,
-  },
-};
-```
-
-## Creating Text Overlay Templates
+## Templates
 
 ```typescript
 interface TextOverlayTemplate {
@@ -204,38 +99,30 @@ const templates: TextOverlayTemplate[] = [
   {
     name: "title",
     style: {
-      font_family: "Arial",
-      font_size: 72,
-      font_color: "#FFFFFF",
-      text_align: "center",
+      font_family: "Arial", font_size: 72,
+      font_color: "#FFFFFF", text_align: "center",
     },
   },
   {
     name: "subtitle",
     style: {
-      font_family: "Arial",
-      font_size: 42,
-      font_color: "#CCCCCC",
-      text_align: "center",
+      font_family: "Arial", font_size: 42,
+      font_color: "#CCCCCC", text_align: "center",
     },
   },
   {
     name: "lower-third",
     style: {
-      font_family: "Arial",
-      font_size: 36,
-      font_color: "#FFFFFF",
-      background_color: "rgba(0, 0, 0, 0.7)",
+      font_family: "Arial", font_size: 36,
+      font_color: "#FFFFFF", background_color: "rgba(0, 0, 0, 0.7)",
       text_align: "left",
     },
   },
   {
     name: "caption",
     style: {
-      font_family: "Arial",
-      font_size: 32,
-      font_color: "#FFFFFF",
-      background_color: "rgba(0, 0, 0, 0.5)",
+      font_family: "Arial", font_size: 32,
+      font_color: "#FFFFFF", background_color: "rgba(0, 0, 0, 0.5)",
       text_align: "center",
     },
   },
@@ -248,27 +135,31 @@ function createTextOverlay(
   duration?: { start: number; end: number }
 ): TextOverlay {
   const template = templates.find((t) => t.name === templateName);
-
-  if (!template) {
-    throw new Error(`Template "${templateName}" not found`);
-  }
-
-  return {
-    text,
-    x: position.x,
-    y: position.y,
-    ...template.style,
-    duration,
-  };
+  if (!template) throw new Error(`Template "${templateName}" not found`);
+  return { text, x: position.x, y: position.y, ...template.style, duration };
 }
 ```
 
-## Timing Text Overlays
-
-Coordinate text appearance with your script:
+### Usage Examples
 
 ```typescript
-// Script with timing markers
+// Title card (centered, first 3 seconds)
+createTextOverlay("Product Demo", "title", { x: 960, y: 540 }, { start: 0, end: 3 });
+
+// Lower third with name/title
+createTextOverlay("John Smith\nCEO, Company Inc.", "lower-third",
+  { x: 100, y: 900 }, { start: 2, end: 8 });
+
+// Call to action
+createTextOverlay("Visit example.com", "subtitle",
+  { x: 960, y: 1000 }, { start: 25, end: 30 });
+```
+
+## Timing Coordination
+
+Coordinate text appearance with script timing:
+
+```typescript
 const script = `
 Hello and welcome. [0:00 - 0:03]
 Let me show you our features. [0:03 - 0:08]
@@ -276,39 +167,22 @@ First, we have analytics. [0:08 - 0:15]
 Get started today! [0:15 - 0:20]
 `;
 
-// Matching text overlays
 const overlays = [
-  {
-    text: "Welcome",
-    duration: { start: 0, end: 3 },
-    ...titleStyle,
-  },
-  {
-    text: "Feature Overview",
-    duration: { start: 3, end: 8 },
-    ...subtitleStyle,
-  },
-  {
-    text: "Analytics Dashboard",
-    duration: { start: 8, end: 15 },
-    ...lowerThirdStyle,
-  },
-  {
-    text: "www.example.com",
-    duration: { start: 15, end: 20 },
-    ...ctaStyle,
-  },
+  { text: "Welcome", duration: { start: 0, end: 3 }, ...titleStyle },
+  { text: "Feature Overview", duration: { start: 3, end: 8 }, ...subtitleStyle },
+  { text: "Analytics Dashboard", duration: { start: 8, end: 15 }, ...lowerThirdStyle },
+  { text: "www.example.com", duration: { start: 15, end: 20 }, ...ctaStyle },
 ];
 ```
 
 ## Best Practices
 
-1. **Readability** - Use sufficient contrast between text and background
-2. **Size** - Ensure text is large enough to read on mobile devices
-3. **Duration** - Give viewers enough time to read (rule of thumb: 3 seconds minimum)
-4. **Positioning** - Don't overlap with the avatar's face
-5. **Consistency** - Use consistent fonts and styles throughout
-6. **Accessibility** - Consider color-blind friendly palettes
+1. **Contrast** — sufficient contrast between text and background
+2. **Size** — large enough to read on mobile
+3. **Duration** — minimum 3 seconds reading time
+4. **Positioning** — don't overlap the avatar's face
+5. **Consistency** — consistent fonts and styles throughout
+6. **Accessibility** — color-blind friendly palettes
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

- Consolidate three redundant standalone overlay examples (Title Card, Lower Third, CTA) into compact `createTextOverlay()` usage examples that reference the template system
- Remove "Basic Text Overlay" section (showed a video config with a comment about text overlays, not an actual text overlay example)
- Merge coordinate system description (4 bullet points) into single-line summary
- Remove standalone "Available Font Properties" code block (properties already defined in the `TextOverlay` interface)
- Compress template style definitions to single-line format where readable

**Classification:** Reference corpus — single-topic chapter file within `heygen-skill/` directory. Already appropriately scoped (19 sibling `rules-*.md` files). Prose tightening applied, not chapter splitting.

**Reduction:** 318 → 192 lines (40%)

**Content preserved:** All TypeScript interfaces (`TextOverlay`, `Position`, `TextOverlayTemplate`), `getTextPosition()` helper, `createTextOverlay()` factory, all 4 template definitions (title/subtitle/lower-third/caption), font family table (6 fonts), position table (7 positions), timing coordination example, best practices (6 items), limitations (4 items), `captions.md` cross-reference.

**Verification:** markdownlint 0 errors.

Closes #11492