### PR TITLE
GH#14385: tighten task taxonomy doc

### DIFF
--- a/.agents/reference/task-taxonomy.md
+++ b/.agents/reference/task-taxonomy.md
@@ -4,19 +4,18 @@ description: Canonical routing taxonomy — domain labels and model tier labels 
 
 # Task Taxonomy: Domain and Model Tier Classification
 
-Single source of truth for the two classification tables used at task creation time
-(`/new-task`, `/save-todo`, `/define`) and consumed at dispatch time (`/pulse`).
+Canonical source for task classification used by `/new-task`, `/save-todo`,
+`/define`, and `/pulse`.
 
-When a domain or tier is added or changed, update **only this file**. Command files
-reference it by pointer.
+When a domain or tier changes, update **only this file**. Command docs should
+point here, not duplicate the tables.
 
 ---
 
 ## Domain Routing Table
 
-Maps task content to a specialist agent. Used by task creation commands to apply
-GitHub labels and TODO tags, and by the pulse to select the `--agent` flag at
-dispatch time.
+Add a domain tag and label only when the task clearly belongs to a specialist
+agent. Code work stays unlabeled and routes to Build+.
 
 | Domain Signal | TODO Tag | GitHub Label | Agent |
 |--------------|----------|--------------|-------|
@@ -32,16 +31,15 @@ dispatch time.
 | Health and wellness content, nutrition | `#health` | `health` | Health |
 | Code: features, bug fixes, refactors, CI, tests | *(none)* | *(none)* | Build+ (default) |
 
-**Rule:** Omit the domain tag for code tasks — Build+ is the default and needs no
-label. Only add a domain tag when the task clearly maps to a specialist domain.
+**Rule:** Omit the domain tag for code tasks. Build+ is the default.
 
 ---
 
 ## Model Tier Table
 
-Maps task reasoning complexity to a model tier. Used by task creation commands to
-apply `tier:` GitHub labels and TODO tags, and by the pulse to resolve the
-`--model` flag at dispatch time via `model-availability-helper.sh resolve <tier>`.
+Add a tier tag and label only when the task clearly needs more or less reasoning
+than the default dispatch path (currently sonnet-tier). `/pulse` resolves labels
+through `model-availability-helper.sh resolve <tier>`.
 
 | Tier | TODO Tag | GitHub Label | When to Apply |
 |------|----------|--------------|---------------|
@@ -49,18 +47,17 @@ apply `tier:` GitHub labels and TODO tags, and by the pulse to resolve the
 | simple | `tier:simple` | `tier:simple` | Docs-only changes, simple renames, formatting, config tweaks, label/tag updates |
 | *(coding)* | *(none)* | *(none)* | Standard implementation, bug fixes, refactors, tests — **default, no label needed** |
 
-**Rule:** Default to no tier label — most tasks are coding tasks that use sonnet.
-Only add a tier label when the task clearly needs more reasoning power (`thinking`)
-or clearly needs less (`simple`). When uncertain, omit.
+**Rule:** Default to no tier label. Use `thinking` for deeper reasoning, `simple`
+for lighter work, and omit when uncertain.
 
 ---
 
-## Usage by Command Files
+## Command Use
 
-- **`/new-task`** — classify after brief creation (Step 6.5); apply labels via `gh issue edit`
-- **`/save-todo`** — classify during dispatch tag evaluation (Step 1b)
-- **`/define`** — classify during task type detection (Step 1)
-- **`/pulse`** — consume labels at dispatch time (Agent routing + Model tier selection sections)
+- **`/new-task`** — classify after brief creation; apply labels via `gh issue edit`
+- **`/save-todo`** — classify during dispatch tag evaluation
+- **`/define`** — classify during task type detection
+- **`/pulse`** — consume labels for agent routing and model tier selection
 
-See `scripts/commands/pulse.md` "Agent routing from labels" and "Model tier selection"
-for how these labels are consumed at dispatch time.
+See `scripts/commands/pulse.md` "Agent routing from labels" and "Model tier
+selection" for dispatch behaviour.


### PR DESCRIPTION
## Summary
- tighten `.agents/reference/task-taxonomy.md` so task classification guidance stays centralized without repeating command-specific detail
- make default routing expectations explicit for unlabeled code tasks and default-tier dispatch

## Testing
- `bunx markdownlint-cli2 ".agents/reference/task-taxonomy.md"`

## Runtime Testing
- self-assessed: low risk docs-only change

Closes #14385

---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 3m and 68,500 tokens on this as a headless worker. Overall, 10h 11m since this issue was created.