### PR TITLE
GH#14313: tighten cron-triggers.md — remove duplicate bullets, fix MD040

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md
@@ -4,15 +4,13 @@ Schedule Workers execution using cron expressions. Runs on Cloudflare's global n
 
 ## Key Features
 
-- **UTC-only execution** - All schedules run on UTC time
 - **5-field cron syntax** - Quartz scheduler extensions (L, W, #)
-- **Global propagation** - 15min deployment delay
 - **At-least-once delivery** - Rare duplicate executions possible
 - **Workflow integration** - Trigger long-running multi-step tasks
 
 ## Cron Syntax
 
-```
+```text
  ┌─────────── minute (0-59)
  │ ┌───────── hour (0-23)
  │ │ ┌─────── day of month (1-31)


### PR DESCRIPTION
## Summary

- Removes 2 duplicate bullets from `## Key Features` that restated facts already present in `## Limits` (UTC-only execution, 15min propagation delay)
- Fixes pre-existing MD040 linter violation: adds `text` language specifier to the cron syntax diagram fenced code block
- All unique knowledge preserved: 5-field cron syntax, at-least-once delivery, workflow integration, all code blocks, URLs, command examples

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md` (86 → 84 lines)

## Testing

- `markdownlint` passes with zero violations (was 1 pre-existing violation before fix)
- Content verification: all code blocks, URLs, command examples present before and after
- Knowledge check: removed bullets (UTC-only, propagation) still present in `## Limits` section

## Classification

**Reference corpus** (domain knowledge base). File was already compact at 86 lines — no chapter splitting needed. Tightening removed exact duplicates only.

Closes #14313


---
[aidevops.sh](https://aidevops.sh) v3.5.564 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6