### PR TITLE
GH#12656: tighten animejs.md 185→168 lines

### DIFF
--- a/.agents/tools/animation/animejs.md
+++ b/.agents/tools/animation/animejs.md
@@ -10,6 +10,8 @@ docs_url: https://animejs.com/documentation
 ## Quick Reference
 
 ```javascript
+// npm install animejs  |  CDN: https://cdn.jsdelivr.net/npm/animejs@4/lib/anime.min.js
+// Targets: CSS selector, DOM element, NodeList, JS object, array
 import { animate, createTimeline, stagger, utils, svg } from 'animejs';
 
 animate('.element', { translateX: 250, opacity: 0.5, duration: 800, ease: 'outExpo' });
@@ -19,23 +21,6 @@ tl.add('.box1', { translateX: 100 }).add('.box2', { translateY: 100 }, '-=200');
 
 animate('.items', { scale: [0, 1], delay: stagger(100, { from: 'center' }) });
 ```
-
-## Installation
-
-```bash
-npm install animejs
-# or CDN: <script src="https://cdn.jsdelivr.net/npm/animejs@4/lib/anime.min.js"></script>
-```
-
-## Targets
-
-| Type | Example |
-|------|---------|
-| CSS Selector | `'.my-class'`, `'#my-id'` |
-| DOM Element | `document.querySelector('.el')` |
-| NodeList | `document.querySelectorAll('.els')` |
-| JS Object | `{ x: 0, y: 0 }` |
-| Array | `[element1, element2]` |
 
 ## Animation Parameters
 
@@ -180,6 +165,4 @@ utils.round(3.14159, 2);           // 3.14
 
 ## Resources
 
-- [Official Documentation](https://animejs.com/documentation)
-- [GitHub Repository](https://github.com/juliangarnier/anime)
 - [CodePen Examples](https://codepen.io/collection/XLebem)


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/animation/animejs.md` from 185 to 168 lines (9% reduction).

## Changes

- Folded `## Installation` section into Quick Reference as a comment (saves 6 lines)
- Folded `## Targets` table into Quick Reference as a comment (saves 10 lines)
- Removed `## Resources` entries that duplicate frontmatter `docs_url`/`upstream_url`; kept unique CodePen link (saves 3 lines)

## Content Preservation

All functional content preserved:
- Installation command and CDN URL: present in Quick Reference comment
- All target types: present in Quick Reference comment
- Official docs and GitHub repo URLs: present in frontmatter (`docs_url`, `upstream_url`)
- CodePen examples link: retained in Resources section

## Runtime Testing

- Risk level: **Low** (docs-only change, agent prompt)
- Testing: **self-assessed** — no runtime environment needed for markdown doc changes
- Verification: `wc -l` confirms 185→168; all code blocks, URLs, and migration table intact

Closes #12656

---
[aidevops.sh](https://aidevops.sh) v3.5.184 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,779 tokens on this as a headless worker.