### PR TITLE
fix: Signature shows 'automated scan.' for non-LLM contexts

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -583,6 +583,12 @@ _build_signature() {
 		fi
 	fi
 
+	# If signature is just the version (no CLI, model, tokens, or time),
+	# append "automated scan" so it reads naturally on non-LLM issues
+	if [[ -z "$cli_name" ]] && [[ -z "$display_model" ]] && [[ -z "$has_stats" ]]; then
+		sig="${sig} automated scan."
+	fi
+
 	echo "$sig"
 	return 0
 }


### PR DESCRIPTION
When the helper runs from pulse-wrapper scans (no LLM involved), it can't detect CLI, model, or tokens. Previously produced a bare `[aidevops.sh](...) v3.5.79` which looked incomplete.

Now: `[aidevops.sh](https://aidevops.sh) v3.5.79 automated scan.`

43/43 tests pass.

---
[aidevops.sh](https://aidevops.sh) v3.5.79 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 144,658 tokens for 4h 38m.