### PR TITLE
refactor: Signature footer uses natural prose format

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -185,11 +185,12 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 3. Add TODO entry WITH `ref:GH#NNN` in same commit. Split commits → duplicate issues.
 4. Code changes still need worktree + PR.
 
-**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--tokens N]` to generate it, or compose manually:
+**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM]` to generate it. Example output:
 ```
-\n---\n[CLI Name](url) vX.Y.Z, [aidevops.sh](https://aidevops.sh) vX.Y.Z, provider/model-id, N tokens
+---
+[aidevops.sh](https://aidevops.sh) v3.5.10 in [OpenCode CLI](https://opencode.ai) v1.3.3 with anthropic/claude-opus-4-6 used 65,009 tokens for 42m to respond in 13m, 31m since this issue was created.
 ```
-The helper auto-detects the runtime CLI (with version) and aidevops version. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. Token count: pass `--tokens` when available from session usage data; omit when the runtime doesn't expose it. The model ID should be the full `provider/model-name` (e.g., `anthropic/claude-opus-4-6`). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+The helper auto-detects CLI, version, tokens, session time, and response time from the runtime DB. Pass `--issue` for total time since issue creation. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -408,7 +408,7 @@ cmd_generate() {
 	local tokens="${AIDEVOPS_SIG_TOKENS:-}"
 	local cli_name="${AIDEVOPS_SIG_CLI:-}"
 	local cli_version="${AIDEVOPS_SIG_CLI_VERSION:-}"
-	local issue_ref="" issue_created=""
+	local issue_ref="" issue_created="" solved="false"
 
 	# Parse args
 	while [[ $# -gt 0 ]]; do
@@ -436,6 +436,10 @@ cmd_generate() {
 		--issue-created)
 			issue_created="$2"
 			shift 2
+			;;
+		--solved)
+			solved="true"
+			shift
 			;;
 		*) shift ;;
 		esac
@@ -486,27 +490,32 @@ cmd_generate() {
 		fi
 	fi
 
-	# Part 2: aidevops with link and version
-	local aidevops_part="[aidevops.sh](https://aidevops.sh) v${aidevops_version}"
-	if [[ -n "$parts" ]]; then
-		parts="${parts}, ${aidevops_part}"
-	else
-		parts="${aidevops_part}"
+	# --- Build natural-language sentence ---
+	# Target: [aidevops.sh](...) v3.5.10 in [CLI](...) v1.3.3 with model used N tokens for Xm to respond in Ym, Zm since this issue was created.
+
+	# Start with aidevops
+	local sig="[aidevops.sh](https://aidevops.sh) v${aidevops_version}"
+
+	# "in [CLI] vX.Y.Z"
+	if [[ -n "$cli_name" ]]; then
+		local url
+		url=$(_cli_url "$cli_name")
+		if [[ -n "$url" ]]; then
+			sig="${sig} in [${cli_name}](${url})"
+		else
+			sig="${sig} in ${cli_name}"
+		fi
+		if [[ -n "$cli_version" ]]; then
+			sig="${sig} v${cli_version}"
+		fi
 	fi
 
-	# Part 3: model
+	# "with model"
 	if [[ -n "$model" ]]; then
-		parts="${parts}, ${model}"
+		sig="${sig} with ${model}"
 	fi
 
-	# Part 4: tokens (formatted with commas)
-	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then
-		local formatted
-		formatted=$(_format_number "$tokens")
-		parts="${parts}, ${formatted} tokens"
-	fi
-
-	# Part 5: time metrics (session, response, total)
+	# Detect time metrics
 	local session_time_str="" response_time_str="" total_time_str=""
 
 	local times_raw
@@ -530,17 +539,42 @@ cmd_generate() {
 		fi
 	fi
 
-	if [[ -n "$session_time_str" ]]; then
-		parts="${parts}, session: ${session_time_str}"
-	fi
-	if [[ -n "$response_time_str" ]]; then
-		parts="${parts}, response: ${response_time_str}"
-	fi
-	if [[ -n "$total_time_str" ]]; then
-		parts="${parts}, total: ${total_time_str}"
+	# "used N tokens" — only if we have tokens or time data to follow
+	local has_stats=""
+	if { [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; } || [[ -n "$session_time_str" ]] || [[ -n "$response_time_str" ]] || [[ -n "$total_time_str" ]]; then
+		has_stats="true"
 	fi
 
-	echo "$parts"
+	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then
+		local formatted
+		formatted=$(_format_number "$tokens")
+		sig="${sig} used ${formatted} tokens"
+	fi
+
+	# "for Xm" (session time)
+	if [[ -n "$session_time_str" ]]; then
+		sig="${sig} for ${session_time_str}"
+	fi
+
+	# "to respond in Ym" (response time)
+	if [[ -n "$response_time_str" ]]; then
+		sig="${sig} to respond in ${response_time_str}"
+	fi
+
+	# Total time: "--solved" → "Solved in Xm." / default → ", Xm since this issue was created."
+	if [[ -n "$total_time_str" ]]; then
+		if [[ "$solved" == "true" ]]; then
+			sig="${sig}. Solved in ${total_time_str}."
+		elif [[ -n "$session_time_str" ]] || [[ -n "$response_time_str" ]]; then
+			sig="${sig}, ${total_time_str} since this issue was created."
+		else
+			sig="${sig} ${total_time_str} since this issue was created."
+		fi
+	elif [[ -n "$has_stats" ]]; then
+		sig="${sig}."
+	fi
+
+	echo "$sig"
 	return 0
 }
 
@@ -580,6 +614,7 @@ Options:
   --cli-version VER         CLI version override (e.g., "1.3.3")
   --issue OWNER/REPO#NUM    GitHub issue ref for total time (e.g., owner/repo#42)
   --issue-created ISO       Issue creation timestamp for total time
+  --solved                  Use "Solved in Xm." instead of "Xm since this issue was created."
 
 Auto-detected fields (OpenCode sessions):
   - CLI name and version

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -67,10 +67,10 @@ echo ""
 # ─────────────────────────────────────────────────────────────────────────────
 echo "Test 1: generate with all explicit fields"
 result=$("$HELPER" generate --cli "OpenCode CLI" --cli-version "1.3.3" --model "anthropic/claude-opus-4-6" --tokens 1234)
-assert_contains "contains CLI link" "[OpenCode CLI](https://opencode.ai) v1.3.3" "$result"
-assert_contains "contains aidevops link" "[aidevops.sh](https://aidevops.sh)" "$result"
-assert_contains "contains model" "anthropic/claude-opus-4-6" "$result"
-assert_contains "contains formatted tokens" "1,234 tokens" "$result"
+assert_contains "starts with aidevops" "[aidevops.sh](https://aidevops.sh)" "$result"
+assert_contains "contains CLI with in" "in [OpenCode CLI](https://opencode.ai) v1.3.3" "$result"
+assert_contains "contains model with with" "with anthropic/claude-opus-4-6" "$result"
+assert_contains "contains formatted tokens" "used 1,234 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 2: generate with explicit --tokens 0 (should omit tokens)
@@ -78,7 +78,7 @@ assert_contains "contains formatted tokens" "1,234 tokens" "$result"
 echo ""
 echo "Test 2: explicit --tokens 0 omits tokens"
 result=$("$HELPER" generate --cli "Claude Code" --cli-version "2.0.1" --model "anthropic/claude-sonnet-4-6" --tokens 0)
-assert_contains "contains Claude Code link" "[Claude Code](https://claude.ai/code) v2.0.1" "$result"
+assert_contains "contains Claude Code" "in [Claude Code](https://claude.ai/code) v2.0.1" "$result"
 assert_not_contains "no tokens field" "tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -94,11 +94,10 @@ assert_not_contains "zero tokens omitted" "tokens" "$result"
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
 echo "Test 4: no model"
-result=$("$HELPER" generate --cli "Cursor")
-assert_contains "contains Cursor link" "[Cursor](https://cursor.com)" "$result"
+result=$("$HELPER" generate --cli "Cursor" --tokens 0)
+assert_contains "contains Cursor link" "in [Cursor](https://cursor.com)" "$result"
 assert_contains "contains aidevops" "aidevops.sh" "$result"
-# Should only have CLI and aidevops, no trailing comma-model
-assert_not_contains "no model field" "anthropic" "$result"
+assert_not_contains "no model field" "with " "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 5: footer command includes --- separator
@@ -107,8 +106,8 @@ echo ""
 echo "Test 5: footer includes --- separator"
 result=$("$HELPER" footer --cli "OpenCode CLI" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
 assert_contains "contains ---" "---" "$result"
-assert_contains "contains signature" "[OpenCode CLI](https://opencode.ai) v1.0.0" "$result"
-assert_contains "contains tokens" "5,000 tokens" "$result"
+assert_contains "contains signature" "in [OpenCode CLI](https://opencode.ai) v1.0.0" "$result"
+assert_contains "contains tokens" "used 5,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 6: comma formatting for various numbers
@@ -177,10 +176,10 @@ assert_not_contains "no CLI markdown link" "[SomeNewTool](" "$result"
 echo ""
 echo "Test 9: environment variable overrides"
 result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG_MODEL="test/model" AIDEVOPS_SIG_TOKENS="42000" "$HELPER" generate)
-assert_contains "env CLI name" "EnvCLI" "$result"
+assert_contains "env CLI name" "in EnvCLI" "$result"
 assert_contains "env CLI version" "v9.9.9" "$result"
-assert_contains "env model" "test/model" "$result"
-assert_contains "env tokens" "42,000 tokens" "$result"
+assert_contains "env model" "with test/model" "$result"
+assert_contains "env tokens" "used 42,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 10: auto-detect tokens from OpenCode session DB (if running in OpenCode)
@@ -201,8 +200,8 @@ echo ""
 echo "Test 11: session and response time auto-detection"
 if [[ "${OPENCODE:-}" == "1" ]] && [[ -r "${HOME}/.local/share/opencode/opencode.db" ]]; then
 	result=$("$HELPER" generate --cli "OpenCode CLI" --model "m" --tokens 1)
-	assert_contains "session time present" "session:" "$result"
-	assert_contains "response time present" "response:" "$result"
+	assert_contains "session time present" "for " "$result"
+	assert_contains "response time present" "to respond in " "$result"
 else
 	echo "  SKIP: not running in OpenCode"
 fi
@@ -215,17 +214,30 @@ echo "Test 12: total time with --issue-created"
 two_hours_ago=$(date -u -v-2H "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "2 hours ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
 if [[ -n "$two_hours_ago" ]]; then
 	result=$("$HELPER" generate --cli "Test" --model "m" --tokens 1 --issue-created "$two_hours_ago")
-	assert_contains "total time present" "total:" "$result"
-	assert_contains "total time ~2h" "total: 2h" "$result"
+	assert_contains "total time present" "since this issue was created" "$result"
+	assert_contains "total time ~2h" "2h" "$result"
 else
 	echo "  SKIP: date command does not support relative time"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test 13: help command exits cleanly
+# Test 13: --solved flag changes total time phrasing
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 13: help command"
+echo "Test 13: --solved flag"
+if [[ -n "$two_hours_ago" ]]; then
+	result=$("$HELPER" generate --cli "Test" --model "m" --tokens 1 --issue-created "$two_hours_ago" --solved)
+	assert_contains "solved phrasing" "Solved in 2h" "$result"
+	assert_not_contains "no since phrasing" "since this issue" "$result"
+else
+	echo "  SKIP: date command does not support relative time"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 14: help command exits cleanly
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 14: help command"
 result=$("$HELPER" help 2>&1)
 assert_contains "help shows usage" "Usage:" "$result"
 assert_contains "help shows examples" "Examples:" "$result"


### PR DESCRIPTION
## Summary

Replaces the CSV-style signature footer with natural English prose. Adds `--solved` flag for closing comments.

## Before

```
[OpenCode CLI](https://opencode.ai) v1.3.3, [aidevops.sh](https://aidevops.sh) v3.5.10, anthropic/claude-opus-4-6, 65,009 tokens, session: 42m, response: 13m, total: 31m
```

## After

**Dispatch/in-progress comment:**
```
[aidevops.sh](https://aidevops.sh) v3.5.10 in [OpenCode CLI](https://opencode.ai) v1.3.3 with anthropic/claude-opus-4-6 used 65,009 tokens for 42m to respond in 13m, 31m since this issue was created.
```

**Closing comment (`--solved`):**
```
[aidevops.sh](https://aidevops.sh) v3.5.10 in [OpenCode CLI](https://opencode.ai) v1.3.3 with anthropic/claude-opus-4-6 used 65,009 tokens for 42m to respond in 13m. Solved in 31m.
```

**Minimal (no tokens/times available):**
```
[aidevops.sh](https://aidevops.sh) v3.5.10 in [Claude Code](https://claude.ai/code) v2.0 with anthropic/claude-sonnet-4-6
```

## Testing

- 42/42 tests pass (added `--solved` flag test)
- ShellCheck clean

---
[aidevops.sh](https://aidevops.sh) v3.5.11 in [OpenCode CLI](https://opencode.ai) v1.3.3 with anthropic/claude-opus-4-6 used 76,079 tokens for 53m to respond in 3m. Solved in 42m.