### PR TITLE
GH#14753: tighten postflight-loop command guidance

### DIFF
--- a/.agents/scripts/commands/postflight-loop.md
+++ b/.agents/scripts/commands/postflight-loop.md
@@ -9,27 +9,27 @@ Monitor release health after deployment. Arguments: `$ARGUMENTS`
 ## Usage
 
 ```bash
-/postflight-loop [--monitor-duration Nm] [--max-iterations N]
+/postflight-loop [--monitor-duration 5m] [--max-iterations 5]
 ```
+
+## Core Contract
+
+1. Parse `$ARGUMENTS` into `monitor_duration` and `max_iterations`.
+2. On each iteration, use `gh` to verify:
+   - latest CI workflow status
+   - release tag exists
+   - `VERSION` matches the release tag
+3. Track progress in `.agents/loop-state/quality-loop.local.md` with status, iteration, elapsed time, last check, and per-check results.
+4. Emit `<promise>RELEASE_HEALTHY</promise>` only when every check passes within the monitoring window.
 
 ## Options
 
 | Option | Purpose | Default |
 |--------|---------|---------|
-| `--monitor-duration <t>` | Total monitoring window (`5m`, `10m`, `1h`) | `5m` |
+| `--monitor-duration <t>` | Total monitoring window such as `5m`, `10m`, or `1h` | `5m` |
 | `--max-iterations <n>` | Max monitoring passes | `5` |
 
-## Workflow
-
-1. Parse `$ARGUMENTS` into `monitor_duration` and `max_iterations`.
-2. Use `gh` CLI to check release health iteratively.
-3. On each pass verify:
-   - CI workflow status
-   - release tag exists
-   - `VERSION` matches the release tag
-4. Emit `<promise>RELEASE_HEALTHY</promise>` only when all checks pass.
-
-## Examples
+## Typical Invocations
 
 ```bash
 /postflight-loop --monitor-duration 10m
@@ -37,23 +37,7 @@ Monitor release health after deployment. Arguments: `$ARGUMENTS`
 /postflight-loop --monitor-duration 2m --max-iterations 3
 ```
 
-## State Tracking
-
-Progress is tracked in `.agents/loop-state/quality-loop.local.md`.
-
-```markdown
-## Postflight Loop State
-
-- **Status:** monitoring
-- **Iteration:** 3/5
-- **Elapsed:** 180s/600s
-- **Last Check:** 2025-01-11T14:30:00Z
-
-### Check Results
-- [x] CI workflow: passing
-- [x] Release tag: v2.44.0 exists
-- [x] Version consistency: matched
-```
+Use the default command for quick verification, extend the duration for slower release pipelines, and lower iterations only when you need a bounded smoke check.
 
 ## Use When
 
@@ -63,9 +47,8 @@ Progress is tracked in `.agents/loop-state/quality-loop.local.md`.
 
 ## Related
 
-| Command | Purpose |
-|---------|---------|
-| `/preflight` | Quality checks before release |
-| `/release` | Full release workflow |
-| `/postflight` | Single postflight check |
-| `/preflight-loop` | Iterative preflight until passing |
+- `/postflight` - single postflight check
+- `/release` - full release workflow
+- `/preflight` - quality checks before release
+- `/preflight-loop` - iterative preflight until passing
+- `workflows/postflight.md` - broader release-health checks and rollback guidance


### PR DESCRIPTION
## Summary
- compress `/postflight-loop` into a shorter command contract that keeps the monitoring requirements and state file path
- replace repetitive workflow prose with a single core-contract section plus focused invocation guidance
- keep related command links and examples while reducing instruction overhead for the agent

## Testing
- `npx markdownlint-cli2 ".agents/scripts/commands/postflight-loop.md"`

## Runtime Testing
- Level: low-risk docs change
- Result: self-assessed per `full-loop.md` runtime testing gate

Closes #14753


---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 4m on this as a headless worker.