### PR TITLE
GH#14014: tighten routine command card

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1031,6 +1031,11 @@
       "at": "2026-03-31T02:20:51Z",
       "pr": 14484
     },
+    ".agents/scripts/commands/routine.md": {
+      "hash": "3f41b68e706f479c75df03b199f4b7c8a027644d",
+      "at": "2026-03-31T03:14:22Z",
+      "pr": 14509
+    },
     ".agents/workflows/pr.md": {
       "hash": "8f6584d97315d02aa4914a1f26165c57ff873479",
       "at": "2026-03-29T14:29:47Z",

--- a/.agents/scripts/commands/routine.md
+++ b/.agents/scripts/commands/routine.md
@@ -4,18 +4,18 @@ agent: Build+
 mode: subagent
 ---
 
-Create a recurring operational routine (reports, audits, monitoring, outreach) without forcing `/full-loop`.
+Create recurring operational routines (reports, audits, monitoring, outreach) without forcing `/full-loop`.
 
 Arguments: $ARGUMENTS
 
-## Decision Rule
+## Route by work type
 
-- Needs repo code changes + PR traceability → `/full-loop`
-- Operational execution → direct commands with `opencode run`
+- Code changes + PR traceability needed → `/full-loop`
+- Operational execution only → direct commands with `opencode run`
 
-## Goal
+## Model the routine in 3 dimensions
 
-Build routines from three independent dimensions — each evolves separately:
+Keep these independent so each can change without rewriting the others:
 
 1. **SOP** — what to do
 2. **Targets** — who/what to apply it to
@@ -25,7 +25,7 @@ Build routines from three independent dimensions — each evolves separately:
 
 ### Step 1: Define the SOP command
 
-Select or create a command that performs one run for one target. Prefer deterministic helper/script commands over free-form prompts.
+Pick or create a command that performs one run for one target. Prefer deterministic helpers/scripts over free-form prompts.
 
 ```bash
 /seo-export --account client-a --format summary
@@ -35,7 +35,7 @@ Select or create a command that performs one run for one target. Prefer determin
 
 ### Step 2: Validate quality and safety
 
-Run ad-hoc before scheduling:
+Run it ad hoc before scheduling:
 
 ```bash
 opencode run --dir ~/Git/<repo> --agent SEO --title "Routine dry run" \
@@ -55,7 +55,7 @@ Roll out in order: (1) internal/self → (2) single client → (3) small cohort 
 
 ### Step 4: Schedule
 
-Use launchd/cron via `routine-helper.sh` (recommended):
+Use launchd/cron via `routine-helper.sh` when possible:
 
 ```bash
 ~/.aidevops/agents/scripts/routine-helper.sh plan \
@@ -75,11 +75,11 @@ opencode run --dir ~/Git/<repo> --agent SEO --title "Weekly rankings" \
   "/seo-export --account client-a --format summary"
 ```
 
-Queue-driven dev work → `/pulse`. Fixed-time routines → scheduler entries.
+Queue-driven dev work goes through `/pulse`. Fixed-time routines go through scheduler entries.
 
-## Example: GH Failure Miner Routine
+## Example: GH Failure Miner routine
 
-Cluster CI failure signatures from GitHub notifications and surface systemic fixes. Mines both PR and push sources by default (`--pr-only` for PR-only).
+Cluster CI failure signatures from GitHub notifications and surface systemic fixes. It mines both PR and push sources by default (`--pr-only` for PR-only).
 
 ```bash
 # Ad-hoc report
@@ -107,11 +107,11 @@ Schedule via `routine-helper.sh`:
   --prompt "Run ~/.aidevops/agents/scripts/gh-failure-miner-helper.sh create-issues --since-hours 6 --pulse-repos --systemic-threshold 3 --max-issues 3 --label auto-dispatch and then print ~/.aidevops/agents/scripts/gh-failure-miner-helper.sh report --since-hours 6 --pulse-repos."
 ```
 
-This routine is operational (triage + issue filing) — do not use `/full-loop`.
+This is operational work (triage + issue filing), so do not use `/full-loop`.
 
-## Routine Spec Template
+## Routine spec template
 
-Store definitions in your repo (e.g., `routines/seo-weekly.yaml`):
+Store routine definitions in your repo, for example `routines/seo-weekly.yaml`:
 
 ```yaml
 name: weekly-seo-rankings
@@ -122,7 +122,7 @@ targets_cmd: "wp-helper --list-category client --jsonl"
 run_template: "/seo-export --account {{target.account}} --format summary"
 ```
 
-`targets_cmd` emits one JSON object per line for target iteration. Note: `routine-helper.sh` currently schedules a literal `--prompt` and does not parse `targets_cmd`/`run_template` directly.
+`targets_cmd` emits one JSON object per line for target iteration. `routine-helper.sh` currently schedules a literal `--prompt`; it does not parse `targets_cmd` or `run_template` directly.
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Summary
- tighten `.agents/scripts/commands/routine.md` wording without changing workflow structure, examples, or decision rules
- preserve the routing rule, rollout checks, scheduler guidance, GH Failure Miner example, and routine spec template while reducing prose overhead
- record the new content hash in `.agents/configs/simplification-state.json` so the simplification registry matches PR #14509

## Testing
- `bunx markdownlint-cli2 ".agents/scripts/commands/routine.md"`
- `jq empty ".agents/configs/simplification-state.json"`

## Runtime Testing
- self-assessed
- risk level: low (agent-doc prose + state registry only)

Closes #14014


---
[aidevops.sh](https://aidevops.sh) v3.5.470 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4