### PR TITLE
fix: guard against empty agent config writing to opencode.json

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -493,21 +493,26 @@ sorted_agents = dict(sorted(primary_agents.items(), key=lambda x: sort_key(x[0])
 # Build+ is now the unified coding agent (Plan+ and AI-DevOps consolidated)
 # =============================================================================
 
-sorted_agents["build"] = {"disable": True}
-sorted_agents["plan"] = {"disable": True}
-# Disable demoted agents (now subagents accessible via @mention)
-sorted_agents["Plan+"] = {"disable": True}
-sorted_agents["AI-DevOps"] = {"disable": True}
-sorted_agents["Browser-Extension-Dev"] = {"disable": True}
-sorted_agents["Mobile-App-Dev"] = {"disable": True}
-print("  Disabled default 'build' and 'plan' agents")
-print("  Disabled 'Plan+', 'AI-DevOps', 'Browser-Extension-Dev', 'Mobile-App-Dev' (available as @subagents)")
+# Guard: skip agent config if no primary agents discovered (avoids fatal OpenCode crash)
+if not primary_agents:
+    print("  WARNING: No primary agents discovered — skipping agent config update", file=sys.stderr)
+    print("  (agents directory may be empty or deploy incomplete)", file=sys.stderr)
+else:
+    sorted_agents["build"] = {"disable": True}
+    sorted_agents["plan"] = {"disable": True}
+    # Disable demoted agents (now subagents accessible via @mention)
+    sorted_agents["Plan+"] = {"disable": True}
+    sorted_agents["AI-DevOps"] = {"disable": True}
+    sorted_agents["Browser-Extension-Dev"] = {"disable": True}
+    sorted_agents["Mobile-App-Dev"] = {"disable": True}
+    print("  Disabled default 'build' and 'plan' agents")
+    print("  Disabled 'Plan+', 'AI-DevOps', 'Browser-Extension-Dev', 'Mobile-App-Dev' (available as @subagents)")
 
-config['agent'] = sorted_agents
+    config['agent'] = sorted_agents
 
-# Set Build+ as the default agent (first in Tab cycle, auto-selected on startup)
-config['default_agent'] = "Build+"
-print("  Set Build+ as default agent")
+    # Set Build+ as the default agent (first in Tab cycle, auto-selected on startup)
+    config['default_agent'] = "Build+"
+    print("  Set Build+ as default agent")
 
 # =============================================================================
 # INSTRUCTIONS - Auto-load aidevops AGENTS.md for full framework context

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -360,16 +360,25 @@ if output_format == "opencode-json":
         print(f"Error: Failed to load {config_path}: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Disable default and demoted agents
-    sorted_agents["build"] = {"disable": True}
-    sorted_agents["plan"] = {"disable": True}
-    sorted_agents["Plan+"] = {"disable": True}
-    sorted_agents["AI-DevOps"] = {"disable": True}
-    sorted_agents["Browser-Extension-Dev"] = {"disable": True}
-    sorted_agents["Mobile-App-Dev"] = {"disable": True}
+    # Guard: if no primary agents were discovered, skip writing agent config
+    # to avoid leaving OpenCode with only disabled entries (fatal crash:
+    # "undefined is not an object evaluating agents()[0].name").
+    # This can happen if the deploy step hasn't completed or the agents
+    # directory was cleaned but not yet repopulated.
+    if not primary_agents:
+        print("  WARNING: No primary agents discovered — skipping agent config update", file=sys.stderr)
+        print("  (agents directory may be empty or deploy incomplete)", file=sys.stderr)
+    else:
+        # Disable default and demoted agents
+        sorted_agents["build"] = {"disable": True}
+        sorted_agents["plan"] = {"disable": True}
+        sorted_agents["Plan+"] = {"disable": True}
+        sorted_agents["AI-DevOps"] = {"disable": True}
+        sorted_agents["Browser-Extension-Dev"] = {"disable": True}
+        sorted_agents["Mobile-App-Dev"] = {"disable": True}
 
-    config['agent'] = sorted_agents
-    config['default_agent'] = "Build+"
+        config['agent'] = sorted_agents
+        config['default_agent'] = "Build+"
 
     # Instructions — merge into existing list to preserve user-added entries
     instructions_path = os.path.expanduser("~/.aidevops/agents/AGENTS.md")


### PR DESCRIPTION
## Summary

- When no primary agents are discovered (deploy incomplete, agents dir empty during clean phase), the generator wrote only disabled entries to opencode.json
- OpenCode crashes with `undefined is not an object (evaluating 'agents()[0].name')` when all agents are disabled and no active agent exists
- Added guard to both `generate-runtime-config.sh` and `generate-opencode-agents.sh`: skip writing agent config if `primary_agents` is empty, preserving the existing working config

## Root cause

Setup.sh has a "clean mode" step that removes stale files from `~/.aidevops/agents/` before copying new ones. If the config generator runs during this window (or if setup times out mid-deploy), `glob("*.md")` finds nothing, `primary_agents` is empty, and only the 6 disabled entries get written.

## Runtime Testing

- **Risk level**: Low (config generation guard)
- **Level**: self-assessed
- Verified: generator produces correct 10-agent config when agents dir is populated
- Verified: the guard prevents writing when `primary_agents` is empty