### PR TITLE
GH#13606: tighten wrangler-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
@@ -1,30 +1,14 @@
 # Wrangler Development Patterns
 
-## New Worker / Local Dev
+Multi-step workflows. For individual commands see [wrangler.md](./wrangler.md); for pitfalls see [wrangler-gotchas.md](./wrangler-gotchas.md).
+
+## New Worker
 
 ```bash
 wrangler init my-worker && cd my-worker
 wrangler dev              # Local (fast, limited accuracy)
 wrangler dev --remote     # Remote (slower, production-accurate)
-wrangler dev --env staging
-wrangler dev --port 8787
 wrangler deploy
-```
-
-## Secrets
-
-**Never commit secrets.** Use `wrangler secret put` for production, `.dev.vars` for local.
-
-```bash
-echo "secret-value" | wrangler secret put SECRET_KEY
-wrangler secret list
-wrangler secret delete SECRET_KEY
-```
-
-`.dev.vars` (gitignored):
-
-```
-SECRET_KEY=local-dev-key
 ```
 
 ## Adding KV
@@ -53,16 +37,16 @@ wrangler d1 migrations apply my-db --remote
 
 ## Multi-Environment
 
+```jsonc
+{ "env": { "staging": { "vars": { "ENV": "staging" } } } }
+```
+
 ```bash
 wrangler deploy --env staging
 wrangler deploy --env production
 ```
 
-```jsonc
-{ "env": { "staging": { "vars": { "ENV": "staging" } } } }
-```
-
-## Testing
+## Integration Testing
 
 ```typescript
 import { unstable_startWorker } from "wrangler";
@@ -72,24 +56,7 @@ const response = await worker.fetch("/api/users");
 await worker.dispose();
 ```
 
-## Monitoring
-
-```bash
-wrangler tail                 # Real-time logs
-wrangler tail --status error
-wrangler tail --env production
-wrangler whoami
-```
-
-## Version Control
-
-```bash
-wrangler versions list
-wrangler deployments list
-wrangler rollback [id]
-```
-
-## TypeScript
+## TypeScript Worker Scaffold
 
 ```bash
 wrangler types  # Generate types from config
@@ -137,8 +104,3 @@ return new Response(data, {
   headers: { "Cache-Control": "public, max-age=3600" }
 });
 ```
-
-## See Also
-
-- [wrangler.md](./wrangler.md) - Commands
-- [wrangler-gotchas.md](./wrangler-gotchas.md) - Issues


### PR DESCRIPTION
## Summary

- Tighten `wrangler-patterns.md` (144 → 106 lines, 26% reduction) by removing sections duplicated in sibling files
- Removed: Secrets (covered by `wrangler.md` + `wrangler-gotchas.md`), Monitoring (`wrangler.md`), Version Control (`wrangler.md`)
- Preserved all unique multi-step workflow patterns: KV/D1 setup, multi-env config, integration testing, TypeScript scaffold, DO migration, performance patterns

## What changed

| Section | Action | Rationale |
|---------|--------|-----------|
| Secrets | Removed | `wrangler.md:77-82` has commands; `wrangler-gotchas.md:44-46` has `.dev.vars` tip |
| Monitoring | Removed | `wrangler.md:86-90` has `tail` commands |
| Version Control | Removed | `wrangler.md:35-36` has `versions list`, `rollback` |
| New Worker | Trimmed | Removed `--env staging`/`--port 8787` flags (standard CLI, covered elsewhere) |
| See Also | Moved to intro | Same links, now in opening line for immediate context |
| Testing → Integration Testing | Renamed | Clearer purpose |
| TypeScript → TypeScript Worker Scaffold | Renamed | Clearer purpose |

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — no runtime behaviour change, markdown lint clean

Closes #13606

---
[aidevops.sh](https://aidevops.sh) v3.5.387 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 5,873 tokens on this as a headless worker.