### PR TITLE
GH#14422: tighten Cloudflare R2 doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/r2.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2.md
@@ -1,17 +1,14 @@
 # Cloudflare R2 Object Storage
 
-S3-compatible object storage with zero egress fees, optimized for large file storage and delivery.
+S3-compatible object storage with zero egress fees for assets, uploads, backups, and lake-style datasets.
 
 ## Overview
 
-R2 provides:
-- S3-compatible API (Workers API + S3 REST)
+- S3-compatible API (Workers binding + S3 REST)
 - Zero egress fees globally
-- Strong consistency for writes/deletes
-- Storage classes (Standard/Infrequent Access)
+- Strong consistency for writes and deletes
+- Storage classes: Standard and Infrequent Access
 - SSE-C encryption support
-
-**Use cases:** Media storage, backups, static assets, user uploads, data lakes
 
 ## Quick Start
 
@@ -46,14 +43,14 @@ if (object) return new Response(object.body);
 - **Standard**: Frequent access, low latency reads
 - **InfrequentAccess**: 30-day minimum storage, retrieval fees, lower storage cost
 
-## In This Reference
+## Related Docs
 
-- [patterns.md](./patterns.md) - Streaming, caching, presigned URLs, storage transitions
-- [gotchas.md](./gotchas.md) - List truncation, etag format, checksum limits, multipart pitfalls
+- [r2-patterns.md](./r2-patterns.md) - Streaming, caching, presigned URLs, storage transitions
+- [r2-gotchas.md](./r2-gotchas.md) - List truncation, ETag format, checksum limits, multipart pitfalls
 
 ## See Also
 
-- [workers](../workers/) - Worker runtime and fetch handlers
-- [kv](../kv/) - Metadata storage for R2 objects
-- [d1](../d1/) - Store R2 URLs in relational database
-- [queues](../queues/) - Process R2 uploads asynchronously
+- [workers.md](./workers.md) - Worker runtime and fetch handlers
+- [kv.md](./kv.md) - Metadata storage for R2 objects
+- [d1.md](./d1.md) - Store R2 URLs in a relational database
+- [queues.md](./queues.md) - Process R2 uploads asynchronously


### PR DESCRIPTION
## Summary
- tighten the R2 overview wording so the entry doc stays concise while preserving the existing examples and operations table
- fix the related-doc and see-also links so the index points to the actual R2, Workers, KV, D1, and Queues reference files

## Testing
- bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/r2.md"
- python3 verification for preserved code blocks/examples and referenced local markdown files

## Runtime Testing
- self-assessed: low-risk docs-only change per .agents/scripts/commands/full-loop.md runtime testing gate

Closes #14422


---
[aidevops.sh](https://aidevops.sh) v3.5.482 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m on this as a headless worker.