### PR TITLE
GH#14198: tighten Lumen git companion doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -249,7 +249,7 @@
     ".agents/tools/git/lumen.md": {
       "hash": "b5072fd1c8f99084c696c043abdd92ac1373fb3e",
       "at": "2026-03-31T04:49:19Z",
-      "pr": null
+      "pr": 14619
     },
     ".agents/services/hosting/webhosting.md": {
       "hash": "fb3877648d049a414407d7f9e6beb747c2f92f1d",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -246,6 +246,11 @@
       "at": "2026-03-28T03:54:27Z",
       "pr": 11349
     },
+    ".agents/tools/git/lumen.md": {
+      "hash": "b5072fd1c8f99084c696c043abdd92ac1373fb3e",
+      "at": "2026-03-31T04:49:19Z",
+      "pr": null
+    },
     ".agents/services/hosting/webhosting.md": {
       "hash": "fb3877648d049a414407d7f9e6beb747c2f92f1d",
       "at": "2026-03-28T03:54:32Z",

--- a/.agents/tools/git/lumen.md
+++ b/.agents/tools/git/lumen.md
@@ -14,14 +14,11 @@ tools:
 
 ## Quick Reference
 
-- **CLI Tool**: `lumen` - Beautiful git diff viewer + AI commit messages
-- **Install**: `brew install jnsahaj/lumen/lumen` (macOS/Linux) | `cargo install lumen` (any)
-- **Config**: `~/.config/lumen/lumen.config.json`
-- **Setup**: `lumen configure` (interactive provider/key setup)
+- **CLI**: `lumen` — visual git diffs, AI commit drafts, change explanations
+- **Install**: `brew install jnsahaj/lumen/lumen` or `cargo install lumen`
+- **Config**: `~/.config/lumen/lumen.config.json` or `lumen configure`
 - **Repo**: https://github.com/jnsahaj/lumen (Rust, MIT)
 - **Note**: `lumen diff` works without AI config; AI features need a provider
-
-**Key Commands**:
 
 ```bash
 lumen diff                        # Visual side-by-side diff (uncommitted)
@@ -37,17 +34,15 @@ lumen operate "squash last 3"     # Natural language to git command
 
 <!-- AI-CONTEXT-END -->
 
-## Installation
+## Setup
 
 ```bash
 brew install jnsahaj/lumen/lumen   # macOS/Linux
 cargo install lumen                # Any platform with Rust
-brew install fzf mdcat             # Optional: interactive picker + pretty output
+brew install fzf mdcat             # Optional: picker + pretty output
 ```
 
-## Configuration
-
-Run `lumen configure` for interactive setup, or create `~/.config/lumen/lumen.config.json`:
+Run `lumen configure`, or create `~/.config/lumen/lumen.config.json`:
 
 ```json
 {
@@ -57,26 +52,19 @@ Run `lumen configure` for interactive setup, or create `~/.config/lumen/lumen.co
 }
 ```
 
-**Precedence** (highest to lowest): CLI flags > `--config` file > project `lumen.config.json` > global config > env vars > defaults.
+Config precedence: CLI flags > `--config` file > project `lumen.config.json` > global config > env vars > defaults.
 
-### API Key Setup
-
-Reuse keys already in `~/.config/aidevops/credentials.sh` or set per-provider env vars:
+Reuse keys already in `~/.config/aidevops/credentials.sh`, or set env vars:
 
 ```bash
-# Environment variables (alternative to config file)
 export LUMEN_AI_PROVIDER="openai"   # or claude, gemini, groq, etc.
 export LUMEN_API_KEY="your-key"
 export LUMEN_AI_MODEL="gpt-5-mini"  # optional, uses provider default
 ```
 
-### Supported Providers
+Providers: `openai` (default), `claude`, `gemini`, `groq`, `deepseek`, `xai`, `ollama`, `openrouter`.
 
-`openai` (default), `claude`, `gemini` (free tier), `groq` (free), `deepseek`, `xai`, `ollama` (local, no key), `openrouter`. Run `lumen configure` to select provider and model interactively.
-
-## Additional Options
-
-`lumen diff` extras beyond Quick Reference:
+## Common Workflows
 
 ```bash
 lumen diff --watch                  # Auto-refresh on file changes
@@ -88,17 +76,14 @@ lumen explain --query "impact?"     # Ask specific questions about changes
 lumen explain --list                # Interactive commit picker (requires fzf)
 ```
 
-**Diff keybindings**: `j/k` navigate, `{/}` jump hunks, `tab` sidebar, `space` mark viewed, `i` annotate, `e` open in editor, `?` all keys.
+- **Pre-commit review**: `lumen diff`, then `lumen draft`
+- **PR review**: `lumen diff --pr 123` alongside `gh pr view`
+- **AI-generated changes**: `lumen explain --staged` before committing
+- **Commit messages**: `lumen draft --context "task description"`
+- **Complex git ops**: `lumen operate "description"`
+- **Conflict resolution**: use `lumen diff`; see `conflict-resolution.md`
 
-## When to Use Lumen
-
-- **Pre-commit review**: `lumen diff` to review, then `lumen draft` for the commit message
-- **PR review**: `lumen diff --pr 123` for visual side-by-side review alongside `gh pr view`
-- **Understanding AI-generated changes**: `lumen explain --staged` before committing agent output
-- **Commit message generation**: `lumen draft --context "task description"` for conventional commits
-- **Complex git ops**: `lumen operate "description"` instead of memorising git syntax
-- **Stacked review**: `lumen diff main..feature --stacked` to review commits one by one
-- **Conflict resolution**: Use `lumen diff` to visualise merge conflicts (see `conflict-resolution.md`)
+Diff keybindings: `j/k` navigate, `{/}` jump hunks, `tab` sidebar, `space` mark viewed, `i` annotate, `e` open in editor, `?` all keys.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/git/lumen.md` by collapsing repetitive setup and workflow prose into a shorter reference-style guide
- preserve the repo URL, install/config examples, command examples, and related-doc pointers while reducing the doc from 106 to 91 lines
- register the simplified file in `.agents/configs/simplification-state.json` with PR #14619

## Testing
- `bunx markdownlint-cli2 ".agents/tools/git/lumen.md"`
- `jq empty .agents/configs/simplification-state.json`

## Runtime Testing
- Level: self-assessed
- Rationale: low-risk documentation and metadata change; no runtime behavior changed
- Runtime verification: not required for this doc-only update

Closes #14198

---
[aidevops.sh](https://aidevops.sh) v3.5.486 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 8m and 81,526 tokens on this as a headless worker. Overall, 15h 24m since this issue was created.