### PR TITLE
GH#14366: tighten seo-analyze command doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1614,7 +1614,7 @@
     ".agents/scripts/commands/seo-analyze.md": {
       "hash": "4e16b075f7d019c5c8f65815e2cbb7d9eb484840",
       "at": "2026-03-31T05:34:33Z",
-      "pr": null
+      "pr": 14655
     },
     ".agents/seo/debug-favicon.md": {
       "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1611,6 +1611,11 @@
       "at": "2026-03-31T04:45:56Z",
       "pr": 14604
     },
+    ".agents/scripts/commands/seo-analyze.md": {
+      "hash": "4e16b075f7d019c5c8f65815e2cbb7d9eb484840",
+      "at": "2026-03-31T05:34:33Z",
+      "pr": null
+    },
     ".agents/seo/debug-favicon.md": {
       "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",
       "at": "2026-03-29T22:09:18Z",

--- a/.agents/scripts/commands/seo-analyze.md
+++ b/.agents/scripts/commands/seo-analyze.md
@@ -4,15 +4,16 @@ agent: SEO
 mode: subagent
 ---
 
-Analyze exported SEO data for ranking opportunities, content cannibalization, and optimization targets.
+Analyze exported SEO data for ranking opportunities, cannibalization, and optimization targets.
 
 Target: $ARGUMENTS
 
 ## Quick Reference
 
-- **Purpose**: Find actionable SEO opportunities
-- **Input**: TOON files from `/seo-export`
-- **Output**: Analysis report in TOON format
+- Input: TOON exports from `/seo-export`
+- Helper: `~/.aidevops/agents/scripts/seo-analysis-helper.sh $ARGUMENTS`
+- Output: `~/.aidevops/.agent-workspace/work/seo-data/{domain}/analysis-{date}.toon`
+- Modes: full analysis, `quick-wins`, `striking-distance`, `low-ctr`, `cannibalization`, `summary`
 
 ## Usage
 
@@ -20,47 +21,34 @@ Target: $ARGUMENTS
 # Full analysis
 /seo-analyze example.com
 
-# Specific analyses
+# Focused views
 /seo-analyze example.com quick-wins
 /seo-analyze example.com striking-distance
 /seo-analyze example.com low-ctr
 /seo-analyze example.com cannibalization
 
-# View data summary
+# Export summary only
 /seo-analyze example.com summary
 ```
 
-## Process
+## Workflow
 
-1. Parse $ARGUMENTS to extract domain and analysis type
-2. Run the analysis script:
-
-```bash
-~/.aidevops/agents/scripts/seo-analysis-helper.sh $ARGUMENTS
-```
-
-3. Present results with actionable recommendations
+1. Parse `$ARGUMENTS` for domain and analysis type.
+2. Run the helper.
+3. Return the report with concrete recommendations.
 
 ## Analysis Types
 
-| Type | Criteria | Action |
-|------|----------|--------|
+| Type | Criteria | Primary action |
+|------|----------|----------------|
 | Quick Wins | Position 4-20, high impressions | On-page optimization |
 | Striking Distance | Position 11-30, high volume | Content expansion, backlinks |
 | Low CTR | CTR < 2%, high impressions | Title/meta optimization |
 | Cannibalization | Same query, multiple URLs | Consolidate content |
 
-## Output
+## Prerequisite
 
-Results are saved to:
-
-```text
-~/.aidevops/.agent-workspace/work/seo-data/{domain}/analysis-{date}.toon
-```
-
-## Prerequisites
-
-Requires exported data. If no data exists, suggest:
+If no export exists, run:
 
 ```bash
 /seo-export all example.com --days 90
@@ -68,4 +56,4 @@ Requires exported data. If no data exists, suggest:
 
 ## Documentation
 
-For full documentation, read `seo/ranking-opportunities.md`.
+See `seo/ranking-opportunities.md` for the full reference.


### PR DESCRIPTION
## Summary
- tighten `.agents/scripts/commands/seo-analyze.md` into a shorter command card while preserving usage modes, helper path, output location, and analysis criteria
- register the simplified file in `.agents/configs/simplification-state.json` so the simplification routine tracks the current hash

## Testing
- `bunx markdownlint-cli2 ".agents/scripts/commands/seo-analyze.md"`
- `jq empty .agents/configs/simplification-state.json`

## Runtime Testing
- Level: self-assessed
- Reason: docs and simplification-state metadata only; no runtime behavior changed

Closes #14366

---
[aidevops.sh](https://aidevops.sh) v3.5.495 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 3m and 61,921 tokens on this as a headless worker.