### PR TITLE
GH#12051: Tighten Domain Research DNS Intelligence agent doc

### DIFF
--- a/.agents/seo/domain-research-api-reference.md
+++ b/.agents/seo/domain-research-api-reference.md
@@ -1,0 +1,142 @@
+# Domain Research - API Reference
+
+Detailed endpoint documentation for THC and Reconeer APIs. Parent: `seo/domain-research.md`.
+
+## THC API
+
+**4.51 billion records.** Base URL: `https://ip.thc.org`. Rate limit: 250 requests, 0.5/sec replenish (~8 min full recovery). Helper handles backoff automatically.
+
+### Simple CLI Endpoints
+
+| Endpoint | Purpose | Example |
+|----------|---------|---------|
+| `/{ip}` | Reverse DNS | `curl https://ip.thc.org/1.1.1.1` |
+| `/me` | Your IP's rDNS | `curl https://ip.thc.org/me` |
+| `/sb/{domain}` | Subdomain lookup | `curl https://ip.thc.org/sb/wikipedia.org` |
+| `/cn/{domain}` | CNAME lookup | `curl https://ip.thc.org/cn/github.io` |
+
+Query params: `f=example.com` (filter by apex) | `l=50` (limit, max 100) | `nocolor=1` | `raw=1` | `noheader=1`
+
+### JSON API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/lookup` | POST | Filtered rDNS with pagination |
+| `/api/v1/lookup/subdomains` | POST | Subdomain lookup with pagination |
+| `/api/v1/lookup/cnames` | POST | CNAME lookup with pagination |
+| `/api/v1/download` | GET | CSV export for rDNS (max 50,000) |
+| `/api/v1/subdomains/download` | GET | CSV export for subdomains |
+| `/api/v1/cnames/download` | GET | CSV export for CNAMEs |
+
+### JSON API Examples
+
+```bash
+# Paginated reverse DNS
+curl https://ip.thc.org/api/v1/lookup -X POST \
+  -d '{"ip_address":"1.1.1.1", "limit": 10}' -s | jq
+
+# With TLD filter
+curl https://ip.thc.org/api/v1/lookup -X POST \
+  -d '{"ip_address":"1.1.1.1", "limit": 10, "tld":["com","org"]}' -s | jq
+
+# Next page (use page_state from previous response)
+curl https://ip.thc.org/api/v1/lookup -X POST \
+  -d '{"ip_address":"1.1.1.1", "limit": 10, "page_state":"..."}' -s | jq
+
+# Subdomain lookup
+curl https://ip.thc.org/api/v1/lookup/subdomains -X POST \
+  -d '{"domain":"github.com", "limit": 10}' -s | jq
+
+# CNAME lookup with apex filter
+curl https://ip.thc.org/api/v1/lookup/cnames -X POST \
+  -d '{"target_domain":"google.com", "apex_domain":"example.com", "limit": 10}' -s | jq
+```
+
+### CSV Exports
+
+```bash
+curl 'https://ip.thc.org/api/v1/download?ip_address=1.1.1.1&limit=500' -o rdns.csv
+curl 'https://ip.thc.org/api/v1/subdomains/download?domain=thc.org&limit=500' -o subs.csv
+curl 'https://ip.thc.org/api/v1/cnames/download?target_domain=google.com&limit=500' -o cnames.csv
+curl 'https://ip.thc.org/api/v1/download?ip_address=1.1.1.1&hide_header=true' -o rdns.csv
+```
+
+### Database Downloads (Offline Analysis)
+
+```bash
+curl -O https://dns.team-teso.net/2025/rdns-oct.parquet.gz  # Parquet (recommended for DuckDB)
+curl -O https://dns.team-teso.net/2025/rdns-oct.csv.gz      # CSV
+
+duckdb -c "SELECT * FROM 'rdns-oct.parquet' WHERE ip_address='1.1.1.1' LIMIT 10"
+zcat rdns-oct.csv.gz | grep -m 10 'example.com'
+```
+
+### Response Headers
+
+`ASN` | `Org` | `City` | `Country` | `GPS` | `Entries` (results/total) | `Rate Limit` (remaining + replenish rate)
+
+### Output Formats
+
+```text
+;ASN    : 13335
+;Org    : Cloudflare, Inc.
+;;Entries: 50/1234
+
+one.one.one.one
+cloudflare-dns.com
+```
+
+```json
+{
+  "meta": {"asn": 13335, "org": "Cloudflare, Inc.", "total_entries": 1234, "returned_entries": 50},
+  "domains": ["one.one.one.one", "cloudflare-dns.com"],
+  "page_state": "..."
+}
+```
+
+```csv
+domain,ip_address,first_seen,last_seen
+one.one.one.one,1.1.1.1,2018-04-01,2025-01-15
+```
+
+---
+
+## Reconeer API
+
+Curated subdomain enumeration with enriched data (IP addresses, metadata).
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/api/domain/:domain` | Subdomains, IPs, counts |
+| `/api/ip/:ip` | Hostnames for an IP |
+| `/api/subdomain/:subdomain` | Details for specific subdomain |
+
+**Auth**: Free tier = 10 queries/day, no key. Premium = $49/mo unlimited, requires `RECONEER_API_KEY`.
+
+```bash
+domain-research-helper.sh reconeer domain github.com
+domain-research-helper.sh reconeer ip 140.82.121.4
+domain-research-helper.sh reconeer subdomain api.github.com
+domain-research-helper.sh reconeer domain example.com --json
+```
+
+**Response format**:
+
+```json
+{
+  "domain": "example.com",
+  "subdomains": [
+    {"name": "www.example.com", "ip": "93.184.216.34"},
+    {"name": "api.example.com", "ip": "93.184.216.35"}
+  ],
+  "count": 2
+}
+```
+
+**CLI tool** (alternative):
+
+```bash
+go install -v github.com/reconeer/reconeer/cmd/reconeer@latest
+reconeer -d example.com
+reconeer -dL domains.txt -o results.txt
+```

--- a/.agents/seo/domain-research.md
+++ b/.agents/seo/domain-research.md
@@ -20,6 +20,7 @@ tools:
 
 - **Purpose**: Domain reconnaissance via reverse DNS, subdomain enumeration, and CNAME discovery
 - **Helper**: `~/.aidevops/agents/scripts/domain-research-helper.sh`
+- **API Reference**: `seo/domain-research-api-reference.md` (endpoints, response formats, raw curl examples)
 
 **Data Sources**:
 
@@ -33,7 +34,7 @@ tools:
 **THC Commands**:
 
 ```bash
-domain-research-helper.sh rdns 1.1.1.1                          # Reverse DNS (IP → domains)
+domain-research-helper.sh rdns 1.1.1.1                          # Reverse DNS (IP -> domains)
 domain-research-helper.sh subdomains example.com                 # Subdomain enumeration
 domain-research-helper.sh cnames github.io                       # CNAME lookup
 domain-research-helper.sh rdns-block 1.1.1.0/24                 # IP block lookup
@@ -52,152 +53,11 @@ domain-research-helper.sh reconeer domain example.com --api-key YOUR_KEY
 # Or set RECONEER_API_KEY in ~/.config/aidevops/credentials.sh
 ```
 
-**Use Cases**: Attack surface discovery · Infrastructure mapping · Competitor analysis · Subdomain takeover detection · DNS migration planning · Security reconnaissance
+**Use Cases**: Attack surface discovery | Infrastructure mapping | Competitor analysis | Subdomain takeover detection | DNS migration planning | Security reconnaissance
 
 <!-- AI-CONTEXT-END -->
 
-## THC API
-
-**4.51 billion records.** Rate limit: 250 requests, 0.5/sec replenish (~8 min full recovery). Helper handles backoff automatically.
-
-### Simple CLI Endpoints
-
-| Endpoint | Purpose | Example |
-|----------|---------|---------|
-| `/{ip}` | Reverse DNS | `curl https://ip.thc.org/1.1.1.1` |
-| `/me` | Your IP's rDNS | `curl https://ip.thc.org/me` |
-| `/sb/{domain}` | Subdomain lookup | `curl https://ip.thc.org/sb/wikipedia.org` |
-| `/cn/{domain}` | CNAME lookup | `curl https://ip.thc.org/cn/github.io` |
-
-Query params: `f=example.com` (filter by apex) · `l=50` (limit, max 100) · `nocolor=1` · `raw=1` · `noheader=1`
-
-### JSON API Endpoints
-
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/api/v1/lookup` | POST | Filtered rDNS with pagination |
-| `/api/v1/lookup/subdomains` | POST | Subdomain lookup with pagination |
-| `/api/v1/lookup/cnames` | POST | CNAME lookup with pagination |
-| `/api/v1/download` | GET | CSV export for rDNS (max 50,000) |
-| `/api/v1/subdomains/download` | GET | CSV export for subdomains |
-| `/api/v1/cnames/download` | GET | CSV export for CNAMEs |
-
-### JSON API Examples
-
-```bash
-# Paginated reverse DNS
-curl https://ip.thc.org/api/v1/lookup -X POST \
-  -d '{"ip_address":"1.1.1.1", "limit": 10}' -s | jq
-
-# With TLD filter
-curl https://ip.thc.org/api/v1/lookup -X POST \
-  -d '{"ip_address":"1.1.1.1", "limit": 10, "tld":["com","org"]}' -s | jq
-
-# Next page (use page_state from previous response)
-curl https://ip.thc.org/api/v1/lookup -X POST \
-  -d '{"ip_address":"1.1.1.1", "limit": 10, "page_state":"..."}' -s | jq
-
-# Subdomain lookup
-curl https://ip.thc.org/api/v1/lookup/subdomains -X POST \
-  -d '{"domain":"github.com", "limit": 10}' -s | jq
-
-# CNAME lookup with apex filter
-curl https://ip.thc.org/api/v1/lookup/cnames -X POST \
-  -d '{"target_domain":"google.com", "apex_domain":"example.com", "limit": 10}' -s | jq
-```
-
-### CSV Exports
-
-```bash
-curl 'https://ip.thc.org/api/v1/download?ip_address=1.1.1.1&limit=500' -o rdns.csv
-curl 'https://ip.thc.org/api/v1/subdomains/download?domain=thc.org&limit=500' -o subs.csv
-curl 'https://ip.thc.org/api/v1/cnames/download?target_domain=google.com&limit=500' -o cnames.csv
-curl 'https://ip.thc.org/api/v1/download?ip_address=1.1.1.1&hide_header=true' -o rdns.csv
-```
-
-### Database Downloads (Offline Analysis)
-
-```bash
-curl -O https://dns.team-teso.net/2025/rdns-oct.parquet.gz  # Parquet (recommended for DuckDB)
-curl -O https://dns.team-teso.net/2025/rdns-oct.csv.gz      # CSV
-
-duckdb -c "SELECT * FROM 'rdns-oct.parquet' WHERE ip_address='1.1.1.1' LIMIT 10"
-zcat rdns-oct.csv.gz | grep -m 10 'example.com'
-```
-
-### Response Headers
-
-`ASN` · `Org` · `City` · `Country` · `GPS` · `Entries` (results/total) · `Rate Limit` (remaining + replenish rate)
-
-### Output Formats
-
-```text
-;ASN    : 13335
-;Org    : Cloudflare, Inc.
-;;Entries: 50/1234
-
-one.one.one.one
-cloudflare-dns.com
-```
-
-```json
-{
-  "meta": {"asn": 13335, "org": "Cloudflare, Inc.", "total_entries": 1234, "returned_entries": 50},
-  "domains": ["one.one.one.one", "cloudflare-dns.com"],
-  "page_state": "..."
-}
-```
-
-```csv
-domain,ip_address,first_seen,last_seen
-one.one.one.one,1.1.1.1,2018-04-01,2025-01-15
-```
-
----
-
-## Reconeer API
-
-Curated subdomain enumeration with enriched data (IP addresses, metadata).
-
-| Endpoint | Purpose |
-|----------|---------|
-| `/api/domain/:domain` | Subdomains, IPs, counts |
-| `/api/ip/:ip` | Hostnames for an IP |
-| `/api/subdomain/:subdomain` | Details for specific subdomain |
-
-**Auth**: Free tier = 10 queries/day, no key. Premium = $49/mo unlimited, requires `RECONEER_API_KEY`.
-
-```bash
-domain-research-helper.sh reconeer domain github.com
-domain-research-helper.sh reconeer ip 140.82.121.4
-domain-research-helper.sh reconeer subdomain api.github.com
-domain-research-helper.sh reconeer domain example.com --json
-```
-
-**Response format**:
-
-```json
-{
-  "domain": "example.com",
-  "subdomains": [
-    {"name": "www.example.com", "ip": "93.184.216.34"},
-    {"name": "api.example.com", "ip": "93.184.216.35"}
-  ],
-  "count": 2
-}
-```
-
-**CLI tool** (alternative):
-
-```bash
-go install -v github.com/reconeer/reconeer/cmd/reconeer@latest
-reconeer -d example.com
-reconeer -dL domains.txt -o results.txt
-```
-
----
-
-## Use Cases
+## Operational Examples
 
 ```bash
 # Attack surface discovery


### PR DESCRIPTION
## Summary

- Extract API reference material (THC endpoints, JSON examples, CSV exports, response formats, database downloads, Reconeer API) into `domain-research-api-reference.md`
- Tighten main agent doc from 256 to 116 lines — retains all operational content (helper commands, use cases, integration, troubleshooting, related agents)
- Zero content loss: 258 combined lines across both files

## Changes

| File | Action |
|------|--------|
| `.agents/seo/domain-research.md` | Tightened from 256 → 116 lines; removed inline API reference, added pointer to extracted file |
| `.agents/seo/domain-research-api-reference.md` | **New** — 142 lines of extracted API reference (THC + Reconeer endpoints, examples, formats) |

## Classification

**Hybrid file** — instruction doc with embedded reference corpus. Strategy: keep operational instructions in the agent doc, extract reference material to a sub-file with progressive disclosure.

## Verification

- All URLs preserved (17 across both files)
- All helper command references preserved (29 across both files)
- All code blocks preserved (26 across both files)
- markdownlint: 0 errors
- No task IDs or incident references to preserve (none in original)

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompts only)
- **Rationale**: No code changes, no runtime behavior affected

Closes #12051