### PR TITLE
GH#13588: tighten revenuecat.md agent doc

### DIFF
--- a/.agents/services/payments/revenuecat.md
+++ b/.agents/services/payments/revenuecat.md
@@ -6,14 +6,13 @@ tools:
   write: true
   edit: true
   bash: true
-  glob: true
   grep: true
   webfetch: true
   task: true
   context7_*: true
 ---
 
-# RevenueCat - In-App Subscriptions Made Easy
+# RevenueCat
 
 <!-- AI-CONTEXT-START -->
 
@@ -73,8 +72,6 @@ Purchases.configure(withAPIKey: "appl_your_ios_api_key")
 
 ## Common Operations
 
-### Check Status / Display Offerings / Purchase / Restore
-
 ```typescript
 // Check subscription status
 const customerInfo = await Purchases.getCustomerInfo();
@@ -111,7 +108,7 @@ await Purchases.logIn(userId);   // After login
 await Purchases.logOut();        // After logout
 ```
 
-## RevenueCat Paywalls (Optional)
+## Paywalls
 
 Server-configurable paywalls — update design without app releases:
 
@@ -141,8 +138,6 @@ Configure in dashboard to sync events with your backend:
 **Sandbox**: iOS — sandbox Apple ID in App Store Connect. Android — license testing in Play Console. Dashboard shows sandbox vs production.
 
 **Debug**: `Purchases.setLogLevel(LOG_LEVEL.DEBUG)` → inspect `getCustomerInfo()`.
-
-**Rules**:
 
 - Never cache entitlements locally — always call `getCustomerInfo()`
 - Handle offline gracefully — SDK caches last known state


### PR DESCRIPTION
## Summary

- Remove marketing title suffix (`- In-App Subscriptions Made Easy`) — description frontmatter already covers it
- Remove redundant `### Check Status / Display Offerings / Purchase / Restore` sub-heading — code comments already label each operation
- `## RevenueCat Paywalls (Optional)` → `## Paywalls` — prefix and "Optional" are noise
- Remove `**Rules**:` sub-label in Testing section — redundant with section title
- Remove `glob: true` from tools — not needed for a service integration agent

All code blocks, URLs, and command examples preserved. Zero content loss. markdownlint: 0 errors.

## Runtime Testing

Risk: **Low** (docs/agent prompt only — no code execution path). Self-assessed.

Closes #13588

---
[aidevops.sh](https://aidevops.sh) v3.5.376 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 4,390 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified and tightened documentation across guides, integrations, and workflows for improved clarity.
  * Reorganized content structure for better usability and consistency.
  * Updated examples and formatting for better readability.

* **Chores**
  * Version bumped to 3.5.376.
  * Updated configuration and metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->