### PR TITLE
GH#15155: tighten claude-code.md agent doc (83→60 lines)

### DIFF
--- a/.agents/tools/ai-assistants/claude-code.md
+++ b/.agents/tools/ai-assistants/claude-code.md
@@ -11,42 +11,20 @@ tools:
 
 <!-- AI-CONTEXT-START -->
 
-## Quick Reference
-
 - **Purpose**: Spawn Claude Code as a sub-agent for complex, multi-step tasks
 - **MCP**: `claude-code-mcp` (loaded on-demand when this subagent is invoked)
 - **Source**: https://github.com/steipete/claude-code-mcp
 - **Install**: `npm install -g @steipete/claude-code-mcp`
-- **Tool exposure**: `claude-code-mcp_*` tools become available when invoked
-
-**When to use**:
-- Complex multi-file refactoring that benefits from fresh context
-- Tasks requiring extended thinking or different model capabilities
-- Parallel execution of independent subtasks
-- Second opinion on complex architectural decisions
-
-**When NOT to use**:
-- Simple file edits (use native Edit tool)
-- Quick searches (use grep/rg)
-- Single-file changes (overhead not worth it)
+- **Use when**: complex multi-file refactoring, parallel independent subtasks, second opinion on architecture
+- **Skip when**: simple file edits, quick searches, single-file changes (overhead not worth it)
 
 <!-- AI-CONTEXT-END -->
-
-Use this subagent when fresh context or parallel execution is worth the overhead. It loads the `claude-code-mcp` tools, runs the prompt in Claude Code, and returns the result to the parent agent.
 
 ## Invocation
 
 ```text
-@claude-code Refactor the authentication module to use JWT tokens
-```
-
-## Example Prompts
-
-```text
 @claude-code Refactor src/auth/ to use the new token validation library
 @claude-code Analyze all API endpoints and create a comprehensive test suite
-@claude-code Review the database schema and suggest optimizations
-@claude-code Update all React components to use the new design system
 ```
 
 ## Configuration
@@ -73,7 +51,6 @@ The MCP stays disabled globally and starts on demand when this subagent is invok
 ## Best Practices
 
 - Be specific; detailed prompts improve results.
-- Scope appropriately; trivial edits are cheaper with native tools.
 - Review sub-agent output before acting on it.
 - Avoid nested sub-agents; they multiply token usage and cost quickly.
 


### PR DESCRIPTION
## Summary

- Tighten  from 83 to 60 lines (28% reduction)
- Merged Quick Reference section into AI-CONTEXT block as a flat bullet list
- Removed redundant paragraph that restated the purpose already in Quick Reference
- Collapsed separate "Example Prompts" section into Invocation (2 examples sufficient)
- Trimmed Best Practices from 4 to 3 bullets (scope guidance moved to Skip-when bullet)
- All institutional knowledge preserved: source URL, install command, config block, tool patterns, related links

## Changes

- `.agents/tools/ai-assistants/claude-code.md` — 83→60 lines

## Runtime Testing

Risk level: **Low** (docs/agent prompt only, no code changes). Self-assessed.

Closes #15155


---
[aidevops.sh](https://aidevops.sh) v3.5.556 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m on this as a headless worker.