### PR TITLE
GH#11865: Tighten pglite-local-first.md from 273 to 233 lines

### DIFF
--- a/.agents/tools/database/pglite-local-first.md
+++ b/.agents/tools/database/pglite-local-first.md
@@ -27,15 +27,15 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Decision Guide: PGlite vs SQLite
+## When to Use PGlite
 
 ```text
 Is your production DB PostgreSQL?
   NO  --> Use SQLite (better-sqlite3 / bun:sqlite)
-  YES --> Are you using Drizzle pg-core schemas (pgTable, pgEnum, timestamp)?
+  YES --> Using Drizzle pg-core schemas (pgTable, pgEnum, timestamp)?
     NO  --> Either works; SQLite is simpler
-    YES --> Is the target Electron, Tauri, or browser extension?
-      NO (React Native)  --> SQLite + PowerSync (WASM not supported in RN)
+    YES --> Target is Electron, Tauri, or browser extension?
+      NO (React Native)  --> SQLite + PowerSync (WASM unsupported in RN)
       YES --> PGlite (shared schema, zero translation layer)
 ```
 
@@ -43,22 +43,25 @@ Is your production DB PostgreSQL?
 
 | Factor | PGlite | SQLite |
 |--------|--------|--------|
-| Schema sharing | Same `pgTable` / `pgEnum` / `timestamp` | Requires separate `sqliteTable` schema |
+| Schema sharing | Same `pgTable`/`pgEnum`/`timestamp` | Requires separate `sqliteTable` schema |
 | Migrations | Identical SQL for local and production | Separate migration sets per dialect |
 | Drizzle dialect | `drizzle-orm/pglite` (pg-core) | `drizzle-orm/better-sqlite3` (sqlite-core) |
-| Type fidelity | Full: enums, timestamps, booleans | Lossy: enum→text, timestamp→text, boolean→integer |
-| ORM code reuse | 100% — same queries work everywhere | Separate query layer per dialect |
-| Performance | ~3-5x slower (WASM) | Native speed |
+| Type fidelity | Full: enums, timestamps, booleans | Lossy: enum->text, timestamp->text, boolean->integer |
+| ORM code reuse | 100% — same queries everywhere | Separate query layer per dialect |
+| Cold startup | 500ms-2s | <50ms |
+| SELECT by PK | ~0.5ms | ~0.1ms |
+| Complex JOIN | ~15ms | ~5ms |
+| Full scan | ~80ms | ~20ms |
+| INSERT throughput | ~5k/sec | ~50k/sec |
 | Bundle size | +3MB gzipped | ~1MB native addon |
-| Startup time | 500ms-2s | <50ms |
 
-Maintaining two Drizzle dialects means duplicate schemas, separate migrations, type mapping bugs, and divergent query logic. PGlite eliminates all of this when production is Postgres.
+PGlite is 3-10x slower than native SQLite — acceptable for desktop/extension CRUD, not for high-throughput ingestion or real-time analytics. Benchmarks on Apple Silicon, 100k rows.
 
 ## Implementation Pattern
 
 ### 1. Drizzle adapter swap (one schema, two runtimes)
 
-Your `@workspace/db` package exports schema and a factory; each runtime provides its own client. Add `"./local": "./src/local.ts"` and `"./schema": "./src/schema/index.ts"` to `package.json` exports.
+Export schema and a factory from `@workspace/db`; each runtime provides its own client. Add `"./local"` and `"./schema"` to `package.json` exports.
 
 ```typescript
 // packages/db/src/schema/index.ts (SHARED - no changes needed)
@@ -96,7 +99,7 @@ export async function createLocalDb(dataDir: string) {
 
 ### 2. Electron integration
 
-Run PGlite in the main process. **Security**: never expose raw SQL over IPC — a compromised renderer (XSS) could escalate to full DB access. Expose named operations only.
+Run PGlite in the main process. **Security**: never expose raw SQL over IPC — a compromised renderer could escalate to full DB access. Expose named operations only.
 
 ```typescript
 // apps/desktop/src/main/database.ts
@@ -111,14 +114,12 @@ let db: Awaited<ReturnType<typeof createLocalDb>>;
 
 export async function initDatabase() {
   db = await createLocalDb(path.join(app.getPath("userData"), "pgdata"));
-
-  // __dirname is unreliable in asar archives — bundle migrations as extraResources
+  // __dirname unreliable in asar — bundle migrations as extraResources
   await migrate(db, {
     migrationsFolder: app.isPackaged
       ? path.join(process.resourcesPath, "migrations")
       : path.join(app.getAppPath(), "packages/db/migrations"),
   });
-
   ipcMain.handle("db:items:list", async () => db.select().from(schema.items));
   ipcMain.handle("db:items:get", async (_event, id: string) =>
     db.select().from(schema.items).where(eq(schema.items.id, id))
@@ -138,7 +139,7 @@ export const items = {
 
 ### 3. Browser extension (WXT / Manifest V3)
 
-PGlite runs in the service worker or offscreen document with IndexedDB persistence. Use a lazy singleton to avoid re-initialising on every message.
+Runs in service worker or offscreen document with IndexedDB persistence. Wrap in a lazy singleton to avoid re-init on every message:
 
 ```typescript
 // apps/extension/src/background/database.ts
@@ -159,24 +160,11 @@ export async function getDb() {
 
 ### 4. Tauri integration
 
-PGlite runs in the webview's JS context. Use `appDataDir()` for filesystem persistence.
-
-```typescript
-import { PGlite } from "@electric-sql/pglite";
-import { drizzle } from "drizzle-orm/pglite";
-import { appDataDir } from "@tauri-apps/api/path";
-import * as schema from "@workspace/db/schema";
-
-export async function createLocalDb() {
-  const client = new PGlite(`${await appDataDir()}/pgdata`);
-  await client.waitReady;
-  return drizzle({ client, schema, casing: "snake_case" });
-}
-```
+Same `createLocalDb` pattern — use `appDataDir()` from `@tauri-apps/api/path` for filesystem persistence: `new PGlite(\`${await appDataDir()}/pgdata\`)`.
 
 ## Sync with Production Postgres
 
-**Write-through-API pattern (recommended)**: PGlite is a local read cache. Reads hit PGlite; writes go through your API (Hono, tRPC) to production Postgres; ElectricSQL syncs changes back down via logical replication.
+**Write-through-API pattern (recommended)**: PGlite is a local read cache. Reads hit PGlite; writes go through your API to production Postgres; ElectricSQL syncs changes back via logical replication.
 
 ```typescript
 import { PGlite } from "@electric-sql/pglite";
@@ -190,19 +178,11 @@ await client.electric.syncShapeToTable({
 });
 ```
 
-**ElectricSQL v1 limitations**: pull-only (writes require API calls), requires Postgres logical replication, self-hosting needs Docker, large initial shape loads can be slow.
+**ElectricSQL v1 limitations**: pull-only (writes require API), requires Postgres logical replication, self-hosting needs Docker, large initial shape loads can be slow. For apps without server sync, PGlite works standalone.
 
-For apps that don't need server sync, PGlite works standalone — no ElectricSQL needed.
+## Persistence and Extensions
 
-## Persistence Options
-
-| Backend | Use case | Config |
-|---------|----------|--------|
-| In-memory | Tests, ephemeral | `new PGlite()` |
-| Filesystem | Electron, Tauri, Node | `new PGlite("./path/to/pgdata")` |
-| IndexedDB | Browser extension, PWA | `new PGlite("idb://db-name")` |
-
-## Extensions
+**Persistence**: in-memory `new PGlite()` (tests), filesystem `new PGlite("./path")` (Electron/Tauri/Node), IndexedDB `new PGlite("idb://name")` (extension/PWA).
 
 ```typescript
 import { PGlite } from "@electric-sql/pglite";
@@ -215,38 +195,18 @@ await db.exec(`CREATE TABLE embeddings (id TEXT PRIMARY KEY, content TEXT, embed
 
 Supported: pgvector, pg_trgm, ltree, hstore, uuid-ossp. Full list: https://pglite.dev/extensions/
 
-## Platform Compatibility
+## Platform Compatibility and Gotchas
 
-| Platform | Runtime | Works? | Persistence | Notes |
-|----------|---------|--------|-------------|-------|
-| Electron (main) | Node.js | Yes | Filesystem | Recommended: run in main process |
-| Electron (renderer) | Chromium | Yes | IndexedDB | Use multi-tab worker for shared access |
-| Tauri (webview) | WebView | Yes | Filesystem via Tauri API | |
-| Browser extension (MV3) | Service worker | Yes | IndexedDB | Use offscreen doc for heavy queries |
-| React Native / Expo | Hermes/JSC | No | N/A | WASM unsupported; use SQLite + PowerSync |
-| Node.js / Bun | Server | Yes | Filesystem | Useful for local dev without Docker Postgres |
-| Deno | Server | Yes | Filesystem | |
+| Platform | Runtime | Persistence | Notes |
+|----------|---------|-------------|-------|
+| Electron (main) | Node.js | Filesystem | Recommended; requires Electron 28+ for SharedArrayBuffer |
+| Electron (renderer) | Chromium | IndexedDB | Use multi-tab worker for shared access |
+| Tauri (webview) | WebView | Filesystem via Tauri API | |
+| Browser extension (MV3) | Service worker | IndexedDB | Use offscreen doc for heavy queries |
+| React Native / Expo | Hermes/JSC | **Not supported** | WASM unsupported; use SQLite + PowerSync |
+| Node.js / Bun / Deno | Server | Filesystem | Local dev without Docker Postgres |
 
-## Performance (Apple Silicon, 100k rows)
-
-| Operation | PGlite (WASM) | better-sqlite3 (native) |
-|-----------|---------------|------------------------|
-| SELECT by PK | ~0.5ms | ~0.1ms |
-| Complex JOIN | ~15ms | ~5ms |
-| Full scan | ~80ms | ~20ms |
-| INSERT throughput | ~5k/sec | ~50k/sec |
-| Cold startup | 500ms-2s | <50ms |
-
-PGlite is 3-10x slower than native SQLite — acceptable for desktop/extension CRUD, not suitable for high-throughput ingestion or real-time analytics.
-
-## Gotchas
-
-1. **Single connection only** — no concurrent writers. Use a mutex or message queue for multiple renderer windows.
-2. **WASM startup latency** — show a loading state; don't block app launch on DB init.
-3. **Electron version** — requires Electron 28+ for reliable WASM SharedArrayBuffer support.
-4. **Bundle size** — WASM binary adds ~3MB gzipped.
-5. **Extension support** — check https://pglite.dev/extensions/ before assuming production extensions work locally.
-6. **No `LISTEN/NOTIFY`** — use PGlite's live query API instead for reactivity.
+**Gotchas**: (1) Single connection — no concurrent writers; use mutex/message queue for multi-window. (2) WASM startup 500ms-2s — show loading state, don't block app launch. (3) Bundle +3MB gzipped. (4) Check https://pglite.dev/extensions/ before assuming production extension parity. (5) No `LISTEN/NOTIFY` — use live query API instead (see below).
 
 ## Live Queries
 
@@ -265,9 +225,9 @@ const { unsubscribe } = await client.live.query(
 
 ## Related
 
-- **Vector search**: `tools/database/vector-search.md` — decision guide including PGlite+pgvector for local-first vector search
-- **SQLite (aidevops internals)**: `reference/memory.md` — SQLite FTS5 for cross-session memory
-- **Multi-org isolation**: `services/database/multi-org-isolation.md` — tenant isolation schema for server-side Postgres
-- **PowerSync**: https://www.powersync.com — SQLite sync with Postgres (better for React Native)
-- **ElectricSQL**: https://electric-sql.com — Postgres sync engine (works with PGlite)
-- **TanStack DB**: https://tanstack.com/db — Reactive client store (pairs with Electric)
+- `tools/database/vector-search.md` — PGlite+pgvector for local-first vector search
+- `reference/memory.md` — SQLite FTS5 for cross-session memory
+- `services/database/multi-org-isolation.md` — tenant isolation for server-side Postgres
+- [PowerSync](https://www.powersync.com) — SQLite sync with Postgres (React Native)
+- [ElectricSQL](https://electric-sql.com) — Postgres sync engine (works with PGlite)
+- [TanStack DB](https://tanstack.com/db) — Reactive client store (pairs with Electric)


### PR DESCRIPTION
## Summary

- Tightens `.agents/tools/database/pglite-local-first.md` from 273 to 233 lines (-15%, -40 lines)
- Merges standalone Performance section into the Decision Guide comparison table (single reference point)
- Merges Platform Compatibility and Gotchas into one section, collapses Persistence Options inline
- Collapses Tauri code block to inline reference (identical pattern to `createLocalDb`)
- Compresses prose around code blocks without removing any knowledge

Closes #11865

## What was preserved

- All 10 code blocks (1 removed was duplicate Tauri pattern — knowledge kept inline)
- All 7 URLs
- All key terms: SharedArrayBuffer, Electron 28+, LISTEN/NOTIFY, pgvector, PowerSync, ElectricSQL, etc.
- Security warning about raw SQL over IPC
- Decision tree, comparison table, gotchas, live queries

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs-only change, no code)
- **Verification**: markdownlint-cli2 — 0 errors. All URLs, code blocks, and key knowledge terms verified present via automated checks.