### PR TITLE
feat: add origin:worker/origin:interactive labels to PR creation

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -121,7 +121,7 @@ Changelog: `feat:` → Added, `fix:` → Fixed, `docs:`/`perf:`/`refactor:` → 
 
 **4.1 Preflight:** Quality checks, auto-fixes. See `workflows/preflight.md`.
 
-**4.2 PR Create:** Verify `gh auth`, rebase onto `origin/main`, push, create PR. **PR body MUST include `Closes #NNN`** (only mechanism creating a GitHub PR-issue link). Backtick-escape issue refs in bug descriptions to avoid unintended closes. **Append signature footer** to the PR body: run `SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL")` and append `${SIG_FOOTER}` as the last content in the `--body`.
+**4.2 PR Create:** Verify `gh auth`, rebase onto `origin/main`, push, create PR. **PR body MUST include `Closes #NNN`** (only mechanism creating a GitHub PR-issue link). Backtick-escape issue refs in bug descriptions to avoid unintended closes. **Append signature footer** to the PR body: run `SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL")` and append `${SIG_FOOTER}` as the last content in the `--body`. **Add origin label** to the PR: include `--label "origin:worker"` or `--label "origin:interactive"` based on session type (detect via `detect_session_origin` from `shared-constants.sh`, or infer: headless → worker, user present → interactive).
 
 ### 4.3 Label Update — `status:in-review` (t1343 — MANDATORY)
 

--- a/.agents/scripts/github-cli-helper.sh
+++ b/.agents/scripts/github-cli-helper.sh
@@ -425,6 +425,11 @@ create_pr() {
 		gh_args+=("--body" "$body")
 	fi
 
+	# Add session origin label (origin:worker or origin:interactive)
+	local origin_label
+	origin_label=$(session_origin_label)
+	gh_args+=("--label" "$origin_label")
+
 	if gh pr create "${gh_args[@]}"; then
 		print_success "$SUCCESS_PR_CREATED"
 	else

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -1218,12 +1218,19 @@ _push_and_create_pr() {
 	sig_footer=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$pr_body" 2>/dev/null || true)
 	pr_body="${pr_body}${sig_footer}"
 
+	# Detect session origin for PR label
+	local origin_label="origin:worker"
+	if type detect_session_origin &>/dev/null; then
+		origin_label="origin:$(detect_session_origin)"
+	fi
+
 	local pr_create_output
 	pr_create_output=$(gh pr create \
 		--head "$branch_name" \
 		--base "$default_branch" \
 		--title "$pr_title" \
 		--body "$pr_body" \
+		--label "$origin_label" \
 		--repo "$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo '')" \
 		2>&1) || {
 		log_error "Failed to create PR for $label: ${pr_create_output}"
@@ -1653,7 +1660,13 @@ ${failed_note}
 
 	local repo_name_with_owner
 	repo_name_with_owner=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
-	local pr_create_args=("--head" "$branch_name" "--base" "$default_branch" "--title" "$pr_title" "--body" "$pr_body")
+	# Detect session origin for PR label
+	local batch_origin_label="origin:worker"
+	if type detect_session_origin &>/dev/null; then
+		batch_origin_label="origin:$(detect_session_origin)"
+	fi
+
+	local pr_create_args=("--head" "$branch_name" "--base" "$default_branch" "--title" "$pr_title" "--body" "$pr_body" "--label" "$batch_origin_label")
 	if [[ -n "$repo_name_with_owner" ]]; then
 		pr_create_args+=("--repo" "$repo_name_with_owner")
 	fi


### PR DESCRIPTION
## Summary

Closes the gap where issues got `origin:worker`/`origin:interactive` labels (v3.5.131) but PRs did not. Now all PR creation paths include the origin label.

- `full-loop.md` Step 4.2: instructs agents to include `--label origin:*` on `gh pr create`
- `github-cli-helper.sh` `create_pr()`: adds origin label programmatically via `session_origin_label()`
- `skill-update-helper.sh`: both single-skill and batch PR creation paths add the label

## Runtime Testing

- **Level:** self-assessed
- **Risk:** Low (additive label on PR creation, no behavioral change)


---
[aidevops.sh](https://aidevops.sh) v3.5.131 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6