### PR TITLE
GH#13503: tighten mom-test-ux.md (132→120 lines)

### DIFF
--- a/.agents/seo/mom-test-ux.md
+++ b/.agents/seo/mom-test-ux.md
@@ -48,8 +48,6 @@ Every element is evaluated against these principles:
 
 ### Step 1: Capture the Page
 
-Use browser automation to get the page state:
-
 ```bash
 # ARIA snapshot (preferred - fast, structured, no vision tokens)
 playwright screenshot --aria-snapshot https://example.com/pricing
@@ -58,11 +56,9 @@ playwright screenshot --aria-snapshot https://example.com/pricing
 playwright screenshot https://example.com/pricing --full-page
 ```
 
-Or use Stagehand/Playwright programmatically. For manual review, the user provides the URL and you fetch with `webfetch`.
+For manual review: user provides URL → fetch with `webfetch`.
 
 ### Step 2: Screen-by-Screen Analysis
-
-For each screen/page, generate the findings table:
 
 | Confusing Element | Mom's Reaction | Principle | Severity | Fix |
 |-------------------|----------------|-----------|----------|-----|
@@ -84,11 +80,7 @@ Prioritise fixes by effort vs. impact:
 | Redesign pricing table | High | 1-2 days | **Plan** |
 | Adjust spacing/polish | Low | 30 min | **Batch later** |
 
-Priority rules: High impact + Low effort = Do first. High impact + High effort = Plan. Low impact = Batch later.
-
 ### Step 4: CRO Recommendations
-
-Apply proven UX patterns that directly improve conversion:
 
 | Pattern | Why It Works | Implementation |
 |---------|-------------|----------------|
@@ -100,9 +92,7 @@ Apply proven UX patterns that directly improve conversion:
 
 ## Browser Automation Integration
 
-### Automated UX Scan
-
-Use Playwright to programmatically check for common Mom Test failures:
+Playwright checks for common Mom Test failures:
 
 1. **ARIA snapshot** - Parse `page.accessibility.snapshot()` for structure issues
 2. **Hidden CTAs** - Query `button, a[href]` and flag any with `offsetParent === null`
@@ -113,8 +103,6 @@ Use Playwright to programmatically check for common Mom Test failures:
 Each finding maps to a severity (S1-S4) and principle (Clarity/Simplicity/etc).
 
 ## Output Format
-
-The final report follows this structure:
 
 1. **One-line verdict**: Pass / Needs Work / Fail (with overall severity)
 2. **Findings table**: Every issue with Severity, Principle, Mom's Reaction, Fix


### PR DESCRIPTION
## Summary

- Removes 12 lines of redundant prose from `.agents/seo/mom-test-ux.md` (132→120 lines)
- All actionable content preserved: 6 UX principles table, severity ranking, all 4 workflow steps with example tables, browser automation checklist, output format, related links
- Cuts: intro sentences that restate what the following table shows, the "Priority rules" sentence (already encoded in the Priority column), the "Or use Stagehand/Playwright programmatically" sentence, and the "The final report follows this structure:" lead-in

## Runtime Testing

Risk: **Low** — doc-only change, no code. Self-assessed.

Closes #13503

---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 2,999 tokens on this as a headless worker.