### PR TITLE
GH#14306: tighten Cloudflare Sandbox SDK doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/sandbox.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/sandbox.md
@@ -1,8 +1,6 @@
 # Cloudflare Sandbox SDK
 
-Isolated container execution on Cloudflare's edge (Durable Object + Container per sandbox). Persistent across requests (same ID = same sandbox), isolated filesystem/processes/network, configurable sleep/wake.
-
-**Use cases**: AI code execution, dev environments, data analysis, CI/CD, code interpreters, multi-tenant.
+Run isolated containers on Cloudflare's edge. Each sandbox pairs a Durable Object with a container, reuses state when IDs match, and supports sleep/wake controls for AI code execution, dev environments, CI/CD, data analysis, and multi-tenant runners.
 
 ## Quick Start
 
@@ -25,7 +23,9 @@ export default {
 };
 ```
 
-**wrangler.jsonc**:
+## Configuration
+
+### `wrangler.jsonc`
 
 ```jsonc
 {
@@ -51,7 +51,7 @@ export default {
 }
 ```
 
-**Dockerfile**:
+### `Dockerfile`
 
 ```dockerfile
 FROM docker.io/cloudflare/sandbox:latest
@@ -68,13 +68,13 @@ EXPOSE 8080 3000  # Required for wrangler dev
 - `sandbox.exposePort(port, options)` → Get preview URL
 - `sandbox.createSession(options)` → Isolated session
 
-## Critical Rules
+## Key Rules
 
-- ALWAYS call `proxyToSandbox()` first
-- Same ID = reuse sandbox
-- Use `/workspace` for persistent files
-- `normalizeId: true` for preview URLs
-- Retry on `CONTAINER_NOT_READY`
+- Call `proxyToSandbox()` first so preview URLs resolve correctly
+- Reuse the sandbox ID when you want persistent state
+- Store persistent files in `/workspace`
+- Use `normalizeId: true` for preview URLs
+- Retry `CONTAINER_NOT_READY` during provisioning or wake-up
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- tighten the Sandbox SDK overview so the opening guidance is denser without dropping the existing code samples or links
- group configuration snippets under a single section and rewrite the rules list into direct action-oriented guidance

Closes #14306

## Testing
- bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/sandbox.md"

## Runtime Testing
- Level: self-assessed
- Reason: markdown-only agent doc change
- Evidence: markdownlint passed and all existing code blocks/resources were preserved

---
[aidevops.sh](https://aidevops.sh) v3.5.514 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 1m on this as a headless worker.