### PR TITLE
GH#14277: fix maintainer-gate commit status not posted on PR events

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -14,7 +14,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
   issues:
-    types: [unlabeled, labeled]
+    types: [unlabeled, labeled, assigned]
 
 jobs:
   # =========================================================================
@@ -34,6 +34,7 @@ jobs:
       pull-requests: write
       issues: read
       contents: read
+      statuses: write
 
     steps:
       # Security: This job uses pull_request_target for fork PR write access.
@@ -45,6 +46,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAINTAINER_GATE_DEBUG: ${{ vars.MAINTAINER_GATE_DEBUG || 'false' }}
@@ -81,6 +83,13 @@ jobs:
             echo "blocked=true" >> "$GITHUB_OUTPUT"
             printf 'Title-based issue lookup for task ID %s failed — cannot verify linked issues.\n' "$TASK_ID" > /tmp/gate-reasons.txt
             echo "has_reasons=true" >> "$GITHUB_OUTPUT"
+            # Post failure commit status so branch protection sees the result
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=failure \
+              -f context="maintainer-gate" \
+              -f description="Title-based issue lookup failed — cannot verify linked issues" \
+              2>/dev/null || echo "::warning::Could not post commit status"
             exit 0
           fi
 
@@ -88,6 +97,13 @@ jobs:
             echo "No linked issues found — gate passes (no issues to check)"
             echo "blocked=false" >> "$GITHUB_OUTPUT"
             echo "reason=" >> "$GITHUB_OUTPUT"
+            # Post success commit status so branch protection sees the result
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=success \
+              -f context="maintainer-gate" \
+              -f description="No linked issues to check" \
+              2>/dev/null || echo "::warning::Could not post commit status"
             exit 0
           fi
 
@@ -162,6 +178,28 @@ jobs:
           # Use a temp file for multi-line reasons
           printf '%b' "$REASONS" > /tmp/gate-reasons.txt
           echo "has_reasons=true" >> "$GITHUB_OUTPUT"
+
+          # Post commit status so branch protection sees the result (GH#14277)
+          # The check-run (job name) is separate from the commit status context.
+          # Branch protection may require the "maintainer-gate" commit status,
+          # which was previously only posted by the retrigger-pr-checks job on
+          # issue label changes — not on PR open/sync events.
+          if [[ "$BLOCKED" == "true" ]]; then
+            DESCRIPTION=$(head -c 140 /tmp/gate-reasons.txt | tr '\n' ' ')
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=failure \
+              -f context="maintainer-gate" \
+              -f description="${DESCRIPTION}" \
+              2>/dev/null || echo "::warning::Could not post commit status"
+          else
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=success \
+              -f context="maintainer-gate" \
+              -f description="All linked issues pass gate checks" \
+              2>/dev/null || echo "::warning::Could not post commit status"
+          fi
 
       - name: Post or update gate comment
         if: steps.check.outputs.blocked == 'true'
@@ -270,14 +308,14 @@ jobs:
           fi
 
   # =========================================================================
-  # Job 3: Re-evaluate PR gate when a linked issue's labels change
+  # Job 3: Re-evaluate PR gate when a linked issue's labels or assignees change
   #         (evaluates conditions and posts final success/failure status)
   # =========================================================================
   retrigger-pr-checks:
-    name: Re-evaluate PR Gate on Issue Label Change
+    name: Re-evaluate PR Gate on Issue Change
     if: >-
       github.event_name == 'issues' &&
-      (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled' || github.event.action == 'assigned')
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -294,7 +332,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAINTAINER_GATE_DEBUG: ${{ vars.MAINTAINER_GATE_DEBUG || 'false' }}
         run: |
-          echo "Issue #$ISSUE_NUMBER labels changed — checking for linked PRs"
+          echo "Issue #$ISSUE_NUMBER updated (labels/assignee) — checking for linked PRs"
 
           # Find open PRs that reference this issue
           OPEN_PRS=$(gh pr list --repo "$REPO" --state open --json number,body --limit 50 \

--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -14,7 +14,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
   issues:
-    types: [unlabeled, labeled, assigned]
+    types: [unlabeled, labeled, assigned, unassigned]
 
 jobs:
   # =========================================================================
@@ -84,12 +84,21 @@ jobs:
             printf 'Title-based issue lookup for task ID %s failed — cannot verify linked issues.\n' "$TASK_ID" > /tmp/gate-reasons.txt
             echo "has_reasons=true" >> "$GITHUB_OUTPUT"
             # Post failure commit status so branch protection sees the result
+            # Fail-closed: if status post fails after retry, fail the job to avoid
+            # leaving the PR without a maintainer-gate status (GH#14277)
             gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
               --method POST \
               -f state=failure \
               -f context="maintainer-gate" \
               -f description="Title-based issue lookup failed — cannot verify linked issues" \
-              2>/dev/null || echo "::warning::Could not post commit status"
+              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=failure \
+              -f context="maintainer-gate" \
+              -f description="Title-based issue lookup failed — cannot verify linked issues"; } || {
+              echo "::error::Failed to post maintainer-gate commit status after retry"
+              exit 1
+            }
             exit 0
           fi
 
@@ -98,12 +107,20 @@ jobs:
             echo "blocked=false" >> "$GITHUB_OUTPUT"
             echo "reason=" >> "$GITHUB_OUTPUT"
             # Post success commit status so branch protection sees the result
+            # Fail-closed: if status post fails after retry, fail the job (GH#14277)
             gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
               --method POST \
               -f state=success \
               -f context="maintainer-gate" \
               -f description="No linked issues to check" \
-              2>/dev/null || echo "::warning::Could not post commit status"
+              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=success \
+              -f context="maintainer-gate" \
+              -f description="No linked issues to check"; } || {
+              echo "::error::Failed to post maintainer-gate commit status after retry"
+              exit 1
+            }
             exit 0
           fi
 
@@ -184,6 +201,7 @@ jobs:
           # Branch protection may require the "maintainer-gate" commit status,
           # which was previously only posted by the retrigger-pr-checks job on
           # issue label changes — not on PR open/sync events.
+          # Fail-closed: if status post fails after retry, fail the job (GH#14277)
           if [[ "$BLOCKED" == "true" ]]; then
             DESCRIPTION=$(head -c 140 /tmp/gate-reasons.txt | tr '\n' ' ')
             gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
@@ -191,14 +209,28 @@ jobs:
               -f state=failure \
               -f context="maintainer-gate" \
               -f description="${DESCRIPTION}" \
-              2>/dev/null || echo "::warning::Could not post commit status"
+              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=failure \
+              -f context="maintainer-gate" \
+              -f description="${DESCRIPTION}"; } || {
+              echo "::error::Failed to post maintainer-gate commit status after retry"
+              exit 1
+            }
           else
             gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
               --method POST \
               -f state=success \
               -f context="maintainer-gate" \
               -f description="All linked issues pass gate checks" \
-              2>/dev/null || echo "::warning::Could not post commit status"
+              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              --method POST \
+              -f state=success \
+              -f context="maintainer-gate" \
+              -f description="All linked issues pass gate checks"; } || {
+              echo "::error::Failed to post maintainer-gate commit status after retry"
+              exit 1
+            }
           fi
 
       - name: Post or update gate comment
@@ -315,7 +347,7 @@ jobs:
     name: Re-evaluate PR Gate on Issue Change
     if: >-
       github.event_name == 'issues' &&
-      (github.event.action == 'labeled' || github.event.action == 'unlabeled' || github.event.action == 'assigned')
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled' || github.event.action == 'assigned' || github.event.action == 'unassigned')
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:


### PR DESCRIPTION
## Summary

- **Root cause**: The `check-pr` job (Job 1) created a GitHub Actions check run named `Maintainer Review & Assignee Gate` on `pull_request_target` events, but never posted the `maintainer-gate` **commit status** that branch protection requires. The commit status was only posted by Job 3 (`retrigger-pr-checks`) on issue label changes — so PRs only got the status if a linked issue's labels happened to change after the PR was opened.
- **Fix**: Add `statuses: write` permission and commit status posting to all exit paths in the `check-pr` job, so every PR open/synchronize/reopen/edit event posts the `maintainer-gate` commit status immediately.
- **Bonus**: Add `assigned` to the `issues` trigger types so the gate re-evaluates when an issue gets an assignee (since the gate checks for assignees, this was a missing trigger).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/maintainer-gate.yml` | Add `statuses: write` permission to `check-pr` job |
| | Add `HEAD_SHA` env var from `github.event.pull_request.head.sha` |
| | Post `maintainer-gate` commit status in all 3 exit paths: no-linked-issues (success), title-lookup-failed (failure), and after issue evaluation loop (success/failure) |
| | Add `assigned` to `issues` trigger types |
| | Update `retrigger-pr-checks` job condition to also fire on `assigned` events |

## Testing

Once merged, the workflow will fire on the next PR event and post the `maintainer-gate` commit status. Existing PRs that already have the status from Job 3 will continue to work. PRs that were missing the status will get it on their next push/sync.

Closes #14277

---
[aidevops.sh](https://aidevops.sh) v3.5.462 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 6m and 14,008 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced pull request status reporting with clearer maintainer-gate feedback, including explicit checks for linked issues and final gate results.
  * Workflow now responds to issue assignment and unassignment as well as label changes, broadening when automated checks run.
  * Status posts employ a retry-and-fail-safe behavior to ensure gate results are recorded reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->