### PR TITLE
GH#14832: tighten pre-edit workflow doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -231,6 +231,11 @@
       "at": "2026-03-28T03:54:08Z",
       "pr": 11341
     },
+    ".agents/workflows/pre-edit.md": {
+      "hash": "8cb5476f1750b4c5b3dcbc962019db62a9268e11",
+      "at": "2026-03-31T11:00:45Z",
+      "pr": null
+    },
     ".agents/aidevops/recommendations.md": {
       "hash": "67c3f660425b669feae3238d7b42589449caa860",
       "at": "2026-03-28T03:54:11Z",

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -5,26 +5,25 @@ tools:
 ---
 # Pre-Edit Git Check
 
-## Usage
+Run before any file edits:
 
 ```bash
 ~/.aidevops/agents/scripts/pre-edit-check.sh
-# Loop mode (headless/full-loop):
 ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "task description"
 ```
 
 ## Exit Codes
 
-| Code | Meaning | Action |
-|------|---------|--------|
-| `0` | OK to proceed | Continue with edits |
-| `1` | On protected branch (main/master) | STOP — present branch options (interactive) |
-| `2` | Loop mode: worktree needed | Auto-create worktree |
-| `3` | Feature branch in main repo | Present options to user |
+| Code | Meaning | Required action |
+|------|---------|-----------------|
+| `0` | Safe to edit | Proceed |
+| `1` | On `main`/`master` | STOP and present branch options |
+| `2` | Loop mode needs worktree | Auto-create worktree |
+| `3` | Feature branch in main repo | Present worktree options |
 
 ## Interactive Prompts
 
-**Exit 1 — on main:** Present and WAIT for user response (do NOT proceed without reply):
+**Exit 1 — on `main`:** present this prompt and WAIT for a reply.
 
 > On `main`. Suggested branch: `{type}/{suggested-name}`
 >
@@ -38,43 +37,42 @@ tools:
 >
 > 1. Create worktree for this task (recommended)
 > 2. Continue on current branch
-> 3. Switch to main, then create worktree
+> 3. Switch to `main`, then create worktree
 
-## Loop Mode Auto-Decision
+## Loop Mode
 
-- **Docs-only** (`readme`, `changelog`, `documentation`, `docs/`, `typo`, `spelling`) → stay on main
-- **Code** (`feature`, `fix`, `bug`, `implement`, `refactor`, `add`, `update`, `enhance`, `port`, `ssl`, `helper`) → create worktree (overrides docs keywords)
+- Docs-only (`readme`, `changelog`, `documentation`, `docs/`, `typo`, `spelling`) → stay on `main`
+- Code (`feature`, `fix`, `bug`, `implement`, `refactor`, `add`, `update`, `enhance`, `port`, `ssl`, `helper`) → create worktree; code keywords override docs keywords
 
-## Worktree Rationale
+## Why Worktrees Are Default
 
-Main repo (`~/Git/{repo}/`) stays on `main` always. Prevents: uncommitted changes blocking switches, parallel sessions inheriting wrong branch, "local changes would be overwritten" errors.
+Keep `~/Git/{repo}/` on `main`. This avoids blocked branch switches, parallel sessions inheriting the wrong branch, and `local changes would be overwritten` errors.
 
-**Stay on main acceptable for:** docs-only (README, CHANGELOG, docs/), typos, version bumps, planning files (TODO.md, todo/).
+Stay on `main` only for docs-only changes (README, CHANGELOG, `docs/`), typos, version bumps, and planning files (`TODO.md`, `todo/`). Planning-file commits use `planning-commit-helper.sh "plan: add new task"`.
 
-**Planning files** edit directly on main: `planning-commit-helper.sh "plan: add new task"`
+## Feature-Branch Cases
 
-## Feature Branch Scenarios
-
-| Scenario | Script Output | Action |
+| Scenario | Script output | Action |
 |----------|---------------|--------|
 | In worktree | `OK - On branch: X (in worktree)` | Proceed |
-| In main repo | `WARNING - MAIN REPO ON FEATURE BRANCH` | Present exit 3 options |
+| In main repo | `WARNING - MAIN REPO ON FEATURE BRANCH` | Present exit-3 options |
 
-**Continue on current branch** acceptable IF: task relates to current branch purpose, will complete before session ends, no parallel sessions expected.
+Continuing on the current branch is acceptable only when the task matches the branch purpose, will be finished in this session, and no parallel sessions are expected.
 
-## aidevops Framework Note
+## aidevops Source vs Deployed Copy
 
-Two locations: **Source** `~/Git/aidevops/.agents/` (git repo, check branch here) and **Deployed** `~/.aidevops/agents/` (copy, not git). Run pre-edit-check.sh in source repo BEFORE changes to either.
+- Source: `~/Git/aidevops/.agents/` — git-tracked, branch matters
+- Deployed: `~/.aidevops/agents/` — copied output, not a git repo
+
+Run `pre-edit-check.sh` in the source repo before changing either location.
 
 ## Worktree Creation
 
 ```bash
-# Preferred
 wt switch -c {type}/{name}
-# Fallback
 ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{name}
 ```
 
-After creating, call `session-rename_sync_branch` tool.
+After creating the worktree, call `session-rename_sync_branch`.
 
-**Branch types:** `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
+Branch types: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`


### PR DESCRIPTION
## Summary
- tighten `.agents/workflows/pre-edit.md` so the pre-edit workflow stays concise while preserving the required branch/worktree rules
- backfill `.agents/configs/simplification-state.json` for `.agents/workflows/pre-edit.md` so the simplification scanner stops reopening stale work on an already-processed file

## Testing
- `bunx markdownlint-cli2 ".agents/workflows/pre-edit.md"`
- `jq empty .agents/configs/simplification-state.json`

## Runtime Testing
- self-assessed: low-risk docs and metadata changes only
- Overall impact: no runtime behavior change

Closes #14832
${SIG_FOOTER}