### PR TITLE
GH#14011: split Mobile CRO reference chapter

### DIFF
--- a/.agents/marketing-sales/cro-chapter-11.md
+++ b/.agents/marketing-sales/cro-chapter-11.md
@@ -2,132 +2,28 @@
 
 60%+ of web traffic is mobile, yet mobile converts 1-3% vs desktop 3-5%.
 
-## Thumb Zone Design
+This chapter is a reference corpus. The original content now lives in section files under `cro-chapter-11/` so the chapter entry point stays short while preserving the full material.
 
-- **Bottom third (natural rest):** Primary CTAs — Buy Now, Add to Cart, Submit
-- **Middle third (easy reach):** Navigation, filters, secondary actions
-- **Top third (hard to reach):** Headings, images, informational content
+## Reading Path
 
-**Sticky CTA** — highest-impact mobile CRO change (10-30% click increase). CTA stays visible regardless of scroll position.
+1. [Thumb Zone Design](cro-chapter-11/01-thumb-zone-design.md) — reach zones, sticky CTA guidance, and CTA sizing rules
+2. [Mobile Form Optimization](cro-chapter-11/02-mobile-form-optimization.md) — field reduction, input types, autofill, and validation
+3. [Mobile Navigation](cro-chapter-11/03-mobile-navigation.md) — navigation patterns, trade-offs, and breadcrumb guidance
+4. [Click-to-Call and App Banners](cro-chapter-11/04-click-to-call-and-app-banners.md) — phone CTA placement and app banner timing
+5. [Mobile Page Speed](cro-chapter-11/05-mobile-page-speed.md) — performance priorities, Core Web Vitals, and tools
+6. [AMP Considerations](cro-chapter-11/06-amp-considerations.md) — when AMP still fits and when SSR/edge is better
+7. [Mobile Checkout](cro-chapter-11/07-mobile-checkout.md) — checkout friction removal and wallet-first guidance
+8. [Mobile A/B Testing](cro-chapter-11/08-mobile-ab-testing.md) — mobile-specific experiments and segmentation caveats
+9. [Mobile CRO Checklist](cro-chapter-11/09-mobile-cro-checklist.md) — deployment and review checklist
 
-**CTA sizing:** Min 44x44px (Apple) / 48x48px (Google), recommended 56px+ height full-width. Mobile copy = brevity ("Get Free Consultation" not "Request a Free Consultation with Our Experts").
+## Key Themes
 
-```css
-.mobile-cta { min-height: 56px; width: 100%; font-size: 18px; font-weight: bold; border-radius: 8px; margin: 16px 0; }
-```
+- Thumb-friendly interaction design beats desktop patterns squeezed onto small screens.
+- Mobile conversion work spans design, forms, navigation, speed, and checkout together.
+- Testing mobile separately matters because device constraints and user behaviour differ from desktop.
 
-## Mobile Form Optimization
+## Related CRO References
 
-1. **Minimize fields** — target <5 (each feels 3x harder on mobile)
-2. **Single-column layout** — always
-3. **48px min height**, 16px+ font (prevents iOS Safari auto-zoom)
-4. **Correct input types + autofill** — triggers appropriate keyboard and one-tap fill:
-
-```html
-<input type="email" autocomplete="email">   <!-- @ and .com keys -->
-<input type="tel" autocomplete="tel">       <!-- Number pad -->
-<input type="url">                          <!-- .com and / keys -->
-<input type="number">                       <!-- Number pad -->
-<input type="date">                         <!-- Native date picker -->
-<input type="text" autocomplete="name">
-<input type="text" autocomplete="street-address">
-```
-
-5. **Labels above fields** (not placeholder-only)
-6. **Inline validation** — errors on blur, not on submit
-7. **Input masks** for formatted fields (Cleave.js, react-input-mask)
-
-```css
-input, select, textarea { min-height: 48px; padding: 12px; font-size: 16px; /* Prevents iOS auto-zoom */ }
-```
-
-## Mobile Navigation
-
-| Pattern | Best for | Trade-off |
-|---------|----------|-----------|
-| Hamburger (☰) | Content-heavy sites | Saves space, reduces discoverability |
-| Bottom tab bar | App-like / e-commerce | Thumb-friendly, takes vertical space |
-| Priority+ | 3-5 key pages | Shows top items, overflow for rest |
-
-Limit top-level items to 5-7. Search prominent with autocomplete. Sticky header. Mega menus → accordion/drill-down. Breadcrumbs: `← Running Shoes` not full path.
-
-## Click-to-Call and App Banners
-
-**Click-to-call** — high-impact for high-ticket, complex, local, or urgent needs. Place in sticky header, FAB (bottom-right), or inline on product pages. Test vs form — calls = higher intent/faster close; forms = scalable/trackable.
-
-```html
-<a href="tel:+18005551234">📞 Call Now: 1-800-555-1234</a>
-```
-
-**iOS Smart Banner:** `<meta name="apple-itunes-app" content="app-id=123456789">`
-
-Show for engaged users (3+ pages, 2+ min), repeat visitors, cart holders. Never on first visit, after dismissal, or during checkout. Use Universal Links (iOS) / App Links (Android) — not custom URI schemes.
-
-## Mobile Page Speed
-
-Bounce probability: 32% at 1-3s → 90% at 1-5s.
-
-1. Responsive images: `srcset` + `loading="lazy"`
-2. WebP/AVIF (25-35% smaller than JPEG)
-3. Inline critical CSS, async load rest
-4. Code-split JS per page, `defer` non-critical
-5. SSR over CSR for faster initial render
-6. CDN + Brotli/Gzip (70-90% text reduction)
-7. `<link rel="preconnect" href="https://cdn.example.com">`
-8. Eliminate redirect chains (each = full round-trip)
-
-**Core Web Vitals (mobile):** FCP <1.8s | LCP <2.5s | TTI <3.8s | CLS <0.1 | FID <100ms
-
-**Tools:** PageSpeed Insights, Lighthouse, WebPageTest, Chrome DevTools (3G throttle).
-
-## AMP Considerations
-
-Near-instant loads (<1s) but Google has reduced ranking advantage; SSR/edge rendering are mature alternatives. **Use for:** content pages, simple product pages, basic lead-gen. **Skip for:** checkout, interactive tools, rich media. **Hybrid:** AMP landing (fast acquisition) → full site for conversion.
-
-## Mobile Checkout
-
-Highest mobile drop-off point — optimize aggressively:
-
-1. **Guest checkout default** — forced account creation kills conversions
-2. **Digital wallets front and center** — Apple Pay / Google Pay reduce checkout to ~10s
-3. **Max 2 steps** (ideally 1)
-4. **Autofill everything** — especially `cc-number`, `cc-exp`, `cc-csc`
-5. **Sticky progress indicator** + "Complete Order" CTA with price
-6. **Remove distractions** — hide nav, no promos during checkout
-7. **Real-time validation** — errors on blur
-8. **Progress saving** — save cart on abandon, email recovery with pre-filled info
-9. **Click-to-call support** visible during checkout
-
-**Case study:** 7-step desktop checkout → 2-step mobile-optimized (guest default, large fields, Apple/Google Pay). Result: 0.8% → 2.4% conversion (200% increase).
-
-## Mobile A/B Testing
-
-Test mobile separately from desktop — behaviour differs too much for combined tests.
-
-| Test | Expected Impact |
-|------|----------------|
-| Sticky vs non-sticky CTA | 10-30% click increase |
-| Hamburger vs bottom tab nav | Audience-dependent |
-| Click-to-call vs form | Measure leads, not just clicks |
-| One-page vs multi-step checkout | Multi-step often wins on mobile |
-| Accordion vs expanded content | Reduces scroll fatigue |
-
-**Challenges:** Smaller segments (run longer, segment by OS not device), cross-device journeys (user ID tracking not cookies), iOS vs Android behavioural differences.
-
-## Mobile CRO Checklist
-
-**Performance:** Load <3s on 3G | Images optimized (WebP, lazy) | Critical CSS inlined | JS deferred | CDN enabled
-
-**Forms:** Single-column | 48px+ height | 16px+ font | Correct input types | Autofill | Inline validation | Labels above
-
-**Navigation:** Mobile-appropriate pattern | Search prominent | Breadcrumbs simplified | Sticky header
-
-**CTAs:** 44px+ min (56px+ recommended) | Full-width | High contrast | Concise copy | Sticky on long pages
-
-**Checkout:** Guest default | 1-2 steps | Digital wallets | Autofill | Progress indicator | Minimal distractions | Click-to-call
-
-**Content:** Short paragraphs (2-3 lines) | 16px+ font | Ample whitespace | Videos load on tap
-
-**Usability:** No hover-only elements | Adequate tap spacing | No content-blocking popups | Landscape supported
-
-**Testing:** iOS Safari + Android Chrome | Multiple screen sizes | 3G throttled | Touch gestures verified
+- [Chapter 8: Form Optimization](cro-chapter-08.md)
+- [Chapter 10: Checkout Flow](cro-chapter-10.md)
+- [Chapter 13: Heatmaps and Session Recordings](cro-chapter-13.md)

--- a/.agents/marketing-sales/cro-chapter-11/01-thumb-zone-design.md
+++ b/.agents/marketing-sales/cro-chapter-11/01-thumb-zone-design.md
@@ -1,0 +1,13 @@
+# Thumb Zone Design
+
+- **Bottom third (natural rest):** Primary CTAs — Buy Now, Add to Cart, Submit
+- **Middle third (easy reach):** Navigation, filters, secondary actions
+- **Top third (hard to reach):** Headings, images, informational content
+
+**Sticky CTA** — highest-impact mobile CRO change (10-30% click increase). CTA stays visible regardless of scroll position.
+
+**CTA sizing:** Min 44x44px (Apple) / 48x48px (Google), recommended 56px+ height full-width. Mobile copy = brevity ("Get Free Consultation" not "Request a Free Consultation with Our Experts").
+
+```css
+.mobile-cta { min-height: 56px; width: 100%; font-size: 18px; font-weight: bold; border-radius: 8px; margin: 16px 0; }
+```

--- a/.agents/marketing-sales/cro-chapter-11/02-mobile-form-optimization.md
+++ b/.agents/marketing-sales/cro-chapter-11/02-mobile-form-optimization.md
@@ -1,0 +1,24 @@
+# Mobile Form Optimization
+
+1. **Minimize fields** — target <5 (each feels 3x harder on mobile)
+2. **Single-column layout** — always
+3. **48px min height**, 16px+ font (prevents iOS Safari auto-zoom)
+4. **Correct input types + autofill** — triggers appropriate keyboard and one-tap fill:
+
+```html
+<input type="email" autocomplete="email">   <!-- @ and .com keys -->
+<input type="tel" autocomplete="tel">       <!-- Number pad -->
+<input type="url">                          <!-- .com and / keys -->
+<input type="number">                       <!-- Number pad -->
+<input type="date">                         <!-- Native date picker -->
+<input type="text" autocomplete="name">
+<input type="text" autocomplete="street-address">
+```
+
+5. **Labels above fields** (not placeholder-only)
+6. **Inline validation** — errors on blur, not on submit
+7. **Input masks** for formatted fields (Cleave.js, react-input-mask)
+
+```css
+input, select, textarea { min-height: 48px; padding: 12px; font-size: 16px; /* Prevents iOS auto-zoom */ }
+```

--- a/.agents/marketing-sales/cro-chapter-11/03-mobile-navigation.md
+++ b/.agents/marketing-sales/cro-chapter-11/03-mobile-navigation.md
@@ -1,0 +1,9 @@
+# Mobile Navigation
+
+| Pattern | Best for | Trade-off |
+|---------|----------|-----------|
+| Hamburger (☰) | Content-heavy sites | Saves space, reduces discoverability |
+| Bottom tab bar | App-like / e-commerce | Thumb-friendly, takes vertical space |
+| Priority+ | 3-5 key pages | Shows top items, overflow for rest |
+
+Limit top-level items to 5-7. Search prominent with autocomplete. Sticky header. Mega menus → accordion/drill-down. Breadcrumbs: `← Running Shoes` not full path.

--- a/.agents/marketing-sales/cro-chapter-11/04-click-to-call-and-app-banners.md
+++ b/.agents/marketing-sales/cro-chapter-11/04-click-to-call-and-app-banners.md
@@ -1,0 +1,11 @@
+# Click-to-Call and App Banners
+
+**Click-to-call** — high-impact for high-ticket, complex, local, or urgent needs. Place in sticky header, FAB (bottom-right), or inline on product pages. Test vs form — calls = higher intent/faster close; forms = scalable/trackable.
+
+```html
+<a href="tel:+18005551234">📞 Call Now: 1-800-555-1234</a>
+```
+
+**iOS Smart Banner:** `<meta name="apple-itunes-app" content="app-id=123456789">`
+
+Show for engaged users (3+ pages, 2+ min), repeat visitors, cart holders. Never on first visit, after dismissal, or during checkout. Use Universal Links (iOS) / App Links (Android) — not custom URI schemes.

--- a/.agents/marketing-sales/cro-chapter-11/05-mobile-page-speed.md
+++ b/.agents/marketing-sales/cro-chapter-11/05-mobile-page-speed.md
@@ -1,0 +1,16 @@
+# Mobile Page Speed
+
+Bounce probability: 32% at 1-3s → 90% at 1-5s.
+
+1. Responsive images: `srcset` + `loading="lazy"`
+2. WebP/AVIF (25-35% smaller than JPEG)
+3. Inline critical CSS, async load rest
+4. Code-split JS per page, `defer` non-critical
+5. SSR over CSR for faster initial render
+6. CDN + Brotli/Gzip (70-90% text reduction)
+7. `<link rel="preconnect" href="https://cdn.example.com">`
+8. Eliminate redirect chains (each = full round-trip)
+
+**Core Web Vitals (mobile):** FCP <1.8s | LCP <2.5s | TTI <3.8s | CLS <0.1 | FID <100ms
+
+**Tools:** PageSpeed Insights, Lighthouse, WebPageTest, Chrome DevTools (3G throttle).

--- a/.agents/marketing-sales/cro-chapter-11/06-amp-considerations.md
+++ b/.agents/marketing-sales/cro-chapter-11/06-amp-considerations.md
@@ -1,0 +1,7 @@
+# AMP Considerations
+
+Near-instant loads (<1s) but Google has reduced ranking advantage; SSR/edge rendering are mature alternatives.
+
+- **Use for:** content pages, simple product pages, basic lead-gen
+- **Skip for:** checkout, interactive tools, rich media
+- **Hybrid:** AMP landing (fast acquisition) → full site for conversion

--- a/.agents/marketing-sales/cro-chapter-11/07-mobile-checkout.md
+++ b/.agents/marketing-sales/cro-chapter-11/07-mobile-checkout.md
@@ -1,0 +1,15 @@
+# Mobile Checkout
+
+Highest mobile drop-off point — optimize aggressively:
+
+1. **Guest checkout default** — forced account creation kills conversions
+2. **Digital wallets front and center** — Apple Pay / Google Pay reduce checkout to ~10s
+3. **Max 2 steps** (ideally 1)
+4. **Autofill everything** — especially `cc-number`, `cc-exp`, `cc-csc`
+5. **Sticky progress indicator** + "Complete Order" CTA with price
+6. **Remove distractions** — hide nav, no promos during checkout
+7. **Real-time validation** — errors on blur
+8. **Progress saving** — save cart on abandon, email recovery with pre-filled info
+9. **Click-to-call support** visible during checkout
+
+**Case study:** 7-step desktop checkout → 2-step mobile-optimized (guest default, large fields, Apple/Google Pay). Result: 0.8% → 2.4% conversion (200% increase).

--- a/.agents/marketing-sales/cro-chapter-11/08-mobile-ab-testing.md
+++ b/.agents/marketing-sales/cro-chapter-11/08-mobile-ab-testing.md
@@ -1,0 +1,13 @@
+# Mobile A/B Testing
+
+Test mobile separately from desktop — behaviour differs too much for combined tests.
+
+| Test | Expected Impact |
+|------|----------------|
+| Sticky vs non-sticky CTA | 10-30% click increase |
+| Hamburger vs bottom tab nav | Audience-dependent |
+| Click-to-call vs form | Measure leads, not just clicks |
+| One-page vs multi-step checkout | Multi-step often wins on mobile |
+| Accordion vs expanded content | Reduces scroll fatigue |
+
+**Challenges:** Smaller segments (run longer, segment by OS not device), cross-device journeys (user ID tracking not cookies), iOS vs Android behavioural differences.

--- a/.agents/marketing-sales/cro-chapter-11/09-mobile-cro-checklist.md
+++ b/.agents/marketing-sales/cro-chapter-11/09-mobile-cro-checklist.md
@@ -1,0 +1,17 @@
+# Mobile CRO Checklist
+
+**Performance:** Load <3s on 3G | Images optimized (WebP, lazy) | Critical CSS inlined | JS deferred | CDN enabled
+
+**Forms:** Single-column | 48px+ height | 16px+ font | Correct input types | Autofill | Inline validation | Labels above
+
+**Navigation:** Mobile-appropriate pattern | Search prominent | Breadcrumbs simplified | Sticky header
+
+**CTAs:** 44px+ min (56px+ recommended) | Full-width | High contrast | Concise copy | Sticky on long pages
+
+**Checkout:** Guest default | 1-2 steps | Digital wallets | Autofill | Progress indicator | Minimal distractions | Click-to-call
+
+**Content:** Short paragraphs (2-3 lines) | 16px+ font | Ample whitespace | Videos load on tap
+
+**Usability:** No hover-only elements | Adequate tap spacing | No content-blocking popups | Landscape supported
+
+**Testing:** iOS Safari + Android Chrome | Multiple screen sizes | 3G throttled | Touch gestures verified

--- a/todo/tasks/GH-14011-brief.md
+++ b/todo/tasks/GH-14011-brief.md
@@ -1,0 +1,40 @@
+# GH#14011: Restructure Mobile CRO reference chapter
+
+## Session Origin
+
+Interactive `/full-loop` invocation targeting GitHub issue #14011.
+
+## What
+
+Restructure `.agents/marketing-sales/cro-chapter-11.md` as a reference corpus index that points to section files for the Mobile CRO chapter, preserving all chapter knowledge without compressing or deleting it.
+
+## Why
+
+Issue #14011 flagged the file as a simplification target. The file is a textbook-style reference chapter, so the correct fix is restructuring into a slim index plus section files per the reference-corpus rule in `.agents/tools/code-review/code-simplifier.md`.
+
+## How
+
+1. Classify the file as a reference corpus, not an instruction doc.
+2. Move each major section into a dedicated file under `.agents/marketing-sales/cro-chapter-11/`.
+3. Replace `.agents/marketing-sales/cro-chapter-11.md` with a slim index linking each section file and preserving reading order.
+4. Verify that code blocks and all substantive guidance still exist after the split.
+
+## Acceptance Criteria
+
+- [ ] `.agents/marketing-sales/cro-chapter-11.md` becomes an index for the chapter section files.
+- [ ] Every major section from the original chapter exists in a dedicated file under `.agents/marketing-sales/cro-chapter-11/`.
+- [ ] The chapter's code blocks and practical examples remain present after restructuring.
+- [ ] Markdown linting passes for the touched Markdown files.
+- [ ] Total lines across the section files are at least the original chapter size minus index overhead.
+- [ ] PR created with `Closes #14011`.
+
+## Context
+
+The issue explicitly distinguishes instruction-doc tightening from reference-corpus restructuring. Chapter 11 is already a self-contained knowledge chapter, so the safe change is progressive disclosure via a slim index plus section files.
+
+## Relevant Files
+
+- `.agents/marketing-sales/cro-chapter-11.md` — replace dense chapter body with section index.
+- `.agents/marketing-sales/cro-chapter-11/` — new section files holding the moved reference content.
+- `.agents/tools/code-review/code-simplifier.md` — classification rule for reference corpora.
+- `.agents/tools/build-agent/build-agent.md` — progressive disclosure and subdivision guidance.


### PR DESCRIPTION
## Summary
- classify `.agents/marketing-sales/cro-chapter-11.md` as a reference corpus and convert it into a slim chapter index
- move each major Mobile CRO section into `cro-chapter-11/*.md` so the source material stays intact while the entry point becomes lighter
- add a task brief documenting the issue-driven restructuring work

## Runtime Testing
- Risk level: low
- Verification level: self-assessed
- `bunx markdownlint-cli2 "todo/tasks/GH-14011-brief.md" ".agents/marketing-sales/cro-chapter-11.md" ".agents/marketing-sales/cro-chapter-11/*.md"`
- `wc -l .agents/marketing-sales/cro-chapter-11.md .agents/marketing-sales/cro-chapter-11/*.md` → 154 total lines across index + section files versus 133 original lines
- `rg -n "mobile-cta|apple-itunes-app|PageSpeed Insights|Apple Pay / Google Pay|iOS Safari \+ Android Chrome" .agents/marketing-sales/cro-chapter-11 .agents/marketing-sales/cro-chapter-11.md` confirms representative implementation details survived the split

Closes #14011


---
[aidevops.sh](https://aidevops.sh) v3.5.471 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 6m and 203,455 tokens on this as a headless worker. Overall, 19h 24m since this issue was created.