### PR TITLE
GH#12474: simplification: tighten gitea-cli.md from 193 to 105 lines

### DIFF
--- a/.agents/tools/git/gitea-cli.md
+++ b/.agents/tools/git/gitea-cli.md
@@ -12,66 +12,34 @@ tools:
   task: true
 ---
 
-# Gitea CLI Helper Documentation
+# Gitea CLI Helper
 
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
-- **CLI Tool**: `tea` (Gitea CLI)
-- **Install**: `brew install tea` (macOS) | `go install code.gitea.io/tea/cmd/tea@latest`
+- **Install**: `brew install tea` | `go install code.gitea.io/tea/cmd/tea@latest` | [dl.gitea.io](https://dl.gitea.io/tea/)
 - **Auth**: `tea login add --name <name> --url <url> --token <token>`
-- **Config**: `configs/gitea-cli-config.json`
+- **Config**: `configs/gitea-cli-config.json` (copy from `configs/gitea-cli-config.json.txt`)
 - **Script**: `.agents/scripts/gitea-cli-helper.sh`
-- **Requires**: `jq` for JSON parsing
-
-**Commands**: `list-repos|create-repo|delete-repo|list-issues|create-issue|close-issue|list-prs|create-pr|merge-pr|list-branches|create-branch`
+- **Requires**: `jq`
 
 **Usage**: `./providers/gitea-cli-helper.sh [command] [account] [args]`
 
-**Multi-Instance**: Account name in config MUST match `tea` login name
-**Note**: Token in JSON used for API calls tea doesn't support (e.g., branch creation)
+**Commands**: `list-repos|create-repo|get-repo|delete-repo|list-issues|create-issue|close-issue|list-prs|create-pr|merge-pr|list-branches|create-branch`
+
+**Multi-account**: Account name in config MUST match `tea` login name. Token in JSON used for API calls `tea` doesn't support (e.g., branch creation).
+
 <!-- AI-CONTEXT-END -->
-
-## Overview
-
-The Gitea CLI Helper provides a comprehensive interface for managing Gitea repositories, issues, pull requests, and branches directly from the command line. It leverages the `tea` CLI tool and the Gitea API to offer a seamless experience for developers working with one or multiple Gitea instances.
-
-## Prerequisites
-
-1. **Gitea CLI (`tea`)**: Must be installed.
-    - **Homebrew (macOS/Linux)**: `brew install tea`
-    - **Go**: `go install code.gitea.io/tea/cmd/tea@latest`
-    - **Binary**: Download from [dl.gitea.io](https://dl.gitea.io/tea/)
-2. **`jq`**: JSON processor (required for configuration parsing).
-3. **Authentication**: You must authenticate `tea` with your Gitea instance(s).
 
 ## Configuration
 
-The helper uses a JSON configuration file located at `configs/gitea-cli-config.json`.
-
-### Setup
-
-1. Copy the template:
-
-    ```bash
-    cp configs/gitea-cli-config.json.txt configs/gitea-cli-config.json
-    ```
-
-2. Edit `configs/gitea-cli-config.json` with your account details.
-
-### Multi-Account Support
-
-The configuration supports multiple accounts (e.g., `primary`, `work`, `selfhosted`). Each account in the JSON config MUST match a login name configured in `tea`.
-
-**1. Authenticate `tea`:**
+Account names in `configs/gitea-cli-config.json` must match `tea` login names:
 
 ```bash
 tea login add --name work --url https://git.company.com --token <your_token>
 tea login add --name personal --url https://gitea.com --token <your_token>
 ```
-
-**2. Update `configs/gitea-cli-config.json`:**
 
 ```json
 {
@@ -79,7 +47,7 @@ tea login add --name personal --url https://gitea.com --token <your_token>
     "work": {
       "api_url": "https://git.company.com/api/v1",
       "owner": "your-work-username",
-      "token": "<your_token>", 
+      "token": "<your_token>",
       "default_visibility": "private"
     },
     "personal": {
@@ -92,102 +60,46 @@ tea login add --name personal --url https://gitea.com --token <your_token>
 }
 ```
 
-*Note: The `token` in the JSON is primarily used for API calls that `tea` doesn't support yet (e.g., creating branches).*
+## Commands
 
-## Usage
-
-Run the helper script:
+### Repositories
 
 ```bash
-./providers/gitea-cli-helper.sh [command] [account] [arguments]
+./providers/gitea-cli-helper.sh list-repos personal
+./providers/gitea-cli-helper.sh get-repo personal my-repo
+# create-repo <account> <name> [desc] [visibility] [auto_init]
+./providers/gitea-cli-helper.sh create-repo personal my-repo "Description" private true
+./providers/gitea-cli-helper.sh delete-repo personal my-repo
 ```
 
-### Repository Management
+### Issues
 
-- **List Repositories**:
+```bash
+./providers/gitea-cli-helper.sh list-issues personal my-repo open
+./providers/gitea-cli-helper.sh create-issue personal my-repo "Bug Title" "Issue body"
+./providers/gitea-cli-helper.sh close-issue personal my-repo 1
+```
 
-    ```bash
-    ./providers/gitea-cli-helper.sh list-repos personal
-    ```
+### Pull Requests
 
-- **Create Repository**:
+```bash
+./providers/gitea-cli-helper.sh list-prs personal my-repo open
+# create-pr <account> <repo> <title> <head_branch> [base_branch] [body]
+./providers/gitea-cli-helper.sh create-pr personal my-repo "Feature X" feature-branch main "Description"
+# merge-pr <account> <repo> <pr_number> [method]
+./providers/gitea-cli-helper.sh merge-pr personal my-repo 1 squash
+```
 
-    ```bash
-    # Usage: create-repo <account> <name> [desc] [visibility] [auto_init]
-    ./providers/gitea-cli-helper.sh create-repo personal my-new-repo "Description" private true
-    ```
+### Branches
 
-- **Get Repository Details**:
-
-    ```bash
-    ./providers/gitea-cli-helper.sh get-repo personal my-new-repo
-    ```
-
-- **Delete Repository**:
-
-    ```bash
-    ./providers/gitea-cli-helper.sh delete-repo personal my-new-repo
-    ```
-
-### Issue Management
-
-- **List Issues**:
-
-    ```bash
-    ./providers/gitea-cli-helper.sh list-issues personal my-repo open
-    ```
-
-- **Create Issue**:
-
-    ```bash
-    ./providers/gitea-cli-helper.sh create-issue personal my-repo "Bug Title" "Issue description body"
-    ```
-
-- **Close Issue**:
-
-    ```bash
-    ./providers/gitea-cli-helper.sh close-issue personal my-repo 1
-    ```
-
-### Pull Request Management
-
-- **List Pull Requests**:
-
-    ```bash
-    ./providers/gitea-cli-helper.sh list-prs personal my-repo open
-    ```
-
-- **Create Pull Request**:
-
-    ```bash
-    # Usage: create-pr <account> <repo> <title> <head_branch> [base_branch] [body]
-    ./providers/gitea-cli-helper.sh create-pr personal my-repo "Feature X" feature-branch main "Description"
-    ```
-
-- **Merge Pull Request**:
-
-    ```bash
-    # Usage: merge-pr <account> <repo> <pr_number> [method]
-    ./providers/gitea-cli-helper.sh merge-pr personal my-repo 1 squash
-    ```
-
-### Branch Management
-
-- **List Branches**:
-
-    ```bash
-    ./providers/gitea-cli-helper.sh list-branches personal my-repo
-    ```
-
-- **Create Branch**:
-
-    ```bash
-    # Usage: create-branch <account> <repo> <new_branch> [source_branch]
-    ./providers/gitea-cli-helper.sh create-branch personal my-repo feature-branch main
-    ```
+```bash
+./providers/gitea-cli-helper.sh list-branches personal my-repo
+# create-branch <account> <repo> <new_branch> [source_branch]
+./providers/gitea-cli-helper.sh create-branch personal my-repo feature-branch main
+```
 
 ## Troubleshooting
 
-- **"Gitea CLI is not authenticated"**: Run `tea login list` to see configured logins. Ensure the `account` name you use in the script command matches one of these logins.
-- **"Owner not configured"**: Check `configs/gitea-cli-config.json` and ensure the `owner` field is set for the account you are using.
-- **API Errors**: Verify your `token` in the configuration file is correct and has sufficient scopes.
+- **"Gitea CLI is not authenticated"**: `tea login list` — account name must match a configured login.
+- **"Owner not configured"**: Set `owner` in `configs/gitea-cli-config.json` for the account.
+- **API Errors**: Verify token has sufficient scopes.


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/git/gitea-cli.md` per simplification-debt scan (GH#12474).

- Removed: Overview fluff, duplicated Prerequisites section, verbose section intros, per-command bullet labels
- Consolidated: all commands into grouped code blocks (repos/issues/PRs/branches)
- Preserved: all commands, config JSON schema, multi-account setup, URLs, troubleshooting entries
- Result: 193 → 105 lines (46% reduction), zero content loss

Closes #12474

## Runtime Testing

- **Risk level**: Low (docs-only change — agent prompt file)
- **Verification**: self-assessed — content preservation verified by diff review; all code blocks, URLs, and command signatures present before and after

## Files Changed

- `.agents/tools/git/gitea-cli.md` — removed noise, consolidated command examples


---
[aidevops.sh](https://aidevops.sh) v3.5.147 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 2,983 tokens on this as a headless worker.