### PR TITLE
GH#14180: tighten email-design-test.md

### DIFF
--- a/.agents/scripts/commands/email-design-test.md
+++ b/.agents/scripts/commands/email-design-test.md
@@ -4,23 +4,15 @@ agent: Build+
 mode: subagent
 ---
 
-Run email design tests locally (HTML validation, CSS compatibility, accessibility, images, links) and optionally submit to Email on Acid for real-client rendering screenshots.
+Run local email design tests (HTML, CSS, accessibility, images, links) and optionally submit to Email on Acid (EOA) for real-client rendering.
 
 Arguments: $ARGUMENTS
 
-## Workflow
+## Dispatch
 
-### Step 1: Determine Test Mode
+Parse `$ARGUMENTS`: HTML file path → local tests; `eoa` prefix → EOA API commands; empty/help → show usage.
 
-Parse `$ARGUMENTS` to determine what to run:
-
-- If argument is an HTML file path: run local design tests
-- If argument starts with "eoa": run Email on Acid API commands
-- If argument is "help" or empty: show available commands
-
-### Step 2: Run Appropriate Tests
-
-**Local design tests (no API key needed):**
+**Local tests (no API key):**
 
 ```bash
 ~/.aidevops/agents/scripts/email-design-test-helper.sh test "$ARGUMENTS"
@@ -32,33 +24,19 @@ Parse `$ARGUMENTS` to determine what to run:
 ~/.aidevops/agents/scripts/email-design-test-helper.sh eoa-test "$ARGUMENTS"
 ```
 
-**Sandbox mode (no API key needed):**
+**Sandbox mode (no API key):**
 
 ```bash
 ~/.aidevops/agents/scripts/email-design-test-helper.sh eoa-sandbox "$ARGUMENTS"
 ```
 
-### Step 3: Present Results
+## Output
 
-Format the output as a clear report with:
+Present results as a report: local test results (HTML, CSS, dark mode, responsive, accessibility, images, links), EOA screenshots grouped by client category, issues with severity, actionable recommendations.
 
-- Local test results (HTML, CSS, dark mode, responsive, accessibility, images, links)
-- EOA rendering screenshots grouped by client category (Application, Mobile, Web)
-- Issues highlighted with severity
-- Actionable recommendations
+Follow-up actions: full health check (`email-health-check-helper.sh`), view client screenshot, reprocess failures, get inlined CSS, run delivery/placement tests.
 
-### Step 4: Offer Follow-up Actions
-
-```text
-Actions:
-1. Run full health check (email-health-check-helper.sh)
-2. View specific client screenshot
-3. Reprocess failed screenshots
-4. Get inlined CSS version
-5. Run delivery/placement tests
-```
-
-## Options
+## Commands
 
 | Command | Purpose |
 |---------|---------|
@@ -67,41 +45,6 @@ Actions:
 | `/email-design-test eoa-test newsletter.html "Subject" outlook16,gmail_chr26_win` | Full EOA test with specific clients |
 | `/email-design-test eoa-results abc123` | Get results for existing test |
 | `/email-design-test eoa-clients` | List available email clients |
-
-## Examples
-
-**Local design test:**
-
-```text
-User: /email-design-test newsletter.html
-AI: Running local design tests on newsletter.html...
-
-    HTML Structure: OK (2 warnings)
-    CSS Compatibility: 1 issue (flexbox in Outlook)
-    Dark Mode: OK
-    Responsive: OK
-    Accessibility: 1 warning (missing role="presentation")
-    Images: OK (3 images, all with dimensions)
-    Links: OK (12 links, all HTTPS)
-    Preheader: Detected
-
-    For real-client rendering: eoa-test newsletter.html
-```
-
-**EOA sandbox test:**
-
-```text
-User: /email-design-test eoa-sandbox newsletter.html
-AI: Running sandbox test (no actual screenshots)...
-
-    Local Tests: Passed (2 warnings)
-    EOA Test Created: sandbox-abc123
-    Status: Sandbox mode - no actual rendering
-
-    To run real tests, configure EOA API credentials:
-    aidevops secret set EOA_API_KEY
-    aidevops secret set EOA_API_PASSWORD
-```
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/email-design-test.md` from 110 → 53 lines (52% reduction)
- Merge 4 verbose workflow steps into 2 focused sections (Dispatch + Output)
- Remove example transcripts that duplicated the commands table

## What changed

| Aspect | Before | After |
|--------|--------|-------|
| Lines | 110 | 53 |
| Workflow steps | 4 numbered steps | 2 sections |
| Example transcripts | 2 (34 lines) | 0 (commands table sufficient) |
| Follow-up actions | Code block | Inline prose |

## Preserved

- All 3 helper script command blocks (`test`, `eoa-test`, `eoa-sandbox`)
- Full commands table (5 entries, identical)
- All 3 related links
- YAML frontmatter
- Argument parsing logic

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdown lint clean, content preservation verified

Closes #14180


---
[aidevops.sh](https://aidevops.sh) v3.5.520 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6