### PR TITLE
GH#14191: tighten Bing Webmaster Tools agent doc

### DIFF
--- a/.agents/seo/bing-webmaster-tools.md
+++ b/.agents/seo/bing-webmaster-tools.md
@@ -16,74 +16,66 @@ tools:
 
 ## Quick Reference
 
-- **Primary access**: Direct API via `curl`
-- **API Endpoint**: `https://ssl.bing.com/webmaster/api.svc/json/`
-- **Auth**: API Key as query param `apikey`
+- **API Base**: `https://ssl.bing.com/webmaster/api.svc/json/`
+- **Auth**: query param `apikey=$BING_API_KEY`
 - **Credentials**: `~/.config/aidevops/credentials.sh` → `BING_API_KEY`
-- **Capabilities**: Submit URLs, URL inspection, search analytics, sitemap management
 - **Docs**: [Bing Webmaster API](https://www.bing.com/webmasters/help/webmaster-api-5f3c5e1e)
 
 ## Setup
 
-1. Log in to [Bing Webmaster Tools](https://www.bing.com/webmasters/) → **Settings** → **API Access** → **Generate API Key**
-2. Add to `~/.config/aidevops/credentials.sh`:
-
-```bash
-export BING_API_KEY="your_api_key_here"
-```
-
+1. [Bing Webmaster Tools](https://www.bing.com/webmasters/) → **Settings** → **API Access** → **Generate API Key**
+2. Add `export BING_API_KEY="your_api_key_here"` to `~/.config/aidevops/credentials.sh`
 3. `source ~/.config/aidevops/credentials.sh`
 
 ## API Operations
 
+Base: `BASE="https://ssl.bing.com/webmaster/api.svc/json"`
+
 ### Submit URL
 
 ```bash
-curl -s -X POST "https://ssl.bing.com/webmaster/api.svc/json/SubmitUrl?apikey=$BING_API_KEY" \
+curl -s -X POST "$BASE/SubmitUrl?apikey=$BING_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"siteUrl": "https://example.com", "url": "https://example.com/new-page"}'
 ```
 
-### Batch Submit URLs (up to 10,000/day)
+### Batch Submit (up to 10,000/day)
 
 ```bash
-curl -s -X POST "https://ssl.bing.com/webmaster/api.svc/json/SubmitUrlBatch?apikey=$BING_API_KEY" \
+curl -s -X POST "$BASE/SubmitUrlBatch?apikey=$BING_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "siteUrl": "https://example.com",
-    "urlList": ["https://example.com/page1", "https://example.com/page2"]
-  }'
+  -d '{"siteUrl": "https://example.com", "urlList": ["https://example.com/page1", "https://example.com/page2"]}'
 ```
 
 ### URL Inspection
 
 ```bash
-curl -s -G "https://ssl.bing.com/webmaster/api.svc/json/GetUrlInfo" \
+curl -s -G "$BASE/GetUrlInfo" \
   --data-urlencode "apikey=$BING_API_KEY" \
   --data-urlencode "siteUrl=https://example.com" \
   --data-urlencode "url=https://example.com/page"
 ```
 
-### Search Analytics (Query Stats)
+### Search Analytics
 
 ```bash
-curl -s -X POST "https://ssl.bing.com/webmaster/api.svc/json/GetQueryStats?apikey=$BING_API_KEY" \
+curl -s -X POST "$BASE/GetQueryStats?apikey=$BING_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"siteUrl": "https://example.com", "startDate": "2025-01-01", "endDate": "2025-01-31"}'
 ```
 
-### Sitemap — Submit
+### Sitemap Submit
 
 ```bash
-curl -s -X POST "https://ssl.bing.com/webmaster/api.svc/json/SubmitFeed?apikey=$BING_API_KEY" \
+curl -s -X POST "$BASE/SubmitFeed?apikey=$BING_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"siteUrl": "https://example.com", "feedUrl": "https://example.com/sitemap.xml"}'
 ```
 
-### Sitemap — List
+### Sitemap List
 
 ```bash
-curl -s -G "https://ssl.bing.com/webmaster/api.svc/json/GetFeedStats" \
+curl -s -G "$BASE/GetFeedStats" \
   --data-urlencode "apikey=$BING_API_KEY" \
   --data-urlencode "siteUrl=https://example.com"
 ```
@@ -92,17 +84,13 @@ curl -s -G "https://ssl.bing.com/webmaster/api.svc/json/GetFeedStats" \
 
 | Error | Cause / Fix |
 |-------|-------------|
-| HTTP 400 | Bad JSON syntax, or `siteUrl` doesn't match registered site (check http/https, www/non-www) |
+| HTTP 400 | Bad JSON or `siteUrl` mismatch (check http/https, www/non-www) |
 | HTTP 401 | `BING_API_KEY` incorrect or revoked |
-| HTTP 500 | Transient — retry; check Bing Webmaster Tools status |
-| Quota exceeded | `SubmitUrl` limit: 10,000 URLs/day/site. Crawl rate depends on site authority. |
+| HTTP 500 | Transient — retry |
+| Quota exceeded | 10,000 URLs/day/site limit |
 
 <!-- AI-CONTEXT-END -->
 
 ## Integration with SEO Audit
 
-Used by `seo-audit-skill` for cross-engine verification:
-
-1. Check GSC for index status
-2. Check Bing for index status
-3. Compare to identify engine-specific issues
+Used by `seo-audit-skill` for cross-engine verification: check GSC index status, check Bing index status, compare for engine-specific issues.


### PR DESCRIPTION
## Summary

- Tighten `.agents/seo/bing-webmaster-tools.md` from 108 to 96 lines (11% reduction)
- Extract repeated API base URL into a $BASE variable reference across all 6 code blocks
- Condense Quick Reference by removing redundant "Primary access" and "Capabilities" bullets
- Inline Setup step 2 code block into a single line
- Tighten troubleshooting table entries (remove verbose explanations)
- Collapse Integration section from numbered list to single-line prose

## Content Preservation

All 6 API operations preserved: SubmitUrl, SubmitUrlBatch, GetUrlInfo, GetQueryStats, SubmitFeed, GetFeedStats. All code blocks, URLs, `BING_API_KEY` references, and troubleshooting entries intact. Zero markdown lint violations.

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only, no code execution paths)
- **Verification**: `self-assessed` — markdown lint clean, content preservation verified via rg counts

Closes #14191


---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6