### PR TITLE
refactor: Signature 'spent 4m and 11,432 tokens on this.' + pulse gets full CLI

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -188,7 +188,7 @@ Git is the audit trail. Chain: TODO → issue → worktree → PR → merge. Gap
 **GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM] [--solved]` to generate it. Example output:
 ```
 ---
-[aidevops.sh](https://aidevops.sh) v3.5.67 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 has used 118,502 tokens for 42m. Solved in 3d 4h.
+[aidevops.sh](https://aidevops.sh) v3.5.100 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 42m and 118,502 tokens on this. Solved in 3d 4h.
 ```
 The helper auto-detects CLI, version, tokens (input+output, excluding cache), and session time from the runtime DB. Pass `--issue` on comments to existing issues for "Overall, Xm since this issue was created." phrasing. Pass `--solved` on closing comments for "Solved in Xm." phrasing. Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -618,28 +618,30 @@ _build_signature() {
 		sig="${sig} with ${display_model}"
 	fi
 
-	# "used N tokens"
-	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then
-		local formatted
-		formatted=$(_format_number "$tokens")
-		sig="${sig} spent ${formatted} tokens"
+	# "spent Xm and N tokens on this." — time first, tokens second
+	local has_time="" has_tokens=""
+	if [[ -n "$session_time_str" ]]; then has_time="true"; fi
+	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then has_tokens="true"; fi
+
+	if [[ -n "$has_time" ]] || [[ -n "$has_tokens" ]]; then
+		sig="${sig} spent"
+		if [[ -n "$has_time" ]]; then
+			sig="${sig} ${session_time_str}"
+		fi
+		if [[ -n "$has_time" ]] && [[ -n "$has_tokens" ]]; then
+			sig="${sig} and"
+		fi
+		if [[ -n "$has_tokens" ]]; then
+			local formatted
+			formatted=$(_format_number "$tokens")
+			sig="${sig} ${formatted} tokens"
+		fi
+		sig="${sig} on this."
 	fi
 
-	# "in Xm on this." (session time)
-	if [[ -n "$session_time_str" ]]; then
-		sig="${sig} in ${session_time_str} on this."
-	fi
-
-	# Total time or trailing period (only if no session time already added period)
 	local has_stats=""
-	if { [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; } ||
-		[[ -n "$session_time_str" ]] || [[ -n "$total_time_str" ]]; then
+	if [[ -n "$has_time" ]] || [[ -n "$has_tokens" ]] || [[ -n "$total_time_str" ]]; then
 		has_stats="true"
-	fi
-
-	# Trailing period if we had stats but no session time (which already ends with period)
-	if [[ -n "$has_stats" ]] && [[ -z "$session_time_str" ]]; then
-		sig="${sig}."
 	fi
 
 	# Total time as a separate sentence

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3606,9 +3606,9 @@ _complexity_scan_process_single_md_file() {
 This file was previously simplified (PR #${prev_pr}) but has since been modified. The content hash no longer matches the post-simplification state. Please re-evaluate."
 	fi
 
-	# Append signature footer
+	# Append signature footer (pass --cli since pulse runs inside OpenCode headless)
 	local sig_footer=""
-	sig_footer=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$issue_body" 2>/dev/null || true)
+	sig_footer=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$issue_body" --cli "OpenCode" 2>/dev/null || true)
 	issue_body="${issue_body}${sig_footer}"
 
 	local create_ok=false
@@ -3770,7 +3770,7 @@ This is an automated scan. The function lengths are factual, but the best decomp
 - \`declined: <reason>\` — closes this issue (include your reason after the colon)"
 		# Append signature footer
 		local sig_footer2=""
-		sig_footer2=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$issue_body" 2>/dev/null || true)
+		sig_footer2=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$issue_body" --cli "OpenCode" 2>/dev/null || true)
 		issue_body="${issue_body}${sig_footer2}"
 
 		local issue_key="$file_path"

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -71,7 +71,7 @@ assert_contains "starts with aidevops" "[aidevops.sh](https://aidevops.sh)" "$re
 assert_contains "contains CLI with plugin for" "plugin for [OpenCode](https://opencode.ai) v1.3.3" "$result"
 assert_contains "model strips provider prefix" "with claude-opus-4-6" "$result"
 assert_not_contains "no provider prefix" "anthropic/" "$result"
-assert_contains "contains formatted tokens" "spent 1,234 tokens" "$result"
+assert_contains "contains formatted tokens" "1,234 tokens on this." "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 2: generate with explicit --tokens 0 (should omit tokens)
@@ -108,7 +108,7 @@ echo "Test 5: footer includes --- separator"
 result=$("$HELPER" footer --cli "OpenCode" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
 assert_contains "contains ---" "---" "$result"
 assert_contains "contains signature" "plugin for [OpenCode](https://opencode.ai) v1.0.0" "$result"
-assert_contains "contains tokens" "spent 5,000 tokens" "$result"
+assert_contains "contains tokens" "5,000 tokens on this." "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 6: comma formatting for various numbers
@@ -180,7 +180,7 @@ result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG
 assert_contains "env CLI name" "plugin for EnvCLI" "$result"
 assert_contains "env CLI version" "v9.9.9" "$result"
 assert_contains "env model strips prefix" "with model" "$result"
-assert_contains "env tokens" "spent 42,000 tokens" "$result"
+assert_contains "env tokens" "42,000 tokens on this." "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 10: auto-detect tokens from OpenCode session DB (if running in OpenCode)
@@ -201,7 +201,7 @@ echo ""
 echo "Test 11: session time auto-detection (no response time)"
 if [[ "${OPENCODE:-}" == "1" ]] && [[ -r "${HOME}/.local/share/opencode/opencode.db" ]]; then
 	result=$("$HELPER" generate --cli "OpenCode" --model "m" --tokens 1)
-	assert_contains "session time present" " in " "$result"
+	assert_contains "session time present" "spent " "$result"
 	assert_not_contains "no response time" "to respond" "$result"
 else
 	echo "  SKIP: not running in OpenCode"


### PR DESCRIPTION
Two changes:

1. **Phrasing**: time before tokens, joined with "and"
   - Before: `spent 11,432 tokens in 4m on this.`
   - After: `spent 4m and 11,432 tokens on this.`

2. **Pulse scans**: pass `--cli "OpenCode"` so automated scan issues get the full signature instead of bare `automated scan.`

43/43 tests pass.

---
[aidevops.sh](https://aidevops.sh) v3.5.100 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 10,429 tokens in 6h 44m on this.