### PR TITLE
GH#13219: tighten agent doc cloud-gpu.md

### DIFF
--- a/.agents/tools/infrastructure/cloud-gpu.md
+++ b/.agents/tools/infrastructure/cloud-gpu.md
@@ -1,5 +1,5 @@
 ---
-description: "Cloud GPU deployment guide for AI model hosting - provider comparison, SSH setup, Docker deployment, model caching, cost optimization"
+description: "Cloud GPU deployment - provider comparison, SSH/Docker setup, model caching, cost optimization"
 mode: subagent
 tools:
   read: true
@@ -91,11 +91,11 @@ curl http://<instance-ip>:8000/v1/completions -H "Content-Type: application/json
 
 ## Cost Optimization
 
-**Strategies:** Spot instances (50-80% savings, risk of termination) | Off-peak (10-30%) | Smaller GPU + quantization (40-60%) | Serverless/RunPod (pay per request, cold starts) | Reserved/Lambda (20-30%, commitment) | Vast.ai auction (50-70% vs fixed).
+Spot instances (50-80% savings, termination risk) | Off-peak (10-30%) | Smaller GPU + quantization (40-60%) | Serverless/RunPod (pay per request, cold starts) | Reserved/Lambda (20-30%, commitment) | Vast.ai auction (50-70% vs fixed).
 
 **Quantization**: 4-bit GPTQ/AWQ cuts VRAM ~75%. Llama 3.1 70B: FP16 ~140GB -> 4-bit ~35GB (1x A100). Search HuggingFace for `TheBloke/<model>-GPTQ` or `<model>-AWQ`.
 
-**Auto-shutdown** (30min idle -- provider-native alternatives: RunPod auto-stop, Vast.ai max idle, Lambda API):
+**Auto-shutdown** (30min idle -- alternatives: RunPod auto-stop, Vast.ai max idle, Lambda API):
 
 ```bash
 */5 * * * * GPU_UTIL=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader | awk '{print $1+0}'); \
@@ -107,21 +107,12 @@ curl http://<instance-ip>:8000/v1/completions -H "Content-Type: application/json
 
 ## Monitoring + Troubleshooting
 
-**Health check:**
-
 ```bash
+# Health check
 nvidia-smi --query-gpu=name,memory.total,memory.used,temperature.gpu,utilization.gpu --format=csv,noheader
-```
-
-**CUDA check:**
-
-```bash
+# CUDA check
 python3 -c "import torch; print(torch.cuda.is_available(), torch.cuda.device_count())"
-```
-
-**Continuous monitoring:**
-
-```bash
+# Continuous monitoring (background)
 nvidia-smi --query-gpu=timestamp,utilization.gpu,memory.used,temperature.gpu --format=csv -l 30 > /tmp/gpu_metrics.csv &
 ```
 


### PR DESCRIPTION
## Summary

- Consolidate 3 separate monitoring code blocks (Health check, CUDA check, Continuous monitoring) into a single block with inline comments -- saves 9 lines of markdown scaffolding
- Compress prose in Cost Optimization section (remove redundant "Strategies:" bold label) and frontmatter description
- Tighten auto-shutdown parenthetical ("provider-native alternatives" -> "alternatives")

## Details

**File:** `.agents/tools/infrastructure/cloud-gpu.md`
**Before:** 147 lines | **After:** 138 lines (6% reduction)

**Classification:** Instruction doc (agent subagent with operational procedures). Tightened prose, not knowledge.

**Content preservation verified:** All code blocks, URLs (4 provider links), CLI commands (runpodctl, vastai, Lambda API, vLLM, TGI, docker, ssh), cross-references (5 See Also links + 2 inline refs), secret management commands, and troubleshooting table entries present in both versions.

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` -- markdown lint clean (0 errors), diff reviewed, content preservation verified via pattern matching

Closes #13219

---
[aidevops.sh](https://aidevops.sh) v3.5.325 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 10m and 6,249 tokens on this as a headless worker.