### PR TITLE
GH#14825: tighten security history command guidance

### DIFF
--- a/.agents/scripts/commands/security-history.md
+++ b/.agents/scripts/commands/security-history.md
@@ -4,26 +4,26 @@ agent: Build+
 mode: subagent
 ---
 
-Scan git history for security vulnerabilities in past commits.
+Scan git history for vulnerabilities introduced in past commits.
 
 Target: $ARGUMENTS
 
 ## Quick Reference
 
-- **Purpose**: Find vulnerabilities in historical commits
-- **Use case**: Audit, compliance, incident investigation
-- **Default**: Last 50 commits
+- **Default scope**: last 50 commits
+- **Scopes**: commit count, commit range, `--since`, `--until`, `--author`
+- **Helper**: `./.agents/scripts/security-helper.sh history`
+- **Use cases**: audit, compliance, incident investigation
 
 ## Process
 
-1. **Determine scope** from $ARGUMENTS:
+1. **Resolve scope** from `$ARGUMENTS`:
    - Empty → last 50 commits
-   - Number (e.g., `100`) → last N commits
-   - Range (e.g., `abc123..def456`) → specific commit range
-   - `--since="2024-01-01"` → commits since date
-   - `--author="email"` → commits by author
-
-2. **Run history scan**:
+   - Number (for example `100`) → last N commits
+   - Range (for example `abc123..def456`) → explicit commit range
+   - `--since="2024-01-01"` / `--until="2024-03-31"` → date window
+   - `--author="email"` → author filter
+2. **Run the history scan**:
 
    ```bash
    ./.agents/scripts/security-helper.sh history              # default: last 50
@@ -32,15 +32,14 @@ Target: $ARGUMENTS
    ./.agents/scripts/security-helper.sh history --since="2024-01-01"
    ```
 
-3. **Review findings** with commit context
+3. **Review each finding** with commit, author, file, severity, and whether it is still present in `HEAD`.
+4. **Assess impact**: is it still present, was it deployed, and what data or secrets may have been exposed?
 
-4. **Assess impact**: still present? deployed to production? data exposed?
-
-## Output Format
+## Output
 
 Each finding includes severity, commit, author, file, issue description, and current status (still present or fixed in which commit).
 
-## Use Cases
+## Common Invocations
 
 ```bash
 /security-history --since="2024-01-01" --until="2024-03-31"  # compliance audit
@@ -51,12 +50,12 @@ Each finding includes severity, commit, author, file, issue description, and cur
 
 ## Remediation
 
-**Still present:** create fix, rotate exposed secrets, check if deployed, document in incident log.
+**Still present:** fix in a new commit, rotate exposed secrets, check whether it reached production, and document the incident.
 
-**Already fixed:** verify fix completeness, rotate secrets if exposed, add to lessons learned.
+**Already fixed:** verify the fix is complete, confirm whether secrets were exposed, rotate if needed, and capture the lesson learned.
 
 ## Related Commands
 
-- `/security-analysis` — analyze current code
-- `/security-scan` — quick security check
-- `/security-deps` — dependency vulnerabilities
+- `/security-analysis` - Analyze current code
+- `/security-scan` - Quick security check
+- `/security-deps` - Dependency vulnerabilities


### PR DESCRIPTION
## Summary
- tighten `/security-history` into a shorter command reference with the key scope options first
- condense examples and remediation guidance while preserving the audit and incident-investigation use cases

## Testing
- `bunx markdownlint-cli2 ".agents/scripts/commands/security-history.md"`
- `git diff --check`

## Runtime Testing
- self-assessed; low-risk documentation-only change

Closes #14825

---
[aidevops.sh](https://aidevops.sh) v3.5.519 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 6m and 82,602 tokens on this as a headless worker. Overall, 15m since this issue was created.