### PR TITLE
GH#14248: tighten Cloudflare Code Mode MCP doc

### DIFF
--- a/.agents/tools/api/cloudflare-mcp.md
+++ b/.agents/tools/api/cloudflare-mcp.md
@@ -18,52 +18,51 @@ tools:
 
 ## Quick Reference
 
-- **Server**: `https://mcp.cloudflare.com/mcp` (remote, no install)
-- **Auth**: OAuth 2.0 via Cloudflare dashboard (browser flow on first connect)
+- **Server**: `https://mcp.cloudflare.com/mcp` (remote)
+- **Auth**: OAuth 2.0 browser flow on first use
 - **Config key**: `cloudflare-api` in `configs/mcp-servers-config.json.txt`
-- **Setup guide**: `aidevops/mcp-integrations.md` → Cloudflare Code Mode MCP section
-- **Platform docs**: `services/hosting/cloudflare-platform-skill.md` (60 products, API refs)
-
-**Capabilities**: Workers (deploy/update/list/tail), D1 (SQL/schema), KV (get/put/delete/list), R2 (buckets/objects), Pages (list/deploy), AI Gateway (logs/analytics), DNS (read/manage), Analytics (zone traffic)
+- **Setup**: `aidevops/mcp-integrations.md` → Cloudflare Code Mode MCP
+- **Platform reference**: `services/hosting/cloudflare-platform-skill.md`
+- **Capabilities**: Workers, D1, KV, R2, Pages, AI Gateway, DNS, Analytics
 
 <!-- AI-CONTEXT-END -->
 
+## Security Model
+
+- **Scopes**: Access matches Cloudflare dashboard permissions
+- **Secrets**: No tokens in config; MCP client stores OAuth token
+- **Revocation**: `dash.cloudflare.com` → My Profile → API Tokens → OAuth Apps
+- **Least privilege**: For tighter scope, use a sub-account or scoped API token; see `services/hosting/cloudflare.md`
+- **Audit trail**: Actions appear in the Cloudflare audit log
+
 ## Auth Setup
 
-OAuth 2.0 — no API tokens to manage. On first tool call, a browser window opens to `dash.cloudflare.com`; authorize once and the client stores the token.
+OAuth 2.0; first tool call opens `dash.cloudflare.com` for authorization.
 
-**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`)
 
 ```json
 { "mcpServers": { "cloudflare-api": { "url": "https://mcp.cloudflare.com/mcp" } } }
 ```
 
-**OpenCode** (`~/.config/opencode/config.json`):
+**OpenCode** (`~/.config/opencode/config.json`)
 
 ```json
 { "mcp": { "cloudflare-api": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp" } } }
 ```
 
-**Claude Code CLI**:
+**Claude Code CLI**
 
 ```bash
 claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp
 ```
 
-> `--transport http` selects the MCP transport type (streamable HTTP), not the URL scheme — `http` is correct even though the endpoint uses HTTPS.
-
-## Security Model
-
-- **OAuth scopes**: Access matches your Cloudflare dashboard permissions
-- **No secrets in config**: OAuth tokens stored by the MCP client in its secure token store
-- **Revocation**: `dash.cloudflare.com` > My Profile > API Tokens > OAuth Apps
-- **Least privilege**: For restricted scope, use a sub-account or scoped API token (see `services/hosting/cloudflare.md`)
-- **Audit trail**: All MCP actions appear in Cloudflare's audit log under your account
+`--transport http` is the MCP transport type; keep it even with an HTTPS endpoint.
 
 ## Usage Patterns
 
-| Service | Example prompts |
-|---------|----------------|
+| Service | Typical prompts |
+|---------|-----------------|
 | **Workers** | `List all Workers` · `Show code for Worker "api-gateway"` · `Deploy ./src/worker.ts as "my-worker"` · `Tail logs for "my-worker"` |
 | **D1** | `List D1 databases` · `Run SQL: SELECT * FROM users LIMIT 10 on "prod-db"` · `Show schema for "prod-db"` |
 | **KV** | `List KV namespaces` · `Get key "config:feature-flags" from "APP_CONFIG"` · `List keys with prefix "user:" in "APP_DATA"` |
@@ -72,7 +71,7 @@ claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp
 | **AI Gateway** | `List AI Gateways` · `Show logs for "production"` · `Get analytics for last 24h` |
 | **DNS** | `List DNS records for "example.com"` · `Add A record: api.example.com → 1.2.3.4 TTL 300` |
 
-### Multi-step examples
+### Multi-Step Examples
 
 ```text
 # Deploy Worker with bindings
@@ -88,7 +87,7 @@ Upload all files in ./dist/ to R2 "static-assets" under prefix "v2.1.0/". List t
 
 ## Per-Agent Enablement
 
-`cloudflare-api_*: true` in this subagent's frontmatter enables the MCP tools (disabled globally, enabled per-agent).
+Set `cloudflare-api_*: true` in subagent frontmatter. The server stays disabled globally and enabled per agent.
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary
- tighten the Cloudflare Code Mode MCP quick-reference section so the highest-value setup and capability details are easier to scan
- move the security model ahead of setup steps and shorten repeated phrasing without dropping config examples or related references

## Testing
- markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/tools/api/cloudflare-mcp.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Runtime Testing
- Level: self-assessed (low-risk documentation change)
- Not required: no runtime behavior changed

Closes #14248

---
[aidevops.sh](https://aidevops.sh) v3.5.507 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 4m and 66,110 tokens on this as a headless worker. Overall, 15h 41m since this issue was created.