### PR TITLE
GH#13217: tighten remotion-compositions.md

### DIFF
--- a/.agents/tools/video/remotion-compositions.md
+++ b/.agents/tools/video/remotion-compositions.md
@@ -6,9 +6,7 @@ metadata:
   tags: composition, still, folder, props, metadata
 ---
 
-A `<Composition>` defines the component, width, height, fps and duration of a renderable video.
-
-It normally is placed in the `src/Root.tsx` file.
+`<Composition>` defines component, dimensions, fps and duration for a renderable video. Place in `src/Root.tsx`.
 
 ```tsx
 import { Composition } from "remotion";
@@ -30,8 +28,7 @@ export const RemotionRoot = () => {
 
 ## Default Props
 
-Pass `defaultProps` to provide initial values for your component.  
-Values must be JSON-serializable (`Date`, `Map`, `Set`, and `staticFile()` are supported).
+`defaultProps` provides initial values. Must be JSON-serializable (`Date`, `Map`, `Set`, `staticFile()` supported). Use `type` (not `interface`) for props to ensure type safety with `satisfies`.
 
 ```tsx
 import { Composition } from "remotion";
@@ -55,12 +52,9 @@ export const RemotionRoot = () => {
 };
 ```
 
-Use `type` declarations for props rather than `interface` to ensure `defaultProps` type safety.
-
 ## Folders
 
-Use `<Folder>` to organize compositions in the sidebar.  
-Folder names can only contain letters, numbers, and hyphens.
+`<Folder>` organizes compositions in the sidebar. Names: letters, numbers, hyphens only. Supports nesting.
 
 ```tsx
 import { Composition, Folder } from "remotion";
@@ -85,7 +79,7 @@ export const RemotionRoot = () => {
 
 ## Stills
 
-Use `<Still>` for single-frame images. It does not require `durationInFrames` or `fps`.
+`<Still>` renders single-frame images. No `durationInFrames` or `fps` required.
 
 ```tsx
 import { Still } from "remotion";
@@ -105,7 +99,7 @@ export const RemotionRoot = () => {
 
 ## Calculate Metadata
 
-Use `calculateMetadata` to make dimensions, duration, or props dynamic based on data.
+`calculateMetadata` makes dimensions, duration, or props dynamic. Runs once before rendering. Can return `props`, `durationInFrames`, `width`, `height`, `fps`, and codec defaults.
 
 ```tsx
 import { Composition, CalculateMetadataFunction } from "remotion";
@@ -143,5 +137,3 @@ export const RemotionRoot = () => {
   );
 };
 ```
-
-The function can return `props`, `durationInFrames`, `width`, `height`, `fps`, and codec-related defaults. It runs once before rendering begins.


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/video/remotion-compositions.md` prose (147 → 139 lines, -5.4%).

Closes #13217

## Changes

- Compressed multi-line section descriptions into single lines
- Moved the `type` vs `interface` tip from standalone paragraph into Default Props description
- Moved `calculateMetadata` return values and timing note from trailing paragraph into section header
- Added explicit "Supports nesting" note to Folders section (was only implicit from code)
- All 5 code blocks preserved exactly as-is
- All API details, serialization types, and constraints preserved

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** `self-assessed` — markdown lint clean, diff reviewed for content preservation

---
[aidevops.sh](https://aidevops.sh) v3.5.325 plugin for [Claude Code](https://claude.ai/code) with claude-opus-4-6 spent 8m on this as an interactive session.