### PR TITLE
GH#14393: tighten ip-check.md command doc

### DIFF
--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -19,6 +19,8 @@ Arguments: $ARGUMENTS
 | `1.2.3.4 --no-cache` | Bypass cache | `ip-reputation-helper.sh check "$IP" --no-cache` |
 | _(no args)_ | Show usage | |
 
+Ops subcommands: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
+
 All commands: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`
 
 ## Output Format
@@ -37,7 +39,7 @@ Providers (8/10 responded):
 Flags: Tor=NO  Proxy=NO  VPN=NO
 ```
 
-Providers: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
+Supported providers: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
 
 After presenting results, offer follow-up: full report, single-provider recheck, batch check, raw JSON, cache-clear recheck.
 

--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -4,53 +4,40 @@ agent: Build+
 mode: subagent
 ---
 
-Check IP reputation and risk level across multiple providers.
-
 Arguments: $ARGUMENTS
 
 ## Argument Dispatch
 
-| Input | Action |
-|-------|--------|
-| `1.2.3.4` | Full multi-provider check, table output |
-| `1.2.3.4 -f json` | JSON output |
-| `1.2.3.4 report` | Detailed markdown report |
-| `1.2.3.4 --provider abuseipdb` | Single-provider check |
-| `ips.txt` | Batch check from file |
-| `ips.txt --dnsbl-overlap` | Batch with DNSBL cross-reference |
-| `1.2.3.4 --no-cache` | Bypass cache |
-| _(no args)_ | Show usage |
+| Input | Action | Command |
+|-------|--------|---------|
+| `1.2.3.4` | Full multi-provider check, table output | `ip-reputation-helper.sh check "$IP"` |
+| `1.2.3.4 -f json` | JSON output | `ip-reputation-helper.sh check "$IP" -f json` |
+| `1.2.3.4 report` | Detailed markdown report | `ip-reputation-helper.sh report "$IP"` |
+| `1.2.3.4 --provider abuseipdb` | Single-provider check | `ip-reputation-helper.sh check "$IP" --provider "$PROVIDER"` |
+| `ips.txt` | Batch check from file | `ip-reputation-helper.sh batch "$FILE"` |
+| `ips.txt --dnsbl-overlap` | Batch with DNSBL cross-reference | `ip-reputation-helper.sh batch "$FILE" --dnsbl-overlap` |
+| `1.2.3.4 --no-cache` | Bypass cache | `ip-reputation-helper.sh check "$IP" --no-cache` |
+| _(no args)_ | Show usage | |
 
-## Commands
-
-```bash
-~/.aidevops/agents/scripts/ip-reputation-helper.sh check "$IP"
-~/.aidevops/agents/scripts/ip-reputation-helper.sh check "$IP" -f json
-~/.aidevops/agents/scripts/ip-reputation-helper.sh report "$IP"
-~/.aidevops/agents/scripts/ip-reputation-helper.sh check "$IP" --provider "$PROVIDER"
-~/.aidevops/agents/scripts/ip-reputation-helper.sh batch "$FILE"
-```
+All commands: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`
 
 ## Output Format
 
 ```text
 IP Reputation: 1.2.3.4
-
 Risk Level:  CLEAN (score: 2/100)
 Verdict:     SAFE — no significant flags detected
 
 Providers (8/10 responded):
   Spamhaus DNSBL    clean   (0)
-  ProxyCheck.io     clean   (0)
-  StopForumSpam     clean   (0)
-  Blocklist.de      clean   (0)
-  GreyNoise         clean   (0)
   AbuseIPDB         clean   (0)
   IPQualityScore    clean   (2)
-  Scamalytics       clean   (0)
+  ...
 
 Flags: Tor=NO  Proxy=NO  VPN=NO
 ```
+
+Providers: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
 
 After presenting results, offer follow-up: full report, single-provider recheck, batch check, raw JSON, cache-clear recheck.
 


### PR DESCRIPTION
## Summary

- Merged separate "Argument Dispatch" and "Commands" sections into a single unified table with Input/Action/Command columns
- Compressed output format example from 17 to 11 lines — kept structure, trimmed redundant provider entries (all 8 providers listed inline)
- Removed redundant description line that duplicated frontmatter

**Result**: 62 → 49 lines (21% reduction). Zero knowledge loss — all 8 argument patterns, all 5 CLI commands, all 8 provider names, output structure, follow-up instruction, and all 4 related links preserved.

Closes #14393

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, content preservation verified by diffing all code blocks, URLs, command examples, and provider names


---
[aidevops.sh](https://aidevops.sh) v3.5.463 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6 spent 33m and 12 tokens on this with the user in an interactive session. Overall, 39m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated IP check command documentation with improved structure, including expanded command dispatch table and streamlined output examples for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->