### PR TITLE
GH#12130: Tighten curl-copy.md from 245 to 149 lines

### DIFF
--- a/.agents/tools/browser/curl-copy.md
+++ b/.agents/tools/browser/curl-copy.md
@@ -22,29 +22,11 @@ tools:
 - **No install required**: Uses browser DevTools + curl (built into macOS/Linux)
 - **Best for**: Dashboards, gated content, private APIs, admin panels, one-off extractions
 
-**When to Use Curl-Copy**:
-
-- Quick one-off data extraction from authenticated pages
-- Scraping behind login walls without setting up automation
-- Accessing private/internal APIs discovered in DevTools
-- Extracting data from dashboards (analytics, admin panels, CRMs)
-- Debugging API responses with real session state
-
-**When NOT to Use**:
-
-- Repeated/scheduled scraping (tokens expire) - use sweet-cookie or Playwright persistent sessions
-- Multi-page crawling - use Crawl4AI or Playwright
-- Sites requiring interaction (clicks, form fills) - use Stagehand or Playwright
-- Long-running sessions (cookies expire in minutes to hours depending on site)
-
-**Quick Decision**:
-
 ```text
 Need data from an authenticated page?
-    |
     +-> One-off extraction? --> Curl-Copy (this workflow)
     +-> Repeated/scheduled? --> sweet-cookie + cron
-    +-> Need to interact first? --> Playwright or Stagehand
+    +-> Need interaction first? --> Playwright or Stagehand
     +-> Bulk pages? --> Crawl4AI with exported cookies
 ```
 
@@ -54,108 +36,69 @@ Need data from an authenticated page?
 
 ### Step 1: Copy the Request from DevTools
 
-1. Open the target page in your browser (Chrome, Firefox, Edge, Safari)
-2. Open DevTools: `Cmd+Option+I` (macOS) or `F12` (Windows/Linux)
-3. Go to the **Network** tab
-4. Perform the action or reload the page to capture the request
-5. Find the request you want (click on it to inspect headers/response)
-6. Right-click the request → **Copy** → **Copy as cURL**
+1. Open the target page in your browser
+2. Open DevTools (`Cmd+Option+I` / `F12`) → **Network** tab
+3. Perform the action or reload to capture the request
+4. Find the request (filter by `Fetch/XHR` for API calls)
+5. Right-click the request → **Copy** → **Copy as cURL** (all browsers support this; Firefox: Copy Value → Copy as cURL)
 
-**Browser-specific paths**:
+### Step 2: Use the Copied Command
 
-| Browser | Menu Path |
-|---------|-----------|
-| Chrome | Right-click request → Copy → Copy as cURL (bash) |
-| Firefox | Right-click request → Copy Value → Copy as cURL |
-| Edge | Right-click request → Copy → Copy as cURL (bash) |
-| Safari | Right-click request → Copy as cURL |
-
-### Step 2: Use the Copied cURL Command
-
-Paste the copied command directly into your terminal or AI assistant. The command includes all headers, cookies, and authentication tokens from your active session.
-
-**Example copied command** (headers truncated for brevity):
+Paste directly into terminal or AI assistant. The command includes all headers, cookies, and auth tokens from your active session:
 
 ```bash
 curl 'https://analytics.example.com/api/v1/reports/traffic' \
   -H 'accept: application/json' \
   -H 'authorization: Bearer eyJhbGciOiJSUzI1NiIs...' \
-  -H 'cookie: session_id=abc123; csrf_token=xyz789; _ga=GA1.2.123456' \
-  -H 'referer: https://analytics.example.com/dashboard' \
+  -H 'cookie: session_id=abc123; csrf_token=xyz789' \
   -H 'user-agent: Mozilla/5.0 ...'
 ```
 
-### Step 3: Modify for Your Needs
-
-Common modifications to the copied command:
+### Step 3: Common Modifications
 
 ```bash
-# Save output to file
-curl '...' -o output.json
-
-# Pretty-print JSON response
-curl '...' -s | jq .
-
-# Follow redirects
-curl '...' -L
-
-# Change request method
-curl '...' -X POST -d '{"query": "new data"}'
-
-# Add pagination
-curl '...?page=1&per_page=100' -s | jq .
-curl '...?page=2&per_page=100' -s | jq .
-
-# Extract specific fields
-curl '...' -s | jq '.data[] | {name: .name, value: .value}'
-
-# Save with timestamp
-curl '...' -s -o "export-$(date +%Y%m%d-%H%M%S).json"
+curl '...' -o output.json                              # Save to file
+curl '...' -s | jq .                                   # Pretty-print JSON
+curl '...' -L                                          # Follow redirects
+curl '...' -X POST -d '{"query": "new data"}'          # Change method
+curl '...?page=1&per_page=100' -s | jq .               # Pagination
+curl '...' -s | jq '.data[] | {name, value}'           # Extract fields
+curl '...' -s -o "export-$(date +%Y%m%d-%H%M%S).json"  # Timestamped save
 ```
 
 ## Practical Examples
 
-### Extract Analytics Dashboard Data
+### Analytics Dashboard Data
 
 ```bash
-# 1. Navigate to analytics dashboard in browser
-# 2. Open DevTools Network tab
-# 3. Copy the API request that loads the chart/table data
-# 4. Paste and pipe through jq
-
 curl 'https://analytics.example.com/api/reports?range=30d' \
   -H 'cookie: session=...' \
   -s | jq '.rows[] | [.page, .views, .bounceRate] | @csv'
 ```
 
-### Scrape Admin Panel Listings
+### Paginated Admin Panel
 
 ```bash
-# Paginate through all results
 for page in $(seq 1 10); do
   curl "https://admin.example.com/api/users?page=$page&limit=100" \
     -H 'cookie: session=...' \
     -s | jq '.users[]' >> all-users.json
-  sleep 1  # Be respectful
+  sleep 1
 done
 ```
 
-### Download Private API Schema
+### Private API Schema
 
 ```bash
-# Many apps expose OpenAPI/Swagger docs behind auth
 curl 'https://app.example.com/api/docs/openapi.json' \
   -H 'cookie: session=...' \
   -s | jq . > api-schema.json
 ```
 
-### Extract Data from SPA (Single Page App)
+### SPA GraphQL Endpoint
 
 ```bash
-# SPAs often use XHR/fetch calls - look for these in Network tab
-# Filter by "Fetch/XHR" in DevTools to find the API calls
-# The actual data endpoints are often cleaner than scraping HTML
-
+# SPAs use XHR/fetch — filter by Fetch/XHR in DevTools to find API calls
 curl 'https://app.example.com/graphql' \
   -H 'content-type: application/json' \
   -H 'cookie: session=...' \
@@ -165,77 +108,38 @@ curl 'https://app.example.com/graphql' \
 
 ## Tips
 
-### Finding the Right Request
+**Finding the right request**: Filter by `Fetch/XHR` in DevTools Network tab. Click requests to check Response/Preview tabs for structured JSON data. Use the filter box to search by URL path.
 
-- **Filter by type**: In DevTools Network tab, filter by `Fetch/XHR` to see API calls (skip images, CSS, JS)
-- **Look for JSON responses**: Click requests and check the Response tab - API endpoints return structured data
-- **Check the Preview tab**: Chrome shows formatted JSON, making it easy to identify data-rich endpoints
-- **Search in Network tab**: Use the filter box to search by URL path or response content
+**Session lifetime**: Keep the browser tab open (sessions often auto-refresh). If you get 401/403, re-copy a fresh cURL command. Note which cookie names are session tokens for quick updates.
 
-### Extending Session Lifetime
+**Security**:
 
-- **Keep the browser tab open**: Some sessions refresh automatically while the tab is active
-- **Re-copy when expired**: If you get a 401/403, go back to the browser and copy a fresh cURL command
-- **Note the cookie names**: Identify which cookies are session tokens so you know what to update
+- Never commit copied cURL commands to git (they contain session tokens)
+- Tokens expire in minutes to hours — re-copy as needed
+- Add `sleep` between requests to avoid abuse detection
+- Strip `cookie`, `authorization`, `x-csrf-token` headers before sharing
+- Respect robots.txt even with valid auth
 
-### Security Considerations
-
-- **Never commit** copied cURL commands to git (they contain session tokens)
-- **Tokens expire**: Session cookies and Bearer tokens have limited lifetimes (minutes to hours)
-- **Rate limit yourself**: Add `sleep` between requests to avoid triggering abuse detection
-- **Respect robots.txt**: Even with valid auth, follow the site's scraping policies
-- **Strip sensitive headers** before sharing: Remove `cookie`, `authorization`, and `x-csrf-token` headers
-
-### Working with AI Assistants
-
-The curl-copy workflow pairs well with AI assistants:
-
-1. Copy the cURL command from DevTools
-2. Paste it to your AI assistant with instructions like:
-   - "Run this and extract all product names and prices"
-   - "Paginate through this API and compile the results"
-   - "Parse this response and create a CSV"
-3. The AI can execute the curl, parse the JSON, and transform the data
-
-**Privacy note**: The pasted cURL command contains your session cookies. Only share with trusted AI assistants running locally or with appropriate data handling policies.
+**With AI assistants**: Paste the cURL command with instructions like "run this and extract all product names" or "paginate and compile results as CSV". Note: the command contains your session cookies — only share with trusted assistants.
 
 ## Comparison with Other Auth Methods
 
-| Method | Setup Time | Session Duration | Automation | Best For |
-|--------|-----------|-----------------|------------|----------|
-| **Curl-Copy** | Seconds | Minutes-hours | Manual | One-off extractions |
+| Method | Setup | Duration | Automation | Best For |
+|--------|-------|----------|------------|----------|
+| **Curl-Copy** | Seconds | Min-hours | Manual | One-off extractions |
 | **Sweet Cookie** | Minutes | Browser session | Scriptable | Repeated local access |
-| **Playwright persistent** | Minutes | Configurable | Full | Automated workflows |
-| **Dev-browser** | Minutes | Persistent profile | Full | Interactive + automation |
+| **Playwright** | Minutes | Configurable | Full | Automated workflows |
+| **Dev-browser** | Minutes | Persistent | Full | Interactive + automation |
 | **API keys** | Varies | Long-lived | Full | Official API access |
 
 ## Troubleshooting
 
-### 401 Unauthorized / 403 Forbidden
-
-Session expired. Go back to the browser, reload the page, and copy a fresh cURL command.
-
-### CORS Errors
-
-Not applicable - curl bypasses CORS entirely (CORS is browser-only). If you see CORS-related headers in the response, they can be ignored.
-
-### Empty or HTML Response Instead of JSON
-
-The endpoint may require specific `Accept` headers. Add:
-
-```bash
-curl '...' -H 'accept: application/json'
-```
-
-Or the URL may be a page URL, not an API URL. Look for XHR/Fetch requests in DevTools instead.
-
-### SSL Certificate Errors
-
-For internal/dev servers with self-signed certs:
-
-```bash
-curl '...' -k  # Skip certificate verification (dev only)
-```
+| Problem | Solution |
+|---------|----------|
+| 401/403 | Session expired — reload page in browser, re-copy cURL command |
+| CORS errors | Not applicable — curl bypasses CORS (browser-only restriction) |
+| HTML instead of JSON | Add `-H 'accept: application/json'`, or find the XHR/Fetch request instead of the page URL |
+| SSL cert errors | Use `curl '...' -k` for dev servers with self-signed certs |
 
 ## Related Tools
 


### PR DESCRIPTION
## Summary

- Reduced `.agents/tools/browser/curl-copy.md` from 245 to 149 lines (39% reduction, well under the 200-line target)
- Merged redundant "When to Use" / "When NOT to Use" lists into the decision tree
- Compressed browser-specific table into inline note, consolidated code examples, converted troubleshooting to compact table
- All actionable guidance preserved: workflow steps, practical examples, tips, security considerations, comparison table, related tools

Closes #12130


---
[aidevops.sh](https://aidevops.sh) v3.5.87 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 3,933 tokens in 2m on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
* Streamlined curl-copy tool documentation with clearer and more concise DevTools workflow instructions
* Reorganized troubleshooting section into a consolidated reference table for faster problem-solving
* Renamed and simplified practical examples to improve clarity and user understanding
* Condensed tips and comparison information for quicker reference and navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->