### PR TITLE
GH#14088: tighten imessage agent doc

### DIFF
--- a/.agents/services/communications/imessage.md
+++ b/.agents/services/communications/imessage.md
@@ -18,11 +18,11 @@ tools:
 
 ## Quick Reference
 
-- **Platform**: macOS only (Messages.app required as relay)
-- **BlueBubbles**: REST API + webhooks — DMs/groups/reactions/attachments/typing/read receipts. [Repo](https://github.com/BlueBubblesApp/bluebubbles-server) (Apache-2.0)
-- **imsg**: Send-only CLI. [Repo](https://github.com/steipete/imsg) (MIT)
-- **Encryption**: iMessage E2E (Apple-managed); BlueBubbles reads locally on Mac
-- **vs SimpleX/Matrix/Signal**: Use iMessage to reach Apple users natively; SimpleX for max privacy; Matrix for team collab; Signal for secure 1:1
+- **Platform**: macOS only; Messages.app is the relay
+- **BlueBubbles**: Recommended for bots — REST API + webhooks for DMs, groups, reactions, attachments, typing, and read receipts. [Repo](https://github.com/BlueBubblesApp/bluebubbles-server) (Apache-2.0)
+- **imsg**: Send-only CLI for alerts/one-way notifications. [Repo](https://github.com/steipete/imsg) (MIT)
+- **Security model**: iMessage stays Apple-managed E2E; BlueBubbles reads decrypted messages locally on the Mac
+- **Trade-off**: Use iMessage to reach Apple users natively; SimpleX for max privacy; Matrix for team chat; Signal for secure 1:1
 
 <!-- AI-CONTEXT-END -->
 
@@ -30,15 +30,13 @@ tools:
 
 `iPhone/iPad/Mac → iMessage (E2E) → Apple Servers → Messages.app + BlueBubbles Server → REST API/Webhooks → Bot → aidevops dispatch`
 
-Messages.app decrypts to local SQLite (`~/Library/Messages/chat.db`) → BlueBubbles detects via filesystem events → fires webhook → bot responds via REST API. imsg: send-only via AppleScript.
+Messages.app decrypts into local SQLite (`~/Library/Messages/chat.db`), BlueBubbles watches filesystem events, then emits webhook events the bot answers via REST API. `imsg` is send-only via AppleScript.
 
 ## BlueBubbles (Recommended)
 
-**Requirements**: macOS 11+, Messages.app signed in, Full Disk Access + Accessibility, persistent GUI session.
-
-**Install**: Download DMG from [GitHub Releases](https://github.com/BlueBubblesApp/bluebubbles-server/releases) (Homebrew cask deprecated 2026-09-01). Drag to /Applications, right-click Open (Gatekeeper), grant Full Disk Access + Accessibility, set password, configure Cloudflare tunnel.
-
-**Server config**: Port `1234` · Password (header only — query params are logged) · Proxy: Cloudflare · Poll: `1000ms` · **Headless**: `caffeinate -d` to prevent sleep; complete iCloud 2FA interactively first.
+- **Requirements**: macOS 11+, Messages.app signed in, Full Disk Access, Accessibility, persistent GUI session
+- **Install**: Download DMG from [GitHub Releases](https://github.com/BlueBubblesApp/bluebubbles-server/releases) (Homebrew cask deprecated 2026-09-01), drag to `/Applications`, right-click Open, grant permissions, set password, configure Cloudflare tunnel
+- **Server config**: Port `1234`; send password in headers only (query params are logged); proxy through Cloudflare; poll `1000ms`; for headless hosts use `caffeinate -d`; complete iCloud 2FA interactively first
 
 ### REST API
 
@@ -54,19 +52,19 @@ curl -X POST "$BB/server/webhook" -H "Content-Type: application/json" \
   -d '{"url":"http://localhost:8080/webhook","password":"YOUR_PASSWORD"}'
 ```
 
-**Other endpoints**: `GET /api/v1/chat/:guid/message` · `GET /api/v1/contact` · `GET /api/v1/server/info`
+**Endpoints**
 
-**Chat GUID**: `iMessage;-;+14155551234` (phone) · `iMessage;-;user@example.com` (email) · `iMessage;+;chat123456789` (group) · `SMS;-;+14155551234` (SMS)
-
-**Reactions**: `love` `like` `dislike` `laugh` `emphasize` `question`
-
-**Webhook events**: `new-message` · `updated-message` · `typing-indicator` · `read-receipt` · `group-name-change` · `participant-added/removed/left` · `chat-read-status-changed`. Key `new-message` fields: `data.guid` · `data.text` · `data.chatGuid` · `data.handle.address` · `data.isFromMe` · `data.hasAttachments`
-
-**Supported**: text · attachments · tapbacks (6 types) · reply threading · edit/unsend detection · typing indicators (inbound) · read receipts · SMS fallback · group management (add/remove via AppleScript). **Not supported**: @mentions · stickers
+- **Useful reads**: `GET /api/v1/chat/:guid/message` · `GET /api/v1/contact` · `GET /api/v1/server/info`
+- **Chat GUIDs**: `iMessage;-;+14155551234` (phone) · `iMessage;-;user@example.com` (email) · `iMessage;+;chat123456789` (group) · `SMS;-;+14155551234` (SMS)
+- **Reactions**: `love` `like` `dislike` `laugh` `emphasize` `question`
+- **Webhook events**: `new-message` · `updated-message` · `typing-indicator` · `read-receipt` · `group-name-change` · `participant-added/removed/left` · `chat-read-status-changed`
+- **Key `new-message` fields**: `data.guid` · `data.text` · `data.chatGuid` · `data.handle.address` · `data.isFromMe` · `data.hasAttachments`
+- **Supported**: text, attachments, tapbacks (6 types), reply threading, edit/unsend detection, inbound typing indicators, read receipts, SMS fallback, group add/remove via AppleScript
+- **Not supported**: `@mentions`, stickers
 
 ## imsg CLI (Send-Only)
 
-macOS 12+, Messages.app signed in, Accessibility permission. Notifications/alerts only; use BlueBubbles for interactive bots.
+macOS 12+, Messages.app signed in, Accessibility permission. Good for alerts; use BlueBubbles for interactive bots.
 
 ```bash
 brew install steipete/tap/imsg
@@ -78,11 +76,9 @@ imsg check "+14155551234"
 
 ## macOS Host
 
-**Options**: Mac mini (~$600+, recommended) · macOS VM on Apple Silicon (UTM/Parallels) · Cloud Mac (MacStadium/AWS EC2, $50–200/month)
-
-**Prevent sleep**: `caffeinate -d &` or `sudo pmset -a sleep 0`
-
-**Keepalive** (`sh.aidevops.imessage-keepalive`): restart Messages.app and BlueBubbles if not running.
+- **Options**: Mac mini (~$600+, recommended) · macOS VM on Apple Silicon (UTM/Parallels) · Cloud Mac (MacStadium/AWS EC2, $50–200/month)
+- **Prevent sleep**: `caffeinate -d &` or `sudo pmset -a sleep 0`
+- **Keepalive** (`sh.aidevops.imessage-keepalive`): restart Messages.app and BlueBubbles if missing
 
 ```bash
 check_and_restart() {
@@ -97,21 +93,20 @@ check_and_restart "Messages"; check_and_restart "BlueBubbles"
 
 - **API**: Bind to `127.0.0.1`; Cloudflare tunnel for remote; block port 1234 externally
 - **Secret**: `aidevops secret set BLUEBUBBLES_PASSWORD`
-- **Bot-level** (in bot process, not BlueBubbles): allowlist by phone/email · allowlist by group · command-level permissions · rate limiting · `prompt-guard-helper.sh` before passing to AI
+- **Bot-level** (in bot process, not BlueBubbles): allowlist by phone/email, allowlist by group, command-level permissions, rate limiting, and `prompt-guard-helper.sh` before handing content to AI
 
 ## Privacy and Security
 
-**iMessage encryption**: E2E — Classic: RSA-OAEP; iOS 13+: ECIES P-256; iOS 17.4+ (PQ3): AES-256-CTR + ML-KEM-1024. ECDSA P-256 signing; CKV key verification (iOS 17.2+, optional). Apple sees metadata (who, when, IP, contact graph) but not content (with ADP enabled).
-
-**BlueBubbles risk**: Mac compromise = full message access. Server compromise = attacker reads/sends as bot's Apple ID.
-
-**Recommendations**: Enable ADP · Dedicated Apple ID · Bind to localhost + Cloudflare · Rotate password · Monitor host (FileVault, firewall) · Don't store sensitive data in iMessage.
+- **iMessage encryption**: E2E. Classic uses RSA-OAEP; iOS 13+ uses ECIES P-256; iOS 17.4+ PQ3 uses AES-256-CTR + ML-KEM-1024. ECDSA P-256 signing; optional CKV key verification on iOS 17.2+. Apple still sees metadata (who, when, IP, contact graph), not message content when ADP is enabled.
+- **BlueBubbles risk**: If the Mac is compromised, all messages are exposed; if the server is compromised, an attacker can read/send as the bot Apple ID.
+- **Recommendations**: Enable ADP, use a dedicated Apple ID, bind to localhost + Cloudflare, rotate password, monitor host hardening (FileVault, firewall), avoid storing sensitive data in iMessage
 
 ## aidevops Integration
 
 `iMessage User → Bot (webhook handler) → aidevops Runner → AI session → response`
 
-**Bot pattern**: Listener on port 8080 → on `new-message`: verify allowlist, extract `text`+`chatGuid` → `runner-helper.sh` → reply via REST API. **Matterbridge**: not natively supported; bridge via BlueBubbles API → custom adapter, or via Matrix (`matterbridge.md`).
+- **Bot pattern**: Listener on port 8080 → on `new-message`: verify allowlist, extract `text` + `chatGuid`, call `runner-helper.sh`, reply via REST API
+- **Matterbridge**: Not native; bridge through the BlueBubbles API with a custom adapter, or route through Matrix (`matterbridge.md`)
 
 ## Limitations
 
@@ -135,7 +130,6 @@ check_and_restart "Messages"; check_and_restart "BlueBubbles"
 | SMS instead of iMessage | `imsg check <number>` |
 | Apple ID locked | Wait 24h or contact Apple |
 | macOS update broke BlueBubbles | Check GitHub releases for compatible version |
-
 
 ## Related
 


### PR DESCRIPTION
## Summary
- tighten  by compressing setup, API, security, and integration guidance without dropping operational detail
- restructure dense prose into concise bullets so the agent card remains easier to scan and cheaper to load

## Runtime Testing
- self-assessed: docs-only change
- verified with markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/services/communications/imessage.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Files Changed
- 

Closes #14088


---
[aidevops.sh](https://aidevops.sh) v3.5.477 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 144,368 tokens on this as a headless worker. Overall, 17h 24m since this issue was created.