### PR TITLE
GH#14639: tighten OpenCode plugin architecture doc

### DIFF
--- a/.agents/tools/build-mcp/aidevops-plugin.md
+++ b/.agents/tools/build-mcp/aidevops-plugin.md
@@ -17,41 +17,38 @@ tools:
 
 - **Status**: Implemented (`t008.1` PR #1138, `t008.2` PR #1149, `t008.3` PR #1150)
 - **Purpose**: Native OpenCode plugin wrapper for aidevops
-- **Approach**: Single-file ESM plugin with SDK hooks
+- **Approach**: Single-file ESM plugin using SDK hooks
 - **Location**: `.agents/plugins/opencode-aidevops/index.mjs` plus package metadata
 - **SDK**: `@opencode-ai/plugin` v1.1.56+ (`index.d.ts` on npm)
 - **Boundary**: `generate-opencode-agents.sh` and `setup.sh` own static config; the plugin owns runtime hooks and tools. Shell-generated config wins on conflicts.
 
 <!-- AI-CONTEXT-END -->
 
-## Runtime Surface
+## Runtime surface
 
-| Concern | Mechanism |
-|---|---|
-| Agent loading + MCP registration | `config` hook |
-| Custom tools | `tool` registration |
-| Quality checks | `tool.execute.before` / `tool.execute.after` |
-| Shell environment | `shell.env` hook |
-| Compaction context | `experimental.session.compacting` hook |
+| Concern | Mechanism | Notes |
+|---|---|---|
+| Agent loading + MCP registration | `config` hook | Runtime-only layer |
+| Custom tools | `tool` registration | Adds aidevops-specific tools |
+| Quality checks | `tool.execute.before` / `tool.execute.after` | Enforces local quality gates |
+| Shell environment | `shell.env` hook | Exports aidevops paths and version |
+| Compaction context | `experimental.session.compacting` hook | Preserves loop state across resets |
 
-## Hooks
+## Hook details
 
-### Config hook
+### `config` hook
 
-- **Agent loading (`t008.1`)**: reads `~/.aidevops/agents/`, parses YAML frontmatter, and injects subagent definitions into `config.agent`.
-- **Precedence**: skips agents already configured by shell-generated config.
-- **MCP registration (`t008.2`)**: uses a data-driven registry so MCP servers do not require re-running `generate-opencode-agents.sh`.
-- **Registry fields**: `name`, `type` (`local` or `remote`), `command` or `url`, `eager`, `toolPattern`, `globallyEnabled`, `requiresBinary`, `macOnly`.
-- **Lazy loading**: all MCPs are lazy-loaded, saving ~7K tokens at startup.
+- **Agent loading (`t008.1`)**: reads `~/.aidevops/agents/`, parses YAML frontmatter, injects subagent definitions into `config.agent`, and skips agents already defined by shell-generated config.
+- **MCP registration (`t008.2`)**: data-driven registry avoids re-running `generate-opencode-agents.sh`.
+- **Registry fields**: `name`, `type` (`local`/`remote`), `command` or `url`, `eager`, `toolPattern`, `globallyEnabled`, `requiresBinary`, `macOnly`.
+- **Startup policy**: all 11 MCPs are lazy-loaded, saving ~7K tokens at startup.
 - **Per-agent permissions**: `AGENT_MCP_TOOLS` maps agents to tool globs, for example `@dataforseo` -> `dataforseo_*`.
-
-Registered MCPs:
 
 | MCP | Type | Global tools |
 |---|---|---|
 | `playwriter` | local | yes |
-| `context7` | remote | no |
 | `augment-context-engine` | local | no |
+| `context7` | remote | no |
 | `outscraper` | local | no |
 | `dataforseo` | local | no |
 | `shadcn` | local | no |
@@ -61,7 +58,7 @@ Registered MCPs:
 | `sentry` | remote | no |
 | `socket` | remote | no |
 
-### Custom tools
+### `tool` registration
 
 | Tool | Purpose |
 |---|---|
@@ -70,25 +67,18 @@ Registered MCPs:
 | `aidevops_pre_edit_check` | Run the pre-edit git safety check |
 | `model-accounts-pool` | Manage OAuth account pools and provider rotation |
 
-### Quality hooks (`t008.3`)
+### `tool.execute.before` / `tool.execute.after` (`t008.3`)
 
-**Pre-tool (`tool.execute.before`)**
+| Phase | Coverage |
+|---|---|
+| Pre-tool | ShellCheck (`-x -S warning`), return validation, `local var="$1"` enforcement, Markdown MD031, trailing whitespace, secret scanning on writes |
+| Post-tool | Git operation detection, pattern tracking via cross-session memory, audit logging to `~/.aidevops/logs/quality-hooks.log` |
 
-- Shell: ShellCheck (`-x -S warning`), return validation, `local var="$1"` enforcement, secret scanning
-- Markdown: MD031 and trailing whitespace checks
-- All writes: secret scanning for API keys, AWS keys, GitHub tokens, and similar patterns
-
-**Post-tool (`tool.execute.after`)**
-
-- Detect git operations
-- Track patterns through cross-session memory
-- Write audit logs to `~/.aidevops/logs/quality-hooks.log`
-
-### Shell environment hook
+### `shell.env` hook
 
 Exports `PATH` (prepends `~/.aidevops/agents/scripts/`), `AIDEVOPS_AGENTS_DIR`, `AIDEVOPS_WORKSPACE_DIR`, and `AIDEVOPS_VERSION`.
 
-### Compaction hook
+### `experimental.session.compacting` hook
 
 Preserves active agent state, loop guardrails, session checkpoint, project-scoped memories (limit 5), git context, and pending mailbox messages.
 
@@ -99,7 +89,7 @@ Preserves active agent state, loop guardrails, session checkpoint, project-scope
 | Single-file ESM, no build step | OpenCode loads `file://` ESM directly; avoids TypeScript compilation |
 | Zero runtime dependencies | Uses built-in Node.js APIs plus a lightweight YAML parser, not `gray-matter` or `zod` |
 | Plugin complements shell setup | Shell handles primary config; plugin adds runtime behavior |
-| Subagents loaded only in `config` hook | Prevents auto-registration from overriding intentional primary-agent config |
+| Subagents load only in `config` hook | Prevents auto-registration from overriding intentional primary-agent config |
 | Data-driven MCP registry | Captures runtime binary checks and platform logic that static JSON cannot |
 | All MCPs lazy-loaded | Reduces startup cost by ~7K tokens |
 


### PR DESCRIPTION
## Summary
- tighten the OpenCode plugin architecture doc around runtime ownership, hook responsibilities, and tool registration
- consolidate quality-hook behavior into compact tables while preserving task refs, implementation pointers, and MCP coverage
- correct the documented MCP count to match the 11 entries implemented in `.agents/plugins/opencode-aidevops/index.mjs`

## Testing
- `bunx markdownlint-cli2 .agents/tools/build-mcp/aidevops-plugin.md`
- `wc -l .agents/tools/build-mcp/aidevops-plugin.md` → 100 lines

## Runtime Testing
- level: low
- method: self-assessed (docs-only change)
- rationale: no runtime behavior changed

Closes #14639


---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 58,480 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured and refined documentation for hook behavior, MCP registration, and tool registration with improved table formats for clarity.
  * Updated descriptions of startup policies, agent loading behavior, and quality scanning coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->