### PR TITLE
GH#12612: tighten playwright-emulation.md structural noise

### DIFF
--- a/.agents/tools/browser/playwright-emulation.md
+++ b/.agents/tools/browser/playwright-emulation.md
@@ -98,7 +98,7 @@ test.use({ javaScriptEnabled: false, userAgent: 'Custom Bot/1.0' });
 
 **Permission values**: `geolocation`, `midi`, `midi-sysex`, `notifications`, `camera`, `microphone`, `background-sync`, `ambient-light-sensor`, `accelerometer`, `gyroscope`, `magnetometer`, `accessibility-events`, `clipboard-read`, `clipboard-write`, `payment-handler`
 
-### Common Locale/Timezone Combinations
+**Common locale/timezone combinations:**
 
 | Market | Locale | Timezone |
 |--------|--------|----------|
@@ -140,7 +140,7 @@ for (const { name, device } of testDevices) {
 // testDevices: [{ name, device }] where device = devices['iPhone 13'] | devices['Pixel 7'] | { viewport: {...} }
 ```
 
-### Touch / Network / Dark Mode
+### Touch, Network, Dark Mode
 
 ```typescript
 // Touch gestures


### PR DESCRIPTION
## Summary

- Demote locale/timezone table label from `###` sub-heading to bold inline text — it is a table within a section, not a standalone section
- Fix slash-separated recipe heading (`Touch / Network / Dark Mode`) to comma-separated (`Touch, Network, Dark Mode`)
- Zero information loss; all code blocks, URLs, task IDs, and command examples preserved

## Runtime Testing

- **Level**: self-assessed (docs-only change, no code)
- **Verification**: diff reviewed line-by-line; content identical except structural heading changes

## Files Changed

- `.agents/tools/browser/playwright-emulation.md` — 2 line changes

Closes #12612


---
[aidevops.sh](https://aidevops.sh) v3.5.416 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 3m and 6,828 tokens on this as a headless worker.