### PR TITLE
GH#14152: tighten research.md (113→106 lines)

### DIFF
--- a/.agents/reference/define-probes/research.md
+++ b/.agents/reference/define-probes/research.md
@@ -16,7 +16,7 @@ Apply these unless the user overrides during interview:
 - Compare at least 2 options (never recommend without alternatives)
 - Include cost/effort estimates for each option
 
-## Structured Questions
+## Required Questions
 
 ### Time Box
 
@@ -103,11 +103,4 @@ After this research is done, what's the next concrete action?
 
 ## Sufficiency Test
 
-Before generating the brief, verify you can answer:
-
-- What's the time box?
-- What format is the deliverable?
-- What are the decision criteria, ranked?
-- Who makes the final decision?
-
-If any answer is "I don't know" — ask one more targeted question.
+Before generating the brief, verify: time box, deliverable format, ranked decision criteria, and who decides. If any is unknown, ask one more targeted question.


### PR DESCRIPTION
## Summary

- Renamed `## Structured Questions` → `## Required Questions` to clarify semantics (always-asked vs pick-2 probes)
- Compacted Sufficiency Test from 8 lines to 1 line — all 4 checklist items preserved inline (time box, deliverable format, ranked decision criteria, who decides)
- Zero content loss: all 7 code blocks, all numbered options, all default assumptions unchanged

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, content preservation verified via diff

Closes #14152

---
[aidevops.sh](https://aidevops.sh) v3.5.456 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 2m and 5,347 tokens on this with the user in an interactive session. Overall, 19m since this issue was created.