### PR TITLE
t1682: fix: add errored MCP server guard to AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -35,6 +35,15 @@ New to aidevops? Type `/onboarding`.
 
 **Specialist subagents**: `@aidevops`, `@seo`, `@wordpress`, etc.
 
+## Errored MCP Server Guard (t1682)
+
+MCP servers that fail to start (e.g., "MCP error -32000: Connection closed", "spawn ENOENT", "ECONNREFUSED") may still have their tool schemas present in the tool list. Calling these tools wastes tokens and always fails.
+
+- When a tool call returns "MCP error -32000", "Connection closed", "spawn ENOENT", or similar startup errors, mark that MCP server as unavailable for the rest of the session. Do NOT retry tools from that server.
+- If you see tools in the tool list from a server that has previously errored, skip them entirely — do not attempt to call them.
+- To identify and fix errored MCP servers: `~/.aidevops/agents/scripts/mcp-diagnose.sh check-all`. This scans all enabled MCP servers and reports which ones are unavailable, with remediation steps.
+- To disable a persistently errored server: set `"enabled": false` in your runtime's MCP config for that server entry. This removes its tool schemas from context entirely. Claude Code CLI: `~/.config/Claude/Claude.json`; Claude Desktop (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`.
+
 ## Pre-Edit Git Check
 
 > **Skip this section if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent). Instead, proceed directly to responding to the user.


### PR DESCRIPTION
## Summary

- Adds the **Errored MCP Server Guard** section to `.agents/AGENTS.md` (user-facing guide), mirroring the guard already present in `prompts/build.txt`
- MCP servers that fail to start (e.g., `MCP error -32000: Connection closed`, `spawn ENOENT`) may still have tool schemas registered in context; calling them wastes tokens and always fails
- Guard instructs agents to: detect error patterns on first call, skip all subsequent calls to that server, use `mcp-diagnose.sh check-all` to identify dead servers, and disable via `"enabled": false` in MCP config

## Files Changed

- `.agents/AGENTS.md` — added "Errored MCP Server Guard (t1682)" section after the Specialist subagents line, before Pre-Edit Git Check

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only — no code logic changed)
- **Level**: self-assessed
- **Lint**: markdownlint-cli2 — 0 errors

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12270


---
[aidevops.sh](https://aidevops.sh) v3.5.54 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 945,496 tokens for 2m.