### PR TITLE
GH#14664: setup.sh fails when backing up missing deployed agent files

### DIFF
--- a/.agents/scripts/setup/_backup.sh
+++ b/.agents/scripts/setup/_backup.sh
@@ -7,7 +7,54 @@ set -euo pipefail
 # Example: create_backup_with_rotation "$target_dir" "agents"
 # Creates: ~/.aidevops/agents-backups/20251221_123456/
 create_backup_with_rotation() {
-	# TODO: Extract from setup.sh lines 246-283
-	:
+	local source_path="$1"
+	local backup_name="$2"
+	local backup_base="$HOME/.aidevops/${backup_name}-backups"
+	local backup_dir
+	local backup_target
+	backup_dir="$backup_base/$(date +%Y%m%d_%H%M%S)"
+	backup_target="$backup_dir/$(basename "$source_path")"
+
+	mkdir -p "$backup_dir"
+
+	if [[ -d "$source_path" ]]; then
+		mkdir -p "$backup_target"
+		if command -v rsync >/dev/null 2>&1; then
+			local rsync_status=0
+			if rsync -a "$source_path/" "$backup_target/"; then
+				rsync_status=0
+			else
+				rsync_status=$?
+			fi
+
+			if [[ "$rsync_status" -eq 24 ]]; then
+				print_warning "Backup completed with missing source entries skipped: $source_path"
+			elif [[ "$rsync_status" -ne 0 ]]; then
+				print_error "Backup failed for $source_path (rsync exit $rsync_status)"
+				return "$rsync_status"
+			fi
+		else
+			cp -R "$source_path" "$backup_dir/"
+		fi
+	elif [[ -f "$source_path" ]]; then
+		cp "$source_path" "$backup_dir/"
+	else
+		print_warning "Source path does not exist: $source_path"
+		return 1
+	fi
+
+	print_info "Backed up to $backup_dir"
+
+	local backup_count
+	backup_count=$(find "$backup_base" -maxdepth 1 -type d -name "20*" 2>/dev/null | wc -l | tr -d ' ')
+
+	if [[ $backup_count -gt $BACKUP_KEEP_COUNT ]]; then
+		local to_delete=$((backup_count - BACKUP_KEEP_COUNT))
+		print_info "Rotating backups: removing $to_delete old backup(s), keeping last $BACKUP_KEEP_COUNT"
+		find "$backup_base" -maxdepth 1 -type d -name "20*" 2>/dev/null | sort | head -n "$to_delete" | while read -r old_backup; do
+			rm -rf "$old_backup"
+		done
+	fi
+
 	return 0
 }

--- a/.agents/scripts/tests/test-setup-backup.sh
+++ b/.agents/scripts/tests/test-setup-backup.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+BACKUP_HELPER="${SCRIPT_DIR}/../setup/_backup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+print_info() { return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+
+BACKUP_KEEP_COUNT=10
+
+# shellcheck disable=SC1090
+source "$BACKUP_HELPER"
+
+backup_file_exists() {
+	local backup_root="$1"
+	local backup_match
+	for backup_match in "$backup_root"/*/source-tree/nested/file.txt; do
+		if [[ -f "$backup_match" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+test_directory_backup_uses_basename_target() {
+	local test_home
+	test_home="$(mktemp -d)"
+	local source_dir="${test_home}/source-tree"
+	mkdir -p "${source_dir}/nested"
+	printf 'ok\n' >"${source_dir}/nested/file.txt"
+
+	HOME="$test_home" create_backup_with_rotation "$source_dir" "agents"
+
+	if backup_file_exists "${test_home}/.aidevops/agents-backups"; then
+		print_result "directory backup preserves source basename" 0
+	else
+		print_result "directory backup preserves source basename" 1 "backup file missing"
+	fi
+
+	rm -rf "$test_home"
+	return 0
+}
+
+test_directory_backup_tolerates_rsync_vanished_entries() {
+	local test_home
+	test_home="$(mktemp -d)"
+	local source_dir="${test_home}/source-tree"
+	local real_rsync
+	mkdir -p "${source_dir}/nested"
+	printf 'ok\n' >"${source_dir}/nested/file.txt"
+
+	real_rsync="$(command -v rsync || true)"
+	if [[ -z "$real_rsync" ]]; then
+		print_result "directory backup tolerates rsync vanished entries" 1 "rsync unavailable"
+		rm -rf "$test_home"
+		return 0
+	fi
+
+	rsync() {
+		"$real_rsync" "$@"
+		return 24
+	}
+
+	local status=0
+	if ! HOME="$test_home" create_backup_with_rotation "$source_dir" "agents"; then
+		status=$?
+	fi
+
+	unset -f rsync
+
+	if [[ "$status" -ne 0 ]]; then
+		print_result "directory backup tolerates rsync vanished entries" 1 "status=${status}"
+	elif backup_file_exists "${test_home}/.aidevops/agents-backups"; then
+		print_result "directory backup tolerates rsync vanished entries" 0
+	else
+		print_result "directory backup tolerates rsync vanished entries" 1 "backup file missing"
+	fi
+
+	rm -rf "$test_home"
+	return 0
+}
+
+main() {
+	test_directory_backup_uses_basename_target
+	test_directory_backup_tolerates_rsync_vanished_entries
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -500,14 +500,33 @@ create_backup_with_rotation() {
 	local backup_name="$2"
 	local backup_base="$HOME/.aidevops/${backup_name}-backups"
 	local backup_dir
+	local backup_target
 	backup_dir="$backup_base/$(date +%Y%m%d_%H%M%S)"
+	backup_target="$backup_dir/$(basename "$source_path")"
 
 	# Create backup directory
 	mkdir -p "$backup_dir"
 
 	# Copy source to backup
 	if [[ -d "$source_path" ]]; then
-		cp -R "$source_path" "$backup_dir/"
+		mkdir -p "$backup_target"
+		if command -v rsync >/dev/null 2>&1; then
+			local rsync_status=0
+			if rsync -a "$source_path/" "$backup_target/"; then
+				rsync_status=0
+			else
+				rsync_status=$?
+			fi
+
+			if [[ "$rsync_status" -eq 24 ]]; then
+				print_warning "Backup completed with missing source entries skipped: $source_path"
+			elif [[ "$rsync_status" -ne 0 ]]; then
+				print_error "Backup failed for $source_path (rsync exit $rsync_status)"
+				return "$rsync_status"
+			fi
+		else
+			cp -R "$source_path" "$backup_dir/"
+		fi
 	elif [[ -f "$source_path" ]]; then
 		cp "$source_path" "$backup_dir/"
 	else


### PR DESCRIPTION
## Summary
- switch directory backups to `rsync -a` so setup can preserve the deployed tree without aborting when source entries disappear mid-copy
- treat rsync exit 24 as a warning instead of a fatal error, keeping missing-entry backups best-effort for partially removed agent trees
- add a focused shell regression test that covers the normal backup layout and the vanished-entry path

## Testing
- `shellcheck setup.sh .agents/scripts/setup/_backup.sh .agents/scripts/tests/test-setup-backup.sh`
- `bash .agents/scripts/tests/test-setup-backup.sh`

## Runtime Testing
- self-assessed: low-risk shell backup-path change with direct regression coverage; no broader runtime environment required

Closes #14664

---
[aidevops.sh](https://aidevops.sh) v3.5.501 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 30m on this as a headless worker.