### PR TITLE
GH#11683: tighten i18next.md from 298 to 225 lines

### DIFF
--- a/.agents/tools/ui/i18next.md
+++ b/.agents/tools/ui/i18next.md
@@ -31,6 +31,7 @@ tools:
 | Nested key path wrong | `t("ai.sidebar.title")` returns key | Check JSON structure matches dot notation |
 | Namespace not loaded | Translation returns key | Ensure namespace is loaded in component |
 | Type safety | No autocomplete for keys | Use typed `useTranslation` hook |
+| Missing `"use client"` | `useTranslation` hook fails in server component | Use `getTranslation` for server components |
 
 **File Structure**:
 
@@ -48,91 +49,22 @@ packages/i18n/src/translations/
     └── common.json
 ```
 
-**Adding New Translation Key**:
-
-```bash
-# 1. Add to English first
-# packages/i18n/src/translations/en/common.json
-
-# 2. Find same location in other locales
-grep -n '"feedback":' packages/i18n/src/translations/*/common.json
-
-# 3. Add to ALL locales at same position
-```
-
-**Translation JSON Pattern**:
-
-```json
-{
-  "ai": {
-    "sidebar": {
-      "title": "Awards AI",
-      "subtitle": "Your awards assistant",
-      "open": "Open AI assistant",
-      "close": "Close AI assistant",
-      "placeholder": "Ask me anything...",
-      "prompts": {
-        "search": "Find relevant awards",
-        "help": "Writing tips"
-      }
-    }
-  }
-}
-```
-
-**Usage in Components**:
-
-```tsx
-import { useTranslation } from "@workspace/i18n";
-
-function Component() {
-  const { t } = useTranslation("common");
-  
-  return (
-    <div>
-      <h1>{t("ai.sidebar.title")}</h1>
-      <p>{t("ai.sidebar.subtitle")}</p>
-      <button aria-label={t("ai.sidebar.open")}>
-        Open
-      </button>
-    </div>
-  );
-}
-```
-
-**Locale-Specific Translations**:
-
-| Locale | Example Key | Translation |
-|--------|-------------|-------------|
-| `en` | `social` | "Social" |
-| `de` | `social` | "Soziale Medien" |
-| `es` | `social` | "Redes sociales" |
-| `fr` | `social` | "Réseaux sociaux" |
-
 <!-- AI-CONTEXT-END -->
 
-## Detailed Patterns
+## Adding Translation Keys
 
-### Adding Translations to Multiple Locales
-
-When adding a new key, update all locales:
+Always update ALL locales when adding a key. Find the insertion point, then add to every locale file:
 
 ```bash
-# Find the insertion point in all locales
+# Find insertion point across all locales
 grep -n '"feedback"' packages/i18n/src/translations/*/common.json
-
-# Output:
 # de/common.json:44:  "feedback": "Feedback",
 # en/common.json:44:  "feedback": "Feedback",
 # es/common.json:44:  "feedback": "Comentarios",
 # fr/common.json:44:  "feedback": "Commentaires",
 ```
 
-Then add the new key after `feedback` in each file:
-
 ```json
-// Add to each locale's common.json:
-
 // en/common.json
 "feedback": "Feedback",
 "social": "Social",
@@ -147,15 +79,44 @@ Then add the new key after `feedback` in each file:
 
 // fr/common.json
 "feedback": "Commentaires",
-"social": "Réseaux sociaux",
+"social": "Réseaux sociaux"
 ```
 
-### Nested Translations
+## Usage Patterns
+
+### Client Components
+
+```tsx
+import { useTranslation } from "@workspace/i18n";
+
+function Component() {
+  const { t } = useTranslation("common");
+
+  return (
+    <div>
+      <h1>{t("ai.sidebar.title")}</h1>
+      <p>{t("ai.sidebar.subtitle")}</p>
+      <button aria-label={t("ai.sidebar.open")}>Open</button>
+    </div>
+  );
+}
+```
+
+### Nested Keys and JSON Structure
 
 ```json
 {
   "ai": {
     "sidebar": {
+      "title": "Awards AI",
+      "subtitle": "Your awards assistant",
+      "open": "Open AI assistant",
+      "close": "Close AI assistant",
+      "placeholder": "Ask me anything...",
+      "prompts": {
+        "search": "Find relevant awards",
+        "help": "Writing tips"
+      },
       "welcome": {
         "title": "How can I help?",
         "description": "Ask me about finding awards..."
@@ -165,13 +126,9 @@ Then add the new key after `feedback` in each file:
 }
 ```
 
-```tsx
-// Access nested keys with dot notation
-t("ai.sidebar.welcome.title")
-t("ai.sidebar.welcome.description")
-```
+Access with dot notation: `t("ai.sidebar.welcome.title")`
 
-### Interpolation
+### Interpolation and Plurals
 
 ```json
 {
@@ -190,10 +147,7 @@ t("items", { count: 5 })           // "You have 5 items"
 ### Multiple Namespaces
 
 ```tsx
-// Load multiple namespaces
 const { t } = useTranslation(["common", "dashboard"]);
-
-// Use namespace prefix
 t("common:save")
 t("dashboard:stats.title")
 ```
@@ -201,18 +155,16 @@ t("dashboard:stats.title")
 ### Server Components (Next.js App Router)
 
 ```tsx
-// Use server-side translation
 import { getTranslation } from "@workspace/i18n/server";
 
 // Next.js 15+: params is a Promise
-export default async function Page({ 
-  params 
-}: { 
-  params: { locale: string } 
+export default async function Page({
+  params
+}: {
+  params: { locale: string }
 }) {
   const { locale } = params;
   const { t } = await getTranslation(locale, "common");
-  
   return <h1>{t("title")}</h1>;
 }
 
@@ -226,49 +178,24 @@ export default async function Page({
 ### Type-Safe Translations
 
 ```tsx
-// Define translation keys type
-type TranslationKeys = 
+type TranslationKeys =
   | "ai.sidebar.title"
   | "ai.sidebar.subtitle"
   | "ai.sidebar.open"
   | "ai.sidebar.close";
 
-// Use with typed hook
 const { t } = useTranslation<TranslationKeys>("common");
 t("ai.sidebar.title"); // Autocomplete works!
 ```
-
-## Common Mistakes
-
-1. **Forgetting locale files**
-   - Always update en, de, es, fr (or all configured locales)
-   - Use grep to find insertion points
-
-2. **Wrong namespace**
-   - Check which JSON file contains the key
-   - Use correct namespace in `useTranslation`
-
-3. **Missing "use client"**
-   - `useTranslation` hook requires client component
-   - Use server translation for server components
-
-4. **Key not found returns key**
-   - Check JSON structure matches dot notation
-   - Verify namespace is loaded
 
 ## Validation Script
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
-
-# Check for missing translation keys across locales
-# Run from repository root (the script cd's into the translations directory)
-
-# Prerequisites
+# Check for missing translation keys across locales. Run from repo root.
 command -v jq >/dev/null 2>&1 || { echo "Error: jq is required" >&2; exit 1; }
 
-# Configuration
 BASE_LOCALE="en"
 TARGET_LOCALES=("de" "es" "fr")
 NAMESPACE="common"


### PR DESCRIPTION
## Summary

- Tightens `.agents/tools/ui/i18next.md` from 298 → 225 lines (24.5% reduction)
- Classified as **instruction doc** (agent subagent with operational procedures, not reference corpus)
- Zero knowledge loss — all code blocks, URLs, libraries, patterns, and the validation script preserved

## Changes

| What | How |
|------|-----|
| Duplicate "Adding Translation Key" sections | Merged Quick Ref summary + Detailed Patterns into single workflow |
| Duplicate nested JSON examples | Consolidated into one comprehensive block with all keys |
| Locale-specific translations table | Folded into the add-key workflow (same `social` example) |
| "Common Mistakes" section (4 items) | Merged into hazards table; added `"use client"` as 5th row |
| Duplicate component usage examples | Kept one client component example |

## Verification

- `wc -l`: 298 → 225
- All knowledge items verified present: `i18next`, `react-i18next`, `next-i18n-router`, `common.json`, `marketing.json`, `dashboard.json`, `use client`, Next.js 14/15 patterns, `TranslationKeys`, interpolation, plurals, namespaces, validation script, locale translations
- `markdownlint-cli2`: 0 errors
- YAML frontmatter unchanged

Closes #11683