### PR TITLE
GH#14705: fix sequence numbering in nurture email index

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md
@@ -6,10 +6,10 @@ Reference corpus: examples stay intact in companion files; this page is the inde
 
 ## Examples
 
-1. `04-morning-brew-story-driven-value`
+4. `04-morning-brew-story-driven-value`
    - File: `direct-response-copy-swipe-file-emails-02-nurture-04-morning-brew-story-driven-value.md`
    - Angle: story-led nurture email that teaches through a surprising business failure.
-2. `05-james-clear-value-first`
+5. `05-james-clear-value-first`
    - File: `direct-response-copy-swipe-file-emails-02-nurture-05-james-clear-value-first.md`
    - Angle: repeatable newsletter structure built around ideas, quotes, and a question.
 


### PR DESCRIPTION
## Summary
- Fix index entry numbering from `1.`/`2.` to `4.`/`5.` to match the actual example numbers in the wider swipe-file set.
- Addresses unactioned review feedback from PR #14662 (coderabbit finding: sequence drift).

## Runtime Testing
- Level: self-assessed
- Risk: low — single markdown file, two-character change on two lines.
- Verification: `bunx markdownlint-cli2` — 0 errors.

## Files Changed
- `.agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md` — lines 9, 12: `1.` → `4.`, `2.` → `5.`

Closes #14705

---
[aidevops.sh](https://aidevops.sh) v3.5.514 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6