### PR TITLE
GH#14904: tighten Cloudflare Network Interconnect doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3154,6 +3154,11 @@
       "hash": "fbaf83d04fce904137096c772adb42790e04badb",
       "at": "2026-03-31T14:03:00Z",
       "pr": 14941
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
+      "hash": "867372b20ef0d4adf0cbefddf0d59533f2ef5a1b",
+      "at": "2026-03-31T13:06:56Z",
+      "pr": 14916
     }
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/network-interconnect.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/network-interconnect.md
@@ -1,23 +1,27 @@
 # Cloudflare Network Interconnect (CNI)
 
-Private, high-performance connectivity to Cloudflare's network. **Enterprise-only**.
+Private, high-performance connectivity to Cloudflare's network. **Enterprise-only** and **not SLA-backed**, so keep backup Internet connectivity.
 
-## Connection Model
+## Quick Choices
 
-| Type | Best for | Notes |
+### Connection type
+
+| Type | Use when | Notes |
 |------|----------|-------|
-| **Direct** | Physical presence in a shared datacenter | Physical fiber, 10/100 Gbps, you order the cross-connect |
-| **Partner** | Faster virtual handoff | Via Console Connect, Equinix, Megaport, or similar partner SDN |
-| **Cloud** | AWS Direct Connect or GCP Cloud Interconnect | Magic WAN only |
+| **Direct** | You share a datacenter with Cloudflare | Physical fiber cross-connect, 10/100 Gbps |
+| **Partner** | You want a faster virtual handoff | Via Console Connect, Equinix, Megaport, or similar SDN partner |
+| **Cloud** | You connect from AWS Direct Connect or GCP Cloud Interconnect | Magic WAN only |
 
-## Dataplane Choice
+### Dataplane version
 
-| Version | Use when | Trade-offs |
-|---------|----------|------------|
+| Version | Prefer when | Limits |
+|---------|-------------|--------|
 | **v1 (Classic)** | You need GRE, VLAN, BFD, LACP, or peering | Asymmetric MTU (1500↓/1476↑) |
-| **v2 (Beta)** | You want native 1500-byte MTU and simpler routing | No GRE, VLAN, BFD, or LACP yet; uses ECMP |
+| **v2 (Beta)** | You want native 1500-byte MTU and simpler routing | No GRE, VLAN, BFD, or LACP; uses ECMP |
 
-## Supported Fits
+Default to **v2** unless you need a v1-only feature.
+
+## Supported deployments
 
 - **Magic Transit DSR**: DDoS protection, egress via ISP (v1/v2)
 - **Magic Transit + Egress**: DDoS protection plus egress via Cloudflare (v1/v2)
@@ -25,7 +29,7 @@ Private, high-performance connectivity to Cloudflare's network. **Enterprise-onl
 - **Peering**: Public routes at a PoP (v1 only)
 - **App Security**: WAF, Cache, or Load Balancing over Magic Transit (v1/v2)
 
-## Requirements & Physical Limits
+## Requirements and limits
 
 - Enterprise plan
 - IPv4 /24+ or IPv6 /48+ prefixes
@@ -34,7 +38,6 @@ Private, high-performance connectivity to Cloudflare's network. **Enterprise-onl
 - 10 km max optical distance
 - 10G requires 10GBASE-LR single-mode optics
 - 100G requires 100GBASE-LR4 single-mode optics
-- **No SLA**; keep backup Internet connectivity
 - Location availability: [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-30-10-2025.pdf)
 
 ## Throughput
@@ -45,11 +48,11 @@ Private, high-performance connectivity to Cloudflare's network. **Enterprise-onl
 | Customer → CF (peering) | 10 Gbps | 100 Gbps |
 | Customer → CF (Magic) | 1 Gbps per tunnel or CNI | 1 Gbps per tunnel or CNI |
 
-## Delivery Timeline
+## Delivery timeline
 
 Typical lead time is **2-4 weeks**: request → config review → order connection → configure → test → enable health checks → activate → monitor.
 
-## See Also
+## See also
 
 - [network-interconnect-patterns.md](./network-interconnect-patterns.md) - HA, hybrid cloud, failover
 - [network-interconnect-gotchas.md](./network-interconnect-gotchas.md) - Troubleshooting, limits


### PR DESCRIPTION
## Summary
- move the no-SLA caveat and main routing choice to the top of the CNI overview
- reframe connection and dataplane sections as quick decision tables without dropping deployment, limit, or throughput details

## Testing
- bunx markdownlint-cli2 .agents/services/hosting/cloudflare-platform-skill/network-interconnect.md

## Runtime Testing
- self-assessed: low-risk documentation-only change

Closes #14904

---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 4m and 51,246 tokens on this as a headless worker. Overall, 16m since this issue was created.