### PR TITLE
GH#13038: tighten Customer Testimonial Brief (156→91 lines)

### DIFF
--- a/.agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md
+++ b/.agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md
@@ -6,116 +6,64 @@
 
 ## About This Testimonial
 
-**Customer Name:** [Name]
-**Company:** [Company]
-**Role:** [Title]
-**How Long Using Product:** [Duration]
+**Customer:** [Name] · [Company] · [Title] · [Duration using product]
 
 ---
 
 ## Pre-Interview Checklist
 
-**Before filming, confirm:**
-- [ ] Customer has signed release form
-- [ ] Customer is comfortable on camera
-- [ ] Quiet space available
-- [ ] Good lighting arranged
-- [ ] Product is available for b-roll
+- [ ] Release form signed
+- [ ] Customer comfortable on camera
+- [ ] Quiet space with good lighting
+- [ ] Product available for b-roll
 
 ---
 
 ## Questions to Ask
 
-### Opening (Builds context)
-1. "Tell us a bit about yourself and what you do."
-2. "What was your situation before [PRODUCT]?"
+**Opening** (context): "Tell us about yourself." · "What was your situation before [PRODUCT]?"
 
-### The Problem (Creates relatability)
-3. "What challenges were you facing with [PROBLEM AREA]?"
-4. "How was that affecting your [work/life/business]?"
-5. "What had you tried before that didn't work?"
+**Problem** (relatability): "What challenges were you facing with [PROBLEM AREA]?" · "How was that affecting your [work/life/business]?" · "What had you tried before that didn't work?"
 
-### Discovery (Builds narrative)
-6. "How did you find out about [PRODUCT]?"
-7. "What made you decide to try it?"
-8. "Were you skeptical at first?"
+**Discovery** (narrative): "How did you find [PRODUCT]?" · "What made you try it?" · "Were you skeptical at first?"
 
-### Experience (Shows product value)
-9. "What was it like getting started?"
-10. "What features do you use most?"
-11. "What surprised you about using [PRODUCT]?"
+**Experience** (value): "What was getting started like?" · "What features do you use most?" · "What surprised you?"
 
-### Results (Provides proof)
-12. "What results have you seen?"
-13. "Can you share any specific numbers or improvements?"
-14. "How has [PRODUCT] changed your [workflow/business/life]?"
+**Results** (proof): "What results have you seen?" · "Any specific numbers or improvements?" · "How has [PRODUCT] changed your [workflow/business/life]?"
 
-### Recommendation (Drives action)
-15. "Who would you recommend [PRODUCT] to?"
-16. "What would you tell someone considering it?"
-17. "If [PRODUCT] disappeared tomorrow, what would you do?"
+**Recommendation** (action): "Who would you recommend [PRODUCT] to?" · "What would you tell someone considering it?" · "If [PRODUCT] disappeared tomorrow, what would you do?"
 
 ---
 
 ## Ideal Quotes to Capture
 
-**Problem Quote:**
-"Before [PRODUCT], I was [specific struggle]..."
-
-**Result Quote:**
-"Since using [PRODUCT], I've [specific improvement/number]..."
-
-**Recommendation Quote:**
-"If you're [target audience], you need [PRODUCT] because..."
-
-**Emotional Quote:**
-"I finally feel [positive emotion] about [area]..."
+**Problem:** "Before [PRODUCT], I was [specific struggle]..."  
+**Result:** "Since using [PRODUCT], I've [specific improvement/number]..."  
+**Recommendation:** "If you're [target audience], you need [PRODUCT] because..."  
+**Emotional:** "I finally feel [positive emotion] about [area]..."
 
 ---
 
 ## Technical Requirements
 
-### Video
-- Resolution: 1080p minimum, 4K preferred
-- Format: Horizontal (16:9) for editing flexibility
-- Frame: Medium shot (head and shoulders)
-- Background: Clean, professional, relevant
-
-### Audio
-- External mic (lav or shotgun)
-- Quiet environment
-- No echo/reverb
-
-### Lighting
-- Soft, flattering light
-- No harsh shadows on face
-- Consider 3-point lighting setup
+**Video:** 1080p min (4K preferred) · Horizontal 16:9 · Medium shot (head and shoulders) · Clean, professional background  
+**Audio:** External mic (lav or shotgun) · Quiet, no echo  
+**Lighting:** Soft, flattering · No harsh shadows · 3-point setup preferred
 
 ---
 
 ## Interview Tips
 
-**For Natural Responses:**
-- Ask them to include the question in their answer
-- Let them talk; don't interrupt
-- Ask "Can you tell me more about that?"
-- Get them to repeat great quotes with slight variations
+**Natural responses:** Ask them to include the question in their answer · Let them talk, don't interrupt · "Can you tell me more about that?" · Get repeat takes with slight variations
 
-**Body Language:**
-- Have them look at interviewer, not camera
-- Encourage natural hand gestures
-- Get them relaxed before "real" questions
+**Body language:** Look at interviewer, not camera · Encourage natural hand gestures · Warm them up before "real" questions
 
-**Multiple Takes:**
-- "That was great, can we do that one more time?"
-- "Can you say that same thing but shorter?"
-- "Try starting with [specific phrase]"
+**Multiple takes:** "That was great, can we do that one more time?" · "Can you say that but shorter?" · "Try starting with [specific phrase]"
 
 ---
 
 ## B-Roll to Capture
 
-While on site, also capture:
 - [ ] Customer using product
 - [ ] Customer at their workspace
 - [ ] Product close-ups
@@ -126,31 +74,18 @@ While on site, also capture:
 
 ## Release Form
 
-**Must be signed before filming:**
-- Video/image release
-- Name/company usage rights
-- Ad placement consent
-- Duration of usage rights
+Must be signed before filming: video/image release · name/company usage rights · ad placement consent · duration of usage rights
 
 ---
 
-## Post-Production Notes
+## Post-Production
 
-**Deliverables:**
-- Full interview footage
-- Selected b-roll
-- Transcript (if possible)
+**Deliverables:** Full interview footage · Selected b-roll · Transcript (if possible)
 
-**Edit Priorities:**
-1. 15-30 second highlight clip
-2. 60-second full testimonial
-3. 5-10 second quote clips for static ads
+**Edit priorities:** 1. 15-30s highlight clip · 2. 60s full testimonial · 3. 5-10s quote clips for static ads
 
 ---
 
 ## Contact
 
-**Interviewer:** [Name]
-**Date/Time:** [When]
-**Location:** [Where]
-**Duration:** [Expected time - usually 30-60 min total]
+**Interviewer:** [Name] · **Date/Time:** [When] · **Location:** [Where] · **Duration:** 30-60 min


### PR DESCRIPTION
## Summary

- Compress testimonial brief from 156 to 91 lines (42% reduction) matching the density of the existing founder-video-brief.md
- All content preserved: 17 interview questions, 4 quote templates, technical specs, checklists, release form items, post-production deliverables
- Technique: inline `·` separators for related items, remove redundant sub-headers, consolidate multi-line field groups to single lines

## Runtime Testing

Risk level: **Low** — doc-only change, no code, no agent rules. Self-assessed.

## Files Changed

- `.agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md` — 156→91 lines

Closes #13038


---
[aidevops.sh](https://aidevops.sh) v3.5.277 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 2m and 3,153 tokens on this as a headless worker.