### PR TITLE
GH#14047: tighten browser QA workflow doc

### DIFF
--- a/.agents/workflows/browser-qa.md
+++ b/.agents/workflows/browser-qa.md
@@ -18,9 +18,10 @@ tools:
 
 | Item | Value |
 |------|-------|
-| **Script** | `scripts/browser-qa-worker.sh` (shell) + `scripts/browser-qa/browser-qa.mjs` (Playwright) |
-| **Invoked by** | `milestone-validation-worker.sh --browser-qa` or standalone |
-| **Output** | Pass/fail report, screenshots, broken links, console errors, `{output-dir}/qa-report.json` |
+| **Scripts** | `scripts/browser-qa-worker.sh` (shell) + `scripts/browser-qa/browser-qa.mjs` (Playwright) |
+| **Entry points** | Standalone or `milestone-validation-worker.sh --browser-qa` |
+| **Purpose** | Visual smoke QA: screenshots, broken links, console/network errors, empty/error pages |
+| **Output** | Text/JSON report plus `{output-dir}/qa-report.json` and screenshots |
 | **Prerequisites** | Node.js v18+, Playwright (`npm install playwright && npx playwright install`) |
 
 **Key files:** `scripts/browser-qa-worker.sh`, `scripts/browser-qa/browser-qa.mjs`, `scripts/milestone-validation-worker.sh`, `workflows/milestone-validation.md`, `tools/browser/browser-automation.md`
@@ -29,25 +30,25 @@ tools:
 
 ## When to Use
 
-| Flag | Effect | When |
-|------|--------|------|
-| `--browser-tests` | Runs project's Playwright test suite | Project has `playwright.config.{ts,js}` |
-| `--browser-qa` | Generic visual QA (screenshots, links, errors) | Any UI project; POC-mode missions without test suite |
+| Flag | Runs | Use when |
+|------|------|----------|
+| `--browser-tests` | Project Playwright test suite | Repo already has `playwright.config.{ts,js}` |
+| `--browser-qa` | Generic browser smoke QA | Any UI project, especially POC/milestone validation without a dedicated suite |
 
-## Per-Page Checks
+## Checks
 
-| Check | Detects | Severity |
-|-------|---------|----------|
+| Check | Detects | Result |
+|-------|---------|--------|
 | HTTP status | 4xx/5xx responses | Fail |
-| Empty page | Body text < 10 chars | Fail |
-| Error states | "Application error", hydration failures | Fail |
+| Empty page | Body text under 10 chars | Fail |
+| Error states | `Application error`, hydration failures | Fail |
 | Console errors | JS exceptions, uncaught errors | Fail |
 | Network errors | Failed fetch/XHR | Fail |
-| Broken links | `<a>` hrefs returning 4xx/5xx or timing out | Fail |
-| Screenshot | Full-page capture for human review | Info |
-| ARIA snapshot | Structural accessibility tree | Info |
+| Broken links | `<a>` targets returning 4xx/5xx or timing out | Fail |
+| Screenshot | Full-page capture for review | Info |
+| ARIA snapshot | Accessibility tree snapshot | Info |
 
-**Aggregate report:** pages visited/passed/failed, broken links, console errors, screenshot paths. JSON at `{output-dir}/qa-report.json`.
+Aggregate output includes visited/passed/failed pages, broken links, console errors, and screenshot paths. JSON summary: `{output-dir}/qa-report.json`.
 
 ## Usage
 
@@ -66,7 +67,7 @@ browser-qa-worker.sh --url http://localhost:3000 \
   --milestone 2
 ```
 
-### From Milestone Validation
+### Via milestone validation
 
 ```bash
 milestone-validation-worker.sh mission.md 2 \
@@ -78,17 +79,17 @@ milestone-validation-worker.sh mission.md 1 \
   --browser-tests --browser-qa --browser-url http://localhost:3000
 ```
 
-### Exit Codes
+### Exit codes
 
 | Code | Meaning |
 |------|---------|
 | `0` | All checks passed |
-| `1` | Checks failed (issues found) |
-| `2` | Configuration error (missing args, Playwright not installed) |
+| `1` | QA found failures |
+| `2` | Configuration error (missing args, Playwright unavailable) |
 
-## Flow Definitions
+## Flows and output
 
-Flows define which pages to visit. Two formats:
+Flows define the pages to visit. Supported formats:
 
 ```json
 ["/", "/about", "/contact", "/login"]
@@ -100,28 +101,24 @@ Flows define which pages to visit. Two formats:
 ]
 ```
 
-With `--mission-file` and `--milestone`, the worker extracts URL-like patterns from the milestone's acceptance criteria.
+With `--mission-file` and `--milestone`, the worker extracts URL-like patterns from the milestone acceptance criteria.
 
-## Output
-
-- **Screenshots:** `{output-dir}/{hostname}_{path}.png`; on error: `{hostname}_{path}-error.png`
-- **JSON report:** `{output-dir}/qa-report.json` -- `baseUrl`, `timestamp`, `viewport`, per-page results (`status`, `title`, `screenshot`, `consoleErrors`, `networkErrors`, `linkResults`, `loadTimeMs`, `passed`, `failures`), top-level `passed`
-
-## Related Tools
-
-| Tool | Purpose | When |
-|------|---------|------|
-| **browser-qa-worker.sh** | Generic visual QA (this tool) | Milestone validation, smoke testing |
-| **playwright-contrast.mjs** | WCAG contrast analysis | Accessibility audits |
-| **accessibility-audit-helper.sh** | Full accessibility audit | WCAG compliance |
-| **pagespeed** | Performance testing | Core Web Vitals |
-| **Playwright test suite** | Project-specific E2E tests | CI/CD, regression testing |
+- Screenshots: `{output-dir}/{hostname}_{path}.png`; failures also get `{hostname}_{path}-error.png`
+- JSON: `{output-dir}/qa-report.json` with `baseUrl`, `timestamp`, `viewport`, top-level `passed`, and per-page results (`status`, `title`, `screenshot`, `consoleErrors`, `networkErrors`, `linkResults`, `loadTimeMs`, `passed`, `failures`)
 
 ## Related
 
-- `scripts/milestone-validation-worker.sh` -- Parent validation worker
-- `workflows/milestone-validation.md` -- Validation workflow
-- `workflows/mission-orchestrator.md` -- Mission orchestrator (invokes validation)
-- `tools/browser/browser-automation.md` -- Browser tool selection guide
-- `tools/browser/playwright.md` -- Playwright reference
-- `scripts/accessibility/playwright-contrast.mjs` -- Similar Playwright script pattern
+| Tool | Purpose | Use when |
+|------|---------|----------|
+| `browser-qa-worker.sh` | Generic browser smoke QA | Milestone validation, manual smoke checks |
+| `playwright-contrast.mjs` | WCAG contrast analysis | Accessibility audits |
+| `accessibility-audit-helper.sh` | Broader accessibility audit | WCAG compliance reviews |
+| `pagespeed` | Performance testing | Core Web Vitals work |
+| Project Playwright suite | Project-specific E2E coverage | CI/CD and regression testing |
+
+- `scripts/milestone-validation-worker.sh` - parent validation worker
+- `workflows/milestone-validation.md` - validation workflow
+- `workflows/mission-orchestrator.md` - mission orchestrator
+- `tools/browser/browser-automation.md` - browser tool selection guide
+- `tools/browser/playwright.md` - Playwright reference
+- `scripts/accessibility/playwright-contrast.mjs` - related Playwright script pattern


### PR DESCRIPTION
## Summary
- streamline `.agents/workflows/browser-qa.md` so the entry points, use cases, checks, and outputs are faster to scan
- keep all existing command examples and file references while removing redundant wording and merging overlapping sections

## Testing
- `bunx markdownlint-cli2 ".agents/workflows/browser-qa.md"`

## Runtime Testing
- Level: self-assessed
- Reason: docs-only change in an agent workflow file
- Evidence: markdown lint passed; no runtime behavior changed

Closes #14047
---
[aidevops.sh](https://aidevops.sh) v3.5.474 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 46,164 tokens on this as a headless worker.