### PR TITLE
GH#13270: add stateful idempotency guard to framework-agnostic SQL runner

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2390,6 +2390,11 @@
       "hash": "5e96cd787b4b8b6ae97d6f3113978c0b334e5484",
       "at": "2026-03-29T19:05:52Z",
       "pr": 13190
+    },
+    ".agents/marketing-sales/ad-creative-chapter-11.md": {
+      "hash": "d1ab934388110ed38c41c414ad164ff2b78414a3",
+      "at": "2026-03-29T19:49:56Z",
+      "pr": 13222
     }
   }
 }

--- a/.agents/workflows/sql-migrations.md
+++ b/.agents/workflows/sql-migrations.md
@@ -194,24 +194,35 @@ psql "$DB_URL" -c "
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );"
 
+# Guard: exit cleanly when no migration files exist
+compgen -G "migrations/*.sql" > /dev/null || { echo "No migration files found."; exit 0; }
+
 for f in migrations/*.sql; do
   name="$(basename "$f")"
-  applied=$(psql "$DB_URL" -tAc \
-    "SELECT COUNT(*) FROM schema_migrations WHERE filename = '$name'")
-  if [ "$applied" -eq 0 ]; then
-    echo "Applying $name..."
-    psql "$DB_URL" -f "$f"
-    psql "$DB_URL" -c \
-      "INSERT INTO schema_migrations (filename) VALUES ('$name');"
-    echo "  Done."
-  else
-    echo "Skipping $name (already applied)."
-  fi
+  # psql -v binds the filename as a safe literal (:'name') — no shell interpolation into SQL.
+  # \i runs the migration file; the INSERT records it — both inside one transaction.
+  # pg_advisory_xact_lock serialises concurrent runners on the same DB.
+  psql "$DB_URL" -v "name=$name" <<SQL
+SELECT pg_advisory_xact_lock(hashtext('schema_migrations'));
+BEGIN;
+\i $f
+INSERT INTO schema_migrations (filename)
+  SELECT :'name'
+  WHERE NOT EXISTS (
+    SELECT 1 FROM schema_migrations WHERE filename = :'name'
+  );
+COMMIT;
+SQL
+  echo "Applied (or skipped): $name"
 done
 ```
 
+> **Note:** `\i` inside a transaction applies the migration file and the `INSERT` records it atomically in one psql session. For production use, prefer a dedicated migration tool (Flyway, Atlas, Prisma Migrate) which handles locking, ordering, and checksums natively.
+
 Key properties of this pattern:
-- **Idempotent**: re-running the script skips already-applied files.
+- **Idempotent**: the `WHERE NOT EXISTS` guard prevents double-application.
 - **Ordered**: glob expansion is lexicographic — use timestamp-prefixed filenames (`YYYYMMDDHHMMSS_name.sql`) to guarantee order.
 - **Auditable**: `schema_migrations` records what ran and when.
-- **Atomic per file**: each migration is applied then recorded; a failure leaves the tracking table consistent with what actually ran.
+- **Safe filenames**: `psql -v "name=$name"` with `:'name'` avoids SQL injection from filenames containing quotes.
+- **Concurrent-safe**: `pg_advisory_xact_lock` serialises concurrent runner instances.
+- **Empty-directory safe**: `compgen -G` guard exits cleanly when no `.sql` files exist.

--- a/.agents/workflows/sql-migrations.md
+++ b/.agents/workflows/sql-migrations.md
@@ -168,4 +168,50 @@ jobs:
       - run: psql $DATABASE_URL -c "SELECT 1"
 ```
 
-Most tools auto-create a tracking table (e.g., `flyway_schema_history`). If you must run SQL directly, execute only unapplied files tracked in a migrations table (do not replay all files each run).
+Most tools auto-create a tracking table (e.g., `flyway_schema_history`). **Prefer a managed tool** — it handles ordering, locking, and state tracking automatically.
+
+**Framework-agnostic runner (stateful):** If you must run SQL directly without a migration tool, gate execution on a tracking table — never replay all files on every invocation.
+
+```sql
+-- Bootstrap: create the tracking table once
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename   TEXT PRIMARY KEY,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+```bash
+#!/usr/bin/env bash
+# scripts/migrate.sh — apply only unapplied migrations in order
+set -euo pipefail
+
+DB_URL="${DATABASE_URL:?DATABASE_URL is required}"
+
+# Bootstrap tracking table
+psql "$DB_URL" -c "
+  CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename   TEXT PRIMARY KEY,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );"
+
+for f in migrations/*.sql; do
+  name="$(basename "$f")"
+  applied=$(psql "$DB_URL" -tAc \
+    "SELECT COUNT(*) FROM schema_migrations WHERE filename = '$name'")
+  if [ "$applied" -eq 0 ]; then
+    echo "Applying $name..."
+    psql "$DB_URL" -f "$f"
+    psql "$DB_URL" -c \
+      "INSERT INTO schema_migrations (filename) VALUES ('$name');"
+    echo "  Done."
+  else
+    echo "Skipping $name (already applied)."
+  fi
+done
+```
+
+Key properties of this pattern:
+- **Idempotent**: re-running the script skips already-applied files.
+- **Ordered**: glob expansion is lexicographic — use timestamp-prefixed filenames (`YYYYMMDDHHMMSS_name.sql`) to guarantee order.
+- **Auditable**: `schema_migrations` records what ran and when.
+- **Atomic per file**: each migration is applied then recorded; a failure leaves the tracking table consistent with what actually ran.


### PR DESCRIPTION
## Summary

- Replaces the bare advisory sentence at `sql-migrations.md:171` with a full stateful runner pattern
- Adds a `schema_migrations` tracking table (SQL bootstrap) and a `migrate.sh` shell script that gates each file on a `SELECT COUNT(*)` check before applying
- Documents the four key properties: idempotent, ordered, auditable, atomic-per-file

## Problem

The previous text said "execute only unapplied files" but gave no example of how to do that. A reader following the old pattern (`for f in migrations/*.sql; do psql $DATABASE_URL -f "$f"; done`) would re-run every migration on every invocation — a HIGH severity finding from CodeRabbit on PR #13167.

## Solution

The new section shows:
1. A `CREATE TABLE IF NOT EXISTS schema_migrations` bootstrap (SQL)
2. A `migrate.sh` that queries the tracking table before each file and inserts a record after success
3. Explicit guidance on why timestamp-prefixed filenames are required for correct ordering

## Runtime Testing

Risk level: **Low** — documentation-only change, no executable code in the repo. Self-assessed.

## Files Changed

- `.agents/workflows/sql-migrations.md` — 1 file, +47/-1 lines

Closes #13270

---
[aidevops.sh](https://aidevops.sh) v3.5.312 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 1m and 2,691 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SQL migration best practices and added guidance for stateful database schema management.

* **Chores**
  * Updated internal configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->