### PR TITLE
GH#14195: tighten e-commerce CRO chapter

### DIFF
--- a/.agents/marketing-sales/cro-chapter-22.md
+++ b/.agents/marketing-sales/cro-chapter-22.md
@@ -2,68 +2,29 @@
 
 ## 22.1 Product Page Optimization
 
-### High-Converting Product Page Elements
+**Hero section:** multiple product images (zoom, 360° view), video demos, clear pricing with savings highlighted, prominent Add to Cart, stock indicator.
 
-**Hero Section:**
-- Multiple product images (zoom, 360° view)
-- Video demonstrations
-- Clear pricing with savings highlighted
-- Prominent Add to Cart button
-- Stock availability indicator
+**Social proof:** customer reviews with photos, star-rating distribution, purchase velocity ("X people bought this today"), trust badges.
 
-**Social Proof:**
-- Customer reviews with photos
-- Star ratings distribution
-- "X people bought this today"
-- Trust badges and certifications
+**Product details:** expandable description, technical specs, size/fit guides, shipping and return policies.
 
-**Product Details:**
-- Expandable description
-- Technical specifications
-- Size guides and fit information
-- Shipping and return policies
-
-### Image Optimization
-
-- Minimum 4 images per product: lifestyle, detail/texture, scale reference
-- Lazy loading, WebP with fallbacks
-- Alt text for accessibility
-- Zoom functionality
+**Image optimization:** at least four images (lifestyle, detail/texture, scale reference), lazy loading, WebP with fallbacks, alt text, zoom.
 
 ## 22.2 Cart and Checkout Optimization
 
-### Cart Page
+**Cart page:** clear item images, descriptions, quantity controls, remove option, price breakdown (subtotal, tax, shipping), promo code field, urgency cues ("Only 3 left," limited-time offers, free-shipping thresholds), recently viewed items.
 
-- Clear item images, descriptions, quantity adjusters, remove option
-- Price breakdown (subtotal, tax, shipping) + promo code field
-- Urgency: stock levels ("Only 3 left"), time-limited offers, free shipping thresholds
-- Recently viewed items
+**Checkout flow:** single-page checkout lowers perceived effort for simple purchases; multi-step checkout adds progress indicators, easier error correction, and better mobile handling.
 
-### Checkout Flow
-
-**Single-page** — see entire process, faster for simple purchases, lower perceived effort.
-**Multi-step** — progress indicators reduce anxiety, easier error correction, better on mobile.
-
-**Key tactics:**
-1. Guest checkout option
-2. Address autocomplete
-3. Saved payment methods
-4. Clear error messaging
-5. Order summary sidebar
+**Key tactics:** guest checkout, address autocomplete, saved payment methods, clear error messaging, order-summary sidebar.
 
 ## 22.3 Mobile Commerce
 
-### Mobile UX
+**Mobile UX:** touch targets at least 44px × 44px, adequate spacing, thumb-friendly navigation, page load under 3 seconds, optimized images, minimal JS, AMP on key pages, autofill, simplified forms, one-click reordering.
 
-- Touch targets: minimum 44px x 44px, adequate spacing, thumb-friendly navigation
-- Performance: page load < 3s, optimized images, minimal JS, AMP for key pages
-- Auto-fill, simplified forms, one-click reordering
+**Mobile payment:** express checkout via Apple Pay, Google Pay, PayPal One Touch, Shop Pay, and Amazon Pay.
 
-### Mobile Payment
-
-**Express checkout:** Apple Pay, Google Pay, PayPal One Touch, Shop Pay, Amazon Pay
-
-**Friction reduction:** No account required, minimal data entry, clear security indicators, quick confirmation
+**Friction reduction:** no account required, minimal data entry, clear security indicators, fast confirmation.
 
 ## 22.4 Personalization
 
@@ -76,32 +37,16 @@
 | Behavioral | "Based on your browsing history" |
 | Popular | "Trending now" / "Best sellers" |
 
-### Dynamic Pricing
-
-- First-time buyer offers, loyalty tiers, abandoned cart incentives, win-back campaigns
-- Countdown timers, limited quantity messaging, member-exclusive pricing, flash deals
+**Dynamic pricing:** first-time buyer offers, loyalty tiers, abandoned-cart incentives, win-back campaigns, countdown timers, limited-quantity messaging, member-exclusive pricing, flash deals.
 
 ## 22.5 Category and Search
 
-### Category Page
+**Category page:** filters with multiple options, price sliders, color/size selectors, clear-all control; product grid with quick view, wishlist, comparison, and a deliberate infinite-scroll vs pagination choice.
 
-- Filters: multiple options, price range sliders, color/size selectors, clear all
-- Product grid: quick view, wishlist buttons, comparison, infinite scroll vs pagination
-
-### Search
-
-- Autocomplete, spell correction, visual search, voice search
-- Results: relevance ranking, faceted navigation, results count, related searches
+**Search:** autocomplete, spell correction, visual search, voice search, plus relevance ranking, faceted navigation, result count, and related searches.
 
 ## 22.6 Post-Purchase
 
-### Order Confirmation
+**Order confirmation:** thank-you page with order details, delivery timeline, next steps, plus an email sequence for order confirmation, shipping/tracking, delivery confirmation, review request, and replenishment reminder.
 
-- Confirmation page: thank you, order details, delivery timeline, next steps
-- Email sequence: (1) order confirmation, (2) shipping + tracking, (3) delivery confirmation, (4) review request, (5) replenishment reminder
-
-### Reducing Returns
-
-**Pre-purchase:** Detailed sizing, customer photos, video demos, virtual try-on
-
-**Post-purchase:** Care instructions, usage tips, customer support access
+**Reducing returns:** pre-purchase aids like detailed sizing, customer photos, video demos, virtual try-on; post-purchase support like care instructions, usage tips, and customer support access.


### PR DESCRIPTION
## Summary
- condense the e-commerce CRO chapter into the shorter reference-card style used by neighboring chapters
- preserve the existing guidance while reducing heading and list overhead for cheaper prompt loads

## Testing
- bunx markdownlint-cli2 \".agents/marketing-sales/cro-chapter-22.md\"

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Environment: not required for markdown-only content

Closes #14195

---
[aidevops.sh](https://aidevops.sh) v3.5.480 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m on this as a headless worker.