### PR TITLE
GH#12798: tighten pr-loop.md agent doc

### DIFF
--- a/.agents/scripts/commands/pr-loop.md
+++ b/.agents/scripts/commands/pr-loop.md
@@ -19,58 +19,39 @@ Arguments: $ARGUMENTS
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--pr <n>` | PR number (auto-detects from current branch if omitted) | auto |
-| `--wait-for-ci` | Wait for CI checks to complete before checking review status | false |
+| `--wait-for-ci` | Wait for CI checks before checking review status | false |
 | `--max-iterations <n>` | Max check iterations | 10 |
 | `--no-auto-trigger` | Disable automatic re-review trigger for stale reviews | false |
 
 ## Workflow
 
-### Step 1: Parse Arguments
+Each iteration checks:
 
-Extract from $ARGUMENTS:
-- `pr_number` - PR number (or auto-detect from branch)
-- `wait_for_ci` - Whether to wait for CI before checking reviews
-- `max_iterations` - Maximum iterations before giving up
-- `auto_trigger` - Whether to trigger re-review if stale
+1. **CI Status** — all GitHub Actions workflows
+2. **Review Bot Gate (t1382)** — verify AI review bots have posted (see below)
+3. **Review Status** — approvals or change requests
+4. **Merge Readiness** — verify PR can be merged
 
-### Step 2: Run PR Review Loop
+**On issues:** CI failures → report and wait. Changes requested → verify before acting, then address valid feedback. Stale review → auto-trigger re-review (unless `--no-auto-trigger`).
 
-Monitor the PR iteratively using `gh` CLI to check CI status, reviews, and merge readiness.
-
-### Step 3: Monitor and Iterate
-
-The script performs these checks each iteration:
-
-1. **CI Status** - Check all GitHub Actions workflows
-2. **Review Bot Gate (t1382)** - Verify AI review bots have posted (see below)
-3. **Review Status** - Check for approvals or change requests
-4. **Merge Readiness** - Verify PR can be merged
-
-If issues are found:
-- CI failures: Report and wait for fixes
-- Changes requested: **Verify before acting** (see below), then address valid feedback
-- Unresolved AI feedback (COMMENTED): Some bots (e.g., Gemini Code Assist) post as `COMMENTED` rather than `CHANGES_REQUESTED`, so GitHub's `reviewDecision` stays `NONE`. The loop detects unresolved review threads and surfaces this feedback for action.
-- Stale review: Auto-trigger re-review (unless `--no-auto-trigger`)
+**COMMENTED reviews:** Some bots (e.g., Gemini Code Assist) post as `COMMENTED` not `CHANGES_REQUESTED`, so `reviewDecision` stays `NONE`. The loop detects unresolved review threads and surfaces them.
 
 ### Review Bot Gate (t1382)
 
-Before proceeding to merge, the loop MUST verify that at least one AI review bot has posted. This prevents the pattern where PRs are merged before bots finish analysis, losing security findings.
+Before merge, verify at least one AI review bot has posted — prevents merging before bots finish analysis.
 
 ```bash
-# Check if bots have posted
 RESULT=$(~/.aidevops/agents/scripts/review-bot-gate-helper.sh check "$PR_NUMBER" "$REPO")
 # Returns: PASS (bots found), WAITING (no bots yet), SKIP (label present)
 ```
 
-**If WAITING**: The loop continues polling. Most bots post within 2-5 minutes. The `review-bot-gate` CI check (if configured as required) also blocks merge at the GitHub level.
+| Result | Action |
+|--------|--------|
+| `WAITING` | Continue polling (most bots post within 2-5 min). `review-bot-gate` CI check also blocks at GitHub level. |
+| `PASS` | Read bot reviews; address critical/security findings before merge. Non-critical → follow-up. |
+| `SKIP` | PR has `skip-review-gate` label — proceed. |
 
-**If PASS**: Read the bot reviews and address critical/security findings before merging. Non-critical suggestions can be noted for follow-up.
-
-**If SKIP**: The PR has the `skip-review-gate` label — proceed without waiting.
-
-### AI Bot Review Verification
-
-For handling AI code reviewer feedback, see `Bot Reviewer Feedback` guidance in `.agents/reference/session.md` and `AI Suggestion Verification` in `.agents/prompts/build.txt`.
+**AI review verification:** See `Bot Reviewer Feedback` in `.agents/reference/session.md` and `AI Suggestion Verification` in `.agents/prompts/build.txt`.
 
 ## Completion Promises
 
@@ -82,8 +63,6 @@ For handling AI code reviewer feedback, see `Bot Reviewer Feedback` guidance in 
 
 ## Intelligent Timing
 
-The loop uses evidence-based timing for different CI services:
-
 | Service Category | Initial Wait | Poll Interval |
 |------------------|--------------|---------------|
 | Fast (CodeFactor, Version) | 10s | 5s |
@@ -92,78 +71,24 @@ The loop uses evidence-based timing for different CI services:
 
 ## Examples
 
-**Monitor current branch's PR:**
-
 ```bash
-/pr-loop
-```
-
-**Monitor specific PR with CI wait:**
-
-```bash
-/pr-loop --pr 123 --wait-for-ci
-```
-
-**Extended monitoring:**
-
-```bash
-/pr-loop --pr 123 --max-iterations 20
-```
-
-**Disable auto re-review trigger:**
-
-```bash
-/pr-loop --no-auto-trigger
+/pr-loop                              # Monitor current branch's PR
+/pr-loop --pr 123 --wait-for-ci       # Specific PR, wait for CI
+/pr-loop --pr 123 --max-iterations 20 # Extended monitoring
+/pr-loop --no-auto-trigger            # Disable auto re-review
 ```
 
 ## State Tracking
 
-Progress is tracked in `.agents/loop-state/quality-loop.local.state`:
-
-```markdown
-## PR Review Loop State
-
-- **Status:** monitoring
-- **PR:** #123
-- **Iteration:** 3/10
-- **Last Check:** <timestamp>
-
-### Check Results
-- [x] CI: all checks passing
-- [ ] Review: awaiting approval
-- [ ] Merge: blocked (needs approval)
-```
-
-## When to Use
-
-- After creating a PR to monitor until merge
-- When waiting for CI checks and reviews
-- As part of `/full-loop` workflow (automatic)
+Progress tracked in `.agents/loop-state/quality-loop.local.state` (PR number, iteration count, check results).
 
 ## Timeout Recovery
 
-If the loop times out before completion:
+```bash
+gh pr view --json state,reviewDecision,statusCheckRollup  # Check current status
+```
 
-1. **Check current status:**
-
-   ```bash
-   gh pr view --json state,reviewDecision,statusCheckRollup
-   ```
-
-2. **Review what's pending** - usually one of:
-   - CI checks still running (wait and re-check)
-   - Review requested but not completed (ping reviewer)
-   - Failing checks that need manual intervention
-
-3. **Fix and continue:**
-
-   ```bash
-   # Re-run single review cycle
-   /pr review
-
-   # Or restart loop
-   /pr-loop
-   ```
+Common blockers: CI still running (wait), review not completed (ping reviewer), failing checks (manual fix). Resume with `/pr review` (single cycle) or `/pr-loop` (restart loop).
 
 ## Related Commands
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/pr-loop.md` from 176 → 101 lines (42% reduction)
- Remove structural noise: redundant parse-arguments section, verbose state tracking example, obvious "When to Use" section
- Collapse 4 separate example code blocks into one compact block
- Compress timeout recovery from 24 lines to 3
- Convert review bot gate prose to scannable table format

## Knowledge Preserved

All institutional knowledge verified present:
- Task ID `t1382` (review bot gate)
- `review-bot-gate-helper.sh` command and return values
- `COMMENTED` vs `CHANGES_REQUESTED` nuance (Gemini Code Assist)
- CI timing table (CodeFactor, SonarCloud, CodeRabbit)
- Completion promises (`PR_APPROVED`, `PR_MERGED`)
- Cross-references to `session.md` and `build.txt`
- `skip-review-gate` label handling
- State file path, all CLI options, related commands

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — markdown lint clean, content preservation verified via `rg` checks

Closes #12798

---
[aidevops.sh](https://aidevops.sh) v3.5.405 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 6m and 7,048 tokens on this as a headless worker.