### PR TITLE
GH#14207: tighten langflow.md (153→117 lines) — compress custom component, inline Docker Compose, trim .env

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3037,9 +3037,9 @@
       "pr": 13844
     },
     ".agents/tools/ai-orchestration/langflow.md": {
-      "hash": "9010935d83c2b8113ae0c32b3d4f7eb7ee720b06",
-      "at": "2026-03-30T06:49:09Z",
-      "pr": 13930
+      "hash": "8c8c05859cc60d2e341b6cd191075ec540e10c12",
+      "at": "2026-03-31T13:00:00Z",
+      "pr": 14207
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
       "hash": "be2d56c6fe66266362fd66f78066478f683491cf",

--- a/.agents/tools/ai-orchestration/langflow.md
+++ b/.agents/tools/ai-orchestration/langflow.md
@@ -26,21 +26,13 @@ tools:
 
 ## Installation
 
-Automated (recommended) — runs setup, prompts for `.env` config, starts server:
-
 ```bash
-bash .agents/scripts/langflow-helper.sh setup
+bash .agents/scripts/langflow-helper.sh setup  # recommended: setup + .env config + start
 ```
 
 Manual: `mkdir -p ~/.aidevops/langflow && cd ~/.aidevops/langflow && python3 -m venv venv && source venv/bin/activate && pip install langflow && langflow run`
 
-Docker:
-
-```bash
-docker run -p 7860:7860 langflowai/langflow:latest
-# Persistent storage:
-docker run -p 7860:7860 -v langflow_data:/app/langflow langflowai/langflow:latest
-```
+Docker: `docker run -p 7860:7860 -v langflow_data:/app/langflow langflowai/langflow:latest`
 
 Desktop app: <https://www.langflow.org/desktop> (Windows/macOS)
 
@@ -49,27 +41,13 @@ Desktop app: <https://www.langflow.org/desktop> (Windows/macOS)
 `~/.aidevops/langflow/.env` — set API keys via `aidevops secret` or edit directly:
 
 ```bash
-LANGFLOW_HOST=0.0.0.0
-LANGFLOW_PORT=7860
-LANGFLOW_WORKERS=1
-LANGFLOW_DATABASE_URL=sqlite:///./langflow.db
+LANGFLOW_HOST=0.0.0.0              # LANGFLOW_PORT=7860 (default)
 OPENAI_API_KEY=<your-key>
 ANTHROPIC_API_KEY=<your-key>       # optional
 OLLAMA_BASE_URL=http://localhost:11434
 ```
 
-Custom components in `~/.aidevops/langflow/components/` — load with `langflow run --components-path ~/.aidevops/langflow/components/`:
-
-```python
-from langflow.custom import CustomComponent
-from langflow.schema import Data
-
-class MyCustomComponent(CustomComponent):
-    display_name = "My Custom Component"
-    description = "A custom component for aidevops"
-    def build(self, input_text: str) -> Data:
-        return Data(text=input_text.upper())
-```
+Custom components: place `.py` files in `~/.aidevops/langflow/components/`, load with `langflow run --components-path ~/.aidevops/langflow/components/`. Subclass `langflow.custom.CustomComponent`, implement `build()` → `langflow.schema.Data`.
 
 ## Usage
 
@@ -127,21 +105,7 @@ langflow import --directory flows/                                # bulk
 
 ## Deployment
 
-```yaml
-services:
-  langflow:
-    image: langflowai/langflow:latest
-    ports: ["7860:7860"]
-    volumes:
-      - langflow_data:/app/langflow
-      - ./flows:/app/flows
-    environment: [OPENAI_API_KEY=${OPENAI_API_KEY}]
-    restart: unless-stopped
-volumes:
-  langflow_data:
-```
-
-Production: PostgreSQL, auth for multi-user, reverse proxy for HTTPS.
+Docker Compose: `langflowai/langflow:latest` with ports `7860:7860`, volumes `langflow_data:/app/langflow` + `./flows:/app/flows`, env `OPENAI_API_KEY`, `restart: unless-stopped`. Production: PostgreSQL, auth for multi-user, reverse proxy for HTTPS.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Recheck simplification of `.agents/tools/ai-orchestration/langflow.md` (153→117 lines, 24% reduction).

Closes #14207

## Changes

- **Custom component Python example** (10 lines → 1 line prose): replaced full boilerplate code block with inline description of class/method/return type — the example was generic and not authoritative
- **Docker Compose YAML** (13 lines → 1 line prose): inlined key params (image, ports, volumes, env, restart) — standard compose pattern doesn't need a full block
- **`.env` config block** (7 → 4 lines): removed `LANGFLOW_WORKERS`, `LANGFLOW_DATABASE_URL` defaults that add no value; noted port as comment on host line
- **Installation section** (7 → 4 lines): removed redundant prose wrapper around setup command, consolidated Docker run to single line with persistent volume

## Content Preservation Verification

- All URLs preserved: `docs.langflow.org`, `github.com/langflow-ai/langflow`, Discord, Templates, Desktop, Ollama install, LM Studio
- All commands preserved: `langflow-helper.sh setup`, lifecycle scripts, `docker run`, `langflow export/import`, `langflow run --mcp`
- All code blocks preserved: `.env` config, API Python example, MCP JSON config, Git integration bash, RAG/multi-agent ASCII diagrams
- Custom component info preserved as prose (class, method, return type)
- Troubleshooting table fully preserved
- No task IDs or issue refs in this file

## Runtime Testing

- **Risk level**: Low (docs/agent prompt only)
- **Verification**: `self-assessed` — markdownlint clean, content preservation verified

---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with claude-opus-4-6