### PR TITLE
GH#12690: tighten heygen webhooks agent doc

### DIFF
--- a/.agents/content/heygen-skill/rules-webhooks.md
+++ b/.agents/content/heygen-skill/rules-webhooks.md
@@ -19,37 +19,27 @@ Push notifications to your server when async operations complete, avoiding polli
 
 ```typescript
 import express from "express";
-import crypto from "crypto";
-
 const app = express();
 app.use(express.json());
 
 app.post("/webhook/heygen", async (req, res) => {
   res.status(200).send("OK"); // Acknowledge immediately
-
   processWebhookEvent(req.body).catch(console.error);
 });
 
 async function processWebhookEvent(event: HeyGenWebhookEvent) {
   switch (event.event_type) {
-    case "avatar_video.success":
-      await handleVideoSuccess(event);
-      break;
-    case "avatar_video.fail":
-      await handleVideoFailure(event);
-      break;
-    case "video_translate.success":
-      await handleTranslationSuccess(event);
-      break;
-    default:
-      console.log(`Unknown event type: ${event.event_type}`);
+    case "avatar_video.success": await handleVideoSuccess(event); break;
+    case "avatar_video.fail": await handleVideoFailure(event); break;
+    case "video_translate.success": await handleTranslationSuccess(event); break;
+    default: console.log(`Unknown event type: ${event.event_type}`);
   }
 }
 
 app.listen(3000);
 ```
 
-**Local testing:** Use `ngrok http 3000` and register the ngrok URL as your webhook endpoint.
+**Local testing:** `ngrok http 3000` — register the ngrok URL as your webhook endpoint.
 
 ## Event Types
 
@@ -64,8 +54,6 @@ app.listen(3000);
 
 ## Event Payloads
 
-### Video Success
-
 ```typescript
 interface VideoSuccessEvent {
   event_type: "avatar_video.success";
@@ -77,11 +65,7 @@ interface VideoSuccessEvent {
     callback_id?: string;    // Your custom identifier from video generation
   };
 }
-```
 
-### Video Failure
-
-```typescript
 interface VideoFailureEvent {
   event_type: "avatar_video.fail";
   event_data: {
@@ -139,15 +123,12 @@ Validate `x-heygen-signature` header using HMAC-SHA256:
 import crypto from "crypto";
 
 function verifyWebhookSignature(
-  payload: string,
-  signature: string,
-  secret: string
+  payload: string, signature: string, secret: string
 ): boolean {
   const expected = crypto
     .createHmac("sha256", secret)
     .update(payload)
     .digest("hex");
-
   return crypto.timingSafeEqual(
     Buffer.from(signature),
     Buffer.from(expected)
@@ -157,11 +138,9 @@ function verifyWebhookSignature(
 app.post("/webhook/heygen", (req, res) => {
   const signature = req.headers["x-heygen-signature"] as string;
   const payload = JSON.stringify(req.body);
-
   if (!verifyWebhookSignature(payload, signature, WEBHOOK_SECRET)) {
     return res.status(401).send("Invalid signature");
   }
-
   // Process event...
 });
 ```
@@ -170,20 +149,17 @@ app.post("/webhook/heygen", (req, res) => {
 
 ```typescript
 async function processWebhookEvent(event: HeyGenWebhookEvent) {
-  const maxRetries = 3;
-
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+  for (let attempt = 1; attempt <= 3; attempt++) {
     try {
       await handleEvent(event);
       return;
     } catch (error) {
       console.error(`Attempt ${attempt} failed:`, error);
-      if (attempt < maxRetries) {
+      if (attempt < 3) {
         await new Promise((r) => setTimeout(r, Math.pow(2, attempt) * 1000));
       }
     }
   }
-
   await storeFailedEvent(event); // Manual review queue
 }
 ```


### PR DESCRIPTION
## Summary

- Tighten `.agents/content/heygen-skill/rules-webhooks.md` (189 → 165 lines, 13% reduction)
- Remove structural noise: unused `crypto` import, redundant subsection headers (`### Video Success`, `### Video Failure`), decorative blank lines, verbose switch cases
- Merge event payload interfaces into single code block, inline trivial `maxRetries` constant, compact function signature

## Content Preservation

All knowledge preserved — verified:
- 4 URLs (files.heygen.ai ×2, api.heygen.com, your-domain.com)
- 6 code blocks (5 TypeScript, 1 bash)
- 7 section headers
- Event types table (6 rows), registration fields table (3 rows)
- Security-critical signature verification code fully intact
- YAML frontmatter unchanged

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — markdown lint clean, diff reviewed, content preservation verified

Closes #12690

---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 4m and 6,703 tokens on this as a headless worker.