### PR TITLE
GH#14836: harden pulse backlog count parsing

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5114,6 +5114,38 @@ get_max_workers_target() {
 }
 
 #######################################
+# Normalize a counter command's stdout into a single integer.
+#
+# Some helper commands may emit debug chatter before or after the numeric
+# result. Prefer the last line that is only digits; otherwise fall back.
+#
+# Arguments:
+#   $1 - raw stdout
+#   $2 - fallback value (optional, default 0)
+# Returns: integer via stdout
+#######################################
+normalize_count_output() {
+	local raw_output="$1"
+	local fallback_value="${2:-0}"
+	local line
+	local normalized=""
+
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^[[:space:]]*([0-9]+)[[:space:]]*$ ]]; then
+			normalized="${BASH_REMATCH[1]}"
+		fi
+	done <<<"$raw_output"
+
+	if [[ -n "$normalized" ]]; then
+		echo "$normalized"
+		return 0
+	fi
+
+	echo "$fallback_value"
+	return 0
+}
+
+#######################################
 # Count runnable backlog candidates across pulse scope
 # Heuristic for t1453 utilization loop:
 # - open inactive backlog issues (unassigned or only passively assigned to
@@ -5462,8 +5494,8 @@ dispatch_deterministic_fill_floor() {
 	local max_workers active_workers available_slots runnable_count queued_without_worker
 	max_workers=$(get_max_workers_target)
 	active_workers=$(count_active_workers)
-	runnable_count=$(normalize_count_output "$(count_runnable_candidates)")
-	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)")
+	runnable_count=$(normalize_count_output "$(count_runnable_candidates)" 0)
+	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)" 0)
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
 
@@ -5709,8 +5741,8 @@ maybe_refill_underfilled_pool_during_active_pulse() {
 	local max_workers active_workers runnable_count queued_without_worker
 	max_workers=$(get_max_workers_target)
 	active_workers=$(count_active_workers)
-	runnable_count=$(normalize_count_output "$(count_runnable_candidates)")
-	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)")
+	runnable_count=$(normalize_count_output "$(count_runnable_candidates)" 0)
+	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)" 0)
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
 
@@ -5830,8 +5862,8 @@ _compute_initial_underfill() {
 	fi
 
 	local runnable_count queued_without_worker
-	runnable_count=$(normalize_count_output "$(count_runnable_candidates)")
-	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)")
+	runnable_count=$(normalize_count_output "$(count_runnable_candidates)" 0)
+	queued_without_worker=$(normalize_count_output "$(count_queued_without_worker)" 0)
 	run_underfill_worker_recycler "$max_workers" "$active_workers" "$runnable_count" "$queued_without_worker"
 
 	# Re-check after recycler
@@ -5898,8 +5930,8 @@ _run_early_exit_recycle_loop() {
 		local post_max post_active post_runnable post_queued
 		post_max=$(get_max_workers_target)
 		post_active=$(count_active_workers)
-		post_runnable=$(normalize_count_output "$(count_runnable_candidates)")
-		post_queued=$(normalize_count_output "$(count_queued_without_worker)")
+		post_runnable=$(normalize_count_output "$(count_runnable_candidates)" 0)
+		post_queued=$(normalize_count_output "$(count_queued_without_worker)" 0)
 		[[ "$post_max" =~ ^[0-9]+$ ]] || post_max=1
 		[[ "$post_active" =~ ^[0-9]+$ ]] || post_active=0
 
@@ -5916,8 +5948,8 @@ _run_early_exit_recycle_loop() {
 
 		dispatch_deterministic_fill_floor >/dev/null || true
 		post_active=$(count_active_workers)
-		post_runnable=$(normalize_count_output "$(count_runnable_candidates)")
-		post_queued=$(normalize_count_output "$(count_queued_without_worker)")
+		post_runnable=$(normalize_count_output "$(count_runnable_candidates)" 0)
+		post_queued=$(normalize_count_output "$(count_queued_without_worker)" 0)
 		[[ "$post_active" =~ ^[0-9]+$ ]] || post_active=0
 		if [[ "$post_active" -ge "$post_max" ]]; then
 			break

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -721,6 +721,59 @@ test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity() {
 	return 0
 }
 
+test_dispatch_deterministic_fill_floor_tolerates_noisy_backlog_counts() {
+	local dispatch_log="${TEST_ROOT}/deterministic-noisy-counts.log"
+	: >"$dispatch_log"
+
+	build_ranked_dispatch_candidates_json() {
+		printf '%s\n' '[
+		  {"number":9401,"repo_slug":"marcusquinn/aidevops","repo_path":"/tmp/aidevops","url":"https://github.com/marcusquinn/aidevops/issues/9401","title":"candidate one","labels":["bug"],"updatedAt":"2026-03-31T00:00:00Z","score":8000},
+		  {"number":9402,"repo_slug":"marcusquinn/aidevops","repo_path":"/tmp/aidevops","url":"https://github.com/marcusquinn/aidevops/issues/9402","title":"candidate two","labels":["simplification-debt"],"updatedAt":"2026-03-31T00:01:00Z","score":4000}
+		]'
+	}
+	get_max_workers_target() { echo 2; }
+	count_active_workers() { echo 0; }
+	count_runnable_candidates() {
+		printf 'debug: runnable prefilter returned candidates\n'
+		printf '5\n'
+		return 0
+	}
+	count_queued_without_worker() {
+		printf 'debug: queued scan complete\n'
+		printf '0\n'
+		return 0
+	}
+	check_terminal_blockers() { return 1; }
+	dispatch_with_dedup() {
+		printf '%s\n' "$1" >>"$dispatch_log"
+		return 0
+	}
+	check_worker_launch() { return 0; }
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+			printf 'testuser\n'
+			return 0
+		fi
+		return 0
+	}
+	export -f gh
+
+	local dispatch_count dispatched_numbers
+	dispatch_count=$(dispatch_deterministic_fill_floor)
+	dispatched_numbers=$(tr '\n' ',' <"$dispatch_log" | sed 's/,$//')
+
+	unset -f gh build_ranked_dispatch_candidates_json get_max_workers_target count_active_workers count_runnable_candidates count_queued_without_worker check_terminal_blockers dispatch_with_dedup check_worker_launch
+
+	if [[ "$dispatch_count" == "2" && "$dispatched_numbers" == "9401,9402" ]]; then
+		print_result "dispatch_deterministic_fill_floor tolerates noisy backlog counter output" 0
+		return 0
+	fi
+
+	print_result "dispatch_deterministic_fill_floor tolerates noisy backlog counter output" 1 \
+		"Expected count=2 and issues 9401,9402 with noisy counter output; got count=${dispatch_count}, issues=${dispatched_numbers}"
+	return 0
+}
+
 test_build_ranked_dispatch_candidates_json_respects_schedule_gate() {
 	local original_repos_json="$REPOS_JSON"
 	cat >"${REPOS_JSON}" <<'JSON'
@@ -945,6 +998,7 @@ main() {
 	test_build_ranked_dispatch_candidates_json_scores_candidates
 	test_build_ranked_dispatch_candidates_json_respects_schedule_gate
 	test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity
+	test_dispatch_deterministic_fill_floor_tolerates_noisy_backlog_counts
 	test_dispatch_deterministic_fill_floor_honors_stop_flag
 	test_dispatch_deterministic_fill_floor_ignores_noisy_count_output
 	test_active_pulse_refill_skips_without_idle_or_stall_signal


### PR DESCRIPTION
## Summary
- normalize noisy stdout from `count_runnable_candidates` and `count_queued_without_worker` before deterministic fill and refill decisions are made
- apply the same parsing guard in the active refill and early-exit recycle paths so debug chatter cannot collapse runnable backlog counts to zero
- add a regression test that proves deterministic backfill still dispatches ranked candidates when backlog counters emit debug lines

## Runtime Testing
- Level: runtime-verified
- Evidence: executed the affected shell paths through the pulse-wrapper test harness after the patch and after rebasing onto `origin/main`

## Testing
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh`
- `shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`

## Notes
- `bash .agents/scripts/linters-local.sh` still reports pre-existing repository-wide blockers unrelated to this change, including markdown/style debt and existing quality gate failures outside the touched files

Closes #14836

---
[aidevops.sh](https://aidevops.sh) v3.5.524 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of count detection with better fallback handling, ensuring reliable operation when processing edge cases

* **Tests**
  * Added test coverage to verify dispatch operations handle malformed backlog count outputs correctly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->