### PR TITLE
GH#12872: tighten miniflare-patterns.md (189 → 187 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md
@@ -91,8 +91,6 @@ test("scheduled cron handler", async () => {
 
 ## Isolated Test Data
 
-Fresh Miniflare instance per test — no shared state between tests.
-
 ```js
 import test, { beforeEach, afterEach } from "node:test";
 import { Miniflare } from "miniflare";


### PR DESCRIPTION
## Summary

- Removed one redundant prose sentence from the "Isolated Test Data" section: "Fresh Miniflare instance per test — no shared state between tests." — this duplicated both the section heading and the inline code comment `// In-memory: no persist option = fresh state each run`.
- All code examples, patterns, cross-references, and the CI integration note are preserved unchanged.

## Classification

This file is a **reference corpus** (code-example patterns, not an instruction doc). Per the issue guidance, content was not compressed — only genuine noise (a duplicated sentence) was removed.

## Verification

- All code blocks present before and after: ✓
- All cross-references (`gotchas.md`) intact: ✓
- No task IDs or command examples removed: ✓
- Line count: 189 → 187 (2 lines removed: sentence + blank line)

## Runtime Testing

Risk level: **Low** — docs-only change, no code execution paths affected. Self-assessed.

Closes #12872

---
[aidevops.sh](https://aidevops.sh) v3.5.268 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 1m and 2,646 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified isolated test data documentation by removing redundant statements while retaining code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->