### PR TITLE
GH#14150: tighten sandbox-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md
@@ -1,21 +1,15 @@
 # Common Patterns
 
-All patterns use the Worker boilerplate from `sandbox.md` Quick Start. Subsequent examples show only the handler body.
+Handler-body-only examples — all use the Worker boilerplate from `sandbox.md` Quick Start.
 
-## AI Code Execution Agent
+## AI Code Execution
 
 ```typescript
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const { code } = await request.json();
-    const sandbox = getSandbox(env.Sandbox, 'ai-agent');
-    await sandbox.writeFile('/workspace/user_code.py', code);
-    const result = await sandbox.exec('python3 /workspace/user_code.py');
-    return Response.json({
-      output: result.stdout, error: result.stderr, success: result.success
-    });
-  }
-};
+const { code } = await request.json();
+const sandbox = getSandbox(env.Sandbox, 'ai-agent');
+await sandbox.writeFile('/workspace/user_code.py', code);
+const result = await sandbox.exec('python3 /workspace/user_code.py');
+return Response.json({ output: result.stdout, error: result.stderr, success: result.success });
 ```
 
 ## Interactive Dev Environment
@@ -60,7 +54,7 @@ const result = await sandbox.exec(`${config.cmd} ${filename}`);
 return Response.json({ output: result.stdout, error: result.stderr, exitCode: result.exitCode });
 ```
 
-## Multi-Tenant Pattern
+## Multi-Tenant
 
 ```typescript
 const userId = request.headers.get('X-User-ID');
@@ -79,7 +73,7 @@ return Response.json({ output: result.stdout });
 
 **Dockerfile**: `FROM docker.io/cloudflare/sandbox:latest` + `RUN pip3 install --no-cache-dir jupyter-server ipykernel matplotlib pandas` + `EXPOSE 8888`
 
-**Worker** (interactive notebook):
+**Interactive notebook**:
 
 ```typescript
 await sandbox.startProcess('jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser', {


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md` (113 → 107 lines) by removing structural noise while preserving all knowledge.

Closes #14150

## Changes

- **Remove redundant boilerplate wrapper** from the AI Code Execution pattern — the intro states "handler-body-only examples" but the first pattern included the full `export default { async fetch() { ... } }` wrapper. Now consistent with all other patterns.
- **Tighten intro line** — two-clause sentence → concise one-liner
- **Remove noise words from headings** — "AI Code Execution Agent" → "AI Code Execution", "Multi-Tenant Pattern" → "Multi-Tenant"
- **Simplify Jupyter sub-heading** — "**Worker** (interactive notebook)" → "**Interactive notebook**" (redundant since entire file is Worker patterns)

## Content Preservation

All 7 patterns preserved. Every API call (`getSandbox`, `exec`, `writeFile`, `readFile`, `startProcess`, `exposePort`, `createSession`, `getSession`), URL, option, and technique is present in the output.

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, diff reviewed for knowledge loss


---
[aidevops.sh](https://aidevops.sh) v3.5.456 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 3m and 6,334 tokens on this with the user in an interactive session. Overall, 20m since this issue was created.