### PR TITLE
GH#12810: tighten cro-chapter-15.md (175→167 lines, prose compression)

### DIFF
--- a/.agents/marketing-sales/cro-chapter-15.md
+++ b/.agents/marketing-sales/cro-chapter-15.md
@@ -1,6 +1,6 @@
 # Chapter 15: Personalization and Dynamic Content
 
-Personalization delivers tailored experiences based on user attributes, behavior, or context. Dynamic content adapts per visitor, increasing relevance and conversion rates.
+Tailor experiences based on user attributes, behavior, or context. Dynamic content adapts per visitor, increasing relevance and conversion.
 
 ---
 
@@ -8,22 +8,20 @@ Personalization delivers tailored experiences based on user attributes, behavior
 
 ### 1. Geo-Based
 
-Customize content by visitor location (country, state, city).
+Customize by visitor location (country, state, city).
 
 **What to personalize**: shipping messaging, currency display, local store/event references, language auto-detection.
 
-**Implementation options**:
+**Implementation**:
 
 - **Client-side**: IP geolocation API (ipapi.co, MaxMind GeoIP) → JS conditional rendering
 - **Server-side** (better for SEO): detect IP on server, render appropriate content
 - **Edge**: Cloudflare Workers for zero-latency personalization
 - **Platforms**: AB Tasty, Optimizely, VWO (with geo-targeting)
 
-**Benchmark**: Booking.com reports 20-30% higher conversion from local currency + nearby properties + local payment methods.
+**Benchmark**: Booking.com — 20-30% higher conversion from local currency + nearby properties + local payment methods.
 
 ### 2. Returning Visitor Optimization
-
-Recognize returning visitors and adapt the experience.
 
 | Visitor State | Content Strategy |
 |---|---|
@@ -31,13 +29,11 @@ Recognize returning visitors and adapt the experience.
 | Return visit | Case studies, pricing, direct CTAs, cart recovery |
 | Known user | Personalized recommendations based on history |
 
-**Implementation**: Cookie or localStorage flag on first visit. Show different headlines, content focus, and CTAs based on visit count.
+**Implementation**: Cookie/localStorage flag on first visit. Vary headlines, content focus, and CTAs by visit count.
 
-**Benchmark**: Amazon-style "Welcome back, [Name]" with personalized recommendations yields 15-25% higher engagement from returning visitors.
+**Benchmark**: Amazon-style "Welcome back, [Name]" with personalized recommendations — 15-25% higher engagement from returning visitors.
 
 ### 3. Referral Source
-
-Adapt messaging based on traffic source.
 
 | Source | Strategy |
 |---|---|
@@ -48,11 +44,9 @@ Adapt messaging based on traffic source.
 
 **Implementation**: URL parameters (`?source=facebook-ad&campaign=50-off`) or `document.referrer` detection.
 
-**Benchmark**: Shopify uses source-specific landing pages — 30-50% higher conversion vs generic pages.
+**Benchmark**: Shopify source-specific landing pages — 30-50% higher conversion vs generic.
 
 ### 4. Behavioral
-
-Adapt based on on-site user actions.
 
 | Trigger | Response |
 |---|---|
@@ -64,17 +58,15 @@ Adapt based on on-site user actions.
 
 **Implementation**: Scroll tracking, time-based triggers (`setTimeout`), page-view counters, cart value monitoring.
 
-**Benchmark**: Netflix — 80% of viewing comes from personalized recommendations based on watch/rate/search/list behavior.
+**Benchmark**: Netflix — 80% of viewing from personalized recommendations based on watch/rate/search/list behavior.
 
 ### 5. Dynamic Headlines
 
-Change headlines based on visitor attributes: location, industry (from form/referrer), device type, or time of day.
+Change headlines by visitor attributes: location, industry (from form/referrer), device type, or time of day.
 
-**Combine with A/B testing**: show price-focused variants to coupon-site traffic, social-proof variants to organic traffic.
+**Combine with A/B testing**: price-focused variants for coupon-site traffic, social-proof variants for organic.
 
 ### 6. Smart CTAs
-
-CTAs that adapt to user context.
 
 | Lifecycle Stage | CTA |
 |---|---|
@@ -85,7 +77,7 @@ CTAs that adapt to user context.
 
 Also adapt by cart state (empty → "Start Shopping", items → "Checkout Now ($142)") and time sensitivity (during sale → urgency CTA, after sale → standard CTA).
 
-**Benchmark**: HubSpot smart CTAs — 200%+ CTR increase vs static CTAs.
+**Benchmark**: HubSpot smart CTAs — 200%+ CTR increase vs static.
 
 ### 7. Recommendation Engines
 
@@ -99,15 +91,15 @@ Also adapt by cart state (empty → "Start Shopping", items → "Checkout Now ($
 
 ### 8. Segmented A/B Testing
 
-Instead of showing the same variants to all users, segment tests by user attributes.
+Segment tests by user attributes instead of showing the same variants to all users.
 
-**Example**: E-commerce site tested returning vs first-time visitors separately:
+**Example**: E-commerce returning vs first-time visitors:
 
-- Returning customers: 12% uplift with "Continue shopping" (vs "Welcome back!")
-- First-time visitors: 34% uplift with "Get 10% off" (vs "Browse best sellers")
+- Returning: 12% uplift with "Continue shopping" (vs "Welcome back!")
+- First-time: 34% uplift with "Get 10% off" (vs "Browse best sellers")
 - Overall: 23% lift vs 8% from unsegmented test
 
-**Why it works**: Mobile/desktop, new/returning, and source-based behaviors differ enough that aggregate tests mask segment-specific winners.
+**Why**: Mobile/desktop, new/returning, and source-based behaviors differ enough that aggregate tests mask segment-specific winners.
 
 ---
 
@@ -131,13 +123,13 @@ Instead of showing the same variants to all users, segment tests by user attribu
 4. Behavioral triggers
 5. AI-powered recommendations
 
-**Privacy**: Don't be creepy (no specific addresses). Be transparent about data usage. Comply with GDPR/CCPA. Provide opt-out.
+**Privacy**: Avoid creepy specificity (no addresses). Be transparent about data usage. GDPR/CCPA compliant. Provide opt-out.
 
-**Always test**: Don't assume personalization wins — test generic vs personalized. Sometimes over-personalization feels invasive and hurts conversion.
+**Always test**: Don't assume personalization wins — test generic vs personalized. Over-personalization can feel invasive and hurt conversion.
 
-**Fallbacks are mandatory**: If cookies blocked or VPN hides location, show generic content. Never break the page.
+**Fallbacks mandatory**: Cookies blocked or VPN hides location → show generic content. Never break the page.
 
-**Don't over-personalize**: "Hi Sarah, welcome back!" is good. Using someone's name 5 times on one page is overkill.
+**Don't over-personalize**: "Hi Sarah, welcome back!" is fine. Using someone's name 5 times on one page is overkill.
 
 ---
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/marketing-sales/cro-chapter-15.md` from 175 → 167 lines (prose compression only)
- Removed filler intro sentences before tables (heading already conveys the topic), trimmed verbose phrasing ("Implementation options" → "Implementation", "reports" → em-dash, "Customize content by" → "Customize by")
- Zero knowledge loss: all benchmarks, tool names, data points, case studies, URLs, and examples preserved

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: self-assessed — content-only change, no code paths affected

## Changes

| File | Before | After | Delta |
|------|--------|-------|-------|
| `.agents/marketing-sales/cro-chapter-15.md` | 175 lines | 167 lines | -8 |

Closes #12810

---
[aidevops.sh](https://aidevops.sh) v3.5.402 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,178 tokens on this as a headless worker.