### PR TITLE
GH#13864: restructure landing page swipe file into chapters

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md
@@ -1,0 +1,81 @@
+# SaaS Landing Page Examples
+
+## 1. Slack — "Where Work Happens"
+
+**Hero:**
+
+```text
+Slack is where work happens
+Connect your tools. Automate your tasks. Build the workflows that move your company forward.
+[Get Started] [Talk to Sales]
+✓ Free forever for small teams
+```
+
+- 4-word headline claims the category (not "a place" — "THE place")
+- Two CTAs for different buyer types; trust signal reduces friction
+
+**Social Proof:** Logos + "Trusted by millions" + G2 rating — three proof types simultaneously.
+
+**Features:** Benefit-led header → 3 features each with outcome. "Already use" reduces friction.
+
+**Why it converts:** Extreme clarity in 5 seconds, low-barrier CTA, features tied to outcomes.
+
+## 2. Notion — "Your Wiki, Docs, & Projects. Together."
+
+**Hero:**
+
+```text
+Your wiki, docs, & projects. Together.
+Notion is the connected workspace where better, faster work happens.
+[Get Notion Free]
+[Animated product demo]
+```
+
+- Headline covers 3 use cases; single CTA reduces decision fatigue; demo shows, not tells
+
+**Social Proof:** `Trusted by: [Figma] [Pixar] [Nike] [Toyota]` + "Join 10M+ teams" — specific number, "teams" signals B2B.
+
+**Use Cases:** Wiki / Docs / Projects each with one-line benefit. "Your way" = flexibility.
+
+**Why it converts:** Multi-use-case without confusion, strong visual demo, free tier removes friction.
+
+## 3. Basecamp — "The All-In-One Toolkit for Working Remotely"
+
+**Hero:**
+
+```text
+Frustrated with your project management?
+Basecamp's the calm, organized way to manage projects, work with clients, and communicate company-wide.
+[Try Basecamp for free]
+```
+
+- Opens with pain point; "calm, organized" = emotional benefit
+
+**Before/After:**
+
+```text
+Before: Constant meetings | Lost files | Scattered apps | Anxiety
+After:  One place | Real progress | Everyone in the loop | Calmer teams
+```
+
+**Pricing:** `$299/month flat. Unlimited users, unlimited projects. No per-user pricing games.` — simple one-tier; anti-competitor positioning.
+
+**Why it converts:** Strong POV, before/after transformation, flat pricing, long-form testimonials.
+
+## 4. Mailchimp — "Turn Emails into Revenue"
+
+**Hero:**
+
+```text
+Turn Emails into Revenue
+Grow your business with email marketing and automations that convert.
+[Start Free Trial] — No credit card required
+```
+
+- Outcome-focused headline (revenue); low-friction CTA
+
+**Features:** Email Builder / Audience Tools / Automations / Analytics — each with action-oriented benefit.
+
+**Stat:** `Generate up to 25x more orders with automations* (*Mailchimp data, 2023)` — specific, sourced, believable.
+
+**Why it converts:** Clear value prop (emails → revenue), free trial + no CC, specific sourced stats.

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-02-course-sales-page.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-02-course-sales-page.md
@@ -1,0 +1,28 @@
+# Course Sales Page Example
+
+## 1. Copyhackers — "Copy School"
+
+**Hero:**
+
+```text
+Stop Writing Copy That Blends In
+Get the exact frameworks, formulas, and feedback top copywriters use.
+[Join Copy School] [$3,497 or 6 payments]
+Doors close in [countdown]
+```
+
+- Pain point headline; price upfront; scarcity via countdown
+
+**Problem:**
+
+```text
+You've read the blogs. Watched the videos. Tried the templates.
+Your copy still sounds like everyone else's.
+Why: Free stuff teaches WHAT. Not HOW. Not how to THINK like a copywriter.
+```
+
+- Acknowledges prior attempts → validates frustration → reveals the gap → positions solution
+
+**Testimonial:** `"I went from charging $500 to $5,000 for a landing page — and getting it."` — specific 10x number, named person with photo.
+
+**Why it converts:** Long-form for unaware audience, extensive social proof, clear curriculum, real urgency.

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-03-hero-section-templates.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-03-hero-section-templates.md
@@ -1,0 +1,25 @@
+# Hero Section Templates
+
+## Problem-Solution
+
+```text
+[Pain Point Statement]
+[Product] helps [audience] [achieve outcome] without [objection].
+[CTA]
+```
+
+## Outcome-Focused
+
+```text
+[Desirable Outcome in X Time]
+The [category] that [key differentiator].
+[CTA]
+```
+
+## Transformation
+
+```text
+From [Current State] to [Desired State]
+[Product] makes it possible.
+[CTA]
+```

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-04-social-proof-and-cta-templates.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-04-social-proof-and-cta-templates.md
@@ -1,0 +1,20 @@
+# Social Proof and CTA Templates
+
+## Social Proof Bar Templates
+
+```text
+Trusted by [X]+ [customers/companies/users]
+[Logo] [Logo] [Logo] [Logo] [Logo]
+```
+
+```text
+[Stat 1] | [Stat 2] | [Stat 3]
+"97% report faster results" | "4.9/5 on G2" | "10,000+ users"
+```
+
+## CTA Button Text
+
+- Start Free Trial / Get Started Free / Try [Product] Free
+- Start My [X]-Day Trial / Get Instant Access
+- Yes, I Want [Outcome] / Show Me How
+- Book My Demo / Claim My [Thing] / Start [Action]ing Now

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-05-guarantees-and-design-principles.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-05-guarantees-and-design-principles.md
@@ -1,0 +1,24 @@
+# Guarantees and Design Principles
+
+## Guarantee Templates
+
+```text
+100% Money-Back Guarantee
+Try [Product] for [X] days. If you don't [achieve outcome], we'll refund every penny. No questions asked.
+```
+
+```text
+The "[Product] Promise"
+If [Product] doesn't [specific result] within [timeframe], show us you implemented it and we'll give you a full refund.
+```
+
+## Design Principles
+
+1. **One CTA** — same action repeated multiple times
+2. **F-pattern reading** — important content on left
+3. **Above the fold** — value prop visible without scrolling
+4. **Visual hierarchy** — Headlines > subheads > body
+5. **Whitespace** — elements need room to breathe
+6. **Mobile-first** — 60%+ of traffic is mobile
+7. **Minimal navigation** — don't give them exit options
+8. **Consistent styling** — same button color throughout

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md
@@ -1,160 +1,30 @@
 # Landing Page Swipe File
 
-## 1. Slack — "Where Work Happens"
+Annotated landing page examples, reusable section templates, and design principles.
 
-**Hero:**
-```
-Slack is where work happens
-Connect your tools. Automate your tasks. Build the workflows that move your company forward.
-[Get Started] [Talk to Sales]
-✓ Free forever for small teams
-```
-- 4-word headline claims the category (not "a place" — "THE place")
-- Two CTAs for different buyer types; trust signal reduces friction
+## Chapters
 
-**Social Proof:** Logos + "Trusted by millions" + G2 rating — three proof types simultaneously.
+| Chapter | Contents |
+|---------|----------|
+| [SaaS Landing Page Examples](direct-response-copy-swipe-file-landing-pages-01-saas-examples.md) | Slack, Notion, Basecamp, and Mailchimp breakdowns |
+| [Course Sales Page Example](direct-response-copy-swipe-file-landing-pages-02-course-sales-page.md) | Copyhackers "Copy School" breakdown |
+| [Hero Section Templates](direct-response-copy-swipe-file-landing-pages-03-hero-section-templates.md) | Problem-solution, outcome-focused, and transformation hero patterns |
+| [Social Proof and CTA Templates](direct-response-copy-swipe-file-landing-pages-04-social-proof-and-cta-templates.md) | Social proof bar patterns and CTA button text |
+| [Guarantees and Design Principles](direct-response-copy-swipe-file-landing-pages-05-guarantees-and-design-principles.md) | Refund language patterns and page layout principles |
 
-**Features:** Benefit-led header → 3 features each with outcome. "Already use" reduces friction.
+## How to Use This Swipe File
 
-**Why it converts:** Extreme clarity in 5 seconds, low-barrier CTA, features tied to outcomes.
+1. Match the example to your offer type before borrowing structure.
+2. Swipe the framework, not the specific claims or proof points.
+3. Keep one primary CTA and align proof, pricing, and guarantees around it.
+4. Test the hero, proof, and CTA layers separately so you can isolate wins.
 
-## 2. Notion — "Your Wiki, Docs, & Projects. Together."
+## Quick Reference
 
-**Hero:**
-```
-Your wiki, docs, & projects. Together.
-Notion is the connected workspace where better, faster work happens.
-[Get Notion Free]
-[Animated product demo]
-```
-- Headline covers 3 use cases; single CTA reduces decision fatigue; demo shows, not tells
-
-**Social Proof:** `Trusted by: [Figma] [Pixar] [Nike] [Toyota]` + "Join 10M+ teams" — specific number, "teams" signals B2B.
-
-**Use Cases:** Wiki / Docs / Projects each with one-line benefit. "Your way" = flexibility.
-
-**Why it converts:** Multi-use-case without confusion, strong visual demo, free tier removes friction.
-
-## 3. Basecamp — "The All-In-One Toolkit for Working Remotely"
-
-**Hero:**
-```
-Frustrated with your project management?
-Basecamp's the calm, organized way to manage projects, work with clients, and communicate company-wide.
-[Try Basecamp for free]
-```
-- Opens with pain point; "calm, organized" = emotional benefit
-
-**Before/After:**
-```
-Before: Constant meetings | Lost files | Scattered apps | Anxiety
-After:  One place | Real progress | Everyone in the loop | Calmer teams
-```
-
-**Pricing:** `$299/month flat. Unlimited users, unlimited projects. No per-user pricing games.` — simple one-tier; anti-competitor positioning.
-
-**Why it converts:** Strong POV, before/after transformation, flat pricing, long-form testimonials.
-
-## 4. Mailchimp — "Turn Emails into Revenue"
-
-**Hero:**
-```
-Turn Emails into Revenue
-Grow your business with email marketing and automations that convert.
-[Start Free Trial] — No credit card required
-```
-- Outcome-focused headline (revenue); low-friction CTA
-
-**Features:** Email Builder / Audience Tools / Automations / Analytics — each with action-oriented benefit.
-
-**Stat:** `Generate up to 25x more orders with automations* (*Mailchimp data, 2023)` — specific, sourced, believable.
-
-**Why it converts:** Clear value prop (emails → revenue), free trial + no CC, specific sourced stats.
-
-## 5. Copyhackers — "Copy School" (Course Sales Page)
-
-**Hero:**
-```
-Stop Writing Copy That Blends In
-Get the exact frameworks, formulas, and feedback top copywriters use.
-[Join Copy School] [$3,497 or 6 payments]
-Doors close in [countdown]
-```
-- Pain point headline; price upfront; scarcity via countdown
-
-**Problem:**
-```
-You've read the blogs. Watched the videos. Tried the templates.
-Your copy still sounds like everyone else's.
-Why: Free stuff teaches WHAT. Not HOW. Not how to THINK like a copywriter.
-```
-- Acknowledges prior attempts → validates frustration → reveals the gap → positions solution
-
-**Testimonial:** `"I went from charging $500 to $5,000 for a landing page — and getting it."` — specific 10x number, named person with photo.
-
-**Why it converts:** Long-form for unaware audience, extensive social proof, clear curriculum, real urgency.
-
-## Hero Section Templates
-
-**Problem-Solution:**
-```
-[Pain Point Statement]
-[Product] helps [audience] [achieve outcome] without [objection].
-[CTA]
-```
-
-**Outcome-Focused:**
-```
-[Desirable Outcome in X Time]
-The [category] that [key differentiator].
-[CTA]
-```
-
-**Transformation:**
-```
-From [Current State] to [Desired State]
-[Product] makes it possible.
-[CTA]
-```
-
-## Social Proof Bar Templates
-
-```
-Trusted by [X]+ [customers/companies/users]
-[Logo] [Logo] [Logo] [Logo] [Logo]
-```
-
-```
-[Stat 1] | [Stat 2] | [Stat 3]
-"97% report faster results" | "4.9/5 on G2" | "10,000+ users"
-```
-
-## CTA Button Text
-
-- Start Free Trial / Get Started Free / Try [Product] Free
-- Start My [X]-Day Trial / Get Instant Access
-- Yes, I Want [Outcome] / Show Me How
-- Book My Demo / Claim My [Thing] / Start [Action]ing Now
-
-## Guarantee Templates
-
-```
-100% Money-Back Guarantee
-Try [Product] for [X] days. If you don't [achieve outcome], we'll refund every penny. No questions asked.
-```
-
-```
-The "[Product] Promise"
-If [Product] doesn't [specific result] within [timeframe], show us you implemented it and we'll give you a full refund.
-```
-
-## Design Principles
-
-1. **One CTA** — same action repeated multiple times
-2. **F-pattern reading** — important content on left
-3. **Above the fold** — value prop visible without scrolling
-4. **Visual hierarchy** — Headlines > subheads > body
-5. **Whitespace** — elements need room to breathe
-6. **Mobile-first** — 60%+ of traffic is mobile
-7. **Minimal navigation** — don't give them exit options
-8. **Consistent styling** — same button color throughout
+| When You Need | Start Here |
+|---------------|------------|
+| SaaS positioning and product-led structure | SaaS Landing Page Examples |
+| Course or info-product sales angles | Course Sales Page Example |
+| Hero copy frameworks | Hero Section Templates |
+| Proof bars and button ideas | Social Proof and CTA Templates |
+| Risk reversal and layout checks | Guarantees and Design Principles |

--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md
@@ -23,8 +23,8 @@ Annotated landing page examples, reusable section templates, and design principl
 
 | When You Need | Start Here |
 |---------------|------------|
-| SaaS positioning and product-led structure | SaaS Landing Page Examples |
-| Course or info-product sales angles | Course Sales Page Example |
-| Hero copy frameworks | Hero Section Templates |
-| Proof bars and button ideas | Social Proof and CTA Templates |
-| Risk reversal and layout checks | Guarantees and Design Principles |
+| SaaS positioning and product-led structure | [SaaS Landing Page Examples](direct-response-copy-swipe-file-landing-pages-01-saas-examples.md) |
+| Course or info-product sales angles | [Course Sales Page Example](direct-response-copy-swipe-file-landing-pages-02-course-sales-page.md) |
+| Hero copy frameworks | [Hero Section Templates](direct-response-copy-swipe-file-landing-pages-03-hero-section-templates.md) |
+| Proof bars and button ideas | [Social Proof and CTA Templates](direct-response-copy-swipe-file-landing-pages-04-social-proof-and-cta-templates.md) |
+| Risk reversal and layout checks | [Guarantees and Design Principles](direct-response-copy-swipe-file-landing-pages-05-guarantees-and-design-principles.md) |


### PR DESCRIPTION
## Summary
- Reclassify ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md" as a reference corpus and replace the monolithic file with a slim index.
- Split the swipe file into chapter files for SaaS examples, course sales examples, hero templates, CTA/proof templates, and guarantee/design principles.
- Add direct chapter links and usage guidance so agents can jump to the right section without scanning the full corpus.

## Runtime Testing
- Risk level: **Low** — markdown-only reference corpus restructure.
- Verification: markdownlint-cli2 v0.22.0 (markdownlint v0.40.0)
Finding: .agents/marketing-sales/direct-response-copy-swipe-file-landing-pages*.md !node_modules/** !.opencode/node_modules/** !python-env/** !.aider*
Linting: 6 file(s)
Summary: 0 error(s).
- Verification: chapter preservation check passed (, , , ).
- Verification: key content tokens preserved across the split corpus (Slack, Notion, Basecamp, Mailchimp, Copyhackers, guarantees, CTA templates, design principles).

## Closes
Closes #13864


---
[aidevops.sh](https://aidevops.sh) v3.5.537 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 1s on this as a headless worker.