### PR TITLE
t11747: tighten distribution-youtube-topic-research.md from 298 lines

### DIFF
--- a/.agents/content/distribution/youtube/topic-research.md
+++ b/.agents/content/distribution/youtube/topic-research.md
@@ -15,25 +15,14 @@ tools:
 
 # YouTube Topic Research
 
-Find video topics that have proven demand but low competition. Combines YouTube search data, competitor content analysis, keyword research, and trend detection to surface opportunities.
-
-## When to Use
-
-Read this subagent when the user wants to:
-
-- Find video topic ideas for their niche
-- Identify content gaps (topics competitors haven't covered)
-- Detect rising trends before they peak
-- Cluster keywords into video topic groups
-- Generate unique angles on proven topics
-- Validate whether a topic idea has enough search demand
+Find video topics with proven demand and low competition. Use for: content gaps, rising trends, keyword clustering, angle generation, and validating search demand.
 
 ## Data Sources
 
 | Source | What It Provides | Tool |
 |--------|-----------------|------|
 | YouTube Data API | Search results, video counts per topic | `youtube-helper.sh search` |
-| Competitor videos | What topics are already covered | `youtube-helper.sh videos` |
+| Competitor videos | Topics already covered | `youtube-helper.sh videos` |
 | yt-dlp transcripts | Deep topic extraction from video content | `youtube-helper.sh transcript` |
 | DataForSEO | YouTube SERP data, keyword volume, competition | `keyword-research-helper.sh` |
 | Serper | Google Trends signals, web search context | `seo/serper.md` |
@@ -41,14 +30,11 @@ Read this subagent when the user wants to:
 
 ## Workflow: Content Gap Analysis
 
-The most reliable way to find topics: compare what competitors cover vs what's missing.
+Compare what competitors cover vs what's missing.
 
 ### Step 1: Extract Competitor Topic Maps
 
-For each competitor, get their video titles and cluster by topic:
-
 ```bash
-# Get all video titles from a competitor
 youtube-helper.sh videos @competitor 200 json | node -e "
 process.stdin.on('data', d => {
     JSON.parse(d).forEach(v => console.log(v.snippet?.title));
@@ -56,11 +42,8 @@ process.stdin.on('data', d => {
 " > /tmp/competitor_titles.txt
 ```
 
-Repeat for 3-5 competitors. Then use the AI to cluster titles into topic groups:
-
-**Prompt pattern**:
-> Here are [N] video titles from [competitor]. Group them into topic clusters.
-> For each cluster, note: topic name, video count, and whether views trend up or down.
+Repeat for 3-5 competitors. Cluster titles with AI:
+> Here are [N] video titles from [competitor]. Group into topic clusters. For each: topic name, video count, view trend direction.
 
 ### Step 2: Map Your Own Coverage
 
@@ -74,15 +57,7 @@ process.stdin.on('data', d => {
 
 ### Step 3: Identify Gaps
 
-Compare the topic maps. Gaps are topics that:
-1. Multiple competitors cover (proven demand)
-2. You haven't covered yet
-3. Have outlier videos in competitor channels (high engagement)
-
-**Prompt pattern**:
-> Compare these topic clusters from my channel vs competitors.
-> Identify topics where: (a) 2+ competitors have videos, (b) I have zero coverage,
-> (c) at least one competitor video is an outlier (3x+ their median views).
+Gaps = topics where: (a) 2+ competitors have videos, (b) you have zero coverage, (c) at least one competitor video is an outlier (3x+ their median views).
 
 ### Step 4: Store Findings
 
@@ -94,85 +69,50 @@ memory-helper.sh store --type WORKING_SOLUTION --namespace youtube-topics \
 
 ## Workflow: Trend Detection
 
-Find topics gaining momentum before they saturate.
-
 ### Method 1: YouTube Search Volume Signals
 
 ```bash
-# Search for your niche topic — look at publish dates
 youtube-helper.sh search "your niche topic 2026" video 20
-
-# If most results are recent (last 30 days), the topic is trending
-# If results are old, the topic may be saturated
+# Most results recent (last 30 days) = trending. Old results = saturated.
 ```
 
 ### Method 2: DataForSEO YouTube SERP
 
-If DataForSEO is configured, use the YouTube SERP endpoint:
-
 ```bash
-# Check keyword-research-helper for YouTube-specific data
 keyword-research-helper.sh volume "topic keyword" --engine youtube
+# Returns: video rankings, estimated search volume, competition, related keywords
 ```
-
-DataForSEO's `serp/youtube/organic/live` endpoint returns:
-- Video rankings for a keyword on YouTube search
-- Estimated search volume
-- Competition level
-- Related keywords
 
 ### Method 3: Competitor Upload Velocity
 
-If multiple competitors suddenly start covering a topic, it's trending:
-
 ```bash
-# Get recent videos from multiple competitors
 for ch in @comp1 @comp2 @comp3; do
     echo "=== $ch ==="
     youtube-helper.sh videos "$ch" 20 | head -15
-    echo ""
 done
+# Same topic across multiple channels within 2 weeks = trending
 ```
-
-Look for the same topic appearing across multiple channels within the same 2-week window.
 
 ### Method 4: Google Trends via Serper
 
-```bash
-# Use Serper to check Google Trends signals
-# (requires serper.md configuration)
-```
+> Search Google Trends for "[topic]" — is interest rising, stable, or declining over the past 12 months?
 
-**Prompt pattern**:
-> Search Google Trends for "[topic]" and tell me if interest is rising,
-> stable, or declining over the past 12 months.
+## Workflow: Keyword Clustering
 
-## Workflow: Keyword Clustering for YouTube
-
-Group related keywords into video topics. One video should target one keyword cluster.
+One video should target one keyword cluster.
 
 ### Step 1: Seed Keywords
 
-Start with 5-10 broad keywords in your niche:
-
 ```bash
-# Search YouTube for each seed keyword
 for kw in "keyword1" "keyword2" "keyword3"; do
     echo "=== $kw ==="
     youtube-helper.sh search "$kw" video 10
-    echo ""
 done
 ```
 
 ### Step 2: Extract Related Terms
 
-From search results, extract:
-- Video titles (contain natural keyword variations)
-- Tags from top-performing videos
-- Description keywords
-
 ```bash
-# Get tags from top videos
 youtube-helper.sh video VIDEO_ID json | node -e "
 process.stdin.on('data', d => {
     const tags = JSON.parse(d).items?.[0]?.snippet?.tags || [];
@@ -183,17 +123,9 @@ process.stdin.on('data', d => {
 
 ### Step 3: Cluster with AI
 
-**Prompt pattern**:
-> Here are [N] keywords related to [niche]. Group them into clusters where
-> each cluster represents one video topic. For each cluster:
-> 1. Primary keyword (highest volume)
-> 2. Supporting keywords (2-5)
-> 3. Suggested video title
-> 4. Estimated competition (low/medium/high based on existing video count)
+> Here are [N] keywords for [niche]. Group into clusters (one per video topic). For each: primary keyword (highest volume), supporting keywords (2-5), suggested title, estimated competition (low/medium/high).
 
 ### Step 4: Validate with Search Volume
-
-If DataForSEO is available:
 
 ```bash
 keyword-research-helper.sh volume "primary keyword" --engine youtube
@@ -201,26 +133,19 @@ keyword-research-helper.sh volume "primary keyword" --engine youtube
 
 ## Workflow: Angle Generation
 
-The same topic can be covered from many angles. Find the unique take that hasn't been done.
-
 ### Step 1: Analyze Existing Coverage
 
 ```bash
-# Search for the topic
 youtube-helper.sh search "topic" video 20
-
-# Get transcripts of top 3 videos to understand their angle
 youtube-helper.sh transcript VIDEO_ID_1
 youtube-helper.sh transcript VIDEO_ID_2
 youtube-helper.sh transcript VIDEO_ID_3
 ```
 
-### Step 2: Identify Angle Patterns
+### Step 2: Angle Types
 
-Common YouTube angle types:
-
-| Angle Type | Example | When It Works |
-|-----------|---------|---------------|
+| Angle | Example | When It Works |
+|-------|---------|---------------|
 | **Contrarian** | "Why [popular opinion] is wrong" | Established topics with consensus |
 | **Personal experience** | "I tried [thing] for 30 days" | Lifestyle, health, tech |
 | **Comparison** | "[A] vs [B] — which is actually better?" | Products, tools, methods |
@@ -234,21 +159,10 @@ Common YouTube angle types:
 
 ### Step 3: Generate Unique Angles
 
-**Prompt pattern**:
-> Topic: [topic]
-> Existing angles found in top 10 videos: [list angles]
-> My channel's voice: [description from memory]
-> My audience: [description from memory]
->
-> Generate 5 unique angles for this topic that:
-> 1. Haven't been covered by the top 10 videos
-> 2. Match my channel voice
-> 3. Would appeal to my specific audience
-> 4. Have a clear hook for the first 30 seconds
+> Topic: [topic]. Existing angles in top 10 videos: [list]. My channel voice: [from memory]. My audience: [from memory].
+> Generate 5 unique angles that: (1) aren't in the top 10, (2) match my voice, (3) appeal to my audience, (4) have a clear 30-second hook.
 
 ## Output Format
-
-When reporting topic research, use this structure:
 
 ```markdown
 ## Topic Opportunity: [Topic Name]
@@ -275,15 +189,14 @@ When reporting topic research, use this structure:
 ## Memory Integration
 
 ```bash
-# Store a validated topic opportunity
+# Store validated opportunity
 memory-helper.sh store --type WORKING_SOLUTION --namespace youtube-topics \
-  "Topic: [name]. Demand: [signal]. Competition: [level]. \
-   Best angle: [type] — [description]. Keywords: [list]."
+  "Topic: [name]. Demand: [signal]. Competition: [level]. Best angle: [type] — [description]. Keywords: [list]."
 
 # Recall previous research
 memory-helper.sh recall --namespace youtube-topics "content gap"
 
-# Store a failed topic idea (so we don't revisit it)
+# Store rejected topic (avoid revisiting)
 memory-helper.sh store --type FAILED_APPROACH --namespace youtube-topics \
   "Topic [name] rejected: [reason — e.g., too saturated, no search volume]"
 ```


### PR DESCRIPTION
## Summary

- Reduces `.agents/content/distribution/youtube/topic-research.md` from 298 → 211 lines (29% reduction)
- Removes verbosity and redundancy; preserves all technical content
- Collapses When-to-Use section into description, inlines prompt patterns as blockquotes, removes obvious prose between code blocks, tightens step headers

## Runtime Testing

- **Risk**: Low (docs-only change, no code)
- **Testing level**: self-assessed
- **Verification**: `wc -l` confirms 211 lines; all code blocks, tool references, angle types, workflows, memory commands, and related links present

## Files Changed

- `.agents/content/distribution/youtube/topic-research.md` — tightened from 298 to 211 lines

Closes #11747