### PR TITLE
GH#13184: tighten crawl4ai-integration.md prose

### DIFF
--- a/.agents/tools/browser/crawl4ai-integration.md
+++ b/.agents/tools/browser/crawl4ai-integration.md
@@ -31,16 +31,7 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Setup
-
-```bash
-./.agents/scripts/crawl4ai-helper.sh install       # Python package
-./.agents/scripts/crawl4ai-helper.sh docker-setup  # Docker deployment
-./.agents/scripts/crawl4ai-helper.sh docker-start  # Start with dashboard
-./.agents/scripts/crawl4ai-helper.sh mcp-setup     # MCP integration
-```
-
-### MCP Config (Claude Desktop)
+## MCP Config (Claude Desktop)
 
 ```json
 {
@@ -54,7 +45,7 @@ tools:
 }
 ```
 
-## Core Usage
+## Usage
 
 ```bash
 # Crawl to markdown
@@ -64,7 +55,7 @@ tools:
 ./.agents/scripts/crawl4ai-helper.sh extract https://example.com '{"title":"h1","price":".price"}' data.json
 ```
 
-### LLM Extraction (Python)
+### LLM Extraction
 
 ```python
 from crawl4ai import AsyncWebCrawler, LLMExtractionStrategy, LLMConfig
@@ -91,18 +82,16 @@ state = await adaptive_crawler.digest(start_url="https://news.example.com", quer
 
 ## Configuration
 
-### Environment Variables
+Environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY` from secure storage):
 
 ```bash
-OPENAI_API_KEY=sk-your-key
-ANTHROPIC_API_KEY=your-key
 LLM_PROVIDER=openai/gpt-4o-mini
 CRAWL4AI_MAX_PAGES=50
 CRAWL4AI_TIMEOUT=60
 CRAWL4AI_DEFAULT_FORMAT=markdown
 ```
 
-### Browser / Crawler Config (Python)
+### Browser / Crawler Config
 
 ```python
 from crawl4ai import BrowserConfig, CrawlerRunConfig, CacheMode


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/browser/crawl4ai-integration.md` prose (153 -> 142 lines, ~7% reduction) without losing meaning.

Closes #13184

## Changes

- **Remove duplicate Setup code block** (-8 lines) — Quick Reference already lists all 4 helper commands with inline comments
- **Remove placeholder API key values** (-2 lines) — `sk-your-key` / `your-key` patterns replaced with "from secure storage" note (security improvement)
- **Tighten section headers** — removed redundant "(Python)" suffixes, promoted "MCP Config" to H2, renamed "Core Usage" to "Usage"
- **Fold "Environment Variables" sub-heading** into Configuration intro line

## Content Preservation

All code blocks (6), URLs (11 references), MCP tool names (6), tables (Advanced Features, Troubleshooting), config paths, and doc links verified present after edit.

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** `self-assessed` — markdownlint-cli2 passes with 0 errors, diff reviewed for content preservation

## Files Changed

- `.agents/tools/browser/crawl4ai-integration.md` (5 insertions, 16 deletions)

---
[aidevops.sh](https://aidevops.sh) v3.5.311 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 2m and 5,817 tokens on this as a headless worker.