### PR TITLE
GH#13307: tighten email-design-test.md

### DIFF
--- a/.agents/services/email/email-design-test.md
+++ b/.agents/services/email/email-design-test.md
@@ -21,7 +21,7 @@ tools:
 - **Local tool**: Playwright (headless Chromium/WebKit) -- free, ~2s per viewport, approximation only
 - **Remote tool**: Email on Acid API v5 -- paid, 30-120s, 90+ real email clients
 - **Credentials**: `aidevops secret set EOA_API_KEY` + `aidevops secret set EOA_API_PASSWORD`
-- **Related**: `email-testing.md` (HTML/CSS validation), `email-health-check.md` (DNS auth)
+- **Related**: `email-testing.md` (HTML/CSS validation), `email-health-check.md` (DNS auth), `ses.md` (SES sending), `tools/browser/playwright.md`
 
 ```bash
 # Local Playwright rendering (free, instant)
@@ -35,7 +35,7 @@ email-design-test-helper.sh eoa-results <test_id>
 email-design-test-helper.sh eoa-clients
 ```
 
-**Workflow:** Playwright locally → `email-testing.md` validation → Email on Acid for real-client verification.
+**Workflow:** Playwright locally -> `email-testing.md` validation -> Email on Acid for real-client verification.
 
 <!-- AI-CONTEXT-END -->
 
@@ -54,55 +54,45 @@ email-design-test-helper.sh eoa-clients
 
 Full test suite (all viewports + dark mode + image blocking): `email-design-test-helper.sh render --all`.
 
-- **Dark mode**: `colorScheme: 'dark'` -- catches missing `prefers-color-scheme`, hardcoded white backgrounds, invisible text
-- **Image blocking**: route images to `abort()` + `img { visibility: hidden !important; }` -- catches missing `alt` text, layout collapse
+### Rendering Modes
+
+- **Dark mode** (`colorScheme: 'dark'`): catches missing `prefers-color-scheme`, hardcoded white backgrounds, invisible text
+- **Image blocking** (route to `abort()` + `img { visibility: hidden !important; }`): catches missing `alt` text, layout collapse
 - **Limitations**: does **not** replicate Outlook Word engine, Gmail `<style>` stripping, Yahoo/AOL quirks, or real mobile rendering -- use Email on Acid for these
 
-## Email on Acid API Integration
+## Email on Acid API
 
-Base URL: `https://api.emailonacid.com/v5` — HTTP Basic Auth (`EOA_API_KEY:EOA_API_PASSWORD`). Sandbox (free, no credits): `sandbox:sandbox`.
+Base URL: `https://api.emailonacid.com/v5` -- HTTP Basic Auth (`EOA_API_KEY:EOA_API_PASSWORD`). Sandbox (free, no credits): `sandbox:sandbox`.
 
-### Key Endpoints
+### Endpoints
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
 | `/auth` | GET | Test authentication |
 | `/email/clients` | GET | List available clients |
-| `/email/tests` | POST | Create a new test |
-| `/email/tests/<id>` | GET | Get test status |
-| `/email/tests/<id>/results` | GET | Get screenshot URLs |
+| `/email/tests` | POST | Create test (`subject`, `html`, `clients[]`, `image_blocking`) |
+| `/email/tests/<id>` | GET | Poll status (~30-120s, every 5s until `processing` empty) |
+| `/email/tests/<id>/results` | GET | Screenshot URLs (Basic Auth: 90d; presigned: 24h) |
 | `/email/tests/<id>/results/reprocess` | PUT | Retake failed screenshots |
-| `/email/tests/<id>/spam/results` | GET | Get spam test results |
-
-### Create and Poll a Test
-
-```bash
-AUTH="$EOA_API_KEY:$EOA_API_PASSWORD"
-# Create test
-curl -s -u "$AUTH" -H "Content-Type: application/json" \
-  -X POST https://api.emailonacid.com/v5/email/tests \
-  -d '{"subject":"Newsletter","html":"'"$(cat newsletter.html | jq -Rs .)"'","clients":["outlook16","gmail_chr26_win","iphone6p_9","appmail14"],"image_blocking":true}'
-# Poll (~30-120s, every 5s until processing array empty)
-curl -s -u "$AUTH" https://api.emailonacid.com/v5/email/tests/<test_id>
-# Get screenshots (Basic Auth: 90d; presigned: 24h)
-curl -s -u "$AUTH" https://api.emailonacid.com/v5/email/tests/<test_id>/results
-```
+| `/email/tests/<id>/spam/results` | GET | Spam test results |
 
 ### Common Client IDs
 
-| Client ID | Display Name | Category |
-|-----------|-------------|----------|
-| `outlook16` | Outlook 2016 | Application |
-| `ol365_win` | Outlook 365 (Windows) | Application |
-| `gmail_chr26_win` | Gmail (Chrome/Windows) | Web |
-| `gmail_and11` | Gmail (Android 11) | Mobile |
-| `iphone6p_9` | iPhone 6+ (iOS 9) | Mobile |
-| `appmail14` | Apple Mail (macOS 14) | Application |
-| `yahoo_chr26_win` | Yahoo (Chrome/Windows) | Web |
+| Client ID | Approximates |
+|-----------|-------------|
+| `outlook16` | Outlook 2016 |
+| `ol365_win` | Outlook 365 (Windows) |
+| `gmail_chr26_win` | Gmail (Chrome/Windows) |
+| `gmail_and11` | Gmail (Android 11) |
+| `iphone6p_9` | iPhone 6+ (iOS 9) |
+| `appmail14` | Apple Mail (macOS 14) |
+| `yahoo_chr26_win` | Yahoo (Chrome/Windows) |
+
+Live list: `email-design-test-helper.sh eoa-clients`.
 
 ## CI/CD Integration
 
-Playwright rendering gate — triggers on `emails/**`, `templates/**`:
+Playwright rendering gate -- triggers on `emails/**`, `templates/**`:
 
 ```yaml
 # .github/workflows/email-test.yml
@@ -133,10 +123,3 @@ jobs:
 | `InvalidClient` from EoA | Fetch valid IDs from `/v5/email/clients` |
 | Screenshots stuck processing | Wait 3 min, then call `/results/reprocess` |
 | Encoding issues | Use `transfer_encoding: base64` with base64-encoded HTML |
-
-## Related
-
-- `services/email/email-testing.md` -- HTML/CSS validation, dark mode, responsive checks
-- `services/email/email-health-check.md` -- DNS authentication (SPF, DKIM, DMARC)
-- `services/email/ses.md` -- Amazon SES sending
-- `tools/browser/playwright.md` -- Playwright reference


### PR DESCRIPTION
## Summary

Tighten `.agents/services/email/email-design-test.md` from 142 to 125 lines (12% reduction) while preserving all institutional knowledge.

## Changes

- **Merge Related into Quick Reference**: the Related section (4 links) duplicated what was already in Quick Reference -- consolidated into one location
- **Remove raw curl examples**: the helper script `email-design-test-helper.sh` abstracts all API calls; raw curl was redundant. Operational details (polling interval, auth expiry, request body fields) folded into the endpoint table descriptions
- **Compress Client IDs table**: removed "Display Name" and "Category" columns (redundant -- client ID is self-descriptive, category adds no operational value). Added pointer to `eoa-clients` for live list
- **Add Rendering Modes subheading**: improves scannability of dark mode / image blocking / limitations bullets

## Content Preservation Verification

- All URLs intact (`https://api.emailonacid.com/v5`)
- All credential references intact (`EOA_API_KEY`, `EOA_API_PASSWORD`)
- All 7 client IDs preserved
- All 7 endpoints preserved (with enriched descriptions)
- CI/CD workflow YAML unchanged
- All 8 troubleshooting entries unchanged
- All cross-references to related docs preserved

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` -- no runtime behaviour change, content-only restructuring

Closes #13307

---
[aidevops.sh](https://aidevops.sh) v3.5.320 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 5,062 tokens on this as a headless worker.