### PR TITLE
fix: Completion comments use --issue --solved for full signature

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -153,7 +153,7 @@ if [[ "$REPO_SLUG" == "marcusquinn/aidevops" ]]; then
 fi
 ```
 
-**4.7 Issue Closing Comment (MANDATORY):** Post structured comment on every linked issue: **What was done**, **Testing Evidence** (level: `runtime-verified`/`self-assessed`/`untested`, smoke checks), **Key decisions**, **Files changed** (path — what/why), **Blockers**, **Follow-up needs**, **Released in** (aidevops only). Every section ≥1 bullet ("None"/"N/A" if empty). Append a signature footer (see `build.txt` "GitHub comment signature footer" — use `gh-signature-helper.sh footer --model <model>`). Gate — no `FULL_LOOP_COMPLETE` until posted.
+**4.7 Issue Closing Comment (MANDATORY):** Post structured comment on every linked issue: **What was done**, **Testing Evidence** (level: `runtime-verified`/`self-assessed`/`untested`, smoke checks), **Key decisions**, **Files changed** (path — what/why), **Blockers**, **Follow-up needs**, **Released in** (aidevops only). Every section ≥1 bullet ("None"/"N/A" if empty). Append a signature footer: `gh-signature-helper.sh footer --model <model> --issue <slug>#<number> --solved`. Gate — no `FULL_LOOP_COMPLETE` until posted.
 
 ### 4.8 Worktree Cleanup (GH#6740 — MANDATORY)
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -776,10 +776,10 @@ Every comment the supervisor posts on an issue or PR must be **sufficient for a 
 
 When dispatching a worker, comment on the issue with:
 
-Generate the signature footer: `SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<full model ID>")`.
+Generate the signature footer: `SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<full model ID>" --issue "<slug>#<number>")`.
 
 ```bash
-SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<full model ID, e.g., anthropic/claude-sonnet-4-6>")
+SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<full model ID, e.g., anthropic/claude-sonnet-4-6>" --issue "<slug>#<number>")
 gh issue comment <number> --repo <slug> --body "Dispatching worker.
 - **Branch**: <branch name, e.g., fix/t748-ai-migration>
 - **Scope**: <1-line description of what the worker should do>
@@ -795,7 +795,7 @@ ${SIG_FOOTER}"
 When killing a worker or closing a failed PR, comment with:
 
 ```bash
-SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<tier used>")
+SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<tier used>" --issue "<slug>#<number>")
 gh issue comment <number> --repo <slug> --body "Worker killed after <duration> with <N> commits (struggle_ratio: <ratio>).
 - **Branch**: <branch name>
 - **Reason**: <why it was killed — thrashing, timeout, CI loop, etc.>
@@ -814,7 +814,7 @@ ${SIG_FOOTER}"
 When merging a PR or closing an issue as done:
 
 ```bash
-SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<tier that succeeded>")
+SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "<tier that succeeded>" --issue "<slug>#<number>" --solved)
 gh issue comment <number> --repo <slug> --body "Completed via PR #<N>.
 - **Attempts**: <total attempts including failures>
 - **Duration**: <wall-clock from first dispatch to merge>


### PR DESCRIPTION
Completion/merge comments were missing `--issue` and `--solved` flags, so they showed only `spent 2m and 3,354 tokens on this.` without `Solved in Xm.` or total token accumulation.

Updated all three pulse.md comment templates (dispatch, kill, merge) and full-loop.md closing comment to pass the issue ref.

---
[aidevops.sh](https://aidevops.sh) v3.5.108 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 8h 11m and 174,855 tokens on this. Solved in 5h 58m. 186,501 total tokens on this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Updated signature footer generation to include issue context parameters across all supervisor audit comment types (worker dispatch, worker termination, and merge completion).
  * Enhanced issue-closing comments to include solved status in signature footers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->