### PR TITLE
GH#14254: tighten workerd-patterns.md prose

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
@@ -40,7 +40,7 @@ const config :Workerd.Config = (
 
 ## Durable Objects
 
-Add to a worker block (see Multi-Service Architecture for full config structure):
+Add as a service entry in the `services` list (see Multi-Service Architecture for full config structure):
 
 ```capnp
 (name = "app", worker = (

--- a/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
@@ -40,7 +40,7 @@ const config :Workerd.Config = (
 
 ## Durable Objects
 
-Add to the worker block inside a config (see Multi-Service Architecture for full structure):
+Add to a worker block (see Multi-Service Architecture for full config structure):
 
 ```capnp
 (name = "app", worker = (
@@ -57,7 +57,7 @@ Add to the worker block inside a config (see Multi-Service Architecture for full
 
 ## Dev vs Prod Configs
 
-Separate named configs per environment; override bindings via `fromEnvironment`:
+Named configs per environment; override bindings via `fromEnvironment`:
 
 ```capnp
 const devWorker :Workerd.Worker = (
@@ -74,7 +74,7 @@ Run with: `API_URL=http://localhost:3000 DEBUG=true workerd serve dev.capnp`
 
 ## HTTP Reverse Proxy
 
-Service-worker syntax with external backend (add to config services/sockets):
+Service-worker syntax with external backend (add to `services`/`sockets`):
 
 ```capnp
 (name = "proxy", worker = (
@@ -115,7 +115,7 @@ workerd test config.capnp --test-only=test.js
 
 ### Systemd
 
-`/etc/systemd/system/workerd.service` and `workerd.socket`:
+`/etc/systemd/system/workerd.service` + `workerd.socket`:
 
 ```ini
 # workerd.service


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md` per GH#14254.

**Classification**: Reference corpus (domain knowledge base with self-contained capnp/bash/ini code examples). At 164 lines, below the ~300-line split threshold — no restructuring needed.

**Changes**: 4 section intro lines tightened (word-level only):
- "Add to the worker block inside a config (see Multi-Service Architecture for full structure):" → "Add to a worker block (see Multi-Service Architecture for full config structure):"
- "Separate named configs per environment; override bindings via `fromEnvironment`:" → "Named configs per environment; override bindings via `fromEnvironment`:"
- "Service-worker syntax with external backend (add to config services/sockets):" → "Service-worker syntax with external backend (add to `services`/`sockets`):"
- "`/etc/systemd/system/workerd.service` and `workerd.socket`:" → "`/etc/systemd/system/workerd.service` + `workerd.socket`:"

## Runtime Testing

**Risk level**: Low (docs/agent prompt only — no code, no scripts, no config)
**Verification**: `self-assessed` — markdownlint: 0 errors. All code blocks, URLs, task ID refs, and command examples preserved before and after.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md`

Closes #14254

---
[aidevops.sh](https://aidevops.sh) v3.5.560 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m on this as a headless worker.