### PR TITLE
GH#14430: tighten warmforge.md agent doc

### DIFF
--- a/.agents/services/outreach/warmforge.md
+++ b/.agents/services/outreach/warmforge.md
@@ -13,11 +13,19 @@ tools:
 
 ## Quick Reference
 
-- Use WarmForge to monitor domain-level deliverability signals and automate mailbox warmup state transitions
-- Keep warmup deterministic: only one active schedule profile per mailbox (`conservative`, `standard`, or `aggressive`)
-- Gate scale decisions on evidence: improve volume only after at least 7 days of stable health (low bounce, low spam-folder drift, steady positive reply baseline)
-- Pause warmup automatically on anomaly thresholds (bounce spike, complaint spike, sudden inbox-placement drop)
-- Resume warmup with reduced profile after remediation; never jump directly back to prior peak volume
+- Monitor domain-level deliverability signals; automate mailbox warmup state transitions
+- One active schedule profile per mailbox: `conservative`, `standard`, or `aggressive`
+- Scale only after 7+ days of stable health (low bounce, low spam-folder drift, steady positive reply baseline)
+- Auto-pause on anomaly thresholds (bounce spike, complaint spike, inbox-placement drop)
+- Resume with reduced profile after remediation — never jump back to prior peak volume
+
+### Operational Policy
+
+1. Check `health` and `domains` before any orchestration command.
+2. Pull `deliverability` metrics for the active domain window (default `7d`).
+3. Stable health → `warmup-start` or `warmup-resume`.
+4. Degraded metrics → `warmup-pause`; open incident note with root-cause hypothesis.
+5. After remediation → resume with lower profile before re-scaling.
 
 ### Helper Script
 
@@ -38,20 +46,10 @@ Use `.agents/scripts/warmforge-helper.sh` for API access.
 - `WARMFORGE_API_KEY` (required)
 - `WARMFORGE_API_BASE_URL` (optional, defaults to `https://api.warmforge.ai/v1`)
 
-### Operational Policy
-
-1. Check `health` and `domains` before running orchestration commands.
-2. Pull `deliverability` metrics for the active domain window (default `7d`).
-3. If health is stable, run `warmup-start` or `warmup-resume` for the mailbox.
-4. If metrics degrade, run `warmup-pause` and open an incident note with root-cause hypothesis.
-5. Re-check after remediation and resume with a lower profile before re-scaling.
-
 ### Failure Handling
 
-- Treat HTTP 4xx as configuration/auth problems first (token scope, mailbox ID, domain ID)
-- Treat HTTP 5xx as provider-side reliability incidents; retry with backoff and preserve request context for debugging
-- Keep API-key handling terminal-local only; never paste secrets into chat or issue comments
+- HTTP 4xx → configuration/auth problem (token scope, mailbox ID, domain ID)
+- HTTP 5xx → provider-side incident; retry with backoff, preserve request context
+- API keys: terminal-local only; never paste into chat or issue comments
 
 <!-- AI-CONTEXT-END -->
-
-This document defines the baseline WarmForge operating model for deliverability monitoring and warmup orchestration tasks.


### PR DESCRIPTION
## Summary

Tighten `.agents/services/outreach/warmforge.md` per issue #14430 (automated simplification scan).

### Changes

- Removed redundant trailing summary line (duplicate of frontmatter `description`)
- Tightened Quick Reference bullets — removed filler phrases ("Use WarmForge to", "Keep warmup deterministic:", "Gate scale decisions on evidence:")
- Reordered sections: Operational Policy moved before Helper Script (decision logic first, tools second — primacy effect)
- Compressed Operational Policy steps (removed verbose conditionals → arrow notation)
- Compressed Failure Handling prose (removed "Treat HTTP 4xx as" → "HTTP 4xx →")

### Verification

- All commands, environment variables, and operational rules preserved
- All security rules preserved (API key handling, no secrets in chat)
- Line count: 57 → 55 (content reduction, not just whitespace)
- Risk level: **Low** (docs/agent prompt only, no code changes)

## Runtime Testing

**Level: self-assessed** — docs/agent prompt change only. No code paths affected.

Closes #14430

---
[aidevops.sh](https://aidevops.sh) v3.5.577 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.