### PR TITLE
GH#14331: tighten Cloudflare Tunnel agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2176,6 +2176,11 @@
       "at": "2026-03-29T12:36:34Z",
       "pr": 12955
     },
+    ".agents/services/hosting/cloudflare-platform-skill/tunnel.md": {
+      "hash": "30da7271e27a63cb3a093a68b4fc709c3fd4c747",
+      "at": "2026-03-31T06:14:46Z",
+      "pr": 14685
+    },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
       "hash": "07e97feffa7bc2100478d39e614278ab867ba605",
       "at": "2026-03-29T12:36:58Z",

--- a/.agents/services/hosting/cloudflare-platform-skill/tunnel.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/tunnel.md
@@ -1,57 +1,41 @@
 # Cloudflare Tunnel
 
-Secure outbound-only connections between infrastructure and Cloudflare's global network.
+Use Cloudflare Tunnel when you need outbound-only connectivity from an origin to Cloudflare with no inbound ports, direct firewall exposure, or public IP on the service host.
 
-## Overview
+## Architecture
 
-Cloudflare Tunnel (formerly Argo Tunnel) enables:
-- **Outbound-only connections** - No inbound ports or firewall changes
-- **Public hostname routing** - Expose local services to internet
-- **Private network access** - Connect internal networks via WARP
-- **Zero Trust integration** - Built-in access policies
+`Tunnel` (named, persistent object) → `cloudflared` connector(s) → origin service(s)
 
-**Architecture**: Tunnel (persistent object) → Connector (`cloudflared` process) → Origin services
+- **Public hostname routing**: expose HTTP, HTTPS, SSH, or gRPC services through Cloudflare
+- **Private routing**: publish private CIDRs for WARP-connected users
+- **Zero Trust**: pair hostnames with Access policies instead of opening the origin directly
 
-## Quick Start
+## Quick start
 
 ```bash
-# Install cloudflared
-brew install cloudflared  # macOS
-
-# Authenticate
-cloudflared tunnel login
-
-# Create tunnel
-cloudflared tunnel create my-tunnel
-
-# Route DNS
+brew install cloudflared               # macOS; use your package manager elsewhere
+cloudflared tunnel login               # authorizes this machine
+cloudflared tunnel create my-tunnel    # creates named tunnel + credentials
 cloudflared tunnel route dns my-tunnel app.example.com
-
-# Run tunnel
 cloudflared tunnel run my-tunnel
 ```
 
-## Core Commands
+## Core commands
 
 ```bash
-# Tunnel lifecycle
 cloudflared tunnel create <name>
 cloudflared tunnel list
 cloudflared tunnel info <name>
 cloudflared tunnel delete <name>
 
-# DNS routing
 cloudflared tunnel route dns <tunnel> <hostname>
 cloudflared tunnel route list
-
-# Private network
 cloudflared tunnel route ip add 10.0.0.0/8 <tunnel>
 
-# Run tunnel
 cloudflared tunnel run <name>
 ```
 
-## Configuration Example
+## Config skeleton
 
 ```yaml
 # ~/.cloudflared/config.yml
@@ -64,17 +48,18 @@ ingress:
   - hostname: api.example.com
     service: https://localhost:8443
     originRequest:
-      noTLSVerify: true
+      noTLSVerify: true # dev only; prefer valid TLS in production
   - service: http_status:404
 ```
 
-## In This Reference
+## Operating notes
 
-- [patterns.md](./patterns.md) - Docker, Kubernetes, HA, service types, use cases
-- [gotchas.md](./gotchas.md) - Troubleshooting, limitations, best practices
+- Run multiple connectors against the same named tunnel for HA; Cloudflare load-balances them automatically.
+- Ingress rules are first-match-wins; always keep a final catch-all such as `http_status:404`.
+- Long-lived connections can drop during connector restarts or replica replacements.
+- Prefer remotely managed tunnels and Access policies for sensitive services.
 
-## See Also
+## Related docs
 
-- [workers](../workers/) - Workers with Tunnel integration
-- [access](../access/) - Zero Trust access policies
-- [warp](../warp/) - WARP client for private networks
+- [Tunnel patterns](./tunnel-patterns.md) - Docker, Kubernetes, HA, service types, use cases
+- [Tunnel gotchas](./tunnel-gotchas.md) - troubleshooting, limits, operational guardrails


### PR DESCRIPTION
## Summary
- tighten the Cloudflare Tunnel overview into a shorter operator-focused reference
- keep the core commands and config example while surfacing the highest-risk operating notes earlier
- fix the related-doc links to the actual sibling tunnel pattern and gotcha docs

## Runtime Testing
- Level: self-assessed
- Risk: low (documentation-only change)
- Evidence: `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/tunnel.md"`

Closes #14331

---
[aidevops.sh](https://aidevops.sh) v3.5.501 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 1m on this as a headless worker.