### PR TITLE
GH#13215: tighten content/optimization.md prose

### DIFF
--- a/.agents/content/optimization.md
+++ b/.agents/content/optimization.md
@@ -55,7 +55,7 @@ Data-driven content improvement through systematic testing, variant generation, 
 6. **Length** (word count, duration, scene count)
 7. **Publishing time** (day, time)
 
-**Hook types** (generate 5-10 per topic): Bold Claim, Question, Story, Contrarian, Result, Problem-Agitate, Curiosity Gap. Example: "95% of AI influencers fail — here's why" | "I spent $10K on AI video tools — here's what worked" | "Stop using Sora for UGC content"
+**Hook types** (generate 5-10 per topic): Bold Claim, Question, Story, Contrarian, Result, Problem-Agitate, Curiosity Gap. Examples: "95% of AI influencers fail — here's why" | "I spent $10K on AI video tools — here's what worked" | "Stop using Sora for UGC content"
 
 **Thumbnail pipeline** (`thumbnail-helper.sh`):
 
@@ -66,22 +66,22 @@ thumbnail-helper.sh ab-test VIDEO_ID ~/.cache/aidevops/thumbnails/[output_dir]/
 thumbnail-helper.sh analyze VIDEO_ID
 ```
 
-### Test Execution Workflow
+### Test Execution
 
 1. **Generate**: 10+ variants via `content/production-*.md` agents
-2. **Deploy**: Platform-specific (YouTube A/B, TikTok separate videos, Google Optimize for blog, email list split)
+2. **Deploy**: YouTube A/B, TikTok separate videos, Google Optimize for blog, email list split
 3. **Collect**: 250+ samples per variant (CTR, retention, completion, time on page)
-4. **Analyze**: Lift = `(variant - baseline) / baseline * 100`; check 95% significance
+4. **Analyze**: Lift = `(variant - baseline) / baseline * 100`; require 95% significance
 5. **Scale winners**: Extract pattern, store (`/remember "Hook pattern: ..."`), apply to next 10 pieces
 6. **Batch cycle**: Week 1 produce → Week 2 collect → Week 3 analyze + kill bottom 7 → Week 4 produce from top 3
 
 ## Variant Generation
 
-**Hook variants**: Generate 10 per topic using all 7 types, 6-12 words each. Prompt: `Generate 10 hook variants for topic: [topic]. Use all 7 hook types, 6-12 words each. Output as table: Type | Hook | Word Count`
+**Hook variants**: 10 per topic, all 7 types, 6-12 words each. Prompt: `Generate 10 hook variants for topic: [topic]. Use all 7 hook types, 6-12 words each. Output as table: Type | Hook | Word Count`
 
 **Seed bracketing** (see `content/production-video.md`): Ranges — People 1000-1999, Action 2000-2999, Landscape 3000-3999, Product 4000-4999. Test 10 outputs; score: Composition 30%, Quality 30%, Style 20%, Accuracy 20%. Threshold: 4.0+ winner, 3.0-3.9 maybe, <3.0 reject. Cuts AI video costs ~60% (15% → 70%+ success).
 
-**Scene-level testing**: Publish → analyze YouTube Studio retention curve → identify >10% drops in <5s → generate 3-5 scene variants (B-roll, pacing, music, angle) → re-upload → compare → scale winner.
+**Scene-level testing**: Publish → analyze retention curve → identify >10% drops in <5s → generate 3-5 scene variants (B-roll, pacing, music, angle) → re-upload → compare → scale winner.
 
 **Thumbnail scoring**: CTR 50%, Text readability 20%, Face prominence 15%, Contrast 10%, Emotion 5%. Style template (Nanobanana Pro JSON): define palette/font/composition/lighting, swap subject, keep style constant. Test 10 thumbnails across 10 videos at 1000+ impressions.
 
@@ -116,7 +116,7 @@ content-calendar-helper.sh due --days 7         # upcoming
 content-calendar-helper.sh stats                # overall health
 ```
 
-**Cadence**: YouTube 2-3/week (algorithm favors consistency) | Shorts/TikTok/Reels daily (volume finds viral) | Blog 1-2/week (SEO favors depth) | Email 1/week (avoid fatigue) | Social daily (engagement requires presence)
+**Cadence**: YouTube 2-3/week | Shorts/TikTok/Reels daily | Blog 1-2/week | Email 1/week | Social daily
 
 **Seasonality**: Q4 (Oct-Dec) highest buying intent → reviews, comparisons, affiliate. Q1 educational/how-to. Q2-Q3 experiment + build backlog.
 
@@ -141,7 +141,7 @@ Example: "I spent $10K testing every AI video tool" (1M views) → twist: "free 
 
 **Scripts**: `content-calendar-helper.sh` (calendar/cadence/gaps, t208) | `analytics-helper.sh` (cross-platform reports) | `variant-generator-helper.sh` (10 variants) | `seed-bracket-helper.sh` (AI video seed testing) | `thumbnail-factory-helper.sh` (thumbnail variants, t207)
 
-## Integration & Next Steps
+## Integration
 
 **Feeds into**: `content/research.md` (next research), `content/production-*.md` (next batch). **Uses from**: `content/distribution-*.md` (analytics), `content/production-*.md` (variants). **Related**: `tools/task-management/beads.md`, `reference/memory.md`.
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/content/optimization.md` prose — remove noise words and redundant parenthetical rationales while preserving all institutional knowledge
- File classified as **instruction doc** (A/B testing discipline, variant generation workflows, analytics thresholds) — prose tightening applied per `build-agent.md` guidance
- 2.3% byte reduction (8118 → 7932 bytes, 186 bytes saved). Modest but honest — the file was already well-optimized

## Changes

- Remove wrapper phrases (`Platform-specific (...)` → direct list)
- Drop explanatory parentheticals from cadence line (rationales are not actionable rules)
- Simplify section headings (`Test Execution Workflow` → `Test Execution`, `Integration & Next Steps` → `Integration`)
- Compress verbose phrasing (`Generate 10 per topic using all 7 types` → `10 per topic, all 7 types`)
- Fix grammar (`Example` → `Examples` for 3-item list)
- Tighten verb choices (`check 95% significance` → `require 95% significance`)

## Content Preservation Verification

- **Task IDs**: t207, t208 — preserved
- **Code blocks**: 4 (2 bash blocks) — preserved
- **Inline code references**: 24 paths/commands — preserved
- **All section headings**: 13 sections — preserved
- **Markdownlint**: 0 errors

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — no runtime behavior change, prose-only edits

Closes #13215

---
[aidevops.sh](https://aidevops.sh) v3.5.311 plugin for [OpenCode](https://opencode.ai) v1.3.5 with claude-opus-4-6 spent 2m and 7,091 tokens on this as a headless worker.