### PR TITLE
GH#14229: tighten Modern JavaScript skill index

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill.md
+++ b/.agents/tools/programming/modern-javascript-skill.md
@@ -3,11 +3,9 @@ description: "|"
 mode: subagent
 imported_from: external
 ---
-# modern-javascript
-
 # Modern JavaScript (ES6-ES2025)
 
-Write clean, performant, maintainable JavaScript using modern language features. This skill covers ES6 through ES2025, emphasizing immutability, functional patterns, and expressive syntax.
+Use this file as the reference index: quick decision trees up front, then chapter links for the full corpus. The detailed material lives in `modern-javascript-skill/*.md`.
 
 ## Quick Decision Trees
 
@@ -67,7 +65,7 @@ Always prefer non-mutating methods:
 | ES2024 | 2024 | Object.groupBy(), Map.groupBy(), Promise.withResolvers(), RegExp v flag, resizable ArrayBuffer |
 | ES2025 | 2025 | Iterator helpers (.map, .filter, .take), Set methods (.union, .intersection), RegExp.escape(), using/await using |
 
-## Reference Documentation
+## Reference Chapters
 
 ### ES Version References
 


### PR DESCRIPTION
## Summary
- remove the redundant alias heading so the imported skill opens with a single H1
- tighten the intro to position the file as a slim index pointing to the chapter corpus
- rename the reference section to reflect that the detailed material lives in chapter files

## Testing
- bunx markdownlint-cli2 ".agents/tools/programming/modern-javascript-skill.md"
- python3 link check for local markdown targets in ".agents/tools/programming/modern-javascript-skill.md"

## Runtime Testing
- Level: self-assessed
- Rationale: docs-only change to a markdown reference index
- Runtime verification: not required

Overall, this PR keeps the reference corpus split into chapter files and makes the index itself clearer.

Closes #14229


---
[aidevops.sh](https://aidevops.sh) v3.5.536 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4