### PR TITLE
GH#12684: fix proxy-integration.md — remove undocumented dns-check command

### DIFF
--- a/.agents/tools/browser/proxy-integration.md
+++ b/.agents/tools/browser/proxy-integration.md
@@ -129,10 +129,9 @@ anti-detect-helper.sh proxy check "http://user:pass@host:port"
 # Check all profile proxies
 anti-detect-helper.sh proxy check-all
 # Output: IP, country, city, ISP, speed, anonymity level
-
-# Verify no DNS leaks through proxy
-anti-detect-helper.sh proxy dns-check "profile-name"
 ```
+
+DNS leak prevention: Playwright handles automatically; Camoufox uses `network.proxy.socks_remote_dns = true` (default).
 
 ## Rotation Strategies
 


### PR DESCRIPTION
## Summary

Addresses Gemini review feedback on PR #12727 for issue #12684.

### Changes

1. **Remove undocumented `dns-check` command** — `anti-detect-helper.sh proxy dns-check` was documented but not implemented (falls through to "Unknown proxy command" error). Removed from docs.
2. **Add DNS leak prevention note** — Added clarification that DNS leak prevention is handled at the browser engine level (Playwright automatic, Camoufox via `network.proxy.socks_remote_dns`).

### Gemini feedback items — all addressed

| # | Gemini item | Status |
|---|-------------|--------|
| 1 | Restore WebShare "Direct proxy list" example | ✅ Present (never removed on this branch) |
| 2 | Restore proxy health check output description | ✅ Present (never removed on this branch) |
| 3 | Revert Camoufox proxy dict to multi-line | ✅ Multi-line (never changed on this branch) |
| 4 | Revert Playwright/Crawl4AI proxy dict to multi-line | ✅ Multi-line (never changed on this branch) |
| 5 | Remove undocumented `dns-check` command | ✅ Removed |

### Verification

- `markdownlint-cli2`: 0 errors
- All code blocks, URLs, and commands verified
- Rebased onto latest main (no conflicts)

## Runtime Testing

- **Testing level**: `self-assessed`
- **Risk classification**: Low (docs only)

Closes #12684