### PR TITLE
GH#13592: tighten pages-gotchas.md — tables for framework/errors, debug order

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md
@@ -92,30 +92,36 @@
 
 ## Framework-Specific
 
-- **Next.js**: `@cloudflare/next-on-pages` adapter. Some features unsupported (ISR, Middleware with waitUntil). [Compatibility](https://github.com/cloudflare/next-on-pages/blob/main/docs/compatibility.md)
-- **SvelteKit**: `@sveltejs/adapter-cloudflare`. Set `platform: 'cloudflare'` in svelte.config.js
-- **Remix**: `@remix-run/cloudflare-pages`. Check server context for bindings
+| Framework | Adapter | Notes |
+|-----------|---------|-------|
+| Next.js | `@cloudflare/next-on-pages` | ISR + Middleware `waitUntil` unsupported — [compat matrix](https://github.com/cloudflare/next-on-pages/blob/main/docs/compatibility.md) |
+| SvelteKit | `@sveltejs/adapter-cloudflare` | Set `platform: 'cloudflare'` in svelte.config.js |
+| Remix | `@remix-run/cloudflare-pages` | Access bindings via server context |
 
 ## Debugging
 
-```typescript
-console.log('Request:', { method: request.method, url: request.url, headers: Object.fromEntries(request.headers) });
-console.log('Env:', Object.keys(env));
+```bash
+# Tail live logs
+npx wrangler pages deployment tail --project-name=my-project
 ```
 
-```bash
-npx wrangler pages deployment tail --project-name=my-project
+```typescript
+// In Function: log request + available bindings
+console.log('Request:', { method: request.method, url: request.url });
+console.log('Env keys:', Object.keys(env));
 ```
 
 ## Common Errors
 
-- **"Module not found"**: Ensure dependencies bundled in build output
-- **"Binding not found"**: Verify wrangler.toml, regenerate types
-- **"Request exceeded CPU limit"**: Optimize hot paths; use Workers for heavy compute
-- **"Script too large"**: Tree-shake, dynamic imports, code-split
-- **"Too many subrequests"**: Max 50/request, batch where possible
-- **"KV key not found"**: Check namespace matches (production vs preview)
-- **"D1 error"**: Verify database_id, check migrations applied
+| Error | Fix |
+|-------|-----|
+| "Module not found" | Bundle dependencies in build output |
+| "Binding not found" | Verify wrangler.toml, regenerate types |
+| "Request exceeded CPU limit" | Optimize hot paths; offload to Workers |
+| "Script too large" | Tree-shake, dynamic imports, code-split |
+| "Too many subrequests" | Batch calls; max 50/request |
+| "KV key not found" | Check namespace (production vs preview) |
+| "D1 error" | Verify database_id, check migrations applied |
 
 ## Limits
 


### PR DESCRIPTION
## Summary

- Convert `Framework-Specific` and `Common Errors` bullet lists to tables for improved scannability (consistent with existing `Limits` table style)
- Reorder `Debugging` section: bash tail command first, TypeScript snippet second; add inline comments; trim verbose `headers` spread from `console.log`
- All knowledge preserved — no content removed, only restructured

## Classification

Reference corpus (domain knowledge base). Not compressed — restructured for readability per issue guidance.

## Verification

- All code blocks, URLs, and command examples present before and after
- No broken internal links
- `wc -l` before: 131, after: 137 (tables have header rows; net content unchanged)

## Runtime Testing

Risk: **Low** — docs-only change, no agent behaviour affected. `self-assessed`.

Closes #13592

---
[aidevops.sh](https://aidevops.sh) v3.5.376 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 3,991 tokens on this as a headless worker.