### PR TITLE
GH#14378: tighten @mac subagent doc

### DIFF
--- a/.agents/tools/automation/mac.md
+++ b/.agents/tools/automation/mac.md
@@ -14,17 +14,24 @@ tools:
 
 # @mac - macOS Automation Subagent
 
-Invoke with `@mac` to enable the macos-automator MCP tools for AppleScript and JXA automation.
+Use `@mac` for local macOS automation through AppleScript, JXA, and Accessibility APIs.
 
-## Tools
+## Quick Reference
 
-| Tool | Purpose |
-|------|---------|
-| `execute_script` | Run AppleScript or JXA code |
-| `get_scripting_tips` | Search 200+ pre-built automation scripts |
-| `accessibility_query` | Query and interact with UI elements |
+- **Scope**: macOS-only app, UI, and system automation
+- **Tools enabled**: `execute_script`, `get_scripting_tips`, `accessibility_query`
+- **Permissions**: System Settings > Privacy & Security > Automation and Accessibility
+- **Full setup + params**: `tools/automation/macos-automator.md`
 
-## Examples
+## Tool Use
+
+| Tool | Use it for |
+|------|------------|
+| `execute_script` | Run AppleScript or JXA code directly |
+| `get_scripting_tips` | Search 200+ built-in scripts before writing custom automation |
+| `accessibility_query` | Inspect or click UI elements when an app lacks a scripting API |
+
+## Example Prompts
 
 ```text
 @mac Get the current Safari URL
@@ -38,13 +45,6 @@ Invoke with `@mac` to enable the macos-automator MCP tools for AppleScript and J
 @mac Search for clipboard scripts
 ```
 
-The MCP includes 200+ pre-built scripts searchable via `get_scripting_tips` (categories, search terms, or browse all).
+## Related
 
-## Requirements
-
-- **macOS only** — AppleScript is macOS-specific
-- **Permissions**: System Settings > Privacy & Security > Automation + Accessibility
-
-## Full Documentation
-
-See `tools/automation/macos-automator.md` for setup, configuration, and tool parameter reference.
+See `tools/automation/macos-automator.md` for installation, configuration, and parameter details.


### PR DESCRIPTION
## Summary
- move the @mac card to a quick-reference structure so the purpose, permissions, and full setup pointer appear first
- clarify when to use each macOS automation tool, including searching built-in scripts before writing custom automation
- keep the existing example prompts while tightening section names and wording

## Testing
- npx --yes markdownlint-cli2 ".agents/tools/automation/mac.md"

## Runtime Testing
- self-assessed: low-risk documentation-only change; no runtime behavior changed

Closes #14378


---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4