### PR TITLE
GH#14022: tighten stealth patches reference card

### DIFF
--- a/.agents/tools/browser/stealth-patches.md
+++ b/.agents/tools/browser/stealth-patches.md
@@ -10,19 +10,19 @@ tools:
 
 # Stealth Patches (Chromium/Playwright)
 
-Remove automation detection signals from Playwright/Chromium. Primary: `rebrowser-patches` (MIT). Lightweight alternative: `playwright-stealth`.
+Remove Playwright/Chromium automation signals. Primary: `rebrowser-patches` (MIT). Lightweight fallback: `playwright-stealth`.
 
-## Tool Selection
+## Choose the Tool First
 
-| Tool | Approach | Stealth | Best For |
+| Tool | Approach | Stealth | Use When |
 |------|----------|---------|----------|
-| **rebrowser-patches** | Patches Playwright source | High | Production, Cloudflare/DataDome |
+| **rebrowser-patches** | Patches Playwright source | High | Production Chromium, Cloudflare/DataDome, existing Playwright code |
 | **playwright-stealth** | Runtime JS evasions | Medium | Quick Python scripts, basic evasion |
-| **Manual args** | Chrome flags only | Low | Dev testing |
+| **Manual args** | Chrome flags only | Low | Dev testing only |
 
 ## rebrowser-patches
 
-Fixes: `Runtime.enable` CDP leak, `navigator.webdriver`, CDP artifacts, headless indicators, `//# sourceURL=` leaks.
+Patches `Runtime.enable` CDP leaks, `navigator.webdriver`, other CDP artifacts, headless indicators, and `//# sourceURL=` leaks.
 
 ```bash
 npx rebrowser-patches@latest patch        # Patch existing Playwright
@@ -35,14 +35,8 @@ npx rebrowser-patches@latest unpatch     # Restore original
 
 ```javascript
 import { chromium } from 'rebrowser-playwright';  // or 'playwright' after patching
-const browser = await chromium.launch({
-  headless: true,
-  args: ['--disable-blink-features=AutomationControlled'],
-});
-const context = await browser.newContext({
-  viewport: { width: 1920, height: 1080 },
-  userAgent: '<realistic UA string>',
-});
+const browser = await chromium.launch({ headless: true, args: ['--disable-blink-features=AutomationControlled'] });
+const context = await browser.newContext({ viewport: { width: 1920, height: 1080 }, userAgent: '<realistic UA string>' });
 ```
 
 **Python:**
@@ -56,7 +50,7 @@ with sync_playwright() as p:
 
 ## playwright-stealth (Python)
 
-JS-level evasions: `navigator.webdriver`, plugins, languages, `chrome.runtime`, `window.chrome`, Permissions API, iframe detection, WebGL, `hardwareConcurrency`.
+JS-level evasions cover `navigator.webdriver`, plugins, languages, `chrome.runtime`, `window.chrome`, Permissions API, iframe detection, WebGL, and `hardwareConcurrency`.
 
 ```python
 from playwright.sync_api import sync_playwright
@@ -71,18 +65,12 @@ with sync_playwright() as p:
 
 ## Manual Stealth Args
 
-Minimal evasion via Chrome flags (no patching required):
+Chrome flags only; useful for dev checks, not serious anti-bot bypass.
 
 ```javascript
 const browser = await chromium.launch({
   headless: true,
-  args: [
-    '--disable-blink-features=AutomationControlled',
-    '--disable-infobars',
-    '--no-first-run',
-    '--no-default-browser-check',
-    '--disable-component-extensions-with-background-pages',
-  ],
+  args: ['--disable-blink-features=AutomationControlled', '--disable-infobars', '--no-first-run', '--no-default-browser-check', '--disable-component-extensions-with-background-pages'],
   ignoreDefaultArgs: ['--enable-automation'],
 });
 ```
@@ -99,11 +87,11 @@ import { createStealthContext } from '~/.aidevops/agents/scripts/stealth-context
 const { browser, context, page } = await createStealthContext({
   headless: true,
   proxy: { server: 'socks5://127.0.0.1:1080' },  // optional
-  profile: 'my-profile',                           // optional: saved state
+  profile: 'my-profile',  // optional: saved state
 });
 ```
 
-## Detection Test Sites
+## Test Against Detection Sites
 
 | Site | URL |
 |------|-----|
@@ -116,10 +104,10 @@ const { browser, context, page } = await createStealthContext({
 
 ## Limitations
 
-- **rebrowser-patches**: Chromium only; re-patch after Playwright updates
-- **playwright-stealth**: JS-level only; detectable by sophisticated anti-bots
-- **Neither** handles fingerprint rotation, WebRTC/font spoofing
-- **Full anti-detect**: Use Camoufox (`fingerprint-profiles.md`) -- C++ level fingerprint spoofing, Firefox-based, `pip upgrade` maintenance
+- **rebrowser-patches**: Chromium only; re-patch after Playwright updates.
+- **playwright-stealth**: JS-level only; sophisticated anti-bots still detect it.
+- **Neither** handles fingerprint rotation or WebRTC/font spoofing.
+- **Full anti-detect**: use Camoufox (`fingerprint-profiles.md`) for C++-level fingerprint spoofing on Firefox, with `pip upgrade` maintenance.
 
 | Aspect | rebrowser-patches | Camoufox |
 |--------|------------------|----------|

--- a/todo/tasks/GH-14022-brief.md
+++ b/todo/tasks/GH-14022-brief.md
@@ -1,0 +1,26 @@
+# GH#14022: Tighten `.agents/tools/browser/stealth-patches.md`
+
+## Session Origin
+Interactive `/full-loop` run for GitHub issue #14022 under the headless continuation contract.
+
+## What
+Restructure `.agents/tools/browser/stealth-patches.md` into a tighter reference card that preserves every command, URL, limitation, and decision signal while reducing redundant prose.
+
+## Why
+The doc is already a compact reference, but it still repeats setup details across sections and buries the selection guidance behind narrative text. A slimmer layout reduces token cost on load without changing the agent guidance.
+
+## How
+1. Classify the file as a short single-topic reference card, not a multi-chapter corpus.
+2. Keep one page, but reorder it for primacy: choose tool, install/use, test, limits.
+3. Preserve all command examples, detection URLs, and comparisons; compress explanatory sentences.
+4. Run markdown lint on the edited file.
+
+## Acceptance Criteria
+- [ ] All existing command examples, URLs, and comparison facts remain present.
+- [ ] Tool-selection guidance appears before implementation details.
+- [ ] The file is shorter than the original 129 lines without adding companion chapter files.
+- [ ] Markdown lint passes for `.agents/tools/browser/stealth-patches.md`.
+- [ ] PR created with `Closes #14022`.
+
+## Context
+Issue #14022 is a simplification-debt task created by the automated scan. The issue asked for classification first; current assessment is that this file is a small reference card, so the correct action is prose tightening and reordering rather than chapter splitting.


### PR DESCRIPTION
## Summary
- reframe `.agents/tools/browser/stealth-patches.md` as a quick reference that puts tool selection before implementation details
- keep every command example, detection URL, and limitation while trimming redundant prose and compressing long code snippets
- add a task brief for GH#14022 so the simplification rationale and acceptance criteria are preserved in-repo

## Runtime Testing
- Level: self-assessed (low-risk documentation change)
- Verification: `bunx markdownlint-cli2 .agents/tools/browser/stealth-patches.md`
- Verification: `wc -l .agents/tools/browser/stealth-patches.md` -> `117` lines (down from 129)

## Traceability
- Closes #14022

---
[aidevops.sh](https://aidevops.sh) v3.5.470 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m on this as a headless worker.
