### PR TITLE
GH#13352: tighten realtimekit-patterns.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2323,7 +2323,7 @@
     },
     ".agents/services/communications/imessage.md": {
       "hash": "6739eea3f16ee84c8d647388816d022bb26c6a22",
-      "at": "2026-03-30T01:16:31Z",
+      "at": "2026-03-30T00:32:20Z",
       "pr": 13468
     },
     ".agents/tools/context/github-search.md": {
@@ -2353,7 +2353,7 @@
     },
     ".agents/content/production-audio.md": {
       "hash": "e25e6c20e39bf0e3ddecacd21aa5c1425aa997ef",
-      "at": "2026-03-30T01:16:27Z",
+      "at": "2026-03-30T00:32:17Z",
       "pr": 13478
     },
     ".agents/workflows/bug-fixing.md": {
@@ -2638,7 +2638,7 @@
     },
     ".agents/tools/code-review/security-analysis.md": {
       "hash": "81663c87a7964c1938d704dd3698d51a4910621a",
-      "at": "2026-03-30T01:16:28Z",
+      "at": "2026-03-30T00:32:18Z",
       "pr": 13467
     },
     ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
@@ -2648,12 +2648,12 @@
     },
     ".agents/tools/architecture/feature-slicing-skill/migration.md": {
       "hash": "b399eacef76e87bedfd8da058f9c0b1707ffde13",
-      "at": "2026-03-30T01:16:29Z",
+      "at": "2026-03-30T00:32:19Z",
       "pr": 13466
     },
     ".agents/marketing-sales/cro-chapters.md": {
       "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
-      "at": "2026-03-30T00:22:02Z",
+      "at": "2026-03-30T00:32:32Z",
       "pr": 13457
     },
     ".agents/tools/browser/browser-automation.md": {

--- a/.agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md
@@ -59,7 +59,7 @@ const switchCamera = async (deviceId: string) => {
 };
 ```
 
-### Chat Component (React)
+### Chat & Custom Hook (React)
 
 ```typescript
 function ChatComponent({ meeting }) {
@@ -77,11 +77,7 @@ function ChatComponent({ meeting }) {
     <button onClick={send}>Send</button>
   </div>;
 }
-```
 
-### Custom Hook
-
-```typescript
 export function useMeeting(authToken: string) {
   const [meeting, setMeeting] = useState<RealtimeKitClient | null>(null);
   const [joined, setJoined] = useState(false);
@@ -101,9 +97,8 @@ export function useMeeting(authToken: string) {
 
 ## Backend Integration
 
-### Token Generation (Express)
-
 ```typescript
+// Express — token generation
 app.post('/api/join-meeting', async (req, res) => {
   const { meetingId, userName, presetName } = req.body;
   const response = await fetch(
@@ -117,11 +112,8 @@ app.post('/api/join-meeting', async (req, res) => {
   const data = await response.json();
   res.json({ authToken: data.result.authToken });
 });
-```
 
-### Workers Integration
-
-```typescript
+// Workers — meeting creation
 export interface Env { CLOUDFLARE_API_TOKEN: string; CLOUDFLARE_ACCOUNT_ID: string; REALTIMEKIT_APP_ID: string; }
 
 export default {
@@ -140,11 +132,11 @@ export default {
 
 ## Best Practices
 
-**Security**: Never expose API tokens client-side — generate participant tokens server-side only. Fresh token per session (use refresh endpoint if expired). Use `custom_participant_id` to map to your user system.
-
-**Performance**: Event-driven updates — listen to events, don't poll. Use `toArray()` only when needed. Set appropriate resolution/bitrate limits via `mediaConfiguration`. Enable `autoSwitchAudioDevice`.
-
-**Architecture**: Separate Apps for staging vs production. Create presets at App level, reuse across meetings. Backend generates tokens, frontend receives via authenticated endpoint.
+| Area | Guidance |
+|------|----------|
+| Security | Never expose API tokens client-side — server-side token generation only. Fresh token per session (refresh endpoint if expired). `custom_participant_id` maps to your user system |
+| Performance | Event-driven updates, don't poll. `toArray()` only when needed. Set resolution/bitrate via `mediaConfiguration`. Enable `autoSwitchAudioDevice` |
+| Architecture | Separate Apps for staging vs production. Presets at App level, reuse across meetings. Backend generates tokens, frontend receives via authenticated endpoint |
 
 ## In This Reference
 


### PR DESCRIPTION
## Summary

- Merge Chat Component and Custom Hook into single code block (eliminates redundant section headers and code fences)
- Merge Express and Workers backend examples into single code block with inline comments
- Convert Best Practices prose paragraphs into scannable table format

152 → 144 lines. All code blocks, URLs, API patterns, and best practice guidance preserved.

Closes #13352

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, content preservation verified

---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 2m and 6,753 tokens on this as a headless worker.