### PR TITLE
t11463: restructure vectorize.md into standard 3-file split

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md
@@ -1,0 +1,28 @@
+# Vectorize Gotchas & Troubleshooting
+
+## Common Mistakes
+
+**Do:**
+
+1. Create metadata indexes BEFORE inserting vectors (existing vectors not retroactively indexed)
+2. Use `upsert` for updates -- `insert` ignores duplicates
+3. Batch 1000-2500 vectors per operation for optimal throughput
+4. Use `returnMetadata: "indexed"` for speed, `"all"` only when needed
+5. Use namespace filtering instead of metadata when possible (faster)
+6. Handle async operations -- inserts/upserts take seconds to be queryable
+
+**Don't:**
+
+1. Pass wrong data shape: Workers AI -> `embeddings.data[0]`; OpenAI -> `response.data[0].embedding`
+2. Return all values/metadata by default -- impacts performance and topK limit
+3. Use high-cardinality range queries -- bucket or use discrete values
+4. Forget `npx wrangler types` after config changes
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Vectors not appearing | Wait 5-10s; check `wrangler vectorize info <index>` for mutation processing |
+| Dimension mismatch | Verify query vector length matches index dimensions exactly |
+| Filter not working | Verify metadata index exists (`list-metadata-index`); re-upsert vectors after creating index |
+| Performance issues | Reduce topK with returnValues/returnMetadata; simplify filters; batch operations |

--- a/.agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md
@@ -1,0 +1,71 @@
+# Vectorize Patterns & Integration
+
+## Workers AI
+
+```typescript
+const embeddings = await ai.run("@cf/baai/bge-base-en-v1.5", { text: [userQuery] });
+// Pass embeddings.data[0], NOT embeddings or embeddings.data
+const matches = await env.VECTORIZE.query(embeddings.data[0], { topK: 3, returnMetadata: "all" });
+```
+
+**Common models**: `@cf/baai/bge-base-en-v1.5` (768d), `@cf/baai/bge-large-en-v1.5` (1024d), `@cf/baai/bge-small-en-v1.5` (384d)
+
+## OpenAI
+
+```typescript
+const response = await openai.embeddings.create({ model: "text-embedding-ada-002", input: userQuery });
+// Pass response.data[0].embedding, NOT response
+const matches = await env.VECTORIZE.query(response.data[0].embedding, { topK: 5 });
+```
+
+## RAG Pattern
+
+```typescript
+// 1. Generate query embedding
+const embeddings = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: [query] });
+// 2. Search Vectorize
+const matches = await env.VECTORIZE.query(embeddings.data[0], { topK: 5, returnMetadata: "all" });
+// 3. Fetch full documents from R2/D1/KV
+const documents = await Promise.all(matches.matches.map(m => env.R2_BUCKET.get(m.metadata?.r2_key).then(o => o?.text())));
+// 4. Generate response with context
+const llmResponse = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
+  prompt: `Context: ${documents.filter(Boolean).join("\n\n")}\n\nQuestion: ${query}\n\nAnswer:`
+});
+```
+
+## Multi-Tenant Architecture
+
+```typescript
+// Option 1: Separate indexes per tenant (if < 50K tenants)
+const tenantIndex = env[`VECTORIZE_${tenantId.toUpperCase()}`];
+
+// Option 2: Namespaces (up to 50K, fastest)
+await env.VECTORIZE.insert([{ id: "doc-1", values: [...], namespace: `tenant-${tenantId}` }]);
+const matches = await env.VECTORIZE.query(queryVector, { namespace: `tenant-${tenantId}` });
+
+// Option 3: Metadata filtering (flexible but slower)
+const matches = await env.VECTORIZE.query(queryVector, { filter: { tenantId } });
+```
+
+## Performance Optimization
+
+### Write Throughput
+
+Vectorize batches up to 200K vectors OR 1000 operations per job. Batch size matters:
+
+```typescript
+// BAD: 250,000 individual inserts = 250 jobs = ~1 hour
+for (const vector of vectors) { await env.VECTORIZE.insert([vector]); }
+
+// GOOD: 100 batches of 2,500 = 2-3 jobs = minutes
+for (let i = 0; i < vectors.length; i += 2500) {
+  await env.VECTORIZE.insert(vectors.slice(i, i + 2500));
+}
+```
+
+### Query Performance
+
+- `returnValues: true` -> high-precision scoring (slower, topK max 20)
+- Default -> approximate scoring (faster, topK max 100)
+- Namespace filters applied first (fastest); high-cardinality range queries degrade performance
+- Track mutations: `npx wrangler vectorize info <index-name>` (compare `processedUpToMutation` with insert `mutationId`)

--- a/.agents/services/hosting/cloudflare-platform-skill/vectorize.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/vectorize.md
@@ -1,4 +1,4 @@
-# Cloudflare Vectorize Skill
+# Cloudflare Vectorize
 
 Expert guidance for Cloudflare Vectorize - globally distributed vector database for AI applications.
 
@@ -8,7 +8,7 @@ Vectorize stores and queries vector embeddings for semantic search, recommendati
 
 **Key specs**: Up to 1536 dimensions (32-bit float), up to 5M vectors per index (V2), 3 distance metrics, metadata filtering (up to 10 indexes per index), namespace support.
 
-**Status**: Generally Available (GA) — requires Wrangler 3.71.0+
+**Status**: Generally Available (GA) -- requires Wrangler 3.71.0+
 
 ## Index Configuration
 
@@ -30,9 +30,9 @@ npx wrangler@latest vectorize create <index-name> \
 | `cosine` | Text embeddings, semantic similarity | Higher = closer (1.0 = identical) |
 | `dot-product` | Recommendation systems, normalized vectors | Higher = closer |
 
-- Text/semantic search → `cosine` (most common)
-- Image similarity → `euclidean`
-- Pre-normalized vectors → `dot-product`
+- Text/semantic search -> `cosine` (most common)
+- Image similarity -> `euclidean`
+- Pre-normalized vectors -> `dot-product`
 
 #### Naming Conventions
 
@@ -43,14 +43,14 @@ Lowercase/numeric ASCII, start with letter, dashes only, < 32 characters. E.g., 
 Enable filtering on metadata properties (up to 10 per index):
 
 ```bash
-# Create BEFORE inserting vectors — existing vectors won't be indexed retroactively
+# Create BEFORE inserting vectors -- existing vectors won't be indexed retroactively
 npx wrangler vectorize create-metadata-index <index-name> \
   --property-name=<field-name> \
   --type=<string|number|boolean>
 ```
 
 - String fields: first 64 bytes indexed (UTF-8 boundary); number fields: float64 precision
-- **High cardinality** (UUIDs, ms timestamps): Good for `$eq`, poor for range queries — bucket to 5-min windows
+- **High cardinality** (UUIDs, ms timestamps): Good for `$eq`, poor for range queries -- bucket to 5-min windows
 - **Low cardinality** (enum values, status): Good for filters
 
 ```bash
@@ -63,11 +63,13 @@ npx wrangler vectorize list-vectors <index-name> --count=100 --cursor=<cursor>
 ## Worker Binding
 
 **wrangler.jsonc:**
+
 ```jsonc
 { "vectorize": [{ "binding": "VECTORIZE", "index_name": "production-index" }] }
 ```
 
 **wrangler.toml:**
+
 ```toml
 [[vectorize]]
 binding = "VECTORIZE"
@@ -104,7 +106,7 @@ await env.VECTORIZE.insert([{ id: "1", values: [...], metadata: { url: "/product
 await env.VECTORIZE.upsert([{ id: "1", values: [...], metadata: { url: "/products/sku/123", updated: true } }]);
 ```
 
-Both return `{ mutationId: string }`. Asynchronous — takes a few seconds to be queryable.
+Both return `{ mutationId: string }`. Asynchronous -- takes a few seconds to be queryable.
 
 **Batch limits**: Workers: 1000 vectors/batch; HTTP API: 5000/batch; File upload: 100 MB max.
 
@@ -170,41 +172,6 @@ const matches = await env.VECTORIZE.query(queryVector, { namespace: "customer-ab
 
 **Limits**: 50,000 namespaces (Paid) / 1,000 (Free). Max 64 bytes per namespace name.
 
-## Integration Patterns
-
-### Workers AI
-
-```typescript
-const embeddings = await ai.run("@cf/baai/bge-base-en-v1.5", { text: [userQuery] });
-// Pass embeddings.data[0], NOT embeddings or embeddings.data
-const matches = await env.VECTORIZE.query(embeddings.data[0], { topK: 3, returnMetadata: "all" });
-```
-
-**Common models**: `@cf/baai/bge-base-en-v1.5` (768d), `@cf/baai/bge-large-en-v1.5` (1024d), `@cf/baai/bge-small-en-v1.5` (384d)
-
-### OpenAI
-
-```typescript
-const response = await openai.embeddings.create({ model: "text-embedding-ada-002", input: userQuery });
-// Pass response.data[0].embedding, NOT response
-const matches = await env.VECTORIZE.query(response.data[0].embedding, { topK: 5 });
-```
-
-### RAG Pattern
-
-```typescript
-// 1. Generate query embedding
-const embeddings = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: [query] });
-// 2. Search Vectorize
-const matches = await env.VECTORIZE.query(embeddings.data[0], { topK: 5, returnMetadata: "all" });
-// 3. Fetch full documents from R2/D1/KV
-const documents = await Promise.all(matches.matches.map(m => env.R2_BUCKET.get(m.metadata?.r2_key).then(o => o?.text())));
-// 4. Generate response with context
-const llmResponse = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
-  prompt: `Context: ${documents.filter(Boolean).join("\n\n")}\n\nQuestion: ${query}\n\nAnswer:`
-});
-```
-
 ## CLI Operations
 
 ### Bulk Upload (NDJSON)
@@ -212,7 +179,7 @@ const llmResponse = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
 ```bash
 # File format: { "id": "1", "values": [0.1, 0.2, ...], "metadata": {"url": "/doc/1"}}
 npx wrangler vectorize insert <index-name> --file=embeddings.ndjson
-# Max 5000 vectors per file — use multiple files for larger batches
+# Max 5000 vectors per file -- use multiple files for larger batches
 ```
 
 ### Python HTTP API
@@ -223,30 +190,7 @@ with open('embeddings.ndjson', 'rb') as f:
     resp = requests.post(url, headers={"Authorization": f"Bearer {api_token}"}, files=dict(vectors=f))
 ```
 
-## Performance Optimization
-
-### Write Throughput
-
-Vectorize batches up to 200K vectors OR 1000 operations per job. Batch size matters:
-
-```typescript
-// BAD: 250,000 individual inserts = 250 jobs = ~1 hour
-for (const vector of vectors) { await env.VECTORIZE.insert([vector]); }
-
-// GOOD: 100 batches of 2,500 = 2-3 jobs = minutes
-for (let i = 0; i < vectors.length; i += 2500) {
-  await env.VECTORIZE.insert(vectors.slice(i, i + 2500));
-}
-```
-
-### Query Performance
-
-- `returnValues: true` → high-precision scoring (slower, topK max 20)
-- Default → approximate scoring (faster, topK max 100)
-- Namespace filters applied first (fastest); high-cardinality range queries degrade performance
-- Track mutations: `npx wrangler vectorize info <index-name>` (compare `processedUpToMutation` with insert `mutationId`)
-
-## Limits (V2)
+## Platform Limits (V2)
 
 | Resource | Limit |
 |----------|-------|
@@ -264,45 +208,6 @@ for (let i = 0; i < vectors.length; i += 2500) {
 | Max metadata indexes | 10 |
 | Indexed metadata per field | 64 bytes (strings, UTF-8) |
 
-## Multi-Tenant Architecture
-
-```typescript
-// Option 1: Separate indexes per tenant (if < 50K tenants)
-const tenantIndex = env[`VECTORIZE_${tenantId.toUpperCase()}`];
-
-// Option 2: Namespaces (up to 50K, fastest)
-await env.VECTORIZE.insert([{ id: "doc-1", values: [...], namespace: `tenant-${tenantId}` }]);
-const matches = await env.VECTORIZE.query(queryVector, { namespace: `tenant-${tenantId}` });
-
-// Option 3: Metadata filtering (flexible but slower)
-const matches = await env.VECTORIZE.query(queryVector, { filter: { tenantId } });
-```
-
-## Best Practices & Common Mistakes
-
-**Do:**
-1. Create metadata indexes BEFORE inserting vectors (existing vectors not retroactively indexed)
-2. Use `upsert` for updates — `insert` ignores duplicates
-3. Batch 1000-2500 vectors per operation for optimal throughput
-4. Use `returnMetadata: "indexed"` for speed, `"all"` only when needed
-5. Use namespace filtering instead of metadata when possible (faster)
-6. Handle async operations — inserts/upserts take seconds to be queryable
-
-**Don't:**
-1. Pass wrong data shape: Workers AI → `embeddings.data[0]`; OpenAI → `response.data[0].embedding`
-2. Return all values/metadata by default — impacts performance and topK limit
-3. Use high-cardinality range queries — bucket or use discrete values
-4. Forget `npx wrangler types` after config changes
-
-## Troubleshooting
-
-| Problem | Solution |
-|---------|----------|
-| Vectors not appearing | Wait 5-10s; check `wrangler vectorize info <index>` for mutation processing |
-| Dimension mismatch | Verify query vector length matches index dimensions exactly |
-| Filter not working | Verify metadata index exists (`list-metadata-index`); re-upsert vectors after creating index |
-| Performance issues | Reduce topK with returnValues/returnMetadata; simplify filters; batch operations |
-
 ## Resources
 
 - [Official Docs](https://developers.cloudflare.com/vectorize/)
@@ -313,10 +218,15 @@ const matches = await env.VECTORIZE.query(queryVector, { filter: { tenantId } })
 - [Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/commands/#vectorize)
 - [Discord: #vectorize](https://discord.cloudflare.com)
 
-## Related
+## In This Reference
 
-- **Vector search decision guide**: `tools/database/vector-search.md` — compare Vectorize with zvec, pgvector, and other vector databases
-- **Multi-org isolation**: `services/database/multi-org-isolation.md` — tenant isolation schema patterns
+- [vectorize-patterns.md](./vectorize-patterns.md) - Workers AI, OpenAI, RAG, multi-tenant, performance optimization
+- [vectorize-gotchas.md](./vectorize-gotchas.md) - Common mistakes, troubleshooting, best practices
+
+## See Also
+
+- **Vector search decision guide**: `tools/database/vector-search.md` -- compare Vectorize with zvec, pgvector, and other vector databases
+- **Multi-org isolation**: `services/database/multi-org-isolation.md` -- tenant isolation schema patterns
 
 ---
 


### PR DESCRIPTION
## Summary

- Restructured monolithic `vectorize.md` (323 lines) into the established `{product}.md` + `{product}-gotchas.md` + `{product}-patterns.md` convention used by all other cloudflare-platform-skill products
- Classified as **reference corpus** (not instruction doc) per code-simplifier GH#6432 — restructured into chapters, not compressed
- Zero content loss verified: all 8 URLs, 36 code block markers, 14 wrangler commands, 17 API methods, 3 embedding models, 7 filter operators identical before and after

## File Changes

| File | Lines | Content |
|------|-------|---------|
| `vectorize.md` | 323 → 233 | Core reference: overview, index config, worker binding, vector ops, metadata filtering, namespaces, CLI, limits, resources |
| `vectorize-patterns.md` | new (71) | Workers AI, OpenAI, RAG pattern, multi-tenant architecture, performance optimization |
| `vectorize-gotchas.md` | new (28) | Common mistakes (do/don't), troubleshooting table |
| **Total** | 332 | 9 lines overhead from new file headers and cross-references |

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/agent prompts only, no code changes)
- **Verification**: markdownlint 0 errors, content preservation verified by counting code blocks, URLs, wrangler commands, API methods, embedding models, and filter operators

Closes #11463