### PR TITLE
GH#13239: tighten programmatic-seo.md prose

### DIFF
--- a/.agents/seo/programmatic-seo.md
+++ b/.agents/seo/programmatic-seo.md
@@ -41,7 +41,7 @@ tools:
 
 ### 1. Keyword Research and Clustering
 
-Run `/keyword-research-extended "seed keyword"`. Look for repeating modifiers (city names, "vs", "alternative to"). Cluster signals: same head term + varying modifier, consistent volume across variations, similar SERP intent, low keyword difficulty.
+Run `/keyword-research-extended "seed keyword"`. Cluster signals: same head term + varying modifier, consistent volume across variations, similar SERP intent, low keyword difficulty.
 
 ### 2. Template Design
 
@@ -96,12 +96,12 @@ For each {modifier} in data_source:
 
 ### 5. Internal Linking
 
-- **Hub and spoke**: Parent category page links to all variations
+- **Hub and spoke**: Parent category page links to all variations; hub links all children (paginated if >50)
 - **Cross-linking**: Related variations link to each other (same region, same category)
 - **Breadcrumbs**: Clear hierarchy (Home > Category > Variation)
 - **Footer/sidebar**: "Related {type}" blocks with 5–10 contextual links
 - **Sitemap**: Dedicated XML sitemap for the programmatic section
-- Each page: 3–10 internal links to cluster pages; hub links all children (paginated if >50); avoid all-to-all linking (dilutes link equity)
+- Each page: 3–10 internal links to cluster pages; avoid all-to-all linking (dilutes link equity)
 
 ### 6. Quality Assurance
 
@@ -142,4 +142,4 @@ For each {modifier} in data_source:
 
 **Don't use**: <20 variations (write individual pages), no unique data per variation (consolidate), variations have no search volume.
 
-**Post-launch monitoring**: Track indexation via GSC (`google-search-console.md`), monitor soft 404s and crawl errors, check ranking progress per cluster, watch for cannibalization (`ranking-opportunities.md`), review engagement metrics.
+**Post-launch monitoring**: Track indexation via GSC (`google-search-console.md`); monitor soft 404s and crawl errors; check ranking progress per cluster; watch for cannibalization (`ranking-opportunities.md`); review engagement metrics.


### PR DESCRIPTION
## Summary

Tightens prose in `.agents/seo/programmatic-seo.md` (145 lines) per issue #13239. All knowledge preserved.

**Classification**: Instruction doc (workflow + decision rules) — prose tightening, not chapter split.

**Changes**:
- Step 1: Remove redundant modifier examples `(city names, "vs", "alternative to")` — already covered by the page types table above
- Step 5: Consolidate "hub links all children (paginated if >50)" into the hub-and-spoke bullet, eliminating duplication with the standalone sentence
- Post-launch monitoring: Comma-separated run-on → semicolons for scan-readability

**Verification**:
- All code blocks, URLs, task ID references, and command examples present before and after
- No broken internal links or references
- Agent behaviour unchanged (doc-only change)
- Line count: 145 → 145 (same; file was already tight)

## Runtime Testing

Risk: **Low** (docs/agent prompt only — no code, no scripts, no config)
Level: `self-assessed`

Closes #13239

---
[aidevops.sh](https://aidevops.sh) v3.5.313 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 6m and 5,118 tokens on this as a headless worker.