### PR TITLE
GH#12995: tighten cro-chapter-20.md maturity model to table format

### DIFF
--- a/.agents/marketing-sales/cro-chapter-20.md
+++ b/.agents/marketing-sales/cro-chapter-20.md
@@ -118,45 +118,12 @@
 
 ## 20.4 CRO Maturity Model
 
-### Level 1: Reactive
+| Level | Name | Characteristics |
+|-------|------|----------------|
+| 1 | Reactive | Ad-hoc testing, limited resources, basic tools, no formal process |
+| 2 | Developing | Regular testing, dedicated resources, standard tools, emerging process |
+| 3 | Defined | Structured program, full-time team, advanced tools, documented process |
+| 4 | Managed | Optimized program, center of excellence, integrated stack, metrics-driven |
+| 5 | Optimizing | Innovation leader, industry best practice, custom solutions, continuous improvement |
 
-- Ad-hoc testing
-- Limited resources
-- Basic tools
-- No formal process
-
-### Level 2: Developing
-
-- Regular testing
-- Dedicated resources
-- Standard tools
-- Emerging process
-
-### Level 3: Defined
-
-- Structured program
-- Full-time team
-- Advanced tools
-- Documented process
-
-### Level 4: Managed
-
-- Optimized program
-- Center of excellence
-- Integrated stack
-- Metrics-driven
-
-### Level 5: Optimizing
-
-- Innovation leader
-- Industry best practice
-- Custom solutions
-- Continuous improvement
-
-**Advancement Roadmap:**
-- Capability assessment
-- Gap analysis
-- Investment planning
-- Milestone definition
-
-This chapter provides enterprise organizations with frameworks for building and scaling world-class CRO programs.
+**Advancement Roadmap:** Capability assessment → gap analysis → investment planning → milestone definition


### PR DESCRIPTION
## Summary

- Condense 5-level CRO maturity model from 36 lines of repeated bullet groups into a single compact table (7 lines)
- Inline advancement roadmap as a single line (was 6 lines)
- Remove filler closing sentence
- Result: 162 → 129 lines (20% reduction), zero content loss

## Changes

- `.agents/marketing-sales/cro-chapter-20.md` — maturity model section restructured

## Runtime Testing

**Risk level:** Low (agent doc / reference corpus — no executable code)
**Verification:** All content present before and after — every maturity level characteristic preserved in table form; advancement roadmap items preserved inline.

Closes #12995


---
[aidevops.sh](https://aidevops.sh) v3.5.290 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 1m and 3,372 tokens on this as a headless worker.