### PR TITLE
GH#12966: tighten sandbox-gotchas.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md
@@ -125,7 +125,7 @@ const result = await sandbox.exec('git clone ...', {
 
 ### Preview URL Security
 
-Preview URLs include auto-generated tokens (e.g., `https://8080-sandbox-abc123def456.yourdomain.com`). Token changes on each expose operation, preventing unauthorized access.
+Preview URLs include auto-generated tokens (e.g., `https://8080-sandbox-abc123def456.yourdomain.com`) that rotate on each expose operation, reducing the risk of unauthorized access. Note: tokens can be leaked prior to rotation.
 
 ## Limits
 

--- a/.agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md
@@ -4,9 +4,7 @@
 
 ### Container Not Ready
 
-**Error**: `CONTAINER_NOT_READY`  
-**Cause**: Container still provisioning (first request or after sleep)  
-**Fix**: Retry after 2-3s
+`CONTAINER_NOT_READY` — container still provisioning (first request or after sleep). Retry after 2-3s:
 
 ```typescript
 async function execWithRetry(sandbox, cmd) {
@@ -26,13 +24,10 @@ async function execWithRetry(sandbox, cmd) {
 
 ### Port Exposure Fails in Dev
 
-**Error**: "Connection refused: container port not found"  
-**Cause**: Missing `EXPOSE` directive in Dockerfile  
-**Fix**: Add `EXPOSE <port>` to Dockerfile (only needed for `wrangler dev`, production auto-exposes)
+"Connection refused: container port not found" — missing `EXPOSE` directive in Dockerfile. Add `EXPOSE <port>` (only needed for `wrangler dev`; production auto-exposes).
 
 ### Preview URLs Not Working
 
-**Checklist**:
 1. Custom domain configured? (not `.workers.dev`)
 2. Wildcard DNS set up? (`*.domain.com → worker.domain.com`)
 3. `normalizeId: true` in getSandbox?
@@ -40,16 +35,11 @@ async function execWithRetry(sandbox, cmd) {
 
 ### Slow First Request
 
-**Cause**: Cold start (container provisioning)  
-**Solutions**:
-- Use `sleepAfter` instead of creating new sandboxes
-- Pre-warm with cron triggers
-- Set `keepAlive: true` for critical sandboxes
+Cold start from container provisioning. Mitigations: `sleepAfter` instead of new sandboxes, pre-warm with cron triggers, `keepAlive: true` for critical sandboxes.
 
 ### File Not Persisting
 
-**Cause**: Files in `/tmp` or other ephemeral paths  
-**Fix**: Use `/workspace` for persistent files
+Files in `/tmp` or ephemeral paths don't survive. Use `/workspace` for persistent files.
 
 ## Performance Optimization
 
@@ -96,9 +86,7 @@ const sandbox = getSandbox(env.Sandbox, 'id', {
 
 ### Sandbox Isolation
 
-- Each sandbox = isolated container (filesystem, network, processes)
-- Use unique sandbox IDs per tenant for multi-tenant apps
-- Sandboxes cannot communicate directly
+Each sandbox = isolated container (filesystem, network, processes). Use unique sandbox IDs per tenant for multi-tenant apps. Sandboxes cannot communicate directly.
 
 ### Input Validation
 
@@ -137,13 +125,7 @@ const result = await sandbox.exec('git clone ...', {
 
 ### Preview URL Security
 
-Preview URLs include auto-generated tokens:
-
-```
-https://8080-sandbox-abc123def456.yourdomain.com
-```
-
-Token changes on each expose operation, preventing unauthorized access.
+Preview URLs include auto-generated tokens (e.g., `https://8080-sandbox-abc123def456.yourdomain.com`). Token changes on each expose operation, preventing unauthorized access.
 
 ## Limits
 


### PR DESCRIPTION
## Summary

- Compressed verbose `**Error**:`/`**Cause**:`/`**Fix**:` multi-line patterns into single-line inline descriptions (5 instances)
- Merged bullet lists into flowing prose, removed redundant labels and unnecessary code block wrappers
- 165 → 147 lines (11% reduction), zero technical content loss

## Details

All code blocks (6), URLs (5), commands, technical terms, and limits data preserved exactly. Only prose structure changed.

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, diff reviewed for content preservation

Closes #12966

---
[aidevops.sh](https://aidevops.sh) v3.5.363 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 1m and 4,878 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted hosting troubleshooting content into concise inline sentence-style guidance for errors like container readiness, port exposure, slow first request, file persistence, and sandbox isolation.
  * Removed an explicit "Checklist" label while preserving numbered steps for preview URL troubleshooting.
  * Consolidated preview URL security notes to mention rotated tokens and the risk of pre-rotation leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->