### PR TITLE
GH#14216: split email sequence templates into chapters

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md
@@ -1,0 +1,19 @@
+# Shared Patterns
+
+Reusable defaults and snippets referenced across the email sequence templates.
+
+Source: split from `direct-response-copy-templates-email-sequences.md` to keep the index slim without dropping any template content.
+
+## Shared Conventions
+
+**Defaults** (don't repeat per email): Greeting `Hey [First Name],` / Sign-off `[Your Name]` / Reply invitation at end / Guarantee: `"Protected by our [X]-day guarantee. Zero risk."`
+
+## Reusable Patterns
+
+Referenced by name across sequences — customize inline.
+
+**Social Proof**: `I want to introduce you to [Customer]. Before: [situation] → Challenge: [blocker] → Then they [action]. After: [results with numbers]. "[Testimonial]" The key insight? [Differentiator] [CTA]`
+
+**Objection Handling (Q&A)**: `"Worth the price?" → [Value statement] · "Work for me?" → [Use cases] · "What if I don't like it?" → [Guarantee] · [Product-specific Qs] [CTA]`
+
+**Urgency / Final Push**: `[What's ending] disappear in [timeframe]. After [deadline]: ❌ [Loss 1] ❌ [Loss 2] ❌ [Price increase]. If you've been on the fence, now's the time. [CTA]`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md
@@ -6,7 +6,12 @@ Source: split from `direct-response-copy-templates-email-sequences.md` to keep t
 
 ## Shared Conventions
 
-**Defaults** (don't repeat per email): Greeting `Hey [First Name],` / Sign-off `[Your Name]` / Reply invitation at end / Guarantee: `"Protected by our [X]-day guarantee. Zero risk."`
+**Defaults** (don't repeat per email):
+
+- Greeting: `Hey [First Name],`
+- Sign-off: `[Your Name]`
+- Reply invitation: at end
+- Guarantee: `"Protected by our [X]-day guarantee. Zero risk."`
 
 ## Reusable Patterns
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md
@@ -24,7 +24,7 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `How [Customer] [achieved result]`
 
-**Body:** Uses **Social Proof**. Soft CTA: preview tomorrow's offer.
+**Body:** Uses [**Social Proof**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Soft CTA: preview tomorrow's offer.
 
 ## E5 — Offer (Day 7)
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md
@@ -1,0 +1,33 @@
+# Welcome Sequence (5 Emails)
+
+Source: split from `direct-response-copy-templates-email-sequences.md`.
+
+## E1 — Welcome + Delivery (Day 0)
+
+**Subject:** `Welcome to [Brand] + Your [Resource] Is Here`
+
+**Body:** Welcome intro → deliver [Resource] via [Download Link] → "I created this because [their problem]" → preview next 3 emails → `P.S. The [section] is my favorite—start there.`
+
+## E2 — Quick Win (Day 1)
+
+**Subject:** `Try this [timeframe] trick for [quick result]`
+
+**Body:** Reference yesterday's resource → [Actionable tip, 3-5 sentences] → why it works → preview next email.
+
+## E3 — Story + Lesson (Day 3)
+
+**Subject:** `The [mistake/discovery] that changed everything`
+
+**Body:** `"[Timeframe] ago, I was [their situation]"` → tried [failures] → [discovery moment] → lesson + specific action step.
+
+## E4 — Social Proof (Day 5)
+
+**Subject:** `How [Customer] [achieved result]`
+
+**Body:** Uses **Social Proof**. Soft CTA: preview tomorrow's offer.
+
+## E5 — Offer (Day 7)
+
+**Subject:** `Ready to [desired outcome]?`
+
+**Body:** Recap week's value (3 bullets) → introduce [Product] → benefits (3 bullets) → bonuses → CTA button → `P.S. [Urgency]`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
@@ -12,7 +12,7 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `Quick question about your [Product] order`
 
-**Body:** Uses **Objection Handling**. Include cart link after Q&A.
+**Body:** Uses [**Objection Handling**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Include cart link after Q&A.
 
 ## E3 — Final + Incentive (48h)
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
@@ -1,0 +1,21 @@
+# Cart Abandonment (3 Emails)
+
+Source: split from `direct-response-copy-templates-email-sequences.md`.
+
+## E1 — Reminder (1h)
+
+**Subject:** `Did something go wrong?`
+
+**Body:** `"Noticed you didn't finish checkout. Your cart is saved: [Cart Link]. Hit reply if you need help."`
+
+## E2 — Objections (24h)
+
+**Subject:** `Quick question about your [Product] order`
+
+**Body:** Uses **Objection Handling**. Include cart link after Q&A.
+
+## E3 — Final + Incentive (48h)
+
+**Subject:** `[First Name], one more thing before you go`
+
+**Body:** `"Use code [CODE] for [discount]. [Cart Link] — expires in 24 hours. P.S. [Guarantee]"`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
@@ -12,7 +12,7 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `Quick question about your [Product] order`
 
-**Body:** Uses [**Objection Handling**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Include cart link after Q&A.
+**Body:** Uses [**Objection Handling (Q&A)**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Include cart link after Q&A.
 
 ## E3 — Final + Incentive (48h)
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
@@ -1,0 +1,45 @@
+# SaaS Trial (7 Emails)
+
+Source: split from `direct-response-copy-templates-email-sequences.md`.
+
+## E1 — Welcome + Quick Start (Day 0)
+
+**Subject:** `Welcome to [Product]! Here's how to start`
+
+**Body:** 3-step setup (each: action → benefit → direct link) → `"Most users finish in [X] min"` → `P.S. Trial lasts [X] days.`
+
+## E2 — Feature Highlight (Day 2)
+
+**Subject:** `Have you tried [Key Feature] yet?`
+
+**Body:** `"[Feature] is what hooked most users"` → 2-3 sentences on benefit → screenshot/GIF → feature link + tutorial link.
+
+## E3 — Social Proof (Day 4)
+
+**Subject:** `"[Result]" — How [Customer] uses [Product]`
+
+**Body:** Uses **Social Proof** + `"They did it by [product action]."` Hard CTA.
+
+## E4 — Check-in (Day 7)
+
+**Subject:** `How's [Product] working for you?`
+
+**Body:** `"Halfway through—how's it going?"` → ask about key action → 3 undiscovered features/tips → login CTA.
+
+## E5 — Feature #2 (Day 10)
+
+**Subject:** `The [Feature] trick most users miss`
+
+**Body:** Same as E2 structure. Power-user feature + 3-4 step how-to.
+
+## E6 — Trial Ending (Day 12)
+
+**Subject:** `Your trial ends in 2 days`
+
+**Body:** Uses **Urgency** (losses = features + data). CTA: `[Upgrade →]`. `"Need more time? Reply."`
+
+## E7 — Last Day (Day 14)
+
+**Subject:** `Your trial expires today`
+
+**Body:** `"Ends at midnight"` → keep list (✓ features, ✓ data) → upgrade CTA → discount code [CODE].

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
@@ -18,7 +18,7 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `"[Result]" — How [Customer] uses [Product]`
 
-**Body:** Uses **Social Proof** + `"They did it by [product action]."` Hard CTA.
+**Body:** Uses [**Social Proof**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns) + `"They did it by [product action]."` Hard CTA.
 
 ## E4 — Check-in (Day 7)
 
@@ -36,7 +36,7 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `Your trial ends in 2 days`
 
-**Body:** Uses **Urgency** (losses = features + data). CTA: `[Upgrade →]`. `"Need more time? Reply."`
+**Body:** Uses [**Urgency**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns) (losses = features + data). CTA: `[Upgrade →]`. `"Need more time? Reply."`
 
 ## E7 — Last Day (Day 14)
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
@@ -36,7 +36,7 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `Your trial ends in 2 days`
 
-**Body:** Uses [**Urgency**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns) (losses = features + data). CTA: `[Upgrade →]`. `"Need more time? Reply."`
+**Body:** Uses [**Urgency / Final Push**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns) (losses = features + data). CTA: `[Upgrade →]`. `"Need more time? Reply."`
 
 ## E7 — Last Day (Day 14)
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
@@ -1,0 +1,45 @@
+# Launch Sequence (7 Emails)
+
+Source: split from `direct-response-copy-templates-email-sequences.md`.
+
+## E1 — Teaser (Day -3)
+
+**Subject:** `Something new is coming...`
+
+**Body:** `"Working on this for [timeframe]. On [Date], ready to share."` → 1-2 sentence teaser → `"For [who] who want [outcome]"` → mark calendar. `P.S. [Waitlist CTA]`
+
+## E2 — Problem Agitation (Day -1)
+
+**Subject:** `The real reason [problem] happens`
+
+**Body:** `"Tomorrow's the day. First, let's talk about [problem]."` → detail problem → failed approaches (2 bullets) → key insight → `"Tomorrow, a different approach."`
+
+## E3 — Launch Day (Day 0)
+
+**Subject:** `It's here: [Product Name] is LIVE`
+
+**Body:** Introduce + sales page link → `"[Product] helps [outcome] without [objection]"` → benefits (3) → launch-week bonuses with values → price (launch vs regular) → CTA. `P.S. [Scarcity]`
+
+## E4 — Case Study (Day 2)
+
+**Subject:** `"I can't believe this worked" — [Customer]`
+
+**Body:** Uses **Social Proof**. Frame as launch momentum. Hard CTA.
+
+## E5 — FAQ (Day 4)
+
+**Subject:** `Your [Product] questions, answered`
+
+**Body:** Uses **Objection Handling** + `"How long for results?"` + `"What's included?"`
+
+## E6 — Urgency (Day 6)
+
+**Subject:** `48 hours left for [bonus/price]`
+
+**Body:** Uses **Urgency**. Losses = bonuses + price increase.
+
+## E7 — Final Hours (Day 7)
+
+**Subject:** `[FINAL] Last chance for [Product Name]`
+
+**Body:** `"At midnight: [changes]"` → CTA → offer summary → `P.S. Question? Reply now—I'll answer before midnight.`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
@@ -30,13 +30,13 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `Your [Product] questions, answered`
 
-**Body:** Uses [**Objection Handling**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns) + `"How long for results?"` + `"What's included?"`
+**Body:** Uses [**Objection Handling (Q&A)**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns) + `"How long for results?"` + `"What's included?"`
 
 ## E6 — Urgency (Day 6)
 
 **Subject:** `48 hours left for [bonus/price]`
 
-**Body:** Uses [**Urgency**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Losses = bonuses + price increase.
+**Body:** Uses [**Urgency / Final Push**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Losses = bonuses + price increase.
 
 ## E7 — Final Hours (Day 7)
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
@@ -24,19 +24,19 @@ Source: split from `direct-response-copy-templates-email-sequences.md`.
 
 **Subject:** `"I can't believe this worked" — [Customer]`
 
-**Body:** Uses **Social Proof**. Frame as launch momentum. Hard CTA.
+**Body:** Uses [**Social Proof**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Frame as launch momentum. Hard CTA.
 
 ## E5 — FAQ (Day 4)
 
 **Subject:** `Your [Product] questions, answered`
 
-**Body:** Uses **Objection Handling** + `"How long for results?"` + `"What's included?"`
+**Body:** Uses [**Objection Handling**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns) + `"How long for results?"` + `"What's included?"`
 
 ## E6 — Urgency (Day 6)
 
 **Subject:** `48 hours left for [bonus/price]`
 
-**Body:** Uses **Urgency**. Losses = bonuses + price increase.
+**Body:** Uses [**Urgency**](direct-response-copy-templates-email-sequences-01-shared-patterns.md#reusable-patterns). Losses = bonuses + price increase.
 
 ## E7 — Final Hours (Day 7)
 

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md
@@ -1,0 +1,11 @@
+# Subject Line Quick Reference
+
+Source: split from `direct-response-copy-templates-email-sequences.md`.
+
+| Category | Templates |
+|----------|-----------|
+| **Value** | `[Number] [things] to [result] this week` · `The [adj] way to [outcome]` · `How I [result] (finally)` |
+| **Curiosity** | `I need to tell you something...` · `The [topic] lesson I learned the hard way` · `What nobody tells you about [topic]` |
+| **Urgency** | `[X] hours left` · `Last chance: [offer]` · `Before midnight tonight...` |
+| **Personal** | `Quick question, [First Name]` · `[First Name], saw this and thought of you` · `Can I be honest?` |
+| **Story** | `How [Name] went from [before] to [after]` · `I almost [negative] until this happened` · `The email I didn't want to send` |

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
@@ -2,102 +2,35 @@
 
 Copy-paste templates for common sequences. Strategy/planning: [Email Sequences Framework](direct-response-copy-frameworks-email-sequences.md).
 
-## Shared Conventions
+## Chapters
 
-**Defaults** (don't repeat per email): Greeting `Hey [First Name],` / Sign-off `[Your Name]` / Reply invitation at end / Guarantee: `"Protected by our [X]-day guarantee. Zero risk."`
+| File | Contents |
+|------|----------|
+| [direct-response-copy-templates-email-sequences-01-shared-patterns.md](direct-response-copy-templates-email-sequences-01-shared-patterns.md) | Shared defaults and reusable patterns used across every sequence |
+| [direct-response-copy-templates-email-sequences-02-welcome.md](direct-response-copy-templates-email-sequences-02-welcome.md) | Welcome sequence — 5 emails from delivery to offer |
+| [direct-response-copy-templates-email-sequences-03-cart-abandonment.md](direct-response-copy-templates-email-sequences-03-cart-abandonment.md) | Cart abandonment sequence — 3 emails from reminder to final incentive |
+| [direct-response-copy-templates-email-sequences-04-saas-trial.md](direct-response-copy-templates-email-sequences-04-saas-trial.md) | SaaS trial sequence — 7 emails from onboarding to upgrade deadline |
+| [direct-response-copy-templates-email-sequences-05-launch.md](direct-response-copy-templates-email-sequences-05-launch.md) | Launch sequence — 7 emails from teaser to final-hours close |
+| [direct-response-copy-templates-email-sequences-06-subject-lines.md](direct-response-copy-templates-email-sequences-06-subject-lines.md) | Subject line quick reference by trigger category |
 
-## Reusable Patterns
+## How to Use
 
-Referenced by name across sequences — customize inline.
+1. Pick the sequence that matches the funnel stage.
+2. Reuse the shared patterns instead of rewriting them per email.
+3. Replace every bracketed placeholder with product-, audience-, and offer-specific detail.
+4. Adjust timing, CTA strength, and urgency to fit the campaign.
 
-**Social Proof**: `I want to introduce you to [Customer]. Before: [situation] → Challenge: [blocker] → Then they [action]. After: [results with numbers]. "[Testimonial]" The key insight? [Differentiator] [CTA]`
+This file is now the index for the email-sequence reference set. The chapter files retain the original template content.
 
-**Objection Handling (Q&A)**: `"Worth the price?" → [Value statement] · "Work for me?" → [Use cases] · "What if I don't like it?" → [Guarantee] · [Product-specific Qs] [CTA]`
+## Selection Guide
 
-**Urgency / Final Push**: `[What's ending] disappear in [timeframe]. After [deadline]: ❌ [Loss 1] ❌ [Loss 2] ❌ [Price increase]. If you've been on the fence, now's the time. [CTA]`
+- **Welcome**: New lead, subscriber, or download opt-in.
+- **Cart abandonment**: Checkout started but not completed.
+- **SaaS trial**: Product activation and upgrade conversion.
+- **Launch**: Timed launch, bonus window, or price-rise campaign.
 
----
+## Preservation Notes
 
-## Welcome Sequence (5 Emails)
-
-**E1 — Welcome + Delivery (Day 0)** · Subject: `Welcome to [Brand] + Your [Resource] Is Here`
-Body: Welcome intro → deliver [Resource] via [Download Link] → "I created this because [their problem]" → preview next 3 emails → `P.S. The [section] is my favorite—start there.`
-
-**E2 — Quick Win (Day 1)** · Subject: `Try this [timeframe] trick for [quick result]`
-Body: Reference yesterday's resource → [Actionable tip, 3-5 sentences] → why it works → preview next email.
-
-**E3 — Story + Lesson (Day 3)** · Subject: `The [mistake/discovery] that changed everything`
-Body: "[Timeframe] ago, I was [their situation]" → tried [failures] → [discovery moment] → lesson + specific action step.
-
-**E4 — Social Proof (Day 5)** · Subject: `How [Customer] [achieved result]` · Uses **Social Proof**. Soft CTA: preview tomorrow's offer.
-
-**E5 — Offer (Day 7)** · Subject: `Ready to [desired outcome]?`
-Body: Recap week's value (3 bullets) → introduce [Product] → benefits (3 bullets) → bonuses → CTA button → `P.S. [Urgency]`
-
----
-
-## Cart Abandonment (3 Emails)
-
-**E1 — Reminder (1h)** · Subject: `Did something go wrong?`
-Body: "Noticed you didn't finish checkout. Your cart is saved: [Cart Link]. Hit reply if you need help."
-
-**E2 — Objections (24h)** · Subject: `Quick question about your [Product] order` · Uses **Objection Handling**. Include cart link after Q&A.
-
-**E3 — Final + Incentive (48h)** · Subject: `[First Name], one more thing before you go`
-Body: "Use code [CODE] for [discount]. [Cart Link] — expires in 24 hours. P.S. [Guarantee]"
-
----
-
-## SaaS Trial (7 Emails)
-
-**E1 — Welcome + Quick Start (Day 0)** · Subject: `Welcome to [Product]! Here's how to start`
-Body: 3-step setup (each: action → benefit → direct link) → "Most users finish in [X] min" → `P.S. Trial lasts [X] days.`
-
-**E2 — Feature Highlight (Day 2)** · Subject: `Have you tried [Key Feature] yet?`
-Body: "[Feature] is what hooked most users" → 2-3 sentences on benefit → screenshot/GIF → feature link + tutorial link.
-
-**E3 — Social Proof (Day 4)** · Subject: `"[Result]" — How [Customer] uses [Product]` · Uses **Social Proof** + "They did it by [product action]." Hard CTA.
-
-**E4 — Check-in (Day 7)** · Subject: `How's [Product] working for you?`
-Body: "Halfway through—how's it going?" → ask about key action → 3 undiscovered features/tips → login CTA.
-
-**E5 — Feature #2 (Day 10)** · Subject: `The [Feature] trick most users miss` · Same as E2 structure. Power-user feature + 3-4 step how-to.
-
-**E6 — Trial Ending (Day 12)** · Subject: `Your trial ends in 2 days` · Uses **Urgency** (losses = features + data). CTA: `[Upgrade →]`. "Need more time? Reply."
-
-**E7 — Last Day (Day 14)** · Subject: `Your trial expires today`
-Body: "Ends at midnight" → keep list (✓ features, ✓ data) → upgrade CTA → discount code [CODE].
-
----
-
-## Launch Sequence (7 Emails)
-
-**E1 — Teaser (Day -3)** · Subject: `Something new is coming...`
-Body: "Working on this for [timeframe]. On [Date], ready to share." → 1-2 sentence teaser → "For [who] who want [outcome]" → mark calendar. `P.S. [Waitlist CTA]`
-
-**E2 — Problem Agitation (Day -1)** · Subject: `The real reason [problem] happens`
-Body: "Tomorrow's the day. First, let's talk about [problem]." → detail problem → failed approaches (2 bullets) → key insight → "Tomorrow, a different approach."
-
-**E3 — Launch Day (Day 0)** · Subject: `It's here: [Product Name] is LIVE`
-Body: Introduce + sales page link → "[Product] helps [outcome] without [objection]" → benefits (3) → launch-week bonuses with values → price (launch vs regular) → CTA. `P.S. [Scarcity]`
-
-**E4 — Case Study (Day 2)** · Subject: `"I can't believe this worked" — [Customer]` · Uses **Social Proof**. Frame as launch momentum. Hard CTA.
-
-**E5 — FAQ (Day 4)** · Subject: `Your [Product] questions, answered` · Uses **Objection Handling** + "How long for results?" + "What's included?"
-
-**E6 — Urgency (Day 6)** · Subject: `48 hours left for [bonus/price]` · Uses **Urgency**. Losses = bonuses + price increase.
-
-**E7 — Final Hours (Day 7)** · Subject: `[FINAL] Last chance for [Product Name]`
-Body: "At midnight: [changes]" → CTA → offer summary → `P.S. Question? Reply now—I'll answer before midnight.`
-
----
-
-## Subject Line Quick Reference
-
-| Category | Templates |
-|----------|-----------|
-| **Value** | "[Number] [things] to [result] this week" · "The [adj] way to [outcome]" · "How I [result] (finally)" |
-| **Curiosity** | "I need to tell you something..." · "The [topic] lesson I learned the hard way" · "What nobody tells you about [topic]" |
-| **Urgency** | "[X] hours left" · "Last chance: [offer]" · "Before midnight tonight..." |
-| **Personal** | "Quick question, [First Name]" · "[First Name], saw this and thought of you" · "Can I be honest?" |
-| **Story** | "How [Name] went from [before] to [after]" · "I almost [negative] until this happened" · "The email I didn't want to send" |
+- All original templates now live in the chapter files above.
+- Shared defaults and reusable patterns moved to the shared-patterns chapter.
+- Subject line formulas moved to the subject-lines chapter.

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
@@ -6,12 +6,12 @@ Copy-paste templates for common sequences. Strategy/planning: [Email Sequences F
 
 | File | Contents |
 |------|----------|
-| [direct-response-copy-templates-email-sequences-01-shared-patterns.md](direct-response-copy-templates-email-sequences-01-shared-patterns.md) | Shared defaults and reusable patterns used across every sequence |
-| [direct-response-copy-templates-email-sequences-02-welcome.md](direct-response-copy-templates-email-sequences-02-welcome.md) | Welcome sequence — 5 emails from delivery to offer |
-| [direct-response-copy-templates-email-sequences-03-cart-abandonment.md](direct-response-copy-templates-email-sequences-03-cart-abandonment.md) | Cart abandonment sequence — 3 emails from reminder to final incentive |
-| [direct-response-copy-templates-email-sequences-04-saas-trial.md](direct-response-copy-templates-email-sequences-04-saas-trial.md) | SaaS trial sequence — 7 emails from onboarding to upgrade deadline |
-| [direct-response-copy-templates-email-sequences-05-launch.md](direct-response-copy-templates-email-sequences-05-launch.md) | Launch sequence — 7 emails from teaser to final-hours close |
-| [direct-response-copy-templates-email-sequences-06-subject-lines.md](direct-response-copy-templates-email-sequences-06-subject-lines.md) | Subject line quick reference by trigger category |
+| [01: Shared Patterns](direct-response-copy-templates-email-sequences-01-shared-patterns.md) | Shared defaults and reusable patterns used across every sequence |
+| [02: Welcome Sequence](direct-response-copy-templates-email-sequences-02-welcome.md) | Welcome sequence — 5 emails from delivery to offer |
+| [03: Cart Abandonment](direct-response-copy-templates-email-sequences-03-cart-abandonment.md) | Cart abandonment sequence — 3 emails from reminder to final incentive |
+| [04: SaaS Trial](direct-response-copy-templates-email-sequences-04-saas-trial.md) | SaaS trial sequence — 7 emails from onboarding to upgrade deadline |
+| [05: Launch Sequence](direct-response-copy-templates-email-sequences-05-launch.md) | Launch sequence — 7 emails from teaser to final-hours close |
+| [06: Subject Lines](direct-response-copy-templates-email-sequences-06-subject-lines.md) | Subject line quick reference by trigger category |
 
 ## How to Use
 


### PR DESCRIPTION
## Summary
- convert `direct-response-copy-templates-email-sequences.md` into a slim index for the email-sequence reference set
- move the original shared patterns, sequences, and subject-line reference into six chapter files so the content stays intact
- keep selection and preservation notes in the index so the split remains discoverable

## Testing
- `bunx markdownlint-cli2 ".agents/marketing-sales/direct-response-copy-templates-email-sequences*.md"`
- line-count check: `index_lines=36`, `chapter_count=6`, `chapter_lines=174`, `combined_lines=210`, `original_lines=103`

## Runtime Testing
- self-assessed: low-risk markdown-only reference split; no runtime behavior changed

Closes #14216

${SIG_FOOTER}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized email sequence templates into modular chapters for improved navigation and maintainability.
  * Added comprehensive email sequence templates for welcome, cart abandonment, SaaS trial, and product launch campaigns.
  * Introduced shared patterns reference with reusable copy components and subject-line quick reference guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->