### PR TITLE
11874: tighten wxt.md agent doc (214→205 lines)

### DIFF
--- a/.agents/tools/ui/wxt.md
+++ b/.agents/tools/ui/wxt.md
@@ -45,11 +45,13 @@ cd my-extension && npm install
 
 npm run dev              # Dev with HMR (Chrome)
 npm run dev:firefox      # Dev (Firefox)
-npm run build            # Production (Chrome MV3)
-npm run build:firefox    # Production (Firefox MV2/MV3)
-npm run zip              # Package for Chrome Web Store
-npm run zip:firefox      # Package for Firefox Add-ons
+npm run build            # Production → .output/chrome-mv3/
+npm run build:firefox    # Production → .output/firefox-mv2/
+npm run zip              # Package → .output/chrome-mv3.zip
+npm run zip:firefox      # Package → .output/firefox-mv2.zip
 ```
+
+Direct CLI: `wxt build -b edge` → `.output/edge-mv3/` | `wxt build -b safari` → `.output/safari-mv3/`
 
 ## Project Structure
 
@@ -92,7 +94,7 @@ export default defineConfig({
 
 ## Entrypoints
 
-Each entrypoint exports config via `defineBackground`, `defineContentScript`, etc.
+Auto-discovered from `entrypoints/`. Each exports config via `defineBackground`, `defineContentScript`, etc.
 
 ### Background (Service Worker)
 
@@ -190,18 +192,7 @@ export const { sendMessage, onMessage } = defineExtensionMessaging<ProtocolMap>(
 
 ## Cross-Browser
 
-WXT handles browser differences automatically: `browser` namespace (auto-polyfilled for Chrome), correct manifest format per browser, MV2/MV3 differences. Conditional code: `import.meta.env.BROWSER === 'firefox'`.
-
-## Build Commands
-
-| Command | Output |
-|---------|--------|
-| `wxt build` | `.output/chrome-mv3/` |
-| `wxt build -b firefox` | `.output/firefox-mv2/` |
-| `wxt build -b edge` | `.output/edge-mv3/` |
-| `wxt build -b safari` | `.output/safari-mv3/` |
-| `wxt zip` | `.output/chrome-mv3.zip` |
-| `wxt zip -b firefox` | `.output/firefox-mv2.zip` |
+`browser` namespace auto-polyfilled for Chrome; correct manifest format per browser; MV2/MV3 differences handled automatically. Conditional: `import.meta.env.BROWSER === 'firefox'`.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Merged redundant Build Commands table into Quick Start (output paths now inline as comments)
- Compressed Cross-Browser section from a paragraph to a single line
- Tightened Entrypoints intro prose (one word added, removes redundant sentence)
- All code blocks, URLs, command examples, and task/issue references preserved

## Classification

Reference corpus (code examples, command tables, API patterns) — no chapter split needed at 205 lines.

## Verification

- `wc -l`: 214 → 205 lines (net -9)
- All code blocks present: background, content script, shadow DOM UI, storage, messaging
- All URLs present: github.com/wxt-dev/wxt, wxt.dev
- All Related links intact
- Build output paths preserved (moved from table to inline comments)

## Runtime Testing

- **Level**: self-assessed
- **Risk**: low (docs-only change, no code execution)
- **Smoke check**: file reads correctly, no broken markdown structure

Closes #11874