### PR TITLE
GH#13547: tighten google-chat.md (162->160 lines)

### DIFF
--- a/.agents/services/communications/google-chat.md
+++ b/.agents/services/communications/google-chat.md
@@ -24,7 +24,7 @@ tools: { read: true, bash: true }
 
 ## Setup
 
-### Step 1: Google Cloud Project
+### Step 1: GCP Project
 
 ```bash
 gcloud projects create aidevops-chat-bot --name="aidevops Chat Bot"
@@ -37,7 +37,7 @@ gcloud iam service-accounts keys create \
 chmod 600 ~/.config/aidevops/google-chat-sa-key.json
 ```
 
-### Step 2: Configure Chat App
+### Step 2: Chat App Config
 
 Cloud Console > APIs & Services > Google Chat API > Configuration: set HTTP endpoint URL, enable "Receive 1:1 messages" + "Join spaces and group conversations", set auth audience to endpoint URL.
 
@@ -68,9 +68,7 @@ Cloud Console > APIs & Services > Google Chat API > Configuration: set HTTP endp
 
 ## Authentication
 
-### Inbound (Google → Bot)
-
-> **CRITICAL**: Verify Google's bearer token on every request — without this, anyone can send forged events.
+**Inbound (Google → Bot)** — verify Google's bearer token on every request; without this, anyone can forge events:
 
 ```typescript
 import { createRemoteJWKSet, jwtVerify } from "jose";
@@ -82,7 +80,7 @@ async function verifyGoogleChatToken(token: string, audience: string): Promise<b
 }
 ```
 
-### Outbound (Bot → Google)
+**Outbound (Bot → Google)** — service account JWT with `chat.bot` scope:
 
 ```typescript
 import { GoogleAuth } from "google-auth-library";


### PR DESCRIPTION
## Summary

- Tighten `.agents/services/communications/google-chat.md` from 162 → 160 lines (regression re-tightening)
- Merge `### Inbound` / `### Outbound` Authentication subsection headers into inline bold labels, eliminating 2 heading lines + 1 blockquote
- Shorten Setup step headers ("Google Cloud Project" → "GCP Project", "Configure Chat App" → "Chat App Config")

## Changes

| What | Before | After |
|------|--------|-------|
| Authentication subsections | 2 `###` headers + `> CRITICAL` blockquote | Inline bold labels with critical info preserved |
| Setup step headers | Verbose names | Shortened to "GCP Project", "Chat App Config" |
| Line count | 162 | 160 |

## Content Preservation

All code blocks (5 fenced), URLs (6), helper commands (11 `google-chat-helper.sh` refs), section structure, tables, and security-critical details preserved. Zero markdownlint violations.

## Runtime Testing

- **Risk**: Low (docs/agent prompt only)
- **Level**: `self-assessed`
- **Evidence**: markdownlint clean, all content elements verified present

Closes #13547

---
[aidevops.sh](https://aidevops.sh) v3.5.367 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,755 tokens on this as a headless worker.