### PR TITLE
GH#14130: tighten response scoring framework card

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2267,9 +2267,9 @@
       "pr": 13494
     },
     ".agents/tools/ai-assistants/response-scoring.md": {
-      "hash": "6eadf895b9b3ea1caaf55456d25937d9152c15eb",
-      "at": "2026-03-29T15:50:37Z",
-      "pr": 13072
+      "hash": "33f943f8dc56e52eee464c193d4b0fce97d1305d",
+      "at": "2026-03-31T04:26:00Z",
+      "pr": 14565
     },
     ".agents/tools/deployment/coolify-setup.md": {
       "hash": "5041a915d0c96f4651205ed6ca0799a2d190757c",

--- a/.agents/tools/ai-assistants/response-scoring.md
+++ b/.agents/tools/ai-assistants/response-scoring.md
@@ -1,5 +1,5 @@
 ---
-description: Evaluate and score AI model responses side-by-side with structured criteria
+description: Score AI responses with weighted evaluation criteria
 mode: subagent
 tools:
   read: true
@@ -19,17 +19,14 @@ model: sonnet
 
 ## Quick Reference
 
-- **Purpose**: Evaluate AI model responses against structured scoring criteria
+- **Purpose**: Evaluate real model outputs with structured scoring
+- **Use for**: Task-type model selection, prompt before/after tests, reproducible benchmarks
 - **Command**: `/score-responses` (interactive evaluation)
 - **Helper**: `response-scoring-helper.sh [init|prompt|record|score|compare|leaderboard|export|history|criteria]`
 - **Criteria**: Correctness (30%), Completeness (25%), Code Quality (25%), Clarity (20%)
 - **Storage**: SQLite at `~/.aidevops/.agent-workspace/response-scoring.db`
 
 <!-- AI-CONTEXT-END -->
-
-## When to Use
-
-Evaluate **actual responses** (distinct from `compare-models` which compares specs): model selection for task types, before/after prompt engineering, reproducible benchmarks.
 
 ## Scoring Criteria (1–5 scale, weighted average)
 
@@ -42,7 +39,7 @@ Evaluate **actual responses** (distinct from `compare-models` which compares spe
 
 ## Workflow
 
-**1. Create prompt:**
+### 1. Create prompt
 
 ```bash
 response-scoring-helper.sh prompt add \
@@ -51,7 +48,7 @@ response-scoring-helper.sh prompt add \
 # Or: --file prompts/rest-api.txt
 ```
 
-**2. Record responses:**
+### 2. Record responses
 
 ```bash
 response-scoring-helper.sh record \
@@ -61,7 +58,7 @@ response-scoring-helper.sh record \
 # Or: --file responses/gpt4o-output.txt
 ```
 
-**3. Score:**
+### 3. Score
 
 ```bash
 response-scoring-helper.sh score \
@@ -69,7 +66,7 @@ response-scoring-helper.sh score \
   --correctness 5 --completeness 4 --code-quality 5 --clarity 4
 ```
 
-**4. Compare and rank:**
+### 4. Compare and rank
 
 ```bash
 response-scoring-helper.sh compare --prompt 1        # or --json
@@ -88,14 +85,14 @@ response-scoring-helper.sh export --csv > scores.csv
 
 ## Pattern Tracker Integration (t1099)
 
-Scores feed into the shared pattern tracker:
+Scores feed the shared pattern tracker:
 
 - **On score**: `SUCCESS_PATTERN` (weighted avg >= 3.5) or `FAILURE_PATTERN` (< 3.5), tagged with model tier + category
 - **On compare**: Winner → `SUCCESS_PATTERN` with comparison metadata
 - **Bulk sync**: `response-scoring-helper.sh sync` (`--dry-run` to preview). Disable: `SCORING_NO_PATTERN_SYNC=1`
 - **Tier mapping**: Full model names (e.g., `claude-sonnet-4-6`) auto-mapped to routing tiers (`sonnet`)
 
-Feeds `/route <task>` and `/patterns recommend --task-type <type>` with real A/B data.
+Outputs feed `/route <task>` and `/patterns recommend --task-type <type>` with real A/B data.
 
 ## Database Schema
 


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/ai-assistants/response-scoring.md` into a denser quick-reference card without dropping command examples or integration notes
- move usage guidance into the quick-reference block and promote workflow steps to stable subsection headings for easier scanning
- preserve the t1099 pattern-tracker integration details, related references, and helper commands
- refresh `.agents/configs/simplification-state.json` with the new blob hash and PR reference for this file

## Testing
- `bunx markdownlint-cli2 ".agents/tools/ai-assistants/response-scoring.md"`
- `python3` content-preservation check for required commands, refs, and task IDs
- `git diff --check`

## Runtime Testing
- self-assessed: low-risk docs-only change; runtime verification not required by the full-loop risk table

Closes #14130

---
[aidevops.sh](https://aidevops.sh) v3.5.477 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 15m on this as a headless worker.