### PR TITLE
refactor: remove dispatch claim release — keep claims as audit trail

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -87,9 +87,6 @@ gh issue edit NUMBER --repo SLUG --add-assignee "$RUNNER_USER" --add-label "stat
   --title "Issue #NUMBER: TITLE" \
   --prompt "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" &
 sleep 2
-
-# Clean up claim comment after dispatch (non-fatal)
-release_dispatch_claim NUMBER SLUG "$RUNNER_USER"
 ```
 
 Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
@@ -865,12 +862,9 @@ if check_dispatch_dedup <number> <slug> "Issue #<number>: <title>" "<task-id>: <
   gh issue comment <number> --repo <slug> --body "Dispatch skipped — deterministic dedup guard detected overlap (active worker, merged PR evidence, assigned to another runner, or lost claim). See check_dispatch_dedup in pulse-wrapper.sh." 2>/dev/null || true
   continue
 fi
-
-# After dispatch succeeds, clean up the claim comment (non-fatal)
-release_dispatch_claim <number> <slug> "$RUNNER_USER"
 ```
 
-`check_dispatch_dedup` runs all seven checks in sequence: (1) in-flight dispatch ledger, (2) exact repo+issue process overlap, (3) title variants via dispatch-dedup-helper (e.g., `issue-3502` vs `Issue #3502: description`), (4) merged-PR evidence via close keywords and task-ID fallback, (5) cross-machine dispatch comment check (GH#11141) — detects "Dispatching worker" comments posted by other runners, the persistent cross-machine signal that survives beyond the claim lock's 8-second window, (6) cross-machine assignee guard — blocks if assigned to any login other than self (GH#11141 fix: repo owner/maintainer are no longer excluded since they may also be runners), and (7) cross-machine optimistic claim lock (GH#11086) — posts an HTML comment claim, sleeps the consensus window, and checks who was first. Only the oldest claimant proceeds; others back off.
+`check_dispatch_dedup` runs all seven checks in sequence: (1) in-flight dispatch ledger, (2) exact repo+issue process overlap, (3) title variants via dispatch-dedup-helper (e.g., `issue-3502` vs `Issue #3502: description`), (4) merged-PR evidence via close keywords and task-ID fallback, (5) cross-machine dispatch comment check (GH#11141) — detects "Dispatching worker" comments posted by other runners, the persistent cross-machine signal that survives beyond the claim lock's 8-second window, (6) cross-machine assignee guard — blocks if assigned to any login other than self (GH#11141 fix: repo owner/maintainer are no longer excluded since they may also be runners), and (7) cross-machine optimistic claim lock (GH#11086) — posts a plain-text claim comment, sleeps the consensus window, and checks who was first. Only the oldest claimant proceeds; others back off. The winning claim comment persists as audit trail.
 
 The deterministic guard is the safety net, not the primary layer. Over time, as the intelligence scan catches more duplicates earlier, the deterministic guard should fire less often. See "Dedup health monitoring" below for how to track this.
 

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -23,10 +23,6 @@
 #     Exit 1 = claim lost (another runner was first — do NOT dispatch)
 #     Exit 2 = error (fail-open — caller should proceed with dispatch)
 #
-#   dispatch-claim-helper.sh release <issue-number> <repo-slug> [runner-login]
-#     Clean up claim comments posted by this runner.
-#     Exit 0 = cleaned up (or nothing to clean)
-#
 #   dispatch-claim-helper.sh check <issue-number> <repo-slug>
 #     Check if any active claim exists on this issue.
 #     Exit 0 = active claim exists (do NOT dispatch)
@@ -281,8 +277,6 @@ cmd_claim() {
 	local claims
 	claims=$(_fetch_claims "$issue_number" "$repo_slug") || {
 		echo "CLAIM_ERROR: failed to fetch claims — proceeding (fail-open)" >&2
-		# Clean up our claim on error
-		_delete_comment "$repo_slug" "$comment_id" 2>/dev/null || true
 		return 2
 	}
 
@@ -317,63 +311,6 @@ cmd_claim() {
 	_delete_comment "$repo_slug" "$comment_id" 2>/dev/null || true
 
 	return 1
-}
-
-#######################################
-# Release (clean up) claim comments posted by this runner.
-#
-# Args:
-#   $1 = issue number
-#   $2 = repo slug (owner/repo)
-#   $3 = runner login (optional, auto-detected)
-# Returns:
-#   exit 0 = cleaned up (or nothing to clean)
-#######################################
-cmd_release() {
-	local issue_number="${1:-}"
-	local repo_slug="${2:-}"
-	local runner_login="${3:-}"
-
-	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
-		echo "Error: release requires <issue-number> <repo-slug>" >&2
-		return 1
-	fi
-
-	local runner
-	runner=$(_resolve_runner "$runner_login") || runner="unknown"
-
-	local claims
-	claims=$(_fetch_claims "$issue_number" "$repo_slug") || {
-		echo "Warning: failed to fetch claims for cleanup" >&2
-		return 0
-	}
-
-	local claim_count
-	claim_count=$(printf '%s' "$claims" | jq 'length' 2>/dev/null) || claim_count=0
-
-	if [[ "$claim_count" -eq 0 ]]; then
-		return 0
-	fi
-
-	# Delete all claim comments from this runner
-	local deleted=0
-	local i
-	for i in $(seq 0 $((claim_count - 1))); do
-		local claim_runner claim_id
-		claim_runner=$(printf '%s' "$claims" | jq -r ".[$i].runner // \"\"" 2>/dev/null) || claim_runner=""
-		claim_id=$(printf '%s' "$claims" | jq -r ".[$i].id // \"\"" 2>/dev/null) || claim_id=""
-
-		if [[ "$claim_runner" == "$runner" && -n "$claim_id" ]]; then
-			_delete_comment "$repo_slug" "$claim_id" 2>/dev/null && deleted=$((deleted + 1))
-		fi
-	done
-
-	if [[ "$deleted" -gt 0 ]]; then
-		printf 'RELEASED: cleaned up %d claim comment(s) for runner=%s on issue #%s\n' \
-			"$deleted" "$runner" "$issue_number"
-	fi
-
-	return 0
 }
 
 #######################################
@@ -436,10 +373,6 @@ Usage:
     Exit 1 = claim lost (do NOT dispatch)
     Exit 2 = error (fail-open — proceed with dispatch)
 
-  dispatch-claim-helper.sh release <issue-number> <repo-slug> [runner-login]
-    Clean up claim comments posted by this runner.
-    Exit 0 = cleaned up (or nothing to clean)
-
   dispatch-claim-helper.sh check <issue-number> <repo-slug>
     Check if any active claim exists on this issue.
     Exit 0 = active claim exists (do NOT dispatch)
@@ -458,7 +391,7 @@ Protocol:
   2. Waits DISPATCH_CLAIM_WINDOW seconds for other runners
   3. Fetches all claim comments on the issue
   4. Oldest claim wins — others back off and delete their claims
-  5. Winner proceeds with dispatch, calls 'release' after dispatch completes
+  5. Winner proceeds with dispatch; claim comment persists as audit trail
 
 Examples:
   # Claim before dispatching (in pulse dedup guard)
@@ -466,8 +399,6 @@ Examples:
   if dispatch-claim-helper.sh claim 42 owner/repo "$RUNNER"; then
     # Won the claim — dispatch worker
     headless-runtime-helper.sh run --session-key "issue-42" ...
-    # Clean up after dispatch
-    dispatch-claim-helper.sh release 42 owner/repo "$RUNNER"
   else
     exit_code=$?
     if [[ $exit_code -eq 1 ]]; then
@@ -491,9 +422,6 @@ main() {
 	case "$command" in
 	claim)
 		cmd_claim "$@"
-		;;
-	release)
-		cmd_release "$@"
 		;;
 	check)
 		cmd_check "$@"

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -41,9 +41,6 @@
 #     Cross-machine optimistic lock via GitHub comments (t1686).
 #     Exit 0 = claim won (safe to dispatch), exit 1 = lost, exit 2 = error (fail-open).
 #
-#   dispatch-dedup-helper.sh release <issue> <slug> [runner-login]
-#     Clean up claim comments after dispatch completes.
-#
 #   dispatch-dedup-helper.sh normalize <title>
 #     Return the normalized (lowercased, stripped) form of a title for comparison.
 
@@ -629,8 +626,6 @@ Usage:
                                                        Check if assigned to another login (exit 0=blocked, 1=free)
   dispatch-dedup-helper.sh claim <issue> <slug> [runner-login]
                                                      Cross-machine claim lock (exit 0=won, 1=lost, 2=error)
-  dispatch-dedup-helper.sh release <issue> <slug> [runner-login]
-                                                     Clean up claim comments after dispatch
   dispatch-dedup-helper.sh list-running-keys        List keys for all running workers
   dispatch-dedup-helper.sh normalize <title>        Normalize a title for comparison
   dispatch-dedup-helper.sh help                     Show this help
@@ -674,7 +669,7 @@ Examples:
   if dispatch-dedup-helper.sh claim 2300 owner/repo mylogin; then
     echo "Claim won — safe to dispatch"
     # ... dispatch worker ...
-    dispatch-dedup-helper.sh release 2300 owner/repo mylogin
+    # Claim comment persists as audit trail
   else
     echo "Claim lost or error — skip dispatch"
   fi
@@ -735,17 +730,6 @@ main() {
 			return 2
 		fi
 		"$CLAIM_HELPER" claim "$1" "$2" "${3:-}"
-		;;
-	release)
-		[[ $# -lt 2 ]] && {
-			echo "Error: release requires <issue-number> <repo-slug> [runner-login]" >&2
-			return 1
-		}
-		if [[ ! -x "$CLAIM_HELPER" ]]; then
-			echo "Warning: dispatch-claim-helper.sh not found — skipping release" >&2
-			return 0
-		fi
-		"$CLAIM_HELPER" release "$1" "$2" "${3:-}"
 		;;
 	list-running-keys)
 		list_running_keys

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4101,28 +4101,6 @@ check_dispatch_dedup() {
 }
 
 #######################################
-# Release the dispatch claim comment after a worker has been dispatched.
-# Call this after the dispatch command succeeds. Non-fatal — errors are logged
-# but do not block the dispatch flow.
-#
-# Arguments:
-#   $1 - issue number
-#   $2 - repo slug (owner/repo)
-#   $3 - runner login (optional; auto-detected if omitted)
-#######################################
-release_dispatch_claim() {
-	local issue_number="$1"
-	local repo_slug="$2"
-	local self_login="${3:-}"
-
-	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
-	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
-		"$dedup_helper" release "$issue_number" "$repo_slug" "$self_login" >>"$LOGFILE" 2>&1 || true
-	fi
-	return 0
-}
-
-#######################################
 # Check issue comments for terminal blocker patterns (GH#5141)
 #
 # Scans the last N comments on an issue for known patterns that indicate

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -106,19 +106,6 @@ test_claim_non_numeric_issue() {
 }
 
 #######################################
-# Test: release with missing args returns exit 1
-#######################################
-test_release_missing_args() {
-	run_helper "$CLAIM_HELPER" release
-	if [[ "$LAST_EXIT" -eq 1 ]]; then
-		print_result "release with no args returns exit 1" 0
-	else
-		print_result "release with no args returns exit 1" 1 "got exit $LAST_EXIT"
-	fi
-	return 0
-}
-
-#######################################
 # Test: check with missing args returns exit 2
 #######################################
 test_check_missing_args() {
@@ -159,19 +146,6 @@ test_dedup_claim_routing() {
 }
 
 #######################################
-# Test: dispatch-dedup-helper.sh release subcommand routes correctly
-#######################################
-test_dedup_release_routing() {
-	run_helper "$DEDUP_HELPER" release
-	if [[ "$LAST_EXIT" -eq 1 ]]; then
-		print_result "dedup release with no args returns exit 1" 0
-	else
-		print_result "dedup release with no args returns exit 1" 1 "got exit $LAST_EXIT"
-	fi
-	return 0
-}
-
-#######################################
 # Test: DISPATCH_CLAIM_WINDOW env var is respected
 #######################################
 test_env_var_defaults() {
@@ -204,11 +178,9 @@ main() {
 	test_help_exits_zero
 	test_claim_missing_args
 	test_claim_non_numeric_issue
-	test_release_missing_args
 	test_check_missing_args
 	test_unknown_command
 	test_dedup_claim_routing
-	test_dedup_release_routing
 	test_env_var_defaults
 
 	echo ""


### PR DESCRIPTION
## Summary

- Dispatch claim comments are now plain text (since v3.5.55), so they're useful audit trail — no reason to delete them
- Removes `cmd_release`, `release_dispatch_claim()`, and all release call sites across 5 files
- Net removal: 147 lines of release/cleanup code and 2 API calls per dispatch

## Files Changed

| File | What | Why |
|------|------|-----|
| `.agents/scripts/dispatch-claim-helper.sh` | Removed `cmd_release`, release from help/main, error-path deletion | Core change — claims persist |
| `.agents/scripts/pulse-wrapper.sh` | Removed `release_dispatch_claim()` | Caller of release |
| `.agents/scripts/dispatch-dedup-helper.sh` | Removed `release` subcommand routing + help text | Router for release |
| `.agents/scripts/commands/pulse.md` | Removed `release_dispatch_claim` calls, updated dedup description | LLM-facing dispatch instructions |
| `.agents/scripts/tests/test-dispatch-claim-helper.sh` | Removed 2 release-related tests | Tests for removed code |

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low — removing dead code path; claim+check still work identically
- **Verification**: ShellCheck clean, 10/10 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed post-dispatch cleanup operations; dispatch claim comments now persist as permanent audit trails for tracking dispatch activity history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->