### PR TITLE
t15176: tighten Stagehand benchmark scripts agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6,6 +6,11 @@
       "at": "2026-04-01T12:00:00Z",
       "pr": 15177
     },
+    ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
+      "hash": "8d79ff6b9aa02ab04c5f72924b3a7798ee561893",
+      "at": "2026-04-01T12:00:00Z",
+      "pr": 15176
+    },
     ".agents/aidevops/agent-sources.md": {
       "hash": "86113ed3f6cb39ad363af10d420942cff1af592c",
       "at": "2026-03-31T05:32:40Z",

--- a/.agents/tools/browser/browser-benchmark-scripts-05-stagehand.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-05-stagehand.md
@@ -1,6 +1,6 @@
 # Stagehand Benchmark Scripts
 
-AI-driven `act()`/`extract()` instead of CSS selectors. New `Stagehand` instance per run (measures cold-start). Tests receive `sh`; access page via `sh.ctx.pages()[0]`.
+AI-driven `act()`/`extract()`. New `Stagehand` per run (cold-start). Tests use `sh`; page: `sh.ctx.pages()[0]`.
 
 ```javascript
 import { Stagehand } from "@browserbasehq/stagehand";
@@ -31,7 +31,7 @@ const TESTS = {
   }
 };
 
-// Harness: new Stagehand → init → time fn(sh) → close; 3 runs per test, JSON output.
+// Harness: new Stagehand → init → time fn(sh) → close; 3 runs, JSON output.
 async function run() {
   const results = {};
   for (const [name, fn] of Object.entries(TESTS)) {


### PR DESCRIPTION
## Summary
- Tightened introductory prose and comments in `.agents/tools/browser/browser-benchmark-scripts-05-stagehand.md`.
- Updated `simplification-state.json` with the new file hash.
- Preserved all code examples and institutional knowledge.

Closes #15176

---

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.13 with gemini-3-flash spent 1h 11m and 14,955 tokens on this with the user in an interactive session.