### PR TITLE
GH#13431: tighten imessage.md — improve scannability

### DIFF
--- a/.agents/services/communications/imessage.md
+++ b/.agents/services/communications/imessage.md
@@ -1,5 +1,5 @@
 ---
-description: iMessage/BlueBubbles bot integration — BlueBubbles REST API (recommended), imsg CLI (send-only), macOS requirements, messaging features, access control, privacy/security assessment, and aidevops runner dispatch
+description: iMessage/BlueBubbles bot integration — REST API, imsg CLI, macOS setup, access control, security, and aidevops runner dispatch
 mode: subagent
 tools:
   read: true
@@ -30,11 +30,13 @@ tools:
 
 `iPhone/iPad/Mac → iMessage (E2E) → Apple Servers → Messages.app + BlueBubbles Server → REST API/Webhooks → Bot → aidevops dispatch`
 
-Inbound: Messages.app decrypts to local SQLite → BlueBubbles detects via filesystem events → fires webhook → bot responds via REST API. imsg: send-only via AppleScript.
+Messages.app decrypts to local SQLite → BlueBubbles detects via filesystem events → fires webhook → bot responds via REST API. imsg: send-only via AppleScript.
 
 ## BlueBubbles (Recommended)
 
-**Requirements**: macOS 11+, Messages.app signed in, Full Disk Access + Accessibility, persistent GUI session. **Install**: Download DMG from [GitHub Releases](https://github.com/BlueBubblesApp/bluebubbles-server/releases) (Homebrew cask deprecated 2026-09-01). Right-click Open (Gatekeeper), grant Full Disk Access + Accessibility, set password, configure Cloudflare tunnel.
+**Requirements**: macOS 11+, Messages.app signed in, Full Disk Access + Accessibility, persistent GUI session.
+
+**Install**: Download DMG from [GitHub Releases](https://github.com/BlueBubblesApp/bluebubbles-server/releases) (Homebrew cask deprecated 2026-09-01). Right-click Open (Gatekeeper), grant Full Disk Access + Accessibility, set password, configure Cloudflare tunnel.
 
 **Server config**: Port `1234` · Password (header only — query params are logged) · Proxy: Cloudflare · Poll: `1000ms` · **Headless**: `caffeinate -d` to prevent sleep; complete iCloud 2FA interactively first.
 
@@ -111,7 +113,9 @@ check_and_restart "Messages"; check_and_restart "BlueBubbles"
 
 ## Access Control
 
-**API**: Bind to `127.0.0.1`; Cloudflare tunnel for remote; block port 1234 externally. Store password: `aidevops secret set BLUEBUBBLES_PASSWORD`. **Bot-level** (in bot process, not BlueBubbles): allowlist by phone/email · allowlist by group · command-level permissions · rate limiting · `prompt-guard-helper.sh` before passing to AI.
+- **API**: Bind to `127.0.0.1`; Cloudflare tunnel for remote; block port 1234 externally
+- **Secret**: `aidevops secret set BLUEBUBBLES_PASSWORD`
+- **Bot-level** (in bot process, not BlueBubbles): allowlist by phone/email · allowlist by group · command-level permissions · rate limiting · `prompt-guard-helper.sh` before passing to AI
 
 ## Privacy and Security
 
@@ -133,7 +137,11 @@ check_and_restart "Messages"; check_and_restart "BlueBubbles"
 
 ## Limitations
 
-macOS only · Apple ID required · no official Apple API · Messages.app crashes need monitoring · macOS updates may break BlueBubbles · heavy automation may trigger Apple ID lockouts · no @mentions/bot profile/command menus · AppleScript + direct DB reads not Apple-sanctioned (use dedicated Apple ID; no spam)
+- macOS only; Apple ID required; no official Apple API
+- Messages.app crashes need monitoring; macOS updates may break BlueBubbles
+- Heavy automation may trigger Apple ID lockouts
+- No @mentions, bot profile, or command menus
+- AppleScript + direct DB reads not Apple-sanctioned — use dedicated Apple ID; no spam
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Tightens \`.agents/services/communications/imessage.md\` per the simplification-debt scan (GH#13431 regression from PR #13112).

**Classification**: Instruction doc (operational procedures) — content compression approach, not chapter split.

## Changes

- Split dense Requirements/Install paragraph into two separate bold paragraphs
- Convert Access Control run-on sentence to bullet list (3 items)
- Convert Limitations run-on to bullet list (5 items, grouped logically)
- Remove redundant \`Inbound:\` label in Architecture section
- Trim frontmatter description (removed redundant qualifiers)

## Content Preservation

All institutional knowledge preserved: code blocks (4 curl examples), URLs (6), command examples, \`prompt-guard-helper.sh\`, \`runner-helper.sh\`, \`BLUEBUBBLES_PASSWORD\`, \`chat.db\`, ADP, PQ3, matterbridge references.

## Runtime Testing

**Risk level**: Low — documentation only, no code changes.
**Testing**: \`self-assessed\` — agent behaviour unchanged; content verified present via grep.

Closes #13431

---
[aidevops.sh](https://aidevops.sh) v3.5.341 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 5,426 tokens on this as a headless worker.