### PR TITLE
GH#12736: tighten skills.md command doc (179→77 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -922,9 +922,9 @@
       "pr": 11813
     },
     ".agents/workflows/git-workflow.md": {
-      "hash": "549fdf7138a059f5338b5cc825a3280fb4ee9a48",
-      "at": "2026-03-28T11:52:27Z",
-      "pr": 11814
+      "hash": "7b3fa2141daa4cec0c3c33e73997f3519a9534d4",
+      "at": "2026-03-29T07:32:12Z",
+      "pr": 12550
     },
     ".agents/marketing-sales/ad-creative-copywriting.md": {
       "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
@@ -1787,9 +1787,9 @@
       "pr": 12666
     },
     ".agents/tools/ai-orchestration/openprose.md": {
-      "hash": "60f188b3ffd45f7943dec1cb45902fe7d3a22318",
-      "at": "2026-03-29T07:02:14Z",
-      "pr": 12657
+      "hash": "352f5da544f3c05517e1012dc060b516aa995506",
+      "at": "2026-03-29T07:31:39Z",
+      "pr": 12707
     },
     ".agents/content/heygen-skill/rules-avatars.md": {
       "hash": "e600865474071a7973fe0ed89b4fd361065e080a",
@@ -1880,6 +1880,26 @@
       "hash": "96d5278ed393a25379da0c21d04db2269219cbf9",
       "at": "2026-03-29T07:03:02Z",
       "pr": 12616
+    },
+    ".agents/workflows/ui-verification.md": {
+      "hash": "c59b154d588638a381fc14e85f435772cb88e31a",
+      "at": "2026-03-29T07:31:37Z",
+      "pr": 12705
+    },
+    ".agents/content/heygen-skill/rules-video-agent.md": {
+      "hash": "1d039d6d91c08e661a96696b19d43edbefe54b0e",
+      "at": "2026-03-29T07:31:38Z",
+      "pr": 12706
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
+      "hash": "29cb61e27a1b31b1f2d08b21b38d276774f9353d",
+      "at": "2026-03-29T07:31:41Z",
+      "pr": 12708
+    },
+    ".agents/tools/deployment/cloudron-server-ops-skill.md": {
+      "hash": "c1fcd168d83da66b8a48ff30f23197361d174aa5",
+      "at": "2026-03-29T07:31:42Z",
+      "pr": 12709
     }
   }
 }

--- a/.agents/scripts/commands/skills.md
+++ b/.agents/scripts/commands/skills.md
@@ -12,116 +12,38 @@ Arguments: $ARGUMENTS
 
 ### Step 1: Determine Operation Mode
 
-Parse `$ARGUMENTS` to determine what to run:
+| Argument pattern | Action |
+|-----------------|--------|
+| empty / "help" | Show available commands and quick examples |
+| free-text query / "search" | `skills-helper.sh search "$ARGUMENTS"` |
+| "search --registry" / "--online" | `skills-helper.sh search --registry "$ARGUMENTS"` |
+| "browse" [category] | `skills-helper.sh browse [category]` |
+| "describe" / "show" \<name\> | `skills-helper.sh describe <name>` |
+| "info" \<name\> | `skills-helper.sh info <name> [--json]` |
+| "list" [filter] | `skills-helper.sh list [--imported\|--native]` |
+| "categories" / "cats" | `skills-helper.sh categories` |
+| "recommend" \<task\> | `skills-helper.sh recommend "<task>"` |
+| "install" \<owner/repo@skill\> | `skills-helper.sh install <owner/repo@skill>` |
+| "registry" / "online" \<query\> | `skills-helper.sh search --registry "$ARGUMENTS"` |
+| "add" \<source\> | `add-skill-helper.sh add <source>` |
+| "update" / "check" | `skill-update-helper.sh check` |
+| "remove" \<name\> | `add-skill-helper.sh remove <name>` |
 
-- If empty or "help": show available commands and quick examples
-- If starts with "search" or is a free-text query: search for matching skills
-- If "search --registry" or "search --online" <query>: search the public skills.sh registry
-- If "browse" [category]: browse skills by category
-- If "describe" or "show" <name>: show detailed skill description
-- If "info" <name>: show metadata (path, source, model tier)
-- If "list" [filter]: list all skills with optional filter
-- If "categories" or "cats": list all categories with counts
-- If "recommend" <task>: suggest skills for a task description
-- If "install" <owner/repo@skill>: install from the public skills.sh registry
-- If "registry" or "online" <query>: search the public skills.sh registry
-- If "add" <source>: delegate to `aidevops skill add` for importing
-- If "update" or "check": delegate to `aidevops skill check/update`
-- If "remove" <name>: delegate to `aidevops skill remove`
+All scripts at `~/.aidevops/agents/scripts/`.
 
-### Step 2: Run Appropriate Command
+### Step 2: Present Results
 
-**Search (most common — also handles free-text queries):**
+Format output conversationally:
 
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh search "$ARGUMENTS"
-```
-
-**Search the public skills.sh registry (online):**
-
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh search --registry "$ARGUMENTS"
-# or
-~/.aidevops/agents/scripts/skills-helper.sh search --online "$ARGUMENTS"
-```
-
-**Browse categories:**
-
-```bash
-# Top-level categories
-~/.aidevops/agents/scripts/skills-helper.sh browse
-
-# Specific category
-~/.aidevops/agents/scripts/skills-helper.sh browse tools/browser
-```
-
-**Describe a skill:**
-
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh describe playwright
-```
-
-**Skill metadata:**
-
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh info seo-audit-skill
-~/.aidevops/agents/scripts/skills-helper.sh info playwright --json
-```
-
-**List skills:**
-
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh list
-~/.aidevops/agents/scripts/skills-helper.sh list --imported
-~/.aidevops/agents/scripts/skills-helper.sh list --native
-```
-
-**Categories:**
-
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh categories
-```
-
-**Recommendations:**
-
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh recommend "scrape a website and extract product data"
-```
-
-**Install from public registry:**
-
-```bash
-~/.aidevops/agents/scripts/skills-helper.sh install vercel-labs/agent-browser@agent-browser
-# or via aidevops CLI
-aidevops skills install vercel-labs/agent-browser@agent-browser
-```
-
-**Import/manage (delegate to existing skill commands):**
-
-```bash
-~/.aidevops/agents/scripts/add-skill-helper.sh add <source>
-~/.aidevops/agents/scripts/skill-update-helper.sh check
-~/.aidevops/agents/scripts/add-skill-helper.sh remove <name>
-```
-
-### Step 3: Present Results
-
-Format the output conversationally:
-
-- **Search results**: List matching skills with category and type (native/imported)
-- **Browse**: Show skills grouped by category with descriptions
+- **Search**: List matching skills with category and type (native/imported)
+- **Browse**: Skills grouped by category with descriptions
 - **Describe**: Full description, subagents, preview, and usage hints
 - **Recommend**: Matched categories with relevant skills and usage tips
 - **Registry search**: Results from skills.sh with install count and URL
 
-**When local search returns no results**, proactively offer registry search:
+**No local results** → proactively offer: `"No local skills found. Try: /skills search --registry <query>"`
 
-> "No local skills found for '<query>'. Search the public skills.sh registry?"
-> Run: `/skills search --registry <query>`
-
-### Step 4: Offer Follow-up Actions
-
-After presenting results, suggest relevant next steps:
+### Step 3: Offer Follow-up Actions
 
 ```text
 Next steps:
@@ -133,41 +55,17 @@ Next steps:
 6. aidevops skill add <repo>            — Import a community skill
 ```
 
-## Quick Reference
-
-| Command | Purpose |
-|---------|---------|
-| `/skills` | Show help and quick examples |
-| `/skills browser` | Search for browser-related skills |
-| `/skills search "deploy"` | Search by keyword |
-| `/skills search --registry "seo"` | Search the public skills.sh registry |
-| `/skills browse tools` | Browse tools category |
-| `/skills browse services` | Browse services category |
-| `/skills describe playwright` | Full description of playwright |
-| `/skills info seo-audit-skill` | Metadata for imported skill |
-| `/skills list --imported` | List imported community skills |
-| `/skills categories` | List all categories with counts |
-| `/skills recommend "test my API"` | Get skill recommendations |
-| `/skills install owner/repo@skill` | Install from public registry |
-
 ## Conversational Mode
 
-When the user asks questions like:
+Interpret natural language and map to the appropriate command:
 
-- "What skills do I have for browser automation?" → Run search "browser automation"
-- "Show me all SEO tools" → Run browse seo
-- "What does the playwright skill do?" → Run describe playwright
-- "I need to deploy a Next.js app" → Run recommend "deploy Next.js app"
-- "How many skills are installed?" → Run list, report count
-- "What categories are available?" → Run categories
-- "Are there any public skills for X?" → Run search --registry "X"
-- "Find skills on skills.sh for Y" → Run search --registry "Y"
-- "Install the vercel browser skill" → Run install vercel-labs/agent-browser@agent-browser
-
-Interpret natural language intent and map to the appropriate command.
-
-**Registry search fallback**: When local search returns 0 results, always suggest:
-> "No local skills found. Try the public registry: `/skills search --registry <query>`"
+- "What skills do I have for browser automation?" → search "browser automation"
+- "Show me all SEO tools" → browse seo
+- "What does the playwright skill do?" → describe playwright
+- "I need to deploy a Next.js app" → recommend "deploy Next.js app"
+- "How many skills are installed?" → list, report count
+- "Are there any public skills for X?" → search --registry "X"
+- "Install the vercel browser skill" → install vercel-labs/agent-browser@agent-browser
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Collapsed verbose per-command code blocks (14 separate blocks) into a single operation-mode lookup table
- Removed duplicate Quick Reference table (identical to Step 1 argument list)
- Removed duplicate registry fallback note (appeared twice)
- Merged Conversational Mode examples into a compact list (removed redundant intro prose)
- All commands, scripts, task IDs, and institutional knowledge preserved

## Changes

- `.agents/scripts/commands/skills.md`: 179 → 77 lines (57% reduction)

## Verification

- All 14 operation modes present in new table
- All 5 script references preserved (`skills-helper`, `add-skill-helper`, `skill-update-helper`, `generate-skills`, `add-skill.md`)
- Registry fallback behaviour preserved
- Follow-up actions block unchanged
- Agent behaviour unchanged — same commands, same routing logic

## Runtime Testing

- Risk: **Low** (docs-only change, no code)
- Level: `self-assessed`

Closes #12736

---
[aidevops.sh](https://aidevops.sh) v3.5.184 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6 — origin:interactive