### PR TITLE
GH#14426: tighten route command doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1589,7 +1589,7 @@
     ".agents/scripts/commands/route.md": {
       "hash": "8167fb30e984e156e02b5fb22c134db28ed8853d",
       "at": "2026-03-31T04:45:56Z",
-      "pr": null
+      "pr": 14604
     },
     ".agents/seo/debug-favicon.md": {
       "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1586,6 +1586,11 @@
       "at": "2026-03-28T23:06:00Z",
       "pr": 12326
     },
+    ".agents/scripts/commands/route.md": {
+      "hash": "8167fb30e984e156e02b5fb22c134db28ed8853d",
+      "at": "2026-03-31T04:45:56Z",
+      "pr": null
+    },
     ".agents/seo/debug-favicon.md": {
       "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",
       "at": "2026-03-29T22:09:18Z",

--- a/.agents/scripts/commands/route.md
+++ b/.agents/scripts/commands/route.md
@@ -5,38 +5,30 @@ mode: subagent
 model: haiku
 ---
 
-Analyze the task description and recommend the optimal model tier.
+Recommend the optimal model tier for the task.
 
 Task: $ARGUMENTS
 
-<!-- NOTE: $ARGUMENTS is raw free-form text from the user, not necessarily a --task-type
-     value. The recommend command (cmd_recommend in model-routing) only filters by
-     --task-type. When called with free-form text, recommend shows global model stats
-     (not task-type-specific). For task-specific routing, extract a task type (e.g.,
-     "code", "triage", "research") from ARGUMENTS before calling recommend. -->
+<!-- NOTE: $ARGUMENTS is raw free-form text, not guaranteed to match --task-type.
+     compare-models-helper.sh recommend only filters by --task-type. For task-specific
+     routing, first extract a task type such as "code", "triage", or "research". -->
 
 ## Instructions
 
-1. First, check pattern history from cross-session memory:
+1. Recall cross-session pattern history:
 
 ```bash
 ~/.aidevops/agents/scripts/memory-helper.sh recall --type SUCCESS_PATTERN --limit 10
 ~/.aidevops/agents/scripts/memory-helper.sh recall --type FAILURE_PATTERN --limit 10
 ```
 
-2. Read `tools/context/model-routing.md` for the routing rules and tier definitions.
-
-3. Analyze the task description against the routing rules:
-   - **Complexity**: Simple transform vs reasoning vs novel design
-   - **Context size**: Small focused task vs large codebase sweep
-   - **Output type**: Classification vs code vs architecture
-
-4. Combine pattern history with routing rules:
-   - If pattern data exists and shows a clear winner (>75% success rate with 3+ samples), weight it heavily
-   - If pattern data is sparse or inconclusive, rely on routing rules
-   - If pattern data contradicts routing rules, note the conflict and explain
-
-5. Output a recommendation in this format:
+2. Read `tools/context/model-routing.md` for tier definitions and routing rules.
+3. Assess the task on three axes: complexity, context size, and output type.
+4. Combine rules with pattern data:
+   - >75% success with 3+ samples: weight pattern history heavily
+   - sparse or inconclusive data: use routing rules
+   - conflict between data and rules: recommend a tier and explain the conflict
+5. Output:
 
 ```text
 Recommended: {tier} ({model_name})
@@ -45,14 +37,9 @@ Cost: ~{relative}x vs sonnet baseline
 Pattern data: {success_rate}% success rate from {N} samples (or "no data")
 ```
 
-6. If the task is ambiguous, suggest the tier and note what would push it up or down:
+6. If ambiguous, keep the recommendation and add:
 
 ```text
-Recommended: sonnet (claude-sonnet-4-6)
-Reason: Code modification with moderate reasoning
-Cost: ~1x baseline
-Pattern data: 85% success rate from 12 samples
-
 Could be haiku if: the change is a simple rename/reformat
 Could be opus if: the change requires architectural decisions
 ```


### PR DESCRIPTION
## Summary
- tighten `.agents/scripts/commands/route.md` by compressing repeated wording while preserving the routing steps, output contract, and ambiguity guidance
- keep the raw-argument caveat and pattern-history/routing-rule decision logic in a shorter command doc
- record the simplification hash in `.agents/configs/simplification-state.json`

## Runtime Testing
- self-assessed: doc-only change
- `bunx markdownlint-cli2 ".agents/scripts/commands/route.md"`
- `python3 -c 'import json; json.load(open(".agents/configs/simplification-state.json")); print("JSON OK")'`
- `rg -n 'compare-models-helper\.sh recommend|memory-helper\.sh recall|Recommended: \{tier\}|Could be haiku if|Could be opus if' .agents/scripts/commands/route.md`

Closes #14426


---
[aidevops.sh](https://aidevops.sh) v3.5.491 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4
