### PR TITLE
GH#14929: tighten Vision AI tools overview doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3122,8 +3122,8 @@
       "pr": 14701
     },
     ".agents/tools/vision/overview.md": {
-      "hash": "e760976eca7d7c554a6e625d70816805258ebcb1",
-      "at": "2026-03-31T08:01:28Z",
+      "hash": "03b9c9b416982c3a220eb0d47da8a08882cb4a97",
+      "at": "2026-03-31T13:32:37Z",
       "pr": 14726
     },
     ".agents/seo/geo-strategy.md": {

--- a/.agents/tools/vision/overview.md
+++ b/.agents/tools/vision/overview.md
@@ -18,11 +18,11 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Route image tasks to the right generation, understanding, or editing guide
-- **Create images**: `image-generation.md` — DALL-E 3, Midjourney, FLUX, Stable Diffusion
-- **Analyze images**: `image-understanding.md` — GPT-4o vision, Claude vision, Gemini, LLaVA, Qwen-VL
-- **Edit images**: `image-editing.md` — DALL-E 3 edit, Stable Diffusion inpaint, FLUX fill
-- **Local stack**: Ollama for VLMs; ComfyUI for generation/editing; `tools/infrastructure/cloud-gpu.md` for GPU deployment
+- **Route by task**: generate → `image-generation.md`; analyze → `image-understanding.md`; edit → `image-editing.md`
+- **Create**: DALL-E 3, Midjourney, FLUX, Stable Diffusion
+- **Analyze**: GPT-4o vision, Claude vision, Gemini, LLaVA, Qwen-VL
+- **Edit**: DALL-E 3 edit, Stable Diffusion inpaint, FLUX fill
+- **Local stack**: Ollama for VLMs, ComfyUI for generation/editing, `tools/infrastructure/cloud-gpu.md` for GPU deployment
 - **Specialized routes**: OCR → `tools/ocr/glm-ocr.md`; GUI screenshots → `tools/browser/peekaboo.md`
 
 <!-- AI-CONTEXT-END -->
@@ -48,12 +48,10 @@ tools:
 | **Local (ComfyUI)** | FLUX, Stable Diffusion XL, ControlNet | Generation, editing, workflow control |
 | **Cloud GPU** | Any model via vLLM/ComfyUI | Scale, large local models, batch processing |
 
-## Integration with aidevops
+## Related aidevops Routes
 
-| Integration | Description |
-|-------------|-------------|
-| `tools/ocr/glm-ocr.md` | Dedicated OCR (prefer over general vision for text extraction) |
-| `tools/browser/peekaboo.md` | Screen capture + vision analysis for GUI automation |
-| `tools/video/` | Image-to-video pipelines (Kling, Seedance via Higgsfield) |
-| `tools/infrastructure/cloud-gpu.md` | GPU deployment for local vision models |
-| `content/` | AI-generated images for content workflows |
+- `tools/ocr/glm-ocr.md` — dedicated OCR for text extraction
+- `tools/browser/peekaboo.md` — screen capture plus vision analysis for GUI automation
+- `tools/video/` — image-to-video pipelines (Kling, Seedance via Higgsfield)
+- `tools/infrastructure/cloud-gpu.md` — GPU deployment for local vision models
+- `content/` — AI-generated images for content workflows


### PR DESCRIPTION
## Summary
- condense the vision overview quick reference so task routing stays visible without repeating the same labels in every bullet
- replace the aidevops integration table with a shorter related-routes list while preserving every downstream pointer
- refresh `.agents/configs/simplification-state.json` with the new content hash and timestamp for this doc

## Testing Evidence
- `bunx markdownlint-cli2 ".agents/tools/vision/overview.md"`
- `jq empty .agents/configs/simplification-state.json`

## Runtime Testing
- Level: self-assessed
- Rationale: markdown and simplification metadata only; no runtime behavior changed

Closes #14929

---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.9 with gpt-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized vision tools documentation with updated "Quick Reference" section featuring explicit task-to-tool routing
  * Restructured integration references from table format to simplified bullet list format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->