### PR TITLE
GH#13097: tighten story.md agent doc (regression)

### DIFF
--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -24,10 +24,10 @@ model: sonnet
 
 ## Pre-flight Checklist
 
-1. **Theme** — universal truth this content explores?
-2. **Takeaway** — what should the audience think, feel, or do differently?
-3. **Story** — tension, transformation, and resolution present?
-4. **Protagonist** — audience, character, or brand — right choice?
+1. **Theme** — universal truth explored?
+2. **Takeaway** — audience thinks, feels, or does what differently?
+3. **Story** — tension, transformation, resolution present?
+4. **Protagonist** — audience, character, or brand?
 
 ## 7 Hook Formulas
 
@@ -35,13 +35,13 @@ model: sonnet
 |---|---------|---------|----------|
 | 1 | **Bold Claim** | "95% of AI influencers will fail this year" | YouTube, blog, LinkedIn |
 | 2 | **Question** | "Why do most AI creators quit in 6 months?" | Social, email, podcast |
-| 3 | **Story** | "I spent $10K on AI tools and here's what happened" | YouTube, podcast, blog |
-| 4 | **Contrarian** | "The AI tool everyone recommends is actually terrible" | X, Reddit, short-form |
+| 3 | **Story** | "I spent $10K on AI tools — here's what happened" | YouTube, podcast, blog |
+| 4 | **Contrarian** | "The AI tool everyone recommends is terrible" | X, Reddit, short-form |
 | 5 | **Result** | "How I got 1M views using only free AI tools" | YouTube, short-form, social |
-| 6 | **Problem-Agitate** | "You're wasting 4 hours/day on content that nobody sees" | Email, LinkedIn, blog |
-| 7 | **Curiosity Gap** | "The one AI trick that changed everything (it's not what you think)" | Short-form, X, email |
+| 6 | **Problem-Agitate** | "You're wasting 4h/day on content nobody sees" | Email, LinkedIn, blog |
+| 7 | **Curiosity Gap** | "The one AI trick that changed everything" | Short-form, X, email |
 
-**Hook process**: Write 10 variants → score specificity/emotion/curiosity (1-5 each) → pick top 3 for A/B → archive rest for repurposing.
+**Hook process**: Write 10 variants → score specificity/emotion/curiosity (1-5 each) → top 3 for A/B → archive rest.
 
 ## 4-Part Script Framework
 
@@ -60,34 +60,34 @@ model: sonnet
 |-------|-------------|-----------|
 | **Pain** | Audience frustrated, seeking solutions | Blog, email, YouTube |
 | **Aspiration** | Audience wants to level up | Short-form, social, YouTube |
-| **Contrarian** | Conventional wisdom is wrong | X, Reddit, podcast |
-| **Educational** | Audience needs to learn a skill | Blog, YouTube, podcast |
+| **Contrarian** | Conventional wisdom wrong | X, Reddit, podcast |
+| **Educational** | Audience needs a skill | Blog, YouTube, podcast |
 | **Hot take** | Trending conversation | X, short-form, Reddit |
 | **Behind the scenes** | Audience wants authenticity | YouTube, podcast, social |
 
 ## Campaign Audit (7-step)
 
-1. **Offer clarity** — value explainable in one sentence?
-2. **Urgency** — reason to act now (not manufactured)?
-3. **Pain angle** — real, specific pain point addressed?
-4. **Cosmetic vs life-changing** — nice-to-have or must-have?
+1. **Offer clarity** — value in one sentence?
+2. **Urgency** — real reason to act now?
+3. **Pain angle** — specific pain addressed?
+4. **Cosmetic vs life-changing** — must-have or nice-to-have?
 5. **Hook + visual alignment** — hook matches thumbnail/preview?
-6. **4 elements present** — hook, story, soft sell, visual cues all included?
-7. **Test readiness** — 3+ variants ready for A/B testing?
+6. **4 elements present** — hook, story, soft sell, visual cues?
+7. **Test readiness** — 3+ variants for A/B?
 
 ## Pattern Interrupt Techniques
 
-1. **Contrast** — juxtapose unexpected elements ("The $0 tool that beats $500/month software")
-2. **Extremes** — specific, surprising numbers ("I analyzed 10,000 AI videos and found this")
-3. **Unexpected combinations** — pair unrelated concepts ("What chess taught me about AI prompting")
+1. **Contrast** — juxtapose unexpected elements ("$0 tool that beats $500/month software")
+2. **Extremes** — specific surprising numbers ("I analyzed 10,000 AI videos — found this")
+3. **Unexpected combos** — pair unrelated concepts ("What chess taught me about AI prompting")
 
-## Story Package Output Format
+## Story Package Output
 
 ```text
 # Story Package: [Topic]
-## Hook Variants (scored) — min 5, format: [Hook] — Formula: [name] — Score: S/E/C = total
-## Narrative Arc — Before state / Struggle / Transformation / After state
-## Angle — Primary: [name] — Rationale: [why for this audience]
+## Hook Variants (scored) — min 5: [Hook] — Formula: [name] — Score: S/E/C = total
+## Narrative Arc — Before / Struggle / Transformation / After
+## Angle — Primary: [name] — Rationale: [why]
 ## Script Skeleton — Hook / Story / Soft Sell / Visual Cues
 ## Platform Adaptation — YouTube / Short-form / Social / Blog / Email / Podcast
 ```
@@ -99,36 +99,36 @@ Multi-shot storyboard from a business brief. Uses 4-Part Script Framework + 7-co
 ### Input Brief
 
 ```text
-Business:   [Company name and what they do]
-Product:    [Specific product/service being featured]
+Business:   [Company + what they do]
+Product:    [Product/service featured]
 Audience:   [Target customer — demographics, pain points]
-Presenter:  [Character description — 15+ attributes per video-prompt-design.md]
+Presenter:  [Character — 15+ attributes per video-prompt-design.md]
 Tone:       [warm | energetic | authoritative | casual | inspirational]
 Platform:   [TikTok/Reels (9:16) | YouTube (16:9) | both]
 Duration:   [15s | 30s | 60s]
-CTA:        [What the viewer should do]
+CTA:        [Viewer action]
 ```
 
 ### 5-Shot Storyboard Structure
 
-| Shot | Framework Role | Duration | Purpose |
-|------|---------------|----------|---------|
+| Shot | Role | Duration | Purpose |
+|------|------|----------|---------|
 | 1 | **Hook** | 2-3s | Pattern interrupt — bold claim or question |
-| 2 | **Story: Before State** | 3-5s | Show the pain/frustration |
-| 3 | **Story: Transformation** | 5-8s | Product hero — demonstrate solution |
-| 4 | **Story: After State** | 3-5s | Result proof — show the outcome |
+| 2 | **Before State** | 3-5s | Show pain/frustration |
+| 3 | **Transformation** | 5-8s | Product hero — demonstrate solution |
+| 4 | **After State** | 3-5s | Result proof — show outcome |
 | 5 | **Soft Sell + CTA** | 2-3s | Direct CTA, presenter to camera |
 
 ### Per-Shot Format (7 components — `video-prompt-design.md`)
 
 ```text
 ## Shot [N]: [FRAMEWORK_ROLE]
-Subject:   [Presenter — identical across all shots for consistency]
+Subject:   [Presenter — identical across shots]
 Action:    [Movements, gestures, micro-expressions]
 Scene:     [Environment, props, lighting]
-Style:     [Camera: shot type, angle, movement | Colour palette | DOF]
+Style:     [Camera: type, angle, movement | Palette | DOF]
 Dialogue:  (Presenter): "[8s-rule: 12-15 words max]" (Tone: [from brief])
-Sounds:    [Diegetic audio only — no score, no stock music]
+Sounds:    [Diegetic only — no score, no stock music]
 Technical: [Negatives: subtitles, watermark, text overlays, amateur quality]
 ```
 
@@ -136,27 +136,27 @@ Technical: [Negatives: subtitles, watermark, text overlays, amateur quality]
 
 | Duration | Shots | Adjustment |
 |----------|-------|------------|
-| 15s | 3 | Merge: Hook + Before State, Transformation, CTA |
-| 30s | 5 | Standard 5-shot template |
-| 60s | 7-8 | Split Transformation into 2-3 demo shots, add testimonial |
+| 15s | 3 | Merge Hook + Before State, Transformation, CTA |
+| 30s | 5 | Standard 5-shot |
+| 60s | 7-8 | Split Transformation into 2-3 demo shots + testimonial |
 
 ### Generation Process
 
-1. Fill the brief → select hook formula → generate 5 shots
-2. Score 5+ hook variants for Shot 1 on specificity/emotion/curiosity
-3. Generate image keyframes → feed each shot to `content/production-image.md`
-4. Generate video → Sora 2 Pro (UGC) or Veo 3.1 (cinematic)
-5. Assemble in editing tool; add text overlays in post (not in generation)
+1. Fill brief → select hook formula → generate 5 shots
+2. Score 5+ hook variants (Shot 1) on specificity/emotion/curiosity
+3. Image keyframes → feed each shot to `content/production-image.md`
+4. Video → Sora 2 Pro (UGC) or Veo 3.1 (cinematic)
+5. Assemble; add text overlays in post (not in generation)
 
 ## Related
 
-- `content/research.md` — feeds into story design (audience data, pain points)
-- `content/production-writing.md` — expands story into full scripts and copy
-- `content/production-image.md` — UGC Brief Image Template for per-shot keyframes
-- `content/optimization.md` — A/B tests hook variants and story angles
 - `content.md` — parent orchestrator (diamond pipeline)
-- `tools/video/video-prompt-design.md` — 7-component format used in each shot
+- `content/research.md` — audience data, pain points → story input
+- `content/production-writing.md` — story → full scripts and copy
+- `content/production-image.md` — per-shot keyframes
 - `content/production-video.md` — video generation (Sora 2 Pro for UGC)
-- `content/production-audio.md` — UGC audio design (diegetic only)
-- `content/production-characters.md` — presenter consistency across shots
+- `content/production-audio.md` — UGC audio (diegetic only)
+- `content/production-characters.md` — presenter consistency
+- `content/optimization.md` — A/B tests hooks and angles
 - `content/distribution-short-form.md` — platform specs
+- `tools/video/video-prompt-design.md` — 7-component shot format


### PR DESCRIPTION
## Summary

- Tightened prose across all sections of `.agents/content/story.md` — ~7% byte reduction (7673 → 7153 bytes), same 162 line count
- Regression re-tightening after PR #13090 modified the file post-simplification

## Changes

- **Pre-flight Checklist**: Shortened question phrasing
- **7 Hook Formulas**: Compressed example hooks (removed filler words)
- **Hook process**: Removed "pick" and "for repurposing"
- **Angle Selection**: Tightened "When to Use" descriptions
- **Campaign Audit**: Compressed all 7 audit questions
- **Pattern Interrupt Techniques**: Shortened descriptions and label
- **Story Package Output**: Compressed section title and template fields
- **UGC Brief Storyboard**: Tightened Input Brief fields, 5-Shot table headers, Per-Shot format, Shot Count table, Generation Process steps
- **Related**: Reordered (parent first), compressed descriptions

## Verification

- All file references preserved (10 unique `.md` paths — identical before/after)
- All code blocks, tables, formulas, and structural elements intact
- `markdownlint-cli2`: 0 errors
- No task IDs, incident refs, or decision rationale removed
- Agent behaviour unchanged — pure prose compression

## Runtime Testing

- **Risk**: Low (agent prompt doc, no code)
- **Level**: `self-assessed`

Closes #13097

---
[aidevops.sh](https://aidevops.sh) v3.5.298 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 3m and 8,415 tokens on this as a headless worker.