### PR TITLE
GH#13696: tighten cqrs-events.md (191→185 lines)

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md
@@ -86,12 +86,6 @@ export class OrderConfirmed extends DomainEvent {
 }
 ```
 
-```
-class OrderConfirmedHandler:
-    handle(event: OrderConfirmed):
-        db.ordersRead.where(id: event.orderId.value).update({ status: "confirmed", total: event.total.amount, confirmedAt: event.occurredAt })
-```
-
 ## Domain Events vs Integration Events
 
 | | Domain Events | Integration Events |
@@ -182,10 +176,10 @@ Saga: PlaceOrderSaga
 
 ```
 class OrderConfirmedHandler:
-    processedIds: Set<string>
-
     handle(event: OrderConfirmed):
-        if event.eventId in processedIds: return
-        doWork(event)
-        processedIds.add(event.eventId)
+        if db.processedEvents.exists(event.eventId): return
+        db.transaction((tx) => {
+            doWork(event, tx)
+            tx.processedEvents.insert({ id: event.eventId, processedAt: now() })
+        })
 ```


### PR DESCRIPTION
## Summary

- Removed redundant pseudocode `OrderConfirmedHandler` block (5 lines) — a third language showing a trivial DB update already implied by the CQRS diagram and the TypeScript `DomainEvent`/`OrderConfirmed` examples above it
- Fixed `IdempotentConsumer` example: replaced in-memory `Set<string>` (wrong — doesn't survive restarts, not shared across instances) with a DB-based transactional pattern that matches the prose's own recommendation ("store processed IDs in DB")

## Changes

- `.agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md`: 191 → 185 lines

## Runtime Testing

Risk: **Low** — doc-only change, no code execution paths affected. Self-assessed.

Closes #13696

---
[aidevops.sh](https://aidevops.sh) v3.5.402 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 2m and 3,259 tokens on this as a headless worker.