### PR TITLE
GH#13865: tighten remotion extract frames doc

### DIFF
--- a/.agents/tools/video/remotion-extract-frames.md
+++ b/.agents/tools/video/remotion-extract-frames.md
@@ -8,11 +8,9 @@ metadata:
 
 # Extracting frames from videos
 
-Use [Mediabunny](https://mediabunny.dev) to extract frames at specific timestamps. Useful for thumbnails, filmstrips, and per-frame processing.
+Use [Mediabunny](https://mediabunny.dev) to extract frames at specific timestamps for thumbnails, filmstrips, and per-frame processing.
 
-## API
-
-### `extractFrames(props)` — copy-paste into any project
+## `extractFrames(props)`
 
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
@@ -88,9 +86,9 @@ await extractFrames({
 });
 ```
 
-## Filmstrip (dynamic timestamps via callback)
+## Filmstrip (dynamic timestamps)
 
-Pass a callback to `timestampsInSeconds` to compute timestamps from video metadata:
+Use a callback when timestamps depend on video metadata:
 
 ```tsx
 const canvasWidth = 500;
@@ -119,7 +117,7 @@ await extractFrames({
 
 ## Cancellation and timeout
 
-Pass `signal` for cancellation. For simple timeout: `setTimeout(() => controller.abort(), ms)`. For racing with a cleanup-safe timeout:
+Pass `signal` to support cancellation. For a timeout, abort the controller and race extraction against a rejecting promise:
 
 ```tsx
 const controller = new AbortController();


### PR DESCRIPTION
## Summary
- remove redundant structure from the Remotion frame extraction doc by collapsing the API heading and tightening section copy
- keep the existing code examples and parameter details unchanged so the guide stays behaviorally equivalent

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Verification:
  - markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/tools/video/remotion-extract-frames.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)
  - reviewed the markdown diff to confirm the code examples, parameter table, and links stayed intact

## Risks
- low: prose-only documentation change in a single agent doc

Closes #13865


---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.