### PR TITLE
GH#12724: tighten hexagonal.md prose style

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
@@ -48,7 +48,7 @@ flowchart TB
 | **Driver** (Primary / Inbound) | → App | Application | How the world uses your app (use cases) | Adapter *calls* port — app defines what it **offers** |
 | **Driven** (Secondary / Outbound) | App → | Application | What your app needs from external systems | Adapter *implements* port — app defines what it **needs** |
 
-**Driver ports** — called by adapters, represent use cases:
+**Driver ports** (called by adapters, represent use cases):
 
 ```typescript
 // application/ports/driver/place_order_port.ts
@@ -65,7 +65,7 @@ export interface ICancelOrderPort {
 }
 ```
 
-**Driven ports** — implemented by adapters, called by the application:
+**Driven ports** (implemented by adapters, called by the application):
 
 ```typescript
 // application/ports/driven/order_repository_port.ts
@@ -88,7 +88,7 @@ export interface IPaymentGatewayPort {
 
 ## Adapters
 
-**Driver adapter** — converts external input → port call:
+**Driver adapter** (converts external input to port call):
 
 ```typescript
 // infrastructure/adapters/driver/rest/order_controller.ts
@@ -110,7 +110,7 @@ export class OrderController {
 }
 ```
 
-**Driven adapters** — implement port interface using specific technology:
+**Driven adapters** (implement port interface using specific technology):
 
 ```
 class PostgresOrderRepository implements IOrderRepositoryPort:


### PR DESCRIPTION
## Summary

- Normalize 4 sub-section labels in `hexagonal.md` from em-dash prose (`— called by adapters, represent use cases:`) to parenthetical style (`(called by adapters, represent use cases):`)
- All 4 labels made internally consistent: Driver ports, Driven ports, Driver adapter, Driven adapters
- Zero information loss — all code blocks, tables, mermaid diagram, and knowledge preserved unchanged

## Changes

- `.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md`: 4 lines changed (style only)

## Runtime Testing

- **Risk level:** Low (docs/agent prompt, no code)
- **Verification:** `self-assessed` — prose style change only, no logic or content altered

Closes #12724

---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 5,654 tokens on this as a headless worker.