### PR TITLE
#12224: docs(architecture): tighten layers.md — remove redundant dependency table and prose

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md
@@ -177,13 +177,6 @@ Presentation ──calls──▶ Application ──uses──▶ Domain (interf
 Infrastructure ──────implements──────────────────────┘
 ```
 
-| From | To | Relationship |
-|------|----|-------------|
-| Presentation | Application | calls use case ports |
-| Application | Domain | uses entities, defines interfaces |
-| Infrastructure | Domain | implements repository/event interfaces |
-| Infrastructure | Application | implements unit-of-work, event publisher |
-
 ---
 
 ## Composition Root
@@ -201,8 +194,6 @@ Wire all dependencies at the application entry point (e.g. `infrastructure/confi
 ---
 
 ## Language-Agnostic Structure
-
-Dependency direction is the invariant: outer layers import inner layers, never the reverse.
 
 | Language | Root | Presentation alias |
 |----------|------|--------------------|


### PR DESCRIPTION
## Summary

- Removes the dependency relationship table (lines 180-185) that fully duplicates the ASCII diagram directly above it — the diagram is more readable and sufficient
- Removes one prose sentence in "Language-Agnostic Structure" that restates the dependency direction rule already established throughout the document
- 213 → 204 lines (4.2% reduction); all code blocks, URLs, directory trees, and structural knowledge preserved

## Classification

**Reference corpus** (textbook-style chapter with code examples) — prose tightening applied, not content compression. Per `tools/code-review/code-simplifier.md` "Reference corpora" guidance.

## Verification

- All code blocks present: Domain (TypeScript), Application (TypeScript), Infrastructure (pseudocode), Presentation (TypeScript)
- All directory trees present: `domain/`, `application/`, `infrastructure/`
- All URLs preserved in sources blockquote
- No broken internal links (`cheatsheet.md` references `layers.md` by filename, no section anchors affected)
- Agent behaviour unchanged — no rules, constraints, or decision logic removed

## Runtime Testing

- **Risk level**: Low (agent docs, no runtime code)
- **Level**: self-assessed
- **Smoke check**: File renders correctly, all section headings intact, no broken markdown

Closes #12224

---

---
[aidevops.sh](https://aidevops.sh) v3.5.37 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 1,247,400 tokens for 4m.