### PR TITLE
GH#14295: tighten memory-log command doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -56,6 +56,11 @@
       "at": "2026-03-27T21:25:13Z",
       "pr": 11007
     },
+    ".agents/scripts/commands/memory-log.md": {
+      "hash": "2904340ce8cab8b5a4076f91e5742d67c4f8375a",
+      "at": "2026-03-31T08:03:53Z",
+      "pr": 14729
+    },
     ".agents/services/communications/xmtp.md": {
       "hash": "0b5b1bb178865dc7efff9f7578cd26dd9bf82bc9",
       "at": "2026-03-27T21:25:14Z",

--- a/.agents/scripts/commands/memory-log.md
+++ b/.agents/scripts/commands/memory-log.md
@@ -4,31 +4,29 @@ agent: Build+
 mode: subagent
 ---
 
-Show the auto-capture memory log - memories stored automatically by AI agents during sessions.
+Show recent auto-captured memories from AI sessions.
 
-Arguments: $ARGUMENTS
+Arguments: `$ARGUMENTS`
 
 ## Workflow
 
-### Step 1: Show Auto-Capture Log
-
-Run the log command:
+1. Run the log command:
 
 ```bash
 ~/.aidevops/agents/scripts/memory-helper.sh log
 ```
 
-### Step 2: Apply Filters (if requested)
+2. Apply requested filters:
 
 | Argument | Command |
 |----------|---------|
-| (none) | `memory-helper.sh log` (last 20 auto-captures) |
+| (none) | `memory-helper.sh log` — last 20 auto-captures |
 | `--limit N` | `memory-helper.sh log --limit N` |
 | `--json` | `memory-helper.sh log --json` |
 
-### Step 3: Present Results
+3. Present results.
 
-If results found:
+If entries exist:
 
 ```text
 Auto-Capture Log (last 20):
@@ -43,7 +41,7 @@ Auto-Capture Log (last 20):
 Total auto-captured: 15
 ```
 
-If no results:
+If empty:
 
 ```text
 No auto-captured memories yet.
@@ -54,13 +52,13 @@ Auto-capture stores memories when AI agents detect:
   - Architecture decisions
   - Tool configurations
 
-Trigger auto-capture by using the --auto flag:
+Trigger auto-capture with:
   memory-helper.sh store --auto --content "..."
 ```
 
-## How Auto-Capture Works
+## Auto-capture triggers
 
-AI agents automatically store memories using `--auto` flag when they detect:
+Agents store memories with `--auto` when they detect:
 
 | Trigger | Memory Type | Example |
 |---------|-------------|---------|
@@ -73,13 +71,13 @@ AI agents automatically store memories using `--auto` flag when they detect:
 
 ## Privacy
 
-Auto-captured memories are subject to privacy filters:
+Apply privacy filters before storage:
 
 - `<private>...</private>` tags are stripped before storage
 - Content matching secret patterns (API keys, tokens) is rejected
 - Use `privacy-filter-helper.sh scan` for comprehensive scanning
 
-## Related Commands
+## Related
 
 | Command | Purpose |
 |---------|---------|


### PR DESCRIPTION
## Summary
- tighten ".agents/scripts/commands/memory-log.md" wording so the slash command reads like a compact operator reference instead of a tutorial
- keep the command examples, filter matrix, trigger taxonomy, and privacy guidance while renaming sections for faster scanning

## Testing
- markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/scripts/commands/memory-log.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Runtime Testing
- Level: self-assessed (low-risk agent doc change)
- Evidence: markdown lint passed; no runtime behavior changed

Closes #14295


---
[aidevops.sh](https://aidevops.sh) v3.5.513 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 8m and 115,640 tokens on this with the user in an interactive session. Overall, 15h 35m since this issue was created.