### PR TITLE
GH#14345: tighten Infraforge agent doc

### DIFF
--- a/.agents/services/outreach/infraforge.md
+++ b/.agents/services/outreach/infraforge.md
@@ -8,7 +8,7 @@ tools:
 
 # Infraforge
 
-Infraforge is the private-infrastructure option for outreach sending. Use it when you need dedicated IP control, tighter isolation, and deeper DNS/server ownership than shared mailbox providers.
+Infraforge is the private-infrastructure option for outreach sending. Use it when you need dedicated IP control, tighter isolation, and direct DNS/server ownership.
 
 ## Infraforge vs Mailforge
 
@@ -20,25 +20,25 @@ Infraforge is the private-infrastructure option for outreach sending. Use it whe
 | Operational burden | Higher (you own more moving parts) | Lower (provider abstracts infrastructure operations) |
 | Best fit | Teams optimizing long-term sender control | Teams optimizing speed-to-launch |
 
-## What This Covers
+## API Surfaces
 
 - Domain provisioning (`domains/provision`)
-- Mailbox creation (`mailboxes/create`)
 - DNS automation (`dns/upsert`)
+- Mailbox creation (`mailboxes/create`)
 - Dedicated IP assignment (`ips/assign`)
 - SSL enablement (`ssl/enable`)
 - Domain masking (`domain-masking/enable`)
 
 ## Helper Script
 
-Use `.agents/scripts/infraforge-helper.sh` for API operations.
+Use `.agents/scripts/infraforge-helper.sh` for all Infraforge API operations.
 
 ### Required Environment
 
 - `INFRAFORGE_API_KEY`
 - `INFRAFORGE_MAILBOX_PASSWORD` (only for mailbox creation)
 
-WARNING: Never paste secret values into AI chat. Run secret setup commands in your terminal and enter values at hidden prompts.
+Never paste secret values into AI chat. Set secrets in your terminal with hidden prompts.
 
 Suggested setup:
 
@@ -48,16 +48,16 @@ export INFRAFORGE_API_KEY="<loaded-in-your-terminal-session>"
 export INFRAFORGE_MAILBOX_PASSWORD="<mailbox-password>"
 ```
 
-## Typical Provisioning Flow
+## Provisioning Flow
 
-1. Provision sending domain
-2. Apply DNS records (SPF/DKIM/DMARC, MX, tracking host)
-3. Create mailbox(es)
-4. Assign dedicated IP to the sending domain
-5. Enable SSL
-6. Enable domain masking if required by your sending architecture
+1. Provision sending domain (`domains-provision`)
+2. Apply DNS records (`dns-upsert` for SPF/DKIM/DMARC, MX, tracking host)
+3. Create mailboxes (`mailboxes-create`)
+4. Assign dedicated IP (`ips-assign`)
+5. Enable SSL (`ssl-enable`)
+6. Enable domain masking when required by your sending architecture
 
-## Example Commands
+## Command Examples
 
 ```bash
 .agents/scripts/infraforge-helper.sh domains-provision sender-example.com
@@ -68,7 +68,7 @@ export INFRAFORGE_MAILBOX_PASSWORD="<mailbox-password>"
 .agents/scripts/infraforge-helper.sh ssl-enable sender-example.com
 ```
 
-## Operational Notes
+## Operational Guardrails
 
 - Keep mailbox throughput conservative during warmup (align with `services/outreach/cold-outreach.md` guidance)
 - Roll out DNS changes in small batches to reduce reputation shocks


### PR DESCRIPTION
## Summary
- Tightened wording in `.agents/services/outreach/infraforge.md` to reduce verbosity without removing operational guidance.
- Renamed sections for clearer scanning (`API Surfaces`, `Provisioning Flow`, `Operational Guardrails`) and aligned flow steps to helper command names.
- Kept all key operational constraints (provider comparison, secrets handling, DNS/IP/SSL steps, warmup and authentication guardrails).

## Testing Evidence
- `bash .agents/scripts/markdown-formatter.sh check ".agents/services/outreach/infraforge.md"` (pass)
- `.agents/scripts/linters-local.sh --help` (markdown section reported pass; repo-wide baseline errors are pre-existing and unrelated)

## Runtime Testing
- Level: self-assessed (docs-only change)
- Rationale: no runtime code path changed

Closes #14345

---
[aidevops.sh](https://aidevops.sh) v3.5.462 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 5m and 108,084 tokens on this with the user in an interactive session. Overall, 12m since this issue was created.