### PR TITLE
GH#14322: tighten agent doc setup.md

### DIFF
--- a/.agents/aidevops/setup.md
+++ b/.agents/aidevops/setup.md
@@ -21,21 +21,15 @@ tools:
 - **Purpose**: Deploy aidevops agents to `~/.aidevops/agents/`
 - **Run**: `cd ~/Git/aidevops && ./setup.sh`
 - **Update**: `git pull && ./setup.sh` (backs up existing configs automatically)
+- **Agents**: `~/.aidevops/agents/` | **Backups**: `~/.aidevops/config-backups/` | **Credentials**: `~/.config/aidevops/credentials.sh`
 
 **What setup.sh does**:
 
 1. Checks required deps: `jq`, `curl`, `ssh`, `sqlite3` (FTS5 memory system)
 2. Checks optional deps: `sshpass` (Hostinger SSH), `gh`, `glab`, `tea`
-3. Copies `.agents/` → `~/.aidevops/agents/`
-4. Backs up existing configs to `~/.aidevops/config-backups/[timestamp]/`
-5. Injects `Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.` into `~/.opencode/AGENTS.md`, `~/.cursor/AGENTS.md`, `~/.claude/AGENTS.md`, `~/.config/cursor/AGENTS.md`
-6. Updates OpenCode agent paths in `~/.config/opencode/opencode.json`
-
-**Post-setup locations**:
-
-- Agents: `~/.aidevops/agents/`
-- Backups: `~/.aidevops/config-backups/`
-- Credentials: `~/.config/aidevops/credentials.sh`
+3. Copies `.agents/` → `~/.aidevops/agents/`; backs up existing configs to `~/.aidevops/config-backups/[timestamp]/`
+4. Injects `Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.` into `~/.opencode/AGENTS.md`, `~/.cursor/AGENTS.md`, `~/.claude/AGENTS.md`, `~/.config/cursor/AGENTS.md`
+5. Updates OpenCode agent paths in `~/.config/opencode/opencode.json`
 
 <!-- AI-CONTEXT-END -->
 


### PR DESCRIPTION
## Summary

Tighten and restructure `.agents/aidevops/setup.md` per build-agent.md guidance (GH#14322).

### Changes

- Merged redundant "Post-setup locations" section into Quick Reference as a single compact line
- Consolidated copy + backup steps (formerly steps 3+4) into one line — they are one logical operation
- Renumbered steps 5+6 → 4+5 accordingly
- Result: 82 → 76 lines, zero content loss

### Verification

- All paths, commands, dep lists, and troubleshooting steps preserved
- All code blocks, URLs, and command examples present before and after
- Agent behaviour unchanged (doc-only change, no logic modified)
- `git diff` reviewed: 4 insertions, 10 deletions — all deletions are redundant prose

### Runtime Testing

Risk level: **Low** (docs/agent prompt only — no code, no scripts, no logic). Self-assessed.

Closes #14322


---
[aidevops.sh](https://aidevops.sh) v3.5.565 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.