### PR TITLE
GH#13873: tighten workerd-patterns.md, remove redundant prose

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
@@ -57,8 +57,6 @@ Add to the worker block inside a config (see Multi-Service Architecture for full
 
 ## Dev vs Prod Configs
 
-Override bindings per environment via `fromEnvironment`:
-
 ```capnp
 const devWorker :Workerd.Worker = (
   modules = [(name = "index.js", esModule = embed "src/index.js")],
@@ -115,7 +113,7 @@ workerd test config.capnp --test-only=test.js
 
 ### Systemd
 
-`/etc/systemd/system/workerd.service` + `workerd.socket`:
+`/etc/systemd/system/workerd.service` and `workerd.socket`:
 
 ```ini
 # workerd.service


### PR DESCRIPTION
## Summary

- Remove redundant intro sentence in "Dev vs Prod Configs" section — section title + `fromEnvironment` usage in the code block are self-explanatory
- Fix Systemd path annotation: `+` → `and` (grammatical clarity)
- All code blocks, command examples, URLs, and actionable content preserved unchanged

## Runtime Testing

Risk: **Low** — docs-only change, no executable code modified. `self-assessed`.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md`: 164 → 162 lines (-2 lines of prose noise)

Closes #13873

---
[aidevops.sh](https://aidevops.sh) v3.5.450 plugin for [OpenCode](https://opencode.ai) v1.3.6 with claude-sonnet-4-6 spent 8m on this as an interactive worker.