### PR TITLE
GH#13979: tighten agent-browser.md (170→161 lines)

### DIFF
--- a/.agents/tools/browser/agent-browser.md
+++ b/.agents/tools/browser/agent-browser.md
@@ -25,6 +25,7 @@ tools:
 - **Limitations**: No proxy, no extensions, no Chrome DevTools MCP pairing
 - **Performance** (warm): navigate+screenshot 1.9s, form fill 1.4s, reliability 0.6s. Cold-start ~3-5s.
 - **iOS** (macOS only): `-p ios --device "iPhone 16 Pro"` — Mobile Safari via Appium
+- **License**: Apache-2.0 | TypeScript (74%), Rust (22%)
 
 **Core workflow** — use refs from `snapshot -i` for deterministic targeting:
 
@@ -46,7 +47,6 @@ agent-browser screenshot page.png && agent-browser close
 ```bash
 # Navigate
 agent-browser open <url> | back | forward | reload
-
 # Interact
 agent-browser click <sel>
 agent-browser fill <sel> <text>       # clear+fill
@@ -56,12 +56,10 @@ agent-browser select <sel> <val>      # dropdown
 agent-browser check/uncheck <sel>
 agent-browser scroll <dir> [px]       # up/down/left/right
 agent-browser drag <src> <tgt> | upload <sel> <files> | hover <sel>
-
 # Read
 agent-browser get text/html/value/title/url <sel>
 agent-browser get attr <sel> <attr> | get count/box <sel>
 agent-browser is visible/enabled/checked <sel>
-
 # Output
 agent-browser screenshot [path] [--full] | pdf <path> | eval <js> | close
 ```
@@ -78,19 +76,14 @@ agent-browser find label "Email" fill "test@test.com"
 agent-browser find first ".item" click | find nth 2 "a" text
 ```
 
-## Sessions
+## Sessions, Wait, Storage, Network
 
-Each session has isolated browser instance, cookies, storage, history, and auth state. Parallel sessions supported (`--session s1/s2/s3`; 3 parallel tested in 2.0s).
+Isolated browser per session (cookies, storage, history, auth). Parallel: `--session s1/s2/s3` (3 parallel tested in 2.0s).
 
 ```bash
-agent-browser --session agent1 open site-a.com
-AGENT_BROWSER_SESSION=agent1 agent-browser click "#btn"
+agent-browser --session agent1 open site-a.com         # named session
+AGENT_BROWSER_SESSION=agent1 agent-browser click "#btn" # env var
 agent-browser session list
-```
-
-## Wait, Cookies, Storage, Network
-
-```bash
 agent-browser wait <selector> | <ms> | --text "Welcome" | --url "**/dash" | --load networkidle
 agent-browser wait --fn "window.ready === true"
 agent-browser cookies | cookies set <name> <val> | cookies clear
@@ -114,13 +107,13 @@ agent-browser trace start/stop [path] | console [--clear] | errors [--clear]
 agent-browser highlight <sel> | state save/load <path>
 ```
 
-## iOS Simulator
-
-- **Env vars**: `AGENT_BROWSER_PROVIDER=ios`, `AGENT_BROWSER_IOS_DEVICE="iPhone 16 Pro"`, `AGENT_BROWSER_IOS_UDID=<udid>`
-- **First launch**: ~30-60s to boot simulator; subsequent commands are fast
-- **Real device**: UDID via `xcrun xctrace list devices`, sign WebDriverAgent in Xcode (free Apple Developer account)
+## iOS Simulator (macOS only)
 
 ```bash
+# Env vars: AGENT_BROWSER_PROVIDER=ios, AGENT_BROWSER_IOS_DEVICE="iPhone 16 Pro",
+#           AGENT_BROWSER_IOS_UDID=<udid>
+# First launch ~30-60s (simulator boot); subsequent commands fast
+# Real device: UDID via `xcrun xctrace list devices`, sign WebDriverAgent in Xcode (free Apple Developer account)
 agent-browser device list
 agent-browser -p ios --device "iPhone 16 Pro" open https://example.com
 agent-browser -p ios snapshot -i | tap @e1 | swipe up/down/left/right [px]
@@ -148,12 +141,12 @@ agent-browser -p ios screenshot mobile.png | close
 ## Common Patterns
 
 ```bash
-# Login flow
+# Login flow — fill, submit, save auth state
 agent-browser open https://app.example.com/login && agent-browser snapshot -i
 agent-browser fill @e3 "user@example.com" && agent-browser fill @e4 "password"
 agent-browser click @e5 && agent-browser wait --url "**/dashboard" && agent-browser state save auth.json
 
-# Form submission
+# Form submission — fill fields, select, check, submit
 agent-browser open https://example.com/form && agent-browser snapshot -i
 agent-browser fill @e1 "John Doe" && agent-browser fill @e2 "john@example.com"
 agent-browser select @e3 "US" && agent-browser check @e4
@@ -162,9 +155,7 @@ agent-browser click @e5 && agent-browser wait --text "Success"
 # Data extraction
 agent-browser open https://example.com/products && agent-browser snapshot --json > products.json
 
-# Multi-session parallel
+# Multi-session parallel — load saved auth per session
 agent-browser --session s1 open https://site-a.com && agent-browser --session s1 state load auth-a.json
 agent-browser --session s2 open https://site-b.com && agent-browser --session s2 state load auth-b.json
 ```
-
-**License**: Apache-2.0 | TypeScript (74%), Rust (22%)


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/browser/agent-browser.md` — 170→161 lines (~5% reduction), zero information loss.

Closes #13979

## Changes

- **Merged Sessions + Wait/Cookies/Storage/Network** into one section with a single code block — eliminates redundant section header and code fences
- **Folded iOS env vars** from bullet-point prose into code block comments — same info, fewer lines
- **Moved License line** from orphaned footer to Quick Reference section (better discoverability)
- **Removed blank lines** between command groups inside Core Commands code block
- **Added descriptive comments** to Common Patterns examples (login flow, form submission, multi-session)

## Content Preservation

- All 63 `agent-browser` command references preserved
- All URLs identical (verified via diff)
- All key terms verified: Appium, xcuitest, env vars, WebDriverAgent, networkidle, all comparison tools
- Institutional knowledge retained: "free Apple Developer account", session history, cold-start timing

## Runtime Testing

- **Risk**: Low (docs/agent prompts only)
- **Level**: `self-assessed` — no runtime behaviour change

---
[aidevops.sh](https://aidevops.sh) v3.5.455 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 3m and 7,001 tokens on this as a headless worker.