### PR TITLE
docs: tighten multi-org-isolation.md agent doc (205→203 lines)

### DIFF
--- a/.agents/services/database/multi-org-isolation.md
+++ b/.agents/services/database/multi-org-isolation.md
@@ -32,9 +32,7 @@ tools:
 
 ## Architecture Overview
 
-### Isolation Strategy: Row-Level Tenancy
-
-Row-level tenancy chosen (shared database, shared schema, `org_id` column) — orgs share the same feature set, superadmin needs cross-org visibility, single migration path, PostgreSQL RLS enforces at DB level.
+Row-level tenancy (shared database, shared schema, `org_id` column) — orgs share the same feature set, superadmin needs cross-org visibility, single migration path, PostgreSQL RLS enforces at DB level.
 
 | Strategy | Pros | Cons | When to use |
 |----------|------|------|-------------|
@@ -50,7 +48,7 @@ Row-level tenancy chosen (shared database, shared schema, `org_id` column) — o
 | **Org-optional** | Nullable | Conditional | memories, patterns (can be global or org-specific) |
 | **Global** | None | None | organisations, users, system_config |
 
-## Schema Design
+## Schema
 
 ### Entity Relationship
 
@@ -176,9 +174,9 @@ const superadminDb = drizzle(superuserPool);
 const allOrgs = await superadminDb.select().from(organisations);
 ```
 
-## Integration with Existing Multi-Tenant Credentials
+## Credential System Integration
 
-File-based credential system continues to work for CLI/local development. Database schema adds server-side isolation for hosted/multi-user deployments.
+File-based credential system continues for CLI/local development. Database schema adds server-side isolation for hosted/multi-user deployments.
 
 | Existing concept | New schema equivalent |
 |-----------------|----------------------|


### PR DESCRIPTION
## Summary

- Removed redundant `### Isolation Strategy: Row-Level Tenancy` heading — prose was a single line already captured by the table's "(chosen)" marker
- `## Schema Design` → `## Schema` (shorter, same meaning)
- `## Integration with Existing Multi-Tenant Credentials` → `## Credential System Integration` (concise)
- Tightened one prose line in credential section

All code blocks, task IDs (t004.1–t004.5), command examples, file paths, and decision rationale preserved. 205→203 lines.

Closes #12174

## Runtime Testing

- **Risk level**: Low (agent doc, no code)
- **Level**: self-assessed
- **Verification**: all task IDs, code blocks, URLs, and command examples present before and after

## Files Changed

- `.agents/services/database/multi-org-isolation.md` — prose tightening, redundant heading removal, section title shortening

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

---
[aidevops.sh](https://aidevops.sh) v3.5.37 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 1,130,365 tokens for 5m.