### PR TITLE
GH#14946: route fast simplification workers below gpt-5.4 by default

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -550,6 +550,8 @@ This handles provider backoff and cross-provider fallback automatically (e.g., i
 3. **Bundle defaults**: `bundle-helper.sh get model_defaults.implementation <repo-path>`. If the bundle says `opus` for this task type, resolve that tier.
 4. **No signal** → omit `--model` (default round-robin, currently sonnet-tier).
 
+**Simplification heuristic:** automated `.md` simplification-debt issues should default to `tier:simple`. Reserve `tier:thinking` for cases where the issue clearly calls for architectural judgment, security trade-offs, or novel design work rather than prose tightening/reordering.
+
 | Label | Tier to Resolve | Use Case |
 |-------|----------------|----------|
 | `tier:thinking` | `opus` | Architecture, novel design, complex trade-offs |

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1296,6 +1296,7 @@ cmd_metrics() {
 	local role_filter="pulse"
 	local hours="24"
 	local model_filter=""
+	local fast_threshold_secs="120"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -1311,6 +1312,10 @@ cmd_metrics() {
 			model_filter="${2:-}"
 			shift 2
 			;;
+		--fast-threshold)
+			fast_threshold_secs="${2:-120}"
+			shift 2
+			;;
 		*)
 			print_error "Unknown option for metrics: $1"
 			return 1
@@ -1322,13 +1327,17 @@ cmd_metrics() {
 		print_error "--hours must be an integer"
 		return 1
 	fi
+	if [[ ! "$fast_threshold_secs" =~ ^[0-9]+$ ]]; then
+		print_error "--fast-threshold must be an integer"
+		return 1
+	fi
 
 	if [[ ! -f "$METRICS_FILE" ]]; then
 		print_info "No runtime metrics recorded yet: $METRICS_FILE"
 		return 0
 	fi
 
-	ROLE_FILTER="$role_filter" HOURS="$hours" MODEL_FILTER="$model_filter" METRICS_PATH="$METRICS_FILE" python3 - <<'PY'
+	ROLE_FILTER="$role_filter" HOURS="$hours" MODEL_FILTER="$model_filter" FAST_THRESHOLD_SECS="$fast_threshold_secs" METRICS_PATH="$METRICS_FILE" python3 - <<'PY'
 import json
 import os
 import time
@@ -1338,7 +1347,17 @@ metrics_path = os.environ["METRICS_PATH"]
 role_filter = os.environ.get("ROLE_FILTER", "pulse")
 hours = int(os.environ.get("HOURS", "24"))
 model_filter = os.environ.get("MODEL_FILTER", "")
+fast_threshold_secs = int(os.environ.get("FAST_THRESHOLD_SECS", "120"))
 cutoff = int(time.time()) - (hours * 3600)
+
+def is_expensive_model(model: str) -> bool:
+    normalized = (model or "").lower()
+    return any(token in normalized for token in (
+        "gpt-5.4",
+        "claude-opus",
+        "gemini-2.5-pro",
+        "cursor/composer-2",
+    )) or normalized in {"opus", "pro"}
 
 rows = []
 with open(metrics_path) as f:
@@ -1363,7 +1382,7 @@ if not rows:
     print("No matching runtime metrics in selected window")
     raise SystemExit(0)
 
-agg = defaultdict(lambda: {"runs": 0, "success": 0, "productive": 0, "retry_recovered": 0, "sum_duration": 0})
+agg = defaultdict(lambda: {"runs": 0, "success": 0, "productive": 0, "retry_recovered": 0, "sum_duration": 0, "fast_productive": 0})
 for row in rows:
     model = row.get("model", "unknown")
     item = agg[model]
@@ -1372,18 +1391,28 @@ for row in rows:
         item["success"] += 1
     if row.get("result") == "success" and bool(row.get("activity", False)):
         item["productive"] += 1
+        if int(row.get("duration_ms", 0) or 0) <= (fast_threshold_secs * 1000):
+            item["fast_productive"] += 1
     if int(row.get("exit_code", 1)) == 76:
         item["retry_recovered"] += 1
     item["sum_duration"] += int(row.get("duration_ms", 0) or 0)
 
-print(f"Headless runtime metrics (window={hours}h, role={role_filter})")
+print(f"Headless runtime metrics (window={hours}h, role={role_filter}, fast_threshold={fast_threshold_secs}s)")
+review_candidates = []
 for model in sorted(agg.keys()):
     item = agg[model]
     runs = item["runs"]
     success_pct = (item["success"] / runs) * 100 if runs else 0
     productive_pct = (item["productive"] / runs) * 100 if runs else 0
     avg_sec = (item["sum_duration"] / runs) / 1000 if runs else 0
-    print(f"- {model}: runs={runs}, success={item['success']} ({success_pct:.1f}%), productive={item['productive']} ({productive_pct:.1f}%), pool-recovered={item['retry_recovered']}, avg_duration={avg_sec:.1f}s")
+    print(f"- {model}: runs={runs}, success={item['success']} ({success_pct:.1f}%), productive={item['productive']} ({productive_pct:.1f}%), fast_productive={item['fast_productive']} (<={fast_threshold_secs}s), pool-recovered={item['retry_recovered']}, avg_duration={avg_sec:.1f}s")
+    if item["fast_productive"] > 0 and is_expensive_model(model):
+        review_candidates.append((model, item["fast_productive"], item["productive"]))
+
+if review_candidates:
+    print("Review candidates:")
+    for model, fast_count, productive_count in review_candidates:
+        print(f"- {model}: {fast_count}/{productive_count} productive successful runs finished within {fast_threshold_secs}s; review tier labels for simplification/doc work and prefer a cheaper default where possible")
 PY
 	return 0
 }
@@ -1506,7 +1535,7 @@ Usage:
   headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--agent NAME] [--opencode-arg ARG]
   headless-runtime-helper.sh backoff [status|set MODEL-OR-PROVIDER REASON [SECONDS]|clear MODEL-OR-PROVIDER]
   headless-runtime-helper.sh session [status|clear PROVIDER SESSION_KEY]
-  headless-runtime-helper.sh metrics [--role pulse|worker] [--hours N] [--model SUBSTRING]
+  headless-runtime-helper.sh metrics [--role pulse|worker] [--hours N] [--model SUBSTRING] [--fast-threshold N]
   headless-runtime-helper.sh help
 
 Backoff granularity:

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -245,6 +245,7 @@ OPENCODE_BIN="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "opencod
 PULSE_DIR="${PULSE_DIR:-${HOME}/.aidevops/.agent-workspace}"
 PULSE_MODEL="${PULSE_MODEL:-}"
 HEADLESS_RUNTIME_HELPER="${HEADLESS_RUNTIME_HELPER:-${SCRIPT_DIR}/headless-runtime-helper.sh}"
+MODEL_AVAILABILITY_HELPER="${MODEL_AVAILABILITY_HELPER:-${SCRIPT_DIR}/model-availability-helper.sh}"
 REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 STATE_FILE="${HOME}/.aidevops/logs/pulse-state.txt"
 QUEUE_METRICS_FILE="${HOME}/.aidevops/logs/pulse-queue-metrics"
@@ -269,6 +270,26 @@ if [[ ! -x "$HEADLESS_RUNTIME_HELPER" ]]; then
 	printf '[pulse-wrapper] ERROR: headless runtime helper is missing or not executable: %s (SCRIPT_DIR=%s)\n' "$HEADLESS_RUNTIME_HELPER" "$SCRIPT_DIR" >&2
 	exit 1
 fi
+
+resolve_dispatch_model_for_labels() {
+	local labels_csv="$1"
+	local tier=""
+	local resolved_model=""
+
+	case ",${labels_csv}," in
+	*,tier:thinking,*) tier="opus" ;;
+	*,tier:simple,*) tier="haiku" ;;
+	esac
+
+	if [[ -z "$tier" || ! -x "$MODEL_AVAILABILITY_HELPER" ]]; then
+		printf '%s' ""
+		return 0
+	fi
+
+	resolved_model=$("$MODEL_AVAILABILITY_HELPER" resolve "$tier" --quiet 2>/dev/null || true)
+	printf '%s' "$resolved_model"
+	return 0
+}
 
 #######################################
 # Ensure log and workspace directories exist
@@ -3829,13 +3850,13 @@ This file was previously simplified (PR #${prev_pr}) but has since been modified
 	if [[ "$needs_recheck" == true ]]; then
 		gh issue create --repo "$aidevops_slug" \
 			--title "$issue_title" \
-			--label "simplification-debt" --label "needs-maintainer-review" --label "tier:thinking" --label "recheck-simplicity" \
+			--label "simplification-debt" --label "needs-maintainer-review" --label "tier:simple" --label "recheck-simplicity" \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	else
 		gh issue create --repo "$aidevops_slug" \
 			--title "$issue_title" \
-			--label "simplification-debt" --label "needs-maintainer-review" --label "tier:thinking" \
+			--label "simplification-debt" --label "needs-maintainer-review" --label "tier:simple" \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	fi
@@ -3854,8 +3875,9 @@ This file was previously simplified (PR #${prev_pr}) but has since been modified
 }
 
 # Create GitHub issues for agent docs flagged for simplification review.
-# Uses tier:thinking label (opus) because doc simplification requires deep
-# reasoning to distinguish noise from institutional knowledge.
+# Default these to tier:simple so short doc-tightening work routes to a
+# cheaper worker by default; maintainers can raise to tier:thinking when the
+# issue requires architectural reasoning, security trade-offs, or novel design.
 # Arguments: $1 - scan_results (pipe-delimited: file_path|line_count), $2 - repos_json, $3 - aidevops_slug
 _complexity_scan_create_md_issues() {
 	local scan_results="$1"
@@ -4022,8 +4044,9 @@ This is an automated scan. The function lengths are factual, but the best decomp
 # Results are processed longest-first so the biggest wins come early
 # and the process is refined by the time shorter files are reached.
 #
-# .md issues get tier:thinking (opus) because doc simplification requires
-# deep reasoning to distinguish noise from institutional knowledge.
+# .md issues get tier:simple by default because most simplification debt here
+# is prose tightening/reordering; promote to tier:thinking only for genuinely
+# architectural or security-sensitive docs.
 #
 # Runs at most once per COMPLEXITY_SCAN_INTERVAL (default 15 min — each
 # pulse cycle). Creates up to 5 issues per run; the open cap (200) is
@@ -4662,6 +4685,7 @@ dispatch_with_dedup() {
 	local repo_path="$6"
 	local prompt="$7"
 	local session_key="${8:-issue-${issue_number}}"
+	local model_override="${9:-}"
 
 	# Hard stop for supervisor/telemetry issues (t1702 pulse guard).
 	# The pulse prompt should already avoid these, but this deterministic
@@ -4718,13 +4742,16 @@ dispatch_with_dedup() {
 	ln -s "$worker_log" "$worker_log_fallback" 2>/dev/null || true
 
 	# Launch worker
-	"$HEADLESS_RUNTIME_HELPER" run \
-		--role worker \
-		--session-key "$session_key" \
-		--dir "$repo_path" \
-		--title "$dispatch_title" \
-		--prompt "$prompt" \
-		</dev/null >>"$worker_log" 2>&1 &
+	local -a worker_cmd=("$HEADLESS_RUNTIME_HELPER" run
+		--role worker
+		--session-key "$session_key"
+		--dir "$repo_path"
+		--title "$dispatch_title"
+		--prompt "$prompt")
+	if [[ -n "$model_override" ]]; then
+		worker_cmd+=(--model "$model_override")
+	fi
+	"${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 &
 	local worker_pid="$!"
 	sleep 2
 
@@ -5503,12 +5530,13 @@ dispatch_deterministic_fill_floor() {
 			break
 		fi
 
-		local issue_number repo_slug repo_path issue_url issue_title dispatch_title prompt
+		local issue_number repo_slug repo_path issue_url issue_title dispatch_title prompt labels_csv model_override
 		issue_number=$(printf '%s' "$candidate_json" | jq -r '.number // empty' 2>/dev/null)
 		repo_slug=$(printf '%s' "$candidate_json" | jq -r '.repo_slug // empty' 2>/dev/null)
 		repo_path=$(printf '%s' "$candidate_json" | jq -r '.repo_path // empty' 2>/dev/null)
 		issue_url=$(printf '%s' "$candidate_json" | jq -r '.url // empty' 2>/dev/null)
 		issue_title=$(printf '%s' "$candidate_json" | jq -r '.title // empty' 2>/dev/null | tr '\n' ' ')
+		labels_csv=$(printf '%s' "$candidate_json" | jq -r '(.labels // []) | join(",")' 2>/dev/null)
 		[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
 		[[ -n "$repo_slug" && -n "$repo_path" ]] || continue
 
@@ -5521,10 +5549,11 @@ dispatch_deterministic_fill_floor() {
 		if [[ -n "$issue_url" ]]; then
 			prompt="${prompt} (${issue_url})"
 		fi
+		model_override=$(resolve_dispatch_model_for_labels "$labels_csv")
 
 		local dispatch_rc=0
 		dispatch_with_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
-			"$self_login" "$repo_path" "$prompt" || dispatch_rc=$?
+			"$self_login" "$repo_path" "$prompt" "issue-${issue_number}" "$model_override" || dispatch_rc=$?
 		if [[ "$dispatch_rc" -ne 0 ]]; then
 			continue
 		fi

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -616,6 +616,75 @@ EOF
 	return 0
 }
 
+test_dispatch_with_dedup_passes_explicit_model_override() {
+	local original_script_dir="$SCRIPT_DIR"
+	local original_helper="$HEADLESS_RUNTIME_HELPER"
+	local args_log="${TEST_ROOT}/worker-args.log"
+	SCRIPT_DIR="$TEST_ROOT"
+
+	set_ps_fixture ""
+	: >"$args_log"
+
+	cat >"${TEST_ROOT}/dispatch-dedup-helper.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+claim) exit 0 ;;
+*) exit 1 ;;
+esac
+FIXTURE
+	chmod +x "${TEST_ROOT}/dispatch-dedup-helper.sh"
+
+	cat >"${TEST_ROOT}/dispatch-ledger-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+check-issue) exit 1 ;;
+*) exit 0 ;;
+esac
+STUB
+	chmod +x "${TEST_ROOT}/dispatch-ledger-helper.sh"
+
+	HEADLESS_RUNTIME_HELPER="${TEST_ROOT}/headless-model-stub.sh"
+	cat >"$HEADLESS_RUNTIME_HELPER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >"${args_log}"
+exit 0
+EOF
+	chmod +x "$HEADLESS_RUNTIME_HELPER"
+
+	gh() {
+		if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+			printf '{"state":"OPEN","title":"t8891: model override","labels":[{"name":"tier:simple"}]}'
+			return 0
+		fi
+		return 0
+	}
+	export -f gh
+
+	local dispatch_rc=0
+	dispatch_with_dedup "8891" "marcusquinn/aidevops" "Issue #8891: model override" "t8891: model override" \
+		"testuser" "/tmp/aidevops" "/full-loop test" "issue-8891" "anthropic/claude-haiku-4-5" || dispatch_rc=$?
+
+	local args_contents=""
+	if [[ -f "$args_log" ]]; then
+		args_contents=$(tr '\n' ' ' <"$args_log")
+	fi
+
+	HEADLESS_RUNTIME_HELPER="$original_helper"
+	SCRIPT_DIR="$original_script_dir"
+	unset -f gh
+
+	if [[ "$dispatch_rc" -eq 0 && "$args_contents" == *"--model anthropic/claude-haiku-4-5"* ]]; then
+		print_result "dispatch_with_dedup forwards explicit model override to worker launch" 0
+		return 0
+	fi
+
+	print_result "dispatch_with_dedup forwards explicit model override to worker launch" 1 \
+		"dispatch_rc=${dispatch_rc}, args='${args_contents}'"
+	return 0
+}
+
 test_build_ranked_dispatch_candidates_json_scores_candidates() {
 	local original_repos_json="$REPOS_JSON"
 	cat >"${REPOS_JSON}" <<'JSON'
@@ -679,10 +748,19 @@ test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity() {
 	local dispatch_log="${TEST_ROOT}/deterministic-dispatch.log"
 	: >"$dispatch_log"
 
+	resolve_dispatch_model_for_labels() {
+		if [[ "$1" == *"tier:simple"* ]]; then
+			echo "anthropic/claude-haiku-4-5"
+			return 0
+		fi
+		echo ""
+		return 0
+	}
+
 	build_ranked_dispatch_candidates_json() {
 		printf '%s\n' '[
 		  {"number":9101,"repo_slug":"marcusquinn/aidevops","repo_path":"/tmp/aidevops","url":"https://github.com/marcusquinn/aidevops/issues/9101","title":"candidate one","labels":["bug"],"updatedAt":"2026-03-31T00:00:00Z","score":8000},
-		  {"number":9102,"repo_slug":"marcusquinn/aidevops","repo_path":"/tmp/aidevops","url":"https://github.com/marcusquinn/aidevops/issues/9102","title":"candidate two","labels":["simplification-debt"],"updatedAt":"2026-03-31T00:01:00Z","score":4000},
+		  {"number":9102,"repo_slug":"marcusquinn/aidevops","repo_path":"/tmp/aidevops","url":"https://github.com/marcusquinn/aidevops/issues/9102","title":"candidate two","labels":["simplification-debt","tier:simple"],"updatedAt":"2026-03-31T00:01:00Z","score":4000},
 		  {"number":9103,"repo_slug":"marcusquinn/aidevops","repo_path":"/tmp/aidevops","url":"https://github.com/marcusquinn/aidevops/issues/9103","title":"candidate three","labels":["simplification-debt"],"updatedAt":"2026-03-31T00:02:00Z","score":4000}
 		]'
 	}
@@ -692,7 +770,7 @@ test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity() {
 	count_queued_without_worker() { echo 0; }
 	check_terminal_blockers() { return 1; }
 	dispatch_with_dedup() {
-		printf '%s\n' "$1" >>"$dispatch_log"
+		printf '%s|%s\n' "$1" "${9:-}" >>"$dispatch_log"
 		return 0
 	}
 	check_worker_launch() { return 0; }
@@ -711,12 +789,12 @@ test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity() {
 
 	unset -f gh build_ranked_dispatch_candidates_json get_max_workers_target count_active_workers count_runnable_candidates count_queued_without_worker check_terminal_blockers dispatch_with_dedup check_worker_launch
 
-	if [[ "$dispatch_count" == "2" && "$dispatched_numbers" == "9101,9102" ]]; then
-		print_result "dispatch_deterministic_fill_floor dispatches ranked candidates up to capacity" 0
+	if [[ "$dispatch_count" == "2" && "$dispatched_numbers" == "9101|,9102|anthropic/claude-haiku-4-5" ]]; then
+		print_result "dispatch_deterministic_fill_floor dispatches ranked candidates up to capacity and honors simple-tier override" 0
 		return 0
 	fi
 
-	print_result "dispatch_deterministic_fill_floor dispatches ranked candidates up to capacity" 1 \
+	print_result "dispatch_deterministic_fill_floor dispatches ranked candidates up to capacity and honors simple-tier override" 1 \
 		"Expected count=2 and issues 9101,9102; got count=${dispatch_count}, issues=${dispatched_numbers}"
 	return 0
 }
@@ -942,6 +1020,7 @@ main() {
 	test_dispatch_with_dedup_fails_closed_when_issue_metadata_missing
 	test_dispatch_with_dedup_proceeds_when_no_duplicate
 	test_dispatch_with_dedup_detaches_worker_stdio
+	test_dispatch_with_dedup_passes_explicit_model_override
 	test_build_ranked_dispatch_candidates_json_scores_candidates
 	test_build_ranked_dispatch_candidates_json_respects_schedule_gate
 	test_dispatch_deterministic_fill_floor_dispatches_up_to_capacity

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -45,9 +45,15 @@ export STUB_LOG_FILE="$TEST_TMP_DIR/opencode-args.log"
 # Set a known model list so tests are self-contained and don't depend on
 # the user's environment. Includes two providers for rotation/fallback tests.
 export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex"
+unset AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST
 # Disable sandbox for tests — the sandbox strips env vars (STUB_*) needed
 # by the opencode stub, causing test failures.
 export AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1
+# Disable pattern-driven downgrades so selection-order tests stay deterministic.
+unset AIDEVOPS_TIER_DOWNGRADE_TASK_TYPE
+# Provide a fake Anthropic API key so Anthropic remains selectable even when
+# the local environment has no OpenCode auth session.
+export ANTHROPIC_API_KEY="test-key-for-provider-auth-check"
 # Provide a fake OpenAI API key so provider_auth_available("openai") returns true
 # in tests that exercise OpenAI model selection. Tests for the no-auth path
 # explicitly unset this and remove the auth file.
@@ -493,6 +499,20 @@ if [[ "$config_selected" == "openai/gpt-5.4" ]]; then
 	pass "JSONC orchestration.headless_models overrides default selection"
 else
 	fail "JSONC orchestration.headless_models overrides default selection" "got: $config_selected"
+fi
+
+section "Metrics Review Signals"
+METRICS_PATH="$HOME/.aidevops/logs"
+mkdir -p "$METRICS_PATH"
+cat >"$METRICS_PATH/headless-runtime-metrics.jsonl" <<'JSONL'
+{"ts":4102444800,"role":"worker","model":"openai/gpt-5.4","result":"success","activity":true,"duration_ms":45000,"exit_code":0}
+{"ts":4102444800,"role":"worker","model":"anthropic/claude-sonnet-4-6","result":"success","activity":true,"duration_ms":240000,"exit_code":0}
+JSONL
+metrics_output=$(bash "$HELPER" metrics --role worker --hours 24 2>/dev/null || true)
+if [[ "$metrics_output" == *"fast_productive=1 (<=120s)"* && "$metrics_output" == *"Review candidates:"* && "$metrics_output" == *"openai/gpt-5.4"* ]]; then
+	pass "metrics flags fast successful expensive-model runs for review"
+else
+	fail "metrics flags fast successful expensive-model runs for review" "got: $metrics_output"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- route `tier:simple` work through an explicit haiku-tier model override in the deterministic pulse fill floor instead of leaving simplification/doc debt on the default worker rotation
- relabel automated `.md` simplification-debt issues to `tier:simple` by default and document when maintainers should promote them back to `tier:thinking`
- extend headless runtime metrics with fast-success review signals so productive sub-120s runs on expensive models are surfaced for reclassification

## Testing
- `bash -n .agents/scripts/pulse-wrapper.sh && bash -n .agents/scripts/headless-runtime-helper.sh && bash -n .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh && bash -n tests/test-headless-runtime-helper.sh`
- `shellcheck -e SC1091 .agents/scripts/pulse-wrapper.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`
- `bash tests/test-headless-runtime-helper.sh`

## Runtime Testing
- Level: self-assessed
- Evidence: exercised the changed dispatch and metrics paths via shell test fixtures in `.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh` and `tests/test-headless-runtime-helper.sh`
- Limitation: no live pulse cycle was run against production queues in this session

Closes #14946

---
[aidevops.sh](https://aidevops.sh) v3.5.524 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 12m and 167,606 tokens on this with the user in an interactive session. Overall, 20m since this issue was created.