### PR TITLE
GH#13264: tighten ios-simulator-mcp.md prose (142→121 lines)

### DIFF
--- a/.agents/tools/mobile/ios-simulator-mcp.md
+++ b/.agents/tools/mobile/ios-simulator-mcp.md
@@ -52,37 +52,18 @@ tools:
 
 ## Configuration
 
-### Claude Code
+**Claude Code**: `claude mcp add ios-simulator npx ios-simulator-mcp`
 
-```bash
-claude mcp add ios-simulator npx ios-simulator-mcp
-```
-
-### OpenCode
-
-Managed by `generate-opencode-agents.sh` (macOS only, lazy-loaded):
+**OpenCode** (managed by `generate-opencode-agents.sh`, macOS only, lazy-loaded):
 
 ```json
-{
-  "ios-simulator": {
-    "type": "local",
-    "command": ["npx", "-y", "ios-simulator-mcp"],
-    "enabled": false
-  }
-}
+{ "ios-simulator": { "type": "local", "command": ["npx", "-y", "ios-simulator-mcp"], "enabled": false } }
 ```
 
-### Cursor / Windsurf / Claude Desktop
+**Cursor / Windsurf / Claude Desktop**:
 
 ```json
-{
-  "mcpServers": {
-    "ios-simulator": {
-      "command": "npx",
-      "args": ["-y", "ios-simulator-mcp"]
-    }
-  }
-}
+{ "mcpServers": { "ios-simulator": { "command": "npx", "args": ["-y", "ios-simulator-mcp"] } } }
 ```
 
 ### Environment Variables
@@ -95,7 +76,7 @@ Managed by `generate-opencode-agents.sh` (macOS only, lazy-loaded):
 
 ## AI-Assisted QA Patterns
 
-Use these prompts after implementing a feature to validate behaviour:
+Post-implementation validation prompts:
 
 - **Verify UI elements**: "Describe all accessibility elements on the current screen"
 - **Confirm text input**: "Enter 'Hello World' into the text field and confirm the input"
@@ -113,8 +94,6 @@ Use these prompts after implementing a feature to validate behaviour:
 | **MiniSim** | Simulator launcher | MiniSim manages simulator lifecycle; this MCP interacts with running sims |
 
 ## Comparison: ios-simulator-mcp vs AXe CLI
-
-Both enable simulator interaction but take different approaches:
 
 | Aspect | ios-simulator-mcp | AXe CLI |
 |--------|-------------------|---------|


### PR DESCRIPTION
## Summary

- Collapsed verbose Configuration subsections (4 headers + multi-line JSON blocks) into inline bold labels with single-line JSON — all config values preserved
- Replaced "Use these prompts after implementing a feature to validate behaviour:" with "Post-implementation validation prompts:" (same meaning, fewer words)
- Removed redundant "Both enable simulator interaction but take different approaches:" intro before the comparison table (table heading is self-explanatory)
- All knowledge preserved: tool list, env vars, QA prompts, integration table, comparison table, troubleshooting, related tools

## Testing Evidence

- `self-assessed` (docs-only change, no runtime behaviour)
- Line count: 142 → 121 (15% reduction)
- Diff reviewed: no content removed, only prose/formatting tightened

## Files Changed

- `.agents/tools/mobile/ios-simulator-mcp.md`

Closes #13264

---
[aidevops.sh](https://aidevops.sh) v3.5.313 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 6m and 5,118 tokens on this as a headless worker.