### PR TITLE
GH#13357: tighten cloudflare-code-mode.md (95→69 lines)

### DIFF
--- a/.agents/tools/mcp/cloudflare-code-mode.md
+++ b/.agents/tools/mcp/cloudflare-code-mode.md
@@ -36,36 +36,15 @@ Both tools run in a **sandboxed V8 isolate** (no filesystem, no env var leakage,
 Searches the Cloudflare OpenAPI spec. The `spec` object has all `$refs` pre-resolved. Write JavaScript to filter endpoints — the full spec never enters model context, only filtered results.
 
 ```javascript
-// Find endpoints matching a path pattern
-async () => {
-  const results = [];
-  for (const [path, methods] of Object.entries(spec.paths)) {
-    if (path.includes('/zones/') &&
-        (path.includes('firewall/waf') || path.includes('rulesets'))) {
-      for (const [method, op] of Object.entries(methods)) {
-        results.push({ method: method.toUpperCase(), path, summary: op.summary });
-      }
-    }
-  }
-  return results;
-}
+// Find WAF/ruleset endpoints in zones
+async () => Object.entries(spec.paths)
+  .filter(([p]) => p.includes('/zones/') && (p.includes('firewall/waf') || p.includes('rulesets')))
+  .flatMap(([p, ms]) => Object.entries(ms).map(([m, op]) => ({ method: m.toUpperCase(), path: p, summary: op.summary })))
 ```
 
 ### `execute(code)`
 
-Executes JavaScript against the Cloudflare API via `cloudflare.request()`. Zone-level endpoints use `/zones/{zone_id}/...`, account-level use `/accounts/{account_id}/...`.
-
-```javascript
-// Simple GET — list DNS records
-async () => {
-  const zoneId = "<YOUR_ZONE_ID>";
-  const res = await cloudflare.request({
-    method: "GET",
-    path: `/zones/${zoneId}/dns_records`
-  });
-  return res.result;
-}
-```
+Executes JavaScript against the Cloudflare API via `cloudflare.request()`. Zone-level: `/zones/{zone_id}/...`, account-level: `/accounts/{account_id}/...`. Chain multiple calls in one invocation to batch operations.
 
 ```javascript
 // PUT with body — enable managed WAF ruleset
@@ -75,17 +54,12 @@ async () => {
     method: "PUT",
     path: `/zones/${zoneId}/rulesets/phases/http_request_firewall_managed/entrypoint`,
     body: {
-      rules: [{
-        action: "execute",
-        expression: "true",
-        action_parameters: { id: "efb7b8c949ac4650a09736fc376e9aee" }
-      }]
+      rules: [{ action: "execute", expression: "true",
+        action_parameters: { id: "efb7b8c949ac4650a09736fc376e9aee" } }]
     }
   });
 }
 ```
-
-Chain multiple `cloudflare.request()` calls in a single `execute` invocation to batch related operations (e.g., fetching DDoS + WAF rulesets together).
 
 ## References
 


### PR DESCRIPTION
## Summary

- Compress `search` example from 14-line nested loop to a 3-line functional chain (same logic, less noise)
- Remove redundant GET example from `execute` — the PUT example already demonstrates the full pattern (zone_id, method, path, body); GET is a strict subset
- Fold "chain multiple calls" batching note into the `execute` description line

## What changed

- `.agents/tools/mcp/cloudflare-code-mode.md`: 95 → 69 lines (27% reduction)

## Knowledge preservation

All content retained: both tools documented, security sandbox note, OAuth + CI/CD setup, when-to-use disambiguation, all URLs and references. No rules or operational knowledge removed — only redundant prose and a trivially-derivable example compressed.

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code execution paths changed.
Self-assessed: agent behaviour unchanged; representative query (list DNS records, enable WAF ruleset) still fully answerable from the doc.

Closes #13357

---
[aidevops.sh](https://aidevops.sh) v3.5.334 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6.