### PR TITLE
feat: deploy aidevops agents to runtime-native agent directories

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1019,6 +1019,11 @@ _parse_run_args() {
 			agent_name="${2:-}"
 			shift 2
 			;;
+		--runtime)
+			# Explicit runtime override: "opencode" (default), "claude", etc.
+			headless_runtime="${2:-}"
+			shift 2
+			;;
 		--opencode-arg)
 			extra_args+=("${2:-}")
 			shift 2
@@ -1178,6 +1183,80 @@ _invoke_opencode() {
 	return 0
 }
 
+# _build_claude_cmd: build the claude CLI headless command as null-delimited tokens.
+# Used when --runtime claude is explicitly specified. OpenCode remains the default.
+# Args: selected_model work_dir prompt title agent_name [extra_args...]
+_build_claude_cmd() {
+	local selected_model="$1"
+	local work_dir="$2"
+	local prompt="$3"
+	local title="$4"
+	local agent_name="$5"
+	shift 5
+
+	# claude -p runs headless and prints output. --output-format stream-json
+	# gives structured output compatible with our result parsing.
+	printf '%s\0' "claude" "-p" "$prompt" "--output-format" "stream-json" "--verbose"
+	if [[ -n "$work_dir" ]]; then
+		printf '%s\0' "--directory" "$work_dir"
+	fi
+	if [[ -n "$agent_name" ]]; then
+		printf '%s\0' "--agent" "$agent_name"
+	elif type -P claude >/dev/null 2>&1; then
+		# Default to build-plus agent when none specified, if it exists in
+		# the agent directory. This gives headless Claude sessions the same
+		# aidevops agent behaviour as interactive sessions.
+		local claude_agent_dir="$HOME/.claude/agents"
+		if [[ -f "$claude_agent_dir/build-plus.md" ]]; then
+			printf '%s\0' "--agent" "build-plus"
+		fi
+	fi
+	# Model override: claude CLI uses --model flag
+	if [[ -n "$selected_model" ]]; then
+		# Strip provider prefix (anthropic/) — claude CLI doesn't need it
+		local claude_model="${selected_model#*/}"
+		printf '%s\0' "--model" "$claude_model"
+	fi
+	# Max turns for safety
+	printf '%s\0' "--max-turns" "50"
+	# Permission mode: allow all tools in headless
+	printf '%s\0' "--permission-mode" "bypassPermissions"
+	# Emit any extra args
+	while [[ $# -gt 0 ]]; do
+		printf '%s\0' "$1"
+		shift
+	done
+	return 0
+}
+
+# _invoke_claude: run the claude CLI command and capture output.
+# Same interface as _invoke_opencode for interchangeability.
+# Args: output_file exit_code_file cmd_args...
+_invoke_claude() {
+	local output_file="$1"
+	local exit_code_file="$2"
+	shift 2
+	local -a cmd=("$@")
+
+	(
+		set +e
+		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
+			local passthrough_csv
+			passthrough_csv="$(build_sandbox_passthrough_csv)"
+			if [[ -n "$passthrough_csv" ]]; then
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+			else
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
+			fi
+			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
+		else
+			"${cmd[@]}" 2>&1 | tee "$output_file"
+			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
+		fi
+	) || true
+	return 0
+}
+
 # _handle_run_result: process output_file after opencode exits.
 # Args: exit_code output_file role provider session_key selected_model
 # Sets caller variable _run_failure_reason on failure.
@@ -1230,9 +1309,11 @@ _handle_run_result() {
 	return "$exit_code"
 }
 
-# _execute_run_attempt: run one opencode invocation and handle the result.
+# _execute_run_attempt: run one headless invocation and handle the result.
+# Dispatches to OpenCode (default) or Claude CLI (when --runtime claude specified).
 # Args: role session_key work_dir title prompt selected_model agent_name model_override
 #       extra_args (array passed as remaining positional args after the named ones)
+# Reads caller variable headless_runtime (set by _parse_run_args --runtime flag).
 # Prints the discovered session ID to stdout on success (may be empty).
 # Returns: 0 success, 75 no-activity backoff, non-zero on failure.
 # Sets caller variable _run_failure_reason on failure.
@@ -1248,12 +1329,15 @@ _execute_run_attempt() {
 	shift 8
 	local -a extra_args=("$@")
 
+	# Determine which runtime to use. Default is opencode unless explicitly overridden.
+	local runtime="${headless_runtime:-opencode}"
+
 	local provider persisted_session=""
 	provider=$(extract_provider "$selected_model")
 	if [[ "$role" == "pulse" ]]; then
 		# Pulse runs must start from the current pre-fetched state each cycle.
-		# Reusing a prior OpenCode session contaminates later /pulse runs with
-		# stale conversational context, which leads to idle watchdog kills and an
+		# Reusing a prior session contaminates later /pulse runs with stale
+		# conversational context, which leads to idle watchdog kills and an
 		# empty worker pool. Workers still keep session reuse.
 		clear_session_id "$provider" "$session_key"
 	else
@@ -1261,10 +1345,24 @@ _execute_run_attempt() {
 	fi
 
 	local -a cmd=()
-	while IFS= read -r -d '' arg; do
-		cmd+=("$arg")
-	done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
-		"$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
+	case "$runtime" in
+	claude)
+		if ! type -P claude >/dev/null 2>&1; then
+			print_error "Claude CLI not found in PATH (requested via --runtime claude)"
+			return 1
+		fi
+		while IFS= read -r -d '' arg; do
+			cmd+=("$arg")
+		done < <(_build_claude_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
+			"$agent_name" "${extra_args[@]+"${extra_args[@]}"}")
+		;;
+	opencode | *)
+		while IFS= read -r -d '' arg; do
+			cmd+=("$arg")
+		done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
+			"$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
+		;;
+	esac
 
 	local output_file exit_code_file exit_code
 	local start_ms end_ms duration_ms
@@ -1273,7 +1371,10 @@ _execute_run_attempt() {
 	exit_code_file=$(mktemp)
 	exit_code=0
 
-	_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
+	case "$runtime" in
+	claude) _invoke_claude "$output_file" "$exit_code_file" "${cmd[@]}" ;;
+	*) _invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}" ;;
+	esac
 	exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
 	rm -f "$exit_code_file"
 
@@ -1500,6 +1601,7 @@ cmd_run() {
 	local prompt_file=""
 	local model_override=""
 	local agent_name=""
+	local headless_runtime=""
 	local -a extra_args=()
 
 	_parse_run_args "$@" || return 1
@@ -1570,15 +1672,19 @@ cmd_run() {
 
 show_help() {
 	cat <<'EOF'
-headless-runtime-helper.sh - Model-aware headless OpenCode runtime
+headless-runtime-helper.sh - Model-aware headless runtime (OpenCode default, Claude CLI opt-in)
 
 Usage:
   headless-runtime-helper.sh select [--role pulse|worker] [--model provider/model]
-  headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--agent NAME] [--opencode-arg ARG]
+  headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG]
   headless-runtime-helper.sh backoff [status|set MODEL-OR-PROVIDER REASON [SECONDS]|clear MODEL-OR-PROVIDER]
   headless-runtime-helper.sh session [status|clear PROVIDER SESSION_KEY]
   headless-runtime-helper.sh metrics [--role pulse|worker] [--hours N] [--model SUBSTRING] [--fast-threshold N]
   headless-runtime-helper.sh help
+
+Runtime selection:
+  Default runtime is OpenCode. Use --runtime claude to dispatch via Claude CLI.
+  Claude CLI headless uses `claude -p` with --agent build-plus (auto-detected).
 
 Backoff granularity:
   Rate limits and provider errors are recorded per model (e.g. anthropic/claude-sonnet-4-6).

--- a/.agents/scripts/runtime-registry.sh
+++ b/.agents/scripts/runtime-registry.sh
@@ -229,6 +229,24 @@ _RT_PROCESS_PATTERN=(
 	"amp"      # amp
 )
 
+# --- Agent directories (where the runtime loads agent definitions) ---
+# Runtimes that support user-defined agents via markdown + YAML frontmatter.
+# Empty string means "no agent directory support".
+_RT_AGENT_DIR=(
+	""                      # opencode (agents via config, not directory)
+	"\$HOME/.claude/agents" # claude-code
+	""                      # codex (no agent dir)
+	"\$HOME/.cursor/agents" # cursor
+	""                      # droid (no agent dir)
+	""                      # gemini-cli (no agent dir)
+	""                      # windsurf (no agent dir)
+	""                      # continue (no agent dir)
+	""                      # kilo (no agent dir)
+	""                      # kiro (no agent dir)
+	""                      # aider (no agent dir)
+	"\$HOME/.amp/agents"    # amp
+)
+
 # --- Headless support (can the runtime run without a UI?) ---
 # "yes" = has a headless/CLI mode, "no" = GUI/editor only, "" = unknown
 _RT_HEADLESS_SUPPORT=(
@@ -427,6 +445,14 @@ rt_command_dir() {
 	local idx
 	idx=$(_rt_index "$id") || return 1
 	_rt_expand_path "${_RT_COMMAND_DIR[$idx]}"
+	return 0
+}
+
+rt_agent_dir() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	_rt_expand_path "${_RT_AGENT_DIR[$idx]}"
 	return 0
 }
 
@@ -645,6 +671,19 @@ rt_list_with_commands() {
 	return 0
 }
 
+# List runtimes that have agent directories.
+# Prints runtime IDs, one per line.
+rt_list_with_agents() {
+	local i=0
+	while [[ $i -lt $_RT_COUNT ]]; do
+		if [[ -n "${_RT_AGENT_DIR[$i]}" ]]; then
+			echo "${_RT_IDS[$i]}"
+		fi
+		i=$((i + 1))
+	done
+	return 0
+}
+
 # =============================================================================
 # Validation (called by test suite, safe to call at source time)
 # =============================================================================
@@ -660,6 +699,7 @@ rt_validate_registry() {
 		"_RT_CONFIG_FORMAT"
 		"_RT_MCP_ROOT_KEY"
 		"_RT_COMMAND_DIR"
+		"_RT_AGENT_DIR"
 		"_RT_PROMPT_MECHANISM"
 		"_RT_SESSION_DB"
 		"_RT_SESSION_DB_FORMAT"

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -530,6 +530,235 @@ _deploy_droid_agents_reference() {
 	return 0
 }
 
+# =============================================================================
+# Deploy aidevops main agents to runtime-native agent directories
+# =============================================================================
+# Converts aidevops agents from ~/.aidevops/agents/*.md into each runtime's
+# native agent format and copies them to the runtime's agent directory.
+# Only deploys to installed runtimes that support agent directories.
+#
+# aidevops frontmatter fields stripped (not understood by target runtimes):
+#   mode, subagents
+#
+# Kept/mapped fields (compatible with Claude Code, Cursor, Amp):
+#   name, description, tools, model, permissionMode, hooks, mcpServers,
+#   maxTurns, initialPrompt, memory, background, isolation
+
+# _convert_agent_frontmatter: strips aidevops-only fields from agent markdown.
+# Reads from stdin, writes converted content to stdout.
+# Tracks whether we're inside an indented block (subagents list) to correctly
+# skip its child lines without stripping other indented YAML fields.
+_convert_agent_frontmatter() {
+	local in_frontmatter=false
+	local frontmatter_started=false
+	local in_skip_block=false
+	local line_num=0
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		line_num=$((line_num + 1))
+		if [[ $line_num -eq 1 && "$line" == "---" ]]; then
+			in_frontmatter=true
+			frontmatter_started=true
+			echo "$line"
+			continue
+		fi
+		if [[ "$frontmatter_started" == "true" && "$in_frontmatter" == "true" && "$line" == "---" ]]; then
+			in_frontmatter=false
+			echo "$line"
+			continue
+		fi
+		if [[ "$in_frontmatter" == "true" ]]; then
+			# Detect top-level keys (no leading whitespace)
+			case "$line" in
+			mode:*)
+				in_skip_block=false
+				continue
+				;;
+			subagents:*)
+				in_skip_block=true
+				continue
+				;;
+			esac
+			# If inside a skipped block, consume indented continuation lines
+			if [[ "$in_skip_block" == "true" ]]; then
+				case "$line" in
+				[[:space:]]*)
+					# Indented line under a skipped key — skip it
+					continue
+					;;
+				*)
+					# Non-indented line — we've left the skip block
+					in_skip_block=false
+					echo "$line"
+					;;
+				esac
+			else
+				echo "$line"
+			fi
+		else
+			echo "$line"
+		fi
+	done
+	return 0
+}
+
+# _is_agent_definition: check if a markdown file has agent frontmatter (name: field).
+# Returns 0 if the file is an agent definition, 1 otherwise.
+_is_agent_definition() {
+	local file="$1"
+	# Check first 30 lines for name: in YAML frontmatter (fast path)
+	head -30 "$file" 2>/dev/null | grep -q '^name:' 2>/dev/null
+	return $?
+}
+
+# _agent_source_dirs: list directories under agents_source that contain subagents.
+# Excludes framework infrastructure directories that are not agent definitions.
+# Prints directory paths, one per line.
+_agent_source_dirs() {
+	local agents_source="$1"
+	local dir
+	for dir in "$agents_source"/*/; do
+		[[ -d "$dir" ]] || continue
+		local dirname
+		dirname=$(basename "$dir")
+		# Skip framework infrastructure directories
+		case "$dirname" in
+		scripts | reference | prompts | templates | configs | hooks | \
+			plugins | bundles | loop-state | advisories | aidevops | \
+			custom | draft | tests | rules)
+			continue
+			;;
+		*)
+			echo "$dir"
+			;;
+		esac
+	done
+	return 0
+}
+
+# deploy_agents_to_runtimes: main entry point called by setup.sh.
+# Iterates all installed runtimes with agent directory support, converts and
+# deploys aidevops agents (top-level and subagent directories) to each runtime's
+# native agent directory. Only files with name: frontmatter are deployed.
+# SKILL.md stubs (directory indexes) are excluded.
+deploy_agents_to_runtimes() {
+	# Source runtime registry if not already loaded
+	local registry_script="${INSTALL_DIR:-.}/.agents/scripts/runtime-registry.sh"
+	if [[ -z "${_RUNTIME_REGISTRY_LOADED:-}" ]]; then
+		if [[ -f "$registry_script" ]]; then
+			# shellcheck source=/dev/null
+			source "$registry_script"
+		else
+			print_warning "Runtime registry not found — skipping agent deployment to runtimes"
+			return 0
+		fi
+	fi
+
+	local agents_source="${HOME}/.aidevops/agents"
+	if [[ ! -d "$agents_source" ]]; then
+		print_warning "No deployed agents found at $agents_source — skipping"
+		return 0
+	fi
+
+	# Build the list of agent files to deploy (once, shared across runtimes).
+	# Includes top-level *.md and all *.md in subagent directories that:
+	#   1. Have name: in frontmatter (actual agent definitions)
+	#   2. Are not SKILL.md stubs (directory index files)
+	local -a agent_files=()
+	local -a agent_relpaths=()
+
+	# Top-level agents
+	local f bn
+	for f in "$agents_source"/*.md; do
+		[[ -f "$f" ]] || continue
+		bn=$(basename "$f")
+		[[ "$bn" == "AGENTS.md" ]] && continue
+		if _is_agent_definition "$f"; then
+			agent_files+=("$f")
+			agent_relpaths+=("$bn")
+		fi
+	done
+
+	# Subagent directories (recursive)
+	local subdir
+	while IFS= read -r subdir; do
+		while IFS= read -r f; do
+			[[ -f "$f" ]] || continue
+			bn=$(basename "$f")
+			# Skip SKILL.md stubs — they're directory indexes, not real agents
+			[[ "$bn" == "SKILL.md" ]] && continue
+			if _is_agent_definition "$f"; then
+				# Compute path relative to agents_source
+				local relpath="${f#"$agents_source"/}"
+				agent_files+=("$f")
+				agent_relpaths+=("$relpath")
+			fi
+		done < <(find "$subdir" -name '*.md' -type f 2>/dev/null)
+	done < <(_agent_source_dirs "$agents_source")
+
+	local total_agents=${#agent_files[@]}
+	if [[ $total_agents -eq 0 ]]; then
+		print_warning "No agent definitions found in $agents_source"
+		return 0
+	fi
+
+	local deployed_count=0
+	local runtime_count=0
+
+	# Deploy to each installed runtime
+	local runtime_id agent_dir
+	while IFS= read -r runtime_id; do
+		agent_dir=$(rt_agent_dir "$runtime_id")
+		[[ -z "$agent_dir" ]] && continue
+
+		# Only deploy if the runtime is actually installed
+		local binary
+		binary=$(rt_binary "$runtime_id")
+		local config_path
+		config_path=$(rt_config_path "$runtime_id")
+		local config_dir
+		config_dir="$(dirname "$config_path" 2>/dev/null)"
+
+		if ! type -P "$binary" >/dev/null 2>&1 && [[ ! -d "$config_dir" ]]; then
+			continue
+		fi
+
+		mkdir -p "$agent_dir"
+		runtime_count=$((runtime_count + 1))
+		local agent_count=0
+		local i=0
+
+		while [[ $i -lt $total_agents ]]; do
+			local src="${agent_files[$i]}"
+			local rel="${agent_relpaths[$i]}"
+			local target="$agent_dir/$rel"
+
+			# Ensure target subdirectory exists
+			local target_parent
+			target_parent=$(dirname "$target")
+			[[ -d "$target_parent" ]] || mkdir -p "$target_parent"
+
+			if _convert_agent_frontmatter <"$src" >"$target"; then
+				agent_count=$((agent_count + 1))
+			fi
+			i=$((i + 1))
+		done
+
+		local display_name
+		display_name=$(rt_display_name "$runtime_id")
+		print_info "Deployed $agent_count agents to $display_name ($agent_dir)"
+		deployed_count=$((deployed_count + agent_count))
+	done < <(rt_list_with_agents)
+
+	if [[ $runtime_count -eq 0 ]]; then
+		print_info "No runtimes with agent directory support detected — skipping"
+	else
+		print_success "Deployed $deployed_count agent(s) across $runtime_count runtime(s)"
+	fi
+
+	return 0
+}
+
 install_beads_binary() {
 	local os arch tarball_name
 	os=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/setup.sh
+++ b/setup.sh
@@ -794,6 +794,7 @@ _setup_run_non_interactive() {
 	wait "$_pid_scan" 2>/dev/null || print_warning "Skill security scan encountered issues (non-critical)"
 
 	inject_agents_reference
+	deploy_agents_to_runtimes
 	update_opencode_config
 	update_claude_config
 	update_codex_config
@@ -866,6 +867,7 @@ _setup_run_interactive() {
 	confirm_step "Check for skill updates from upstream" && check_skill_updates
 	confirm_step "Security scan imported skills" && scan_imported_skills
 	confirm_step "Inject agents reference into AI configs" && inject_agents_reference
+	confirm_step "Deploy aidevops agents to runtime agent directories" && deploy_agents_to_runtimes
 	confirm_step "Setup Python environment (DSPy, crawl4ai)" && setup_python_env
 	confirm_step "Setup Node.js environment" && setup_nodejs_env
 	confirm_step "Install MCP packages globally (fast startup)" && install_mcp_packages


### PR DESCRIPTION
## Summary

- Adds `_RT_AGENT_DIR` array to runtime registry mapping each runtime to its native agent directory (Claude Code, Cursor, Amp supported)
- Deploys 108 aidevops agents (11 main + 97 subagents) to each installed runtime during setup, stripping aidevops-only frontmatter (`mode`, `subagents`) while preserving compatible fields
- Adds opt-in `--runtime claude` flag to headless-runtime-helper.sh for Claude CLI headless dispatch with auto-detected `--agent build-plus`. OpenCode remains the default.

Closes #14938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--runtime` CLI flag allowing users to select between OpenCode and Claude runtimes.
  * Implemented automatic agent deployment that installs agents into runtime-specific directories during setup.
  * Enabled full Claude runtime integration with headless execution and configurable agent selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->