### PR TITLE
t1736: fix pipefail + head -1 SIGPIPE in version capture

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -543,7 +543,7 @@ _check_quality_tool() {
 	if command -v "$tool_name" >/dev/null 2>&1; then
 		case "$tool_name" in
 		shellcheck)
-			version=$(shellcheck --version 2>/dev/null | head -1)
+			version=$(shellcheck --version 2>/dev/null | head -1 || true)
 			;;
 		shfmt)
 			version=$(shfmt --version 2>/dev/null)
@@ -561,13 +561,13 @@ _check_markdownlint_tool() {
 	local version=""
 
 	if command -v markdownlint >/dev/null 2>&1; then
-		version=$(markdownlint --version 2>/dev/null | head -1)
+		version=$(markdownlint --version 2>/dev/null | head -1 || true)
 		print_success "markdownlint: ${version:-installed}"
 		return 0
 	fi
 
 	if command -v markdownlint-cli2 >/dev/null 2>&1; then
-		version=$(markdownlint-cli2 --version 2>/dev/null | head -1)
+		version=$(markdownlint-cli2 --version 2>/dev/null | head -1 || true)
 		print_success "markdownlint-cli2: ${version:-installed}"
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Adds `|| true` guard to 3 `cmd | head -1` pipelines in `setup-modules/core.sh` that were missing it, causing fatal SIGPIPE under `set -Eeuo pipefail` + `inherit_errexit`.

- Line 546: `shellcheck --version | head -1`
- Line 564: `markdownlint --version | head -1`
- Line 570: `markdownlint-cli2 --version | head -1`

Regression from `88837581a` (GH#14226, PR #14858). The `|| true` pattern is already used in 13+ other version-capture lines in `setup-modules/tool-install.sh`.

## Files Changed

- `setup-modules/core.sh` — 3 lines

## Runtime Testing

- **Risk level**: Low (version string capture, no side effects)
- **Testing**: `self-assessed` — ShellCheck clean, pattern matches established codebase convention

Closes #15216
Closes #15189


---
[aidevops.sh](https://aidevops.sh) v3.5.561 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 1h 8m and 1,685 tokens on this with the user in an interactive session. Overall, 1m since this issue was created.