### PR TITLE
GH#14409: add regression test for fail-closed dispatch metadata guard

### DIFF
--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -432,6 +432,38 @@ test_dispatch_with_dedup_blocks_when_duplicate() {
 	return 0
 }
 
+test_dispatch_with_dedup_fails_closed_when_issue_metadata_missing() {
+	local original_script_dir="$SCRIPT_DIR"
+	SCRIPT_DIR="$TEST_ROOT"
+
+	set_ps_fixture ""
+
+	# Stub gh issue view to fail so metadata cannot be loaded.
+	gh() {
+		if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+			return 1
+		fi
+		return 0
+	}
+	export -f gh
+
+	local dispatch_rc=0
+	dispatch_with_dedup "7777" "marcusquinn/aidevops" "Issue #7777: fail-closed" "t7777: fail-closed" \
+		"testuser" "/tmp/aidevops" "/full-loop test" || dispatch_rc=$?
+
+	SCRIPT_DIR="$original_script_dir"
+	unset -f gh
+
+	if [[ "$dispatch_rc" -eq 1 ]]; then
+		print_result "dispatch_with_dedup fails closed when issue metadata lookup fails (GH#14409)" 0
+		return 0
+	fi
+
+	print_result "dispatch_with_dedup fails closed when issue metadata lookup fails (GH#14409)" 1 \
+		"Expected exit 1 (blocked), got ${dispatch_rc}"
+	return 0
+}
+
 test_dispatch_with_dedup_proceeds_when_no_duplicate() {
 	local original_script_dir="$SCRIPT_DIR"
 	SCRIPT_DIR="$TEST_ROOT"
@@ -524,6 +556,7 @@ main() {
 	test_review_issue_pr_session_key_fallback_dedup
 	test_check_dispatch_dedup_treats_merged_pr_as_duplicate
 	test_dispatch_with_dedup_blocks_when_duplicate
+	test_dispatch_with_dedup_fails_closed_when_issue_metadata_missing
 	test_dispatch_with_dedup_proceeds_when_no_duplicate
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary
- Add a regression test that exercises `dispatch_with_dedup` when `gh issue view` fails so dispatch blocks instead of proceeding.
- Lock in the fail-closed behavior requested in PR #14395 review feedback and tracked by issue #14409.

## Verification
- `shellcheck .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`

## Runtime Testing
- Level: self-assessed (low risk, test-only change)
- Runtime verification not required for this change type.

Closes #14409

---
[aidevops.sh](https://aidevops.sh) v3.5.464 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.3-codex spent 4m and 213,506 tokens on this as a headless worker. Overall, 3h 36m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test to verify error handling when required metadata is missing during dispatch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->