### PR TITLE
GH#14148: enforce mode-aware full-loop signature provenance

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -97,7 +97,13 @@ Changelog: `feat:` → Added, `fix:` → Fixed, `docs:`/`perf:`/`refactor:` → 
 
 **4.1 Preflight** — quality checks, auto-fixes.
 
-**4.2 PR Create** — rebase onto `origin/main`, push, create PR. Body MUST include `Closes #NNN` (MANDATORY). Add `origin:worker` or `origin:interactive` label. **Signature footer (GH#12805 — MANDATORY):** `SIG_FOOTER=$(gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL")` — append to body, verify with `gh pr view --json body -q .body | grep -q 'aidevops.sh'`; edit to add if missing.
+**4.2 PR Create** — rebase onto `origin/main`, push, create PR. Body MUST include `Closes #NNN` (MANDATORY). Add `origin:worker` or `origin:interactive` label. **Signature footer (GH#12805 — MANDATORY):** append `gh-signature-helper.sh footer` output with explicit mode and issue context so provenance remains audit-grade in both interactive and headless runs.
+
+- Interactive `/full-loop` (default): `SIG_FOOTER=$(gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" --issue "$REPO#$ISSUE_NUM" --session-type interactive)`
+- Headless `/full-loop` (`FULL_LOOP_HEADLESS=true`): `SIG_FOOTER=$(gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" --issue "$REPO#$ISSUE_NUM" --no-session --session-type worker --time "$WORKER_ELAPSED_SECS")`
+- If token telemetry is available, pass `--tokens "$WORKER_TOKENS"`; if unavailable, omit token override (do not fabricate).
+
+Append footer to PR body, then verify the final body includes `aidevops.sh` **and** either `spent` or `Overall,` (time provenance present): `gh pr view --json body -q .body | grep -q 'aidevops.sh' && gh pr view --json body -q .body | grep -Eq 'spent|Overall,'`.
 
 **4.3 Label `status:in-review` (t1343)** — check issue is `OPEN` first. `status:done` set by `sync-on-pr-merge` — workers don't set it.
 


### PR DESCRIPTION
## Summary
- tighten `/full-loop` Step 4.2 so signature footer generation is mode-aware (interactive vs headless worker)
- require issue-context and session-type arguments to improve provenance and self-activity triage reliability
- require PR-body verification for both aidevops signature marker and time provenance text (`spent` or `Overall,`)

## Testing
- `bash .agents/scripts/markdown-formatter.sh check ".agents/scripts/commands/full-loop.md"`

Closes #14148

---
[aidevops.sh](https://aidevops.sh) v3.5.454 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 3h 51m and 5,079,225 tokens on this with the user in an interactive session. Overall, 1h 1m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR creation workflow to support context-specific footer generation for interactive and headless modes.
  * Enhanced PR body verification to include time-provenance validation in addition to existing signature checks.
  * Improved token telemetry handling to conditionally include metrics only when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->