### PR TITLE
GH#13516: tighten settings.md reference (130→115 lines)

### DIFF
--- a/.agents/reference/settings.md
+++ b/.agents/reference/settings.md
@@ -1,15 +1,11 @@
 # aidevops Settings Reference
 
-**File**: `~/.config/aidevops/settings.json` — canonical config, created by `setup.sh` or `settings-helper.sh init`
+**File**: `~/.config/aidevops/settings.json` — created by `setup.sh` or `settings-helper.sh init`
 **Helper**: `~/.aidevops/agents/scripts/settings-helper.sh`
 
-## Precedence
+**Precedence** (highest wins): env var (`AIDEVOPS_*`) → `settings.json` → built-in default
 
-Highest wins: **env var** (`AIDEVOPS_*`) → **settings.json** → **built-in default**
-
-Env vars override without editing the file — useful for CI/CD or one-off runs.
-
-## Settings Reference
+## Settings
 
 ### auto_update
 
@@ -37,10 +33,10 @@ Env vars override without editing the file — useful for CI/CD or one-off runs.
 | `supervisor.circuit_breaker_max_failures` | number | `3` | -- | Consecutive failures before dispatch pauses. |
 | `supervisor.strategic_review_hours` | number | `4` | -- | Hours between opus-tier queue health reviews. |
 | `supervisor.peak_hours_enabled` | boolean | `false` | `AIDEVOPS_PEAK_HOURS_ENABLED` | Cap workers during peak window. **Disabled by default.** |
-| `supervisor.peak_hours_start` | number | `5` | `AIDEVOPS_PEAK_HOURS_START` | Peak window start hour (0–23, local time). |
-| `supervisor.peak_hours_end` | number | `11` | `AIDEVOPS_PEAK_HOURS_END` | Peak window end hour (0–23, exclusive). Overnight: set start > end. |
+| `supervisor.peak_hours_start` | number | `5` | `AIDEVOPS_PEAK_HOURS_START` | Peak window start hour (0–23, local time). Overnight: set start > end. |
+| `supervisor.peak_hours_end` | number | `11` | `AIDEVOPS_PEAK_HOURS_END` | Peak window end hour (0–23, exclusive). |
 | `supervisor.peak_hours_tz` | string | `"America/Los_Angeles"` | `AIDEVOPS_PEAK_HOURS_TZ` | Documentation label — pulse uses system `date +%H`. |
-| `supervisor.peak_hours_worker_fraction` | number | `0.2` | `AIDEVOPS_PEAK_HOURS_WORKER_FRACTION` | Fraction of off-peak workers allowed during peak (min 1, rounded up). |
+| `supervisor.peak_hours_worker_fraction` | number | `0.2` | `AIDEVOPS_PEAK_HOURS_WORKER_FRACTION` | Fraction of off-peak workers allowed during peak (min 1, rounded up). `calculate_max_workers()` applies this after the RAM-based clamp — cap can only reduce, never increase. |
 
 ### repo_sync
 
@@ -105,16 +101,7 @@ Edit directly: `${EDITOR:-vi} ~/.config/aidevops/settings.json`
 
 ## Migration from Environment Variables
 
-Env vars continue to work as overrides — no migration required. To consolidate, remove `AIDEVOPS_*` exports from your shell config and set values in settings.json instead.
-
-| Old env var | settings.json key |
-|-------------|-------------------|
-| `AIDEVOPS_AUTO_UPDATE=false` | `auto_update.enabled = false` |
-| `AIDEVOPS_UPDATE_INTERVAL=30` | `auto_update.interval_minutes = 30` |
-| `AIDEVOPS_SKILL_AUTO_UPDATE=false` | `auto_update.skill_auto_update = false` |
-| `AIDEVOPS_TOOL_AUTO_UPDATE=false` | `auto_update.tool_auto_update = false` |
-| `AIDEVOPS_SUPERVISOR_PULSE=false` | `supervisor.pulse_enabled = false` |
-| `AIDEVOPS_REPO_SYNC=false` | `repo_sync.enabled = false` |
+Env vars continue to work as overrides — no migration required. To consolidate, remove `AIDEVOPS_*` exports from your shell config and set values in `settings.json` instead. The `Env Var` column in each table above shows the mapping.
 
 ## Peak Hours Configuration
 
@@ -126,5 +113,3 @@ settings-helper.sh set supervisor.peak_hours_start 5
 settings-helper.sh set supervisor.peak_hours_end 11
 settings-helper.sh set supervisor.peak_hours_worker_fraction 0.2
 ```
-
-`calculate_max_workers()` in `pulse-wrapper.sh` applies `apply_peak_hours_cap()` after the RAM-based clamp — the cap can only reduce, never increase, the worker count. Overnight windows: set `start > end` (e.g., `start=22, end=6`).


### PR DESCRIPTION
## Summary

- Collapse `## Precedence` section to a single inline line (removes 3 lines)
- Remove redundant `## Settings Reference` heading (file title already says this)
- Merge overnight/peak-hours notes into `peak_hours_start` description cell
- Move `calculate_max_workers()` implementation detail into `peak_hours_worker_fraction` row where it belongs
- Replace 8-line migration table with a one-liner — the `Env Var` column in each settings table already shows the mapping

## Verification

- All keys, defaults, env vars, and command examples present before and after
- No broken internal references
- `wc -l`: 130 → 115 lines (12% reduction)
- Risk: **Low** (docs only, no code changes) — self-assessed

## Runtime Testing

**Level**: `self-assessed` — docs-only change, no executable code modified.

Closes #13516

---
[aidevops.sh](https://aidevops.sh) v3.5.373 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 3,797 tokens on this as a headless worker.