### PR TITLE
GH#13364: tighten ddos-patterns.md (145→128 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md
@@ -28,18 +28,12 @@ const config = {
     {
       expression: "not http.request.uri.path matches \"^/api/\"",
       action: "execute",
-      action_parameters: {
-        id: managedRulesetId,
-        overrides: { sensitivity_level: "default", action: "block" },
-      },
+      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "default", action: "block" } },
     },
     {
       expression: "http.request.uri.path matches \"^/api/\"",
       action: "execute",
-      action_parameters: {
-        id: managedRulesetId,
-        overrides: { sensitivity_level: "low", action: "managed_challenge" },
-      },
+      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "low", action: "managed_challenge" } },
     },
   ],
 };
@@ -52,28 +46,27 @@ Gradual rollout: MONITORING (week 1) → LOW (week 2) → MEDIUM (week 3) → HI
 ```typescript
 enum ProtectionLevel { MONITORING = "monitoring", LOW = "low", MEDIUM = "medium", HIGH = "high" }
 
+const levelConfig: Record<ProtectionLevel, { action: string; sensitivity: string }> = {
+  [ProtectionLevel.MONITORING]: { action: "log", sensitivity: "eoff" },
+  [ProtectionLevel.LOW]:        { action: "managed_challenge", sensitivity: "low" },
+  [ProtectionLevel.MEDIUM]:     { action: "managed_challenge", sensitivity: "medium" },
+  [ProtectionLevel.HIGH]:       { action: "block", sensitivity: "default" },
+};
+
 async function setProtectionLevel(zoneId: string, level: ProtectionLevel, managedRulesetId: string, apiToken: string) {
-  const levelConfig = {
-    [ProtectionLevel.MONITORING]: { action: "log", sensitivity: "eoff" },
-    [ProtectionLevel.LOW]: { action: "managed_challenge", sensitivity: "low" },
-    [ProtectionLevel.MEDIUM]: { action: "managed_challenge", sensitivity: "medium" },
-    [ProtectionLevel.HIGH]: { action: "block", sensitivity: "default" },
-  } as const;
-
-  const settings = levelConfig[level];
-  const config = {
-    description: `DDoS protection level: ${level}`,
-    rules: [{
-      expression: "true",
-      action: "execute",
-      action_parameters: {
-        id: managedRulesetId,
-        overrides: { action: settings.action, sensitivity_level: settings.sensitivity },
-      },
-    }],
-  };
-
-  return fetch(/* ... */);
+  const { action, sensitivity } = levelConfig[level];
+  return fetch(/* PUT zones/${zoneId}/rulesets/phases/ddos_l7/entrypoint */, {
+    method: "PUT",
+    headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      description: `DDoS protection level: ${level}`,
+      rules: [{
+        expression: "true",
+        action: "execute",
+        action_parameters: { id: managedRulesetId, overrides: { action, sensitivity_level: sensitivity } },
+      }],
+    }),
+  });
 }
 ```
 
@@ -87,8 +80,7 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     if (request.url.includes("/attack-detected")) {
       await env.KV_NAMESPACE.put(`attack:${Date.now()}`, await request.text(), { expirationTtl: 86400 });
-      const recentAttacks = await getRecentAttacks(env.KV_NAMESPACE);
-      if (recentAttacks.length > 5) {
+      if ((await getRecentAttacks(env.KV_NAMESPACE)).length > 5) {
         await increaseProtection(env.ZONE_ID, "managed-ruleset-id", env.CLOUDFLARE_API_TOKEN);
         return new Response("Protection increased", { status: 200 });
       }
@@ -115,26 +107,17 @@ const config = {
     { // Unknown traffic — strictest
       expression: "not ip.src in $known_ips and not cf.bot_management.score gt 30",
       action: "execute",
-      action_parameters: {
-        id: managedRulesetId,
-        overrides: { sensitivity_level: "default", action: "block" },
-      },
+      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "default", action: "block" } },
     },
     { // Verified bots — medium
       expression: "cf.bot_management.verified_bot",
       action: "execute",
-      action_parameters: {
-        id: managedRulesetId,
-        overrides: { sensitivity_level: "medium", action: "managed_challenge" },
-      },
+      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "medium", action: "managed_challenge" } },
     },
     { // Trusted IPs — low
       expression: "ip.src in $trusted_ips",
       action: "execute",
-      action_parameters: {
-        id: managedRulesetId,
-        overrides: { sensitivity_level: "low" },
-      },
+      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "low" } },
     },
   ],
 };


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md` from 145 to 128 lines (12% reduction) — regression re-simplification per GH#13364.

Closes #13364

## Changes

- **Route-Specific Sensitivity**: Collapsed `action_parameters` objects to single lines (short enough to be readable inline)
- **Progressive Enhancement**: Extracted `levelConfig` to module scope with proper `Record<>` type annotation; destructured in function; replaced placeholder `fetch(/* ... */)` with actual API endpoint URL in comment; inlined config into `JSON.stringify`
- **Dynamic Response**: Inlined single-use `recentAttacks` variable
- **Multi-Rule Tiered Protection**: Collapsed `action_parameters` objects to single lines (same pattern)

## Content Preservation

- All 5 code blocks preserved
- All 6 section headers preserved
- Cross-references to `waf-patterns.md`, `bot-management-patterns.md` preserved
- All `managedRulesetId` references (8) preserved
- API endpoint `ddos_l7/entrypoint` preserved
- No task IDs, URLs, or knowledge removed

## Runtime Testing

- **Risk**: Low (docs/agent prompt only)
- **Level**: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.326 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 5m and 8,128 tokens on this as a headless worker.