### PR TITLE
GH#14405: tighten remotion video duration doc

### DIFF
--- a/.agents/tools/video/remotion-get-video-duration.md
+++ b/.agents/tools/video/remotion-get-video-duration.md
@@ -8,9 +8,9 @@ metadata:
 
 # Getting video duration with Mediabunny
 
-Mediabunny can extract the duration of a video file. It works in browser, Node.js, and Bun environments.
+Use `Input.computeDuration()` to get video duration in seconds. This works in browser, Node.js, and Bun.
 
-## Getting video duration
+## URL source
 
 ```tsx
 import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
@@ -28,16 +28,14 @@ export const getVideoDuration = async (src: string) => {
 };
 ```
 
-## Usage
+Example:
 
 ```tsx
 const duration = await getVideoDuration("https://remotion.media/video.mp4");
 console.log(duration); // e.g. 10.5 (seconds)
 ```
 
-## Using with local files
-
-For local files, use `FileSource` instead of `UrlSource`:
+## Local file source
 
 ```tsx
 import { Input, ALL_FORMATS, FileSource } from "mediabunny";
@@ -50,7 +48,9 @@ const input = new Input({
 const durationInSeconds = await input.computeDuration();
 ```
 
-## Using with staticFile in Remotion
+Use `FileSource` instead of `UrlSource` when `file` comes from an input or drag-and-drop handler.
+
+## Remotion `staticFile()`
 
 ```tsx
 import { staticFile } from "remotion";


### PR DESCRIPTION
## Summary
- tighten the opening guidance so the main Mediabunny API call is visible first
- rename sections to match the actual source choices: URL, local file, and Remotion `staticFile()`
- keep all existing examples while reducing surrounding prose

## Runtime Testing
- Risk level: low
- Verification: self-assessed for docs-only change
- Evidence: `bunx markdownlint-cli2 ".agents/tools/video/remotion-get-video-duration.md"`

Closes #14405

---
[aidevops.sh](https://aidevops.sh) v3.5.482 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 1m on this as a headless worker.