### PR TITLE
GH#15060: pre-dispatch backoff check — skip rate-limited providers before launch

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4824,16 +4824,50 @@ dispatch_with_dedup() {
 	: >"$worker_log"
 	ln -s "$worker_log" "$worker_log_fallback" 2>/dev/null || true
 
-	# Launch worker
+	# Pre-dispatch model selection: check provider backoff BEFORE launching.
+	# Previously, the wrapper dispatched blindly with whatever model was
+	# configured, wasting an assign/claim/launch cycle when the provider was
+	# rate-limited. Now we ask headless-runtime-helper.sh to select the best
+	# available model (respects backoff DB, auth availability, round-robin).
+	# If a model_override is requested (e.g., tier:thinking → opus), we
+	# validate it against backoff first and fall back to auto-selection if
+	# it's currently backed off.
+	local selected_model=""
+	if [[ -n "$model_override" ]]; then
+		# Check if the requested model is backed off
+		if "$HEADLESS_RUNTIME_HELPER" select --role worker --model "$model_override" >/dev/null 2>&1; then
+			selected_model="$model_override"
+		else
+			# Requested model is backed off — fall back to auto-selection
+			selected_model=$("$HEADLESS_RUNTIME_HELPER" select --role worker 2>/dev/null) || selected_model=""
+			if [[ -n "$selected_model" ]]; then
+				echo "[dispatch_with_dedup] Model ${model_override} backed off — using ${selected_model} instead for #${issue_number}" >>"$LOGFILE"
+			fi
+		fi
+	else
+		# No override — auto-select best available model
+		selected_model=$("$HEADLESS_RUNTIME_HELPER" select --role worker 2>/dev/null) || selected_model=""
+	fi
+
+	# If ALL models are backed off, skip this dispatch entirely.
+	# The issue stays assigned+queued and will be retried next cycle
+	# when backoffs may have expired.
+	if [[ -z "$selected_model" ]]; then
+		echo "[dispatch_with_dedup] All models backed off — skipping dispatch for #${issue_number} in ${repo_slug} (will retry next cycle)" >>"$LOGFILE"
+		# Unassign and remove queued label so the issue is re-dispatchable
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--remove-assignee "$self_login" --remove-label "status:queued" 2>/dev/null || true
+		return 1
+	fi
+
+	# Launch worker with the pre-validated model
 	local -a worker_cmd=("$HEADLESS_RUNTIME_HELPER" run
 		--role worker
 		--session-key "$session_key"
 		--dir "$repo_path"
 		--title "$dispatch_title"
-		--prompt "$prompt")
-	if [[ -n "$model_override" ]]; then
-		worker_cmd+=(--model "$model_override")
-	fi
+		--prompt "$prompt"
+		--model "$selected_model")
 	"${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 &
 	local worker_pid="$!"
 	sleep 2


### PR DESCRIPTION
## Summary

`dispatch_with_dedup()` now checks provider backoff state BEFORE launching workers. Previously it launched blindly, wasting assign/claim/launch cycles on rate-limited providers that the activity watchdog would kill 90s later.

### Change

In `dispatch_with_dedup()`, before building the worker command:
1. If `model_override` set: validate against backoff DB, fall back to auto-select if backed off
2. If no override: auto-select best available model via `headless-runtime-helper.sh select`
3. If ALL models backed off: skip dispatch entirely, unassign/unqueue issue for next cycle

### Complete provider health chain

| Layer | When | What | Response time |
|-------|------|------|---------------|
| **Pre-dispatch** (this fix) | Before launch | Check backoff DB | **0s — never launches** |
| Activity watchdog (v3.5.546) | During launch | No LLM output in 90s | 90s |
| Pulse watchdog (v3.5.546) | Every cycle | Workers >5min with no output | 2-5 min |
| Post-exit handler (existing) | After exit | Classify failure, record backoff | Immediate |

Closes #15060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dispatch system with intelligent model selection that checks provider availability and resource status.
  * Implemented automatic fallback logic to select alternative models when preferred options are unavailable or overloaded.
  * Improved issue management by automatically preparing issues for re-dispatch when no suitable models are currently accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->