### PR TITLE
t12205: fix regression — update simplification state hash for ad-creative-copywriting.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -927,9 +927,9 @@
       "pr": 11814
     },
     ".agents/marketing-sales/ad-creative-copywriting.md": {
-      "hash": "797777145365782185769e625b807eb3d0c0b0f4",
-      "at": "2026-03-28T13:37:23Z",
-      "pr": 11885
+      "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
+      "at": "2026-03-28T21:14:35Z",
+      "pr": 12018
     },
     ".agents/marketing-sales/direct-response-copy-templates-landing-page.md": {
       "hash": "cbaa0cc29c6e3639ea5254866f8fefe1c02a329c",


### PR DESCRIPTION
## Summary

- File `ad-creative-copywriting.md` was simplified from 277→217 lines in PR #12018 but `simplification-state.json` still recorded the hash from PR #11885 (277 lines)
- This stale hash caused the regression scanner to flag the file as modified post-simplification
- Update the state entry to hash `84d60fe` (current 217-line state) and `pr: 12018`

## Changes

- `.agents/configs/simplification-state.json` — update hash, timestamp, and PR reference for `ad-creative-copywriting.md`

## Verification

- JSON valid: `python3 -m json.tool` passes
- Hash matches current file: `git rev-parse HEAD:.agents/marketing-sales/ad-creative-copywriting.md` = `84d60fe17b4cc01ac5bec4ce3363428510a2ece6`
- No content changes to the doc itself — file is already at 217 lines (well within target)

## Runtime Testing

- **Risk level**: Low (docs/config only, no code)
- **Level**: self-assessed
- **Dev environment**: N/A

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tracking configuration for marketing materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->