### PR TITLE
GH#13922: tighten hexagonal.md (196→186 lines)

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
@@ -48,26 +48,16 @@ flowchart TB
 | **Driver** (Primary / Inbound) | → App | Application | How the world uses your app (use cases) | Adapter *calls* port — app defines what it **offers** |
 | **Driven** (Secondary / Outbound) | App → | Application | What your app needs from external systems | Adapter *implements* port — app defines what it **needs** |
 
-**Driver ports** (called by adapters, represent use cases):
+**Driver ports** (called by adapters, represent use cases) · **Driven ports** (implemented by adapters, called by the application):
 
 ```typescript
 // application/ports/driver/place_order_port.ts
-export interface IPlaceOrderPort {
-  execute(command: PlaceOrderCommand): Promise<OrderId>;
-}
+export interface IPlaceOrderPort { execute(command: PlaceOrderCommand): Promise<OrderId>; }
 // application/ports/driver/get_order_port.ts
-export interface IGetOrderPort {
-  execute(query: GetOrderQuery): Promise<OrderDTO | null>;
-}
+export interface IGetOrderPort { execute(query: GetOrderQuery): Promise<OrderDTO | null>; }
 // application/ports/driver/cancel_order_port.ts
-export interface ICancelOrderPort {
-  execute(command: CancelOrderCommand): Promise<void>;
-}
-```
+export interface ICancelOrderPort { execute(command: CancelOrderCommand): Promise<void>; }
 
-**Driven ports** (implemented by adapters, called by the application):
-
-```typescript
 // application/ports/driven/order_repository_port.ts
 export interface IOrderRepositoryPort {
   findById(id: OrderId): Promise<Order | null>;


### PR DESCRIPTION
## Summary

- Merged driver/driven port TypeScript blocks into a single code block (eliminated duplicate fence + blank line + redundant bold label)
- Inlined single-method driver port interfaces onto one line each (no information lost — method signatures unchanged)
- Combined section labels into one line with middle-dot separator

**196 → 186 lines (-10 lines, -5%)**. Zero information loss — all code examples, file paths, comments, and architectural concepts preserved.

Closes #13922

## Runtime Testing

- Risk level: **Low** (docs/reference corpus only, no executable code changed)
- Verification:        0 confirms 186 lines; diff reviewed for content preservation


---
[aidevops.sh](https://aidevops.sh) v3.5.440 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 2m and 4,543 tokens on this as a headless worker.