### PR TITLE
GH#14400: tighten DO Storage agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage.md
@@ -1,60 +1,55 @@
 # Cloudflare Durable Objects Storage
 
-Persistent storage API for Durable Objects with SQLite and KV backends, PITR, and automatic concurrency control.
+Persistent storage API for Durable Objects — SQLite/KV backends, PITR, automatic concurrency gates.
 
-## Overview
+**Use cases:** Stateful coordination, real-time collaboration, counters, sessions, rate limiters.
 
-DO Storage provides:
-- SQLite-backed (recommended) or KV-backed
-- SQL API + synchronous/async KV APIs
-- Automatic input/output gates (race-free)
-- 30-day point-in-time recovery (PITR)
-- Transactions and alarms
+## Storage Backends
 
-**Use cases:** Stateful coordination, real-time collaboration, counters, sessions, rate limiters
+| Backend | Wrangler Config | APIs | PITR |
+|---------|-----------------|------|------|
+| SQLite (recommended) | `new_sqlite_classes` | SQL + sync KV + async KV | ✅ |
+| KV (legacy) | `new_classes` | async KV only | ❌ |
+
+## Core APIs
+
+| API | Access | Notes |
+|-----|--------|-------|
+| SQL | `ctx.storage.sql` | Full SQLite (FTS5, JSON, math) |
+| Sync KV | `ctx.storage.kv` | SQLite-backed only |
+| Async KV | `ctx.storage` | Both backends |
+| Transactions | `transactionSync()` / `transaction()` | Never use raw `BEGIN`/`COMMIT` |
+| PITR | `getBookmarkForTime()` | 30-day point-in-time recovery |
+| Alarms | `setAlarm()` + `alarm()` handler | Must `deleteAlarm()` separately from `deleteAll()` |
 
 ## Quick Start
 
 ```typescript
 export class Counter extends DurableObject {
   sql: SqlStorage;
-  
+
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
-    this.sql.exec('CREATE TABLE IF NOT EXISTS data(key TEXT PRIMARY KEY, value INTEGER)');
+    this.sql.exec("CREATE TABLE IF NOT EXISTS data(key TEXT PRIMARY KEY, value INTEGER)");
   }
-  
+
   async increment(): Promise<number> {
-    this.sql.exec('INSERT OR REPLACE INTO data VALUES (?, ?) RETURNING value', 'counter', 
-      (this.sql.exec('SELECT value FROM data WHERE key = ?', 'counter').one()?.value || 0) + 1);
+    const row = this.sql.exec("SELECT value FROM data WHERE key = ?", "counter").one();
+    const next = ((row?.value as number) || 0) + 1;
+    this.sql.exec("INSERT OR REPLACE INTO data VALUES (?, ?)", "counter", next);
+    return next;
   }
 }
 ```
 
-## Storage Backends
+## Related Files
 
-| Backend | Create Method | APIs | PITR |
-|---------|---------------|------|------|
-| SQLite (recommended) | `new_sqlite_classes` | SQL + sync KV + async KV | ✅ |
-| KV (legacy) | `new_classes` | async KV only | ❌ |
-
-## Core APIs
-
-- **SQL API** (`ctx.storage.sql`): Full SQLite with extensions (FTS5, JSON, math)
-- **Sync KV** (`ctx.storage.kv`): Synchronous key-value (SQLite only)
-- **Async KV** (`ctx.storage`): Asynchronous key-value (both backends)
-- **Transactions** (`transactionSync()`, `transaction()`)
-- **PITR** (`getBookmarkForTime()`, `onNextSessionRestoreBookmark()`)
-- **Alarms** (`setAlarm()`, `alarm()` handler)
-
-## In This Reference
-
-- [patterns.md](./patterns.md) - Schema migrations, caching, rate limiting, batch processing
-- [gotchas.md](./gotchas.md) - Concurrency gates, transaction rules, SQL limits, async pitfalls
+- [do-storage-patterns.md](./do-storage-patterns.md) — schema migrations, caching, rate limiting, batch processing
+- [do-storage-gotchas.md](./do-storage-gotchas.md) — concurrency gates, transaction rules, SQL limits, async pitfalls
 
 ## See Also
 
-- [durable-objects](../durable-objects/) - DO fundamentals and coordination patterns
-- [workers](../workers/) - Worker runtime for DO stubs
-- [d1](../d1/) - Shared database alternative to per-DO storage
+- [durable-objects.md](./durable-objects.md) — DO fundamentals and coordination patterns
+- [workers.md](./workers.md) — Worker runtime for DO stubs
+- [d1.md](./d1.md) — shared database alternative to per-DO storage


### PR DESCRIPTION
## Summary

- Tighten `.agents/services/hosting/cloudflare-platform-skill/do-storage.md` (60 → 55 lines)
- Fix broken internal links (`./patterns.md` → `./do-storage-patterns.md`, `./gotchas.md` → `./do-storage-gotchas.md`)
- Fix broken See Also links to use flat naming convention (`../durable-objects/` → `./durable-objects.md`)
- Convert Core APIs from bullet list to table with gotcha notes surfaced in index
- Fix Quick Start code: add missing `return` statement, split complex one-liner into readable steps
- Compress Overview into subtitle, rename "In This Reference" → "Related Files"

Closes #14400

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** `self-assessed` — markdownlint clean, all internal links verified against `git ls-files`


---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6