### PR TITLE
refactor: Signature — accurate token count, no response time, clean model name

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -185,12 +185,12 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 3. Add TODO entry WITH `ref:GH#NNN` in same commit. Split commits → duplicate issues.
 4. Code changes still need worktree + PR.
 
-**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM]` to generate it. Example output:
+**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM] [--solved]` to generate it. Example output:
 ```
 ---
-[aidevops.sh](https://aidevops.sh) v3.5.10 in [OpenCode CLI](https://opencode.ai) v1.3.3 with anthropic/claude-opus-4-6 used 65,009 tokens for 42m to respond in 13m, 31m since this issue was created.
+[aidevops.sh](https://aidevops.sh) v3.5.12 in [OpenCode CLI](https://opencode.ai) v1.3.3 with claude-opus-4-6 used 38,800,000 tokens for 42m, 31m since this issue was created.
 ```
-The helper auto-detects CLI, version, tokens, session time, and response time from the runtime DB. Pass `--issue` for total time since issue creation. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+The helper auto-detects CLI, version, tokens (including cache), and session time from the runtime DB. Pass `--issue` for total time since issue creation. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -200,11 +200,16 @@ _detect_session_tokens() {
 		return 0
 	fi
 
+	# Sum all token types: input + output + cache reads + cache writes.
+	# Cache tokens are the bulk of API usage (context loaded each turn)
+	# and are billed (cache reads at reduced rate).
 	local total_tokens
 	total_tokens=$(sqlite3 "$db_path" "
 		SELECT COALESCE(
 			SUM(json_extract(data, '$.tokens.input')) +
-			SUM(json_extract(data, '$.tokens.output')), 0
+			SUM(json_extract(data, '$.tokens.output')) +
+			SUM(COALESCE(json_extract(data, '$.tokens.cache.read'), 0)) +
+			SUM(COALESCE(json_extract(data, '$.tokens.cache.write'), 0)), 0
 		)
 		FROM message
 		WHERE session_id='${session_id}'
@@ -220,22 +225,20 @@ _detect_session_tokens() {
 }
 
 # =============================================================================
-# Detect session time and response time from runtime DB
+# Detect session time from runtime DB
 # =============================================================================
-# Returns pipe-separated: session_seconds|response_seconds
-# Session time: now - session.time_created
-# Response time: now - last user message timestamp
+# Returns session duration in seconds (now - session.time_created), or empty.
 
-_detect_session_times() {
+_detect_session_time() {
 	local db_path="${HOME}/.local/share/opencode/opencode.db"
 
 	if [[ "${OPENCODE:-}" != "1" ]] && ! ps -o comm= -p "${PPID:-0}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | grep -q opencode; then
-		echo "|"
+		echo ""
 		return 0
 	fi
 
 	if [[ ! -r "$db_path" ]] || ! command -v sqlite3 &>/dev/null; then
-		echo "|"
+		echo ""
 		return 0
 	fi
 
@@ -272,7 +275,7 @@ _detect_session_times() {
 	fi
 
 	if [[ -z "$session_id" ]]; then
-		echo "|"
+		echo ""
 		return 0
 	fi
 
@@ -282,15 +285,11 @@ _detect_session_times() {
 		FROM session WHERE id='${session_id}'
 	" 2>/dev/null || echo "")
 
-	local response_seconds
-	response_seconds=$(sqlite3 "$db_path" "
-		SELECT (strftime('%s','now') * 1000 - MAX(time_created)) / 1000
-		FROM message
-		WHERE session_id='${session_id}'
-		  AND json_extract(data, '$.role') = 'user'
-	" 2>/dev/null || echo "")
-
-	echo "${session_seconds}|${response_seconds}"
+	if [[ -n "$session_seconds" ]] && [[ "$session_seconds" -gt 0 ]] 2>/dev/null; then
+		echo "$session_seconds"
+	else
+		echo ""
+	fi
 	return 0
 }
 
@@ -478,27 +477,21 @@ _resolve_cli_inputs() {
 }
 
 # =============================================================================
-# _collect_time_metrics — gather session/response/total time strings
+# _collect_time_metrics — gather session and total time strings
 # =============================================================================
-# Outputs pipe-separated: session_time_str|response_time_str|total_time_str
+# Outputs pipe-separated: session_time_str|total_time_str
 
 _collect_time_metrics() {
 	local issue_ref="$1"
 	local issue_created="$2"
 
-	local session_time_str="" response_time_str="" total_time_str=""
+	local session_time_str="" total_time_str=""
 
-	local times_raw
-	times_raw=$(_detect_session_times)
-	local session_secs response_secs
-	session_secs="${times_raw%%|*}"
-	response_secs="${times_raw##*|}"
+	local session_secs
+	session_secs=$(_detect_session_time)
 
 	if [[ -n "$session_secs" ]] && [[ "$session_secs" -gt 0 ]] 2>/dev/null; then
 		session_time_str=$(_format_duration "$session_secs")
-	fi
-	if [[ -n "$response_secs" ]] && [[ "$response_secs" -gt 0 ]] 2>/dev/null; then
-		response_time_str=$(_format_duration "$response_secs")
 	fi
 
 	if [[ -n "$issue_ref" ]] || [[ -n "$issue_created" ]]; then
@@ -509,7 +502,7 @@ _collect_time_metrics() {
 		fi
 	fi
 
-	printf '%s|%s|%s\n' "$session_time_str" "$response_time_str" "$total_time_str"
+	printf '%s|%s\n' "$session_time_str" "$total_time_str"
 	return 0
 }
 
@@ -524,14 +517,19 @@ _build_signature() {
 	local cli_version="$3"
 	local tokens="$4"
 	local session_time_str="$5"
-	local response_time_str="$6"
-	local total_time_str="$7"
-	local solved="$8"
+	local total_time_str="$6"
+	local solved="$7"
 
 	local aidevops_version
 	aidevops_version=$(aidevops_find_version)
 
-	# Target: [aidevops.sh](...) v3.5.10 in [CLI](...) v1.3.3 with model used N tokens for Xm to respond in Ym, Zm since this issue was created.
+	# Strip provider prefix from model (anthropic/claude-opus-4-6 → claude-opus-4-6)
+	local display_model="$model"
+	if [[ "$display_model" == */* ]]; then
+		display_model="${display_model##*/}"
+	fi
+
+	# Target: [aidevops.sh](...) v3.5.10 in [CLI](...) v1.3.3 with claude-opus-4-6 used N tokens for Xm, Zm since this issue was created.
 	local sig="[aidevops.sh](https://aidevops.sh) v${aidevops_version}"
 
 	# "in [CLI] vX.Y.Z"
@@ -549,8 +547,8 @@ _build_signature() {
 	fi
 
 	# "with model"
-	if [[ -n "$model" ]]; then
-		sig="${sig} with ${model}"
+	if [[ -n "$display_model" ]]; then
+		sig="${sig} with ${display_model}"
 	fi
 
 	# "used N tokens"
@@ -565,22 +563,17 @@ _build_signature() {
 		sig="${sig} for ${session_time_str}"
 	fi
 
-	# "to respond in Ym" (response time)
-	if [[ -n "$response_time_str" ]]; then
-		sig="${sig} to respond in ${response_time_str}"
-	fi
-
 	# Total time or trailing period
 	local has_stats=""
 	if { [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; } ||
-		[[ -n "$session_time_str" ]] || [[ -n "$response_time_str" ]] || [[ -n "$total_time_str" ]]; then
+		[[ -n "$session_time_str" ]] || [[ -n "$total_time_str" ]]; then
 		has_stats="true"
 	fi
 
 	if [[ -n "$total_time_str" ]]; then
 		if [[ "$solved" == "true" ]]; then
 			sig="${sig}. Solved in ${total_time_str}."
-		elif [[ -n "$session_time_str" ]] || [[ -n "$response_time_str" ]]; then
+		elif [[ -n "$session_time_str" ]]; then
 			sig="${sig}, ${total_time_str} since this issue was created."
 		else
 			sig="${sig} ${total_time_str} since this issue was created."
@@ -618,13 +611,13 @@ cmd_generate() {
 	# Collect time metrics
 	local time_metrics
 	time_metrics=$(_collect_time_metrics "$issue_ref" "$issue_created")
-	local session_time_str response_time_str total_time_str
-	IFS='|' read -r session_time_str response_time_str total_time_str <<<"$time_metrics"
+	local session_time_str total_time_str
+	IFS='|' read -r session_time_str total_time_str <<<"$time_metrics"
 
 	# Build and emit the signature
 	_build_signature \
 		"$model" "$cli_name" "$cli_version" "$tokens" \
-		"$session_time_str" "$response_time_str" "$total_time_str" "$solved"
+		"$session_time_str" "$total_time_str" "$solved"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -69,7 +69,8 @@ echo "Test 1: generate with all explicit fields"
 result=$("$HELPER" generate --cli "OpenCode CLI" --cli-version "1.3.3" --model "anthropic/claude-opus-4-6" --tokens 1234)
 assert_contains "starts with aidevops" "[aidevops.sh](https://aidevops.sh)" "$result"
 assert_contains "contains CLI with in" "in [OpenCode CLI](https://opencode.ai) v1.3.3" "$result"
-assert_contains "contains model with with" "with anthropic/claude-opus-4-6" "$result"
+assert_contains "model strips provider prefix" "with claude-opus-4-6" "$result"
+assert_not_contains "no provider prefix" "anthropic/" "$result"
 assert_contains "contains formatted tokens" "used 1,234 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -178,7 +179,7 @@ echo "Test 9: environment variable overrides"
 result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG_MODEL="test/model" AIDEVOPS_SIG_TOKENS="42000" "$HELPER" generate)
 assert_contains "env CLI name" "in EnvCLI" "$result"
 assert_contains "env CLI version" "v9.9.9" "$result"
-assert_contains "env model" "with test/model" "$result"
+assert_contains "env model strips prefix" "with model" "$result"
 assert_contains "env tokens" "used 42,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -197,11 +198,11 @@ fi
 # Test 11: session and response time auto-detection (OpenCode only)
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 11: session and response time auto-detection"
+echo "Test 11: session time auto-detection (no response time)"
 if [[ "${OPENCODE:-}" == "1" ]] && [[ -r "${HOME}/.local/share/opencode/opencode.db" ]]; then
 	result=$("$HELPER" generate --cli "OpenCode CLI" --model "m" --tokens 1)
 	assert_contains "session time present" "for " "$result"
-	assert_contains "response time present" "to respond in " "$result"
+	assert_not_contains "no response time" "to respond" "$result"
 else
 	echo "  SKIP: not running in OpenCode"
 fi


### PR DESCRIPTION
## Summary

Three refinements to the signature footer:

1. **Token count includes cache** — was only counting input+output (78K), now includes cache_read+cache_write (1.6M for this session). Cache tokens are the bulk of API billing.

2. **Dropped response time** — "to respond in Xm" was always the same as session time in worker sessions (single user message). Removed the noise.

3. **Model strips provider prefix** — `anthropic/claude-opus-4-6` → `claude-opus-4-6`. Provider is implied by context.

## Before

```
...with anthropic/claude-opus-4-6 used 78,047 tokens for 58m to respond in 8m. Solved in 47m.
```

## After

```
...with claude-opus-4-6 used 1,658,312 tokens for 2h 38m. Solved in 2h 27m.
```

## Testing

- 43/43 tests pass
- ShellCheck clean

---
[aidevops.sh](https://aidevops.sh) v3.5.29 in [OpenCode CLI](https://opencode.ai) v1.3.3 with claude-opus-4-6 used 44,871,720 tokens for 2h 38m, 2h 28m since this issue was created.