### PR TITLE
GH#12864: tighten openprose.md frontmatter

### DIFF
--- a/.agents/tools/ai-orchestration/openprose.md
+++ b/.agents/tools/ai-orchestration/openprose.md
@@ -1,14 +1,7 @@
 ---
 description: OpenProse DSL for multi-agent orchestration - structured English for AI session control flow
 mode: subagent
-tools:
-  read: true
-  write: true
-  edit: true
-  bash: true
-  glob: true
-  grep: true
-  task: true
+tools: [read, write, edit, bash, glob, grep, task]
 ---
 
 # OpenProse - Multi-Agent Orchestration DSL
@@ -157,7 +150,7 @@ session "Synthesize all reviews"
 
 ### Development Loop with Quality Gates
 
-See `scripts/commands/full-loop.md` for the canonical full-loop workflow. OpenProse equivalent:
+See `scripts/commands/full-loop.md` for the canonical workflow. OpenProse equivalent:
 
 ```prose
 agent developer:


### PR DESCRIPTION
## Summary

- Condense `tools:` frontmatter block from 8 lines to 1 inline array (`[read, write, edit, bash, glob, grep, task]`)
- Minor prose tightening: "canonical full-loop workflow" → "canonical workflow" (redundant with file reference)
- 186 → 179 lines. Zero information loss.

## Classification

Instruction doc (not reference corpus) — content compression applied per issue guidance.

## Verification

- All code blocks preserved verbatim
- All URLs intact
- No broken internal references
- Agent behaviour unchanged (syntax reference only)

## Runtime Testing

- Risk: Low (docs/agent prompt only)
- Level: self-assessed
- No runtime verification required

Closes #12864

---

---
[aidevops.sh](https://aidevops.sh) v3.5.222 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,761 tokens on this as a headless worker.