### PR TITLE
GH#12349: Tighten distribution-youtube.md from 206 to 111 lines

### DIFF
--- a/.agents/content/distribution-youtube.md
+++ b/.agents/content/distribution-youtube.md
@@ -3,21 +3,8 @@ name: youtube
 description: YouTube competitor research, content strategy, and video production automation
 mode: subagent
 model: sonnet
-subagents:
-  - channel-intel
-  - topic-research
-  - script-writer
-  - optimizer
-  - pipeline
-tools:
-  read: true
-  write: false
-  edit: false
-  bash: true
-  glob: true
-  grep: true
-  webfetch: true
-  task: true
+subagents: [channel-intel, topic-research, script-writer, optimizer, pipeline]
+tools: {read: true, write: false, edit: false, bash: true, glob: true, grep: true, webfetch: true, task: true}
 ---
 
 # YouTube - Main Agent
@@ -28,113 +15,61 @@ tools:
 
 - **Purpose**: YouTube competitor research, content ideation, script generation, and channel optimization
 - **Tools**: YouTube Data API v3 (via service account), yt-dlp, DataForSEO, Serper, Outscraper
-- **Helper**: `youtube-helper.sh` - Channel lookup, video enumeration, search, transcripts, competitor comparison
+- **Helper**: `youtube-helper.sh` — channel lookup, video enumeration, search, transcripts, competitor comparison
 - **Memory**: Cross-session persistence via `memory-helper.sh` (namespace: `youtube`)
 - **Commands**: `/youtube setup`, `/youtube research`, `/youtube competitors`, `/youtube script`, `/youtube pipeline`
-
-**Subagents** (this directory):
 
 | Subagent | Purpose |
 |----------|---------|
 | `channel-intel` | Channel profiling, competitor analysis, outlier detection |
 | `topic-research` | Niche trends, content gaps, keyword clustering, angle generation |
-| `script-writer` | YouTube script generation with hooks, retention curves, remix mode |
+| `script-writer` | Script generation with hooks, retention curves, remix mode |
 | `optimizer` | Title, tags, description, hook, and thumbnail optimization |
 | `pipeline` | Automated cron-driven research pipeline |
 
 <!-- AI-CONTEXT-END -->
 
-## When to Use
-
-Read this agent when the user wants to:
-
-- Research YouTube competitors and their content strategy
-- Find video topic ideas and content gaps in a niche
-- Generate YouTube video scripts (hooks, outlines, full scripts)
-- Optimize titles, tags, descriptions, and thumbnails
-- Set up automated competitor monitoring
-- Analyze what's working in a niche (outlier detection)
-
 ## Architecture
 
-The YouTube agent composes existing aidevops tools rather than building from scratch:
+Subagent docs: `content/distribution-youtube/`. Helpers: `scripts/youtube-helper.sh` (API wrapper), `yt-dlp-helper.sh` (transcripts), `keyword-research-helper.sh` (SEO), `memory-helper.sh` (persistence).
 
-```text
-content/distribution-youtube/
-  |
-  +-- youtube.md (orchestrator)
-  +-- channel-intel.md           Competitor profiling
-  +-- topic-research.md          Ideation & gap analysis
-  +-- script-writer.md           Script generation
-  +-- optimizer.md               Title/tag/description optimization
-  +-- pipeline.md                Automated cron pipeline
-  |
-  +-- youtube-helper.sh          YouTube Data API v3 wrapper (scripts/)
-  +-- yt-dlp-helper.sh           Video/transcript download (scripts/)
-  +-- keyword-research-helper.sh SEO keyword data (scripts/)
-  +-- memory-helper.sh           Cross-session persistence (scripts/)
-```
+## Data Sources
 
-## Data Sources (No Browser Required)
-
-| Source | What It Provides | Quota/Cost |
-|--------|-----------------|------------|
+| Source | Provides | Quota/Cost |
+|--------|----------|------------|
 | YouTube Data API v3 | Channel metadata, video stats, playlists | 10,000 units/day free |
 | yt-dlp | Transcripts, full metadata, downloads | Unlimited (local) |
 | DataForSEO | YouTube SERP rankings, keyword volume | Per-request pricing |
 | Serper | Google Trends, web search | Per-request pricing |
 | Outscraper | YouTube comments, sentiment | Per-request pricing |
 
-**Key insight**: Most YouTube research does NOT need browser automation. The API + yt-dlp approach avoids the context-filling screenshot problem entirely.
+Most research needs no browser automation — API + yt-dlp avoids context-filling screenshots.
 
 ## Quick Start
 
-### 1. Setup (one-time)
-
 ```bash
-# Test YouTube API access
+# 1. Setup (one-time)
 youtube-helper.sh auth-test
-
-# Store your channel and competitors in memory
 memory-helper.sh store --type WORKING_SOLUTION --namespace youtube \
   "My channel: @myhandle. Niche: [topic]. Competitors: @comp1, @comp2, @comp3"
-```
 
-### 2. Research a competitor
-
-```bash
-# Channel overview
+# 2. Research a competitor
 youtube-helper.sh channel @competitor
-
-# List their videos with stats
 youtube-helper.sh videos @competitor 100
-
-# Compare multiple channels
 youtube-helper.sh competitors @me @comp1 @comp2 @comp3
-
-# Get transcript of a high-performing video
 youtube-helper.sh transcript VIDEO_ID
-```
 
-### 3. Find opportunities
-
-```bash
-# Trending in your niche
+# 3. Find opportunities
 youtube-helper.sh trending "your niche topic" 20
-
-# Search for specific topics
 youtube-helper.sh search "topic keyword" video 20
-```
 
-### 4. Check quota
-
-```bash
+# 4. Check quota
 youtube-helper.sh quota
 ```
 
 ## Quota Management
 
-The YouTube Data API has a 10,000 unit daily quota. Budget carefully:
+Daily limit: 10,000 units. **Search costs 100 units** — prefer `playlistItems` (1 unit/50 videos). Transcripts via yt-dlp cost 0 units.
 
 | Operation | Cost | Budget for 10k |
 |-----------|------|----------------|
@@ -144,11 +79,7 @@ The YouTube Data API has a 10,000 unit daily quota. Budget carefully:
 | **Search** | **100 units** | **100 searches** |
 | Transcript (via yt-dlp) | 0 units | Unlimited |
 
-**Strategy**: Use `playlistItems` to enumerate channel videos (1 unit/50 videos) instead of `search` (100 units/50 results). Use yt-dlp for transcripts (free, no quota).
-
 ## Memory Namespaces
-
-The YouTube agent uses these memory namespaces for cross-session persistence:
 
 | Namespace | Content |
 |-----------|---------|
@@ -158,49 +89,23 @@ The YouTube agent uses these memory namespaces for cross-session persistence:
 | `youtube-patterns` | What titles/hooks/topics performed well |
 
 ```bash
-# Store research finding
 memory-helper.sh store --type WORKING_SOLUTION --namespace youtube-topics \
   "Content gap: No one covers [topic] from [angle] perspective"
-
-# Recall previous research
 memory-helper.sh recall --namespace youtube "competitor analysis"
 ```
 
 ## Workflow: Full Research Cycle
 
-1. **Channel Intel** (read `channel-intel.md`)
-   - Profile your channel and 3-5 competitors
-   - Identify outlier videos (3x+ channel average views)
-   - Extract content DNA (topics, formats, angles)
-
-2. **Topic Research** (read `topic-research.md`)
-   - Content gap analysis (your topics vs competitors)
-   - Keyword clustering for YouTube search
-   - Trend detection (rising topics before they peak)
-   - Angle generation (unique takes on proven topics)
-
-3. **Script Writing** (read `script-writer.md`)
-   - Generate scripts with hook -> intro -> body -> CTA
-   - Remix mode: transform competitor video into unique script
-   - Audience retention curve optimization
-
-4. **Optimization** (read `optimizer.md`)
-   - Title variants with CTR signals
-   - Tag generation (primary + long-tail + competitor)
-   - SEO-optimized descriptions
-   - Thumbnail analysis and generation brief
-
-5. **Pipeline** (read `pipeline.md`)
-   - Automated daily/weekly research via cron
-   - Each phase runs as isolated worker (no context overflow)
-   - Results persist in memory across sessions
+1. **Channel Intel** (`channel-intel.md`) — profile 3-5 competitors, identify outlier videos (3x+ avg views), extract content DNA
+2. **Topic Research** (`topic-research.md`) — content gap analysis, keyword clustering, trend detection, angle generation
+3. **Script Writing** (`script-writer.md`) — hook → intro → body → CTA scripts, remix mode, retention curve optimization
+4. **Optimization** (`optimizer.md`) — title variants with CTR signals, tag generation, SEO descriptions, thumbnail briefs
+5. **Pipeline** (`pipeline.md`) — automated daily/weekly cron research, isolated workers, cross-session memory persistence
 
 ## Related Agents
 
 | Agent | When to Use |
 |-------|-------------|
 | `seo.md` | Deep keyword research, SERP analysis, backlink data |
-| `content.md` | General content writing, SEO optimization |
-| `content.md` | Video production (Remotion, Higgsfield, HeyGen) |
+| `content.md` | General content writing, video production (Remotion, HeyGen), cross-platform promotion |
 | `research.md` | Broad web research beyond YouTube |
-| `content.md` | Cross-platform promotion strategy |


### PR DESCRIPTION
## Summary

- Tightened `.agents/content/distribution-youtube.md` from 206 lines to 111 lines (46% reduction), well within the ≤120 target
- Preserved all 10 CLI commands, 5 data tables, 2 code blocks, all subagent/helper references, and YAML frontmatter
- Fixed a bug: consolidated 3 duplicate `content.md` rows in Related Agents into 1

## What changed

| Technique | Lines saved |
|-----------|-------------|
| Inline YAML frontmatter (subagents/tools as flow sequences) | ~12 |
| Removed redundant "When to Use" section (covered by subagent table) | ~11 |
| Replaced verbose ASCII architecture tree with one-line summary | ~14 |
| Merged Quick Start subsections into single code block | ~15 |
| Compressed Workflow steps to one-line-per-step | ~20 |
| Consolidated duplicate Related Agents entries | ~5 |
| Removed verbose prose intros | ~8 |

## Verification

- `wc -l`: 111 lines (target: ≤120)
- All 10 `youtube-helper.sh`/`memory-helper.sh` commands: present
- All 14 key references (subagents, data sources, related agents, context markers): present
- YAML frontmatter: parses correctly (`python3 -c "import yaml; ..."`)
- Code blocks: 2 bash blocks preserved
- Tables: 5 tables preserved

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompt only, no code logic)
- **Rationale**: Documentation-only change — no runtime behavior affected

Closes #12349

---
[aidevops.sh](https://aidevops.sh) v3.5.84 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 8,306 tokens in 3m on this.