### PR TITLE
GH#14978: clarify AGENTS planning-file main exception

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -122,6 +122,8 @@ Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-
 
 Planning files go direct to main. Code changes need worktree + PR. Workers NEVER edit TODO.md.
 
+**Main-branch planning exception:** `TODO.md` and `todo/*` are the explicit exception to the PR-only flow — planning-only edits may be committed and pushed directly to `main`.
+
 **Simplification state policy:** Keep all changes to `.agents/configs/simplification-state.json`. It is the shared hash registry used by the simplification routine to detect unchanged vs changed files and decide when recheck/re-processing is needed.
 
 **Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture. Repos with `"local_only": true` have no GitHub remote — skip `gh` operations on them. Repo paths may be nested (e.g., `~/Git/cloudron/netbird-app`), not just `~/Git/<name>`.


### PR DESCRIPTION
## Summary
- add an explicit reminder in `.agents/AGENTS.md` that planning-only edits to `TODO.md` and `todo/*` may be committed and pushed directly to `main`
- keep the broader rule intact that code changes still require a worktree and PR

## Testing
- `npx markdownlint-cli2 ".agents/AGENTS.md"`

## Runtime Testing
- level: self-assessed
- rationale: docs-only change to framework guidance

Closes #14978


---
[aidevops.sh](https://aidevops.sh) v3.5.532 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 4h 18m and 1,080,578 tokens on this with the user in an interactive session. Overall, 2h 10m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow policies to streamline planning document edits on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->