### PR TITLE
GH#14953: default-open pulse eligibility except needs-* labels

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4362,27 +4362,19 @@ list_dispatchable_issue_candidates_json() {
 	fi
 	[[ "$limit" =~ ^[0-9]+$ ]] || limit=100
 
-	local repo_owner repo_maintainer passive_assignees_json issue_json
-	repo_owner=$(get_repo_owner_by_slug "$repo_slug")
-	repo_maintainer=$(get_repo_maintainer_by_slug "$repo_slug")
-	passive_assignees_json=$(printf '%s\n%s\n' "$repo_owner" "$repo_maintainer" | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || passive_assignees_json='[]'
+	local issue_json
 
 	issue_json=$(gh issue list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,updatedAt --limit "$limit" 2>/dev/null) || issue_json="[]"
 
-	printf '%s' "$issue_json" | jq -c --argjson passive "$passive_assignees_json" '
+	printf '%s' "$issue_json" | jq -c '
 		[
 			.[] |
 			(.labels | map(.name)) as $labels |
 			(.assignees | map(.login)) as $assignees |
 			select(($labels | index("status:blocked")) == null) |
-			select(($labels | index("status:needs-info")) == null) |
-			select(($labels | index("needs-maintainer-review")) == null) |
-			select(($labels | index("status:queued")) == null) |
-			select(($labels | index("status:in-progress")) == null) |
-			select(($labels | index("status:in-review")) == null) |
+			select(([$labels[] | select(startswith("needs-"))] | length) == 0) |
 			select(($labels | index("supervisor")) == null) |
 			select(($labels | index("persistent")) == null) |
-			select(($assignees | length) == 0 or ($assignees | all(.[]; . as $a | $passive | index($a) != null))) |
 			{
 				number,
 				title,
@@ -4401,11 +4393,11 @@ list_dispatchable_issue_candidates_json() {
 # in a single repo.
 #
 # Candidate rules:
-# - open and not blocked / needs-info / needs-maintainer-review
-# - not already in queued/in-progress/in-review state
-# - not supervisor/persistent telemetry issues
-# - unassigned OR assigned only to passive backlog holders
-#   (repo owner and/or repo maintainer)
+# - open and not blocked
+# - exclude any issue carrying a needs-* label (e.g. needs-maintainer-review)
+# - include queued/in-progress/in-review states (status labels are not blockers)
+# - include assigned issues (assignment state is resolved by dedup/claim checks)
+# - exclude supervisor/persistent telemetry issues
 #
 # Active PR/worker overlap is handled later by deterministic dedup guards.
 # This helper only answers: "should the pulse look at this issue at all?"
@@ -5116,8 +5108,8 @@ get_max_workers_target() {
 #######################################
 # Count runnable backlog candidates across pulse scope
 # Heuristic for t1453 utilization loop:
-# - open inactive backlog issues (unassigned or only passively assigned to
-#   repo owner/maintainer)
+# - open issues passing default-open candidate filter
+#   (non-needs-* and non-management labels)
 # - open PRs with failing checks or changes requested
 # Returns: count via stdout
 #######################################

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -234,7 +234,7 @@ test_counts_review_issue_pr_workers() {
 	return 0
 }
 
-test_list_dispatchable_candidates_include_passive_assignees() {
+test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	local repos_json_path="${HOME}/.config/aidevops/repos.json"
 	mkdir -p "$(dirname "$repos_json_path")"
 	printf '{"initialized_repos":[{"slug":"owner/repo","path":"/tmp/repo","pulse":true,"maintainer":"maintainer-bot"}]}\n' >"$repos_json_path"
@@ -247,23 +247,25 @@ test_list_dispatchable_candidates_include_passive_assignees() {
 	  {"number":4,"title":"runner assigned","updatedAt":"2026-03-31T00:03:00Z","assignees":[{"login":"other-runner"}],"labels":[{"name":"priority:high"}]},
 	  {"number":5,"title":"owner queued","updatedAt":"2026-03-31T00:04:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:queued"}]},
 	  {"number":6,"title":"needs review","updatedAt":"2026-03-31T00:05:00Z","assignees":[],"labels":[{"name":"needs-maintainer-review"}]},
-	  {"number":7,"title":"supervisor telemetry","updatedAt":"2026-03-31T00:06:00Z","assignees":[],"labels":[{"name":"supervisor"}]}
+	  {"number":7,"title":"needs docs","updatedAt":"2026-03-31T00:06:00Z","assignees":[],"labels":[{"name":"needs-docs"}]},
+	  {"number":8,"title":"supervisor telemetry","updatedAt":"2026-03-31T00:07:00Z","assignees":[],"labels":[{"name":"supervisor"}]},
+	  {"number":9,"title":"in progress but runnable","updatedAt":"2026-03-31T00:08:00Z","assignees":[{"login":"owner"}],"labels":[{"name":"status:in-progress"}]}
 	]'
 	GH_PR_LIST_JSON='[]'
 
 	local output
 	output=$(list_dispatchable_issue_candidates "owner/repo" 100)
 
-	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" != *$'4|runner assigned'* && "$output" != *$'5|owner queued'* && "$output" != *$'6|needs review'* && "$output" != *$'7|supervisor telemetry'* ]]; then
-		print_result "list_dispatchable_issue_candidates includes passive assignees only" 0
+	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" == *$'9|in progress but runnable'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* ]]; then
+		print_result "list_dispatchable_issue_candidates is default-open except needs-*" 0
 		return 0
 	fi
 
-	print_result "list_dispatchable_issue_candidates includes passive assignees only" 1 "Unexpected candidate set: ${output}"
+	print_result "list_dispatchable_issue_candidates is default-open except needs-*" 1 "Unexpected candidate set: ${output}"
 	return 0
 }
 
-test_count_runnable_candidates_counts_passive_assignee_backlog() {
+test_count_runnable_candidates_counts_default_open_backlog() {
 	local repos_json_path="${HOME}/.config/aidevops/repos.json"
 	mkdir -p "$(dirname "$repos_json_path")"
 	printf '{"initialized_repos":[{"slug":"owner/repo","path":"/tmp/repo","pulse":true,"maintainer":"maintainer-bot"}]}\n' >"$repos_json_path"
@@ -283,12 +285,12 @@ test_count_runnable_candidates_counts_passive_assignee_backlog() {
 	local count
 	count=$(count_runnable_candidates)
 
-	if [[ "$count" == "5" ]]; then
-		print_result "count_runnable_candidates counts passive assignee backlog" 0
+	if [[ "$count" == "6" ]]; then
+		print_result "count_runnable_candidates counts default-open backlog" 0
 		return 0
 	fi
 
-	print_result "count_runnable_candidates counts passive assignee backlog" 1 "Expected 5 runnable items, got '${count}'"
+	print_result "count_runnable_candidates counts default-open backlog" 1 "Expected 6 runnable items, got '${count}'"
 	return 0
 }
 
@@ -359,8 +361,8 @@ main() {
 	test_has_worker_exact_dir_match_no_sibling_false_positive
 	test_has_worker_exact_dir_match_accepts_correct_path
 	test_counts_review_issue_pr_workers
-	test_list_dispatchable_candidates_include_passive_assignees
-	test_count_runnable_candidates_counts_passive_assignee_backlog
+	test_list_dispatchable_candidates_default_open_except_needs_labels
+	test_count_runnable_candidates_counts_default_open_backlog
 	test_count_runnable_candidates_keeps_stdout_numeric_with_debug
 	test_count_queued_without_worker_keeps_stdout_numeric_with_debug
 


### PR DESCRIPTION
## Summary
- Switch pulse issue candidate filtering to a default-open model: include assigned and status-labeled issues unless they are blocked by `status:blocked`, `needs-*`, or management labels.
- Preserve self-assignment and dispatch-claim coordination by keeping dedup/claim logic unchanged and moving assignment/status gating out of candidate prefiltering.
- Add regression coverage proving queued/in-progress/assigned issues remain dispatchable while `needs-*` stays excluded.

## Testing
- `shellcheck .agents/scripts/pulse-wrapper.sh`
- `shellcheck .agents/scripts/tests/test-pulse-wrapper-worker-count.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh`

## Runtime Testing
- Level: self-assessed (low-risk shell filtering + test updates)
- Evidence: targeted shellchecks and worker-count regression suite pass

Closes #14953


---
[aidevops.sh](https://aidevops.sh) v3.5.525 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.3-codex spent 5m and 171,643 tokens on this with the user in an interactive session. Overall, 15m since this issue was created.