### PR TITLE
GH#12605: simplify turborepo.md — remove duplicate filtering commands

### DIFF
--- a/.agents/tools/monorepo/turborepo.md
+++ b/.agents/tools/monorepo/turborepo.md
@@ -24,16 +24,6 @@ tools:
 - **Docs**: Use Context7 MCP for current documentation
 - **Features**: Incremental builds with caching · Parallel task execution · Remote caching (Vercel) · Dependency-aware task ordering
 
-**Common Commands**:
-
-```bash
-pnpm dev                              # all packages
-pnpm build                            # all packages
-pnpm --filter web dev                 # single package
-pnpm --filter @workspace/ui build     # by full name
-pnpm --filter web... build            # package + dependencies
-```
-
 **Workspace Structure**:
 
 ```text
@@ -75,6 +65,20 @@ pnpm --filter web... build            # package + dependencies
 
 ## Patterns
 
+### Filtering
+
+```bash
+pnpm dev                               # all packages
+pnpm build                             # all packages
+pnpm --filter web dev                  # single package
+pnpm --filter @workspace/ui build      # by full name
+pnpm --filter web... build             # package + dependencies
+pnpm --filter ...web build             # package + dependents
+pnpm --filter web --filter mobile dev  # multiple
+pnpm --filter "./packages/*" build     # by directory
+pnpm --filter "!web" build             # exclude
+```
+
 ### Package.json Exports
 
 ```json
@@ -103,21 +107,11 @@ Use `"workspace:*"` protocol (not `"*"`):
 { "dependencies": { "@workspace/ui-web": "workspace:*", "@workspace/api": "workspace:*" } }
 ```
 
-### Filtering
-
-```bash
-pnpm --filter web dev                  # single
-pnpm --filter web... build             # + dependencies
-pnpm --filter ...web build             # + dependents
-pnpm --filter web --filter mobile dev  # multiple
-pnpm --filter "./packages/*" build     # by directory
-pnpm --filter "!web" build             # exclude
-```
-
 ### Environment Variables
 
+Use `dotenv-cli` to load `.env` before turbo:
+
 ```bash
-# "with-env" loads .env via dotenv-cli before turbo (equivalent: pnpm dotenv -- turbo build)
 pnpm with-env turbo build
 ```
 


### PR DESCRIPTION
## Summary

- Merged the Quick Reference 'Common Commands' block into the Patterns 'Filtering' section, eliminating duplication between the two sections
- Consolidated filtering section now covers all variants (single, deps, dependents, multiple, directory, exclude) in one place with consistent formatting
- Tightened env-vars prose (replaced inline comment with a prose line before the code block)
- 183 → 177 lines; all actionable guidance preserved

## Changes

- `.agents/tools/monorepo/turborepo.md` — removed duplicate filtering block from Quick Reference, merged into Patterns Filtering section, tightened env-vars comment

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only — no code execution paths)
- **Level**: self-assessed
- **Verification**: `diff` confirms all unique filter variants, code blocks, URLs, and Common Mistakes table present before and after

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12605