### PR TITLE
GH#14317: tighten GitHub Actions setup guide

### DIFF
--- a/.agents/tools/git/github-actions.md
+++ b/.agents/tools/git/github-actions.md
@@ -18,19 +18,16 @@ tools:
 
 ## Quick Reference
 
-- **Workflow File**: `.github/workflows/code-quality.yml`
-- **Triggers**: Push to main/develop, PRs to main
-- **Jobs**: Framework validation, SonarCloud analysis, Codacy analysis
-- **Required Secrets**: `SONAR_TOKEN` (configured), `CODACY_API_TOKEN` (needs setup)
-- **Auto-Provided**: `GITHUB_TOKEN` by GitHub
-- **SonarCloud Dashboard**: https://sonarcloud.io/project/overview?id=marcusquinn_aidevops
-- **Codacy Dashboard**: https://app.codacy.com/gh/marcusquinn/aidevops
-- **Actions URL**: https://github.com/marcusquinn/aidevops/actions
-- **Add Secrets**: Repository Settings → Secrets and variables → Actions
+- **Workflow**: `.github/workflows/code-quality.yml`
+- **Triggers**: push to `main`/`develop`; pull requests to `main`
+- **Jobs**: Framework Validation, SonarCloud Analysis, Codacy Analysis
+- **Secrets**: `SONAR_TOKEN` configured; `CODACY_API_TOKEN` still needed; `GITHUB_TOKEN` is auto-provided
+- **Dashboards**: SonarCloud https://sonarcloud.io/project/overview?id=marcusquinn_aidevops · Codacy https://app.codacy.com/gh/marcusquinn/aidevops · Actions https://github.com/marcusquinn/aidevops/actions
+- **Secret management**: Repository Settings → Secrets and variables → Actions
 
 <!-- AI-CONTEXT-END -->
 
-## Required Secrets
+## Secrets
 
 | Secret | Status | Source |
 |--------|--------|--------|
@@ -38,23 +35,28 @@ tools:
 | `CODACY_API_TOKEN` | Needs setup | https://app.codacy.com/account/api-tokens |
 | `GITHUB_TOKEN` | Auto-provided | GitHub |
 
-## Add CODACY_API_TOKEN
+### Add `CODACY_API_TOKEN`
 
-1. Go to https://github.com/marcusquinn/aidevops/settings/secrets/actions
-2. Click "New repository secret"
-3. Name: `CODACY_API_TOKEN` — Value: token from secure local storage
+1. Open https://github.com/marcusquinn/aidevops/settings/secrets/actions.
+2. Click **New repository secret**.
+3. Set **Name** to `CODACY_API_TOKEN` and **Value** to the token from secure local storage.
 
-## Workflow Triggers
+## Workflow Behavior
 
-- Push to main or develop → full analysis
-- Pull Request to main → full analysis
-- Jobs: Framework Validation, SonarCloud Analysis, Codacy Analysis (conditional on token)
+- Push to `main` or `develop` runs full analysis.
+- Pull requests to `main` run full analysis.
+- `Codacy Analysis` is conditional on the token being present.
 
 ## Concurrent Push Patterns
 
-When workflows commit and push, concurrent runs cause race conditions. Use:
+| Scenario | Pattern |
+|----------|---------|
+| Pushing to external repo | Full retry |
+| Auto-fix commits to same repo | Simple |
+| Wiki sync | Full retry |
+| Release workflows | Simple |
 
-### Full Retry (external repos, wiki sync)
+### Full retry
 
 ```yaml
 for i in 1 2 3; do
@@ -65,20 +67,13 @@ done
 exit 1
 ```
 
-### Simple (same-repo auto-fixes, release workflows)
+### Simple
 
 ```yaml
 git pull --rebase origin main || true
 git push
 ```
 
-| Scenario | Pattern |
-|----------|---------|
-| Pushing to external repo | Full retry |
-| Auto-fix commits to same repo | Simple |
-| Wiki sync | Full retry |
-| Release workflows | Simple |
-
-- Always `git pull --rebase` before pushing
-- Use `|| true` after pull to continue if pull fails (empty repo, etc.)
-- Exit with error after all retries fail to surface the issue
+- Always `git pull --rebase` before `git push`.
+- Keep `|| true` on pull so empty-repo or no-op pull failures do not abort the workflow.
+- Exit non-zero after retries fail so the workflow surfaces the push problem.

--- a/todo/tasks/GH-14317-brief.md
+++ b/todo/tasks/GH-14317-brief.md
@@ -1,0 +1,32 @@
+# GH#14317: Tighten `.agents/tools/git/github-actions.md`
+
+## Session Origin
+
+Interactive `/full-loop` run operating under the headless continuation contract for GitHub issue #14317.
+
+## What
+
+Restructure `.agents/tools/git/github-actions.md` into a shorter setup card that preserves every workflow trigger, job name, secret requirement, dashboard URL, and concurrent-push pattern.
+
+## Why
+
+The file is an instruction doc, not a reference corpus. It is already small, so the correct simplification is prose tightening and better ordering rather than splitting or deleting content.
+
+## How
+
+1. Keep the document single-file.
+2. Put the quick-reference summary first, then secrets, workflow behavior, and concurrent-push guidance.
+3. Preserve the `SONAR_TOKEN`, `CODACY_API_TOKEN`, and `GITHUB_TOKEN` guidance, all URLs, both YAML snippets, and the scenario-to-pattern table.
+4. Run markdown lint on the edited file.
+
+## Acceptance Criteria
+
+- [ ] All existing triggers, job names, secrets, URLs, and push-pattern examples remain present.
+- [ ] The file stays single-file and shorter than the original 84-line version.
+- [ ] The quick-reference block surfaces the workflow, triggers, jobs, secrets, and dashboards before detailed setup steps.
+- [ ] Markdown lint passes for `.agents/tools/git/github-actions.md`.
+- [ ] PR created with `Closes #14317`.
+
+## Context
+
+Issue #14317 is an automated simplification-debt task. The file covers one operational concern, so progressive disclosure is unnecessary; the win is tighter wording and clearer order.


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/git/github-actions.md` into a shorter single-file setup card with quick-reference, secrets, workflow behavior, and push-pattern guidance in priority order
- preserve the existing secrets, dashboards, workflow triggers, job names, and retry examples while reducing the guide from 84 lines to 79
- add `todo/tasks/GH-14317-brief.md` so the issue has a task brief for future cold-start context

## Testing
- `bunx markdownlint-cli2 ".agents/tools/git/github-actions.md" "todo/tasks/GH-14317-brief.md"`
- `wc -l ".agents/tools/git/github-actions.md"` → `79`

## Runtime Testing
- Level: self-assessed
- Reason: docs-only change to an agent guide and task brief

Closes #14317

---
[aidevops.sh](https://aidevops.sh) v3.5.504 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.