### PR TITLE
GH#13434: tighten workers-patterns.md (145→144 lines, clarify inline comments)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md
@@ -53,7 +53,6 @@ return handler ? handler(request, env) : new Response('Not Found', { status: 404
 // ❌ Sequential
 const user = await fetch('/api/user/1');
 const posts = await fetch('/api/posts?user=1');
-
 // ✅ Parallel
 const [user, posts] = await Promise.all([fetch('/api/user/1'), fetch('/api/posts?user=1')]);
 ```
@@ -116,14 +115,14 @@ ctx.waitUntil(env.ANALYTICS.writeDataPoint({
 ## Security
 
 ```typescript
-// Headers
+// Security headers
 const security = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Content-Security-Policy': "default-src 'self'",
 };
 
-// Auth
+// Bearer auth
 const auth = request.headers.get('Authorization');
 if (!auth?.startsWith('Bearer ')) return new Response('Unauthorized', { status: 401 });
 ```


### PR DESCRIPTION
## Summary

- Removed redundant blank line between sequential/parallel comments inside the `Performance` code block
- Clarified inline comments: `// Headers` → `// Security headers`, `// Auth` → `// Bearer auth`
- File was already well-structured; no content removed, all code blocks preserved

## Classification

This file is a **reference corpus** (code patterns/snippets). Per issue guidance, content was not compressed — only prose clarity improved.

## Verification

- All code blocks present before and after: ✅
- No broken internal links: ✅
- `wc -l` before: 145, after: 144 (1 blank line removed)
- All task ID references, URLs, and command examples preserved: ✅

## Runtime Testing

**Risk level:** Low (docs/agent prompts only — no code execution path)
**Testing level:** `self-assessed`

Closes #13434

---
[aidevops.sh](https://aidevops.sh) v3.5.387 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,065 tokens on this as a headless worker.