### PR TITLE
GH#13998: tighten security.md (106→80 lines, 25% reduction)

### DIFF
--- a/.agents/aidevops/security.md
+++ b/.agents/aidevops/security.md
@@ -13,15 +13,31 @@ tools:
 
 # Security Best Practices
 
+Core security rules (never expose credentials, gopass/credentials.sh storage, secret-handling): `prompts/build.txt`.
+API key compliance, incident response, provider rotation: `aidevops/security-requirements.md`.
+
 ## Credential Management
 
-- Never commit API tokens or secrets to version control
-- Store in `~/.config/aidevops/credentials.sh` (600 perms) or gopass
+- Store in `~/.config/aidevops/credentials.sh` (600 perms) or gopass — never in source
 - Use env vars for CI/CD; add config files to `.gitignore`
 - Rotate tokens quarterly; least-privilege per project/environment
 - SSH passwords in separate files (never in scripts), perms 600
 
-## SSH Security
+## File Permissions
+
+```bash
+chmod 600 configs/.*.json ~/.ssh/id_* ~/.ssh/config ~/.ssh/*_password
+chmod 644 ~/.ssh/id_*.pub
+chmod 700 ~/.ssh/
+chmod 755 *.sh .agents/scripts/*.sh
+```
+
+```bash
+# .gitignore entries
+printf "configs/.*.json\n*.password\n.env\n*.key\n*.pem\n" >> .gitignore
+```
+
+## SSH Hardening
 
 ```bash
 # Generate Ed25519 key with passphrase
@@ -43,27 +59,6 @@ Host *
 
 Server: disable root login, non-standard SSH port, fail2ban.
 
-## Access Control
-
-- Minimum necessary permissions; separate tokens per project/environment
-- MFA on all cloud accounts; hardware security keys where available
-- VPNs or bastion hosts for production; IP whitelisting
-- TLS 1.2+ for all API communications; rotate certificates regularly
-
-## File Permissions
-
-```bash
-chmod 600 configs/.*.json ~/.ssh/id_* ~/.ssh/config ~/.ssh/*_password
-chmod 644 ~/.ssh/id_*.pub
-chmod 700 ~/.ssh/
-chmod 755 *.sh .agents/scripts/*.sh
-```
-
-```bash
-# .gitignore entries
-printf "configs/.*.json\n*.password\n.env\n*.key\n*.pem\n" >> .gitignore
-```
-
 ## Script Security
 
 ```text
@@ -76,31 +71,10 @@ printf "configs/.*.json\n*.password\n.env\n*.key\n*.pem\n" >> .gitignore
 - **Private scripts**: safe for real API keys; create from `scripts/` templates; never share outside secure channels
 - Verify: `git status --ignored | grep scripts-private` → should show `(ignored)`
 
-## Monitoring and Incident Response
+## Access Control
+
+MFA on all cloud accounts; hardware security keys where available. VPNs or bastion hosts for production; IP whitelisting. TLS 1.2+ for all API communications; separate tokens per project/environment.
+
+## Monitoring
 
 Monitor API rate limits; alert on unusual activity; log all API calls in production.
-
-**Incident response:**
-
-1. **Immediate** — disable compromised credentials, block suspicious IPs, isolate affected systems
-2. **Investigate** — analyze logs, identify scope, document findings
-3. **Recover** — rotate all potentially compromised credentials, patch, restore from clean backups
-4. **Prevent** — implement additional controls, update procedures
-
-## Security Checklist
-
-**Initial setup:**
-
-- [ ] Ed25519 SSH keys with passphrases
-- [ ] File permissions on all sensitive files
-- [ ] Secure SSH client config
-- [ ] Sensitive files in `.gitignore`
-- [ ] MFA on all cloud accounts
-
-**Regular maintenance:**
-
-- [ ] Rotate API tokens quarterly
-- [ ] Audit SSH keys, remove unused
-- [ ] Review and update access permissions
-- [ ] Monitor logs for suspicious activity
-- [ ] Update and patch all systems


### PR DESCRIPTION
## Summary

- Tighten `.agents/aidevops/security.md` from 106→80 lines (25% reduction)
- Remove duplicated incident response and security checklist (authoritative versions in `security-requirements.md`)
- Add cross-references to `build.txt` and `security-requirements.md` for deduplication
- Compress access control section; reorder by importance (credentials → file perms → SSH → scripts)
- All code blocks, unique knowledge, and command references preserved

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, content preservation verified via diff

Closes #13998

---
[aidevops.sh](https://aidevops.sh) v3.5.455 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 2m and 5,280 tokens on this as a headless worker.