### PR TITLE
GH#13935: tighten playwright-emulation.md

### DIFF
--- a/.agents/tools/browser/playwright-emulation.md
+++ b/.agents/tools/browser/playwright-emulation.md
@@ -128,6 +128,7 @@ for (const bp of breakpoints) {
 ### Multi-Device Parallel Testing
 
 ```typescript
+// testDevices: [{ name, device }] where device = devices['iPhone 13'] | devices['Pixel 7'] | { viewport: {...} }
 for (const { name, device } of testDevices) {
   test.describe(name, () => {
     test.use({ ...device });
@@ -137,7 +138,6 @@ for (const { name, device } of testDevices) {
     });
   });
 }
-// testDevices: [{ name, device }] where device = devices['iPhone 13'] | devices['Pixel 7'] | { viewport: {...} }
 ```
 
 ### Touch, Network, Dark Mode
@@ -167,7 +167,7 @@ for (const scheme of ['light', 'dark'] as const) {
 }
 ```
 
-## Integration with aidevops Tools
+## Integration
 
 - **Chrome DevTools MCP**: navigate in mobile emulation → `npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222` for Lighthouse mobile audit.
 - **Stagehand**: `new Stagehand({ env: 'LOCAL', browserOptions: { ...devices['iPhone 13'] } })` → `stagehand.act('tap the hamburger menu')`.
@@ -179,5 +179,5 @@ for (const scheme of ['light', 'dark'] as const) {
 - `browser-automation.md` — tool selection decision tree
 - `browser-benchmark.md` — performance benchmarks
 - `pagespeed.md` — PageSpeed Insights integration
-- Maestro (t096) — native mobile E2E testing
+- Maestro (t096) — native mobile E2E
 - iOS Simulator MCP (t097) — iOS simulator interaction


### PR DESCRIPTION
## Summary

- Move inline type comment to conventional top-of-block position in Multi-Device Parallel Testing recipe
- Shorten section header "Integration with aidevops Tools" → "Integration" (redundant qualifier in an aidevops doc)
- Remove redundant word: "native mobile E2E testing" → "native mobile E2E"

Zero information loss. File was already lean — content is dense reference material with code blocks, not prose bloat.

Closes #13935


---
[aidevops.sh](https://aidevops.sh) v3.5.450 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 3m and 4,177 tokens on this as a headless worker.