### PR TITLE
GH#14427: tighten recall.md agent doc

### DIFF
--- a/.agents/scripts/commands/recall.md
+++ b/.agents/scripts/commands/recall.md
@@ -13,8 +13,9 @@ Search query: $ARGUMENTS
 1. Run: `~/.aidevops/agents/scripts/memory-helper.sh recall "{query}"`
 2. Present results with type, tags, project, and age. Offer to apply selected memory to current context.
 3. No results: suggest different keywords, broader terms, or `--recent`.
+4. Search proactively when starting a project, encountering errors, making architecture decisions, or setting up tools. Check `--project {current-project}` at session start.
 
-## Search Options
+## Options
 
 | Command | Purpose |
 |---------|---------|
@@ -43,16 +44,12 @@ AI: Found 2 memories for "cors":
     Which memory is relevant to your current task?
 ```
 
-## Proactive Recall
-
-Search memories proactively when: starting a project, encountering errors, making architecture decisions, or setting up tools. Check `--project {current-project}` at session start.
-
 ## Maintenance
+
+Stale memories (>90 days, never accessed) are candidates for pruning.
 
 ```bash
 ~/.aidevops/agents/scripts/memory-helper.sh validate
 ~/.aidevops/agents/scripts/memory-helper.sh prune --dry-run
 ~/.aidevops/agents/scripts/memory-helper.sh prune
 ```
-
-Stale memories (>90 days, never accessed) are candidates for pruning.


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/recall.md` per GH#14427 simplification scan.

**Changes:**
- Merged standalone "Proactive Recall" section into Workflow step 4 (eliminates section header + blank lines)
- Renamed "Search Options" → "Options" for consistency with other command docs
- Moved stale-memory note before code block in Maintenance (better reading order)

**Result:** 58 → 55 lines. Zero content loss — all commands, types, examples, and task references preserved.

## Runtime Testing

Risk level: **Low** (docs/agent prompt only — no code, no scripts, no config).
Self-assessed: markdownlint-cli2 passes with 0 errors.

## Verification

- [x] `markdownlint-cli2` — 0 errors
- [x] All memory types present: `WORKING_SOLUTION`, `FAILED_APPROACH`, `USER_PREFERENCE`, `CODEBASE_PATTERN`, `DECISION`, `TOOL_CONFIG`
- [x] All commands present: `--recent`, `--project`, `--type`, `--stats`, `validate`, `prune`
- [x] Example block preserved intact
- [x] No broken references

Closes #14427

---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.