### PR TITLE
12192: tighten durable-objects-patterns.md prose

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1332,9 +1332,9 @@
       "pr": 12071
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md": {
-      "hash": "955301443c3fc1556d8d226fa318dc99d277c7ef",
-      "at": "2026-03-28T20:56:10Z",
-      "pr": 12189
+      "hash": "70f6f1b16aeb637c122232aa75b789bedfbe63a7",
+      "at": "2026-03-28T21:50:53Z",
+      "pr": 12192
     },
     ".agents/tools/browser/fingerprint-profiles.md": {
       "hash": "d910625e173f65063d64d51ca549494b97a2ba87",

--- a/.agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md
@@ -7,7 +7,6 @@ Don't put all data in a single DO. For hierarchical data (workspaces → project
 ```typescript
 export class GameServer extends DurableObject<Env> {
   async createMatch(matchId: string): Promise<string> {
-    // Store child reference in parent
     this.ctx.storage.sql.exec(
       "INSERT INTO matches (id, created_at, status) VALUES (?, ?, ?)",
       matchId, Date.now(), "active"
@@ -16,7 +15,6 @@ export class GameServer extends DurableObject<Env> {
   }
 
   async routeToMatch(matchId: string, playerId: string, action: string) {
-    // Route to child DO - operations on different children run in parallel
     const childId = this.env.MATCH.idFromName(matchId);
     const child = this.env.MATCH.get(childId);
     return await child.handleAction(playerId, action);
@@ -49,7 +47,7 @@ app.all('*', async (c) => {
   return c.env.FLEET_DO.get(id).fetch(c.req.raw);
 });
 
-// Single unified DO class handles both manager and agent roles
+// Single DO class handles both manager and agent roles
 export class FleetDO extends DurableObject<Env> {
   async deleteWithCascade() {
     const data = await this.ctx.storage.get<{ agents: string[] }>('data');
@@ -59,7 +57,6 @@ export class FleetDO extends DurableObject<Env> {
       const child = this.env.FLEET_DO.get(this.env.FLEET_DO.idFromName(childPath));
       await child.fetch(new Request('https://internal' + childPath, { method: 'DELETE' }));
     }
-    
     await this.ctx.storage.deleteAll();
   }
 }
@@ -105,9 +102,8 @@ export class UserDO extends DurableObject<Env> {
   }
 }
 
-// Worker
-const id = env.USER_DO.idFromName(userId); // deterministic per-user routing
-const user = env.USER_DO.get(id);
+// Worker: deterministic per-user routing
+const stub = env.USER_DO.get(env.USER_DO.idFromName(userId));
 ```
 
 ## Colo-Aware Sharding


### PR DESCRIPTION
## Summary

- Remove self-evident inline comments from code examples (`// Store child reference in parent`, `// Route to child DO`)
- Tighten `FleetDO` comment: "Single unified DO class" → "Single DO class"
- Remove trailing blank line inside `FleetDO.deleteWithCascade()` code block
- Consolidate redundant Worker snippet: two lines → one (`const stub = env.USER_DO.get(env.USER_DO.idFromName(userId))`)
- Update simplification state registry with new hash

244 → 240 lines. All patterns, code blocks, section headings, and Best Practices content preserved.

Closes #12192

## Runtime Testing

- **Risk level**: Low (agent doc — no runtime behaviour)
- **Verification**: self-assessed — all code blocks, section headings, and Best Practices bullets verified present before and after

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md` — remove self-evident comments, tighten Worker snippet
- `.agents/configs/simplification-state.json` — update hash for this file (pr: 12192)

## Actionable Findings

actionable_findings_total=0, fixed_in_pr=0, deferred_tasks_created=0, coverage=100%