### PR TITLE
GH#14146: tighten OCR overview guide

### DIFF
--- a/.agents/tools/ocr/overview.md
+++ b/.agents/tools/ocr/overview.md
@@ -24,19 +24,19 @@ tools:
 - **Local quick OCR**: GLM-OCR via Ollama — no install beyond `ollama pull glm-ocr`
 - **PDF manipulation**: LibPDF — text extraction with positions, form filling, signing
 
-**Tool Selection**:
+**Tool selection:**
 
-| Input | Tool | Output | Best For |
+| Input | Tool | Output | Use when |
 |-------|------|--------|----------|
-| Screenshot / photo / sign | PaddleOCR | Raw text + bounding boxes | Scene text, UI captures, varied lighting/angles |
-| Complex PDF (tables, columns, formulas) | MinerU | Markdown / JSON | LLM-ready document conversion |
-| Invoice / receipt / form | Docling + ExtractThinker | Structured JSON | Schema-validated extraction with PII redaction |
-| Any image (quick, local) | GLM-OCR (Ollama) | Plain text | Privacy-sensitive, no install overhead |
-| PDF text + positions | LibPDF | Text with coordinates | Form filling, signing, PDF manipulation |
-| Simple text PDF | Pandoc | Markdown | Fast conversion, no GPU needed |
-| Document understanding (VLM) | PaddleOCR-VL | Structured understanding | Complex document reasoning, local |
+| Screenshot / photo / sign | PaddleOCR | Raw text + bounding boxes | You need scene-text accuracy, UI capture support, or varied lighting / angles |
+| Complex PDF (tables, columns, formulas) | MinerU | Markdown / JSON | You need LLM-ready document conversion |
+| Invoice / receipt / form | Docling + ExtractThinker | Structured JSON | You need schema validation or PII redaction |
+| Any image (quick, local) | GLM-OCR (Ollama) | Plain text | You need a private local fallback with minimal setup |
+| PDF text + positions | LibPDF | Text with coordinates | You need form filling, signing, or PDF manipulation |
+| Simple text PDF | Pandoc | Markdown | You need the fastest text-only conversion |
+| Document understanding (VLM) | PaddleOCR-VL | Structured understanding | You need local document understanding, not plain OCR |
 
-**Subagents**:
+**Subagents:**
 
 | File | Purpose |
 |------|---------|
@@ -51,46 +51,36 @@ tools:
 
 ## Tool Profiles
 
-| Tool | Stars / License | Strengths | Weaknesses | Do NOT use when |
-|------|----------------|-----------|------------|-----------------|
-| **PaddleOCR** (Baidu) | 71k / Apache-2.0 | Best scene text accuracy; bounding boxes; PP-StructureV3 tables; PaddleOCR-VL (0.9B); native MCP server (v3.1.0+); 100+ languages | ~500MB PaddlePaddle dep; not for doc-to-markdown | PDF-to-markdown → MinerU; structured invoices → Docling; PDF forms → LibPDF |
-| **MinerU** (OpenDataLab) | 53k / AGPL-3.0 | Layout-aware (multi-column, tables, formulas); LaTeX conversion; strips headers/footers; 109 languages; JSON with reading order; multiple backends (pipeline/hybrid/VLM) | PDF-only; AGPL copyleft; heavier hybrid/VLM backends | Screenshot OCR → PaddleOCR; schema extraction → Docling; simple text PDFs → Pandoc |
-| **Docling + ExtractThinker** (IBM) | 52.7k / MIT | Schema-mapped Pydantic output; multi-format (PDF, DOCX, PPTX, XLSX, HTML, images); PII redaction (Presidio); local/edge/cloud privacy modes; UK VAT schemas + QuickFile; MCP server | Requires LLM; 3-component setup; slower than pure OCR | Simple screenshot text → PaddleOCR/GLM-OCR; PDF-to-markdown → MinerU; PDF manipulation → LibPDF |
-| **GLM-OCR** (THUDM/Ollama) | N/A / MIT | Zero-config (`ollama pull glm-ocr`); fully local; Peekaboo screen capture integration | No bounding boxes; no structured JSON; less accurate on scene text; ~2GB model | Bounding boxes → PaddleOCR; structured extraction → Docling; max scene accuracy → PaddleOCR |
-| **LibPDF** | N/A / Commercial | Text + coordinate positions; form filling; digital signatures (PAdES); handles malformed PDFs; ~5MB, no Python/GPU | PDF-only; cannot OCR scanned/image PDFs; no layout-aware markdown | Scanned PDFs → MinerU; image OCR → PaddleOCR; structured extraction → Docling |
+| Tool | Fit | Limits | Avoid when |
+|------|-----|--------|------------|
+| **PaddleOCR** (Baidu, 71k, Apache-2.0) | Best scene-text accuracy; bounding boxes; PP-StructureV3 tables; PaddleOCR-VL (0.9B); native MCP server (v3.1.0+); 100+ languages | ~500MB PaddlePaddle dependency; not for doc-to-markdown | PDF-to-markdown → MinerU; structured invoices → Docling; PDF forms → LibPDF |
+| **MinerU** (OpenDataLab, 53k, AGPL-3.0) | Layout-aware multi-column, tables, formulas; LaTeX conversion; strips headers/footers; 109 languages; JSON with reading order; pipeline / hybrid / VLM backends | PDF-only; AGPL copyleft; heavier hybrid/VLM backends | Screenshot OCR → PaddleOCR; schema extraction → Docling; simple text PDFs → Pandoc |
+| **Docling + ExtractThinker** (IBM, 52.7k, MIT) | Schema-mapped Pydantic output; PDF/DOCX/PPTX/XLSX/HTML/images; PII redaction (Presidio); local/edge/cloud privacy modes; UK VAT schemas + QuickFile; MCP server | Requires an LLM; three-component setup; slower than pure OCR | Simple screenshot text → PaddleOCR/GLM-OCR; PDF-to-markdown → MinerU; PDF manipulation → LibPDF |
+| **GLM-OCR** (THUDM/Ollama, MIT) | Zero-config via `ollama pull glm-ocr`; fully local; Peekaboo screen capture integration | No bounding boxes; no structured JSON; weaker on scene text; ~2GB model | Bounding boxes or max scene accuracy → PaddleOCR; structured extraction → Docling |
+| **LibPDF** (Commercial) | Text with coordinate positions; form filling; digital signatures (PAdES); handles malformed PDFs; ~5MB, no Python/GPU | PDF-only; cannot OCR scanned/image PDFs; no layout-aware markdown | Scanned PDFs → MinerU; image OCR → PaddleOCR; structured extraction → Docling |
 
 ## Common Workflows
 
-### Screenshot to Text
-
 ```bash
+# Screenshot to text
 # PaddleOCR (best accuracy, bounding boxes)
 paddleocr-helper.sh ocr screenshot.png
 
 # GLM-OCR (simplest, Ollama required)
 ollama run glm-ocr "Extract all text" --images screenshot.png
-```
 
-### PDF to LLM-Ready Markdown
-
-```bash
+# PDF to LLM-ready markdown
 # MinerU (complex layouts, tables, formulas)
 mineru -p document.pdf -o output_dir
 
 # Pandoc (simple text PDFs, fastest)
 pandoc document.pdf -o document.md
-```
 
-### Invoice to Structured JSON
-
-```bash
+# Invoice to structured JSON
 # Docling + ExtractThinker pipeline
 document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --privacy local
-```
 
-### Batch Image OCR
-
-```bash
+# Batch image OCR
 # PaddleOCR (100+ languages, bounding boxes)
 for img in ./images/*.png; do paddleocr-helper.sh ocr "$img"; done
 
@@ -100,14 +90,8 @@ for img in ./images/*.png; do ollama run glm-ocr "Extract all text" --images "$i
 
 ## Integration Points
 
-```text
-Image/Screenshot ──→ PaddleOCR ──→ Raw text ──→ LLM analysis
-                                       │
-                                       └──→ ExtractThinker ──→ Structured JSON
-
-PDF ──→ MinerU ──→ Markdown ──→ LLM context window
-    └──→ Docling ──→ ExtractThinker ──→ Structured JSON ──→ QuickFile
-
-PaddleOCR MCP Server ──→ Claude Desktop / Agent framework
-Docling MCP Server   ──→ Claude Desktop / Agent framework
-```
+- Image / screenshot → PaddleOCR → raw text → LLM analysis
+- Image / screenshot → PaddleOCR → ExtractThinker → structured JSON
+- PDF → MinerU → markdown → LLM context window
+- PDF → Docling → ExtractThinker → structured JSON → QuickFile
+- PaddleOCR MCP server and Docling MCP server both plug into Claude Desktop / the agent framework


### PR DESCRIPTION
## Summary
- tighten the OCR selection matrix so tool choice reads as direct operator guidance
- condense tool profiles, workflows, and integration notes while preserving commands and decision criteria

## Testing
- markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/tools/ocr/overview.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Runtime Testing
- self-assessed: low-risk docs-only change; no runtime behavior changed

Closes #14146


---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.