### PR TITLE
GH#13874: fix package.json merge conflict markers causing systemic CI failures

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,11 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-<<<<<<< Updated upstream
 # Version: 3.5.422
-=======
-# Version: 3.5.422
->>>>>>> Stashed changes
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,11 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-<<<<<<< Updated upstream
   url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.422.tar.gz"
-=======
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.422.tar.gz"
->>>>>>> Stashed changes
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "aidevops",
-<<<<<<< Updated upstream
   "version": "3.5.422",
-=======
-  "version": "3.5.422",
->>>>>>> Stashed changes
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,11 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-<<<<<<< Updated upstream
 # Version: 3.5.422
-=======
-# Version: 3.5.422
->>>>>>> Stashed changes
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,11 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-<<<<<<< Updated upstream
 sonar.projectVersion=3.5.422
-=======
-sonar.projectVersion=3.5.422
->>>>>>> Stashed changes
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
## Summary

- Remove git merge conflict markers (`<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed changes`) from `package.json` that were committed to main
- These markers made `package.json` invalid JSON, causing two CI checks to fail on **every PR**

## Root Cause

The `package.json` on `main` contained unresolved git merge conflict markers (both sides had identical content `"version": "3.5.422"`). This caused:

1. **Framework Validation** (`code-quality.yml` → `framework-validation` job → `JSON Config Validation` step): `python3 -m json.tool package.json` failed because conflict markers aren't valid JSON
2. **Version Consistency Check** (`version-validation.yml` → `version-consistency` job): `jq -r '.version'` returned `"not found"` because `jq` couldn't parse the broken JSON

## Affected PRs

- #13863, #13860, #13859, #13857, #13856 (and any other open PR targeting main)

## Testing

- `python3 -m json.tool package.json` passes
- `jq -r '.version' package.json` returns `3.5.422`
- `validate-version-consistency.sh` passes all checks
- All `*.json` files in repo pass JSON validation

## Runtime Testing

- **Risk level**: Low (CI config/data fix, no code logic changes)
- **Verification**: self-assessed (linter/CI config category)

Closes #13874

---
[aidevops.sh](https://aidevops.sh) v3.5.404 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 2m and 6,094 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed conflict markers from the package configuration to ensure proper manifest integrity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->