### PR TITLE
GH#14945: keep pulse helper counts numeric under debug

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5141,6 +5141,7 @@ count_runnable_candidates() {
 		local pr_count
 		pr_count=$(echo "$pr_json" | jq '[.[] | select(.reviewDecision == "CHANGES_REQUESTED" or ((.statusCheckRollup // []) | any((.conclusion // .state) == "FAILURE")))] | length' 2>/dev/null) || pr_count=0
 		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+		pulse_count_debug_log "count_runnable_candidates repo=${slug} issues=${issue_count} prs=${pr_count} total=$((issue_count + pr_count))"
 
 		total=$((total + issue_count + pr_count))
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
@@ -5174,6 +5175,7 @@ count_queued_without_worker() {
 		local queued_count
 		queued_count=$(echo "$queued_json" | jq 'length' 2>/dev/null) || queued_count=0
 		[[ "$queued_count" =~ ^[0-9]+$ ]] || queued_count=0
+		pulse_count_debug_log "count_queued_without_worker repo=${slug} queued=${queued_count}"
 		if [[ "$queued_count" -eq 0 ]]; then
 			continue
 		fi
@@ -5190,11 +5192,32 @@ count_queued_without_worker() {
 
 			if ! has_worker_for_repo_issue "$issue_num" "$slug"; then
 				total=$((total + 1))
+				pulse_count_debug_log "count_queued_without_worker repo=${slug} issue=${issue_num} missing_worker=true"
 			fi
 		done < <(echo "$queued_json" | jq -r --arg self "$self_login" '.[] | .number as $n | ((.assignees | length) > 0 and (([.assignees[].login] | index($self)) == null)) as $assigned_other | "\($n)|\($assigned_other)"' 2>/dev/null)
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
 
 	echo "$total"
+	return 0
+}
+
+#######################################
+# Emit debug logs for pulse count helpers without polluting stdout.
+#
+# Debug logs are opt-in via PULSE_DEBUG and always go to stderr so helpers that
+# are consumed numerically keep a strict stdout contract.
+#
+# Arguments:
+#   $1 - message to log
+# Returns: 0 always
+#######################################
+pulse_count_debug_log() {
+	local message="$1"
+	case "${PULSE_DEBUG:-}" in
+	1 | true | TRUE | yes | YES | on | ON)
+		printf '[pulse-wrapper] DEBUG: %s\n' "$message" >&2
+		;;
+	esac
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -69,6 +69,11 @@ gh() {
 		return 0
 	fi
 
+	if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+		printf 'owner\n'
+		return 0
+	fi
+
 	printf 'unsupported gh invocation in test stub\n' >&2
 	return 1
 }
@@ -287,6 +292,61 @@ test_count_runnable_candidates_counts_passive_assignee_backlog() {
 	return 0
 }
 
+test_count_runnable_candidates_keeps_stdout_numeric_with_debug() {
+	local repos_json_path="${HOME}/.config/aidevops/repos.json"
+	mkdir -p "$(dirname "$repos_json_path")"
+	printf '{"initialized_repos":[{"slug":"owner/repo","path":"/tmp/repo","pulse":true,"maintainer":"maintainer-bot"}]}\n' >"$repos_json_path"
+	REPOS_JSON="$repos_json_path"
+
+	GH_ISSUE_LIST_JSON='[
+	  {"number":1,"title":"unassigned","updatedAt":"2026-03-31T00:00:00Z","assignees":[],"labels":[]}
+	]'
+	GH_PR_LIST_JSON='[
+	  {"reviewDecision":"CHANGES_REQUESTED","statusCheckRollup":[]}
+	]'
+
+	local count stderr_file
+	stderr_file="${TEST_ROOT}/count-runnable-debug.stderr"
+	PULSE_DEBUG=1 count=$(count_runnable_candidates 2>"$stderr_file")
+
+	if [[ "$count" == "2" ]] && grep -q 'count_runnable_candidates repo=owner/repo issues=1 prs=1 total=2' "$stderr_file"; then
+		print_result "count_runnable_candidates keeps stdout numeric with debug enabled" 0
+		return 0
+	fi
+
+	print_result "count_runnable_candidates keeps stdout numeric with debug enabled" 1 \
+		"Expected numeric stdout 2 with stderr debug log; got count='${count}', stderr='$(tr '\n' '|' <"$stderr_file")'"
+	return 0
+}
+
+test_count_queued_without_worker_keeps_stdout_numeric_with_debug() {
+	local repos_json_path="${HOME}/.config/aidevops/repos.json"
+	mkdir -p "$(dirname "$repos_json_path")"
+	printf '{"initialized_repos":[{"slug":"owner/repo","path":"/tmp/repo","pulse":true}]}\n' >"$repos_json_path"
+	REPOS_JSON="$repos_json_path"
+
+	GH_ISSUE_LIST_JSON='[
+	  {"number":11,"assignees":[]}
+	]'
+	has_worker_for_repo_issue() {
+		return 1
+	}
+
+	local count stderr_file
+	stderr_file="${TEST_ROOT}/count-queued-debug.stderr"
+	PULSE_DEBUG=1 count=$(count_queued_without_worker 2>"$stderr_file")
+	unset -f has_worker_for_repo_issue
+
+	if [[ "$count" == "1" ]] && grep -q 'count_queued_without_worker repo=owner/repo queued=1' "$stderr_file" && grep -q 'count_queued_without_worker repo=owner/repo issue=11 missing_worker=true' "$stderr_file"; then
+		print_result "count_queued_without_worker keeps stdout numeric with debug enabled" 0
+		return 0
+	fi
+
+	print_result "count_queued_without_worker keeps stdout numeric with debug enabled" 1 \
+		"Expected numeric stdout 1 with stderr debug logs; got count='${count}', stderr='$(tr '\n' '|' <"$stderr_file")'"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -301,6 +361,8 @@ main() {
 	test_counts_review_issue_pr_workers
 	test_list_dispatchable_candidates_include_passive_assignees
 	test_count_runnable_candidates_counts_passive_assignee_backlog
+	test_count_runnable_candidates_keeps_stdout_numeric_with_debug
+	test_count_queued_without_worker_keeps_stdout_numeric_with_debug
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- move count-helper diagnostics onto stderr behind `PULSE_DEBUG` so helper stdout stays strictly numeric
- keep the defensive count normalizer in place for downstream callers while restoring the helpers' direct stdout contract
- add regression coverage for both helpers proving debug logging does not pollute numeric stdout

## Testing
- bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh
- bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
- shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-worker-count.sh

## Runtime Testing
- runtime-verified via direct bash execution of the affected pulse helper test suites

Closes #14945


---
[aidevops.sh](https://aidevops.sh) v3.5.524 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 6m and 86,777 tokens on this as a headless worker. Overall, 13m since this issue was created.