### PR TITLE
t11850: tighten ad-creative-copywriting.md (292 -> 277 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -950,6 +950,51 @@
       "hash": "ae6964334f78f335903d2ac453388735b2014756",
       "at": "2026-03-28T12:19:15Z",
       "pr": 11839
+    },
+    ".agents/tools/browser/crawl4ai-resources.md": {
+      "hash": "0dfcf5f7dccd4fb6230ff9c86571aebc7cb832e6",
+      "at": "2026-03-28T13:00:57Z",
+      "pr": 11858
+    },
+    ".agents/tools/build-mcp/build-mcp.md": {
+      "hash": "011bbdb6bb11427a0d8b27c195a96427f89db225",
+      "at": "2026-03-28T13:00:58Z",
+      "pr": 11844
+    },
+    ".agents/tools/deployment/daytona.md": {
+      "hash": "dba4e71b1e6c5b109b764b115a0e6edd2986f1dd",
+      "at": "2026-03-28T13:00:59Z",
+      "pr": 11846
+    },
+    ".agents/tools/ocr/ocr-research.md": {
+      "hash": "550b3d759426dae22ed192810a85c2f13d8c332f",
+      "at": "2026-03-28T13:01:01Z",
+      "pr": 11857
+    },
+    ".agents/seo/contentking.md": {
+      "hash": "72687052121c77b1fa4af4b5300f11291826b3a3",
+      "at": "2026-03-28T13:01:02Z",
+      "pr": 11845
+    },
+    ".agents/services/email/mission-email.md": {
+      "hash": "a159479f3a7a89fd7a455085507a2a97ccc5d7e9",
+      "at": "2026-03-28T13:01:05Z",
+      "pr": 11842
+    },
+    ".agents/tools/mobile/app-store-connect.md": {
+      "hash": "177ca90c1c84ad979fa2e77e9ac4cc4b14cce9b3",
+      "at": "2026-03-28T13:01:10Z",
+      "pr": 11830
+    },
+    ".agents/tools/browser/stagehand-examples.md": {
+      "hash": "f557a876737b6ab698fa5dcf1d43b98305418786",
+      "at": "2026-03-28T13:01:11Z",
+      "pr": 11838
+    },
+    ".agents/tools/ui/wxt.md": {
+      "hash": "33b6cdd803bd3f494efeed8385a62516279d0707",
+      "at": "2026-03-28T13:01:12Z",
+      "pr": 11870
     }
   }
 }

--- a/.agents/marketing-sales/ad-creative-copywriting.md
+++ b/.agents/marketing-sales/ad-creative-copywriting.md
@@ -228,8 +228,7 @@ Good: "See which leads are ready to buy. Connect your entire tech stack. Make de
 
 Test: primary vs secondary benefit, question vs statement, long vs short, with/without numbers, personal vs impersonal, generic vs specific.
 
-Winning traits: specific (numbers, names), clear, relevant (matches pain/desire), urgent, beneficial.
-Avoid: vague, too clever (pun over clarity), too long, brand-focused, no differentiation.
+Winning traits: specific (numbers, names), clear, relevant (matches pain/desire), urgent, beneficial. Avoid: vague, too clever (pun over clarity), too long, brand-focused, no differentiation.
 
 ---
 
@@ -256,26 +255,12 @@ Voice stays constant; tone adapts per platform: LinkedIn (B2B) = formal, feature
 ### Brand Voice Guide Template
 
 ```text
-1. VOICE OVERVIEW
-   We are: [3-5 adjectives]  |  We are NOT: [3-5 adjectives]
-
-2. PERSONALITY TRAITS
-   [Trait]: Sounds like [example] / Doesn't sound like [counter-example]
-
-3. VOCABULARY
-   Words we use: [list]  |  Words we avoid: [word] -> use [alternative]
-   Jargon policy: [use/avoid/explain]
-
-4. GRAMMAR & MECHANICS
-   Contractions: [Always/Sometimes/Never]  |  Sentence length: [Short/Medium/Long]
-   Exclamation points: [Frequent/Occasional/Rare]  |  Emoji: [Yes/No/Platform-specific]
-
-5. VOICE BY CONTEXT
-   Acquisition (cold): [tone]  |  Retargeting (warm): [tone]
-   Customer comms: [tone]  |  Social: [tone]
-
+1. VOICE OVERVIEW: We are [3-5 adjectives] | We are NOT [3-5 adjectives]
+2. PERSONALITY TRAITS: [Trait]: Sounds like [example] / Doesn't sound like [counter-example]
+3. VOCABULARY: Words we use [list] | Words we avoid [word] -> use [alternative] | Jargon policy [use/avoid/explain]
+4. GRAMMAR: Contractions [Always/Sometimes/Never] | Sentence length [Short/Medium/Long] | Exclamation points [Frequent/Occasional/Rare] | Emoji [Yes/No/Platform-specific]
+5. VOICE BY CONTEXT: Acquisition (cold) [tone] | Retargeting (warm) [tone] | Customer comms [tone] | Social [tone]
 6. EXAMPLES: 5-10 on-brand + off-brand with explanations
-
 7. CHECKLIST: Does this sound like [BRAND]? Appropriate for platform/audience?
 ```
 


### PR DESCRIPTION
## Summary

- Reduces `.agents/marketing-sales/ad-creative-copywriting.md` from 292 to 277 lines (5% reduction, below 280-line threshold)
- Compresses Brand Voice Guide Template code block (removes internal blank lines between numbered items)
- Merges Headline Testing two-line prose into single paragraph
- Regression fix: file grew back above threshold after PR #11823 (326→294)

## Content Preservation

- All 7 copywriting frameworks preserved with examples (PAS, AIDA, BAB, 4 Us, Star-Story-Solution, Extended BAB, Features→Benefits)
- All 102 headline templates preserved across 10 categories
- Brand Voice section fully preserved (dimensions, examples, guide template, mistakes table)
- No content removed — formatting only

## Runtime Testing

- **Testing level:** `self-assessed`
- **Risk classification:** Low (docs/agent prompts only)
- **Verification:** markdownlint: 0 errors. Line count: 277 (target: <280). Content audit: all 7 frameworks, 10 headline categories, 4 brand voice sections present.

Closes #11850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and reformatted internal copywriting guidance documentation for improved readability.

* **Chores**
  * Updated internal resource tracking configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->