### PR TITLE
GH#15274: add --no-pager to systemctl status in coolify-setup.md

### DIFF
--- a/.agents/tools/deployment/coolify-setup.md
+++ b/.agents/tools/deployment/coolify-setup.md
@@ -36,7 +36,7 @@ tools:
 ```bash
 ssh root@your-server-ip
 curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash
-systemctl status coolify  # verify
+systemctl status coolify --no-pager  # verify
 ufw allow 22/tcp && ufw allow 80/tcp && ufw allow 443/tcp && ufw allow 8000/tcp && ufw --force enable
 apt update && apt upgrade -y
 apt install unattended-upgrades -y && dpkg-reconfigure -plow unattended-upgrades


### PR DESCRIPTION
## Summary

Addresses the unactioned MEDIUM-severity review feedback from PR #15213 on `.agents/tools/deployment/coolify-setup.md`.

**Finding (gemini, MEDIUM):** `systemctl status coolify` at line 39 invokes a pager by default, which can pause execution and prevent subsequent commands from running in scripted/automated documentation blocks.

**Fix:** Added `--no-pager` flag to ensure non-interactive output.

**Note:** The HIGH-severity coderabbit finding (`ufw --force enable`) was already addressed in commit `19943f9` from PR #15213 and is confirmed present in the current file.

## Changes

- `.agents/tools/deployment/coolify-setup.md`: `systemctl status coolify` → `systemctl status coolify --no-pager`

## Runtime Testing

**Risk level:** Low — documentation-only change (no executable code, no tests required).
**Verification:** File content confirmed correct via Read tool after edit.

## Completion Criteria

- [DONE] `systemctl status coolify --no-pager` present at line 39
- [DONE] `ufw --force enable` confirmed present at line 40 (pre-existing fix)
- [DONE] Single file changed (within quality-debt blast radius limit of ≤5 files)

Closes #15274


---
[aidevops.sh](https://aidevops.sh) v3.5.569 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.