### PR TITLE
fix: Signature token count excludes cache — was inflated ~100x

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -188,9 +188,9 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 **GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM] [--solved]` to generate it. Example output:
 ```
 ---
-[aidevops.sh](https://aidevops.sh) v3.5.36 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 1,658,312 tokens for 42m. Solved in 3d 4h.
+[aidevops.sh](https://aidevops.sh) v3.5.67 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 118,502 tokens for 42m. Solved in 3d 4h.
 ```
-The helper auto-detects CLI, version, tokens (including cache), and session time from the runtime DB. Pass `--issue` on comments to existing issues for "Overall, Xm since this issue was created." phrasing. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+The helper auto-detects CLI, version, tokens (input+output, excluding cache), and session time from the runtime DB. Pass `--issue` on comments to existing issues for "Overall, Xm since this issue was created." phrasing. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -200,16 +200,15 @@ _detect_session_tokens() {
 		return 0
 	fi
 
-	# Sum all token types: input + output + cache reads + cache writes.
-	# Cache tokens are the bulk of API usage (context loaded each turn)
-	# and are billed (cache reads at reduced rate).
+	# Sum input + output tokens only. Cache tokens (cache.read, cache.write)
+	# represent the same context re-loaded each turn — counting them
+	# cumulatively inflates the number by ~100x (175K context × N turns).
+	# Input + output reflects actual new content processed per session.
 	local total_tokens
 	total_tokens=$(sqlite3 "$db_path" "
 		SELECT COALESCE(
 			SUM(json_extract(data, '$.tokens.input')) +
-			SUM(json_extract(data, '$.tokens.output')) +
-			SUM(COALESCE(json_extract(data, '$.tokens.cache.read'), 0)) +
-			SUM(COALESCE(json_extract(data, '$.tokens.cache.write'), 0)), 0
+			SUM(json_extract(data, '$.tokens.output')), 0
 		)
 		FROM message
 		WHERE session_id='${session_id}'


### PR DESCRIPTION
## Summary

Token count in the signature was including cache_read + cache_write tokens cumulatively across all turns. Cache tokens represent the same context (system prompt, AGENTS.md, etc.) re-loaded each turn — summing them across 400 turns inflated the count by ~100x.

**Root cause**: OpenCode stores per-message `tokens.total = input + output + cache.read + cache.write`. The helper was summing this across all messages. But cache.read is ~175K per turn × N turns = millions, while the actual new content is only input + output.

**Fix**: Sum only `tokens.input + tokens.output` — the actual new content processed.

| Metric | Before | After |
|--------|--------|-------|
| This session (3h 50m, opus) | 76,834,042 | 126,955 |
| Worker session (8m, sonnet) | 1,765,752 | ~7,700 |

## Testing

- 43/43 tests pass
- ShellCheck clean

---
[aidevops.sh](https://aidevops.sh) v3.5.67 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 127,498 tokens for 3h 51m.