### PR TITLE
GH#14582: tighten security scan command doc

### DIFF
--- a/.agents/scripts/commands/security-scan.md
+++ b/.agents/scripts/commands/security-scan.md
@@ -6,53 +6,26 @@ mode: subagent
 
 Fast security check before commits. Target: $ARGUMENTS
 
+Run every check below and report findings with severity and location.
+
 ## Process
 
-Run each step, report findings with severity and location.
+1. **Secretlint** — credential detection (API keys, private keys, hardcoded passwords for AWS, GCP, GitHub, OpenAI, etc.): `./.agents/scripts/secretlint-helper.sh scan`
+2. **Ferret** — AI CLI config security (prompt injection, jailbreaks): `./.agents/scripts/security-helper.sh ferret`
+3. **Quick code scan** — staged/diff analysis (command injection, SQL injection): `./.agents/scripts/security-helper.sh analyze staged`
+4. **MCP audit** — prompt injection in MCP tool descriptions: `./.agents/scripts/mcp-audit-helper.sh scan`
+5. **Secret hygiene + supply chain** — plaintext secrets (AWS, GCP, Azure, k8s, Docker, npm, PyPI, SSH), `.pth` IoCs, unpinned deps (`>=` in requirements.txt, `^` in package.json), and `uvx`/`npx` auto-download risk in MCP configs: `aidevops security scan` or `./.agents/scripts/secret-hygiene-helper.sh scan`
 
-1. **Secretlint** — credential detection (API keys, private keys, hardcoded passwords for AWS, GCP, GitHub, OpenAI, etc.):
+For deeper analysis, use `/security-analysis` for taint analysis, git history scanning, and detailed remediation.
 
-   ```bash
-   ./.agents/scripts/secretlint-helper.sh scan
-   ```
+## CLI reference
 
-2. **Ferret** — AI CLI config security (prompt injection, jailbreaks):
-
-   ```bash
-   ./.agents/scripts/security-helper.sh ferret
-   ```
-
-3. **Quick code scan** — staged/diff analysis (command injection, SQL injection):
-
-   ```bash
-   ./.agents/scripts/security-helper.sh analyze staged
-   ```
-
-4. **MCP audit** — prompt injection in MCP tool descriptions:
-
-   ```bash
-   ./.agents/scripts/mcp-audit-helper.sh scan
-   ```
-
-5. **Secret hygiene & supply chain** — plaintext secrets (AWS, GCP, Azure, k8s, Docker, npm, PyPI, SSH), `.pth` IoCs, unpinned deps (`>=` in requirements.txt, `^` in package.json), `uvx`/`npx` auto-download risk in MCP configs:
-
-   ```bash
-   aidevops security scan
-   # Or directly: ./.agents/scripts/secret-hygiene-helper.sh scan
-   ```
-
-For deeper analysis, use `/security-analysis` (full taint analysis, git history scanning, detailed remediation).
-
-## CLI Reference
-
-```bash
-aidevops security              # ALL checks (posture + hygiene + supply chain)
-aidevops security posture      # Interactive setup (gopass, gh, SSH, secretlint)
-aidevops security status       # Combined posture + hygiene summary
-aidevops security scan         # Secret hygiene & supply chain only
-aidevops security scan-pth     # Python .pth file audit only
-aidevops security scan-secrets # Plaintext secret locations only
-aidevops security scan-deps    # Unpinned dependency check only
-aidevops security check        # Per-repo security posture assessment
-aidevops security dismiss <id> # Dismiss advisory after action
-```
+- `aidevops security` — all checks: posture, hygiene, supply chain
+- `aidevops security posture` — interactive setup: gopass, gh, SSH, secretlint
+- `aidevops security status` — combined posture + hygiene summary
+- `aidevops security scan` — secret hygiene + supply chain only
+- `aidevops security scan-pth` — Python `.pth` audit only
+- `aidevops security scan-secrets` — plaintext secret locations only
+- `aidevops security scan-deps` — unpinned dependency check only
+- `aidevops security check` — per-repo security posture assessment
+- `aidevops security dismiss <id>` — dismiss advisory after action


### PR DESCRIPTION
## Summary
- compress `/security-scan` into a shorter command card while keeping every scan step and CLI entry
- switch process instructions from fenced blocks to inline commands so the workflow is faster to read in agent context
- keep the deeper-analysis handoff to `/security-analysis` and preserve the unified security CLI reference

## Testing
- `bash .agents/scripts/markdown-formatter.sh check ".agents/scripts/commands/security-scan.md"`
- `wc -l .agents/scripts/commands/security-scan.md` → `31`

## Runtime Testing
- self-assessed (low risk docs-only change)

Closes #14582


---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 60,437 tokens on this as a headless worker.