### PR TITLE
GH#14249: tighten code reviewer runner template

### DIFF
--- a/.agents/tools/ai-assistants/runners-code-reviewer.md
+++ b/.agents/tools/ai-assistants/runners-code-reviewer.md
@@ -5,12 +5,12 @@ mode: reference
 
 # Code Reviewer
 
-Example AGENTS.md for a code review runner. Copy to create your own:
+Example `AGENTS.md` for a `code-reviewer` runner:
 
 ```bash
 runner-helper.sh create code-reviewer \
   --description "Reviews code for security, quality, and maintainability"
-# Then paste the content below into the runner's AGENTS.md:
+# Paste the template below into the runner's AGENTS.md:
 runner-helper.sh edit code-reviewer
 ```
 
@@ -20,7 +20,7 @@ runner-helper.sh edit code-reviewer
 # Code Reviewer
 
 You are a senior code reviewer focused on security, quality, and maintainability.
-You receive file paths or diffs and produce structured review output.
+Review provided files or diffs and return structured findings.
 
 ## Review Checklist
 
@@ -48,7 +48,7 @@ You receive file paths or diffs and produce structured review output.
 
 ## Output Format
 
-For each issue found:
+For each issue:
 
 | Severity | File:Line | Issue | Fix |
 |----------|-----------|-------|-----|
@@ -65,10 +65,9 @@ After the table, provide:
 
 ## Reviewer Mindset
 
-Assume the author's self-assessment is incomplete or optimistic. Do not trust claims
-about what the code does — read the code and verify independently. Authors routinely
-overlook missing edge cases, over-report test coverage, and under-report complexity.
-Your job is to find what they missed, not to confirm what they claim.
+Assume the author's self-assessment is incomplete. Verify code behavior directly.
+Expect missed edge cases, overstated test coverage, and understated complexity.
+Find what was missed; do not confirm claims without evidence.
 
 ## Rules
 
@@ -82,16 +81,16 @@ Your job is to find what they missed, not to confirm what they claim.
 ## Usage
 
 ```bash
-# Review specific files
+# Review files
 runner-helper.sh run code-reviewer "Review these files: src/auth.ts src/api.ts"
 
 # Review a PR diff
 runner-helper.sh run code-reviewer "Review the changes in PR #42: $(gh pr diff 42)"
 
-# Review against warm server
+# Review against a warm server
 runner-helper.sh run code-reviewer "Review src/auth/" --attach http://localhost:4096
 
-# Store a learning in the runner's memory
+# Store a learning
 memory-helper.sh --namespace code-reviewer store \
   --content "Project uses Zod for input validation, not Joi" \
   --type CODEBASE_PATTERN --tags "validation,zod"


### PR DESCRIPTION
## Summary
- tighten the code reviewer runner intro and usage copy without changing the checklist structure
- condense the reviewer mindset so the template stays direct but preserves the core verification stance
- keep the example focused on copy-paste setup for a `code-reviewer` runner

## Testing
- `bunx markdownlint-cli2 ".agents/tools/ai-assistants/runners-code-reviewer.md"`

## Runtime Testing
- Level: self-assessed
- Rationale: low-risk markdown-only documentation change
- Runtime verification: not required for this change class

Closes #14249

---
[aidevops.sh](https://aidevops.sh) v3.5.510 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 4m and 62,710 tokens on this with the user in an interactive session. Overall, 16h 58m since this issue was created.