### PR TITLE
GH#14500: tighten scaling checklist doc

### DIFF
--- a/.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md
+++ b/.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md
@@ -1,59 +1,59 @@
 # Scaling Checklist
 
-> Before increasing spend, confirm the campaign, account, and business can absorb more volume.
+> Increase spend only when performance, creative, and operations can absorb more volume.
 
-## Readiness Check
+## 1. Readiness
 
 ### Performance
 
 - [ ] CPA at or below target for 5+ consecutive days
 - [ ] 50+ conversions with statistical confidence
-- [ ] CTR stable (not declining)
-- [ ] ROAS meets target (if tracking revenue)
-- [ ] Daily performance is consistent, not wildly fluctuating
+- [ ] CTR is stable, not declining
+- [ ] ROAS meets target, if revenue is tracked
+- [ ] Daily performance is stable, not swinging wildly
 
 ### Creative Health
 
 - [ ] Clear winning creative identified
-- [ ] Frequency under 3
-- [ ] Creative has been running under 3 weeks
-- [ ] Multiple ads are performing, not just one winner
+- [ ] Frequency is under 3
+- [ ] Winning creative has been live under 3 weeks
+- [ ] More than one ad is performing
 
-### Account and Business
+### Account and Business Capacity
 
 - [ ] Payment method can handle higher spend
-- [ ] No policy issues pending
-- [ ] Spending limits allow scale, or have been raised
-- [ ] Inventory or operational capacity can handle more orders
+- [ ] No policy issues are pending
+- [ ] Spending limits allow scale or have been raised
+- [ ] Inventory or operations can handle more orders
 - [ ] Cash flow supports higher spend
 - [ ] Customer service can absorb higher volume
-- [ ] Landing page can handle added traffic (speed, uptime)
+- [ ] Landing page can handle added traffic
 
-## Quick Go/No-Go
+## 2. Go / No-Go Gate
 
-Scale only if all four are true:
+Scale only if every box is checked:
 
 - [ ] CPA is below target for 5+ days
-- [ ] 50+ conversions recorded
+- [ ] 50+ conversions are recorded
 - [ ] Frequency is under 3
-- [ ] Business can handle more volume
+- [ ] The business can handle more volume
 
-If any box is unchecked, fix that constraint before increasing spend.
+If any box is unchecked, fix that bottleneck before increasing budget.
 
-## Pick the Right Scaling Method
+## 3. Choose the Scaling Method
 
-| Method | Use when | Execution |
-|--------|----------|-----------|
+| Method | Use when | Next action |
+|--------|----------|-------------|
 | **Vertical scaling** | CPA is 20%+ below target, frequency is still low (<2.5), diminishing returns have not started, and one campaign or ad set is the clear winner | Increase budget 20-30% every 2-3 days |
-| **Horizontal scaling** | Vertical scaling is flattening out, you want audience variation, you want to spread risk across ad sets, or the campaign is mature | Duplicate the winning ad set and change **one** variable |
+| **Horizontal scaling** | Vertical scaling is flattening, you want audience variation, you want to spread risk across ad sets, or the campaign is mature | Duplicate the winning ad set and change **one** variable |
 | **Creative scaling** | Performance is capped by fatigue, you want more volume without a budget jump, or testing already found multiple winners | Add proven new creative to existing ad sets |
 
-## Execution Checklist
+## 4. Execute
 
 ### Vertical Scaling
 
-- [ ] Calculate new budget (`current × 1.2-1.3`)
-- [ ] Raise budget early in the day if possible
+- [ ] Calculate the new budget (`current × 1.2-1.3`)
+- [ ] Raise budget early in the day when possible
 - [ ] Set a maximum budget cap
 - [ ] Schedule a check-in 48 hours later
 - [ ] Document the change
@@ -63,7 +63,7 @@ If any box is unchecked, fix that constraint before increasing spend.
 - [ ] Select the ad set to duplicate
 - [ ] Change exactly one variable
 - [ ] Start with the same budget as the original
-- [ ] Check for audience overlap issues
+- [ ] Check for audience overlap
 - [ ] Schedule a check-in 5 days later
 
 ### Creative Scaling
@@ -72,32 +72,32 @@ If any box is unchecked, fix that constraint before increasing spend.
 - [ ] Keep audience and budget stable while judging creative impact
 - [ ] Document which creative was added and why
 
-## Post-Scale Monitoring
+## 5. Monitor After Scaling
 
-| Window | Checks |
-|--------|--------|
-| **First 48 hours** | Spend rises as expected; CPA stays within 20% of pre-scale; no delivery issues; learning phase is not reset |
-| **Day 3-5** | CPA starts stabilising; no major performance swings; frequency remains acceptable; decide whether to keep scaling or pause |
-| **Day 7** | Review full-week data; compare CPA to pre-scale baseline; decide whether the next increment is justified |
+| Window | Check |
+|--------|-------|
+| **First 48 hours** | Spend rises as expected, CPA stays within 20% of pre-scale, no delivery issues appear, and learning phase is not reset |
+| **Day 3-5** | CPA starts stabilising, no major swings appear, frequency stays acceptable, and you can decide to keep scaling or pause |
+| **Day 7** | Review full-week data, compare CPA to the pre-scale baseline, and decide whether another increment is justified |
 
-## Stop Signals and Recovery
+## 6. Stop Signals and Recovery
 
-Stop scaling if any of these happen:
+Stop scaling if any box is checked:
 
 - [ ] CPA rises 30%+ and does not recover within 48 hours
-- [ ] Prospecting frequency jumps above 3.5
+- [ ] Prospecting frequency rises above 3.5
 - [ ] CTR drops 30%+ week over week
 - [ ] The algorithm re-enters learning phase
 - [ ] Business capacity becomes the bottleneck
 
-| Problem | Action |
-|---------|--------|
+| Problem | Response |
+|---------|----------|
 | CPA spike | Pause increases, wait, or reduce budget |
 | High frequency | Add new creative or new audiences |
 | CTR drop | Refresh creative |
 | Learning reset | Wait before making more changes |
 
-## Scale Tracking Template
+## 7. Track Each Change
 
 | Date | Action | Budget Before | Budget After | CPA Before | CPA After | Notes |
 |------|--------|---------------|--------------|------------|-----------|-------|
@@ -105,14 +105,14 @@ Stop scaling if any of these happen:
 | | | $ | $ | $ | $ | |
 | | | $ | $ | $ | $ | |
 
-## Scaling Limits
+## 8. Record the Ceiling
 
-Before the next increase, document the ceiling:
+Before the next increase, document the current limits:
 
 - [ ] Maximum efficient daily spend before diminishing returns
 - [ ] Maximum daily business capacity
 - [ ] Cash flow limit
-- [ ] CPA level where the campaign becomes unprofitable
+- [ ] CPA where the campaign becomes unprofitable
 
 ```text
 Max Efficient Daily Spend: $_______


### PR DESCRIPTION
## Summary
- tighten the scaling checklist so the readiness gate, method selection, execution steps, and stop criteria read in a cleaner order
- standardize headings and phrasing in .agents/marketing-sales/meta-ads-checklists-scaling-checklist.md without changing the underlying scaling rules or tracking template

## Runtime Testing
- self-assessed: low-risk docs-only change in .agents/marketing-sales/meta-ads-checklists-scaling-checklist.md
- verified with bunx markdownlint-cli2 ".agents/marketing-sales/meta-ads-checklists-scaling-checklist.md"

Closes #14500


---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4 spent 3m on this as a headless worker.