### PR TITLE
feat: add origin:worker/origin:interactive labels to issues and TODOs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -125,6 +125,8 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 - `tier:simple`: For haiku-tier tasks.
 - **Default (no label)**: sonnet.
 
+**Session origin labels**: Issues and PRs are automatically tagged with `origin:worker` (headless/pulse dispatch) or `origin:interactive` (user session). Applied by `claim-task-id.sh`, `issue-sync-helper.sh`, and `pulse-wrapper.sh`. In TODO.md, use `#worker` or `#interactive` tags to set origin explicitly; these map to the corresponding labels on push.
+
 Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`. Every completed task must link to its verification evidence — work without an audit trail is unverifiable and may be reverted.
 
 Planning files go direct to main. Code changes need worktree + PR. Workers NEVER edit TODO.md.

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -691,8 +691,13 @@ create_github_issue() {
 		gh_args+=(--body "Task created via claim-task-id.sh")
 	fi
 
+	# Append session origin label (origin:worker or origin:interactive)
+	local origin_label
+	origin_label=$(session_origin_label)
 	if [[ -n "$labels" ]]; then
-		gh_args+=(--label "$labels")
+		gh_args+=(--label "${labels},${origin_label}")
+	else
+		gh_args+=(--label "$origin_label")
 	fi
 
 	local issue_url

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -44,6 +44,8 @@ Skip if `--no-decompose` or already has subtasks. Run `task-decompose-helper.sh 
 
 **Step 0.7 — Label dispatch model:** Detect from `$ANTHROPIC_MODEL`/`$CLAUDE_MODEL` or system prompt. Map: `*opus*`→`dispatched:opus`, `*sonnet*`→`dispatched:sonnet`, `*haiku*`→`dispatched:haiku`. Remove stale labels first.
 
+**Step 0.8 — Label session origin:** Detect via `session_origin_label` (from `shared-constants.sh`). Adds `origin:worker` (headless/pulse dispatch) or `origin:interactive` (user session). Applied automatically by `claim-task-id.sh`, `issue-sync-helper.sh`, and `pulse-wrapper.sh`. TODO.md tags `#worker`/`#interactive` also map to these labels.
+
 **Step 1.7 — Lineage context (t1408.3):** If dispatch prompt contains `TASK LINEAGE:` block: (1) only implement `<-- THIS TASK`, (2) stub sibling dependencies, (3) no sibling work, (4) include lineage in PR body, (5) hard dependency not stub-able → exit `BLOCKED`.
 
 ---

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -305,7 +305,11 @@ _push_create_issue() {
 		status_label="status:claimed"
 		gh_create_label "$repo" "status:claimed" "D93F0B" "Task is claimed"
 	}
-	local all_labels="${labels:+${labels},}${status_label}"
+	# Add session origin label (origin:worker or origin:interactive)
+	local origin_label
+	origin_label=$(session_origin_label)
+	gh_create_label "$repo" "$origin_label" "C5DEF5" "Created from ${origin_label#origin:} session"
+	local all_labels="${labels:+${labels},}${status_label},${origin_label}"
 
 	# Race-condition guard: re-check immediately before creating
 	local recheck

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -663,6 +663,8 @@ map_tags_to_labels() {
 		hardening) label="quality" ;;
 		sync) label="git" ;;
 		docs) label="documentation" ;;
+		worker) label="origin:worker" ;;
+		interactive) label="origin:interactive" ;;
 		esac
 
 		labels="${labels:+$labels,}$label"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4424,9 +4424,9 @@ dispatch_with_dedup() {
 		return 1
 	fi
 
-	# Assign issue and label as queued
+	# Assign issue and label as queued + origin:worker (dispatched by pulse)
 	gh issue edit "$issue_number" --repo "$repo_slug" \
-		--add-assignee "$self_login" --add-label "status:queued" 2>/dev/null || true
+		--add-assignee "$self_login" --add-label "status:queued" --add-label "origin:worker" 2>/dev/null || true
 
 	# Launch worker
 	"$HEADLESS_RUNTIME_HELPER" run \

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -713,6 +713,64 @@ files_include_workflow_changes() {
 }
 
 # =============================================================================
+# Session Origin Detection
+# =============================================================================
+# Detects whether the current session is a headless worker or interactive user.
+# Used to tag issues, TODOs, and PRs with origin:worker or origin:interactive.
+#
+# Detection signals (checked in priority order):
+#   1. FULL_LOOP_HEADLESS=true — set by supervisor dispatch
+#   2. AIDEVOPS_HEADLESS=true — set by headless-runtime-helper.sh
+#   3. OPENCODE_HEADLESS=true — set by OpenCode headless mode
+#   4. GITHUB_ACTIONS=true — CI environment
+#   5. No TTY (! -t 0 && ! -t 1) — non-interactive shell
+#   6. Default: interactive
+#
+# Usage:
+#   local origin; origin=$(detect_session_origin)
+#   # Returns: "worker" or "interactive"
+#
+#   local label; label=$(session_origin_label)
+#   # Returns: "origin:worker" or "origin:interactive"
+
+detect_session_origin() {
+	# Explicit headless env vars (set by dispatch infrastructure)
+	if [[ "${FULL_LOOP_HEADLESS:-}" == "true" ]]; then
+		echo "worker"
+		return 0
+	fi
+	if [[ "${AIDEVOPS_HEADLESS:-}" == "true" ]]; then
+		echo "worker"
+		return 0
+	fi
+	if [[ "${OPENCODE_HEADLESS:-}" == "true" ]]; then
+		echo "worker"
+		return 0
+	fi
+	# CI environments are always workers
+	if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+		echo "worker"
+		return 0
+	fi
+	# No TTY = non-interactive (headless dispatch, cron, pipe)
+	if [[ ! -t 0 ]] && [[ ! -t 1 ]]; then
+		echo "worker"
+		return 0
+	fi
+	echo "interactive"
+	return 0
+}
+
+# Returns the GitHub label string for the current session origin.
+# Usage: local label; label=$(session_origin_label)
+session_origin_label() {
+	local origin
+	origin=$(detect_session_origin)
+	echo "origin:${origin}"
+	return 0
+}
+
+# =============================================================================
 # TODO.md Serialized Commit+Push
 # =============================================================================
 # Provides atomic locking and pull-rebase-retry for TODO.md operations.


### PR DESCRIPTION
## Summary

- Adds automatic `origin:worker` / `origin:interactive` GitHub labels to issues based on session type (headless dispatch vs user session)
- Adds `detect_session_origin()` and `session_origin_label()` utility functions to `shared-constants.sh`
- Integrates origin labeling into all issue creation paths: `claim-task-id.sh`, `issue-sync-helper.sh`, and `pulse-wrapper.sh`
- Maps `#worker` / `#interactive` TODO.md tags to the corresponding labels via `issue-sync-lib.sh`

## Detection Logic

Checks in priority order:
1. `FULL_LOOP_HEADLESS=true` (supervisor dispatch)
2. `AIDEVOPS_HEADLESS=true` (headless-runtime-helper)
3. `OPENCODE_HEADLESS=true` (OpenCode headless mode)
4. `GITHUB_ACTIONS=true` (CI)
5. No TTY (`! -t 0 && ! -t 1`)
6. Default: interactive

## Files Changed

| File | Change |
|------|--------|
| `shared-constants.sh` | New `detect_session_origin()` + `session_origin_label()` |
| `claim-task-id.sh` | Adds origin label on bare issue creation |
| `issue-sync-helper.sh` | Adds origin label on push-created issues |
| `pulse-wrapper.sh` | Adds `origin:worker` on dispatch |
| `issue-sync-lib.sh` | Maps `#worker`/`#interactive` tags to labels |
| `full-loop.md` | Documents Step 0.8 origin labeling |
| `AGENTS.md` | Documents session origin labels |

## Runtime Testing

- **Level:** self-assessed
- **Risk:** Low (label-only changes, no behavioral impact on existing flows)
- **Verification:** Tested `detect_session_origin()` and `map_tags_to_labels()` in bash; all cases return expected values


---
[aidevops.sh](https://aidevops.sh) v3.5.130 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6