### PR TITLE
GH#14752: sync pulumi gotchas simplification state

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1417,9 +1417,49 @@
       "pr": 12117
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md": {
-      "hash": "d6c5d947d875cdc44eaa56161654450e39a0596e",
-      "at": "2026-03-28T19:15:33Z",
-      "pr": 12113
+      "hash": "733d3525cbf26277967990e47a34c41691036be8",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md": {
+      "hash": "785bdeaad722d0f542517cebae0f89e8f6828e73",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md": {
+      "hash": "93baaad7916863404459e50d80bfbba593f30589",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md": {
+      "hash": "97c3a7d841885f7124cda4603bc4f24f25394771",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md": {
+      "hash": "bf9eb0a6805213c30a476ba1a193467d85f8a0b7",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md": {
+      "hash": "eb8f44407cfde984193f403d441a2f080f32db71",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md": {
+      "hash": "1f2ca15e1758f9c72bf63021b81902c746f08a5d",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md": {
+      "hash": "3459fb86214d51707322f38fc1de4c32ca7434a0",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md": {
+      "hash": "8225af6a25a3cbad5d152becfc7be32b66146897",
+      "at": "2026-03-31T07:50:54Z",
+      "pr": 14717
     },
     ".agents/scripts/framework-issue-helper.sh": {
       "hash": "a53fde8f11aabd50fbda03386f967721d987e07a",


### PR DESCRIPTION
## Summary
- Refresh the `pulumi-gotchas.md` simplification hash to match the current split index shipped in PR #14717.
- Register the extracted `pulumi-gotchas/*` chapter files so future recheck jobs track the split corpus instead of only the old monolith.
- Resolve this recheck without further doc edits because `origin/main` already contains the chapterized structure.

## Runtime Testing
- Level: self-assessed
- Risk: low (state-registry bookkeeping only)
- Verification:
  - `python3 -m json.tool .agents/configs/simplification-state.json >/dev/null`
  - `python3` hash validation for 9 `pulumi-gotchas` entries against the tracked files

Overall, this follow-up only synchronizes the simplification registry after PR #14717 landed the chapter split.

Closes #14752

---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4