### PR TITLE
GH#12651: tighten agent doc Creative Testing and Iteration Frameworks

### DIFF
--- a/.agents/marketing-sales/ad-creative-chapter-04.md
+++ b/.agents/marketing-sales/ad-creative-chapter-04.md
@@ -1,48 +1,39 @@
 # Chapter 4: Creative Testing and Iteration Frameworks
 
-## Section 1: Foundations of Creative Testing
+## Foundations of Creative Testing
 
 **Testing cycle:** `HYPOTHESIS → DESIGN → EXECUTE → ANALYZE → IMPLEMENT → ITERATE`
 
 **Core principles:**
 1. **Hypothesis-driven:** Specific, testable prediction before every test. ("Real customer images will generate 25% higher CTR than stock because they create authenticity" — not "Let's test different images")
 2. **Variable isolation:** One variable at a time (A/B) or statistical isolation (MVT)
-3. **Statistical rigor:** Reach significance before drawing conclusions — early decisions cause false positives
+3. **Statistical rigor:** Reach significance before conclusions — early decisions cause false positives
 4. **Documentation:** Every test produces learnings for future creative
 
-### Test Types
-
-| Type | When to use | Key caution |
-|------|-------------|-------------|
+| Test type | When to use | Key caution |
+|-----------|-------------|-------------|
 | **A/B** | Single variable, limited traffic | 50/50 split, test against current best performer |
 | **A/B/n** | Multiple directions, high traffic | Bonferroni correction for multiple comparisons |
 | **MVT** | Multiple elements, interaction effects matter | Full factorial = comprehensive; fractional = efficient |
 | **Sequential** | Limited budget, learning-focused | Longer time to optimal; external factors may shift |
 
-### Statistical Foundations
+**Sample size:** `n = (Zα/2 + Zβ)² × 2 × σ² / δ²` (Zα/2=1.96, Zβ=0.84). Minimums: 100 conversions/variation; 1,000+ impressions for CTR tests.
 
-**Sample size formula:** `n = (Zα/2 + Zβ)² × 2 × σ² / δ²` (Zα/2=1.96, Zβ=0.84)
+**Common errors:** stopping early, ignoring confidence intervals, too many variations, inadequate power. Statistical significance ≠ business importance — weigh implementation cost vs. improvement magnitude.
 
-**Practical minimums:** 100 conversions/variation; 1,000+ impressions for CTR tests
+**Test design:** 7-day minimum (full business cycle); 50/50 standard split; 90/10 for untested creative; multi-armed bandit for exploration/exploitation. Validity threats: selection bias, history effects, instrumentation changes, seasonal maturation.
 
-**Common errors:** stopping early, ignoring confidence intervals, too many variations, inadequate power
-
-**Practical significance:** Statistical significance ≠ business importance. Weigh implementation cost vs. improvement magnitude.
-
-**Test design:** 7-day minimum duration (full business cycle); 50/50 standard split; 90/10 for untested creative; multi-armed bandit for exploration/exploitation. Validity threats: selection bias, history effects, instrumentation changes, seasonal maturation.
-
----
-
-## Section 2: Multivariate Testing Framework
+## Multivariate Testing
 
 **Full factorial:** 3 headlines × 3 images × 2 CTAs = 18 variations. Captures all interactions; traffic-intensive.
 
 **Fractional factorial:** Taguchi orthogonal arrays — half the combinations, detects main effects, some interactions confounded.
 
-**Variable selection:** expected impact, execution quality, strategic importance, measurable outcomes, independence
+**Variable selection criteria:** expected impact, execution quality, strategic importance, measurable outcomes, independence
 
-**Experimental design:**
-```
+**Design steps:**
+
+```text
 Step 1: Define variables/levels (e.g., Headline: benefit/curiosity/urgency; Image: product/lifestyle/people; CTA: action/benefit)
 Step 2: Create variation matrix (A1B1C1 … A3B3C2)
 Step 3: Traffic = variations × 1,000 conversions minimum
@@ -51,50 +42,43 @@ Step 4: Execute → main effects → interaction effects → identify winner
 
 **Main effects:** Average performance with A1 minus average with A2. Positive = improves performance.
 
-**Interaction effects:** Synergistic (combined > sum), antagonistic (combined < expected), none (independent). Example: Headline A + Image X outperforms Headline A + Image Y → optimal combination depends on pairing.
+**Interaction effects:** Synergistic (combined > sum), antagonistic (combined < expected), none (independent). Headline A + Image X outperforms Headline A + Image Y → optimal combination depends on pairing.
 
-**Winner:** Highest-performing combination. Validate against control before scaling.
+**Winner validation:** Highest-performing combination. Validate against control before scaling.
 
----
-
-## Section 3: Creative Fatigue Detection and Management
+## Creative Fatigue Detection and Management
 
 **Fatigue curve:** Introduction → Growth → Peak → Decline → Fatigue
 
-**Fatigue indicators (primary):** CTR decline, conversion rate decrease, CPA increase, engagement drop
+**Primary indicators:** CTR decline, conversion rate decrease, CPA increase, engagement drop
 
 **Platform signals:** Meta: frequency >3/week, CTR decline >20% | TikTok: completion rate decline, negative engagement | Google: Quality Score decrease, CPC inflation | YouTube: skip rate increase, view-through decline
 
-**Automated alerts:** CTR drops >15% from baseline | Frequency >3/week | CPA increases >20% | Engagement drops >25%
+**Alert thresholds:** CTR drops >15% from baseline | Frequency >3/week | CPA increases >20% | Engagement drops >25%
 
 **Detection cadence:** Daily dashboard; weekly WoW + frequency distribution; monthly fatigue rate + cost impact
 
-### Prevention and Recovery
-
-**Rotation models:** time-based (2–4 weeks), performance-based (metric triggers), hybrid (minimum duration + triggers)
-
-**Best practices:** 3–5 active variations minimum; introduce new creative before complete fatigue; retire underperformers quickly
+**Rotation models:** time-based (2–4 weeks), performance-based (metric triggers), hybrid (minimum duration + triggers). Keep 3–5 active variations minimum; introduce new creative before complete fatigue; retire underperformers quickly.
 
 **Audience management:** exclude users after 3+ exposures, frequency caps, lookalike expansion, rotate audiences between creative sets
 
 **Variation types:** evolutionary (same concept, different execution) vs. revolutionary (new approach, diversifies fatigue risk)
 
-**Velocity:** High-spend → weekly; Medium → bi-weekly; Low → monthly
+**Refresh velocity:** High-spend → weekly; Medium → bi-weekly; Low → monthly
 
 **Recovery sequence:** reduce budget → expand audience → frequency caps → activate backup → analyze → refresh creative → gradual re-launch
 
----
+## Winner Identification and Scaling
 
-## Section 4: Winner Identification and Scaling
+**Primary criteria:** p < 0.05, minimum sample size, sustained performance, practical significance
 
-**Winner criteria (primary):** p < 0.05, minimum sample size, sustained performance, practical significance
-
-**Winner criteria (secondary):** consistency across segments, robustness to external factors, implementation feasibility, brand alignment
+**Secondary criteria:** consistency across segments, robustness to external factors, implementation feasibility, brand alignment
 
 **Validation:** test winner against control in new test; verify across audiences and conditions
 
 **Budget ramp:**
-```
+
+```text
 Week 1: $1K/day (testing) → Week 2: $3K/day (validation) → Week 3: $10K/day (scaling) → Week 4+: $30K+/day
 Increase 20–30% daily; pause if efficiency degrades
 ```
@@ -103,9 +87,7 @@ Increase 20–30% daily; pause if efficiency degrades
 
 **Scaling challenges:** efficiency degradation (refresh velocity, audience expansion, bidding optimization); auction dynamics (higher CPMs → dayparting, audience segmentation); operational complexity (automation rules, dashboard tools, team scaling)
 
----
-
-## Section 5: Modular Creative Systems
+## Modular Creative Systems
 
 **Visual:** Background (colors, gradients, textures, photos) | Subject (product, lifestyle, people) | Overlay (logos, badges, text)
 
@@ -118,7 +100,8 @@ Increase 20–30% daily; pause if efficiency degrades
 **Component-level testing:** same visual + different headlines (isolate messaging); same headline + different visuals (isolate visual); pairing tests (interaction effects)
 
 **Asset structure:**
-```
+
+```text
 /Brand Assets: Logos | Colors | Fonts | Templates
 /Campaign Assets/[Name]: Backgrounds | Products | People | Messaging | Final_Exports
 /Performance Data: Test_Results | Component_Performance | Insights
@@ -126,31 +109,25 @@ Increase 20–30% daily; pause if efficiency degrades
 
 **Metadata:** component type, campaign, performance data, usage rights, creation date, creator
 
----
-
-## Section 6: Creative Velocity and Production Systems
+## Creative Velocity and Production
 
 **Key metrics:** concept-to-completion time, assets/week, cost/asset, revision cycles, tests/period, refresh frequency
 
-**Industry benchmarks:** Top performers: weekly | Average: monthly | Laggards: quarterly
+**Benchmarks:** Top performers: weekly | Average: monthly | Laggards: quarterly
 
 **Platform velocity:** TikTok (weekly) > Meta (bi-weekly) > YouTube/LinkedIn (monthly)
 
 **Agile sprint:** Mon: planning/brief → Tue–Wed: production → Thu: review/refinement → Fri: launch/monitoring
 
-### Production Model Comparison
-
-| Model | Pros | Cons | Best for |
-|-------|------|------|---------|
+| Production model | Pros | Cons | Best for |
+|------------------|------|------|---------|
 | In-house | Brand knowledge, fast, cost-efficient at scale | Limited perspectives, capacity constraints | Core assets, high-volume recurring |
 | Agency | Expertise, fresh perspectives, scalable | Higher cost, slower turnaround | Hero campaigns, complex productions |
 | Freelance | Flexibility, specialized skills, cost control | Quality consistency, management overhead | Specialized needs, overflow |
 
 **Hybrid:** In-house (day-to-day) + Agency (campaign concepts) + Freelance (specialized/overflow)
 
----
-
-## Section 7: Performance Benchmarks and KPIs
+## Performance Benchmarks and KPIs
 
 **Meta:** Video 3s views 30–50%, ThruPlay 15–30%, completion 10–20%; CTR 0.5–1.5%; CPM $5–15, CPC $0.50–3.00
 **TikTok:** 2s view 35–50%, completion 15–25%; engagement 5–15%; CTR 1–3%; CPM $3–10
@@ -158,8 +135,6 @@ Increase 20–30% daily; pause if efficiency degrades
 **Google Display:** CTR 0.3–0.8%, viewability 70%+, CPM $1–5
 **YouTube:** VTR 15–30%, completion 20–40%, CPV $0.05–0.30
 **LinkedIn:** CTR 0.3–0.8%, engagement 1–3%, CPM $15–50, CPC $3–10
-
-### KPI Frameworks by Objective
 
 | Objective | Primary KPIs | Secondary KPIs |
 |-----------|-------------|----------------|
@@ -169,9 +144,7 @@ Increase 20–30% daily; pause if efficiency degrades
 
 **Benchmarking sources:** WordStream, HubSpot, Salesforce marketing reports, Meta/Google platform insights, ad library analysis
 
----
-
-## Section 8: Attribution and Creative Impact Measurement
+## Attribution and Creative Impact Measurement
 
 **Attribution models:** First-touch (awareness) | Last-touch (direct response) | Linear (equal credit) | Time-decay (recency weighted) | Position-based/U-shaped (40% first, 40% last, 20% distributed) | Data-driven (algorithmic, most accurate, requires volume)
 
@@ -179,31 +152,20 @@ Increase 20–30% daily; pause if efficiency degrades
 
 **View-through windows:** 1-day, 7-day, 28-day; validate with control group comparison
 
-### Incrementality Testing
-
-**Holdout testing:** exclude random audience portion → compare exposed vs. unexposed conversion rates → difference = incremental impact
-
-**Methods:** geo-holdout, audience holdout, time-based holdout
+**Holdout testing:** exclude random audience portion → compare exposed vs. unexposed conversion rates → difference = incremental impact. Methods: geo-holdout, audience holdout, time-based holdout.
 
 **Platform tools:** Meta Conversion Lift, Google Conversion Lift; DIY: PSA testing, geo-matched markets, matched cohort analysis
 
 **Creative impact analytics:** correlation analysis (elements vs. performance), regression analysis (isolate variable impact), cohort analysis (LTV, retention by creative seen)
 
----
+## Building a Testing Culture
 
-## Section 9: Building a Testing Culture
-
-**Leadership requirements:** executive sponsorship, resource allocation, patience for learning phase, celebrating insights not just wins
+**Leadership:** executive sponsorship, resource allocation, patience for learning phase, celebrating insights not just wins
 
 **Team roles:** test strategist (hypotheses) | creative producer (assets) | analyst (measurement) | project manager (coordination)
 
 **Technology stack:** native platform testing (Meta, Google), third-party tools (Optimizely, VWO), creative intelligence platforms, analytics/visualization
 
-**Process documentation:** SOPs, hypothesis templates, test design guidelines, analysis frameworks, centralized results repository
+**Process:** SOPs, hypothesis templates, test design guidelines, analysis frameworks, centralized results repository. Learning loop: Test → Learn → Document → Share → Apply → Iterate.
 
-**Learning loop:** Test → Learn → Document → Share → Apply → Iterate
-
-**Innovation pipeline:**
-- 70%: proven concepts (exploitation)
-- 20%: iterations of winners (evolution)
-- 10%: new concept exploration (innovation)
+**Innovation pipeline:** 70% proven concepts (exploitation) | 20% iterations of winners (evolution) | 10% new concept exploration (innovation)


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing-sales/ad-creative-chapter-04.md` from 209 to 171 lines (18% reduction)
- Removed "Section N:" heading prefixes, horizontal rules between sections, redundant subheadings ("Test Types", "Statistical Foundations", "Prevention and Recovery", "Production Model Comparison", "KPI Frameworks by Objective", "Incrementality Testing"), and verbose phrasing
- Merged closely related one-liners (e.g., sample size + minimums, common errors + practical significance, rotation models + best practices, holdout testing + methods, process docs + learning loop, innovation pipeline to single line)
- Added `text` language specifiers to 3 fenced code blocks (fixes pre-existing MD040 lint violations)

## Content Preservation

All actionable content preserved — verified counts:
- 6 code block markers (3 blocks)
- 16 table rows (3 tables)
- 1 statistical formula
- 1 UTM strategy example
- 9 sections (all retained)
- All platform benchmarks, metrics, and data points intact

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (docs-only change — agent prompt reference material)
- No dev environment needed

Closes #12651


---
[aidevops.sh](https://aidevops.sh) v3.5.164 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6