### PR TITLE
t1706: develop chromium-debug-use live Chromium session skill

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -255,5 +255,5 @@ Per-agent enablement: `services/document-processing/unstract.md`.
 ## Resources
 
 - [Setup Script](.agents/scripts/setup-mcp-integrations.sh) | [Validation Script](.agents/scripts/validate-mcp-integrations.sh) | [Config Templates](configs/mcp-templates/)
-- [Chrome DevTools Guide](.agents/tools/browser/chrome-devtools.md) | [Playwright Guide](.agents/tools/browser/playwright.md)
+- [Chrome DevTools Guide](.agents/tools/browser/chrome-devtools.md) | [Playwright Guide](.agents/tools/browser/playwright.md) | [Chromium Debug Use Guide](.agents/tools/browser/chromium-debug-use.md)
 - [Troubleshooting](.agents/aidevops/mcp-troubleshooting.md)

--- a/.agents/reference/domain-index.md
+++ b/.agents/reference/domain-index.md
@@ -11,7 +11,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Product (shared) | `product/validation.md`, `product/onboarding.md`, `product/monetisation.md`, `product/growth.md`, `product/ui-design.md`, `product/analytics.md` |
-| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/browser/browser-use.md`, `tools/browser/skyvern.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |
+| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/browser/browser-use.md`, `tools/browser/chromium-debug-use.md`, `tools/browser/skyvern.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md`, `tools/voice/transcription.md` |
 | Design | `tools/design/ui-ux-inspiration.md`, `tools/design/ui-ux-catalogue.toon`, `tools/design/brand-identity.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |

--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -24,6 +24,7 @@ EXTRACT?
 AUTOMATE?
   Password manager/extensions:
     Already unlocked → Playwriter | Unlock once → dev-browser | Programmatic → Playwright + Bitwarden CLI
+  Live already-open Chromium/Chrome session → chromium-debug-use
   Parallel sessions: speed → Playwright | CLI → playwright-cli/agent-browser --session
   Persistent login: with extensions → dev-browser | without → playwright-cli/storageState
   Proxy: direct → Playwright/Crawl4AI | via extension → Playwriter
@@ -116,4 +117,4 @@ agent-browser screenshot /tmp/debug.png && agent-browser errors && agent-browser
 
 <!-- AI-CONTEXT-END -->
 
-Per-tool docs: `playwright.md` · `playwright-cli.md` · `dev-browser.md` · `agent-browser.md` · `crawl4ai.md` · `playwriter.md` · `stagehand.md`. Ethics: respect ToS, rate limit (2-5s delays), no spam, legitimate use only, no personal data without consent.
+Per-tool docs: `playwright.md` · `playwright-cli.md` · `chromium-debug-use.md` · `dev-browser.md` · `agent-browser.md` · `crawl4ai.md` · `playwriter.md` · `stagehand.md`. Ethics: respect ToS, rate limit (2-5s delays), no spam, legitimate use only, no personal data without consent.

--- a/.agents/tools/browser/chromium-debug-use.md
+++ b/.agents/tools/browser/chromium-debug-use.md
@@ -1,0 +1,131 @@
+---
+description: Attach Playwright to a live Chromium session via remote debugging
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  grep: true
+  task: true
+---
+
+# Chromium Debug Use
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Reuse an already-open Chrome/Chromium/Brave/Edge session instead of launching a fresh browser
+- **Mechanism**: Start the browser with `--remote-debugging-port=9222`, then attach with Playwright CDP
+- **Best for**: Logged-in/manual-auth flows, extension-heavy sessions, debugging real state, handoff between manual and scripted work
+- **Not for**: Isolated parallel test runs, Firefox/WebKit, or hostile sites where exposed remote debugging is unsafe
+
+**Core rule**: This pattern attaches to a live browser profile. Treat it as stateful and non-isolated. Prefer fresh Playwright contexts for reproducible tests.
+
+<!-- AI-CONTEXT-END -->
+
+## Start a Debuggable Browser
+
+Use a dedicated profile when possible.
+
+```bash
+# Chrome
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chromium-debug-use-profile
+
+# Chromium
+chromium \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chromium-debug-use-profile
+```
+
+Check the endpoint:
+
+```bash
+curl http://127.0.0.1:9222/json/version
+```
+
+Use loopback only. Never expose the debug port to untrusted networks.
+
+## Attach with Playwright
+
+```javascript
+import { chromium } from 'playwright';
+
+const browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
+const context = browser.contexts()[0];
+const page = context.pages()[0] ?? await context.newPage();
+
+await page.goto('https://example.com');
+console.log({ title: await page.title(), url: page.url() });
+
+await browser.close(); // disconnects; does not close the live browser
+```
+
+## Attach by WebSocket Endpoint
+
+If an HTTP endpoint is unavailable, read `webSocketDebuggerUrl` from `/json/version` and attach directly.
+
+```bash
+curl http://127.0.0.1:9222/json/version
+```
+
+```javascript
+const browser = await chromium.connectOverCDP(
+  'ws://127.0.0.1:9222/devtools/browser/<id>'
+);
+```
+
+## Common Patterns
+
+### Reuse manual login
+
+1. Start Chromium with remote debugging.
+2. Complete login or CAPTCHA manually.
+3. Attach with Playwright CDP.
+4. Continue scripted actions in the same session.
+
+### Inspect existing tabs
+
+```javascript
+const pages = browser.contexts().flatMap(ctx => ctx.pages());
+for (const page of pages) {
+  console.log(page.url());
+}
+```
+
+### Pair with Chrome DevTools MCP
+
+```bash
+npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222
+```
+
+Use CDP attachment for automation and DevTools MCP for performance, network, and console inspection against the same live browser.
+
+## Trade-offs
+
+| Need | Prefer |
+|------|--------|
+| Existing logged-in Chromium session | Chromium Debug Use |
+| Persistent local profile managed by aidevops | `tools/browser/dev-browser.md` |
+| Your everyday browser with extension click-to-connect | `tools/browser/playwriter.md` |
+| Fast isolated automation | `tools/browser/playwright.md` |
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `ECONNREFUSED` on `9222` | Browser was not started with `--remote-debugging-port=9222` |
+| No pages found | Open a tab manually or create one with `context.newPage()` |
+| Attach works but state is wrong | You launched a different profile than expected; verify `--user-data-dir` |
+| Browser closes unexpectedly | Another tool owns the session or the profile lock; use a dedicated debug profile |
+| Need repeatable tests | Stop using live-session attach; launch a fresh Playwright context instead |
+
+## Related
+
+- `tools/browser/browser-automation.md` - browser tool selection
+- `tools/browser/playwright.md` - fresh browser automation and CDP usage
+- `tools/browser/dev-browser.md` - managed persistent Chromium profile on port 9222
+- `tools/browser/chrome-devtools.md` - inspection and performance tooling over the same debug port


### PR DESCRIPTION
## Summary
- add a new `chromium-debug-use` browser guide for attaching Playwright to an already-open Chromium session over the remote debugging port
- document when to prefer this live-session pattern versus dev-browser, Playwright, and Playwriter
- link the new guide from browser discovery docs and MCP integration references

## Runtime Testing
- Level: self-assessed
- Evidence: `bunx markdownlint-cli2 ".agents/tools/browser/chromium-debug-use.md" ".agents/tools/browser/browser-automation.md" ".agents/reference/domain-index.md" ".agents/aidevops/mcp-integrations.md"`
- Notes: docs-only change; no runtime path changed

Closes #14948
---
[aidevops.sh](https://aidevops.sh) v3.5.524 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4