### PR TITLE
GH#14208: guard migrations from missing overwrite helper

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -71,7 +71,7 @@ cleanup_deprecated_paths() {
 	# See: ~/.config/aidevops/settings.json { "preserve_oh_my_opencode": true }
 	local omo_config="$HOME/.config/opencode/oh-my-opencode.json"
 	if [[ -f "$omo_config" ]]; then
-		if should_overwrite_user_file "preserve_oh_my_opencode" "oh-my-opencode config ($omo_config)"; then
+		if should_cleanup_oh_my_opencode_artifacts "oh-my-opencode config ($omo_config)"; then
 			rm -f "$omo_config"
 			print_info "Removed oh-my-opencode config"
 		fi
@@ -91,7 +91,7 @@ cleanup_deprecated_paths() {
 	opencode_config=$(find_opencode_config 2>/dev/null) || true
 	if [[ -n "$opencode_config" ]] && [[ -f "$opencode_config" ]] && command -v jq &>/dev/null; then
 		if jq -e '.plugin | index("oh-my-opencode")' "$opencode_config" >/dev/null 2>&1; then
-			if should_overwrite_user_file "preserve_oh_my_opencode" "oh-my-opencode plugin entry in OpenCode config"; then
+			if should_cleanup_oh_my_opencode_artifacts "oh-my-opencode plugin entry in OpenCode config"; then
 				local tmp_file
 				tmp_file=$(mktemp)
 				trap 'rm -f "${tmp_file:-}"' RETURN
@@ -102,6 +102,20 @@ cleanup_deprecated_paths() {
 	fi
 
 	return 0
+}
+
+# Backward-compatibility guard for oh-my-opencode cleanup migration.
+# setup.sh no longer defines should_overwrite_user_file() in current runtime.
+# Preserve user files by default when the legacy helper is unavailable.
+should_cleanup_oh_my_opencode_artifacts() {
+	local description="$1"
+
+	if type should_overwrite_user_file &>/dev/null; then
+		should_overwrite_user_file "preserve_oh_my_opencode" "$description"
+		return $?
+	fi
+
+	return 1
 }
 
 # Remove osgrep completely — one-time cleanup for all aidevops users

--- a/tests/test-migrate-orphaned-supervisor.sh
+++ b/tests/test-migrate-orphaned-supervisor.sh
@@ -68,8 +68,6 @@ find_opencode_config() { return 1; }
 # shellcheck disable=SC2329
 create_backup_with_rotation() { return 0; }
 # shellcheck disable=SC2329
-should_overwrite_user_file() { return 0; }
-# shellcheck disable=SC2329
 resolve_mcp_binary_path() {
 	echo ""
 	return 1
@@ -83,7 +81,7 @@ sanitize_plugin_namespace() {
 }
 # Export stubs so sourced script can find them
 export -f print_info print_success print_warning _launchd_has_agent
-export -f find_opencode_config create_backup_with_rotation should_overwrite_user_file
+export -f find_opencode_config create_backup_with_rotation
 export -f resolve_mcp_binary_path update_mcp_paths_in_opencode sanitize_plugin_namespace
 
 # Source the migrations script to get the function
@@ -230,6 +228,69 @@ if command -v crontab &>/dev/null; then
 	fi
 else
 	pass "Cron test skipped (crontab not available)"
+fi
+
+# ============================================================================
+section "Test: cleanup_deprecated_paths works when should_overwrite_user_file is undefined"
+# ============================================================================
+
+omo_config="$HOME/.config/opencode/oh-my-opencode.json"
+opencode_config="$HOME/.config/opencode/opencode.json"
+mkdir -p "$HOME/.config/opencode"
+printf '{"legacy":true}\n' >"$omo_config"
+printf '{"plugin":["oh-my-opencode","other-plugin"]}\n' >"$opencode_config"
+
+# Point migration lookup at our temporary config file.
+# shellcheck disable=SC2329
+find_opencode_config() {
+	echo "$opencode_config"
+	return 0
+}
+export -f find_opencode_config
+
+# Avoid global side effects from cleanup paths unrelated to this regression test.
+# shellcheck disable=SC2329
+cleanup_osgrep() { return 0; }
+# shellcheck disable=SC2329
+cleanup_antigravity_plugin() { return 0; }
+export -f cleanup_osgrep cleanup_antigravity_plugin
+
+# Explicitly verify the legacy helper is not available.
+unset -f should_overwrite_user_file 2>/dev/null || true
+
+cleanup_output=$(cleanup_deprecated_paths 2>&1)
+cleanup_exit_code=$?
+
+if [[ $cleanup_exit_code -eq 0 ]]; then
+	pass "cleanup_deprecated_paths succeeds without should_overwrite_user_file"
+else
+	fail "cleanup_deprecated_paths should succeed without should_overwrite_user_file" "exit code: $cleanup_exit_code"
+fi
+
+if [[ "$cleanup_output" == *"should_overwrite_user_file: command not found"* ]]; then
+	fail "No command-not-found error when helper is undefined" "$cleanup_output"
+else
+	pass "No command-not-found error when helper is undefined"
+fi
+
+if [[ -f "$omo_config" ]]; then
+	pass "oh-my-opencode config preserved by default when helper is undefined"
+else
+	fail "oh-my-opencode config should be preserved by default"
+fi
+
+if command -v jq &>/dev/null; then
+	if jq -e '.plugin | index("oh-my-opencode")' "$opencode_config" >/dev/null 2>&1; then
+		pass "oh-my-opencode plugin entry preserved by default when helper is undefined"
+	else
+		fail "oh-my-opencode plugin entry should be preserved by default"
+	fi
+else
+	if grep -qF '"oh-my-opencode"' "$opencode_config"; then
+		pass "oh-my-opencode plugin entry preserved by default when helper is undefined"
+	else
+		fail "oh-my-opencode plugin entry should be preserved by default"
+	fi
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- replace direct `should_overwrite_user_file` calls in `cleanup_deprecated_paths` with a local compatibility guard
- preserve default behavior (do not remove user oh-my-opencode files) when the legacy helper is missing
- add regression coverage proving migrations do not fail when the helper is undefined

## Root Cause
`migrations.sh` still called `should_overwrite_user_file`, but that helper is no longer defined in current runtime setup code.

## Testing Evidence
- `shellcheck setup-modules/migrations.sh tests/test-migrate-orphaned-supervisor.sh`
- `bash tests/test-migrate-orphaned-supervisor.sh`

## Runtime Testing
- Level: medium
- Result: runtime-verified via migration test execution in isolated HOME fixture

Closes #14208


---
[aidevops.sh](https://aidevops.sh) v3.5.459 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 19m and 162,062 tokens on this with the user in an interactive session. Overall, 32m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward compatibility by gracefully handling missing legacy components during cleanup operations, preventing errors.
  * User configuration files and settings are now automatically preserved during cleanup when legacy system utilities are unavailable.

* **Tests**
  * Added regression test to verify cleanup operations succeed and protect user files when legacy helper functions are not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->