### PR TITLE
GH#14347: tighten screaming-frog.md agent doc

### DIFF
--- a/.agents/seo/screaming-frog.md
+++ b/.agents/seo/screaming-frog.md
@@ -17,35 +17,22 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Advanced site crawling and SEO auditing via CLI
-- **License**: **Paid license required** for CLI automation ($259/yr)
-- **Free Tier**: GUI only, limited to 500 URLs (CLI not supported in free mode)
+- **License**: Paid license required for CLI automation ($259/yr); free tier = GUI only, 500 URL cap
 - **Command**: `screamingfrogseospider` (requires alias/path setup)
 - **Output**: Headless mode supports CSV, PDF, and Google Sheets exports
 
-## Prerequisites
-
-1. **Installation**: Download from [screamingfrog.co.uk](https://www.screamingfrog.co.uk/seo-spider/)
-2. **License**: Enter license key in GUI first (`Help > Enter License`)
-3. **CLI Setup**:
-   - **macOS**: Alias required (see below)
-   - **Linux**: Standard package install
-   - **Windows**: Path configuration required
-
 ## Setup
 
-### macOS Alias
-
-Add to `~/.zshrc` or `~/.bashrc`:
+1. Download from [screamingfrog.co.uk](https://www.screamingfrog.co.uk/seo-spider/)
+2. Enter license key in GUI (`Help > Enter License`)
+3. **macOS**: Add alias to `~/.zshrc` or `~/.bashrc`:
 
 ```bash
 alias screamingfrogseospider="/Applications/Screaming\ Frog\ SEO\ Spider.app/Contents/MacOS/ScreamingFrogSEOSpiderLauncher"
 ```
 
-### Verification
-
-```bash
-screamingfrogseospider --help
-```
+4. **Linux**: Standard package install. **Windows**: Add install dir to PATH.
+5. Verify: `screamingfrogseospider --help`
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Tighten `.agents/seo/screaming-frog.md` per `build-agent.md` guidance (GH#14347).

**Changes:**
- Merged redundant `## Prerequisites` + `## Setup` sections into a single `## Setup` section
- Folded `### Verification` step inline as numbered list item (eliminates a heading for a single command)
- Collapsed `## Quick Reference` free/paid tier into one bullet
- Removed platform CLI setup sub-bullets that added no actionable info beyond "standard" / "path config"
- 75 → 62 lines (~17% reduction); zero content loss

**Verification:**
- All code blocks, URLs, command examples, and routing guidance preserved
- `markdownlint-cli2`: 0 errors
- Agent behaviour unchanged — same commands, same routing, same export options

Closes #14347

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code execution paths changed.
Self-assessed: content preservation verified by grep checks on all key identifiers.


---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6