### PR TITLE
GH#12683: tighten whatsapp.md from 218 to 208 lines

### DIFF
--- a/.agents/services/communications/whatsapp.md
+++ b/.agents/services/communications/whatsapp.md
@@ -3,13 +3,7 @@ description: WhatsApp bot integration via Baileys — QR linking, multi-device, 
 mode: subagent
 tools:
   read: true
-  write: false
-  edit: false
   bash: true
-  glob: false
-  grep: false
-  webfetch: false
-  task: false
 ---
 
 # WhatsApp Bot Integration (Baileys)
@@ -50,7 +44,6 @@ npm install baileys @bufbuild/protobuf  # or: bun add baileys
 import makeWASocket, { DisconnectReason, useMultiFileAuthState, WASocket } from "baileys"
 import { Boom } from "@hapi/boom"
 import pino from "pino"
-
 async function startBot(): Promise<void> {
   const { state, saveCreds } = await useMultiFileAuthState("./auth_info")
   const sock: WASocket = makeWASocket({ auth: state, logger: pino({ level: "warn" }), printQRInTerminal: true, browser: ["aidevops Bot", "Chrome", "1.0.0"] })
@@ -158,7 +151,6 @@ function isRateLimited(sender: string): boolean {
 import { execFileSync } from "child_process"
 import { WASocket, proto } from "baileys"
 interface CommandContext { sock: WASocket; msg: proto.IWebMessageInfo; sender: string; jid: string; args: string; isAdmin: boolean; isGroup: boolean }
-
 // ALWAYS execFileSync with arg arrays — never execSync with string interpolation (shell injection)
 async function dispatchToRunner(runner: string, prompt: string, sender: string): Promise<string> {
   try {
@@ -192,7 +184,6 @@ Native WhatsApp support via [whatsmeow](https://github.com/tulir/whatsmeow) (Go)
 [whatsapp]
   [whatsapp.mywa]
   # No token — QR pairing on first run
-
 [[gateway]]
 name="wa-matrix-bridge"
 enable=true
@@ -214,5 +205,4 @@ E2E broken at bridge — bridge host has plaintext access. See `tools/security/o
 - `services/communications/xmtp.md` — XMTP (Web3 messaging)
 - `tools/security/opsec.md` — Platform trust matrix
 - `tools/security/prompt-injection-defender.md` — Prompt injection defense
-- https://www.whatsapp.com/security/WhatsApp-Security-Whitepaper.pdf
-- https://github.com/42wim/matterbridge
+- [WA Security Whitepaper](https://www.whatsapp.com/security/WhatsApp-Security-Whitepaper.pdf) | [Matterbridge](https://github.com/42wim/matterbridge)


### PR DESCRIPTION
## Summary

- Tightens `.agents/services/communications/whatsapp.md` from 218 to 208 lines (~4.6% reduction)
- Removes false-value tool flags from frontmatter (only list enabled tools — consistent with how other agents omit disabled tools)
- Removes blank lines inside code blocks (between imports and function body; inside TOML config)
- Consolidates two external URL lines into one linked line

## Verification

- [x] All code blocks preserved
- [x] Meta AI privacy warning preserved (line 137)
- [x] URL image example preserved (line 89)
- [x] `commands` map and `CommandContext` interface preserved
- [x] All security warnings preserved (ToS risk, E2E limitations, shell injection)
- [x] All internal doc references intact

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (docs-only change, no code)
- **Smoke check**: `wc -l` confirms 208 lines; diff shows only structural whitespace/frontmatter changes

Closes #12683

---
[aidevops.sh](https://aidevops.sh) v3.5.184 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 3m and 7,287 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WhatsApp service documentation with refined configuration settings.
  * Reformatted related links section for improved readability.

* **Chores**
  * Cleaned up documentation formatting by removing unnecessary whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->