### PR TITLE
GH#11727: Tighten nextjs-layouts.md from 294 to 220 lines

### DIFF
--- a/.agents/tools/ui/nextjs-layouts.md
+++ b/.agents/tools/ui/nextjs-layouts.md
@@ -19,20 +19,19 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Nested layouts, route groups, and provider patterns in Next.js App Router
-- **Version**: Next.js 14+ with App Router
+- **Scope**: Nested layouts, route groups, providers in Next.js 14+ App Router
 - **Docs**: Use Context7 MCP for current documentation
 
-**Common Hazards** (from real sessions):
+**Common Hazards**:
 
 | Hazard | Problem | Solution |
 |--------|---------|----------|
-| Provider in wrong layout | Context not available in child routes | Place provider in parent layout that wraps all consumers |
+| Provider in wrong layout | Context not available in child routes | Place provider in parent layout wrapping all consumers |
 | Server vs Client | Using hooks in server component | Add `"use client"` or move to client component |
 | Layout re-renders | Entire layout re-renders on navigation | Layouts are cached; check if issue is in page component |
 | Cookie reading | Can't read cookies in client component | Read in server layout, pass as prop to provider |
 
-**Layout Hierarchy**:
+## Layout Hierarchy
 
 ```text
 app/
@@ -52,28 +51,33 @@ app/
 │       └── page.tsx
 ```
 
-**Provider Placement**:
+## Server Layout with Cookie-Driven Providers
+
+Read cookies server-side, pass initial state to client providers:
 
 ```tsx
 // app/[locale]/dashboard/layout.tsx
-// Place providers here if ALL dashboard routes need them
-
+import { cookies } from "next/headers";
 import { SidebarProvider } from "@/components/sidebar/context";
 import { AISidebarProvider } from "@/components/ai-sidebar/context";
-
-import { cookies } from "next/headers";
-// Import your sidebar components
 import { Sidebar } from "@/components/sidebar";
 import { AISidebar } from "@/components/ai-sidebar";
 
-export default async function DashboardLayout({ children }) {
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const cookieStore = await cookies();
   const sidebarOpen = cookieStore.get("sidebar_state")?.value === "true";
   const aiSidebarOpen = cookieStore.get("ai_sidebar_state")?.value !== "false";
+  const aiSidebarWidth = parseInt(
+    cookieStore.get("ai_sidebar_width")?.value || "384"
+  );
 
   return (
     <SidebarProvider defaultOpen={sidebarOpen}>
-      <AISidebarProvider defaultOpen={aiSidebarOpen}>
+      <AISidebarProvider defaultOpen={aiSidebarOpen} defaultWidth={aiSidebarWidth}>
         <div className="flex min-h-screen">
           <Sidebar />
           <main className="flex-1">{children}</main>
@@ -85,78 +89,9 @@ export default async function DashboardLayout({ children }) {
 }
 ```
 
-**Route Groups** (parentheses don't affect URL):
+## Client Shell Component
 
-```text
-dashboard/
-├── (user)/           # /dashboard/* - user routes
-│   ├── layout.tsx    # User-specific layout
-│   ├── page.tsx      # /dashboard
-│   └── settings/
-│       └── page.tsx  # /dashboard/settings
-└── [organization]/   # /dashboard/[org]/* - org routes
-    ├── layout.tsx    # Org-specific layout
-    └── page.tsx      # /dashboard/acme
-```
-
-**3-Column Flex Layout**:
-
-```tsx
-// Dashboard with left sidebar, content, and right AI sidebar
-<div className="flex min-h-screen">
-  {/* Left sidebar - fixed width */}
-  <aside className="w-64 shrink-0 border-r">
-    <Sidebar />
-  </aside>
-  
-  {/* Main content - flexible */}
-  <main className="flex-1 min-w-0">
-    {children}
-  </main>
-  
-  {/* Right AI sidebar - collapsible */}
-  <AISidebar />
-</div>
-```
-
-<!-- AI-CONTEXT-END -->
-
-## Detailed Patterns
-
-### Reading Cookies in Server Layout
-
-```tsx
-// app/[locale]/dashboard/layout.tsx
-import { cookies } from "next/headers";
-
-export default async function DashboardLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const cookieStore = await cookies();
-  
-  // Read initial state from cookies
-  const sidebarOpen = cookieStore.get("sidebar_state")?.value === "true";
-  const aiSidebarOpen = cookieStore.get("ai_sidebar_state")?.value !== "false";
-  const aiSidebarWidth = parseInt(
-    cookieStore.get("ai_sidebar_width")?.value || "384"
-  );
-
-  return (
-    <SidebarProvider defaultOpen={sidebarOpen}>
-      <AISidebarProvider 
-        defaultOpen={aiSidebarOpen}
-        defaultWidth={aiSidebarWidth}
-      >
-        <DashboardShell>{children}</DashboardShell>
-      </AISidebarProvider>
-    </SidebarProvider>
-  );
-}
-```
-
-### Shared Layout Components
+Extract layout structure into a client component when you need hooks:
 
 ```tsx
 // components/layout/dashboard-shell.tsx
@@ -182,41 +117,46 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
 }
 ```
 
-### Multiple Layouts for Same Route
+<!-- AI-CONTEXT-END -->
 
-Use route groups to apply different layouts:
+## Route Groups
+
+Parenthesized directories don't affect URLs. Use for applying different layouts to the same route prefix:
 
 ```text
-app/[locale]/dashboard/
-├── (with-sidebar)/
-│   ├── layout.tsx      # Has sidebar
-│   ├── page.tsx        # /dashboard
+dashboard/
+├── (user)/               # /dashboard/* — user routes
+│   ├── layout.tsx        # User-specific layout (has sidebar)
+│   ├── page.tsx          # /dashboard
 │   └── settings/
-│       └── page.tsx    # /dashboard/settings
-└── (fullscreen)/
-    ├── layout.tsx      # No sidebar, fullscreen
-    └── focus/
-        └── page.tsx    # /dashboard/focus
+│       └── page.tsx      # /dashboard/settings
+├── (fullscreen)/         # /dashboard/* — fullscreen variant
+│   ├── layout.tsx        # No sidebar
+│   └── focus/
+│       └── page.tsx      # /dashboard/focus
+└── [organization]/       # /dashboard/[org]/* — org routes
+    ├── layout.tsx        # Org-specific layout
+    └── page.tsx          # /dashboard/acme
 ```
 
-### Parallel Routes
+## Parallel Routes
 
-For modals or split views:
+For modals or split views using `@slot` directories:
 
 ```text
 app/[locale]/dashboard/
 ├── layout.tsx
 ├── page.tsx
 ├── @modal/
-│   ├── default.tsx     # Empty when no modal
+│   ├── default.tsx       # Empty when no modal
 │   └── (.)settings/
-│       └── page.tsx    # Intercepts /dashboard/settings as modal
+│       └── page.tsx      # Intercepts /dashboard/settings as modal
 └── settings/
-    └── page.tsx        # Full page version
+    └── page.tsx          # Full page version
 ```
 
 ```tsx
-// layout.tsx
+// layout.tsx — receives parallel route slots as props
 export default function Layout({
   children,
   modal,
@@ -233,20 +173,18 @@ export default function Layout({
 }
 ```
 
-### Loading States
+## Loading & Error States
 
 ```tsx
 // app/[locale]/dashboard/loading.tsx
 export default function Loading() {
   return (
     <div className="flex items-center justify-center h-full">
-      <Spinner /> {/* Your loading spinner component */}
+      <Spinner />
     </div>
   );
 }
 ```
-
-### Error Boundaries
 
 ```tsx
 // app/[locale]/dashboard/error.tsx
@@ -270,25 +208,13 @@ export default function Error({
 
 ## Common Mistakes
 
-1. **Providers in page instead of layout**
-   - Context resets on navigation
-   - Move providers to layout for persistence
-
-2. **Async in client component**
-   - Can't use `await cookies()` in client
-   - Read in server layout, pass as props
-
-3. **Missing default.tsx for parallel routes**
-   - Causes 404 when parallel route not matched
-   - Add `default.tsx` returning `null`
-
-4. **Layout vs Template**
-   - Layout: persists across navigations (cached)
-   - Template: re-mounts on every navigation
-   - Use layout for providers, template for animations
+1. **Providers in page instead of layout** — context resets on navigation. Move to layout for persistence.
+2. **Async in client component** — can't `await cookies()` in client. Read in server layout, pass as props.
+3. **Missing `default.tsx` for parallel routes** — causes 404 when slot not matched. Return `null`.
+4. **Layout vs Template** — layouts persist across navigations (cached); templates re-mount every navigation. Use layout for providers, template for animations.
 
 ## Related
 
-- `tools/ui/react-context.md` - Context patterns for layouts
-- `tools/ui/tailwind-css.md` - Layout styling
+- `tools/ui/react-context.md` — Context patterns for layouts
+- `tools/ui/tailwind-css.md` — Layout styling
 - Context7 MCP for Next.js documentation


### PR DESCRIPTION
## Summary

- Merge 3 duplicate patterns (cookie reading, route groups, 3-column flex) into single comprehensive examples
- Remove verbose prose while preserving all technical content
- 294 → 220 lines (25% reduction, net -74 lines)

## What Changed

**Merged duplicates:**
- Cookie reading pattern appeared twice (Quick Reference + Detailed Patterns) — merged into one comprehensive example that includes `aiSidebarWidth`
- Route group directory trees appeared twice — combined into one showing both basic and fullscreen variants
- 3-column flex layout appeared twice (standalone + DashboardShell) — kept DashboardShell as the richer pattern

**Preserved all technical content:**
- Hazards table (4 rows)
- Layout hierarchy tree
- Server-side cookie reading → provider props pattern
- Client shell component with hooks
- Route groups, parallel routes (`@modal`)
- Loading and error state patterns
- Common mistakes (4 items)
- Related links (3 references)
- All frontmatter/tooling config

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs/agent prompt only)
- **Verification**: markdownlint — 0 errors. All code blocks, URLs, and pattern references verified present.

Closes #11727