### PR TITLE
feat: Add signature footer to GitHub issues, PRs, and comments

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -185,6 +185,12 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 3. Add TODO entry WITH `ref:GH#NNN` in same commit. Split commits → duplicate issues.
 4. Code changes still need worktree + PR.
 
+**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id>` to generate it, or compose manually:
+```
+\n---\n[CLI Name](url) vX.Y.Z, [aidevops.sh](https://aidevops.sh) vX.Y.Z, provider/model-id, N tokens
+```
+Tokens are optional (omit when unavailable). The helper auto-detects the runtime CLI and aidevops version. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 
 **Pulse scope (t1405):** `PULSE_SCOPE_REPOS` limits code changes. Issues allowed anywhere. Empty/unset = no restriction.

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -38,6 +38,9 @@ pr_body='WIP - incremental commits'
 [[ -n "$gh_issue" ]] && pr_body="${pr_body}
 
 Ref #${gh_issue}"
+# Append signature footer (auto-detects CLI, aidevops version)
+SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" 2>/dev/null || echo "")
+pr_body="${pr_body}${SIG_FOOTER}"
 gh pr create --draft --title '<task-id>: <description>' --body "$pr_body"
 ```
 

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -185,7 +185,7 @@ if [[ "$REPO_SLUG" == "marcusquinn/aidevops" ]]; then
 fi
 ```
 
-**4.7 Issue Closing Comment (MANDATORY):** Post structured comment on every linked issue: **What was done**, **Testing Evidence** (level: `runtime-verified`/`self-assessed`/`untested`, smoke checks), **Key decisions**, **Files changed** (path — what/why), **Blockers**, **Follow-up needs**, **Released in** (aidevops only). Every section ≥1 bullet ("None"/"N/A" if empty). Gate — no `FULL_LOOP_COMPLETE` until posted.
+**4.7 Issue Closing Comment (MANDATORY):** Post structured comment on every linked issue: **What was done**, **Testing Evidence** (level: `runtime-verified`/`self-assessed`/`untested`, smoke checks), **Key decisions**, **Files changed** (path — what/why), **Blockers**, **Follow-up needs**, **Released in** (aidevops only). Every section ≥1 bullet ("None"/"N/A" if empty). Append a signature footer (see `build.txt` "GitHub comment signature footer" — use `gh-signature-helper.sh footer --model <model>`). Gate — no `FULL_LOOP_COMPLETE` until posted.
 
 ### 4.8 Worktree Cleanup (GH#6740 — MANDATORY)
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -670,16 +670,16 @@ Every comment the supervisor posts on an issue or PR must be **sufficient for a 
 
 When dispatching a worker, comment on the issue with:
 
-Read the aidevops version: `AIDEVOPS_VERSION=$(cat ~/.aidevops/agents/VERSION 2>/dev/null || echo "unknown")`.
+Generate the signature footer: `SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<full model ID>")`.
 
 ```bash
+SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<full model ID, e.g., anthropic/claude-sonnet-4-6>")
 gh issue comment <number> --repo <slug> --body "Dispatching worker.
-- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v${AIDEVOPS_VERSION}
-- **Model**: <tier and full model ID, e.g., sonnet (anthropic/claude-sonnet-4-6)>
 - **Branch**: <branch name, e.g., fix/t748-ai-migration>
 - **Scope**: <1-line description of what the worker should do>
 - **Attempt**: <N of M, e.g., 1 of 1, or 3 of 3 (escalated to opus)>
-- **Direction**: <any specific guidance, e.g., 'focus on migration chain from PR #213'>"
+- **Direction**: <any specific guidance, e.g., 'focus on migration chain from PR #213'>
+${SIG_FOOTER}"
 ```
 
 **Required fields in kill/failure comments:**
@@ -687,13 +687,13 @@ gh issue comment <number> --repo <slug> --body "Dispatching worker.
 When killing a worker or closing a failed PR, comment with:
 
 ```bash
+SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<tier used>")
 gh issue comment <number> --repo <slug> --body "Worker killed after <duration> with <N> commits (struggle_ratio: <ratio>).
-- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v${AIDEVOPS_VERSION}
-- **Model**: <tier used>
 - **Branch**: <branch name>
 - **Reason**: <why it was killed — thrashing, timeout, CI loop, etc.>
 - **Diagnosis**: <1-line hypothesis of what went wrong>
-- **Next action**: <re-dispatch at same tier / escalate to opus / needs manual review>"
+- **Next action**: <re-dispatch at same tier / escalate to opus / needs manual review>
+${SIG_FOOTER}"
 # IMPORTANT: <duration> MUST come from the process_uptime field in the Active
 # Workers pre-fetched data (sourced from ps etime = actual process lifetime).
 # Do NOT compute duration from dispatch comment timestamps, branch ages, or
@@ -706,11 +706,11 @@ gh issue comment <number> --repo <slug> --body "Worker killed after <duration> w
 When merging a PR or closing an issue as done:
 
 ```bash
+SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<tier that succeeded>")
 gh issue comment <number> --repo <slug> --body "Completed via PR #<N>.
-- **[aidevops.sh](https://github.com/marcusquinn/aidevops)**: v${AIDEVOPS_VERSION}
-- **Model**: <tier that succeeded>
 - **Attempts**: <total attempts including failures>
-- **Duration**: <wall-clock from first dispatch to merge>"
+- **Duration**: <wall-clock from first dispatch to merge>
+${SIG_FOOTER}"
 ```
 
 **Why this matters:** Without these fields, auditing a task requires reading pulse logs, cross-referencing `ps` output timestamps, and guessing which model was used. The t748 incident had 7 kill comments that all said "Worker killed after Xh with 0 commits" but none recorded the model tier, making it impossible to determine whether escalation was attempted. Issue comments are the state dashboard — they must be self-contained.

--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -342,6 +342,16 @@ This issue was automatically routed to the aidevops framework repo by \`framewor
 Filed from: $(git rev-parse --show-toplevel 2>/dev/null || echo 'unknown repo')"
 	fi
 
+	# Append signature footer
+	local sig_helper="${SCRIPT_DIR}/gh-signature-helper.sh"
+	if [[ -x "$sig_helper" ]]; then
+		local sig_footer
+		sig_footer=$("$sig_helper" footer 2>/dev/null || echo "")
+		if [[ -n "$sig_footer" ]]; then
+			body="${body}${sig_footer}"
+		fi
+	fi
+
 	if [[ "$dry_run" == "true" ]]; then
 		log_info "DRY RUN — would create issue on ${AIDEVOPS_SLUG}:"
 		log_info "  Title: $title"

--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -649,6 +649,16 @@ create_or_preview_issue() {
 		return 0
 	fi
 
+	# Append signature footer
+	local sig_helper="${SCRIPT_DIR}/gh-signature-helper.sh"
+	if [[ -x "$sig_helper" ]]; then
+		local sig_footer
+		sig_footer=$("$sig_helper" footer 2>/dev/null || echo "")
+		if [[ -n "$sig_footer" ]]; then
+			body="${body}${sig_footer}"
+		fi
+	fi
+
 	local create_cmd=(gh issue create --repo "$repo_slug" --title "$title" --body "$body" --label bug --label "source:ci-failure-miner")
 	local label
 	for label in ${extra_labels[@]+"${extra_labels[@]}"}; do

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# =============================================================================
+# gh-signature-helper.sh — Generate signature footer for GitHub comments
+# =============================================================================
+#
+# Produces a one-line signature footer for issues, PRs, and comments created
+# by aidevops agents. Format:
+#
+#   ---
+#   [OpenCode CLI](https://opencode.ai) v1.3.3, [aidevops.sh](https://aidevops.sh) v3.5.6, anthropic/opus-4-6, 1,234 tokens
+#
+# Usage:
+#   gh-signature-helper.sh generate [--model MODEL] [--tokens N] [--cli NAME] [--cli-version VER]
+#   gh-signature-helper.sh footer   [--model MODEL] [--tokens N] [--cli NAME] [--cli-version VER]
+#   gh-signature-helper.sh help
+#
+# The "generate" command outputs just the signature line (no leading ---).
+# The "footer" command outputs the full footer block (--- + newline + signature).
+#
+# Environment variables (override auto-detection):
+#   AIDEVOPS_SIG_CLI          CLI name (e.g., "OpenCode CLI")
+#   AIDEVOPS_SIG_CLI_VERSION  CLI version (e.g., "1.3.3")
+#   AIDEVOPS_SIG_MODEL        Model ID (e.g., "anthropic/opus-4-6")
+#   AIDEVOPS_SIG_TOKENS       Token count (e.g., "1234")
+#
+# Dependencies: lib/version.sh (aidevops version), aidevops-update-check.sh (CLI detection)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+
+# shellcheck source=lib/version.sh
+source "${SCRIPT_DIR}/lib/version.sh"
+
+# =============================================================================
+# CLI-to-URL mapping
+# =============================================================================
+# Maps CLI display names to their canonical repo/website URLs.
+# Add new runtimes here as they become supported.
+
+_cli_url() {
+	local cli_name="$1"
+	# Bash 3.2 compat: no ${var,,} — use tr for case conversion
+	local cli_lower
+	cli_lower=$(printf '%s' "$cli_name" | tr '[:upper:]' '[:lower:]')
+
+	case "$cli_lower" in
+	*opencode*) echo "https://opencode.ai" ;;
+	*claude*code*) echo "https://claude.ai/code" ;;
+	*cursor*) echo "https://cursor.com" ;;
+	*windsurf*) echo "https://windsurf.com" ;;
+	*aider*) echo "https://aider.chat" ;;
+	*continue*) echo "https://continue.dev" ;;
+	*copilot*) echo "https://github.com/features/copilot" ;;
+	*cody*) echo "https://sourcegraph.com/cody" ;;
+	*kilo*code*) echo "https://kilocode.ai" ;;
+	*augment*) echo "https://augmentcode.com" ;;
+	*factory* | *droid*) echo "https://factory.ai" ;;
+	*codex*) echo "https://github.com/openai/codex" ;;
+	*warp*) echo "https://warp.dev" ;;
+	*) echo "" ;;
+	esac
+	return 0
+}
+
+# =============================================================================
+# CLI detection (reuses aidevops-update-check.sh logic)
+# =============================================================================
+
+_detect_cli() {
+	local update_check="${SCRIPT_DIR}/aidevops-update-check.sh"
+	if [[ -x "$update_check" ]]; then
+		# detect_app() outputs "Name|version" or "Name"
+		local result
+		result=$("$update_check" 2>/dev/null <<<"" | head -1 || echo "")
+		# The script's main() runs on execution; we need just detect_app.
+		# Safer: source the function directly isn't possible (it runs main).
+		# Use the env-var detection inline instead.
+		:
+	fi
+
+	# Inline detection (mirrors aidevops-update-check.sh detect_app)
+	local app_name="" app_version=""
+
+	if [[ "${OPENCODE:-}" == "1" ]]; then
+		app_name="OpenCode CLI"
+		app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
+	elif [[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+		app_name="Claude Code"
+		app_version=$(claude --version 2>/dev/null | head -1 | sed 's/ (Claude Code)//' || echo "")
+	elif [[ -n "${CURSOR_SESSION:-}" ]] || [[ "${TERM_PROGRAM:-}" == "cursor" ]]; then
+		app_name="Cursor"
+	elif [[ -n "${WINDSURF_SESSION:-}" ]]; then
+		app_name="Windsurf"
+	elif [[ -n "${CONTINUE_SESSION:-}" ]]; then
+		app_name="Continue"
+	elif [[ -n "${AIDER_SESSION:-}" ]]; then
+		app_name="Aider"
+		app_version=$(aider --version 2>/dev/null | head -1 || echo "")
+	elif [[ -n "${FACTORY_DROID:-}" ]]; then
+		app_name="Factory Droid"
+	elif [[ -n "${AUGMENT_SESSION:-}" ]]; then
+		app_name="Augment"
+	elif [[ -n "${COPILOT_SESSION:-}" ]]; then
+		app_name="GitHub Copilot"
+	elif [[ -n "${CODY_SESSION:-}" ]]; then
+		app_name="Cody"
+	elif [[ -n "${KILO_SESSION:-}" ]]; then
+		app_name="Kilo Code"
+	elif [[ -n "${WARP_SESSION:-}" ]]; then
+		app_name="Warp"
+	else
+		# Fallback: check parent process name
+		local parent parent_lower
+		parent=$(ps -o comm= -p "${PPID:-0}" 2>/dev/null || echo "")
+		parent_lower=$(printf '%s' "$parent" | tr '[:upper:]' '[:lower:]')
+		case "$parent_lower" in
+		*opencode*)
+			app_name="OpenCode CLI"
+			app_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+			if [[ -z "$app_version" ]]; then
+				app_version=$(npm list -g opencode-ai --json 2>/dev/null | jq -r '.dependencies["opencode-ai"].version // empty' 2>/dev/null || echo "")
+			fi
+			;;
+		*claude*)
+			app_name="Claude Code"
+			app_version=$(claude --version 2>/dev/null | head -1 | sed 's/ (Claude Code)//' || echo "")
+			;;
+		*cursor*) app_name="Cursor" ;;
+		*windsurf*) app_name="Windsurf" ;;
+		*aider*)
+			app_name="Aider"
+			app_version=$(aider --version 2>/dev/null | head -1 || echo "")
+			;;
+		*) app_name="" ;;
+		esac
+	fi
+
+	echo "${app_name}|${app_version}"
+	return 0
+}
+
+# =============================================================================
+# Format number with commas (Bash 3.2 compatible)
+# =============================================================================
+
+_format_number() {
+	local num="$1"
+	# Strip non-digits
+	num=$(printf '%s' "$num" | tr -cd '0-9')
+	if [[ -z "$num" ]]; then
+		echo "0"
+		return 0
+	fi
+	# Pure bash comma insertion (macOS BSD sed lacks label loops)
+	local formatted=""
+	local len=${#num}
+	local i=0
+	while [[ $i -lt $len ]]; do
+		local remaining=$((len - i))
+		if [[ $i -gt 0 ]] && [[ $((remaining % 3)) -eq 0 ]]; then
+			formatted="${formatted},"
+		fi
+		formatted="${formatted}${num:$i:1}"
+		i=$((i + 1))
+	done
+	echo "$formatted"
+	return 0
+}
+
+# =============================================================================
+# generate — produce the signature line
+# =============================================================================
+
+cmd_generate() {
+	local model="${AIDEVOPS_SIG_MODEL:-}"
+	local tokens="${AIDEVOPS_SIG_TOKENS:-}"
+	local cli_name="${AIDEVOPS_SIG_CLI:-}"
+	local cli_version="${AIDEVOPS_SIG_CLI_VERSION:-}"
+
+	# Parse args
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--model)
+			model="$2"
+			shift 2
+			;;
+		--tokens)
+			tokens="$2"
+			shift 2
+			;;
+		--cli)
+			cli_name="$2"
+			shift 2
+			;;
+		--cli-version)
+			cli_version="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	# Auto-detect CLI if not provided
+	if [[ -z "$cli_name" ]]; then
+		local detected
+		detected=$(_detect_cli)
+		cli_name="${detected%%|*}"
+		if [[ -z "$cli_version" ]]; then
+			cli_version="${detected#*|}"
+			# If no pipe separator was present, cli_version == cli_name
+			if [[ "$cli_version" == "$cli_name" ]]; then
+				cli_version=""
+			fi
+		fi
+	fi
+
+	# Get aidevops version
+	local aidevops_version
+	aidevops_version=$(aidevops_find_version)
+
+	# Build the signature parts
+	local parts=""
+
+	# Part 1: CLI with link and version
+	if [[ -n "$cli_name" ]]; then
+		local url
+		url=$(_cli_url "$cli_name")
+		if [[ -n "$url" ]]; then
+			if [[ -n "$cli_version" ]]; then
+				parts="[${cli_name}](${url}) v${cli_version}"
+			else
+				parts="[${cli_name}](${url})"
+			fi
+		else
+			if [[ -n "$cli_version" ]]; then
+				parts="${cli_name} v${cli_version}"
+			else
+				parts="${cli_name}"
+			fi
+		fi
+	fi
+
+	# Part 2: aidevops with link and version
+	local aidevops_part="[aidevops.sh](https://aidevops.sh) v${aidevops_version}"
+	if [[ -n "$parts" ]]; then
+		parts="${parts}, ${aidevops_part}"
+	else
+		parts="${aidevops_part}"
+	fi
+
+	# Part 3: model
+	if [[ -n "$model" ]]; then
+		parts="${parts}, ${model}"
+	fi
+
+	# Part 4: tokens (formatted with commas)
+	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then
+		local formatted
+		formatted=$(_format_number "$tokens")
+		parts="${parts}, ${formatted} tokens"
+	fi
+
+	echo "$parts"
+	return 0
+}
+
+# =============================================================================
+# footer — produce the full footer block (--- + signature)
+# =============================================================================
+
+cmd_footer() {
+	local sig
+	sig=$(cmd_generate "$@")
+	printf '\n---\n%s\n' "$sig"
+	return 0
+}
+
+# =============================================================================
+# help
+# =============================================================================
+
+show_help() {
+	cat <<'EOF'
+gh-signature-helper.sh — Generate signature footer for GitHub comments
+
+Usage:
+  gh-signature-helper.sh generate [--model MODEL] [--tokens N] [--cli NAME] [--cli-version VER]
+  gh-signature-helper.sh footer   [--model MODEL] [--tokens N] [--cli NAME] [--cli-version VER]
+  gh-signature-helper.sh help
+
+Commands:
+  generate    Output the signature line (no leading ---)
+  footer      Output the full footer block (--- + newline + signature)
+  help        Show this help
+
+Options:
+  --model MODEL         Model ID (e.g., anthropic/claude-opus-4-6)
+  --tokens N            Token count for the session
+  --cli NAME            CLI name override (e.g., "OpenCode CLI")
+  --cli-version VER     CLI version override (e.g., "1.3.3")
+
+Environment variables (override auto-detection):
+  AIDEVOPS_SIG_CLI          CLI name
+  AIDEVOPS_SIG_CLI_VERSION  CLI version
+  AIDEVOPS_SIG_MODEL        Model ID
+  AIDEVOPS_SIG_TOKENS       Token count
+
+Examples:
+  # Auto-detect everything, just specify model
+  gh-signature-helper.sh generate --model anthropic/claude-opus-4-6
+
+  # Full footer with all fields
+  gh-signature-helper.sh footer --model anthropic/claude-sonnet-4-6 --tokens 45000
+
+  # Override CLI detection
+  gh-signature-helper.sh generate --cli "OpenCode CLI" --cli-version "1.3.3" --model anthropic/claude-opus-4-6 --tokens 1234
+
+  # Use in a gh issue comment
+  FOOTER=$(gh-signature-helper.sh footer --model anthropic/claude-sonnet-4-6)
+  gh issue comment 42 --repo owner/repo --body "Comment body${FOOTER}"
+EOF
+	return 0
+}
+
+# =============================================================================
+# main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	generate) cmd_generate "$@" ;;
+	footer) cmd_footer "$@" ;;
+	help | --help | -h) show_help ;;
+	*)
+		echo "Error: Unknown command: $command" >&2
+		show_help >&2
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -67,6 +67,14 @@ create_issue() {
 	gh label create "source:review-scanner" --repo "$repo" \
 		--description "Auto-created by post-merge-review-scanner.sh" --color "C2E0C6" --force || true
 	local body
+	# Build signature footer
+	local sig_footer=""
+	local sig_helper
+	sig_helper="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/gh-signature-helper.sh"
+	if [[ -x "$sig_helper" ]]; then
+		sig_footer=$("$sig_helper" footer 2>/dev/null || echo "")
+	fi
+
 	body="## Unaddressed review bot suggestions
 
 PR #${pr} was merged with unaddressed review bot feedback.
@@ -74,9 +82,7 @@ PR #${pr} was merged with unaddressed review bot feedback.
 
 ### Actionable comments
 
-${summary}
----
-*Auto-created by post-merge-review-scanner.sh (t1386)*"
+${summary}${sig_footer}"
 	gh issue create --repo "$repo" --title "$title" --label "$SCANNER_LABEL,source:review-scanner" --body "$body"
 }
 

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for gh-signature-helper.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../gh-signature-helper.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected: $expected"
+		echo "    actual:   $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_contains() {
+	local test_name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected to contain: $needle"
+		echo "    actual: $haystack"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local test_name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected NOT to contain: $needle"
+		echo "    actual: $haystack"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+echo "=== gh-signature-helper.sh tests ==="
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1: generate with explicit CLI, model, tokens
+# ─────────────────────────────────────────────────────────────────────────────
+echo "Test 1: generate with all explicit fields"
+result=$("$HELPER" generate --cli "OpenCode CLI" --cli-version "1.3.3" --model "anthropic/claude-opus-4-6" --tokens 1234)
+assert_contains "contains CLI link" "[OpenCode CLI](https://opencode.ai) v1.3.3" "$result"
+assert_contains "contains aidevops link" "[aidevops.sh](https://aidevops.sh)" "$result"
+assert_contains "contains model" "anthropic/claude-opus-4-6" "$result"
+assert_contains "contains formatted tokens" "1,234 tokens" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2: generate with no tokens (should omit tokens)
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 2: generate without tokens"
+result=$("$HELPER" generate --cli "Claude Code" --cli-version "2.0.1" --model "anthropic/claude-sonnet-4-6")
+assert_contains "contains Claude Code link" "[Claude Code](https://claude.ai/code) v2.0.1" "$result"
+assert_not_contains "no tokens field" "tokens" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3: generate with zero tokens (should omit)
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 3: zero tokens omitted"
+result=$("$HELPER" generate --cli "OpenCode CLI" --model "anthropic/claude-opus-4-6" --tokens 0)
+assert_not_contains "zero tokens omitted" "tokens" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 4: generate with no model (should omit model)
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 4: no model"
+result=$("$HELPER" generate --cli "Cursor")
+assert_contains "contains Cursor link" "[Cursor](https://cursor.com)" "$result"
+assert_contains "contains aidevops" "aidevops.sh" "$result"
+# Should only have CLI and aidevops, no trailing comma-model
+assert_not_contains "no model field" "anthropic" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 5: footer command includes --- separator
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 5: footer includes --- separator"
+result=$("$HELPER" footer --cli "OpenCode CLI" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
+assert_contains "contains ---" "---" "$result"
+assert_contains "contains signature" "[OpenCode CLI](https://opencode.ai) v1.0.0" "$result"
+assert_contains "contains tokens" "5,000 tokens" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 6: comma formatting for various numbers
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 6: comma formatting"
+result=$("$HELPER" generate --cli "Test" --model "m" --tokens 999)
+assert_contains "3-digit no comma" "999 tokens" "$result"
+
+result=$("$HELPER" generate --cli "Test" --model "m" --tokens 1000)
+assert_contains "4-digit with comma" "1,000 tokens" "$result"
+
+result=$("$HELPER" generate --cli "Test" --model "m" --tokens 45000)
+assert_contains "5-digit with comma" "45,000 tokens" "$result"
+
+result=$("$HELPER" generate --cli "Test" --model "m" --tokens 1234567)
+assert_contains "7-digit with commas" "1,234,567 tokens" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 7: CLI URL mapping for known runtimes
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 7: CLI URL mapping"
+result=$("$HELPER" generate --cli "OpenCode CLI" --model "m")
+assert_contains "OpenCode URL" "https://opencode.ai" "$result"
+
+result=$("$HELPER" generate --cli "Claude Code" --model "m")
+assert_contains "Claude Code URL" "https://claude.ai/code" "$result"
+
+result=$("$HELPER" generate --cli "Cursor" --model "m")
+assert_contains "Cursor URL" "https://cursor.com" "$result"
+
+result=$("$HELPER" generate --cli "Aider" --model "m")
+assert_contains "Aider URL" "https://aider.chat" "$result"
+
+result=$("$HELPER" generate --cli "Windsurf" --model "m")
+assert_contains "Windsurf URL" "https://windsurf.com" "$result"
+
+result=$("$HELPER" generate --cli "Continue" --model "m")
+assert_contains "Continue URL" "https://continue.dev" "$result"
+
+result=$("$HELPER" generate --cli "GitHub Copilot" --model "m")
+assert_contains "Copilot URL" "https://github.com/features/copilot" "$result"
+
+result=$("$HELPER" generate --cli "Cody" --model "m")
+assert_contains "Cody URL" "https://sourcegraph.com/cody" "$result"
+
+result=$("$HELPER" generate --cli "Kilo Code" --model "m")
+assert_contains "Kilo Code URL" "https://kilocode.ai" "$result"
+
+result=$("$HELPER" generate --cli "Augment" --model "m")
+assert_contains "Augment URL" "https://augmentcode.com" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 8: unknown CLI gets no link
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 8: unknown CLI has no link"
+result=$("$HELPER" generate --cli "SomeNewTool" --model "m")
+assert_contains "CLI name present" "SomeNewTool" "$result"
+assert_not_contains "no CLI markdown link" "[SomeNewTool](" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 9: env var overrides
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 9: environment variable overrides"
+result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG_MODEL="test/model" AIDEVOPS_SIG_TOKENS="42000" "$HELPER" generate)
+assert_contains "env CLI name" "EnvCLI" "$result"
+assert_contains "env CLI version" "v9.9.9" "$result"
+assert_contains "env model" "test/model" "$result"
+assert_contains "env tokens" "42,000 tokens" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 10: help command exits cleanly
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 10: help command"
+result=$("$HELPER" help 2>&1)
+assert_contains "help shows usage" "Usage:" "$result"
+assert_contains "help shows examples" "Examples:" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a standardized signature footer to all GitHub issues, PRs, and comments created by aidevops agents. Provides traceability for which CLI, framework version, model, and token cost produced each piece of content.

## What changed

- **New**: `gh-signature-helper.sh` — generates a one-line signature footer with auto-detection of runtime CLI (OpenCode, Claude Code, Cursor, Aider, Windsurf, etc.), aidevops version, model ID, and optional token count
- **New**: 35-test suite covering all CLI URL mappings, comma formatting, env var overrides, edge cases
- **Updated**: Pulse dispatch/kill/merge comment templates in `pulse.md` — replaced inline version+model bullets with signature footer
- **Updated**: `full-loop.md` closing comment guidance — references signature footer
- **Updated**: `worker-efficiency-protocol.md` PR creation — appends signature footer to PR body
- **Updated**: `framework-issue-helper.sh` — appends footer to auto-generated framework issues
- **Updated**: `gh-failure-miner-helper.sh` — appends footer to CI failure issues
- **Updated**: `post-merge-review-scanner.sh` — appends footer to review scanner issues
- **Updated**: `build.txt` — added agent guidance requiring signature footer on all GitHub comments

## Output format

```
---
[OpenCode CLI](https://opencode.ai) v1.3.3, [aidevops.sh](https://aidevops.sh) v3.5.6, anthropic/claude-opus-4-6, 1,234 tokens
```

CLI name is linked to its canonical website/repo. Tokens are optional (omitted when unavailable). Unknown CLIs render without a link.

## Testing

- 35/35 tests pass
- ShellCheck clean (zero violations)
- Markdownlint clean on all modified .md files
- Bash 3.2 compatible (no ${var,,}, no GNU sed label loops)

---
[OpenCode CLI](https://opencode.ai), [aidevops.sh](https://aidevops.sh) v3.5.6, anthropic/claude-opus-4-6