### PR TITLE
GH#13009: tighten agent doc react-context.md

### DIFF
--- a/.agents/tools/ui/react-context.md
+++ b/.agents/tools/ui/react-context.md
@@ -34,13 +34,13 @@ tools:
 | Forgetting `"use client"` | Context requires client-side React — add at top of file |
 | Mutating state directly | Always use setter functions — React won't detect direct mutation |
 
-**Adding New State Checklist**: Update interface -> Update hook defaults -> Add `useState` in provider -> Add `useCallback` setter -> Add to provider value object -> Update CSS variables if needed.
+**Adding New State Checklist**: interface -> hook defaults -> `useState` in provider -> `useCallback` setter -> provider value object -> CSS variables if needed.
 
 <!-- AI-CONTEXT-END -->
 
 ## Full Provider Example
 
-Authoritative reference — interface, context, hooks (with fallback + optional), cookie persistence, CSS variables, clamped setters.
+Authoritative reference — interface, context, hooks (fallback + optional), cookie persistence, CSS variables, clamped setters.
 
 ```tsx
 "use client";
@@ -118,7 +118,7 @@ export function SidebarProvider({ children, defaultOpen = false, defaultWidth = 
 
 ## Usage Patterns
 
-**Conditional rendering** — use `useSidebarOptional()` to skip rendering when no provider exists:
+**Conditional rendering** — `useSidebarOptional()` skips rendering when no provider:
 
 ```tsx
 const AISidebarToggle = () => {
@@ -128,7 +128,7 @@ const AISidebarToggle = () => {
 };
 ```
 
-**Server-side cookie hydration** — read initial state in a server component:
+**Server-side cookie hydration** — read initial state in server component:
 
 ```tsx
 import { cookies } from "next/headers";


### PR DESCRIPTION
## Summary

- Tightened prose in `.agents/tools/ui/react-context.md` (158 lines, instruction doc classification)
- Removed redundant verbs from checklist, filler words from descriptions, converted to active voice
- All 4 code blocks, hazards table (6 rows), related links, and YAML frontmatter preserved identically

## Classification

**Instruction doc** — not reference corpus. The file was already well-structured. ~73 of 158 lines are authoritative code blocks that cannot be compressed. Prose tightening was modest and appropriate.

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, diff reviewed, content preservation verified

## Changes

| Line | Before | After |
|------|--------|-------|
| 37 | `Update interface -> Update hook defaults -> Add useState...` | `interface -> hook defaults -> useState...` |
| 43 | `(with fallback + optional)` | `(fallback + optional)` |
| 121 | `use useSidebarOptional() to skip rendering when no provider exists` | `useSidebarOptional() skips rendering when no provider` |
| 131 | `in a server component` | `in server component` |

Closes #13009

---
[aidevops.sh](https://aidevops.sh) v3.5.378 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,388 tokens on this as a headless worker.