### PR TITLE
GH#12100: tighten addons-ref.md from 248 to 222 lines

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
@@ -1,24 +1,20 @@
 # Addons Reference
 
-Full environment variable and option reference for Cloudron addons. Declare addons in `CloudronManifest.json` under the `addons` key.
-
-Read env vars at runtime on every start — values can change across restarts.
+Env var and option reference for Cloudron addons. Declare in `CloudronManifest.json` under `addons`. Read env vars at runtime on every start — values can change across restarts.
 
 ## localstorage
 
-Provides writable `/app/data` directory. Contents are backed up. Directory is empty on first install; files from the Docker image are not present. Restore permissions in `start.sh`.
+Writable `/app/data` directory. Backed up. Empty on first install (Docker image files not present). Restore permissions in `start.sh`.
 
-Options:
-
-- `ftp` — Enable FTP access: `{ "ftp": { "uid": 33, "uname": "www-data" } }`
-- `sqlite` — Declare SQLite files for consistent backup: `{ "sqlite": { "paths": ["/app/data/db.sqlite"] } }`
+- `ftp` — FTP access: `{ "ftp": { "uid": 33, "uname": "www-data" } }`
+- `sqlite` — Consistent backup: `{ "sqlite": { "paths": ["/app/data/db.sqlite"] } }`
 
 ## mysql
 
-MySQL 8.0. Database is pre-created.
+MySQL. Database is pre-created. Default charset: `utf8mb4` / `utf8mb4_unicode_ci`.
 
 ```text
-CLOUDRON_MYSQL_URL          # full connection URL
+CLOUDRON_MYSQL_URL
 CLOUDRON_MYSQL_USERNAME
 CLOUDRON_MYSQL_PASSWORD
 CLOUDRON_MYSQL_HOST
@@ -26,17 +22,13 @@ CLOUDRON_MYSQL_PORT
 CLOUDRON_MYSQL_DATABASE
 ```
 
-Options:
-
 - `multipleDatabases: true` — Provides `CLOUDRON_MYSQL_DATABASE_PREFIX` instead of `CLOUDRON_MYSQL_DATABASE`. Create databases with that prefix.
-
-Default charset: `utf8mb4` / `utf8mb4_unicode_ci`.
 
 Debug: `cloudron exec` then `MYSQL_PWD=$CLOUDRON_MYSQL_PASSWORD mysql --user=$CLOUDRON_MYSQL_USERNAME --host=$CLOUDRON_MYSQL_HOST $CLOUDRON_MYSQL_DATABASE`
 
 ## postgresql
 
-PostgreSQL 14.9.
+PostgreSQL.
 
 ```text
 CLOUDRON_POSTGRESQL_URL
@@ -47,17 +39,15 @@ CLOUDRON_POSTGRESQL_PORT
 CLOUDRON_POSTGRESQL_DATABASE
 ```
 
-Options:
-
 - `locale` — Set `LC_LOCALE` and `LC_CTYPE` at database creation.
 
-Supported extensions: `btree_gist`, `btree_gin`, `citext`, `hstore`, `pgcrypto`, `pg_trgm`, `postgis`, `uuid-ossp`, `unaccent`, `vector`, `vectors`, and more.
+Extensions: `btree_gist`, `btree_gin`, `citext`, `hstore`, `pgcrypto`, `pg_trgm`, `postgis`, `uuid-ossp`, `unaccent`, `vector`, `vectors`, and more.
 
 Debug: `PGPASSWORD=$CLOUDRON_POSTGRESQL_PASSWORD psql -h $CLOUDRON_POSTGRESQL_HOST -p $CLOUDRON_POSTGRESQL_PORT -U $CLOUDRON_POSTGRESQL_USERNAME -d $CLOUDRON_POSTGRESQL_DATABASE`
 
 ## mongodb
 
-MongoDB 8.0.
+MongoDB.
 
 ```text
 CLOUDRON_MONGODB_URL
@@ -69,13 +59,11 @@ CLOUDRON_MONGODB_DATABASE
 CLOUDRON_MONGODB_OPLOG_URL      # only when oplog enabled
 ```
 
-Options:
-
 - `oplog: true` — Enable oplog access.
 
 ## redis
 
-Redis 8.4. Data is persistent.
+Redis. Data is persistent.
 
 ```text
 CLOUDRON_REDIS_URL
@@ -83,8 +71,6 @@ CLOUDRON_REDIS_HOST
 CLOUDRON_REDIS_PORT
 CLOUDRON_REDIS_PASSWORD
 ```
-
-Options:
 
 - `noPassword: true` — Skip password auth (safe: Redis is only reachable on internal Docker network).
 
@@ -127,8 +113,6 @@ CLOUDRON_OIDC_CLIENT_ID
 CLOUDRON_OIDC_CLIENT_SECRET
 ```
 
-Options:
-
 - `loginRedirectUri` — Callback path (e.g. `/auth/openid/callback`). Multiple paths: comma-separated.
 - `logoutRedirectUri` — Post-logout path.
 - `tokenSignatureAlgorithm` — `RS256` (default) or `EdDSA`.
@@ -148,15 +132,13 @@ CLOUDRON_MAIL_FROM_DISPLAY_NAME   # only when supportsDisplayName is set
 CLOUDRON_MAIL_DOMAIN
 ```
 
-Options:
-
 - `optional: true` — All env vars absent; app uses user-provided email config.
 - `supportsDisplayName: true` — Enables `CLOUDRON_MAIL_FROM_DISPLAY_NAME`.
 - `requiresValidCertificate: true` — Sets `CLOUDRON_MAIL_SMTP_SERVER` to FQDN.
 
 ## recvmail
 
-Incoming email (IMAP/POP3).
+Incoming email (IMAP/POP3). May be disabled if the server is not receiving email for the domain — handle absent env vars.
 
 ```text
 CLOUDRON_MAIL_IMAP_SERVER
@@ -170,11 +152,9 @@ CLOUDRON_MAIL_TO
 CLOUDRON_MAIL_TO_DOMAIN
 ```
 
-May be disabled if the server is not receiving email for the domain. Handle absent env vars.
-
 ## email
 
-Full email capabilities (SMTP + IMAP + ManageSieve). For webmail applications.
+Full email (SMTP + IMAP + ManageSieve). For webmail apps. Accept self-signed certificates for internal IMAP/Sieve connections.
 
 ```text
 CLOUDRON_EMAIL_SMTP_SERVER
@@ -191,16 +171,12 @@ CLOUDRON_EMAIL_DOMAINS
 CLOUDRON_EMAIL_SERVER_HOST
 ```
 
-Accept self-signed certificates for internal IMAP/Sieve connections.
-
 ## proxyauth
 
 Authentication wall in front of the app. Reserves `/login` and `/logout` routes.
 
-Options:
-
 - `path` — Restrict to a path (e.g. `/admin`). Prefix with `!` to exclude (e.g. `!/webhooks`).
-- `basicAuth` — Enable HTTP Basic auth (bypasses 2FA).
+- `basicAuth` — HTTP Basic auth (bypasses 2FA).
 - `supportsBearerAuth` — Forward `Bearer` tokens to the app.
 
 Cannot be added to an existing app — reinstall required.
@@ -222,9 +198,7 @@ Commands run in the app's environment (same env vars, access to `/tmp` and `/run
 
 ## tls
 
-Certificate access for non-HTTP protocols.
-
-Files: `/etc/certs/tls_cert.pem`, `/etc/certs/tls_key.pem` (read-only). App restarts on certificate renewal.
+Certificate access for non-HTTP protocols. Files: `/etc/certs/tls_cert.pem`, `/etc/certs/tls_key.pem` (read-only). App restarts on certificate renewal.
 
 ## turn
 


### PR DESCRIPTION
## Summary

- Remove 6× redundant `Options:` headers and surrounding blank lines
- Remove stale version numbers (MySQL 8.0, PostgreSQL 14.9, MongoDB 8.0, Redis 8.4)
- Merge verbose multi-line descriptions to single lines where content is unchanged
- Move inline warnings/notes to section header lines to reduce blank line overhead
- All env vars, options, debug commands, and actionable constraints preserved

248 → 222 lines (11% reduction).

Closes #12100


---
[aidevops.sh](https://aidevops.sh) v3.5.147 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 6m and 7,441 tokens on this as a headless worker.