### PR TITLE
#12196: simplification: tighten OpenCode GitHub Security Guide

### DIFF
--- a/.agents/tools/git/opencode-github-security.md
+++ b/.agents/tools/git/opencode-github-security.md
@@ -21,8 +21,6 @@ tools:
 - **Trigger**: `/oc` or `/opencode` in issue/PR comments
 - **Requirements**: Collaborator access + `ai-approved` label on issues
 
-**Security Layers**:
-
 | Layer | Protection |
 |-------|------------|
 | User validation | OWNER/MEMBER/COLLABORATOR only |
@@ -36,52 +34,39 @@ tools:
 
 ## Threat Model
 
-| Attack | Mitigations |
-|--------|-------------|
-| **Prompt injection** (hidden instructions in issues) | `ai-approved` label (maintainer reviews first); pattern detection; system prompt forbids unsafe actions |
-| **Unauthorized execution** (untrusted user comments `/oc`) | OWNER/MEMBER/COLLABORATOR only; untrusted users get notice; all attempts logged |
-| **Credential exfiltration** (`/oc read .env`) | System prompt forbids credential files; pattern detection blocks secret/token/password mentions; no network beyond GitHub API |
-| **Workflow tampering** (`/oc modify the workflow`) | System prompt forbids workflow edits; `actions:` permission not granted; changes require PR review |
-| **Resource exhaustion** (spam `/oc`) | Concurrency limit: one execution at a time; 15-min timeout; collaborators only |
-
-### Residual Risks
-
-| Risk | Likelihood | Impact | Mitigation |
-|------|------------|--------|------------|
-| Novel prompt injection | Medium | Medium | Human PR review required |
-| Compromised collaborator | Low | High | Audit logs, PR review |
-| AI hallucination/mistakes | Medium | Low | PR review, CI checks |
-| API key exposure | Low | Medium | GitHub Secrets, rotation policy |
+| Attack | Mitigations | Residual risk |
+|--------|-------------|---------------|
+| **Prompt injection** (hidden instructions in issues) | `ai-approved` label; pattern detection; system prompt forbids unsafe actions | Novel patterns — Medium/Medium — human PR review |
+| **Unauthorized execution** (untrusted user comments `/oc`) | OWNER/MEMBER/COLLABORATOR only; untrusted users notified; all attempts logged | Compromised collaborator — Low/High — audit logs, PR review |
+| **Credential exfiltration** (`/oc read .env`) | System prompt forbids credential files; pattern detection blocks secret/token/password; no network beyond GitHub API | API key exposure — Low/Medium — GitHub Secrets, rotation policy |
+| **Workflow tampering** (`/oc modify the workflow`) | System prompt forbids workflow edits; `actions:` permission not granted; changes require PR review | AI hallucination — Medium/Low — PR review, CI checks |
+| **Resource exhaustion** (spam `/oc`) | Concurrency limit: one execution at a time; 15-min timeout; collaborators only | — |
 
 ## Security Configuration
 
-### Required Labels
+### Labels
 
 ```bash
 gh label create "ai-approved" --color "0E8A16" --description "Issue approved for AI agent processing"
 gh label create "security-review" --color "D93F0B" --description "Requires security review - suspicious AI request"
 ```
 
-| Label | Color | Purpose |
-|-------|-------|---------|
-| `ai-approved` | `#0E8A16` | Issue vetted for AI processing |
-| `security-review` | `#D93F0B` | Auto-added when suspicious patterns detected |
+- `ai-approved` (`#0E8A16`) — issue vetted for AI processing
+- `security-review` (`#D93F0B`) — auto-added when suspicious patterns detected
 
-### Secrets Configuration
+### Secrets
 
-Only one secret required: `ANTHROPIC_API_KEY` (rotate every 90 days).
-
-**Do NOT add**: Personal Access Tokens with elevated permissions, deployment credentials, or other API keys.
+Only one secret required: `ANTHROPIC_API_KEY` (rotate every 90 days). **Do NOT add** PATs with elevated permissions, deployment credentials, or other API keys.
 
 ### Branch Protection
 
-Require on `main`/`master`: PR reviews before merging, status checks to pass, branches up to date, no bypass. This ensures AI-created PRs always require human review.
+Require on `main`/`master`: PR reviews before merging, status checks to pass, branches up to date, no bypass. Ensures AI-created PRs always require human review.
 
-## Workflow Deep Dive
+## Workflow
 
 ### Security Check Job
 
-Validates before any AI execution. Checks: trigger presence, user association (must be trusted), label requirement (issues), pattern scanning.
+Validates before any AI execution: trigger presence, user association (must be trusted), label requirement (issues), pattern scanning.
 
 ### Suspicious Pattern Detection
 
@@ -139,15 +124,9 @@ permissions:
 
 ## Usage Guide
 
-### For Maintainers
+**Maintainers — approving an issue**: Review content for safety, check raw markdown for hidden content, add `ai-approved` label. For `security-review` alerts: check Actions log → review triggering comment → remove label or take action.
 
-**Approving an issue**: Review content for safety, check raw markdown for hidden content, add `ai-approved` label.
-
-**Responding to `security-review` alerts**: Check Actions log for what was blocked → review triggering comment → determine false positive or threat → remove label or take action.
-
-### For Collaborators
-
-**Safe commands**:
+**Collaborators — safe commands**:
 
 ```text
 /oc explain this issue
@@ -166,45 +145,25 @@ permissions:
 /oc modify the GitHub workflow               # Workflow tampering
 ```
 
-### For External Contributors
+**External contributors** (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE) cannot trigger the agent — describe what you need and a maintainer can run it, or submit a PR manually.
 
-External contributors (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE) cannot trigger the AI agent. Options: describe what you need and a maintainer can run it, or submit a PR manually.
-
-## Monitoring & Alerts
+## Monitoring
 
 ```bash
-# List recent AI agent runs
 gh run list --workflow=opencode-agent.yml --limit=20
-
-# View specific run logs
 gh run view <run-id> --log
 ```
 
 Set up failure notifications: Repository → Settings → Actions → General → Email notifications.
 
-**Weekly/monthly review checklist**:
-- [ ] Check for `security-review` labeled issues
-- [ ] Review audit logs for unusual patterns
-- [ ] Verify branch protection still enabled
-- [ ] Rotate API key if approaching 90 days
-- [ ] Review any PRs created by AI agent
+Weekly/monthly: check `security-review` issues · review audit logs · verify branch protection · rotate API key if approaching 90 days · review AI-created PRs.
 
 ## Incident Response
 
-### Suspicious Activity
-
-1. **Disable**: `gh workflow disable opencode-agent.yml`
-2. **Investigate**: `gh run list --workflow=opencode-agent.yml --json conclusion,createdAt,headBranch`
-3. **Contain**: `git revert <commit-sha>`
-4. **Rotate**: Change API key in GitHub Secrets
-5. **Report**: Document incident and update patterns if needed
-
-### API Key Compromised
-
-1. Rotate immediately in Anthropic dashboard
-2. Update GitHub Secret
-3. Review recent API usage for anomalies
-4. Check if key was exposed in logs/commits
+| Scenario | Steps |
+|----------|-------|
+| **Suspicious activity** | 1. Disable: `gh workflow disable opencode-agent.yml` · 2. Investigate: `gh run list --workflow=opencode-agent.yml --json conclusion,createdAt,headBranch` · 3. Contain: `git revert <commit-sha>` · 4. Rotate API key · 5. Document and update patterns |
+| **API key compromised** | 1. Rotate immediately in Anthropic dashboard · 2. Update GitHub Secret · 3. Review recent API usage for anomalies · 4. Check if key was exposed in logs/commits |
 
 ## OpenCode App vs Bot Account
 
@@ -217,9 +176,9 @@ Set up failure notifications: Repository → Settings → Actions → General �
 | **Cost** | GitHub Actions minutes | Hosting + Actions |
 | **Recommendation** | **Preferred for security** | Only if specific needs |
 
-## Related Documentation
+## Related
 
-- `tools/git/opencode-github.md` - Basic setup guide
-- `tools/git/github-cli.md` - GitHub CLI reference
-- `workflows/git-workflow.md` - Git workflow standards
-- `aidevops/security-requirements.md` - Framework security requirements
+- `tools/git/opencode-github.md` — Basic setup guide
+- `tools/git/github-cli.md` — GitHub CLI reference
+- `workflows/git-workflow.md` — Git workflow standards
+- `aidevops/security-requirements.md` — Framework security requirements


### PR DESCRIPTION
## Summary

- Reduces `.agents/tools/git/opencode-github-security.md` from 225 to 184 lines (−18%)
- Merges threat model + residual risks tables into one combined table
- Collapses Usage Guide section headers into inline prose
- Compresses Incident Response two sub-sections into a two-row table
- Tightens Monitoring checklist to a single line
- Removes redundant "Security Layers" label from Quick Reference (table already conveys it)

## Content Preservation

All code blocks, pattern detection regexes, audit log JSON, permission YAML, URLs, and institutional knowledge preserved. Verified with `rg` across all key identifiers.

## Risk

**Low** — docs-only change, no code or workflow modifications. Self-assessed.

## Runtime Testing

- Risk level: Low (agent prompt / docs only)
- Verification: self-assessed — content diff reviewed, all code blocks and references confirmed present

Closes #12196


---
[aidevops.sh](https://aidevops.sh) v3.5.37 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 668,755 tokens for 5m.