### PR TITLE
GH#14367: tighten WordPress orchestrator doc

### DIFF
--- a/.agents/tools/wordpress.md
+++ b/.agents/tools/wordpress.md
@@ -10,24 +10,27 @@ mode: subagent
 
 ## Quick Reference
 
-- **Purpose**: WordPress ecosystem management
-- **Local Dev**: LocalWP with MCP integration
-- **Fleet Management**: MainWP for multi-site operations
-- **Preferred Plugins**: See `wp-preferred.md` (127+ plugins)
+- **Purpose**: Route WordPress work to the right specialist doc
+- **Local dev**: LocalWP + `localwp.md`
+- **Fleet ops**: MainWP + `mainwp.md`
+- **Plugin curation**: `wp-preferred.md` (127+ plugins across 19 categories)
+- **Custom fields**: `scf.md` for Secure Custom Fields / ACF
 
-**Subagents**:
-- `wp-dev.md` - Theme/plugin development, debugging
-- `wp-admin.md` - Content management, maintenance
-- `localwp.md` - Local development with MCP
-- `mainwp.md` - Multi-site fleet management
-- `wp-preferred.md` - Curated plugin list by category
-- `scf.md` - Secure Custom Fields / ACF
+**Subagents**
 
-**MCP Integration**:
-- LocalWP MCP: Direct database access for local sites
-- MainWP REST API: Fleet operations
+- `wp-dev.md` — theme/plugin development, debugging, test patterns
+- `wp-admin.md` — content management and maintenance
+- `localwp.md` — LocalWP development and MCP-backed database access
+- `mainwp.md` — multi-site fleet operations via MainWP
+- `wp-preferred.md` — curated plugin list by category
+- `scf.md` — Secure Custom Fields / ACF guidance
 
-**Key Commands**:
+**Platform integrations**
+
+- LocalWP MCP — direct database access for local sites
+- MainWP REST API — fleet operations across multiple sites
+
+**Key commands**
 
 ```bash
 # LocalWP sites
@@ -39,32 +42,31 @@ mode: subagent
 
 <!-- AI-CONTEXT-END -->
 
-## WordPress Ecosystem
+## Route by task
 
-### Local Development
+| Need | Use | Why |
+|------|-----|-----|
+| Build or debug code | `wp-dev.md` | Development workflow, debugging, implementation patterns |
+| Manage content or routine upkeep | `wp-admin.md` | Admin tasks and site maintenance |
+| Inspect a local site or database | `localwp.md` | LocalWP setup and MCP-backed local DB access |
+| Update many sites | `mainwp.md` | Centralized MainWP operations |
+| Choose plugins | `wp-preferred.md` | Curated, reliability-first recommendations |
+| Work with custom fields | `scf.md` | Field modeling and SCF/ACF guidance |
 
-Use LocalWP for local WordPress development:
-- Full MCP integration for database access
-- See `localwp.md` for setup
+## Operating model
 
-### Fleet Management
+- **Local development**: Use LocalWP for WordPress development and local database access.
+- **Fleet management**: Use MainWP for bulk updates, backups, monitoring, and security scans.
+- **Plugin selection**: Prefer the curated list in `wp-preferred.md` for reliability.
 
-MainWP provides centralized WordPress management:
-- Bulk updates, backups, security scans
-- See `mainwp.md` for operations
+## Default workflow
 
-### Development Workflow
+1. **Local** — develop in a LocalWP environment.
+2. **Test** — follow `wp-dev.md` patterns.
+3. **Deploy** — push via MainWP or the hosting provider.
+4. **Manage** — handle ongoing operations via `wp-admin.md`.
 
-1. **Local**: Develop in LocalWP environment
-2. **Test**: Use `wp-dev.md` patterns
-3. **Deploy**: Push via MainWP or hosting provider
-4. **Manage**: Ongoing via `wp-admin.md`
+## Notes
 
-### Plugin Selection
-
-`wp-preferred.md` contains 127+ curated plugins across 19 categories:
-- Performance, Security, SEO
-- Forms, E-commerce, Membership
-- Backup, Staging, Development tools
-
-Always prefer curated plugins for reliability.
+- `wp-preferred.md` covers performance, security, SEO, forms, e-commerce, membership, backup, staging, and development tooling.
+- Use this file as the router; keep detailed procedures in the specialist docs.


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/wordpress.md` into a routing-first orchestrator doc for WordPress work
- keep the LocalWP, MainWP, SCF, and preferred-plugin pointers while clarifying which specialist doc to use for each task
- preserve the default Local → Test → Deploy → Manage workflow in a more compact structure

## Testing
- bunx markdownlint-cli2 ".agents/tools/wordpress.md"

## Runtime Testing
- Level: self-assessed
- Reason: low-risk documentation-only change to an agent prompt
- Evidence: markdown lint passed and the doc still preserves the existing workflow and subagent references

Closes #14367


---
[aidevops.sh](https://aidevops.sh) v3.5.496 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.
