### PR TITLE
GH#12000: tighten Cloudron App Platform Guide agent doc

### DIFF
--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -20,31 +20,17 @@ tools:
 - **Type**: Self-hosted app platform (100+ apps), auto-updates/backups/SSL
 - **Auth**: API token from Dashboard > Settings > API Access (9.1+: passkey/OIDC login)
 - **Config**: `configs/cloudron-config.json`
-- **Commands**: `cloudron-helper.sh [servers|connect|status|apps|install-app|update-app|restart-app|logs|backup-app|domains|add-domain|users|add-user] [server] [args]`
-- **CLI ops**: `cloudron-server-ops-skill.md` (full CLI reference from upstream)
-- **Packaging**: `cloudron-app-packaging.md` (native guide), `cloudron-app-packaging-skill.md` (upstream skill)
+- **Commands**: `cloudron-helper.sh [servers|connect|status|apps|install-app|update-app|restart-app|logs|backup-app|domains|add-domain|ssl-status|users|add-user|update-user] [server] [args]`
+- **CLI ops**: `cloudron-server-ops-skill.md` (full CLI reference)
+- **Packaging**: `cloudron-app-packaging.md` (native), `cloudron-app-packaging-skill.md` (upstream)
 - **Publishing**: `cloudron-app-publishing-skill.md` (community packages via CloudronVersions.json)
 - **API test**: `curl -H "Authorization: Bearer TOKEN" https://cloudron.domain.com/api/v1/cloudron/status`
-- **SSH access**: `ssh root@cloudron.domain.com` for direct server diagnosis
-- **Forum**: [forum.cloudron.io](https://forum.cloudron.io) for known issues and solutions
+- **SSH**: `ssh root@cloudron.domain.com` for direct server diagnosis
+- **Forum**: [forum.cloudron.io](https://forum.cloudron.io) — search error messages first
 - **Docker**: `docker ps -a` (states), `docker logs <container>`, `docker exec -it <container> /bin/bash`
-- **DB creds**: `docker inspect <container> | grep CLOUDRON_MYSQL` (redact secrets before sharing output)
+- **DB creds**: `docker inspect <container> | grep CLOUDRON_MYSQL` (redact secrets before sharing)
 
 <!-- AI-CONTEXT-END -->
-
-## What's New in 9.1
-
-Cloudron 9.1 (released to unstable 2026-03-01) introduces:
-
-- **Custom app build and deploy**: `cloudron install` uploads package source and builds on-server. Source is backed up and rebuilt on restore.
-- **Community packages**: Install third-party apps from a `CloudronVersions.json` URL via the dashboard. See `cloudron-app-publishing-skill.md`.
-- **Passkey authentication**: FIDO2/WebAuthn passkey support. Tested with Bitwarden, YubiKey 5, Nitrokey, and native browser/OS support.
-- **OIDC CLI login**: Browser-based OIDC login for CLI. Pre-obtained API tokens still work for CI/CD.
-- **Addon upgrades**: MongoDB 8, Redis 8.4, Node.js 24.x
-- **ACME ARI support**: RFC 9773 for certificate renewal information
-- **Backup integrity verification UI** and improved progress reporting
-
-**Source**: [forum.cloudron.io/topic/14976](https://forum.cloudron.io/topic/14976/what-s-coming-in-9-1)
 
 ## Configuration
 
@@ -69,41 +55,15 @@ cp configs/cloudron-config.json.txt configs/cloudron-config.json
 
 API token: Dashboard > Settings > API Access > Generate.
 
-## Usage Examples
-
-```bash
-# Server management
-./.agents/scripts/cloudron-helper.sh servers
-./.agents/scripts/cloudron-helper.sh status production
-./.agents/scripts/cloudron-helper.sh apps production
-
-# App management
-./.agents/scripts/cloudron-helper.sh install-app production wordpress blog.yourdomain.com
-./.agents/scripts/cloudron-helper.sh update-app production app-id
-./.agents/scripts/cloudron-helper.sh restart-app production app-id
-./.agents/scripts/cloudron-helper.sh logs production app-id
-./.agents/scripts/cloudron-helper.sh backup-app production app-id
-
-# Domain management
-./.agents/scripts/cloudron-helper.sh domains production
-./.agents/scripts/cloudron-helper.sh add-domain production newdomain.com
-./.agents/scripts/cloudron-helper.sh ssl-status production newdomain.com
-
-# User management
-./.agents/scripts/cloudron-helper.sh users production
-./.agents/scripts/cloudron-helper.sh add-user production newuser@domain.com
-./.agents/scripts/cloudron-helper.sh update-user production user-id admin
-```
-
 ## Troubleshooting
 
-**Always check [forum.cloudron.io](https://forum.cloudron.io) first** — search error messages from app logs. Most post-update issues have forum threads with official workarounds.
+**Always check [forum.cloudron.io](https://forum.cloudron.io) first** — most post-update issues have forum threads with official workarounds.
 
 ### Post-Reboot / Post-Update Diagnostic Playbook
 
-Follow this order — each step narrows the diagnosis.
+Follow in order — each step narrows the diagnosis.
 
-**Step 1: Establish context**
+**Step 1: Context**
 
 ```bash
 ssh root@my.cloudron.domain.com
@@ -113,13 +73,13 @@ journalctl -b -1 --no-pager | grep -i -E 'cloudron.*update|cloudron-updater'
 jq -r '.version // "not found"' /home/yellowtent/box/package.json
 ```
 
-**Step 2: Assess system resources**
+**Step 2: Resources**
 
 ```bash
 free -h && df -h / && uptime
 ```
 
-**Step 3: Container state summary**
+**Step 3: Container states**
 
 ```bash
 docker ps -a --format '{{.State}}' | sort | uniq -c | sort -rn
@@ -127,7 +87,7 @@ docker ps -a --filter 'status=exited' --format '{{.Names}}\t{{.Status}}' \
   | grep -v -E 'cleanup|archive|housekeeping|previewcleanup|jobs'
 ```
 
-**Step 4: Read the box.log** (primary diagnostic)
+**Step 4: Box log** (primary diagnostic)
 
 ```bash
 tail -100 /home/yellowtent/platformdata/logs/box.log
@@ -135,7 +95,7 @@ systemctl status box.service
 grep 'app health:' /home/yellowtent/platformdata/logs/box.log | tail -5
 ```
 
-**Step 5: Monitor progress** (run every 60 seconds)
+**Step 5: Monitor** (run every 60s)
 
 ```bash
 echo "=== $(date) ===" && \
@@ -143,62 +103,64 @@ docker ps -a --format '{{.State}}' | sort | uniq -c | sort -rn && \
 tail -1 /home/yellowtent/platformdata/logs/box.log
 ```
 
-### Cloudron Startup Architecture
+### Startup Architecture
 
-Understanding the startup sequence prevents premature intervention:
+Startup sequence (prevents premature intervention):
 
-1. **Infrastructure services** (2-3 min): `box.service` starts, then MySQL, PostgreSQL, MongoDB, mail, graphite, sftp, turn — sequentially.
-2. **Redis sidecars** (3-5 min): Each app with a Redis addon gets its own container, started **one at a time** (~16 seconds each). Initial `ECONNREFUSED` on attempt 1 is normal.
-3. **App containers** (2-5 min): Started with a concurrency limit (~15). `At concurrency limit, cannot drain anymore` and `N apptasks pending` are normal queuing messages.
-4. **Health checks** (1-2 min): Apps need time to initialize. `unresponsive` until the HTTP endpoint responds.
+| Phase | Duration | Details |
+|-------|----------|---------|
+| Infrastructure | 2-3 min | `box.service` → MySQL, PostgreSQL, MongoDB, mail, graphite, sftp, turn (sequential) |
+| Redis sidecars | 3-5 min | One per app with Redis addon, started sequentially (~16s each). Initial `ECONNREFUSED` on attempt 1 is normal |
+| App containers | 2-5 min | Concurrency limit (~15). `At concurrency limit, cannot drain anymore` and `N apptasks pending` are normal queuing |
+| Health checks | 1-2 min | Apps `unresponsive` until HTTP endpoint responds |
 
-**Expected total recovery time**: 8-15 minutes for 30+ apps. High load average (5-15) and "restarting"/"not responding" in the dashboard are normal during this window.
+**Expected recovery**: 8-15 min for 30+ apps. High load (5-15) and "restarting"/"not responding" in dashboard are normal during this window.
 
-**When to intervene**: After 15 minutes if box.log shows the same Redis container failing repeatedly (>5 attempts) or container state counts aren't changing.
+**When to intervene**: After 15 min if box.log shows same Redis container failing repeatedly (>5 attempts) or container state counts aren't changing.
 
-### Identifying Stuck vs Normal Startup
+### Normal Startup vs Stuck
 
-| Symptom | Normal Startup | Genuinely Stuck |
-|---------|---------------|-----------------|
-| `ECONNREFUSED` in box.log | Attempt 1-2 per Redis, then moves on | Same container >5 attempts, never moves to next |
-| `At concurrency limit` | Pending count decreases over time | Pending count stays the same for >5 min |
+| Symptom | Normal | Stuck |
+|---------|--------|-------|
+| `ECONNREFUSED` in box.log | Attempt 1-2 per Redis, moves on | Same container >5 attempts, never advances |
+| `At concurrency limit` | Pending count decreasing | Pending count static >5 min |
 | High load average | Decreasing over 5-10 min | Sustained >10 after 15 min |
-| Exited containers | Count decreasing as apps start | Count not changing after 10 min |
-| `created` state containers | Transitioning to `running` | Stuck in `created` for >10 min |
+| Exited containers | Count decreasing | Count static after 10 min |
+| `created` state containers | Transitioning to `running` | Stuck >10 min |
 
-### Known Cloudron 9.x Post-Update Issues
+### Known 9.x Post-Update Issues
 
-**Redis not starting (9.1.3+)**: Containers fail with `Permission denied` writing PID file to `/run/redis`. One stuck Redis blocks the entire sequential startup chain. Forum: search "redis not starting 9.1".
+**Redis not starting (9.1.3+)**: `Permission denied` writing PID to `/run/redis`. One stuck Redis blocks entire sequential chain. Forum: search "redis not starting 9.1".
 
-**DB migration failures (8.x to 9.x upgrade)**: The `oidcClients` migration fails if any app's `cloudronManifest.json` has no `addons` object. Symptoms: `Cannot read properties of undefined (reading 'oidc')` or `Unknown column 'pending'/'completed' in 'field list'`. Fix: manually add empty addons objects to the MySQL `apps` table, then run `cloudron-support --apply-db-migrations`. Forum: search "Error accessing Dashboard after update from 8.x to 9.x".
+**DB migration failures (8.x→9.x)**: `oidcClients` migration fails if app's `cloudronManifest.json` has no `addons` object. Symptoms: `Cannot read properties of undefined (reading 'oidc')` or `Unknown column 'pending'/'completed'`. Fix: add empty addons objects to MySQL `apps` table, then `cloudron-support --apply-db-migrations`. Forum: search "Error accessing Dashboard after update from 8.x to 9.x".
 
-**Docker network removal failure**: Infrastructure upgrade from 49.8.0 to 49.9.0 fails because Docker reports "network has active endpoints". All apps stuck in "Configuring". Fix: manually disconnect endpoints and remove the network, then restart box service. Forum: search "Apps stuck in Configuring due to failed infrastructure upgrade".
+**Docker network removal failure**: Infrastructure upgrade 49.8.0→49.9.0 fails — "network has active endpoints". All apps stuck in "Configuring". Fix: disconnect endpoints, remove network, restart box service. Forum: search "Apps stuck in Configuring due to failed infrastructure upgrade".
 
-**Services stuck in "Starting services"**: After 9.0.11 update, infinite `grep -q avx /proc/cpuinfo` loops. Related to CPU feature detection on VMs without AVX support. Forum: search "Update 9.0.11 Broke Services".
+**Services stuck in "Starting services"**: After 9.0.11, infinite `grep -q avx /proc/cpuinfo` loops on VMs without AVX. Forum: search "Update 9.0.11 Broke Services".
 
-**Health monitor stuck**: Apps work fine but dashboard shows permanent "Starting...". Fix: `systemctl restart box`. Forum: search "apps responsive but showing a permanent Starting status".
+**Health monitor stuck**: Apps work but dashboard shows permanent "Starting...". Fix: `systemctl restart box`. Forum: search "apps responsive but showing a permanent Starting status".
 
 ### Container State Reference
 
 | State | Meaning | Action |
 |-------|---------|--------|
-| `Up` | Healthy | Normal operation |
-| `Restarting` | Crash loop | Check logs, likely app/db issue |
-| `Exited (0)` | Clean shutdown | Cloudron hasn't started it yet (normal post-reboot) |
-| `Exited (1)` | Error exit | Check `docker logs <container>` for the error |
-| `Exited (137)` | Killed (SIGKILL/OOM) | Check `dmesg \| grep -i oom` and memory limits |
-| `Created` | Never started | Waiting in Cloudron's startup queue |
+| `Up` | Healthy | Normal |
+| `Restarting` | Crash loop | Check logs — likely app/db issue |
+| `Exited (0)` | Clean shutdown | Not yet started (normal post-reboot) |
+| `Exited (1)` | Error exit | `docker logs <container>` |
+| `Exited (137)` | OOM/SIGKILL | `dmesg \| grep -i oom`, check memory limits |
+| `Created` | Never started | Waiting in startup queue |
 
 ### Key Log Files
 
-| Log/Service | Location | Purpose |
-|-------------|----------|---------|
-| Box service log | `/home/yellowtent/platformdata/logs/box.log` | Primary diagnostic |
-| Box service status | `systemctl status box.service` | Is the Cloudron platform running? |
-| App-specific logs | `docker logs <container_name>` | Individual app errors |
-| System journal (previous boot) | `journalctl -b -1 --no-pager -n 50 -p warning` | Pre-reboot events |
-| Cloudron troubleshoot | `cloudron-support --troubleshoot` | Built-in diagnostic checks |
-| Cloudron version | `jq -r '.version // "not found"' /home/yellowtent/box/package.json` | Current version |
+| Log | Location | Purpose |
+|-----|----------|---------|
+| Box service | `/home/yellowtent/platformdata/logs/box.log` | Primary diagnostic |
+| Box status | `systemctl status box.service` | Platform running? |
+| App logs | `docker logs <container_name>` | Individual app errors |
+| Previous boot | `journalctl -b -1 --no-pager -n 50 -p warning` | Pre-reboot events |
+| Built-in diag | `cloudron-support --troubleshoot` | Diagnostic checks |
+| Version | `jq -r '.version // "not found"' /home/yellowtent/box/package.json` | Current version |
 
 ### Database Troubleshooting (MySQL)
 
@@ -211,7 +173,7 @@ docker inspect <app_container> | grep CLOUDRON_MYSQL
 docker exec -it mysql mysql -u<username> -p<password> <database>
 ```
 
-> **Security note**: `docker inspect` reveals database credentials. Redact passwords before sharing output. The `-p$(cat ...)` pattern briefly exposes the password in the process list — prefer env var injection where possible (see `reference/secret-handling.md` §8.3).
+> **Security**: `docker inspect` reveals credentials. Redact passwords before sharing. The `-p$(cat ...)` pattern exposes password in process list — prefer env var injection (see `reference/secret-handling.md` §8.3).
 
 **Charset/Collation Issues** (common after updates):
 
@@ -225,38 +187,68 @@ ALTER TABLE sso_nonce CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_c
 ALTER TABLE sso_users CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ```
 
-### App Recovery Mode
+### App Recovery
 
-When an app won't start: Apps → Select App → Advanced → Enable Recovery Mode. App starts with minimal config, bypassing startup scripts. Use for database repairs, config fixes, manual migrations.
+**Recovery mode**: Apps > Select App > Advanced > Enable Recovery Mode. Starts with minimal config, bypassing startup scripts. Use for DB repairs, config fixes, manual migrations.
 
 ```bash
 docker exec -it <app_container> /bin/bash
 # Make fixes, then disable recovery mode via dashboard
 ```
 
-### App Startup Failures (Post-Update)
+**App startup failure checklist**:
 
-1. Check container state: `docker ps -a | grep <app_subdomain>`
-2. Review logs: `docker logs --tail 200 <container>`
-3. Search forum: Copy error message to forum.cloudron.io search
-4. Check database: Often charset/migration issues
-5. Enable recovery mode if database fix needed
-6. Apply fix (usually SQL commands from forum solution)
-7. Restart app via dashboard or `docker restart <container>`
+1. Container state: `docker ps -a | grep <app_subdomain>`
+2. Logs: `docker logs --tail 200 <container>`
+3. Forum: copy error message to forum.cloudron.io search
+4. Database: often charset/migration issues
+5. Recovery mode if DB fix needed
+6. Apply fix (usually SQL from forum)
+7. Restart: dashboard or `docker restart <container>`
 
-### App-Specific Troubleshooting
+**App-specific**: Vaultwarden → `tools/credentials/vaultwarden.md` | WordPress → `tools/wordpress/`
 
-- **Vaultwarden**: `../../tools/credentials/vaultwarden.md`
-- **WordPress**: `../../tools/wordpress/`
+## Usage Examples
+
+```bash
+# Server management
+cloudron-helper.sh servers
+cloudron-helper.sh status production
+cloudron-helper.sh apps production
+
+# App management (install-app|update-app|restart-app|logs|backup-app)
+cloudron-helper.sh install-app production wordpress blog.yourdomain.com
+cloudron-helper.sh update-app production app-id
+
+# Domain management (domains|add-domain|ssl-status)
+cloudron-helper.sh domains production
+cloudron-helper.sh add-domain production newdomain.com
+
+# User management (users|add-user|update-user)
+cloudron-helper.sh users production
+cloudron-helper.sh add-user production newuser@domain.com
+```
+
+## What's New in 9.1
+
+Source: [forum.cloudron.io/topic/14976](https://forum.cloudron.io/topic/14976/what-s-coming-in-9-1) (released to unstable 2026-03-01)
+
+- **Custom app build/deploy**: `cloudron install` uploads source, builds on-server. Source backed up and rebuilt on restore.
+- **Community packages**: Third-party apps via `CloudronVersions.json` URL in dashboard. See `cloudron-app-publishing-skill.md`.
+- **Passkey auth**: FIDO2/WebAuthn. Tested: Bitwarden, YubiKey 5, Nitrokey, native browser/OS.
+- **OIDC CLI login**: Browser-based OIDC for CLI. Pre-obtained API tokens still work for CI/CD.
+- **Addon upgrades**: MongoDB 8, Redis 8.4, Node.js 24.x
+- **ACME ARI**: RFC 9773 certificate renewal information
+- **Backup integrity verification UI** and improved progress reporting
 
 ## Related Skills and Subagents
 
 | Resource | Path | Purpose |
 |----------|------|---------|
-| App packaging (native) | `tools/deployment/cloudron-app-packaging.md` | Full packaging guide with aidevops helper scripts |
+| App packaging (native) | `tools/deployment/cloudron-app-packaging.md` | Packaging guide with aidevops helpers |
 | App packaging (upstream) | `tools/deployment/cloudron-app-packaging-skill.md` | Official Cloudron skill with manifest/addon refs |
 | App publishing | `tools/deployment/cloudron-app-publishing-skill.md` | CloudronVersions.json and community packages |
-| Server ops | `tools/deployment/cloudron-server-ops-skill.md` | Full CLI reference for managing installed apps |
-| Git reference | `tools/deployment/cloudron-git-reference.md` | Using git.cloudron.io for packaging patterns |
+| Server ops | `tools/deployment/cloudron-server-ops-skill.md` | Full CLI reference for managing apps |
+| Git reference | `tools/deployment/cloudron-git-reference.md` | git.cloudron.io packaging patterns |
 | Helper script | `scripts/cloudron-helper.sh` | Multi-server management via API |
 | Package helper | `scripts/cloudron-package-helper.sh` | Local packaging development workflow |


### PR DESCRIPTION
## Summary

- Tightens `.agents/services/hosting/cloudron.md` (262 → 254 lines, 12,336 → 10,910 bytes = 11.6% reduction)
- Reorders sections by importance: Quick Ref → Config → Troubleshooting → Usage → What's New (troubleshooting is the most-used section, moved up from bottom)
- Compresses startup architecture narrative into table format
- Consolidates redundant usage examples while preserving the command pattern
- Adds missing `ssl-status` and `update-user` to Quick Reference command list

Closes #12000

## Classification

**File type**: Instruction doc (operational guide for managing Cloudron servers)
**Action taken**: Prose tightening, section reordering by importance, table consolidation

## Content Preservation Verification

| Check | Result |
|-------|--------|
| URLs | All preserved (exact match) |
| Code blocks | 22 → 22 (preserved) |
| Forum references | 4 → 4 (preserved) |
| Docker commands | 14 → 14 (preserved) |
| `cloudron-support` refs | 2 → 2 |
| `systemctl restart box` | 1 → 1 |
| `docker inspect` | 3 → 3 |
| `reference/secret-handling.md` | 1 → 1 |
| Known issues (5 entries) | All preserved |
| Container state table | Preserved |
| Key log files table | Preserved |
| Related skills table | Preserved |

## Changes

- **Reordered**: Troubleshooting moved before Usage Examples (higher importance, primacy effect)
- **Compressed**: "Cloudron Startup Architecture" narrative → table with Duration/Details columns
- **Consolidated**: Usage examples reduced from 14 to 9 (removed `restart-app`, `logs`, `backup-app`, `ssl-status`, `update-user` examples — pattern is clear, all subcommands listed in Quick Reference)
- **Quick Ref improved**: Added `ssl-status` and `update-user` to command list (were in examples but missing from Quick Ref)
- **Tightened**: Section headers, prose throughout

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification level**: `self-assessed`
- No code changes, no runtime behavior affected

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`