### PR TITLE
GH#11958: Tighten production-image.md (266 → 229 lines)

### DIFF
--- a/.agents/content/production-image.md
+++ b/.agents/content/production-image.md
@@ -15,14 +15,12 @@ tools:
 
 # Image Production
 
-AI-powered image generation for thumbnails, social media graphics, blog headers, product visuals, and brand assets using structured prompting and style libraries.
-
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
-- **Primary Tools**: Nanobanana Pro (JSON prompts), Midjourney (objects/environments), Freepik (characters), Seedream 4 (4K refinement), Ideogram (face swap)
-- **Key Techniques**: Style library system, annotated frame-to-video workflow, Shotdeck reference library, thumbnail factory pattern
+- **Tools**: Nanobanana Pro (JSON prompts), Midjourney (objects/environments), Freepik (characters), Seedream 4 (4K refinement), Ideogram (face swap)
+- **Techniques**: Style library system, annotated frame-to-video, Shotdeck references, thumbnail factory
 - **Related**: `tools/vision/image-generation.md`, `content/production-video.md`, `content/optimization.md`
 
 <!-- AI-CONTEXT-END -->
@@ -30,77 +28,48 @@ AI-powered image generation for thumbnails, social media graphics, blog headers,
 ## Tool Routing
 
 ```text
-Need structured JSON control?           → Nanobanana Pro
-Need objects/environments/landscapes?   → Midjourney (--ar 16:9 --style raw)
-Need character-driven scenes?           → Freepik
-Need 4K refinement/upscaling?          → Seedream 4
-Need face swap/character consistency?   → Ideogram
-Need text in images?                    → DALL-E 3 or Ideogram
-Need local/open-source?                 → FLUX.1 or SD XL (see tools/vision/image-generation.md)
+Structured JSON control?        → Nanobanana Pro
+Objects/environments?           → Midjourney (--ar 16:9 --style raw)
+Character-driven scenes?        → Freepik
+4K refinement/upscaling?        → Seedream 4
+Face swap/consistency?          → Ideogram
+Text in images?                 → DALL-E 3 or Ideogram
+Local/open-source?              → FLUX.1 or SD XL (tools/vision/image-generation.md)
 ```
 
-## Nanobanana Pro JSON Prompt Schema
+## Nanobanana Pro JSON Schema
 
-Structured JSON prompts enable **style library reuse** — save working JSON as named templates, swap `subject`/`concept`, maintain brand consistency.
+Save working JSON as named templates, swap `subject`/`concept`, keep brand consistency.
 
 ```json
 {
-  "subject": "Primary subject description with physical details",
-  "concept": "High-level creative direction or theme",
-  "composition": {
-    "framing": "close-up | medium shot | wide shot | extreme wide",
-    "angle": "eye-level | low angle | high angle | dutch angle | bird's eye | worm's eye",
-    "rule_of_thirds": true,
-    "focal_point": "where viewer's eye should land",
-    "depth_of_field": "shallow | medium | deep"
-  },
-  "lighting": {
-    "type": "natural | studio | dramatic | soft | hard | rim | backlit",
-    "direction": "front | side | back | top | bottom | three-point",
-    "quality": "soft diffused | harsh direct | golden hour | blue hour | overcast",
-    "color_temperature": "warm (3000K) | neutral (5500K) | cool (7000K)",
-    "mood": "bright and airy | dark and moody | high contrast | low contrast"
-  },
-  "color": {
-    "palette": ["#HEX1", "#HEX2", "#HEX3"],
-    "dominant": "#HEX",
-    "accent": "#HEX",
-    "saturation": "vibrant | muted | desaturated | monochrome",
-    "harmony": "complementary | analogous | triadic | monochromatic"
-  },
-  "style": {
-    "aesthetic": "photorealistic | cinematic | editorial | minimalist | maximalist | vintage | modern",
-    "texture": "smooth | grainy | film grain | digital clean",
-    "post_processing": "none | light grading | heavy grading | film emulation",
-    "reference": "Optional: photographer/artist style to emulate"
-  },
-  "technical": {
-    "camera": "Sony A7IV | Canon R5 | RED Komodo | iPhone 15 Pro | etc.",
-    "lens": "24mm f/1.4 | 50mm f/1.8 | 85mm f/1.2 | 16-35mm f/2.8",
-    "settings": "f/2.8, 1/250s, ISO 400",
-    "resolution": "4K | 8K | web-optimized",
-    "aspect_ratio": "16:9 | 9:16 | 1:1 | 4:5"
-  },
-  "negative": "Elements to exclude: blurry, low quality, distorted, watermark, text, etc."
+  "subject": "Primary subject with physical details",
+  "concept": "Creative direction or theme",
+  "composition": { "framing": "close-up|medium|wide|extreme wide", "angle": "eye-level|low|high|dutch|bird's eye|worm's eye", "rule_of_thirds": true, "focal_point": "where eye lands", "depth_of_field": "shallow|medium|deep" },
+  "lighting": { "type": "natural|studio|dramatic|soft|hard|rim|backlit", "direction": "front|side|back|top|bottom|three-point", "quality": "soft diffused|harsh direct|golden hour|blue hour|overcast", "color_temperature": "warm 3000K|neutral 5500K|cool 7000K", "mood": "bright airy|dark moody|high contrast|low contrast" },
+  "color": { "palette": ["#HEX1","#HEX2","#HEX3"], "dominant": "#HEX", "accent": "#HEX", "saturation": "vibrant|muted|desaturated|monochrome", "harmony": "complementary|analogous|triadic|monochromatic" },
+  "style": { "aesthetic": "photorealistic|cinematic|editorial|minimalist|maximalist|vintage|modern", "texture": "smooth|grainy|film grain|digital clean", "post_processing": "none|light grading|heavy grading|film emulation", "reference": "photographer/artist to emulate" },
+  "technical": { "camera": "Sony A7IV|Canon R5|RED Komodo|iPhone 15 Pro", "lens": "24mm f/1.4|50mm f/1.8|85mm f/1.2|16-35mm f/2.8", "settings": "f/2.8, 1/250s, ISO 400", "resolution": "4K|8K|web-optimized", "aspect_ratio": "16:9|9:16|1:1|4:5" },
+  "negative": "blurry, low quality, distorted, watermark, text, etc."
 }
 ```
 
 ### Template Variants
 
-Swap `subject`, `concept`, and `composition.focal_point` per shot; keep lighting, color, and style constant for brand consistency.
+Swap `subject`, `concept`, `focal_point` per shot; keep lighting/color/style constant.
 
 | Template | Use for | Camera / Lens | Aspect |
 |----------|---------|---------------|--------|
 | **Editorial Portrait** | Headshots, author bios | Canon R5, 85mm f/1.2, studio 3-point, 5500K | 4:5 |
 | **Environmental Product** | E-commerce, lifestyle | Sony A7IV, 50mm f/1.8, golden hour, 3500K | 16:9 |
 | **Magazine Cover** | YouTube thumbnails, hero images | Canon R5, 85mm f/1.2, dramatic front+rim | 9:16 |
-| **Street Photography** | Authentic lifestyle, UGC aesthetic | Leica Q2, 28mm f/1.7, overcast, monochromatic | 3:2 |
+| **Street Photography** | Authentic lifestyle, UGC | Leica Q2, 28mm f/1.7, overcast, monochromatic | 3:2 |
 
-## Style Library System
+## Style Library
 
-Save winning JSON templates with descriptive names (`brand-thumbnail-v1.json`). Reuse by swapping only `subject` and `concept`.
+Save winning templates as `brand-thumbnail-v1.json`. Reuse by swapping `subject` and `concept`.
 
-**Storage**: `~/.aidevops/.agent-workspace/work/[project]/style-library/` or version-control in your content repo.
+**Storage**: `~/.aidevops/.agent-workspace/work/[project]/style-library/` or version-control in content repo.
 
 | Category | Use Case | Key Attributes |
 |----------|----------|----------------|
@@ -111,7 +80,7 @@ Save winning JSON templates with descriptive names (`brand-thumbnail-v1.json`). 
 | **Lifestyle** | Blog content, storytelling | Environmental context, natural lighting |
 | **Editorial** | Magazine-style content | Dramatic lighting, bold composition |
 
-## Thumbnail Factory Pattern
+## Thumbnail Factory
 
 ```bash
 thumbnail-helper.sh generate "Your Video Topic" --count 10 --template high-contrast-face
@@ -120,47 +89,47 @@ thumbnail-helper.sh ab-test VIDEO_ID ~/.cache/aidevops/thumbnails/[output_dir]/
 thumbnail-helper.sh analyze VIDEO_ID
 ```
 
-**Available templates**: `high-contrast-face`, `text-heavy`, `before-after`, `curiosity-gap`, `product-showcase`, `cinematic`, `minimalist`, `action-packed`
+**Templates**: `high-contrast-face`, `text-heavy`, `before-after`, `curiosity-gap`, `product-showcase`, `cinematic`, `minimalist`, `action-packed`
 
-**Best practices**: Human faces increase CTR 30-40% (close-up, clear emotion). Must be readable at 320px. Leave 30% of frame clear for title text. Surprised/excited/curious expressions outperform neutral.
+**Best practices**: Faces increase CTR 30-40% (close-up, clear emotion). Readable at 320px. Leave 30% frame clear for title text. Surprised/excited/curious > neutral.
 
-### Thumbnail Scoring Rubric
-
-| Criterion | Weight | What to Check |
-|-----------|--------|---------------|
+| Criterion | Weight | Check |
+|-----------|--------|-------|
 | **Face Prominence** | 25% | Visible, clear, emotionally expressive? |
-| **Contrast** | 20% | Stands out in a thumbnail grid? |
+| **Contrast** | 20% | Stands out in thumbnail grid? |
 | **Text Space** | 15% | Clear space for title overlay? |
 | **Brand Alignment** | 15% | Matches channel visual identity? |
-| **Emotion** | 15% | Evokes curiosity, surprise, or excitement? |
-| **Clarity** | 10% | Readable at small sizes (320px)? |
+| **Emotion** | 15% | Evokes curiosity, surprise, excitement? |
+| **Clarity** | 10% | Readable at 320px? |
 
-**Threshold**: Only use thumbnails scoring 7.5+. Below 7.5 = regenerate.
+**Threshold**: 7.5+ only. Below = regenerate.
 
-## Annotated Frame-to-Video Workflow
+## Image-to-Video Workflows
 
-1. **Generate base frame** using Nanobanana Pro or Midjourney (16:9, subject in desired starting position)
-2. **Annotate with motion indicators** — arrows (direction), labels (action descriptions), timing markers. Color-code: red = character, blue = camera, green = object
-3. **Feed to video model** — Veo 3.1 or Sora 2. Prompt: "Animate this scene following the annotated motion indicators."
-4. **Refine** — adjust annotations and regenerate if motion is incorrect
+### Annotated Frame-to-Video
 
-**Reference**: `content/production-video.md` for Veo 3.1 ingredients-to-video workflow (NOT frame-to-video, which produces grainy output).
+1. **Generate base frame** — Nanobanana Pro or Midjourney (16:9, subject in starting position)
+2. **Annotate** — arrows (direction), labels (action), timing markers. Color: red=character, blue=camera, green=object
+3. **Feed to video model** — Veo 3.1 or Sora 2: "Animate this scene following the annotated motion indicators."
+4. **Refine** — adjust annotations, regenerate if motion incorrect
 
-## Shotdeck Reference Library Workflow
+See `content/production-video.md` for Veo 3.1 ingredients-to-video (NOT frame-to-video, which produces grainy output).
 
-1. **Find reference on [Shotdeck](https://shotdeck.com/)** — search by mood, genre, or visual style
-2. **Reverse-engineer with Gemini** — upload frame, prompt: "Analyze this cinematic frame. Describe composition, lighting, color palette (hex codes), camera settings, and mood. Output as structured data."
-3. **Convert to Nanobanana JSON** — map analysis to JSON schema, adjust `subject` and `concept`, keep composition/lighting/color from reference
+### Shotdeck Reference
 
-## Color, Camera, and Texture Reference
+1. Find reference on [Shotdeck](https://shotdeck.com/) by mood, genre, or visual style
+2. Reverse-engineer with Gemini: "Analyze this cinematic frame. Describe composition, lighting, color palette (hex codes), camera settings, mood. Output as structured data."
+3. Map analysis to Nanobanana JSON schema, adjust `subject`/`concept`, keep composition/lighting/color
 
-Always specify exact hex codes (not "blue" or "warm tones"). Use [Coolors.co](https://coolors.co/) or [Adobe Color](https://color.adobe.com/).
+## Color and Camera Reference
 
-| Harmony | When to Use | Example Palette |
-|---------|-------------|-----------------|
+Specify exact hex codes (not "blue" or "warm tones"). Use [Coolors.co](https://coolors.co/) or [Adobe Color](https://color.adobe.com/).
+
+| Harmony | When to Use | Palette |
+|---------|-------------|---------|
 | **Monochromatic** | Professional, minimalist | #2C3E50, #34495E, #5D6D7E |
 | **Analogous** | Natural, cohesive | #FF6B35, #F7931E, #FDC830 |
-| **Complementary** | High contrast, bold | #FF6B35 (orange), #004E89 (blue) |
+| **Complementary** | High contrast, bold | #FF6B35, #004E89 |
 | **Triadic** | Vibrant, balanced | #FF6B35, #4ECDC4, #C44569 |
 
 | Use Case | Camera | Lens | Settings | Texture |
@@ -171,64 +140,58 @@ Always specify exact hex codes (not "blue" or "warm tones"). Use [Coolors.co](ht
 | **Street** | Leica Q2 | 28mm f/1.7 | f/5.6, 1/500s, ISO 800 | film grain |
 | **Cinematic** | RED Komodo 6K | 35mm f/1.4 | f/2.0, 1/50s, ISO 800 | film grain |
 
-## Midjourney, Freepik, Seedream 4, and Ideogram
+## Tool-Specific Prompting
 
-**Midjourney**: `[SUBJECT] [ACTION] in [ENVIRONMENT], [LIGHTING], [STYLE], [CAMERA], --ar 16:9 --style raw --v 6 --no text, watermark` — always use `--style raw` for content production.
+**Midjourney**: `[SUBJECT] [ACTION] in [ENVIRONMENT], [LIGHTING], [STYLE], [CAMERA], --ar 16:9 --style raw --v 6 --no text, watermark` — always `--style raw` for production.
 
-**Freepik**: Character-driven scenes (team photos, lifestyle, testimonials). Specify demographics, emotion, environment, and style.
+**Freepik**: Character-driven scenes (team photos, lifestyle, testimonials). Specify demographics, emotion, environment, style.
 
-**Seedream 4**: Post-processing upscale after Nanobanana/Midjourney/Freepik. Use for 4K print or video prep. Only refine images that passed initial quality checks.
+**Seedream 4**: Post-processing upscale after initial generation. 4K print/video prep. Only refine images that passed quality checks.
 
-**Ideogram**: Face swap for character consistency. Generate base portrait → upload as reference face → generate new scenes → face swap. Alternative: `content/production-characters.md` (Facial Engineering Framework).
+**Ideogram**: Face swap for character consistency. Generate base portrait, upload as reference, generate new scenes, swap. Alt: `content/production-characters.md` (Facial Engineering Framework).
 
-## Platform-Specific Image Specs
+## Platform Specs
 
-| Platform | Dimensions | Aspect Ratio | Notes |
-|----------|------------|--------------|-------|
+| Platform | Dimensions | Ratio | Notes |
+|----------|------------|-------|-------|
 | **YouTube Thumbnail** | 1280x720 | 16:9 | Max 2MB, high contrast |
-| **Instagram Feed** | 1080x1080 | 1:1 | Square, vibrant colors |
+| **Instagram Feed** | 1080x1080 | 1:1 | Square, vibrant |
 | **Instagram Story** | 1080x1920 | 9:16 | Vertical, text-safe zones |
 | **Twitter/X** | 1200x675 | 16:9 | Clear at small size |
 | **LinkedIn** | 1200x627 | 1.91:1 | Professional aesthetic |
 | **Pinterest** | 1000x1500 | 2:3 | Vertical, text overlay friendly |
-| **Blog Header** | 1920x1080 | 16:9 | High res, SEO-optimized alt text |
+| **Blog Header** | 1920x1080 | 16:9 | High res, SEO alt text |
 
-**Formats**: JPG (photos), PNG (transparency/text overlays), WebP (modern web).
+**Formats**: JPG (photos), PNG (transparency/overlays), WebP (web).
 
-## UGC Brief Image Template
+## UGC Keyframe Template
 
-Generate keyframe images for each shot in a UGC storyboard. Each keyframe becomes a standalone social image or reference frame for the annotated frame-to-video workflow.
-
-Extends the Street Photography Template with UGC-specific defaults. Swap `subject`, `concept`, and `composition.focal_point` per shot; keep the authentic UGC aesthetic constant.
+Generate keyframe images per UGC storyboard shot. Each becomes a social image or frame-to-video reference. Extends Street Photography Template.
 
 ```json
 {
-  "subject": "[PRESENTER_DESCRIPTION — identical across all shots]",
+  "subject": "[PRESENTER — identical across shots]",
   "concept": "[SHOT_PURPOSE from storyboard]",
-  "composition": { "framing": "[CU for hook/emotion, MS for dialogue, WS for context]", "angle": "eye-level", "rule_of_thirds": true, "focal_point": "[Per shot]", "depth_of_field": "shallow" },
-  "lighting": { "type": "natural", "direction": "available light", "quality": "soft diffused", "color_temperature": "warm (4000K)", "mood": "authentic and approachable" },
-  "color": { "palette": ["[BRAND_PRIMARY]", "[BRAND_SECONDARY]", "[NEUTRAL]"], "dominant": "[BRAND_PRIMARY]", "accent": "[BRAND_SECONDARY]", "saturation": "muted", "harmony": "analogous" },
+  "composition": { "framing": "[CU hook/emotion, MS dialogue, WS context]", "angle": "eye-level", "rule_of_thirds": true, "focal_point": "[Per shot]", "depth_of_field": "shallow" },
+  "lighting": { "type": "natural", "direction": "available light", "quality": "soft diffused", "color_temperature": "warm 4000K", "mood": "authentic and approachable" },
+  "color": { "palette": ["[BRAND_PRIMARY]","[BRAND_SECONDARY]","[NEUTRAL]"], "dominant": "[BRAND_PRIMARY]", "accent": "[BRAND_SECONDARY]", "saturation": "muted", "harmony": "analogous" },
   "style": { "aesthetic": "photorealistic", "texture": "film grain", "post_processing": "film emulation", "reference": "iPhone 15 Pro casual photography" },
-  "technical": { "camera": "iPhone 15 Pro", "lens": "24mm f/1.78", "settings": "f/1.78, 1/120s, ISO 640", "resolution": "4K", "aspect_ratio": "[9:16 for TikTok/Reels | 16:9 for YouTube]" },
+  "technical": { "camera": "iPhone 15 Pro", "lens": "24mm f/1.78", "settings": "f/1.78, 1/120s, ISO 640", "resolution": "4K", "aspect_ratio": "[9:16 TikTok/Reels | 16:9 YouTube]" },
   "negative": "studio lighting, professional setup, staged, posed, oversaturated, digital artifacts, watermark, text overlays, perfect skin retouching"
 }
 ```
 
-### Per-Shot Keyframe Variations
+| Shot | Framing | Focal Point | Concept | Lighting |
+|------|---------|-------------|---------|----------|
+| 1: Hook | CU | Eyes | "Pattern interrupt — [hook]" | Warm natural, bright |
+| 2: Before | MS | Presenter (frustrated) | "Pain point — [problem]" | Flat, desaturated |
+| 3: Product Hero | CU to MS | Product in hands | "Product reveal — [name]" | Warm golden, product lit |
+| 4: After | CU | Face (satisfied) | "Transformation — [outcome]" | Warm, rich, inviting |
+| 5: CTA | MS | Presenter (direct) | "Call to action — [CTA]" | Clean, warm, confident |
 
-| Shot | Framing | Focal Point | Concept Override | Lighting Override |
-|------|---------|-------------|-----------------|-------------------|
-| 1: Hook | CU | Eyes | "Pattern interrupt — [hook text]" | Warm natural, slightly bright |
-| 2: Before State | MS | Presenter (frustrated) | "Pain point — [problem]" | Flat, slightly desaturated |
-| 3: Product Hero | CU → MS | Product in hands | "Product reveal — [product name]" | Warm golden, product lit |
-| 4: After State | CU | Face (satisfied) | "Transformation result — [outcome]" | Warm, rich, inviting |
-| 5: CTA | MS | Presenter (direct to camera) | "Call to action — [CTA text]" | Clean, warm, confident |
+**Batch**: Create base JSON, override `concept`/`framing`/`focal_point`/`lighting` per shot, batch generate, score (7.5+), assemble shot list, annotate for video, feed to Sora 2 Pro (UGC) or Veo 3.1 (cinematic).
 
-**Batch workflow**: Create base JSON → override `concept`, `composition.framing`, `composition.focal_point`, and `lighting` per shot → batch generate → score all (7.5+ threshold) → assemble visual shot list → annotate for video → feed to Sora 2 Pro (UGC) or Veo 3.1 (cinematic).
-
-## Post-Processing with Enhancor AI
-
-Use after generating images for professional-grade portrait enhancement, upscaling, and AI generation (Kora Pro).
+## Enhancor AI Post-Processing
 
 ```bash
 # Professional headshot enhancement
@@ -246,7 +209,7 @@ enhancor-helper.sh batch --command enhance --input photoshoot.txt \
     --output-dir enhanced/ --model enhancorv3 --skin-refinement 50 --resolution 2048
 ```
 
-**Best practices**: `skin_refinement_level` 40-60; `professional` mode for final deliverables; only enhance images that passed initial quality checks. Full API: `content/video-enhancor.md`.
+`skin_refinement_level` 40-60. `professional` mode for final deliverables. Only enhance images that passed quality checks. Full API: `content/video-enhancor.md`.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/content/production-image.md` from 266 to 229 lines (-14%)
- Compressed Nanobanana Pro JSON schema from expanded (39 lines) to compact inline format (8 lines)
- Merged "Annotated Frame-to-Video" and "Shotdeck Reference" under unified "Image-to-Video Workflows" section
- Tightened section headers and removed redundant prose throughout

## Content Preservation Verification

| Metric | Original | After | Status |
|--------|----------|-------|--------|
| URLs | 4 | 4 | preserved |
| File references | 15 | 15 | preserved |
| Helper commands | 7 | 7 | preserved |
| Code blocks | 10 | 10 | preserved |
| JSON schemas | 2 | 2 | preserved |
| Table rows | 65 | 65 | preserved |
| Reference entries | 12 | 12 | preserved |

All tool names (Nanobanana, Midjourney, Freepik, Seedream, Ideogram, DALL-E, FLUX, Enhancor, Shotdeck, Gemini, Sora, Veo) remain documented with routing, usage, and cross-references intact.

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (docs/agent prompt only, no code logic)
- **Verification**: Content count comparison against original via `rg -c` on all key patterns

Closes #11958