### PR TITLE
GH#12685: Convert addons-ref.md to table format

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
@@ -1,57 +1,51 @@
 # Addons Reference
 
-Full environment variable and option reference for Cloudron addons. Declare addons in `CloudronManifest.json` under the `addons` key.
-
-Read env vars at runtime on every start — values can change across restarts.
+Full environment variable and option reference for Cloudron addons. Declare addons in `CloudronManifest.json` under the `addons` key. Read env vars at runtime on every start — values can change across restarts.
 
 ## localstorage
 
 Provides writable `/app/data` directory. Contents are backed up. Directory is empty on first install; files from the Docker image are not present. Restore permissions in `start.sh`.
 
-Options:
-
-- `ftp` — Enable FTP access: `{ "ftp": { "uid": 33, "uname": "www-data" } }`
-- `sqlite` — Declare SQLite files for consistent backup: `{ "sqlite": { "paths": ["/app/data/db.sqlite"] } }`
+| Option | Description |
+|--------|-------------|
+| `ftp` | Enable FTP access: `{ "ftp": { "uid": 33, "uname": "www-data" } }` |
+| `sqlite` | Declare SQLite files for consistent backup: `{ "sqlite": { "paths": ["/app/data/db.sqlite"] } }` |
 
 ## mysql
 
-MySQL 8.0. Database is pre-created.
+MySQL 8.0. Database is pre-created. Default charset: `utf8mb4` / `utf8mb4_unicode_ci`.
 
-```text
-CLOUDRON_MYSQL_URL          # full connection URL
-CLOUDRON_MYSQL_USERNAME
-CLOUDRON_MYSQL_PASSWORD
-CLOUDRON_MYSQL_HOST
-CLOUDRON_MYSQL_PORT
-CLOUDRON_MYSQL_DATABASE
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_MYSQL_URL` | Full connection URL |
+| `CLOUDRON_MYSQL_USERNAME` | Database username |
+| `CLOUDRON_MYSQL_PASSWORD` | Database password |
+| `CLOUDRON_MYSQL_HOST` | Database host |
+| `CLOUDRON_MYSQL_PORT` | Database port |
+| `CLOUDRON_MYSQL_DATABASE` | Database name |
 
-Options:
-
-- `multipleDatabases: true` — Provides `CLOUDRON_MYSQL_DATABASE_PREFIX` instead of `CLOUDRON_MYSQL_DATABASE`. Create databases with that prefix.
-
-Default charset: `utf8mb4` / `utf8mb4_unicode_ci`.
+| Option | Description |
+|--------|-------------|
+| `multipleDatabases: true` | Provides `CLOUDRON_MYSQL_DATABASE_PREFIX` instead of `CLOUDRON_MYSQL_DATABASE`. Create databases with that prefix. |
 
 Debug: `cloudron exec` then `MYSQL_PWD=$CLOUDRON_MYSQL_PASSWORD mysql --user=$CLOUDRON_MYSQL_USERNAME --host=$CLOUDRON_MYSQL_HOST $CLOUDRON_MYSQL_DATABASE`
 
 ## postgresql
 
-PostgreSQL 14.9.
+PostgreSQL 14.9. Supported extensions: `btree_gist`, `btree_gin`, `citext`, `hstore`, `pgcrypto`, `pg_trgm`, `postgis`, `uuid-ossp`, `unaccent`, `vector`, `vectors`, and more.
 
-```text
-CLOUDRON_POSTGRESQL_URL
-CLOUDRON_POSTGRESQL_USERNAME
-CLOUDRON_POSTGRESQL_PASSWORD
-CLOUDRON_POSTGRESQL_HOST
-CLOUDRON_POSTGRESQL_PORT
-CLOUDRON_POSTGRESQL_DATABASE
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_POSTGRESQL_URL` | Full connection URL |
+| `CLOUDRON_POSTGRESQL_USERNAME` | Database username |
+| `CLOUDRON_POSTGRESQL_PASSWORD` | Database password |
+| `CLOUDRON_POSTGRESQL_HOST` | Database host |
+| `CLOUDRON_POSTGRESQL_PORT` | Database port |
+| `CLOUDRON_POSTGRESQL_DATABASE` | Database name |
 
-Options:
-
-- `locale` — Set `LC_LOCALE` and `LC_CTYPE` at database creation.
-
-Supported extensions: `btree_gist`, `btree_gin`, `citext`, `hstore`, `pgcrypto`, `pg_trgm`, `postgis`, `uuid-ossp`, `unaccent`, `vector`, `vectors`, and more.
+| Option | Description |
+|--------|-------------|
+| `locale` | Set `LC_LOCALE` and `LC_CTYPE` at database creation |
 
 Debug: `PGPASSWORD=$CLOUDRON_POSTGRESQL_PASSWORD psql -h $CLOUDRON_POSTGRESQL_HOST -p $CLOUDRON_POSTGRESQL_PORT -U $CLOUDRON_POSTGRESQL_USERNAME -d $CLOUDRON_POSTGRESQL_DATABASE`
 
@@ -59,49 +53,49 @@ Debug: `PGPASSWORD=$CLOUDRON_POSTGRESQL_PASSWORD psql -h $CLOUDRON_POSTGRESQL_HO
 
 MongoDB 8.0.
 
-```text
-CLOUDRON_MONGODB_URL
-CLOUDRON_MONGODB_USERNAME
-CLOUDRON_MONGODB_PASSWORD
-CLOUDRON_MONGODB_HOST
-CLOUDRON_MONGODB_PORT
-CLOUDRON_MONGODB_DATABASE
-CLOUDRON_MONGODB_OPLOG_URL      # only when oplog enabled
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_MONGODB_URL` | Full connection URL |
+| `CLOUDRON_MONGODB_USERNAME` | Database username |
+| `CLOUDRON_MONGODB_PASSWORD` | Database password |
+| `CLOUDRON_MONGODB_HOST` | Database host |
+| `CLOUDRON_MONGODB_PORT` | Database port |
+| `CLOUDRON_MONGODB_DATABASE` | Database name |
+| `CLOUDRON_MONGODB_OPLOG_URL` | Oplog URL (only when oplog enabled) |
 
-Options:
-
-- `oplog: true` — Enable oplog access.
+| Option | Description |
+|--------|-------------|
+| `oplog: true` | Enable oplog access |
 
 ## redis
 
 Redis 8.4. Data is persistent.
 
-```text
-CLOUDRON_REDIS_URL
-CLOUDRON_REDIS_HOST
-CLOUDRON_REDIS_PORT
-CLOUDRON_REDIS_PASSWORD
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_REDIS_URL` | Full connection URL |
+| `CLOUDRON_REDIS_HOST` | Redis host |
+| `CLOUDRON_REDIS_PORT` | Redis port |
+| `CLOUDRON_REDIS_PASSWORD` | Redis password |
 
-Options:
-
-- `noPassword: true` — Skip password auth (safe: Redis is only reachable on internal Docker network).
+| Option | Description |
+|--------|-------------|
+| `noPassword: true` | Skip password auth (safe: Redis is only reachable on internal Docker network) |
 
 ## ldap
 
-LDAP v3 authentication.
+LDAP v3 authentication. Cannot be added to an existing app — reinstall required.
 
-```text
-CLOUDRON_LDAP_SERVER
-CLOUDRON_LDAP_HOST
-CLOUDRON_LDAP_PORT
-CLOUDRON_LDAP_URL
-CLOUDRON_LDAP_USERS_BASE_DN
-CLOUDRON_LDAP_GROUPS_BASE_DN
-CLOUDRON_LDAP_BIND_DN
-CLOUDRON_LDAP_BIND_PASSWORD
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_LDAP_SERVER` | LDAP server |
+| `CLOUDRON_LDAP_HOST` | LDAP host |
+| `CLOUDRON_LDAP_PORT` | LDAP port |
+| `CLOUDRON_LDAP_URL` | Full LDAP URL |
+| `CLOUDRON_LDAP_USERS_BASE_DN` | Users base DN |
+| `CLOUDRON_LDAP_GROUPS_BASE_DN` | Groups base DN |
+| `CLOUDRON_LDAP_BIND_DN` | Bind DN |
+| `CLOUDRON_LDAP_BIND_PASSWORD` | Bind password |
 
 Suggested filter: `(&(objectclass=user)(|(username=%uid)(mail=%uid)))`
 
@@ -109,105 +103,97 @@ User attributes: `uid`, `cn`, `mail`, `displayName`, `givenName`, `sn`, `usernam
 
 Group attributes: `cn`, `gidnumber`, `memberuid`
 
-Cannot be added to an existing app — reinstall required.
-
 ## oidc
 
 OpenID Connect authentication.
 
-```text
-CLOUDRON_OIDC_PROVIDER_NAME
-CLOUDRON_OIDC_DISCOVERY_URL
-CLOUDRON_OIDC_ISSUER
-CLOUDRON_OIDC_AUTH_ENDPOINT
-CLOUDRON_OIDC_TOKEN_ENDPOINT
-CLOUDRON_OIDC_KEYS_ENDPOINT
-CLOUDRON_OIDC_PROFILE_ENDPOINT
-CLOUDRON_OIDC_CLIENT_ID
-CLOUDRON_OIDC_CLIENT_SECRET
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_OIDC_PROVIDER_NAME` | Provider name |
+| `CLOUDRON_OIDC_DISCOVERY_URL` | Discovery URL |
+| `CLOUDRON_OIDC_ISSUER` | Issuer |
+| `CLOUDRON_OIDC_AUTH_ENDPOINT` | Authorization endpoint |
+| `CLOUDRON_OIDC_TOKEN_ENDPOINT` | Token endpoint |
+| `CLOUDRON_OIDC_KEYS_ENDPOINT` | Keys endpoint |
+| `CLOUDRON_OIDC_PROFILE_ENDPOINT` | Profile endpoint |
+| `CLOUDRON_OIDC_CLIENT_ID` | Client ID |
+| `CLOUDRON_OIDC_CLIENT_SECRET` | Client secret |
 
-Options:
-
-- `loginRedirectUri` — Callback path (e.g. `/auth/openid/callback`). Multiple paths: comma-separated.
-- `logoutRedirectUri` — Post-logout path.
-- `tokenSignatureAlgorithm` — `RS256` (default) or `EdDSA`.
+| Option | Description |
+|--------|-------------|
+| `loginRedirectUri` | Callback path (e.g. `/auth/openid/callback`). Multiple paths: comma-separated |
+| `logoutRedirectUri` | Post-logout path |
+| `tokenSignatureAlgorithm` | `RS256` (default) or `EdDSA` |
 
 ## sendmail
 
 Outgoing email (SMTP relay).
 
-```text
-CLOUDRON_MAIL_SMTP_SERVER
-CLOUDRON_MAIL_SMTP_PORT           # STARTTLS disabled on this port
-CLOUDRON_MAIL_SMTPS_PORT
-CLOUDRON_MAIL_SMTP_USERNAME
-CLOUDRON_MAIL_SMTP_PASSWORD
-CLOUDRON_MAIL_FROM
-CLOUDRON_MAIL_FROM_DISPLAY_NAME   # only when supportsDisplayName is set
-CLOUDRON_MAIL_DOMAIN
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_MAIL_SMTP_SERVER` | SMTP server |
+| `CLOUDRON_MAIL_SMTP_PORT` | SMTP port (STARTTLS disabled on this port) |
+| `CLOUDRON_MAIL_SMTPS_PORT` | SMTPS port |
+| `CLOUDRON_MAIL_SMTP_USERNAME` | SMTP username |
+| `CLOUDRON_MAIL_SMTP_PASSWORD` | SMTP password |
+| `CLOUDRON_MAIL_FROM` | From address |
+| `CLOUDRON_MAIL_FROM_DISPLAY_NAME` | From display name (only when supportsDisplayName is set) |
+| `CLOUDRON_MAIL_DOMAIN` | Mail domain |
 
-Options:
-
-- `optional: true` — All env vars absent; app uses user-provided email config.
-- `supportsDisplayName: true` — Enables `CLOUDRON_MAIL_FROM_DISPLAY_NAME`.
-- `requiresValidCertificate: true` — Sets `CLOUDRON_MAIL_SMTP_SERVER` to FQDN.
+| Option | Description |
+|--------|-------------|
+| `optional: true` | All env vars absent; app uses user-provided email config |
+| `supportsDisplayName: true` | Enables `CLOUDRON_MAIL_FROM_DISPLAY_NAME` |
+| `requiresValidCertificate: true` | Sets `CLOUDRON_MAIL_SMTP_SERVER` to FQDN |
 
 ## recvmail
 
-Incoming email (IMAP/POP3).
+Incoming email (IMAP/POP3). May be disabled if the server is not receiving email for the domain. Handle absent env vars.
 
-```text
-CLOUDRON_MAIL_IMAP_SERVER
-CLOUDRON_MAIL_IMAP_PORT
-CLOUDRON_MAIL_IMAPS_PORT
-CLOUDRON_MAIL_POP3_PORT
-CLOUDRON_MAIL_POP3S_PORT
-CLOUDRON_MAIL_IMAP_USERNAME
-CLOUDRON_MAIL_IMAP_PASSWORD
-CLOUDRON_MAIL_TO
-CLOUDRON_MAIL_TO_DOMAIN
-```
-
-May be disabled if the server is not receiving email for the domain. Handle absent env vars.
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_MAIL_IMAP_SERVER` | IMAP server |
+| `CLOUDRON_MAIL_IMAP_PORT` | IMAP port |
+| `CLOUDRON_MAIL_IMAPS_PORT` | IMAPS port |
+| `CLOUDRON_MAIL_POP3_PORT` | POP3 port |
+| `CLOUDRON_MAIL_POP3S_PORT` | POP3S port |
+| `CLOUDRON_MAIL_IMAP_USERNAME` | IMAP username |
+| `CLOUDRON_MAIL_IMAP_PASSWORD` | IMAP password |
+| `CLOUDRON_MAIL_TO` | To address |
+| `CLOUDRON_MAIL_TO_DOMAIN` | To domain |
 
 ## email
 
-Full email capabilities (SMTP + IMAP + ManageSieve). For webmail applications.
+Full email capabilities (SMTP + IMAP + ManageSieve). For webmail applications. Accept self-signed certificates for internal IMAP/Sieve connections.
 
-```text
-CLOUDRON_EMAIL_SMTP_SERVER
-CLOUDRON_EMAIL_SMTP_PORT
-CLOUDRON_EMAIL_SMTPS_PORT
-CLOUDRON_EMAIL_STARTTLS_PORT
-CLOUDRON_EMAIL_IMAP_SERVER
-CLOUDRON_EMAIL_IMAP_PORT
-CLOUDRON_EMAIL_IMAPS_PORT
-CLOUDRON_EMAIL_SIEVE_SERVER
-CLOUDRON_EMAIL_SIEVE_PORT
-CLOUDRON_EMAIL_DOMAIN
-CLOUDRON_EMAIL_DOMAINS
-CLOUDRON_EMAIL_SERVER_HOST
-```
-
-Accept self-signed certificates for internal IMAP/Sieve connections.
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_EMAIL_SMTP_SERVER` | SMTP server |
+| `CLOUDRON_EMAIL_SMTP_PORT` | SMTP port |
+| `CLOUDRON_EMAIL_SMTPS_PORT` | SMTPS port |
+| `CLOUDRON_EMAIL_STARTTLS_PORT` | STARTTLS port |
+| `CLOUDRON_EMAIL_IMAP_SERVER` | IMAP server |
+| `CLOUDRON_EMAIL_IMAP_PORT` | IMAP port |
+| `CLOUDRON_EMAIL_IMAPS_PORT` | IMAPS port |
+| `CLOUDRON_EMAIL_SIEVE_SERVER` | Sieve server |
+| `CLOUDRON_EMAIL_SIEVE_PORT` | Sieve port |
+| `CLOUDRON_EMAIL_DOMAIN` | Email domain |
+| `CLOUDRON_EMAIL_DOMAINS` | Email domains (multiple) |
+| `CLOUDRON_EMAIL_SERVER_HOST` | Server host |
 
 ## proxyauth
 
-Authentication wall in front of the app. Reserves `/login` and `/logout` routes.
+Authentication wall in front of the app. Reserves `/login` and `/logout` routes. Cannot be added to an existing app — reinstall required.
 
-Options:
-
-- `path` — Restrict to a path (e.g. `/admin`). Prefix with `!` to exclude (e.g. `!/webhooks`).
-- `basicAuth` — Enable HTTP Basic auth (bypasses 2FA).
-- `supportsBearerAuth` — Forward `Bearer` tokens to the app.
-
-Cannot be added to an existing app — reinstall required.
+| Option | Description |
+|--------|-------------|
+| `path` | Restrict to a path (e.g. `/admin`). Prefix with `!` to exclude (e.g. `!/webhooks`) |
+| `basicAuth` | Enable HTTP Basic auth (bypasses 2FA) |
+| `supportsBearerAuth` | Forward `Bearer` tokens to the app |
 
 ## scheduler
 
-Cron-like periodic tasks.
+Cron-like periodic tasks. Commands run in the app's environment (same env vars, access to `/tmp` and `/run`). 30-minute grace period per task.
 
 ```json
 "scheduler": {
@@ -218,31 +204,30 @@ Cron-like periodic tasks.
 }
 ```
 
-Commands run in the app's environment (same env vars, access to `/tmp` and `/run`). 30-minute grace period per task.
-
 ## tls
 
-Certificate access for non-HTTP protocols.
+Certificate access for non-HTTP protocols. App restarts on certificate renewal.
 
-Files: `/etc/certs/tls_cert.pem`, `/etc/certs/tls_key.pem` (read-only). App restarts on certificate renewal.
+| File | Description |
+|------|-------------|
+| `/etc/certs/tls_cert.pem` | TLS certificate (read-only) |
+| `/etc/certs/tls_key.pem` | TLS private key (read-only) |
 
 ## turn
 
 STUN/TURN service.
 
-```text
-CLOUDRON_TURN_SERVER
-CLOUDRON_TURN_PORT
-CLOUDRON_TURN_TLS_PORT
-CLOUDRON_TURN_SECRET
-```
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_TURN_SERVER` | TURN server |
+| `CLOUDRON_TURN_PORT` | TURN port |
+| `CLOUDRON_TURN_TLS_PORT` | TURN TLS port |
+| `CLOUDRON_TURN_SECRET` | TURN secret |
 
 ## docker
 
-Create Docker containers (restricted). Only superadmins can install/exec apps with this addon.
+Create Docker containers (restricted). Only superadmins can install/exec apps with this addon. Restrictions: bind mounts under `/app/data` only, created containers join `cloudron` network, containers removed on app uninstall.
 
-```text
-CLOUDRON_DOCKER_HOST              # tcp://<IP>:<port>
-```
-
-Restrictions: bind mounts under `/app/data` only, created containers join `cloudron` network, containers removed on app uninstall.
+| Env var | Description |
+|---------|-------------|
+| `CLOUDRON_DOCKER_HOST` | Docker host (`tcp://<IP>:<port>`) |


### PR DESCRIPTION
## Summary

- Convert `addons-ref.md` from prose+code-block format to table format for consistency with `manifest-ref.md`
- Preserve all 77 `CLOUDRON_*` env vars, options, debug commands, and warnings
- Reduce line count from 248 to 233 lines (~6% reduction)
- Improve scannability for LLM and human readers

## Classification

This file is a **reference corpus** (env var listings, configuration options), not an instruction doc. Per the issue guidance, reference corpora should not be compressed — but they can be reformatted for consistency. The table format matches the sibling `manifest-ref.md` and improves readability.

## Verification

- [x] All 77 `CLOUDRON_*` env var references preserved
- [x] Both "reinstall required" warnings preserved (ldap, proxyauth)
- [x] Both debug commands preserved (mysql, postgresql)
- [x] All addon options preserved
- [x] markdownlint passes

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs-only change, no code)
- **Behaviour verified**: N/A — reference documentation

Closes #12685