### PR TITLE
GH#13228: restore traceability and signature rules to build.txt

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -159,13 +159,7 @@ PR title: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NN
 
 Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `main`, and treat the Git ref as an internal detail inside the linked worktree. User-facing guidance should talk about the worktree path, not "using a branch". Re-read files at worktree path before editing. NEVER remove others' worktrees.
 
-**Traceability:**
-- PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
-- PR body MUST include `Closes #NNN` — only mechanism creating GitHub PR-issue link.
-- Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref=GH#NNN`.
-- Link both sides when closing (issue→PR, PR→issue).
-
-**GitHub comment signature footer:** Every issue, PR, and comment created by aidevops agents MUST include a signature footer. Use `gh-signature-helper.sh footer --model <model-id> [--issue OWNER/REPO#NUM] [--solved]` to generate it. The helper auto-detects CLI, version, tokens (input+output, excluding cache), and session time from the runtime DB. Pass `--issue` on comments to existing issues. Pass `--solved` on closing comments. Do NOT pass `--issue` when creating new issues. Append the footer as the last line of every `gh issue comment`, `gh issue create`, and `gh pr create` body. See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
+**Traceability and signature footer:** Hard rules in `prompts/build.txt` (sections "Traceability" and "#8 Signature footer"). Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -165,7 +165,18 @@ Reference code as `file_path:line_number` for easy navigation.
 # Full details: `reference/audit-logging.md`
 
 # Git Workflow
-Git is the audit trail. Traceability details: AGENTS.md "Git Workflow" section.
+Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
+
+**Traceability (MANDATORY):**
+- PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
+- PR body MUST include `Closes #NNN` — only mechanism creating GitHub PR-issue link.
+- Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref=GH#NNN`.
+
+# 8. Signature footer hallucination (observed: model composes inline, gets runtime/version wrong)
+- NEVER compose signature footers inline. ALWAYS call `gh-signature-helper.sh footer --model <model-id>`.
+- The helper auto-detects runtime, version, tokens, and session time. Manual composition gets these wrong.
+- Every `gh issue create`, `gh issue comment`, and `gh pr create` body MUST end with the helper's output.
+- Pass `--issue OWNER/REPO#NUM` on comments to existing issues. Pass `--solved` on closing comments.
 
 **Pre-edit rules:**
 - Before ANY file modification: run `pre-edit-check.sh`

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -170,7 +170,7 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 **Traceability (MANDATORY):**
 - PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
 - PR body MUST include `Closes #NNN` — only mechanism creating GitHub PR-issue link.
-- Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref=GH#NNN`.
+- Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref:GH#NNN`.
 
 # 8. Signature footer hallucination (observed: model composes inline, gets runtime/version wrong)
 - NEVER compose signature footers inline. ALWAYS call `gh-signature-helper.sh footer --model <model-id>`.


### PR DESCRIPTION
## Summary

- Restores traceability constraints (PR title format, `Closes #NNN`) and signature footer rules to `build.txt` — the highest-priority instruction set
- Adds signature footer as Error Prevention #8 with explicit NEVER-compose-inline prohibition
- AGENTS.md retains procedural details, points to build.txt for the hard rules

## Root cause

The signature instruction was moved from build.txt to AGENTS.md in 382ed6357. After that, the model started composing signatures inline — getting the runtime wrong ("Claude Code" instead of "OpenCode") and omitting version numbers, tokens, and session time. Evidence: [PR #1149 comment](https://github.com/afragen/git-updater/pull/1149#issuecomment-4151171548).

build.txt rules are treated as highest priority by the model. AGENTS.md content gets deprioritised in long sessions.

## Principle

**Hard behavioural constraints** (MUST/NEVER rules) belong in build.txt alongside other non-negotiable rules like "NEVER expose credentials" and "NEVER edit on main". **Procedures** (how to use helpers, step-by-step workflows) belong in AGENTS.md.

---
[aidevops.sh](https://aidevops.sh) v3.5.325 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 9m and 13,830 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development process and workflow documentation to consolidate traceability and GitHub linking requirements.

**Note:** This is an internal-only update with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->