### PR TITLE
GH#14025: tighten cron triggers gotchas doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2985,6 +2985,11 @@
       "hash": "f459c108bb4697a61a23da603c732273ea6b8fb6",
       "at": "2026-03-31T02:26:11Z",
       "pr": 14489
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md": {
+      "hash": "3352a9e2c76ad857c0d92cc485e7eb126bb3d0dd",
+      "at": "2026-03-31T03:17:07Z",
+      "pr": 14516
     }
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md
@@ -1,8 +1,9 @@
 # Cron Triggers Gotchas
 
-## Timezone Issues
+## Time and propagation
 
-**⚠️ UTC ONLY** - No timezone configuration
+- **UTC only** — cron triggers have no timezone setting.
+- **Propagation delay** — trigger changes can take up to 15 minutes. Verify in Dashboard → Workers → Select Worker → Settings → Triggers.
 
 ```typescript
 // ❌ Wrong: "0 9 * * *" // 9am UTC, not local
@@ -10,11 +11,7 @@
 // Calculate: utcHour = (localHour - utcOffset + 24) % 24
 ```
 
-## Propagation Delay
-
-**Changes take up to 15 minutes**. Verify: Dashboard → Workers → Select Worker → Settings → Triggers
-
-## Limits
+## Limits and long-running work
 
 | Plan | Triggers/Worker | CPU Time | Execution |
 |------|----------------|----------|-----------|
@@ -27,9 +24,9 @@
 // ✅ OR: await env.WORKFLOW.create({});
 ```
 
-## Duplicate Executions
+## Duplicate executions
 
-**At-least-once delivery** - duplicates possible. Make idempotent:
+At-least-once delivery means duplicates are possible; make scheduled handlers idempotent.
 
 ```typescript
 export default {
@@ -43,9 +40,9 @@ export default {
 };
 ```
 
-## Debugging Not Executing
+## Not executing
 
-**Check:** `scheduled()` exported, recent deploy, 15min wait, valid cron ([crontab.guru](https://crontab.guru/)), plan limits
+Check: `scheduled()` exported, recent deploy, 15-minute wait elapsed, valid cron ([crontab.guru](https://crontab.guru/)), and plan limits.
 
 ```typescript
 export default {
@@ -56,9 +53,9 @@ export default {
 };
 ```
 
-## Execution Failures
+## Execution failures
 
-**Common:** CPU exceeded, unhandled exceptions, network timeouts, binding misconfiguration
+Common causes: CPU exceeded, unhandled exceptions, network timeouts, and binding misconfiguration.
 
 ```typescript
 export default {
@@ -78,9 +75,11 @@ export default {
 };
 ```
 
-## Local Testing Issues
+## Local testing
 
-Ensure `wrangler dev` runs, `scheduled()` exists, update Wrangler: `npm i -g wrangler@latest`
+- Ensure `wrangler dev` runs.
+- Ensure `scheduled()` exists.
+- Update Wrangler if needed: `npm i -g wrangler@latest`.
 
 ```bash
 curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*" # URL encode spaces
@@ -88,7 +87,7 @@ curl "http://localhost:8787/__scheduled" # No params = default
 # Python: curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*/5+*+*+*+*"
 ```
 
-## Security
+## Dev-only trigger endpoint
 
 ```typescript
 export default {
@@ -105,7 +104,7 @@ export default {
 };
 ```
 
-## Secrets Management
+## Secrets management
 
 ```typescript
 // ❌ BAD: headers: { "Authorization": "Bearer sk_live_abc123..." }
@@ -118,7 +117,7 @@ npx wrangler secret put API_KEY
 
 ## Green Compute
 
-Dashboard: Workers & Pages → Account details → Compute Setting → Green Compute. Tradeoffs: fewer locations, higher latency, ideal for non-time-critical jobs
+Dashboard: Workers & Pages → Account details → Compute Setting → Green Compute. Tradeoffs: fewer locations, higher latency, ideal for non-time-critical jobs.
 
 ## Resources
 

--- a/todo/tasks/GH-14025-brief.md
+++ b/todo/tasks/GH-14025-brief.md
@@ -1,0 +1,33 @@
+# GH#14025: Tighten cron triggers gotchas doc
+
+## Session Origin
+
+Interactive user session — `/full-loop` invocation with GitHub issue reference, executed under headless continuation rules.
+
+## What
+
+Simplify `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md` into a tighter reference card while preserving every code example, URL, operational constraint, and troubleshooting cue.
+
+## Why
+
+The doc is already knowledge-dense, but its current layout spends lines on repeated one-line sections. Tightening the structure lowers token cost for Cloudflare-platform context loads without losing any troubleshooting guidance.
+
+## How
+
+1. Classify the file as a slim reference card inside the Cloudflare platform skill, not a long-form instruction workflow.
+2. Keep all existing examples, URLs, limits, and debugging checks.
+3. Consolidate adjacent sections where the reader needs the same decision context (timing, limits, debugging, local testing, secrets).
+4. Preserve the file in-place rather than splitting into chapter files because it is already within the intended slim-index size range.
+5. Update `.agents/configs/simplification-state.json` after the doc change.
+
+## Acceptance Criteria
+
+- [ ] All code blocks, URLs, and command examples from the original file remain present.
+- [ ] Troubleshooting guidance still covers timezone, propagation, limits, duplicate execution, debugging, failures, local testing, security, secrets, and green compute.
+- [ ] Markdown lint passes for the touched files.
+- [ ] Simplification state updated for `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md`.
+- [ ] PR created with `Closes #14025`.
+
+## Context
+
+Issue #14025 is an automated simplification-debt ticket for the Cloudflare platform skill. The safest change is structural tightening, not chapter extraction, because the file already behaves like a compact reference page.


### PR DESCRIPTION
## Summary
- tighten `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md` into a more compact reference card while preserving every existing code example and external link
- add a task brief documenting the classification decision to keep the file in place instead of splitting it into chapters
- update `.agents/configs/simplification-state.json` with the merged-reference hash for this file

## Runtime Testing
- Level: self-assessed
- Rationale: docs-only change to an agent skill reference card; no executable behavior changed
- Verification: `bunx markdownlint-cli2 \"todo/tasks/GH-14025-brief.md\" \".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md\"`

Closes #14025


---
[aidevops.sh](https://aidevops.sh) v3.5.472 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 6m and 79,359 tokens on this as a headless worker. Overall, 19h 4m since this issue was created.