### PR TITLE
GH#14415: clarify shared mailbox limitation rationale

### DIFF
--- a/.agents/services/email/email-providers.md
+++ b/.agents/services/email/email-providers.md
@@ -112,7 +112,7 @@ POP does not sync folders, flags, or read-state across devices.
 - **Zoho Mail**: Group mailboxes in paid plans.
 - **Cloudron**: Separate mailbox accounts or aliases via admin panel / CLI.
 - **Proton Mail**: Business plans support multi-user access and catch-all.
-- **Others**: Limited or no native shared mailbox/delegation support — check provider docs for group alias or forwarding workarounds.
+- **Others**: Native shared mailbox or delegation support is often limited because standard IMAP setups usually lack delegated-access semantics; check provider docs for aliases, forwarding, or separate mailbox workarounds.
 
 ## Cloudron Mail Management
 


### PR DESCRIPTION
## Summary
- replace the absolute shared-mailbox limitation wording in .agents/services/email/email-providers.md with a qualified statement
- add a concise technical reason that standard IMAP deployments usually lack delegated-access semantics
- point readers to aliases, forwarding, or separate mailboxes as common workarounds

## Testing
- git diff --check
- ./.agents/scripts/linters-local.sh (repo-level baseline failures unrelated to this change; Markdown section passed)

## Runtime Testing
- Level: self-assessed
- Reason: low-risk documentation-only change
- Runtime verification: not required

Closes #14415

---
[aidevops.sh](https://aidevops.sh) v3.5.465 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 171,935 tokens on this as a headless worker. Overall, 5h 10m since this issue was created.