### PR TITLE
GH#13698: restore sales-qualification checkpoint in lead handoff

### DIFF
--- a/.agents/marketing-sales.md
+++ b/.agents/marketing-sales.md
@@ -97,7 +97,7 @@ Marketing agent: strategy, campaigns, paid ads (Meta/Google), email, landing pag
 
 **Lead magnet**: Create → landing page + form → `fluentcrm_create_list` → delivery automation → nurture. Forms: Fluent Forms, WPForms, Gravity Forms, Contact Form 7, custom API.
 
-**Lead handoff**: Tag `lead-mql` → automation notifies sales → sales accepts → tag `lead-sql` → remove from marketing.
+**Lead handoff**: Apply `lead-mql` tag → automation notifies sales → sales qualifies/accepts lead → apply `lead-sql` tag → remove from marketing sequences.
 
 ## Analytics & Testing
 


### PR DESCRIPTION
## Summary

- Restore explicit sales-qualification checkpoint in lead handoff workflow
- Add 'sales qualifies/accepts lead' step between MQL notification and SQL tagging, preventing premature removal from nurture sequences

## Changes

Single-line fix to `.agents/marketing-sales.md` line 100: restore the qualification gate that was accidentally dropped in the original tightening.

## Runtime Testing

Risk: **Low** — agent prompt/doc only, no code. Self-assessed.

## Verification

- Lead handoff line now reads: `Apply `lead-mql` tag → automation notifies sales → sales qualifies/accepts lead → apply `lead-sql` tag → remove from marketing sequences.`
- Rebased cleanly onto main (single commit on top of d66d99bf1)

Closes #13698

---
[aidevops.sh](https://aidevops.sh) v3.5.422 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6.