### PR TITLE
feat: add status:needs-info contributor reply scan to pulse

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -125,6 +125,31 @@ Skip triage reviews when:
 - The issue was created less than 5 minutes ago (give the author time to add context)
 - The maintainer has already commented on the issue (they're already engaged)
 
+### 4.6. Scan status:needs-info issues for contributor replies
+
+Check the pre-fetched "Needs Info — Contributor Reply Status" section. For each issue marked **replied** (contributor commented after the label was applied), relabel to `needs-maintainer-review` so it re-enters the triage pipeline for re-evaluation.
+
+```bash
+# For each replied issue from the pre-fetched needs-info status:
+REPO=$(echo "$SLUG" | cut -d/ -f1-2)
+MAINTAINER=$(jq -r --arg slug "$SLUG" \
+  '.[] | select(.slug == $slug) | .maintainer // empty' "$REPOS_JSON")
+
+gh issue edit <number> --repo "$SLUG" \
+  --remove-label "status:needs-info" \
+  --add-label "needs-maintainer-review"
+gh issue comment <number> --repo "$SLUG" \
+  --body "Contributor replied to the information request. Relabeled to \`needs-maintainer-review\` for re-evaluation."
+```
+
+This is a lightweight label transition — no worker dispatch, no slots consumed. The issue will be picked up by the triage review pipeline (step 4.5) on the next cycle.
+
+**Skip when:**
+
+- No issues have `status:needs-info` label
+- The contributor has not commented since the label was applied (pre-fetched status shows **waiting**)
+- The only new comments are from bots or the maintainer (not the original issue author)
+
 ### 5. Record initial dispatch success
 
 ```bash
@@ -167,7 +192,8 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
 
 4. **If slots are open**: check for mergeable PRs (free), then dispatch workers for the
    highest-priority open issues, then dispatch triage reviews for unreviewed
-   `needs-maintainer-review` issues (same rules as Step 4.5). Use the same dedup guards
+   `needs-maintainer-review` issues (same rules as Step 4.5), then scan `status:needs-info`
+   issues for contributor replies (same rules as Step 4.6). Use the same dedup guards
    and dispatch commands as the initial dispatch. Re-fetch issue state with targeted `gh`
    calls only for repos where you need to dispatch (not a full re-fetch of all repos).
 
@@ -280,6 +306,7 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Too large for one worker** → classify with `task-decompose-helper.sh classify`. If composite, decompose into subtask issues, label parent `status:blocked`. Child tasks enter the normal dispatch queue.
 - **`status:queued` or `status:in-progress`** → check `updatedAt`. If updated within 3 hours, skip. If 3+ hours with no PR and no worker, relabel `status:available`, unassign, comment the recovery. Note: issues claimed at creation via `/new-task` option 2 (t1687) will have `status:in-progress` + assignee set immediately, so the pulse correctly skips them during the interactive work window.
 - **`needs-maintainer-review`** → Do NOT dispatch an implementation worker. Instead, dispatch a **triage review worker** if no agent review comment exists yet (see "Automated triage review" below).
+- **`status:needs-info`** → Do NOT dispatch. Check the pre-fetched "Needs Info — Contributor Reply Status" section. If the contributor has replied since the label was applied, relabel to `needs-maintainer-review` so the triage pipeline re-evaluates (see "Contributor reply scan for status:needs-info" below).
 - **`status:available` or no status (without `needs-maintainer-review`)** → dispatch a worker.
 
 ### External issues and PRs — maintainer review gate (t1545)
@@ -616,6 +643,31 @@ fi
 - Only check the maintainer's **most recent** comment — earlier comments may have been superseded.
 - This is additive — direct label manipulation still works. If the maintainer has already removed `needs-maintainer-review` via labels, the item won't appear in this scan.
 - Keep this lightweight — one API call per `needs-maintainer-review` item per cycle. These items are low-volume by design.
+
+### Contributor reply scan for status:needs-info
+
+Issues labeled `status:needs-info` are waiting for the contributor to provide additional information. Each cycle, check the pre-fetched "Needs Info — Contributor Reply Status" section for issues where the contributor has replied.
+
+**Detection logic** (handled by `prefetch_needs_info_replies()` in `pulse-wrapper.sh`): For each `status:needs-info` issue, compare the label's `updatedAt` timestamp against the most recent comment from the issue author. If the author commented after the label was applied, the issue is marked **replied**.
+
+**When a contributor has replied:**
+
+```bash
+gh issue edit <number> --repo <slug> \
+  --remove-label "status:needs-info" \
+  --add-label "needs-maintainer-review"
+gh issue comment <number> --repo <slug> \
+  --body "Contributor replied to the information request. Relabeled to \`needs-maintainer-review\` for re-evaluation."
+```
+
+The issue re-enters the triage pipeline. On the next cycle, `prefetch_triage_review_status()` will mark it **needs-review** (since the previous review predates the new information), and step 4.5 will dispatch a follow-up triage review worker.
+
+**Guard rails:**
+
+- Only count comments from the **original issue author** — not bots, maintainer, or other contributors.
+- This is a label transition only — no worker dispatch, no slots consumed.
+- If the maintainer has already relabeled the issue manually, it won't appear in this scan.
+- One API call per `status:needs-info` issue per cycle. These are low-volume by design.
 
 ### Kill stuck workers
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -820,6 +820,15 @@ _append_prefetch_sub_helpers() {
 	cat "$triage_tmp" >>"$STATE_FILE"
 	rm -f "$triage_tmp"
 
+	# Append status:needs-info contributor reply status
+	local needs_info_tmp
+	needs_info_tmp=$(mktemp)
+	run_cmd_with_timeout 30 prefetch_needs_info_replies "$repo_entries" >"$needs_info_tmp" 2>/dev/null || {
+		echo "[pulse-wrapper] prefetch_needs_info_replies timed out after 30s (non-fatal)" >>"$LOGFILE"
+	}
+	cat "$needs_info_tmp" >>"$STATE_FILE"
+	rm -f "$needs_info_tmp"
+
 	return 0
 }
 
@@ -2812,6 +2821,109 @@ prefetch_triage_review_status() {
 		echo "**Total pending triage reviews: ${total_pending}**"
 		echo ""
 		echo "[pulse-wrapper] Triage review status: ${total_pending} issues pending review" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+#######################################
+# Pre-fetch contributor reply status for status:needs-info issues
+#
+# For each pulse-enabled repo, finds issues with the status:needs-info
+# label and checks whether the original issue author has commented since
+# the label was applied. This enables the pulse to relabel issues back
+# to needs-maintainer-review when the contributor provides the requested
+# information.
+#
+# Detection: compare the label event timestamp (from timeline API) or
+# issue updatedAt against the most recent comment from the issue author.
+# If the author commented after the label was applied, mark as "replied".
+#
+# Arguments:
+#   $1 - repo_entries (slug|path pairs, one per line)
+# Output: needs-info reply status section to stdout
+#######################################
+prefetch_needs_info_replies() {
+	local repo_entries="$1"
+	local found_any=false
+	local total_replied=0
+
+	while IFS='|' read -r slug path; do
+		[[ -n "$slug" ]] || continue
+
+		# Get status:needs-info issues for this repo
+		local ni_json
+		ni_json=$(gh issue list --repo "$slug" --label "status:needs-info" \
+			--state open --json number,title,author,createdAt,updatedAt \
+			--limit 50 2>/dev/null) || ni_json="[]"
+
+		local ni_count
+		ni_count=$(echo "$ni_json" | jq 'length')
+		[[ "$ni_count" -gt 0 ]] || continue
+
+		if [[ "$found_any" == false ]]; then
+			echo ""
+			echo "# Needs Info — Contributor Reply Status"
+			echo ""
+			echo "Issues with \`status:needs-info\` label. For items marked **replied**, relabel to"
+			echo "\`needs-maintainer-review\` so the triage pipeline re-evaluates with the new information."
+			echo ""
+			found_any=true
+		fi
+
+		echo "## ${slug}"
+		echo ""
+
+		local i=0
+		while [[ "$i" -lt "$ni_count" ]]; do
+			local number title author created_at
+			number=$(echo "$ni_json" | jq -r ".[$i].number")
+			title=$(echo "$ni_json" | jq -r ".[$i].title")
+			author=$(echo "$ni_json" | jq -r ".[$i].author.login")
+			created_at=$(echo "$ni_json" | jq -r ".[$i].createdAt")
+
+			# Find when status:needs-info was applied via timeline events
+			# Fall back to updatedAt if timeline API fails
+			local label_date=""
+			local api_ok=true
+			label_date=$(gh api "repos/${slug}/issues/${number}/timeline" --paginate \
+				--jq '[.[] | select(.event == "labeled" and .label.name == "status:needs-info")] | last | .created_at' 2>/dev/null) || api_ok=false
+
+			if [[ "$api_ok" != true || -z "$label_date" || "$label_date" == "null" ]]; then
+				# Fall back: use issue updatedAt as approximate label time
+				label_date=$(echo "$ni_json" | jq -r ".[$i].updatedAt")
+			fi
+
+			# Check for author comments after the label was applied
+			local author_replied=false
+			local latest_author_comment_date=""
+			latest_author_comment_date=$(gh api "repos/${slug}/issues/${number}/comments" --paginate \
+				--jq "[.[] | select(.user.login == \"${author}\")] | last | .created_at" 2>/dev/null) || latest_author_comment_date=""
+
+			if [[ -n "$latest_author_comment_date" && "$latest_author_comment_date" != "null" && "$latest_author_comment_date" > "$label_date" ]]; then
+				author_replied=true
+			fi
+
+			local status_label
+			if [[ "$author_replied" == true ]]; then
+				status_label="replied"
+				total_replied=$((total_replied + 1))
+			else
+				status_label="waiting"
+			fi
+
+			echo "- Issue #${number}: ${title} [author: @${author}] [status: **${status_label}**] [labeled: ${label_date}]"
+
+			i=$((i + 1))
+		done
+
+		echo ""
+	done <<<"$repo_entries"
+
+	if [[ "$found_any" == true ]]; then
+		echo "**Total contributor replies pending action: ${total_replied}**"
+		echo ""
+		echo "[pulse-wrapper] Needs-info reply status: ${total_replied} issues with contributor replies" >>"$LOGFILE"
 	fi
 
 	return 0


### PR DESCRIPTION
## Summary

- Adds `prefetch_needs_info_replies()` to `pulse-wrapper.sh` — detects when contributors reply to `status:needs-info` issues by comparing comment timestamps against label application time (via timeline API)
- Adds Step 4.6 to `pulse.md` — relabels replied issues from `status:needs-info` → `needs-maintainer-review` so they re-enter the triage pipeline
- Adds `status:needs-info` to the issue triage decision list in pulse.md

## Problem

When an issue was relabeled from `needs-maintainer-review` to `status:needs-info` (asking the contributor for more information), it fell completely out of the pulse's triage scan. Contributors who replied with the requested information were never re-evaluated — the issue sat in limbo indefinitely.

Discovered via [#11487](https://github.com/marcusquinn/aidevops/issues/11487) where `@vRobM` replied to feedback but the pulse never picked it up.

## How it works

1. `prefetch_needs_info_replies()` runs during state prefetch (30s timeout, non-fatal)
2. For each `status:needs-info` issue, checks if the original author commented after the label was applied
3. Outputs a "Needs Info — Contributor Reply Status" section with **replied** / **waiting** status
4. The pulse reads this section and relabels **replied** issues to `needs-maintainer-review`
5. On the next cycle, the existing triage review pipeline (step 4.5) picks them up for re-evaluation

## Testing

- ShellCheck clean on `pulse-wrapper.sh`
- Self-assessed (docs + shell function, no runtime testing needed)

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (new prefetch function + docs, no changes to existing logic)
- **Verification**: ShellCheck clean, manual review of logic flow