### PR TITLE
t1682: fix errored MCP server guard — detect all runtime configs and handle SSE/remote types

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -79,7 +79,7 @@ Use TodoWrite frequently. Break complex tasks into steps. Mark todos completed i
 - When a tool call returns "MCP error -32000", "Connection closed", "spawn ENOENT", or similar startup errors, mark that MCP server as unavailable for the rest of the session. Do NOT retry tools from that server.
 - If you see tools in the tool list from a server that has previously errored, skip them entirely — do not attempt to call them.
 - To identify and fix errored MCP servers: `~/.aidevops/agents/scripts/mcp-diagnose.sh check-all`. This scans all enabled MCP servers and reports which ones are unavailable, with remediation steps.
-- To disable a persistently errored server: set `"enabled": false` in your runtime's MCP config for that server entry. This removes its tool schemas from context entirely. Claude Code CLI: `~/.config/Claude/Claude.json`; Claude Desktop (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`.
+- To disable a persistently errored server: set `"enabled": false` in your runtime's MCP config for that server entry. This removes its tool schemas from context entirely. Claude Code CLI: `~/.claude.json`; Claude Desktop (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`; OpenCode: `~/.config/opencode/opencode.json`.
 
 # File Discovery (MANDATORY)
 - NEVER use Glob when Bash is available

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -79,7 +79,7 @@ Use TodoWrite frequently. Break complex tasks into steps. Mark todos completed i
 - When a tool call returns "MCP error -32000", "Connection closed", "spawn ENOENT", or similar startup errors, mark that MCP server as unavailable for the rest of the session. Do NOT retry tools from that server.
 - If you see tools in the tool list from a server that has previously errored, skip them entirely — do not attempt to call them.
 - To identify and fix errored MCP servers: `~/.aidevops/agents/scripts/mcp-diagnose.sh check-all`. This scans all enabled MCP servers and reports which ones are unavailable, with remediation steps.
-- To disable a persistently errored server: set `"enabled": false` in your runtime's MCP config for that server entry. This removes its tool schemas from context entirely. Claude Code CLI: `~/.claude.json`; Claude Desktop (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`; OpenCode: `~/.config/opencode/opencode.json`.
+- To disable a persistently errored server: set `"enabled": false` in your runtime's MCP config for that server entry. This removes its tool schemas from context entirely. Claude Code CLI: `~/.claude.json`; Claude Code CLI (Linux): `~/.config/Claude/Claude.json`; Claude Desktop (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`; OpenCode: `~/.config/opencode/opencode.json`.
 
 # File Discovery (MANDATORY)
 - NEVER use Glob when Bash is available

--- a/.agents/scripts/mcp-diagnose.sh
+++ b/.agents/scripts/mcp-diagnose.sh
@@ -228,15 +228,18 @@ _collect_all_configs() {
 # Scan a single config file and report MCP server health.
 # Arguments:
 #   $1 - config file path
-# Outputs results to stdout. Sets global ok_count/error_count/skip_count/errored_names.
+#   $2 - name of array variable to append errored server names to (passed by name)
+# Outputs results to stdout. Increments global ok_count/error_count/skip_count.
+# Parse failures are non-fatal: logs an error and returns 0 so the caller continues.
 _scan_config_file() {
 	local config_file="$1"
+	local errored_var="$2"
 
 	local server_list
-	server_list=$(_extract_server_list "$config_file") || {
-		echo -e "  ${RED}✗ Failed to parse config file${NC}"
-		return 1
-	}
+	if ! server_list=$(_extract_server_list "$config_file" 2>/dev/null); then
+		echo -e "  ${RED}✗ Failed to parse config file — skipping${NC}"
+		return 0
+	fi
 
 	if [[ -z "$server_list" ]]; then
 		echo -e "  ${YELLOW}(no enabled MCP servers)${NC}"
@@ -268,7 +271,8 @@ _scan_config_file() {
 			((++ok_count))
 		else
 			echo -e "  ${RED}[error]${NC}  $name — command not found: ${cmd_path:-<none>}"
-			errored_names+=("$name")
+			# Append to the caller-provided array variable by name
+			eval "${errored_var}+=(\"$name\")"
 			((++error_count))
 		fi
 	done <<<"$server_list"
@@ -299,21 +303,24 @@ _check_all_mcps() {
 	local ok_count=0
 	local error_count=0
 	local skip_count=0
-	local errored_names=()
-	local last_config_file=""
+	local any_errors=false
 
 	local config_file
 	for config_file in "${all_configs[@]}"; do
 		echo "Config: $config_file"
-		_scan_config_file "$config_file"
+		# Per-config errored names array — remediation points to the correct config
+		local _cfg_errored=()
+		_scan_config_file "$config_file" "_cfg_errored"
 		echo ""
-		last_config_file="$config_file"
+		if [[ ${#_cfg_errored[@]} -gt 0 ]]; then
+			_print_remediation "$config_file" "${_cfg_errored[@]}"
+			any_errors=true
+		fi
 	done
 
 	echo "Summary: ${ok_count} ok, ${error_count} errored, ${skip_count} skipped (remote)"
 
-	if [[ ${#errored_names[@]} -gt 0 ]]; then
-		_print_remediation "$last_config_file" "${errored_names[@]}"
+	if [[ "$any_errors" == "true" ]]; then
 		return 1
 	fi
 
@@ -333,13 +340,43 @@ fi
 echo -e "${BLUE}=== MCP Diagnosis: $MCP_NAME ===${NC}"
 echo ""
 
-# 0. Detect if this is a remote/SSE MCP (no local command to check)
+# 0. Detect if this is a remote/SSE MCP by reading its type from config files.
+# Config-driven: reads the 'type' field from the MCP entry rather than hardcoding names.
 MCP_IS_REMOTE=false
-case "$MCP_NAME" in
-cloudflare-api | openapi-search | context7)
+MCP_CONFIGURED_TYPE=""
+_detect_mcp_type() {
+	local mcp_name="$1"
+	local config_file="$2"
+	python3 - "$config_file" "$mcp_name" <<'PYEOF'
+import json, sys
+config_file, mcp_name = sys.argv[1], sys.argv[2]
+try:
+    with open(config_file) as f:
+        cfg = json.load(f)
+    mcp_section = cfg.get('mcp', cfg.get('mcpServers', {}))
+    entry = mcp_section.get(mcp_name, {})
+    print(entry.get('type', ''))
+except Exception:
+    print('')
+PYEOF
+}
+
+# Check all config files for this MCP's type.
+# Prefer 'remote' or 'sse' if found in any config (an enabled remote entry
+# takes precedence over a disabled local entry in another config).
+while IFS= read -r _diag_cfg; do
+	_mcp_type=$(_detect_mcp_type "$MCP_NAME" "$_diag_cfg" 2>/dev/null)
+	if [[ "$_mcp_type" == "remote" || "$_mcp_type" == "sse" ]]; then
+		MCP_CONFIGURED_TYPE="$_mcp_type"
+		break
+	elif [[ -n "$_mcp_type" && -z "$MCP_CONFIGURED_TYPE" ]]; then
+		MCP_CONFIGURED_TYPE="$_mcp_type"
+	fi
+done < <(_collect_all_configs)
+
+if [[ "$MCP_CONFIGURED_TYPE" == "remote" || "$MCP_CONFIGURED_TYPE" == "sse" ]]; then
 	MCP_IS_REMOTE=true
-	;;
-esac
+fi
 
 # 1. Check if command exists
 echo "1. Checking command availability..."
@@ -360,7 +397,7 @@ context7)
 esac
 
 if [[ "$MCP_IS_REMOTE" == "true" ]]; then
-	echo -e "   ${CYAN}[remote]${NC} $MCP_NAME is a remote/SSE MCP — no local command required."
+	echo -e "   ${CYAN}[remote]${NC} $MCP_NAME is a remote/SSE MCP (type: ${MCP_CONFIGURED_TYPE}) — no local command required."
 	echo "   Remote MCPs connect over the network and cannot be diagnosed locally."
 	echo ""
 	echo "4. Known issues for $MCP_NAME..."
@@ -380,6 +417,10 @@ if [[ "$MCP_IS_REMOTE" == "true" ]]; then
 	context7)
 		echo "   - Remote MCP, no local command needed"
 		echo "   - Use: \"type\": \"remote\", \"url\": \"https://mcp.context7.com/mcp\""
+		;;
+	*)
+		echo "   - Remote/SSE MCP (type: ${MCP_CONFIGURED_TYPE}) — no local command required"
+		echo "   - To disable: set \"enabled\": false in your MCP config"
 		;;
 	esac
 	exit 0

--- a/.agents/scripts/mcp-diagnose.sh
+++ b/.agents/scripts/mcp-diagnose.sh
@@ -67,6 +67,7 @@ _resolve_mcp_config() {
 	# Fallback: platform-aware candidate paths in priority order
 	if [[ -z "$config_file" || ! -f "$config_file" ]]; then
 		local _candidates=(
+			"$HOME/.claude.json"
 			"$HOME/.config/Claude/Claude.json"
 			"$HOME/Library/Application Support/Claude/claude_desktop_config.json"
 			"$HOME/.config/opencode/opencode.json"
@@ -82,6 +83,7 @@ _resolve_mcp_config() {
 
 	if [[ -z "$config_file" || ! -f "$config_file" ]]; then
 		echo -e "${RED}✗ No MCP config file found. Checked:${NC}" >&2
+		echo -e "${RED}  ~/.claude.json${NC}" >&2
 		echo -e "${RED}  ~/.config/Claude/Claude.json${NC}" >&2
 		echo -e "${RED}  ~/Library/Application Support/Claude/claude_desktop_config.json${NC}" >&2
 		echo -e "${RED}  ~/.config/opencode/opencode.json${NC}" >&2
@@ -114,9 +116,9 @@ for name, server in mcp_section.items():
     enabled = server.get('enabled', True)
     if not enabled:
         continue
-    server_type = server.get('type', 'local')
-    if server_type == 'remote':
-        # Remote MCPs: just print name with remote marker
+    server_type = server.get('type', 'stdio')
+    # 'remote' and 'sse' are network-based MCPs — skip connectivity check
+    if server_type in ('remote', 'sse'):
         print(f"{name}\tremote\t")
         continue
     cmd = server.get('command', [])
@@ -169,35 +171,77 @@ _print_remediation() {
 	return 0
 }
 
-# Orchestrator: scan all enabled MCP servers and report health.
-_check_all_mcps() {
-	echo -e "${BLUE}=== MCP Server Health Check (t1682) ===${NC}"
-	echo ""
-	echo "Scanning all enabled MCP servers for connection errors..."
-	echo "Errored servers inject dead tool schemas into context, wasting tokens."
-	echo ""
+# Collect all unique MCP config files across all detected runtimes.
+# Outputs one config file path per line (no duplicates).
+_collect_all_configs() {
+	local seen=()
+	local config_file=""
 
-	local config_file
-	config_file=$(_resolve_mcp_config) || return 1
+	# Registry-driven: iterate all detected runtimes
+	if type rt_detect_configured &>/dev/null; then
+		local _rt_id
+		while IFS= read -r _rt_id; do
+			local _cfg
+			_cfg=$(rt_config_path "$_rt_id" 2>/dev/null) || continue
+			if [[ -n "$_cfg" && -f "$_cfg" ]]; then
+				# Deduplicate: check if already in seen array
+				local _dup=false
+				if [[ ${#seen[@]} -gt 0 ]]; then
+					local _s
+					for _s in "${seen[@]}"; do
+						[[ "$_s" == "$_cfg" ]] && _dup=true && break
+					done
+				fi
+				if [[ "$_dup" == "false" ]]; then
+					seen+=("$_cfg")
+					echo "$_cfg"
+				fi
+			fi
+		done < <(rt_detect_configured 2>/dev/null)
+	fi
 
-	echo "Config: $config_file"
-	echo ""
+	# Fallback candidates not covered by registry
+	local _fallback_candidates=(
+		"$HOME/.claude.json"
+		"$HOME/.config/Claude/Claude.json"
+		"$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+		"$HOME/.config/opencode/opencode.json"
+	)
+	local _c
+	for _c in "${_fallback_candidates[@]}"; do
+		[[ -f "$_c" ]] || continue
+		local _dup=false
+		if [[ ${#seen[@]} -gt 0 ]]; then
+			local _s
+			for _s in "${seen[@]}"; do
+				[[ "$_s" == "$_c" ]] && _dup=true && break
+			done
+		fi
+		if [[ "$_dup" == "false" ]]; then
+			seen+=("$_c")
+			echo "$_c"
+		fi
+	done
+	return 0
+}
+
+# Scan a single config file and report MCP server health.
+# Arguments:
+#   $1 - config file path
+# Outputs results to stdout. Sets global ok_count/error_count/skip_count/errored_names.
+_scan_config_file() {
+	local config_file="$1"
 
 	local server_list
 	server_list=$(_extract_server_list "$config_file") || {
-		echo -e "${RED}✗ Failed to parse config file${NC}"
+		echo -e "  ${RED}✗ Failed to parse config file${NC}"
 		return 1
 	}
 
 	if [[ -z "$server_list" ]]; then
-		echo -e "${YELLOW}No enabled MCP servers found in config.${NC}"
+		echo -e "  ${YELLOW}(no enabled MCP servers)${NC}"
 		return 0
 	fi
-
-	local ok_count=0
-	local error_count=0
-	local skip_count=0
-	local errored_names=()
 
 	while IFS=$'\t' read -r name server_type cmd_path; do
 		[[ -z "$name" ]] && continue
@@ -228,12 +272,48 @@ _check_all_mcps() {
 			((++error_count))
 		fi
 	done <<<"$server_list"
+	return 0
+}
 
+# Orchestrator: scan all enabled MCP servers across all runtime configs.
+_check_all_mcps() {
+	echo -e "${BLUE}=== MCP Server Health Check (t1682) ===${NC}"
 	echo ""
+	echo "Scanning all enabled MCP servers for connection errors..."
+	echo "Errored servers inject dead tool schemas into context, wasting tokens."
+	echo ""
+
+	local all_configs=()
+	while IFS= read -r _cfg; do
+		all_configs+=("$_cfg")
+	done < <(_collect_all_configs)
+
+	if [[ ${#all_configs[@]} -eq 0 ]]; then
+		echo -e "${RED}✗ No MCP config files found.${NC}"
+		echo "  Checked: ~/.claude.json, ~/.config/Claude/Claude.json,"
+		echo "           ~/Library/Application Support/Claude/claude_desktop_config.json,"
+		echo "           ~/.config/opencode/opencode.json"
+		return 1
+	fi
+
+	local ok_count=0
+	local error_count=0
+	local skip_count=0
+	local errored_names=()
+	local last_config_file=""
+
+	local config_file
+	for config_file in "${all_configs[@]}"; do
+		echo "Config: $config_file"
+		_scan_config_file "$config_file"
+		echo ""
+		last_config_file="$config_file"
+	done
+
 	echo "Summary: ${ok_count} ok, ${error_count} errored, ${skip_count} skipped (remote)"
 
 	if [[ ${#errored_names[@]} -gt 0 ]]; then
-		_print_remediation "$config_file" "${errored_names[@]}"
+		_print_remediation "$last_config_file" "${errored_names[@]}"
 		return 1
 	fi
 
@@ -253,6 +333,14 @@ fi
 echo -e "${BLUE}=== MCP Diagnosis: $MCP_NAME ===${NC}"
 echo ""
 
+# 0. Detect if this is a remote/SSE MCP (no local command to check)
+MCP_IS_REMOTE=false
+case "$MCP_NAME" in
+cloudflare-api | openapi-search | context7)
+	MCP_IS_REMOTE=true
+	;;
+esac
+
 # 1. Check if command exists
 echo "1. Checking command availability..."
 # Map MCP names to their CLI commands
@@ -270,6 +358,32 @@ context7)
 	NPM_PKG="$MCP_NAME"
 	;;
 esac
+
+if [[ "$MCP_IS_REMOTE" == "true" ]]; then
+	echo -e "   ${CYAN}[remote]${NC} $MCP_NAME is a remote/SSE MCP — no local command required."
+	echo "   Remote MCPs connect over the network and cannot be diagnosed locally."
+	echo ""
+	echo "4. Known issues for $MCP_NAME..."
+	case "$MCP_NAME" in
+	cloudflare-api)
+		echo "   - SSE-based remote MCP (type: sse)"
+		echo "   - Requires Cloudflare account and OAuth; errors if unauthenticated"
+		echo "   - Use: \"type\": \"sse\", \"url\": \"https://mcp.cloudflare.com/mcp\""
+		echo "   - To disable: set \"enabled\": false in your MCP config"
+		;;
+	openapi-search)
+		echo "   - SSE-based remote MCP (type: sse)"
+		echo "   - Requires network access to openapi-mcp.openapisearch.com"
+		echo "   - Use: \"type\": \"sse\", \"url\": \"https://openapi-mcp.openapisearch.com/mcp\""
+		echo "   - To disable: set \"enabled\": false in your MCP config"
+		;;
+	context7)
+		echo "   - Remote MCP, no local command needed"
+		echo "   - Use: \"type\": \"remote\", \"url\": \"https://mcp.context7.com/mcp\""
+		;;
+	esac
+	exit 0
+fi
 
 if command -v "$CLI_CMD" &>/dev/null; then
 	echo -e "   ${GREEN}✓ Command found: $(which "$CLI_CMD")${NC}"
@@ -308,6 +422,7 @@ fi
 if [[ ${#_MCP_DIAG_CONFIGS[@]} -eq 0 ]]; then
 	declare -a _fallback_candidates
 	_fallback_candidates=(
+		"claude-code:$HOME/.claude.json"
 		"claude-code:$HOME/.config/Claude/Claude.json"
 		"claude-code:$HOME/Library/Application Support/Claude/claude_desktop_config.json"
 		"opencode:$HOME/.config/opencode/opencode.json"
@@ -371,6 +486,24 @@ augment-context-engine | augment)
 context7)
 	echo "   - Remote MCP, no local command needed"
 	echo "   - Use: \"type\": \"remote\", \"url\": \"https://mcp.context7.com/mcp\""
+	;;
+cloudflare-api)
+	echo "   - SSE-based remote MCP (type: sse)"
+	echo "   - Requires Cloudflare account and OAuth; errors if unauthenticated"
+	echo "   - Use: \"type\": \"sse\", \"url\": \"https://mcp.cloudflare.com/mcp\""
+	echo "   - To disable: set \"enabled\": false in your MCP config"
+	;;
+openapi-search)
+	echo "   - SSE-based remote MCP (type: sse)"
+	echo "   - Requires network access to openapi-mcp.openapisearch.com"
+	echo "   - Use: \"type\": \"sse\", \"url\": \"https://openapi-mcp.openapisearch.com/mcp\""
+	echo "   - To disable: set \"enabled\": false in your MCP config"
+	;;
+playwright)
+	echo "   - Requires @anthropic-ai/mcp-server-playwright (npx -y)"
+	echo "   - Needs Playwright browsers installed: npx playwright install"
+	echo "   - May fail if browsers not installed or npx cache is stale"
+	echo "   - To reinstall: npx -y @anthropic-ai/mcp-server-playwright@latest"
 	;;
 *)
 	echo "   No known issues documented for this MCP"

--- a/.agents/scripts/runtime-registry.sh
+++ b/.agents/scripts/runtime-registry.sh
@@ -380,21 +380,26 @@ rt_config_path() {
 	local path
 	path=$(_rt_expand_path "${_RT_CONFIG_PATH[$idx]}")
 
-	# Platform-aware override for claude-code: on macOS the Desktop app stores
-	# its config in ~/Library/Application Support/Claude/ rather than ~/.config/Claude/.
-	# Check both locations and return the one that exists (Desktop path takes priority
-	# since it's the primary MCP config on macOS).
+	# Platform-aware override for claude-code: config location varies by install type.
+	# Priority order:
+	#   1. ~/.claude.json          — Claude Code CLI (global MCP config, all platforms)
+	#   2. ~/Library/.../claude_desktop_config.json — Claude Desktop macOS
+	#   3. ~/.config/Claude/Claude.json             — Claude Code CLI Linux fallback
 	if [[ "$id" == "claude-code" ]]; then
+		local cli_path="$HOME/.claude.json"
 		local macos_path="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
 		local linux_path="$HOME/.config/Claude/Claude.json"
-		if [[ -f "$macos_path" ]]; then
+		if [[ -f "$cli_path" ]]; then
+			echo "$cli_path"
+			return 0
+		elif [[ -f "$macos_path" ]]; then
 			echo "$macos_path"
 			return 0
 		elif [[ -f "$linux_path" ]]; then
 			echo "$linux_path"
 			return 0
 		fi
-		# Neither exists — fall through to return the registry default (may not exist)
+		# None found — fall through to return the registry default (may not exist)
 	fi
 
 	echo "$path"


### PR DESCRIPTION
## Summary

- **Root cause**: `mcp-diagnose.sh check-all` only scanned the first runtime config found (OpenCode), missing Claude Code CLI's `~/.claude.json` where MCP servers like `cloudflare-api`, `playwright`, `context7` are registered
- **SSE MCPs misclassified**: `cloudflare-api` and `openapi-search` use `type: sse` (not `type: remote`), causing them to be treated as local commands and falsely flagged as errored
- **Runtime registry gap**: `runtime-registry.sh` didn't know about `~/.claude.json` as the Claude Code CLI global MCP config path

## Changes

### `runtime-registry.sh`
- Add `~/.claude.json` as the primary candidate for `claude-code` config path (checked before Desktop/Linux paths)

### `mcp-diagnose.sh`
- **`check-all`**: Refactored to scan **all** runtime configs (new `_collect_all_configs()` + `_scan_config_file()` helpers) — deduplicates across OpenCode, Claude Code CLI, and Desktop
- **`_extract_server_list`**: Treat `type: sse` as remote (same as `type: remote`) — SSE MCPs have no local command
- **`_resolve_mcp_config` fallback**: Add `~/.claude.json` as first candidate
- **Single-server path**: Config-driven remote detection via `_detect_mcp_type()` reads `type` field from config — replaces hardcoded name-based check
- **Parse failures non-fatal**: `_scan_config_file` logs error and continues on malformed config instead of aborting the whole run
- **Per-config remediation**: `_check_all_mcps` tracks errored names per config file and calls `_print_remediation` with the correct config for each errored set
- **Known issues**: Add entries for `cloudflare-api`, `openapi-search`, `playwright`

### `build.txt`
- Add OpenCode config path (`~/.config/opencode/opencode.json`) and restore Linux fallback `~/.config/Claude/Claude.json` to the errored MCP server disable instruction

### `email-providers.md`
- Qualify "Others" shared mailbox claim: "Limited or no native shared mailbox support (varies by provider/plan; verify before production use)"

## CodeRabbit Review Feedback Addressed

All 4 actionable comments from PR #13826 have been addressed:

1. ✅ **build.txt line 82**: Restored `~/.config/Claude/Claude.json` Linux fallback path alongside `~/.claude.json`, macOS Desktop, and OpenCode paths
2. ✅ **mcp-diagnose.sh lines 236-239**: Parse failures in `_scan_config_file` are now non-fatal — logs error and continues to next config
3. ✅ **mcp-diagnose.sh lines 299-316**: Remediation now tied to originating config — per-config error tracking with correct `_print_remediation` call
4. ✅ **email-providers.md line 120**: Qualified categorical "Others: No shared mailbox support" claim
5. ✅ **Outside diff (lines 336-385)**: Config-driven remote detection via `_detect_mcp_type()` — reads `type` field from config, no hardcoded names

## Testing Evidence

`mcp-diagnose.sh check-all` now correctly scans all 3 configs and classifies all servers:

```
Config: /Users/justin/.config/opencode/opencode.json
  [remote] seo-utils — skipping connectivity check (remote MCP)

Config: /Users/justin/.claude.json
  [remote] cloudflare-api — skipping connectivity check (remote MCP)
  [ok]     context7
  [ok]     macos-automator
  [remote] openapi-search — skipping connectivity check (remote MCP)
  [ok]     playwright
  [ok]     shadcn

Config: ~/Library/Application Support/Claude/claude_desktop_config.json
  (no enabled MCP servers)

Summary: 4 ok, 0 errored, 3 skipped (remote)
```

ShellCheck: only pre-existing SC1091 info (sourced file not followed) — no new violations.

## Runtime Testing

Risk: **Low** — prompt/script changes only, no auth/payment/data paths. Self-assessed.

Closes #13798

---
[aidevops.sh](https://aidevops.sh) v3.5.422 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6 spent 8m on this as an interactive session.