### PR TITLE
GH#12927: tighten unbuilt.md agent doc (167→132 lines)

### DIFF
--- a/.agents/tools/research/providers/unbuilt.md
+++ b/.agents/tools/research/providers/unbuilt.md
@@ -24,6 +24,7 @@ tools:
 - **Strengths**: Real-time code analysis of bundled/minified JS (not static signatures)
 - **Prerequisite**: Node.js 16+, Playwright Chromium (`npx playwright install chromium`)
 - **Helper**: `tech-stack-helper.sh unbuilt <url> [--json]`
+- **Install**: `npm install -g @unbuilt/cli && npx playwright install chromium`
 
 ## What It Detects
 
@@ -46,33 +47,15 @@ tools:
 | Monitoring | Sentry, Datadog, Rollbar, New Relic, OpenTelemetry, Vercel Speed Insights |
 | Platforms | Wix, Weebly, Webflow, Squarespace, Shopify |
 
-## CLI Installation
-
-```bash
-npm install -g @unbuilt/cli
-npx playwright install chromium
-```
-
 ## CLI Usage
 
 ```bash
-# Basic analysis (human-readable output)
-unbuilt https://example.com
-
-# JSON output (machine-readable, for integration)
-unbuilt https://example.com --json
-
-# Remote analysis (uses unbuilt.app server, no local Playwright needed)
-unbuilt https://example.com --remote --json
-
-# With authenticated session (uses local Chrome profile)
-unbuilt https://example.com --session
-
-# Custom timeout (default 120s)
-unbuilt https://example.com --timeout 60
-
-# Batch analysis from CSV
-unbuilt batch urls.csv --concurrent 4 --json --output results.json
+unbuilt https://example.com                                          # human-readable
+unbuilt https://example.com --json                                   # machine-readable
+unbuilt https://example.com --remote --json                          # no local Playwright
+unbuilt https://example.com --session                                # local Chrome profile
+unbuilt https://example.com --timeout 60                             # custom timeout (default 120s)
+unbuilt batch urls.csv --concurrent 4 --json --output results.json  # batch from CSV
 ```
 
 ## CLI Options
@@ -86,27 +69,11 @@ unbuilt batch urls.csv --concurrent 4 --json --output results.json
 | `-t, --timeout <s>` | Max wait time in seconds (default: 120) |
 | `--session` | Use local Chrome profile for authenticated analysis |
 
-## Integration Pattern
+## Helper Integration
 
-The `tech-stack-helper.sh` script wraps the CLI for the aidevops framework:
-
-```bash
-# Analyze a single URL
-tech-stack-helper.sh unbuilt https://example.com
-
-# JSON output for programmatic use
-tech-stack-helper.sh unbuilt https://example.com --json
-
-# Auto-install CLI if missing
-tech-stack-helper.sh install unbuilt
-```
+`tech-stack-helper.sh` wraps the CLI: `tech-stack-helper.sh unbuilt <url> [--json]`. Auto-installs CLI if missing: `tech-stack-helper.sh install unbuilt`.
 
 ## Output Schema (JSON mode)
-
-The `--json` flag returns structured results grouped by detection category.
-Each detected technology includes the technology name, category, and evidence.
-
-Example structure:
 
 ```json
 {
@@ -124,8 +91,6 @@ Example structure:
 ```
 
 ## Common Schema Mapping
-
-The helper normalises Unbuilt output into a common tech-stack schema:
 
 | Common Field | Unbuilt Category |
 |-------------|-----------------|


### PR DESCRIPTION
## Summary

- Compress `.agents/tools/research/providers/unbuilt.md` from 167 to 132 lines (21% reduction) with zero knowledge loss
- Merge CLI install commands into Quick Reference bullet (eliminates separate section)
- Compact CLI Usage examples to single-line inline-comment format
- Collapse Integration Pattern section to one prose line (was a redundant code block)
- Drop redundant intro prose from Output Schema and Common Schema Mapping sections

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only — no code execution paths changed)
- **Level**: self-assessed
- **Verification**: `markdownlint-cli2` — 0 errors; `wc -l` confirms 132 lines

## Files Changed

- `.agents/tools/research/providers/unbuilt.md` — terse pass per `tools/build-agent/build-agent.md` guidance

## Actionable Findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12927

---
[aidevops.sh](https://aidevops.sh) v3.5.245 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 4m and 339,042 tokens on this as a headless worker.