### PR TITLE
GH#13366: tighten sales emails — remove code fence language tags

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md
@@ -8,7 +8,7 @@ High-converting sales email swipe file with pattern analysis.
 
 **Subject:** Zero to Launch is NOW OPEN (spots limited)
 
-```text
+```
 I want to tell you about a student named [Name].
 
 [Story about student's transformation]
@@ -51,7 +51,7 @@ P.S. Doors close Friday at 11:59pm. No extensions.
 
 **Subject:** Your trial ends tomorrow
 
-```text
+```
 Hey [Name],
 
 Quick heads up: your [Product] trial expires tomorrow.
@@ -81,7 +81,7 @@ We're here to help.
 
 **Subject:** Did something go wrong?
 
-```text
+```
 Hey [Name],
 
 I noticed you started checking out but didn't finish.
@@ -112,7 +112,7 @@ totally fine too. Just let me know and I'll stop bugging you.
 
 **Subject:** Free training: [Specific Outcome] in [Timeframe]
 
-```text
+```
 [Name],
 
 What if you could [achieve desired outcome] in the next [timeframe]?


### PR DESCRIPTION
## Summary

- Removes `text` language hint from all 4 code fences in `.agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md`
- Supersedes PR #13805 (same change, dispatched from interactive session per owner direction)

## Classification

Reference corpus (swipe file with self-contained email examples). Per the issue's own guidance, reference corpora should not have content compressed — only structural noise removed. The `text` language hint is the only genuine noise: adds no rendering value for plain-text email templates and breaks series consistency with all 5 siblings (`-01-welcome`, `-02-nurture`, `-04-reengagement`, `-05-subject-lines`, `-06-templates`).

## Changes

- `.agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md`: 4 code fences changed from ` ```text ` to ` ``` `

## Runtime Testing

Risk level: **Low** (docs/agent prompt edit, no code). Self-assessed.

- All 4 email templates, subject lines, and `**Patterns:**` analysis lines intact
- Series consistency: code fences now match all sibling files
- No broken references

Closes #13366

---
[aidevops.sh](https://aidevops.sh) v3.5.446 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 6m and 7,079 tokens on this as a headless worker.