### PR TITLE
GH#13233: tighten cro-chapter-17.md B2B Lead Gen, ABM, Lead Scoring

### DIFF
--- a/.agents/marketing-sales/cro-chapter-17.md
+++ b/.agents/marketing-sales/cro-chapter-17.md
@@ -1,6 +1,6 @@
 # Chapter 17: B2B Lead Generation, ABM, and Lead Scoring
 
-B2B CRO: extended sales cycles, 6-10 decision-makers, $100K–$1M+ contracts. Buyers complete 57–70% of research independently (Gartner); only 17% of evaluation time is spent with suppliers.
+B2B CRO: extended sales cycles, 6-10 decision-makers, $100K-$1M+ contracts. Buyers complete 57-70% of research independently (Gartner); only 17% of evaluation time with suppliers.
 
 ---
 
@@ -8,7 +8,7 @@ B2B CRO: extended sales cycles, 6-10 decision-makers, $100K–$1M+ contracts. Bu
 
 ### Four Pillars
 
-1. **Audience Precision** — Firmographic + psychographic + behavioral data. Measure ICP gap via conversion-to-opportunity rates, deal size, cycle length by source. Segment by buying stage, role, interests, signals.
+1. **Audience Precision** — Firmographic + psychographic + behavioral data. Measure ICP gap via conversion-to-opportunity rates, deal size, cycle length by source. Segment by stage, role, interests, signals.
 2. **Content & Offer** — Map to journey: educational/strategic (early) → solution/comparison (mid) → ROI calculators/specs/references (late). Every offer must justify the data exchange. Test formats: PDF vs interactive, video vs written.
 3. **Experience & Conversion** — Consumer-grade UX: personalization, mobile-first, fast load. Progressive profiling — every added field reduces completion.
 4. **Attribution & Measurement** — Multi-touch attribution for extended cycles. Track: conversion-to-opportunity, cycle length, revenue by source.
@@ -23,7 +23,6 @@ B2B CRO: extended sales cycles, 6-10 decision-makers, $100K–$1M+ contracts. Bu
 ### Advanced Tactics
 
 **Conversational Marketing:** Optimize intent recognition, response relevance, escalation, conversion completion. A/B test greetings, qualification sequences, response patterns.
-
 
 **Interactive Content:** Value-first (insights before contact request). Progressive profiling. Personalized results. Shareability within accounts. Auto-route to nurture tracks.
 
@@ -41,21 +40,15 @@ ABM inverts the funnel: identify high-value accounts first, then orchestrate coo
 
 ### ABM Optimization Framework
 
-**1. Account Selection Scorecard (weighted)**
+**1. Account Selection Scorecard (weighted):** Firmographic Fit 25% (size, industry, geography, structure) | Technographic Alignment 20% (stack compatibility, integration needs, maturity) | Behavioral Intent 25% (research activity, competitor engagement, buying signals) | Relationship Foundation 15% (existing connections, past engagement, referrals) | Strategic Value 15% (deal size potential, expansion opportunity, reference value).
 
-- Firmographic Fit 25% — size, industry, geography, structure
-- Technographic Alignment 20% — stack compatibility, integration needs, infrastructure maturity
-- Behavioral Intent 25% — research activity, competitor engagement, buying signals
-- Relationship Foundation 15% — existing connections, past engagement, referral pathways
-- Strategic Value 15% — deal size potential, expansion opportunity, reference value
-
-**2. Stakeholder Engagement** (influence × attitude): High-influence champions → max investment (exec access, custom content, relationship dev). High-influence skeptics → targeted persuasion. Low-influence supporters → amplify internally. Low-influence blockers → neutralize without disproportionate spend. Role-specific: Executives → thought leadership, peer networking | Technical evaluators → detailed docs, POC | End users → training, usability demos | Procurement → transparent pricing, flexible terms.
+**2. Stakeholder Engagement** (influence x attitude): High-influence champions → max investment (exec access, custom content, relationship dev). High-influence skeptics → targeted persuasion. Low-influence supporters → amplify internally. Low-influence blockers → neutralize without disproportionate spend. By role: Executives → thought leadership, peer networking | Technical evaluators → detailed docs, POC | End users → training, usability demos | Procurement → transparent pricing, flexible terms.
 
 **3. Personalization Tiers:** Tier 1 (Strategic) — fully custom content, dedicated teams, exec programs, bespoke events. Tier 2 (High-Priority) — modular personalization, industry-specific content, role-based messaging. Tier 3 (Target) — dynamic content insertion, industry-aligned messaging, automated personalization.
 
 **4. Channel-to-Stage:** Awareness → programmatic ads, social, publications, search. Engagement → email nurture, webinars, content syndication, website personalization. Consideration → sales outreach, demos, proposals, reference calls. Validation → exec meetings, site visits, POC trials, contract negotiation.
 
-**5. Account-Centric Metrics:** Account Engagement Score (website + content + email + events + sales, weighted by seniority/recency). Stage: unaware → aware → engaged → opportunity → customer → expanded. Also: Engagement Heat Maps, Intent Trend Analysis, Competitive Presence Indicators, Relationship Depth Scoring, Opportunity Risk Indicators.
+**5. Account-Centric Metrics:** Account Engagement Score (website + content + email + events + sales, weighted by seniority/recency). Stage progression: unaware → aware → engaged → opportunity → customer → expanded. Also: Engagement Heat Maps, Intent Trend Analysis, Competitive Presence Indicators, Relationship Depth Scoring, Opportunity Risk Indicators.
 
 ### ABM Tactics
 
@@ -84,10 +77,12 @@ ABM inverts the funnel: identify high-value accounts first, then orchestrate coo
 
 ### Model Architecture
 
-- **Rule-Based** — low complexity, high transparency, moderate predictive power. Best for simple processes, small data.
-- **Multi-Dimensional** — medium complexity, high transparency, good predictive power. Best for complex journeys, multiple segments. Separates fit and engagement dimensions — high-fit/low-engagement needs different treatment than low-fit/high-engagement.
-- **Predictive ML** — high complexity, low-medium transparency, excellent predictive power. Best for large data, sophisticated ops.
-- **Hybrid** — high complexity, medium transparency, excellent predictive power. Best for accuracy + explainability.
+| Model | Complexity | Transparency | Predictive Power | Best For |
+|-------|-----------|-------------|-----------------|----------|
+| Rule-Based | Low | High | Moderate | Simple processes, small data |
+| Multi-Dimensional | Medium | High | Good | Complex journeys, multiple segments (separates fit vs engagement) |
+| Predictive ML | High | Low-Medium | Excellent | Large data, sophisticated ops |
+| Hybrid | High | Medium | Excellent | Accuracy + explainability |
 
 ### Thresholds & Routing
 
@@ -99,12 +94,11 @@ Route: high-fit/low-engagement → targeted awareness | high-engagement/moderate
 
 **Behavioral Patterns:** Research-to-Evaluation (educational → solution content 7d → demo request 14d). Stakeholder Expansion (end user → technical evaluator → exec sponsor). Competitive Evaluation (comparison content + pricing visits + reference cases, compressed timeframe).
 
-**Negative Scoring & Decay:** Fit deterioration (job change, unsuitable acquisition, tech decision against platform). Engagement quality (careers page, support-seeking, competitor events). Decay: reduce scores after 30 days of inactivity.
+**Negative Scoring & Decay:** Fit deterioration (job change, unsuitable acquisition, tech decision against platform). Engagement quality (careers page, support-seeking, competitor events). Decay: reduce scores after 30 days inactivity.
 
 **Account-Level Scoring:** Aggregate individual scores + breadth multiplier (unique contacts) + depth weighting (seniority/influence) + account fit baseline + intent multiplier.
 
 **Predictive ML:** Data prep → feature engineering → training + tuning → holdout validation → deployment → drift monitoring.
-
 
 ### Scoring Governance
 
@@ -123,19 +117,19 @@ Key workflows with unified data infrastructure:
 - **Lead-to-Account:** Inbound leads → evaluate account context → route to ABM if target account; trigger multi-threading if colleagues already engaged
 - **Scoring-Driven ABM:** High scores from non-target accounts → account research + potential ABM enrollment; declining engagement → proactive intervention
 - **Sales Handoff:** Transfer full context (engagement history, content, scores, talking points); continue support with account-based ads, content portals, triggered nurture
-- **Unified Measurement:** Attribute revenue to all touchpoints; reveal which tactic combinations drive results for different prospect types.
+- **Unified Measurement:** Attribute revenue to all touchpoints; reveal which tactic combinations drive results for different prospect types
 
 ---
 
 ## Part V: Case Studies
 
-**Case 1 — Enterprise Software Lead Gen:** 5K MQLs/mo, 12% → opportunity, sales ignoring leads. Fix: redefined ICP, mid/bottom-funnel content, progressive qualification, fit+behavior scoring, marketing-sales SLAs. Result: lead volume −40%, opportunity CVR 12%→28%, cost per opportunity −60%, sales acceptance 30%→75%.
+**Case 1 — Enterprise Software Lead Gen:** 5K MQLs/mo, 12% → opportunity, sales ignoring leads. Fix: redefined ICP, mid/bottom-funnel content, progressive qualification, fit+behavior scoring, marketing-sales SLAs. Result: lead volume -40%, opportunity CVR 12%→28%, cost per opportunity -60%, sales acceptance 30%→75%.
 
-**Case 2 — ABM Program Launch:** Pilot (50 accounts): 3x visits, 5x engagement, only 8 opportunities. Root cause: size-over-fit selection, known-contacts-only engagement, no sales coordination. Fix: intent data in selection, stakeholder mapping, ABM specialists in sales pods, tiered personalization, weekly joint reviews. Result: pipeline per account 4x, sales cycle −30%, win rates +15pp.
+**Case 2 — ABM Program Launch:** Pilot (50 accounts): 3x visits, 5x engagement, only 8 opportunities. Root cause: size-over-fit selection, known-contacts-only engagement, no sales coordination. Fix: intent data in selection, stakeholder mapping, ABM specialists in sales pods, tiered personalization, weekly joint reviews. Result: pipeline per account 4x, sales cycle -30%, win rates +15pp.
 
 **Case 3 — Lead Scoring Redesign:** Rule-based model misaligned — demo requests (20pts) converted 45% vs similar-scored leads at 5%. Fix: analyzed 2yr data, multi-dimensional model (fit + engagement + intent), negative scoring, 30-day decay. Result: top-quartile lead-to-opportunity 18%→34%, sales acceptance 45%→78%, marketing-sourced revenue 25%→42% (18mo).
 
-**Case 4 — Integrated Optimization:** Siloed demand gen, ABM, sales ops. Fix: unified team, common data platform, cross-functional workflows (high scores trigger ABM enrollment, ABM engagement adjusts scores). Result: pipeline +45% (no additional spend), marketing ROI +60%, CAC −35%, deal value +20%.
+**Case 4 — Integrated Optimization:** Siloed demand gen, ABM, sales ops. Fix: unified team, common data platform, cross-functional workflows (high scores trigger ABM enrollment, ABM engagement adjusts scores). Result: pipeline +45% (no additional spend), marketing ROI +60%, CAC -35%, deal value +20%.
 
 ---
 


### PR DESCRIPTION
## Summary

- Tightened prose in `.agents/marketing-sales/cro-chapter-17.md` (146 → 140 lines, 4% reduction)
- Collapsed Account Selection Scorecard from 7-line bullet list to inline paragraph
- Converted Model Architecture bullets to comparison table for clearer scanning
- Removed extra blank lines, normalized Unicode dashes/symbols to ASCII
- Zero content loss: all metrics, percentages, case study data, and domain concepts preserved

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** self-assessed — content diff reviewed, all data points confirmed present

Closes #13233


---
[aidevops.sh](https://aidevops.sh) v3.5.325 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 5m and 6,404 tokens on this as a headless worker.