### PR TITLE
GH#13463: tighten production-audio.md (151→139 lines)

### DIFF
--- a/.agents/content/production-audio.md
+++ b/.agents/content/production-audio.md
@@ -29,16 +29,12 @@ tools:
 
 ## Voice Production Pipeline
 
-**NEVER feed raw AI video audio directly to ElevenLabs** — it amplifies artifacts.
-
-```text
-AI Video Output → CapCut AI Voice Cleanup → ElevenLabs Transformation → Final Audio
-```
+**NEVER feed raw AI video audio directly to ElevenLabs** — it amplifies artifacts. Always clean first:
 
 | Step | Tool | Purpose |
 |------|------|---------|
-| 1 (FIRST) | CapCut AI Voice Cleanup | Normalize accents/artifacts, remove robotic patterns, clean noise, standardize volume |
-| 2 (SECOND) | ElevenLabs Transformation | Voice cloning, emotional delivery, character consistency |
+| 1 | CapCut AI Voice Cleanup | Normalize accents/artifacts, remove robotic patterns, clean noise, standardize volume |
+| 2 | ElevenLabs Transformation | Voice cloning, emotional delivery, character consistency |
 
 **Alternative**: MiniMax TTS — talking-head content where ElevenLabs is overkill. $5/month for 120 min; 10-second clip for voice clone. See `tools/voice/voice-models.md`.
 
@@ -54,17 +50,11 @@ AI Video Output → CapCut AI Voice Cleanup → ElevenLabs Transformation → Fi
 
 **Source quality**: Single speaker, quiet environment, clear pronunciation. Cloning from existing content → run CapCut cleanup first.
 
-**Voice consistency checklist:**
-
-- [ ] Same voice model across all channel content
-- [ ] Consistent speaking pace (words per minute)
-- [ ] Matching emotional tone for content type
-- [ ] Standardized pronunciation for brand terms
-- [ ] Voice sample updated quarterly
+**Voice consistency**: Same voice model across all channel content. Consistent pace, emotional tone, and brand term pronunciation. Update voice samples quarterly.
 
 ### Emotional Block Cues
 
-Per-word emotion tagging for natural AI speech. TTS engines with emotion support (ElevenLabs, ChatTTS) parse these directly.
+Emotion tags for TTS engines with emotion support (ElevenLabs, ChatTTS):
 
 ```text
 [neutral]Welcome to the channel.[/neutral] [excited]Today we're covering something amazing![/excited] [serious]But first, let's understand the problem.[/serious]
@@ -133,11 +123,9 @@ voice-helper.sh benchmark                  # Test component speeds
 
 | Service | Details | CLI |
 |---------|---------|-----|
-| ElevenLabs | Voice cloning from 3-5 min, 29 languages, 100+ voices, emotional control | `voice-pipeline-helper.sh [transform\|tts\|voices\|clone]` |
-| CapCut-equivalent (local ffmpeg) | Noise reduction, high-pass, de-essing, loudness normalization | `voice-pipeline-helper.sh cleanup <audio> [output] [target-lufs]` |
-| Edge TTS (Microsoft, free) | 400+ voices, 100+ languages, no API key | Used by `voice-helper.sh` |
-
-For advanced use cases (custom LLMs, server/client deployment, phone integration), see `tools/voice/speech-to-speech.md`.
+| ElevenLabs | Voice cloning (3-5 min sample), 29 languages, emotional control | `voice-pipeline-helper.sh [transform\|tts\|voices\|clone]` |
+| Local ffmpeg | Noise reduction, high-pass, de-essing, loudness normalization | `voice-pipeline-helper.sh cleanup <audio> [output] [target-lufs]` |
+| Edge TTS (free) | 400+ voices, 100+ languages, no API key | Used by `voice-helper.sh` |
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/content/production-audio.md` from 151 to 139 lines (~8% reduction)
- Remove redundant pipeline code block (table already conveys the same flow)
- Compress voice consistency checklist (5 checkbox items → 1-line summary)
- Trim wordy intro sentences, verbose service names, and duplicate cross-references
- All actionable content preserved: tables, code blocks, CLI commands, key rules, See Also links

## What was removed

| Removed | Reason |
|---------|--------|
| Pipeline code block (`AI Video Output → ...`) | Redundant with the step table directly below it |
| `(FIRST)`/`(SECOND)` step labels | Implicit in step numbers + warning sentence |
| Voice consistency checklist (5 items) | Compressed to 1-line prose — all items preserved |
| "Per-word emotion tagging" intro sentence | Replaced with shorter "Emotion tags for..." |
| Verbose service names | "CapCut-equivalent (local ffmpeg)" → "Local ffmpeg", "Edge TTS (Microsoft, free)" → "Edge TTS (free)" |
| Duplicate `speech-to-speech.md` pointer | Already in Quick Reference and See Also |

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — content diff reviewed, all actionable content preserved

Closes #13463

---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 1m and 4,949 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined voice production guidance with clearer, simplified instructions.
  * Consolidated voice consistency requirements into essential elements.
  * Updated voice tools descriptions for accuracy and clarity.
  * Refined emotional tagging guidance for improved TTS compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->