### PR TITLE
fix: use atomic JSON writes to prevent config truncation on crash

### DIFF
--- a/.agents/scripts/ai-cli-config.sh
+++ b/.agents/scripts/ai-cli-config.sh
@@ -31,7 +31,7 @@ json_set_nested() {
 	fi
 
 	python3 - "$file" "$outer_key" "$inner_key" "$value_json" <<'PYEOF'
-import json, sys
+import json, sys, os, tempfile
 
 file_path = sys.argv[1]
 outer_key = sys.argv[2]
@@ -49,9 +49,13 @@ if outer_key not in config or not isinstance(config[outer_key], dict):
 
 existed = inner_key in config[outer_key]
 config[outer_key][inner_key] = json.loads(value_json)
-with open(file_path, 'w') as f:
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(file_path) or '.', suffix='.tmp')
+with os.fdopen(fd, 'w') as f:
     json.dump(config, f, indent=2)
     f.write('\n')
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, file_path)
 if existed:
     print(f"Updated {inner_key} in {file_path}")
 else:
@@ -81,7 +85,7 @@ json_append_to_array() {
 	fi
 
 	python3 - "$file" "$array_key" "$value_json" "$match_key" "$match_val" <<'PYEOF'
-import json, sys
+import json, sys, os, tempfile
 
 file_path = sys.argv[1]
 array_key = sys.argv[2]
@@ -105,9 +109,13 @@ for item in config[array_key]:
         sys.exit(0)
 
 config[array_key].append(json.loads(value_json))
-with open(file_path, 'w') as f:
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(file_path) or '.', suffix='.tmp')
+with os.fdopen(fd, 'w') as f:
     json.dump(config, f, indent=2)
     f.write('\n')
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, file_path)
 print(f"Added {match_val} to {array_key} array in {file_path}")
 PYEOF
 	return 0

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -95,6 +95,26 @@ import os
 import glob
 import re
 import sys
+import tempfile
+
+def atomic_json_write(path, data, indent=2, trailing_newline=False):
+    """Write JSON atomically: tmp file + fsync + rename. Prevents truncation on crash."""
+    dir_name = os.path.dirname(path) or '.'
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix='.tmp', prefix='.atomic-')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=indent)
+            if trailing_newline:
+                f.write('\n')
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 config_path = os.path.expanduser("~/.config/opencode/opencode.json")
 agents_dir = os.path.expanduser("~/.aidevops/agents")
@@ -809,8 +829,7 @@ for tool_pattern in omo_tool_patterns:
         print(f"  Disabled {tool_pattern} tools globally (use matching subagent/CLI workflow)")
 
 if config_loaded:
-    with open(config_path, 'w', encoding='utf-8') as f:
-        json.dump(config, f, indent=2)
+    atomic_json_write(config_path, config)
     print(f"  Updated {len(primary_agents)} primary agents in opencode.json")
 else:
     print("Error: config was not loaded successfully, skipping write", file=sys.stderr)

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -112,6 +112,26 @@ import json
 import os
 import glob
 import sys
+import tempfile
+
+def atomic_json_write(path, data, indent=2, trailing_newline=False):
+    """Write JSON atomically: tmp file + fsync + rename. Prevents truncation on crash."""
+    dir_name = os.path.dirname(path) or '.'
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix='.tmp', prefix='.atomic-')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=indent)
+            if trailing_newline:
+                f.write('\n')
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 runtime_id = sys.argv[1]
 output_format = sys.argv[2]
@@ -510,8 +530,7 @@ if output_format == "opencode-json":
         if config['tools'].get(tool_pattern) is not False:
             config['tools'][tool_pattern] = False
 
-    with open(config_path, 'w', encoding='utf-8') as f:
-        json.dump(config, f, indent=2)
+    atomic_json_write(config_path, config)
 
     print(f"  Updated {len(primary_agents)} primary agents in opencode.json")
     if subagent_filtered_count > 0:
@@ -649,9 +668,7 @@ elif output_format == "claude-settings":
 
     if changed:
         os.makedirs(os.path.dirname(settings_path), exist_ok=True)
-        with open(settings_path, 'w') as f:
-            json.dump(settings, f, indent=2)
-            f.write('\n')
+        atomic_json_write(settings_path, settings, trailing_newline=True)
         print(f"  Updated {settings_path}")
     else:
         print(f"  {settings_path} (no changes needed)")

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -35,70 +35,70 @@ print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
 
 # Find the source hook script (repo .agents/hooks/ or deployed ~/.aidevops/agents/hooks/)
 find_source_hook() {
-    local script_dir
-    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local repo_hook="$script_dir/../hooks/git_safety_guard.py"
-    local deployed_hook="$HOME/.aidevops/agents/hooks/git_safety_guard.py"
+	local script_dir
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local repo_hook="$script_dir/../hooks/git_safety_guard.py"
+	local deployed_hook="$HOME/.aidevops/agents/hooks/git_safety_guard.py"
 
-    if [[ -f "$repo_hook" ]]; then
-        echo "$repo_hook"
-        return 0
-    elif [[ -f "$deployed_hook" ]]; then
-        echo "$deployed_hook"
-        return 0
-    else
-        print_error "Source hook not found in repo or deployed agents"
-        return 1
-    fi
+	if [[ -f "$repo_hook" ]]; then
+		echo "$repo_hook"
+		return 0
+	elif [[ -f "$deployed_hook" ]]; then
+		echo "$deployed_hook"
+		return 0
+	else
+		print_error "Source hook not found in repo or deployed agents"
+		return 1
+	fi
 }
 
 install_hook() {
-    print_info "Installing Claude Code safety hooks..."
+	print_info "Installing Claude Code safety hooks..."
 
-    # Check Python is available
-    if ! command -v python3 &>/dev/null; then
-        print_error "Python 3 is required but not found"
-        return 1
-    fi
+	# Check Python is available
+	if ! command -v python3 &>/dev/null; then
+		print_error "Python 3 is required but not found"
+		return 1
+	fi
 
-    # Find source hook
-    local source_hook
-    source_hook=$(find_source_hook) || return 1
+	# Find source hook
+	local source_hook
+	source_hook=$(find_source_hook) || return 1
 
-    # Create hooks directory
-    mkdir -p "$HOOKS_DIR"
+	# Create hooks directory
+	mkdir -p "$HOOKS_DIR"
 
-    # Copy hook script
-    cp "$source_hook" "$HOOK_SCRIPT"
-    chmod +x "$HOOK_SCRIPT"
-    print_success "Installed $HOOK_SCRIPT"
+	# Copy hook script
+	cp "$source_hook" "$HOOK_SCRIPT"
+	chmod +x "$HOOK_SCRIPT"
+	print_success "Installed $HOOK_SCRIPT"
 
-    # Configure Claude Code settings.json
-    configure_claude_settings || return 1
+	# Configure Claude Code settings.json
+	configure_claude_settings || return 1
 
-    # Run self-test
-    test_hook || return 1
+	# Run self-test
+	test_hook || return 1
 
-    echo ""
-    print_success "Safety hooks installed successfully"
-    echo ""
-    echo "Blocked commands:"
-    echo "  git checkout -- <files>    git restore <files>"
-    echo "  git reset --hard           git clean -f"
-    echo "  git push --force / -f      git branch -D"
-    echo "  rm -rf (non-temp paths)    git stash drop/clear"
-    echo ""
-    print_warning "Restart Claude Code for the hook to take effect"
-    return 0
+	echo ""
+	print_success "Safety hooks installed successfully"
+	echo ""
+	echo "Blocked commands:"
+	echo "  git checkout -- <files>    git restore <files>"
+	echo "  git reset --hard           git clean -f"
+	echo "  git push --force / -f      git branch -D"
+	echo "  rm -rf (non-temp paths)    git stash drop/clear"
+	echo ""
+	print_warning "Restart Claude Code for the hook to take effect"
+	return 0
 }
 
 configure_claude_settings() {
-    mkdir -p "$(dirname "$CLAUDE_SETTINGS")"
+	mkdir -p "$(dirname "$CLAUDE_SETTINGS")"
 
-    if [[ ! -f "$CLAUDE_SETTINGS" ]]; then
-        # Create new settings with hook
-        python3 -c "
-import json, sys
+	if [[ ! -f "$CLAUDE_SETTINGS" ]]; then
+		# Create new settings with hook
+		python3 -c "
+import json, sys, os, tempfile
 settings = {
     'hooks': {
         'PreToolUse': [
@@ -114,16 +114,24 @@ settings = {
         ]
     }
 }
-with open('$CLAUDE_SETTINGS', 'w') as f:
+path = '$CLAUDE_SETTINGS'
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+with os.fdopen(fd, 'w') as f:
     json.dump(settings, f, indent=2)
     f.write('\n')
-" || { print_error "Failed to create settings.json"; return 1; }
-        print_success "Created $CLAUDE_SETTINGS with hook configuration"
-        return 0
-    fi
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, path)
+" || {
+			print_error "Failed to create settings.json"
+			return 1
+		}
+		print_success "Created $CLAUDE_SETTINGS with hook configuration"
+		return 0
+	fi
 
-    # Check if hook is already configured
-    if python3 -c "
+	# Check if hook is already configured
+	if python3 -c "
 import json, sys
 with open('$CLAUDE_SETTINGS') as f:
     d = json.load(f)
@@ -134,13 +142,13 @@ for h in hooks:
             sys.exit(0)
 sys.exit(1)
 " 2>/dev/null; then
-        print_info "Hook already configured in $CLAUDE_SETTINGS"
-        return 0
-    fi
+		print_info "Hook already configured in $CLAUDE_SETTINGS"
+		return 0
+	fi
 
-    # Merge hook into existing settings
-    python3 -c "
-import json, sys
+	# Merge hook into existing settings
+	python3 -c "
+import json, sys, os, tempfile
 
 with open('$CLAUDE_SETTINGS') as f:
     settings = json.load(f)
@@ -163,29 +171,37 @@ if 'PreToolUse' not in settings['hooks']:
 else:
     settings['hooks']['PreToolUse'].append(hook_entry)
 
-with open('$CLAUDE_SETTINGS', 'w') as f:
+path = '$CLAUDE_SETTINGS'
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+with os.fdopen(fd, 'w') as f:
     json.dump(settings, f, indent=2)
     f.write('\n')
-" || { print_error "Failed to update settings.json"; return 1; }
-    print_success "Updated $CLAUDE_SETTINGS with hook configuration"
-    return 0
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, path)
+" || {
+		print_error "Failed to update settings.json"
+		return 1
+	}
+	print_success "Updated $CLAUDE_SETTINGS with hook configuration"
+	return 0
 }
 
 uninstall_hook() {
-    print_info "Removing Claude Code safety hooks..."
+	print_info "Removing Claude Code safety hooks..."
 
-    # Remove hook script
-    if [[ -f "$HOOK_SCRIPT" ]]; then
-        rm "$HOOK_SCRIPT"
-        print_success "Removed $HOOK_SCRIPT"
-    else
-        print_info "Hook script not found (already removed)"
-    fi
+	# Remove hook script
+	if [[ -f "$HOOK_SCRIPT" ]]; then
+		rm "$HOOK_SCRIPT"
+		print_success "Removed $HOOK_SCRIPT"
+	else
+		print_info "Hook script not found (already removed)"
+	fi
 
-    # Remove from Claude settings
-    if [[ -f "$CLAUDE_SETTINGS" ]]; then
-        python3 -c "
-import json
+	# Remove from Claude settings
+	if [[ -f "$CLAUDE_SETTINGS" ]]; then
+		python3 -c "
+import json, os, tempfile
 
 with open('$CLAUDE_SETTINGS') as f:
     settings = json.load(f)
@@ -206,54 +222,59 @@ elif 'PreToolUse' in settings.get('hooks', {}):
     if not settings['hooks']:
         del settings['hooks']
 
-with open('$CLAUDE_SETTINGS', 'w') as f:
+path = '$CLAUDE_SETTINGS'
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+with os.fdopen(fd, 'w') as f:
     json.dump(settings, f, indent=2)
     f.write('\n')
+    f.flush()
+    os.fsync(f.fileno())
+os.rename(tmp, path)
 " 2>/dev/null && print_success "Removed hook from $CLAUDE_SETTINGS"
-    fi
+	fi
 
-    # Clean up empty hooks directory
-    if [[ -d "$HOOKS_DIR" ]] && [[ -z "$(ls -A "$HOOKS_DIR" 2>/dev/null)" ]]; then
-        rmdir "$HOOKS_DIR"
-        print_info "Removed empty hooks directory"
-    fi
+	# Clean up empty hooks directory
+	if [[ -d "$HOOKS_DIR" ]] && [[ -z "$(ls -A "$HOOKS_DIR" 2>/dev/null)" ]]; then
+		rmdir "$HOOKS_DIR"
+		print_info "Removed empty hooks directory"
+	fi
 
-    print_success "Safety hooks uninstalled"
-    print_warning "Restart Claude Code for changes to take effect"
-    return 0
+	print_success "Safety hooks uninstalled"
+	print_warning "Restart Claude Code for changes to take effect"
+	return 0
 }
 
 check_status() {
-    local all_ok=true
+	local all_ok=true
 
-    echo "Claude Code Safety Hooks Status"
-    echo "================================"
+	echo "Claude Code Safety Hooks Status"
+	echo "================================"
 
-    # Check hook script
-    if [[ -f "$HOOK_SCRIPT" ]]; then
-        print_success "Hook script: $HOOK_SCRIPT"
-        if [[ -x "$HOOK_SCRIPT" ]]; then
-            print_success "  Executable: yes"
-        else
-            print_warning "  Executable: no (run: chmod +x $HOOK_SCRIPT)"
-            all_ok=false
-        fi
-    else
-        print_error "Hook script: not installed"
-        all_ok=false
-    fi
+	# Check hook script
+	if [[ -f "$HOOK_SCRIPT" ]]; then
+		print_success "Hook script: $HOOK_SCRIPT"
+		if [[ -x "$HOOK_SCRIPT" ]]; then
+			print_success "  Executable: yes"
+		else
+			print_warning "  Executable: no (run: chmod +x $HOOK_SCRIPT)"
+			all_ok=false
+		fi
+	else
+		print_error "Hook script: not installed"
+		all_ok=false
+	fi
 
-    # Check Python
-    if command -v python3 &>/dev/null; then
-        print_success "Python 3: $(python3 --version 2>&1)"
-    else
-        print_error "Python 3: not found"
-        all_ok=false
-    fi
+	# Check Python
+	if command -v python3 &>/dev/null; then
+		print_success "Python 3: $(python3 --version 2>&1)"
+	else
+		print_error "Python 3: not found"
+		all_ok=false
+	fi
 
-    # Check Claude settings
-    if [[ -f "$CLAUDE_SETTINGS" ]]; then
-        if python3 -c "
+	# Check Claude settings
+	if [[ -f "$CLAUDE_SETTINGS" ]]; then
+		if python3 -c "
 import json, sys
 with open('$CLAUDE_SETTINGS') as f:
     d = json.load(f)
@@ -264,124 +285,124 @@ for h in hooks:
             sys.exit(0)
 sys.exit(1)
 " 2>/dev/null; then
-            print_success "Claude settings: hook configured"
-        else
-            print_warning "Claude settings: exists but hook not configured"
-            all_ok=false
-        fi
-    else
-        print_error "Claude settings: $CLAUDE_SETTINGS not found"
-        all_ok=false
-    fi
+			print_success "Claude settings: hook configured"
+		else
+			print_warning "Claude settings: exists but hook not configured"
+			all_ok=false
+		fi
+	else
+		print_error "Claude settings: $CLAUDE_SETTINGS not found"
+		all_ok=false
+	fi
 
-    echo ""
-    if [[ "$all_ok" == "true" ]]; then
-        print_success "All checks passed - safety hooks are active"
-    else
-        print_warning "Some checks failed - run: install-hooks-helper.sh install"
-    fi
-    return 0
+	echo ""
+	if [[ "$all_ok" == "true" ]]; then
+		print_success "All checks passed - safety hooks are active"
+	else
+		print_warning "Some checks failed - run: install-hooks-helper.sh install"
+	fi
+	return 0
 }
 
 test_hook() {
-    print_info "Running hook self-test..."
+	print_info "Running hook self-test..."
 
-    local test_script="$HOOK_SCRIPT"
-    if [[ ! -f "$test_script" ]]; then
-        # Fall back to source
-        test_script=$(find_source_hook) || return 1
-    fi
+	local test_script="$HOOK_SCRIPT"
+	if [[ ! -f "$test_script" ]]; then
+		# Fall back to source
+		test_script=$(find_source_hook) || return 1
+	fi
 
-    local pass=0
-    local fail=0
+	local pass=0
+	local fail=0
 
-    # Test blocked commands
-    local -a blocked_cmds=(
-        "git checkout -- test.txt"
-        "git reset --hard"
-        "git clean -f"
-        "git push --force origin main"
-        "git push -f origin main"
-        "git branch -D old-branch"
-        "rm -rf /some/path"
-        "git stash drop"
-        "git stash clear"
-        "/usr/bin/git reset --hard"
-        "git restore file.txt"
-    )
+	# Test blocked commands
+	local -a blocked_cmds=(
+		"git checkout -- test.txt"
+		"git reset --hard"
+		"git clean -f"
+		"git push --force origin main"
+		"git push -f origin main"
+		"git branch -D old-branch"
+		"rm -rf /some/path"
+		"git stash drop"
+		"git stash clear"
+		"/usr/bin/git reset --hard"
+		"git restore file.txt"
+	)
 
-    for cmd in "${blocked_cmds[@]}"; do
-        local result
-        result=$(echo "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
-        if echo "$result" | grep -q "permissionDecision.*deny" 2>/dev/null; then
-            pass=$((pass + 1))
-        else
-            print_error "  FAIL: should block: $cmd"
-            fail=$((fail + 1))
-        fi
-    done
+	for cmd in "${blocked_cmds[@]}"; do
+		local result
+		result=$(echo "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
+		if echo "$result" | grep -q "permissionDecision.*deny" 2>/dev/null; then
+			pass=$((pass + 1))
+		else
+			print_error "  FAIL: should block: $cmd"
+			fail=$((fail + 1))
+		fi
+	done
 
-    # Test allowed commands
-    local -a allowed_cmds=(
-        "git status"
-        "git checkout -b new-branch"
-        "git restore --staged file.txt"
-        "git clean -fn"
-        "git clean --dry-run"
-        "rm -rf /tmp/test-dir"
-        "git push --force-with-lease"
-        "git branch -d old-branch"
-        "ls -la"
-    )
+	# Test allowed commands
+	local -a allowed_cmds=(
+		"git status"
+		"git checkout -b new-branch"
+		"git restore --staged file.txt"
+		"git clean -fn"
+		"git clean --dry-run"
+		"rm -rf /tmp/test-dir"
+		"git push --force-with-lease"
+		"git branch -d old-branch"
+		"ls -la"
+	)
 
-    for cmd in "${allowed_cmds[@]}"; do
-        local result
-        result=$(echo "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
-        if [[ -z "$result" ]]; then
-            pass=$((pass + 1))
-        else
-            print_error "  FAIL: should allow: $cmd"
-            fail=$((fail + 1))
-        fi
-    done
+	for cmd in "${allowed_cmds[@]}"; do
+		local result
+		result=$(echo "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
+		if [[ -z "$result" ]]; then
+			pass=$((pass + 1))
+		else
+			print_error "  FAIL: should allow: $cmd"
+			fail=$((fail + 1))
+		fi
+	done
 
-    if [[ "$fail" -eq 0 ]]; then
-        print_success "All $pass tests passed"
-        return 0
-    else
-        print_error "$fail tests failed, $pass passed"
-        return 1
-    fi
+	if [[ "$fail" -eq 0 ]]; then
+		print_success "All $pass tests passed"
+		return 0
+	else
+		print_error "$fail tests failed, $pass passed"
+		return 1
+	fi
 }
 
 show_help() {
-    echo "install-hooks-helper.sh - Claude Code destructive command protection"
-    echo ""
-    echo "Usage: install-hooks-helper.sh [command]"
-    echo ""
-    echo "Commands:"
-    echo "  install     Install safety hooks (default)"
-    echo "  uninstall   Remove safety hooks"
-    echo "  status      Check installation status"
-    echo "  test        Run hook self-test"
-    echo "  help        Show this help"
-    echo ""
-    echo "Installs to:"
-    echo "  ~/.aidevops/hooks/git_safety_guard.py"
-    echo "  ~/.claude/settings.json (PreToolUse hook config)"
-    return 0
+	echo "install-hooks-helper.sh - Claude Code destructive command protection"
+	echo ""
+	echo "Usage: install-hooks-helper.sh [command]"
+	echo ""
+	echo "Commands:"
+	echo "  install     Install safety hooks (default)"
+	echo "  uninstall   Remove safety hooks"
+	echo "  status      Check installation status"
+	echo "  test        Run hook self-test"
+	echo "  help        Show this help"
+	echo ""
+	echo "Installs to:"
+	echo "  ~/.aidevops/hooks/git_safety_guard.py"
+	echo "  ~/.claude/settings.json (PreToolUse hook config)"
+	return 0
 }
 
 # Main
 case "${1:-install}" in
-    install)   install_hook ;;
-    uninstall) uninstall_hook ;;
-    status)    check_status ;;
-    test)      test_hook ;;
-    help|--help|-h) show_help ;;
-    *)
-        print_error "Unknown command: $1"
-        show_help
-        exit 1
-        ;;
+install) install_hook ;;
+uninstall) uninstall_hook ;;
+status) check_status ;;
+test) test_hook ;;
+help | --help | -h) show_help ;;
+*)
+	print_error "Unknown command: $1"
+	show_help
+	exit 1
+	;;
 esac


### PR DESCRIPTION
## Summary

- Replace all 8 `open('w') + json.dump()` write sites across 4 config scripts with atomic writes (`mkstemp` + `fsync` + `rename`)
- Prevents config file truncation when process is interrupted mid-write (Ctrl-C, crash, OOM)
- Fixes the root cause of OpenCode crash where `opencode.json` was truncated at 8188 bytes during setup/update

## Files changed

| Script | Write sites | Config target |
|--------|------------|---------------|
| `generate-runtime-config.sh` | 2 | `opencode.json`, `settings.json` |
| `generate-opencode-agents.sh` | 1 | `opencode.json` |
| `install-hooks-helper.sh` | 3 | `settings.json` |
| `ai-cli-config.sh` | 2 | any JSON config |

## How it works

Before: `open(path, 'w')` truncates the file to 0 bytes, then `json.dump()` writes new content. Interruption between truncate and write completion = corrupted file.

After: `tempfile.mkstemp()` creates a temp file in the same directory, writes + `fsync()`, then `os.rename()` atomically replaces the original. Interruption at any point leaves either the old file intact or a harmless `.tmp` file.

## Testing

- Ran `generate-runtime-config.sh agents --runtime opencode` — 10 agents configured, valid JSON
- Ran `generate-runtime-config.sh agents --runtime claude-code` — settings updated, valid JSON
- No leftover `.tmp` files after successful writes
- ShellCheck clean (no new violations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of configuration file writing across multiple scripts by implementing atomic write operations, reducing the risk of data corruption if the process is interrupted unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->