### PR TITLE
GH#14230: tighten quality management doc

### DIFF
--- a/.agents/tools/code-review/management.md
+++ b/.agents/tools/code-review/management.md
@@ -18,31 +18,31 @@ tools:
 
 ## Quick Reference
 
-- Methodology: Zero technical debt through systematic resolution
-- Core principle: Enhance functionality, never delete to fix issues
-- Priority order: S7679 (critical) → S1481 → S1192 → S7682 → ShellCheck
-- S7679 fix: `printf 'Price: %s50/month\n' '$'` — not `echo "Price: $50/month"`
-- S1481 fix: Enhance variable usage or remove if truly unused
-- S1192 fix: `readonly CONSTANT="repeated string"` at file top
+- Goal: zero technical debt through systematic resolution
+- Rule: enhance functionality; never delete behavior to silence a warning
+- Priority: S7679 (critical) → S1481 → S1192 → S7682 → ShellCheck
+- S7679: `printf 'Price: %s50/month\n' '$'`, not `echo "Price: $50/month"`
+- S1481: improve variable usage before deleting
+- S1192: lift repeated literals to top-level `readonly` constants
 - Key scripts: `linters-local.sh`, `quality-fix.sh`, `quality-cli-manager.sh`
-- Achievement: 349 → 42 issues (88% reduction), 100% critical resolved
-- Success criteria: Zero S7679/S1481, <10 S1192, 100% feature retention
+- Baseline: 349 → 42 issues (88% reduction), 100% critical resolved
+- Targets: zero S7679/S1481, <10 S1192, 100% feature retention
 
 <!-- AI-CONTEXT-END -->
 
 > Supplementary to [AGENTS.md](../AGENTS.md). AGENTS.md takes precedence on conflicts.
 
-## Core Principles
+## Core Rules
 
-1. **Enhance, never delete** — fix violations by adding value, not removing functionality
-2. **Priority order** — S7679 → S1481 → S1192 → S7682 → ShellCheck
-3. **Automation-first** — batch-process violations; build quality gates into workflow
+1. **Enhance, never delete** — fix violations by adding value, not removing behavior.
+2. **Use the priority order** — resolve S7679 before S1481, then S1192, S7682, and ShellCheck.
+3. **Automate first** — batch fixes and keep quality gates in the workflow.
 
 ## Issue Resolution Patterns
 
-### S7679 — Positional Parameters (RESOLVED)
+### S7679 — positional parameters (resolved)
 
-Shell interprets `$50`, `$200` as positional parameters.
+Shell treats `$50`, `$200`, and similar values as positional parameters.
 
 ```bash
 # ❌ BEFORE
@@ -52,9 +52,9 @@ echo "Price: $50/month"
 printf 'Price: %s50/month\n' '$'
 ```
 
-### S1481 — Unused Variables (RESOLVED)
+### S1481 — unused variables (resolved)
 
-Prefer enhancing usage over removal.
+Prefer meaningful usage over removal.
 
 ```bash
 # ❌ BEFORE
@@ -65,9 +65,9 @@ local port; read -r port
 if [[ -n "$port" && "$port" != "22" ]]; then ssh -p "$port" "$host"; else ssh "$host"; fi
 ```
 
-### S1192 — String Literals (major progress)
+### S1192 — string literals (major progress)
 
-Repeated literals (3+ occurrences) → `readonly` constant.
+Lift literals repeated 3+ times into `readonly` constants.
 
 ```bash
 # ❌ BEFORE
@@ -78,23 +78,23 @@ readonly CONTENT_TYPE_JSON="Content-Type: application/json"
 curl -H "$CONTENT_TYPE_JSON"  # × 3
 ```
 
-## Tools & Scripts
+## Tools
 
 | Tool | Purpose |
 |------|---------|
 | `linters-local.sh` | Multi-platform quality validation |
-| `fix-content-type.sh` | Content-Type header consolidation |
-| `fix-auth-headers.sh` | Authorization header standardization |
-| `fix-error-messages.sh` | Common error message constants |
-| `markdown-formatter.sh` | Markdown quality compliance |
-| `quality-cli-manager.sh` | Unified CLI management (CodeRabbit, Codacy, SonarScanner) |
+| `fix-content-type.sh` | Consolidate `Content-Type` headers |
+| `fix-auth-headers.sh` | Standardize authorization headers |
+| `fix-error-messages.sh` | Extract common error-message constants |
+| `markdown-formatter.sh` | Enforce Markdown quality |
+| `quality-cli-manager.sh` | Manage CodeRabbit, Codacy, and SonarScanner |
 
 ## Success Criteria
 
 | Metric | Target |
 |--------|--------|
-| S7679, S1481 violations | 0 |
+| S7679 and S1481 violations | 0 |
 | S1192 violations | <10 |
-| ShellCheck critical per file | <5 |
+| ShellCheck critical findings per file | <5 |
 | Feature retention | 100% |
-| SonarCloud issues | 42 (from 349, 88% reduction) |
+| SonarCloud issues | 42 (down from 349, 88% reduction) |


### PR DESCRIPTION
## Summary
- tighten the quality management quick reference and core rules so the document reads like a concise reference card
- keep all existing resolution patterns, scripts, and success criteria while improving wording clarity

## Testing
- `bunx markdownlint-cli2 ".agents/tools/code-review/management.md"`
- reviewed the diff to confirm all examples, scripts, and metrics remain present

## Runtime Testing
- Level: self-assessed
- Reason: docs-only change to an agent reference file

Closes #14230

---
[aidevops.sh](https://aidevops.sh) v3.5.510 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 3m and 97,126 tokens on this with the user in an interactive session. Overall, 17h 21m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured management documentation with updated terminology for quick reference items, core rules section, and success metrics.
  * Refined issue descriptions and tool purpose descriptions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->