### PR TITLE
t11741: tighten distribution-youtube-pipeline.md (301→255 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -758,12 +758,12 @@
     },
     ".agents/services/payments/procurement.md": {
       "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
-      "at": "2026-03-28T09:39:19Z",
+      "at": "2026-03-28T09:48:49Z",
       "pr": 11713
     },
     ".agents/tools/build-agent/build-agent.md": {
       "hash": "4c52d5b08eba50130bce788693dd955886e1753d",
-      "at": "2026-03-28T09:39:20Z",
+      "at": "2026-03-28T09:48:51Z",
       "pr": 11723
     },
     ".agents/content/distribution-youtube-topic-research.md": {
@@ -773,7 +773,7 @@
     },
     ".agents/content/heygen-skill/rules-captions.md": {
       "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
-      "at": "2026-03-28T09:39:22Z",
+      "at": "2026-03-28T09:48:53Z",
       "pr": 11707
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
@@ -793,7 +793,7 @@
     },
     ".agents/services/database/postgres-drizzle-skill/relations.md": {
       "hash": "673a7c2abd65766f454b57e79a259a7217463210",
-      "at": "2026-03-28T09:39:26Z",
+      "at": "2026-03-28T09:48:57Z",
       "pr": 11717
     },
     ".agents/tools/build-mcp/server-patterns.md": {

--- a/.agents/content/distribution-youtube-pipeline.md
+++ b/.agents/content/distribution-youtube-pipeline.md
@@ -17,13 +17,6 @@ tools:
 
 Cron-driven autonomous pipeline for YouTube competitor research and content generation. Each phase runs as an isolated worker with fresh context, storing results in memory — solves context overflow by decomposing research into independent tasks.
 
-## When to Use
-
-- Automated daily/weekly competitor monitoring
-- Full research-to-script pipeline (autonomous or manual)
-- Cron job configuration for YouTube research
-- Pipeline debugging and monitoring
-
 ## Architecture
 
 ```text
@@ -133,8 +126,6 @@ Each worker receives these prompts via the supervisor:
 ### Worker 1: Channel Intel
 
 ```text
-You are a YouTube research worker. Your task is to scan competitor channels.
-
 1. Recall competitor list: memory-helper.sh recall --namespace youtube "Competitor"
 2. For each competitor:
    a. Run: youtube-helper.sh channel @handle json
@@ -151,8 +142,6 @@ You are a YouTube research worker. Your task is to scan competitor channels.
 ### Worker 2: Topic Research
 
 ```text
-You are a YouTube research worker. Your task is to find content opportunities.
-
 1. Recall intel data: memory-helper.sh recall --namespace youtube "Intel scan"
 2. Recall my channel topics: memory-helper.sh recall --namespace youtube "My channel"
 3. Extract topic clusters from competitor videos (group by title keywords)
@@ -170,8 +159,6 @@ You are a YouTube research worker. Your task is to find content opportunities.
 ### Worker 3: Script Generation
 
 ```text
-You are a YouTube script writer. Your task is to draft scripts for top opportunities.
-
 1. Recall opportunities: memory-helper.sh recall --namespace youtube-topics "Opportunity"
 2. Recall channel voice: memory-helper.sh recall --namespace youtube "Channel voice"
 3. Select top 3 opportunities by demand/competition ratio
@@ -187,8 +174,6 @@ You are a YouTube script writer. Your task is to draft scripts for top opportuni
 ### Worker 4: Optimization
 
 ```text
-You are a YouTube metadata optimizer. Your task is to generate titles, tags, and descriptions.
-
 1. Read draft scripts from: ~/.aidevops/.agent-workspace/work/youtube/scripts/
 2. For each script:
    a. Generate 5 title options with CTR signals
@@ -203,21 +188,17 @@ You are a YouTube metadata optimizer. Your task is to generate titles, tags, and
 ## Monitoring
 
 ```bash
-# Pipeline status
+# Pipeline status and quota
 supervisor-helper.sh dashboard --batch youtube-daily
 supervisor-helper.sh status youtube-daily
-
-# Reports and quota
-mail-helper.sh check
 youtube-helper.sh quota
+mail-helper.sh check
 
-# Recent results
+# View results
 memory-helper.sh recall --namespace youtube "Intel scan" --recent
 memory-helper.sh recall --namespace youtube-topics "Opportunity" --recent
-
-# Generated scripts and learned patterns
-ls ~/.aidevops/.agent-workspace/work/youtube/scripts/
 memory-helper.sh recall --namespace youtube-patterns --recent
+ls ~/.aidevops/.agent-workspace/work/youtube/scripts/
 ```
 
 ## Frequency Recommendations


### PR DESCRIPTION
## Summary

- Removed redundant `When to Use` section (restated the title)
- Collapsed verbose `Why This Solves Context Overflow` table into a single inline sentence
- Stripped boilerplate worker preambles ("You are a YouTube research worker. Your task is to...") — section headings already convey this
- Merged duplicate `Check Pipeline Status` + `View Results` monitoring subsections into one unified bash block
- Removed trivial prose ("This runs the pipeline every day at 6 AM.")

**Result:** 301 → 255 lines. All technical content preserved: architecture diagram, quota figures, all 4 worker prompts with full step-by-step instructions, all commands, troubleshooting table, workspace structure, frequency table, and related links.

## Verification

- `wc -l`: 255 (< 300 ✓)
- All code blocks, commands, task IDs, and worker instructions present before and after
- No broken internal links

Closes #11741