### PR TITLE
GH#11806: Tighten email sequence templates — remove redundancy

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
@@ -11,7 +11,7 @@
 
 ## Reusable Patterns
 
-### Pattern: Social Proof
+### Social Proof
 
 ```
 I want to introduce you to [Customer Name].
@@ -24,7 +24,7 @@ The key insight? [What made the difference]
 [CTA — soft or hard depending on sequence stage]
 ```
 
-### Pattern: Objection Handling (Q&A)
+### Objection Handling (Q&A)
 
 ```
 Here are the questions most people have:
@@ -35,7 +35,7 @@ Here are the questions most people have:
 [CTA]
 ```
 
-### Pattern: Urgency / Final Push
+### Urgency / Final Push
 
 ```
 [What's ending] disappear in [timeframe].
@@ -155,9 +155,11 @@ You're in! Fastest way to get value from [Product]:
 P.S. Your trial lasts [X] days. Let's make them count!
 ```
 
-### Email 2: Feature Highlight (Day 2)
+### Emails 2 & 5: Feature Highlight (Day 2, Day 10)
 
-**Subject:** Have you tried [Key Feature] yet?
+**Subject:** Have you tried [Key Feature] yet? / The [Feature] trick most users miss
+
+Send twice during trial — first for the core hook feature, second for a power-user feature most overlook.
 
 ```
 Most [Product] users say [Feature Name] is what hooked them.
@@ -166,6 +168,8 @@ Most [Product] users say [Feature Name] is what hooked them.
 Try it now: [Link directly to feature]
 Not sure how? 2-minute tutorial: [Video link]
 ```
+
+Email 5 variant: include step-by-step (3-4 steps) + screenshot for the power-user feature.
 
 ### Email 3: Social Proof (Day 4)
 
@@ -184,12 +188,6 @@ Things you might not have discovered yet:
 • [Missed feature]  • [Underutilized feature]  • [Pro tip]
 [Log in to [Product] →]
 ```
-
-### Email 5: Feature Highlight #2 (Day 10)
-
-**Subject:** The [Feature] trick most users miss
-
-Same structure as Email 2. Focus on a power-user feature most overlook. Include step-by-step (3-4 steps) + screenshot.
 
 ### Email 6: Trial Ending Soon (Day 12)
 


### PR DESCRIPTION
## Summary

- Merged SaaS Trial Emails 2 & 5 (Feature Highlight) into a single section — Email 5 was explicitly "Same structure as Email 2" with minor variant notes
- Removed redundant `Pattern: ` prefix from 3 reusable pattern headings (already under `## Reusable Patterns`)
- 300 → 298 lines (net -2). All template content, subject lines, code blocks preserved.

Closes #11806

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low — docs/agent prompt only, no code changes
- **Verification**: All 17 code block pairs intact, all 4 sequences preserved (Welcome 5, Cart 3, SaaS 7, Launch 7), subject line table unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified reusable pattern section headings for improved clarity and usability
  * Enhanced SaaS trial email sequence guidance with expanded feature highlight instructions spanning multiple campaign touchpoints, including additional subject line variant options, explicit send timing directives, and detailed step-by-step procedures with visual elements to support power-user feature positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->