### PR TITLE
GH#14547: tighten web analytics patterns doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md
@@ -1,37 +1,19 @@
 ## Common Use Cases
 
-1. **Core Web Vitals triage** — use the LCP debug view to map slow pages back to the element that needs optimization.
+1. **LCP triage** — open Core Web Vitals → LCP → Debug View, inspect the reported selector, then optimize that element.
 
    ```typescript
-   // 1. Enable Web Analytics
-   // 2. Dashboard → Core Web Vitals → LCP
-   // 3. Debug View lists the top 5 problematic elements
-   document.querySelector('.hero-image') // Example selector from Debug View
-   // 4. Optimize the element (lazy loading, compression, preloading)
+   document.querySelector('.hero-image') // Selector copied from Debug View
    ```
 
-2. **Human-only reporting** — enable bot exclusion before comparing traffic or engagement so the dashboard reflects real visitors.
+2. **Human-only reporting** — set `Exclude Bots: Yes` before comparing traffic or engagement trends.
+
+3. **Multi-site comparisons** — use the `Site` dimension to compare proxied properties (unlimited) and up to 10 non-proxied sites.
 
    ```text
-   Dashboard filters:
-   - Exclude Bots: Yes
-   ```
-
-3. **Multi-site comparisons** — track several properties in one account, then pivot on the `Site` dimension to compare them.
-
-   ```text
-   Proxied sites: Unlimited
-   Non-proxied sites: Up to 10
-
-   Site dimension:
+   Site:
    - example.com
    - blog.example.com
    ```
 
-4. **Audience segmentation** — combine geography and device filters to isolate a cohort before investigating trends.
-
-   ```text
-   Filter by:
-   - Country: United States
-   - Device type: Mobile
-   ```
+4. **Segment analysis** — combine filters such as `Country: United States` and `Device type: Mobile` before investigating behavior.


### PR DESCRIPTION
## Summary
- tighten the Web Analytics patterns doc into four concise, scannable use cases
- keep the key workflow hints for LCP triage, bot exclusion, site comparison, and segment analysis while removing tutorial-style repetition

## Runtime Testing
- self-assessed: docs-only change
- `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md"`

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md`

Closes #14547
---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 15m on this as a headless worker.