### PR TITLE
GH#13174: tighten flowcharts.md agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2650,6 +2650,11 @@
       "hash": "44a71ae7e0ea47a168373d7b7cffdd3f7d107e1b",
       "at": "2026-03-29T23:53:53Z",
       "pr": 13452
+    },
+    ".agents/marketing-sales/cro-chapters.md": {
+      "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
+      "at": "2026-03-30T00:22:02Z",
+      "pr": 13457
     }
   }
 }

--- a/.agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md
+++ b/.agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md
@@ -45,14 +45,6 @@ Syntax: `node@{ shape: name, label: "Text" }`
 | `lin-doc` | Lined document | `tag-doc` / `tag-rect` | Tagged shapes |
 | `half-rounded-rect` | Half rounded | `curv-trap` | Curved trapezoid |
 
-```mermaid
-flowchart LR
-    doc@{ shape: doc, label: "Document" }
-    db@{ shape: cyl, label: "Database" }
-    proc@{ shape: rect, label: "Process" }
-    dec@{ shape: diamond, label: "Decision" }
-```
-
 ## Edge Types
 
 ```
@@ -89,38 +81,19 @@ Nested subgraphs supported. Add `direction TB` inside a subgraph to override dir
 
 ## Multi-Target Edges
 
-```mermaid
-flowchart LR
-    A --> B & C --> D
-    E & F --> G
-```
+`A --> B & C --> D` — fan-out; `E & F --> G` — fan-in
 
 ## Markdown in Labels
 
-```mermaid
-flowchart LR
-    A["`**Bold** and *italic*`"]
-    B["`Multi
-    line
-    text`"]
-    A --> B
-```
+Wrap label in backtick-quotes: `A["`**Bold** and *italic*`"]` — supports bold, italic, multi-line.
 
 ## Icons
 
-```mermaid
-flowchart LR
-    A[fa:fa-user User] --> B[fa:fa-database Database]
-```
+`A[fa:fa-user User]` — FontAwesome prefix `fa:fa-name`
 
 ## Click Events
 
-```mermaid
-flowchart LR
-    A[GitHub] --> B[Docs]
-    click A href "https://github.com" _blank
-    click B call callback()
-```
+`click A href "https://url" _blank` — open URL; `click B call callback()` — JS callback
 
 ## Styling
 


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md` from 161 → 134 lines (-17%) without knowledge loss.

## Changes

- **Removed** redundant extended-shapes example code block (4 shapes already fully documented in the table above it)
- **Condensed** Multi-Target Edges, Markdown in Labels, Icons, and Click Events sections from standalone code blocks to inline syntax notes — these are simple one-liner patterns that don't benefit from a full fenced block

## Verification

- All code syntax, shape names, edge types, and command patterns present before and after
- Extended shapes table (28 shapes): unchanged
- Edge types block: unchanged
- Subgraphs, Styling, ELK, CI/CD example: unchanged
- No broken references or internal links

## Runtime Testing

Risk: **Low** — docs-only change, no executable code modified. Self-assessed.

Closes #13174

---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 4,590 tokens on this as a headless worker.