### PR TITLE
GH#14992: tighten postflight-loop command doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1062,9 +1062,9 @@
       "pr": 14484
     },
     ".agents/scripts/commands/postflight-loop.md": {
-      "hash": "c78f879537d08532f631523c4021e7ebc9f462ff",
-      "at": "2026-03-31T14:55:57Z",
-      "pr": 14942
+      "hash": "bac68676a8291dc0c84e4f52c76ea7d01fdc51eb",
+      "at": "2026-03-31T15:48:00Z",
+      "pr": 14995
     },
     ".agents/scripts/commands/routine.md": {
       "hash": "2f4f41fc7eb38924a7bceaa39ef60657f92e48ba",

--- a/.agents/scripts/commands/postflight-loop.md
+++ b/.agents/scripts/commands/postflight-loop.md
@@ -6,27 +6,27 @@ mode: subagent
 
 Monitor release health after deployment. Arguments: `$ARGUMENTS`
 
-## Usage
+**Usage**
 
 ```bash
 /postflight-loop [--monitor-duration 5m] [--max-iterations 5]
 ```
 
-## Core Contract
+**Contract**
 
-1. Parse `$ARGUMENTS` into `monitor_duration` and `max_iterations`.
-2. On each pass, use `gh` to verify the latest CI status, release tag presence, and `VERSION` ↔ release-tag match.
-3. Record status, iteration, elapsed time, last check, and per-check results in `.agents/loop-state/quality-loop.local.md`.
-4. Emit `<promise>RELEASE_HEALTHY</promise>` only when every check passes inside the monitoring window.
+- Parse `$ARGUMENTS` into `monitor_duration` and `max_iterations`.
+- On each pass, use `gh` to verify latest CI status, release tag presence, and `VERSION` matches the released tag.
+- Record status, iteration, elapsed time, last check, and per-check results in `.agents/loop-state/quality-loop.local.md`.
+- Emit `<promise>RELEASE_HEALTHY</promise>` only when every check passes inside the monitoring window.
 
-## Options
+**Options**
 
 | Option | Purpose | Default |
 |--------|---------|---------|
 | `--monitor-duration <t>` | Total monitoring window such as `5m`, `10m`, or `1h` | `5m` |
 | `--max-iterations <n>` | Max monitoring passes | `5` |
 
-## Examples
+**Examples**
 
 ```bash
 /postflight-loop --monitor-duration 10m
@@ -34,11 +34,11 @@ Monitor release health after deployment. Arguments: `$ARGUMENTS`
 /postflight-loop --monitor-duration 2m --max-iterations 3
 ```
 
-## Use When
+**Use when**
 
-- After `/release`, a manual release, or CI/CD verification
+- After `/release`, a manual release, or CI/CD verification.
 
-## Related
+**Related**
 
 - `/postflight` — single postflight check
 - `/release` — full release workflow


### PR DESCRIPTION
## Summary
- tighten `.agents/scripts/commands/postflight-loop.md` by collapsing section headings into a lighter command-reference format
- keep the monitoring contract, examples, and related workflow pointers intact while reducing scan overhead
- refresh `.agents/configs/simplification-state.json` with the new file hash for this recheck

## Runtime Testing
- Level: self-assessed (low-risk agent command doc change)
- `bunx markdownlint-cli2 '.agents/scripts/commands/postflight-loop.md'`
- `python3 - <<'PY' ... json.loads(pathlib.Path('.agents/configs/simplification-state.json').read_text()) ... PY`
- `shasum '.agents/scripts/commands/postflight-loop.md'`

Closes #14992

---
[aidevops.sh](https://aidevops.sh) v3.5.532 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4