### PR TITLE
GH#14089: tighten headline testing checklist

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-checklists-headline-testing.md
+++ b/.agents/marketing-sales/direct-response-copy-checklists-headline-testing.md
@@ -1,119 +1,90 @@
 # Headline Testing Checklist
 
----
-
 ## Before Writing
 
-- [ ] Target audience defined (specific)
+- [ ] Specific target audience defined
 - [ ] Audience awareness level known
 - [ ] Primary pain point identified
 - [ ] Desired outcome identified
 - [ ] Unique offer value identified
 - [ ] Swipe file reviewed for inspiration
 
----
+## Drafting Pass
 
-## Writing Headlines
-
-- [ ] At least 25 variations written
-- [ ] Formulas tried:
+- [ ] Write at least 25 variations
+- [ ] Try these formulas:
   - [ ] How to [Outcome]
   - [ ] [Number] Ways to [Benefit]
   - [ ] The [Adjective] Guide to [Topic]
-  - [ ] Why [Common Belief] is Wrong
+  - [ ] Why [Common Belief] Is Wrong
   - [ ] [Outcome] Without [Objection]
   - [ ] Warning: [Negative Outcome]
   - [ ] Are You Making These [Topic] Mistakes?
   - [ ] Who Else Wants [Desired Outcome]?
   - [ ] The Secret of [Desirable Group]
   - [ ] [Question about their problem]
-- [ ] Angles tried: benefit-focused, problem-focused, curiosity-driven, social proof, urgency/scarcity, contrarian
+- [ ] Try these angles: benefit-focused, problem-focused, curiosity-driven, social proof, urgency/scarcity, contrarian
 
----
+## 4 U's Scorecard
 
-## The 4 U's Test
-
-Score each headline 1–4 per dimension. Aim for 12+.
+Score each headline 1-4 per dimension. Aim for 12+.
 
 | Criteria | Score (1-4) |
 |----------|-------------|
 | **Useful:** Clear benefit promised? | ___ |
-| **Ultra-specific:** Numbers/details used? | ___ |
+| **Ultra-specific:** Numbers or details used? | ___ |
 | **Urgent:** Reason to act now? | ___ |
 | **Unique:** Different from competitors? | ___ |
-| **TOTAL** | ___ / 16 |
+| **Total** | ___ / 16 |
 
----
+## Evaluate the Shortlist
 
-## Evaluation Criteria
-
-**Clarity:** Understandable in 5 seconds? Unfamiliar reader knows what it's about?
-
-**Benefit:** Clear "what's in it for me"? Speaks to desire or pain?
-
-**Specificity:** Specific numbers, results, or timeframes? Avoids vague words (better, easier, more)?
-
-**Believability:** Sounds plausible, not hype-y? Skeptic would believe it?
-
-**Curiosity:** Makes reader want more? Unanswered question present?
-
-**Audience Fit:** Speaks to specific audience? Target customer sees themselves in it?
-
----
+- **Clarity:** Understood in 5 seconds by an unfamiliar reader
+- **Benefit:** Clear "what's in it for me"
+- **Specificity:** Concrete numbers, results, or timeframes; avoid vague words like "better," "easier," and "more"
+- **Believability:** Plausible to a skeptic; not hypey
+- **Curiosity:** Creates interest without hiding the offer
+- **Audience fit:** Target customer sees themselves in it
 
 ## Red Flags
 
-- [ ] **Too vague:** "Improve your business" (improve how? which business?)
-- [ ] **Too clever:** Puns or wordplay that sacrifices clarity
-- [ ] **Too long:** Over 15 words (hard to scan)
-- [ ] **Too hypey:** "Revolutionary" "Game-changing" "Breakthrough"
-- [ ] **Features-only:** "128-bit encryption" (so what?)
-- [ ] **Me-focused:** "We're excited to announce..." (nobody cares)
-- [ ] **Clickbait:** Promises more than content delivers
+- [ ] Too vague: "Improve your business"
+- [ ] Too clever: wordplay hurts clarity
+- [ ] Too long: over 15 words
+- [ ] Too hypey: "Revolutionary," "Game-changing," "Breakthrough"
+- [ ] Features-only: "128-bit encryption" with no payoff
+- [ ] Me-focused: "We're excited to announce..."
+- [ ] Clickbait: promise exceeds delivery
 
----
+## Quick Tests Before Publishing
 
-## Quick Tests (Before Publishing)
+- **5-second test:** Show it for 5 seconds and ask, "What is this offering and who is it for?" If they cannot answer, revise.
+- **Would I click?** Imagine it beside 10 competing posts. If you would not stop scrolling, revise.
+- **So what?** Read it aloud and ask, "Why should I care?" If the answer is unclear, revise.
 
-**5-Second Test:** Show to someone unfamiliar for 5 seconds. Ask: "What is this offering and who is it for?" If they can't answer, revise.
+## A/B Testing After Publishing
 
-**"Would I Click?" Test:** Imagine seeing this in your feed among 10 other posts. Would you stop scrolling? If no, revise.
-
-**"So What?" Test:** Read aloud. Ask: "So what? Why should I care?" No clear answer → revise.
-
----
-
-## A/B Tests (After Publishing)
-
-**What to test:** Different benefits · question vs. statement · number vs. no number · short vs. long
-
-**Sample size:** 100 impressions minimum per variation; 500+ for statistical significance; run ≥48 hours
-
-**Metrics:** Click-through rate (primary) · time on page (secondary) · conversion rate (ultimate)
-
----
+- **Test:** different benefits, question vs. statement, number vs. no number, short vs. long
+- **Sample size:** 100 impressions minimum per variation; 500+ for statistical significance; run for at least 48 hours
+- **Metrics:** click-through rate (primary), time on page (secondary), conversion rate (ultimate)
 
 ## Improvement Tactics
 
 1. **Add specificity:** "Grow your email list" → "Grow your email list to 10,000 in 90 days"
 2. **Add urgency:** "Learn copywriting" → "Learn copywriting before your competitors do"
 3. **Address objection:** "Get fit" → "Get fit without giving up your favorite foods"
-4. **Make personal:** "How to improve sales" → "How to improve YOUR sales this quarter"
+4. **Make it personal:** "How to improve sales" → "How to improve YOUR sales this quarter"
 5. **Add proof:** "Increase conversions" → "Increase conversions 47% (like 500+ others)"
-6. **Curiosity gap:** "SEO tips" → "The SEO trick I learned that doubled my traffic"
-
----
+6. **Open a curiosity gap:** "SEO tips" → "The SEO trick I learned that doubled my traffic"
 
 ## Final Selection
 
-- [ ] Passes 4 U's test (12+ score)
-- [ ] Works for audience's awareness level
-- [ ] Significantly better than alternatives
-- [ ] Matches the content/offer that follows
-- [ ] Would stop scrolling to read this
-- [ ] Fresh eyes approved it
-
----
+- [ ] Passes the 4 U's test (12+)
+- [ ] Matches the audience's awareness level
+- [ ] Clearly beats the alternatives
+- [ ] Matches the content or offer that follows
+- [ ] Strong enough to stop scrolling
+- [ ] Approved by fresh eyes
 
 ## Headline Bank
 


### PR DESCRIPTION
## Summary
- tighten the headline testing checklist so the workflow is easier to scan without losing any formulas, review criteria, or testing guidance
- collapse decorative separators and redundant prose into shorter headings and bullets that match nearby checklist docs

## Testing
- bunx markdownlint-cli2 ".agents/marketing-sales/direct-response-copy-checklists-headline-testing.md"

## Runtime Testing
- Level: self-assessed
- Rationale: markdown-only documentation change with no runtime behavior

Closes #14089

---
[aidevops.sh](https://aidevops.sh) v3.5.477 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4