### PR TITLE
GH#12839: tighten cro-chapter-08.md form optimization doc

### DIFF
--- a/.agents/marketing-sales/cro-chapter-08.md
+++ b/.agents/marketing-sales/cro-chapter-08.md
@@ -1,6 +1,6 @@
 # Chapter 8: Form Optimization and Field Reduction
 
-Forms are the highest-friction conversion points. Every field added reduces conversion ~4-7%.
+Every field added reduces conversion ~4-7%.
 
 ## Field Cost Reference
 
@@ -27,8 +27,6 @@ Forms are the highest-friction conversion points. Every field added reduces conv
 **"Can We Get This Later?" test** — remove or make optional if: (1) collectable post-conversion, (2) inferable/enrichable, (3) no immediate user value, (4) not required to serve the user.
 
 ## Progressive Profiling
-
-Collect across interactions rather than upfront.
 
 | Step | Form | New Fields | Rate |
 |------|------|-----------|------|
@@ -104,7 +102,7 @@ Key `autocomplete` values: `name`, `email`, `tel`, `organization`, `street-addre
 
 Validate on field blur (not every keystroke): focus → type → blur → validate → show result.
 
-**Error messages** — specific and actionable:
+**Error messages** — specific, not accusatory:
 
 | Bad | Good |
 |-----|------|
@@ -168,5 +166,3 @@ Social proof near form: testimonials, subscriber count ("Join 50,000+"), trust b
 | B2B lead: 12 fields → 4 (email, company, open-ended challenge, optional phone) | 3.2% CVR | 9.7% CVR | +203% |
 | SaaS trial: single-page 8 fields → 3-step (email+pw / name+company / goal+size) | 12% CVR | 17.5% CVR | +46% |
 | Field reorder: engaging question first, phone optional | 38% abandonment | 22% abandonment | -42% |
-
-**Key insight across all three**: starting with an engaging question and making sensitive fields optional reduces early abandonment and improves both quantity and quality of leads.


### PR DESCRIPTION
## Summary

- Remove 4 lines of decorative/redundant prose from `cro-chapter-08.md` (172 → 168 lines)
- Intro sentence restated the chapter title — removed
- "Collect across interactions" restated the section name "Progressive Profiling" — removed
- "specific and actionable" label on error table — table is self-evident; tightened to "specific, not accusatory" (preserves the intent, removes the redundant qualifier)
- "Key insight across all three" summary restated what the case study table already shows — removed

## Verification

- All data tables, code blocks, stats (HubSpot +120%, field cost percentages), command examples, and operational rules preserved
- `wc -l`: 168 (was 172) — 4 lines removed, zero knowledge lost
- No broken internal links or references

## Runtime Testing

Risk: **Low** — documentation-only change, no code, no agent behaviour affected.
Level: `self-assessed`

Closes #12839

---
[aidevops.sh](https://aidevops.sh) v3.5.392 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 3,995 tokens on this as a headless worker.