### PR TITLE
GH#13265: tighten sweet-cookie.md agent doc

### DIFF
--- a/.agents/tools/browser/sweet-cookie.md
+++ b/.agents/tools/browser/sweet-cookie.md
@@ -18,17 +18,15 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Extract browser cookies for automation, session reuse, and authenticated scraping
-- **Two Libraries**: `@steipete/sweet-cookie` (TypeScript, cross-platform) and `SweetCookieKit` (Swift, macOS)
-- **Use when**: reusing existing browser sessions, authenticated API calls, bypassing automation detection, CI/CD auth state
-- **Don't use when**: fresh browser automation → agent-browser/stagehand; simple scraping without auth → crawl4ai
-
-**Decision**:
+- **Purpose**: Extract browser cookies for automation, session reuse, authenticated scraping
+- **Libraries**: `@steipete/sweet-cookie` (TypeScript, cross-platform) | `SweetCookieKit` (Swift, macOS-only)
+- **Use when**: reusing browser sessions, authenticated API calls, bypassing automation detection, CI/CD auth state
+- **Don't use when**: fresh browser automation -> agent-browser/stagehand; unauthenticated scraping -> crawl4ai
 
 ```text
 Need cookies from existing browser session?
-    +-> TypeScript/Node.js project? --> @steipete/sweet-cookie
-    +-> Swift/macOS native app?     --> SweetCookieKit
+    +-> TypeScript/Node.js? --> @steipete/sweet-cookie
+    +-> Swift/macOS native? --> SweetCookieKit
     +-> App-bound cookies (Chrome 127+)? --> Chrome extension
 ```
 
@@ -36,24 +34,21 @@ Need cookies from existing browser session?
 
 ## @steipete/sweet-cookie (TypeScript)
 
-Cross-platform cookie extraction for Node.js (>=22, `node:sqlite`) and Bun (`bun:sqlite`).
+Cross-platform extraction for Node.js (>=22, `node:sqlite`) and Bun (`bun:sqlite`).
 
 ```bash
 npm install @steipete/sweet-cookie   # or: pnpm add / bun add
 ```
 
-### Usage
-
 ```typescript
 import { getCookies, toCookieHeader } from '@steipete/sweet-cookie';
 
-// Basic
+// Basic extraction
 const { cookies, warnings } = await getCookies({
   url: 'https://example.com/',
   names: ['session', 'csrf'],
   browsers: ['chrome', 'edge', 'firefox', 'safari'],
 });
-for (const warning of warnings) console.warn(warning);
 await fetch('https://api.example.com/data', {
   headers: { Cookie: toCookieHeader(cookies, { dedupeByName: true }) }
 });
@@ -69,7 +64,7 @@ await getCookies({
 await getCookies({ url: 'https://example.com/', browsers: ['chrome'], chromeProfile: 'Default' });
 await getCookies({ url: 'https://example.com/', browsers: ['edge'], edgeProfile: 'Profile 1' });
 
-// Inline cookies (CI/CD — when browser DB access isn't possible)
+// Inline cookies (CI/CD — no browser DB access)
 await getCookies({ url: 'https://example.com/', inlineCookiesFile: '/path/to/cookies.json' });
 await getCookies({ url: 'https://example.com/', inlineCookiesJson: '{"cookies": [...]}' });
 await getCookies({ url: 'https://example.com/', inlineCookiesBase64: 'eyJjb29raWVzIjogWy4uLl19' });
@@ -77,17 +72,17 @@ await getCookies({ url: 'https://example.com/', inlineCookiesBase64: 'eyJjb29raW
 
 ### Environment Variables
 
-```bash
-SWEET_COOKIE_BROWSERS=chrome,safari,firefox
-SWEET_COOKIE_MODE=merge                        # or 'first'
-SWEET_COOKIE_CHROME_PROFILE=Default
-SWEET_COOKIE_EDGE_PROFILE=Default
-SWEET_COOKIE_FIREFOX_PROFILE=default-release
-SWEET_COOKIE_LINUX_KEYRING=gnome               # or kwallet, basic
-SWEET_COOKIE_CHROME_SAFE_STORAGE_PASSWORD=...
-```
+| Variable | Example |
+|----------|---------|
+| `SWEET_COOKIE_BROWSERS` | `chrome,safari,firefox` |
+| `SWEET_COOKIE_MODE` | `merge` or `first` |
+| `SWEET_COOKIE_CHROME_PROFILE` | `Default` |
+| `SWEET_COOKIE_EDGE_PROFILE` | `Default` |
+| `SWEET_COOKIE_FIREFOX_PROFILE` | `default-release` |
+| `SWEET_COOKIE_LINUX_KEYRING` | `gnome`, `kwallet`, `basic` |
+| `SWEET_COOKIE_CHROME_SAFE_STORAGE_PASSWORD` | (keychain password) |
 
-### Supported Browsers
+### Browser Support
 
 | Browser | macOS | Windows | Linux |
 |---------|-------|---------|-------|
@@ -96,11 +91,11 @@ SWEET_COOKIE_CHROME_SAFE_STORAGE_PASSWORD=...
 | Firefox | Yes   | Yes     | Yes   |
 | Safari  | Yes   | -       | -     |
 
-**Chrome Extension (App-Bound Cookies, Chrome 127+):** Install from `apps/extension` in the sweet-cookie repo → export cookies as JSON/base64/file → use `inlineCookiesFile` or `inlineCookiesJson`.
+**App-Bound Cookies (Chrome 127+):** Install extension from `apps/extension` in sweet-cookie repo -> export as JSON/base64/file -> use `inlineCookiesFile`/`inlineCookiesJson`.
 
 ## SweetCookieKit (Swift)
 
-Native macOS cookie extraction. **Requirements**: macOS 13+, Swift 6. Install: `.package(url: "https://github.com/steipete/SweetCookieKit.git", from: "0.2.0")`
+macOS-only. Requirements: macOS 13+, Swift 6. Install: `.package(url: "https://github.com/steipete/SweetCookieKit.git", from: "0.2.0")`
 
 ```swift
 import SweetCookieKit
@@ -110,7 +105,7 @@ let store = client.stores(for: .chrome).first { $0.profile.name == "Default" }
 let query = BrowserCookieQuery(domains: ["example.com"], domainMatch: .suffix, includeExpired: false)
 let cookies = try client.cookies(matching: query, in: store!)
 
-// Browser import order
+// Iterate all browsers
 for browser in Browser.defaultImportOrder {
     let results = try client.records(matching: query, in: browser)
 }
@@ -120,23 +115,19 @@ let entries = ChromiumLocalStorageReader.readEntries(for: "https://example.com",
 let tokens = ChromiumLevelDBReader.readTokenCandidates(in: levelDBURL, minimumLength: 80)
 ```
 
-**CLI**: `swift run SweetCookieCLI stores` | `swift run SweetCookieCLI export --domain example.com --format json`
+CLI: `swift run SweetCookieCLI stores` | `swift run SweetCookieCLI export --domain example.com --format json`
 
-## Security Notes
+## Security
 
-- **Keychain prompts**: Chrome/Edge may trigger Keychain access prompts on macOS
-- **Full Disk Access**: Safari requires Full Disk Access permission
-- **Browser must be closed**: Some browsers lock their cookie DB while running
-- **Encrypted cookies**: Chromium cookies are encrypted; sweet-cookie handles decryption via OS keychain
-- **Keychain handler (Swift)**: `BrowserCookieKeychainPromptHandler.shared.handler = { context in /* context.kind = .chromiumSafeStorage */ }`
+- Chrome/Edge trigger Keychain access prompts on macOS
+- Safari requires Full Disk Access
+- Some browsers lock cookie DB while running — close first
+- Chromium cookies encrypted; sweet-cookie decrypts via OS keychain
+- Swift keychain handler: `BrowserCookieKeychainPromptHandler.shared.handler = { context in /* .chromiumSafeStorage */ }`
 
-## Resources & Related
+## Related
 
-- **sweet-cookie (TypeScript)**: https://github.com/steipete/sweet-cookie
-- **SweetCookieKit (Swift)**: https://github.com/steipete/SweetCookieKit
-- **Documentation**: https://sweetcookie.dev
-- **Bird (X/Twitter CLI)**: auto-extracts X/Twitter cookies — `bird whoami`, `bird tweet "Hello"` → `tools/social-media/bird.md`
-- **Crawl4AI**: `crawl4ai https://app.example.com --cookies /path/to/cookies.json`
-- `tools/browser/agent-browser.md` - CLI browser automation (default)
-- `tools/browser/stagehand.md` - AI-powered browser automation
-- `tools/browser/playwriter.md` - Chrome extension MCP for existing sessions
+- [sweet-cookie (TS)](https://github.com/steipete/sweet-cookie) | [SweetCookieKit (Swift)](https://github.com/steipete/SweetCookieKit) | [Docs](https://sweetcookie.dev)
+- Bird (X/Twitter CLI): auto-extracts cookies -> `tools/social-media/bird.md`
+- Crawl4AI: `crawl4ai https://app.example.com --cookies /path/to/cookies.json`
+- `tools/browser/agent-browser.md` (CLI browser automation) | `tools/browser/stagehand.md` (AI browser) | `tools/browser/playwriter.md` (Chrome extension MCP)


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/browser/sweet-cookie.md` from 142 -> 133 lines (6% reduction)
- Compress environment variables from code block to table format
- Consolidate TypeScript code examples into a single block (removed redundant `### Usage` heading)
- Tighten prose in Quick Reference, Security Notes, and Resources sections
- Merge Resources & Related links into compact single-line format

## Content Preservation

All 36 key references verified present: APIs (`getCookies`, `toCookieHeader`, `BrowserCookieClient`, `ChromiumLocalStorageReader`, `ChromiumLevelDBReader`), URLs (GitHub repos, sweetcookie.dev), env vars (`SWEET_COOKIE_*`), security notes (Keychain, Full Disk Access), and cross-references (bird, crawl4ai, agent-browser, stagehand, playwriter).

## Runtime Testing

- **Risk**: Low (docs/agent prompt only)
- **Level**: `self-assessed`
- No code logic changed; markdown lint passes with 0 errors

Closes #13265

---
[aidevops.sh](https://aidevops.sh) v3.5.320 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 2m and 4,912 tokens on this as a headless worker.