### PR TITLE
GH#14368: tighten D1 gotchas doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md
@@ -1,6 +1,6 @@
 # D1 Gotchas & Troubleshooting
 
-## SQL Injection Prevention (CRITICAL)
+## Critical: Bind Parameters, Never Interpolate
 
 ```typescript
 // ❌ NEVER: String interpolation - SQL injection vulnerability
@@ -10,15 +10,11 @@ await env.DB.prepare(`SELECT * FROM users WHERE id = ${userId}`).all(); // DANGE
 await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).all();
 ```
 
-Attacker could pass `1 OR 1=1` to dump table or `1; DROP TABLE users;--` to delete data.
+Interpolated SQL lets attackers pass `1 OR 1=1` to dump a table or `1; DROP TABLE users;--` to delete data.
 
-## Common Errors
+## Query Performance Pitfalls
 
-**Missing Table:** "no such table" → Run migrations first  
-**Unique Constraint:** "UNIQUE constraint failed" → Catch and return 409  
-**Query Timeout:** 30s exceeded → Break into smaller queries or add indexes
-
-## N+1 Query Problem
+### N+1 Queries
 
 ```typescript
 // ❌ BAD: N+1 queries (multiple round trips)
@@ -32,14 +28,22 @@ const postsWithAuthors = await env.DB.prepare(`
 `).all();
 ```
 
-## Missing Indexes
+### Missing Indexes
 
 ```sql
 EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?;  -- Check for "USING INDEX"
 CREATE INDEX idx_users_email ON users(email);  -- Add if missing
 ```
 
-## Limits to Watch
+Monitor query performance via `meta.duration`, add indexes on frequently queried columns, and break long work into smaller queries instead of long transactions.
+
+## Common Errors
+
+- **`no such table`** — run migrations first.
+- **`UNIQUE constraint failed`** — catch and return `409`.
+- **Query timeout (`30s`)** — add indexes or split the query.
+
+## Limits That Change Design
 
 | Limit | Value | Impact |
 |-------|-------|--------|
@@ -48,23 +52,25 @@ CREATE INDEX idx_users_email ON users(email);  -- Add if missing
 | Query timeout | 30s | Break long queries into smaller chunks |
 | Batch size | 10,000 statements | Split large batches |
 
+Avoid a single large database when horizontal partitioning fits the workload better.
+
 ## Local vs Remote
 
-Local uses `.wrangler/state/v3/d1/<database-id>.sqlite`. Always test migrations locally before remote.
+Local D1 uses `.wrangler/state/v3/d1/<database-id>.sqlite`. Test migrations locally before applying them remotely.
 
-## Data Types
+## Data Type Gotchas
 
-**Boolean:** SQLite uses INTEGER (0/1) not boolean - bind 1 or 0, not true/false  
-**Date/Time:** Use TEXT (ISO 8601) or INTEGER (unix timestamp), not native DATE/TIME
+- **Boolean:** SQLite uses `INTEGER` (`0`/`1`), not a native boolean. Bind `1` or `0`, not `true`/`false`.
+- **Date/time:** Use `TEXT` (ISO 8601) or `INTEGER` (Unix timestamp), not native `DATE`/`TIME`.
 
-## Best Practices
+## Operating Rules
 
-- ✅ Use prepared statements with bind() - ALWAYS
-- ✅ Create indexes on frequently queried columns
-- ✅ Use batch() for multiple queries (reduces latency)
-- ✅ Design for horizontal scaling (multiple small DBs vs single large DB)
-- ✅ Test migrations locally before applying remotely
-- ✅ Monitor query performance via meta.duration
-- ❌ Don't store binary data directly (use R2 for blobs)
-- ❌ Don't use single large database (scale horizontally instead)
-- ❌ Don't run long transactions (30s timeout)
+- ✅ Use prepared statements with `bind()`.
+- ✅ Create indexes on frequently queried columns.
+- ✅ Use `batch()` for multiple queries to reduce latency.
+- ✅ Design for horizontal scaling with multiple small DBs when needed.
+- ✅ Test migrations locally before applying remotely.
+- ✅ Monitor query performance via `meta.duration`.
+- ❌ Don't store binary data directly in D1; use R2 for blobs.
+- ❌ Don't rely on a single large database as the default scaling plan.
+- ❌ Don't run long transactions; the timeout is `30s`.


### PR DESCRIPTION
## Summary
- reorder the D1 gotchas doc around the highest-risk guidance so SQL injection and query-shape pitfalls are easier to find first
- tighten troubleshooting and design guidance into grouped sections without dropping D1 limits, local-vs-remote behavior, or datatype rules
- keep the existing examples while making the operating rules more scannable for headless agent use

## Testing
- markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Runtime Testing
- Level: self-assessed (docs-only change)
- Evidence: markdown lint passed; no runtime behavior changed

Closes #14368

---
[aidevops.sh](https://aidevops.sh) v3.5.495 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 1s on this as a headless worker.