### PR TITLE
GH#14294: tighten D1 reference overview

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/d1.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/d1.md
@@ -1,50 +1,56 @@
 # Cloudflare D1 Database
 
-Expert guidance for Cloudflare D1, a serverless SQLite database designed for horizontal scale-out across multiple databases.
+Managed SQLite for Cloudflare Workers. Use it when queries need SQL semantics and stronger consistency than KV, but keep the data model horizontally partitionable.
 
-## Overview
+## Core Model
 
-D1 is Cloudflare's managed, serverless database with:
-- SQLite SQL semantics and compatibility
-- Built-in disaster recovery via Time Travel (30-day point-in-time recovery)
-- Horizontal scale-out architecture (10 GB per database)
-- Worker and HTTP API access
-- Pricing based on query and storage costs only
+- SQLite-compatible SQL
+- 10 GB maximum per database
+- 30-day Time Travel recovery window
+- Worker bindings and HTTP API access
+- Query- and storage-based pricing
 
-**Architecture Philosophy**: D1 is optimized for per-user, per-tenant, or per-entity database patterns rather than single large databases.
+**Design bias:** Prefer many small databases (per tenant, user, or entity) over one large shared database.
 
 ## Quick Start
 
 ```bash
-# Create database
 wrangler d1 create <database-name>
-
-# Execute migration
 wrangler d1 execute <db-name> --remote --file=./migrations/0001_schema.sql
-
-# Local development
 wrangler dev
 ```
 
-## Core Query Methods
+## Query API
 
 ```typescript
-// .all() - Returns all rows; .first() - First row or null; .first(col) - Single column value
-// .run() - INSERT/UPDATE/DELETE; .raw() - Array of arrays (efficient)
-const { results, success, meta } = await env.DB.prepare('SELECT * FROM users WHERE active = ?').bind(true).all();
-const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).first();
+const { results, success, meta } = await env.DB
+  .prepare('SELECT * FROM users WHERE active = ?')
+  .bind(true)
+  .all();
+
+const user = await env.DB
+  .prepare('SELECT * FROM users WHERE id = ?')
+  .bind(userId)
+  .first();
 ```
+
+- `.all()` returns all rows
+- `.first()` returns the first row or `null`
+- `.first(column)` returns one column value
+- `.run()` is for write statements
+- `.raw()` returns array rows for lower-overhead reads
 
 ## Batch Operations
 
 ```typescript
-// Multiple queries in single round trip (atomic transaction)
 const results = await env.DB.batch([
   env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(1),
   env.DB.prepare('SELECT * FROM posts WHERE author_id = ?').bind(1),
-  env.DB.prepare('UPDATE users SET last_access = ? WHERE id = ?').bind(Date.now(), 1)
+  env.DB.prepare('UPDATE users SET last_access = ? WHERE id = ?').bind(Date.now(), 1),
 ]);
 ```
+
+Use `batch()` for multiple independent statements in one round trip. It is also the main transaction primitive exposed by the Worker binding.
 
 ## Platform Limits
 
@@ -56,35 +62,28 @@ const results = await env.DB.batch([
 | Batch size | 10,000 statements |
 | Time Travel retention | 30 days |
 
-## CLI Commands
+## Essential Commands
 
 ```bash
-# Database management
 wrangler d1 create <db-name>
 wrangler d1 list
 wrangler d1 delete <db-name>
-
-# Execute queries
 wrangler d1 execute <db-name> --remote --command="SELECT * FROM users"
 wrangler d1 execute <db-name> --local --file=./migrations/0001_schema.sql
-
-# Backups
 wrangler d1 export <db-name> --remote --output=./backup.sql
 wrangler d1 time-travel restore <db-name> --timestamp="2024-01-15T14:30:00Z"
-
-# Development
 wrangler dev --persist-to=./.wrangler/state
 ```
 
 ## In This Reference
 
-- [patterns.md](./patterns.md) - Pagination, bulk operations, caching, multi-tenant patterns
-- [gotchas.md](./gotchas.md) - SQL injection prevention, error handling, performance pitfalls
+- [d1-patterns.md](./d1-patterns.md) - Pagination, bulk operations, caching, session storage, multi-tenant layouts
+- [d1-gotchas.md](./d1-gotchas.md) - SQL injection prevention, indexing, query limits, local-vs-remote differences
 
 ## See Also
 
-- [workers](../workers/) - Worker runtime and fetch handler patterns
-- [kv](../kv/) - Workers KV for caching D1 results
-- [r2](../r2/) - R2 for storing binary data instead of D1 BLOBs
-- [queues](../queues/) - Queue writes to D1 for high-throughput scenarios
-- [durable-objects](../durable-objects/) - Coordinate D1 writes with strong consistency
+- [workers.md](./workers.md) - Runtime and handler patterns
+- [kv.md](./kv.md) - Read-heavy caching and eventual consistency
+- [r2.md](./r2.md) - Store blobs outside D1
+- [queues.md](./queues.md) - Buffer high-throughput writes
+- [durable-objects.md](./durable-objects.md) - Coordinate strongly ordered workflows


### PR DESCRIPTION
## Summary
- tighten the D1 overview so the high-signal model, API, and operational limits appear first
- replace stale relative links with the actual flat skill filenames used in this directory

## Testing
- bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/d1.md"
- git ls-files '.agents/services/hosting/cloudflare-platform-skill/d1-patterns.md' '.agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md' '.agents/services/hosting/cloudflare-platform-skill/workers.md' '.agents/services/hosting/cloudflare-platform-skill/kv.md' '.agents/services/hosting/cloudflare-platform-skill/r2.md' '.agents/services/hosting/cloudflare-platform-skill/queues.md' '.agents/services/hosting/cloudflare-platform-skill/durable-objects.md'

## Runtime Testing
- Level: self-assessed
- Reason: doc-only change in a Cloudflare skill reference; no runtime behavior changed

Closes #14294


---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 11m and 120,353 tokens on this as a headless worker. Overall, 15h 38m since this issue was created.