### PR TITLE
GH#11430: tighten CHAPTER-03 Platform-Specific Creative Strategies (330→248 lines)

### DIFF
--- a/.agents/marketing-sales/ad-creative-chapter-03.md
+++ b/.agents/marketing-sales/ad-creative-chapter-03.md
@@ -1,14 +1,12 @@
 # Chapter 3: Platform-Specific Creative Strategies
 
-Each platform has distinct user behaviours, formats, algorithmic preferences, and creative expectations. What works on TikTok fails on LinkedIn. This chapter covers Meta, TikTok, Google/YouTube, LinkedIn, Pinterest, and Snapchat — specs, algorithm factors, winning patterns, and cross-platform adaptation.
+Each platform has distinct formats, algorithmic preferences, and creative expectations. This chapter covers Meta, TikTok, Google/YouTube, LinkedIn, Pinterest, and Snapchat — specs, algorithm factors, winning patterns, and cross-platform adaptation.
 
 ## 1. Meta (Facebook & Instagram)
 
-### Platform Context
+**Facebook**: Mobile-first (98.5% mobile, 1.7s attention span). Video gets 59% more engagement. Engagement bait penalised.
 
-**Facebook** is a mobile-first content discovery engine (98.5% mobile access, 38 min/day avg, 1.7s attention span). Video gets 59% more engagement. Engagement bait is penalised; authentic engagement rewarded.
-
-**Instagram** is aspirational + community. 500M+ daily Stories users, Reels get 22% more engagement than regular video, 70% of shoppers use IG for product discovery. Native formats (Reels, Stories) get algorithmic preference.
+**Instagram**: 500M+ daily Stories users. Reels get 22% more engagement. 70% of shoppers use IG for product discovery. Native formats get algorithmic preference.
 
 ### Specs
 
@@ -16,102 +14,60 @@ Each platform has distinct user behaviours, formats, algorithmic preferences, an
 
 | Format | Resolution | Aspect Ratio | Notes |
 |--------|-----------|-------------|-------|
-| Image | 1080x1080 (square), 1200x628 (landscape) | 1.91:1 to 4:5 | JPG/PNG. Text: 125 primary, 40 headline, 30 description |
-| Video | 1080x1080 min | 16:9, 1:1, 4:5, 9:16 | 1s–240min (15s optimal), max 4GB. 85% watch without sound — captions essential |
-| Carousel | 1080x1080 per card | 1:1 | 2–10 cards, video supported |
+| Image | 1080x1080 / 1200x628 | 1.91:1 to 4:5 | JPG/PNG. Text: 125 primary, 40 headline, 30 description |
+| Video | 1080x1080 min | 16:9, 1:1, 4:5, 9:16 | 1s–240min (15s optimal), max 4GB. Captions essential (85% watch without sound) |
+| Carousel | 1080x1080/card | 1:1 | 2–10 cards, video supported |
 
 #### Instagram
 
 | Format | Resolution | Aspect Ratio | Notes |
 |--------|-----------|-------------|-------|
-| Feed Image | 1080x1080 min | 1:1, 4:5 | Minimal on-image text preferred |
+| Feed Image | 1080x1080 min | 1:1, 4:5 | Minimal on-image text |
 | Feed Video | 1080x1080 min | 1:1, 4:5 | 3–60s, max 4GB |
-| Stories | 1080x1920 | 9:16 | Up to 15s (longer splits into cards). 70% watch with sound. Keep key elements in central 80%. Interactive: polls, questions, countdowns, sliders |
-| Reels | 1080x1920 min | 9:16 | Up to 60s, max 4GB. Native-feel content outperforms. Use trending audio, fast cuts. How-to Reels perform exceptionally well |
+| Stories | 1080x1920 | 9:16 | Up to 15s. 70% watch with sound. Keep key elements in central 80%. Interactive: polls, questions, countdowns, sliders |
+| Reels | 1080x1920 min | 9:16 | Up to 60s, max 4GB. Use trending audio, fast cuts. How-to Reels perform well |
 
-### Algorithm Factors
+### Algorithm & Creative
 
-Meta predicts engagement probability to determine distribution.
+**Signal weights** (descending): Shares > Comments > Saves > Watch time > Likes. Early engagement (first 30 min) critical.
 
-**Signal weights** (descending): Shares > Comments > Saves (especially IG) > Watch time > Likes. Early engagement (first 30 min) is critical.
+**Scroll-stopping hooks**: Pattern interrupts, direct address, curiosity gaps, emotional triggers, social proof.
 
-**Optimisation by format:**
+**Creative fatigue**: Same creative shown >3x/week → declining CTR, rising CPM. Rotate 3–5 variations, refresh every 2–4 weeks.
 
-- **Video**: Hook in first 3s, design for sound-off (captions), front-load value, encourage saves
-- **Image**: Minimal text overlay (algorithm favours low text), high contrast, emotional resonance, clear focal point
-- **Carousel**: Strong first card (determines click-through), sequential storytelling, each card delivers value
+**PAS framework**: Problem (visual pain point) → Agitate (amplify consequences) → Solution (product as hero). Map: single image for impact, video for problem demo, carousel for features.
 
-### Creative Patterns
-
-**Scroll-stopping hooks** (users scroll ~300 ft/day equivalent):
-
-- Pattern interrupts (unexpected visuals/sounds)
-- Direct address to viewer
-- Curiosity gaps (information demanding completion)
-- Emotional triggers
-- Social proof ("Thousands of people are...")
-
-**Creative fatigue signals**: Same creative shown >3x/week to same user, declining CTR, rising CPM. Rotate 3–5 active variations minimum, refresh every 2–4 weeks for high-spend campaigns.
-
-### Frameworks
-
-**PAS (Problem–Agitate–Solution):**
-
-1. **Problem** — Visual demonstration of pain point, relatable scenario, emotional resonance
-2. **Agitate** — Amplify consequences, create urgency
-3. **Solution** — Product as hero, transformation demo, clear benefit
-
-Map to formats: single image for immediate impact, video for problem demo, carousel for solution features.
-
-**AIDA (Attention–Interest–Desire–Action):**
-
-1. **Attention** — Bold visual/statement, movement, personal relevance
-2. **Interest** — Problem acknowledgment, curiosity gap, relatable scenario
-3. **Desire** — Benefit visualisation, social proof, aspirational outcome
-4. **Action** — Clear urgent CTA, offer reinforcement, easy next step
+**AIDA framework**: Attention (bold visual) → Interest (curiosity gap) → Desire (social proof, aspirational outcome) → Action (clear urgent CTA).
 
 ## 2. TikTok
 
-### Platform Context
-
-1B+ MAU, 45+ min avg session. The For You Page (FYP) is democratic — any content can go viral regardless of follower count. **Completion rate is the most important algorithm signal**, followed by interactions (likes, comments, shares, follows), video info (captions, hashtags, sounds), and device settings.
-
-Authenticity beats production value. 90% watch with sound on. Fast pace, no slow build-ups.
+1B+ MAU, 45+ min avg session. FYP is democratic — any content can go viral. **Completion rate is the most important signal**, followed by interactions, captions/hashtags/sounds. Authenticity beats production value. 90% watch with sound on.
 
 ### Specs
 
 | Format | Aspect Ratio | Resolution | Duration | Max Size | Notes |
 |--------|-------------|-----------|----------|----------|-------|
-| In-Feed | 9:16 (strongly rec), 1:1, 16:9 | 1080x1920 min | 5–60s (9–15s optimal) | 500MB | MP4/MOV/MPEG/3GP/AVI. Ad name 2–40 chars, description 12–100 chars |
-| TopView | 9:16 | Full-screen | Up to 60s | — | First thing on app open, auto-play with sound |
+| In-Feed | 9:16 (rec), 1:1, 16:9 | 1080x1920 min | 5–60s (9–15s optimal) | 500MB | MP4/MOV/MPEG/3GP/AVI. Ad name 2–40 chars, description 12–100 chars |
+| TopView | 9:16 | Full-screen | Up to 60s | — | First on app open, auto-play with sound |
 | Hashtag Challenge | — | Banner 1200x675 | Video 3–15s | — | Description 50–100 chars. Optional branded effects/sounds |
-| Branded Effects | — | — | — | — | Types: 2D (stickers/filters), 3D (objects), AR (augmented reality) |
+| Branded Effects | — | — | — | — | 2D (stickers/filters), 3D (objects), AR |
 
 ### Hook Architecture
 
-TikTok's infinite scroll demands attention capture within the first frame.
-
-**Winning hook patterns:**
-
 ```
-POV Hook:        "POV: You just discovered the life hack that changes everything"
-Relatable:       "That moment when..." / "Anyone else do this?"
-Tease:           "Wait for the ending..." / "I can't believe this worked"
+POV Hook:         "POV: You just discovered the life hack that changes everything"
+Relatable:        "That moment when..." / "Anyone else do this?"
+Tease:            "Wait for the ending..." / "I can't believe this worked"
 Direct Challenge: "Stop scrolling if..." / "Only [group] will understand"
-Educational:     "Here's how to..." / "Stop doing this and start doing that"
+Educational:      "Here's how to..." / "Stop doing this and start doing that"
 ```
 
 ### Creative Strategies
 
-**Trend participation**: Monitor TikTok Creative Center. Trend types: audio, challenge, format (e.g. GRWM), meme. Move quickly — trends have short lifespans. Adapt to brand message, don't force it.
-
-**Creator collaboration**: Spark Ads (boost organic creator content), branded content, Creator Marketplace. Brief with talking points not scripts — encourage authentic voice within brand safety parameters.
-
-**Edutainment**: Quick tutorials, myth-busting, behind-the-scenes, "how it's made", expert tips. Break complex topics into segments, use text overlays, show don't tell, use trending sounds.
-
-### Testing
-
-Low production requirements enable rapid iteration. Produce multiple variations → test hooks/sounds/formats → analyse completion rates → iterate → scale winners.
+- **Trend participation**: Monitor TikTok Creative Center. Move quickly — trends have short lifespans. Adapt to brand, don't force it.
+- **Creator collaboration**: Spark Ads (boost organic creator content), Creator Marketplace. Brief with talking points not scripts.
+- **Edutainment**: Quick tutorials, myth-busting, behind-the-scenes. Use text overlays, trending sounds.
+- **Testing**: Low production requirements enable rapid iteration. Test hooks/sounds/formats → analyse completion rates → scale winners.
 
 **Benchmarks**: Good completion rate >25%, good engagement rate >8%.
 
@@ -119,25 +75,21 @@ Low production requirements enable rapid iteration. Produce multiple variations 
 
 ### Search (Intent-Based)
 
-Users are actively problem-solving with high purchase intent. Relevance and clarity beat creativity.
+Users actively problem-solving with high purchase intent. Relevance and clarity beat creativity.
 
 #### Responsive Search Ads (RSA)
 
 Components: 15 headlines (30 chars each), 4 descriptions (90 chars each), final URL, display path, ad assets.
 
-**Headline categories to cover:**
-
 ```
+Headline categories:
 1. Brand/Keyword (3–4): target keywords, brand name
 2. Value Proposition (3–4): key benefits, USPs
 3. Urgency/Scarcity (2–3): time-sensitive offers, limited availability
 4. Social Proof (2–3): customer numbers, ratings, awards
 5. Call-to-Action (2–3): action-oriented, clear next steps
-```
 
-**Description structure:**
-
-```
+Description structure:
 1. Problem/Solution: address pain point, present solution
 2. Feature/Benefit: connect features to outcomes
 3. Social Proof: evidence of effectiveness
@@ -157,13 +109,9 @@ Components: 15 headlines (30 chars each), 4 descriptions (90 chars each), final 
 
 ### Display (Awareness/Consideration)
 
-Users are passively browsing — visual impact and contextual relevance essential.
-
 #### Responsive Display Ads (RDA)
 
 Components: up to 15 images (incl logos), 5 headlines (30 chars), 5 descriptions (90 chars), 5 videos (optional), business name, final URL.
-
-**Image requirements:**
 
 | Orientation | Ratio | Min Resolution |
 |-------------|-------|---------------|
@@ -173,42 +121,31 @@ Components: up to 15 images (incl logos), 5 headlines (30 chars), 5 descriptions
 | Logo (square) | 1:1 | 1200x1200 |
 | Logo (wide) | 4:1 | 1200x300 |
 
-#### Gmail Ads
-
-Collapsed: 300x300 image, 25-char headline, 100-char description. Expanded: full email-like experience with images, text, CTAs. Teaser approach in collapsed state, email-like design expanded.
-
-#### Discovery Ads
-
-Appear in YouTube Home, Watch Next, Gmail Promotions, Discover feed. Native image-heavy format. Use high-quality lifestyle imagery with authentic (non-stock) appearance.
+**Gmail Ads**: Collapsed: 300x300 image, 25-char headline, 100-char description. Expanded: full email-like experience. **Discovery Ads**: YouTube Home, Watch Next, Gmail Promotions, Discover feed — use high-quality lifestyle imagery.
 
 ### YouTube
 
-#### Ad Formats
-
 | Format | Duration | Skip | Billing | Notes |
 |--------|----------|------|---------|-------|
-| Skippable In-Stream | 12s–6min | After 5s | CPV (30s or completion) | Must deliver value in first 5s |
+| Skippable In-Stream | 12s–6min | After 5s | CPV (30s or completion) | Deliver value in first 5s |
 | Non-Skippable In-Stream | 15–20s | No | CPM | Must-watch |
 | Bumper | 6s max | No | CPM | High frequency, message reinforcement |
 | In-Feed Video | — | — | CPC (on click) | Thumbnail + text in search/related |
 | Shorts | Up to 60s | — | — | Vertical 9:16, appears between Shorts |
 
-#### The 5-Second Framework
-
 ```
-Second 0–1: Visual hook (movement, face, product)
-Second 1–3: Problem statement or promise
-Second 3–5: Transition to main content
-Second 5+:  Expanded content for non-skippers
+5-Second Framework:
+0–1s: Visual hook (movement, face, product)
+1–3s: Problem statement or promise
+3–5s: Transition to main content
+5s+:  Expanded content for non-skippers
 ```
 
-**Video length strategy**: 6s = single message/brand reinforcement, 15s = one key benefit, 30s = problem-solution narrative, 60s+ = storytelling/multiple benefits.
+**Video length**: 6s = single message, 15s = one key benefit, 30s = problem-solution, 60s+ = storytelling.
 
 ## 4. LinkedIn
 
-### Platform Context
-
-Professional context — users are in career-focused, business-oriented mindsets during work hours. Longer attention spans for relevant content. Professional tone, value-driven, educational focus, credibility emphasis.
+Professional context — career-focused mindset during work hours. Longer attention spans. Professional tone, value-driven, educational focus.
 
 ### Specs
 
@@ -216,32 +153,28 @@ Professional context — users are in career-focused, business-oriented mindsets
 |--------|----------------|-------------|--------|
 | Single Image | 1200x627 | 1.91:1 | JPG/PNG/GIF, max 8MB |
 | Carousel | 1080x1080 | 1:1 | 2–10 cards, max 8MB/card |
-| Video | 1920x1080 (16:9), 1080x1080 (1:1) | 16:9, 1:1, 9:16, 2.4:1 | 3s–30min (15–30s optimal), max 200MB, MP4/AVI/MOV |
+| Video | 1920x1080 / 1080x1080 | 16:9, 1:1, 9:16, 2.4:1 | 3s–30min (15–30s optimal), max 200MB, MP4/AVI/MOV |
 | Document | PDF/PPT/Word | — | Max 300 pages or 100MB |
 | Conversation Ads | — | — | Multiple CTAs, branching paths, personalised sender |
 | Message Ads | — | — | Subject 60 chars, body 1500 chars |
 
 ### Content Strategy
 
-**What performs**: Thought leadership (original research, industry insights, expert commentary), educational content (how-to, best practices, tutorials), case studies with quantified results, employee spotlights and culture content.
-
-**Document posts** generate high engagement — slide decks with key insights, industry reports, step-by-step guides, checklists, data visualisations. Each slide should stand alone, be mobile-readable, include progress indicators.
-
-**Video**: Native uploads outperform links. Captions essential (often sound-off). Types: executive messages, product demos, customer testimonials, expert interviews.
-
-**Tone**: Professional but not stuffy. Lead with insight, not promotion. Jargon-appropriate for audience.
+- **Thought leadership**: Original research, industry insights, expert commentary
+- **Educational**: How-to, best practices, tutorials, case studies with quantified results
+- **Document posts**: High engagement — slide decks, reports, guides, checklists. Each slide standalone, mobile-readable, with progress indicators
+- **Video**: Native uploads outperform links. Captions essential. Types: executive messages, product demos, testimonials, expert interviews
+- **Tone**: Lead with insight, not promotion. Jargon-appropriate for audience.
 
 ## 5. Pinterest
 
-### Platform Context
-
-Visual discovery engine — users actively seek inspiration, plan future activities, and welcome brand content. Future-oriented, purchase-consideration mindset. Post seasonal content 45 days in advance.
+Visual discovery engine — users seek inspiration and plan future activities. Purchase-consideration mindset. Post seasonal content 45 days in advance.
 
 ### Specs
 
 | Format | Aspect Ratio | Resolution | Limits |
 |--------|-------------|-----------|--------|
-| Standard Image | 2:3 (rec, 1000x1500) | Min 600px wide | PNG/JPEG, max 20MB |
+| Standard Image | 2:3 rec (1000x1500) | Min 600px wide | PNG/JPEG, max 20MB |
 | Video | 1:1, 2:3, 4:5, 9:16 | 240p–4K | 4s–15min, max 2GB |
 | Carousel | 1:1 or 2:3 | — | 2–5 images, max 20MB/image |
 | Shopping | — | — | Requires product catalogue. Price, availability, direct purchase |
@@ -256,41 +189,31 @@ Visual discovery engine — users actively seek inspiration, plan future activit
 | Product | Real-time pricing, availability, descriptions, direct shopping |
 | Recipe | Ingredients, cooking times, serving sizes, ratings |
 
-### Strategy by Objective
+**Keyword targeting** works like search intent, not social hashtags — use long-tail keywords naturally in descriptions.
 
-- **Awareness**: Broad targeting, high-quality imagery, brand story, Video Pins
-- **Consideration**: Tutorials, educational content, detailed product info, Rich Pins
-- **Conversions**: Shopping Pins, clear product imagery, pricing/offer display, strong CTAs
-
-Keyword targeting on Pinterest works like search intent, not social hashtags — use long-tail keywords naturally in descriptions.
+**By objective**: Awareness → broad targeting, Video Pins. Consideration → tutorials, Rich Pins. Conversions → Shopping Pins, clear pricing/offer.
 
 ## 6. Snapchat
 
-### Platform Context
-
-Reaches 75% of millennials and Gen Z. Users open app ~30x daily. Camera-first, ephemeral, authentic. 70% of ads viewed with sound. Vertical-only.
+Reaches 75% of millennials and Gen Z. ~30 app opens/day. Camera-first, ephemeral, authentic. 70% of ads viewed with sound. Vertical-only.
 
 ### Specs
 
 | Format | Resolution | Duration | Max Size | Notes |
 |--------|-----------|----------|----------|-------|
 | Snap Ads | 1080x1920 (9:16) | 3–180s (10s rec) | 1GB | MP4/MOV H.264. Swipe-up attachment (website, app install, long-form video) |
-| Collection | Main: same as Snap Ads, Thumbnails: 300x600 | — | — | Main asset + 4 thumbnail tiles, product names up to 34 chars |
+| Collection | Main: same as Snap Ads; Thumbnails: 300x600 | — | — | Main asset + 4 thumbnail tiles, product names up to 34 chars |
 | Story Ads | Full-screen | 3–20 snaps | — | Tile in Discover section |
 | AR World Lenses | — | — | — | Front/rear camera AR, interactive elements |
 | AR Face Lenses | — | — | — | Facial recognition triggers, transformative effects |
 
 ### Creative Approach
 
-**Aesthetic**: User-generated appearance, real/relatable scenarios, bright bold colours, native Snapchat features (stickers, doodles). No slow builds — start with the most compelling moment.
-
-**Sound**: Music and audio essential. Voiceover common and effective.
-
-**CTAs**: "Swipe up to..." with visual swipe indicators and clear value proposition.
-
-**Gen Z tone**: Casual, conversational, avoid corporate speak. Authenticity, value-driven messaging, diversity, humour. Respect audience intelligence.
-
-**AR strategy**: Create memorable brand experiences that encourage sharing. Product visualisation, viral potential. Location-based geofilters for events.
+- **Aesthetic**: UGC appearance, real/relatable scenarios, bright bold colours, native Snapchat features (stickers, doodles). Start with the most compelling moment.
+- **Sound**: Music and audio essential. Voiceover common and effective.
+- **CTAs**: "Swipe up to..." with visual swipe indicators and clear value proposition.
+- **Gen Z tone**: Casual, conversational, no corporate speak. Authenticity, humour, diversity.
+- **AR strategy**: Product visualisation, viral potential. Location-based geofilters for events.
 
 ## 7. Cross-Platform Strategy
 
@@ -320,11 +243,6 @@ Platform Adaptations:
 - Tone adjustments
 ```
 
-**Production efficiency**: Shoot for multiple aspect ratios from the start. Create master content with safe zones. Design flexible layouts. Plan platform variations before production, not after.
+**Production efficiency**: Shoot for multiple aspect ratios from the start. Create master content with safe zones. Plan platform variations before production, not after.
 
-### Creative Refresh
-
-- Maintain platform-specific creative libraries
-- Plan refreshes based on fatigue data per platform
-- Cross-pollinate winning concepts across platforms
-- Track universal vs platform-specific learnings separately
+**Creative refresh**: Maintain platform-specific libraries. Plan refreshes based on fatigue data. Cross-pollinate winning concepts. Track universal vs platform-specific learnings separately.


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/marketing/ad-creative/CHAPTER-03.md` from 330 to 248 lines (25% reduction)
- Removed verbose platform context prose (restated obvious facts), redundant framework elaborations, and wordy transitions
- Preserved all specs tables, code blocks (hook patterns, RSA categories, 5-second framework, modular creative system), algorithm signal weights, benchmarks, and the cross-platform matrix

## What was removed

- Intro paragraph (scene-setting, not actionable)
- Verbose "Platform Context" subsections — kept only key stats inline
- Separate "Algorithm Factors" section for Meta — merged into "Algorithm & Creative"
- PAS/AIDA prose elaborations — kept structure, cut the explanatory padding
- TikTok platform context paragraph — trimmed to essential facts
- Gmail Ads and Discovery Ads as separate subsections — condensed to two sentences
- LinkedIn platform context paragraph — trimmed
- Pinterest "Strategy by Objective" as separate section — condensed to one line
- Snapchat "Creative Approach" prose — tightened to bullet list

## Verification

- All code blocks present: hook patterns, RSA headline/description categories, 5-second framework, modular creative system
- All spec tables intact: Facebook Feed, Instagram, TikTok, Google Display, YouTube, LinkedIn, Pinterest, Snapchat
- All benchmarks preserved: TikTok completion >25%, engagement >8%
- Cross-platform optimisation matrix unchanged
- Line count: 330 → 248 (within 200-250 target)

## Runtime Testing

- **Testing level**: self-assessed
- **Risk classification**: low (docs-only change, agent prompt content)
- **Behaviour verified**: content preservation confirmed by diff review

Closes #11430