### PR TITLE
GH#13606: tighten wrangler-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md
@@ -78,7 +78,6 @@ await worker.dispose();
 wrangler tail                 # Real-time logs
 wrangler tail --status error
 wrangler tail --env production
-wrangler whoami
 ```
 
 ## Version Control
@@ -117,10 +116,6 @@ export default {
 ```
 
 ## Performance
-
-```jsonc
-{ "minify": true }
-```
 
 ```typescript
 // KV caching


### PR DESCRIPTION
## Summary

- Remove `wrangler whoami` from Monitoring section — it's an auth check, not log monitoring; already covered in `wrangler.md` commands reference
- Remove standalone `{ "minify": true }` jsonc block from Performance — single-line config option, not a reusable pattern
- 144 → 139 lines; all code examples, command patterns, and cross-references preserved

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution path.
Level: `self-assessed`

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md` — 5 lines removed

Closes #13606

---
[aidevops.sh](https://aidevops.sh) v3.5.387 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 3,839 tokens on this as a headless worker.