### PR TITLE
GH#13206: tighten wrangler-patterns.md (149→140 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
@@ -1,22 +1,14 @@
 # Wrangler Development Patterns
 
-Common workflows and best practices.
-
-## New Worker Project
+## New Worker / Local Dev
 
 ```bash
 wrangler init my-worker && cd my-worker
-wrangler dev              # Develop locally
-wrangler deploy           # Deploy
-```
-
-## Local Development
-
-```bash
 wrangler dev              # Local (fast, limited accuracy)
 wrangler dev --remote     # Remote (slower, production-accurate)
 wrangler dev --env staging
 wrangler dev --port 8787
+wrangler deploy
 ```
 
 ## Secrets
@@ -24,7 +16,6 @@ wrangler dev --port 8787
 **Never commit secrets.** Use `wrangler secret put` for production, `.dev.vars` for local.
 
 ```bash
-# Production
 echo "secret-value" | wrangler secret put SECRET_KEY
 wrangler secret list
 wrangler secret delete SECRET_KEY
@@ -41,16 +32,16 @@ SECRET_KEY=local-dev-key
 ```bash
 wrangler kv namespace create MY_KV
 wrangler kv namespace create MY_KV --preview
-# Add to wrangler.jsonc: { "binding": "MY_KV", "id": "abc123" }
 wrangler deploy
 ```
+
+Add to `wrangler.jsonc`: `{ "binding": "MY_KV", "id": "abc123" }`
 
 ## Adding D1
 
 ```bash
 wrangler d1 create my-db
 wrangler d1 migrations create my-db "initial_schema"
-# Edit migration file, then:
 wrangler d1 migrations apply my-db --local
 wrangler deploy
 wrangler d1 migrations apply my-db --remote
@@ -81,9 +72,9 @@ await worker.dispose();
 
 ```bash
 wrangler tail                 # Real-time logs
-wrangler tail --status error  # Filter errors
+wrangler tail --status error
 wrangler tail --env production
-wrangler whoami               # Check auth
+wrangler whoami
 ```
 
 ## Version Control
@@ -131,7 +122,7 @@ export default {
 // KV caching
 const cached = await env.CACHE.get("key", { cacheTtl: 3600 });
 
-// Batch DB
+// Batch D1
 await env.DB.batch([
   env.DB.prepare("SELECT * FROM users"),
   env.DB.prepare("SELECT * FROM posts")
@@ -145,5 +136,5 @@ return new Response(data, {
 
 ## See Also
 
-- [README.md](./README.md) - Commands
-- [gotchas.md](./gotchas.md) - Issues
+- [wrangler.md](./wrangler.md) - Commands
+- [wrangler-gotchas.md](./wrangler-gotchas.md) - Issues

--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
@@ -35,7 +35,11 @@ wrangler kv namespace create MY_KV --preview
 wrangler deploy
 ```
 
-Add to `wrangler.jsonc`: `{ "binding": "MY_KV", "id": "abc123" }`
+Add to `wrangler.jsonc`:
+
+```jsonc
+{ "binding": "MY_KV", "id": "abc123", "preview_id": "def456" }
+```
 
 ## Adding D1
 


### PR DESCRIPTION
## Summary

- Merged redundant `New Worker Project` + `Local Development` sections into one
- Removed obvious inline comments (`# Production`, `# Edit migration file`, `# Filter errors`, `# Check auth`)
- Moved KV config note out of code block into prose (more readable)
- Fixed broken `See Also` links: `README.md` → `wrangler.md`, `gotchas.md` → `wrangler-gotchas.md` (neither `README.md` nor `gotchas.md` exist in the directory)
- Fixed comment label: `Batch DB` → `Batch D1` (accuracy)
- Added `preview_id` alongside `id` in KV binding example (CodeRabbit feedback — Wrangler v3+ recommended shape)

All actionable content preserved. No code examples removed.

## Runtime Testing

Risk: **Low** — doc-only change, no code. Self-assessed.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md` (149→140 lines, -9 net)

Closes #13206

---
[aidevops.sh](https://aidevops.sh) v3.5.355 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 2,323 tokens on this as a headless worker.