### PR TITLE
GH#11959: tighten r2-sql.md prose while preserving all technical content

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -112,9 +112,9 @@
       "pr": 11276
     },
     ".agents/aidevops/add-new-mcp-to-aidevops.md": {
-      "hash": "526e453f459ec07c5283fb2602c607a31ce3601f",
-      "at": "2026-03-28T02:51:02Z",
-      "pr": 11277
+      "hash": "385fd2d645f5c7685e81a1cf981591ba9c025b4e",
+      "at": "2026-03-28T14:16:10Z",
+      "pr": 11832
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
       "hash": "a80eb99acba160fa0f034a4989c0b886f37a32a0",
@@ -987,9 +987,9 @@
       "pr": 11893
     },
     ".agents/tools/browser/stagehand-examples.md": {
-      "hash": "728f1064ad1de2bb36719a8a9a10d14369695cde",
-      "at": "2026-03-28T13:37:46Z",
-      "pr": 11838
+      "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
+      "at": "2026-03-28T14:15:24Z",
+      "pr": 11899
     },
     ".agents/tools/ui/wxt.md": {
       "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
@@ -997,8 +997,8 @@
       "pr": 11870
     },
     ".agents/tools/code-review/secretlint.md": {
-      "hash": "204aa2a11cbd3d6715a90b3bd867749e92e7472d",
-      "at": "2026-03-28T13:37:18Z",
+      "hash": "856b7ef872c17141c3c19db1c7f1f0d04a442cbe",
+      "at": "2026-03-28T14:15:30Z",
       "pr": 11879
     },
     ".agents/tools/database/pglite-local-first.md": {
@@ -1015,6 +1015,106 @@
       "hash": "06e2affe5aaa285c3139fde0d808dc89c0140e31",
       "at": "2026-03-28T13:38:47Z",
       "pr": 11771
+    },
+    ".agents/tools/browser/dev-browser.md": {
+      "hash": "b91119084487e01388827e51faca29441bde9ce0",
+      "at": "2026-03-28T14:15:19Z",
+      "pr": 11921
+    },
+    ".agents/tools/code-review/code-standards.md": {
+      "hash": "6f18e4189c1acca11376f4001a33d583c46742e5",
+      "at": "2026-03-28T14:15:20Z",
+      "pr": 11922
+    },
+    ".agents/scripts/commands/full-loop.md": {
+      "hash": "8a350103e8b6a9977876cbb5cf6fd2679c4133af",
+      "at": "2026-03-28T14:15:27Z",
+      "pr": 11904
+    },
+    ".agents/workflows/pr.md": {
+      "hash": "2814eecb1a03db8967c46e83a046936cf3ecc5b5",
+      "at": "2026-03-28T14:15:29Z",
+      "pr": 11878
+    },
+    ".agents/tools/git/conflict-resolution.md": {
+      "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
+      "at": "2026-03-28T14:15:35Z",
+      "pr": 11909
+    },
+    ".agents/aidevops/configs.md": {
+      "hash": "d23f9f9bd20c081fdeacff30b9bd845e72a66a31",
+      "at": "2026-03-28T14:15:36Z",
+      "pr": 11897
+    },
+    ".agents/services/communications/twilio.md": {
+      "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
+      "at": "2026-03-28T14:15:37Z",
+      "pr": 11900
+    },
+    ".agents/marketing-sales/ad-creative-platform-google.md": {
+      "hash": "99985395fdf504ae5562f8f46d2d17a14629c43f",
+      "at": "2026-03-28T14:15:38Z",
+      "pr": 11903
+    },
+    ".agents/tools/ai-assistants/openclaw.md": {
+      "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
+      "at": "2026-03-28T14:15:40Z",
+      "pr": 11901
+    },
+    ".agents/content/video-wavespeed.md": {
+      "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
+      "at": "2026-03-28T14:15:41Z",
+      "pr": 11895
+    },
+    ".agents/seo/debug-opengraph.md": {
+      "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
+      "at": "2026-03-28T14:15:42Z",
+      "pr": 11898
+    },
+    ".agents/aidevops/plugins.md": {
+      "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
+      "at": "2026-03-28T14:15:43Z",
+      "pr": 11894
+    },
+    ".agents/services/hosting/local-hosting.md": {
+      "hash": "b8cfeb51df4a7588a4e19feada4a1ff3eddd5a1d",
+      "at": "2026-03-28T14:15:45Z",
+      "pr": 11918
+    },
+    ".agents/tools/data-extraction/outscraper.md": {
+      "hash": "a6ff4d6a6aae8fdf8f2c7dc0d6ae064ee4da1856",
+      "at": "2026-03-28T14:15:48Z",
+      "pr": 11916
+    },
+    ".agents/content/distribution-email.md": {
+      "hash": "28c765046fccce83806038dd7a6c4a21a8b4b8f7",
+      "at": "2026-03-28T14:15:50Z",
+      "pr": 11913
+    },
+    ".agents/services/database/postgres-drizzle-skill/migrations.md": {
+      "hash": "dc4f2a2e3391e9b86013342bf4563b77b07cea31",
+      "at": "2026-03-28T14:15:59Z",
+      "pr": 11917
+    },
+    ".agents/workflows/code-audit-remote.md": {
+      "hash": "58b0fd2ed083489003b72485e208a6adac4dbcb9",
+      "at": "2026-03-28T14:16:09Z",
+      "pr": 11825
+    },
+    ".agents/tools/credentials/api-key-setup.md": {
+      "hash": "ee10d602e9a5a6b081507cf9ff52a2d8fc4eed86",
+      "at": "2026-03-28T14:16:13Z",
+      "pr": 11908
+    },
+    ".agents/marketing-sales/ad-creative.md": {
+      "hash": "4ab10a843352fed5cff30fdb8055e0cb3a5b3e40",
+      "at": "2026-03-28T14:16:15Z",
+      "pr": 11902
+    },
+    ".agents/tools/mcp-toolkit/mcporter.md": {
+      "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
+      "at": "2026-03-28T14:16:17Z",
+      "pr": 11906
     }
   },
   ".agents/tools/code-review/best-practices.md": {

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1115,6 +1115,31 @@
       "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
       "at": "2026-03-28T14:16:17Z",
       "pr": 11906
+    },
+    ".agents/marketing-sales/ad-creative-campaign-management.md": {
+      "hash": "25789717a8ebdaf23d939bbbf2a70de8e9e6c00e",
+      "at": "2026-03-28T14:51:10Z",
+      "pr": 11938
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
+      "hash": "d070389302c44050de078cb0dd5e39097c2d9d3b",
+      "at": "2026-03-28T14:51:16Z",
+      "pr": 11929
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
+      "hash": "78727b54babac09c10d5b04015dc077dbe8373de",
+      "at": "2026-03-28T14:51:17Z",
+      "pr": 11935
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
+      "hash": "400d292b7a77abbfdcdb45b69ef168baffef2cdf",
+      "at": "2026-03-28T14:51:17Z",
+      "pr": 11935
+    },
+    ".agents/tools/video/remotion.md": {
+      "hash": "4ff044818b1d40d557297d63aa7d05bb336b0b84",
+      "at": "2026-03-28T14:51:24Z",
+      "pr": 11928
     }
   },
   ".agents/tools/code-review/best-practices.md": {

--- a/.agents/services/hosting/cloudflare-platform-skill/r2-sql.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2-sql.md
@@ -1,31 +1,20 @@
-# Cloudflare R2 SQL Skill
+# Cloudflare R2 SQL
 
-Serverless distributed query engine for Apache Iceberg tables in R2 Data Catalog. Serverless, zero egress fees, open beta (free beyond standard R2 storage costs).
+Serverless distributed query engine for Apache Iceberg tables in R2 Data Catalog. Zero egress fees, open beta (free beyond standard R2 storage costs).
 
 ## Core Concepts
 
-### Apache Iceberg Table Format
+**Apache Iceberg**: Open table format for large-scale analytics — ACID transactions, schema evolution (add/rename/drop columns without rewriting data), optimized metadata (avoids full table scans). Supported by Spark, Trino, Snowflake, DuckDB, ClickHouse, PyIceberg.
 
-- Open table format for large-scale analytics; ACID transactions
-- Schema evolution — add/rename/drop columns without rewriting data
-- Optimized metadata — avoids full table scans via indexed metadata
-- Supported by Spark, Trino, Snowflake, DuckDB, ClickHouse, PyIceberg
+**R2 Data Catalog**: Managed Iceberg catalog built into R2 bucket; standard Iceberg REST interface. Single source of truth for table metadata via immutable snapshots. Supports multiple query engines safely accessing same tables.
 
-### R2 Data Catalog
+**Architecture**:
 
-- Managed Iceberg catalog built into R2 bucket; standard Iceberg REST interface
-- Single source of truth for table metadata via immutable snapshots
-- Supports multiple query engines safely accessing same tables
+- **Query Planner**: top-down metadata investigation, multi-layer pruning (partition/column/row-group), streaming pipeline with early termination, uses partition and column stats (min/max, null counts)
+- **Query Execution**: coordinator distributes to workers across Cloudflare network; workers run Apache DataFusion; Arrow IPC format; Parquet column pruning; ranged reads from R2
+- **Aggregation**: scatter-gather (sum, count, avg) or shuffling (ORDER BY/HAVING via hash partitioning)
 
-### Architecture
-
-**Query Planner**: top-down metadata investigation, multi-layer pruning (partition/column/row-group), streaming pipeline with early termination, uses partition and column stats (min/max, null counts).
-
-**Query Execution**: coordinator distributes to workers across Cloudflare network; workers run Apache DataFusion; Arrow IPC format; Parquet column pruning; ranged reads from R2.
-
-**Aggregation**: scatter-gather (sum, count, avg) or shuffling (ORDER BY/HAVING via hash partitioning).
-
-## Setup & Configuration
+## Setup
 
 ### 1. Enable R2 Data Catalog
 
@@ -33,11 +22,11 @@ Serverless distributed query engine for Apache Iceberg tables in R2 Data Catalog
 npx wrangler r2 bucket catalog enable <bucket-name>
 ```
 
-Note the Warehouse name and Catalog URI from output. (Dashboard: R2 Object Storage → bucket → Settings → R2 Data Catalog → Enable.)
+Note the Warehouse name and Catalog URI from output. (Dashboard: R2 Object Storage > bucket > Settings > R2 Data Catalog > Enable.)
 
 ### 2. Create API Token
 
-Permissions required: R2 Admin Read & Write (includes R2 SQL Read). Dashboard: R2 Object Storage → Manage API tokens → Create API token → Admin Read & Write.
+Permissions required: R2 Admin Read & Write (includes R2 SQL Read). Dashboard: R2 Object Storage > Manage API tokens > Create API token > Admin Read & Write.
 
 ### 3. Configure Environment
 
@@ -45,7 +34,7 @@ Permissions required: R2 Admin Read & Write (includes R2 SQL Read). Dashboard: R
 export WRANGLER_R2_SQL_AUTH_TOKEN=<your-token>
 ```
 
-## Common Code Patterns
+## Code Patterns
 
 ### Wrangler CLI Query
 
@@ -54,7 +43,7 @@ npx wrangler r2 sql query "<warehouse-name>" "
   SELECT * FROM namespace.table_name WHERE condition LIMIT 10"
 ```
 
-### PyIceberg Setup
+### PyIceberg
 
 ```python
 from pyiceberg.catalog.rest import RestCatalog
@@ -148,20 +137,18 @@ GROUP BY category HAVING SUM(amount) > 10000 LIMIT 10;
 Comparison: `=`, `!=`, `<`, `<=`, `>`, `>=`, `LIKE`, `BETWEEN`, `IS NULL`, `IS NOT NULL`
 Logical: `AND` (higher precedence), `OR` (lower precedence)
 
-**CRITICAL**: `ORDER BY` only supports partition key columns. LIMIT range: 1–10,000 (default 500).
+**CRITICAL**: `ORDER BY` only supports partition key columns. LIMIT range: 1-10,000 (default 500).
 
 ## Pipelines Integration
 
 Schema file (`schema.json`):
 
 ```json
-{
-  "fields": [
-    {"name": "user_id", "type": "string", "required": true},
-    {"name": "event_type", "type": "string", "required": true},
-    {"name": "amount", "type": "float64", "required": false}
-  ]
-}
+{"fields": [
+  {"name": "user_id", "type": "string", "required": true},
+  {"name": "event_type", "type": "string", "required": true},
+  {"name": "amount", "type": "float64", "required": false}
+]}
 ```
 
 ```bash
@@ -178,16 +165,16 @@ curl -X POST https://{stream-id}.ingest.cloudflare.com \
   -d '[{"user_id": "user_123", "event_type": "purchase", "amount": 29.99}]'
 ```
 
-## Performance Optimization
+## Performance
 
 - **Partitioning**: choose key based on query patterns (day(timestamp), hour(timestamp), region). Required for ORDER BY.
 - **Query**: use WHERE filters, specify LIMIT, filter on high-selectivity columns first.
-- **File size**: 100–500MB Parquet files after compression; use 300+ second roll intervals in Pipelines.
-- **Pruning** (automatic): partition-level → file-level (column stats) → row-group level.
+- **File size**: 100-500MB Parquet files after compression; use 300+ second roll intervals in Pipelines.
+- **Pruning** (automatic): partition-level > file-level (column stats) > row-group level.
 
 ## Iceberg Metadata Structure
 
-```
+```text
 bucket/
   metadata/
     snap-{id}.avro          # Snapshot (points to manifest list)
@@ -198,18 +185,16 @@ bucket/
     00000-0-{uuid}.parquet  # Data files
 ```
 
-Hierarchy: Table metadata JSON → Snapshot → Manifest list → Manifest files → Parquet row group stats.
+Hierarchy: Table metadata JSON > Snapshot > Manifest list > Manifest files > Parquet row group stats.
 
-## Limitations & Best Practices
-
-### Current Limitations (Open Beta)
+## Limitations (Open Beta)
 
 - `ORDER BY` only on partition key columns
 - `COUNT(*)` only — `COUNT(column)` not supported
 - No aliases in SELECT, no subqueries, joins, or CTEs
 - No nested column access; LIMIT max 10,000
 
-### Best Practices
+## Best Practices
 
 - Partition by time dimension for time-series data; use `BETWEEN` for time ranges
 - Combine filters with `AND` for better pruning; use compression (zstd recommended)
@@ -254,7 +239,7 @@ Currently open beta — no charges beyond standard R2 costs. 30+ days notice bef
 | "Token authentication failed" | Verify `WRANGLER_R2_SQL_AUTH_TOKEN`; ensure R2 Admin Read & Write + SQL Read permissions; token may be expired |
 | "Table not found" | `SHOW DATABASES`; `SHOW TABLES IN namespace`; ensure catalog enabled on bucket |
 | "No data returned" | Check WHERE conditions; verify BETWEEN time range; try removing filters |
-| Slow queries | Check partition pruning; reduce LIMIT; ensure filters on partition key; review Parquet file sizes (100–500MB) |
+| Slow queries | Check partition pruning; reduce LIMIT; ensure filters on partition key; review Parquet file sizes (100-500MB) |
 | Query timeout | Add more restrictive WHERE filters; reduce LIMIT; consider better partitioning |
 
 ## Resources


### PR DESCRIPTION
## Summary

- Tightens `.agents/services/hosting/cloudflare-platform-skill/r2-sql.md` from 265 to 250 lines (5.7% reduction)
- Compresses prose structure (Core Concepts subsections → inline bold-key paragraphs, shorter section titles, compacted JSON schema)
- Splits combined Limitations & Best Practices into separate H2 sections for clearer navigation
- Adds `text` language tag to metadata structure code block (fixes MD040 lint violation)

## Content Preservation Verification

| Check | Result |
|-------|--------|
| Code blocks | 28/28 preserved |
| URLs | 5/5 preserved |
| Pricing table values | All 7 present |
| Troubleshooting entries | All 6 present |
| Key technical terms (30+) | All present |
| SQL examples | All preserved |

## Analysis

The file was already well-structured reference material — ~70% code blocks, tables, and SQL examples (irreducible functional content). The automated scanner flagged it by line count, but the actual prose-to-content ratio was already low. Further reduction would require removing technical content, which the issue explicitly prohibits.

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdown lint clean, content preservation verified via automated checks

Closes #11959