### PR TITLE
GH#12932: tighten meta-ads-foundations-glossary.md

### DIFF
--- a/.agents/marketing-sales/meta-ads-foundations-glossary.md
+++ b/.agents/marketing-sales/meta-ads-foundations-glossary.md
@@ -2,28 +2,28 @@
 
 ## A
 **A/B Testing (Split Testing)** — Two ad versions shown to split audiences to compare performance.
-**ABO (Ad Set Budget Optimization)** — Budget set per ad set; each spends exactly its allocation. Use for even creative testing.
+**ABO (Ad Set Budget Optimization)** — Budget per ad set; each spends exactly its allocation. Use for even creative testing.
 **Account** — Top-level Meta Ads container for campaigns, payment methods, and access.
-**Ad** — The creative (image/video/carousel), copy, and destination users see. Lives inside ad sets.
+**Ad** — Creative (image/video/carousel), copy, and destination users see. Lives inside ad sets.
 **Ad Account ID** — Unique account identifier in Business Manager. Required for API integrations.
-**Ad Quality Ranking** — Perceived quality vs. competing ads. Tiers: Above Average, Average, Bottom 35%, Bottom 20%.
-**Ad Recall Lift** — Estimated people likely to remember your ad within 2 days. Used in awareness campaigns.
+**Ad Quality Ranking** — Perceived quality vs. competitors. Tiers: Above Average, Average, Bottom 35%, Bottom 20%.
+**Ad Recall Lift** — Estimated people likely to remember your ad within 2 days. Awareness campaigns.
 **Ad Relevance Diagnostics** — Three metrics: Quality Ranking, Engagement Rate Ranking, Conversion Rate Ranking.
 **Ad Set** — Middle campaign tier. Contains targeting, budget (ABO), schedule, placements. Parent: campaign; child: ads.
-**Advantage+ Audience** — AI-driven expansion beyond your targeting suggestions to find additional converters.
-**Advantage+ Creative** — Auto-generates creative variations (crops, brightness, etc.) to find best performers.
+**Advantage+ Audience** — AI-driven expansion beyond targeting suggestions to find additional converters.
+**Advantage+ Creative** — Auto-generates creative variations (crops, brightness, etc.) for best performers.
 **Advantage+ Placements** — Auto-distributes ads across all placements to maximize results.
-**Advantage+ Shopping Campaigns (ASC)** — Fully automated ecommerce campaign type; handles targeting, placements, creative.
+**Advantage+ Shopping Campaigns (ASC)** — Fully automated ecommerce campaign; handles targeting, placements, creative.
 **AEM (Aggregated Event Measurement)** — iOS privacy framework limiting tracking to 8 prioritized events per domain.
-**Attribution Window** — Period after ad interaction during which conversions are credited. Default: 7-day click, 1-day view.
-**Audience Network** — Meta's extended network of third-party apps/websites for ad delivery.
+**Attribution Window** — Period after ad interaction during which conversions credit. Default: 7-day click, 1-day view.
+**Audience Network** — Meta's third-party app/website network for ad delivery.
 **Automated Rules** — Conditions that auto-adjust campaigns (e.g., "Pause if CPA > $50").
 
 ## B
-**Bid** — Amount you're willing to pay per result (click, conversion, impression).
-**Bid Cap** — Manual strategy setting the maximum bid per auction.
-**Bid Strategy** — How Meta bids on your behalf. Options: Lowest Cost, Cost Cap, Bid Cap, ROAS Target.
-**Breakdown** — Segment data by dimension (age, gender, placement, device) to analyze performance.
+**Bid** — Amount you'll pay per result (click, conversion, impression).
+**Bid Cap** — Manual strategy setting maximum bid per auction.
+**Bid Strategy** — How Meta bids for you. Options: Lowest Cost, Cost Cap, Bid Cap, ROAS Target.
+**Breakdown** — Segment data by dimension (age, gender, placement, device) for analysis.
 **Broad Targeting** — Minimal/no interest targeting; lets Meta's algorithm find ideal customers.
 **Business Manager** — Meta's platform for managing business assets, ad accounts, pages, and team access.
 
@@ -31,64 +31,64 @@
 **Campaign** — Top ad structure tier. Contains objective, budget (CBO), and ad sets. One campaign = one objective.
 **Campaign Budget Optimization (CBO)** — Budget at campaign level; Meta auto-distributes across ad sets by performance.
 **CAPI (Conversion API)** — Server-side tracking sending conversion data directly to Meta, bypassing browser limits.
-**Carousel** — Ad format with 2–10 scrollable cards, each with image/video, headline, and link.
+**Carousel** — Ad format: 2–10 scrollable cards, each with image/video, headline, and link.
 **Click-Through Rate (CTR)** — `CTR = Clicks / Impressions × 100`
-**Collection** — Mobile-optimized ad combining cover image/video with catalog product images.
+**Collection** — Mobile-optimized ad combining cover image/video with catalog products.
 **Confidence Interval** — Statistical range for a metric's likely true value. Wider = less certainty.
-**Conversion** — A completed valuable action (purchase, lead, signup).
+**Conversion** — Completed valuable action (purchase, lead, signup).
 **Conversion Rate (CVR)** — `CVR = Conversions / Clicks × 100`
-**Conversion Rate Ranking** — Your ad's conversion rate vs. ads with the same goal targeting the same audience.
-**Cost Cap** — Bid strategy keeping average cost per result at or below your set cap.
+**Conversion Rate Ranking** — Your ad's conversion rate vs. same-goal ads targeting the same audience.
+**Cost Cap** — Bid strategy keeping average cost per result at or below your cap.
 **Cost Per Action (CPA)** — `CPA = Spend / Actions`
 **Cost Per Click (CPC)** — `CPC = Spend / Clicks`
 **Cost Per Mille (CPM)** — `CPM = Spend / Impressions × 1000`
 **CPL (Cost Per Lead)** — `CPL = Spend / Leads`
 **Creative** — Visual and text elements of an ad (image, video, copy, headline).
-**Creative Fatigue** — Performance decline when audience has seen the ad too many times.
-**Custom Audience** — Audience from your own data: website visitors, customer lists, app users, or engagement.
-**Custom Conversion** — Conversion event defined by URL rules or standard events with specific parameters.
+**Creative Fatigue** — Performance decline when audience sees the ad too often.
+**Custom Audience** — Audience from your data: website visitors, customer lists, app users, or engagement.
+**Custom Conversion** — Conversion defined by URL rules or standard events with specific parameters.
 
 ## D
 **Daily Budget** — Maximum spend per day for an ad set or campaign.
-**Delivery** — The process of showing ads to your target audience.
-**Delivery Insights** — Detailed information on why an ad is or isn't spending.
+**Delivery** — Process of showing ads to your target audience.
+**Delivery Insights** — Detail on why an ad is or isn't spending.
 **Dynamic Ads** — Auto-show relevant catalog products to people who've shown interest.
-**Dynamic Creative** — Auto-tests combinations of creative assets (images, headlines, CTAs) to find best performers.
+**Dynamic Creative** — Auto-tests combinations of creative assets (images, headlines, CTAs) for best performers.
 
 ## E
-**Engagement** — Interactions with your ad: likes, comments, shares, saves, clicks.
-**Engagement Rate Ranking** — Your ad's expected engagement rate vs. competing ads for the same audience.
-**Estimated Action Rate** — Meta's prediction of how likely a person is to take your desired action.
-**Event** — Specific action tracked by Pixel or CAPI (PageView, Purchase, Lead, etc.).
-**Existing Customer Budget Cap (ASC)** — In Advantage+ Shopping, max percentage of budget for existing customers.
+**Engagement** — Ad interactions: likes, comments, shares, saves, clicks.
+**Engagement Rate Ranking** — Expected engagement rate vs. competing ads for the same audience.
+**Estimated Action Rate** — Meta's prediction of how likely someone is to take your desired action.
+**Event** — Action tracked by Pixel or CAPI (PageView, Purchase, Lead, etc.).
+**Existing Customer Budget Cap (ASC)** — In Advantage+ Shopping, max budget percentage for existing customers.
 
 ## F
-**Facebook Pixel** — JavaScript on your website that tracks user actions and sends data to Meta.
+**Facebook Pixel** — JavaScript on your site tracking user actions and sending data to Meta.
 **Frequency** — `Frequency = Impressions / Reach`
-**Frequency Cap** — Limit on how many times a person sees your ad in a given period.
-**Funnel Stage** — Customer journey position: TOFU (awareness), MOFU (consideration), BOFU (decision).
+**Frequency Cap** — Max times a person sees your ad in a given period.
+**Funnel Stage** — Journey position: TOFU (awareness), MOFU (consideration), BOFU (decision).
 
 ## H
 **Hold Rate** — Percentage of video viewers who watched past a set point (e.g., 15 seconds).
-**Hook** — First few seconds of video or first text line that captures attention.
+**Hook** — First seconds of video or first text line that captures attention.
 **Hook Rate** — `Hook Rate = 3-Second Views / Impressions × 100`
 
 ## I
-**Impression** — One instance of your ad being displayed to someone.
+**Impression** — One instance of your ad being displayed.
 **Incrementality** — Conversions that would NOT have happened without the ad (true net-new business).
-**Instant Experience** — Full-screen mobile experience that opens when someone taps your ad.
+**Instant Experience** — Full-screen mobile experience opening when someone taps your ad.
 **Instant Form (Lead Form)** — In-platform form pre-filled with user info.
 **Interest Targeting** — Targeting based on interests inferred from Facebook/Instagram behavior.
 
 ## L
-**Landing Page** — Webpage users arrive at after clicking your ad.
-**Landing Page Views** — Times the landing page loaded after ad click (more accurate than link clicks).
-**Lead** — Person who expressed interest by submitting information.
-**Learning Limited** — Ad set not getting enough conversions to optimize effectively (<50/week).
-**Learning Phase** — Initial period for Meta's algorithm to gather optimization data (~50 conversions needed).
+**Landing Page** — Webpage users reach after clicking your ad.
+**Landing Page Views** — Times landing page loaded after ad click (more accurate than link clicks).
+**Lead** — Person who submitted information expressing interest.
+**Learning Limited** — Ad set not getting enough conversions to optimize (<50/week).
+**Learning Phase** — Initial period for Meta's algorithm to gather optimization data (~50 conversions).
 **Lifetime Budget** — Total spend over the campaign's entire duration.
-**Link Click** — Click on the ad leading to a destination (website, app, etc.).
-**Lookalike Audience** — People similar to an existing audience. Ranges 1% (most similar) to 10%.
+**Link Click** — Click leading to a destination (website, app, etc.).
+**Lookalike Audience** — People similar to an existing audience. Range: 1% (most similar) to 10%.
 **Lowest Cost** — Default bid strategy; Meta gets the most results for your budget.
 
 ## M
@@ -97,37 +97,37 @@
 **Messenger Ads** — Ads appearing in Messenger or driving conversations to Messenger.
 
 ## N
-**Negative Feedback** — When users hide, report, or indicate they don't want to see your ad.
+**Negative Feedback** — Users hide, report, or indicate they don't want your ad.
 
 ## O
 **Objective** — Campaign goal: Awareness, Traffic, Engagement, Leads, App Promotion, Sales.
-**Optimization Event** — Specific action Meta optimizes for (purchases, leads, landing page views).
-**Outbound Clicks** — Clicks leading people away from Facebook/Instagram.
+**Optimization Event** — Action Meta optimizes for (purchases, leads, landing page views).
+**Outbound Clicks** — Clicks leading away from Facebook/Instagram.
 
 ## P
 **Page** — Your Facebook Page, required to run ads.
 **Placement** — Where your ad appears: Feed, Stories, Reels, Explore, Messenger, Audience Network, etc.
 **Post Engagement** — Likes, comments, shares, and clicks on a post-style ad.
-**Primary Text** — Main body copy appearing above the image/video.
-**Prospecting** — Targeting new potential customers who haven't interacted with you (cold audience).
+**Primary Text** — Main body copy above the image/video.
+**Prospecting** — Targeting new potential customers (cold audience).
 **Purchase** — Standard event for completed transactions.
 
 ## Q
-**Quality Ranking** — Your ad's perceived quality vs. competing ads for the same audience.
+**Quality Ranking** — Perceived quality vs. competing ads for the same audience.
 
 ## R
-**Reach** — Number of unique people who saw your ad at least once.
+**Reach** — Unique people who saw your ad at least once.
 **Relevance Score** — (Deprecated) Combined engagement/quality/conversion metric. Replaced by Ad Relevance Diagnostics.
 **Retargeting** — Ads shown to people who've already interacted with your brand.
-**ROAS (Return on Ad Spend)** — `ROAS = Revenue / Ad Spend` (e.g., $300 revenue / $100 spend = 3×)
-**ROAS Target** — Bid strategy setting the minimum return on ad spend.
+**ROAS (Return on Ad Spend)** — `ROAS = Revenue / Ad Spend` (e.g., $300/$100 = 3x)
+**ROAS Target** — Bid strategy setting minimum return on ad spend.
 
 ## S
 **Scale** — Increasing spend on winning campaigns while maintaining performance.
 **Schedule** — When ads run: always-on, specific dates, or specific hours/days.
-**Signal** — Data helping Meta understand who converts (pixel events, CAPI data, engagement).
+**Signal** — Data helping Meta understand who converts (pixel events, CAPI, engagement).
 **Special Ad Category** — Restricted categories: Credit, Employment, Housing, Social Issues/Elections/Politics.
-**Split Test** — A/B test run by Meta at campaign level to compare variables.
+**Split Test** — A/B test at campaign level to compare variables.
 **Standard Events** — Pre-defined conversion events Meta recognizes (PageView, Purchase, Lead, etc.).
 
 ## T
@@ -140,27 +140,13 @@
 **UTM Parameters** — URL tags tracking traffic source in analytics. Example: `?utm_source=facebook&utm_medium=paid&utm_campaign=name`
 
 ## V
-**Value-Based Lookalike** — Lookalike weighted by customer LTV, finding people similar to your best customers.
-**Video Views** — Times video was watched (thresholds: 3-second, 10-second, ThruPlay).
-**View Content** — Standard event when someone views a key page (product, article, etc.).
+**Value-Based Lookalike** — Lookalike weighted by customer LTV to find people similar to best customers.
+**Video Views** — Times video was watched (thresholds: 3s, 10s, ThruPlay).
+**View Content** — Standard event when someone views a key page (product, article).
 **View-Through Conversion** — Conversion after someone saw (but didn't click) your ad.
 
 ## W
 **Warm Audience** — People who've interacted with your brand but haven't converted.
 **Website Conversion** — Conversion on your website, tracked by Pixel/CAPI.
-
-## Key Formulas
-
-| Metric | Formula |
-|--------|---------|
-| CTR | Clicks ÷ Impressions × 100 |
-| CVR | Conversions ÷ Clicks × 100 |
-| CPC | Spend ÷ Clicks |
-| CPM | Spend ÷ Impressions × 1000 |
-| CPA | Spend ÷ Actions |
-| ROAS | Revenue ÷ Spend |
-| Frequency | Impressions ÷ Reach |
-| Hook Rate | 3-Second Views ÷ Impressions × 100 |
-| MER | Total Revenue ÷ Total Marketing Spend |
 
 *Back to: [meta-ads.md](meta-ads.md)*


### PR DESCRIPTION
## Summary

- Tighten `.agents/marketing-sales/meta-ads-foundations-glossary.md` from 166 → 152 lines (8.4% reduction)
- Remove redundant Key Formulas table (13 lines) — all 9 formulas already appear inline in their respective glossary entries
- Compress verbose phrasing across ~40 definitions while preserving all 109 glossary terms and technical content

## Changes

- **Removed**: Key Formulas summary table (lines 152-165) — pure duplication of inline formulas in CTR, CVR, CPC, CPM, CPA, ROAS, Frequency, Hook Rate, MER entries
- **Compressed**: Verbose definitions throughout (e.g., "The process of showing ads" → "Process of showing ads", "Number of unique people who saw" → "Unique people who saw")

## Verification

- All 109 glossary terms preserved (verified via `rg -c '^\*\*'`)
- All 10 inline formulas preserved (CTR, CVR, CPA, CPC, CPM, CPL, Frequency, Hook Rate, MER, ROAS)
- Back-link to `meta-ads.md` preserved
- No new markdownlint violations (20 pre-existing MD022 from glossary heading format)

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: self-assessed — no behavioral change, content-only compression

Closes #12932

---
[aidevops.sh](https://aidevops.sh) v3.5.364 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 4m and 11,552 tokens on this as a headless worker.