### PR TITLE
GH#15060: isolate pulse supervisor backoff from worker dispatch

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1379,7 +1379,16 @@ _handle_run_result() {
 		return 76
 	fi
 
-	record_provider_backoff "$provider" "$failure_reason" "$output_file" "$selected_model"
+	# Pulse supervisor failures must NOT block worker dispatch. The supervisor
+	# and workers may use different accounts (isolated auth) and the supervisor
+	# hitting a rate limit doesn't mean the provider is down for workers.
+	# Record pulse backoffs under a role-scoped key so the pre-dispatch check
+	# (which queries the model key) doesn't see them.
+	if [[ "$role" == "pulse" ]]; then
+		record_provider_backoff "$provider" "$failure_reason" "$output_file" "pulse/${selected_model}"
+	else
+		record_provider_backoff "$provider" "$failure_reason" "$output_file" "$selected_model"
+	fi
 	rm -f "$output_file"
 	_run_failure_reason="$failure_reason"
 	_run_should_retry=0


### PR DESCRIPTION
Supervisor rate limit was blocking all worker dispatch. Fix: role-scoped backoff keys. Closes #15060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced provider failure recovery data organization and tracking across the system. Service provider failures and recovery logic are now properly scoped based on operational context, strengthening overall system reliability and consistency when managing failed operations and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->