### PR TITLE
GH#13211: tighten pulumi-gotchas.md from 148 to 100 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1382,9 +1382,9 @@
       "pr": 13117
     },
     ".agents/tools/browser/stagehand-python.md": {
-      "hash": "b08490af463189a93ec652b087e8ac7238a018d0",
-      "at": "2026-03-28T19:42:04Z",
-      "pr": 12132
+      "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
+      "at": "2026-03-30T02:31:00Z",
+      "pr": 13486
     },
     ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
       "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
@@ -1567,9 +1567,9 @@
       "pr": 12324
     },
     ".agents/scripts/commands/new-task.md": {
-      "hash": "efc169b2e604ea55058ffa7ebae2224cc5286699",
-      "at": "2026-03-28T23:05:58Z",
-      "pr": 12328
+      "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
+      "at": "2026-03-30T02:30:59Z",
+      "pr": 13489
     },
     ".agents/scripts/commands/runners.md": {
       "hash": "e15f89fc275c14393073efaa842849957733470c",
@@ -1747,9 +1747,9 @@
       "pr": 12346
     },
     ".agents/reference/foss-contributions.md": {
-      "hash": "7a70a570a9191eedf42aa4c3c21dfcd875a6e983",
-      "at": "2026-03-29T03:52:33Z",
-      "pr": 12538
+      "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
+      "at": "2026-03-30T02:30:24Z",
+      "pr": 13561
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
       "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
@@ -2221,7 +2221,7 @@
       "at": "2026-03-29T15:50:25Z",
       "pr": 13052
     },
-     ".agents/content/story.md": {
+    ".agents/content/story.md": {
       "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
       "at": "2026-03-29T17:14:35Z",
       "pr": 13457
@@ -2232,14 +2232,14 @@
       "pr": 13101
     },
     ".agents/services/communications/google-chat.md": {
-      "hash": "74f908818596936deef7c897bc75545ea29dd46f",
-      "at": "2026-03-29T23:54:03Z",
-      "pr": 13401
+      "hash": "076924e5ac489a973af77f1ed114afed20e399b6",
+      "at": "2026-03-30T02:30:36Z",
+      "pr": 13509
     },
     ".agents/tools/deployment/fly-io.md": {
-      "hash": "9f909cc457859b48bda12935f7a39f40ec9df3d2",
-      "at": "2026-03-30T01:50:36Z",
-      "pr": 13563
+      "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
+      "at": "2026-03-30T02:30:21Z",
+      "pr": 13596
     },
     ".agents/tools/design/brand-identity.md": {
       "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
@@ -2252,9 +2252,9 @@
       "pr": 13064
     },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-      "hash": "2ffa4e3cbf27dbf0e0df7d9a9f2db871a6777fbc",
-      "at": "2026-03-29T22:50:07Z",
-      "pr": 13375
+      "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
+      "at": "2026-03-30T02:30:53Z",
+      "pr": 13494
     },
     ".agents/tools/ai-assistants/response-scoring.md": {
       "hash": "6eadf895b9b3ea1caaf55456d25937d9152c15eb",
@@ -2307,9 +2307,9 @@
       "pr": 13105
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-      "hash": "5c4ef31eed87a7f0c732b1aa94c4cbec4b9494d6",
-      "at": "2026-03-29T16:34:30Z",
-      "pr": 13107
+      "hash": "646a0cd9e95fa8260ca7a5406ec48a25b7c5bbcd",
+      "at": "2026-03-30T02:31:12Z",
+      "pr": 13506
     },
     ".agents/tools/document/docstrange.md": {
       "hash": "3982c1885258882161976446bb94216d4e7df262",
@@ -2382,8 +2382,8 @@
       "pr": 13113
     },
     ".agents/workflows/sql-migrations.md": {
-      "hash": "bef81496721c1b74e3b3f78d0f0d6dfb684c4e54",
-      "at": "2026-03-30T01:50:42Z",
+      "hash": "747a775a8b87d032fc35a7f93ea47ed5ca5826b3",
+      "at": "2026-03-30T02:30:33Z",
       "pr": 13485
     },
     ".agents/tools/voice/qwen3-tts.md": {
@@ -2632,9 +2632,9 @@
       "pr": 13425
     },
     ".agents/tools/ai-orchestration/autogen.md": {
-      "hash": "8347d30c1f8864e0fa2dd72e7a57fb90df430f13",
-      "at": "2026-03-29T23:53:43Z",
-      "pr": 13439
+      "hash": "7a98e97dcab197dd361b85a1df796f02b14195ab",
+      "at": "2026-03-30T02:30:28Z",
+      "pr": 13493
     },
     ".agents/tools/code-review/security-analysis.md": {
       "hash": "81663c87a7964c1938d704dd3698d51a4910621a",
@@ -2655,6 +2655,36 @@
       "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
       "at": "2026-03-30T00:32:32Z",
       "pr": 13457
+    },
+    ".agents/workflows/wiki-update.md": {
+      "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
+      "at": "2026-03-30T02:30:16Z",
+      "pr": 13594
+    },
+    ".agents/marketing-sales/direct-response-copy.md": {
+      "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
+      "at": "2026-03-30T02:30:17Z",
+      "pr": 13597
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
+      "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
+      "at": "2026-03-30T02:30:18Z",
+      "pr": 13595
+    },
+    ".agents/services/email/email-health-check.md": {
+      "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
+      "at": "2026-03-30T02:30:20Z",
+      "pr": 13593
+    },
+    ".agents/tools/git/authentication.md": {
+      "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
+      "at": "2026-03-30T02:30:25Z",
+      "pr": 13538
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
+      "hash": "a5e68fe9a2aaaf524aa5ed57f7c9e4b21bba7a3d",
+      "at": "2026-03-30T02:30:26Z",
+      "pr": 13564
     }
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md
@@ -33,23 +33,6 @@ config:
   app:zoneId: "xyz789"
 ```
 
-**Explicit provider configuration** (multi-account):
-
-```typescript
-const devProvider = new cloudflare.Provider("dev", {apiToken: devToken});
-const prodProvider = new cloudflare.Provider("prod", {apiToken: prodToken});
-const devWorker = new cloudflare.WorkerScript("dev-worker", {
-    accountId: devAccountId, name: "worker", content: code,
-}, {provider: devProvider});
-```
-
-**Resource naming** — prefix with stack name:
-
-```typescript
-const stack = pulumi.getStack();
-const kv = new cloudflare.WorkersKvNamespace(`${stack}-kv`, {accountId, title: `${stack}-my-kv`});
-```
-
 **Protect production resources:**
 
 ```typescript
@@ -69,6 +52,8 @@ const worker = new cloudflare.WorkerScript("worker", {
 }, {dependsOn: [migration]});
 ```
 
+For multi-account providers, resource naming, and environment patterns, see [pulumi-patterns.md](./pulumi-patterns.md).
+
 ## Security
 
 **Secrets management:**
@@ -80,11 +65,8 @@ const worker = new cloudflare.WorkerScript("worker", {
     accountId, name: "my-worker", content: code,
     secretTextBindings: [{name: "API_KEY", text: apiKey}],
 });
-```
-
-```bash
-pulumi config set --secret apiKey "secret-value"
-export CLOUDFLARE_API_TOKEN="..."
+// CLI: pulumi config set --secret apiKey "secret-value"
+// Env: export CLOUDFLARE_API_TOKEN="..."
 ```
 
 **API token scopes** (minimal permissions): Workers — `Workers Routes:Edit`, `Workers Scripts:Edit` | KV — `Workers KV Storage:Edit` | R2 — `R2:Edit` | D1 — `D1:Edit` | DNS — `Zone:Edit`, `DNS:Edit` | Pages — `Pages:Edit`
@@ -111,37 +93,7 @@ pulumi import cloudflare:index/r2Bucket:R2Bucket my-bucket <account_id>/<bucket_
 
 ## CI/CD
 
-**GitHub Actions:**
-
-```yaml
-name: Deploy
-on: [push]
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: pulumi/actions@v4
-        with:
-          command: up
-          stack-name: prod
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-```
-
-**GitLab CI:**
-
-```yaml
-deploy:
-  image: pulumi/pulumi:latest
-  script:
-    - pulumi stack select prod
-    - pulumi up --yes
-  only: [main]
-  variables:
-    CLOUDFLARE_API_TOKEN: $CLOUDFLARE_API_TOKEN
-```
+Use [`pulumi/actions@v4`](https://github.com/pulumi/actions) (GitHub Actions) or `pulumi/pulumi:latest` image (GitLab CI). Set `PULUMI_ACCESS_TOKEN` and `CLOUDFLARE_API_TOKEN` as secrets. Run `pulumi up --yes` with `--stack prod`.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md` from 148 to 100 lines (32% reduction)
- Remove generic CI/CD YAML boilerplate (GitHub Actions + GitLab CI) — compress to one-line reference with action name, image, and required secrets
- Remove multi-account provider and resource naming code examples that duplicate `pulumi-patterns.md` — add cross-reference instead
- Merge secrets management bash commands into TypeScript code block as inline comments

## What's preserved

All institutional knowledge: error table (4 rows), debugging commands (5), stack config YAML, protect pattern, dependency ordering, secrets management, API token scopes, state security, performance tips (3), migration import commands (3), Terraform/Wrangler migration note, resource links (4 URLs).

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — markdownlint clean, all code blocks/URLs/commands verified present

Closes #13211

---
[aidevops.sh](https://aidevops.sh) v3.5.374 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,068 tokens on this as a headless worker.