### PR TITLE
GH#14329: tighten agent doc Claude-Flow vs aidevops Comparison

### DIFF
--- a/.agents/aidevops/claude-flow-comparison.md
+++ b/.agents/aidevops/claude-flow-comparison.md
@@ -15,7 +15,7 @@ model: haiku
 
 Selective feature adoption from [ruvnet/claude-flow](https://github.com/ruvnet/claude-flow) v3.
 
-## Philosophy
+## Baseline Differences
 
 | Aspect | Claude-Flow | aidevops |
 |--------|-------------|----------|
@@ -26,56 +26,16 @@ Selective feature adoption from [ruvnet/claude-flow](https://github.com/ruvnet/c
 | Memory | HNSW vector (built-in) | FTS5 default + embeddings opt-in |
 | Coordination | Byzantine fault-tolerant | Async TOON mailbox |
 
-## Feature Adoption Status
+## Adoption Summary
 
-| Feature | Claude-Flow | aidevops Adoption | Status |
-|---------|-------------|-------------------|--------|
-| Vector memory | HNSW (built-in) | Optional embeddings via all-MiniLM-L6-v2 | Done |
-| Cost routing | 3-tier automatic (SONA) | Model tier guidance + `model:` frontmatter | Done |
-| Self-learning | SONA neural architecture | SUCCESS/FAILURE pattern tracking | Done |
-| Swarm consensus | Byzantine/Raft | Skipped (async mailbox sufficient) | Skipped |
-| WASM transforms | Agent Booster | Skipped (Edit tool fast enough) | Skipped |
+| Area | Claude-Flow | aidevops | Status | Why |
+|------|-------------|----------|--------|-----|
+| Cost-aware routing | Automatic 3-tier routing via SONA | `model:` frontmatter, `tools/context/model-routing.md`, `/route`, five tiers (haiku, flash, sonnet, pro, opus) | Adopted | Host runtimes already choose models; guidance is a better fit than framework-level automation |
+| Semantic memory | Built-in HNSW, always-on semantic search | Optional `memory-embeddings-helper.sh` with all-MiniLM-L6-v2 (~90MB); FTS5 stays default; `memory-helper.sh recall --semantic` opts in | Adopted | Keyword search covers most use; embeddings stay optional to keep the framework lightweight |
+| Outcome learning | SONA tracks routing decisions and outcomes | Pulse supervisor observes GitHub outcomes; agents use `/remember`, `/recall`, and `/patterns`; `pattern-tracker-helper.sh` was retired in favour of universal memory | Adopted | SQLite-backed pattern storage is enough for a small corpus |
+| Swarm consensus | Byzantine/Raft-style consensus | Not adopted | Skipped | Async TOON mailbox handles coordination without adding consensus machinery |
+| WASM transforms | Agent Booster | Not adopted | Skipped | The Edit tool is already fast enough for the file sizes aidevops handles |
 
-## What We Adopted
+## Scale Fit
 
-### 1. Cost-Aware Model Routing
-
-**Claude-Flow**: Automatic 3-tier routing with SONA neural architecture that learns optimal model selection.
-
-**aidevops**: Documented routing guidance in `tools/context/model-routing.md` with `model:` field in subagent YAML frontmatter. Five tiers: haiku, flash, sonnet, pro, opus. `/route` command suggests optimal tier for a task.
-
-**Why this approach**: aidevops agents run inside existing AI tools (Claude Code, OpenCode, Cursor) which handle model selection. Guidance is more appropriate than automatic routing.
-
-### 2. Semantic Memory with Embeddings
-
-**Claude-Flow**: Built-in HNSW vector index, always-on semantic search.
-
-**aidevops**: Optional `memory-embeddings-helper.sh` using all-MiniLM-L6-v2 (~90MB). FTS5 keyword search remains default. `--semantic` flag on `memory-helper.sh recall` delegates to embeddings when available.
-
-**Why this approach**: Most memory queries work fine with keyword search. Embeddings add ~90MB of dependencies. Opt-in keeps the framework lightweight for users who don't need it.
-
-### 3. Success Pattern Tracking
-
-**Claude-Flow**: SONA neural architecture tracks routing decisions and outcomes.
-
-**aidevops**: The pulse supervisor observes outcomes from GitHub state and agents record patterns via cross-session memory (`/remember`, `/recall`). `/patterns` command surfaces relevant patterns for new tasks.
-
-**Why this approach**: Simple pattern storage in existing SQLite memory is sufficient. No need for neural architecture when the pattern corpus is small (hundreds, not millions). The dedicated `pattern-tracker-helper.sh` was archived in favour of the universal memory system.
-
-## What We Skipped
-
-### Swarm Consensus
-
-**Claude-Flow**: Byzantine fault-tolerant coordination for multi-agent consensus.
-
-**Why skipped**: aidevops uses async TOON mailbox for inter-agent communication. Most tasks don't need consensus - they need coordination. The mailbox pattern is simpler and sufficient.
-
-### WASM Transforms (Agent Booster)
-
-**Claude-Flow**: WASM-based code transforms for performance.
-
-**Why skipped**: The Edit tool is already fast enough. WASM adds complexity without meaningful benefit for the file sizes aidevops typically handles.
-
-## Key Insight
-
-Claude-Flow solves problems at scale (thousands of agents, millions of memories, real-time routing). aidevops operates at human scale (1-5 agents, hundreds of memories, session-based routing). The right solution depends on the scale.
+aidevops keeps the Claude-Flow ideas that improve human-scale agent work and drops the ones aimed at much larger systems. Claude-Flow targets thousands of agents, millions of memories, and real-time routing. aidevops targets 1-5 agents, hundreds of memories, and session-scoped routing, so guidance, optional embeddings, and mailbox coordination are usually enough.


### PR DESCRIPTION
## Summary
- condense the Claude-Flow comparison into a baseline table, a single adoption summary table, and a short scale-fit conclusion
- keep every adopted and skipped decision, including the routing, memory, pattern-tracking, consensus, and WASM rationale, while removing repeated prose
- reduce the document from 81 lines to 41 lines without changing its scope

## Testing
- `npm exec -- markdownlint-cli2 ".agents/aidevops/claude-flow-comparison.md"`

## Runtime Testing
- self-assessed: low risk docs-only change; runtime verification not required

Closes #14329
---
[aidevops.sh](https://aidevops.sh) v3.5.501 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 10m on this as a headless worker.