### PR TITLE
GH#13449: tighten cqrs-events.md prose (198→191 lines)

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md
@@ -4,13 +4,11 @@
 
 ## When to Use
 
-> **Warning:** "You should be very cautious about using CQRS... the majority of cases I've run into have not been so good." — Martin Fowler
+> "You should be very cautious about using CQRS... the majority of cases I've run into have not been so good." — Martin Fowler
 
 **CQRS — use when:** Read/write workloads scale differently; complex queries don't map to the domain model; event sourcing is used; simpler approaches are proven insufficient. **Skip when:** Simple CRUD; similar read/write patterns; small team or simple domain. Applies to specific bounded contexts, never entire systems.
 
-**Event Sourcing — use when:** Complete audit trail required; need to reconstruct state at any point in time; domain is inherently event-driven (financial transactions, workflows). **Avoid when:** Simple CRUD; team unfamiliar with event-driven patterns; adding retroactively.
-
-> **Warning:** "Extremely difficult to add Event Sourcing to systems not originally designed for it." — Martin Fowler
+**Event Sourcing — use when:** Complete audit trail required; need to reconstruct state at any point in time; domain is inherently event-driven (financial transactions, workflows). **Avoid when:** Simple CRUD; team unfamiliar with event-driven patterns; adding retroactively. "Extremely difficult to add Event Sourcing to systems not originally designed for it." — Fowler
 
 **Event Sourcing requirements:**
 1. **Events store deltas** — what changed, not final state (enables reversal)
@@ -168,7 +166,7 @@ class OutboxProcessor:
 
 ## Saga Pattern (Cross-Aggregate Workflows)
 
-Use sagas for workflows spanning multiple aggregates — not raw domain event coordination.
+Use sagas for workflows spanning multiple aggregates — not raw domain event coordination. **Choreography:** each service listens/publishes events (simpler, harder to trace). **Orchestration:** central coordinator manages steps (explicit, easier to debug).
 
 ```
 Saga: PlaceOrderSaga
@@ -178,12 +176,9 @@ Saga: PlaceOrderSaga
 └── Compensating actions if any step fails
 ```
 
-- **Choreography:** Each service listens/publishes events (simpler, harder to trace)
-- **Orchestration:** Central coordinator manages steps (explicit, easier to debug)
-
 ## Idempotent Consumer
 
-**Required for reliable event processing** — messages may be delivered more than once.
+**Required for reliable event processing** — messages may be delivered more than once. Options: store processed IDs in DB; use broker deduplication; design handlers to be naturally idempotent.
 
 ```
 class OrderConfirmedHandler:
@@ -194,5 +189,3 @@ class OrderConfirmedHandler:
         doWork(event)
         processedIds.add(event.eventId)
 ```
-
-**Implementation options:** Store processed message IDs in database; use message broker's deduplication features; design handlers to be naturally idempotent.


### PR DESCRIPTION
## Summary

- Merged duplicate `> **Warning:**` blockquotes — second Fowler quote inlined into Event Sourcing paragraph (same content, fewer structural elements)
- Inlined Saga choreography/orchestration bullet list into the section intro sentence
- Inlined Idempotent Consumer "Implementation options" trailing paragraph into the section header sentence

All code blocks, Mermaid diagram, URLs, and knowledge preserved verbatim. 198 → 191 lines.

## Classification

Reference corpus (domain knowledge base with code examples) — prose tightened, no content removed.

## Runtime Testing

Risk level: **Low** — documentation only, no executable code changed.
Testing: `self-assessed` — content preservation verified via diff review; all code blocks, URLs, and section headings present before and after.

Closes #13449

---
[aidevops.sh](https://aidevops.sh) v3.5.376 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 5,693 tokens on this as a headless worker.