### PR TITLE
GH#12925: tighten openprose.md 172→167 lines

### DIFF
--- a/.agents/tools/ai-orchestration/openprose.md
+++ b/.agents/tools/ai-orchestration/openprose.md
@@ -6,12 +6,7 @@ tools: [read, write, edit, bash, glob, grep, task]
 
 # OpenProse - Multi-Agent Orchestration DSL
 
-Multi-agent orchestration DSL. Use for repeatable workflows, parallel session spawning, and AI-evaluated conditions. Use aidevops scripts for single-agent DevOps tasks and deterministic logic.
-
-- **Repo**: <https://github.com/openprose/prose>
-- **Telemetry**: Disabled by default. Override: `"OPENPROSE_TELEMETRY": "disabled"` in `.prose/state.json` or `--no-telemetry`
-
-**Install:**
+Use for repeatable workflows, parallel session spawning, and AI-evaluated conditions. Use aidevops scripts for single-agent DevOps tasks and deterministic logic. **Repo**: <https://github.com/openprose/prose> · **Telemetry**: disabled by default (`"OPENPROSE_TELEMETRY": "disabled"` in `.prose/state.json` or `--no-telemetry`)
 
 ```bash
 # Claude Code


### PR DESCRIPTION
## Summary

- Collapse intro prose + repo/telemetry bullets into a single line (removes 3 lines)
- Remove redundant `**Install:**` bold label before bash block (removes 2 lines)
- All code blocks, URLs, task refs, and actionable guidance preserved

## Verification

- All code blocks, URLs, and actionable guidance preserved
- `markdownlint-cli2`: 0 errors
- 172 → 167 lines (5 lines removed, no content loss)

## Runtime Testing

- **Risk level**: Low (docs-only change)
- **Level**: self-assessed
- **Dev environment**: N/A

Closes #12925

---
[aidevops.sh](https://aidevops.sh) v3.5.248 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 5m and 866,920 tokens on this as a headless worker.