### PR TITLE
GH#11460: split voice-models.md into chapter files for progressive disclosure

### DIFF
--- a/.agents/tools/voice/cloud-tts-apis.md
+++ b/.agents/tools/voice/cloud-tts-apis.md
@@ -1,0 +1,66 @@
+---
+description: Cloud TTS API reference - ElevenLabs, MiniMax, OpenAI, Google Cloud, HF Inference
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Cloud TTS APIs
+
+API keys required. Store via `aidevops secret set <KEY_NAME>`.
+
+## Provider Comparison
+
+| Provider | Quality | Voices | Voice Clone | Streaming | Docs |
+|----------|---------|--------|-------------|-----------|------|
+| **ElevenLabs** | Highest | 1000+ | Yes (instant) | Yes | https://elevenlabs.io/docs/api-reference/text-to-speech |
+| **MiniMax (Hailuo)** | High | Multiple | Yes (10s clip) | Yes | https://www.minimax.io/ |
+| **OpenAI TTS** | High | 6 built-in | No | Yes | https://platform.openai.com/docs/api-reference/audio/createSpeech |
+| **Google Cloud TTS** | High | 400+ | No | Yes | https://cloud.google.com/text-to-speech/docs |
+| **HF Inference** | Varies | Model-dependent | Model-dependent | Some | https://huggingface.co/docs/api-inference/tasks/text-to-speech |
+
+## ElevenLabs (Highest Quality Cloud)
+
+```bash
+curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/21m00Tcm4TlvDq8ikWAM" \
+  -H "xi-api-key: ${ELEVENLABS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello world", "model_id": "eleven_multilingual_v2"}'
+```
+
+## MiniMax / Hailuo (Best Value for Talking-Head Content)
+
+$5/month for 120 minutes. Voice clone from 10s clip. High default quality, less tuning than ElevenLabs. Best for talking-head videos when cost > peak quality.
+
+```bash
+curl -X POST "https://api.minimax.chat/v1/t2a_v2" \
+  -H "Authorization: Bearer ${MINIMAX_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "speech-02-hd", "text": "Hello world", "voice_setting": {"voice_id": "your-cloned-voice-id"}}'
+```
+
+## OpenAI TTS
+
+Models: `tts-1` (fast), `tts-1-hd` (higher quality). Voices: alloy, echo, fable, onyx, nova, shimmer.
+
+```bash
+curl https://api.openai.com/v1/audio/speech \
+  -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "tts-1-hd", "input": "Hello world", "voice": "alloy"}'
+```
+
+## Related
+
+- `tools/voice/voice-models.md` - Voice bridge engines and model selection index
+- `tools/voice/voice-ai-models.md` - Complete model comparison (TTS, STT, S2S)
+- `tools/voice/local-tts-models.md` - Local open-weight TTS models
+- `tools/voice/qwen3-tts.md` - Qwen3-TTS (recommended for quality + multilingual)
+- `content/production-audio.md` - Audio production workflows

--- a/.agents/tools/voice/local-tts-models.md
+++ b/.agents/tools/voice/local-tts-models.md
@@ -1,0 +1,121 @@
+---
+description: Local open-weight TTS models - Kokoro, Dia, F5-TTS, Bark, Coqui, Piper
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Local Open-Weight TTS Models
+
+Reference for local TTS models available for standalone inference. For Qwen3-TTS (recommended for quality + multilingual), see `tools/voice/qwen3-tts.md`. For voice bridge engines (EdgeTTS, macOS Say, FacebookMMS), see `tools/voice/voice-models.md`.
+
+## Kokoro (Recommended for Lightweight + Fast)
+
+82M parameter open-weight TTS. 5.6k stars, Apache-2.0.
+
+- **Languages**: American/British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin
+- **Features**: Fast inference, multiple voice presets, MPS (Apple Silicon)
+- **Requires**: `espeak-ng`, Python 3.9+ — **Install**: `pip install kokoro`
+
+```python
+from kokoro import KPipeline
+import soundfile as sf
+
+pipeline = KPipeline(lang_code='a')  # 'a' = American English
+for i, (gs, ps, audio) in enumerate(pipeline("Hello world!", voice='af_heart')):
+    sf.write(f'{i}.wav', audio, 24000)
+```
+
+Docs: https://github.com/hexgrad/kokoro
+
+## Dia (Recommended for Dialogue)
+
+1.6B parameter dialogue TTS by Nari Labs. 19.1k stars, Apache-2.0. English only (~4.4GB VRAM).
+
+- **Features**: Multi-speaker in one pass (`[S1]`/`[S2]` tags), non-verbal sounds (laughs, coughs, sighs), voice cloning via audio prompt
+- **Requires**: CUDA GPU, PyTorch 2.0+ — **Install**: `pip install git+https://github.com/nari-labs/dia.git`
+- **Dia2**: https://github.com/nari-labs/dia2
+
+```python
+from dia.model import Dia
+
+model = Dia.from_pretrained("nari-labs/Dia-1.6B-0626")
+output = model.generate(
+    "[S1] Hey, how are you doing? [S2] I'm great, thanks for asking! (laughs)"
+)
+```
+
+Docs: https://github.com/nari-labs/dia
+
+## F5-TTS (Recommended for Voice Cloning)
+
+Flow-matching TTS with zero-shot voice cloning. 14.1k stars, MIT (code), CC-BY-NC (weights).
+
+- **Languages**: Chinese, English (base), extensible via fine-tuning
+- **Features**: Zero-shot cloning from short reference audio, sway sampling, multi-speaker, Gradio UI, CLI, Docker, TensorRT-LLM
+- **Requires**: CUDA/ROCm/XPU/MPS, Python 3.10+ — **Install**: `pip install f5-tts`
+
+```bash
+f5-tts_infer-cli \
+  --model F5TTS_v1_Base \
+  --ref_audio "reference.wav" \
+  --ref_text "Transcript of reference audio." \
+  --gen_text "Text to generate in the cloned voice."
+```
+
+Docs: https://github.com/SWivid/F5-TTS
+
+## Bark (Suno)
+
+Transformer-based TTS with non-speech generation. 39k+ stars, MIT. **No active development since 2023.**
+
+- **Languages**: 13 languages including English, Chinese, French, German, Hindi, Japanese, Spanish
+- **Features**: Non-speech sounds (music, laughter, background noise), speaker presets
+- **Install**: `pip install git+https://github.com/suno-ai/bark.git`
+
+Docs: https://github.com/suno-ai/bark
+
+## Coqui TTS
+
+Multi-model TTS toolkit. 44k+ stars, MPL-2.0. **Company shut down late 2023; community-maintained.**
+
+- **Features**: 20+ models (Tacotron2, VITS, YourTTS, Bark, etc.), voice cloning, multi-speaker, training
+- **Install**: `pip install TTS`
+
+Docs: https://github.com/coqui-ai/TTS
+
+## Piper TTS (Archived)
+
+Fast local neural TTS. 10.5k stars, MIT. **Archived Oct 2025** — active fork: https://github.com/OHF-Voice/piper1-gpl (GPL).
+
+- **Features**: Lightweight C++ binary, 100+ voices, CPU-friendly; best for embedded/IoT, Home Assistant
+
+Docs: https://github.com/rhasspy/piper (archived)
+
+## Installation
+
+```bash
+pip install kokoro                                    # Kokoro 82M
+pip install f5-tts                                    # F5-TTS
+pip install TTS                                       # Coqui TTS
+pip install git+https://github.com/nari-labs/dia.git  # Dia
+pip install git+https://github.com/suno-ai/bark.git   # Bark
+
+# System dependencies (macOS)
+brew install espeak-ng  # Required by Kokoro
+# Linux: apt install espeak-ng
+```
+
+## Related
+
+- `tools/voice/qwen3-tts.md` - Qwen3-TTS (recommended for quality + multilingual)
+- `tools/voice/voice-models.md` - Voice bridge engines and model selection index
+- `tools/voice/voice-ai-models.md` - Complete model comparison (TTS, STT, S2S)
+- `tools/voice/speech-to-speech.md` - Full voice pipeline (VAD+STT+LLM+TTS)

--- a/.agents/tools/voice/voice-models.md
+++ b/.agents/tools/voice/voice-models.md
@@ -28,9 +28,18 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Text-to-Speech (TTS) Models
+## Chapter Index
 
-### Implemented in This Repo
+| Chapter | Content |
+|---------|---------|
+| **This file** | Voice bridge engines (EdgeTTS, macOS Say, FacebookMMS), STT summary, selection guides |
+| `tools/voice/qwen3-tts.md` | Qwen3-TTS — quality + multilingual, voice cloning, voice design |
+| `tools/voice/local-tts-models.md` | Kokoro, Dia, F5-TTS, Bark, Coqui, Piper |
+| `tools/voice/cloud-tts-apis.md` | ElevenLabs, MiniMax, OpenAI, Google Cloud, HF Inference |
+| `tools/voice/voice-ai-models.md` | High-level TTS/STT/S2S comparison tables and decision flow |
+| `tools/voice/transcription.md` | STT models, cloud APIs, transcription pipeline |
+
+## Text-to-Speech (TTS) — Voice Bridge Engines
 
 The voice bridge (`voice-bridge.py`) implements three TTS engines:
 
@@ -44,157 +53,7 @@ The voice bridge (`voice-bridge.py`) implements three TTS engines:
 voice-helper.sh talk  # Use via voice bridge
 ```
 
-### Local Open-Weight Models
-
-#### Qwen3-TTS (Recommended for Quality + Multilingual)
-
-Alibaba's open-weight TTS series. 7.1k stars, Apache-2.0. Sizes: 0.6B and 1.7B.
-
-- **Languages**: Chinese, English, Japanese, Korean, German, French, Russian, Portuguese, Spanish, Italian
-- **Features**: Voice cloning (3s reference), voice design (text description), 9 built-in speakers, emotion/prosody control, streaming (97ms first-packet)
-- **Requires**: CUDA GPU, Python 3.12, PyTorch 2.4+; vLLM day-0 support
-- **Install**: `pip install qwen-tts`
-
-```python
-from qwen_tts import Qwen3TTSModel
-import torch, soundfile as sf
-
-model = Qwen3TTSModel.from_pretrained("Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-    device_map="cuda:0", dtype=torch.bfloat16)
-wavs, sr = model.generate_custom_voice(text="Hello, this is a test.",
-    language="English", speaker="Ryan")
-sf.write("output.wav", wavs[0], sr)
-```
-
-Docs: https://github.com/QwenLM/Qwen3-TTS
-
-#### Kokoro (Recommended for Lightweight + Fast)
-
-82M parameter open-weight TTS. 5.6k stars, Apache-2.0.
-
-- **Languages**: American/British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin
-- **Features**: Fast inference, multiple voice presets, MPS (Apple Silicon)
-- **Requires**: `espeak-ng`, Python 3.9+ — **Install**: `pip install kokoro`
-
-```python
-from kokoro import KPipeline
-import soundfile as sf
-
-pipeline = KPipeline(lang_code='a')  # 'a' = American English
-for i, (gs, ps, audio) in enumerate(pipeline("Hello world!", voice='af_heart')):
-    sf.write(f'{i}.wav', audio, 24000)
-```
-
-Docs: https://github.com/hexgrad/kokoro
-
-#### Dia (Recommended for Dialogue)
-
-1.6B parameter dialogue TTS by Nari Labs. 19.1k stars, Apache-2.0. English only (~4.4GB VRAM).
-
-- **Features**: Multi-speaker in one pass (`[S1]`/`[S2]` tags), non-verbal sounds (laughs, coughs, sighs), voice cloning via audio prompt
-- **Requires**: CUDA GPU, PyTorch 2.0+ — **Install**: `pip install git+https://github.com/nari-labs/dia.git`
-- **Dia2**: https://github.com/nari-labs/dia2
-
-```python
-from dia.model import Dia
-
-model = Dia.from_pretrained("nari-labs/Dia-1.6B-0626")
-output = model.generate(
-    "[S1] Hey, how are you doing? [S2] I'm great, thanks for asking! (laughs)"
-)
-```
-
-Docs: https://github.com/nari-labs/dia
-
-#### F5-TTS (Recommended for Voice Cloning)
-
-Flow-matching TTS with zero-shot voice cloning. 14.1k stars, MIT (code), CC-BY-NC (weights).
-
-- **Languages**: Chinese, English (base), extensible via fine-tuning
-- **Features**: Zero-shot cloning from short reference audio, sway sampling, multi-speaker, Gradio UI, CLI, Docker, TensorRT-LLM
-- **Requires**: CUDA/ROCm/XPU/MPS, Python 3.10+ — **Install**: `pip install f5-tts`
-
-```bash
-f5-tts_infer-cli \
-  --model F5TTS_v1_Base \
-  --ref_audio "reference.wav" \
-  --ref_text "Transcript of reference audio." \
-  --gen_text "Text to generate in the cloned voice."
-```
-
-Docs: https://github.com/SWivid/F5-TTS
-
-#### Bark (Suno)
-
-Transformer-based TTS with non-speech generation. 39k+ stars, MIT. **No active development since 2023.**
-
-- **Languages**: 13 languages including English, Chinese, French, German, Hindi, Japanese, Spanish
-- **Features**: Non-speech sounds (music, laughter, background noise), speaker presets
-- **Install**: `pip install git+https://github.com/suno-ai/bark.git`
-
-Docs: https://github.com/suno-ai/bark
-
-#### Coqui TTS
-
-Multi-model TTS toolkit. 44k+ stars, MPL-2.0. **Company shut down late 2023; community-maintained.**
-
-- **Features**: 20+ models (Tacotron2, VITS, YourTTS, Bark, etc.), voice cloning, multi-speaker, training
-- **Install**: `pip install TTS`
-
-Docs: https://github.com/coqui-ai/TTS
-
-#### Piper TTS (Archived)
-
-Fast local neural TTS. 10.5k stars, MIT. **Archived Oct 2025** — active fork: https://github.com/OHF-Voice/piper1-gpl (GPL).
-
-- **Features**: Lightweight C++ binary, 100+ voices, CPU-friendly; best for embedded/IoT, Home Assistant
-
-Docs: https://github.com/rhasspy/piper (archived)
-
-### Cloud TTS APIs
-
-Require API keys. Store via `aidevops secret set <KEY_NAME>`.
-
-| Provider | Quality | Voices | Voice Clone | Streaming | Docs |
-|----------|---------|--------|-------------|-----------|------|
-| **ElevenLabs** | Highest | 1000+ | Yes (instant) | Yes | https://elevenlabs.io/docs/api-reference/text-to-speech |
-| **MiniMax (Hailuo)** | High | Multiple | Yes (10s clip) | Yes | https://www.minimax.io/ |
-| **OpenAI TTS** | High | 6 built-in | No | Yes | https://platform.openai.com/docs/api-reference/audio/createSpeech |
-| **Google Cloud TTS** | High | 400+ | No | Yes | https://cloud.google.com/text-to-speech/docs |
-| **HF Inference** | Varies | Model-dependent | Model-dependent | Some | https://huggingface.co/docs/api-inference/tasks/text-to-speech |
-
-#### ElevenLabs (Highest Quality Cloud)
-
-```bash
-curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/21m00Tcm4TlvDq8ikWAM" \
-  -H "xi-api-key: ${ELEVENLABS_API_KEY}" \
-  -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "model_id": "eleven_multilingual_v2"}'
-```
-
-#### MiniMax / Hailuo (Best Value for Talking-Head Content)
-
-$5/month for 120 minutes. Voice clone from 10s clip. High default quality, less tuning than ElevenLabs. Best for talking-head videos when cost > peak quality.
-
-```bash
-curl -X POST "https://api.minimax.chat/v1/t2a_v2" \
-  -H "Authorization: Bearer ${MINIMAX_API_KEY}" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "speech-02-hd", "text": "Hello world", "voice_setting": {"voice_id": "your-cloned-voice-id"}}'
-```
-
-#### OpenAI TTS
-
-Models: `tts-1` (fast), `tts-1-hd` (higher quality). Voices: alloy, echo, fable, onyx, nova, shimmer.
-
-```bash
-curl https://api.openai.com/v1/audio/speech \
-  -H "Authorization: Bearer ${OPENAI_API_KEY}" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "tts-1-hd", "input": "Hello world", "voice": "alloy"}'
-```
-
-## Speech-to-Text (STT) Models
+## Speech-to-Text (STT) Summary
 
 Full STT coverage (model comparisons, cloud APIs, transcription pipeline): `tools/voice/transcription.md`.
 
@@ -249,7 +108,7 @@ Voice bridge (`voice-bridge.py:99-115`) implements `FasterWhisperSTT`. Speech-to
 # Voice bridge engines
 pip install edge-tts transformers
 
-# Local TTS models
+# Local TTS models (see chapter files for details)
 pip install qwen-tts kokoro f5-tts TTS
 pip install git+https://github.com/nari-labs/dia.git
 pip install git+https://github.com/suno-ai/bark.git
@@ -265,6 +124,10 @@ brew install espeak-ng ffmpeg yt-dlp
 
 ## Related
 
+- `tools/voice/qwen3-tts.md` - Qwen3-TTS (quality + multilingual, voice cloning)
+- `tools/voice/local-tts-models.md` - Local open-weight TTS models (Kokoro, Dia, F5-TTS, Bark, Coqui, Piper)
+- `tools/voice/cloud-tts-apis.md` - Cloud TTS API reference (ElevenLabs, MiniMax, OpenAI)
+- `tools/voice/voice-ai-models.md` - High-level TTS/STT/S2S comparison and decision flow
 - `tools/voice/speech-to-speech.md` - Full voice pipeline (VAD+STT+LLM+TTS)
 - `tools/voice/transcription.md` - STT/transcription models and cloud APIs
 - `tools/voice/buzz.md` - Buzz offline transcription GUI


### PR DESCRIPTION
## Summary

- Restructured `voice-models.md` (reference corpus, 273 lines) into a 136-line index with chapter files
- Extracted local TTS models (Kokoro, Dia, F5-TTS, Bark, Coqui, Piper) into `local-tts-models.md` (121 lines)
- Extracted cloud TTS APIs (ElevenLabs, MiniMax, OpenAI, Google, HF) into `cloud-tts-apis.md` (66 lines)
- Kept voice bridge engines, STT summary, selection guides, and install reference in the index file
- Added chapter index table for progressive disclosure navigation

## Content Preservation

- **URLs**: All preserved (21/21 across all files; Qwen3-TTS URL in existing `qwen3-tts.md`)
- **Code blocks**: 18/18 preserved
- **Cross-references**: All `Related` links maintained
- **Line count**: 136 (index) + 121 + 66 + 151 (existing qwen3-tts.md) = 474 total vs 273 original

## Runtime Testing

- testing_level: `self-assessed`
- risk_classification: Low (docs/agent prompts only, no code changes)
- No runtime verification needed — markdown restructuring with zero functional impact

## Files Changed (3 — within 5-file blast radius cap)

| File | Change |
|------|--------|
| `.agents/tools/voice/voice-models.md` | Slimmed from 273 to 136 lines; added chapter index |
| `.agents/tools/voice/local-tts-models.md` | New — extracted local TTS model details |
| `.agents/tools/voice/cloud-tts-apis.md` | New — extracted cloud TTS API reference |

Closes #11460