### PR TITLE
GH#11828: Tighten landing page templates — move SOLUTION to Common Sections

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-templates-landing-page.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-landing-page.md
@@ -1,6 +1,6 @@
 # Landing Page Templates
 
-Copy-paste frameworks for different landing page types. Common Sections (Hero, Problem, Social Proof, Final CTA) appear once below — reference them from any template.
+Copy-paste frameworks for different landing page types. Common Sections appear once — reference from any template.
 
 ## Common Sections
 
@@ -22,6 +22,15 @@ You've tried:
 - [Solution 2] — but [why it fails]
 - [Solution 3] — but [why it fails]
 Meanwhile, [negative consequence escalates].
+```
+
+### SOLUTION
+
+```text
+Introducing [Product Name]
+The [category] that [key differentiator].
+Unlike [competitors], [Product] uses [unique approach] to [achieve result] without [common objection].
+[Screenshot or diagram]
 ```
 
 ### SOCIAL PROOF
@@ -60,15 +69,6 @@ Hero -> Problem -> Solution -> How It Works -> Features -> Social Proof -> Prici
 Trust: No credit card | Free [X] days | Cancel anytime
 Logos: Trusted by [X]+ [companies] including [Logo x5]
 [Product screenshot or demo video]
-```
-
-### SOLUTION
-
-```text
-Introducing [Product Name]
-The [category] that [key differentiator].
-Unlike [competitors], [Product] uses [unique approach] to [achieve result] without [common objection].
-[Screenshot or diagram]
 ```
 
 ### HOW IT WORKS
@@ -187,7 +187,6 @@ Module 2: [Name] — [What it covers] — Value: $[X]
 Bonuses (when you join today):
 BONUS #1: [Name] ($[X] value) — [Description]
 BONUS #2: [Name] ($[X] value) — [Description]
-(continue for all bonuses)
 Total Value: $[Big Number]
 Your Investment Today: $[Price] (or [X] payments of $[Y])
 ```
@@ -201,7 +200,7 @@ If you don't [achieve specific outcome] or you're not satisfied,
 email us within [X] days for a full refund. No questions asked.
 ```
 
-### FINAL CTA (sales-specific)
+### FINAL CTA
 
 ```text
 You Have Two Choices:


### PR DESCRIPTION
## Summary

- Moves the SOLUTION block from Template 1 into Common Sections (the canonical shared location), eliminating duplication with Template 3's similar block
- Removes redundant `(continue for all bonuses)` comment in the OFFER block (pattern is already established by the module lines above it)
- Tightens `### FINAL CTA (sales-specific)` heading — the qualifier is unnecessary given section context
- Tightens intro line prose (removes redundant enumeration of section names)

## What was preserved

All functional copy templates, placeholders, structural flow lines, and the Quick Substitution Guide are intact. No content loss — structural reorganisation only.

## Runtime Testing

- **Risk classification:** Low (docs/agent prompt file, no code)
- **Testing level:** self-assessed
- **Verification:** `wc -l` before (241) and after (240); `git diff` reviewed for content preservation

## Files changed

- `.agents/marketing-sales/direct-response-copy-templates-landing-page.md` — structural tightening

Closes #11828