### PR TITLE
GH#14369: tighten agent routing doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3015,6 +3015,11 @@
       "hash": "102c82fd40a93f9e219e84ee053645eff00db29b",
       "at": "2026-03-31T03:46:07Z",
       "pr": 14541
+    },
+    ".agents/reference/agent-routing.md": {
+      "hash": "83e56233f5c7fc633bc3a64de90d9b5529a0bd33",
+      "at": "2026-03-31T05:34:14Z",
+      "pr": 14650
     }
   }
 }

--- a/.agents/reference/agent-routing.md
+++ b/.agents/reference/agent-routing.md
@@ -1,37 +1,36 @@
 # Agent Routing
 
-Not every task is code. The framework has multiple primary agents, each with domain expertise. When dispatching workers (via `/pulse`, `/runners`, or `headless-runtime-helper.sh run`), route to the appropriate agent using `--agent <name>`.
+## Core rule
 
-## Available Primary Agents
+Dispatch workers with `headless-runtime-helper.sh run`, not bare runtime CLIs. The helper provides provider rotation, session persistence, backoff, and lifecycle reinforcement. Bare `claude run`, `claude`, `claude -p`, or similar commands can skip lifecycle reinforcement and stop after PR creation (GH#5096).
 
-Full index in `subagent-index.toon`.
+## Routing order
+
+1. Read the task or issue description.
+2. If it is clearly code work (`implement`, `fix`, `refactor`, `CI`), use Build+ or omit `--agent`.
+3. If it matches another domain, pass `--agent <name>`.
+4. If uncertain, default to Build+; it can load narrower docs on demand.
+5. **Bundle-aware routing (t1364.6):** project bundles can define `agent_routing` overrides. Check with `bundle-helper.sh get agent_routing <repo-path>`. An explicit `--agent` flag wins.
+
+The selected agent changes the system prompt and domain knowledge loaded for the worker.
+
+## Primary agents
+
+Full index: `subagent-index.toon`.
 
 | Agent | Use for |
 |-------|---------|
 | Build+ | Code: features, bug fixes, refactors, CI, PRs (default) |
 | Automate | Scheduling, dispatch, monitoring, background orchestration, pulse supervisor |
 | SEO | SEO audits, keyword research, GSC, schema markup |
-| Content | All media production and distribution: blog, video, audio, image, social, newsletters, AI video generation |
+| Content | Media production and distribution: blog, video, audio, image, social, newsletters, AI video generation |
 | Marketing-Sales | Email campaigns, FluentCRM, Meta Ads, CRO, direct response copy, CRM pipeline, proposals, outreach |
 | Business | Company operations, financial ops, invoicing, receipts, runner configs, strategy |
 | Legal | Compliance, terms of service, privacy policy |
 | Research | Tech research, competitive analysis, market research |
 | Health | Health and wellness content |
 
-## Routing Rules
-
-- Read the task/issue description and match it to the domain above
-- If the task is clearly code (implement, fix, refactor, CI), use Build+ or omit `--agent`
-- If the task matches another domain, pass `--agent <name>` to `headless-runtime-helper.sh run`
-- When uncertain, default to Build+ — it can read subagent docs on demand
-- The agent choice affects which system prompt and domain knowledge the worker loads
-- **Bundle-aware routing (t1364.6):** Project bundles can define `agent_routing` overrides per task domain. For example, a content-site bundle routes `marketing` tasks to the Marketing-Sales agent. Check with `bundle-helper.sh get agent_routing <repo-path>`. Explicit `--agent` flags always override bundle defaults.
-
-## Headless Dispatch
-
-ALWAYS use `headless-runtime-helper.sh run` for dispatching workers. This helper handles provider rotation, session persistence, backoff, and lifecycle reinforcement. NEVER use bare `claude run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (GH#5096). NEVER use `claude`, `claude -p`, or any other CLI.
-
-### Dispatch Example
+## Dispatch example
 
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"


### PR DESCRIPTION
## Summary
- Move the headless dispatch rule to the top so the GH#5096 guard is the first instruction readers see.
- Reorder routing guidance into a short decision sequence and keep the primary-agent table plus dispatch examples intact.
- Record the updated .agents/reference/agent-routing.md hash in .agents/configs/simplification-state.json for the simplification pipeline.

## Testing
- npx markdownlint-cli2 ".agents/reference/agent-routing.md"
- python3 -m json.tool .agents/configs/simplification-state.json >/dev/null

## Runtime Testing
- Level: self-assessed
- Reason: low-risk docs-only change to agent guidance.

Closes #14369


---
[aidevops.sh](https://aidevops.sh) v3.5.495 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 100,592 tokens on this as a headless worker. Overall, 10h 43m since this issue was created.