### PR TITLE
GH#14033: tighten toon.md - remove redundant description

### DIFF
--- a/.agents/tools/context/toon.md
+++ b/.agents/tools/context/toon.md
@@ -29,8 +29,6 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-**Token-Oriented Object Notation (TOON)** — compact, human-readable, schema-aware serialization for LLM prompts.
-
 ## Format Examples
 
 ### Simple Object


### PR DESCRIPTION
## Summary

- Remove redundant standalone description paragraph from `.agents/tools/context/toon.md` that duplicated the Quick Reference Purpose bullet
- 128 → 126 lines; all code blocks, URLs, command examples, and tables preserved
- Classification: instruction doc (not reference corpus) — prose tightening applies

## Changes

- `.agents/tools/context/toon.md`: removed 2 lines (description + blank line)

## Runtime Testing

Risk level: **Low** — agent doc only, no code or scripts changed. Self-assessed.

## Verification

- All code blocks present: toon format examples (3), bash commands, LLM preamble, config command ✓
- URLs preserved: https://toonformat.dev, https://github.com/toon-format/toon ✓
- Tables preserved: Token Efficiency, Use Cases ✓
- No task ID refs in this file ✓

Closes #14033

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-sonnet-4-6