### PR TITLE
GH#12891: tighten rules-scripts.md (152→144 lines)

### DIFF
--- a/.agents/content/heygen-skill/rules-scripts.md
+++ b/.agents/content/heygen-skill/rules-scripts.md
@@ -116,15 +116,7 @@ const multiSceneVideo = {
       },
       background: { type: "color", value: "#1a1a2e" },
     },
-    {
-      character: { type: "avatar", avatar_id: "josh_lite3_20230714", avatar_style: "normal" },
-      voice: {
-        type: "text",
-        input_text: "Let's start with revenue. <break time=\"0.5s\"/> We grew 25 percent quarter over quarter. <break time=\"1s\"/> Here's what drove that growth.",
-        voice_id: "voice_id_here",
-      },
-      background: { type: "image", url: "https://..." },
-    },
+    // Additional scenes follow the same structure with different input_text and background
   ],
 };
 ```


### PR DESCRIPTION
## Summary

- Removes redundant second scene from the multi-scene TypeScript example — it was a verbatim repeat of the first scene with different field values
- Replaces with a comment that conveys the extension pattern without 9 lines of boilerplate
- All reference tables, templates, rules, and institutional knowledge preserved

## Changes

- : 152 → 144 lines (−8 lines)

## Runtime Testing

**Risk level:** Low — agent prompt/doc file, no executable code changed.
**Testing method:** self-assessed — content verified against original for completeness.

Closes #12891


---
[aidevops.sh](https://aidevops.sh) v3.5.392 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 3,132 tokens on this as a headless worker.