### PR TITLE
GH#13869: tighten rules-webhooks.md (165→158 lines)

### DIFF
--- a/.agents/content/heygen-skill/rules-webhooks.md
+++ b/.agents/content/heygen-skill/rules-webhooks.md
@@ -11,11 +11,9 @@ Push notifications to your server when async operations complete, avoiding polli
 
 ## Endpoint Requirements
 
-1. Accept POST requests
-2. Return 200 within 5 seconds
-3. Process events asynchronously (respond first, then handle)
-4. Handle duplicate deliveries (same event may arrive multiple times)
-5. Use job queues for expensive processing
+- Accept POST; return 200 within 5 seconds
+- Respond first, then process asynchronously (use job queues for expensive work)
+- Handle duplicate deliveries (same event may arrive multiple times)
 
 ```typescript
 import express from "express";
@@ -35,8 +33,6 @@ async function processWebhookEvent(event: HeyGenWebhookEvent) {
     default: console.log(`Unknown event type: ${event.event_type}`);
   }
 }
-
-app.listen(3000);
 ```
 
 **Local testing:** `ngrok http 3000` — register the ngrok URL as your webhook endpoint.
@@ -78,8 +74,6 @@ interface VideoFailureEvent {
 
 ## Registering a Webhook
 
-Configure via the HeyGen dashboard or API:
-
 | Field | Type | Req | Description |
 |-------|------|:---:|-------------|
 | `url` | string | ✓ | Your webhook endpoint URL |
@@ -103,7 +97,7 @@ Pass `callback_id` during video generation to correlate webhooks to your records
 ```typescript
 const videoConfig = {
   video_inputs: [...],
-  callback_id: "order_12345", // Your custom identifier
+  callback_id: "order_12345",
 };
 
 async function handleVideoSuccess(event: VideoSuccessEvent) {
@@ -141,7 +135,6 @@ app.post("/webhook/heygen", (req, res) => {
   if (!verifyWebhookSignature(payload, signature, WEBHOOK_SECRET)) {
     return res.status(401).send("Invalid signature");
   }
-  // Process event...
 });
 ```
 


### PR DESCRIPTION
## Summary

Tighten `.agents/content/heygen-skill/rules-webhooks.md` — remove structural noise with zero information loss.

## Changes

- Compress 5-item numbered endpoint requirements list to 3-item bullets (items 1+2 merged; items 3+5 merged; item 4 unchanged)
- Remove `app.listen(3000)` — not part of the webhook handler pattern, noise in a reference doc
- Remove filler sentence "Configure via the HeyGen dashboard or API:" before the registration table
- Remove redundant inline comments (`// Your custom identifier`, `// Process event...`) — conveyed by context

**All preserved:** code blocks, TypeScript interfaces, event type table, field table, curl example, `ngrok` tip, `timingSafeEqual` security detail, `storeFailedEvent` manual review queue note, all URLs.

## Runtime Testing

Risk: **Low** — documentation-only change, no code execution paths affected.
Level: `self-assessed`

## Verification

- `wc -l`: 165 → 158 lines (7 lines removed, all noise)
- All code blocks present: ✓
- All URLs present: ✓
- All event types present: ✓
- All TypeScript interfaces present: ✓
- `timingSafeEqual` security pattern: ✓
- `storeFailedEvent` manual review queue: ✓

Closes #13869

---
[aidevops.sh](https://aidevops.sh) v3.5.444 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 5m on this as a headless worker.