### PR TITLE
GH#14242: tighten streaming avatars doc

### DIFF
--- a/.agents/content/heygen-skill/rules-streaming-avatars.md
+++ b/.agents/content/heygen-skill/rules-streaming-avatars.md
@@ -17,7 +17,7 @@ Real-time interactive avatar via WebRTC. Use for live customer service, virtual 
 |-------|------|:---:|-------------|
 | `avatar_id` | string | ✓ | Avatar to use |
 | `voice_id` | string | ✓ | Voice for TTS |
-| `quality` | string | | `"low"` / `"medium"` / `"high"` |
+| `quality` | string | | `"low"` (480p ~500kbps) / `"medium"` (720p ~1Mbps) / `"high"` (1080p ~2Mbps) |
 | `video_encoding` | string | | `"H264"` / `"VP8"` |
 
 **Response:** `{ session_id, access_token, url, ice_servers[] }`
@@ -38,14 +38,6 @@ const res = await fetch("https://api.heygen.com/v1/streaming.new", {
 const { data } = await res.json(); // { session_id, access_token, url, ice_servers }
 ```
 
-## Quality Options
-
-| Quality | Resolution | Bandwidth |
-|---------|------------|-----------|
-| `low` | 480p | ~500kbps |
-| `medium` | 720p | ~1Mbps |
-| `high` | 1080p | ~2Mbps |
-
 ## Send Text (Avatar Speaks)
 
 `POST https://api.heygen.com/v1/streaming.task`
@@ -64,17 +56,13 @@ curl -X POST "https://api.heygen.com/v1/streaming.task" \
   -d '{"session_id": "your_session_id", "text": "Hello!", "task_type": "talk"}'
 ```
 
-## Stop Session
+## Session Management
 
-`POST https://api.heygen.com/v1/streaming.stop` — body: `{ session_id }`
-
-## Interrupt Speech
-
-`POST https://api.heygen.com/v1/streaming.interrupt` — body: `{ session_id }` — then send new text task.
-
-## List Active Sessions
-
-`GET https://api.heygen.com/v1/streaming.list` — returns `{ data: { sessions: string[] } }`
+| Action | Endpoint | Body |
+|--------|----------|------|
+| Stop | `POST https://api.heygen.com/v1/streaming.stop` | `{ session_id }` |
+| Interrupt speech | `POST https://api.heygen.com/v1/streaming.interrupt` | `{ session_id }` — then send new task |
+| List active | `GET https://api.heygen.com/v1/streaming.list` | — returns `{ data: { sessions: string[] } }` |
 
 ## WebRTC Integration Pattern
 
@@ -88,10 +76,9 @@ await pc.setLocalDescription(offer);
 // Exchange SDP with server via signaling, then attach stream to <video>
 ```
 
-Keep-alive: send a ping task every 30s to prevent session timeout.
-
 ## Best Practices
 
+- Send a ping task every 30s to prevent session timeout
 - Implement reconnection logic for disconnections
 - Adjust `quality` based on available bandwidth
 - Close unused sessions promptly — credits consumed per session-second


### PR DESCRIPTION
## Summary

Tighten  (99 → 86 lines, -13 lines).

### Changes

- **Inline quality options**: Merged the standalone `## Quality Options` table into the `quality` parameter description in the Create Session table — same data, one fewer section
- **Session Management table**: Consolidated three separate one-liner sections (Stop Session, Interrupt Speech, List Active Sessions) into a single `## Session Management` table — cleaner, scannable
- **Keep-alive note**: Moved from standalone paragraph after WebRTC code block into Best Practices list where it belongs

### Verification

- All code blocks present: bash curl examples, TypeScript fetch, WebRTC pattern ✓
- All URLs preserved ✓
- All API endpoints preserved ✓
- No task IDs or incident refs in this file ✓
- Zero content loss — every piece of information is present in the simplified version ✓

### Risk

Low — documentation-only change, no code or logic affected.

## Runtime Testing

Self-assessed (Low risk: docs-only change, no code paths affected)

Closes #14242


---
[aidevops.sh](https://aidevops.sh) v3.5.565 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.