### PR TITLE
GH#13087: tighten story.md Quick Reference — merge redundant sections

### DIFF
--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -13,7 +13,7 @@ model: sonnet
 
 - **Input**: Research brief (`content/research.md`) or topic + audience
 - **Output**: Story package — hook variants, narrative arc, transformation framework, angle selection
-- **Principle**: One story, many outputs — design once, adapt everywhere
+- **Principle**: One story, many outputs — design the narrative once, adapt everywhere
 - **Hook-first always** — every output starts with the hook, regardless of platform
 - **6-12 word constraint** on hooks — forces clarity and punch
 - **Proven first, original second** — 97% proven structure, 3% unique twist

--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -11,13 +11,9 @@ model: sonnet
 
 ## Quick Reference
 
-- **Purpose**: Craft platform-agnostic narratives for any media format or distribution channel
-- **Input**: Research brief (from `content/research.md`) or topic + audience
-- **Output**: Story package: hook variants, narrative arc, transformation framework, angle selection
-- **Key Principle**: One story, many outputs — design the narrative once, adapt everywhere
-
-**Critical Rules**:
-
+- **Input**: Research brief (`content/research.md`) or topic + audience
+- **Output**: Story package — hook variants, narrative arc, transformation framework, angle selection
+- **Principle**: One story, many outputs — design once, adapt everywhere
 - **Hook-first always** — every output starts with the hook, regardless of platform
 - **6-12 word constraint** on hooks — forces clarity and punch
 - **Proven first, original second** — 97% proven structure, 3% unique twist


### PR DESCRIPTION
## Summary

- Merged the split Quick Reference + Critical Rules sub-sections into a single flat list — same knowledge, fewer lines
- Removed redundant "Purpose" bullet (duplicated frontmatter description) and "Critical Rules:" sub-header
- 166 → 162 lines; all tables, code blocks, cross-references, and task IDs preserved

## Runtime Testing

Risk level: **Low** — agent prompt doc only, no code changes. Self-assessed.

## Files Changed

- `.agents/content/story.md` — Quick Reference tightened

Closes #13087


---
[aidevops.sh](https://aidevops.sh) v3.5.285 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 1m and 3,274 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the Quick Reference section with a clearer, more concise layout.
  * Updated formatting and refined terminology for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->