### PR TITLE
GH#14005: tighten es2016-es2017.md reference doc

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/es2016-es2017.md
+++ b/.agents/tools/programming/modern-javascript-skill/es2016-es2017.md
@@ -8,12 +8,9 @@ Checks if array contains a value; handles `NaN` correctly (unlike `indexOf`).
 
 ```javascript
 const arr = [1, 2, 3, NaN];
-
 arr.includes(2);      // true
 arr.includes(4);      // false
 arr.includes(NaN);    // true  (indexOf returns -1 here)
-
-// Optional start index
 arr.includes(2, 2);   // false (searches from index 2)
 ```
 
@@ -45,18 +42,17 @@ async function fetchUser(id) {
   }
 }
 
-// Arrow and method syntax also supported
+// Arrow and method syntax
 const getUser = async (id) => { const res = await fetch(`/api/users/${id}`); return res.json(); };
 const obj = { async getData() { return await fetchSomething(); } };
 ```
 
 ### Object.values() and Object.entries()
 
-Extract object values or key-value pairs as arrays for easy iteration and transformation.
+Extract object values or key-value pairs as arrays for iteration and transformation.
 
 ```javascript
 const user = { name: 'Alice', age: 30, city: 'NYC' };
-
 Object.values(user);   // ['Alice', 30, 'NYC']
 Object.entries(user);  // [['name', 'Alice'], ['age', 30], ['city', 'NYC']]
 
@@ -64,7 +60,6 @@ for (const [key, value] of Object.entries(user)) {
   console.log(`${key}: ${value}`);
 }
 
-// Transform object values
 const doubled = Object.fromEntries(
   Object.entries(prices).map(([k, v]) => [k, v * 2])
 );
@@ -82,7 +77,6 @@ Pad strings to a target length for alignment and formatting.
 '5'.padEnd(3, '0');     // '500'
 'hi'.padEnd(5, '.');    // 'hi...'
 
-// Practical uses
 const formatId = id => String(id).padStart(6, '0');
 formatId(42);  // '000042'
 
@@ -104,13 +98,11 @@ const source = {
   get fullName() { return this.name; }
 };
 
-// Object.assign loses the getter
+// Object.assign loses the getter — fullName becomes a static value
 const bad = Object.assign({}, source);
-// bad.fullName -> 'Alice' (value, not getter)
 
 // Preserve descriptors
 const good = Object.defineProperties({}, Object.getOwnPropertyDescriptors(source));
-// good.fullName -> getter intact
 ```
 
 ### Trailing Commas in Function Parameters
@@ -118,10 +110,9 @@ const good = Object.defineProperties({}, Object.getOwnPropertyDescriptors(source
 Allows trailing commas in parameter lists and arguments for cleaner version-control diffs.
 
 ```javascript
-// Trailing commas now allowed — cleaner diffs
 function greet(
   name,
-  greeting,  // OK
+  greeting,
 ) {
   return `${greeting}, ${name}!`;
 }


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/programming/modern-javascript-skill/es2016-es2017.md` by removing redundant inline comments and cosmetic whitespace in code blocks
- All 8 feature sections (Array.includes, exponentiation, async/await, Object.values/entries, string padding, getOwnPropertyDescriptors, trailing commas, SharedArrayBuffer/Atomics) and all code examples preserved
- 144 → 135 lines (6% reduction)

## Classification

**Reference corpus** — code examples with minimal prose. Already a chapter file within the modern-javascript-skill directory. Tightened prose and removed redundant comments rather than splitting (file is already appropriately scoped).

## Changes

- Removed redundant `// Optional start index`, `// also supported`, `// Transform object values`, `// Practical uses`, `// OK`, `// Trailing commas now allowed` comments where prose or context already conveys the information
- Consolidated `Object.getOwnPropertyDescriptors` comments into a single descriptive line
- Removed cosmetic blank lines within code blocks

## Runtime Testing

- **Risk level**: Low (docs/reference only, no runtime behavior)
- **Verification**: `self-assessed` — markdownlint clean, all sections and code blocks present before and after

Closes #14005

---
[aidevops.sh](https://aidevops.sh) v3.5.470 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6 spent 2m on this as a headless worker.