### PR TITLE
t1708: add browser-specific Chromium enablement and consent guidance

### DIFF
--- a/.agents/tools/browser/chromium-debug-use.md
+++ b/.agents/tools/browser/chromium-debug-use.md
@@ -16,7 +16,7 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Reuse an already-open Chrome/Chromium/Brave/Edge session instead of launching a fresh browser
+- **Purpose**: Reuse an already-open Chrome/Chromium/Brave/Edge/Vivaldi session instead of launching a fresh browser
 - **Mechanism**: Start the browser with `--remote-debugging-port=9222`, then attach with Playwright CDP
 - **Best for**: Logged-in/manual-auth flows, extension-heavy sessions, debugging real state, handoff between manual and scripted work
 - **Not for**: Isolated parallel test runs, Firefox/WebKit, or hostile sites where exposed remote debugging is unsafe
@@ -25,21 +25,85 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
+## Enable Only for This Investigation
+
+Use this path only when aidevops explicitly needs to inspect or automate your live Chromium-family browser. Do not leave remote debugging enabled as a standing default.
+
+What you are approving when you launch with `--remote-debugging-port=9222`:
+
+- Local processes on your machine can inspect and automate tabs in that browser profile.
+- Session state in that profile (cookies, local storage, logged-in tabs) becomes available to the attached tool.
+- The approval lasts until you close that debug-enabled browser or restart it without the flag.
+
+Security boundaries:
+
+- Bind to loopback only: `http://127.0.0.1:9222`, not a LAN IP.
+- Prefer a temporary `--user-data-dir` so investigation state is isolated and easy to discard.
+- If you want per-tab, click-to-connect consent instead of profile-level consent, use `tools/browser/playwriter.md`.
+
 ## Start a Debuggable Browser
 
 Use a dedicated profile when possible.
 
+### Chrome
+
 ```bash
-# Chrome
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
   --remote-debugging-port=9222 \
   --user-data-dir=/tmp/chromium-debug-use-profile
+```
 
-# Chromium
+Approval model: by launching Chrome with the debug port, you are granting local tooling profile-level access for this temporary investigation window.
+
+### Brave
+
+```bash
+"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chromium-debug-use-profile
+```
+
+Use Brave when the issue depends on your normal extension stack or privacy defaults, but still prefer a temporary profile unless the investigation requires your existing state.
+
+### Edge
+
+```bash
+"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chromium-debug-use-profile
+```
+
+Use Edge when the behavior is browser-specific or policy-specific. The consent scope is the same: local profile-level control while that flagged browser stays open.
+
+### Vivaldi
+
+```bash
+"/Applications/Vivaldi.app/Contents/MacOS/Vivaldi" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chromium-debug-use-profile
+```
+
+Vivaldi usually behaves like other Chromium browsers for CDP attachment, but custom UI features do not change the underlying consent model: attach is still local and profile-scoped.
+
+### Chromium
+
+```bash
 chromium \
   --remote-debugging-port=9222 \
   --user-data-dir=/tmp/chromium-debug-use-profile
 ```
+
+This is the cleanest baseline when you want Chromium behavior without vendor-specific browser features.
+
+### Ungoogled Chromium
+
+```bash
+"/Applications/Ungoogled Chromium.app/Contents/MacOS/Ungoogled Chromium" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chromium-debug-use-profile
+```
+
+Support is build-dependent. If your Ungoogled Chromium package does not expose a working DevTools endpoint at `127.0.0.1:9222`, treat this path as unsupported for that build and fall back to a supported Chromium browser, `tools/browser/playwriter.md`, or `tools/browser/chrome-devtools.md` in headless mode.
 
 Check the endpoint:
 
@@ -104,6 +168,18 @@ npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222
 
 Use CDP attachment for automation and DevTools MCP for performance, network, and console inspection against the same live browser.
 
+## Consent and Browser Choice
+
+Choose the consent model that matches the task:
+
+| Need | Consent model | Prefer |
+|------|---------------|--------|
+| Reuse a whole live Chromium profile | Start browser with debug flag | Chromium Debug Use |
+| Approve only selected tabs in your everyday browser | Click extension per tab | `tools/browser/playwriter.md` |
+| Inspection/perf analysis without reusing your active session | Launch or connect DevTools MCP | `tools/browser/chrome-devtools.md` |
+
+For Chrome, Brave, Edge, and Vivaldi, the enablement step is explicit because you must relaunch the browser with the debug flag. For Playwriter, the enablement step is explicit because you must click the extension on the tab you want to share. In both cases, aidevops should treat the session as local-only and user-approved, not ambient or permanent access.
+
 ## Trade-offs
 
 | Need | Prefer |
@@ -121,6 +197,9 @@ Use CDP attachment for automation and DevTools MCP for performance, network, and
 | No pages found | Open a tab manually or create one with `context.newPage()` |
 | Attach works but state is wrong | You launched a different profile than expected; verify `--user-data-dir` |
 | Browser closes unexpectedly | Another tool owns the session or the profile lock; use a dedicated debug profile |
+| Browser policy or packaging blocks remote debugging | Use `tools/browser/playwriter.md` for tab-level consent or `tools/browser/chrome-devtools.md --headless` for isolated inspection |
+| You do not want to relaunch your browser | Use `tools/browser/playwriter.md` instead of profile-level CDP attach |
+| Ungoogled Chromium never exposes `/json/version` | Treat that build as unsupported for this workflow and switch to Chrome/Brave/Edge/Vivaldi/Chromium |
 | Need repeatable tests | Stop using live-session attach; launch a fresh Playwright context instead |
 
 ## Related

--- a/.agents/tools/browser/chromium-debug-use.md
+++ b/.agents/tools/browser/chromium-debug-use.md
@@ -53,6 +53,8 @@ Use a dedicated profile when possible.
   --user-data-dir=/tmp/chromium-debug-use-profile
 ```
 
+Adjust the executable path for your platform. On Linux, check `which google-chrome`, `which chromium`, or `/opt/...`; on Windows, use `where chrome.exe` or the installed path under `C:\Program Files\...`.
+
 Approval model: by launching Chrome with the debug port, you are granting local tooling profile-level access for this temporary investigation window.
 
 ### Brave


### PR DESCRIPTION
## Summary
- add browser-specific enablement steps for Chrome, Brave, Edge, Vivaldi, Chromium, and Ungoogled Chromium in `chromium-debug-use`
- explain the explicit consent model, local-only security boundaries, and why remote debugging should only be enabled for an active investigation
- add fallback guidance to Playwriter and Chrome DevTools MCP when profile-level CDP attach is unavailable or inappropriate

## Testing
- `npx markdownlint-cli2 ".agents/tools/browser/chromium-debug-use.md"`

## Runtime Testing
- self-assessed: low-risk docs-only change
- Overall, no runtime execution was required because the change only updates usage guidance

Closes #14950


---
[aidevops.sh](https://aidevops.sh) v3.5.525 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded browser compatibility documentation to include Vivaldi
  * Added security guidance for remote debugging with local-only bindings and temporary data directory usage
  * Enhanced browser startup instructions for Chrome, Brave, Edge, Vivaldi, Chromium, and Ungoogled Chromium variants
  * Added consent model guidance and browser selection recommendations
  * Improved troubleshooting section with additional failure-handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->