### PR TITLE
GH#14231: split pulumi gotchas into chapters

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md
@@ -1,100 +1,20 @@
 # Troubleshooting & Best Practices
 
-## Common Errors
+Reference index for Cloudflare + Pulumi troubleshooting. Detailed sections moved into chapter files so the entry doc stays short and scannable.
 
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `Missing required property 'accountId'` | Account ID not set | Add to stack config or pass explicitly |
-| Binding name mismatch | Worker expects `MY_KV` but binding differs | Match binding names in Pulumi and worker code |
-| `resource 'abc123' not found` | Resource missing in account/zone | Ensure resource exists in correct account/zone |
-| API token permissions error | Token lacks required scopes | Verify token has Workers, KV, R2, D1 permissions |
+## Chapters
 
-## Debugging
+| Topic | Covers |
+|-------|--------|
+| [common-errors](./pulumi-gotchas/common-errors.md) | Frequent Pulumi + Cloudflare failures, causes, and fixes |
+| [debugging](./pulumi-gotchas/debugging.md) | Verbose logging and state inspection commands |
+| [best-practices](./pulumi-gotchas/best-practices.md) | Stack config, production protection, dependency ordering |
+| [security](./pulumi-gotchas/security.md) | Secret handling, token scopes, state protection |
+| [performance](./pulumi-gotchas/performance.md) | State-size and refresh guidance |
+| [migration](./pulumi-gotchas/migration.md) | Importing existing resources and moving from Wrangler/Terraform |
+| [ci-cd](./pulumi-gotchas/ci-cd.md) | Automation patterns for GitHub Actions and GitLab CI |
+| [resources](./pulumi-gotchas/resources.md) | Primary docs and registry links |
 
-```bash
-pulumi up --logtostderr -v=9   # verbose logging
-pulumi preview                  # preview changes
-pulumi stack export             # view resource state
-pulumi stack --show-urns
-pulumi state delete <urn>       # use with caution
-```
+## Related
 
-## Best Practices
-
-**Stack configuration:**
-
-```yaml
-# Pulumi.<stack>.yaml
-config:
-  cloudflare:accountId: "abc123"
-  cloudflare:apiToken:
-    secure: "encrypted-value"
-  app:domain: "example.com"
-  app:zoneId: "xyz789"
-```
-
-**Protect production resources:**
-
-```typescript
-const prodDb = new cloudflare.D1Database("prod-db", {accountId, name: "production-database"},
-    {protect: true});
-```
-
-**Dependency ordering:**
-
-```typescript
-const migration = new command.local.Command("migration", {
-    create: pulumi.interpolate`wrangler d1 execute ${db.name} --file ./schema.sql`,
-}, {dependsOn: [db]});
-const worker = new cloudflare.WorkerScript("worker", {
-    accountId, name: "worker", content: code,
-    d1DatabaseBindings: [{name: "DB", databaseId: db.id}],
-}, {dependsOn: [migration]});
-```
-
-For multi-account providers, resource naming, and environment patterns, see [pulumi-patterns.md](./pulumi-patterns.md).
-
-## Security
-
-**Secrets management:**
-
-```typescript
-const config = new pulumi.Config();
-const apiKey = config.requireSecret("apiKey");
-const worker = new cloudflare.WorkerScript("worker", {
-    accountId, name: "my-worker", content: code,
-    secretTextBindings: [{name: "API_KEY", text: apiKey}],
-});
-// CLI: pulumi config set --secret apiKey "secret-value"
-// Env: export CLOUDFLARE_API_TOKEN="..."
-```
-
-**API token scopes** (minimal permissions): Workers — `Workers Routes:Edit`, `Workers Scripts:Edit` | KV — `Workers KV Storage:Edit` | R2 — `R2:Edit` | D1 — `D1:Edit` | DNS — `Zone:Edit`, `DNS:Edit` | Pages — `Pages:Edit`
-
-**State security:** Use Pulumi Cloud or S3 backend with encryption. Never commit state files to VCS. Use RBAC to control stack access.
-
-## Performance
-
-- Avoid storing large files in state; use `ignoreChanges` for frequently changing properties
-- Pulumi automatically parallelizes independent resource updates
-- `pulumi refresh --yes` — sync state with actual infrastructure
-
-## Migration
-
-**Import existing resources:**
-
-```bash
-pulumi import cloudflare:index/workerScript:WorkerScript my-worker <account_id>/<worker_name>
-pulumi import cloudflare:index/workersKvNamespace:WorkersKvNamespace my-kv <namespace_id>
-pulumi import cloudflare:index/r2Bucket:R2Bucket my-bucket <account_id>/<bucket_name>
-```
-
-**From Terraform/Wrangler:** Use `pulumi import` and rewrite configs in Pulumi DSL. For wrangler.toml: create matching Pulumi resources, import, verify with `pulumi preview`, then switch deployments.
-
-## CI/CD
-
-Use [`pulumi/actions@v4`](https://github.com/pulumi/actions) (GitHub Actions) or `pulumi/pulumi:latest` image (GitLab CI). Set `PULUMI_ACCESS_TOKEN` and `CLOUDFLARE_API_TOKEN` as secrets. Run `pulumi up --yes` with `--stack prod`.
-
-## Resources
-
-[Pulumi Registry](https://www.pulumi.com/registry/packages/cloudflare/) · [API Docs](https://www.pulumi.com/registry/packages/cloudflare/api-docs/) · [GitHub](https://github.com/pulumi/pulumi-cloudflare) · [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
+- For multi-account providers, resource naming, and environment patterns, see [pulumi-patterns.md](./pulumi-patterns.md).

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md
@@ -1,0 +1,34 @@
+# Best Practices
+
+## Stack Configuration
+
+```yaml
+# Pulumi.<stack>.yaml
+config:
+  cloudflare:accountId: "abc123"
+  cloudflare:apiToken:
+    secure: "encrypted-value"
+  app:domain: "example.com"
+  app:zoneId: "xyz789"
+```
+
+## Protect Production Resources
+
+```typescript
+const prodDb = new cloudflare.D1Database("prod-db", {accountId, name: "production-database"},
+    {protect: true});
+```
+
+## Dependency Ordering
+
+```typescript
+const migration = new command.local.Command("migration", {
+    create: pulumi.interpolate`wrangler d1 execute ${db.name} --file ./schema.sql`,
+}, {dependsOn: [db]});
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId, name: "worker", content: code,
+    d1DatabaseBindings: [{name: "DB", databaseId: db.id}],
+}, {dependsOn: [migration]});
+```
+
+For multi-account providers, resource naming, and environment patterns, see [../pulumi-patterns.md](../pulumi-patterns.md).

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md
@@ -1,0 +1,3 @@
+# CI/CD
+
+Use [`pulumi/actions@v4`](https://github.com/pulumi/actions) (GitHub Actions) or `pulumi/pulumi:latest` image (GitLab CI). Set `PULUMI_ACCESS_TOKEN` and `CLOUDFLARE_API_TOKEN` as secrets. Run `pulumi up --yes` with `--stack prod`.

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md
@@ -1,0 +1,8 @@
+# Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Missing required property 'accountId'` | Account ID not set | Add to stack config or pass explicitly |
+| Binding name mismatch | Worker expects `MY_KV` but binding differs | Match binding names in Pulumi and worker code |
+| `resource 'abc123' not found` | Resource missing in account/zone | Ensure resource exists in correct account/zone |
+| API token permissions error | Token lacks required scopes | Verify token has Workers, KV, R2, D1 permissions |

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md
@@ -1,0 +1,9 @@
+# Debugging
+
+```bash
+pulumi up --logtostderr -v=9   # verbose logging
+pulumi preview                  # preview changes
+pulumi stack export             # view resource state
+pulumi stack --show-urns
+pulumi state delete <urn>       # use with caution
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md
@@ -1,0 +1,13 @@
+# Migration
+
+## Import Existing Resources
+
+```bash
+pulumi import cloudflare:index/workerScript:WorkerScript my-worker <account_id>/<worker_name>
+pulumi import cloudflare:index/workersKvNamespace:WorkersKvNamespace my-kv <namespace_id>
+pulumi import cloudflare:index/r2Bucket:R2Bucket my-bucket <account_id>/<bucket_name>
+```
+
+## From Terraform or Wrangler
+
+Use `pulumi import` and rewrite configs in Pulumi DSL. For `wrangler.toml`: create matching Pulumi resources, import, verify with `pulumi preview`, then switch deployments.

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md
@@ -1,0 +1,5 @@
+# Performance
+
+- Avoid storing large files in state; use `ignoreChanges` for frequently changing properties
+- Pulumi automatically parallelizes independent resource updates
+- `pulumi refresh --yes` — sync state with actual infrastructure

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md
@@ -1,0 +1,6 @@
+# Resources
+
+- [Pulumi Registry](https://www.pulumi.com/registry/packages/cloudflare/)
+- [API Docs](https://www.pulumi.com/registry/packages/cloudflare/api-docs/)
+- [GitHub](https://github.com/pulumi/pulumi-cloudflare)
+- [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)

--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md
@@ -1,0 +1,22 @@
+# Security
+
+## Secrets Management
+
+```typescript
+const config = new pulumi.Config();
+const apiKey = config.requireSecret("apiKey");
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId, name: "my-worker", content: code,
+    secretTextBindings: [{name: "API_KEY", text: apiKey}],
+});
+// CLI: pulumi config set --secret apiKey "secret-value"
+// Env: export CLOUDFLARE_API_TOKEN="..."
+```
+
+## API Token Scopes
+
+Minimal permissions: Workers — `Workers Routes:Edit`, `Workers Scripts:Edit` | KV — `Workers KV Storage:Edit` | R2 — `R2:Edit` | D1 — `D1:Edit` | DNS — `Zone:Edit`, `DNS:Edit` | Pages — `Pages:Edit`
+
+## State Security
+
+Use Pulumi Cloud or S3 backend with encryption. Never commit state files to VCS. Use RBAC to control stack access.


### PR DESCRIPTION
## Summary
- Reclassify `pulumi-gotchas.md` as a reference index instead of compressing away platform guidance.
- Split the troubleshooting, security, migration, and CI/CD material into chapter files under `pulumi-gotchas/`.
- Keep the entry doc short and link the extracted chapters plus the existing `pulumi-patterns.md` companion.

## Runtime Testing
- Level: self-assessed (low risk docs-only change)
- Verification: `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md" ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/*.md"`
- Content preservation: split set totals 120 lines across the new index and chapter files, preserving the original examples, commands, and links.

Closes #14231
---
[aidevops.sh](https://aidevops.sh) v3.5.510 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 5m and 67,748 tokens on this as a headless worker. Overall, 17h 24m since this issue was created.