### PR TITLE
GH#13810: tighten stream-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/stream-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/stream-patterns.md
@@ -28,53 +28,11 @@ export async function POST(req: Request) {
 }
 ```
 
-**Frontend** — upload with progress tracking:
-
-```tsx
-'use client';
-import { useState } from 'react';
-
-export function VideoUploader() {
-  const [uploading, setUploading] = useState(false);
-  const [progress, setProgress] = useState(0);
-  
-  async function handleUpload(file: File) {
-    setUploading(true);
-    const { uploadURL, uid } = await fetch('/api/upload-url', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ videoName: file.name })
-    }).then(r => r.json());
-    
-    const formData = new FormData();
-    formData.append('file', file);
-    
-    const xhr = new XMLHttpRequest();
-    xhr.upload.addEventListener('progress', (e) => {
-      if (e.lengthComputable) setProgress((e.loaded / e.total) * 100);
-    });
-    xhr.addEventListener('load', () => {
-      setUploading(false);
-      window.location.href = `/videos/${uid}`;
-    });
-    xhr.open('POST', uploadURL);
-    xhr.send(formData);
-  }
-  
-  return (
-    <div>
-      <input type="file" accept="video/*"
-        onChange={(e) => e.target.files?.[0] && handleUpload(e.target.files[0])}
-        disabled={uploading} />
-      {uploading && <progress value={progress} max={100} />}
-    </div>
-  );
-}
-```
+**Frontend** — fetch upload URL from backend, POST file as FormData to the signed URL. Use `XMLHttpRequest` for upload progress (`xhr.upload` `progress` event). The upload URL is single-use and expires.
 
 ## Video Status Polling
 
-Poll for processing completion (max 60 attempts, 5s intervals):
+Poll `GET /accounts/{id}/stream/{videoId}` until `readyToStream` or `error`:
 
 ```typescript
 interface VideoState {
@@ -88,17 +46,19 @@ async function waitForVideoReady(
   maxAttempts = 60, intervalMs = 5000
 ): Promise<VideoState> {
   for (let i = 0; i < maxAttempts; i++) {
-    const response = await fetch(
+    const res = await fetch(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/${videoId}`,
       { headers: { 'Authorization': `Bearer ${apiToken}` } }
     );
-    const { result } = await response.json();
+    const { result } = await res.json();
     if (result.readyToStream || result.status.state === 'error') return result;
-    await new Promise(resolve => setTimeout(resolve, intervalMs));
+    await new Promise(r => setTimeout(r, intervalMs));
   }
   throw new Error('Video processing timeout');
 }
 ```
+
+Prefer webhooks over polling for production use.
 
 ## Webhook Handler (Workers)
 
@@ -109,18 +69,17 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const signature = request.headers.get('Webhook-Signature');
     if (!signature) return new Response('No signature', { status: 401 });
-    
+
     const body = await request.text();
-    // Verify HMAC-SHA256: parse time/sig1, check 5min window, compare signature
+    // Verify HMAC-SHA256: parse time1,sig1 from header, check 5min window, compare digest
     const isValid = await verifySignature(signature, body, env.WEBHOOK_SECRET);
     if (!isValid) return new Response('Invalid', { status: 401 });
-    
+
     const payload = JSON.parse(body);
     if (payload.readyToStream) console.log(`Video ${payload.uid} ready`);
     return new Response('OK');
   }
 };
-// Full verifySignature impl in gotchas.md
 ```
 
 ## Live Streaming
@@ -141,10 +100,3 @@ export default {
 - **Creator metadata** — enable per-user filtering/analytics
 - **Enable recordings for live** — automatic VOD after stream ends
 - **GraphQL analytics** — track views, watch time, geo
-
-## Related
-
-- [README.md](./README.md) — overview and quick start
-- [gotchas.md](./gotchas.md) — error codes, troubleshooting
-- [workers](../workers/) — deploy Stream APIs in Workers
-- [pages](../pages/) — integrate Stream with Pages


### PR DESCRIPTION
## Summary

- Tighten `.agents/services/hosting/cloudflare-platform-skill/stream-patterns.md` (150 → 102 lines, 32% reduction)
- Replace 40-line generic React upload component with 1-line prose summary preserving all Stream-specific knowledge (signed URL, FormData POST, XHR progress tracking)
- Remove redundant "Related" section (already covered by `stream.md` navigation)
- Remove false reference to non-existent `verifySignature` implementation in gotchas.md
- Add webhook-over-polling recommendation near the polling section

## Classification

Reference corpus file — tightened prose and removed boilerplate, not restructured into chapters (102 lines doesn't warrant splitting).

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — content preservation verified via before/after comparison of all code blocks, URLs, and domain-specific knowledge

Closes #13810

---
[aidevops.sh](https://aidevops.sh) v3.5.402 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 5m and 6,794 tokens on this as a headless worker.