### PR TITLE
12188: simplification: tighten browser-profiles.md

### DIFF
--- a/.agents/tools/browser/browser-profiles.md
+++ b/.agents/tools/browser/browser-profiles.md
@@ -12,10 +12,6 @@ tools:
 
 <!-- AI-CONTEXT-START -->
 
-## Overview
-
-Profile management system replicating commercial anti-detect browsers (AdsPower, GoLogin, OctoBrowser). Each profile maintains its own fingerprint, cookies, proxy, and browsing state.
-
 ## Profile Storage
 
 ```text


### PR DESCRIPTION
## Summary

- Removed redundant `## Overview` section (4 lines) that duplicated the frontmatter `description` field
- All code blocks, tables, CLI examples, Python API patterns, and integration points preserved verbatim
- File: `.agents/tools/browser/browser-profiles.md` — 229 → 225 lines

## Classification

This file is a **reference corpus** (code examples, CLI reference, comparison table). The bulk of the content is non-compressible code blocks. The only genuine prose redundancy was the Overview section.

## Runtime Testing

- **Risk level**: Low (agent doc, no executable code changed)
- **Verification**: `self-assessed` — all code blocks, URLs, command examples, and integration point references present before and after

## Actionable Findings

- `actionable_findings_total=1`
- `fixed_in_pr=1`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12188

---
[aidevops.sh](https://aidevops.sh) v3.5.37 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 723,020 tokens for 4m.