### PR TITLE
GH#11882: tighten headline swipe file doc (272 -> 228 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -747,9 +747,9 @@
       "pr": 11712
     },
     ".agents/marketing-sales/meta-ads-campaigns-retargeting.md": {
-      "hash": "a9c426923d4e68ffcbda9632256e77e757a22e39",
-      "at": "2026-03-28T11:20:39Z",
-      "pr": 11746
+      "hash": "76a66a236cc7fbeb40d74384e9dbe4bd75a4a155",
+      "at": "2026-03-28T11:52:21Z",
+      "pr": 11822
     },
     ".agents/content/heygen-skill/rules-remotion-integration.md": {
       "hash": "5ccb546152546cd33344a76d42a4b90c0acd0dbd",
@@ -833,7 +833,7 @@
     },
     ".agents/aidevops/requirements.md": {
       "hash": "9a75f9e14252e2364ed8ceeb9e24e8df3a95e310",
-      "at": "2026-03-28T11:39:16Z",
+      "at": "2026-03-28T11:52:46Z",
       "pr": 11770
     },
     ".agents/tools/video/yt-dlp.md": {
@@ -913,7 +913,7 @@
     },
     ".agents/aidevops/supervisor-module-map.md": {
       "hash": "6dc1ff5f9d7243b29d768c024123338d11496a5f",
-      "at": "2026-03-28T11:39:04Z",
+      "at": "2026-03-28T11:52:24Z",
       "pr": 11811
     },
     ".agents/business/company-runners.md": {
@@ -987,9 +987,9 @@
       "pr": 11893
     },
     ".agents/tools/browser/stagehand-examples.md": {
-      "hash": "728f1064ad1de2bb36719a8a9a10d14369695cde",
-      "at": "2026-03-28T13:37:46Z",
-      "pr": 11838
+      "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
+      "at": "2026-03-28T13:57:03Z",
+      "pr": 11899
     },
     ".agents/tools/ui/wxt.md": {
       "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
@@ -997,8 +997,8 @@
       "pr": 11870
     },
     ".agents/tools/code-review/secretlint.md": {
-      "hash": "204aa2a11cbd3d6715a90b3bd867749e92e7472d",
-      "at": "2026-03-28T13:37:18Z",
+      "hash": "856b7ef872c17141c3c19db1c7f1f0d04a442cbe",
+      "at": "2026-03-28T13:57:08Z",
       "pr": 11879
     },
     ".agents/tools/database/pglite-local-first.md": {
@@ -1016,10 +1016,65 @@
       "at": "2026-03-28T13:38:47Z",
       "pr": 11771
     },
-    ".agents/workflows/code-audit-remote.md": {
-      "hash": "ee3d88acdee975bb4d937d27ee48e80f003016e1",
-      "at": "2026-03-28T11:39:16Z",
-      "pr": 11825
+    ".agents/scripts/commands/full-loop.md": {
+      "hash": "b5da86b3b8075f9e62573a4e2e135c70f527d1c6",
+      "at": "2026-03-28T13:57:05Z",
+      "pr": 11904
+    },
+    ".agents/workflows/pr.md": {
+      "hash": "2814eecb1a03db8967c46e83a046936cf3ecc5b5",
+      "at": "2026-03-28T13:57:06Z",
+      "pr": 11878
+    },
+    ".agents/tools/git/conflict-resolution.md": {
+      "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
+      "at": "2026-03-28T13:57:11Z",
+      "pr": 11909
+    },
+    ".agents/aidevops/configs.md": {
+      "hash": "fecc0e08b16083bdd8f7e82c6f1636c136af3287",
+      "at": "2026-03-28T13:57:12Z",
+      "pr": 11897
+    },
+    ".agents/services/communications/twilio.md": {
+      "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
+      "at": "2026-03-28T13:57:13Z",
+      "pr": 11900
+    },
+    ".agents/marketing-sales/ad-creative-platform-google.md": {
+      "hash": "99985395fdf504ae5562f8f46d2d17a14629c43f",
+      "at": "2026-03-28T13:57:14Z",
+      "pr": 11903
+    },
+    ".agents/tools/ai-assistants/openclaw.md": {
+      "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
+      "at": "2026-03-28T13:57:15Z",
+      "pr": 11901
+    },
+    ".agents/content/video-wavespeed.md": {
+      "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
+      "at": "2026-03-28T13:57:17Z",
+      "pr": 11895
+    },
+    ".agents/seo/debug-opengraph.md": {
+      "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
+      "at": "2026-03-28T13:57:18Z",
+      "pr": 11898
+    },
+    ".agents/aidevops/plugins.md": {
+      "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
+      "at": "2026-03-28T13:57:19Z",
+      "pr": 11894
+    },
+    ".agents/marketing-sales/ad-creative.md": {
+      "hash": "4ab10a843352fed5cff30fdb8055e0cb3a5b3e40",
+      "at": "2026-03-28T13:57:38Z",
+      "pr": 11902
+    },
+    ".agents/tools/mcp-toolkit/mcporter.md": {
+      "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
+      "at": "2026-03-28T13:57:39Z",
+      "pr": 11906
     }
   },
   ".agents/tools/code-review/best-practices.md": {

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-headlines.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-headlines.md
@@ -2,54 +2,32 @@
 
 50+ proven headlines with analysis of why they work.
 
----
-
 ## Classic Headlines (Timeless)
 
 ### 1. "At 60 Miles an Hour, the Loudest Noise in This New Rolls-Royce Comes from the Electric Clock"
 **— David Ogilvy for Rolls-Royce**
-
 Extreme specificity (60 mph), unexpected comparison (clock vs. engine), implies luxury without saying "luxury", creates a mental picture.
-
 **Template:** "At [specific situation], the [surprising element] in this [product] comes from [unexpected source]"
-
----
 
 ### 2. "They Laughed When I Sat Down at the Piano — But When I Started to Play..."
 **— John Caples for U.S. School of Music**
-
-Opens with social tension, creates curiosity about the resolution, reader identifies with underdog, transformation implied.
-
+Opens with social tension, creates curiosity about resolution, reader identifies with underdog, transformation implied.
 **Template:** "They [negative reaction] when I [action] — but when I [result]..."
-
----
 
 ### 3. "Do You Make These Mistakes in English?"
 **— Sherwin Cody for Language Course**
-
 Direct address ("You"), fear of looking foolish, curiosity about which mistakes, implies a solution.
-
 **Template:** "Do You Make These [topic] Mistakes?"
-
----
 
 ### 4. "The Lazy Man's Way to Riches"
 **— Joe Karbo**
-
 Speaks to desire for easy results, contradiction creates intrigue, targets aspirational outcome.
-
 **Template:** "The [Unlikely Approach] Way to [Desired Outcome]"
-
----
 
 ### 5. "How to Win Friends and Influence People"
 **— Dale Carnegie (book title)**
-
 Clear promise, two benefits in one headline, universal desire, "How to" signals practical value.
-
 **Template:** "How to [Benefit 1] and [Benefit 2]"
-
----
 
 ## SaaS Headlines (Modern)
 
@@ -73,8 +51,6 @@ Ambitious positioning, "infrastructure" = essential, appeals to builders.
 Two opposing ideas reconciled, speaks to team pain point, rhythmic.
 **Template:** "[Action]. [Preserve/Maintain something important]."
 
----
-
 ## Curiosity Headlines
 
 ### 11. "What Never to Eat on an Airplane"
@@ -96,8 +72,6 @@ Challenges authority, information asymmetry implied, reader becomes "insider".
 ### 15. "An Open Letter to Anyone Who's Ever Been Frustrated by [Problem]"
 "Open letter" = personal/intimate, self-qualifying audience, empathy first.
 **Template:** "An Open Letter to Anyone Who [Relatable Experience]"
-
----
 
 ## Problem Headlines
 
@@ -121,8 +95,6 @@ Curiosity about which mistakes, fear of looking foolish, number adds specificity
 Challenges conventional wisdom, reader wants to know what DOES work, provides solution.
 **Template:** "Why [Common Approach] Doesn't Work (And What to Do Instead)"
 
----
-
 ## Social Proof Headlines
 
 ### 21. "How I Made $15,000 in 30 Days with [Method]"
@@ -144,8 +116,6 @@ Authority figure, information asymmetry, desire to be like successful people.
 ### 25. "The [Method] That [Person/Company] Used to [Achieve Result]"
 Proven methodology, social proof, specific result, replicable implied.
 **Template:** "The [Method] That [Person/Company] Used to [Result]"
-
----
 
 ## Benefit Headlines
 
@@ -169,8 +139,6 @@ Acknowledges current pain, shows transformation, clear contrast.
 "Secret" = exclusive knowledge, challenges assumptions, creates curiosity gap.
 **Template:** "The Secret to [Outcome] (It's Not What You Think)"
 
----
-
 ## Urgency Headlines
 
 ### 31. "Last Chance: [Offer] Ends [Date]"
@@ -185,8 +153,6 @@ Positions reader mid-decision, implies important information, creates curiosity.
 Scarcity, specific number, urgency.
 **Template:** "Only [Number] [Things] Left"
 
----
-
 ## Question Headlines
 
 ### 34. "What Would You Do with [Desirable Resource]?"
@@ -200,8 +166,6 @@ Challenge to ego, curiosity about the answer, implies "yes, with help".
 ### 36. "Who Else Wants [Desirable Outcome]?"
 Social proof implied, self-qualifying, direct benefit stated.
 **Template:** "Who Else Wants [Outcome]?"
-
----
 
 ## How-To Headlines
 
@@ -221,52 +185,44 @@ Multiple options, specific number, immediate action ("Today").
 "Only" = definitive, "Ever need" = complete solution, reduces search.
 **Template:** "The Only Guide to [Topic] You'll Ever Need"
 
----
-
 ## Headlines for Jacky's Businesses
 
 ### BrowserBlast
 
 41. **"Stop Waiting for Google — Force Your Pages to Index in 24 Hours"**
-→ Clear benefit, specific timeframe, addresses frustration
+Clear benefit, specific timeframe, addresses frustration.
 
 42. **"The Indexing Secret 10,000 SEOs Don't Want You to Know"**
-→ Curiosity, social proof, insider knowledge
+Curiosity, social proof, insider knowledge.
 
 43. **"Why Your Content Marketing Is Failing (Hint: It's Not Indexed)"**
-→ Problem revelation, "aha" moment promised
+Problem revelation, "aha" moment promised.
 
 44. **"Finally: Predictable, Reliable Google Indexing"**
-→ Addresses randomness of current solutions
+Addresses randomness of current solutions.
 
 45. **"Is Your Best Content Invisible to Google?"**
-→ Fear-based question, self-qualifying
+Fear-based question, self-qualifying.
 
 ### LocalRank
 
 46. **"See Exactly Why You're Not Ranking on Google Maps"**
-→ Clear benefit, specific platform
+Clear benefit, specific platform.
 
 47. **"The Local SEO Dashboard That Proves Your Work is Working"**
-→ Addresses agency reporting pain point
+Addresses agency reporting pain point.
 
 48. **"Stop Guessing. Start Ranking."**
-→ Contrast, action-oriented, rhythmic
+Contrast, action-oriented, rhythmic.
 
 49. **"Your Competitors Know Their Rankings. Do You?"**
-→ Competitive fear, self-qualifying
+Competitive fear, self-qualifying.
 
 50. **"The Only Local SEO Tool That Tracks Across Every Zip Code"**
-→ Differentiator, unique capability
-
----
+Differentiator, unique capability.
 
 ## Build Your Own Swipe File
 
-As you browse the web, save headlines that grab YOUR attention. Ask:
-- What made me stop?
-- What emotion did it trigger?
-- What technique is being used?
-- How could I adapt this?
+As you browse the web, save headlines that grab YOUR attention. Ask: What made me stop? What emotion did it trigger? What technique is being used? How could I adapt this?
 
 Tools: Notion database, Swipefile.com, Google Doc, screenshot folder.


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing-sales/direct-response-copy-swipe-file-headlines.md` from 272 to 228 lines (16% reduction)
- Removed 14 redundant `---` horizontal rules (section headers already provide separation)
- Compressed classic headline entries (1-5) to match the compact format already used by SaaS headlines (6-10)
- Replaced `→` arrow prefixes with direct text in Jacky's Businesses section
- Collapsed "Build Your Own" questions from bullet list to single line

## Content Preservation

- All 50 headlines preserved with attributions
- All analysis points preserved (zero knowledge loss)
- All templates preserved verbatim
- All section structure preserved (Classic, SaaS, Curiosity, Problem, Social Proof, Benefit, Urgency, Question, How-To, Jacky's Businesses, Build Your Own)
- External reference from `direct-response-copy-frameworks-headline-formulas.md` unchanged

## Classification

File classified as **reference corpus** (curated headline collection with analysis, not an instruction doc). At 272 lines, splitting into chapter files would add overhead without benefit — tightened formatting instead.

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs-only, no code changes)
- MD022 violations: 40 pre-existing (same count before and after) — structural to the heading-as-headline pattern

Closes #11882