### PR TITLE
GH#13433: tighten autogen.md agent doc

### DIFF
--- a/.agents/tools/ai-orchestration/autogen.md
+++ b/.agents/tools/ai-orchestration/autogen.md
@@ -52,9 +52,8 @@ AUTOGEN_STUDIO_PORT=8081
 
 ## Usage
 
-Common imports (add per-example extras as shown):
-
 ```python
+# Common imports — add per-example extras as shown below
 import asyncio
 from autogen_agentchat.agents import AssistantAgent
 from autogen_ext.models.openai import OpenAIChatCompletionClient
@@ -88,8 +87,6 @@ asyncio.run(main())
 ```
 
 ### Multi-Agent with AgentTool
-
-Compose specialist agents under an orchestrator:
 
 ```python
 from autogen_agentchat.tools import AgentTool


### PR DESCRIPTION
## Summary

- Fold 'Common imports' prose into a code comment — same information, one fewer standalone line
- Remove 'Compose specialist agents under an orchestrator:' prose — the section heading already conveys this
- All code blocks, URLs, commands, and institutional knowledge preserved

## Runtime Testing

Risk level: **Low** — docs-only change, no code or scripts modified. Self-assessed.

## Files Changed

- `.agents/tools/ai-orchestration/autogen.md`: 151 → 148 lines (-3)

Closes #13433

---
[aidevops.sh](https://aidevops.sh) v3.5.341 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 1m and 4,416 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation organization by consolidating redundant standalone text into concise inline comments, enhancing code clarity and readability.
  * Cleaned up unnecessary whitespace and formatting throughout the documentation for a more streamlined and visually organized presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->