### PR TITLE
GH#12980: tighten agent doc marketing-sales.md

### DIFF
--- a/.agents/marketing-sales.md
+++ b/.agents/marketing-sales.md
@@ -42,7 +42,7 @@ You are the Marketing agent. Domain: marketing strategy, campaign execution, pai
 
 - **CRM**: FluentCRM MCP — `services/crm/fluentcrm.md`. Prerequisites: FluentCRM plugin on WordPress, application password, MCP server configured, SMTP/SES sending. Credentials in `~/.config/aidevops/credentials.sh` (600 perms) — never commit.
 - **Analytics**: GA4 — `services/analytics/google-analytics.md`
-- **Content/copy**: `content.md` | **SEO**: `seo.md` | **Sales handoff**: `marketing-sales.md`
+- **Content/copy**: `content.md` | **SEO**: `seo.md` | **Sales**: `sales.md`
 
 **Paid Advertising & CRO** (from [Indexsy Skills](https://github.com/Indexsy-Skills/skills)):
 
@@ -65,7 +65,7 @@ You are the Marketing agent. Domain: marketing strategy, campaign execution, pai
 | **Smart Links** | `fluentcrm_create_smart_link`, `fluentcrm_generate_smart_link_shortcode` — track clicks, trigger tag actions, lead scoring |
 | **Reports** | `fluentcrm_dashboard_stats` |
 
-**Google Analytics MCP Tools** (when `google-analytics` subagent loaded): `get_account_summaries`, `get_property_details`, `list_google_ads_links`, `run_report`, `get_custom_dimensions_and_metrics`, `run_realtime_report`
+**Google Analytics MCP Tools** (when `google-analytics` subagent loaded): see `services/analytics/google-analytics.md` for tool list.
 
 <!-- AI-CONTEXT-END -->
 
@@ -101,8 +101,6 @@ Before generating marketing strategy or campaign output, validate:
 | **Welcome** | `list_added` (Newsletter) | Day 0: welcome → Day 2: value → Day 5: product intro → Day 7: social proof → Day 10: soft CTA |
 | **Lead Nurture** | `tag_added` (lead-mql) | Day 0: education → Day 3: case study → Day 7: comparison → Day 10: demo invite → Day 14: follow-up |
 | **Re-engagement** | `tag_added` (inactive-90-days) | Day 0: "we miss you" → Day 3: best content → Day 7: offer → Day 14: last chance + unsub |
-
-Create with `fluentcrm_create_automation` (title, description, trigger), then configure steps/delays/conditions in FluentCRM admin.
 
 ## Segmentation
 


### PR DESCRIPTION
## Summary

- Fix self-referential link: `marketing-sales.md` pointed to itself under "Sales handoff" — corrected to `sales.md`
- Replace inline GA4 tool list with pointer to `services/analytics/google-analytics.md` (tools belong in the subagent doc, not duplicated here)
- Remove redundant `fluentcrm_create_automation` prose sentence — the tool name already appears in the Automations row of the table directly above

## Verification

- Content preservation: all code blocks, URLs, command examples, and workflow sequences intact
- No broken internal links (self-referential link was already broken)
- Line count: 164 → 162 (net -2 lines; 3 targeted removals)
- Agent behaviour unchanged — no operational rules removed

## Runtime Testing

Risk: **Low** — agent prompt doc only, no executable code. Self-assessed.

Closes #12980

---
[aidevops.sh](https://aidevops.sh) v3.5.355 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 1m and 3,236 tokens on this as a headless worker.