### PR TITLE
GH#12875: tighten accessibility.md

### DIFF
--- a/.agents/tools/accessibility/accessibility.md
+++ b/.agents/tools/accessibility/accessibility.md
@@ -18,39 +18,39 @@ tools:
 
 ## Quick Reference
 
-- **Helper**: `.agents/scripts/accessibility-helper.sh` — Lighthouse, pa11y, Playwright contrast, WAVE API, email, contrast calc
-- **Audit Helper**: `.agents/scripts/accessibility-audit-helper.sh` — axe-core, WAVE API, WebAIM contrast, Lighthouse
-- **Commands (helper)**: `audit [url]` | `lighthouse [url]` | `pa11y [url]` | `playwright-contrast [url]` | `wave [url]` | `email [file]` | `contrast [fg] [bg]` | `bulk [file]`
-- **Commands (audit)**: `axe [url]` | `wave [url]` | `contrast [fg] [bg]` | `compare [url]` | `status`
-- **Install**: `accessibility-helper.sh install-deps` or `accessibility-audit-helper.sh install-deps`
-- **Standards**: WCAG 2.1 Level A, AA (default), AAA
+- **Helper**: `accessibility-helper.sh` — Lighthouse, pa11y, Playwright contrast, WAVE API, email, contrast calc
+- **Audit Helper**: `accessibility-audit-helper.sh` — axe-core, WAVE API, WebAIM contrast, Lighthouse
+- **Commands (helper)**: `audit` | `lighthouse` | `pa11y` | `playwright-contrast` | `wave` | `email` | `contrast` | `bulk`
+- **Commands (audit)**: `axe` | `wave` | `contrast` | `compare` | `status`
+- **Install**: either helper's `install-deps` command
+- **Standards**: WCAG 2.1 A, AA (default), AAA
 - **Reports**: `~/.aidevops/reports/accessibility/` and `~/.aidevops/reports/accessibility-audit/`
-- **Env vars**: `A11Y_WCAG_LEVEL` / `AUDIT_WCAG_LEVEL` (default `WCAG2AA`), `WAVE_API_KEY`
+- **Env**: `A11Y_WCAG_LEVEL` / `AUDIT_WCAG_LEVEL` (default `WCAG2AA`), `WAVE_API_KEY`
 
 <!-- AI-CONTEXT-END -->
 
 ## Tools Overview
 
-| Tool | Helper | Purpose | Speed | Depth |
-|------|--------|---------|-------|-------|
-| **Lighthouse** | both | Accessibility score + audit failures | ~15s | Broad (axe-core engine) |
-| **pa11y** | helper | WCAG-specific violation reporting | ~10s | Deep (HTML_CodeSniffer) |
-| **Playwright contrast** | helper | Computed style analysis for all visible elements | ~5-15s | Every text element |
-| **WAVE API** | both | Comprehensive analysis (CSS/JS-rendered) | ~2-5s | Deep (WAVE engine) |
-| **@axe-core/cli** | audit | Standalone axe scanner | ~10s | Deep (axe-core direct) |
-| **WebAIM Contrast API** | audit | Programmatic colour contrast (no key required) | Instant | AA + AAA levels |
-| **Email checker** | helper | HTML email accessibility (static analysis) | <1s | Email-specific rules |
-| **Contrast calculator** | helper | WCAG contrast ratio for color pairs | Instant | AA + AAA levels |
+| Tool | Helper | Purpose | Speed |
+|------|--------|---------|-------|
+| **Lighthouse** | both | Score + audit failures (axe-core engine) | ~15s |
+| **pa11y** | helper | WCAG violations (HTML_CodeSniffer) | ~10s |
+| **Playwright contrast** | helper | Computed style analysis, all visible elements | ~5-15s |
+| **WAVE API** | both | Full analysis incl. CSS/JS-rendered content | ~2-5s |
+| **@axe-core/cli** | audit | Standalone axe scanner | ~10s |
+| **WebAIM Contrast API** | audit | Colour contrast check (no key required) | Instant |
+| **Email checker** | helper | HTML email a11y (static analysis) | <1s |
+| **Contrast calculator** | helper | WCAG contrast ratio for color pairs | Instant |
 
 ## Setup
 
 ```bash
-.agents/scripts/accessibility-helper.sh install-deps
-.agents/scripts/accessibility-audit-helper.sh install-deps
+accessibility-helper.sh install-deps
+accessibility-audit-helper.sh install-deps
 
-# WAVE API key (optional — register at https://wave.webaim.org/api/register)
+# WAVE API key (optional — https://wave.webaim.org/api/register)
 aidevops secret set wave-api-key   # encrypted (recommended)
-export WAVE_API_KEY="your-key"     # or environment variable
+export WAVE_API_KEY="your-key"     # or env var
 ```
 
 ## Usage
@@ -58,86 +58,70 @@ export WAVE_API_KEY="your-key"     # or environment variable
 ### accessibility-helper.sh
 
 ```bash
-# Full audit — Lighthouse + pa11y, desktop and mobile
-.agents/scripts/accessibility-helper.sh audit https://example.com
+# Full audit (Lighthouse + pa11y, desktop and mobile)
+accessibility-helper.sh audit https://example.com
 
-# Lighthouse — score (0-100%), failed audits (contrast, ARIA, labels), ARIA validation
-.agents/scripts/accessibility-helper.sh lighthouse https://example.com         # desktop
-.agents/scripts/accessibility-helper.sh lighthouse https://example.com mobile  # mobile
+# Lighthouse — score, failed audits, ARIA validation
+accessibility-helper.sh lighthouse https://example.com         # desktop
+accessibility-helper.sh lighthouse https://example.com mobile  # mobile
 
-# pa11y — errors (must fix), warnings (should fix), notices (advisory)
-.agents/scripts/accessibility-helper.sh pa11y https://example.com           # AA (default)
-.agents/scripts/accessibility-helper.sh pa11y https://example.com WCAG2AAA  # AAA
-.agents/scripts/accessibility-helper.sh pa11y https://example.com WCAG2A    # A
+# pa11y — errors/warnings/notices by WCAG level
+accessibility-helper.sh pa11y https://example.com           # AA (default)
+accessibility-helper.sh pa11y https://example.com WCAG2AAA  # AAA
+accessibility-helper.sh pa11y https://example.com WCAG2A    # A
 
-# WAVE API (requires WAVE_API_KEY) — evaluates after CSS/JS rendering
-# Types: 1=counts (1 credit), 2=+details (2 credits), 3/4=+locations+contrast (3 credits)
-# Categories: errors, contrast errors, alerts, features, structural elements, ARIA
-.agents/scripts/accessibility-helper.sh wave https://example.com    # type 2 (default)
-.agents/scripts/accessibility-helper.sh wave https://example.com 3  # + XPath locations
-.agents/scripts/accessibility-helper.sh wave https://example.com 4  # + CSS selectors
-.agents/scripts/accessibility-helper.sh wave-mobile https://example.com  # 375px viewport
-.agents/scripts/accessibility-helper.sh wave-docs alt_missing            # look up WAVE item
-.agents/scripts/accessibility-helper.sh wave-credits                     # check remaining credits
+# WAVE API (requires WAVE_API_KEY) — CSS/JS-rendered analysis
+# Types: 1=counts, 2=+details (default), 3=+XPath, 4=+CSS selectors
+accessibility-helper.sh wave https://example.com    # type 2
+accessibility-helper.sh wave https://example.com 3  # + XPath locations
+accessibility-helper.sh wave https://example.com 4  # + CSS selectors
+accessibility-helper.sh wave-mobile https://example.com  # 375px viewport
+accessibility-helper.sh wave-docs alt_missing            # look up WAVE item
+accessibility-helper.sh wave-credits                     # check remaining credits
 
-# Contrast ratio — pass/fail for AA normal (4.5:1), AA large (3:1), AAA normal (7:1), AAA large (4.5:1)
-.agents/scripts/accessibility-helper.sh contrast '#333333' '#ffffff'
+# Contrast ratio — AA normal (4.5:1), AA large (3:1), AAA normal (7:1), AAA large (4.5:1)
+accessibility-helper.sh contrast '#333333' '#ffffff'
 
-# Playwright contrast — headless DOM traversal; computed fg/bg colors, font size/weight,
-# WCAG ratio per element (L1+0.05)/(L2+0.05), SC 1.4.3/1.4.6, large text (≥18pt or ≥14pt bold),
-# gradient/image background flags. Exit: 0=pass, 1=failures, 2=script error.
-.agents/scripts/accessibility-helper.sh playwright-contrast https://example.com           # summary
-.agents/scripts/accessibility-helper.sh playwright-contrast https://example.com json      # JSON
-.agents/scripts/accessibility-helper.sh playwright-contrast https://example.com markdown AAA
+# Playwright contrast — headless DOM traversal, computed fg/bg, font size/weight,
+# WCAG ratio per element, SC 1.4.3/1.4.6, large text (≥18pt or ≥14pt bold),
+# gradient/image background flags. Exit: 0=pass, 1=failures, 2=error.
+accessibility-helper.sh playwright-contrast https://example.com           # summary
+accessibility-helper.sh playwright-contrast https://example.com json      # JSON
+accessibility-helper.sh playwright-contrast https://example.com markdown AAA
 node .agents/scripts/accessibility/playwright-contrast.mjs https://example.com --format json --fail-only
 node .agents/scripts/accessibility/playwright-contrast.mjs https://example.com --limit 20
 
-# Email HTML — checks: alt (1.1.1), lang (3.1.1), role="presentation" on layout tables (1.3.1),
-# font <12px (1.4.4), generic link text (2.4.4), heading structure (1.3.1), color-only (1.4.1)
-# Key: email clients strip CSS/JS — use alt text, role="presentation", lang, ≥14px font, descriptive links
-.agents/scripts/accessibility-helper.sh email ./newsletter.html
+# Email HTML — alt (1.1.1), lang (3.1.1), role="presentation" (1.3.1),
+# font <12px (1.4.4), link text (2.4.4), headings (1.3.1), color-only (1.4.1)
+accessibility-helper.sh email ./newsletter.html
 
 # Bulk audit — one URL per line, # for comments
-.agents/scripts/accessibility-helper.sh bulk sites.txt
+accessibility-helper.sh bulk sites.txt
 ```
 
 ### accessibility-audit-helper.sh
 
 ```bash
-.agents/scripts/accessibility-audit-helper.sh axe https://example.com                    # default: wcag2a, wcag2aa, best-practice
-.agents/scripts/accessibility-audit-helper.sh axe https://example.com wcag2aa,wcag21aa
-.agents/scripts/accessibility-audit-helper.sh wave https://example.com                   # requires WAVE_API_KEY
-.agents/scripts/accessibility-audit-helper.sh contrast '#333333' '#ffffff'               # WebAIM, no key required
-.agents/scripts/accessibility-audit-helper.sh compare https://example.com               # multi-engine comparison
-.agents/scripts/accessibility-audit-helper.sh status                                     # check installed engines
+accessibility-audit-helper.sh axe https://example.com                    # default: wcag2a, wcag2aa, best-practice
+accessibility-audit-helper.sh axe https://example.com wcag2aa,wcag21aa
+accessibility-audit-helper.sh wave https://example.com                   # requires WAVE_API_KEY
+accessibility-audit-helper.sh contrast '#333333' '#ffffff'               # WebAIM, no key
+accessibility-audit-helper.sh compare https://example.com               # multi-engine comparison
+accessibility-audit-helper.sh status                                     # check installed engines
 ```
 
 ## WCAG 2.1 Quick Reference
 
-| Level | Criterion | Description |
-|-------|-----------|-------------|
-| **A** | 1.1.1 | Non-text content has text alternatives |
-| **A** | 1.3.1 | Information and relationships are programmatically determinable |
-| **A** | 1.4.1 | Color is not the only means of conveying information |
-| **A** | 2.1.1 | All functionality is keyboard accessible |
-| **A** | 2.4.1 | Skip navigation mechanism available |
-| **A** | 4.1.1 | HTML validates without significant errors |
-| **A** | 4.1.2 | Name, role, value for all UI components |
-| **AA** | 1.4.3 | Contrast ratio at least 4.5:1 (normal text) |
-| **AA** | 1.4.4 | Text can be resized up to 200% without loss |
-| **AA** | 1.4.5 | Text is used instead of images of text |
-| **AA** | 2.4.6 | Headings and labels describe topic or purpose |
-| **AA** | 2.4.7 | Keyboard focus is visible |
-| **AA** | 3.1.2 | Language of parts is identified |
-| **AAA** | 1.4.6 | Contrast ratio at least 7:1 (normal text) |
-| **AAA** | 1.4.8 | Visual presentation is configurable |
-| **AAA** | 2.4.9 | Link purpose is clear from link text alone |
-| **AAA** | 2.4.10 | Section headings organise content |
+| Level | Key Criteria |
+|-------|-------------|
+| **A** | 1.1.1 text alternatives · 1.3.1 programmatic structure · 1.4.1 not color-only · 2.1.1 keyboard accessible · 2.4.1 skip nav · 4.1.1 valid HTML · 4.1.2 name/role/value |
+| **AA** | 1.4.3 contrast ≥4.5:1 · 1.4.4 resize to 200% · 1.4.5 real text not images · 2.4.6 descriptive headings/labels · 2.4.7 visible focus · 3.1.2 language of parts |
+| **AAA** | 1.4.6 contrast ≥7:1 · 1.4.8 configurable presentation · 2.4.9 link purpose from text · 2.4.10 section headings |
 
 ## Related
 
-- `tools/browser/pagespeed.md` — Performance testing (includes Lighthouse accessibility score)
+- `tools/browser/pagespeed.md` — Lighthouse a11y score
 - `tools/performance/performance.md` — Core Web Vitals
-- `tools/browser/browser-automation.md` — Browser tool selection for dynamic/SPA testing
-- `seo/` — SEO (overlapping concerns: headings, alt text, semantic HTML)
-- Chrome DevTools MCP — real-time accessibility tree inspection
+- `tools/browser/browser-automation.md` — dynamic/SPA testing
+- `seo/` — overlapping: headings, alt text, semantic HTML
+- Chrome DevTools MCP — accessibility tree inspection


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/accessibility/accessibility.md` from 143 → 127 lines (11% reduction)
- Compressed prose in Quick Reference, Tools Overview table, inline code comments, WCAG reference table, and Related section
- Removed redundant `.agents/scripts/` path prefixes from command examples (scripts are on PATH)
- Collapsed 17-row WCAG table into 3-row compact format preserving all criteria numbers

## What changed

- **Quick Reference**: removed redundant `[url]`/`[file]` arg hints (visible in usage section), shortened labels
- **Tools Overview**: dropped Depth column (redundant with engine names), compressed Purpose text
- **Usage code blocks**: stripped `.agents/scripts/` prefix, compressed inline comments while keeping all commands and flags
- **WCAG table**: consolidated from per-criterion rows to per-level rows with `·`-separated criteria — all 17 criteria preserved
- **Related**: shortened descriptions to essentials

## Content preservation

All code blocks, URLs, commands, WCAG criteria (1.1.1–2.4.10), env vars, report paths, and tool references verified present.

## Runtime Testing

- **Risk**: Low (docs/agent prompt only)
- **Level**: `self-assessed`

Closes #12875

---
[aidevops.sh](https://aidevops.sh) v3.5.275 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 2m and 7,754 tokens on this as a headless worker.