### PR TITLE
GH#14358: tighten mutations cheatsheet

### DIFF
--- a/.agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md
+++ b/.agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md
@@ -3,37 +3,29 @@
 ## Insert
 
 ```typescript
-// Single
-const [user] = await db.insert(users)
-  .values({ email, name })
-  .returning();
+// Single insert
+const [user] = await db.insert(users).values({ email, name }).returning();
 
-// Multiple
+// Batch insert
 await db.insert(users).values([
   { email: 'a@b.com', name: 'A' },
   { email: 'b@b.com', name: 'B' },
 ]);
 
 // Upsert
-await db.insert(users)
-  .values({ email, name })
-  .onConflictDoUpdate({
-    target: users.email,
-    set: { name },
-  });
+await db.insert(users).values({ email, name }).onConflictDoUpdate({
+  target: users.email,
+  set: { name },
+});
 
 // Ignore conflict
-await db.insert(users)
-  .values({ email, name })
-  .onConflictDoNothing();
+await db.insert(users).values({ email, name }).onConflictDoNothing();
 ```
 
 ## Update
 
 ```typescript
-await db.update(users)
-  .set({ status: 'active' })
-  .where(eq(users.id, id));
+await db.update(users).set({ status: 'active' }).where(eq(users.id, id));
 
 // With returning
 const [updated] = await db.update(users)
@@ -52,9 +44,8 @@ await db.update(posts)
 ```typescript
 await db.delete(users).where(eq(users.id, id));
 
-const [deleted] = await db.delete(users)
-  .where(eq(users.id, id))
-  .returning();
+// With returning
+const [deleted] = await db.delete(users).where(eq(users.id, id)).returning();
 ```
 
 ## Transactions
@@ -69,6 +60,6 @@ await db.transaction(async (tx) => {
 // Rollback
 await db.transaction(async (tx) => {
   await tx.insert(users).values({ ... });
-  if (condition) tx.rollback();  // Throws
+  if (condition) tx.rollback(); // Throws
 });
 ```


### PR DESCRIPTION
## Summary
- condense the Postgres Drizzle mutations cheatsheet without dropping any mutation patterns
- keep insert, update, delete, and transaction examples while removing redundant line breaks and wording

## Testing
- `bunx markdownlint-cli2 ".agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md"`

## Runtime Testing
- Level: self-assessed (low-risk doc-only change)
- Runtime verification not required for this markdown-only simplification

Closes #14358

---
[aidevops.sh](https://aidevops.sh) v3.5.496 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 15m on this as a headless worker.