### PR TITLE
GH#13001: tighten meta-ads-creative-psychology.md

### DIFF
--- a/.agents/marketing-sales/meta-ads-creative-psychology.md
+++ b/.agents/marketing-sales/meta-ads-creative-psychology.md
@@ -1,26 +1,20 @@
 # The Psychology of Scroll-Stopping Creative
 
-> Understanding how humans process information in a feed is the foundation of effective ad creative.
-
----
-
 ## How People Scroll
 
-**Eye-tracking findings:** Average time on content: 1.7s. Engagement decision: 0.5–1s. 80%+ scroll without sound. Thumb does ~90% of scrolling. F/Z-pattern eye movement.
+**Eye-tracking:** Average content time: 1.7s. Engagement decision: 0.5–1s. 80%+ scroll without sound. Thumb ~90% of scrolling. F/Z-pattern eye movement.
 
-**The three-second window:**
+**Three-second window:**
 
-| Second | Question | Brain activity |
-|--------|----------|----------------|
+| Second | User question | Brain activity |
+|--------|---------------|----------------|
 | 0–1 | "What is this?" | Visual registers; categorises (ad/content/friend) |
 | 1–2 | "Is this for me?" | Message absorption; relevance assessment |
 | 2–3 | "Should I stop?" | Hook payoff; curiosity created or not |
 
-**Mobile-first (90%+ of Meta impressions):** Vertical formats (9:16, 4:5) preferred. Text must be large. First 1–2 inches = prime real estate. Thumb zone (bottom-right) = CTA placement.
+**Mobile-first (90%+ of Meta impressions):** Vertical (9:16, 4:5). Large text. First 1–2 inches = prime real estate. Thumb zone (bottom-right) = CTA placement.
 
 **Sound-off (80% of feed video):** Captions mandatory. Visual storytelling must work silently. Text overlays carry the message.
-
----
 
 ## Attention Science
 
@@ -34,15 +28,13 @@
 | Complex visuals, industry jargon | Clean visuals, plain language |
 | Many choices | One clear CTA |
 
-**Mere exposure effect:** People prefer things they've seen before. Consistent brand visuals build familiarity; retargeting works partly through exposure.
+**Mere exposure effect:** People prefer familiar things. Consistent brand visuals build familiarity; retargeting works partly through exposure.
 
 **Novelty vs familiarity:** Too familiar = ignored. Too novel = confusing. Sweet spot = familiar enough to understand, novel enough to notice.
 
----
-
 ## Pattern Interrupts
 
-Something that breaks the expected visual pattern of a feed, forcing attention.
+Breaks the expected visual pattern of a feed, forcing attention.
 
 | Type | Examples |
 |------|---------|
@@ -53,22 +45,22 @@ Something that breaks the expected visual pattern of a feed, forcing attention.
 | Emotional | Strong facial expression; surprising image |
 
 **Hook examples:**
+
 - `[HAND SLAPS TABLE] "Stop scrolling. This is important."` — motion + direct address
 - `[CLOSE-UP SHOCKED FACE] "I can't believe this worked"` — emotion + curiosity
 - `[BOLD TEXT ON BLACK] "EVERYTHING YOU KNOW ABOUT [TOPIC] IS WRONG"` — contrast + controversy
 - `[PRODUCT FLYING IN] "This little thing changed my life"` — motion + intrigue
 
-**Warning:** Pattern interrupt ≠ clickbait. Interrupt gets attention; content must deliver on the promise. Bait-and-switch = user feels tricked.
-
----
+Pattern interrupt ≠ clickbait. Interrupt gets attention; content must deliver on the promise. Bait-and-switch = user feels tricked.
 
 ## Visual Hierarchy
 
 Priority order: largest/boldest → supporting visual → body text → CTA.
 
-**Hierarchy tools:** Size (bigger = more important), colour (contrast draws eyes), position (top-left reads first in LTR), space (isolation creates importance).
+**Tools:** Size (bigger = more important), colour (contrast draws eyes), position (top-left reads first in LTR), space (isolation creates importance).
 
 **Mobile zones:**
+
 - Top third: hook text or key visual (must stop scroll)
 - Middle third: supporting info, social proof
 - Bottom third: CTA, price/offer
@@ -82,9 +74,7 @@ Priority order: largest/boldest → supporting visual → body text → CTA.
 | CTA buried | Make CTA prominent |
 | Text too small | Minimum 24px for key text |
 
----
-
-## The Psychology of Persuasion
+## Persuasion Psychology
 
 **Cialdini's principles:**
 
@@ -107,11 +97,9 @@ Priority order: largest/boldest → supporting visual → body text → CTA.
 
 **Endowment effect:** People value things more once they "own" them. Apply via free trials, "Your free [thing] is waiting", personalisation ("Your custom plan").
 
----
-
 ## Emotional Triggers
 
-**Hierarchy by motivational strength:**
+**By motivational strength:**
 
 | Strength | Emotions |
 |----------|---------|
@@ -120,13 +108,14 @@ Priority order: largest/boldest → supporting visual → body text → CTA.
 | Weaker | Trust (reliability/safety), Anticipation (future reward) |
 
 **Hook templates by emotion:**
+
 - **Fear:** "Are you making this expensive mistake?" / "You're leaving $X on the table every month"
 - **Desire:** "What would you do with 10 extra hours per week?" / "Imagine waking up to [outcome]"
 - **Curiosity:** "I discovered this by accident…" / "The one thing [experts] won't tell you"
 - **Anger:** "Tired of [frustration]?" / "We built this because we were fed up with [status quo]"
 - **Humour:** "POV: You just discovered [product]" / "The face you make when [relatable situation]"
 
-**Match emotion to funnel stage:**
+**Emotion → funnel stage:**
 
 | Stage | Best emotions |
 |-------|--------------|
@@ -134,11 +123,9 @@ Priority order: largest/boldest → supporting visual → body text → CTA.
 | Consideration | Desire, Trust, Social proof |
 | Decision | Scarcity, Loss aversion, Urgency |
 
----
-
 ## Scroll-Stopping Formula
 
-```
+```text
 1. PATTERN INTERRUPT (0–1s)  — motion, contrast, face, or text breaks the scroll
 2. HOOK (1–3s)               — curiosity/fear/desire trigger; "Is this for me?" = YES
 3. VALUE DELIVERY (3–10s)    — fulfil the hook promise; build understanding
@@ -147,6 +134,7 @@ Priority order: largest/boldest → supporting visual → body text → CTA.
 ```
 
 **Pre-launch checklist:**
+
 - [ ] What pattern does this interrupt?
 - [ ] What emotion does this trigger?
 - [ ] Is the visual hierarchy clear?
@@ -154,7 +142,5 @@ Priority order: largest/boldest → supporting visual → body text → CTA.
 - [ ] Is cognitive load minimised?
 - [ ] What persuasion principle is at work?
 - [ ] Would I stop scrolling for this?
-
----
 
 *Next: [Creative Formats](formats.md)*


### PR DESCRIPTION
## Summary

- Tightened prose in `.agents/marketing-sales/meta-ads-creative-psychology.md` (160 → 146 lines, 8.75% reduction)
- Removed decorative blockquote intro and horizontal rules between sections
- Compressed verbose section intros and headings without losing content
- Added `text` language tag to fenced code block (fixes MD040)
- All 8 tables, 4 hook examples, 7-item checklist, Cialdini principles, emotional triggers, and internal link preserved

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** `self-assessed` — markdownlint clean, content preservation verified via table row count (46/46) and internal link check

Closes #13001

---
[aidevops.sh](https://aidevops.sh) v3.5.378 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,183 tokens on this as a headless worker.