### PR TITLE
GH#11911: tighten agent doc Email Sequence Templates

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
@@ -1,18 +1,17 @@
 # Email Sequence Templates
 
-## Shared Conventions
+## Shared Conventions (omit from each email)
 
-**Defaults for all templates** (omit from each email):
 - Greeting: `Hey [First Name],` or `[First Name],`
-- Sign-off: `[Your Name]` (solo brand) or `— [Your Name/Team]` (SaaS/company)
+- Sign-off: `[Your Name]` (solo) or `— [Your Name/Team]` (SaaS/company)
 - Every email ends with a reply invitation ("Just reply", "Hit reply", etc.)
-- Guarantee phrasing: `"You're protected by our [X]-day guarantee. Zero risk."`
+- Guarantee: `"You're protected by our [X]-day guarantee. Zero risk."`
 
 ## Reusable Patterns
 
 ### Social Proof
 
-```
+```text
 I want to introduce you to [Customer Name].
 Before: [Their situation before]
 Challenge: [What was holding them back]
@@ -23,9 +22,9 @@ The key insight? [What made the difference]
 [CTA — soft or hard depending on sequence stage]
 ```
 
-### Objection Handling (Q&A)
+### Objection Handling
 
-```
+```text
 Here are the questions most people have:
 "Is it really worth the price?" → [Brief value statement]
 "Will it work for my situation?" → [Address common use cases]
@@ -34,9 +33,9 @@ Here are the questions most people have:
 [CTA]
 ```
 
-### Urgency / Final Push
+### Urgency
 
-```
+```text
 [What's ending] disappear in [timeframe].
 After [deadline]:
 ❌ [Loss 1]  ❌ [Loss 2]  ❌ [Price increase]
@@ -49,9 +48,10 @@ If you've been on the fence, now's the time.
 ## Welcome Sequence (5 Emails)
 
 ### Email 1: Welcome + Delivery (Day 0)
+
 **Subject:** Welcome to [Brand] + Your [Resource] Is Here
 
-```
+```text
 Welcome! I'm [Your Name], and I'm glad you're here.
 As promised, here's your [Resource Name]: [Download Link]
 I created [Resource] because [connect to their problem].
@@ -62,9 +62,10 @@ P.S. The [specific section/page] is my favorite part—start there.
 ```
 
 ### Email 2: Quick Win (Day 1)
+
 **Subject:** Try this [timeframe] trick for [quick result]
 
-```
+```text
 Yesterday I sent you [Resource]. Did you grab it?
 Here's a quick win you can use right now:
 [Actionable tip in 3-5 sentences]
@@ -73,9 +74,10 @@ Try it today. Tomorrow, I'll share [preview of next email].
 ```
 
 ### Email 3: Story + Lesson (Day 3)
+
 **Subject:** The [mistake/discovery] that changed everything
 
-```
+```text
 [Timeframe] ago, I was [in their situation].
 I tried [what didn't work]. Spent [money/time] on [failed solutions]. Was about to [give up].
 Then [discovery moment]. [What changed]
@@ -84,14 +86,14 @@ If you're in a similar spot: [Specific action step]
 ```
 
 ### Email 4: Social Proof (Day 5)
-**Subject:** How [Customer Name] [achieved specific result]
 
-Uses **Social Proof pattern**. Soft CTA: preview tomorrow's offer.
+**Subject:** How [Customer Name] [achieved specific result] — Uses **Social Proof pattern**, soft CTA previewing tomorrow's offer.
 
 ### Email 5: Offer (Day 7)
+
 **Subject:** Ready to [achieve their desired outcome]?
 
-```
+```text
 Over the past week, I've shared: • [Value 1] • [Value 2] • [Value 3]
 Now I have something for you: [Product Name] — [one-sentence description].
 What you get: • [Benefit 1] • [Benefit 2] • [Benefit 3]
@@ -104,24 +106,25 @@ P.S. [Urgency element—deadline, limited spots, etc.]
 
 ## Cart Abandonment Sequence (3 Emails)
 
-### Email 1: Reminder (1 Hour After)
+### Email 1: Reminder (1 Hour)
+
 **Subject:** Did something go wrong?
 
-```
+```text
 I noticed you started checking out but didn't finish.
 No worries—your cart is still saved: [Link to Cart]
 If you ran into any issues, just hit reply.
 ```
 
 ### Email 2: Objection Handling (24 Hours)
-**Subject:** Quick question about your [Product] order
 
-Uses **Objection Handling pattern**. Include cart link after Q&A block.
+**Subject:** Quick question about your [Product] order — Uses **Objection Handling pattern** with cart link after Q&A block.
 
 ### Email 3: Final Push + Incentive (48 Hours)
+
 **Subject:** [First Name], one more thing before you go
 
-```
+```text
 One more check-in about [Product].
 Use code [CODE] at checkout for [discount/bonus].
 [Link to Cart] — This code expires in 24 hours.
@@ -133,9 +136,10 @@ P.S. [Guarantee reminder]
 ## SaaS Trial Sequence (7 Emails)
 
 ### Email 1: Welcome + Quick Start (Day 0)
+
 **Subject:** Welcome to [Product]! Here's how to start
 
-```
+```text
 You're in! Fastest way to get value from [Product]:
 1. [First action] — [benefit] [Link]
 2. [Second action] — [benefit] [Link]
@@ -146,11 +150,10 @@ P.S. Your trial lasts [X] days. Let's make them count!
 ```
 
 ### Emails 2 & 5: Feature Highlight (Day 2, Day 10)
-**Subject:** Have you tried [Key Feature] yet? / The [Feature] trick most users miss
 
-Send twice — first for the core hook feature (Day 2), second for a power-user feature most overlook (Day 10).
+**Subject:** Have you tried [Key Feature] yet? / The [Feature] trick most users miss — Send twice: core hook feature (Day 2), power-user feature (Day 10).
 
-```
+```text
 Most [Product] users say [Feature Name] is what hooked them.
 [2-3 sentences: feature + benefit]
 [Screenshot or GIF]
@@ -158,17 +161,17 @@ Try it now: [Link directly to feature]
 Not sure how? 2-minute tutorial: [Video link]
 ```
 
-Email 5 variant: add step-by-step (3-4 steps) + screenshot for the power-user feature.
+Email 5 variant: add step-by-step (3-4 steps) + screenshot.
 
 ### Email 3: Social Proof (Day 4)
-**Subject:** "[Result achieved]" — How [Customer] uses [Product]
 
-Uses **Social Proof pattern**. Add: "They did it by [specific action in the product]." Hard CTA to feature link.
+**Subject:** "[Result achieved]" — How [Customer] uses [Product] — Uses **Social Proof pattern** + "They did it by [specific action in the product]." Hard CTA to feature link.
 
 ### Email 4: Check-in (Day 7)
+
 **Subject:** How's [Product] working for you?
 
-```
+```text
 You're halfway through your trial—how's it going?
 - Have you [completed key action]?  - Need help with anything?
 Things you might not have discovered yet:
@@ -177,14 +180,14 @@ Things you might not have discovered yet:
 ```
 
 ### Email 6: Trial Ending Soon (Day 12)
-**Subject:** Your trial ends in 2 days
 
-Uses **Urgency pattern** (trial context). Losses: key feature access, data/work created. CTA: `[Upgrade Now →]`. Offer extension: "If you need more time, just reply."
+**Subject:** Your trial ends in 2 days — Uses **Urgency pattern** (trial context). Losses: feature access, data/work created. CTA: `[Upgrade Now →]`. Offer extension: "If you need more time, just reply."
 
 ### Email 7: Last Day (Day 14)
+
 **Subject:** Your trial expires today
 
-```
+```text
 Your [Product] trial ends at midnight tonight.
 Upgrade now to keep: ✓ [Feature 1] ✓ [Feature 2] ✓ [Work/data created]
 [Upgrade Now →]
@@ -196,9 +199,10 @@ As a thank you, use code [CODE] for [discount] off your first [month/year].
 ## Launch Sequence (7 Emails)
 
 ### Email 1: Announcement/Teaser (Day -3)
+
 **Subject:** Something new is coming...
 
-```
+```text
 I've been working on something for [timeframe].
 On [Date], I'm ready to share it.
 [1-2 sentence teaser—what it is without full details]
@@ -208,9 +212,10 @@ P.S. [Optional: early access or waitlist CTA]
 ```
 
 ### Email 2: Problem Agitation (Day -1)
+
 **Subject:** The real reason [problem] happens
 
-```
+```text
 Tomorrow is the big day. But first, let's talk about [the problem].
 [Describe the problem in detail]
 Most people try:
@@ -221,9 +226,10 @@ Tomorrow, I'll show you a different approach.
 ```
 
 ### Email 3: Launch Day (Day 0)
+
 **Subject:** It's here: [Product Name] is LIVE
 
-```
+```text
 Introducing [Product Name]: [Link to Sales Page]
 [Product Name] helps you [outcome] without [objection].
 What you get: • [Benefit 1] • [Benefit 2] • [Benefit 3]
@@ -235,24 +241,22 @@ P.S. [Scarcity/urgency element]
 ```
 
 ### Email 4: Story/Case Study (Day 2)
-**Subject:** "I can't believe this actually worked" — [Customer Name]
 
-Uses **Social Proof pattern**. Open with: "The response to [Product Name] has been incredible." Hard CTA.
+**Subject:** "I can't believe this actually worked" — [Customer Name] — Uses **Social Proof pattern**, open with: "The response to [Product Name] has been incredible." Hard CTA.
 
 ### Email 5: FAQ/Objections (Day 4)
-**Subject:** Your [Product] questions, answered
 
-Uses **Objection Handling pattern**. Add product-specific Qs: "How long to see results?" → [Answer]; "What's included exactly?" → [Brief summary].
+**Subject:** Your [Product] questions, answered — Uses **Objection Handling pattern** + product-specific Qs: "How long to see results?" → [Answer]; "What's included exactly?" → [Brief summary].
 
 ### Email 6: Urgency (Day 6)
-**Subject:** 48 hours left for [bonus/price]
 
-Uses **Urgency pattern**. Losses: launch bonuses + price increase.
+**Subject:** 48 hours left for [bonus/price] — Uses **Urgency pattern**. Losses: launch bonuses + price increase.
 
 ### Email 7: Final Hours (Day 7)
+
 **Subject:** [FINAL] Last chance for [Product Name]
 
-```
+```text
 This is it. At midnight tonight:
 • [Bonus/price change 1]  • [Bonus/price change 2]
 [Get [Product Name] Before Midnight →]


### PR DESCRIPTION
## Summary

- Tightened prose in email sequence templates: collapsed standalone pattern-reference paragraphs into subject-line descriptions, removed redundant heading suffixes ("(Q&A)", "/ Final Push")
- Fixed all 38 pre-existing markdownlint violations: added `text` language tags to 17 fenced code blocks (MD040), added blank lines around headings (MD022)
- Zero content loss: all 17 code blocks, 21 subject lines, 7 pattern references, 24 email sections preserved

## Classification

**Reference corpus** — email templates are domain knowledge, not agent instructions. At 274 lines (already through 5 prior tightening rounds), the file is too small to benefit from chapter-file splitting. Applied prose tightening + lint fixes instead.

## Verification

- `markdownlint-cli2`: 38 errors → 0 errors
- Content counts verified: code blocks (34 fences), pattern refs (7), subject lines (21), sections (31 headings) — all match original
- No task IDs, URLs, or command examples in this file to preserve

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompts only)
- **Rationale**: No code, no runtime behaviour change

Closes #11911