### PR TITLE
GH#12414: tighten workerd-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
@@ -90,7 +90,7 @@ const config :Workerd.Config = (
 | Direct | `workerd serve config.capnp --socket-addr http=*:3000 --verbose` |
 | With env vars | `export DATABASE_URL="postgres://..." && workerd serve config.capnp` |
 
-**Environment variable bindings:**
+### Environment Variables
 
 ```capnp
 bindings = [
@@ -118,7 +118,9 @@ workerd test config.capnp --test-only=test.js
 
 ## Production Deployment
 
-**Systemd** (`/etc/systemd/system/workerd.service` + `workerd.socket`):
+### Systemd
+
+`/etc/systemd/system/workerd.service` + `workerd.socket`:
 
 ```ini
 [Unit]
@@ -145,7 +147,7 @@ ListenStream=0.0.0.0:80
 WantedBy=sockets.target
 ```
 
-**Docker:**
+### Docker
 
 ```dockerfile
 FROM debian:bookworm-slim
@@ -157,7 +159,7 @@ EXPOSE 8080
 CMD ["workerd", "serve", "/etc/workerd/config.capnp"]
 ```
 
-**Compiled binary:**
+### Compiled Binary
 
 ```bash
 workerd compile config.capnp myConfig -o production-server
@@ -177,7 +179,7 @@ workerd compile config.capnp myConfig -o production-server
 | Error handling | Wrap handlers in try/catch |
 | Resource limits | Configure limits on caches/storage |
 
-## Worker Patterns
+## Fetch Handler
 
 ```javascript
 export default {


### PR DESCRIPTION
## Summary

- Replace bold prose labels with sub-headings (`### Environment Variables`, `### Systemd`, `### Docker`, `### Compiled Binary`) for consistent heading-based navigation
- Rename `## Worker Patterns` → `## Fetch Handler` (the section contains a fetch handler pattern, not a generic worker pattern — the old name was redundant with the file title)
- Zero content removed; all code blocks, capnp configs, commands, and references preserved

## Classification

Reference corpus (code examples, config patterns). Tightening applied to structure/navigation, not content compression.

## Verification

- `markdownlint-cli2`: 0 errors
- `wc -l`: 199 lines (197 → 199; +2 from sub-heading lines replacing bold labels)
- All code blocks, URLs, and command examples present before and after

## Runtime Testing

Risk: **Low** — agent doc restructure only, no code changes.
Level: `self-assessed`

Closes #12414

---
[aidevops.sh](https://aidevops.sh) v3.5.300 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-sonnet-4-6 spent 5m and 4,781 tokens on this as a headless worker.