### PR TITLE
GH#14457: tighten patterns command guidance

### DIFF
--- a/.agents/scripts/commands/patterns.md
+++ b/.agents/scripts/commands/patterns.md
@@ -5,44 +5,37 @@ mode: subagent
 model: haiku
 ---
 
-Analyze and display success/failure patterns relevant to the current context.
+Show cross-session success/failure patterns relevant to the current task.
 
-Arguments: $ARGUMENTS
+Arguments: `$ARGUMENTS`
 
 ## Instructions
 
-1. Query cross-session memory for pattern data:
+1. Query memory for all pattern types:
 
 ```bash
-# Get success patterns
 ~/.aidevops/agents/scripts/memory-helper.sh recall "success pattern" --type SUCCESS_PATTERN --limit 20
-
-# Get failure patterns
 ~/.aidevops/agents/scripts/memory-helper.sh recall "failure pattern" --type FAILURE_PATTERN --limit 20
-
-# Get working solutions
 ~/.aidevops/agents/scripts/memory-helper.sh recall "working solution" --type WORKING_SOLUTION --limit 10
-
-# Get failed approaches
 ~/.aidevops/agents/scripts/memory-helper.sh recall "failed approach" --type FAILED_APPROACH --limit 10
 ```
 
-2. If arguments are provided, filter results relevant to the task description.
+2. Apply mode from arguments:
+   - Contains `recommend` → prioritize model-tier recommendation from observed outcomes.
+   - Contains `report` → return full pattern summary.
+   - Otherwise → return concise task-focused suggestions.
 
-3. If arguments contain "recommend", focus on model tier recommendations based on success/failure rates per tier.
+3. If arguments are provided, filter findings to task-relevant patterns.
 
-4. If arguments contain "report", provide a comprehensive summary of all patterns.
+4. Present output in this order:
+   - **What works:** approaches with repeated success in similar tasks
+   - **What fails:** approaches with repeated failure or regressions
+   - **Recommended tier:** best model tier with short rationale from pattern evidence
 
-5. Present the results with actionable guidance:
-   - Highlight what approaches have worked for similar tasks
-   - Warn about approaches that have failed
-   - Suggest the optimal model tier based on pattern data
-
-6. If no patterns exist yet, explain how to start recording:
+5. If no patterns exist, return:
 
 ```text
-No patterns recorded yet. Patterns are recorded automatically by the
-pulse supervisor after observing outcomes, or manually with:
+No patterns recorded yet. Patterns are recorded automatically by the pulse supervisor after observing outcomes, or manually with:
 
   /remember "SUCCESS: bugfix with sonnet — structured debugging found root cause quickly"
   /remember "FAILURE: architecture with sonnet — needed opus for cross-service trade-offs"


### PR DESCRIPTION
## Summary
- tighten `/patterns` command instructions to prioritize output ordering and argument-driven modes
- preserve all recall commands while reducing verbosity and improving scannability for fast execution
- keep no-pattern fallback guidance with explicit `/remember` examples

## Testing Evidence
- `npx --yes markdownlint-cli2 ".agents/scripts/commands/patterns.md"`

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Not required: no runtime behavior or executable code changed

Closes #14457


---
[aidevops.sh](https://aidevops.sh) v3.5.464 plugin for [OpenCode](https://opencode.ai) v1.3.7 with gpt-5.3-codex spent 2m and 57,268 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated patterns command documentation with restructured output format
  * Clarified argument modes for different pattern analysis operations
  * Improved focus on cross-session success/failure patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->