### PR TITLE
GH#14217: split welcome email swipe file into chapters

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome-01-notion-casual-personal.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome-01-notion-casual-personal.md
@@ -1,0 +1,28 @@
+# Notion — Casual & Personal
+
+**Subject:** Welcome to Notion! 🎉
+
+```text
+Hey [Name],
+
+Welcome to Notion — you're in for a treat.
+
+Here are 3 things to try first:
+
+1. **Create your first page**
+   Just click "New Page" and start typing
+
+2. **Try a template**
+   Browse Templates → pick one that fits your work
+
+3. **Invite your team** (optional)
+   Everything's better with friends
+
+If you get stuck, hit reply. Real humans answer.
+
+– The Notion Team
+
+P.S. Pro tip: Use "/" to access any command instantly.
+```
+
+**Why it works:** Warm tone, 3 actionable steps, "Real humans answer" builds trust, P.S. delivers quick value.

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome-02-basecamp-personality-driven.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome-02-basecamp-personality-driven.md
@@ -1,0 +1,30 @@
+# Basecamp — Personality-Driven
+
+**Subject:** You made it! Here's what's next.
+
+```text
+Howdy,
+
+You've just joined thousands of teams who use Basecamp
+to get their best work done without the chaos.
+
+Here's the fastest way to see what Basecamp can do:
+
+Step 1: Create a project (takes 30 seconds)
+Step 2: Invite one teammate
+Step 3: Post your first message or to-do
+
+That's it. You'll "get it" after that.
+
+If you want a tour, we made a 3-minute video:
+[Watch the quick tour →]
+
+Questions? Just reply. I'm a real person
+and I love hearing from new customers.
+
+Cheers,
+Jonas
+Head of Support, Basecamp
+```
+
+**Why it works:** Specific steps with low commitment ("30 seconds"), video for different learners, real name + personality.

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome-03-copyblogger-lead-magnet-delivery.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome-03-copyblogger-lead-magnet-delivery.md
@@ -1,0 +1,33 @@
+# Copyblogger — Lead Magnet Delivery
+
+**Subject:** Your guide is here + what to read first
+
+```text
+Hey [Name],
+
+As promised, here's your copy of "Copywriting 101":
+
+[DOWNLOAD GUIDE]
+
+Here's what I recommend reading first:
+
+1. Chapter 3: Headlines That Hook
+   (This alone can 10x your clicks)
+
+2. Chapter 7: The PAS Formula
+   (Use this for every email you write)
+
+The whole guide is 45 pages, but those two chapters
+will give you the biggest bang for your time.
+
+Over the next few days, I'll share some bonus tips
+that aren't in the guide.
+
+Talk soon,
+[Name]
+
+P.S. Hit reply and tell me your biggest copywriting
+challenge. I read every response.
+```
+
+**Why it works:** Delivers the promise immediately, guides what to read (reduces overwhelm), sets expectation for future emails, engagement prompt.

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome.md
@@ -1,103 +1,24 @@
 # Welcome Emails
 
-High-converting welcome email examples with analysis.
+Reference corpus of annotated welcome email examples.
 
----
+## Chapters
 
-### 1. Notion — Casual & Personal
+| File | Contents |
+|------|----------|
+| [direct-response-copy-swipe-file-emails-01-welcome-01-notion-casual-personal.md](direct-response-copy-swipe-file-emails-01-welcome-01-notion-casual-personal.md) | Notion-style onboarding email with 3 first actions and a lightweight support cue |
+| [direct-response-copy-swipe-file-emails-01-welcome-02-basecamp-personality-driven.md](direct-response-copy-swipe-file-emails-01-welcome-02-basecamp-personality-driven.md) | Basecamp-style welcome email using fast activation steps, a tour offer, and a named sender |
+| [direct-response-copy-swipe-file-emails-01-welcome-03-copyblogger-lead-magnet-delivery.md](direct-response-copy-swipe-file-emails-01-welcome-03-copyblogger-lead-magnet-delivery.md) | Copyblogger-style delivery email that fulfills the opt-in promise and previews follow-up |
 
-**Subject:** Welcome to Notion! 🎉
+## Quick Comparison
 
-```
-Hey [Name],
+| Example | Primary job | Key pattern |
+|---------|-------------|-------------|
+| Notion | Get the user to first value fast | Three simple first steps + helpful P.S. |
+| Basecamp | Reduce activation friction | Tiny setup sequence + real-person signoff |
+| Copyblogger | Deliver a lead magnet and set expectations | Immediate fulfillment + guided next steps |
 
-Welcome to Notion — you're in for a treat.
+## Notes
 
-Here are 3 things to try first:
-
-1. **Create your first page**
-   Just click "New Page" and start typing
-
-2. **Try a template**
-   Browse Templates → pick one that fits your work
-
-3. **Invite your team** (optional)
-   Everything's better with friends
-
-If you get stuck, hit reply. Real humans answer.
-
-– The Notion Team
-
-P.S. Pro tip: Use "/" to access any command instantly.
-```
-
-**Why it works:** Warm tone, 3 actionable steps, "Real humans answer" builds trust, P.S. delivers quick value.
-
----
-
-### 2. Basecamp — Personality-Driven
-
-**Subject:** You made it! Here's what's next.
-
-```
-Howdy,
-
-You've just joined thousands of teams who use Basecamp
-to get their best work done without the chaos.
-
-Here's the fastest way to see what Basecamp can do:
-
-Step 1: Create a project (takes 30 seconds)
-Step 2: Invite one teammate
-Step 3: Post your first message or to-do
-
-That's it. You'll "get it" after that.
-
-If you want a tour, we made a 3-minute video:
-[Watch the quick tour →]
-
-Questions? Just reply. I'm a real person 
-and I love hearing from new customers.
-
-Cheers,
-Jonas
-Head of Support, Basecamp
-```
-
-**Why it works:** Specific steps with low commitment ("30 seconds"), video for different learners, real name + personality.
-
----
-
-### 3. Copyblogger — Lead Magnet Delivery
-
-**Subject:** Your guide is here + what to read first
-
-```
-Hey [Name],
-
-As promised, here's your copy of "Copywriting 101":
-
-[DOWNLOAD GUIDE]
-
-Here's what I recommend reading first:
-
-1. Chapter 3: Headlines That Hook
-   (This alone can 10x your clicks)
-
-2. Chapter 7: The PAS Formula
-   (Use this for every email you write)
-
-The whole guide is 45 pages, but those two chapters 
-will give you the biggest bang for your time.
-
-Over the next few days, I'll share some bonus tips 
-that aren't in the guide.
-
-Talk soon,
-[Name]
-
-P.S. Hit reply and tell me your biggest copywriting 
-challenge. I read every response.
-```
-
-**Why it works:** Delivers the promise immediately, guides what to read (reduces overwhelm), sets expectation for future emails, engagement prompt.
+- Use this index when you want a fast pattern-level comparison.
+- Open the chapter files for the full email copy and the original analysis.


### PR DESCRIPTION
## Summary
- Convert the welcome email swipe file into a slim index because this file is a reference corpus, not an instruction doc.
- Preserve each annotated example in its own chapter file and add a quick comparison table for fast scanning.

## Testing
- `bunx markdownlint-cli2 ".agents/marketing-sales/direct-response-copy-swipe-file-emails-01-welcome*.md"`
- Verified the new chapter links resolve locally.
- Checked representative original phrases remain present across the new chapter files.

## Runtime Testing
- Level: self-assessed
- Reason: low-risk markdown-only reference corpus change.

Closes #14217

---
[aidevops.sh](https://aidevops.sh) v3.5.520 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 6m and 100,190 tokens on this as a headless worker.