### PR TITLE
chore: add Claude CLI alignment comments to oauth-pool-helper.sh

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -246,9 +246,9 @@
       "pr": 11341
     },
     ".agents/workflows/pre-edit.md": {
-      "hash": "8cb5476f1750b4c5b3dcbc962019db62a9268e11",
-      "at": "2026-03-31T11:00:45Z",
-      "pr": null
+      "hash": "86ff0d26a5216ac2809dd8369df64f9d88551e64",
+      "at": "2026-04-01T01:29:20Z",
+      "pr": 14839
     },
     ".agents/aidevops/recommendations.md": {
       "hash": "67c3f660425b669feae3238d7b42589449caa860",
@@ -267,7 +267,7 @@
     },
     ".agents/tools/browser/playwright.md": {
       "hash": "2895bdfcfc2653298c02eddaec5913eaf0396156",
-      "at": "2026-03-31T09:28:43Z",
+      "at": "2026-04-01T01:29:34Z",
       "pr": 14790
     },
     ".agents/tools/database/vector-search.md": {
@@ -1496,8 +1496,8 @@
       "pr": 12145
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "17c1d423856a0d7e58fe5d0f201ec112d78815dc",
-      "at": "2026-03-31T21:31:15Z",
+      "hash": "15c49aa827ae8aae8f3d497f9ea8a3f96315db12",
+      "at": "2026-04-01T01:29:16Z",
       "pr": 14846
     },
     ".agents/tools/browser/stagehand-python.md": {
@@ -1777,7 +1777,7 @@
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md": {
       "hash": "6be4c58234dacd462fbb89034a8cffb21ede28d5",
-      "at": "2026-03-31T19:26:26Z",
+      "at": "2026-04-01T01:29:44Z",
       "pr": 15014
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
@@ -3160,9 +3160,9 @@
       "pr": 14650
     },
     ".agents/marketing-sales/meta-ads-creative-briefs-founder-video-brief.md": {
-      "hash": "a4bf29e5b45891eeb157e02f740965cd3370cb9d",
-      "at": "2026-03-31T06:30:29Z",
-      "pr": 14701
+      "hash": "4663b6f4a18ffba178e090fd696bba98f87535b8",
+      "at": "2026-04-01T01:29:45Z",
+      "pr": 14719
     },
     ".agents/tools/vision/overview.md": {
       "hash": "5abddf3f89fc529bd3119b8ae147961451728199",
@@ -3170,9 +3170,9 @@
       "pr": 14932
     },
     ".agents/seo/geo-strategy.md": {
-      "hash": "9e140122413dbbd69a12a6c545c7df84b07f448a",
-      "at": "2026-03-31T09:56:41Z",
-      "pr": 14785
+      "hash": "099f6b6ea92399ffab7e7aece025d2abb6f0c449",
+      "at": "2026-04-01T01:29:14Z",
+      "pr": 14852
     },
     ".agents/tools/credentials/bitwarden.md": {
       "hash": "2383188cabb629a721c7dfef63da8ab43b52b44e",
@@ -3185,9 +3185,9 @@
       "pr": 14883
     },
     ".agents/scripts/commands/security-deps.md": {
-      "hash": "837b301fe989e4eae715b71ed8150d1bfe207b7f",
-      "at": "2026-03-31T21:30:54Z",
-      "pr": 14941
+      "hash": "265f2d26f358ffb425e374dca8aa76a7c20c3565",
+      "at": "2026-04-01T01:28:52Z",
+      "pr": 14994
     },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
       "hash": "a87bdad3db117a280177a98592d12acba7a2e676",
@@ -3220,9 +3220,9 @@
       "pr": 14881
     },
     ".agents/services/monitoring/socket.md": {
-      "hash": "34908f8a4d31f318c2c7e65f73f7277106d3c6d3",
-      "at": "2026-03-31T21:31:11Z",
-      "pr": 14882
+      "hash": "788506798f5a1eedd29bb5d84aaa61a758c1acd8",
+      "at": "2026-04-01T01:29:07Z",
+      "pr": 14896
     },
     ".agents/scripts/commands/security-history.md": {
       "hash": "7164de660f471db3fdf292f714218cf6b86a7c92",
@@ -3265,34 +3265,19 @@
       "pr": 14921
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md": {
-      "hash": "f6caa2244bb5170ee50dbcb0f268cd42a12b40a8",
-      "at": "2026-03-31T22:11:36Z",
+      "hash": "4c6d024fd0bd6ab3cbc9881e5cd83bd7dec582e4",
+      "at": "2026-04-01T01:29:12Z",
       "pr": 14853
     },
     ".agents/tools/code-review/skill-scanner.md": {
-      "hash": "44610d12c6666e506e869c5c40b7cb1b0e8c19b3",
-      "at": "2026-03-31T22:11:43Z",
+      "hash": "621b5412cc6b9928088daf6ed6938a7cf78f1ecc",
+      "at": "2026-04-01T01:29:19Z",
       "pr": 14837
     },
-    ".agents/workflows/pre-edit.md": {
-      "hash": "4dce8edfb8fde958c599b565e92b8d910a77e848",
-      "at": "2026-03-31T22:11:44Z",
-      "pr": 14839
-    },
     ".agents/scripts/commands/youtube-script.md": {
-      "hash": "90f828282be8300a6b1dd012f0b53eafbf4a9049",
-      "at": "2026-03-31T22:11:52Z",
+      "hash": "75adb0043f5df965408fe3bfeb4f475d1ffa2953",
+      "at": "2026-04-01T01:29:27Z",
       "pr": 14805
-    },
-    ".agents/tools/browser/playwright.md": {
-      "hash": "620cb00e7a1706e11f0e03d66a2aac7a9fd6947e",
-      "at": "2026-03-31T22:11:59Z",
-      "pr": 14790
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md": {
-      "hash": "090f4a4d018d8f3fa89861f9d254a6ae60098706",
-      "at": "2026-03-31T22:12:11Z",
-      "pr": 15014
     }
   }
 }

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -29,10 +29,25 @@ POOL_FILE="${HOME}/.aidevops/oauth-pool.json"
 OPENCODE_AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
 
 # Anthropic OAuth
+# Alignment notes (vs Claude CLI codebase, for troubleshooting):
+#   CLIENT_ID        — identical to Claude CLI (public, same for all clients)
+#   TOKEN_ENDPOINT   — identical to Claude CLI prod config
+#   AUTHORIZE_URL    — we hit claude.ai directly; Claude CLI now routes through
+#                      https://claude.com/cai/oauth/authorize for attribution,
+#                      which 307-redirects to claude.ai. Ours is the final dest.
+#                      FALLBACK: if authorize breaks, try the claude.com route.
+#   REDIRECT_URI     — we use console.anthropic.com; Claude CLI switched to
+#                      platform.claude.com (the new Console domain). Both are
+#                      currently registered redirect URIs. If Anthropic
+#                      deregisters the old domain, switch to the new one below.
+#                      FALLBACK: "https://platform.claude.com/oauth/code/callback"
+#   SCOPES           — identical to Claude CLI's ALL_OAUTH_SCOPES union
 ANTHROPIC_CLIENT_ID="9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 ANTHROPIC_TOKEN_ENDPOINT="https://platform.claude.com/v1/oauth/token"
 ANTHROPIC_AUTHORIZE_URL="https://claude.ai/oauth/authorize"
+# FALLBACK_AUTHORIZE_URL="https://claude.com/cai/oauth/authorize"
 ANTHROPIC_REDIRECT_URI="https://console.anthropic.com/oauth/code/callback"
+# FALLBACK_REDIRECT_URI="https://platform.claude.com/oauth/code/callback"
 ANTHROPIC_SCOPES="org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
 
 # OpenAI OAuth
@@ -54,6 +69,11 @@ GOOGLE_SCOPES="https://www.googleapis.com/auth/generative-language https://www.g
 GOOGLE_HEALTH_CHECK_URL="https://generativelanguage.googleapis.com/v1beta/models?pageSize=1"
 
 # User-Agent (detect Claude CLI version)
+# Note: Claude CLI itself uses axios defaults (no custom UA) for token exchange
+# and refresh requests. We set an explicit UA to appear as a Claude CLI client.
+# The "(external, cli)" suffix is our addition — not sent by the real CLI.
+# FALLBACK: if UA filtering ever causes issues, try removing the suffix or
+# switching to an axios-style UA like "axios/1.7.9".
 CLAUDE_VERSION="2.1.80"
 if command -v claude &>/dev/null; then
 	local_ver=$(claude --version 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
@@ -297,6 +317,13 @@ _oauth_exchange_code() {
 
 # Extract access_token, refresh_token, expires_in from a JSON token response (stdin).
 # Prints three lines: access_token, refresh_token, expires_in.
+# Alignment note: Claude CLI's token response also contains 'scope' (space-delimited
+# string) and optionally 'account' (object with uuid, email_address) and
+# 'organization' (object with uuid). We ignore these — pool doesn't need them.
+# DIAGNOSTIC: if debugging, parse the full response to inspect granted scopes:
+#   d.get('scope', '').split()     — should include user:inference
+#   d.get('account', {})           — account uuid + email
+#   d.get('organization', {})      — org uuid (for team/enterprise)
 _extract_token_fields() {
 	python3 -c "
 import sys, json
@@ -354,7 +381,14 @@ _add_build_authorize_url() {
 	fi
 	full_url="${full_url}?client_id=${client_id}&response_type=code&redirect_uri=${encoded_redirect}&scope=${encoded_scopes}&code_challenge=${challenge}&code_challenge_method=S256&state=${state_nonce}"
 	if [[ "$provider" == "anthropic" ]]; then
+		# Alignment: &code=true matches Claude CLI — tells the login page to show
+		# the Claude Max upsell. Required for parity with the official client.
 		full_url="${full_url}&code=true"
+		# Claude CLI also supports these optional params (we don't send them):
+		#   &orgUUID=...      — pre-select org for team/enterprise logins
+		#   &login_hint=...   — pre-populate email (standard OIDC parameter)
+		#   &login_method=... — request specific login method (sso, magic_link, google)
+		# FALLBACK: if org-scoped auth is needed, add &orgUUID= to the URL.
 	fi
 	printf '%s' "$full_url"
 	return 0
@@ -521,6 +555,10 @@ _add_build_token_body() {
 		# Build JSON via Python to safely encode the auth code.
 		# The 'state' field is required by Anthropic's token endpoint as of
 		# Claude CLI v2.1.x — omitting it causes HTTP 400 "Invalid request format".
+		# Alignment: body fields match Claude CLI's exchangeCodeForTokens() exactly:
+		#   grant_type, code, redirect_uri, client_id, code_verifier, state
+		# Claude CLI also supports an optional 'expires_in' field for custom token
+		# lifetimes — we don't send it (server default is fine for pool rotation).
 		CODE="$code" CLIENT_ID="$client_id" REDIR="$redirect_uri" \
 			VERIFIER="$verifier" STATE="$state_nonce" python3 -c "
 import json, os
@@ -624,6 +662,16 @@ _cmd_add_exchange_and_save() {
 		print_error "No access token in response"
 		return 1
 	fi
+
+	# Alignment note: after token exchange, Claude CLI fetches the user profile
+	# via GET https://api.anthropic.com/api/oauth/profile (Bearer token auth) to
+	# determine subscription type (pro/max/team/enterprise) and rate limit tier.
+	# We skip this — pool rotation doesn't need subscription info. But if
+	# debugging auth issues, this endpoint is useful for verifying the token
+	# grants the expected access level.
+	# DIAGNOSTIC: curl -s -H "Authorization: Bearer $access_token" \
+	#   -H "Content-Type: application/json" \
+	#   https://api.anthropic.com/api/oauth/profile
 
 	local now_ms expires_ms now_iso
 	now_ms=$(get_now_ms)
@@ -1115,6 +1163,10 @@ def _check_token_validity(a, prov, expires_in, ua):
                 req.add_header('Authorization', f'Bearer {token}')
                 req.add_header('User-Agent', ua)
                 req.add_header('anthropic-version', '2023-06-01')
+                # Claude CLI sends this beta header on profile/API requests.
+                # We include it on health checks for parity. If this endpoint
+                # ever rejects the header, remove it — it is not required for
+                # the /v1/models listing, only for OAuth-specific endpoints.
                 req.add_header('anthropic-beta', 'oauth-2025-04-20')
                 urlopen(req, timeout=10)
                 print(f\"    Validity: OK\")
@@ -1436,6 +1488,12 @@ def _try_refresh(account, provider, now_ms):
     client_id = CLIENT_IDS.get(provider, '')
     if not (refresh_tok and token_url and client_id):
         return
+    # Alignment note: Claude CLI sends 'scope' on refresh requests (the full
+    # CLAUDE_AI_OAUTH_SCOPES set). The backend allows scope expansion beyond
+    # what the initial authorize granted. We omit it — the server returns the
+    # originally granted scopes, which is sufficient for our use.
+    # FALLBACK: if refresh starts returning fewer scopes than expected, add:
+    #   'scope': 'user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload'
     body = json.dumps({
         'grant_type': 'refresh_token',
         'refresh_token': refresh_tok,
@@ -1736,6 +1794,8 @@ try:
         if expires and expires > now_ms + 3600000:
             continue
 
+        # Alignment: Claude CLI sends 'scope' on refresh (see _try_refresh note).
+        # FALLBACK: add 'scope' key if refresh returns insufficient scopes.
         body = json.dumps({
             'grant_type': 'refresh_token',
             'refresh_token': refresh_tok,


### PR DESCRIPTION
## Summary

- Adds alignment documentation throughout `oauth-pool-helper.sh` comparing our Anthropic OAuth flow to the upstream Claude CLI implementation
- Includes `FALLBACK:` comments with ready-to-uncomment alternative values (redirect URI, authorize URL, refresh scopes) for quick fixes if upstream changes break our OAuth flow
- Includes `DIAGNOSTIC:` comments with curl commands and response field docs for debugging auth failures

No behavioral changes. Comments and commented-out fallback values only.

### Key alignment findings documented

| Constant | Our value | Claude CLI value | Risk |
|---|---|---|---|
| Redirect URI | `console.anthropic.com` | `platform.claude.com` | **Highest** — old domain may be deregistered |
| Authorize URL | `claude.ai/oauth/authorize` | `claude.com/cai/oauth/authorize` | Medium — ours is the final redirect target |
| Refresh scope | omitted | full scope set | Low — server returns original scopes |
| User-Agent | custom `(external, cli)` | axios defaults | Negligible |

---
[aidevops.sh](https://aidevops.sh) v3.5.540 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 39m on this as a headless worker.