### PR TITLE
fix(cr): update story.md hash in simplification-state + resolve 5-shot contradiction

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2222,9 +2222,9 @@
       "pr": 13052
     },
     ".agents/content/story.md": {
-      "hash": "e883144cdfcdb85b2c73df49d30c9323769ef4f7",
+      "hash": "49e03dac3b7941d4818099c6ec50cff44de830c1",
       "at": "2026-03-29T17:14:35Z",
-      "pr": 13123
+      "pr": 13507
     },
     ".agents/build-plus.md": {
       "hash": "9a8681dd42ae12e35c79f2f2479a29dfc90794f9",

--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -95,7 +95,9 @@ Duration:   [15s | 30s | 60s]
 CTA:        [Viewer action]
 ```
 
-### 5-Shot Storyboard Structure
+### Duration-Based Storyboard Structure (3/5/7-8 shots)
+
+Base template — adjust shot count to fit runtime.
 
 | Shot | Role | Duration | Purpose |
 |------|------|----------|---------|
@@ -105,7 +107,7 @@ CTA:        [Viewer action]
 | 4 | **After State** | 3-5s | Result proof — show outcome |
 | 5 | **Soft Sell + CTA** | 2-3s | Direct CTA, presenter to camera |
 
-**Shot count**: 15s → 3 shots (merge Hook+Before, Transformation, CTA) · 30s → 5 shots (standard) · 60s → 7-8 shots (split Transformation into 2-3 demo + testimonial)
+**Shot count rule**: 15s → 3 shots (merge Hook+Before, Transformation, CTA) · 30s → 5 shots (base template above) · 60s → 7-8 shots (expand Transformation into 2-3 demo shots + testimonial)
 
 ### Per-Shot Format (7 components — `video-prompt-design.md`)
 


### PR DESCRIPTION
## Summary

Fixes CodeRabbit CHANGES_REQUESTED on PR #13507.

- **Hash fix**: Update `simplification-state.json` entry for `.agents/content/story.md` — stale hash `e883144` (PR 13123) → current post-tighten hash `49e03dac`, pr → 13507
- **Story fix**: Rename `### 5-Shot Storyboard Structure` → `### Duration-Based Storyboard Structure (3/5/7-8 shots)` to resolve the contradiction between the fixed "5-shot" heading and the variable 3/5/7-8 shot count rule on the next line; add "base template — adjust shot count to fit runtime" note

## CodeRabbit findings addressed

- **Inline (CHANGES_REQUESTED)**: `.agents/configs/simplification-state.json` lines 2656-2657 — stale hash for story.md
- **Outside diff (Major)**: `.agents/content/story.md` lines 98-109 — 5-shot vs variable-shot contradiction

## Runtime Testing

- **Risk**: Low (docs/config only)
- **Level**: `self-assessed`