### PR TITLE
GH#14940: tighten postflight-loop command doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1062,9 +1062,9 @@
       "pr": 14484
     },
     ".agents/scripts/commands/postflight-loop.md": {
-      "hash": "2691eaecbdc82f96bb0368fc04ebdfcfebc65153",
-      "at": "2026-03-31T06:26:08Z",
-      "pr": 14692
+      "hash": "c78f879537d08532f631523c4021e7ebc9f462ff",
+      "at": "2026-03-31T14:55:57Z",
+      "pr": 14942
     },
     ".agents/scripts/commands/routine.md": {
       "hash": "2f4f41fc7eb38924a7bceaa39ef60657f92e48ba",

--- a/.agents/scripts/commands/postflight-loop.md
+++ b/.agents/scripts/commands/postflight-loop.md
@@ -15,12 +15,9 @@ Monitor release health after deployment. Arguments: `$ARGUMENTS`
 ## Core Contract
 
 1. Parse `$ARGUMENTS` into `monitor_duration` and `max_iterations`.
-2. On each iteration, use `gh` to verify:
-   - latest CI workflow status
-   - release tag exists
-   - `VERSION` matches the release tag
-3. Track progress in `.agents/loop-state/quality-loop.local.md` with status, iteration, elapsed time, last check, and per-check results.
-4. Emit `<promise>RELEASE_HEALTHY</promise>` only when every check passes within the monitoring window.
+2. On each pass, use `gh` to verify the latest CI status, release tag presence, and `VERSION` ↔ release-tag match.
+3. Record status, iteration, elapsed time, last check, and per-check results in `.agents/loop-state/quality-loop.local.md`.
+4. Emit `<promise>RELEASE_HEALTHY</promise>` only when every check passes inside the monitoring window.
 
 ## Options
 
@@ -29,7 +26,7 @@ Monitor release health after deployment. Arguments: `$ARGUMENTS`
 | `--monitor-duration <t>` | Total monitoring window such as `5m`, `10m`, or `1h` | `5m` |
 | `--max-iterations <n>` | Max monitoring passes | `5` |
 
-## Typical Invocations
+## Examples
 
 ```bash
 /postflight-loop --monitor-duration 10m
@@ -37,18 +34,14 @@ Monitor release health after deployment. Arguments: `$ARGUMENTS`
 /postflight-loop --monitor-duration 2m --max-iterations 3
 ```
 
-Use the default command for quick verification, extend the duration for slower release pipelines, and lower iterations only when you need a bounded smoke check.
-
 ## Use When
 
-- After `/release`
-- After a manual release
-- During CI/CD verification
+- After `/release`, a manual release, or CI/CD verification
 
 ## Related
 
-- `/postflight` - single postflight check
-- `/release` - full release workflow
-- `/preflight` - quality checks before release
-- `/preflight-loop` - iterative preflight until passing
-- `workflows/postflight.md` - broader release-health checks and rollback guidance
+- `/postflight` — single postflight check
+- `/release` — full release workflow
+- `/preflight` — quality checks before release
+- `/preflight-loop` — iterative preflight until passing
+- `workflows/postflight.md` — broader release-health checks and rollback guidance


### PR DESCRIPTION
## Summary
- condense the `/postflight-loop` command reference without changing its monitoring contract
- keep the release checks, loop-state tracking, examples, and related command pointers while removing repetitive prose
- refresh `.agents/configs/simplification-state.json` with the new file hash for this recheck

## Runtime Testing
- Level: self-assessed (low-risk agent prompt doc change)
- `bunx markdownlint-cli2 \".agents/scripts/commands/postflight-loop.md\"`
- `python3 - <<'PY' ... json.loads(pathlib.Path('.agents/configs/simplification-state.json').read_text()) ... PY`

Closes #14940
---
[aidevops.sh](https://aidevops.sh) v3.5.524 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 6m and 45,903 tokens on this as a headless worker. Overall, 16m since this issue was created.