### PR TITLE
GH#15147: tighten hotfix.md agent doc

### DIFF
--- a/.agents/workflows/branch/hotfix.md
+++ b/.agents/workflows/branch/hotfix.md
@@ -6,8 +6,6 @@ tools:
   write: true
   edit: true
   bash: true
-  glob: true
-  grep: true
 ---
 
 # Hotfix Branch
@@ -19,7 +17,7 @@ tools:
 | **Prefix** | `hotfix/` |
 | **Commit** | `fix: [HOTFIX] description` |
 | **Version** | Patch bump (1.0.0 → 1.0.1) |
-| **Create from** | **Latest tag** (not `main`) |
+| **Create from** | **Latest tag** (not `main`) — fix matches production, not unreleased changes |
 | **Urgency** | Immediate; can bypass normal review if authorized |
 
 ```bash
@@ -32,29 +30,24 @@ git checkout -b hotfix/{description}
 
 ## When to Use
 
-- Critical production bugs
-- Security vulnerabilities
-- Data corruption issues
-- Service outages
+- Critical production bugs, security vulnerabilities, data corruption, service outages
 
 If it can wait for the normal release cycle, use `bugfix/` instead.
 
 ## Workflow
 
-### Branch from the Latest Tag
-
-Hotfixes start from the latest tag so the fix matches production, not unreleased `main` changes.
-
-### Keep the Scope Tight
-
 1. Apply the minimal fix only.
 2. Test immediately.
 3. Fast-track review, or deploy directly if authorized.
-4. Merge the deployed fix back to `main`.
+4. Merge back to `main` and push.
+
+```bash
+git checkout main && git pull origin main
+git merge hotfix/critical-issue && git push origin main
+```
 
 ### After Deployment
 
-- [ ] Merge the fix to `main`
 - [ ] Add regression tests
 - [ ] Document the incident
 - [ ] Review how the issue escaped
@@ -67,8 +60,6 @@ hotfix/production-database-lock
 hotfix/payment-processing-failure
 ```
 
-## Commit Example
-
 ```bash
 fix: [HOTFIX] prevent authentication bypass
 
@@ -77,13 +68,4 @@ CRITICAL SECURITY FIX
 - Validate session token
 
 Deploy immediately. Full audit to follow.
-```
-
-## Merge Back to Main
-
-```bash
-git checkout main
-git pull origin main
-git merge hotfix/critical-issue
-git push origin main
 ```


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/branch/hotfix.md` per simplification scan (GH#15147).

**Changes:**
- Collapse 3-heading workflow section into a single numbered list + inline merge command
- Inline branch-from-tag rationale into the quick-ref table (removes a redundant sub-heading)
- Consolidate "Merge Back to Main" section into workflow step 4 (was duplicated)
- Remove `glob: true` and `grep: true` from YAML frontmatter (not needed for a workflow doc)
- 89 → 71 lines; all code blocks, commands, and knowledge preserved

**Verification:**
- All original code blocks present: branch creation, merge-back, examples, commit example
- No task IDs or URLs existed in original — nothing to preserve there
- `bugfix/` redirect preserved
- After-deployment checklist preserved (merge step moved to workflow, not deleted)

Closes #15147

---
[aidevops.sh](https://aidevops.sh) v3.5.556 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.