### PR TITLE
GH#12805: add signature footer gate to plugin quality hooks

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -698,6 +698,22 @@ async function toolExecuteBefore(input, output) {
     }
   }
 
+  // Signature footer gate (GH#12805): warn when gh pr create / gh issue create
+  // / gh issue comment is called without the aidevops.sh signature footer.
+  // This is the systemic enforcement — prompt instructions alone are insufficient.
+  if (isBashTool(input.tool)) {
+    const cmd = output.args?.command || "";
+    if (/gh\s+(pr\s+create|issue\s+(create|comment))/.test(cmd)) {
+      if (!cmd.includes("aidevops.sh") && !cmd.includes("gh-signature-helper")) {
+        console.error(
+          "[aidevops] SIGNATURE GATE: gh pr/issue command missing aidevops.sh signature footer. " +
+          "Generate with: gh-signature-helper.sh footer --model <model-id>",
+        );
+        qualityLog("WARN", `Signature footer missing in: ${cmd.substring(0, 120)}`);
+      }
+    }
+  }
+
   if (!isWriteOrEditTool(input.tool)) return;
 
   const filePath = output.args?.filePath || output.args?.file_path || "";


### PR DESCRIPTION
## Summary

- Add systemic enforcement for the signature footer requirement (GH#12805)
- Plugin's `toolExecuteBefore` hook now warns when `gh pr create`, `gh issue create`, or `gh issue comment` is called without the `aidevops.sh` signature footer
- Warning appears in TUI console output, making the omission visible to the model

## Motivation

Prompt-only enforcement ("MUST include signature footer") was not being followed consistently in interactive sessions. The instruction exists in AGENTS.md but models skip it under cognitive load. A plugin-level gate makes the omission visible via `console.error`, which the model sees and can correct.

## How it works

The hook checks Bash tool calls matching `gh (pr create|issue create|issue comment)`. If the command string doesn't contain `aidevops.sh` or `gh-signature-helper`, it logs a warning. This is advisory (doesn't block), matching the pattern of other quality hooks.

## Runtime Testing

- Risk: **Low** (advisory warning only, no blocking behaviour)
- Self-assessed: regex pattern tested against common gh command formats


---
[aidevops.sh](https://aidevops.sh) v3.5.317 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 4h 31m and 76,282 tokens on this with the user in an interactive session.