### PR TITLE
GH#12605: tighten turborepo.md from 183 to 143 lines

### DIFF
--- a/.agents/tools/monorepo/turborepo.md
+++ b/.agents/tools/monorepo/turborepo.md
@@ -12,23 +12,38 @@ tools: [read, write, edit, bash, glob, grep, webfetch, task, context7_*]
 
 - **Purpose**: High-performance build system for JS/TS monorepos
 - **Package Manager**: pnpm (recommended), npm, yarn
-- **Docs**: Context7 MCP · **Features**: Incremental caching · Parallel execution · Remote caching (Vercel)
+- **Docs**: [turbo.build/repo/docs](https://turbo.build/repo/docs) (via Context7 MCP) · **Features**: Incremental caching · Parallel execution · Remote caching (Vercel)
 
-**Commands**: `pnpm dev` (all) · `pnpm --filter web dev` (single) · `pnpm --filter web... build` (+ deps)
+**Commands**: `pnpm dev` (all) · `pnpm build` (all) · `pnpm --filter web dev` (single) · `pnpm --filter @workspace/ui build` (full name) · `pnpm --filter web... build` (+ deps)
 
-**Structure**: `apps/{web,mobile,extension}` · `packages/{ui,api,db,auth,shared}` · `tooling/{eslint,typescript}`
+**Structure**:
 
-**Naming**: `packages/ui/web` → `@workspace/ui-web` → `import from "@workspace/ui-web/button"`
+```text
+apps/     (web, mobile, extension)
+packages/ (ui, api, db, auth, i18n, shared)
+tooling/  (eslint, typescript, prettier)
+```
+
+**Package Naming**:
+
+| Location | Name Pattern | Import |
+|----------|--------------|--------|
+| `packages/ui/web` | `@workspace/ui-web` | `@workspace/ui-web/button` |
+| `packages/db` | `@workspace/db` | `@workspace/db/schema` |
+| `tooling/eslint` | `@workspace/eslint-config` | `@workspace/eslint-config` |
 
 **turbo.json**:
 
 ```json
-{ "$schema": "https://turbo.build/schema.json",
+{
+  "$schema": "https://turbo.build/schema.json",
   "tasks": {
-    "build": { "dependsOn": ["^build"], "outputs": [".next/**", "dist/**"] },
-    "dev": { "cache": false, "persistent": true },
-    "lint": { "dependsOn": ["^build"] }, "typecheck": { "dependsOn": ["^build"] }
-  } }
+    "build":     { "dependsOn": ["^build"], "outputs": [".next/**", "dist/**"] },
+    "dev":       { "cache": false, "persistent": true },
+    "lint":      { "dependsOn": ["^build"] },
+    "typecheck": { "dependsOn": ["^build"] }
+  }
+}
 ```
 
 <!-- AI-CONTEXT-END -->

--- a/.agents/tools/monorepo/turborepo.md
+++ b/.agents/tools/monorepo/turborepo.md
@@ -1,16 +1,7 @@
 ---
 description: Turborepo monorepo build system - workspaces, caching, pipelines
 mode: subagent
-tools:
-  read: true
-  write: true
-  edit: true
-  bash: true
-  glob: true
-  grep: true
-  webfetch: true
-  task: true
-  context7_*: true
+tools: [read, write, edit, bash, glob, grep, webfetch, task, context7_*]
 ---
 
 # Turborepo - Monorepo Build System
@@ -19,56 +10,25 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: High-performance build system for JavaScript/TypeScript monorepos
+- **Purpose**: High-performance build system for JS/TS monorepos
 - **Package Manager**: pnpm (recommended), npm, yarn
-- **Docs**: Use Context7 MCP for current documentation
-- **Features**: Incremental builds with caching · Parallel task execution · Remote caching (Vercel) · Dependency-aware task ordering
+- **Docs**: Context7 MCP · **Features**: Incremental caching · Parallel execution · Remote caching (Vercel)
 
-**Common Commands**:
+**Commands**: `pnpm dev` (all) · `pnpm --filter web dev` (single) · `pnpm --filter web... build` (+ deps)
 
-```bash
-pnpm dev                              # all packages
-pnpm build                            # all packages
-pnpm --filter web dev                 # single package
-pnpm --filter @workspace/ui build     # by full name
-pnpm --filter web... build            # package + dependencies
-```
+**Structure**: `apps/{web,mobile,extension}` · `packages/{ui,api,db,auth,shared}` · `tooling/{eslint,typescript}`
 
-**Workspace Structure**:
-
-```text
-/
-├── apps/
-│   ├── web/        # Next.js app
-│   ├── mobile/     # React Native app
-│   └── extension/  # Browser extension
-├── packages/
-│   ├── ui/{web,mobile,shared}/
-│   ├── api/  db/  auth/  i18n/  shared/
-└── tooling/
-    ├── eslint/  typescript/  prettier/
-```
-
-**Package Naming**:
-
-| Location | Name Pattern | Import |
-|----------|--------------|--------|
-| `packages/ui/web` | `@workspace/ui-web` | `@workspace/ui-web/button` |
-| `packages/db` | `@workspace/db` | `@workspace/db/schema` |
-| `tooling/eslint` | `@workspace/eslint-config` | `@workspace/eslint-config` |
+**Naming**: `packages/ui/web` → `@workspace/ui-web` → `import from "@workspace/ui-web/button"`
 
 **turbo.json**:
 
 ```json
-{
-  "$schema": "https://turbo.build/schema.json",
+{ "$schema": "https://turbo.build/schema.json",
   "tasks": {
-    "build":     { "dependsOn": ["^build"], "outputs": [".next/**", "dist/**"] },
-    "dev":       { "cache": false, "persistent": true },
-    "lint":      { "dependsOn": ["^build"] },
-    "typecheck": { "dependsOn": ["^build"] }
-  }
-}
+    "build": { "dependsOn": ["^build"], "outputs": [".next/**", "dist/**"] },
+    "dev": { "cache": false, "persistent": true },
+    "lint": { "dependsOn": ["^build"] }, "typecheck": { "dependsOn": ["^build"] }
+  } }
 ```
 
 <!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

- Consolidate Quick Reference section by inlining commands, structure, and naming patterns
- Convert tools frontmatter from verbose object to compact array format
- Compact turbo.json example while preserving all task configurations

## Changes

**Before:** 183 lines
**After:** 143 lines (22% reduction, well under 150-line target)

## Content Preserved

- All tools in frontmatter
- Purpose, package manager, docs reference, features
- All common commands (pnpm dev, filter patterns)
- Workspace structure (apps, packages, tooling)
- Package naming convention with example
- turbo.json configuration with all tasks
- All Patterns sections (unchanged)
- Common Mistakes table (unchanged)
- Related links (unchanged)

## Runtime Testing

- **Testing level:** self-assessed
- **Risk classification:** Low (docs-only change)
- **Verification:** Markdown linting passes (0 errors)

Closes #12605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Turborepo docs: condensed wording (e.g., "JS/TS"), shortened quick-reference bullets, and replaced verbose command and workspace examples with compact lists/summaries for easier scanning.
  * Simplified frontmatter tools formatting for a cleaner, more concise presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->