### PR TITLE
GH#14259: tighten model-specific subagent routing guide

### DIFF
--- a/.agents/tools/ai-assistants/models-README.md
+++ b/.agents/tools/ai-assistants/models-README.md
@@ -1,6 +1,12 @@
 # Model-Specific Subagents
 
-Model-specific subagents enable cross-provider model routing. Instead of passing a model parameter to the Task tool (which most AI tools don't support), the orchestrating agent selects a model by invoking the corresponding subagent.
+Model-specific subagents are the model-routing mechanism. Instead of passing a model to Task directly, the orchestrator selects a subagent whose frontmatter declares the concrete provider/model.
+
+## Core Rules
+
+- **In-session Task calls use the session model.** A prompt can request another model, but the runtime does not switch models mid-session.
+- **True cross-model routing requires headless dispatch.** Supervisor/runner helpers read the selected subagent frontmatter and pass the resolved model ID to the CLI.
+- **Tier names are the stable interface.** Callers should target `haiku`, `sonnet`, `pro`, `opus`, etc.; the concrete model can change behind that alias.
 
 ## Tier Mapping
 
@@ -13,40 +19,32 @@ Model-specific subagents enable cross-provider model routing. Instead of passing
 | `pro` | `models/pro.md` | gemini-2.5-pro | claude-sonnet-4-6 |
 | `opus` | `models/opus.md` | claude-opus-4-6 | gpt-5.4 |
 
-## How It Works
+## Resolution Flow
 
-### In-Session (Task Tool)
-
-The Task tool uses `subagent_type` to select an agent. Model-specific subagents are invoked by name:
+### In-session Task tool
 
 ```text
 Task(subagent_type="general", prompt="Review this code using gemini-2.5-pro...")
 ```
 
-The Task tool in Claude Code always uses the session model. For true cross-model dispatch, use headless dispatch.
+The prompt can describe the desired model, but the Task tool still runs on the current session model.
 
-### Headless Dispatch (CLI)
-
-The supervisor and runner helpers use model subagents to determine which CLI model flag to pass:
+### Headless dispatch
 
 ```bash
 # Runner reads model from subagent frontmatter
 Claude -m "gemini-2.5-pro" -p "Review this codebase..."
 ```
 
-### Supervisor Integration
+Supervisor flow:
 
-The supervisor resolves model tiers from subagent frontmatter:
-
-1. Task specifies `model: pro` in TODO.md metadata
-2. Supervisor reads `models/pro.md` frontmatter for concrete model ID
-3. Dispatches runner with `--model` flag set to the resolved model
+1. Task metadata specifies a tier such as `model: pro`
+2. The supervisor reads `models/pro.md` frontmatter
+3. The runner receives `--model` with the resolved provider/model ID
 
 ## Fallback Chains (t132.4)
 
-Each tier supports a configurable fallback chain that goes beyond the simple primary/fallback pair. When a provider fails (API error, timeout, rate limit), the system walks the chain until a healthy provider is found, including gateway providers like OpenRouter and Cloudflare AI Gateway.
-
-Add `fallback-chain:` to any model tier's YAML frontmatter for per-agent overrides:
+Each tier can define a longer fallback chain than the simple primary/fallback pair. On provider failure (API error, timeout, rate limit), resolution walks the chain until it finds a healthy provider, including gateways such as OpenRouter and Cloudflare AI Gateway.
 
 ```yaml
 fallback-chain:
@@ -56,25 +54,27 @@ fallback-chain:
   - openrouter/anthropic/claude-sonnet-4-6
 ```
 
-Global defaults are configured in `configs/fallback-chain-config.json`. See `tools/ai-assistants/fallback-chains.md` for full documentation.
+- Per-tier override: add `fallback-chain:` to the model subagent frontmatter
+- Global defaults: `configs/fallback-chain-config.json`
+- Full docs: `tools/ai-assistants/fallback-chains.md`
 
-## Adding New Models
+## Adding or Updating a Tier
 
-1. Create a new subagent file in this directory
-2. Set `model:` in YAML frontmatter to the provider/model ID
-3. Optionally add `fallback-chain:` for per-agent chain override
-4. Add to the tier mapping in `model-routing.md`
-5. Add to `compare-models-helper.sh` MODEL_DATA if tracking pricing
-6. Run `model-registry-helper.sh sync --force` to update the registry
-7. Run `model-registry-helper.sh check` to verify availability
+1. Create or edit the model subagent in `models/`
+2. Set `model:` to the provider/model ID
+3. Optionally add `fallback-chain:`
+4. Update the tier mapping in `tools/context/model-routing.md`
+5. Update `compare-models-helper.sh` `MODEL_DATA` if pricing/capability tracking applies
+6. Run `model-registry-helper.sh sync --force`
+7. Run `model-registry-helper.sh check`
 
 ## Model Registry
 
-The model registry (`model-registry-helper.sh`) maintains a SQLite database of all known models, synced from three sources:
+`model-registry-helper.sh` maintains `~/.aidevops/.agent-workspace/model-registry.db` from three sources:
 
-1. **Subagent frontmatter** — tier definitions from `models/*.md`
-2. **Embedded data** — pricing/capabilities from `compare-models-helper.sh`
-3. **Provider APIs** — live model discovery from configured providers
+1. Subagent frontmatter in `models/*.md`
+2. Embedded pricing/capability data in `compare-models-helper.sh`
+3. Provider APIs for live model discovery
 
 ```bash
 model-registry-helper.sh sync          # Sync from all sources
@@ -85,13 +85,13 @@ model-registry-helper.sh deprecations  # Deprecated/unavailable models
 model-registry-helper.sh diff          # Registry vs local config
 ```
 
-The registry runs automatically on `aidevops update` and can be added to cron for periodic sync. Storage: `~/.aidevops/.agent-workspace/model-registry.db`
+The registry syncs automatically on `aidevops update` and can also run on a schedule.
 
 ## Related
 
-- `tools/ai-assistants/fallback-chains.md` — Fallback chain configuration and gateway providers
-- `tools/context/model-routing.md` — Cost-aware routing rules
-- `scripts/compare-models-helper.sh discover --probe` — Detect available providers
-- `model-registry-helper.sh` — Provider/model registry with periodic sync
-- `fallback-chain-helper.sh` — Fallback chain resolution with trigger detection
+- `tools/ai-assistants/fallback-chains.md` — fallback configuration and gateway providers
+- `tools/context/model-routing.md` — cost-aware routing rules
+- `scripts/compare-models-helper.sh discover --probe` — provider discovery
+- `model-registry-helper.sh` — registry maintenance and health checks
+- `fallback-chain-helper.sh` — fallback resolution and trigger detection
 - `tools/ai-assistants/headless-dispatch.md` — CLI dispatch with model selection


### PR DESCRIPTION
## Summary
- move the session-vs-headless routing rules to the top so agents see the key constraints first
- tighten the resolution, fallback, and registry sections without dropping tier mappings, commands, or `t132.4` context

## Testing
- `bunx markdownlint-cli2 ".agents/tools/ai-assistants/models-README.md"`
- `git diff --check`
- `rg -n "t132\.4|fallback-chain:|model-registry-helper\.sh|compare-models-helper\.sh|gpt-5\.4|gemini-2\.5-pro|claude-sonnet-4-6" .agents/tools/ai-assistants/models-README.md`

## Runtime Testing
- Level: self-assessed
- Reason: doc-only change in `.agents/tools/ai-assistants/models-README.md`
- Runtime verification: not required for this low-risk documentation update

Closes #14259


---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 8m and 74,463 tokens on this as a headless worker. Overall, 1d 4h since this issue was created.