### PR TITLE
GH#14447: tighten workerd runtime agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workerd.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd.md
@@ -1,29 +1,8 @@
 # Workerd Runtime
 
-V8-based JS/Wasm runtime powering Cloudflare Workers. Use as app server, dev tool, or HTTP proxy.
+V8-based JS/Wasm runtime powering Cloudflare Workers. Standards-based (Fetch API, Web Crypto, Streams, WebSocket), capability-secured bindings (prevent SSRF), nanoservice architecture with local-call-perf service bindings. Version = max compat date supported.
 
-## When to Use
-
-- Local Workers development (via Wrangler)
-- Self-hosted Workers runtime
-- Custom embedded runtime
-- Debugging runtime-specific issues
-
-## Key Features
-
-- **Standards-based**: Fetch API, Web Crypto, Streams, WebSocket
-- **Nanoservices**: Service bindings with local call performance
-- **Capability security**: Explicit bindings prevent SSRF
-- **Backwards compatible**: Version = max compat date supported
-
-## Architecture
-
-```
-Config (workerd.capnp)
-├── Services (workers/endpoints)
-├── Sockets (HTTP/HTTPS listeners)
-└── Extensions (global capabilities)
-```
+**Use cases:** local Workers dev (via Wrangler), self-hosted Workers runtime, custom embedded runtime, debugging runtime-specific issues.
 
 ## Quick Start
 
@@ -35,15 +14,18 @@ workerd test config.capnp
 
 ## Core Concepts
 
-- **Service**: Named endpoint (worker/network/disk/external)
-- **Binding**: Capability-based resource access (KV/DO/R2/services)
-- **Compatibility date**: Feature gate (always set!)
-- **Modules**: ES modules (recommended) or service worker syntax
+| Concept | Detail |
+|---------|--------|
+| **Service** | Named endpoint (worker/network/disk/external) |
+| **Binding** | Capability-based resource access (KV/DO/R2/services) |
+| **Compatibility date** | Feature gate — always set |
+| **Modules** | ES modules (recommended) or service worker syntax |
+| **Config** | `workerd.capnp` — services, sockets (HTTP/HTTPS listeners), extensions |
 
 ## See Also
 
-- [patterns.md](./patterns.md) - Multi-service, DO, proxies
-- [gotchas.md](./gotchas.md) - Common errors, debugging
+- [workerd-patterns.md](./workerd-patterns.md) — multi-service, DO, proxies, dev/prod configs, deployment
+- [workerd-gotchas.md](./workerd-gotchas.md) — config errors, network access, debugging, performance, security
 
 ## References
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/hosting/cloudflare-platform-skill/workerd.md` from 52 → 34 lines (35% reduction)
- Merged "When to Use" and "Key Features" sections into a dense intro paragraph
- Converted "Core Concepts" from bullet list to compact table, added Config row from removed Architecture section
- Fixed "See Also" links from generic `patterns.md`/`gotchas.md` to actual filenames `workerd-patterns.md`/`workerd-gotchas.md`

## What changed

- **Removed**: "When to Use" section header (content merged into intro "Use cases:" line)
- **Removed**: "Key Features" section (4 bullets merged into intro paragraph)
- **Removed**: "Architecture" ASCII tree (config structure now a row in Core Concepts table)
- **Preserved**: All 3 external URLs, all 3 Quick Start commands, all 4 core concepts, all 4 use cases, all 4 key features

## Content preservation

All code blocks, URLs, and domain knowledge preserved. Zero content loss — only prose compression and structural consolidation.

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, content audit confirms all knowledge preserved

Closes #14447


---
[aidevops.sh](https://aidevops.sh) v3.5.475 plugin for [OpenCode](https://opencode.ai) v1.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Streamlined and reorganized workerd documentation for improved clarity and usability.
  * Consolidated introductory sections and expanded descriptions with additional runtime characteristics.
  * Updated cross-references with more specific documentation links covering deployment patterns and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->