### PR TITLE
GH#12413: tighten sandbox-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md
@@ -1,6 +1,6 @@
 # Common Patterns
 
-All patterns use the Worker boilerplate from `sandbox.md` Quick Start. First example shows the full Worker; subsequent examples show only the handler body.
+All patterns use the Worker boilerplate from `sandbox.md` Quick Start. Subsequent examples show only the handler body.
 
 ## AI Code Execution Agent
 
@@ -106,9 +106,8 @@ return Response.json({ success: result.success, notebook: JSON.parse(output.cont
 
 ```typescript
 await sandbox.exec('git clone https://github.com/user/repo.git /workspace/repo');
-await sandbox.exec('git clone -b main --single-branch https://github.com/user/repo.git /workspace/repo');
-const token = env.GITHUB_TOKEN; // Authenticated clone
-await sandbox.exec(`git clone https://${token}@github.com/user/private-repo.git`);
+await sandbox.exec('git clone -b main --single-branch https://github.com/user/repo.git /workspace/repo'); // shallow
+await sandbox.exec(`git clone https://${env.GITHUB_TOKEN}@github.com/user/private-repo.git`); // authenticated
 await sandbox.exec('git pull', { cwd: '/workspace/repo' });
 await sandbox.exec('git checkout -b feature', { cwd: '/workspace/repo' });
 ```


### PR DESCRIPTION
## Summary

- Remove redundant intro clause ("First example shows the full Worker" — self-evident from the code)
- Inline `env.GITHUB_TOKEN` to eliminate a dead intermediate `const token` line
- Add `// shallow` and `// authenticated` inline comments to distinguish the two `git clone` variants (previously the comment was misplaced on the `const token` line, not the exec that used it)

## Changes

| File | What/Why |
|------|----------|
| `.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md` | Tighten from 114 → 113 lines; remove noise, improve Git Operations clarity |

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only — no code execution)
- **Level**: self-assessed
- **Smoke check**: Content verified — all code blocks, URLs, and command examples preserved

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12413

---
[aidevops.sh](https://aidevops.sh) v3.5.132 plugin for [OpenCode](https://opencode.ai) v1.3.4 with claude-sonnet-4-6 spent 1m and 706,145 tokens on this as a headless worker.