### PR TITLE
fix: prevent pulse dispatcher from inventing line count targets

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -731,6 +731,8 @@ gh issue comment <number> --repo <slug> --body "Dispatching worker.
 ${SIG_FOOTER}"
 ```
 
+**No arbitrary line targets in Scope/Direction.** For simplification issues, do not invent target line counts (e.g., "from 206 to ≤120 lines"). The worker reads `code-simplifier.md` which says the resulting size is whatever remains after removing genuine noise. For large files, the worker will subdivide per `build-agent.md` (~300-line threshold). Inventing a number creates pressure to cut content to hit a target.
+
 **Required fields in kill/failure comments:**
 
 When killing a worker or closing a failed PR, comment with:


### PR DESCRIPTION
## Summary

- Adds explicit "no arbitrary line targets" guidance to the dispatch comment template in `pulse.md`
- Placed immediately after the Scope/Direction template fields — the exact point where dispatchers compose free-text that workers treat as requirements

## Why

PR #12386 showed a worker on v3.5.84 still optimizing to "≤120 lines" because the **dispatcher** invented that target in the Scope field. The prior fix (v3.5.83) added the rule to `code-simplifier.md` and `build-agent.md` — which the worker reads during implementation — but the dispatcher reads `pulse.md` to compose the dispatch comment *before* the worker starts. The dispatcher was the source of the arbitrary target, not the worker.

## Testing

- `self-assessed` — agent prompt change only, no runtime behaviour
- `markdownlint-cli2`: zero errors

---
[aidevops.sh](https://aidevops.sh) v3.5.87 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6