### PR TITLE
GH#14782: tighten seo-opportunities command guidance

### DIFF
--- a/.agents/scripts/commands/seo-opportunities.md
+++ b/.agents/scripts/commands/seo-opportunities.md
@@ -4,16 +4,15 @@ agent: SEO
 mode: subagent
 ---
 
-Run the complete SEO export + analysis workflow in one step.
+Run the complete SEO export + analysis workflow.
 
 Target: $ARGUMENTS
 
 ## Quick Reference
 
-- **Purpose**: Full SEO opportunity workflow
 - **Combines**: `/seo-export all` + `/seo-analyze`
 - **Default range**: 90 days
-- **Output**: Export TOON files plus one analysis report
+- **Outputs**: Platform export TOON files plus one analysis report
 
 ## Usage
 
@@ -25,10 +24,10 @@ Target: $ARGUMENTS
 /seo-opportunities example.com --days 30
 ```
 
-## Process
+## Workflow
 
-1. Parse `$ARGUMENTS` for domain and options.
-2. Export from all configured platforms:
+1. Parse `$ARGUMENTS` for the domain and options.
+2. Export all configured platforms:
 
 ```bash
 ~/.aidevops/agents/scripts/seo-export-helper.sh all $DOMAIN --days $DAYS
@@ -40,13 +39,13 @@ Target: $ARGUMENTS
 ~/.aidevops/agents/scripts/seo-analysis-helper.sh $DOMAIN
 ```
 
-4. Summarize findings:
+4. Summarize:
    - Top 10 quick wins
    - Top 10 striking-distance opportunities
    - Low-CTR pages needing optimization
    - Content cannibalization issues
 
-## Output
+## Outputs
 
 Created files:
 
@@ -55,12 +54,10 @@ Created files:
 ~/.aidevops/.agent-workspace/work/seo-data/{domain}/analysis-{date}.toon
 ```
 
-## Recommendations
-
-Prioritize recommendations in this order:
+## Recommendation Order
 
 1. **Quick Wins** — fastest ROI, minimal effort, on-page only
-2. **Low CTR** — title/meta changes with fast traffic upside
+2. **Low CTR** — quick title/meta changes with traffic upside
 3. **Cannibalization** — consolidate ranking signals before new work
 4. **Striking Distance** — higher effort, higher upside
 


### PR DESCRIPTION
## Summary
- tighten the seo-opportunities slash command copy without changing the workflow, command examples, or output paths
- keep the default 90-day range, export/analyze helper commands, recommendation order, and supporting docs while removing redundant prose

## Testing
- `bunx markdownlint-cli2 ".agents/scripts/commands/seo-opportunities.md"`

## Runtime Testing
- self-assessed
- low risk: agent markdown doc change only

Closes #14782


---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the SEO opportunities command with improved structure and clearer descriptions. Updated workflow steps, output specifications for platform exports and analysis reports, and recommendation ordering for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->