### PR TITLE
GH#14267: tighten chore branch workflow doc

### DIFF
--- a/.agents/workflows/branch/chore.md
+++ b/.agents/workflows/branch/chore.md
@@ -30,22 +30,17 @@ git checkout -b chore/{description}
 
 ## When to Use
 
-- Dependency updates
-- CI/CD configuration changes
-- Documentation updates
-- Build system changes
-- Tooling configuration
+- Dependency, CI/CD, docs, build, and tooling maintenance
 - Code formatting/linting fixes
-- License updates
-- Gitignore changes
+- License or `.gitignore` updates
 
-**Not for**: Code changes that affect behavior (use `feature/`, `bugfix/`, or `refactor/`).
+**Not for** behavior changes; use `feature/`, `bugfix/`, or `refactor/` instead.
 
-## Unique Guidance
+## Guidance
 
-### Multiple Commit Prefixes
-
-Use specific prefixes when applicable:
+- Branch names use `chore/{description}`.
+- Pick the narrowest commit prefix for the change.
+- Chore branches usually do not need a version bump.
 
 | Prefix | Use For |
 |--------|---------|
@@ -54,9 +49,9 @@ Use specific prefixes when applicable:
 | `ci:` | CI/CD changes |
 | `build:` | Build system |
 
-### Common Chore Tasks
+## Common Tasks
 
-**Dependency Updates:**
+### Dependency updates
 
 ```bash
 npm outdated          # Check for updates
@@ -64,7 +59,7 @@ npm update            # Update and test
 git commit -m "chore: update dependencies"
 ```
 
-**CI/CD Changes:**
+### CI/CD changes
 
 ```bash
 git commit -m "ci: optimize GitHub Actions workflow
@@ -74,7 +69,7 @@ git commit -m "ci: optimize GitHub Actions workflow
 - Reduce build time by 40%"
 ```
 
-**Documentation:**
+### Documentation
 
 ```bash
 git commit -m "docs: improve installation instructions


### PR DESCRIPTION
## Summary
- tighten ".agents/workflows/branch/chore.md" to make chore-branch selection and commit-prefix guidance faster to scan
- preserve the existing branch, dependency-update, CI, docs, and branch-name command examples while removing redundant headings and prose

## Runtime Testing
- Risk level: low
- Verification: self-assessed; markdown-only agent doc change

## Testing
- \markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/workflows/branch/chore.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)
- verified all existing command examples remain present after the edit

Closes #14267


---
[aidevops.sh](https://aidevops.sh) v3.5.512 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 7m and 87,772 tokens on this as a headless worker. Overall, 16h 28m since this issue was created.