### PR TITLE
GH#13464: tighten autogen.md (148→140 lines)

### DIFF
--- a/.agents/tools/ai-orchestration/autogen.md
+++ b/.agents/tools/ai-orchestration/autogen.md
@@ -19,16 +19,13 @@ tools:
 
 - **Purpose**: Microsoft multi-agent AI framework — autonomous or human-in-the-loop
 - **License**: MIT (code) / CC-BY-4.0 (docs)
-- **Setup**: `bash .agents/scripts/autogen-helper.sh setup` → edit `~/.aidevops/autogen/.env` → `~/.aidevops/scripts/start-autogen-studio.sh`
-- **Stop/Status**: `~/.aidevops/scripts/stop-autogen-studio.sh`, `autogen-status.sh`
-- **Studio**: http://localhost:8081 | `autogenstudio ui --port 8081 --appdir ./my-app`
-- **Install**: `pip install autogen-agentchat autogen-ext[openai]`
+- **Install**: `pip install autogen-agentchat autogen-ext[openai] autogenstudio`
 - **Architecture**: Core API (message passing, event-driven, distributed) → AgentChat API (rapid prototyping) → Extensions API. Python + .NET.
 - **.NET**: `Microsoft.AutoGen.Contracts` + `Microsoft.AutoGen.Core` — same `AssistantAgent` pattern.
 
 <!-- AI-CONTEXT-END -->
 
-## Installation (Manual)
+## Setup
 
 ```bash
 mkdir -p ~/.aidevops/autogen && cd ~/.aidevops/autogen
@@ -37,7 +34,9 @@ pip install autogen-agentchat autogen-ext[openai] autogenstudio
 autogenstudio ui --port 8081
 ```
 
-## Configuration
+Helper scripts: `autogen-helper.sh setup` → edit `~/.aidevops/autogen/.env` → `start-autogen-studio.sh` | `stop-autogen-studio.sh` | `autogen-status.sh`
+
+Studio UI: http://localhost:8081 | `autogenstudio ui --port 8081 --appdir ./my-app`
 
 `~/.aidevops/autogen/.env`:
 
@@ -52,13 +51,7 @@ AUTOGEN_STUDIO_PORT=8081
 
 ## Usage
 
-All examples assume these common imports (add per-example extras as shown):
-
-```python
-import asyncio
-from autogen_agentchat.agents import AssistantAgent
-from autogen_ext.models.openai import OpenAIChatCompletionClient
-```
+All examples use: `import asyncio`, `from autogen_agentchat.agents import AssistantAgent`, `from autogen_ext.models.openai import OpenAIChatCompletionClient`.
 
 ### Basic Agent
 
@@ -89,8 +82,6 @@ asyncio.run(main())
 
 ### Multi-Agent with AgentTool
 
-Use `AgentTool` to compose specialist agents under an orchestrator (e.g., code reviewer + deployer for aidevops pipelines):
-
 ```python
 from autogen_agentchat.tools import AgentTool
 from autogen_agentchat.ui import Console
@@ -109,7 +100,7 @@ async def main():
 asyncio.run(main())
 ```
 
-## Alternative Model Clients
+### Alternative Model Clients
 
 ```python
 # Ollama (local)
@@ -125,8 +116,6 @@ client = AzureOpenAIChatCompletionClient(
 
 ## Deployment
 
-**Docker:**
-
 ```dockerfile
 FROM python:3.11-slim
 WORKDIR /app
@@ -135,7 +124,7 @@ RUN pip install autogen-agentchat autogen-ext[openai]
 CMD ["python", "main.py"]
 ```
 
-For **FastAPI** or other web frameworks, wrap any agent pattern above in a route handler. Always call `await client.close()` after each request.
+For web frameworks (FastAPI etc.), wrap agent patterns in route handlers. Always call `await client.close()` after each request.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/ai-orchestration/autogen.md` from 151 to 140 lines (-7.3%) by removing redundant prose while preserving all actionable content.

Closes #13464

## Changes

- **Merged Quick Reference entries**: Consolidated Setup/Stop/Studio/Install into single Install line; moved operational details to Setup section
- **Unified Setup section**: Merged separate Installation and Configuration sections into one cohesive Setup section
- **Eliminated redundant imports block**: Replaced 5-line "common imports" code block with 1-line inline reference — each example already shows its additional imports
- **Removed filler prose**: "Compose specialist agents under an orchestrator:" and "**Docker:**" label
- **Demoted Alternative Model Clients**: From H2 to H3 (it's a Usage subsection, not a top-level section)

## Content Preservation

All actionable content preserved:
- ✅ 6 code blocks (bash setup, 3 Python examples, alt clients, Dockerfile)
- ✅ All URLs (docs, GitHub, Discord, Blog, PyPI, migration guide)
- ✅ Troubleshooting table (4 rows)
- ✅ Resources section
- ✅ YAML frontmatter and AI-CONTEXT markers
- ✅ Helper script references (autogen-helper.sh, start/stop/status scripts)

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only, no code logic)
- **Verification**: `self-assessed` — content diff reviewed, all code blocks and URLs confirmed present

---
[aidevops.sh](https://aidevops.sh) v3.5.339 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 2m and 7,122 tokens on this as a headless worker.