### PR TITLE
GH#14379: tighten remotion-lottie.md prose

### DIFF
--- a/.agents/tools/video/remotion-lottie.md
+++ b/.agents/tools/video/remotion-lottie.md
@@ -10,24 +10,18 @@ metadata:
 
 ## Prerequisites
 
-First, the @remotion/lottie package needs to be installed.  
-If it is not, use the following command:
+Install `@remotion/lottie`:
 
 ```bash
-npx remotion add @remotion/lottie # If project uses npm
-bunx remotion add @remotion/lottie # If project uses bun
-yarn remotion add @remotion/lottie # If project uses yarn
-pnpm exec remotion add @remotion/lottie # If project uses pnpm
+npx remotion add @remotion/lottie # npm
+bunx remotion add @remotion/lottie # bun
+yarn remotion add @remotion/lottie # yarn
+pnpm exec remotion add @remotion/lottie # pnpm
 ```
 
 ## Displaying a Lottie file
 
-To import a Lottie animation:
-
-- Fetch the Lottie asset
-- Wrap the loading process in `delayRender()` and `continueRender()`
-- Save the animation data in a state
-- Render the Lottie animation using the `Lottie` component from the `@remotion/lottie` package
+Fetch the asset inside `delayRender()`/`continueRender()`, store in state, render with `<Lottie>`:
 
 ```tsx
 import {Lottie, LottieAnimationData} from '@remotion/lottie';
@@ -61,7 +55,7 @@ export const MyAnimation = () => {
 
 ## Styling and animating
 
-Lottie supports the `style` prop to allow styles and animations:
+Use the `style` prop:
 
 ```tsx
 return <Lottie animationData={animationData} style={{width: 400, height: 400}} />;


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/tools/video/remotion-lottie.md` per the simplification issue.

**Classification**: Instruction doc (subagent operational procedures) — prose tightening, not restructuring.

### Changes

- Compressed verbose Prerequisites intro ("First, the @remotion/lottie package needs to be installed. If it is not, use the following command:") → "Install `@remotion/lottie`:"
- Removed redundant bullet list preamble (restated what the code example already shows)
- Tightened "Lottie supports the `style` prop to allow styles and animations:" → "Use the `style` prop:"
- Result: 68 → 62 lines

### Preservation verification

- All code blocks: ✅ (bash install block + 2 tsx blocks)
- All URLs: ✅ (`https://assets4.lottiefiles.com/packages/lf20_zyquagfl.json`)
- All command examples: ✅ (all 4 package manager variants: npm, bun, yarn, pnpm)
- No task IDs/GH refs in original: ✅ (nothing to preserve)
- Agent behavior unchanged: ✅

### Runtime Testing

**Risk level**: Low — docs/agent prompt only, no code execution path.
**Verification**: Self-assessed. All code blocks, URLs, and command examples verified present before and after.

Closes #14379


---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6