### PR TITLE
GH#14044: tighten voice-ai-models.md (147→126 lines)

### DIFF
--- a/.agents/tools/voice/voice-ai-models.md
+++ b/.agents/tools/voice/voice-ai-models.md
@@ -87,9 +87,9 @@ Also available: EdgeTTS (free, 300+ voices), macOS Say (zero deps), FacebookMMS 
 | Whisper Small | 461MB | 8.5 | Medium | 2GB |
 | Whisper Large v3 | 2.9GB | 9.8 | Slow | 10GB |
 | Whisper Large v3 Turbo | 1.5GB | 9.7 | Fast | 5GB |
-| NVIDIA Parakeet V2 | 0.6B | 9.4 | Fastest | 2GB |
-| NVIDIA Parakeet V3 | 0.6B | 9.6 | Fastest | 2GB |
-| Apple Speech | Built-in | 9.0 | Fast | On-device |
+| NVIDIA Parakeet V2 | 0.6B | 9.4 | Fastest | 2GB (English-only) |
+| NVIDIA Parakeet V3 | 0.6B | 9.6 | Fastest | 2GB (25 langs) |
+| Apple Speech | Built-in | 9.0 | Fast | On-device (macOS 26+) |
 
 Backends: `faster-whisper` (4x speed, recommended), `whisper.cpp` (C++ native, Apple Silicon optimized). See `transcription.md`.
 

--- a/.agents/tools/voice/voice-ai-models.md
+++ b/.agents/tools/voice/voice-ai-models.md
@@ -21,105 +21,7 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## TTS (Text-to-Speech)
-
-### Cloud
-
-| Provider | Latency | Quality | Voice Clone | Languages | Pricing |
-|----------|---------|---------|-------------|-----------|---------|
-| ElevenLabs | ~300ms | Best | Yes | 29 | $5-330/mo |
-| OpenAI TTS | ~400ms | Great | No | 57 | $15/1M chars |
-| Cartesia Sonic 3 | ~90ms | Great | Yes (10s ref) | 17 | $8-66/mo |
-| NVIDIA Magpie TTS | ~200ms | Great | Yes (zero-shot) | 17+ | NIM API (free tier) |
-| Google Cloud TTS | ~200ms | Good | No (custom) | 50+ | $4-16/1M chars |
-
-Pick: ElevenLabs → quality/cloning. Cartesia → lowest latency. NVIDIA Magpie → enterprise/self-hosted. Google → language breadth.
-
-### Local
-
-| Model | Params | License | Languages | Voice Clone | VRAM |
-|-------|--------|---------|-----------|-------------|------|
-| Qwen3-TTS 0.6B | 0.6B | Apache-2.0 | 10 | Yes (5s ref) | 2GB |
-| Qwen3-TTS 1.7B | 1.7B | Apache-2.0 | 10 | Yes (5s ref) | 4GB |
-| Bark (Suno) | 1.0B | MIT | 13+ | Yes (prompt) | 6GB (stale) |
-| Coqui TTS | varies | MPL-2.0 | 20+ | Yes | 2-6GB |
-| Piper | <100M | MIT | 30+ | No | CPU only |
-
-Pick: Qwen3-TTS → quality + cloning. Piper → CPU-only/embedded. Bark → expressiveness (laughter, music).
-
-Also available: EdgeTTS (free, 300+ voices), macOS Say (zero deps), FacebookMMS (1100+ languages). See `voice-models.md`.
-
-## STT (Speech-to-Text)
-
-### Cloud
-
-| Provider | Model | Accuracy | Real-time | Cost |
-|----------|-------|----------|-----------|------|
-| Groq | Whisper Large v3 Turbo | 9.6 | No (batch) | Free tier |
-| ElevenLabs | Scribe v2 | 9.9 | No | Per minute |
-| NVIDIA Riva | Parakeet CTC/RNNT | 9.4-9.6 | Yes (streaming) | NIM API (free tier) |
-| Deepgram | Nova-2 / Nova-3 | 9.5-9.6 | Yes | Per minute |
-| Soniox | stt-async-v3 | 9.6 | Yes | Per minute |
-
-Pick: Groq → free/fast batch. ElevenLabs Scribe → accuracy. NVIDIA Parakeet → enterprise/self-hosted. Deepgram → real-time streaming.
-
-### Local
-
-| Model | Size | Accuracy | Speed | VRAM |
-|-------|------|----------|-------|------|
-| Whisper Tiny | 75MB | 6.0 | Fastest | 1GB |
-| Whisper Base | 142MB | 7.3 | Fast | 1GB |
-| Whisper Small | 461MB | 8.5 | Medium | 2GB |
-| Whisper Large v3 | 2.9GB | 9.8 | Slow | 10GB |
-| Whisper Large v3 Turbo | 1.5GB | 9.7 | Fast | 5GB |
-| NVIDIA Parakeet V2 | 0.6B | 9.4 | Fastest | 2GB |
-| NVIDIA Parakeet V3 | 0.6B | 9.6 | Fastest | 2GB |
-| Apple Speech | Built-in | 9.0 | Fast | On-device |
-
-Pick: Large v3 Turbo → best balance. Parakeet V3 → multilingual speed (25 langs). Parakeet V2 → English-only. Apple Speech → zero-setup macOS 26+.
-
-Backends: `faster-whisper` (4x speed, recommended), `whisper.cpp` (C++ native, Apple Silicon optimized). See `transcription.md`.
-
-## S2S (Speech-to-Speech)
-
-### Native Models
-
-| Model | Type | Latency | Availability | Notes |
-|-------|------|---------|--------------|-------|
-| GPT-4o Realtime | Cloud API | ~300ms | OpenAI API (GA) | Emotion-aware, function calling, SIP telephony |
-| Gemini 2.0 Live | Cloud API | ~350ms | Google API | Multimodal, streaming |
-| MiniCPM-o 2.6 | Open weights | ~500ms | Local (8GB+) | 8B, Apache-2.0, vision+speech+streaming |
-| AWS Nova Sonic | Cloud API | ~600ms | AWS API | AWS ecosystem, 7 languages |
-| Ultravox | Open weights | ~400ms | Local (6GB+) | Audio-text multimodal |
-
-### NVIDIA Riva Composable Pipelines
-
-| Component | Model | Role | Languages | NIM Available |
-|-----------|-------|------|-----------|---------------|
-| ASR | Parakeet TDT 0.6B v2 | Speech-to-text | English | HF (research) |
-| ASR | Parakeet CTC 1.1B | Speech-to-text | English | Yes |
-| ASR | Parakeet RNNT 1.1B | Speech-to-text | 25 languages | Yes |
-| TTS | Magpie TTS Multilingual | Text-to-speech | 17+ languages | Yes |
-| TTS | Magpie TTS Zero-Shot | Voice cloning TTS | English+ | API |
-| Enhancement | StudioVoice | Noise removal | Any | Yes |
-| Translation | Riva Translate | NMT | 36 languages | Yes |
-
-Compose as: `Audio -> [Parakeet ASR] -> [Any LLM] -> [Magpie TTS] -> Audio`. See `cloud-voice-agents.md`.
-
-Pick: GPT-4o Realtime → production cloud (lowest latency, GA). MiniCPM-o 2.6 → self-hosted/private (Apache-2.0, multimodal). NVIDIA Riva → enterprise on-prem (composable, 25+ languages). Cascaded S2S (VAD+STT+LLM+TTS): see `speech-to-speech.md`.
-
-## Selection by Priority
-
-| Priority | TTS | STT | S2S |
-|----------|-----|-----|-----|
-| Quality | ElevenLabs / Qwen3-TTS 1.7B | ElevenLabs Scribe / Large v3 | GPT-4o Realtime |
-| Speed | Cartesia Sonic 3 / EdgeTTS | Groq / Parakeet V3 | GPT-4o Realtime / Cascaded |
-| Cost | EdgeTTS (free) / Piper | Local Whisper ($0) / Groq free | MiniCPM-o 2.6 (local) |
-| Privacy | Piper / Qwen3-TTS | faster-whisper / whisper.cpp | MiniCPM-o 2.6 |
-| Enterprise | NVIDIA Magpie / ElevenLabs | NVIDIA Parakeet / Scribe | NVIDIA Riva pipeline |
-| Voice clone | ElevenLabs / Qwen3-TTS | N/A | MiniCPM-o 2.6 |
-
-### Decision Flow
+## Decision Flow
 
 ```text
 Need voice AI?
@@ -139,6 +41,83 @@ Need voice AI?
     ├── Local/private? → MiniCPM-o 2.6 or cascaded pipeline
     └── Default → speech-to-speech.md cascaded pipeline
 ```
+
+## TTS (Text-to-Speech)
+
+### Cloud
+
+| Provider | Latency | Quality | Voice Clone | Languages | Pricing |
+|----------|---------|---------|-------------|-----------|---------|
+| ElevenLabs | ~300ms | Best | Yes | 29 | $5-330/mo |
+| OpenAI TTS | ~400ms | Great | No | 57 | $15/1M chars |
+| Cartesia Sonic 3 | ~90ms | Great | Yes (10s ref) | 17 | $8-66/mo |
+| NVIDIA Magpie TTS | ~200ms | Great | Yes (zero-shot) | 17+ | NIM API (free tier) |
+| Google Cloud TTS | ~200ms | Good | No (custom) | 50+ | $4-16/1M chars |
+
+### Local
+
+| Model | Params | License | Languages | Voice Clone | VRAM |
+|-------|--------|---------|-----------|-------------|------|
+| Qwen3-TTS 0.6B | 0.6B | Apache-2.0 | 10 | Yes (5s ref) | 2GB |
+| Qwen3-TTS 1.7B | 1.7B | Apache-2.0 | 10 | Yes (5s ref) | 4GB |
+| Bark (Suno) | 1.0B | MIT | 13+ | Yes (prompt) | 6GB (stale, expressive: laughter/music) |
+| Coqui TTS | varies | MPL-2.0 | 20+ | Yes | 2-6GB |
+| Piper | <100M | MIT | 30+ | No | CPU only |
+
+Also available: EdgeTTS (free, 300+ voices), macOS Say (zero deps), FacebookMMS (1100+ languages). See `voice-models.md`.
+
+## STT (Speech-to-Text)
+
+### Cloud
+
+| Provider | Model | Accuracy | Real-time | Cost |
+|----------|-------|----------|-----------|------|
+| Groq | Whisper Large v3 Turbo | 9.6 | No (batch) | Free tier |
+| ElevenLabs | Scribe v2 | 9.9 | No | Per minute |
+| NVIDIA Riva | Parakeet CTC/RNNT | 9.4-9.6 | Yes (streaming) | NIM API (free tier) |
+| Deepgram | Nova-2 / Nova-3 | 9.5-9.6 | Yes | Per minute |
+| Soniox | stt-async-v3 | 9.6 | Yes | Per minute |
+
+### Local
+
+| Model | Size | Accuracy | Speed | VRAM |
+|-------|------|----------|-------|------|
+| Whisper Tiny | 75MB | 6.0 | Fastest | 1GB |
+| Whisper Base | 142MB | 7.3 | Fast | 1GB |
+| Whisper Small | 461MB | 8.5 | Medium | 2GB |
+| Whisper Large v3 | 2.9GB | 9.8 | Slow | 10GB |
+| Whisper Large v3 Turbo | 1.5GB | 9.7 | Fast | 5GB |
+| NVIDIA Parakeet V2 | 0.6B | 9.4 | Fastest | 2GB |
+| NVIDIA Parakeet V3 | 0.6B | 9.6 | Fastest | 2GB |
+| Apple Speech | Built-in | 9.0 | Fast | On-device |
+
+Backends: `faster-whisper` (4x speed, recommended), `whisper.cpp` (C++ native, Apple Silicon optimized). See `transcription.md`.
+
+## S2S (Speech-to-Speech)
+
+### Native Models
+
+| Model | Type | Latency | Availability | Notes |
+|-------|------|---------|--------------|-------|
+| GPT-4o Realtime | Cloud API | ~300ms | OpenAI API (GA) | Emotion-aware, function calling, SIP telephony |
+| Gemini 2.0 Live | Cloud API | ~350ms | Google API | Multimodal, streaming |
+| MiniCPM-o 2.6 | Open weights | ~500ms | Local (8GB+) | 8B, Apache-2.0, vision+speech+streaming |
+| AWS Nova Sonic | Cloud API | ~600ms | AWS API | AWS ecosystem, 7 languages |
+| Ultravox | Open weights | ~400ms | Local (6GB+) | Audio-text multimodal |
+
+### NVIDIA Riva Composable Pipelines
+
+| Component | Model | Languages | NIM |
+|-----------|-------|-----------|-----|
+| ASR | Parakeet TDT 0.6B v2 | English | HF (research) |
+| ASR | Parakeet CTC 1.1B | English | Yes |
+| ASR | Parakeet RNNT 1.1B | 25 | Yes |
+| TTS | Magpie Multilingual | 17+ | Yes |
+| TTS | Magpie Zero-Shot | English+ | API |
+| Enhancement | StudioVoice | Any | Yes |
+| Translation | Riva Translate | 36 | Yes |
+
+Pipeline: `Audio -> [Parakeet ASR] -> [Any LLM] -> [Magpie TTS] -> Audio`. See `cloud-voice-agents.md`. Cascaded S2S (VAD+STT+LLM+TTS): see `speech-to-speech.md`.
 
 ## GPU Planning
 


### PR DESCRIPTION
## Summary

- Deduplicate selection guidance: remove 4 redundant "Pick:" lines and the "Selection by Priority" table — both fully covered by the Decision Flow tree
- Move Decision Flow to top of doc (primacy effect — most actionable content first)
- Compress NVIDIA Riva table: remove redundant "Role" column, shorten headers
- Preserve Bark expressiveness note (laughter/music) in table cell

## Details

**Classification**: Reference corpus (model selection reference). At 126 lines, well under the 300-line split threshold — tightening, not splitting.

**What was removed** (and why safe):
- 4 "Pick:" lines after each model table — every recommendation exists in the Decision Flow tree
- "Selection by Priority" table (6 rows × 4 cols) — every cell's recommendation is in the Decision Flow tree
- "Role" column from Riva table — redundant with Component column (ASR=Speech-to-text, TTS=Text-to-speech)

**Zero knowledge loss**: All 28 models, all specs, all cross-references, GPU planning, decision paths, and the Bark expressiveness note retained.

## Runtime Testing

- **Risk**: Low (docs/agent prompts only)
- **Level**: `self-assessed`
- Markdown lint: 0 errors

Closes #14044

---
[aidevops.sh](https://aidevops.sh) v3.5.455 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 2m and 7,249 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a decision framework for selecting between text-to-speech, speech-to-text, and conversational voice models based on cloning, latency, offline needs, accuracy, cost, and deployment requirements.
  * Reorganized voice model comparison tables for improved clarity and navigation.
  * Enhanced voice synthesis capability descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->