### PR TITLE
GH#14296: tighten MCP troubleshooting quick reference

### DIFF
--- a/.agents/aidevops/mcp-troubleshooting.md
+++ b/.agents/aidevops/mcp-troubleshooting.md
@@ -13,8 +13,24 @@ tools:
 <!-- AI-CONTEXT-START -->
 
 - **Scripts**: `mcp-diagnose.sh check-all`, `tool-version-check.sh`
-- **Common cause**: Version mismatch (outdated tool with changed MCP command)
+- **Primary cause**: version mismatch (outdated tool, changed MCP command)
 - **Config**: `~/.config/opencode/opencode.json`
+- **Dead schemas (t1682)**: MCP tools can remain listed after startup failure; treat that server as unavailable for the session
+
+## Errored Servers — Dead Tool Schemas (t1682)
+
+When an MCP server fails to start, its tool schemas can remain in the tool list. Calls then fail with `MCP error -32000: Connection closed`, wasting context tokens.
+
+```bash
+# Detect errored servers
+~/.aidevops/agents/scripts/mcp-diagnose.sh check-all
+
+# Disable persistently errored server in ~/.config/opencode/opencode.json
+{ "playwright": { "enabled": false } }
+# Restart runtime to reload tool list.
+```
+
+**Agent rule:** On `MCP error -32000`, `Connection closed`, `spawn ENOENT`, or similar startup failures, mark that server unavailable for the session and do not retry it. See `prompts/build.txt` "Errored MCP Server Guard".
 
 ## Common Errors
 
@@ -26,22 +42,6 @@ tools:
 | "Permission denied" | Missing credentials | Check `~/.config/aidevops/credentials.sh` |
 | "Timeout" | Server not starting | Check Node.js version, run command manually |
 | "unauthorized" | HTTP server instead of MCP | Use correct MCP command (not `serve`) |
-
-## Errored Servers — Dead Tool Schemas (t1682)
-
-When an MCP server fails to start, its tool schemas remain in the tool list. Every call returns "MCP error -32000: Connection closed", wasting context tokens.
-
-```bash
-# Detect errored servers
-~/.aidevops/agents/scripts/mcp-diagnose.sh check-all
-
-# Disable persistently errored server (removes schemas from context)
-# In ~/.config/opencode/opencode.json:
-{ "playwright": { "enabled": false } }
-# Restart runtime to reload tool list.
-```
-
-**Agent rule:** On "MCP error -32000" or "Connection closed", mark that server unavailable for the session — do not retry. See `prompts/build.txt` "Errored MCP Server Guard".
 
 ## Diagnostic Commands
 
@@ -59,16 +59,12 @@ opencode mcp list                                        # verify MCP status
 
 ### augment-context-engine
 
-| Issue | Solution |
-|-------|----------|
-| "unauthorized" | Run `auggie login` first |
-| Session expired | Re-run `auggie login` |
-
-**Correct command**: `["auggie", "--mcp"]`
+- `unauthorized` or expired session → run `auggie login`
+- Correct command: `["auggie", "--mcp"]`
 
 ### context7
 
-Remote MCP — no local installation needed.
+Remote MCP; no local installation needed.
 
 ```json
 { "context7": { "type": "remote", "url": "https://mcp.context7.com/mcp", "enabled": true } }
@@ -76,11 +72,11 @@ Remote MCP — no local installation needed.
 
 ## Manual MCP Testing
 
-Run the MCP command directly — it should output JSON-RPC, not HTTP server info:
+Run the configured MCP command directly. Expect JSON-RPC startup output, not an HTTP server banner:
 
 ```bash
 auggie --mcp   # augment
-<tool> serve   # most MCPs
+<configured MCP command>
 ```
 
 ## Related

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -199,7 +199,7 @@
     ".agents/aidevops/mcp-troubleshooting.md": {
       "hash": "53599e9a3e7d9799a065eb9bc1fe9df2e7dbd1d7",
       "at": "2026-03-31T08:03:51Z",
-      "pr": null
+      "pr": 14740
     },
     ".agents/tools/ai-assistants/opencode-server.md": {
       "hash": "15e90e96d742cfe07ffd4cb37c340157d5a8bb74",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -196,6 +196,11 @@
       "at": "2026-03-28T03:53:54Z",
       "pr": 11339
     },
+    ".agents/aidevops/mcp-troubleshooting.md": {
+      "hash": "53599e9a3e7d9799a065eb9bc1fe9df2e7dbd1d7",
+      "at": "2026-03-31T08:03:51Z",
+      "pr": null
+    },
     ".agents/tools/ai-assistants/opencode-server.md": {
       "hash": "15e90e96d742cfe07ffd4cb37c340157d5a8bb74",
       "at": "2026-03-28T03:53:56Z",


### PR DESCRIPTION
## Summary
- move the dead-tool-schema warning into the quick-reference section so MCP startup failures are surfaced before the error table
- tighten the MCP troubleshooting wording without dropping task references, commands, or version-specific guidance
- register the simplified doc in `.agents/configs/simplification-state.json` so future simplification scans track the file and link back to PR #14740

## Testing
- `bunx markdownlint-cli2 ".agents/aidevops/mcp-troubleshooting.md"`
- `python3 -m json.tool ".agents/configs/simplification-state.json" >/dev/null`
- agent-review check: no concrete regressions found

## Runtime Testing
- self-assessed: low-risk documentation and metadata changes only

Closes #14296


---
[aidevops.sh](https://aidevops.sh) v3.5.514 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 20m on this as a headless worker.