### PR TITLE
GH#13381: tighten cro-chapter-23.md SaaS CRO Optimization (138→56 lines)

### DIFF
--- a/.agents/marketing-sales/cro-chapter-23.md
+++ b/.agents/marketing-sales/cro-chapter-23.md
@@ -2,137 +2,55 @@
 
 ## 23.1 Trial-to-Paid Conversion
 
-### The SaaS Trial Challenge
+**SaaS trial challenges:** value must precede payment; time-delayed decision; multiple B2B stakeholders; PQLs vs MQLs.
 
-SaaS companies face unique conversion challenges:
-- Users must experience value before paying
-- Time-delayed conversion decision
-- Multiple stakeholders in B2B
-- Product-qualified leads (PQLs) vs marketing-qualified
+**Onboarding milestones:**
+1. First Login — welcome sequence, guided tour
+2. First Action — core feature activation
+3. Team Invitation — collaboration setup
+4. Integration — connected to existing tools
+5. Value Realization — first successful outcome
 
-### Trial Engagement Optimization
+**Engagement metrics:** days active, features used, data input volume, team members added, time-to-first-value.
 
-**Onboarding Milestones:**
-1. **First Login:** Welcome sequence, guided tour
-2. **First Action:** Core feature activation
-3. **Team Invitation:** Collaboration setup
-4. **Integration:** Connected to existing tools
-5. **Value Realization:** First successful outcome
+**Optimal trial length** (not always 14 days):
+- Time to first value ≤3 days → 7-day trial
+- Complex implementation → 30-day trial
+- Simple tools → 3-day trial
 
-**Engagement Metrics:**
-- Days active during trial
-- Features used
-- Data input volume
-- Team members added
-- Time-to-first-value
-
-### Conversion Timing Optimization
-
-**The 14-Day Trial Myth:**
-Standard 14-day trials aren't optimal for all products.
-
-**Finding Optimal Trial Length:**
-- Time to first value: 3 days → 7-day trial
-- Complex implementation: 30-day trial
-- Simple tools: 3-day trial
-
-**Trial Extension Strategy:**
-- Offer extensions to engaged users
-- Require specific actions to extend
-- Use as conversion opportunity
+**Trial extension:** offer to engaged users; require specific actions to extend; treat as conversion opportunity.
 
 ## 23.2 Pricing Page Optimization
 
-### Pricing Page Best Practices
+**Plan structure:** 3–4 plans max; clear differentiation; recommended plan highlighted; annual discount visible.
 
-**Plan Structure:**
-- 3-4 plans maximum
-- Clear differentiation
-- Recommended plan highlighted
-- Annual discount visible
+**Pricing psychology:** decoy pricing (middle plan most popular); anchoring (enterprise price makes others look reasonable); charm pricing ($99 vs $100); free trial emphasis.
 
-**Pricing Psychology:**
-- Decoy pricing (middle plan most popular)
-- Anchoring (enterprise price makes others look reasonable)
-- Charm pricing ($99 vs $100)
-- Free trial emphasis
-
-### Interactive Pricing
-
-**Calculators:**
-- ROI calculators
-- Savings estimators
-- Cost comparison tools
-
-**Sliders:**
-- Usage-based pricing
-- Team size adjustments
-- Feature toggles
+**Interactive pricing tools:**
+- Calculators — ROI, savings estimators, cost comparison
+- Sliders — usage-based pricing, team size, feature toggles
 
 ## 23.3 Product-Led Growth CRO
 
-### PLG Principles
+**Self-serve onboarding:** no sales required; immediate value delivery; in-app education; viral sharing mechanisms.
 
-**Self-Serve Onboarding:**
-- No sales required to start
-- Immediate value delivery
-- In-app education
-- Viral sharing mechanisms
+**Viral loops:** team invites, shareable content, public profiles, social proof.
 
-**Viral Loops:**
-- Invite team members
-- Shareable content
-- Public profiles
-- Social proof
+**Freemium optimization:** clear upgrade triggers; feature limitations; usage quotas; watermarks/removal.
 
-**Freemium Optimization:**
-- Clear upgrade triggers
-- Feature limitations
-- Usage quotas
-- Watermarks/removal
+**In-app conversion:**
 
-### In-App Conversion Tactics
-
-**Contextual Upsells:**
-- Feature gate messages
-- Usage limit warnings
-- Advanced feature teasers
-- Power user prompts
-
-**Upgrade Triggers:**
-- Feature attempt
-- Limit reached
-- Team size growth
-- Usage milestone
+| Tactic | Examples |
+|--------|---------|
+| Contextual upsells | Feature gate messages, usage limit warnings, advanced feature teasers, power user prompts |
+| Upgrade triggers | Feature attempt, limit reached, team size growth, usage milestone |
 
 ## 23.4 B2B SaaS Specifics
 
-### Multi-Stakeholder Conversion
+**Champion enablement:** business case templates, ROI calculators, competitor comparisons, security documentation.
 
-**Champion Enablement:**
-- Business case templates
-- ROI calculators
-- Competitor comparisons
-- Security documentation
+**Decision maker content:** executive summaries, total cost of ownership, implementation timelines, risk mitigation.
 
-**Decision Maker Content:**
-- Executive summaries
-- Total cost of ownership
-- Implementation timelines
-- Risk mitigation
+**Sales-assisted trials:** dedicated success manager, custom onboarding, technical implementation support, executive business reviews.
 
-### Enterprise Conversion
-
-**Sales-Assisted Trials:**
-- Dedicated success manager
-- Custom onboarding
-- Technical implementation support
-- Executive business reviews
-
-**Proof of Concept:**
-- Limited scope pilot
-- Success criteria defined
-- Timeline commitments
-- Expansion planning
-
-This SaaS CRO deep dive addresses the unique challenges of software conversion optimization.
+**Proof of concept:** limited scope pilot; success criteria defined upfront; timeline commitments; expansion planning.


### PR DESCRIPTION
## Summary

- Tighten `.agents/marketing-sales/cro-chapter-23.md` per `build-agent.md` terse pass guidance
- 138 → 56 lines (59% reduction), zero content loss
- Removed: redundant sub-headers restating parent sections, filler closing sentence, verbose narrative wrapping bullet lists
- Preserved: all four sections (23.1–23.4), all tactics, all metrics, all decision rules, all examples

## Changes

- `cro-chapter-23.md`: compress prose → direct rules; merge single-item bold sub-headers into inline bold; convert in-app conversion tactics to table; remove trailing filler sentence

## Runtime Testing

Risk: **Low** — agent doc only, no code, no commands, no URLs, no task ID refs in this file.
Testing level: `self-assessed`

## Verification

- `wc -l`: 138 → 56 lines
- `markdownlint-cli2`: 0 errors
- Content audit: all four sections present, all bullet points accounted for

Closes #13381


---
[aidevops.sh](https://aidevops.sh) v3.5.387 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 4,435 tokens on this as a headless worker.