### PR TITLE
GH#11626: restore lost VSL Best Practices section and fix broken anchor link

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md
@@ -16,6 +16,16 @@ A Video Sales Letter (VSL) is a sales page in video format leveraging voice for 
 | [Complete VSL Example](direct-response-copy-swipe-file-vsl-scripts-example.md) | Full 15-minute script for a $497 landing page copywriting course |
 | [VSL Script Template](direct-response-copy-templates-vsl-script.md) | Detailed section-by-section template with coaching notes and best practices |
 
+## VSL Best Practices
+
+| Area | Guidance |
+|------|----------|
+| **Pacing** | Start slow (trust) → speed up in story (momentum) → slow for offer (comprehension) → fast close (urgency) |
+| **Visuals** | Text on screen reinforces key points; slides > talking head for longer VSLs; show proof |
+| **Voice** | Conversational, not scripted; vary energy; pause for emphasis; talk to one person |
+| **Length** | Lead magnet: 5-10 min · Low-ticket ($100-500): 10-20 min · Mid-ticket ($500-2k): 20-35 min · High-ticket ($2k+): 30-60 min |
+| **Testing** | Test hooks first (first 30s determines everything), then story angles, offer presentation, CTA timing |
+
 ## Quick VSL Script Template
 
 ```text

--- a/.agents/marketing-sales/direct-response-copy-templates-vsl-script.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-vsl-script.md
@@ -16,7 +16,7 @@ A complete Video Sales Letter script framework. Replace `[BRACKETS]` with your c
 | Guarantee | 14:00-15:00 | Remove risk | 40-42 |
 | Close | 15:00-16:00 | Final CTA | 43-46 |
 
-**Total:** 15-20 min for mid-ticket ($500-2000). Adjust by price point — see [VSL Best Practices](direct-response-copy-swipe-file-vsl-scripts.md#vsl-best-practices).
+**Total:** 15-20 min for mid-ticket ($500-2000). Adjust by price point — see "VSL Best Practices" in [VSL Scripts Swipe File](direct-response-copy-swipe-file-vsl-scripts.md#vsl-best-practices).
 
 ---
 


### PR DESCRIPTION
## Summary

- Restored the "VSL Best Practices" section (pacing, visuals, voice, length-by-price, testing guidance) that was lost during the prior restructure (PR #11597) of the VSL swipe file from a 309-line monolith into chapter files
- Fixed broken anchor link in the VSL Script Template that referenced `#vsl-best-practices` — the heading now exists in the index file
- Made the link text in the template more descriptive for clarity

Closes #11626

## Context

The original 309-line file was already restructured into chapter files with a slim 37-line index by PR #11597 (GH#11531). However, the "VSL Best Practices" table (5 rows covering pacing, visuals, voice, length-by-price, and testing) was dropped during that split. The VSL Script Template still referenced it via `#vsl-best-practices` anchor — a broken link.

This PR restores the lost content to the index file and fixes the broken reference.

## Content Preservation

- All 5 best-practices rows restored verbatim from the pre-restructure version (commit `09426c646`)
- No content removed from any file
- Index file: 37 → 47 lines (+10 lines for the restored section)
- Template file: 235 lines (unchanged line count, 1 line edited for link text)

## Runtime Testing

- **Testing level:** `self-assessed`
- **Risk classification:** Low (docs-only, no code changes)
- **Verification:** Confirmed anchor `#vsl-best-practices` now resolves to `## VSL Best Practices` heading in the index file