### PR TITLE
t1738: restructure: hexagonal.md simplification

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2084,9 +2084,44 @@
       "pr": 12706
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
-      "hash": "cc7a9cfce528e2d77c1fe2c9b29e09442b5eaf25",
-      "at": "2026-03-30T06:49:15Z",
-      "pr": 13931
+      "hash": "81a0340b6952cd9e7ac91d17fe56e1beaabe741c",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/01-introduction.md": {
+      "hash": "ed2e4d0e0715be8197715bbf6226572d74a77b79",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/02-ports.md": {
+      "hash": "c2b7f80d0786e44fbda732fca3a3127aa8260da8",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/03-adapters.md": {
+      "hash": "eab75a38abca400a683375a9b704ae22cff54342",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/04-naming-conventions.md": {
+      "hash": "79be0f8f36336c51bcedffb2ae4ae81420c0a735",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/05-project-structure.md": {
+      "hash": "5404d5b27b0796a0670e5724f27a7020dbd731e3",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/06-configurability.md": {
+      "hash": "2432649b3e35064458417856462e8f8b04a776d5",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/07-strong-vs-weak-ports.md": {
+      "hash": "56250a21b9ce4b86b88dacd52d358a26c6c32452",
+      "at": "2026-04-01T10:00:00Z",
+      "pr": 15078
     },
     ".agents/tools/deployment/cloudron-server-ops-skill.md": {
       "hash": "254ad33e9ddc52578f62584070efe94ef28a6860",
@@ -3427,6 +3462,11 @@
       "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
       "at": "2026-04-01T00:00:00Z",
       "issue": 15113
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md": {
+      "hash": "fd75a08e7897d3ea95b083de86964c919e81542d",
+      "at": "2026-04-01T19:30:00Z",
+      "pr": 15076
     }
   },
   ".agents/tools/mobile/app-dev-testing.md": {

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md
@@ -1,160 +1,48 @@
+---
+description: Hexagonal Architecture (Ports & Adapters) - Core principles, patterns, and project structure
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: false
+  glob: false
+  grep: false
+  webfetch: false
+  task: false
+---
+
 # Hexagonal Architecture (Ports & Adapters)
 
-> Sources: [Cockburn 2005](https://alistair.cockburn.us/hexagonal-architecture/) · [Cockburn & Garrido de Paz 2024](https://openlibrary.org/works/OL38388131W) · [AWS](https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/hexagonal-architecture.html)
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
 
 **Goal:** Application equally driveable by users, programs, tests, or batch scripts — developed and tested in isolation from runtime devices and databases.
-
-**Validation:** If you can run the entire application from test fixtures (FIT-style), your hexagonal boundaries are correct.
-
-```mermaid
-flowchart TB
-    subgraph DriverSide["DRIVER SIDE (Primary / Inbound)"]
-        REST["REST API"] --> DriverPorts["DRIVER PORTS\n(Use Case Interfaces)"]
-        CLI["CLI"] --> DriverPorts
-    end
-    subgraph Hexagon["THE HEXAGON"]
-        Domain["DOMAIN\n(Business Logic)"]
-    end
-    subgraph DrivenSide["DRIVEN SIDE (Secondary / Outbound)"]
-        DrivenPorts["DRIVEN PORTS\n(Repository Interfaces)"] --> Postgres["Postgres"]
-        DrivenPorts --> RabbitMQ["RabbitMQ"]
-    end
-    DriverPorts --> Domain
-    Domain --> DrivenPorts
-    style DriverSide fill:#3b82f6,stroke:#2563eb,color:white
-    style Hexagon fill:#10b981,stroke:#059669,color:white
-    style DrivenSide fill:#f59e0b,stroke:#d97706,color:white
-    style Domain fill:#059669,stroke:#047857,color:white
-```
-
-## Ports
 
 | Type | Direction | Defined by | Purpose | Asymmetry |
 |------|-----------|------------|---------|-----------|
 | **Driver** (Primary / Inbound) | → App | Application | How the world uses your app (use cases) | Adapter *calls* port — app defines what it **offers** |
 | **Driven** (Secondary / Outbound) | App → | Application | What your app needs from external systems | Adapter *implements* port — app defines what it **needs** |
 
-```typescript
-// Driver ports — called by adapters, represent use cases
-export interface IPlaceOrderPort { execute(command: PlaceOrderCommand): Promise<OrderId>; }
-export interface IGetOrderPort { execute(query: GetOrderQuery): Promise<OrderDTO | null>; }
-export interface ICancelOrderPort { execute(command: CancelOrderCommand): Promise<void>; }
+<!-- AI-CONTEXT-END -->
 
-// Driven ports — implemented by adapters, called by the application
-export interface IOrderRepositoryPort {
-  findById(id: OrderId): Promise<Order | null>;
-  save(order: Order): Promise<void>;
-  delete(order: Order): Promise<void>;
-}
-export interface IEventPublisherPort {
-  publish(event: DomainEvent): Promise<void>;
-  publishAll(events: DomainEvent[]): Promise<void>;
-}
-export interface IPaymentGatewayPort {
-  charge(amount: Money, method: PaymentMethod): Promise<PaymentResult>;
-  refund(paymentId: PaymentId, amount: Money): Promise<RefundResult>;
-}
-```
+## Chapter Index
 
-## Adapters
+Full principles, code examples, and structure guidance in focused chapters:
 
-**Driver adapter** — converts external input → port call:
+| # | Chapter | Description |
+|---|---------|-------------|
+| 01 | [Introduction](hexagonal/01-introduction.md) | Core goal, validation rule, and high-level mermaid diagram |
+| 02 | [Ports](hexagonal/02-ports.md) | Driver vs Driven ports with TypeScript interface examples |
+| 03 | [Adapters](hexagonal/03-adapters.md) | Controller (Driver) and Repository/Gateway (Driven) implementations |
+| 04 | [Naming Conventions](hexagonal/04-naming-conventions.md) | Cockburn, Interface/Impl, and Port suffix patterns |
+| 05 | [Project Structure](hexagonal/05-project-structure.md) | Standard directory layout for application, domain, and infrastructure |
+| 06 | [Configurability](hexagonal/06-configurability.md) | Dependency injection container setup for dev vs production |
+| 07 | [Strong vs Weak Ports](hexagonal/07-strong-vs-weak-ports.md) | Avoiding concept leaks and maintaining domain purity |
 
-```typescript
-// infrastructure/adapters/driver/rest/order_controller.ts
-export class OrderController {
-  constructor(private readonly placeOrder: IPlaceOrderPort, private readonly getOrder: IGetOrderPort) {}
-  async create(req: Request, res: Response): Promise<void> {
-    const orderId = await this.placeOrder.execute({
-      customerId: req.user.id,
-      items: req.body.items.map((i: any) => ({ productId: i.product_id, quantity: i.quantity })),
-    });
-    res.status(201).json({ id: orderId.value });
-  }
-}
-```
+## Related
 
-**Driven adapters** — implement port interface using specific technology:
-
-```
-class PostgresOrderRepository implements IOrderRepositoryPort:
-    findById(id) -> Order | null:
-        row = db.orders.where(id: id.value).first()
-        return row ? OrderMapper.toDomain(row) : null
-    save(order): db.orders.upsert(OrderMapper.toPersistence(order))
-    delete(order): db.orders.where(id: order.id.value).delete()
-
-class InMemoryOrderRepository implements IOrderRepositoryPort:  # for tests
-    orders: Map<string, Order> = {}
-    findById(id): return orders.get(id.value) or null
-    save(order): orders.set(order.id.value, order)
-    delete(order): orders.delete(order.id.value)
-
-class StripePaymentGateway implements IPaymentGatewayPort:
-    charge(amount, method) -> PaymentResult:
-        intent = stripe.paymentIntents.create({amount: amount.cents, ...})
-        return PaymentResult.success(PaymentId.from(intent.id))
-    refund(paymentId, amount): stripe.refunds.create({paymentIntent: paymentId.value, ...})
-
-class RabbitMQEventPublisher implements IEventPublisherPort:
-    publish(event): channel.publish("domain_events", event.eventType, serialize(event))
-    publishAll(events): for event in events: publish(event)
-```
-
-## Naming Conventions
-
-| Pattern | Port | Adapter |
-|---------|------|---------|
-| **Cockburn** (recommended) | `ForPlacingOrders` | `CliCommandForPlacingOrders` |
-| Interface/Impl | `IOrderRepository` | `PostgresOrderRepository` |
-| Port suffix | `OrderRepositoryPort` | `PostgresOrderAdapter` |
-| Using prefix | `IOrderStorage` | `OrderStorageUsingPostgres` |
-
-## Project Structure
-
-```
-src/
-├── application/
-│   ├── ports/
-│   │   ├── driver/          # place_order_port.ts, get_order_port.ts, cancel_order_port.ts
-│   │   └── driven/          # order_repository_port.ts, event_publisher_port.ts, payment_gateway_port.ts
-│   └── use_cases/
-│       ├── place_order/handler.ts   # implements driver port
-│       └── get_order/handler.ts
-├── infrastructure/adapters/
-│   ├── driver/              # rest/, grpc/, cli/
-│   └── driven/              # postgres/, rabbitmq/, stripe/, in_memory/
-└── domain/
-```
-
-## Configurability
-
-```typescript
-// infrastructure/config/container.ts
-function configureDevelopment(container: Container): void {
-  container.bind<IOrderRepositoryPort>('IOrderRepositoryPort').to(InMemoryOrderRepository);
-  container.bind<IEventPublisherPort>('IEventPublisherPort').to(InMemoryEventPublisher);
-  container.bind<IPaymentGatewayPort>('IPaymentGatewayPort').to(FakePaymentGateway);
-}
-function configureProduction(container: Container): void {
-  container.bind<IOrderRepositoryPort>('IOrderRepositoryPort').to(PostgresOrderRepository);
-  container.bind<IEventPublisherPort>('IEventPublisherPort').to(RabbitMQEventPublisher);
-  container.bind<IPaymentGatewayPort>('IPaymentGatewayPort').to(StripePaymentGateway);
-}
-```
-
-## Strong vs Weak Ports
-
-```typescript
-// ❌ Weak: leaks SQL concepts into the port
-interface IOrderRepository {
-  findByQuery(sql: string, params: any[]): Promise<Order[]>;
-}
-
-// ✅ Strong: pure domain concepts only
-interface IOrderRepository {
-  findById(id: OrderId): Promise<Order | null>;
-  findByCustomer(customerId: CustomerId): Promise<Order[]>;
-  save(order: Order): Promise<void>;
-}
-```
+- `layers.md` - Traditional N-tier layering comparison
+- `ddd-tactical.md` - Domain-Driven Design patterns (Entities, Value Objects)
+- `testing.md` - Testing strategy for hexagonal boundaries

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/01-introduction.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/01-introduction.md
@@ -1,0 +1,28 @@
+# Introduction
+
+> Sources: [Cockburn 2005](https://alistair.cockburn.us/hexagonal-architecture/) · [Cockburn & Garrido de Paz 2024](https://openlibrary.org/works/OL38388131W) · [AWS](https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/hexagonal-architecture.html)
+
+**Goal:** Application equally driveable by users, programs, tests, or batch scripts — developed and tested in isolation from runtime devices and databases.
+
+**Validation:** If you can run the entire application from test fixtures (FIT-style), your hexagonal boundaries are correct.
+
+```mermaid
+flowchart TB
+    subgraph DriverSide["DRIVER SIDE (Primary / Inbound)"]
+        REST["REST API"] --> DriverPorts["DRIVER PORTS\n(Use Case Interfaces)"]
+        CLI["CLI"] --> DriverPorts
+    end
+    subgraph Hexagon["THE HEXAGON"]
+        Domain["DOMAIN\n(Business Logic)"]
+    end
+    subgraph DrivenSide["DRIVEN SIDE (Secondary / Outbound)"]
+        DrivenPorts["DRIVEN PORTS\n(Repository Interfaces)"] --> Postgres["Postgres"]
+        DrivenPorts --> RabbitMQ["RabbitMQ"]
+    end
+    DriverPorts --> Domain
+    Domain --> DrivenPorts
+    style DriverSide fill:#3b82f6,stroke:#2563eb,color:white
+    style Hexagon fill:#10b981,stroke:#059669,color:white
+    style DrivenSide fill:#f59e0b,stroke:#d97706,color:white
+    style Domain fill:#059669,stroke:#047857,color:white
+```

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/02-ports.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/02-ports.md
@@ -1,0 +1,28 @@
+# Ports
+
+| Type | Direction | Defined by | Purpose | Asymmetry |
+|------|-----------|------------|---------|-----------|
+| **Driver** (Primary / Inbound) | → App | Application | How the world uses your app (use cases) | Adapter *calls* port — app defines what it **offers** |
+| **Driven** (Secondary / Outbound) | App → | Application | What your app needs from external systems | Adapter *implements* port — app defines what it **needs** |
+
+```typescript
+// Driver ports — called by adapters, represent use cases
+export interface IPlaceOrderPort { execute(command: PlaceOrderCommand): Promise<OrderId>; }
+export interface IGetOrderPort { execute(query: GetOrderQuery): Promise<OrderDTO | null>; }
+export interface ICancelOrderPort { execute(command: CancelOrderCommand): Promise<void>; }
+
+// Driven ports — implemented by adapters, called by the application
+export interface IOrderRepositoryPort {
+  findById(id: OrderId): Promise<Order | null>;
+  save(order: Order): Promise<void>;
+  delete(order: Order): Promise<void>;
+}
+export interface IEventPublisherPort {
+  publish(event: DomainEvent): Promise<void>;
+  publishAll(events: DomainEvent[]): Promise<void>;
+}
+export interface IPaymentGatewayPort {
+  charge(amount: Money, method: PaymentMethod): Promise<PaymentResult>;
+  refund(paymentId: PaymentId, amount: Money): Promise<RefundResult>;
+}
+```

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/03-adapters.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/03-adapters.md
@@ -1,0 +1,44 @@
+# Adapters
+
+**Driver adapter** — converts external input → port call:
+
+```typescript
+// infrastructure/adapters/driver/rest/order_controller.ts
+export class OrderController {
+  constructor(private readonly placeOrder: IPlaceOrderPort, private readonly getOrder: IGetOrderPort) {}
+  async create(req: Request, res: Response): Promise<void> {
+    const orderId = await this.placeOrder.execute({
+      customerId: req.user.id,
+      items: req.body.items.map((i: any) => ({ productId: i.product_id, quantity: i.quantity })),
+    });
+    res.status(201).json({ id: orderId.value });
+  }
+}
+```
+
+**Driven adapters** — implement port interface using specific technology:
+
+```
+class PostgresOrderRepository implements IOrderRepositoryPort:
+    findById(id) -> Order | null:
+        row = db.orders.where(id: id.value).first()
+        return row ? OrderMapper.toDomain(row) : null
+    save(order): db.orders.upsert(OrderMapper.toPersistence(order))
+    delete(order): db.orders.where(id: order.id.value).delete()
+
+class InMemoryOrderRepository implements IOrderRepositoryPort:  # for tests
+    orders: Map<string, Order> = {}
+    findById(id): return orders.get(id.value) or null
+    save(order): orders.set(order.id.value, order)
+    delete(order): orders.delete(order.id.value)
+
+class StripePaymentGateway implements IPaymentGatewayPort:
+    charge(amount, method) -> PaymentResult:
+        intent = stripe.paymentIntents.create({amount: amount.cents, ...})
+        return PaymentResult.success(PaymentId.from(intent.id))
+    refund(paymentId, amount): stripe.refunds.create({paymentIntent: paymentId.value, ...})
+
+class RabbitMQEventPublisher implements IEventPublisherPort:
+    publish(event): channel.publish("domain_events", event.eventType, serialize(event))
+    publishAll(events): for event in events: publish(event)
+```

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/04-naming-conventions.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/04-naming-conventions.md
@@ -1,0 +1,8 @@
+# Naming Conventions
+
+| Pattern | Port | Adapter |
+|---------|------|---------|
+| **Cockburn** (recommended) | `ForPlacingOrders` | `CliCommandForPlacingOrders` |
+| Interface/Impl | `IOrderRepository` | `PostgresOrderRepository` |
+| Port suffix | `OrderRepositoryPort` | `PostgresOrderAdapter` |
+| Using prefix | `IOrderStorage` | `OrderStorageUsingPostgres` |

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/05-project-structure.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/05-project-structure.md
@@ -1,0 +1,16 @@
+# Project Structure
+
+```
+src/
+├── application/
+│   ├── ports/
+│   │   ├── driver/          # place_order_port.ts, get_order_port.ts, cancel_order_port.ts
+│   │   └── driven/          # order_repository_port.ts, event_publisher_port.ts, payment_gateway_port.ts
+│   └── use_cases/
+│       ├── place_order/handler.ts   # implements driver port
+│       └── get_order/handler.ts
+├── infrastructure/adapters/
+│   ├── driver/              # rest/, grpc/, cli/
+│   └── driven/              # postgres/, rabbitmq/, stripe/, in_memory/
+└── domain/
+```

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/06-configurability.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/06-configurability.md
@@ -1,0 +1,15 @@
+# Configurability
+
+```typescript
+// infrastructure/config/container.ts
+function configureDevelopment(container: Container): void {
+  container.bind<IOrderRepositoryPort>('IOrderRepositoryPort').to(InMemoryOrderRepository);
+  container.bind<IEventPublisherPort>('IEventPublisherPort').to(InMemoryEventPublisher);
+  container.bind<IPaymentGatewayPort>('IPaymentGatewayPort').to(FakePaymentGateway);
+}
+function configureProduction(container: Container): void {
+  container.bind<IOrderRepositoryPort>('IOrderRepositoryPort').to(PostgresOrderRepository);
+  container.bind<IEventPublisherPort>('IEventPublisherPort').to(RabbitMQEventPublisher);
+  container.bind<IPaymentGatewayPort>('IPaymentGatewayPort').to(StripePaymentGateway);
+}
+```

--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/07-strong-vs-weak-ports.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal/07-strong-vs-weak-ports.md
@@ -1,0 +1,15 @@
+# Strong vs Weak Ports
+
+```typescript
+// ❌ Weak: leaks SQL concepts into the port
+interface IOrderRepository {
+  findByQuery(sql: string, params: any[]): Promise<Order[]>;
+}
+
+// ✅ Strong: pure domain concepts only
+interface IOrderRepository {
+  findById(id: OrderId): Promise<Order | null>;
+  findByCustomer(customerId: CustomerId): Promise<Order[]>;
+  save(order: Order): Promise<void>;
+}
+```

--- a/.gitignore
+++ b/.gitignore
@@ -227,4 +227,3 @@ __pycache__/
 
 # Accidentally committed binaries
 bv
-.agents

--- a/TODO.md
+++ b/TODO.md
@@ -58,6 +58,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 <!--TOON:ready[0]{id,desc,owner,tags,est,logged}:
 -->
 
+- [ ] t1738 restructure: hexagonal.md simplification @marcusquinn #simplification-debt ~1h ref:GH#15078
+
 - [ ] t1729 simplification: tighten agent doc Model-Specific Subagents @marcusquinn #simplification-debt ~1h ref:GH#15020
 - [x] t1544 fix: setup script errors with Unknown MCP integration: context7 — setup script does not recognize context7 as a valid MCP integration despite documentation and subagent docs referencing it. Investigate mcp-setup.sh and migrations.sh for the integration registry and add context7. #bugfix #setup #mcp ~30m model:sonnet ref:GH#5248 logged:2026-03-19 pr:#5251 pr:#5251 completed:2026-03-19
 


### PR DESCRIPTION
Closes #15078

## Summary
- Restructured `hexagonal.md` into chapter files for better maintainability and slim index.
- Fixed `.gitignore` rule that was accidentally ignoring the entire `.agents` directory.
- Updated `simplification-state.json` with new hashes for the simplified files.


---
[aidevops.sh](https://aidevops.sh) v3.5.564 plugin for [OpenCode](https://opencode.ai) v1.3.13 with gemini-3-flash spent 30m and 2,199 tokens on this as a headless worker.