### PR TITLE
GH#14480: tighten ip-check command phrasing

### DIFF
--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -6,26 +6,26 @@ mode: subagent
 
 Arguments: `$ARGUMENTS`
 
-Always route through `~/.aidevops/agents/scripts/ip-reputation-helper.sh`.
+Use only: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`.
 
-## Route map
+## Command routing
 
-| Input | Run |
+| Input | Helper invocation |
 |---|---|
-| `1.2.3.4` | `check "$IP"` (multi-provider summary) |
+| `1.2.3.4` | `check "$IP"` |
 | `1.2.3.4 -f json` | `check "$IP" -f json` |
-| `1.2.3.4 report` | `report "$IP"` (markdown report) |
+| `1.2.3.4 report` | `report "$IP"` |
 | `1.2.3.4 --provider abuseipdb` | `check "$IP" --provider "$PROVIDER"` |
 | `1.2.3.4 --no-cache` | `check "$IP" --no-cache` |
 | `ips.txt` | `batch "$FILE"` |
 | `ips.txt --dnsbl-overlap` | `batch "$FILE" --dnsbl-overlap` |
-| _(no args)_ | Show help/usage |
+| _(no args)_ | Show usage/help |
 
-Operational commands: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
+Ops subcommands: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
 
-## Output contract
+## Output shape
 
-Expected structure:
+Return a summary with risk score, provider results, and proxy flags:
 
 ```text
 IP Reputation: 1.2.3.4
@@ -43,7 +43,7 @@ Flags: Tor=NO  Proxy=NO  VPN=NO
 
 Provider set: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
 
-After returning results, offer next actions: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
+After showing results, offer: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Tightened wording in `.agents/scripts/commands/ip-check.md` without changing behavior.
- Clarified routing table labels and helper invocation wording for faster command selection.
- Kept provider coverage, output contract example, and follow-up action guidance intact.

## Testing Evidence
- `npx --yes markdownlint-cli2 ".agents/scripts/commands/ip-check.md"`

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- No runtime behavior changed.

Closes #14480


---
[aidevops.sh](https://aidevops.sh) v3.5.466 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.3-codex spent 4m and 54,978 tokens on this as a headless worker. Overall, 11m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Enhanced `ip-check` command documentation to improve clarity and consistency. Updated section terminology and headers to better explain command routing, helper invocation procedures, and output structure. Refined action descriptions and instructions to more clearly guide users on expected behavior and next steps after command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->