### PR TITLE
GH#14437: tighten SaaS CRO chapter doc

### DIFF
--- a/.agents/marketing-sales/cro-chapter-23.md
+++ b/.agents/marketing-sales/cro-chapter-23.md
@@ -2,41 +2,51 @@
 
 ## 23.1 Trial-to-Paid Conversion
 
-**SaaS trial challenges:** value must precede payment; time-delayed decision; multiple B2B stakeholders; PQLs vs MQLs.
+### Trial design constraints
 
-**Onboarding milestones:**
+- SaaS trial challenges: value must precede payment; time-delayed decision; multiple B2B stakeholders; PQLs vs MQLs
+- Engagement metrics: days active, features used, data input volume, team members added, time-to-first-value
+- Trial extension: offer to engaged users; require specific actions to extend; treat as conversion opportunity
+
+### Onboarding milestones
+
 1. First Login — welcome sequence, guided tour
 2. First Action — core feature activation
 3. Team Invitation — collaboration setup
 4. Integration — connected to existing tools
 5. Value Realization — first successful outcome
 
-**Engagement metrics:** days active, features used, data input volume, team members added, time-to-first-value.
+### Trial length guidance
 
-**Optimal trial length** (not always 14 days):
-- Time to first value ≤3 days → 7-day trial
-- Complex implementation → 30-day trial
-- Simple tools → 3-day trial
-
-**Trial extension:** offer to engaged users; require specific actions to extend; treat as conversion opportunity.
+| Scenario | Recommended trial |
+|----------|-------------------|
+| Time to first value ≤3 days | 7-day trial |
+| Complex implementation | 30-day trial |
+| Simple tools | 3-day trial |
 
 ## 23.2 Pricing Page Optimization
 
-**Plan structure:** 3–4 plans max; clear differentiation; recommended plan highlighted; annual discount visible.
+### Core structure
 
-**Pricing psychology:** decoy pricing (middle plan most popular); anchoring (enterprise price makes others look reasonable); charm pricing ($99 vs $100); free trial emphasis.
+- Plan structure: 3-4 plans max; clear differentiation; recommended plan highlighted; annual discount visible
 
-**Interactive pricing tools:**
+### Pricing psychology
+
+- Decoy pricing — middle plan most popular
+- Anchoring — enterprise price makes other plans look reasonable
+- Charm pricing — $99 vs $100
+- Free trial emphasis
+
+### Interactive pricing tools
+
 - Calculators — ROI, savings estimators, cost comparison
 - Sliders — usage-based pricing, team size, feature toggles
 
 ## 23.3 Product-Led Growth CRO
 
-**Self-serve onboarding:** no sales required; immediate value delivery; in-app education; viral sharing mechanisms.
-
-**Viral loops:** team invites, shareable content, public profiles, social proof.
-
-**Freemium optimization:** clear upgrade triggers; feature limitations; usage quotas; watermarks/removal.
+- Self-serve onboarding: no sales required; immediate value delivery; in-app education; viral sharing mechanisms
+- Viral loops: team invites, shareable content, public profiles, social proof
+- Freemium optimization: clear upgrade triggers; feature limitations; usage quotas; watermarks/removal
 
 **In-app conversion:**
 
@@ -47,10 +57,7 @@
 
 ## 23.4 B2B SaaS Specifics
 
-**Champion enablement:** business case templates, ROI calculators, competitor comparisons, security documentation.
-
-**Decision maker content:** executive summaries, total cost of ownership, implementation timelines, risk mitigation.
-
-**Sales-assisted trials:** dedicated success manager, custom onboarding, technical implementation support, executive business reviews.
-
-**Proof of concept:** limited scope pilot; success criteria defined upfront; timeline commitments; expansion planning.
+- Champion enablement: business case templates, ROI calculators, competitor comparisons, security documentation
+- Decision maker content: executive summaries, total cost of ownership, implementation timelines, risk mitigation
+- Sales-assisted trials: dedicated success manager, custom onboarding, technical implementation support, executive business reviews
+- Proof of concept: limited scope pilot; success criteria defined upfront; timeline commitments; expansion planning


### PR DESCRIPTION
## Summary
- Restructured the SaaS CRO chapter into clearer subsections so trial strategy, pricing guidance, and B2B-specific tactics scan faster.
- Converted dense inline prose into bullets and a comparison table without dropping any chapter guidance.

## Testing Evidence
- `bunx markdownlint-cli2 ".agents/marketing-sales/cro-chapter-23.md"`
- `git diff --check`
- `bun test` *(fails: repository has no matching test files for this docs-only change)*

## Runtime Testing
- self-assessed: low-risk docs-only change in `.agents/marketing-sales/cro-chapter-23.md`

## Key Decisions
- Treated this file as a reference chapter and preserved all existing guidance while tightening structure.
- Kept the existing in-app conversion table and introduced a trial-length table to reduce scanning effort.

## Files Changed
- `.agents/marketing-sales/cro-chapter-23.md`

## Follow-up
- None.

## Release Notes
- Not applicable; docs-only change.

Closes #14437

Overall, this change is a documentation-only simplification with no runtime impact.

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4
