### PR TITLE
GH#14413: enforce single-session worktree ownership gate

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -161,6 +161,8 @@ PR title: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NN
 
 Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `main`, and treat the Git ref as an internal detail inside the linked worktree. User-facing guidance should talk about the worktree path, not "using a branch". Re-read files at worktree path before editing. NEVER remove others' worktrees.
 
+**Worktree/session isolation (MANDATORY):** exactly one active session may own a writable worktree path at a time. Never reuse a live worktree across sessions (interactive or headless). If ownership conflict is detected, create a fresh worktree for the current task/session instead of continuing in the contested path.
+
 **Traceability and signature footer:** Hard rules in `prompts/build.txt` (sections "Traceability" and "#8 Signature footer"). Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -182,6 +182,7 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 - Before ANY file modification: run `pre-edit-check.sh`
 - Exit 0=proceed, 1=STOP (main), 2=create worktree, 3=warn off-main
 - NEVER edit on main/master. Code work in worktrees (`~/Git/{repo}-{type}-{name}/`).
+- Exactly one active session may own a writable worktree path. Never share a live worktree between sessions; create a new worktree on ownership conflict.
 - Loop mode: `pre-edit-check.sh --loop-mode --task "description"`
 - NEVER revert others' changes without explicit user request
 

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -370,6 +370,60 @@ else
 		"$SCRIPT_DIR/session-rename-helper.sh" sync-branch >/dev/null 2>&1 || true
 	fi
 
+	# Linked worktree ownership gate (GH#14413 hardening):
+	# exactly one active session/process may hold a writable worktree at a time.
+	worktree_path=""
+	worktree_path=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+	worktree_owner_pid="${OPENCODE_PID:-${PRE_EDIT_OWNER_PID:-${PPID:-$$}}}"
+	worktree_owner_session="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+
+	if declare -f claim_worktree_ownership >/dev/null 2>&1; then
+		if ! claim_worktree_ownership "$worktree_path" "$current_branch" --owner-pid "$worktree_owner_pid" --session "$worktree_owner_session"; then
+			owner_info=""
+			owner_info=$(check_worktree_owner "$worktree_path" 2>/dev/null || true)
+			owner_pid="unknown"
+			owner_session=""
+			owner_created=""
+			if [[ -n "$owner_info" ]]; then
+				IFS='|' read -r owner_pid owner_session _ _ owner_created <<<"$owner_info"
+			fi
+
+			if [[ ! -t 0 ]] || [[ "${FULL_LOOP_HEADLESS:-false}" == "true" ]] || [[ "$LOOP_MODE" == "true" ]]; then
+				echo -e "${RED}BLOCKED${NC}: linked worktree is owned by another active session/process"
+				echo "WORKTREE_OWNERSHIP_CONFLICT=true"
+				echo "ACTION_REQUIRED=create_worktree"
+				echo "WORKTREE_PATH=$worktree_path"
+				echo "WORKTREE_OWNER_PID=$owner_pid"
+				if [[ -n "$owner_session" ]]; then
+					echo "WORKTREE_OWNER_SESSION=$owner_session"
+				fi
+				if [[ -n "$owner_created" ]]; then
+					echo "WORKTREE_OWNER_SINCE=$owner_created"
+				fi
+				echo "HINT: create a dedicated worktree for this session/task and retry"
+				exit 2
+			fi
+
+			echo ""
+			echo -e "${RED}${BOLD}======================================================${NC}"
+			echo -e "${RED}${BOLD}  STOP - WORKTREE OWNED BY ANOTHER ACTIVE SESSION${NC}"
+			echo -e "${RED}${BOLD}======================================================${NC}"
+			echo ""
+			echo "Worktree: $worktree_path"
+			echo "Owner PID: $owner_pid"
+			if [[ -n "$owner_session" ]]; then
+				echo "Owner session: $owner_session"
+			fi
+			if [[ -n "$owner_created" ]]; then
+				echo "Owned since: $owner_created"
+			fi
+			echo ""
+			echo -e "${YELLOW}Use a dedicated linked worktree for this session/task to avoid cross-session edits.${NC}"
+			echo ""
+			exit 1
+		fi
+	fi
+
 	if [[ "$is_main_worktree" == "true" ]]; then
 		# Loop mode: auto-decide for canonical repo directory off main
 		if [[ "$LOOP_MODE" == "true" ]]; then

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -945,13 +945,102 @@ _todo_commit_push_inner() {
 #
 # Available to all scripts that source shared-constants.sh.
 
-WORKTREE_REGISTRY_DIR="${HOME}/.aidevops/.agent-workspace"
-WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
+WORKTREE_REGISTRY_DIR="${WORKTREE_REGISTRY_DIR:-${HOME}/.aidevops/.agent-workspace}"
+WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DB:-${WORKTREE_REGISTRY_DIR}/worktree-registry.db}"
+
+# Resolve the long-lived process ID that should own a worktree lock.
+# Priority:
+#   1) Explicit override (first argument)
+#   2) OpenCode interactive PID (OPENCODE_PID)
+#   3) Parent process PID (PPID)
+#   4) Current shell PID ($$)
+# Returns: PID string on stdout
+_resolve_worktree_owner_pid() {
+	local explicit_pid="${1:-}"
+	if [[ -n "$explicit_pid" ]]; then
+		printf '%s' "$explicit_pid"
+		return 0
+	fi
+
+	if [[ -n "${OPENCODE_PID:-}" ]]; then
+		printf '%s' "$OPENCODE_PID"
+		return 0
+	fi
+
+	if [[ -n "${PPID:-}" ]]; then
+		printf '%s' "$PPID"
+		return 0
+	fi
+
+	printf '%s' "$$"
+	return 0
+}
 
 # SQL-escape a value for SQLite (double single quotes)
 _wt_sql_escape() {
 	local val="$1"
 	echo "${val//\'/\'\'}"
+}
+
+# Normalize a filesystem path to a stable absolute form.
+# This prevents duplicate registry rows for equivalent paths
+# such as /var/... vs /private/var/... on macOS.
+_wt_normalize_path() {
+	local raw_path="$1"
+	if [[ -z "$raw_path" ]]; then
+		printf '%s' ""
+		return 0
+	fi
+
+	local normalized=""
+	if command -v python3 >/dev/null 2>&1; then
+		normalized=$(
+			python3 - "$raw_path" <<'PY' 2>/dev/null || true
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+		)
+	fi
+
+	if [[ -z "$normalized" ]]; then
+		if [[ -d "$raw_path" ]]; then
+			normalized=$(cd "$raw_path" 2>/dev/null && pwd -P) || normalized="$raw_path"
+		else
+			normalized="$raw_path"
+		fi
+	fi
+
+	printf '%s' "$normalized"
+	return 0
+}
+
+# Resolve the registry key for a worktree path.
+# If a legacy non-normalized row already exists for an equivalent path,
+# return that stored key so ownership checks remain backward compatible.
+# Otherwise return the normalized path.
+_wt_registry_lookup_path() {
+	local requested_path="$1"
+	local normalized
+	normalized=$(_wt_normalize_path "$requested_path")
+
+	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && {
+		printf '%s' "$normalized"
+		return 0
+	}
+
+	local stored_path=""
+	while IFS= read -r stored_path; do
+		[[ -z "$stored_path" ]] && continue
+		local stored_normalized
+		stored_normalized=$(_wt_normalize_path "$stored_path")
+		if [[ "$stored_normalized" == "$normalized" ]]; then
+			printf '%s' "$stored_path"
+			return 0
+		fi
+	done < <(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT worktree_path FROM worktree_owners;" 2>/dev/null || true)
+
+	printf '%s' "$normalized"
+	return 0
 }
 
 # Initialize the registry database
@@ -981,7 +1070,7 @@ register_worktree() {
 	local branch="$2"
 	shift 2
 
-	local task_id="" batch_id="" session_id=""
+	local task_id="" batch_id="" session_id="" owner_pid_override=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--task)
@@ -996,24 +1085,127 @@ register_worktree() {
 			session_id="${2:-}"
 			shift 2
 			;;
+		--owner-pid)
+			owner_pid_override="${2:-}"
+			shift 2
+			;;
 		*) shift ;;
 		esac
 	done
 
+	if [[ -z "$session_id" ]]; then
+		session_id="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+	fi
+
+	local owner_pid
+	owner_pid=$(_resolve_worktree_owner_pid "$owner_pid_override")
+
 	_init_registry_db
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
 	sqlite3 "$WORKTREE_REGISTRY_DB" "
         INSERT OR REPLACE INTO worktree_owners
             (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id)
         VALUES
+			 ('$(_wt_sql_escape "$wt_path")',
+			  '$(_wt_sql_escape "$branch")',
+			  ${owner_pid},
+			  '$(_wt_sql_escape "$session_id")',
+			  '$(_wt_sql_escape "$batch_id")',
+			  '$(_wt_sql_escape "$task_id")');
+    " 2>/dev/null || true
+	return 0
+}
+
+# Claim ownership of a worktree without overwriting another live owner.
+# Arguments:
+#   $1 - worktree path (required)
+#   $2 - branch name (required)
+#   Flags: --task <id>, --batch <id>, --session <id>, --owner-pid <pid>
+# Returns:
+#   0 - ownership acquired or already held by this owner_pid
+#   1 - another live owner currently holds the worktree
+claim_worktree_ownership() {
+	local wt_path="$1"
+	local branch="$2"
+	shift 2
+
+	local task_id="" batch_id="" session_id="" owner_pid_override=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--task)
+			task_id="${2:-}"
+			shift 2
+			;;
+		--batch)
+			batch_id="${2:-}"
+			shift 2
+			;;
+		--session)
+			session_id="${2:-}"
+			shift 2
+			;;
+		--owner-pid)
+			owner_pid_override="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$session_id" ]]; then
+		session_id="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+	fi
+
+	local owner_pid
+	owner_pid=$(_resolve_worktree_owner_pid "$owner_pid_override")
+
+	_init_registry_db
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
+
+	local existing_owner_pid
+	existing_owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+        SELECT owner_pid FROM worktree_owners
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+    " 2>/dev/null || echo "")
+
+	if [[ -n "$existing_owner_pid" ]] && [[ "$existing_owner_pid" != "$owner_pid" ]]; then
+		if ! kill -0 "$existing_owner_pid" 2>/dev/null; then
+			unregister_worktree "$wt_path"
+		fi
+	fi
+
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        INSERT OR IGNORE INTO worktree_owners
+            (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id)
+        VALUES
             ('$(_wt_sql_escape "$wt_path")',
              '$(_wt_sql_escape "$branch")',
-             $$,
+             ${owner_pid},
              '$(_wt_sql_escape "$session_id")',
              '$(_wt_sql_escape "$batch_id")',
              '$(_wt_sql_escape "$task_id")');
     " 2>/dev/null || true
-	return 0
+
+	local final_owner_pid
+	final_owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+        SELECT owner_pid FROM worktree_owners
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+    " 2>/dev/null || echo "")
+
+	if [[ "$final_owner_pid" == "$owner_pid" ]]; then
+		sqlite3 "$WORKTREE_REGISTRY_DB" "
+            UPDATE worktree_owners
+            SET branch = '$(_wt_sql_escape "$branch")',
+                owner_session = '$(_wt_sql_escape "$session_id")',
+                owner_batch = '$(_wt_sql_escape "$batch_id")',
+                task_id = '$(_wt_sql_escape "$task_id")'
+            WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+        " 2>/dev/null || true
+		return 0
+	fi
+
+	return 1
 }
 
 # Unregister ownership of a worktree
@@ -1023,6 +1215,7 @@ unregister_worktree() {
 	local wt_path="$1"
 
 	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
 	sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners
@@ -1040,6 +1233,7 @@ check_worktree_owner() {
 	local wt_path="$1"
 
 	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 1
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
 	local owner_info
 	owner_info=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
@@ -1063,6 +1257,7 @@ is_worktree_owned_by_others() {
 	local wt_path="$1"
 
 	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 1
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
 	local owner_pid
 	owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -12,6 +12,8 @@ readonly TEST_RESET='\033[0m'
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
+TEST_REGISTRY_DIR=""
+TEST_REGISTRY_DB=""
 
 print_result() {
 	local test_name="$1"
@@ -34,6 +36,8 @@ print_result() {
 
 setup_test_repo() {
 	TEST_ROOT=$(mktemp -d)
+	TEST_REGISTRY_DIR="${TEST_ROOT}/.registry"
+	TEST_REGISTRY_DB="${TEST_REGISTRY_DIR}/worktree-registry.db"
 	git -C "$TEST_ROOT" init -b main >/dev/null 2>&1 || {
 		git -C "$TEST_ROOT" init >/dev/null 2>&1
 		git -C "$TEST_ROOT" checkout -b main >/dev/null 2>&1
@@ -58,9 +62,27 @@ run_helper() {
 	shift
 	(
 		cd "$target_dir" || exit 1
-		"$HELPER" "$@"
+		WORKTREE_REGISTRY_DIR="$TEST_REGISTRY_DIR" \
+			WORKTREE_REGISTRY_DB="$TEST_REGISTRY_DB" \
+			"$HELPER" "$@"
 	)
 	return $?
+}
+
+ensure_registry_schema() {
+	mkdir -p "$TEST_REGISTRY_DIR"
+	sqlite3 "$TEST_REGISTRY_DB" "
+        CREATE TABLE IF NOT EXISTS worktree_owners (
+            worktree_path TEXT PRIMARY KEY,
+            branch        TEXT,
+            owner_pid     INTEGER,
+            owner_session TEXT DEFAULT '',
+            owner_batch   TEXT DEFAULT '',
+            task_id       TEXT DEFAULT '',
+            created_at    TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        );
+    " >/dev/null 2>&1
+	return 0
 }
 
 test_blocks_headless_edits_on_main_with_worktree_guidance() {
@@ -110,6 +132,39 @@ test_warns_when_canonical_repo_is_off_main() {
 	return 0
 }
 
+test_blocks_when_linked_worktree_owned_by_another_live_process() {
+	local worktree_path="${TEST_ROOT}/owned-worktree"
+	git -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/owned-worktree >/dev/null 2>&1
+
+	ensure_registry_schema
+	sqlite3 "$TEST_REGISTRY_DB" "
+        INSERT OR REPLACE INTO worktree_owners
+            (worktree_path, branch, owner_pid, owner_session)
+        VALUES
+            ('$worktree_path',
+             'bugfix/owned-worktree',
+             $$,
+             'other-session');
+    " >/dev/null 2>&1
+
+	local output=""
+	local exit_code=0
+	local claim_pid=""
+	sleep 30 >/dev/null 2>&1 &
+	claim_pid=$!
+	output=$(PRE_EDIT_OWNER_PID="$claim_pid" run_helper "$worktree_path" 2>&1) || exit_code=$?
+	kill "$claim_pid" >/dev/null 2>&1 || true
+	wait "$claim_pid" 2>/dev/null || true
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"WORKTREE_OWNERSHIP_CONFLICT=true"* ]] && [[ "$output" == *"WORKTREE_OWNER_PID=$$"* ]] && [[ "$output" == *"ACTION_REQUIRED=create_worktree"* ]]; then
+		print_result "blocks linked worktree edits when owned by another live process" 0
+		return 0
+	fi
+
+	print_result "blocks linked worktree edits when owned by another live process" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
 main() {
 	trap teardown_test_repo EXIT
 	setup_test_repo
@@ -117,6 +172,7 @@ main() {
 	test_blocks_headless_edits_on_main_with_worktree_guidance
 	test_allows_linked_worktree_edits
 	test_warns_when_canonical_repo_is_off_main
+	test_blocks_when_linked_worktree_owned_by_another_live_process
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Add an edit-time ownership claim in `pre-edit-check.sh` so linked worktrees are blocked when another active session/process already owns the path.
- Extend the shared worktree registry helpers with explicit owner PID resolution and non-destructive claim semantics, including path-key compatibility for `/var` vs `/private/var` aliases.
- Add coverage in `test-pre-edit-check.sh` for ownership conflict blocking, and codify one-session-per-worktree policy in AGENTS/build pre-edit rules.

Closes #14413


---
[aidevops.sh](https://aidevops.sh) v3.5.464 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.3-codex spent 2h 6m and 109,706 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented mandatory session isolation for development paths to prevent concurrent modification conflicts between active sessions
  * Automatic worktree creation triggered when ownership conflicts are detected

* **Improvements**
  * Enhanced session ownership tracking and validation across interactive and headless workflows
  * Improved detection and cleanup of abandoned session records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->