### PR TITLE
GH#14885: tighten Socket MCP agent doc

### DIFF
--- a/.agents/services/monitoring/socket.md
+++ b/.agents/services/monitoring/socket.md
@@ -31,7 +31,7 @@ mcp:
 ## Setup
 
 1. Sign up at [socket.dev](https://socket.dev). GitHub connection is optional for repo scans.
-2. Go to Settings → API Tokens, create a token, and grant Full Access if available.
+2. Create an API token in Settings → API Tokens. Grant Full Access if available.
 3. Save the token:
 
 ```bash
@@ -47,7 +47,7 @@ jq '.mcp.socket = {"type": "remote", "url": "https://mcp.socket.dev/", "enabled"
 ```
 
 5. If API-token auth fails, complete the browser OAuth flow on first use.
-6. Test connection:
+6. Test the token:
 
 ```bash
 source ~/.config/aidevops/credentials.sh
@@ -56,12 +56,10 @@ curl -s -H "Authorization: Bearer $SOCKET_YOURNAME" "https://api.socket.dev/v0/o
 
 ## MCP Tools
 
-| Tool | Description |
-|------|-------------|
-| `scan_package` | Scan a specific package for issues |
-| `scan_repo` | Scan a repository's dependencies |
-| `get_package_info` | Get security info for a package |
-| `list_issues` | List known issues in dependencies |
+- `scan_package` — scan a package for issues
+- `scan_repo` — scan repository dependencies
+- `get_package_info` — fetch package security data
+- `list_issues` — list known dependency issues
 
 ## Example prompts
 
@@ -97,11 +95,12 @@ socket npm info lodash
 
 ### MCP not connecting
 
-`mcp.socket.dev` may require browser OAuth instead of API-token auth. Start the MCP and complete the prompt if shown.
+- `mcp.socket.dev` may require browser OAuth instead of API-token auth
+- Start the MCP and complete the prompt if shown
 
 ### Rate limits
 
-Free tier requests are rate-limited. Upgrade if scans are throttled.
+- Free tier requests are rate-limited; upgrade if scans are throttled
 
 ## Related
 


### PR DESCRIPTION
## Summary
- tighten the Socket MCP setup wording so the setup steps read as a shorter reference card
- replace the MCP tool table with concise bullets and compress troubleshooting guidance without dropping commands or links
- note the issue was opened against the pre-#14882 version; this PR applies a smaller follow-up tighten on the current file

## Testing
- `bunx markdownlint-cli2 ".agents/services/monitoring/socket.md"`
- reviewed the diff to confirm all URLs, commands, and prompt examples remain present

## Runtime Testing
- self-assessed
- low risk: documentation-only change to an agent markdown file

Closes #14885
---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 10m on this as a headless worker.