### PR TITLE
GH#14482: tighten ip-check command card

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1026,6 +1026,11 @@
       "at": "2026-03-29T16:31:29Z",
       "pr": 13117
     },
+    ".agents/scripts/commands/ip-check.md": {
+      "hash": "50712771a5effc6d34ec205c3dd4616540d26311",
+      "at": "2026-03-31T02:20:51Z",
+      "pr": 14484
+    },
     ".agents/workflows/pr.md": {
       "hash": "8f6584d97315d02aa4914a1f26165c57ff873479",
       "at": "2026-03-29T14:29:47Z",

--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -6,11 +6,11 @@ mode: subagent
 
 Arguments: `$ARGUMENTS`
 
-Use only: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`.
+Helper: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`
 
-## Command routing
+## Route inputs
 
-| Input | Helper invocation |
+| Input | Invoke |
 |---|---|
 | `1.2.3.4` | `check "$IP"` |
 | `1.2.3.4 -f json` | `check "$IP" -f json` |
@@ -19,13 +19,13 @@ Use only: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`.
 | `1.2.3.4 --no-cache` | `check "$IP" --no-cache` |
 | `ips.txt` | `batch "$FILE"` |
 | `ips.txt --dnsbl-overlap` | `batch "$FILE" --dnsbl-overlap` |
-| _(no args)_ | Show usage/help |
+| _(no args)_ | Show usage |
 
-Ops subcommands: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
+Ops: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
 
-## Output shape
+## Output
 
-Return a summary with risk score, provider results, and proxy flags:
+Return risk score, provider results, and proxy flags:
 
 ```text
 IP Reputation: 1.2.3.4
@@ -41,9 +41,9 @@ Providers (8/10 responded):
 Flags: Tor=NO  Proxy=NO  VPN=NO
 ```
 
-Provider set: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
+Providers: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
 
-After showing results, offer: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
+Then offer: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- tighten `.agents/scripts/commands/ip-check.md` phrasing without changing routing coverage or follow-up guidance
- keep the helper path, output example, provider list, related references, and simplification-state tracking

## Runtime Testing
- self-assessed: low-risk doc-only change
- verified with `bunx markdownlint-cli2 ".agents/scripts/commands/ip-check.md"`
- verified with `python3 -m json.tool .agents/configs/simplification-state.json >/dev/null`

Closes #14482


---
[aidevops.sh](https://aidevops.sh) v3.5.466 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 65,579 tokens on this as a headless worker. Overall, 12m since this issue was created.