### PR TITLE
GH#14387: tighten agent doc Schema Definition

### DIFF
--- a/.agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md
+++ b/.agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md
@@ -3,35 +3,26 @@
 ## Column Types
 
 ```typescript
-import { pgTable, uuid, text, varchar, integer, bigint, boolean,
-  timestamp, date, numeric, json, jsonb, pgEnum, serial } from 'drizzle-orm/pg-core';
+import { bigint, boolean, integer, jsonb, numeric, serial, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 
-// Primary Keys
-id: uuid('id').primaryKey().defaultRandom(),           // UUIDv4
-id: uuid('id').primaryKey().default(sql`uuidv7()`),    // UUIDv7 (PG18+)
-id: integer('id').primaryKey().generatedAlwaysAsIdentity(),  // Identity
-id: serial('id').primaryKey(),                          // Serial (legacy)
+// Primary keys
+id: uuid('id').primaryKey().defaultRandom(),
+id: uuid('id').primaryKey().default(sql`uuidv7()`),
+id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+id: serial('id').primaryKey(),
 
-// Strings
+// Scalars
 name: text('name').notNull(),
 email: varchar('email', { length: 255 }).unique(),
-
-// Numbers
 age: integer('age'),
 price: numeric('price', { precision: 10, scale: 2 }),
 count: bigint('count', { mode: 'number' }),
-
-// Boolean
 active: boolean('active').default(true),
 
-// Timestamps
+// Time and structured data
 createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 updatedAt: timestamp('updated_at', { withTimezone: true }).$onUpdate(() => new Date()),
-
-// JSON
 data: jsonb('data').$type<{ key: string }>(),
-
-// Arrays
 tags: text('tags').array(),
 ```
 
@@ -42,7 +33,7 @@ email: text('email').notNull().unique(),
 status: text('status').notNull().default('pending'),
 price: numeric('price').check(sql`price > 0`),
 
-// Foreign Key
+// Foreign key
 authorId: uuid('author_id').references(() => users.id, { onDelete: 'cascade' }),
 ```
 


### PR DESCRIPTION
## Summary
- tighten the Drizzle schema cheatsheet into a shorter reference card by removing unused imports and collapsing repetitive category blocks
- keep the same schema examples while making section labels more consistent and faster to scan

## Testing
- bunx markdownlint-cli2 ".agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md"

## Runtime Testing
- self-assessed: low risk docs-only change to an agent/reference cheatsheet

Closes #14387


---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4