### PR TITLE
GH#12973: tighten agent doc production-audio.md

### DIFF
--- a/.agents/content/production-audio.md
+++ b/.agents/content/production-audio.md
@@ -29,8 +29,6 @@ tools:
 
 ## Voice Production Pipeline
 
-### Critical 2-Step Workflow
-
 **NEVER feed raw AI video audio directly to ElevenLabs** — it amplifies artifacts.
 
 ```text
@@ -57,7 +55,7 @@ voice-helper.sh voices            # List available TTS voices
 | Instant Clone | 10-30 second clean clip | Quick personas |
 | Professional Clone | 3-5 minutes | AI influencer personas (highest fidelity) |
 
-**Source quality rules**: Single speaker, quiet environment, clear pronunciation. Clone from existing content → run CapCut cleanup first.
+**Source quality**: Single speaker, quiet environment, clear pronunciation. Cloning from existing content → run CapCut cleanup first.
 
 **Alternative**: MiniMax TTS — talking-head content where ElevenLabs is overkill. $5/month for 120 min; 10-second clip for voice clone. See `tools/voice/voice-models.md`.
 
@@ -110,8 +108,6 @@ Scripts from `content/production-writing.md` should include emotional block mark
 
 ## LUFS Reference
 
-**Platform targets:**
-
 | Platform | Target LUFS | Notes |
 |----------|-------------|-------|
 | YouTube | -14 to -16 | Normalizes to -14 |
@@ -120,8 +116,6 @@ Scripts from `content/production-writing.md` should include emotional block mark
 | Broadcast TV | -23 to -24 | EBU R128 |
 | Streaming (Netflix) | -27 | Wide dynamic range |
 | Audiobook | -18 to -23 | Consistent, comfortable |
-
-**Measuring LUFS:**
 
 ```bash
 ffmpeg -i input.mp4 -af loudnorm=print_format=json -f null -
@@ -142,8 +136,7 @@ voice-helper.sh voices                        # List available TTS voices
 voice-helper.sh benchmark                     # Test component speeds
 ```
 
-**Architecture**: `Mic → Silero VAD → Whisper MLX (1.4s) → OpenCode run --attach (~4-6s) → Edge TTS (0.4s) → Speaker`
-**Round-trip**: ~6-8s conversational, longer for tool execution.
+**Architecture**: `Mic → Silero VAD → Whisper MLX (1.4s) → OpenCode run --attach (~4-6s) → Edge TTS (0.4s) → Speaker`. Round-trip: ~6-8s conversational, longer for tool execution.
 
 | Service | Details | CLI |
 |---------|---------|-----|


### PR DESCRIPTION
## Summary

- Removed redundant `### Critical 2-Step Workflow` subheading (content self-evident from table)
- Dropped `**Platform targets:**` and `**Measuring LUFS:**` labels (tables/code blocks are self-labelling)
- Merged two-line Architecture/Round-trip into one sentence
- Compressed `Source quality rules` → `Source quality` (minor label tightening)
- 165 → 158 lines; zero content/rule loss; markdownlint clean

## Runtime Testing

Risk: **Low** (docs/agent prompt only — no code, no behaviour change). Self-assessed.

## Files Changed

- `.agents/content/production-audio.md` — prose tightening only

Closes #12973


---
[aidevops.sh](https://aidevops.sh) v3.5.290 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 3m and 7,031 tokens on this as a headless worker.