### PR TITLE
feat: Signature shows 'interactive session' or 'headless worker'

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -224,6 +224,69 @@ _detect_session_tokens() {
 }
 
 # =============================================================================
+# Detect session type: "interactive" (>1 user messages) or "worker" (0-1)
+# =============================================================================
+
+_detect_session_type() {
+	local db_path="${HOME}/.local/share/opencode/opencode.db"
+
+	if [[ ! -r "$db_path" ]] || ! command -v sqlite3 &>/dev/null; then
+		echo ""
+		return 0
+	fi
+
+	local cwd repo_root canonical_dir
+	cwd=$(pwd 2>/dev/null || echo "")
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+	canonical_dir="${repo_root%%.*}"
+
+	local session_id=""
+	if [[ -n "${OPENCODE_PID:-}" ]]; then
+		local pid_start_epoch lstart
+		lstart=$(ps -o lstart= -p "$OPENCODE_PID" 2>/dev/null || echo "")
+		if [[ -n "$lstart" ]]; then
+			pid_start_epoch=$(date -j -f "%a %b %d %H:%M:%S %Y" "$lstart" "+%s" 2>/dev/null ||
+				date -d "$lstart" "+%s" 2>/dev/null || echo "")
+		fi
+		if [[ -n "$pid_start_epoch" ]]; then
+			local pid_start_ms=$((pid_start_epoch * 1000))
+			session_id=$(sqlite3 "$db_path" "
+				SELECT id FROM session
+				WHERE directory IN ('${cwd}', '${repo_root}', '${canonical_dir}')
+				ORDER BY ABS(time_created - ${pid_start_ms}) ASC LIMIT 1
+			" 2>/dev/null || echo "")
+		fi
+	fi
+
+	if [[ -z "$session_id" ]]; then
+		session_id=$(sqlite3 "$db_path" "
+			SELECT id FROM session
+			WHERE directory IN ('${cwd}', '${repo_root}', '${canonical_dir}')
+			ORDER BY time_updated DESC LIMIT 1
+		" 2>/dev/null || echo "")
+	fi
+
+	if [[ -z "$session_id" ]]; then
+		echo ""
+		return 0
+	fi
+
+	local user_msg_count
+	user_msg_count=$(sqlite3 "$db_path" "
+		SELECT COUNT(*) FROM message
+		WHERE session_id='${session_id}'
+		  AND json_extract(data, '$.role') = 'user'
+	" 2>/dev/null || echo "0")
+
+	if [[ "$user_msg_count" -gt 1 ]] 2>/dev/null; then
+		echo "interactive"
+	else
+		echo "worker"
+	fi
+	return 0
+}
+
+# =============================================================================
 # Detect session time from runtime DB
 # =============================================================================
 # Returns session duration in seconds (now - session.time_created), or empty.
@@ -575,7 +638,7 @@ _collect_time_metrics() {
 # =============================================================================
 # _build_signature — assemble the natural-language signature string
 # =============================================================================
-# Args: model cli_name cli_version tokens session_time_str total_time_str solved issue_total_tokens
+# Args: model cli_name cli_version tokens session_time_str total_time_str solved issue_total_tokens session_type
 
 _build_signature() {
 	local model="$1"
@@ -586,6 +649,7 @@ _build_signature() {
 	local total_time_str="$6"
 	local solved="$7"
 	local issue_total_tokens="${8:-}"
+	local session_type="${9:-}"
 
 	local aidevops_version
 	aidevops_version=$(aidevops_find_version)
@@ -636,7 +700,13 @@ _build_signature() {
 			formatted=$(_format_number "$tokens")
 			sig="${sig} ${formatted} tokens"
 		fi
-		sig="${sig} on this."
+		if [[ "$session_type" == "interactive" ]]; then
+			sig="${sig} on this with the user in an interactive session."
+		elif [[ "$session_type" == "worker" ]]; then
+			sig="${sig} on this as a headless worker."
+		else
+			sig="${sig} on this."
+		fi
 	fi
 
 	local has_stats=""
@@ -713,10 +783,14 @@ cmd_generate() {
 		fi
 	fi
 
+	# Detect session type (interactive vs worker)
+	local session_type
+	session_type=$(_detect_session_type)
+
 	# Build and emit the signature
 	_build_signature \
 		"$model" "$cli_name" "$cli_version" "$tokens" \
-		"$session_time_str" "$total_time_str" "$solved" "$issue_total_tokens"
+		"$session_time_str" "$total_time_str" "$solved" "$issue_total_tokens" "$session_type"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -71,7 +71,7 @@ assert_contains "starts with aidevops" "[aidevops.sh](https://aidevops.sh)" "$re
 assert_contains "contains CLI with plugin for" "plugin for [OpenCode](https://opencode.ai) v1.3.3" "$result"
 assert_contains "model strips provider prefix" "with claude-opus-4-6" "$result"
 assert_not_contains "no provider prefix" "anthropic/" "$result"
-assert_contains "contains formatted tokens" "1,234 tokens on this." "$result"
+assert_contains "contains formatted tokens" "1,234 tokens on this" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 2: generate with explicit --tokens 0 (should omit tokens)
@@ -98,7 +98,7 @@ echo "Test 4: no model"
 result=$("$HELPER" generate --cli "Cursor" --tokens 0)
 assert_contains "contains Cursor link" "plugin for [Cursor](https://cursor.com)" "$result"
 assert_contains "contains aidevops" "aidevops.sh" "$result"
-assert_not_contains "no model field" "with " "$result"
+assert_not_contains "no model field" "with claude" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 5: footer command includes --- separator
@@ -108,7 +108,7 @@ echo "Test 5: footer includes --- separator"
 result=$("$HELPER" footer --cli "OpenCode" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
 assert_contains "contains ---" "---" "$result"
 assert_contains "contains signature" "plugin for [OpenCode](https://opencode.ai) v1.0.0" "$result"
-assert_contains "contains tokens" "5,000 tokens on this." "$result"
+assert_contains "contains tokens" "5,000 tokens on this" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 6: comma formatting for various numbers
@@ -180,7 +180,7 @@ result=$(AIDEVOPS_SIG_CLI="EnvCLI" AIDEVOPS_SIG_CLI_VERSION="9.9.9" AIDEVOPS_SIG
 assert_contains "env CLI name" "plugin for EnvCLI" "$result"
 assert_contains "env CLI version" "v9.9.9" "$result"
 assert_contains "env model strips prefix" "with model" "$result"
-assert_contains "env tokens" "42,000 tokens on this." "$result"
+assert_contains "env tokens" "42,000 tokens on this" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 10: auto-detect tokens from OpenCode session DB (if running in OpenCode)


### PR DESCRIPTION
Appends session type to the signature based on user message count in the OpenCode DB:

- **Interactive** (>1 user messages): `spent 8h and 182,174 tokens on this with the user in an interactive session.`
- **Worker** (0-1 user messages): `spent 4m and 7,166 tokens on this as a headless worker.`

43/43 tests pass.

---
[aidevops.sh](https://aidevops.sh) v3.5.111 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 8h 25m and 182,666 tokens on this with the user in an interactive session.