### PR TITLE
t1735: fix 5 headless worker lifecycle bugs (event mismatch, orphans, watchdog, timeout, stdout)

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -769,7 +769,7 @@ for line in Path(sys.argv[1]).read_text(errors="ignore").splitlines():
     except Exception:
         continue
     event_type = obj.get("type", "")
-    if event_type in {"text", "tool", "tool-invocation", "tool-result", "step-start", "step_finish", "reasoning"}:
+    if event_type in {"text", "tool", "tool-invocation", "tool-result", "step_start", "step_finish", "reasoning"}:
         activity = True
         break
 
@@ -1219,17 +1219,22 @@ _invoke_opencode() {
 		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
 			local passthrough_csv
 			passthrough_csv="$(build_sandbox_passthrough_csv)"
+			# --stream-stdout: let child stdout flow through the pipe to tee
+			# so the activity watchdog can monitor output in real-time
+			# (GH#15180 bug #4). Without this, the sandbox captures stdout to
+			# a temp file and replays it after exit — the watchdog sees nothing
+			# and kills every sandboxed worker at ~93s.
 			if [[ -n "$passthrough_csv" ]]; then
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
 			else
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout -- "${cmd[@]}" 2>&1 | tee "$output_file"
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		else
-			"${cmd[@]}" 2>&1 | tee "$output_file"
+			timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${cmd[@]}" 2>&1 | tee "$output_file"
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		fi
-	) &
+	) >/dev/null 2>&1 &
 	local worker_pid=$!
 
 	# Activity watchdog: monitor the output file for LLM activity.
@@ -1260,7 +1265,7 @@ _invoke_opencode() {
 #
 # Runs as a background process alongside the worker. Polls the output
 # file for LLM activity indicators (JSON events from opencode: text,
-# tool, reasoning, step-start). If none appear within the timeout,
+# tool, reasoning, step_start). If none appear within the timeout,
 # kills the worker process.
 #
 # The initial output always contains the sandbox startup line (~300 bytes).
@@ -1294,7 +1299,7 @@ _run_activity_watchdog() {
 			# output_has_activity is defined earlier — checks for JSON events
 			# But we can't call it from a background process easily.
 			# Instead, check for common activity markers directly.
-			if grep -qE '"type"\s*:\s*"(text|tool|tool-invocation|tool-result|step-start|reasoning)"' "$output_file" 2>/dev/null; then
+			if grep -qE '"type"\s*:\s*"(text|tool|tool-invocation|tool-result|step_start|step_finish|reasoning)"' "$output_file" 2>/dev/null; then
 				# Real LLM activity detected — worker is alive
 				return 0
 			fi
@@ -1304,15 +1309,21 @@ _run_activity_watchdog() {
 		elapsed=$((elapsed + poll_interval))
 	done
 
-	# Timeout reached with no activity — kill the stalled worker
+	# Timeout reached with no activity — kill the stalled worker and all its
+	# children (opencode, tee, etc.). Sending only to $worker_pid leaves
+	# pipeline children as orphans consuming CPU+memory (GH#15180 bug #2).
 	if kill -0 "$worker_pid" 2>/dev/null; then
 		print_warning "Activity watchdog: no LLM activity in ${timeout}s — killing stalled worker (PID $worker_pid)"
 		# Write the marker BEFORE killing — the dying subshell may overwrite
 		# exit_code_file with its own exit code (race condition). The marker
 		# file survives because only the watchdog writes to it.
 		touch "${exit_code_file}.watchdog_killed"
+		# Kill child processes first (pipeline members: opencode, tee), then
+		# the subshell itself. pkill -P walks the process tree by PPID.
+		pkill -P "$worker_pid" 2>/dev/null || true
 		kill "$worker_pid" 2>/dev/null || true
 		sleep 2
+		pkill -9 -P "$worker_pid" 2>/dev/null || true
 		kill -9 "$worker_pid" 2>/dev/null || true
 		printf '124' >"$exit_code_file"
 	fi

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -457,8 +457,20 @@ _sandbox_spawn_child() {
 	# its descendants share a PGID distinct from the wrapper's PGID.
 	# stdout/stderr are redirected here so the redirection applies to the
 	# backgrounded child process, not to the polling loop.
+	#
+	# --stream-stdout mode (GH#15180 bug #4): when stream_stdout=true (set
+	# by sandbox_run via dynamic scoping), stdout is NOT redirected to the
+	# capture file. Instead it flows to the caller's stdout (e.g., through
+	# a pipe to tee in headless-runtime-helper.sh) so external watchdogs
+	# can monitor activity in real-time. Stderr is still captured. The
+	# capture file remains empty; _sandbox_emit_redacted_output handles
+	# this gracefully (returns early on empty/missing files).
 	if command -v setsid &>/dev/null; then
-		setsid "$@" >"$sc_stdout_file" 2>"$sc_stderr_file" &
+		if [[ "${stream_stdout:-false}" == "true" ]]; then
+			setsid "$@" 2>"$sc_stderr_file" &
+		else
+			setsid "$@" >"$sc_stdout_file" 2>"$sc_stderr_file" &
+		fi
 		child_pid=$!
 		# Retrieve the process group ID of the child.
 		# On Linux: ps -o pgid= returns the PGID. On macOS: same flag works.
@@ -469,7 +481,11 @@ _sandbox_spawn_child() {
 			child_pgid=""
 		fi
 	else
-		"$@" >"$sc_stdout_file" 2>"$sc_stderr_file" &
+		if [[ "${stream_stdout:-false}" == "true" ]]; then
+			"$@" 2>"$sc_stderr_file" &
+		else
+			"$@" >"$sc_stdout_file" 2>"$sc_stderr_file" &
+		fi
 		child_pid=$!
 		# setsid not available — child shares the script's process group.
 		# Do NOT read the PGID here: ps would return the script's own PGID,
@@ -918,8 +934,12 @@ _sandbox_run_post_exec() {
 		log_sandbox "WARN" "Command timed out after ${timeout_secs}s"
 	fi
 
-	# Output results with redaction and taint-aware handling
-	_sandbox_emit_redacted_output "$stdout_file" "stdout" "$command_tainted"
+	# Output results with redaction and taint-aware handling.
+	# In --stream-stdout mode, stdout was already sent to the caller in
+	# real-time (not captured to file), so skip its emission here.
+	if [[ "${stream_stdout:-false}" != "true" ]]; then
+		_sandbox_emit_redacted_output "$stdout_file" "stdout" "$command_tainted"
+	fi
 	_sandbox_emit_redacted_output "$stderr_file" "stderr" "$command_tainted"
 
 	# Audit log
@@ -1004,6 +1024,12 @@ sandbox_run() {
 	local worker_id="sandbox-$$"
 	local extra_passthrough=""
 	local secret_io_guard="${AIDEVOPS_BLOCK_SECRET_IO:-$SECRET_IO_GUARD_DEFAULT}"
+	# Stream stdout mode (GH#15180 bug #4): when true, child stdout flows to
+	# the caller's stdout in real-time instead of being captured to a file and
+	# replayed after exit. This allows external watchdogs (e.g., the headless
+	# activity watchdog) to monitor output as it's produced. Stderr is still
+	# captured. Post-exec stdout emission is skipped (already streamed).
+	local stream_stdout=false
 	# cmd_args is an array — preserves spaces, avoids bash -c eval risks
 	local -a cmd_args=()
 
@@ -1037,6 +1063,10 @@ sandbox_run() {
 		--passthrough)
 			extra_passthrough="$2"
 			shift 2
+			;;
+		--stream-stdout)
+			stream_stdout=true
+			shift
 			;;
 		--)
 			shift


### PR DESCRIPTION
## Summary

Fixes all 5 bugs reported in #15180:

1. **Event type mismatch** — `step-start` (hyphen) vs `step_start` (underscore) in `output_has_activity()` and watchdog grep caused false negatives during activity detection
2. **Orphaned processes** — watchdog killed only the subshell PID, leaving opencode/tee as orphans consuming ~4% CPU + 400MB RSS each. Now uses `pkill -P` to walk the process tree.
3. **Missing timeout** — non-sandbox execution path had no overall timeout. Added `timeout $HEADLESS_SANDBOX_TIMEOUT_DEFAULT` wrapper.
4. **Sandbox blocks watchdog (critical)** — sandbox's store-and-replay captured child stdout to a temp file; the activity watchdog (reading tee output) saw nothing and killed every sandboxed worker at ~93s. Added `--stream-stdout` flag to `sandbox-exec-helper.sh` that lets child stdout flow to the caller in real-time.
5. **Subshell FD leak** — backgrounded subshell inherited parent FDs, blocking Claude Code's bash tool on `/runners` dispatches. Added `>/dev/null 2>&1` redirect.

## Files Changed

- `.agents/scripts/headless-runtime-helper.sh` — bugs 1, 2, 3, 5
- `.agents/scripts/sandbox-exec-helper.sh` — bug 4 (`--stream-stdout` flag)

## Runtime Testing

- **Risk level**: Medium (worker lifecycle, no auth/payment/data-deletion)
- **Testing**: `self-assessed` — tests pass (`test-headless-runtime-helper.sh`, `test-worker-sandbox-helper.sh`), ShellCheck clean
- **Rationale**: Changes are to background process management and event parsing. Full runtime verification requires a multi-worker dispatch environment. Static analysis + existing tests confirm correctness.

## Design Decisions

- **`--stream-stdout` over env var**: Explicit CLI flag is cleaner than implicit env var coupling. The sandbox's stderr capture + audit log remain intact; only stdout emission is skipped (already streamed).
- **`pkill -P` over `setsid`/process group**: Process tree walk is simpler than wrapping the subshell in `setsid` and avoids changing the process group semantics of the existing pipeline.
- **Stdout `/dev/null` redirect**: `tee` still writes to `$output_file`; only the duplicate copy to the parent's terminal/pipe is suppressed.

Closes #15186
Closes #15180


---
[aidevops.sh](https://aidevops.sh) v3.5.555 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 14m and 22,495 tokens on this with the user in an interactive session. Overall, 9m since this issue was created.