### PR TITLE
GH#12155: Tighten meta-ads-optimization-metrics.md 232→203 lines

### DIFF
--- a/.agents/marketing-sales/meta-ads-optimization-metrics.md
+++ b/.agents/marketing-sales/meta-ads-optimization-metrics.md
@@ -53,7 +53,7 @@
 | Metric | Definition | Good | Great |
 |--------|------------|------|-------|
 | **Hook Rate** | 3s Views ÷ Impressions | 30%+ | 45%+ |
-| **Hold Rate** | 15s Views ÷ 3s Views | 30%+ | 50%+ |
+| **Hold Rate** | ThruPlays ÷ 3s Views | 30%+ | 50%+ |
 | **ThruPlay Rate** | ThruPlays ÷ Impressions | 10%+ | 20%+ |
 | **Avg Watch Time** | Total Watch Time ÷ Views | 5s+ | 10s+ |
 | **CPV (ThruPlay)** | Spend ÷ ThruPlays | <$0.05 | <$0.02 |
@@ -117,7 +117,7 @@ Frequency = Impressions ÷ Reach
 | Retargeting | 4.0+ | 6.0+ |
 | Brand Awareness | 3.0+ | 5.0+ |
 
-**High frequency signs:** CTR declining, CPA increasing, negative feedback increasing, same audience seeing ad repeatedly.
+**High frequency signs:** CTR declining, CPA increasing, negative feedback increasing.
 
 ## Conversion & Revenue Metrics
 
@@ -140,8 +140,6 @@ ROAS = Revenue ÷ Ad Spend
 Breakeven ROAS = 1 ÷ Profit Margin   (e.g. 30% margin → 3.33x)
 Breakeven CPA  = AOV × Gross Margin % (e.g. $80 AOV × 60% → $48)
 ```
-
-**Example:** $1,000 spend, $4,000 revenue → ROAS 4x (400%).
 
 ### MER (Marketing Efficiency Ratio)
 
@@ -167,57 +165,30 @@ Example: 3.0x × 60% lift = 1.8x true value
 
 Use for budget allocation, channel comparison, and true ROI reporting.
 
-## Custom Metrics to Create
-
-### In Ads Manager
+## Custom Metrics to Create in Ads Manager
 
 | Metric | Formula | Purpose |
 |--------|---------|---------|
 | Click to LPV Ratio | Landing Page Views ÷ Link Clicks × 100 | Identify page load issues |
-| Hook Rate | 3-Second Video Views ÷ Impressions × 100 | Measure hook effectiveness |
-| Hold Rate | ThruPlays ÷ 3-Second Video Views × 100 | Measure content engagement |
 | Cost Per LPV | Amount Spent ÷ Landing Page Views | Landing page cost efficiency |
-
-### In Spreadsheet
-
-| Metric | Formula | Purpose |
-|--------|---------|---------|
 | True CPA | Ad Spend ÷ Qualified Conversions | Real cost of quality conversions |
 | Blended ROAS | Total Revenue ÷ Total Ad Spend (all platforms) | True return across channels |
 
-## Diagnostic Combos
-
-| High | Low | Likely Issue |
-|------|-----|--------------|
-| CPM | CTR | Creative not compelling |
-| CTR | CVR | Landing page problem |
-| CPM | — | Competition or quality |
-| Frequency | CTR | Ad fatigue |
-| LPV Gap | — | Page load issues |
-
-### Performance Patterns
+## Diagnostic Patterns
 
 | Pattern | CPM | CTR | Frequency | CPA | Action |
 |---------|-----|-----|-----------|-----|--------|
 | **Healthy** | Stable | 1%+ | <3 | At/below target | Maintain |
 | **Fatiguing** | Rising/stable | Declining | Rising (>3) | Rising | Refresh creative |
 | **Quality issue** | High/rising | Low | — | — | Improve creative/targeting |
+| **LP problem** | Normal | Normal | Normal | High | Fix landing page |
+| **Audience exhausted** | Rising | Declining | High | Rising | Expand audience |
 
 ## Metric Review Cadence
 
 - **Daily:** Spend (on budget?), CPA/ROAS (meeting targets?), delivery issues
 - **Weekly:** CTR trend, frequency, creative performance, audience performance
 - **Monthly:** Overall ROAS/CPA vs target, attribution review, creative refresh needs, budget allocation
-
-## Cohort Analysis
-
-Track acquisition cohort performance over time:
-
-| Cohort | Month 1 Revenue | Month 3 Revenue | LTV at 6 Months |
-|--------|-----------------|-----------------|-----------------|
-| Jan Acquired | $100 | $180 | $320 |
-| Feb Acquired | $95 | $165 | $290 |
-| Mar Acquired | $110 | $195 | $350 |
 
 ## Recommended Custom Columns
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing-sales/meta-ads-optimization-metrics.md` from 232 to 203 lines (13% reduction, 29 lines removed)
- Removed duplicate Hook Rate/Hold Rate definitions from custom metrics (already defined in Video engagement table)
- Merged "Diagnostic Combos" + "Performance Patterns" into single "Diagnostic Patterns" table; added 2 missing patterns (LP problem, Audience exhausted)
- Removed Cohort Analysis section (example data with no actionable guidance)
- Merged "In Ads Manager" + "In Spreadsheet" custom metrics into single table
- Corrected Hold Rate formula inconsistency (15s Views → ThruPlays, consistent with custom metrics section)
- Removed redundant ROAS example and tightened frequency signs prose

## Verification

- All formulas, benchmarks, industry data, custom column recommendations, and review cadence preserved
- All code blocks intact
- No broken internal links
- `scaling.md` link preserved
- Risk: `self-assessed` (docs-only, low risk)

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs-only change, agent prompt file)
- Dev environment: N/A

actionable_findings_total=0
fixed_in_pr=0
deferred_tasks_created=0
coverage=100%

Closes #12155

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 4,621 tokens in 2m on this.