### PR TITLE
GH#11978: tighten agent doc VoiceInk to OpenCode via macOS Shortcut

### DIFF
--- a/.agents/tools/voice/voiceink-shortcut.md
+++ b/.agents/tools/voice/voiceink-shortcut.md
@@ -13,8 +13,8 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Send VoiceInk voice transcriptions to an OpenCode server session via macOS Shortcut
-- **Flow**: VoiceInk transcription -> macOS Shortcut -> HTTP POST -> OpenCode server -> AI response
-- **Prerequisites**: [VoiceInk](https://apps.apple.com/app/voiceink-ai-transcription/id6478838191) (macOS, local Whisper STT), OpenCode server running (`opencode serve`)
+- **Flow**: VoiceInk (Whisper STT) -> macOS Shortcut / shell script -> HTTP POST -> OpenCode server
+- **Prerequisites**: [VoiceInk](https://apps.apple.com/app/voiceink-ai-transcription/id6478838191), OpenCode server (`opencode serve`)
 - **Related**: `tools/ai-assistants/opencode-server.md`, `tools/voice/speech-to-speech.md`
 
 <!-- AI-CONTEXT-END -->
@@ -47,21 +47,21 @@ curl -s -X POST http://localhost:4096/session \
   -d '{"title": "Voice Commands"}' | jq -r '.id'
 ```
 
-Save the returned session ID (or use an existing session from the OpenCode TUI).
+Save the returned session ID (or use an existing one from the OpenCode TUI).
 
 ### 3. Configure the macOS Shortcut
 
 #### Option A: Shortcuts App (Recommended)
 
-Create a new Shortcut with these actions:
+Create a Shortcut with these actions:
 
 1. **Receive** input from VoiceInk (text)
-2. **Set Variable** `transcription` to the Shortcut Input
+2. **Set Variable** `transcription` to Shortcut Input
 3. **Get Contents of URL**:
    - URL: `http://localhost:4096/session/SESSION_ID/prompt_async`
    - Method: POST
    - Headers: `Content-Type: application/json`
-   - Request Body (JSON):
+   - Body:
 
      ```json
      {
@@ -78,16 +78,16 @@ Create a new Shortcut with these actions:
 
 Replace `SESSION_ID` with your actual session ID.
 
-**Sync vs Async endpoints**:
+**Endpoints:**
 
 | Endpoint | Behaviour | Use When |
 |----------|-----------|----------|
-| `/session/:id/prompt_async` | Returns 204 immediately | Default - non-blocking |
-| `/session/:id/message` | Waits for full AI response | You want the response in the Shortcut |
+| `/session/:id/prompt_async` | Returns 204 immediately | Default — non-blocking |
+| `/session/:id/message` | Waits for full AI response | Need response in Shortcut |
 
-#### Option B: Shell Script Action
+#### Option B: Shell Script
 
-VoiceInk can also run shell scripts directly:
+VoiceInk can run shell scripts directly:
 
 ```bash
 #!/bin/bash
@@ -127,19 +127,16 @@ chmod +x ~/.local/bin/voiceink-to-opencode.sh
 
 ### 4. Configure VoiceInk Action
 
-In VoiceInk preferences > **Actions** (or **Custom Actions**):
+In VoiceInk preferences > **Actions**:
 
-1. Add a new action
-2. Set the trigger (e.g., keyword prefix, or default action)
-3. Choose either:
-   - **Run Shortcut**: Select the Shortcut from Option A
-   - **Run Script**: Point to `~/.local/bin/voiceink-to-opencode.sh`
+1. Add a new action with trigger (keyword prefix or default)
+2. Choose **Run Shortcut** (Option A) or **Run Script** pointing to `~/.local/bin/voiceink-to-opencode.sh` (Option B)
 
 ## Advanced Configuration
 
 ### Session Auto-Discovery
 
-Discover the most recent active session instead of hardcoding an ID:
+Use the most recent active session instead of hardcoding an ID:
 
 ```bash
 #!/bin/bash
@@ -151,23 +148,25 @@ curl -s -X POST "http://localhost:4096/session/${local_session_id}/prompt_async"
   -d "{\"parts\": [{\"type\": \"text\", \"text\": $(printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}]}"
 ```
 
-### With Authentication
+### Authentication
 
 ```bash
-# Shell script — add -u flag
+# Add -u flag to curl commands
 curl -s -X POST "http://localhost:4096/session/${local_session_id}/prompt_async" \
   -u "user:${OPENCODE_SERVER_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d "{\"parts\": [{\"type\": \"text\", \"text\": ${local_json_text}}]}"
 ```
 
-In macOS Shortcuts, add an `Authorization` header with value `Basic <base64(user:password)>`.
+In macOS Shortcuts, add an `Authorization` header: `Basic <base64(user:password)>`.
 
-### Sync Mode with Response Display
+### Sync Mode (Response Display)
+
+Use `/session/:id/message` instead of `prompt_async` to get the AI response:
 
 ```bash
 #!/bin/bash
-# voiceink-to-opencode-sync.sh - Shows AI response
+# voiceink-to-opencode-sync.sh
 
 set -euo pipefail
 
@@ -202,14 +201,14 @@ Use VoiceInk's action matching to route different voice commands:
 
 | Issue | Solution |
 |-------|----------|
-| "Connection refused" | Ensure `opencode serve` is running on port 4096 |
-| "Session not found" | Create a session first or use auto-discovery |
-| Empty transcription | Check VoiceInk is passing text to the action correctly |
-| JSON parse error | Ensure special characters are escaped (use the python3 JSON escape) |
+| Connection refused | Ensure `opencode serve` is running on port 4096 |
+| Session not found | Create a session first or use auto-discovery |
+| Empty transcription | Check VoiceInk is passing text to the action |
+| JSON parse error | Ensure special characters are escaped (use python3 JSON escape) |
 | Auth failure | Check `OPENCODE_SERVER_PASSWORD` matches server config |
-| Shortcut not triggering | Verify VoiceInk action is set to "Run Shortcut" with correct name |
+| Shortcut not triggering | Verify VoiceInk action is set to correct Shortcut name |
 
-### Test the Flow Manually
+### Manual Test
 
 ```bash
 # 1. Health check
@@ -226,14 +225,14 @@ curl -s -X POST "http://localhost:4096/session/SESSION_ID/prompt_async" \
 
 ## Security Notes
 
-- The OpenCode server defaults to `127.0.0.1` (localhost only) - safe for local use
+- OpenCode server defaults to `127.0.0.1` (localhost only) — safe for local use
 - If exposing to the network, always set `OPENCODE_SERVER_PASSWORD`
-- VoiceInk transcription is local (Whisper on-device) - audio never leaves your Mac
-- Store any auth credentials via `aidevops secret set OPENCODE_SERVER_PASSWORD`
+- VoiceInk transcription is local (Whisper on-device) — audio never leaves your Mac
+- Store auth credentials via `aidevops secret set OPENCODE_SERVER_PASSWORD`
 
 ## See Also
 
-- `tools/ai-assistants/opencode-server.md` - Full OpenCode server API reference
-- `tools/voice/speech-to-speech.md` - Full voice pipeline (bidirectional)
-- `tools/voice/transcription.md` - Transcription model options
+- `tools/ai-assistants/opencode-server.md` — full OpenCode server API reference
+- `tools/voice/speech-to-speech.md` — full voice pipeline (bidirectional)
+- `tools/voice/transcription.md` — transcription model options
 - Related task: t113 (iPhone Shortcut for voice dispatch)


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/tools/voice/voiceink-shortcut.md` — remove filler words, compress verbose descriptions, consolidate nested lists
- All code blocks, URLs, task IDs (t113), API endpoints, command examples, and security notes preserved
- Markdown linter: 0 errors

## Changes

| What | Detail |
|------|--------|
| File | `.agents/tools/voice/voiceink-shortcut.md` |
| Classification | Instruction doc (not reference corpus) |
| Before | 239 lines |
| After | 238 lines |
| Diff | 34 insertions, 35 deletions |

**Note:** This file is ~85% code blocks and tables — the prose between them was already concise. The tightening is in filler words and structural compression (e.g., VoiceInk action config from 5-line nested list to 2-line flat list), not content removal.

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompt only, no code changes)
- **Verification**: markdownlint-cli2 clean, all critical content verified present via `rg`

Closes #11978