### PR TITLE
GH#14384: tighten score-responses evaluation workflow

### DIFF
--- a/.agents/scripts/commands/score-responses.md
+++ b/.agents/scripts/commands/score-responses.md
@@ -4,15 +4,21 @@ agent: Build+
 mode: subagent
 ---
 
-Score AI model responses against structured criteria (correctness, completeness, code quality, clarity).
+Evaluate real AI responses against correctness, completeness, code quality, and clarity.
 
 Target: $ARGUMENTS
 
 ## Instructions
 
-Read `tools/ai-assistants/response-scoring.md` for full scoring workflow, criteria weights, and CLI reference.
+Read `tools/ai-assistants/response-scoring.md` for criteria weights, storage details, and helper syntax.
 
-**Workflow:** `prompt add` → `record` → `score` → `compare`/`leaderboard`. For live comparisons, send the same prompt to multiple models, record with timing/tokens, score all four criteria, present side-by-side.
+## Workflow
+
+1. `prompt add` — save the shared evaluation prompt.
+2. `record` — capture one response per model with timing/tokens.
+3. `score` — rate all four criteria for each response.
+4. `compare` or `leaderboard` — rank the responses side-by-side.
+5. `export` — optional CSV output for reuse.
 
 Scores auto-sync to the pattern tracker (t1099), feeding `/route` and `/patterns`. Disable: `SCORING_NO_PATTERN_SYNC=1`. Bulk sync: `response-scoring-helper.sh sync`.
 


### PR DESCRIPTION
## Summary
- rewrite `/score-responses` as a compact step-by-step workflow instead of a dense inline sentence
- keep the command doc focused on the live evaluation loop while preserving the pointer to the full response-scoring reference
- clarify the optional export step without changing command behavior

## Runtime Testing
- Level: low-risk docs change
- Verification: self-assessed
- Evidence: `bunx markdownlint-cli2 \".agents/scripts/commands/score-responses.md\"`

## Files Changed
- `.agents/scripts/commands/score-responses.md`

## Overall
- Simplifies the command doc without changing the underlying scoring workflow.

Closes #14384

---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4