### PR TITLE
GH#14048: tighten Remotion captions doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1141,6 +1141,11 @@
       "at": "2026-03-28T16:00:33Z",
       "pr": 11987
     },
+    ".agents/tools/video/remotion-display-captions.md": {
+      "hash": "eeb59904b83f9d4edbf179c97266e73c7b0e0598",
+      "at": "2026-03-31T03:20:58Z",
+      "pr": 14524
+    },
     ".agents/tools/video/remotion.md": {
       "hash": "e587ff6f81433c2bcc6b89ee139561849007d27e",
       "at": "2026-03-28T15:30:25Z",

--- a/.agents/tools/video/remotion-display-captions.md
+++ b/.agents/tools/video/remotion-display-captions.md
@@ -8,12 +8,9 @@ metadata:
 
 # Displaying captions in Remotion
 
-This guide explains how to display captions in Remotion, assuming you already have captions in the `Caption` format.
+Display `Caption[]` data with TikTok-style pages and per-word highlighting.
 
-## Prerequisites
-
-First, the @remotion/captions package needs to be installed.
-If it is not installed, use the following command:
+## Install `@remotion/captions`
 
 ```bash
 npx remotion add @remotion/captions # If project uses npm
@@ -22,9 +19,9 @@ yarn remotion add @remotion/captions # If project uses yarn
 pnpm exec remotion add @remotion/captions # If project uses pnpm
 ```
 
-## Creating pages
+## 1. Group captions into pages
 
-Use `createTikTokStyleCaptions()` to group captions into pages. The `combineTokensWithinMilliseconds` option controls how many words appear at once:
+Use `createTikTokStyleCaptions()` to batch words into timed pages. `combineTokensWithinMilliseconds` controls how many words appear at once.
 
 ```tsx
 import {useMemo} from 'react';
@@ -36,23 +33,25 @@ import type {Caption} from '@remotion/captions';
 // Lower values = fewer words (more word-by-word)
 const SWITCH_CAPTIONS_EVERY_MS = 1200;
 
-const {pages} = useMemo(() => {
-  return createTikTokStyleCaptions({
-    captions,
-    combineTokensWithinMilliseconds: SWITCH_CAPTIONS_EVERY_MS,
-  });
-}, [captions]);
+const CaptionedContent: React.FC<{captions: Caption[]}> = ({captions}) => {
+  const {pages} = useMemo(() => {
+    return createTikTokStyleCaptions({
+      captions,
+      combineTokensWithinMilliseconds: SWITCH_CAPTIONS_EVERY_MS,
+    });
+  }, [captions]);
+};
 ```
 
-## Rendering with Sequences
+## 2. Render each page in a `<Sequence>`
 
-Map over the pages and render each one in a `<Sequence>`. Calculate the start frame and duration from the page timing:
+Map over `pages` and derive each sequence from the page timing.
 
 ```tsx
 import {Sequence, useVideoConfig, AbsoluteFill} from 'remotion';
 import type {TikTokPage} from '@remotion/captions';
 
-const CaptionedContent: React.FC = () => {
+const CaptionedContent: React.FC<{pages: TikTokPage[]}> = ({pages}) => {
   const {fps} = useVideoConfig();
 
   return (
@@ -85,9 +84,9 @@ const CaptionedContent: React.FC = () => {
 };
 ```
 
-## Word highlighting
+## 3. Highlight the active word
 
-A caption page contains `tokens` which you can use to highlight the currently spoken word:
+Each page exposes `tokens`, so you can compare the current playback time against `fromMs` and `toMs`.
 
 ```tsx
 import {AbsoluteFill, useCurrentFrame, useVideoConfig} from 'remotion';
@@ -99,9 +98,7 @@ const CaptionPage: React.FC<{page: TikTokPage}> = ({page}) => {
   const frame = useCurrentFrame();
   const {fps} = useVideoConfig();
 
-  // Current time relative to the start of the sequence
   const currentTimeMs = (frame / fps) * 1000;
-  // Convert to absolute time by adding the page start
   const absoluteTimeMs = page.startMs + currentTimeMs;
 
   return (


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/video/remotion-display-captions.md` into a shorter reference card while preserving the installation and rendering examples
- make the page-creation, sequence-rendering, and active-word-highlighting flow easier to scan in order

## Testing
- `bunx markdownlint-cli2 ".agents/tools/video/remotion-display-captions.md"`

## Runtime Testing
- self-assessed: low-risk documentation-only change; runtime verification not required

Closes #14048


---
[aidevops.sh](https://aidevops.sh) v3.5.473 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4