### PR TITLE
GH#12929: tighten remote-dispatch.md

### DIFF
--- a/.agents/tools/containers/remote-dispatch.md
+++ b/.agents/tools/containers/remote-dispatch.md
@@ -25,9 +25,8 @@ tools:
 | Logs | `~/.aidevops/.agent-workspace/supervisor/logs/remote/` |
 | Task | t1165.3 |
 
-**Use when**: GPU-heavy tasks, multi-machine distribution, isolated containers, Tailscale mesh dispatch.
-
-**Don't use when**: Local tasks, tasks needing local filesystem access, interactive development.
+**Use when**: GPU tasks, multi-machine distribution, isolated containers, Tailscale mesh dispatch.
+**Don't use when**: Local tasks, local filesystem access needed, interactive development.
 
 <!-- AI-CONTEXT-END -->
 
@@ -55,7 +54,7 @@ Local Supervisor                    Remote Host
 ## Host Management
 
 ```bash
-# Add hosts
+# Add
 remote-dispatch-helper.sh add gpu-server 192.168.1.100
 remote-dispatch-helper.sh add build-node build-node.tailnet.ts.net --transport tailscale
 remote-dispatch-helper.sh add docker-host 10.0.0.5 --user deploy --container worker-1
@@ -70,13 +69,12 @@ remote-dispatch-helper.sh check gpu-server   # verifies SSH, Docker, AI CLI, age
 ## Dispatching Tasks
 
 ```bash
-# Manual dispatch
 remote-dispatch-helper.sh dispatch t123 gpu-server \
   --model anthropic/claude-opus-4-6 \
   --description "Implement feature X"
 ```
 
-**Supervisor integration**: Use `target:hostname` label on GitHub issues or TODO.md tag to route tasks to specific hosts. GitHub is the state DB (SQLite `supervisor.db` dispatch_target is deprecated).
+**Routing**: `target:hostname` label on GitHub issues or TODO.md tag. GitHub is the state DB (`supervisor.db` dispatch_target is deprecated).
 
 ## Credential Forwarding
 
@@ -89,12 +87,12 @@ remote-dispatch-helper.sh dispatch t123 gpu-server \
 | `GOOGLE_API_KEY` | Env var | For Google AI models |
 
 **Security**:
-- SSH agent forwarding passes the socket, not the keys themselves
-- API keys are embedded in a shell script uploaded via SSH stdin — does NOT rely on `AcceptEnv`/`SendEnv`
-- Keys are NOT written to disk as standalone files; they exist only within the generated dispatch script
-- On Linux, env vars are readable from `/proc/<pid>/environ` by same user and root while worker runs
-- For sensitive deployments: restrict remote host access or use short-lived/scoped tokens
-- Remote workspace is cleaned up after task completion
+- SSH agent forwarding passes the socket, not keys
+- API keys embedded in shell script uploaded via SSH stdin — no `AcceptEnv`/`SendEnv` dependency
+- Keys exist only in the generated dispatch script, never as standalone files on disk
+- Linux: env vars readable via `/proc/<pid>/environ` by same user + root while worker runs
+- Sensitive deployments: restrict remote host access or use short-lived/scoped tokens
+- Remote workspace cleaned up after task completion
 
 ## Log Collection
 
@@ -104,9 +102,9 @@ remote-dispatch-helper.sh logs t123 gpu-server --follow  # stream in real-time
 remote-dispatch-helper.sh logs t123 gpu-server --tail 100
 ```
 
-**Automatic collection**: When pulse Phase 1 detects a remote worker has finished (PID gone), it calls `logs`, updates `log_file` in the DB to the local copy, then proceeds with normal evaluation.
+**Auto-collection**: Pulse Phase 1 detects worker exit (PID gone) → calls `logs` → updates `log_file` in DB to local copy → normal evaluation.
 
-## Worker Status and Cleanup
+## Status and Cleanup
 
 ```bash
 remote-dispatch-helper.sh status t123 gpu-server    # host, transport, container, PID, state, log size
@@ -124,9 +122,9 @@ remote-dispatch-helper.sh cleanup t123 gpu-server --keep-logs
 | Auth | SSH keys / agent | Tailscale identity |
 | Command | `ssh` | `tailscale ssh` (falls back to `ssh`) |
 
-Tailscale auto-detected for `*.ts.net` addresses and `100.x.x.x` IPs.
+Tailscale auto-detected for `*.ts.net` and `100.x.x.x` addresses.
 
-## Configuration File (`~/.config/aidevops/remote-hosts.json`)
+## Configuration (`~/.config/aidevops/remote-hosts.json`)
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/containers/remote-dispatch.md` prose (167 → 165 lines)
- Compressed verbose phrasing in security bullets, log collection, section headings, and use-when/don't-use-when lines
- All technical content preserved: code blocks (6), task IDs (t1165.3), URLs, command examples (17), config paths, tables

## Changes

| Section | Change |
|---------|--------|
| Quick Reference | Removed blank line between use-when/don't-use-when; tightened wording |
| Host Management | `# Add hosts` → `# Add` |
| Dispatching Tasks | Removed `# Manual dispatch` comment; compressed supervisor integration prose |
| Credential Forwarding | Tightened 6 security bullets — same content, fewer words |
| Log Collection | `Automatic collection` → `Auto-collection`; converted prose to arrow chain |
| Worker Status | `Worker Status and Cleanup` → `Status and Cleanup` |
| Transport | `addresses and 100.x.x.x IPs` → `and 100.x.x.x addresses` |
| Configuration | `Configuration File` → `Configuration` |

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint-cli2: 0 errors; all code blocks, task IDs, URLs, and commands verified present

## Verification

```
markdownlint-cli2: 0 errors
wc -l: 167 → 165
Code blocks: 6 (12 markers)
remote-dispatch-helper.sh refs: 17
Task ID t1165.3: present
```

Closes #12929

---
[aidevops.sh](https://aidevops.sh) v3.5.364 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 2m and 5,336 tokens on this as a headless worker.