### PR TITLE
GH#13902: tighten error-feedback.md (164→99 lines)

### DIFF
--- a/.agents/workflows/error-feedback.md
+++ b/.agents/workflows/error-feedback.md
@@ -14,7 +14,7 @@ tools:
 
 # Error Checking and Feedback Loops
 
-## GitHub Actions Workflow Monitoring
+## GitHub Actions Monitoring
 
 ```bash
 gh run list --limit 10                          # recent runs
@@ -25,16 +25,6 @@ gh api repos/{owner}/{repo}/actions/runs --jq '.workflow_runs[:5] | .[] | "\(.na
 gh api repos/{owner}/{repo}/actions/runs/{run_id}/jobs
 ```
 
-### Common GitHub Actions Errors
-
-| Error | Solution |
-|-------|----------|
-| Missing action version | Update: `uses: actions/checkout@v4` |
-| Deprecated action | Replace with recommended alternative |
-| Secret not found | Verify secret name in repository settings |
-| Permission denied | Check workflow permissions or GITHUB_TOKEN scope |
-| Timeout | Increase timeout or optimize slow steps |
-
 **Concurrency control:**
 
 ```yaml
@@ -43,41 +33,17 @@ concurrency:
   cancel-in-progress: true
 ```
 
-## Local Build and Test Feedback
+## Code Quality Tools
 
 ```bash
-npm test && npm run test:coverage   # JS/Node
-pytest --cov=module/                # Python
-vendor/bin/phpunit                  # PHP
-go test ./...                       # Go
-cargo test                          # Rust
-```
-
-### Common Local Test Errors
-
-| Error Type | Diagnosis | Solution |
-|------------|-----------|----------|
-| Dependency missing | Check error for package name | `npm install` / `pip install` |
-| Port in use | Check error for port number | Kill process or use different port |
-| Database connection | DB not running | Start database service |
-| Permission denied | File/directory access | Check permissions |
-
-## Code Quality Tool Integration
-
-```bash
-bash ~/Git/aidevops/.agents/scripts/linters-local.sh   # universal quality check
-shellcheck script.sh                                    # bash scripts
-npx eslint . --format json                              # JavaScript
-pylint module/ --output-format=json                     # Python
-
+bash ~/Git/aidevops/.agents/scripts/linters-local.sh      # universal quality check
 bash ~/Git/aidevops/.agents/scripts/qlty-cli.sh fmt --all  # auto-fix all
-npx eslint . --fix
-composer phpcbf
+shellcheck script.sh                                       # bash scripts
+npx eslint . --format json                                 # JavaScript
+pylint module/ --output-format=json                        # Python
 ```
 
-## Efficient Quality Tool Feedback via GitHub API
-
-The GitHub Checks API provides structured access to all code quality tool feedback (Codacy, CodeFactor, SonarCloud, CodeRabbit, etc.) without visiting each tool's dashboard.
+## Quality Feedback via GitHub Checks API
 
 ```bash
 # All check runs for current commit
@@ -110,55 +76,24 @@ gh api repos/{owner}/{repo}/commits/{sha}/check-runs \
   --jq '.check_runs[] | select(.name | contains("SonarCloud")) | {conclusion: .conclusion, url: .details_url}'
 ```
 
-### Processing Code Quality Feedback
+**Processing feedback:** Collect (`gh pr view {number} --comments --json comments` + `gh api repos/{owner}/{repo}/pulls/{number}/reviews`). Prioritize: Critical (security, breaking) → High (quality) → Medium (style) → Low (docs). Fix critical first; group related.
 
-1. Collect: `gh pr view {number} --comments --json comments` + `gh api repos/{owner}/{repo}/pulls/{number}/reviews`
-2. Categorize: Critical (security, breaking) → High (quality violations) → Medium (style) → Low (docs)
-3. Fix critical first; group related issues for efficiency
-
-## Automated Error Resolution
+## CI Error Resolution Loop
 
 ```bash
-gh run list --status failure --limit 1          # get failed workflow
-gh run view {run_id} --log-failed               # get failure details
+gh run list --status failure --limit 1          # identify failure
+gh run view {run_id} --log-failed               # diagnose
+# fix locally, then:
 git add . && git commit -m "fix: CI error description"
-git push origin {branch} && gh run watch        # push fix and monitor
-
-# Dependency issues
-npm ci && npm test
-composer install
-
-# Test failures
-npm test -- --grep "failing test name"
-npm test -- --updateSnapshot
-
-# Linting
-npm run lint:fix
+git push origin {branch} && gh run watch        # push and monitor
 ```
 
-## When to Consult Humans
+## Escalation to Humans
 
-| Scenario | What to Provide |
-|----------|-----------------|
-| Product design decisions | Options with trade-offs |
-| Security-critical changes | Security implications |
-| Architectural decisions | Architecture options |
-| Deployment approvals | Deployment plan |
-| Ambiguous requirements | Questions and assumptions |
+Escalate: product design decisions, security-critical changes, architectural decisions, deployment approvals, ambiguous requirements.
 
 Format: issue summary → context (goal + what happened) → error details → attempted solutions → specific questions → recommendations with pros/cons.
 
 ## Contributing Fixes Upstream
 
-```bash
-cd ~/git && git clone https://github.com/owner/repo.git
-cd repo && git checkout -b fix/descriptive-name
-git add -A && git commit -m "Fix: Description\n\nFixes #issue-number"
-gh repo fork owner/repo --clone=false --remote=true
-git remote add fork https://github.com/your-username/repo.git
-git push fork fix/descriptive-name
-gh pr create --repo owner/repo \
-  --head your-username:fix/descriptive-name \
-  --title "Fix: Description" \
-  --body "## Summary\nDescription.\n\nFixes #issue-number"
-```
+See `reference/external-repo-submissions.md` for fork/PR workflow to external repos.

--- a/.agents/workflows/error-feedback.md
+++ b/.agents/workflows/error-feedback.md
@@ -76,7 +76,7 @@ gh api repos/{owner}/{repo}/commits/{sha}/check-runs \
   --jq '.check_runs[] | select(.name | contains("SonarCloud")) | {conclusion: .conclusion, url: .details_url}'
 ```
 
-**Processing feedback:** Collect (`gh pr view {number} --comments --json comments` + `gh api repos/{owner}/{repo}/pulls/{number}/reviews`). Prioritize: Critical (security, breaking) → High (quality) → Medium (style) → Low (docs). Fix critical first; group related.
+**Processing feedback:** Collect (`gh pr view {pr_number} --comments --json comments` + `gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews`). Prioritize: Critical (security, breaking) → High (quality) → Medium (style) → Low (docs). Fix critical first; group related.
 
 ## CI Error Resolution Loop
 
@@ -85,7 +85,7 @@ gh run list --status failure --limit 1          # identify failure
 gh run view {run_id} --log-failed               # diagnose
 # fix locally, then:
 git add . && git commit -m "fix: CI error description"
-git push origin {branch} && gh run watch        # push and monitor
+git push origin {branch} && gh run watch {run_id} # push and monitor latest run
 ```
 
 ## Escalation to Humans


### PR DESCRIPTION
## Summary

- Remove generic troubleshooting tables (common GH Actions errors, local test errors, language-specific test commands) that an LLM already knows
- Deduplicate CI commands that appeared in both monitoring and resolution sections
- Replace inline fork/PR workflow (12 lines) with pointer to `reference/external-repo-submissions.md`
- Compress escalation guidance from table+format description to compact prose

All `gh` API commands, Checks API queries, `linters-local.sh`/`qlty-cli.sh` references, concurrency control YAML, feedback prioritization order, and escalation scenarios preserved.

Closes #13902

## Runtime Testing

Risk: **Low** — documentation/agent prompt only, no code changes.
Level: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.446 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-opus-4-6 spent 3m and 6,750 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined error feedback and GitHub Actions monitoring guidance
  * Simplified code quality tool integration examples
  * Updated CI error resolution workflow for clearer troubleshooting
  * Clarified escalation procedures with improved reference structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->