### PR TITLE
GH#13379: tighten telfon.md (138→117 lines)

### DIFF
--- a/.agents/services/communications/telfon.md
+++ b/.agents/services/communications/telfon.md
@@ -13,21 +13,14 @@ tools:
 
 # Telfon - Cloud VoIP & Virtual Phone System
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
-- **Type**: Twilio-powered cloud phone system with mobile/desktop apps
 - **Website**: https://mytelfon.com/
 - **Apps**: iOS, Android, Chrome Extension, Microsoft Edge Add-on
 - **Features**: Calls, SMS, WhatsApp, Call Recording, Bulk SMS, Multi-number
 - **Pricing**: Telfon subscription + Twilio pay-as-you-go usage
 - **Setup Time**: ~5 minutes
-- **Best For**: End users who want a calling/SMS interface without coding
-
-**When to Recommend Telfon**: user needs a phone interface (not just API), sales/support teams needing softphone, WhatsApp + SMS in one app, non-technical users managing Twilio numbers.
-
-<!-- AI-CONTEXT-END -->
+- **Use when**: user needs a phone interface (not just API), sales/support teams needing softphone, WhatsApp + SMS in one app, non-technical users managing Twilio numbers
 
 ## Telfon vs Direct Twilio
 
@@ -80,21 +73,7 @@ Numbers always remain in your Twilio account; Telfon provides the interface only
 | Voicemail | Settings > Voicemail → enable, record greeting, optional transcription | |
 | Call Forwarding | Settings > Call Forwarding → always/busy/no-answer/unreachable rules | |
 
-## Use Cases
-
-| Use Case | Key Setup |
-|----------|-----------|
-| Sales teams | Per-rep numbers, shared inbound, call recording, Chrome ext for CRM click-to-call |
-| Customer support | Toll-free inbound, call forwarding, voicemail, SMS for ticket updates |
-| Remote teams | Virtual numbers in multiple countries, mobile app |
-| Real estate | Dedicated number per listing, SMS reminders, call tracking |
-
 ## Integration with aidevops
-
-```text
-AI Workflows → Twilio API → Telfon App
-(automation)   (backend)    (user UI)
-```
 
 - **AI uses Twilio directly**: automated reminders, OTP, bulk notifications, webhook-triggered messages
 - **Users use Telfon**: manual calls, conversational SMS, WhatsApp, reviewing recordings


### PR DESCRIPTION
## Summary

- Remove `<!-- AI-CONTEXT-START/END -->` wrappers — subagent context injection pattern, not needed in a subagent file itself
- Remove `## Use Cases` table — marketing content, not operational guidance; agent doesn't need it to help users
- Remove ASCII art diagram in `## Integration with aidevops` — the three bullet points below it carry all the content

138 → 117 lines. All URLs, setup steps, feature paths, troubleshooting table, pricing figures, security notes, alternatives table, and Related links preserved.

Closes #13379

## Runtime Testing

- **Risk level**: Low (docs-only change, no code, no commands, no URLs modified)
- **Verification**: `self-assessed` — content preservation confirmed by line-by-line review; all code blocks, URLs, and operational content present before and after

## Files Changed

- `.agents/services/communications/telfon.md` — 22 lines removed (decorative noise only)

---
[aidevops.sh](https://aidevops.sh) v3.5.402 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-sonnet-4-6 spent 1m and 3,822 tokens on this as a headless worker.