### PR TITLE
GH#14939: tighten security-deps command doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3140,6 +3140,11 @@
       "hash": "7123b1f29ba3cba9eedf7f7f19f04c561c73a353",
       "at": "2026-03-31T12:08:05Z",
       "pr": 14883
+    },
+    ".agents/scripts/commands/security-deps.md": {
+      "hash": "fbaf83d04fce904137096c772adb42790e04badb",
+      "at": "2026-03-31T14:03:00Z",
+      "pr": 14941
     }
   }
 }

--- a/.agents/scripts/commands/security-deps.md
+++ b/.agents/scripts/commands/security-deps.md
@@ -4,39 +4,29 @@ agent: Build+
 mode: subagent
 ---
 
-Scan project dependencies for known vulnerabilities with OSV.
+Scan dependency lockfiles for known vulnerabilities with OSV.
 
 Target: $ARGUMENTS
 
-## Quick Reference
+## Command
 
-- **Tool**: OSV-Scanner — CVEs and GHSAs via OSV.dev
-- **Command**: `./.agents/scripts/security-helper.sh scan-deps`
+- Tool: OSV-Scanner via OSV.dev (CVEs, GHSAs)
+- Run: `./.agents/scripts/security-helper.sh scan-deps`
+- Scope: pass a directory path (for example `/security-deps ./packages/api`)
+- Output: add `--format=json` for machine-readable results
+- Recursive scan is enabled by default in `security-helper.sh`
 
-## Process
+## Workflow
 
 1. Run `./.agents/scripts/security-helper.sh scan-deps`
-2. Prioritize critical/high findings
+2. Triage critical/high findings first
 3. For each finding, confirm the package is used, identify the fixed version, and assess upgrade risk
-4. Update dependencies, test, then re-scan
+4. Upgrade, test, and re-scan
+5. If no fix exists, document reachability, compensating controls, and follow-up
 
 ## Supported Lockfiles
 
-npm/Yarn/pnpm (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`), pip (`requirements.txt`, `Pipfile.lock`), Go (`go.mod`), Cargo (`Cargo.lock`), Composer (`composer.lock`), Maven (`pom.xml`), Gradle (`gradle.lockfile`).
-
-## Options
-
-```bash
-/security-deps --format=json      # JSON output
-/security-deps ./packages/api     # Specific directory
-```
-
-Recursive scan is enabled by default in `security-helper.sh`.
-
-## Remediation
-
-- Check compatibility before upgrading (`npm update <pkg>`, `yarn upgrade <pkg>`, `pip install --upgrade <pkg>`)
-- Treat unfixable findings as triage work: document reachability, compensating controls, and follow-up
+npm/Yarn/pnpm (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`), pip (`requirements.txt`, `Pipfile.lock`), Go (`go.mod`), Cargo (`Cargo.lock`), Composer (`composer.lock`), Maven (`pom.xml`), and Gradle (`gradle.lockfile`).
 
 ## CI Example
 


### PR DESCRIPTION
## Summary
- tighten `/security-deps` into a shorter command-first reference
- keep OSV helper usage, supported lockfiles, CI example, and remediation guidance
- record the simplified doc hash in `.agents/configs/simplification-state.json`

## Runtime Testing
- self-assessed: low-risk markdown and simplification-state change
- `bunx markdownlint-cli2 ".agents/scripts/commands/security-deps.md"`
- `python3 -m json.tool .agents/configs/simplification-state.json >/dev/null`

## Files Changed
- `.agents/scripts/commands/security-deps.md`
- `.agents/configs/simplification-state.json`

Closes #14939


---
[aidevops.sh](https://aidevops.sh) v3.5.524 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4