### PR TITLE
refactor: Signature phrasing — 'has used', sentence break before total time

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -188,9 +188,9 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 **GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM] [--solved]` to generate it. Example output:
 ```
 ---
-[aidevops.sh](https://aidevops.sh) v3.5.35 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 used 1,658,312 tokens for 42m. Solved in 3d 4h.
+[aidevops.sh](https://aidevops.sh) v3.5.36 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 1,658,312 tokens for 42m. Solved in 3d 4h.
 ```
-The helper auto-detects CLI, version, tokens (including cache), and session time from the runtime DB. Pass `--issue` on comments to existing issues for "Xm since this issue was created." phrasing. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+The helper auto-detects CLI, version, tokens (including cache), and session time from the runtime DB. Pass `--issue` on comments to existing issues for "Overall, Xm since this issue was created." phrasing. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -555,7 +555,7 @@ _build_signature() {
 	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then
 		local formatted
 		formatted=$(_format_number "$tokens")
-		sig="${sig} used ${formatted} tokens"
+		sig="${sig} has used ${formatted} tokens"
 	fi
 
 	# "for Xm" (session time)
@@ -570,16 +570,18 @@ _build_signature() {
 		has_stats="true"
 	fi
 
+	# Trailing period before optional total time
+	if [[ -n "$has_stats" ]]; then
+		sig="${sig}."
+	fi
+
+	# Total time as a separate sentence
 	if [[ -n "$total_time_str" ]]; then
 		if [[ "$solved" == "true" ]]; then
-			sig="${sig}. Solved in ${total_time_str}."
-		elif [[ -n "$session_time_str" ]]; then
-			sig="${sig}, ${total_time_str} since this issue was created."
+			sig="${sig} Solved in ${total_time_str}."
 		else
-			sig="${sig} ${total_time_str} since this issue was created."
+			sig="${sig} Overall, ${total_time_str} since this issue was created."
 		fi
-	elif [[ -n "$has_stats" ]]; then
-		sig="${sig}."
 	fi
 
 	echo "$sig"

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -71,7 +71,7 @@ assert_contains "starts with aidevops" "[aidevops.sh](https://aidevops.sh)" "$re
 assert_contains "contains CLI with plugin for" "plugin for [OpenCode](https://opencode.ai) v1.3.3" "$result"
 assert_contains "model strips provider prefix" "with claude-opus-4-6" "$result"
 assert_not_contains "no provider prefix" "anthropic/" "$result"
-assert_contains "contains formatted tokens" "used 1,234 tokens" "$result"
+assert_contains "contains formatted tokens" "has used 1,234 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 2: generate with explicit --tokens 0 (should omit tokens)
@@ -108,7 +108,7 @@ echo "Test 5: footer includes --- separator"
 result=$("$HELPER" footer --cli "OpenCode" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
 assert_contains "contains ---" "---" "$result"
 assert_contains "contains signature" "plugin for [OpenCode](https://opencode.ai) v1.0.0" "$result"
-assert_contains "contains tokens" "used 5,000 tokens" "$result"
+assert_contains "contains tokens" "has used 5,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 6: comma formatting for various numbers
@@ -180,7 +180,7 @@ result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG
 assert_contains "env CLI name" "plugin for EnvCLI" "$result"
 assert_contains "env CLI version" "v9.9.9" "$result"
 assert_contains "env model strips prefix" "with model" "$result"
-assert_contains "env tokens" "used 42,000 tokens" "$result"
+assert_contains "env tokens" "has used 42,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 10: auto-detect tokens from OpenCode session DB (if running in OpenCode)
@@ -215,7 +215,7 @@ echo "Test 12: total time with --issue-created"
 two_hours_ago=$(date -u -v-2H "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "2 hours ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
 if [[ -n "$two_hours_ago" ]]; then
 	result=$("$HELPER" generate --cli "Test" --model "m" --tokens 1 --issue-created "$two_hours_ago")
-	assert_contains "total time present" "since this issue was created" "$result"
+	assert_contains "total time present" "Overall, 2h since this issue was created" "$result"
 	assert_contains "total time ~2h" "2h" "$result"
 else
 	echo "  SKIP: date command does not support relative time"


### PR DESCRIPTION
## Summary

- `used` → `has used` (present perfect — session is ongoing)
- Total time is now a separate sentence with period break: `for 42m. Overall, 1h 28m since this issue was created.`
- Solved variant: `for 42m. Solved in 1h 28m.`

## Testing

- 43/43 tests pass
- ShellCheck clean

---
[aidevops.sh](https://aidevops.sh) v3.5.36 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 59,784,815 tokens for 2h 59m.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated GitHub comment signature generation with revised wording for token usage reporting and adjusted time calculation formatting when using the `--issue` flag.

* **Tests**
  * Updated test cases to reflect the new signature formatting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->