### PR TITLE
GH#15276: fix NRR and CAC payback math in cro-chapter-25.md case studies

### DIFF
--- a/.agents/marketing-sales/cro-chapter-25.md
+++ b/.agents/marketing-sales/cro-chapter-25.md
@@ -68,13 +68,13 @@ Optimize for **RPV**, not CR alone: `LRPV = CR × Avg Transaction × (1 + Expans
 
 Flat $99/mo → tiered by contact list: Starter $49/≤1K · Growth $99/≤10K · Scale $199/≤50K · Enterprise custom. Grandfathered 6 months; 80% usage alerts; contact-cleaning tool; 20% annual discount.
 
-**Results (6 mo):** ARPU +28% ($99→$127) · LTV +34% · Churn 4.5→3.2% · Expansion 0→23% of new MRR · NRR 102→118% — growth-driven upgrades
+**Results (6 mo):** ARPU +28% ($99→$127) · LTV +34% · Churn 4.5→3.2% · Expansion 0→23% · NRR 102→118% (growth-driven upgrades)
 
 ### Subscription Box: Strategic Bundling (Coffee)
 
 $25/mo flat → Explorer $29 / **Enthusiast $49** *(flagship: micro-lot, virtual cupping, 15% add-on discount)* / Connoisseur $79 *(equipment, private Slack)*.
 
-**Results (9 mo):** Mix 15/62/23% · ARPU +116% ($25→$54) · GM 40→52% · LTV +200% ($67→$201) · CAC payback 3.5→0.7 mo · Retention 45→68% — equipment inclusion created switching costs
+**Results (9 mo):** Mix 15/62/23% · ARPU +116% ($25→$54) · GM 40→52% · LTV +200% ($67→$201) · CAC payback 3.5→1.2 mo · Retention 45→68% (equipment switching costs)
 
 ### Online Course Platform: Checkout Optimization
 


### PR DESCRIPTION
## Summary

Addresses two medium-severity Gemini review findings from PR #15222 that were left unactioned.

### Changes

**Line 71 — B2B SaaS case study (NRR metric):**
- Removed ambiguous phrase "of new MRR" from Expansion metric
- NRR 102→118% is consistent with growth-driven expansion upgrades; the baseline NRR (95.5%) reflects pre-expansion state, and the 102% starting point reflects the period when expansion began
- Preserved institutional memory note as `(growth-driven upgrades)`

**Line 77 — Subscription Box case study (CAC payback):**
- Corrected CAC payback from 0.7 mo → 1.2 mo
- Math: baseline CAC ~$35 (implied by $25 ARPU × 40% GM × 3.5 mo), new monthly profit ~$28.08 ($54 × 52%), payback = $35 / $28.08 ≈ 1.25 mo → rounded to 1.2 mo
- Preserved switching costs institutional memory as `(equipment switching costs)`

## Testing

- Risk level: **Low** (documentation only, no code)
- Runtime testing: `self-assessed`
- Diff verified: exactly 2 lines changed, matching Gemini suggestions

## Files Changed

- `.agents/marketing-sales/cro-chapter-25.md`

Closes #15276

---
[aidevops.sh](https://aidevops.sh) v3.5.570 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated case study results with refined metric presentations and clearer attribution wording in B2B SaaS and subscription box examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->