### PR TITLE
GH#14903: tighten R2 object storage doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -61,6 +61,11 @@
       "at": "2026-03-27T21:25:14Z",
       "pr": 11009
     },
+    ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
+      "hash": "c0c080bb82f1488a996f7cf50c231ac89179bc6f",
+      "at": "2026-03-31T13:03:34Z",
+      "pr": 14912
+    },
     ".agents/tools/credentials/multi-tenant.md": {
       "hash": "efa55dc5b3f2f5222982c1c9f0214ad1e2601624",
       "at": "2026-03-27T21:25:16Z",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -64,7 +64,7 @@
     ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
       "hash": "c0c080bb82f1488a996f7cf50c231ac89179bc6f",
       "at": "2026-03-31T13:03:34Z",
-      "pr": 14912
+      "pr": 14914
     },
     ".agents/tools/credentials/multi-tenant.md": {
       "hash": "efa55dc5b3f2f5222982c1c9f0214ad1e2601624",

--- a/.agents/services/hosting/cloudflare-platform-skill/r2.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2.md
@@ -1,14 +1,16 @@
 # Cloudflare R2 Object Storage
 
-S3-compatible object storage with zero egress fees for assets, uploads, backups, and lake-style datasets.
+Use R2 for assets, uploads, backups, and dataset blobs when you want S3 compatibility without egress fees.
 
-## Overview
+## Quick Reference
 
-- S3-compatible API (Workers binding + S3 REST)
-- Zero egress fees globally
-- Strong consistency for writes and deletes
-- Storage classes: Standard and Infrequent Access
-- SSE-C encryption support
+| Capability | Notes |
+|------------|-------|
+| API surface | Workers binding and S3-compatible REST API |
+| Consistency | Strong consistency for writes and deletes |
+| Cost model | Zero egress fees; Infrequent Access adds retrieval and minimum-duration costs |
+| Storage classes | `Standard`, `InfrequentAccess` |
+| Encryption | SSE-C supported |
 
 ## Quick Start
 
@@ -18,39 +20,34 @@ wrangler r2 object put my-bucket/file.txt --file=./local.txt
 ```
 
 ```typescript
-// Upload
 await env.MY_BUCKET.put(key, data, {
-  httpMetadata: { contentType: 'image/jpeg' }
+  httpMetadata: { contentType: 'image/jpeg' },
 });
 
-// Download
 const object = await env.MY_BUCKET.get(key);
 if (object) return new Response(object.body);
 ```
 
 ## Core Operations
 
-| Method | Purpose | Returns |
-|--------|---------|---------|
-| `put(key, value, options?)` | Upload object | `R2Object \| null` |
-| `get(key, options?)` | Download object | `R2ObjectBody \| R2Object \| null` |
-| `head(key)` | Get metadata only | `R2Object \| null` |
-| `delete(keys)` | Delete object(s) | `Promise<void>` |
-| `list(options?)` | List objects | `R2Objects` |
+| Method | Use |
+|--------|-----|
+| `put(key, value, options?)` | Upload object data and metadata |
+| `get(key, options?)` | Read object body or conditional result |
+| `head(key)` | Read metadata without the body |
+| `delete(keys)` | Delete one key or a batch |
+| `list(options?)` | Page through objects by prefix/cursor |
 
 ## Storage Classes
 
-- **Standard**: Frequent access, low latency reads
-- **InfrequentAccess**: 30-day minimum storage, retrieval fees, lower storage cost
+- **Standard**: frequent access, low-latency reads.
+- **InfrequentAccess**: lower storage cost, but 30-day minimum billing and retrieval fees.
 
-## Related Docs
+## Read Next
 
-- [r2-patterns.md](./r2-patterns.md) - Streaming, caching, presigned URLs, storage transitions
-- [r2-gotchas.md](./r2-gotchas.md) - List truncation, ETag format, checksum limits, multipart pitfalls
-
-## See Also
-
-- [workers.md](./workers.md) - Worker runtime and fetch handlers
-- [kv.md](./kv.md) - Metadata storage for R2 objects
-- [d1.md](./d1.md) - Store R2 URLs in a relational database
-- [queues.md](./queues.md) - Process R2 uploads asynchronously
+- [r2-patterns.md](./r2-patterns.md) - streaming downloads, conditional requests, multipart upload, public buckets
+- [r2-gotchas.md](./r2-gotchas.md) - list truncation, `httpEtag`, checksum limits, multipart rules
+- [workers.md](./workers.md) - request handling around R2 bindings
+- [kv.md](./kv.md) - metadata and lookup records for R2 objects
+- [d1.md](./d1.md) - relational records pointing at R2 keys or URLs
+- [queues.md](./queues.md) - async processing for upload and ingest pipelines


### PR DESCRIPTION
## Summary
- replace the overview bullets with a tighter quick-reference table for the core R2 capabilities
- shorten the examples and operation descriptions while keeping the same decision-useful guidance
- update the simplification-state registry so future scans treat this file as handled by this PR

## Runtime Testing
- Level: self-assessed (docs-only change)
- Verification:
  - markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/services/hosting/cloudflare-platform-skill/r2.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)
  - reviewed the markdown diff to confirm the links and code examples were preserved

Closes #14903

---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4