### PR TITLE
GH#12704: tighten recall.md — 182→58 lines, zero knowledge loss

### DIFF
--- a/.agents/scripts/commands/recall.md
+++ b/.agents/scripts/commands/recall.md
@@ -10,54 +10,9 @@ Search query: $ARGUMENTS
 
 ## Workflow
 
-### Step 1: Search Memories
-
-Run the search:
-
-```bash
-~/.aidevops/agents/scripts/memory-helper.sh recall "{query}"
-```
-
-### Step 2: Present Results
-
-If results found:
-
-```text
-Found {count} memories for "{query}":
-
-1. [{type}] {content}
-   Tags: {tags} | Project: {project} | {age}
-   
-2. [{type}] {content}
-   Tags: {tags} | Project: {project} | {age}
-
----
-Actions:
-- Use memory #1 in current context
-- Search with different terms
-- Show more results
-```
-
-If no results:
-
-```text
-No memories found for "{query}"
-
-Try:
-- Different keywords
-- Broader search terms
-- /recall --recent (show latest memories)
-```
-
-### Step 3: Apply Memory
-
-When user selects a memory, incorporate it into the current context:
-
-```text
-Applying memory: "{content}"
-
-This suggests: {interpretation for current task}
-```
+1. Run: `~/.aidevops/agents/scripts/memory-helper.sh recall "{query}"`
+2. Present results with type, tags, project, and age. Offer to apply selected memory to current context.
+3. No results: suggest different keywords, broader terms, or `--recent`.
 
 ## Search Options
 
@@ -69,9 +24,11 @@ This suggests: {interpretation for current task}
 | `/recall --recent` | Show 10 most recent |
 | `/recall --stats` | Show memory statistics |
 
-## Examples
+## Memory Types
 
-**Basic search:**
+`WORKING_SOLUTION`, `FAILED_APPROACH`, `USER_PREFERENCE`, `CODEBASE_PATTERN`, `DECISION`, `TOOL_CONFIG`
+
+## Example
 
 ```text
 User: /recall cors
@@ -79,104 +36,23 @@ AI: Found 2 memories for "cors":
 
     1. [WORKING_SOLUTION] Fixed CORS by adding Access-Control-Allow-Origin header to nginx.conf
        Tags: cors,nginx,headers | Project: api-gateway | 3 days ago
-       
+
     2. [FAILED_APPROACH] Setting CORS in Express middleware didn't work with nginx proxy
        Tags: cors,express,nginx | Project: api-gateway | 3 days ago
 
     Which memory is relevant to your current task?
 ```
 
-**Type-filtered search:**
-
-```text
-User: /recall --type USER_PREFERENCE
-AI: Found 5 user preferences:
-
-    1. [USER_PREFERENCE] Use conventional commit format
-       Tags: git,commits | Global | 1 week ago
-       
-    2. [USER_PREFERENCE] Prefer tabs over spaces (width: 2)
-       Tags: formatting,style | Global | 2 weeks ago
-    ...
-```
-
-**Project-specific search:**
-
-```text
-User: /recall --project wordpress-plugin
-AI: Found 8 memories for project "wordpress-plugin":
-
-    1. [CODEBASE_PATTERN] All hooks use prefix 'myplugin_'
-    2. [DECISION] Using SCF instead of ACF for custom fields
-    3. [WORKING_SOLUTION] Fixed activation hook by checking PHP version first
-    ...
-```
-
-**Recent memories:**
-
-```text
-User: /recall --recent
-AI: 10 most recent memories:
-
-    1. [WORKING_SOLUTION] Memory system uses SQLite FTS5 (today)
-    2. [DECISION] Chose SQLite over Postgres for zero dependencies (today)
-    3. [TOOL_CONFIG] ShellCheck requires local var pattern (yesterday)
-    ...
-```
-
-## Memory Statistics
-
-```text
-User: /recall --stats
-AI: Memory Statistics:
-    
-    Total entries: 47
-    By type:
-      WORKING_SOLUTION: 15
-      CODEBASE_PATTERN: 12
-      USER_PREFERENCE: 8
-      FAILED_APPROACH: 6
-      DECISION: 4
-      TOOL_CONFIG: 2
-    
-    By project:
-      global: 20
-      api-gateway: 12
-      wordpress-plugin: 8
-      aidevops: 7
-    
-    Oldest: 45 days ago
-    Most accessed: "conventional commits" (12 accesses)
-```
-
 ## Proactive Recall
 
-AI assistants should proactively search memories when:
+Search memories proactively when: starting a project, encountering errors, making architecture decisions, or setting up tools. Check `--project {current-project}` at session start.
 
-1. Starting work on a project (check project-specific memories)
-2. Encountering an error (search for similar issues)
-3. Making architecture decisions (check past decisions)
-4. Setting up tools (check TOOL_CONFIG memories)
-
-```text
-AI: Before we start, let me check for relevant memories...
-    [Searches: /recall --project {current-project}]
-    
-    Found 3 relevant memories:
-    - This project uses conventional commits
-    - API routes follow /api/v1/{resource} pattern
-    - Tests require DATABASE_URL env var
-```
-
-## Memory Maintenance
-
-Memories track access patterns. Stale memories (>90 days, never accessed) can be pruned:
+## Maintenance
 
 ```bash
-# Validate memory health
 ~/.aidevops/agents/scripts/memory-helper.sh validate
-
-# Prune stale entries (dry-run first)
 ~/.aidevops/agents/scripts/memory-helper.sh prune --dry-run
 ~/.aidevops/agents/scripts/memory-helper.sh prune
 ```
+
+Stale memories (>90 days, never accessed) are candidates for pruning.


### PR DESCRIPTION
## Summary

- Tightened `.agents/scripts/commands/recall.md` from 182 → 58 lines (68% reduction)
- Removed 4 redundant examples (kept 1 representative), verbose mock output templates, and boilerplate prose
- Preserved all institutional knowledge: commands, memory types, search options, proactive recall triggers, maintenance procedures

## What was removed

| Section | Before | After | Rationale |
|---------|--------|-------|-----------|
| Examples | 4 verbose examples (54 lines) | 1 example (12 lines) | All showed same output format; one is sufficient |
| Step 2/3 templates | 39 lines of mock output | 3-line workflow | Agent can format results naturally |
| Memory Statistics | 24-line mock output | Row in search options table | `--stats` already documented |
| Proactive Recall | 18 lines with mock block | 2 sentences | Triggers preserved, mock removed |
| Maintenance | 12 lines with prose wrapper | 6 lines (commands only) | Commands are self-documenting |

## What was preserved

- All `memory-helper.sh` commands: `recall`, `validate`, `prune`, `prune --dry-run`
- All 6 memory types: `WORKING_SOLUTION`, `FAILED_APPROACH`, `USER_PREFERENCE`, `CODEBASE_PATTERN`, `DECISION`, `TOOL_CONFIG`
- All search options: `--type`, `--project`, `--recent`, `--stats`
- Proactive recall triggers (4 scenarios)
- Stale memory threshold (>90 days)
- YAML frontmatter unchanged

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdown lint clean, content preservation verified via `rg` checks

Closes #12704

---
[aidevops.sh](https://aidevops.sh) v3.5.405 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 4m and 7,438 tokens on this as a headless worker.