### PR TITLE
GH#14669: tighten agent sources doc

### DIFF
--- a/.agents/aidevops/agent-sources.md
+++ b/.agents/aidevops/agent-sources.md
@@ -1,37 +1,45 @@
 # Agent Sources (Private Repos)
 
-Use agent sources when agents should stay in a private Git repo but remain available framework-wide. Sync copies them into `~/.aidevops/agents/custom/<source-name>/`, so they follow `custom/` tier rules: survive framework updates, are never overwritten by `setup.sh`, and auto-sync during `aidevops update` and `./setup.sh` after `deploy_aidevops_agents`.
+Use agent sources when agents should stay in a private Git repo but remain available framework-wide.
 
-## Lifecycle
+- Sync target: `~/.aidevops/agents/custom/<source-name>/`
+- Survives framework updates and is never overwritten by `setup.sh`
+- Sync runs on `aidevops update`, `./setup.sh` after `deploy_aidevops_agents`, or `aidevops sources sync`
+- `mode: primary` docs symlink into `~/.aidevops/agents/`
+- `.md` files with `agent:` frontmatter symlink into `~/.config/opencode/command/`
+
+## Quick Start
 
 1. Keep private agents under `.agents/` in a private Git repo.
 2. Register the repo with `aidevops sources add <path>`.
 3. Run `aidevops update` or `aidevops sources sync`.
 4. Synced files land in `~/.aidevops/agents/custom/<source-name>/`.
-5. `mode: primary` docs symlink into `~/.aidevops/agents/`, and `.md` files with `agent:` frontmatter symlink into `~/.config/opencode/command/`.
 
 ## CLI
 
 ```bash
 aidevops sources add ~/Git/my-private-agents                  # Add local repo
-aidevops sources add-remote git@github.com:user/agents.git    # Clone + add
+aidevops sources add-remote git@github.com:user/agents.git    # Clone and add
 aidevops sources list                                         # List sources
 aidevops sources status                                       # Path, agent count, git state
 aidevops sources sync                                         # Pull, rsync, symlink
-aidevops sources remove my-private-agents                     # Remove (keeps files on disk)
+aidevops sources remove my-private-agents                     # Remove source, keep files on disk
 ```
 
 ## File Classification
 
 | Frontmatter | Classification | Sync behavior |
 |-------------|----------------|---------------|
-| `mode: primary` | Primary agent | Sync + symlink to `~/.aidevops/agents/` root |
+| `mode: primary` | Primary agent | Sync and symlink to `~/.aidevops/agents/` root |
 | `mode: subagent` | Subagent doc | Sync only |
-| `agent: <Name>` | Slash command | Sync + symlink to `~/.config/opencode/command/` |
+| `agent: <Name>` | Slash command | Sync and symlink to `~/.config/opencode/command/` |
 | none / other | Regular file | Sync only |
 
-- The main agent doc is the file whose name matches its directory, for example `my-agent/my-agent.md`; `mode:` decides whether it is primary or subagent, and other `.md` files with `agent:` frontmatter become slash commands.
-- Slash command conflicts append the source slug, for example `/run-pipeline-my-private-agents`. Primary agents that would overwrite core agents backed by real files, not symlinks, are skipped with a warning.
+- The main agent doc is the file whose name matches its directory, for example `my-agent/my-agent.md`.
+- `mode:` decides whether that main doc is primary or subagent.
+- Other `.md` files with `agent:` frontmatter become slash commands.
+- Slash command conflicts append the source slug, for example `/run-pipeline-my-private-agents`.
+- Primary agents that would overwrite core agents backed by real files, not symlinks, are skipped with a warning.
 
 ## Layout
 
@@ -59,38 +67,14 @@ my-private-agents/.agents/my-agent/
 └── check-status.md → symlink
 ```
 
-## Configuration
-
-Source metadata lives in `~/.aidevops/agents/configs/agent-sources.json`:
-
-| Field | Type | Meaning |
-|-------|------|---------|
-| `name` | string | Directory name used for the deploy subdirectory |
-| `local_path` | string | Absolute path to the local repo |
-| `remote_url` | string | Git remote URL, if detected |
-| `added_at` | string | ISO timestamp when the source was added |
-| `last_synced` | string | ISO timestamp of the last sync |
-| `agent_count` | number | Agent count from the last sync |
-
-## Agent Sources vs Plugins
-
-| Feature | Agent Sources | Plugins |
-|---------|---------------|---------|
-| Config | `agent-sources.json` | `.aidevops.json` per project |
-| Deploy target | `custom/<source-name>/` | `<namespace>/` at top level |
-| Scope | Global | Per-project |
-| Use case | Private agent repos | Third-party extensions |
-| Primary agents | Yes | No |
-| Slash commands | Yes | No |
-| Sync trigger | `aidevops update` / `sources sync` | `aidevops plugin update` |
-
-## Creating a Private Agent Repo
+## Repo Checklist
 
 1. Create a Git repo with a `.agents/` directory.
-2. Add an agent subdirectory with `<name>.md`; use `mode: primary` if it should auto-discover.
-3. Add slash commands as `.md` files with `agent: <Name>` frontmatter and any helper `.sh` scripts needed for CLI automation.
-4. Follow `tools/build-agent/build-agent.md`.
-5. Register the repo with `aidevops sources add <path>`.
+2. Add an agent subdirectory with `<name>.md`.
+3. Use `mode: primary` when the agent should auto-discover in `~/.aidevops/agents/`.
+4. Add slash commands as `.md` files with `agent: <Name>` frontmatter.
+5. Add any helper `.sh` scripts needed for CLI automation.
+6. Follow `tools/build-agent/build-agent.md`.
 
 ### Slash Command Format
 
@@ -104,3 +88,19 @@ Instructions for the AI when this command is invoked.
 
 Arguments: $ARGUMENTS
 ```
+
+## Agent Sources vs Plugins
+
+| Feature | Agent Sources | Plugins |
+|---------|---------------|---------|
+| Config | `agent-sources.json` | `.aidevops.json` per project |
+| Deploy target | `custom/<source-name>/` | `<namespace>/` at top level |
+| Scope | Global | Per-project |
+| Use case | Private agent repos | Third-party extensions |
+| Primary agents | Yes | No |
+| Slash commands | Yes | No |
+| Sync trigger | `aidevops update` / `sources sync` | `aidevops plugin update` |
+
+## Configuration
+
+Source metadata lives in `~/.aidevops/agents/configs/agent-sources.json` with: `name`, `local_path`, `remote_url`, `added_at`, `last_synced`, and `agent_count`.


### PR DESCRIPTION
## Summary
- tighten the agent sources doc by front-loading sync behavior and symlink rules
- consolidate private repo setup guidance into quick-start and checklist sections without dropping key behaviors

## Runtime Testing
- self-assessed: docs-only change
- verified with markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/aidevops/agent-sources.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

Closes #14669


---
[aidevops.sh](https://aidevops.sh) v3.5.501 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.