### PR TITLE
feat: Automated opus-tier triage review for needs-maintainer-review issues

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -312,17 +312,7 @@ Before waiting for the maintainer to manually review `needs-maintainer-review` i
 
 **When to dispatch a triage review:**
 
-For each `needs-maintainer-review` issue/PR in the pre-fetched state, check whether an agent review comment already exists. An agent review comment is identified by containing the string `## Issue/PR Review:` or `## Review:` (the structured output format from `review-issue-pr.md`).
-
-```bash
-# Check if an agent review comment already exists
-REVIEW_EXISTS=$(gh api "repos/<slug>/issues/<number>/comments" \
-  --jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | length')
-
-if [[ "$REVIEW_EXISTS" -eq 0 ]]; then
-  # No review yet — dispatch a triage review worker
-fi
-```
+Use the pre-fetched "Needs Maintainer Review — Triage Status" section (produced by `prefetch_triage_review_status()` in `pulse-wrapper.sh`). Each issue is already marked as **needs-review**, **reviewed**, or **unknown**. Dispatch only for items marked **needs-review** — do NOT re-query the GitHub API for comment checks here; the pre-fetched state is the single source of truth.
 
 **Skip triage review when:**
 
@@ -358,7 +348,7 @@ sleep 2
 
 Issues/PRs with `needs-maintainer-review` can be approved or declined by the maintainer commenting. Each cycle, fetch the maintainer's most recent comment on these items:
 
-- **"approved"** → remove `needs-maintainer-review`, add `status:available` (issues) or allow merge (PRs). If the triage review recommended a specific tier label (e.g., `tier:simple`), apply it.
+- **"approved"** → remove `needs-maintainer-review`, add `auto-dispatch` (issues) or allow merge (PRs). If the triage review recommended a specific tier label (e.g., `tier:simple`), apply it. The `auto-dispatch` label is the established pattern — see the command block in "Cross-Repo TODO Sync" below.
 - **"declined"** → close with the maintainer's reason
 - **Further direction** → if the maintainer's comment doesn't start with "approved" or "declined", treat it as additional context. On the next cycle, if no agent review exists that incorporates this direction, dispatch a new triage review worker with the maintainer's feedback included in the prompt.
 - **No matching comment from maintainer** → skip, check next cycle
@@ -516,7 +506,7 @@ fi
 # Fetch comments and check for maintainer approval/decline
 # Works for both issues and PRs (GitHub's issues API handles both)
 COMMENT_DATA=$(gh api "repos/<slug>/issues/<number>/comments" \
-  --jq "[.[] | select(.user.login == \"$MAINTAINER\")] | last | {body: .body, id: .id}")
+  --jq "[.[] | select(.user.login == \"$MAINTAINER\")] | last | {body: .body, id: .id, created_at: .created_at}")
 COMMENT_BODY=$(echo "$COMMENT_DATA" | jq -r '.body // empty' | tr '[:upper:]' '[:lower:]' | xargs)
 ```
 
@@ -566,8 +556,12 @@ gh pr close <number> --repo <slug> \
 3. **Comment contains further direction** (doesn't start with `approved` or `declined`) — the maintainer is providing feedback. If an agent triage review already exists but was posted BEFORE the maintainer's comment, dispatch a new triage review worker that incorporates the maintainer's feedback:
 
 ```bash
+# Note: COMMENT_DATA must include created_at for this comparison to work.
+# Update the COMMENT_DATA projection earlier in this section to:
+#   --jq "[.[] | select(.user.login == \"$MAINTAINER\")] | last | {body: .body, id: .id, created_at: .created_at}"
+
 # Check if the maintainer's comment is newer than the last agent review
-LAST_REVIEW_DATE=$(gh api "repos/<slug>/issues/<number>/comments" \
+LAST_REVIEW_DATE=$(gh api "repos/<slug>/issues/<number>/comments" --paginate \
   --jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | last | .created_at' 2>/dev/null || echo "")
 MAINTAINER_COMMENT_DATE=$(echo "$COMMENT_DATA" | jq -r '.created_at // empty')
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -94,6 +94,40 @@ release_dispatch_claim NUMBER SLUG "$RUNNER_USER"
 
 Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
 
+### 4.5. Dispatch triage reviews for needs-maintainer-review issues
+
+After filling implementation worker slots, check the pre-fetched "Needs Maintainer Review — Triage Status" section. For each issue marked **needs-review** (no agent review comment yet), dispatch an opus-tier triage review worker. These are operational (no code changes) and use `/review-issue-pr` directly.
+
+```bash
+# Only dispatch if worker slots are available
+# Max 2 triage reviews per pulse cycle (opus-tier, expensive)
+TRIAGE_REVIEW_COUNT=0
+TRIAGE_REVIEW_MAX=2
+
+# For each needs-review issue from the pre-fetched triage status:
+if [[ "$AVAILABLE" -gt 0 && "$TRIAGE_REVIEW_COUNT" -lt "$TRIAGE_REVIEW_MAX" ]]; then
+  RESOLVED_MODEL=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus)
+
+  ~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+    --role worker \
+    --session-key "triage-review-NUMBER" \
+    --dir PATH \
+    --model "$RESOLVED_MODEL" \
+    --title "Triage review: Issue #NUMBER" \
+    --prompt "/review-issue-pr NUMBER" &
+  sleep 2
+
+  TRIAGE_REVIEW_COUNT=$((TRIAGE_REVIEW_COUNT + 1))
+  AVAILABLE=$((AVAILABLE - 1))
+fi
+```
+
+Skip triage reviews when:
+
+- All worker slots are occupied (implementation work takes priority)
+- The issue was created less than 5 minutes ago (give the author time to add context)
+- The maintainer has already commented on the issue (they're already engaged)
+
 ### 5. Record initial dispatch success
 
 ```bash
@@ -135,9 +169,10 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    ```
 
 4. **If slots are open**: check for mergeable PRs (free), then dispatch workers for the
-   highest-priority open issues. Use the same dedup guards and dispatch commands as the
-   initial dispatch. Re-fetch issue state with targeted `gh` calls only for repos where
-   you need to dispatch (not a full re-fetch of all repos).
+   highest-priority open issues, then dispatch triage reviews for unreviewed
+   `needs-maintainer-review` issues (same rules as Step 4.5). Use the same dedup guards
+   and dispatch commands as the initial dispatch. Re-fetch issue state with targeted `gh`
+   calls only for repos where you need to dispatch (not a full re-fetch of all repos).
 
 5. **If fully staffed**: log it, mark the cycle todo complete, continue to next cycle.
 
@@ -247,7 +282,7 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Duplicate issues for same task ID** → keep the one referenced by `ref:GH#` in TODO.md, close others with a comment.
 - **Too large for one worker** → classify with `task-decompose-helper.sh classify`. If composite, decompose into subtask issues, label parent `status:blocked`. Child tasks enter the normal dispatch queue.
 - **`status:queued` or `status:in-progress`** → check `updatedAt`. If updated within 3 hours, skip. If 3+ hours with no PR and no worker, relabel `status:available`, unassign, comment the recovery. Note: issues claimed at creation via `/new-task` option 2 (t1687) will have `status:in-progress` + assignee set immediately, so the pulse correctly skips them during the interactive work window.
-- **`needs-maintainer-review`** → SKIP. Awaiting maintainer review. Do NOT dispatch.
+- **`needs-maintainer-review`** → Do NOT dispatch an implementation worker. Instead, dispatch a **triage review worker** if no agent review comment exists yet (see "Automated triage review" below).
 - **`status:available` or no status (without `needs-maintainer-review`)** → dispatch a worker.
 
 ### External issues and PRs — maintainer review gate (t1545)
@@ -271,13 +306,62 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Destructive behaviour reports** → valid bug, dispatch a fix (no label needed)
 - **Bug fixes and docs PRs** → normal review process
 
+### Automated triage review (opus-tier)
+
+Before waiting for the maintainer to manually review `needs-maintainer-review` issues, the pulse dispatches an opus-tier worker to post a structured analysis and recommendation. This gives the maintainer a pre-digested assessment so they can approve, decline, or provide direction with minimal effort.
+
+**When to dispatch a triage review:**
+
+For each `needs-maintainer-review` issue/PR in the pre-fetched state, check whether an agent review comment already exists. An agent review comment is identified by containing the string `## Issue/PR Review:` or `## Review:` (the structured output format from `review-issue-pr.md`).
+
+```bash
+# Check if an agent review comment already exists
+REVIEW_EXISTS=$(gh api "repos/<slug>/issues/<number>/comments" \
+  --jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | length')
+
+if [[ "$REVIEW_EXISTS" -eq 0 ]]; then
+  # No review yet — dispatch a triage review worker
+fi
+```
+
+**Skip triage review when:**
+
+- An agent review comment already exists (idempotency guard)
+- The maintainer has already commented (approved/declined/direction) — they don't need the review
+- The issue was created less than 5 minutes ago (give the author time to add context)
+- Worker slots are fully occupied with higher-priority work (triage reviews are lower priority than merges, CI fixes, and implementation dispatches)
+
+**Dispatch the triage review worker:**
+
+Triage reviews are operational (no code changes), so they do NOT use `/full-loop`. They use `/review-issue-pr` directly. They use opus tier because the analysis requires deep codebase understanding and architectural judgment.
+
+```bash
+RESOLVED_MODEL=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus)
+
+~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+  --role worker \
+  --session-key "triage-review-<number>" \
+  --dir <path> \
+  --model "$RESOLVED_MODEL" \
+  --title "Triage review: Issue #<number>" \
+  --prompt "/review-issue-pr <number>" &
+sleep 2
+```
+
+**Concurrency cap:** Max 2 triage review workers per pulse cycle. These are opus-tier and expensive — don't flood the worker pool with reviews when implementation work is waiting.
+
+**Priority:** Triage reviews are dispatched AFTER all merges, CI fixes, and implementation dispatches are handled. They fill remaining worker slots. If no slots are available, skip triage reviews this cycle — the issues will still be there next cycle.
+
+**Cost justification:** One opus triage review (~$0.10-0.30) saves the maintainer 10-30 minutes of manual investigation per issue. The review also captures architectural context that would otherwise require the maintainer to read code, check related issues, and trace root causes themselves.
+
 ### Comment-based approval
 
 Issues/PRs with `needs-maintainer-review` can be approved or declined by the maintainer commenting. Each cycle, fetch the maintainer's most recent comment on these items:
 
-- **"approved"** → remove `needs-maintainer-review`, add `status:available` (issues) or allow merge (PRs)
+- **"approved"** → remove `needs-maintainer-review`, add `status:available` (issues) or allow merge (PRs). If the triage review recommended a specific tier label (e.g., `tier:simple`), apply it.
 - **"declined"** → close with the maintainer's reason
-- **No matching comment** → skip, check next cycle
+- **Further direction** → if the maintainer's comment doesn't start with "approved" or "declined", treat it as additional context. On the next cycle, if no agent review exists that incorporates this direction, dispatch a new triage review worker with the maintainer's feedback included in the prompt.
+- **No matching comment from maintainer** → skip, check next cycle
 
 Only process comments from the repo maintainer (from `repos.json` or slug owner).
 
@@ -479,7 +563,37 @@ gh pr close <number> --repo <slug> \
   -c "Closed per maintainer decision. Reason: ${REASON:-no reason given}"
 ```
 
-3. **No matching comment from maintainer** — skip, check again next cycle.
+3. **Comment contains further direction** (doesn't start with `approved` or `declined`) — the maintainer is providing feedback. If an agent triage review already exists but was posted BEFORE the maintainer's comment, dispatch a new triage review worker that incorporates the maintainer's feedback:
+
+```bash
+# Check if the maintainer's comment is newer than the last agent review
+LAST_REVIEW_DATE=$(gh api "repos/<slug>/issues/<number>/comments" \
+  --jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | last | .created_at' 2>/dev/null || echo "")
+MAINTAINER_COMMENT_DATE=$(echo "$COMMENT_DATA" | jq -r '.created_at // empty')
+
+# If maintainer commented after the last review, dispatch a follow-up review
+if [[ -n "$MAINTAINER_COMMENT_DATE" && "$MAINTAINER_COMMENT_DATE" > "$LAST_REVIEW_DATE" ]]; then
+  MAINTAINER_FEEDBACK=$(echo "$COMMENT_DATA" | jq -r '.body // empty')
+  RESOLVED_MODEL=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus)
+
+  ~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+    --role worker \
+    --session-key "triage-review-<number>-followup" \
+    --dir <path> \
+    --model "$RESOLVED_MODEL" \
+    --title "Triage review followup: Issue #<number>" \
+    --prompt "/review-issue-pr <number>
+
+The maintainer provided the following feedback on the previous review:
+---
+${MAINTAINER_FEEDBACK}
+---
+Please incorporate this feedback into your analysis and update your recommendation." &
+  sleep 2
+fi
+```
+
+4. **No matching comment from maintainer** — skip, check again next cycle.
 
 **How to distinguish issues from PRs:** Check the pre-fetched state — PRs have a `headRefName` field, issues don't. Alternatively, use `gh api repos/<slug>/issues/<number> --jq '.pull_request // empty'` — non-empty means it's a PR.
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -295,7 +295,7 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 2. Workflow checks `authorAssociation` — if not OWNER/MEMBER/COLLABORATOR, applies `needs-maintainer-review` label and posts a welcome comment
 3. Pulse sees `needs-maintainer-review` → **skip, do not dispatch**
 4. Maintainer reviews the issue and either:
-   - Removes `needs-maintainer-review` and adds `status:available` → dispatchable next cycle
+   - Removes `needs-maintainer-review` and adds `auto-dispatch` → dispatchable next cycle
    - Asks for more information → keeps label
    - Closes as duplicate/invalid/out-of-scope
 
@@ -505,7 +505,8 @@ fi
 
 # Fetch comments and check for maintainer approval/decline
 # Works for both issues and PRs (GitHub's issues API handles both)
-COMMENT_DATA=$(gh api "repos/<slug>/issues/<number>/comments" \
+# --paginate ensures all comments are fetched on issues with many comments
+COMMENT_DATA=$(gh api "repos/<slug>/issues/<number>/comments" --paginate \
   --jq "[.[] | select(.user.login == \"$MAINTAINER\")] | last | {body: .body, id: .id, created_at: .created_at}")
 COMMENT_BODY=$(echo "$COMMENT_DATA" | jq -r '.body // empty' | tr '[:upper:]' '[:lower:]' | xargs)
 ```
@@ -556,10 +557,6 @@ gh pr close <number> --repo <slug> \
 3. **Comment contains further direction** (doesn't start with `approved` or `declined`) — the maintainer is providing feedback. If an agent triage review already exists but was posted BEFORE the maintainer's comment, dispatch a new triage review worker that incorporates the maintainer's feedback:
 
 ```bash
-# Note: COMMENT_DATA must include created_at for this comparison to work.
-# Update the COMMENT_DATA projection earlier in this section to:
-#   --jq "[.[] | select(.user.login == \"$MAINTAINER\")] | last | {body: .body, id: .id, created_at: .created_at}"
-
 # Check if the maintainer's comment is newer than the last agent review
 LAST_REVIEW_DATE=$(gh api "repos/<slug>/issues/<number>/comments" --paginate \
   --jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | last | .created_at' 2>/dev/null || echo "")

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2713,13 +2713,24 @@ prefetch_triage_review_status() {
 			created_at=$(echo "$nmr_json" | jq -r ".[$i].createdAt")
 
 			# Check for agent review comment (contains "## Review:" or "## Issue/PR Review:")
+			# Use --paginate to handle issues with many comments (default page size is 30).
+			# On API failure, mark as "unknown" rather than falsely reporting "needs-review".
+			local review_response=""
 			local review_exists=0
-			review_exists=$(gh api "repos/${slug}/issues/${number}/comments" \
-				--jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | length' 2>/dev/null) || review_exists=0
-			[[ "$review_exists" =~ ^[0-9]+$ ]] || review_exists=0
+			local api_ok=true
+			review_response=$(gh api "repos/${slug}/issues/${number}/comments" --paginate \
+				--jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | length' 2>/dev/null) || api_ok=false
+
+			if [[ "$api_ok" == true ]]; then
+				review_exists="$review_response"
+				[[ "$review_exists" =~ ^[0-9]+$ ]] || review_exists=0
+			fi
 
 			local status_label
-			if [[ "$review_exists" -gt 0 ]]; then
+			if [[ "$api_ok" != true ]]; then
+				status_label="unknown"
+				echo "[pulse-wrapper] API error checking review status for ${slug}#${number}" >>"$LOGFILE"
+			elif [[ "$review_exists" -gt 0 ]]; then
 				status_label="reviewed"
 			else
 				status_label="needs-review"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -748,6 +748,15 @@ _append_prefetch_sub_helpers() {
 	cat "$ghfail_tmp" >>"$STATE_FILE"
 	rm -f "$ghfail_tmp"
 
+	# Append needs-maintainer-review triage status for automated review dispatch
+	local triage_tmp
+	triage_tmp=$(mktemp)
+	run_cmd_with_timeout 30 prefetch_triage_review_status "$repo_entries" >"$triage_tmp" 2>/dev/null || {
+		echo "[pulse-wrapper] prefetch_triage_review_status timed out after 30s (non-fatal)" >>"$LOGFILE"
+	}
+	cat "$triage_tmp" >>"$STATE_FILE"
+	rm -f "$triage_tmp"
+
 	return 0
 }
 
@@ -2642,6 +2651,93 @@ prefetch_contribution_watch() {
 			echo ""
 		}
 		echo "[pulse-wrapper] Contribution watch: ${cw_count} items need attention" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+#######################################
+# Pre-fetch triage review status for needs-maintainer-review issues
+#
+# For each pulse-enabled repo, finds issues with the needs-maintainer-review
+# label and checks whether an agent triage review comment already exists.
+# This data enables the pulse to dispatch opus-tier review workers only
+# for issues that haven't been reviewed yet.
+#
+# Detection: an agent review comment contains "## Review:" or
+# "## Issue/PR Review:" in the body (the structured output format
+# from review-issue-pr.md).
+#
+# Arguments:
+#   $1 - repo_entries (slug|path pairs, one per line)
+# Output: triage review status section to stdout
+#######################################
+prefetch_triage_review_status() {
+	local repo_entries="$1"
+	local found_any=false
+	local total_pending=0
+
+	while IFS='|' read -r slug path; do
+		[[ -n "$slug" ]] || continue
+
+		# Get needs-maintainer-review issues for this repo
+		local nmr_json
+		nmr_json=$(gh issue list --repo "$slug" --label "needs-maintainer-review" \
+			--state open --json number,title,createdAt,updatedAt \
+			--limit 50 2>/dev/null) || nmr_json="[]"
+
+		local nmr_count
+		nmr_count=$(echo "$nmr_json" | jq 'length')
+		[[ "$nmr_count" -gt 0 ]] || continue
+
+		if [[ "$found_any" == false ]]; then
+			echo ""
+			echo "# Needs Maintainer Review — Triage Status"
+			echo ""
+			echo "Issues with \`needs-maintainer-review\` label and their automated triage review status."
+			echo "Dispatch an opus-tier \`/review-issue-pr\` worker for items marked **needs-review**."
+			echo "Max 2 triage review dispatches per pulse cycle."
+			echo ""
+			found_any=true
+		fi
+
+		echo "## ${slug}"
+		echo ""
+
+		# Check each issue for an existing agent review comment
+		local i=0
+		while [[ "$i" -lt "$nmr_count" ]]; do
+			local number title created_at
+			number=$(echo "$nmr_json" | jq -r ".[$i].number")
+			title=$(echo "$nmr_json" | jq -r ".[$i].title")
+			created_at=$(echo "$nmr_json" | jq -r ".[$i].createdAt")
+
+			# Check for agent review comment (contains "## Review:" or "## Issue/PR Review:")
+			local review_exists=0
+			review_exists=$(gh api "repos/${slug}/issues/${number}/comments" \
+				--jq '[.[] | select(.body | test("## (Issue/PR )?Review:"))] | length' 2>/dev/null) || review_exists=0
+			[[ "$review_exists" =~ ^[0-9]+$ ]] || review_exists=0
+
+			local status_label
+			if [[ "$review_exists" -gt 0 ]]; then
+				status_label="reviewed"
+			else
+				status_label="needs-review"
+				total_pending=$((total_pending + 1))
+			fi
+
+			echo "- Issue #${number}: ${title} [status: **${status_label}**] [created: ${created_at}]"
+
+			i=$((i + 1))
+		done
+
+		echo ""
+	done <<<"$repo_entries"
+
+	if [[ "$found_any" == true ]]; then
+		echo "**Total pending triage reviews: ${total_pending}**"
+		echo ""
+		echo "[pulse-wrapper] Triage review status: ${total_pending} issues pending review" >>"$LOGFILE"
 	fi
 
 	return 0

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -1,5 +1,5 @@
 ---
-description: Review external issues and PRs - validate problems and evaluate proposed solutions
+description: Review external issues and PRs - validate problems and evaluate proposed solutions. Used interactively and by the pulse supervisor for automated triage of needs-maintainer-review items.
 mode: subagent
 tools:
   read: true
@@ -18,9 +18,10 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Triage and review issues/PRs submitted by external contributors
+- **Purpose**: Triage and review issues/PRs — interactive or pulse-automated
 - **Focus**: Validate the problem exists, evaluate if the solution is optimal
-- **When**: Before approving/merging external contributions
+- **When**: Before approving/merging contributions, or automatically by the pulse for `needs-maintainer-review` items
+- **Modes**: Interactive (user invokes `/review-issue-pr`) or headless (pulse dispatches for triage)
 
 **Core Questions**:
 
@@ -115,8 +116,10 @@ gh pr diff 456 --stat
 
 ## Review Output Format
 
+The review comment MUST contain `## Review:` or `## Issue/PR Review:` in the heading — this is the marker the pulse uses to detect whether a triage review has already been posted (idempotency guard).
+
 ```markdown
-## Issue/PR Review: #123 - [Title]
+## Review: Approved / Needs Changes / Decline
 
 ### Issue Validation
 
@@ -129,7 +132,7 @@ gh pr diff 456 --stat
 
 **Root Cause**: [Brief description]
 
-### Solution Evaluation
+### Solution Evaluation (if PR or proposed fix)
 
 | Criterion | Assessment | Notes |
 |-----------|------------|-------|
@@ -138,28 +141,39 @@ gh pr diff 456 --stat
 | Completeness | Good/Needs Work | [edge cases covered?] |
 | Consistency | Good/Needs Work | [follows patterns?] |
 
-**Alternative Approaches Considered**:
-1. [Alternative 1] - [why not chosen]
+**Alternative Approaches (Recommended)**:
+1. [Recommended approach] - [why]
 
 ### Scope Assessment
 
-- [ ] All changes documented in PR description
-- [ ] No unrelated changes
-- [ ] Minimal diff for the fix
-- [ ] No "while I was here" additions
-
-**Undocumented Changes**: [list any, or "None"]
+- Scope creep risk: Low/Medium/High
+- Complexity: Low (tier:simple) / Medium (default sonnet) / High (tier:thinking)
 
 ### Recommendation
 
-**Decision**: APPROVE / REQUEST CHANGES / CLOSE
+**Decision**: APPROVE / REQUEST CHANGES / DECLINE
 
-**Required Changes** (if any):
-1. [Change 1]
+**Suggested labels**: [e.g., `tier:simple`, `bug`, `status:available`]
 
-**Suggestions** (optional):
-1. [Suggestion 1]
+**Implementation guidance** (if approving):
+1. [Key implementation step]
+2. [Test case to add]
 ```
+
+## Headless / Pulse-Driven Mode
+
+When invoked by the pulse supervisor (via `/review-issue-pr <number>`), this workflow runs headlessly:
+
+1. **Fetch the issue/PR** using `gh issue view` or `gh pr view`
+2. **Read the relevant codebase files** referenced in the issue body
+3. **Perform the full review checklist** (problem validation, root cause, solution evaluation, scope)
+4. **Post the review as a comment** on the issue/PR using `gh issue comment` or `gh pr comment`
+5. **Do NOT modify labels** — the pulse handles label transitions based on the maintainer's response
+6. **Exit cleanly** — this is an operational task, not a code change. No worktree, no PR, no commit.
+
+**The review comment is the only output.** The pulse detects it on the next cycle and knows the issue has been triaged. The maintainer reads the review and responds with "approved", "declined", or further direction.
+
+**Incorporating maintainer feedback:** If the dispatch prompt includes prior maintainer comments (e.g., "The maintainer asked: can this be done without adding a dependency?"), incorporate that context into the review. Address the maintainer's specific concerns in the analysis.
 
 ## Common Scenarios
 


### PR DESCRIPTION
## Summary

- Pulse now proactively dispatches opus-tier workers to analyze `needs-maintainer-review` issues and post structured review comments with recommendations
- Maintainer can respond with "approved", "declined", or further direction — the pulse handles each case including follow-up reviews incorporating feedback
- Pre-fetched state includes triage review status so the pulse knows which issues need reviews vs already have them

## Changes

### `pulse.md`
- **Step 4.5**: New triage review dispatch step after implementation dispatches, capped at 2 per cycle
- **Automated triage review section**: Full specification of when/how to dispatch reviews, skip conditions, concurrency cap, cost justification
- **Comment-based approval**: Updated to handle "further direction" (outcome 3) — dispatches follow-up review with maintainer feedback
- **Monitoring loop**: Updated to include triage reviews during backfill

### `pulse-wrapper.sh`
- **`prefetch_triage_review_status()`**: New function that scans `needs-maintainer-review` issues across all pulse-enabled repos and checks each for existing agent review comments (detected by `## Review:` / `## Issue/PR Review:` markers)
- Integrated into `_append_prefetch_sub_helpers()` with 30s timeout (non-fatal on failure)

### `review-issue-pr.md`
- **Headless/pulse-driven mode**: New section documenting how the workflow operates when dispatched by the pulse (no labels, no worktree, comment-only output)
- **Output format**: Updated with idempotency marker requirement, tier/label suggestions, and streamlined scope assessment
- **Description**: Updated to reflect dual-mode usage (interactive + automated)

## Flow

```
Issue created with needs-maintainer-review
    ↓
Pulse prefetch detects it (status: needs-review)
    ↓
Pulse dispatches opus-tier /review-issue-pr worker
    ↓
Worker posts structured review comment
    ↓
Maintainer reads review, comments:
  "approved"  → pulse removes label, adds status:available
  "declined"  → pulse closes issue
  direction   → pulse dispatches follow-up review with feedback
```

## Testing

- ShellCheck: clean on pulse-wrapper.sh
- markdownlint: clean on both .md files
- Self-assessed: prompt-level changes, no runtime code paths affected until next pulse cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated triage review phase for items needing maintainer review, improving triage efficiency.

* **Improvements**
  * Enhanced triage review detection and status tracking across repositories.
  * Updated review workflow to support both interactive and automated operating modes.
  * Improved maintainer feedback integration into triage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->