### PR TITLE
GH#15276: fix case study metrics in cro-chapter-25.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,6 +1,11 @@
 {
   "_comment": null,
   "files": {
+    ".agents/marketing-sales/cro-chapter-25.md": {
+      "hash": "b74f0ff498c385d2647512d5f68dc6261a0063e3",
+      "at": "2026-04-01T21:00:00Z",
+      "pr": 15276
+    },
     ".agents/marketing-sales/cro-chapter-22.md": {
       "hash": "882c97fc64eb63b11312049223c04eaa52882296",
       "at": "2026-04-01T20:58:50Z",

--- a/.agents/marketing-sales/cro-chapter-25.md
+++ b/.agents/marketing-sales/cro-chapter-25.md
@@ -68,13 +68,13 @@ Optimize for **RPV**, not CR alone: `LRPV = CR × Avg Transaction × (1 + Expans
 
 Flat $99/mo → tiered by contact list: Starter $49/≤1K · Growth $99/≤10K · Scale $199/≤50K · Enterprise custom. Grandfathered 6 months; 80% usage alerts; contact-cleaning tool; 20% annual discount.
 
-**Results (6 mo):** ARPU +28% ($99→$127) · LTV +34% · Churn 4.5→3.2% · Expansion 0→23% of new MRR · NRR 102→118% — growth-driven upgrades
+**Results (6 mo):** ARPU +28% ($99→$127) · LTV +34% · Churn 4.5→3.2% · Expansion 0→23% · NRR 102→118% (growth-driven upgrades)
 
 ### Subscription Box: Strategic Bundling (Coffee)
 
 $25/mo flat → Explorer $29 / **Enthusiast $49** *(flagship: micro-lot, virtual cupping, 15% add-on discount)* / Connoisseur $79 *(equipment, private Slack)*.
 
-**Results (9 mo):** Mix 15/62/23% · ARPU +116% ($25→$54) · GM 40→52% · LTV +200% ($67→$201) · CAC payback 3.5→0.7 mo · Retention 45→68% — equipment inclusion created switching costs
+**Results (9 mo):** Mix 15/62/23% · ARPU +116% ($25→$54) · GM 40→52% · LTV +200% ($67→$201) · CAC payback 3.5→1.2 mo · Retention 45→68% (equipment switching costs)
 
 ### Online Course Platform: Checkout Optimization
 


### PR DESCRIPTION
## Summary

Address medium-priority review feedback from PR #15222 on `.agents/marketing-sales/cro-chapter-25.md`.

### Changes

**B2B SaaS case study (line 71):**
- Remove ambiguous phrase "of new MRR" from Expansion metric (NRR measures expansion of existing cohort, not new MRR)
- Add "(growth-driven upgrades)" note to preserve institutional context

**Subscription Box case study (line 77):**
- Correct CAC payback from 0.7 → 1.2 mo (math fix: with stable CAC $35, new monthly profit $54×52%=$28.08 → $35/$28.08 ≈ 1.25 mo, rounded to 1.2)
- Add "(equipment switching costs)" note to preserve strategic insight

**simplification-state.json:** Add cro-chapter-25.md entry with current hash.

### Verification

- Content preservation: all data points, benchmarks, empirical results present ✓
- Math consistency: CAC payback now internally consistent with stated ARPU/GM/CAC baseline ✓
- No broken internal links ✓
- Risk level: Low (agent doc, no code logic) → self-assessed

## Runtime Testing

**Level:** Low (agent doc, no code logic)
**Method:** self-assessed — content diff reviewed, math verified

Closes #15276

---

---
[aidevops.sh](https://aidevops.sh) v3.5.570 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m on this as a headless worker.