### PR TITLE
GH#14475: tighten ip-check command guidance

### DIFF
--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -6,11 +6,11 @@ mode: subagent
 
 Arguments: `$ARGUMENTS`
 
-Use `~/.aidevops/agents/scripts/ip-reputation-helper.sh` for all checks.
+Always route through `~/.aidevops/agents/scripts/ip-reputation-helper.sh`.
 
-## Dispatch routes
+## Route map
 
-| Input | Route |
+| Input | Run |
 |---|---|
 | `1.2.3.4` | `check "$IP"` (multi-provider summary) |
 | `1.2.3.4 -f json` | `check "$IP" -f json` |
@@ -19,11 +19,13 @@ Use `~/.aidevops/agents/scripts/ip-reputation-helper.sh` for all checks.
 | `1.2.3.4 --no-cache` | `check "$IP" --no-cache` |
 | `ips.txt` | `batch "$FILE"` |
 | `ips.txt --dnsbl-overlap` | `batch "$FILE" --dnsbl-overlap` |
-| _(no args)_ | Show usage/help |
+| _(no args)_ | Show help/usage |
 
-Operational subcommands: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
+Operational commands: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
 
-## Expected output
+## Output contract
+
+Expected structure:
 
 ```text
 IP Reputation: 1.2.3.4
@@ -41,7 +43,7 @@ Flags: Tor=NO  Proxy=NO  VPN=NO
 
 Provider set: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
 
-After results, offer follow-up options: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
+After returning results, offer next actions: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Tightened `.agents/scripts/commands/ip-check.md` wording to make routing intent and command mapping more explicit.
- Clarified the output contract section while preserving existing provider and follow-up guidance.
- Kept scope to one doc file to maintain low blast radius for simplification debt work.

## Testing
- `npm exec --yes markdownlint-cli2 ".agents/scripts/commands/ip-check.md"`

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Evidence: markdownlint passed with 0 errors

Closes #14475

---
[aidevops.sh](https://aidevops.sh) v3.5.465 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.3-codex spent 3m and 121,265 tokens on this as a headless worker. Overall, 11m since this issue was created.