### PR TITLE
GH#12808: Tighten validation.md from 175 to 143 lines

### DIFF
--- a/.agents/product/validation.md
+++ b/.agents/product/validation.md
@@ -29,17 +29,15 @@ tools:
 
 ### Painkiller vs Vitamin Test
 
-Strong product ideas solve painful, frequent problems. Weak ideas are "nice to have."
-
-**Painkiller criteria** (need 3+ of these):
+**Painkiller criteria** (need 3+):
 
 - Solves something uncomfortable or embarrassing
 - Problem occurs daily or multiple times per week
-- People are already trying to fix it (with workarounds, other products, manual effort)
-- Creates emotional urgency (guilt, fear, frustration, shame, urgency)
+- People already trying to fix it (workarounds, other products, manual effort)
+- Creates emotional urgency (guilt, fear, frustration, shame)
 - People would pay to make it go away
 
-**Red flags** (likely a vitamin, not a painkiller):
+**Red flags** (likely a vitamin):
 
 - "It would be cool if..."
 - No existing solutions (may mean no real demand)
@@ -48,20 +46,14 @@ Strong product ideas solve painful, frequent problems. Weak ideas are "nice to h
 
 ### Market Research Process
 
-1. **Search relevant stores** for similar products using browser tools
-   - App Store / Play Store (mobile)
-   - Chrome Web Store / Firefox Add-ons (extensions)
-   - Product Hunt / AlternativeTo (all types)
-   - Setapp / Mac App Store (desktop)
-2. **Read 1-star and 2-star reviews** of competitors — these reveal unmet needs
-3. **Read 5-star reviews** — these reveal what users value most
+1. **Search relevant stores** — App Store, Play Store, Chrome Web Store, Firefox Add-ons, Product Hunt, AlternativeTo, Setapp, Mac App Store
+2. **Read 1-2 star reviews** — reveal unmet needs
+3. **Read 5-star reviews** — reveal what users value most
 4. **Check download counts and ratings** — validates market size
 5. **Search social media** for complaints about the problem domain
-6. **Check Google Trends** for search volume on related terms
+6. **Check Google Trends** for search volume
 
 ### Competitive Analysis Template
-
-For each competitor product, capture:
 
 | Field | What to Record |
 |-------|---------------|
@@ -73,96 +65,72 @@ For each competitor product, capture:
 | Missing features | What users ask for but don't get |
 | UI quality | Screenshots, design quality assessment |
 | Last updated | Active development signal |
-| Growth channels | How they acquire users (ads, content, organic, influencers) |
+| Growth channels | How they acquire users |
 
 ### Competitor Onboarding as Validation
 
-If a competitor is making significant revenue ($10k+/month), their onboarding flow is battle-tested. Study it structurally:
+If a competitor makes $10k+/month, their onboarding is battle-tested. Study it:
 
-1. **Download/install the top 3-5 competitors** making the most money
-2. **Screenshot every onboarding screen** — capture the full flow from first launch to paywall
-3. **Map the structure**: What questions do they ask? What value do they promise? Where is the paywall?
-4. **Identify the pattern**: Most successful products in a niche converge on a similar onboarding structure because they've A/B tested it extensively
-5. **Adapt the structure, not the content**: Use their proven flow architecture with your own branding, copy, and value proposition. The structure is validated data; the content should be original.
+1. **Download top 3-5 competitors** making the most money
+2. **Screenshot every onboarding screen** — first launch to paywall
+3. **Map the structure**: Questions asked, value promised, paywall placement
+4. **Identify the pattern**: Successful products converge through A/B testing
+5. **Adapt structure, not content**: Use their proven architecture with your branding
 
-This is not copying — it's using market-validated data to inform your design decisions. The same principle applies to pricing: if competitors charge $4.99/month and succeed, that price point is validated.
+Same applies to pricing: if competitors charge $4.99/month and succeed, that price is validated.
 
 ### Feature Scoping
 
-**MVP rules**:
+**MVP rules**: One core daily action, one clean onboarding (3-5 screens), one monetisation path. No social/settings/accounts in v1 unless core to the product.
 
-- One core daily action (the heart of the product)
-- One clean onboarding flow (3-5 screens)
-- One monetisation path (even if free initially)
-- No social features in v1 (unless social IS the core)
-- No settings screen in v1 (sensible defaults)
-- No account system in v1 (unless data sync is core)
-
-**Speed over perfection**: MVP 1 should be functional, not beautiful. Ship in days, not months. Iterate based on real user data. The market rewards speed — a working product with real users beats a polished product with none.
-
-**Feature prioritisation**:
+**Speed over perfection**: Ship in days, not months. Iterate on real user data.
 
 | Priority | Criteria | Example |
 |----------|----------|---------|
-| P0 - Must have | Product doesn't work without it | Core daily action, basic navigation |
-| P1 - Should have | Significantly improves core experience | Streak tracking, notifications |
+| P0 - Must have | Product doesn't work without it | Core action, navigation |
+| P1 - Should have | Significantly improves core | Streaks, notifications |
 | P2 - Nice to have | Enhances but not essential | Themes, sharing, export |
-| P3 - Future | Save for v2+ | Social features, integrations, widgets |
+| P3 - Future | Save for v2+ | Social, integrations, widgets |
 
 ### Output: Product Specification
 
-After planning, produce a specification covering:
-
-1. **Problem statement**: One paragraph describing the pain point
+1. **Problem statement**: One paragraph on the pain point
 2. **Target user**: Demographics, psychographics, usage context
 3. **Core daily action**: The one thing users repeat
 4. **Feature list**: Prioritised P0-P3
-5. **Monetisation model**: How the product makes money (see `product/monetisation.md`)
-6. **Platform**: Which platforms to target and why (see platform-specific agents)
-7. **Design brief**: Colour palette, typography, mood, reference products
-8. **Growth strategy**: How users will discover the product (see `product/growth.md`)
-9. **Success metrics**: What "working" looks like (downloads, retention, revenue)
+5. **Monetisation**: Revenue model (see `product/monetisation.md`)
+6. **Platform**: Target platforms and rationale
+7. **Design brief**: Colours, typography, mood, references
+8. **Growth strategy**: Discovery channels (see `product/growth.md`)
+9. **Success metrics**: Downloads, retention, revenue targets
 
 ## Design Research
 
-Before development, gather visual inspiration. See `tools/design/design-inspiration.md` for the full catalogue of 60+ resources.
+See `tools/design/design-inspiration.md` for 60+ resources. Quick workflow:
 
-**Quick workflow**:
-
-1. **Search Mobbin** (https://mobbin.com) for your product category — study onboarding flows, navigation patterns, paywall designs, and empty states from top-rated products
-2. **Browse Screenlane** (https://screenlane.com) for free UI screenshots by component type
-3. **Search Pinterest** for mood boards: "minimal app UI", "dark onboarding flow", "paywall design"
-4. **Select 4-5 design components** you like (onboarding screens, typography, colours, progress bars, card layouts)
-5. **Capture screenshots** using browser tools for reference during development
+1. **Mobbin** (https://mobbin.com) — onboarding flows, navigation, paywalls
+2. **Screenlane** (https://screenlane.com) — free UI screenshots by component
+3. **Pinterest** — mood boards: "minimal app UI", "dark onboarding", "paywall design"
+4. **Select 4-5 components** you like and capture screenshots for reference
 
 ## Store Research Techniques
 
-### Searching Stores
+### Store URLs
 
-Use browser tools to search:
-
-- Apple App Store: `https://apps.apple.com/search?term={query}`
-- Google Play Store: `https://play.google.com/store/search?q={query}`
+- App Store: `https://apps.apple.com/search?term={query}`
+- Play Store: `https://play.google.com/store/search?q={query}`
 - Chrome Web Store: `https://chromewebstore.google.com/search/{query}`
 - Product Hunt: `https://www.producthunt.com/search?q={query}`
 - AlternativeTo: `https://alternativeto.net/software/{app-name}/`
 - Setapp: `https://setapp.com/search?query={query}`
 
-### Gathering Reviews
+### Review Extraction
 
-Use crawl4ai or browser tools to extract reviews. Focus on:
-
-- **Pain points**: What frustrates users about existing products?
-- **Feature requests**: What do users wish the product could do?
-- **Praise patterns**: What do users love? (Don't break these)
-- **Pricing complaints**: Is the market price-sensitive?
+Use crawl4ai or browser tools. Focus on: pain points, feature requests, praise patterns, pricing complaints.
 
 ### Trend Analysis
 
-- Google Trends for search interest over time
-- App Annie / Sensor Tower (if accessible) for download estimates
-- Reddit/Twitter for community sentiment
-- YouTube for "best X app" review videos (shows what reviewers value)
+Google Trends (search interest), App Annie/Sensor Tower (downloads), Reddit/Twitter (sentiment), YouTube "best X app" videos (reviewer priorities).
 
 ## Related
 
@@ -171,5 +139,5 @@ Use crawl4ai or browser tools to extract reviews. Focus on:
 - `product/growth.md` - User acquisition channels
 - `product/ui-design.md` - Design standards
 - `product/analytics.md` - Metrics and iteration
-- `tools/mobile/app-dev.md` - Mobile-specific development
-- `tools/browser/extension-dev.md` - Extension-specific development
+- `tools/mobile/app-dev.md` - Mobile development
+- `tools/browser/extension-dev.md` - Extension development


### PR DESCRIPTION
## Summary

- Reduces `.agents/product/validation.md` from 175 to 143 lines (18% reduction)
- Preserves all functional content: URLs, file references, tables, decision criteria
- Removes redundant prose without losing institutional knowledge

## Changes

| Section | Before | After | Method |
|---------|--------|-------|--------|
| Painkiller criteria | 5 items verbose | 5 items concise | Trimmed parentheticals |
| Market Research | 6 steps with sub-bullets | 6 steps inline | Merged store list |
| MVP rules | 6 separate bullets | 1 dense line | Condensed |
| Review extraction | 4 separate bullets | 1 line | Condensed |
| Trend analysis | 4 separate bullets | 1 line | Condensed |

## Content Preservation Verification

- [x] All 6 store URLs preserved
- [x] All 7 Related file references preserved
- [x] Both tables (Competitive Analysis, Feature Prioritisation) preserved
- [x] All decision criteria (Painkiller test, Red flags) preserved
- [x] Product Specification 9-item checklist preserved

## Runtime Testing

- **Testing level**: self-assessed
- **Risk classification**: Low (docs-only change)
- **Verification**: markdownlint passes, line count verified

Closes #12808