### PR TITLE
GH#13212: tighten agent doc unstract.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1382,9 +1382,9 @@
       "pr": 13117
     },
     ".agents/tools/browser/stagehand-python.md": {
-      "hash": "b08490af463189a93ec652b087e8ac7238a018d0",
-      "at": "2026-03-28T19:42:04Z",
-      "pr": 12132
+      "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
+      "at": "2026-03-30T02:31:00Z",
+      "pr": 13486
     },
     ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
       "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
@@ -1567,9 +1567,9 @@
       "pr": 12324
     },
     ".agents/scripts/commands/new-task.md": {
-      "hash": "efc169b2e604ea55058ffa7ebae2224cc5286699",
-      "at": "2026-03-28T23:05:58Z",
-      "pr": 12328
+      "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
+      "at": "2026-03-30T02:30:59Z",
+      "pr": 13489
     },
     ".agents/scripts/commands/runners.md": {
       "hash": "e15f89fc275c14393073efaa842849957733470c",
@@ -1747,9 +1747,9 @@
       "pr": 12346
     },
     ".agents/reference/foss-contributions.md": {
-      "hash": "7a70a570a9191eedf42aa4c3c21dfcd875a6e983",
-      "at": "2026-03-29T03:52:33Z",
-      "pr": 12538
+      "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
+      "at": "2026-03-30T02:30:24Z",
+      "pr": 13561
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
       "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
@@ -2221,7 +2221,7 @@
       "at": "2026-03-29T15:50:25Z",
       "pr": 13052
     },
-     ".agents/content/story.md": {
+    ".agents/content/story.md": {
       "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
       "at": "2026-03-29T17:14:35Z",
       "pr": 13457
@@ -2232,14 +2232,14 @@
       "pr": 13101
     },
     ".agents/services/communications/google-chat.md": {
-      "hash": "74f908818596936deef7c897bc75545ea29dd46f",
-      "at": "2026-03-29T23:54:03Z",
-      "pr": 13401
+      "hash": "076924e5ac489a973af77f1ed114afed20e399b6",
+      "at": "2026-03-30T02:30:36Z",
+      "pr": 13509
     },
     ".agents/tools/deployment/fly-io.md": {
-      "hash": "9f909cc457859b48bda12935f7a39f40ec9df3d2",
-      "at": "2026-03-30T01:50:36Z",
-      "pr": 13563
+      "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
+      "at": "2026-03-30T02:30:21Z",
+      "pr": 13596
     },
     ".agents/tools/design/brand-identity.md": {
       "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
@@ -2252,9 +2252,9 @@
       "pr": 13064
     },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-      "hash": "2ffa4e3cbf27dbf0e0df7d9a9f2db871a6777fbc",
-      "at": "2026-03-29T22:50:07Z",
-      "pr": 13375
+      "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
+      "at": "2026-03-30T02:30:53Z",
+      "pr": 13494
     },
     ".agents/tools/ai-assistants/response-scoring.md": {
       "hash": "6eadf895b9b3ea1caaf55456d25937d9152c15eb",
@@ -2307,9 +2307,9 @@
       "pr": 13105
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-      "hash": "5c4ef31eed87a7f0c732b1aa94c4cbec4b9494d6",
-      "at": "2026-03-29T16:34:30Z",
-      "pr": 13107
+      "hash": "646a0cd9e95fa8260ca7a5406ec48a25b7c5bbcd",
+      "at": "2026-03-30T02:31:12Z",
+      "pr": 13506
     },
     ".agents/tools/document/docstrange.md": {
       "hash": "3982c1885258882161976446bb94216d4e7df262",
@@ -2382,8 +2382,8 @@
       "pr": 13113
     },
     ".agents/workflows/sql-migrations.md": {
-      "hash": "bef81496721c1b74e3b3f78d0f0d6dfb684c4e54",
-      "at": "2026-03-30T01:50:42Z",
+      "hash": "747a775a8b87d032fc35a7f93ea47ed5ca5826b3",
+      "at": "2026-03-30T02:30:33Z",
       "pr": 13485
     },
     ".agents/tools/voice/qwen3-tts.md": {
@@ -2632,9 +2632,9 @@
       "pr": 13425
     },
     ".agents/tools/ai-orchestration/autogen.md": {
-      "hash": "8347d30c1f8864e0fa2dd72e7a57fb90df430f13",
-      "at": "2026-03-29T23:53:43Z",
-      "pr": 13439
+      "hash": "7a98e97dcab197dd361b85a1df796f02b14195ab",
+      "at": "2026-03-30T02:30:28Z",
+      "pr": 13493
     },
     ".agents/tools/code-review/security-analysis.md": {
       "hash": "81663c87a7964c1938d704dd3698d51a4910621a",
@@ -2655,6 +2655,36 @@
       "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
       "at": "2026-03-30T00:32:32Z",
       "pr": 13457
+    },
+    ".agents/workflows/wiki-update.md": {
+      "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
+      "at": "2026-03-30T02:30:16Z",
+      "pr": 13594
+    },
+    ".agents/marketing-sales/direct-response-copy.md": {
+      "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
+      "at": "2026-03-30T02:30:17Z",
+      "pr": 13597
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
+      "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
+      "at": "2026-03-30T02:30:18Z",
+      "pr": 13595
+    },
+    ".agents/services/email/email-health-check.md": {
+      "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
+      "at": "2026-03-30T02:30:20Z",
+      "pr": 13593
+    },
+    ".agents/tools/git/authentication.md": {
+      "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
+      "at": "2026-03-30T02:30:25Z",
+      "pr": 13538
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
+      "hash": "a5e68fe9a2aaaf524aa5ed57f7c9e4b21bba7a3d",
+      "at": "2026-03-30T02:30:26Z",
+      "pr": 13564
     }
   }
 }

--- a/.agents/services/document-processing/unstract.md
+++ b/.agents/services/document-processing/unstract.md
@@ -22,33 +22,28 @@ mcp:
 
 - **Purpose**: Extract structured data from unstructured documents (PDFs, images, DOCX, etc.)
 - **MCP Server**: `unstract/mcp-server` (Docker) or `@unstract/mcp-server` (npx)
-- **Tool**: `unstract_tool` - submits files to Unstract API, polls for completion, returns structured JSON
+- **Tool**: `unstract_tool` — submit file to Unstract API, poll for completion, return structured JSON
 - **Credentials**: `UNSTRACT_API_KEY` + `API_BASE_URL` in `~/.config/aidevops/credentials.sh` (chmod 600)
 - **Docs**: https://docs.unstract.com/unstract/unstract_platform/mcp/unstract_platform_mcp_server/
 - **GitHub**: https://github.com/Zipstack/unstract
-- **On-demand loading**: MCP disabled globally; enabled per-agent when document extraction is needed
+- **Loading**: MCP disabled globally; enabled per-agent when document extraction needed
 - **Trigger keywords**: document, extract, parse, invoice, statement, PDF, OCR, unstructured
 
 <!-- AI-CONTEXT-END -->
 
 ## Supported File Types
 
-| Category | Formats |
-|----------|---------|
-| Documents | PDF, DOCX, DOC, ODT, TXT, CSV, JSON |
-| Spreadsheets | XLSX, XLS, ODS |
-| Presentations | PPTX, PPT, ODP |
-| Images | PNG, JPG, JPEG, TIFF, BMP, GIF, WEBP |
+- **Documents**: PDF, DOCX, DOC, ODT, TXT, CSV, JSON
+- **Spreadsheets**: XLSX, XLS, ODS
+- **Presentations**: PPTX, PPT, ODP
+- **Images**: PNG, JPG, JPEG, TIFF, BMP, GIF, WEBP
 
-## MCP Tool
-
-### `unstract_tool`
-
-Submits a file to the Unstract API, polls for completion, and returns structured extraction results.
+## MCP Tool: `unstract_tool`
 
 **Parameters**:
-- `file_path` (required): Path to the document to process
-- `include_metadata` (optional): Include extraction metadata in response
+
+- `file_path` (required): Path to document
+- `include_metadata` (optional): Include extraction metadata
 - `include_metrics` (optional): Include processing metrics (tokens, cost)
 
 **Example prompt**: "Process the document /tmp/invoice.pdf"
@@ -58,15 +53,15 @@ Submits a file to the Unstract API, polls for completion, and returns structured
 ### Option A: Cloud (Quick Start)
 
 1. Sign up at https://unstract.com/start-for-free/ (14-day free trial)
-2. Create a Prompt Studio project, define extraction schema, deploy as API endpoint
-3. Store credentials (preferred: `~/.aidevops/agents/scripts/setup-local-api-keys.sh`; or manually in `~/.config/aidevops/credentials.sh` chmod 600):
+2. Create Prompt Studio project, define extraction schema, deploy as API endpoint
+3. Store credentials (preferred: `setup-local-api-keys.sh`; or manually in `credentials.sh`):
 
 ```bash
 export UNSTRACT_API_KEY="your_api_key_here"
 export API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
 ```
 
-### Option B: Self-Hosted (Local) - Recommended
+### Option B: Self-Hosted (Recommended)
 
 Requires Docker, 8GB RAM. Full data privacy — no documents leave your machine.
 
@@ -75,7 +70,7 @@ Requires Docker, 8GB RAM. Full data privacy — no documents leave your machine.
 # Or: ~/.aidevops/agents/scripts/setup-mcp-integrations.sh unstract
 ```
 
-Clones to `~/.aidevops/unstract/`, disables analytics, starts Docker Compose. Visit http://frontend.unstract.localhost (login: unstract/unstract)
+Clones to `~/.aidevops/unstract/`, disables analytics, starts Docker Compose. Visit http://frontend.unstract.localhost (login: unstract/unstract).
 
 **Management:**
 
@@ -83,18 +78,18 @@ Clones to `~/.aidevops/unstract/`, disables analytics, starts Docker Compose. Vi
 ~/.aidevops/agents/scripts/unstract-helper.sh start|stop|status|logs|configure-llm|uninstall
 ```
 
-Set credentials pointing at local instance (preferred: `~/.aidevops/agents/scripts/setup-local-api-keys.sh`; or manually):
+Set credentials for local instance (preferred: `setup-local-api-keys.sh`; or manually):
 
 ```bash
 export UNSTRACT_API_KEY="your_api_key_here"
 export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
 ```
 
-**Note**: The MCP expects `API_BASE_URL` (not prefixed). This matches the official Unstract spec.
+MCP expects `API_BASE_URL` (not prefixed) — matches official Unstract spec.
 
 ### LLM Adapters (Self-Hosted)
 
-Add existing API keys as adapters in Unstract UI (Settings > Adapters). Run `~/.aidevops/agents/scripts/unstract-helper.sh configure-llm` to see configured keys.
+Add API keys as adapters in Unstract UI (Settings > Adapters). Run `unstract-helper.sh configure-llm` to see configured keys.
 
 | Your Key | Unstract Adapter |
 |----------|-----------------|
@@ -107,9 +102,9 @@ Add existing API keys as adapters in Unstract UI (Settings > Adapters). Run `~/.
 
 For fully local/offline operation, use **Ollama** — no cloud API keys needed.
 
-### OpenCode / Claude Desktop Configuration
+### Runtime Configuration
 
-- **OpenCode**: See `configs/mcp-templates/unstract.json` (on-demand, disabled globally)
+- **Claude Code / OpenCode**: See `configs/mcp-templates/unstract.json` (on-demand, disabled globally)
 - **Claude Desktop** (Docker):
 
 ```json
@@ -137,12 +132,12 @@ For fully local/offline operation, use **Ollama** — no cloud API keys needed.
 - **KYC/onboarding**: Parse identity documents and application forms
 - **Contract analysis**: Extract key terms, dates, parties from legal documents
 
-## Analytics / Telemetry
+## Telemetry
 
-The `unstract/mcp-server` Docker image has no telemetry. For self-hosted, disable frontend analytics: set `REACT_APP_ENABLE_POSTHOG=false` in `frontend/.env`. The cloud API may collect server-side usage metrics — use self-hosted if this is a concern.
+`unstract/mcp-server` Docker image: no telemetry. Self-hosted: set `REACT_APP_ENABLE_POSTHOG=false` in `frontend/.env`. Cloud API may collect server-side metrics — use self-hosted if concerned.
 
 ## Related
 
-- `tools/context/mcp-discovery.md` - On-demand MCP loading pattern
-- `.agents/aidevops/mcp-integrations.md` - All MCP integrations
-- `configs/mcp-templates/unstract.json` - OpenCode config template
+- `tools/context/mcp-discovery.md` — on-demand MCP loading pattern
+- `.agents/aidevops/mcp-integrations.md` — all MCP integrations
+- `configs/mcp-templates/unstract.json` — config template


### PR DESCRIPTION
## Summary

- Tighten `.agents/services/document-processing/unstract.md` from 148 → 143 lines
- Convert file types table to bullet list, merge redundant headings, compress prose
- Zero knowledge loss: all code blocks, URLs, commands, env vars, and adapter table preserved

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdownlint-cli2 passes with 0 errors, diff confirms all code blocks and references intact

## Changes

- File types: table → bullet list (faster to scan, 2 fewer lines)
- `## MCP Tool` + `### unstract_tool` → single `## MCP Tool: unstract_tool` heading
- Removed redundant tool description (already in Quick Reference)
- Shortened verbose script paths where context is clear
- Fixed runtime config section: "OpenCode" → "Claude Code / OpenCode"
- Consistent em-dash formatting in Related section

Closes #13212

---
[aidevops.sh](https://aidevops.sh) v3.5.373 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 2m and 4,780 tokens on this as a headless worker.