### PR TITLE
GH#14446: tighten Stagehand benchmark scripts agent doc

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts-05-stagehand.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-05-stagehand.md
@@ -1,6 +1,6 @@
 # Stagehand Benchmark Scripts
 
-Uses AI-driven `act()` / `extract()` instead of CSS selectors. Same harness as Playwright but creates a new `Stagehand({ env: "LOCAL", headless: true, verbose: 0 })` per run (measures cold-start). Tests receive `sh` instead of `page`; access page via `sh.ctx.pages()[0]`.
+AI-driven `act()`/`extract()` instead of CSS selectors. New `Stagehand` instance per run (measures cold-start). Tests receive `sh`; access page via `sh.ctx.pages()[0]`.
 
 ```javascript
 import { Stagehand } from "@browserbasehq/stagehand";
@@ -8,8 +8,9 @@ import { z } from "zod";
 
 const TESTS = {
   async navigate(sh) {
-    await sh.ctx.pages()[0].goto('https://the-internet.herokuapp.com/');
-    await sh.ctx.pages()[0].screenshot({ path: '/tmp/bench-sh-nav.png' });
+    const page = sh.ctx.pages()[0];
+    await page.goto('https://the-internet.herokuapp.com/');
+    await page.screenshot({ path: '/tmp/bench-sh-nav.png' });
   },
   async formFill(sh) {
     await sh.ctx.pages()[0].goto('https://the-internet.herokuapp.com/login');
@@ -30,8 +31,7 @@ const TESTS = {
   }
 };
 
-// Harness: same as Playwright — iterate TESTS, 3 runs, JSON output.
-// Per run: sh = new Stagehand(...); sh.init(); <time fn(sh)>; sh.close().
+// Harness: new Stagehand → init → time fn(sh) → close; 3 runs per test, JSON output.
 async function run() {
   const results = {};
   for (const [name, fn] of Object.entries(TESTS)) {


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/browser/browser-benchmark-scripts-05-stagehand.md` intro and inline comments
- Remove redundant "Same harness as Playwright" (parent index `browser-benchmark-scripts.md` already establishes this context)
- Extract local `page` variable in `navigate` test to reduce `sh.ctx.pages()[0]` repetition
- Merge two harness comments into one concise line

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only — no code, no runtime behaviour change)
- **Verification:** `self-assessed` — markdownlint clean, all code blocks/URLs/test functions preserved

## Content Preservation

All institutional knowledge retained: `@browserbasehq/stagehand` import, `zod` schema, 4 test functions (navigate, formFill, extract, multiStep), cold-start harness pattern, all URLs.

Closes #14446

---
[aidevops.sh](https://aidevops.sh) v3.5.475 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6