### PR TITLE
t1661.3: Update cross-references and indexes for Fly.io integration

### DIFF
--- a/.agents/tools/deployment/hosting-comparison.md
+++ b/.agents/tools/deployment/hosting-comparison.md
@@ -250,3 +250,12 @@ NVIDIA Cloud (build.nvidia.com): Free cloud endpoints for prototyping (1000 API 
 | Batch processing at scale | Fireworks or Together AI (50% off) | Cloud GPU |
 | GPU clusters for training | Together AI (GPU Clusters) | Cloud GPU providers |
 | Cheapest experimentation | Cloudflare (10K free neurons/day) | NVIDIA Cloud (free credits) |
+
+## Related
+
+- `tools/deployment/fly-io.md` — Fly.io deployment agent (flyctl, Machines API, Sprites, Tigris)
+- `tools/deployment/daytona.md` — Daytona sandbox agent (gVisor, GPU, ephemeral CI)
+- `tools/deployment/coolify.md` — Coolify self-hosted PaaS agent
+- `tools/deployment/vercel.md` — Vercel serverless/edge agent
+- `tools/deployment/uncloud.md` — Uncloud multi-machine container orchestration
+- `.agents/scripts/fly-io-helper.sh` — Fly.io CLI helper (deploy, scale, secrets, volumes, logs, ssh, postgres)


### PR DESCRIPTION
## Summary

- Add `## Related` section to `hosting-comparison.md` linking all platform-specific docs (`fly-io.md`, `daytona.md`, `coolify.md`, `vercel.md`, `uncloud.md`) and `fly-io-helper.sh`
- Confirms existing cross-references in `reference/domain-index.md` (Hosting/Deployment row) and `subagent-index.toon` (tools/deployment/ entry) are already complete

## Task Lineage

Parent: t1661 (Fly.io integration)
Sibling: t1661.2 (fly-io-helper.sh, #12272)

## Changes

- `.agents/tools/deployment/hosting-comparison.md` — added `## Related` section (9 lines) with bidirectional links to all platform docs and the CLI helper

## Runtime Testing

- **Risk level**: Low (docs-only change)
- **Testing level**: self-assessed
- **Verification**: `markdownlint` confirms no new lint errors in added section

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12273