### PR TITLE
GH#15136: tighten axe-cli.md agent doc

### DIFF
--- a/.agents/tools/mobile/axe-cli.md
+++ b/.agents/tools/mobile/axe-cli.md
@@ -3,13 +3,7 @@ description: AXe - CLI tool for iOS Simulator automation via Apple's Accessibili
 mode: subagent
 tools:
   read: true
-  write: false
-  edit: false
   bash: true
-  glob: false
-  grep: false
-  webfetch: false
-  task: false
 ---
 
 # AXe - iOS Simulator Automation CLI
@@ -18,12 +12,11 @@ tools:
 
 - **Install**: `brew install cameroncooke/axe/axe`
 - **Requirements**: macOS with Xcode and iOS Simulator
-- **GitHub**: https://github.com/cameroncooke/AXe (1.2k stars, MIT, by XcodeBuildMCP author)
-- **vs idb**: Single binary (no client/server/daemon), complete HID coverage, gesture presets, timing controls
+- **GitHub**: https://github.com/cameroncooke/AXe (MIT, by XcodeBuildMCP author)
+- **vs idb**: Single binary (no daemon), complete HID coverage, gesture presets, timing controls
+- All commands require `--udid SIMULATOR_UDID`. Get UDIDs: `axe list-simulators`.
 
 ## Core Commands
-
-All commands require `--udid SIMULATOR_UDID`. Get UDIDs: `axe list-simulators`.
 
 ### Touch, Gestures, and Input
 
@@ -32,27 +25,20 @@ axe tap -x 100 -y 200 --udid $UDID                # coordinates
 axe tap --id "Safari" --udid $UDID                  # accessibility ID
 axe tap --label "Submit" --udid $UDID               # label
 axe swipe --start-x 100 --start-y 300 --end-x 300 --end-y 100 --udid $UDID
-# Presets: scroll-up/down/left/right, swipe-from-{left,right,top,bottom}-edge
-axe gesture scroll-down --udid $UDID
-axe type 'Hello World!' --udid $UDID                # direct text input
-echo "text" | axe type --stdin --udid $UDID         # stdin
-# Timing: --pre-delay / --post-delay (seconds) on any touch/gesture
-axe tap -x 100 -y 200 --pre-delay 1.0 --post-delay 0.5 --udid $UDID
+axe gesture scroll-down --udid $UDID               # presets: scroll-up/down/left/right, swipe-from-{left,right,top,bottom}-edge
+axe type 'Hello World!' --udid $UDID               # direct text; echo "text" | axe type --stdin --udid $UDID
+axe tap -x 100 -y 200 --pre-delay 1.0 --post-delay 0.5 --udid $UDID  # timing on any touch/gesture
 ```
 
 ### Keyboard and Buttons
 
 ```bash
-# Key press by HID keycode (40=Enter, 42=Backspace)
-axe key 40 --udid $UDID
+axe key 40 --udid $UDID                                        # HID keycode (40=Enter, 42=Backspace)
 axe key 42 --duration 1.0 --udid $UDID
-# Key sequences (type "hello" by keycodes)
-axe key-sequence --keycodes 11,8,15,15,18 --udid $UDID
-# Combos: modifier + key (227=Cmd, 225=Shift)
-axe key-combo --modifiers 227 --key 4 --udid $UDID          # Cmd+A
-axe key-combo --modifiers 227,225 --key 4 --udid $UDID      # Cmd+Shift+A
-# Hardware buttons: home, lock, side-button, siri, apple-pay
-axe button home --udid $UDID
+axe key-sequence --keycodes 11,8,15,15,18 --udid $UDID         # type "hello" by keycodes
+axe key-combo --modifiers 227 --key 4 --udid $UDID             # Cmd+A (227=Cmd, 225=Shift)
+axe key-combo --modifiers 227,225 --key 4 --udid $UDID         # Cmd+Shift+A
+axe button home --udid $UDID                                   # hardware: home, lock, side-button, siri, apple-pay
 axe button lock --duration 2.0 --udid $UDID
 ```
 
@@ -60,40 +46,34 @@ axe button lock --duration 2.0 --udid $UDID
 
 ```bash
 axe screenshot --output ~/Desktop/capture.png --udid $UDID
-# Video recording (H.264 MP4, Ctrl+C to stop); flags: --fps, --quality, --scale
-axe record-video --udid $UDID --fps 15 --output recording.mp4
-# Stream formats: mjpeg, ffmpeg, raw, bgra
-axe stream-video --udid $UDID --fps 30 --format ffmpeg | \
+axe record-video --udid $UDID --fps 15 --output recording.mp4  # H.264 MP4; flags: --fps, --quality, --scale
+axe stream-video --udid $UDID --fps 30 --format ffmpeg | \     # stream formats: mjpeg, ffmpeg, raw, bgra
   ffmpeg -f image2pipe -framerate 30 -i - -c:v libx264 output.mp4
-# Accessibility tree (full screen or specific point)
-axe describe-ui --udid $UDID
-axe describe-ui --point 100,200 --udid $UDID
+axe describe-ui --udid $UDID                                   # accessibility tree (full screen)
+axe describe-ui --point 100,200 --udid $UDID                   # or specific point
+```
+
+### Common Patterns
+
+```bash
+# Accessibility audit
+axe describe-ui --udid "$UDID" > ui-tree.txt && axe screenshot --output ui-state.png --udid "$UDID"
+# UI flow: tap, scroll, verify
+axe tap --label "Settings" --pre-delay 0.5 --udid "$UDID"
+axe gesture scroll-down --post-delay 0.5 --udid "$UDID"
+axe describe-ui --udid "$UDID"
 ```
 
 ## AXe CLI vs iOS Simulator MCP
 
 | Aspect | AXe CLI | iOS Simulator MCP |
 |--------|---------|-------------------|
-| Interface | CLI (scriptable) | MCP server (AI-native) |
 | Dependencies | Single binary | Node.js + MCP runtime |
 | Tap targeting | Coordinates, ID, label | Coordinates only |
 | Gesture presets | 8 built-in | Manual swipe params |
 | Video | H.264 recording, 4 stream formats | `record_video` / `stop_recording` |
 | Accessibility | `describe-ui` (full/point) | `ui_describe_all`, `ui_describe_point` |
-| App management | Not available | `install_app`, `launch_app` |
 | Best for | Scripts, CI, pipelines | Direct AI tool calling |
-
-## Common Patterns
-
-```bash
-# Accessibility audit: dump UI tree + screenshot
-axe describe-ui --udid "$UDID" > ui-tree.txt
-axe screenshot --output ui-state.png --udid "$UDID"
-# UI flow: tap, scroll, verify
-axe tap --label "Settings" --pre-delay 0.5 --udid "$UDID"
-axe gesture scroll-down --post-delay 0.5 --udid "$UDID"
-axe describe-ui --udid "$UDID"
-```
 
 ## Related
 


### PR DESCRIPTION
## Summary

Simplification pass on `.agents/tools/mobile/axe-cli.md` per issue #15136.

**Changes (102 → 82 lines, 20% reduction):**
- Remove 5 explicit `false` YAML frontmatter entries (false is default, noise)
- Inline standalone comment lines into adjacent code block inline comments
- Move `--udid` requirement note into Quick Reference (better placement)
- Move Common Patterns section into Core Commands (logical grouping)
- Merge accessibility audit into single chained command
- Trim comparison table: remove Interface row (obvious from column headers) and App management row (negative capability, low value for agent using this tool)
- Trim star count from GitHub link (volatile data)

**Preservation check:**
- All code blocks intact
- All URLs preserved
- All command examples present
- All HID keycodes and modifier values preserved
- No task IDs or incident references in this file

## Runtime Testing

Risk: **Low** (docs/agent prompt only, no code changes)
Level: `self-assessed` — content verified by diff review

Closes #15136


---
[aidevops.sh](https://aidevops.sh) v3.5.556 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.