### PR TITLE
GH#14179: tighten Cloudflare Zaraz agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/zaraz.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/zaraz.md
@@ -1,10 +1,10 @@
 # Cloudflare Zaraz
 
-Server-side tag manager: offloads third-party scripts (analytics, ads, chat) to Cloudflare's edge. Zero client-side JS overhead; single HTTP request for all tools; privacy-first data control.
+Server-side tag manager: offloads third-party scripts (analytics, ads, chat) to Cloudflare's edge. Zero client-side JS; single HTTP request for all tools; privacy-first data control.
 
 ## Setup
 
-Dashboard: domain > Zaraz > Start setup > add tools > configure triggers and actions. Config file (`zaraz.toml`):
+Dashboard: domain > Zaraz > Start setup > add tools > configure triggers/actions. Config (`zaraz.toml`):
 
 ```toml
 [settings]
@@ -28,7 +28,7 @@ zaraz.set('userId', 'user_12345');
 zaraz.set({ email: '[email protected]', country: 'US' });
 ```
 
-Tool-specific event names follow each platform's conventions (e.g. GA4: `sign_up`; Facebook Pixel: `Purchase`; Google Ads: `conversion` with `send_to`).
+Event names follow platform conventions (GA4: `sign_up`; Facebook Pixel: `Purchase`; Google Ads: `conversion` with `send_to`).
 
 Data layer: `window.zaraz.dataLayer = { user_id: '12345', page_type: 'product' }`. Access in triggers: `{{client.__zarazTrack.page_type}}`.
 
@@ -57,15 +57,7 @@ zaraz.consent.addEventListener('consentChanged', () => {
 
 ## Triggers
 
-| Type | Description |
-|------|-------------|
-| Pageview | Every page load |
-| DOM Ready | When DOM is ready |
-| Click | CSS selector match |
-| Form submission | Form submits |
-| Scroll depth | User scrolls % |
-| Timer | After elapsed time |
-| Variable match | Custom conditions |
+Types: Pageview, DOM Ready, Click (CSS selector), Form submission, Scroll depth (%), Timer, Variable match (custom conditions).
 
 Example: Trigger `Button Click` on `.buy-button` → action `Track event "purchase_intent"`.
 
@@ -93,15 +85,15 @@ zaraz.set('user_id', user.id);
 zaraz.track('login', { method: 'password' });
 ```
 
-For Workers integration patterns, see `cloudflare-workers` skill.
+For Workers integration, see `cloudflare-workers` skill.
 
 ## Privacy & Limits
 
-IP anonymization (automatic), consent-based cookie control, GDPR/CCPA compliance. Tools and events unlimited; request size 100 KB; data retention per tool's policy.
+Automatic IP anonymization, consent-based cookie control, GDPR/CCPA compliant. Tools/events unlimited; request size 100 KB; data retention per tool's policy.
 
 ## Debugging
 
-Enable debug mode in dashboard or `zaraz.debug = true`. Check: trigger conditions, tool enabled status, browser console, `zaraz.consent.getAll()` for consent issues.
+Enable debug: dashboard toggle or `zaraz.debug = true`. Check trigger conditions, tool enabled status, browser console, `zaraz.consent.getAll()` for consent issues.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/services/hosting/cloudflare-platform-skill/zaraz.md` (110 → 102 lines, 7% reduction)
- Convert triggers table to compact inline list (9 lines → 1 line — main savings)
- Remove filler words while preserving all technical content

## Changes

- **Triggers section**: Replaced 9-line markdown table with single-line comma-separated list. All trigger types and their descriptions preserved.
- **Prose tightening**: Compressed descriptive text across Setup, Web API, Privacy & Limits, and Debugging sections. No code blocks, URLs, command examples, or technical details removed.

## Content Preservation Verification

| Element | Original | Simplified |
|---------|----------|------------|
| Code blocks | 6 | 6 |
| URLs | 4 | 4 |
| Sections | 9 | 9 |
| Lines | 110 | 102 |

## Runtime Testing

- **Risk level**: Low (docs/agent prompts only)
- **Verification**: `self-assessed` — markdownlint clean, diff reviewed, all code blocks/URLs/section headings preserved

Closes #14179

---
[aidevops.sh](https://aidevops.sh) v3.5.520 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6 spent 3m on this as a headless worker.