### PR TITLE
fix: raise simplification open issue cap to 200

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3363,7 +3363,7 @@ ISSUE_BODY_EOF
 # Exit codes: 0 = under cap (safe to create), 1 = at/over cap (skip)
 _complexity_scan_check_open_cap() {
 	local aidevops_slug="$1"
-	local cap="${2:-100}"
+	local cap="${2:-200}"
 	local log_prefix="${3:-Complexity scan}"
 
 	local total_open
@@ -3644,7 +3644,7 @@ This is an automated scan. The function lengths are factual, but the best decomp
 # deep reasoning to distinguish noise from institutional knowledge.
 #
 # Runs at most once per COMPLEXITY_SCAN_INTERVAL (default 15 min — each
-# pulse cycle). Creates up to 5 issues per run; the open cap (100) is
+# pulse cycle). Creates up to 5 issues per run; the open cap (200) is
 # the safety valve against backlog flooding.
 #
 # Returns: 0 always (best-effort, never breaks the pulse)

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -2452,8 +2452,8 @@ _create_simplification_issues() {
 	local total_open
 	total_open=$(gh api graphql -f query="query { repository(owner:\"${repo_slug%%/*}\", name:\"${repo_slug##*/}\") { issues(labels:[\"simplification-debt\"], states:OPEN) { totalCount } } }" \
 		--jq '.data.repository.issues.totalCount' 2>/dev/null) || total_open="0"
-	if [[ "${total_open:-0}" -ge 100 ]]; then
-		echo "[stats] Simplification issues: skipping — ${total_open} open (cap: 100)" >>"$LOGFILE"
+	if [[ "${total_open:-0}" -ge 200 ]]; then
+		echo "[stats] Simplification issues: skipping — ${total_open} open (cap: 200)" >>"$LOGFILE"
 		return 0
 	fi
 


### PR DESCRIPTION
Raises the total-open cap from 100 to 200 in both pulse-wrapper.sh and stats-functions.sh. Gives workers a deeper queue during off-peak 2x boost hours.