### PR TITLE
#12153: tighten FSD implementation patterns doc

### DIFF
--- a/.agents/tools/architecture/feature-slicing-skill/implementation.md
+++ b/.agents/tools/architecture/feature-slicing-skill/implementation.md
@@ -61,9 +61,6 @@ export { userSchema, type UserFormData } from './model/schema';
 
 ## Feature: Authentication
 
-- Features own state (stores), forms, action handlers
-- Import from entities; entities never import from features
-
 ```typescript
 // features/auth/model/store.ts — Zustand with persistence
 import { create } from 'zustand';
@@ -126,8 +123,6 @@ export function LoginForm() {
 
 ## Widget: Header
 
-Widgets compose features and entities into reusable UI blocks (layer above features).
-
 ```tsx
 // widgets/header/ui/Header.tsx
 import { Link } from 'react-router-dom';
@@ -154,8 +149,6 @@ export { Header } from './ui/Header';
 
 ## Page: Product Detail
 
-Pages compose widgets, features, and entities into route screens. One slice per route.
-
 ```tsx
 // pages/product-detail/ui/ProductDetailPage.tsx
 import { useLoaderData } from 'react-router-dom';
@@ -173,8 +166,6 @@ export { productDetailLoader } from './api/loader';
 ```
 
 ## Shared: API Client
-
-`shared/` has no slices — domain-agnostic infrastructure only.
 
 ```typescript
 // shared/api/client.ts


### PR DESCRIPTION
## Summary

- Removes 9 lines of prose from Widget, Page, Shared, and Feature sections that duplicate content already in `LAYERS.md`
- All code examples preserved intact — zero content loss
- 234 → 225 lines

## What changed

Removed redundant prose descriptions under section headers:
- `Feature: Authentication` — removed 2 bullet points (covered by LAYERS.md)
- `Widget: Header` — removed 1-line description (covered by LAYERS.md)
- `Page: Product Detail` — removed 1-line description (covered by LAYERS.md)
- `Shared: API Client` — removed 1-line description (covered by LAYERS.md)

## Verification

- Content preservation: all code blocks, URLs, and command examples present before and after ✅
- No broken internal links or references ✅
- Classification: reference corpus — code examples are the value, prose was overhead ✅

## Runtime Testing

- Risk: Low (docs-only change, no code)
- Level: self-assessed
- Smoke check: file renders correctly, all code blocks intact

Closes #12153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined architecture documentation by removing explanatory narrative sections. Changes only affect documentation text; no functional changes or code examples were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->