### PR TITLE
t1833: Add priority-based account rotation to model-accounts-pool

### DIFF
--- a/.agents/plugins/opencode-aidevops/provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth.mjs
@@ -133,7 +133,10 @@ export function createProviderAuthHook(client) {
                 const aOrder = STATUS_ORDER[a.status] ?? 99;
                 const bOrder = STATUS_ORDER[b.status] ?? 99;
                 if (aOrder !== bOrder) return aOrder - bOrder;
-                // Within same status, prefer least recently used
+                // t1833: prefer higher priority within same status
+                const pDiff = (b.priority || 0) - (a.priority || 0);
+                if (pDiff !== 0) return pDiff;
+                // Then least recently used
                 return new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0);
               });
 
@@ -418,7 +421,12 @@ export function createProviderAuthHook(client) {
                     (a.status === "active" || a.status === "idle") &&
                     (!a.cooldownUntil || a.cooldownUntil <= now),
                 )
-                .sort((a, b) => new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0));
+                .sort((a, b) => {
+                  // t1833: prefer higher priority, then LRU
+                  const pDiff = (b.priority || 0) - (a.priority || 0);
+                  if (pDiff !== 0) return pDiff;
+                  return new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0);
+                });
 
               for (const alt of alternates) {
                 // Force-refresh alternate accounts too — their tokens may
@@ -510,7 +518,12 @@ export function createProviderAuthHook(client) {
                   (a.status === "active" || a.status === "idle") &&
                   (!a.cooldownUntil || a.cooldownUntil <= now),
               )
-              .sort((a, b) => new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0));
+              .sort((a, b) => {
+                // t1833: prefer higher priority, then LRU
+                const pDiff = (b.priority || 0) - (a.priority || 0);
+                if (pDiff !== 0) return pDiff;
+                return new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0);
+              });
 
             let rotated = false;
             for (const alt of alternates) {

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -1481,6 +1481,15 @@ cmd_set_priority() {
 		print_error "Usage: set-priority <provider> <email> <N> (higher = preferred, 0 = clear)"
 		return 1
 	fi
+
+	case "$provider" in
+	anthropic | openai | cursor | google) ;;
+	*)
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google)"
+		return 1
+		;;
+	esac
+
 	if ! [[ "$priority" =~ ^-?[0-9]+$ ]]; then
 		print_error "Priority must be an integer, got: $priority"
 		return 1
@@ -1488,10 +1497,26 @@ cmd_set_priority() {
 
 	local pool new_pool
 	pool=$(load_pool)
-	new_pool=$(printf '%s' "$pool" | jq -e --arg p "$provider" --arg e "$email" --argjson n "$priority" \
-		'if (.[$p] | map(select(.email == $e)) | length) == 0 then error("not found")
-		 else .[$p] |= map(if .email == $e then (if $n == 0 then del(.priority) else .priority = $n end) else . end)
-		 end') || {
+	new_pool=$(printf '%s' "$pool" | PROVIDER="$provider" EMAIL="$email" PRIORITY="$priority" python3 -c "
+import json, os, sys
+pool = json.load(sys.stdin)
+provider = os.environ['PROVIDER']
+email = os.environ['EMAIL']
+priority = int(os.environ['PRIORITY'])
+accounts = pool.get(provider, [])
+found = False
+for a in accounts:
+    if a.get('email') == email:
+        if priority == 0:
+            a.pop('priority', None)
+        else:
+            a['priority'] = priority
+        found = True
+        break
+if not found:
+    sys.exit(1)
+json.dump(pool, sys.stdout, indent=2)
+") || {
 		print_error "Account ${email} not found in ${provider} pool"
 		return 1
 	}

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -1460,9 +1460,44 @@ prov = os.environ['PROVIDER']
 for i, a in enumerate(pool.get(prov, []), 1):
     status = a.get('status', 'unknown')
     email = a.get('email', 'unknown')
-    print(f'  {i}. {email} [{status}]')
+    prio = a.get('priority', 0)
+    prio_str = f' (priority={prio})' if prio else ''
+    print(f'  {i}. {email} [{status}]{prio_str}')
 "
 	done
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Set account priority (higher = preferred during rotation)
+# ---------------------------------------------------------------------------
+
+cmd_set_priority() {
+	local provider="${1:-}"
+	local email="${2:-}"
+	local priority="${3:-}"
+
+	if [[ -z "$provider" || -z "$email" || -z "$priority" ]]; then
+		print_error "Usage: set-priority <provider> <email> <N> (higher = preferred, 0 = clear)"
+		return 1
+	fi
+	if ! [[ "$priority" =~ ^-?[0-9]+$ ]]; then
+		print_error "Priority must be an integer, got: $priority"
+		return 1
+	fi
+
+	local pool new_pool
+	pool=$(load_pool)
+	new_pool=$(printf '%s' "$pool" | jq -e --arg p "$provider" --arg e "$email" --argjson n "$priority" \
+		'if (.[$p] | map(select(.email == $e)) | length) == 0 then error("not found")
+		 else .[$p] |= map(if .email == $e then (if $n == 0 then del(.priority) else .priority = $n end) else . end)
+		 end') || {
+		print_error "Account ${email} not found in ${provider} pool"
+		return 1
+	}
+
+	save_pool "$new_pool"
+	print_success "priority=${priority} for ${email} in ${provider}"
 	return 0
 }
 
@@ -1666,7 +1701,7 @@ try:
         print('ERROR:no_alternate')
         sys.exit(0)
 
-    candidates.sort(key=lambda a: a.get('lastUsed', ''))
+    candidates.sort(key=lambda a: (-a.get('priority', 0), a.get('lastUsed', '')))
     next_account = candidates[0]
     next_email   = next_account.get('email', 'unknown')
 
@@ -2567,6 +2602,7 @@ Commands:
   mark-failure <provider> <reason> [retry_secs]   Mark current account cooldown/status from runtime failures
   reset-cooldowns [provider|all]                  Clear rate-limit cooldowns so all accounts retry
   assign-pending <provider> [email]               Assign a stranded pending token to an account
+  set-priority <provider> <email> <N>             Set rotation priority (higher = preferred, 0 = clear)
   remove <provider> <email>                       Remove an account from the pool
   import [claude-cli]                             Import account from Claude CLI auth
 
@@ -2592,8 +2628,11 @@ Examples:
   oauth-pool-helper.sh remove anthropic user@example.com
   oauth-pool-helper.sh assign-pending anthropic           # Show pending token info
   oauth-pool-helper.sh assign-pending anthropic user@example.com  # Assign pending token
+  oauth-pool-helper.sh set-priority anthropic user@example.com 10  # Prefer this account
+  oauth-pool-helper.sh set-priority anthropic user@example.com 0   # Clear priority
 
 Notes:
+  - Rotation prefers accounts with higher priority, then least-recently-used
   - Pool file: ~/.aidevops/oauth-pool.json (600 permissions)
   - Auth file: ~/.local/share/opencode/auth.json (written by rotate)
   - After adding/rotating an account, restart OpenCode to use the new token
@@ -2628,6 +2667,7 @@ main() {
 	rotate) cmd_rotate "$@" ;;
 	reset-cooldowns | reset_cooldowns | reset) cmd_reset_cooldowns "$@" ;;
 	remove) cmd_remove "$@" ;;
+	set-priority | set_priority) cmd_set_priority "$@" ;;
 	status) cmd_status "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)

--- a/todo/tasks/t1833-brief.md
+++ b/todo/tasks/t1833-brief.md
@@ -1,0 +1,30 @@
+# t1833: Add priority account selection to model-accounts-pool rotate
+
+**Session origin**: Interactive session, user request
+**GitHub issue**: marcusquinn/aidevops#15184
+
+## What
+Add a `priority` field to oauth-pool accounts so rotate prefers accounts with higher priority. This lets users burn through accounts whose tokens/quota expire sooner.
+
+## Why
+Users with multiple provider accounts (e.g., personal + work Anthropic) want to maximize utilization by preferring the account whose billing cycle resets first. Current LRU-only rotation doesn't support this.
+
+## How
+1. In `_rotate_execute()` (line 1669 of `oauth-pool-helper.sh`), change sort key from `lastUsed` to `(-priority, lastUsed)`
+2. Add `cmd_set_priority()` subcommand: `set-priority <provider> <email> <N>`
+3. Update `cmd_list()` to display priority when set
+4. Default priority = 0 (backwards compatible)
+
+## Acceptance Criteria
+- [ ] `oauth-pool.json` supports optional `priority` field (integer, higher = preferred)
+- [ ] `_rotate_execute()` sorts by `(-priority, lastUsed)`
+- [ ] `list` command shows priority when set
+- [ ] `set-priority <provider> <email> <N>` subcommand works
+- [ ] Backwards compatible — missing priority defaults to 0
+- [ ] Existing tests/shellcheck pass
+
+## Context
+- File: `.agents/scripts/oauth-pool-helper.sh`
+- Pool file: `~/.aidevops/oauth-pool.json`
+- Rotation logic: lines 1524-1706
+- List command: search for `cmd_list`


### PR DESCRIPTION
## Summary
- Rotation now prefers accounts with higher `priority` field, then LRU
- New `set-priority <provider> <email> <N>` subcommand
- `list` shows priority when set

Use case: burn through the account whose billing cycle resets sooner.

Closes #15184