### PR TITLE
GH#13512: tighten app-dev-expo.md

### DIFF
--- a/.agents/tools/mobile/app-dev-expo.md
+++ b/.agents/tools/mobile/app-dev-expo.md
@@ -8,9 +8,9 @@ tools: [read, write, edit, bash, glob, grep, webfetch, task, context7_*]
 
 ## Quick Reference
 
-- **Docs**: Use Context7 MCP for latest Expo and React Native docs
+- **Docs**: Context7 MCP for latest Expo/React Native docs
 - **CLI**: `npx create-expo-app`, `npx expo start`, `npx expo prebuild`
-- **Router**: Expo Router (file-based routing, like Next.js for mobile)
+- **Router**: Expo Router (file-based, like Next.js for mobile)
 - **Build**: EAS Build (`eas build`) or local (`npx expo run:ios`)
 
 ```bash
@@ -18,27 +18,8 @@ npx create-expo-app my-app --template tabs
 cd my-app && npx expo start
 ```
 
-**Key dependencies** (verify versions via Context7 before installing):
-
-| Package | Purpose |
-|---------|---------|
-| `expo-router` | File-based navigation |
-| `expo-notifications` | Push notifications |
-| `expo-secure-store` | Secure credential storage |
-| `expo-haptics` | Tactile feedback |
-| `expo-image` | Optimised image loading |
-| `expo-av` | Audio/video playback |
-| `expo-sensors` | Accelerometer, gyroscope, etc. |
-| `expo-location` | GPS and geolocation |
-| `expo-camera` | Camera access |
-| `expo-local-authentication` | Biometric auth (Face ID, fingerprint) |
-| `expo-file-system` | Local file management |
-| `expo-sharing` | Share content to other apps |
-| `expo-clipboard` | Copy/paste |
-| `expo-linking` | Deep links, URL schemes |
-| `react-native-reanimated` | Performant animations |
-| `react-native-gesture-handler` | Touch gestures |
-| `@react-native-async-storage/async-storage` | Local data persistence |
+**Key packages** (verify versions via Context7):
+`expo-router` (navigation), `expo-notifications`, `expo-secure-store` (credentials), `expo-haptics`, `expo-image`, `expo-av` (audio/video), `expo-sensors`, `expo-location`, `expo-camera`, `expo-local-authentication` (biometrics), `expo-file-system`, `expo-sharing`, `expo-clipboard`, `expo-linking` (deep links), `react-native-reanimated` (animations), `react-native-gesture-handler`, `@react-native-async-storage/async-storage`
 
 ## Project Structure
 
@@ -58,9 +39,9 @@ app/
 ├── _layout.tsx          # Root layout
 ├── +not-found.tsx       # 404 screen
 └── modal.tsx
-components/ui/           # Reusable UI components
+components/ui/           # Reusable UI
 components/forms/
-constants/Colors.ts      # Colour tokens (light/dark: primary, background, surface, text, border, success, warning, error)
+constants/Colors.ts      # Colour tokens (light/dark)
 constants/Layout.ts      # Spacing, sizing
 constants/Typography.ts  # Font families, sizes
 hooks/                   # Custom React hooks
@@ -71,20 +52,15 @@ assets/                  # Images, fonts, icons
 
 ## Development Standards
 
-**TypeScript**: Always. Define interfaces for all props, state, and API responses.
+**TypeScript**: Always. Interfaces for all props, state, API responses.
 
-**Styling**: `StyleSheet.create()` for performance. Design tokens in `constants/Colors.ts` with `light`/`dark` variants.
+**Styling**: `StyleSheet.create()`. Design tokens in `constants/Colors.ts` with `light`/`dark` variants.
 
-**Navigation** (Expo Router): `(group)` for layout groups, `[param]` for dynamic routes, `_layout.tsx` per group, `+not-found.tsx` for 404.
+**Navigation** (Expo Router): `(group)` for layouts, `[param]` for dynamic routes, `_layout.tsx` per group, `+not-found.tsx` for 404.
 
-**Animations**: `react-native-reanimated` (not `Animated` API). Key APIs: `useSharedValue` + `useAnimatedStyle`, `withSpring`, `withTiming`, `Layout` animations. Pair with `expo-haptics`.
+**Animations**: `react-native-reanimated` (not `Animated` API). `useSharedValue` + `useAnimatedStyle`, `withSpring`, `withTiming`, `Layout` animations. Pair with `expo-haptics`.
 
-**State Management**:
-- Simple: React Context + `useReducer`
-- Complex: Zustand
-- Server: TanStack Query (React Query)
-- Persistent: `@react-native-async-storage/async-storage`
-- Secure: `expo-secure-store` for tokens/credentials
+**State management**: Simple → React Context + `useReducer`. Complex → Zustand. Server → TanStack Query. Persistent → `async-storage`. Secure → `expo-secure-store`.
 
 **Performance**: `expo-image` over `Image`; `FlatList` with `getItemLayout`; `React.memo` for list items; `useDeferredValue` for heavy renders.
 
@@ -92,20 +68,18 @@ assets/                  # Images, fonts, icons
 
 ```bash
 npm install -g eas-cli && eas build:configure
-
-eas build --platform ios --profile development    # iOS simulator
-eas build --platform android --profile development # Android emulator
-eas build --platform ios --profile preview         # TestFlight
-eas build --platform ios --profile production      # App Store
-
-eas submit --platform ios      # App Store
-eas submit --platform android  # Google Play
+eas build --platform ios --profile development      # Simulator
+eas build --platform android --profile development  # Emulator
+eas build --platform ios --profile preview           # TestFlight
+eas build --platform ios --profile production        # App Store
+eas submit --platform ios                            # App Store
+eas submit --platform android                        # Google Play
 ```
 
 ## Local Development
 
 ```bash
-npx expo start           # Start dev server
+npx expo start           # Dev server
 npx expo run:ios         # iOS simulator
 npx expo run:android     # Android emulator
 npx expo prebuild        # Generate native projects


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/mobile/app-dev-expo.md` from 131 → 105 lines (20% reduction)
- Converted 20-line dependency table to compact inline list (same 17 packages, fewer tokens)
- Compressed verbose prose in Development Standards section to direct rules
- Merged EAS Build and Submit code blocks, removed redundant comments

## Verification

- All 17 packages preserved
- All code blocks, project structure, testing tools, and Related links intact
- Zero markdownlint violations
- No task IDs or issue refs in original — nothing lost

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — no runtime behaviour change

Closes #13512

---
[aidevops.sh](https://aidevops.sh) v3.5.373 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 1m and 4,211 tokens on this as a headless worker.