### PR TITLE
GH#14162: split DO storage patterns into chapter files

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns.md
@@ -1,112 +1,22 @@
 # DO Storage Patterns & Best Practices
 
-## Schema Migration
+Reference corpus for Durable Objects storage examples. Content moved into chapter files to keep the entry point short while preserving every example.
 
-```typescript
-export class MyDurableObject extends DurableObject {
-  constructor(ctx: DurableObjectState, env: Env) {
-    super(ctx, env);
-    this.sql = ctx.storage.sql;
-    this.sql.exec(`CREATE TABLE IF NOT EXISTS _meta(key TEXT PRIMARY KEY, value TEXT)`);
-    const ver = this.sql.exec("SELECT value FROM _meta WHERE key = 'schema_version'").toArray()[0]?.value || "0";
-    if (ver === "0") this.sql.exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); INSERT OR REPLACE INTO _meta VALUES ('schema_version', '1')`);
-    if (ver === "1") this.sql.exec(`ALTER TABLE users ADD COLUMN email TEXT; UPDATE _meta SET value = '2' WHERE key = 'schema_version'`);
-  }
-}
-```
+## Chapters
 
-## In-Memory Caching
+- [01-schema-migration.md](./do-storage-patterns/01-schema-migration.md) - Versioned SQLite schema upgrades during Durable Object startup.
+- [02-in-memory-caching.md](./do-storage-patterns/02-in-memory-caching.md) - Read-through cache pattern backed by Durable Object storage.
+- [03-rate-limiting.md](./do-storage-patterns/03-rate-limiting.md) - Sliding-window request counting with SQL cleanup.
+- [04-batch-processing-with-alarms.md](./do-storage-patterns/04-batch-processing-with-alarms.md) - Queue items in memory and flush them on an alarm.
+- [05-initialization-and-counters.md](./do-storage-patterns/05-initialization-and-counters.md) - `blockConcurrencyWhile()` initialization plus safe counter increment patterns.
+- [06-cleanup.md](./do-storage-patterns/06-cleanup.md) - Explicit alarm cleanup before deleting storage state.
 
-```typescript
-export class UserCache extends DurableObject {
-  cache = new Map<string, User>();
-  async getUser(id: string): Promise<User> {
-    if (this.cache.has(id)) return this.cache.get(id)!;
-    const user = await this.ctx.storage.get<User>(`user:${id}`);
-    if (user) this.cache.set(id, user);
-    return user;
-  }
-  async updateUser(id: string, data: Partial<User>) {
-    const updated = { ...await this.getUser(id), ...data };
-    this.cache.set(id, updated);
-    await this.ctx.storage.put(`user:${id}`, updated);
-    return updated;
-  }
-}
-```
+## Related
 
-## Rate Limiting
+- [do-storage.md](./do-storage.md) - API overview, storage backends, and core capabilities.
+- [do-storage-gotchas.md](./do-storage-gotchas.md) - Concurrency, transaction, limit, and alarm pitfalls.
 
-```typescript
-export class RateLimiter extends DurableObject {
-  async checkLimit(key: string, limit: number, window: number): Promise<boolean> {
-    const now = Date.now();
-    this.sql.exec('DELETE FROM requests WHERE key = ? AND timestamp < ?', key, now - window);
-    const count = this.sql.exec('SELECT COUNT(*) as count FROM requests WHERE key = ?', key).one().count;
-    if (count >= limit) return false;
-    this.sql.exec('INSERT INTO requests (key, timestamp) VALUES (?, ?)', key, now);
-    return true;
-  }
-}
-```
+## Preservation Notes
 
-## Batch Processing with Alarms
-
-```typescript
-export class BatchProcessor extends DurableObject {
-  pending: string[] = [];
-  async addItem(item: string) {
-    this.pending.push(item);
-    if (!await this.ctx.storage.getAlarm()) await this.ctx.storage.setAlarm(Date.now() + 5000);
-  }
-  async alarm() {
-    const items = [...this.pending];
-    this.pending = [];
-    this.sql.exec(`INSERT INTO processed_items (item, timestamp) VALUES ${items.map(() => "(?, ?)").join(", ")}`, ...items.flatMap(item => [item, Date.now()]));
-  }
-}
-```
-
-## Initialization Pattern
-
-```typescript
-export class Counter extends DurableObject {
-  value: number;
-  constructor(ctx: DurableObjectState, env: Env) {
-    super(ctx, env);
-    ctx.blockConcurrencyWhile(async () => { this.value = (await ctx.storage.get("value")) || 0; });
-  }
-  async increment() {
-    this.value++;
-    this.ctx.storage.put("value", this.value); // Don't await (output gate protects)
-    return this.value;
-  }
-}
-```
-
-## Safe Counter / Optimized Write
-
-```typescript
-// Input gate blocks other requests
-async getUniqueNumber(): Promise<number> {
-  let val = await this.ctx.storage.get("counter");
-  await this.ctx.storage.put("counter", val + 1);
-  return val;
-}
-
-// No await on write - output gate delays response until write confirms
-async increment(): Promise<Response> {
-  let val = await this.ctx.storage.get("counter");
-  this.ctx.storage.put("counter", val + 1);
-  return new Response(String(val));
-}
-```
-
-## Cleanup
-
-```typescript
-async cleanup() {
-  await this.ctx.storage.deleteAlarm(); // Separate from deleteAll
-  await this.ctx.storage.deleteAll();
-}
-```
+- All original code blocks moved to the chapter files above.
+- No examples were removed; this file is now the index for the same material.

--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/01-schema-migration.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/01-schema-migration.md
@@ -1,0 +1,14 @@
+# Schema Migration
+
+```typescript
+export class MyDurableObject extends DurableObject {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+    this.sql.exec(`CREATE TABLE IF NOT EXISTS _meta(key TEXT PRIMARY KEY, value TEXT)`);
+    const ver = this.sql.exec("SELECT value FROM _meta WHERE key = 'schema_version'").toArray()[0]?.value || "0";
+    if (ver === "0") this.sql.exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); INSERT OR REPLACE INTO _meta VALUES ('schema_version', '1')`);
+    if (ver === "1") this.sql.exec(`ALTER TABLE users ADD COLUMN email TEXT; UPDATE _meta SET value = '2' WHERE key = 'schema_version'`);
+  }
+}
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/02-in-memory-caching.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/02-in-memory-caching.md
@@ -1,0 +1,19 @@
+# In-Memory Caching
+
+```typescript
+export class UserCache extends DurableObject {
+  cache = new Map<string, User>();
+  async getUser(id: string): Promise<User> {
+    if (this.cache.has(id)) return this.cache.get(id)!;
+    const user = await this.ctx.storage.get<User>(`user:${id}`);
+    if (user) this.cache.set(id, user);
+    return user;
+  }
+  async updateUser(id: string, data: Partial<User>) {
+    const updated = { ...await this.getUser(id), ...data };
+    this.cache.set(id, updated);
+    await this.ctx.storage.put(`user:${id}`, updated);
+    return updated;
+  }
+}
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/03-rate-limiting.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/03-rate-limiting.md
@@ -1,0 +1,14 @@
+# Rate Limiting
+
+```typescript
+export class RateLimiter extends DurableObject {
+  async checkLimit(key: string, limit: number, window: number): Promise<boolean> {
+    const now = Date.now();
+    this.sql.exec('DELETE FROM requests WHERE key = ? AND timestamp < ?', key, now - window);
+    const count = this.sql.exec('SELECT COUNT(*) as count FROM requests WHERE key = ?', key).one().count;
+    if (count >= limit) return false;
+    this.sql.exec('INSERT INTO requests (key, timestamp) VALUES (?, ?)', key, now);
+    return true;
+  }
+}
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/04-batch-processing-with-alarms.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/04-batch-processing-with-alarms.md
@@ -1,0 +1,16 @@
+# Batch Processing with Alarms
+
+```typescript
+export class BatchProcessor extends DurableObject {
+  pending: string[] = [];
+  async addItem(item: string) {
+    this.pending.push(item);
+    if (!await this.ctx.storage.getAlarm()) await this.ctx.storage.setAlarm(Date.now() + 5000);
+  }
+  async alarm() {
+    const items = [...this.pending];
+    this.pending = [];
+    this.sql.exec(`INSERT INTO processed_items (item, timestamp) VALUES ${items.map(() => "(?, ?)").join(", ")}`, ...items.flatMap(item => [item, Date.now()]));
+  }
+}
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/05-initialization-and-counters.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/05-initialization-and-counters.md
@@ -1,0 +1,36 @@
+# Initialization and Counters
+
+## Initialization Pattern
+
+```typescript
+export class Counter extends DurableObject {
+  value: number;
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    ctx.blockConcurrencyWhile(async () => { this.value = (await ctx.storage.get("value")) || 0; });
+  }
+  async increment() {
+    this.value++;
+    this.ctx.storage.put("value", this.value); // Don't await (output gate protects)
+    return this.value;
+  }
+}
+```
+
+## Safe Counter / Optimized Write
+
+```typescript
+// Input gate blocks other requests
+async getUniqueNumber(): Promise<number> {
+  let val = await this.ctx.storage.get("counter");
+  await this.ctx.storage.put("counter", val + 1);
+  return val;
+}
+
+// No await on write - output gate delays response until write confirms
+async increment(): Promise<Response> {
+  let val = await this.ctx.storage.get("counter");
+  this.ctx.storage.put("counter", val + 1);
+  return new Response(String(val));
+}
+```

--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/06-cleanup.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/06-cleanup.md
@@ -1,0 +1,8 @@
+# Cleanup
+
+```typescript
+async cleanup() {
+  await this.ctx.storage.deleteAlarm(); // Separate from deleteAll
+  await this.ctx.storage.deleteAll();
+}
+```


### PR DESCRIPTION
## Summary

Split `do-storage-patterns.md` (112 lines, reference corpus) into 6 chapter files with a slim index, following the reference corpus restructuring pattern from the issue guidance.

## Changes

- `.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns.md` — replaced with 22-line index
- `.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/01-schema-migration.md` — new
- `.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/02-in-memory-caching.md` — new
- `.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/03-rate-limiting.md` — new
- `.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/04-batch-processing-with-alarms.md` — new
- `.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/05-initialization-and-counters.md` — new
- `.agents/services/hosting/cloudflare-platform-skill/do-storage-patterns/06-cleanup.md` — new
- `.agents/services/hosting/cloudflare-platform-skill/do-storage.md` — updated Related Files link

## Verification

- All original code blocks preserved in chapter files (zero content loss)
- Index file is 22 lines (down from 112)
- Chapter files total 107 lines (>= original minus index overhead)
- No broken internal links
- `do-storage.md` Related Files section updated to point to the index

## Runtime Testing

Risk: **Low** — documentation restructuring only, no code changes. Self-assessed.

Closes #14162


---
[aidevops.sh](https://aidevops.sh) v3.5.565 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.