### PR TITLE
GH#14257: tighten docs probes

### DIFF
--- a/.agents/reference/define-probes/docs.md
+++ b/.agents/reference/define-probes/docs.md
@@ -5,18 +5,16 @@ mode: subagent
 
 # Docs Probes
 
-Use 2 probes from this file during `/define` for tasks classified as **docs**.
+Use this for `/define` tasks classified as **docs**: ask the 2 questions below, then select 2 probes.
 
 ## Default Assumptions
-
-Apply these unless the user overrides during interview:
 
 - Follow existing documentation patterns and style in the project
 - Accurate and verifiable — no speculative claims
 - Concise — prefer examples over lengthy explanations
 - Maintainable — don't document implementation details that change frequently
 
-## Structured Questions
+## Required Questions
 
 ### Audience
 


### PR DESCRIPTION
## Summary
- tighten `.agents/reference/define-probes/docs.md` intro wording so `/define` usage is clearer at a glance
- rename `Structured Questions` to `Required Questions` and remove redundant prose without changing probe content

## Testing
- `./.agents/scripts/linters-local.sh` *(repo-wide baseline failures remain unrelated; Markdown check passed for this change)*
- `git diff --check`

## Runtime Testing
- self-assessed
- low-risk docs-only change; no runtime behaviour changed

Closes #14257


---
[aidevops.sh](https://aidevops.sh) v3.5.508 plugin for [OpenCode](https://opencode.ai) v1.3.8 with gpt-5.4 spent 5m on this as a headless worker.