### PR TITLE
GH#13874: fix git merge conflict in package.json causing systemic CI failures

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,11 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-<<<<<<< Updated upstream
 # Version: 3.5.426
-=======
-# Version: 3.5.426
->>>>>>> Stashed changes
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,11 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-<<<<<<< Updated upstream
   url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.426.tar.gz"
-=======
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.426.tar.gz"
->>>>>>> Stashed changes
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "aidevops",
-<<<<<<< Updated upstream
   "version": "3.5.426",
-=======
-  "version": "3.5.426",
->>>>>>> Stashed changes
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,11 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-<<<<<<< Updated upstream
 # Version: 3.5.426
-=======
-# Version: 3.5.426
->>>>>>> Stashed changes
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,11 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-<<<<<<< Updated upstream
 sonar.projectVersion=3.5.426
-=======
-sonar.projectVersion=3.5.426
->>>>>>> Stashed changes
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
## Summary

Resolves the systemic `Framework Validation` and `Version Consistency Check` CI failures affecting all open simplification/tighten PRs.

## Root Cause

5 version-tracking files had unresolved git merge conflict markers from a stash/rebase operation. Both sides of each conflict were identical (same version string), so the resolution is removing the 4 conflict marker lines from each file.

**Affected files:**
- `package.json` — invalid JSON (conflict markers at line 3)
- `aidevops.sh` — ShellCheck SC1073/SC1072 parse error at line 6
- `setup.sh` — ShellCheck parse error at line 13
- `sonar-project.properties` — version field unparseable
- `homebrew/aidevops.rb` — version URL unparseable

## Why This Caused Both CI Failures

- **Framework Validation** (JSON Config Validation): `python3 -m json.tool` fails on `package.json` — `<` char in `<<<<<<<` is invalid JSON
- **Framework Validation** (ShellCheck Lint): `aidevops.sh` and `setup.sh` fail ShellCheck with SC1073 "Couldn't parse this here string"
- **Version Consistency Check**: `grep` for version field in `package.json` returns `not found` because file is unparseable

## Fix

Removed the 4 conflict marker lines from each file, keeping the single version line (upstream version in each case).

## Verification

- `python3 -c "import json; json.load(open('package.json'))"` → valid JSON
- `shellcheck aidevops.sh` → zero violations
- `shellcheck setup.sh` → zero violations
- Version Consistency Check: **passing** on this PR

## Affected PRs (will unblock after merge)

All open tighten/simplification PRs including #13859, #13857, #13856, #13863, #13860, #13835, #13831, #13824, #13823, #13820, #13819, #13818 and others.

## Runtime Testing

Risk level: **Low** — removes conflict markers only, no logic changes.
Self-assessed: JSON validity and ShellCheck verified locally.

Closes #13874


---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 12m and 12,802 tokens on this as a headless worker.