### PR TITLE
GH#12894: tighten vaultwarden.md from 153 to 122 lines

### DIFF
--- a/.agents/tools/credentials/vaultwarden.md
+++ b/.agents/tools/credentials/vaultwarden.md
@@ -21,43 +21,22 @@ tools:
 - **Type**: Self-hosted password manager (Bitwarden API compatible)
 - **CLI**: `npm install -g @bitwarden/cli` then `bw`
 - **Auth**: `bw login email` → `export BW_SESSION=$(bw unlock --raw)`
-- **Config**: `configs/vaultwarden-config.json`
+- **Config**: `configs/vaultwarden-config.json` (copy from `configs/vaultwarden-config.json.txt`)
 - **Commands**: `vaultwarden-helper.sh [instances|status|login|unlock|list|search|get|get-password|create|audit|start-mcp] [instance] [args]`
 - **Session**: `BW_SESSION` env var required after unlock; `unset BW_SESSION && bw lock` when done
+- **Server**: `vault.bitwarden.com` = cloud; any other domain = self-hosted (`bw config server <url>`)
 - **MCP**: Port 3002 for AI assistant credential access
 - **Backup**: `bw export --format json` (encrypt with GPG)
 
 <!-- AI-CONTEXT-END -->
 
-## Service Detection
-
-| Server URL | Service |
-|------------|---------|
-| `vault.bitwarden.com` (default) | Bitwarden Cloud |
-| Any other domain | Vaultwarden self-hosted |
-
-```bash
-bw config server                                    # check current server
-bw config server https://vault.yourdomain.com       # set self-hosted
-```
-
 ## Configuration
-
-```bash
-cp configs/vaultwarden-config.json.txt configs/vaultwarden-config.json
-```
 
 ```json
 {
   "instances": {
-    "production": {
-      "server_url": "https://vault.yourdomain.com",
-      "description": "Production Vaultwarden instance"
-    },
-    "development": {
-      "server_url": "https://dev-vault.yourdomain.com",
-      "description": "Development Vaultwarden instance"
-    }
+    "production": { "server_url": "https://vault.yourdomain.com" },
+    "development": { "server_url": "https://dev-vault.yourdomain.com" }
   }
 }
 ```
@@ -98,16 +77,12 @@ vaultwarden-helper.sh test-mcp 3002
 
 ## MCP Integration
 
-Add to AI assistant MCP servers config:
-
 ```json
 {
   "bitwarden": {
     "command": "bitwarden-mcp-server",
     "args": ["--port", "3002"],
-    "env": {
-      "BW_SERVER": "https://vault.yourdomain.com"
-    }
+    "env": { "BW_SERVER": "https://vault.yourdomain.com" }
   }
 }
 ```
@@ -120,7 +95,7 @@ vaultwarden-helper.sh export production json vault-backup-$(date +%Y%m%d).json
 chmod 600 vault-backup-*.json
 ```
 
-Automated backup script:
+Automated backup (GPG-encrypted, 30-day retention):
 
 ```bash
 #!/bin/bash
@@ -139,15 +114,9 @@ find "$BACKUP_DIR" -name "vault-*.json.gpg" -mtime +30 -delete
 ## Troubleshooting
 
 ```bash
-# Connection
-curl -I https://vault.yourdomain.com
-bw config server https://vault.yourdomain.com
-
-# Auth
-bw status
-bw logout && bw login user@example.com
-bw unlock
-
-# Sync
-bw sync --force
+curl -I https://vault.yourdomain.com          # connection check
+bw config server https://vault.yourdomain.com  # set server
+bw status                                      # auth state
+bw logout && bw login user@example.com         # re-auth
+bw sync --force                                # force sync
 ```


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/credentials/vaultwarden.md` per simplification-debt issue GH#12894.

**Changes:**
- Merged Service Detection section into Quick Reference (server URL rule as a single bullet)
- Removed redundant `cp` command from Configuration section (moved to Quick Reference note)
- Collapsed JSON config example (removed `description` fields — not used by the helper)
- Removed prose intro line from MCP Integration section
- Consolidated Troubleshooting into a single annotated code block (removed duplicate `bw config server` call)
- Added inline comment to Backup section heading

**Result:** 153 → 122 lines (20% reduction). All code blocks, commands, GPG cipher flags, and institutional knowledge preserved.

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only — no code changes)
- **Verification:** Self-assessed — content preservation verified by review

## Actionable findings

- `actionable_findings_total=0`
- `fixed_in_pr=0`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12894

---
[aidevops.sh](https://aidevops.sh) v3.5.248 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 3m and 398,876 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated Vaultwarden configuration and setup documentation for improved clarity
* Simplified configuration examples by removing unnecessary fields
* Streamlined troubleshooting instructions while preserving all diagnostic commands
* Enhanced guidance on cloud vs self-hosted server configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->