### PR TITLE
GH#13807: tighten sql-migrations.md (165 → 143 lines)

### DIFF
--- a/.agents/workflows/sql-migrations.md
+++ b/.agents/workflows/sql-migrations.md
@@ -12,15 +12,7 @@ mode: subagent
 
 ## Directory Structure
 
-```text
-project/
-├── schemas/          # Declarative schema (source of truth; prefix: 00, 01, 10, 20...)
-├── migrations/       # Generated migration files
-├── seeds/            # Initial/test data
-└── scripts/
-    ├── migrate.sh    # Run pending migrations
-    └── rollback.sh   # Rollback last migration
-```
+`schemas/` (source of truth, prefix: 00, 01, 10, 20...) | `migrations/` (generated) | `seeds/` (initial/test data) | `scripts/migrate.sh`, `scripts/rollback.sh`
 
 ## Tool Commands
 
@@ -116,25 +108,11 @@ Mark irreversible DOWN sections: `-- IRREVERSIBLE: restore from backup if needed
 
 **Team rules:** Pull before creating. Timestamps not sequential numbers. One migration per PR. Rebase carefully — regenerate timestamps for conflicts. Commit style: `feat(db): add user_preferences table`, `fix(db): correct FK on orders`, `chore(db): backfill user status`.
 
-**CI/CD:** Trigger on `push` to `main` with `paths: ['migrations/**']`. Steps: backup → migrate → verify. Most tools auto-create a tracking table (e.g., `flyway_schema_history`). Prefer managed tools — they handle ordering, locking, and state tracking.
-
-```yaml
-on: { push: { branches: [main], paths: ['migrations/**'] } }
-jobs:
-  migrate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: pg_dump $DATABASE_URL > backup_$(date +%Y%m%d_%H%M%S).sql
-        env: { DATABASE_URL: "${{ secrets.DATABASE_URL }}" }
-      - run: flyway migrate
-        env: { DATABASE_URL: "${{ secrets.DATABASE_URL }}" }
-      - run: psql $DATABASE_URL -c "SELECT 1"
-```
+**CI/CD:** Trigger on `push` to `main` with `paths: ['migrations/**']`. Steps: backup → migrate → verify. Most tools auto-create a tracking table (e.g., `flyway_schema_history`). Prefer managed tools — they handle ordering, locking, and state tracking. Example workflow: `on: push(main, migrations/**) → pg_dump → flyway migrate → psql SELECT 1`.
 
 ## Framework-Agnostic Runner
 
-When running SQL directly without a migration tool, gate execution on a tracking table. Properties: idempotent (`WHERE NOT EXISTS`), ordered (lexicographic glob), auditable (`schema_migrations`), injection-safe (`psql -v` + `:'name'`), concurrent-safe (`pg_advisory_xact_lock`), empty-dir safe (`compgen -G`), `-- no-tx` convention for `CREATE INDEX CONCURRENTLY`.
+When no migration tool is available, gate execution on a tracking table. Properties: idempotent (`WHERE NOT EXISTS`), ordered (lexicographic glob), auditable (`schema_migrations`), injection-safe (`psql -v` + `:'name'`), concurrent-safe (`pg_advisory_xact_lock`), empty-dir safe (`compgen -G`), `-- no-tx` convention for `CREATE INDEX CONCURRENTLY`.
 
 ```bash
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/sql-migrations.md` from 165 → 143 lines (13% reduction) while preserving all institutional knowledge.

Closes #13807

### Changes

- **Directory structure**: Converted 9-line tree diagram to single inline description — same information, fewer tokens
- **CI/CD section**: Replaced 13-line YAML boilerplate with inline workflow summary — the rules above it are the knowledge; the YAML was illustration
- All SQL code blocks, bash runner script, tool command table, naming conventions, rollback/safety tables, production safety table, and expand-contract pattern preserved verbatim

### Content preservation verification

- All inline code references: verified via `rg -o` diff (only additions, zero deletions)
- Code blocks: 6 → 4 (removed: directory tree text block, CI/CD YAML block — both converted to inline)
- markdownlint-cli2: 0 errors

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — no runtime behaviour change, content-only edit

---
[aidevops.sh](https://aidevops.sh) v3.5.402 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,111 tokens on this as a headless worker.