### PR TITLE
GH#13283: tighten agent doc Email Sequences Framework

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1382,9 +1382,9 @@
       "pr": 13117
     },
     ".agents/tools/browser/stagehand-python.md": {
-      "hash": "b08490af463189a93ec652b087e8ac7238a018d0",
-      "at": "2026-03-28T19:42:04Z",
-      "pr": 12132
+      "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
+      "at": "2026-03-30T02:31:00Z",
+      "pr": 13486
     },
     ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
       "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
@@ -1567,9 +1567,9 @@
       "pr": 12324
     },
     ".agents/scripts/commands/new-task.md": {
-      "hash": "efc169b2e604ea55058ffa7ebae2224cc5286699",
-      "at": "2026-03-28T23:05:58Z",
-      "pr": 12328
+      "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
+      "at": "2026-03-30T02:30:59Z",
+      "pr": 13489
     },
     ".agents/scripts/commands/runners.md": {
       "hash": "e15f89fc275c14393073efaa842849957733470c",
@@ -1747,9 +1747,9 @@
       "pr": 12346
     },
     ".agents/reference/foss-contributions.md": {
-      "hash": "7a70a570a9191eedf42aa4c3c21dfcd875a6e983",
-      "at": "2026-03-29T03:52:33Z",
-      "pr": 12538
+      "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
+      "at": "2026-03-30T02:30:24Z",
+      "pr": 13561
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
       "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
@@ -2221,7 +2221,7 @@
       "at": "2026-03-29T15:50:25Z",
       "pr": 13052
     },
-     ".agents/content/story.md": {
+    ".agents/content/story.md": {
       "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
       "at": "2026-03-29T17:14:35Z",
       "pr": 13457
@@ -2232,14 +2232,14 @@
       "pr": 13101
     },
     ".agents/services/communications/google-chat.md": {
-      "hash": "74f908818596936deef7c897bc75545ea29dd46f",
-      "at": "2026-03-29T23:54:03Z",
-      "pr": 13401
+      "hash": "076924e5ac489a973af77f1ed114afed20e399b6",
+      "at": "2026-03-30T02:30:36Z",
+      "pr": 13509
     },
     ".agents/tools/deployment/fly-io.md": {
-      "hash": "9f909cc457859b48bda12935f7a39f40ec9df3d2",
-      "at": "2026-03-30T01:50:36Z",
-      "pr": 13563
+      "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
+      "at": "2026-03-30T02:30:21Z",
+      "pr": 13596
     },
     ".agents/tools/design/brand-identity.md": {
       "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
@@ -2252,9 +2252,9 @@
       "pr": 13064
     },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-      "hash": "2ffa4e3cbf27dbf0e0df7d9a9f2db871a6777fbc",
-      "at": "2026-03-29T22:50:07Z",
-      "pr": 13375
+      "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
+      "at": "2026-03-30T02:30:53Z",
+      "pr": 13494
     },
     ".agents/tools/ai-assistants/response-scoring.md": {
       "hash": "6eadf895b9b3ea1caaf55456d25937d9152c15eb",
@@ -2307,9 +2307,9 @@
       "pr": 13105
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-      "hash": "5c4ef31eed87a7f0c732b1aa94c4cbec4b9494d6",
-      "at": "2026-03-29T16:34:30Z",
-      "pr": 13107
+      "hash": "646a0cd9e95fa8260ca7a5406ec48a25b7c5bbcd",
+      "at": "2026-03-30T02:31:12Z",
+      "pr": 13506
     },
     ".agents/tools/document/docstrange.md": {
       "hash": "3982c1885258882161976446bb94216d4e7df262",
@@ -2382,8 +2382,8 @@
       "pr": 13113
     },
     ".agents/workflows/sql-migrations.md": {
-      "hash": "bef81496721c1b74e3b3f78d0f0d6dfb684c4e54",
-      "at": "2026-03-30T01:50:42Z",
+      "hash": "747a775a8b87d032fc35a7f93ea47ed5ca5826b3",
+      "at": "2026-03-30T02:30:33Z",
       "pr": 13485
     },
     ".agents/tools/voice/qwen3-tts.md": {
@@ -2632,9 +2632,9 @@
       "pr": 13425
     },
     ".agents/tools/ai-orchestration/autogen.md": {
-      "hash": "8347d30c1f8864e0fa2dd72e7a57fb90df430f13",
-      "at": "2026-03-29T23:53:43Z",
-      "pr": 13439
+      "hash": "7a98e97dcab197dd361b85a1df796f02b14195ab",
+      "at": "2026-03-30T02:30:28Z",
+      "pr": 13493
     },
     ".agents/tools/code-review/security-analysis.md": {
       "hash": "81663c87a7964c1938d704dd3698d51a4910621a",
@@ -2655,6 +2655,36 @@
       "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
       "at": "2026-03-30T00:32:32Z",
       "pr": 13457
+    },
+    ".agents/workflows/wiki-update.md": {
+      "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
+      "at": "2026-03-30T02:30:16Z",
+      "pr": 13594
+    },
+    ".agents/marketing-sales/direct-response-copy.md": {
+      "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
+      "at": "2026-03-30T02:30:17Z",
+      "pr": 13597
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
+      "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
+      "at": "2026-03-30T02:30:18Z",
+      "pr": 13595
+    },
+    ".agents/services/email/email-health-check.md": {
+      "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
+      "at": "2026-03-30T02:30:20Z",
+      "pr": 13593
+    },
+    ".agents/tools/git/authentication.md": {
+      "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
+      "at": "2026-03-30T02:30:25Z",
+      "pr": 13538
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
+      "hash": "a5e68fe9a2aaaf524aa5ed57f7c9e4b21bba7a3d",
+      "at": "2026-03-30T02:30:26Z",
+      "pr": 13564
     }
   }
 }

--- a/.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md
@@ -1,16 +1,14 @@
 # Email Sequences Framework
 
-> "Email has an ability many channels don't: creating valuable, personal touches—at scale." — David Newman
+Email converts 2-5x vs social, you own the list, ~$36 ROI per $1. Works for acquisition, nurturing, retention.
 
-Email converts at 2-5x the rate of social media, you own the list, and it delivers ~$36 ROI per $1 spent. Works for acquisition, nurturing, and retention.
-
-**For copy-paste templates**: See [Email Sequence Templates](direct-response-copy-templates-email-sequences.md).
+**Copy-paste templates**: [Email Sequence Templates](direct-response-copy-templates-email-sequences.md)
 
 ---
 
 ## Anatomy of a High-Converting Email
 
-### Subject Line (50% of Your Success)
+### Subject Line Formulas
 
 | Formula | Example |
 |---------|---------|
@@ -25,15 +23,15 @@ Email converts at 2-5x the rate of social media, you own the list, and it delive
 | Contrarian | "Why I stopped chasing backlinks" |
 | Direct | "Your free trial starts now" |
 
-**Best practices**: 40-50 characters (mobile), first 3 words must hook, avoid spam triggers (FREE!!!, $$$$), preview text extends subject line.
+40-50 chars (mobile-first), first 3 words must hook, avoid spam triggers (FREE!!!, $$$$), preview text extends subject.
 
-### Email Structure: Star-Chain-Hook
+### Structure: Star-Chain-Hook
 
 - **Star**: Attention-grabbing opening (fact, bold statement, question, mini-story)
-- **Chain**: Facts, benefits, proof points, emotional connection, objection handling
+- **Chain**: Facts, benefits, proof, emotional connection, objection handling
 - **Hook**: Clear CTA with deadline if applicable
 
-### The PAS Template
+### PAS Template
 
 ```text
 Subject: [Problem-focused subject line]
@@ -48,93 +46,86 @@ But here's the thing... [Solution + brief explanation + social proof]
 
 ---
 
-## Core Email Sequences
+## Core Sequences
 
-### 1. Welcome Sequence (5-7 Emails Over 2 Weeks)
+### 1. Welcome (5-7 Emails, 2 Weeks)
 
-**Purpose**: Deliver lead magnet, build trust, introduce brand, make first offer.
+Deliver lead magnet, build trust, introduce brand, make first offer.
 
-| Email | Timing | Goal | Key Element |
-|-------|--------|------|-------------|
-| 1 — Welcome | Day 0 | Deliver resource, set expectations | Origin story teaser, social link |
-| 2 — Origin Story | Day 1-2 | Build connection through vulnerability | Relatable struggle, reply prompt |
-| 3 — Quick Win | Day 3-4 | Prove value with immediate result | Actionable 3-step tip |
-| 4 — Social Proof | Day 5-7 | Build trust through results | Before/after case study |
-| 5 — The Pitch | Day 7-10 | Convert to customer | Offer + incentive + guarantee |
+| # | Timing | Goal | Key Element |
+|---|--------|------|-------------|
+| 1 | Day 0 | Deliver resource, set expectations | Origin story teaser, social link |
+| 2 | Day 1-2 | Build connection through vulnerability | Relatable struggle, reply prompt |
+| 3 | Day 3-4 | Prove value with immediate result | Actionable 3-step tip |
+| 4 | Day 5-7 | Build trust through results | Before/after case study |
+| 5 | Day 7-10 | Convert to customer | Offer + incentive + guarantee |
 
-### 2. Nurture Sequence (Ongoing — Weekly/Bi-Weekly)
+### 2. Nurture (Ongoing, Weekly/Bi-Weekly)
 
-**Content Mix**: 80% value (tips, insights, stories) / 20% promotion (soft sells, offers)
+80% value (tips, insights, stories) / 20% promotion (soft sells, offers).
 
 | Type | Purpose | Example Subject |
 |------|---------|-----------------|
 | Educational | Teach something useful | "The 3-step framework for [result]" |
-| Story | Share a lesson through narrative | "I almost quit until this happened" |
+| Story | Lesson through narrative | "I almost quit until this happened" |
 | Curated | Share valuable resources | "5 things I'm reading this week" |
 | Behind-the-scenes | Build connection | "What I'm working on right now" |
 | Social proof | Show results | "How [Customer] achieved [Result]" |
 | Soft pitch | Mention product naturally | "The tool that saved me 10 hours/week" |
 
-### 3. Launch Sequence (7-10 Emails Over 7-14 Days)
+### 3. Launch (7-10 Emails, 7-14 Days)
 
-**Purpose**: Build anticipation, reveal product, handle objections, close with urgency.
+Build anticipation, reveal product, handle objections, close with urgency.
 
-| Email | Timing | Goal | Key Element |
-|-------|--------|------|-------------|
-| 1 — Announcement | Day 0 | Tease launch, build anticipation | Calendar date, waitlist CTA |
-| 2 — The Problem | Day 2 | Agitate pain, show why existing solutions fail | Problem deep-dive |
-| 3 — The Solution | Day 4 | Show what's possible, preview approach | Success story |
-| 4 — The Reveal | Day 5 | Launch — present full offer | Benefits, bonuses, price, CTA |
-| 5 — FAQ | Day 6 | Handle objections | Q&A format, guarantee reminder |
-| 6 — Social Proof | Day 7 | Reinforce with results | Customer screenshots/quotes |
-| 7 — Urgency | Day 9 | Create deadline pressure | 48-hour countdown |
-| 8 — Last Chance | Day 10 | Final close | Midnight deadline, reply offer |
+| # | Timing | Goal | Key Element |
+|---|--------|------|-------------|
+| 1 | Day 0 | Tease launch, build anticipation | Calendar date, waitlist CTA |
+| 2 | Day 2 | Agitate pain, show why existing solutions fail | Problem deep-dive |
+| 3 | Day 4 | Show what's possible, preview approach | Success story |
+| 4 | Day 5 | Launch — present full offer | Benefits, bonuses, price, CTA |
+| 5 | Day 6 | Handle objections | Q&A format, guarantee reminder |
+| 6 | Day 7 | Reinforce with results | Customer screenshots/quotes |
+| 7 | Day 9 | Create deadline pressure | 48-hour countdown |
+| 8 | Day 10 | Final close | Midnight deadline, reply offer |
 
-### 4. Cart Abandonment Sequence (3 Emails)
+### 4. Cart Abandonment (3 Emails)
 
-**Purpose**: Recover lost sales with escalating incentives.
+Recover lost sales with escalating incentives.
 
-| Email | Timing | Goal | Key Element |
-|-------|--------|------|-------------|
-| 1 — Reminder | 1 hour | Gentle nudge, offer help | Cart link, reply prompt |
-| 2 — Objection Handling | 24 hours | Address common concerns | FAQ format, guarantee |
-| 3 — Final + Incentive | 48 hours | Last push with discount | Coupon code, 24h expiry |
+| # | Timing | Goal | Key Element |
+|---|--------|------|-------------|
+| 1 | 1 hour | Gentle nudge, offer help | Cart link, reply prompt |
+| 2 | 24 hours | Address common concerns | FAQ format, guarantee |
+| 3 | 48 hours | Last push with discount | Coupon code, 24h expiry |
 
-### 5. SaaS Trial Sequence (7 Emails Over 14 Days)
+### 5. SaaS Trial (7 Emails, 14 Days)
 
-**Purpose**: Drive activation, demonstrate value, convert to paid.
+Drive activation, demonstrate value, convert to paid.
 
-| Email | Timing | Goal | Key Element |
-|-------|--------|------|-------------|
-| 1 — Welcome + Quick Start | Day 0 | Get to "aha moment" fast | 3-step setup, app link |
-| 2 — Feature Highlight #1 | Day 2 | Show key differentiator | Direct link to feature |
-| 3 — Social Proof | Day 4 | Build confidence with results | Customer quote + specific numbers |
-| 4 — Check-In | Day 7 | Re-engage, surface blockers | Reply prompt, call booking |
-| 5 — Feature Highlight #2 | Day 9 | Show hidden value | Underutilized feature |
-| 6 — Trial Ending Soon | Day 12 | Create urgency | Loss aversion (what they'll lose) |
-| 7 — Last Day + Incentive | Day 14 | Final conversion push | Discount code, guarantee |
-
----
-
-## Email Best Practices
-
-| Email Type | Best Send Time |
-|------------|----------------|
-| B2B | Tuesday-Thursday, 9-11 AM |
-| B2C | Weekends can work; test 8 PM |
-| Transactional | Immediately |
-| Cart abandonment | 1 hour, 24 hours, 48 hours |
-
-**Length**: Subject lines 40-50 chars, preview text 40-100 chars, body 200-500 words (sales emails 500-1000).
-
-**Formatting**: Short paragraphs (1-3 sentences), one clear CTA per email, mobile-friendly (50%+ read on mobile), plain text often outperforms HTML.
-
-**Personalization**: [First Name] in subject increases opens, [Company Name] for B2B, behavioral triggers, segment by engagement level.
-
-## Subject Line Testing Checklist
-
-Would I open this? · Under 50 chars? · Preview text complements it? · Curiosity, urgency, or clear benefit? · Matches email content? · Free of spam triggers? · Tested on mobile?
+| # | Timing | Goal | Key Element |
+|---|--------|------|-------------|
+| 1 | Day 0 | Get to "aha moment" fast | 3-step setup, app link |
+| 2 | Day 2 | Show key differentiator | Direct link to feature |
+| 3 | Day 4 | Build confidence with results | Customer quote + specific numbers |
+| 4 | Day 7 | Re-engage, surface blockers | Reply prompt, call booking |
+| 5 | Day 9 | Show hidden value | Underutilized feature |
+| 6 | Day 12 | Create urgency | Loss aversion (what they'll lose) |
+| 7 | Day 14 | Final conversion push | Discount code, guarantee |
 
 ---
 
-**Further reading**: [Headline Formulas](headline-formulas.md) · [Objection Handling](objection-handling.md) · [Templates](direct-response-copy-templates-email-sequences.md)
+## Best Practices
+
+**Send timing**: B2B Tue-Thu 9-11 AM · B2C test weekends/8 PM · Transactional immediately · Cart abandonment 1h/24h/48h
+
+**Length**: Subject 40-50 chars · Preview text 40-100 chars · Body 200-500 words (sales 500-1000)
+
+**Formatting**: Short paragraphs (1-3 sentences) · One CTA per email · Mobile-first (50%+ read on mobile) · Plain text often outperforms HTML
+
+**Personalization**: [First Name] in subject increases opens · [Company Name] for B2B · Behavioral triggers · Segment by engagement level
+
+**Subject line checklist**: Would I open this? · Under 50 chars? · Preview text complements? · Curiosity/urgency/benefit? · Matches content? · No spam triggers? · Tested on mobile?
+
+---
+
+**Further reading**: [Templates](direct-response-copy-templates-email-sequences.md)


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md` (140 → 131 lines)
- Removed decorative quote, verbose labels, redundant `**Purpose**:` prefixes
- Consolidated best practices section from table + paragraphs into compact inline format
- Fixed dead links to non-existent `headline-formulas.md` and `objection-handling.md`
- Simplified table headers (`Email` name column → `#` since heading provides context)

## Content Preservation

All institutional knowledge preserved:
- All 10 subject line formulas with examples
- Star-Chain-Hook structure and PAS template (code block intact)
- All 5 core sequences with every table row
- All timing, goal, and key element data
- Best practices (send timing, length, formatting, personalization)
- Subject line testing checklist
- Link to templates file
- All specific numbers ($36 ROI, 2-5x, 80/20 split, etc.)

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — content diff reviewed, all knowledge items accounted for

Closes #13283

---
[aidevops.sh](https://aidevops.sh) v3.5.375 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 2m and 5,546 tokens on this as a headless worker.