### PR TITLE
GH#14144: tighten email delivery test command card

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3154,6 +3154,11 @@
       "hash": "fbaf83d04fce904137096c772adb42790e04badb",
       "at": "2026-03-31T14:03:00Z",
       "pr": 14941
+    },
+    ".agents/scripts/commands/email-delivery-test.md": {
+      "hash": "04c59ed327fb01506e3f7e3607804dbef3e0b7f0",
+      "at": "2026-03-31T04:20:58Z",
+      "pr": 14572
     }
   }
 }

--- a/.agents/scripts/commands/email-delivery-test.md
+++ b/.agents/scripts/commands/email-delivery-test.md
@@ -4,61 +4,40 @@ agent: Build+
 mode: subagent
 ---
 
-Run email deliverability testing — spam content analysis, provider-specific checks, and inbox placement guidance.
+Run email deliverability testing: spam analysis, provider checks, warm-up guidance, and seed-list guidance.
 
-Arguments: $ARGUMENTS
+Arguments: `$ARGUMENTS`
 
 ## Workflow
 
-### Step 1: Determine Test Type
+### Step 1: Classify Input
 
-Parse `$ARGUMENTS` to determine what to test:
+- File path → spam content analysis
+- Domain → all-provider deliverability check
+- `gmail|outlook|yahoo <domain>` → provider-specific check
+- `warmup <domain>` → warm-up guidance
+- `seed-test <domain>` → inbox placement test guide
+- `report <domain>` → full report
+- Empty or `help` → helper usage
 
-- If argument is an HTML/text file path: run spam content analysis
-- If argument is a domain: run provider deliverability checks
-- If argument is "warmup": show warm-up guidance
-- If argument is "seed-test": show seed-list testing guide
-- If argument is "help" or empty: show available commands
-
-### Step 2: Run Appropriate Tests
-
-**For email content (spam analysis):**
+### Step 2: Run Helper
 
 ```bash
+# File path
 ~/.aidevops/agents/scripts/email-delivery-test-helper.sh spam-check "$ARGUMENTS"
-```
 
-**For domains (provider deliverability):**
-
-```bash
-~/.aidevops/agents/scripts/email-delivery-test-helper.sh providers "$ARGUMENTS"
-```
-
-**For full report:**
-
-```bash
-~/.aidevops/agents/scripts/email-delivery-test-helper.sh report "$ARGUMENTS"
+# Domain or subcommand
+~/.aidevops/agents/scripts/email-delivery-test-helper.sh "$ARGUMENTS"
 ```
 
 ### Step 3: Present Results
 
-Format the output as a clear report with:
+Present helper output as a concise report:
 
-- Spam score and risk rating
-- Provider-specific scores (Gmail, Outlook, Yahoo)
-- Actionable recommendations
-- Links to monitoring services
-
-### Step 4: Offer Follow-up Actions
-
-```text
-Actions:
-1. Run full deliverability report
-2. Check specific provider (Gmail/Outlook/Yahoo)
-3. Analyze email content for spam triggers
-4. View warm-up schedule
-5. Run seed-list placement test
-```
+- Spam score and risk level
+- Provider scores and failures
+- Actionable remediation steps
+- Relevant monitoring or follow-up links
 
 ## Options
 
@@ -69,43 +48,6 @@ Actions:
 | `/email-delivery-test gmail example.com` | Gmail-specific check |
 | `/email-delivery-test warmup example.com` | Warm-up guidance |
 | `/email-delivery-test seed-test example.com` | Seed-list testing guide |
-
-## Examples
-
-**Spam content analysis:**
-
-```text
-User: /email-delivery-test newsletter.html
-AI: Running spam content analysis on newsletter.html...
-
-    Subject Line: 2 issues (excessive caps, exclamation marks)
-    Body Content: 3 high-risk phrases, 5 medium-risk phrases
-    Structural: Low text-to-image ratio, missing physical address
-
-    Spam Score: 45/100 - MEDIUM RISK
-    Content may trigger spam filters in some providers
-
-    Top Issues:
-    1. "Act now" and "Limited time" are high-risk phrases
-    2. Image-heavy with little text content
-    3. Missing physical address (CAN-SPAM requirement)
-```
-
-**Provider deliverability check:**
-
-```text
-User: /email-delivery-test example.com
-AI: Checking deliverability across major providers...
-
-    Gmail:   7/8 - Excellent
-    Outlook: 5/7 - Good
-    Yahoo:   4/5 - Good
-
-    All providers require:
-    - SPF + DKIM + DMARC enforcement
-    - One-click unsubscribe headers
-    - Spam rate < 0.3%
-```
 
 ## Related
 


### PR DESCRIPTION
## Summary
- remove duplicated examples and follow-up boilerplate from the /email-delivery-test command card
- keep the command focused on input classification, helper invocation, and expected report output
- record the simplified command doc in the simplification state registry to avoid repeat debt scans

## Runtime Testing
- self-assessed: low-risk documentation-only change
- verified: bunx markdownlint-cli2 ".agents/scripts/commands/email-delivery-test.md"
- verified: jq empty .agents/configs/simplification-state.json

Closes #14144


---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 6m and 217,343 tokens on this as a headless worker. Overall, 16h 10m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated email delivery test command with clearer descriptions, simplified execution flow, and streamlined result output presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->