### PR TITLE
fix: replace arbitrary line targets with subdivision threshold for simplification

### DIFF
--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -10,7 +10,8 @@ mode: subagent
 
 ## Quick Reference
 
-- **Budget**: ~50-100 instructions per agent; root AGENTS.md <150 lines, universally applicable only
+- **Budget**: ~50-100 instructions per agent; root AGENTS.md universally applicable only
+- **Subdivision**: Agent docs exceeding ~300 lines — split into entry point + sub-docs, don't cut to hit a line count
 - **MCP servers**: Disabled globally, enabled per-agent
 - **Code refs**: `rg "pattern"` search patterns, not `file:line` (line numbers drift)
 - **Subagents**: `agent-review.md` (review), `agent-testing.md` (testing)
@@ -117,6 +118,8 @@ marketing-sales/                          # Extended knowledge — flat, prefix-
 - `ls marketing-sales/meta-ads*` groups all Meta Ads knowledge; `*swipe*` finds swipe files
 - Max depth: 2 levels from `.agents/` — never 5+
 - Subdirectory only when a prefix group exceeds ~20 files. One level max.
+
+**Subdivision threshold (~300 lines):** Agent docs exceeding ~300 lines should be split into an entry point + sub-docs using the `{name}.md` + `{name}/` convention above. The goal is progressive disclosure (smaller always-loaded context, detail on demand) — not content reduction. Never set an arbitrary target line count for simplification; the resulting size is whatever remains after removing genuine noise and extracting sub-docs.
 
 ### Scripts: Flat by Design
 

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -108,6 +108,7 @@ Knowledge bases (skill docs, domain reference) whose size comes from breadth, no
 3. **Apply project standards** — but standards themselves are not simplification targets.
 4. **Enhance clarity without losing depth.** Reduce nesting, improve naming, remove "what" comments (not "why").
 5. **Maintain balance.** Avoid over-simplification that removes helpful abstractions or loses edge-case handling.
+6. **No arbitrary line targets.** Never set a target line count for simplification. The resulting size is whatever remains after removing genuine noise. Dispatchers and issue creators must not invent reduction targets — this creates pressure to cut content for the sake of a number, conflicting with principle 1. For large files, subdivide per `build-agent.md` (~300-line threshold) instead of compressing.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Adds ~300-line subdivision guideline to `build-agent.md` — agent docs exceeding this threshold should split into entry point + sub-docs, not be compressed to hit a line count
- Adds explicit "No arbitrary line targets" principle (#6) to `code-simplifier.md` Core Principles — dispatchers and issue creators must not invent reduction targets
- Removes the `<150 lines` from the build-agent Quick Reference budget line (was specific to root AGENTS.md but was being misapplied as a general simplification target)

## Why

The pulse dispatcher was inventing arbitrary line count targets (e.g., "target <150 lines") in simplification issue dispatch comments. This creates pressure to cut content for the sake of a number, directly conflicting with the code-simplifier's preservation-first philosophy. The root cause: no subdivision threshold existed, so agents pattern-matched on the AGENTS.md-specific `<150 lines` rule and generalized it.

## Testing

- `self-assessed` — agent doc changes only, no runtime behaviour
- Both files pass `markdownlint-cli2` with zero errors

Closes #12315

---
[aidevops.sh](https://aidevops.sh) v3.5.82 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6