### PR TITLE
GH#14356: tighten Agent SDK gotchas doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -346,6 +346,11 @@
       "at": "2026-03-28T05:50:52Z",
       "pr": 11443
     },
+    ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md": {
+      "hash": "819096c73ef171c0e0e58c2929c5d11f72401931",
+      "at": "2026-03-31T05:38:15Z",
+      "pr": 14658
+    },
     ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
       "hash": "b59a17a028d181e2f55c45e58c371ca999d9a2ee",
       "at": "2026-03-28T05:50:55Z",

--- a/.agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md
@@ -1,9 +1,9 @@
 # Gotchas & Best Practices
 
-## Security first
+## Security and auth first
 
-- DO: Validate/sanitize input, require WS auth, keep secrets in env bindings.
-- DON'T: Trust headers blindly, expose sensitive data, or store secrets in state.
+- Validate/sanitize input, require WebSocket auth before `conn.accept()`, and keep secrets in env bindings.
+- Don't trust client-controlled headers blindly, expose sensitive data, or store secrets in agent/connection state.
 
 ```ts
 async onConnect(conn: Connection, ctx: ConnectionContext) {
@@ -14,19 +14,16 @@ async onConnect(conn: Connection, ctx: ConnectionContext) {
 }
 ```
 
-## State
+## State and SQL discipline
 
-- DO: Use `setState()` (auto-sync), keep state serializable/small, move large data to SQL.
-- DON'T: Mutate `this.state` directly or store functions/circular objects.
+- Use `setState()` for auto-sync, keep state serializable/small, and move large data to SQL.
+- Don't mutate `this.state` directly or store functions/circular objects.
+- Initialize schema in `onStart()`, parameterize queries, and use explicit types when possible.
+- Don't interpolate user input into SQL or assume tables already exist.
 
 ```ts
 // ❌ this.state.count++ | ✅ this.setState({...this.state, count: this.state.count + 1})
 ```
-
-## SQL
-
-- DO: Parameterize queries, initialize schema in `onStart()`, use explicit types when possible.
-- DON'T: Interpolate input directly or assume tables already exist.
 
 ```ts
 // ❌ this.sql`...WHERE id = '${userId}'` | ✅ this.sql`...WHERE id = ${userId}`
@@ -34,8 +31,8 @@ async onConnect(conn: Connection, ctx: ConnectionContext) {
 
 ## WebSocket lifecycle
 
-- DO: Call `conn.accept()` promptly, handle errors, clean up on disconnect.
-- DON'T: Assume persistence or keep sensitive data in connection state.
+- Call `conn.accept()` promptly, handle errors, and clean up on disconnect.
+- Don't assume persistence or keep sensitive data in connection state.
 
 ```ts
 async onConnect(conn: Connection, ctx: ConnectionContext) { conn.accept(); conn.setState({sessionRef: "sess_abc123"}); }
@@ -43,8 +40,9 @@ async onConnect(conn: Connection, ctx: ConnectionContext) { conn.accept(); conn.
 
 ## Scheduling constraints
 
-- Limits: 1 alarm at a time per DO (new `setAlarm()` overwrites prior); retries use exponential backoff (up to 6 attempts); alarm handler wall-clock limit 15 min.
-- Practice: clean stale schedules, use descriptive names, handle failures.
+- Only 1 alarm exists per DO; a new `setAlarm()` overwrites the prior alarm.
+- Retries use exponential backoff for up to 6 attempts, and alarm handlers have a 15-minute wall-clock limit.
+- Clean stale schedules, use descriptive names, and handle failures.
 
 ```ts
 async checkSchedules() { const schedules = await this.getSchedules(); if (schedules.length > 0) console.log("Active schedule:", schedules[0]); }
@@ -52,21 +50,20 @@ async checkSchedules() { const schedules = await this.getSchedules(); if (schedu
 
 ## AI reliability and performance
 
-- Optimize with AI Gateway cache, streaming, and rate limiting.
-- Use `try/catch` + fallback for quota/timeout/provider errors.
-- Batch `setState()` writes; reduce write frequency.
-- Limit broadcast fan-out, prefer selective sends, apply backpressure.
+- Prefer AI Gateway cache, streaming, and rate limiting.
+- Wrap model calls in `try/catch` with quota/timeout/provider fallbacks.
+- Batch `setState()` writes, reduce write frequency, and limit broadcast fan-out with backpressure/selective sends.
 
 ```ts
 try { return await this.env.AI.run(model, {prompt}); } catch (e) { return {error: "Unavailable"}; }
 ```
 
-## Limits, debugging, migration
+## Limits, debugging, and migration
 
-- Runtime limits: CPU 30s/request (configurable to 5 min via `limits.cpu_ms`), memory 128MB/instance, SQL shares DO quota, 1 alarm/DO, max 32,768 WS connections/DO (practical limit lower due to CPU/memory).
-- Debug: `npx wrangler dev` (local), `npx wrangler tail` (remote).
+- Runtime limits: CPU 30s/request (configurable to 5 min via `limits.cpu_ms`), memory 128MB/instance, SQL shares DO quota, 1 alarm/DO, max 32,768 WebSocket connections/DO; practical limits are lower due to CPU/memory.
+- Debug with `npx wrangler dev` locally and `npx wrangler tail` remotely.
 - Common failures: "Agent not found" (DO binding), state not syncing (`setState()`), connect timeout (`conn.accept()`), startup SQL errors (`onStart()` init).
-- Migration: SQLite backend must be enabled at class creation (`new_sqlite_classes`); cannot be added to an existing deployed class. Test in staging; delete migrations are destructive and permanent.
+- SQLite backend migrations must enable `new_sqlite_classes` when the class is first created; you cannot add it to an existing deployed class. Test in staging; delete migrations are destructive and permanent.
 
 ```toml
 [[migrations]]


### PR DESCRIPTION
## Summary
- tighten the Agent SDK gotchas doc by moving security/auth guidance to the top and combining state/SQL rules into a shorter reference card
- keep all existing code examples and operational constraints while making scheduling, AI reliability, and migration guidance more direct
- record the updated document hash in ".agents/configs/simplification-state.json" for future simplification scans

## Testing
- bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md"
- python3 -m json.tool .agents/configs/simplification-state.json >/dev/null

## Runtime Testing
- self-assessed: docs-only change; runtime testing not required

Closes #14356


---
[aidevops.sh](https://aidevops.sh) v3.5.498 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m on this as a headless worker.