### PR TITLE
GH#12540: tighten meta-ads scaling checklist (190→156 lines)

### DIFF
--- a/.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md
+++ b/.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md
@@ -2,39 +2,31 @@
 
 > Before increasing spend, confirm you're ready to scale.
 
----
-
 ## Pre-Scale Requirements
 
-### Performance Confirmation
+**Performance**
+- [ ] CPA at or below target for 5+ consecutive days
+- [ ] 50+ conversions with statistical confidence
+- [ ] CTR stable (not declining)
+- [ ] ROAS meets target (if tracking revenue)
+- [ ] Consistent daily performance (not wildly fluctuating)
 
-- [ ] **CPA at or below target** for 5+ consecutive days
-- [ ] **50+ conversions** with statistical confidence
-- [ ] **CTR stable** (not declining)
-- [ ] **ROAS meets target** (if tracking revenue)
-- [ ] **Consistent daily performance** (not wildly fluctuating)
+**Creative Health**
+- [ ] Winning creative identified (clear top performers)
+- [ ] Frequency under 3 (no fatigue yet)
+- [ ] Creative running <3 weeks (still fresh)
+- [ ] Multiple ads performing (not just one winner)
 
-### Creative Health
+**Account Health**
+- [ ] Payment method valid (can handle higher spend)
+- [ ] No policy issues pending
+- [ ] Spending limits allow scale (or raised)
 
-- [ ] **Winning creative identified** (clear top performers)
-- [ ] **Frequency under 3** (no fatigue yet)
-- [ ] **Creative running <3 weeks** (still fresh)
-- [ ] **Multiple ads performing** (not just one winner)
-
-### Account Health
-
-- [ ] **Payment method valid** (can handle higher spend)
-- [ ] **No policy issues pending**
-- [ ] **Spending limits allow scale** (or raised)
-
-### Business Readiness
-
-- [ ] **Can fulfill increased orders** (inventory, capacity)
-- [ ] **Cash flow supports increased spend**
-- [ ] **Customer service can handle volume**
-- [ ] **Landing page can handle traffic** (speed, uptime)
-
----
+**Business Readiness**
+- [ ] Can fulfill increased orders (inventory, capacity)
+- [ ] Cash flow supports increased spend
+- [ ] Customer service can handle volume
+- [ ] Landing page can handle traffic (speed, uptime)
 
 ## Scaling Decision Tree
 
@@ -57,15 +49,12 @@ Ready to Scale?
 │   ├── Yes → Ready to scale
 │   └── No → Fix operations first
 │
-└── SCALE IT 🚀
+└── SCALE IT
 ```
-
----
 
 ## Scaling Method Selection
 
-### When to Use Vertical Scaling (Budget Increase)
-
+**Vertical Scaling (Budget Increase)** — use when:
 - [ ] CPA is 20%+ below target
 - [ ] Frequency still low (<2.5)
 - [ ] Haven't hit diminishing returns yet
@@ -73,8 +62,7 @@ Ready to Scale?
 
 **How:** Increase budget 20-30% every 2-3 days
 
-### When to Use Horizontal Scaling (Duplication)
-
+**Horizontal Scaling (Duplication)** — use when:
 - [ ] Vertical scaling hitting diminishing returns
 - [ ] Want to test audience variations
 - [ ] Diversify risk across ad sets
@@ -82,71 +70,58 @@ Ready to Scale?
 
 **How:** Duplicate winning ad set, change ONE variable
 
-### When to Use Creative Scaling
-
+**Creative Scaling** — use when:
 - [ ] Performance limited by creative fatigue
 - [ ] Want to scale without budget increase
 - [ ] Testing phase identified multiple winners
 
 **How:** Add new proven creative to existing ad sets
 
----
+## Scaling Execution
 
-## Scaling Execution Checklist
-
-### Vertical Scaling
-
+**Vertical Scaling**
 - [ ] Calculate new budget (current × 1.2-1.3)
 - [ ] Set budget increase time (early morning best)
 - [ ] Set maximum budget cap
 - [ ] Schedule check-in for 48 hours later
 - [ ] Document the change
 
-### Horizontal Scaling
-
+**Horizontal Scaling**
 - [ ] Select ad set to duplicate
 - [ ] Choose ONE variable to change
 - [ ] Set starting budget (same as original)
 - [ ] Confirm no audience overlap issues
 - [ ] Schedule check-in for 5 days later
 
----
-
 ## Post-Scale Monitoring
 
-### First 48 Hours
-
+**First 48 Hours**
 - [ ] Spend is increasing as expected
 - [ ] CPA holding (within 20% of pre-scale)
 - [ ] No delivery issues
 - [ ] Learning phase not reset
 
-### Day 3-5
-
+**Day 3-5**
 - [ ] CPA stabilizing
 - [ ] No dramatic performance shifts
 - [ ] Frequency still acceptable
 - [ ] Decide: continue scaling or pause
 
-### Day 7
-
+**Day 7**
 - [ ] Full week data review
 - [ ] CPA vs pre-scale comparison
 - [ ] Ready for next scale increment?
 
----
-
 ## Warning Signs During Scale
 
-### Stop Scaling If:
-
+**Stop scaling if:**
 - [ ] CPA rises 30%+ and doesn't recover in 48 hours
 - [ ] Frequency jumps above 3.5 (prospecting)
 - [ ] CTR drops 30%+ week-over-week
 - [ ] Algorithm enters learning phase
 - [ ] Business capacity becomes an issue
 
-### Recovery Actions:
+**Recovery Actions**
 
 | Problem | Action |
 |---------|--------|
@@ -155,28 +130,23 @@ Ready to Scale?
 | CTR drop | Refresh creative |
 | Learning reset | Wait, don't make more changes |
 
----
-
 ## Scale Tracking Template
 
-| Date | Action | Budget (Before) | Budget (After) | CPA (Before) | CPA (After) | Notes |
-|------|--------|-----------------|----------------|--------------|-------------|-------|
+| Date | Action | Budget Before | Budget After | CPA Before | CPA After | Notes |
+|------|--------|---------------|--------------|------------|-----------|-------|
 | | | $ | $ | $ | $ | |
 | | | $ | $ | $ | $ | |
 | | | $ | $ | $ | $ | |
-
----
 
 ## Scaling Limits
 
-### Know Your Ceiling
-
+**Know Your Ceiling**
 - [ ] What's maximum daily budget before diminishing returns?
 - [ ] What's maximum business can handle?
 - [ ] What's cash flow limit?
 - [ ] When does CPA become unprofitable?
 
-### Document Your Ceiling
+**Document Your Ceiling**
 
 ```
 Max Efficient Daily Spend: $_______
@@ -184,7 +154,3 @@ Max Business Daily Capacity: $_______
 Breakeven CPA: $_______
 Target CPA at Scale: $_______
 ```
-
----
-
-*Complete this checklist before every scaling decision.*


### PR DESCRIPTION
## Summary

- Remove 8 decorative horizontal rules, redundant `###` sub-headers (Performance Confirmation, When to Use X, Execution Checklist, Know/Document Your Ceiling), trailing footer line, and excess bold markup on checklist items
- Collapse "When to Use" sub-headers into bold inline labels within the parent section
- Remove emoji from decision tree leaf node
- 190 → 156 lines (18% reduction), zero information loss — all checklist items, decision tree, tables, and code blocks preserved

## Runtime Testing

- Risk level: **Low** (docs-only change, no code, no agent logic)
- Self-assessed: content verified line-by-line against original

## Files Changed

- `.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md` — 39 insertions, 73 deletions

Closes #12540

---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6