### PR TITLE
GH#14735: tighten Workers gotchas doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1756,6 +1756,11 @@
       "at": "2026-03-29T03:15:00Z",
       "pr": 12502
     },
+    ".agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md": {
+      "hash": "6be4c58234dacd462fbb89034a8cffb21ede28d5",
+      "at": "2026-03-31T19:26:26Z",
+      "pr": 15014
+    },
     ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
       "hash": "12b23db6429e9400868f947faff09d534d18165d",
       "at": "2026-03-31T09:29:58Z",

--- a/.agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md
@@ -1,22 +1,18 @@
 # Workers Gotchas
 
-## CPU Time Limits
+## Design Constraints
 
-**Standard**: 10ms CPU time  
-**Unbound**: 30ms CPU time
+### CPU Budget
 
-**Solutions**:
-- Use `ctx.waitUntil()` for background work
-- Offload heavy compute to Durable Objects
-- Consider Workers AI for ML workloads
+Standard: 10ms CPU time. Unbound: 30ms CPU time.
 
-## No Persistent State in Worker
+Use `ctx.waitUntil()` for background work, Durable Objects for heavy compute, and Workers AI for ML workloads.
 
-Workers are stateless between requests - module-level variables reset unpredictably.
+### No Persistent State in Worker
 
-**Solution**: Use KV, D1, or Durable Objects for persistent state.
+Workers are stateless between requests. Module-level variables reset unpredictably, so store persistent state in KV, D1, or Durable Objects.
 
-## Response Bodies Are Streams
+### Response Bodies Are Streams
 
 ```typescript
 // ❌ BAD
@@ -31,7 +27,7 @@ await logBody(text);
 return new Response(text, response);
 ```
 
-## No Node.js Built-ins (by default)
+### No Node.js Built-ins by Default
 
 ```typescript
 // ❌ BAD
@@ -44,7 +40,7 @@ const data = await env.MY_BUCKET.get('file.txt');
 { "compatibility_flags": ["nodejs_compat_v2"] }
 ```
 
-## Fetch in Global Scope Forbidden
+### Fetch in Global Scope Is Forbidden
 
 ```typescript
 // ❌ BAD
@@ -63,7 +59,7 @@ export default {
 };
 ```
 
-## Limits
+## Runtime Limits
 
 | Resource | Limit |
 |----------|-------|
@@ -79,19 +75,19 @@ export default {
 
 ### "Error: Body has already been used"
 
-**Cause**: Response body read twice  
-**Solution**: Clone response before reading: `response.clone()`
+- Cause: response body read twice
+- Solution: clone before reading with `response.clone()`
 
 ### "Error: Too much CPU time used"
 
-**Cause**: Exceeded CPU limit  
-**Solution**: Use `ctx.waitUntil()` for background work
+- Cause: exceeded CPU limit
+- Solution: move background work into `ctx.waitUntil()`
 
 ### "Error: Subrequest depth limit exceeded"
 
-**Cause**: Too many nested subrequests  
-**Solution**: Flatten request chain, use service bindings
+- Cause: too many nested subrequests
+- Solution: flatten the request chain and use service bindings
 
 ## See Also
 
-- [Patterns](./patterns.md) - Best practices
+- [workers-patterns.md](./workers-patterns.md) - Best practices


### PR DESCRIPTION
## Summary
- regroup Workers runtime constraints under a single design-constraints section so the high-signal pitfalls read faster
- tighten the common-error guidance without removing the existing examples or limits table
- fix the See Also link to point at the actual `workers-patterns.md` companion doc
- record the new post-simplification blob hash in `.agents/configs/simplification-state.json`

## Runtime Testing
- Level: self-assessed (low-risk doc-only change)
- Verification: `bunx markdownlint-cli2 ".agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md"`
- Link check: verified `.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md` exists
- JSON check: `jq empty .agents/configs/simplification-state.json`

Closes #14735


---
[aidevops.sh](https://aidevops.sh) v3.5.537 plugin for [OpenCode](https://opencode.ai) v1.3.10 with gpt-5.4 spent 10m on this as a headless worker.