### PR TITLE
GH#14673: tighten email health check command wording

### DIFF
--- a/.agents/scripts/commands/email-health-check.md
+++ b/.agents/scripts/commands/email-health-check.md
@@ -6,34 +6,34 @@ mode: subagent
 
 Check email authentication, deliverability, and content quality.
 
-Arguments: $ARGUMENTS
+Arguments: `$ARGUMENTS`
 
 ## Workflow
 
-### Step 1: Detect mode and run the helper
+### Step 1: Select the helper
 
 - `example.com` → infrastructure: `email-health-check-helper.sh check "$DOMAIN"`
 - `newsletter.html` → content: `email-health-check-helper.sh content-check "$FILE"`
 - `example.com newsletter.html` → combined: `email-health-check-helper.sh precheck "$DOMAIN" "$FILE"`
-- `example.com spf` / `newsletter.html check-links` → targeted check
+- Extra selector/check arg (`example.com spf`, `newsletter.html check-links`) → targeted check
 
 ```bash
-# Domain only
+# Domain
 ~/.aidevops/agents/scripts/email-health-check-helper.sh check "$DOMAIN"
 
-# HTML file only
+# HTML file
 ~/.aidevops/agents/scripts/email-health-check-helper.sh content-check "$FILE"
 
 # Domain + HTML file
 ~/.aidevops/agents/scripts/email-health-check-helper.sh precheck "$DOMAIN" "$FILE"
 ```
 
-### Step 2: Return a formatted report
+### Step 2: Format the report
 
-- Score infrastructure out of 15: SPF, DKIM, DMARC, MX, blacklist
-- Score content out of 10: subject, preheader, accessibility, links, images, spam words
-- Show combined score out of 25 with letter grade when both checks run
-- Preserve helper findings verbatim and end with actionable recommendations
+- Infrastructure: score out of 15 for SPF, DKIM, DMARC, MX, blacklist
+- Content: score out of 10 for subject, preheader, accessibility, links, images, spam words
+- Combined runs: score out of 25 with a letter grade
+- Keep helper findings verbatim and end with actionable recommendations
 
 ## Options
 
@@ -52,7 +52,8 @@ Arguments: $ARGUMENTS
 
 ```text
 User: /email-health-check example.com
-AI: Email Health Check: example.com
+AI:
+    Email Health Check: example.com
     SPF: OK - v=spf1 include:_spf.google.com ~all
     DKIM: OK - Found: google, selector1
     DMARC: WARN - p=none (monitoring only)


### PR DESCRIPTION
## Summary
- tighten the email health check command doc wording so the helper-selection flow reads faster in prompt context
- keep the same command examples and reporting requirements while clarifying targeted checks and response formatting

## Testing
- `bunx markdownlint-cli2 ".agents/scripts/commands/email-health-check.md"`
- verified the command examples and related references remain present in `.agents/scripts/commands/email-health-check.md`

## Runtime Testing
- Level: self-assessed
- Reason: doc-only change to an agent command file

Closes #14673

---
[aidevops.sh](https://aidevops.sh) v3.5.501 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m and 163,110 tokens on this as a headless worker. Overall, 13m since this issue was created.
