### PR TITLE
GH#14637: tighten agent sources private repo doc

### DIFF
--- a/.agents/aidevops/agent-sources.md
+++ b/.agents/aidevops/agent-sources.md
@@ -1,15 +1,14 @@
 # Agent Sources (Private Repos)
 
-Use agent sources when agents should live in a private Git repo but stay available framework-wide. Sync copies them into `~/.aidevops/agents/custom/<source-name>/`, so they follow `custom/` tier rules: survive framework updates, are never overwritten by `setup.sh`, and auto-sync during `aidevops update` and `./setup.sh` after `deploy_aidevops_agents`.
+Use agent sources when agents should stay in a private Git repo but remain available framework-wide. Sync copies them into `~/.aidevops/agents/custom/<source-name>/`, so they follow `custom/` tier rules: survive framework updates, are never overwritten by `setup.sh`, and auto-sync during `aidevops update` and `./setup.sh` after `deploy_aidevops_agents`.
 
-## Sync Lifecycle
+## Lifecycle
 
 1. Keep private agents under `.agents/` in a private Git repo.
 2. Register the repo with `aidevops sources add <path>`.
 3. Run `aidevops update` or `aidevops sources sync`.
-4. Files sync into `~/.aidevops/agents/custom/<source-name>/`.
-5. `mode: primary` docs are symlinked into `~/.aidevops/agents/` for auto-discovery.
-6. `.md` files with `agent:` frontmatter are symlinked into `~/.config/opencode/command/`.
+4. Synced files land in `~/.aidevops/agents/custom/<source-name>/`.
+5. `mode: primary` docs symlink into `~/.aidevops/agents/`, and `.md` files with `agent:` frontmatter symlink into `~/.config/opencode/command/`.
 
 ## CLI
 
@@ -24,8 +23,6 @@ aidevops sources remove my-private-agents                     # Remove (keeps fi
 
 ## File Classification
 
-Sync classifies `.md` files by YAML frontmatter:
-
 | Frontmatter | Classification | Sync behavior |
 |-------------|----------------|---------------|
 | `mode: primary` | Primary agent | Sync + symlink to `~/.aidevops/agents/` root |
@@ -33,7 +30,8 @@ Sync classifies `.md` files by YAML frontmatter:
 | `agent: <Name>` | Slash command | Sync + symlink to `~/.config/opencode/command/` |
 | none / other | Regular file | Sync only |
 
-The main agent doc is the file whose name matches its directory, for example `my-agent/my-agent.md`; `mode:` decides whether it is primary or subagent. Other `.md` files with `agent:` frontmatter become slash commands. Slash command conflicts append the source slug, for example `/run-pipeline-my-private-agents`. Primary agents that would overwrite core agents backed by real files, not symlinks, are skipped with a warning.
+- The main agent doc is the file whose name matches its directory, for example `my-agent/my-agent.md`; `mode:` decides whether it is primary or subagent, and other `.md` files with `agent:` frontmatter become slash commands.
+- Slash command conflicts append the source slug, for example `/run-pipeline-my-private-agents`. Primary agents that would overwrite core agents backed by real files, not symlinks, are skipped with a warning.
 
 ## Layout
 

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,6 +1,11 @@
 {
   "_comment": null,
   "files": {
+    ".agents/aidevops/agent-sources.md": {
+      "hash": "86113ed3f6cb39ad363af10d420942cff1af592c",
+      "at": "2026-03-31T05:32:40Z",
+      "pr": 14645
+    },
     ".agents/seo/analytics-tracking.md": {
       "hash": "07ff0feec55ad3f8477a6badd724b479c1b09370",
       "at": "2026-03-27T21:25:04Z",


### PR DESCRIPTION
## Summary
- tighten .agents/aidevops/agent-sources.md by merging repetitive guidance while preserving sync behavior, classification rules, and plugin comparison
- keep the example layout, CLI usage, and slash command format intact while reducing narrative overhead

## Runtime Testing
- level: self-assessed (docs-only change)
- evidence: 	npx markdownlint-cli2 .agents/aidevops/agent-sources.md

gh issue view 14637 confirms this PR addresses the requested simplification.

Closes #14637

---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4