### PR TITLE
GH#14709: tighten aidevops plugin architecture doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -122,8 +122,8 @@
       "pr": 11276
     },
     ".agents/tools/build-mcp/aidevops-plugin.md": {
-      "hash": "e6c20b6bebe7bba7df1f71048584087448284262",
-      "at": "2026-03-31T04:46:03Z",
+      "hash": "965406d3098998fb4121161a272f41b8db9b9f9e",
+      "at": "2026-03-31T07:46:05Z",
       "pr": 14599
     },
     ".agents/aidevops/add-new-mcp-to-aidevops.md": {

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -123,8 +123,8 @@
     },
     ".agents/tools/build-mcp/aidevops-plugin.md": {
       "hash": "965406d3098998fb4121161a272f41b8db9b9f9e",
-      "at": "2026-03-31T07:46:05Z",
-      "pr": 14599
+      "at": "2026-03-31T07:48:15Z",
+      "pr": 14720
     },
     ".agents/aidevops/add-new-mcp-to-aidevops.md": {
       "hash": "818de6a118b3981cbc732aace97a1220ad7f27ee",

--- a/.agents/tools/build-mcp/aidevops-plugin.md
+++ b/.agents/tools/build-mcp/aidevops-plugin.md
@@ -37,7 +37,7 @@ tools:
 
 ### `config` hook
 
-- Reads `~/.aidevops/agents/`, parses YAML frontmatter, injects subagent definitions into `config.agent`, and skips agents already defined by shell-generated config (`t008.1`).
+- Loads subagents from `~/.aidevops/agents/`, parses YAML frontmatter, injects them into `config.agent`, and skips agents already defined by shell-generated config (`t008.1`).
 - Registers MCP servers from a data-driven registry instead of re-running `generate-opencode-agents.sh` (`t008.2`).
 - Registry fields: `name`, `type` (`local`/`remote`), `command` or `url`, `eager`, `toolPattern`, `globallyEnabled`, `requiresBinary`, `macOnly`.
 - `AGENT_MCP_TOOLS` maps agents to tool globs, for example `@dataforseo` -> `dataforseo_*`.
@@ -57,34 +57,15 @@ tools:
 | `sentry` | remote | no |
 | `socket` | remote | no |
 
-### `tool` registration
+### Supporting hooks
 
-| Tool | Purpose |
+| Hook | Coverage |
 |---|---|
-| `aidevops` | Run aidevops CLI commands |
-| `aidevops_memory` | Recall or store cross-session memory (`recall` or `store`) |
-| `aidevops_pre_edit_check` | Run the pre-edit git safety check |
-| `model-accounts-pool` | Manage OAuth account pools and provider rotation |
-
-### `tool.execute.before` / `tool.execute.after` (`t008.3`)
-
-| Phase | Coverage |
-|---|---|
-| Pre-tool | ShellCheck (`-x -S warning`), return validation, `local var="$1"` enforcement, Markdown MD031, trailing whitespace, secret scanning on writes |
-| Post-tool | Git operation detection, pattern tracking via cross-session memory, audit logging to `~/.aidevops/logs/quality-hooks.log` |
-
-### `shell.env` hook
-
-Exports:
-
-- `PATH` with `~/.aidevops/agents/scripts/` prepended
-- `AIDEVOPS_AGENTS_DIR`
-- `AIDEVOPS_WORKSPACE_DIR`
-- `AIDEVOPS_VERSION`
-
-### `experimental.session.compacting` hook
-
-Preserves active agent state, loop guardrails, session checkpoint, project-scoped memories (limit 5), git context, and pending mailbox messages.
+| `tool` registration | `aidevops`, `aidevops_memory`, `aidevops_pre_edit_check`, `model-accounts-pool` |
+| `tool.execute.before` (`t008.3`) | ShellCheck (`-x -S warning`), return validation, `local var="$1"` enforcement, Markdown MD031, trailing whitespace, secret scanning on writes |
+| `tool.execute.after` (`t008.3`) | Git operation detection, pattern tracking via cross-session memory, audit logging to `~/.aidevops/logs/quality-hooks.log` |
+| `shell.env` | Prepends `~/.aidevops/agents/scripts/` to `PATH`; exports `AIDEVOPS_AGENTS_DIR`, `AIDEVOPS_WORKSPACE_DIR`, `AIDEVOPS_VERSION` |
+| `experimental.session.compacting` | Preserves active agent state, loop guardrails, session checkpoint, project-scoped memories (limit 5), git context, pending mailbox messages |
 
 ## Design decisions
 


### PR DESCRIPTION
## Summary
- consolidate the non-config plugin hooks into a single coverage table so the runtime surface stays scan-friendly without losing details
- tighten the config-hook wording while preserving the MCP registry fields, lazy-loading policy, and task references
- refresh `.agents/configs/simplification-state.json` with the new file hash, timestamp, and PR link for this doc

## Testing Evidence
- `bunx markdownlint-cli2 ".agents/tools/build-mcp/aidevops-plugin.md"`
- `jq empty .agents/configs/simplification-state.json`

## Runtime Testing
- Level: self-assessed
- Rationale: docs and metadata only; no runtime behavior changed

Closes #14709


---
[aidevops.sh](https://aidevops.sh) v3.5.510 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 10m on this as a headless worker.