### PR TITLE
GH#14411: align YouTube setup memory keys

### DIFF
--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -6,7 +6,7 @@ mode: subagent
 
 Arguments: `$ARGUMENTS`
 
-Run all checks through `~/.aidevops/agents/scripts/ip-reputation-helper.sh`.
+Use `~/.aidevops/agents/scripts/ip-reputation-helper.sh` for all checks.
 
 ## Dispatch routes
 
@@ -41,7 +41,7 @@ Flags: Tor=NO  Proxy=NO  VPN=NO
 
 Provider set: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
 
-After showing results, offer follow-up options: full report, single-provider recheck, batch check, raw JSON, and cache-clear recheck.
+After results, offer follow-up options: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
 
 ## Related
 

--- a/.agents/scripts/commands/youtube-setup.md
+++ b/.agents/scripts/commands/youtube-setup.md
@@ -51,7 +51,12 @@ Verify the channel exists and display basic stats (subscribers, videos, total vi
 ~/.aidevops/agents/scripts/memory-helper.sh store \
   --type WORKING_SOLUTION \
   --namespace youtube \
-  "Channel voice: [voice description]. Audience: [target audience]."
+  "Channel voice: [voice description]."
+
+~/.aidevops/agents/scripts/memory-helper.sh store \
+  --type WORKING_SOLUTION \
+  --namespace youtube \
+  "Audience: [target audience]."
 ```
 
 Also store individual competitor profiles:
@@ -86,7 +91,7 @@ Setup complete! Next steps:
 
 Your configuration is stored in memory and will persist across sessions.
 
-The explicit `Channel voice` entry keeps `/youtube script` and the script-writer guide aligned with the stored recall key.
+The explicit `Channel voice` entry ensures `/youtube script` and the script-writer guide can reliably recall it via FTS5 full-text search. Phrase stored entries around likely search tokens such as `Channel voice` instead of relying on exact string equality.
 ```
 
 ## Options

--- a/.agents/scripts/commands/youtube-setup.md
+++ b/.agents/scripts/commands/youtube-setup.md
@@ -24,7 +24,9 @@ Prompt the user for:
 
 1. **Your channel handle** (e.g., @myhandle)
 2. **Niche/topic** (e.g., "AI coding tools", "productivity software")
-3. **Competitor channels** (3-5 handles, e.g., @competitor1 @competitor2)
+3. **Channel voice** (e.g., "data-driven, conversational, mildly contrarian")
+4. **Target audience** (e.g., "indie founders evaluating AI tools")
+5. **Competitor channels** (3-5 handles, e.g., @competitor1 @competitor2)
 
 If the user provides these in $ARGUMENTS, parse them. Otherwise, ask interactively.
 
@@ -45,6 +47,11 @@ Verify the channel exists and display basic stats (subscribers, videos, total vi
   --type WORKING_SOLUTION \
   --namespace youtube \
   "My channel: @myhandle. Niche: [topic]. Competitors: @comp1, @comp2, @comp3"
+
+~/.aidevops/agents/scripts/memory-helper.sh store \
+  --type WORKING_SOLUTION \
+  --namespace youtube \
+  "Channel voice: [voice description]. Audience: [target audience]."
 ```
 
 Also store individual competitor profiles:
@@ -78,6 +85,8 @@ Setup complete! Next steps:
 4. Generate your first script with /youtube script "topic"
 
 Your configuration is stored in memory and will persist across sessions.
+
+The explicit `Channel voice` entry keeps `/youtube script` and the script-writer guide aligned with the stored recall key.
 ```
 
 ## Options


### PR DESCRIPTION
## Summary
- add explicit `Channel voice` and `Target audience` inputs to `/youtube setup`
- store a dedicated `Channel voice` memory entry so `/youtube script` and the script-writer guide recall the documented key consistently
- document the recall-key alignment in the setup follow-up text

## Runtime Testing
- **Risk level**: Low (agent docs / prompt workflow only)
- **Testing**:
  - `./.agents/scripts/linters-local.sh` *(repo has pre-existing unrelated baseline failures; markdown and secret checks passed for this change)*
  - `git diff --check`

Closes #14411

---
[aidevops.sh](https://aidevops.sh) v3.5.465 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 104,832 tokens on this as a headless worker. Overall, 4h 52m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Channel voice and Target audience configuration prompts to the YouTube setup process
  * These settings are now persisted and stored for later reference across related tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->