### PR TITLE
GH#15124: tighten model-routing.md agent doc

### DIFF
--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -87,13 +87,13 @@ Interactive: `/compare-models`, `/compare-models-free`, `/route <task>`
     "architecture": "opus", "verification": "sonnet", "documentation": "haiku" } }
 ```
 
-**Precedence** (highest wins): (1) `model:` in TODO.md, (2) subagent frontmatter, (3) bundle `model_defaults`, (4) default `sonnet`. Multiple bundles → most-restrictive tier wins. CLI: `bundle-helper.sh get|resolve`. Integration: `cron-dispatch.sh`, pulse `agent_routing`, `linters-local.sh` `skip_gates`.
+**Precedence** (highest wins): `model:` in TODO.md → subagent frontmatter → bundle `model_defaults` → default `sonnet`. Multiple bundles → most-restrictive tier wins. CLI: `bundle-helper.sh get|resolve`. Integration: `cron-dispatch.sh`, pulse `agent_routing`, `linters-local.sh` `skip_gates`.
 
 ## Failure-Based Escalation (t1416 + GH#14964)
 
 After 2 failed attempts, escalate to next tier (sonnet → opus via `--model anthropic/claude-opus-4-6`). One opus (~3x) < 3+ failed sonnet dispatches. Dispatch/kill comments MUST include model tier for escalation auditing.
 
-**Worker BLOCKED policy (GH#14964 — MANDATORY):** Workers must attempt model escalation before exiting `BLOCKED`. Review-policy metadata, nominal GitHub states, and lower-tier model limits are NOT valid blockers on their own. A genuine blocker requires evidence that persists after escalation. See `prompts/worker-efficiency-protocol.md` "Model escalation before BLOCKED".
+**Worker BLOCKED policy (GH#14964 — MANDATORY):** Attempt model escalation before exiting `BLOCKED`. Review-policy metadata, nominal GitHub states, and lower-tier model limits are NOT valid blockers on their own — a genuine blocker must persist after escalation. See `prompts/worker-efficiency-protocol.md` "Model escalation before BLOCKED".
 
 ## Tier Drift Detection (t1191)
 


### PR DESCRIPTION
## Summary

Tighten  per GH#15124 (recheck simplification scan).

This is an **instruction doc** (decision trees, routing rules, operational procedures) — content is compressed, not restructured.

### Changes

- **BLOCKED policy paragraph**: Removed redundant "Workers must" opener; merged two sentences into one with em-dash for flow. Same rule, fewer words.
- **Bundle Presets precedence**: Replaced numbered list `(1)...(2)...(3)...(4)` with arrow notation `→` — matches the doc's existing style and removes 8 characters of overhead.

### Verification

- All task IDs preserved: t1416, GH#14964, t1549, t1364.6, t1191, t1396
- All model IDs preserved (fully-qualified)
- All command examples preserved
- All decision logic preserved
- Line count: 113 → 113 (no lines removed, prose compressed in-place)
- No broken internal references

Closes #15124


---
[aidevops.sh](https://aidevops.sh) v3.5.558 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.