### PR TITLE
GH#11779: simplification: tighten AI Orchestration overview doc

### DIFF
--- a/.agents/tools/ai-orchestration/overview.md
+++ b/.agents/tools/ai-orchestration/overview.md
@@ -70,15 +70,7 @@ git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-p
 | Agno | - | localhost:3000 | `pip install "agno[all]"` | `~/.aidevops/scripts/start-agno-stack.sh` |
 | OpenProse | 500+ | None (DSL) | `git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-prose` | AI session = VM |
 
-**Langflow**: Visual flow builder, exports to Python, LangChain ecosystem, MCP server support, desktop app.
-
-**CrewAI**: Role-playing agents, hierarchical task delegation, YAML config, event-driven Flows, 100k+ certified developers.
-
-**AutoGen**: Python + .NET, MCP integration, human-in-the-loop, AgentChat for prototyping, Core API for advanced control.
-
-**Agno**: Complete local processing (privacy), specialized DevOps agents, knowledge base support, production runtime.
-
-**OpenProse**: Zero dependencies (pattern, not framework). Explicit control flow (`parallel:`, `loop until`, `try/catch`), AI-evaluated conditions (`**the code is production ready**`), portable across Claude Code, OpenCode, Amp. Operates at the **workflow layer**, complementing DSPy (prompt optimization), TOON (context compression), and Context7/Augment (knowledge retrieval).
+**OpenProse** is zero-dependency (pattern, not framework): explicit control flow (`parallel:`, `loop until`, `try/catch`), AI-evaluated conditions (`**the code is production ready**`), portable across Claude Code, OpenCode, Amp. Operates at the **workflow layer**, complementing DSPy (prompt optimization), TOON (context compression), and Context7/Augment (knowledge retrieval).
 
 ## Common Patterns
 
@@ -92,11 +84,9 @@ git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-p
 └── start_{tool}.sh # Startup script
 ```
 
-**Helper scripts** at `.agents/scripts/{tool}-helper.sh`: `setup | start | stop | status | check | help`
-
-**Config templates** at `configs/{tool}-config.json.txt` (committed); working configs at `configs/{tool}-config.json` (gitignored).
-
-**Management scripts** created at `~/.aidevops/scripts/`: `start-{tool}-stack.sh`, `stop-{tool}-stack.sh`, `{tool}-status.sh`
+- **Helper scripts**: `.agents/scripts/{tool}-helper.sh` — `setup | start | stop | status | check | help`
+- **Config templates**: `configs/{tool}-config.json.txt` (committed); working: `configs/{tool}-config.json` (gitignored)
+- **Management scripts**: `~/.aidevops/scripts/` — `start-{tool}-stack.sh`, `stop-{tool}-stack.sh`, `{tool}-status.sh`
 
 ## Integration with aidevops
 
@@ -109,20 +99,13 @@ git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-p
 | AutoGen | Python/JSON | `agents/*.py`, `*.json` |
 | Agno | Python | `agent_os.py` |
 
-**Langflow JSON sync**:
-
-```bash
-langflow export --flow-id <id> --output flows/my-flow.json
-langflow import --file flows/my-flow.json
-```
+**Langflow JSON sync**: `langflow export --flow-id <id> --output flows/my-flow.json` / `langflow import --file flows/my-flow.json`
 
 **Local LLM (Ollama)**:
 
 ```bash
-curl -fsSL https://ollama.com/install.sh | sh
-ollama pull llama3.2
-# In .env:
-OLLAMA_BASE_URL=http://localhost:11434
+curl -fsSL https://ollama.com/install.sh | sh && ollama pull llama3.2
+# In .env: OLLAMA_BASE_URL=http://localhost:11434
 ```
 
 ## Related Documentation
@@ -145,19 +128,9 @@ OLLAMA_BASE_URL=http://localhost:11434
 ~/.aidevops/scripts/localhost-helper.sh find-port 7860
 ~/.aidevops/scripts/localhost-helper.sh list-ports
 ~/.aidevops/scripts/localhost-helper.sh kill-port 7860
-# Manual fallback:
-lsof -i :7860 && kill -9 $(lsof -t -i:7860)
+# Manual fallback: lsof -i :7860 && kill -9 $(lsof -t -i:7860)
 ```
 
-**Venv issues**:
+**Venv issues**: `rm -rf ~/.aidevops/{tool}/venv && bash .agents/scripts/{tool}-helper.sh setup`
 
-```bash
-rm -rf ~/.aidevops/{tool}/venv && bash .agents/scripts/{tool}-helper.sh setup
-```
-
-**API key errors**:
-
-```bash
-cat ~/.aidevops/{tool}/.env
-env | grep -E "(OPENAI|ANTHROPIC|OLLAMA)"
-```
+**API key errors**: `cat ~/.aidevops/{tool}/.env` or `env | grep -E "(OPENAI|ANTHROPIC|OLLAMA)"`


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/ai-orchestration/overview.md` from 163 → 136 lines (16% reduction)
- Remove redundant framework prose descriptions (Langflow/CrewAI/AutoGen/Agno bullets duplicated Decision Matrix content)
- Collapse single-command code blocks to inline lines (Langflow JSON sync, Ollama setup, venv/API key troubleshooting)
- Tighten Common Patterns bullet list formatting

## Classification

**Reference corpus** (framework comparison, decision matrix, tables) — not an instruction doc. File already serves as the slim index pointing to per-framework docs. Splitting further would add navigation overhead without benefit at this size.

## Verification

- All code blocks, URLs, command examples preserved
- All task ID references and institutional knowledge intact
- No broken internal links (Related Documentation table unchanged)
- OpenProse unique detail (workflow layer, DSPy/TOON/Context7 complementarity) preserved
- Agent behaviour unchanged — same decision matrix, same framework comparison

## Runtime Testing

- **Risk**: Low (docs-only change, no code)
- **Level**: self-assessed
- **Verification**: `wc -l` before=163, after=136; diff reviewed for content loss

Closes #11779