### PR TITLE
GH#12906: tighten openprose.md (175→172 lines)

### DIFF
--- a/.agents/tools/ai-orchestration/openprose.md
+++ b/.agents/tools/ai-orchestration/openprose.md
@@ -6,7 +6,7 @@ tools: [read, write, edit, bash, glob, grep, task]
 
 # OpenProse - Multi-Agent Orchestration DSL
 
-Use for multi-agent orchestration, repeatable workflows, parallel session spawning, and AI-evaluated conditions. Use aidevops scripts for single-agent DevOps tasks and deterministic logic.
+Multi-agent orchestration DSL. Use for repeatable workflows, parallel session spawning, and AI-evaluated conditions. Use aidevops scripts for single-agent DevOps tasks and deterministic logic.
 
 - **Repo**: <https://github.com/openprose/prose>
 - **Telemetry**: Disabled by default. Override: `"OPENPROSE_TELEMETRY": "disabled"` in `.prose/state.json` or `--no-telemetry`
@@ -42,10 +42,7 @@ agent researcher:
 let result = session "Get result"         # mutable
 const config = session "Get config"       # immutable
 session "Use both"
-  context: [result, config]               # array form
-# or:
-session "Use both"
-  context: { result, config }             # object form
+  context: [result, config]               # array form (or object: { result, config })
 ```
 
 ### Parallel Execution
@@ -127,7 +124,7 @@ let results = items
       session "Combine" context: [acc, item]
 ```
 
-## Integration with aidevops
+## Integrations
 
 | Tool | Role |
 |------|------|


### PR DESCRIPTION
## Summary

- Remove redundant 'Use for' opener (title already states DSL purpose)
- Collapse dual-context example into single inline comment (saves 3 lines)
- Rename section 'Integration with aidevops' → 'Integrations' (shorter, less self-referential)

## Verification

- All code blocks preserved
- All URLs preserved (Repo, Language Spec, VM Semantics, Examples)
- All task/issue refs preserved
- Agent behaviour unchanged (syntax reference doc only)
- 175 → 172 lines (3 lines removed)

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Level**: self-assessed
- **Dev environment**: N/A

## Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12906

---
[aidevops.sh](https://aidevops.sh) v3.5.240 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,189 tokens on this as a headless worker.