### PR TITLE
GH#14333: tighten agent doc Importing assets in Remotion

### DIFF
--- a/.agents/tools/video/remotion-assets.md
+++ b/.agents/tools/video/remotion-assets.md
@@ -8,13 +8,9 @@ metadata:
 
 # Importing assets in Remotion
 
-## The public folder
+## Local assets: `public/` + `staticFile()`
 
-Place assets in the `public/` folder at your project root.
-
-## Using staticFile()
-
-You MUST use `staticFile()` to reference files from the `public/` folder:
+Place project assets in `public/` and reference them with `staticFile()`. It returns an encoded URL that keeps local asset paths working, including deployments under subdirectories and filenames with characters like `#`, `?`, and `&`.
 
 ```tsx
 import {Img, staticFile} from 'remotion';
@@ -24,37 +20,20 @@ export const MyComposition = () => {
 };
 ```
 
-The function returns an encoded URL that works correctly when deploying to subdirectories.
+## Supported asset types
 
-## Using with components
-
-**Images:**
+Use `staticFile()` for local images, videos, audio, and fonts:
 
 ```tsx
 import {Img, staticFile} from 'remotion';
+import {Video, Audio} from '@remotion/media';
 
 <Img src={staticFile('photo.png')} />;
-```
-
-**Videos:**
-
-```tsx
-import {Video} from '@remotion/media';
-import {staticFile} from 'remotion';
-
 <Video src={staticFile('clip.mp4')} />;
-```
-
-**Audio:**
-
-```tsx
-import {Audio} from '@remotion/media';
-import {staticFile} from 'remotion';
-
 <Audio src={staticFile('music.mp3')} />;
 ```
 
-**Fonts:**
+For fonts, load the file URL returned by `staticFile()`:
 
 ```tsx
 import {staticFile} from 'remotion';
@@ -66,14 +45,13 @@ document.fonts.add(fontFamily);
 
 ## Remote URLs
 
-Remote URLs can be used directly without `staticFile()`:
+Remote URLs can be passed directly without `staticFile()`:
 
 ```tsx
 <Img src="https://example.com/image.png" />
 <Video src="https://remotion.media/video.mp4" />
 ```
 
-## Important notes
+## Why use Remotion components
 
 - Remotion components (`<Img>`, `<Video>`, `<Audio>`) ensure assets are fully loaded before rendering
-- Special characters in filenames (`#`, `?`, `&`) are automatically encoded


### PR DESCRIPTION
## Summary
- compress the Remotion assets doc around the core rule: keep local media in `public/` and reference it with `staticFile()`
- group local image, video, audio, and font examples into a shorter structure without dropping the encoded-path guidance
- keep remote URL usage and the Remotion component loading guarantee explicit

## Runtime Testing
- self-assessed: low-risk documentation-only change
- markdown lint: `npx --yes markdownlint-cli2 ".agents/tools/video/remotion-assets.md"`

## Files Changed
- `.agents/tools/video/remotion-assets.md`

Closes #14333


---
[aidevops.sh](https://aidevops.sh) v3.5.499 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 15m on this as a headless worker.