### PR TITLE
GH#13202: tighten ad-creative-video-ugc.md from 150 to 143 lines

### DIFF
--- a/.agents/marketing-sales/ad-creative-video-ugc.md
+++ b/.agents/marketing-sales/ad-creative-video-ugc.md
@@ -1,6 +1,6 @@
 ## Video Ad Hooks: The Critical First 3 Seconds
 
-Users scroll 400+ posts/hour. Hook decision in <1 second. Every hook needs: visual pattern interrupt, immediate relevance, curiosity gap, emotional trigger, clear value promise. **Target:** 3-second view rate >50%.
+Hook decision in <1 second. Every hook needs: visual pattern interrupt, immediate relevance, curiosity gap, emotional trigger, clear value promise. **Target:** 3-second view rate >50%.
 
 ### Question Hooks (1-20)
 
@@ -89,20 +89,13 @@ Users scroll 400+ posts/hour. Hook decision in <1 second. Every hook needs: visu
 
 ### Hook Testing
 
-**Variables:** Hook type (question/statement/visual), specificity, emotion (fear/desire/curiosity), length (1s vs 3s), visual (with/without person). **Winners:** Immediately signals relevance, creates open loop, stands out visually, speaks to avatar, promises specific value.
+**Test variables:** Hook type (question/statement/visual), specificity, emotion (fear/desire/curiosity), length (1s vs 3s), visual (with/without person).
 
 ---
 
 ## UGC-Style Ad Creation
 
-Content that looks customer-created — smartphone-shot, casual setting, authentic delivery. Works because: native to platform, higher trust, lower cost, better engagement, algorithm-favored.
-
-| Traditional | UGC-Style |
-|-------------|-----------|
-| Professional/studio | Smartphone/casual |
-| Scripted, polished | Conversational, natural |
-| Product-focused | Person-focused with product |
-| High cost, slow iteration | Low cost, fast testing |
+Smartphone-shot, casual, authentic — native to platform, higher trust, lower cost, faster iteration than studio production.
 
 ### Creation Process
 


### PR DESCRIPTION
## Summary

- Remove redundant prose from `.agents/marketing-sales/ad-creative-video-ugc.md` (150 → 143 lines, -5%)
- All 65 hooks, 5 script frameworks, brief template, filming/editing guidance, and optimization tables preserved intact
- No actionable content removed — only restatements and a comparison table whose information is already encoded in the brief template

## Changes

**Removed:**
1. `"Users scroll 400+ posts/hour."` — scroll-rate stat; title "Critical First 3 Seconds" already conveys urgency
2. `"Winners: Immediately signals relevance..."` — restates hook requirements already listed in the same paragraph
3. UGC intro sentence + Traditional vs UGC-Style comparison table (6 lines) — replaced by single-line summary; the brief template already encodes the UGC production approach

## Verification

- `wc -l`: 150 → 143 lines
- All 65 hook templates present (verified by line count of tables: Q1-20, S21-40, V41-55, C56-65)
- All 5 script frameworks present
- Brief template code block unchanged
- No broken references (file has no internal links)
- Risk: **Low** (docs-only change, no code)

## Runtime Testing

`self-assessed` — docs-only change, no runtime required.

Closes #13202

---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,312 tokens on this as a headless worker.