### PR TITLE
GH#14964: require model escalation before BLOCKED in worker policy

### DIFF
--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -66,6 +66,33 @@ ai_research(prompt: "Find all functions that dispatch workers in supervisor-help
 - Minimise token waste: read only needed line ranges, keep commits concise, and after one failed approach try one fundamentally different strategy before `BLOCKED`.
 - Replan when stuck. Do not patch a broken path incrementally.
 
+## 4. Model escalation before BLOCKED (GH#14964 — MANDATORY)
+
+`BLOCKED` is only valid after exhausting all autonomous solution paths. Before exiting `BLOCKED`:
+
+1. Attempt model escalation: retry with the next tier (sonnet → opus via `--model anthropic/claude-opus-4-6`).
+2. One opus attempt (~3x cost) is cheaper than a failed worker cycle plus human triage.
+3. Review-policy metadata, nominal GitHub states, and lower-tier model limits are **not** valid blockers on their own.
+4. A genuine blocker requires evidence that persists after escalation: failing check, missing permission, unresolved conflict, or explicit policy gate.
+
+```bash
+# Escalation pattern — use when current model stalls or cannot finish safely
+ESCALATED_MODEL="anthropic/claude-opus-4-6"
+headless-runtime-helper.sh run --role worker --session-key "$SESSION_KEY" \
+  --dir "$WORK_DIR" --title "$TITLE" --prompt "$PROMPT" --model "$ESCALATED_MODEL"
+```
+
+Escalation decision matrix:
+
+| Situation | Action |
+|-----------|--------|
+| Model stalls after 2+ attempts | Escalate to next tier |
+| Review-policy state (e.g. "changes requested") | Continue — address findings, do not stop |
+| Rate limit / auth error | Rotate provider (handled by headless-runtime-helper.sh) |
+| Missing credentials | EXIT BLOCKED (genuine blocker) |
+| Architectural decision needed | EXIT BLOCKED (genuine blocker) |
+| Failing CI check | Fix the check, do not stop |
+
 ## Completion self-check
 
 Before `FULL_LOOP_COMPLETE`, verify all of the following:

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -88,6 +88,7 @@ Detection is intelligence, not regex. ANY critical pattern → entire PR require
 6. **Time budget:** 45 min → self-check. 90 min → draft PR, exit. 120 min → stop.
 7. Verify prerequisites at START. Missing → exit. Push/PR failure (#2452) → retry after rebase → exit `BLOCKED`.
 8. `PULSE_SCOPE_REPOS` restricts code; issues always allowed (t1405). Mismatch → new issue (t1344).
+9. **Model escalation before BLOCKED (GH#14964 — MANDATORY):** `BLOCKED` is only valid after exhausting all autonomous solution paths. Before exiting `BLOCKED`, a worker MUST attempt model escalation: if the current model stalls or cannot finish safely, retry with the next tier (sonnet → opus via `--model anthropic/claude-opus-4-6`). Review-policy metadata, nominal GitHub states, and lower-tier model limits are NOT valid blockers on their own. Genuine blockers require evidence: failing check, missing permission, unresolved conflict, or explicit policy gate that persists after escalation. See `tools/context/model-routing.md` "Failure-Based Escalation".
 
 Changelog: `feat:` → Added, `fix:` → Fixed, `docs:`/`perf:`/`refactor:` → Changed, `chore:` → excluded. See `workflows/changelog.md`.
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1132,6 +1132,7 @@ Mandatory behavior:
 3. Continue through review polling, merge readiness checks, merge, and required closing comments.
 4. If merge/close cannot complete, exit only with a clear BLOCKED outcome and evidence (failing check, missing permission, unresolved conflict, or explicit policy gate).
 5. Do not emit user-directed language like "If you want, I can...".
+6. Model escalation before BLOCKED (GH#14964): BLOCKED is only valid after exhausting all autonomous solution paths. Before exiting BLOCKED, attempt model escalation — retry with the next tier (sonnet -> opus via --model anthropic/claude-opus-4-6). Review-policy metadata, nominal GitHub states, and lower-tier model limits are NOT valid blockers on their own. A genuine blocker requires evidence that persists after escalation.
 EOF
 	)
 

--- a/.agents/scripts/tests/test-headless-contract-escalation.sh
+++ b/.agents/scripts/tests/test-headless-contract-escalation.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# test-headless-contract-escalation.sh — Regression tests for GH#14964
+#
+# Verifies that:
+# 1. The headless continuation contract injected by headless-runtime-helper.sh
+#    includes the model escalation requirement (rule 6).
+# 2. The contract is NOT injected when AIDEVOPS_HEADLESS_APPEND_CONTRACT=0.
+# 3. The contract is NOT injected for non-/full-loop prompts.
+# 4. The contract is NOT injected when already present (idempotent).
+# 5. The escalation rule text is present and references GH#14964.
+#
+# Strategy: extract the append_worker_headless_contract function body from the
+# helper script and test it directly, avoiding the need to source the full
+# script (which has complex dependencies and runs main() at load time).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HEADLESS_HELPER="${SCRIPT_DIR}/../headless-runtime-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Extract the contract text directly from the heredoc in headless-runtime-helper.sh.
+# This is the source of truth — we test the actual contract content, not the
+# injection logic (which is already tested by the existing contract injection tests).
+extract_contract_text() {
+	python3 - "${HEADLESS_HELPER}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+content = Path(sys.argv[1]).read_text()
+
+# Find the heredoc block for the contract
+match = re.search(
+    r"cat\s+<<'EOF'\s*\n(.*?)\nEOF",
+    content,
+    re.DOTALL,
+)
+if match:
+    print(match.group(1))
+else:
+    print("")
+PY
+	return 0
+}
+
+# Test the append_worker_headless_contract function by running it in a subprocess
+# that sources only the function (not main). We do this by extracting the function
+# body and running it standalone.
+_call_append_contract() {
+	local append_enabled="${1:-1}"
+	local prompt_text="$2"
+
+	# Extract just the append_worker_headless_contract function from the helper
+	local func_body
+	func_body=$(
+		python3 - "${HEADLESS_HELPER}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+content = Path(sys.argv[1]).read_text()
+
+# Extract the append_worker_headless_contract function
+match = re.search(
+    r'(append_worker_headless_contract\(\)\s*\{.*?\n\})',
+    content,
+    re.DOTALL,
+)
+if match:
+    print(match.group(1))
+else:
+    print("")
+PY
+	)
+
+	if [[ -z "$func_body" ]]; then
+		printf '%s' "ERROR: could not extract function"
+		return 1
+	fi
+
+	AIDEVOPS_HEADLESS_APPEND_CONTRACT="$append_enabled" \
+		bash --norc --noprofile -c "
+			set -euo pipefail
+			${func_body}
+			append_worker_headless_contract \"\$1\"
+		" -- "$prompt_text" 2>/dev/null
+	return 0
+}
+
+test_contract_includes_escalation_rule() {
+	local contract_text
+	contract_text=$(extract_contract_text)
+
+	if [[ "$contract_text" == *"GH#14964"* ]]; then
+		print_result "contract heredoc includes GH#14964 escalation reference" 0
+		return 0
+	fi
+
+	print_result "contract heredoc includes GH#14964 escalation reference" 1 \
+		"Expected GH#14964 in contract heredoc; got: $(printf '%s' "$contract_text" | tail -5)"
+	return 0
+}
+
+test_contract_includes_escalation_text() {
+	local contract_text
+	contract_text=$(extract_contract_text)
+
+	if [[ "$contract_text" == *"escalation"* ]] ||
+		[[ "$contract_text" == *"escalate"* ]]; then
+		print_result "contract heredoc includes model escalation requirement text" 0
+		return 0
+	fi
+
+	print_result "contract heredoc includes model escalation requirement text" 1 \
+		"Expected escalation text in contract heredoc; got: $(printf '%s' "$contract_text" | tail -5)"
+	return 0
+}
+
+test_contract_includes_rule_6() {
+	local contract_text
+	contract_text=$(extract_contract_text)
+
+	# Rule 6 should be present (the new escalation rule)
+	if [[ "$contract_text" == *"6."* ]]; then
+		print_result "contract heredoc includes rule 6 (escalation)" 0
+		return 0
+	fi
+
+	print_result "contract heredoc includes rule 6 (escalation)" 1 \
+		"Expected rule 6 in contract heredoc; got: $(printf '%s' "$contract_text" | tail -10)"
+	return 0
+}
+
+test_contract_not_injected_when_disabled() {
+	local prompt='/full-loop Implement issue #14964'
+	local result
+	result=$(_call_append_contract "0" "$prompt")
+
+	if [[ "$result" == *"HEADLESS_CONTINUATION_CONTRACT_V1"* ]]; then
+		print_result "contract not injected when AIDEVOPS_HEADLESS_APPEND_CONTRACT=0" 1 \
+			"Expected no contract injection when disabled"
+		return 0
+	fi
+
+	print_result "contract not injected when AIDEVOPS_HEADLESS_APPEND_CONTRACT=0" 0
+	return 0
+}
+
+test_contract_not_injected_for_non_full_loop() {
+	local prompt='Run some other task'
+	local result
+	result=$(_call_append_contract "1" "$prompt")
+
+	if [[ "$result" == *"HEADLESS_CONTINUATION_CONTRACT_V1"* ]]; then
+		print_result "contract not injected for non-/full-loop prompts" 1 \
+			"Expected no contract injection for non-/full-loop prompt"
+		return 0
+	fi
+
+	print_result "contract not injected for non-/full-loop prompts" 0
+	return 0
+}
+
+test_contract_idempotent() {
+	local prompt
+	prompt=$(printf '/full-loop Implement issue #14964\n\n[HEADLESS_CONTINUATION_CONTRACT_V1]\nThis worker run is unattended.')
+	local result
+	result=$(_call_append_contract "1" "$prompt")
+
+	# Count occurrences of the contract marker
+	local count
+	count=$(printf '%s' "$result" | grep -c "HEADLESS_CONTINUATION_CONTRACT_V1" || true)
+
+	if [[ "$count" -eq 1 ]]; then
+		print_result "contract injection is idempotent (not duplicated)" 0
+		return 0
+	fi
+
+	print_result "contract injection is idempotent (not duplicated)" 1 \
+		"Expected exactly 1 contract marker, found ${count}"
+	return 0
+}
+
+test_genuine_blockers_distinguished() {
+	local contract_text
+	contract_text=$(extract_contract_text)
+
+	# The contract should mention that genuine blockers (missing credentials, etc.)
+	# ARE valid — it should not say ALL blockers are invalid
+	if [[ "$contract_text" == *"genuine blocker"* ]] ||
+		[[ "$contract_text" == *"persists after escalation"* ]]; then
+		print_result "contract distinguishes genuine blockers from invalid ones" 0
+		return 0
+	fi
+
+	print_result "contract distinguishes genuine blockers from invalid ones" 1 \
+		"Expected contract to mention genuine blockers; got: $(printf '%s' "$contract_text" | tail -5)"
+	return 0
+}
+
+test_contract_injected_for_full_loop() {
+	local prompt='/full-loop Implement issue #14964'
+	local result
+	result=$(_call_append_contract "1" "$prompt")
+
+	if [[ "$result" == *"HEADLESS_CONTINUATION_CONTRACT_V1"* ]]; then
+		print_result "contract injected for /full-loop prompts" 0
+		return 0
+	fi
+
+	print_result "contract injected for /full-loop prompts" 1 \
+		"Expected contract injection for /full-loop prompt"
+	return 0
+}
+
+main() {
+	if [[ ! -f "$HEADLESS_HELPER" ]]; then
+		printf '%bFAIL%b headless-runtime-helper.sh not found at %s\n' \
+			"$TEST_RED" "$TEST_RESET" "$HEADLESS_HELPER"
+		exit 1
+	fi
+
+	test_contract_includes_escalation_rule
+	test_contract_includes_escalation_text
+	test_contract_includes_rule_6
+	test_contract_not_injected_when_disabled
+	test_contract_not_injected_for_non_full_loop
+	test_contract_idempotent
+	test_genuine_blockers_distinguished
+	test_contract_injected_for_full_loop
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -89,9 +89,11 @@ Interactive: `/compare-models`, `/compare-models-free`, `/route <task>`
 
 **Precedence** (highest wins): (1) `model:` in TODO.md, (2) subagent frontmatter, (3) bundle `model_defaults`, (4) default `sonnet`. Multiple bundles → most-restrictive tier wins. CLI: `bundle-helper.sh get|resolve`. Integration: `cron-dispatch.sh`, pulse `agent_routing`, `linters-local.sh` `skip_gates`.
 
-## Failure-Based Escalation (t1416)
+## Failure-Based Escalation (t1416 + GH#14964)
 
 After 2 failed attempts, escalate to next tier (sonnet → opus via `--model anthropic/claude-opus-4-6`). One opus (~3x) < 3+ failed sonnet dispatches. Dispatch/kill comments MUST include model tier for escalation auditing.
+
+**Worker BLOCKED policy (GH#14964 — MANDATORY):** Workers must attempt model escalation before exiting `BLOCKED`. Review-policy metadata, nominal GitHub states, and lower-tier model limits are NOT valid blockers on their own. A genuine blocker requires evidence that persists after escalation. See `prompts/worker-efficiency-protocol.md` "Model escalation before BLOCKED".
 
 ## Tier Drift Detection (t1191)
 


### PR DESCRIPTION
## Summary

Implements the worker escalation policy required by GH#14964: workers must attempt model escalation before exiting `BLOCKED` or handing off to a human.

## Changes

- **`.agents/prompts/worker-efficiency-protocol.md`** — Added section 4 "Model escalation before BLOCKED" with decision matrix and escalation pattern
- **`.agents/scripts/commands/full-loop.md`** — Added rule 9 to headless dispatch rules: BLOCKED only valid after escalation attempt
- **`.agents/scripts/headless-runtime-helper.sh`** — Added rule 6 to the HEADLESS_CONTINUATION_CONTRACT_V1 injected into every worker prompt
- **`.agents/tools/context/model-routing.md`** — Extended "Failure-Based Escalation" section with BLOCKED policy reference
- **`.agents/scripts/tests/test-headless-contract-escalation.sh`** — 8 regression tests verifying contract content and injection behavior

## Acceptance Criteria

- [DONE] Headless worker contract updated to require escalation before BLOCKED
- [DONE] full-loop.md headless dispatch rules updated
- [DONE] worker-efficiency-protocol.md has escalation decision matrix
- [DONE] model-routing.md cross-references the new policy
- [DONE] Regression tests added and passing (8/8)

## Runtime Testing

Risk level: **Low** — documentation/prompt changes only, no runtime code paths changed. The test script validates contract content statically.

Test results:
```
PASS contract heredoc includes GH#14964 escalation reference
PASS contract heredoc includes model escalation requirement text
PASS contract heredoc includes rule 6 (escalation)
PASS contract not injected when AIDEVOPS_HEADLESS_APPEND_CONTRACT=0
PASS contract not injected for non-/full-loop prompts
PASS contract injection is idempotent (not duplicated)
PASS contract distinguishes genuine blockers from invalid ones
PASS contract injected for /full-loop prompts

Ran 8 tests, 0 failed.
```

Closes #14964


---
[aidevops.sh](https://aidevops.sh) v3.5.555 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal protocol documentation and model escalation guidance.

* **Tests**
  * Added regression test suite for model escalation behavior validation.

**Note:** This release contains internal infrastructure and documentation updates with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->