### PR TITLE
GH#13419: tighten SQL Migrations Workflow agent doc

### DIFF
--- a/.agents/workflows/sql-migrations.md
+++ b/.agents/workflows/sql-migrations.md
@@ -3,26 +3,15 @@ mode: subagent
 ---
 # SQL Migrations Workflow
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 - **Purpose**: Version-controlled database schema changes with rollback support
 - **Declarative**: `schemas/` — desired state, generate migrations automatically
 - **Migrations**: `migrations/` — versioned, timestamped files
 - **Naming**: `{YYYYMMDDHHMMSS}_{action}_{target}.sql`
+- **Workflow**: Edit `schemas/` → generate migration via diff → review → apply locally → commit both
 
-**Critical Rules**:
-
-- NEVER modify pushed/deployed migrations — create a NEW migration instead
-- ALWAYS generate migrations via diff (don't write manually)
-- ALWAYS review generated migrations before committing
-- ALWAYS backup before running migrations in production
-- ONE logical change per migration file
-
-**Workflow**: Edit `schemas/` → generate migration via diff → review → apply locally → commit both schema and migration files
-
-<!-- AI-CONTEXT-END -->
+**Critical Rules**: NEVER modify pushed/deployed migrations (create a NEW one instead). ALWAYS generate via diff, review before committing, backup before production. ONE logical change per file.
 
 ## Directory Structure
 
@@ -49,7 +38,7 @@ project/
 | **Laravel** | `php artisan make:migration` | `php artisan migrate` | `php artisan migrate:rollback --step=1` |
 | **Rails** | `rails g migration` | `rails db:migrate` | `rails db:rollback STEP=1` |
 
-**Dev-only commands:** `drizzle-kit push`/`pull`, `prisma migrate reset`, `php artisan migrate:fresh --seed`.
+**Dev-only:** `drizzle-kit push`/`pull`, `prisma migrate reset`, `php artisan migrate:fresh --seed`.
 
 **Flyway naming:** `V1__create_users.sql`, `V2__add_email.sql`, `R__refresh_views.sql` (repeatable), `U2__undo_add_email.sql` (undo).
 
@@ -86,7 +75,7 @@ DROP INDEX IF EXISTS idx_users_email;
 DROP TABLE IF EXISTS users;
 ```
 
-**Idempotent column addition (PostgreSQL)** — lacks `IF NOT EXISTS` for `ALTER TABLE ADD COLUMN`:
+**Idempotent column addition (PostgreSQL — no `IF NOT EXISTS` for `ALTER TABLE ADD COLUMN`):**
 
 ```sql
 DO $$
@@ -174,14 +163,6 @@ Most tools auto-create a tracking table (e.g., `flyway_schema_history`). **Prefe
 
 If running SQL directly without a migration tool, gate execution on a tracking table -- never replay all files on every invocation.
 
-```sql
--- Bootstrap: create the tracking table once
-CREATE TABLE IF NOT EXISTS schema_migrations (
-    filename   TEXT PRIMARY KEY,
-    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-```
-
 ```bash
 #!/usr/bin/env bash
 # scripts/migrate.sh -- apply only unapplied migrations in order
@@ -219,6 +200,6 @@ SQL
 done
 ```
 
-Key properties: idempotent (`WHERE NOT EXISTS` guard), ordered (lexicographic glob with timestamp-prefixed filenames), auditable (`schema_migrations` records what ran and when), safe filenames (`psql -v "name=$name"` with `:'name'` avoids SQL injection), concurrent-safe (`pg_advisory_xact_lock`), empty-directory safe (`compgen -G` guard).
+Key properties: idempotent (`WHERE NOT EXISTS`), ordered (lexicographic glob with timestamp-prefixed filenames), auditable (`schema_migrations` records what ran and when), safe filenames (`psql -v` with `:'name'` avoids SQL injection), concurrent-safe (`pg_advisory_xact_lock`), empty-directory safe (`compgen -G`).
 
 > **Note:** `\i` inside a transaction applies the migration file and the `INSERT` records it atomically in one psql session. For production, prefer a dedicated migration tool (Flyway, Atlas, Prisma Migrate) which handles locking, ordering, and checksums natively.


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/sql-migrations.md` prose per code-simplifier guidelines. Classified as **instruction doc** (not reference corpus) — prose compressed, knowledge preserved.

## Changes

- Inline Critical Rules into single compact paragraph (saves 7 lines)
- Merge Workflow line into Quick Reference bullet list (saves 2 lines)
- Remove `<!-- AI-CONTEXT-START/END -->` wrapper (no content value, saves 4 lines)
- Tighten 'Dev-only commands:' label to 'Dev-only:' (cleaner)
- Compress idempotent column addition label to single line (saves 1 line)
- Compress key-properties sentence: remove redundant parenthetical expansions (saves 1 line)
- Remove duplicate SQL bootstrap block (already embedded in bash script, saves 7 lines)

## Content Preservation Verification

- **Code blocks**: 6 blocks (12 fences) preserved — text, 3×SQL, YAML, bash
- **Tool commands table**: All 8 tools (Supabase, Drizzle, Prisma, Atlas, migra, Flyway, Laravel, Rails) present
- **Safety tables**: Rollback and Production Safety tables intact
- **Runner script**: Full bash script with all safety properties preserved
- **Critical keywords**: NEVER modify, ALWAYS generate, pg_advisory_xact_lock, WHERE NOT EXISTS, compgen -G, Expand-contract, IRREVERSIBLE, flyway_schema_history, CREATE INDEX CONCURRENTLY, IF NOT EXISTS — all present
- **Line count**: 224 → 205 (net -19 lines, ~8.5% reduction)
- **markdownlint**: 0 errors

## Runtime Testing

- **Risk level**: Low (docs-only change, no code/config/runtime impact)
- **Verification**: `self-assessed` — markdownlint clean, content preservation verified by keyword search and code block count

Closes #13419


---
[aidevops.sh](https://aidevops.sh) v3.5.346 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 4,155 tokens on this as a headless worker.