### PR TITLE
GH#14003: tighten hashline-edit-format.md (139→135 lines)

### DIFF
--- a/.agents/reference/hashline-edit-format.md
+++ b/.agents/reference/hashline-edit-format.md
@@ -1,25 +1,25 @@
 # Hashline Edit Format
 
-Content-addressed line reference system (`LINE#HASH`) used in oh-my-pi's coding agent. Hash mismatches on stale reads fail loudly with actionable output rather than silently corrupting the file.
+Content-addressed line reference system (`LINE#HASH`) for oh-my-pi's coding agent. Hash mismatches on stale reads fail loudly with actionable output instead of silently corrupting files.
 
 **Source**: `oh-my-pi/packages/coding-agent/src/patch/hashline.ts`
 
 ## Line Reference Format
 
 ```text
-LINENUM#HASH:CONTENT   ← display format (shown to model)
-"LINENUM#HASH"         ← reference format (used in edit operations)
+LINENUM#HASH:CONTENT   ← display (shown to model)
+"LINENUM#HASH"         ← reference (used in edits)
 ```
 
-Example: `1#ZP:function hi() {` / `"5#aa"` — line 5, hash `aa`.
+Example: `1#ZP:function hi() {` (display) / `"5#aa"` (reference — line 5, hash `aa`).
 
 ## Hash Algorithm
 
-**`computeLineHash(idx, line)`** — xxHash32 (`Bun.hash.xxHash32`). Strips all whitespace (`/\s+/g` → `""`) and trailing `\r`; line number accepted but not mixed into hash. Output: 2 chars from alphabet `ZPMQVRWSNKTXJBYH` (visually distinct, unlikely in code tokens). Encoding: low byte (`& 0xff`) indexes a 256-entry lookup table; each entry maps high/low nibbles to the alphabet.
+**`computeLineHash(idx, line)`** — xxHash32 (`Bun.hash.xxHash32`). Strips whitespace (`/\s+/g` → `""`) and trailing `\r`; line number accepted but not mixed into hash. Output: 2 chars from alphabet `ZPMQVRWSNKTXJBYH` (visually distinct, unlikely in code). Encoding: low byte (`& 0xff`) → 256-entry lookup table mapping high/low nibbles to alphabet.
 
-**`parseTag(ref)`** — regex: `/^\s*[>+-]*\s*(\d+)\s*#\s*([ZPMQVRWSNKTXJBYH]{2})/`. Strips leading `>+` markers, surrounding whitespace, and optional trailing display suffixes. Tolerates diff markers in model output.
+**`parseTag(ref)`** — regex: `/^\s*[>+-]*\s*(\d+)\s*#\s*([ZPMQVRWSNKTXJBYH]{2})/`. Strips leading `>+` markers, whitespace, trailing display suffixes. Tolerates diff markers.
 
-**Hash collision**: 2 chars from 16-char alphabet = 256 values, ~0.4% collision per line. Line number is the primary address; hash is a staleness signal, not a cryptographic guarantee.
+**Collision**: 2 chars × 16-char alphabet = 256 values (~0.4% per line). Line number is primary address; hash is staleness signal, not cryptographic guarantee.
 
 ## Edit Operations
 
@@ -31,7 +31,7 @@ Example: `1#ZP:function hi() {` / `"5#aa"` — line 5, hash `aa`.
 | `prepend` | Insert `content[]` before `before` (BOF if omitted) |
 | `insert` | Insert `content[]` between `after` and `before` (both required) |
 
-`ReplaceTextEdit` (`op: "replaceText"`) is a separate type for content-addressed replacement without line numbers; not processed by `applyHashlineEdits`.
+`ReplaceTextEdit` (`op: "replaceText"`) — content-addressed replacement without line numbers; not processed by `applyHashlineEdits`.
 
 ```typescript
 export type LineTag = { line: number; hash: string };
@@ -46,7 +46,7 @@ export type HashlineEdit =
 
 ## Staleness Detection
 
-`applyHashlineEdits` validates all refs before any mutation. Computes `actualHash = computeLineHash(line, fileLines[line-1])` for each ref; if any mismatch, throws `HashlineMismatchError` with all mismatches and current file lines. No partial mutations.
+Pre-validates all refs before mutation. For each ref, computes `actualHash = computeLineHash(line, fileLines[line-1])`; any mismatch throws `HashlineMismatchError` with all mismatches and current file lines. No partial mutations.
 
 **HashlineMismatchError** output:
 
@@ -60,25 +60,21 @@ export type HashlineEdit =
 >>> 13#KT:// updated comment
 ```
 
-- `>>>` marks mismatched lines with their **current** `LINE#HASH`
-- Context: 2 lines above/below each mismatch; `...` separates non-contiguous regions
-- `remaps`: `Map<"LINE#OLD_HASH", "LINE#NEW_HASH">` for programmatic correction
+`>>>` marks mismatched lines with **current** `LINE#HASH` (2 lines context; `...` separates regions). `remaps`: `Map<"LINE#OLD_HASH", "LINE#NEW_HASH">` for programmatic correction.
 
-**Error recovery**: on `HashlineMismatchError`, use `error.remaps` to update stale refs, re-read the file, recompute edits, retry. Check `result.noopEdits` (edits with no effect) and `result.warnings` for non-fatal issues.
+**Recovery**: use `error.remaps` to update stale refs, re-read file, recompute edits, retry. Check `result.noopEdits` and `result.warnings`.
 
 ## Edit Application: `applyHashlineEdits`
 
-Returns `{ content, firstChangedLine, warnings?, noopEdits? }`.
-
-**Pipeline**: (1) split into `fileLines[]` + `originalFileLines[]` snapshot; (2) build `explicitlyTouchedLines: Set<number>`; (3) pre-validate refs; (4) deduplicate same `op+line+content`; (5) sort bottom-up; (6) apply with autocorrect; (7) return content + `firstChangedLine` + `noopEdits`.
+Returns `{ content, firstChangedLine, warnings?, noopEdits? }`. Pipeline: (1) split `fileLines[]` + `originalFileLines[]` snapshot; (2) build `explicitlyTouchedLines: Set<number>`; (3) pre-validate refs; (4) deduplicate `op+line+content`; (5) sort bottom-up; (6) apply with autocorrect; (7) return result.
 
 **Sort order** — primary: `sortLine` descending (`set`→`tag.line`, `replace`→`last.line`, `append`→`after.line`/EOF, `prepend`→`before.line`/0, `insert`→`before.line`). Secondary: precedence ascending (`set`/`replace`: 0, `append`: 1, `prepend`: 2, `insert`: 3). Tertiary: original index (stable).
 
-**Bottom-up is mandatory**: apply highest-line-first to avoid shifting line numbers for subsequent edits. `applyHashlineEdits` handles this; custom implementations must replicate it.
+**Bottom-up mandatory**: highest-line-first avoids shifting line numbers for subsequent edits. `applyHashlineEdits` handles this; custom implementations must replicate.
 
-**Noop detection** — if `newLines` equals `origLines` element-by-element after autocorrect, edit is recorded in `noopEdits` and not applied. Prevents spurious writes when model re-emits unchanged content.
+**Noop detection** — `newLines` equals `origLines` element-by-element after autocorrect → recorded in `noopEdits`, not applied. Prevents spurious writes on unchanged content.
 
-**Deduplication key format** (`\n`-joined `content[]`):
+**Dedup key format** (`\n`-joined `content[]`):
 
 ```text
 "s:{line}:{content}"             // set
@@ -94,7 +90,7 @@ Enabled when `PI_HL_AUTOCORRECT=1`. All heuristics bypassed without it.
 
 ### 1. Anchor echo stripping
 
-Models often include the anchor line in replacement content even though it's not being replaced.
+Models often echo the anchor line in replacement content despite it not being replaced.
 
 | Function | Op | Strips |
 |----------|----|--------|
@@ -105,15 +101,15 @@ Models often include the anchor line in replacement content even though it's not
 
 ### 2. Line merge detection: `maybeExpandSingleLineMerge`
 
-Only triggered for `set` with `content.length === 1`. Detects when a model merges two adjacent lines into one.
+Triggered only for `set` with `content.length === 1`. Detects model merging two adjacent lines into one.
 
-- **Case A — absorbed next line**: `origLooksLikeContinuation` when `stripTrailingContinuationTokens` shortens the canonical form. Continuation tokens: `&&`, `||`, `??`, `?`, `:`, `=`, `,`, `+`, `-`, `*`, `/`, `.`, `(`. Result: `{ startLine: line, deleteCount: 2 }`.
-- **Case B — absorbed previous line**: previous line ends with continuation token; uses `stripMergeOperatorChars` (removes `|`, `&`, `?`) for operator changes like `||` → `??`. Result: `{ startLine: line-1, deleteCount: 2 }`.
-- **Guard**: `explicitlyTouchedLines` prevents merge detection from consuming a line targeted by another edit.
+- **Case A — absorbed next**: `origLooksLikeContinuation` when `stripTrailingContinuationTokens` shortens canonical form. Tokens: `&&`, `||`, `??`, `?`, `:`, `=`, `,`, `+`, `-`, `*`, `/`, `.`, `(`. → `{ startLine: line, deleteCount: 2 }`.
+- **Case B — absorbed previous**: previous line ends with continuation token; `stripMergeOperatorChars` (removes `|`, `&`, `?`) for operator changes like `||` → `??`. → `{ startLine: line-1, deleteCount: 2 }`.
+- **Guard**: `explicitlyTouchedLines` prevents consuming a line targeted by another edit.
 
 ### 3. Wrapped line restoration: `restoreOldWrappedLines`
 
-Models sometimes reflow a single logical line into multiple lines. Builds `canonToOld: Map<strippedContent, { line, count }>` from `oldLines`; for each span of 2-10 consecutive `newLines`, if `canonSpan` matches a unique old line (`count=1`, `length >= 6`) and is unique in new output, restores it back-to-front via `splice`.
+Detects model reflowing a single logical line into multiple. Builds `canonToOld: Map<strippedContent, { line, count }>` from `oldLines`; for spans of 2-10 consecutive `newLines`, if `canonSpan` matches a unique old line (`count=1`, `length >= 6`) and is unique in new output, restores back-to-front via `splice`.
 
 ### 4. Indent restoration: `restoreIndentForPairedReplacement`
 
@@ -126,7 +122,7 @@ Only when `oldLines.length === newLines.length`. For each pair: if `newLines[i]`
 | `streamHashLinesFromUtf8(source, options)` | `ReadableStream<Uint8Array>` or `AsyncIterable<Uint8Array>` | Decodes UTF-8 incrementally, handles partial chunks |
 | `streamHashLinesFromLines(lines, options)` | `Iterable<string>` or `AsyncIterable<string>` | Simpler path when lines are pre-split |
 
-**`HashlineStreamOptions`**: `startLine` (default: 1), `maxChunkLines` (default: 200), `maxChunkBytes` (default: 65536). Chunks flush when either limit is reached; final chunk always flushes at stream end.
+**`HashlineStreamOptions`**: `startLine` (1), `maxChunkLines` (200), `maxChunkBytes` (65536). Flushes on either limit; final chunk flushes at stream end.
 
 ## Related Files
 


### PR DESCRIPTION
## Summary

Tighten `.agents/reference/hashline-edit-format.md` from 139 → 135 lines via prose compression with zero knowledge loss.

**Classification**: Reference corpus (technical doc of `oh-my-pi/packages/coding-agent/src/patch/hashline.ts`). Below 300-line split threshold — terse pass applied, no chapter split needed.

## Changes

- Compress intro, code block annotations, and section descriptions (remove filler words: "all", "surrounding", "optional", "same", "the")
- Merge 3-item bullet list (error output markers) into single dense paragraph
- Merge return type + pipeline description into single line
- Shorten heading labels ("Deduplication" → "Dedup", "Error recovery" → "Recovery", "Hash collision" → "Collision")
- Compress autocorrect heuristic descriptions (remove redundant "line" in "absorbed next line")
- Simplify `HashlineStreamOptions` defaults notation (remove "default:" prefix)

## Content Preservation

All technical knowledge preserved:
- All function names, type definitions, regex patterns
- All code blocks (TypeScript types, dedup keys, error output format)
- All tables (operations, anchor echo stripping, streaming formatters, related files)
- All 4 autocorrect heuristics with full detail
- Hash algorithm, collision stats, sort order, pipeline, noop detection

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — no runtime behavior change, content-only edit
- `markdownlint-cli2`: 0 errors

Closes #14003

---
[aidevops.sh](https://aidevops.sh) v3.5.455 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 3m and 8,380 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Hashline Edit Format specification documentation for improved clarity. Changes include refined distinctions between display and reference formats in examples, adjusted wording in key sections, tightened phrasing around edit operations and staleness detection, and explicit streaming option defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->