### PR TITLE
GH#14814: record content-analyzer simplification state

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -11,6 +11,11 @@
       "at": "2026-03-27T21:25:04Z",
       "pr": 11015
     },
+    ".agents/seo/content-analyzer.md": {
+      "hash": "de734f568f2e1dcf4a3a57daba80fadd7eb6c543",
+      "at": "2026-03-31T09:57:05Z",
+      "pr": 14761
+    },
     ".agents/tools/credentials/gopass.md": {
       "hash": "a59a0077d4d56694894c8cadef6b9c3a294dede0",
       "at": "2026-03-27T21:25:05Z",


### PR DESCRIPTION
## Summary

- Confirms `.agents/seo/content-analyzer.md` was already simplified on `main` by commit `c4c1bff50` in PR #14761
- Adds the missing `.agents/configs/simplification-state.json` entry for `.agents/seo/content-analyzer.md` so the simplification scanner stops re-opening stale follow-up work
- Leaves the agent doc unchanged because the current `main` version is already the tightened 60-line form

## Verification

- `python3` validation confirmed the registry entry matches `git hash-object .agents/seo/content-analyzer.md` (`de734f568f2e1dcf4a3a57daba80fadd7eb6c543`) and PR `14761`
- `git log --oneline -- .agents/seo/content-analyzer.md` shows `c4c1bff50 GH#14096: tighten agent doc SEO Content Analyzer (.agents/seo/content-analyzer.md, 121 -> 60 lines) (#14761)` already on `main`

## Runtime Testing

- Risk level: **Low** — hash-registry metadata only
- Testing level: `self-assessed`
- Checks run: JSON parse + git blob hash match assertion for `.agents/configs/simplification-state.json`

Closes #14814

---

---
[aidevops.sh](https://aidevops.sh) v3.5.519 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 20m on this as a headless worker.
