### PR TITLE
GH#14204: tighten Vercel Agent Skills guide

### DIFF
--- a/.agents/tools/deployment/agent-skills.md
+++ b/.agents/tools/deployment/agent-skills.md
@@ -8,6 +8,8 @@ tools:
 
 # Vercel Agent Skills
 
+Community [Agent Skills](https://agentskills.io/) packages for common Vercel-adjacent tasks.
+
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
@@ -32,22 +34,18 @@ tools:
 
 ## vercel-deploy-claimable
 
-The primary deployment skill. Deploys without Vercel auth via "claimable" URLs.
-
-**How it works:**
+Primary deployment skill. It deploys without Vercel auth by returning a live preview URL plus a claim URL.
 
 1. Packages project as tarball (excludes `node_modules`, `.git`)
 2. Auto-detects framework from `package.json` (40+ frameworks)
 3. Uploads to deployment service
 4. Returns preview URL (live site) + claim URL (transfer ownership)
 
-**Framework detection** includes: Next.js, Remix, Astro, Vite, SvelteKit, Nuxt,
-Angular, Gatsby, Hono, Express, NestJS, Fastify, Storybook, and many more.
-Static HTML projects (no `package.json`) are handled automatically.
+Framework detection covers Next.js, Remix, Astro, Vite, SvelteKit, Nuxt, Angular, Gatsby, Hono, Express, NestJS, Fastify, Storybook, and more. Static HTML projects (no `package.json`) also work.
 
-## SKILL.md Format Specification
+## SKILL.md Layout
 
-Each skill is a directory containing:
+Each skill directory contains:
 
 ```text
 skill-name/
@@ -56,7 +54,7 @@ skill-name/
   references/    # Supporting documentation (optional)
 ```
 
-**SKILL.md frontmatter:**
+Minimal frontmatter:
 
 ```yaml
 ---
@@ -68,8 +66,7 @@ metadata:
 ---
 ```
 
-The body contains agent instructions: how the skill works, usage examples,
-expected output format, and troubleshooting guidance.
+The body should cover how the skill works, usage examples, expected output format, and troubleshooting.
 
 ## Installation
 
@@ -79,12 +76,11 @@ aidevops skill add vercel-labs/agent-skills       # aidevops (preferred)
 /add-skill vercel-labs/agent-skills --name vercel-deploy  # With custom name
 ```
 
-Skills are auto-detected after installation. The agent uses them when relevant
-tasks are detected (e.g., "deploy my app" triggers vercel-deploy).
+Installed skills are auto-detected and used when the task matches (for example, "deploy my app" triggers `vercel-deploy`).
 
 ## aidevops Integration
 
-The `add-skill-helper.sh` script handles importing Agent Skills:
+`add-skill-helper.sh` imports Agent Skills by:
 
 1. Clones the repo (`git clone --depth 1`)
 2. Detects SKILL.md format, converts frontmatter to aidevops style
@@ -92,8 +88,7 @@ The `add-skill-helper.sh` script handles importing Agent Skills:
 4. Registers in `.agents/configs/skill-sources.json` for update tracking
 5. `setup.sh` creates symlinks to all AI assistant skill directories
 
-**Naming**: Imported skills get a `-skill` suffix (e.g., `vercel-deploy-skill.md`)
-to distinguish from native subagents. See `tools/build-agent/add-skill.md`.
+Imported skills get a `-skill` suffix (for example `vercel-deploy-skill.md`) to distinguish them from native subagents. See `tools/build-agent/add-skill.md`.
 
 ## When to Use What
 

--- a/.agents/tools/deployment/agent-skills.md
+++ b/.agents/tools/deployment/agent-skills.md
@@ -8,7 +8,7 @@ tools:
 
 # Vercel Agent Skills
 
-Community [Agent Skills](https://agentskills.io/) packages for common Vercel-adjacent tasks.
+Use this doc for community [Agent Skills](https://agentskills.io/) from `vercel-labs/agent-skills`. For full Vercel CLI workflows, use `vercel.md`.
 
 <!-- AI-CONTEXT-START -->
 
@@ -24,24 +24,33 @@ Community [Agent Skills](https://agentskills.io/) packages for common Vercel-adj
 
 ## Available Skills
 
-| Skill | Use When | Impact |
-|-------|----------|--------|
-| `vercel-deploy-claimable` | "Deploy my app", "Push this live" | Instant deploy, no auth |
-| `react-best-practices` | Writing/reviewing React or Next.js code | 40+ rules, 8 categories |
+| Skill | Use when | Notes |
+|-------|----------|-------|
+| `vercel-deploy-claimable` | "Deploy my app", "Push this live" | Primary skill; instant deploy without auth |
+| `react-best-practices` | Writing/reviewing React or Next.js code | 40+ rules across 8 categories |
 | `web-design-guidelines` | "Review my UI", "Check accessibility" | 100+ rules across 11 areas |
-| `react-native-guidelines` | Building React Native or Expo apps | 16 rules, 7 sections |
+| `react-native-guidelines` | Building React Native or Expo apps | 16 rules across 7 sections |
 | `composition-patterns` | Refactoring components with boolean props | Compound component patterns |
 
-## vercel-deploy-claimable
+## Primary Skill: `vercel-deploy-claimable`
 
-Primary deployment skill. It deploys without Vercel auth by returning a live preview URL plus a claim URL.
+Deploys without Vercel auth by returning a live preview URL plus a claim URL.
 
-1. Packages project as tarball (excludes `node_modules`, `.git`)
-2. Auto-detects framework from `package.json` (40+ frameworks)
+1. Packages the project as a tarball (excluding `node_modules`, `.git`)
+2. Detects the framework from `package.json` when present
 3. Uploads to deployment service
 4. Returns preview URL (live site) + claim URL (transfer ownership)
 
-Framework detection covers Next.js, Remix, Astro, Vite, SvelteKit, Nuxt, Angular, Gatsby, Hono, Express, NestJS, Fastify, Storybook, and more. Static HTML projects (no `package.json`) also work.
+Framework detection covers 40+ frameworks, including Next.js, Remix, Astro, Vite, SvelteKit, Nuxt, Angular, Gatsby, Hono, Express, NestJS, Fastify, and Storybook. Static HTML projects without `package.json` also work.
+
+## When to Use What
+
+| Need | Use |
+|------|-----|
+| Full Vercel CLI (teams, env vars, domains) | `vercel.md` |
+| Quick deploy without auth | `vercel-deploy-claimable` |
+| Import any community skill | `/add-skill <source>` |
+| Create aidevops-compatible SKILL.md | `scripts/generate-skills.sh` |
 
 ## SKILL.md Layout
 
@@ -66,9 +75,9 @@ metadata:
 ---
 ```
 
-The body should cover how the skill works, usage examples, expected output format, and troubleshooting.
+The body should cover how the skill works, usage examples, expected output, and troubleshooting.
 
-## Installation
+## Install
 
 ```bash
 npx skills add vercel-labs/agent-skills          # Native CLI
@@ -76,9 +85,9 @@ aidevops skill add vercel-labs/agent-skills       # aidevops (preferred)
 /add-skill vercel-labs/agent-skills --name vercel-deploy  # With custom name
 ```
 
-Installed skills are auto-detected and used when the task matches (for example, "deploy my app" triggers `vercel-deploy`).
+Installed skills are auto-detected. Relevant requests trigger them automatically (for example, "deploy my app" → `vercel-deploy`).
 
-## aidevops Integration
+## aidevops Import Flow
 
 `add-skill-helper.sh` imports Agent Skills by:
 
@@ -89,12 +98,3 @@ Installed skills are auto-detected and used when the task matches (for example, 
 5. `setup.sh` creates symlinks to all AI assistant skill directories
 
 Imported skills get a `-skill` suffix (for example `vercel-deploy-skill.md`) to distinguish them from native subagents. See `tools/build-agent/add-skill.md`.
-
-## When to Use What
-
-| Need | Use |
-|------|-----|
-| Full Vercel CLI (teams, env vars, domains) | `vercel.md` |
-| Quick deploy without auth (claimable) | This skill (`vercel-deploy-claimable`) |
-| Import any community skill | `/add-skill <source>` |
-| Create aidevops-compatible SKILL.md | `scripts/generate-skills.sh` |


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/deployment/agent-skills.md` by moving the usage matrix ahead of implementation details and clarifying when to use the community skill vs `vercel.md`
- compress the claimable deploy, SKILL.md layout, install, and import guidance without dropping commands, URLs, or integration steps

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Verification: `bunx markdownlint-cli2 ".agents/tools/deployment/agent-skills.md"`

Closes #14204
---
[aidevops.sh](https://aidevops.sh) v3.5.533 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 10m on this as a headless worker.