### PR TITLE
GH#13994: tighten Content Context Templates agent doc

### DIFF
--- a/.agents/content/context-templates.md
+++ b/.agents/content/context-templates.md
@@ -9,7 +9,7 @@ model: haiku
 
 Project-level context files for SEO content creation. Adapted from [TheCraigHewitt/seomachine](https://github.com/TheCraigHewitt/seomachine) (MIT License).
 
-Run `mkdir -p context` then populate from templates below. Subagents (`seo-writer.md`, `editor.md`, `internal-linker.md`) check for these files automatically.
+Setup: `mkdir -p context` then populate from templates below. Auto-detected by `seo-writer.md`, `editor.md`, `internal-linker.md`.
 
 ### context/brand-voice.md
 
@@ -38,9 +38,7 @@ Run `mkdir -p context` then populate from templates below. Subagents (`seo-write
 - **Vocabulary level**: [Professional but accessible]
 - **Contractions**: [Yes/No]
 - **Person**: ["We" for company, "You" for reader]
-
-## Preferred / Avoided Terminology
-[List preferred terms and terms to avoid]
+- **Preferred / Avoided terms**: [List here]
 ```
 
 ### context/style-guide.md
@@ -74,7 +72,6 @@ Run `mkdir -p context` then populate from templates below. Subagents (`seo-write
 # Target Keywords
 
 ## Pillar Topics
-
 ### [Topic Cluster Name]
 - **Pillar keyword**: [main keyword] (volume: X, difficulty: Y)
 - **Cluster keywords**: [subtopic 1] (vol: X), [subtopic 2] (vol: X)


### PR DESCRIPTION
## Summary

- Tightened `.agents/content/context-templates.md` (152→149 lines) per simplification-debt issue
- Consolidated intro prose, merged "Preferred / Avoided Terminology" into Writing Style section, removed redundant blank lines in templates
- This is a reference corpus (template collection) — templates preserved in full, only prose and structure tightened

## Testing

- `self-assessed` — agent prompt doc, low risk (no code, no logic changes)
- All template code blocks, URLs, and structural patterns preserved

Closes #13994

---
[aidevops.sh](https://aidevops.sh) v3.5.466 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6 spent 2m and 3,903 tokens on this as a headless worker. Overall, 18h 59m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised context auto-detection description in agent setup instructions to reflect automatic detection by multiple agents
  * Added dedicated field for managing preferred and avoided terminology preferences within brand voice configuration templates
  * Removed unnecessary blank line from target keywords section for improved formatting consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->