### PR TITLE
GH#10308: Fix duplicate issue creation between quality sweep and pulse LLM

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -418,6 +418,31 @@ Serial merge for quality-debt: do not dispatch a second quality-debt worker for 
 
 Close quality-debt PRs that have been CONFLICTING for 24+ hours with a comment explaining they'll be superseded by smaller PRs. Relabel corresponding issues `status:available`.
 
+### Sweep-pulse dedup (GH#10308)
+
+The quality sweep (`stats-functions.sh`) and the pulse LLM are two independent systems that
+both discover code quality findings. Without coordination, they create duplicate issues for
+the same problems. The dedup contract:
+
+1. **The sweep creates issues with `source:quality-sweep` or `source:review-feedback` labels.**
+   These are the authoritative tracker for findings from ShellCheck, Qlty, SonarCloud, Codacy,
+   CodeRabbit, and merged PR review feedback.
+
+2. **The pre-fetched state separates sweep-tracked issues** into an "Already Tracked by Quality
+   Sweep" section. These issues are already filed — do NOT create new issues for the same
+   findings. Dispatch them as normal quality-debt/simplification-debt work when slots are
+   available.
+
+3. **Before creating any quality-related issue**, check whether an existing `quality-debt` or
+   `simplification-debt` issue already covers the same file or finding. Search by file path
+   in the title: `gh issue list --repo SLUG --label quality-debt --label simplification-debt
+   --state open --search "in:title FILENAME"`. If a match exists, skip creation.
+
+4. **The dashboard issue (labelled `persistent` + `quality-review`) is a reporting snapshot**
+   that may lag behind the codebase. The codebase is the primary source of truth. Do NOT
+   use dashboard findings as the sole basis for creating new issues — always verify against
+   the existing issue backlog first.
+
 ## Cross-Repo TODO Sync
 
 Issue creation (push) is handled exclusively by CI. The pulse runs pull and close only:

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -594,15 +594,38 @@ _prefetch_single_repo() {
 		local issue_count
 		issue_count=$(echo "$filtered_json" | jq 'length')
 
-		if [[ "$issue_count" -gt 0 ]]; then
-			echo "### Open Issues ($issue_count)"
-			echo "$filtered_json" | jq -r '.[] | "- Issue #\(.number): \(.title) [labels: \(if (.labels | length) == 0 then "none" else (.labels | map(.name) | join(", ")) end)] [assignees: \(if (.assignees | length) == 0 then "none" else (.assignees | map(.login) | join(", ")) end)] [updated: \(.updatedAt)]"'
+		# GH#10308: Split issues into dispatchable vs quality-sweep-tracked.
+		# The sweep (stats-functions.sh) creates quality-debt and simplification-debt
+		# issues with source:quality-sweep labels. Showing these separately prevents
+		# the pulse LLM from independently creating duplicate issues for the same
+		# findings it reads from the quality dashboard comments.
+		local dispatchable_json sweep_tracked_json
+		dispatchable_json=$(echo "$filtered_json" | jq '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")) | not)]')
+		sweep_tracked_json=$(echo "$filtered_json" | jq '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")))]')
+
+		local dispatchable_count sweep_tracked_count
+		dispatchable_count=$(echo "$dispatchable_json" | jq 'length')
+		sweep_tracked_count=$(echo "$sweep_tracked_json" | jq 'length')
+
+		if [[ "$dispatchable_count" -gt 0 ]]; then
+			echo "### Open Issues ($dispatchable_count)"
+			echo "$dispatchable_json" | jq -r '.[] | "- Issue #\(.number): \(.title) [labels: \(if (.labels | length) == 0 then "none" else (.labels | map(.name) | join(", ")) end)] [assignees: \(if (.assignees | length) == 0 then "none" else (.assignees | map(.login) | join(", ")) end)] [updated: \(.updatedAt)]"'
 		else
 			echo "### Open Issues (0)"
 			echo "- None"
 		fi
 
 		echo ""
+
+		# GH#10308: Show quality-sweep-tracked issues so the LLM knows what's
+		# already filed and avoids creating duplicates from sweep findings.
+		if [[ "$sweep_tracked_count" -gt 0 ]]; then
+			echo "### Already Tracked by Quality Sweep ($sweep_tracked_count)"
+			echo "_These issues were auto-created by the quality sweep or review feedback pipeline._"
+			echo "_DO NOT create new issues for findings already covered below. Dispatch these as normal quality-debt/simplification-debt work._"
+			echo "$sweep_tracked_json" | jq -r '.[] | "- Issue #\(.number): \(.title) [labels: \(if (.labels | length) == 0 then "none" else (.labels | map(.name) | join(", ")) end)] [assignees: \(if (.assignees | length) == 0 then "none" else (.assignees | map(.login) | join(", ")) end)]"'
+			echo ""
+		fi
 	} >"$outfile"
 	return 0
 }

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -1351,8 +1351,10 @@ update_health_issues() {
 #   4. Codacy — via API if CODACY_API_TOKEN available
 #   5. SonarCloud — via API if sonar-project.properties exists
 #
-# The supervisor (LLM) reads the comment on the next pulse and creates
-# actionable GitHub issues for findings that warrant fixes.
+# The sweep creates simplification-debt issues directly (with
+# source:quality-sweep label). The pulse LLM dispatches these as normal
+# work — it should NOT independently create issues for the same findings.
+# See GH#10308 for the sweep-pulse dedup contract.
 #######################################
 run_daily_quality_sweep() {
 	# Time-of-day gate — only run during Anthropic's 2x usage boost hours.
@@ -2873,7 +2875,9 @@ _build_quality_issue_body() {
 ${bot_coverage_section}
 
 ---
-_Auto-updated by daily quality sweep. Comments below contain detailed findings per sweep. Do not edit manually._
+_Auto-updated by daily quality sweep. Findings as of \`${sweep_time}\` — may not reflect recent merges between sweeps._
+_The codebase is the primary source of truth. This dashboard is a reporting snapshot that may lag behind reality._
+_Do not edit manually._
 BODY
 	return 0
 }


### PR DESCRIPTION
## Summary

Closes #10308

The quality sweep (`stats-functions.sh`) and pulse LLM independently discover the same code quality findings and create separate GitHub issues, causing duplicate work dispatch and wasted compute.

### Root cause

Two independent code paths create issues for the same findings:
1. **Quality sweep** — runs on cron, creates `simplification-debt` and `quality-debt` issues with `source:quality-sweep` labels
2. **Pulse LLM** — reads sweep findings from the persistent dashboard issue comments, independently discovers the same problems, and creates new issues without checking what's already tracked

The prefetch filter at `pulse-wrapper.sh:592` correctly hides `persistent`/`quality-review` issues from the LLM (to prevent it from closing them), but doesn't distinguish sweep-tracked actionable issues from other issues — so the LLM doesn't know which findings are already filed.

### Changes

- **`pulse-wrapper.sh`**: Split prefetched issues into dispatchable vs sweep-tracked (`source:quality-sweep`/`source:review-feedback` labels). Sweep-tracked issues appear in a separate "Already Tracked by Quality Sweep" section with explicit DO NOT DUPLICATE guidance for the LLM.
- **`pulse.md`**: Added "Sweep-pulse dedup (GH#10308)" section with a 4-point dedup contract: (1) sweep creates authoritative issues with source labels, (2) prefetch separates them, (3) LLM must search before creating, (4) dashboard is secondary to codebase.
- **`stats-functions.sh`**: Added staleness disclaimer to dashboard body ("Findings as of {timestamp} — may not reflect recent merges"), updated sweep docstring to reference the dedup contract.

### Testing

- `shellcheck` — both modified shell scripts pass clean
- `markdownlint` — pulse.md passes clean
- Risk level: **Low** — changes are additive (new prefetch section, new docs section, updated disclaimer). No existing behavior removed. The jq filters are straightforward label checks following the existing pattern at line 592.

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (agent prompt guidance + prefetch formatting — no runtime behavior changes)
- The fix operates at the LLM instruction level (what the pulse sees in prefetched state) and documentation level (what pulse.md tells it to do). No new code paths, no state mutations, no API changes.