### PR TITLE
fix: Signature footer silently failed — unbound array under set -u

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -746,7 +746,8 @@ cmd_footer() {
 	fi
 
 	local sig
-	sig=$(cmd_generate "${args[@]}")
+	# ${args[@]+"${args[@]}"} handles empty array under set -u (Bash 3.2 compat)
+	sig=$(cmd_generate ${args[@]+"${args[@]}"})
 	printf '\n---\n%s\n' "$sig"
 	return 0
 }


### PR DESCRIPTION
## Summary

Root cause of missing signatures on issue descriptions (e.g., #12385).

`cmd_footer` parsed `--body` into a separate variable, leaving `args=()` empty. Under `set -u` (nounset), `${args[@]}` on an empty array throws an unbound variable error in Bash 3.2. The error was suppressed by `2>/dev/null` in callers, so the footer silently returned nothing.

Fix: `${args[@]+"${args[@]}"}` — the standard empty-array-safe pattern for Bash 3.2 + `set -u`.

## Testing

- 43/43 tests pass
- Verified: `footer --body "clean"` with no env vars now produces `automated scan.` footer
- Verified: dedup still works (body containing `aidevops.sh` → empty)

---
[aidevops.sh](https://aidevops.sh) v3.5.87 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 41,640 tokens in 6h 1m on this.