### PR TITLE
GH#14812: tighten Evaluation Datasets doc

### DIFF
--- a/.agents/tools/ai-assistants/datasets.md
+++ b/.agents/tools/ai-assistants/datasets.md
@@ -1,38 +1,36 @@
 # Evaluation Datasets
 
-Standardised JSONL format and directory convention for LLM evaluation test cases. Used by bench and evaluator workflows.
+Standardised JSONL format and storage convention for LLM evaluation cases. Used by bench and evaluator workflows.
 
-## Dataset Format
+## Format
 
-Each line is a JSON object (JSONL). Required fields: `id`, `input`.
+One JSON object per line. Required fields: `id`, `input`.
 
 ```jsonl
 {"id":"001","input":"What is the capital of France?","expected":"Paris","context":"France is in Western Europe.","tags":["geography","factual"],"source":"manual"}
 {"id":"002","input":"Summarize this PR","expected":null,"context":"PR #123 adds auth middleware...","tags":["code-review","summarization"],"source":"trace:abc123"}
 ```
 
-### Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | string | Yes | Unique identifier (auto-generated on `add`) |
-| `input` | string | Yes | Prompt or input to send to the model |
-| `expected` | string/null | No | Expected output (null for open-ended evaluations) |
-| `context` | string/null | No | Context for grounding (faithfulness evaluation) |
-| `tags` | string[] | No | Filtering: scenario type, domain, difficulty |
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `id` | string | Yes | Unique identifier; auto-generated on `add` |
+| `input` | string | Yes | Prompt or input sent to the model |
+| `expected` | string/null | No | Expected output; `null` for open-ended evals |
+| `context` | string/null | No | Grounding context for faithfulness checks |
+| `tags` | string[] | No | Scenario, domain, or difficulty filters |
 | `source` | string | No | Provenance: `manual`, `trace:<id>`, `generated:<model>` |
-| `metadata` | object/null | No | Arbitrary key-value pairs |
+| `metadata` | object/null | No | Extra key-value pairs |
 
-Full JSON Schema: `dataset-helper.sh schema`
+Full schema: `dataset-helper.sh schema`
 
-## Directory Convention
+## Storage
 
 ```text
-~/.aidevops/.agent-workspace/datasets/    # Global (cross-project)
-~/Git/myproject/datasets/                  # Project-specific (version-controlled)
+~/.aidevops/.agent-workspace/datasets/    # Global, cross-project
+~/Git/myproject/datasets/                 # Project-local, version-controlled
 ```
 
-## CLI Reference
+## CLI
 
 ```bash
 DATASET_DIR="$HOME/.aidevops/.agent-workspace/datasets"
@@ -53,7 +51,7 @@ dataset-helper.sh add "$DATASET_DIR/golden-prompts.jsonl" \
 dataset-helper.sh validate "$DATASET_DIR/golden-prompts.jsonl"            # Basic
 dataset-helper.sh validate "$DATASET_DIR/golden-prompts.jsonl" --strict   # + type checking
 
-# List / Stats
+# List and stats
 dataset-helper.sh list                                     # Global only
 dataset-helper.sh list --project ~/Git/myapp               # Global + project
 dataset-helper.sh stats "$DATASET_DIR/golden-prompts.jsonl"
@@ -62,40 +60,33 @@ dataset-helper.sh stats "$DATASET_DIR/golden-prompts.jsonl"
 dataset-helper.sh promote --trace-id abc123
 dataset-helper.sh promote --trace-id abc123 -o "$DATASET_DIR/regression.jsonl" --tags "regression"
 
-# Merge (dedup by ID, file2 wins on conflict)
+# Merge (dedup by ID; file2 wins on conflict)
 dataset-helper.sh merge dataset1.jsonl dataset2.jsonl -o merged.jsonl
 ```
 
 ## Workflows
 
-### Building a Golden Dataset
+### Golden dataset
 
-1. Add manual entries for known test cases
-2. Run evaluations, identify failures → add failure cases with tags
-3. Re-run after prompt changes to detect regressions
+1. Add manual entries for known cases.
+2. Run evaluations; add failures with tags.
+3. Re-run after prompt changes to catch regressions.
 
-### Promoting from Traces
+### Promote from traces
 
-1. Find trace ID: `jq '.request_id' ~/.aidevops/.agent-workspace/observability/metrics.jsonl | tail`
-2. Promote: `dataset-helper.sh promote --trace-id <id> --tags "edge-case"`
-3. Edit promoted entry to add expected output and refine input
+1. Find the trace ID: `jq '.request_id' ~/.aidevops/.agent-workspace/observability/metrics.jsonl | tail`
+2. Promote it: `dataset-helper.sh promote --trace-id <id> --tags "edge-case"`
+3. Edit the promoted entry with expected output and cleaner input.
 
-### Integration with Bench (t1393)
+### Integrations
 
-```bash
-compare-models-helper.sh bench --dataset golden-prompts.jsonl
-```
+- Bench (t1393): `compare-models-helper.sh bench --dataset golden-prompts.jsonl`
+- Evaluators (t1394): `ai-judgment-helper.sh evaluate --dataset golden-prompts.jsonl`
 
-### Integration with Evaluators (t1394)
+## Design decisions
 
-```bash
-ai-judgment-helper.sh evaluate --dataset golden-prompts.jsonl
-```
-
-## Design Decisions
-
-- **JSONL over CSV/JSON-array**: Streamable, one entry per line (grep/wc), standard in ML/eval tooling, consistent with observability-helper.sh
-- **`id` required**: Deduplication, trace-back, merge operations
-- **`expected` optional**: Many evaluations lack a single correct answer (summarization, creative)
-- **`source` provenance**: Distinguish hand-written, promoted from production, or synthetically generated
-- **`tags` filtering**: Run dataset subsets by scenario type, domain, or difficulty
+- **JSONL over CSV/JSON-array**: Streamable, append-friendly, grep/wc-friendly, standard in ML/eval tooling, consistent with observability-helper.sh.
+- **`id` required**: Enables deduplication, trace-back, and merges.
+- **`expected` optional**: Some evals have no single correct answer.
+- **`source` provenance**: Distinguishes manual, promoted, and generated cases.
+- **`tags` filtering**: Supports subsets by scenario, domain, or difficulty.


### PR DESCRIPTION
## Summary
- shorten `.agents/tools/ai-assistants/datasets.md` by collapsing section titles and workflow prose while preserving the JSONL schema, commands, and task references
- keep the doc focused on storage, CLI usage, integrations, and design decisions for evaluation datasets

## Testing
- `bunx markdownlint-cli2 ".agents/tools/ai-assistants/datasets.md"`
- `git diff --check`
- content preservation verified against the diff: JSONL examples, CLI commands, and t1393/t1394 references remain present

## Runtime Testing
- Level: self-assessed
- Reason: markdown-only agent doc change

Closes #14812


---
[aidevops.sh](https://aidevops.sh) v3.5.517 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 5m on this as a headless worker.