### PR TITLE
GH#13581: tighten pages-patterns.md, remove redundant prose

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pages-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pages-patterns.md
@@ -114,18 +114,18 @@ export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
 
 ```bash
 npm create cloudflare@latest my-app -- --framework=<framework>
-# next, svelte, remix, nuxt, astro, qwik
+# next | svelte | remix | nuxt | astro | qwik
 ```
 
 [Framework Guides](https://developers.cloudflare.com/pages/framework-guides/)
 
 ## Monorepo
 
-Dashboard → Project → Settings → Build settings → Root directory → set to subproject path (e.g., `apps/web`).
+Dashboard → Project → Settings → Build settings → Root directory: set to subproject path (e.g., `apps/web`).
 
 ## Best Practices
 
-**Performance:** Exclude static via `_routes.json` · Cache with KV · Use Cache API: `await caches.default.match(request)` · Keep Functions < 1MB (tree-shake, dynamic imports)
+**Performance:** Exclude static via `_routes.json` · Use Cache API: `await caches.default.match(request)` · Keep Functions < 1MB (tree-shake, dynamic imports)
 
 **Security:** Set headers in `_headers` · Use secrets, never commit to `wrangler.toml` · Validate inputs · Rate limit with KV/DO
 


### PR DESCRIPTION
## Summary

- Remove `· Cache with KV` from Best Practices Performance bullet — redundant with the dedicated `## Caching` section above it
- Tighten Monorepo navigation path: `→ set to` → `: set to` (correct punctuation, removes extra arrow)
- Normalize framework list separator: comma-list → pipe-separated (consistent inline list style)

All code blocks and actionable content preserved. File remains 132 lines (changes are within-line, not line removals).

## Runtime Testing

Risk: **Low** — documentation-only change, no code or agent logic modified.
Level: `self-assessed`

Closes #13581

---
[aidevops.sh](https://aidevops.sh) v3.5.366 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 1m and 3,900 tokens on this as a headless worker.