### PR TITLE
GH#14579: tighten query fan-out research doc

### DIFF
--- a/.agents/seo/query-fanout-research.md
+++ b/.agents/seo/query-fanout-research.md
@@ -15,73 +15,73 @@ tools:
 
 # Query Fan-Out Research
 
-Simulate how AI systems decompose broad prompts into sub-queries, then use that map to guide content coverage.
+Model how AI systems split a broad prompt into sub-queries, then use that map to find coverage gaps.
 
 ## Quick Reference
 
-- Purpose: expose hidden sub-query themes behind user intents
+- Purpose: expose hidden sub-query themes behind one user intent
 - Inputs: seed intent, market context, existing page set
-- Outputs: fan-out map, priority tiers, coverage matrix, implementation backlog
-
-## Core Model
-
-Treat fan-out as a 3-stage retrieval model. Frontier AI systems (observed in GPT-5.4-thinking and similar) often generate 10+ sub-queries from one prompt, including `site:` queries that target specific domains directly.
-
-1. **Broad discovery**: open-web category and comparison queries such as `best ATS for SMB [year]` or `[BrandA] vs [BrandB] applicant tracking`
-2. **Site-specific deep-dive**: domain-scoped queries such as `site:brand.com pricing`, `site:brand.com integrations`, `site:brand.com enterprise features`
-3. **Third-party validation**: independent checks such as `site:g2.com brand review`, `site:capterra.com brand pricing`, `site:trustradius.com brand alternatives`
-
-Predict which stage each branch needs before content production. Product claims usually need Stage 2; trust and risk claims usually need Stage 3.
+- Outputs: fan-out map, priority tiers, coverage matrix, remediation backlog
 
 ## Workflow
 
-### 1) Generate theme branches
+### 1) Build theme branches
 
 - Start with one core user intent
-- Produce 3-7 thematic branches (selection criteria, trust checks, risk checks, alternatives, constraints)
-- Keep each branch as a distinct retrieval objective
+- Produce 3-7 distinct branches such as selection criteria, trust, risk, alternatives, and constraints
+- Keep each branch as its own retrieval objective
 
-### 2) Create actionable sub-queries
+### 2) Generate sub-queries
 
-- Generate sub-queries per theme with clear purpose tags
-- Tag each sub-query: high, medium, low priority
-- Include common modifiers: location, budget, urgency, compliance, integration
-- Classify each sub-query by retrieval scope:
-  - **Open-web**: discovery-stage queries influenced by traditional SEO ranking
-  - **Domain-scoped**: `site:yourdomain.com` queries where the model has already chosen your domain and is extracting detail; content architecture and on-site searchability determine success
-  - **Third-party validation**: `site:g2.com` or `site:capterra.com` queries where review platform profiles, not your site, determine retrieval
+- Write sub-queries per branch with a clear purpose tag
+- Assign priority: high, medium, low
+- Include common modifiers where relevant: location, budget, urgency, compliance, integration
 
-### 3) Map pages to branches
+### 3) Classify retrieval stage and scope
 
-- Link each sub-query to the best existing page
-- Mark branch coverage: complete, partial, missing
-- Tag each branch by likely retrieval scope: open-web, domain-scoped, or third-party
-- Flag where one page tries to cover too many unrelated branches
-- Treat a branch as incomplete if it is covered on your site but missing from key review platforms; that is only 2/3 coverage
+Treat fan-out as a 3-stage retrieval model:
 
-### 4) Build remediation plan
+Frontier models often generate 10+ sub-queries from one prompt, including direct `site:` lookups.
 
-- Add concise sections for partial branches
+1. **Broad discovery**: open-web category and comparison queries such as `best ATS for SMB [year]`
+2. **Domain deep-dive**: `site:brand.com` queries such as `site:brand.com pricing` or `site:brand.com enterprise features`
+3. **Third-party validation**: `site:g2.com`, `site:capterra.com`, or `site:trustradius.com` queries that confirm claims independently
+
+Tag each branch by likely scope:
+
+- **Open-web**: model has not committed to a domain; traditional ranking still matters
+- **Domain-scoped**: model already chose a domain and is extracting detail; page architecture and self-contained answers matter more than SERP position
+- **Third-party**: model wants corroboration from review platforms or independent sources
+
+Predict required stages before content work begins: product-detail branches usually need stage 2, while trust and risk branches usually need stage 3 as well.
+
+### 4) Map coverage
+
+- Link each sub-query to the best existing page or external proof source
+- Mark coverage as complete, partial, or missing
+- Flag overloaded pages trying to answer unrelated branches
+- Treat a branch as incomplete if your site covers it but review-platform evidence does not
+
+### 5) Build remediation and validate
+
+- Add concise sections for partial high-priority branches
 - Create focused support pages only for genuinely missing high-priority branches
 - Add internal links that mirror fan-out relationships
-- Ensure domain-scoped branches have individually addressable pages with self-contained answers; the model is searching your site like a database, not reading a narrative
-- Ensure third-party branches have complete, current review platform profiles with the same canonical facts as your primary site content
+- Re-run fan-out prompts and stage-specific retrieval checks
+- Record sentence/page match quality, citation mix changes, and unresolved branches for the next sprint
 
-### 5) Validate with retrieval simulation
+## Coverage Rules
 
-- Re-run fan-out prompts and compare page/sentence match quality
-- Confirm top branches are answered by high-confidence sections
-- Record unresolved branches for the next sprint
-- Run explicit simulations for each retrieval stage and record citation/source mix shifts after updates
+- Domain-scoped branches need individually addressable pages with self-contained answers; the model is searching your site like a database
+- Important pages should match `site:yourdomain.com [category] [feature] [year]` query patterns
+- Third-party branches need current review-platform profiles with the same canonical facts as the primary site
 
 ## Guardrails
 
 - Optimize for thematic completeness, not maximal query count
-- Avoid duplicate pages targeting near-identical branches
+- Avoid duplicate pages for near-identical branches
 - Keep branch language aligned with real user phrasing
 - Re-baseline when SERP intent or product positioning changes
-- Ensure domain-scoped branches return relevant results for `site:yourdomain.com [category] [feature] [year]` query patterns
-- Verify third-party review profiles contain the same facts as primary site content
 
 ## Related Subagents
 


### PR DESCRIPTION
## Summary
- tighten `.agents/seo/query-fanout-research.md` around a single workflow-oriented structure
- merge duplicated retrieval-stage guidance into one retrieval classification step while preserving site-scoped and third-party coverage rules
- keep the doc focused on actionable branch mapping, coverage tagging, and validation

## Testing
- `bunx markdownlint-cli2 ".agents/seo/query-fanout-research.md"`

## Runtime Testing
- self-assessed: docs-only change

Closes #14579

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.