### PR TITLE
t1681: finalise plugin tools.mjs consolidation (7→4 tools)

### DIFF
--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -160,10 +160,9 @@ function createPreEditCheckTool(scriptsDir) {
  *
  * @param {string} scriptsDir - Path to scripts directory
  * @param {function} run - Shell command runner
- * @param {object} _pipelines - Quality pipeline functions (unused — kept for API compatibility)
  * @returns {Record<string, object>}
  */
-export function createTools(scriptsDir, run, _pipelines) {
+export function createTools(scriptsDir, run) {
   return {
     aidevops: createAidevopsTool(run),
     aidevops_memory: createMemoryTool(scriptsDir, run),

--- a/.agents/reference/memory-lookup.md
+++ b/.agents/reference/memory-lookup.md
@@ -12,7 +12,7 @@ every vague reference — match the source to the question.
 
 ## Tier 1 — Local cached (instant, zero cost)
 
-1. **Cross-session memory**: `memory-helper.sh recall "keywords"` (CLI) or `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have the answer. Solutions, decisions, preferences, patterns.
+1. **Cross-session memory**: `memory-helper.sh recall "keywords"` (CLI) or `aidevops_memory` MCP tool with `action: "recall"` — curated signal, most likely to have the answer. Solutions, decisions, preferences, patterns.
 2. **TODO.md + completed tasks**: `rg "keyword" TODO.md` — task IDs, PR numbers, completion dates, brief descriptions of all past work.
 
 ## Tier 2 — Local indexed (fast, local I/O)


### PR DESCRIPTION
## Summary

Closes #12269

Finalises the t1681 consolidation of opencode-aidevops plugin tools from 7 to 4. The bulk of the work was done in prior PRs (#6836 merged memory_recall+memory_store into aidevops_memory, #11115 removed aidevops_install_hooks). This PR closes the remaining cleanup items:

- **Remove dead `_pipelines` parameter** from `createTools()` in `tools.mjs` — the parameter was marked `_pipelines` (unused) and `index.mjs` already called `createTools(SCRIPTS_DIR, run)` without it. Dead code removed.
- **Fix stale tool reference** in `reference/memory-lookup.md` — still referenced `aidevops_memory_recall` (the old split tool). Updated to `aidevops_memory` with `action: "recall"`.

## Tool count: 7 → 4

| Removed | Reason |
|---------|--------|
| `aidevops_memory_recall` | Merged into `aidevops_memory` (PR #6836) |
| `aidevops_memory_store` | Merged into `aidevops_memory` (PR #6836) |
| `aidevops_quality_check` | Runs automatically via `tool.execute.before` hook (PR #6836) |
| `aidevops_install_hooks` | One-time setup; use Bash directly (PR #11115) |

**Remaining tools (4):** `aidevops`, `aidevops_memory`, `aidevops_pre_edit_check`, `model-accounts-pool`

## Files changed

- `.agents/plugins/opencode-aidevops/tools.mjs` — remove dead `_pipelines` param from `createTools()`
- `.agents/reference/memory-lookup.md` — update stale `aidevops_memory_recall` reference

## Runtime Testing

- **Risk level**: Low (docs + dead parameter removal, no logic change)
- **Testing**: self-assessed — syntax check passed (`node --input-type=module`), markdownlint 0 errors
- **Dev environment**: N/A

## Actionable findings

- actionable_findings_total=0
- fixed_in_pr=2
- deferred_tasks_created=0
- coverage=100%


---
[aidevops.sh](https://aidevops.sh) v3.5.55 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 1,877,345 tokens for 3m.