### PR TITLE
GH#14425: tighten Cloudflare Workers KV doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/kv.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/kv.md
@@ -1,17 +1,20 @@
 # Cloudflare Workers KV
 
-Globally-distributed, eventually-consistent key-value store optimized for high read volume and low latency.
+Globally distributed, eventually consistent key-value store for read-heavy, low-latency access.
 
-## Overview
+## Best Fit
 
-KV provides:
-- Eventual consistency (60s global propagation)
-- Read-optimized performance
-- 25 MiB value limit per key
-- Auto-replication to Cloudflare edge
-- Metadata support (1024 bytes)
+- Use for config storage, user sessions, feature flags, caching, and A/B testing.
+- Choose D1 or Durable Objects when you need strong consistency.
 
-**Use cases:** Config storage, user sessions, feature flags, caching, A/B testing
+## Core Properties
+
+| Property | Detail |
+|----------|--------|
+| Consistency | Eventual; writes visible immediately in the same location and within 60s globally |
+| Performance | Read optimized with automatic edge replication |
+| Limits | 25 MiB value per key, 1024-byte metadata |
+| Write rate | 1 write/second per key; exceed it and expect 429s |
 
 ## Quick Start
 
@@ -29,30 +32,21 @@ const value = await env.MY_KV.get("key");
 const json = await env.MY_KV.get<Config>("config", "json");
 ```
 
-## Core Operations
+## Core API
 
 | Method | Purpose | Returns |
 |--------|---------|---------|
 | `get(key, type?)` | Single read | `string \| null` |
-| `get(keys, type?)` | Bulk read (≤100) | `Map<string, T \| null>` |
+| `get(keys, type?)` | Bulk read (≤100 keys) | `Map<string, T \| null>` |
 | `put(key, value, options?)` | Write | `Promise<void>` |
 | `delete(key)` | Delete | `Promise<void>` |
 | `list(options?)` | List keys | `{ keys, list_complete, cursor? }` |
-| `getWithMetadata(key)` | Get + metadata | `{ value, metadata }` |
+| `getWithMetadata(key)` | Read with metadata | `{ value, metadata }` |
 
-## Consistency Model
+## Read Next
 
-- **Write visibility:** Immediate in same location, ≤60s globally
-- **Read path:** Eventually consistent
-- **Write rate:** 1 write/second per key (429 on exceed)
-
-## In This Reference
-
-- [patterns.md](./patterns.md) - Caching, sessions, rate limiting, A/B testing
-- [gotchas.md](./gotchas.md) - Eventual consistency, concurrent writes, value limits
-
-## See Also
-
-- [workers](../workers/) - Worker runtime for KV access
-- [d1](../d1/) - Use D1 for strong consistency needs
-- [durable-objects](../durable-objects/) - Strongly consistent alternative
+- [kv-patterns.md](./kv-patterns.md) - Caching, sessions, rate limiting, A/B testing
+- [kv-gotchas.md](./kv-gotchas.md) - Eventual consistency, concurrent writes, value limits
+- [workers.md](./workers.md) - Worker runtime for KV access
+- [d1.md](./d1.md) - Better fit for relational or strongly consistent data
+- [durable-objects.md](./durable-objects.md) - Strong consistency and coordination


### PR DESCRIPTION
## Summary
- tighten `kv.md` into a slimmer reference card while preserving the core limits, consistency model, API surface, and quick-start examples
- replace generic cross-directory links with local `kv-*` and sibling doc pointers so follow-up reading is more direct

## Runtime Testing
- self-assessed: docs-only change
- `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/kv.md"`

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/kv.md`

Closes #14425

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 8m on this as a headless worker.