### PR TITLE
GH#14491: tighten content context templates doc

### DIFF
--- a/.agents/content/context-templates.md
+++ b/.agents/content/context-templates.md
@@ -7,32 +7,28 @@ model: haiku
 
 # Content Context Templates
 
-Project-level context files for SEO content creation. Adapted from [TheCraigHewitt/seomachine](https://github.com/TheCraigHewitt/seomachine) (MIT License).
+Optional project-level `context/*.md` files for SEO content creation. Adapted from [TheCraigHewitt/seomachine](https://github.com/TheCraigHewitt/seomachine) (MIT License).
 
-Setup: `mkdir -p context` then populate from templates below. Auto-detected by `seo-writer.md`, `editor.md`, `internal-linker.md`.
+Setup: `mkdir -p context`, then copy the templates you need. They are auto-detected by `seo-writer.md`, `editor.md`, and `internal-linker.md`.
 
 ### context/brand-voice.md
 
 ```markdown
 # Brand Voice Guide
-
 ## Voice Pillars
 - **[Pillar 1]**: [Description]
 - **[Pillar 2]**: [Description]
 - **[Pillar 3]**: [Description]
-
 ## Tone by Content Type
 | Content Type | Tone | Example |
 |---|---|---|
 | Blog posts | [conversational, expert] | "Here's what we found..." |
 | Landing pages | [confident, direct] | "Get started in minutes" |
 | Documentation | [clear, helpful] | "Follow these steps..." |
-
 ## Core Messages
 1. [Primary value proposition]
 2. [Secondary message]
 3. [Differentiator]
-
 ## Writing Style
 - **Sentence length**: [Mix of short and medium]
 - **Vocabulary level**: [Professional but accessible]
@@ -45,7 +41,6 @@ Setup: `mkdir -p context` then populate from templates below. Auto-detected by `
 
 ```markdown
 # Style Guide
-
 ## Grammar and Formatting
 - **Oxford comma**: [Yes/No]
 - **Capitalization**: [Title case / Sentence case for headings]
@@ -54,12 +49,10 @@ Setup: `mkdir -p context` then populate from templates below. Auto-detected by `
 - **Headings**: [H2 main sections, H3 subsections]
 - **Lists**: [Bullet unordered, numbered for steps]
 - **Emphasis**: [Bold for key terms, backticks for code]
-
 ## Terminology
 | Use | Don't Use |
 |---|---|
 | [preferred term] | [avoided term] |
-
 ## Content Structure
 - Introduction: [Hook + context + promise]
 - Body: [H2 sections every 300-400 words]
@@ -70,16 +63,13 @@ Setup: `mkdir -p context` then populate from templates below. Auto-detected by `
 
 ```markdown
 # Target Keywords
-
 ## Pillar Topics
 ### [Topic Cluster Name]
 - **Pillar keyword**: [main keyword] (volume: X, difficulty: Y)
 - **Cluster keywords**: [subtopic 1] (vol: X), [subtopic 2] (vol: X)
 - **Long-tail variations**: [long-tail 1], [long-tail 2]
 - **Search intent**: [informational/commercial/transactional]
-
 Repeat structure per cluster.
-
 ## Current Rankings
 | Keyword | Position | URL | Opportunity |
 |---|---|---|---|
@@ -90,15 +80,12 @@ Repeat structure per cluster.
 
 ```markdown
 # Internal Links Map
-
 ## Product/Feature Pages
 - [/features](/features) - Main features overview (anchor: "our features")
 - [/pricing](/pricing) - Pricing plans (anchor: "pricing", "plans")
-
 ## Pillar & Top Content
 - [/blog/guide-to-X](/blog/guide-to-X) - Primary pillar (anchor: "complete guide to X")
 - [/blog/how-to-Z](/blog/how-to-Z) - High traffic (anchor: "how to Z")
-
 ## Topic Clusters
 ### Cluster: [Topic A]
 - Pillar: /blog/topic-a-guide
@@ -109,17 +96,14 @@ Repeat structure per cluster.
 
 ```markdown
 # Competitor Analysis
-
 ## Primary Competitors
 | Competitor | Domain | Strengths | Weaknesses |
 |---|---|---|---|
 | [Name] | [domain.com] | [what they do well] | [gaps we can exploit] |
-
 ## Content Strategy Comparison
 | Topic | Us | Competitor A | Competitor B | Gap |
 |---|---|---|---|---|
 | [topic] | [our coverage] | [their coverage] | [their coverage] | [opportunity] |
-
 ## Keyword Gaps
 - [keyword] - [competitor] ranks #[X], we don't rank
 ```
@@ -128,12 +112,10 @@ Repeat structure per cluster.
 
 ```markdown
 # SEO Guidelines
-
 ## Content Requirements
 - Minimum word count: 2,000 (optimal: 2,500-3,000)
 - Primary keyword density: 1-2%
 - Reading level: Grade 8-10
-
 ## On-Page SEO
 - Meta title: 50-60 chars, keyword near front
 - Meta description: 150-160 chars, keyword + CTA
@@ -141,7 +123,6 @@ Repeat structure per cluster.
 - H2: 4+ sections, 2-3 include keyword variations
 - Internal links: 3-5 per article
 - External links: 2-3 to authoritative sources
-
 ## Technical
 - URL slug: lowercase, hyphens, include keyword
 - Image alt text: descriptive, include keyword variation


### PR DESCRIPTION
## Summary
- clarify that `context/*.md` files are optional project inputs and tighten the setup guidance
- remove redundant blank lines inside the embedded markdown templates while preserving every template section and example value

## Runtime Testing
- self-assessed: doc-only change

## Verification
- `npx markdownlint-cli2 ".agents/content/context-templates.md"`
- `wc -l '.agents/content/context-templates.md'` reports 130 lines (down from 149)

Closes #14491


---
[aidevops.sh](https://aidevops.sh) v3.5.468 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 58,895 tokens on this as a headless worker. Overall, 16m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that context templates are optional and improved setup instructions to emphasize selecting needed templates
  * Enhanced consistency in auto-detection terminology across template documentation
  * Improved formatting for better readability by adjusting whitespace in template sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->