### PR TITLE
GH#13475: tighten product/ui-design.md

### DIFF
--- a/.agents/product/ui-design.md
+++ b/.agents/product/ui-design.md
@@ -18,7 +18,6 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Ensure every product is simple, clean, stylish, and beautiful
 - **Principle**: Aesthetics drive downloads; usability drives retention
 - **Standards**: Apple HIG, Material Design 3, WCAG 2.1 AA accessibility
 - **Tools**: Vision AI for asset generation, Remotion for animated previews, Gemini for SVG design
@@ -130,5 +129,4 @@ See `tools/accessibility/accessibility-audit.md` for comprehensive auditing.
 - `tools/browser/remotion-best-practices-skill.md` — Animated previews
 - `tools/ui/tailwind-css.md` — Tailwind CSS
 - `tools/ui/shadcn.md` — shadcn/ui component library
-- `tools/design/design-inspiration.md` — 60+ design resources
-- `tools/accessibility/accessibility-audit.md` — Accessibility auditing
+


### PR DESCRIPTION
## Summary

- Remove `Purpose` bullet from Quick Reference (restates H1 title verbatim)
- Remove two Related entries (`design-inspiration.md`, `accessibility-audit.md`) already referenced inline in the body

134 → 132 lines. All actionable content, task IDs, URLs, and command references preserved.

## Runtime Testing

Risk level: **Low** (docs-only change, agent prompt file). Self-assessed — no runtime verification required per testing gate.

Closes #13475

---
[aidevops.sh](https://aidevops.sh) v3.5.355 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,210 tokens on this as a headless worker.