### PR TITLE
GH#12195: simplification: tighten animejs.md 226→222 lines

### DIFF
--- a/.agents/tools/animation/animejs.md
+++ b/.agents/tools/animation/animejs.md
@@ -9,8 +9,6 @@ context7_id: /websites/animejs
 ---
 # Anime.js
 
-Lightweight JavaScript animation library. Works with CSS properties, SVG, DOM attributes, and JS objects.
-
 ## Quick Reference
 
 ```javascript
@@ -127,7 +125,6 @@ tl.seek('content');
 ## Stagger
 
 ```javascript
-// Basic
 animate('.items', { translateY: [50, 0], delay: stagger(100) });
 
 // Options
@@ -165,7 +162,6 @@ animate('.element', { ...path(), duration: 2000, ease: 'linear' });
 
 ```javascript
 animate('.element', {
-  translateX: 250,
   onBegin: (anim) => {},
   onUpdate: (anim) => {},   // anim.progress (0–100)
   onLoop: (anim) => {},


### PR DESCRIPTION
## Summary

- Remove redundant intro sentence (duplicates frontmatter `description` field)
- Remove `// Basic` comment in Stagger section (self-evident from code)
- Remove filler `translateX: 250` property from Callbacks example (irrelevant to callbacks demo)

## Classification

This is a **reference corpus** (imported from context7, cheat-sheet style). The file was already tightened from 496→222 lines across two PRs. Further content compression would lose knowledge — these 4 lines are genuine noise.

## Verification

- All code blocks preserved
- All URLs preserved
- All section headings preserved
- Migration table preserved
- No knowledge removed — only decorative/redundant lines

## Runtime Testing

- **Risk level**: Low (docs-only change)
- **Level**: self-assessed
- **Dev environment**: N/A

## Files Changed

- `.agents/tools/animation/animejs.md` — removed 4 redundant lines (226→222)

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12195

---
[aidevops.sh](https://aidevops.sh) v3.5.37 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 694,230 tokens for 4m.