### PR TITLE
GH#14190: tighten agent doc fallback-chains.md

### DIFF
--- a/.agents/tools/ai-assistants/fallback-chains.md
+++ b/.agents/tools/ai-assistants/fallback-chains.md
@@ -26,13 +26,11 @@ tools:
 
 ## Overview
 
-The fallback system uses a **data-driven routing table** (JSON) that AI reads directly to understand available models per tier. The bash script only checks model availability — all routing decisions (which model to try, when to fall back, cooldown logic) are made by the AI agent.
-
-This follows the **Intelligence Over Scripts** principle: deterministic utilities (health checks) stay in bash; judgment calls (routing priority, error recovery) belong to the AI.
+Data-driven routing table (JSON) that AI reads directly. The bash script only checks availability — all routing decisions (which model to try, when to fall back, error recovery) are made by the AI agent, not bash. Follows the **Intelligence Over Scripts** principle.
 
 ## Routing Table
 
-The routing table at `configs/model-routing-table.json` defines models per tier:
+`configs/model-routing-table.json` defines models per tier:
 
 ```json
 {
@@ -50,26 +48,20 @@ Tiers: `haiku`, `flash`, `sonnet`, `pro`, `opus`, `coding`, `eval`, `health`
 ## CLI Usage
 
 ```bash
-# Resolve best available model for a tier
 fallback-chain-helper.sh resolve coding
 fallback-chain-helper.sh resolve sonnet --json --quiet
-
-# Print the full routing table
 fallback-chain-helper.sh table
-
-# Help
 fallback-chain-helper.sh help
 ```
 
 ## How Resolution Works
 
-1. Script reads the routing table for the requested tier
-2. Walks the model list in order
-3. For each model, checks provider availability via `model-availability-helper.sh`
-4. Returns the first available model
-5. If all models exhausted, returns exit code 1
+1. Read routing table for the requested tier
+2. Walk model list in order
+3. Check each model via `model-availability-helper.sh`
+4. Return first available model; exit code 1 if all exhausted
 
-No cooldowns, triggers, gateway probing, or SQLite database. The AI handles error recovery and routing decisions using the routing table as reference data.
+No cooldowns, triggers, gateway probing, or SQLite database.
 
 ## Integration
 
@@ -83,7 +75,7 @@ No cooldowns, triggers, gateway probing, or SQLite database. The AI handles erro
 
 ### AI Agent Usage
 
-AI agents read `model-routing.md` for routing rules and the routing table for available models. When a provider fails at runtime, the AI decides the next action (retry, fall back, escalate) — not bash.
+AI agents read `model-routing.md` for routing rules and the routing table for available models. Runtime failures → AI decides next action (retry, fall back, escalate).
 
 ## Migration from v1
 


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/tools/ai-assistants/fallback-chains.md` (108 → 100 lines, -7%).

### Changes

- **Overview**: Merged two paragraphs stating the same thing into one sentence
- **Routing Table**: Removed verbose "The routing table at" prefix
- **CLI Usage**: Removed 3 "what" comments that restated the next line
- **How Resolution Works**: Tightened 5-item list to 4 items; removed trailing sentence that restated Overview
- **AI Agent Usage**: Tightened final sentence

### Content Preservation

All preserved:
- Code blocks (JSON routing table example, bash CLI examples)
- File paths (`configs/model-routing-table.json`, `scripts/fallback-chain-helper.sh`, etc.)
- Command examples (`resolve`, `table`, `help` with all flags)
- Integration table (all 3 callers, functions, and call patterns)
- Migration from v1 section (all 6 removed items, all 3 kept items)
- Related links section

### Runtime Testing

Risk level: **Low** — docs-only change, no code modified.
Self-assessed: no runtime verification required per testing gate.

Closes #14190


---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-sonnet-4-6 spent 10m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity of AI fallback chain documentation with enhanced descriptions of routing behavior and model selection processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->