### PR TITLE
GH#13778: tighten rules-scripts.md, remove structural noise (regression fix)

### DIFF
--- a/.agents/content/heygen-skill/rules-scripts.md
+++ b/.agents/content/heygen-skill/rules-scripts.md
@@ -7,7 +7,7 @@ metadata:
 
 # Writing Scripts for HeyGen Videos
 
-AI avatar scripts differ from human presenter scripts — pacing, pauses, and pronunciation must be explicit.
+Pacing, pauses, and pronunciation must be explicit — AI avatars don't improvise.
 
 ## Speech Rate and Duration
 
@@ -94,11 +94,9 @@ Head to [location] to learn more. <break time="0.5s"/> We can't wait to hear wha
 
 ## Writing Tips
 
-**Do:** Write conversationally, use contractions, spell out abbreviations ("A-P-I"), end sections clearly.
-
-**Avoid:** Jargon without context, long parentheticals, ambiguous pronunciations, excessive `!`, run-ons, dense info without pauses.
-
-**Pronunciation:** Spell phonetically inline — `"Our API (A-P-I)"`, `"HeyGen (hey-jen)"`, `"I read (red) the docs"`.
+- Write conversationally; use contractions; end sections clearly
+- Spell out abbreviations: `"Our API (A-P-I)"`, `"HeyGen (hey-jen)"`, `"I read (red) the docs"`
+- Avoid: jargon without context, long parentheticals, ambiguous pronunciations, excessive `!`, run-ons, dense info without pauses
 
 ## Multi-Scene Scripts
 


### PR DESCRIPTION
## Summary

- Tighten intro sentence: same meaning, fewer words (removes redundant contrast clause)
- Collapse 3 bold-lead paragraphs (`**Do:**`, `**Avoid:**`, `**Pronunciation:**`) into 3 bullets — identical content, less structural noise
- 138 → 136 lines; zero actionable content removed

## Changes

- `.agents/content/heygen-skill/rules-scripts.md`: 4 insertions, 6 deletions

## Runtime Testing

Risk: **Low** — agent prompt/doc file only, no code paths. Self-assessed.

## Content Preservation

- All tables intact (speech rate, punctuation effects, pause reference, voice speed)
- All code blocks intact (break tag XML, all 3 script templates, multi-scene TypeScript, voice speed snippet)
- All break tag rules, pronunciation examples, and `voices.md` reference preserved
- No task IDs, incident references, or command examples were present to preserve

Closes #13778


---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m on this as a headless worker.