### PR TITLE
GH#14096: tighten agent doc SEO Content Analyzer (.agents/seo/content-analyzer.md, 121 -> 60 lines)

### DIFF
--- a/.agents/seo/content-analyzer.md
+++ b/.agents/seo/content-analyzer.md
@@ -15,18 +15,15 @@ tools:
 
 # SEO Content Analyzer
 
-Comprehensive, data-driven content analysis combining 5 specialised Python modules for readability, keyword density, search intent, content length comparison, and SEO quality rating.
+Full content audit via `seo-content-analyzer.py` — 5 Python modules covering readability, keyword density, search intent, content length, and SEO quality scoring.
 
 ## Quick Reference
 
-- **Purpose**: Full content audit with scoring and actionable recommendations
 - **Input**: Article file/URL, primary keyword, secondary keywords
-- **Output**: Executive summary, scores, priority action plan
-- **Script**: `seo-content-analyzer.py` (unified analysis)
+- **Output**: Executive summary with scores, publishing readiness, priority actions
+- **Script**: `~/.aidevops/agents/scripts/seo-content-analyzer.py`
 
 ## Analysis Pipeline
-
-Run the unified analyzer for a full audit, or individual commands:
 
 ```bash
 # Full analysis (readability + keywords + quality + intent)
@@ -44,74 +41,16 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py quality article.md \
   --meta-title "Article Title Here" --meta-desc "Article description here"
 ```
 
-## Output Format
-
-### Executive Summary
-
-```markdown
-## Content Analysis Report
-
-**Article**: [title]
-**Keyword**: [primary keyword]
-**Date**: [analysis date]
-
-### Scores
-
-| Category | Score | Grade |
-|----------|-------|-------|
-| Overall SEO Quality | X/100 | A-F |
-| Readability | X/100 | A-F |
-| Keyword Optimization | X/100 | - |
-| Content Length | [status] | - |
-| Search Intent Alignment | [intent] | - |
-
-### Publishing Readiness: [Yes/No]
-
-### Priority Actions
-
-1. **Critical**: [issues that must be fixed]
-2. **High Priority**: [issues that should be fixed]
-3. **Optimization**: [nice-to-have improvements]
-
-### Detailed Findings
-
-[Per-module results with specific recommendations]
-```
-
 ## Analysis Categories
 
-### Readability
+| Module | Key Metrics |
+|--------|-------------|
+| **Readability** | Flesch Reading Ease (target: 60-70), Flesch-Kincaid Grade (target: 8-10), sentence length, passive voice ratio, transition words, complex word ratio |
+| **Keyword Optimization** | Primary density (target: 1-2%), critical placements (H1/first 100 words/H2s/conclusion), section heatmap, stuffing risk, LSI suggestions, secondary coverage |
+| **Search Intent** | Intent classification (informational/navigational/transactional/commercial), confidence scores, content-intent alignment, SERP feature targeting |
+| **SEO Quality** | 6-category scoring (content, keywords, meta, structure, links, readability), critical issues, publishing readiness, meta element validation |
 
-- Flesch Reading Ease (target: 60-70)
-- Flesch-Kincaid Grade Level (target: 8-10)
-- Sentence length analysis
-- Paragraph structure
-- Passive voice ratio
-- Transition word usage
-- Complex word ratio
-
-### Keyword Optimization
-
-- Primary keyword density (target: 1-2%)
-- Critical placements (H1, first 100 words, H2s, conclusion)
-- Section distribution heatmap
-- Keyword stuffing risk detection
-- LSI keyword suggestions
-- Secondary keyword coverage
-
-### Search Intent
-
-- Intent classification (informational/navigational/transactional/commercial)
-- Confidence scores
-- Content-intent alignment check
-- SERP feature targeting recommendations
-
-### SEO Quality
-
-- 6-category scoring (content, keywords, meta, structure, links, readability)
-- Critical issues identification
-- Publishing readiness assessment
-- Meta element validation
+Output report structure: scores table → Publishing Readiness (Yes/No) → Priority Actions (Critical / High Priority / Optimization) → Detailed Findings per module.
 
 ## Integration
 

--- a/.agents/seo/content-analyzer.md
+++ b/.agents/seo/content-analyzer.md
@@ -45,7 +45,7 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py quality article.md \
 
 | Module | Key Metrics |
 |--------|-------------|
-| **Readability** | Flesch Reading Ease (target: 60-70), Flesch-Kincaid Grade (target: 8-10), sentence length, passive voice ratio, transition words, complex word ratio |
+| **Readability** | Flesch Reading Ease (target: 60-70), Flesch-Kincaid Grade (target: 8-10), sentence length, paragraph structure, passive voice ratio, transition words, complex word ratio |
 | **Keyword Optimization** | Primary density (target: 1-2%), critical placements (H1/first 100 words/H2s/conclusion), section heatmap, stuffing risk, LSI suggestions, secondary coverage |
 | **Search Intent** | Intent classification (informational/navigational/transactional/commercial), confidence scores, content-intent alignment, SERP feature targeting |
 | **SEO Quality** | 6-category scoring (content, keywords, meta, structure, links, readability), critical issues, publishing readiness, meta element validation |


### PR DESCRIPTION
## Summary

Tightens `.agents/seo/content-analyzer.md` from 121 to 60 lines (50% reduction) per the simplification scan in issue #14096.

**Classification:** Instruction doc (agent rules, workflow, command examples) — not a reference corpus.

**Changes:**
- Compressed "Analysis Categories" from 4 verbose sections into a single compact table — all metrics, targets, and classifications preserved
- Removed the large output format template block (reference material, not instructions); replaced with a one-line structural description
- Tightened intro prose; removed redundant Quick Reference bullets already covered by frontmatter description
- All command examples, numeric targets (60-70, 8-10, 1-2%), integration references, and SERP/intent classifications preserved verbatim

## Verification

- All 5 `seo-content-analyzer.py` subcommands present: `analyze`, `readability`, `keywords`, `intent`, `quality`
- All 4 integration references intact: `seo-writer.md`, `dataforseo.md`, `eeat-score.md`, `meta-creator.md`
- All numeric targets preserved: Flesch 60-70, Grade 8-10, keyword density 1-2%
- `wc -l` before: 121 / after: 60 — no content loss, only structural compression

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code execution paths changed.
Testing level: `self-assessed` — content preservation verified by grep checks above.

Closes #14096

---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-sonnet-4-6 spent 1s on this as a headless worker.