### PR TITLE
GH#13501: tighten maestro.md, remove redundant prose (132→125 lines)

### DIFF
--- a/.agents/tools/mobile/maestro.md
+++ b/.agents/tools/mobile/maestro.md
@@ -18,15 +18,10 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Human-readable YAML-based E2E testing for Android, iOS, and web
 - **Install**: `curl -fsSL "https://get.maestro.mobile.dev" | bash`
 - **Requirements**: Java 17+ (`java -version` to verify)
 - **Docs**: https://docs.maestro.dev
-- **GitHub**: https://github.com/mobile-dev-inc/maestro (10.6k stars, Apache-2.0)
-
-**Why Maestro**: Built on learnings from Appium, Espresso, XCTest, and Selenium.
-Interpreted YAML flows (no compilation), built-in flakiness tolerance, automatic
-waiting. Write your first test in under five minutes.
+- **GitHub**: https://github.com/mobile-dev-inc/maestro
 
 <!-- AI-CONTEXT-END -->
 
@@ -82,12 +77,10 @@ waiting. Write your first test in under five minutes.
 
 ## Maestro Studio and Cloud
 
-**Studio** (`maestro studio` or standalone desktop app) -- visual IDE for test building:
-live device mirror, element inspector, click-to-select YAML generation, AI assistance.
-Download: https://maestro.dev/#maestro-studio
-
-**Cloud** -- parallel execution on dedicated infrastructure, up to 90% faster,
-deterministic environments. Free trial: https://maestro.dev/cloud
+| | Description | URL |
+|--|-------------|-----|
+| **Studio** | Visual IDE: device mirror, element inspector, YAML generation, AI assist | https://maestro.dev/#maestro-studio |
+| **Cloud** | Parallel execution, deterministic environments, free trial | https://maestro.dev/cloud |
 
 ## Common Patterns
 
@@ -124,7 +117,7 @@ appId: com.example.app
 | XcodeBuildMCP | Build iOS `.app`, install on simulator, then test |
 | iOS Simulator MCP | Manage simulator state alongside Maestro flows |
 
-Typical workflow: boot simulator (`xcrun simctl boot`), build app (`xcodebuild`), run `maestro test flows/`.
+Workflow: `xcrun simctl boot` → `xcodebuild` → `maestro test flows/`
 
 ## Related Tools
 


### PR DESCRIPTION
## Summary

- Removed marketing paragraph ("Why Maestro") — not actionable for an agent
- Removed star count and license from Quick Reference — not operationally relevant
- Converted verbose Studio/Cloud prose paragraphs to a compact table
- Condensed workflow sentence to a one-liner arrow notation
- All commands, selectors, code examples, URLs, cross-platform table, integration table, and Related Tools preserved intact

## Verification

- Line count: 132 → 125 (7 lines removed)
- All code blocks present: `curl` install, YAML selector examples, Common Patterns flow
- All URLs present: `docs.maestro.dev`, `maestro.dev/#maestro-studio`, `maestro.dev/cloud`
- All command tables intact: Key Commands, Core Commands, Cross-Platform Support, Integration
- Agent behaviour unchanged — no rules, decision logic, or task IDs were present to preserve

## Runtime Testing

Risk: **Low** — documentation-only change, no code paths affected. `self-assessed`.

Closes #13501

---
[aidevops.sh](https://aidevops.sh) v3.5.351 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 2,544 tokens on this as a headless worker.