### PR TITLE
GH#14401: tighten agent doc worktree-cleanup.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3140,6 +3140,11 @@
       "hash": "7123b1f29ba3cba9eedf7f7f19f04c561c73a353",
       "at": "2026-03-31T12:08:05Z",
       "pr": 14883
+    },
+    ".agents/scripts/commands/worktree-cleanup.md": {
+      "hash": "380299466e05179c628e6989550697c01accb722",
+      "at": "2026-03-31T13:00:00Z",
+      "pr": 0
     }
   }
 }

--- a/.agents/scripts/commands/worktree-cleanup.md
+++ b/.agents/scripts/commands/worktree-cleanup.md
@@ -1,10 +1,10 @@
 # Worktree Cleanup After Merge
 
-After a PR is merged, clean up the linked worktree and return the canonical repo to a clean state.
+Clean up the linked worktree and return the canonical repo to a clean state after a PR merge.
 
-## Automated Cleanup (workers — GH#6740)
+## Automated (workers — GH#6740)
 
-Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (Step 4.8). This prevents worktree accumulation during batch dispatch.
+Workers MUST self-cleanup after merge (full-loop Step 4.9). Prevents worktree accumulation during batch dispatch.
 
 ```bash
 # After gh pr merge --squash succeeds:
@@ -12,7 +12,6 @@ WORKTREE_PATH="$(pwd)"
 BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 CANONICAL_DIR="${WORKTREE_PATH%%.*}"
 
-# Return to canonical repo, pull, remove worktree
 cd "$CANONICAL_DIR" || cd "$HOME"
 git pull origin main 2>/dev/null || true
 
@@ -28,33 +27,24 @@ git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
 git branch -D "$BRANCH_NAME" 2>/dev/null || true
 ```
 
-Cleanup failures are non-fatal — the PR is already merged. The pulse `cleanup_worktrees()` stage acts as a safety net for any worktrees workers fail to clean up.
+Cleanup failures are non-fatal — the PR is already merged. The pulse `cleanup_worktrees()` acts as a safety net.
 
-## Manual Cleanup (interactive sessions)
+## Manual (interactive sessions)
 
 ```bash
-# Merge the PR without --delete-branch (required when working from a worktree)
-gh pr merge --squash
-
-# Return to the canonical repo directory
-cd ~/Git/$(basename "$PWD" | cut -d. -f1)
-
-# Pull the merged changes into main
+gh pr merge --squash                              # no --delete-branch from worktrees
+cd ~/Git/$(basename "$PWD" | cut -d. -f1)         # return to canonical repo
 git pull origin main
-
-# Remove merged worktrees
-wt prune
+wt prune                                          # remove merged worktrees
 ```
 
-## Notes
+**Key rules:**
 
-- **Do not use `--delete-branch`** with `gh pr merge` when running from inside a worktree — it will fail because the branch is checked out in the worktree, not the canonical repo.
-- `wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run it from the canonical repo directory (on `main`), not from inside the worktree.
-- If `wt prune` is unavailable, use `git worktree prune` to remove stale worktree entries, then manually delete the worktree directory.
-- The pulse runs `cleanup_worktrees()` every cycle as a safety net, but workers should not rely on it — self-cleanup prevents accumulation during batch operations.
+- **No `--delete-branch`** — fails from inside a worktree (branch is checked out there, not in canonical repo).
+- **`wt prune`** — run from canonical repo on `main`. Falls back: `git worktree prune` + manual directory removal.
 
 ## See Also
 
 - `workflows/git-workflow.md` — full worktree lifecycle
 - `reference/session.md` — session and worktree conventions
-- `full-loop.md` Step 4.8 — worker self-cleanup specification
+- `full-loop.md` Step 4.9 — worker self-cleanup specification


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/worktree-cleanup.md` from 60 → 50 lines (17% reduction)
- Consolidate duplicate pulse safety net mentions, merge Notes into inline Key Rules
- Fix Step reference 4.8 → 4.9 to match `full-loop.md`
- All institutional knowledge preserved: GH#6740 task ID, code blocks, cross-references, `--delete-branch` warning

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — no runtime behavior change, content-only restructuring

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/commands/worktree-cleanup.md` | Tightened prose, consolidated redundancy, fixed step ref |
| `.agents/configs/simplification-state.json` | Registered post-simplification hash |

Closes #14401

---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6