### PR TITLE
GH#14451: tighten heygen-skill.md index

### DIFF
--- a/.agents/content/heygen-skill.md
+++ b/.agents/content/heygen-skill.md
@@ -7,46 +7,50 @@ imported_from: https://github.com/heygen-com/skills
 
 # HeyGen Skill
 
-Best practices for HeyGen - AI avatar video creation API.
+Load when working with HeyGen API code — avatar videos, video generation workflows, service integration.
 
-## When to use
-
-Use this skill whenever you are dealing with HeyGen API code to obtain domain-specific knowledge for creating AI avatar videos, managing avatars, handling video generation workflows, and integrating with HeyGen's services.
-
-## How to use
-
-Read individual rule files for detailed explanations and code examples:
+## Rule Files
 
 ### Foundation
 
-- [heygen-skill/rules-authentication.md](heygen-skill/rules-authentication.md) - API key setup, X-Api-Key header, and authentication patterns
-- [heygen-skill/rules-quota.md](heygen-skill/rules-quota.md) - Credit system, usage limits, and checking remaining quota
-- [heygen-skill/rules-video-status.md](heygen-skill/rules-video-status.md) - Polling patterns, status types, and retrieving download URLs
-- [heygen-skill/rules-assets.md](heygen-skill/rules-assets.md) - Uploading images, videos, and audio for use in video generation
+| Rule | Covers |
+|------|--------|
+| [rules-authentication.md](heygen-skill/rules-authentication.md) | API key setup, X-Api-Key header, auth patterns |
+| [rules-quota.md](heygen-skill/rules-quota.md) | Credit system, usage limits, remaining quota |
+| [rules-video-status.md](heygen-skill/rules-video-status.md) | Polling patterns, status types, download URLs |
+| [rules-assets.md](heygen-skill/rules-assets.md) | Uploading images, videos, audio for generation |
 
 ### Core Video Creation
 
-- [heygen-skill/rules-avatars.md](heygen-skill/rules-avatars.md) - Listing avatars, avatar styles, and avatar_id selection
-- [heygen-skill/rules-voices.md](heygen-skill/rules-voices.md) - Listing voices, locales, speed/pitch configuration
-- [heygen-skill/rules-scripts.md](heygen-skill/rules-scripts.md) - Writing scripts, pauses/breaks, pacing, and structure templates
-- [heygen-skill/rules-video-generation.md](heygen-skill/rules-video-generation.md) - POST /v2/video/generate workflow and multi-scene videos
-- [heygen-skill/rules-video-agent.md](heygen-skill/rules-video-agent.md) - One-shot prompt video generation with Video Agent API
-- [heygen-skill/rules-dimensions.md](heygen-skill/rules-dimensions.md) - Resolution options (720p/1080p) and aspect ratios
+| Rule | Covers |
+|------|--------|
+| [rules-avatars.md](heygen-skill/rules-avatars.md) | Avatar listing, styles, avatar_id selection |
+| [rules-voices.md](heygen-skill/rules-voices.md) | Voice listing, locales, speed/pitch config |
+| [rules-scripts.md](heygen-skill/rules-scripts.md) | Script writing, pauses/breaks, pacing, templates |
+| [rules-video-generation.md](heygen-skill/rules-video-generation.md) | POST /v2/video/generate, multi-scene videos |
+| [rules-video-agent.md](heygen-skill/rules-video-agent.md) | One-shot prompt generation via Video Agent API |
+| [rules-dimensions.md](heygen-skill/rules-dimensions.md) | Resolution (720p/1080p), aspect ratios |
 
 ### Video Customization
 
-- [heygen-skill/rules-backgrounds.md](heygen-skill/rules-backgrounds.md) - Solid colors, images, and video backgrounds
-- [heygen-skill/rules-text-overlays.md](heygen-skill/rules-text-overlays.md) - Adding text with fonts and positioning
-- [heygen-skill/rules-captions.md](heygen-skill/rules-captions.md) - Auto-generated captions and subtitle options
+| Rule | Covers |
+|------|--------|
+| [rules-backgrounds.md](heygen-skill/rules-backgrounds.md) | Solid colors, images, video backgrounds |
+| [rules-text-overlays.md](heygen-skill/rules-text-overlays.md) | Text with fonts and positioning |
+| [rules-captions.md](heygen-skill/rules-captions.md) | Auto-generated captions, subtitle options |
 
 ### Advanced Features
 
-- [heygen-skill/rules-templates.md](heygen-skill/rules-templates.md) - Template listing and variable replacement
-- [heygen-skill/rules-video-translation.md](heygen-skill/rules-video-translation.md) - Translating videos, quality/fast modes, and dubbing
-- [heygen-skill/rules-streaming-avatars.md](heygen-skill/rules-streaming-avatars.md) - Real-time interactive avatar sessions
-- [heygen-skill/rules-photo-avatars.md](heygen-skill/rules-photo-avatars.md) - Creating avatars from photos (talking photos)
-- [heygen-skill/rules-webhooks.md](heygen-skill/rules-webhooks.md) - Registering webhook endpoints and event types
+| Rule | Covers |
+|------|--------|
+| [rules-templates.md](heygen-skill/rules-templates.md) | Template listing, variable replacement |
+| [rules-video-translation.md](heygen-skill/rules-video-translation.md) | Translation, quality/fast modes, dubbing |
+| [rules-streaming-avatars.md](heygen-skill/rules-streaming-avatars.md) | Real-time interactive avatar sessions |
+| [rules-photo-avatars.md](heygen-skill/rules-photo-avatars.md) | Avatars from photos (talking photos) |
+| [rules-webhooks.md](heygen-skill/rules-webhooks.md) | Webhook endpoints, event types |
 
 ### Integration
 
-- [heygen-skill/rules-remotion-integration.md](heygen-skill/rules-remotion-integration.md) - Using HeyGen avatar videos in Remotion compositions
+| Rule | Covers |
+|------|--------|
+| [rules-remotion-integration.md](heygen-skill/rules-remotion-integration.md) | HeyGen avatar videos in Remotion compositions |


### PR DESCRIPTION
## Summary

- Tighten `.agents/content/heygen-skill.md` (simplification-debt)
- Remove verbose "When to use" and "How to use" prose sections — replaced with single directive line
- Convert bullet-list index to table format (Rule | Covers) for faster scanning
- All 19 rule file references preserved, zero content loss

## Changes

| Before | After |
|--------|-------|
| 52 lines | 56 lines (tables add header rows but improve scannability) |
| Verbose "When to use" section (3 lines) | Single directive line |
| Verbose "How to use" preamble | Removed (self-evident from structure) |
| Bullet lists with full paths | Tables with short names + full link paths |

## Classification

This is a **reference corpus index** (SKILL.md pattern) — already structured as slim index + 19 chapter files. Per code-simplifier guidance (GH#6432), restructured for clarity rather than compressed.

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only, no code changes)
- **Verification**: `self-assessed` — markdown lint passes (0 errors), all 19 rule file links verified present

## Verification

- `bunx markdownlint-cli2 ".agents/content/heygen-skill.md"` — 0 errors
- `rg -c 'heygen-skill/rules-' .agents/content/heygen-skill.md` — 19 matches (all rule files)

Closes #14451


---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6