### PR TITLE
GH#14281: tighten cro-chapter-21.md (93→81 lines)

### DIFF
--- a/.agents/marketing-sales/cro-chapter-21.md
+++ b/.agents/marketing-sales/cro-chapter-21.md
@@ -2,36 +2,24 @@
 
 ## 21.1 Hypothesis Development
 
-### Hypothesis Framework
-
 Structure: **IF** [change], **THEN** [expected result], **BECAUSE** [reasoning]
 
-Example: "IF we simplify checkout from 12 to 6 fields, THEN checkout completion increases 15%, BECAUSE reducing friction removes purchase barriers"
-
-**Data Sources:**
-- Analytics drop-off points
-- Heatmap clicks/scrolls
-- Session recordings
-- User surveys and support tickets
-- Competitor benchmarking
+**Data Sources:** Analytics drop-off points, heatmap clicks/scrolls, session recordings, user surveys, support tickets, competitor benchmarking
 
 **Prioritization Matrix:**
 
-| Factor | Weight | Score | Weighted |
-|--------|--------|-------|----------|
-| Potential Impact | 30% | 8 | 2.4 |
-| Confidence | 20% | 7 | 1.4 |
-| Ease of Implementation | 25% | 9 | 2.25 |
-| Resource Requirements | 25% | 6 | 1.5 |
-| **Total** | | | **7.55** |
+| Factor | Weight |
+|--------|--------|
+| Potential Impact | 30% |
+| Confidence | 20% |
+| Ease of Implementation | 25% |
+| Resource Requirements | 25% |
 
 ## 21.2 Advanced Test Design
 
 ### Factorial Experiments
 
-Test multiple variables simultaneously to detect interaction effects.
-
-Example (2×2×2 = 8 variations): Headline A/B × Image X/Y × CTA Red/Blue
+Test multiple variables simultaneously to detect interaction effects. Example (2×2×2 = 8 variations): Headline A/B × Image X/Y × CTA Red/Blue
 
 | | Benefits | Challenges |
 |-|----------|------------|


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/marketing-sales/cro-chapter-21.md` per GH#14281
- Remove decorative subheader (`### Hypothesis Framework`), illustrative example hypothesis, and example-data columns (Score/Weighted) from prioritization matrix
- Collapse data sources bullet list to inline — same information, less vertical space
- Merge factorial example onto description line

## Classification

**Instruction doc** (decision frameworks, prioritization methodology, statistical rigor rules) — prose tightening applied, not restructuring.

## Verification

- All statistical methods preserved (Type I/II errors, sequential testing, bandit algorithms)
- SQL code block unchanged
- All tables preserved (structure retained, example-data columns removed)
- `bunx markdownlint-cli2`: 0 errors
- Line count: 93 → 81 (13% reduction)

## Runtime Testing

Risk level: **Low** (docs/agent prompts — self-assessed). No runtime environment required.

## Files Changed

- `.agents/marketing-sales/cro-chapter-21.md`

Closes #14281


---
[aidevops.sh](https://aidevops.sh) v3.5.565 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined chapter documentation for improved clarity and usability. Streamlined data source formatting, simplified table structures by removing redundant columns, and consolidated example content while preserving all essential frameworks and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->