### PR TITLE
GH#14383: tighten queues.md — remove structural noise, fix broken links (67→45 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/queues.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/queues.md
@@ -1,6 +1,6 @@
 # Cloudflare Queues
 
-Flexible message queuing for async task processing. At-least-once delivery, push-based (Worker) and pull-based (HTTP) consumers, configurable batching/retries, Dead Letter Queues (DLQ), delays up to 12 hours.
+Flexible message queuing for async task processing with at-least-once delivery. Supports push-based (Worker) and pull-based (HTTP) consumers, configurable batching/retries, Dead Letter Queues (DLQ), and delays up to 12 hours.
 
 **Use cases:** Async processing, API buffering, rate limiting, event workflows, deferred jobs
 

--- a/.agents/services/hosting/cloudflare-platform-skill/queues.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/queues.md
@@ -1,15 +1,6 @@
 # Cloudflare Queues
 
-Flexible message queuing for async task processing with guaranteed at-least-once delivery and configurable batching.
-
-## Overview
-
-Queues provide:
-- At-least-once delivery guarantee
-- Push-based (Worker) and pull-based (HTTP) consumers
-- Configurable batching and retries
-- Dead Letter Queues (DLQ)
-- Delays up to 12 hours
+Flexible message queuing for async task processing. At-least-once delivery, push-based (Worker) and pull-based (HTTP) consumers, configurable batching/retries, Dead Letter Queues (DLQ), delays up to 12 hours.
 
 **Use cases:** Async processing, API buffering, rate limiting, event workflows, deferred jobs
 
@@ -45,23 +36,10 @@ export default {
 | `message.retry(options?)` | Retry with delay | - |
 | `batch.ackAll()` | Ack entire batch | - |
 
-## Architecture
-
-```
-[Producer Worker] → [Queue] → [Consumer Worker/HTTP] → [Processing]
-```
-
-- Max 10,000 queues per account
-- 5,000 msgs/second per queue
-- 4-14 day retention (configurable)
-
-## In This Reference
-
-- [patterns.md](./patterns.md) - Async tasks, buffering, rate limiting, event workflows
-- [gotchas.md](./gotchas.md) - Idempotency, retry limits, content types, cost optimization
-
 ## See Also
 
-- [workers](../workers/) - Worker runtime for producers/consumers
-- [r2](../r2/) - Process R2 event notifications via queues
-- [d1](../d1/) - Batch write to D1 from queue consumers
+- [queues-patterns.md](./queues-patterns.md) — async tasks, buffering, rate limiting, fan-out, event workflows, DLQ
+- [queues-gotchas.md](./queues-gotchas.md) — idempotency, retry limits, content types, cost optimization, limits
+- [workers](../workers/) — Worker runtime for producers/consumers
+- [r2](../r2/) — process R2 event notifications via queues
+- [d1](../d1/) — batch write to D1 from queue consumers

--- a/.agents/services/hosting/cloudflare-platform-skill/queues.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/queues.md
@@ -40,6 +40,6 @@ export default {
 
 - [queues-patterns.md](./queues-patterns.md) — async tasks, buffering, rate limiting, fan-out, event workflows, DLQ
 - [queues-gotchas.md](./queues-gotchas.md) — idempotency, retry limits, content types, cost optimization, limits
-- [workers](../workers/) — Worker runtime for producers/consumers
-- [r2](../r2/) — process R2 event notifications via queues
-- [d1](../d1/) — batch write to D1 from queue consumers
+- [workers.md](./workers.md) — Worker runtime for producers/consumers
+- [r2.md](./r2.md) — process R2 event notifications via queues
+- [d1.md](./d1.md) — batch write to D1 from queue consumers


### PR DESCRIPTION
## GH#14383: tighten queues.md — remove structural noise, preserve all knowledge

### Changes

- **Merged `## Overview` section** into the intro sentence — the bullet list duplicated what the intro already said (−8 lines)
- **Removed `## Architecture` section** — ASCII diagram `[Producer] → [Queue] → [Consumer]` is trivially obvious from the Quick Start code; the 3 limits bullets are fully covered in `queues-gotchas.md` Limits table (−7 lines)
- **Merged `## In This Reference` + `## See Also`** into a single `## See Also` section (−4 lines)
- **Fixed broken relative links**: `./patterns.md` → `./queues-patterns.md`, `./gotchas.md` → `./queues-gotchas.md` (actual filenames in the directory)
- **Consistent dash style**: `-` → `—` in See Also entries

### Result

67 lines → 45 lines (33% reduction). All knowledge preserved — no code blocks, URLs, commands, or operational content removed.

### Verification

- All code blocks present: ✅ bash wrangler commands, TypeScript producer/consumer
- All Core Operations table entries: ✅ send, sendBatch, ack, retry, ackAll with limits
- All use cases: ✅ merged into intro + use cases line
- Links to companion docs: ✅ fixed and working
- No broken internal references: ✅

## Runtime Testing

Risk level: **Low** — documentation-only change, no code or agent logic modified.
Testing: `self-assessed` — verified file content, link targets exist in directory.

Closes #14383

---
[aidevops.sh](https://aidevops.sh) v3.5.462 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined Cloudflare Queues documentation with a simplified introduction and condensed sections.
  * Removed detailed architecture diagrams and configuration limits from the reference.
  * Updated links to related guides for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->