### PR TITLE
GH#12685: tighten addons-ref.md — 210→203 lines

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
@@ -4,10 +4,7 @@ Declare in `CloudronManifest.json` under `addons`. Read env vars at runtime — 
 
 ## localstorage
 
-Writable `/app/data` directory. Backed up. Empty on first install (Docker image files not present). Restore permissions in `start.sh`.
-
-- `ftp` — FTP access: `{ "ftp": { "uid": 33, "uname": "www-data" } }`
-- `sqlite` — Consistent backup: `{ "sqlite": { "paths": ["/app/data/db.sqlite"] } }`
+Writable `/app/data`. Backed up. Empty on first install (Docker image files not present). Restore permissions in `start.sh`. Sub-addons: `ftp` (`{ "ftp": { "uid": 33, "uname": "www-data" } }`), `sqlite` (`{ "sqlite": { "paths": ["/app/data/db.sqlite"] } }`).
 
 ## mysql
 
@@ -23,10 +20,11 @@ CLOUDRON_MYSQL_DATABASE
 ```
 
 - `multipleDatabases: true` — Provides `CLOUDRON_MYSQL_DATABASE_PREFIX` instead of `CLOUDRON_MYSQL_DATABASE`.
-
 Debug: `MYSQL_PWD=$CLOUDRON_MYSQL_PASSWORD mysql --user=$CLOUDRON_MYSQL_USERNAME --host=$CLOUDRON_MYSQL_HOST $CLOUDRON_MYSQL_DATABASE`
 
 ## postgresql
+
+Database pre-created. Extensions: `btree_gist`, `btree_gin`, `citext`, `hstore`, `pgcrypto`, `pg_trgm`, `postgis`, `uuid-ossp`, `unaccent`, `vector`, `vectors`, and more.
 
 ```text
 CLOUDRON_POSTGRESQL_URL
@@ -38,9 +36,6 @@ CLOUDRON_POSTGRESQL_DATABASE
 ```
 
 - `locale` — Set `LC_LOCALE` and `LC_CTYPE` at database creation.
-
-Extensions: `btree_gist`, `btree_gin`, `citext`, `hstore`, `pgcrypto`, `pg_trgm`, `postgis`, `uuid-ossp`, `unaccent`, `vector`, `vectors`, and more.
-
 Debug: `PGPASSWORD=$CLOUDRON_POSTGRESQL_PASSWORD psql -h $CLOUDRON_POSTGRESQL_HOST -p $CLOUDRON_POSTGRESQL_PORT -U $CLOUDRON_POSTGRESQL_USERNAME -d $CLOUDRON_POSTGRESQL_DATABASE`
 
 ## mongodb
@@ -84,9 +79,7 @@ CLOUDRON_LDAP_BIND_PASSWORD
 ```
 
 Filter: `(&(objectclass=user)(|(username=%uid)(mail=%uid)))`
-
 User attrs: `uid`, `cn`, `mail`, `displayName`, `givenName`, `sn`, `username`, `samaccountname`, `memberof`
-
 Group attrs: `cn`, `gidnumber`, `memberuid`
 
 ## oidc


### PR DESCRIPTION
## Summary

- Consolidate `localstorage` sub-addons (ftp/sqlite) from bullet list into inline prose — saves 3 lines
- Move postgresql extensions list before env var block (consistent with mysql pattern) and remove redundant blank lines
- Collapse LDAP filter/user-attrs/group-attrs from 5 lines to 3 (remove blank separators between related items)
- Remove blank line between `multipleDatabases` option and debug command in mysql/postgresql sections

All env var names, debug commands, code blocks, and option flags preserved verbatim.

Closes #12685

## Runtime Testing

- **Risk level**: Low (docs-only change, agent prompt file)
- **Level**: self-assessed
- **Smoke check**: `wc -l` confirms 203 lines (down from 210); all env var names present via grep

## Files Changed

- `.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md` — tighten prose and remove redundant blank lines while preserving all content

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`


---
[aidevops.sh](https://aidevops.sh) v3.5.184 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 4,537 tokens on this as a headless worker.