### PR TITLE
GH#13933: tighten hexagonal.md — remove structural noise, compress prose

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
@@ -19,7 +19,6 @@ flowchart TB
     subgraph Hexagon["THE HEXAGON"]
         subgraph AppCore["APPLICATION CORE"]
             subgraph Domain["DOMAIN\n(Business Logic)"]
-                BL[" "]
             end
         end
     end
@@ -47,8 +46,6 @@ flowchart TB
 |------|-----------|------------|---------|-----------|
 | **Driver** (Primary / Inbound) | → App | Application | How the world uses your app (use cases) | Adapter *calls* port — app defines what it **offers** |
 | **Driven** (Secondary / Outbound) | App → | Application | What your app needs from external systems | Adapter *implements* port — app defines what it **needs** |
-
-**Driver ports** (called by adapters, represent use cases) · **Driven ports** (implemented by adapters, called by the application):
 
 ```typescript
 // application/ports/driver/place_order_port.ts


### PR DESCRIPTION
## Summary

- Remove redundant prose line in `## Ports` that restated the table above it
- Remove blank `BL[" "]` node from mermaid diagram (visual noise, no semantic value)
- 186 → 183 lines, zero information loss

## Changes

- `.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md`

## Runtime Testing

Risk: **Low** — doc-only change, no code paths affected. `self-assessed`.

Closes #13933

---
[aidevops.sh](https://aidevops.sh) v3.5.450 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 6m and 6,377 tokens on this as a headless worker.