### PR TITLE
GH#13192: tighten autogen.md — remove redundant prose

### DIFF
--- a/.agents/tools/ai-orchestration/autogen.md
+++ b/.agents/tools/ai-orchestration/autogen.md
@@ -28,7 +28,7 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Installation (Manual)
+## Installation
 
 ```bash
 mkdir -p ~/.aidevops/autogen && cd ~/.aidevops/autogen
@@ -52,7 +52,7 @@ AUTOGEN_STUDIO_PORT=8081
 
 ## Usage
 
-All examples assume these common imports (add per-example extras as shown):
+Common imports (add per-example extras as shown):
 
 ```python
 import asyncio
@@ -89,7 +89,7 @@ asyncio.run(main())
 
 ### Multi-Agent with AgentTool
 
-Use `AgentTool` to compose specialist agents under an orchestrator (e.g., code reviewer + deployer for aidevops pipelines):
+Compose specialist agents under an orchestrator:
 
 ```python
 from autogen_agentchat.tools import AgentTool
@@ -135,7 +135,7 @@ RUN pip install autogen-agentchat autogen-ext[openai]
 CMD ["python", "main.py"]
 ```
 
-For **FastAPI** or other web frameworks, wrap any agent pattern above in a route handler. Always call `await client.close()` after each request.
+For web frameworks (FastAPI etc.), wrap agent patterns in route handlers. Always call `await client.close()` after each request.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Remove redundant "Manual" qualifier from Installation heading
- Trim verbose preamble in Usage section ("All examples assume these common imports" → "Common imports")
- Shorten AgentTool section comment (removed aidevops-specific example that doesn't belong in a reference doc)
- Tighten Deployment FastAPI note to one concise sentence

## Classification

Reference corpus (code examples, API patterns) — content preserved, prose tightened. All code blocks, URLs, and command examples unchanged.

## Runtime Testing

Risk: **Low** — docs-only change, no code modified.
Level: self-assessed.

## Verification

- `wc -l`: 151 → 151 (line count unchanged — code blocks dominate)
- Byte reduction: 5336 → 5210 (126 bytes, 2.4%)
- `bunx markdownlint-cli2`: 0 errors
- All code blocks, URLs, and references preserved

Closes #13192


---
[aidevops.sh](https://aidevops.sh) v3.5.327 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 4,292 tokens on this as a headless worker.