### PR TITLE
GH#12794: tighten openprose.md — remove redundant parallel-all, fix dual-context ambiguity

### DIFF
--- a/.agents/tools/ai-orchestration/openprose.md
+++ b/.agents/tools/ai-orchestration/openprose.md
@@ -49,8 +49,10 @@ agent researcher:
 let result = session "Get result"         # mutable
 const config = session "Get config"       # immutable
 session "Use both"
-  context: [result, config]               # array
-  context: { result, config }             # object
+  context: [result, config]               # array form
+# or:
+session "Use both"
+  context: { result, config }             # object form
 ```
 
 ### Parallel Execution
@@ -62,8 +64,7 @@ parallel:                                 # Default: wait for all
 
 parallel ("first"):                       # race - first wins
 parallel ("any"):                         # first success
-parallel ("all"):                         # wait for all (explicit)
-parallel (on-fail: "continue"):           # let all complete
+parallel (on-fail: "continue"):           # don't abort on failure
 parallel (on-fail: "ignore"):             # treat failures as success
 ```
 
@@ -138,7 +139,7 @@ let results = items
 | Tool | Role |
 |------|------|
 | DSPy | Prompt optimization — optimized prompts work in agent definitions |
-| Context7 | Library docs; Augment → code search; LLM-TLDR → summarize |
+| Context7 | Inject library docs into session context |
 | TOON | Token-efficient serialization (40-70% fewer tokens) — encode large context before passing between sessions |
 
 ## Patterns


### PR DESCRIPTION
## Summary

- Remove `parallel ("all"):` — redundant with the default `# Default: wait for all` comment already on the `parallel:` block
- Fix dual `context:` lines on same session block (syntactically ambiguous — implies a session can have two context declarations) — add `# or:` separator to show these are alternative forms
- Fix `on-fail: "continue"` comment: `"let all complete"` was misleading (implies waiting, not failure tolerance) → `"don't abort on failure"`
- Tighten Context7 integration table row: was describing Context7's own capabilities (`Library docs; Augment → code search; LLM-TLDR → summarize`), now describes the integration with OpenProse (`Inject library docs into session context`)

## Changes

- `.agents/tools/ai-orchestration/openprose.md` — 185→186 lines (net +1 from clarity fix; -1 redundant line, +2 clarification lines)

## Runtime Testing

- **Risk level**: Low (docs/agent prompt — no code execution)
- **Level**: self-assessed
- **Verification**: Content preservation confirmed — all code blocks, URLs, and command examples present before and after

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12794


---
[aidevops.sh](https://aidevops.sh) v3.5.210 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,513 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified context configuration options with updated examples for better clarity
  * Simplified parallel execution documentation with improved guidance on failure handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->