### PR TITLE
GH#14833: tighten skill-scanner agent doc

### DIFF
--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -54,7 +54,7 @@ tools:
 
 ## aidevops Integration
 
-- **Import gate**: `add-skill-helper.sh` scans on import; `CRITICAL`/`HIGH` blocks unless `--force`
+- **Import gate**: `add-skill-helper.sh` scans on import; `CRITICAL`/`HIGH` blocks unless `--skip-security` (or an explicit interactive override)
 - **Batch scans**: `aidevops skill scan`, `security-helper.sh skill-scan all`
 - **Update path**: `setup.sh` scans all skills during `aidevops update` (non-blocking); `skill-update-helper.sh update` re-imports with `add-skill-helper.sh --force`
 - **Audit log**: `.agents/configs/configs/SKILL-SCAN-RESULTS.md`
@@ -90,7 +90,7 @@ Store required keys in `~/.config/aidevops/credentials.sh` (600 perms) or gopass
 | Severity | Action |
 |----------|--------|
 | CRITICAL | Do not import. Remove if already imported. |
-| HIGH | Block import. Review before allowing with `--force`. |
+| HIGH | Block import. Review before allowing with `--skip-security` (or an explicit interactive override). |
 | MEDIUM | Warn. Review findings and plan fixes. |
 | LOW | Informational. Address in future. |
 

--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -18,15 +18,15 @@ tools:
 
 ## Quick Reference
 
-- **Type**: Security scanner for AI Agent Skills (SKILL.md, AGENTS.md, scripts)
+- **Purpose**: Scan AI agent skills (`SKILL.md`, `AGENTS.md`, scripts) for import-blocking security risks
 - **Source**: [cisco-ai-defense/skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) (Apache 2.0)
-- **Install**: `uv tool install cisco-ai-skill-scanner` (auto-installed by `setup.sh`)
-- **Run without install**: `uvx cisco-ai-skill-scanner scan /path/to/skill`
-- **aidevops integration**: `aidevops skill scan` or `security-helper.sh skill-scan`
-- **Formats**: summary, json, markdown, table, sarif
-- **Exit codes**: 0=safe, 1=findings detected
+- **Install**: `uv tool install cisco-ai-skill-scanner` (`setup.sh` auto-installs it)
+- **No install**: `uvx cisco-ai-skill-scanner scan /path/to/skill`
+- **aidevops entry points**: `aidevops skill scan`, `security-helper.sh skill-scan`, `add-skill-helper.sh`
+- **Formats**: `summary`, `json`, `markdown`, `table`, `sarif`
+- **Exit codes**: `0` safe, `1` findings
 
-## Threat Detection
+## Threat Coverage
 
 | Category | AITech Code | Severity | Detection |
 |----------|-------------|----------|-----------|
@@ -41,50 +41,49 @@ tools:
 | Autonomy abuse | AITech-13.1 | MEDIUM-HIGH | YAML + YARA + LLM |
 | Tool chaining | AITech-8.2.3 | HIGH | YARA + LLM |
 
-## Analysis Engines
+## Engines
 
 | Engine | Cost | Speed | Requirements |
 |--------|------|-------|-------------|
 | Static (YAML + YARA) | Free | ~150ms | None |
-| Behavioral (AST dataflow) | Free | ~150ms | None |
+| Behavioral (AST/dataflow) | Free | ~150ms | None |
 | LLM-as-judge | API cost | ~2s | `SKILL_SCANNER_LLM_API_KEY` |
 | Meta-analyzer (FP filter) | API cost | ~1s | `SKILL_SCANNER_LLM_API_KEY` |
-| VirusTotal | Free tier | ~16s/req | `VIRUSTOTAL_MARCUSQUINN` or `VIRUSTOTAL_API_KEY` (gopass) |
+| VirusTotal | Free tier | ~16s/request | `VIRUSTOTAL_MARCUSQUINN` or `VIRUSTOTAL_API_KEY` |
 | Cisco AI Defense | Enterprise | ~1s | `AI_DEFENSE_API_KEY` |
 
 ## aidevops Integration
 
-- **Import-time** (automatic): `add-skill-helper.sh` scans on import; CRITICAL/HIGH blocks unless `--force`
-- **Batch**: `aidevops skill scan` / `security-helper.sh skill-scan all`
-- **Setup-time**: `setup.sh` scans all skills on `aidevops update` (non-blocking)
-- **Update-time**: `skill-update-helper.sh update` re-imports via `add-skill-helper.sh --force`
-- **Results log**: `.agents/configs/configs/SKILL-SCAN-RESULTS.md` (latest summary + audit history)
+- **Import gate**: `add-skill-helper.sh` scans on import; `CRITICAL`/`HIGH` blocks unless `--force`
+- **Batch scans**: `aidevops skill scan`, `security-helper.sh skill-scan all`
+- **Update path**: `setup.sh` scans all skills during `aidevops update` (non-blocking); `skill-update-helper.sh update` re-imports with `add-skill-helper.sh --force`
+- **Audit log**: `.agents/configs/configs/SKILL-SCAN-RESULTS.md`
 
-## CLI Usage
+## CLI
 
 ```bash
-skill-scanner scan /path/to/skill                                    # static only (fast)
+skill-scanner scan /path/to/skill                                    # static only
 skill-scanner scan /path/to/skill --use-behavioral --use-llm         # full scan
-skill-scanner scan-all /path/to/skills --recursive                   # batch
-skill-scanner scan-all ./skills --fail-on-findings --format sarif    # CI/CD
+skill-scanner scan-all /path/to/skills --recursive                   # batch scan
+skill-scanner scan-all ./skills --fail-on-findings --format sarif    # CI/CD gate
 ```
 
-Additional flags: `--use-llm --enable-meta` (FP filtering), `--custom-rules /path/`, `--disable-rule RULE_NAME`, `--yara-mode permissive`.
+Useful flags: `--enable-meta` (false-positive filter), `--custom-rules /path/`, `--disable-rule RULE_NAME`, `--yara-mode permissive`.
 
-## VirusTotal Integration
+## VirusTotal Layer
 
-Advisory second layer — checks file hashes (SHA256) against 70+ AV engines and scans domains/URLs. **VT is advisory only** — Cisco scanner remains the import gate. Rate limit: 4 req/min, 500 req/day; max 8 requests per skill scan.
+Advisory second layer for file hashes (SHA256) and embedded domains/URLs. **VirusTotal never replaces the Cisco scanner import gate.** Limits: 4 requests/minute, 500/day, max 8 requests per skill scan.
 
 ```bash
-virustotal-helper.sh scan-skill /path/to/skill/    # scan all skill files
-virustotal-helper.sh scan-file /path/to/file.md    # single file
-virustotal-helper.sh scan-domain example.com       # domain check
-security-helper.sh vt-scan skill /path/to/skill/   # via security-helper (also runs automatically after Cisco scanner)
+virustotal-helper.sh scan-skill /path/to/skill/
+virustotal-helper.sh scan-file /path/to/file.md
+virustotal-helper.sh scan-domain example.com
+security-helper.sh vt-scan skill /path/to/skill/   # also runs automatically after Cisco scanner
 ```
 
-## Environment
+## Credentials
 
-API keys (see Analysis Engines table for which engines need them). Store in `~/.config/aidevops/credentials.sh` (600 perms) or use gopass: `aidevops secret set <KEY_NAME>`.
+Store required keys in `~/.config/aidevops/credentials.sh` (600 perms) or gopass via `aidevops secret set <KEY_NAME>`. See the engine table for which integrations require which key.
 
 ## Response Guidelines
 


### PR DESCRIPTION
## Summary
- tighten the Cisco skill scanner quick-reference wording so the import gate, entry points, and output semantics are easier to skim
- compress the engine, CLI, VirusTotal, and credentials sections without removing security constraints or command examples

## Runtime Testing
- Level: self-assessed
- Risk: low (docs-only agent prompt update)
- Verification: `bunx markdownlint-cli2 ".agents/tools/code-review/skill-scanner.md"`

## Files Changed
- `.agents/tools/code-review/skill-scanner.md`

Closes #14833

---
[aidevops.sh](https://aidevops.sh) v3.5.519 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified skill-scanner tool's threat coverage scope and import-blocking security focus
  * Consolidated integration and entry point descriptions for improved clarity
  * Updated CLI usage examples with revised batch scan and CI/CD gate terminology
  * Refined available flags documentation with updated settings guidance
  * Reorganized credential configuration section with improved key-storage guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->