### PR TITLE
GH#14414: address review feedback on onboarding.md

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -65,7 +65,7 @@ Hand-fix: `"tools": {}` (not `[]`), `"type": "local"|"remote"`, `"tool_name": tr
 | Domains | 101domains | `configs/101domains-config.json` | — |
 | Secrets | Vaultwarden | `configs/vaultwarden-config.json` | — |
 
-CodeRabbit key: `mkdir -p ~/.config/coderabbit && chmod 700 ~/.config/coderabbit`, write key to `~/.config/coderabbit/api_key`, `chmod 600 ~/.config/coderabbit/api_key`.
+CodeRabbit key setup (single command): `mkdir -p ~/.config/coderabbit && chmod 700 ~/.config/coderabbit && echo "YOUR_API_KEY_HERE" > ~/.config/coderabbit/api_key && chmod 600 ~/.config/coderabbit/api_key`
 
 SEO: `/keyword-research`, `/autocomplete-research`, `/keyword-research-extended`, `/webmaster-keywords`
 
@@ -110,8 +110,9 @@ chmod 600 ~/.config/aidevops/credentials.sh && chmod 700 ~/.config/aidevops
 ## Repo Sync & Orchestration
 
 ```bash
-# Configure git parent directories for repo sync
-jq --argjson dirs '["~/Git", "~/Projects"]' '. + {git_parent_dirs: $dirs}' \
+# Configure git parent directories for repo sync (creates repos.json if missing)
+mkdir -p ~/.config/aidevops && { [ -s ~/.config/aidevops/repos.json ] || echo '{}' > ~/.config/aidevops/repos.json; } && \
+  jq --argjson dirs '["~/Git", "~/Projects"]' '. + {git_parent_dirs: $dirs}' \
   ~/.config/aidevops/repos.json > /tmp/repos.json && mv /tmp/repos.json ~/.config/aidevops/repos.json
 aidevops repo-sync enable
 aidevops config set orchestration.supervisor_pulse true && ./setup.sh  # Enable autonomous orchestration

--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -65,7 +65,7 @@ Hand-fix: `"tools": {}` (not `[]`), `"type": "local"|"remote"`, `"tool_name": tr
 | Domains | 101domains | `configs/101domains-config.json` | — |
 | Secrets | Vaultwarden | `configs/vaultwarden-config.json` | — |
 
-CodeRabbit key setup (single command): `mkdir -p ~/.config/coderabbit && chmod 700 ~/.config/coderabbit && echo "YOUR_API_KEY_HERE" > ~/.config/coderabbit/api_key && chmod 600 ~/.config/coderabbit/api_key`
+CodeRabbit key setup (single command): `read -rsp "CodeRabbit API key: " CODERABBIT_API_KEY && echo && mkdir -p ~/.config/coderabbit && chmod 700 ~/.config/coderabbit && printf '%s\n' "$CODERABBIT_API_KEY" > ~/.config/coderabbit/api_key && chmod 600 ~/.config/coderabbit/api_key && unset CODERABBIT_API_KEY`
 
 SEO: `/keyword-research`, `/autocomplete-research`, `/keyword-research-extended`, `/webmaster-keywords`
 
@@ -112,8 +112,9 @@ chmod 600 ~/.config/aidevops/credentials.sh && chmod 700 ~/.config/aidevops
 ```bash
 # Configure git parent directories for repo sync (creates repos.json if missing)
 mkdir -p ~/.config/aidevops && { [ -s ~/.config/aidevops/repos.json ] || echo '{}' > ~/.config/aidevops/repos.json; } && \
+  tmp_file="$(mktemp "${TMPDIR:-/tmp}/repos.XXXXXX")" && \
   jq --argjson dirs '["~/Git", "~/Projects"]' '. + {git_parent_dirs: $dirs}' \
-  ~/.config/aidevops/repos.json > /tmp/repos.json && mv /tmp/repos.json ~/.config/aidevops/repos.json
+  ~/.config/aidevops/repos.json > "$tmp_file" && mv "$tmp_file" ~/.config/aidevops/repos.json
 aidevops repo-sync enable
 aidevops config set orchestration.supervisor_pulse true && ./setup.sh  # Enable autonomous orchestration
 # Runners: see scripts/commands/runners.md (launchd/cron)


### PR DESCRIPTION
## Summary

- CodeRabbit key setup (line 68): replaced prose-style multi-step instruction with a single copy-pasteable command, eliminating ambiguity
- Repo sync jq command (line 114): added `mkdir -p` + empty-file fallback guard so first-time setup doesn't fail when `repos.json` is missing

## Verification

| Metric | Before | After |
|--------|--------|-------|
| markdownlint | 0 errors | 0 errors |
| Lines | 128 | 129 |
| Code blocks | 4 | 4 |

## Runtime Testing

- **Level**: self-assessed
- **Risk**: Low (docs/agent prompt only, no code changes)
- **Rationale**: Agent doc fix — no runtime behavior change

Closes #14414


---
[aidevops.sh](https://aidevops.sh) v3.5.463 plugin for [OpenCode](https://opencode.ai) v1.3.7 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified CodeRabbit API key setup with a single interactive command that handles directory creation, file permissions, and secure key storage.
  * Improved Repo Sync & Orchestration docs to ensure the config file exists (creates default when missing) and performs safer temporary-file updates when modifying repo configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->