### PR TITLE
GH#14320: tighten psst secret manager doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -16,6 +16,11 @@
       "at": "2026-03-27T21:25:05Z",
       "pr": 11021
     },
+    ".agents/tools/credentials/psst.md": {
+      "hash": "cbb2379680b3ce35dc2b7ba4e2be3efe46c509c6",
+      "at": "2026-03-31T06:15:51Z",
+      "pr": 14687
+    },
     ".agents/marketing-sales/meta-ads-creative-hooks.md": {
       "hash": "f7c8e3356361a9ab1941f729337bbf7d0f8447ef",
       "at": "2026-03-27T21:25:06Z",

--- a/.agents/tools/credentials/psst.md
+++ b/.agents/tools/credentials/psst.md
@@ -18,15 +18,14 @@ tools:
 
 ## Quick Reference
 
-- **Status**: Documented alternative (gopass is recommended primary)
+- **Status**: Documented alternative; `gopass` remains the default recommendation
 - **Repo**: https://github.com/nicholasgasior/psst (61 stars, v0.3.0)
 - **Install**: `bun install -g psst-cli`
 - **Requires**: Bun runtime
-
-**Trade-offs vs gopass**:
+- **Use psst when**: you want the simplest solo setup, already use Bun, and do not need team sharing or an audit trail
 
 | Feature | gopass (recommended) | psst |
-|---------|---------------------|------|
+|---------|----------------------|------|
 | Maturity | 6.7k stars, 8+ years | 61 stars, v0.3.0 |
 | Encryption | GPG/age (industry standard) | AES-256-GCM |
 | Team sharing | Git sync + GPG recipients | No |
@@ -36,17 +35,9 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## When to Use psst
-
-- Solo developer who wants simplest possible setup
-- Already using Bun in your stack
-- Don't need team sharing or audit trail
-- Prefer AI-native design over established tooling
-
 ## Installation
 
 ```bash
-# Requires Bun
 bun install -g psst-cli
 ```
 
@@ -65,16 +56,16 @@ psst run MY_API_KEY -- curl https://api.example.com
 
 ## Recommendation
 
-For most users, **gopass is recommended** over psst because:
+Prefer `gopass` for most aidevops setups:
 
-1. Mature ecosystem (6.7k stars, 8+ years of development)
-2. GPG encryption (industry-standard, audited)
-3. Team sharing via git sync
-4. Zero runtime dependencies (single Go binary)
-5. Audit trail via git history
-6. `gopass audit` for breach detection
+- Mature ecosystem (6.7k stars, 8+ years of development)
+- GPG encryption (industry-standard, audited)
+- Team sharing via git sync
+- Zero runtime dependencies (single Go binary)
+- Audit trail via git history
+- `gopass audit` for breach detection
 
-Use psst only if you specifically prefer its simplicity and don't need team features.
+Choose psst only when simplicity matters more than maturity, team workflows, and auditability.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- condense `.agents/tools/credentials/psst.md` by moving psst selection criteria into Quick Reference and removing duplicated recommendation prose
- preserve the existing trade-off table, install command, usage examples, and gopass recommendation while tightening the document from 82 to 73 lines
- register the simplified file in `.agents/configs/simplification-state.json` for future simplification tracking

## Testing
- `npx markdownlint-cli2 ".agents/tools/credentials/psst.md"`
- `jq empty ".agents/configs/simplification-state.json"`
- docs-only change; runtime testing not required

## Runtime Testing
- Level: self-assessed
- Rationale: docs-only agent prompt change plus simplification state metadata update; no runtime behavior changed

Closes #14320


---
[aidevops.sh](https://aidevops.sh) v3.5.503 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 65,728 tokens on this with the user in an interactive session. Overall, 12h 59m since this issue was created.