### PR TITLE
fix: Signature footer auto-detects CLI version and session tokens

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -185,11 +185,11 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 3. Add TODO entry WITH `ref:GH#NNN` in same commit. Split commits → duplicate issues.
 4. Code changes still need worktree + PR.
 
-**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id>` to generate it, or compose manually:
+**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--tokens N]` to generate it, or compose manually:
 ```
 \n---\n[CLI Name](url) vX.Y.Z, [aidevops.sh](https://aidevops.sh) vX.Y.Z, provider/model-id, N tokens
 ```
-Tokens are optional (omit when unavailable). The helper auto-detects the runtime CLI and aidevops version. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+The helper auto-detects the runtime CLI (with version) and aidevops version. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. Token count: pass `--tokens` when available from session usage data; omit when the runtime doesn't expose it. The model ID should be the full `provider/model-name` (e.g., `anthropic/claude-opus-4-6`). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -22,8 +22,14 @@ detect_app() {
 	# Check environment variables set by various tools
 	if [[ "${OPENCODE:-}" == "1" ]]; then
 		app_name="OpenCode"
-		# OpenCode doesn't have --version flag, check package.json
-		app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
+		# Try multiple version detection methods (install path varies: bun, npm, homebrew)
+		app_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+		if [[ -z "$app_version" ]]; then
+			app_version=$(npm list -g opencode-ai --json 2>/dev/null | jq -r '.dependencies["opencode-ai"].version // empty' 2>/dev/null || echo "")
+		fi
+		if [[ -z "$app_version" ]]; then
+			app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
+		fi
 	elif [[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
 		app_name="Claude Code"
 		app_version=$(claude --version 2>/dev/null | head -1 | sed 's/ (Claude Code)//' || echo "")

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -84,7 +84,14 @@ _detect_cli() {
 
 	if [[ "${OPENCODE:-}" == "1" ]]; then
 		app_name="OpenCode CLI"
-		app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
+		# Try multiple version detection methods (install path varies: bun, npm, homebrew)
+		app_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+		if [[ -z "$app_version" ]]; then
+			app_version=$(npm list -g opencode-ai --json 2>/dev/null | jq -r '.dependencies["opencode-ai"].version // empty' 2>/dev/null || echo "")
+		fi
+		if [[ -z "$app_version" ]]; then
+			app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
+		fi
 	elif [[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
 		app_name="Claude Code"
 		app_version=$(claude --version 2>/dev/null | head -1 | sed 's/ (Claude Code)//' || echo "")
@@ -137,6 +144,78 @@ _detect_cli() {
 	fi
 
 	echo "${app_name}|${app_version}"
+	return 0
+}
+
+# =============================================================================
+# Auto-detect session token count from runtime DB
+# =============================================================================
+# Queries the runtime's session database for cumulative token usage.
+# Currently supports OpenCode (SQLite DB at ~/.local/share/opencode/opencode.db).
+# Returns total input+output tokens for the most recent session in the current
+# working directory, or empty string if unavailable.
+
+_detect_session_tokens() {
+	local db_path="${HOME}/.local/share/opencode/opencode.db"
+
+	# Only attempt for OpenCode (other runtimes can be added later)
+	if [[ "${OPENCODE:-}" != "1" ]] && ! ps -o comm= -p "${PPID:-0}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | grep -q opencode; then
+		echo ""
+		return 0
+	fi
+
+	if [[ ! -r "$db_path" ]]; then
+		echo ""
+		return 0
+	fi
+
+	if ! command -v sqlite3 &>/dev/null; then
+		echo ""
+		return 0
+	fi
+
+	# Find the most recently updated session matching the current directory
+	local cwd
+	cwd=$(pwd 2>/dev/null || echo "")
+	if [[ -z "$cwd" ]]; then
+		echo ""
+		return 0
+	fi
+
+	# Also check the canonical repo root and worktree's linked repo
+	local repo_root canonical_dir
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+	# Worktree paths like ~/Git/repo.branch-name → canonical is ~/Git/repo
+	canonical_dir="${repo_root%%.*}"
+
+	local session_id
+	session_id=$(sqlite3 "$db_path" "
+		SELECT id FROM session
+		WHERE directory IN ('${cwd}', '${repo_root}', '${canonical_dir}')
+		ORDER BY time_updated DESC LIMIT 1
+	" 2>/dev/null || echo "")
+
+	if [[ -z "$session_id" ]]; then
+		echo ""
+		return 0
+	fi
+
+	local total_tokens
+	total_tokens=$(sqlite3 "$db_path" "
+		SELECT COALESCE(
+			SUM(json_extract(data, '$.tokens.input')) +
+			SUM(json_extract(data, '$.tokens.output')), 0
+		)
+		FROM message
+		WHERE session_id='${session_id}'
+		  AND json_extract(data, '$.tokens.input') > 0
+	" 2>/dev/null || echo "")
+
+	if [[ -n "$total_tokens" ]] && [[ "$total_tokens" -gt 0 ]] 2>/dev/null; then
+		echo "$total_tokens"
+	else
+		echo ""
+	fi
 	return 0
 }
 
@@ -213,6 +292,11 @@ cmd_generate() {
 				cli_version=""
 			fi
 		fi
+	fi
+
+	# Auto-detect tokens from session DB if not provided
+	if [[ -z "$tokens" ]]; then
+		tokens=$(_detect_session_tokens)
 	fi
 
 	# Get aidevops version

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -73,11 +73,11 @@ assert_contains "contains model" "anthropic/claude-opus-4-6" "$result"
 assert_contains "contains formatted tokens" "1,234 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test 2: generate with no tokens (should omit tokens)
+# Test 2: generate with explicit --tokens 0 (should omit tokens)
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 2: generate without tokens"
-result=$("$HELPER" generate --cli "Claude Code" --cli-version "2.0.1" --model "anthropic/claude-sonnet-4-6")
+echo "Test 2: explicit --tokens 0 omits tokens"
+result=$("$HELPER" generate --cli "Claude Code" --cli-version "2.0.1" --model "anthropic/claude-sonnet-4-6" --tokens 0)
 assert_contains "contains Claude Code link" "[Claude Code](https://claude.ai/code) v2.0.1" "$result"
 assert_not_contains "no tokens field" "tokens" "$result"
 
@@ -183,10 +183,22 @@ assert_contains "env model" "test/model" "$result"
 assert_contains "env tokens" "42,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test 10: help command exits cleanly
+# Test 10: auto-detect tokens from OpenCode session DB (if running in OpenCode)
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 10: help command"
+echo "Test 10: auto-detect tokens from session DB"
+if [[ "${OPENCODE:-}" == "1" ]] && [[ -r "${HOME}/.local/share/opencode/opencode.db" ]]; then
+	result=$("$HELPER" generate --cli "OpenCode CLI" --model "anthropic/claude-opus-4-6")
+	assert_contains "auto-detected tokens present" "tokens" "$result"
+else
+	echo "  SKIP: not running in OpenCode (auto-detect test requires OpenCode session DB)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 11: help command exits cleanly
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 11: help command"
 result=$("$HELPER" help 2>&1)
 assert_contains "help shows usage" "Usage:" "$result"
 assert_contains "help shows examples" "Examples:" "$result"


### PR DESCRIPTION
## Summary

Fixes two issues with the signature footer from PR #12125:

1. **OpenCode CLI version missing** — the `OPENCODE=1` env var detection path only checked the bun install location (`~/.bun/install/global/node_modules/opencode-ai/package.json`). Now tries `opencode --version` first, then `npm list -g`, then bun as fallback. Same fix applied to `aidevops-update-check.sh`.

2. **Token count missing** — added `_detect_session_tokens()` that queries `~/.local/share/opencode/opencode.db` for cumulative input+output tokens in the most recent session matching the current working directory. Resolves worktree paths to their canonical repo directory. Explicit `--tokens` still overrides. Non-OpenCode runtimes gracefully skip.

## Before

```
[OpenCode CLI](https://opencode.ai), [aidevops.sh](https://aidevops.sh) v3.5.6, anthropic/claude-opus-4-6
```

## After

```
[OpenCode CLI](https://opencode.ai) v1.3.3, [aidevops.sh](https://aidevops.sh) v3.5.8, anthropic/claude-opus-4-6, 35,044 tokens
```

## Testing

- 36/36 tests pass (added auto-detection test)
- ShellCheck clean
- Bash 3.2 compatible

---
[OpenCode CLI](https://opencode.ai) v1.3.3, [aidevops.sh](https://aidevops.sh) v3.5.8, anthropic/claude-opus-4-6, 39,003 tokens