### PR TITLE
GH#13643: tighten react-context.md — remove redundant frontmatter and prose

### DIFF
--- a/.agents/tools/ui/react-context.md
+++ b/.agents/tools/ui/react-context.md
@@ -5,7 +5,6 @@ tools:
   read: true
   write: true
   edit: true
-  bash: false
   glob: true
   grep: true
   webfetch: true
@@ -39,8 +38,6 @@ tools:
 <!-- AI-CONTEXT-END -->
 
 ## Full Provider Example
-
-Authoritative reference — interface, context, hooks (fallback + optional), cookie persistence, CSS variables, clamped setters.
 
 ```tsx
 "use client";


### PR DESCRIPTION
## Summary

- Remove explicit `bash: false` from YAML frontmatter — `false` is the default; only truthy values need to be listed
- Drop redundant prose description before the Full Provider Example code block — the section heading is sufficient context

## Verification

- All hazard table entries, checklists, code examples, and institutional knowledge preserved
- No broken internal links or references
- 158 → 155 lines (3 lines removed, zero content loss)
- Agent behaviour unchanged — no rules, patterns, or decision logic modified

## Runtime Testing

Risk level: **Low** (docs/agent prompt only — no code, no logic, no executable changes)
Testing level: `self-assessed`

Closes #13643

---
[aidevops.sh](https://aidevops.sh) v3.5.388 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 2,363 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed unused tool configuration entries and streamlined reference content for improved documentation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->