### PR TITLE
GH#13588: tighten revenuecat.md agent doc

### DIFF
--- a/.agents/services/payments/revenuecat.md
+++ b/.agents/services/payments/revenuecat.md
@@ -6,14 +6,12 @@ tools:
   write: true
   edit: true
   bash: true
-  glob: true
-  grep: true
   webfetch: true
   task: true
   context7_*: true
 ---
 
-# RevenueCat - In-App Subscriptions Made Easy
+# RevenueCat
 
 <!-- AI-CONTEXT-START -->
 
@@ -73,8 +71,6 @@ Purchases.configure(withAPIKey: "appl_your_ios_api_key")
 
 ## Common Operations
 
-### Check Status / Display Offerings / Purchase / Restore
-
 ```typescript
 // Check subscription status
 const customerInfo = await Purchases.getCustomerInfo();
@@ -111,9 +107,9 @@ await Purchases.logIn(userId);   // After login
 await Purchases.logOut();        // After logout
 ```
 
-## RevenueCat Paywalls (Optional)
+## Paywalls
 
-Server-configurable paywalls — update design without app releases:
+Server-configurable — update without app releases:
 
 ```typescript
 import RevenueCatUI from 'react-native-purchases-ui';
@@ -141,8 +137,6 @@ Configure in dashboard to sync events with your backend:
 **Sandbox**: iOS — sandbox Apple ID in App Store Connect. Android — license testing in Play Console. Dashboard shows sandbox vs production.
 
 **Debug**: `Purchases.setLogLevel(LOG_LEVEL.DEBUG)` → inspect `getCustomerInfo()`.
-
-**Rules**:
 
 - Never cache entitlements locally — always call `getCustomerInfo()`
 - Handle offline gracefully — SDK caches last known state


### PR DESCRIPTION
## Summary

Tighten `.agents/services/payments/revenuecat.md` (158 → 152 lines, -6 lines).

Closes #13588

## Changes

- **Title**: removed marketing tagline (`- In-App Subscriptions Made Easy`) — `description` frontmatter already covers purpose
- **Frontmatter**: removed unused `glob: true` and `grep: true` tools — not needed for a service integration agent
- **Common Operations**: removed redundant `### Check Status / Display Offerings / Purchase / Restore` sub-heading — inline code comments already label each operation
- **Paywalls section**: `## RevenueCat Paywalls (Optional)` → `## Paywalls` — prefix redundant within RevenueCat doc, "(Optional)" is noise
- **Paywalls description**: tightened "Server-configurable paywalls — update design without app releases" → "Server-configurable — update without app releases"
- **Testing section**: removed redundant `**Rules**:` label before bullet list

## Content Preservation

All code blocks, URLs, SDK examples, webhook events, setup steps, and cross-references preserved. Zero knowledge loss.

## Runtime Testing

- **Risk**: Low (docs/agent prompt only)
- **Level**: `self-assessed`
- **markdownlint**: 0 errors

---
[aidevops.sh](https://aidevops.sh) v3.5.400 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 1m and 4,264 tokens on this as a headless worker.