### PR TITLE
GH#13186: tighten stream-patterns.md prose

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/stream-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/stream-patterns.md
@@ -1,7 +1,5 @@
 # Stream Patterns
 
-Common workflows, full-stack flows, and best practices.
-
 ## Full-Stack Upload Flow
 
 **Backend API (Next.js route)**
@@ -130,23 +128,20 @@ export default {
 
 ## Best Practices
 
-1. **Use Direct Creator Uploads** - Avoid proxying video through servers
-2. **Enable requireSignedURLs** - Control access to private content
-3. **Use signing keys for high volume** - Self-sign tokens instead of API calls
-4. **Set allowedOrigins** - Prevent hotlinking
-5. **Use webhooks over polling** - Efficient status updates
-6. **Cache video metadata** - Reduce API calls
-7. **Set maxDurationSeconds** - Prevent abuse on direct uploads
-8. **Use creator metadata** - Enable per-user filtering/analytics
-9. **Enable recordings for live** - Automatic VOD after stream ends
-10. **Monitor with GraphQL analytics** - Track views, watch time, geo
+1. **Direct Creator Uploads** — avoid proxying video through servers
+2. **requireSignedURLs** — control access to private content
+3. **Signing keys for high volume** — self-sign tokens instead of API calls
+4. **allowedOrigins** — prevent hotlinking
+5. **Webhooks over polling** — efficient status updates
+6. **Cache video metadata** — reduce API calls
+7. **maxDurationSeconds** — prevent abuse on direct uploads
+8. **Creator metadata** — enable per-user filtering/analytics
+9. **Enable recordings for live** — automatic VOD after stream ends
+10. **GraphQL analytics** — track views, watch time, geo
 
-## In This Reference
+## Related
 
-- [README.md](./README.md) - Overview and quick start
-- [gotchas.md](./gotchas.md) - Error codes, troubleshooting
-
-## See Also
-
-- [workers](../workers/) - Deploy Stream APIs in Workers
-- [pages](../pages/) - Integrate Stream with Pages
+- [README.md](./README.md) — overview and quick start
+- [gotchas.md](./gotchas.md) — error codes, troubleshooting
+- [workers](../workers/) — deploy Stream APIs in Workers
+- [pages](../pages/) — integrate Stream with Pages


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/services/hosting/cloudflare-platform-skill/stream-patterns.md` (152 → 147 lines) without losing meaning.

Closes #13186

## Changes

- Remove redundant intro line — heading is self-explanatory
- Compact best practices list: strip filler verbs ("Use", "Set", "Enable", "Monitor with") from bold labels, keeping the feature name + explanation
- Merge "In This Reference" + "See Also" into single "Related" section (eliminates 4 lines of section overhead)
- Standardize separators from hyphens to em dashes

## Content Preservation

- All 4 code blocks (backend API, frontend component, video state management, webhook handler) — byte-identical
- All Cloudflare API URLs and RTMPS URLs — preserved
- All 4 relative links (README.md, gotchas.md, workers/, pages/) — preserved
- All 10 best practices — preserved with same meaning

## Runtime Testing

- **Risk level**: Low (docs-only change, no code execution paths affected)
- **Verification**: `self-assessed` — markdownlint clean, diff reviewed for content preservation

---
[aidevops.sh](https://aidevops.sh) v3.5.311 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 2m and 4,710 tokens on this as a headless worker.