### PR TITLE
GH#12964: tighten flowcharts.md (165→161 lines)

### DIFF
--- a/.agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md
@@ -1,7 +1,5 @@
 # Flowchart Diagrams
 
-Flowcharts visualize processes, algorithms, and decision flows using nodes and edges.
-
 ## Basic Syntax
 
 ```mermaid
@@ -87,7 +85,7 @@ flowchart TB
     UI --> WS
 ```
 
-**Nested subgraphs** supported. **Per-subgraph direction** — add `direction TB` inside to override locally.
+Nested subgraphs supported. Add `direction TB` inside a subgraph to override direction locally.
 
 ## Multi-Target Edges
 
@@ -136,9 +134,7 @@ flowchart LR
     linkStyle default stroke:gray,stroke-width:1px
 ```
 
-## Layout Engine
-
-ELK for complex diagrams (v9.4+):
+## Layout Engine (ELK, v9.4+)
 
 ```mermaid
 %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%


### PR DESCRIPTION
## Summary

- Remove redundant intro sentence (heading already conveys the topic)
- Tighten subgraph note: remove unnecessary bold formatting, clarify wording
- Merge Layout Engine section header with version annotation (2 lines → 1)

## Verification

- All code blocks preserved (7 mermaid blocks + 2 plain blocks)
- All tables preserved (extended shapes table intact)
- All URLs preserved (`https://github.com` click event example)
- No task IDs or issue refs in source to preserve
- Line count: 165 → 161 (4 lines removed, all prose/formatting)

## Runtime Testing

Risk: **Low** — agent doc (reference corpus), no executable code changed.
Level: `self-assessed`

Closes #12964


---
[aidevops.sh](https://aidevops.sh) v3.5.290 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 2m and 4,708 tokens on this as a headless worker.