### PR TITLE
GH#13813: tighten turborepo.md - remove structural noise, compress prose

### DIFF
--- a/.agents/tools/monorepo/turborepo.md
+++ b/.agents/tools/monorepo/turborepo.md
@@ -6,13 +6,9 @@ tools: [read, write, edit, bash, glob, grep, webfetch, task, context7_*]
 
 # Turborepo - Monorepo Build System
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 **High-performance build system for JS/TS monorepos.** Package managers: pnpm (recommended), npm, yarn. Docs: [turbo.build/repo/docs](https://turbo.build/repo/docs) (Context7 MCP).
-
-**Core commands**: `pnpm dev` · `pnpm build` · `pnpm --filter web dev` (see Filtering for full syntax)
 
 **Directory structure**:
 ```text
@@ -41,11 +37,7 @@ tooling/  (eslint, typescript, prettier)
 }
 ```
 
-<!-- AI-CONTEXT-END -->
-
-## Patterns
-
-### Filtering
+## Filtering
 
 ```bash
 pnpm dev                               # all packages
@@ -59,7 +51,7 @@ pnpm --filter "./packages/*" build     # by directory
 pnpm --filter "!web" build             # exclude
 ```
 
-### Package.json Exports
+## Package.json Exports
 
 ```json
 // packages/ui/web/package.json
@@ -72,19 +64,19 @@ import { cn } from "@workspace/ui-web";
 import "@workspace/ui-web/globals.css";
 ```
 
-### Workspace Dependencies
+## Workspace Dependencies
 
 Use `"workspace:*"` protocol (not `"*"`): `{ "dependencies": { "@workspace/ui-web": "workspace:*" } }`
 
-### Environment Variables
+## Environment Variables
 
-Use `dotenv-cli` to load `.env` before turbo: `pnpm with-env turbo build`
+Use `dotenv-cli` to load `.env` before turbo:
 
 ```json
 { "scripts": { "build": "pnpm with-env turbo build", "dev": "pnpm with-env turbo dev" } }
 ```
 
-### Shared TypeScript Config
+## Shared TypeScript Config
 
 ```json
 // tooling/typescript/base.json
@@ -99,7 +91,7 @@ Use `dotenv-cli` to load `.env` before turbo: `pnpm with-env turbo build`
 { "extends": "@workspace/tsconfig/base.json", "compilerOptions": { "outDir": "dist" }, "include": ["src"] }
 ```
 
-### Shared ESLint Config
+## Shared ESLint Config
 
 ```js
 // tooling/eslint/base.js
@@ -109,7 +101,7 @@ import baseConfig from "@workspace/eslint-config/base";
 export default [...baseConfig];
 ```
 
-### Database Package
+## Database Package
 
 ```tsx
 // packages/db/src/index.ts — public API


### PR DESCRIPTION
## Summary

- Removed `<!-- AI-CONTEXT-START/END -->` tags (framework-internal markers with no value in a tool doc)
- Removed `## Patterns` wrapper heading — subsections stand alone under the h1; the extra nesting level was noise
- Removed redundant `**Core commands**` line — the full Filtering section immediately below covers all commands
- Promoted `### Filtering`, `### Package.json Exports`, etc. from `###` to `##` (now that the `## Patterns` wrapper is gone)
- Compressed Environment Variables prose: removed inline duplicate of `pnpm with-env turbo build` (already in the code block)

**Result:** 142 → 134 lines. Zero information loss. All code blocks, URLs, tables, and command examples preserved.

## Runtime Testing

- Risk: Low (docs/agent prompts only)
- Level: `self-assessed`
- Content preservation verified via `git diff`

Closes #13813

---
[aidevops.sh](https://aidevops.sh) v3.5.444 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 3m and 4,591 tokens on this as a headless worker.