### PR TITLE
GH#14129: register postgres-drizzle simplification state

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -321,6 +321,11 @@
       "at": "2026-03-28T05:50:34Z",
       "pr": 11415
     },
+    ".agents/services/database/postgres-drizzle-skill.md": {
+      "hash": "18032dc865df1fd4a1b2e31a05b63c216058ae23",
+      "at": "2026-03-31T04:16:29Z",
+      "pr": 14113
+    },
     ".agents/services/database/postgres-drizzle-skill/queries.md": {
       "hash": "2647d7cd620f871bdbc5ca89466f013792b777fd",
       "at": "2026-03-28T06:40:05Z",


### PR DESCRIPTION
## Summary
- record the current blob hash for `.agents/services/database/postgres-drizzle-skill.md` in the shared simplification registry
- link the registry entry back to PR #14113, which already tightened the doc from 160 to 88 lines
- stop the simplification scanner from reopening debt for an unchanged file that is already in its slim index form

## Testing
- `python3 - <<'PY' ... json.load(...)` parsed `.agents/configs/simplification-state.json` successfully
- `jq -e '.files[".agents/services/database/postgres-drizzle-skill.md"].hash == "18032dc865df1fd4a1b2e31a05b63c216058ae23"' .agents/configs/simplification-state.json` returned true
- `jq -e '.files[".agents/services/database/postgres-drizzle-skill.md"].pr == 14113' .agents/configs/simplification-state.json` returned true

## Runtime Testing
- Level: self-assessed
- Reason: low-risk JSON registry update only; no runtime code path changed

Closes #14129


---
[aidevops.sh](https://aidevops.sh) v3.5.477 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 78,447 tokens on this as a headless worker. Overall, 16h 33m since this issue was created.
