### PR TITLE
GH#14067: tighten agent doc SEO Content Writer

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3055,6 +3055,11 @@
       "hash": "83e56233f5c7fc633bc3a64de90d9b5529a0bd33",
       "at": "2026-03-31T05:34:14Z",
       "pr": 14650
+    },
+    ".agents/content/seo-writer.md": {
+      "hash": "1ca2cbdd68d18ff9ee75c8d6dc33d58e52f89c97bb4ba692635b3265b403b12b",
+      "at": "2026-03-31T06:25:43Z",
+      "pr": 0
     }
   }
 }

--- a/.agents/content/seo-writer.md
+++ b/.agents/content/seo-writer.md
@@ -15,111 +15,76 @@ tools:
 
 # SEO Content Writer
 
-Writes long-form, SEO-optimized content that ranks well and serves the target audience.
+Long-form, SEO-optimized content that ranks well and serves the target audience.
 
 ## Quick Reference
 
 - **Purpose**: Create 2000-3000+ word SEO-optimized articles
 - **Input**: Topic, primary keyword, secondary keywords, research brief
-- **Output**: Complete article with meta elements, internal links, SEO checklist
+- **Output**: Article with meta elements, internal links, SEO checklist
 - **Script**: `seo-content-analyzer.py` (readability, keywords, intent, quality)
 
 ## Workflow
 
 ### 1. Pre-Writing Research
 
-Before writing, gather:
+Gather before writing:
 
-- **Primary keyword** and search volume (from `seo/keyword-research.md`)
+- **Primary keyword** + search volume (from `seo/keyword-research.md`)
 - **Secondary keywords** (3-5 related terms)
-- **Search intent** (run `seo-content-analyzer.py intent "keyword"`)
-- **Brand voice** (check project `context/brand-voice.md` if exists)
-- **Internal links map** (check project `context/internal-links-map.md` if exists)
+- **Search intent** (`seo-content-analyzer.py intent "keyword"`)
+- **Brand voice** (`context/brand-voice.md` if exists)
+- **Internal links map** (`context/internal-links-map.md` if exists)
 
 ### 2. Article Structure
 
-```markdown
-# [H1 with Primary Keyword] (50-60 chars for meta title)
-
-[Introduction: Hook + problem + promise. Primary keyword in first 100 words.]
-
-## [H2 with keyword variation]
-[2-4 sentence paragraphs. Short, punchy sentences.]
-
-## [H2 section]
-[Include secondary keywords naturally.]
-
-## [H2 with keyword variation]
-[Data, examples, actionable advice.]
-
-## [FAQ Section - target People Also Ask]
-### [Question with long-tail keyword]
-[Concise answer targeting featured snippet.]
-
-## Conclusion
-[Summary + CTA. Mention primary keyword.]
-```
+H1 with primary keyword (50-60 chars) → intro with keyword in first 100 words → 4-6 H2 sections with keyword variations and secondary keywords → FAQ section targeting People Also Ask → conclusion with CTA. Paragraphs: 2-4 sentences. Sentences: short, punchy.
 
 ### 3. Content Requirements
 
 | Requirement | Target |
 |-------------|--------|
-| Word count | 2000-3000+ words |
+| Word count | 2000-3000+ |
 | Primary keyword density | 1-2% |
 | Keyword in H1 | Required |
 | Keyword in first 100 words | Required |
 | Keyword in 2-3 H2s | Required |
-| Internal links | 3-5 with descriptive anchor text |
-| External links | 2-3 to authority sources |
-| Meta title | 50-60 characters with keyword |
-| Meta description | 150-160 characters with keyword |
+| Internal links | 3-5 (descriptive anchor text) |
+| External links | 2-3 (authority sources) |
+| Meta title | 50-60 chars with keyword |
+| Meta description | 150-160 chars with keyword |
 | H2 sections | 4-6 minimum |
 | Paragraph length | 2-4 sentences |
-| Sentence length | 15-20 words average |
+| Sentence length | 15-20 words avg |
 | Reading level | Grade 8-10 |
 
-### 4. Post-Writing Analysis
-
-After writing, run these scripts to validate:
+### 4. Post-Writing Validation
 
 ```bash
-# Full analysis
+# Full analysis (subcommands: readability, keywords, quality, intent)
 python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py analyze article.md \
   --keyword "primary keyword" --secondary "kw1,kw2"
-
-# Individual checks
-python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py readability article.md
-python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py keywords article.md --keyword "primary keyword"
-python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py quality article.md \
-  --keyword "primary keyword" --meta-title "Title" --meta-desc "Description"
 ```
 
-### 5. Output Format
+### 5. Deliverables
 
-Deliver the article with:
-
-1. **Article content** in markdown
-2. **Meta elements** block:
-   - Meta title (50-60 chars)
-   - Meta description (150-160 chars)
-   - Focus keyword
-   - Secondary keywords
-3. **SEO checklist** (pass/fail for each requirement)
+1. **Article** in markdown
+2. **Meta elements**: title (50-60 chars), description (150-160 chars), focus keyword, secondary keywords
+3. **SEO checklist** (pass/fail per requirement above)
 4. **Internal link suggestions** (if links map available)
 
 ## Writing Guidelines
 
-- **Natural keyword integration** - if it sounds forced, rewrite
-- **Show, don't tell** - use specific examples and data
-- **One idea per paragraph** - break up walls of text
-- **Use transition words** - however, therefore, additionally
-- **Active voice** - keep passive voice under 20%
-- **Cite sources** - link to statistics and data
-- **Answer questions** - address "People Also Ask" queries
+- Natural keyword integration — forced = rewrite
+- Show, don't tell — specific examples and data
+- One idea per paragraph
+- Active voice (passive <20%)
+- Cite sources with links
+- Address People Also Ask queries
 
 ## Integration
 
-- Uses `content/guidelines.md` for voice and style
-- Uses `content/humanise.md` for removing AI patterns
-- Uses `seo/keyword-research.md` for keyword data
-- Uses `seo/eeat-score.md` for quality validation
+- `content/guidelines.md` — voice and style
+- `content/humanise.md` — removing AI patterns
+- `seo/keyword-research.md` — keyword data
+- `seo/eeat-score.md` — quality validation


### PR DESCRIPTION
## Summary

- Tighten `.agents/content/seo-writer.md` from 125 to 90 lines (28% reduction)
- Classified as **instruction doc** — prose tightened, not content removed

## Changes

- Compressed 21-line article structure markdown template into 1-line prose description (same information, no placeholder filler)
- Consolidated 4 individual `seo-content-analyzer.py` script examples into 1 full-analysis command with subcommand note
- Tightened verbose phrasing throughout (removed filler words like "Complete", "run", "check project", "Deliver the article with")
- Removed redundant "Uses" prefix from Integration section
- Removed low-value "Use transition words" guideline (not SEO-critical)

## Content Preservation

All preserved:
- Script paths (`seo-content-analyzer.py`, full `python3` command)
- File references (`seo/keyword-research.md`, `content/guidelines.md`, `content/humanise.md`, `seo/eeat-score.md`, `context/brand-voice.md`, `context/internal-links-map.md`)
- All requirements table values
- All subcommand names (readability, keywords, quality, intent)
- YAML frontmatter unchanged
- All deliverable items

## Runtime Testing

- **Risk**: Low (docs/agent prompts only)
- **Level**: `self-assessed`
- Markdown lint: 0 errors

Closes #14067


---
[aidevops.sh](https://aidevops.sh) v3.5.505 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6