### PR TITLE
GH#12813: tighten agent doc clean-ddd-hexagonal-skill.md

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill.md
@@ -1,32 +1,17 @@
 ---
-description: ">"
+description: Clean Architecture + DDD + Hexagonal patterns for maintainable backend systems
 mode: subagent
 imported_from: external
 ---
-# clean-ddd-hexagonal
-
 # Clean Architecture + DDD + Hexagonal
 
-Backend architecture combining DDD tactical patterns, Clean Architecture dependency rules, and Hexagonal ports/adapters for maintainable, testable systems.
-
-## When to Use (and When NOT to)
-
-| Use When | Skip When |
-|----------|-----------|
-| Complex business domain with many rules | Simple CRUD, few business rules |
-| Long-lived system (years of maintenance) | Prototype, MVP, throwaway code |
-| Team of 5+ developers | Solo developer or small team (1-2) |
-| Multiple entry points (API, CLI, events) | Single entry point, simple API |
-| Need to swap infrastructure (DB, broker) | Fixed infrastructure, unlikely to change |
-| High test coverage required | Quick scripts, internal tools |
-
-**Start simple. Evolve complexity only when needed.** Most systems don't need full CQRS or Event Sourcing.
+DDD tactical patterns, Clean Architecture dependency rules, and Hexagonal ports/adapters for maintainable, testable systems. **Start simple. Evolve complexity only when needed.** When-to-use decision tree: [cheatsheet.md](clean-ddd-hexagonal-skill/cheatsheet.md#when-to-use--skip).
 
 ## CRITICAL: The Dependency Rule
 
 Dependencies point **inward only**. Outer layers depend on inner layers, never the reverse.
 
-```
+```text
 Infrastructure → Application → Domain
    (adapters)     (use cases)    (core)
 ```
@@ -38,44 +23,11 @@ Infrastructure → Application → Domain
 
 **Design validation:** "Create your application to work without either a UI or a database" — Alistair Cockburn. If you can run your domain logic from tests with no infrastructure, your boundaries are correct.
 
-## Quick Decision Trees
-
-### "Where does this code go?"
-
-```
-Where does it go?
-├─ Pure business logic, no I/O           → domain/
-├─ Orchestrates domain + has side effects → application/
-├─ Talks to external systems              → infrastructure/
-├─ Defines HOW to interact (interface)    → port (domain or application)
-└─ Implements a port                      → adapter (infrastructure)
-```
-
-### "Is this an Entity or Value Object?"
-
-```
-Entity or Value Object?
-├─ Has unique identity that persists → Entity
-├─ Defined only by its attributes    → Value Object
-├─ "Is this THE same thing?"         → Entity (identity comparison)
-└─ "Does this have the same value?"  → Value Object (structural equality)
-```
-
-### "Should this be its own Aggregate?"
-
-```
-Aggregate boundaries?
-├─ Must be consistent together in a transaction → Same aggregate
-├─ Can be eventually consistent                 → Separate aggregates
-├─ Referenced by ID only                        → Separate aggregates
-└─ >10 entities in aggregate                    → Split it
-```
-
-**Rule:** One aggregate per transaction. Cross-aggregate consistency via domain events (eventual consistency).
+Decision trees (code placement, entity vs value object, aggregate boundaries): [cheatsheet.md](clean-ddd-hexagonal-skill/cheatsheet.md#quick-decision-trees).
 
 ## Directory Structure
 
-```
+```text
 src/
 ├── domain/                    # Core business logic (NO external dependencies)
 │   ├── {aggregate}/
@@ -114,18 +66,7 @@ src/
 | **Domain Service** | Stateless logic | Domain | When logic doesn't fit an entity |
 | **Application Service** | Orchestration | Application | Coordinates domain + infra |
 
-## Anti-Patterns (CRITICAL)
-
-| Anti-Pattern | Problem | Fix |
-|--------------|---------|-----|
-| **Anemic Domain Model** | Entities are data bags, logic in services | Move behavior INTO entities |
-| **Repository per Entity** | Breaks aggregate boundaries | One repository per AGGREGATE |
-| **Leaking Infrastructure** | Domain imports DB/HTTP libs | Domain has ZERO external deps |
-| **God Aggregate** | Too many entities, slow transactions | Split into smaller aggregates |
-| **Skipping Ports** | Controllers → Repositories directly | Always go through application layer |
-| **CRUD Thinking** | Modeling data, not behavior | Model business operations |
-| **Premature CQRS** | Adding complexity before needed | Start with simple read/write, evolve |
-| **Cross-Aggregate TX** | Multiple aggregates in one transaction | Use domain events for consistency |
+Anti-patterns (anemic domain, leaking infrastructure, god aggregate, etc.): [cheatsheet.md](clean-ddd-hexagonal-skill/cheatsheet.md#common-anti-patterns).
 
 ## Implementation Order
 
@@ -149,26 +90,4 @@ src/
 | [clean-ddd-hexagonal-skill/testing.md](clean-ddd-hexagonal-skill/testing.md) | Unit, integration, architecture tests |
 | [clean-ddd-hexagonal-skill/cheatsheet.md](clean-ddd-hexagonal-skill/cheatsheet.md) | Quick decision guide |
 
-## Sources
-
-### Primary Sources
-
-- [The Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) — Robert C. Martin (2012)
-- [Hexagonal Architecture](https://alistair.cockburn.us/hexagonal-architecture/) — Alistair Cockburn (2005)
-- [Domain-Driven Design: The Blue Book](https://www.domainlanguage.com/ddd/blue-book/) — Eric Evans (2003)
-- [Implementing Domain-Driven Design](https://openlibrary.org/works/OL17392277W) — Vaughn Vernon (2013)
-
-### Pattern References
-
-- [CQRS](https://martinfowler.com/bliki/CQRS.html) — Martin Fowler
-- [Event Sourcing](https://martinfowler.com/eaaDev/EventSourcing.html) — Martin Fowler
-- [Repository Pattern](https://martinfowler.com/eaaCatalog/repository.html) — Martin Fowler (PoEAA)
-- [Unit of Work](https://martinfowler.com/eaaCatalog/unitOfWork.html) — Martin Fowler (PoEAA)
-- [Bounded Context](https://martinfowler.com/bliki/BoundedContext.html) — Martin Fowler
-- [Transactional Outbox](https://microservices.io/patterns/data/transactional-outbox.html) — microservices.io
-- [Effective Aggregate Design](https://www.dddcommunity.org/library/vernon_2011/) — Vaughn Vernon
-
-### Implementation Guides
-
-- [Microsoft: DDD + CQRS Microservices](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/)
-- [Domain Events](https://udidahan.com/2009/06/14/domain-events-salvation/) — Udi Dahan
+Sources and references: [cheatsheet.md](clean-ddd-hexagonal-skill/cheatsheet.md#resources).


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/architecture/clean-ddd-hexagonal-skill.md` from 174 → 93 lines (46.6% reduction)
- Remove content duplicated in `cheatsheet.md` (decision trees, anti-patterns table, when-to-use table, sources section) and replace with pointers
- Fix broken YAML `description: ">"` → proper description string
- Merge duplicate headings (`# clean-ddd-hexagonal` + `# Clean Architecture + DDD + Hexagonal`)
- Add `text` language tags to fenced code blocks (MD040 fix)

## Content Preservation

Zero knowledge loss. All removed content already exists in `clean-ddd-hexagonal-skill/cheatsheet.md`. Unique content retained in main file: dependency rule (CRITICAL), directory structure, DDD building blocks table, implementation order, reference documentation table.

## Runtime Testing

- **Risk level:** Low (agent prompt/docs only, no code logic)
- **Verification:** `self-assessed` — markdownlint clean, all internal links verified against existing chapter files

Closes #12813


---
[aidevops.sh](https://aidevops.sh) v3.5.402 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 4m and 7,166 tokens on this as a headless worker.