### PR TITLE
GH#14386: tighten letter post bridge doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1426,6 +1426,11 @@
       "at": "2026-03-28T20:16:44Z",
       "pr": 12163
     },
+    ".agents/services/email/letter-post-bridge.md": {
+      "hash": "f6065bec96f8cb306e39fe1862b7bf456e1901d3",
+      "at": "2026-03-31T05:33:36Z",
+      "pr": 14646
+    },
     ".agents/services/hosting/cloudflare-platform-skill.md": {
       "hash": "6008b298c541d6b044eb0779f76074b818140d27",
       "at": "2026-03-28T20:16:45Z",

--- a/.agents/services/email/letter-post-bridge.md
+++ b/.agents/services/email/letter-post-bridge.md
@@ -13,50 +13,51 @@ tools:
 
 # Letter Post Bridge (Placeholder)
 
-This placeholder captures candidate providers for future implementation of physical mail workflows that integrate with email systems.
+Discovery-only reference for future physical post workflows bridged through email. No provider is selected yet.
 
-## Scope
+## Quick Reference
 
-- Outbound: print-and-send APIs for posting letters from digital payloads
-- Inbound: scan-and-receive services that forward physical post as email/PDF
-- Status: discovery only (no provider selected yet)
+- **Outbound**: print-and-send APIs that post letters from app payloads
+- **Inbound**: scan-and-receive services that forward physical mail as email/PDF
+- **Bridge**: email remains the orchestration layer for confirmations, routing, and audit trails
 
-## Candidate Print-and-Send APIs
+## Candidate Providers
 
-| Service | Region focus | Typical capabilities | Notes for future evaluation |
+### Print and send
+
+| Service | Region focus | Typical capabilities | Validate before adoption |
 |---|---|---|---|
-| Lob | US | Address verification, print and mail letters/postcards/checks | Mature API footprint; verify current UK/EU support limits |
-| ClickSend | Global (strong in AU/UK/US) | Programmatic postal sending from API or email trigger | Confirm API feature parity by country |
-| PostGrid | US/Canada (growing international) | Mail API, address validation, templated document sends | Validate production scale references |
-| PostalMethods | US | Batch and API-driven letter printing/mailing | Check modern API ergonomics and webhook coverage |
-| Hybrid Mail by iMail (formerly UK hybrid mail providers) | UK | API-assisted letter dispatch through Royal Mail workflows | Confirm active API product and SLA terms |
+| Lob | US | Address verification; print and mail letters, postcards, checks | Current UK/EU support limits |
+| ClickSend | Global; strong in AU/UK/US | Postal sending from API or email trigger | Country-by-country API parity |
+| PostGrid | US/Canada; growing international | Mail API, address validation, templated sends | Production scale references |
+| PostalMethods | US | Batch and API-driven letter printing and mailing | API ergonomics and webhook coverage |
+| Hybrid Mail by iMail / UK hybrid mail providers | UK | API-assisted dispatch through Royal Mail-style workflows | Active API product and SLA terms |
 
-## Candidate Scan-and-Receive Services
+### Scan and receive
 
-| Service | Region focus | Typical capabilities | Notes for future evaluation |
+| Service | Region focus | Typical capabilities | Validate before adoption |
 |---|---|---|---|
-| Earth Class Mail | US | Mailroom scanning, PDF forwarding, mailbox management | Verify current API/automation endpoints |
-| Traveling Mailbox | US | Envelope scan + open/scan + digital forwarding | Confirm programmatic access vs UI-only operations |
-| VirtualPostMail | US | Postal address, scan-to-email, mail management | Assess API support and webhook availability |
-| Anytime Mailbox | Global network | Virtual mailbox operators, mail scan and forwarding | Check consistency across operator locations |
-| UK Postbox / UK virtual mailroom providers | UK | Scan-and-email inbound post for UK addresses | Compare provider API maturity and compliance posture |
+| Earth Class Mail | US | Mailroom scanning, PDF forwarding, mailbox management | Current API and automation endpoints |
+| Traveling Mailbox | US | Envelope scan, open-and-scan, digital forwarding | Programmatic access vs UI-only flows |
+| VirtualPostMail | US | Postal address, scan-to-email, mail management | API support and webhook availability |
+| Anytime Mailbox | Global network | Virtual mailbox operators, mail scan, forwarding | Cross-operator consistency |
+| UK Postbox / UK virtual mailroom providers | UK | Scan-and-email inbound post for UK addresses | API maturity and compliance posture |
 
-## Integration Intent (Future)
+## Target Flows
 
-- Treat email as the orchestration bridge for physical post events
-- Outbound flow target: app event -> render payload -> print/send API -> status callback -> email confirmation
-- Inbound flow target: scanned mail event -> PDF/metadata capture -> routing rules -> destination mailbox
-- Compliance checks to include data residency, retention controls, and redaction support
+- **Outbound**: app event -> render payload -> print/send API -> status callback -> email confirmation
+- **Inbound**: scanned mail event -> PDF/metadata capture -> routing rules -> destination mailbox
+- **Compliance**: review data residency, retention controls, and redaction support before implementation
 
-## Next Step Criteria
+## Shortlisting Criteria
 
-Before implementation, shortlist 2-3 providers in each direction and score against:
+Score 2-3 providers in each direction against:
 
-1. API completeness (templates, status, webhooks, idempotency)
+1. API completeness: templates, status, webhooks, idempotency
 2. Geographic coverage for required destinations
 3. Pricing model and minimum volume commitments
-4. Security/compliance (SOC 2, ISO 27001, GDPR handling)
-5. Operational reliability (SLA, support quality, retry semantics)
+4. Security/compliance: SOC 2, ISO 27001, GDPR handling
+5. Operational reliability: SLA, support quality, retry semantics
 
 ## Related
 


### PR DESCRIPTION
## Summary
- tighten the placeholder doc into a quick-reference layout with clearer provider groupings and validation notes
- keep the discovery-only scope while surfacing target outbound/inbound flows and shortlisting criteria earlier

## Testing
- bunx markdownlint-cli2 ".agents/services/email/letter-post-bridge.md"
- python3 -m json.tool .agents/configs/simplification-state.json >/dev/null

## Runtime Testing
- Level: self-assessed
- Reason: docs-only change to agent guidance

Closes #14386


---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m on this as a headless worker.