### PR TITLE
t12302: tighten runners.md from 211 to 133 lines

### DIFF
--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -4,62 +4,22 @@ agent: Build+
 mode: subagent
 ---
 
-Dispatch one or more workers to handle tasks. Pick the execution mode per task type:
+Dispatch one or more workers to handle tasks. Route by type:
 
 - **Code-change work** (repo edits, tests, PRs) -> `/full-loop`
 - **Operational work** (reports, audits, monitoring, outreach) -> direct command execution (no PR ceremony)
 
 Arguments: $ARGUMENTS
 
-## Scope Boundary
+## Scope
 
-**`/runners` is a targeted dispatch tool, not a supervisor.**
+**`/runners` is a targeted dispatch tool, not a supervisor.** It resolves the specified items, dispatches one worker per item, shows the dispatch table, and stops.
 
-When invoked as `/runners GH#267 GH#268` (or any explicit list of items), it does exactly this:
+It does **NOT** run supervisor phases, auto-pickup unrelated tasks, stale claim recovery, phantom queue reconciliation, AI lifecycle evaluation, CodeRabbit pulse, or audit checks. For unattended operation that fills all available slots, use `/pulse` (see `scripts/commands/pulse.md`).
 
-1. Resolve the specified items
-2. Dispatch one worker per item
-3. Show the dispatch table
-4. Stop
+Workers are independent — they succeed or fail on their own. `/runners` never reads source code, implements features, runs tests, pushes branches, or resolves merge conflicts. If a worker fails, improve the worker's instructions, not the dispatcher.
 
-It does **NOT**:
-
-- Run supervisor phases
-- Perform auto-pickup of unrelated tasks
-- Run stale claim recovery
-- Run phantom queue reconciliation
-- Run AI lifecycle evaluation
-- Run CodeRabbit pulse
-- Run audit checks
-- Fill worker slots beyond the explicitly specified items
-
-For unattended operation that fills all available slots and runs supervisor phases, use `/pulse`. See `.agents/scripts/commands/pulse.md`.
-
-## How It Works
-
-The runners system is intentionally simple:
-
-1. **You tell it what to work on** (task IDs, PR numbers, issue URLs, or descriptions)
-2. **It dispatches `opencode run` for each item** — one worker per task
-3. **Code workers** handle branch -> implementation -> PR -> CI -> merge
-4. **Ops workers** execute the requested SOP/command and report outcomes
-5. **No databases, no state machines, no complex bash pipelines**
-
-## Interactive Mode: `/runners`
-
-**Scope boundary:** When invoked as `/runners`, ONLY resolve and dispatch the items explicitly specified in the arguments. Do NOT:
-
-- Run supervisor phases
-- Auto-pickup additional tasks
-- Perform lifecycle evaluation
-- Run quality sweeps
-- Trigger a CodeRabbit pulse
-
-Dispatch exactly the requested items and stop.
-
-For manual dispatch of specific work items.
-
-### Input Types
+## Input Types
 
 | Pattern | Type | Example |
 |---------|------|---------|
@@ -69,9 +29,9 @@ For manual dispatch of specific work items.
 | Issue URL | GitHub issue | `/runners https://github.com/user/repo/issues/42` |
 | Free text | Description | `/runners "Fix the login bug"` |
 
-### Step 1: Resolve What to Work On
+## Step 1: Resolve Items
 
-For each input item, resolve it to a description:
+For each input, resolve to a description:
 
 ```bash
 # GitHub issue/PR numbers (GH#NNN format)
@@ -88,16 +48,15 @@ gh pr view 382 --json number,title,headRefName,url
 gh issue view 42 --repo user/repo --json number,title,url
 ```
 
-### Step 2: Dispatch Workers
+## Step 2: Dispatch Workers
 
-For each resolved item, launch a worker using `headless-runtime-helper.sh run`. This is the **ONLY** correct dispatch path — it constructs the full lifecycle prompt, handles provider rotation, session persistence, and backoff. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (see GH#5096).
+Launch each worker via `headless-runtime-helper.sh run`. This is the **ONLY** correct dispatch path — it constructs the full lifecycle prompt, handles provider rotation, session persistence, and backoff. NEVER use bare `opencode run` — workers launched that way miss lifecycle reinforcement and stop after PR creation (GH#5096).
 
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
-# Dynamic path respects user configuration of paths.agents_dir in config.jsonc
 
-# For code tasks (Build+ is default — omit --agent)
+# Code task (Build+ is default — omit --agent)
 $HELPER run \
   --role worker \
   --session-key "task-t083" \
@@ -106,17 +65,7 @@ $HELPER run \
   --prompt "/full-loop t083 -- <description>" &
 sleep 2
 
-# For code tasks in a specialist domain
-$HELPER run \
-  --role worker \
-  --session-key "task-t084" \
-  --dir ~/Git/<repo> \
-  --agent SEO \
-  --title "t084: <description>" \
-  --prompt "/full-loop t084 -- <description>" &
-sleep 2
-
-# For non-code operational tasks (no /full-loop)
+# Specialist or operational task (no /full-loop for non-code ops)
 $HELPER run \
   --role worker \
   --session-key "seo-weekly" \
@@ -126,16 +75,7 @@ $HELPER run \
   --prompt "/seo-export --account client-a --format summary" &
 sleep 2
 
-# For PRs
-$HELPER run \
-  --role worker \
-  --session-key "pr-382" \
-  --dir ~/Git/<repo> \
-  --title "PR #382: <title>" \
-  --prompt "/full-loop Fix PR #382 (https://github.com/user/repo/pull/382) -- <what needs fixing>" &
-sleep 2
-
-# For issues
+# PR or issue
 $HELPER run \
   --role worker \
   --session-key "issue-42" \
@@ -145,18 +85,15 @@ $HELPER run \
 sleep 2
 ```
 
-**Dispatch rules:**
+### Dispatch Rules
 
-- Use `--dir ~/Git/<repo-name>` matching the repo the task belongs to
-- Use `--agent <name>` to route to a specialist (SEO, Content, Marketing, etc.)
-- Omit `--agent` for code tasks — defaults to Build+
-- Use `/full-loop` only when the task needs repo code changes and PR traceability
-- For non-code operations, run the task command directly (for example `/seo-export ...`)
+- `--dir ~/Git/<repo-name>` must match the repo the task belongs to
+- `--agent <name>` routes to a specialist (SEO, Content, Marketing, etc.); omit for code tasks (defaults to Build+)
+- `/full-loop` only for tasks needing repo code changes and PR traceability
 - Do NOT add `--model` unless escalation is required by workflow policy
-- **Background each dispatch with `&`** and `sleep 2` between dispatches to avoid thundering herd
-- Code workers handle branch/PR lifecycle; ops workers execute and report outcomes
+- Background each dispatch with `&` and `sleep 2` between to avoid thundering herd
 
-### Step 3: Show Dispatch Table
+## Step 3: Show Dispatch Table
 
 After dispatching, show the user what was launched:
 
@@ -169,35 +106,20 @@ After dispatching, show the user what was launched:
 | 2 | GH#268: <title> | dispatched |
 ```
 
-Then stop. Workers are independent — they succeed or fail on their own. The next `/pulse` cycle (or the user) can check on outcomes and dispatch follow-ups.
-
-## Dispatch Philosophy
-
-`/runners` dispatches workers. It does not supervise them.
-
-- **Never** reads source code or implements features
-- **Never** runs tests or linters on behalf of workers
-- **Never** pushes branches or resolves merge conflicts for workers
-- **Always** dispatches workers via `headless-runtime-helper.sh run` (never bare `opencode run`)
-- **Always** routes to the right agent — not every task is code
-- **Always** stops after dispatching the explicitly specified items
-
-`/runners` is a targeted dispatch tool, not a supervisor. It dispatches exactly what you specify and stops.
-
-If a worker fails (whether dispatched by `/pulse` or `/runners`), improve the worker's instructions or command definition, not the dispatcher's role. Each fixed failure improves the next run.
+Then stop. The next `/pulse` cycle (or the user) can check outcomes and dispatch follow-ups.
 
 ## Examples
 
-All items in a single `/runners` invocation are dispatched concurrently — each becomes a separate `opencode run ... &` background process. They do not block each other.
+All items in a single `/runners` invocation dispatch concurrently — each becomes a separate background process.
 
 ```bash
-# Dispatch specific GitHub issues (both launch concurrently, then stop)
+# Dispatch specific GitHub issues
 /runners GH#267 GH#268
 
-# Dispatch specific tasks (all three launch concurrently)
+# Dispatch specific tasks
 /runners t083 t084 t085
 
-# Fix specific PRs (both launch concurrently)
+# Fix specific PRs
 /runners #382 #383
 
 # Work on a GitHub issue
@@ -206,6 +128,6 @@ All items in a single `/runners` invocation are dispatched concurrently — each
 # Free-form task
 /runners "Add rate limiting to the API endpoints"
 
-# Multiple mixed items (all three launch concurrently)
+# Multiple mixed items
 /runners t083 #382 "Fix the login bug"
 ```


### PR DESCRIPTION
## Summary

- Merged 3 redundant scope/philosophy sections into a single **Scope** section (lines 14-36, 50-58, 174-187 all said "targeted dispatch tool, not a supervisor")
- Removed **How It Works** overview section (duplicated by the step-by-step workflow)
- Consolidated 5 dispatch code examples into 3 representative patterns (code task, specialist/ops, PR/issue)
- Tightened prose throughout while preserving all institutional knowledge

## Verification

- **211 → 133 lines** (37% reduction, under 150-line target)
- All task IDs preserved: GH#5096
- All commands preserved: `headless-runtime-helper.sh run`, `gh issue view`, `gh pr view`, dynamic `AGENTS_DIR` path
- All 5 input type patterns preserved (GH#, t-IDs, PR#, URLs, free text)
- All code blocks preserved (4 blocks)
- Zero markdownlint violations

Closes #12302


---
[aidevops.sh](https://aidevops.sh) v3.5.77 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 4,839 tokens for 2m.