### PR TITLE
GH#12600: tighten hono.md — remove noise, redundant section

### DIFF
--- a/.agents/tools/api/hono.md
+++ b/.agents/tools/api/hono.md
@@ -6,7 +6,6 @@ tools:
   write: true
   edit: true
   bash: true
-  glob: true
   grep: true
   webfetch: true
   task: true
@@ -14,8 +13,6 @@ tools:
 ---
 
 # Hono - Lightweight Web Framework
-
-<!-- AI-CONTEXT-START -->
 
 **Purpose**: TypeScript-first lightweight API framework. Runs on Edge/Node.js/Bun/Deno/Cloudflare Workers. Full type inference, built-in middleware (CORS, auth, validation), type-safe RPC client.
 **Docs**: Context7 MCP for current documentation.
@@ -73,8 +70,6 @@ export const GET = handle(app);
 export const POST = handle(app);
 ```
 
-<!-- AI-CONTEXT-END -->
-
 ## Middleware
 
 ```tsx
@@ -128,16 +123,6 @@ const users = new Hono()
   .get("/:id", (c) => c.json({ id: c.req.param("id") }))
   .post("/", (c) => c.json({ created: true }));
 app.route("/api/users", users);
-```
-
-## Context Variables
-
-```tsx
-app.use("*", async (c, next) => {
-  c.set("user", await getAuthUser(c.req.header("Authorization")));
-  await next();
-});
-app.get("/api/profile", (c) => c.json(c.get("user")));
 ```
 
 ## Streaming


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/api/hono.md` (188 → 173 lines) per issue #12600 simplification scan.

### Changes

- **Remove `glob: true`** from frontmatter — Hono agents use context7 MCP + grep for discovery; glob is not needed
- **Remove `<!-- AI-CONTEXT-START/END -->` markers** — no functional value in this instruction doc
- **Remove standalone "Context Variables" section** — `c.set`/`c.get` pattern already demonstrated in the auth middleware example (`c.set("user", user)`); the section was pure redundancy

### Verification

- All code blocks present: basic routes, Zod validation, RPC client, Next.js, middleware/auth, error handling, grouped routes, streaming, file uploads ✓
- Common Mistakes table intact ✓
- Related links intact ✓
- No broken references ✓
- 188 → 173 lines (−15 lines, −8%)

### Runtime Testing

- **Risk level**: Low (docs/agent prompt — no runtime code)
- **Level**: self-assessed
- Agent behaviour unchanged — all actionable patterns preserved

Closes #12600

---

## Actionable Findings

actionable_findings_total=0
fixed_in_pr=0
deferred_tasks_created=0
coverage=100%


---
[aidevops.sh](https://aidevops.sh) v3.5.146 plugin for [OpenCode](https://opencode.ai) v1.3.4 with claude-sonnet-4-6 spent 1m and 524,757 tokens on this as a headless worker.