### PR TITLE
GH#14316: tighten Bitwarden CLI integration doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3130,6 +3130,11 @@
       "hash": "9e140122413dbbd69a12a6c545c7df84b07f448a",
       "at": "2026-03-31T09:56:41Z",
       "pr": 14785
+    },
+    ".agents/tools/credentials/bitwarden.md": {
+      "hash": "2383188cabb629a721c7dfef63da8ab43b52b44e",
+      "at": "2026-03-31T11:51:54Z",
+      "pr": 14867
     }
   }
 }

--- a/.agents/tools/credentials/bitwarden.md
+++ b/.agents/tools/credentials/bitwarden.md
@@ -14,69 +14,52 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Manage credentials via Bitwarden's official CLI (`bw`)
+- **Purpose**: Manage credentials with Bitwarden's official CLI (`bw`)
 - **Install**: `brew install bitwarden-cli` or `npm install -g @bitwarden/cli`
 - **Docs**: https://bitwarden.com/help/cli/
-- **Auth**: `bw login` (interactive) or `BW_SESSION` env var
+- **Auth**: `bw login` or `BW_SESSION`
 
-**When to use**: Retrieving passwords/secrets for automation, syncing credentials across environments, bulk credential operations.
+**When to use**: Retrieve passwords for automation, sync vault state, run bulk item operations.
 
 <!-- AI-CONTEXT-END -->
 
 ## Setup
 
 ```bash
-# Install
 brew install bitwarden-cli
 # or
 npm install -g @bitwarden/cli
 
-# Login and unlock
 bw login
 export BW_SESSION=$(bw unlock --raw)
-
-# Verify
 bw status | jq .
 ```
 
 ## Common Commands
 
 ```bash
-# Search for items
 bw list items --search "github"
-
-# Get specific item
 bw get item "GitHub Token" | jq -r '.login.password'
-
-# Get TOTP code
 bw get totp "GitHub"
-
-# Create item
 bw create item "$(bw get template item | jq '.name="New Item" | .login.username="user" | .login.password="pass"')"
-
-# Sync vault
 bw sync
 ```
 
 ## Automation Patterns
 
 ```bash
-# Non-interactive session (for scripts)
 export BW_SESSION=$(bw unlock --passwordenv BW_PASSWORD --raw)
 
-# Retrieve secret for deployment
 DB_PASSWORD=$(bw get item "Production DB" | jq -r '.login.password')
-
-# List all items in a folder
 bw list items --folderid "$(bw get folder 'Servers' | jq -r '.id')"
 ```
 
 ## Security Notes
 
-- Never store `BW_SESSION` in files -- use env vars only
-- Session tokens expire after inactivity (configurable)
-- Use `bw lock` when done with automation
-- For server/CI use: Bitwarden Secrets Manager (`bws`) is preferred over vault CLI
+- Keep `BW_SESSION` in env vars only
+- Session tokens expire after inactivity
+- Run `bw lock` when automation finishes
+- For server or CI use, prefer Bitwarden Secrets Manager (`bws`)
 
 ## Related
 


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/credentials/bitwarden.md` by compressing setup, command, and automation examples without removing Bitwarden CLI guidance
- preserve the quick reference, security notes, related links, and all documented commands while removing repetitive prose
- record the new hash in `.agents/configs/simplification-state.json` so the simplification scanner tracks this file correctly

## Runtime Testing
- level: self-assessed (agent doc and scanner state only)
- verification:
  - `bunx markdownlint-cli2 .agents/tools/credentials/bitwarden.md`
  - `python3 -m json.tool .agents/configs/simplification-state.json >/dev/null`

Closes #14316


---
[aidevops.sh](https://aidevops.sh) v3.5.520 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 4m on this as a headless worker.
