### PR TITLE
GH#12471: tighten browser-use.md — remove redundant Key Features section

### DIFF
--- a/.agents/tools/browser/browser-use.md
+++ b/.agents/tools/browser/browser-use.md
@@ -82,7 +82,7 @@ agent = Agent(task="...", llm=ChatAnthropic(model="claude-sonnet-4-6"))
 
 ## CLI
 
-Persistent browser automation from the command line -- the browser stays running between commands:
+Persistent browser session from the command line:
 
 ```bash
 browser-use open https://example.com    # Navigate to URL
@@ -95,25 +95,12 @@ browser-use close                       # Close browser
 
 ## Templates
 
-Generate ready-to-run starter files:
-
 ```bash
 uvx browser-use init --template default    # Minimal setup
 uvx browser-use init --template advanced   # All config options with comments
 uvx browser-use init --template tools      # Custom tools examples
 uvx browser-use init --template default --output my_agent.py  # Custom path
 ```
-
-## Key Features
-
-- **Vision + DOM**: Combines screenshot analysis with DOM extraction for robust element identification
-- **Multi-tab support**: Navigate across multiple tabs and windows
-- **File handling**: Upload and download files
-- **Form filling**: Intelligent form detection and completion
-- **Error recovery**: Automatic retry with alternative strategies
-- **Custom tools**: Register Python functions as agent tools
-- **CLI**: Persistent browser session with element-indexed interaction
-- **Cloud mode**: Stealth browsers with CAPTCHA handling via Browser Use Cloud
 
 ## Custom Tools
 
@@ -135,8 +122,6 @@ agent = Agent(
 ```
 
 ## Cloud Mode
-
-Use managed stealth browsers for CAPTCHA handling, proxy rotation, and scalable parallel execution:
 
 ```python
 from browser_use import Agent, Browser, ChatBrowserUse


### PR DESCRIPTION
## Summary

- Removes the Key Features section (8 bullets entirely covered by the comparison table)
- Trims verbose section header prose in CLI, Templates, and Cloud Mode sections
- 194 → 179 lines (8% reduction); all code examples, URLs, and actionable content preserved

## Changes

- `.agents/tools/browser/browser-use.md` — removed redundant Key Features section; tightened CLI/Templates/Cloud Mode headers

## Runtime Testing

- **Risk level**: Low (docs/agent prompt — no code)
- **Level**: self-assessed
- **Verification**: content diff confirms all code blocks, URLs, command examples, and comparison table intact

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12471


---
[aidevops.sh](https://aidevops.sh) v3.5.147 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 2,906 tokens on this as a headless worker.