### PR TITLE
GH#14197: restructure Promise reference into chapters

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/promises.md
+++ b/.agents/tools/programming/modern-javascript-skill/promises.md
@@ -1,106 +1,23 @@
 # Promises and Async/Await
 
-## Promise Creation
+Reference index for Promise fundamentals, `async`/`await`, combinators, and common traps.
 
-```javascript
-// Constructor
-const p = new Promise((resolve, reject) => {
-  success ? resolve(result) : reject(new Error('Failed'));
-});
+## Contents
 
-// ES2024: external control
-const { promise, resolve, reject } = Promise.withResolvers();
-someEvent.on('complete', resolve);
-someEvent.on('error', reject);
+| File | Focus |
+|------|-------|
+| [modern-javascript-skill/promises/01-promise-creation.md](promises/01-promise-creation.md) | Creating promises with constructors, shortcuts, and `Promise.withResolvers()` |
+| [modern-javascript-skill/promises/02-async-await.md](promises/02-async-await.md) | `async`/`await`, error handling patterns, top-level await |
+| [modern-javascript-skill/promises/03-promise-combinators.md](promises/03-promise-combinators.md) | `Promise.all`, `allSettled`, `race`, and `any` |
+| [modern-javascript-skill/promises/04-anti-patterns.md](promises/04-anti-patterns.md) | Common mistakes and the preferred fixes |
 
-// Shortcuts
-Promise.resolve(42);
-Promise.reject(new Error('Failed'));
-```
+## When to read what
 
-## Async/Await
+- Need to create or expose a promise? Start with `promises/01-promise-creation.md`.
+- Need sequential async flow or module-level `await`? Start with `promises/02-async-await.md`.
+- Need parallelism, timeouts, or fallback sources? Start with `promises/03-promise-combinators.md`.
+- Debugging awkward async code? Check `promises/04-anti-patterns.md`.
 
-```javascript
-async function getUserData(userId) {
-  try {
-    const user = await fetchUser(userId);
-    const posts = await fetchPosts(user.id);
-    return { user, posts };
-  } catch (error) {
-    throw error;
-  }
-}
-```
+## Scope
 
-### Error Handling Patterns
-
-```javascript
-// try/catch
-try { return await riskyOp(); } catch { return defaultValue; }
-
-// Error-first return (Go-style)
-async function safe() {
-  try { return [null, await riskyOp()]; }
-  catch (e) { return [e, null]; }
-}
-const [err, data] = await safe();
-
-// Wrapper utility
-const to = p => p.then(d => [null, d]).catch(e => [e, null]);
-const [err, user] = await to(fetchUser(id));
-```
-
-### Top-Level Await (ES2022, ES modules only)
-
-```javascript
-const config = await loadConfig();
-export const db = await connectDatabase(config);
-```
-
-## Promise Combinators
-
-| Method | Behaviour | Use when |
-|--------|-----------|----------|
-| `Promise.all(arr)` | Resolves when all resolve; rejects on first rejection | All must succeed |
-| `Promise.allSettled(arr)` | Resolves when all settle; returns `{status, value/reason}[]` | Need all results regardless of failure |
-| `Promise.race(arr)` | Settles with first to settle (resolve or reject) | Timeout patterns, first responder |
-| `Promise.any(arr)` | Resolves with first success; rejects (`AggregateError`) only if all fail | Fallback sources |
-
-```javascript
-// all — parallel fetch
-const [users, posts] = await Promise.all([fetchUsers(), fetchPosts()]);
-
-// allSettled — partial results
-const results = await Promise.allSettled([primary(), backup(), cache()]);
-const ok = results.filter(r => r.status === 'fulfilled').map(r => r.value);
-
-// race — timeout (ES2024)
-async function fetchWithTimeout(url, ms) {
-  const { promise: timeout, reject } = Promise.withResolvers();
-  const id = setTimeout(() => reject(new Error('Timeout')), ms);
-  try { return await Promise.race([fetch(url), timeout]); }
-  finally { clearTimeout(id); }
-}
-
-// any — fallback
-const data = await Promise.any([primary(), secondary(), tertiary()]);
-// throws AggregateError (error.errors[]) if all fail
-```
-
-## Anti-Patterns
-
-| Anti-pattern | Fix |
-|--------------|-----|
-| `async function f() { return await p; }` | `function f() { return p; }` — no wrapper needed |
-| Sequential awaits for independent ops | `Promise.all([a(), b(), c()])` |
-| `async` callback in `forEach` | `for...of` (sequential) or `Promise.all(arr.map(...))` (parallel) |
-| Unhandled rejection | Wrap in `try/catch` or `.catch()` |
-| Callback inside `async` function | `promisify(fn)` or `fs/promises` |
-
-```javascript
-// forEach trap — items not awaited
-items.forEach(async item => await processItem(item)); // ❌
-
-for (const item of items) await processItem(item);                    // ✅ sequential
-await Promise.all(items.map(item => processItem(item)));              // ✅ parallel
-```
+This index keeps the Promise material discoverable without compressing the reference examples.

--- a/.agents/tools/programming/modern-javascript-skill/promises/01-promise-creation.md
+++ b/.agents/tools/programming/modern-javascript-skill/promises/01-promise-creation.md
@@ -1,0 +1,17 @@
+# Promise Creation
+
+```javascript
+// Constructor
+const p = new Promise((resolve, reject) => {
+  success ? resolve(result) : reject(new Error('Failed'));
+});
+
+// ES2024: external control
+const { promise, resolve, reject } = Promise.withResolvers();
+someEvent.on('complete', resolve);
+someEvent.on('error', reject);
+
+// Shortcuts
+Promise.resolve(42);
+Promise.reject(new Error('Failed'));
+```

--- a/.agents/tools/programming/modern-javascript-skill/promises/02-async-await.md
+++ b/.agents/tools/programming/modern-javascript-skill/promises/02-async-await.md
@@ -1,0 +1,38 @@
+# Async/Await
+
+```javascript
+async function getUserData(userId) {
+  try {
+    const user = await fetchUser(userId);
+    const posts = await fetchPosts(user.id);
+    return { user, posts };
+  } catch (error) {
+    throw error;
+  }
+}
+```
+
+## Error Handling Patterns
+
+```javascript
+// try/catch
+try { return await riskyOp(); } catch { return defaultValue; }
+
+// Error-first return (Go-style)
+async function safe() {
+  try { return [null, await riskyOp()]; }
+  catch (e) { return [e, null]; }
+}
+const [err, data] = await safe();
+
+// Wrapper utility
+const to = p => p.then(d => [null, d]).catch(e => [e, null]);
+const [err, user] = await to(fetchUser(id));
+```
+
+## Top-Level Await (ES2022, ES modules only)
+
+```javascript
+const config = await loadConfig();
+export const db = await connectDatabase(config);
+```

--- a/.agents/tools/programming/modern-javascript-skill/promises/03-promise-combinators.md
+++ b/.agents/tools/programming/modern-javascript-skill/promises/03-promise-combinators.md
@@ -1,0 +1,29 @@
+# Promise Combinators
+
+| Method | Behaviour | Use when |
+|--------|-----------|----------|
+| `Promise.all(arr)` | Resolves when all resolve; rejects on first rejection | All must succeed |
+| `Promise.allSettled(arr)` | Resolves when all settle; returns `{status, value/reason}[]` | Need all results regardless of failure |
+| `Promise.race(arr)` | Settles with first to settle (resolve or reject) | Timeout patterns, first responder |
+| `Promise.any(arr)` | Resolves with first success; rejects (`AggregateError`) only if all fail | Fallback sources |
+
+```javascript
+// all — parallel fetch
+const [users, posts] = await Promise.all([fetchUsers(), fetchPosts()]);
+
+// allSettled — partial results
+const results = await Promise.allSettled([primary(), backup(), cache()]);
+const ok = results.filter(r => r.status === 'fulfilled').map(r => r.value);
+
+// race — timeout (ES2024)
+async function fetchWithTimeout(url, ms) {
+  const { promise: timeout, reject } = Promise.withResolvers();
+  const id = setTimeout(() => reject(new Error('Timeout')), ms);
+  try { return await Promise.race([fetch(url), timeout]); }
+  finally { clearTimeout(id); }
+}
+
+// any — fallback
+const data = await Promise.any([primary(), secondary(), tertiary()]);
+// throws AggregateError (error.errors[]) if all fail
+```

--- a/.agents/tools/programming/modern-javascript-skill/promises/04-anti-patterns.md
+++ b/.agents/tools/programming/modern-javascript-skill/promises/04-anti-patterns.md
@@ -1,0 +1,17 @@
+# Anti-Patterns
+
+| Anti-pattern | Fix |
+|--------------|-----|
+| `async function f() { return await p; }` | `function f() { return p; }` — no wrapper needed |
+| Sequential awaits for independent ops | `Promise.all([a(), b(), c()])` |
+| `async` callback in `forEach` | `for...of` (sequential) or `Promise.all(arr.map(...))` (parallel) |
+| Unhandled rejection | Wrap in `try/catch` or `.catch()` |
+| Callback inside `async` function | `promisify(fn)` or `fs/promises` |
+
+```javascript
+// forEach trap — items not awaited
+items.forEach(async item => await processItem(item)); // ❌
+
+for (const item of items) await processItem(item);                    // ✅ sequential
+await Promise.all(items.map(item => processItem(item)));              // ✅ parallel
+```


### PR DESCRIPTION
## Summary
- Split `.agents/tools/programming/modern-javascript-skill/promises.md` into a slim index plus focused chapter files.
- Preserved the original Promise and async/await examples without compressing reference content.
- Kept the existing top-level reference path stable while making sections easier to navigate.

## Testing
- `npx --yes markdownlint-cli2 "/Users/marcusquinn/Git/aidevops-chore-GH-14197-promises/.agents/tools/programming/modern-javascript-skill/promises.md" "/Users/marcusquinn/Git/aidevops-chore-GH-14197-promises/.agents/tools/programming/modern-javascript-skill/promises/*.md"`
- `wc -l "/Users/marcusquinn/Git/aidevops-chore-GH-14197-promises/.agents/tools/programming/modern-javascript-skill/promises.md" "/Users/marcusquinn/Git/aidevops-chore-GH-14197-promises/.agents/tools/programming/modern-javascript-skill/promises"/*.md`

## Runtime Testing
- Risk level: low
- Result: self-assessed
- Reason: documentation-only restructure with no runtime behavior changes

Closes #14197
---
[aidevops.sh](https://aidevops.sh) v3.5.486 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 7m and 81,344 tokens on this as a headless worker. Overall, 15h 23m since this issue was created.