### PR TITLE
GH#12681: tighten postgres-drizzle-skill/performance.md

### DIFF
--- a/.agents/services/database/postgres-drizzle-skill/performance.md
+++ b/.agents/services/database/postgres-drizzle-skill/performance.md
@@ -1,7 +1,5 @@
 # Performance Optimization
 
-PostgreSQL and Drizzle ORM performance reference.
-
 ## Indexing
 
 ### B-Tree (Default)


### PR DESCRIPTION
## Summary

- Removes redundant intro sentence ('PostgreSQL and Drizzle ORM performance reference.') which duplicates the file title and directory context
- All code blocks, tables, technical content, and prose descriptions preserved
- 238 lines (was 240)

## Classification

Reference corpus (code-heavy, textbook-style). Per code-simplifier guidance, reference corpora should not be compressed — only restructured. At 238 lines this is already a single well-structured chapter within the larger skill. The only genuine noise was the redundant intro sentence.

## Runtime Testing

- **Risk level**: Low (agent doc, no code changes)
- **Level**: self-assessed
- **Verification**: markdownlint-cli2 — 0 errors

## Files Changed

- `.agents/services/database/postgres-drizzle-skill/performance.md` — removed redundant intro sentence (2 lines)

Closes #12681

---

---
[aidevops.sh](https://aidevops.sh) v3.5.184 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 4,578 tokens on this as a headless worker.