### PR TITLE
GH#14173: scope signature token detection to issue context

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -372,7 +372,46 @@ _find_session_id() {
 	return 0
 }
 
-_detect_session_tokens() {
+# Sum non-cached input + output tokens for a session.
+# Args:
+#   $1 - sqlite db path
+#   $2 - session ID
+#   $3 - since milliseconds epoch (optional; include messages >= this time)
+# Output: integer token count (may be 0)
+_sum_session_tokens_for_session() {
+	local db_path="$1"
+	local session_id="$2"
+	local since_ms="${3:-}"
+
+	local since_filter=""
+	if [[ -n "$since_ms" ]] && [[ "$since_ms" =~ ^[0-9]+$ ]] && [[ "$since_ms" -gt 0 ]]; then
+		since_filter="AND time_created >= ${since_ms}"
+	fi
+
+	sqlite3 "$db_path" "
+		SELECT COALESCE(SUM(
+			CASE
+				WHEN json_extract(data, '$.tokens.input') >
+				     COALESCE(json_extract(data, '$.tokens.cache.read'), 0)
+				THEN MAX(
+					json_extract(data, '$.tokens.input')
+					- COALESCE(json_extract(data, '$.tokens.cache.read'), 0)
+					- COALESCE(json_extract(data, '$.tokens.cache.write'), 0),
+					0)
+				ELSE json_extract(data, '$.tokens.input')
+			END
+			+ json_extract(data, '$.tokens.output')
+		), 0)
+		FROM message
+		WHERE session_id='${session_id}'
+		  AND json_extract(data, '$.tokens.input') > 0
+		  ${since_filter}
+	" 2>/dev/null || echo ""
+	return 0
+}
+
+_detect_session_tokens_with_since() {
+	local since_epoch="${1:-}"
 	local db_path="${HOME}/.local/share/opencode/opencode.db"
 
 	# If the OpenCode DB exists, try it — don't gate on process detection.
@@ -391,37 +430,75 @@ _detect_session_tokens() {
 		return 0
 	fi
 
-	# Sum non-cached input + output tokens only.
-	# OpenCode >= v1.3.5 stores tokens.input as total input (including
-	# cache.read + cache.write). Earlier versions stored only non-cached input.
-	# Detect which format per-message: if input > cache.read, input includes
-	# cache — subtract cache.read + cache.write. Otherwise use input as-is.
-	# Clamp to 0 to avoid negatives from rounding.
+	local since_ms=""
+	if [[ -n "$since_epoch" ]] && [[ "$since_epoch" =~ ^[0-9]+$ ]] && [[ "$since_epoch" -gt 0 ]]; then
+		since_ms=$((since_epoch * 1000))
+	fi
+
 	local total_tokens
-	total_tokens=$(sqlite3 "$db_path" "
-		SELECT COALESCE(SUM(
-			CASE
-				WHEN json_extract(data, '$.tokens.input') >
-				     COALESCE(json_extract(data, '$.tokens.cache.read'), 0)
-				THEN MAX(
-					json_extract(data, '$.tokens.input')
-					- COALESCE(json_extract(data, '$.tokens.cache.read'), 0)
-					- COALESCE(json_extract(data, '$.tokens.cache.write'), 0),
-					0)
-				ELSE json_extract(data, '$.tokens.input')
-			END
-			+ json_extract(data, '$.tokens.output')
-		), 0)
-		FROM message
-		WHERE session_id='${session_id}'
-		  AND json_extract(data, '$.tokens.input') > 0
-	" 2>/dev/null || echo "")
+	total_tokens=$(_sum_session_tokens_for_session "$db_path" "$session_id" "$since_ms")
 
 	if [[ -n "$total_tokens" ]] && [[ "$total_tokens" -gt 0 ]] 2>/dev/null; then
 		echo "$total_tokens"
 	else
 		echo ""
 	fi
+	return 0
+}
+
+_detect_session_tokens() {
+	_detect_session_tokens_with_since ""
+	return 0
+}
+
+# Resolve issue creation time to epoch seconds.
+# Args: issue_ref (OWNER/REPO#NUM), issue_created ISO timestamp
+# Output: epoch seconds, or empty string if unavailable
+_resolve_issue_created_epoch() {
+	local issue_ref="$1"
+	local issue_created="$2"
+
+	if [[ -n "$issue_created" ]]; then
+		if date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" &>/dev/null 2>&1; then
+			date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" 2>/dev/null || echo ""
+			return 0
+		fi
+		date -d "$issue_created" "+%s" 2>/dev/null || echo ""
+		return 0
+	fi
+
+	if [[ -n "$issue_ref" ]] && command -v gh &>/dev/null; then
+		local repo_slug issue_number created_at
+		repo_slug="${issue_ref%%#*}"
+		issue_number="${issue_ref##*#}"
+		if [[ -n "$repo_slug" ]] && [[ -n "$issue_number" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+			created_at=$(gh api "repos/${repo_slug}/issues/${issue_number}" --jq '.created_at' 2>/dev/null || echo "")
+			if [[ -n "$created_at" ]]; then
+				_resolve_issue_created_epoch "" "$created_at"
+				return 0
+			fi
+		fi
+	fi
+
+	echo ""
+	return 0
+}
+
+# Detect session tokens scoped to issue creation time when issue context is known.
+# Args: issue_ref (OWNER/REPO#NUM), issue_created ISO timestamp
+# Output: scoped token count, or empty when issue timestamp/session unavailable.
+_detect_issue_scoped_tokens() {
+	local issue_ref="$1"
+	local issue_created="$2"
+
+	local issue_created_epoch
+	issue_created_epoch=$(_resolve_issue_created_epoch "$issue_ref" "$issue_created")
+	if [[ -z "$issue_created_epoch" ]] || ! [[ "$issue_created_epoch" =~ ^[0-9]+$ ]] || [[ "$issue_created_epoch" -le 0 ]]; then
+		echo ""
+		return 0
+	fi
+
+	_detect_session_tokens_with_since "$issue_created_epoch"
 	return 0
 }
 
@@ -627,8 +704,8 @@ _detect_total_time() {
 
 	if [[ -n "$issue_created" ]]; then
 		local created_epoch now_epoch
-		if date -j -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" &>/dev/null 2>&1; then
-			created_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" 2>/dev/null || echo "")
+		if date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" &>/dev/null 2>&1; then
+			created_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" 2>/dev/null || echo "")
 		else
 			created_epoch=$(date -d "$issue_created" "+%s" 2>/dev/null || echo "")
 		fi
@@ -980,9 +1057,16 @@ cmd_generate() {
 			model=$(_detect_session_model)
 		fi
 
-		# Auto-detect tokens from session DB if not provided
+		# Auto-detect tokens from session DB if not provided.
+		# When issue context is provided, scope tokens to issue lifetime first
+		# (prevents unrelated early-session work inflating issue/PR signatures).
 		if [[ -z "$tokens" ]]; then
-			tokens=$(_detect_session_tokens)
+			if [[ -n "$issue_ref" ]] || [[ -n "$issue_created" ]]; then
+				tokens=$(_detect_issue_scoped_tokens "$issue_ref" "$issue_created")
+			fi
+			if [[ -z "$tokens" ]]; then
+				tokens=$(_detect_session_tokens)
+			fi
 		fi
 
 		# Collect time metrics

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -438,7 +438,7 @@ _detect_session_tokens_with_since() {
 	local total_tokens
 	total_tokens=$(_sum_session_tokens_for_session "$db_path" "$session_id" "$since_ms")
 
-	if [[ -n "$total_tokens" ]] && [[ "$total_tokens" -gt 0 ]] 2>/dev/null; then
+	if [[ -n "$total_tokens" ]] && [[ "$total_tokens" =~ ^[0-9]+$ ]]; then
 		echo "$total_tokens"
 	else
 		echo ""
@@ -459,12 +459,17 @@ _resolve_issue_created_epoch() {
 	local issue_created="$2"
 
 	if [[ -n "$issue_created" ]]; then
+		local parsed_epoch=""
 		if date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" &>/dev/null 2>&1; then
-			date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" 2>/dev/null || echo ""
+			parsed_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$issue_created" "+%s" 2>/dev/null || echo "")
+		elif date -d "$issue_created" "+%s" &>/dev/null 2>&1; then
+			parsed_epoch=$(date -d "$issue_created" "+%s" 2>/dev/null || echo "")
+		fi
+
+		if [[ -n "$parsed_epoch" ]]; then
+			echo "$parsed_epoch"
 			return 0
 		fi
-		date -d "$issue_created" "+%s" 2>/dev/null || echo ""
-		return 0
 	fi
 
 	if [[ -n "$issue_ref" ]] && command -v gh &>/dev/null; then

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -238,10 +238,63 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test 14: help command exits cleanly
+# Test 14: issue-created scopes token detection to issue window
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 14: help command"
+echo "Test 14: issue-created token scoping"
+tmp_home=$(mktemp -d 2>/dev/null || mktemp -d -t sighelper)
+mkdir -p "${tmp_home}/.local/share/opencode"
+db_path="${tmp_home}/.local/share/opencode/opencode.db"
+
+now_epoch=$(date +%s)
+session_created_ms=$(((now_epoch - 3600) * 1000))
+pre_msg_ms=$(((now_epoch - 1200) * 1000))
+issue_created_epoch=$((now_epoch - 600))
+post_msg_ms=$(((now_epoch - 300) * 1000))
+
+issue_created_iso=$(date -u -r "$issue_created_epoch" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+	date -u -d "@${issue_created_epoch}" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+
+cwd_sql=$(pwd)
+cwd_sql=${cwd_sql//\'/\'\'}
+
+sqlite3 "$db_path" "
+CREATE TABLE session (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  directory TEXT NOT NULL,
+  time_created INTEGER NOT NULL
+);
+CREATE TABLE message (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL,
+  data TEXT NOT NULL
+);
+INSERT INTO session (id,title,directory,time_created)
+VALUES ('ses_test_scope','sig-test','${cwd_sql}',${session_created_ms});
+INSERT INTO message (id,session_id,time_created,time_updated,data)
+VALUES
+  ('msg_pre','ses_test_scope',${pre_msg_ms},${pre_msg_ms},'{\"tokens\":{\"input\":100,\"output\":10,\"cache\":{\"read\":0,\"write\":0}},\"role\":\"assistant\"}'),
+  ('msg_post','ses_test_scope',${post_msg_ms},${post_msg_ms},'{\"tokens\":{\"input\":200,\"output\":20,\"cache\":{\"read\":0,\"write\":0}},\"role\":\"assistant\"}');
+"
+
+if [[ -n "$issue_created_iso" ]]; then
+	result=$(HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_created_iso")
+	assert_contains "issue window uses scoped tokens" "220 tokens on this" "$result"
+	assert_not_contains "issue window excludes pre-issue tokens" "330 tokens on this" "$result"
+else
+	echo "  SKIP: could not construct issue-created timestamp"
+fi
+
+rm -rf "$tmp_home"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 15: help command exits cleanly
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 15: help command"
 result=$("$HELPER" help 2>&1)
 assert_contains "help shows usage" "Usage:" "$result"
 assert_contains "help shows examples" "Examples:" "$result"

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -258,7 +258,8 @@ issue_created_iso=$(date -u -r "$issue_created_epoch" "+%Y-%m-%dT%H:%M:%SZ" 2>/d
 cwd_sql=$(pwd)
 cwd_sql=${cwd_sql//\'/\'\'}
 
-sqlite3 "$db_path" "
+if command -v sqlite3 &>/dev/null; then
+	sqlite3 "$db_path" "
 CREATE TABLE session (
   id TEXT PRIMARY KEY,
   title TEXT,
@@ -280,12 +281,26 @@ VALUES
   ('msg_post','ses_test_scope',${post_msg_ms},${post_msg_ms},'{\"tokens\":{\"input\":200,\"output\":20,\"cache\":{\"read\":0,\"write\":0}},\"role\":\"assistant\"}');
 "
 
-if [[ -n "$issue_created_iso" ]]; then
-	result=$(HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_created_iso")
-	assert_contains "issue window uses scoped tokens" "220 tokens on this" "$result"
-	assert_not_contains "issue window excludes pre-issue tokens" "330 tokens on this" "$result"
+	if [[ -n "$issue_created_iso" ]]; then
+		result=$(HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_created_iso")
+		assert_contains "issue window uses scoped tokens" "220 tokens on this" "$result"
+		assert_not_contains "issue window excludes pre-issue tokens" "330 tokens on this" "$result"
+
+		issue_after_epoch=$((now_epoch - 60))
+		issue_after_iso=$(date -u -r "$issue_after_epoch" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+			date -u -d "@${issue_after_epoch}" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+		if [[ -n "$issue_after_iso" ]]; then
+			result=$(HOME="$tmp_home" "$HELPER" generate --cli "OpenCode" --model "m" --issue-created "$issue_after_iso")
+			assert_not_contains "post-window excludes pre-issue fallback" "330 tokens on this" "$result"
+			assert_not_contains "post-window omits scoped zero token phrase" "0 tokens on this" "$result"
+		else
+			echo "  SKIP: could not construct post-window issue-created timestamp"
+		fi
+	else
+		echo "  SKIP: could not construct issue-created timestamp"
+	fi
 else
-	echo "  SKIP: could not construct issue-created timestamp"
+	echo "  SKIP: sqlite3 not available"
 fi
 
 rm -rf "$tmp_home"


### PR DESCRIPTION
## Summary
- scope interactive token auto-detection to issue context when `--issue` / `--issue-created` is provided
- keep existing fallback behavior by using full-session token totals when issue timestamp resolution is unavailable
- add regression coverage with a synthetic OpenCode DB test proving pre-issue tokens are excluded

## Testing
- `bash -n .agents/scripts/gh-signature-helper.sh .agents/scripts/tests/test-gh-signature-helper.sh`
- `bash .agents/scripts/tests/test-gh-signature-helper.sh`

## Runtime Testing
- self-assessed: helper script and unit-test-only change; no production runtime surface changed

Closes #14173
---
[aidevops.sh](https://aidevops.sh) v3.5.456 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 4h 38m and 779,005 tokens on this with the user in an interactive session. Overall, 6m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added issue-scoped token counting that limits detection to messages at/after an issue's creation
  * Updated token auto-detection to prefer issue-scoped totals when issue info is provided, with session-wide fallback

* **Bug Fixes**
  * Fixed macOS UTC date parsing for accurate issue-created timestamp handling

* **Tests**
  * Updated tests to cover the new issue-scoped token behavior and adjusted help checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->