### PR TITLE
GH#11470: Detect stale Homebrew install during aidevops update

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -715,6 +715,32 @@ _update_check_tools() {
 	return 0
 }
 
+# Check for stale Homebrew-installed copy after git update (GH#11470)
+_update_check_homebrew() {
+	command -v brew &>/dev/null || return 0
+	brew list aidevops &>/dev/null 2>&1 || return 0
+	local brew_version=""
+	brew_version=$(brew info aidevops --json=v2 2>/dev/null | jq -r '.formulae[0].installed[0].version // empty' 2>/dev/null || true)
+	[[ -z "$brew_version" ]] && return 0
+	local current_version
+	current_version=$(get_version)
+	[[ -z "$current_version" ]] && return 0
+	if [[ "$brew_version" != "$current_version" ]]; then
+		echo ""
+		print_warning "Homebrew-installed copy is outdated ($brew_version vs $current_version)"
+		print_info "The Homebrew wrapper should prefer your git copy, but if your PATH"
+		print_info "resolves the Homebrew libexec copy directly, you'll run the old version."
+		echo ""
+		read -r -p "Run 'brew upgrade aidevops' now? [y/N] " response
+		if [[ "$response" =~ ^[Yy]$ ]]; then
+			brew upgrade aidevops 2>&1 || print_warning "brew upgrade failed — run manually: brew upgrade aidevops"
+		else
+			print_info "Run 'brew upgrade aidevops' to sync the Homebrew copy"
+		fi
+	fi
+	return 0
+}
+
 # Update/upgrade command
 cmd_update() {
 	local skip_project_sync=false
@@ -802,6 +828,7 @@ cmd_update() {
 	fi
 
 	_update_sync_projects "$skip_project_sync" "$(get_version)"
+	_update_check_homebrew
 	_update_check_planning
 	_update_check_tools
 	return 0


### PR DESCRIPTION
## Summary

- Adds `_update_check_homebrew()` to `cmd_update()` that detects when the Homebrew-installed copy of aidevops is out of sync with the git repo version
- Compares `brew info aidevops` installed version against `get_version()` and warns with an offer to run `brew upgrade aidevops`
- Follows the existing `_update_check_*` pattern used by `_update_check_planning` and `_update_check_tools`

## Root Cause

When a user has both a git clone and Homebrew install, `aidevops update` updates the git copy but leaves the Homebrew `libexec` copy stale. The Homebrew wrapper prefers `$HOME/Git/aidevops/aidevops.sh` if it exists, but if the git repo path doesn't match or PATH resolves the `libexec` copy directly, the user runs the old version without knowing.

## Testing

- No Homebrew install: `_update_check_homebrew` returns immediately (line 720-721)
- Homebrew installed, versions match: no output
- Homebrew installed, versions differ: warns and offers `brew upgrade`
- ShellCheck: zero violations

Closes #11470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic Homebrew installation update check during the update command. When your installed package version differs from the latest CLI version, you'll receive a warning with options to upgrade automatically or upgrade manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->