### PR TITLE
GH#14748: harden setup command copy for missing security-audit

### DIFF
--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -1351,6 +1351,10 @@ if [[ -d "$COMMANDS_DIR" ]]; then
 			((++command_count))
 			echo -e "  ${GREEN}✓${NC} Auto-discovered /$cmd_name command"
 		else
+			if [[ ! -f "$cmd_file" ]]; then
+				echo -e "  ${YELLOW}!${NC} Skipped /$cmd_name command (source missing: $cmd_file)" >&2
+				continue
+			fi
 			echo -e "  ${RED}✗${NC} Failed to copy /$cmd_name command" >&2
 			exit 1
 		fi

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -992,6 +992,7 @@ _generate_commands_for_runtime() {
 	mkdir -p "$cmd_dir"
 
 	local command_count=0
+	local skipped_count=0
 	local display_name
 	display_name=$(rt_display_name "$runtime_id") || display_name="$runtime_id"
 
@@ -1014,16 +1015,40 @@ _generate_commands_for_runtime() {
 			case "$runtime_id" in
 			opencode)
 				# Copy as-is (OpenCode format already)
-				cp "$cmd_file" "${cmd_dir}/${cmd_name}.md"
+				if ! cp "$cmd_file" "${cmd_dir}/${cmd_name}.md"; then
+					if [[ ! -f "$cmd_file" ]]; then
+						print_warning "Skipping command ${cmd_name}: source file disappeared (${cmd_file})"
+						skipped_count=$((skipped_count + 1))
+						continue
+					fi
+					print_warning "Failed to copy command ${cmd_name} for ${display_name}"
+					return 1
+				fi
 				;;
 			claude-code)
 				# Strip OpenCode-specific frontmatter fields (agent, subtask, mode)
-				sed -E '/^---$/,/^---$/{/^(agent|subtask|mode):/d;}' "$cmd_file" \
-					>"${cmd_dir}/${cmd_name}.md"
+				if ! sed -E '/^---$/,/^---$/{/^(agent|subtask|mode):/d;}' "$cmd_file" \
+					>"${cmd_dir}/${cmd_name}.md"; then
+					if [[ ! -f "$cmd_file" ]]; then
+						print_warning "Skipping command ${cmd_name}: source file disappeared (${cmd_file})"
+						skipped_count=$((skipped_count + 1))
+						continue
+					fi
+					print_warning "Failed to render command ${cmd_name} for ${display_name}"
+					return 1
+				fi
 				;;
 			*)
 				# Generic: copy as-is
-				cp "$cmd_file" "${cmd_dir}/${cmd_name}.md"
+				if ! cp "$cmd_file" "${cmd_dir}/${cmd_name}.md"; then
+					if [[ ! -f "$cmd_file" ]]; then
+						print_warning "Skipping command ${cmd_name}: source file disappeared (${cmd_file})"
+						skipped_count=$((skipped_count + 1))
+						continue
+					fi
+					print_warning "Failed to copy command ${cmd_name} for ${display_name}"
+					return 1
+				fi
 				;;
 			esac
 
@@ -1037,6 +1062,9 @@ _generate_commands_for_runtime() {
 	local hc_count=$?
 	command_count=$((command_count + hc_count))
 
+	if [[ "$skipped_count" -gt 0 ]]; then
+		print_warning "$display_name: skipped $skipped_count command file(s) that disappeared during generation"
+	fi
 	print_success "$display_name: $command_count commands in $cmd_dir"
 	return 0
 }


### PR DESCRIPTION
## Summary
- Hardened runtime command generation to skip command files that disappear during copy/render instead of failing setup.
- Added equivalent guard in the legacy OpenCode command generator so fallback paths do not abort on transient missing command files.
- Kept hard failure behavior for real copy/render errors (permission/IO), while downgrading missing-source races to warnings.

## Testing
- shellcheck -e SC1091 .agents/scripts/generate-runtime-config.sh .agents/scripts/generate-opencode-commands.sh
- ./.agents/scripts/generate-runtime-config.sh commands --runtime opencode (with security-audit.md temporarily removed and restored)
- ./setup.sh --non-interactive > /tmp/gh14748-setup.log 2>&1
- rg -n \"OpenCode configuration encountered issues|OpenCode command generation encountered issues|cp: .*security-audit\.md|OpenCode configuration complete\" /tmp/gh14748-setup.log

## Runtime Testing
- Level: low
- Result: self-assessed (script and setup-path execution validated; no runtime app behavior changes)

Closes #14748


---
[aidevops.sh](https://aidevops.sh) v3.5.522 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.3-codex