### PR TITLE
GH#13453: tighten google-chat.md (169→162 lines)

### DIFF
--- a/.agents/services/communications/google-chat.md
+++ b/.agents/services/communications/google-chat.md
@@ -13,7 +13,7 @@ tools: { read: true, bash: true }
 - **Mode**: HTTP endpoint (Google POSTs events) — not WebSocket/polling
 - **Config**: `~/.config/aidevops/google-chat-bot.json` (600 perms)
 - **Data**: `~/.aidevops/.agent-workspace/google-chat-bot/`
-- **Auth**: SA JWT (outbound); Google-signed bearer (inbound)
+- **Auth**: Service account JWT (outbound); Google-signed bearer (inbound)
 - **Requires**: Google Workspace, GCP project, public HTTPS URL, Node.js >= 18, jq
 - **Setup**: `google-chat-helper.sh setup` (interactive wizard)
 - **Privacy**: No E2E encryption; Google retains all messages; Gemini may train on data unless DPA configured. See [Privacy and Security](#privacy-and-security).
@@ -101,7 +101,7 @@ await (await auth.getClient()).request({ url: "https://chat.googleapis.com/v1/sp
 
 Payload fields: `message.argumentText` (prompt, mention stripped), `user.email` (ACL), `space.name` (runner mapping), `message.thread.name` (threading).
 
-**Sync (< 30s)**: Return `{ "text": "..." }` in HTTP response. **Async (> 30s)**: Return `cardsV2` ack, then POST full response to `spaces/SPACE_ID/messages` with bearer token, `thread.name`, `threadReply: true`.
+**Sync (< 30s)**: Return `{ "text": "..." }` in HTTP response. **Async (> 30s)**: Return `cardsV2` ack, then POST full response to `spaces/SPACE_ID/messages` with `Authorization: Bearer <token>`, `thread.name`, `threadReply: true`.
 
 **Card v2**: `cardsV2[].card` with `header`/`sections[].widgets`. Limits: 1 card/msg, 100 sections, 100 widgets/section, 4096 chars/widget, 40 chars/button. Public HTTPS image URLs only. [Reference](https://developers.google.com/workspace/chat/api/reference/rest/v1/cards).
 

--- a/.agents/services/communications/google-chat.md
+++ b/.agents/services/communications/google-chat.md
@@ -13,18 +13,14 @@ tools: { read: true, bash: true }
 - **Mode**: HTTP endpoint (Google POSTs events) — not WebSocket/polling
 - **Config**: `~/.config/aidevops/google-chat-bot.json` (600 perms)
 - **Data**: `~/.aidevops/.agent-workspace/google-chat-bot/`
-- **Auth**: Service account JWT (outbound); Google-signed bearer token (inbound)
+- **Auth**: SA JWT (outbound); Google-signed bearer (inbound)
 - **Requires**: Google Workspace, GCP project, public HTTPS URL, Node.js >= 18, jq
-
-```bash
-google-chat-helper.sh setup  # Interactive wizard
-```
-
-**Privacy**: No E2E encryption. Google retains all messages; admins have full read access. Gemini AI may train on workspace data unless DPA configured. See [Privacy and Security](#privacy-and-security).
+- **Setup**: `google-chat-helper.sh setup` (interactive wizard)
+- **Privacy**: No E2E encryption; Google retains all messages; Gemini may train on data unless DPA configured. See [Privacy and Security](#privacy-and-security).
 
 <!-- AI-CONTEXT-END -->
 
-**Flow**: `Google Chat → HTTPS → Bot (:8443)` → verify token → parse event → check perms → `runner-helper.sh dispatch` → AI session → Card v2 or text response
+**Flow**: `Google Chat → HTTPS → Bot (:8443)` → verify token → parse → ACL check → `runner-helper.sh dispatch` → AI session → Card v2/text response
 
 ## Setup
 
@@ -43,7 +39,7 @@ chmod 600 ~/.config/aidevops/google-chat-sa-key.json
 
 ### Step 2: Configure Chat App
 
-Cloud Console > APIs & Services > Google Chat API > Configuration: set HTTP endpoint URL, enable "Receive 1:1 messages" + "Join spaces and group conversations", set Authentication Audience to endpoint URL.
+Cloud Console > APIs & Services > Google Chat API > Configuration: set HTTP endpoint URL, enable "Receive 1:1 messages" + "Join spaces and group conversations", set auth audience to endpoint URL.
 
 ### Step 3: Public URL
 
@@ -72,20 +68,21 @@ Cloud Console > APIs & Services > Google Chat API > Configuration: set HTTP endp
 
 ## Authentication
 
-### Inbound (Google to Bot)
+### Inbound (Google → Bot)
 
 > **CRITICAL**: Verify Google's bearer token on every request — without this, anyone can send forged events.
 
 ```typescript
 import { createRemoteJWKSet, jwtVerify } from "jose";
 const JWKS = createRemoteJWKSet(new URL("https://www.googleapis.com/service_accounts/v1/jwk/chat@system.gserviceaccount.com"));
+// Validate: iss = chat@system.gserviceaccount.com, aud = project number or endpoint URL
 async function verifyGoogleChatToken(token: string, audience: string): Promise<boolean> {
   await jwtVerify(token, JWKS, { issuer: "chat@system.gserviceaccount.com", audience });
   return true;
-} // Validate: iss = chat@system.gserviceaccount.com, aud = project number or endpoint URL
+}
 ```
 
-### Outbound (Bot to Google)
+### Outbound (Bot → Google)
 
 ```typescript
 import { GoogleAuth } from "google-auth-library";
@@ -102,9 +99,9 @@ await (await auth.getClient()).request({ url: "https://chat.googleapis.com/v1/sp
 | `MESSAGE` | User mentions bot or DMs | Parse prompt, dispatch runner |
 | `CARD_CLICKED` | Card button click | Handle card action |
 
-Payload: `message.argumentText` (prompt, mention stripped), `user.email` (ACL), `space.name` (runner mapping), `message.thread.name` (threading).
+Payload fields: `message.argumentText` (prompt, mention stripped), `user.email` (ACL), `space.name` (runner mapping), `message.thread.name` (threading).
 
-**Sync (< 30s)**: Return `{ "text": "..." }` in HTTP response body. **Async (> 30s)**: Return `cardsV2` ack immediately, then POST full response via `https://chat.googleapis.com/v1/spaces/SPACE_ID/messages` with `Authorization: Bearer <token>`, `thread.name`, `threadReply: true`.
+**Sync (< 30s)**: Return `{ "text": "..." }` in HTTP response. **Async (> 30s)**: Return `cardsV2` ack, then POST full response to `spaces/SPACE_ID/messages` with bearer token, `thread.name`, `threadReply: true`.
 
 **Card v2**: `cardsV2[].card` with `header`/`sections[].widgets`. Limits: 1 card/msg, 100 sections, 100 widgets/section, 4096 chars/widget, 40 chars/button. Public HTTPS image URLs only. [Reference](https://developers.google.com/workspace/chat/api/reference/rest/v1/cards).
 
@@ -116,27 +113,27 @@ google-chat-helper.sh mappings   # list all
 google-chat-helper.sh unmap 'spaces/AAAA1234'
 ```
 
-DMs use `defaultRunner`; unconfigured = help message. **Permission check order**: token verification → domain → allowlist → space mapping. Domain control: Admin Console > Apps > Google Workspace > Google Chat > Chat apps settings.
+DMs use `defaultRunner`; unconfigured = help message. **ACL order**: token verification → domain → allowlist → space mapping. Domain control: Admin Console > Apps > Google Workspace > Google Chat > Chat apps settings.
 
 ## Operations
 
 ```bash
-google-chat-helper.sh start --daemon  # background
-google-chat-helper.sh start           # foreground (debug)
+google-chat-helper.sh start --daemon   # background
+google-chat-helper.sh start            # foreground (debug)
 google-chat-helper.sh stop && google-chat-helper.sh status
 google-chat-helper.sh logs [--follow] [--tail 200]
-google-chat-helper.sh test code-reviewer "Review src/auth.ts"    # test dispatch
-google-chat-helper.sh test-event message "Test message from CLI" # test event
-google-chat-helper.sh test-auth                                  # verify token
+google-chat-helper.sh test code-reviewer "Review src/auth.ts"     # dispatch test
+google-chat-helper.sh test-event message "Test message from CLI"  # event test
+google-chat-helper.sh test-auth                                   # token verify
 ```
 
-**Health**: `GET /health` → `{"status":"ok","uptime":...,"spaces":N}`. **Runners**: `runner-helper.sh create|edit <name>`
+**Health**: `GET /health` → `{"status":"ok","uptime":...,"spaces":N}` · **Runners**: `runner-helper.sh create|edit <name>`
 
 ## Privacy and Security
 
 No E2E encryption (TLS in transit only). Google retains all messages; admins have full read access. Retention: Google Vault. **Gemini AI**: workspace data may train AI unless DPA configured — verify Admin Console > Additional Google services > Gemini and [Workspace DPA](https://workspace.google.com/terms/dpa_terms.html) before deploying with sensitive data.
 
-**Bot security**: SA key 600 perms, never commit | `allowedUsers`: restrict in production | Scan inbound with `prompt-guard-helper.sh`, outbound for credential patterns | Reverse proxy (Caddy/Cloudflare) for TLS | Log events, redact sensitive content | FCM: Google knows when users receive Chat push notifications.
+**Bot security**: SA key 600 perms, never commit · `allowedUsers` allowlist in production · Scan inbound (`prompt-guard-helper.sh`) and outbound (credential patterns) · Reverse proxy for TLS · Log events, redact sensitive content · FCM: Google sees push notification metadata.
 
 ## Limitations
 
@@ -153,9 +150,8 @@ No E2E encryption (TLS in transit only). Google retains all messages; admins hav
 
 | Issue | Solution |
 |-------|----------|
-| Not receiving events | Verify public URL accessible; check Chat API config |
-| 401 Unauthorized | Verify SA key valid; check `chat.bot` scope |
-| Token verification fails | `verifyGoogleTokens: true`; check clock sync (JWT expiry) |
+| Not receiving events | Verify public URL reachable; check Chat API config |
+| 401 / token verification | SA key valid? `chat.bot` scope? `verifyGoogleTokens: true`? Clock sync (JWT expiry)? |
 | Bot not visible | Check Chat app visibility in Cloud Console |
 | Async messages fail | Verify `chat.bot` scope; check space name format |
 | Cards not rendering | Validate Card v2 JSON; check widget types |
@@ -163,7 +159,4 @@ No E2E encryption (TLS in transit only). Google retains all messages; admins hav
 
 ## Related
 
-- `services/communications/matrix-bot.md` (Matrix, E2E) | `simplex.md` (SimpleX) | `matterbridge.md` (bridge, 40+ platforms)
-- `tools/security/opsec.md` (trust matrix) | `prompt-injection-defender.md` (injection scanning)
-- `tools/ai-assistants/headless-dispatch.md` | `scripts/runner-helper.sh`
-- [Chat API](https://developers.google.com/workspace/chat/api/reference/rest) | [Card v2](https://developers.google.com/workspace/chat/api/reference/rest/v1/cards)
+`matrix-bot.md` (E2E) · `simplex.md` · `matterbridge.md` (40+ platforms) · `opsec.md` (trust matrix) · `prompt-injection-defender.md` · `headless-dispatch.md` · `runner-helper.sh` · [Chat API](https://developers.google.com/workspace/chat/api/reference/rest) · [Card v2](https://developers.google.com/workspace/chat/api/reference/rest/v1/cards)


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/communications/google-chat.md` from 169→162 lines (4% reduction)
- Compressed redundant prose while preserving all actionable content: code blocks, commands, URLs, tables, security rules
- Fresh attempt after PR #13474 was closed due to merge conflicts

## Changes

- Inlined `google-chat-helper.sh setup` into Quick Reference bullet (removed standalone code block)
- Shortened auth descriptions: "Service account JWT" → "SA JWT", "Google-signed bearer token" → "Google-signed bearer"
- Compressed flow description and privacy summary
- Merged troubleshooting rows: 401 Unauthorized + token verification → single row
- Compressed Related section from multi-line bullets to single-line dot-separated
- Used arrow notation (→) consistently in auth section headings
- Shortened verbose phrases throughout

## Verification

- All helper commands preserved (`google-chat-helper.sh` subcommands verified via diff)
- All code blocks preserved (gcloud setup, TypeScript auth inbound/outbound, space mapping, operations)
- All URLs preserved (googleapis JWKS, Chat API, Card v2, Workspace DPA)
- All security rules preserved (token verification, SA key perms, prompt-guard, FCM metadata)
- markdownlint: 0 errors
- Risk: Low (docs-only, agent prompt file)

## Runtime Testing

- **Level**: `self-assessed` (docs/agent prompt — low risk)
- No runtime testing required per testing gate

Closes #13453

---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 8,235 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Google Chat service documentation with clearer, standardized terminology
  * Simplified authentication descriptions and flow labels for improved understanding
  * Clarified messaging behavior and authorization process documentation
  * Enhanced readability of setup instructions and troubleshooting sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->