### PR TITLE
GH#14416: restore DSPyGround intro context

### DIFF
--- a/.agents/tools/context/dspyground.md
+++ b/.agents/tools/context/dspyground.md
@@ -23,7 +23,7 @@ tools:
 - Metrics: accuracy, tone, efficiency, tool_accuracy, guardrails (customizable)
 - Workflow: Chat + Sample → Organize → Optimize → Export prompt
 
-Optional tool — install via `npm install -g dspyground` when needed.
+DSPyGround is a visual prompt optimization playground powered by the GEPA (Genetic-Pareto Evolutionary Algorithm) optimizer. It's an optional tool that can be installed separately when needed via `npm install -g dspyground`.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- restore the missing DSPyGround introduction so readers get tool context before setup steps
- keep the install guidance inline so the document stays concise while restoring missing context from PR #14004 review feedback

## Testing
- self-assessed: docs-only change
- git diff --check
- markdownlint-cli2 unavailable in this shell (command not found)

## Runtime Testing
- self-assessed: low-risk documentation-only change

Closes #14416


---
[aidevops.sh](https://aidevops.sh) v3.5.470 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 3m on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced DSPyGround tool guide with detailed description identifying it as a visual prompt optimization playground using a GEPA (Genetic-Pareto Evolutionary Algorithm) optimizer, while clarifying optional installation via `npm install -g dspyground`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->