### PR TITLE
chore: increase FOSS daily token budget default from 50k to 200k

### DIFF
--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -137,7 +137,7 @@
     // Daily token ceiling across all FOSS repos combined.
     // Contributions are refused once this limit is reached for the day.
     // Counter resets at UTC midnight. Env override: AIDEVOPS_FOSS_MAX_DAILY_TOKENS
-    "max_daily_tokens": 50000,
+    "max_daily_tokens": 200000,
 
     // Maximum number of simultaneous FOSS contribution workers.
     // Prevents runaway parallel contributions to multiple repos at once.

--- a/.agents/reference/foss-contributions.md
+++ b/.agents/reference/foss-contributions.md
@@ -15,7 +15,7 @@ AI DevOps can contribute to FOSS projects on your behalf, subject to per-repo et
 {
   "foss": {
     "enabled": true,
-    "max_daily_tokens": 50000,
+    "max_daily_tokens": 200000,
     "max_concurrent_contributions": 2
   }
 }
@@ -86,7 +86,7 @@ foss-contribution-helper.sh check owner/some-oss-project
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `foss.enabled` | bool | `false` | Master switch. All contributions refused when `false`. |
-| `foss.max_daily_tokens` | int | `50000` | Daily token ceiling across all repos. Resets at UTC midnight. |
+| `foss.max_daily_tokens` | int | `200000` | Daily token ceiling across all repos. Resets at UTC midnight. |
 | `foss.max_concurrent_contributions` | int | `2` | Max simultaneous contribution workers. |
 
 **Env overrides**: `AIDEVOPS_FOSS_ENABLED`, `AIDEVOPS_FOSS_MAX_DAILY_TOKENS`, `AIDEVOPS_FOSS_MAX_CONCURRENT`
@@ -138,9 +138,9 @@ foss-contribution-helper.sh record owner/repo 7500
 foss-contribution-helper.sh budget
 # FOSS Contribution Budget
 #   Enabled:              true
-#   Max daily tokens:     50000
-#   Used today:           12500 (25%)
-#   Remaining:            37500
+#   Max daily tokens:     200000
+#   Used today:           12500 (6%)
+#   Remaining:            187500
 #   Max concurrent:       2
 ```
 

--- a/.agents/scripts/foss-contribution-helper.sh
+++ b/.agents/scripts/foss-contribution-helper.sh
@@ -52,7 +52,7 @@ LOGFILE="${HOME}/.aidevops/logs/foss-contribution.log"
 
 # Global defaults (overridden by config.jsonc foss section)
 DEFAULT_FOSS_ENABLED="true"
-DEFAULT_MAX_DAILY_TOKENS=50000
+DEFAULT_MAX_DAILY_TOKENS=200000
 DEFAULT_MAX_CONCURRENT=2
 
 # Per-repo defaults (overridden by repos.json foss_config)
@@ -620,7 +620,7 @@ Valid app_type values:
 
 Global config (config.jsonc foss section):
   foss.enabled: true                    Enable/disable all FOSS contributions
-  foss.max_daily_tokens: 50000          Daily token ceiling across all repos
+  foss.max_daily_tokens: 200000         Daily token ceiling across all repos
   foss.max_concurrent_contributions: 2  Max simultaneous contribution workers
 
 Examples:


### PR DESCRIPTION
## Summary

- Increase default `foss.max_daily_tokens` from 50,000 to 200,000
- 50k was too conservative for meaningful FOSS contributions
- 200k allows 2-3 contribution attempts per day with headroom for maintainer feedback response cycles

## Files Changed

- `.agents/scripts/foss-contribution-helper.sh` — runtime default + help text
- `.agents/configs/aidevops.defaults.jsonc` — config default
- `.agents/reference/foss-contributions.md` — docs, examples, table


---
[aidevops.sh](https://aidevops.sh) v3.5.100 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 7,731 tokens in 3h 38m on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased default daily FOSS token limit from 50,000 to 200,000 tokens
  * Updated configuration defaults and reference documentation to reflect the new ceiling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->