### PR TITLE
GH#14363: tighten score-responses.md

### DIFF
--- a/.agents/scripts/commands/score-responses.md
+++ b/.agents/scripts/commands/score-responses.md
@@ -4,69 +4,22 @@ agent: Build+
 mode: subagent
 ---
 
-Evaluate AI model responses against structured scoring criteria (correctness, completeness, code quality, clarity).
+Score AI model responses against structured criteria (correctness, completeness, code quality, clarity).
 
 Target: $ARGUMENTS
 
 ## Instructions
 
-1. Read `tools/ai-assistants/response-scoring.md` for the full scoring workflow.
+Read `tools/ai-assistants/response-scoring.md` for full scoring workflow, criteria weights, and CLI reference.
 
-2. If the user wants to create a new evaluation:
+**Workflow:** `prompt add` → `record` → `score` → `compare`/`leaderboard`. For live comparisons, send the same prompt to multiple models, record with timing/tokens, score all four criteria, present side-by-side.
 
-   ```bash
-   # Create a prompt
-   ~/.aidevops/agents/scripts/response-scoring-helper.sh prompt add --title "Title" --text "Prompt text"
-
-   # Record model responses
-   ~/.aidevops/agents/scripts/response-scoring-helper.sh record --prompt <id> --model <model_id> --text "response"
-
-   # Score each response
-   ~/.aidevops/agents/scripts/response-scoring-helper.sh score --response <id> --correctness <1-5> --completeness <1-5> --code-quality <1-5> --clarity <1-5>
-   ```
-
-3. If the user wants to compare existing results:
-
-   ```bash
-   # Compare responses for a prompt
-   ~/.aidevops/agents/scripts/response-scoring-helper.sh compare --prompt <id>
-
-   # View leaderboard
-   ~/.aidevops/agents/scripts/response-scoring-helper.sh leaderboard
-   ```
-
-4. If the user wants to run a live comparison:
-   - Send the same prompt to multiple models using their respective APIs
-   - Record each response with timing and token count
-   - Score each response on all four criteria
-   - Present the side-by-side comparison
-
-5. Present results with:
-   - Side-by-side scoring table
-   - Winner declaration with rationale
-   - Per-criterion breakdown
-   - Cost-effectiveness analysis (score per dollar)
-
-6. Scores automatically sync to the pattern tracker (t1099), feeding into `/route` and `/patterns` for data-driven model selection. Disable with `SCORING_NO_PATTERN_SYNC=1`. Bulk sync existing data with `response-scoring-helper.sh sync`.
-
-## Scoring Criteria
-
-| Criterion | Weight | Description |
-|-----------|--------|-------------|
-| Correctness | 30% | Factual accuracy and technical correctness |
-| Completeness | 25% | Coverage of all requirements and edge cases |
-| Code Quality | 25% | Clean code, best practices, maintainability |
-| Clarity | 20% | Clear explanation, good formatting, readability |
+Scores auto-sync to the pattern tracker (t1099), feeding `/route` and `/patterns`. Disable: `SCORING_NO_PATTERN_SYNC=1`. Bulk sync: `response-scoring-helper.sh sync`.
 
 ## Examples
 
 ```bash
-# Full evaluation workflow
 /score-responses --prompt "Write a Python function to merge two sorted lists" --models "claude-sonnet-4-6,gpt-4o,gemini-2.5-pro"
-
-# View existing comparisons
 /score-responses --leaderboard
-
-# Export results
 /score-responses --export --csv
 ```


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/score-responses.md` from 72 → 25 lines (65% reduction)
- Remove duplicated scoring criteria table (authoritative copy in `response-scoring.md`)
- Collapse verbose conditional prose into concise workflow directive
- Preserve all functionality: frontmatter, reference pointer, workflow steps, pattern tracker (t1099), examples

## What changed

| Before | After | Removed |
|--------|-------|---------|
| 72 lines | 25 lines | Duplicated criteria table, verbose "If the user wants to..." blocks, redundant CLI examples, results presentation list |

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** self-assessed — no runtime behavior change, content preservation verified against original

Closes #14363


---
[aidevops.sh](https://aidevops.sh) v3.5.462 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined command documentation with improved clarity and workflow guidance, condensing instructions while maintaining essential information and adding references to detailed resource guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->