### PR TITLE
t1806: auto-clear expired oauth cooldowns during status checks

### DIFF
--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -109,6 +109,41 @@ get_now_ms() {
 	return 0
 }
 
+# Auto-clear expired cooldowns so stale rate limits do not block availability.
+# Usage: printf '%s' "$pool" | normalize_expired_cooldowns [provider|all]
+# Prints JSON object: {"updated": <count>, "pool": <updated_pool>}
+normalize_expired_cooldowns() {
+	local provider="${1:-all}"
+	local now_ms
+	now_ms=$(get_now_ms)
+	NOW_MS="$now_ms" PROVIDER="$provider" python3 -c "
+import sys, json, os
+
+pool = json.load(sys.stdin)
+target = os.environ['PROVIDER']
+now = int(os.environ['NOW_MS'])
+providers = ['anthropic', 'openai', 'cursor', 'google'] if target == 'all' else [target]
+updated = 0
+
+for prov in providers:
+    for account in pool.get(prov, []):
+        if account.get('status') != 'rate-limited':
+            continue
+        cooldown_until = account.get('cooldownUntil')
+        try:
+            cooldown_ms = int(cooldown_until)
+        except (TypeError, ValueError):
+            continue
+        if cooldown_ms > 0 and cooldown_ms <= now:
+            account['status'] = 'idle'
+            account['cooldownUntil'] = 0
+            updated += 1
+
+json.dump({'updated': updated, 'pool': pool}, sys.stdout, separators=(',', ':'))
+" 2>/dev/null
+	return 0
+}
+
 # Load pool JSON (create if missing)
 load_pool() {
 	if [[ -f "$POOL_FILE" ]]; then
@@ -1067,42 +1102,7 @@ now = int(os.environ['NOW_MS'])
 prov = os.environ['PROV']
 ua = os.environ['UA']
 
-for a in pool.get(prov, []):
-    print(f\"  {a['email']}:\")
-    expires_in = a.get('expires', 0) - now
-    if expires_in <= 0:
-        print(f\"    Token: EXPIRED\")
-    else:
-        mins = expires_in // 60000
-        hours = mins // 60
-        if hours > 0:
-            print(f\"    Token: expires in {hours}h {mins % 60}m\")
-        else:
-            print(f\"    Token: expires in {mins}m\")
-    print(f\"    Status: {a.get('status', 'unknown')}\")
-    cd = a.get('cooldownUntil')
-    if cd and cd > now:
-        cd_mins = (cd - now + 59999) // 60000
-        print(f\"    Cooldown: {cd_mins}m remaining\")
-    lu = a.get('lastUsed')
-    if lu:
-        try:
-            lu_ts = datetime.fromisoformat(lu.replace('Z','+00:00')).timestamp() * 1000
-            ago = now - lu_ts
-            ago_mins = int(ago // 60000)
-            ago_hours = ago_mins // 60
-            if ago_hours > 0:
-                print(f\"    Last used: {ago_hours}h {ago_mins % 60}m ago\")
-            else:
-                print(f\"    Last used: {ago_mins}m ago\")
-        except Exception:
-            print(f\"    Last used: {lu}\")
-    print(f\"    Refresh token: {'present' if a.get('refresh') else 'MISSING'}\")
-    _check_token_validity(a, prov, expires_in, ua)
-
 def _check_token_validity(a, prov, expires_in, ua):
-    from urllib.request import Request, urlopen
-    from urllib.error import HTTPError, URLError
     token = a.get('access', '')
     if prov == 'anthropic':
         if not token:
@@ -1149,6 +1149,39 @@ def _check_token_validity(a, prov, expires_in, ua):
                 print(f\"    Validity: ERROR (network)\")
             except Exception:
                 print(f\"    Validity: ERROR\")
+
+for a in pool.get(prov, []):
+    print(f\"  {a['email']}:\")
+    expires_in = a.get('expires', 0) - now
+    if expires_in <= 0:
+        print(f\"    Token: EXPIRED\")
+    else:
+        mins = expires_in // 60000
+        hours = mins // 60
+        if hours > 0:
+            print(f\"    Token: expires in {hours}h {mins % 60}m\")
+        else:
+            print(f\"    Token: expires in {mins}m\")
+    print(f\"    Status: {a.get('status', 'unknown')}\")
+    cd = a.get('cooldownUntil')
+    if cd and cd > now:
+        cd_mins = (cd - now + 59999) // 60000
+        print(f\"    Cooldown: {cd_mins}m remaining\")
+    lu = a.get('lastUsed')
+    if lu:
+        try:
+            lu_ts = datetime.fromisoformat(lu.replace('Z','+00:00')).timestamp() * 1000
+            ago = now - lu_ts
+            ago_mins = int(ago // 60000)
+            ago_hours = ago_mins // 60
+            if ago_hours > 0:
+                print(f\"    Last used: {ago_hours}h {ago_mins % 60}m ago\")
+            else:
+                print(f\"    Last used: {ago_mins}m ago\")
+        except Exception:
+            print(f\"    Last used: {lu}\")
+    print(f\"    Refresh token: {'present' if a.get('refresh') else 'MISSING'}\")
+    _check_token_validity(a, prov, expires_in, ua)
 " 2>/dev/null
 	return 0
 }
@@ -1171,6 +1204,15 @@ cmd_check() {
 
 	local pool
 	pool=$(load_pool)
+
+	local normalized updated
+	normalized=$(printf '%s' "$pool" | normalize_expired_cooldowns "$provider")
+	updated=$(printf '%s' "$normalized" | jq -r '.updated // 0')
+	pool=$(printf '%s' "$normalized" | jq -c '.pool')
+	if [[ "$updated" != "0" ]]; then
+		save_pool "$pool"
+		print_info "Auto-cleared ${updated} expired cooldown(s)."
+	fi
 
 	local -a providers_to_check
 	if [[ "$provider" == "all" ]]; then
@@ -1225,6 +1267,15 @@ cmd_list() {
 
 	local pool
 	pool=$(load_pool)
+
+	local normalized updated
+	normalized=$(printf '%s' "$pool" | normalize_expired_cooldowns "$provider")
+	updated=$(printf '%s' "$normalized" | jq -r '.updated // 0')
+	pool=$(printf '%s' "$normalized" | jq -c '.pool')
+	if [[ "$updated" != "0" ]]; then
+		save_pool "$pool"
+		print_info "Auto-cleared ${updated} expired cooldown(s)."
+	fi
 
 	local -a providers_to_list
 	if [[ "$provider" == "all" ]]; then
@@ -1834,6 +1885,15 @@ cmd_status() {
 	local pool
 	pool=$(load_pool)
 
+	local normalized updated
+	normalized=$(printf '%s' "$pool" | normalize_expired_cooldowns "$provider")
+	updated=$(printf '%s' "$normalized" | jq -r '.updated // 0')
+	pool=$(printf '%s' "$normalized" | jq -c '.pool')
+	if [[ "$updated" != "0" ]]; then
+		save_pool "$pool"
+		print_info "Auto-cleared ${updated} expired cooldown(s)."
+	fi
+
 	local -a providers_to_check
 	if [[ "$provider" == "all" ]]; then
 		providers_to_check=(anthropic openai cursor google)
@@ -2235,6 +2295,15 @@ cmd_status() {
 
 	local pool
 	pool=$(load_pool)
+
+	local normalized updated
+	normalized=$(printf '%s' "$pool" | normalize_expired_cooldowns "$provider")
+	updated=$(printf '%s' "$normalized" | jq -r '.updated // 0')
+	pool=$(printf '%s' "$normalized" | jq -c '.pool')
+	if [[ "$updated" != "0" ]]; then
+		save_pool "$pool"
+		print_info "Auto-cleared ${updated} expired cooldown(s)."
+	fi
 
 	local now_ms
 	now_ms=$(python3 -c "import time; print(int(time.time() * 1000))")

--- a/tests/test-oauth-pool-helper.sh
+++ b/tests/test-oauth-pool-helper.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$REPO_DIR/.agents/scripts/oauth-pool-helper.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+	PASS_COUNT=$((PASS_COUNT + 1))
+	printf "  PASS %s\n" "$1"
+	return 0
+}
+
+fail() {
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	printf "  FAIL %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
+	return 0
+}
+
+run_test_expired_cooldown_auto_clear() {
+	printf "\n=== expired cooldown auto-clear ===\n"
+
+	local test_home
+	test_home="$(mktemp -d)"
+	trap 'rm -rf "$test_home"' RETURN
+
+	mkdir -p "$test_home/.aidevops"
+	local now_ms
+	now_ms=$(python3 -c "import time; print(int(time.time() * 1000))")
+	local expired_ms
+	expired_ms=$((now_ms - 60000))
+
+	python3 - "$test_home/.aidevops/oauth-pool.json" "$expired_ms" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+expired_ms = int(sys.argv[2])
+pool = {
+    "openai": [
+        {
+            "email": "expired@example.com",
+            "access": "token",
+            "refresh": "refresh",
+            "expires": expired_ms + 3600000,
+            "status": "rate-limited",
+            "cooldownUntil": expired_ms,
+            "lastUsed": "2026-01-01T00:00:00Z"
+        }
+    ]
+}
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(pool, f, indent=2)
+PY
+
+	HOME="$test_home" bash "$SCRIPT_PATH" check openai >/tmp/oauth-check.out 2>/tmp/oauth-check.err
+
+	local status_after
+	status_after=$(jq -r '.openai[0].status' "$test_home/.aidevops/oauth-pool.json")
+	local cooldown_after
+	cooldown_after=$(jq -r '.openai[0].cooldownUntil' "$test_home/.aidevops/oauth-pool.json")
+
+	if [[ "$status_after" == "idle" ]]; then
+		pass "check auto-clears expired cooldown status"
+	else
+		fail "check did not auto-clear status" "status=$status_after"
+	fi
+
+	if [[ "$cooldown_after" == "0" ]]; then
+		pass "check clears cooldownUntil to 0"
+	else
+		fail "check did not clear cooldownUntil to 0" "cooldownUntil=$cooldown_after"
+	fi
+
+	local status_output
+	status_output=$(HOME="$test_home" bash "$SCRIPT_PATH" status openai 2>&1)
+	if [[ "$status_output" == *"Available now  : 1"* && "$status_output" == *"Rate limited   : 0"* ]]; then
+		pass "status reflects account as available after auto-clear"
+	else
+		fail "status output did not reflect cleared cooldown" "$status_output"
+	fi
+
+	local list_output
+	list_output=$(HOME="$test_home" bash "$SCRIPT_PATH" list openai 2>&1)
+	if [[ "$list_output" == *"expired@example.com [idle]"* ]]; then
+		pass "list shows idle status after auto-clear"
+	else
+		fail "list output did not show idle status" "$list_output"
+	fi
+
+	return 0
+}
+
+run_test_expired_cooldown_auto_clear
+
+printf "\nSummary: %s passed, %s failed\n" "$PASS_COUNT" "$FAIL_COUNT"
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add `normalize_expired_cooldowns` to automatically convert expired `rate-limited` entries back to `idle` and clear `cooldownUntil` to `0`
- run normalization before `check`, `list`, and both `status` implementations so stale cooldowns are persisted and no longer counted as unavailable
- reorder `_check_print_provider_accounts` Python helper so token validity checks execute without hanging during `check`

## Testing Evidence
- `shellcheck .agents/scripts/oauth-pool-helper.sh tests/test-oauth-pool-helper.sh`
- `bash tests/test-oauth-pool-helper.sh`

## Runtime Testing
- Level: High (polling/state handling in account availability logic)
- Verification: Executed helper command flow in regression test covering `check`, `status`, and `list` behavior after cooldown expiry

Closes #14326

---
[aidevops.sh](https://aidevops.sh) v3.5.462 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 7m and 92,338 tokens on this as a headless worker. Overall, 30m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accounts with expired rate-limit cooldowns are now automatically restored to available status when running check, list, or status commands.

* **Tests**
  * Added test coverage for automatic cooldown expiration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->