### PR TITLE
GH#12437: tighten tailscale.md — remove redundancy, consolidate sections

### DIFF
--- a/.agents/services/networking/tailscale.md
+++ b/.agents/services/networking/tailscale.md
@@ -22,7 +22,7 @@ tools:
 - **Install**: `brew install tailscale` (macOS) | `curl -fsSL https://tailscale.com/install.sh | sh` (Linux)
 - **CLI**: `tailscale` (control) + `tailscaled` (daemon)
 - **Admin**: https://login.tailscale.com/admin
-- **Docs**: https://tailscale.com/kb
+- **Docs**: [KB](https://tailscale.com/kb) · [Serve](https://tailscale.com/kb/1312/serve) · [Funnel](https://tailscale.com/kb/1223/tailscale-funnel) · [ACLs](https://tailscale.com/kb/1018/acls) · [Pricing](https://tailscale.com/pricing)
 - **Free tier**: 100 devices, 3 users
 
 **Key Concepts**: **Tailnet** = your private mesh network. **MagicDNS** = auto DNS (e.g., `my-vps.tail1234.ts.net`). **Serve** = expose local port to tailnet via HTTPS. **Funnel** = expose to public internet via HTTPS. **ACLs** = access control lists.
@@ -39,7 +39,7 @@ sudo tailscaled &               # Start daemon
 tailscale up                    # Authenticate
 ```
 
-App Store version available (GUI only, no Funnel support).
+App Store version: GUI only, no Funnel support.
 
 ### Linux
 
@@ -47,20 +47,9 @@ App Store version available (GUI only, no Funnel support).
 curl -fsSL https://tailscale.com/install.sh | sh
 sudo systemctl enable --now tailscaled
 sudo tailscale up
-tailscale status                # Verify
 ```
 
-### Status Commands
-
-```bash
-tailscale status                # All devices on tailnet
-tailscale ip -4                 # Your Tailscale IP
-tailscale ping <device-name>    # Ping another device
-```
-
-## Tailscale Serve
-
-Expose a local service to your tailnet with automatic HTTPS:
+## Serve (Tailnet-Only HTTPS)
 
 ```bash
 tailscale serve https / http://127.0.0.1:18789
@@ -70,9 +59,7 @@ tailscale serve reset           # Remove
 
 HTTPS must be enabled for your tailnet. Serve injects `tailscale-user-login` headers for user identification without separate auth.
 
-## Tailscale Funnel
-
-Expose a local service to the **public internet**:
+## Funnel (Public Internet HTTPS)
 
 ```bash
 tailscale funnel https / http://127.0.0.1:18789
@@ -98,13 +85,13 @@ Configure at https://login.tailscale.com/admin/acls:
 }
 ```
 
-Restrict to specific ports by replacing `"dst": ["*:*"]` with e.g. `["tag:server:18789"]` (OpenClaw gateway only).
+Restrict to specific ports: replace `"dst": ["*:*"]` with e.g. `["tag:server:18789"]`.
 
 ## Common Use Cases
 
 ### Secure OpenClaw Gateway
 
-Run OpenClaw on a VPS, access via tailnet. In `~/.openclaw/openclaw.json`:
+In `~/.openclaw/openclaw.json`:
 
 ```json5
 {
@@ -130,29 +117,18 @@ Access Coolify, Cloudron, etc. without public exposure: `https://<vps-magicdns>:
 
 ## Integration with aidevops
 
-### VPS Provisioning
-
-1. Provision server via `@hetzner` or `@hostinger`
-2. Install Tailscale, tag node (`tag:server`)
-3. Install services, configure Tailscale Serve for HTTPS
-
-### Tailscale + Cloudflare (Custom Domains)
-
-1. Set up Funnel on target machine
-2. CNAME in Cloudflare → Funnel hostname
-3. Disable Cloudflare proxy (grey cloud) — Tailscale handles TLS
+1. **VPS provisioning**: Provision via `@hetzner`/`@hostinger` → install Tailscale → tag node (`tag:server`) → configure Serve for HTTPS
+2. **Custom domains (Cloudflare)**: Set up Funnel → CNAME in Cloudflare → Funnel hostname. Disable Cloudflare proxy (grey cloud) — Tailscale handles TLS.
 
 ## Troubleshooting
 
 ```bash
-tailscale status                # Connection status
+tailscale status                # Connection status + all devices
+tailscale ip -4                 # Your Tailscale IP
+tailscale ping <device-name>    # Ping another device
 tailscale debug daemon-status   # Daemon health
 tailscale netcheck              # Network connectivity
 tailscale up --reset            # Re-authenticate
 ```
 
 **Logs**: macOS: `log show --predicate 'process == "tailscaled"' --last 5m` | Linux: `journalctl -u tailscaled -f`
-
-## Resources
-
-- [Docs](https://tailscale.com/kb) · [Serve](https://tailscale.com/kb/1312/serve) · [Funnel](https://tailscale.com/kb/1223/tailscale-funnel) · [ACLs](https://tailscale.com/kb/1018/acls) · [Pricing](https://tailscale.com/pricing)


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/networking/tailscale.md` from 158 → 134 lines (15% reduction) while preserving all actionable guidance
- Merged duplicate content: Resources URLs → Quick Reference, Status Commands → Troubleshooting, Integration subsections → compact list
- Removed verbose lead-in sentences; made section headers self-descriptive (e.g., "Serve (Tailnet-Only HTTPS)")
- Fixed inaccurate "(OpenClaw gateway only)" qualifier on ACL port restriction note

## Verification

- All code blocks, URLs, CLI commands, key concepts, and security warnings preserved
- Zero markdownlint violations
- Self-assessed (docs-only, low risk)

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (docs/agent prompt only)
- **Rationale**: No code, no runtime behaviour change

Closes #12437

---
[aidevops.sh](https://aidevops.sh) v3.5.104 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 1m and 4,344 tokens on this.