### PR TITLE
t11579: tighten ad-creative-chapter-12.md 303→198 lines

### DIFF
--- a/.agents/marketing-sales/ad-creative-chapter-12.md
+++ b/.agents/marketing-sales/ad-creative-chapter-12.md
@@ -1,0 +1,198 @@
+# Chapter 12: Creative Testing and Experimentation Framework
+
+## 12.1 The Scientific Method for Creative
+
+### The Creative Testing Process
+
+**Step 1: Hypothesis Formation**
+
+Form testable hypotheses: "If we [change], then [metric] will [increase/decrease] because [reasoning]."
+
+Example: "If we add customer testimonials to hero images, then CTR will increase 15% because social proof reduces perceived risk."
+
+**Step 2: Test Design**
+
+- **Control**: Existing best performer
+- **Variation**: Single change from control
+- **Sample Size**: Calculate required conversions for statistical significance
+- **Duration**: Minimum 3-7 days (accounts for day-of-week effects)
+- **Success Metric**: Primary metric for decision-making
+
+**Step 3: Execution**
+
+- Equal budget allocation between variations
+- Random audience assignment
+- Consistent placement and targeting
+- Clean data collection setup
+
+**Step 4: Analysis**
+
+- Statistical significance (95% confidence minimum)
+- Practical significance (lift magnitude)
+- Segment performance differences
+- Secondary metric impacts
+
+**Step 5: Implementation**
+
+- Scale winning variations
+- Document insights in knowledge base
+- Plan follow-up tests
+- Share learnings across team
+
+## 12.2 Types of Creative Tests
+
+### Element Testing
+
+**Headline**
+- Emotional vs. rational appeals
+- Question vs. statement formats
+- Length variations (short, medium, long)
+- Benefit vs. feature focus
+- Urgency vs. evergreen messaging
+
+**Visual**
+- Lifestyle vs. product-focused imagery
+- Color palette variations
+- Talent diversity and representation
+- Background context changes
+- Image orientation and cropping
+
+**CTA**
+- Action verb variations ("Get," "Start," "Try," "Claim")
+- Benefit inclusion ("Get My Free Trial" vs. "Start Free Trial")
+- Urgency indicators ("Now," "Today," limited time mention)
+- Button color and design
+- Placement within creative
+
+### Format Testing
+
+- Static image vs. video
+- Single image vs. carousel
+- Short-form vs. long-form video
+- Story format vs. feed placement
+- Interactive vs. static
+
+### Concept Testing
+
+- Problem-solution vs. aspiration-based
+- Humor vs. serious tone
+- User-generated vs. brand-produced
+- Educational vs. entertainment focus
+- Direct response vs. brand storytelling
+
+## 12.3 Test Prioritization Frameworks
+
+### ICE Framework (1-10 scale)
+
+- **Impact**: Potential effect on key metrics (10=transformational, 5=meaningful, 1=incremental)
+- **Confidence**: Likelihood of success based on evidence (10=strong data, 5=some evidence, 1=intuition)
+- **Ease**: Resource requirements (10=minimal effort, 5=moderate production, 1=major production)
+
+**ICE Score = Impact × Confidence × Ease** — prioritize highest scores.
+
+### RICE Framework
+
+Adds **Reach** (number of users affected: 10=all audiences, 5=major segments, 1=niche subset).
+
+**RICE Score = (Reach × Impact × Confidence) ÷ Effort**
+
+Use RICE when resources are constrained and you need to maximize impact per effort unit.
+
+## 12.4 Sample Size and Statistical Significance
+
+### Required Sample Size
+
+Factors: baseline conversion rate, minimum detectable effect (MDE), statistical power (80%), significance level (95%).
+
+**Rules of thumb:**
+- High-volume campaigns: 100 conversions per variation minimum
+- Lower volume: 50 conversions with larger effect sizes
+- Brand campaigns: 10,000+ impressions per variation
+
+### Statistical Significance
+
+- **Confidence Level**: 95% = 5% false positive rate; 99% = 1% false positive rate
+- **P-Value**: P < 0.05 = significant at 95%; P < 0.01 = significant at 99%
+- **Practical vs. Statistical**: 2% lift at 99% confidence may not justify production costs; 50% lift at 90% confidence likely worth pursuing
+
+## 12.5 Common Testing Pitfalls
+
+| Pitfall | Problem | Solution |
+|---------|---------|----------|
+| Multiple variables | Can't identify what drove results | Test one change at a time, or use multivariate with sufficient traffic |
+| Ending early | False conclusions from pre-significance data | Pre-determine sample sizes; avoid daily peeking |
+| Atypical periods | Holidays/events skew results | Avoid known atypical periods or extend duration to normalize |
+| Ignoring segments | Overall winner may fail in key segments | Analyze by audience segment, geography, and platform |
+| Novelty effects | New creative performs better just by being different | Monitor over time — true winners maintain performance |
+
+## 12.6 Building a Testing Culture
+
+### Test Velocity Metrics
+
+- **Tests per month**: Volume of experiments
+- **Win rate**: Percentage of tests beating control
+- **Learning rate**: Insights generated per test
+- **Implementation rate**: Percentage of insights applied
+- **Time to insight**: Speed from hypothesis to conclusion
+
+### Testing Backlog
+
+- Capture ideas from all team members
+- Score using ICE or RICE framework
+- Review and prioritize weekly
+- Archive irrelevant ideas
+
+### Documentation Template
+
+```
+Test ID: [Unique identifier]
+Date: [Test period]
+Hypothesis: [Testable prediction]
+Variations: [Description of control and variants]
+Sample size: [Number of users/conversions]
+Results: [Performance data by variation]
+Winner: [Winning variation and confidence level]
+Learnings: [Key insights]
+Next steps: [Follow-up actions]
+```
+
+### Knowledge Sharing Cadence
+
+- Weekly creative review meetings
+- Monthly testing retrospectives
+- Quarterly creative strategy sessions
+- Internal wiki or knowledge base
+
+## 12.7 Advanced Testing Methodologies
+
+### Sequential Testing
+
+Test A vs. Control → winner becomes new Control → repeat until no further improvement.
+
+- Benefits: Faster initial insight, less traffic required
+- Drawbacks: Longer for comprehensive learning
+
+### Multi-Armed Bandit
+
+Algorithmically allocates traffic to better-performing variations during the test.
+
+- Automatically shifts traffic toward winners
+- Reduces opportunity cost of showing underperformers
+- Useful for high-traffic, low-risk tests
+- Caution: Requires technical implementation; can mask true performance differences
+
+### Bayesian Testing
+
+- Provides probability that variation is best (not just p-values)
+- Allows continuous monitoring without p-hacking concerns
+- More intuitive for business decisions
+- Tools: VWO, Optimizely
+
+## 12.8 Testing Program Maturity
+
+| Level | Name | Characteristics |
+|-------|------|-----------------|
+| 1 | Ad Hoc | Intuition-driven, no process, limited docs, results often ignored |
+| 2 | Structured | Regular cadence, basic docs, hypothesis-driven, results inform some decisions |
+| 3 | Systematic | Comprehensive roadmap, statistical rigor, cross-functional, insights drive strategy |
+| 4 | Predictive | AI/ML optimization, automated test generation, predictive modeling, continuous autonomous optimization |


### PR DESCRIPTION
## Summary

- Reduces `.agents/marketing-sales/ad-creative-chapter-12.md` from 303 to 198 lines (~35% reduction)
- Removes verbose prose, redundant section intros, and wordy explanations
- Preserves all commands, formulas, code blocks, and functional content

## Changes

- Compressed pitfalls section (§12.5) into a table — eliminates repeated "The Problem/The Solution" headers
- Compressed maturity levels (§12.8) into a table — 4 levels in 6 lines vs. 24
- Inlined ICE/RICE scoring descriptions (removed redundant 1-10 scale prose)
- Removed verbose chapter intro ("Systematic creative testing separates high-performance marketing teams...")
- Removed closing summary paragraph (restates what the chapter already shows)
- Tightened knowledge sharing list (removed "Cross-functional learning sessions" duplicate)
- All 8 section headers, documentation template code block, ICE/RICE formulas, and all bullet content preserved

## Runtime Testing

- **Risk classification**: Low (docs-only change, no code)
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 198 lines; all section headers, formulas, and code blocks verified present

Closes #11579