### PR TITLE
t1713: fix broken aidevops CLI symlink and add to non-interactive setup

### DIFF
--- a/setup-modules/config.sh
+++ b/setup-modules/config.sh
@@ -35,13 +35,13 @@ setup_configs() {
 install_aidevops_cli() {
 	print_info "Installing aidevops CLI command..."
 
-	local script_dir
-	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-	local cli_source="$script_dir/aidevops.sh"
+	# Use INSTALL_DIR (repo root, exported by setup.sh) — not BASH_SOURCE[0]
+	# which resolves to setup-modules/ when sourced from setup.sh.
+	local cli_source="${INSTALL_DIR:?INSTALL_DIR not set}/aidevops.sh"
 	local cli_target="/usr/local/bin/aidevops"
 
 	if [[ ! -f "$cli_source" ]]; then
-		print_warning "aidevops.sh not found - skipping CLI installation"
+		print_warning "aidevops.sh not found at $cli_source - skipping CLI installation"
 		return 0
 	fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -775,6 +775,7 @@ _setup_run_non_interactive() {
 	validate_opencode_config
 	deploy_aidevops_agents
 	sync_agent_sources
+	install_aidevops_cli
 	setup_shellcheck_wrapper
 	if is_feature_enabled safety_hooks 2>/dev/null; then
 		setup_safety_hooks


### PR DESCRIPTION
## Summary

- **Bug**: `install_aidevops_cli()` used `BASH_SOURCE[0]` to locate `aidevops.sh`, which resolved to `setup-modules/` (the sourced file's directory) instead of the repo root — so the symlink target was always wrong
- **Bug**: `install_aidevops_cli` was only called from the interactive setup path, meaning `aidevops update` (non-interactive) could never repair a broken CLI symlink
- **Fix**: Use `$INSTALL_DIR` (repo root, already exported by `setup.sh`) and add the call to `_setup_run_non_interactive()`

## Changes

| File | Change |
|------|--------|
| `setup-modules/config.sh` | Replace `BASH_SOURCE[0]` path resolution with `$INSTALL_DIR` |
| `setup.sh` | Add `install_aidevops_cli` to `_setup_run_non_interactive()` |

## Testing

- ShellCheck: zero violations on both files
- Manual verification: fixed symlink resolves correctly, `aidevops status` works

Closes #14771

---
[aidevops.sh](https://aidevops.sh) v3.5.538 plugin for [OpenCode](https://opencode.ai) v1.3.12 with claude-opus-4-6 spent 20m and 8,077 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during installation with more informative error messages that clearly indicate when required installation files cannot be located.

* **Chores**
  * Updated setup workflow to automatically include CLI installation as a core step, ensuring more comprehensive system configuration and streamlining the initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->