### PR TITLE
GH#13673: tighten ad-creative-video-ugc.md (143→135 lines)

### DIFF
--- a/.agents/marketing-sales/ad-creative-video-ugc.md
+++ b/.agents/marketing-sales/ad-creative-video-ugc.md
@@ -1,6 +1,6 @@
 ## Video Ad Hooks: The Critical First 3 Seconds
 
-Hook decision in <1 second. Every hook needs: visual pattern interrupt, immediate relevance, curiosity gap, emotional trigger, clear value promise. **Target:** 3-second view rate >50%.
+Hook decision in <1 second. Every hook needs: visual pattern interrupt, immediate relevance, curiosity gap, emotional trigger, clear value promise. **Target:** 3-second view rate >50%. **Test variables:** Hook type (question/statement/visual), specificity, emotion (fear/desire/curiosity), length (1s vs 3s), visual (with/without person).
 
 ### Question Hooks (1-20)
 
@@ -87,17 +87,9 @@ Hook decision in <1 second. Every hook needs: visual pattern interrupt, immediat
 | 64 | Challenge + Invitation | "Think you can't [goal]? Watch this" |
 | 65 | Pain + Solution | "Struggling with [problem]? I found the fix" |
 
-### Hook Testing
-
-**Test variables:** Hook type (question/statement/visual), specificity, emotion (fear/desire/curiosity), length (1s vs 3s), visual (with/without person).
-
----
-
 ## UGC-Style Ad Creation
 
 Smartphone-shot, casual, authentic — native to platform, higher trust, lower cost, faster iteration than studio production.
-
-### Creation Process
 
 **Sourcing:** Hire (Fiverr/Billo/Insense: $100-500, 3-7 days) | Customer testimonials (incentive) | Internal team (free, fastest).
 


### PR DESCRIPTION
## Summary

- Merge Hook Testing section into intro paragraph — removes redundant `### Hook Testing` heading and `---` separator (4 lines)
- Remove redundant `### Creation Process` subheading — it was the only subsection under UGC, adding no navigational value (2 lines)
- All 65 hook templates, 5 script frameworks, brief template, filming/editing checklists, and scaling table preserved

## Classification

Reference corpus (65 numbered hook templates in tables + script frameworks). Tightening limited to structural noise removal only — no content compressed or removed.

## Runtime Testing

`self-assessed` — docs-only change, no executable code.

Closes #13673

---
[aidevops.sh](https://aidevops.sh) v3.5.388 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6 spent 5m on this as an interactive worker.