### PR TITLE
GH#12962: tighten openprose.md 167→164 lines

### DIFF
--- a/.agents/tools/ai-orchestration/openprose.md
+++ b/.agents/tools/ai-orchestration/openprose.md
@@ -96,10 +96,8 @@ else:
   session "Approve"
 
 choice **the best approach**:
-  option "Quick fix":
-    session "Apply quick fix"
-  option "Full refactor":
-    session "Refactor completely"
+  option "Quick fix"
+  option "Full refactor"
 ```
 
 ### Blocks & Pipelines
@@ -145,7 +143,6 @@ session "Synthesize all reviews"
 ```prose
 agent developer:
   model: opus
-  prompt: "You are a senior developer"
 
 loop until **task is complete** (max: 50):
   session: developer


### PR DESCRIPTION
## Summary

- `choice` block: remove redundant `session` lines — option names are self-documenting, the session calls just repeated them verbatim
- Dev loop pattern: drop boilerplate `prompt: "You are a senior developer"` from agent definition — the `prompt:` field is already demonstrated in the Sessions & Agents syntax section

## Verification

- All code blocks preserved
- All URLs preserved (Repo, Language Spec, VM Semantics, Examples, install commands)
- No task/issue refs in this file
- `choice` syntax still shows the construct correctly — options without session bodies are valid OpenProse
- Agent definition still shows `model:` field; `prompt:` field shown elsewhere in the doc
- Agent behaviour unchanged (syntax reference doc only)
- 167 → 164 lines (3 lines removed)

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Level**: self-assessed
- **Dev environment**: N/A

Closes #12962

---
[aidevops.sh](https://aidevops.sh) v3.5.266 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 1m and 4,038 tokens on this as a headless worker.