### PR TITLE
GH#13335: tighten meta-ads-optimization-metrics.md

### DIFF
--- a/.agents/marketing-sales/meta-ads-optimization-metrics.md
+++ b/.agents/marketing-sales/meta-ads-optimization-metrics.md
@@ -85,7 +85,7 @@ CPA = Spend ÷ Actions = CPC ÷ Conversion Rate ← lower via: lower CPC, higher
 
 ### Ad Relevance Diagnostics
 
-Quality / Engagement Rate / Conversion Rate Rankings:
+Applies to Quality, Engagement Rate, and Conversion Rate rankings:
 
 | Ranking | Meaning |
 |---------|---------|
@@ -159,9 +159,11 @@ Use MER for cross-channel budget allocation. Use Incremental ROAS for true ROI r
 
 Set via Ads Manager → Columns → Customize Columns.
 
-- **Ecommerce:** ROAS, Cost Per Purchase, Purchase Conversion Value, Website Purchases, CTR (Link Click), CPM, Frequency, Reach
-- **Lead Gen:** Cost Per Lead, Leads, Lead Conversion Rate, CTR (Link Click), Landing Page Views, CPM, Frequency, Quality Ranking
-- **Video:** ThruPlay Cost, ThruPlays, 3-Second Video Views, Video Average Watch Time, CTR (All), CPM, Reach, Frequency
+| Objective | Columns |
+|-----------|---------|
+| **Ecommerce** | ROAS, Cost Per Purchase, Purchase Conversion Value, Website Purchases, CTR (Link Click), CPM, Frequency, Reach |
+| **Lead Gen** | Cost Per Lead, Leads, Lead Conversion Rate, CTR (Link Click), Landing Page Views, CPM, Frequency, Quality Ranking |
+| **Video** | ThruPlay Cost, ThruPlays, 3-Second Video Views, Video Average Watch Time, CTR (All), CPM, Reach, Frequency |
 
 ---
 


### PR DESCRIPTION
## Summary

- Convert `Recommended Custom Columns` prose bullets to a table for improved scannability
- Clarify `Ad Relevance Diagnostics` label from ambiguous colon-terminated phrase to a proper sentence

## Classification

**Reference corpus** (structured benchmark tables, formulas, industry data). Content was not compressed — all values, formulas, and benchmarks are preserved verbatim. The two changes improve readability without altering any data.

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code paths affected.
**Testing:** `self-assessed` — content diff verified manually; all tables, code blocks, formulas, and cross-references intact.

## Files Changed

- `.agents/marketing-sales/meta-ads-optimization-metrics.md` — 2 structural improvements, zero content loss

Closes #13335

---
[aidevops.sh](https://aidevops.sh) v3.5.376 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 3,555 tokens on this as a headless worker.