### PR TITLE
GH#14403: tighten AI search KPI scorecard template

### DIFF
--- a/.agents/seo/ai-search-kpi-template.md
+++ b/.agents/seo/ai-search-kpi-template.md
@@ -1,8 +1,9 @@
 # AI Search KPI Scorecard Template
 
-Capture baseline vs current measurements for each AI-search optimization cycle.
+Use one scorecard per AI-search optimization cycle. Record baseline vs current values,
+then capture the evidence behind any change.
 
-## Metadata
+## Cycle Metadata
 
 - Project:
 - Date:
@@ -25,46 +26,23 @@ Capture baseline vs current measurements for each AI-search optimization cycle.
 | Citation confidence (avg) | | | | | |
 | Citation stability (variance) | | | | | |
 
-## Diagnostics
+## Diagnostic Evidence
 
-### Grounding eligibility
+| Area | Record |
+|------|--------|
+| Grounding eligibility | Queries tested; queries predicted to ground; queries confirmed grounded; key blockers |
+| Fan-out and criteria gaps | Missing high-priority branches; partial branches; missing decision criteria |
+| SRO and snippet findings | Low-survival sections; high-survival sections; proposed sentence-level edits |
+| Integrity and hallucination risk | Conflicting facts; unsupported claims; canonical source gaps |
+| Agent discoverability | Task set used; completion failures; navigation/comprehension blockers |
 
-- Queries tested:
-- Queries predicted to ground:
-- Queries confirmed grounded:
-- Key blockers:
-
-### Fan-out and criteria gaps
-
-- Missing high-priority branches:
-- Partial branches:
-- Missing decision criteria:
-
-### SRO and snippet findings
-
-- Low-survival sections:
-- High-survival sections:
-- Proposed sentence-level edits:
-
-### Integrity and hallucination risk
-
-- Conflicting facts:
-- Unsupported claims:
-- Canonical source gaps:
-
-### Agent discoverability
-
-- Task set used:
-- Completion failures:
-- Navigation/comprehension blockers:
-
-## Prioritized backlog
+## Prioritized Backlog
 
 1. [ ]
 2. [ ]
 3. [ ]
 
-## Re-test plan
+## Re-test Plan
 
 - Next run date:
 - Intents to re-test:


### PR DESCRIPTION
## Summary
- tighten the KPI scorecard intro and section names so the template is faster to scan in agent context
- replace five repeated diagnostic subsections with one evidence table while preserving every tracked field
- keep the KPI snapshot, backlog, and re-test plan intact while reducing the template from 72 to 50 lines

## Testing
- `git diff --check`
- `wc -l .agents/seo/ai-search-kpi-template.md`
- `markdownlint-cli2 .agents/seo/ai-search-kpi-template.md` *(not available in this worktree: command not found)*

## Runtime Testing
- Level: self-assessed
- Reason: docs-only template change; no runtime path affected

Closes #14403
---
[aidevops.sh](https://aidevops.sh) v3.5.489 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 7m and 106,649 tokens on this as a headless worker. Overall, 8h 50m since this issue was created.