### PR TITLE
GH#14365: tighten Instantly v2 doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1851,6 +1851,11 @@
       "at": "2026-03-29T07:02:24Z",
       "pr": 12699
     },
+    ".agents/services/outreach/instantly.md": {
+      "hash": "4d19b6424aa379940ec9b8b60dd80d08e9e472fc",
+      "at": "2026-03-31T05:36:34Z",
+      "pr": 14656
+    },
     ".agents/services/outreach/manyreach.md": {
       "hash": "94a3e08bcf4edafcd9654e8252a1a8851b004217",
       "at": "2026-03-29T07:02:27Z",

--- a/.agents/services/outreach/instantly.md
+++ b/.agents/services/outreach/instantly.md
@@ -14,9 +14,9 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Manage Instantly outbound infrastructure via API v2
-- **Auth**: `Authorization: Bearer <INSTANTLY_API_KEY>`
 - **Base URL**: `https://api.instantly.ai/api/v2`
-- **Helper**: `scripts/instantly-helper.sh` (repo path: `.agents/scripts/instantly-helper.sh`)
+- **Auth**: `Authorization: Bearer <INSTANTLY_API_KEY>`
+- **Helper**: `scripts/instantly-helper.sh` (`.agents/scripts/instantly-helper.sh`)
 - **Secret setup**: `aidevops secret set INSTANTLY_API_KEY`
 - **Safe execution**: `aidevops secret run INSTANTLY_API_KEY -- instantly-helper.sh <command>`
 
@@ -32,25 +32,25 @@ tools:
 - `instantly-helper.sh warmup enable --email-account-id <account_id>`
 - `instantly-helper.sh analytics campaign --campaign-id <campaign_id>`
 
-## Raw Endpoint Access
+## Raw Requests
 
-Use raw mode when an endpoint evolves faster than helper aliases:
+Use raw mode when helper aliases lag API changes:
 
 ```bash
 instantly-helper.sh request --method GET --endpoint /campaigns
 instantly-helper.sh request --method POST --endpoint /leads --json-file ./lead.json
 ```
 
-## Payload Workflow
+Payload workflow:
 
-1. Prepare payload file (for example `campaign.json`, `lead.json`)
+1. Prepare a payload file such as `campaign.json` or `lead.json`
 2. Validate JSON locally with `python3 -m json.tool <file>`
-3. Execute helper command with `--json-file`
-4. Keep payload templates in project docs, not in shared terminal history
+3. Execute the helper with `--json-file`
+4. Keep payload templates in project docs, not shared terminal history
 
-## Warmup Operating Pattern
+## Warmup
 
-- List all email accounts or account warmup state with `warmup list`
+- Check account warmup state with `warmup list`
 - Enable warmup for newly connected inboxes before high-volume sends
 - Disable warmup only after mailbox health and reply rates stabilize
 - Pair warmup actions with cold-outreach guardrails from `services/outreach/cold-outreach.md`


### PR DESCRIPTION
## Summary
- tighten the Instantly API v2 doc wording and headings without removing commands, URLs, or troubleshooting guidance
- keep raw request and payload guidance together so API fallback usage stays easier to scan

## Testing
- bunx markdownlint-cli2 ".agents/services/outreach/instantly.md"
- git diff --check
- python3 -c \"from pathlib import Path; t=Path('.agents/services/outreach/instantly.md').read_text(); required=['https://api.instantly.ai/api/v2','aidevops secret set INSTANTLY_API_KEY','instantly-helper.sh request --method GET --endpoint /campaigns','instantly-helper.sh request --method POST --endpoint /leads --json-file ./lead.json','services/outreach/cold-outreach.md']; missing=[s for s in required if s not in t]; print('OK' if not missing else 'MISSING: ' + ', '.join(missing))\" 

## Runtime Testing
- self-assessed: low-risk agent doc change only

Closes #14365

---
[aidevops.sh](https://aidevops.sh) v3.5.496 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4