### PR TITLE
GH#12364: tighten Amazon SES provider guide

### DIFF
--- a/.agents/services/email/ses.md
+++ b/.agents/services/email/ses.md
@@ -21,39 +21,38 @@ tools:
 - **Auth**: AWS IAM credentials (access key + secret key)
 - **Config**: `configs/ses-config.json`
 - **Commands**: `ses-helper.sh [accounts|quota|stats|monitor|verified-emails|verified-domains|verify-email|verify-domain|dkim|reputation|suppressed|send-test|audit] [account] [args]`
-- **Key metrics**: Bounce rate < 5%, Complaint rate < 0.1%
+- **Thresholds**: Bounce rate < 5%, Complaint rate < 0.1%
 - **Regions**: us-east-1, eu-west-1, etc.
 - **Test addresses**: success@simulator.amazonses.com, bounce@simulator.amazonses.com
 - **DKIM**: Enable for all domains
-- **IAM policy**: ses:GetSendQuota, ses:SendEmail, sesv2:ListSuppressedDestinations
+- **IAM permissions**: ses:GetSendQuota, ses:SendEmail, sesv2:ListSuppressedDestinations
 
 <!-- AI-CONTEXT-END -->
 
 ## Configuration
 
 ```bash
-# Copy template and edit with actual AWS credentials
 cp configs/ses-config.json.txt configs/ses-config.json
 ```
 
-**Multi-account config (`configs/ses-config.json`):**
+Multi-account config (`configs/ses-config.json`):
 
 ```json
 {
   "accounts": {
     "production": {
-      "aws_access_key_id": "YOUR_PRODUCTION_AWS_ACCESS_KEY_ID_HERE",
-      "aws_secret_access_key": "YOUR_PRODUCTION_AWS_SECRET_ACCESS_KEY_HERE",
+      "aws_access_key_id": "YOUR_KEY",
+      "aws_secret_access_key": "YOUR_SECRET",
       "region": "us-east-1",
       "description": "Production SES account",
       "verified_domains": ["yourdomain.com"],
       "verified_emails": ["noreply@yourdomain.com"]
     },
     "staging": {
-      "aws_access_key_id": "YOUR_STAGING_AWS_ACCESS_KEY_ID_HERE",
-      "aws_secret_access_key": "YOUR_STAGING_AWS_SECRET_ACCESS_KEY_HERE",
+      "aws_access_key_id": "YOUR_KEY",
+      "aws_secret_access_key": "YOUR_SECRET",
       "region": "us-east-1",
-      "description": "Staging/Development SES account",
+      "description": "Staging SES account",
       "verified_domains": ["staging.yourdomain.com"],
       "verified_emails": ["test@yourdomain.com"]
     }
@@ -61,13 +60,7 @@ cp configs/ses-config.json.txt configs/ses-config.json
 }
 ```
 
-**AWS CLI** (credentials managed per account — no `aws configure` needed):
-
-```bash
-brew install awscli   # macOS
-sudo apt-get install awscli  # Linux
-aws --version
-```
+Credentials managed per account — no `aws configure` needed. Prerequisite: `awscli` installed.
 
 ## Commands
 
@@ -131,65 +124,29 @@ ses-helper.sh audit production
 }
 ```
 
-Use dedicated IAM users per environment. Rotate access keys regularly. Use separate AWS accounts for prod/staging.
+Dedicated IAM users per environment. Rotate access keys regularly. Separate AWS accounts for prod/staging.
 
 ## Monitoring
 
 ```bash
-# Daily routine
 ses-helper.sh monitor production   # bounce rate, complaint rate, quota, reputation
 ses-helper.sh stats production
 ```
 
-Thresholds: bounce < 5%, complaint < 0.1%. Alert script skeleton:
-
-```bash
-#!/bin/bash
-ACCOUNT="production"
-BOUNCE_THRESHOLD=5.0
-COMPLAINT_THRESHOLD=0.1
-STATS=$(ses-helper.sh stats "$ACCOUNT")
-# Add alerting logic
-```
+Thresholds: bounce < 5%, complaint < 0.1%.
 
 ## Troubleshooting
 
-**Auth errors:**
-
-```bash
-aws sts get-caller-identity
-ses-helper.sh quota production
-```
-
-**Sending limits:**
-
-```bash
-ses-helper.sh quota production   # check current
-ses-helper.sh stats production   # monitor rate
-# Request increase via AWS Support if needed
-```
-
-**Delivery issues:**
-
-```bash
-ses-helper.sh reputation production
-ses-helper.sh suppressed production
-ses-helper.sh debug production problematic@example.com
-ses-helper.sh monitor production
-```
-
-**Verification problems:**
-
-```bash
-ses-helper.sh verify-identity production yourdomain.com
-ses-helper.sh verify-domain production yourdomain.com
-dig TXT _amazonses.yourdomain.com
-```
+| Problem | Commands |
+|---------|----------|
+| Auth errors | `aws sts get-caller-identity` then `ses-helper.sh quota production` |
+| Sending limits | `ses-helper.sh quota production` — request increase via AWS Support if needed |
+| Delivery issues | `ses-helper.sh reputation production`, `ses-helper.sh suppressed production`, `ses-helper.sh debug production user@example.com` |
+| Verification | `ses-helper.sh verify-identity production yourdomain.com`, `dig TXT _amazonses.yourdomain.com` |
 
 ## Compliance & Backup
 
 ```bash
-# Export config snapshot
 ses-helper.sh audit production > ses-config-backup-$(date +%Y%m%d).txt
 ses-helper.sh verified-emails production > verified-emails-backup.txt
 ses-helper.sh verified-domains production > verified-domains-backup.txt


### PR DESCRIPTION
## Summary

Tighten `.agents/services/email/ses.md` from 201 → 158 lines (21% reduction) while preserving all actionable content.

Closes #12364

## Changes

- Remove generic AWS CLI install instructions (not SES-specific)
- Shorten config JSON placeholder values (`YOUR_PRODUCTION_AWS_ACCESS_KEY_ID_HERE` → `YOUR_KEY`)
- Convert verbose troubleshooting subsections into a single table
- Remove stub alert script skeleton (contained only `# Add alerting logic`)
- Deduplicate commands appearing in both Commands and Troubleshooting sections
- Compress prose throughout (remove filler words, redundant headers)

## Content Preservation Verification

All critical patterns verified present after tightening:
- ✓ All 15 `ses-helper.sh` subcommands
- ✓ All 12 IAM permissions in policy block
- ✓ Test addresses (success@, bounce@simulator.amazonses.com)
- ✓ Thresholds (bounce < 5%, complaint < 0.1%)
- ✓ Config path, DKIM, SPF/DMARC/GDPR/CAN-SPAM references
- ✓ Backup/export commands
- ✓ `AI-CONTEXT-START`/`AI-CONTEXT-END` markers
- ✓ 12 code blocks (6 in original were merged/removed as duplicates)

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdownlint clean, pattern verification via `rg`

---
[aidevops.sh](https://aidevops.sh) v3.5.277 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 1m and 6,096 tokens on this as a headless worker.