### PR TITLE
GH#12333: tighten onboarding wizard doc from 209 to 194 lines

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -5,7 +5,7 @@ mode: subagent
 subagents: [setup, troubleshooting, api-key-setup, list-keys, mcp-integrations, services, service-links, general, explore]
 ---
 
-# Onboarding Wizard - aidevops Configuration
+# Onboarding Wizard
 
 <!-- AI-CONTEXT-START -->
 
@@ -14,32 +14,17 @@ subagents: [setup, troubleshooting, api-key-setup, list-keys, mcp-integrations, 
 - **Command**: `/onboarding` or `@onboarding`
 - **Script**: `~/.aidevops/agents/scripts/onboarding-helper.sh`
 - **Settings**: `~/.config/aidevops/settings.json` — `settings-helper.sh list|set|reset`
-- **Purpose**: Interactive wizard to discover, configure, and verify aidevops integrations
 
-**CRITICAL - OpenCode Setup**: NEVER manually write `opencode.json`. Always run:
+**OpenCode Setup**: NEVER manually write `opencode.json`. Run `~/.aidevops/agents/scripts/generate-opencode-agents.sh`. If OpenCode won't start: `mv ~/.config/opencode/opencode.json ~/.config/opencode/opencode.json.broken` then re-run the generator.
 
-```bash
-~/.aidevops/agents/scripts/generate-opencode-agents.sh
-```
-
-If OpenCode won't start: `mv ~/.config/opencode/opencode.json ~/.config/opencode/opencode.json.broken && ~/.aidevops/agents/scripts/generate-opencode-agents.sh`
-
-**OpenCode JSON errors**:
-
-| Error | Wrong | Correct |
-|-------|-------|---------|
-| `expected record, received array` for tools | `"tools": []` | `"tools": {}` |
-| `Invalid input mcp.*` | Missing `type` field | Add `"type": "local"` or `"type": "remote"` |
-| `expected boolean, received object` for tools | `"tool_name": {...}` | `"tool_name": true` |
-
-Verify: `jq . ~/.config/opencode/opencode.json > /dev/null && echo "Valid JSON"`
+OpenCode JSON errors: `expected record, received array` for tools → use `"tools": {}` not `[]` | `Invalid input mcp.*` → add `"type": "local"` or `"type": "remote"` | `expected boolean, received object` for tools → use `"tool_name": true` not `{...}`. Verify: `jq . ~/.config/opencode/opencode.json > /dev/null`
 
 <!-- AI-CONTEXT-END -->
 
 ## Welcome Flow
 
-1. **Introduction** (new users) — ask if they want an explanation. Capabilities: Autonomous Orchestration (supervisor dispatches AI workers, merges PRs), Infrastructure (Hetzner, Hostinger, Cloudron, Coolify), Domains/DNS (Cloudflare, Spaceship, 101domains), Git (GitHub, GitLab, Gitea), Code Quality (SonarCloud, Codacy, CodeRabbit, Snyk), WordPress (LocalWP, MainWP), SEO (DataForSEO, Serper, GSC), Browser Automation (Playwright, Stagehand), Context (Augment, Context7, Repomix)
-2. **Concept familiarity** — ask which they know (Git, Terminal, API keys, Hosting, SEO, AI assistants). Offer 3-4 sentence explanations. Save: `onboarding-helper.sh save-concepts 'git,terminal'`
+1. **Introduction** — ask new users if they want an explanation. Capabilities: Autonomous Orchestration, Infrastructure (Hetzner, Hostinger, Cloudron, Coolify), Domains/DNS (Cloudflare, Spaceship, 101domains), Git (GitHub, GitLab, Gitea), Code Quality (SonarCloud, Codacy, CodeRabbit, Snyk), WordPress (LocalWP, MainWP), SEO (DataForSEO, Serper, GSC), Browser Automation (Playwright, Stagehand), Context (Augment, Context7, Repomix)
+2. **Concept familiarity** — ask which they know (Git, Terminal, API keys, Hosting, SEO, AI assistants). Offer brief explanations. Save: `onboarding-helper.sh save-concepts 'git,terminal'`
 3. **Work type** — ask what they do (web dev, DevOps, SEO, WordPress, other). Save: `onboarding-helper.sh save-work-type devops`
 4. **Current status** — `onboarding-helper.sh status` — show configured vs needs-setup
 5. **Guide setup** — for each service: explain purpose, link to credentials, setup command, verification
@@ -48,63 +33,63 @@ Verify: `jq . ~/.config/opencode/opencode.json > /dev/null && echo "Valid JSON"`
 
 ### AI Providers
 
-| Service | Env Var | Setup Link | Purpose |
-|---------|---------|------------|---------|
-| OpenAI | `OPENAI_API_KEY` | https://platform.openai.com/api-keys | GPT models, Stagehand |
-| Anthropic | `ANTHROPIC_API_KEY` | https://console.anthropic.com/settings/keys | Claude models |
+| Service | Env Var | Setup Link |
+|---------|---------|------------|
+| OpenAI | `OPENAI_API_KEY` | https://platform.openai.com/api-keys |
+| Anthropic | `ANTHROPIC_API_KEY` | https://console.anthropic.com/settings/keys |
 
 Set keys: `~/.aidevops/agents/scripts/setup-local-api-keys.sh set OPENAI_API_KEY "sk-..."`
 
 ### Git Platforms
 
-| Service | Auth | Purpose |
-|---------|------|---------|
-| GitHub | `gh auth login` | Repos, PRs, Actions |
-| GitLab | `glab auth login` | Repos, MRs, Pipelines |
-| Gitea | `tea login add` | Self-hosted Git |
+| Service | Auth |
+|---------|------|
+| GitHub | `gh auth login` |
+| GitLab | `glab auth login` |
+| Gitea | `tea login add` |
 
-### Hosting Providers
+### Hosting & Infrastructure
 
-| Service | Env Var(s) | Setup Link | Purpose |
-|---------|------------|------------|---------|
-| Hetzner Cloud | `HCLOUD_TOKEN_*` | https://console.hetzner.cloud/ → Security → API Tokens | VPS, networking |
-| Cloudflare | `CLOUDFLARE_API_TOKEN` | https://dash.cloudflare.com/profile/api-tokens | DNS, CDN, security |
-| Coolify | `COOLIFY_API_TOKEN` | Your Coolify instance → Settings → API | Self-hosted PaaS |
-| Vercel | `VERCEL_TOKEN` | https://vercel.com/account/tokens | Serverless deployment |
+| Service | Env Var(s) | Setup Link |
+|---------|------------|------------|
+| Hetzner Cloud | `HCLOUD_TOKEN_*` | https://console.hetzner.cloud/ → Security → API Tokens |
+| Cloudflare | `CLOUDFLARE_API_TOKEN` | https://dash.cloudflare.com/profile/api-tokens |
+| Coolify | `COOLIFY_API_TOKEN` | Your Coolify instance → Settings → API |
+| Vercel | `VERCEL_TOKEN` | https://vercel.com/account/tokens |
 
 ### Code Quality
 
-| Service | Env Var | Setup Link | Purpose |
-|---------|---------|------------|---------|
-| SonarCloud | `SONAR_TOKEN` | https://sonarcloud.io/account/security | Security analysis |
-| Codacy | `CODACY_PROJECT_TOKEN` | https://app.codacy.com → Project → Settings | Code quality |
-| CodeRabbit | `CODERABBIT_API_KEY` | https://app.coderabbit.ai/settings | AI code review |
-| Snyk | `SNYK_TOKEN` | https://app.snyk.io/account | Vulnerability scanning |
+| Service | Env Var | Setup Link |
+|---------|---------|------------|
+| SonarCloud | `SONAR_TOKEN` | https://sonarcloud.io/account/security |
+| Codacy | `CODACY_PROJECT_TOKEN` | https://app.codacy.com → Project → Settings |
+| CodeRabbit | `CODERABBIT_API_KEY` | https://app.coderabbit.ai/settings |
+| Snyk | `SNYK_TOKEN` | https://app.snyk.io/account |
 
 CodeRabbit key: `mkdir -p ~/.config/coderabbit && echo "key" > ~/.config/coderabbit/api_key && chmod 600 ~/.config/coderabbit/api_key`
 
 ### SEO & Research
 
-| Service | Env Var(s) | Setup Link | Purpose |
-|---------|------------|------------|---------|
-| DataForSEO | `DATAFORSEO_USERNAME`, `DATAFORSEO_PASSWORD` | https://app.dataforseo.com/api-access | SERP, keywords, backlinks |
-| Serper | `SERPER_API_KEY` | https://serper.dev/api-key | Google Search API |
-| Outscraper | `OUTSCRAPER_API_KEY` | https://outscraper.com/dashboard | Business data extraction |
-| Google Search Console | OAuth via MCP | https://search.google.com/search-console | Site search performance |
+| Service | Env Var(s) | Setup Link |
+|---------|------------|------------|
+| DataForSEO | `DATAFORSEO_USERNAME`, `DATAFORSEO_PASSWORD` | https://app.dataforseo.com/api-access |
+| Serper | `SERPER_API_KEY` | https://serper.dev/api-key |
+| Outscraper | `OUTSCRAPER_API_KEY` | https://outscraper.com/dashboard |
+| Google Search Console | OAuth via MCP | https://search.google.com/search-console |
 
 SEO commands: `/keyword-research`, `/autocomplete-research`, `/keyword-research-extended`, `/webmaster-keywords`
 
 ### Context, Browser & Containers
 
-| Tool | Setup | Purpose |
-|------|-------|---------|
-| Augment | `npm install -g @augmentcode/auggie@prerelease && auggie login` | Semantic codebase search |
-| Context7 | MCP config only | Library documentation |
-| Playwright | `npx playwright install` (Node.js) | Cross-browser testing |
-| Stagehand | OpenAI/Anthropic key required | AI browser automation |
-| Chrome DevTools | `--remote-debugging-port=9222` | Browser debugging |
-| OrbStack | `brew install orbstack` — docs: `@orbstack` | Docker + Linux VMs (macOS) |
-| Tailscale | `brew install tailscale` — docs: `@tailscale` | Zero-config mesh VPN |
+| Tool | Setup |
+|------|-------|
+| Augment | `npm install -g @augmentcode/auggie@prerelease && auggie login` |
+| Context7 | MCP config only |
+| Playwright | `npx playwright install` (Node.js) |
+| Stagehand | OpenAI/Anthropic key required |
+| Chrome DevTools | `--remote-debugging-port=9222` |
+| OrbStack | `brew install orbstack` — docs: `@orbstack` |
+| Tailscale | `brew install tailscale` — docs: `@tailscale` |
 
 ### Personal AI Assistant (OpenClaw)
 
@@ -167,22 +152,22 @@ opencode mcp list && ~/.aidevops/agents/scripts/mcp-diagnose.sh <name>
 chmod 600 ~/.config/aidevops/credentials.sh && chmod 700 ~/.config/aidevops
 ```
 
-## Agents, Commands & Workflow
+## Agents & Commands
 
-**Agent layers**: Main agents (Tab key) → Subagents (`@name`) → Commands (`/name`). Root AGENTS.md → Main agent → Subagents on @mention → Commands on /invoke.
+**Agent layers**: Main agents (Tab key) → Subagents (`@name`) → Commands (`/name`)
 
 **Main agents**: `Build+` (coding/DevOps), `SEO` (search optimization), `WordPress` (WP ecosystem)
 
 **Common subagents**: `@hetzner`, `@cloudflare`, `@coolify`, `@vercel`, `@github-cli`, `@dataforseo`, `@augment-context-engine`, `@code-standards`, `@wp-dev`
 
-**Project init**: `cd ~/your-project && aidevops init` — creates `.aidevops.json`, `.agent` symlink, `TODO.md`, `todo/PLANS.md`
+**Project init**: `cd ~/your-project && aidevops init`
 
 **Key commands**: `/create-prd`, `/generate-tasks`, `/feature`, `/bugfix`, `/hotfix`, `/pr`, `/preflight`, `/release`, `/linters-local`, `/keyword-research`
 
-## Repo Sync, Settings & Orchestration
+## Repo Sync & Orchestration
 
 ```bash
-# Repo sync — configure git parent directories
+# Configure git parent directories for repo sync
 jq --argjson dirs '["~/Git", "~/Projects"]' '. + {git_parent_dirs: $dirs}' \
   ~/.config/aidevops/repos.json > /tmp/repos.json && mv /tmp/repos.json ~/.config/aidevops/repos.json
 aidevops repo-sync enable
@@ -190,14 +175,14 @@ aidevops repo-sync enable
 # Settings
 ~/.aidevops/agents/scripts/settings-helper.sh set orchestration.enabled true
 
-# Enable autonomous orchestration (supervisor pulse, auto-pickup, cross-repo visibility)
+# Enable autonomous orchestration
 ~/.aidevops/agents/scripts/onboarding-helper.sh save-orchestration true
 # See scripts/commands/runners.md for launchd (macOS) and cron (Linux) setup
 ```
 
 Settings sections: `user`, `orchestration`, `repo_sync`, `quality`, `model_routing`, `notifications`, `ui`.
 
-Cost note: subscription plans (Claude Max/Pro, OpenAI Pro/Plus) are significantly cheaper than API for sustained use. Reserve API keys for testing.
+Cost note: subscription plans (Claude Max/Pro, OpenAI Pro/Plus) are cheaper than API for sustained use. Reserve API keys for testing.
 
 ## Next Steps After Setup
 


### PR DESCRIPTION
## Summary

- Removed redundant "Purpose" columns from 6 service catalog tables (service names + setup links are self-explanatory)
- Collapsed OpenCode setup section from code block + table (19 lines) to inline text (3 lines)
- Trimmed verbose prose in section headers and descriptions without losing any configuration steps

## Changes

**File:** `.agents/aidevops/onboarding.md` (209 → 194 lines, -7.2%)

**What was removed (redundancy only):**
- "Purpose" column from AI Providers, Git Platforms, Hosting, Code Quality, SEO, and Context/Browser tables
- OpenCode JSON errors table → inline `→` format (same info, fewer lines)
- Redundant explanatory text ("Root AGENTS.md → Main agent → Subagents on @mention → Commands on /invoke", "creates `.aidevops.json`, `.agent` symlink, `TODO.md`, `todo/PLANS.md`", etc.)

**What was preserved (all of it):**
- All 18 URLs, all env var names, all setup commands
- All 4 code blocks (verification, OpenClaw install, troubleshooting, repo sync)
- All service entries, recommended setup order profiles, credential storage table
- YAML frontmatter, AI-CONTEXT markers, section structure

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs-only change, no code/config)
- Verification: markdownlint clean, all URLs/commands/env vars confirmed present via `rg`

Closes #12333

---
[aidevops.sh](https://aidevops.sh) v3.5.108 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 2m and 6,824 tokens on this.