### PR TITLE
fix: exclude cache tokens from signature footer token count

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -256,16 +256,27 @@ _detect_session_tokens() {
 		return 0
 	fi
 
-	# Sum input + output tokens only. Cache tokens (cache.read, cache.write)
-	# represent the same context re-loaded each turn — counting them
-	# cumulatively inflates the number by ~100x (175K context × N turns).
-	# Input + output reflects actual new content processed per session.
+	# Sum non-cached input + output tokens only.
+	# OpenCode >= v1.3.5 stores tokens.input as total input (including
+	# cache.read + cache.write). Earlier versions stored only non-cached input.
+	# Detect which format per-message: if input > cache.read, input includes
+	# cache — subtract cache.read + cache.write. Otherwise use input as-is.
+	# Clamp to 0 to avoid negatives from rounding.
 	local total_tokens
 	total_tokens=$(sqlite3 "$db_path" "
-		SELECT COALESCE(
-			SUM(json_extract(data, '$.tokens.input')) +
-			SUM(json_extract(data, '$.tokens.output')), 0
-		)
+		SELECT COALESCE(SUM(
+			CASE
+				WHEN json_extract(data, '$.tokens.input') >
+				     COALESCE(json_extract(data, '$.tokens.cache.read'), 0)
+				THEN MAX(
+					json_extract(data, '$.tokens.input')
+					- COALESCE(json_extract(data, '$.tokens.cache.read'), 0)
+					- COALESCE(json_extract(data, '$.tokens.cache.write'), 0),
+					0)
+				ELSE json_extract(data, '$.tokens.input')
+			END
+			+ json_extract(data, '$.tokens.output')
+		), 0)
 		FROM message
 		WHERE session_id='${session_id}'
 		  AND json_extract(data, '$.tokens.input') > 0


### PR DESCRIPTION
## Summary

- OpenCode >= v1.3.5 changed `tokens.input` to include `cache.read + cache.write` tokens, inflating reported counts by ~100-200x (e.g., 1.6M reported vs 6.9K actual)
- Added per-message detection: if `input > cache.read`, input includes cache — subtract both `cache.read` and `cache.write`. For older data where input already excludes cache, use as-is.
- Verified against both v1.3.3 (old format) and v1.3.5 (new format) session data — correct results for both

## Evidence

| Session | Old query | Fixed query |
|---------|-----------|-------------|
| GH#12893 (v1.3.5) | 1,496,043 | 6,907 |
| GH#12894 (v1.3.5) | 2,055,518 | 9,330 |
| GH#12229 (v1.3.3) | 10,087 | 10,085 |

## Runtime Testing

- **Risk level**: Low (signature display only, no functional impact)
- **Level**: self-assessed
- SQL verified directly against local OpenCode DB for both old and new format sessions
- ShellCheck: clean (only expected SC1091)
- Existing test suite: 42/43 pass (1 pre-existing skip for non-OpenCode env)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token counting accuracy across different system versions
  * Added safeguards to prevent invalid token counts from computational errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->