### PR TITLE
GH#13147: tighten cloudron-server-ops-skill.md

### DIFF
--- a/.agents/tools/deployment/cloudron-server-ops-skill.md
+++ b/.agents/tools/deployment/cloudron-server-ops-skill.md
@@ -57,9 +57,9 @@ cloudron repair --app <app>    # reconfigure without changing image
 cloudron clone --app <app> --location new-location
 ```
 
-`install` and `update` key flags: `--image <repo:tag>`, `--no-backup`, `-l <subdomain>`, `-s <secondary-domains>`, `-p <port-bindings>`, `-m <memory-bytes>`, `--versions-url <url>`
+Key flags for `install`/`update`: `--image <repo:tag>`, `--no-backup`, `-l <subdomain>`, `-s <secondary-domains>`, `-p <port-bindings>`, `-m <memory-bytes>`, `--versions-url <url>`
 
-**On-server build (9.1+):** From a directory with `CloudronManifest.json` + `Dockerfile`:
+**On-server build (9.1+)** — from a directory with `CloudronManifest.json` + `Dockerfile`:
 
 ```bash
 cloudron install --location myapp   # upload source, build on server, install
@@ -85,7 +85,7 @@ cloudron logs --system                 # platform system logs
 cloudron logs --system mail            # specific system service
 ```
 
-### Shell and Exec
+### Shell, Exec, and Debug
 
 ```bash
 cloudron exec --app <app>                              # interactive shell
@@ -93,9 +93,7 @@ cloudron exec --app <app> -- ls -la /app/data          # run a command
 cloudron exec --app <app> -- bash -c 'echo $CLOUDRON_MYSQL_URL'
 ```
 
-### Debug Mode
-
-When an app keeps crashing, `exec` may disconnect. Debug mode pauses the app (skips CMD) and makes the filesystem read-write:
+Debug mode pauses the app (skips CMD), makes filesystem read-write — useful when a crashing app disconnects `exec`:
 
 ```bash
 cloudron debug --app <app>             # enter debug mode


### PR DESCRIPTION
## Summary

- Merged "Shell and Exec" + "Debug Mode" into single "Shell, Exec, and Debug" section — removed redundant heading
- Compressed debug mode prose from two sentences to one while preserving all technical detail
- Minor phrasing tightening on `install`/`update` flags line and on-server build note

## Changes

- `.agents/tools/deployment/cloudron-server-ops-skill.md`: 161 → 159 lines (-2 net, 4 ins / 6 del)

## Verification

- All 13 code blocks preserved (26 fence markers before and after)
- All 3 URLs identical
- All 28 unique `cloudron` commands present
- All 15 CLI flags preserved
- markdownlint: 0 errors
- No broken internal links or references

## Runtime Testing

Risk: **Low** — documentation-only change, no code or procedural rules.
Level: `self-assessed`

Closes #13147

---
[aidevops.sh](https://aidevops.sh) v3.5.364 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 4m and 6,974 tokens on this as a headless worker.