### PR TITLE
GH#12211: tighten concurrency.md — remove redundant inline comment

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/concurrency.md
+++ b/.agents/tools/programming/modern-javascript-skill/concurrency.md
@@ -15,7 +15,6 @@ const results = await Array.fromAsync(processSequentially(items));
 ## Parallel Execution
 
 ```javascript
-// All at once
 const results = await Promise.all(items.map(item => processItem(item)));
 ```
 


### PR DESCRIPTION
## Summary

- Removes `// All at once` comment from Parallel Execution code block — redundant with the section heading
- All code blocks, ES version annotations (`ES2024`, `ES2025`), behavioral notes, and pattern knowledge preserved
- 214 → 213 lines (1 line removed)

## Classification

This file is a **reference corpus** (self-contained code examples, textbook-style), not an instruction doc. Per `code-simplifier.md` "Reference corpora" guidance: do not compress content. At 213 lines it is under the 300-line split threshold — no restructuring needed.

The only legitimate noise was one redundant comment where the heading already conveyed the same information.

## Runtime Testing

**Risk level:** Low — docs/agent prompt file, no executable code changed.
**Testing level:** `self-assessed`
- Markdownlint: 0 errors
- Content preservation: all code blocks, ES version refs, task IDs intact
- No broken internal links

## Files Changed

- `.agents/tools/programming/modern-javascript-skill/concurrency.md` — 1 line removed

Closes #12211

---
[aidevops.sh](https://aidevops.sh) v3.5.300 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 2m and 5,380 tokens on this as a headless worker.