### PR TITLE
t11670: tighten uncloud.md from 195 to 157 lines

### DIFF
--- a/.agents/tools/deployment/uncloud.md
+++ b/.agents/tools/deployment/uncloud.md
@@ -18,27 +18,34 @@ tools:
 
 ## Quick Reference
 
-- **Type**: Multi-machine container orchestration (Docker-based, decentralised)
-- **CLI**: `uc` (install: `brew install psviderski/tap/uncloud` or `curl -fsS https://get.uncloud.run/install.sh | sh`)
+- **Type**: Multi-machine container orchestration (Docker-based, decentralised, no control plane)
+- **CLI**: `uc` — commands: `status|machines|services|deploy|run|scale|logs|exec|inspect|volumes|dns|caddy|help`
 - **Config**: `configs/uncloud-config.json` (copy from `configs/uncloud-config.json.txt`)
-- **Script**: `.agents/scripts/uncloud-helper.sh`
-- **Docs**: https://uncloud.run/docs
-- **Source**: https://github.com/psviderski/uncloud (Apache-2.0, Go)
+- **Helper**: `.agents/scripts/uncloud-helper.sh {status|machines|services|deploy|run|logs|scale}`
+- **Docs**: <https://uncloud.run/docs> | **Source**: <https://github.com/psviderski/uncloud> (Apache-2.0, Go)
 - **Status**: Active development, not yet production-ready (v0.16.0 as of Jan 2026)
-- **Commands**: `status|machines|services|deploy|run|scale|logs|exec|inspect|volumes|dns|caddy|help`
+- **Contexts**: `uc ctx ls && uc ctx use staging && uc ctx connection`
 
-**Key features**: WireGuard mesh networking, Docker Compose format, no control plane, Caddy reverse proxy with auto HTTPS, Unregistry (registryless image push), managed DNS (`*.uncld.dev`), rolling deployments, ~150 MB RAM per machine daemon.
+**Key features**: WireGuard mesh networking, Docker Compose format, Caddy reverse proxy with auto HTTPS (Let's Encrypt), Unregistry (registryless image push), managed DNS (`*.uncld.dev`), rolling deployments, ~150 MB RAM per machine daemon.
 
 <!-- AI-CONTEXT-END -->
+
+## Architecture
+
+```text
+uc CLI --SSH--> uncloudd daemon (Go)
+               corrosion (CRDT/SQLite, peer-to-peer state sync by Fly.io)
+               Docker + WireGuard mesh + Caddy proxy
+```
+
+Each machine runs `uncloudd`. Cluster state syncs peer-to-peer via corrosion — no control plane, no quorum. Security: WireGuard encrypts all inter-machine traffic; CLI communicates via SSH tunnels (only ports 22, 80, 443, 51820 needed).
 
 ## Installation
 
 ```bash
-# macOS/Linux via Homebrew
-brew install psviderski/tap/uncloud
-
-# macOS/Linux via curl
-curl -fsS https://get.uncloud.run/install.sh | sh
+# macOS/Linux
+brew install psviderski/tap/uncloud          # Homebrew
+curl -fsS https://get.uncloud.run/install.sh | sh  # or curl
 
 # Initialise first machine (installs Docker, uncloudd, WireGuard)
 uc machine init root@your-server-ip
@@ -90,8 +97,7 @@ uc machine update node-1 --ssh root@new-ip           # update SSH target
 
 ```bash
 # Unregistry — push local image directly (no external registry)
-uc image push my-app:latest
-uc image ls
+uc image push my-app:latest && uc image ls
 
 # DNS
 uc dns show && uc dns reserve && uc dns release
@@ -102,12 +108,6 @@ uc caddy config && uc caddy deploy
 # Volumes
 uc volume create my-data --machine web-1
 uc volume ls && uc volume inspect my-data && uc volume rm my-data
-```
-
-## Multi-Cluster Contexts
-
-```bash
-uc ctx ls && uc ctx use staging && uc ctx connection
 ```
 
 ## Compose File
@@ -135,61 +135,23 @@ volumes:
   app-data:
 ```
 
-## Helper Script
-
-```bash
-./.agents/scripts/uncloud-helper.sh status
-./.agents/scripts/uncloud-helper.sh machines
-./.agents/scripts/uncloud-helper.sh services
-./.agents/scripts/uncloud-helper.sh deploy
-./.agents/scripts/uncloud-helper.sh run my-app:latest -p app.example.com:8000/https
-./.agents/scripts/uncloud-helper.sh logs my-service
-./.agents/scripts/uncloud-helper.sh scale my-service 3
-```
-
 ## Troubleshooting
 
-**Machine init fails:**
-
 ```bash
+# Machine init fails
 ssh root@your-server-ip 'echo ok'                    # verify SSH
 ssh root@your-server-ip 'docker info'                # check Docker
 ssh root@your-server-ip 'systemctl status uncloud'   # check daemon
-```
 
-**Services not accessible:**
+# Services not accessible
+uc ls && uc inspect my-service                       # service status
+uc caddy config                                      # Caddy config
+uc wg show                                           # WireGuard connectivity
+dig app.example.com                                  # DNS resolution
 
-```bash
-uc ls && uc inspect my-service   # service status
-uc caddy config                  # Caddy config
-uc wg show                       # WireGuard connectivity
-dig app.example.com              # DNS
-```
-
-**Container networking:**
-
-```bash
+# Container networking
 uc wg show && uc machine ls && uc ps
+
+# Uninstall (run on the machine)
+uncloud-uninstall
 ```
-
-**Uninstall:**
-
-```bash
-uncloud-uninstall   # run on the machine
-```
-
-## Security
-
-- WireGuard encrypts all inter-machine traffic
-- CLI communicates via SSH tunnels — only SSH (22), HTTP (80), HTTPS (443), WireGuard (51820) needed
-- Auto HTTPS via Let's Encrypt (Caddy)
-
-## Architecture
-
-```text
-uc CLI --SSH--> uncloudd daemon (Go)
-               corrosion (CRDT/SQLite, peer-to-peer state sync by Fly.io)
-               Docker + WireGuard mesh + Caddy proxy
-```
-
-Each machine runs `uncloudd`. Cluster state syncs peer-to-peer via corrosion. No control plane, no quorum.


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/deployment/uncloud.md` from 195 → 157 lines (19.5% reduction)
- Remove redundant Helper Script section (duplicated Service Management commands with path prefix; path already in Quick Reference)
- Merge Multi-Cluster Contexts (3 commands) into Quick Reference bullet
- Merge Security section into Architecture paragraph
- Move Architecture above operational sections (understanding before operations)
- Consolidate Troubleshooting diagnostic commands into single code block

## Content Preservation

All actionable content verified present:
- 24/24 CLI commands (`uc machine init`, `uc deploy`, `uc run`, etc.)
- 3/3 URLs (docs, source, install script)
- 8 code blocks (bash, json, yaml, text)
- Config example, Compose file example, cluster config — all intact

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs-only change, no code/config)
- **Verification**: markdownlint-cli2 — 0 errors; content audit — all commands/URLs/blocks present

Closes #11670