### PR TITLE
GH#14097: tighten security-history.md agent doc (121 -> 62 lines)

### DIFF
--- a/.agents/scripts/commands/security-history.md
+++ b/.agents/scripts/commands/security-history.md
@@ -4,7 +4,7 @@ agent: Build+
 mode: subagent
 ---
 
-Scan git history for security vulnerabilities that may have been introduced in past commits.
+Scan git history for security vulnerabilities in past commits.
 
 Target: $ARGUMENTS
 
@@ -17,105 +17,46 @@ Target: $ARGUMENTS
 ## Process
 
 1. **Determine scope** from $ARGUMENTS:
-   - Empty → Last 50 commits
-   - Number (e.g., `100`) → Last N commits
-   - Range (e.g., `abc123..def456`) → Specific commit range
-   - `--since="2024-01-01"` → Commits since date
-   - `--author="email"` → Commits by author
+   - Empty → last 50 commits
+   - Number (e.g., `100`) → last N commits
+   - Range (e.g., `abc123..def456`) → specific commit range
+   - `--since="2024-01-01"` → commits since date
+   - `--author="email"` → commits by author
 
 2. **Run history scan**:
 
    ```bash
-   # Last 50 commits (default)
-   ./.agents/scripts/security-helper.sh history
-
-   # Last 100 commits
-   ./.agents/scripts/security-helper.sh history 100
-
-   # Specific range
-   ./.agents/scripts/security-helper.sh history abc123..def456
-
-   # Since date
+   ./.agents/scripts/security-helper.sh history              # default: last 50
+   ./.agents/scripts/security-helper.sh history 100           # last N
+   ./.agents/scripts/security-helper.sh history abc123..def456 # range
    ./.agents/scripts/security-helper.sh history --since="2024-01-01"
    ```
 
 3. **Review findings** with commit context
 
-4. **Assess impact**:
-   - Is the vulnerability still present?
-   - Was it ever deployed to production?
-   - What data may have been exposed?
+4. **Assess impact**: still present? deployed to production? data exposed?
 
 ## Output Format
 
-```text
-Git History Security Scan
-=========================
-Scanned: 50 commits
-Vulnerabilities: 2 found
-
-[HIGH] Commit abc1234 (2024-01-15)
-  Author: developer@example.com
-  Message: Add user authentication
-  File: src/auth/login.ts:45
-  Issue: Hardcoded API key introduced
-  Status: Still present in HEAD
-
-[MEDIUM] Commit def5678 (2024-01-10)
-  Author: developer@example.com
-  Message: Add database queries
-  File: src/db/users.ts:23
-  Issue: SQL injection vulnerability
-  Status: Fixed in commit ghi9012
-```
+Each finding includes severity, commit, author, file, issue description, and current status (still present or fixed in which commit).
 
 ## Use Cases
 
-### Compliance Audit
-
 ```bash
-# Scan all commits in the last quarter
-/security-history --since="2024-01-01" --until="2024-03-31"
-```
-
-### Incident Investigation
-
-```bash
-# Scan commits around suspected breach
-/security-history abc123~10..abc123+10
-```
-
-### New Team Member Audit
-
-```bash
-# Review commits by specific author
-/security-history --author="new-dev@example.com"
-```
-
-### Pre-Release Audit
-
-```bash
-# Scan all commits since last release
-/security-history v1.0.0..HEAD
+/security-history --since="2024-01-01" --until="2024-03-31"  # compliance audit
+/security-history abc123~10..abc123+10                        # incident investigation
+/security-history --author="new-dev@example.com"              # team member audit
+/security-history v1.0.0..HEAD                                # pre-release audit
 ```
 
 ## Remediation
 
-For vulnerabilities still present:
+**Still present:** create fix, rotate exposed secrets, check if deployed, document in incident log.
 
-1. **Create fix** in new commit
-2. **Consider** if secrets need rotation
-3. **Check** if vulnerability was deployed
-4. **Document** in security incident log
-
-For historical vulnerabilities (already fixed):
-
-1. **Verify** fix is complete
-2. **Check** if secrets were exposed (rotate if needed)
-3. **Add** to lessons learned
+**Already fixed:** verify fix completeness, rotate secrets if exposed, add to lessons learned.
 
 ## Related Commands
 
-- `/security-analysis` - Analyze current code
-- `/security-scan` - Quick security check
-- `/security-deps` - Dependency vulnerabilities
+- `/security-analysis` — analyze current code
+- `/security-scan` — quick security check
+- `/security-deps` — dependency vulnerabilities


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/security-history.md` from 121 to 62 lines (49% reduction)
- Consolidate 4 separate use case sections (each with heading + code block) into a single compact code block
- Replace verbose 20-line output format example with a concise description
- Merge two separate remediation lists into inline prose
- Compress process step code block by removing per-line comments

## What changed

All institutional knowledge preserved: command syntax, argument patterns, use case examples, remediation steps, and related command references. No rules, task IDs, or command examples removed.

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdown lint passes with 0 errors

Closes #14097


---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6 spent 5m on this as a headless worker.