### PR TITLE
GH#12547: tighten state-journey.md, 188→176 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -922,9 +922,9 @@
       "pr": 11813
     },
     ".agents/workflows/git-workflow.md": {
-      "hash": "549fdf7138a059f5338b5cc825a3280fb4ee9a48",
-      "at": "2026-03-28T11:52:27Z",
-      "pr": 11814
+      "hash": "7b3fa2141daa4cec0c3c33e73997f3519a9534d4",
+      "at": "2026-03-29T07:32:12Z",
+      "pr": 12550
     },
     ".agents/marketing-sales/ad-creative-copywriting.md": {
       "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
@@ -1787,9 +1787,9 @@
       "pr": 12666
     },
     ".agents/tools/ai-orchestration/openprose.md": {
-      "hash": "60f188b3ffd45f7943dec1cb45902fe7d3a22318",
-      "at": "2026-03-29T07:02:14Z",
-      "pr": 12657
+      "hash": "352f5da544f3c05517e1012dc060b516aa995506",
+      "at": "2026-03-29T07:31:39Z",
+      "pr": 12707
     },
     ".agents/content/heygen-skill/rules-avatars.md": {
       "hash": "e600865474071a7973fe0ed89b4fd361065e080a",
@@ -1880,6 +1880,26 @@
       "hash": "96d5278ed393a25379da0c21d04db2269219cbf9",
       "at": "2026-03-29T07:03:02Z",
       "pr": 12616
+    },
+    ".agents/workflows/ui-verification.md": {
+      "hash": "c59b154d588638a381fc14e85f435772cb88e31a",
+      "at": "2026-03-29T07:31:37Z",
+      "pr": 12705
+    },
+    ".agents/content/heygen-skill/rules-video-agent.md": {
+      "hash": "1d039d6d91c08e661a96696b19d43edbefe54b0e",
+      "at": "2026-03-29T07:31:38Z",
+      "pr": 12706
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
+      "hash": "29cb61e27a1b31b1f2d08b21b38d276774f9353d",
+      "at": "2026-03-29T07:31:41Z",
+      "pr": 12708
+    },
+    ".agents/tools/deployment/cloudron-server-ops-skill.md": {
+      "hash": "c1fcd168d83da66b8a48ff30f23197361d174aa5",
+      "at": "2026-03-29T07:31:42Z",
+      "pr": 12709
     }
   }
 }

--- a/.agents/tools/deployment/coolify.md
+++ b/.agents/tools/deployment/coolify.md
@@ -48,13 +48,6 @@ Multi-server config (`configs/coolify-config.json`):
       "ip": "your-server-ip",
       "coolify_url": "https://coolify.yourdomain.com",
       "ssh_key": "~/.ssh/id_ed25519"
-    },
-    "coolify-staging": {
-      "name": "Staging Coolify Server",
-      "host": "staging-coolify.yourdomain.com",
-      "ip": "staging-server-ip",
-      "coolify_url": "https://staging-coolify.yourdomain.com",
-      "ssh_key": "~/.ssh/id_ed25519"
     }
   },
   "api_configuration": {
@@ -65,6 +58,8 @@ Multi-server config (`configs/coolify-config.json`):
   }
 }
 ```
+
+Add additional entries under `servers` for staging/prod environments.
 
 ## Usage
 
@@ -77,91 +72,61 @@ Multi-server config (`configs/coolify-config.json`):
 ./.agents/scripts/coolify-helper.sh status coolify-main
 ```
 
-### Application Management
+### Application & Container Management
 
 ```bash
+# App listing and SSH setup
 ./.agents/scripts/coolify-helper.sh apps main_server
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker ps'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker logs container-name'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'df -h'
-```
+./.agents/scripts/coolify-helper.sh generate-ssh-configs && ssh coolify-main
 
-### SSH Configuration
+# Container operations
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker ps -a'
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker logs -f container-name'
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker exec -it container-name bash'
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker stats'
 
-```bash
-./.agents/scripts/coolify-helper.sh generate-ssh-configs
-ssh coolify-main
+# Image/volume cleanup
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker image prune -a'
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker volume prune'
 ```
 
 ## Security
 
-### Firewall
-
-```bash
-./.agents/scripts/coolify-helper.sh exec coolify-main 'ufw allow 22/tcp'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'ufw allow 80/tcp'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'ufw allow 443/tcp'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'ufw allow 8000/tcp'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'ufw enable'
-```
-
-### SSH Keys
-
 - Use Ed25519 keys; rotate regularly; restrict SSH access to specific IPs
 - Store backup access credentials securely
 
-## Troubleshooting
-
-### Deployment Failures
-
 ```bash
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker logs build-container'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'df -h'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'free -h'
+# Firewall setup (run once on new server)
+./.agents/scripts/coolify-helper.sh exec coolify-main 'ufw allow 22/tcp && ufw allow 80/tcp && ufw allow 443/tcp && ufw allow 8000/tcp && ufw enable'
 ```
 
-### SSL Certificate Issues
+## Troubleshooting
 
 ```bash
+# Deployment failures — check logs, disk, memory
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker logs build-container'
+./.agents/scripts/coolify-helper.sh exec coolify-main 'df -h && free -h'
+
+# SSL issues — verify DNS, check Coolify logs, renew cert
 nslookup yourdomain.com
 ./.agents/scripts/coolify-helper.sh exec coolify-main 'docker logs coolify'
 ./.agents/scripts/coolify-helper.sh exec coolify-main 'certbot renew'
-```
 
-### Application Not Accessible
-
-```bash
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker ps'
+# App not accessible — check containers and ports
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker ps && netstat -tlnp'
 ./.agents/scripts/coolify-helper.sh exec coolify-main 'docker logs app-container'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'netstat -tlnp'
 ```
 
-## Performance
+## Performance & Monitoring
 
 ```bash
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker stats'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'htop'
+./.agents/scripts/coolify-helper.sh exec coolify-main 'docker stats && htop'
 ./.agents/scripts/coolify-helper.sh exec coolify-main 'iostat -x 1'
 ./.agents/scripts/coolify-helper.sh exec coolify-main 'docker exec postgres-container pg_stat_activity'
 ./.agents/scripts/coolify-helper.sh exec coolify-main 'docker exec postgres-container pg_dump dbname > backup.sql'
 ```
 
 - Set CPU/memory limits per container; configure health checks; use Redis caching; CDN for static assets
-
-## Docker & Container Management
-
-```bash
-# Container operations
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker ps -a'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker logs -f container-name'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker exec -it container-name bash'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker stats container-name'
-
-# Image cleanup
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker images'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker image prune -a'
-./.agents/scripts/coolify-helper.sh exec coolify-main 'docker volume prune'
-```
 
 ## Backup & Recovery
 

--- a/.agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md
@@ -2,21 +2,9 @@
 
 State diagrams model state machines and lifecycles. User journey diagrams map user experiences across tasks.
 
----
+## State Diagrams
 
-# State Diagrams
-
-## Basic Syntax
-
-```mermaid
-stateDiagram-v2
-    [*] --> Idle
-    Idle --> Processing : start
-    Processing --> Complete : finish
-    Complete --> [*]
-```
-
-## States & Transitions
+### States & Transitions
 
 ```mermaid
 stateDiagram-v2
@@ -32,7 +20,7 @@ Transition formats: `A --> B`, `B --> C : event`, `C --> D : event [guard]`, `D 
 
 Self-transition: `Processing --> Processing : retry`
 
-## Composite States
+### Composite States
 
 ```mermaid
 stateDiagram-v2
@@ -49,7 +37,7 @@ stateDiagram-v2
     Active --> [*] : terminate
 ```
 
-## Choice, Fork/Join, Concurrent
+### Choice, Fork/Join, Concurrent
 
 ```mermaid
 stateDiagram-v2
@@ -83,7 +71,7 @@ stateDiagram-v2
     }
 ```
 
-## Notes, Direction, Styling
+### Notes, Direction, Styling
 
 ```mermaid
 stateDiagram-v2
@@ -101,7 +89,7 @@ stateDiagram-v2
 
 Direction options: `TB` (default), `BT`, `LR`, `RL`
 
-## Example: Authentication Flow
+### Example: Authentication Flow
 
 ```mermaid
 stateDiagram-v2
@@ -135,9 +123,9 @@ stateDiagram-v2
 
 ---
 
-# User Journey Diagrams
+## User Journey Diagrams
 
-## Basic Syntax
+### Basic Syntax
 
 ```mermaid
 journey
@@ -157,7 +145,7 @@ journey
 
 Task format: `Task name: score: actor1, actor2, ...` — Score 1–5 (1 = negative, 5 = positive).
 
-## Example: SaaS Onboarding
+### Example: SaaS Onboarding
 
 ```mermaid
 journey
@@ -181,7 +169,7 @@ journey
         Upgrade complete: 5: Customer
 ```
 
-## Use Cases & Tips
+### Use Cases & Tips
 
 **When to use:** UX research, identifying pain points, stakeholder communication, service design.
 


### PR DESCRIPTION
## Summary

- Remove redundant Basic Syntax section (merged into States & Transitions — the minimal example added no value over the named-states example that follows it)
- Demote top-level `#` section headers to `##`/`###` for consistent hierarchy
- Remove redundant top-level `---` divider after intro line

## Content Preservation

All code blocks, transition format docs, direction options, examples (Auth Flow, SaaS Onboarding), and tips are preserved intact. Zero knowledge loss.

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Level:** self-assessed
- **Verification:** `wc -l` before: 188, after: 176. All code blocks present.

## Files Changed

- `.agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md` — tightened structure, removed redundant section

Closes #12547

---

---
[aidevops.sh](https://aidevops.sh) v3.5.184 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,561 tokens on this as a headless worker.