### PR TITLE
GH#14424: tighten network interconnect overview doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/network-interconnect.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/network-interconnect.md
@@ -2,43 +2,40 @@
 
 Private, high-performance connectivity to Cloudflare's network. **Enterprise-only**.
 
-## Connection Types
+## Connection Model
 
-**Direct**: Physical fiber in shared datacenter. 10/100 Gbps. You order cross-connect.
+| Type | Best for | Notes |
+|------|----------|-------|
+| **Direct** | Physical presence in a shared datacenter | Physical fiber, 10/100 Gbps, you order the cross-connect |
+| **Partner** | Faster virtual handoff | Via Console Connect, Equinix, Megaport, or similar partner SDN |
+| **Cloud** | AWS Direct Connect or GCP Cloud Interconnect | Magic WAN only |
 
-**Partner**: Virtual via Console Connect, Equinix, Megaport, etc. Managed via partner SDN.
+## Dataplane Choice
 
-**Cloud**: AWS Direct Connect or GCP Cloud Interconnect. Magic WAN only.
+| Version | Use when | Trade-offs |
+|---------|----------|------------|
+| **v1 (Classic)** | You need GRE, VLAN, BFD, LACP, or peering | Asymmetric MTU (1500↓/1476↑) |
+| **v2 (Beta)** | You want native 1500-byte MTU and simpler routing | No GRE, VLAN, BFD, or LACP yet; uses ECMP |
 
-## Dataplane Versions
-
-**v1 (Classic)**: GRE tunnel support, VLAN/BFD/LACP, asymmetric MTU (1500↓/1476↑), peering support.
-
-**v2 (Beta)**: No GRE, 1500 MTU both ways, no VLAN/BFD/LACP yet, ECMP instead.
-
-## Use Cases
+## Supported Fits
 
 - **Magic Transit DSR**: DDoS protection, egress via ISP (v1/v2)
-- **Magic Transit + Egress**: DDoS + egress via CF (v1/v2)
-- **Magic WAN + Zero Trust**: Private backbone (v1 needs GRE, v2 native)
-- **Peering**: Public routes at PoP (v1 only)
-- **App Security**: WAF/Cache/LB (v1/v2 over Magic Transit)
+- **Magic Transit + Egress**: DDoS protection plus egress via Cloudflare (v1/v2)
+- **Magic WAN + Zero Trust**: Private backbone; v1 needs GRE, v2 is native
+- **Peering**: Public routes at a PoP (v1 only)
+- **App Security**: WAF, Cache, or Load Balancing over Magic Transit (v1/v2)
 
-## Prerequisites
+## Requirements & Physical Limits
 
 - Enterprise plan
 - IPv4 /24+ or IPv6 /48+ prefixes
 - BGP ASN for v1
-- See [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-30-10-2025.pdf)
-
-## Specs
-
 - /31 point-to-point subnets
-- 10km max optical distance
-- 10G: 10GBASE-LR single-mode
-- 100G: 100GBASE-LR4 single-mode
-- **No SLA** (free service)
-- Backup Internet required
+- 10 km max optical distance
+- 10G requires 10GBASE-LR single-mode optics
+- 100G requires 100GBASE-LR4 single-mode optics
+- **No SLA**; keep backup Internet connectivity
+- Location availability: [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-30-10-2025.pdf)
 
 ## Throughput
 
@@ -46,13 +43,13 @@ Private, high-performance connectivity to Cloudflare's network. **Enterprise-onl
 |-----------|-----|------|
 | CF → Customer | 10 Gbps | 100 Gbps |
 | Customer → CF (peering) | 10 Gbps | 100 Gbps |
-| Customer → CF (Magic) | 1 Gbps/tunnel or CNI | 1 Gbps/tunnel or CNI |
+| Customer → CF (Magic) | 1 Gbps per tunnel or CNI | 1 Gbps per tunnel or CNI |
 
-## Timeline
+## Delivery Timeline
 
-2-4 weeks typical. Steps: request → config review → order connection → configure → test → enable health checks → activate → monitor.
+Typical lead time is **2-4 weeks**: request → config review → order connection → configure → test → enable health checks → activate → monitor.
 
 ## See Also
 
-- [patterns.md](./patterns.md) - HA, hybrid cloud, failover
-- [gotchas.md](./gotchas.md) - Troubleshooting, limits
+- [network-interconnect-patterns.md](./network-interconnect-patterns.md) - HA, hybrid cloud, failover
+- [network-interconnect-gotchas.md](./network-interconnect-gotchas.md) - Troubleshooting, limits


### PR DESCRIPTION
## Summary
- tighten the CNI overview into decision-oriented tables and grouped requirements so the entry doc is faster to scan
- fix the overview's broken related-document links to the existing CNI patterns and gotchas docs

## Testing
- bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md"
- verified linked files exist: network-interconnect-patterns.md, network-interconnect-gotchas.md

## Runtime Testing
- Level: self-assessed (low-risk docs-only change)
- Runtime verification not required

Closes #14424


---
[aidevops.sh](https://aidevops.sh) v3.5.482 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 10m on this as a headless worker.
