### PR TITLE
GH#14991: tighten security-deps command doc

### DIFF
--- a/.agents/scripts/commands/security-deps.md
+++ b/.agents/scripts/commands/security-deps.md
@@ -8,25 +8,22 @@ Scan dependency lockfiles for known vulnerabilities with OSV.
 
 Target: $ARGUMENTS
 
-## Command
+## Quick Reference
 
 - Tool: OSV-Scanner via OSV.dev (CVEs, GHSAs)
 - Run: `./.agents/scripts/security-helper.sh scan-deps`
 - Scope: pass a directory path (for example `/security-deps ./packages/api`)
 - Output: add `--format=json` for machine-readable results
-- Recursive scan is enabled by default in `security-helper.sh`
+- Behavior: recursive scan is enabled by default in `security-helper.sh`
+- Lockfiles: npm/Yarn/pnpm (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`), pip (`requirements.txt`, `Pipfile.lock`), Go (`go.mod`), Cargo (`Cargo.lock`), Composer (`composer.lock`), Maven (`pom.xml`), and Gradle (`gradle.lockfile`)
 
 ## Workflow
 
-1. Run `./.agents/scripts/security-helper.sh scan-deps`
-2. Triage critical/high findings first
-3. For each finding, confirm the package is used, identify the fixed version, and assess upgrade risk
-4. Upgrade, test, and re-scan
-5. If no fix exists, document reachability, compensating controls, and follow-up
-
-## Supported Lockfiles
-
-npm/Yarn/pnpm (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`), pip (`requirements.txt`, `Pipfile.lock`), Go (`go.mod`), Cargo (`Cargo.lock`), Composer (`composer.lock`), Maven (`pom.xml`), and Gradle (`gradle.lockfile`).
+1. Run the scan.
+2. Triage critical/high findings first.
+3. For each finding, confirm the package is used, identify the fixed version, and assess upgrade risk.
+4. Upgrade, test, and re-scan.
+5. If no fix exists, document reachability, compensating controls, and follow-up.
 
 ## CI Example
 


### PR DESCRIPTION
## Summary
- fold command behavior and supported lockfiles into one quick-reference section
- keep the remediation workflow concise while preserving triage and no-fix guidance
- retain the existing CI example and related security command links

## Testing
- markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/scripts/commands/security-deps.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 1 file(s)
Summary: 0 error(s)

## Runtime Testing
- self-assessed: docs-only change; no runtime behavior changed

Closes #14991


---
[aidevops.sh](https://aidevops.sh) v3.5.532 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 4m and 70,680 tokens on this as a headless worker. Overall, 12m since this issue was created.