### PR TITLE
GH#14073: restore automatic OpenCode session title sync

### DIFF
--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -364,6 +364,12 @@ else
 		"$SCRIPT_DIR/terminal-title-helper.sh" sync 2>/dev/null || true
 	fi
 
+	# Sync OpenCode session title with current branch (silent, non-blocking).
+	# Only runs inside OpenCode sessions; helper resolves target session by cwd.
+	if [[ "${OPENCODE:-}" == "1" ]] && [[ -x "$SCRIPT_DIR/session-rename-helper.sh" ]]; then
+		"$SCRIPT_DIR/session-rename-helper.sh" sync-branch >/dev/null 2>&1 || true
+	fi
+
 	if [[ "$is_main_worktree" == "true" ]]; then
 		# Loop mode: auto-decide for canonical repo directory off main
 		if [[ "$LOOP_MODE" == "true" ]]; then

--- a/.agents/scripts/session-rename-helper.sh
+++ b/.agents/scripts/session-rename-helper.sh
@@ -29,6 +29,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 # =============================================================================
@@ -68,6 +69,56 @@ _require_sqlite3() {
 	return 0
 }
 
+# Escape a string for SQL single-quoted literals.
+# Arguments:
+#   $1 - raw string
+# Output: escaped string on stdout
+_sql_escape() {
+	local raw_value="$1"
+	printf '%s' "$raw_value" | sed "s/'/''/g"
+	return 0
+}
+
+# Resolve sync target session ID.
+# Priority:
+#   1) explicit session ID argument
+#   2) most recent session whose directory matches $PWD
+#   3) most recent session globally
+# Arguments:
+#   $1 - sqlite database path
+#   $2 - optional explicit session ID
+# Output: session ID on stdout
+# Returns: 0 on success, 1 when no session found
+_resolve_sync_session_id() {
+	local db_path="$1"
+	local explicit_session_id="${2:-}"
+
+	if [[ -n "$explicit_session_id" ]]; then
+		printf '%s' "$explicit_session_id"
+		return 0
+	fi
+
+	local cwd_escaped
+	cwd_escaped="$(_sql_escape "$PWD")"
+
+	local session_id
+	session_id="$(sqlite3 "$db_path" \
+		"SELECT id FROM session WHERE directory = '${cwd_escaped}' ORDER BY time_updated DESC LIMIT 1;" 2>/dev/null || echo "")"
+
+	if [[ -z "$session_id" ]]; then
+		session_id="$(sqlite3 "$db_path" \
+			"SELECT id FROM session ORDER BY time_updated DESC LIMIT 1;" 2>/dev/null || echo "")"
+	fi
+
+	if [[ -z "$session_id" ]]; then
+		print_error "No sessions found in database"
+		return 1
+	fi
+
+	printf '%s' "$session_id"
+	return 0
+}
+
 # =============================================================================
 # Commands
 # =============================================================================
@@ -101,9 +152,13 @@ cmd_rename() {
 	local now_ms
 	now_ms="$(date +%s)000"
 
+	local escaped_title escaped_session_id
+	escaped_title="$(_sql_escape "$new_title")"
+	escaped_session_id="$(_sql_escape "$session_id")"
+
 	local changes
 	changes="$(sqlite3 "$db_path" \
-		"UPDATE session SET title = '$(printf '%s' "$new_title" | sed "s/'/''/g")', time_updated = ${now_ms} WHERE id = '$(printf '%s' "$session_id" | sed "s/'/''/g")'; SELECT changes();")"
+		"UPDATE session SET title = '${escaped_title}', time_updated = ${now_ms} WHERE id = '${escaped_session_id}'; SELECT changes();")"
 
 	if [[ "$changes" -eq 0 ]]; then
 		print_error "Session not found: ${session_id}"
@@ -115,9 +170,9 @@ cmd_rename() {
 	return 0
 }
 
-# Rename the most recent (or specified) session to match the current git branch.
+# Rename the most relevant (or specified) session to match the current git branch.
 # Arguments:
-#   $1 - session ID (optional; defaults to most recent session)
+#   $1 - session ID (optional; defaults to current-directory session)
 # Returns: 0 on success, 1 on failure
 cmd_sync_branch() {
 	local session_id="${1:-}"
@@ -127,15 +182,8 @@ cmd_sync_branch() {
 	local db_path
 	db_path="$(_get_db_path)" || return 1
 
-	# Resolve session ID if not provided
-	if [[ -z "$session_id" ]]; then
-		session_id="$(sqlite3 "$db_path" \
-			"SELECT id FROM session ORDER BY time_updated DESC LIMIT 1;" 2>/dev/null || echo "")"
-		if [[ -z "$session_id" ]]; then
-			print_error "No sessions found in database"
-			return 1
-		fi
-	fi
+	# Resolve session ID (explicit argument, then cwd match, then global fallback)
+	session_id="$(_resolve_sync_session_id "$db_path" "$session_id")" || return 1
 
 	# Get current git branch
 	local branch

--- a/.agents/tools/terminal/terminal-title.md
+++ b/.agents/tools/terminal/terminal-title.md
@@ -20,7 +20,7 @@ tools:
 - **Purpose**: Sync terminal tab titles with git repo/branch via OSC escape sequences
 - **Script**: `~/.aidevops/agents/scripts/terminal-title-helper.sh`
 - **Auto-sync**: Runs automatically via `pre-edit-check.sh` when on a feature branch in a git repo
-- **Session sync**: OpenCode session names sync via `session-rename_sync_branch` tool; tab titles via the helper script
+- **Session sync**: OpenCode session titles auto-sync in `pre-edit-check.sh` (best effort by current directory) and can be forced via `session-rename_sync_branch`
 
 **Commands**:
 


### PR DESCRIPTION
## Summary
- Make `session-rename-helper.sh sync-branch` resolve the target session by current working directory first, then fall back to global latest session.
- Trigger best-effort OpenCode session title sync from `pre-edit-check.sh` so branch/session names stay aligned during normal branch/worktree flows.
- Update terminal-title reference docs to reflect automatic session sync behavior.

## Why
Manual `session-rename_sync_branch` calls are easy to miss in practice. Losing automatic session naming reduces tab/session clarity in parallel worktrees.

## Runtime Testing
- **Required level:** runtime-verified (session/workflow behavior)
- **ShellCheck:** `shellcheck .agents/scripts/session-rename-helper.sh .agents/scripts/pre-edit-check.sh`
- **Markdown lint:** `npx --yes markdownlint-cli2 .agents/tools/terminal/terminal-title.md`
- **Behavior verification:**
  - `OPENCODE_DB=<tmpdb> .agents/scripts/session-rename-helper.sh sync-branch` updates cwd-matched session ID over newer global session
  - fallback path updates newest global session when cwd match is absent
  - `OPENCODE=1 OPENCODE_DB=<tmpdb> .agents/scripts/pre-edit-check.sh --loop-mode --task \"runtime verification\"` auto-syncs session title to branch

## Files Changed
- `.agents/scripts/session-rename-helper.sh`
- `.agents/scripts/pre-edit-check.sh`
- `.agents/tools/terminal/terminal-title.md`

Closes #14073
---
[aidevops.sh](https://aidevops.sh) v3.5.454 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex" spent 24m and 131,472 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode session titles now automatically sync with the current branch during edit operations.

* **Improvements**
  * Enhanced session identification to prioritize directory-specific sessions over global ones.

* **Documentation**
  * Updated session synchronization behavior documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->