### PR TITLE
GH#14905: tighten sonnet tier model doc

### DIFF
--- a/.agents/tools/ai-assistants/models-sonnet.md
+++ b/.agents/tools/ai-assistants/models-sonnet.md
@@ -22,21 +22,20 @@ tools:
 
 # Sonnet Tier Model (Default)
 
-Default tier for most development work: balanced capability, cost, and speed.
+Default tier for most development work: balanced capability, cost, and speed for implementation-heavy tasks.
 
 ## Use For
 
 - Writing and modifying code
-- Code review with actionable feedback
-- Debugging and implementation reasoning
+- Debugging, implementation reasoning, and code review
+- Test writing and execution
 - Documentation derived from code
 - Interactive development tasks
-- Test writing and execution
 
 ## Routing Rules
 
-- Default to sonnet unless the task clearly needs less or more capability.
-- Route simple classification or formatting to haiku.
+- Use sonnet unless the task clearly needs less, more, or much larger context.
+- Route simple classification and formatting to haiku.
 - Route architecture decisions and novel problems to opus.
 - Route very large context needs (100K+ tokens) to pro.
 


### PR DESCRIPTION
## Summary
- tighten the sonnet tier doc intro so it states the default role more directly
- merge overlapping use-case bullets and simplify routing language without changing tier guidance

## Testing
- `bunx markdownlint-cli2 '.agents/tools/ai-assistants/models-sonnet.md'`

## Runtime Testing
- Level: self-assessed
- Reason: low-risk docs-only change
- Evidence: markdownlint passed and no runtime behavior changed

Closes #14905

---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 15m on this as a headless worker.
