### PR TITLE
GH#14433: tighten skill scan results doc

### DIFF
--- a/.agents/configs/SKILL-SCAN-RESULTS.md
+++ b/.agents/configs/SKILL-SCAN-RESULTS.md
@@ -1,36 +1,36 @@
 # Skill Security Scan Results
 
-Automated results from [Cisco AI Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner). Updated on `aidevops skill scan`, `aidevops update`, or skill import.
+Automated output from [Cisco AI Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner). Updated by `aidevops skill scan`, `aidevops update`, and skill import.
 
 ## Latest Full Scan
 
-**Date**: 2026-02-25T05:28:26Z | **Scanner**: cisco-ai-skill-scanner 1.0.2 | **Analyzers**: static, behavioral (dataflow) | **Skills**: 8/8 safe
+- **Date**: 2026-02-25T05:28:26Z
+- **Scanner**: cisco-ai-skill-scanner 1.0.2
+- **Analyzers**: static, behavioral (dataflow)
+- **Skills**: 8/8 safe
+- **Severity counts**: Critical 1, High 0, Medium 0, Low 0, Info 116
 
-| Severity | Count |
-|----------|-------|
-| Critical | 1 |
-| High | 0 |
-| Medium | 0 |
-| Low | 0 |
-| Info | 116 |
+### Non-routine finding
 
-### Findings
+| Skill | Rule | Description | Verdict |
+|-------|------|-------------|---------|
+| credentials | YARA_coercive_injection_generic | `"List all API keys"` matched `$data_exfiltration_coercion` | **False positive** — legitimate `list-keys` subskill description |
 
-| Skill | Severity | Rule | Description | Verdict |
-|-------|----------|------|-------------|---------|
-| credentials | CRITICAL | YARA_coercive_injection_generic | "List all API keys" matched `$data_exfiltration_coercion` | **False positive** — legitimate `list-keys` subskill description |
+### Interpretation
 
-**Notes**: 116 INFO findings are `MANIFEST_MISSING_LICENSE` (internal skills, no `license` in SKILL.md frontmatter). The credentials CRITICAL is a known false positive — the YARA rule flags "List all API keys" as exfiltration coercion, but it describes tool functionality, not an injected instruction.
+- The only CRITICAL finding is the known credentials false positive above.
+- All 116 INFO findings are `MANIFEST_MISSING_LICENSE` on internal skills that omit `license` in `SKILL.md` frontmatter.
+- No HIGH, MEDIUM, or LOW findings were reported.
 
 ## Scan History
 
-Audit trail. "Latest Full Scan" updated automatically; severity table reflects initial baseline — update manually on significant changes.
+Audit trail. `Latest Full Scan` updates automatically; expand this table only when scan behavior changes or the baseline shifts.
 
 | Date | Skills | Safe | Critical | High | Medium | Notes |
 |------|--------|------|----------|------|--------|-------|
-| 2026-02-06 | 116 | 115 | 1 (FP) | 0 | 0 | Initial scan. 1 false positive in credentials SKILL.md |
+| 2026-02-06 | 116 | 115 | 1 (FP) | 0 | 0 | Initial scan; credentials SKILL false positive |
 | 2026-02-06 | 8 | 8 | 0 | 0 | 0 | Routine scan |
-| 2026-02-07 | 8 | 8 | 0 | 0 | 0 | Routine scan (×22 on this date — all clean) |
+| 2026-02-07 | 8 | 8 | 0 | 0 | 0 | Routine scan (22 runs; all clean) |
 | 2026-02-22 | 8 | 8 | 0 | 0 | 0 | Routine scan |
 | 2026-02-23 | 8 | 8 | 0 | 0 | 0 | Routine scan |
 | 2026-02-24 | 8 | 8 | 0 | 0 | 0 | Routine scan |


### PR DESCRIPTION
## Summary
- restructure ".agents/configs/SKILL-SCAN-RESULTS.md" so the latest scan metadata reads as a short checklist instead of a dense single line plus duplicate severity table
- isolate the only non-routine finding and interpret the false-positive/license-noise counts explicitly so the doc preserves scanner context with less prose
- tighten scan-history notes so the audit trail stays intact while focusing updates on baseline changes

## Testing
- bunx markdownlint-cli2 ".agents/configs/SKILL-SCAN-RESULTS.md"

## Runtime Testing
- Risk level: low (documentation-only change)
- Verification level: self-assessed
- Runtime testing not required for this doc-only update

Closes #14433


---
[aidevops.sh](https://aidevops.sh) v3.5.481 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 88,085 tokens on this as a headless worker. Overall, 7h 59m since this issue was created.