### PR TITLE
GH#12001: tighten agent doc Modern JavaScript Cheatsheet

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/cheatsheet.md
+++ b/.agents/tools/programming/modern-javascript-skill/cheatsheet.md
@@ -1,6 +1,6 @@
 # Modern JavaScript Cheatsheet
 
-Variables, arrow functions, destructuring, spread/rest, template literals, optional chaining, nullish coalescing, array methods, string methods, object methods, promises, async/await, classes, modules, Set/Map, iterators, generators, RegExp, BigInt, Temporal, resource management.
+Syntax-only quick reference (ES6-ES2025). For decision trees and migration patterns, see `modern-javascript-skill.md`.
 
 ## Variables & Scope
 
@@ -237,25 +237,3 @@ Temporal.Duration.from({ hours: 2 }); date.add({ months: 1 })  // Immutable
 @logged class User { @validate name; @memoize getData() { } }
 User[Symbol.metadata]  // Decorator Metadata
 ```
-
-## Quick Migration Guide
-
-| Legacy | Modern |
-|--------|--------|
-| `var x = 1` | `const x = 1` or `let x = 1` |
-| `function(x) { return x * 2 }` | `x => x * 2` |
-| `arr[arr.length - 1]` | `arr.at(-1)` |
-| `arr.sort()` | `arr.toSorted()` |
-| `arr.reverse()` | `arr.toReversed()` |
-| `arr.splice(i, 1)` | `arr.toSpliced(i, 1)` |
-| `arr[i] = val` | `arr.with(i, val)` |
-| `str.replace(/a/g, 'b')` | `str.replaceAll('a', 'b')` |
-| `obj.hasOwnProperty('k')` | `Object.hasOwn(obj, 'k')` |
-| `a && a.b && a.b.c` | `a?.b?.c` |
-| `x \|\| 'default'` | `x ?? 'default'` |
-| `Object.assign({}, a, b)` | `{ ...a, ...b }` |
-| `[].concat(a, b)` | `[...a, ...b]` |
-| `.then().catch()` | `async/await + try/catch` |
-| `let resolve; new Promise(r => resolve = r)` | `Promise.withResolvers()` |
-| `new Date()` | `Temporal.Now.*` (polyfill) |
-| Manual grouping with reduce | `Object.groupBy()` |


### PR DESCRIPTION
## Summary

- Remove Quick Migration Guide table (21 lines) that duplicated content already in the parent `modern-javascript-skill.md` (decision trees at lines 24-51, modernization patterns at lines 78-94, ES version table at lines 64-68)
- Replace verbose topic-list header with concise description and cross-reference pointer to parent
- All 18 code blocks and ES version annotations preserved; zero knowledge loss

## Classification

**Reference corpus** (per GH#6432) — syntax-only quick reference card, not agent instructions. Restructuring into chapters not needed: chapters already exist (`es2016-es2017.md`, `es2022-es2023.md`, etc.) and the cheatsheet serves as a cross-cutting syntax lookup at 239 lines.

## Verification

- `wc -l`: 261 → 239 (22 lines removed, 8.4% reduction)
- Code blocks: 18/18 preserved (verified with `rg -c '```javascript'`)
- All removed migration patterns confirmed present in parent entry point (verified with `rg`)
- `markdownlint-cli2`: 0 errors
- No task IDs, issue refs, or URLs in the removed content

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompt only, no code changes)
- **Rationale**: Agent doc tightening — no runtime behaviour to test

Closes #12001