### PR TITLE
simplification: tighten meta-ads-optimization-metrics.md from 232 to 202 lines

### DIFF
--- a/.agents/marketing-sales/meta-ads-optimization-metrics.md
+++ b/.agents/marketing-sales/meta-ads-optimization-metrics.md
@@ -67,7 +67,7 @@
 | **Bounce Rate** | Single page visits | <70% | <50% |
 | **Conversion Rate** | Conversions ÷ LPV | 5%+ | 15%+ |
 
-## Cost Metrics Deep Dive
+## Cost Metrics
 
 ### CPM Factors
 
@@ -81,21 +81,20 @@
 | Finance | $20-30 |
 | Gaming | $8-12 |
 
-### CPC & CPA Formulas
+### Cost Formulas
 
 ```
 CPC = Spend ÷ Clicks = CPM ÷ (CTR × 10)
 CPA = Spend ÷ Actions = CPC ÷ Conversion Rate
 ```
 
-**Lower CPC through:** higher CTR, lower CPM, better ad relevance.
-**Lower CPA through:** lower CPC, higher conversion rate, better landing page/offer.
+Lower CPC: higher CTR, lower CPM, better ad relevance. Lower CPA: lower CPC, higher conversion rate, better landing page/offer.
 
 ## Quality Metrics
 
 ### Ad Relevance Diagnostics
 
-Meta rates ads on three dimensions — **Quality Ranking**, **Engagement Rate Ranking**, **Conversion Rate Ranking** — each compared to competitors:
+Meta rates ads on **Quality Ranking**, **Engagement Rate Ranking**, **Conversion Rate Ranking** (each vs competitors):
 
 | Ranking | Meaning |
 |---------|---------|
@@ -117,18 +116,16 @@ Frequency = Impressions ÷ Reach
 | Retargeting | 4.0+ | 6.0+ |
 | Brand Awareness | 3.0+ | 5.0+ |
 
-**High frequency signs:** CTR declining, CPA increasing, negative feedback increasing, same audience seeing ad repeatedly.
-
 ## Conversion & Revenue Metrics
 
-### Conversion Rate
+### Conversion Rate by Industry
 
 ```
 CVR = Conversions ÷ Landing Page Views × 100
 ```
 
-| Industry | Good CVR | Great CVR |
-|----------|----------|-----------|
+| Industry | Good | Great |
+|----------|------|-------|
 | E-commerce | 2-4% | 5%+ |
 | Lead Gen | 10-15% | 20%+ |
 | SaaS Trial | 5-10% | 15%+ |
@@ -141,15 +138,13 @@ Breakeven ROAS = 1 ÷ Profit Margin   (e.g. 30% margin → 3.33x)
 Breakeven CPA  = AOV × Gross Margin % (e.g. $80 AOV × 60% → $48)
 ```
 
-**Example:** $1,000 spend, $4,000 revenue → ROAS 4x (400%).
-
 ### MER (Marketing Efficiency Ratio)
 
 ```
 MER = Total Revenue ÷ Total Marketing Spend
 ```
 
-Advantages over ROAS: accounts for all channels, reduces attribution arguments, provides business-level view.
+Broader than ROAS: accounts for all channels, reduces attribution arguments.
 
 ### Contribution Margin
 
@@ -173,51 +168,26 @@ Use for budget allocation, channel comparison, and true ROI reporting.
 
 | Metric | Formula | Purpose |
 |--------|---------|---------|
-| Click to LPV Ratio | Landing Page Views ÷ Link Clicks × 100 | Identify page load issues |
-| Hook Rate | 3-Second Video Views ÷ Impressions × 100 | Measure hook effectiveness |
-| Hold Rate | ThruPlays ÷ 3-Second Video Views × 100 | Measure content engagement |
 | Cost Per LPV | Amount Spent ÷ Landing Page Views | Landing page cost efficiency |
-
-### In Spreadsheet
-
-| Metric | Formula | Purpose |
-|--------|---------|---------|
 | True CPA | Ad Spend ÷ Qualified Conversions | Real cost of quality conversions |
 | Blended ROAS | Total Revenue ÷ Total Ad Spend (all platforms) | True return across channels |
 
-## Diagnostic Combos
+## Diagnostic Patterns
 
-| High | Low | Likely Issue |
-|------|-----|--------------|
-| CPM | CTR | Creative not compelling |
-| CTR | CVR | Landing page problem |
-| CPM | — | Competition or quality |
-| Frequency | CTR | Ad fatigue |
-| LPV Gap | — | Page load issues |
-
-### Performance Patterns
-
-| Pattern | CPM | CTR | Frequency | CPA | Action |
-|---------|-----|-----|-----------|-----|--------|
-| **Healthy** | Stable | 1%+ | <3 | At/below target | Maintain |
-| **Fatiguing** | Rising/stable | Declining | Rising (>3) | Rising | Refresh creative |
-| **Quality issue** | High/rising | Low | — | — | Improve creative/targeting |
+| Pattern | Signals | Action |
+|---------|---------|--------|
+| **Creative not compelling** | High CPM, low CTR | Improve creative |
+| **Landing page problem** | High CTR, low CVR | Fix landing page |
+| **Ad fatigue** | High frequency (>3), declining CTR, rising CPA | Refresh creative |
+| **Quality issue** | High/rising CPM, low CTR | Improve creative/targeting |
+| **Page load issues** | Large LPV vs Clicks gap | Fix page speed |
+| **Healthy** | Stable CPM, CTR 1%+, frequency <3, CPA at target | Maintain |
 
 ## Metric Review Cadence
 
 - **Daily:** Spend (on budget?), CPA/ROAS (meeting targets?), delivery issues
 - **Weekly:** CTR trend, frequency, creative performance, audience performance
 - **Monthly:** Overall ROAS/CPA vs target, attribution review, creative refresh needs, budget allocation
-
-## Cohort Analysis
-
-Track acquisition cohort performance over time:
-
-| Cohort | Month 1 Revenue | Month 3 Revenue | LTV at 6 Months |
-|--------|-----------------|-----------------|-----------------|
-| Jan Acquired | $100 | $180 | $320 |
-| Feb Acquired | $95 | $165 | $290 |
-| Mar Acquired | $110 | $195 | $350 |
 
 ## Recommended Custom Columns
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing-sales/meta-ads-optimization-metrics.md` from 232 to 202 lines (13% reduction)
- Removed duplicate metric definitions (Hook Rate, Hold Rate, Click-to-LPV Ratio already defined in engagement tables)
- Merged overlapping "Diagnostic Combos" + "Performance Patterns" into single "Diagnostic Patterns" table
- Removed template-only Cohort Analysis section (example data with no actionable guidance)
- Tightened verbose prose (MER explanation, ad relevance intro, frequency signs, ROAS example)
- Consolidated "In Spreadsheet" custom metrics into single table

All formulas, benchmarks, industry data, custom column recommendations, review cadence, and the scaling.md link preserved.

Closes #12155

---
[aidevops.sh](https://aidevops.sh) v3.5.100 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 5,540 tokens in 2m on this.