### PR TITLE
GH#14390: tighten bugfix branch doc prose

### DIFF
--- a/.agents/workflows/branch/bugfix.md
+++ b/.agents/workflows/branch/bugfix.md
@@ -30,17 +30,13 @@ git checkout -b bugfix/{description}
 
 ## When to Use
 
-- Non-urgent bug fixes
-- Issues that can wait for normal release cycle
-- Bugs found in development/staging
+- Non-urgent bug fixes, issues that can wait for the normal release cycle, bugs found in development/staging.
 
-**For urgent production issues**, use `hotfix/` instead.
+For urgent production issues, use `hotfix/` instead.
 
-## Unique Guidance
+## Guidance
 
-**Always add a regression test** to prevent the bug from recurring.
-
-For detailed bug investigation patterns, see `workflows/bug-fixing.md`.
+Always add a regression test to prevent recurrence. For investigation patterns, see `workflows/bug-fixing.md`.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/workflows/branch/bugfix.md` per simplification-debt issue.

- Compress 3-bullet "When to Use" to a single line (same information, less vertical space)
- Rename "Unique Guidance" → "Guidance" for consistency with `feature.md`
- Tighten "Guidance" prose: same rules, fewer words
- 63 → 59 lines; zero knowledge loss

## Verification

- All rules preserved: regression test requirement, `hotfix/` redirect, `workflows/bug-fixing.md` reference
- All code blocks, examples, commit example intact
- `bunx markdownlint-cli2` → 0 errors

## Runtime Testing

Risk: **Low** (docs/agent prompt only — no code, no logic, no runtime behaviour changed)
Level: `self-assessed`

Closes #14390


---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6