### PR TITLE
GH#14453: tighten cheatsheet-config.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -778,7 +778,8 @@
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
       "hash": "8eb705ea0ac51157ecf6c3c93a6f3898b754f1233f3257c3e5e33d65837d71c3",
-      "at": "2026-03-31T00:00:00Z"
+      "at": "2026-03-31T00:00:00Z",
+      "pr": 14577
     },
     ".agents/services/database/postgres-drizzle-skill/schema.md": {
       "hash": "ed1952db54651cd46710ca9cfa4db950635e42a6",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -776,6 +776,10 @@
       "at": "2026-03-28T10:27:24Z",
       "pr": 11709
     },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
+      "hash": "8eb705ea0ac51157ecf6c3c93a6f3898b754f1233f3257c3e5e33d65837d71c3",
+      "at": "2026-03-31T00:00:00Z"
+    },
     ".agents/services/database/postgres-drizzle-skill/schema.md": {
       "hash": "ed1952db54651cd46710ca9cfa4db950635e42a6",
       "at": "2026-03-28T10:27:24Z",

--- a/.agents/services/database/postgres-drizzle-skill/cheatsheet-config.md
+++ b/.agents/services/database/postgres-drizzle-skill/cheatsheet-config.md
@@ -26,25 +26,20 @@ export default defineConfig({
 });
 ```
 
-## Connection Setup
-
-### postgres.js (Recommended)
+## Connection
 
 ```typescript
+// postgres.js (recommended)
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
 
 const client = postgres(process.env.DATABASE_URL!);
 export const db = drizzle(client, { schema });
-```
 
-### node-postgres
-
-```typescript
+// node-postgres
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
-import * as schema from './schema';
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 export const db = drizzle(pool, { schema });


### PR DESCRIPTION
## Summary

- Merged `## Connection Setup` with two H3 subsections (`### postgres.js (Recommended)`, `### node-postgres`) into a single `## Connection` section with one code block and inline comments
- Removed redundant `import * as schema` from node-postgres example (already shown in postgres.js block above)
- All 6 drizzle-kit commands, config example, and both connection patterns preserved
- 51 → 46 lines (10% reduction)

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** `self-assessed` — markdown lint clean, all code blocks and commands preserved

## Content Preservation Check

| Element | Before | After |
|---------|--------|-------|
| drizzle-kit commands | 6 | 6 |
| drizzle.config.ts example | ✓ | ✓ |
| postgres.js connection | ✓ | ✓ |
| node-postgres connection | ✓ | ✓ |
| `(Recommended)` annotation | H3 heading | inline comment |

Closes #14453

---
[aidevops.sh](https://aidevops.sh) v3.5.478 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized PostgreSQL connection documentation with improved clarity and consistency in code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->