### PR TITLE
GH#14781: tighten D1 reference overview

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/d1.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/d1.md
@@ -1,16 +1,16 @@
 # Cloudflare D1 Database
 
-Managed SQLite for Cloudflare Workers. Use it when queries need SQL semantics and stronger consistency than KV, but keep the data model horizontally partitionable.
+Managed SQLite for Cloudflare Workers. Use it when you need relational queries and stronger consistency than KV, and design around many small databases rather than one large shared database.
 
-## Core Model
+## Core Properties
 
-- SQLite-compatible SQL
-- 10 GB maximum per database
-- 30-day Time Travel recovery window
-- Worker bindings and HTTP API access
-- Query- and storage-based pricing
-
-**Design bias:** Prefer many small databases (per tenant, user, or entity) over one large shared database.
+| Property | Detail |
+|----------|--------|
+| Query model | SQLite-compatible SQL |
+| Scale unit | 10 GB maximum per database |
+| Recovery | 30-day Time Travel window |
+| Access | Worker bindings and HTTP API |
+| Pricing | Query and storage based |
 
 ## Quick Start
 
@@ -23,22 +23,11 @@ wrangler dev
 ## Query API
 
 ```typescript
-const { results, success, meta } = await env.DB
-  .prepare('SELECT * FROM users WHERE active = ?')
-  .bind(true)
-  .all();
-
-const user = await env.DB
-  .prepare('SELECT * FROM users WHERE id = ?')
-  .bind(userId)
-  .first();
+// .all() returns all rows; .first() returns the first row or null
+// .first(column) returns one value; .run() writes; .raw() returns array rows
+const { results, success, meta } = await env.DB.prepare('SELECT * FROM users WHERE active = ?').bind(true).all();
+const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).first();
 ```
-
-- `.all()` returns all rows
-- `.first()` returns the first row or `null`
-- `.first(column)` returns one column value
-- `.run()` is for write statements
-- `.raw()` returns array rows for lower-overhead reads
 
 ## Batch Operations
 
@@ -75,13 +64,10 @@ wrangler d1 time-travel restore <db-name> --timestamp="2024-01-15T14:30:00Z"
 wrangler dev --persist-to=./.wrangler/state
 ```
 
-## In This Reference
+## Read Next
 
 - [d1-patterns.md](./d1-patterns.md) - Pagination, bulk operations, caching, session storage, multi-tenant layouts
 - [d1-gotchas.md](./d1-gotchas.md) - SQL injection prevention, indexing, query limits, local-vs-remote differences
-
-## See Also
-
 - [workers.md](./workers.md) - Runtime and handler patterns
 - [kv.md](./kv.md) - Read-heavy caching and eventual consistency
 - [r2.md](./r2.md) - Store blobs outside D1


### PR DESCRIPTION
## Summary
- tighten the D1 overview around its best fit and core platform properties
- collapse the query API explanation into a shorter example while preserving the same methods and commands
- merge cross-reference sections into a single `Read Next` block

## Testing
- `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/d1.md"`

## Runtime Testing
- self-assessed: docs-only markdown change for an agent reference file; no runtime behavior changed

Closes #14781

---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 7m on this as a headless worker.