### PR TITLE
GH#14536: tighten ip-check command card

### DIFF
--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -4,28 +4,24 @@ agent: Build+
 mode: subagent
 ---
 
-Arguments: `$ARGUMENTS`
+Arguments: $ARGUMENTS
 
 Helper: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`
 
 ## Route inputs
 
-| Input | Invoke |
-|---|---|
-| `1.2.3.4` | `check "$IP"` |
-| `1.2.3.4 -f json` | `check "$IP" -f json` |
-| `1.2.3.4 report` | `report "$IP"` |
-| `1.2.3.4 --provider abuseipdb` | `check "$IP" --provider "$PROVIDER"` |
-| `1.2.3.4 --no-cache` | `check "$IP" --no-cache` |
-| `ips.txt` | `batch "$FILE"` |
-| `ips.txt --dnsbl-overlap` | `batch "$FILE" --dnsbl-overlap` |
-| _(no args)_ | Show usage |
+- `1.2.3.4` → `check "$IP"`
+- `1.2.3.4 -f json` → `check "$IP" -f json`
+- `1.2.3.4 report` → `report "$IP"`
+- `1.2.3.4 --provider abuseipdb` → `check "$IP" --provider "$PROVIDER"`
+- `1.2.3.4 --no-cache` → `check "$IP" --no-cache`
+- `ips.txt` → `batch "$FILE"`
+- `ips.txt --dnsbl-overlap` → `batch "$FILE" --dnsbl-overlap`
+- no args → show usage
 
 Ops: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
 
 ## Output
-
-Return risk score, provider results, and proxy flags:
 
 ```text
 IP Reputation: 1.2.3.4


### PR DESCRIPTION
## Summary
- replace the route-input table with a shorter bullet list while preserving every supported invocation
- remove redundant output narration and keep the helper path, provider list, and follow-up guidance intact

## Testing
- \markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/scripts/commands/ip-check.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s) (pass)

## Runtime Testing
- self-assessed: low-risk docs-only change to a slash-command reference card

Closes #14536


---
[aidevops.sh](https://aidevops.sh) v3.5.469 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 10m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced `ip-check` command documentation with improved formatting for arguments and example inputs.
  * Restructured helper invocation examples for better clarity and readability.
  * Streamlined output section description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->