### PR TITLE
GH#14355: tighten Infraforge outreach doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1856,6 +1856,11 @@
       "at": "2026-03-29T07:02:27Z",
       "pr": 12581
     },
+    ".agents/services/outreach/infraforge.md": {
+      "hash": "0d891dd02a90d75779370f3c62f2929df0bdcd31",
+      "at": "2026-03-31T05:38:33Z",
+      "pr": 14659
+    },
     ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
       "hash": "a2b88a20fedbcbbf37624126551caf4b6a101400",
       "at": "2026-03-29T07:02:28Z",

--- a/.agents/services/outreach/infraforge.md
+++ b/.agents/services/outreach/infraforge.md
@@ -8,39 +8,30 @@ tools:
 
 # Infraforge
 
-Infraforge is the private-infrastructure option for outreach sending. Use it when you need dedicated IP control, tighter isolation, and direct DNS/server ownership.
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- Use Infraforge when outreach needs dedicated IP control, tighter isolation, and direct DNS/server ownership.
+- Prefer Mailforge when speed-to-launch and lower operational burden matter more than infrastructure control.
+- Use `.agents/scripts/infraforge-helper.sh` for all Infraforge API operations.
+- Required environment: `INFRAFORGE_API_KEY`; add `INFRAFORGE_MAILBOX_PASSWORD` only for `mailboxes-create`.
+- Core flow: `domains-provision` → `dns-upsert` → `mailboxes-create` → `ips-assign` → `ssl-enable` → domain masking when required.
+- Before scaling, validate SPF/DKIM/DMARC, keep warmup conservative, and roll out DNS/IP changes in small batches.
 
 ## Infraforge vs Mailforge
 
 | Dimension | Infraforge | Mailforge |
 |---|---|---|
 | Infrastructure model | Private/dedicated | Shared infrastructure |
-| Deliverability control | High (dedicated IP and DNS posture control) | Medium (provider-managed shared pool posture) |
-| Setup speed | Slower (more provisioning steps) | Faster (lower setup overhead) |
-| Operational burden | Higher (you own more moving parts) | Lower (provider abstracts infrastructure operations) |
-| Best fit | Teams optimizing long-term sender control | Teams optimizing speed-to-launch |
+| Deliverability control | High — you control dedicated IP and DNS posture | Medium — provider manages shared pool posture |
+| Setup speed | Slower | Faster |
+| Operational burden | Higher | Lower |
+| Best fit | Long-term sender control | Faster launch with less ops overhead |
 
-## API Surfaces
+## Setup
 
-- Domain provisioning (`domains/provision`)
-- DNS automation (`dns/upsert`)
-- Mailbox creation (`mailboxes/create`)
-- Dedicated IP assignment (`ips/assign`)
-- SSL enablement (`ssl/enable`)
-- Domain masking (`domain-masking/enable`)
-
-## Helper Script
-
-Use `.agents/scripts/infraforge-helper.sh` for all Infraforge API operations.
-
-### Required Environment
-
-- `INFRAFORGE_API_KEY`
-- `INFRAFORGE_MAILBOX_PASSWORD` (only for mailbox creation)
-
-Never paste secret values into AI chat. Set secrets in your terminal with hidden prompts.
-
-Suggested setup:
+Never paste secret values into AI chat. Set them in your terminal with hidden prompts.
 
 ```bash
 aidevops secret set INFRAFORGE_API_KEY
@@ -48,16 +39,14 @@ export INFRAFORGE_API_KEY="<loaded-in-your-terminal-session>"
 export INFRAFORGE_MAILBOX_PASSWORD="<mailbox-password>"
 ```
 
-## Provisioning Flow
+## Commands
 
-1. Provision sending domain (`domains-provision`)
-2. Apply DNS records (`dns-upsert` for SPF/DKIM/DMARC, MX, tracking host)
-3. Create mailboxes (`mailboxes-create`)
-4. Assign dedicated IP (`ips-assign`)
-5. Enable SSL (`ssl-enable`)
-6. Enable domain masking when required by your sending architecture
-
-## Command Examples
+- Domain provisioning: `domains/provision`
+- DNS automation: `dns/upsert`
+- Mailbox creation: `mailboxes/create`
+- Dedicated IP assignment: `ips/assign`
+- SSL enablement: `ssl/enable`
+- Domain masking: `domain-masking/enable`
 
 ```bash
 .agents/scripts/infraforge-helper.sh domains-provision sender-example.com
@@ -68,9 +57,18 @@ export INFRAFORGE_MAILBOX_PASSWORD="<mailbox-password>"
 .agents/scripts/infraforge-helper.sh ssl-enable sender-example.com
 ```
 
-## Operational Guardrails
+## Operating Rules
 
-- Keep mailbox throughput conservative during warmup (align with `services/outreach/cold-outreach.md` guidance)
-- Roll out DNS changes in small batches to reduce reputation shocks
-- Use one dedicated IP pool per campaign cohort when possible for cleaner diagnostics
-- Validate SPF/DKIM/DMARC before scaling volume
+1. Provision the sending domain.
+2. Apply SPF/DKIM/DMARC, MX, and tracking-host DNS records.
+3. Create mailboxes.
+4. Assign a dedicated IP.
+5. Enable SSL.
+6. Enable domain masking when the sending architecture requires it.
+
+- Keep mailbox throughput conservative during warmup; align with `services/outreach/cold-outreach.md`.
+- Roll out DNS changes in small batches to reduce reputation shocks.
+- Prefer one dedicated IP pool per campaign cohort for cleaner diagnostics.
+- Validate SPF/DKIM/DMARC before scaling volume.
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary
- add a quick-reference-first structure so Infraforge guidance front-loads the operating decision, required secrets, and provisioning flow
- keep the existing command examples and infrastructure comparison while tightening prose and consolidating repetitive sections
- classify runtime testing as self-assessed because this PR only changes agent documentation

## Runtime Testing
- Level: self-assessed
- Evidence: `bunx markdownlint-cli2 ".agents/services/outreach/infraforge.md"`

Closes #14355

---
[aidevops.sh](https://aidevops.sh) v3.5.494 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 15m on this as a headless worker.