### PR TITLE
GH#13578: tighten dns-providers.md

### DIFF
--- a/.agents/services/hosting/dns-providers.md
+++ b/.agents/services/hosting/dns-providers.md
@@ -29,7 +29,7 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Configuration
+## Config schemas
 
 **Cloudflare** (`configs/cloudflare-dns-config.json`):
 
@@ -90,39 +90,21 @@ tools:
 ./.agents/scripts/dns-helper.sh health-check route53 production example.com https://example.com/health
 ./.agents/scripts/dns-helper.sh weighted-routing route53 production example.com www A 192.168.1.100 50
 ./.agents/scripts/dns-helper.sh geo-routing route53 production example.com www A 192.168.1.100 US
-```
 
-## Security
-
-```bash
-# DNSSEC
+# Security: DNSSEC + CAA + auth checks
 ./.agents/scripts/dns-helper.sh enable-dnssec cloudflare personal example.com
-
-# CAA record (restrict certificate issuance)
 ./.agents/scripts/dns-helper.sh add cloudflare personal example.com @ CAA "0 issue letsencrypt.org"
-
-# Auth test / permission check
 ./.agents/scripts/dns-helper.sh test-auth cloudflare personal
 ./.agents/scripts/dns-helper.sh check-permissions cloudflare personal
-```
 
-## Troubleshooting
-
-```bash
-# Propagation
+# Troubleshooting: propagation + validation
 dig @8.8.8.8 example.com
 ./.agents/scripts/dns-helper.sh propagation-check example.com
 ./.agents/scripts/dns-helper.sh ttl-check example.com
-
-# Conflicts / validation
 ./.agents/scripts/dns-helper.sh conflict-check cloudflare personal example.com
 ./.agents/scripts/dns-helper.sh validate cloudflare personal example.com
 ./.agents/scripts/dns-helper.sh compare example.com cloudflare:personal namecheap:personal
-```
 
-## Operations
-
-```bash
 # Monitoring / reporting
 ./.agents/scripts/dns-helper.sh monitor-resolution example.com
 ./.agents/scripts/dns-helper.sh performance-check example.com


### PR DESCRIPTION
## Summary

- Consolidate Security, Troubleshooting, and Operations sections into a single `## Usage` code block — all commands were already in code blocks, the section headings were the only prose
- Rename `## Configuration` → `## Config schemas` (more precise)
- 141 → 123 lines (13% reduction); all commands, config schemas, and security rules preserved

## Runtime Testing

- **Risk level**: Low (docs-only change, no code)
- **Verification**: `self-assessed` — content diff confirms all commands present before and after

## Files changed

- `.agents/services/hosting/dns-providers.md` — 18 lines removed (redundant section headings and blank lines between now-merged code blocks)

Closes #13578


---
[aidevops.sh](https://aidevops.sh) v3.5.373 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 1m and 3,689 tokens on this as a headless worker.