### PR TITLE
GH#14472: tighten ip-check command wording

### DIFF
--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -6,7 +6,7 @@ mode: subagent
 
 Arguments: `$ARGUMENTS`
 
-Run all checks through `~/.aidevops/agents/scripts/ip-reputation-helper.sh`.
+Use `~/.aidevops/agents/scripts/ip-reputation-helper.sh` for all checks.
 
 ## Dispatch routes
 
@@ -41,7 +41,7 @@ Flags: Tor=NO  Proxy=NO  VPN=NO
 
 Provider set: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
 
-After showing results, offer follow-up options: full report, single-provider recheck, batch check, raw JSON, and cache-clear recheck.
+After results, offer follow-up options: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Tightened two sentences in `.agents/scripts/commands/ip-check.md` to reduce verbosity while preserving behavior and dispatch semantics.
- Kept all command routes, providers, output shape, and related links unchanged.

## Testing
- `npx markdownlint-cli2 ".agents/scripts/commands/ip-check.md"`

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Evidence: markdown lint passed; no runtime behavior changed.

Closes #14472

---
[aidevops.sh](https://aidevops.sh) v3.5.465 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.3-codex spent 3m and 53,478 tokens on this as a headless worker. Overall, 10m since this issue was created.