### PR TITLE
GH#13579: tighten fly-io.md agent doc (140→135 lines)

### DIFF
--- a/.agents/tools/deployment/fly-io.md
+++ b/.agents/tools/deployment/fly-io.md
@@ -21,9 +21,8 @@ tools:
 - **Helper**: `.agents/scripts/fly-io-helper.sh <cmd> <app> [args]` — `deploy`, `scale <N>`, `status`, `secrets`, `volumes`, `logs`, `machines list`, `ssh`, `postgres <db> status`, `apps`
 - **Config**: `fly.toml` (per-app, repo root) | [Dashboard](https://fly.io/dashboard) | [Docs](https://fly.io/docs/) | [Pricing](https://fly.io/docs/about/pricing/)
 - **Concepts**: Fly Machines (Firecracker micro-VMs), anycast routing, auto-stop/start, Sprites (AI sandboxes), Tigris (S3-compatible storage)
-
-**Best for**: low-latency global apps, AI sandboxes, Elixir/Phoenix, multi-region DBs (LiteFS/Fly Postgres), GPU inference.
-**Not for**: serverless functions (CF Workers), static-only sites (CF Pages), Kubernetes-native, Windows containers.
+- **Best for**: low-latency global apps, AI sandboxes, Elixir/Phoenix, multi-region DBs (LiteFS/Fly Postgres), GPU inference
+- **Not for**: serverless functions (CF Workers), static-only sites (CF Pages), Kubernetes-native, Windows containers
 
 ## fly.toml
 
@@ -66,11 +65,7 @@ fly ssh console --app my-app [--command "rails db:migrate"]
 fly status --app my-app                        # Overview + health
 fly logs --app my-app                          # Stream logs
 fly config validate --app my-app               # Validate fly.toml
-```
-
-**Machines REST API** — base: `https://api.machines.dev`, token: `fly tokens create`:
-
-```bash
+# Machines REST API — base: https://api.machines.dev, token: fly tokens create
 curl "${FLY_API_HOSTNAME}/v1/apps/{app}/machines[/{id}[/{action}]]" \
   -H "Authorization: Bearer ${FLY_API_TOKEN}" [-d '{"signal":"SIGTERM","timeout":"30s"}']
 ```
@@ -126,7 +121,7 @@ fly redis attach my-redis --app my-app         # Sets REDIS_URL
 
 ## Sprites (AI Agent Sandboxes)
 
-Isolated ephemeral Machines for untrusted AI agent code. TypeScript SDK: `@fly/sprites` ([Sprites SDK](https://github.com/superfly/sprites-js)).
+TypeScript SDK: `@fly/sprites` ([Sprites SDK](https://github.com/superfly/sprites-js)).
 
 ```bash
 fly machines run my-image --app my-sprites-app --region lhr \


### PR DESCRIPTION
## Summary

- Merged `Best for`/`Not for` standalone bold lines into Quick Reference bullet list (removes orphaned paragraph break)
- Collapsed Machines REST API prose header + separate fenced block into single code block with inline comment (-4 lines)
- Removed "Isolated ephemeral Machines for untrusted AI agent code." from Sprites section — redundant with section title "AI Agent Sandboxes" (-1 line)
- All actionable content, commands, URLs, and code examples preserved

## Verification

- `wc -l`: 140 → 135 lines
- All code blocks, URLs, and command examples present before and after
- No broken internal links or references
- Agent behaviour unchanged (doc-only change, no logic)

## Runtime Testing

Risk: **Low** — documentation-only change, no code or logic modified. `self-assessed`.

Closes #13579

---
[aidevops.sh](https://aidevops.sh) v3.5.366 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 4,655 tokens on this as a headless worker.