### PR TITLE
GH#14063: tighten jujutsu.md agent doc

### DIFF
--- a/.agents/tools/git/jujutsu.md
+++ b/.agents/tools/git/jujutsu.md
@@ -18,43 +18,21 @@ tools:
 
 ## Quick Reference
 
-- **CLI**: `jj` (Jujutsu) - Git-compatible VCS, written in Rust
+- **CLI**: `jj` — Git-compatible VCS, written in Rust
 - **Install**: `brew install jj` (macOS) | `cargo install jj-cli` (all platforms)
 - **Repo**: <https://github.com/jj-vcs/jj> (25k+ stars, Apache-2.0)
 - **Docs**: <https://docs.jj-vcs.dev/latest/>
-- **Status**: Experimental but daily-driven by core team; Git backend is stable
+- **Status**: Experimental; Git backend stable, daily-driven by core team
 
 ## Key Advantages Over Git
 
-### Working-Copy-as-Commit
-
-Every file change is automatically recorded as a commit. No staging area, no index.
-`jj` snapshots the working copy before every command - eliminates "dirty working
-directory" errors, removes the need for `git stash`, and lets you set commit messages
-anytime with `jj describe`.
-
-### Operation Log with Undo
-
-Every repository operation is recorded. `jj op log` shows history, `jj undo` reverses
-the last operation, `jj op restore <op-id>` restores any previous state.
-
-### First-Class Conflicts
-
-Conflicts are stored in commits, not as blocking errors. No command fails due to
-conflicts. Resolve them later at your convenience. Conflict resolutions propagate
-automatically to descendant commits, subsuming most `git rerere` use cases.
-
-### Automatic Rebase of Descendants
-
-Modifying any commit automatically rebases all descendants. Edit a parent and children
-update in place. Equivalent to transparent `git rebase --update-refs`. Bookmark
-(branch) pointers update automatically.
-
-### Anonymous Branches
-
-No need to name every branch. Jujutsu tracks all visible heads of the commit graph.
-Commits are never lost while reachable. Use bookmarks (named branches) only when
-pushing to remotes.
+| Feature | How it works |
+|---------|-------------|
+| **Working-copy-as-commit** | Every file change auto-recorded as commit. No staging area/index. Snapshots before every command — no dirty-directory errors, no `git stash`. Set messages anytime: `jj describe`. |
+| **Operation log + undo** | All ops recorded. `jj op log` shows history, `jj undo` reverses last op, `jj op restore <id>` restores any state. |
+| **First-class conflicts** | Conflicts stored in commits, not blocking errors. Resolve later; resolutions propagate to descendants (subsumes `git rerere`). |
+| **Auto-rebase descendants** | Modifying any commit rebases all descendants in place. Bookmark pointers update automatically. Equivalent to transparent `git rebase --update-refs`. |
+| **Anonymous branches** | Tracks all visible heads — commits never lost while reachable. Bookmarks (named branches) only needed for pushing to remotes. |
 
 ## Essential Commands
 
@@ -86,34 +64,21 @@ jj bookmark set main         # Set a bookmark (branch) on current commit
 
 ## Colocated Mode (Gradual Adoption)
 
-Run `jj init --git-repo=.` in any existing git repo to use both tools side by side.
-Creates `.jj/` alongside `.git/` - both `jj` and `git` commands work in the same repo,
-reading/writing the same Git objects and refs. Team members continue using git while
-you use jj. Low-risk way to evaluate on real projects.
+`jj init --git-repo=.` in any existing git repo creates `.jj/` alongside `.git/`. Both `jj` and `git` commands work on the same objects and refs. Team members continue using git; low-risk evaluation path.
 
 ## Benefits for AI-Assisted Development
 
-- **No staging friction**: File writes are automatically part of the working-copy
-  commit. No `git add` needed - eliminates a common source of agent errors.
-- **Safe experimentation**: `jj undo` reverses any operation instantly. Agents can
-  try approaches and roll back without risk of lost work.
-- **Parallel agent conflicts**: Multiple agents modifying overlapping files produce
-  committed conflicts rather than blocking errors. Resolve asynchronously.
-- **Simpler mental model**: One object type (commits) vs Git's working tree + index +
-  HEAD + stash. Fewer concepts means fewer agent mistakes.
-- **Audit trail**: `jj op log` provides complete operation history for debugging
-  autonomous agent actions in headless workflows.
+- **No staging friction** — file writes auto-commit; no `git add` errors
+- **Safe experimentation** — `jj undo` reverses any op instantly; agents try and roll back freely
+- **Parallel agent conflicts** — overlapping edits produce committed conflicts, not blocking errors
+- **Simpler mental model** — one object type (commits) vs git's working tree + index + HEAD + stash
+- **Audit trail** — `jj op log` provides complete operation history for headless workflow debugging
 
-## Integration with aidevops Worktree Workflow
+## aidevops Worktree Integration
 
-Colocated mode works alongside `wt` (Worktrunk) worktree workflows. Worktrees created
-by `wt switch -c` are standard git worktrees; colocate each with `jj init --git-repo=.`
-if desired. `jj git push` replaces `git push` using the same remotes. Bookmarks map
-directly to git branches.
+Colocated mode works with `wt` (Worktrunk) worktrees. Colocate each with `jj init --git-repo=.` if desired. `jj git push` replaces `git push` using the same remotes; bookmarks map directly to git branches.
 
-**See also**: `tools/git/github-cli.md` (PR and remote workflows),
-`tools/git/conflict-resolution.md` (git conflict strategies),
-`tools/git/worktrunk.md` (worktree management)
+**See also**: `tools/git/github-cli.md` (PR/remote workflows), `tools/git/conflict-resolution.md` (conflict strategies), `tools/git/worktrunk.md` (worktree management)
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/tools/git/jujutsu.md` from 125 → 90 lines (28% reduction)
- Converted verbose "Key Advantages" prose sections into a compact table format
- Compressed Colocated Mode and aidevops Integration sections into terse paragraphs

## What Changed

- **Key Advantages Over Git**: 5 subsections with multi-line prose → single table with concise descriptions
- **Colocated Mode**: 5-line paragraph → 2-line paragraph
- **Benefits for AI-Assisted Development**: Tightened bullet text (removed redundant phrasing)
- **Integration with aidevops**: Renamed heading, compressed to 2 lines

## Content Preservation

All institutional knowledge preserved:
- All 18 `jj` commands in the code block (unchanged)
- All 4 external resource URLs
- All 3 cross-reference links (`github-cli.md`, `conflict-resolution.md`, `worktrunk.md`)
- All technical terms (`git rerere`, bookmarks, colocated mode)
- YAML frontmatter unchanged
- AI-CONTEXT markers intact

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdown lint clean, content preservation verified via grep for all key terms

Closes #14063


---
[aidevops.sh](https://aidevops.sh) v3.5.500 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Jujutsu documentation for improved clarity and usability
  * Consolidated key features and capabilities into a streamlined summary table format
  * Reorganized and simplified multiple documentation sections for better readability
  * Updated terminology and renamed sections for improved consistency and navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->