### PR TITLE
GH#12564: tighten agent doc ManyReach

### DIFF
--- a/.agents/services/outreach/manyreach.md
+++ b/.agents/services/outreach/manyreach.md
@@ -18,159 +18,86 @@ tools:
 - **Credential**: `MANYREACH_API_KEY` — set via `aidevops secret set MANYREACH_API_KEY`
 - **Docs**: https://docs.manyreach.com
 - **Strategy context**: `services/outreach/cold-outreach.md`
+- **Verify connectivity**: `scripts/manyreach-helper.sh status`
 
-## Setup
+## Core Commands
 
-```bash
-# Store API key securely
-aidevops secret set MANYREACH_API_KEY
+### Campaigns
 
-# Verify connectivity
-scripts/manyreach-helper.sh status
-```
+- `manyreach-helper.sh campaigns list`
+- `manyreach-helper.sh campaigns get <campaign_id>`
+- `manyreach-helper.sh campaigns create --name "Q2 Outreach" --from-email sender@yourdomain.com`
+- `manyreach-helper.sh campaigns pause <campaign_id>`
+- `manyreach-helper.sh campaigns resume <campaign_id>`
+- `manyreach-helper.sh campaigns delete <campaign_id>`
+- `manyreach-helper.sh stats campaign <campaign_id>`
 
-## Campaigns
+### Leads
 
-Campaigns are the top-level container for outreach sequences and leads.
+- `manyreach-helper.sh leads list [--campaign <campaign_id>] [--page N]`
+- `manyreach-helper.sh leads get <lead_id>`
+- `manyreach-helper.sh leads unsubscribe <lead_id>`
+- `manyreach-helper.sh leads import --campaign <campaign_id> --file prospects.csv`
 
-```bash
-# List all campaigns
-scripts/manyreach-helper.sh campaigns list
-
-# Get campaign details
-scripts/manyreach-helper.sh campaigns get <campaign_id>
-
-# Create a campaign
-scripts/manyreach-helper.sh campaigns create --name "Q2 Outreach" --from-email sender@yourdomain.com
-
-# Pause / resume
-scripts/manyreach-helper.sh campaigns pause <campaign_id>
-scripts/manyreach-helper.sh campaigns resume <campaign_id>
-
-# Delete
-scripts/manyreach-helper.sh campaigns delete <campaign_id>
-
-# Campaign performance stats
-scripts/manyreach-helper.sh stats campaign <campaign_id>
-```
-
-## Leads
-
-Leads are the contacts enrolled in a campaign.
+Add a single lead:
 
 ```bash
-# List leads (all, or filtered by campaign)
-scripts/manyreach-helper.sh leads list
-scripts/manyreach-helper.sh leads list --campaign <campaign_id>
-scripts/manyreach-helper.sh leads list --campaign <campaign_id> --page 2
-
-# Get a single lead
-scripts/manyreach-helper.sh leads get <lead_id>
-
-# Add a single lead to a campaign
-scripts/manyreach-helper.sh leads add \
+manyreach-helper.sh leads add \
   --campaign <campaign_id> \
   --email prospect@company.com \
   --first-name Jane \
   --last-name Smith \
   --company "Acme Corp"
-
-# Bulk import from CSV
-# CSV must have headers: email, first_name, last_name, company (at minimum)
-scripts/manyreach-helper.sh leads import \
-  --campaign <campaign_id> \
-  --file prospects.csv
-
-# Unsubscribe a lead
-scripts/manyreach-helper.sh leads unsubscribe <lead_id>
 ```
 
-## Sequences
+### Sequences
 
-Sequences define the email steps (subject, body, delay) within a campaign.
+- `manyreach-helper.sh sequences list --campaign <campaign_id>`
+- `manyreach-helper.sh sequences get <sequence_id>`
 
 ```bash
-# List sequences for a campaign
-scripts/manyreach-helper.sh sequences list --campaign <campaign_id>
-
-# Get a sequence step
-scripts/manyreach-helper.sh sequences get <sequence_id>
-
-# Add a step to a sequence
-scripts/manyreach-helper.sh sequences add-step \
+manyreach-helper.sh sequences add-step \
   --sequence <sequence_id> \
   --subject "Following up on my last email" \
   --body "Hi {{first_name}}, just wanted to check in..." \
   --delay-days 3
 ```
 
-## Mailboxes
+### Mailboxes
 
-Mailboxes are the sending email accounts connected to ManyReach.
+- `manyreach-helper.sh mailboxes list`
+- `manyreach-helper.sh mailboxes get <mailbox_id>` — includes status, warmup, daily limits
 
-```bash
-# List all mailboxes
-scripts/manyreach-helper.sh mailboxes list
-
-# Get mailbox details (status, warmup, daily limits)
-scripts/manyreach-helper.sh mailboxes get <mailbox_id>
-```
-
-## JSON Output
-
-All commands accept `--json` to return raw API JSON for scripting:
-
-```bash
-scripts/manyreach-helper.sh campaigns list --json | jq '.data[].id'
-scripts/manyreach-helper.sh stats campaign <id> --json | jq '{sent, replied}'
-```
+All commands accept `--json` for raw API output (e.g., `campaigns list --json | jq '.data[].id'`).
 
 ## Operational Notes
 
 ### Sending Limits
 
-ManyReach enforces per-mailbox daily limits. Check current usage before scaling:
+Per-mailbox daily limits enforced. Check `mailboxes get <id>` for `daily_limit` and `sent_today`. Warmup ramp and hard cap (100/day): see `services/outreach/cold-outreach.md`.
 
-```bash
-scripts/manyreach-helper.sh mailboxes get <mailbox_id>
-# Review: daily_limit and sent_today fields
-```
+### Personalisation
 
-Follow the warmup ramp from `services/outreach/cold-outreach.md`:
-- Week 1: 5–8/day per mailbox
-- Week 4+: up to 20/day per stable mailbox
-- Hard cap: 100/day per mailbox (all outbound activity combined)
-
-### Sequence Personalisation
-
-ManyReach supports `{{variable}}` merge tags in subject and body fields:
-
-| Tag | Source |
-|-----|--------|
-| `{{first_name}}` | Lead `first_name` field |
-| `{{last_name}}` | Lead `last_name` field |
-| `{{company}}` | Lead `company` field |
-| `{{email}}` | Lead `email` field |
-
-Keep variation high across sequence steps to reduce template fingerprinting.
+Merge tags in subject/body: `{{first_name}}`, `{{last_name}}`, `{{company}}`, `{{email}}`. Custom CSV fields also available as merge tags. Keep variation high across steps to reduce template fingerprinting.
 
 ### Reply Handling
 
-ManyReach auto-stops sequences on any reply. After a reply:
+Auto-stops sequences on any reply. Post-reply workflow:
+
 1. Classify: positive, neutral, objection, or unsubscribe
-2. Route positive/high-intent replies to a human owner with SLA
+2. Route positive/high-intent to human owner with SLA
 3. Feed objection patterns back into copy and segmentation
 
 ### Compliance
 
-- Include a physical postal address in every campaign email
-- Provide a one-click unsubscribe mechanism
-- Honor opt-out requests immediately — use `leads unsubscribe` to suppress
-- For EU/UK contacts: document legitimate interest basis before sending
+- Physical postal address in every campaign email
+- One-click unsubscribe mechanism required
+- Honor opt-outs immediately — `leads unsubscribe <lead_id>`
+- EU/UK contacts: document legitimate interest basis before sending
 
 ### CSV Import Format
 
-Minimum required columns for bulk import:
+Minimum columns: `email,first_name,last_name,company`. Additional custom fields pass through as merge tags.
 
 ```csv
 email,first_name,last_name,company
@@ -178,8 +105,6 @@ jane@acme.com,Jane,Smith,Acme Corp
 bob@example.com,Bob,Jones,Example Ltd
 ```
 
-Additional custom fields are passed through as merge tags if the campaign template references them.
-
 <!-- AI-CONTEXT-END -->
 
-Use this document for ManyReach-specific execution. For platform selection, warmup strategy, and compliance baseline, read `services/outreach/cold-outreach.md`.
+For platform selection, warmup strategy, and compliance baseline: `services/outreach/cold-outreach.md`.


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/outreach/manyreach.md` from 185 to 110 lines (40% reduction)
- Consolidated per-section code blocks into compact "Core Commands" list format (matching `instantly.md` pattern)
- Removed duplicate Setup section (already in Quick Reference), removed redundant warmup ramp (points to `cold-outreach.md`), compressed personalisation table to inline note
- All commands, URLs, merge tags, compliance rules, and CSV format preserved — verified via automated content checks

## Runtime Testing

- **Level**: `self-assessed`
- **Risk**: Low (docs/agent prompt only, no code logic)
- **Verification**: markdownlint clean, all 18 helper commands present, all 4 merge tags present, all compliance rules present, all cross-references intact

Closes #12564

---
[aidevops.sh](https://aidevops.sh) v3.5.131 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6