### PR TITLE
GH#13057: tighten cloudron-server-ops-skill.md

### DIFF
--- a/.agents/tools/deployment/cloudron-server-ops-skill.md
+++ b/.agents/tools/deployment/cloudron-server-ops-skill.md
@@ -11,8 +11,6 @@ tools:
 
 # Cloudron Server Operations
 
-The `cloudron` CLI manages apps on a Cloudron server. All commands operate on apps, not the server itself.
-
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
@@ -21,7 +19,7 @@ The `cloudron` CLI manages apps on a Cloudron server. All commands operate on ap
 - **Upstream skill**: [git.cloudron.io/docs/skills](https://git.cloudron.io/docs/skills) (`cloudron-server-ops`)
 - **Install**: `sudo npm install -g cloudron` (on your PC/Mac, NOT the server)
 - **Login**: `cloudron login my.example.com` (browser-based; 9.1+ uses OIDC/passkey)
-- **CI/CD**: `--server <domain> --token <api-token>` for non-interactive use (get token from `https://my.example.com/#/profile`)
+- **CI/CD**: `--server <domain> --token <api-token>` (get token from `https://my.example.com/#/profile`); example: `cloudron update --server my.example.com --token <token> --app blog.example.com --image user/image:tag`
 - **Token stored**: `~/.cloudron.json`; self-signed TLS: add `--allow-selfsigned`
 - **Also see**: `cloudron-helper.sh` for multi-server management via API
 
@@ -162,6 +160,3 @@ cloudron completion             # shell completion
 | `--allow-selfsigned` | Accept self-signed TLS certificates |
 | `--no-wait` | Do not wait for the operation to complete |
 
-## CI/CD Integration
-
-Non-interactive use: add `--server <domain> --token <api-token>` (see Global Options). Example: `cloudron update --server my.example.com --token <token> --app blog.example.com --image user/image:tag`


### PR DESCRIPTION
## Summary

- Remove redundant intro sentence (covered by frontmatter `description` field)
- Fold CI/CD example command into Quick Reference CI/CD bullet (was a standalone section duplicating Global Options)
- Remove duplicate `## CI/CD Integration` section at end of file

## Changes

- **File**: `.agents/tools/deployment/cloudron-server-ops-skill.md`
- **Before**: 167 lines
- **After**: 162 lines
- **Content preserved**: All code blocks, URLs, command examples, flags, and functional guidance intact

## Runtime Testing

Risk level: **Low** — agent doc (markdown), no executable code changed.
Verification: all code blocks, URLs, command examples present before and after (verified via diff).

Closes #13057


---
[aidevops.sh](https://aidevops.sh) v3.5.300 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 1m and 3,826 tokens on this as a headless worker.