### PR TITLE
GH#14887: tighten Remotion 3D doc

### DIFF
--- a/.agents/tools/video/remotion-3d.md
+++ b/.agents/tools/video/remotion-3d.md
@@ -6,13 +6,9 @@ metadata:
   tags: 3d, three, threejs
 ---
 
-# Using Three.js and React Three Fiber in Remotion
+Follow normal React Three Fiber / Three.js practices, plus these Remotion-specific rules.
 
-Follow normal React Three Fiber / Three.js practices. Apply these Remotion-specific rules.
-
-## Prerequisites
-
-Install `@remotion/three` first.
+## Install `@remotion/three`
 
 ```bash
 npx remotion add @remotion/three # If project uses npm
@@ -41,11 +37,11 @@ const { width, height } = useVideoConfig();
 </ThreeCanvas>
 ```
 
-## Drive all animation from `useCurrentFrame()`
+## Animation rule
 
-Shaders, models, and other scene elements must not animate on their own. Drive every animation from `useCurrentFrame()` or renders will flicker.
+Drive all animation from `useCurrentFrame()`. Shaders, models, and other scene elements must not animate on their own or renders may flicker.
 
-`useFrame()` from `@react-three/fiber` is forbidden.
+Never use `useFrame()` from `@react-three/fiber`.
 
 ## Animation example
 


### PR DESCRIPTION
## Summary
- remove redundant title and prerequisite wording from the Remotion 3D agent doc
- tighten the animation guidance while preserving the `useCurrentFrame()` and `useFrame()` constraints
- keep all install commands and code examples intact while reducing doc length from 80 to 76 lines

## Runtime Testing
- Level: self-assessed
- Reason: doc-only agent guidance change; no runtime path changed
- Verification: `bunx markdownlint-cli2 ".agents/tools/video/remotion-3d.md"`

Closes #14887
---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4