### PR TITLE
GH#11957: Tighten voiceink-shortcut.md from 266 to 239 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -112,9 +112,9 @@
       "pr": 11276
     },
     ".agents/aidevops/add-new-mcp-to-aidevops.md": {
-      "hash": "526e453f459ec07c5283fb2602c607a31ce3601f",
-      "at": "2026-03-28T02:51:02Z",
-      "pr": 11277
+      "hash": "385fd2d645f5c7685e81a1cf981591ba9c025b4e",
+      "at": "2026-03-28T14:16:10Z",
+      "pr": 11832
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
       "hash": "a80eb99acba160fa0f034a4989c0b886f37a32a0",
@@ -987,9 +987,9 @@
       "pr": 11893
     },
     ".agents/tools/browser/stagehand-examples.md": {
-      "hash": "728f1064ad1de2bb36719a8a9a10d14369695cde",
-      "at": "2026-03-28T13:37:46Z",
-      "pr": 11838
+      "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
+      "at": "2026-03-28T14:15:24Z",
+      "pr": 11899
     },
     ".agents/tools/ui/wxt.md": {
       "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
@@ -997,8 +997,8 @@
       "pr": 11870
     },
     ".agents/tools/code-review/secretlint.md": {
-      "hash": "204aa2a11cbd3d6715a90b3bd867749e92e7472d",
-      "at": "2026-03-28T13:37:18Z",
+      "hash": "856b7ef872c17141c3c19db1c7f1f0d04a442cbe",
+      "at": "2026-03-28T14:15:30Z",
       "pr": 11879
     },
     ".agents/tools/database/pglite-local-first.md": {
@@ -1015,6 +1015,106 @@
       "hash": "06e2affe5aaa285c3139fde0d808dc89c0140e31",
       "at": "2026-03-28T13:38:47Z",
       "pr": 11771
+    },
+    ".agents/tools/browser/dev-browser.md": {
+      "hash": "b91119084487e01388827e51faca29441bde9ce0",
+      "at": "2026-03-28T14:15:19Z",
+      "pr": 11921
+    },
+    ".agents/tools/code-review/code-standards.md": {
+      "hash": "6f18e4189c1acca11376f4001a33d583c46742e5",
+      "at": "2026-03-28T14:15:20Z",
+      "pr": 11922
+    },
+    ".agents/scripts/commands/full-loop.md": {
+      "hash": "8a350103e8b6a9977876cbb5cf6fd2679c4133af",
+      "at": "2026-03-28T14:15:27Z",
+      "pr": 11904
+    },
+    ".agents/workflows/pr.md": {
+      "hash": "2814eecb1a03db8967c46e83a046936cf3ecc5b5",
+      "at": "2026-03-28T14:15:29Z",
+      "pr": 11878
+    },
+    ".agents/tools/git/conflict-resolution.md": {
+      "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
+      "at": "2026-03-28T14:15:35Z",
+      "pr": 11909
+    },
+    ".agents/aidevops/configs.md": {
+      "hash": "d23f9f9bd20c081fdeacff30b9bd845e72a66a31",
+      "at": "2026-03-28T14:15:36Z",
+      "pr": 11897
+    },
+    ".agents/services/communications/twilio.md": {
+      "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
+      "at": "2026-03-28T14:15:37Z",
+      "pr": 11900
+    },
+    ".agents/marketing-sales/ad-creative-platform-google.md": {
+      "hash": "99985395fdf504ae5562f8f46d2d17a14629c43f",
+      "at": "2026-03-28T14:15:38Z",
+      "pr": 11903
+    },
+    ".agents/tools/ai-assistants/openclaw.md": {
+      "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
+      "at": "2026-03-28T14:15:40Z",
+      "pr": 11901
+    },
+    ".agents/content/video-wavespeed.md": {
+      "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
+      "at": "2026-03-28T14:15:41Z",
+      "pr": 11895
+    },
+    ".agents/seo/debug-opengraph.md": {
+      "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
+      "at": "2026-03-28T14:15:42Z",
+      "pr": 11898
+    },
+    ".agents/aidevops/plugins.md": {
+      "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
+      "at": "2026-03-28T14:15:43Z",
+      "pr": 11894
+    },
+    ".agents/services/hosting/local-hosting.md": {
+      "hash": "b8cfeb51df4a7588a4e19feada4a1ff3eddd5a1d",
+      "at": "2026-03-28T14:15:45Z",
+      "pr": 11918
+    },
+    ".agents/tools/data-extraction/outscraper.md": {
+      "hash": "a6ff4d6a6aae8fdf8f2c7dc0d6ae064ee4da1856",
+      "at": "2026-03-28T14:15:48Z",
+      "pr": 11916
+    },
+    ".agents/content/distribution-email.md": {
+      "hash": "28c765046fccce83806038dd7a6c4a21a8b4b8f7",
+      "at": "2026-03-28T14:15:50Z",
+      "pr": 11913
+    },
+    ".agents/services/database/postgres-drizzle-skill/migrations.md": {
+      "hash": "dc4f2a2e3391e9b86013342bf4563b77b07cea31",
+      "at": "2026-03-28T14:15:59Z",
+      "pr": 11917
+    },
+    ".agents/workflows/code-audit-remote.md": {
+      "hash": "58b0fd2ed083489003b72485e208a6adac4dbcb9",
+      "at": "2026-03-28T14:16:09Z",
+      "pr": 11825
+    },
+    ".agents/tools/credentials/api-key-setup.md": {
+      "hash": "ee10d602e9a5a6b081507cf9ff52a2d8fc4eed86",
+      "at": "2026-03-28T14:16:13Z",
+      "pr": 11908
+    },
+    ".agents/marketing-sales/ad-creative.md": {
+      "hash": "4ab10a843352fed5cff30fdb8055e0cb3a5b3e40",
+      "at": "2026-03-28T14:16:15Z",
+      "pr": 11902
+    },
+    ".agents/tools/mcp-toolkit/mcporter.md": {
+      "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
+      "at": "2026-03-28T14:16:17Z",
+      "pr": 11906
     }
   },
   ".agents/tools/code-review/best-practices.md": {

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1115,6 +1115,31 @@
       "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
       "at": "2026-03-28T14:16:17Z",
       "pr": 11906
+    },
+    ".agents/marketing-sales/ad-creative-campaign-management.md": {
+      "hash": "25789717a8ebdaf23d939bbbf2a70de8e9e6c00e",
+      "at": "2026-03-28T14:51:10Z",
+      "pr": 11938
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
+      "hash": "d070389302c44050de078cb0dd5e39097c2d9d3b",
+      "at": "2026-03-28T14:51:16Z",
+      "pr": 11929
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
+      "hash": "78727b54babac09c10d5b04015dc077dbe8373de",
+      "at": "2026-03-28T14:51:17Z",
+      "pr": 11935
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
+      "hash": "400d292b7a77abbfdcdb45b69ef168baffef2cdf",
+      "at": "2026-03-28T14:51:17Z",
+      "pr": 11935
+    },
+    ".agents/tools/video/remotion.md": {
+      "hash": "4ff044818b1d40d557297d63aa7d05bb336b0b84",
+      "at": "2026-03-28T14:51:24Z",
+      "pr": 11928
     }
   },
   ".agents/tools/code-review/best-practices.md": {

--- a/.agents/tools/voice/voiceink-shortcut.md
+++ b/.agents/tools/voice/voiceink-shortcut.md
@@ -14,16 +14,10 @@ tools:
 
 - **Purpose**: Send VoiceInk voice transcriptions to an OpenCode server session via macOS Shortcut
 - **Flow**: VoiceInk transcription -> macOS Shortcut -> HTTP POST -> OpenCode server -> AI response
-- **Prerequisites**: VoiceInk (macOS), OpenCode server running (`opencode serve`)
+- **Prerequisites**: [VoiceInk](https://apps.apple.com/app/voiceink-ai-transcription/id6478838191) (macOS, local Whisper STT), OpenCode server running (`opencode serve`)
 - **Related**: `tools/ai-assistants/opencode-server.md`, `tools/voice/speech-to-speech.md`
 
 <!-- AI-CONTEXT-END -->
-
-## Overview
-
-[VoiceInk](https://apps.apple.com/app/voiceink-ai-transcription/id6478838191) is a macOS app that provides fast, local Whisper-based voice transcription. It supports custom actions that run after transcription completes, including macOS Shortcuts and shell scripts.
-
-This guide connects VoiceInk to the OpenCode server API so you can speak a command and have it executed by your AI coding agent.
 
 ```text
 ┌──────────┐    ┌──────────────┐    ┌──────────────────┐    ┌──────────────┐
@@ -39,10 +33,6 @@ This guide connects VoiceInk to the OpenCode server API so you can speak a comma
 ### 1. Start OpenCode Server
 
 ```bash
-# Default (localhost:4096)
-opencode serve
-
-# With fixed port (recommended for Shortcuts)
 opencode serve --port 4096
 
 # With auth (if exposing beyond localhost)
@@ -52,19 +42,18 @@ OPENCODE_SERVER_PASSWORD=your-password opencode serve --port 4096
 ### 2. Create or Identify a Session
 
 ```bash
-# Create a dedicated voice session
 curl -s -X POST http://localhost:4096/session \
   -H "Content-Type: application/json" \
   -d '{"title": "Voice Commands"}' | jq -r '.id'
 ```
 
-Save the returned session ID. You can also use an existing session from the OpenCode TUI.
+Save the returned session ID (or use an existing session from the OpenCode TUI).
 
 ### 3. Configure the macOS Shortcut
 
-#### Option A: macOS Shortcuts App (Recommended)
+#### Option A: Shortcuts App (Recommended)
 
-Create a new Shortcut in the Shortcuts app with these actions:
+Create a new Shortcut with these actions:
 
 1. **Receive** input from VoiceInk (text)
 2. **Set Variable** `transcription` to the Shortcut Input
@@ -93,12 +82,12 @@ Replace `SESSION_ID` with your actual session ID.
 
 | Endpoint | Behaviour | Use When |
 |----------|-----------|----------|
-| `/session/:id/prompt_async` | Returns 204 immediately | Default - non-blocking, fast |
+| `/session/:id/prompt_async` | Returns 204 immediately | Default - non-blocking |
 | `/session/:id/message` | Waits for full AI response | You want the response in the Shortcut |
 
 #### Option B: Shell Script Action
 
-VoiceInk can also run shell scripts. Create a script:
+VoiceInk can also run shell scripts directly:
 
 ```bash
 #!/bin/bash
@@ -129,7 +118,6 @@ curl -s -X POST "${local_server}/session/${local_session_id}/prompt_async" \
   -H "Content-Type: application/json" \
   -d "{\"parts\": [{\"type\": \"text\", \"text\": ${local_json_text}}]}"
 
-# Optional: macOS notification
 osascript -e 'display notification "Sent to OpenCode" with title "VoiceInk"'
 ```
 
@@ -137,28 +125,24 @@ osascript -e 'display notification "Sent to OpenCode" with title "VoiceInk"'
 chmod +x ~/.local/bin/voiceink-to-opencode.sh
 ```
 
-Then configure VoiceInk to run this script as a custom action.
-
 ### 4. Configure VoiceInk Action
 
-In VoiceInk preferences:
+In VoiceInk preferences > **Actions** (or **Custom Actions**):
 
-1. Open **Actions** (or **Custom Actions**)
-2. Add a new action
-3. Set the trigger (e.g., a specific keyword prefix, or make it the default action)
-4. Choose either:
-   - **Run Shortcut**: Select the Shortcut you created in Option A
+1. Add a new action
+2. Set the trigger (e.g., keyword prefix, or default action)
+3. Choose either:
+   - **Run Shortcut**: Select the Shortcut from Option A
    - **Run Script**: Point to `~/.local/bin/voiceink-to-opencode.sh`
 
 ## Advanced Configuration
 
 ### Session Auto-Discovery
 
-Instead of hardcoding a session ID, discover the most recent active session:
+Discover the most recent active session instead of hardcoding an ID:
 
 ```bash
 #!/bin/bash
-# Get the most recent session ID
 local_session_id=""
 local_session_id=$(curl -s http://localhost:4096/session | jq -r '.[0].id')
 
@@ -169,10 +153,8 @@ curl -s -X POST "http://localhost:4096/session/${local_session_id}/prompt_async"
 
 ### With Authentication
 
-If the server requires auth:
-
 ```bash
-# In shell script
+# Shell script — add -u flag
 curl -s -X POST "http://localhost:4096/session/${local_session_id}/prompt_async" \
   -u "user:${OPENCODE_SERVER_PASSWORD}" \
   -H "Content-Type: application/json" \
@@ -182,8 +164,6 @@ curl -s -X POST "http://localhost:4096/session/${local_session_id}/prompt_async"
 In macOS Shortcuts, add an `Authorization` header with value `Basic <base64(user:password)>`.
 
 ### Sync Mode with Response Display
-
-To see the AI response after speaking:
 
 ```bash
 #!/bin/bash
@@ -202,7 +182,6 @@ local_response=$(curl -s -X POST "${local_server}/session/${local_session_id}/me
   -H "Content-Type: application/json" \
   -d "{\"parts\": [{\"type\": \"text\", \"text\": ${local_json_text}}]}")
 
-# Extract text from response and show as notification
 local_reply=""
 local_reply=$(echo "$local_response" | jq -r '.parts[] | select(.type=="text") | .text' | head -c 200)
 
@@ -230,17 +209,11 @@ Use VoiceInk's action matching to route different voice commands:
 | Auth failure | Check `OPENCODE_SERVER_PASSWORD` matches server config |
 | Shortcut not triggering | Verify VoiceInk action is set to "Run Shortcut" with correct name |
 
-### Verify Server is Running
-
-```bash
-curl -s http://localhost:4096/global/health | jq .
-```
-
 ### Test the Flow Manually
 
 ```bash
-# 1. Check server
-curl -s http://localhost:4096/global/health
+# 1. Health check
+curl -s http://localhost:4096/global/health | jq .
 
 # 2. List sessions
 curl -s http://localhost:4096/session | jq '.[].id'


### PR DESCRIPTION
## Summary

- Tightens `.agents/tools/voice/voiceink-shortcut.md` from 266 to 239 lines (10% reduction)
- Compresses prose while preserving all functional content and technical accuracy
- Merges VoiceInk App Store link into Quick Reference, removes redundant Overview section, consolidates duplicate health check endpoint

## What changed

- **Removed redundant Overview section** — the VoiceInk description and App Store link are now in the Quick Reference prerequisites
- **Consolidated health check** — merged standalone "Verify Server is Running" subsection into "Test the Flow Manually" (was duplicated)
- **Trimmed filler** — removed obvious code comments (`# Default`, `# Create a dedicated voice session`, `# Optional: macOS notification`, etc.) and redundant prose sentences
- **Preserved all functional content** — every code block, URL, API endpoint, env var, task ID (t113), and troubleshooting entry is intact

## Verification

- `wc -l`: 266 → 239 (27 lines removed)
- `markdownlint-cli2`: 0 errors
- All critical content verified: 6x `prompt_async`, 2x `/message`, 1x `global/health`, 3x `OPENCODE_SESSION_ID`, 5x `OPENCODE_SERVER_PASSWORD`, all See Also refs, App Store URL, t113 reference

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (docs/agent prompt only, no code changes)
- **Rationale**: Documentation-only change with no runtime behaviour impact

Closes #11957