### PR TITLE
GH#13924: tighten pages-functions-patterns.md (182→178 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md
@@ -19,10 +19,6 @@ export async function onRequest(context) {
 export const onRequest = [errorHandling, authentication, logging];
 ```
 
-- First middleware = error handler (wraps others)
-- Use `context.next()` to pass control
-- Share state via `context.data`
-
 ## Authentication
 
 ```typescript
@@ -148,7 +144,7 @@ export async function onRequest(context) {
 
 ## Advanced Mode (_worker.js)
 
-For complex routing, replace `/functions` with `_worker.js`. Use when: existing Worker too complex for file-based routing; need full routing control; framework-generated Workers (Next.js, SvelteKit).
+Replace `/functions` with `_worker.js` for full routing control (complex Workers, framework-generated output: Next.js, SvelteKit).
 
 ```typescript
 interface Env {


### PR DESCRIPTION
## Summary

- Remove 3 prose bullets under Middleware that restated visible code behaviour (`context.next()`, `context.data`, error-handler ordering — all shown in the code block)
- Compress verbose Advanced Mode intro from 2 sentences to 1 without dropping any use-case information

## What was NOT changed

- All code blocks: untouched
- `_worker.js` constraint bullets (lines 170-173): retained — these are non-obvious runtime constraints not visible from the code
- See Also section: retained

## Runtime Testing

Risk: **Low** — doc-only change, no code or agent logic modified.
Level: `self-assessed`

## Verification

- `wc -l` before: 182, after: 178
- All code blocks present: confirmed
- No broken internal links: confirmed
- Agent behaviour unchanged: doc is reference corpus, no decision logic

Closes #13924


---
[aidevops.sh](https://aidevops.sh) v3.5.440 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 1m and 3,226 tokens on this as a headless worker.