### PR TITLE
GH#12768: tighten postgres-drizzle-skill/performance.md (238→236 lines)

### DIFF
--- a/.agents/services/database/postgres-drizzle-skill/performance.md
+++ b/.agents/services/database/postgres-drizzle-skill/performance.md
@@ -24,8 +24,6 @@ export const users = pgTable('users', {
 
 ### Partial Indexes
 
-Index only matching rows — smaller, faster.
-
 ```sql
 CREATE INDEX active_users_email_idx ON users(email) WHERE deleted_at IS NULL;
 CREATE INDEX pending_orders_idx ON orders(created_at) WHERE status = 'pending';


### PR DESCRIPTION
## Summary

- Removes redundant prose line under `### Partial Indexes`: _"Index only matching rows — smaller, faster."_
- This is self-evident from the section heading and the SQL `WHERE` clause examples directly below it
- All code blocks, tables, SQL snippets, and technical specifics preserved

## Changes

| File | Before | After |
|------|--------|-------|
| `.agents/services/database/postgres-drizzle-skill/performance.md` | 238 lines | 236 lines |

## Verification

- Content preservation: all code blocks, URLs, and command examples present before and after ✓
- No broken internal links or references ✓
- Agent behaviour unchanged — no actionable content removed ✓

## Runtime Testing

- **Risk level:** Low (docs-only change)
- **Level:** self-assessed
- **Rationale:** Markdown doc edit; no code paths affected

## Context

This is a regression simplification task. The file was previously simplified in #12757 (240→238), #12668 (244→240), and #12567 (251→244). The scanner re-flagged at 238 lines. Two prior opus-tier worker attempts thrashed (62 messages, 0 commits) because they targeted too aggressive a reduction (145→175 lines) on a file that is already well-tightened.

The only genuine noise remaining was this one redundant prose line. Further reduction without information loss is not possible — the file is at its natural floor for this structure.

Closes #12768

---
[aidevops.sh](https://aidevops.sh) v3.5.210 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 4,441 tokens on this as a headless worker.