### PR TITLE
GH#14156: tighten sales emails chapter analysis

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2592,9 +2592,9 @@
       "pr": 13314
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
-      "hash": "0a96775e8682e8b03590b673f9c8180c5cc99908",
-      "at": "2026-03-29T22:09:33Z",
-      "pr": 13317
+      "hash": "ff7eca6c909c49c6cdefd01bc703545707c6827b",
+      "at": "2026-03-31T04:22:38Z",
+      "pr": 14573
     },
     ".agents/tools/browser/extension-dev.md": {
       "hash": "5d6ac2671414bfdce4481294fce9019711d28c01",

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md
@@ -1,6 +1,6 @@
 # Sales Emails
 
-High-converting sales email examples with analysis.
+High-converting sales email swipe examples with analysis.
 
 ---
 
@@ -42,7 +42,7 @@ I'll see you inside.
 P.S. Doors close Friday at 11:59pm. No extensions.
 ```
 
-**Why it works:** Social proof via student story, before/after transformation, scarcity (5 days, small group), exclusivity filter, and a hard deadline in the P.S.
+**Why it works:** Student-story social proof, before/after transformation, launch scarcity, exclusivity filter, and a hard P.S. deadline.
 
 ---
 
@@ -71,7 +71,7 @@ We're here to help.
 — [Name/Team]
 ```
 
-**Why it works:** Specific deadline, loss aversion (itemized losses), low-friction solution (30 seconds), and a reply escape valve.
+**Why it works:** Specific deadline, itemized loss aversion, low-friction upgrade path, and a reply escape valve.
 
 ---
 
@@ -102,7 +102,7 @@ P.S. If you decided it's not right for you, that's
 totally fine too. Just let me know and I'll stop bugging you.
 ```
 
-**Why it works:** Personal (not automated) tone, objections surfaced as questions, open dialogue, and pressure release in the P.S.
+**Why it works:** Personal tone, objection prompts, open dialogue, and a low-pressure P.S.
 
 ---
 
@@ -136,4 +136,4 @@ See you there,
 [Name]
 ```
 
-**Why it works:** Outcome-first subject, specific date/time, bullet takeaways, and replay availability to remove attendance friction.
+**Why it works:** Outcome-first subject, specific schedule, bullet takeaways, and replay availability that removes attendance friction.


### PR DESCRIPTION
## Summary
- tighten the sales emails chapter intro so it identifies the file as a swipe example set
- condense each `Why it works` note without removing any sales patterns or example copy
- keep the chapter aligned with the rest of the email swipe series by preserving the existing section structure

## Testing
- \.agents/scripts/markdown-formatter.sh lint '.agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md'

## Runtime Testing
- **Risk level:** Low
- **Verification:** self-assessed — docs-only change with no runtime behaviour

Closes #14156

---

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m on this as a headless worker.