### PR TITLE
GH#14811: tighten OrbStack agent doc

### DIFF
--- a/.agents/tools/containers/orbstack.md
+++ b/.agents/tools/containers/orbstack.md
@@ -18,48 +18,87 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Fast, lightweight Docker and Linux VM runtime for macOS (replaces Docker Desktop)
-- **Install**: `brew install orbstack` → verify with `orb status` and `docker --version`
-- **CLI**: `orb` (management) + `docker` (Docker-compatible — all existing commands work unchanged)
-- **Docs**: https://docs.orbstack.dev
-- **Website**: https://orbstack.dev | **GitHub**: https://github.com/orbstack/orbstack
-- **Pricing**: Free for personal use, paid for teams
+| Item | Details |
+|------|---------|
+| Purpose | Fast, lightweight Docker and Linux VM runtime for macOS; practical Docker Desktop replacement |
+| Install | `brew install orbstack` then verify with `orb status` and `docker --version` |
+| CLI | `orb` for OrbStack management, `docker` / `docker compose` for normal container workflows |
+| Docs | https://docs.orbstack.dev |
+| Links | https://orbstack.dev · https://github.com/orbstack/orbstack |
+| Pricing | Free for personal use, paid for teams |
 
-**Why OrbStack over Docker Desktop**: Faster startup, lower memory, native macOS integration (Finder, menu bar, `.orb.local` domains), built-in Linux VMs, Rosetta x86 emulation on Apple Silicon.
+Prefer OrbStack when you want lower memory use, faster startup, native macOS integration, automatic `.orb.local` DNS, built-in Linux VMs, or Rosetta-based x86 emulation on Apple Silicon.
 
 <!-- AI-CONTEXT-END -->
 
-## OrbStack-Specific Commands
+## Core Commands
 
-Standard `docker` and `docker compose` commands work without modification. OrbStack-only:
+Standard `docker` and `docker compose` commands work unchanged. Use `orb` for OrbStack-specific management:
 
 ```bash
-orb list                          # List all containers and VMs
-orb shell <container-name>        # Quick shell access
-orb start / orb stop              # Start/stop OrbStack
-
-# Automatic .orb.local DNS — no config needed
+orb list                          # List containers and VMs
+orb shell <name>                  # Quick shell into a container or VM
+orb start                         # Start OrbStack
+orb stop                          # Stop OrbStack and free resources
 curl http://<container-name>.orb.local
 ```
 
 ## Linux VMs
 
-Lightweight VMs alongside Docker with `.orb.local` DNS, SSH, and shared filesystem:
+OrbStack can run lightweight Linux VMs with shared filesystem access, SSH, and `.orb.local` networking:
 
 ```bash
 orb create ubuntu my-ubuntu       # Create VM
-orb shell my-ubuntu               # Shell into VM (or: ssh my-ubuntu@orb)
+orb shell my-ubuntu               # Shell into VM
+ssh my-ubuntu@orb                 # SSH alternative
 orb stop my-ubuntu                # Stop VM
 orb start my-ubuntu               # Start VM
 orb delete my-ubuntu              # Delete VM
 ```
 
+## OpenClaw Workflows
+
+### Setup
+
+```bash
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
+./docker-setup.sh                 # Build image, run onboarding, start gateway
+open http://127.0.0.1:18789/      # Access Control UI
+```
+
+### Routine Management
+
+```bash
+docker compose ps                                     # Status
+docker compose logs -f openclaw-gateway               # Logs
+docker compose restart openclaw-gateway               # Restart gateway
+docker compose run --rm openclaw-cli doctor           # Health check
+docker compose run --rm openclaw-cli security audit   # Security audit
+docker compose run --rm openclaw-cli channels login   # Channel setup
+```
+
+### Persistent Host Data
+
+| Path | Purpose |
+|------|---------|
+| `~/.openclaw/openclaw.json` | Config |
+| `~/.openclaw/workspace` | Workspace |
+| `~/.openclaw/credentials/` | Credentials |
+| `~/.openclaw/agents/<agentId>/sessions/` | Sessions |
+
 ## Common Use Cases
 
 ```bash
-# Isolated dev database (access at postgres.orb.local or localhost:5432)
+# Isolated dev database at postgres.orb.local or localhost:5432
 docker run -d --name postgres -p 5432:5432 \
   -e POSTGRES_PASSWORD=dev postgres:16
+
+# OpenClaw sandbox images for agent-tool isolation
+cd openclaw
+scripts/sandbox-setup.sh           # Base sandbox
+scripts/sandbox-common-setup.sh    # Adds build tools
+scripts/sandbox-browser-setup.sh   # Adds Chromium
 ```
 
 ## Troubleshooting
@@ -69,7 +108,12 @@ orb status                        # Check OrbStack status
 orb restart                       # Restart OrbStack
 orb logs                          # View OrbStack logs
 docker info                       # Check Docker daemon
-docker system df                  # Check disk usage
-docker system prune -a            # DESTRUCTIVE: removes ALL unused resources
-orb reset                         # Factory reset (last resort)
+docker system df                  # Check Docker disk usage
+```
+
+`docker system prune -a` is destructive: it permanently removes all unused containers, images, networks, and build cache. Prefer `docker image prune`, `docker container prune`, or dropping `-a` unless you explicitly want a full reset.
+
+```bash
+docker system prune -a            # Full destructive cleanup
+orb reset                         # Factory reset; last resort
 ```


### PR DESCRIPTION
## Summary
- restore the OpenClaw-specific setup, management, persistence, and sandbox examples that the prior simplification dropped
- reorder the OrbStack guide around quick-reference tables and core workflows while keeping the destructive cleanup warning explicit

## Testing
- markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/tools/containers/orbstack.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Runtime Testing
- self-assessed: docs-only change to an agent markdown file; no runtime behavior changed

Closes #14811


---
[aidevops.sh](https://aidevops.sh) v3.5.517 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 4m on this as a headless worker.