### PR TITLE
11829: tighten mission-email.md from 279 to 213 lines

### DIFF
--- a/.agents/services/email/mission-email.md
+++ b/.agents/services/email/mission-email.md
@@ -27,8 +27,6 @@ tools:
 
 ## When to Use
 
-Missions that involve:
-
 - **Signing up for services** (API providers, SaaS platforms, cloud services)
 - **Requesting API access** (developer programs, partner APIs)
 - **Communicating with vendors** (support tickets, billing inquiries)
@@ -43,10 +41,7 @@ Mission Orchestrator
     v
 mission-email-helper.sh
     |
-    +-- send ---------> SES (aws ses send-raw-email)
-    |                       |
-    |                       v
-    |                   Recipient inbox
+    +-- send ---------> SES (aws ses send-raw-email) --> Recipient inbox
     |
     +-- receive <------- S3 bucket (SES receipt rule)
     |       |
@@ -59,34 +54,13 @@ mission-email-helper.sh
     +-- templates ----> templates/email/*.txt
 ```
 
-### Receiving Email
+**Receive setup:** SES receipt rule → S3; S3 accessible with same AWS credentials; domain MX records pointing to SES.
 
-SES can store inbound emails in S3 via receipt rules. The `receive` command polls an S3 bucket, downloads raw `.eml` files, parses them, matches them to conversation threads, and extracts verification codes.
+**Thread matching priority:** (1) `In-Reply-To` header matching a previous SES Message-ID, (2) sender email matching thread's counterparty, (3) new thread created if no match.
 
-**Setup requirements:**
+**Thread fields:** `thread_id` (e.g., `thr-20260228-143022-a1b2c3d4`), `mission_id`, `counterparty`, `status` (`active` | `waiting` | `resolved` | `abandoned`).
 
-1. SES receipt rule configured to store emails in S3
-2. S3 bucket accessible with the same AWS credentials as the SES account
-3. Domain MX records pointing to SES for the receiving domain
-
-### Conversation Threading
-
-Every email exchange is tracked as a **thread** in the SQLite database:
-
-- **Thread ID**: Unique identifier (e.g., `thr-20260228-143022-a1b2c3d4`)
-- **Mission ID**: Links the thread to a specific mission
-- **Counterparty**: The external email address we're communicating with
-- **Status**: `active` | `waiting` | `resolved` | `abandoned`
-
-Inbound emails are matched to threads by:
-
-1. `In-Reply-To` header matching a previous SES Message-ID
-2. Sender email matching a thread's counterparty
-3. If no match, a new thread is created
-
-### Verification Code Extraction
-
-The `extract-code` command and automatic extraction on `receive` detect:
+**Verification code extraction** (auto on `receive`, or via `extract-code`):
 
 | Pattern | Example | Type |
 |---------|---------|------|
@@ -95,14 +69,12 @@ The `extract-code` command and automatic extraction on `receive` detect:
 | Verification URLs | `https://example.com/verify?token=abc` | `verification_url` |
 | Temporary passwords | `Temporary password: Xk9#mP2q` | `temporary_password` |
 
-Extracted codes are stored in the database and can be retrieved by thread or message.
-
 ## Usage
 
-### Sending Email
+### Send
 
 ```bash
-# Send using a template
+# Template send
 mission-email-helper.sh send \
   --account production \
   --from noreply@yourdomain.com \
@@ -113,7 +85,7 @@ mission-email-helper.sh send \
   --var USE_CASE="Automated integration" \
   --var SENDER_NAME="John Smith"
 
-# Send plain text
+# Plain text (with thread)
 mission-email-helper.sh send \
   --account production \
   --from noreply@yourdomain.com \
@@ -123,15 +95,12 @@ mission-email-helper.sh send \
   --thread-id thr-20260228-143022-a1b2c3d4
 ```
 
-### Receiving Email
+### Receive
 
 ```bash
-# Poll S3 for new emails
-mission-email-helper.sh receive \
-  --account production \
-  --mailbox my-ses-bucket/inbound
+mission-email-helper.sh receive --account production --mailbox my-ses-bucket/inbound
 
-# Only process recent emails for a specific thread
+# Filter by thread and date
 mission-email-helper.sh receive \
   --account production \
   --mailbox my-ses-bucket/inbound \
@@ -139,54 +108,38 @@ mission-email-helper.sh receive \
   --thread-id thr-20260228-143022-a1b2c3d4
 ```
 
-### Parsing and Code Extraction
+### Parse and Extract
 
 ```bash
-# Parse a raw email file
 mission-email-helper.sh parse /path/to/email.eml
-
-# Parse from stdin
 cat email.eml | mission-email-helper.sh parse -
-
-# Extract verification codes from text
 echo "Your verification code is 847291" | mission-email-helper.sh extract-code -
-
-# Extract from a file
 mission-email-helper.sh extract-code /path/to/email-body.txt
 ```
 
 ### Thread Management
 
 ```bash
-# Create a thread before starting communication
 mission-email-helper.sh thread --create \
   --mission m001 \
   --subject "Stripe API Access" \
   --counterparty api-support@stripe.com \
   --context "Need API keys for payment processing integration"
 
-# List all threads for a mission
 mission-email-helper.sh thread --list --mission m001
-
-# View full conversation with extracted codes
 mission-email-helper.sh thread --show thr-20260228-143022-a1b2c3d4
 ```
 
 ### Templates
 
 ```bash
-# List available templates
 mission-email-helper.sh templates --list
-
-# View a template
 mission-email-helper.sh templates --show api-access-request
 ```
 
 ## Templates
 
-Templates live in `~/.aidevops/agents/templates/email/` as `.txt` files. They use `{{KEY}}` placeholders.
-
-### Built-in Templates
+Location: `~/.aidevops/agents/templates/email/*.txt`. Placeholders: `{{KEY}}`, replaced by `--var KEY=value`.
 
 | Template | Purpose |
 |----------|---------|
@@ -196,9 +149,7 @@ Templates live in `~/.aidevops/agents/templates/email/` as `.txt` files. They us
 | `support-inquiry` | Technical support or billing questions |
 | `generic` | Minimal template for custom messages |
 
-### Creating Custom Templates
-
-Create a `.txt` file in the templates directory:
+Custom template format — first `#` line is the description:
 
 ```text
 # Template Description - shown in template list
@@ -210,21 +161,11 @@ Best regards,
 {{SENDER_NAME}}
 ```
 
-The first line (starting with `#`) is the template description. All `{{KEY}}` placeholders are replaced by `--var KEY=value` arguments.
-
 ## Mission Integration
 
-### In Mission State File
-
-Record email threads in the mission's Resources table:
+Record threads in the mission state file:
 
 ```markdown
-### Accounts & Credentials
-
-| Service | Purpose | Status | Secret Key |
-|---------|---------|--------|------------|
-| Stripe | Payment processing | waiting | gopass:aidevops/stripe/api-key |
-
 ### External Dependencies
 
 | Dependency | Type | Status | Notes |
@@ -232,43 +173,36 @@ Record email threads in the mission's Resources table:
 | Stripe API access | api | pending | Thread: thr-20260228-143022-a1b2c3d4 |
 ```
 
-### Orchestrator Workflow
+**Orchestrator workflow:**
 
-1. **Create thread**: Before first contact, create a thread linked to the mission
-2. **Send email**: Use appropriate template with mission context
-3. **Poll for responses**: Periodically run `receive` to check for replies
-4. **Extract codes**: Verification codes are auto-extracted and stored
-5. **Use credentials**: Pass extracted codes/tokens to `credential-helper.sh`
-6. **Update thread status**: Mark as `resolved` when communication is complete
+1. **Create thread** before first contact
+2. **Send email** using appropriate template
+3. **Poll for responses** with `receive`
+4. **Extract codes** — auto-extracted and stored in DB
+5. **Hand off credentials** to `credential-helper.sh`
+6. **Mark thread** `resolved` when complete
 
-### Credential Handoff
-
-When a verification code or API key is extracted from an email:
+**Credential handoff:**
 
 ```bash
-# Get the latest unused code from a thread
 code=$(sqlite3 ~/.aidevops/.agent-workspace/mail/mission-email.db \
   "SELECT ec.code_value FROM extracted_codes ec
    JOIN messages m ON ec.message_id = m.id
    WHERE m.thread_id = 'thr-xxx' AND ec.used = 0
    ORDER BY ec.extracted_at DESC LIMIT 1;")
 
-# Store in credential management
 aidevops secret set VENDOR_API_KEY  # user enters the value
 
-# Mark code as used
 sqlite3 ~/.aidevops/.agent-workspace/mail/mission-email.db \
-  "UPDATE extracted_codes SET used = 1
-   WHERE code_value = '$code';"
+  "UPDATE extracted_codes SET used = 1 WHERE code_value = '$code';"
 ```
 
 ## Security
 
-- Email credentials are managed through `ses-config.json` (same as `ses-helper.sh`)
-- Extracted codes and tokens are stored in the local SQLite database only
-- The database file permissions should be 600 (owner read/write only)
-- Never log or output full API keys or passwords in verbose mode
-- Thread context may contain sensitive information -- treat the database as confidential
+- Credentials managed via `ses-config.json` (same as `ses-helper.sh`)
+- Extracted codes stored in local SQLite only — database permissions must be 600
+- Never log full API keys or passwords in verbose mode
+- Thread context is sensitive — treat the database as confidential
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Reduced `.agents/services/email/mission-email.md` from 279 to 213 lines (24% reduction)
- Removed filler prose and redundant introductory sentences
- Collapsed verbose Architecture sub-sections into inline bold labels
- Condensed code block comments; merged single-command examples to one line
- Removed duplicate "Accounts & Credentials" example table (redundant with External Dependencies table)
- All commands, code blocks, tables, URLs, and operational rules preserved

## Runtime Testing

- **Risk classification**: Low (docs-only change, no code)
- **Testing level**: self-assessed
- **Behaviour verified**: diff reviewed — no functional content removed

## Files Changed

- `.agents/services/email/mission-email.md` — tightened from 279 to 213 lines

Closes #11829