### PR TITLE
GH#14246: tighten Buzz transcription doc

### DIFF
--- a/.agents/tools/voice/buzz.md
+++ b/.agents/tools/voice/buzz.md
@@ -14,79 +14,58 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Offline audio/video transcription using OpenAI Whisper models
-- **Install**: `brew install --cask buzz` (macOS) or download from https://buzzcaptions.com
-- **Repo**: https://github.com/chidiwilliams/buzz (13k+ stars, Python, MIT)
-- **Models**: Whisper (tiny to large), faster-whisper, whisper.cpp
-
-**When to use**: Local transcription without sending audio to cloud APIs. Supports 100+ languages, speaker diarization, and subtitle export (SRT/VTT).
+- **Purpose**: Local audio/video transcription with Whisper-family models; no cloud API required
+- **Install**: `brew install --cask buzz` (macOS GUI), `pip install buzz-captions` (CLI), or build from source
+- **Repo**: https://github.com/chidiwilliams/buzz (Python, MIT)
+- **Backends**: Whisper, `faster-whisper`, `whisper.cpp`
+- **When to use**: Privacy-sensitive transcription, subtitle export, offline batch work, quick GUI workflow on macOS
 
 <!-- AI-CONTEXT-END -->
 
-## Installation
+## Install
 
 ```bash
-# macOS (GUI app)
 brew install --cask buzz
-
-# CLI / Python
 pip install buzz-captions
-
-# From source
-git clone https://github.com/chidiwilliams/buzz
-cd buzz && pip install -e .
+git clone https://github.com/chidiwilliams/buzz && cd buzz && pip install -e .
 ```
 
-## CLI Usage
+## Capabilities
+
+- **Input**: MP3, WAV, FLAC, OGG, M4A, WMA, MP4, MKV, AVI, MOV, WebM
+- **Output**: TXT, SRT, VTT, JSON
+- **Languages**: 100+ via Whisper language support
+- **Extras**: Speaker diarization, subtitle export, automatic audio extraction from video
+
+Use `Buzz` when the requirement is local/private transcription. For provider comparison and cloud options, see `tools/voice/transcription.md`.
+
+## CLI
 
 ```bash
-# Transcribe audio file
 buzz transcribe audio.mp3 --model large-v3 --language en
-
-# Transcribe with timestamps
 buzz transcribe audio.mp3 --model medium --task transcribe --output-format srt
-
-# Translate to English
 buzz transcribe foreign-audio.mp3 --task translate --language auto
-
-# Use faster-whisper backend (faster, lower memory)
 buzz transcribe audio.mp3 --model-type faster-whisper --model large-v3
 ```
 
-## Supported Formats
+## Model and backend choices
 
-- **Audio**: MP3, WAV, FLAC, OGG, M4A, WMA
-- **Video**: MP4, MKV, AVI, MOV, WebM (extracts audio automatically)
-- **Output**: TXT, SRT, VTT, JSON
+| Option | Best for | Trade-off |
+|--------|----------|-----------|
+| `tiny` / `base` | Quick drafts | Lower accuracy |
+| `medium` | Default choice | Slower than small models |
+| `large-v3` | Accuracy-critical transcripts | Highest VRAM and latency |
+| `faster-whisper` | Faster, lower-memory runs | Different backend/runtime |
+| `whisper.cpp` | CPU-first local use | Fewer ecosystem conveniences |
 
-## Model Selection
+Approximate Whisper model sizes: `tiny` 39MB, `base` 74MB, `small` 244MB, `medium` 769MB, `large-v3` 1.5GB. Typical VRAM: 1GB, 1GB, 2GB, 5GB, 10GB respectively.
 
-| Model | Size | Speed | Quality | VRAM |
-|-------|------|-------|---------|------|
-| tiny | 39MB | Fastest | Low | 1GB |
-| base | 74MB | Fast | Fair | 1GB |
-| small | 244MB | Medium | Good | 2GB |
-| medium | 769MB | Slow | Great | 5GB |
-| large-v3 | 1.5GB | Slowest | Best | 10GB |
-
-**Recommendation**: Use `medium` for general use, `large-v3` for accuracy-critical work, `tiny`/`base` for quick drafts.
-
-## Backends
-
-- **Whisper**: Original OpenAI implementation (PyTorch)
-- **faster-whisper**: CTranslate2 backend, 4x faster, lower memory
-- **whisper.cpp**: C++ implementation, runs on CPU efficiently
-
-## Integration with aidevops
+## aidevops examples
 
 ```bash
-# Transcribe meeting recording
 buzz transcribe meeting.mp4 --model medium --output-format txt > meeting-notes.txt
-
-# Generate subtitles for video content
 buzz transcribe video.mp4 --model large-v3 --output-format srt > subtitles.srt
 
-# Batch transcribe
 for f in recordings/*.mp3; do
   buzz transcribe "$f" --model medium --output-format txt > "${f%.mp3}.txt"
 done
@@ -94,5 +73,6 @@ done
 
 ## Related
 
-- `tools/voice/speech-to-speech.md` - Real-time speech processing
-- `tools/video/remotion.md` - Video generation (can use transcripts)
+- `tools/voice/transcription.md` - local vs cloud transcription options
+- `tools/voice/speech-to-speech.md` - real-time speech pipeline
+- `tools/video/remotion.md` - video workflows that consume transcripts


### PR DESCRIPTION
## Summary
- Tighten `.agents/tools/voice/buzz.md` into a shorter reference card focused on the offline Buzz workflow.
- Keep the install commands, CLI examples, format support, model sizing, and aidevops-specific usage while removing redundant prose.
- Add an explicit pointer to `tools/voice/transcription.md` for broader provider comparison.

## Testing
- `bunx markdownlint-cli2 ".agents/tools/voice/buzz.md"`

## Runtime Testing
- Level: self-assessed
- Reason: agent documentation change only; no runtime code path changed.

Closes #14246


---
[aidevops.sh](https://aidevops.sh) v3.5.507 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4