### PR TITLE
GH#12684: fix proxy-integration.md review feedback

### DIFF
--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -26,7 +26,7 @@ COMMANDS:
     launch              Launch browser with anti-detect profile
     profile             Manage browser profiles (create/list/show/delete/clone)
     cookies             Manage profile cookies (export/import/clear)
-    proxy               Proxy operations (check/check-all/dns-check)
+    proxy               Proxy operations (check/check-all)
     test                Test detection status against bot-detection sites
     warmup              Warm up a profile with browsing history
     status              Show installation status of all tools

--- a/.agents/tools/browser/proxy-integration.md
+++ b/.agents/tools/browser/proxy-integration.md
@@ -129,10 +129,9 @@ anti-detect-helper.sh proxy check "http://user:pass@host:port"
 # Check all profile proxies
 anti-detect-helper.sh proxy check-all
 # Output: IP, country, city, ISP, speed, anonymity level
-
-# Verify no DNS leaks through proxy
-anti-detect-helper.sh proxy dns-check "profile-name"
 ```
+
+DNS leak prevention: Playwright handles automatically; Camoufox uses `network.proxy.socks_remote_dns = true` (default).
 
 ## Rotation Strategies
 


### PR DESCRIPTION
## Summary

Addresses review feedback from CodeRabbit and Gemini on the original simplification PR.

### Changes

1. **Remove undocumented `dns-check` command** — The command `anti-detect-helper.sh proxy dns-check` was documented but not implemented (falls through to "Unknown proxy command" error). Removed from docs.

2. **Add DNS leak prevention note** — Added clarification that DNS leak prevention is handled at the browser engine level (Playwright automatic, Camoufox via `network.proxy.socks_remote_dns`).

3. **Preserve WebShare "Direct proxy list" example** — Kept the `http://user:pass@proxy1.webshare.io:80` example as requested.

4. **Keep multi-line code examples** — Preserved readable multi-line dictionary formats in Python examples.

5. **Keep health check output description** — Preserved the "Output: IP, country, city, ISP, speed, anonymity level" comment.

### Verification

- `markdownlint-cli2`: 0 errors
- All code blocks, URLs, and commands present
- Rebased onto latest main (no conflicts)

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs only)

Closes #12684