### PR TITLE
GH#11880: tighten architecture diagrams reference (272→218 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1085,11 +1085,11 @@
       "hash": "75edb74d82b5c0ef79b5dda64026b3145359d72f",
       "at": "2026-03-28T10:12:10Z",
       "pr": 11735
+    },
+    ".agents/tools/code-review/best-practices.md": {
+      "hash": "f0869021889e61a681d25d171ebff01435b2294a",
+      "at": "2026-03-28T10:11:16Z",
+      "pr": 11771
     }
-  },
-  ".agents/tools/code-review/best-practices.md": {
-    "hash": "f0869021889e61a681d25d171ebff01435b2294a",
-    "at": "2026-03-28T10:11:16Z",
-    "pr": 11771
   }
 }

--- a/.agents/tools/diagrams/mermaid-diagrams-skill.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill.md
@@ -157,7 +157,7 @@ A -->|text| B # Labeled
 | [mermaid-diagrams-skill/class-er.md](mermaid-diagrams-skill/class-er.md) | Classes, ER diagrams, relationships |
 | [mermaid-diagrams-skill/state-journey.md](mermaid-diagrams-skill/state-journey.md) | States, user journeys |
 | [mermaid-diagrams-skill/data-charts.md](mermaid-diagrams-skill/data-charts.md) | Gantt, Pie, Timeline, Quadrant |
-| [mermaid-diagrams-skill/architecture.md](mermaid-diagrams-skill/architecture.md) | C4, Block, Kanban |
+| [mermaid-diagrams-skill/architecture.md](mermaid-diagrams-skill/architecture.md) | Architecture, Block, C4, Kanban, Packet, Requirement |
 | [mermaid-diagrams-skill/cheatsheet.md](mermaid-diagrams-skill/cheatsheet.md) | All syntax quick reference |
 
 ## Resources

--- a/.agents/tools/diagrams/mermaid-diagrams-skill/architecture.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/architecture.md
@@ -1,33 +1,23 @@
 # Architecture Diagrams
 
-Cloud and CI/CD infrastructure visualization using icons and groups.
+Cloud, CI/CD, and system architecture visualization.
 
-### Components
+## Architecture-Beta
 
 **Groups:** `group {id}({icon})[{title}]` / `group {id}({icon})[{title}] in {parent_id}`
-
 **Services:** `service {id}({icon})[{title}]` / `service {id}({icon})[{title}] in {group_id}`
-
 **Junctions:** `junction {id}` / `junction {id} in {group_id}`
 
-### Edges
+**Edges:** `{service}:{direction} {arrow} {direction}:{service}`
 
-`{service}:{direction} {arrow} {direction}:{service}`
-
-| Direction | Code | Arrow Types | Syntax |
-|-----------|------|-------------|--------|
+| Direction | Code | Arrow | Syntax |
+|-----------|------|-------|--------|
 | Top | `T` | Undirected | `--` |
 | Bottom | `B` | Right | `-->` |
 | Left | `L` | Left | `<--` |
 | Right | `R` | Bidirectional | `<-->` |
 
-### Icons
-
-Default: `cloud`, `database`, `disk`, `internet`, `server`
-
-Iconify (200,000+ icons): `logos:aws`, `logos:google-cloud`, etc.
-
-### Example
+**Icons:** Built-in: `cloud`, `database`, `disk`, `internet`, `server`. Iconify (200k+): `logos:aws`, `logos:google-cloud`, etc.
 
 ```mermaid
 architecture-beta
@@ -47,37 +37,14 @@ architecture-beta
     api1:R --> L:cache
 ```
 
----
-
 ## Block Diagrams
 
-System component layouts with flexible positioning.
+Layout-based system component diagrams with flexible positioning.
 
 **Columns:** `columns N` — controls layout width. **Spanning:** `a:1 b:2 c:3`
-
 **Shapes:** `["Rectangle"]` `("Rounded")` `(["Stadium"])` `[("Database")]` `(("Circle"))` `{"Diamond"}` `{{"Hexagon"}}`
-
-**Nested blocks:**
-
-```mermaid
-block-beta
-    columns 2
-    block:frontend
-        columns 1
-        UI["React App"]
-        State["Redux Store"]
-    end
-    block:backend
-        columns 1
-        API["REST API"]
-        DB[("PostgreSQL")]
-    end
-    frontend --> backend
-```
-
+**Nesting:** `block:name["Label"] ... end`
 **Styling:** `classDef name fill:#hex,stroke:#hex` then `class NodeId name`
-
-### Example: Three-Tier Architecture
 
 ```mermaid
 block-beta
@@ -105,26 +72,20 @@ block-beta
     class presentation,application,data tier
 ```
 
----
-
 ## C4 Diagrams
 
 Software architecture using the C4 model (Context, Container, Component, Code).
 
 | Type | Declaration | Level |
 |------|-------------|-------|
-| System Context | `C4Context` | 1 — Highest |
+| Context | `C4Context` | 1 — Highest |
 | Container | `C4Container` | 2 |
 | Component | `C4Component` | 3 |
 | Dynamic | `C4Dynamic` | Interactions |
 | Deployment | `C4Deployment` | Infrastructure |
 
-**Context elements:** `Person`, `Person_Ext`, `System`, `System_Ext`, `SystemDb`, `SystemQueue`, `Boundary`, `Enterprise_Boundary`
-
-**Container elements:** `Container(alias, label, tech, desc)`, `Container_Ext`, `ContainerDb`, `ContainerQueue`, `Container_Boundary`
-
+**Elements:** `Person(alias, label, desc)`, `Person_Ext`, `System`, `System_Ext`, `SystemDb`, `SystemQueue`, `Boundary`, `Enterprise_Boundary`, `Container(alias, label, tech, desc)`, `Container_Ext`, `ContainerDb`, `ContainerQueue`, `Container_Boundary`, `Deployment_Node(alias, label, tech) { ... }`
 **Relationships:** `Rel(from, to, label[, tech])`, `BiRel()`, `Rel_U/D/L/R()`, `Rel_Back()`
-
 **Styling:** `UpdateElementStyle(alias, $fontColor, $bgColor)`, `UpdateRelStyle(from, to, $textColor, $lineColor)`
 
 ### C4Context
@@ -186,9 +147,7 @@ C4Deployment
     Rel(api, db, "SQL")
 ```
 
----
-
-## Kanban Diagrams
+## Kanban
 
 ```mermaid
 kanban
@@ -207,17 +166,7 @@ kanban
 
 **Metadata keys:** `ticket`, `assigned`, `priority`
 
-**Config:**
-
-```yaml
----
-config:
-  kanban:
-    ticketBaseUrl: 'https://jira.example.com/browse/#TICKET#'
----
-```
-
----
+**Config:** `ticketBaseUrl` links tickets — `'https://jira.example.com/browse/#TICKET#'` in `config.kanban`.
 
 ## Packet Diagrams
 
@@ -236,14 +185,11 @@ packet-beta
     192-255: "Data"
 ```
 
----
-
 ## Requirement Diagrams
 
 System requirements and traceability.
 
 **Types:** `requirement`, `functionalRequirement`, `interfaceRequirement`, `performanceRequirement`, `physicalRequirement`, `designConstraint`
-
 **Relationships:** `contains`, `copies`, `derives`, `satisfies`, `verifies`, `refines`, `traces`
 
 ```mermaid

--- a/.agents/tools/diagrams/mermaid-diagrams-skill/architecture.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/architecture.md
@@ -84,7 +84,7 @@ Software architecture using the C4 model (Context, Container, Component, Code).
 | Dynamic | `C4Dynamic` | Interactions |
 | Deployment | `C4Deployment` | Infrastructure |
 
-**Elements:** `Person(alias, label, desc)`, `Person_Ext`, `System`, `System_Ext`, `SystemDb`, `SystemQueue`, `Boundary`, `Enterprise_Boundary`, `Container(alias, label, tech, desc)`, `Container_Ext`, `ContainerDb`, `ContainerQueue`, `Container_Boundary`, `Deployment_Node(alias, label, tech) { ... }`
+**Elements:** `Person(alias, label, desc)`, `Person_Ext`, `System`, `System_Ext`, `SystemDb`, `SystemQueue`, `Boundary`, `System_Boundary`, `Enterprise_Boundary`, `Container(alias, label, tech, desc)`, `Container_Ext`, `ContainerDb`, `ContainerQueue`, `Container_Boundary`, `Deployment_Node(alias, label, tech) { ... }`
 **Relationships:** `Rel(from, to, label[, tech])`, `BiRel()`, `Rel_U/D/L/R()`, `Rel_Back()`
 **Styling:** `UpdateElementStyle(alias, $fontColor, $bgColor)`, `UpdateRelStyle(from, to, $textColor, $lineColor)`
 


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/diagrams/mermaid-diagrams-skill/architecture.md` from 272 to 218 lines (20% reduction) while preserving all knowledge.

Closes #11880

## Changes

- **Merged redundant Block Diagram examples**: Two examples (nested blocks + three-tier) consolidated into one that demonstrates all features (nesting, columns, shapes, `space`, `classDef`/`class` styling)
- **Compressed prose**: Verbose section descriptions → direct reference format
- **Inlined Kanban config**: 7-line YAML code block → single-line reference preserving `ticketBaseUrl` pattern
- **Removed redundant separators**: Horizontal rules between sections replaced by heading hierarchy
- **Consolidated C4 element references**: Separate Context/Container element lists → single compact reference
- **Fixed parent index**: Updated `mermaid-diagrams-skill.md` table to list all 6 diagram types (was "C4, Block, Kanban" — missing Architecture, Packet, Requirement)

## Content Preservation Verification

- All 9 mermaid code blocks preserved (was 10 — two Block examples merged into 1)
- All key terms verified present: `architecture-beta`, `block-beta`, `C4Context`, `C4Container`, `C4Dynamic`, `C4Deployment`, `kanban`, `packet-beta`, `requirementDiagram`, `Iconify`, `classDef`, `junction`, `Deployment_Node`, `ticketBaseUrl`, all requirement types, all C4 relationship types, all styling functions
- Zero lint violations (`markdownlint-cli2`)

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs-only, no code changes)
- Verification: content preservation check via term-by-term comparison, markdown linting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved architecture and diagram tool docs with clearer formatting, reorganized sections, and expanded descriptions for diagram types (Architecture, Block, C4, Kanban, Packet, Requirement) and elements.

* **Chores**
  * Adjusted internal agent configuration metadata and tracking locations to reflect updated tool references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->