### PR TITLE
t1709: feat: extend chromium-debug-use routing and automation-planning workflow

### DIFF
--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -24,7 +24,9 @@ EXTRACT?
 AUTOMATE?
   Password manager/extensions:
     Already unlocked → Playwriter | Unlock once → dev-browser | Programmatic → Playwright + Bitwarden CLI
-  Live already-open Chromium/Chrome session → chromium-debug-use
+  Live already-open Chromium/Chrome session:
+    Inspect current state / understand workflow first → chromium-debug-use
+    Flow understood, need repeatable automation → Playwright / dev-browser / Playwriter / Stagehand
   Parallel sessions: speed → Playwright | CLI → playwright-cli/agent-browser --session
   Persistent login: with extensions → dev-browser | without → playwright-cli/storageState
   Proxy: direct → Playwright/Crawl4AI | via extension → Playwriter
@@ -77,6 +79,19 @@ Overhead: dev-browser +0.1-0.4s | agent-browser +0.5-1.5s (cold) | Stagehand +1-
 | Extensions | Yes | No | Yes | No | No | Yes | Possible |
 | Self-healing/NL | No | No | No | No | LLM only | No | Yes |
 | Setup | npm install | npm install -g | Server running | npm install | pip/Docker | Extension click | npm + API key |
+
+## Inspect First, Then Formalize
+
+Use `chromium-debug-use` when the fastest path is to inspect a browser session that is already open, confirm what the user is doing now, or learn a flow before deciding how to automate it long-term.
+
+| If you learned... | Stay or hand off to... | Why |
+|-------------------|------------------------|-----|
+| You just need to inspect the live session, read DOM state, click lightly, or capture the current flow | `chromium-debug-use` | Fastest path to what is already open |
+| The flow should become reproducible, isolated, parallel, or CI-friendly | `tools/browser/playwright.md` | Fresh contexts are better for repeatable automation |
+| The flow needs a managed persistent profile that aidevops can keep reusing | `tools/browser/dev-browser.md` | Better long-lived state than a user-owned live browser |
+| The user wants tab-by-tab consent in their everyday browser instead of a debug-enabled profile | `tools/browser/playwriter.md` | Extension click keeps the consent boundary narrower |
+| The page structure is still fuzzy and you want natural-language exploration before hardening selectors | `tools/browser/stagehand.md` | Better when the next step is exploratory automation |
+| The goal is console, network, performance, or general DevTools inspection against the same live browser | `tools/browser/chrome-devtools.md` | Better debugging surface than automation-first CDP commands |
 
 ## Parallel Sessions
 

--- a/.agents/tools/browser/chromium-debug-use.md
+++ b/.agents/tools/browser/chromium-debug-use.md
@@ -191,6 +191,20 @@ For Chrome, Brave, Edge, and Vivaldi, the enablement step is explicit because yo
 | Your everyday browser with extension click-to-connect | `tools/browser/playwriter.md` |
 | Fast isolated automation | `tools/browser/playwright.md` |
 
+## Workflow Boundary
+
+Use this tool to understand what is already happening in a live Chromium session. Once the flow is understood, move to the tool that matches the long-term job instead of keeping every task attached to the live browser.
+
+| After inspection, if you need... | Hand off to... | Why |
+|----------------------------------|----------------|-----|
+| Repeatable scripts, clean state, parallel runs, or CI | `tools/browser/playwright.md` | Fresh contexts are more reliable than a live user session |
+| A managed persistent profile that aidevops can keep reusing | `tools/browser/dev-browser.md` | Better for ongoing stateful automation owned by aidevops |
+| Everyday-browser, tab-by-tab consent | `tools/browser/playwriter.md` | Narrower consent boundary than profile-level remote debugging |
+| Deeper console, network, or performance debugging on the same session | `tools/browser/chrome-devtools.md` | Better inspection surface once you know the target tab |
+| Natural-language experimentation before you lock in selectors or code | `tools/browser/stagehand.md` | Better when the next step is exploratory automation design |
+
+Rule of thumb: inspect and gather facts with `chromium-debug-use`, then formalize the durable workflow with the stronger-purpose browser tool.
+
 ## Troubleshooting
 
 | Problem | Fix |

--- a/.agents/tools/browser/dev-browser.md
+++ b/.agents/tools/browser/dev-browser.md
@@ -160,14 +160,16 @@ If the server doesn't expose `executablePath`, use Playwright direct with `launc
 
 ## Comparison with Other Browser Tools
 
-| Feature | Dev-Browser | Playwriter | Playwright MCP | Stagehand |
-|---------|-------------|------------|----------------|-----------|
-| **State** | Persistent | Per-tab | Fresh each call | Fresh |
-| **Speed** | Fast (batched) | Medium | Slow (round-trips) | Medium |
-| **Context** | Low | Minimal | High (17+ tools) | Low |
-| **Approach** | Scripts | Single tool | Tool calls | Natural language |
-| **Best for** | Dev testing | Existing sessions | Cross-browser | AI automation |
-| **Requires** | Bun + server | Chrome extension | Nothing | API key |
+| Feature | Dev-Browser | Chromium Debug Use | Playwriter | Playwright MCP | Stagehand |
+|---------|-------------|--------------------|------------|----------------|-----------|
+| **State** | Persistent aidevops profile | Existing live browser profile | Per-tab | Fresh each call | Fresh |
+| **Speed** | Fast (batched) | Fast for live-session reuse | Medium | Slow (round-trips) | Medium |
+| **Context** | Low | Very low | Minimal | High (17+ tools) | Low |
+| **Approach** | Scripts | CDP attach to current browser | Single tool | Tool calls | Natural language |
+| **Best for** | Dev testing and managed persistent automation | Inspect first, then choose the right automation path | Existing sessions with click consent | Cross-browser | AI automation |
+| **Requires** | Bun + server | Debug-enabled Chromium browser | Chrome extension | Nothing | API key |
+
+Use `chromium-debug-use` when you need to understand a live session that is already open. Switch to dev-browser when that investigation turns into a repeatable workflow that should keep its own persistent state under aidevops control.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- extend the browser automation decision tree so `chromium-debug-use` is the explicit first step when aidevops should inspect an already-open Chromium session or learn a flow before automating it
- document the handoff boundaries from live-session inspection into Playwright, dev-browser, Playwriter, Stagehand, and Chrome DevTools so long-term automation choices are explicit
- update the neighboring dev-browser guidance so the difference between a user-owned live session and an aidevops-managed persistent profile is clear

## Testing
- `npx markdownlint-cli2 ".agents/tools/browser/browser-automation.md" ".agents/tools/browser/chromium-debug-use.md" ".agents/tools/browser/dev-browser.md"`
- `.agents/scripts/linters-local.sh` *(fails on existing repo-wide baseline issues unrelated to this PR, including string-literal, skill-frontmatter, bash-3.2, complexity, nesting-depth, and file-size gates)*

## Runtime Testing
- Level: self-assessed
- Rationale: documentation-only changes with no runtime behavior changes

Closes #14951

---
[aidevops.sh](https://aidevops.sh) v3.5.532 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 4h 41m and 224,089 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced browser automation workflow with clearer decision guidance for inspection versus automation phases
  * Added instructions for transitioning from initial session inspection to appropriate long-term automation tools
  * Improved browser tool comparison table with updated selection criteria

<!-- end of auto-generated comment: release notes by coderabbit.ai -->