### PR TITLE
GH#13247: tighten Account Structure Philosophy agent doc

### DIFF
--- a/.agents/marketing-sales/meta-ads-foundations-account-structure.md
+++ b/.agents/marketing-sales/meta-ads-foundations-account-structure.md
@@ -1,10 +1,8 @@
 # Account Structure Philosophy
 
-> The way you organize your Meta ads account determines whether you succeed or waste money fighting the algorithm.
+Account structure determines algorithm performance. Simplified structures win in 2026 — Meta's AI outperforms manual segmentation when given enough data.
 
----
-
-## The Hierarchy
+## Hierarchy
 
 ```
 Business Account
@@ -14,55 +12,43 @@ Business Account
             └── Ad(s)     ← Creative, copy, headline, CTA, destination URL
 ```
 
----
+## Simplified vs Granular
 
-## Simplified vs Granular Structure
-
-**Simplified wins in 2026.** Meta's AI outperforms manual segmentation when given enough data.
-
-Each ad set needs ~50 conversions/week to exit the learning phase.
+Each ad set needs ~50 conversions/week to exit learning phase.
 
 | Structure | Ad Sets | Daily Budget | Conversions/Week | Result |
 |-----------|---------|--------------|------------------|--------|
-| Granular (10 ad sets) | 10 × $50 | $500 | ~12/ad set | All learning-limited |
-| Simplified (3 ad sets) | 3 × $165 | $495 | ~39/ad set | Closer to exiting learning |
+| Granular (10 ad sets) | 10 x $50 | $500 | ~12/ad set | All learning-limited |
+| Simplified (3 ad sets) | 3 x $165 | $495 | ~39/ad set | Closer to exiting learning |
 
-**Still use granular when:** testing truly different audiences (US vs EU), different products/buyers, different offers, or A/B testing specific variables.
+**Use granular when:** truly different audiences (US vs EU), different products/buyers, different offers, or A/B testing specific variables.
 
----
+## Power 5 to 2026 Evolution
 
-## Power 5 → 2026 Update
-
-Meta's original Power 5 (2019–2022) has evolved:
-
-| Original | 2026 Equivalent |
-|----------|-----------------|
+| Original (2019-2022) | 2026 Equivalent |
+|----------------------|-----------------|
 | Account Simplification | Consolidation — fewer campaigns, more budget per campaign |
 | CBO | Use contextually (not always) |
 | Automatic Placements | Advantage+ Placements |
 | Auto Advanced Matching | CAPI (now mandatory) |
 | Dynamic Ads | Advantage+ Shopping/Creative |
 
----
+## Consolidation
 
-## Account Consolidation
-
-**Why it works:** more conversions per ad set → faster learning → lower CPMs → less internal competition.
+**Why:** more conversions per ad set -> faster learning -> lower CPMs -> less internal competition.
 
 **Before vs After (same $300/day budget):**
 
 | Setup | Ad Sets | Conversions/Week | Outcome |
 |-------|---------|------------------|---------|
-| 3 campaigns × 5 ad sets | 15 | ~5/ad set | All learning-limited |
-| Testing (ABO 3 sets) + Scale (CBO 2 sets) | 5 | ~8–24/ad set | Better distributed |
+| 3 campaigns x 5 ad sets | 15 | ~5/ad set | All learning-limited |
+| Testing (ABO 3 sets) + Scale (CBO 2 sets) | 5 | ~8-24/ad set | Better distributed |
 
 **Consolidate when:** same objective, similar audiences, same funnel stage, overlap >30%, or any ad set gets <50 conversions/week.
 
 **Split when:** different objectives, different funnel stages (prospecting vs retargeting), different products/geographies, or testing vs scaling.
 
-**Audience overlap check:** Ads Manager → Audiences → select 2+ → ⋮ → "Show Audience Overlap". If >30%, consolidate or exclude.
-
----
+**Audience overlap check:** Ads Manager -> Audiences -> select 2+ -> ... -> "Show Audience Overlap". If >30%, consolidate or exclude.
 
 ## CBO vs ABO
 
@@ -72,23 +58,7 @@ Meta's original Power 5 (2019–2022) has evolved:
 | Best for | Scaling proven winners | Creative testing |
 | Downside | Some ad sets get starved | Manual management |
 
-**Two-campaign system (optimal):**
-
-```
-Campaign 1: Creative Testing (ABO)
-├── Ad Set: Angle A ($50/day)
-├── Ad Set: Angle B ($50/day)
-└── Ad Set: Angle C ($50/day)
-
-Campaign 2: Scale (CBO)
-├── Ad Set: Proven Winner 1
-├── Ad Set: Proven Winner 2
-└── Ad Set: Proven Winner 3
-```
-
-Workflow: test in ABO → identify winners (3+ days good CPA) → duplicate into CBO → scale CBO → kill ABO losers → add new tests → repeat.
-
----
+**Workflow:** test in ABO -> identify winners (3+ days good CPA) -> duplicate into CBO -> scale CBO -> kill ABO losers -> add new tests -> repeat.
 
 ## 2026 Optimal Structure
 
@@ -110,7 +80,7 @@ AD ACCOUNT
     └── Ad Set: Cart Abandoners → 2-3 ads
 ```
 
-**For Advantage+ Shopping (ecommerce):** replace Campaign 2 with an ASC campaign (combines prospecting + retargeting). Separate retargeting campaign may not be needed.
+**Advantage+ Shopping (ecommerce):** replace Campaign 2 with ASC (combines prospecting + retargeting). Separate retargeting campaign may not be needed.
 
 ### Naming Convention
 
@@ -126,8 +96,6 @@ Ad:       [FORMAT]_[HOOK]_[VERSION]
   e.g.  VID_PainPoint_v1, IMG_Comparison_v2
 ```
 
----
-
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -138,7 +106,5 @@ Ad:       [FORMAT]_[HOOK]_[VERSION]
 | Mixed objectives in one campaign | One objective per campaign |
 | Retargeting mixed with prospecting | Separate retargeting campaign |
 | Duplicate audiences competing | Check overlap, consolidate or exclude |
-
----
 
 *Next: [Glossary](glossary.md)*


### PR DESCRIPTION
## Summary

Tighten `.agents/marketing-sales/meta-ads-foundations-account-structure.md` from 144 to 110 lines (24% reduction) with zero knowledge loss.

## Changes

- Remove 7 decorative `---` horizontal rules (headings already provide structure)
- Replace motivational blockquote with factual one-liner
- Eliminate duplicate two-campaign code block from CBO vs ABO section (same content preserved in 2026 Optimal Structure)
- Compress prose preambles ("Meta's original Power 5 has evolved:" → table header says it)

## Content Preservation Verified

All data points, thresholds, tables, code blocks, naming conventions, workflow steps, and the glossary link are intact:
- 50 conversions/week threshold, $500/$495/$300 budget examples
- All 5 tables (Simplified vs Granular, Power 5, Consolidation, CBO vs ABO, Common Mistakes)
- Both code blocks (Hierarchy, 2026 Optimal Structure, Naming Convention)
- Consolidate/Split decision rules, audience overlap check procedure
- ABO→CBO workflow steps

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — content diff confirms no knowledge removed

Closes #13247

---
[aidevops.sh](https://aidevops.sh) v3.5.320 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 4,906 tokens on this as a headless worker.