### PR TITLE
GH#14947: add review-backlog backpressure and merge prioritization

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -161,21 +161,25 @@ if [[ -z "${AIDEVOPS_HEADLESS_MODELS:-}" ]]; then
 		export AIDEVOPS_HEADLESS_MODELS
 	fi
 fi
-PULSE_BACKFILL_MAX_ATTEMPTS="${PULSE_BACKFILL_MAX_ATTEMPTS:-3}"              # Additional pulse passes when below utilization target (t1453)
-PULSE_LAUNCH_GRACE_SECONDS="${PULSE_LAUNCH_GRACE_SECONDS:-20}"               # Grace window for worker process to appear after dispatch (t1453)
-PRE_RUN_STAGE_TIMEOUT="${PRE_RUN_STAGE_TIMEOUT:-600}"                        # 10 min cap per pre-run stage (cleanup/prefetch)
-PULSE_PREFETCH_PR_LIMIT="${PULSE_PREFETCH_PR_LIMIT:-200}"                    # Open PR list window per repo for pre-fetched state
-PULSE_PREFETCH_ISSUE_LIMIT="${PULSE_PREFETCH_ISSUE_LIMIT:-200}"              # Open issue list window for pulse prompt payload (keep compact)
-PULSE_RUNNABLE_PR_LIMIT="${PULSE_RUNNABLE_PR_LIMIT:-200}"                    # Open PR sample size for runnable-candidate counting
-PULSE_RUNNABLE_ISSUE_LIMIT="${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}"             # Open issue sample size for runnable-candidate counting
-PULSE_QUEUED_SCAN_LIMIT="${PULSE_QUEUED_SCAN_LIMIT:-1000}"                   # Queued/in-progress scan window per repo
-UNDERFILL_RECYCLE_DEFICIT_MIN_PCT="${UNDERFILL_RECYCLE_DEFICIT_MIN_PCT:-25}" # Run worker recycler when underfill reaches this threshold
-GH_FAILURE_PREFETCH_HOURS="${GH_FAILURE_PREFETCH_HOURS:-24}"                 # Window for failed-notification mining summary
-GH_FAILURE_PREFETCH_LIMIT="${GH_FAILURE_PREFETCH_LIMIT:-100}"                # Notification page size for failed-notification mining
-GH_FAILURE_SYSTEMIC_THRESHOLD="${GH_FAILURE_SYSTEMIC_THRESHOLD:-3}"          # Cluster threshold for systemic-failure flag
-GH_FAILURE_MAX_RUN_LOGS="${GH_FAILURE_MAX_RUN_LOGS:-6}"                      # Max failed workflow runs to sample for signatures per pulse
-FOSS_SCAN_TIMEOUT="${FOSS_SCAN_TIMEOUT:-30}"                                 # Timeout for FOSS contribution scan prefetch (t1702)
-FOSS_MAX_DISPATCH_PER_CYCLE="${FOSS_MAX_DISPATCH_PER_CYCLE:-2}"              # Max FOSS contribution workers per pulse cycle (t1702)
+PULSE_BACKFILL_MAX_ATTEMPTS="${PULSE_BACKFILL_MAX_ATTEMPTS:-3}"                    # Additional pulse passes when below utilization target (t1453)
+PULSE_LAUNCH_GRACE_SECONDS="${PULSE_LAUNCH_GRACE_SECONDS:-20}"                     # Grace window for worker process to appear after dispatch (t1453)
+PRE_RUN_STAGE_TIMEOUT="${PRE_RUN_STAGE_TIMEOUT:-600}"                              # 10 min cap per pre-run stage (cleanup/prefetch)
+PULSE_PREFETCH_PR_LIMIT="${PULSE_PREFETCH_PR_LIMIT:-200}"                          # Open PR list window per repo for pre-fetched state
+PULSE_PREFETCH_ISSUE_LIMIT="${PULSE_PREFETCH_ISSUE_LIMIT:-200}"                    # Open issue list window for pulse prompt payload (keep compact)
+PULSE_RUNNABLE_PR_LIMIT="${PULSE_RUNNABLE_PR_LIMIT:-200}"                          # Open PR sample size for runnable-candidate counting
+PULSE_RUNNABLE_ISSUE_LIMIT="${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}"                   # Open issue sample size for runnable-candidate counting
+PULSE_QUEUED_SCAN_LIMIT="${PULSE_QUEUED_SCAN_LIMIT:-1000}"                         # Queued/in-progress scan window per repo
+UNDERFILL_RECYCLE_DEFICIT_MIN_PCT="${UNDERFILL_RECYCLE_DEFICIT_MIN_PCT:-25}"       # Run worker recycler when underfill reaches this threshold
+PULSE_PR_BACKLOG_HEAVY_THRESHOLD="${PULSE_PR_BACKLOG_HEAVY_THRESHOLD:-100}"        # Stronger PR-first mode when open backlog reaches this size
+PULSE_PR_BACKLOG_CRITICAL_THRESHOLD="${PULSE_PR_BACKLOG_CRITICAL_THRESHOLD:-175}"  # Merge-first mode when open backlog becomes severe
+PULSE_READY_PR_MERGE_HEAVY_THRESHOLD="${PULSE_READY_PR_MERGE_HEAVY_THRESHOLD:-10}" # Merge-first when enough PRs are ready immediately
+PULSE_FAILING_PR_HEAVY_THRESHOLD="${PULSE_FAILING_PR_HEAVY_THRESHOLD:-25}"         # PR-first when failing/review-blocked queue is large
+GH_FAILURE_PREFETCH_HOURS="${GH_FAILURE_PREFETCH_HOURS:-24}"                       # Window for failed-notification mining summary
+GH_FAILURE_PREFETCH_LIMIT="${GH_FAILURE_PREFETCH_LIMIT:-100}"                      # Notification page size for failed-notification mining
+GH_FAILURE_SYSTEMIC_THRESHOLD="${GH_FAILURE_SYSTEMIC_THRESHOLD:-3}"                # Cluster threshold for systemic-failure flag
+GH_FAILURE_MAX_RUN_LOGS="${GH_FAILURE_MAX_RUN_LOGS:-6}"                            # Max failed workflow runs to sample for signatures per pulse
+FOSS_SCAN_TIMEOUT="${FOSS_SCAN_TIMEOUT:-30}"                                       # Timeout for FOSS contribution scan prefetch (t1702)
+FOSS_MAX_DISPATCH_PER_CYCLE="${FOSS_MAX_DISPATCH_PER_CYCLE:-2}"                    # Max FOSS contribution workers per pulse cycle (t1702)
 
 # Process guard limits (t1398)
 CHILD_RSS_LIMIT_KB="${CHILD_RSS_LIMIT_KB:-2097152}"           # 2 GB default — kill child if RSS exceeds this
@@ -213,6 +217,13 @@ PULSE_QUEUED_SCAN_LIMIT=$(_validate_int PULSE_QUEUED_SCAN_LIMIT "$PULSE_QUEUED_S
 UNDERFILL_RECYCLE_DEFICIT_MIN_PCT=$(_validate_int UNDERFILL_RECYCLE_DEFICIT_MIN_PCT "$UNDERFILL_RECYCLE_DEFICIT_MIN_PCT" 25 1)
 if [[ "$UNDERFILL_RECYCLE_DEFICIT_MIN_PCT" -gt 100 ]]; then
 	UNDERFILL_RECYCLE_DEFICIT_MIN_PCT=100
+fi
+PULSE_PR_BACKLOG_HEAVY_THRESHOLD=$(_validate_int PULSE_PR_BACKLOG_HEAVY_THRESHOLD "$PULSE_PR_BACKLOG_HEAVY_THRESHOLD" 100 1)
+PULSE_PR_BACKLOG_CRITICAL_THRESHOLD=$(_validate_int PULSE_PR_BACKLOG_CRITICAL_THRESHOLD "$PULSE_PR_BACKLOG_CRITICAL_THRESHOLD" 175 1)
+PULSE_READY_PR_MERGE_HEAVY_THRESHOLD=$(_validate_int PULSE_READY_PR_MERGE_HEAVY_THRESHOLD "$PULSE_READY_PR_MERGE_HEAVY_THRESHOLD" 10 1)
+PULSE_FAILING_PR_HEAVY_THRESHOLD=$(_validate_int PULSE_FAILING_PR_HEAVY_THRESHOLD "$PULSE_FAILING_PR_HEAVY_THRESHOLD" 25 1)
+if [[ "$PULSE_PR_BACKLOG_CRITICAL_THRESHOLD" -lt "$PULSE_PR_BACKLOG_HEAVY_THRESHOLD" ]]; then
+	PULSE_PR_BACKLOG_CRITICAL_THRESHOLD="$PULSE_PR_BACKLOG_HEAVY_THRESHOLD"
 fi
 GH_FAILURE_PREFETCH_HOURS=$(_validate_int GH_FAILURE_PREFETCH_HOURS "$GH_FAILURE_PREFETCH_HOURS" 24 1)
 GH_FAILURE_PREFETCH_LIMIT=$(_validate_int GH_FAILURE_PREFETCH_LIMIT "$GH_FAILURE_PREFETCH_LIMIT" 100 1)
@@ -5000,7 +5011,7 @@ _compute_queue_governor_guidance() {
 	[[ "$ready_prs" =~ ^[0-9]+$ ]] || ready_prs=0
 	[[ "$failing_prs" =~ ^[0-9]+$ ]] || failing_prs=0
 
-	local prev_total_prs=0 prev_total_issues=0 prev_ready_prs=0 prev_failing_prs=0
+	local prev_total_prs=0 prev_total_issues=0 prev_ready_prs=0 prev_failing_prs=0 prev_recorded_at=0
 	if [[ -f "$QUEUE_METRICS_FILE" ]]; then
 		while IFS='=' read -r key value; do
 			case "$key" in
@@ -5008,6 +5019,7 @@ _compute_queue_governor_guidance() {
 			prev_total_issues) prev_total_issues="$value" ;;
 			prev_ready_prs) prev_ready_prs="$value" ;;
 			prev_failing_prs) prev_failing_prs="$value" ;;
+			prev_recorded_at) prev_recorded_at="$value" ;;
 			esac
 		done <"$QUEUE_METRICS_FILE"
 	fi
@@ -5016,12 +5028,34 @@ _compute_queue_governor_guidance() {
 	[[ "$prev_total_issues" =~ ^-?[0-9]+$ ]] || prev_total_issues=0
 	[[ "$prev_ready_prs" =~ ^-?[0-9]+$ ]] || prev_ready_prs=0
 	[[ "$prev_failing_prs" =~ ^-?[0-9]+$ ]] || prev_failing_prs=0
+	[[ "$prev_recorded_at" =~ ^[0-9]+$ ]] || prev_recorded_at=0
+
+	local now_epoch elapsed_seconds
+	now_epoch=$(date +%s)
+	elapsed_seconds=$((now_epoch - prev_recorded_at))
+	if [[ "$elapsed_seconds" -lt 0 ]]; then
+		elapsed_seconds=0
+	fi
 
 	local pr_delta issue_delta ready_delta failing_delta
 	pr_delta=$((total_prs - prev_total_prs))
 	issue_delta=$((total_issues - prev_total_issues))
 	ready_delta=$((ready_prs - prev_ready_prs))
 	failing_delta=$((failing_prs - prev_failing_prs))
+
+	local backlog_drain_per_cycle backlog_growth_pressure drain_rate_per_hour
+	backlog_drain_per_cycle=$((prev_total_prs - total_prs))
+	if [[ "$backlog_drain_per_cycle" -lt 0 ]]; then
+		backlog_drain_per_cycle=0
+	fi
+	backlog_growth_pressure=$pr_delta
+	if [[ "$backlog_growth_pressure" -lt 0 ]]; then
+		backlog_growth_pressure=0
+	fi
+	drain_rate_per_hour="n/a"
+	if [[ "$elapsed_seconds" -gt 0 && "$backlog_drain_per_cycle" -gt 0 ]]; then
+		drain_rate_per_hour=$(((backlog_drain_per_cycle * 3600) / elapsed_seconds))
+	fi
 
 	local denominator pr_share_pct growth_bias pr_focus_pct new_issue_pct
 	denominator=$((total_prs + total_issues))
@@ -5043,32 +5077,68 @@ _compute_queue_governor_guidance() {
 	fi
 	new_issue_pct=$((100 - pr_focus_pct))
 
-	local queue_mode
+	local queue_mode backlog_band
 	queue_mode="balanced"
-	if [[ "$ready_prs" -gt 0 && "$pr_delta" -ge 0 ]]; then
-		queue_mode="merge-heavy"
-	elif [[ "$pr_focus_pct" -ge 60 ]]; then
-		queue_mode="pr-heavy"
+	backlog_band="normal"
+	if [[ "$total_prs" -ge "$PULSE_PR_BACKLOG_CRITICAL_THRESHOLD" ]]; then
+		backlog_band="critical"
+	elif [[ "$total_prs" -ge "$PULSE_PR_BACKLOG_HEAVY_THRESHOLD" ]]; then
+		backlog_band="heavy"
 	fi
+
+	if [[ "$backlog_band" == "critical" || ("$ready_prs" -ge "$PULSE_READY_PR_MERGE_HEAVY_THRESHOLD" && "$pr_delta" -ge 0) ]]; then
+		queue_mode="merge-heavy"
+		if [[ "$pr_focus_pct" -lt 90 ]]; then
+			pr_focus_pct=90
+		fi
+	elif [[ "$backlog_band" == "heavy" || "$failing_prs" -ge "$PULSE_FAILING_PR_HEAVY_THRESHOLD" || "$pr_focus_pct" -ge 60 ]]; then
+		queue_mode="pr-heavy"
+		if [[ "$pr_focus_pct" -lt 75 ]]; then
+			pr_focus_pct=75
+		fi
+	fi
+	new_issue_pct=$((100 - pr_focus_pct))
+
+	local active_workers max_workers utilization_pct
+	active_workers=$(count_active_workers)
+	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+	max_workers=$(get_max_workers_target)
+	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
+	if [[ "$max_workers" -lt 1 ]]; then
+		max_workers=1
+	fi
+	utilization_pct=$(((active_workers * 100) / max_workers))
 
 	cat >"$QUEUE_METRICS_FILE" <<EOF
 prev_total_prs=${total_prs}
 prev_total_issues=${total_issues}
 prev_ready_prs=${ready_prs}
 prev_failing_prs=${failing_prs}
+prev_recorded_at=${now_epoch}
 EOF
 
 	{
 		echo ""
 		echo "## Adaptive Queue Governor"
 		echo "- Queue totals: PRs=${total_prs} (delta ${pr_delta}), issues=${total_issues} (delta ${issue_delta})"
+		echo "- Backlog thresholds: heavy>=${PULSE_PR_BACKLOG_HEAVY_THRESHOLD}, critical>=${PULSE_PR_BACKLOG_CRITICAL_THRESHOLD}; current_band=${backlog_band}"
 		echo "- PR execution pressure: ready=${ready_prs} (delta ${ready_delta}), failing_or_changes_requested=${failing_prs} (delta ${failing_delta})"
+		echo "- Merge-drain telemetry: open_pr_drain_per_cycle=${backlog_drain_per_cycle}, open_pr_growth_pressure=${backlog_growth_pressure}, estimated_merge_drain_per_hour=${drain_rate_per_hour}"
+		echo "- Worker utilization snapshot: active=${active_workers}/${max_workers} (${utilization_pct}%)"
 		echo "- Adaptive mode this cycle: ${queue_mode}"
 		echo "- Recommended dispatch focus: PR remediation ${pr_focus_pct}% / new issue dispatch ${new_issue_pct}%"
 		echo ""
 		echo "PULSE_QUEUE_MODE=${queue_mode}"
+		echo "PULSE_PR_BACKLOG_BAND=${backlog_band}"
 		echo "PR_REMEDIATION_FOCUS_PCT=${pr_focus_pct}"
 		echo "NEW_ISSUE_DISPATCH_PCT=${new_issue_pct}"
+		echo "OPEN_PR_BACKLOG=${total_prs}"
+		echo "OPEN_PR_DRAIN_PER_CYCLE=${backlog_drain_per_cycle}"
+		echo "OPEN_PR_GROWTH_PRESSURE=${backlog_growth_pressure}"
+		echo "ESTIMATED_MERGE_DRAIN_PER_HOUR=${drain_rate_per_hour}"
+		echo "PULSE_ACTIVE_WORKERS=${active_workers}"
+		echo "PULSE_MAX_WORKERS=${max_workers}"
+		echo "PULSE_WORKER_UTILIZATION_PCT=${utilization_pct}"
 		echo ""
 		echo "When PR backlog is rising, prioritize merge-ready and failing-check PR advancement before new issue starts."
 	} >>"$STATE_FILE"

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -347,6 +347,74 @@ test_count_queued_without_worker_keeps_stdout_numeric_with_debug() {
 	return 0
 }
 
+test_queue_governor_enters_merge_heavy_at_critical_backlog() {
+	STATE_FILE="${HOME}/.aidevops/logs/pulse-state.txt"
+	QUEUE_METRICS_FILE="${HOME}/.aidevops/logs/pulse-queue-metrics"
+	: >"$STATE_FILE"
+	printf '12\n' >"${HOME}/.aidevops/logs/pulse-max-workers"
+	PS_MOCK_OUTPUT="/usr/local/bin/.opencode run --dir /repo-a --title \"Issue #100\" \"/full-loop Implement issue #100\"
+/usr/local/bin/.opencode run --dir /repo-b --title \"Issue #101\" \"/full-loop Implement issue #101\"
+/usr/local/bin/.opencode run --dir /repo-c --title \"Issue #102\" \"/full-loop Implement issue #102\""
+
+	_compute_queue_governor_guidance 180 40 12 8
+
+	local state_text
+	state_text=$(<"$STATE_FILE")
+	if [[ "$state_text" == *"PULSE_QUEUE_MODE=merge-heavy"* && "$state_text" == *"PULSE_PR_BACKLOG_BAND=critical"* && "$state_text" == *"NEW_ISSUE_DISPATCH_PCT=10"* && "$state_text" == *"PULSE_WORKER_UTILIZATION_PCT=25"* ]]; then
+		print_result "queue governor enters merge-heavy at critical backlog" 0
+		return 0
+	fi
+
+	print_result "queue governor enters merge-heavy at critical backlog" 1 "Unexpected governor output: ${state_text}"
+	return 0
+}
+
+test_queue_governor_enters_pr_heavy_at_heavy_backlog() {
+	STATE_FILE="${HOME}/.aidevops/logs/pulse-state.txt"
+	QUEUE_METRICS_FILE="${HOME}/.aidevops/logs/pulse-queue-metrics"
+	: >"$STATE_FILE"
+	printf 'prev_total_prs=80\nprev_total_issues=110\nprev_ready_prs=4\nprev_failing_prs=10\nprev_recorded_at=1\n' >"$QUEUE_METRICS_FILE"
+	printf '8\n' >"${HOME}/.aidevops/logs/pulse-max-workers"
+	PS_MOCK_OUTPUT="/usr/local/bin/.opencode run --dir /repo-a --title \"Issue #200\" \"/full-loop Implement issue #200\""
+
+	_compute_queue_governor_guidance 110 120 3 28
+
+	local state_text
+	state_text=$(<"$STATE_FILE")
+	if [[ "$state_text" == *"PULSE_QUEUE_MODE=pr-heavy"* && "$state_text" == *"PULSE_PR_BACKLOG_BAND=heavy"* && "$state_text" == *"PR_REMEDIATION_FOCUS_PCT=75"* && "$state_text" == *"NEW_ISSUE_DISPATCH_PCT=25"* ]]; then
+		print_result "queue governor enters pr-heavy at heavy backlog" 0
+		return 0
+	fi
+
+	print_result "queue governor enters pr-heavy at heavy backlog" 1 "Unexpected governor output: ${state_text}"
+	return 0
+}
+
+test_queue_governor_reports_drain_rate_telemetry() {
+	STATE_FILE="${HOME}/.aidevops/logs/pulse-state.txt"
+	QUEUE_METRICS_FILE="${HOME}/.aidevops/logs/pulse-queue-metrics"
+	: >"$STATE_FILE"
+	local now_epoch previous_epoch
+	now_epoch=$(date +%s)
+	previous_epoch=$((now_epoch - 1800))
+	printf 'prev_total_prs=120\nprev_total_issues=80\nprev_ready_prs=8\nprev_failing_prs=18\nprev_recorded_at=%s\n' "$previous_epoch" >"$QUEUE_METRICS_FILE"
+	printf '6\n' >"${HOME}/.aidevops/logs/pulse-max-workers"
+	PS_MOCK_OUTPUT="/usr/local/bin/.opencode run --dir /repo-a --title \"Issue #300\" \"/full-loop Implement issue #300\"
+/usr/local/bin/.opencode run --dir /repo-b --title \"Issue #301\" \"/full-loop Implement issue #301\""
+
+	_compute_queue_governor_guidance 114 82 6 16
+
+	local state_text
+	state_text=$(<"$STATE_FILE")
+	if [[ "$state_text" == *"OPEN_PR_DRAIN_PER_CYCLE=6"* && "$state_text" == *"ESTIMATED_MERGE_DRAIN_PER_HOUR=12"* && "$state_text" == *"PULSE_ACTIVE_WORKERS=2"* && "$state_text" == *"PULSE_MAX_WORKERS=6"* && "$state_text" == *"PULSE_WORKER_UTILIZATION_PCT=33"* ]]; then
+		print_result "queue governor reports drain rate telemetry" 0
+		return 0
+	fi
+
+	print_result "queue governor reports drain rate telemetry" 1 "Unexpected telemetry output: ${state_text}"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -363,6 +431,9 @@ main() {
 	test_count_runnable_candidates_counts_passive_assignee_backlog
 	test_count_runnable_candidates_keeps_stdout_numeric_with_debug
 	test_count_queued_without_worker_keeps_stdout_numeric_with_debug
+	test_queue_governor_enters_merge_heavy_at_critical_backlog
+	test_queue_governor_enters_pr_heavy_at_heavy_backlog
+	test_queue_governor_reports_drain_rate_telemetry
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Add PR-backlog thresholds to pulse queue governance so large open PR queues apply stronger issue-dispatch backpressure.
- Escalate queue mode to `pr-heavy` and `merge-heavy` based on backlog size and readiness/failure pressure, with enforced minimum PR remediation focus.
- Emit merge-drain and worker-utilization telemetry in pre-fetched pulse state so throughput bottlenecks are visible to the pulse model.

## Testing
- `shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-worker-count.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh`

## Runtime Testing
- Level: high
- Evidence: exercised queue-governor execution path in shell runtime via deterministic tests for critical/heavy backlog modes and drain-rate/utilization telemetry output.

Closes #14947


---
[aidevops.sh](https://aidevops.sh) v3.5.525 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.3-codex spent 6m and 76,992 tokens on this with the user in an interactive session. Overall, 28m since this issue was created.