### PR TITLE
GH#12963: tighten story.md agent doc

### DIFF
--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -26,12 +26,12 @@ model: sonnet
 
 <!-- AI-CONTEXT-END -->
 
-## Pre-flight Questions
+## Pre-flight Checklist
 
-1. What is the theme — the universal truth this content explores?
-2. What is the single takeaway — what should the audience think, feel, or do differently?
-3. Does this tell a story — is there tension, transformation, and resolution?
-4. Who is the protagonist — the audience, a character, or the brand — and is that the right choice?
+1. **Theme** — universal truth this content explores?
+2. **Takeaway** — what should the audience think, feel, or do differently?
+3. **Story** — tension, transformation, and resolution present?
+4. **Protagonist** — audience, character, or brand — right choice?
 
 ## 7 Hook Formulas
 
@@ -45,7 +45,7 @@ model: sonnet
 | 6 | **Problem-Agitate** | "You're wasting 4 hours/day on content that nobody sees" | Email, LinkedIn, blog |
 | 7 | **Curiosity Gap** | "The one AI trick that changed everything (it's not what you think)" | Short-form, X, email |
 
-**Hook generation process**: Write 10 variants → score each on specificity/emotion/curiosity (1-5 each) → pick top 3 for A/B testing → archive the rest for repurposing.
+**Hook process**: Write 10 variants → score specificity/emotion/curiosity (1-5 each) → pick top 3 for A/B → archive rest for repurposing.
 
 ## 4-Part Script Framework
 
@@ -98,7 +98,7 @@ model: sonnet
 
 ## UGC Brief Storyboard
 
-Generates a complete multi-shot storyboard from a business description. Combines the 4-Part Script Framework with the 7-component video prompt format (`tools/video/video-prompt-design.md`).
+Multi-shot storyboard from a business description. Uses 4-Part Script Framework + 7-component video prompt format (`tools/video/video-prompt-design.md`).
 
 ### Input Brief
 


### PR DESCRIPTION
## Summary

- Compressed Pre-flight Questions section: verbose question phrasing → bold-label checklist format
- Shortened "Hook generation process" label to "Hook process"
- Tightened UGC Brief Storyboard intro from 2 sentences to 1

## Changes

- `.agents/content/story.md` — 7 lines changed (same line count, tighter prose)

## Verification

- All rules, tables, code blocks, file references, and command examples preserved
- `markdownlint-cli2`: 0 errors
- Agent behaviour unchanged — no rules removed, only prose compressed

## Runtime Testing

Risk level: **Low** (agent prompt doc, no code). Self-assessed.

Closes #12963

---
[aidevops.sh](https://aidevops.sh) v3.5.274 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 2m and 3,832 tokens on this as a headless worker.