### PR TITLE
GH#12701: tighten opencode.md from 191 to 181 lines

### DIFF
--- a/.agents/tools/opencode/opencode.md
+++ b/.agents/tools/opencode/opencode.md
@@ -13,8 +13,6 @@ tools:
 
 # OpenCode Integration
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 - **Primary Agent**: `aidevops` — full framework access
@@ -29,13 +27,6 @@ tools:
 | Alternative config | `~/.opencode/` (some installations) |
 | aidevops agents | `~/.aidevops/agents/` (after setup.sh) |
 | Credentials | `~/.config/aidevops/credentials.sh` |
-
-```bash
-opencode auth login   # See tools/opencode/opencode-anthropic-auth.md
-# Tab = switch primary agents | @agent-name = invoke subagent
-```
-
-<!-- AI-CONTEXT-END -->
 
 ## Authentication
 
@@ -188,4 +179,3 @@ See `workflows/session-manager.md` for session lifecycle, terminal tab spawning,
 
 - [OpenCode Agents Documentation](https://opencode.ai/docs/agents)
 - [OpenCode MCP Servers](https://opencode.ai/docs/mcp-servers/)
-- [aidevops Framework](https://github.com/marcusquinn/aidevops)


### PR DESCRIPTION
## Summary

- Remove `<!-- AI-CONTEXT-START/END -->` wrapper tags (4 lines) — these are a Claude Code context hint pattern not needed in this subagent doc
- Remove redundant `opencode auth login` bash block from Quick Reference (already covered in the Authentication section below it)
- Remove redundant `[aidevops Framework]` link from References (we're inside the framework)

All functional content preserved: agent architecture table, configuration examples, permission model, troubleshooting, parallel sessions, CLI testing, MCP env var workaround.

## Runtime Testing

- **Risk level**: Low (docs-only change)
- **Verification**: `self-assessed` — no code paths changed

## Files Changed

- `.agents/tools/opencode/opencode.md` — 191 → 181 lines, removed noise/redundancy

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12701

---
[aidevops.sh](https://aidevops.sh) v3.5.184 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 4,070 tokens on this as a headless worker.