### PR TITLE
GH#13385: tighten stagehand-python.md (136→128 lines)

### DIFF
--- a/.agents/tools/browser/stagehand-python.md
+++ b/.agents/tools/browser/stagehand-python.md
@@ -35,18 +35,13 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Setup
-
-```bash
-bash .agents/scripts/stagehand-python-helper.sh setup
-```
-
 ## Usage
 
 ```python
 import asyncio
 from stagehand import StagehandConfig, Stagehand
 from pydantic import BaseModel, Field
+from typing import List
 
 class PageData(BaseModel):
     title: str = Field(..., description="Page title")
@@ -83,9 +78,6 @@ buttons = await page.observe("find all buttons")  # filtered
 ### Extract
 
 ```python
-from pydantic import BaseModel, Field
-from typing import List
-
 class Product(BaseModel):
     name: str = Field(..., description="Product name")
     price: float = Field(..., description="Price in USD")
@@ -124,7 +116,7 @@ BROWSERBASE_PROJECT_ID=your_browserbase_project_id_here
 ## MCP Integration
 
 ```bash
-bash .agents/scripts/setup-mcp-integrations.sh stagehand-python  # pass via integrations=[] in agent()
+bash .agents/scripts/setup-mcp-integrations.sh stagehand-python
 ```
 
 ## Resources


### PR DESCRIPTION
## Summary

- Remove redundant `## Setup` section — the helper command is already in the Quick Reference table
- Consolidate `from typing import List` import into the main Usage block; remove duplicate imports from the Extract section
- Remove misleading inline comment from MCP integration command (`# pass via integrations=[] in agent()` implied incorrect usage)

## Verification

- All code blocks, URLs, commands, and actionable content preserved
- `wc -l`: 136 → 128 lines (6% reduction)
- `diff` confirms only redundant/duplicate content removed — no knowledge loss

Closes #13385

---
[aidevops.sh](https://aidevops.sh) v3.5.339 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 4,063 tokens on this as a headless worker.