### PR TITLE
GH#12941: tighten bug-fixing.md (145→105 lines)

### DIFF
--- a/.agents/workflows/bug-fixing.md
+++ b/.agents/workflows/bug-fixing.md
@@ -1,5 +1,5 @@
 ---
-description: Guidance for AI assistants to help with bug fixing workflows
+description: Bug fixing workflow for AI assistants
 mode: subagent
 tools:
   read: true
@@ -12,134 +12,94 @@ tools:
   task: true
 ---
 
-# Bug Fixing Guide for AI Assistants
+# Bug Fixing Workflow
 
-## Workflow
-
-### 1. Create Branch
-
-```bash
-git checkout main && git pull origin main
-git checkout -b fix/123-bug-description  # Include issue number
-```
-
-### 2. Understand the Bug
+## 1. Understand the Bug
 
 | Question | Why |
 |----------|-----|
 | Expected vs actual behavior | Defines goal and problem |
 | Steps to reproduce | Enables testing |
-| Impact | Prioritizes fix |
+| Impact and scope | Prioritizes fix |
 | Root cause | Prevents symptom-only fixes |
 
-### 3. Fix
+Identify root cause before writing code. Document findings in the commit message.
 
-- Minimal changes only — no new features
+## 2. Fix
+
+- Minimal changes only — no new features, no refactoring
 - Maintain backward compatibility
-- Comment explaining the fix
-- Add regression tests
+- Comment explaining *why* the fix works
+- Add regression test covering the exact failure
 
-### 4. Update Documentation
-
-Update CHANGELOG (`## [Unreleased] → ### Fixed`) and README/docs if fix affects user-facing functionality.
-
-### 5. Testing
+## 3. Test
 
 - [ ] Bug is fixed, no regression in related functionality
-- [ ] Latest and minimum supported versions tested
 - [ ] Automated test suite and quality checks pass
+- [ ] Tested on latest and minimum supported versions
 
 ```bash
-npm test && composer test
-bash ~/Git/aidevops/.agents/scripts/linters-local.sh
+# Project-specific test runner (npm test, composer test, pytest, etc.)
+# Then framework quality checks:
+~/.aidevops/agents/scripts/linters-local.sh
 ```
 
 **Frontend bugs (CRITICAL):** HTTP 200 does NOT verify frontend fixes — server returns 200 even when React crashes client-side. Use browser screenshot via `dev-browser-helper.sh start`. See `tools/ui/frontend-debugging.md`.
 
-### 6. Commit
+## 4. Commit and Document
+
+Conventional commit with issue reference:
 
 ```bash
-git add .
-git commit -m "Fix #123: Brief description
+git commit -m "fix(scope): brief description (#NNN)
 
-- What was wrong
-- How this fixes it"
+- Root cause: what was wrong
+- Fix: how this resolves it"
 ```
 
-### 7. Version Increment
+Update CHANGELOG (`## [Unreleased] → ### Fixed`) and README/docs if fix affects user-facing behavior.
+
+## 5. Version Increment
 
 | Increment | When |
 |-----------|------|
-| **PATCH** | Most bug fixes (no functionality change) |
-| **MINOR** | Bug fix with new features or significant changes |
-| **MAJOR** | Bug fix with breaking changes |
+| **PATCH** | Most bug fixes (no API/behavior change) |
+| **MINOR** | Fix introduces new behavior or deprecates old |
+| **MAJOR** | Fix requires breaking changes |
 
-Don't update version numbers during development — only when fix is confirmed working.
+Only bump version after fix is confirmed working. Use `version-manager.sh release patch` for aidevops releases.
 
-### 8. Prepare Release
+## 6. Hotfix (Critical Production Bugs)
 
-```bash
-git checkout -b v{MAJOR}.{MINOR}.{PATCH}
-git merge fix/bug-description --no-ff
-# Update version numbers, commit: "Version {VERSION} - Bug fix release"
-```
-
----
-
-## Hotfix Process
-
-For critical bugs requiring immediate release:
+For bugs requiring immediate release, branch from the latest tag:
 
 ```bash
-# 1. Branch from latest tag
 git tag -l "v*" --sort=-v:refname | head -5
-git checkout v{MAJOR}.{MINOR}.{PATCH}
-git checkout -b hotfix/v{MAJOR}.{MINOR}.{PATCH+1}
-
-# 2. Apply minimal fix, update PATCH version in:
-#    main app file, CHANGELOG, README, package.json/composer.json, localization
-
-# 3. Commit, tag, push
-git add . && git commit -m "Hotfix: Critical bug description"
-git tag -a v{MAJOR}.{MINOR}.{PATCH+1} -m "Hotfix release"
-git push origin hotfix/v{MAJOR}.{MINOR}.{PATCH+1}
-git push origin v{MAJOR}.{MINOR}.{PATCH+1}
-
-# 4. Merge to main
-git checkout main && git merge hotfix/v{MAJOR}.{MINOR}.{PATCH+1} --no-ff && git push origin main
+git checkout -b hotfix/v{VERSION} v{LATEST_TAG}
+# Apply minimal fix, bump PATCH, commit, tag, push
+# Merge back to main after release
 ```
+
+Standard bugs use the normal worktree + PR flow via `/full-loop`.
 
 ---
 
-## Common Bug Types
+## Common Bug Patterns
 
 | Type | Fix Strategy |
 |------|-------------|
 | **Null/Undefined** | Safe access with fallback: `user?.name ?? 'Unknown'` |
-| **Race Conditions** | async/await, locks/semaphores, initialization order |
-| **Memory Leaks** | Clean up event listeners, clear timers, release references |
+| **Race Conditions** | async/await, locks, initialization order |
+| **Memory Leaks** | Clean up listeners, clear timers, release references |
 | **API/Network** | Error handling, retries with backoff, timeouts, response validation |
-| **Security** | Validate/sanitize inputs, escape outputs, parameterized queries, check permissions |
-
----
-
-## Version Testing & Rollback
-
-```bash
-# Test previous version
-git checkout v{MAJOR}.{MINOR}.{PATCH}
-
-# Rollback: find stable tag, branch, apply corrected fix
-git tag -l "*-stable" --sort=-v:refname | head -5
-git checkout v{VERSION}-stable -b fix/rollback-based-fix
-```
+| **Security** | Validate inputs, escape outputs, parameterized queries, check permissions |
 
 ---
 
 ## Completion Checklist
 
-- [ ] Root cause identified and documented
-- [ ] Fix is minimal, focused, no new features
-- [ ] Regression tests added, all tests pass
-- [ ] Quality checks pass, documentation updated
-- [ ] Changelog updated, ready for code review
+- [ ] Root cause identified and documented in commit
+- [ ] Fix is minimal and focused — no unrelated changes
+- [ ] Regression test added, all tests pass
+- [ ] Quality checks pass (`linters-local.sh`)
+- [ ] CHANGELOG updated, docs updated if user-facing


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/bug-fixing.md` from 145 to 105 lines (28% reduction) per simplification issue #12941.

Closes #12941

## Changes

- **Removed** redundant "Create Branch" section — branch creation is handled by `pre-edit-check.sh` / worktree workflow, not manual `git checkout -b`
- **Removed** manual "Prepare Release" section — redundant with `version-manager.sh release`
- **Removed** generic "Version Testing & Rollback" section — low-value git commands any LLM knows
- **Compressed** hotfix process from 20 lines to 4-line essence with `/full-loop` pointer
- **Fixed** linter path from hardcoded `~/Git/aidevops/` to deployed `~/.aidevops/agents/`
- **Aligned** commit example with conventional commit format (`fix(scope):`)
- **Added** `version-manager.sh release patch` and `/full-loop` pointers

## Content Preservation

All framework-specific references preserved:
- `tools/ui/frontend-debugging.md`, `dev-browser-helper.sh start`
- `linters-local.sh`, `version-manager.sh`
- Frontend debugging CRITICAL warning (HTTP 200 ≠ frontend fix)
- All tables (understanding, version increment, common bug patterns)
- YAML frontmatter with tool permissions
- Completion checklist (tightened with specific tool references)

## Runtime Testing

- **Risk level:** Low (agent prompt/docs only, no code execution paths)
- **Verification:** `self-assessed` — markdown lint passes (0 errors), content preservation verified via rg

---
[aidevops.sh](https://aidevops.sh) v3.5.275 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 2m and 5,060 tokens on this as a headless worker. Overall, 3h 6m since this issue was created.