### PR TITLE
refactor: Signature 'has used' → 'spent', add 'on this.'

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -554,23 +554,23 @@ _build_signature() {
 	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then
 		local formatted
 		formatted=$(_format_number "$tokens")
-		sig="${sig} has used ${formatted} tokens"
+		sig="${sig} spent ${formatted} tokens"
 	fi
 
-	# "in Xm" (session time)
+	# "in Xm on this." (session time)
 	if [[ -n "$session_time_str" ]]; then
-		sig="${sig} in ${session_time_str}"
+		sig="${sig} in ${session_time_str} on this."
 	fi
 
-	# Total time or trailing period
+	# Total time or trailing period (only if no session time already added period)
 	local has_stats=""
 	if { [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; } ||
 		[[ -n "$session_time_str" ]] || [[ -n "$total_time_str" ]]; then
 		has_stats="true"
 	fi
 
-	# Trailing period before optional total time
-	if [[ -n "$has_stats" ]]; then
+	# Trailing period if we had stats but no session time (which already ends with period)
+	if [[ -n "$has_stats" ]] && [[ -z "$session_time_str" ]]; then
 		sig="${sig}."
 	fi
 

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -71,7 +71,7 @@ assert_contains "starts with aidevops" "[aidevops.sh](https://aidevops.sh)" "$re
 assert_contains "contains CLI with plugin for" "plugin for [OpenCode](https://opencode.ai) v1.3.3" "$result"
 assert_contains "model strips provider prefix" "with claude-opus-4-6" "$result"
 assert_not_contains "no provider prefix" "anthropic/" "$result"
-assert_contains "contains formatted tokens" "has used 1,234 tokens" "$result"
+assert_contains "contains formatted tokens" "spent 1,234 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 2: generate with explicit --tokens 0 (should omit tokens)
@@ -108,7 +108,7 @@ echo "Test 5: footer includes --- separator"
 result=$("$HELPER" footer --cli "OpenCode" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
 assert_contains "contains ---" "---" "$result"
 assert_contains "contains signature" "plugin for [OpenCode](https://opencode.ai) v1.0.0" "$result"
-assert_contains "contains tokens" "has used 5,000 tokens" "$result"
+assert_contains "contains tokens" "spent 5,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 6: comma formatting for various numbers
@@ -180,7 +180,7 @@ result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG
 assert_contains "env CLI name" "plugin for EnvCLI" "$result"
 assert_contains "env CLI version" "v9.9.9" "$result"
 assert_contains "env model strips prefix" "with model" "$result"
-assert_contains "env tokens" "has used 42,000 tokens" "$result"
+assert_contains "env tokens" "spent 42,000 tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 10: auto-detect tokens from OpenCode session DB (if running in OpenCode)


### PR DESCRIPTION
`has used 7,166 tokens in 3m.` → `spent 7,166 tokens in 3m on this.`

43/43 tests pass.

---
[aidevops.sh](https://aidevops.sh) v3.5.79 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 138,572 tokens for 4h 29m.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated signature wording to display "spent tokens" instead of "has used tokens" for clearer communication about token consumption.
  * Improved formatting of session time phrases in generated signatures.
  * Fixed punctuation logic to prevent duplicate periods when both token usage and session time information are present in signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->