### PR TITLE
t1679.6: Verify no safety regressions after build.txt progressive-load refactor

### DIFF
--- a/.agents/scripts/progressive-load-check.sh
+++ b/.agents/scripts/progressive-load-check.sh
@@ -81,9 +81,11 @@ check_inline_only() {
 
 	[[ "$QUIET" != "--quiet" ]] && printf "\n[%s]\n" "$section"
 
-	local match_count
-	match_count=$(grep -cE "$inline_pattern" "$source_file" 2>/dev/null || echo "0")
-	if [[ "$match_count" -gt 0 ]]; then
+	# Use grep -q to avoid the grep -c exit-1-on-no-match bug where
+	# "count=$(grep -c ... || echo 0)" produces "0\n0" (two lines).
+	local match_count=0
+	if grep -qE "$inline_pattern" "$source_file" 2>/dev/null; then
+		match_count=$(grep -cE "$inline_pattern" "$source_file" 2>/dev/null)
 		log_info "still inline ($match_count matching lines) — no extraction yet"
 	else
 		log_fail "section appears missing from $(basename "$source_file") (pattern: $inline_pattern)"
@@ -101,11 +103,13 @@ check_build_txt_extractions() {
 		"screenshot-limits.md" \
 		"reference/screenshot-limits\.md"
 
-	# Secret Handling (8.1-8.4): reference file is a supplement; inline content kept in build.txt
-	check_inline_only \
-		"Secret Handling (8.1-8.4) — inline + reference/secret-handling.md supplement" \
+	# Secret Handling (8.1-8.4): extracted to reference/secret-handling.md by t1679.5.
+	# Inline trigger (pointer comment) retained in build.txt; full rules in reference file.
+	check_extraction \
+		"Secret Handling (8.1-8.4)" \
 		"$BUILD_TXT" \
-		"8\.1 Session transcript|8\.2 Secret as command|8\.3 Post-execution|8\.4 App config"
+		"secret-handling.md" \
+		"reference/secret-handling\.md"
 
 	check_extraction \
 		"External Repo Issue/PR Submission" \


### PR DESCRIPTION
## Summary

- Ran full safety regression verification after t1679 progressive-load build.txt refactor
- Found and fixed two bugs in `progressive-load-check.sh` that caused a false FAIL
- All 10 safety checks now pass (was: 8 passed, 1 failed with syntax error)

## Verification Results

| Section | Inline trigger | Reference file | Status |
|---------|---------------|----------------|--------|
| Screenshot Size Limits | `# Full rules: reference/screenshot-limits.md` (line 115) | `reference/screenshot-limits.md` | PASS |
| Secret Handling (8.1-8.4) | `# Full secret-handling rules...: reference/secret-handling.md` (line 158) | `reference/secret-handling.md` | PASS |
| External Repo Submissions | `# Full guide: reference/external-repo-submissions.md` (line 201) | `reference/external-repo-submissions.md` | PASS |
| Bash 3.2 Compat | `# Full rules: reference/bash-compat.md` (line 217) | `reference/bash-compat.md` | INFO (still inline) |
| Conversational Memory Lookup | `# Full guide: reference/memory-lookup.md` (line 232) | `reference/memory-lookup.md` | PASS |
| Parallel Model Verification | `verify-operation-helper.sh` (line 165) | — | INFO (still inline) |
| Tamper-Evident Audit Logging | `audit-log-helper.sh` (line 170) | — | INFO (still inline) |
| Review Bot Gate | `review-bot-gate-helper.sh` (line 257) | — | INFO (still inline) |
| Domain Index (AGENTS.md) | `reference/domain-index.md` | `reference/domain-index.md` | PASS |
| Self-Improvement (AGENTS.md) | `## Self-Improvement` | — | INFO (still inline) |
| Agent Routing (AGENTS.md) | `headless-runtime-helper.sh` | — | INFO (still inline) |

**Security rules confirmed present in build.txt:**
- Prompt injection: `prompt-guard-helper.sh scan` trigger + `tools/security/prompt-injection-defender.md` pointer (lines 150-153)
- Credentials: `NEVER expose credentials`, `NEVER accept secret values`, pointer to `reference/secret-handling.md` (lines 155-158)
- Destructive ops: `Confirm destructive operations before execution` (line 159)
- Secret files: `Don't commit secret files (.env, credentials.json)` (line 161)
- Private repo names: `NEVER include private repo names in public TODO.md/issues` (line 162)
- Git safety: `pre-edit-check.sh`, `NEVER edit on main/master`, worktree rules (lines 205-210)

## Bugs Fixed in progressive-load-check.sh

**Bug 1: `grep -c` false-positive on zero matches**
`grep -cE ... || echo "0"` produced `"0\n0"` (two lines) when no match, because `grep -c` exits 1 on zero matches, triggering `|| echo "0"` and appending a second `0`. The `[[ $match_count -gt 0 ]]` comparison then failed with `syntax error in expression`. Fixed by using `grep -q` first to test for match, then `grep -c` only when confirmed.

**Bug 2: Wrong check type for Secret Handling**
`check_inline_only` was looking for `8.1 Session transcript|8.2 Secret as command|...` in `build.txt`, but t1679.5 correctly extracted those section headers to `reference/secret-handling.md`. The check was testing for content that was intentionally moved out. Fixed by switching to `check_extraction` which verifies: (1) `reference/secret-handling.md` exists, (2) inline pointer `reference/secret-handling.md` present in `build.txt`.

## Runtime Testing

- **Risk level:** Low (script fix only — no security rules changed)
- **Level:** runtime-verified
- **Smoke check:** `bash .agents/scripts/progressive-load-check.sh` → `RESULT: PASS (10 checks passed, 0 failures)`
- **ShellCheck:** zero violations

## Files Changed

- `.agents/scripts/progressive-load-check.sh` — fix grep-c bug in `check_inline_only`, fix Secret Handling check to use `check_extraction`

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=2` (both bugs fixed inline)
- `deferred_tasks_created=0`
- `coverage=100%`

## Task Lineage

Parent: t1679 (progressive-load build.txt, #12255). Siblings: t1679.1–t1679.5 (all merged).

Closes #12261


---
[aidevops.sh](https://aidevops.sh) v3.5.59 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 has used 1,928,331 tokens for 5m.