### PR TITLE
GH#13273: tighten ios-shortcut.md prose (140→133 lines)

### DIFF
--- a/.agents/tools/voice/ios-shortcut.md
+++ b/.agents/tools/voice/ios-shortcut.md
@@ -19,7 +19,7 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Dictate voice commands on iPhone, dispatch to OpenCode server, hear response
-- **Flow**: Dictate (iOS STT) -> HTTP POST to OpenCode -> Wait -> Speak (iOS TTS)
+- **Flow**: Dictate (iOS STT) → HTTP POST to OpenCode → Wait → Speak (iOS TTS)
 - **Network**: Requires OpenCode server reachable from iPhone (Tailscale, local Wi-Fi, or port forward)
 - **Related**: `tools/voice/speech-to-speech.md`, `tools/ai-assistants/opencode-server.md`
 
@@ -81,25 +81,18 @@ Create a new Shortcut in iOS Shortcuts app with these actions in order:
 
 - URL: `ServerURL/session/SessionID/message`
 - Method: `POST`
-- Headers: `Content-Type: application/json`, `Authorization: Basic base64(user:password)` (if auth enabled)
+- Headers: `Content-Type: application/json`; if auth enabled: `Authorization: Basic <base64(user:password)>` — default username `user` (override with `OPENCODE_SERVER_USERNAME`). Encode: `echo -n "user:password" | base64`.
 - Request Body (JSON):
 
   ```json
   {
-    "parts": [
-      {
-        "type": "text",
-        "text": "Dictated Text"
-      }
-    ]
+    "parts": [{ "type": "text", "text": "Dictated Text" }]
   }
   ```
 
   Use the `Dictated Text` variable from step 1 as the `text` value.
 
 ### Optional Enhancements
-
-**Authentication** (if `OPENCODE_SERVER_PASSWORD` is set): Add header `Authorization: Basic <base64(user:password)>` in step 4. Default username is `user` unless `OPENCODE_SERVER_USERNAME` is set. Encode: `echo -n "user:password" | base64`.
 
 **Error handling**: After step 4, add `If` action checking `Contents of URL` is not empty. Failure branch: `Show Alert` with "Could not reach OpenCode server".
 


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/tools/voice/ios-shortcut.md` (140 → 133 lines)
- Consolidate duplicated auth header info into Step 4 Request Config (was repeated in both the header row and Optional Enhancements)
- Compact JSON request body example to single-line object (valid JSON, saves 4 lines)
- Fix `->` → `→` arrow in Quick Reference for consistency with rest of doc

## Knowledge Preservation

All institutional knowledge preserved:
- Architecture diagram, prerequisites, shortcut action table
- Full auth details (username env var, base64 encoding command)
- Error handling and auto session creation enhancements
- Async variant, Siri integration, security rules, troubleshooting table, see-also links

## Runtime Testing

Risk: **Low** (docs-only change, no code). Self-assessed.

## Files Changed

- `.agents/tools/voice/ios-shortcut.md` — 7 lines removed, 3 lines added (net -7)

Closes #13273

---
[aidevops.sh](https://aidevops.sh) v3.5.313 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 5m and 3,330 tokens on this as a headless worker.