### PR TITLE
GH#13812: fix maintainer-gate cancel-in-progress race condition

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 3
     concurrency:
       group: maintainer-gate-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       pull-requests: write
       issues: read


### PR DESCRIPTION
## Summary

- Fix systemic CI failure: `Maintainer Review & Assignee Gate` check cancelling mid-run on 4 PRs
- Root cause: `cancel-in-progress: true` causes a race when multiple PR events fire rapidly
- Fix: `cancel-in-progress: false` — runs queue instead of cancel, gate always completes

## Root Cause Analysis

The `check-pr` job uses:
```yaml
concurrency:
  group: maintainer-gate-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

When a PR triggers multiple events in rapid succession (e.g., `opened` + `synchronize`, or `synchronize` + `edited`), the second run cancels the first before it completes. GitHub treats a cancelled run as a **failed check**, blocking the PR.

Evidence from the 4 affected runs:
- Run 23728320822 (PR #13764): `Canceling since a higher priority waiting request for maintainer-gate-13764 exists`
- Run 23728267186 (PR #13793): `Canceling since a higher priority waiting request for maintainer-gate-13793 exists`
- Run 23728264379 (PR #13793): same cancellation message
- Run 23728287409 (PR #13795): log not retained but same pattern

## Fix

Change `cancel-in-progress: true` → `cancel-in-progress: false` in the `check-pr` job.

**Why this is correct for a gate check:** `cancel-in-progress: true` is appropriate for build/deploy workflows where you want the latest run to supersede stale ones. For a blocking gate check, cancellation = failure. Queuing is the right behaviour — the latest run always completes and produces a definitive pass/fail result.

The other workflows with `cancel-in-progress: true` (issue-sync, version-validation, code-quality, etc.) are unaffected — those are build/sync workflows where cancellation is safe.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/maintainer-gate.yml:32` | `cancel-in-progress: true` → `cancel-in-progress: false` |

## Runtime Testing

- **Risk level**: Low (CI workflow config only, no code execution change)
- **Verification**: `self-assessed` — single-line config change with clear causal chain from evidence

Closes #13812

---
[aidevops.sh](https://aidevops.sh) v3.5.405 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 7m and 6,596 tokens on this as a headless worker.