### PR TITLE
GH#13272: tighten email-design-test.md prose

### DIFF
--- a/.agents/services/email/email-design-test.md
+++ b/.agents/services/email/email-design-test.md
@@ -35,7 +35,7 @@ email-design-test-helper.sh eoa-results <test_id>
 email-design-test-helper.sh eoa-clients
 ```
 
-**Workflow:** Iterate locally with Playwright -> run `email-testing.md` validation -> submit to Email on Acid for final real-client verification.
+**Workflow:** Playwright locally → `email-testing.md` validation → Email on Acid for real-client verification.
 
 <!-- AI-CONTEXT-END -->
 
@@ -60,7 +60,7 @@ Full test suite (all viewports + dark mode + image blocking): `email-design-test
 
 ## Email on Acid API Integration
 
-Base URL: `https://api.emailonacid.com/v5` -- HTTP Basic Auth (`EOA_API_KEY:EOA_API_PASSWORD`). Sandbox (free, no credits): credentials `sandbox:sandbox`.
+Base URL: `https://api.emailonacid.com/v5` — HTTP Basic Auth (`EOA_API_KEY:EOA_API_PASSWORD`). Sandbox (free, no credits): `sandbox:sandbox`.
 
 ### Key Endpoints
 
@@ -78,12 +78,13 @@ Base URL: `https://api.emailonacid.com/v5` -- HTTP Basic Auth (`EOA_API_KEY:EOA_
 
 ```bash
 AUTH="$EOA_API_KEY:$EOA_API_PASSWORD"
+# Create test
 curl -s -u "$AUTH" -H "Content-Type: application/json" \
   -X POST https://api.emailonacid.com/v5/email/tests \
   -d '{"subject":"Newsletter","html":"'"$(cat newsletter.html | jq -Rs .)"'","clients":["outlook16","gmail_chr26_win","iphone6p_9","appmail14"],"image_blocking":true}'
-# Poll status (~30-120s, every 5s until processing array empty)
+# Poll (~30-120s, every 5s until processing array empty)
 curl -s -u "$AUTH" https://api.emailonacid.com/v5/email/tests/<test_id>
-# Get screenshots (valid 90 days Basic Auth, 24h presigned)
+# Get screenshots (Basic Auth: 90d; presigned: 24h)
 curl -s -u "$AUTH" https://api.emailonacid.com/v5/email/tests/<test_id>/results
 ```
 
@@ -101,7 +102,7 @@ curl -s -u "$AUTH" https://api.emailonacid.com/v5/email/tests/<test_id>/results
 
 ## CI/CD Integration
 
-Playwright rendering gate for PRs touching email templates (`emails/**`, `templates/**`):
+Playwright rendering gate — triggers on `emails/**`, `templates/**`:
 
 ```yaml
 # .github/workflows/email-test.yml


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/services/email/email-design-test.md` per GH#13272 simplification-debt scan
- All knowledge preserved: viewport table, API endpoints, client IDs, CI/CD YAML, troubleshooting table, related links
- No content removed — compressed verbose sentences and inline comments only

## Changes

- Workflow line: verbose arrow chain → compact `→` notation
- EoA base URL: `credentials \`sandbox:sandbox\`` → inline code only; `--` → `—`
- Create/poll bash block: added `# Create test` label; tightened poll/screenshot comments
- CI/CD intro: "Playwright rendering gate for PRs touching email templates (`emails/**`, `templates/**`)" → "Playwright rendering gate — triggers on `emails/**`, `templates/**`"

## Runtime Testing

Risk: **Low** (docs-only change, no code paths affected) — `self-assessed`.

## Verification

- All code blocks, URLs, client IDs, and command examples present before and after (verified via `git diff`)
- No broken internal links
- Agent behaviour unchanged

Closes #13272

---
[aidevops.sh](https://aidevops.sh) v3.5.313 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 6m and 4,436 tokens on this as a headless worker.