### PR TITLE
GH#12531: tighten agent doc shadcn/ui MCP Server

### DIFF
--- a/.agents/tools/ui/shadcn.md
+++ b/.agents/tools/ui/shadcn.md
@@ -24,27 +24,20 @@ mcp:
 - **Purpose**: Browse, search, and install shadcn/ui components via MCP
 - **MCP Config**: `configs/mcp-templates/shadcn.json`
 - **Docs**: https://ui.shadcn.com/docs/mcp
-- **Registry Docs**: https://ui.shadcn.com/docs/registry/mcp
 
 **When to use**: User asks for UI components; mentions "shadcn", "radix", or component names; project has `components.json` in root.
 
-**MCP tools**: browse registries, search by name/function, install components, work with multiple registries.
-
-**Components**: accordion, alert, alert-dialog, aspect-ratio, avatar, badge, breadcrumb, button, button-group, calendar, card, carousel, chart, checkbox, collapsible, combobox, command, context-menu, data-table, date-picker, dialog, drawer, dropdown-menu, empty, field, form, hover-card, input, input-group, input-otp, item, kbd, label, menubar, native-select, navigation-menu, pagination, popover, progress, radio-group, resizable, scroll-area, select, separator, sheet, sidebar, skeleton, slider, sonner, spinner, switch, table, tabs, textarea, toast, toggle, toggle-group, tooltip, typography
+**MCP tools**: browse registries, search by name/function, install components, work with multiple registries. Use the MCP browse tool to list available components (do not rely on a static list).
 
 <!-- AI-CONTEXT-END -->
 
 ## Setup
 
-Init project (creates `components.json`):
-
-```bash
-npx shadcn@latest init
-```
+Init project (creates `components.json`): `npx shadcn@latest init`
 
 ### MCP Configuration
 
-MCP server config — key and file path differ per client:
+Config key and file path differ per client:
 
 | Client | Config file | Key |
 |--------|-------------|-----|
@@ -62,15 +55,9 @@ MCP server config — key and file path differ per client:
 }
 ```
 
-## Usage Examples
-
-- "Show me all available components" / "Find a login form" / "What dialog components exist?"
-- "Add button, dialog and card components" / "Install form with all dependencies"
-- "Create a contact form / landing page / dashboard layout using shadcn components"
-
 ## Multiple Registries
 
-Configure in `components.json`:
+Add to `components.json`. Use namespace syntax (`@acme/component-name`). Set auth tokens in `.env.local`.
 
 ```json
 {
@@ -84,26 +71,17 @@ Configure in `components.json`:
 }
 ```
 
-Use namespace syntax: `"Install @internal/auth-form"`. Set auth tokens in `.env.local`.
-
 ## Troubleshooting
 
 | Problem | Fix |
 |---------|-----|
 | MCP not responding | Check config; restart client; `npx shadcn@latest --version`; `/mcp` in Claude Code |
-| No tools available | `npx clear-npx-cache`; re-enable server; check logs (Cursor: View → Output → MCP: project-*) |
+| No tools available | `npx clear-npx-cache`; re-enable server; check logs (Cursor: View -> Output -> MCP: project-*) |
 | Registry access | Verify URLs in `components.json`; check auth env vars |
 
 ## Integration with aidevops
 
 1. **Detection**: `components.json` in root = shadcn project
 2. **Installation**: use shadcn MCP for component management
-3. **Styling**: Tailwind CSS — ensure configured
+3. **Styling**: Tailwind CSS -- ensure configured
 4. **Forms**: pair with React Hook Form or TanStack Form (see `tools/browser/` for testing)
-
-## Related Resources
-
-- [shadcn/ui Documentation](https://ui.shadcn.com/docs)
-- [Component Registry](https://ui.shadcn.com/docs/components)
-- [Blocks & Templates](https://ui.shadcn.com/blocks)
-- [Theming Guide](https://ui.shadcn.com/docs/theming)


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/ui/shadcn.md` from 109 to 87 lines (20% reduction)
- Remove static component list that goes stale on shadcn releases; replaced with guidance to use MCP browse tool
- Remove Usage Examples section (user prompt examples, not agent instructions)
- Remove redundant Related Resources links (main docs URL already in Quick Reference)
- Inline init command, compress registry section prose

## What changed

| Section | Action |
|---------|--------|
| Components list (line 33) | Removed — 57 static names that go stale; replaced with "use MCP browse tool" |
| Usage Examples | Removed — prompt examples for users, not agent instructions |
| Related Resources | Removed — main docs URL already in Quick Reference; rest discoverable from there |
| Setup init command | Inlined into single line (was code block) |
| Registry section | Compressed prose, merged namespace/auth guidance |
| Registry Docs URL | Removed (redundant with main docs URL) |

## Content preservation

All code blocks, MCP config JSON, troubleshooting table, client config table, and integration guidance preserved. No task IDs in original. Frontmatter unchanged.

## Runtime Testing

- Level: self-assessed
- Risk: low (docs/agent prompt only, no code changes)
- No runtime verification needed per testing gate

Closes #12531


---
[aidevops.sh](https://aidevops.sh) v3.5.134 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6