### PR TITLE
GH#12914: tighten tunnel-patterns.md — 168 → 164 lines

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md
@@ -80,17 +80,13 @@ ingress:
   - service: http_status:404
 ```
 
-Run on multiple machines:
+Run the same command on each server — Cloudflare automatically load balances:
 
 ```bash
-# Server 1
-cloudflared tunnel run my-tunnel
-
-# Server 2 (same config)
 cloudflared tunnel run my-tunnel
 ```
 
-Cloudflare automatically load balances. Long-lived connections (WebSocket, SSH) will drop during updates.
+Long-lived connections (WebSocket, SSH) drop during replica updates.
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary

- Collapsed redundant HA bash block: two identical `cloudflared tunnel run my-tunnel` commands (with `# Server 1` / `# Server 2` comments) into one, with explanation folded into prose
- All code blocks, URLs, command examples, and YAML patterns preserved
- Zero content loss — the two commands were identical; the comments added no information beyond what the prose now states

## Classification

Reference corpus (code examples, not instruction prose). File is 97% code blocks — no prose tightening applicable beyond the HA section redundancy.

## Runtime Testing

- **Risk level**: Low (agent docs, no runtime)
- **Verification**: `self-assessed` — markdownlint-cli2 passes (0 errors), all code blocks intact
- **Smoke check**: `wc -l` 168 → 164; diff confirms only HA bash block collapsed

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md` — collapse redundant HA bash block

## Actionable Findings

- `actionable_findings_total=1`
- `fixed_in_pr=1`
- `deferred_tasks_created=0`
- `coverage=100%`

Closes #12914

---
[aidevops.sh](https://aidevops.sh) v3.5.248 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 4m and 765,007 tokens on this as a headless worker.