### PR TITLE
12177: simplification: tighten wp-dev.md prose

### DIFF
--- a/.agents/tools/wordpress/wp-dev.md
+++ b/.agents/tools/wordpress/wp-dev.md
@@ -143,7 +143,7 @@ ln -s ~/Git/wordpress/plugin-slug "~/Local Sites/test-site/app/public/wp-content
 
 ### Patching Pro/Closed Plugins
 
-Create a companion plugin (`{slug}-fix`) that survives updates. Guard with `class_exists`/`function_exists`. Use priority > 10. Document issue URL and affected versions. Version-gate: `version_compare(ORIGINAL_PLUGIN_VERSION, '2.4.0', '<')`.
+Create a companion `{slug}-fix` plugin that survives updates. Guard with `class_exists`/`function_exists`. Use priority > 10. Document issue URL and affected versions. Version-gate: `version_compare(ORIGINAL_PLUGIN_VERSION, '2.4.0', '<')`.
 
 ```php
 <?php
@@ -174,7 +174,7 @@ Logs: `~/Local Sites/site-name/app/public/wp-content/debug.log` (LocalWP) | `wp-
 
 **Query Monitor**: `wp plugin install query-monitor --activate` — shows DB queries, PHP errors, HTTP requests, hooks, template hierarchy, memory.
 
-**OpenCode PHP LSP (Intelephense)**: If WordPress symbols are unresolved (`add_action`, `WP_Query`), configure `~/.config/opencode/config.json` with `lsp.intelephense` using local binary path, `extensions: ["php"]`, and `intelephense.stubs` including `"wordpress"`. If diagnostics persist, clear/rebuild cache. Do not suggest Claude-specific commands (e.g., `/lsp-restart`) in OpenCode sessions.
+**OpenCode PHP LSP (Intelephense)**: Unresolved WordPress symbols (`add_action`, `WP_Query`) → configure `~/.config/opencode/config.json` with `lsp.intelephense` using local binary path, `extensions: ["php"]`, and `intelephense.stubs` including `"wordpress"`. Persistent diagnostics → clear/rebuild cache. Do not suggest Claude-specific commands (e.g., `/lsp-restart`) in OpenCode sessions.
 
 **Error Diagnosis**: Enable `WP_DEBUG` → check `debug.log` → Query Monitor → `@localwp` for DB → `wp hook list` → `wp profile` or Code Profiler Pro.
 


### PR DESCRIPTION
## Summary

- Tightened prose in `wp-dev.md` per simplification-debt scan (GH#12177)
- Replaced verbose "If X, configure..." conditionals with direct arrow notation (`→`) consistent with the rest of the doc
- Replaced `Create a companion plugin (\`{slug}-fix\`)` with `Create a companion \`{slug}-fix\` plugin` (tighter phrasing)
- All code blocks, URLs, command examples, and institutional knowledge preserved unchanged
- Markdownlint: 0 errors

## Classification

File type: **instruction doc** (agent rules, workflows, decision trees) — prose tightening applied, not chapter split.

## Runtime Testing

- Risk: **Low** (docs/agent prompt only, no code changes)
- Level: `self-assessed`
- Smoke check: markdownlint passes, content diff verified

## Files Changed

- `.agents/tools/wordpress/wp-dev.md` — prose tightening, 2 lines changed

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12177

---
[aidevops.sh](https://aidevops.sh) v3.5.27 in [OpenCode CLI](https://opencode.ai) v1.3.3 with anthropic/claude-sonnet-4-6 used 6,209 tokens for 2m to respond in 2m, 21m since this issue was created.