### PR TITLE
GH#14013: tighten image upscaling doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2781,6 +2781,11 @@
       "at": "2026-03-30T03:34:18Z",
       "pr": 13531
     },
+    ".agents/seo/upscale.md": {
+      "hash": "9ac63de45de90e25c2de33409fc931e65da4c121",
+      "at": "2026-03-31T03:14:42Z",
+      "pr": 14510
+    },
     ".agents/tools/mobile/maestro.md": {
       "hash": "9cfba2015ca5bd40086f5d15c690910a0a3c6bfd",
       "at": "2026-03-30T03:34:20Z",

--- a/.agents/seo/upscale.md
+++ b/.agents/seo/upscale.md
@@ -11,9 +11,8 @@ tools:
 
 # Image Upscaling
 
-**Decision tree**: Local CLI for bulk/privacy → Replicate for quality/convenience → Cloudflare for CDN-integrated
-
-**Minimum targets**: 1200px wide (social sharing), 800px (blog content), 2x for retina
+- **Decision tree**: Real-ESRGAN for bulk/privacy, Replicate for best quality, Cloudflare for CDN-integrated resizing.
+- **Minimum targets**: 1200px wide for social sharing, 800px for blog content, 2x variants for retina.
 
 ## Providers
 
@@ -65,7 +64,7 @@ curl -s "https://api.replicate.com/v1/predictions/$PREDICTION_ID" \
 
 ### Cloudflare Images (CDN-Integrated)
 
-Resize/optimize on-the-fly (requires Cloudflare Pro+). Not AI upscaling — handles format conversion and responsive variants.
+Resize and optimize on the fly. Not AI upscaling; use it for format conversion and responsive delivery when already on Cloudflare Pro+.
 
 ```bash
 # Upload via API
@@ -77,7 +76,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/image
 
 ### Sharp (Node.js — Format Conversion)
 
-Not upscaling. Use for WebP/AVIF conversion and responsive variants.
+Not upscaling. Use it for WebP/AVIF conversion, responsive variants, and `withoutEnlargement` safety.
 
 ```javascript
 import sharp from 'sharp';
@@ -89,7 +88,7 @@ for (const width of [400, 800, 1200, 1600]) {
 }
 ```
 
-## When to Upscale
+## Tool Selection
 
 | Scenario | Tool |
 |----------|------|
@@ -103,14 +102,14 @@ for (const width of [400, 800, 1200, 1600]) {
 ## Pipeline
 
 ```text
-1. Analyze (Moondream)  — get content description
-2. Upscale if needed    — ensure minimum dimensions
-3. Convert format       — WebP (primary), JPEG (fallback)
-4. Compress             — target < 200KB for web
-5. Generate variants    — 400w, 800w, 1200w, 1600w
-6. Rename               — SEO-friendly filename
-7. Add metadata         — alt text, title, IPTC keywords
-8. Validate             — check OG requirements met
+1. Analyze (Moondream) — get content description
+2. Upscale if needed — ensure minimum dimensions
+3. Convert format — WebP (primary), JPEG (fallback)
+4. Compress — target < 200KB for web
+5. Generate variants — 400w, 800w, 1200w, 1600w
+6. Rename — SEO-friendly filename
+7. Add metadata — alt text, title, IPTC keywords
+8. Validate — check OG requirements met
 ```
 
 ## Size Targets


### PR DESCRIPTION
## Summary
- tighten the image upscaling quick-reference wording so provider guidance is faster to scan
- clarify Cloudflare and Sharp roles without changing commands, tables, or related references
- record the updated hash for .agents/seo/upscale.md in the simplification state registry

## Runtime Testing
- Level: self-assessed (agent doc and registry change only)
- Verification:
  - bunx markdownlint-cli2 ".agents/seo/upscale.md"
  - reviewed the .agents/configs/simplification-state.json entry for .agents/seo/upscale.md

Closes #14013

---
[aidevops.sh](https://aidevops.sh) v3.5.470 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 10m on this as a headless worker.
