### PR TITLE
GH#12110: tighten image-generation.md (247 → 143 lines)

### DIFF
--- a/.agents/tools/vision/image-generation.md
+++ b/.agents/tools/vision/image-generation.md
@@ -14,41 +14,6 @@ tools:
 
 # Image Generation
 
-<!-- AI-CONTEXT-START -->
-
-## Quick Reference
-
-- **Purpose**: Generate images from text prompts using AI models
-- **Cloud**: DALL-E 3 (OpenAI), Midjourney, Google Imagen 3, Ideogram
-- **Local**: FLUX (Black Forest Labs), Stable Diffusion XL (Stability AI)
-- **Workflow tool**: ComfyUI (node-based, local), Automatic1111 (web UI, local)
-
-**When to use**: Creating product images, concept art, marketing visuals, UI mockups, social media graphics, or any task requiring new images from text descriptions.
-
-**Quick start** (cloud):
-
-```bash
-# DALL-E 3 via OpenAI API
-curl https://api.openai.com/v1/images/generations \
-  -H "Authorization: Bearer $OPENAI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "dall-e-3",
-    "prompt": "A professional product photo of a laptop on a clean desk",
-    "size": "1024x1024",
-    "quality": "hd"
-  }'
-```
-
-**Quick start** (local):
-
-```bash
-# FLUX via ComfyUI (requires GPU with 12GB+ VRAM)
-# See ComfyUI setup section below
-```
-
-<!-- AI-CONTEXT-END -->
-
 ## Model Comparison
 
 | Model | Provider | Quality | Speed | Cost | Local | Best For |
@@ -62,16 +27,14 @@ curl https://api.openai.com/v1/images/generations \
 | **SD XL** | Stability AI | Good | Fast | Free (local) | Yes | Established ecosystem, ControlNet |
 | **SD 3.5** | Stability AI | High | Medium | Free (local) | Yes | Latest Stability model |
 
-### Choosing a Model
-
 ```text
-Need text rendered in images?     → DALL-E 3 or Ideogram
-Need photorealistic quality?      → Midjourney or Imagen 3
-Need full local control?          → FLUX.1 [dev] or SD XL
-Need fast iteration (local)?      → FLUX.1 [schnell]
-Need ControlNet / img2img?        → SD XL (most mature ecosystem)
-Need API integration?             → DALL-E 3 (simplest API)
-Budget-conscious?                 → FLUX or SD locally (GPU cost only)
+Need text rendered in images?  → DALL-E 3 or Ideogram
+Need photorealistic quality?   → Midjourney or Imagen 3
+Need full local control?       → FLUX.1 [dev] or SD XL
+Need fast iteration (local)?   → FLUX.1 [schnell]
+Need ControlNet / img2img?     → SD XL (most mature ecosystem)
+Need API integration?          → DALL-E 3 (simplest API)
+Budget-conscious?              → FLUX or SD locally (GPU cost only)
 ```
 
 ## Cloud APIs
@@ -79,84 +42,47 @@ Budget-conscious?                 → FLUX or SD locally (GPU cost only)
 ### DALL-E 3 (OpenAI)
 
 ```bash
-# Store API key
 aidevops secret set OPENAI_API_KEY
 
-# Generate image
 curl https://api.openai.com/v1/images/generations \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "model": "dall-e-3",
-    "prompt": "A minimalist logo for a tech startup called Nexus",
-    "size": "1024x1024",
-    "quality": "hd",
-    "style": "natural"
-  }'
+  -d '{"model": "dall-e-3", "prompt": "...", "size": "1024x1024", "quality": "hd", "style": "natural"}'
 ```
 
 | Parameter | Options | Notes |
 |-----------|---------|-------|
 | `size` | 1024x1024, 1024x1792, 1792x1024 | Square, portrait, landscape |
-| `quality` | standard, hd | HD costs 2x but significantly better |
+| `quality` | standard, hd | HD costs 2x; standard $0.04, HD $0.08 per image |
 | `style` | natural, vivid | Natural = photorealistic, vivid = artistic |
-| `n` | 1 | DALL-E 3 only supports 1 image per request |
-
-**Pricing**: Standard $0.04/img, HD $0.08/img (1024x1024). Larger sizes cost more.
-
-**Strengths**: Excellent text rendering, good prompt adherence, simple API.
-
-**Limitations**: No inpainting in v3 API (use v2 for edits), 1 image per request, no negative prompts.
+| `n` | 1 | Only 1 image per request; no inpainting (use v2 API for edits) |
 
 ### Midjourney
 
-Midjourney operates via Discord bot or web interface (no REST API at time of writing).
+No REST API — use Discord `/imagine` or web UI at [midjourney.com](https://www.midjourney.com/).
 
-**Access**: Subscribe at [midjourney.com](https://www.midjourney.com/), use via Discord `/imagine` command or web UI.
-
-**Prompt tips**:
-
-- Use `--ar 16:9` for aspect ratio
-- Use `--v 6` for latest model
-- Use `--style raw` for less stylised output
-- Use `--no text, watermark` for negative prompts
+Prompt flags: `--ar 16:9` (aspect ratio) · `--v 6` (latest model) · `--style raw` (less stylised) · `--no text, watermark` (negatives)
 
 ### Google Imagen 3
 
-Available via Vertex AI API or Google AI Studio.
-
 ```bash
-# Via Vertex AI (requires Google Cloud project)
 curl -X POST \
   "https://us-central1-aiplatform.googleapis.com/v1/projects/$PROJECT_ID/locations/us-central1/publishers/google/models/imagen-3.0-generate-002:predict" \
   -H "Authorization: Bearer $(gcloud auth print-access-token)" \
   -H "Content-Type: application/json" \
-  -d '{
-    "instances": [{"prompt": "A serene mountain landscape at sunset"}],
-    "parameters": {"sampleCount": 1, "aspectRatio": "16:9"}
-  }'
+  -d '{"instances": [{"prompt": "..."}], "parameters": {"sampleCount": 1, "aspectRatio": "16:9"}}'
 ```
 
-## Local Generation
+## Local Generation (ComfyUI)
 
-### ComfyUI (Recommended)
-
-Node-based workflow tool for local image generation. Supports FLUX, SD XL, ControlNet, and custom pipelines.
+Node-based workflow tool supporting FLUX, SD XL, ControlNet, and custom pipelines.
 
 ```bash
-# Install ComfyUI
 git clone https://github.com/comfyanonymous/ComfyUI.git
-cd ComfyUI
-pip install -r requirements.txt
-
-# Download FLUX model (~12GB)
-# Place in ComfyUI/models/checkpoints/
-# Download from https://huggingface.co/black-forest-labs/FLUX.1-dev
-
-# Start ComfyUI
+cd ComfyUI && pip install -r requirements.txt
+# Download FLUX model (~12GB) to ComfyUI/models/checkpoints/
+# https://huggingface.co/black-forest-labs/FLUX.1-dev
 python main.py --listen 0.0.0.0 --port 8188
-
-# Access at http://localhost:8188
 ```
 
 **VRAM requirements**:
@@ -168,56 +94,37 @@ python main.py --listen 0.0.0.0 --port 8188
 | SD XL | 6GB | 8GB+ |
 | SD 3.5 | 8GB | 12GB+ |
 
-### ComfyUI API (Headless)
+**ComfyUI API (headless)**:
 
 ```bash
-# Queue a prompt via API (headless generation)
-curl -X POST http://localhost:8188/prompt \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": <workflow-json>}'
-
-# Check queue status
+curl -X POST http://localhost:8188/prompt -H "Content-Type: application/json" -d '{"prompt": <workflow-json>}'
 curl http://localhost:8188/queue
-
-# Get generated image
-curl http://localhost:8188/view?filename=<output-filename>
+curl "http://localhost:8188/view?filename=<output-filename>"
 ```
-
-### Ollama (Simple Local)
-
-Some vision models in Ollama can generate image descriptions but not images. For generation, use ComfyUI or Automatic1111.
 
 ## Prompt Engineering
 
-### General Principles
+Effective prompts: subject + style + lighting + composition + mood.
 
-1. **Be specific**: "A golden retriever puppy sitting on a red velvet cushion" > "a dog"
-2. **Include style**: "oil painting style", "photorealistic", "minimalist vector"
-3. **Specify lighting**: "soft natural light", "dramatic side lighting", "studio lighting"
-4. **Add composition**: "close-up", "wide angle", "bird's eye view", "rule of thirds"
-5. **Set mood**: "warm and inviting", "dark and moody", "bright and cheerful"
+Example: `"A golden retriever puppy on red velvet, oil painting, soft natural light, close-up, warm and inviting"`
 
-### Negative Prompts (SD/FLUX)
+**Negative prompts (SD/FLUX)**:
 
 ```text
-Useful negatives for quality:
 blurry, low quality, distorted, deformed, ugly, duplicate, watermark,
 text, signature, oversaturated, underexposed, overexposed
 ```
 
-### Batch Generation Script
+**Batch generation (DALL-E 3)**:
 
 ```bash
 #!/usr/bin/env bash
-# Generate multiple variations via DALL-E 3
 set -euo pipefail
-
 local prompt="$1"
 local count="${2:-4}"
 local output_dir="${3:-.}"
 
 for i in $(seq 1 "$count"); do
-  echo "Generating image $i/$count..."
   curl -s https://api.openai.com/v1/images/generations \
     -H "Authorization: Bearer $OPENAI_API_KEY" \
     -H "Content-Type: application/json" \
@@ -226,17 +133,6 @@ for i in $(seq 1 "$count"); do
   echo "Saved: $output_dir/gen_$i.png"
 done
 ```
-
-## Cost Comparison
-
-| Model | Per Image | Monthly (100 imgs) | Notes |
-|-------|-----------|---------------------|-------|
-| DALL-E 3 HD | $0.08 | $8 | Pay per image |
-| Midjourney Basic | $0.10 | $10/mo (200 imgs) | Subscription |
-| Imagen 3 | ~$0.04 | ~$4 | Vertex AI pricing |
-| FLUX (local) | ~$0.01 | GPU electricity only | Requires 12GB+ VRAM |
-| SD XL (local) | ~$0.005 | GPU electricity only | Requires 8GB+ VRAM |
-| FLUX (cloud GPU) | ~$0.02 | ~$2 + GPU rental | RunPod/Vast.ai |
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/vision/image-generation.md` from 247 to 143 lines (42% reduction) per GH#12110.

Closes #12110

## What was removed

- `<!-- AI-CONTEXT-START/END -->` wrapper (no value in agent docs)
- "Quick Reference" section (duplicated Model Comparison table + obvious "when to use")
- Empty "Quick start (local)" code block (just a comment pointing elsewhere)
- Duplicate DALL-E 3 curl example from Quick Reference (kept in Cloud APIs section)
- "Strengths/Limitations" prose under DALL-E 3 (folded into params table Notes column)
- Midjourney prose intro (kept prompt flags as compact one-liner)
- "Ollama" section (stated it cannot generate images — pure noise)
- Verbose numbered "General Principles" list (replaced with compact example)
- "Cost Comparison" table (duplicated data already in Model Comparison)

## What was preserved

- All 8 models in comparison table with full metadata
- All model-selection decision tree
- All API code examples (DALL-E 3, Imagen 3, ComfyUI)
- All URLs (OpenAI, Midjourney, Vertex AI, HuggingFace, ComfyUI)
- VRAM requirements table
- ComfyUI headless API
- Negative prompts list
- Batch generation script
- See Also links

## Runtime Testing

- Risk: **Low** (docs-only change, no code)
- Level: `self-assessed`
- Smoke check: `wc -l` confirms 143 lines; all models, URLs, code blocks verified present


---
[aidevops.sh](https://aidevops.sh) v3.5.147 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 12m and 5,289 tokens on this as a headless worker.