### PR TITLE
GH#15271: improve scannability of hyperdrive.md intro paragraph

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/hyperdrive.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/hyperdrive.md
@@ -1,6 +1,8 @@
 # Hyperdrive
 
-Connect Workers to PostgreSQL or MySQL with edge connection setup, pooled origin connections, and optional caching for non-mutating queries. It removes ~7 TCP/TLS/auth round-trips per connection. Compatible with CockroachDB, Timescale, PlanetScale, Neon, and Supabase.
+Connect Workers to PostgreSQL or MySQL with edge connection setup, pooled origin connections, and optional caching for non-mutating queries. Removes ~7 TCP/TLS/auth round-trips per connection.
+
+Compatible with CockroachDB, Timescale, PlanetScale, Neon, and Supabase.
 
 ## Best Fit
 


### PR DESCRIPTION
## Summary

- Splits the 50+ word intro sentence in `hyperdrive.md` into two shorter sentences for easier scanning
- Addresses the optional scannability improvement from CodeRabbit review feedback on PR #15235
- The grammar fix ("supports compatibles" → "Compatible with") was already applied in PR #15235; this closes the remaining quality-debt item

## Changes

- `.agents/services/hosting/cloudflare-platform-skill/hyperdrive.md`: split intro paragraph into two sentences for scannability

## Testing

- Risk level: **Low** (docs-only change, no code logic)
- Self-assessed: sentence structure verified correct, no functional impact

## Runtime Testing

- Level: `self-assessed` (documentation change only)

Closes #15271

---


---
[aidevops.sh](https://aidevops.sh) v3.5.569 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m on this as a headless worker.