### PR TITLE
t1703: standardize PR title convention for debt-dispatch workers

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -162,7 +162,7 @@ Full rules: `reference/planning-detail.md`
 
 Worktree naming prefixes: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
-PR title: `{task-id}: {description}`. Create TODO entry first for unplanned work.
+PR title: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for debt/issue-only work). Examples: `t1702: integrate FOSS scanning`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. Create TODO entry first for unplanned work.
 
 Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `main`, and treat the Git ref as an internal detail inside the linked worktree. User-facing guidance should talk about the worktree path, not "using a branch". Re-read files at worktree path before editing. NEVER remove others' worktrees.
 

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -83,7 +83,12 @@ If `shellcheck` is not installed, skip this gate and note it in the PR body.
 
 **3b. PR title MUST contain task ID (MANDATORY - t318.2)**
 When creating a PR, the title MUST start with the task ID: `<task-id>: <description>`.
-Example: `t318.2: Verify supervisor worker PRs include task ID`
+The task ID is one of:
+- `tNNN` — TODO.md task ID (e.g., `t318.2: Verify supervisor worker PRs include task ID`)
+- `GH#NNN` — GitHub issue number, for quality-debt/simplification-debt/issue-only work (e.g., `GH#12455: tighten hashline-edit-format.md`)
+
+NEVER use `qd-`, bare numbers, `t` followed by a GitHub issue number (e.g., `t12345`), or other invented prefixes. The `qd-` prefix is for branch names only (set by the pulse dispatcher), not PR titles.
+
 The CI pipeline and supervisor both validate this. PRs without task IDs fail the check.
 If you used `gh pr create --draft --title '<task-id>: <description>'` as instructed above,
 this is already handled. This note reinforces: NEVER omit the task ID from the PR title.

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -1297,6 +1297,8 @@ fi
 sleep 2
 ```
 
+**PR title for debt issues (MANDATORY):** Workers dispatched for quality-debt or simplification-debt issues use `GH#<number>: <description>` as the PR title (e.g., `GH#12455: tighten hashline-edit-format.md`). The `GH#` prefix distinguishes GitHub issue numbers from `t`-prefixed TODO.md task IDs. NEVER use `qd-`, bare numbers, or `t` followed by a GitHub issue number in PR titles — `qd-` is a branch-naming convention only.
+
 **Why worktrees, not canonical dir:** When the pulse dispatches N quality-debt workers all pointing to the same canonical repo path, each worker's `full-loop.md` Step 1 tries to create a branch in that directory. The first worker succeeds; subsequent workers find the repo already on a non-main branch and either fail or compound the problem. Worktrees give each worker an isolated directory with its own branch, so they never interfere with each other or with the canonical repo.
 
 **`git -C <path>` for worktree creation:** The pulse runs from its own working directory (not the target repo). Use `git -C <path>` to create worktrees in the correct repo without changing the pulse's cwd. Do NOT call `worktree-helper.sh` for this — it uses `get_repo_root()` which depends on cwd and would target the wrong repo.

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -129,7 +129,7 @@ Files: `~/.aidevops/hooks/git_safety_guard.py` (guard), `~/.claude/settings.json
 
 After file changes: run preflight automatically. Pass → auto-commit with suggested message (confirm or override). Fail → show issues, offer fixes. After commit → auto-push, offer: create PR, continue working, or done.
 
-**PR Title (MANDATORY)**: `{task-id}: {description}` (e.g., `t318: Update PR workflow documentation`). For unplanned work: create TODO entry first. Every code change must be traceable to a task.
+**PR Title (MANDATORY)**: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for quality-debt/simplification-debt/issue-only work). Examples: `t318: Update PR workflow documentation`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes like `t12345` (that conflates GitHub issue numbers with the `t` task-ID system). For unplanned work: create TODO entry first. Every code change must be traceable to a task.
 
 **If changes include `.agents/` files**: Offer to run `./setup.sh` to deploy to `~/.aidevops/agents/`.
 


### PR DESCRIPTION
## Summary

- Debt-dispatch workers were hallucinating 6+ different PR title formats (`qd-NNN`, `GH#NNN`, `tNNN`, bare `NNN`, `simplification:`, `docs(simplification):`) because the convention only specified `tNNN` task IDs and debt issues only have GitHub issue numbers
- Explicitly documents that debt/issue-only work uses `GH#NNN` prefix in PR titles, and prohibits `qd-` prefix in PR titles (branch-naming only)
- Updated across all 4 locations where PR title convention is specified: AGENTS.md, git-workflow.md, worker-efficiency-protocol.md, pulse.md

## Testing

- Level: `self-assessed` (docs-only change, no runtime behavior)
- Risk: Low — agent prompt/docs changes only
- Verified: markdownlint clean, no shellcheck-relevant files changed

Closes #2386

---
[aidevops.sh](https://aidevops.sh) v3.5.125 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6