### PR TITLE
GH#14116: tighten list-todo.md (117 -> 62 lines)

### DIFF
--- a/.agents/scripts/commands/list-todo.md
+++ b/.agents/scripts/commands/list-todo.md
@@ -4,50 +4,34 @@ agent: Build+
 mode: subagent
 ---
 
-Display tasks from TODO.md and optionally PLANS.md with fast script-based output.
+Display tasks from TODO.md and optionally PLANS.md.
 
 Arguments: $ARGUMENTS
 
 ## Quick Output (Default)
 
-Run the helper script for instant output:
-
 ```bash
 ~/.aidevops/agents/scripts/list-todo-helper.sh $ARGUMENTS
 ```
 
-Display the output directly to the user. The script handles all formatting.
+Display output directly — the script handles all formatting (Markdown tables, grouping, summary).
 
 ## Fallback (Script Unavailable)
 
-If the script fails or is unavailable, read and parse the files manually:
+If the script fails, parse manually:
 
 1. Read `TODO.md` and `todo/PLANS.md`
 2. Parse tasks by status (In Progress, Backlog, Done)
-3. Apply any filters from arguments
+3. Apply filters from arguments
 4. Format as Markdown tables
 
 ## Arguments
 
-**Sorting options:**
-- `--priority` or `-p` - Sort by priority (security/bugfix first)
-- `--estimate` or `-e` - Sort by time estimate (shortest first)
-- `--date` or `-d` - Sort by logged date (newest first)
-- `--alpha` or `-a` - Sort alphabetically
+**Sorting:** `--priority`/`-p` (security/bugfix first), `--estimate`/`-e` (shortest first), `--date`/`-d` (newest first), `--alpha`/`-a` (alphabetical).
 
-**Filtering options:**
-- `--tag <tag>` or `-t <tag>` - Filter by tag (seo, security, etc.)
-- `--owner <name>` or `-o <name>` - Filter by assignee (marcus, etc.)
-- `--status <status>` - Filter by status (pending, in-progress, done)
-- `--estimate-filter <range>` - Filter by estimate (<2h, >1d, 1h-4h)
+**Filtering:** `--tag <tag>`/`-t <tag>`, `--owner <name>`/`-o <name>`, `--status <status>`, `--estimate-filter <range>` (`<2h`, `>1d`, `1h-4h`).
 
-**Display options:**
-- `--plans` - Include plan details from PLANS.md
-- `--done` - Include completed tasks
-- `--all` - Show everything (pending + done + plans)
-- `--compact` - One-line per task (no tables)
-- `--limit <n>` - Limit results
-- `--json` - Output as JSON
+**Display:** `--plans` (include PLANS.md), `--done` (completed tasks), `--all` (everything), `--compact` (one-line per task), `--limit <n>`, `--json`.
 
 ## Examples
 
@@ -61,57 +45,18 @@ If the script fails or is unavailable, read and parse the files manually:
 /list-todo --all --compact           # Everything, one line each
 ```
 
-## Output Format
-
-The script outputs Markdown tables:
-
-```markdown
-## Tasks Overview
-
-### In Progress (N)
-
-| # | ID | Task | Est | Tags | Owner |
-|---|-----|------|-----|------|-------|
-| 1 | t001 | Task description | ~2h | #tag | @owner |
-
----
-
-### Backlog (N pending)
-
-| # | ID | Task | Est | Tags | Owner | Logged |
-|---|-----|------|-----|------|-------|--------|
-| 1 | t002 | Another task | ~4h | #feature | - | 2025-01-15 |
-
-**Blocked tasks** (N):
-- t003 blocked-by:t001
-
----
-
-**Summary:** N pending | N in progress | N done | N active plans
-
----
-
-**Options:**
-1. Work on a specific task (enter task ID like `t014` or row number from `#` column)
-2. Filter/sort differently (e.g., `--priority`, `-t seo`)
-3. Done browsing
-```
-
 ## After Display
 
 Wait for user input:
 
-1. **Task ID or row number** - Start working on that task (e.g., `t014` or `5`)
-2. **Filter command** - Re-run with new filters (e.g., `-t seo`)
-3. **"3" or "done"** - End browsing
+1. **Task ID or row number** — start working on that task (e.g., `t014` or `5`)
+2. **Filter command** — re-run with new filters (e.g., `-t seo`)
+3. **"done"** — end browsing
 
-When user selects a task:
-- Check if it's a plan reference (`#plan` tag or `→ PLANS.md`)
-- If plan: suggest `/show-plan <name>`
-- If task: offer to start work (check branch, create if needed)
+On task selection: if `#plan` tag or `→ PLANS.md` → suggest `/show-plan <name>`. Otherwise offer to start work (check branch, create if needed).
 
-## Related Commands
+## Related
 
-- `/show-plan <name>` - Show detailed plan information
-- `/ready` - Show only tasks with no blockers
-- `/save-todo` - Save current discussion as task
+- `/show-plan <name>` — detailed plan information
+- `/ready` — tasks with no blockers
+- `/save-todo` — save discussion as task


### PR DESCRIPTION
## Summary

- Tightened `.agents/scripts/commands/list-todo.md` from 117 to 62 lines (47% reduction)
- Removed 34-line Output Format sample (the script handles all formatting — agent doesn't need to reproduce it)
- Compressed Arguments section from verbose bullet lists to inline format
- Condensed After Display section from 12 to 5 lines

Closes #14116

## Content Preservation

All CLI flags (`--priority`, `--estimate`, `--date`, `--alpha`, `--tag`, `--owner`, `--status`, `--estimate-filter`, `--plans`, `--done`, `--all`, `--compact`, `--limit`, `--json`) and short aliases (`-p`, `-e`, `-d`, `-a`, `-t`, `-o`) verified present. All command references (`/show-plan`, `/ready`, `/save-todo`), file references (`TODO.md`, `PLANS.md`, `list-todo-helper.sh`), and the fallback workflow preserved.

## What Was Removed

The Output Format section contained a 34-line sample of what the helper script produces. Since the command doc says "Display the output directly to the user. The script handles all formatting," the agent never needs to reproduce this format — it just runs the script. Replaced with a one-line note.

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdownlint clean, all flags/references verified present

---
[aidevops.sh](https://aidevops.sh) v3.5.516 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6