### PR TITLE
GH#14298: tighten Playwright benchmark script overview

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
@@ -1,8 +1,12 @@
 # Playwright Benchmark Scripts
 
-Canonical reference. Implements all four tests (navigate, formFill, extract, multiStep) against `https://the-internet.herokuapp.com` — 3 runs each, median reported.
+Reference implementation for `browser-benchmark-scripts.md`.
 
-## Sequential benchmark
+- Target: `https://the-internet.herokuapp.com`
+- Coverage: `navigate`, `formFill`, `extract`, `multiStep`
+- Sampling: 3 runs per test, median reported
+
+## Sequential script
 
 ```javascript
 import { chromium } from 'playwright';
@@ -53,7 +57,9 @@ async function run() {
 run();
 ```
 
-## Parallel benchmark — multi-context, multi-browser, multi-page
+## Parallel script
+
+Measures multi-context, multi-browser, and multi-page throughput.
 
 ```javascript
 import { chromium } from 'playwright';


### PR DESCRIPTION
## Summary
- tighten the Playwright benchmark script chapter intro into a compact reference block
- rename the section headings so the sequential and parallel snippets read more consistently with the chapter index
- preserve both code samples and benchmark scope while making the file easier to scan

## Testing
- bunx markdownlint-cli2 ".agents/tools/browser/browser-benchmark-scripts-01-playwright.md"
- reviewed `git diff -- .agents/tools/browser/browser-benchmark-scripts-01-playwright.md` to confirm both code blocks, the target URL, and benchmark coverage remained intact

## Runtime Testing
- level: self-assessed
- rationale: low-risk agent-doc change only; no runtime behavior changed

Closes #14298

---
[aidevops.sh](https://aidevops.sh) v3.5.513 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4