### PR TITLE
GH#14549: tighten ip-check command card

### DIFF
--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -4,19 +4,17 @@ agent: Build+
 mode: subagent
 ---
 
-Arguments: $ARGUMENTS
+Arguments: $ARGUMENTS. Helper: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`
 
-Helper: `~/.aidevops/agents/scripts/ip-reputation-helper.sh`
-
-## Route inputs
+## Commands
 
 - `1.2.3.4` → `check "$IP"`
 - `1.2.3.4 -f json` → `check "$IP" -f json`
 - `1.2.3.4 report` → `report "$IP"`
 - `1.2.3.4 --provider abuseipdb` → `check "$IP" --provider "$PROVIDER"`
-- `1.2.3.4 --no-cache` → `check "$IP" --no-cache`
 - `ips.txt` → `batch "$FILE"`
 - `ips.txt --dnsbl-overlap` → `batch "$FILE" --dnsbl-overlap`
+- `1.2.3.4 --no-cache` → `check "$IP" --no-cache`
 - no args → show usage
 
 Ops: `providers`, `cache-stats`, `cache-clear [--provider P] [--ip IP]`, `rate-limit-status`, `help`.
@@ -37,9 +35,7 @@ Providers (8/10 responded):
 Flags: Tor=NO  Proxy=NO  VPN=NO
 ```
 
-Providers: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics.
-
-Then offer: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
+Providers: Spamhaus DNSBL, ProxyCheck.io, StopForumSpam, Blocklist.de, GreyNoise, AbuseIPDB, IPQualityScore, Scamalytics. After results, offer: full report, single-provider recheck, batch check, raw JSON, or cache-clear recheck.
 
 ## Related
 

--- a/todo/tasks/GH-14549-brief.md
+++ b/todo/tasks/GH-14549-brief.md
@@ -1,0 +1,32 @@
+# GH#14549: Tighten `.agents/scripts/commands/ip-check.md`
+
+## Session Origin
+
+Interactive `/full-loop` run for GitHub issue #14549 under the headless continuation contract.
+
+## What
+
+Restructure `.agents/scripts/commands/ip-check.md` into a shorter command card that keeps every supported invocation, provider name, output example, and follow-up prompt intact.
+
+## Why
+
+The doc is already small, but it still spends lines on repeated routing phrasing for a single helper script. A tighter layout reduces prompt cost without changing command behavior or operator guidance.
+
+## How
+
+1. Classify the file as an instruction doc, not a reference corpus.
+2. Keep a single file, but order it as helper, primary commands, output, follow-up, related references.
+3. Preserve all command variants, ops subcommands, provider names, and output example.
+4. Run markdown lint on the edited doc.
+
+## Acceptance Criteria
+
+- [ ] All existing command variants, provider names, and the output example remain present.
+- [ ] The primary `check` workflow appears before niche variants and ops subcommands.
+- [ ] The file is shorter than the original 49-line worktree version and stays single-file.
+- [ ] Markdown lint passes for `.agents/scripts/commands/ip-check.md`.
+- [ ] PR created with `Closes #14549`.
+
+## Context
+
+Issue #14549 is an automated simplification-debt task. The file is a short operational command doc, so the correct action is prose tightening and reordering rather than chapter splitting.


### PR DESCRIPTION
## Summary
- tighten ".agents/scripts/commands/ip-check.md" into a shorter command card while preserving every supported invocation, ops subcommand, provider name, and follow-up prompt
- add "todo/tasks/GH-14549-brief.md" so the issue has a task brief aligned with the "/full-loop" workflow
- reduce the command doc from 49 to 45 lines by merging repeated helper/follow-up prose and renaming the routing section to "Commands"

## Testing
- "bunx markdownlint-cli2 .agents/scripts/commands/ip-check.md todo/tasks/GH-14549-brief.md"

## Runtime Testing
- Level: self-assessed (low-risk docs-only change)
- Evidence: markdown lint passed; no runtime behavior changed

Closes #14549


---
[aidevops.sh](https://aidevops.sh) v3.5.477 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 73,257 tokens on this as a headless worker. Overall, 17m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ip-check command documentation with reorganized structure, consolidated helper references, and restructured command examples for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->