### PR TITLE
t1704: guard all setup.sh prompts against non-interactive hang

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -229,6 +229,32 @@ verified_install() {
 	fi
 }
 
+# Prompt the user for input, with non-interactive fallback.
+# In non-interactive mode (NON_INTERACTIVE=true or stdin is not a TTY),
+# automatically returns the default value without blocking.
+# Usage: setup_prompt "variable_name" "Prompt text [Y/n]: " "default_value"
+# Example: setup_prompt answer "Install foo? [Y/n]: " "Y"
+#          [[ "$answer" =~ ^[Yy]?$ ]] && install_foo
+# Returns: 0 always (sets the named variable via printf -v)
+setup_prompt() {
+	local var_name="$1"
+	local prompt_text="$2"
+	local default_value="${3:-}"
+
+	# Non-interactive: use default without prompting
+	if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
+		# shellcheck disable=SC2059  # var_name is a variable name, not a format string
+		printf -v "$var_name" '%s' "$default_value"
+		return 0
+	fi
+
+	local _setup_prompt_reply=""
+	read -r -p "$prompt_text" _setup_prompt_reply || _setup_prompt_reply="$default_value"
+	# shellcheck disable=SC2059  # var_name is a variable name, not a format string
+	printf -v "$var_name" '%s' "$_setup_prompt_reply"
+	return 0
+}
+
 # Confirm step in interactive mode
 # Usage: confirm_step "Step description" && function_to_run
 # Returns: 0 if confirmed or not interactive, 1 if skipped
@@ -343,7 +369,7 @@ ensure_homebrew() {
 	print_info "Homebrew (Linuxbrew) is not installed."
 	print_info "Several optional tools (Beads CLI, Worktrunk, bv) install via Homebrew taps."
 	echo ""
-	read -r -p "Install Homebrew for Linux? [Y/n]: " install_brew
+	setup_prompt install_brew "Install Homebrew for Linux? [Y/n]: " "Y"
 
 	if [[ ! "$install_brew" =~ ^[Yy]?$ ]]; then
 		print_info "Skipped Homebrew installation"
@@ -557,7 +583,7 @@ offer_python_brew_install() {
 		return 1
 	fi
 
-	read -r -p "${prompt_verb} Python via Homebrew now? [Y/n]: " install_python
+	setup_prompt install_python "${prompt_verb} Python via Homebrew now? [Y/n]: " "Y"
 	if [[ "$install_python" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing $recommended_formula" brew install "$recommended_formula"; then
 			local python3_bin

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -685,7 +685,7 @@ setup_beads() {
 # _install_bv_tool: install the bv (beads_viewer) TUI tool.
 # Returns 0 if installed, 1 if skipped or failed.
 _install_bv_tool() {
-	read -r -p "  Install bv (TUI with PageRank, critical path, graph analytics)? [Y/n]: " install_viewer
+	setup_prompt install_viewer "  Install bv (TUI with PageRank, critical path, graph analytics)? [Y/n]: " "Y"
 	if [[ ! "$install_viewer" =~ ^[Yy]?$ ]]; then
 		print_info "Install later:"
 		print_info "  Homebrew: brew tap dicklesworthstone/tap && brew install dicklesworthstone/tap/bv"
@@ -711,7 +711,7 @@ _install_bv_tool() {
 		fi
 	else
 		# Offer verified install script (download-then-execute, not piped)
-		read -r -p "  Install bv via install script? [Y/n]: " use_script
+		setup_prompt use_script "  Install bv via install script? [Y/n]: " "Y"
 		if [[ "$use_script" =~ ^[Yy]?$ ]]; then
 			if verified_install "bv (beads viewer)" "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh"; then
 				print_info "Run: bv (in a beads-enabled project)"
@@ -738,14 +738,14 @@ _install_beads_node_tools() {
 		echo "$count"
 		return 0
 	fi
-	read -r -p "  Install beads-ui (Web dashboard)? [Y/n]: " install_web
+	setup_prompt install_web "  Install beads-ui (Web dashboard)? [Y/n]: " "Y"
 	if [[ "$install_web" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing beads-ui" npm_global_install beads-ui; then
 			print_info "Run: beads-ui"
 			count=$((count + 1))
 		fi
 	fi
-	read -r -p "  Install bdui (React/Ink TUI)? [Y/n]: " install_bdui
+	setup_prompt install_bdui "  Install bdui (React/Ink TUI)? [Y/n]: " "Y"
 	if [[ "$install_bdui" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing bdui" npm_global_install bdui; then
 			print_info "Run: bdui"
@@ -762,7 +762,7 @@ _install_perles() {
 	if ! command -v cargo &>/dev/null; then
 		return 1
 	fi
-	read -r -p "  Install perles (BQL query language TUI)? [Y/n]: " install_perles
+	setup_prompt install_perles "  Install perles (BQL query language TUI)? [Y/n]: " "Y"
 	if [[ ! "$install_perles" =~ ^[Yy]?$ ]]; then
 		return 1
 	fi
@@ -782,7 +782,7 @@ setup_beads_ui() {
 	echo "  • perles (Rust)      - BQL query language TUI"
 	echo ""
 
-	read -r -p "Install optional Beads UI tools? [Y/n]: " install_beads_ui
+	setup_prompt install_beads_ui "Install optional Beads UI tools? [Y/n]: " "Y"
 
 	if [[ ! "$install_beads_ui" =~ ^[Yy]?$ ]]; then
 		print_info "Skipped Beads UI tools (can install later from beads.md docs)"

--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -170,7 +170,10 @@ bootstrap_repo() {
 			echo "  1) Install on this Mac (recommended)"
 			echo "  2) Install in a Linux VM (via OrbStack)"
 			echo ""
-			read -r -p "Choose [1/2] (default: 1): " install_target
+			# Cannot use setup_prompt here — _common.sh not yet sourced during bootstrap.
+			# The _bootstrap_non_interactive guard above prevents reaching this line.
+			local install_target=""
+			read -r -p "Choose [1/2] (default: 1): " install_target || install_target="1"
 
 			if [[ "$install_target" == "2" ]]; then
 				print_info "Setting up OrbStack VM installation..."

--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -151,7 +151,19 @@ bootstrap_repo() {
 		print_info "Remote install detected - bootstrapping repository..."
 
 		# On macOS, offer choice: install locally or in an OrbStack VM
-		if [[ "$(uname)" == "Darwin" ]]; then
+		# Skip prompt in non-interactive mode (parse_args hasn't run yet,
+		# so check $@ directly for --non-interactive/-n flags)
+		local _bootstrap_non_interactive=false
+		local _arg
+		for _arg in "$@"; do
+			case "$_arg" in
+			--non-interactive | -n) _bootstrap_non_interactive=true ;;
+			esac
+		done
+		[[ "${AIDEVOPS_NON_INTERACTIVE:-false}" == "true" ]] && _bootstrap_non_interactive=true
+		[[ ! -t 0 ]] && _bootstrap_non_interactive=true
+
+		if [[ "$(uname)" == "Darwin" && "$_bootstrap_non_interactive" == "false" ]]; then
 			echo ""
 			echo "Where would you like to install aidevops?"
 			echo ""
@@ -301,7 +313,7 @@ ensure_homebrew() {
 	print_info "Homebrew (Linuxbrew) is not installed."
 	print_info "Several optional tools (Beads CLI, Worktrunk, bv) install via Homebrew taps."
 	echo ""
-	read -r -p "Install Homebrew for Linux? [Y/n]: " install_brew
+	setup_prompt install_brew "Install Homebrew for Linux? [Y/n]: " "Y"
 
 	if [[ ! "$install_brew" =~ ^[Yy]?$ ]]; then
 		print_info "Skipped Homebrew installation"
@@ -497,7 +509,7 @@ check_requirements() {
 		fi
 
 		echo ""
-		read -r -p "Install missing dependencies using $pkg_manager? [Y/n]: " install_deps
+		setup_prompt install_deps "Install missing dependencies using $pkg_manager? [Y/n]: " "Y"
 
 		if [[ "$install_deps" =~ ^[Yy]?$ ]]; then
 			print_info "Installing ${missing_packages[*]}..."
@@ -567,7 +579,7 @@ check_quality_tools() {
 	fi
 
 	echo ""
-	read -r -p "Install quality tools using $pkg_manager? [Y/n]: " install_quality
+	setup_prompt install_quality "Install quality tools using $pkg_manager? [Y/n]: " "Y"
 
 	if [[ "$install_quality" =~ ^[Yy]?$ ]]; then
 		print_info "Installing ${missing_tools[*]}..."

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -261,7 +261,7 @@ setup_localwp_mcp() {
 	fi
 
 	print_info "LocalWP MCP server enables AI assistants to query WordPress databases"
-	read -r -p "Install LocalWP MCP server (@verygoodplugins/mcp-local-wp)? [Y/n]: " install_mcp
+	setup_prompt install_mcp "Install LocalWP MCP server (@verygoodplugins/mcp-local-wp)? [Y/n]: " "Y"
 
 	if [[ "$install_mcp" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing LocalWP MCP server" npm_global_install "@verygoodplugins/mcp-local-wp"; then
@@ -402,7 +402,7 @@ _setup_browser_tools_playwright() {
 	fi
 
 	local install_playwright
-	read -r -p "Install Playwright MCP with browsers (chromium, firefox, webkit)? [Y/n]: " install_playwright
+	setup_prompt install_playwright "Install Playwright MCP with browsers (chromium, firefox, webkit)? [Y/n]: " "Y"
 
 	if [[ "$install_playwright" =~ ^[Yy]?$ ]]; then
 		print_info "Installing Playwright browsers..."
@@ -875,7 +875,7 @@ _setup_quickfile_mcp_clone_and_build() {
 
 	print_info "QuickFile MCP provides AI access to UK accounting (invoices, clients, reports)"
 	local install_qf
-	read -r -p "Clone and build QuickFile MCP server? [Y/n]: " install_qf
+	setup_prompt install_qf "Clone and build QuickFile MCP server? [Y/n]: " "Y"
 
 	if [[ ! "$install_qf" =~ ^[Yy]?$ ]]; then
 		print_info "Skipped QuickFile MCP installation"

--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -614,7 +614,7 @@ setup_multi_tenant_credentials() {
 		print_info "Everything continues to work as before - this is non-breaking."
 		echo ""
 
-		read -r -p "Enable multi-tenant credential storage? [Y/n]: " enable_mt
+		setup_prompt enable_mt "Enable multi-tenant credential storage? [Y/n]: " "Y"
 		enable_mt=$(echo "$enable_mt" | tr '[:upper:]' '[:lower:]')
 
 		if [[ "$enable_mt" =~ ^[Yy]?$ || "$enable_mt" == "yes" ]]; then
@@ -681,7 +681,7 @@ check_tool_updates() {
 	bash "$tool_check_script" --quiet
 	echo ""
 
-	read -r -p "Update all outdated tools now? [Y/n]: " do_update
+	setup_prompt do_update "Update all outdated tools now? [Y/n]: " "Y"
 
 	if [[ "$do_update" =~ ^[Yy]?$ || "$do_update" == "Y" ]]; then
 		print_info "Updating tools..."

--- a/setup-modules/post-setup.sh
+++ b/setup-modules/post-setup.sh
@@ -39,7 +39,7 @@ setup_auto_update() {
 			echo "Auto-update keeps aidevops current by checking every 10 minutes."
 			echo "Safe to run while AI sessions are active."
 			echo ""
-			read -r -p "Enable auto-update? [Y/n]: " enable_auto
+			setup_prompt enable_auto "Enable auto-update? [Y/n]: " "Y"
 			if [[ "$enable_auto" =~ ^[Yy]?$ ]]; then
 				bash "$auto_update_script" enable
 			else
@@ -179,7 +179,7 @@ setup_tabby() {
 	echo ""
 	bash "$tabby_helper" status || true
 	echo ""
-	read -r -p "Sync Tabby profiles from repos.json? [Y/n]: " sync_tabby
+	setup_prompt sync_tabby "Sync Tabby profiles from repos.json? [Y/n]: " "Y"
 	if [[ "$sync_tabby" =~ ^[Yy]?$ ]]; then
 		bash "$tabby_helper" sync
 	else
@@ -227,7 +227,7 @@ setup_onboarding_prompt() {
 	echo "  - Get personalized recommendations based on your work"
 	echo "  - Set up API keys and credentials interactively"
 	echo ""
-	read -r -p "Launch ${_onb_name} with /onboarding now? [Y/n]: " launch_onboarding
+	setup_prompt launch_onboarding "Launch ${_onb_name} with /onboarding now? [Y/n]: " "Y"
 	if [[ "$launch_onboarding" =~ ^[Yy]?$ ]]; then
 		echo ""
 		echo "Starting ${_onb_name} with onboarding wizard..."

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -76,7 +76,7 @@ _determine_pulse_install() {
 			echo "  - 4-hourly strategic review (opus-tier) for queue health" >&2
 			echo "  - Circuit breaker pauses dispatch on consecutive failures" >&2
 			echo "" >&2
-			read -r -p "Enable supervisor pulse? [y/N]: " enable_pulse
+			setup_prompt enable_pulse "Enable supervisor pulse? [y/N]: " "n"
 			if [[ "$enable_pulse" =~ ^[Yy]$ ]]; then
 				_do_install=true
 				# Record explicit consent
@@ -1263,7 +1263,7 @@ setup_repo_sync() {
 			echo "Repo sync keeps your local git repos up to date by running"
 			echo "git pull --ff-only daily on clean repos on their default branch."
 			echo ""
-			read -r -p "Enable daily repo sync? [Y/n]: " enable_repo_sync
+			setup_prompt enable_repo_sync "Enable daily repo sync? [Y/n]: " "Y"
 			if [[ "$enable_repo_sync" =~ ^[Yy]?$ || -z "$enable_repo_sync" ]]; then
 				bash "$repo_sync_script" enable
 			else

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -101,7 +101,7 @@ _omz_offer_shell_change() {
 	fi
 
 	echo ""
-	read -r -p "Change default shell to zsh? [y/N]: " change_shell
+	setup_prompt change_shell "Change default shell to zsh? [y/N]: " "n"
 	if [[ "$change_shell" =~ ^[Yy]$ ]]; then
 		if chsh -s "$(command -v zsh)"; then
 			print_success "Default shell changed to zsh"
@@ -165,7 +165,7 @@ setup_oh_my_zsh() {
 	echo "  This is optional - plain zsh works fine without it."
 	echo ""
 
-	read -r -p "Install Oh My Zsh? [y/N]: " install_omz
+	setup_prompt install_omz "Install Oh My Zsh? [y/N]: " "n"
 
 	if [[ "$install_omz" =~ ^[Yy]$ ]]; then
 		_omz_run_install "$default_shell"
@@ -435,10 +435,8 @@ _shell_compat_prompt_user() {
 	print_info "both bash and zsh, so your customizations work in either shell."
 	echo ""
 
-	local setup_compat="Y"
-	if [[ "$NON_INTERACTIVE" != "true" ]]; then
-		read -r -p "Create shared shell profile for cross-shell compatibility? [Y/n]: " setup_compat
-	fi
+	local setup_compat
+	setup_prompt setup_compat "Create shared shell profile for cross-shell compatibility? [Y/n]: " "Y"
 
 	if [[ ! "$setup_compat" =~ ^[Yy]?$ ]]; then
 		print_info "Skipped cross-shell compatibility setup"
@@ -538,7 +536,7 @@ check_optional_deps() {
 		pkg_manager=$(detect_package_manager)
 
 		if [[ "$pkg_manager" != "unknown" ]]; then
-			read -r -p "Install optional dependencies using $pkg_manager? [Y/n]: " install_optional
+			setup_prompt install_optional "Install optional dependencies using $pkg_manager? [Y/n]: " "Y"
 
 			if [[ "$install_optional" =~ ^[Yy]?$ ]]; then
 				print_info "Installing ${missing_optional[*]}..."
@@ -1097,7 +1095,7 @@ setup_aliases() {
 	fi
 
 	print_info "Detected default shell: $default_shell"
-	read -r -p "Add shell aliases? [Y/n]: " add_aliases
+	setup_prompt add_aliases "Add shell aliases? [Y/n]: " "Y"
 
 	if [[ "$add_aliases" =~ ^[Yy]?$ ]]; then
 		local added_to
@@ -1162,7 +1160,7 @@ _terminal_title_prompt_and_install() {
 	local setup_script="$1"
 
 	echo ""
-	read -r -p "Install terminal title integration? [Y/n]: " install_title
+	setup_prompt install_title "Install terminal title integration? [Y/n]: " "Y"
 
 	if [[ "$install_title" =~ ^[Yy]?$ ]]; then
 		if bash "$setup_script" install; then

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1132,9 +1132,11 @@ setup_ssh_key() {
 			return 0
 		fi
 
+		local generate_key
 		setup_prompt generate_key "Generate new Ed25519 SSH key? [Y/n]: " "Y"
 
 		if [[ "$generate_key" =~ ^[Yy]?$ ]]; then
+			local email
 			setup_prompt email "Enter your email address: " ""
 			if [[ -z "$email" ]]; then
 				print_warning "No email provided — skipping SSH key generation"

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -47,7 +47,7 @@ setup_git_clis() {
 
 		if [[ "$pkg_manager" != "unknown" ]]; then
 			echo ""
-			read -r -p "Install Git CLI tools (${missing_packages[*]}) using $pkg_manager? [Y/n]: " install_git_clis
+			setup_prompt install_git_clis "Install Git CLI tools (${missing_packages[*]}) using $pkg_manager? [Y/n]: " "Y"
 
 			if [[ "$install_git_clis" =~ ^[Yy]?$ ]]; then
 				print_info "Installing ${missing_packages[*]}..."
@@ -229,10 +229,7 @@ setup_file_discovery_tools() {
 		pkg_manager=$(detect_package_manager)
 
 		if [[ "$pkg_manager" != "unknown" ]]; then
-			local install_fd_tools="y"
-			if [[ "$INTERACTIVE_MODE" == "true" ]]; then
-				read -r -p "Install file discovery tools (${missing_packages[*]}) using $pkg_manager? [Y/n]: " install_fd_tools
-			fi
+			setup_prompt install_fd_tools "Install file discovery tools (${missing_packages[*]}) using $pkg_manager? [Y/n]: " "Y"
 
 			if [[ "$install_fd_tools" =~ ^[Yy]?$ ]]; then
 				_install_file_discovery_packages "$pkg_manager" "${missing_packages[@]}"
@@ -271,10 +268,7 @@ setup_rtk() {
 		echo "  Single binary, zero dependencies, <10ms overhead."
 		echo ""
 
-		local install_rtk="n"
-		if [[ "$INTERACTIVE_MODE" == "true" ]]; then
-			read -r -p "Install rtk for token-optimized CLI output? [y/N]: " install_rtk
-		fi
+		setup_prompt install_rtk "Install rtk for token-optimized CLI output? [y/N]: " "n"
 
 		if [[ "$install_rtk" =~ ^[Yy]$ ]]; then
 			VERIFIED_INSTALL_SHELL="sh"
@@ -371,11 +365,7 @@ setup_shell_linting_tools() {
 
 		if [[ "$pkg_manager" != "unknown" ]]; then
 			local install_linters
-			if [[ "${NON_INTERACTIVE:-}" == "true" ]]; then
-				install_linters="Y"
-			else
-				read -r -p "Install missing shell linting tools using $pkg_manager? [Y/n]: " install_linters
-			fi
+			setup_prompt install_linters "Install missing shell linting tools using $pkg_manager? [Y/n]: " "Y"
 
 			if [[ "$install_linters" =~ ^[Yy]?$ ]]; then
 				if install_packages "$pkg_manager" "${missing_tools[@]}"; then
@@ -508,10 +498,8 @@ setup_qlty_cli() {
 	echo "  - Used by the daily code quality sweep (pulse-wrapper.sh)"
 	echo ""
 
-	local install_qlty="Y"
-	if [[ "${NON_INTERACTIVE:-}" != "true" ]]; then
-		read -r -p "Install Qlty CLI? [Y/n]: " install_qlty
-	fi
+	local install_qlty
+	setup_prompt install_qlty "Install Qlty CLI? [Y/n]: " "Y"
 
 	if [[ "$install_qlty" =~ ^[Yy]?$ ]]; then
 		if command -v curl >/dev/null 2>&1; then
@@ -612,7 +600,7 @@ _check_worktrunk_shell_integration() {
 	if [[ "$wt_integrated" == "false" ]]; then
 		print_info "Shell integration not detected"
 		local install_shell
-		read -r -p "Install Worktrunk shell integration (enables 'wt switch' to change directories)? [Y/n]: " install_shell
+		setup_prompt install_shell "Install Worktrunk shell integration (enables 'wt switch' to change directories)? [Y/n]: " "Y"
 		if [[ "$install_shell" =~ ^[Yy]?$ ]]; then
 			_setup_worktrunk_shell_integration
 		fi
@@ -625,7 +613,7 @@ _check_worktrunk_shell_integration() {
 # Install Worktrunk via Homebrew and set up shell integration.
 _install_worktrunk_brew() {
 	local install_wt
-	read -r -p "Install Worktrunk via Homebrew? [Y/n]: " install_wt
+	setup_prompt install_wt "Install Worktrunk via Homebrew? [Y/n]: " "Y"
 
 	if [[ "$install_wt" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing Worktrunk via Homebrew" brew install max-sixty/worktrunk/wt; then
@@ -652,7 +640,7 @@ _install_worktrunk_brew() {
 # Install Worktrunk via Cargo and set up shell integration.
 _install_worktrunk_cargo() {
 	local install_wt
-	read -r -p "Install Worktrunk via Cargo? [Y/n]: " install_wt
+	setup_prompt install_wt "Install Worktrunk via Cargo? [Y/n]: " "Y"
 
 	if [[ "$install_wt" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing Worktrunk via Cargo" cargo install worktrunk; then
@@ -714,7 +702,7 @@ setup_worktrunk() {
 # Trigger OpenCode extension install in Zed via the zed:// URI scheme.
 _install_opencode_ext_for_zed() {
 	local install_opencode_ext
-	read -r -p "Install OpenCode extension for Zed? [Y/n]: " install_opencode_ext
+	setup_prompt install_opencode_ext "Install OpenCode extension for Zed? [Y/n]: " "Y"
 	if [[ "$install_opencode_ext" =~ ^[Yy]?$ ]]; then
 		print_info "Installing OpenCode extension..."
 		if [[ "$(uname)" == "Darwin" ]]; then
@@ -789,7 +777,7 @@ _install_tabby_linux() {
 # Offer and perform Tabby terminal installation.
 _install_tabby() {
 	local install_tabby
-	read -r -p "Install Tabby terminal? [Y/n]: " install_tabby
+	setup_prompt install_tabby "Install Tabby terminal? [Y/n]: " "Y"
 
 	if [[ "$install_tabby" =~ ^[Yy]?$ ]]; then
 		if [[ "$(uname)" == "Darwin" ]]; then
@@ -816,7 +804,7 @@ _install_tabby() {
 # Offer and perform Zed editor installation, then optionally install OpenCode extension.
 _install_zed_and_opencode_ext() {
 	local install_zed
-	read -r -p "Install Zed editor? [Y/n]: " install_zed
+	setup_prompt install_zed "Install Zed editor? [Y/n]: " "Y"
 
 	if [[ "$install_zed" =~ ^[Yy]?$ ]]; then
 		local zed_installed=false
@@ -976,11 +964,7 @@ setup_cursor_cli() {
 	echo ""
 
 	local install_cursor
-	if [[ "${NON_INTERACTIVE:-}" != "true" ]]; then
-		read -r -p "Install Cursor CLI? [Y/n]: " install_cursor
-	else
-		install_cursor="Y"
-	fi
+	setup_prompt install_cursor "Install Cursor CLI? [Y/n]: " "Y"
 
 	if [[ "$install_cursor" =~ ^[Yy]?$ ]]; then
 		print_info "Installing Cursor CLI..."
@@ -1071,7 +1055,7 @@ setup_minisim() {
 	fi
 
 	local install_minisim
-	read -r -p "Install MiniSim? [Y/n]: " install_minisim
+	setup_prompt install_minisim "Install MiniSim? [Y/n]: " "Y"
 
 	if [[ "$install_minisim" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing MiniSim" brew install --cask minisim; then
@@ -1118,7 +1102,7 @@ setup_claudebar() {
 	echo ""
 
 	local install_claudebar
-	read -r -p "Install ClaudeBar? [Y/n]: " install_claudebar
+	setup_prompt install_claudebar "Install ClaudeBar? [Y/n]: " "Y"
 
 	if [[ "$install_claudebar" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing ClaudeBar" brew install --cask claudebar; then
@@ -1141,10 +1125,21 @@ setup_ssh_key() {
 
 	if [[ ! -f ~/.ssh/id_ed25519 ]]; then
 		print_warning "Ed25519 SSH key not found"
-		read -r -p "Generate new Ed25519 SSH key? [Y/n]: " generate_key
+
+		# SSH key generation requires email input — skip in non-interactive mode
+		if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
+			print_info "Skipping SSH key generation (non-interactive mode)"
+			return 0
+		fi
+
+		setup_prompt generate_key "Generate new Ed25519 SSH key? [Y/n]: " "Y"
 
 		if [[ "$generate_key" =~ ^[Yy]?$ ]]; then
-			read -r -p "Enter your email address: " email
+			setup_prompt email "Enter your email address: " ""
+			if [[ -z "$email" ]]; then
+				print_warning "No email provided — skipping SSH key generation"
+				return 0
+			fi
 			install -d -m 700 ~/.ssh
 			ssh-keygen -t ed25519 -C "$email" -f ~/.ssh/id_ed25519
 			print_success "SSH key generated"
@@ -1420,10 +1415,10 @@ setup_nodejs() {
 	local pkg_manager
 	pkg_manager=$(detect_package_manager)
 
+	local install_node
 	case "$pkg_manager" in
 	brew)
-		local install_node
-		read -r -p "Install Node.js via Homebrew? [Y/n]: " install_node
+		setup_prompt install_node "Install Node.js via Homebrew? [Y/n]: " "Y"
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if run_with_spinner "Installing Node.js" brew install node; then
 				print_success "Node.js installed: $(node --version)"
@@ -1433,15 +1428,13 @@ setup_nodejs() {
 		fi
 		;;
 	apt)
-		local install_node
-		read -r -p "Install Node.js via apt? [Y/n]: " install_node
+		setup_prompt install_node "Install Node.js via apt? [Y/n]: " "Y"
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			_install_nodejs_apt
 		fi
 		;;
 	dnf | yum)
-		local install_node
-		read -r -p "Install Node.js via $pkg_manager? [Y/n]: " install_node
+		setup_prompt install_node "Install Node.js via $pkg_manager? [Y/n]: " "Y"
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if sudo "$pkg_manager" install -y nodejs npm; then
 				print_success "Node.js installed: $(node --version)"
@@ -1451,8 +1444,7 @@ setup_nodejs() {
 		fi
 		;;
 	pacman)
-		local install_node
-		read -r -p "Install Node.js via pacman? [Y/n]: " install_node
+		setup_prompt install_node "Install Node.js via pacman? [Y/n]: " "Y"
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if sudo pacman -S --noconfirm nodejs npm; then
 				print_success "Node.js installed: $(node --version)"
@@ -1462,8 +1454,7 @@ setup_nodejs() {
 		fi
 		;;
 	apk)
-		local install_node
-		read -r -p "Install Node.js via apk? [Y/n]: " install_node
+		setup_prompt install_node "Install Node.js via apk? [Y/n]: " "Y"
 		if [[ "$install_node" =~ ^[Yy]?$ ]]; then
 			if sudo apk add nodejs npm; then
 				print_success "Node.js installed: $(node --version)"
@@ -1510,10 +1501,8 @@ setup_opencode_cli() {
 	echo "  It provides an AI-powered terminal interface for development tasks."
 	echo ""
 
-	local install_oc="Y"
-	if [[ "$NON_INTERACTIVE" != "true" ]]; then
-		read -r -p "Install OpenCode via $installer? [Y/n]: " install_oc || install_oc="Y"
-	fi
+	local install_oc
+	setup_prompt install_oc "Install OpenCode via $installer? [Y/n]: " "Y"
 	if [[ "$install_oc" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing OpenCode" npm_global_install "$install_pkg"; then
 			print_success "OpenCode installed"
@@ -1566,10 +1555,8 @@ setup_codex_cli() {
 	echo "  It provides an AI-powered terminal interface using OpenAI models."
 	echo ""
 
-	local install_codex="Y"
-	if [[ "${NON_INTERACTIVE:-}" != "true" ]]; then
-		read -r -p "Install Codex via $installer? [Y/n]: " install_codex || install_codex="Y"
-	fi
+	local install_codex
+	setup_prompt install_codex "Install Codex via $installer? [Y/n]: " "Y"
 	if [[ "$install_codex" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing Codex" npm_global_install "$install_pkg"; then
 			print_success "Codex installed"
@@ -1651,10 +1638,8 @@ setup_droid_cli() {
 	echo "  It provides autonomous coding capabilities with Factory.AI models."
 	echo ""
 
-	local install_droid="Y"
-	if [[ "${NON_INTERACTIVE:-}" != "true" ]]; then
-		read -r -p "Install Droid CLI? [Y/n]: " install_droid || install_droid="Y"
-	fi
+	local install_droid
+	setup_prompt install_droid "Install Droid CLI? [Y/n]: " "Y"
 	if [[ "$install_droid" =~ ^[Yy]?$ ]]; then
 		print_info "Installing Droid CLI..."
 		if command -v curl >/dev/null 2>&1; then
@@ -1708,10 +1693,8 @@ setup_google_workspace_cli() {
 	echo "  Used by Email, Business, and Accounts agents for Google Workspace integration."
 	echo ""
 
-	local install_gws="Y"
-	if [[ "$NON_INTERACTIVE" != "true" ]]; then
-		read -r -p "Install Google Workspace CLI via $installer? [Y/n]: " install_gws || install_gws="Y"
-	fi
+	local install_gws
+	setup_prompt install_gws "Install Google Workspace CLI via $installer? [Y/n]: " "Y"
 	if [[ "$install_gws" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing Google Workspace CLI" npm_global_install "$install_pkg"; then
 			print_success "Google Workspace CLI installed"
@@ -1755,7 +1738,7 @@ setup_orbstack_vm() {
 		return 0
 	fi
 
-	read -r -p "Install OrbStack? [y/N]: " install_orb
+	setup_prompt install_orb "Install OrbStack? [y/N]: " "n"
 	if [[ "$install_orb" =~ ^[Yy]$ ]]; then
 		if run_with_spinner "Installing OrbStack" brew install --cask orbstack; then
 			print_success "OrbStack installed"

--- a/setup.sh
+++ b/setup.sh
@@ -422,6 +422,32 @@ npm_global_install() {
 	fi
 }
 
+# Prompt the user for input, with non-interactive fallback.
+# In non-interactive mode (NON_INTERACTIVE=true or stdin is not a TTY),
+# automatically returns the default value without blocking.
+# Usage: setup_prompt "variable_name" "Prompt text [Y/n]: " "default_value"
+# Example: setup_prompt answer "Install foo? [Y/n]: " "Y"
+#          [[ "$answer" =~ ^[Yy]?$ ]] && install_foo
+# Returns: 0 always (sets the named variable via printf -v)
+setup_prompt() {
+	local var_name="$1"
+	local prompt_text="$2"
+	local default_value="${3:-}"
+
+	# Non-interactive: use default without prompting
+	if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
+		# shellcheck disable=SC2059  # var_name is a variable name, not a format string
+		printf -v "$var_name" '%s' "$default_value"
+		return 0
+	fi
+
+	local _setup_prompt_reply=""
+	read -r -p "$prompt_text" _setup_prompt_reply || _setup_prompt_reply="$default_value"
+	# shellcheck disable=SC2059  # var_name is a variable name, not a format string
+	printf -v "$var_name" '%s' "$_setup_prompt_reply"
+	return 0
+}
+
 # Confirm step in interactive mode
 # Usage: confirm_step "Step description" && function_to_run
 # Returns: 0 if confirmed or not interactive, 1 if skipped

--- a/setup.sh
+++ b/setup.sh
@@ -423,30 +423,29 @@ npm_global_install() {
 }
 
 # Prompt the user for input, with non-interactive fallback.
-# In non-interactive mode (NON_INTERACTIVE=true or stdin is not a TTY),
-# automatically returns the default value without blocking.
-# Usage: setup_prompt "variable_name" "Prompt text [Y/n]: " "default_value"
-# Example: setup_prompt answer "Install foo? [Y/n]: " "Y"
-#          [[ "$answer" =~ ^[Yy]?$ ]] && install_foo
-# Returns: 0 always (sets the named variable via printf -v)
-setup_prompt() {
-	local var_name="$1"
-	local prompt_text="$2"
-	local default_value="${3:-}"
+# Canonical definition in .agents/scripts/setup/_common.sh; this fallback
+# ensures the function exists even when _common.sh was not sourced (e.g.
+# bootstrap from curl where setup-modules/ doesn't exist yet).
+if ! type setup_prompt &>/dev/null; then
+	setup_prompt() {
+		local var_name="$1"
+		local prompt_text="$2"
+		local default_value="${3:-}"
 
-	# Non-interactive: use default without prompting
-	if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
+		# Non-interactive: use default without prompting
+		if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
+			# shellcheck disable=SC2059  # var_name is a variable name, not a format string
+			printf -v "$var_name" '%s' "$default_value"
+			return 0
+		fi
+
+		local _setup_prompt_reply=""
+		read -r -p "$prompt_text" _setup_prompt_reply || _setup_prompt_reply="$default_value"
 		# shellcheck disable=SC2059  # var_name is a variable name, not a format string
-		printf -v "$var_name" '%s' "$default_value"
+		printf -v "$var_name" '%s' "$_setup_prompt_reply"
 		return 0
-	fi
-
-	local _setup_prompt_reply=""
-	read -r -p "$prompt_text" _setup_prompt_reply || _setup_prompt_reply="$default_value"
-	# shellcheck disable=SC2059  # var_name is a variable name, not a format string
-	printf -v "$var_name" '%s' "$_setup_prompt_reply"
-	return 0
-}
+	}
+fi
 
 # Confirm step in interactive mode
 # Usage: confirm_step "Step description" && function_to_run


### PR DESCRIPTION
## Summary

- Added `setup_prompt()` helper function that wraps `read -r -p` with automatic non-interactive fallback — returns default value when `NON_INTERACTIVE=true` or stdin is not a TTY
- Converted all 40+ bare `read -r -p` calls across 10 setup module files to use `setup_prompt()`, eliminating potential hangs in headless/CI environments
- Fixed `bootstrap_repo()` in `core.sh` to check for `--non-interactive` flag in `$@` before prompting for OrbStack VM choice (since `parse_args` hasn't run yet at that point)

## What was done

The root cause: setup.sh had 40+ `read -r -p` calls scattered across setup modules that would block on stdin when no TTY is available. While the non-interactive code path (`_setup_run_non_interactive`) only calls safe functions, the prompts in other functions lacked individual guards — making the system fragile if any function was ever moved into the non-interactive path.

### Changes by file

| File | Prompts converted | Notes |
|------|:-:|-------|
| `setup.sh` | +`setup_prompt()` | New centralized prompt helper |
| `setup-modules/tool-install.sh` | 26 | Node.js, SSH, Worktrunk, Tabby, Zed, etc. |
| `setup-modules/shell-env.sh` | 6 | zsh, Oh My Zsh, aliases, terminal title |
| `setup-modules/agent-deploy.sh` | 6 | Beads UI tools |
| `setup-modules/core.sh` | 4 | bootstrap, Homebrew, deps, quality tools |
| `setup-modules/mcp-setup.sh` | 3 | LocalWP, Playwright, QuickFile |
| `setup-modules/post-setup.sh` | 3 | auto-update, Tabby sync, onboarding |
| `setup-modules/plugins.sh` | 2 | multi-tenant creds, tool updates |
| `setup-modules/schedulers.sh` | 2 | pulse, repo sync |
| `.agents/scripts/setup/_common.sh` | 2 | Homebrew, Python |

## Testing Evidence

- **Level**: self-assessed
- **Smoke check**: `setup.sh --non-interactive` completes successfully without hanging
- **Function test**: `setup_prompt` correctly returns default value when `NON_INTERACTIVE=true`

## Runtime Testing

- Risk: **Medium** (setup script, no runtime app changes)
- Level: `self-assessed`
- Dev environment: Linux (tested on actual machine)

Closes #12593


---
[aidevops.sh](https://aidevops.sh) v3.5.146 plugin for [OpenCode](https://opencode.ai) v1.3.4 with claude-opus-4-6 spent 25m and 30,978,461 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup scripts now support non-interactive mode, automatically selecting recommended defaults when stdin is not a TTY or the `NON_INTERACTIVE=true` environment variable is set, enabling automated setup workflows.

* **Refactor**
  * Centralized and standardized user prompts across all setup modules for consistent handling and improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->