### PR TITLE
GH#12965: auto-detect model/tokens/time in signature helper from session DB

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -168,7 +168,7 @@ _detect_cli() {
 _find_session_id() {
 	local db_path="$1"
 
-	local cwd repo_root canonical_dir
+	local cwd repo_root canonical_dir main_worktree
 	cwd=$(pwd 2>/dev/null || echo "")
 	if [[ -z "$cwd" ]]; then
 		echo ""
@@ -177,6 +177,11 @@ _find_session_id() {
 
 	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
 	canonical_dir="${repo_root%%.*}"
+
+	# Resolve the main worktree path (first entry in git worktree list).
+	# In linked worktrees, cwd/repo_root differ from the canonical repo path
+	# where sessions are typically stored (GH#12965).
+	main_worktree=$(git worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //' || echo "")
 
 	local session_id=""
 
@@ -214,7 +219,7 @@ _find_session_id() {
 			local pid_start_ms=$((pid_start_epoch * 1000))
 			session_id=$(sqlite3 "$db_path" "
 				SELECT id FROM session
-				WHERE directory IN ('${cwd}', '${repo_root}', '${canonical_dir}')
+				WHERE directory IN ('${cwd}', '${repo_root}', '${canonical_dir}', '${main_worktree}')
 				ORDER BY ABS(time_created - ${pid_start_ms}) ASC LIMIT 1
 			" 2>/dev/null || echo "")
 		fi
@@ -225,7 +230,7 @@ _find_session_id() {
 	if [[ -z "$session_id" ]]; then
 		session_id=$(sqlite3 "$db_path" "
 			SELECT id FROM session
-			WHERE directory IN ('${cwd}', '${repo_root}', '${canonical_dir}')
+			WHERE directory IN ('${cwd}', '${repo_root}', '${canonical_dir}', '${main_worktree}')
 			ORDER BY time_created DESC LIMIT 1
 		" 2>/dev/null || echo "")
 	fi
@@ -273,6 +278,57 @@ _detect_session_tokens() {
 
 	if [[ -n "$total_tokens" ]] && [[ "$total_tokens" -gt 0 ]] 2>/dev/null; then
 		echo "$total_tokens"
+	else
+		echo ""
+	fi
+	return 0
+}
+
+# =============================================================================
+# Detect model from runtime DB
+# =============================================================================
+# Queries the OpenCode session DB for the model used in the current session.
+# Returns "provider/model" (e.g., "anthropic/claude-sonnet-4-6") or empty.
+# This eliminates the need for callers to pass --model explicitly (GH#12965).
+
+_detect_session_model() {
+	local db_path="${HOME}/.local/share/opencode/opencode.db"
+
+	if [[ ! -r "$db_path" ]] || ! command -v sqlite3 &>/dev/null; then
+		echo ""
+		return 0
+	fi
+
+	local session_id
+	session_id=$(_find_session_id "$db_path")
+
+	if [[ -z "$session_id" ]]; then
+		echo ""
+		return 0
+	fi
+
+	# Extract provider/model from the first message that has model data
+	local provider model_id
+	provider=$(sqlite3 "$db_path" "
+		SELECT json_extract(data, '\$.model.providerID')
+		FROM message
+		WHERE session_id='${session_id}'
+		  AND json_extract(data, '\$.model.modelID') IS NOT NULL
+		LIMIT 1
+	" 2>/dev/null || echo "")
+
+	model_id=$(sqlite3 "$db_path" "
+		SELECT json_extract(data, '\$.model.modelID')
+		FROM message
+		WHERE session_id='${session_id}'
+		  AND json_extract(data, '\$.model.modelID') IS NOT NULL
+		LIMIT 1
+	" 2>/dev/null || echo "")
+
+	if [[ -n "$provider" ]] && [[ -n "$model_id" ]]; then
+		echo "${provider}/${model_id}"
+	elif [[ -n "$model_id" ]]; then
+		echo "$model_id"
 	else
 		echo ""
 	fi
@@ -755,6 +811,11 @@ cmd_generate() {
 	cli_resolved=$(_resolve_cli_inputs "$cli_name" "$cli_version")
 	cli_name="${cli_resolved%%|*}"
 	cli_version="${cli_resolved##*|}"
+
+	# Auto-detect model from session DB if not provided (GH#12965)
+	if [[ -z "$model" ]]; then
+		model=$(_detect_session_model)
+	fi
 
 	# Auto-detect tokens from session DB if not provided
 	if [[ -z "$tokens" ]]; then

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -91,14 +91,17 @@ result=$("$HELPER" generate --cli "OpenCode" --model "anthropic/claude-opus-4-6"
 assert_not_contains "zero tokens omitted" "tokens" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test 4: generate with no model (should omit model)
+# Test 4: generate with no --model flag (auto-detects from session DB if available)
+# GH#12965: model is now auto-detected from the OpenCode session DB, so the
+# output may contain a model even without --model. We only verify the CLI
+# override works and aidevops branding is present.
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 4: no model"
+echo "Test 4: no explicit model (auto-detect from DB)"
 result=$("$HELPER" generate --cli "Cursor" --tokens 0)
 assert_contains "contains Cursor link" "plugin for [Cursor](https://cursor.com)" "$result"
 assert_contains "contains aidevops" "aidevops.sh" "$result"
-assert_not_contains "no model field" "with claude" "$result"
+# Model may or may not be present depending on whether a session DB is available
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 5: footer command includes --- separator

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -146,6 +146,9 @@ EXISTING=$(gh issue list --repo <slug> \
 if [[ "$EXISTING" -gt 0 ]]; then
   echo "Skipping <file_path> — existing open simplification-debt issue found"
 else
+  # Generate signature footer (auto-detects model, tokens, time from session DB)
+  SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer 2>/dev/null || echo "")
+
   gh issue create --repo <slug> \
     --title "simplification: <brief description>" \
     --label "simplification-debt" --label "needs-maintainer-review" \
@@ -155,7 +158,8 @@ else
 ---
 **To approve or decline**, comment on this issue:
 - \`approved\` — removes the review gate and queues for automated dispatch
-- \`declined: <reason>\` — closes this issue"
+- \`declined: <reason>\` — closes this issue
+${SIG_FOOTER}"
 fi
 ```
 


### PR DESCRIPTION
## Summary

Signature footers on issue creation comments were incomplete — showing only `[aidevops.sh](...) v3.5.262 plugin for [OpenCode](...)` without model, tokens, or time. Verified across issues #12960-#12965 — all had truncated signatures.

**Root cause (two bugs):**
1. `gh-signature-helper.sh` had no model auto-detection — it relied on callers passing `--model`, which supervisors/pulse sessions weren't doing
2. `_find_session_id()` only checked `cwd`, `repo_root`, and `canonical_dir` — in linked worktrees, none of these matched the main worktree path where sessions are stored

## Changes

### `gh-signature-helper.sh`
- **`_detect_session_model()`** (new) — queries OpenCode session DB for `$.model.providerID`/`$.model.modelID` from message data. Same pattern as existing `_detect_session_tokens()` and `_detect_session_time()`
- **`_find_session_id()`** — now also checks the main worktree path via `git worktree list --porcelain`. This fixes token/time/model detection when running from linked worktrees
- **`cmd_generate()`** — calls `_detect_session_model()` as fallback when `--model` not provided

### `code-simplifier.md`
- Issue creation template now explicitly calls `gh-signature-helper.sh footer` with the signature appended to the issue body. No `--model` flag needed — auto-detected from DB

### `test-gh-signature-helper.sh`
- Test 4 updated to reflect auto-detection behaviour (model may be present without `--model` flag)

## Verification

- [x] `shellcheck`: clean (only SC1091 info for sourced file)
- [x] `markdownlint`: 0 errors on code-simplifier.md
- [x] All 42 tests pass, 0 failures
- [x] Before fix: `generate` without `--model` → no model in output
- [x] After fix: `generate` without `--model` → `with claude-opus-4-6` auto-detected
- [x] Explicit `--model` override still works correctly
- [x] Worktree path matching verified: running from linked worktree now finds sessions

## Runtime Testing

- **Testing level**: `unit-tested`
- **Risk classification**: Low (shell script utility, no side effects)
- **Test suite**: 42/42 passing

Closes #12965

---
[aidevops.sh](https://aidevops.sh) v3.5.262 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 Solved in 1h 15m.