### PR TITLE
t11206: simplification: tighten ai-orchestration/overview.md from 364 to 163 lines

### DIFF
--- a/.agents/tools/ai-orchestration/overview.md
+++ b/.agents/tools/ai-orchestration/overview.md
@@ -25,20 +25,11 @@ tools:
 **Quick Setup**:
 
 ```bash
-# Langflow (visual flow builder)
-bash .agents/scripts/langflow-helper.sh setup
-
-# CrewAI (multi-agent teams)
-bash .agents/scripts/crewai-helper.sh setup
-
-# AutoGen (conversational agents)
-bash .agents/scripts/autogen-helper.sh setup
-
-# Agno (enterprise agent OS)
-bash .agents/scripts/agno-setup.sh setup
-
-# OpenProse (multi-agent DSL - no setup required, pattern-based)
-git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-prose
+bash .agents/scripts/langflow-helper.sh setup   # Langflow (visual flow builder)
+bash .agents/scripts/crewai-helper.sh setup     # CrewAI (multi-agent teams)
+bash .agents/scripts/autogen-helper.sh setup    # AutoGen (conversational agents)
+bash .agents/scripts/agno-setup.sh setup        # Agno (enterprise agent OS)
+git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-prose  # OpenProse
 ```
 
 **Port Allocation** (auto-managed via `localhost-helper.sh`):
@@ -50,15 +41,11 @@ git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-p
 | AutoGen Studio | 8081 | / | /tmp/autogen_studio_port |
 | Agno | 7777 (API), 3000 (UI) | /health | - |
 
-**Port Conflict Resolution**: All helper scripts integrate with `localhost-helper.sh` for automatic port management. If a port is in use, an alternative is automatically selected.
-
 **Draft agents**: Orchestration tasks that discover reusable patterns should create draft agents in `~/.aidevops/agents/draft/`. These can be promoted to private (`custom/`) or shared (`.agents/`) after review. See `tools/build-agent/build-agent.md` "Agent Lifecycle Tiers".
 
 <!-- AI-CONTEXT-END -->
 
 ## Decision Matrix
-
-Use this matrix to select the right framework for your use case:
 
 | Objective | Recommended | Why | Alternatives |
 |-----------|-------------|-----|--------------|
@@ -75,230 +62,68 @@ Use this matrix to select the right framework for your use case:
 
 ## Framework Comparison
 
-### Langflow
+| Framework | Stars | GUI | Install | Run |
+|-----------|-------|-----|---------|-----|
+| Langflow | 143k+ | localhost:7860 | `pip install langflow` | `langflow run` |
+| CrewAI | 42.5k+ | localhost:8501 (Studio) | `pip install crewai` | `crewai run` |
+| AutoGen | 53.4k+ | AutoGen Studio | `pip install autogen-agentchat autogen-ext[openai]` | `autogenstudio ui` |
+| Agno | - | localhost:3000 | `pip install "agno[all]"` | `~/.aidevops/scripts/start-agno-stack.sh` |
+| OpenProse | 500+ | None (DSL) | `git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-prose` | AI session = VM |
 
-**Best for**: Visual prototyping, RAG pipelines, quick iterations
+**Langflow**: Visual flow builder, exports to Python, LangChain ecosystem, MCP server support, desktop app.
 
-- **License**: MIT
-- **Stars**: 143k+
-- **GUI**: Native web UI (localhost:7860)
-- **Install**: `pip install langflow`
-- **Run**: `langflow run`
+**CrewAI**: Role-playing agents, hierarchical task delegation, YAML config, event-driven Flows, 100k+ certified developers.
 
-**Strengths**:
+**AutoGen**: Python + .NET, MCP integration, human-in-the-loop, AgentChat for prototyping, Core API for advanced control.
 
-- Drag-and-drop visual flow builder
-- Exports flows to Python code
-- Built-in MCP server support
-- LangChain ecosystem integration
-- Desktop app available
+**Agno**: Complete local processing (privacy), specialized DevOps agents, knowledge base support, production runtime.
 
-**Use Cases**:
+**OpenProse**: Zero dependencies (pattern, not framework). Explicit control flow (`parallel:`, `loop until`, `try/catch`), AI-evaluated conditions (`**the code is production ready**`), portable across Claude Code, OpenCode, Amp. Operates at the **workflow layer**, complementing DSPy (prompt optimization), TOON (context compression), and Context7/Augment (knowledge retrieval).
 
-- RAG applications
-- Chatbot prototypes
-- API workflow automation
-- Visual debugging of agent flows
+## Common Patterns
 
-### CrewAI
-
-**Best for**: Role-based multi-agent teams, production workflows
-
-- **License**: MIT
-- **Stars**: 42.5k+
-- **GUI**: CrewAI Studio (Streamlit-based)
-- **Install**: `pip install crewai`
-- **Run**: `crewai run`
-
-**Strengths**:
-
-- Role-playing autonomous agents
-- Hierarchical task delegation
-- YAML-based configuration
-- Flows for event-driven control
-- Strong community (100k+ certified developers)
-
-**Use Cases**:
-
-- Content generation teams
-- Research automation
-- Sales/marketing workflows
-- Code review pipelines
-
-### AutoGen
-
-**Best for**: Conversational agents, research tasks, Microsoft integration
-
-- **License**: MIT (code) / CC-BY-4.0 (docs)
-- **Stars**: 53.4k+
-- **GUI**: AutoGen Studio
-- **Install**: `pip install autogen-agentchat autogen-ext[openai]`
-- **Run**: `autogenstudio ui`
-
-**Strengths**:
-
-- Multi-language support (Python, .NET)
-- MCP server integration
-- Human-in-the-loop workflows
-- AgentChat for rapid prototyping
-- Core API for advanced control
-
-**Use Cases**:
-
-- Code generation/review
-- Research assistants
-- Interactive debugging
-- Enterprise .NET integration
-
-### Agno
-
-**Best for**: Enterprise DevOps, production agent runtime
-
-- **License**: MIT
-- **GUI**: Agent-UI (localhost:3000)
-- **Install**: `pip install "agno[all]"`
-- **Run**: `~/.aidevops/scripts/start-agno-stack.sh`
-
-**Strengths**:
-
-- Complete local processing (privacy)
-- Specialized DevOps agents
-- Knowledge base support
-- Production-ready runtime
-
-**Use Cases**:
-
-- Infrastructure automation
-- Code review workflows
-- Documentation generation
-- DevOps task automation
-
-### OpenProse
-
-**Best for**: Multi-agent orchestration DSL, explicit control flow, loop agents
-
-- **License**: MIT
-- **Stars**: 500+
-- **GUI**: None (DSL executed by AI session)
-- **Install**: `git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-prose`
-- **Run**: AI session becomes the VM
-
-**Strengths**:
-
-- Zero dependencies (pattern, not framework)
-- Explicit control flow (`parallel:`, `loop until`, `try/catch`)
-- AI-evaluated conditions (`**the code is production ready**`)
-- Portable across Claude Code, OpenCode, Amp
-- Complements DSPy, TOON, Context7
-
-**Use Cases**:
-
-- Multi-agent parallel workflows
-- Iterative development loops (Ralph-style)
-- Complex conditional orchestration
-- Reusable workflow templates
-
-**Relationship to Other Tools**:
-
-OpenProse operates at the **workflow layer**, complementing:
-- **DSPy**: Prompt optimization (can use DSPy-compiled prompts in agents)
-- **TOON**: Data compression (can TOON-encode context between sessions)
-- **Context7/Augment**: Knowledge retrieval (sessions can call these tools)
-
-## Common Design Patterns
-
-All AI orchestration tools in aidevops follow these patterns:
-
-### Directory Structure
+**Directory structure** (all tools):
 
 ```text
 ~/.aidevops/{tool}/
-├── venv/                 # Python virtual environment
-├── .env                  # API keys and configuration
-├── .env.example          # Template for .env
-├── start_{tool}.sh       # Startup script
-└── {tool-specific}/      # Tool-specific files
+├── venv/           # Python virtual environment
+├── .env            # API keys and configuration
+├── .env.example    # Template
+└── start_{tool}.sh # Startup script
 ```
 
-### Helper Script Pattern
+**Helper scripts** at `.agents/scripts/{tool}-helper.sh`: `setup | start | stop | status | check | help`
 
-Each tool has a helper script at `.agents/scripts/{tool}-helper.sh` with:
+**Config templates** at `configs/{tool}-config.json.txt` (committed); working configs at `configs/{tool}-config.json` (gitignored).
 
-```bash
-# Standard commands
-setup     # Install and configure
-start     # Start services
-stop      # Stop services
-status    # Check health
-check     # Verify prerequisites
-help      # Show usage
-```
-
-### Configuration Template
-
-Each tool has a config template at `configs/{tool}-config.json.txt` with:
-
-- Default ports and URLs
-- Agent definitions
-- Model configuration
-- Security settings
-- Integration options
-
-### Management Scripts
-
-After setup, management scripts are created at `~/.aidevops/scripts/`:
-
-- `start-{tool}-stack.sh` - Start all services
-- `stop-{tool}-stack.sh` - Stop all services
-- `{tool}-status.sh` - Check service health
+**Management scripts** created at `~/.aidevops/scripts/`: `start-{tool}-stack.sh`, `stop-{tool}-stack.sh`, `{tool}-status.sh`
 
 ## Integration with aidevops
 
-### Git Version Control
+**Git export formats**:
 
-All frameworks support exporting configurations for Git:
-
-| Framework | Export Format | Location |
-|-----------|---------------|----------|
+| Framework | Format | Location |
+|-----------|--------|----------|
 | Langflow | JSON flows | `flows/*.json` |
 | CrewAI | YAML configs | `config/agents.yaml`, `config/tasks.yaml` |
 | AutoGen | Python/JSON | `agents/*.py`, `*.json` |
 | Agno | Python | `agent_os.py` |
 
-### Bi-directional Sync
-
-For Langflow, use the JSON bridge pattern:
+**Langflow JSON sync**:
 
 ```bash
-# Export flow to JSON
 langflow export --flow-id <id> --output flows/my-flow.json
-
-# Import JSON to Langflow
 langflow import --file flows/my-flow.json
 ```
 
-### Local LLM Support
-
-All frameworks support Ollama for local LLMs:
+**Local LLM (Ollama)**:
 
 ```bash
-# Install Ollama
 curl -fsSL https://ollama.com/install.sh | sh
-
-# Pull a model
 ollama pull llama3.2
-
-# Configure in .env
+# In .env:
 OLLAMA_BASE_URL=http://localhost:11434
 ```
-
-## Packaging for Production
-
-See `packaging.md` for detailed deployment guides:
-
-- **Web/SaaS**: FastAPI + Docker + Kubernetes
-- **Desktop**: PyInstaller executables
-- **Mobile**: React Native/Flutter wrappers
 
 ## Related Documentation
 
@@ -309,56 +134,30 @@ See `packaging.md` for detailed deployment guides:
 | `autogen.md` | AutoGen setup and usage |
 | `agno.md` | Agno setup and usage |
 | `openprose.md` | OpenProse DSL for multi-agent orchestration |
-| `packaging.md` | Deployment and packaging |
+| `packaging.md` | Web/SaaS (FastAPI+Docker+K8s), Desktop (PyInstaller), Mobile (RN/Flutter) |
 
 ## Troubleshooting
 
-### Common Issues
-
-**Port conflicts**:
-
-All AI orchestration helper scripts integrate with `localhost-helper.sh` for automatic port management. If a default port is in use, an alternative is automatically selected and saved to `/tmp/{tool}_port`.
+**Port conflicts** — all helpers auto-select alternatives via `localhost-helper.sh`:
 
 ```bash
-# Check port availability (uses localhost-helper.sh if available)
 ~/.aidevops/scripts/localhost-helper.sh check-port 7860
-
-# Find next available port
 ~/.aidevops/scripts/localhost-helper.sh find-port 7860
-
-# List all dev ports in use
 ~/.aidevops/scripts/localhost-helper.sh list-ports
-
-# Kill process on port
 ~/.aidevops/scripts/localhost-helper.sh kill-port 7860
-
-# Manual fallback
-lsof -i :7860
-kill -9 $(lsof -t -i:7860)
+# Manual fallback:
+lsof -i :7860 && kill -9 $(lsof -t -i:7860)
 ```
 
-**Virtual environment issues**:
+**Venv issues**:
 
 ```bash
-# Recreate venv
-rm -rf ~/.aidevops/{tool}/venv
-bash .agents/scripts/{tool}-helper.sh setup
+rm -rf ~/.aidevops/{tool}/venv && bash .agents/scripts/{tool}-helper.sh setup
 ```
 
 **API key errors**:
 
 ```bash
-# Verify .env file
 cat ~/.aidevops/{tool}/.env
-
-# Check environment
 env | grep -E "(OPENAI|ANTHROPIC|OLLAMA)"
 ```
-
-### Getting Help
-
-- Langflow: https://github.com/langflow-ai/langflow/discussions
-- CrewAI: https://community.crewai.com
-- AutoGen: https://github.com/microsoft/autogen/discussions
-- Agno: https://github.com/agno-ai/agno/discussions
-- OpenProse: https://github.com/openprose/prose/issues


### PR DESCRIPTION
## Summary

- Reduced `.agents/tools/ai-orchestration/overview.md` from 364 lines to 163 lines (55% reduction)
- Collapsed verbose per-framework Strengths/Use Cases bullet lists into a single compact comparison table
- Removed redundant prose introductions and boilerplate pattern descriptions
- Preserved all commands, URLs, port tables, decision matrix, troubleshooting commands, and functional content
- Zero markdownlint errors

## What was removed

- Per-framework "Strengths" and "Use Cases" bullet sections (info already captured in Decision Matrix or now inlined as single-line summaries)
- "Common Design Patterns" verbose prose (directory tree kept, helper script/config/management script descriptions condensed to 3 lines)
- "Packaging for Production" section body (collapsed into Related Documentation table entry)
- "Getting Help" community links (belong in individual framework docs, not the overview)
- Redundant port conflict resolution prose (port table already conveys this)

## Runtime Testing

- **Risk classification**: Low (docs-only change, no code)
- **Testing level**: self-assessed
- **Verification**: markdownlint-cli2 — 0 errors; all commands/URLs/ports confirmed present via grep

Closes #11206