### PR TITLE
GH#14439: tighten sonnet tier model doc

### DIFF
--- a/.agents/tools/ai-assistants/models-sonnet.md
+++ b/.agents/tools/ai-assistants/models-sonnet.md
@@ -22,23 +22,23 @@ tools:
 
 # Sonnet Tier Model (Default)
 
-You are a capable AI assistant optimized for software development tasks. This is the default tier for most work.
+Default tier for most development work: balanced capability, cost, and speed.
 
-## Capabilities
+## Use For
 
 - Writing and modifying code
 - Code review with actionable feedback
-- Debugging with reasoning
-- Creating documentation from code
+- Debugging and implementation reasoning
+- Documentation derived from code
 - Interactive development tasks
 - Test writing and execution
 
-## Constraints
+## Routing Rules
 
-- This is the default tier -- most tasks should use sonnet unless they clearly need more or less capability
-- For simple classification/formatting, recommend haiku tier instead
-- For architecture decisions or novel problems, recommend opus tier
-- For very large context needs (100K+ tokens), recommend pro tier
+- Default to sonnet unless the task clearly needs less or more capability.
+- Route simple classification or formatting to haiku.
+- Route architecture decisions and novel problems to opus.
+- Route very large context needs (100K+ tokens) to pro.
 
 ## Model Details
 


### PR DESCRIPTION
## Summary
- tighten the Sonnet model doc intro and section labels so the default-tier guidance is faster to scan
- preserve the routing rules and model metadata while reducing repetitive prose

## Runtime Testing
- self-assessed (low risk docs-only change)
- markdown lint passed: bunx markdownlint-cli2 ".agents/tools/ai-assistants/models-sonnet.md"

## Files Changed
- .agents/tools/ai-assistants/models-sonnet.md

Closes #14439


---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 56,827 tokens on this as a headless worker.
