### PR TITLE
12221: tighten resources.md — 214→54 lines, defer to service-links.md

### DIFF
--- a/.agents/aidevops/resources.md
+++ b/.agents/aidevops/resources.md
@@ -17,198 +17,38 @@ tools:
 
 ## Quick Reference
 
-- **Hosting APIs**: Hostinger, Hetzner, Closte, Cloudron, Coolify
-- **Quality APIs**: CodeRabbit, CodeFactor, Codacy, SonarCloud
-- **Git APIs**: GitHub REST/GraphQL, GitLab v4, Gitea
-- **DNS APIs**: Cloudflare, Namecheap, Route 53
-- **MCP Protocol**: https://spec.modelcontextprotocol.io/
+- **Service links** (hosting, DNS, git, quality, AI tools, MCP consoles): `service-links.md`
+- **MCP Protocol spec**: https://spec.modelcontextprotocol.io/
 - **AGENTS.md Standard**: https://agents.md/
-- **CLI Tools**: jq, curl, git, Bitwarden CLI
-- **DevOps**: Terraform, Ansible, Docker, Kubernetes
-- **CI/CD**: GitHub Actions, GitLab CI/CD
-- **Config templates**: `configs/[service]-config.json.txt`
+- **Config templates**: `../configs/[service]-config.json.txt`
+
 <!-- AI-CONTEXT-END -->
 
-## Service Documentation & APIs
+## Service Links
 
-### Infrastructure & Hosting
+For all service consoles and API docs (hosting, DNS, git platforms, quality tools, AI CLI tools, MCP integrations), see `service-links.md`.
 
-- **Hostinger API**: https://developers.hostinger.com/
-- **Hetzner Cloud API**: https://docs.hetzner.cloud/
-- **Closte API**: https://closte.com/api-documentation
-- **Cloudron API**: https://docs.cloudron.io/api/
+## MCP Server Repositories
 
-### Deployment & Orchestration
-
-- **Coolify API**: https://coolify.io/docs/api-reference
-- **Coolify GitHub**: https://github.com/coollabsio/coolify
-
-### Content Management
-
-- **MainWP API**: https://mainwp.com/help/mainwp-rest-api/
-- **MainWP Extensions**: https://mainwp.com/extensions/
-
-### Security & Secrets
-
-- **Vaultwarden**: https://github.com/dani-garcia/vaultwarden
-- **Bitwarden API**: https://bitwarden.com/help/api/
-- **Bitwarden CLI**: https://bitwarden.com/help/cli/
-
-### Code Quality & Auditing
-
-- **CodeRabbit API**: https://docs.coderabbit.ai/
-- **CodeFactor API**: https://docs.codefactor.io/
-- **Codacy API**: https://docs.codacy.com/codacy-api/
-- **SonarCloud API**: https://docs.sonarsource.com/sonarqube-cloud/
-
-### Version Control & Git Platforms
-
-- **GitHub API**: https://docs.github.com/en/rest
-- **GitLab API**: https://docs.gitlab.com/ee/api/
-- **Gitea API**: https://docs.gitea.io/en-us/api-usage/
-
-### Email Services
-
-- **Amazon SES API**: https://docs.aws.amazon.com/ses/
-- **SES Developer Guide**: https://docs.aws.amazon.com/ses/latest/dg/
-
-### Domain & DNS
-
-- **Spaceship API**: https://spaceship.com/api
-- **101domains API**: https://101domain.com/api
-- **Cloudflare API**: https://developers.cloudflare.com/api/
-- **Namecheap API**: https://www.namecheap.com/support/api/
-- **Route 53 API**: https://docs.aws.amazon.com/route53/
-
-## MCP Server Resources
-
-### Official MCP Servers
-
-- **Context7 MCP**: https://github.com/context7/mcp-server
-- **Bitwarden MCP**: https://github.com/bitwarden/mcp-server
-- **GitHub MCP**: https://github.com/github/mcp-server
-
-### Community MCP Servers
-
-- **Codacy MCP**: https://github.com/codacy/codacy-mcp-server
-- **SonarQube MCP**: https://github.com/SonarSource/sonarqube-mcp-server
-- **GitLab MCP**: https://gitlab.com/gitlab-org/mcp-server
-
-### MCP Protocol Documentation
-
-- **MCP Specification**: https://spec.modelcontextprotocol.io/
-- **MCP SDK**: https://github.com/modelcontextprotocol/sdk
-- **MCP Examples**: https://github.com/modelcontextprotocol/examples
-
-## Development Tools & Resources
-
-### CLI Tools
-
-- **jq (JSON processor)**: https://jqlang.github.io/jq/
-- **curl (HTTP client)**: https://curl.se/docs/
-- **git (Version control)**: https://git-scm.com/docs
-- **Bitwarden CLI**: https://bitwarden.com/help/cli/
-
-### Package Managers
-
-- **Homebrew (macOS)**: https://brew.sh/
-- **APT (Ubuntu/Debian)**: https://ubuntu.com/server/docs/package-management
-- **npm (Node.js)**: https://docs.npmjs.com/
-
-### Security Tools
-
-- **OpenSSL**: https://www.openssl.org/docs/
-- **GPG**: https://gnupg.org/documentation/
-- **SSH**: https://www.openssh.com/manual.html
+| MCP | Repository |
+|-----|------------|
+| Context7 | https://github.com/context7/mcp-server |
+| Bitwarden | https://github.com/bitwarden/mcp-server |
+| GitHub | https://github.com/github/mcp-server |
+| Codacy | https://github.com/codacy/codacy-mcp-server |
+| SonarQube | https://github.com/SonarSource/sonarqube-mcp-server |
+| GitLab | https://gitlab.com/gitlab-org/mcp-server |
+| MCP SDK | https://github.com/modelcontextprotocol/sdk |
+| MCP Examples | https://github.com/modelcontextprotocol/examples |
 
 ## Standards & Specifications
 
-### AI Agent Standards
-
-- **AGENTS.md Standard**: https://agents.md/
-- **Agent Directory Proposal**: https://github.com/agents-md/agents.md
-- **MCP Protocol**: https://spec.modelcontextprotocol.io/
-
-### API Standards
-
-- **REST API Design**: https://restfulapi.net/
-- **OpenAPI Specification**: https://swagger.io/specification/
-- **JSON Schema**: https://json-schema.org/
-
-### Security Standards
-
-- **OWASP API Security**: https://owasp.org/www-project-api-security/
-- **OAuth 2.0**: https://oauth.net/2/
-- **JWT**: https://jwt.io/
-
-## Monitoring & Observability
-
-### Monitoring Tools
-
-- **Prometheus**: https://prometheus.io/docs/
-- **Grafana**: https://grafana.com/docs/
-- **Uptime Robot**: https://uptimerobot.com/api/
-
-### Log Management
-
-- **ELK Stack**: https://www.elastic.co/elastic-stack/
-- **Fluentd**: https://docs.fluentd.org/
-- **Logrotate**: https://linux.die.net/man/8/logrotate
-
-## DevOps Resources
-
-### Infrastructure as Code
-
-- **Terraform**: https://developer.hashicorp.com/terraform/docs
-- **Ansible**: https://docs.ansible.com/
-- **Docker**: https://docs.docker.com/
-
-### CI/CD Platforms
-
-- **GitHub Actions**: https://docs.github.com/en/actions
-- **GitLab CI/CD**: https://docs.gitlab.com/ee/ci/
-- **Jenkins**: https://www.jenkins.io/doc/
-
-### Container Orchestration
-
-- **Kubernetes**: https://kubernetes.io/docs/
-- **Docker Compose**: https://docs.docker.com/compose/
-- **Portainer**: https://docs.portainer.io/
-
-## Learning Resources
-
-### DevOps Learning
-
-- **DevOps Roadmap**: https://roadmap.sh/devops
-- **AWS Training**: https://aws.amazon.com/training/
-- **Google Cloud Training**: https://cloud.google.com/training
-
-### API Development
-
-- **Postman Learning**: https://learning.postman.com/
-- **REST API Tutorial**: https://restapitutorial.com/
-- **GraphQL Learning**: https://graphql.org/learn/
-
-### Security Learning
-
-- **OWASP Learning**: https://owasp.org/www-project-top-ten/
-- **Security Headers**: https://securityheaders.com/
-- **SSL Labs**: https://www.ssllabs.com/ssltest/
-
-## Configuration Examples
-
-### Service Configuration Templates
-
-- All configuration templates are in `../configs/` directory
-- Follow the pattern: `[service]-config.json.txt`
-- Use placeholder values like `YOUR_API_TOKEN_HERE`
-
-### Environment Setup
-
-- **macOS Setup**: Use Homebrew for package management
-- **Linux Setup**: Use distribution package manager
-- **Windows Setup**: Use WSL2 for best compatibility
-
----
-
-**These resources provide comprehensive external documentation and tools needed to effectively use and extend the AI DevOps Framework.**
+| Standard | URL |
+|----------|-----|
+| MCP Specification | https://spec.modelcontextprotocol.io/ |
+| AGENTS.md | https://agents.md/ |
+| OpenAPI | https://swagger.io/specification/ |
+| JSON Schema | https://json-schema.org/ |
+| OWASP API Security | https://owasp.org/www-project-api-security/ |
+| OAuth 2.0 | https://oauth.net/2/ |
+| JWT | https://jwt.io/ |


### PR DESCRIPTION
## Summary

- Reduces `resources.md` from 214 to 54 lines (75% reduction)
- Removes generic noise: learning resources, generic DevOps tools (Terraform, Ansible, Docker, Kubernetes, Jenkins, ELK, Prometheus, Grafana), package managers, environment setup — none of this is aidevops-specific
- Removes service API links that duplicate `service-links.md` (hosting, DNS, git, quality, security)
- Preserves unique content: MCP server GitHub repos table + standards/specifications table
- Adds pointer to `service-links.md` as the canonical service link directory

## Files Changed

- `.agents/aidevops/resources.md` — rewritten as slim pointer + unique content only

## Runtime Testing

- Risk: **Low** (docs/agent prompt only, no code)
- Level: `self-assessed`
- Verification: markdownlint 0 errors, content preservation confirmed

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12221


---
[aidevops.sh](https://aidevops.sh) v3.5.37 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 1,174,023 tokens for 5m.