### PR TITLE
t11745: tighten schema.md 298→289 lines, consolidate imports

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -755,6 +755,66 @@
       "hash": "5642d959165b452f2c132f2d2ecdb7d484e06061",
       "at": "2026-03-28T09:17:43Z",
       "pr": 11716
+    },
+    ".agents/services/payments/procurement.md": {
+      "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
+      "at": "2026-03-28T09:48:49Z",
+      "pr": 11713
+    },
+    ".agents/tools/build-agent/build-agent.md": {
+      "hash": "4c52d5b08eba50130bce788693dd955886e1753d",
+      "at": "2026-03-28T09:48:51Z",
+      "pr": 11723
+    },
+    ".agents/content/distribution-youtube-topic-research.md": {
+      "hash": "5cad3eadce10ee33a862ef8040dc746457b7bf8a",
+      "at": "2026-03-28T09:48:52Z",
+      "pr": 11708
+    },
+    ".agents/content/heygen-skill/rules-captions.md": {
+      "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
+      "at": "2026-03-28T09:48:53Z",
+      "pr": 11707
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
+      "hash": "1679befdbb328a28617cb3e59957a033bba35409",
+      "at": "2026-03-28T09:48:55Z",
+      "pr": 11709
+    },
+    ".agents/services/database/postgres-drizzle-skill/schema.md": {
+      "hash": "99ebb3bdfd27856e94ed29c7851699d12739ef67",
+      "at": "2026-03-28T09:48:55Z",
+      "pr": 11709
+    },
+    ".agents/tools/ui/i18next.md": {
+      "hash": "ad0db76988832be07bb31badbcc1eb57283d0424",
+      "at": "2026-03-28T09:48:56Z",
+      "pr": 11710
+    },
+    ".agents/services/database/postgres-drizzle-skill/relations.md": {
+      "hash": "673a7c2abd65766f454b57e79a259a7217463210",
+      "at": "2026-03-28T09:48:57Z",
+      "pr": 11717
+    },
+    ".agents/tools/build-mcp/server-patterns.md": {
+      "hash": "5eb6823c314d82301636ec87d7ff3720480cea13",
+      "at": "2026-03-28T09:49:04Z",
+      "pr": 11679
+    },
+    ".agents/tools/git/worktrunk.md": {
+      "hash": "cd84573d4010381648d025eb355743bcf1396d87",
+      "at": "2026-03-28T09:49:05Z",
+      "pr": 11678
+    },
+    ".agents/content/distribution-youtube-pipeline.md": {
+      "hash": "de1a4b45ed69d1c248513eee27d35b778fd00045",
+      "at": "2026-03-28T09:49:07Z",
+      "pr": 11676
+    },
+    ".agents/content/heygen-skill/rules-video-generation.md": {
+      "hash": "e6c74b411a5ea6ce2e63aa71a20cbd312b695a3f",
+      "at": "2026-03-28T09:49:08Z",
+      "pr": 11675
     }
   }
 }

--- a/.agents/services/database/postgres-drizzle-skill/schema.md
+++ b/.agents/services/database/postgres-drizzle-skill/schema.md
@@ -12,8 +12,9 @@ import {
   numeric, decimal, real, doublePrecision,
   json, jsonb, pgEnum,
   index, uniqueIndex, primaryKey, foreignKey, check,
+  AnyPgColumn,
 } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm';
+import { sql, isNull, arrayContains, arrayContained, arrayOverlaps } from 'drizzle-orm';
 ```
 
 ## Primary Keys
@@ -134,8 +135,7 @@ tags: text('tags').array(),
 scores: integer('scores').array(),
 categories: text('categories').array().default([]),
 
-// Querying
-import { arrayContains, arrayContained, arrayOverlaps } from 'drizzle-orm';
+// Querying (arrayContained, arrayOverlaps also available)
 .where(arrayContains(posts.tags, ['typescript', 'drizzle']))
 .where(arrayOverlaps(posts.tags, ['react', 'vue']))
 ```
@@ -143,11 +143,6 @@ import { arrayContains, arrayContained, arrayOverlaps } from 'drizzle-orm';
 ## Constraints
 
 ```typescript
-// Not null & default
-email: text('email').notNull(),
-status: text('status').notNull().default('active'),
-createdAt: timestamp('created_at').notNull().defaultNow(),
-
 // Unique (column-level)
 email: text('email').notNull().unique(),
 
@@ -179,7 +174,6 @@ authorId: uuid('author_id').notNull().references(() => users.id, {
 }),
 
 // Self-referential
-import { AnyPgColumn } from 'drizzle-orm/pg-core';
 parentId: uuid('parent_id').references((): AnyPgColumn => categories.id),
 
 // Composite foreign key
@@ -210,8 +204,6 @@ export const orderItems = pgTable('order_items', {
 ## Composite Primary Key
 
 ```typescript
-import { primaryKey } from 'drizzle-orm/pg-core';
-
 export const usersToGroups = pgTable('users_to_groups', {
   userId: uuid('user_id').notNull().references(() => users.id),
   groupId: uuid('group_id').notNull().references(() => groups.id),
@@ -245,7 +237,6 @@ export const users = pgTable('users', {
   index('active_users_email_idx').on(table.email).where(sql`deleted_at IS NULL`),
 ]);
 
-import { isNull } from 'drizzle-orm';
 const activeUsers = await db.select().from(users).where(isNull(users.deletedAt));
 ```
 


### PR DESCRIPTION
## Summary

- Consolidate 5 scattered inline imports (`AnyPgColumn`, `isNull`, `arrayContains`, `arrayContained`, `arrayOverlaps`, `primaryKey`) into the top-level imports block
- Remove 3 duplicate `notNull`/`default`/`defaultNow` examples from Constraints section (identical patterns already shown in String Types and Date/Time Types sections)
- Result: 298 → 289 lines, all technical content preserved

## Runtime Testing

- **Risk classification:** Low (docs/agent prompt only, no code execution)
- **Testing level:** self-assessed
- **Verification:** `wc -l` confirms 289 lines; full file review confirms no content loss

## Files Changed

- `.agents/services/database/postgres-drizzle-skill/schema.md` — removed redundant inline imports and duplicate constraint examples; imports block now canonical

Closes #11745