### PR TITLE
GH#14845: tighten landing page structure framework

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md
+++ b/.agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md
@@ -1,6 +1,6 @@
 # Landing Page Structure
 
-One goal, one CTA, one path. Every element moves the visitor toward that action.
+One goal, one CTA, one path.
 
 ## Length by Awareness Level
 
@@ -10,68 +10,31 @@ One goal, one CTA, one path. Every element moves the visitor toward that action.
 | Product Aware | Medium (500-1000) | Hero, Differentiation, Proof, Offer, CTA |
 | Solution Aware | Medium-Long (1000-2000) | Hero, Mechanism, Features, Proof, Offer, CTA |
 | Problem Aware | Long (2000-4000) | Hero, Problem, Agitate, Solution, Proof, Offer, CTA |
-| Unaware | Very Long (4000+) | Story-driven with full education |
+| Unaware | Very Long (4000+) | Story-driven full education |
 
 Less awareness = more education. Cold traffic needs longer pages.
 
 ## Universal Framework
 
-### 1. Hero (Above the Fold)
-
-Logo + minimal nav | Headline | Subheadline | Primary CTA | Trust bar + logos | Hero image/video/demo.
-
-- **Headline:** `[End Result] + [Time Period] + [Address Objection]` -- "Get More Qualified Leads in 30 Days -- Without Paid Ads"
-- **Subheadline:** `[Audience] use [Product] to [Benefit] so they can [Outcome]`
-
-### 2. Social Proof Bar
-
-Logo bar ("Trusted by teams at [logos]") | Stats ("10,000+ users | 4.8/5 on G2") | Results ("$47M+ revenue generated").
-
-### 3. Problem Agitation
-
-List 2-3 failed solutions ("You've tried [X], but [why it fails]"), then escalate: "Meanwhile, [negative consequence]. Every day this continues is [cost]."
-
-### 4. Solution Introduction
-
-"Introducing [Product]: The [category] that [key differentiator]. Unlike [competitors], [Product] uses [unique mechanism] to [achieve result] in [timeframe]."
-
-### 5. How It Works (3-5 steps)
-
-Format: `1. [Action] -> [Immediate result]` per step. Visual and scannable.
-
-### 6. Features -> Benefits -> Outcomes
-
-3-6 key features, each connecting: **Feature** (what it IS) -> **Benefit** (what it DOES) -> **Outcome** (how life changes).
-
-### 7. Deep Social Proof
-
-Testimonials with results (name, title, company + metric) | Case studies (challenge -> solution -> result with numbers) | Video testimonials (30-60s) | Review aggregators (G2, Capterra, TrustPilot) | Usage stats.
-
-### 8. Objection Handling (FAQ)
-
-Cover: "Right for my situation?" / "Worth the price?" / "Can I trust you?" / "What if it doesn't work?" / "Why now?"
-
-### 9. Pricing
-
-3-tier table (Starter / Professional / Enterprise). Mark one "Most Popular". Higher tiers inherit lower. CTA per tier. Anchor with higher price first. Include annual discount.
-
-### 10. Risk Reversal
-
-"Try [Product] Risk-Free. [Timeframe] money-back guarantee. If you don't [specific result], full refund."
-
-Types: money-back, results guarantee, free trial, performance guarantee.
-
-### 11. Final CTA
-
-Outcome headline ("Ready to [Desired Outcome]?") + social proof count ("Join [number] who [achieved result]") + CTA button + friction reducer ("no credit card required").
+| Section | Include | Formula / Notes |
+|---------|---------|-----------------|
+| Hero | Logo + minimal nav, headline, subheadline, primary CTA, trust bar, hero image/video/demo | Headline: `[End Result] + [Time Period] + [Address Objection]` -- "Get More Qualified Leads in 30 Days -- Without Paid Ads". Subheadline: `[Audience] use [Product] to [Benefit] so they can [Outcome]` |
+| Social proof bar | Logos, stats, result callouts | "Trusted by teams at [logos]" · "10,000+ users \| 4.8/5 on G2" · "$47M+ revenue generated" |
+| Problem agitation | 2-3 failed alternatives + escalating cost | "You've tried [X], but [why it fails]" -> "Meanwhile, [negative consequence]. Every day this continues is [cost]." |
+| Solution introduction | Product category, differentiator, mechanism, timeframe | "Introducing [Product]: The [category] that [key differentiator]. Unlike [competitors], [Product] uses [unique mechanism] to [achieve result] in [timeframe]." |
+| How it works | 3-5 visual steps | `1. [Action] -> [Immediate result]` per step |
+| Features -> benefits -> outcomes | 3-6 key features | **Feature** = what it is -> **Benefit** = what it does -> **Outcome** = how life changes |
+| Deep social proof | Testimonials, case studies, video, review widgets, usage stats | Testimonials need name, title, company, metric. Case studies: challenge -> solution -> result. Video testimonials: 30-60s. Review aggregators: G2, Capterra, TrustPilot |
+| Objection handling | FAQ for fit, trust, price, timing, risk | "Right for my situation?" · "Worth the price?" · "Can I trust you?" · "What if it doesn't work?" · "Why now?" |
+| Pricing | 3 tiers, one marked "Most Popular," CTA per tier | Starter / Professional / Enterprise. Higher tiers inherit lower. Anchor with higher price first. Include annual discount |
+| Risk reversal | Guarantee statement | "Try [Product] Risk-Free. [Timeframe] money-back guarantee. If you don't [specific result], full refund." Types: money-back, results guarantee, free trial, performance guarantee |
+| Final CTA | Outcome headline, social proof count, CTA, friction reducer | "Ready to [Desired Outcome]?" + "Join [number] who [achieved result]" + CTA + "no credit card required" |
 
 ## Best Practices
 
-**Writing:** Second person, sentences <20 words, 2-3 sentence paragraphs, subheads for skimming, active voice.
-
-**Visual:** One CTA style, F-pattern reading, whitespace, high-contrast buttons, mobile-first.
-
-**Avoid:** Competing CTAs, text walls, stock photos over product shots, vague headlines, features without benefits, missing social proof or risk reversal.
+- **Writing:** Second person, sentences <20 words, 2-3 sentence paragraphs, subheads for skimming, active voice
+- **Visual:** One CTA style, F-pattern reading, whitespace, high-contrast buttons, mobile-first
+- **Avoid:** Competing CTAs, text walls, stock photos over product shots, vague headlines, features without benefits, missing social proof, missing risk reversal
 
 ## Templates by Use Case
 
@@ -94,7 +57,7 @@ See [Templates](direct-response-copy-templates-landing-page.md) for copy-paste v
 | Conversion Rate | 2-5% (cold), 10-25% (warm) | Effectiveness |
 | CTA Click Rate | 3-5% | CTA compelling? |
 
-**Test:** Headline value props, CTA text/color, social proof type/placement, page length, form fields.
+Test headline value props, CTA text/color, social proof type/placement, page length, and form fields.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- condense the landing-page structure guide into a single scannable framework table
- preserve all formulas, section guidance, benchmarks, and related links while removing repetitive prose

## Testing
- `bunx markdownlint-cli2 ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md"`

## Runtime Testing
- self-assessed: docs-only markdown change

Closes #14845


---
[aidevops.sh](https://aidevops.sh) v3.5.520 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 3m on this as a headless worker.