### PR TITLE
GH#14055: tighten R2 patterns agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/r2-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2-patterns.md
@@ -2,6 +2,8 @@
 
 ## Streaming Large Files
 
+Stream R2 objects with proper HTTP metadata and ETag headers. Add CORS/cache headers for public bucket serving.
+
 ```typescript
 const object = await env.MY_BUCKET.get(key);
 if (!object) return new Response('Not found', { status: 404 });
@@ -9,11 +11,16 @@ if (!object) return new Response('Not found', { status: 404 });
 const headers = new Headers();
 object.writeHttpMetadata(headers);
 headers.set('etag', object.httpEtag);
+// For public buckets: add CORS and immutable caching
+// headers.set('access-control-allow-origin', '*');
+// headers.set('cache-control', 'public, max-age=31536000, immutable');
 
 return new Response(object.body, { headers });
 ```
 
 ## Conditional GET (304 Not Modified)
+
+Use `onlyIf` to return 304 when the client's cached ETag matches. A precondition failure returns the object without a body (not null).
 
 ```typescript
 const ifNoneMatch = request.headers.get('if-none-match');
@@ -27,12 +34,11 @@ if (!object.body) return new Response(null, { status: 304, headers: { 'etag': ob
 return new Response(object.body, { headers: { 'etag': object.httpEtag } });
 ```
 
-## Upload with Validation
+## Upload with Metadata
+
+Upload with content type and custom metadata. For key validation, see `r2-gotchas.md` "Key Validation".
 
 ```typescript
-const key = url.pathname.slice(1);
-if (!key || key.includes('..')) return new Response('Invalid key', { status: 400 });
-
 const object = await env.MY_BUCKET.put(key, request.body, {
   httpMetadata: { contentType: request.headers.get('content-type') || 'application/octet-stream' },
   customMetadata: { uploadedAt: new Date().toISOString(), ip: request.headers.get('cf-connecting-ip') || 'unknown' }
@@ -41,7 +47,9 @@ const object = await env.MY_BUCKET.put(key, request.body, {
 return Response.json({ key: object.key, size: object.size, etag: object.httpEtag });
 ```
 
-## Multipart with Progress
+## Multipart Upload with Progress
+
+5 MB minimum part size. Always abort on failure — uncompleted uploads auto-expire after 7 days.
 
 ```typescript
 const PART_SIZE = 5 * 1024 * 1024; // 5MB
@@ -63,7 +71,9 @@ try {
 }
 ```
 
-## Batch Delete
+## Batch Delete by Prefix
+
+Paginate with `list()` (max 1000 per request) and delete in batches. Uses `truncated`/`cursor` for safe pagination.
 
 ```typescript
 async function deletePrefix(prefix: string, env: Env) {
@@ -83,6 +93,8 @@ async function deletePrefix(prefix: string, env: Env) {
 
 ## Checksum Validation
 
+Only one checksum algorithm per PUT (see `r2-gotchas.md` "Checksum Limits").
+
 ```typescript
 const hash = await crypto.subtle.digest('SHA-256', data);
 await env.MY_BUCKET.put(key, data, { sha256: hash });
@@ -95,8 +107,9 @@ const valid = object.checksums.sha256 && arrayBuffersEqual(retrievedHash, object
 
 ## Storage Class Transitions
 
+Workers binding API doesn't support storage class changes — use S3-compatible SDK with `CopyObject`.
+
 ```typescript
-// Use S3 SDK CopyObject to transition
 const s3 = new S3Client({...});
 await s3.send(new CopyObjectCommand({
   Bucket: 'my-bucket',
@@ -104,24 +117,4 @@ await s3.send(new CopyObjectCommand({
   CopySource: `/my-bucket/${key}`,
   StorageClass: 'STANDARD_IA'
 }));
-```
-
-## Public Bucket with Custom Domain
-
-```typescript
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const key = new URL(request.url).pathname.slice(1);
-    const object = await env.MY_BUCKET.get(key);
-    if (!object) return new Response('Not found', { status: 404 });
-
-    const headers = new Headers();
-    object.writeHttpMetadata(headers);
-    headers.set('etag', object.httpEtag);
-    headers.set('access-control-allow-origin', '*');
-    headers.set('cache-control', 'public, max-age=31536000, immutable');
-
-    return new Response(object.body, { headers });
-  }
-};
 ```

--- a/.agents/services/hosting/cloudflare-platform-skill/r2.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2.md
@@ -45,7 +45,7 @@ if (object) return new Response(object.body);
 
 ## Related Docs
 
-- [r2-patterns.md](./r2-patterns.md) - Streaming, caching, presigned URLs, storage transitions
+- [r2-patterns.md](./r2-patterns.md) - Streaming, conditional GET, uploads, multipart, batch delete, checksums, storage transitions
 - [r2-gotchas.md](./r2-gotchas.md) - List truncation, ETag format, checksum limits, multipart pitfalls
 
 ## See Also


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/r2-patterns.md` (127 → 120 lines) per simplification issue #14055.

**Classification:** Reference corpus (code examples). Applied prose tightening and deduplication — not restructuring.

## Changes

- **Added one-line context descriptions** to each pattern section explaining when/why to use the pattern
- **Merged "Public Bucket with Custom Domain" section** into "Streaming Large Files" — was 90% duplicate; unique CORS/cache headers added as commented variant
- **Removed duplicated key validation** from upload section — already covered in `r2-gotchas.md` "Key Validation"; cross-referenced instead
- **Added cross-references** to `r2-gotchas.md` for related gotchas (checksum limits, key validation)
- **Improved section headers** for clarity ("Batch Delete by Prefix", "Upload with Metadata", "Multipart Upload with Progress")
- **Fixed `r2.md`** description — was listing "presigned URLs" which aren't in the patterns file

## Content Preservation

- All 7 code blocks preserved (streaming, conditional GET, upload, multipart, batch delete, checksum, storage class)
- All API calls, TypeScript types, and patterns intact
- CORS/cache headers preserved as commented variant in streaming section
- Zero knowledge loss — only prose additions and deduplication

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — markdownlint clean, content preservation verified via diff

Closes #14055

---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6