### PR TITLE
GH#13350: tighten email-composition.md agent doc

### DIFF
--- a/.agents/services/email/email-composition.md
+++ b/.agents/services/email/email-composition.md
@@ -42,40 +42,21 @@ email-compose-helper.sh draft --to client@example.com \
 
 **Never auto-send**: `--no-review` skips editor but still requires confirmation. Full bypass (`--no-review` + piping `y`) is for tested automation scripts only.
 
-## Legal Liability Awareness
+## Commands and Model Routing
 
-Email creates a written record. Distinguish clearly:
+| Command | Purpose | Importance | Model |
+|---------|---------|------------|-------|
+| `draft` | Compose new email — AI drafts, human reviews | high | opus |
+| `reply` | Compose reply (auto-detect reply vs reply-all) | high | opus |
+| `draft` / `reply` | Routine correspondence, vendor communication | normal | sonnet |
+| `forward` | Forward with optional commentary | normal | sonnet |
+| `follow-up` | Follow up when replying is delayed | normal | sonnet |
+| `remind` | Reminder for outstanding requests | normal | sonnet |
+| `notify` | Project update notification | normal | sonnet |
+| `acknowledge` | Brief holding-pattern response | low | haiku |
+| `list` | Show saved drafts (`--sent` for archive) | — | — |
 
-- **Agreed** — contractually/verbally committed: *"As agreed in our contract, delivery is scheduled for 15 March."*
-- **Advised** — professional recommendation, not a guarantee: *"I would advise proceeding with Option A. This is my recommendation, not a guarantee of outcome."*
-- **Informational** — sharing without commitment: *"The current market rate is approximately £X. This is not a quote."*
-
-**Avoid:** admitting liability without legal review; commitments outside authority; speculating about outcomes; forwarding confidential info without permission.
-
-**Hedging:** "I understand" not "I agree"; "I'll look into this" not "We'll fix this"; "subject to contract" for commercial commitments. Consult legal before anything usable in a dispute.
-
-## Commands
-
-| Command | Purpose | Model |
-|---------|---------|-------|
-| `draft` | Compose new email — AI drafts, human reviews | sonnet/opus |
-| `reply` | Compose reply (auto-detect reply vs reply-all) | sonnet/opus |
-| `forward` | Forward with optional commentary | sonnet |
-| `acknowledge` | Brief holding-pattern response | haiku |
-| `follow-up` | Follow up when replying is delayed | sonnet |
-| `remind` | Reminder for outstanding requests | sonnet |
-| `notify` | Project update notification | sonnet |
-| `list` | Show saved drafts (`--sent` for archive) | — |
-
-## Model Routing
-
-| Importance | Model | Use for |
-|------------|-------|---------|
-| `high` | opus | Client-facing, legal, negotiations, sensitive topics |
-| `normal` | sonnet | Routine correspondence, vendor communication, team updates |
-| `low` | haiku | Acknowledgements, brief notifications, holding-pattern responses |
-
-Opus for important emails is cost-justified — a poorly worded client email costs more than the model difference.
+`--importance high` routes to opus (client-facing, legal, negotiations, sensitive topics). Opus is cost-justified — a poorly worded client email costs more than the model difference.
 
 ## Composition Rules
 
@@ -84,10 +65,10 @@ Opus for important emails is cost-justified — a poorly worded client email cos
 3. **Numbered lists** for multiple questions or action items
 4. **Explicit CTA** when response needed ("Please confirm by Friday")
 5. **No urgency flags** unless context explicitly requires it
-6. **Overused phrase avoidance** — see table below
+6. **Avoid overused phrases** (auto-flagged — see table below)
 7. **Legal awareness** — distinguish agreed vs advised vs informational
 
-## Overused Phrases (Auto-Flagged)
+### Overused Phrases (Auto-Flagged)
 
 | Avoid | Instead |
 |-------|---------|
@@ -144,6 +125,18 @@ Injected automatically from (in order): config file → signature file → Apple
 ```
 
 Use `--signature formal` to select a named signature.
+
+## Legal Liability Awareness
+
+Email creates a written record. Distinguish clearly:
+
+- **Agreed** — contractually/verbally committed: *"As agreed in our contract, delivery is scheduled for 15 March."*
+- **Advised** — professional recommendation, not a guarantee: *"I would advise proceeding with Option A. This is my recommendation, not a guarantee of outcome."*
+- **Informational** — sharing without commitment: *"The current market rate is approximately £X. This is not a quote."*
+
+**Avoid:** admitting liability without legal review; commitments outside authority; speculating about outcomes; forwarding confidential info without permission.
+
+**Hedging:** "I understand" not "I agree"; "I'll look into this" not "We'll fix this"; "subject to contract" for commercial commitments. Consult legal before anything usable in a dispute.
 
 ## Support and Customer Service
 


### PR DESCRIPTION
## Summary

- Merge `Commands` + `Model Routing` into a single combined table with an `Importance` column — eliminates a redundant `##` section and duplicate model column
- Demote `Overused Phrases` from top-level `##` section to a `###` subsection under `Composition Rules` — logical grouping, reduces section count
- Reorder sections by importance: workflow → commands → composition → tone → CC/BCC → attachments → signatures → legal → support
- Tighten rule 6 wording: "Avoid overused phrases (auto-flagged — see table below)" replaces self-referential "see table below"

165 → 158 lines. All institutional knowledge, command examples, and URLs preserved.

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code changes. `self-assessed`.

## Files Changed

- `.agents/services/email/email-composition.md` — structural tightening, section merge and reorder

Closes #13350

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 5m and 7,779 tokens on this as a headless worker.