### PR TITLE
GH#14936: tighten venv health command doc

### DIFF
--- a/.agents/scripts/commands/venv-health.md
+++ b/.agents/scripts/commands/venv-health.md
@@ -16,23 +16,14 @@ Arguments: $ARGUMENTS
 
 Display the helper output directly; formatting is built in.
 
-## Arguments
+## Modes
 
-| Argument | Description |
-|----------|-------------|
-| (none) | Scan all repos in `~/.config/aidevops/repos.json` |
-| `--quiet`, `-q` | Only report broken/warning venvs |
-| `--json`, `-j` | JSON output for programmatic use |
-| `--path DIR`, `-p DIR` | Scan a specific directory instead of repos.json |
-
-## Common Invocations
-
-| Command | Purpose |
-|---------|---------|
-| `/venv-health` | Scan all managed repos |
+| Invocation | Result |
+|------------|--------|
+| `/venv-health` | Scan all repos in `~/.config/aidevops/repos.json` |
 | `/venv-health --quiet` | Show only warnings and errors |
-| `/venv-health --json` | Return machine-readable output |
-| `/venv-health --path DIR` | Scan one directory |
+| `/venv-health --json` | Return JSON like `{"summary":{"total":3,"healthy":2,"warnings":0,"broken":1},"venvs":[...]}` |
+| `/venv-health --path DIR` | Scan one directory instead of the managed repo list |
 
 ## Checks Performed
 
@@ -44,7 +35,7 @@ Display the helper output directly; formatting is built in.
 
 ## Venv Discovery
 
-Looks for `.venv/pyvenv.cfg` (PEP 405 marker) up to 3 levels deep in each registered repo. Deduplicates by realpath.
+Looks for `.venv/pyvenv.cfg` (PEP 405 marker) up to 3 levels deep in each registered repo, then deduplicates by realpath.
 
 ## Automatic Checks
 
@@ -69,13 +60,6 @@ aidevops config set updates.venv_health_hours 12
 | 0 | All venvs healthy (or no venvs found) |
 | 1 | One or more venvs have issues |
 | 2 | Usage error |
-
-## Output Expectations
-
-- Default: show all detected venvs
-- `--quiet`: show only warnings and errors
-- `--json`: return JSON like `{"summary":{"total":3,"healthy":2,"warnings":0,"broken":1},"venvs":[...]}`
-- `--path`: scan the supplied directory instead of the managed repo list
 
 ## Related
 


### PR DESCRIPTION
## Summary
- merge overlapping argument, invocation, and output sections into a single `Modes` table so the command surface is described once
- keep the helper command, checks, scheduling, exit codes, and related references while trimming repetitive wording
- Closes #14936

## Testing
- `bunx markdownlint-cli2 ".agents/scripts/commands/venv-health.md"`

## Runtime Testing
- self-assessed: low-risk doc-only change

---
[aidevops.sh](https://aidevops.sh) v3.5.528 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 3m and 104,047 tokens on this as a headless worker. Overall, 1h 40m since this issue was created.