### PR TITLE
GH#13936: tighten pages-functions-patterns.md (178→173 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md
@@ -2,10 +2,9 @@
 
 ## Middleware
 
-```javascript
-// functions/_middleware.js - global
-// functions/users/_middleware.js - scoped to /users/*
+`functions/_middleware.js` (global) or `functions/users/_middleware.js` (scoped to `/users/*`).
 
+```javascript
 // Single
 export async function onRequest(context) {
   try {
@@ -127,12 +126,10 @@ export async function onRequest(context) {
 export async function onRequest(context) {
   const url = new URL(context.request.url);
 
-  // Old paths
   if (url.pathname === '/old-page') {
     return Response.redirect(`${url.origin}/new-page`, 301);
   }
 
-  // Force HTTPS
   if (url.protocol === 'http:') {
     url.protocol = 'https:';
     return Response.redirect(url.toString(), 301);
@@ -156,12 +153,10 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    // Custom API
     if (url.pathname.startsWith('/api/')) {
       return new Response('API response');
     }
 
-    // Static assets
     return env.ASSETS.fetch(request);
   }
 } satisfies ExportedHandler<Env>;
@@ -174,5 +169,5 @@ export default {
 
 ## See Also
 
-- [README.md](./README.md) - Overview
-- [gotchas.md](./gotchas.md) - Common issues
+- [pages-functions.md](./pages-functions.md) — Overview
+- [pages-functions-gotchas.md](./pages-functions-gotchas.md) — Common issues


### PR DESCRIPTION
## Summary

- Move middleware file paths from code comments to prose (more scannable, not buried in code block)
- Remove 4 inline comments that restate section context: `// Old paths`, `// Force HTTPS`, `// Custom API`, `// Static assets` — the surrounding code makes these obvious
- Fix broken `See Also` links: `README.md` (doesn't exist) → `pages-functions.md`; `gotchas.md` (wrong name) → `pages-functions-gotchas.md`

## Runtime Testing

Risk: **Low** — doc-only change, no code execution paths affected.
Level: `self-assessed`

## Verification

- All code blocks preserved intact
- No task IDs, URLs, or command examples removed
- `wc -l` before: 178, after: 173 (5 lines removed, net -5 after restructure)
- `See Also` links now resolve to actual files in the directory

Closes #13936


---
[aidevops.sh](https://aidevops.sh) v3.5.450 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 8m and 7,998 tokens on this as a headless worker.