### PR TITLE
GH#13972: tighten workerd-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
@@ -57,6 +57,8 @@ Add to the worker block inside a config (see Multi-Service Architecture for full
 
 ## Dev vs Prod Configs
 
+Separate named configs per environment; override bindings via `fromEnvironment`:
+
 ```capnp
 const devWorker :Workerd.Worker = (
   modules = [(name = "index.js", esModule = embed "src/index.js")],
@@ -159,4 +161,4 @@ workerd compile config.capnp myConfig -o production-server
 ./production-server
 ```
 
-See [gotchas.md](./gotchas.md) for common errors.
+See [workerd-gotchas.md](./workerd-gotchas.md) for common errors.


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md` — add missing context line and fix broken cross-reference.

## Changes

- **Dev vs Prod Configs section**: Added explanatory intro line ("Separate named configs per environment; override bindings via `fromEnvironment`") to orient the reader before the code block
- **Fixed broken link**: `./gotchas.md` → `./workerd-gotchas.md` (actual filename has `workerd-` prefix)

## Content Preservation

No content removed. Two additions: one context line and one link fix.

## Runtime Testing

- Risk: **Low** (docs/agent prompts only)
- Level: `self-assessed`
- Verification: visual diff review, link target verified via `ls`

Closes #13972


---
[aidevops.sh](https://aidevops.sh) v3.5.454 plugin for [OpenCode](https://opencode.ai) v1.3.3 with claude-opus-4-6 spent 5m and 10,994 tokens on this as a headless worker.