### PR TITLE
GH#13644: tighten coolify-cli.md agent doc

### DIFF
--- a/.agents/tools/deployment/coolify-cli.md
+++ b/.agents/tools/deployment/coolify-cli.md
@@ -24,6 +24,7 @@ tools:
 - **Script**: `.agents/scripts/coolify-cli-helper.sh`
 - **Deps**: `jq` (required), `docker` (optional), `node` (optional)
 - **Debug**: `export DEBUG=1` before any command
+- **Security**: Store tokens in env vars or `aidevops secret`. Use context-specific tokens per environment.
 - **API docs**: https://coolify.io/docs/api
 - **Related**: `coolify-setup.md` (server install), `coolify.md` (provider guide, monitoring)
 
@@ -43,13 +44,12 @@ tools:
 ```bash
 cp configs/coolify-cli-config.json.txt configs/coolify-cli-config.json
 
-# Add contexts
 ./.agents/scripts/coolify-cli-helper.sh add-context production https://coolify.example.com your-api-token true
 ./.agents/scripts/coolify-cli-helper.sh add-context staging https://staging.coolify.example.com staging-token
 ./.agents/scripts/coolify-cli-helper.sh list-contexts
 ```
 
-Multi-context config structure (`configs/coolify-cli-config.json`):
+Config structure (`configs/coolify-cli-config.json`):
 
 ```json
 {
@@ -59,14 +59,7 @@ Multi-context config structure (`configs/coolify-cli-config.json`):
     "production": { "url": "https://coolify.example.com" }
   },
   "projects": {
-    "web-app": {
-      "context": "production",
-      "type": "nodejs",
-      "git_repository": "https://github.com/user/web-app.git",
-      "build_command": "npm run build",
-      "start_command": "npm start",
-      "domains": ["app.example.com"]
-    }
+    "web-app": { "context": "production", "type": "nodejs", "domains": ["app.example.com"] }
   }
 }
 ```
@@ -75,7 +68,7 @@ Multi-context config structure (`configs/coolify-cli-config.json`):
 
 ### Local Development (no Coolify required)
 
-Auto-detects project type (Node.js `package.json`, Dockerfile/docker-compose, static HTML):
+Auto-detects project type (`package.json`, `Dockerfile`/`docker-compose`, static HTML):
 
 ```bash
 ./.agents/scripts/coolify-cli-helper.sh dev local ./my-app 3000
@@ -89,6 +82,11 @@ Auto-detects project type (Node.js `package.json`, Dockerfile/docker-compose, st
 ./.agents/scripts/coolify-cli-helper.sh deploy production my-app          # deploy
 ./.agents/scripts/coolify-cli-helper.sh deploy production my-app true     # force deploy
 ./.agents/scripts/coolify-cli-helper.sh get-app production app-uuid-here
+
+# Monitoring (native coolify CLI)
+coolify app logs app-uuid
+coolify deploy list
+coolify server get server-uuid --resources
 ```
 
 ### Server Management
@@ -109,29 +107,12 @@ Auto-detects project type (Node.js `package.json`, Dockerfile/docker-compose, st
 ./.agents/scripts/coolify-cli-helper.sh create-db production mongodb     server-uuid project-uuid main mongo-db true
 ```
 
-### Monitoring
-
-```bash
-coolify app logs app-uuid
-coolify deploy list
-coolify server get server-uuid --resources
-```
-
 ## CI/CD Integration
 
 ```yaml
-name: Deploy to Coolify
-on:
-  push:
-    branches: [main]
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: ./.agents/scripts/coolify-cli-helper.sh deploy production my-app true
-        env:
-          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+- run: ./.agents/scripts/coolify-cli-helper.sh deploy production my-app true
+  env:
+    COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
 ```
 
 ## Troubleshooting
@@ -142,5 +123,3 @@ jobs:
 | Context issues | `list-contexts` then `add-context` |
 | Local dev fails | Check Node.js/Docker installed; verify `package.json`/`Dockerfile` present; check port availability |
 | Deployment fails | Verify server connectivity; check app logs; validate env vars |
-
-**Security**: Store tokens in env vars or `aidevops secret`. Use context-specific tokens per environment.


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/deployment/coolify-cli.md` from 146 → 125 lines (14% reduction)
- Moved security note to Quick Reference for higher visibility
- Trimmed config JSON example to essential fields (removed redundant project fields)
- Merged monitoring commands into Application Management section (eliminated separate section)
- Stripped CI/CD YAML to the essential deploy step — agents don't need the workflow scaffolding
- All commands, URLs, code blocks, and institutional knowledge preserved

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only — no code changes)
- **Assessment**: self-assessed — no runtime verification required per testing gate

Closes #13644


---
[aidevops.sh](https://aidevops.sh) v3.5.392 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 2,598 tokens on this as a headless worker.