### PR TITLE
fix: preserve aidevops plugin registration in opencode.json

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -410,6 +410,26 @@ if output_format == "opencode-json":
             existing.append(instructions_path)
         config['instructions'] = existing
 
+    # Plugin registration — ensure the aidevops plugin is registered.
+    # The plugin provides OAuth Bearer auth, quality hooks, agent loading,
+    # and MCP tool management. Without it, OpenCode falls back to x-api-key
+    # mode which breaks OAuth authentication entirely.
+    # setup.sh (setup-modules/mcp-setup.sh) is the primary registrar, but
+    # if the config was rebuilt (e.g. after truncation recovery), the plugin
+    # key may be lost. This guard re-registers it.
+    aidevops_plugin_url = "file://" + os.path.expanduser(
+        "~/.aidevops/agents/plugins/opencode-aidevops/index.mjs"
+    )
+    plugin_list = config.get('plugin', [])
+    if not isinstance(plugin_list, list):
+        plugin_list = [plugin_list] if plugin_list else []
+    if aidevops_plugin_url not in plugin_list:
+        plugin_list.append(aidevops_plugin_url)
+        config['plugin'] = plugin_list
+        print(f"  Re-registered aidevops plugin (was missing from config)", file=sys.stderr)
+    else:
+        config['plugin'] = plugin_list
+
     # Provider options — prompt caching
     if 'provider' not in config:
         config['provider'] = {}


### PR DESCRIPTION
## Summary

- Add plugin registration guard to `generate-runtime-config.sh` that ensures the aidevops plugin URL is always present in `opencode.json`
- Prevents OAuth auth failure when config is rebuilt after truncation, manual edit, or any other config loss scenario

## Root cause

Config truncation (fixed in v3.5.311 with atomic writes) → manual rebuild stripped the `plugin` key → aidevops plugin didn't load → OpenCode fell back to `x-api-key` mode → OAuth tokens rejected by Anthropic API → "API key is missing" error on all new sessions.

The plugin's `auth` hook (`provider-auth.mjs`) is what converts OAuth tokens to `Authorization: Bearer` headers. Without it, the AI SDK's `createAnthropic()` uses `x-api-key` which doesn't work with OAuth tokens.

## Diagnostic signal

Missing red console text on OpenCode startup = plugin not loading = auth will fail.

## Runtime Testing

- Simulated plugin key loss, ran generator, verified re-registration with log message
- Verified OpenCode starts and authenticates after fix
- Risk: **Low** (additive guard, no existing behaviour changed)