### PR TITLE
GH#12645: tighten rules-avatars.md 186→166 lines

### DIFF
--- a/.agents/content/heygen-skill/rules-avatars.md
+++ b/.agents/content/heygen-skill/rules-avatars.md
@@ -7,17 +7,17 @@ metadata:
 
 # HeyGen Avatars
 
-Avatars are AI-generated presenters. Use public HeyGen avatars or custom avatars.
+Avatars are AI-generated presenters. Use public or custom avatars.
 
 ## Workflow: Preview → Select → Generate
 
-1. List avatars — get names, genders, preview URLs
-2. Open preview in browser — `open <preview_image_url>` (macOS) / `xdg-open` (Linux) — no auth needed
+1. List avatars → get names, genders, preview URLs
+2. Preview in browser — `open <preview_image_url>` (macOS) / `xdg-open` (Linux) — no auth needed
 3. User selects avatar by name or ID
 4. Get avatar details for `default_voice_id`
 5. Generate video with `avatar_id` + `default_voice_id`
 
-## Listing Avatars
+## Listing Avatars (v2)
 
 **Endpoint:** `GET /v2/avatars`
 
@@ -26,27 +26,7 @@ curl -X GET "https://api.heygen.com/v2/avatars" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
-```typescript
-interface Avatar {
-  avatar_id: string;
-  avatar_name: string;
-  gender: "male" | "female";
-  preview_image_url: string;  // open in browser — no auth needed
-  preview_video_url: string;
-}
-
-async function listAvatars(): Promise<Avatar[]> {
-  const response = await fetch("https://api.heygen.com/v2/avatars", {
-    headers: { "X-Api-Key": process.env.HEYGEN_API_KEY! },
-  });
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const json = await response.json();
-  if (json.error) throw new Error(json.error);
-  return json.data.avatars;
-}
-```
-
-**Response shape:**
+**Response:**
 
 ```json
 {
@@ -60,23 +40,32 @@ async function listAvatars(): Promise<Avatar[]> {
         "preview_image_url": "https://files.heygen.ai/...",
         "preview_video_url": "https://files.heygen.ai/..."
       }
-    ],
-    "talking_photos": []
+    ]
   }
+}
+```
+
+```typescript
+interface Avatar {
+  avatar_id: string;
+  avatar_name: string;
+  gender: "male" | "female";
+  preview_image_url: string;
+  preview_video_url: string;
 }
 ```
 
 ## Avatar Types
 
-| Type | How to identify | API |
-|------|----------------|-----|
-| Public | `avatar_id` does not start with `custom_` | `/v2/avatars` |
+| Type | Identification | API |
+|------|---------------|-----|
+| Public | `avatar_id` without `custom_` prefix | `/v2/avatars` |
 | Custom | `avatar_id` starts with `custom_` | `/v2/avatars` |
-| Instant | Created from a single photo/short video | `/v1/instant_avatar.list` |
+| Instant | Created from single photo/short video | `/v1/instant_avatar.list` |
 
-## Avatar Groups (v3 — Recommended)
+## Avatar Groups (v3 — Recommended for Search)
 
-Use v3 for paginated listing and search:
+Paginated listing and search via v3:
 
 ```bash
 # List groups (include public)
@@ -92,9 +81,9 @@ curl -X GET "https://api.heygen.com/v2/avatar_group/{group_id}/avatars" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
 
-**v3 `avatar_group.list` params:** `page` (1–10000), `page_size` (1–1000), `query` (text search), `include_public` (bool)
+**`avatar_group.list` params:** `page` (1–10000), `page_size` (1–1000), `query`, `include_public` (bool)
 
-**v3 `avatar_groups/search` params:** `page`, `page_size`, `query`, `search_tags` (comma-separated), `list_filter`
+**`avatar_groups/search` params:** `page`, `page_size`, `query`, `search_tags` (comma-separated), `list_filter`
 
 ```typescript
 interface AvatarGroupItem {
@@ -111,7 +100,7 @@ interface AvatarGroupItem {
 
 ## Avatar Styles
 
-| Style | Description | Best for |
+| Style | Description | Use case |
 |-------|-------------|----------|
 | `normal` | Full body, standard framing | Full-screen presenter, corporate |
 | `closeUp` | Face close-up, more expressive | Personal/intimate content |
@@ -133,9 +122,9 @@ interface AvatarGroupItem {
 }
 ```
 
-## Using Avatar's Default Voice (Recommended)
+## Default Voice (Recommended)
 
-**Always use `default_voice_id`** — it's pre-matched for gender and lip sync.
+**Always use `default_voice_id`** — pre-matched for gender and lip sync.
 
 **Flow:** `GET /v2/avatars` → `GET /v2/avatar/{id}/details` → `POST /v2/video/generate`
 
@@ -146,7 +135,6 @@ curl -X GET "https://api.heygen.com/v2/avatar/{avatar_id}/details" \
 
 ```typescript
 interface AvatarDetails {
-  type: "avatar";
   id: string;
   name: string;
   gender: "male" | "female";
@@ -159,20 +147,12 @@ interface AvatarDetails {
 }
 ```
 
-## Selecting the Right Avatar
+## Common Mistakes
 
-| Category | Examples | Best for |
-|----------|----------|----------|
-| Business/Professional | Josh, Angela, Wayne | Corporate, product demos, training |
-| Casual/Friendly | Lily, lifestyle avatars | Social media, informal content |
-| Expressive | Avatars with "expressive" in name | Storytelling, dynamic content |
-| Themed/Seasonal | Holiday, costume avatars | Specific campaigns only |
-
-**Common mistakes:**
-- Using themed avatars for business content (looks unprofessional)
+- Using themed/seasonal avatars for business content — looks unprofessional
 - Not previewing before generation — always `open <preview_image_url>`
 - Mismatched voice gender — use `default_voice_id` or match genders manually
-- Wrong style — `circle` doesn't work for full-screen presentations
+- Using `circle` style for full-screen presentations — wrong framing
 
 ## Common Avatar IDs
 
@@ -183,4 +163,4 @@ interface AvatarDetails {
 | `wayne_20240422` | Wayne | Male |
 | `lily_20230614` | Lily | Female |
 
-Always verify availability via the list endpoint before use.
+Always verify availability via the list endpoint — IDs may change.


### PR DESCRIPTION
## Summary

- Tightened `.agents/content/heygen-skill/rules-avatars.md` from 186 → 166 lines (11% reduction)
- Removed redundant `listAvatars()` TypeScript function (curl example + Avatar interface already cover the endpoint)
- Removed empty `talking_photos: []` from JSON response, redundant `type: "avatar"` from AvatarDetails interface
- Removed subjective "Selecting the Right Avatar" category table (low actionable value); kept the concrete "Common Mistakes" list
- Minor prose tightening throughout — all endpoints, interfaces, code blocks, URLs, and actionable guidance preserved

## Verification

- All 5 API endpoints preserved
- All TypeScript interfaces (Avatar, AvatarGroupItem, AvatarDetails) preserved
- All curl examples preserved
- All avatar style code blocks preserved
- Common avatar IDs table preserved
- No broken internal links

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs/agent prompts only)
- No runtime verification needed

Closes #12645


---
[aidevops.sh](https://aidevops.sh) v3.5.164 plugin for [OpenCode](https://opencode.ai) v1.3.4 with claude-opus-4-6 spent 2m and 572,899 tokens on this as a headless worker.