### PR TITLE
GH#13464: tighten autogen.md (148→140 lines)

### DIFF
--- a/.agents/tools/ai-orchestration/autogen.md
+++ b/.agents/tools/ai-orchestration/autogen.md
@@ -19,16 +19,13 @@ tools:
 
 - **Purpose**: Microsoft multi-agent AI framework — autonomous or human-in-the-loop
 - **License**: MIT (code) / CC-BY-4.0 (docs)
-- **Setup**: `bash .agents/scripts/autogen-helper.sh setup` → edit `~/.aidevops/autogen/.env` → `~/.aidevops/scripts/start-autogen-studio.sh`
-- **Stop/Status**: `~/.aidevops/scripts/stop-autogen-studio.sh`, `autogen-status.sh`
-- **Studio**: http://localhost:8081 | `autogenstudio ui --port 8081 --appdir ./my-app`
-- **Install**: `pip install autogen-agentchat autogen-ext[openai]`
+- **Install**: `pip install autogen-agentchat autogen-ext[openai] autogenstudio`
 - **Architecture**: Core API (message passing, event-driven, distributed) → AgentChat API (rapid prototyping) → Extensions API. Python + .NET.
 - **.NET**: `Microsoft.AutoGen.Contracts` + `Microsoft.AutoGen.Core` — same `AssistantAgent` pattern.
 
 <!-- AI-CONTEXT-END -->
 
-## Installation
+## Setup
 
 ```bash
 mkdir -p ~/.aidevops/autogen && cd ~/.aidevops/autogen
@@ -37,7 +34,9 @@ pip install autogen-agentchat autogen-ext[openai] autogenstudio
 autogenstudio ui --port 8081
 ```
 
-## Configuration
+Helper scripts: `autogen-helper.sh setup` → edit `~/.aidevops/autogen/.env` → `start-autogen-studio.sh` | `stop-autogen-studio.sh` | `autogen-status.sh`
+
+Studio UI: http://localhost:8081 | `autogenstudio ui --port 8081 --appdir ./my-app`
 
 `~/.aidevops/autogen/.env`:
 
@@ -52,12 +51,7 @@ AUTOGEN_STUDIO_PORT=8081
 
 ## Usage
 
-```python
-# Common imports — add per-example extras as shown below
-import asyncio
-from autogen_agentchat.agents import AssistantAgent
-from autogen_ext.models.openai import OpenAIChatCompletionClient
-```
+All examples use: `import asyncio`, `from autogen_agentchat.agents import AssistantAgent`, `from autogen_ext.models.openai import OpenAIChatCompletionClient`.
 
 ### Basic Agent
 
@@ -106,7 +100,7 @@ async def main():
 asyncio.run(main())
 ```
 
-## Alternative Model Clients
+### Alternative Model Clients
 
 ```python
 # Ollama (local)
@@ -121,8 +115,6 @@ client = AzureOpenAIChatCompletionClient(
 ```
 
 ## Deployment
-
-**Docker:**
 
 ```dockerfile
 FROM python:3.11-slim


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/ai-orchestration/autogen.md` from 148 to 140 lines (-5.4%) by removing redundant prose while preserving all actionable content.

Closes #13464

## Changes

- **Merged Quick Reference entries**: Consolidated Setup/Stop/Studio/Install into single Install line; moved operational details to Setup section
- **Unified Setup section**: Merged separate Installation and Configuration sections into one cohesive Setup section
- **Eliminated redundant imports block**: Replaced 5-line common imports code block with 1-line inline reference
- **Removed filler prose**: "**Docker:**" label before Dockerfile block
- **Demoted Alternative Model Clients**: From H2 to H3 (it's a Usage subsection, not a top-level section)

## Content Preservation

All actionable content preserved:
- 6 code blocks (bash setup, 3 Python examples, alt clients, Dockerfile)
- All URLs (docs, GitHub, Discord, Blog, PyPI, migration guide)
- Troubleshooting table (4 rows)
- Resources section
- YAML frontmatter and AI-CONTEXT markers
- Helper script references (autogen-helper.sh, start/stop/status scripts)

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only, no code logic)
- **Verification**: `self-assessed` — content diff reviewed, all code blocks and URLs confirmed present

---
[aidevops.sh](https://aidevops.sh) v3.5.339 plugin for [Claude Code](https://claude.ai/code) with claude-opus-4-6.