### PR TITLE
fix(#11702): resolve BASH_SOURCE[0] symlink in shellcheck wrapper fast-path

### DIFF
--- a/.agents/scripts/shellcheck-wrapper.sh
+++ b/.agents/scripts/shellcheck-wrapper.sh
@@ -107,10 +107,22 @@ _find_real_shellcheck() {
 
 	# Fast path: check .real sibling of this script's location first.
 	# When setup.sh replaces the binary, it moves it to shellcheck.real.
-	# This avoids expensive PATH scanning and realpath resolution.
-	local self_dir
-	self_dir="$(dirname "${BASH_SOURCE[0]}" 2>/dev/null || echo ".")"
+	# Resolve symlinks before computing self_dir so that when the wrapper is
+	# invoked via a symlink (e.g. /opt/homebrew/bin/shellcheck → Cellar path),
+	# self_dir reflects the symlink's directory (/opt/homebrew/bin/) where the
+	# .real sibling lives — not the Cellar directory the symlink resolves to.
+	local self_resolved
+	self_resolved="$(realpath "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+	# Also check the unresolved (symlink) directory — covers the case where
+	# setup.sh placed the wrapper at the symlink path and .real is co-located.
+	local self_dir self_link_dir
+	self_dir="$(dirname "$self_resolved" 2>/dev/null || echo ".")"
+	self_link_dir="$(dirname "${BASH_SOURCE[0]}" 2>/dev/null || echo ".")"
 	local sibling="${self_dir}/shellcheck.real"
+	# If the resolved and unresolved dirs differ, also check the symlink dir
+	if [[ "$self_dir" != "$self_link_dir" && ! -x "$sibling" ]]; then
+		sibling="${self_link_dir}/shellcheck.real"
+	fi
 	if [[ -x "$sibling" ]]; then
 		printf '%s' "$sibling"
 		return 0
@@ -126,8 +138,8 @@ _find_real_shellcheck() {
 	done
 
 	# Slow path: search PATH, skipping this wrapper script and any copies of it
-	local self
-	self="$(realpath "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+	# Reuse self_resolved computed above (avoids redundant realpath call)
+	local self="$self_resolved"
 
 	local dir
 	while IFS= read -r -d ':' dir || [[ -n "$dir" ]]; do


### PR DESCRIPTION
## Summary

- Resolves `BASH_SOURCE[0]` with `realpath` before computing `self_dir` in `_find_real_shellcheck()`, so the sibling `.real` check works when the wrapper is invoked via a symlink (e.g. `/opt/homebrew/bin/shellcheck` → Cellar path)
- Adds a fallback to also check the unresolved (symlink) directory when the resolved and unresolved dirs differ — covers both installation layouts
- Reuses `self_resolved` in the slow-path to avoid a redundant `realpath` call

## Root Cause

When `setup.sh` resolves `realpath` on the wrapper path, it may install the wrapper at the Cellar path (`/opt/homebrew/Cellar/shellcheck/0.11.0/bin/shellcheck`). When the binary is then invoked via the `/opt/homebrew/bin/shellcheck` symlink, `BASH_SOURCE[0]` is the symlink path but `dirname` of the unresolved path gives `/opt/homebrew/bin/` — where `.real` lives. The old code used `dirname "${BASH_SOURCE[0]}"` directly (no symlink resolution), so `self_dir` was the Cellar directory, where no `.real` sibling exists. The fast-path fell through to the hardcoded list, which also missed the `.real` on machines where the Cellar version path differed.

## Testing

- ShellCheck passes clean on the modified script (zero violations)
- Functional test: wrapper invoked via symlink from a test directory correctly finds and runs the real binary (`ShellCheck version: 0.11.0`)
- Regression: wrapper invoked directly (no symlink) continues to work

## Runtime Testing

- **Risk level**: Low (shell script utility, no runtime state, no user-facing features)
- **Level**: `self-assessed` — script logic verified via direct invocation test
- **Smoke check**: `bash shellcheck-wrapper.sh --version` → `ShellCheck version: 0.11.0` ✓

## Files Changed

- `.agents/scripts/shellcheck-wrapper.sh` — fix `_find_real_shellcheck()` fast-path symlink resolution; reuse `self_resolved` in slow-path

Closes #11702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced symlink path handling in shellcheck wrapper for proper binary resolution when invoked via symlinks

* **Performance**
  * Optimized path resolution logic by eliminating redundant computations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->