### PR TITLE
GH#14121: tighten CRO chapter 18 structure

### DIFF
--- a/.agents/marketing-sales/cro-chapter-18.md
+++ b/.agents/marketing-sales/cro-chapter-18.md
@@ -1,17 +1,17 @@
 # Chapter 18: CRO Case Studies and Implementation Playbook
 
-Real-world CRO implementations across e-commerce, SaaS, and B2B services, plus a phased implementation playbook. Builds on foundations from [Chapter 1](./CHAPTER-01.md)–[Chapter 12](./CHAPTER-12.md).
+Real-world CRO implementations across e-commerce, SaaS, and B2B services, plus a phased implementation playbook. Builds on foundations from [Chapter 1](./cro-chapter-01.md)–[Chapter 12](./cro-chapter-12.md).
 
 ## 18.1 E-commerce: Fashion Retailer ($50M Revenue)
 
-**Challenge:** 1.2% conversion, 72% cart abandonment, 0.8% mobile conversion | **Baseline:** 500K monthly visitors, 6K orders, $85 AOV
-
-**Changes:**
-
-- **Product pages:** Size guide with visual fitting, 360-degree views, customer photos in reviews, upfront shipping calculator
-- **Checkout:** Fields reduced 12→6, guest checkout, progress indicator, trust badges
-- **Mobile:** Redesigned nav, sticky "Add to Cart", simplified checkout, Apple/Google Pay
-- **Cart recovery:** Email sequence at 1h/24h/72h, 10% discount in final email, cart images, urgency messaging
+| Category | Details |
+|----------|---------|
+| Challenge | 1.2% conversion, 72% cart abandonment, 0.8% mobile conversion |
+| Baseline | 500K monthly visitors, 6K orders, $85 AOV |
+| Product pages | Size guide with visual fitting, 360-degree views, customer photos in reviews, upfront shipping calculator |
+| Checkout | Fields reduced 12→6, guest checkout, progress indicator, trust badges |
+| Mobile | Redesigned nav, sticky "Add to Cart", simplified checkout, Apple/Google Pay |
+| Cart recovery | Email sequence at 1h/24h/72h, 10% discount in final email, cart images, urgency messaging |
 
 | Metric | Before | After | Change |
 |--------|--------|-------|--------|
@@ -25,16 +25,15 @@ Real-world CRO implementations across e-commerce, SaaS, and B2B services, plus a
 
 ## 18.2 SaaS: B2B Project Management (Freemium)
 
-**Challenge:** 8% trial-to-paid, 15% monthly churn, average LTV $1,200 | **Baseline:** 10K monthly signups, 800 conversions
-
-**Root cause:** 55% said "didn't see value", 40% of support tickets were basic setup — users not reaching "aha moment"
-
-**Changes:**
-
-- **Onboarding:** Progressive onboarding, interactive tour, use-case templates, in-app checklists
-- **Value demonstration:** "Quick Wins" dashboard, time-saved metrics, usage-based tips, early collaboration features
-- **Pricing:** Simplified tiers 4→3, ROI calculator, highlighted popular plan, enterprise CTA
-- **Trial nurture:** Day 3 value email → Day 7 case study → Day 10 limited discount → Day 14 CSM outreach
+| Category | Details |
+|----------|---------|
+| Challenge | 8% trial-to-paid, 15% monthly churn, average LTV $1,200 |
+| Baseline | 10K monthly signups, 800 conversions |
+| Root cause | 55% said "didn't see value", 40% of support tickets were basic setup — users not reaching "aha moment" |
+| Onboarding | Progressive onboarding, interactive tour, use-case templates, in-app checklists |
+| Value demonstration | "Quick Wins" dashboard, time-saved metrics, usage-based tips, early collaboration features |
+| Pricing | Simplified tiers 4→3, ROI calculator, highlighted popular plan, enterprise CTA |
+| Trial nurture | Day 3 value email → Day 7 case study → Day 10 limited discount → Day 14 CSM outreach |
 
 | Metric | Before | After | Change |
 |--------|--------|-------|--------|
@@ -48,14 +47,13 @@ Real-world CRO implementations across e-commerce, SaaS, and B2B services, plus a
 
 ## 18.3 Lead Gen: B2B Consulting ($20M Revenue)
 
-**Challenge:** $150 CPL, 5% lead-to-opportunity, 60% of leads unqualified (wrong size, no budget/authority, early research)
-
-**Changes:**
-
-- **Landing pages:** Qualification questions in form, use-case-specific pages, progressive profiling, social proof
-- **Content:** Gated research reports, industry content hubs, content-based lead scoring, segment-specific nurture
-- **Qualification:** BANT scoring, automated workflows, fast-track for high scores, SDR playbook
-- **ABM:** 500-account target list, personalized site experience, account-specific content, engagement alerts
+| Category | Details |
+|----------|---------|
+| Challenge | $150 CPL, 5% lead-to-opportunity, 60% of leads unqualified (wrong size, no budget/authority, early research) |
+| Landing pages | Qualification questions in form, use-case-specific pages, progressive profiling, social proof |
+| Content | Gated research reports, industry content hubs, content-based lead scoring, segment-specific nurture |
+| Qualification | BANT scoring, automated workflows, fast-track for high scores, SDR playbook |
+| ABM | 500-account target list, personalized site experience, account-specific content, engagement alerts |
 
 | Metric | Before | After | Change |
 |--------|--------|-------|--------|
@@ -71,27 +69,35 @@ Real-world CRO implementations across e-commerce, SaaS, and B2B services, plus a
 
 ### Phase 1: Foundation (Weeks 1–4)
 
-- **Week 1 — Setup/Audit:** Install GA4, heatmaps (Hotjar/FullStory), event tracking. Conduct CRO audit. Identify quick wins.
-- **Week 2 — Research:** Analyze GA data, heatmaps, recordings. Survey customers, interview recent converters, analyze competitors.
-- **Week 3 — Prioritize:** PIE framework scoring, test roadmap, stakeholder alignment, testing tool setup (Optimizely/VWO), document baselines.
-- **Week 4 — Quick Wins:** Resolve critical UX issues, add trust signals, optimize page speed, fix mobile issues, improve above-fold content.
+| Week | Focus | Actions |
+|------|-------|---------|
+| 1 | Setup/Audit | Install GA4, heatmaps (Hotjar/FullStory), event tracking. Conduct CRO audit. Identify quick wins. |
+| 2 | Research | Analyze GA data, heatmaps, recordings. Survey customers, interview recent converters, analyze competitors. |
+| 3 | Prioritize | PIE framework scoring, test roadmap, stakeholder alignment, testing tool setup (Optimizely/VWO), document baselines. |
+| 4 | Quick Wins | Resolve critical UX issues, add trust signals, optimize page speed, fix mobile issues, improve above-fold content. |
 
 ### Phase 2: Testing (Months 2–3)
 
-**Month 2:** First A/B tests — headlines, CTAs, forms, social proof placement.
-**Month 3:** Test pricing presentation, product page layouts, checkout flow, email sequences. Implement winners.
+| Period | Focus |
+|--------|-------|
+| Month 2 | First A/B tests — headlines, CTAs, forms, social proof placement |
+| Month 3 | Test pricing presentation, product page layouts, checkout flow, email sequences. Implement winners. |
 
 **Weekly rhythm:** Mon=review results, Tue=launch tests, Wed=deep analysis, Thu=creative dev, Fri=planning/docs.
 
 ### Phase 3: Advanced Optimization (Months 4–6)
 
-**Testing:** Multivariate tests, personalization, segmentation analysis, funnel optimization, cross-channel testing.
-**Operations:** Document results, build test library, create design system, train team, establish reporting cadence.
+| Track | Actions |
+|-------|---------|
+| Testing | Multivariate tests, personalization, segmentation analysis, funnel optimization, cross-channel testing |
+| Operations | Document results, build test library, create design system, train team, establish reporting cadence |
 
 ### Team Structure
 
-- **Minimum viable:** CRO Manager + part-time Frontend Dev, Designer, Analyst
-- **Enterprise:** CRO Director, CRO Manager, 2–3 Specialists, Frontend Dev, UX Researcher, Data Analyst
+| Model | Team |
+|-------|------|
+| Minimum viable | CRO Manager + part-time Frontend Dev, Designer, Analyst |
+| Enterprise | CRO Director, CRO Manager, 2–3 Specialists, Frontend Dev, UX Researcher, Data Analyst |
 
 ### Tools
 
@@ -104,8 +110,8 @@ Real-world CRO implementations across e-commerce, SaaS, and B2B services, plus a
 
 ### Success Metrics
 
-**Primary:** Conversion rate (overall + segment), revenue per visitor, AOV (e-commerce), trial-to-paid (SaaS), CPA
-**Secondary:** Test velocity (tests/month), win rate, revenue impact from CRO, time to significance, implementation rate
+- **Primary:** Conversion rate (overall + segment), revenue per visitor, AOV (e-commerce), trial-to-paid (SaaS), CPA
+- **Secondary:** Test velocity (tests/month), win rate, revenue impact from CRO, time to significance, implementation rate
 
 ### Common Pitfalls
 


### PR DESCRIPTION
## Summary
- tighten the CRO case-study chapter into scan-friendly tables while preserving every scenario, metric, and playbook step
- fix the chapter intro links to point at the tracked lowercase chapter filenames

## Testing
- `bunx markdownlint-cli2 ".agents/marketing-sales/cro-chapter-18.md"`

## Runtime Testing
- self-assessed: low-risk markdown-only documentation change

Closes #14121


---
[aidevops.sh](https://aidevops.sh) v3.5.477 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.
