### PR TITLE
t11883: tighten code-standards.md from 271 to 164 lines

### DIFF
--- a/.agents/tools/code-review/code-standards.md
+++ b/.agents/tools/code-review/code-standards.md
@@ -18,147 +18,78 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Reference documentation for code quality standards
-- **Platforms**: SonarCloud, CodeFactor, Codacy, ShellCheck
+- **Purpose**: Code quality standards reference — SonarCloud, CodeFactor, Codacy, ShellCheck
 - **Target**: A-grade across all platforms, zero critical violations
+- **Workflow**: Reference during development → validated by `linters-local.sh`
 
-**Critical Rules (Zero Tolerance)**:
-
-| Rule | Description | Pattern |
-|------|-------------|---------|
-| S7682 | Explicit return statements | `return 0` or `return 1` in every function |
-| S7679 | No direct positional params | `local param="$1"` not `$1` directly |
-| S1192 | Constants for repeated strings | `readonly MSG="text"` for 3+ uses |
-| S1481 | No unused variables | Remove or use declared variables |
-| ShellCheck | Zero violations | All scripts pass `shellcheck` |
-
-**Validation Commands**:
+**Validation**:
 
 ```bash
 ~/.aidevops/agents/scripts/linters-local.sh                              # all checks
-grep -L "return [01]" .agents/scripts/*.sh                               # S7682
-grep -n '\$[1-9]' .agents/scripts/*.sh | grep -v 'local.*=.*\$[1-9]'   # S7679
 find .agents/scripts/ -name "*.sh" -exec shellcheck {} \;               # ShellCheck
 npx markdownlint-cli2 "**/*.md" --ignore node_modules                   # Markdown
 ~/.aidevops/agents/scripts/secretlint-helper.sh scan                    # Secrets
 ```
 
-**Workflow Position**: Reference during development, validated by `/linters-local`
+**Quality scripts**: `linters-local.sh` (all checks), `quality-fix.sh` (auto-fix), `pre-commit-hook.sh` (git hook), `secretlint-helper.sh` (secret detection).
 
 <!-- AI-CONTEXT-END -->
 
 ## Critical Standards (Zero Tolerance)
 
-### S7682 - Return Statements
+| Rule | Requirement | Check |
+|------|-------------|-------|
+| S7682 | Explicit `return 0` or `return 1` in every function | `grep -L "return [01]" .agents/scripts/*.sh` |
+| S7679 | `local param="$1"` — never use `$1` directly | `grep -n '\$[1-9]' *.sh \| grep -v 'local.*=.*\$[1-9]'` |
+| S1192 | `readonly` constants for strings used 3+ times | Manual review |
+| S1481 | No unused variables — remove or use declared vars | Linter-detected |
+| ShellCheck | Zero violations on all `.sh` files | `shellcheck script.sh` |
 
-Every function MUST end with `return 0` or `return 1`.
+### S7682 + S7679 — Canonical Pattern
 
 ```bash
-# Correct
 function_name() {
     local param="$1"
+    local command="${1:-help}"
     # logic
     return 0
 }
 ```
 
-### S7679 - Positional Parameters
-
-Always assign positional params to locals first — never use `$1`/`$2` directly.
-
-```bash
-# Correct
-main() {
-    local command="${1:-help}"
-    local account_name="$2"
-    local target="$3"
-    case "$command" in
-        "list") list_items "$account_name" ;;
-    esac
-    return 0
-}
-```
-
-### S1192 - String Literals
-
-Define constants for strings used 3+ times.
+### S1192 — String Constants
 
 ```bash
 readonly ERROR_ACCOUNT_REQUIRED="Account name is required"
 print_error "$ERROR_ACCOUNT_REQUIRED"
 ```
 
-**Validation**:
+## Security Hotspots (SonarCloud Suppressions)
 
-```bash
-for file in .agents/scripts/*.sh; do
-    echo "=== $file ==="
-    grep -o '"[^"]*"' "$file" | sort | uniq -c | sort -nr | head -5
-done
-```
+SonarCloud flags these patterns. Acceptable when documented with `# SONAR:` comments.
 
-### S1481 - Unused Variables
-
-Only declare variables that are actually used.
-
-### ShellCheck Compliance
-
-```bash
-find .agents/scripts/ -name "*.sh" -exec shellcheck {} \;
-shellcheck script.sh  # single file
-```
-
-## Security Hotspots (Acceptable Patterns)
-
-SonarCloud flags these patterns. They are acceptable when documented with `# SONAR:` comments.
-
-### HTTP String Detection (S5332)
+| Pattern | Rule | When to suppress |
+|---------|------|-----------------|
+| HTTP string detection | S5332 | Detecting insecure URLs for audit, not using them |
+| Localhost HTTP output | S5332 | Local dev without SSL is intentional |
+| Curl pipe to bash | S4423 | Official installers (bun, nvm, rustup) from verified HTTPS |
 
 ```bash
 # SONAR: Detecting insecure URLs for security audit, not using them
 non_https=$(echo "$data" | jq '[.items[] | select(.url | startswith("http://"))] | length')
-```
 
-### Localhost HTTP Output (S5332)
-
-```bash
-if [[ "$ssl" == "true" ]]; then
-    print_info "Access your app at: https://$domain"
-else
-    # SONAR: Local dev without SSL is intentional
-    print_info "Access your app at: http://$domain"
-fi
-```
-
-### Curl Pipe to Bash (S4423)
-
-```bash
 # SONAR: Official Bun installer from verified HTTPS source
 curl -fsSL https://bun.sh/install | bash
-
-# Better for unknown sources — download and inspect first
-curl -fsSL https://example.com/install.sh -o /tmp/install.sh && less /tmp/install.sh && bash /tmp/install.sh
 ```
 
-**When to suppress vs fix:**
-
-- **Suppress**: Official installers (bun, nvm, rustup), localhost dev, URL detection
-- **Fix**: Actual HTTP usage in production, unverified installer sources
+**Fix** (don't suppress): actual HTTP in production, unverified installer sources. For unknown sources, download and inspect first: `curl -fsSL URL -o /tmp/install.sh && less /tmp/install.sh && bash /tmp/install.sh`.
 
 ## Platform Targets
 
-| Platform | Metric | Target |
-|----------|--------|--------|
-| SonarCloud | Quality Gate | Passed |
-| SonarCloud | Bugs / Vulnerabilities | 0 |
-| SonarCloud | Code Smells | <50 |
-| SonarCloud | Technical Debt | <400 min |
-| SonarCloud | Security / Reliability / Maintainability | A |
-| CodeFactor | Overall Grade | A |
-| CodeFactor | A-grade Files | >85% |
-| CodeFactor | Critical Issues | 0 |
-| Codacy | Grade | A |
-| Codacy | Security / Error Prone | 0 |
+| Platform | Target |
+|----------|--------|
+| SonarCloud | Quality Gate passed, 0 bugs/vulnerabilities, <50 code smells, <400 min debt, A on security/reliability/maintainability |
+| CodeFactor | A overall, >85% A-grade files, 0 critical issues |
+| Codacy | A grade, 0 security/error-prone issues |
 
 ## Markdown Standards
 
@@ -171,67 +102,36 @@ All markdown files must pass markdownlint with zero violations.
 | MD012 | No multiple consecutive blank lines |
 | MD031 | Blank lines before and after fenced code blocks |
 
-**Auto-fix**:
-
-```bash
-npx markdownlint-cli2 "**/*.md" --fix
-```
-
-## Quality Scripts
-
-| Script | Purpose |
-|--------|---------|
-| `linters-local.sh` | Run all local quality checks |
-| `quality-fix.sh` | Auto-fix common issues |
-| `pre-commit-hook.sh` | Git pre-commit validation |
-| `secretlint-helper.sh` | Secret detection |
+Auto-fix: `npx markdownlint-cli2 "**/*.md" --fix`
 
 ## Python Projects
 
-Worktree-specific failure modes differ from single-checkout development.
+Worktree-specific failure modes differ from single-checkout development. Gitignored artifacts (`.venv/`, `__pycache__/`, build dirs) exist only where created — they do not transfer between worktrees.
 
-### Worktrees and Virtual Environments
-
-Gitignored artifacts (`.venv/`, `__pycache__/`, build dirs) exist only where created — they do not transfer between worktrees.
+### Venvs in Worktrees
 
 | Situation | Correct action |
 |-----------|----------------|
-| Project has `.venv/` in canonical repo | Create fresh `.venv/` inside the worktree, or activate canonical venv by absolute path without running `pip install -e` from the worktree |
-| Project has `pyproject.toml` but no `.venv/` | `python3 -m venv .venv && pip install -e ".[dev]"` inside the worktree |
-| Verifying package install | Throwaway venv inside the worktree — never modify canonical repo's venv from a worktree |
+| Canonical repo has `.venv/` | Create fresh `.venv/` in worktree, or activate canonical venv by absolute path (never `pip install -e` from worktree) |
+| `pyproject.toml` but no `.venv/` | `python3 -m venv .venv && pip install -e ".[dev]"` inside worktree |
+| Verifying package install | Throwaway venv inside worktree — never modify canonical venv from a worktree |
 
-### Editable Installs in Worktrees
+### Editable Installs (.pth Hazard)
 
-`pip install -e` writes the worktree's absolute path into a `.pth` file. When the worktree is removed, that path breaks any code importing via the editable install.
+`pip install -e` writes the worktree's absolute path into a `.pth` file. When the worktree is removed, that path breaks imports.
+
+**Rule**: Never run `pip install -e` from a worktree using a venv outside the worktree. Always use a throwaway venv inside the worktree:
 
 ```bash
-# Unsafe — writes worktree path into canonical venv's .pth
-pip install -e shared/project/
-
-# Safe — throwaway venv inside the worktree
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e shared/project/
 ```
 
-**Rule**: Never run `pip install -e` from a worktree using a venv outside the worktree.
-
 ### Installation Scope
 
-Never install to user-local or system scope. Always use a project `.venv/`.
+Never install to user-local or system scope. Always use a project `.venv/`. Verify: `pip --version` must show a path inside the project's `.venv/`.
 
-```bash
-# Unsafe — packages go to ~/.local/lib/python3.x/
-pip install crawl4ai
-
-# Safe
-source .venv/bin/activate && pip install crawl4ai
-# or
-.venv/bin/pip install crawl4ai
-```
-
-Verify scope: `pip --version` must show a path inside the project's `.venv/`.
-
-### Requirements File Discipline
+### Requirements Discipline
 
 | File | When to use |
 |------|-------------|
@@ -239,18 +139,11 @@ Verify scope: `pip --version` must show a path inside the project's `.venv/`.
 | `requirements.txt` | Legacy projects or simple scripts |
 | `requirements-dev.txt` | Dev-only deps (pytest, mypy, ruff) |
 
-After installing any package:
-
-```bash
-pip install -e ".[dev]"          # pyproject.toml — no manual update needed
-pip freeze > requirements.txt    # requirements.txt — pin manually
-```
-
 **A venv that cannot be recreated from committed files is a defect.**
 
-### Project AGENTS.md — Development Environment Section
+### Project AGENTS.md — Dev Environment Section
 
-When a Python project lacks a "Development Environment" section, add one:
+When a Python project lacks a "Development Environment" section, add:
 
 ```markdown
 ## Development Environment


### PR DESCRIPTION
## Summary

- Tightens `.agents/tools/code-review/code-standards.md` from 271 → 164 lines (39% reduction)
- Removes redundancy while preserving all institutional knowledge (rule IDs, code examples, command references, platform targets, Python worktree rules)

### What changed

- **Quick Reference**: Removed duplicated rules table (same content repeated in Critical Standards section); absorbed Quality Scripts table
- **Critical Standards**: Merged S7682 + S7679 into one canonical code example; compressed S1481 to table-only (trivial rule)
- **Security Hotspots**: Replaced 3 verbose code examples with compact table + 1 combined example
- **Platform Targets**: Consolidated SonarCloud from 5 rows to 1 descriptive row
- **Python Projects**: Compressed from ~75 to ~50 lines — same rules, tighter prose, fewer redundant examples

### Verification

- All rule IDs preserved: S7682, S7679, S1192, S1481, S5332, S4423
- All platform names preserved: SonarCloud, CodeFactor, Codacy, ShellCheck, markdownlint, secretlint
- All script references preserved: linters-local, quality-fix, pre-commit-hook, secretlint-helper
- All Python knowledge preserved: .pth hazard, editable installs, venv discipline, requirements files
- All related doc links preserved
- Zero markdownlint violations

Closes #11883