### PR TITLE
GH#13396: tighten ddos-patterns.md (128→110 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md
@@ -25,16 +25,10 @@ Bursty API endpoints need lower sensitivity than static pages.
 const config = {
   description: "Route-specific protection",
   rules: [
-    {
-      expression: "not http.request.uri.path matches \"^/api/\"",
-      action: "execute",
-      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "default", action: "block" } },
-    },
-    {
-      expression: "http.request.uri.path matches \"^/api/\"",
-      action: "execute",
-      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "low", action: "managed_challenge" } },
-    },
+    { expression: "not http.request.uri.path matches \"^/api/\"",
+      action: "execute", action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "default", action: "block" } } },
+    { expression: "http.request.uri.path matches \"^/api/\"",
+      action: "execute", action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "low", action: "managed_challenge" } } },
   ],
 };
 ```
@@ -44,25 +38,24 @@ const config = {
 Gradual rollout: MONITORING (week 1) → LOW (week 2) → MEDIUM (week 3) → HIGH (week 4).
 
 ```typescript
-enum ProtectionLevel { MONITORING = "monitoring", LOW = "low", MEDIUM = "medium", HIGH = "high" }
+type ProtectionLevel = "monitoring" | "low" | "medium" | "high";
 
 const levelConfig: Record<ProtectionLevel, { action: string; sensitivity: string }> = {
-  [ProtectionLevel.MONITORING]: { action: "log", sensitivity: "eoff" },
-  [ProtectionLevel.LOW]:        { action: "managed_challenge", sensitivity: "low" },
-  [ProtectionLevel.MEDIUM]:     { action: "managed_challenge", sensitivity: "medium" },
-  [ProtectionLevel.HIGH]:       { action: "block", sensitivity: "default" },
+  monitoring: { action: "log", sensitivity: "eoff" },
+  low:        { action: "managed_challenge", sensitivity: "low" },
+  medium:     { action: "managed_challenge", sensitivity: "medium" },
+  high:       { action: "block", sensitivity: "default" },
 };
 
 async function setProtectionLevel(zoneId: string, level: ProtectionLevel, managedRulesetId: string, apiToken: string) {
   const { action, sensitivity } = levelConfig[level];
-  return fetch(/* PUT zones/${zoneId}/rulesets/phases/ddos_l7/entrypoint */, {
+  // PUT zones/${zoneId}/rulesets/phases/ddos_l7/entrypoint
+  return fetch(`https://api.cloudflare.com/client/v4/zones/${zoneId}/rulesets/phases/ddos_l7/entrypoint`, {
     method: "PUT",
     headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/json" },
     body: JSON.stringify({
-      description: `DDoS protection level: ${level}`,
       rules: [{
-        expression: "true",
-        action: "execute",
+        expression: "true", action: "execute",
         action_parameters: { id: managedRulesetId, overrides: { action, sensitivity_level: sensitivity } },
       }],
     }),
@@ -72,26 +65,24 @@ async function setProtectionLevel(zoneId: string, level: ProtectionLevel, manage
 
 ## Dynamic Response
 
-Worker that auto-escalates on attack detection, de-escalates via cron when quiet.
+Worker that auto-escalates on attack detection, de-escalates via scheduled cron when quiet.
 
 ```typescript
-// Env: CLOUDFLARE_API_TOKEN, ZONE_ID, KV_NAMESPACE (KVNamespace)
+// Bindings: CLOUDFLARE_API_TOKEN, ZONE_ID, KV_NAMESPACE (KVNamespace)
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    if (request.url.includes("/attack-detected")) {
-      await env.KV_NAMESPACE.put(`attack:${Date.now()}`, await request.text(), { expirationTtl: 86400 });
-      if ((await getRecentAttacks(env.KV_NAMESPACE)).length > 5) {
-        await increaseProtection(env.ZONE_ID, "managed-ruleset-id", env.CLOUDFLARE_API_TOKEN);
-        return new Response("Protection increased", { status: 200 });
-      }
+  async fetch(req: Request, env: Env): Promise<Response> {
+    if (!req.url.includes("/attack-detected")) return new Response("OK");
+    await env.KV_NAMESPACE.put(`attack:${Date.now()}`, await req.text(), { expirationTtl: 86400 });
+    if ((await getRecentAttacks(env.KV_NAMESPACE)).length > 5) {
+      await increaseProtection(env.ZONE_ID, "managed-ruleset-id", env.CLOUDFLARE_API_TOKEN);
+      return new Response("Protection increased", { status: 200 });
     }
     return new Response("OK");
   },
 
   async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
-    if ((await getRecentAttacks(env.KV_NAMESPACE)).length === 0) {
+    if ((await getRecentAttacks(env.KV_NAMESPACE)).length === 0)
       await normalizeProtection(env.ZONE_ID, "managed-ruleset-id", env.CLOUDFLARE_API_TOKEN);
-    }
   },
 };
 ```
@@ -104,21 +95,12 @@ Up to 10 rules with different conditions per zone.
 const config = {
   description: "Multi-tier DDoS protection",
   rules: [
-    { // Unknown traffic — strictest
-      expression: "not ip.src in $known_ips and not cf.bot_management.score gt 30",
-      action: "execute",
-      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "default", action: "block" } },
-    },
-    { // Verified bots — medium
-      expression: "cf.bot_management.verified_bot",
-      action: "execute",
-      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "medium", action: "managed_challenge" } },
-    },
-    { // Trusted IPs — low
-      expression: "ip.src in $trusted_ips",
-      action: "execute",
-      action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "low" } },
-    },
+    { expression: "not ip.src in $known_ips and not cf.bot_management.score gt 30", // unknown — strictest
+      action: "execute", action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "default", action: "block" } } },
+    { expression: "cf.bot_management.verified_bot", // verified bots — medium
+      action: "execute", action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "medium", action: "managed_challenge" } } },
+    { expression: "ip.src in $trusted_ips", // trusted — low
+      action: "execute", action_parameters: { id: managedRulesetId, overrides: { sensitivity_level: "low" } } },
   ],
 };
 ```


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md` from 128 to 110 lines (14% reduction) — regression re-simplification per GH#13396.

Closes #13396

## Changes

- **Route-Specific Sensitivity**: Collapsed multi-line rule objects to two-line `expression` + `action/action_parameters` format
- **Progressive Enhancement**: Replaced `enum ProtectionLevel` with union type; simplified `levelConfig` keys from `[ProtectionLevel.X]` to plain strings; inlined `description` removal from `JSON.stringify` body (redundant in API call); added actual Cloudflare API URL
- **Dynamic Response**: Early-return guard clause instead of nested `if`; renamed `request` → `req`; collapsed `scheduled` handler body
- **Multi-Rule Tiered Protection**: Collapsed multi-line rule objects to two-line format with inline comments

## Content Preservation

- All 5 code blocks preserved
- All 6 section headers preserved
- Cross-references to `waf-patterns.md`, `bot-management-patterns.md` preserved
- All 8 `managedRulesetId` references preserved
- API endpoint `ddos_l7/entrypoint` preserved (3 occurrences)
- No task IDs, URLs, or knowledge removed

## Runtime Testing

- **Risk**: Low (docs/agent prompt only)
- **Level**: `self-assessed`


---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 7,836 tokens on this as a headless worker.
