### PR TITLE
GH#12771: tighten app-dev-publishing.md — remove structural noise

### DIFF
--- a/.agents/tools/mobile/app-dev-publishing.md
+++ b/.agents/tools/mobile/app-dev-publishing.md
@@ -33,8 +33,6 @@ asc auth login --key-id KEY --issuer-id ISSUER --private-key-path ~/.asc/AuthKey
 asc apps list
 ```
 
-The checklists below cover compliance requirements. The `asc` CLI automates execution.
-
 ## Apple App Store
 
 ### Pre-Submission Checklist
@@ -94,8 +92,6 @@ The checklists below cover compliance requirements. The `asc` CLI automates exec
 | iPhone 6.5" | 1284 x 2778 | Yes |
 | iPad Pro 13" | 2064 x 2752 | If iPad supported |
 | iPad Pro 12.9" | 2048 x 2732 | If iPad supported |
-
-**Screenshot tips**:
 
 - Show the app in use, not empty states; highlight key features with captions
 - Use consistent style; first screenshot is most important (shown in search results)


### PR DESCRIPTION
## Summary

Removes 4 lines of structural noise from `.agents/tools/mobile/app-dev-publishing.md` with zero information loss:

- Removed redundant prose sentence after CLI code block ("The checklists below cover compliance requirements. The `asc` CLI automates execution.") — the section heading and code block make this self-evident
- Removed `**Screenshot tips**:` header label before 3 bullets — the bullets are self-evident without a label

**Before**: 188 lines (issue) / 156 lines (actual at branch point)
**After**: 152 lines

All checklist items, tables, URLs, code blocks, and content preserved intact.

## Runtime Testing

Risk: **Low** — doc-only change, no code or agent behaviour affected. `self-assessed`.

Closes #12771

---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 6,120 tokens on this as a headless worker.