### PR TITLE
GH#12695: tighten hexagonal.md - remove noise, preserve actionable content

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
@@ -41,8 +41,6 @@ flowchart TB
     style Domain fill:#059669,stroke:#047857,color:white
 ```
 
----
-
 ## Ports
 
 | Type | Direction | Defined by | Purpose | Asymmetry |
@@ -87,8 +85,6 @@ export interface IPaymentGatewayPort {
   refund(paymentId: PaymentId, amount: Money): Promise<RefundResult>;
 }
 ```
-
----
 
 ## Adapters
 
@@ -141,8 +137,6 @@ class RabbitMQEventPublisher implements IEventPublisherPort:
     publishAll(events): for event in events: publish(event)
 ```
 
----
-
 ## Naming Conventions
 
 | Pattern | Port | Adapter |
@@ -151,8 +145,6 @@ class RabbitMQEventPublisher implements IEventPublisherPort:
 | Interface/Impl | `IOrderRepository` | `PostgresOrderRepository` |
 | Port suffix | `OrderRepositoryPort` | `PostgresOrderAdapter` |
 | Using prefix | `IOrderStorage` | `OrderStorageUsingPostgres` |
-
----
 
 ## Project Structure
 
@@ -171,9 +163,7 @@ src/
 └── domain/
 ```
 
----
-
-## Swap Adapters Without Changing Core
+## Configurability
 
 ```typescript
 // infrastructure/config/container.ts
@@ -188,8 +178,6 @@ function configureProduction(container: Container): void {
   container.bind<IPaymentGatewayPort>('IPaymentGatewayPort').to(StripePaymentGateway);
 }
 ```
-
----
 
 ## Strong vs Weak Ports
 


### PR DESCRIPTION
## Summary

- Removes 31 lines (247 → 216, -12.5%) from `.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md`
- Noise removed: 7 `---` horizontal rules, "Key Asymmetry" section (restated Ports table), "Benefits" table (generic knowledge no agent needs), misleading `(REST, gRPC, CLI, message)` comment where gRPC has no example
- All actionable content preserved: Mermaid diagram, Ports/Adapters/Naming tables, all code blocks (TypeScript + pseudocode), Project Structure, Configurability, Strong vs Weak Ports

## What was removed and why

| Removed | Reason |
|---------|--------|
| 7 `---` horizontal rules | Visual noise; sections already separated by `##` headings |
| "Key Asymmetry" section | Exact restatement of the Ports table (driver calls port / driven implements port) |
| "Benefits" table | Generic knowledge (testability, flexibility, independence) — no agent needs this to apply the pattern |
| `(REST, gRPC, CLI, message)` comment | gRPC not shown in example; misleading |

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only — no code execution path)
- **Level:** self-assessed
- **Dev environment:** N/A
- **Verification:** `wc -l` confirms 216 lines; all code blocks, tables, and diagram present in final file

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12695


---
[aidevops.sh](https://aidevops.sh) v3.5.180 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 4,829 tokens on this as a headless worker.