### PR TITLE
feat: add origin tags to TODO line creation in scripts and command docs

### DIFF
--- a/.agents/scripts/commands/define.md
+++ b/.agents/scripts/commands/define.md
@@ -105,7 +105,8 @@ When `--headless` or `$ARGUMENTS` contains ` -- ` (supervisor dispatch), skip in
 2. Apply default assumptions for that type
 3. Generate brief with `Created by: ai-supervisor` in Origin
 4. Write to `todo/tasks/{task_id}-brief.md`
-5. No confirmation — save immediately
+5. Add `#worker` tag to TODO.md entry (headless sessions are always workers)
+6. No confirmation — save immediately
 
 ## Example
 

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -101,8 +101,10 @@ Run `task-decompose-helper.sh classify "{title}"` if available. Skip with `--no-
 ### Step 6: Add to TODO.md
 
 ```markdown
-- [ ] {task_id} {title} #{tag} ~{estimate} ref:{task_ref} logged:{YYYY-MM-DD}
+- [ ] {task_id} {title} #{tag} #{origin} ~{estimate} ref:{task_ref} logged:{YYYY-MM-DD}
 ```
+
+Where `#{origin}` is `#interactive` (user session) or `#worker` (headless/pulse dispatch). Detect via `detect_session_origin` from `shared-constants.sh`, or infer: if the user is present, use `#interactive`; if running headless (`$FULL_LOOP_HEADLESS`, `$AIDEVOPS_HEADLESS`, or no TTY), use `#worker`. These map to `origin:interactive` / `origin:worker` GitHub labels on issue sync.
 
 **Auto-dispatch:** Only add `#auto-dispatch` if the brief has: (1) 2+ acceptance criteria beyond "tests pass"/"lint clean", (2) non-empty "How" with file references, (3) clear deliverable in "What".
 
@@ -134,8 +136,8 @@ AI:   Allocated: t325 (ref:GH#1260)
 
 User: 2
 AI:   Added and claimed:
-      - TODO.md: - [ ] t325 Add CSV export button #feature #auto-dispatch ~1h ref:GH#1260
-      - Issue #1260: assigned + status:in-progress
+      - TODO.md: - [ ] t325 Add CSV export button #feature #interactive #auto-dispatch ~1h ref:GH#1260
+      - Issue #1260: assigned + status:in-progress + origin:interactive
       Pulse workers will skip until you release or 3h stale recovery kicks in.
 ```
 

--- a/.agents/scripts/findings-to-tasks-helper.sh
+++ b/.agents/scripts/findings-to-tasks-helper.sh
@@ -235,7 +235,11 @@ create_task_for_finding() {
 	local today=""
 	today="$(date +%Y-%m-%d)"
 
-	local todo_line="- [ ] ${task_id} ${title} ${tags}"
+	# Add session origin tag (#worker or #interactive)
+	local origin_tag=""
+	origin_tag="#$(detect_session_origin)"
+
+	local todo_line="- [ ] ${task_id} ${title} ${tags} ${origin_tag}"
 	if [[ -n "$issue_ref" && "$issue_ref" != "offline" ]]; then
 		todo_line+=" ref:${issue_ref}"
 	fi


### PR DESCRIPTION
## Summary

Follow-up to v3.5.131 (PR #12568) which added `origin:worker`/`origin:interactive` GitHub labels to issues. This PR closes the gap where the TODO.md entries themselves didn't include the corresponding `#worker`/`#interactive` tags.

- `findings-to-tasks-helper.sh`: appends `#worker` or `#interactive` tag via `detect_session_origin()` when constructing TODO lines
- `new-task.md` Step 6: template now includes `#{origin}` placeholder with detection guidance for agents
- `define.md`: headless mode step list notes `#worker` tag addition

## Runtime Testing

- **Level:** self-assessed
- **Risk:** Low (tag-only addition to TODO lines, no behavioral change)
- **Verification:** Tested TODO line construction in bash — `#worker` tag correctly appended


---
[aidevops.sh](https://aidevops.sh) v3.5.131 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6