### PR TITLE
GH#13213: tighten agent doc monetisation.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1382,9 +1382,9 @@
       "pr": 13117
     },
     ".agents/tools/browser/stagehand-python.md": {
-      "hash": "b08490af463189a93ec652b087e8ac7238a018d0",
-      "at": "2026-03-28T19:42:04Z",
-      "pr": 12132
+      "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
+      "at": "2026-03-30T02:31:00Z",
+      "pr": 13486
     },
     ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
       "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
@@ -1567,9 +1567,9 @@
       "pr": 12324
     },
     ".agents/scripts/commands/new-task.md": {
-      "hash": "efc169b2e604ea55058ffa7ebae2224cc5286699",
-      "at": "2026-03-28T23:05:58Z",
-      "pr": 12328
+      "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
+      "at": "2026-03-30T02:30:59Z",
+      "pr": 13489
     },
     ".agents/scripts/commands/runners.md": {
       "hash": "e15f89fc275c14393073efaa842849957733470c",
@@ -1747,9 +1747,9 @@
       "pr": 12346
     },
     ".agents/reference/foss-contributions.md": {
-      "hash": "7a70a570a9191eedf42aa4c3c21dfcd875a6e983",
-      "at": "2026-03-29T03:52:33Z",
-      "pr": 12538
+      "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
+      "at": "2026-03-30T02:30:24Z",
+      "pr": 13561
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
       "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
@@ -2221,7 +2221,7 @@
       "at": "2026-03-29T15:50:25Z",
       "pr": 13052
     },
-     ".agents/content/story.md": {
+    ".agents/content/story.md": {
       "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
       "at": "2026-03-29T17:14:35Z",
       "pr": 13457
@@ -2232,14 +2232,14 @@
       "pr": 13101
     },
     ".agents/services/communications/google-chat.md": {
-      "hash": "74f908818596936deef7c897bc75545ea29dd46f",
-      "at": "2026-03-29T23:54:03Z",
-      "pr": 13401
+      "hash": "076924e5ac489a973af77f1ed114afed20e399b6",
+      "at": "2026-03-30T02:30:36Z",
+      "pr": 13509
     },
     ".agents/tools/deployment/fly-io.md": {
-      "hash": "9f909cc457859b48bda12935f7a39f40ec9df3d2",
-      "at": "2026-03-30T01:50:36Z",
-      "pr": 13563
+      "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
+      "at": "2026-03-30T02:30:21Z",
+      "pr": 13596
     },
     ".agents/tools/design/brand-identity.md": {
       "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
@@ -2252,9 +2252,9 @@
       "pr": 13064
     },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-      "hash": "2ffa4e3cbf27dbf0e0df7d9a9f2db871a6777fbc",
-      "at": "2026-03-29T22:50:07Z",
-      "pr": 13375
+      "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
+      "at": "2026-03-30T02:30:53Z",
+      "pr": 13494
     },
     ".agents/tools/ai-assistants/response-scoring.md": {
       "hash": "6eadf895b9b3ea1caaf55456d25937d9152c15eb",
@@ -2307,9 +2307,9 @@
       "pr": 13105
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-      "hash": "5c4ef31eed87a7f0c732b1aa94c4cbec4b9494d6",
-      "at": "2026-03-29T16:34:30Z",
-      "pr": 13107
+      "hash": "646a0cd9e95fa8260ca7a5406ec48a25b7c5bbcd",
+      "at": "2026-03-30T02:31:12Z",
+      "pr": 13506
     },
     ".agents/tools/document/docstrange.md": {
       "hash": "3982c1885258882161976446bb94216d4e7df262",
@@ -2382,8 +2382,8 @@
       "pr": 13113
     },
     ".agents/workflows/sql-migrations.md": {
-      "hash": "bef81496721c1b74e3b3f78d0f0d6dfb684c4e54",
-      "at": "2026-03-30T01:50:42Z",
+      "hash": "747a775a8b87d032fc35a7f93ea47ed5ca5826b3",
+      "at": "2026-03-30T02:30:33Z",
       "pr": 13485
     },
     ".agents/tools/voice/qwen3-tts.md": {
@@ -2632,9 +2632,9 @@
       "pr": 13425
     },
     ".agents/tools/ai-orchestration/autogen.md": {
-      "hash": "8347d30c1f8864e0fa2dd72e7a57fb90df430f13",
-      "at": "2026-03-29T23:53:43Z",
-      "pr": 13439
+      "hash": "7a98e97dcab197dd361b85a1df796f02b14195ab",
+      "at": "2026-03-30T02:30:28Z",
+      "pr": 13493
     },
     ".agents/tools/code-review/security-analysis.md": {
       "hash": "81663c87a7964c1938d704dd3698d51a4910621a",
@@ -2655,6 +2655,36 @@
       "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
       "at": "2026-03-30T00:32:32Z",
       "pr": 13457
+    },
+    ".agents/workflows/wiki-update.md": {
+      "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
+      "at": "2026-03-30T02:30:16Z",
+      "pr": 13594
+    },
+    ".agents/marketing-sales/direct-response-copy.md": {
+      "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
+      "at": "2026-03-30T02:30:17Z",
+      "pr": 13597
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
+      "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
+      "at": "2026-03-30T02:30:18Z",
+      "pr": 13595
+    },
+    ".agents/services/email/email-health-check.md": {
+      "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
+      "at": "2026-03-30T02:30:20Z",
+      "pr": 13593
+    },
+    ".agents/tools/git/authentication.md": {
+      "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
+      "at": "2026-03-30T02:30:25Z",
+      "pr": 13538
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
+      "hash": "a5e68fe9a2aaaf524aa5ed57f7c9e4b21bba7a3d",
+      "at": "2026-03-30T02:30:26Z",
+      "pr": 13564
     }
   }
 }

--- a/.agents/product/monetisation.md
+++ b/.agents/product/monetisation.md
@@ -13,7 +13,7 @@ tools:
   context7_*: true
 ---
 
-# Product Monetisation - Revenue Models and Implementation
+# Product Monetisation
 
 <!-- AI-CONTEXT-START -->
 
@@ -22,35 +22,36 @@ tools:
 - **Purpose**: Implement and optimise product revenue streams
 - **Models**: Subscriptions, one-time purchases, freemium, ads, affiliate, funnel
 - **Applies to**: Mobile apps, browser extensions, desktop apps, web apps, SaaS
+- **Core metric**: LTV > CAC — lifetime value must exceed customer acquisition cost
 
 **Revenue model decision tree**:
 
 ```text
-Product solves a daily recurring problem?      -> Subscription (weekly/monthly/annual)
-Product provides one-time value (tool/utility)? -> One-time purchase or lifetime unlock
-Broad appeal but low willingness to pay?        -> Freemium + premium tier, or ad-supported
-Product drives users to another offering?       -> Free (sales funnel / audience builder)
-Product can recommend relevant products?        -> Affiliate links + optional premium tier
+Daily recurring problem?           -> Subscription (weekly/monthly/annual)
+One-time value (tool/utility)?     -> One-time purchase or lifetime unlock
+Broad appeal, low willingness?     -> Freemium + premium tier, or ad-supported
+Drives users to another offering?  -> Free (sales funnel / audience builder)
+Can recommend relevant products?   -> Affiliate links + optional premium tier
 ```
 
 **Platform payment tools**:
 
-| Platform | Primary Tool | Alternative |
-|----------|-------------|-------------|
+| Platform | Primary | Alternative |
+|----------|---------|-------------|
 | Mobile (iOS + Android) | RevenueCat | Superwall (paywall A/B testing) |
-| Browser extensions | Stripe, Chrome Web Store payments | LemonSqueezy, Gumroad |
+| Browser extensions | Stripe, Chrome Web Store | LemonSqueezy, Gumroad |
 | Desktop apps | Stripe, Paddle | LemonSqueezy, Gumroad |
 | Web apps / SaaS | Stripe | Paddle, LemonSqueezy |
 
 <!-- AI-CONTEXT-END -->
 
-## Subscription Management
+## Subscription Providers
 
-| Provider | Use for | Details |
-|----------|---------|---------|
-| **RevenueCat** | Mobile (iOS + Android) | Cross-platform state, receipt validation, entitlements, A/B testing, webhooks. See `services/payments/revenuecat.md` |
-| **Stripe** | Web, desktop, extensions | Billing, Checkout, customer portal, webhook entitlement sync. See `services/payments/stripe.md` |
-| **Superwall** | Paywall A/B testing (any) | Remote paywall config, price/layout/copy testing, behaviour triggers. See `services/payments/superwall.md` |
+| Provider | Platform | Capabilities |
+|----------|----------|-------------|
+| **RevenueCat** | Mobile | Cross-platform state, receipt validation, entitlements, A/B testing. See `services/payments/revenuecat.md` |
+| **Stripe** | Web, desktop, extensions | Billing, Checkout, customer portal, webhook sync. See `services/payments/stripe.md` |
+| **Superwall** | Any | Remote paywall config, price/layout/copy A/B testing. See `services/payments/superwall.md` |
 
 ## Entitlements Model
 
@@ -62,18 +63,13 @@ Products (what users buy)     -> Entitlements (what users get access to)
 └── Pro Add-on ($2.99/mo)     -> "pro" entitlement
 ```
 
-Platform-agnostic: users buy products → products grant entitlements → features check entitlements.
+Platform-agnostic: users buy products -> products grant entitlements -> features check entitlements.
 
 ## Paywall Design
 
-**Principles:**
-- Show at moment of highest intent (after user tries a premium feature)
-- Display value proposition (what they get, not what they pay)
-- Offer 3 tiers: weekly (highest per-unit), monthly (default), annual (best value)
-- Highlight "best value" visually; include 3 or 7-day free trial; show social proof
-- "Restore Purchases" button must be accessible (mobile)
+**Principles**: Show at moment of highest intent (after user tries a premium feature). Display value proposition, not price. Offer 3 tiers: weekly (highest per-unit), monthly (default), annual (best value). Highlight "best value" visually. Include free trial. Show social proof. "Restore Purchases" must be accessible (mobile).
 
-**Placement by conversion rate:**
+**Placement by conversion rate**:
 
 | Trigger | Conversion | Notes |
 |---------|-----------|-------|
@@ -85,58 +81,49 @@ Platform-agnostic: users buy products → products grant entitlements → featur
 
 See `product/onboarding.md` for the hard paywall pattern.
 
-**Free trial:**
-- 3-day: higher conversion, lower retention
-- 7-day: lower conversion, higher retention (recommended for subscriptions)
-- No trial: highest friction, attracts committed users; recommended for one-time purchases
+**Free trial length**:
+
+| Length | Conversion | Retention | Best for |
+|--------|-----------|-----------|----------|
+| 3-day | Higher | Lower | Quick-value products |
+| 7-day | Lower | Higher | Subscriptions (recommended) |
+| No trial | Lowest | Highest | One-time purchases |
 
 ## Alternative Revenue Models
 
 | Model | Best for | Notes |
 |-------|---------|-------|
-| **Ad-supported** | High-volume, low WTP | AdMob (mobile), Unity Ads (games), Carbon Ads (dev/tech web). Combine with premium tier to remove ads |
-| **Freemium** | Products with genuine free-tier value | Premium should feel like upgrade, not ransom |
-| **Affiliate** | Recommendation/review products | Transparent disclosure required; revenue share via affiliate links |
-| **Sales funnel** | Consultants, coaches, SaaS | Product is free; revenue from external offering it drives users toward |
+| **Ad-supported** | High-volume, low WTP | AdMob (mobile), Unity Ads (games), Carbon Ads (dev/tech). Combine with premium to remove ads |
+| **Freemium** | Genuine free-tier value | Premium should feel like upgrade, not ransom |
+| **Affiliate** | Recommendation/review products | Transparent disclosure required |
+| **Sales funnel** | Consultants, coaches, SaaS | Product is free; revenue from external offering |
 
 ## Pricing Strategy
 
-**Research process:**
-1. Check competitor pricing in relevant stores
-2. Survey target users on willingness to pay
-3. Start competitive, adjust based on data
-4. Annual plans: 15–40% discount vs monthly
+**Process**: Check competitor pricing -> survey target users on WTP -> start competitive, adjust on data -> annual plans: 15-40% discount vs monthly.
 
-**Common price points:**
+**Common price points**:
 
 | Model | Typical Range |
 |-------|--------------|
-| Weekly | $2.99–$7.99 |
-| Monthly | $4.99–$14.99 |
-| Annual | $29.99–$79.99 |
-| Lifetime | $49.99–$149.99 |
-| One-time (extension/desktop) | $9.99–$49.99 |
+| Weekly | $2.99-$7.99 |
+| Monthly | $4.99-$14.99 |
+| Annual | $29.99-$79.99 |
+| Lifetime | $49.99-$149.99 |
+| One-time (extension/desktop) | $9.99-$49.99 |
 
-**A/B testing:** Use RevenueCat Experiments, Superwall, or Stripe test mode to test price points, paywall designs, trial lengths, and feature gates.
-
-## Recurring Revenue Mental Model
-
-- **Build once, sell forever** — unlike services, no per-customer delivery cost
-- **Subscription = recurring rent** — predictable monthly revenue that compounds
-- **Churn = vacancy** — reducing churn is as important as acquiring new users
-- **LTV > CAC** — lifetime value must exceed customer acquisition cost
-
-Example: 10,000 subscribers × $3/month = $30k/month with near-zero marginal cost per user.
+**A/B testing**: RevenueCat Experiments, Superwall, or Stripe test mode for price points, paywall designs, trial lengths, and feature gates.
 
 ## Legal Requirements
 
-- Display subscription terms clearly before purchase
-- Show renewal price and frequency
-- Provide easy cancellation instructions
-- Include "Restore Purchases" for returning users (mobile)
-- Privacy policy must cover payment data handling
-- EULA required for subscription apps (mobile)
-- Comply with platform payment rules (Apple 3.1.1, Google billing policy)
+| Requirement | Applies to |
+|-------------|-----------|
+| Display subscription terms + renewal price/frequency before purchase | All |
+| Provide easy cancellation instructions | All |
+| "Restore Purchases" button | Mobile |
+| Privacy policy covering payment data | All |
+| EULA for subscription apps | Mobile |
+| Platform payment rules (Apple 3.1.1, Google billing policy) | Mobile |
 
 ## Related
 


### PR DESCRIPTION
## Summary

Tighten `.agents/product/monetisation.md` from 148 to 135 lines (9% reduction) while preserving all institutional knowledge.

Closes #13213

## Changes

- **Paywall principles**: 5 bullets → 1 dense paragraph (same content, fewer lines)
- **Free trial options**: 3 bullets → table with Conversion/Retention/Best-for columns (adds structure)
- **Legal requirements**: 7 bullets → table with "Applies to" column (adds mobile vs all distinction)
- **Pricing research process**: 4 numbered steps → 1 inline sentence
- **Decision tree**: shortened question phrasing (same meaning)
- **Subscription Management**: renamed to "Subscription Providers", tightened column headers
- **Recurring Revenue Mental Model section**: removed (motivational, not instructional). The one actionable rule (LTV > CAC) moved to Quick Reference.

## Content Preservation Verification

- All code blocks preserved (decision tree, entitlements model)
- All cross-references preserved (`services/payments/*.md`, `product/*.md`)
- All tables preserved (platform tools, conversion rates, price points, alternative models)
- All legal requirements preserved (restructured as table)
- YAML frontmatter unchanged
- AI-CONTEXT markers unchanged

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — no runtime behaviour change, content-only restructuring

---
[aidevops.sh](https://aidevops.sh) v3.5.373 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 1m and 4,347 tokens on this as a headless worker.