### PR TITLE
GH#14836: fix deterministic pulse fill floor dispatch guard

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5198,6 +5198,41 @@ count_queued_without_worker() {
 }
 
 #######################################
+# Normalize noisy helper stdout to a numeric count.
+#
+# Some count helpers may emit diagnostic lines before their final numeric
+# result. Accept the last line that is purely an integer; otherwise fail closed
+# to 0.
+#
+# Arguments:
+#   $1 - raw helper stdout
+# Returns: normalized integer via stdout
+#######################################
+normalize_count_output() {
+	local raw_output="$1"
+	local normalized
+	normalized=$(printf '%s\n' "$raw_output" | awk '
+		/^[[:space:]]*[0-9]+[[:space:]]*$/ {
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+			last = $0
+		}
+		END {
+			if (last != "") {
+				print last
+			}
+		}
+	')
+
+	if [[ "$normalized" =~ ^[0-9]+$ ]]; then
+		echo "$normalized"
+		return 0
+	fi
+
+	echo "0"
+	return 0
+}
+
+#######################################
 # Recover issue state after launch validation failure (t1702)
 #
 # When launch validation fails, the issue may remain assigned + queued even
@@ -5426,19 +5461,13 @@ dispatch_deterministic_fill_floor() {
 	local max_workers active_workers available_slots runnable_count queued_without_worker
 	max_workers=$(get_max_workers_target)
 	active_workers=$(count_active_workers)
-	runnable_count=$(count_runnable_candidates)
-	queued_without_worker=$(count_queued_without_worker)
+	runnable_count=$(normalize_count_output "$(count_runnable_candidates)")
+	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)")
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
-	[[ "$runnable_count" =~ ^[0-9]+$ ]] || runnable_count=0
-	[[ "$queued_without_worker" =~ ^[0-9]+$ ]] || queued_without_worker=0
 
 	available_slots=$((max_workers - active_workers))
 	if [[ "$available_slots" -le 0 ]]; then
-		echo 0
-		return 0
-	fi
-	if [[ "$runnable_count" -eq 0 && "$queued_without_worker" -eq 0 ]]; then
 		echo 0
 		return 0
 	fi
@@ -5679,12 +5708,10 @@ maybe_refill_underfilled_pool_during_active_pulse() {
 	local max_workers active_workers runnable_count queued_without_worker
 	max_workers=$(get_max_workers_target)
 	active_workers=$(count_active_workers)
-	runnable_count=$(count_runnable_candidates)
-	queued_without_worker=$(count_queued_without_worker)
+	runnable_count=$(normalize_count_output "$(count_runnable_candidates)")
+	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)")
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
-	[[ "$runnable_count" =~ ^[0-9]+$ ]] || runnable_count=0
-	[[ "$queued_without_worker" =~ ^[0-9]+$ ]] || queued_without_worker=0
 
 	if [[ "$active_workers" -ge "$max_workers" || ("$runnable_count" -eq 0 && "$queued_without_worker" -eq 0) ]]; then
 		echo "$last_refill_epoch"
@@ -5802,10 +5829,8 @@ _compute_initial_underfill() {
 	fi
 
 	local runnable_count queued_without_worker
-	runnable_count=$(count_runnable_candidates)
-	queued_without_worker=$(count_queued_without_worker)
-	[[ "$runnable_count" =~ ^[0-9]+$ ]] || runnable_count=0
-	[[ "$queued_without_worker" =~ ^[0-9]+$ ]] || queued_without_worker=0
+	runnable_count=$(normalize_count_output "$(count_runnable_candidates)")
+	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)")
 	run_underfill_worker_recycler "$max_workers" "$active_workers" "$runnable_count" "$queued_without_worker"
 
 	# Re-check after recycler
@@ -5872,12 +5897,10 @@ _run_early_exit_recycle_loop() {
 		local post_max post_active post_runnable post_queued
 		post_max=$(get_max_workers_target)
 		post_active=$(count_active_workers)
-		post_runnable=$(count_runnable_candidates)
-		post_queued=$(count_queued_without_worker)
+		post_runnable=$(normalize_count_output "$(count_runnable_candidates)")
+		post_queued=$(normalize_count_output "$(count_queued_without_worker)")
 		[[ "$post_max" =~ ^[0-9]+$ ]] || post_max=1
 		[[ "$post_active" =~ ^[0-9]+$ ]] || post_active=0
-		[[ "$post_runnable" =~ ^[0-9]+$ ]] || post_runnable=0
-		[[ "$post_queued" =~ ^[0-9]+$ ]] || post_queued=0
 
 		if [[ "$post_active" -ge "$post_max" ]]; then
 			break
@@ -5892,11 +5915,9 @@ _run_early_exit_recycle_loop() {
 
 		dispatch_deterministic_fill_floor >/dev/null || true
 		post_active=$(count_active_workers)
-		post_runnable=$(count_runnable_candidates)
-		post_queued=$(count_queued_without_worker)
+		post_runnable=$(normalize_count_output "$(count_runnable_candidates)")
+		post_queued=$(normalize_count_output "$(count_queued_without_worker)")
 		[[ "$post_active" =~ ^[0-9]+$ ]] || post_active=0
-		[[ "$post_runnable" =~ ^[0-9]+$ ]] || post_runnable=0
-		[[ "$post_queued" =~ ^[0-9]+$ ]] || post_queued=0
 		if [[ "$post_active" -ge "$post_max" ]]; then
 			break
 		fi

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -806,6 +806,56 @@ test_dispatch_deterministic_fill_floor_honors_stop_flag() {
 	return 0
 }
 
+test_dispatch_deterministic_fill_floor_ignores_noisy_count_output() {
+	local dispatch_log="${TEST_ROOT}/deterministic-noisy-counts.log"
+	: >"$dispatch_log"
+
+	build_ranked_dispatch_candidates_json() {
+		printf '%s\n' '[
+		  {"number":9401,"repo_slug":"marcusquinn/aidevops","repo_path":"/tmp/aidevops","url":"https://github.com/marcusquinn/aidevops/issues/9401","title":"candidate one","labels":["bug"],"updatedAt":"2026-03-31T00:00:00Z","score":8000}
+		]'
+	}
+	get_max_workers_target() { echo 2; }
+	count_active_workers() { echo 0; }
+	count_runnable_candidates() {
+		printf 'DEBUG: prefetched runnable backlog\n'
+		echo 5
+	}
+	count_queued_without_worker() {
+		printf 'TRACE: queued scan complete\n'
+		echo 0
+	}
+	check_terminal_blockers() { return 1; }
+	dispatch_with_dedup() {
+		printf '%s\n' "$1" >>"$dispatch_log"
+		return 0
+	}
+	check_worker_launch() { return 0; }
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+			printf 'testuser\n'
+			return 0
+		fi
+		return 0
+	}
+	export -f gh
+
+	local dispatch_count dispatched_numbers
+	dispatch_count=$(dispatch_deterministic_fill_floor)
+	dispatched_numbers=$(tr '\n' ',' <"$dispatch_log" | sed 's/,$//')
+
+	unset -f gh build_ranked_dispatch_candidates_json get_max_workers_target count_active_workers count_runnable_candidates count_queued_without_worker check_terminal_blockers dispatch_with_dedup check_worker_launch
+
+	if [[ "$dispatch_count" == "1" && "$dispatched_numbers" == "9401" ]]; then
+		print_result "dispatch_deterministic_fill_floor ignores noisy count helper output" 0
+		return 0
+	fi
+
+	print_result "dispatch_deterministic_fill_floor ignores noisy count helper output" 1 \
+		"Expected count=1 and issue 9401; got count=${dispatch_count}, issues=${dispatched_numbers}"
+	return 0
+}
+
 test_active_pulse_refill_skips_without_idle_or_stall_signal() {
 	get_max_workers_target() { echo 4; }
 	count_active_workers() { echo 1; }
@@ -896,6 +946,7 @@ main() {
 	test_build_ranked_dispatch_candidates_json_respects_schedule_gate
 	test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity
 	test_dispatch_deterministic_fill_floor_honors_stop_flag
+	test_dispatch_deterministic_fill_floor_ignores_noisy_count_output
 	test_active_pulse_refill_skips_without_idle_or_stall_signal
 	test_active_pulse_refill_dispatches_when_underfilled_and_idle
 


### PR DESCRIPTION
## Summary
- normalize runnable and queued helper count output so deterministic dispatch ignores diagnostic noise and keeps numeric telemetry stable
- remove the pre-candidate zero-count early exit so ranked backlog candidates still dispatch when helper counts are noisy
- add regression coverage for noisy count helper output in deterministic fill-floor tests

## Testing
- `shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`

## Runtime Testing
- Level: runtime-verified
- Evidence: exercised the pulse wrapper shell code paths through the repository test harness, including a regression case where count helpers emit debug lines before their numeric result

Closes #14836

---
[aidevops.sh](https://aidevops.sh) v3.5.520 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 6m and 116,223 tokens on this with the user in an interactive session. Overall, 8m since this issue was created.