### PR TITLE
GH#14024: tighten Sentry MCP guide

### DIFF
--- a/.agents/services/monitoring/sentry.md
+++ b/.agents/services/monitoring/sentry.md
@@ -24,34 +24,28 @@ mcp:
 - **MCP**: Local stdio mode with `@sentry/mcp-server`
 - **Auth**: Personal Auth Token (created after org exists)
 - **Credentials**: `~/.config/aidevops/credentials.sh` → `SENTRY_YOURNAME`
-- **When to use**: Production error debugging, error trend analysis, stack trace investigation, release health checks
+- **When to use**: Production error debugging, trend analysis, stack trace investigation, release health checks
+- **Use something else for**: LLM traces/evals → `services/monitoring/langwatch.md`; dependency security → `services/monitoring/socket.md`
 
 <!-- AI-CONTEXT-END -->
 
 ## MCP Setup
 
-### 1. Create Sentry Account & Organization
-
-1. Sign up at [sentry.io](https://sentry.io)
-2. Create an organization first (Settings → Organizations → Create)
-3. Create a project within the organization
-
-### 2. Generate Personal Auth Token
-
-Create the token **after** creating the organization — tokens created before the org don't inherit access.
-
-1. Settings → Account → Personal Tokens → Create New Token
-2. Required permissions: `alerts:read`, `alerts:write`, `event:admin`, `event:read`, `event:write`, `member:read`, `org:read`, `project:read`, `project:releases`, `team:read`
-3. Save token:
+1. Create the account structure first:
+   - Sign up at [sentry.io](https://sentry.io)
+   - Create the organization (`Settings → Organizations → Create`)
+   - Create a project inside that organization
+2. Generate a **personal** auth token at `Settings → Account → Personal Tokens → Create New Token`
+   - Create the token **after** the organization exists; earlier tokens may not inherit org access
+   - Required scopes: `alerts:read`, `alerts:write`, `event:admin`, `event:read`, `event:write`, `member:read`, `org:read`, `project:read`, `project:releases`, `team:read`
+3. Save the token:
 
 ```bash
 echo 'export SENTRY_YOURNAME="sntryu_..."' >> ~/.config/aidevops/credentials.sh
 chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
-### 3. Configure MCP
-
-Add to your MCP config (`~/.config/opencode/opencode.json` or equivalent):
+4. Configure the MCP in `~/.config/opencode/opencode.json` or equivalent:
 
 ```json
 {
@@ -65,17 +59,17 @@ Add to your MCP config (`~/.config/opencode/opencode.json` or equivalent):
 }
 ```
 
-Or programmatically:
+Or update it programmatically:
 
 ```bash
 source ~/.config/aidevops/credentials.sh
 tmp_json="$(mktemp)"
 jq --arg token "$SENTRY_YOURNAME" \
   '.mcpServers.sentry = {"command": "npx", "args": ["@sentry/mcp-server@latest", "--access-token", $token], "enabled": true}' \
-  ~/.config/opencode/opencode.json > "$tmp_json" && mv "$tmp_json" ~/.config/opencode/opencode.json
+   ~/.config/opencode/opencode.json > "$tmp_json" && mv "$tmp_json" ~/.config/opencode/opencode.json
 ```
 
-### 4. Test Connection
+5. Test the token:
 
 ```bash
 source ~/.config/aidevops/credentials.sh
@@ -84,14 +78,12 @@ curl -s -H "Authorization: Bearer $SENTRY_YOURNAME" "https://sentry.io/api/0/org
 
 ## Available MCP Tools
 
-| Tool | Description |
-|------|-------------|
-| `list_projects` | List all Sentry projects |
-| `get_issue` | Get details of a specific issue |
-| `list_issues` | List issues for a project |
-| `get_event` | Get details of a specific event |
-| `resolve_issue` | Mark an issue as resolved |
-| `assign_issue` | Assign issue to a team member |
+- `list_projects` — list Sentry projects
+- `get_issue` — fetch one issue
+- `list_issues` — list project issues
+- `get_event` — fetch one event
+- `resolve_issue` — mark an issue resolved
+- `assign_issue` — assign an issue
 
 ## Usage Examples
 
@@ -110,20 +102,20 @@ npx @sentry/wizard@latest -i node    # Node.js
 npx @sentry/wizard@latest -i react   # React
 ```
 
-The wizard creates all required config files. See [Sentry Docs](https://docs.sentry.io/) for platform-specific guides. Keep `sendDefaultPii` disabled unless you need user/IP metadata and have privacy coverage.
+The wizard creates the required config files. See [Sentry Docs](https://docs.sentry.io/) for platform-specific guides. Keep `sendDefaultPii` disabled unless you explicitly need user/IP metadata and have privacy coverage.
 
 ## Troubleshooting
 
-**Token returns empty organizations**: Create a new token **after** the organization exists.
-
-**"Not authenticated"**:
-1. Verify key exists: `source ~/.config/aidevops/credentials.sh && printenv | cut -d= -f1 | grep '^SENTRY_YOURNAME$'`
-2. Test API: `curl -H "Authorization: Bearer $SENTRY_YOURNAME" https://sentry.io/api/0/`
-3. Restart your runtime after config changes
-
-**Org token vs Personal token**: Org tokens (`org:ci` scope) are CI/CD-only. Use personal tokens for MCP.
+- **Empty organizations**: create a new token **after** the organization exists.
+- **`Not authenticated`**:
+  1. Verify the variable exists: `source ~/.config/aidevops/credentials.sh && printenv | cut -d= -f1 | grep '^SENTRY_YOURNAME$'`
+  2. Test the API directly: `curl -H "Authorization: Bearer $SENTRY_YOURNAME" https://sentry.io/api/0/`
+  3. Restart the runtime after config changes
+- **Wrong token type**: org tokens (`org:ci`) are for CI/CD; MCP needs a personal token.
 
 ## Related
 
 - [Sentry Documentation](https://docs.sentry.io/)
 - [Sentry MCP](https://mcp.sentry.dev/)
+- `services/monitoring/langwatch.md`
+- `services/monitoring/socket.md`


### PR DESCRIPTION
## Summary
- tighten \.agents/services/monitoring/sentry.md so setup and troubleshooting steps read as a compact reference card
- add cross-links to LangWatch and Socket so monitoring choices are easier to route correctly
- keep the required token scopes, MCP config, test command, and SDK guidance intact while removing redundant prose

## Testing
- bunx markdownlint-cli2 ".agents/services/monitoring/sentry.md"

## Runtime Testing
- Level: self-assessed
- Reason: docs-only change in an agent/service reference file

Closes #14024


---
[aidevops.sh](https://aidevops.sh) v3.5.470 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 75,747 tokens on this as a headless worker. Overall, 19h 2m since this issue was created.