### PR TITLE
GH#12614: tighten remotion-extract-frames.md agent doc

### DIFF
--- a/.agents/tools/video/remotion-extract-frames.md
+++ b/.agents/tools/video/remotion-extract-frames.md
@@ -90,6 +90,8 @@ await extractFrames({
 
 ## Filmstrip (dynamic timestamps via callback)
 
+Pass a callback to `timestampsInSeconds` to compute timestamps from video metadata:
+
 ```tsx
 const canvasWidth = 500;
 const canvasHeight = 80;
@@ -98,7 +100,7 @@ const toSeconds = 10;
 
 await extractFrames({
   src: "https://remotion.media/video.mp4",
-  timestampsInSeconds: async ({ track, durationInSeconds }) => {
+  timestampsInSeconds: async ({ track }) => {
     const aspectRatio = track.width / track.height;
     const amountOfFramesFit = Math.ceil(canvasWidth / (canvasHeight * aspectRatio));
     const segmentDuration = toSeconds - fromSeconds;
@@ -109,43 +111,15 @@ await extractFrames({
     return timestamps;
   },
   onVideoSample: (sample) => {
-    console.log(`Frame at ${sample.timestamp}s`);
-    const canvas = document.createElement("canvas");
-    canvas.width = sample.displayWidth;
-    canvas.height = sample.displayHeight;
-    const ctx = canvas.getContext("2d");
-    sample.draw(ctx!, 0, 0);
+    // Render to canvas (see Basic usage above)
+    sample.draw(document.createElement("canvas").getContext("2d")!, 0, 0);
   },
 });
 ```
 
-## Cancellation with AbortSignal
+## Cancellation and timeout
 
-```tsx
-const controller = new AbortController();
-setTimeout(() => controller.abort(), 5000);
-
-try {
-  await extractFrames({
-    src: "https://remotion.media/video.mp4",
-    timestampsInSeconds: [0, 1, 2, 3, 4],
-    onVideoSample: (sample) => {
-      using frame = sample;
-      const canvas = document.createElement("canvas");
-      canvas.width = frame.displayWidth;
-      canvas.height = frame.displayHeight;
-      const ctx = canvas.getContext("2d");
-      frame.draw(ctx!, 0, 0);
-    },
-    signal: controller.signal,
-  });
-  console.log("Frame extraction complete!");
-} catch (error) {
-  console.error("Frame extraction was aborted or failed:", error);
-}
-```
-
-## Timeout with Promise.race
+Pass `signal` for cancellation. For simple timeout: `setTimeout(() => controller.abort(), ms)`. For racing with a cleanup-safe timeout:
 
 ```tsx
 const controller = new AbortController();
@@ -164,18 +138,12 @@ try {
       src: "https://remotion.media/video.mp4",
       timestampsInSeconds: [0, 1, 2, 3, 4],
       onVideoSample: (sample) => {
-        using frame = sample;
-        const canvas = document.createElement("canvas");
-        canvas.width = frame.displayWidth;
-        canvas.height = frame.displayHeight;
-        const ctx = canvas.getContext("2d");
-        frame.draw(ctx!, 0, 0);
+        sample.draw(document.createElement("canvas").getContext("2d")!, 0, 0);
       },
       signal: controller.signal,
     }),
     timeoutPromise,
   ]);
-  console.log("Frame extraction complete!");
 } catch (error) {
   console.error("Frame extraction was aborted or failed:", error);
 }


### PR DESCRIPTION
## Summary

- Merged redundant "Cancellation with AbortSignal" and "Timeout with Promise.race" sections into a single "Cancellation and timeout" section — the simpler AbortSignal-only example was a strict subset of the Promise.race version
- Deduplicated canvas rendering boilerplate across filmstrip and cancellation examples (shown once in Basic usage, referenced thereafter)
- Added one-line intro to filmstrip section for clarity

## Details

**File:** `.agents/tools/video/remotion-extract-frames.md`
**Classification:** Reference corpus (API docs + code examples, not instruction doc)
**Reduction:** 182 → 150 lines (17.6%)

### Content preservation verified

- All 4 API props in table: `src`, `timestampsInSeconds`, `onVideoSample`, `signal`
- Full `extractFrames` implementation (49 lines, unchanged)
- All URLs: `mediabunny.dev`, `remotion.media/video.mp4`
- All patterns: dynamic timestamps callback, AbortController, Promise.race, VideoSampleSink
- All code blocks: 4 examples (implementation, basic, filmstrip, cancellation+timeout)

### What was removed

- Standalone "Cancellation with AbortSignal" section (22 lines) — redundant with Promise.race example which already demonstrates AbortSignal
- Repeated 6-line canvas boilerplate in 3 examples → replaced with 1-line `sample.draw()` calls referencing the Basic usage pattern
- Unused `durationInSeconds` destructuring in filmstrip callback
- Inconsistent `using frame = sample` alias (appeared only in cancellation examples, not in basic usage)

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — content preservation checked via `rg` for all URLs, code blocks, and API identifiers

Closes #12614

---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,271 tokens on this as a headless worker.