### PR TITLE
GH#14533: tighten pre-publish checklist doc

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-checklists-pre-publish.md
+++ b/.agents/marketing-sales/direct-response-copy-checklists-pre-publish.md
@@ -1,90 +1,25 @@
 # Pre-Publish Checklist
 
-## Research
+## Core Review
 
-- [ ] Specific audience defined with top 3 pain points
-- [ ] Know what they've tried that didn't work
-- [ ] Desired outcome clear
-- [ ] Objections identified and addressed
-- [ ] Awareness level determined
-- [ ] Proof points ready (testimonials, stats, case studies)
+| Area | Checklist |
+|------|-----------|
+| **Research** | Specific audience defined with top 3 pain points · Know what they've tried that didn't work · Desired outcome clear · Objections identified and addressed · Awareness level determined · Proof points ready (testimonials, stats, case studies) |
+| **Headline** | Promises a clear, specific benefit (numbers, outcomes, timeframes) · Speaks to target audience · Creates curiosity or urgency · Passes the "would I click this?" test · At least 10 variations written · Subheadline supports headline (doesn't repeat it) |
+| **Opening/Lead** | First sentence hooks the reader · Connects to current pain or desire · Acknowledges what they've tried before · Reader sees themselves in the opening · Transition to solution feels natural |
+| **Body Copy** | Benefits outnumber features (3:1 minimum) · Each feature tied to an outcome · Second person (you/your), active voice · Short sentences (<20 words) and paragraphs (2-3 sentences) · No jargon; skimmable with subheads, bullets, and bold |
+| **Social Proof** | Testimonials show specific results, named people, and photos where possible · Testimonials address objections · Case studies show before/after transformation · Third-party validation included (G2, press, certifications) · Proof placed strategically throughout copy |
+| **Offer** | Core offer clearly defined · Value established before price revealed · Value stack reaches 5-10x price · Bonuses relevant with specific deliverables · Price justified with anchoring or comparison · Payment options reduce friction (plans for $200+ offers) |
 
-## Headline
+## Conversion Safeguards
 
-- [ ] Promises a clear, specific benefit (numbers, outcomes, timeframes)
-- [ ] Speaks to target audience
-- [ ] Creates curiosity or urgency
-- [ ] Passes the "would I click this?" test
-- [ ] Written at least 10 variations
-- [ ] Subheadline supports headline (doesn't repeat it)
-
-## Opening/Lead
-
-- [ ] First sentence hooks the reader
-- [ ] Connects to current pain or desire
-- [ ] Acknowledges what they've tried before
-- [ ] Reader sees themselves in the opening
-- [ ] Transition to solution feels natural
-
-## Body Copy
-
-- [ ] Benefits outnumber features (3:1 minimum)
-- [ ] Each feature tied to an outcome
-- [ ] Second person (you/your), active voice
-- [ ] Short sentences (<20 words) and paragraphs (2-3 sentences)
-- [ ] No jargon; skimmable (subheads, bullets, bold)
-
-## Social Proof
-
-- [ ] Testimonials: specific results, named people, photos where possible
-- [ ] Testimonials address objections
-- [ ] Case studies show before/after transformation
-- [ ] Third-party validation (G2, press, certifications)
-- [ ] Placed strategically throughout copy
-
-## Offer
-
-- [ ] Core offer clearly defined
-- [ ] Value established before price revealed
-- [ ] Value stack 5-10x price
-- [ ] Bonuses relevant with specific deliverables
-- [ ] Price justified (anchoring, comparison)
-- [ ] Payment options reduce friction (plans for $200+ offers)
-
-## Guarantee
-
-- [ ] Strong, clear, and prominently displayed
-- [ ] Terms reasonable and fair
-- [ ] Addresses fear of wrong decision
-
-## Urgency/Scarcity
-
-- [ ] Real and legitimate (not manufactured)
-- [ ] Deadline or scarcity clearly stated
-- [ ] Consequences of waiting spelled out
-
-## Call to Action
-
-- [ ] One clear action (no competing CTAs)
-- [ ] Button text action-oriented; stands out visually
-- [ ] Appears multiple times on long pages
-- [ ] Friction minimized; next step obvious
-
-## Technical
-
-- [ ] Mobile-optimized (60%+ traffic is mobile)
-- [ ] Load time under 3 seconds
-- [ ] All links work; form submits correctly
-- [ ] Tracking set up (pixels, analytics)
-- [ ] Checkout process smooth
-
-## Final Read
-
-- [ ] Read aloud (catches awkward phrasing)
-- [ ] Spelling, grammar, consistent tone
-- [ ] Redundant words removed
-- [ ] Would you buy based on this page?
-- [ ] Fresh eyes review (someone else)
+| Area | Checklist |
+|------|-----------|
+| **Guarantee** | Strong, clear, prominently displayed · Terms reasonable and fair · Addresses fear of wrong decision |
+| **Urgency/Scarcity** | Real and legitimate (not manufactured) · Deadline or scarcity clearly stated · Consequences of waiting spelled out |
+| **Call to Action** | One clear action (no competing CTAs) · Button text action-oriented and visually distinct · Appears multiple times on long pages · Friction minimized and next step obvious |
+| **Technical** | Mobile-optimized (60%+ traffic is mobile) · Load time under 3 seconds · All links work and form submits correctly · Tracking set up (pixels, analytics) · Checkout process smooth |
+| **Final Read** | Read aloud (catches awkward phrasing) · Spelling, grammar, and tone consistent · Redundant words removed · Would you buy based on this page? · Fresh eyes review it |
 
 ## Quick Pre-Flight
 


### PR DESCRIPTION
## Summary
- condense the pre-publish checklist into two compact review tables so the full checklist scans faster without dropping any criteria
- keep the final six-point quick pre-flight gate intact for last-pass validation

## Testing
- `bunx markdownlint-cli2 ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md"`

## Runtime Testing
- Level: self-assessed (low risk doc-only change)
- Not required for this markdown-only update

Closes #14533

---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 3m and 172,146 tokens on this with the user in an interactive session. Overall, 9h 40m since this issue was created.