### PR TITLE
GH#13476: tighten crft-lookup.md (133 → 101 lines)

### DIFF
--- a/.agents/tools/research/providers/crft-lookup.md
+++ b/.agents/tools/research/providers/crft-lookup.md
@@ -46,51 +46,18 @@ tech-stack-helper.sh lookup example.com --provider crft --json
 tech-stack-helper.sh report example.com --provider crft
 ```
 
-**Complementary Tools**:
-
-| Tool | Strength | Use Together |
-|------|----------|-------------|
-| PageSpeed Insights | Detailed performance metrics | CRFT for overview, PSI for deep dive |
-| Wappalyzer | Browser extension, real-time | CRFT for batch/CLI analysis |
-| BuiltWith | Historical data, market share | CRFT for current snapshot |
-
 <!-- AI-CONTEXT-END -->
-
-## How It Works
-
-Submits URL → headless Chromium → analyzes HTML/JS/headers against 2500+ fingerprints → runs Lighthouse → extracts meta tags + sitemap → generates shareable report (~20s per scan).
-
-## Detection Categories
-
-**Technology Stack**: JS frameworks (React, Vue, Next.js, Astro…), CMS (WordPress, Contentful, Ghost…), analytics (GA, Plausible, PostHog…), CDN/hosting (Cloudflare, Vercel, Netlify…), e-commerce (Shopify, WooCommerce…), marketing automation (HubSpot, Intercom…).
-
-**Lighthouse** (0-100, desktop + mobile — for dedicated analysis use `pagespeed-helper.sh`):
-
-| Category | What It Measures |
-|----------|-----------------|
-| Performance | Loading speed, interactivity, visual stability |
-| Accessibility | WCAG compliance, screen reader support |
-| Best Practices | Security, modern APIs, console errors |
-| SEO | Meta tags, crawlability, mobile-friendliness |
-
-**Meta Tags**: title, description, Open Graph (image/title/description), Twitter Cards, favicon.
 
 ## Usage
 
 ```bash
-# Basic lookup
-tech-stack-helper.sh lookup example.com --provider crft
-
-# JSON output (schema below)
+# JSON output with schema
 tech-stack-helper.sh lookup example.com --provider crft --json
 # {
 #   "url": "https://example.com", "domain": "example.com",
 #   "technologies": [{"name": "React", "category": "ui-libs", "version": "18.2", "confidence": 1.0}],
 #   "categories": [{"category": "ui-libs", "count": 1, "technologies": ["React"]}]
 # }
-
-# Markdown report
-tech-stack-helper.sh report example.com --provider crft
 
 # SEO integration
 tech-stack-helper.sh lookup client-site.com --provider crft --json | jq '.technologies'
@@ -124,6 +91,7 @@ done
 | API | No (web only) | Yes (paid) | Yes (paid) | Yes (free) |
 | Price | Free | Freemium | Paid | Free |
 | CLI | Via helper | Browser ext | No | Via npm |
+| Use with CRFT | Overview → PSI deep dive | Batch/CLI vs real-time | Current snapshot vs history | — |
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Removes 32 lines of redundant prose from `.agents/tools/research/providers/crft-lookup.md` (133 → 101 lines, 24% reduction)
- No actionable content removed: all commands, JSON schema, limitations, related links, and the Alternatives comparison table are preserved
- Merges the "Complementary Tools" table into the Alternatives table as a "Use with" column (two tables covering the same 3 tools → one)
- Drops "How It Works" prose (internals, not actionable for an agent doc)
- Drops "Detection Categories" section (full duplicate of the Capabilities table in Quick Reference)
- Deduplicates basic commands from Usage section (already present verbatim in Quick Reference)

## Runtime Testing

Risk: **Low** — doc-only change, no code paths affected. `self-assessed`.

Closes #13476

---
[aidevops.sh](https://aidevops.sh) v3.5.355 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,675 tokens on this as a headless worker.