### PR TITLE
GH#14131: tighten Hyperdrive gotchas doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md
@@ -1,8 +1,8 @@
-# Gotchas
+# Hyperdrive Gotchas
 
-See [README.md](./README.md), [patterns.md](./patterns.md).
+See [Hyperdrive overview](./hyperdrive.md) and [Hyperdrive patterns](./hyperdrive-patterns.md).
 
-## Limits
+## Hard limits
 
 | Category | Limit | Free | Paid |
 |----------|-------|------|------|
@@ -14,9 +14,9 @@ See [README.md](./README.md), [patterns.md](./patterns.md).
 | Query | Max duration | 60s | 60s |
 | Query | Max cached response | 50MB | 50MB |
 
-Queries >60s are terminated. Responses >50MB are returned but not cached.
+Queries over 60s are terminated. Responses over 50MB are returned but not cached.
 
-## Common Errors
+## Common error handling
 
 ```typescript
 try {
@@ -52,11 +52,15 @@ try {
 
 ## Troubleshooting
 
-**Connection refused:** Check firewall allows Cloudflare IPs → verify DB listening on port → confirm service running → check credentials.
+- **Connection refused** — allow Cloudflare IPs, verify DB port is listening, confirm the service is running, then re-check credentials.
+- **Pool exhausted** — shorten transactions, avoid queries over 60s, do not hold connections during external calls, and upgrade if free-plan limits are the bottleneck.
+- **SSL/TLS failed** — use `sslmode=require` (Postgres) or `sslMode=REQUIRED` (MySQL), upload a CA cert for self-signed deployments, confirm SSL is enabled, and check certificate expiry.
+- **Queries not cached** — ensure the query is non-mutating, remove volatile functions (`NOW()`, `RANDOM()`), confirm caching is enabled, test with `wrangler dev --remote`, and set `prepare=true` for postgres.js.
+- **Query timeout (>60s)** — add indexes, reduce result size with `LIMIT`, split the work into smaller queries, or move it to async processing.
+- **Local DB connection** — verify `localConnectionString`, confirm the DB is running, match the env var name to the binding, and test with `psql` or `mysql`.
+- **Env var not working** — use `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING>`, keep `<BINDING>` aligned with `wrangler.jsonc`, export the variable in the current shell, then restart `wrangler dev`.
 
-**Pool exhausted:** Reduce transaction duration → avoid long queries (>60s) → don't hold connections during external calls → upgrade to paid plan.
-
-Monitor active connections:
+Monitor active Hyperdrive sessions:
 
 ```sql
 SELECT usename, application_name, client_addr, state
@@ -64,52 +68,41 @@ FROM pg_stat_activity
 WHERE application_name = 'Cloudflare Hyperdrive';
 ```
 
-**SSL/TLS failed:** Add `sslmode=require` (Postgres) or `sslMode=REQUIRED` (MySQL) → upload CA cert if self-signed → verify DB has SSL enabled → check cert expiry.
-
-**Queries not cached:** Verify non-mutating (SELECT) → check for volatile functions (NOW(), RANDOM()) → confirm caching not disabled → use `wrangler dev --remote` to test → check `prepare=true` for postgres.js.
-
-**Query timeout (>60s):** Optimize with indexes → reduce dataset (LIMIT) → break into smaller queries → use async processing.
-
-**Local DB connection:** Verify `localConnectionString` correct → check DB running → confirm env var name matches binding → test with psql/mysql client.
-
-**Env var not working:** Format: `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING>` → binding matches wrangler.jsonc → variable exported in shell → restart wrangler dev.
-
-## Migration Checklist
+## Migration checklist
 
 - [ ] Create config via Wrangler
-- [ ] Add binding to wrangler.jsonc
-- [ ] Enable `nodejs_compat` flag
-- [ ] Set `compatibility_date` >= `2024-09-23`
-- [ ] Update code to `env.HYPERDRIVE.connectionString` (Postgres) or properties (MySQL)
+- [ ] Add binding to `wrangler.jsonc`
+- [ ] Enable `nodejs_compat`
+- [ ] Set `compatibility_date >= 2024-09-23`
+- [ ] Update code to `env.HYPERDRIVE.connectionString` (Postgres) or connection properties (MySQL)
 - [ ] Configure `localConnectionString`
 - [ ] Set `prepare: true` (postgres.js) or `disableEval: true` (mysql2)
 - [ ] Test locally with `wrangler dev`
-- [ ] Deploy + monitor pool usage
-- [ ] Validate cache with `wrangler dev --remote`
-- [ ] Update firewall (Cloudflare IPs)
+- [ ] Deploy and monitor pool usage
+- [ ] Validate cache behaviour with `wrangler dev --remote`
+- [ ] Update firewall rules for Cloudflare IPs
 - [ ] Configure observability
 
-## Supported Databases
+## Supported databases
 
-**PostgreSQL 11+** (CockroachDB, Timescale, Materialize, Neon, Supabase) — `pg` >= 8.16.3. `sslmode`: `require`, `verify-ca`, `verify-full`.
+- **PostgreSQL 11+** (CockroachDB, Timescale, Materialize, Neon, Supabase) — `pg >= 8.16.3`; `sslmode`: `require`, `verify-ca`, `verify-full`
+- **MySQL 5.7+** (PlanetScale) — `mysql2 >= 3.13.0`; `sslMode`: `REQUIRED`, `VERIFY_CA`, `VERIFY_IDENTITY`
 
-**MySQL 5.7+** (PlanetScale) — `mysql2` >= 3.13.0. `sslMode`: `REQUIRED`, `VERIFY_CA`, `VERIFY_IDENTITY`.
+## Avoid Hyperdrive when
 
-## When NOT to Use
+- Write-heavy workloads get little cache benefit.
+- Real-time reads need freshness under 1 second.
+- The app already runs close to a single-region database.
+- The app is simple enough that Hyperdrive overhead is unjustified.
+- The origin DB already exceeds strict connection limits.
 
-❌ Write-heavy workloads (limited cache benefit)
-❌ Real-time data requirements (<1s freshness)
-❌ Single-region apps close to DB
-❌ Very simple apps (overhead unjustified)
-❌ DB with strict connection limits already exceeded
-
-Alternatives: D1 (Cloudflare native SQL), Durable Objects (stateful Workers), KV (global key-value), R2 (object storage).
+Alternatives: D1 for Cloudflare-native SQL, Durable Objects for stateful Workers, KV for key-value reads, and R2 for object storage.
 
 ## Resources
 
-- [Docs](https://developers.cloudflare.com/hyperdrive/)
-- [Getting Started](https://developers.cloudflare.com/hyperdrive/get-started/)
-- [Wrangler Reference](https://developers.cloudflare.com/hyperdrive/reference/wrangler-commands/)
-- [Supported DBs](https://developers.cloudflare.com/hyperdrive/reference/supported-databases-and-features/)
+- [Hyperdrive docs](https://developers.cloudflare.com/hyperdrive/)
+- [Getting started](https://developers.cloudflare.com/hyperdrive/get-started/)
+- [Wrangler reference](https://developers.cloudflare.com/hyperdrive/reference/wrangler-commands/)
+- [Supported databases](https://developers.cloudflare.com/hyperdrive/reference/supported-databases-and-features/)
 - [Discord #hyperdrive](https://discord.cloudflare.com)
-- [Limit Increase Form](https://forms.gle/ukpeZVLWLnKeixDu7)
+- [Limit increase form](https://forms.gle/ukpeZVLWLnKeixDu7)


### PR DESCRIPTION
## Summary
- retitle the Hyperdrive gotchas card and fix its stale overview/pattern links
- tighten troubleshooting, migration, and database guidance without dropping operational limits or examples
- keep the existing error-handling and monitoring snippets while making the doc easier to scan

## Testing
- `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md"`

## Runtime Testing
- Level: self-assessed
- Reason: docs-only change; no runtime behaviour changed

Closes #14131
---
[aidevops.sh](https://aidevops.sh) v3.5.477 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 72,536 tokens on this as a headless worker. Overall, 16h 31m since this issue was created.