### PR TITLE
GH#14132: tighten session detail reference

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2756,6 +2756,11 @@
       "at": "2026-03-30T03:34:12Z",
       "pr": 13637
     },
+    ".agents/reference/session.md": {
+      "hash": "1dd4861e05bb3b702948db2b4eeb8d923adbe411",
+      "at": "2026-03-31T04:18:32Z",
+      "pr": null
+    },
     ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
       "hash": "2cbb9c1c836f4b8fce6dbe5b982d8760a75922ce",
       "at": "2026-03-30T03:34:13Z",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2759,7 +2759,7 @@
     ".agents/reference/session.md": {
       "hash": "1dd4861e05bb3b702948db2b4eeb8d923adbe411",
       "at": "2026-03-31T04:18:32Z",
-      "pr": null
+      "pr": 14571
     },
     ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
       "hash": "2cbb9c1c836f4b8fce6dbe5b982d8760a75922ce",

--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -1,78 +1,67 @@
 # Session & Environment — Detail Reference
 
-Loaded on-demand for session management, browser automation, localhost, or quality workflows.
-Core pointers are in `AGENTS.md`.
+Loaded on-demand for session management, browser automation, localhost, or quality workflows. Core rules live in `AGENTS.md`.
 
 ## Terminal Capabilities
 
 Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers, `opencode -p "subtask"`).
 
-- **For long-running processes**: use `&`, `nohup`, or `tmux`.
-- **For parallel AI dispatch**: use `tools/ai-assistants/opencode-server.md`.
+- Long-running processes: use `&`, `nohup`, or `tmux`.
+- Parallel AI dispatch: `tools/ai-assistants/opencode-server.md`.
 
-## Session Completion
+## Session Lifecycle
 
-Run `/session-review` before ending. Suggest new sessions after PR merge, domain switch, or 3+ hours.
-
-**Cleanup**: Commit/stash changes, run `wt merge` to clean merged worktrees.
-
-**Full docs**: `workflows/session-manager.md`
+- Run `/session-review` before ending.
+- Suggest a new session after PR merge, domain switch, or 3+ hours.
+- Cleanup: commit or stash changes, then run `wt merge` to clean merged worktrees.
+- Full docs: `workflows/session-manager.md`.
 
 ## Context Compaction Resilience
 
-When context is compacted (long sessions, autonomous loops), operational state is lost unless persisted to disk. Use `/checkpoint` to save and restore session state.
+Context compaction drops operational state unless it is written to disk. Use `/checkpoint` to persist and restore session state.
 
-**Commands**:
-
-- `/checkpoint` or `session-checkpoint-helper.sh save --task <id> --next <ids>` — save current state
-- `session-checkpoint-helper.sh load` — reload state after compaction
-- `session-checkpoint-helper.sh continuation` — generate a full continuation prompt for new sessions
-
-**When to checkpoint**: After each task completion, before large operations, after PR creation/merge.
-
-**Compaction survival rule**: See `prompts/build.txt` "Context Compaction Survival".
-
-**Full docs**: `workflows/session-manager.md` "Compaction Resilience" section
+- Save: `/checkpoint` or `session-checkpoint-helper.sh save --task <id> --next <ids>`
+- Load: `session-checkpoint-helper.sh load`
+- Continuation prompt: `session-checkpoint-helper.sh continuation`
+- Checkpoint after each task, before large operations, and after PR creation or merge.
+- Survival rules: `prompts/build.txt` "Context Compaction Survival".
+- Full docs: `workflows/session-manager.md` "Compaction Resilience".
 
 ## Git Workflow Detail
 
-**Before edits**: Run pre-edit check (see AGENTS.md top).
+- Before edits: run the pre-edit check from `AGENTS.md`.
+- After branch creation:
+  1. Check `TODO.md` for matching tasks and record `started:`.
+  2. Call `session-rename_sync_branch`.
+  3. Read `workflows/git-workflow.md`.
 
-**After branch creation**:
-1. Check TODO.md for matching tasks, record `started:` timestamp
-2. Call `session-rename_sync_branch` tool
-3. Read `workflows/git-workflow.md` for full guidance
-
-**Worktrees** (preferred for parallel work):
+Worktrees are preferred for parallel work:
 
 ```bash
 wt switch -c feature/my-feature   # Worktrunk (preferred)
 worktree-helper.sh add feature/x  # Fallback
 ```
 
-**After switching to a worktree**: Re-read any file at its worktree path before editing. The Edit tool tracks files by their exact absolute path, so a read from the main repository path is not recognized for the same file in the worktree.
-
-**After completing changes**, offer: 1) Preflight checks 2) Skip preflight 3) Continue editing
-
-**Worktree ownership** (CRITICAL): NEVER remove a worktree unless (a) you created it in this session, (b) it belongs to a task in your active batch, AND the task is deployed/complete, or (c) the user explicitly asks. Worktrees may belong to parallel sessions — removing them destroys another agent's working directory mid-work. When cleaning up, only touch worktrees for tasks you personally merged. Use `git worktree list` to see all worktrees but do NOT assume unrecognized ones are safe to remove. The ownership registry (`worktree-helper.sh registry list`) tracks which PID owns each worktree — `remove` and `clean` commands automatically refuse to touch worktrees owned by other live processes.
-
-**Safety hooks** (Claude Code only): Destructive commands (`git reset --hard`, `rm -rf`, etc.) are blocked by a PreToolUse hook. Run `install-hooks.sh --test` to verify. See `workflows/git-workflow.md` "Destructive Command Safety Hooks" section.
-
-**Full docs**: `workflows/git-workflow.md`, `tools/git/worktrunk.md`
+- After switching to a worktree, re-read files at the worktree path before editing. Edit tracking is path-specific; a read from the main repo path does not authorize edits at the worktree path.
+- After completing changes, offer: 1) Preflight checks 2) Skip preflight 3) Continue editing.
+- Worktree ownership is critical: remove a worktree only if you created it in this session, it belongs to your active batch and is deployed or complete, or the user explicitly asked. Unknown worktrees may belong to parallel sessions. Use `git worktree list` for visibility only; ownership is enforced by `worktree-helper.sh registry list`, and `remove`/`clean` refuse live worktrees owned by other processes.
+- Claude Code safety hooks block destructive commands such as `git reset --hard` and `rm -rf`. Verify with `install-hooks.sh --test`. See `workflows/git-workflow.md` "Destructive Command Safety Hooks".
+- Full docs: `workflows/git-workflow.md`, `tools/git/worktrunk.md`.
 
 ## Browser Automation
 
-Proactively use a browser for: dev server verification, form testing, deployment checks, frontend debugging. Read `tools/browser/browser-automation.md` for tool selection. Quick default: Playwright for dev testing, dev-browser for persistent login.
-
-**CRITICAL: Never use curl/HTTP to verify frontend fixes.** Server returns 200 even when React crashes client-side because error boundaries render successfully. The crash happens during hydration which curl never executes. Always use browser screenshots (dev-browser agent, Playwright) to verify frontend fixes work.
+- Use a browser proactively for dev-server verification, form testing, deployment checks, and frontend debugging.
+- Tool selection: `tools/browser/browser-automation.md`.
+- Quick default: Playwright for dev testing, dev-browser for persistent login.
+- Never use curl or raw HTTP to verify frontend fixes. A server can return 200 while React fails during hydration; browser screenshots are the required proof.
 
 ## Localhost Standards
 
-`.local` domains + SSL via Traefik + mkcert. See `services/hosting/local-hosting.md` (primary) or `services/hosting/localhost.md` (legacy).
+Use `.local` domains with SSL via Traefik + mkcert. Primary doc: `services/hosting/local-hosting.md`. Legacy doc: `services/hosting/localhost.md`.
 
 ## Bot Reviewer Feedback
 
-AI suggestion verification: see `prompts/build.txt`. Dismiss incorrect suggestions with evidence; address valid ones.
+Follow `prompts/build.txt` for AI suggestion verification. Dismiss incorrect suggestions with evidence; address valid ones.
 
 ## Quality Workflow
 
@@ -80,15 +69,12 @@ AI suggestion verification: see `prompts/build.txt`. Dismiss incorrect suggestio
 Development → @code-standards → /code-simplifier → /linters-local → /pr review → /postflight
 ```
 
-**Quick commands**: `linters-local.sh` (pre-commit), `/pr review` (full), `version-manager.sh release [type]`
+Quick commands: `linters-local.sh` (pre-commit), `/pr review` (full), `version-manager.sh release [type]`.
 
-## Agents & Subagents Detail
+## Agents & Subagents
 
-See `subagent-index.toon` for complete listing of agents, subagents, workflows, and scripts.
-
-**Strategy**: Read subagents on-demand when tasks require domain expertise. This keeps context focused.
-
-**Agent tiers** (user-created agents survive `aidevops update`):
+- Full inventory: `subagent-index.toon`.
+- Strategy: load subagents only when domain expertise is needed.
 
 | Tier | Location | Purpose |
 |------|----------|---------|
@@ -96,20 +82,15 @@ See `subagent-index.toon` for complete listing of agents, subagents, workflows, 
 | **Custom** | `~/.aidevops/agents/custom/` | User's permanent private agents |
 | **Shared** | `.agents/` in repo | Open-source, distributed to all users |
 
-Orchestration agents can create drafts in `draft/` for reusable parallel processing context. See `tools/build-agent/build-agent.md` for the full lifecycle and promotion workflow.
+Orchestration agents may create drafts for reusable parallel-processing context. Lifecycle details: `tools/build-agent/build-agent.md`.
 
-## Security Detail
+## Security & Working Directories
 
-Security rules: see `prompts/build.txt`. Additional details:
-
-- Config templates: `configs/*.json.txt` (committed), working: `configs/*.json` (gitignored)
-
-**Full docs**: `tools/credentials/gopass.md`, `tools/credentials/api-key-setup.md`
-
-## Working Directories
-
-Working directory tree: see `prompts/build.txt`. Agent file locations:
-
-- `~/.aidevops/agents/custom/` — User's permanent private agents (survives updates)
-- `~/.aidevops/agents/draft/` — R&D, experimental agents (survives updates)
-- `~/.aidevops/agents/` — Shared agents (deployed from repo, overwritten on update)
+- Security rules: `prompts/build.txt`.
+- Config templates: `configs/*.json.txt` (committed); working configs: `configs/*.json` (gitignored).
+- Credential docs: `tools/credentials/gopass.md`, `tools/credentials/api-key-setup.md`.
+- Working directory tree: `prompts/build.txt`.
+- Agent locations:
+  - `~/.aidevops/agents/custom/` — permanent private agents
+  - `~/.aidevops/agents/draft/` — R&D and experimental agents
+  - `~/.aidevops/agents/` — shared deployed agents overwritten on update


### PR DESCRIPTION
## Summary
- tighten `.agents/reference/session.md` into shorter lifecycle-focused sections while preserving worktree, checkpoint, browser, and security guidance
- reduce the reference from 115 lines to 96 lines without dropping command examples or source pointers
- register `.agents/reference/session.md` in `.agents/configs/simplification-state.json` for future simplification tracking

## Testing
- `bunx markdownlint-cli2 ".agents/reference/session.md"`
- `python3 -m json.tool .agents/configs/simplification-state.json >/dev/null`

## Runtime Testing
- Level: self-assessed
- Reason: docs-only change plus simplification-state metadata update; no runtime behavior changed

Closes #14132


---
[aidevops.sh](https://aidevops.sh) v3.5.478 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.