### PR TITLE
GH#14737: tighten chore branch workflow doc

### DIFF
--- a/.agents/workflows/branch/chore.md
+++ b/.agents/workflows/branch/chore.md
@@ -38,45 +38,27 @@ git checkout -b chore/{description}
 
 ## Guidance
 
-- Branch names use `chore/{description}`.
-- Pick the narrowest commit prefix for the change.
-- Chore branches usually do not need a version bump.
+Pick the narrowest commit prefix for the change:
 
-| Prefix | Use For |
+| Prefix | Use for |
 |--------|---------|
 | `chore:` | General maintenance |
 | `docs:` | Documentation |
 | `ci:` | CI/CD changes |
 | `build:` | Build system |
 
-## Common Tasks
-
-### Dependency updates
+## Commit Examples
 
 ```bash
-npm outdated          # Check for updates
-npm update            # Update and test
-git commit -m "chore: update dependencies"
-```
+chore: update dependencies
 
-### CI/CD changes
+docs: improve installation instructions
 
-```bash
-git commit -m "ci: optimize GitHub Actions workflow
-
+ci: optimize GitHub Actions workflow
 - Add dependency caching
 - Run tests in parallel
-- Reduce build time by 40%"
-```
 
-### Documentation
-
-```bash
-git commit -m "docs: improve installation instructions
-
-- Add troubleshooting section
-- Update screenshots
-- Fix broken links"
+build: switch bundler to esbuild
 ```
 
 ## Examples

--- a/.agents/workflows/branch/chore.md
+++ b/.agents/workflows/branch/chore.md
@@ -55,6 +55,7 @@ chore: update dependencies
 docs: improve installation instructions
 
 ci: optimize GitHub Actions workflow
+
 - Add dependency caching
 - Run tests in parallel
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/workflows/branch/chore.md` (90 → 72 lines, 20% reduction)
- Remove redundant guidance already present in the quick reference table (branch naming, version bump note)
- Condense three verbose commit example subsections into one compact block covering all four prefixes
- Remove generic npm commands that aren't chore-branch-specific knowledge
- All commit prefix mappings, branch examples, and usage guidance preserved

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** `self-assessed` — markdownlint zero violations, content preservation verified

## Changes

| Before | After | Delta |
|--------|-------|-------|
| 90 lines | 72 lines | -18 lines (20%) |

Closes #14737

---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6