### PR TITLE
GH#13676: tighten extension testing doc (135→124 lines)

### DIFF
--- a/.agents/tools/browser/extension-dev/testing.md
+++ b/.agents/tools/browser/extension-dev/testing.md
@@ -34,7 +34,7 @@ npx jest       # Jest alternative
 
 ## E2E Testing (Playwright)
 
-Playwright loads unpacked extensions in Chromium only (headed mode required, not Firefox):
+Playwright loads unpacked extensions in Chromium only (`headless: false` required; Firefox not supported):
 
 ```typescript
 import { test, chromium } from '@playwright/test';
@@ -44,20 +44,12 @@ test('extension popup works', async () => {
   const pathToExtension = path.resolve('.output/chrome-mv3');
   const context = await chromium.launchPersistentContext('', {
     headless: false,
-    args: [
-      `--disable-extensions-except=${pathToExtension}`,
-      `--load-extension=${pathToExtension}`,
-    ],
+    args: [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`],
   });
 
-  let extensionId: string;
-  const serviceWorkers = context.serviceWorkers();
-  if (serviceWorkers.length > 0) {
-    extensionId = serviceWorkers[0].url().split('/')[2];
-  } else {
-    const sw = await context.waitForEvent('serviceworker');
-    extensionId = sw.url().split('/')[2];
-  }
+  // Extract extension ID from service worker URL
+  const sw = context.serviceWorkers()[0] ?? await context.waitForEvent('serviceworker');
+  const extensionId = sw.url().split('/')[2];
 
   const popup = await context.newPage();
   await popup.goto(`chrome-extension://${extensionId}/popup.html`);
@@ -109,12 +101,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - run: npm ci
-      - run: npm run build
-      - run: npx playwright install chromium
-      - run: npm run test:e2e
+        with: { node-version: '20' }
+      - run: npm ci && npm run build
+      - run: npx playwright install chromium && npm run test:e2e
 ```
 
 ## Pre-Submission Checklist


### PR DESCRIPTION
## Summary

- Compress Playwright E2E boilerplate: nullish coalescing for service worker extraction, args collapsed to one line (30→20 lines in that block)
- Collapse CI YAML: `setup-node` with-block inlined, two `run:` steps merged
- Minor prose tightening on E2E section header
- All checklists, debugging table, decision tree, and related links preserved intact

## Runtime Testing

Risk: **Low** (docs-only change, no code). Self-assessed.

## Files Changed

- `.agents/tools/browser/extension-dev/testing.md` — 135→124 lines (8% reduction)

Closes #13676


---
[aidevops.sh](https://aidevops.sh) v3.5.388 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,750 tokens on this as a headless worker.