### PR TITLE
GH#14186: split realtime SFU patterns reference

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3000,6 +3000,11 @@
       "hash": "102c82fd40a93f9e219e84ee053645eff00db29b",
       "at": "2026-03-31T03:46:07Z",
       "pr": 14541
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md": {
+      "hash": "4ab30929c07cb595d6c0e3baabe763cfa4f7849b",
+      "at": "2026-03-31T04:48:18Z",
+      "pr": 14609
     }
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md
@@ -1,109 +1,23 @@
 # Patterns & Use Cases
 
-## Architecture
+Reference corpus for Cloudflare Realtime SFU architecture, session orchestration, media tuning, and operating envelopes.
 
-```
-Client (WebRTC) <---> CF Edge <---> Backend (HTTP)
-                           |
-                    CF Backbone (310+ DCs)
-                           |
-                    Other Edges <---> Other Clients
-```
+## Chapters
 
-Anycast: Last-mile <50ms (95%), no region select, NACK shield, distributed consensus
+- [01-architecture-and-session-topologies.md](./realtime-sfu-patterns/01-architecture-and-session-topologies.md) - Edge architecture, anycast behavior, cascading trees, 1:1/N:N/1:N/breakout flows
+- [02-backend-session-orchestration.md](./realtime-sfu-patterns/02-backend-session-orchestration.md) - Express, Workers, and Durable Objects coordination examples
+- [03-media-controls-and-data-channels.md](./realtime-sfu-patterns/03-media-controls-and-data-channels.md) - Bandwidth limits, simulcast, and DataChannel patterns
+- [04-integrations-and-performance-envelope.md](./realtime-sfu-patterns/04-integrations-and-performance-envelope.md) - R2 and Queues integrations plus latency and scale expectations
 
-Cascading trees auto-scale to millions:
+## Scope
 
-```
-Publisher -> Edge A -> Edge B -> Sub1
-                    \-> Edge C -> Sub2,3
-```
+- Architecture and network shape
+- Session and subscription topologies
+- Backend API orchestration patterns
+- Media sender tuning and auxiliary channels
+- Integrations and expected performance ranges
 
-## Use Cases
+## Preservation Notes
 
-**1:1:** A creates session+publishes, B creates+subscribes to A+publishes, A subscribes to B
-**N:N:** All create session+publish, backend broadcasts track IDs, all subscribe to others
-**1:N:** Publisher creates+publishes, viewers each create+subscribe (no fan-out limit)
-**Breakout:** Same PeerConnection! Backend closes/adds tracks, no recreation
-
-## Backend
-
-Express:
-
-```js
-app.post('/api/new-session', async (req, res) => {
-  const r = await fetch(`${CALLS_API}/apps/${process.env.CALLS_APP_ID}/sessions/new`,
-    {method: 'POST', headers: {'Authorization': `Bearer ${process.env.CALLS_APP_SECRET}`}});
-  res.json(await r.json());
-});
-```
-
-Workers:
-
-```ts
-export default {
-  async fetch(req: Request, env: Env) {
-    return fetch(`https://rtc.live/v1/apps/${env.CALLS_APP_ID}/sessions/new`,
-      {method: 'POST', headers: {'Authorization': `Bearer ${env.CALLS_APP_SECRET}`}});
-  }
-};
-```
-
-DO Presence:
-
-```ts
-export class Room {
-  sessions = new Map(); // sessionId -> {userId, tracks: [{trackName, kind}]}
-
-  async fetch(req: Request) {
-    const {pathname} = new URL(req.url);
-    if (pathname === '/join') {
-      const {sessionId, userId} = await req.json();
-      this.sessions.set(sessionId, {userId, tracks: []});
-      const existingTracks = Array.from(this.sessions.entries())
-        .filter(([id]) => id !== sessionId)
-        .flatMap(([id, data]) => data.tracks.map(t => ({...t, sessionId: id})));
-      return Response.json({existingTracks});
-    }
-    if (pathname === '/publish') {
-      const {sessionId, tracks} = await req.json();
-      this.sessions.get(sessionId)?.tracks.push(...tracks); // Notify others via WS
-      return new Response('OK');
-    }
-  }
-}
-```
-
-## Advanced
-
-Bandwidth mgmt:
-
-```ts
-const s = pc.getSenders().find(s => s.track?.kind === 'video');
-const p = s.getParameters();
-if (!p.encodings) p.encodings = [{}];
-p.encodings[0].maxBitrate = 1200000; p.encodings[0].maxFramerate = 24;
-await s.setParameters(p);
-```
-
-Simulcast (CF auto-forwards best layer):
-
-```ts
-pc.addTransceiver('video', {direction: 'sendonly', sendEncodings: [
-  {rid: 'high', maxBitrate: 1200000},
-  {rid: 'med', maxBitrate: 600000, scaleResolutionDownBy: 2},
-  {rid: 'low', maxBitrate: 200000, scaleResolutionDownBy: 4}
-]});
-```
-
-DataChannel:
-
-```ts
-const dc = pc.createDataChannel('chat', {ordered: true, maxRetransmits: 3});
-dc.onopen = () => dc.send(JSON.stringify({type: 'chat', text: 'Hi'}));
-dc.onmessage = (e) => console.log('RX:', JSON.parse(e.data));
-```
-
-Integrations: R2 for recording `env.R2_BUCKET.put(...)`, Queues for analytics
-
-Perf: 100-250ms connect, ~50ms latency (95%), 200-400ms glass-to-glass, no participant limit (client: 10-50 tracks)
+- All original diagrams, code blocks, and numeric guidance moved into the chapter files.
+- This index replaces the monolithic reference so the parent file stays skimmable while preserving the full corpus.

--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/01-architecture-and-session-topologies.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/01-architecture-and-session-topologies.md
@@ -1,0 +1,32 @@
+# Architecture & Session Topologies
+
+## Architecture
+
+```text
+Client (WebRTC) <---> CF Edge <---> Backend (HTTP)
+                           |
+                    CF Backbone (310+ DCs)
+                           |
+                    Other Edges <---> Other Clients
+```
+
+Anycast: Last-mile <50ms (95%), no region select, NACK shield, distributed consensus
+
+## Cascading Trees
+
+Cascading trees auto-scale to millions:
+
+```text
+Publisher -> Edge A -> Edge B -> Sub1
+                    \-> Edge C -> Sub2,3
+```
+
+## Use Cases
+
+**1:1:** A creates session+publishes, B creates+subscribes to A+publishes, A subscribes to B
+
+**N:N:** All create session+publish, backend broadcasts track IDs, all subscribe to others
+
+**1:N:** Publisher creates+publishes, viewers each create+subscribe (no fan-out limit)
+
+**Breakout:** Same PeerConnection! Backend closes/adds tracks, no recreation

--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/02-backend-session-orchestration.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/02-backend-session-orchestration.md
@@ -1,0 +1,47 @@
+# Backend Session Orchestration
+
+## Express
+
+```js
+app.post('/api/new-session', async (req, res) => {
+  const r = await fetch(`${CALLS_API}/apps/${process.env.CALLS_APP_ID}/sessions/new`,
+    {method: 'POST', headers: {'Authorization': `Bearer ${process.env.CALLS_APP_SECRET}`}});
+  res.json(await r.json());
+});
+```
+
+## Workers
+
+```ts
+export default {
+  async fetch(req: Request, env: Env) {
+    return fetch(`https://rtc.live/v1/apps/${env.CALLS_APP_ID}/sessions/new`,
+      {method: 'POST', headers: {'Authorization': `Bearer ${env.CALLS_APP_SECRET}`}});
+  }
+};
+```
+
+## Durable Objects Presence
+
+```ts
+export class Room {
+  sessions = new Map(); // sessionId -> {userId, tracks: [{trackName, kind}]}
+
+  async fetch(req: Request) {
+    const {pathname} = new URL(req.url);
+    if (pathname === '/join') {
+      const {sessionId, userId} = await req.json();
+      this.sessions.set(sessionId, {userId, tracks: []});
+      const existingTracks = Array.from(this.sessions.entries())
+        .filter(([id]) => id !== sessionId)
+        .flatMap(([id, data]) => data.tracks.map(t => ({...t, sessionId: id})));
+      return Response.json({existingTracks});
+    }
+    if (pathname === '/publish') {
+      const {sessionId, tracks} = await req.json();
+      this.sessions.get(sessionId)?.tracks.push(...tracks); // Notify others via WS
+      return new Response('OK');
+    }
+  }
+}
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/03-media-controls-and-data-channels.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/03-media-controls-and-data-channels.md
@@ -1,0 +1,31 @@
+# Media Controls & Data Channels
+
+## Bandwidth Management
+
+```ts
+const s = pc.getSenders().find(s => s.track?.kind === 'video');
+const p = s.getParameters();
+if (!p.encodings) p.encodings = [{}];
+p.encodings[0].maxBitrate = 1200000; p.encodings[0].maxFramerate = 24;
+await s.setParameters(p);
+```
+
+## Simulcast
+
+Cloudflare auto-forwards the best layer:
+
+```ts
+pc.addTransceiver('video', {direction: 'sendonly', sendEncodings: [
+  {rid: 'high', maxBitrate: 1200000},
+  {rid: 'med', maxBitrate: 600000, scaleResolutionDownBy: 2},
+  {rid: 'low', maxBitrate: 200000, scaleResolutionDownBy: 4}
+]});
+```
+
+## DataChannel
+
+```ts
+const dc = pc.createDataChannel('chat', {ordered: true, maxRetransmits: 3});
+dc.onopen = () => dc.send(JSON.stringify({type: 'chat', text: 'Hi'}));
+dc.onmessage = (e) => console.log('RX:', JSON.parse(e.data));
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/04-integrations-and-performance-envelope.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/04-integrations-and-performance-envelope.md
@@ -1,0 +1,9 @@
+# Integrations & Performance Envelope
+
+## Integrations
+
+R2 for recording `env.R2_BUCKET.put(...)`, Queues for analytics
+
+## Performance
+
+Perf: 100-250ms connect, ~50ms latency (95%), 200-400ms glass-to-glass, no participant limit (client: 10-50 tracks)


### PR DESCRIPTION
## Summary
- Replace the monolithic Realtime SFU patterns reference with a slim index and four chapter files.
- Preserve all original diagrams, code examples, use-case notes, and performance guidance while making the reference skimmable.
- Record the updated parent-file hash in `.agents/configs/simplification-state.json` for future simplification scans.

## Testing
- `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md" ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/*.md"`
- `wc -l .agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md .agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns/*.md` (chapters total 119 lines vs original 109-line corpus)
- `jq empty .agents/configs/simplification-state.json`

## Runtime Testing
- Level: self-assessed (low-risk docs-only change)
- Runtime verification not required; verification used markdown lint, JSON validation, and content-preservation line counts.

Closes #14186


---
[aidevops.sh](https://aidevops.sh) v3.5.482 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 6m and 98,737 tokens on this as a headless worker. Overall, 15h 38m since this issue was created.