### PR TITLE
GH#14671: fix setup Tabby profile sync type hint crash

### DIFF
--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -11,6 +11,8 @@ Creates a profile for each registered repo with:
 Existing profiles (matched by cwd path) are never overwritten.
 """
 
+from __future__ import annotations
+
 import argparse
 import colorsys
 import hashlib

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Tests for tabby-profile-sync.py compatibility and helpers."""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent.parent / ".agents" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+spec = importlib.util.spec_from_file_location(
+    "tabby_profile_sync", SCRIPTS_DIR / "tabby-profile-sync.py"
+)
+tabby_profile_sync = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tabby_profile_sync)
+
+
+class TestTabbyProfileSync(unittest.TestCase):
+    """Test Python 3.9-safe imports and helpers."""
+
+    def test_module_imports_under_current_python(self):
+        self.assertTrue(callable(tabby_profile_sync.extract_group_id))
+
+    def test_extract_group_id_returns_projects_group(self):
+        config_text = """groups:
+  - id: abc-123
+    name: Projects
+  - id: def-456
+    name: Other
+profiles:
+  - name: repo
+"""
+
+        self.assertEqual(tabby_profile_sync.extract_group_id(config_text), "abc-123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Defer annotation evaluation in `.agents/scripts/tabby-profile-sync.py` so the setup-time helper imports cleanly on Python 3.9.
- Add a regression test that imports the script under the current interpreter and verifies Projects group extraction.

## Testing
- `python3 ".agents/scripts/tabby-profile-sync.py" --help`
- `python3 -m unittest tests/test-tabby-profile-sync.py`

## Runtime Testing
- runtime-verified: the script now starts successfully under the local Python 3.9.6 runtime that previously crashed during setup.

Closes #14671

---
[aidevops.sh](https://aidevops.sh) v3.5.501 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 191,727 tokens on this as a headless worker. Overall, 13m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the profile synchronization functionality to validate runtime behavior and compatibility.

* **Chores**
  * Improved code compatibility with enhanced type annotation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->