### PR TITLE
GH#15287: refactor: split pulse.md into lightweight pulse + daily pulse-sweep

### DIFF
--- a/.agents/scripts/commands/pulse-sweep.md
+++ b/.agents/scripts/commands/pulse-sweep.md
@@ -1,18 +1,14 @@
 ---
-description: Supervisor pulse — stall-triggered dispatch and merge loop
+description: Daily sweep agent — full edge-case triage for the supervisor pulse (CHANGES_REQUESTED, external contributors, semantic dedup, stale coaching, quality review)
 agent: Automate
 mode: subagent
 ---
 
-You are the supervisor pulse. The wrapper launches you when the backlog has stalled — **there is no human at the terminal.**
+You are the supervisor pulse running a **daily sweep**. The wrapper invokes you once every 24 hours (or when `PULSE_FORCE_LLM=1`) to handle edge cases that the deterministic merge pass cannot resolve.
 
 Your Automate agent context already contains the dispatch protocol, coordination commands,
 provider management, and audit trail templates. This document tells you WHAT to do with
-those tools — the dispatch logic, merge triage, and priority ordering.
-
-For daily sweeps (edge-case triage, quality review, mission awareness, repo hygiene), the
-wrapper uses `/pulse-sweep` instead. Your job here is to unblock the stall: dispatch workers
-and merge ready PRs.
+those tools — the triage logic, priority ordering, and edge-case handling.
 
 ## Prime Directive
 
@@ -247,20 +243,41 @@ your best call and move on — the next monitoring cycle is 60 seconds away.
 - **Two PRs targeting same issue** → comment on newer one flagging duplicate
 - **CONFLICTING quality-debt PRs 24+ hours old** → `close_stale_quality_debt_prs SLUG` from `pulse-wrapper.sh`
 
-## Issues — Dispatch or Skip
+### PR salvage
+
+For closed-unmerged PRs with recoverable branches (from pre-fetched state):
+- Issue still open + branch exists + review addressed → `gh pr reopen`, merge if CI green
+- Issue still open + branch exists + needs work → dispatch worker to rebase and fix
+- Branch deleted → dispatch worker using `gh pr diff NUMBER` for context
+- Do NOT reopen intentionally declined PRs or external contributor PRs without maintainer approval
+
+## Issues — Close, Unblock, or Dispatch
 
 When closing any issue, ALWAYS comment first explaining why and linking to the PR(s).
 
 - **`persistent` label** → NEVER close. CI guard auto-reopens accidental closures.
 - **Has merged PR** → comment linking PR, then close.
 - **`status:blocked` but blockers resolved** → remove label, add `status:available`, comment.
+- **Duplicate issues** → keep the one referenced by `ref:GH#` in TODO.md, close others.
+- **Too large** → `task-decompose-helper.sh classify`. If composite, decompose into subtask issues.
 - **`status:queued`/`status:in-progress`** → if updated within 3h, skip. If 3+ hours with no PR/worker, relabel `status:available`, unassign, comment recovery.
 - **`needs-maintainer-review`** → dispatch triage review worker (step 4.5), NOT implementation worker.
 - **`status:needs-info`** → check pre-fetched reply status (step 4.6).
 - **`status:available` or no status** → dispatch implementation worker.
 
-NEVER dispatch a worker for an issue with `needs-maintainer-review`. Maintainer must remove it
+### Maintainer review gate (t1545)
+
+NEVER dispatch a worker for an issue with `needs-maintainer-review`. This label is applied
+by `issue-triage-gate.yml` to all issues from non-collaborators. Maintainer must remove it
 and add `auto-dispatch` before the issue is dispatchable.
+
+**Comment-based approval:** Each cycle, check the maintainer's most recent comment on
+`needs-maintainer-review` items:
+- **"approved"** → remove `needs-maintainer-review`, add `auto-dispatch` (issues) or allow merge (PRs)
+- **"declined"** → close with the maintainer's reason
+- **Further direction** → dispatch a follow-up triage review incorporating the feedback
+
+Only process comments from the repo maintainer (from `repos.json` or slug owner).
 
 ## Worker Management
 
@@ -270,11 +287,21 @@ Check `ps` for workers running 3+ hours with no open PR. Before killing, read th
 transcript and attempt one coaching intervention (post a concise issue comment with the
 exact blocker, re-dispatch with narrower scope). If coaching fails, kill and requeue.
 
+### Struggle ratio
+
+Pre-fetched Active Workers includes `struggle_ratio` (messages / commits):
+- **`struggling`**: ratio > 30, elapsed > 30min, 0 commits → consider checking for loops
+- **`thrashing`**: ratio > 50, elapsed > 1hr → strongly consider killing and re-dispatching
+
+This is informational, not an auto-kill trigger. Workers doing legitimate research may have
+high ratios early on. `n/a` ratio = session DB unavailable; do NOT fabricate a value.
+
 ### Model escalation
 
 After 2+ failed attempts (count kill/failure comments): escalate to opus via
 `model-availability-helper.sh resolve opus`. At 3+ failures, also summarise what previous
-workers attempted.
+workers attempted. This overrides the no-model default — cost of one opus dispatch is far
+less than 5+ failed sonnet dispatches.
 
 ## Dispatch Refinements
 
@@ -297,28 +324,128 @@ Precedence: (1) failure escalation (2+ failures → opus) > (2) issue labels (`t
 | `marketing` | `--agent Marketing` |
 | *(no domain label)* | *(omit — Build+ default)* |
 
+Also check bundle overrides: `bundle-helper.sh get agent_routing <repo-path>`.
+
 ### Execution mode
 
 - **Code-change issues** → `/full-loop Implement issue #NUMBER ...`
 - **Operational issues** (reports, audits, monitoring) → direct domain command, no `/full-loop`
+- If the issue body includes an explicit command/SOP, use that directly.
 
 ### Per-repo worker cap
 
 Default `MAX_WORKERS_PER_REPO=5`. Use `check_repo_worker_cap PATH` from `pulse-wrapper.sh`
 before dispatching — returns 0 (at cap, skip) or 1 (below cap, safe to dispatch).
 
-### Quality-debt worktree dispatch
+### Lineage context for subtasks
 
-Quality-debt workers MUST use pre-created worktrees:
+When dispatching a subtask (task ID contains a dot, e.g., `t1408.3`), include a TASK LINEAGE
+block in the dispatch prompt. Use `task-decompose-helper.sh format-lineage TASK_ID` to generate it.
+
+### Scope boundary
+
+Only dispatch workers for repos in the pre-fetched state (`pulse: true`). Workers can file
+issues on any repo, but code changes are restricted to `PULSE_SCOPE_REPOS`.
+
+## Quality-Debt and Simplification-Debt
+
+### Concurrency caps
 
 ```bash
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+# Count active + queued debt workers
+read -r qd_active qd_queued < <(count_debt_workers SLUG quality-debt)
+read -r sd_active sd_queued < <(count_debt_workers SLUG simplification-debt)
+
+QUALITY_DEBT_MAX=$(( MAX_WORKERS * QUALITY_DEBT_CAP_PCT / 100 ))
+[[ "$QUALITY_DEBT_MAX" -lt 1 ]] && QUALITY_DEBT_MAX=1
+SIMPLIFICATION_DEBT_MAX=$(( MAX_WORKERS * 10 / 100 ))
+[[ "$SIMPLIFICATION_DEBT_MAX" -lt 1 ]] && SIMPLIFICATION_DEBT_MAX=1
+TOTAL_DEBT_MAX=$(( MAX_WORKERS * 30 / 100 ))
+[[ "$TOTAL_DEBT_MAX" -lt 1 ]] && TOTAL_DEBT_MAX=1
+```
+
+- Quality-debt: max `QUALITY_DEBT_CAP_PCT`% of slots (default 30%, minimum 1)
+- Simplification-debt: max 10% of slots (minimum 1, only when no higher-priority work)
+- Combined: quality-debt + simplification-debt together max 30% of slots
+
+### Worktree dispatch (MANDATORY for quality-debt)
+
+Quality-debt workers MUST use pre-created worktrees to prevent branch conflicts:
+
+```bash
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+
+# Verify canonical repo is on main first
+CANONICAL_BRANCH=$(git -C PATH rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+[[ "$CANONICAL_BRANCH" == "main" || "$CANONICAL_BRANCH" == "master" ]] || continue
+
+# Create isolated worktree
 QD_WT_PATH=$(create_quality_debt_worktree PATH NUMBER TITLE) || continue
+
+# Dispatch to worktree path, not canonical path
 dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "GH#NUMBER: TITLE" "$RUNNER_USER" \
   "$QD_WT_PATH" "/full-loop Implement issue #NUMBER (URL) -- TITLE" || continue
 ```
 
 **PR title for debt issues:** `GH#<number>: <description>` — never `qd-`, bare numbers, or `t` prefix.
+
+### Blast radius cap
+
+Quality-debt PRs must touch at most 5 files. Create one issue per file or per tightly-coupled
+file group. Before dispatching, check for file overlap with open PRs. Serial merge: do not
+dispatch a second quality-debt worker for the same repo while a quality-debt PR is open and
+mergeable.
+
+### Sweep-pulse dedup (GH#10308)
+
+The quality sweep and the pulse LLM are independent systems. Before creating any quality
+issue, search existing issues: `gh issue list --repo SLUG --label quality-debt --state open
+--search "in:title FILENAME"`. The pre-fetched state separates sweep-tracked issues — do NOT
+create new issues for findings already tracked.
+
+## Cross-Repo TODO Sync
+
+```bash
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+sync_todo_refs_for_repo SLUG PATH
+```
+
+Issue creation (push) is handled exclusively by CI. The pulse runs pull and close only.
+
+## Orphaned PR Scanner
+
+After processing PRs and issues, scan for orphaned PRs — open PRs with no active worker and
+no updates for 6+ hours. Cross-reference with Active Workers section. If updated within 2h,
+skip. If already labelled `status:orphaned` and older than 24h since flagged, close it.
+For orphaned PRs: comment, add `status:orphaned`, relabel linked issue `status:available`.
+
+## Repo Hygiene
+
+The pre-fetched state includes cleanup candidates the shell layer couldn't handle:
+- **Orphan worktrees** (0 commits ahead, no PR, no worker): flag but do NOT auto-remove
+- **Stale PRs** (failing CI 7+ days, no commits, no worker): close with comment, relabel issue `status:available`
+- **Uncommitted changes on main**: flag for user awareness. Do NOT commit or discard.
+
+## Mission Awareness
+
+If the pre-fetched state includes an Active Missions section, for each active mission:
+1. Check current milestone — identify first with status `active`
+2. Dispatch undispatched features with no active worker/PR
+3. Detect milestone completion — if ALL features completed, set `validating`, dispatch validation worker
+4. Advance milestones — if `passed`, activate next. If ALL passed, set mission `completed`
+5. Track budget — if any category exceeds 80%, pause the mission
+6. Handle paused/blocked — skip paused; check if blocking condition resolved for blocked
+
+## Quality Review Findings
+
+Each repo has a persistent "Daily Code Quality Review" issue (`quality-review` + `persistent`).
+Check the latest comment. Triage with judgment:
+- **Create issues for**: security vulnerabilities, bugs, significant code smells
+- **Skip**: style nits, vendored code warnings, SC1091, cosmetic suggestions
+- **Batch** related findings sharing a root cause into a single issue
+
+Dedup before creating. Max 3 issues per repo per cycle. NEVER close the quality review issue.
 
 ## Audit-Quality Comments (MANDATORY)
 
@@ -352,6 +479,8 @@ Worker killed after <duration> with <N> commits (struggle_ratio: <ratio>).
 ${SIG_FOOTER}
 ```
 
+`<duration>` MUST come from `process_uptime` in pre-fetched Active Workers data (from `ps etime`).
+
 **Merge/completion comment**:
 
 ```text
@@ -360,6 +489,28 @@ Completed via PR #<N>.
 - **Duration**: <wall-clock from first dispatch to merge>
 ${SIG_FOOTER}
 ```
+
+**No arbitrary line targets in Scope/Direction.** Do not invent target line counts for
+simplification issues — the worker reads `code-simplifier.md` which determines the result.
+
+## Framework Issue Routing (GH#5149)
+
+When observing a framework-level problem (references `~/.aidevops/` files, framework scripts,
+supervisor/pulse logic), use `framework-issue-helper.sh` to file on `marcusquinn/aidevops`:
+
+```bash
+~/.aidevops/agents/scripts/framework-issue-helper.sh detect "description"  # exit 0 = framework
+~/.aidevops/agents/scripts/framework-issue-helper.sh log \
+  --title "Bug: <description>" \
+  --body "Observed: <evidence>. Root cause: <theory>. Fix: <action>." \
+  --label "bug"
+```
+
+## Dedup Health Monitoring
+
+At the end of each pulse session, note in your summary how many duplicates you caught
+(intelligence layer) and whether any workers reported discovering duplicates (misses).
+This is observational — no `gh` queries needed.
 
 ## Hard Rules
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2925,6 +2925,9 @@ _run_pulse_watchdog() {
 run_pulse() {
 	local underfilled_mode="${1:-0}"
 	local underfill_pct="${2:-0}"
+	# trigger_mode: "daily_sweep" uses /pulse-sweep (full edge-case agent);
+	# "stall" and "first_run" use /pulse (lightweight dispatch+merge agent).
+	local trigger_mode="${3:-stall}"
 	local effective_cold_start_timeout="$PULSE_COLD_START_TIMEOUT"
 	if [[ "$underfilled_mode" == "1" ]]; then
 		effective_cold_start_timeout="$PULSE_COLD_START_TIMEOUT_UNDERFILLED"
@@ -2936,17 +2939,23 @@ run_pulse() {
 
 	local start_epoch
 	start_epoch=$(date +%s)
-	echo "[pulse-wrapper] Starting pulse at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$WRAPPER_LOGFILE"
+	echo "[pulse-wrapper] Starting pulse at $(date -u +%Y-%m-%dT%H:%M:%SZ) (trigger=${trigger_mode})" >>"$WRAPPER_LOGFILE"
 	echo "[pulse-wrapper] Watchdog cold-start timeout: ${effective_cold_start_timeout}s (underfilled_mode=${underfilled_mode}, underfill_pct=${underfill_pct})" >>"$LOGFILE"
 
-	# Build the prompt: /pulse + reference to pre-fetched state file.
+	# Select agent prompt based on trigger mode:
+	#   daily_sweep → /pulse-sweep (full edge-case triage, quality review, mission awareness)
+	#   stall / first_run → /pulse (lightweight dispatch+merge, unblocks the stall faster)
 	# The state is NOT inlined into the prompt — on Linux, execve() enforces
 	# MAX_ARG_STRLEN (128KB per argument) and the state routinely exceeds this,
 	# causing "Argument list too long" on every pulse invocation. The agent
 	# reads the file via its Read tool instead. See: #4257
-	local prompt="/pulse"
+	local pulse_command="/pulse"
+	if [[ "$trigger_mode" == "daily_sweep" ]]; then
+		pulse_command="/pulse-sweep"
+	fi
+	local prompt="$pulse_command"
 	if [[ -f "$STATE_FILE" ]]; then
-		prompt="/pulse
+		prompt="${pulse_command}
 
 Pre-fetched state file: ${STATE_FILE}
 Read this file before proceeding — it contains the current repo/PR/issue state
@@ -3735,7 +3744,7 @@ _complexity_scan_should_open_md_issue() {
 # determines the action, not line count (t1679, code-simplifier.md).
 # Files must pass _complexity_scan_should_open_md_issue to be included —
 # this filters out stubs, short files, and frontmatter-only definitions.
-# Protected files (build.txt, AGENTS.md, pulse.md) are excluded — these are
+# Protected files (build.txt, AGENTS.md, pulse.md, pulse-sweep.md) are excluded — these are
 # core infrastructure that must be simplified manually with a maintainer present.
 # Results are sorted longest-first so biggest wins come early.
 # Arguments: $1 - aidevops_path
@@ -3744,11 +3753,11 @@ _complexity_scan_collect_md_violations() {
 	local aidevops_path="$1"
 
 	# Protected files and directories — excluded from automated simplification.
-	# - build.txt, AGENTS.md, pulse.md: core infrastructure (code-simplifier.md)
+	# - build.txt, AGENTS.md, pulse.md, pulse-sweep.md: core infrastructure (code-simplifier.md)
 	# - templates/: template files meant to be copied, not compressed
 	# - README.md: navigation/index docs, not instruction docs
 	# - todo/: planning files, not code
-	local protected_pattern='prompts/build\.txt|^\.agents/AGENTS\.md|^AGENTS\.md|scripts/commands/pulse\.md'
+	local protected_pattern='prompts/build\.txt|^\.agents/AGENTS\.md|^AGENTS\.md|scripts/commands/pulse\.md|scripts/commands/pulse-sweep\.md'
 	local excluded_dirs='_archive/|archived/|/templates/|/todo/'
 	local excluded_files='/README\.md$'
 
@@ -4441,7 +4450,7 @@ This is an automated scan. The function lengths are factual, but the best decomp
 # - .sh files: functions exceeding COMPLEXITY_FUNC_LINE_THRESHOLD lines
 # - .md files: all agent docs (no size gate — classification determines action, t1679)
 #
-# Protected files (build.txt, AGENTS.md, pulse.md) are excluded from
+# Protected files (build.txt, AGENTS.md, pulse.md, pulse-sweep.md) are excluded from
 # .md scanning — these are core infrastructure requiring manual review.
 #
 # Results are processed longest-first so the biggest wins come early
@@ -6460,9 +6469,15 @@ _Closed by deterministic merge pass (pulse-wrapper.sh)._" 2>/dev/null || true
 #   - Backlog is progressing (counts are decreasing)
 #   - Daily sweep not yet due
 #
+# Side effect: writes the trigger mode to ${PULSE_DIR}/llm_trigger_mode
+#   Values: "daily_sweep" | "stall" | "first_run"
+#   Callers read this file to select the correct agent prompt
+#   (pulse-sweep.md for daily_sweep, pulse.md for stall/first_run).
+#
 # State files:
 #   ${PULSE_DIR}/last_llm_run_epoch     — epoch of last LLM invocation
 #   ${PULSE_DIR}/backlog_snapshot.txt    — "epoch issues_count prs_count"
+#   ${PULSE_DIR}/llm_trigger_mode        — last trigger reason (daily_sweep|stall|first_run)
 #######################################
 PULSE_LLM_STALL_THRESHOLD="${PULSE_LLM_STALL_THRESHOLD:-1800}" # 30 min
 PULSE_LLM_DAILY_INTERVAL="${PULSE_LLM_DAILY_INTERVAL:-86400}"  # 24h
@@ -6481,6 +6496,7 @@ _should_run_llm_supervisor() {
 	local llm_age=$((now_epoch - last_llm_epoch))
 	if [[ "$llm_age" -ge "$PULSE_LLM_DAILY_INTERVAL" ]]; then
 		echo "[pulse-wrapper] LLM supervisor: daily sweep due (last run ${llm_age}s ago)" >>"$LOGFILE"
+		printf 'daily_sweep\n' >"${PULSE_DIR}/llm_trigger_mode"
 		return 0
 	fi
 
@@ -6490,6 +6506,7 @@ _should_run_llm_supervisor() {
 		# First run — take snapshot and run LLM
 		_update_backlog_snapshot "$now_epoch"
 		echo "[pulse-wrapper] LLM supervisor: first run (no snapshot)" >>"$LOGFILE"
+		printf 'first_run\n' >"${PULSE_DIR}/llm_trigger_mode"
 		return 0
 	fi
 
@@ -6526,6 +6543,7 @@ _should_run_llm_supervisor() {
 	if [[ "$snap_age" -ge "$PULSE_LLM_STALL_THRESHOLD" ]]; then
 		echo "[pulse-wrapper] LLM supervisor: backlog stalled for ${snap_age}s (issues=${current_issues} prs=${current_prs}, unchanged from ${snap_issues}+${snap_prs})" >>"$LOGFILE"
 		_update_backlog_snapshot "$now_epoch" "$current_issues" "$current_prs"
+		printf 'stall\n' >"${PULSE_DIR}/llm_trigger_mode"
 		return 0
 	fi
 
@@ -7020,10 +7038,24 @@ main() {
 	#
 	# This saves ~80% of supervisor tokens while maintaining identical
 	# dispatch and merge throughput.
+	#
+	# Trigger mode routing (GH#15287):
+	#   daily_sweep → /pulse-sweep (full edge-case triage, quality review, mission awareness)
+	#   stall / first_run → /pulse (lightweight dispatch+merge, unblocks the stall faster)
 	local skip_llm=false
+	local llm_trigger_mode="stall"
 	if [[ "${PULSE_FORCE_LLM:-0}" != "1" ]] && ! _should_run_llm_supervisor; then
 		skip_llm=true
 		echo "[pulse-wrapper] Skipping LLM supervisor (backlog progressing, daily sweep not due)" >>"$LOGFILE"
+	else
+		# Read the trigger mode written by _should_run_llm_supervisor
+		if [[ -f "${PULSE_DIR}/llm_trigger_mode" ]]; then
+			llm_trigger_mode=$(cat "${PULSE_DIR}/llm_trigger_mode" 2>/dev/null) || llm_trigger_mode="stall"
+		fi
+		# PULSE_FORCE_LLM=1 defaults to daily_sweep (full triage)
+		if [[ "${PULSE_FORCE_LLM:-0}" == "1" && "$llm_trigger_mode" == "stall" ]]; then
+			llm_trigger_mode="daily_sweep"
+		fi
 	fi
 
 	local pulse_duration=0
@@ -7036,7 +7068,7 @@ main() {
 
 		local pulse_start_epoch
 		pulse_start_epoch=$(date +%s)
-		run_pulse "$initial_underfilled_mode" "$initial_underfill_pct"
+		run_pulse "$initial_underfilled_mode" "$initial_underfill_pct" "$llm_trigger_mode"
 		local pulse_end_epoch
 		pulse_end_epoch=$(date +%s)
 		pulse_duration=$((pulse_end_epoch - pulse_start_epoch))


### PR DESCRIPTION
## Summary

- Create `pulse-sweep.md` (~527 lines) with all edge-case handling for daily sweeps: CHANGES_REQUESTED triage, external contributor review, semantic dedup, model escalation, stale coaching, quality review findings, mission awareness, repo hygiene, orphaned PR scanner, cross-repo TODO sync, framework issue routing, dedup health monitoring
- Slim `pulse.md` to 376 lines (<400): only dispatch and merge instructions needed for stall-triggered LLM invocations
- Update `pulse-wrapper.sh` to route daily sweeps to `/pulse-sweep` and stall triggers to `/pulse` via a new `trigger_mode` parameter on `run_pulse()`

## Acceptance Criteria

- [x] `pulse.md` < 400 lines (376 lines)
- [x] `pulse-sweep.md` contains all edge case handling from current `pulse.md`
- [x] No behavioral change — same edge cases handled, just split across two files
- [x] `pulse-wrapper.sh` routes `daily_sweep` trigger to `/pulse-sweep`, `stall`/`first_run` to `/pulse`

## Implementation Details

`_should_run_llm_supervisor()` now writes the trigger mode to `${PULSE_DIR}/llm_trigger_mode` (values: `daily_sweep` | `stall` | `first_run`). The caller reads this file and passes it as the third argument to `run_pulse()`, which selects the agent prompt accordingly.

`PULSE_FORCE_LLM=1` defaults to `daily_sweep` (full triage) when no prior trigger mode is recorded.

Both `pulse.md` and `pulse-sweep.md` are added to the protected files list in the complexity scanner to prevent auto-simplification.

## Runtime Testing

Risk level: **Low** — agent prompt docs and wrapper routing logic only. No data paths, no auth, no state mutations beyond a new state file write. Self-assessed.

## Files Changed

- `.agents/scripts/commands/pulse.md` — slimmed to 376 lines
- `.agents/scripts/commands/pulse-sweep.md` — new file, 527 lines
- `.agents/scripts/pulse-wrapper.sh` — trigger mode routing, protected files update

Closes #15287

---
[aidevops.sh](https://aidevops.sh) v3.5.570 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 10m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily sweep supervisor for automated, unattended control flow including capacity checks and intelligent work dispatch.

* **Documentation**
  * Simplified pulse runbook focusing on stall-unblocking and merge triage operations.
  * Enhanced automation trigger modes for improved supervisor routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->