### PR TITLE
GH#13817: tighten meta-ads-foundations-algorithm.md

### DIFF
--- a/.agents/marketing-sales/meta-ads-foundations-algorithm.md
+++ b/.agents/marketing-sales/meta-ads-foundations-algorithm.md
@@ -2,7 +2,7 @@
 
 ## The Auction System
 
-Every ad impression triggers an auction. Winner = highest **Total Value**:
+Every impression triggers an auction. Winner = highest **Total Value**:
 
 ```text
 Total Value = Bid × Estimated Action Rate × Ad Quality
@@ -10,13 +10,9 @@ Total Value = Bid × Estimated Action Rate × Ad Quality
 
 **Bid strategies:** Lowest Cost (default), Cost Cap, Bid Cap, ROAS Target.
 
-**Estimated Action Rate (EAR)** — Meta's ML prediction of conversion probability. Inputs:
+**Estimated Action Rate (EAR)** — ML prediction of conversion probability. Inputs: user data (demographics, interests, purchase history, device, social), ad data (account history, creative analysis, landing page, CAPI/Pixel), contextual data (time, seasonality, competition).
 
-- **User data**: demographics, interests, purchase history, device patterns, social connections
-- **Ad data**: account history, creative content analysis, landing page quality, CAPI/Pixel data
-- **Contextual data**: time of day, seasonality, competitive landscape
-
-**Ad Quality** — engagement minus negative feedback. Positive: likes, shares, watch time, CTR. Negative: "hide ad", reports, misleading claims, policy violations, high bounce rate.
+**Ad Quality** — engagement minus negative feedback. Positive: likes, shares, watch time, CTR. Negative: "hide ad", reports, misleading claims, policy violations, high bounce.
 
 **Auction example:**
 
@@ -26,15 +22,15 @@ Ad B: $2 bid × 3% EAR × 1.0 quality = 0.060  ← wins despite lowest bid
 Ad C: $5 bid × 1% EAR × 0.7 quality = 0.035
 ```
 
-**Implications:** Better creative lowers effective cost. Poor ads cost MORE. Relevance beats budget.
+**Implications:** Better creative lowers cost. Poor ads cost MORE. Relevance beats budget.
 
 **Help the algorithm:** Clear conversion signals (Pixel + CAPI); consistent creative; quality data (customers, not just leads); sufficient run time; don't fragment budgets or over-narrow targeting.
 
 ## The Learning Phase
 
-On launch or significant changes, Meta builds a new prediction model. **Exit:** 50 optimization events in 7 days OR 7 days elapsed. Expect 20–50% higher CPAs and inconsistent delivery during learning.
+On launch or significant changes, Meta builds a new prediction model. **Exit:** 50 optimization events in 7 days OR 7 days elapsed. Expect 20–50% higher CPAs and inconsistent delivery.
 
-**Learning Limited** — not enough optimization events. Causes and fixes:
+**Learning Limited** — insufficient optimization events:
 
 | Problem | Solution |
 |---------|----------|
@@ -43,7 +39,7 @@ On launch or significant changes, Meta builds a new prediction model. **Exit:** 
 | Optimization event too rare | Optimize for higher-funnel event |
 | Too many ad sets | Consolidate |
 
-**What resets learning phase:**
+**What resets learning:**
 
 | Change | Resets? |
 |--------|---------|
@@ -56,7 +52,7 @@ On launch or significant changes, Meta builds a new prediction model. **Exit:** 
 | All creatives changed | Yes |
 | Pause >7 days | Yes |
 
-**Best practice:** Make changes ≤20% and wait 2–3 days between adjustments.
+**Best practice:** Changes ≤20%, wait 2–3 days between adjustments.
 
 ## Account History & Trust
 
@@ -70,7 +66,7 @@ Established accounts: faster learning, better predictions, delivery priority, lo
 
 Each Pixel fire trains Meta on conversions, content preferences, timing, and device/placement signals.
 
-**Essential events (in priority order for AEM):**
+**Essential events (priority order for AEM):**
 
 | Priority | Event | Purpose |
 |----------|-------|---------|
@@ -89,13 +85,13 @@ Each Pixel fire trains Meta on conversions, content preferences, timing, and dev
 
 ## Aggregated Event Measurement (AEM)
 
-Apple's iOS 14+ forced Meta to AEM: 8 events max per domain, 72-hour delayed reporting, ~20–30% modeled conversions, no user-level data.
+iOS 14+ forced AEM: 8 events max per domain, 72-hour delayed reporting, ~20–30% modeled conversions, no user-level data.
 
-**Working within AEM:** Verify domain in Business Settings. Rank 8 events by importance — only highest priority counts per user. Compare trends, not absolutes (~70–80% directly tracked, ~20–30% modeled).
+**Working within AEM:** Verify domain in Business Settings. Rank 8 events by importance — only highest priority counts per user. Compare trends, not absolutes (~70–80% tracked, ~20–30% modeled).
 
 ## Conversion API (CAPI)
 
-CAPI sends conversion data server-to-server, bypassing ad blockers (20–30% of users), iOS ATT (80%+ opt-out), and browser privacy restrictions.
+Server-to-server conversion data, bypassing ad blockers (20–30% of users), iOS ATT (80%+ opt-out), and browser privacy restrictions.
 
 **Use Pixel + CAPI together** — Meta deduplicates via `event_id`:
 
@@ -112,13 +108,13 @@ User converts → Pixel fires (client) + CAPI fires (server) → Meta deduplicat
 | Custom server integration | Hard | Dev time | Best |
 | Third-party (Segment, etc.) | Medium | $200+/mo | Great |
 
-**Required CAPI parameters:** `event_name`, `event_time`, `action_source`, `event_source_url`, `user_data` (hashed: `em`, `ph`, `fn`, `ln`; cookies: `fbp`, `fbc`). Higher match rate = better optimization. Check quality: Events Manager → Data Sources → Pixel → Overview.
+**Required CAPI parameters:** `event_name`, `event_time`, `action_source`, `event_source_url`, `user_data` (hashed: `em`, `ph`, `fn`, `ln`; cookies: `fbp`, `fbc`). Higher match rate = better optimization. Check: Events Manager → Data Sources → Pixel → Overview.
 
 ## The 2026 Algorithm Reality
 
-**The shift:** Manual interest/behavior targeting → broad targeting with AI finding buyers. Creative IS targeting now.
+**The shift:** Manual interest/behavior targeting → broad targeting with AI finding buyers. Creative IS targeting.
 
-**What this means:** Broad audiences often beat detailed targeting. Creative drives 70–80% of performance. CAPI is mandatory — conversion quality > quantity. Think systems: Testing → Scaling → Retargeting.
+**What this means:** Broad audiences often beat detailed targeting. Creative drives 70–80% of performance. CAPI mandatory — conversion quality > quantity. Think systems: Testing → Scaling → Retargeting.
 
 **Advantage+ features:**
 
@@ -130,7 +126,5 @@ User converts → Pixel fires (client) + CAPI fires (server) → Meta deduplicat
 | Advantage+ Shopping | Full auto ecom | Ecom with 50+ purchases/week |
 
 Manual targeting wins for: niche B2B, controlled creative testing, specific placement requirements, limited conversion data.
-
----
 
 *Next: [Attribution & Measurement](attribution.md)*


### PR DESCRIPTION
## Summary

- Tighten `.agents/marketing-sales/meta-ads-foundations-algorithm.md` — remove structural noise, compress verbose prose
- 136 → 130 lines (4.4% reduction), zero knowledge loss
- All code blocks (3), tables (6), URLs, numbers/stats preserved

## Changes

- Inline EAR bullet list into single dense sentence (3 bullets → 1 line)
- Remove redundant qualifiers ("Meta's ML" → "ML", "Apple's iOS" → "iOS", "ad impression" → "impression")
- Compress filler words ("not enough" → "insufficient", "Make changes" → "Changes", "effective cost" → "cost")
- Remove trailing `---` horizontal rule (structural noise)
- All facts, percentages, dollar amounts, parameter names, and implementation details preserved

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — markdownlint clean, content preservation audited line-by-line

Closes #13817

---
[aidevops.sh](https://aidevops.sh) v3.5.404 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,826 tokens on this as a headless worker.