### PR TITLE
t12279: fix broken runner links in headless-dispatch.md

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -156,7 +156,7 @@ runner-helper.sh status code-reviewer | runner-helper.sh list | runner-helper.sh
 
 Each runner has its own `AGENTS.md` (personality, rules, output format), namespaced memory (`memory-helper.sh store/recall --namespace "runner-name"`), and mailbox (`mail-helper.sh send --to/--from`).
 
-Templates: [code-reviewer](runners/code-reviewer.md), [seo-analyst](runners/seo-analyst.md). See [runners/README.md](runners/README.md).
+Templates: [code-reviewer](runners-code-reviewer.md), [seo-analyst](runners-seo-analyst.md). See [runners-README.md](runners-README.md).
 
 ## Custom Agents
 
@@ -207,7 +207,7 @@ These topics are documented in their canonical locations — loaded on demand, n
 
 - `tools/ai-assistants/opencode-server.md` — full server API reference
 - `tools/ai-assistants/overview.md` — AI assistant comparison
-- `tools/ai-assistants/runners-` — runner templates
+- `tools/ai-assistants/runners-README.md` — runner templates index
 - `scripts/runner-helper.sh` — runner management CLI
 - `scripts/cron-dispatch.sh`, `scripts/cron-helper.sh` — cron-triggered dispatch
 - `scripts/matrix-dispatch-helper.sh`, `services/communications/matrix-bot.md` — Matrix chat dispatch


### PR DESCRIPTION
## Summary

- Fix 3 stale markdown links (`runners/code-reviewer.md`, `runners/seo-analyst.md`, `runners/README.md`) that broke when PR #12107 flattened `runners/` directory to `runners-*.md` files
- Fix truncated Related entry (`runners-` → `runners-README.md`) introduced in PR #12246

## Regression Analysis

PR #12107 (`refactor: flatten remaining nested dirs in tools/`) renamed:
- `runners/code-reviewer.md` → `runners-code-reviewer.md`
- `runners/seo-analyst.md` → `runners-seo-analyst.md`
- `runners/README.md` → `runners-README.md`

PR #12246 (`12186: tighten headless-dispatch.md`) partially updated the Related section but left the entry as `runners-` (truncated) and didn't update the inline markdown links on line 159.

## Changes

| File | What | Why |
|------|------|-----|
| `.agents/tools/ai-assistants/headless-dispatch.md:159` | Update markdown links to flattened names | Stale links from directory flattening |
| `.agents/tools/ai-assistants/headless-dispatch.md:210` | Fix truncated `runners-` → `runners-README.md` | Incomplete reference from PR #12246 |

## Verification

- All 7 task IDs preserved (t1163, t1408, t1412, t1419, t158, t174, t176)
- GH#5096 reference preserved
- All 9 code block pairs preserved
- All URLs preserved
- Line count unchanged (220 lines)
- `markdownlint-cli2`: 0 errors
- All referenced files verified to exist via `git ls-files`

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs-only, no code changes)
- **Rationale**: Agent prompt file — no runtime behaviour to test

Closes #12279

---
[aidevops.sh](https://aidevops.sh) v3.5.67 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 1,024,747 tokens for 2m.