### PR TITLE
GH#13311: tighten remotion-gifs.md animated images agent doc

### DIFF
--- a/.agents/tools/video/remotion-gifs.md
+++ b/.agents/tools/video/remotion-gifs.md
@@ -6,11 +6,11 @@ metadata:
   tags: gif, animation, images, animated, apng, avif, webp
 ---
 
-# Using Animated images in Remotion
+# Animated Images in Remotion
 
-## Basic usage
+## Basic Usage
 
-Use `<AnimatedImage>` to display a GIF, APNG, AVIF or WebP image synchronized with Remotion's timeline:
+`<AnimatedImage>` displays GIF, APNG, AVIF or WebP synchronized with Remotion's timeline:
 
 ```tsx
 import {AnimatedImage, staticFile} from 'remotion';
@@ -20,112 +20,79 @@ export const MyComposition = () => {
 };
 ```
 
-Remote URLs are also supported (must have CORS enabled):
+Remote URLs also work (must have CORS enabled):
 
 ```tsx
 <AnimatedImage src="https://example.com/animation.gif" width={500} height={500} />
 ```
 
-## Sizing and fit
+## Props
 
-Control how the image fills its container with the `fit` prop:
+### `fit` — sizing behavior
 
 ```tsx
-// Stretch to fill (default)
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="fill" />
-
-// Maintain aspect ratio, fit inside container
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="contain" />
-
-// Fill container, crop if needed
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="cover" />
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="fill" />    {/* Stretch (default) */}
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="contain" />  {/* Fit inside, keep ratio */}
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="cover" />    {/* Fill, crop if needed */}
 ```
 
-## Playback speed
-
-Use `playbackRate` to control the animation speed:
+### `playbackRate` — animation speed
 
 ```tsx
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={2} /> {/* 2x speed */}
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={2} />   {/* 2x speed */}
 <AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={0.5} /> {/* Half speed */}
 ```
 
-## Looping behavior
-
-Control what happens when the animation finishes:
+### `loopBehavior` — end-of-animation behavior
 
 ```tsx
-// Loop indefinitely (default)
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="loop" />
-
-// Play once, show final frame
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="pause-after-finish" />
-
-// Play once, then clear canvas
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="clear-after-finish" />
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="loop" />                {/* Loop indefinitely (default) */}
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="pause-after-finish" />  {/* Play once, show final frame */}
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="clear-after-finish" />  {/* Play once, clear canvas */}
 ```
 
-## Styling
+### `style` — additional CSS
 
-Use the `style` prop for additional CSS (use `width` and `height` props for sizing):
+Use `width`/`height` props for sizing; `style` for positioning and decoration:
 
 ```tsx
 <AnimatedImage
   src={staticFile('animation.gif')}
   width={500}
   height={500}
-  style={{
-    borderRadius: 20,
-    position: 'absolute',
-    top: 100,
-    left: 50,
-  }}
+  style={{borderRadius: 20, position: 'absolute', top: 100, left: 50}}
 />
 ```
 
-## Getting GIF duration
+## Getting GIF Duration
 
-Use `getGifDurationInSeconds()` from `@remotion/gif` to get the duration of a GIF.
+Requires `@remotion/gif`:
 
 ```bash
-npx remotion add @remotion/gif # If project uses npm
-bunx remotion add @remotion/gif # If project uses bun
-yarn remotion add @remotion/gif # If project uses yarn
-pnpm exec remotion add @remotion/gif # If project uses pnpm
+npx remotion add @remotion/gif    # npm
+bunx remotion add @remotion/gif   # bun
+yarn remotion add @remotion/gif   # yarn
+pnpm exec remotion add @remotion/gif  # pnpm
 ```
-
-```tsx
-import {getGifDurationInSeconds} from '@remotion/gif';
-import {staticFile} from 'remotion';
-
-const duration = await getGifDurationInSeconds(staticFile('animation.gif'));
-console.log(duration); // e.g. 2.5
-```
-
-This is useful for setting the composition duration to match the GIF:
 
 ```tsx
 import {getGifDurationInSeconds} from '@remotion/gif';
 import {staticFile, CalculateMetadataFunction} from 'remotion';
 
+// Standalone usage
+const duration = await getGifDurationInSeconds(staticFile('animation.gif'));
+console.log(duration); // e.g. 2.5
+
+// Match composition duration to GIF length
 const calculateMetadata: CalculateMetadataFunction = async () => {
   const duration = await getGifDurationInSeconds(staticFile('animation.gif'));
-  return {
-    durationInFrames: Math.ceil(duration * 30),
-  };
+  return {durationInFrames: Math.ceil(duration * 30)};
 };
 ```
 
-## Alternative
+## Fallback: `<Gif>` Component
 
-If `<AnimatedImage>` does not work (only supported in Chrome and Firefox), you can use `<Gif>` from `@remotion/gif` instead.
-
-```bash
-npx remotion add @remotion/gif # If project uses npm
-bunx remotion add @remotion/gif # If project uses bun
-yarn remotion add @remotion/gif # If project uses yarn
-pnpm exec remotion add @remotion/gif # If project uses pnpm
-```
+If `<AnimatedImage>` doesn't work (requires Chrome or Firefox), use `<Gif>` from `@remotion/gif` (same install as above). Same props as `<AnimatedImage>` but only supports GIF files:
 
 ```tsx
 import {Gif} from '@remotion/gif';
@@ -135,5 +102,3 @@ export const MyComposition = () => {
   return <Gif src={staticFile('animation.gif')} width={500} height={500} />;
 };
 ```
-
-The `<Gif>` component has the same props as `<AnimatedImage>` but only supports GIF files.


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/video/remotion-gifs.md` from 139 to 104 lines (25% reduction)
- Deduplicated `@remotion/gif` install block (appeared twice, now once with cross-reference)
- Merged two separate `getGifDurationInSeconds` code blocks into a single example
- Consolidated per-prop H2 sections into a unified "Props" section with H3 subsections
- All technical knowledge preserved: every prop, code example, URL, import, and browser limitation

Closes #13311

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only, no code logic)
- **Verification**: `self-assessed` — content preservation verified via checklist (all props, code blocks, URLs, imports, browser notes present before and after)

---
[aidevops.sh](https://aidevops.sh) v3.5.320 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 2m and 6,219 tokens on this as a headless worker.