### PR TITLE
GH#14428: tighten ad-creative-readme.md

### DIFF
--- a/.agents/marketing-sales/ad-creative-readme.md
+++ b/.agents/marketing-sales/ad-creative-readme.md
@@ -1,21 +1,6 @@
 # Ad Creative Mastery
 
-The complete guide to creating high-converting advertising creative for Meta, Google, and beyond.
-
-## What It Does
-
-This skill teaches you to create scroll-stopping ad creative that drives results. Covers everything from copywriting frameworks and video hooks to platform-specific tactics for Meta, Google, TikTok, and more.
-
-## Features
-
-- Platform-specific creative strategies (Meta, Google, TikTok)
-- 100+ proven headline formulas
-- Video ad hooks and scripts for first 3 seconds
-- UGC-style ad creation frameworks
-- Creative testing methodologies
-- Emotional triggers and psychological principles
-- Dynamic Creative Optimization (DCO)
-- Ad fatigue prevention strategies
+High-converting advertising creative for Meta, Google, TikTok, and beyond.
 
 ## Structure
 
@@ -37,22 +22,6 @@ Sub-documents (loaded on demand):
 
 Deep-dive chapters: see `CHAPTERS.md` (12 chapters covering video mastery, AI production, platform strategies, testing frameworks, and more).
 
-## Usage in aidevops
+## Usage
 
 Available at `marketing-sales/ad-creative*.md`. Reference via the Marketing agent or directly in prompts.
-
-## When to Use
-
-- Creating new ad campaigns on any platform
-- Writing ad copy and headlines
-- Producing video ads or UGC content
-- Testing new creative concepts
-- Optimizing underperforming ads
-- Planning seasonal or promotional campaigns
-
-## Requirements
-
-- Access to ad platforms (Meta Ads Manager, Google Ads, etc.)
-- Basic creative tools (Canva, Adobe, or similar)
-- Video editing software for video ads
-- Creative assets (images, logos, product shots)


### PR DESCRIPTION
## Summary

Tighten `.agents/marketing-sales/ad-creative-readme.md` per issue #14428 (simplification scan).

### Changes

- Removed redundant **What It Does** section (duplicated the title)
- Removed **Features** section (8 bullets duplicating the sub-document table descriptions)
- Removed **When to Use** section (implied by title and table)
- Removed **Requirements** section (user-facing boilerplate, not agent-operational)
- Preserved all operational content: sub-document index table, CHAPTERS.md reference, usage path

### Verification

- All 9 sub-document file references present before and after
- CHAPTERS.md reference preserved
- Usage path `marketing-sales/ad-creative*.md` preserved
- No code blocks, URLs, task IDs, or command examples in original — nothing to verify
- 58 lines → 27 lines (53% reduction), zero knowledge loss

## Runtime Testing

**Risk level:** Low (agent doc, no code, no scripts)
**Verification:** self-assessed — content preservation verified by inspection

Closes #14428


---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6