### PR TITLE
t11743: tighten server-patterns.md from 299 to 281 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -755,6 +755,66 @@
       "hash": "5642d959165b452f2c132f2d2ecdb7d484e06061",
       "at": "2026-03-28T09:17:43Z",
       "pr": 11716
+    },
+    ".agents/services/payments/procurement.md": {
+      "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
+      "at": "2026-03-28T09:48:49Z",
+      "pr": 11713
+    },
+    ".agents/tools/build-agent/build-agent.md": {
+      "hash": "4c52d5b08eba50130bce788693dd955886e1753d",
+      "at": "2026-03-28T09:48:51Z",
+      "pr": 11723
+    },
+    ".agents/content/distribution-youtube-topic-research.md": {
+      "hash": "5cad3eadce10ee33a862ef8040dc746457b7bf8a",
+      "at": "2026-03-28T09:48:52Z",
+      "pr": 11708
+    },
+    ".agents/content/heygen-skill/rules-captions.md": {
+      "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
+      "at": "2026-03-28T09:48:53Z",
+      "pr": 11707
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
+      "hash": "1679befdbb328a28617cb3e59957a033bba35409",
+      "at": "2026-03-28T09:48:55Z",
+      "pr": 11709
+    },
+    ".agents/services/database/postgres-drizzle-skill/schema.md": {
+      "hash": "99ebb3bdfd27856e94ed29c7851699d12739ef67",
+      "at": "2026-03-28T09:48:55Z",
+      "pr": 11709
+    },
+    ".agents/tools/ui/i18next.md": {
+      "hash": "ad0db76988832be07bb31badbcc1eb57283d0424",
+      "at": "2026-03-28T09:48:56Z",
+      "pr": 11710
+    },
+    ".agents/services/database/postgres-drizzle-skill/relations.md": {
+      "hash": "673a7c2abd65766f454b57e79a259a7217463210",
+      "at": "2026-03-28T09:48:57Z",
+      "pr": 11717
+    },
+    ".agents/tools/build-mcp/server-patterns.md": {
+      "hash": "5eb6823c314d82301636ec87d7ff3720480cea13",
+      "at": "2026-03-28T09:49:04Z",
+      "pr": 11679
+    },
+    ".agents/tools/git/worktrunk.md": {
+      "hash": "cd84573d4010381648d025eb355743bcf1396d87",
+      "at": "2026-03-28T09:49:05Z",
+      "pr": 11678
+    },
+    ".agents/content/distribution-youtube-pipeline.md": {
+      "hash": "de1a4b45ed69d1c248513eee27d35b778fd00045",
+      "at": "2026-03-28T09:49:07Z",
+      "pr": 11676
+    },
+    ".agents/content/heygen-skill/rules-video-generation.md": {
+      "hash": "e6c74b411a5ea6ce2e63aa71a20cbd312b695a3f",
+      "at": "2026-03-28T09:49:08Z",
+      "pr": 11675
     }
   }
 }

--- a/.agents/tools/build-mcp/server-patterns.md
+++ b/.agents/tools/build-mcp/server-patterns.md
@@ -250,7 +250,7 @@ server.tool('search_documents',
 );
 ```
 
-**Parameter descriptions** — include constraints and format:
+**Parameter descriptions** — include constraints, format, and use specific types:
 
 ```typescript
 // BAD
@@ -264,36 +264,18 @@ status: z.enum(['pending', 'active', 'completed']).describe('Filter by status')
 limit: z.number().min(1).max(100).optional().default(20).describe('Results per page (1-100, default: 20)')
 date: z.string().describe('Date in ISO 8601 format (YYYY-MM-DD)')
 user_id: z.string().uuid().describe('ID of the user who owns this resource')
-```
-
-**Use specific types** — validates at schema level:
-
-```typescript
 email: z.string().email().describe('User email address')
 url: z.string().url().describe('Webhook URL')
 count: z.number().int().positive().describe('Number of items')
 ```
 
-**Return structured JSON** (not unstructured text):
+**Return structured JSON** (not unstructured text). **Handle errors with `isError`** (don't throw — that crashes the tool call):
 
 ```typescript
 return { content: [{ type: 'text', text: JSON.stringify({ success: true, data: result }, null, 2) }] };
-```
 
-**Handle errors with `isError`** (don't throw — that crashes the tool call):
-
-```typescript
 return {
   content: [{ type: 'text', text: JSON.stringify({ error: true, code: 'NOT_FOUND', message: 'Item not found' }) }],
   isError: true,
 };
-```
-
-**Document side effects in description**:
-
-```typescript
-server.tool('get_user', 'Retrieves user details. Read-only operation.', { /* ... */ });
-server.tool('update_user', 'Updates user profile fields. Modifies the user record in the database.', { /* ... */ });
-server.tool('delete_user', 'Permanently deletes user and all data. IRREVERSIBLE. Requires confirmation.', { /* ... */ });
-server.tool('send_email', 'Sends an email to the specified recipient. Cannot be undone once sent.', { /* ... */ });
 ```


### PR DESCRIPTION
## Summary

- Removed redundant "Document side effects" block (duplicated `get_user`/`delete_user`/`send_email` examples already present in the bad/good tool descriptions section)
- Merged "Use specific types" into the parameter descriptions code block (same context, no separate section needed)
- Merged "Return structured JSON" and "Handle errors with `isError`" into a single section (two one-liners that belong together)

## Result

299 → 281 lines (6% reduction). All technical content, code examples, and rules preserved.

## Runtime Testing

- **Risk**: Low (docs-only change)
- **Testing level**: self-assessed
- **Behaviour verified**: file renders correctly, no broken code blocks

Closes #11743