### PR TITLE
GH#14429: tighten agent doc Runner Templates (.agents/tools/ai-assistants/runners-README.md)

### DIFF
--- a/.agents/tools/ai-assistants/runners-README.md
+++ b/.agents/tools/ai-assistants/runners-README.md
@@ -5,7 +5,7 @@ mode: reference
 
 # Runner Templates
 
-Ready-to-use AGENTS.md templates for common runner types. Copy and customize for your needs.
+Ready-to-use AGENTS.md templates for common runner types. Copy and customize.
 
 ## Available Templates
 
@@ -17,38 +17,29 @@ Ready-to-use AGENTS.md templates for common runner types. Copy and customize for
 ## Creating a Runner from a Template
 
 ```bash
-# 1. Create the runner
 runner-helper.sh create my-runner --description "What it does"
-
-# 2. Open the AGENTS.md for editing
-runner-helper.sh edit my-runner
-
-# 3. Paste the template content from the files above
-
-# 4. Test it
+runner-helper.sh edit my-runner   # paste template content
 runner-helper.sh run my-runner "Your first task"
 ```
 
 ## Writing Your Own Runner Template
 
-A good runner AGENTS.md has four sections:
+Four required sections — keep under 500 words (runners get the full prompt on every dispatch):
 
-1. **Identity** - One sentence: who is this agent and what does it do
-2. **Checklist** - Specific items to check/do (not vague guidance)
-3. **Output format** - Exact structure of the response (tables, sections)
-4. **Rules** - Hard constraints (what to never do, when to escalate)
-
-Keep it under 500 words. Runners get the full prompt on every dispatch, so brevity matters.
+1. **Identity** — one sentence: who is this agent and what does it do
+2. **Checklist** — specific items to check/do (not vague guidance)
+3. **Output format** — exact structure of the response (tables, sections)
+4. **Rules** — hard constraints (what to never do, when to escalate)
 
 ## Evolving Runners into Shared Agents
 
-When a runner proves valuable across multiple projects, consider promoting it:
+When a runner proves valuable across multiple projects:
 
-1. **Draft** -- Save to `~/.aidevops/agents/draft/` with `status: draft` in frontmatter
-2. **Custom** -- Move to `~/.aidevops/agents/custom/` for permanent private use
-3. **Shared** -- Refine to framework standards and submit a PR to `.agents/` in the aidevops repo
+1. **Draft** — save to `~/.aidevops/agents/draft/` with `status: draft` in frontmatter
+2. **Custom** — move to `~/.aidevops/agents/custom/` for permanent private use
+3. **Shared** — refine to framework standards and submit a PR to `.agents/` in the aidevops repo
 
-Log a TODO item when a runner has reuse potential: `- [ ] tXXX Review runner {name} for promotion #agent-review`
+Log a TODO when a runner has reuse potential: `- [ ] tXXX Review runner {name} for promotion #agent-review`
 
 See `tools/build-agent/build-agent.md` "Agent Lifecycle Tiers" for the full promotion workflow.
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/ai-assistants/runners-README.md` per simplification-debt issue GH#14429.

**Classification**: Instruction doc (operational procedures for creating/using runners) — not a reference corpus.

**Changes**:
- Compressed verbose bash block comments (step numbers were self-evident)
- Tightened "Writing Your Own Runner Template" intro prose
- Compressed "Evolving Runners" intro sentence
- Removed redundant "Copy and customize for your needs" → "Copy and customize"
- Result: 57 → 48 lines (-16%)

**Preservation check**:
- [DONE] Template table (code-reviewer.md, seo-analyst.md) — present
- [DONE] All 4 runner sections (Identity, Checklist, Output format, Rules) — present
- [DONE] 500-word brevity rule — present
- [DONE] Promotion workflow (Draft → Custom → Shared) — present
- [DONE] Task ID pattern for promotion logging — present
- [DONE] Cross-references (build-agent.md, headless-dispatch.md) — present
- [DONE] No broken internal links

Closes #14429

## Runtime Testing

Risk: **Low** — docs-only change, no code, no scripts. Self-assessed.


---
[aidevops.sh](https://aidevops.sh) v3.5.572 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m on this as a headless worker.