### PR TITLE
GH#12982: tighten code-simplifier.md prose and merge integration sections

### DIFF
--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -108,7 +108,7 @@ Knowledge bases (skill docs, domain reference) whose size comes from breadth, no
 3. **Apply project standards** — but standards themselves are not simplification targets.
 4. **Enhance clarity without losing depth.** Reduce nesting, improve naming, remove "what" comments (not "why").
 5. **Maintain balance.** Avoid over-simplification that removes helpful abstractions or loses edge-case handling.
-6. **No arbitrary line targets.** Never set a target line count for simplification. The resulting size is whatever remains after removing genuine noise. Dispatchers and issue creators must not invent reduction targets — this creates pressure to cut content for the sake of a number, conflicting with principle 1. For large files, subdivide per `build-agent.md` (~300-line threshold) instead of compressing.
+6. **No arbitrary line targets.** Never set a target line count — the resulting size is whatever remains after removing genuine noise. Invented targets create pressure to cut content for a number, conflicting with principle 1. For large files, subdivide per `build-agent.md` (~300-line threshold) instead of compressing.
 
 ## Usage
 
@@ -180,15 +180,13 @@ Issue created [simplification-debt + needs-maintainer-review] + assigned
   └─ deferred (no comment) → no change
 ```
 
-## Integration with Quality Workflow
+## Quality Workflow and Pulse Integration
 
 **Automated daily scan (GH#5628):** `pulse-wrapper.sh` creates `simplification-debt` issues for files exceeding per-file violation threshold (default: 1+ functions >100 lines). Deduplicated by repo-relative file path. No file size gate (t1679) — classification determines action. Config: `COMPLEXITY_SCAN_INTERVAL` (default 1 day), `COMPLEXITY_FILE_VIOLATION_THRESHOLD` (default 1), `COMPLEXITY_MD_MIN_LINES` (default 50).
 
 **CI threshold ratchet (GH#5628):** Thresholds in `.agents/configs/complexity-thresholds.conf` (`FUNCTION_COMPLEXITY_THRESHOLD`, `NESTING_DEPTH_THRESHOLD`, `FILE_SIZE_THRESHOLD`). Lower after simplification PRs merge.
 
-## Pulse and Supervisor Integration
-
-Approved issues enter dispatch at **priority 8** (below quality-debt, above oldest-issues). Concurrency cap: 10% of worker slots, 30% combined cap with quality-debt. See `scripts/commands/pulse.md`.
+**Dispatch priority:** Approved issues enter at **priority 8** (below quality-debt, above oldest-issues). Concurrency cap: 10% of worker slots, 30% combined cap with quality-debt. See `scripts/commands/pulse.md`.
 
 **Codacy signal (GH#5628):** Grade B or below → temporary priority boost to 7. Workers fix issues → grade recovers → priority returns to normal.
 


### PR DESCRIPTION
## Summary

- Tighten Principle 6 prose: same rule, fewer words (removed redundant "Dispatchers and issue creators must not invent reduction targets" restatement)
- Merge "Integration with Quality Workflow" + "Pulse and Supervisor Integration" into single "Quality Workflow and Pulse Integration" section — no content lost, one fewer header + blank line

## Changes

- `.agents/tools/code-review/code-simplifier.md`: 202 → 200 lines

## Verification

- All task IDs (`t1679`, `GH#5628`, `GH#6432`, `GH#10783`) present before and after
- All code blocks, URLs, command examples intact
- No rules removed — only prose tightened and sections merged
- `rg "GH#|t[0-9]{4}"` output verified identical in scope

## Runtime Testing

**Level**: `self-assessed` — agent doc, no runtime execution path. Low-risk per testing gate.

Closes #12982


---
[aidevops.sh](https://aidevops.sh) v3.5.266 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 1m and 3,328 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined code review workflow guidance for improved clarity
  * Reorganized quality workflow documentation sections for better structure and accessibility
  * Updated constraint descriptions to reduce ambiguity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->