### PR TITLE
GH#12350: tighten sandbox-patterns.md from 205 to 114 lines

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md
@@ -1,5 +1,7 @@
 # Common Patterns
 
+All patterns use the Worker boilerplate from `sandbox.md` Quick Start. First example shows the full Worker; subsequent examples show only the handler body.
+
 ## AI Code Execution Agent
 
 ```typescript
@@ -7,15 +9,10 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const { code } = await request.json();
     const sandbox = getSandbox(env.Sandbox, 'ai-agent');
-    
-    // Execute user code safely
     await sandbox.writeFile('/workspace/user_code.py', code);
     const result = await sandbox.exec('python3 /workspace/user_code.py');
-    
     return Response.json({
-      output: result.stdout,
-      error: result.stderr,
-      success: result.success
+      output: result.stdout, error: result.stderr, success: result.success
     });
   }
 };
@@ -24,182 +21,94 @@ export default {
 ## Interactive Dev Environment
 
 ```typescript
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const proxyResponse = await proxyToSandbox(request, env);
-    if (proxyResponse) return proxyResponse;
-    
-    const sandbox = getSandbox(env.Sandbox, 'ide', { normalizeId: true });
-    
-    if (request.url.endsWith('/start')) {
-      await sandbox.exec('curl -fsSL https://code-server.dev/install.sh | sh');
-      await sandbox.startProcess('code-server --bind-addr 0.0.0.0:8080', {
-        processId: 'vscode'
-      });
-      
-      const exposed = await sandbox.exposePort(8080);
-      return Response.json({ url: exposed.url });
-    }
-    
-    return new Response('Try /start');
-  }
-};
+// Requires proxyToSandbox() call first (see sandbox.md)
+const sandbox = getSandbox(env.Sandbox, 'ide', { normalizeId: true });
+await sandbox.exec('curl -fsSL https://code-server.dev/install.sh | sh');
+await sandbox.startProcess('code-server --bind-addr 0.0.0.0:8080', { processId: 'vscode' });
+const exposed = await sandbox.exposePort(8080);
+return Response.json({ url: exposed.url });
 ```
 
 ## CI/CD Pipeline
 
 ```typescript
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const { repo, branch } = await request.json();
-    const sandbox = getSandbox(env.Sandbox, `ci-${repo}-${Date.now()}`);
-    
-    await sandbox.exec(`git clone -b ${branch} ${repo} /workspace/repo`);
-    
-    const install = await sandbox.exec('npm install', {
-      cwd: '/workspace/repo',
-      stream: true,
-      onOutput: (stream, data) => console.log(data)
-    });
-    
-    if (!install.success) {
-      return Response.json({ success: false, error: 'Install failed' });
-    }
-    
-    const test = await sandbox.exec('npm test', { cwd: '/workspace/repo' });
-    
-    return Response.json({
-      success: test.success,
-      output: test.stdout,
-      exitCode: test.exitCode
-    });
-  }
-};
-```
-
-## Data Analysis Platform
-
-```typescript
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const { notebook } = await request.json();
-    const sandbox = getSandbox(env.Sandbox, 'data-analysis');
-    
-    await sandbox.writeFile('/workspace/analysis.ipynb', JSON.stringify(notebook));
-    
-    const result = await sandbox.exec(
-      'jupyter nbconvert --to notebook --execute analysis.ipynb --output results.ipynb',
-      { cwd: '/workspace' }
-    );
-    
-    const output = await sandbox.readFile('/workspace/results.ipynb');
-    
-    return Response.json({
-      success: result.success,
-      notebook: JSON.parse(output.content)
-    });
-  }
-};
+const { repo, branch } = await request.json();
+const sandbox = getSandbox(env.Sandbox, `ci-${repo}-${Date.now()}`);
+await sandbox.exec(`git clone -b ${branch} ${repo} /workspace/repo`);
+const install = await sandbox.exec('npm install', {
+  cwd: '/workspace/repo', stream: true, onOutput: (stream, data) => console.log(data)
+});
+if (!install.success) return Response.json({ success: false, error: 'Install failed' });
+const test = await sandbox.exec('npm test', { cwd: '/workspace/repo' });
+return Response.json({ success: test.success, output: test.stdout, exitCode: test.exitCode });
 ```
 
 ## Multi-Language Code Runner
 
 ```typescript
-const languageConfigs = {
-  python: { cmd: 'python3', ext: 'py' },
-  javascript: { cmd: 'node', ext: 'js' },
-  typescript: { cmd: 'ts-node', ext: 'ts' },
-  bash: { cmd: 'bash', ext: 'sh' }
+const langs: Record<string, { cmd: string; ext: string }> = {
+  python: { cmd: 'python3', ext: 'py' }, javascript: { cmd: 'node', ext: 'js' },
+  typescript: { cmd: 'ts-node', ext: 'ts' }, bash: { cmd: 'bash', ext: 'sh' }
 };
-
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const { language, code } = await request.json();
-    const config = languageConfigs[language];
-    
-    if (!config) {
-      return Response.json({ error: 'Unsupported language' }, { status: 400 });
-    }
-    
-    const sandbox = getSandbox(env.Sandbox, 'code-runner');
-    const filename = `/workspace/script.${config.ext}`;
-    
-    await sandbox.writeFile(filename, code);
-    const result = await sandbox.exec(`${config.cmd} ${filename}`);
-    
-    return Response.json({
-      output: result.stdout,
-      error: result.stderr,
-      exitCode: result.exitCode
-    });
-  }
-};
+const { language, code } = await request.json();
+const config = langs[language];
+if (!config) return Response.json({ error: 'Unsupported language' }, { status: 400 });
+const sandbox = getSandbox(env.Sandbox, 'code-runner');
+const filename = `/workspace/script.${config.ext}`;
+await sandbox.writeFile(filename, code);
+const result = await sandbox.exec(`${config.cmd} ${filename}`);
+return Response.json({ output: result.stdout, error: result.stderr, exitCode: result.exitCode });
 ```
 
 ## Multi-Tenant Pattern
 
 ```typescript
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const userId = request.headers.get('X-User-ID');
-    const sandbox = getSandbox(env.Sandbox, 'multi-tenant');
-    
-    // Each user gets isolated session
-    let session;
-    try {
-      session = await sandbox.getSession(userId);
-    } catch {
-      session = await sandbox.createSession({
-        id: userId,
-        cwd: `/workspace/users/${userId}`,
-        env: { USER_ID: userId }
-      });
-    }
-    
-    const code = await request.text();
-    const result = await session.exec(`python3 -c "${code}"`);
-    
-    return Response.json({ output: result.stdout });
-  }
-};
+const userId = request.headers.get('X-User-ID');
+const sandbox = getSandbox(env.Sandbox, 'multi-tenant');
+let session;
+try { session = await sandbox.getSession(userId); }
+catch { session = await sandbox.createSession({
+  id: userId, cwd: `/workspace/users/${userId}`, env: { USER_ID: userId }
+}); }
+const code = await request.text();
+const result = await session.exec(`python3 -c "${code}"`);
+return Response.json({ output: result.stdout });
 ```
 
 ## Jupyter Integration
 
-**Dockerfile**:
+**Dockerfile**: `FROM docker.io/cloudflare/sandbox:latest` + `RUN pip3 install --no-cache-dir jupyter-server ipykernel matplotlib pandas` + `EXPOSE 8888`
 
-```dockerfile
-FROM docker.io/cloudflare/sandbox:latest
-RUN pip3 install --no-cache-dir jupyter-server ipykernel matplotlib pandas
-EXPOSE 8888
-```
-
-**Worker**:
+**Worker** (interactive notebook):
 
 ```typescript
 await sandbox.startProcess('jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser', {
-  processId: 'jupyter',
-  cwd: '/workspace'
+  processId: 'jupyter', cwd: '/workspace'
 });
-
 const exposed = await sandbox.exposePort(8888, { name: 'jupyter' });
 return Response.json({ url: exposed.url });
+```
+
+**Headless execution** (nbconvert):
+
+```typescript
+const sandbox = getSandbox(env.Sandbox, 'data-analysis');
+await sandbox.writeFile('/workspace/analysis.ipynb', JSON.stringify(notebook));
+const result = await sandbox.exec(
+  'jupyter nbconvert --to notebook --execute analysis.ipynb --output results.ipynb',
+  { cwd: '/workspace' }
+);
+const output = await sandbox.readFile('/workspace/results.ipynb');
+return Response.json({ success: result.success, notebook: JSON.parse(output.content) });
 ```
 
 ## Git Operations
 
 ```typescript
-// Clone
 await sandbox.exec('git clone https://github.com/user/repo.git /workspace/repo');
-
-// Clone specific branch
 await sandbox.exec('git clone -b main --single-branch https://github.com/user/repo.git /workspace/repo');
-
-// Authenticated clone
-const token = env.GITHUB_TOKEN;
+const token = env.GITHUB_TOKEN; // Authenticated clone
 await sandbox.exec(`git clone https://${token}@github.com/user/private-repo.git`);
-
-// Git ops
 await sandbox.exec('git pull', { cwd: '/workspace/repo' });
 await sandbox.exec('git checkout -b feature', { cwd: '/workspace/repo' });
 ```


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md` from 205 lines to 114 lines (44% reduction), well within the ≤120 target
- All 7 pattern sections preserved: AI Code Execution, Interactive Dev Environment, CI/CD Pipeline, Multi-Language Code Runner, Multi-Tenant Pattern, Jupyter Integration, Git Operations
- All sandbox APIs preserved: `getSandbox`, `exec`, `writeFile`, `readFile`, `startProcess`, `exposePort`, `createSession`, `getSession`, `proxyToSandbox`

## Approach

- Show full Worker boilerplate only in first example; handler body only for subsequent patterns (boilerplate already documented in `sandbox.md` Quick Start)
- Merged Data Analysis Platform into Jupyter Integration section (both Jupyter-based, now shows interactive + headless modes)
- Condensed multi-line objects, try/catch blocks, and return statements
- Inlined Dockerfile as text (3 short commands)
- Removed redundant blank lines within code blocks

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs/reference content only, no executable code changes)
- Verification: `wc -l` confirms 114 lines; `markdownlint-cli2` reports 0 errors; all section headings and API references verified via `rg`

Closes #12350


---
[aidevops.sh](https://aidevops.sh) v3.5.83 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 7,815 tokens in 3m on this.