### PR TITLE
refactor: Signature wording — 'plugin for OpenCode' and usage guidance

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -188,9 +188,9 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 **GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM] [--solved]` to generate it. Example output:
 ```
 ---
-[aidevops.sh](https://aidevops.sh) v3.5.12 in [OpenCode CLI](https://opencode.ai) v1.3.3 with claude-opus-4-6 used 38,800,000 tokens for 42m, 31m since this issue was created.
+[aidevops.sh](https://aidevops.sh) v3.5.35 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 used 1,658,312 tokens for 42m. Solved in 3d 4h.
 ```
-The helper auto-detects CLI, version, tokens (including cache), and session time from the runtime DB. Pass `--issue` for total time since issue creation. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+The helper auto-detects CLI, version, tokens (including cache), and session time from the runtime DB. Pass `--issue` on comments to existing issues for "Xm since this issue was created." phrasing. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -83,7 +83,7 @@ _detect_cli() {
 	local app_name="" app_version=""
 
 	if [[ "${OPENCODE:-}" == "1" ]]; then
-		app_name="OpenCode CLI"
+		app_name="OpenCode"
 		# Try multiple version detection methods (install path varies: bun, npm, homebrew)
 		app_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
 		if [[ -z "$app_version" ]]; then
@@ -123,7 +123,7 @@ _detect_cli() {
 		parent_lower=$(printf '%s' "$parent" | tr '[:upper:]' '[:lower:]')
 		case "$parent_lower" in
 		*opencode*)
-			app_name="OpenCode CLI"
+			app_name="OpenCode"
 			app_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
 			if [[ -z "$app_version" ]]; then
 				app_version=$(npm list -g opencode-ai --json 2>/dev/null | jq -r '.dependencies["opencode-ai"].version // empty' 2>/dev/null || echo "")
@@ -532,14 +532,14 @@ _build_signature() {
 	# Target: [aidevops.sh](...) v3.5.10 in [CLI](...) v1.3.3 with claude-opus-4-6 used N tokens for Xm, Zm since this issue was created.
 	local sig="[aidevops.sh](https://aidevops.sh) v${aidevops_version}"
 
-	# "in [CLI] vX.Y.Z"
+	# "plugin for [CLI] vX.Y.Z"
 	if [[ -n "$cli_name" ]]; then
 		local url
 		url=$(_cli_url "$cli_name")
 		if [[ -n "$url" ]]; then
-			sig="${sig} in [${cli_name}](${url})"
+			sig="${sig} plugin for [${cli_name}](${url})"
 		else
-			sig="${sig} in ${cli_name}"
+			sig="${sig} plugin for ${cli_name}"
 		fi
 		if [[ -n "$cli_version" ]]; then
 			sig="${sig} v${cli_version}"

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -66,9 +66,9 @@ echo ""
 # Test 1: generate with explicit CLI, model, tokens
 # ─────────────────────────────────────────────────────────────────────────────
 echo "Test 1: generate with all explicit fields"
-result=$("$HELPER" generate --cli "OpenCode CLI" --cli-version "1.3.3" --model "anthropic/claude-opus-4-6" --tokens 1234)
+result=$("$HELPER" generate --cli "OpenCode" --cli-version "1.3.3" --model "anthropic/claude-opus-4-6" --tokens 1234)
 assert_contains "starts with aidevops" "[aidevops.sh](https://aidevops.sh)" "$result"
-assert_contains "contains CLI with in" "in [OpenCode CLI](https://opencode.ai) v1.3.3" "$result"
+assert_contains "contains CLI with plugin for" "plugin for [OpenCode](https://opencode.ai) v1.3.3" "$result"
 assert_contains "model strips provider prefix" "with claude-opus-4-6" "$result"
 assert_not_contains "no provider prefix" "anthropic/" "$result"
 assert_contains "contains formatted tokens" "used 1,234 tokens" "$result"
@@ -79,7 +79,7 @@ assert_contains "contains formatted tokens" "used 1,234 tokens" "$result"
 echo ""
 echo "Test 2: explicit --tokens 0 omits tokens"
 result=$("$HELPER" generate --cli "Claude Code" --cli-version "2.0.1" --model "anthropic/claude-sonnet-4-6" --tokens 0)
-assert_contains "contains Claude Code" "in [Claude Code](https://claude.ai/code) v2.0.1" "$result"
+assert_contains "contains Claude Code" "plugin for [Claude Code](https://claude.ai/code) v2.0.1" "$result"
 assert_not_contains "no tokens field" "tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -87,7 +87,7 @@ assert_not_contains "no tokens field" "tokens" "$result"
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
 echo "Test 3: zero tokens omitted"
-result=$("$HELPER" generate --cli "OpenCode CLI" --model "anthropic/claude-opus-4-6" --tokens 0)
+result=$("$HELPER" generate --cli "OpenCode" --model "anthropic/claude-opus-4-6" --tokens 0)
 assert_not_contains "zero tokens omitted" "tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -96,7 +96,7 @@ assert_not_contains "zero tokens omitted" "tokens" "$result"
 echo ""
 echo "Test 4: no model"
 result=$("$HELPER" generate --cli "Cursor" --tokens 0)
-assert_contains "contains Cursor link" "in [Cursor](https://cursor.com)" "$result"
+assert_contains "contains Cursor link" "plugin for [Cursor](https://cursor.com)" "$result"
 assert_contains "contains aidevops" "aidevops.sh" "$result"
 assert_not_contains "no model field" "with " "$result"
 
@@ -105,9 +105,9 @@ assert_not_contains "no model field" "with " "$result"
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
 echo "Test 5: footer includes --- separator"
-result=$("$HELPER" footer --cli "OpenCode CLI" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
+result=$("$HELPER" footer --cli "OpenCode" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
 assert_contains "contains ---" "---" "$result"
-assert_contains "contains signature" "in [OpenCode CLI](https://opencode.ai) v1.0.0" "$result"
+assert_contains "contains signature" "plugin for [OpenCode](https://opencode.ai) v1.0.0" "$result"
 assert_contains "contains tokens" "used 5,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -132,7 +132,7 @@ assert_contains "7-digit with commas" "1,234,567 tokens" "$result"
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
 echo "Test 7: CLI URL mapping"
-result=$("$HELPER" generate --cli "OpenCode CLI" --model "m")
+result=$("$HELPER" generate --cli "OpenCode" --model "m")
 assert_contains "OpenCode URL" "https://opencode.ai" "$result"
 
 result=$("$HELPER" generate --cli "Claude Code" --model "m")
@@ -177,7 +177,7 @@ assert_not_contains "no CLI markdown link" "[SomeNewTool](" "$result"
 echo ""
 echo "Test 9: environment variable overrides"
 result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG_MODEL="test/model" AIDEVOPS_SIG_TOKENS="42000" "$HELPER" generate)
-assert_contains "env CLI name" "in EnvCLI" "$result"
+assert_contains "env CLI name" "plugin for EnvCLI" "$result"
 assert_contains "env CLI version" "v9.9.9" "$result"
 assert_contains "env model strips prefix" "with model" "$result"
 assert_contains "env tokens" "used 42,000 tokens" "$result"
@@ -188,7 +188,7 @@ assert_contains "env tokens" "used 42,000 tokens" "$result"
 echo ""
 echo "Test 10: auto-detect tokens from session DB"
 if [[ "${OPENCODE:-}" == "1" ]] && [[ -r "${HOME}/.local/share/opencode/opencode.db" ]]; then
-	result=$("$HELPER" generate --cli "OpenCode CLI" --model "anthropic/claude-opus-4-6")
+	result=$("$HELPER" generate --cli "OpenCode" --model "anthropic/claude-opus-4-6")
 	assert_contains "auto-detected tokens present" "tokens" "$result"
 else
 	echo "  SKIP: not running in OpenCode (auto-detect test requires OpenCode session DB)"
@@ -200,7 +200,7 @@ fi
 echo ""
 echo "Test 11: session time auto-detection (no response time)"
 if [[ "${OPENCODE:-}" == "1" ]] && [[ -r "${HOME}/.local/share/opencode/opencode.db" ]]; then
-	result=$("$HELPER" generate --cli "OpenCode CLI" --model "m" --tokens 1)
+	result=$("$HELPER" generate --cli "OpenCode" --model "m" --tokens 1)
 	assert_contains "session time present" "for " "$result"
 	assert_not_contains "no response time" "to respond" "$result"
 else


### PR DESCRIPTION
## Summary

- `in [OpenCode CLI]` → `plugin for [OpenCode]` — aidevops is a plugin for the host CLI, and "OpenCode" is the product name
- Updated build.txt: don't pass `--issue` when creating new issues (avoids "since this issue was created" on the issue body itself — the issue doesn't exist yet)

## Output

**Issue body** (no `--issue`):
> [aidevops.sh](https://aidevops.sh) v3.5.35 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 used 53,820,176 tokens for 2h 52m.

**Comment on existing issue** (`--issue`):
> ...used 53,820,176 tokens for 2h 52m, 2h 41m since this issue was created.

**Closing comment** (`--issue --solved`):
> ...used 53,820,176 tokens for 2h 52m. Solved in 2h 41m.

## Testing

- 43/43 tests pass
- ShellCheck clean

---
[aidevops.sh](https://aidevops.sh) v3.5.35 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 used 54,437,826 tokens for 2h 52m.