### PR TITLE
GH#13995: tighten playwright.md agent doc (149 -> 113 lines)

### DIFF
--- a/.agents/tools/browser/playwright.md
+++ b/.agents/tools/browser/playwright.md
@@ -22,26 +22,14 @@ mcp:
 ## Quick Reference
 
 - **Purpose**: Cross-browser testing and automation (fastest browser engine)
-- **Install**: `npm install playwright && npx playwright install`
-- **MCP**: `npx @playwright/mcp` (with `--proxy-server`, `--storage-state` options)
+- **Install**: `npx playwright install` (browsers) | `npx @playwright/mcp@latest` (MCP server)
 - **Browsers**: chromium, firefox, webkit + custom (Brave, Edge, Chrome via `executablePath`)
 - **Headless**: Yes (default)
+- **Performance**: Navigate 1.4s, form fill 0.9s, extraction 1.3s, reliability 0.64s avg
+- **Parallel**: 5 contexts in 2.1s, 3 browsers in 1.9s, 10 pages in 1.8s
+- **Subagents**: `playwright-emulation.md` (device/viewport), `playwright-cli.md` (CLI agent)
 
-**Performance** (fastest of all tools): Navigate 1.4s, form fill 0.9s, extraction 1.3s, reliability 0.64s avg.
-Underlying engine for dev-browser, agent-browser, and Stagehand.
-
-**Key Features**:
-- Full proxy support (HTTP, SOCKS5, per-context)
-- Session persistence via `storageState` or `userDataDir`
-- Cross-browser testing (Chromium, Firefox, WebKit)
-- Custom browser engines (Brave, Edge, Chrome) via `executablePath`
-- Device emulation (iPhone, Samsung, iPad)
-- Network throttling (Fast 3G, Slow 3G, Offline)
-- Browser extensions via `launchPersistentContext` + `--load-extension`
-- Ad blocking via Brave Shields (no extension needed) or uBlock Origin extension
-- Parallel: 5 isolated contexts in 2.1s, 3 browsers in 1.9s, 10 pages in 1.8s
-- AI page understanding: `page.locator('body').ariaSnapshot()` (~0.01s, 50-200 tokens)
-- Chrome DevTools MCP: `npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222` for Lighthouse, network monitoring, CSS coverage
+Underlying engine for dev-browser, agent-browser, and Stagehand. Supports proxy (HTTP/SOCKS5), session persistence (`storageState`/`userDataDir`), extensions via `launchPersistentContext`, network throttling, device emulation, ad blocking (Brave Shields or uBlock Origin), AI page understanding (`page.locator('body').ariaSnapshot()` ~0.01s, 50-200 tokens), Chrome DevTools MCP (`npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222`).
 
 **When to use directly**: Maximum speed, full control, proxy support, parallel instances, extensions, custom browser engines, or when other wrappers add unnecessary overhead.
 
@@ -50,16 +38,14 @@ Underlying engine for dev-browser, agent-browser, and Stagehand.
 ## Installation
 
 ```bash
-# Via setup.sh
-./setup.sh --interactive  # Select: "Setup browser automation tools"
-
-# Manual
-npx playwright install       # Install browsers
-npx @playwright/mcp@latest   # Run MCP server
+./setup.sh --interactive           # Select: "Setup browser automation tools"
+# Or manually:
+npx playwright install             # Install browsers
+npx @playwright/mcp@latest         # Run MCP server
 npx --no-install playwright --version  # Check if installed
 ```
 
-**MCP configuration** (Claude Code, OpenCode, etc.):
+MCP configuration (Claude Code, OpenCode, etc.):
 
 ```json
 {
@@ -70,20 +56,11 @@ npx --no-install playwright --version  # Check if installed
 }
 ```
 
-## Custom Browser Engine (Brave, Edge, Chrome)
+## Custom Browser Engines
 
 Use `executablePath` to launch Brave, Edge, or Chrome instead of bundled Chromium.
 
-```javascript
-import { chromium } from 'playwright';
-
-const browser = await chromium.launch({
-  executablePath: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser', // Brave: built-in ad/tracker blocking
-  headless: true,
-});
-```
-
-### Browser Executable Paths
+### Executable Paths
 
 | Browser | macOS | Linux | Windows |
 |---------|-------|-------|---------|
@@ -92,44 +69,31 @@ const browser = await chromium.launch({
 | **Chrome** | `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` | `/usr/bin/google-chrome` | `C:\Program Files\Google\Chrome\Application\chrome.exe` |
 | **Chromium** (bundled) | Auto-detected by Playwright | Auto-detected | Auto-detected |
 
-### Persistent Context + Extensions
+### Launch, Extensions, and Parallel Contexts
 
-Extensions require `headless: false` on older Chromium; `--headless=new` supports them.
-
-```javascript
-import { chromium } from 'playwright';
-
-const context = await chromium.launchPersistentContext(
-  '/tmp/brave-profile',
-  {
-    executablePath: '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
-    headless: false,
-    args: [
-      '--load-extension=/path/to/ublock-origin-unpacked',
-      '--disable-extensions-except=/path/to/ublock-origin-unpacked',
-    ],
-  }
-);
-// Note: Brave Shields may make uBlock Origin redundant. Same pattern works for Edge.
-```
-
-### Parallel Instances
+Extensions require `headless: false` on older Chromium; `--headless=new` supports them. Brave Shields may make uBlock Origin redundant.
 
 ```javascript
 import { chromium } from 'playwright';
 
 const executablePath = '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser';
 
-const contexts = await Promise.all([
-  chromium.launchPersistentContext('/tmp/profile-1', { executablePath, headless: false }),
-  chromium.launchPersistentContext('/tmp/profile-2', { executablePath, headless: false }),
-  chromium.launchPersistentContext('/tmp/profile-3', { executablePath, headless: false }),
-]);
+// Simple launch
+const browser = await chromium.launch({ executablePath, headless: true });
 
-for (const ctx of contexts) {
-  const page = ctx.pages()[0] || await ctx.newPage();
-  await page.goto('https://example.com');
-}
+// Persistent context with extensions
+const context = await chromium.launchPersistentContext('/tmp/brave-profile', {
+  executablePath,
+  headless: false,
+  args: ['--load-extension=/path/to/ext', '--disable-extensions-except=/path/to/ext'],
+});
+
+// Parallel instances (isolated profiles)
+const contexts = await Promise.all(
+  [1, 2, 3].map(i =>
+    chromium.launchPersistentContext(`/tmp/profile-${i}`, { executablePath, headless: false })
+  )
+);
 ```
 
 ## Testing Patterns

--- a/.agents/tools/browser/playwright.md
+++ b/.agents/tools/browser/playwright.md
@@ -22,7 +22,7 @@ mcp:
 ## Quick Reference
 
 - **Purpose**: Cross-browser testing and automation (fastest browser engine)
-- **Install**: `npx playwright install` (browsers) | `npx @playwright/mcp@latest` (MCP server)
+- **Install**: `npm install playwright && npx playwright install` (lib + browsers) | `npx @playwright/mcp@latest` (MCP server)
 - **Browsers**: chromium, firefox, webkit + custom (Brave, Edge, Chrome via `executablePath`)
 - **Headless**: Yes (default)
 - **Performance**: Navigate 1.4s, form fill 0.9s, extraction 1.3s, reliability 0.64s avg
@@ -40,6 +40,7 @@ Underlying engine for dev-browser, agent-browser, and Stagehand. Supports proxy 
 ```bash
 ./setup.sh --interactive           # Select: "Setup browser automation tools"
 # Or manually:
+npm install playwright             # Install library (needed for JS examples)
 npx playwright install             # Install browsers
 npx @playwright/mcp@latest         # Run MCP server
 npx --no-install playwright --version  # Check if installed


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/browser/playwright.md` from 149 to 113 lines (24% reduction) as an instruction doc simplification.

Closes #13995

## Changes

- **Consolidated code examples**: Three separate JS blocks (simple launch, persistent context + extensions, parallel instances) merged into one combined example showing all three patterns
- **Compressed Key Features**: Bullet list converted to dense prose paragraph in Quick Reference
- **Merged installation**: Two separate bash code blocks combined into one
- **Added subagent cross-references**: Links to `playwright-emulation.md` and `playwright-cli.md` in Quick Reference

## Content Preservation

All institutional knowledge preserved:
- Browser executable paths table (macOS, Linux, Windows)
- Performance benchmarks (navigate, form fill, extraction, reliability)
- MCP configuration JSON
- Chrome DevTools MCP reference
- Testing patterns (cross-browser, mobile, performance, visual regression, security, API interception)
- All command examples and URLs

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, all key terms verified present via `rg`

---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Playwright tool documentation with streamlined MCP usage and installation guidance
  * Reorganized sections for improved clarity, including Custom Browser Engines and Launch/Extensions/Parallel Contexts
  * Simplified code examples and setup instructions for better developer experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->