### PR TITLE
GH#14287: tighten Cloudflare Cache Reserve agent doc (91→48 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cache-reserve.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cache-reserve.md
@@ -1,87 +1,44 @@
 # Cloudflare Cache Reserve
 
-**Persistent cache storage built on R2 for long-term content retention**
+Persistent cache storage built on R2. Sits above tiered cache hierarchy; stores cacheable content for 30+ days to maximise cache hits and reduce origin egress.
 
-## Overview
+## Cache Hierarchy
 
-Cache Reserve is Cloudflare's persistent, large-scale cache storage layer built on R2. It acts as the ultimate upper-tier cache, storing cacheable content for extended periods (30+ days) to maximize cache hits, reduce origin egress fees, and shield origins from repeated requests for long-tail content.
-
-## Core Concepts
-
-### What is Cache Reserve?
-
-- **Persistent storage layer**: Built on R2, sits above tiered cache hierarchy
-- **Long-term retention**: 30-day default retention, extended on each access
-- **Automatic operation**: Works seamlessly with existing CDN, no code changes required
-- **Origin shielding**: Dramatically reduces origin egress by serving cached content longer
-- **Usage-based pricing**: Pay only for storage + read/write operations
-
-### Cache Hierarchy
-
-```
-Visitor Request
-    ↓
-Lower-Tier Cache (closest to visitor)
-    ↓ (on miss)
-Upper-Tier Cache (closest to origin)
-    ↓ (on miss)
-Cache Reserve (R2 persistent storage)
-    ↓ (on miss)
-Origin Server
+```text
+Visitor → Lower-Tier Cache → Upper-Tier Cache → Cache Reserve (R2) → Origin
 ```
 
-### How It Works
-
-1. **On cache miss**: Content fetched from origin �� written to Cache Reserve + edge caches simultaneously
-2. **On edge eviction**: Content may be evicted from edge cache but remains in Cache Reserve
-3. **On subsequent request**: If edge cache misses but Cache Reserve hits → content restored to edge caches
-4. **Retention**: Assets remain in Cache Reserve for 30 days since last access (configurable via TTL)
+On edge eviction, Cache Reserve restores content to edge caches on next request. Retention: 30 days since last access (reset on each hit).
 
 ## Asset Eligibility
 
-Cache Reserve only stores assets meeting **ALL** criteria:
+All criteria must be met:
 
-- Cacheable per Cloudflare's standard rules
-- Minimum 10-hour TTL (36000 seconds)
+- Cacheable per Cloudflare standard rules
+- TTL ≥ 10 hours (36000s)
 - `Content-Length` header present
 - Original files only (not transformed images)
 
-### Not Eligible
+**Not eligible:** TTL < 10h, no `Content-Length`, image transformation variants, `Set-Cookie`, `Vary: *`, R2 public bucket assets on same zone, O2O requests.
 
-- Assets with TTL < 10 hours
-- Responses without `Content-Length` header
-- Image transformation variants (original images are eligible)
-- Responses with `Set-Cookie` headers
-- Responses with `Vary: *` header
-- Assets from R2 public buckets on same zone
-- O2O (Orange-to-Orange) setup requests
+## Setup
 
-## Quick Start
+**Prerequisites:** Paid Cache Reserve plan; Tiered Cache strongly recommended.
+
+Enable via Dashboard: `https://dash.cloudflare.com/caching/cache-reserve` → "Enable Storage Sync".
 
 ```bash
-# Enable via Dashboard
-https://dash.cloudflare.com/caching/cache-reserve
-# Click "Enable Storage Sync" or "Purchase" button
-```
-
-**Prerequisites:**
-- Paid Cache Reserve plan required
-- Tiered Cache strongly recommended
-
-## Essential Commands
-
-```bash
-# Check Cache Reserve status
+# Check status
 curl -X GET "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/cache/cache_reserve" \
   -H "Authorization: Bearer $API_TOKEN"
 
-# Enable Cache Reserve
+# Enable
 curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/cache/cache_reserve" \
   -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"value": "on"}'
 
-# Check asset cache status
+# Verify asset cache status
 curl -I https://example.com/asset.jpg | grep -i cache
 ```
 


### PR DESCRIPTION
## Summary

Tighten  from 91 to 48 lines (47% reduction) per GH#14287.

**Classification:** Instruction doc (not reference corpus) — prose compression applied, not chapter split.

## Changes

- Merged Overview + Core Concepts into a single intro paragraph (removed duplication)
- Flattened cache hierarchy to a single-line text diagram (preserves the concept, removes 10 lines of ASCII art)
- Consolidated eligibility criteria: positive + negative in one section
- Merged Quick Start + Essential Commands into a single Setup section
- Fixed MD040 lint violation: added `text` language tag to fenced code block

## Verification

- All code blocks, URLs, eligibility rules, and API commands preserved
- `markdownlint` passes with zero violations
- No broken internal links (See Also references unchanged)
- Agent behaviour unchanged: same operational guidance, same commands

## Runtime Testing

**Risk level:** Low — documentation-only change, no code or config modified.
**Assessment:** self-assessed (no runtime required for doc changes)

Closes #14287

---

---
[aidevops.sh](https://aidevops.sh) v3.5.565 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.