### PR TITLE
GH#13999: tighten onboarding wizard simplification docs

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -17,17 +17,23 @@ subagents: [setup, troubleshooting, api-key-setup, list-keys, mcp-integrations, 
 - **Credentials**: `~/.config/aidevops/credentials.sh` (600 perms) | `configs/*-config.json` (600, gitignored) | `~/.config/coderabbit/api_key` (600)
 - **Set keys**: `setup-local-api-keys.sh set NAME "value"` | **List**: `list-keys-helper.sh`
 
-**OpenCode Setup**: NEVER manually write `opencode.json`. Run `generate-opencode-agents.sh`. Won't start? `mv ~/.config/opencode/opencode.json{,.broken}` then re-run. JSON fixes: `"tools": {}` not `[]` | add `"type": "local"` or `"type": "remote"` | `"tool_name": true` not `{...}`. Verify: `jq . ~/.config/opencode/opencode.json > /dev/null`
+**OpenCode setup rule**: NEVER manually write `opencode.json`. Run `generate-opencode-agents.sh`.
+If OpenCode fails to start: `mv ~/.config/opencode/opencode.json{,.broken}` and re-run.
+If hand-fixing JSON: `"tools": {}` (not `[]`), include `"type": "local"` or `"type": "remote"`, and use `"tool_name": true` (not objects). Verify with `jq . ~/.config/opencode/opencode.json > /dev/null`.
 
 <!-- AI-CONTEXT-END -->
 
 ## Welcome Flow
 
-1. **Introduction** — ask if they want an explanation of capabilities: Orchestration, Infrastructure (Hetzner, Hostinger, Cloudron, Coolify), Domains/DNS (Cloudflare, Spaceship, 101domains), Git (GitHub, GitLab, Gitea), Code Quality (SonarCloud, Codacy, CodeRabbit, Snyk), WordPress (LocalWP, MainWP), SEO (DataForSEO, Serper, GSC), Browser (Playwright, Stagehand), Context (Augment, Context7, Repomix)
-2. **Concept familiarity** — ask which they know (Git, Terminal, API keys, Hosting, SEO, AI assistants). Save: `onboarding-helper.sh save-concepts 'git,terminal'`
-3. **Work type** — ask what they do (web dev, DevOps, SEO, WordPress, other). Save: `onboarding-helper.sh save-work-type devops`
-4. **Current status** — `onboarding-helper.sh status` — show configured vs needs-setup
-5. **Guide setup** — for each service: explain purpose, link to credentials, setup command, verification
+1. **Introduce capabilities** (only if wanted): orchestration; infrastructure (Hetzner, Hostinger, Cloudron, Coolify); domains/DNS (Cloudflare, Spaceship, 101domains); Git (GitHub, GitLab, Gitea); code quality (SonarCloud, Codacy, CodeRabbit, Snyk); WordPress (LocalWP, MainWP); SEO (DataForSEO, Serper, GSC); browser automation (Playwright, Stagehand); context tools (Augment, Context7, Repomix).
+2. **Capture concept familiarity** (Git, terminal, API keys, hosting, SEO, AI assistants):
+   - `onboarding-helper.sh save-concepts 'git,terminal'`
+3. **Capture work type** (web-dev, devops, seo, wordpress, other):
+   - `onboarding-helper.sh save-work-type devops`
+4. **Show current status**:
+   - `onboarding-helper.sh status`
+5. **Guide service-by-service setup**:
+   - purpose → credential source → setup command → verification
 
 ## Service Catalog
 
@@ -64,7 +70,7 @@ subagents: [setup, troubleshooting, api-key-setup, list-keys, mcp-integrations, 
 | Domains | 101domains | `configs/101domains-config.json` | — |
 | Secrets | Vaultwarden | `configs/vaultwarden-config.json` | — |
 
-CodeRabbit key: `mkdir -p ~/.config/coderabbit && echo "key" > ~/.config/coderabbit/api_key && chmod 600 ~/.config/coderabbit/api_key`
+CodeRabbit key file: `mkdir -p ~/.config/coderabbit && chmod 700 ~/.config/coderabbit` then write key to `~/.config/coderabbit/api_key` and `chmod 600 ~/.config/coderabbit/api_key`.
 
 SEO commands: `/keyword-research`, `/autocomplete-research`, `/keyword-research-extended`, `/webmaster-keywords`
 
@@ -78,6 +84,8 @@ Tiers: (1) Native local, (2) OrbStack container, (3) Remote VPS with Tailscale. 
 
 ## Verification
 
+Run what applies to the selected stack:
+
 ```bash
 gh auth status && glab auth status
 hcloud server list
@@ -87,38 +95,26 @@ auggie token print && openclaw doctor && tailscale status && orb status
 ~/.aidevops/agents/scripts/list-keys-helper.sh
 ```
 
-## Recommended Setup Order
-
-| Profile | Priority order |
-|---------|---------------|
-| Web Developer | GitHub CLI → OpenAI → Augment → Playwright |
-| DevOps Engineer | GitHub/GitLab CLI → Hetzner → Cloudflare → Tailscale → Coolify → OrbStack → SonarCloud/Codacy → Supervisor pulse |
-| SEO Professional | DataForSEO → Serper → Google Search Console → Outscraper |
-| WordPress Developer | LocalWP → MainWP → GitHub CLI → Hostinger |
-| Full Stack | All Git CLIs → OpenAI/Anthropic → Augment → Hetzner/Cloudflare → Tailscale → OrbStack → Code quality → Supervisor pulse → DataForSEO → OpenClaw |
-
 ## Troubleshooting
 
 ```bash
 # Key not loading
 grep "credentials.sh" ~/.zshrc ~/.bashrc && source ~/.config/aidevops/credentials.sh
+
 # MCP not connecting
 opencode mcp list && ~/.aidevops/agents/scripts/mcp-diagnose.sh <name>
+
 # Permission denied
 chmod 600 ~/.config/aidevops/credentials.sh && chmod 700 ~/.config/aidevops
 ```
 
 ## Agents & Commands
 
-**Agent layers**: Main agents (Tab key) → Subagents (`@name`) → Commands (`/name`)
-
-**Main agents**: `Build+` (coding/DevOps), `SEO` (search optimization), `WordPress` (WP ecosystem)
-
-**Common subagents**: `@hetzner`, `@cloudflare`, `@coolify`, `@vercel`, `@github-cli`, `@dataforseo`, `@augment-context-engine`, `@code-standards`, `@wp-dev`
-
-**Project init**: `cd ~/your-project && aidevops init`
-
-**Key commands**: `/create-prd`, `/generate-tasks`, `/feature`, `/bugfix`, `/hotfix`, `/pr`, `/preflight`, `/release`, `/linters-local`, `/keyword-research`
+- **Agent layers**: Main agents (Tab key) → subagents (`@name`) → commands (`/name`)
+- **Main agents**: `Build+`, `SEO`, `WordPress`
+- **Common subagents**: `@hetzner`, `@cloudflare`, `@coolify`, `@vercel`, `@github-cli`, `@dataforseo`, `@augment-context-engine`, `@code-standards`, `@wp-dev`
+- **Project init**: `cd ~/your-project && aidevops init`
+- **Key commands**: `/create-prd`, `/generate-tasks`, `/feature`, `/bugfix`, `/hotfix`, `/pr`, `/preflight`, `/release`, `/linters-local`, `/keyword-research`
 
 ## Repo Sync & Orchestration
 
@@ -126,19 +122,20 @@ chmod 600 ~/.config/aidevops/credentials.sh && chmod 700 ~/.config/aidevops
 # Configure git parent directories for repo sync
 jq --argjson dirs '["~/Git", "~/Projects"]' '. + {git_parent_dirs: $dirs}' \
   ~/.config/aidevops/repos.json > /tmp/repos.json && mv /tmp/repos.json ~/.config/aidevops/repos.json
+
 aidevops repo-sync enable
+
 # Enable autonomous orchestration
 ~/.aidevops/agents/scripts/onboarding-helper.sh save-orchestration true
+
 # See scripts/commands/runners.md for launchd (macOS) and cron (Linux) setup
 ```
 
-Settings: `settings-helper.sh list` to see all sections. Cost note: subscription plans (Claude Max/Pro, OpenAI Pro/Plus) are cheaper than API for sustained use.
+Settings: `settings-helper.sh list` to inspect sections. Cost note: subscription plans (Claude Max/Pro, OpenAI Pro/Plus) are usually cheaper than API for sustained use.
 
 ## Next Steps After Setup
 
 1. **Create playground**: `mkdir ~/Git/aidevops-playground && cd ~/Git/aidevops-playground && git init && aidevops init`
-2. **Test**: "List my GitHub repos" or "Check my Hetzner servers"
-3. **Enable orchestration**: see `scripts/commands/runners.md`
-4. **Try a workflow**: `/create-prd` → `/generate-tasks` → `/feature` → build → `/release`
-5. **Try autonomous mode**: Add `#auto-dispatch` to a TODO.md task
-6. **Read the docs**: `@aidevops` for framework guidance
+2. **Smoke test**: "List my GitHub repos" or "Check my Hetzner servers"
+3. **Run one flow**: `/create-prd` → `/generate-tasks` → `/feature` → build → `/release`
+4. **Enable orchestration/autonomy**: `scripts/commands/runners.md` then add `#auto-dispatch` to a TODO.md task


### PR DESCRIPTION
## Summary
- Tightened `.agents/aidevops/onboarding.md` by reducing verbosity while preserving onboarding steps, setup commands, and service coverage.
- Reworked the welcome flow and command sections for faster scanning and clearer action-oriented phrasing.
- Removed duplicated setup-order guidance and improved credential handling wording for CodeRabbit key file setup.

## Testing Evidence
- `npx markdownlint-cli2 ".agents/aidevops/onboarding.md"`

## Runtime Testing
- Level: self-assessed (low risk docs-only change)

Closes #13999

---
[aidevops.sh](https://aidevops.sh) v3.5.455 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 6m and 134,989 tokens on this as a headless worker.