### PR TITLE
GH#13259: tighten show-plan.md prose (143→71 lines)

### DIFF
--- a/.agents/scripts/commands/show-plan.md
+++ b/.agents/scripts/commands/show-plan.md
@@ -10,8 +10,6 @@ Arguments: $ARGUMENTS
 
 ## Quick Output (Default)
 
-Run the helper script for instant output:
-
 ```bash
 ~/.aidevops/agents/scripts/show-plan-helper.sh $ARGUMENTS
 ```
@@ -19,8 +17,6 @@ Run the helper script for instant output:
 Display the output directly to the user. The script handles all formatting.
 
 ## Fallback (Script Unavailable)
-
-If the script fails or is unavailable:
 
 1. Read `todo/PLANS.md`
 2. Find the matching plan section by fuzzy title match or plan ID
@@ -51,90 +47,22 @@ If the script fails or is unavailable:
 
 ## Output Format
 
-The script outputs formatted Markdown:
-
-```markdown
-# Plan Title
-
-**Status:** Planning (Phase 0/4)
-**Estimate:** ~2d (ai:1d test:0.5d read:0.5d)
-**Progress:** Phase 0 of 4
-
-## Purpose
-
-Brief description of why this work matters and what problem it solves.
-
-## Progress
-
-- [ ] Phase 1: Description ~Xh
-- [ ] Phase 2: Description ~Xh
-- [x] Phase 3: Description ~Xh (completed)
-
-## Context
-
-Key decisions, research findings, constraints from conversation.
-
-## Decisions
-
-- **Decision:** What was decided
-  **Rationale:** Why this choice was made
-  **Date:** YYYY-MM-DD
-
-## Discoveries
-
-- **Observation:** What was unexpected
-  **Evidence:** How we know this
-  **Impact:** How it affects the plan
-
-## Related Tasks
-
-- t008: aidevops-opencode Plugin
-- t009: Claude Code Destructive Command Hooks
-
----
-
-**Options:**
-1. Start working on this plan
-2. View another plan
-3. Back to task list (`/list-todo`)
-```
+Script outputs formatted Markdown with: Status, Estimate, Progress phases (checkboxes), Purpose, Context, Decisions (with Rationale + Date), Discoveries (with Evidence + Impact), Related Tasks, and numbered options (1=start, 2=view another, 3=back to `/list-todo`).
 
 ## After Display
 
 Wait for user input:
 
-1. **"1"** - Begin working on the plan
-   - Run pre-edit check
-   - Create/switch to appropriate branch
-   - Mark first pending phase as in-progress
-
-2. **"2"** - View another plan
-   - Prompt for plan name, then run `/show-plan <name>`
-
-3. **"3"** - Return to task list
-   - Run `/list-todo`
+1. **"1"** - Begin working on the plan → run pre-edit check, create/switch branch, mark first phase in-progress
+2. **"2"** - View another plan → prompt for name, run `/show-plan <name>`
+3. **"3"** - Return to task list → run `/list-todo`
 
 ## Starting Work on a Plan
 
-When user chooses to start:
-
-1. **Check branch status:**
-
-   ```bash
-   ~/.aidevops/agents/scripts/pre-edit-check.sh
-   ```
-
-2. **Create branch if needed:**
-   - Derive branch name from plan title
-   - Use worktree: `wt switch -c feature/<plan-slug>`
-
-3. **Update plan status:**
-   - Change `**Status:** Planning` to `**Status:** In Progress (Phase 1/N)`
-   - Add `started:` timestamp to first phase
-
-4. **Show next steps:**
-   - Display first phase description
-   - List any blockers or dependencies
+1. Run `~/.aidevops/agents/scripts/pre-edit-check.sh`
+2. Create branch if needed: `wt switch -c feature/<plan-slug>`
+3. Update plan status: `**Status:** Planning` → `**Status:** In Progress (Phase 1/N)`, add `started:` timestamp
+4. Display first phase description and any blockers
 
 ## Related Commands
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/scripts/commands/show-plan.md` from 143 to 71 lines (50% reduction)
- Replaced verbose 48-line output format example block with a single-line schema summary — all section names, field types, and option labels preserved
- Collapsed multi-bullet after-display and starting-work steps into compact inline format
- Removed redundant prose preambles ("If the script fails or is unavailable:", "Run the helper script for instant output:", "When user chooses to start:") — section headings already convey this

## Knowledge Preservation

All institutional knowledge retained:
- Helper script path and fallback procedure (read PLANS.md → fuzzy match → extract sections → find tasks)
- All arguments: plan name fuzzy match, plan ID, `--current`, `--list`, `--json`
- All examples (6 usage patterns)
- Output format schema: Status, Estimate, Progress phases, Purpose, Context, Decisions (Rationale+Date), Discoveries (Evidence+Impact), Related Tasks, numbered options
- After-display actions: 1=start, 2=view another, 3=list-todo
- Starting-work steps: pre-edit check, branch creation, status update, next steps display
- Related commands: `/list-todo`, `/save-todo`, `/ready`

## Runtime Testing

**Risk level:** Low (docs/agent prompt only — no code, no scripts changed)
**Verification:** `self-assessed` — agent behaviour unchanged; all commands, paths, and decision logic present before and after

Closes #13259

---
[aidevops.sh](https://aidevops.sh) v3.5.313 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 4m and 3,288 tokens on this as a headless worker.