### PR TITLE
refactor: Signature 'for 3m' → 'in 3m'

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -557,9 +557,9 @@ _build_signature() {
 		sig="${sig} has used ${formatted} tokens"
 	fi
 
-	# "for Xm" (session time)
+	# "in Xm" (session time)
 	if [[ -n "$session_time_str" ]]; then
-		sig="${sig} for ${session_time_str}"
+		sig="${sig} in ${session_time_str}"
 	fi
 
 	# Total time or trailing period

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -201,7 +201,7 @@ echo ""
 echo "Test 11: session time auto-detection (no response time)"
 if [[ "${OPENCODE:-}" == "1" ]] && [[ -r "${HOME}/.local/share/opencode/opencode.db" ]]; then
 	result=$("$HELPER" generate --cli "OpenCode" --model "m" --tokens 1)
-	assert_contains "session time present" "for " "$result"
+	assert_contains "session time present" " in " "$result"
 	assert_not_contains "no response time" "to respond" "$result"
 else
 	echo "  SKIP: not running in OpenCode"


### PR DESCRIPTION
One-word change: `has used 7,166 tokens for 3m.` → `has used 7,166 tokens in 3m.`

43/43 tests pass.

---
[aidevops.sh](https://aidevops.sh) v3.5.79 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 136,269 tokens for 4h 25m.