### PR TITLE
GH#14183: tighten code quality setup guide

### DIFF
--- a/.agents/tools/code-review/setup.md
+++ b/.agents/tools/code-review/setup.md
@@ -18,92 +18,64 @@ tools:
 
 ## Quick Reference
 
-- 4 platforms: CodeRabbit (AI reviews), CodeFactor (grading), Codacy (security), SonarCloud (enterprise)
-- Setup time: ~5 min each, all use GitHub OAuth
-- CodeRabbit: coderabbit.ai -> Add repo -> Enable PR reviews
-- CodeFactor: codefactor.io -> Add repo -> Enable GitHub Checks
-- Codacy: app.codacy.com -> Import repo -> Uses .codacy.yml
-- SonarCloud: sonarcloud.io -> Create org -> Import project -> Get token -> Add `SONAR_TOKEN` secret
-- Config files: .codacy.yml, sonar-project.properties (already in repo)
-- Expected grades: CodeFactor A+, Codacy A, SonarCloud passed gate
-- Troubleshooting: Check secrets, webhook configs, repo permissions
+- Platforms: CodeRabbit (AI PR review), CodeFactor (grade/trends), Codacy (quality/security), SonarCloud (quality gate)
+- Setup time: ~5 minutes per platform, all via GitHub OAuth
+- Existing config files: `.codacy.yml`, `sonar-project.properties`
+- Targets: CodeFactor A+, Codacy A, SonarCloud passed gate, CodeRabbit useful PR feedback
+- Deep dives: `coderabbit.md`, `codacy.md`, `tools.md`, `.agents/scripts/sonarcloud-cli.sh`
+
+| Platform | Setup | Coverage |
+|---|---|---|
+| CodeRabbit | <https://coderabbit.ai/> → add repo → enable automatic PR reviews | AI review, security, best practices, performance |
+| CodeFactor | <https://www.codefactor.io/> → add repo → enable GitHub Checks | A-F grade, cyclomatic complexity, technical debt, trends |
+| Codacy | <https://app.codacy.com/> → import repo; uses `.codacy.yml` | Security scanning, quality metrics, test coverage, standards |
+| SonarCloud | <https://sonarcloud.io/> → create org → import project → add `SONAR_TOKEN` GitHub secret | Security hotspots, bugs, code smells, duplication, quality gate |
 
 <!-- AI-CONTEXT-END -->
 
-## Platform Setup
+## Setup Notes
 
-### 1. CodeRabbit (AI code reviews)
+### CodeRabbit
 
-1. Sign up at <https://coderabbit.ai/> with GitHub
-2. Authorize access, add repository
-3. Enable automatic PR reviews
+1. Sign in with GitHub.
+2. Add the repository.
+3. Enable automatic PR reviews.
 
-### 2. CodeFactor (quality grading)
+### CodeFactor
 
-1. Sign up at <https://www.codefactor.io/> with GitHub
-2. Add repository
-3. Enable GitHub Checks for PR integration
+1. Sign in with GitHub.
+2. Add the repository.
+3. Enable GitHub Checks so PRs show the grade.
 
-### 3. Codacy (security analysis)
+### Codacy
 
-1. Sign up at <https://app.codacy.com/> with GitHub
-2. Import repository — uses the `.codacy.yml` already in the repo
+1. Sign in with GitHub.
+2. Import the repository.
+3. Confirm `.codacy.yml` was detected.
 
-### 4. SonarCloud (enterprise analysis)
+### SonarCloud
 
-1. Sign up at <https://sonarcloud.io/> with GitHub
-2. Create organization linked to your GitHub account
-3. Import project
-4. Generate token: My Account > Security > Generate Token
-5. Add GitHub secret: repo Settings > Secrets and variables > Actions > `SONAR_TOKEN`
-6. Verify: push a commit, check Actions tab for successful analysis
-
-## Analysis Coverage
-
-| Platform | Focus areas |
-|----------|-------------|
-| CodeRabbit | AI code reviews, security vulnerabilities, best practices, performance |
-| CodeFactor | Quality grading (A-F), cyclomatic complexity, technical debt, trends |
-| Codacy | Security scanning, quality metrics, test coverage, coding standards |
-| SonarCloud | Security hotspots, code smells, bug detection, duplication analysis |
+1. Sign in with GitHub.
+2. Create an organization linked to the GitHub account.
+3. Import the project.
+4. Generate a token from `My Account > Security > Generate Token`.
+5. Add `SONAR_TOKEN` under `Settings > Secrets and variables > Actions`.
+6. Push a commit and confirm the SonarCloud workflow succeeds.
 
 ## README Badges
 
-```markdown
-[![CodeRabbit](https://img.shields.io/badge/CodeRabbit-AI%20Reviews-blue)](https://coderabbit.ai)
-```
-
-```markdown
-[![CodeFactor](https://www.codefactor.io/repository/github/marcusquinn/aidevops/badge)](https://www.codefactor.io/repository/github/marcusquinn/aidevops)
-```
-
-```markdown
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/[PROJECT_ID])](https://app.codacy.com/gh/marcusquinn/aidevops/dashboard)
-```
-
-```markdown
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_aidevops&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_aidevops)
-```
-
-## Expected Quality Scores
-
-| Platform | Target | Notes |
-|----------|--------|-------|
-| CodeFactor | A+ | Code organization |
-| Codacy | A | Shell scripts and docs |
-| SonarCloud | Passed gate | Zero security issues |
-| CodeRabbit | Positive feedback | Well-structured framework |
+| Platform | Badge |
+|---|---|
+| CodeRabbit | `[![CodeRabbit](https://img.shields.io/badge/CodeRabbit-AI%20Reviews-blue)](https://coderabbit.ai)` |
+| CodeFactor | `[![CodeFactor](https://www.codefactor.io/repository/github/marcusquinn/aidevops/badge)](https://www.codefactor.io/repository/github/marcusquinn/aidevops)` |
+| Codacy | `[![Codacy Badge](https://app.codacy.com/project/badge/Grade/[PROJECT_ID])](https://app.codacy.com/gh/marcusquinn/aidevops/dashboard)` |
+| SonarCloud | `[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_aidevops&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_aidevops)` |
 
 ## Troubleshooting
 
-**SonarCloud not running:**
-Check `SONAR_TOKEN` secret is set, verify organization setup, check `sonar-project.properties`.
-
-**CodeRabbit not reviewing:**
-Ensure repo is added, check GitHub app permissions, verify PR triggers.
-
-**CodeFactor not updating:**
-Check repository connection, verify GitHub webhook, ensure repo is public or authorized.
-
-**Codacy analysis issues:**
-Check `.codacy.yml` configuration, verify import succeeded, check supported file types.
+| Problem | Checks |
+|---|---|
+| SonarCloud not running | Verify `SONAR_TOKEN`, organization setup, and `sonar-project.properties`. |
+| CodeRabbit not reviewing | Ensure the repo is connected, app permissions are granted, and PR triggers are enabled. |
+| CodeFactor not updating | Check the repo connection, webhook/GitHub Checks status, and repo authorization. |
+| Codacy analysis issues | Check `.codacy.yml`, confirm import succeeded, and verify the file types are supported. |


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/code-review/setup.md` into a shorter setup reference centered on setup paths, coverage, and troubleshooting
- replace repeated prose and separate badge blocks with compact tables while preserving existing service URLs, config file references, and badge snippets
- add pointers to deeper service-specific docs so the setup guide stays concise

## Runtime Testing
- Level: self-assessed (docs-only change)
- Verification: `npx markdownlint-cli2 ".agents/tools/code-review/setup.md"`

Closes #14183
---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m on this as a headless worker.