### PR TITLE
GH#12725: tighten openprose.md — remove PR-merge loop, drop self-referential table row (195→185 lines)

### DIFF
--- a/.agents/tools/ai-orchestration/openprose.md
+++ b/.agents/tools/ai-orchestration/openprose.md
@@ -137,7 +137,6 @@ let results = items
 
 | Tool | Role |
 |------|------|
-| OpenProse | Workflow orchestration — parallel agents, loops, conditions |
 | DSPy | Prompt optimization — optimized prompts work in agent definitions |
 | Context7 | Library docs; Augment → code search; LLM-TLDR → summarize |
 | TOON | Token-efficient serialization (40-70% fewer tokens) — encode large context before passing between sessions |
@@ -157,6 +156,8 @@ session "Synthesize all reviews"
 
 ### Development Loop with Quality Gates
 
+See `scripts/commands/full-loop.md` for the canonical full-loop workflow. OpenProse equivalent:
+
 ```prose
 agent developer:
   model: opus
@@ -175,17 +176,6 @@ if **any checks failed**:
   loop until **all checks pass** (max: 5):
     session "Fix remaining issues"
       context: { lint, types, tests }
-
-let pr = session "Create pull request with gh pr create --fill"
-
-loop until **PR is merged** (max: 20):
-  parallel:
-    ci = session "Check CI status"
-    review = session "Check review status"
-  if **CI failed**:
-    session "Fix CI issues and push"
-  if **changes requested**:
-    session "Address review feedback and push"
 ```
 
 ## Related


### PR DESCRIPTION
## Summary

- Removes the PR-merge loop from the Development Loop pattern (12 lines) — duplicates `full-loop.md`, belongs there not in the syntax reference
- Drops the self-referential OpenProse row from the Integration table (OpenProse describing itself adds no value)
- Adds pointer to `scripts/commands/full-loop.md` in the Development Loop section
- 195 → 185 lines; zero content loss for unique knowledge

## Verification

- All syntax reference code blocks preserved unchanged
- All task IDs, URLs, and command examples intact
- `bunx markdownlint-cli2` — 0 errors
- Risk: **Low** (docs-only, agent prompt file) — self-assessed per runtime testing gate

## Runtime Testing

- Level: `self-assessed`
- Risk: Low (agent prompt doc, no executable code)
- Dev environment: N/A

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12725


---
[aidevops.sh](https://aidevops.sh) v3.5.198 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 891 tokens on this as a headless worker.