### PR TITLE
GH#14343: split nurture email reference corpus

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2621,6 +2621,11 @@
       "at": "2026-03-29T22:09:31Z",
       "pr": 13314
     },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md": {
+      "hash": "213bbe9f8924a85a7f616e9ceb2b50e89fd609d4",
+      "at": "2026-03-31T05:42:16Z",
+      "pr": 14662
+    },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
       "hash": "0a96775e8682e8b03590b673f9c8180c5cc99908",
       "at": "2026-03-29T22:09:33Z",

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture-04-morning-brew-story-driven-value.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture-04-morning-brew-story-driven-value.md
@@ -1,0 +1,32 @@
+# 4. Morning Brew — Story-Driven Value
+
+**Subject:** The $1.4B mistake airlines keep making
+
+```text
+Good morning,
+
+In 2010, Continental Airlines lost $1.4 billion.
+
+Not from crashes. Not from fuel costs.
+
+From revenue management—the system that decides
+which seats to sell at which prices.
+
+Here's what happened:
+
+[Story about their pricing algorithm failure]
+
+The lesson? The best algorithms still need human oversight.
+
+That's why the smartest companies are building
+"human-in-the-loop" AI systems.
+
+More on this tomorrow.
+
+—Morning Brew
+
+P.S. Think your friends would like this? Forward it
+and they can sign up here.
+```
+
+**Why it works:** Hook with surprising number, story structure (curiosity → explanation → lesson), business insight, referral prompt.

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture-05-james-clear-value-first.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture-05-james-clear-value-first.md
@@ -1,0 +1,36 @@
+# 5. James Clear — Value First
+
+**Subject:** 3-2-1: On focus, curiosity, and improving every day
+
+```text
+Happy Thursday,
+
+Here are 3 ideas, 2 quotes, and 1 question to consider this week.
+
+3 IDEAS FROM ME
+
+I. The most productive way to improve is to focus on
+one thing. Not for a day, but for months or even years.
+
+II. [Second insight]
+
+III. [Third insight]
+
+2 QUOTES FROM OTHERS
+
+I. "Do not seek to follow in the footsteps of the wise.
+Seek what they sought." — Matsuo Bashō
+
+II. [Second quote]
+
+1 QUESTION FOR YOU
+
+What habit would your future self thank you for starting today?
+
+Have a great week,
+James
+
+P.S. If you enjoyed this, share it with others.
+```
+
+**Why it works:** Predictable format readers expect, mixed content (ideas/quotes/question), encourages reflection, easy to share.

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md
@@ -2,76 +2,19 @@
 
 High-converting nurture email examples with analysis.
 
----
+Reference corpus: examples stay intact in companion files; this page is the index.
 
-### 4. Morning Brew — Story-Driven Value
+## Examples
 
-**Subject:** The $1.4B mistake airlines keep making
+1. `04-morning-brew-story-driven-value`
+   - File: `direct-response-copy-swipe-file-emails-02-nurture-04-morning-brew-story-driven-value.md`
+   - Angle: story-led nurture email that teaches through a surprising business failure.
+2. `05-james-clear-value-first`
+   - File: `direct-response-copy-swipe-file-emails-02-nurture-05-james-clear-value-first.md`
+   - Angle: repeatable newsletter structure built around ideas, quotes, and a question.
 
-```
-Good morning,
+## Usage
 
-In 2010, Continental Airlines lost $1.4 billion.
-
-Not from crashes. Not from fuel costs.
-
-From revenue management—the system that decides 
-which seats to sell at which prices.
-
-Here's what happened:
-
-[Story about their pricing algorithm failure]
-
-The lesson? The best algorithms still need human oversight.
-
-That's why the smartest companies are building 
-"human-in-the-loop" AI systems.
-
-More on this tomorrow.
-
-—Morning Brew
-
-P.S. Think your friends would like this? Forward it 
-and they can sign up here.
-```
-
-**Why it works:** Hook with surprising number, story structure (curiosity → explanation → lesson), business insight, referral prompt.
-
----
-
-### 5. James Clear — Value First
-
-**Subject:** 3-2-1: On focus, curiosity, and improving every day
-
-```
-Happy Thursday,
-
-Here are 3 ideas, 2 quotes, and 1 question to consider this week.
-
-3 IDEAS FROM ME
-
-I. The most productive way to improve is to focus on
-one thing. Not for a day, but for months or even years.
-
-II. [Second insight]
-
-III. [Third insight]
-
-2 QUOTES FROM OTHERS
-
-I. "Do not seek to follow in the footsteps of the wise.
-Seek what they sought." — Matsuo Bashō
-
-II. [Second quote]
-
-1 QUESTION FOR YOU
-
-What habit would your future self thank you for starting today?
-
-Have a great week,
-James
-
-P.S. If you enjoyed this, share it with others.
-```
-
-**Why it works:** Predictable format readers expect, mixed content (ideas/quotes/question), encourages reflection, easy to share.
+- Start here to pick the nurture pattern you want.
+- Open the companion file for the full example and analysis.
+- Keep the original numbering so the wider swipe-file sequence stays consistent.


### PR DESCRIPTION
## Summary
- Classify `.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md` as a reference corpus, not an instruction doc.
- Replace the monolithic nurture file with a slim index that points to two companion example files.
- Preserve both email examples verbatim in dedicated files so the swipe corpus stays intact while navigation gets lighter.

## Runtime Testing
- Level: self-assessed
- Risk: low — markdown-only reference corpus restructure.
- Verification: `bunx markdownlint-cli2 ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture*.md"`
- Content preservation: `wc -l .agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture*.md` = 88 total lines vs 77 original.

## Files Changed
- `.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md`
- `.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture-04-morning-brew-story-driven-value.md`
- `.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture-05-james-clear-value-first.md`

Closes #14343


---
[aidevops.sh](https://aidevops.sh) v3.5.499 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 7m and 171,855 tokens on this as a headless worker. Overall, 11h 35m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new email template examples to the swipe file library, including a Morning Brew story-driven value email (with curiosity-hook opening) and a James Clear value-first email (featuring 3-2-1 structure). Both templates include subject lines, body copy, and effectiveness notes for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->