### PR TITLE
GH#13380: tighten upscale.md (138→132 lines)

### DIFF
--- a/.agents/seo/upscale.md
+++ b/.agents/seo/upscale.md
@@ -11,17 +11,13 @@ tools:
 
 # Image Upscaling
 
-<!-- AI-CONTEXT-START -->
-
 **Decision tree**: Local CLI for bulk/privacy → Replicate for quality/convenience → Cloudflare for CDN-integrated
 
 **Minimum targets**: 1200px wide (social sharing), 800px (blog content), 2x for retina
 
-<!-- AI-CONTEXT-END -->
-
 ## Providers
 
-### 1. Real-ESRGAN (Local — Bulk/Privacy)
+### Real-ESRGAN (Local — Bulk/Privacy)
 
 ```bash
 brew install real-esrgan  # macOS; or pip install realesrgan
@@ -42,7 +38,7 @@ realesrgan-ncnn-vulkan -i input.jpg -o output.jpg -n realesrgan-x4plus
 | `realesrgan-x4plus-anime` | Illustrations, anime | 4x |
 | `realesr-animevideov3` | Video frames | 4x |
 
-### 2. Replicate API (Cloud — Best Quality)
+### Replicate API (Cloud — Best Quality)
 
 ```bash
 aidevops secret set REPLICATE_API_TOKEN
@@ -67,26 +63,24 @@ curl -s "https://api.replicate.com/v1/predictions/$PREDICTION_ID" \
 | `philz1337x/clarity-upscaler` | Creative upscaling | ~$0.01/image |
 | `tencentarc/gfpgan` | Face restoration | ~$0.003/image |
 
-### 3. Cloudflare Images (CDN-Integrated)
+### Cloudflare Images (CDN-Integrated)
 
 Resize/optimize on-the-fly (requires Cloudflare Pro+). Not AI upscaling — handles format conversion and responsive variants.
 
 ```bash
-# URL-based resizing
-# https://example.com/cdn-cgi/image/width=1200,format=webp/image.jpg
-
 # Upload via API
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/images/v1" \
   -H "Authorization: Bearer $CF_API_TOKEN" \
   -F "file=@image.jpg"
+# URL-based resizing: /cdn-cgi/image/width=1200,format=webp/image.jpg
 ```
 
-### 4. Sharp (Node.js — Format Conversion)
+### Sharp (Node.js — Format Conversion)
 
 Not upscaling. Use for WebP/AVIF conversion and responsive variants.
 
 ```javascript
-import sharp from 'sharp';  // npm install sharp
+import sharp from 'sharp';
 
 await sharp('input.jpg').resize(1200, null, { withoutEnlargement: true }).webp({ quality: 80 }).toFile('output.webp');
 
@@ -97,26 +91,26 @@ for (const width of [400, 800, 1200, 1600]) {
 
 ## When to Upscale
 
-| Scenario | Action | Tool |
-|----------|--------|------|
-| Image < 1200px wide | Upscale to 1200px+ | Real-ESRGAN |
-| Blurry product photo | Upscale + enhance | Replicate (face_enhance) |
-| Legacy content migration | Batch upscale all | Real-ESRGAN CLI |
-| Social sharing (OG image) | Ensure 1200x630+ | Real-ESRGAN or resize |
-| Retina display support | Generate 2x variant | Sharp resize |
-| Wrong format (BMP, TIFF) | Convert to WebP | Sharp |
+| Scenario | Tool |
+|----------|------|
+| Image < 1200px wide | Real-ESRGAN |
+| Blurry product photo | Replicate (`face_enhance: true`) |
+| Legacy content migration (batch) | Real-ESRGAN CLI |
+| Social sharing / OG image | Real-ESRGAN or resize to 1200x630+ |
+| Retina display support | Sharp (2x variant) |
+| Wrong format (BMP, TIFF) | Sharp → WebP |
 
 ## Pipeline
 
 ```text
-1. Analyze (Moondream) -> Get content description
-2. Upscale (if needed) -> Ensure minimum dimensions
-3. Convert format     -> WebP (primary), JPEG (fallback)
-4. Compress           -> Target < 200KB for web
-5. Generate variants  -> 400w, 800w, 1200w, 1600w
-6. Rename             -> SEO-friendly filename
-7. Add metadata       -> Alt text, title, IPTC keywords
-8. Validate           -> Check OG requirements met
+1. Analyze (Moondream)  — get content description
+2. Upscale if needed    — ensure minimum dimensions
+3. Convert format       — WebP (primary), JPEG (fallback)
+4. Compress             — target < 200KB for web
+5. Generate variants    — 400w, 800w, 1200w, 1600w
+6. Rename               — SEO-friendly filename
+7. Add metadata         — alt text, title, IPTC keywords
+8. Validate             — check OG requirements met
 ```
 
 ## Size Targets
@@ -132,7 +126,7 @@ for (const width of [400, 800, 1200, 1600]) {
 
 ## Related
 
-- `seo/image-seo.md` - Image SEO orchestrator (coordinates upscaling)
-- `seo/moondream.md` - AI vision analysis (pre-upscale content check)
-- `seo/debug-opengraph.md` - Validate OG image dimensions
-- `tools/browser/pagespeed.md` - Image optimization scoring
+- `seo/image-seo.md` — Image SEO orchestrator (coordinates upscaling)
+- `seo/moondream.md` — AI vision analysis (pre-upscale content check)
+- `seo/debug-opengraph.md` — Validate OG image dimensions
+- `tools/browser/pagespeed.md` — Image optimization scoring


### PR DESCRIPTION
## Summary

- Remove `<!-- AI-CONTEXT-START/END -->` wrappers — ceremony with no value for a doc this size
- Remove numbered prefixes from provider section headers (`### 1.` → `###`)
- Collapse `## When to Upscale` table from 3 columns to 2 — Action column merged into Tool, no info lost
- Tighten pipeline block: `->` → `—`, consistent alignment
- Consolidate Cloudflare URL-resizing comment inline in code block (removes blank comment-only line)
- Remove redundant `// npm install sharp` inline comment
- Fix Related links: ` - ` → ` — ` for consistency with rest of doc

138 → 132 lines. All signal preserved: decision tree, minimum targets, provider commands, model tables, pipeline steps, size targets, and related links unchanged.

Closes #13380

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code execution paths changed.
Testing: `self-assessed` — content verified against original line-by-line; no broken references.

## Files Changed

- `.agents/seo/upscale.md` — 6 net lines removed, 0 content lost


---
[aidevops.sh](https://aidevops.sh) v3.5.444 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 5m and 3,582 tokens on this as a headless worker.