### PR TITLE
GH#12345: tighten marketing-sales.md from 207 to 164 lines

### DIFF
--- a/.agents/marketing-sales.md
+++ b/.agents/marketing-sales.md
@@ -40,7 +40,7 @@ You are the Marketing agent. Domain: marketing strategy, campaign execution, pai
 
 ## Quick Reference
 
-- **CRM**: FluentCRM MCP — `services/crm/fluentcrm.md`
+- **CRM**: FluentCRM MCP — `services/crm/fluentcrm.md`. Prerequisites: FluentCRM plugin on WordPress, application password, MCP server configured, SMTP/SES sending. Credentials in `~/.config/aidevops/credentials.sh` (600 perms) — never commit.
 - **Analytics**: GA4 — `services/analytics/google-analytics.md`
 - **Content/copy**: `content.md` | **SEO**: `seo.md` | **Sales handoff**: `marketing-sales.md`
 
@@ -62,7 +62,7 @@ You are the Marketing agent. Domain: marketing strategy, campaign execution, pai
 | **Automations** | `fluentcrm_list_automations`, `fluentcrm_create_automation` |
 | **Lists** | `fluentcrm_list_lists`, `fluentcrm_create_list`, `fluentcrm_attach_contact_to_list` |
 | **Tags** | `fluentcrm_list_tags`, `fluentcrm_create_tag`, `fluentcrm_attach_tag_to_contact` |
-| **Smart Links** | `fluentcrm_create_smart_link`, `fluentcrm_generate_smart_link_shortcode` |
+| **Smart Links** | `fluentcrm_create_smart_link`, `fluentcrm_generate_smart_link_shortcode` — track clicks, trigger tag actions, lead scoring |
 | **Reports** | `fluentcrm_dashboard_stats` |
 
 **Google Analytics MCP Tools** (when `google-analytics` subagent loaded): `get_account_summaries`, `get_property_details`, `list_google_ads_links`, `run_report`, `get_custom_dimensions_and_metrics`, `run_realtime_report`
@@ -71,55 +71,30 @@ You are the Marketing agent. Domain: marketing strategy, campaign execution, pai
 
 ## Pre-flight Questions
 
-Before generating marketing strategy or campaign output:
+Before generating marketing strategy or campaign output, validate:
 
-1. Is the offer valuable? What specific problem does it solve — real and painful?
-2. What is unique about our solution vs. alternatives?
-3. Benefits (outcomes) before features (how it works)?
-4. Pricing vs. alternatives — including doing nothing?
-5. Can we guarantee results? Are claims realistic and provable?
-6. Who specifically — named personas with real constraints, not demographics?
-7. What would make someone say "this isn't for me" — and is that the right person to lose?
+1. Is the offer solving a real, painful problem? What's unique vs. alternatives?
+2. Benefits (outcomes) before features? Pricing vs. alternatives including doing nothing?
+3. Can we guarantee results? Are claims realistic and provable?
+4. Who specifically — named personas with real constraints, not demographics?
+5. What would make someone say "this isn't for me" — and is that the right person to lose?
 
-## Email Marketing
+## Email Campaigns
 
-### FluentCRM Setup
+**Campaign workflow**: Plan → `fluentcrm_create_email_template` (title, subject, body HTML) → `fluentcrm_create_campaign` (title, subject, template_id, recipient_list) → test → schedule → monitor.
 
-Prerequisites: FluentCRM plugin on WordPress, application password, MCP server configured, SMTP/SES sending. See `services/crm/fluentcrm.md` for full setup. Store credentials in `~/.config/aidevops/credentials.sh` (600 perms) — never commit.
+| Type | FluentCRM Feature |
+|------|-------------------|
+| Newsletter / Promotional | Email Campaign |
+| Nurture / Transactional / Re-engagement | Automation Funnel |
 
-### Campaign Types
+**Template rules**: Subject 40-60 chars, personalized, clear value. Preheader complements subject, 40-100 chars. Single column, scannable, mobile-first. Clear contrasting CTA above fold. Footer: unsubscribe, contact info, social.
 
-| Type | Use Case | FluentCRM Feature |
-|------|----------|-------------------|
-| **Newsletter** | Regular updates | Email Campaign |
-| **Promotional** | Sales and offers | Email Campaign |
-| **Nurture** | Lead education | Automation Funnel |
-| **Transactional** | Order confirmations | Automation Funnel |
-| **Re-engagement** | Win back inactive | Automation Funnel |
+**Personalization**: `{{contact.first_name}}`, `{{contact.last_name}}`, `{{contact.email}}`, `{{contact.full_name}}`, `{{contact.custom.field_name}}`
 
-### Creating a Campaign
+## Automation
 
-Plan → `fluentcrm_create_email_template` (title, subject, body HTML) → `fluentcrm_create_campaign` (title, subject, template_id, recipient_list) → test → schedule → monitor.
-
-### Template Best Practices
-
-| Element | Best Practice |
-|---------|---------------|
-| **Subject** | 40-60 chars, personalized, clear value |
-| **Preheader** | Complement subject, 40-100 chars |
-| **Body** | Single column, scannable, mobile-first |
-| **CTA** | Clear, contrasting button, above fold |
-| **Footer** | Unsubscribe link, contact info, social |
-
-**Personalization variables**: `{{contact.first_name}}`, `{{contact.last_name}}`, `{{contact.email}}`, `{{contact.full_name}}`, `{{contact.custom.field_name}}`
-
-## Marketing Automation
-
-### Automation Triggers
-
-Triggers: `tag_added`, `list_added`, `form_submitted`, `link_clicked`, `email_opened`.
-
-### Common Sequences
+**Triggers**: `tag_added`, `list_added`, `form_submitted`, `link_clicked`, `email_opened`.
 
 | Sequence | Trigger | Schedule |
 |----------|---------|----------|
@@ -127,63 +102,45 @@ Triggers: `tag_added`, `list_added`, `form_submitted`, `link_clicked`, `email_op
 | **Lead Nurture** | `tag_added` (lead-mql) | Day 0: education → Day 3: case study → Day 7: comparison → Day 10: demo invite → Day 14: follow-up |
 | **Re-engagement** | `tag_added` (inactive-90-days) | Day 0: "we miss you" → Day 3: best content → Day 7: offer → Day 14: last chance + unsub |
 
-Create with `fluentcrm_create_automation` (title, description, trigger), then configure steps, delays, conditions, and exit conditions in FluentCRM admin.
+Create with `fluentcrm_create_automation` (title, description, trigger), then configure steps/delays/conditions in FluentCRM admin.
 
-## Audience Segmentation
+## Segmentation
 
 | Segment Type | Tag Pattern | Use Case |
 |--------------|-------------|----------|
-| **Demographic** | `industry-*`, `company-size-*` | Targeted messaging |
-| **Behavioral** | `engaged-*`, `downloaded-*` | Engagement-based |
-| **Lifecycle** | `lead-*`, `customer-*` | Stage-appropriate |
-| **Interest** | `interest-*`, `product-*` | Relevant content |
-| **Source** | `source-*`, `campaign-*` | Attribution |
+| Demographic | `industry-*`, `company-size-*` | Targeted messaging |
+| Behavioral | `engaged-*`, `downloaded-*` | Engagement-based |
+| Lifecycle | `lead-*`, `customer-*` | Stage-appropriate |
+| Interest | `interest-*`, `product-*` | Relevant content |
+| Source | `source-*`, `campaign-*` | Attribution |
 
-Use `fluentcrm_create_list` for static segments; `fluentcrm_create_tag` + automation for dynamic segments that update on activity.
+Static segments: `fluentcrm_create_list`. Dynamic segments: `fluentcrm_create_tag` + automation.
 
-## Smart Links
+## Content & Lead Generation
 
-Track clicks and trigger actions: `fluentcrm_create_smart_link` (title, slug, target_url, apply_tags). Use cases: content tracking, lead scoring, segmentation, retargeting. Generate shortcodes with `fluentcrm_generate_smart_link_shortcode` (slug, linkText).
+**Platform-specific voice**: `content/platform-personas.md`.
 
-## Content Marketing Integration
+**Content → Campaign**: Create content (`content.md`) → adapt for platforms → SEO (`seo.md`) → email template with excerpt → campaign targeting interest tags → smart link for click tracking → schedule → monitor.
 
-Platform-specific voice: `content/platform-personas.md`.
+**Lead magnet workflow**: Create magnet → landing page with form → `fluentcrm_create_list` → delivery automation → nurture sequence. Form integrations: Fluent Forms, WPForms, Gravity Forms, Contact Form 7, custom API.
 
-**Content to Campaign**: Create content (`content.md`) → adapt for platforms → SEO (`seo.md`) → email template with excerpt → campaign targeting interest tags → smart link for click tracking → schedule → monitor.
+**Lead handoff**: Apply `lead-mql` tag → automation notifies sales → sales accepts → apply `lead-sql` tag → remove from marketing sequences.
 
-## Lead Generation
-
-**Lead Magnet Workflow**: Create magnet → landing page with form → `fluentcrm_create_list` → delivery automation → nurture sequence.
-
-**Form integrations**: Fluent Forms, WPForms, Gravity Forms, Contact Form 7, custom API.
-
-**Lead Handoff**: Apply `lead-mql` tag → automation notifies sales → sales accepts → apply `lead-sql` tag → remove from marketing sequences.
-
-## Analytics & Reporting
+## Analytics & Testing
 
 | Metric | Target | Lever |
 |--------|--------|-------|
-| **Open Rate** | 20-30% | Subject lines, send time |
-| **Click Rate** | 2-5% | CTAs, content relevance |
-| **Conversion Rate** | 1-3% | Landing page optimization |
-| **Unsubscribe Rate** | <0.5% | Targeting, frequency |
-| **List Growth** | 5-10%/mo | Lead magnets, promotion |
+| Open Rate | 20-30% | Subject lines, send time |
+| Click Rate | 2-5% | CTAs, content relevance |
+| Conversion Rate | 1-3% | Landing page optimization |
+| Unsubscribe Rate | <0.5% | Targeting, frequency |
+| List Growth | 5-10%/mo | Lead magnets, promotion |
 
 Use `fluentcrm_dashboard_stats` for contacts, engagement, and campaign performance. After each campaign: review rates by segment, identify top content, document learnings.
 
-## A/B Testing
+**A/B testing**: Test subject lines, send times, from name, CTA text/placement, content length. Process: two variations → 10-20% test split → 24-48h → send winner to remainder.
 
-| Element | Test Ideas |
-|---------|------------|
-| **Subject Line** | Length, personalization, emoji |
-| **Send Time** | Day of week, time of day |
-| **From Name** | Company vs. person |
-| **CTA** | Button text, color, placement |
-| **Content** | Long vs. short, format |
-
-**Process**: Two variations → 10-20% test split → 24-48h → send winner to remainder.
-
-## Best Practices
+## Deliverability & Compliance
 
 **Deliverability**: Authenticate SPF/DKIM/DMARC; warm up new domains; double opt-in; remove hard bounces immediately; re-engage or remove inactive (90+ days); honor unsubscribes instantly.
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing-sales.md` from 207 to 164 lines (21% reduction, net -43 lines)
- Merged 6 related sections into 3 consolidated sections, folded Smart Links into tools table, removed redundant table columns
- All actionable content preserved: every URL, FluentCRM tool name, helper script, personalization variable, tag pattern, compliance reference, and troubleshooting entry verified present

## Changes

| Before | After | What changed |
|--------|-------|--------------|
| Email Marketing (4 subsections) | Email Campaigns | Merged Setup, Campaign Types, Creating a Campaign, Template Best Practices |
| Marketing Automation (2 subsections) | Automation | Merged Triggers + Common Sequences |
| Smart Links (standalone section) | — | Folded into FluentCRM tools table row |
| Content Marketing + Lead Generation (2 sections) | Content & Lead Generation | Merged |
| Analytics & Reporting + A/B Testing (2 sections) | Analytics & Testing | Merged, A/B testing compressed to inline |
| Best Practices (standalone) | Deliverability & Compliance | Renamed for clarity |
| Pre-flight Questions (7 items) | Pre-flight Questions (5 items) | Merged overlapping questions |
| FluentCRM Setup (standalone subsection) | — | Folded into Quick Reference CRM bullet |

## Verification

- `wc -l`: 207 → 164 lines
- All 18 key terms verified present (SPF/DKIM/DMARC, GDPR, CAN-SPAM, CASL, all form integrations, all doc refs, all helper scripts, all tag patterns)
- All FluentCRM tool names (12 occurrences), URLs (2), personalization variables (5) preserved
- No broken internal references

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (docs/agent prompts only, no code changes)
- **Rationale**: Agent prompt file — no runtime behaviour to test

Closes #12345


---
[aidevops.sh](https://aidevops.sh) v3.5.167 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 3m and 6,159 tokens on this as a headless worker.