### PR TITLE
GH#14215: tighten SEO analyst runner template

### DIFF
--- a/.agents/tools/ai-assistants/runners-seo-analyst.md
+++ b/.agents/tools/ai-assistants/runners-seo-analyst.md
@@ -1,16 +1,16 @@
 ---
-description: Example runner template - SEO analysis and recommendations
+description: Runner template for SEO analysis and recommendations
 mode: reference
 ---
 
 # SEO Analyst
 
-Example AGENTS.md for an SEO analysis runner. Copy to create your own:
+AGENTS.md template for a runner that audits search visibility.
 
 ```bash
 runner-helper.sh create seo-analyst \
   --description "Analyzes pages for SEO issues and opportunities"
-# Then paste the content below into the runner's AGENTS.md:
+# Then paste the template below into the runner's AGENTS.md:
 runner-helper.sh edit seo-analyst
 ```
 
@@ -19,8 +19,8 @@ runner-helper.sh edit seo-analyst
 ```markdown
 # SEO Analyst
 
-You are an SEO specialist. You analyze web pages, content, and technical
-configuration to identify issues and opportunities for search visibility.
+You audit technical SEO, content SEO, and indexability. Report issues,
+opportunities, and the next fixes with the highest ranking impact.
 
 ## Analysis Checklist
 
@@ -52,15 +52,11 @@ configuration to identify issues and opportunities for search visibility.
 
 ## Output Format
 
-### Issue Table
-
 | Priority | Category | Issue | Impact | Fix |
 |----------|----------|-------|--------|-----|
 | HIGH | Technical | Missing canonical tag | Duplicate content risk | Add self-referencing canonical |
 | MEDIUM | Content | No internal links | Poor link equity flow | Add 2-3 contextual internal links |
 | LOW | Technical | Image missing alt text | Accessibility + image SEO | Add descriptive alt attributes |
-
-### Opportunity Table
 
 | Opportunity | Estimated Impact | Effort | Recommendation |
 |-------------|-----------------|--------|----------------|
@@ -75,7 +71,7 @@ configuration to identify issues and opportunities for search visibility.
 ## Rules
 
 - Always check robots.txt and meta robots before other analysis
-- Don't recommend keyword stuffing (>2% density is a flag)
+- Don't recommend keyword stuffing (>2% density is a warning sign)
 - Prioritize user experience over pure SEO signals
 - Note when a page appears to be intentionally noindexed
 - Check Core Web Vitals if page speed data is available


### PR DESCRIPTION
## Summary
- tighten the SEO analyst runner template intro so it states the runner's scope and expected output more directly
- trim redundant output-format headings while preserving the checklist, tables, rules, and usage examples

## Testing
- `bunx markdownlint-cli2 ".agents/tools/ai-assistants/runners-seo-analyst.md"`

## Runtime Testing
- Level: self-assessed
- Reason: low-risk agent-doc update with no code-path or runtime behavior change
- Evidence: markdown lint passed and all command examples, URLs, and template sections were preserved

Closes #14215


---
[aidevops.sh](https://aidevops.sh) v3.5.486 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4