### PR TITLE
GH#12938: tighten app-dev-testing.md

### DIFF
--- a/.agents/tools/mobile/app-dev-testing.md
+++ b/.agents/tools/mobile/app-dev-testing.md
@@ -1,18 +1,10 @@
 ---
 description: Mobile app testing - simulator, emulator, device, E2E, accessibility, QA workflows
 mode: subagent
-tools:
-  read: true
-  write: true
-  edit: true
-  bash: true
-  glob: true
-  grep: true
-  webfetch: false
-  task: true
+tools: [read, write, edit, bash, glob, grep, task]
 ---
 
-# Mobile App Testing - Comprehensive QA
+# Mobile App Testing
 
 <!-- AI-CONTEXT-START -->
 
@@ -20,33 +12,33 @@ tools:
 
 - **Purpose**: Test mobile apps across simulators, emulators, and physical devices
 - **Tools**: agent-device, xcodebuild-mcp, maestro, ios-simulator-mcp, playwright-emulation
-- **Levels**: Unit -> Integration -> E2E -> Visual -> Accessibility -> Performance
+- **Levels**: Unit → Integration → E2E → Visual → Accessibility → Performance
 
-**Testing tool decision tree**:
+**Tool decision tree**:
 
 ```text
-AI-driven exploratory testing?  -> agent-device (CLI, both platforms)
-Repeatable E2E test flows?      -> maestro (YAML flows, flakiness tolerance)
-Build/test/deploy iOS apps?     -> xcodebuild-mcp (Xcode integration, LLDB)
-iOS simulator interaction?      -> ios-simulator-mcp (tap/swipe/type/screenshot)
-Mobile web layout testing?      -> playwright-emulation (device presets, touch)
+AI-driven exploratory?     -> agent-device (CLI, both platforms)
+Repeatable E2E flows?      -> maestro (YAML, flakiness tolerance)
+Build/test/deploy iOS?     -> xcodebuild-mcp (Xcode, LLDB)
+iOS simulator interaction? -> ios-simulator-mcp (tap/swipe/type/screenshot)
+Mobile web layout?         -> playwright-emulation (device presets, touch)
 ```
 
 <!-- AI-CONTEXT-END -->
 
 ## Testing Strategy
 
-### Unit Tests
+### Unit
 
 - **Expo**: Jest + React Native Testing Library
-- **Swift**: XCTest (via `xcodebuild-mcp test_sim`)
-- Cover business logic, data transformations, state management
+- **Swift**: XCTest (`xcodebuild-mcp test_sim`)
+- Cover: business logic, data transforms, state management
 
-### Integration Tests
+### Integration
 
 Test API clients (mock servers), navigation flows, state persistence, notification handling.
 
-### E2E Tests (Maestro)
+### E2E (Maestro)
 
 ```yaml
 # flows/onboarding.yaml
@@ -63,11 +55,11 @@ appId: com.example.myapp
 - assertVisible: "Home"
 ```
 
-### AI-Driven Testing (agent-device)
+### AI-Driven (agent-device)
 
 ```bash
 agent-device open "My App" --platform ios   # Open app
-agent-device snapshot                        # Get accessibility tree
+agent-device snapshot                        # Accessibility tree
 agent-device click @e3                       # Interact via refs
 agent-device fill @e7 "test@example.com"
 agent-device screenshot ./test-evidence.png  # Capture state
@@ -76,18 +68,18 @@ agent-device close                           # Clean up
 
 ### Visual Regression
 
-Capture screenshots at key states using `ios-simulator-mcp` or `agent-device`. Test light/dark modes across device sizes (iPhone SE, iPhone 16, iPhone 16 Pro Max, iPad).
+Capture screenshots at key states via `ios-simulator-mcp` or `agent-device`. Test light/dark modes across sizes (iPhone SE, iPhone 16, iPhone 16 Pro Max, iPad).
 
-### Accessibility Testing
+### Accessibility
 
-- `agent-device snapshot` to inspect accessibility tree
-- Verify all elements have labels, test VoiceOver/TalkBack
+- `agent-device snapshot` — inspect accessibility tree
+- Verify all elements have labels; test VoiceOver/TalkBack
 - Check colour contrast, Dynamic Type support
 - See `tools/accessibility/accessibility-audit.md`
 
-### Performance Testing
+### Performance
 
-Targets: app launch < 2s, animations 60fps. Monitor memory, network payload sizes. Test on older devices.
+Targets: launch < 2s, animations 60fps. Monitor memory and network payload sizes. Test on older devices.
 
 ## Device Matrix
 
@@ -97,43 +89,43 @@ Targets: app launch < 2s, animations 60fps. Monitor memory, network payload size
 | iPhone 16 | 6.1" | Standard |
 | iPhone 16 Pro Max | 6.9" | Largest |
 | iPad (10th) | 10.9" | Tablet |
-| Pixel 7 / Galaxy S24 | 6.2-6.3" | Android |
+| Pixel 7 / Galaxy S24 | 6.2–6.3" | Android |
 
 Use `playwright-emulation` device presets for web-based testing.
 
-## TestFlight and Internal Testing
+## TestFlight & Internal Testing
 
 ### iOS (TestFlight)
 
-1. Build: `eas build --platform ios --profile preview` (Expo) or Xcode archive (Swift)
+1. Build: `eas build --platform ios --profile preview` (Expo) or Xcode archive
 2. Upload to App Store Connect
-3. Internal testers (100 max, no review) or external (10,000, requires review)
+3. Internal testers (100 max, no review) or external (10k, requires review)
 4. Collect feedback via TestFlight's built-in mechanism
 
 ### Android (Internal Testing)
 
 1. Build: `eas build --platform android --profile preview` or `./gradlew assembleRelease`
 2. Upload to Google Play Console → internal testing track
-3. Add testers via email/Google Group, distribute via internal testing link
+3. Add testers via email/Google Group; distribute via internal link
 
 ## Pre-Submission Checklist
 
 - [ ] E2E flows pass on latest OS versions
 - [ ] No crashes in crash reporting
 - [ ] Accessibility audit passes
-- [ ] Light and dark modes work
+- [ ] Light/dark modes work
 - [ ] Localisation complete (or English-only intentional)
 - [ ] Offline behaviour graceful
 - [ ] Deep links, push notifications work
 - [ ] In-app purchases complete (sandbox)
-- [ ] App icon, splash screen display correctly
+- [ ] App icon, splash screen correct
 - [ ] No placeholder/test data visible
 
 ## Related
 
-- `tools/mobile/agent-device.md` - AI-driven device automation
-- `tools/mobile/xcodebuild-mcp.md` - Xcode build/test
-- `tools/mobile/maestro.md` - E2E test flows
-- `tools/mobile/ios-simulator-mcp.md` - Simulator interaction
-- `tools/browser/playwright-emulation.md` - Mobile web testing
-- `tools/accessibility/accessibility-audit.md` - Accessibility
+- `tools/mobile/agent-device.md` — AI-driven device automation
+- `tools/mobile/xcodebuild-mcp.md` — Xcode build/test
+- `tools/mobile/maestro.md` — E2E test flows
+- `tools/mobile/ios-simulator-mcp.md` — simulator interaction
+- `tools/browser/playwright-emulation.md` — mobile web testing
+- `tools/accessibility/accessibility-audit.md` — accessibility


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/mobile/app-dev-testing.md` from 139 → 131 lines (6% reduction)
- Compressed YAML frontmatter tools map from 8 lines to 1-line array (removed `webfetch: false` — omission = false)
- Removed redundant qualifiers from title and section headers ("Comprehensive QA", "Tests"/"Testing" suffixes)
- Compressed verbose phrasing in decision tree, prose sections, and checklist items
- Normalised typography: `->` → `→`, `-` → `—` (em-dash in Related), hyphen → en-dash for ranges
- All technical content preserved: 2 code blocks, 5 device matrix rows, 10 checklist items, 6 Related links, all tool references

## Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdownlint-cli2 clean, manual diff review confirms zero content loss

Closes #12938

---
[aidevops.sh](https://aidevops.sh) v3.5.363 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 1m and 4,036 tokens on this as a headless worker.