### PR TITLE
t1702: feat: integrate FOSS contribution scanning into pulse cycle

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1102,9 +1102,9 @@
       "pr": 11908
     },
     ".agents/marketing-sales/ad-creative.md": {
-      "hash": "ade2327052c36bd3ece5c67577aad6f3f9bbd37a",
-      "at": "2026-03-28T15:30:28Z",
-      "pr": 11938
+      "hash": "5f15bf5c531e8ca2d4c6cde4ce7595f07fddfa65",
+      "at": "2026-03-29T01:52:03Z",
+      "pr": 12451
     },
     ".agents/tools/mcp-toolkit/mcporter.md": {
       "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
@@ -1447,9 +1447,9 @@
       "pr": 12171
     },
     ".agents/tools/mobile/app-dev-swift.md": {
-      "hash": "6e91c84b3a04746c00e777f19d2aaadce0ffd3e5",
-      "at": "2026-03-28T20:55:52Z",
-      "pr": 12197
+      "hash": "d27215290fea61b4f036405bedc16867db3935bc",
+      "at": "2026-03-29T01:52:34Z",
+      "pr": 12450
     },
     ".agents/tools/context/context7.md": {
       "hash": "1d98876794a7dc00b2cd2126492a54302f051af8",
@@ -1537,9 +1537,9 @@
       "pr": 12240
     },
     ".agents/tools/browser/browser-profiles.md": {
-      "hash": "a1117a7773814bfc1344b03dbcf154081a47a061",
-      "at": "2026-03-28T21:59:14Z",
-      "pr": 12237
+      "hash": "d719a6a108c1d6f84089ca53d09bc82579c5aa85",
+      "at": "2026-03-29T01:52:18Z",
+      "pr": 12449
     },
     ".agents/services/networking/netbird.md": {
       "hash": "824fc7ee7cdc7e08351310bdb9f99dcf91a3848e",
@@ -1625,6 +1625,11 @@
       "hash": "c79c8baa955bb48f1ce2ded8036ded7940948031",
       "at": "2026-03-29T01:33:56Z",
       "pr": 12442
+    },
+    ".agents/tools/browser/playwriter.md": {
+      "hash": "d299ead621010f02fdad0bcfb17ae1a82b312151",
+      "at": "2026-03-29T01:52:53Z",
+      "pr": 12434
     }
   }
 }

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -150,6 +150,71 @@ This is a lightweight label transition — no worker dispatch, no slots consumed
 - The contributor has not commented since the label was applied (pre-fetched status shows **waiting**)
 - The only new comments are from bots or the maintainer (not the original issue author)
 
+### 4.7. Dispatch FOSS contribution workers when idle capacity exists (t1702)
+
+After filling all managed-repo worker slots (implementation, triage reviews, needs-info relabeling), check the pre-fetched "FOSS Contribution Scan" section. If eligible FOSS repos exist and worker slots remain, dispatch contribution workers.
+
+**When to dispatch FOSS contributions:**
+
+- All managed-repo issues have been dispatched or are at capacity
+- Worker slots are still available (`AVAILABLE > 0`)
+- The pre-fetched FOSS scan shows eligible repos (`eligible_count > 0`)
+- Daily token budget has headroom (check the budget line in the scan section)
+
+**FOSS contributions are the lowest priority work** — below merges, CI fixes, implementation dispatches, triage reviews, quality-debt, and simplification-debt. Only dispatch when genuinely idle.
+
+**Dispatch flow:**
+
+```bash
+# Max FOSS dispatches per cycle (from pre-fetched state)
+FOSS_DISPATCH_COUNT=0
+FOSS_DISPATCH_MAX=2  # Read from pre-fetched "Max FOSS dispatches per cycle" line
+
+# For each eligible FOSS repo from the pre-fetched scan:
+if [[ "$AVAILABLE" -gt 0 && "$FOSS_DISPATCH_COUNT" -lt "$FOSS_DISPATCH_MAX" ]]; then
+  # Pre-dispatch eligibility check (budget + rate limit may have changed)
+  if ~/.aidevops/agents/scripts/foss-contribution-helper.sh check <slug> >/dev/null 2>&1; then
+    # Scan for a suitable issue in the FOSS repo
+    LABELS_FILTER=$(jq -r --arg slug "<slug>" \
+      '.initialized_repos[] | select(.slug == $slug) | .foss_config.labels_filter // ["help wanted", "good first issue", "bug"] | join(",")' \
+      ~/.config/aidevops/repos.json)
+    FOSS_ISSUE=$(gh issue list --repo <slug> --state open \
+      --label "${LABELS_FILTER%%,*}" --limit 1 \
+      --json number,title --jq '.[0] | "\(.number)|\(.title)"' 2>/dev/null) || FOSS_ISSUE=""
+
+    if [[ -n "$FOSS_ISSUE" ]]; then
+      FOSS_ISSUE_NUM="${FOSS_ISSUE%%|*}"
+      FOSS_ISSUE_TITLE="${FOSS_ISSUE#*|}"
+      FOSS_REPO_PATH=$(jq -r --arg slug "<slug>" \
+        '.initialized_repos[] | select(.slug == $slug) | .path' \
+        ~/.config/aidevops/repos.json)
+
+      ~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+        --role worker \
+        --session-key "foss-<slug>-${FOSS_ISSUE_NUM}" \
+        --dir "$FOSS_REPO_PATH" \
+        --title "FOSS: <slug> #${FOSS_ISSUE_NUM}: ${FOSS_ISSUE_TITLE}" \
+        --prompt "/full-loop Implement issue #${FOSS_ISSUE_NUM} (https://github.com/<slug>/issues/${FOSS_ISSUE_NUM}) -- ${FOSS_ISSUE_TITLE}. This is a FOSS contribution. Include AI disclosure note in the PR if disclosure:true in repos.json foss_config. After completion, run: foss-contribution-helper.sh record <slug> <tokens_used>" &
+      sleep 2
+
+      FOSS_DISPATCH_COUNT=$((FOSS_DISPATCH_COUNT + 1))
+      AVAILABLE=$((AVAILABLE - 1))
+    fi
+  fi
+fi
+```
+
+**Concurrency cap:** Max `FOSS_MAX_DISPATCH_PER_CYCLE` (default 2) FOSS workers per pulse cycle. FOSS repos are external — keep the footprint small and respectful.
+
+**Skip FOSS dispatch when:**
+
+- All worker slots are occupied with managed-repo work (FOSS never preempts)
+- Daily token budget is exhausted (the pre-fetched scan shows 0 remaining)
+- No eligible FOSS repos in the scan (all blocklisted, rate-limited, or budget-exceeded)
+- The FOSS repo has no open issues matching the configured `labels_filter`
+
+**FOSS response dispatch:** When the pre-fetched "External Contributions" section shows items needing reply on `foss: true` repos, prioritize responding to maintainer feedback on our existing PRs before opening new contributions. Use `contribution-watch-helper.sh status` to identify which repos need attention.
+
 ### 5. Record initial dispatch success
 
 ```bash
@@ -193,7 +258,8 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
 4. **If slots are open**: check for mergeable PRs (free), then dispatch workers for the
    highest-priority open issues, then dispatch triage reviews for unreviewed
    `needs-maintainer-review` issues (same rules as Step 4.5), then scan `status:needs-info`
-   issues for contributor replies (same rules as Step 4.6). Use the same dedup guards
+   issues for contributor replies (same rules as Step 4.6), then dispatch FOSS contribution
+   workers if idle capacity remains (same rules as Step 4.7). Use the same dedup guards
    and dispatch commands as the initial dispatch. Re-fetch issue state with targeted `gh`
    calls only for repos where you need to dispatch (not a full re-fetch of all repos).
 
@@ -244,6 +310,7 @@ Read adaptive queue mode from pre-fetched state (PULSE_QUEUE_MODE). In `pr-heavy
 7. `quality-debt` issues (unactioned review feedback from merged PRs)
 8. `simplification-debt` issues (approved simplification opportunities)
 9. Oldest issues
+10. FOSS contributions (t1702) — only when all managed-repo work is dispatched and idle capacity exists
 
 ## PRs — Merge, Fix, or Flag
 
@@ -1157,6 +1224,7 @@ batch-strategy-helper.sh validate --tasks "$TASKS_JSON"
 7. `quality-debt` issues (unactioned review feedback from merged PRs) — **use worktree dispatch** (see "Quality-debt worktree dispatch" below)
 8. `simplification-debt` issues (human-approved simplification opportunities)
 9. Oldest issues
+10. FOSS contributions (t1702) — only when all managed-repo work is dispatched and idle capacity exists. See Step 4.7.
 
 ### Quality-debt concurrency cap (configurable, default 30%)
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -153,6 +153,8 @@ GH_FAILURE_PREFETCH_HOURS="${GH_FAILURE_PREFETCH_HOURS:-24}"                    
 GH_FAILURE_PREFETCH_LIMIT="${GH_FAILURE_PREFETCH_LIMIT:-100}"                                           # Notification page size for failed-notification mining
 GH_FAILURE_SYSTEMIC_THRESHOLD="${GH_FAILURE_SYSTEMIC_THRESHOLD:-3}"                                     # Cluster threshold for systemic-failure flag
 GH_FAILURE_MAX_RUN_LOGS="${GH_FAILURE_MAX_RUN_LOGS:-6}"                                                 # Max failed workflow runs to sample for signatures per pulse
+FOSS_SCAN_TIMEOUT="${FOSS_SCAN_TIMEOUT:-30}"                                                            # Timeout for FOSS contribution scan prefetch (t1702)
+FOSS_MAX_DISPATCH_PER_CYCLE="${FOSS_MAX_DISPATCH_PER_CYCLE:-2}"                                         # Max FOSS contribution workers per pulse cycle (t1702)
 
 # Process guard limits (t1398)
 CHILD_RSS_LIMIT_KB="${CHILD_RSS_LIMIT_KB:-2097152}"           # 2 GB default — kill child if RSS exceeds this
@@ -195,6 +197,8 @@ GH_FAILURE_PREFETCH_HOURS=$(_validate_int GH_FAILURE_PREFETCH_HOURS "$GH_FAILURE
 GH_FAILURE_PREFETCH_LIMIT=$(_validate_int GH_FAILURE_PREFETCH_LIMIT "$GH_FAILURE_PREFETCH_LIMIT" 100 1)
 GH_FAILURE_SYSTEMIC_THRESHOLD=$(_validate_int GH_FAILURE_SYSTEMIC_THRESHOLD "$GH_FAILURE_SYSTEMIC_THRESHOLD" 3 1)
 GH_FAILURE_MAX_RUN_LOGS=$(_validate_int GH_FAILURE_MAX_RUN_LOGS "$GH_FAILURE_MAX_RUN_LOGS" 6 0)
+FOSS_SCAN_TIMEOUT=$(_validate_int FOSS_SCAN_TIMEOUT "$FOSS_SCAN_TIMEOUT" 30 5)
+FOSS_MAX_DISPATCH_PER_CYCLE=$(_validate_int FOSS_MAX_DISPATCH_PER_CYCLE "$FOSS_MAX_DISPATCH_PER_CYCLE" 2 0)
 CHILD_RSS_LIMIT_KB=$(_validate_int CHILD_RSS_LIMIT_KB "$CHILD_RSS_LIMIT_KB" 2097152 1)
 CHILD_RUNTIME_LIMIT=$(_validate_int CHILD_RUNTIME_LIMIT "$CHILD_RUNTIME_LIMIT" 1800 1)
 SHELLCHECK_RSS_LIMIT_KB=$(_validate_int SHELLCHECK_RSS_LIMIT_KB "$SHELLCHECK_RSS_LIMIT_KB" 1048576 1)
@@ -828,6 +832,15 @@ _append_prefetch_sub_helpers() {
 	}
 	cat "$needs_info_tmp" >>"$STATE_FILE"
 	rm -f "$needs_info_tmp"
+
+	# Append FOSS contribution scan results (t1702)
+	local foss_tmp
+	foss_tmp=$(mktemp)
+	run_cmd_with_timeout "$FOSS_SCAN_TIMEOUT" prefetch_foss_scan >"$foss_tmp" 2>/dev/null || {
+		echo "[pulse-wrapper] prefetch_foss_scan timed out after ${FOSS_SCAN_TIMEOUT}s (non-fatal)" >>"$LOGFILE"
+	}
+	cat "$foss_tmp" >>"$STATE_FILE"
+	rm -f "$foss_tmp"
 
 	return 0
 }
@@ -2775,6 +2788,113 @@ prefetch_contribution_watch() {
 		echo "[pulse-wrapper] Contribution watch: ${cw_count} items need attention" >>"$LOGFILE"
 	fi
 
+	return 0
+}
+
+#######################################
+# Pre-fetch FOSS contribution scan results (t1702)
+#
+# Runs foss-contribution-helper.sh scan --dry-run and appends a compact
+# summary to STATE_FILE. This gives the pulse agent visibility into
+# eligible FOSS repos so it can dispatch contribution workers when idle
+# capacity exists.
+#
+# The scan checks: foss.enabled globally, per-repo foss:true, blocklist,
+# daily token budget, and weekly PR rate limits. Only repos passing all
+# gates appear as eligible.
+#
+# Output: FOSS scan summary to stdout (appended to STATE_FILE by caller)
+# Returns: 0 always (best-effort, never breaks the pulse)
+#######################################
+prefetch_foss_scan() {
+	local helper="${SCRIPT_DIR}/foss-contribution-helper.sh"
+	if [[ ! -x "$helper" ]]; then
+		return 0
+	fi
+
+	# Quick check: is FOSS globally enabled? Skip the scan entirely if not.
+	local foss_enabled="false"
+	local config_jsonc="${HOME}/.config/aidevops/config.jsonc"
+	if [[ -f "$config_jsonc" ]] && command -v jq &>/dev/null; then
+		foss_enabled=$(sed 's|//.*||g; s|/\*.*\*/||g' "$config_jsonc" 2>/dev/null |
+			jq -r '.foss.enabled // "false"' 2>/dev/null) || foss_enabled="false"
+	fi
+	if [[ "$foss_enabled" != "true" ]]; then
+		return 0
+	fi
+
+	# Check if any foss:true repos exist in repos.json
+	local foss_repo_count=0
+	if [[ -f "$REPOS_JSON" ]] && command -v jq &>/dev/null; then
+		foss_repo_count=$(jq '[.initialized_repos[] | select(.foss == true)] | length' "$REPOS_JSON" 2>/dev/null) || foss_repo_count=0
+	fi
+	if [[ "${foss_repo_count:-0}" -eq 0 ]]; then
+		return 0
+	fi
+
+	local scan_output
+	scan_output=$(bash "$helper" scan --dry-run 2>/dev/null) || scan_output=""
+
+	if [[ -z "$scan_output" ]]; then
+		return 0
+	fi
+
+	# Extract eligible and skipped counts from the summary line
+	local eligible_count=0
+	local skipped_count=0
+	if [[ "$scan_output" =~ ([0-9]+)\ eligible ]]; then
+		eligible_count="${BASH_REMATCH[1]}"
+	fi
+	if [[ "$scan_output" =~ ([0-9]+)\ skipped ]]; then
+		skipped_count="${BASH_REMATCH[1]}"
+	fi
+
+	# Get budget info
+	local budget_output
+	budget_output=$(bash "$helper" budget 2>/dev/null) || budget_output=""
+	local daily_used=0
+	local daily_max=200000
+	local daily_remaining=0
+	if [[ "$budget_output" =~ Used\ today:\ +([0-9]+) ]]; then
+		daily_used="${BASH_REMATCH[1]}"
+	fi
+	if [[ "$budget_output" =~ Max\ daily\ tokens:\ +([0-9]+) ]]; then
+		daily_max="${BASH_REMATCH[1]}"
+	fi
+	daily_remaining=$((daily_max - daily_used))
+	if [[ "$daily_remaining" -lt 0 ]]; then
+		daily_remaining=0
+	fi
+
+	# Extract per-repo eligible details (lines matching ELIGIBLE)
+	local eligible_details
+	eligible_details=$(echo "$scan_output" | grep -i 'ELIGIBLE' | sed 's/\x1b\[[0-9;]*m//g' | sed 's/^[[:space:]]*/  - /' || true)
+
+	{
+		echo ""
+		echo "# FOSS Contribution Scan (t1702)"
+		echo ""
+		echo "FOSS contributions are **enabled**. Scan results from \`foss-contribution-helper.sh scan --dry-run\`."
+		echo ""
+		echo "- Eligible repos: **${eligible_count}**"
+		echo "- Skipped repos: ${skipped_count} (blocklisted, budget exceeded, or rate limited)"
+		echo "- Daily token budget: ${daily_used}/${daily_max} used (${daily_remaining} remaining)"
+		echo "- Max FOSS dispatches per cycle: ${FOSS_MAX_DISPATCH_PER_CYCLE}"
+		echo ""
+		if [[ -n "$eligible_details" && "$eligible_count" -gt 0 ]]; then
+			echo "### Eligible FOSS Repos"
+			echo ""
+			echo "$eligible_details"
+			echo ""
+		fi
+		echo "**Dispatch rule:** When idle worker capacity exists (all managed repo issues dispatched"
+		echo "and worker slots remain), dispatch contribution workers for eligible FOSS repos."
+		echo "Max ${FOSS_MAX_DISPATCH_PER_CYCLE} FOSS dispatches per pulse cycle. Use \`foss-contribution-helper.sh check <slug>\`"
+		echo "before each dispatch. Record token usage after completion with \`foss-contribution-helper.sh record <slug> <tokens>\`."
+		echo ""
+	}
+
+	echo "[pulse-wrapper] FOSS scan: ${eligible_count} eligible, ${skipped_count} skipped, budget ${daily_used}/${daily_max}" >>"$LOGFILE"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Add `prefetch_foss_scan()` function to `pulse-wrapper.sh` that runs `foss-contribution-helper.sh scan --dry-run` during the prefetch phase and appends eligible repo count, budget status, and per-repo details to the pulse state file
- Wire the scan into `_append_prefetch_sub_helpers()` with configurable timeout (`FOSS_SCAN_TIMEOUT`, default 30s) — non-fatal on timeout so the pulse proceeds without FOSS data
- Add FOSS dispatch logic to `pulse.md` as Step 4.7 — lowest priority work (position 10) that only fires when all managed-repo slots are filled and idle capacity exists, capped at `FOSS_MAX_DISPATCH_PER_CYCLE` (default 2) per cycle

## Changes

### `pulse-wrapper.sh`
- **Config**: `FOSS_SCAN_TIMEOUT` (30s) and `FOSS_MAX_DISPATCH_PER_CYCLE` (2) with `_validate_int` guards
- **`prefetch_foss_scan()`**: Early-exits if FOSS is globally disabled or no `foss: true` repos exist. Runs dry-run scan, extracts eligible/skipped counts via regex, fetches budget info, strips ANSI codes from eligible details, and emits a structured markdown section for the pulse agent
- **`_append_prefetch_sub_helpers()`**: Calls `prefetch_foss_scan` via `run_cmd_with_timeout` as the last sub-helper

### `pulse.md`
- **Step 4.7**: Full dispatch flow for FOSS contributions — eligibility check, issue discovery via `labels_filter`, worker dispatch with disclosure note, concurrency cap, skip conditions, and FOSS response prioritization
- **Monitoring loop**: Updated to include FOSS dispatch after needs-info scan
- **Priority order**: Both lists updated with position 10 for FOSS contributions

## Testing

- `shellcheck pulse-wrapper.sh` — clean (0 violations)
- `bash -n pulse-wrapper.sh` — syntax OK
- Risk level: **low** — additive feature, no existing behavior modified. The scan is non-fatal (timeout + early-exit guards) and FOSS dispatch only activates when `foss.enabled: true` in config.jsonc AND `foss: true` repos exist in repos.json

Closes #12462

---
[aidevops.sh](https://aidevops.sh) v3.5.108 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6