### PR TITLE
GH#15113: tighten cro-chapter-18.md header prose

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3422,6 +3422,11 @@
       "hash": "5ea3c763513414dc35f6c2732e8d16197d9144cf",
       "at": "2026-04-01T17:04:30Z",
       "pr": 14820
+    },
+    ".agents/marketing-sales/cro-chapter-18.md": {
+      "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
+      "at": "2026-04-01T00:00:00Z",
+      "issue": 15113
     }
   },
   ".agents/tools/mobile/app-dev-testing.md": {

--- a/.agents/marketing-sales/cro-chapter-18.md
+++ b/.agents/marketing-sales/cro-chapter-18.md
@@ -1,6 +1,6 @@
 # Chapter 18: CRO Case Studies and Implementation Playbook
 
-Real-world CRO implementations across e-commerce, SaaS, and B2B services, plus a phased implementation playbook. Builds on foundations from [Chapter 1](./cro-chapter-01.md)–[Chapter 12](./cro-chapter-12.md).
+Real-world implementations across e-commerce, SaaS, and B2B. Builds on [Chapter 1](./cro-chapter-01.md)–[Chapter 12](./cro-chapter-12.md).
 
 ## 18.1 E-commerce: Fashion Retailer ($50M Revenue)
 


### PR DESCRIPTION
## Summary

- Compresses redundant intro sentence in `cro-chapter-18.md` header (reference corpus, 122 lines)
- All data tables, case study metrics, and institutional knowledge preserved verbatim
- Updates `simplification-state.json` to record file as processed (GH#15113)

## Classification

This file is a **reference corpus** (case studies with data tables + implementation playbook). At 122 lines it is already at slim-index size — splitting into chapter files would add navigation overhead without reducing token cost. The correct action is prose tightening only.

## Verification

- `wc -l` before: 122, after: 122 (no lines removed — only prose compressed within existing line)
- All code blocks, URLs, metrics, and command examples present before and after
- No broken internal links

Closes #15113