### PR TITLE
GH#12036: tighten google-chat.md (259→254 lines)

### DIFF
--- a/.agents/services/communications/google-chat.md
+++ b/.agents/services/communications/google-chat.md
@@ -60,17 +60,13 @@ chmod 600 ~/.config/aidevops/google-chat-sa-key.json
 
 [Google Cloud Console > APIs & Services > Google Chat API > Configuration](https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat): set HTTP endpoint URL, enable "Receive 1:1 messages" and "Join spaces and group conversations", set Authentication Audience to HTTP endpoint URL.
 
-### Step 3: Public URL + Bot Configuration
+### Step 3: Public URL
 
 | Option | Command |
 |--------|---------|
 | Tailscale Funnel | `tailscale funnel 8443` |
 | Caddy | `caddy reverse-proxy --from chat-bot.example.com --to localhost:8443` |
 | Cloudflare Tunnel | `cloudflared tunnel --url http://localhost:8443 run chat-bot` |
-
-```bash
-google-chat-helper.sh setup  # Interactive wizard
-```
 
 ## Configuration
 
@@ -218,8 +214,7 @@ For sensitive communications, prefer Matrix (self-hosted) or SimpleX.
 - Scan inbound with `prompt-guard-helper.sh`; scan outbound for credential patterns
 - Use reverse proxy (Caddy/Cloudflare) for TLS — don't expose bot directly
 - Log all events; redact sensitive content
-
-**FCM note**: Google uses Firebase Cloud Messaging for mobile push — FCM infrastructure knows when users receive Chat notifications.
+- FCM note: Google uses Firebase Cloud Messaging for mobile push — FCM infrastructure knows when users receive Chat notifications
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

- Removed duplicate `google-chat-helper.sh setup` command from Step 3 (already present in Quick Reference at top of file)
- Renamed "Step 3: Public URL + Bot Configuration" → "Step 3: Public URL" (the heading implied bot config happened here; it doesn't)
- Converted standalone `**FCM note**` bold paragraph into an inline bullet in the Bot-Specific Security list (same section, better flow, -1 blank line)

## Verification

- All code blocks, URLs, command examples, and security rules preserved
- `bunx markdownlint-cli2` → 0 errors
- Line count: 259 → 254 (5 lines removed, all genuine noise)
- No information loss — duplicate command removed, not unique content

## Runtime Testing

- **Risk level**: Low (docs-only change)
- **Verification**: self-assessed
- **Smoke check**: markdownlint clean, diff reviewed line-by-line

Closes #12036

actionable_findings_total=0
fixed_in_pr=0
deferred_tasks_created=0
coverage=100%