### PR TITLE
GH#14944: count live headless-runtime-helper wrappers as active workers

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1649,16 +1649,17 @@ list_active_worker_processes() {
 	#   /path/to/.opencode run ...                               (binary grandchild)
 	# All three contain /full-loop (or /review-issue-pr) and opencode in their command line.
 	#
-	# GH#12361: Workers dispatched via headless-runtime-helper.sh without
-	# sandbox-exec-helper.sh run as /bin/.opencode processes directly.
-	# The old approach blanket-excluded /bin/.opencode and node child
-	# processes, which missed standalone workers. New approach:
-	#   1. Match all processes with /full-loop or /review-issue-pr + opencode (any binary path)
+	# GH#12361 / GH#14944: Workers may appear either as direct opencode
+	# processes or as headless-runtime-helper.sh wrappers around sandbox +
+	# opencode children. Counting must treat the whole wrapper/process tree as
+	# one logical worker. New approach:
+	#   1. Match worker processes launched via opencode OR
+	#      headless-runtime-helper.sh run --role worker.
 	#   2. Deduplicate by issue+dir key: when multiple processes share the
-	#      same issue AND --dir path (sandbox chain), prefer the sandbox
-	#      launcher; if no launcher exists, keep the first match (the
-	#      standalone worker). Different --dir paths = different logical
-	#      workers even with the same issue number.
+	#      same issue AND --dir path, prefer the outermost launcher
+	#      (headless-runtime-helper.sh wrapper > sandbox launcher > child).
+	#      Different --dir paths = different logical workers even with the
+	#      same issue number.
 	#
 	# GH#6413: Process state filtering — exclude zombie (Z) and stopped (T)
 	# processes. These are dead/stuck processes that hold no useful work but
@@ -1667,10 +1668,16 @@ list_active_worker_processes() {
 	# used for filtering only; output format remains pid,etime,command for
 	# backward compatibility with all consumers.
 	ps axo pid,stat,etime,command | awk '
-		($0 ~ /\/full-loop/ || $0 ~ /\/review-issue-pr/) &&
-		$0 !~ /(^|[[:space:]])\/pulse([[:space:]]|$)/ &&
-		$0 !~ /Supervisor Pulse/ &&
-		$0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ {
+		{
+			is_headless_wrapper = ($0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/ && $0 ~ /(^|[[:space:]])run([[:space:]]|$)/ && $0 ~ /--role[[:space:]]+worker/)
+			has_worker_prompt = ($0 ~ /\/full-loop/ || $0 ~ /\/review-issue-pr/)
+			has_worker_binary = ($0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ || $0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/)
+
+			if (!(has_worker_prompt || is_headless_wrapper)) next
+			if ($0 ~ /(^|[[:space:]])\/pulse([[:space:]]|$)/) next
+			if ($0 ~ /Supervisor Pulse/) next
+			if (!has_worker_binary) next
+
 			# $2 is the stat column (e.g., S, SN, Ss, Z, Zs, T, TN)
 			stat = $2
 			# Exclude zombies (Z*) and stopped processes (T*)
@@ -1699,20 +1706,25 @@ list_active_worker_processes() {
 				sub(/--dir[[:space:]]+/, "", dir)
 			}
 			dedup_key = issue "|" dir
-			# Prefer sandbox launcher over node/binary children for same issue+dir
-			is_launcher = ($0 ~ /sandbox-exec-helper\.sh/)
+			# Prefer outer launchers over child processes for same issue+dir.
+			launcher_rank = 0
+			if ($0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/ && $0 ~ /--role[[:space:]]+worker/) {
+				launcher_rank = 2
+			} else if ($0 ~ /sandbox-exec-helper\.sh/) {
+				launcher_rank = 1
+			}
 			if (issue != "" && dedup_key in seen) {
 				# Already have a line for this issue+dir
-				if (is_launcher && !seen_launcher[dedup_key]) {
-					# Replace child with launcher
+				if (launcher_rank > seen_launcher_rank[dedup_key]) {
+					# Replace inner child with outer launcher
 					seen_lines[dedup_key] = line
-					seen_launcher[dedup_key] = 1
+					seen_launcher_rank[dedup_key] = launcher_rank
 				}
-				# Otherwise skip (child of existing launcher, or duplicate)
+				# Otherwise skip (lower-rank child of existing launcher, or duplicate)
 			} else if (issue != "") {
 				seen[dedup_key] = 1
 				seen_lines[dedup_key] = line
-				seen_launcher[dedup_key] = is_launcher ? 1 : 0
+				seen_launcher_rank[dedup_key] = launcher_rank
 				key_order[++key_count] = dedup_key
 			} else {
 				# No issue number found — print directly (edge case)

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -315,6 +315,56 @@ test_counts_standalone_opencode_binary_workers() {
 	return 0
 }
 
+test_counts_headless_runtime_helper_wrapper_without_child_process() {
+	# GH#14944: The live worker may be visible only as the outer
+	# headless-runtime-helper.sh wrapper before/without an opencode child in ps.
+	set_ps_fixture "650 S 00:18 bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-14944 --dir /tmp/aidevops --title Issue #14944 --prompt-file /tmp/pulse-14944.prompt"
+
+	local count output
+	count=$(count_active_workers)
+	if [[ "$count" != "1" ]]; then
+		print_result "count_active_workers counts wrapper-only headless-runtime-helper worker (GH#14944)" 1 "Expected 1, got ${count}"
+		return 0
+	fi
+
+	output=$(list_active_worker_processes)
+	if ! echo "$output" | grep -q "^650 "; then
+		print_result "count_active_workers counts wrapper-only headless-runtime-helper worker (GH#14944)" 1 "Expected wrapper PID 650 in output"
+		return 0
+	fi
+
+	print_result "count_active_workers counts wrapper-only headless-runtime-helper worker (GH#14944)" 0
+	return 0
+}
+
+test_deduplicates_headless_runtime_helper_wrapper_with_child_processes() {
+	# GH#14944: Wrapper + sandbox + opencode child chain should count as one
+	# logical worker, keeping the outer headless-runtime-helper wrapper PID.
+	set_ps_fixture "660 S 00:20 bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key issue-14944 --dir /tmp/aidevops --title Issue #14944 --prompt-file /tmp/pulse-14944.prompt
+661 S 00:19 bash /Users/test/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #14944\" --dir /tmp/aidevops --session-key issue-14944 --title Issue #14944
+662 S 00:19 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #14944\" --dir /tmp/aidevops --session-key issue-14944 --title Issue #14944"
+
+	local count output
+	count=$(count_active_workers)
+	if [[ "$count" != "1" ]]; then
+		print_result "count_active_workers deduplicates headless-runtime-helper wrapper with children (GH#14944)" 1 "Expected 1, got ${count}"
+		return 0
+	fi
+
+	output=$(list_active_worker_processes)
+	if ! echo "$output" | grep -q "^660 "; then
+		print_result "count_active_workers deduplicates headless-runtime-helper wrapper with children (GH#14944)" 1 "Expected wrapper PID 660 in output"
+		return 0
+	fi
+	if echo "$output" | grep -q "^661 \|^662 "; then
+		print_result "count_active_workers deduplicates headless-runtime-helper wrapper with children (GH#14944)" 1 "Expected child PIDs 661/662 to be deduplicated away"
+		return 0
+	fi
+
+	print_result "count_active_workers deduplicates headless-runtime-helper wrapper with children (GH#14944)" 0
+	return 0
+}
+
 test_deduplicates_chain_but_keeps_standalone_opencode_binary() {
 	# GH#12361: Mix of sandbox-launched chain and standalone /bin/.opencode worker.
 	# The chain (issue #5001) should deduplicate to 1; the standalone (issue #12361)


### PR DESCRIPTION
## Summary
- count headless-runtime-helper.sh run --role worker wrapper processes as active workers even when no child opencode process is visible yet
- deduplicate wrapper, sandbox, and child chains by issue and repo path while preferring the outermost launcher PID
- add regression coverage for wrapper-only and wrapper-plus-child detection states

## Testing
- shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
- bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
- bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh

## Runtime Testing
- level: runtime-verified
- evidence: exercised the worker-detection path through the bash regression harnesses that source the live pulse wrapper functions and execute count_active_workers and list_active_worker_processes against deterministic process-table fixtures, including the new headless-wrapper states

Closes #14944

---
[aidevops.sh](https://aidevops.sh) v3.5.524 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 8m and 108,751 tokens on this with the user in an interactive session. Overall, 16m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved worker process detection logic to accurately treat wrapper processes as single logical units, preventing miscounts in worker enumeration.
  * Added test coverage to verify proper wrapper and child process identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->