### PR TITLE
GH#12130: Tighten curl-copy.md from 245 to 129 lines

### DIFF
--- a/.agents/tools/browser/curl-copy.md
+++ b/.agents/tools/browser/curl-copy.md
@@ -22,26 +22,12 @@ tools:
 - **No install required**: Uses browser DevTools + curl (built into macOS/Linux)
 - **Best for**: Dashboards, gated content, private APIs, admin panels, one-off extractions
 
-**When to Use Curl-Copy**:
+**Use when**: One-off extraction from authenticated pages, scraping behind login walls, accessing private/internal APIs from DevTools, extracting dashboard data, debugging API responses with real session state.
 
-- Quick one-off data extraction from authenticated pages
-- Scraping behind login walls without setting up automation
-- Accessing private/internal APIs discovered in DevTools
-- Extracting data from dashboards (analytics, admin panels, CRMs)
-- Debugging API responses with real session state
-
-**When NOT to Use**:
-
-- Repeated/scheduled scraping (tokens expire) - use sweet-cookie or Playwright persistent sessions
-- Multi-page crawling - use Crawl4AI or Playwright
-- Sites requiring interaction (clicks, form fills) - use Stagehand or Playwright
-- Long-running sessions (cookies expire in minutes to hours depending on site)
-
-**Quick Decision**:
+**Don't use when**: Repeated/scheduled scraping (tokens expire — use sweet-cookie or Playwright persistent sessions), multi-page crawling (use Crawl4AI or Playwright), interaction required (use Stagehand or Playwright), long-running sessions (cookies expire).
 
 ```text
 Need data from an authenticated page?
-    |
     +-> One-off extraction? --> Curl-Copy (this workflow)
     +-> Repeated/scheduled? --> sweet-cookie + cron
     +-> Need to interact first? --> Playwright or Stagehand
@@ -56,153 +42,72 @@ Need data from an authenticated page?
 
 1. Open the target page in your browser (Chrome, Firefox, Edge, Safari)
 2. Open DevTools: `Cmd+Option+I` (macOS) or `F12` (Windows/Linux)
-3. Go to the **Network** tab
+3. Go to the **Network** tab, filter by `Fetch/XHR` to see API calls
 4. Perform the action or reload the page to capture the request
-5. Find the request you want (click on it to inspect headers/response)
-6. Right-click the request → **Copy** → **Copy as cURL**
+5. Right-click the request → **Copy** → **Copy as cURL** (Chrome/Edge: "Copy as cURL (bash)", Firefox: "Copy Value → Copy as cURL", Safari: "Copy as cURL")
 
-**Browser-specific paths**:
+### Step 2: Execute and Transform
 
-| Browser | Menu Path |
-|---------|-----------|
-| Chrome | Right-click request → Copy → Copy as cURL (bash) |
-| Firefox | Right-click request → Copy Value → Copy as cURL |
-| Edge | Right-click request → Copy → Copy as cURL (bash) |
-| Safari | Right-click request → Copy as cURL |
-
-### Step 2: Use the Copied cURL Command
-
-Paste the copied command directly into your terminal or AI assistant. The command includes all headers, cookies, and authentication tokens from your active session.
-
-**Example copied command** (headers truncated for brevity):
+Paste the copied command directly into terminal or AI assistant. It includes all headers, cookies, and auth tokens from your active session.
 
 ```bash
+# Example copied command (headers truncated)
 curl 'https://analytics.example.com/api/v1/reports/traffic' \
   -H 'accept: application/json' \
   -H 'authorization: Bearer eyJhbGciOiJSUzI1NiIs...' \
-  -H 'cookie: session_id=abc123; csrf_token=xyz789; _ga=GA1.2.123456' \
-  -H 'referer: https://analytics.example.com/dashboard' \
+  -H 'cookie: session_id=abc123; csrf_token=xyz789' \
   -H 'user-agent: Mozilla/5.0 ...'
-```
 
-### Step 3: Modify for Your Needs
-
-Common modifications to the copied command:
-
-```bash
-# Save output to file
-curl '...' -o output.json
-
-# Pretty-print JSON response
-curl '...' -s | jq .
-
-# Follow redirects
-curl '...' -L
-
-# Change request method
-curl '...' -X POST -d '{"query": "new data"}'
-
-# Add pagination
-curl '...?page=1&per_page=100' -s | jq .
-curl '...?page=2&per_page=100' -s | jq .
-
-# Extract specific fields
-curl '...' -s | jq '.data[] | {name: .name, value: .value}'
-
-# Save with timestamp
-curl '...' -s -o "export-$(date +%Y%m%d-%H%M%S).json"
+# Common modifications
+curl '...' -o output.json                                    # Save to file
+curl '...' -s | jq .                                         # Pretty-print JSON
+curl '...' -L                                                # Follow redirects
+curl '...' -X POST -d '{"query": "new data"}'                # Change method
+curl '...' -s | jq '.data[] | {name: .name, value: .value}'  # Extract fields
+curl '...' -s -o "export-$(date +%Y%m%d-%H%M%S).json"        # Timestamped save
+curl '...?page=1&per_page=100' -s | jq .                     # Pagination
 ```
 
 ## Practical Examples
 
-### Extract Analytics Dashboard Data
-
 ```bash
-# 1. Navigate to analytics dashboard in browser
-# 2. Open DevTools Network tab
-# 3. Copy the API request that loads the chart/table data
-# 4. Paste and pipe through jq
-
+# Extract analytics dashboard data — pipe chart/table API through jq
 curl 'https://analytics.example.com/api/reports?range=30d' \
   -H 'cookie: session=...' \
   -s | jq '.rows[] | [.page, .views, .bounceRate] | @csv'
-```
 
-### Scrape Admin Panel Listings
-
-```bash
-# Paginate through all results
+# Paginate admin panel listings
 for page in $(seq 1 10); do
   curl "https://admin.example.com/api/users?page=$page&limit=100" \
     -H 'cookie: session=...' \
     -s | jq '.users[]' >> all-users.json
   sleep 1  # Be respectful
 done
-```
 
-### Download Private API Schema
-
-```bash
-# Many apps expose OpenAPI/Swagger docs behind auth
+# Download private API schema (OpenAPI/Swagger behind auth)
 curl 'https://app.example.com/api/docs/openapi.json' \
-  -H 'cookie: session=...' \
-  -s | jq . > api-schema.json
-```
+  -H 'cookie: session=...' -s | jq . > api-schema.json
 
-### Extract Data from SPA (Single Page App)
-
-```bash
-# SPAs often use XHR/fetch calls - look for these in Network tab
-# Filter by "Fetch/XHR" in DevTools to find the API calls
-# The actual data endpoints are often cleaner than scraping HTML
-
+# SPA GraphQL — filter by Fetch/XHR in DevTools to find data endpoints
 curl 'https://app.example.com/graphql' \
-  -H 'content-type: application/json' \
-  -H 'cookie: session=...' \
-  -d '{"query": "{ users { id name email } }"}' \
-  -s | jq .
+  -H 'content-type: application/json' -H 'cookie: session=...' \
+  -d '{"query": "{ users { id name email } }"}' -s | jq .
 ```
 
 ## Tips
 
-### Finding the Right Request
+**Finding the right request**: Filter by `Fetch/XHR` in DevTools Network tab to skip images/CSS/JS. Click requests and check the Response/Preview tab for structured JSON data. Use the filter box to search by URL path.
 
-- **Filter by type**: In DevTools Network tab, filter by `Fetch/XHR` to see API calls (skip images, CSS, JS)
-- **Look for JSON responses**: Click requests and check the Response tab - API endpoints return structured data
-- **Check the Preview tab**: Chrome shows formatted JSON, making it easy to identify data-rich endpoints
-- **Search in Network tab**: Use the filter box to search by URL path or response content
+**Extending session lifetime**: Keep the browser tab open (some sessions auto-refresh). If you get 401/403, copy a fresh cURL command. Note which cookie names are session tokens for quick updates.
 
-### Extending Session Lifetime
+**Security**: Never commit copied cURL commands to git (they contain session tokens). Add `sleep` between requests to avoid abuse detection. Respect robots.txt. Strip `cookie`, `authorization`, and `x-csrf-token` headers before sharing.
 
-- **Keep the browser tab open**: Some sessions refresh automatically while the tab is active
-- **Re-copy when expired**: If you get a 401/403, go back to the browser and copy a fresh cURL command
-- **Note the cookie names**: Identify which cookies are session tokens so you know what to update
+**With AI assistants**: Paste the cURL command with instructions like "extract all product names" or "paginate and compile results". The AI executes curl, parses JSON, and transforms data. **Privacy**: the command contains session cookies — only share with trusted, locally-running assistants.
 
-### Security Considerations
+## Auth Method Comparison
 
-- **Never commit** copied cURL commands to git (they contain session tokens)
-- **Tokens expire**: Session cookies and Bearer tokens have limited lifetimes (minutes to hours)
-- **Rate limit yourself**: Add `sleep` between requests to avoid triggering abuse detection
-- **Respect robots.txt**: Even with valid auth, follow the site's scraping policies
-- **Strip sensitive headers** before sharing: Remove `cookie`, `authorization`, and `x-csrf-token` headers
-
-### Working with AI Assistants
-
-The curl-copy workflow pairs well with AI assistants:
-
-1. Copy the cURL command from DevTools
-2. Paste it to your AI assistant with instructions like:
-   - "Run this and extract all product names and prices"
-   - "Paginate through this API and compile the results"
-   - "Parse this response and create a CSV"
-3. The AI can execute the curl, parse the JSON, and transform the data
-
-**Privacy note**: The pasted cURL command contains your session cookies. Only share with trusted AI assistants running locally or with appropriate data handling policies.
-
-## Comparison with Other Auth Methods
-
-| Method | Setup Time | Session Duration | Automation | Best For |
-|--------|-----------|-----------------|------------|----------|
+| Method | Setup | Session Duration | Automation | Best For |
+|--------|-------|-----------------|------------|----------|
 | **Curl-Copy** | Seconds | Minutes-hours | Manual | One-off extractions |
 | **Sweet Cookie** | Minutes | Browser session | Scriptable | Repeated local access |
 | **Playwright persistent** | Minutes | Configurable | Full | Automated workflows |
@@ -211,31 +116,10 @@ The curl-copy workflow pairs well with AI assistants:
 
 ## Troubleshooting
 
-### 401 Unauthorized / 403 Forbidden
-
-Session expired. Go back to the browser, reload the page, and copy a fresh cURL command.
-
-### CORS Errors
-
-Not applicable - curl bypasses CORS entirely (CORS is browser-only). If you see CORS-related headers in the response, they can be ignored.
-
-### Empty or HTML Response Instead of JSON
-
-The endpoint may require specific `Accept` headers. Add:
-
-```bash
-curl '...' -H 'accept: application/json'
-```
-
-Or the URL may be a page URL, not an API URL. Look for XHR/Fetch requests in DevTools instead.
-
-### SSL Certificate Errors
-
-For internal/dev servers with self-signed certs:
-
-```bash
-curl '...' -k  # Skip certificate verification (dev only)
-```
+- **401/403**: Session expired — reload the page in browser and copy a fresh cURL command
+- **CORS errors**: Not applicable — curl bypasses CORS entirely (browser-only restriction)
+- **Empty/HTML response instead of JSON**: Add `-H 'accept: application/json'`, or the URL may be a page URL not an API endpoint — look for XHR/Fetch requests in DevTools instead
+- **SSL certificate errors**: For internal/dev servers with self-signed certs: `curl '...' -k` (dev only)
 
 ## Related Tools
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/browser/curl-copy.md` from 245 to 129 lines (47% reduction)
- Compressed prose while preserving all technical content: code blocks, URLs, tool references, key concepts
- Merged workflow steps, consolidated browser-specific paths, compacted tips into dense paragraphs, inlined troubleshooting

## Changes

- Merged "When to Use" / "When NOT to Use" into compact inline sentences
- Combined Steps 2 (paste) and 3 (modify) into single "Execute and Transform" section
- Removed per-browser table — inlined as parenthetical in step 5
- Consolidated 4 practical examples into single code block with comments
- Converted tip subsections into dense paragraphs
- Inlined troubleshooting as bullet list

## Verification

- All 19 key concepts verified present (sweet-cookie, Playwright, Stagehand, Crawl4AI, DevTools, 401, 403, CORS, SSL, robots.txt, jq, GraphQL, OpenAPI, Swagger, session tokens, Bearer, CSRF, pagination, Fetch/XHR)
- All 5 example URLs preserved
- All 4 related tool references preserved
- 6 code blocks retained
- Frontmatter unchanged

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (docs/agent prompt only)
- **Rationale**: No code changes, no runtime behavior affected

Closes #12130


---
[aidevops.sh](https://aidevops.sh) v3.5.87 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 5,049 tokens in 3m on this.