### PR TITLE
GH#14297: tighten Remotion fonts doc

### DIFF
--- a/.agents/tools/video/remotion-fonts.md
+++ b/.agents/tools/video/remotion-fonts.md
@@ -10,80 +10,69 @@ metadata:
 
 ## Google Fonts (`@remotion/google-fonts`)
 
-Type-safe, auto-blocks rendering until ready. Install:
+Use this when the font exists in Google Fonts. It is type-safe and blocks rendering until the font is ready.
 
 ```bash
-npx remotion add @remotion/google-fonts  # npm
-bunx remotion add @remotion/google-fonts  # bun
-yarn remotion add @remotion/google-fonts  # yarn
-pnpm exec remotion add @remotion/google-fonts  # pnpm
+npx remotion add @remotion/google-fonts
+bunx remotion add @remotion/google-fonts
+yarn remotion add @remotion/google-fonts
+pnpm exec remotion add @remotion/google-fonts
 ```
-
-Basic usage — import per-font, destructure `fontFamily`:
 
 ```tsx
 import { loadFont } from "@remotion/google-fonts/Roboto";
 
-const { fontFamily } = loadFont("normal", {
+const { fontFamily, waitUntilDone } = loadFont("normal", {
   weights: ["400", "700"],
-  subsets: ["latin"],  // specify weights/subsets to reduce file size
+  subsets: ["latin"],
 });
+
+await waitUntilDone(); // Needed before measuring text or DOM layout
 
 export const Title: React.FC<{ text: string }> = ({ text }) => (
   <h1 style={{ fontFamily, fontSize: 80, fontWeight: "bold" }}>{text}</h1>
 );
 ```
 
-Wait for font ready (e.g., before measuring text):
-
-```tsx
-const { fontFamily, waitUntilDone } = loadFont();
-await waitUntilDone();
-```
+Specify only the weights and subsets you need to keep bundle size down.
 
 ## Local fonts (`@remotion/fonts`)
 
-Install:
+Use this for custom font files. Put the files in `public/` and load them at module scope, not during render.
 
 ```bash
-npx remotion add @remotion/fonts  # npm
-bunx remotion add @remotion/fonts  # bun
-yarn remotion add @remotion/fonts  # yarn
-pnpm exec remotion add @remotion/fonts  # pnpm
+npx remotion add @remotion/fonts
+bunx remotion add @remotion/fonts
+yarn remotion add @remotion/fonts
+pnpm exec remotion add @remotion/fonts
 ```
-
-Place font files in `public/`. Load at module level (before component render):
 
 ```tsx
 import { loadFont } from "@remotion/fonts";
 import { staticFile } from "remotion";
 
-// Single weight
 await loadFont({
   family: "MyFont",
   url: staticFile("MyFont-Regular.woff2"),
 });
 
-// Multiple weights — same family name, parallel load
 await Promise.all([
   loadFont({ family: "Inter", url: staticFile("Inter-Regular.woff2"), weight: "400" }),
   loadFont({ family: "Inter", url: staticFile("Inter-Bold.woff2"), weight: "700" }),
 ]);
 
-export const MyComposition = () => (
-  <div style={{ fontFamily: "MyFont" }}>Hello World</div>
-);
+export const MyComposition = () => <div style={{ fontFamily: "MyFont" }}>Hello World</div>;
 ```
 
-`loadFont` options:
+`loadFont()` accepts:
 
 ```tsx
 loadFont({
-  family: "MyFont",          // Required: CSS font-family name
-  url: staticFile("f.woff2"), // Required: font file URL
-  format: "woff2",           // Optional: auto-detected from extension
-  weight: "400",             // Optional: font weight
-  style: "normal",           // Optional: normal | italic
-  display: "block",          // Optional: font-display behavior
+  family: "MyFont",           // Required CSS font-family name
+  url: staticFile("f.woff2"), // Required font file URL
+  format: "woff2",            // Optional, inferred from extension by default
+  weight: "400",              // Optional font weight
+  style: "normal",            // Optional normal | italic
+  display: "block",           // Optional font-display value
 });
 ```


### PR DESCRIPTION
## Summary
- tighten the Remotion fonts doc around the two supported loading paths: Google Fonts and local font files
- move the critical guidance earlier so font readiness, module-scope loading, and weight/subset trimming are visible before examples
- keep the examples intact while removing duplicate setup prose and inline commentary

## Runtime Testing
- self-assessed: low-risk docs-only change
- `git diff --check -- .agents/tools/video/remotion-fonts.md`
- `bash .agents/scripts/linters-local.sh` timed out on unrelated repository-wide lint debt; no file-specific failure was reported for this doc before timeout

Closes #14297

---
[aidevops.sh](https://aidevops.sh) v3.5.513 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4