### PR TITLE
GH#14374: tighten email templates swipe file

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md
@@ -2,11 +2,9 @@
 
 Fill-in-the-blank templates for common email types.
 
----
-
 ## Quick Value Email
 
-```
+```text
 Subject: [Number]-minute tip to [benefit]
 
 Hey [Name],
@@ -20,11 +18,9 @@ Try it today and let me know how it goes.
 [Name]
 ```
 
----
-
 ## Story Email
 
-```
+```text
 Subject: [Intriguing statement from story]
 
 [Name],
@@ -42,11 +38,9 @@ The takeaway? [Connection to reader]
 [Name]
 ```
 
----
-
 ## Social Proof Email
 
-```
+```text
 Subject: How [Customer] got [Result]
 
 [Name],


### PR DESCRIPTION
## Summary

- Remove decorative `---` horizontal rules between sections (visual noise, no information value)
- Add `text` language specifier to all 3 fenced code blocks (fixes MD040 lint violations)
- All template content preserved with zero loss: Quick Value Email, Story Email, Social Proof Email
- 69 → 63 lines

## Classification

Reference corpus (swipe file templates). File was already appropriately sized at 69 lines — no splitting needed. Simplification limited to removing decorative separators and fixing pre-existing lint violations.

## Testing

- `markdownlint-cli2`: 0 errors (was 3 MD040 violations pre-fix)
- Content verification: all 3 templates present before and after, all placeholders intact
- Risk: Low (docs-only change) — self-assessed

## Runtime Testing

**Level:** Low (agent doc / reference corpus)
**Method:** self-assessed
**Evidence:** markdownlint-cli2 clean, content diff verified

Closes #14374


---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6