### PR TITLE
GH#14023: tighten curl-copy workflow

### DIFF
--- a/.agents/tools/browser/curl-copy.md
+++ b/.agents/tools/browser/curl-copy.md
@@ -18,19 +18,17 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Extract data from authenticated pages using browser session cookies via DevTools "Copy as cURL"
-- **No install required**: Uses browser DevTools + curl (built into macOS/Linux)
-- **Best for**: Dashboards, gated content, private APIs, admin panels, one-off extractions
-
-**Use when**: One-off extraction from authenticated pages, scraping behind login walls, accessing private/internal APIs from DevTools, extracting dashboard data, debugging API responses with real session state.
-
-**Don't use when**: Repeated/scheduled scraping (tokens expire — use sweet-cookie or Playwright persistent sessions), multi-page crawling (use Crawl4AI or Playwright), interaction required (use Stagehand or Playwright), long-running sessions (cookies expire).
+- **Purpose**: Extract data from authenticated pages with the browser's live session cookies
+- **Setup**: Browser DevTools + `curl` (built into macOS/Linux)
+- **Best for**: Dashboards, gated content, private APIs, admin panels, one-off debugging
+- **Use when**: one-off extraction from an authenticated page or internal API
+- **Don't use when**: repeated jobs -> `sweet-cookie`; interaction required -> Playwright/Stagehand; bulk crawling -> Crawl4AI; long-lived sessions -> persistent browser tooling
 
 ```text
 Need data from an authenticated page?
-    +-> One-off extraction? --> Curl-Copy (this workflow)
+    +-> One-off extraction? --> Curl-Copy
     +-> Repeated/scheduled? --> sweet-cookie + cron
-    +-> Need to interact first? --> Playwright or Stagehand
+    +-> Need interaction first? --> Playwright or Stagehand
     +-> Bulk pages? --> Crawl4AI with exported cookies
 ```
 
@@ -38,17 +36,21 @@ Need data from an authenticated page?
 
 ## Workflow
 
-### Step 1: Copy the Request from DevTools
+### 1. Copy a real request from DevTools
 
-1. Open the target page in your browser (Chrome, Firefox, Edge, Safari)
-2. Open DevTools: `Cmd+Option+I` (macOS) or `F12` (Windows/Linux)
-3. Go to the **Network** tab, filter by `Fetch/XHR` to see API calls
-4. Perform the action or reload the page to capture the request
-5. Right-click the request → **Copy** → **Copy as cURL** (Chrome/Edge: "Copy as cURL (bash)", Firefox: "Copy Value → Copy as cURL", Safari: "Copy as cURL")
+1. Open the target page in Chrome, Firefox, Edge, or Safari.
+2. Open DevTools (`Cmd+Option+I` on macOS, `F12` on Windows/Linux).
+3. In **Network**, filter to `Fetch/XHR`.
+4. Reload or repeat the action that loads the data.
+5. Right-click the request -> **Copy** -> **Copy as cURL**.
 
-### Step 2: Execute and Transform
+- Chrome/Edge: `Copy as cURL (bash)`
+- Firefox: `Copy Value -> Copy as cURL`
+- Safari: `Copy as cURL`
 
-Paste the copied command directly into terminal or AI assistant. It includes all headers, cookies, and auth tokens from your active session.
+### 2. Execute and reshape the response
+
+Paste the copied command into a terminal or local AI assistant. It already contains the active headers, cookies, and auth state.
 
 ```bash
 # Example copied command (headers truncated)
@@ -58,20 +60,20 @@ curl 'https://analytics.example.com/api/v1/reports/traffic' \
   -H 'cookie: session_id=abc123; csrf_token=xyz789' \
   -H 'user-agent: Mozilla/5.0 ...'
 
-# Common modifications
-curl '...' -o output.json                                    # Save to file
-curl '...' -s | jq .                                         # Pretty-print JSON
-curl '...' -L                                                # Follow redirects
-curl '...' -X POST -d '{"query": "new data"}'                # Change method
-curl '...' -s | jq '.data[] | {name: .name, value: .value}'  # Extract fields
-curl '...' -s -o "export-$(date +%Y%m%d-%H%M%S).json"        # Timestamped save
-curl '...?page=1&per_page=100' -s | jq .                     # Pagination
+# Common transforms
+curl '...' -o output.json                                    # save raw output
+curl '...' -s | jq .                                         # pretty-print JSON
+curl '...' -L                                                # follow redirects
+curl '...' -X POST -d '{"query": "new data"}'                # modify method/body
+curl '...' -s | jq '.data[] | {name: .name, value: .value}'  # extract fields
+curl '...' -s -o "export-$(date +%Y%m%d-%H%M%S).json"        # timestamped export
+curl '...?page=1&per_page=100' -s | jq .                     # test pagination
 ```
 
-## Practical Examples
+## Practical Patterns
 
 ```bash
-# Extract analytics dashboard data — pipe chart/table API through jq
+# Analytics/dashboard extraction
 curl 'https://analytics.example.com/api/reports?range=30d' \
   -H 'cookie: session=...' \
   -s | jq '.rows[] | [.page, .views, .bounceRate] | @csv'
@@ -81,33 +83,33 @@ for page in $(seq 1 10); do
   curl "https://admin.example.com/api/users?page=$page&limit=100" \
     -H 'cookie: session=...' \
     -s | jq '.users[]' >> all-users.json
-  sleep 1  # Be respectful
+  sleep 1
 done
 
-# Download private API schema (OpenAPI/Swagger behind auth)
+# Download private OpenAPI/Swagger schema behind auth
 curl 'https://app.example.com/api/docs/openapi.json' \
   -H 'cookie: session=...' -s | jq . > api-schema.json
 
-# SPA GraphQL — filter by Fetch/XHR in DevTools to find data endpoints
+# GraphQL request copied from a SPA
 curl 'https://app.example.com/graphql' \
   -H 'content-type: application/json' -H 'cookie: session=...' \
   -d '{"query": "{ users { id name email } }"}' -s | jq .
 ```
 
-## Tips
+## Operating Notes
 
-**Finding the right request**: Filter by `Fetch/XHR` in DevTools Network tab to skip images/CSS/JS. Click requests and check the Response/Preview tab for structured JSON data. Use the filter box to search by URL path.
+| Topic | Guidance |
+|------|----------|
+| Find the right request | Stay in `Fetch/XHR`, inspect **Response/Preview**, search by URL path |
+| Session lifetime | Keep the tab open if possible; copy a fresh command after `401/403` |
+| Sharing safely | Strip `cookie`, `authorization`, and `x-csrf-token` before sharing |
+| Responsible use | Add `sleep` between requests, respect robots.txt, avoid abuse detection |
+| AI assistants | Safe only with trusted local assistants; copied commands contain live session tokens |
 
-**Extending session lifetime**: Keep the browser tab open (some sessions auto-refresh). If you get 401/403, copy a fresh cURL command. Note which cookie names are session tokens for quick updates.
+## Method Comparison
 
-**Security**: Never commit copied cURL commands to git (they contain session tokens). Add `sleep` between requests to avoid abuse detection. Respect robots.txt. Strip `cookie`, `authorization`, and `x-csrf-token` headers before sharing.
-
-**With AI assistants**: Paste the cURL command with instructions like "extract all product names" or "paginate and compile results". The AI executes curl, parses JSON, and transforms data. **Privacy**: the command contains session cookies — only share with trusted, locally-running assistants.
-
-## Auth Method Comparison
-
-| Method | Setup | Session Duration | Automation | Best For |
-|--------|-------|-----------------|------------|----------|
+| Method | Setup | Session duration | Automation | Best for |
+|--------|-------|------------------|------------|----------|
 | **Curl-Copy** | Seconds | Minutes-hours | Manual | One-off extractions |
 | **Sweet Cookie** | Minutes | Browser session | Scriptable | Repeated local access |
 | **Playwright persistent** | Minutes | Configurable | Full | Automated workflows |
@@ -116,14 +118,16 @@ curl 'https://app.example.com/graphql' \
 
 ## Troubleshooting
 
-- **401/403**: Session expired — reload the page in browser and copy a fresh cURL command
-- **CORS errors**: Not applicable — curl bypasses CORS entirely (browser-only restriction)
-- **Empty/HTML response instead of JSON**: Add `-H 'accept: application/json'`, or the URL may be a page URL not an API endpoint — look for XHR/Fetch requests in DevTools instead
-- **SSL certificate errors**: For internal/dev servers with self-signed certs: `curl '...' -k` (dev only)
+| Problem | Fix |
+|---------|-----|
+| `401/403` | Session expired; reload the page and copy a fresh cURL command |
+| CORS errors | Not applicable; `curl` bypasses browser CORS restrictions |
+| HTML/empty response instead of JSON | Add `-H 'accept: application/json'`, or copy the XHR/Fetch request instead of the page URL |
+| SSL certificate errors | For internal/dev servers with self-signed certs, add `-k` temporarily |
 
-## Related Tools
+## Related
 
-- `tools/browser/sweet-cookie.md` - Programmatic cookie extraction from browser databases
-- `tools/browser/browser-automation.md` - Full browser automation decision tree
-- `tools/browser/dev-browser.md` - Persistent browser profile for automation
-- `tools/browser/crawl4ai.md` - Bulk web crawling and extraction
+- `tools/browser/sweet-cookie.md` - Reuse browser cookies programmatically
+- `tools/browser/browser-automation.md` - Browser tool selection guide
+- `tools/browser/dev-browser.md` - Persistent browser profile automation
+- `tools/browser/crawl4ai.md` - Bulk crawling and extraction


### PR DESCRIPTION
## Summary
- tighten the curl-copy quick reference so agents can pick the workflow faster
- condense execution guidance into compact workflow, operating notes, and troubleshooting tables
- keep the existing command examples while reducing narrative overhead

## Testing
- bunx markdownlint-cli2 ".agents/tools/browser/curl-copy.md"

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Runtime verification not required; no executable behavior changed

Closes #14023

---
[aidevops.sh](https://aidevops.sh) v3.5.470 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 3m on this as a headless worker.