### PR TITLE
GH#14404: tighten feature branch doc

### DIFF
--- a/.agents/workflows/branch/feature.md
+++ b/.agents/workflows/branch/feature.md
@@ -30,19 +30,22 @@ git checkout -b feature/{description}
 
 ## When to Use
 
-- New functionality or capabilities
-- New integrations
-- Significant enhancements
+- New functionality or integrations
+- Significant capability expansion
 
-## Unique Guidance
+**Not for** bug fixes, refactors, or docs/config-only work.
 
-For detailed feature implementation patterns, see `workflows/feature-development.md`.
+## Guidance
+
+- Branch names use `feature/{description}`.
+- Commits use `feat:`.
+- Minor-version guidance applies when the branch ships user-visible capability, not internal-only maintenance.
+- For implementation patterns, see `workflows/feature-development.md`.
 
 ## Examples
 
 ```bash
 feature/user-dashboard
-feature/123-api-rate-limiting
 feature/export-to-csv
 ```
 
@@ -50,10 +53,4 @@ feature/export-to-csv
 
 ```bash
 feat: add user authentication
-
-- Implement OAuth2 flow
-- Add session management
-- Create login/logout endpoints
-
-Closes #123
 ```


### PR DESCRIPTION
## Summary
- condense the feature branch guide into a tighter decision card
- add explicit non-use guidance so feature work is easier to distinguish from bugfix, refactor, and chore branches
- keep branch naming, commit prefix, versioning, and feature-development references intact

## Testing
- bunx markdownlint-cli2 ".agents/workflows/branch/feature.md"

## Runtime Testing
- self-assessed (low risk: documentation-only change)

Closes #14404


---
[aidevops.sh](https://aidevops.sh) v3.5.483 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4s on this as a headless worker.