### PR TITLE
GH#13176: tighten api-key-management.md prose (154 → 122 lines)

### DIFF
--- a/.agents/tools/credentials/api-key-management.md
+++ b/.agents/tools/credentials/api-key-management.md
@@ -18,137 +18,105 @@ tools:
 
 ## Quick Reference
 
-- **Primary Method**: Environment variables (`export CODACY_API_TOKEN="..."`)
-- **Local Storage**: `configs/*-config.json` (gitignored), `~/.config/coderabbit/api_key`
+- **Primary**: Environment variables (`export CODACY_API_TOKEN="..."`)
+- **Local storage**: `configs/*-config.json` (gitignored), `~/.config/coderabbit/api_key`
 - **CI/CD**: GitHub Secrets (`SONAR_TOKEN`, `CODACY_API_TOKEN`, `GITHUB_TOKEN`)
-- **Helper Script**: `.agents/scripts/setup-local-api-keys.sh` (set, load, list)
-- **Token Sources**: Codacy (app.codacy.com/account/api-tokens), SonarCloud (sonarcloud.io/account/security)
-- **Security**: 600 permissions, never commit, regular rotation (90 days)
-- **If Compromised**: Revoke immediately → Generate new → Update local + GitHub secrets → Verify
+- **Helper**: `.agents/scripts/setup-local-api-keys.sh` (set, load, list)
+- **Token sources**: Codacy (app.codacy.com/account/api-tokens), SonarCloud (sonarcloud.io/account/security)
+- **Security**: 600 permissions, never commit, rotate every 90 days
+- **If compromised**: Revoke → regenerate → update local + GitHub secrets → verify
 - **Test**: `echo "${CODACY_API_TOKEN:0:10}..."` to verify without exposing
+
 <!-- AI-CONTEXT-END -->
 
-## Secure API Key Storage Locations
+## Storage Locations
 
-### **1. Environment Variables (Primary Method)**
+### Environment Variables (Primary)
 
 ```bash
-# Set for current session
+# Current session
 export CODACY_API_TOKEN="YOUR_CODACY_API_TOKEN_HERE"
 export SONAR_TOKEN="YOUR_SONAR_TOKEN_HERE"
 
-# Add to shell profile for persistence
+# Persist in shell profile
 echo 'export CODACY_API_TOKEN="YOUR_CODACY_API_TOKEN_HERE"' >> ~/.bashrc
 echo 'export SONAR_TOKEN="YOUR_SONAR_TOKEN_HERE"' >> ~/.bashrc
 ```
 
-### 2. Local Configuration Files (Gitignored)
+### Local Configuration Files (Gitignored)
 
 ```text
-# Repository configs (gitignored)
-configs/codacy-config.json          # Codacy API configuration
-configs/sonar-config.json           # SonarCloud configuration (if needed)
-
-# CLI-specific storage
+configs/codacy-config.json           # Codacy API configuration
+configs/sonar-config.json            # SonarCloud configuration
 ~/.config/coderabbit/api_key         # CodeRabbit CLI token
-~/.codacy/config                     # Codacy CLI configuration (if used)
+~/.codacy/config                     # Codacy CLI configuration
 ```
 
-### 3. GitHub Repository Secrets
+### GitHub Repository Secrets
 
 ```text
-# Required for GitHub Actions
 SONAR_TOKEN                          # SonarCloud analysis
 CODACY_API_TOKEN                     # Codacy analysis
 GITHUB_TOKEN                         # Automatic (provided by GitHub)
 ```
 
-## Current API Key Status
+## Setup
 
-### **✅ CONFIGURED:**
+### 1. Get SonarCloud Token
 
-- **Codacy API Token**: `[CONFIGURED LOCALLY]` (Local environment + config file)
-- **CodeRabbit CLI**: Stored in `~/.config/coderabbit/api_key`
+1. Go to https://sonarcloud.io/account/security
+2. Generate token with project analysis permissions
 
-### **❌ MISSING (CAUSING GITHUB ACTION FAILURES):**
+### 2. Add GitHub Secrets
 
-- **SONAR_TOKEN**: Not set in GitHub Secrets
-- **CODACY_API_TOKEN**: Not set in GitHub Secrets
+1. Go to https://github.com/marcusquinn/aidevops/settings/secrets/actions
+2. Add `SONAR_TOKEN` and `CODACY_API_TOKEN`
 
-## Setup Instructions
-
-### **1. Get SonarCloud Token**
-
-1. Go to: https://sonarcloud.io/account/security
-2. Generate new token with project analysis permissions
-3. Copy the token value
-
-### **2. Add GitHub Secrets**
-
-1. Go to: https://github.com/marcusquinn/aidevops/settings/secrets/actions
-2. Click "New repository secret"
-3. Add:
-   - Name: `SONAR_TOKEN`, Value: [Your SonarCloud token]
-   - Name: `CODACY_API_TOKEN`, Value: [Your Codacy API token]
-
-### **3. Set Local API Keys Securely**
+### 3. Set Local API Keys
 
 ```bash
-# Use secure local storage (RECOMMENDED)
+# Store securely (recommended)
 bash .agents/scripts/setup-local-api-keys.sh set codacy YOUR_CODACY_API_TOKEN
 bash .agents/scripts/setup-local-api-keys.sh set sonar YOUR_SONAR_TOKEN
 
-# Load all API keys into environment when needed
+# Load into environment
 bash .agents/scripts/setup-local-api-keys.sh load
 
 # List configured services
 bash .agents/scripts/setup-local-api-keys.sh list
 ```
 
-### **4. Test Configuration**
+### 4. Test Configuration
 
 ```bash
 # Test Codacy CLI
 cd git/aidevops
 bash .agents/scripts/codacy-cli.sh analyze
 
-# Test environment variables
+# Verify tokens loaded (partial display)
 echo "Codacy token: ${CODACY_API_TOKEN:0:10}..."
 echo "Sonar token: ${SONAR_TOKEN:0:10}..."
 ```
 
 ## Security Audit Checklist
 
-### **✅ SECURE STORAGE:**
-
 - [ ] API keys in environment variables (not hardcoded)
 - [ ] Local config files are gitignored
 - [ ] GitHub Secrets configured for CI/CD
 - [ ] No API keys in commit messages or code
-
-### **✅ ACCESS CONTROL:**
-
-- [ ] Minimal required permissions for each token
+- [ ] Minimal required permissions per token
 - [ ] Regular token rotation (every 90 days)
 - [ ] Revoke old tokens immediately after replacement
 - [ ] Monitor token usage and access logs
-
-### **✅ BACKUP & RECOVERY:**
-
 - [ ] Document token sources and regeneration procedures
 - [ ] Secure backup of configuration templates
-- [ ] Emergency token revocation procedures
+- [ ] Emergency token revocation procedures documented
 - [ ] Team access management for shared tokens
 
-## Emergency Procedures
+## Emergency: Compromised Key
 
-### **If API Key is Compromised:**
-
-1. **IMMEDIATE**: Revoke the compromised key at provider
-2. **IMMEDIATE**: Generate new API key
-3. **UPDATE**: Local environment variables
-4. **UPDATE**: GitHub repository secrets
-5. **VERIFY**: All systems working with new key
-6. **DOCUMENT**: Incident and lessons learned
-
-This guide ensures secure, professional API key management across all platforms and environments.
+1. **Revoke** the compromised key at provider immediately
+2. **Generate** new API key
+3. **Update** local environment variables and GitHub repository secrets
+4. **Verify** all systems working with new key
+5. **Document** incident and lessons learned


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/credentials/api-key-management.md` from 154 → 122 lines (21% reduction)
- Remove stale instance-specific "Current API Key Status" section (not a general guide concern)
- Consolidate three separate audit checklist subsections into a single flat checklist
- Remove redundant bold+numbered headers, emoji decorations, and filler closing sentence
- All URLs, code blocks, script references, and operational knowledge preserved

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only, no code changes)
- **Verification**: `self-assessed` — markdownlint clean (0 errors), all URLs and references verified present before and after

Closes #13176

---
[aidevops.sh](https://aidevops.sh) v3.5.311 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 1m and 4,880 tokens on this as a headless worker.