### PR TITLE
GH#13971: restore inline code comments in pages-functions-patterns.md (regression fix)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md
@@ -126,10 +126,12 @@ export async function onRequest(context) {
 export async function onRequest(context) {
   const url = new URL(context.request.url);
 
+  // Old paths
   if (url.pathname === '/old-page') {
     return Response.redirect(`${url.origin}/new-page`, 301);
   }
 
+  // Force HTTPS
   if (url.protocol === 'http:') {
     url.protocol = 'https:';
     return Response.redirect(url.toString(), 301);
@@ -153,10 +155,12 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
+    // Custom API
     if (url.pathname.startsWith('/api/')) {
       return new Response('API response');
     }
 
+    // Static assets
     return env.ASSETS.fetch(request);
   }
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
## Summary

- Restore 4 inline code comments (`// Old paths`, `// Force HTTPS`, `// Custom API`, `// Static assets`) that were incorrectly removed in PR #13959
- These comments are technical content within code blocks that aid scanning — not structural noise
- Net change: 173→177 lines (+4 lines)

## What was NOT changed

- All code blocks: untouched
- Middleware file path prose (line 5): retained — good change from PR #13959
- Advanced Mode intro compression: retained — preserved use-case info
- See Also link fixes: retained — corrected broken links
- `_worker.js` constraint bullets: retained

## Regression analysis

PR #13959 (GH#13936) removed inline code comments from the Redirects and Advanced Mode code blocks. These comments (`// Old paths`, `// Force HTTPS`, `// Custom API`, `// Static assets`) are self-documenting annotations within code examples — they help readers scan code blocks quickly. Removing them reduced readability without saving meaningful context tokens.

## Runtime Testing

Risk: **Low** — doc-only change, no code or agent logic modified.
Level: `self-assessed`

## Verification

- `wc -l` before: 173, after: 177
- All code blocks present: confirmed
- No broken internal links: confirmed
- Agent behaviour unchanged: doc is reference corpus, no decision logic

Closes #13971

---
[aidevops.sh](https://aidevops.sh) v3.5.454 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 2m and 4,610 tokens on this as a headless worker.