### PR TITLE
GH#14774: fix Beads UI tools install crashing WSL terminal

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -732,6 +732,8 @@ _install_bv_tool() {
 
 # _install_beads_node_tools: install beads-ui and bdui via npm.
 # Echoes the count of tools installed to stdout.
+# All informational output (spinner, status) goes to stderr so that
+# command-substitution callers receive only the numeric count.
 _install_beads_node_tools() {
 	local count=0
 	if ! command -v npm &>/dev/null; then
@@ -740,15 +742,15 @@ _install_beads_node_tools() {
 	fi
 	setup_prompt install_web "  Install beads-ui (Web dashboard)? [Y/n]: " "Y"
 	if [[ "$install_web" =~ ^[Yy]?$ ]]; then
-		if run_with_spinner "Installing beads-ui" npm_global_install beads-ui; then
-			print_info "Run: beads-ui"
+		if run_with_spinner "Installing beads-ui" npm_global_install beads-ui 1>&2; then
+			print_info "Run: beads-ui" >&2
 			count=$((count + 1))
 		fi
 	fi
 	setup_prompt install_bdui "  Install bdui (React/Ink TUI)? [Y/n]: " "Y"
 	if [[ "$install_bdui" =~ ^[Yy]?$ ]]; then
-		if run_with_spinner "Installing bdui" npm_global_install bdui; then
-			print_info "Run: bdui"
+		if run_with_spinner "Installing bdui" npm_global_install bdui 1>&2; then
+			print_info "Run: bdui" >&2
 			count=$((count + 1))
 		fi
 	fi


### PR DESCRIPTION
## Summary

- Fix `_install_beads_node_tools()` writing spinner/status text to stdout, which gets captured by `setup_beads_ui()`'s command substitution (`node_count=$(...)`), corrupting the arithmetic expansion and crashing WSL terminals
- Redirect `run_with_spinner` and `print_info` calls to stderr (`1>&2` / `>&2`), reserving stdout for the numeric count only

Closes #14774

## Root Cause

`setup_beads_ui()` captures `_install_beads_node_tools()` output via command substitution:
```bash
node_count=$(_install_beads_node_tools)
installed_count=$((installed_count + node_count))
```

But `_install_beads_node_tools()` also writes spinner characters, ANSI escape codes, and status messages to stdout via `run_with_spinner` and `print_info`. The captured value becomes non-numeric, breaking the arithmetic expansion and corrupting the ConPTY layer on WSL.

## Changes

| File | Change |
|------|--------|
| `setup-modules/agent-deploy.sh` | Redirect `run_with_spinner` and `print_info` to stderr in `_install_beads_node_tools()` |

## Runtime Testing

- **Risk level**: Low (installer control flow, no data mutation)
- **Verification**: `self-assessed` — shellcheck clean, stderr redirect is a standard bash pattern with no side effects. User-visible terminal output is unchanged (stderr still displays on terminal).

---
[aidevops.sh](https://aidevops.sh) v3.5.517 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6