### PR TITLE
GH#14052: tighten comfy-cli agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -87,9 +87,9 @@
       "pr": 11019
     },
     ".agents/tools/ai-generation/comfy-cli.md": {
-      "hash": "6d885b8f28374a6d71d6f4095a6015f3359a668e",
-      "at": "2026-03-27T21:25:22Z",
-      "pr": 11014
+      "hash": "370b96d8f1a441c0cce9dd93fc376e8ddbfd1685",
+      "at": "2026-03-31T16:45:28Z",
+      "pr": 14977
     },
     ".agents/tools/architecture/feature-slicing-skill/cheatsheet.md": {
       "hash": "b244fb8417fc27f0de33c83c86092f5bebd736f3",

--- a/.agents/tools/ai-generation/comfy-cli.md
+++ b/.agents/tools/ai-generation/comfy-cli.md
@@ -24,12 +24,11 @@ tools:
 - **Docs**: <https://docs.comfy.org/comfy-cli/getting-started>
 - **Repo**: <https://github.com/Comfy-Org/comfy-cli>
 - **Shell completion**: `comfy --install-completion`
-
-**Use for**: installing/managing ComfyUI instances, custom nodes, models, snapshots, workflow dependencies.
+- **Use for**: installing and managing ComfyUI instances, custom nodes, models, snapshots, and workflow dependencies
 
 <!-- AI-CONTEXT-END -->
 
-## Installation
+## Install
 
 Prerequisites: Python >= 3.9, git, CUDA or ROCm (GPU).
 
@@ -41,7 +40,7 @@ conda create -n comfy-env python=3.11 && conda activate comfy-env
 comfy install
 ```
 
-## Commands
+## Native CLI
 
 ### Core
 
@@ -83,7 +82,7 @@ comfy tracking disable   # opt out of usage analytics
 
 ## Helper Script
 
-`comfy-cli-helper.sh` wraps comfy-cli with aidevops conventions:
+`comfy-cli-helper.sh` wraps comfy-cli with aidevops conventions.
 
 ```bash
 comfy-cli-helper.sh status                              # check installation
@@ -99,7 +98,7 @@ comfy-cli-helper.sh node-list [installed|all|enabled|disabled]
 comfy-cli-helper.sh model-list [relative-path]
 ```
 
-## Common Workflows
+## Workflows
 
 ```bash
 # Fresh setup
@@ -115,13 +114,10 @@ comfy-cli-helper.sh snapshot-save --output my-setup.json
 comfy-cli-helper.sh snapshot-restore my-setup.json
 ```
 
-## Integration
+## Related
 
 - `content/production-image.md`, `content/production-video.md` — local ComfyUI generation pipeline
 - `tools/vision/image-generation.md` — local model inference
 - `tools/video/` — local video generation workflows
-
-## Related
-
 - `tools/vision/overview.md` — Vision AI decision tree
 - `content/video-higgsfield.md` — Cloud-based AI generation


### PR DESCRIPTION
## Summary
- tighten `.agents/tools/ai-generation/comfy-cli.md` by folding the use-case note into quick reference bullets, shortening section labels, and consolidating related links
- update `.agents/configs/simplification-state.json` with the new content hash and tracking metadata for this simplification pass

## Runtime Testing
- self-assessed: low-risk doc-only and metadata-only change

## Verification
- `bunx markdownlint-cli2 ".agents/tools/ai-generation/comfy-cli.md"`
- preservation check comparing URLs and comfy-cli command snippets against `origin/main`
- `jq empty .agents/configs/simplification-state.json`

Closes #14052

---
[aidevops.sh](https://aidevops.sh) v3.5.530 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4