### PR TITLE
GH#12140: tighten stagehand-python.md 159→136 lines

### DIFF
--- a/.agents/tools/browser/stagehand-python.md
+++ b/.agents/tools/browser/stagehand-python.md
@@ -27,6 +27,7 @@ tools:
 | API key vars | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY` |
 
 **Core primitives:**
+
 - `page.act("natural language action")` — click, fill, scroll
 - `page.extract("instruction", schema=PydanticModel)` — structured data
 - `page.observe()` — discover available actions
@@ -71,8 +72,6 @@ async def main():
 asyncio.run(main())
 ```
 
-## Core Primitives
-
 ### Act / Observe
 
 ```python
@@ -99,7 +98,7 @@ products = await page.extract("extract all product details", schema=List[Product
 ```python
 agent = stagehand.agent(
     provider="openai", model="computer-use-preview",
-    integrations=[], system_prompt="You are a helpful browser automation agent."
+    system_prompt="You are a helpful browser automation agent."
 )
 await agent.execute("complete the checkout process for 2 items")
 ```
@@ -127,15 +126,6 @@ BROWSERBASE_PROJECT_ID=your_browserbase_project_id_here
 ```bash
 bash .agents/scripts/setup-mcp-integrations.sh stagehand-python  # pass via integrations=[] in agent()
 ```
-
-## Use Cases
-
-| Domain | Examples |
-|--------|---------|
-| E-commerce | Price comparison, purchase workflows, inventory monitoring |
-| Data collection | Web scraping, competitive analysis, content aggregation |
-| Testing & QA | User journey testing, form validation, accessibility reporting |
-| Business automation | Lead generation, CRM data entry, report generation |
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Remove non-actionable "Use Cases" table (informational fluff — not actionable guidance for agents)
- Remove empty `integrations=[]` default from agent example (noise; MCP section covers this)
- Builds on prior commit (e8719eba0) that merged Act/Observe sections and compressed config block

Combined reduction: 159→136 lines (14.5% reduction). All code blocks, URLs, internal references, and task IDs preserved. Zero markdownlint violations.

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs/agent prompt only)
- No runtime verification needed per testing gate

Closes #12140

---
[aidevops.sh](https://aidevops.sh) v3.5.87 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 10,117 tokens in 6m on this.