### PR TITLE
GH#12008: Tighten FSD Public API Patterns agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -998,7 +998,7 @@
     },
     ".agents/tools/code-review/secretlint.md": {
       "hash": "54a79997b8c268d6b3942204a8b6e23a251bcfe3",
-      "at": "2026-03-28T16:00:52Z",
+      "at": "2026-03-28T16:17:28Z",
       "pr": 11991
     },
     ".agents/tools/database/pglite-local-first.md": {
@@ -1088,12 +1088,12 @@
     },
     ".agents/content/distribution-email.md": {
       "hash": "d218dc3fdd2a3e501978d431530820ce810b354e",
-      "at": "2026-03-28T16:00:42Z",
+      "at": "2026-03-28T16:17:20Z",
       "pr": 11989
     },
     ".agents/services/database/postgres-drizzle-skill/migrations.md": {
       "hash": "1b9f3f2536dd65950e7eec906f4c44467b9619e8",
-      "at": "2026-03-28T16:00:44Z",
+      "at": "2026-03-28T16:17:22Z",
       "pr": 11966
     },
     ".agents/workflows/code-audit-remote.md": {
@@ -1118,7 +1118,7 @@
     },
     ".agents/marketing-sales/ad-creative-campaign-management.md": {
       "hash": "cf88e0ca297eabefcb235d1359ee6d2b0e75d576",
-      "at": "2026-03-28T16:00:35Z",
+      "at": "2026-03-28T16:17:14Z",
       "pr": 11974
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
@@ -1133,7 +1133,7 @@
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
       "hash": "9fda0fe135c5d900b529cbf4c9b5095c72c9a79d",
-      "at": "2026-03-28T16:00:33Z",
+      "at": "2026-03-28T16:17:13Z",
       "pr": 11987
     },
     ".agents/tools/video/remotion.md": {
@@ -1148,62 +1148,77 @@
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
       "hash": "3078a83990f41df192998904d47d0641191e7fba",
-      "at": "2026-03-28T16:00:25Z",
+      "at": "2026-03-28T16:17:02Z",
       "pr": 11985
     },
     ".agents/tools/performance/performance.md": {
       "hash": "478f1736c9c362f035765d45caddb4eebdec8071",
-      "at": "2026-03-28T16:00:21Z",
+      "at": "2026-03-28T16:16:58Z",
       "pr": 11983
     },
     ".agents/aidevops/troubleshooting.md": {
       "hash": "9b1e6b69bbb4c48b5d664dbb23d72a25eb867b0f",
-      "at": "2026-03-28T16:00:22Z",
+      "at": "2026-03-28T16:16:59Z",
       "pr": 11982
     },
     ".agents/marketing-sales/cro-chapter-12.md": {
       "hash": "f733b449021696b03a6678fba02aca9940fdeb6a",
-      "at": "2026-03-28T16:00:24Z",
+      "at": "2026-03-28T16:17:00Z",
       "pr": 11988
     },
     ".agents/content/production-image.md": {
       "hash": "7877c8e83fa02239c78d47e537c073939c23d0ab",
-      "at": "2026-03-28T16:00:28Z",
+      "at": "2026-03-28T16:17:05Z",
       "pr": 11973
     },
     ".agents/tools/voice/voiceink-shortcut.md": {
       "hash": "ed9c4916c972e1bb31c1584a07b20d3d9eb8c700",
-      "at": "2026-03-28T16:00:30Z",
+      "at": "2026-03-28T16:17:06Z",
       "pr": 11963
     },
     ".agents/scripts/commands/testing-setup.md": {
       "hash": "52157379b837b5701fe3d85967c51f410679a782",
-      "at": "2026-03-28T16:00:31Z",
+      "at": "2026-03-28T16:17:07Z",
       "pr": 11964
+    },
+    ".agents/services/email/email-actions.md": {
+      "hash": "53d1d1272ae9fd768b8465a9d5c3a46b657a0d73",
+      "at": "2026-03-28T16:17:08Z",
+      "pr": 11975
+    },
+    ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
+      "hash": "b8223967e6f01c448e0fe904091a1e0821ca21ff",
+      "at": "2026-03-28T16:17:09Z",
+      "pr": 11990
+    },
+    ".agents/tools/code-review/security-audit.md": {
+      "hash": "9636ceddb39c6302f75961d643d01a8ca4e1da92",
+      "at": "2026-03-28T16:17:10Z",
+      "pr": 11981
     },
     ".agents/workflows/multi-repo-workspace.md": {
       "hash": "00ea218df67c941a8858e0da60f7c252c850db7a",
-      "at": "2026-03-28T16:00:32Z",
+      "at": "2026-03-28T16:17:11Z",
       "pr": 11984
     },
     ".agents/workflows/version-bump.md": {
       "hash": "d4d8c82182a0c0fce47622e76556260a11747ee8",
-      "at": "2026-03-28T16:00:36Z",
+      "at": "2026-03-28T16:17:15Z",
       "pr": 11986
     },
     ".agents/content/video-higgsfield.md": {
       "hash": "365b9f6acbaa7e54b14209c7eaee723372e836d6",
-      "at": "2026-03-28T16:00:37Z",
+      "at": "2026-03-28T16:17:16Z",
       "pr": 11993
     },
     ".agents/services/hosting/cloudflare.md": {
       "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
-      "at": "2026-03-28T16:00:49Z",
+      "at": "2026-03-28T16:17:26Z",
       "pr": 11992
     },
     ".agents/services/monitoring/langwatch.md": {
       "hash": "a56ed459849e479aaed06d6ac42bf0d60a28adf9",
-      "at": "2026-03-28T16:00:51Z",
+      "at": "2026-03-28T16:17:27Z",
       "pr": 11994
     }
   },

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -998,7 +998,7 @@
     },
     ".agents/tools/code-review/secretlint.md": {
       "hash": "54a79997b8c268d6b3942204a8b6e23a251bcfe3",
-      "at": "2026-03-28T16:17:28Z",
+      "at": "2026-03-28T16:00:52Z",
       "pr": 11991
     },
     ".agents/tools/database/pglite-local-first.md": {
@@ -1088,12 +1088,12 @@
     },
     ".agents/content/distribution-email.md": {
       "hash": "d218dc3fdd2a3e501978d431530820ce810b354e",
-      "at": "2026-03-28T16:17:20Z",
+      "at": "2026-03-28T16:00:42Z",
       "pr": 11989
     },
     ".agents/services/database/postgres-drizzle-skill/migrations.md": {
       "hash": "1b9f3f2536dd65950e7eec906f4c44467b9619e8",
-      "at": "2026-03-28T16:17:22Z",
+      "at": "2026-03-28T16:00:44Z",
       "pr": 11966
     },
     ".agents/workflows/code-audit-remote.md": {
@@ -1118,7 +1118,7 @@
     },
     ".agents/marketing-sales/ad-creative-campaign-management.md": {
       "hash": "cf88e0ca297eabefcb235d1359ee6d2b0e75d576",
-      "at": "2026-03-28T16:17:14Z",
+      "at": "2026-03-28T16:00:35Z",
       "pr": 11974
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
@@ -1133,7 +1133,7 @@
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
       "hash": "9fda0fe135c5d900b529cbf4c9b5095c72c9a79d",
-      "at": "2026-03-28T16:17:13Z",
+      "at": "2026-03-28T16:00:33Z",
       "pr": 11987
     },
     ".agents/tools/video/remotion.md": {
@@ -1148,77 +1148,62 @@
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
       "hash": "3078a83990f41df192998904d47d0641191e7fba",
-      "at": "2026-03-28T16:17:02Z",
+      "at": "2026-03-28T16:00:25Z",
       "pr": 11985
     },
     ".agents/tools/performance/performance.md": {
       "hash": "478f1736c9c362f035765d45caddb4eebdec8071",
-      "at": "2026-03-28T16:16:58Z",
+      "at": "2026-03-28T16:00:21Z",
       "pr": 11983
     },
     ".agents/aidevops/troubleshooting.md": {
       "hash": "9b1e6b69bbb4c48b5d664dbb23d72a25eb867b0f",
-      "at": "2026-03-28T16:16:59Z",
+      "at": "2026-03-28T16:00:22Z",
       "pr": 11982
     },
     ".agents/marketing-sales/cro-chapter-12.md": {
       "hash": "f733b449021696b03a6678fba02aca9940fdeb6a",
-      "at": "2026-03-28T16:17:00Z",
+      "at": "2026-03-28T16:00:24Z",
       "pr": 11988
     },
     ".agents/content/production-image.md": {
       "hash": "7877c8e83fa02239c78d47e537c073939c23d0ab",
-      "at": "2026-03-28T16:17:05Z",
+      "at": "2026-03-28T16:00:28Z",
       "pr": 11973
     },
     ".agents/tools/voice/voiceink-shortcut.md": {
       "hash": "ed9c4916c972e1bb31c1584a07b20d3d9eb8c700",
-      "at": "2026-03-28T16:17:06Z",
+      "at": "2026-03-28T16:00:30Z",
       "pr": 11963
     },
     ".agents/scripts/commands/testing-setup.md": {
       "hash": "52157379b837b5701fe3d85967c51f410679a782",
-      "at": "2026-03-28T16:17:07Z",
+      "at": "2026-03-28T16:00:31Z",
       "pr": 11964
-    },
-    ".agents/services/email/email-actions.md": {
-      "hash": "53d1d1272ae9fd768b8465a9d5c3a46b657a0d73",
-      "at": "2026-03-28T16:17:08Z",
-      "pr": 11975
-    },
-    ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
-      "hash": "b8223967e6f01c448e0fe904091a1e0821ca21ff",
-      "at": "2026-03-28T16:17:09Z",
-      "pr": 11990
-    },
-    ".agents/tools/code-review/security-audit.md": {
-      "hash": "9636ceddb39c6302f75961d643d01a8ca4e1da92",
-      "at": "2026-03-28T16:17:10Z",
-      "pr": 11981
     },
     ".agents/workflows/multi-repo-workspace.md": {
       "hash": "00ea218df67c941a8858e0da60f7c252c850db7a",
-      "at": "2026-03-28T16:17:11Z",
+      "at": "2026-03-28T16:00:32Z",
       "pr": 11984
     },
     ".agents/workflows/version-bump.md": {
       "hash": "d4d8c82182a0c0fce47622e76556260a11747ee8",
-      "at": "2026-03-28T16:17:15Z",
+      "at": "2026-03-28T16:00:36Z",
       "pr": 11986
     },
     ".agents/content/video-higgsfield.md": {
       "hash": "365b9f6acbaa7e54b14209c7eaee723372e836d6",
-      "at": "2026-03-28T16:17:16Z",
+      "at": "2026-03-28T16:00:37Z",
       "pr": 11993
     },
     ".agents/services/hosting/cloudflare.md": {
       "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
-      "at": "2026-03-28T16:17:26Z",
+      "at": "2026-03-28T16:00:49Z",
       "pr": 11992
     },
     ".agents/services/monitoring/langwatch.md": {
       "hash": "a56ed459849e479aaed06d6ac42bf0d60a28adf9",
-      "at": "2026-03-28T16:17:27Z",
+      "at": "2026-03-28T16:00:51Z",
       "pr": 11994
     }
   },

--- a/.agents/tools/architecture/feature-slicing-skill/public-api.md
+++ b/.agents/tools/architecture/feature-slicing-skill/public-api.md
@@ -2,7 +2,7 @@
 
 > **Source:** [Public API Reference](https://feature-sliced.design/docs/reference/public-api)
 
-A public API is a **contract** between a slice and consuming code — an `index.ts` barrel file with explicit re-exports that controls what is accessible and how it can be imported.
+A public API is a **contract** — an `index.ts` barrel file with explicit re-exports controlling what a slice exposes.
 
 ## Three Goals
 
@@ -148,66 +148,3 @@ import { Button } from '@/shared/ui/Button';        // granular
 | Tree-shaking failures (unrelated utilities bundled) | Separate indices per component in `shared/` |
 | Weak enforcement (nothing prevents direct imports) | Review imports during code review |
 | Performance degradation (too many indices slow dev servers) | Consider monorepo for very large projects |
-
----
-
-## Complete Example
-
-```typescript
-// entities/product/model/types.ts
-export interface Product {
-  id: string;
-  name: string;
-  price: number;
-  imageUrl: string;
-  category: string;
-}
-
-export interface ProductFilters {
-  category?: string;
-  minPrice?: number;
-  maxPrice?: number;
-}
-```
-
-```typescript
-// entities/product/api/productApi.ts
-import { apiClient } from '@/shared/api';
-import type { Product, ProductFilters } from '../model/types';
-
-export async function getProducts(filters?: ProductFilters): Promise<Product[]> {
-  const { data } = await apiClient.get('/products', { params: filters });
-  return data;
-}
-
-export async function getProductById(id: string): Promise<Product> {
-  const { data } = await apiClient.get(`/products/${id}`);
-  return data;
-}
-```
-
-```tsx
-// entities/product/ui/ProductCard.tsx
-import type { Product } from '../model/types';
-
-export function ProductCard({ product, onSelect }: {
-  product: Product;
-  onSelect?: (product: Product) => void;
-}) {
-  return (
-    <div onClick={() => onSelect?.(product)}>
-      <img src={product.imageUrl} alt={product.name} />
-      <h3>{product.name}</h3>
-      <p>${product.price}</p>
-    </div>
-  );
-}
-```
-
-```typescript
-// entities/product/index.ts — the public API
-export { ProductCard } from './ui/ProductCard';
-export { getProducts, getProductById } from './api/productApi';
-export type { Product, ProductFilters } from './model/types';
-export { productSchema } from './model/schema';
-```


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/architecture/feature-slicing-skill/public-api.md` — a reference corpus chapter file within the FSD skill.

### Changes

- **Removed redundant "Complete Example" section** (60 lines) — every pattern it demonstrated (type definitions, API functions, React components, barrel files) was already shown individually in the preceding sections
- **Tightened intro prose** — compressed verbose description while preserving the "contract" metaphor and barrel file explanation
- **Restored structured "Three Goals" section** — clearer than inline compressed format

### Classification

**Reference corpus** (not instruction doc) — part of an already-split skill with a slim parent index (`feature-slicing-skill.md`, 126 lines). No further splitting needed.

### Metrics

- **Before:** 213 lines (post-PR #11990 tightening from 267)
- **After:** 150 lines (30% further reduction)
- **Total reduction from original:** 267 → 150 lines (44%)

### Verification

- All 2 URLs preserved
- All 10 code blocks preserved (4 removed were from redundant Complete Example)
- All key patterns present: `@x`, barrel, tree-shaking, circular, segment, wildcard, cross-import, `index.ts`
- Zero markdownlint violations
- Zero knowledge loss — every unique pattern retained

### Runtime Testing

- **Level:** `self-assessed`
- **Risk:** Low (agent docs, no runtime behaviour)

Closes #12008