### PR TITLE
GH#14137: tighten serper.md (114→101 lines)

### DIFF
--- a/.agents/seo/serper.md
+++ b/.agents/seo/serper.md
@@ -23,75 +23,19 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Authentication
+## Setup
+
+Get API key from https://serper.dev/ and add to `~/.config/aidevops/credentials.sh`:
+
+```bash
+export SERPER_API_KEY="your_key_here"
+```
+
+Load credentials and define reusable curl options:
 
 ```bash
 source ~/.config/aidevops/credentials.sh
-```
-
-## API Endpoints
-
-### Web Search
-
-```bash
-curl -s -X POST https://google.serper.dev/search \
-  -H "X-API-KEY: $SERPER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"q": "your search query", "gl": "us", "hl": "en", "num": 10}'
-```
-
-### Image Search
-
-```bash
-curl -s -X POST https://google.serper.dev/images \
-  -H "X-API-KEY: $SERPER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"q": "your image query", "gl": "us", "num": 20}'
-```
-
-### News Search
-
-```bash
-curl -s -X POST https://google.serper.dev/news \
-  -H "X-API-KEY: $SERPER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"q": "topic", "gl": "us", "tbs": "qdr:w"}'
-```
-
-### Places/Local Search
-
-```bash
-curl -s -X POST https://google.serper.dev/places \
-  -H "X-API-KEY: $SERPER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"q": "business type", "location": "City, State"}'
-```
-
-### Shopping Search
-
-```bash
-curl -s -X POST https://google.serper.dev/shopping \
-  -H "X-API-KEY: $SERPER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"q": "product name", "gl": "us"}'
-```
-
-### Scholar Search
-
-```bash
-curl -s -X POST https://google.serper.dev/scholar \
-  -H "X-API-KEY: $SERPER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"q": "research topic", "num": 10}'
-```
-
-### Autocomplete
-
-```bash
-curl -s -X POST https://google.serper.dev/autocomplete \
-  -H "X-API-KEY: $SERPER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"q": "partial query"}'
+SERPER_CURL=(-s -X POST -H "X-API-KEY: $SERPER_API_KEY" -H "Content-Type: application/json")
 ```
 
 ## Parameters
@@ -105,10 +49,53 @@ curl -s -X POST https://google.serper.dev/autocomplete \
 | `tbs` | Time filter | `"qdr:h"` (hour), `"qdr:d"` (day), `"qdr:w"` (week), `"qdr:m"` (month) |
 | `page` | Page number | `1`, `2`, `3` |
 
-## Setup
+## API Endpoints
 
-Get API key from https://serper.dev/ and add to `~/.config/aidevops/credentials.sh`:
+### Web Search
 
 ```bash
-export SERPER_API_KEY="your_key_here"
+curl "${SERPER_CURL[@]}" https://google.serper.dev/search \
+  -d '{"q": "your search query", "gl": "us", "hl": "en", "num": 10}'
+```
+
+### Image Search
+
+```bash
+curl "${SERPER_CURL[@]}" https://google.serper.dev/images \
+  -d '{"q": "your image query", "gl": "us", "num": 20}'
+```
+
+### News Search
+
+```bash
+curl "${SERPER_CURL[@]}" https://google.serper.dev/news \
+  -d '{"q": "topic", "gl": "us", "tbs": "qdr:w"}'
+```
+
+### Places/Local Search
+
+```bash
+curl "${SERPER_CURL[@]}" https://google.serper.dev/places \
+  -d '{"q": "business type", "location": "City, State"}'
+```
+
+### Shopping Search
+
+```bash
+curl "${SERPER_CURL[@]}" https://google.serper.dev/shopping \
+  -d '{"q": "product name", "gl": "us"}'
+```
+
+### Scholar Search
+
+```bash
+curl "${SERPER_CURL[@]}" https://google.serper.dev/scholar \
+  -d '{"q": "research topic", "num": 10}'
+```
+
+### Autocomplete
+
+```bash
+curl "${SERPER_CURL[@]}" https://google.serper.dev/autocomplete \
+  -d '{"q": "partial query"}'
 ```


### PR DESCRIPTION
## Summary

- Tighten `.agents/seo/serper.md` from 114 → 101 lines (11% reduction)
- Extract repeated curl headers into a reusable `SERPER_CURL` bash array variable, eliminating 7× duplicated `-H "X-API-KEY: ..."` and `-H "Content-Type: ..."` lines
- Reorder sections by importance: Setup → Parameters → Endpoints (prerequisites first)
- Merge separate Authentication and Setup sections into one cohesive Setup block

## What changed

| Before | After |
|--------|-------|
| Auth headers repeated in every curl example (7×) | Single `SERPER_CURL` array, referenced via `${SERPER_CURL[@]}` |
| Setup section at bottom of file (line 108) | Setup section immediately after Quick Reference |
| Separate Authentication section (just `source credentials.sh`) | Merged into Setup with credential loading + array definition |
| Parameters table after all endpoints | Parameters table before endpoints (reference-first) |

## Verification

- All 7 API endpoints preserved (search, images, news, places, shopping, scholar, autocomplete)
- All 6 parameters preserved (q, gl, hl, num, tbs, page)
- All 2 external URLs preserved (google.serper.dev, serper.dev)
- YAML frontmatter unchanged
- No task IDs or incident references in original file

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — content preservation verified via `rg` extraction

Closes #14137

---
[aidevops.sh](https://aidevops.sh) v3.5.456 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 1m and 4,272 tokens on this with the user in an interactive session. Overall, 1h 37m since this issue was created.