### PR TITLE
GH#14200: tighten list keys doc

### DIFF
--- a/.agents/tools/credentials/list-keys.md
+++ b/.agents/tools/credentials/list-keys.md
@@ -20,36 +20,31 @@ tools:
 
 - **Command**: `/list-keys` or `@list-keys`
 - **Script**: `~/.aidevops/agents/scripts/list-keys-helper.sh`
-- **Purpose**: Show all API keys available in the session with their file paths
-- **Security**: Shows key names only, never exposes actual values
+- **Purpose**: Show available API key names plus source paths
+- **Security**: Names and locations only — never values
 
-**Key Sources** (checked in order):
-1. `~/.config/aidevops/credentials.sh` - Primary credential store (600 permissions)
-2. `~/.zshrc`, `~/.bashrc`, etc. - Shell config exports (credential patterns)
-3. Environment variables - Session-only keys matching `*_KEY`, `*_TOKEN`, `*_SECRET`, etc.
-4. `~/.config/coderabbit/api_key` - CodeRabbit CLI token
-5. `configs/*-config.json` - Repository-specific configs (gitignored)
+**Key sources** (checked in order):
+1. `~/.config/aidevops/credentials.sh` — primary credential store (600 perms)
+2. Shell configs (`~/.zshrc`, `~/.bashrc`, etc.) — exported credential patterns
+3. Environment variables — session-only keys such as `*_KEY`, `*_TOKEN`, `*_SECRET`
+4. `~/.config/coderabbit/api_key` — CodeRabbit CLI token
+5. `configs/*-config.json` — repo-specific configs (gitignored)
 
 <!-- AI-CONTEXT-END -->
 
 ## Usage
 
 ```bash
-# List all keys with sources
 ~/.aidevops/agents/scripts/list-keys-helper.sh
-
-# Or use the command
 /list-keys
 ```
 
-## Output Format
+## Output
 
-The script outputs a table showing:
-- Key name (environment variable name)
-- Source file path
-- Status (loaded/not loaded in current session)
-
-Example output:
+Shows a table with:
+- key name
+- source path
+- status in the current session
 
 ```text
 API Keys Available in Session
@@ -75,32 +70,30 @@ Total: 7 keys from 4 sources
 
 ## Status Indicators
 
-| Status | Color | Meaning |
-|--------|-------|---------|
-| `[loaded]` | Green | Key has a valid value in the session |
-| `[placeholder]` | Red | Key contains a placeholder value (e.g., `YOUR_KEY_HERE`, `changeme`, `xxx`) |
-| `[not loaded]` | Yellow | Key is defined but not loaded in current session |
-| `[configured]` | Blue | Key exists in a config file |
+| Status | Meaning |
+|--------|---------|
+| `[loaded]` | Valid value is loaded in the session |
+| `[placeholder]` | Placeholder value such as `YOUR_KEY_HERE`, `changeme`, or `xxx` |
+| `[not loaded]` | Defined but not loaded in the current session |
+| `[configured]` | Present in a config file |
 
-### Placeholder Detection
-
-The script detects common placeholder patterns:
+Placeholder detection covers:
 - `YOUR_*_HERE`, `REPLACE_*`, `CHANGEME`, `FIXME`, `TODO`
 - `example`, `sample`, `test-key`, `dummy`, `fake`
 - `xxx`, `yyy`, `zzz`, `placeholder`, `none`, `null`
-- Template markers: `<...>`, `{...}`, `[...]`
-- Repeated characters: `xxxx`, `0000`, etc.
+- template markers: `<...>`, `{...}`, `[...]`
+- repeated characters: `xxxx`, `0000`, etc.
 
 ## Security Notes
 
-- This tool NEVER displays actual key values
-- Only shows key names and their storage locations
-- Use `echo "${KEY_NAME:0:10}..."` to verify a specific key exists
-- All credential files should have 600 permissions
+- Never displays actual key values
+- Only reports key names and storage locations
+- Use `echo "${KEY_NAME:0:10}..."` only to confirm a specific key exists
+- Credential files should have 600 permissions
 
 ## Integration
 
-This subagent is called by:
-- `/list-keys` slash command
-- `@list-keys` agent reference
-- `api-keys list` tool action (simplified version)
+Called by:
+- `/list-keys`
+- `@list-keys`
+- `api-keys list` (simplified action)

--- a/todo/tasks/GH-14200-brief.md
+++ b/todo/tasks/GH-14200-brief.md
@@ -1,0 +1,32 @@
+# GH#14200: Tighten .agents/tools/credentials/list-keys.md
+
+## Session Origin
+
+Headless `/full-loop` worker continuation for GitHub issue #14200.
+
+## What
+
+Simplify `.agents/tools/credentials/list-keys.md` by tightening repeated prose while preserving command usage, source order, statuses, placeholder detection, and security guidance.
+
+## Why
+
+The file is an instruction doc, not a reference corpus. It can be made shorter and easier to load without changing the documented behavior of `/list-keys`.
+
+## How
+
+1. Keep the YAML frontmatter and AI-CONTEXT block intact.
+2. Compress the usage, output, status, and integration sections.
+3. Preserve all example output, source ordering, placeholder patterns, and security rules.
+4. Verify with markdownlint-cli2.
+
+## Acceptance Criteria
+
+- [ ] All command examples and sample output remain present
+- [ ] Source ordering and placeholder detection rules remain documented
+- [ ] Security notes still prohibit value disclosure
+- [ ] Markdown lint passes for the updated files
+- [ ] PR created with `Closes #14200`
+
+## Context
+
+Issue #14200 is simplification debt from the automated scan. The governing guidance is `.agents/tools/build-agent/build-agent.md` prose tightening for instruction docs.


### PR DESCRIPTION
## Summary
- tighten .agents/tools/credentials/list-keys.md by compressing repeated usage and status prose without changing documented behavior
- preserve key source order, sample output, placeholder detection rules, and security guidance
- add the required task brief for the issue workflow

## Testing
- bunx markdownlint-cli2 .agents/tools/credentials/list-keys.md todo/tasks/GH-14200-brief.md

## Runtime Testing
- self-assessed: low risk docs-only change

## Files Changed
- .agents/tools/credentials/list-keys.md
- todo/tasks/GH-14200-brief.md

Closes #14200


---
[aidevops.sh](https://aidevops.sh) v3.5.483 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 78,863 tokens on this as a headless worker. Overall, 15h 5m since this issue was created.