### PR TITLE
GH#14407: tighten Remotion charts doc

### DIFF
--- a/.agents/tools/video/remotion-charts.md
+++ b/.agents/tools/video/remotion-charts.md
@@ -8,21 +8,19 @@ metadata:
 
 # Charts in Remotion
 
-You can create bar charts in Remotion by using regular React code - HTML and SVG is allowed, as well as D3.js.
+Use regular React, HTML, SVG, or D3 to build charts in Remotion.
 
-## No animations not powered by `useCurrentFrame()`
+## Animation rule
 
-Disable all animations by third party libraries.  
-They will cause flickering during rendering.  
-Instead, drive all animations from `useCurrentFrame()`.
+Disable third-party animation systems. They flicker during render. Drive chart motion from `useCurrentFrame()` instead.
 
-## Bar Chart Animations
+## Bar charts
 
-See [Bar Chart Example](assets/charts/bar-chart.tsx) for a basic example implmentation.
+See [Bar Chart Example](assets/charts/bar-chart.tsx) for a basic implementation.
 
-### Staggered Bars
+### Staggered bars
 
-You can animate the height of the bars and stagger them like this:
+Animate each bar height with a per-bar delay:
 
 ```tsx
 const STAGGER_DELAY = 5;
@@ -41,9 +39,9 @@ const bars = data.map((item, i) => {
 });
 ```
 
-## Pie Chart Animation
+## Pie charts
 
-Animate segments using stroke-dashoffset, starting from 12 o'clock.
+Animate segments with `strokeDashoffset` and rotate the circle so drawing starts at 12 o'clock.
 
 ```tsx
 const frame = useCurrentFrame();


### PR DESCRIPTION
## Summary
- tighten the Remotion charts agent doc so the core animation rule appears first and prose is shorter
- keep the bar and pie chart examples intact while clarifying the intended implementation pattern

## Testing
- markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/tools/video/remotion-charts.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Runtime Testing
- Level: low-risk docs change
- Result: self-assessed; runtime verification not required for agent prompt prose

Closes #14407


---
[aidevops.sh](https://aidevops.sh) v3.5.482 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 10m on this as a headless worker.