### PR TITLE
GH#14394: recover failed launch claims and block telemetry dispatch

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -542,6 +542,11 @@ has_open_pr() {
 # cover long-running workers). Only comments from other logins are
 # considered; self-posted comments are ignored.
 #
+# Additional guard (t1702): dispatch comments only block when the issue is
+# still actively claimed (OPEN + assigned + status:queued/in-progress).
+# If the claim state has been cleared, old dispatch comments are treated as
+# stale breadcrumbs and must not block redispatch.
+#
 # Args:
 #   $1 = issue number
 #   $2 = repo slug (owner/repo)
@@ -565,6 +570,27 @@ has_dispatch_comment() {
 
 	local now_epoch
 	now_epoch=$(date -u '+%s')
+
+	# Only treat dispatch comments as active when issue is actively claimed.
+	# This prevents stale historical comments from blocking fresh dispatches.
+	local issue_meta_json
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" --json state,assignees,labels 2>/dev/null) || issue_meta_json=""
+	if [[ -z "$issue_meta_json" ]]; then
+		return 1
+	fi
+
+	local is_open has_assignee has_active_status
+	is_open=$(printf '%s' "$issue_meta_json" | jq -r '.state == "OPEN"' 2>/dev/null)
+	has_assignee=$(printf '%s' "$issue_meta_json" | jq -r '(.assignees | length) > 0' 2>/dev/null)
+	has_active_status=$(printf '%s' "$issue_meta_json" | jq -r '([.labels[].name] | (index("status:queued") != null or index("status:in-progress") != null))' 2>/dev/null)
+
+	[[ "$is_open" == "true" || "$is_open" == "false" ]] || is_open="false"
+	[[ "$has_assignee" == "true" || "$has_assignee" == "false" ]] || has_assignee="false"
+	[[ "$has_active_status" == "true" || "$has_active_status" == "false" ]] || has_active_status="false"
+
+	if [[ "$is_open" != "true" || "$has_assignee" != "true" || "$has_active_status" != "true" ]]; then
+		return 1
+	fi
 
 	# Fetch recent comments and look for "Dispatching worker" from non-self authors
 	local comments_json

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4430,6 +4430,33 @@ dispatch_with_dedup() {
 	local prompt="$7"
 	local session_key="${8:-issue-${issue_number}}"
 
+	# Hard stop for supervisor/telemetry issues (t1702 pulse guard).
+	# The pulse prompt should already avoid these, but this deterministic
+	# gate prevents dispatch when prompt fallback logic is too permissive.
+	local issue_meta_json
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json number,title,state,labels 2>/dev/null) || issue_meta_json=""
+	if [[ -n "$issue_meta_json" ]]; then
+		local target_state target_title
+		target_state=$(echo "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null)
+		target_title=$(echo "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
+
+		if [[ "$target_state" != "OPEN" ]]; then
+			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: issue state is ${target_state:-unknown}" >>"$LOGFILE"
+			return 1
+		fi
+
+		if echo "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review"))' >/dev/null 2>&1; then
+			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
+			return 1
+		fi
+
+		if [[ "$target_title" == \[Supervisor:* ]]; then
+			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: supervisor telemetry title" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
 	# All 7 dedup layers — cannot be skipped
 	if check_dispatch_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" "$self_login"; then
 		echo "[dispatch_with_dedup] Dedup guard blocked #${issue_number} in ${repo_slug}" >>"$LOGFILE"
@@ -4885,24 +4912,129 @@ count_queued_without_worker() {
 		return 0
 	fi
 
+	local self_login
+	self_login=$(gh api user --jq '.login' 2>/dev/null || echo "")
+
 	local total=0
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
-		local queued_numbers
-		queued_numbers=$(gh issue list --repo "$slug" --state open --label "status:queued" --json number --jq '.[].number' --limit "$PULSE_QUEUED_SCAN_LIMIT" 2>/dev/null) || queued_numbers=""
-		if [[ -z "$queued_numbers" ]]; then
+		local queued_json
+		queued_json=$(gh issue list --repo "$slug" --state open --label "status:queued" --json number,assignees --limit "$PULSE_QUEUED_SCAN_LIMIT" 2>/dev/null) || queued_json="[]"
+
+		local queued_count
+		queued_count=$(echo "$queued_json" | jq 'length' 2>/dev/null) || queued_count=0
+		[[ "$queued_count" =~ ^[0-9]+$ ]] || queued_count=0
+		if [[ "$queued_count" -eq 0 ]]; then
 			continue
 		fi
 
-		while IFS= read -r issue_num; do
+		while IFS='|' read -r issue_num assigned_to_other; do
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
+
+			# Cross-runner safety: queued issues assigned to another login are not
+			# counted as "without worker" because the worker may be running on that
+			# runner's machine and invisible to local process inspection.
+			if [[ "$assigned_to_other" == "true" ]]; then
+				continue
+			fi
+
 			if ! has_worker_for_repo_issue "$issue_num" "$slug"; then
 				total=$((total + 1))
 			fi
-		done <<<"$queued_numbers"
+		done < <(echo "$queued_json" | jq -r --arg self "$self_login" '.[] | .number as $n | ((.assignees | length) > 0 and (([.assignees[].login] | index($self)) == null)) as $assigned_other | "\($n)|\($assigned_other)"' 2>/dev/null)
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
 
 	echo "$total"
+	return 0
+}
+
+#######################################
+# Recover issue state after launch validation failure (t1702)
+#
+# When launch validation fails, the issue may remain assigned + queued even
+# though no worker process exists. This traps capacity by blocking redispatch.
+#
+# Safety gates:
+#   - Only act on OPEN issues
+#   - Only act when current GitHub login is assigned on the issue
+#   - Only act when issue still has status:queued label
+#   - Re-check for a late-started worker before mutating issue state
+#
+# Actions (best-effort):
+#   1. Mark any in-flight ledger entry for this issue as failed
+#   2. Remove self assignee and status:queued
+#   3. Re-label status:available unless issue is blocked
+#
+# Args:
+#   $1 - issue number
+#   $2 - repo slug
+#   $3 - failure reason string (for logs)
+#######################################
+recover_failed_launch_state() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local failure_reason="${3:-launch_validation_failed}"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+		return 0
+	fi
+
+	local self_login
+	self_login=$(gh api user --jq '.login' 2>/dev/null || echo "")
+	if [[ -z "$self_login" ]]; then
+		echo "[pulse-wrapper] Launch recovery skipped for #${issue_number} (${repo_slug}): unable to resolve current login" >>"$LOGFILE"
+		return 0
+	fi
+
+	local issue_meta_json
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" --json state,labels,assignees 2>/dev/null) || issue_meta_json=""
+	if [[ -z "$issue_meta_json" ]]; then
+		return 0
+	fi
+
+	local issue_state assigned_to_self has_queued is_blocked
+	issue_state=$(echo "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null)
+	assigned_to_self=$(echo "$issue_meta_json" | jq -r --arg self "$self_login" '([.assignees[].login] | index($self)) != null' 2>/dev/null)
+	has_queued=$(echo "$issue_meta_json" | jq -r '([.labels[].name] | index("status:queued")) != null' 2>/dev/null)
+	is_blocked=$(echo "$issue_meta_json" | jq -r '([.labels[].name] | index("status:blocked")) != null' 2>/dev/null)
+
+	[[ "$assigned_to_self" == "true" || "$assigned_to_self" == "false" ]] || assigned_to_self="false"
+	[[ "$has_queued" == "true" || "$has_queued" == "false" ]] || has_queued="false"
+	[[ "$is_blocked" == "true" || "$is_blocked" == "false" ]] || is_blocked="false"
+
+	if [[ "$issue_state" != "OPEN" ]] || [[ "$assigned_to_self" != "true" ]] || [[ "$has_queued" != "true" ]]; then
+		return 0
+	fi
+
+	# Re-check once for late-started workers before mutating labels/assignees.
+	if has_worker_for_repo_issue "$issue_number" "$repo_slug"; then
+		echo "[pulse-wrapper] Launch recovery skipped for #${issue_number} (${repo_slug}): worker appeared after validation failure" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Mark in-flight ledger entry as failed for this issue.
+	local ledger_helper
+	ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+	if [[ -x "$ledger_helper" ]]; then
+		local ledger_entry session_key
+		ledger_entry=$("$ledger_helper" check-issue --issue "$issue_number" --repo "$repo_slug" 2>/dev/null || true)
+		session_key=$(printf '%s' "$ledger_entry" | jq -r '.session_key // ""' 2>/dev/null)
+		if [[ -n "$session_key" ]]; then
+			"$ledger_helper" fail --session-key "$session_key" >/dev/null 2>&1 || true
+		fi
+	fi
+
+	if [[ "$is_blocked" == "true" ]]; then
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--remove-assignee "$self_login" --remove-label "status:queued" >/dev/null 2>&1 || true
+	else
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--remove-assignee "$self_login" --remove-label "status:queued" --add-label "status:available" >/dev/null 2>&1 ||
+			gh issue edit "$issue_number" --repo "$repo_slug" \
+				--remove-assignee "$self_login" --remove-label "status:queued" >/dev/null 2>&1 || true
+	fi
+
+	echo "[pulse-wrapper] Launch recovery reset #${issue_number} (${repo_slug}) after ${failure_reason}: removed self assignee + status:queued" >>"$LOGFILE"
 	return 0
 }
 
@@ -4946,6 +5078,7 @@ check_worker_launch() {
 			local candidate
 			for candidate in "${log_candidates[@]}"; do
 				if [[ -f "$candidate" ]] && rg -q '^opencode run \[message\.\.\]|^run opencode with a message|^Options:' "$candidate"; then
+					recover_failed_launch_state "$issue_number" "$repo_slug" "cli_usage_output"
 					echo "[pulse-wrapper] Launch validation failed for issue #${issue_number} (${repo_slug}) — CLI usage output detected in ${candidate}" >>"$LOGFILE"
 					return 1
 				fi
@@ -4956,6 +5089,7 @@ check_worker_launch() {
 		elapsed=$((elapsed + poll_seconds))
 	done
 
+	recover_failed_launch_state "$issue_number" "$repo_slug" "no_worker_process"
 	echo "[pulse-wrapper] Launch validation failed for issue #${issue_number} (${repo_slug}) — no active worker process within ${grace_seconds}s" >>"$LOGFILE"
 	return 1
 }

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4436,25 +4436,28 @@ dispatch_with_dedup() {
 	local issue_meta_json
 	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json number,title,state,labels 2>/dev/null) || issue_meta_json=""
-	if [[ -n "$issue_meta_json" ]]; then
-		local target_state target_title
-		target_state=$(echo "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null)
-		target_title=$(echo "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
+	if [[ -z "$issue_meta_json" ]]; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to load issue metadata" >>"$LOGFILE"
+		return 1
+	fi
 
-		if [[ "$target_state" != "OPEN" ]]; then
-			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: issue state is ${target_state:-unknown}" >>"$LOGFILE"
-			return 1
-		fi
+	local target_state target_title
+	target_state=$(echo "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null)
+	target_title=$(echo "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
 
-		if echo "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review"))' >/dev/null 2>&1; then
-			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
-			return 1
-		fi
+	if [[ "$target_state" != "OPEN" ]]; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: issue state is ${target_state:-unknown}" >>"$LOGFILE"
+		return 1
+	fi
 
-		if [[ "$target_title" == \[Supervisor:* ]]; then
-			echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: supervisor telemetry title" >>"$LOGFILE"
-			return 1
-		fi
+	if echo "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review"))' >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
+		return 1
+	fi
+
+	if [[ "$target_title" == \[Supervisor:* ]]; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: supervisor telemetry title" >>"$LOGFILE"
+		return 1
 	fi
 
 	# All 7 dedup layers — cannot be skipped
@@ -4979,6 +4982,27 @@ recover_failed_launch_state() {
 		return 0
 	fi
 
+	# Mark in-flight ledger entry as failed even if GitHub claim edits never stuck.
+	local ledger_helper
+	ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+	if [[ -x "$ledger_helper" ]]; then
+		local ledger_entry session_key
+		ledger_entry=$("$ledger_helper" check-issue --issue "$issue_number" --repo "$repo_slug" 2>/dev/null || true)
+		session_key=$(printf '%s' "$ledger_entry" | jq -r '.session_key // ""' 2>/dev/null)
+		if [[ -n "$session_key" ]]; then
+			"$ledger_helper" fail --session-key "$session_key" >/dev/null 2>&1 || true
+		fi
+	fi
+
+	# For no-worker failures, skip cleanup if a late-started worker appears.
+	# For cli_usage_output failures, always continue to clear stale claim state.
+	if [[ "$failure_reason" != "cli_usage_output" ]]; then
+		if has_worker_for_repo_issue "$issue_number" "$repo_slug"; then
+			echo "[pulse-wrapper] Launch recovery skipped for #${issue_number} (${repo_slug}): worker appeared after validation failure" >>"$LOGFILE"
+			return 0
+		fi
+	fi
+
 	local self_login
 	self_login=$(gh api user --jq '.login' 2>/dev/null || echo "")
 	if [[ -z "$self_login" ]]; then
@@ -5004,24 +5028,6 @@ recover_failed_launch_state() {
 
 	if [[ "$issue_state" != "OPEN" ]] || [[ "$assigned_to_self" != "true" ]] || [[ "$has_queued" != "true" ]]; then
 		return 0
-	fi
-
-	# Re-check once for late-started workers before mutating labels/assignees.
-	if has_worker_for_repo_issue "$issue_number" "$repo_slug"; then
-		echo "[pulse-wrapper] Launch recovery skipped for #${issue_number} (${repo_slug}): worker appeared after validation failure" >>"$LOGFILE"
-		return 0
-	fi
-
-	# Mark in-flight ledger entry as failed for this issue.
-	local ledger_helper
-	ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
-	if [[ -x "$ledger_helper" ]]; then
-		local ledger_entry session_key
-		ledger_entry=$("$ledger_helper" check-issue --issue "$issue_number" --repo "$repo_slug" 2>/dev/null || true)
-		session_key=$(printf '%s' "$ledger_entry" | jq -r '.session_key // ""' 2>/dev/null)
-		if [[ -n "$session_key" ]]; then
-			"$ledger_helper" fail --session-key "$session_key" >/dev/null 2>&1 || true
-		fi
 	fi
 
 	if [[ "$is_blocked" == "true" ]]; then

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -478,7 +478,13 @@ STUB
 	chmod +x "${TEST_ROOT}/dispatch-ledger-helper.sh"
 
 	# Stub gh to avoid real API calls
-	gh() { return 0; }
+	gh() {
+		if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+			printf '{"state":"OPEN","title":"t8888: test pass","labels":[]}\n'
+			return 0
+		fi
+		return 0
+	}
 	export -f gh
 
 	local dispatch_rc=0


### PR DESCRIPTION
## Summary
- Recover issue claim state after launch-validation failure so stale `status:queued` assignments do not trap worker capacity.
- Treat historical "Dispatching worker" comments as blocking only while an issue is actively claimed (`OPEN` + assignee + queued/in-progress label).
- Add deterministic non-dispatchable guardrails in `dispatch_with_dedup` and cross-runner-safe `queued_without_worker` counting.

## Verification
- `shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/dispatch-dedup-helper.sh`
- Deployed pulse validation cycles completed at `2026-03-30T19:30:04Z` and `2026-03-30T19:36:41Z` with `queued_without_worker=0` and no recurrence of dedup-blocked telemetry failure reason.

Closes #14394


---
[aidevops.sh](https://aidevops.sh) v3.5.462 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 2h 58m and 4,086,812 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined dispatch deduplication to better distinguish between active and historical dispatch records, preventing false blocking
  * Strengthened dispatch validation with comprehensive state and label requirement checks
  * Introduced automatic recovery mechanism for failed dispatch operations to enhance system stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->