### PR TITLE
GH#12129: tighten mermaid cheatsheet from 245 to 144 lines

### DIFF
--- a/.agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md
@@ -2,231 +2,130 @@
 
 ## Diagram Declarations
 
-| Diagram | Declaration |
-|---------|-------------|
-| Flowchart | `flowchart LR` / `flowchart TB` |
-| Sequence | `sequenceDiagram` |
-| Class | `classDiagram` |
-| ER | `erDiagram` |
-| State | `stateDiagram-v2` |
-| User Journey | `journey` |
-| Gantt | `gantt` |
-| Pie | `pie` / `pie showData` |
-| Mindmap | `mindmap` |
-| Timeline | `timeline` |
-| Git Graph | `gitGraph` |
-| C4 Context | `C4Context` |
-| C4 Container | `C4Container` |
-| C4 Component | `C4Component` |
-| Architecture | `architecture-beta` |
-| Block | `block-beta` |
-| Quadrant | `quadrantChart` |
-| XY Chart | `xychart-beta` |
-| Sankey | `sankey-beta` |
-| Kanban | `kanban` |
-| Packet | `packet-beta` |
-| Requirement | `requirementDiagram` |
-| Treemap | `treemap-beta` |
+| Diagram | Declaration | Diagram | Declaration |
+|---------|-------------|---------|-------------|
+| Flowchart | `flowchart LR` / `TB` | Sequence | `sequenceDiagram` |
+| Class | `classDiagram` | ER | `erDiagram` |
+| State | `stateDiagram-v2` | User Journey | `journey` |
+| Gantt | `gantt` | Pie | `pie` / `pie showData` |
+| Mindmap | `mindmap` | Timeline | `timeline` |
+| Git Graph | `gitGraph` | C4 Context | `C4Context` |
+| C4 Container | `C4Container` | C4 Component | `C4Component` |
+| Architecture | `architecture-beta` | Block | `block-beta` |
+| Quadrant | `quadrantChart` | XY Chart | `xychart-beta` |
+| Sankey | `sankey-beta` | Kanban | `kanban` |
+| Packet | `packet-beta` | Requirement | `requirementDiagram` |
+| Treemap | `treemap-beta` | | |
 
 ## Flowchart
 
-Direction: `TB`/`TD` (top-bottom) · `BT` · `LR` · `RL`
+Direction: `TB`/`TD` (top-bottom) `BT` `LR` `RL`
 
-### Node Shapes
+**Nodes:** `A[Rect]` `B(Rounded)` `C([Stadium])` `D[[Subroutine]]` `E[(Database)]` `F((Circle))` `G{Diamond}` `H{{Hexagon}}` `I[/Parallelogram/]` `J(((Double)))`
 
-```
-A[Rectangle]       B(Rounded)         C([Stadium])
-D[[Subroutine]]    E[(Database)]      F((Circle))
-G{Diamond}         H{{Hexagon}}       I[/Parallelogram/]
-J(((Double)))
-```
+| Edge | Meaning | Edge | Meaning |
+|------|---------|------|---------|
+| `A --> B` | Solid arrow | `A --- B` | Solid line |
+| `A -.-> B` | Dotted arrow | `A ==> B` | Thick arrow |
+| `A --o B` | Circle end | `A --x B` | Cross end |
+| `A <--> B` | Bidirectional | `A -->\|text\| B` | Labeled |
 
-### Edges
-
-```
-A --> B       Solid arrow         A --- B       Solid line
-A -.-> B      Dotted arrow        A ==> B       Thick arrow
-A --o B       Circle end          A --x B       Cross end
-A <--> B      Bidirectional       A -->|text| B Labeled
-```
-
-### Subgraph
-
-```mermaid
-flowchart TB
-    subgraph Name
-        A --> B
-    end
-```
+**Subgraph:** `subgraph Name` ... `end` (nestable, linkable between subgraphs)
 
 ## Sequence Diagram
 
-### Messages
+| Message | Meaning | Message | Meaning |
+|---------|---------|---------|---------|
+| `A->>B` | Sync (solid) | `A-->>B` | Response (dotted) |
+| `A-xB` | Failed | `A-)B` | Async |
+| `A->>+B` | Activate B | `B-->>-A` | Deactivate B |
 
-```
-A->>B     Solid arrow (sync)      A-->>B    Dotted arrow (response)
-A-xB      Failed message          A-)B      Async message
-A->>+B: Request    Activate B
-B-->>-A: Response  Deactivate B
-```
+**Control flow:** `alt`/`else`/`end` `opt`/`end` `loop`/`end` `par`/`and`/`end` `critical`/`option`/`end` `break`/`end`
 
-### Control Flow
-
-```
-alt Condition          opt Optional           loop Every 30s
-    A->>B: If true         A->>B: Maybe           A->>B: Repeat
-else                   end                    end
-    A->>B: If false
-end
-
-par Parallel
-    A->>B: Task 1
-and
-    A->>C: Task 2
-end
-
-Note right of A: Text
-Note over A,B: Spanning note
-```
+**Notes:** `Note right of A: Text` `Note over A,B: Spanning`
 
 ## Class Diagram
 
-### Visibility
+**Visibility:** `+` Public `-` Private `#` Protected `~` Package
 
-```
-+  Public    -  Private    #  Protected    ~  Package
-```
+| Relationship | Meaning | Relationship | Meaning |
+|-------------|---------|-------------|---------|
+| `A <\|-- B` | Inheritance | `A *-- B` | Composition |
+| `A o-- B` | Aggregation | `A --> B` | Association |
+| `A ..> B` | Dependency | `A ..\|> B` | Realization |
 
-### Relationships
+**Cardinality:** `A "1" --> "*" B : has` `A "0..1" --> "1..*" B`
 
-```
-A <|-- B    Inheritance      A *-- B     Composition
-A o-- B     Aggregation      A --> B     Association
-A ..> B     Dependency       A ..|> B    Realization
-```
-
-### Cardinality & Annotations
-
-```
-A "1" --> "*" B : has
-A "0..1" --> "1..*" B
-
-class A { <<interface>>    +method() }
-class B { <<enumeration>>  VALUE1    }
-```
+**Annotations:** `class A { <<interface>> +method() }` `class B { <<enumeration>> VALUE1 }`
 
 ## ER Diagram
 
-### Cardinality
+| Symbol | Meaning | Symbol | Meaning |
+|--------|---------|--------|---------|
+| `\|\|--\|\|` | One to one | `\|\|--o{` | One to many |
+| `}o--o{` | Many-many (opt) | `}\|--\|{` | Many-many (req) |
+| `--` | Identifying | `..` | Non-identifying |
 
-```
-||--||    One to one         ||--o{    One to many
-}o--o{    Many to many (opt) }|--|{    Many to many (req)
---    Identifying (solid)    ..    Non-identifying (dashed)
-```
-
-### Attributes
-
-```
-ENTITY {
-    type name PK     type name FK     type name UK     type name
-}
-```
+**Attributes:** `ENTITY { type name PK` `type name FK` `type name UK` `type name }`
 
 ## State Diagram
 
-```
-[*] --> State1          state Parent {        state check <<choice>>
-State1 --> State2           [*] --> Child1    A --> check
-State2 --> [*]              Child1 --> Child2 check --> B : cond1
-State1 --> State1       }                     check --> C : cond2
+**Transitions:** `[*] --> State1` `State1 --> State2` `State2 --> [*]` (self: `S --> S`)
 
-state fork <<fork>>    state join <<join>>
-[*] --> fork           fork --> A    fork --> B
-A --> join             B --> join    join --> [*]
-```
+**Composite:** `state Parent { [*] --> Child1` `Child1 --> Child2 }`
+
+**Choice/Fork/Join:** `state check <<choice>>` `state fork <<fork>>` `state join <<join>>`
 
 ## Gantt Chart
 
-```
-Task name : [tags], [id], [start], [end/duration]
+**Format:** `Task name : [tags], [id], [start], [end/duration]`
 
-Completed   :done, t1, 2024-01-01, 7d
-Active      :active, t2, after t1, 5d
-Critical    :crit, t3, 2024-01-15, 3d
-Milestone   :milestone, m1, 2024-01-20, 0d
+**Tags:** `done` `active` `crit` `milestone` -- **Dependencies:** `after t1` `after t1 t2`
 
-after taskId          after t1 t2    (multiple)
-```
+**Example:** `Completed :done, t1, 2024-01-01, 7d` `Active :active, t2, after t1, 5d` `Milestone :milestone, m1, 2024-01-20, 0d`
 
 ## Pie Chart
 
-```mermaid
-pie showData
-    title Chart Title
-    "Label 1" : 42
-    "Label 2" : 28
-```
+`pie showData` then indented `title Chart Title` and `"Label 1" : 42` entries.
 
 ## Timeline
 
-```
-timeline
-    title Title
-    section Period
-        Date : Event 1
-             : Event 2
-```
+`timeline` then indented `title Title`, `section Period`, `Date : Event 1 : Event 2`.
 
 ## C4 Diagrams
 
-```
-Person(alias, "Label", "Description")
-System(alias, "Label", "Description")       System_Ext(alias, "Label", "Description")
-Container(alias, "Label", "Tech", "Desc")   ContainerDb(alias, "Label", "Tech", "Desc")
-Component(alias, "Label", "Tech", "Desc")
+**Elements:** `Person(alias, "Label", "Desc")` `System(alias, "Label", "Desc")` `System_Ext(...)` `Container(alias, "Label", "Tech", "Desc")` `ContainerDb(...)` `Component(alias, "Label", "Tech", "Desc")`
 
-Rel(from, to, "Label")    Rel(from, to, "Label", "Tech")    BiRel(from, to, "Label")
+**Relations:** `Rel(from, to, "Label")` `Rel(from, to, "Label", "Tech")` `BiRel(from, to, "Label")`
 
-System_Boundary(alias, "Label") { Container(...) }
-```
+**Boundaries:** `System_Boundary(alias, "Label") { Container(...) }`
 
 ## Architecture Diagram
 
-```
-group id(icon)[Title]               group id(icon)[Title] in parent
-service id(icon)[Title]             service id(icon)[Title] in group
+**Groups:** `group id(icon)[Title]` `group id(icon)[Title] in parent`
 
-a:R --> L:b     a:T --> B:b     <-->  Bidirectional
-```
+**Services:** `service id(icon)[Title]` `service id(icon)[Title] in group`
 
-Icons: `cloud`, `database`, `disk`, `internet`, `server`
+**Edges:** `a:R --> L:b` `a:T --> B:b` `<-->` bidirectional
+
+**Icons:** `cloud` `database` `disk` `internet` `server`
 
 ## Styling
 
-```mermaid
-%%{init: {'theme': 'dark'}}%%
-```
+**Theme init:** `%%{init: {'theme': 'dark'}}%%` -- Themes: `default` `dark` `forest` `neutral` `base`
 
-Themes: `default`, `dark`, `forest`, `neutral`, `base`
+**Custom:** `%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#3b82f6', 'lineColor': '#64748b'}}}%%`
 
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#3b82f6', 'lineColor': '#64748b'}}}%%
-flowchart LR
-    A:::myClass --> B
-    classDef myClass fill:#f00,stroke:#333,color:#fff
-    style A fill:#f00
-    linkStyle 0 stroke:red
-    linkStyle default stroke:gray
-```
+**Node styling:** `classDef myClass fill:#f00,stroke:#333,color:#fff` `A:::myClass` `style A fill:#f00`
+
+**Link styling:** `linkStyle 0 stroke:red` `linkStyle default stroke:gray`
 
 ## Special Characters
 
-| Char | Escape | Char | Escape |
-|------|--------|------|--------|
-| `"` | `#quot;` | `#` | `#35;` |
-| `<` | `#lt;` | `>` | `#gt;` |
-| `{` | `#123;` | `}` | `#125;` |
+| Char | Escape | Char | Escape | Char | Escape |
+|------|--------|------|--------|------|--------|
+| `"` | `#quot;` | `#` | `#35;` | `<` | `#lt;` |
+| `>` | `#gt;` | `{` | `#123;` | `}` | `#125;` |
 
 ## Quick Decision Guide
 
@@ -242,4 +141,4 @@ flowchart LR
 | Flow allocation | Sankey | Task board | Kanban |
 | Protocol structure | Packet | Requirements | Requirement |
 
-**Resources:** [Live Editor](https://mermaid.live) · [Docs](https://mermaid.js.org) · [GitHub](https://github.com/mermaid-js/mermaid)
+**Resources:** [Live Editor](https://mermaid.live) | [Docs](https://mermaid.js.org) | [GitHub](https://github.com/mermaid-js/mermaid)


### PR DESCRIPTION
## Summary

- Tightens `.agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md` from 245 to 144 lines (41% reduction)
- Converts verbose fenced code blocks into compact inline syntax and dual-column tables
- Merges Pie/Timeline fenced blocks into inline descriptions
- Consolidates Declarations table from single-column to dual-column layout

## Content Preservation (verified)

All technical content preserved — automated checks confirmed presence of:
- All 22 diagram type declarations
- All 10 flowchart node shapes and 8 edge types
- All 6 sequence message types and control flow keywords
- All 4 class visibility modifiers and 6 relationship types
- All ER cardinality symbols
- All state diagram features (choice/fork/join/composite)
- All C4 elements, relations, and boundaries
- All architecture icons and edge syntax
- All Gantt tags and dependency syntax
- All 5 themes and 4 styling features (classDef, linkStyle, themeVariables, primaryColor)
- All 6 special character escapes
- All 19 decision guide entries
- All 3 resource URLs

## Runtime Testing

- **Level:** self-assessed
- **Risk:** Low (docs-only change, no code)
- **Verification:** markdownlint: 0 errors; automated content-preservation grep checks: 100% pass

Closes #12129

---
[aidevops.sh](https://aidevops.sh) v3.5.87 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 7,539 tokens in 5m on this.