### PR TITLE
GH#14054: tighten Socket MCP doc

### DIFF
--- a/.agents/services/monitoring/socket.md
+++ b/.agents/services/monitoring/socket.md
@@ -24,29 +24,23 @@ mcp:
 - **MCP**: Remote at `https://mcp.socket.dev/`
 - **Auth**: API token from socket.dev
 - **Credentials**: `~/.config/aidevops/credentials.sh` → `SOCKET_YOURNAME`
-
-**When to use**:
-
-- Scanning dependencies for vulnerabilities
-- Detecting malware or typosquatting in packages
-- Auditing supply chain security
-- Checking package reputation before installing
+- **When to use**: Scan dependencies for vulnerabilities, malware, typosquatting, and package reputation before install
 
 <!-- AI-CONTEXT-END -->
 
 ## MCP Setup
 
-### 1. Create Socket Account
+### 1. Create account
 
 1. Sign up at [socket.dev](https://socket.dev)
 2. Connect your GitHub account (optional, for repo scanning)
 
-### 2. Generate API Token
+### 2. Generate API token
 
 1. Go to Settings → API Tokens
 2. Click "Create Token"
 3. Select permissions (Full Access recommended for MCP)
-4. Save token:
+4. Save the token:
 
 ```bash
 echo 'export SOCKET_YOURNAME="sktsec_..."' >> ~/.config/aidevops/credentials.sh
@@ -55,14 +49,14 @@ chmod 600 ~/.config/aidevops/credentials.sh
 
 ### 3. Configure OpenCode MCP
 
-The Socket MCP uses the remote endpoint. Update your config:
+Socket uses the remote endpoint. Update your config:
 
 ```bash
 jq '.mcp.socket = {"type": "remote", "url": "https://mcp.socket.dev/", "enabled": false}' \
   ~/.config/opencode/opencode.json > /tmp/oc.json && mv /tmp/oc.json ~/.config/opencode/opencode.json
 ```
 
-**Note**: The remote MCP may use OAuth. If it doesn't work with API token, you may need to authenticate via browser when first using it.
+If API-token auth fails, the remote MCP may require a browser OAuth flow on first use.
 
 ### 4. Test Connection
 
@@ -91,7 +85,7 @@ curl -s -H "Authorization: Bearer $SOCKET_YOURNAME" "https://api.socket.dev/v0/o
 
 ## CLI Alternative
 
-You can also use the Socket CLI directly:
+Use the Socket CLI directly when MCP is unavailable:
 
 ```bash
 # Install
@@ -114,11 +108,11 @@ socket npm info lodash
 
 ### MCP not connecting
 
-The remote MCP at `mcp.socket.dev` may require OAuth authentication via browser rather than API token. Try using the MCP - it should prompt for auth if needed.
+`mcp.socket.dev` may require browser OAuth instead of API-token auth. Start the MCP and complete the auth prompt if shown.
 
 ### Rate limits
 
-Free tier has API rate limits. Upgrade to paid plan for higher limits.
+Free tier requests are rate-limited. Upgrade if scans are throttled.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- tighten the Socket MCP quick-reference and setup copy without removing commands, URLs, or troubleshooting guidance
- collapse repetitive prose so the agent keeps the same setup path in fewer tokens

## Runtime Testing
- Risk level: low (agent markdown doc only)
- Verification: markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/services/monitoring/socket.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)
- Result: pass

Closes #14054

---
[aidevops.sh](https://aidevops.sh) v3.5.513 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 8m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Socket monitoring documentation with clearer, more concise instructions for setup, authentication, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->