### PR TITLE
GH#14580: tighten agent sources private repo guide

### DIFF
--- a/.agents/aidevops/agent-sources.md
+++ b/.agents/aidevops/agent-sources.md
@@ -1,17 +1,15 @@
 # Agent Sources (Private Repos)
 
-Use agent sources when agents should live in a private Git repo but remain available framework-wide. Sync copies them into `~/.aidevops/agents/custom/<source-name>/`, so they follow `custom/` tier rules: they survive framework updates and are never overwritten by `setup.sh`.
+Use agent sources when agents should live in a private Git repo but stay available framework-wide. Sync copies them into `~/.aidevops/agents/custom/<source-name>/`, so they follow `custom/` tier rules: survive framework updates, are never overwritten by `setup.sh`, and auto-sync during `aidevops update` and `./setup.sh` after `deploy_aidevops_agents`.
 
-## Lifecycle
+## Sync Lifecycle
 
-1. Keep agents in a private repo under `.agents/`
-2. Register the repo with `aidevops sources add <path>`
-3. Run `aidevops update` or `aidevops sources sync`
-4. Synced files land in `~/.aidevops/agents/custom/<source-name>/`
-5. `mode: primary` agent docs are symlinked into `~/.aidevops/agents/` for auto-discovery
-6. `.md` files with `agent:` frontmatter are symlinked into `~/.config/opencode/command/`
-
-Automatic sync runs during `aidevops update` and `./setup.sh` after `deploy_aidevops_agents`, so the base directory already exists.
+1. Keep private agents under `.agents/` in a private Git repo.
+2. Register the repo with `aidevops sources add <path>`.
+3. Run `aidevops update` or `aidevops sources sync`.
+4. Files sync into `~/.aidevops/agents/custom/<source-name>/`.
+5. `mode: primary` docs are symlinked into `~/.aidevops/agents/` for auto-discovery.
+6. `.md` files with `agent:` frontmatter are symlinked into `~/.config/opencode/command/`.
 
 ## CLI
 
@@ -35,12 +33,7 @@ Sync classifies `.md` files by YAML frontmatter:
 | `agent: <Name>` | Slash command | Sync + symlink to `~/.config/opencode/command/` |
 | none / other | Regular file | Sync only |
 
-The directory's main agent doc is the file whose name matches the directory (for example, `my-agent/my-agent.md`); its role is determined by `mode:`. Other `.md` files with `agent:` frontmatter become slash commands.
-
-Collision handling:
-
-- Slash command name conflicts append the source slug, for example `/run-pipeline-my-private-agents`
-- Primary agents that would overwrite core agents backed by real files, not symlinks, are skipped with a warning
+The main agent doc is the file whose name matches its directory, for example `my-agent/my-agent.md`; `mode:` decides whether it is primary or subagent. Other `.md` files with `agent:` frontmatter become slash commands. Slash command conflicts append the source slug, for example `/run-pipeline-my-private-agents`. Primary agents that would overwrite core agents backed by real files, not symlinks, are skipped with a warning.
 
 ## Layout
 
@@ -95,12 +88,11 @@ Source metadata lives in `~/.aidevops/agents/configs/agent-sources.json`:
 
 ## Creating a Private Agent Repo
 
-1. Create a Git repo with a `.agents/` directory
-2. Add an agent subdirectory with `<name>.md`; use `mode: primary` if it should auto-discover
-3. Add slash commands as `.md` files with `agent: <Name>` frontmatter
-4. Add any helper `.sh` scripts needed for CLI automation
-5. Follow `tools/build-agent/build-agent.md`
-6. Register the repo with `aidevops sources add <path>`
+1. Create a Git repo with a `.agents/` directory.
+2. Add an agent subdirectory with `<name>.md`; use `mode: primary` if it should auto-discover.
+3. Add slash commands as `.md` files with `agent: <Name>` frontmatter and any helper `.sh` scripts needed for CLI automation.
+4. Follow `tools/build-agent/build-agent.md`.
+5. Register the repo with `aidevops sources add <path>`.
 
 ### Slash Command Format
 


### PR DESCRIPTION
## Summary
- tighten `.agents/aidevops/agent-sources.md` so the private-repo sync rules are stated more directly
- collapse collision and repo-creation guidance without changing the underlying workflow or examples
- keep command examples, layout reference, and config schema intact while reducing doc length from 116 to 108 lines

## Testing
- `bunx markdownlint-cli2 ".agents/aidevops/agent-sources.md"`

## Runtime Testing
- Level: self-assessed
- Reason: low-risk documentation-only change

Closes #14580

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 1s on this as a headless worker.