### PR TITLE
GH#14196: tighten OpenExplorer provider doc

### DIFF
--- a/.agents/tools/research/providers/openexplorer.md
+++ b/.agents/tools/research/providers/openexplorer.md
@@ -23,25 +23,27 @@ tools:
 - **Helper**: `~/.aidevops/agents/scripts/tech-stack-helper.sh openexplorer <url>`
 - **Source**: [github.com/turazashvili/openexplorer.tech](https://github.com/turazashvili/openexplorer.tech)
 - **Cost**: Free, open-source, community-driven
-- **API Auth**: Supabase anon key (embedded in web app, or use Playwright for web UI)
+- **API Auth**: Supabase anon key embedded in the web app; use Playwright for the UI fallback
 - **Rate Limits**: None documented
 
-**Quick Commands**:
-
 ```bash
-tech-stack-helper.sh openexplorer search github.com          # Search by URL
-tech-stack-helper.sh openexplorer tech React                 # Search by technology
+tech-stack-helper.sh openexplorer search github.com            # Search by URL
+tech-stack-helper.sh openexplorer tech React                   # Search by technology
 tech-stack-helper.sh openexplorer category "Frontend Framework"
 tech-stack-helper.sh openexplorer analyse https://example.com  # Playwright (real-time)
-tech-stack-helper.sh providers                               # List all providers
-tech-stack-helper.sh compare https://example.com             # Compare providers
+tech-stack-helper.sh providers                                 # List all providers
+tech-stack-helper.sh compare https://example.com               # Compare providers
 ```
+
+**Use when**: free lookups, metadata/performance/security signals, cross-checking other providers, or when no API key is available.
+
+**Avoid when**: you need broad coverage (~7k indexed sites), version detection, historical tracking, or enterprise-scale research.
 
 <!-- AI-CONTEXT-END -->
 
 ## API Integration
 
-**Endpoint**: `{SUPABASE_URL}/functions/v1/search` (Supabase Edge Function; anon key embedded in web app JS bundle)
+**Endpoint**: `{SUPABASE_URL}/functions/v1/search` via a Supabase Edge Function; the anon key is embedded in the web app JS bundle.
 
 | Param | Type | Description |
 |-------|------|-------------|
@@ -54,23 +56,8 @@ tech-stack-helper.sh compare https://example.com             # Compare providers
 | `limit` | int | Results per page (default: 20) |
 | `responsive` / `https` / `spa` / `service_worker` | bool | Metadata filters |
 
-**Response**: `results[].technologies[{name, category}]`, `results[].metadata{is_responsive, is_https, likely_spa, has_service_worker, page_load_time}`, `pagination{page, limit, total, totalPages}`.
-
-**Playwright fallback**: When API is unavailable or URL not yet indexed — navigate to `https://openexplorer.tech`, enter URL, wait for React SPA to render, parse results table. Helper implements both with automatic fallback.
-
-## Category Normalisation
-
-| OpenExplorer | Common Schema |
-|-------------|---------------|
-| Frontend Framework | `frontend-framework` |
-| Backend | `backend-framework` |
-| Analytics | `analytics` |
-| CMS | `cms` |
-| CDN | `cdn` |
-| Payment | `payment` |
-| Performance | `performance` |
-| Security | `security` |
-| Other | `other` |
+- **Response**: `results[].technologies[{name, category}]`, `results[].metadata{is_responsive, is_https, likely_spa, has_service_worker, page_load_time}`, `pagination{page, limit, total, totalPages}`
+- **Fallback**: if the API is unavailable or a URL is not indexed, open `https://openexplorer.tech`, submit the URL, wait for the React SPA to render, then parse the results table. The helper tries API first, then Playwright.
 
 ## Provider Comparison
 
@@ -86,9 +73,19 @@ tech-stack-helper.sh compare https://example.com             # Compare providers
 | Metadata (perf/security) | Yes | Limited | Limited | No |
 | Real-time updates | Yes | No | No | No |
 
-**Use when**: Free lookups, metadata/perf/security signal analysis, complementary cross-reference, no API keys available.
+## Category Normalisation
 
-**Avoid when**: Comprehensive audits (dataset too small ~7k sites), version-specific analysis, historical tracking, enterprise-scale research.
+| OpenExplorer | Common Schema |
+|-------------|---------------|
+| Frontend Framework | `frontend-framework` |
+| Backend | `backend-framework` |
+| Analytics | `analytics` |
+| CMS | `cms` |
+| CDN | `cdn` |
+| Payment | `payment` |
+| Performance | `performance` |
+| Security | `security` |
+| Other | `other` |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/research/providers/openexplorer.md` so the quick reference surfaces usage guidance earlier
- condense API fallback wording without dropping command examples, comparisons, schema mapping, or references

## Runtime Testing
- self-assessed: docs-only change to an agent/provider reference file
- verified with `bunx markdownlint-cli2 ".agents/tools/research/providers/openexplorer.md"`

## Files Changed
- `.agents/tools/research/providers/openexplorer.md`

Closes #14196

---
[aidevops.sh](https://aidevops.sh) v3.5.481 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 119,418 tokens on this as a headless worker. Overall, 15h 19m since this issue was created.