### PR TITLE
GH#14214: tighten cross-channel continuity doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -166,6 +166,11 @@
       "at": "2026-03-28T03:53:42Z",
       "pr": 11286
     },
+    ".agents/services/communications/cross-channel-conversation-continuity.md": {
+      "hash": "128ac12c662100732f530bc690fafa9c10b7f017",
+      "at": "2026-03-31T04:51:58Z",
+      "pr": 14624
+    },
     ".agents/services/communications/discord.md": {
       "hash": "44cce31bf11bd980e6b95270c913477c86348a15",
       "at": "2026-03-28T03:53:47Z",

--- a/.agents/services/communications/cross-channel-conversation-continuity.md
+++ b/.agents/services/communications/cross-channel-conversation-continuity.md
@@ -14,47 +14,45 @@ tools:
 
 # Cross-Channel Conversation Continuity
 
-## Goal
+Maintain one relationship history per person across email, Matrix, SimpleX, Slack, CLI, and similar channels without leaking private context between unrelated identities.
 
-Maintain one coherent relationship history per person across channels (email, Matrix, SimpleX, Slack, CLI) without leaking private context between unrelated identities.
-
-The continuity key is the entity ID in `memory.db`:
+Use the entity ID in `memory.db` as the continuity key:
 
 - Layer 2 identity: `entities` + `entity_channels`
 - Layer 1 threads: `conversations`
 - Layer 0 evidence: `interactions`
 
-## Core Principle
+## Core Rule
 
 Resolve identity first, then continue the conversation.
 
-Do not infer continuity from display name alone. Use explicit channel mapping and confidence levels.
+Never infer continuity from display name alone. Require explicit channel mapping and an explicit confidence level.
 
-## Continuity Workflow
+## Workflow
 
-1. Resolve incoming sender/channel to an entity.
-2. If no entity exists, suggest candidates and require confirmation.
-3. Reuse existing conversation when topic + participants align.
-4. Start a new conversation when topic or audience has changed.
+1. Resolve the incoming sender and channel to an entity.
+2. If unresolved, suggest candidates and require confirmation.
+3. Reuse an existing conversation when topic and participants still align.
+4. Start a new conversation when topic or audience changed.
 5. Log the interaction to Layer 0 with channel metadata.
-6. Load context from the same entity before responding.
+6. Load context from the same entity before replying.
 
-## Email-Specific Identity Rules
+## Email Identity Rules
 
-Use `entity-helper.sh` email normalization behavior for stable matching:
+Use `entity-helper.sh` email normalization for stable matching:
 
 - trim whitespace
-- lowercase address
-- strip plus aliases from local part
+- lowercase the address
+- strip plus aliases from the local part
 
 Examples:
 
 - ` User+alerts@Example.COM ` -> `user@example.com`
 - `sales+q1@company.com` -> `sales@company.com`
 
-This normalization improves continuity when the same person uses tagged aliases for filtering.
+This preserves continuity when the same person uses tagged aliases for filtering.
 
-## Recommended Command Pattern
+## Command Pattern
 
 ```bash
 # Resolve sender to known entity
@@ -80,21 +78,21 @@ entity-helper.sh context <entity_id> --channel email --limit 20 --privacy-filter
 - Use `--privacy-filter` when rendering context to shared or lower-trust channels.
 - Keep irreversible decisions (identity merges, external sends) human-verifiable.
 
-## Threading Decision Guide
+## Threading Guide
 
-Reply in existing thread when:
+Reply in the existing thread when:
 
-- same topic
-- recent history (roughly <= 30 days)
+- topic is the same
+- history is recent (roughly <= 30 days)
 - recipient set is stable
 
 Start a new thread when:
 
-- new decision/request topic
-- long dormant thread
-- materially different audience
+- the decision or request topic is new
+- the thread is long dormant
+- the audience changed materially
 
-When starting new thread, reference the old thread in the first line for continuity.
+When starting a new thread, reference the old thread in the first line for continuity.
 
 ## Verification Checklist
 


### PR DESCRIPTION
## Summary
- tighten the cross-channel continuity guide so the core rule, workflow, and threading guidance read as an operational reference card
- preserve the existing entity model, email normalization examples, command pattern, and verification checklist while removing redundant phrasing

## Runtime Testing
- self-assessed: docs-only change
- verified with   - \markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/services/communications/cross-channel-conversation-continuity.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)
  - \

Closes #14214


---
[aidevops.sh](https://aidevops.sh) v3.5.486 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4