### PR TITLE
GH#11751: Tighten best-practices.md from 286 to 256 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -755,6 +755,66 @@
       "hash": "5642d959165b452f2c132f2d2ecdb7d484e06061",
       "at": "2026-03-28T09:17:43Z",
       "pr": 11716
+    },
+    ".agents/services/payments/procurement.md": {
+      "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
+      "at": "2026-03-28T09:39:19Z",
+      "pr": 11713
+    },
+    ".agents/tools/build-agent/build-agent.md": {
+      "hash": "4c52d5b08eba50130bce788693dd955886e1753d",
+      "at": "2026-03-28T09:39:20Z",
+      "pr": 11723
+    },
+    ".agents/content/distribution-youtube-topic-research.md": {
+      "hash": "5cad3eadce10ee33a862ef8040dc746457b7bf8a",
+      "at": "2026-03-28T09:39:21Z",
+      "pr": 11708
+    },
+    ".agents/content/heygen-skill/rules-captions.md": {
+      "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
+      "at": "2026-03-28T09:39:22Z",
+      "pr": 11707
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
+      "hash": "1679befdbb328a28617cb3e59957a033bba35409",
+      "at": "2026-03-28T09:39:23Z",
+      "pr": 11709
+    },
+    ".agents/services/database/postgres-drizzle-skill/schema.md": {
+      "hash": "99ebb3bdfd27856e94ed29c7851699d12739ef67",
+      "at": "2026-03-28T09:39:23Z",
+      "pr": 11709
+    },
+    ".agents/tools/ui/i18next.md": {
+      "hash": "ad0db76988832be07bb31badbcc1eb57283d0424",
+      "at": "2026-03-28T09:39:25Z",
+      "pr": 11710
+    },
+    ".agents/services/database/postgres-drizzle-skill/relations.md": {
+      "hash": "673a7c2abd65766f454b57e79a259a7217463210",
+      "at": "2026-03-28T09:39:26Z",
+      "pr": 11717
+    },
+    ".agents/tools/build-mcp/server-patterns.md": {
+      "hash": "5eb6823c314d82301636ec87d7ff3720480cea13",
+      "at": "2026-03-28T09:39:31Z",
+      "pr": 11679
+    },
+    ".agents/tools/git/worktrunk.md": {
+      "hash": "cd84573d4010381648d025eb355743bcf1396d87",
+      "at": "2026-03-28T09:39:32Z",
+      "pr": 11678
+    },
+    ".agents/content/distribution-youtube-pipeline.md": {
+      "hash": "de1a4b45ed69d1c248513eee27d35b778fd00045",
+      "at": "2026-03-28T09:39:34Z",
+      "pr": 11676
+    },
+    ".agents/content/heygen-skill/rules-video-generation.md": {
+      "hash": "e6c74b411a5ea6ce2e63aa71a20cbd312b695a3f",
+      "at": "2026-03-28T09:39:35Z",
+      "pr": 11675
     }
   }
 }

--- a/.agents/tools/code-review/best-practices.md
+++ b/.agents/tools/code-review/best-practices.md
@@ -32,7 +32,7 @@ tools:
 
 ## Shell Script Standards (MANDATORY)
 
-Required for SonarCloud/CodeFactor/Codacy compliance:
+Required for SonarCloud/CodeFactor/Codacy compliance. Full rule reference: `code-standards.md`.
 
 ```bash
 # Function structure — local params, explicit return
@@ -52,18 +52,7 @@ readonly CONTENT_TYPE_JSON="Content-Type: application/json"
 readonly ERROR_UNKNOWN_COMMAND="Unknown command:"
 ```
 
-**Unused variable rule (S1481):** Prefer enhancement over deletion:
-
-```bash
-# ✅ Enhance rather than remove
-local port
-read -r port
-if [[ -n "$port" && "$port" != "22" ]]; then
-    ssh -p "$port" "$host"
-else
-    ssh "$host"
-fi
-```
+**S1481 (unused variables):** Prefer enhancing functionality over deleting — the variable often signals missing logic.
 
 ## Quality Tools
 
@@ -75,7 +64,21 @@ fi
 
 ## Runtime Behaviour Patterns
 
-These patterns cause silent failures, infinite loops, and race conditions that only appear at runtime. Static analysis cannot catch them.
+Patterns that cause silent failures, infinite loops, and race conditions. Static analysis cannot catch these.
+
+**Prevention rule:** Before implementing any pattern below, enumerate the complete state space — every possible state, event, and status value including errors. Implement handlers for all of them before writing the happy path.
+
+### Runtime Testing Signals
+
+| Pattern | Risk | Required testing |
+|---------|------|-----------------|
+| `switch`/`case` on status/state | Missing entry states | Trigger each state |
+| `while true` / unbounded loops | Infinite loop | Verify termination |
+| `setTimeout`/`setInterval` | Timer leak | Verify cleanup |
+| Payment/checkout flows | Duplicate charge | Full payment flow |
+| Auth token refresh | Race condition | Concurrent requests |
+| Webhook handlers | Missing event types | Send each event type |
+| Database migrations | Irreversible | Test on staging first |
 
 ### State Machines
 
@@ -86,7 +89,7 @@ Handle **all** possible states, not just the happy path. Missing states cause si
 **Detection keywords:** `status`, `state`, `phase`, `stage`, `step`, `mode`, `lifecycle`
 
 ```bash
-# ✅ Exhaustive shell state machine with explicit default
+# Exhaustive state machine with explicit default
 handle_deploy_state() {
     local state="$1"
     case "$state" in
@@ -105,29 +108,12 @@ handle_deploy_state() {
 }
 ```
 
-```typescript
-// ✅ TypeScript: exhaustive switch with explicit default
-function handlePaymentStatus(status: string) {
-  switch (status) {
-    case 'succeeded':  showSuccess(); break;
-    case 'failed':     showError(); break;
-    case 'pending':
-    case 'processing': showPending(); break;
-    case 'cancelled':  showCancelled(); break;
-    case 'refunded':   showRefunded(); break;
-    default:
-      console.error(`Unhandled payment status: ${status}`);
-      showError(`Unexpected status: ${status}`);
-  }
-}
-```
-
 #### Transition Guards
 
 Guard state transitions to prevent double-processing and duplicate charges:
 
 ```typescript
-// ✅ Only allow valid transitions from current state
+// Only allow valid transitions from current state
 class OrderProcessor {
   status: 'pending' | 'charging' | 'charged' | 'failed' = 'pending';
 
@@ -155,13 +141,13 @@ class OrderProcessor {
 ```
 
 ```bash
-# ✅ Shell transition guard
+# Shell transition guard
 DEPLOY_STATE="idle"
 transition_deploy_state() {
     local from_state="$1"
     local to_state="$2"
     if [[ "$DEPLOY_STATE" != "$from_state" ]]; then
-        echo "[transition_deploy_state] Invalid: $DEPLOY_STATE → $to_state (expected from: $from_state)" >&2
+        echo "[transition_deploy_state] Invalid: $DEPLOY_STATE -> $to_state (expected from: $from_state)" >&2
         return 1
     fi
     DEPLOY_STATE="$to_state"
@@ -176,7 +162,7 @@ transition_deploy_state() {
 Every polling loop **must** have: success, timeout, terminal failure, and max-iterations termination.
 
 ```bash
-# ✅ Safe polling with all four termination conditions
+# Safe polling with all four termination conditions
 wait_for_deploy() {
     local deploy_id="$1"
     local max_wait="${2:-300}"
@@ -268,19 +254,3 @@ async function waitForQuiescence(
   throw new Error(`Page did not reach quiescence within ${timeoutMs}ms`);
 }
 ```
-
-### Runtime Testing Signals
-
-These patterns require runtime testing — static analysis cannot verify them:
-
-| Pattern | Risk | Required testing |
-|---------|------|-----------------|
-| `switch`/`case` on status/state | Missing entry states | Trigger each state |
-| `while true` / unbounded loops | Infinite loop | Verify termination |
-| `setTimeout`/`setInterval` | Timer leak | Verify cleanup |
-| Payment/checkout flows | Duplicate charge | Full payment flow |
-| Auth token refresh | Race condition | Concurrent requests |
-| Webhook handlers | Missing event types | Send each event type |
-| Database migrations | Irreversible | Test on staging first |
-
-**Prevention rule:** Before implementing any of these patterns, enumerate the complete state space — every possible state, event, and status value including errors. Implement handlers for all of them before writing the happy path.


### PR DESCRIPTION
## Summary

- Classified `.agents/tools/code-review/best-practices.md` as **instruction doc** (not reference corpus) — tighten prose, not split into chapters
- Reduced from 286 → 256 lines (10.5% reduction) while preserving all institutional knowledge
- Removed redundant TypeScript exhaustive switch example (same pattern already shown in bash)
- Removed S1481 code example (rule preserved in Quick Reference + inline prose)
- Added cross-reference to `code-standards.md` for full rule details (progressive disclosure)
- Moved Runtime Testing Signals table before code examples for better decision-aid positioning

## Content Preservation Verification

All preserved:
- **Rule IDs**: SC2155, S7679, S1192, S1481
- **Code patterns**: `handle_deploy_state`, `transition_deploy_state`, `wait_for_deploy`, `poll_with_backoff`, `waitForQuiescence`, `OrderProcessor`
- **References**: AGENTS.md, linters-local, SonarCloud, CodeFactor, Codacy
- **Runtime testing signals table**: complete (7 rows)
- **Detection keywords**, prevention rule, all quality tool references

## What was removed (and why)

| Removed | Lines | Reason |
|---------|-------|--------|
| TypeScript `handlePaymentStatus` exhaustive switch | 16 | Identical concept to bash `handle_deploy_state` — one example sufficient |
| S1481 bash code example | 10 | Rule stated in Quick Reference + prose; trivial `read -r port` example adds little |
| Filler prose | 4 | "These patterns cause..." intro shortened |

## Runtime Testing

- testing_level: `self-assessed`
- risk_classification: Low (docs/agent prompt only, no runtime behaviour)
- No code execution paths changed

Closes #11751