### PR TITLE
GH#14813: backfill email-verification simplification state

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1281,6 +1281,11 @@
       "at": "2026-03-28T16:40:17Z",
       "pr": 12041
     },
+    ".agents/services/email/email-verification.md": {
+      "hash": "d8d5bf1e0ed2feed034371b34ea74d5a572eac25",
+      "at": "2026-03-31T09:57:12Z",
+      "pr": 14757
+    },
     ".agents/services/email/openpgp-setup.md": {
       "hash": "f893cd98da28874d714707765c45a895d991cede",
       "at": "2026-03-28T16:40:18Z",


### PR DESCRIPTION
## Summary
- backfill `.agents/configs/simplification-state.json` for `.agents/services/email/email-verification.md`
- record the git blob hash and original simplification PR metadata from #14757 so the pulse can treat the doc as already simplified
- Closes #14813

## Testing
- `python3 -m json.tool .agents/configs/simplification-state.json >/dev/null`
- `git diff -- .agents/configs/simplification-state.json`

## Runtime Testing
- self-assessed (low risk: simplification state metadata only)
---
[aidevops.sh](https://aidevops.sh) v3.5.517 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 3m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration tracking for documentation files.

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->