### PR TITLE
GH#14483: detach worker stdio from pulse dispatch

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4693,13 +4693,28 @@ dispatch_with_dedup() {
 	gh issue edit "$issue_number" --repo "$repo_slug" \
 		--add-assignee "$self_login" --add-label "status:queued" --add-label "origin:worker" 2>/dev/null || true
 
+	# Detach worker stdio from the dispatcher (GH#14483).
+	# Without this, background workers inherit the candidate-loop stdin created by
+	# process substitutions and can consume the remaining candidate stream,
+	# causing the deterministic fill floor to stop after one dispatch. Redirect
+	# worker stdout/stderr into per-issue temp logs so launch validation reads the
+	# intended output file and dispatcher shells stay clean.
+	local safe_slug worker_log worker_log_fallback
+	safe_slug=$(echo "$repo_slug" | tr '/:' '--')
+	worker_log="/tmp/pulse-${safe_slug}-${issue_number}.log"
+	worker_log_fallback="/tmp/pulse-${issue_number}.log"
+	rm -f "$worker_log" "$worker_log_fallback"
+	: >"$worker_log"
+	ln -s "$worker_log" "$worker_log_fallback" 2>/dev/null || true
+
 	# Launch worker
 	"$HEADLESS_RUNTIME_HELPER" run \
 		--role worker \
 		--session-key "$session_key" \
 		--dir "$repo_path" \
 		--title "$dispatch_title" \
-		--prompt "$prompt" &
+		--prompt "$prompt" \
+		</dev/null >>"$worker_log" 2>&1 &
 	local worker_pid="$!"
 	sleep 2
 

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -538,6 +538,84 @@ STUB
 	return 0
 }
 
+test_dispatch_with_dedup_detaches_worker_stdio() {
+	local original_script_dir="$SCRIPT_DIR"
+	local original_helper="$HEADLESS_RUNTIME_HELPER"
+	local stdin_capture="${TEST_ROOT}/worker-stdin.txt"
+	local issue_log="/tmp/pulse-marcusquinn-aidevops-8890.log"
+	local fallback_log="/tmp/pulse-8890.log"
+	SCRIPT_DIR="$TEST_ROOT"
+
+	rm -f "$stdin_capture" "$issue_log" "$fallback_log"
+	set_ps_fixture ""
+
+	cat >"${TEST_ROOT}/dispatch-dedup-helper.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+command_name="${1:-}"
+case "$command_name" in
+claim) exit 0 ;;
+*) exit 1 ;;
+esac
+FIXTURE
+	chmod +x "${TEST_ROOT}/dispatch-dedup-helper.sh"
+
+	cat >"${TEST_ROOT}/dispatch-ledger-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+check-issue) exit 1 ;;
+*) exit 0 ;;
+esac
+STUB
+	chmod +x "${TEST_ROOT}/dispatch-ledger-helper.sh"
+
+	HEADLESS_RUNTIME_HELPER="${TEST_ROOT}/headless-stdin-stub.sh"
+	cat >"$HEADLESS_RUNTIME_HELPER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+cat >"${stdin_capture}"
+printf 'stub worker output\n'
+exit 0
+EOF
+	chmod +x "$HEADLESS_RUNTIME_HELPER"
+
+	gh() {
+		if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+			printf '{"state":"OPEN","title":"t8890: stdio detach","labels":[]}\n'
+			return 0
+		fi
+		return 0
+	}
+	export -f gh
+
+	local dispatch_rc=0
+	dispatch_with_dedup "8890" "marcusquinn/aidevops" "Issue #8890: stdio detach" "t8890: stdio detach" \
+		"testuser" "/tmp/aidevops" "/full-loop test" <<<"candidate-stream-must-not-leak" || dispatch_rc=$?
+
+	local stdin_contents=""
+	if [[ -f "$stdin_capture" ]]; then
+		stdin_contents=$(tr '\n' ' ' <"$stdin_capture")
+	fi
+	local issue_log_contents=""
+	if [[ -f "$issue_log" ]]; then
+		issue_log_contents=$(tr '\n' ' ' <"$issue_log")
+	fi
+
+	HEADLESS_RUNTIME_HELPER="$original_helper"
+	SCRIPT_DIR="$original_script_dir"
+	unset -f gh
+	rm -f "$issue_log" "$fallback_log"
+
+	if [[ "$dispatch_rc" -eq 0 && -z "$stdin_contents" && "$issue_log_contents" == *"stub worker output"* ]]; then
+		print_result "dispatch_with_dedup detaches stdin and captures worker output to issue log (GH#14483)" 0
+		return 0
+	fi
+
+	print_result "dispatch_with_dedup detaches stdin and captures worker output to issue log (GH#14483)" 1 \
+		"dispatch_rc=${dispatch_rc}, stdin='${stdin_contents}', issue_log='${issue_log_contents}'"
+	return 0
+}
+
 test_build_ranked_dispatch_candidates_json_scores_candidates() {
 	local original_repos_json="$REPOS_JSON"
 	cat >"${REPOS_JSON}" <<'JSON'
@@ -748,6 +826,7 @@ main() {
 	test_dispatch_with_dedup_blocks_when_duplicate
 	test_dispatch_with_dedup_fails_closed_when_issue_metadata_missing
 	test_dispatch_with_dedup_proceeds_when_no_duplicate
+	test_dispatch_with_dedup_detaches_worker_stdio
 	test_build_ranked_dispatch_candidates_json_scores_candidates
 	test_build_ranked_dispatch_candidates_json_respects_schedule_gate
 	test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity


### PR DESCRIPTION
## Summary
- detach worker stdin from `dispatch_with_dedup()` so background workers cannot consume the remaining candidate stream from deterministic fill loops
- redirect worker stdout/stderr into per-issue temp logs so launch validation reads the intended files and dispatcher shells stay clean
- add a regression test proving worker stdin is isolated and output is captured in the issue log

## Runtime Testing
- Level: `runtime-verified` (high-risk polling / dispatch loop)
- Live monitoring identified the bug after `v3.5.466`: deterministic fill logged `available=4` and `candidates=184` but only `dispatched=1`
- After the stdin/stdout isolation patch, a live fill pass produced multiple GPT-5.4 workers in one pass (`#14421`, `#13981`, `#13982`, `#14482`)
- Live counts improved to `active=4`, `runnable=181`, `queued_without_worker=1`, with the installed pulse itself now running as `openai/gpt-5.4`

## Testing
- `shellcheck -P ".agents/scripts" ".agents/scripts/pulse-wrapper.sh" ".agents/scripts/tests/test-pulse-wrapper-worker-detection.sh"`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh && bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh && bash .agents/scripts/tests/test-pulse-wrapper-schedule.sh && bash .agents/scripts/tests/test-pulse-wrapper-terminal-blockers.sh && bash .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh && bash .agents/scripts/tests/test-dispatch-ledger-helper.sh && bash .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh`

## Notes
- this is a follow-up hotfix to `GH#14471` based on live post-release monitoring, not a design change in approach
- the fix is intentionally narrow: only worker stdio isolation, no change to ranking or dispatch policy
- README update not required: this is an orchestration/runtime bugfix

Closes #14483
---
[aidevops.sh](https://aidevops.sh) v3.5.466 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 3h 12m and 508,853 tokens on this with the user in an interactive session. Overall, 11m since this issue was created.