### PR TITLE
GH#12613: tighten landing page swipe file

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md
@@ -1,9 +1,5 @@
 # Landing Page Swipe File
 
-Annotated breakdowns of high-converting landing pages.
-
----
-
 ## 1. Slack — "Where Work Happens"
 
 **Hero:**
@@ -20,9 +16,7 @@ Connect your tools. Automate your tasks. Build the workflows that move your comp
 
 **Features:** Benefit-led header → 3 features each with outcome. "Already use" reduces friction.
 
-**Converts because:** Extreme clarity in 5 seconds, low-barrier CTA, features tied to outcomes.
-
----
+**Why it converts:** Extreme clarity in 5 seconds, low-barrier CTA, features tied to outcomes.
 
 ## 2. Notion — "Your Wiki, Docs, & Projects. Together."
 
@@ -39,9 +33,7 @@ Notion is the connected workspace where better, faster work happens.
 
 **Use Cases:** Wiki / Docs / Projects each with one-line benefit. "Your way" = flexibility.
 
-**Converts because:** Multi-use-case without confusion, strong visual demo, free tier removes friction.
-
----
+**Why it converts:** Multi-use-case without confusion, strong visual demo, free tier removes friction.
 
 ## 3. Basecamp — "The All-In-One Toolkit for Working Remotely"
 
@@ -59,12 +51,9 @@ Before: Constant meetings | Lost files | Scattered apps | Anxiety
 After:  One place | Real progress | Everyone in the loop | Calmer teams
 ```
 
-**Pricing:** `$299/month flat. Unlimited users, unlimited projects. No per-user pricing games.`
-- Simple one-tier; anti-competitor positioning
+**Pricing:** `$299/month flat. Unlimited users, unlimited projects. No per-user pricing games.` — simple one-tier; anti-competitor positioning.
 
-**Converts because:** Strong POV, before/after transformation, flat pricing, long-form testimonials.
-
----
+**Why it converts:** Strong POV, before/after transformation, flat pricing, long-form testimonials.
 
 ## 4. Mailchimp — "Turn Emails into Revenue"
 
@@ -80,9 +69,7 @@ Grow your business with email marketing and automations that convert.
 
 **Stat:** `Generate up to 25x more orders with automations* (*Mailchimp data, 2023)` — specific, sourced, believable.
 
-**Converts because:** Clear value prop (emails → revenue), free trial + no CC, specific sourced stats.
-
----
+**Why it converts:** Clear value prop (emails → revenue), free trial + no CC, specific sourced stats.
 
 ## 5. Copyhackers — "Copy School" (Course Sales Page)
 
@@ -105,9 +92,7 @@ Why: Free stuff teaches WHAT. Not HOW. Not how to THINK like a copywriter.
 
 **Testimonial:** `"I went from charging $500 to $5,000 for a landing page — and getting it."` — specific 10x number, named person with photo.
 
-**Converts because:** Long-form for unaware audience, extensive social proof, clear curriculum, real urgency.
-
----
+**Why it converts:** Long-form for unaware audience, extensive social proof, clear curriculum, real urgency.
 
 ## Hero Section Templates
 
@@ -132,8 +117,6 @@ From [Current State] to [Desired State]
 [CTA]
 ```
 
----
-
 ## Social Proof Bar Templates
 
 ```
@@ -146,16 +129,12 @@ Trusted by [X]+ [customers/companies/users]
 "97% report faster results" | "4.9/5 on G2" | "10,000+ users"
 ```
 
----
-
 ## CTA Button Text
 
 - Start Free Trial / Get Started Free / Try [Product] Free
 - Start My [X]-Day Trial / Get Instant Access
 - Yes, I Want [Outcome] / Show Me How
 - Book My Demo / Claim My [Thing] / Start [Action]ing Now
-
----
 
 ## Guarantee Templates
 
@@ -168,8 +147,6 @@ Try [Product] for [X] days. If you don't [achieve outcome], we'll refund every p
 The "[Product] Promise"
 If [Product] doesn't [specific result] within [timeframe], show us you implemented it and we'll give you a full refund.
 ```
-
----
 
 ## Design Principles
 


### PR DESCRIPTION
## Summary

- Remove 9 horizontal rules and redundant subtitle — headings already provide visual structure
- Merge Basecamp pricing annotation into its parent line (was a standalone bullet restating the label)
- Standardize "Converts because:" → "Why it converts:" across all 5 examples for consistency

## Content Preservation

| Metric | Before | After |
|--------|--------|-------|
| Lines | 183 | 160 |
| Code blocks | 28 | 28 |
| Sections | 10 | 10 |
| Lint errors | 31 | 30 |

Zero knowledge loss. All code blocks, annotations, templates, and design principles preserved verbatim.

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** self-assessed — content preservation verified via code block count, section count, and full diff review

## File Classification

Reference corpus (swipe file). At 183 lines, well under the 300-line subdivision threshold — restructuring into chapter files would add overhead without benefit. Tightened prose and removed structural noise instead.

Closes #12613


---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 7,036 tokens on this as a headless worker.