### PR TITLE
GH#14213: harden headless runtime reliability under provider limits

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -22,6 +22,30 @@ their slots refilled immediately, not after a 3-minute restart penalty.
 needs coding, dispatch a worker. The pulse may only: read pre-fetched state, run `gh` commands
 for coordination (merge/comment/label), and dispatch workers.
 
+## Non-Interactive Continuation Contract (MANDATORY)
+
+This session is unattended. There is no human to ask for confirmation.
+
+- Never ask for permission, confirmation, or input (for example: "If you want, I can...").
+- Never stop after a single dispatch pass unless an exit condition is met.
+- After each cycle, immediately continue to the next cycle.
+
+If you output user-directed language by mistake, self-correct in the next line and continue the loop.
+
+Only exit when one of these is true:
+
+1. Elapsed runtime is at least 55 minutes
+2. Circuit breaker or stop flag is active
+3. No dispatchable work remains after re-check and all worker slots are full
+
+If `AVAILABLE > 0` and `WORKER_COUNT == 0`, you MUST attempt dispatch before sleeping:
+
+1. Managed-repo issue dispatch from pre-fetched state
+2. Targeted refresh for candidate repos if needed
+3. FOSS fallback dispatch
+
+If no worker launches, log `NO_DISPATCHABLE_EVIDENCE` with counts/reasons, sleep 60s, and continue.
+
 ## Initial Dispatch (DO THIS FIRST)
 
 Read this section, then execute it. Everything below this section is refinement.
@@ -252,6 +276,9 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    workers if idle capacity remains (same rules as Step 4.7). Use the same dedup guards
    and dispatch commands as the initial dispatch. Re-fetch issue state with targeted `gh`
    calls only for repos where you need to dispatch (not a full re-fetch of all repos).
+
+   If `AVAILABLE > 0` and `WORKER_COUNT == 0` after this step, do not exit and do not ask
+   for input. Log `NO_DISPATCHABLE_EVIDENCE`, sleep 60s, and continue the loop.
 
 5. **If fully staffed**: log it, mark the cycle todo complete, continue to next cycle.
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -21,9 +21,12 @@ readonly STATE_DB="${STATE_DIR}/state.db"
 readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"
 readonly SANDBOX_EXEC_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
 readonly DISPATCH_LEDGER_HELPER="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+readonly OAUTH_POOL_HELPER="${SCRIPT_DIR}/oauth-pool-helper.sh"
 readonly HEADLESS_SANDBOX_TIMEOUT_DEFAULT="${AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT:-3600}"
 readonly OPENCODE_AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
 readonly LOCK_DIR="${STATE_DIR}/locks"
+readonly METRICS_DIR="${HOME}/.aidevops/logs"
+readonly METRICS_FILE="${METRICS_DIR}/headless-runtime-metrics.jsonl"
 
 # _register_dispatch_ledger: register this dispatch in the in-flight ledger (GH#6696).
 # Extracts issue number from session_key (pattern: "issue-NNN") and registers
@@ -428,6 +431,82 @@ if numeric:
 print(0)
 PY
 	return 0
+}
+
+append_runtime_metric() {
+	local role="$1"
+	local session_key="$2"
+	local model="$3"
+	local provider="$4"
+	local result="$5"
+	local exit_code="$6"
+	local failure_reason="$7"
+	local activity="$8"
+	local duration_ms="$9"
+	mkdir -p "$METRICS_DIR" 2>/dev/null || true
+	ROLE="$role" SESSION_KEY="$session_key" MODEL="$model" PROVIDER="$provider" \
+		RESULT="$result" EXIT_CODE="$exit_code" FAILURE_REASON="$failure_reason" \
+		ACTIVITY="$activity" DURATION_MS="$duration_ms" METRICS_PATH="$METRICS_FILE" python3 - <<'PY' >/dev/null 2>&1 || true
+import json
+import os
+import time
+
+record = {
+    "ts": int(time.time()),
+    "role": os.environ.get("ROLE", ""),
+    "session_key": os.environ.get("SESSION_KEY", ""),
+    "model": os.environ.get("MODEL", ""),
+    "provider": os.environ.get("PROVIDER", ""),
+    "result": os.environ.get("RESULT", "unknown"),
+    "exit_code": int(os.environ.get("EXIT_CODE", "1") or 1),
+    "failure_reason": os.environ.get("FAILURE_REASON", ""),
+    "activity": os.environ.get("ACTIVITY", "0") == "1",
+    "duration_ms": int(os.environ.get("DURATION_MS", "0") or 0),
+}
+with open(os.environ["METRICS_PATH"], "a") as f:
+    f.write(json.dumps(record, separators=(",", ":")) + "\n")
+PY
+	return 0
+}
+
+attempt_pool_recovery() {
+	local provider="$1"
+	local reason="$2"
+	local details_file="$3"
+
+	case "$provider" in
+	anthropic | openai | cursor | google) ;;
+	*)
+		return 1
+		;;
+	esac
+
+	case "$reason" in
+	rate_limit | auth_error) ;;
+	*)
+		return 1
+		;;
+	esac
+
+	[[ -x "$OAUTH_POOL_HELPER" ]] || return 1
+
+	local retry_seconds
+	retry_seconds=$(parse_retry_after_seconds "$details_file")
+	if [[ "$retry_seconds" -le 0 ]]; then
+		case "$reason" in
+		rate_limit) retry_seconds=900 ;;
+		auth_error) retry_seconds=3600 ;;
+		*) retry_seconds=300 ;;
+		esac
+	fi
+
+	"$OAUTH_POOL_HELPER" mark-failure "$provider" "$reason" "$retry_seconds" >/dev/null 2>&1 || true
+	if "$OAUTH_POOL_HELPER" rotate "$provider" >/dev/null 2>&1; then
+		print_warning "${provider} ${reason} detected; cooled down active account and rotated to alternate"
+		return 0
+	fi
+
+	return 1
 }
 
 record_provider_backoff() {
@@ -971,6 +1050,54 @@ _validate_run_args() {
 	return 0
 }
 
+# append_worker_headless_contract: append unattended continuation rules to
+# worker /full-loop prompts without changing interactive /full-loop behavior.
+#
+# This contract is injected at dispatch time by the headless runtime wrapper,
+# so full-loop.md can remain dual-purpose (interactive + headless).
+#
+# Args: $1 = prompt text
+# Output: prompt text (possibly appended)
+# Env:
+#   AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 disables prompt augmentation.
+append_worker_headless_contract() {
+	local prompt_text="$1"
+	local append_enabled="${AIDEVOPS_HEADLESS_APPEND_CONTRACT:-1}"
+
+	if [[ "$append_enabled" == "0" ]]; then
+		printf '%s' "$prompt_text"
+		return 0
+	fi
+
+	if [[ "$prompt_text" != *"/full-loop"* ]]; then
+		printf '%s' "$prompt_text"
+		return 0
+	fi
+
+	if [[ "$prompt_text" == *"HEADLESS_CONTINUATION_CONTRACT_V1"* ]]; then
+		printf '%s' "$prompt_text"
+		return 0
+	fi
+
+	local contract
+	contract=$(
+		cat <<'EOF'
+[HEADLESS_CONTINUATION_CONTRACT_V1]
+This worker run is unattended.
+
+Mandatory behavior:
+1. Never ask for user confirmation or next steps.
+2. Do not stop at "PR opened" or "in review" states.
+3. Continue through review polling, merge readiness checks, merge, and required closing comments.
+4. If merge/close cannot complete, exit only with a clear BLOCKED outcome and evidence (failing check, missing permission, unresolved conflict, or explicit policy gate).
+5. Do not emit user-directed language like "If you want, I can...".
+EOF
+	)
+
+	printf '%s\n\n%s' "$prompt_text" "$contract"
+	return 0
+}
+
 # _build_run_cmd: build the opencode command array for a run attempt.
 # Args: selected_model work_dir prompt title agent_name persisted_session
 #       extra_args (remaining positional args)
@@ -1055,14 +1182,18 @@ _handle_run_result() {
 	local discovered_session activity_detected
 	discovered_session=$(extract_session_id_from_output "$output_file")
 	activity_detected=$(output_has_activity "$output_file")
+	_run_activity_detected="$activity_detected"
+	_run_result_label="failed"
 
 	if [[ "$exit_code" -eq 0 ]]; then
 		if [[ "$activity_detected" != "1" ]]; then
+			_run_result_label="no_activity"
 			record_provider_backoff "$provider" "provider_error" "$output_file" "$selected_model"
 			rm -f "$output_file"
 			print_warning "$selected_model returned exit 0 without any model activity; backing off model"
 			return 75
 		fi
+		_run_result_label="success"
 		if [[ "$role" != "pulse" && -n "$discovered_session" ]]; then
 			store_session_id "$provider" "$session_key" "$discovered_session" "$selected_model"
 		fi
@@ -1072,9 +1203,19 @@ _handle_run_result() {
 
 	local failure_reason
 	failure_reason=$(classify_failure_reason "$output_file")
+	_run_result_label="$failure_reason"
+
+	if attempt_pool_recovery "$provider" "$failure_reason" "$output_file"; then
+		_run_should_retry=1
+		rm -f "$output_file"
+		_run_failure_reason="$failure_reason"
+		return 76
+	fi
+
 	record_provider_backoff "$provider" "$failure_reason" "$output_file" "$selected_model"
 	rm -f "$output_file"
 	_run_failure_reason="$failure_reason"
+	_run_should_retry=0
 	return "$exit_code"
 }
 
@@ -1115,6 +1256,8 @@ _execute_run_attempt() {
 		"$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
 
 	local output_file exit_code_file exit_code
+	local start_ms end_ms duration_ms
+	start_ms=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
 	output_file=$(mktemp)
 	exit_code_file=$(mktemp)
 	exit_code=0
@@ -1123,8 +1266,116 @@ _execute_run_attempt() {
 	exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
 	rm -f "$exit_code_file"
 
-	_handle_run_result "$exit_code" "$output_file" "$role" "$provider" "$session_key" "$selected_model"
-	return $?
+	local handle_exit=0
+	if _handle_run_result "$exit_code" "$output_file" "$role" "$provider" "$session_key" "$selected_model"; then
+		handle_exit=0
+	else
+		handle_exit=$?
+	fi
+	end_ms=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
+	if [[ "$end_ms" =~ ^[0-9]+$ && "$start_ms" =~ ^[0-9]+$ && "$end_ms" -ge "$start_ms" ]]; then
+		duration_ms=$((end_ms - start_ms))
+	else
+		duration_ms=0
+	fi
+	append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "${_run_result_label:-failed}" "$handle_exit" "${_run_failure_reason:-}" "${_run_activity_detected:-0}" "$duration_ms"
+	return "$handle_exit"
+}
+
+cmd_metrics() {
+	local role_filter="pulse"
+	local hours="24"
+	local model_filter=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--role)
+			role_filter="${2:-pulse}"
+			shift 2
+			;;
+		--hours)
+			hours="${2:-24}"
+			shift 2
+			;;
+		--model)
+			model_filter="${2:-}"
+			shift 2
+			;;
+		*)
+			print_error "Unknown option for metrics: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ ! "$hours" =~ ^[0-9]+$ ]]; then
+		print_error "--hours must be an integer"
+		return 1
+	fi
+
+	if [[ ! -f "$METRICS_FILE" ]]; then
+		print_info "No runtime metrics recorded yet: $METRICS_FILE"
+		return 0
+	fi
+
+	ROLE_FILTER="$role_filter" HOURS="$hours" MODEL_FILTER="$model_filter" METRICS_PATH="$METRICS_FILE" python3 - <<'PY'
+import json
+import os
+import time
+from collections import defaultdict
+
+metrics_path = os.environ["METRICS_PATH"]
+role_filter = os.environ.get("ROLE_FILTER", "pulse")
+hours = int(os.environ.get("HOURS", "24"))
+model_filter = os.environ.get("MODEL_FILTER", "")
+cutoff = int(time.time()) - (hours * 3600)
+
+rows = []
+with open(metrics_path) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except Exception:
+            continue
+        if int(row.get("ts", 0)) < cutoff:
+            continue
+        if role_filter and row.get("role") != role_filter:
+            continue
+        model = row.get("model", "")
+        if model_filter and model_filter not in model:
+            continue
+        rows.append(row)
+
+if not rows:
+    print("No matching runtime metrics in selected window")
+    raise SystemExit(0)
+
+agg = defaultdict(lambda: {"runs": 0, "success": 0, "productive": 0, "retry_recovered": 0, "sum_duration": 0})
+for row in rows:
+    model = row.get("model", "unknown")
+    item = agg[model]
+    item["runs"] += 1
+    if row.get("result") == "success":
+        item["success"] += 1
+    if row.get("result") == "success" and bool(row.get("activity", False)):
+        item["productive"] += 1
+    if int(row.get("exit_code", 1)) == 76:
+        item["retry_recovered"] += 1
+    item["sum_duration"] += int(row.get("duration_ms", 0) or 0)
+
+print(f"Headless runtime metrics (window={hours}h, role={role_filter})")
+for model in sorted(agg.keys()):
+    item = agg[model]
+    runs = item["runs"]
+    success_pct = (item["success"] / runs) * 100 if runs else 0
+    productive_pct = (item["productive"] / runs) * 100 if runs else 0
+    avg_sec = (item["sum_duration"] / runs) / 1000 if runs else 0
+    print(f"- {model}: runs={runs}, success={item['success']} ({success_pct:.1f}%), productive={item['productive']} ({productive_pct:.1f}%), pool-recovered={item['retry_recovered']}, avg_duration={avg_sec:.1f}s")
+PY
+	return 0
 }
 
 cmd_run() {
@@ -1140,6 +1391,10 @@ cmd_run() {
 
 	_parse_run_args "$@" || return 1
 	_validate_run_args || return 1
+
+	if [[ "$role" == "worker" ]]; then
+		prompt=$(append_worker_headless_contract "$prompt")
+	fi
 
 	# GH#6538: Acquire a session-key lock to prevent duplicate workers.
 	# The pulse (or any caller) may dispatch the same session-key twice in
@@ -1167,11 +1422,16 @@ cmd_run() {
 	}
 
 	local attempt=1
-	local max_attempts=2
+	local max_attempts=3
 	local _run_failure_reason=""
-	local run_exit=1
+	local _run_should_retry=0
+	local _run_result_label="failed"
+	local _run_activity_detected="0"
 	while [[ "$attempt" -le "$max_attempts" ]]; do
 		_run_failure_reason=""
+		_run_should_retry=0
+		_run_result_label="failed"
+		_run_activity_detected="0"
 		_execute_run_attempt \
 			"$role" "$session_key" "$work_dir" "$title" "$prompt" \
 			"$selected_model" "$agent_name" "$model_override" \
@@ -1185,9 +1445,21 @@ cmd_run() {
 			return 0
 		fi
 
-		# Only retry on auth errors when no explicit model was requested
-		# and we have attempts remaining.
-		if [[ -n "$model_override" || "$_run_failure_reason" != "auth_error" || "$attempt" -ge "$max_attempts" ]]; then
+		# Retry only in auto-selection mode and only when attempts remain.
+		if [[ -n "$model_override" || "$attempt" -ge "$max_attempts" ]]; then
+			_update_dispatch_ledger "$session_key" "fail"
+			_release_session_lock "$session_key"
+			trap - EXIT
+			return "$attempt_exit"
+		fi
+
+		if [[ "$_run_should_retry" == "1" ]]; then
+			print_warning "Retrying ${selected_model} once after pool account rotation"
+			attempt=$((attempt + 1))
+			continue
+		fi
+
+		if [[ "$_run_failure_reason" != "auth_error" && "$_run_failure_reason" != "rate_limit" ]]; then
 			_update_dispatch_ledger "$session_key" "fail"
 			_release_session_lock "$session_key"
 			trap - EXIT
@@ -1202,12 +1474,12 @@ cmd_run() {
 			trap - EXIT
 			return "$attempt_exit"
 		}
-		print_warning "$provider auth failure detected at startup; retrying once with alternate provider model $next_model"
+		print_warning "$provider $_run_failure_reason detected; retrying with alternate provider model $next_model"
 		selected_model="$next_model"
 		attempt=$((attempt + 1))
 	done
 
-	# Unreachable: loop always executes (attempt starts at 1, max_attempts=2)
+	# Unreachable: loop always executes (attempt starts at 1, max_attempts=3)
 	# and every path inside returns explicitly. Kept as defensive fallback.
 	_update_dispatch_ledger "$session_key" "fail"
 	_release_session_lock "$session_key"
@@ -1224,6 +1496,7 @@ Usage:
   headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--agent NAME] [--opencode-arg ARG]
   headless-runtime-helper.sh backoff [status|set MODEL-OR-PROVIDER REASON [SECONDS]|clear MODEL-OR-PROVIDER]
   headless-runtime-helper.sh session [status|clear PROVIDER SESSION_KEY]
+  headless-runtime-helper.sh metrics [--role pulse|worker] [--hours N] [--model SUBSTRING]
   headless-runtime-helper.sh help
 
 Backoff granularity:
@@ -1240,6 +1513,7 @@ Dedup guard (GH#6538):
 Defaults:
   AIDEVOPS_HEADLESS_MODELS defaults to anthropic/claude-sonnet-4-6,openai/gpt-4o
   AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST can restrict selection to providers like: openai
+  AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 disables worker /full-loop contract injection
   Gateway models (opencode/*) are supported when explicitly configured.
 EOF
 	return 0
@@ -1264,6 +1538,10 @@ main() {
 		;;
 	session)
 		cmd_session "$@"
+		return $?
+		;;
+	metrics)
+		cmd_metrics "$@"
 		return $?
 		;;
 	passthrough-csv)

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -559,8 +559,12 @@ check_secrets() {
 _find_markdownlint_cmd() {
 	if command -v markdownlint &>/dev/null; then
 		echo "markdownlint"
+	elif command -v markdownlint-cli2 &>/dev/null; then
+		echo "markdownlint-cli2"
 	elif [[ -f "node_modules/.bin/markdownlint" ]]; then
 		echo "node_modules/.bin/markdownlint"
+	elif [[ -f "node_modules/.bin/markdownlint-cli2" ]]; then
+		echo "node_modules/.bin/markdownlint-cli2"
 	fi
 	return 0
 }
@@ -617,7 +621,7 @@ _report_markdown_result() {
 			if [[ $violations -gt 10 ]]; then
 				echo "... and $((violations - 10)) more"
 			fi
-			print_info "Run: markdownlint --fix <file> to auto-fix"
+			print_info "Run: markdownlint --fix <file> (or markdownlint-cli2 --fix <glob>)"
 			if [[ "$check_mode" == "changed" ]]; then
 				print_error "Markdown: $violations style issues in changed files (BLOCKING)"
 				return 1
@@ -670,7 +674,7 @@ check_markdown_lint() {
 	# NOTE: Without markdownlint, we can't reliably detect MD031/MD040 violations
 	# because we can't distinguish opening fences (need language) from closing fences (always bare)
 	print_warning "Markdown: markdownlint not installed - cannot perform full lint checks"
-	print_info "Install: npm install -g markdownlint-cli"
+	print_info "Install: npm install -g markdownlint-cli2 (or markdownlint-cli)"
 	print_info "Then re-run to get blocking checks for changed files"
 	return 0
 }

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -2043,6 +2043,182 @@ json.dump({'cleared': cleared, 'pool': pool}, sys.stdout, indent=2)
 }
 
 # ---------------------------------------------------------------------------
+# Mark current account failure state (for headless auto-rotation)
+# ---------------------------------------------------------------------------
+
+cmd_mark_failure() {
+	local provider="${1:-}"
+	local reason="${2:-rate_limit}"
+	local retry_seconds="${3:-900}"
+
+	case "$provider" in
+	anthropic | openai | cursor | google) ;;
+	*)
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google)"
+		return 1
+		;;
+	esac
+
+	case "$reason" in
+	rate_limit | auth_error | provider_error) ;;
+	*)
+		print_error "Invalid reason: $reason (valid: rate_limit, auth_error, provider_error)"
+		return 1
+		;;
+	esac
+
+	if [[ ! "$retry_seconds" =~ ^[0-9]+$ ]]; then
+		print_error "retry_seconds must be an integer"
+		return 1
+	fi
+
+	if [[ ! -f "$POOL_FILE" || ! -f "$OPENCODE_AUTH_FILE" ]]; then
+		print_warning "Pool/auth file missing; skipping account failure mark"
+		return 0
+	fi
+
+	local mark_result
+	mark_result=$(POOL_FILE_PATH="$POOL_FILE" AUTH_FILE_PATH="$OPENCODE_AUTH_FILE" \
+		PROVIDER="$provider" REASON="$reason" RETRY_SECONDS="$retry_seconds" python3 -c "
+import json, os, sys, tempfile, time
+from datetime import datetime, timezone
+
+pool_path = os.environ['POOL_FILE_PATH']
+auth_path = os.environ['AUTH_FILE_PATH']
+provider = os.environ['PROVIDER']
+reason = os.environ['REASON']
+retry_seconds = int(os.environ['RETRY_SECONDS'])
+
+def _acquire_lock(lock_fd):
+    if sys.platform == 'win32':
+        import msvcrt
+        deadline = time.time() + 30
+        while True:
+            try:
+                lock_fd.seek(0)
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                if time.time() >= deadline:
+                    raise
+                time.sleep(0.1)
+    else:
+        import fcntl
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+def _release_lock(lock_fd):
+    if sys.platform == 'win32':
+        import msvcrt
+        try:
+            lock_fd.seek(0)
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    else:
+        import fcntl
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+def _atomic_write_json(path, data):
+    d = os.path.dirname(path)
+    fd, tmp = tempfile.mkstemp(dir=d, prefix='.tmp-', suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+status_map = {
+    'rate_limit': 'rate-limited',
+    'auth_error': 'auth-error',
+    'provider_error': 'rate-limited',
+}
+target_status = status_map.get(reason, 'rate-limited')
+
+lock_path = pool_path + '.lock'
+lock_fd = open(lock_path, 'w')
+try:
+    _acquire_lock(lock_fd)
+    with open(pool_path) as f:
+        pool = json.load(f)
+    with open(auth_path) as f:
+        auth = json.load(f)
+
+    accounts = pool.get(provider, [])
+    if not accounts:
+        print('SKIP:no_accounts')
+        sys.exit(0)
+
+    current_auth = auth.get(provider, {}) if isinstance(auth, dict) else {}
+    current_access = current_auth.get('access', '')
+    current_account_id = current_auth.get('accountId', '')
+
+    idx = -1
+    if current_access:
+        for i, acct in enumerate(accounts):
+            if acct.get('access', '') == current_access:
+                idx = i
+                break
+
+    if idx < 0 and provider == 'openai' and current_account_id:
+        for i, acct in enumerate(accounts):
+            if acct.get('accountId', '') == current_account_id:
+                idx = i
+                break
+
+    if idx < 0:
+        best_i = 0
+        best_last = ''
+        for i, acct in enumerate(accounts):
+            last = acct.get('lastUsed', '')
+            if last >= best_last:
+                best_last = last
+                best_i = i
+        idx = best_i
+
+    now_ms = int(time.time() * 1000)
+    cooldown_until = now_ms + retry_seconds * 1000
+    now_iso = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    target = accounts[idx]
+    target['status'] = target_status
+    target['cooldownUntil'] = cooldown_until
+    target['lastUsed'] = now_iso
+    pool[provider] = accounts
+
+    _atomic_write_json(pool_path, pool)
+    email = target.get('email', 'unknown')
+    print(f'OK:{email}:{target_status}:{cooldown_until}')
+finally:
+    _release_lock(lock_fd)
+    lock_fd.close()
+" 2>/dev/null) || {
+		print_warning "Failed to mark account failure state for ${provider}"
+		return 1
+	}
+
+	case "$mark_result" in
+	OK:*)
+		print_info "Marked current ${provider} account as ${reason}"
+		return 0
+		;;
+	SKIP:*)
+		print_warning "No ${provider} accounts available to mark"
+		return 0
+		;;
+	*)
+		print_warning "Unexpected mark-failure result: ${mark_result}"
+		return 1
+		;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
 # Status — pool aggregate stats per provider (distinct from list)
 # ---------------------------------------------------------------------------
 
@@ -2330,6 +2506,7 @@ Commands:
   status [anthropic|openai|cursor|google|all]     Pool aggregate stats (counts, availability)
   refresh [anthropic|openai|google] [email|all]   Refresh expired tokens without re-auth (uses refresh_token)
   rotate [anthropic|openai|cursor|google]         Switch to next available account NOW (auto-refreshes expired tokens)
+  mark-failure <provider> <reason> [retry_secs]   Mark current account cooldown/status from runtime failures
   reset-cooldowns [provider|all]                  Clear rate-limit cooldowns so all accounts retry
   assign-pending <provider> [email]               Assign a stranded pending token to an account
   remove <provider> <email>                       Remove an account from the pool
@@ -2388,6 +2565,7 @@ main() {
 	check | test) cmd_check "$@" ;;
 	import) cmd_import "$@" ;;
 	list) cmd_list "$@" ;;
+	mark-failure | mark_failure) cmd_mark_failure "$@" ;;
 	refresh) cmd_refresh "$@" ;;
 	rotate) cmd_rotate "$@" ;;
 	reset-cooldowns | reset_cooldowns | reset) cmd_reset_cooldowns "$@" ;;

--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -316,6 +316,7 @@ ensure_homebrew() {
 	print_info "Homebrew (Linuxbrew) is not installed."
 	print_info "Several optional tools (Beads CLI, Worktrunk, bv) install via Homebrew taps."
 	echo ""
+	local install_brew="Y"
 	setup_prompt install_brew "Install Homebrew for Linux? [Y/n]: " "Y"
 
 	if [[ ! "$install_brew" =~ ^[Yy]?$ ]]; then
@@ -512,6 +513,7 @@ check_requirements() {
 		fi
 
 		echo ""
+		local install_deps="Y"
 		setup_prompt install_deps "Install missing dependencies using $pkg_manager? [Y/n]: " "Y"
 
 		if [[ "$install_deps" =~ ^[Yy]?$ ]]; then
@@ -532,12 +534,13 @@ check_requirements() {
 	return 0
 }
 
-# Check for quality/linting tools (shellcheck, shfmt)
+# Check for quality/linting tools (shellcheck, shfmt, markdownlint)
 # These are optional but recommended for development
 check_quality_tools() {
 	print_info "Checking quality tools..."
 
 	local missing_tools=()
+	local missing_npm_tools=()
 
 	# Check for shellcheck
 	if command -v shellcheck >/dev/null 2>&1; then
@@ -553,19 +556,42 @@ check_quality_tools() {
 		missing_tools+=("shfmt")
 	fi
 
+	# Check for markdownlint (accept either CLI variant)
+	if command -v markdownlint >/dev/null 2>&1; then
+		print_success "markdownlint: $(markdownlint --version 2>/dev/null | head -1)"
+	elif command -v markdownlint-cli2 >/dev/null 2>&1; then
+		print_success "markdownlint-cli2: $(markdownlint-cli2 --version 2>/dev/null | head -1)"
+	else
+		missing_npm_tools+=("markdownlint-cli2")
+	fi
+
 	# If all tools present, return early
-	if [[ ${#missing_tools[@]} -eq 0 ]]; then
+	if [[ ${#missing_tools[@]} -eq 0 && ${#missing_npm_tools[@]} -eq 0 ]]; then
 		print_success "All quality tools installed"
 		return 0
 	fi
 
 	# Show missing tools
-	print_warning "Missing quality tools: ${missing_tools[*]}"
+	if [[ ${#missing_tools[@]} -gt 0 ]]; then
+		print_warning "Missing quality tools: ${missing_tools[*]}"
+	fi
+	if [[ ${#missing_npm_tools[@]} -gt 0 ]]; then
+		print_warning "Missing npm quality tools: ${missing_npm_tools[*]}"
+	fi
 	print_info "These tools are used by linters-local.sh for code quality checks"
 
 	# In non-interactive mode, just warn and continue
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
-		print_info "Install later: brew install ${missing_tools[*]}"
+		if [[ ${#missing_tools[@]} -gt 0 ]]; then
+			print_info "Install later: brew install ${missing_tools[*]}"
+		fi
+		if [[ ${#missing_npm_tools[@]} -gt 0 ]]; then
+			if command -v npm >/dev/null 2>&1; then
+				print_info "Install later: npm install -g ${missing_npm_tools[*]}"
+			else
+				print_info "Install later: install npm, then run npm install -g ${missing_npm_tools[*]}"
+			fi
+		fi
 		return 0
 	fi
 
@@ -573,27 +599,49 @@ check_quality_tools() {
 	local pkg_manager
 	pkg_manager=$(detect_package_manager)
 
-	if [[ "$pkg_manager" == "unknown" ]]; then
+	if [[ "$pkg_manager" == "unknown" && ${#missing_tools[@]} -gt 0 ]]; then
 		print_info "Install manually:"
 		echo "  macOS: brew install ${missing_tools[*]}"
 		echo "  Ubuntu/Debian: sudo apt-get install ${missing_tools[*]}"
 		echo "  Fedora: sudo dnf install ${missing_tools[*]}"
-		return 0
+	elif [[ ${#missing_tools[@]} -gt 0 ]]; then
+		local install_quality="Y"
+		echo ""
+		setup_prompt install_quality "Install quality tools using $pkg_manager? [Y/n]: " "Y"
+
+		if [[ "$install_quality" =~ ^[Yy]?$ ]]; then
+			print_info "Installing ${missing_tools[*]}..."
+			if install_packages "$pkg_manager" "${missing_tools[@]}"; then
+				print_success "Quality tools installed successfully"
+			else
+				print_warning "Failed to install some quality tools - continuing anyway"
+			fi
+		else
+			print_info "Skipped quality tools installation"
+			print_info "Install later: $pkg_manager install ${missing_tools[*]}"
+		fi
 	fi
 
-	echo ""
-	setup_prompt install_quality "Install quality tools using $pkg_manager? [Y/n]: " "Y"
-
-	if [[ "$install_quality" =~ ^[Yy]?$ ]]; then
-		print_info "Installing ${missing_tools[*]}..."
-		if install_packages "$pkg_manager" "${missing_tools[@]}"; then
-			print_success "Quality tools installed successfully"
+	if [[ ${#missing_npm_tools[@]} -gt 0 ]]; then
+		if ! command -v npm >/dev/null 2>&1; then
+			print_warning "npm not found; cannot auto-install ${missing_npm_tools[*]}"
+			print_info "Install Node.js/npm, then run: npm install -g ${missing_npm_tools[*]}"
 		else
-			print_warning "Failed to install some quality tools - continuing anyway"
+			local install_npm_quality="Y"
+			echo ""
+			setup_prompt install_npm_quality "Install npm quality tools (npm install -g ${missing_npm_tools[*]})? [Y/n]: " "Y"
+			if [[ "$install_npm_quality" =~ ^[Yy]?$ ]]; then
+				print_info "Installing npm quality tools: ${missing_npm_tools[*]}..."
+				if npm install -g "${missing_npm_tools[@]}" >/dev/null 2>&1; then
+					print_success "npm quality tools installed successfully"
+				else
+					print_warning "Failed to install npm quality tools - continuing anyway"
+				fi
+			else
+				print_info "Skipped npm quality tools installation"
+				print_info "Install later: npm install -g ${missing_npm_tools[*]}"
+			fi
 		fi
-	else
-		print_info "Skipped quality tools installation"
-		print_info "Install later: $pkg_manager install ${missing_tools[*]}"
 	fi
 
 	return 0

--- a/setup.sh
+++ b/setup.sh
@@ -740,6 +740,8 @@ _setup_run_non_interactive() {
 	print_info "Non-interactive mode: deploying agents and running safe migrations only"
 	verify_location
 	check_requirements
+	# Run quality tool detection in non-interactive mode too (warn-only path).
+	check_quality_tools
 	check_python_upgrade_available
 	set_permissions
 	migrate_old_backups


### PR DESCRIPTION
## Summary
- Add pool-aware failure recovery in headless runtime: classify rate/auth failures, mark current account cooldown in oauth pool, rotate account, and retry before provider fallback.
- Add runtime metrics capture/reporting via headless-runtime-helper metrics to measure pulse/worker productivity and pool-recovery behavior.
- Preserve /full-loop as dual-use by appending a worker-only headless continuation contract at dispatch time; extend pulse guidance to avoid unattended idle exits.
- Improve setup/lint resilience by detecting either markdownlint binary (markdownlint or markdownlint-cli2) and running quality-tool detection in non-interactive setup.

## Testing Evidence
- shellcheck -S warning .agents/scripts/headless-runtime-helper.sh .agents/scripts/linters-local.sh .agents/scripts/oauth-pool-helper.sh setup-modules/core.sh setup.sh
- markdownlint .agents/scripts/commands/pulse.md (or markdownlint-cli2 equivalent)
- .agents/scripts/linters-local.sh (repo baseline still reports pre-existing global gates unrelated to this diff)

Closes #14213


---
[aidevops.sh](https://aidevops.sh) v3.5.458 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 2h 47m and 593,298 tokens on this as a headless worker.