### PR TITLE
t11952: tighten agent doc Privacy Filter

### DIFF
--- a/.agents/tools/security/privacy-filter.md
+++ b/.agents/tools/security/privacy-filter.md
@@ -28,131 +28,55 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-Mandatory privacy filter before contributing to public repositories. Detects and optionally redacts privacy-sensitive content including credentials, personal information, and internal URLs.
-
-## Why This Matters
-
-When contributing improvements to public repositories (including aidevops itself), you must ensure:
-
-1. **No credentials** - API keys, tokens, passwords
-2. **No personal data** - Email addresses, usernames, paths
-3. **No internal URLs** - localhost, staging servers, internal domains
-4. **No private keys** - SSH keys, certificates, signing keys
-
-This filter runs automatically in the self-improving agent system (t116) before creating PRs.
+Mandatory before contributing to public repos. Detects and redacts credentials, personal data, internal URLs, and private keys. Runs automatically in the self-improving agent system (t116) before PR creation.
 
 ## Usage
 
-### Scan for Issues
-
 ```bash
-# Scan current directory
+# Scan current directory or specific path
 privacy-filter-helper.sh scan
-
-# Scan specific path
 privacy-filter-helper.sh scan ./src
 
 # Scan staged changes only
 git diff --cached --name-only | xargs privacy-filter-helper.sh scan
-```
 
-### Preview Redactions
+# Preview redactions (dry-run)
+privacy-filter-helper.sh filter [path]
 
-```bash
-# See what would be redacted (dry-run)
-privacy-filter-helper.sh filter
-
-# Preview specific files
-privacy-filter-helper.sh filter ./config
-```
-
-### Apply Redactions
-
-```bash
 # Apply redactions (creates .privacy-backup files)
-privacy-filter-helper.sh apply
-
-# Review and commit
-git diff
-git add -p
+privacy-filter-helper.sh apply [path]
+git diff && git add -p
 ```
 
 ## Detected Patterns
 
-### Credentials
-
-| Pattern | Example |
-|---------|---------|
-| API keys | `sk-abc123...`, `pk-xyz789...` |
-| AWS keys | `AKIAIOSFODNN7EXAMPLE` |
-| GitHub tokens | `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` |
-| Stripe keys | `sk_live_...`, `pk_test_...` |
-| Slack tokens | `xoxb-...` |
-| JWT tokens | `eyJhbGciOiJIUzI1NiIs...` |
-| Bearer tokens | `Bearer eyJ...` |
-
-### Personal Information
-
-| Pattern | Example |
-|---------|---------|
-| Email addresses | `user@example.com` |
-| Home paths | `/Users/john/`, `/home/jane/` |
-| Windows paths | `C:\Users\admin\` |
-
-### Internal URLs
-
-| Pattern | Example |
-|---------|---------|
-| Localhost | `localhost:3000`, `127.0.0.1:8080` |
-| Database URLs | `mongodb://user:pass@host/db` |
-| Internal domains | Custom patterns via config |
-
-### Private Keys
-
-| Pattern | Example |
-|---------|---------|
-| RSA keys | `-----BEGIN RSA PRIVATE KEY-----` |
-| EC keys | `-----BEGIN EC PRIVATE KEY-----` |
-| OpenSSH keys | `-----BEGIN OPENSSH PRIVATE KEY-----` |
+| Category | Patterns | Examples |
+|----------|----------|---------|
+| API keys | `sk-`, `pk-`, AWS `AKIA*`, Stripe `sk_live_`/`pk_test_` | `sk-abc123...`, `AKIAIOSFODNN7EXAMPLE` |
+| Tokens | GitHub `ghp_*`, Slack `xoxb-*`, JWT `eyJ*`, `Bearer eyJ*` | `ghp_xxxx...`, `xoxb-...` |
+| Personal info | Email addresses, home paths (`/Users/*/`, `/home/*/`, `C:\Users\*\`) | `user@example.com` |
+| Internal URLs | `localhost:*`, `127.0.0.1:*`, DB connection strings, custom domains | `mongodb://user:pass@host/db` |
+| Private keys | RSA, EC, OpenSSH key headers | `-----BEGIN RSA PRIVATE KEY-----` |
 
 ## Custom Patterns
 
-### Global Patterns
-
-Add patterns that apply to all projects:
+Patterns use POSIX extended regular expressions, one per line (`#` for comments).
 
 ```bash
-# Add a pattern
+# Global patterns (all projects)
 privacy-filter-helper.sh patterns add 'mycompany\.internal'
-
-# Edit patterns file
 privacy-filter-helper.sh patterns edit
-```
+# Location: ~/.aidevops/config/privacy-patterns.txt
 
-Location: `~/.aidevops/config/privacy-patterns.txt`
-
-### Project Patterns
-
-Add patterns specific to a project:
-
-```bash
-# Add project pattern
+# Project-specific patterns
 privacy-filter-helper.sh patterns add-project 'staging\.example\.com'
-
-# Edit project patterns
 privacy-filter-helper.sh patterns edit-project
+# Location: .aidevops/privacy-patterns.txt
 ```
 
-Location: `.aidevops/privacy-patterns.txt`
-
-### Pattern Format
-
-Patterns use POSIX extended regular expressions:
+Example pattern file:
 
 ```text
-# Comments start with #
-# Each line is a regex pattern
-
 # Internal domains
 staging\.mycompany\.com
 dev\.mycompany\.com
@@ -164,38 +88,29 @@ MY_PROJECT_[A-Z]+_KEY
 (john|jane|admin)@mycompany\.com
 ```
 
-## Integration with Self-Improving Agents
+## Integrations
 
-The privacy filter is mandatory in the PR phase (t116.4) of the self-improving agent system:
+### Self-Improving Agent System (t116.4)
 
 ```bash
-# In self-improvement PR workflow (previously self-improve-helper.sh):
-
-# 1. Run privacy filter
+# In self-improvement PR workflow:
+# 1. Scan — fail if issues found
 if ! privacy-filter-helper.sh scan "$worktree_path"; then
     echo "Privacy issues detected. Review and fix before PR."
     exit 1
 fi
-
-# 2. Show redacted diff for approval
+# 2. Preview redacted diff for approval
 privacy-filter-helper.sh filter "$worktree_path"
 read -p "Approve PR creation? [y/N] " approval
-
 # 3. Create PR only if approved
-if [[ "$approval" == "y" ]]; then
-    gh pr create ...
-fi
+[[ "$approval" == "y" ]] && gh pr create ...
 ```
 
-## Integration with Git Hooks
-
-Add to pre-commit hook for automatic scanning:
+### Git Pre-Commit Hook
 
 ```bash
 # .git/hooks/pre-commit
 #!/bin/bash
-
-# Run privacy filter on staged files
 staged_files=$(git diff --cached --name-only)
 if [[ -n "$staged_files" ]]; then
     echo "$staged_files" | xargs ~/.aidevops/agents/scripts/privacy-filter-helper.sh scan
@@ -206,63 +121,26 @@ if [[ -n "$staged_files" ]]; then
 fi
 ```
 
-## Secretlint Integration
+### Secretlint
 
-The privacy filter uses Secretlint for credential detection:
+Uses Secretlint for credential detection (more comprehensive than regex alone):
 
 ```bash
-# Install secretlint
 npm install -g secretlint @secretlint/secretlint-rule-preset-recommend
-
-# Or use npx (automatic)
-# The filter falls back to npx if secretlint isn't installed
+# Falls back to npx if not installed globally
 ```
-
-Secretlint provides more comprehensive credential detection than regex patterns alone.
 
 ## Troubleshooting
 
-### False Positives
+**False positives**: Add exception to `.aidevops/privacy-patterns.txt` (prefix with `!` for exclusions, e.g., `!test/fixtures/`), or modify content to avoid the pattern.
 
-If legitimate content is flagged:
+**Missing detections**: Add custom pattern via `privacy-filter-helper.sh patterns add 'pattern'`. Report gaps for inclusion in defaults.
 
-1. Review the pattern causing the match
-2. Add an exception to `.aidevops/privacy-patterns.txt`:
+**Performance**: Install `ripgrep` (`brew install ripgrep` / `apt install ripgrep`) — the filter uses `rg` automatically when available.
 
-```text
-# Exclude test fixtures
-!test/fixtures/
-```
+## Related
 
-3. Or modify the content to avoid the pattern
-
-### Missing Detections
-
-If sensitive content isn't detected:
-
-1. Add a custom pattern:
-
-```bash
-privacy-filter-helper.sh patterns add 'my_secret_pattern'
-```
-
-2. Report the gap for inclusion in default patterns
-
-### Performance
-
-For large codebases:
-
-```bash
-# Install ripgrep for faster scanning
-brew install ripgrep  # macOS
-apt install ripgrep   # Ubuntu
-
-# The filter automatically uses rg if available
-```
-
-## Related Documentation
-
-- `tools/code-review/secretlint.md` - Secretlint configuration
-- `tools/code-review/security-analysis.md` - Security scanning
-- `workflows/pr.md` - PR creation workflow
-- `aidevops/architecture.md` - Self-improving agent system
+- `tools/code-review/secretlint.md` — Secretlint configuration
+- `tools/code-review/security-analysis.md` — Security scanning
+- `workflows/pr.md` — PR creation workflow
+- `aidevops/architecture.md` — Self-improving agent system


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/security/privacy-filter.md` from 268→146 lines (45% line reduction, 29% byte reduction: 6197→4427 bytes)
- Compress prose while preserving all institutional knowledge, task IDs, code blocks, and command examples

## Changes

- Merged 4 separate pattern tables (Credentials, Personal Info, Internal URLs, Private Keys) into 1 combined table
- Consolidated 3 Usage subsections (Scan, Preview, Apply) into a single code block
- Merged Global/Project custom pattern sections into one compact section
- Compressed Troubleshooting from 3 subsections with code blocks to 3 inline paragraphs
- Removed narrative "Why This Matters" section (content folded into intro line)
- Merged 3 Integration subsections under one parent heading

## Preserved Knowledge

- All task IDs: `t116`, `t116.4`
- All CLI commands: `scan`, `filter`, `apply`, `patterns` (add/edit/add-project/edit-project)
- All pattern examples: API keys, AWS, GitHub, Stripe, Slack, JWT, Bearer, email, paths, localhost, DB URLs, private keys
- All code blocks: self-improving agent workflow, git pre-commit hook, secretlint install
- All config paths: `~/.aidevops/config/privacy-patterns.txt`, `.aidevops/privacy-patterns.txt`
- All 4 related doc links
- YAML frontmatter and AI-CONTEXT block unchanged

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompt only, no code changes)
- **Verification**: markdownlint clean (0 errors), all external references to this file path unchanged (5 files verified)

Closes #11952