### PR TITLE
GH#13645: tighten extension-dev/development.md

### DIFF
--- a/.agents/tools/browser/extension-dev/development.md
+++ b/.agents/tools/browser/extension-dev/development.md
@@ -92,7 +92,7 @@ const { preferences } = await chrome.storage.sync.get('preferences');
 
 ## Permissions
 
-Request only what you need. Prefer optional permissions (requested at runtime):
+Request only what you need. Prefer optional permissions (requested at runtime via `chrome.permissions.request`):
 
 ```json
 {
@@ -101,8 +101,6 @@ Request only what you need. Prefer optional permissions (requested at runtime):
   "host_permissions": ["https://api.example.com/*"]
 }
 ```
-
-Runtime request: `await chrome.permissions.request({ permissions: ['tabs'], origins: ['https://*.example.com/*'] });`
 
 ## Cross-Browser Compatibility
 
@@ -121,7 +119,7 @@ WXT handles most differences automatically. Manual compat: `import browser from 
 - **TypeScript** always — type messages, storage schemas, API responses
 - **UI**: React (recommended), Vue (WXT first-class), Svelte (smallest bundle), or vanilla
 - **Styling**: Tailwind CSS (recommended), CSS Modules, or Shadow DOM for content scripts
-- **Content script isolation**: Use Shadow DOM (`host.attachShadow({ mode: 'closed' })`) to prevent host page style conflicts
+- **Content script isolation**: Shadow DOM (`host.attachShadow({ mode: 'closed' })`) prevents host page style conflicts
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Compress `Permissions` section: fold the standalone runtime-request line into the prose intro (inline `chrome.permissions.request` reference), removing a redundant line
- Compress `Development Standards`: tighten content-script isolation bullet from "Use Shadow DOM ... to prevent" → "Shadow DOM ... prevents" (same meaning, fewer words)
- All code blocks, URLs, table content, and knowledge preserved; no structural changes

## Verification

- `wc -l`: 131 → 129 lines (2 lines removed, no content loss)
- All code blocks intact: `bash`, `text`, `typescript` (×2), `json`
- All cross-references and Related links unchanged
- Risk: **Low** (docs-only, no executable code changed) — `self-assessed`

## Runtime Testing

Risk level: **Low** (agent prompt doc, no executable code). Self-assessed.

Closes #13645

---
[aidevops.sh](https://aidevops.sh) v3.5.388 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 2,358 tokens on this as a headless worker.