### PR TITLE
GH#12892: tighten cloudflare-ai.md (142→139 lines)

### DIFF
--- a/.agents/tools/infrastructure/cloudflare-ai.md
+++ b/.agents/tools/infrastructure/cloudflare-ai.md
@@ -28,8 +28,6 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-Serverless AI inference on Cloudflare's global GPU network. Models run at the edge, close to users. Part of the Cloudflare developer platform (Workers, Pages, KV, D1, R2, Vectorize, AI Gateway).
-
 ## Pricing (March 2026)
 
 Billed in Neurons ($0.011 per 1,000 Neurons). Free allocation: 10,000 Neurons/day on both Free and Paid Workers plans.
@@ -82,7 +80,6 @@ Pattern: CF has cheap input but expensive output for large models. Best value fo
 ### From Workers (recommended)
 
 ```javascript
-// In a Cloudflare Worker
 export default {
   async fetch(request, env) {
     const response = await env.AI.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
@@ -103,7 +100,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 ### OpenAI-Compatible Endpoint
 
-Cloudflare provides an OpenAI-compatible endpoint for supported models. See [OpenAI compat docs](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) for supported models and limitations.
+See [OpenAI compat docs](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) for supported models and limitations.
 
 ## Capabilities
 


### PR DESCRIPTION
## Summary

- Remove redundant intro paragraph (duplicates frontmatter description verbatim)
- Remove `// In a Cloudflare Worker` comment (redundant with section heading "From Workers")
- Trim OpenAI-compat section opening sentence (self-evident from heading)

All pricing tables, code blocks, URLs, capabilities, security, and see-also sections preserved unchanged.

Closes #12892

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code changes.
Testing: self-assessed. Content preservation verified by diff review.

---
[aidevops.sh](https://aidevops.sh) v3.5.392 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 5,106 tokens on this as a headless worker.