### PR TITLE
GH#14330: tighten Context7 CLI doc

### DIFF
--- a/.agents/tools/context/context7-cli.md
+++ b/.agents/tools/context/context7-cli.md
@@ -18,41 +18,30 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Query Context7 library docs and skills over CLI when MCP is unavailable or when compact JSON output is preferred
-- **Install/Setup**: `npx ctx7 setup --opencode --cli`
-- **Core commands**:
-  - `npx ctx7 library <name> [query] --json`
-  - `npx ctx7 docs <libraryId> <query> --json`
-  - `npx ctx7 skills search <query>`
-- **Best use cases**:
-  - MCP transport is unavailable, disabled, or rate-limited
-  - You need quick shell-native docs lookups inside scripts/workflows
-  - You want JSON output for deterministic post-processing
-- **Telemetry**: disable with `export CTX7_TELEMETRY_DISABLED=1`
-
-**Lookup pattern**:
-
-1. Resolve library ID with `ctx7 library`
-2. Query docs with `ctx7 docs`
-3. Only fall back to web docs if Context7 has no coverage
+- **Purpose**: Use Context7 over CLI when MCP is unavailable or JSON output is easier to post-process
+- **Setup**: `npx ctx7 setup --opencode --cli`
+- **Commands**: `npx ctx7 library <name> [query] --json` · `npx ctx7 docs <libraryId> <query> --json` · `npx ctx7 skills search <query>`
+- **Use when**: MCP is unavailable/rate-limited, shell scripts need docs lookups, or downstream tooling expects JSON
+- **Order**: resolve library ID with `ctx7 library` → query docs with `ctx7 docs` → only fall back to web docs if Context7 has no coverage
+- **Telemetry**: `export CTX7_TELEMETRY_DISABLED=1`
 
 <!-- AI-CONTEXT-END -->
 
 ## Usage
 
-### 1) Resolve a library ID
+### Resolve a library ID
 
 ```bash
 npx -y ctx7 library react --json
 ```
 
-### 2) Query focused docs
+### Query focused docs
 
 ```bash
 npx -y ctx7 docs /facebook/react "useEffect examples" --json
 ```
 
-### 3) One-shot lookup from name + question
+### One-shot lookup from name + question
 
 ```bash
 LIB_ID=$(npx -y ctx7 library react --json | jq -r '.library.id // empty')
@@ -65,16 +54,14 @@ fi
 
 ## Backend Selection Guidance
 
-- Prefer `@context7` (MCP) for normal interactive coding flows
+- Prefer `@context7` for normal interactive coding flows
 - Prefer `@context7-cli` for shell-first workflows, scripting, and MCP fallback
 - Keep downstream prompts backend-agnostic by passing normalized outputs (library ID + doc snippet)
 
 ## Verification
 
-Run:
-
 ```text
 @context7-cli Find the React library ID and return docs for useEffect dependency arrays.
 ```
 
-Expected result: a valid Context7 library ID and relevant documentation excerpts returned via CLI calls.
+Expected: a valid Context7 library ID plus relevant documentation excerpts returned via CLI calls.


### PR DESCRIPTION
## Summary
- tighten the Context7 CLI quick reference so key commands, fallback order, and telemetry guidance scan faster
- keep the existing command examples and backend-selection guidance while removing redundant prose

## Testing
- `bunx markdownlint-cli2 ".agents/tools/context/context7-cli.md"`

## Runtime Testing
- self-assessed: low-risk agent-doc change only

Closes #14330


---
[aidevops.sh](https://aidevops.sh) v3.5.501 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 1s on this as a headless worker.