### PR TITLE
GH#14581: tighten branch workflow doc

### DIFF
--- a/.agents/workflows/branch.md
+++ b/.agents/workflows/branch.md
@@ -18,9 +18,10 @@ tools:
 
 ## Quick Reference
 
-- **Resume first**: `git branch -a | rg "(feature|bugfix|hotfix|refactor|chore|experiment)/"`
-- **Continue WIP**: `git checkout <branch>`
-- **New work**: branch from updated `main`
+- **Resume first**: `git worktree list` or `wt list`
+- **Preferred start**: `wt switch -c {type}/{name}` from the canonical repo on `main`
+- **Fallback**: `worktree-helper.sh add {type}/{name}`
+- **Canonical repo rule**: keep `~/Git/{repo}/` on `main`; do branch work in the linked worktree path
 
 | Task Type | Branch Prefix | Subagent |
 |-----------|---------------|----------|
@@ -34,45 +35,45 @@ tools:
 
 **Branch naming**: `{type}/{short-description}` — lowercase, hyphenated, ~50 chars max. Example: `feature/user-dashboard`, `bugfix/123-login-timeout`; releases use semver (`release/1.2.0`).
 
-**Mandatory start**:
+**Start**: `wt switch -c {type}/{description}`. Fallback: `worktree-helper.sh add {type}/{description}`.
 
-```bash
-git checkout main && git pull origin main && git checkout -b {type}/{description}
-```
+**Task status**: move the task to `## In Progress`, add `started:<ISO>`, then `beads-sync-helper.sh push`.
 
-**Task status**: move task to `## In Progress`, add `started:`, then `beads-sync-helper.sh push`.
-
-**Lifecycle**: Create → Develop → Preflight → Push → PR → Review → Merge → Cleanup. Add Version/Release/Postflight only when shipping a release.
+**Lifecycle**: Create → Develop → Preflight → Push → PR → Review → Merge → Cleanup. Add Version → Release → Postflight only for releases.
 
 <!-- AI-CONTEXT-END -->
 
-Read `workflows/git-workflow.md` before branch creation for issue URL handling, fork detection, and new repo setup.
-
-**Names from planning files**: slugify the task description — lowercase, spaces→hyphens, special chars removed. See `git-workflow.md` for full rules.
+Read `workflows/git-workflow.md` before branch creation for issue URL handling, fork detection, commit/PR rules, and repo setup. Read `workflows/worktree.md` for worktree creation and cleanup. Names from planning files: slugify the task description — lowercase, spaces→hyphens, special chars removed.
 
 ## Branch Lifecycle
 
 | Stage | Action | Command / Agent | Required |
 |-------|--------|-----------------|----------|
-| 1. Create | Branch from `main` | `git checkout main && git pull origin main && git checkout -b {type}/{desc}` | Yes |
+| 1. Create | Create linked worktree from `main` | `wt switch -c {type}/{desc}` or `worktree-helper.sh add {type}/{desc}` | Yes |
 | 2. Develop | Conventional commits | `branch/{type}.md`, domain agents | Yes |
 | 3. Preflight | Local quality checks | `.agents/scripts/linters-local.sh --fast` → `workflows/preflight.md` | Yes |
 | 4. Version | Bump for releases | `.agents/scripts/version-manager.sh bump [major\|minor\|patch]` → `workflows/version-bump.md` | Releases only |
 | 5. Push | Remote backup | `git push -u origin HEAD` | Yes |
 | 6. PR | Create PR/MR | `gh pr create --fill` / `glab mr create --fill` → `workflows/pr.md` | Yes |
 | 7. Review | Address feedback | `git add . && git commit -m "fix: ..." && git push` → `workflows/code-audit-remote.md` | Yes |
-| 8. Merge | Squash merge | `gh pr merge --squash --delete-branch` | Yes |
+| 8. Merge | Squash merge | `gh pr merge --squash` | Yes |
 | 9. Release | Tag and publish | `.agents/scripts/version-manager.sh release [major\|minor\|patch]` → `workflows/release.md` | Releases only |
 | 10. Postflight | Verify CI/CD | `gh run watch $(gh run list --limit=1 --json databaseId -q '.[0].databaseId') --exit-status` → `workflows/postflight.md` | Releases only |
-| 11. Cleanup | Delete branch | `git branch -d {name}` / `git push origin --delete {name}` if needed | Yes |
+| 11. Cleanup | Remove merged worktree and delete branch if needed | `worktree-helper.sh remove {type}/{desc}` / `git push origin --delete {name}` | Yes |
 
-On branch creation: move the task from `## Ready`/`## Backlog` to `## In Progress`, add `started:<ISO>`, then `beads-sync-helper.sh push`.
+## Worktree Rules
+
+- Prefer worktrees over `git checkout -b` in the canonical repo; the next session must inherit `main`, not a task branch.
+- Talk about the worktree path (`~/Git/{repo}-{type}-{slug}/`), not "switching the main repo to a branch".
+- After switching to a worktree, re-read files at the worktree path before editing.
+- Never remove a worktree you did not create unless the user explicitly asked.
 
 ## Keeping Branch Updated
 
 ```bash
-git checkout main && git pull origin main && git checkout your-branch && git merge main
-# Resolve conflicts if needed — see tools/git/conflict-resolution.md
+git fetch origin main
+git merge origin/main
+# Or rebase if the repo workflow requires it; resolve conflicts with tools/git/conflict-resolution.md
 ```
 
 ## Safety: Protecting Uncommitted Work
@@ -89,18 +90,12 @@ git stash pop   # or: git stash show -p to review on conflict
 
 ## Commit Message Standards
 
-```text
-type: brief description
-
-Detailed explanation if needed.
-Fixes #123
-```
-
-Types: `feat:` `fix:` `refactor:` `docs:` `chore:` `test:`
+Use conventional commits: `feat:` `fix:` `refactor:` `docs:` `chore:` `test:`. Include issue references when the repo workflow requires them.
 
 ## Related Workflows
 
-- `workflows/git-workflow.md` — issue URLs, fork detection, repo setup
+- `workflows/git-workflow.md` — issue URLs, commit/PR rules, repo setup
+- `workflows/worktree.md` — worktree creation, ownership, cleanup
 - `workflows/pr.md` — PR creation and review
 - `workflows/preflight.md` — quality checks before push
 - `workflows/version-bump.md`, `workflows/changelog.md` — versioning


### PR DESCRIPTION
## Summary
- Tighten `.agents/workflows/branch.md` around the current worktree-first branching workflow.
- Replace branch-in-main guidance with canonical-repo-on-main rules, worktree creation commands, and cleanup/ownership reminders.
- Trim duplicate prose while keeping branch types, lifecycle, safety notes, and related workflow pointers.

## Runtime Testing
- Level: self-assessed (low-risk documentation change)
- Verification: `bunx markdownlint-cli2 ".agents/workflows/branch.md"`

## Testing
- `bunx markdownlint-cli2 ".agents/workflows/branch.md"`

Closes #14581

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 160,115 tokens on this as a headless worker. Overall, 17m since this issue was created.

