### PR TITLE
GH#15317: fix dispatch claim system — 5 design flaws causing duplicate dispatch

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -119,6 +119,6 @@ export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-code
 
 Every action must leave a trace in issue/PR comments. Version from `~/.aidevops/agents/VERSION` or `$AIDEVOPS_VERSION`. All templates include `**[aidevops.sh](https://github.com/marcusquinn/aidevops)**: vX.X.X` + `**Model**` + `**Branch**`.
 
-**Dispatch:** `Dispatching worker.` + Scope, Attempt (N of M), Direction.
+**Dispatch:** Posted automatically by `dispatch_with_dedup()` (GH#15317). Do NOT post manually.
 **Kill/failure:** `Worker killed after Xh Ym with N commits (struggle_ratio: NN).` + Reason, Diagnosis, Next action (escalate/reassign/decompose).
 **Completion:** `Completed via PR #NNN.` + Attempts, Duration.

--- a/.agents/scripts/commands/pulse-sweep.md
+++ b/.agents/scripts/commands/pulse-sweep.md
@@ -457,16 +457,10 @@ SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer \
   --model "<full model ID>" --issue "<slug>#<number>")
 ```
 
-**Dispatch comment** (post on issue when dispatching):
-
-```text
-Dispatching worker.
-- **Branch**: <branch name>
-- **Scope**: <1-line description>
-- **Attempt**: <N of M>
-- **Direction**: <specific guidance>
-${SIG_FOOTER}
-```
+**Dispatch comment** — posted automatically by `dispatch_with_dedup()` (GH#15317).
+Do NOT post a "Dispatching worker" comment manually — the function handles it
+deterministically after confirming the worker PID is alive. Duplicate dispatch
+comments break the Layer 5 dedup check.
 
 **Kill/failure comment**:
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -330,16 +330,10 @@ SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer \
   --model "<full model ID>" --issue "<slug>#<number>")
 ```
 
-**Dispatch comment** (post on issue when dispatching):
-
-```text
-Dispatching worker.
-- **Branch**: <branch name>
-- **Scope**: <1-line description>
-- **Attempt**: <N of M>
-- **Direction**: <specific guidance>
-${SIG_FOOTER}
-```
+**Dispatch comment** — posted automatically by `dispatch_with_dedup()` (GH#15317).
+Do NOT post a "Dispatching worker" comment manually — the function handles it
+deterministically after confirming the worker PID is alive. Duplicate dispatch
+comments break the Layer 5 dedup check.
 
 **Kill/failure comment**:
 

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -41,8 +41,9 @@ DISPATCH_CLAIM_WINDOW="${DISPATCH_CLAIM_WINDOW:-8}"
 # Claims older than this are stale and ignored by the lock check.
 DISPATCH_CLAIM_MAX_AGE="${DISPATCH_CLAIM_MAX_AGE:-120}"
 
-# When the oldest active claim belongs to this same runner and is older than
-# this threshold, reclaim the lock by deleting only the fresh duplicate claim.
+# GH#15317: Self-reclaim removed. Previously, same-runner stale claims were
+# "reclaimed" after this threshold, creating dispatch loops. Now stale self-
+# claims are cleaned up and treated as lost. Variable kept for backward compat.
 DISPATCH_CLAIM_SELF_RECLAIM_AGE="${DISPATCH_CLAIM_SELF_RECLAIM_AGE:-30}"
 
 # Claim comment marker — used as both the posting format and the search pattern.
@@ -309,11 +310,31 @@ cmd_claim() {
 		return 0
 	fi
 
-	if [[ "$oldest_runner" == "$runner" && "$oldest_age_seconds" -ge "$DISPATCH_CLAIM_SELF_RECLAIM_AGE" ]]; then
-		printf 'CLAIM_RECLAIMED: runner=%s reclaimed stale claim nonce=%s on issue #%s (stale_nonce=%s stale_age_s=%s)\n' \
-			"$runner" "$nonce" "$issue_number" "$oldest_nonce" "$oldest_age_seconds"
+	# GH#15317: Self-reclaim removed. Previously, if the oldest claim belonged to
+	# the same runner and was >30s old, the runner would "reclaim" — allowing
+	# re-dispatch. This created same-runner dispatch loops: claim → dispatch →
+	# worker dies → 30s passes → self-reclaim → dispatch again. Evidence:
+	# awardsapp #2051 had 25 claims from alex-solovyev over 6 hours.
+	#
+	# The dispatch_with_dedup() caller now posts a deterministic "Dispatching
+	# worker" comment and cleans up claim comments after dispatch. If a worker
+	# needs to be re-dispatched, the pulse must first post a kill/failure comment
+	# and remove the dispatch comment — making the re-dispatch explicit, not
+	# an implicit side effect of stale claims.
+	#
+	# If the oldest claim is from the same runner, treat as a lost claim (stale
+	# from a previous cycle that wasn't cleaned up). Delete both claims.
+	if [[ "$oldest_runner" == "$runner" && "$oldest_nonce" != "$nonce" ]]; then
+		printf 'CLAIM_STALE_SELF: runner=%s found own stale claim on issue #%s (stale_age_s=%s) — cleaning up\n' \
+			"$runner" "$issue_number" "$oldest_age_seconds"
+		# Delete both the stale claim and the fresh one we just posted
+		local stale_comment_id
+		stale_comment_id=$(printf '%s' "$claims" | jq -r '.[0].id // ""' 2>/dev/null) || stale_comment_id=""
+		if [[ -n "$stale_comment_id" ]]; then
+			_delete_comment "$repo_slug" "$stale_comment_id" 2>/dev/null || true
+		fi
 		_delete_comment "$repo_slug" "$comment_id" 2>/dev/null || true
-		return 0
+		return 1
 	fi
 
 	# Step 5: We lost — another runner's claim is older

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -833,7 +833,14 @@ has_dispatch_comment() {
 		return 1
 	fi
 
-	# Fetch recent comments and look for "Dispatching worker" from non-self authors
+	# Fetch recent comments and look for "Dispatching worker" comments.
+	# GH#15317: Check ALL dispatch comments regardless of author. Previously,
+	# self-posted comments were skipped (self_login filter), which allowed the
+	# same runner to re-dispatch every cycle — its own dispatch comment was
+	# invisible to its own dedup check. Evidence: awardsapp #2040 had
+	# alex-solovyev dispatch twice (20:33 and 22:57) because Layer 5 skipped
+	# its own dispatch comment. The self_login parameter is now unused by this
+	# function but kept in the signature for backward compatibility.
 	local comments_json
 	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--jq '[.[] | select(.body | startswith("Dispatching worker")) | {author: .user.login, created_at: .created_at}]' \
@@ -843,20 +850,15 @@ has_dispatch_comment() {
 		return 1
 	fi
 
-	# Check each dispatch comment
+	# Check each dispatch comment — any recent dispatch blocks, regardless of author
 	local count
 	count=$(printf '%s' "$comments_json" | jq 'length' 2>/dev/null) || count=0
 
 	local i
 	for i in $(seq 0 $((count - 1))); do
-		local author created_at
-		author=$(printf '%s' "$comments_json" | jq -r ".[$i].author // \"\"" 2>/dev/null) || author=""
+		local created_at author
 		created_at=$(printf '%s' "$comments_json" | jq -r ".[$i].created_at // \"\"" 2>/dev/null) || created_at=""
-
-		# Skip self-posted comments
-		if [[ -n "$self_login" && "$author" == "$self_login" ]]; then
-			continue
-		fi
+		author=$(printf '%s' "$comments_json" | jq -r ".[$i].author // \"\"" 2>/dev/null) || author=""
 
 		# Check age
 		if [[ -n "$created_at" ]]; then

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5234,9 +5234,14 @@ check_dispatch_dedup() {
 	# Exit codes from claim: 0=won, 1=lost, 2=error (fail-open).
 	# On error (exit 2), we allow dispatch to proceed — better to risk a rare
 	# duplicate than to block all dispatch on a transient GitHub API failure.
+	#
+	# GH#15317: Capture claim output to extract comment_id for cleanup after
+	# the deterministic dispatch comment is posted.
+	local _claim_comment_id=""
 	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
-		local claim_exit=0
-		"$dedup_helper" claim "$issue_number" "$repo_slug" "$self_login" >>"$LOGFILE" 2>&1 || claim_exit=$?
+		local claim_exit=0 claim_output=""
+		claim_output=$("$dedup_helper" claim "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE") || claim_exit=$?
+		echo "$claim_output" >>"$LOGFILE"
 		if [[ "$claim_exit" -eq 1 ]]; then
 			echo "[pulse-wrapper] Dedup: claim lost for #${issue_number} in ${repo_slug} — another runner claimed first (GH#11086)" >>"$LOGFILE"
 			return 0
@@ -5244,6 +5249,8 @@ check_dispatch_dedup() {
 		if [[ "$claim_exit" -eq 2 ]]; then
 			echo "[pulse-wrapper] Dedup: claim error for #${issue_number} in ${repo_slug} — proceeding (fail-open)" >>"$LOGFILE"
 		fi
+		# Extract claim comment_id for post-dispatch cleanup (GH#15317)
+		_claim_comment_id=$(printf '%s' "$claim_output" | sed -n 's/.*comment_id=\([0-9]*\).*/\1/p')
 		# claim_exit 0 = won, proceed to dispatch
 	fi
 
@@ -5393,6 +5400,34 @@ dispatch_with_dedup() {
 	if [[ -x "$ledger_helper" ]]; then
 		"$ledger_helper" record --issue "$issue_number" --repo "$repo_slug" \
 			--pid "$worker_pid" --title "$dispatch_title" 2>/dev/null || true
+	fi
+
+	# GH#15317: Post deterministic "Dispatching worker" comment from the dispatcher,
+	# not from the worker LLM session. Previously, the worker was responsible for
+	# posting this comment — but workers could crash before posting, leaving no
+	# persistent signal. Without this signal, Layer 5 (has_dispatch_comment) had
+	# nothing to find, and the issue would be re-dispatched every pulse cycle.
+	# Evidence: awardsapp #2051 accumulated 29 DISPATCH_CLAIM comments over 6 hours
+	# because workers kept dying before posting.
+	local dispatch_comment_body
+	dispatch_comment_body="Dispatching worker (deterministic).
+- **Worker PID**: ${worker_pid}
+- **Model**: ${selected_model}
+- **Runner**: ${self_login}
+- **Issue**: #${issue_number}"
+	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--method POST --field body="$dispatch_comment_body" \
+		>/dev/null 2>>"$LOGFILE" || {
+		echo "[dispatch_with_dedup] Warning: failed to post deterministic dispatch comment for #${issue_number}" >>"$LOGFILE"
+	}
+
+	# GH#15317: Clean up the DISPATCH_CLAIM comment now that the persistent
+	# dispatch comment is posted. The claim served its purpose (optimistic lock
+	# during the 8s consensus window). Leaving it pollutes the issue timeline —
+	# awardsapp #2051 had 29 stale claim comments.
+	if [[ -n "$_claim_comment_id" ]]; then
+		gh api "repos/${repo_slug}/issues/comments/${_claim_comment_id}" \
+			--method DELETE >/dev/null 2>>"$LOGFILE" || true
 	fi
 
 	echo "[dispatch_with_dedup] Dispatched worker PID ${worker_pid} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -285,9 +285,13 @@ test_env_var_defaults() {
 }
 
 #######################################
-# Test: stale same-runner oldest claim is reclaimed successfully
+# Test: stale same-runner oldest claim is cleaned up and rejected (GH#15317)
+#
+# Previously this tested self-reclaim (CLAIM_RECLAIMED, exit 0). After
+# GH#15317, same-runner stale claims are treated as lost to prevent
+# dispatch loops. The stale claim and fresh claim are both deleted.
 #######################################
-test_claim_reclaims_stale_same_runner_claim() {
+test_claim_rejects_stale_same_runner_claim() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
 	local mock_path
@@ -309,22 +313,27 @@ test_claim_reclaims_stale_same_runner_claim() {
 	exit_code=$?
 	set -e
 
-	if [[ "$exit_code" -eq 0 ]]; then
-		print_result "stale same-runner claim exits 0" 0
+	if [[ "$exit_code" -eq 1 ]]; then
+		print_result "stale same-runner claim exits 1 (rejected)" 0
 	else
-		print_result "stale same-runner claim exits 0" 1 "got exit $exit_code output: $output"
+		print_result "stale same-runner claim exits 1 (rejected)" 1 "got exit $exit_code output: $output"
 	fi
 
-	if printf '%s' "$output" | grep -q "CLAIM_RECLAIMED:"; then
-		print_result "stale same-runner claim emits CLAIM_RECLAIMED" 0
+	if printf '%s' "$output" | grep -q "CLAIM_STALE_SELF:"; then
+		print_result "stale same-runner claim emits CLAIM_STALE_SELF" 0
 	else
-		print_result "stale same-runner claim emits CLAIM_RECLAIMED" 1 "output: $output"
+		print_result "stale same-runner claim emits CLAIM_STALE_SELF" 1 "output: $output"
 	fi
 
-	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -q '^999$' "${tmp_dir}/delete_ids.log"; then
-		print_result "stale reclaim deletes only fresh duplicate claim" 0
+	# Both the stale claim (id=1) and fresh claim (id=999) should be deleted
+	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -q '^1$' "${tmp_dir}/delete_ids.log" && grep -q '^999$' "${tmp_dir}/delete_ids.log"; then
+		print_result "stale self-claim deletes both stale and fresh claims" 0
 	else
-		print_result "stale reclaim deletes only fresh duplicate claim" 1 "missing delete id 999"
+		local delete_log=""
+		if [[ -f "${tmp_dir}/delete_ids.log" ]]; then
+			delete_log=$(<"${tmp_dir}/delete_ids.log")
+		fi
+		print_result "stale self-claim deletes both stale and fresh claims" 1 "deleted: ${delete_log:-none}"
 	fi
 
 	rm -rf "$tmp_dir"
@@ -332,9 +341,14 @@ test_claim_reclaims_stale_same_runner_claim() {
 }
 
 #######################################
-# Test: fresh same-runner oldest claim still loses
+# Test: fresh same-runner oldest claim is also rejected (GH#15317)
+#
+# After GH#15317, ALL same-runner duplicate claims (fresh or stale)
+# are rejected with CLAIM_STALE_SELF. Both the stale and fresh claims
+# are deleted. This prevents dispatch loops where the same runner
+# keeps reclaiming its own stale claims.
 #######################################
-test_claim_loses_on_fresh_same_runner_claim() {
+test_claim_rejects_fresh_same_runner_claim() {
 	local tmp_dir
 	tmp_dir="$(mktemp -d)"
 	local mock_path
@@ -357,21 +371,26 @@ test_claim_loses_on_fresh_same_runner_claim() {
 	set -e
 
 	if [[ "$exit_code" -eq 1 ]]; then
-		print_result "fresh same-runner claim exits 1" 0
+		print_result "fresh same-runner claim exits 1 (rejected)" 0
 	else
-		print_result "fresh same-runner claim exits 1" 1 "got exit $exit_code output: $output"
+		print_result "fresh same-runner claim exits 1 (rejected)" 1 "got exit $exit_code output: $output"
 	fi
 
-	if printf '%s' "$output" | grep -q "CLAIM_LOST: runner=marcusquinn lost to marcusquinn"; then
-		print_result "fresh same-runner claim emits CLAIM_LOST" 0
+	if printf '%s' "$output" | grep -q "CLAIM_STALE_SELF:"; then
+		print_result "fresh same-runner claim emits CLAIM_STALE_SELF" 0
 	else
-		print_result "fresh same-runner claim emits CLAIM_LOST" 1 "output: $output"
+		print_result "fresh same-runner claim emits CLAIM_STALE_SELF" 1 "output: $output"
 	fi
 
-	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -q '^999$' "${tmp_dir}/delete_ids.log"; then
-		print_result "fresh same-runner loss deletes fresh claim" 0
+	# Both claims should be deleted
+	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -q '^1$' "${tmp_dir}/delete_ids.log" && grep -q '^999$' "${tmp_dir}/delete_ids.log"; then
+		print_result "fresh same-runner deletes both claims" 0
 	else
-		print_result "fresh same-runner loss deletes fresh claim" 1 "missing delete id 999"
+		local delete_log=""
+		if [[ -f "${tmp_dir}/delete_ids.log" ]]; then
+			delete_log=$(<"${tmp_dir}/delete_ids.log")
+		fi
+		print_result "fresh same-runner deletes both claims" 1 "deleted: ${delete_log:-none}"
 	fi
 	return 0
 }
@@ -390,8 +409,8 @@ main() {
 	test_unknown_command
 	test_dedup_claim_routing
 	test_env_var_defaults
-	test_claim_reclaims_stale_same_runner_claim
-	test_claim_loses_on_fresh_same_runner_claim
+	test_claim_rejects_stale_same_runner_claim
+	test_claim_rejects_fresh_same_runner_claim
 
 	echo ""
 	echo "Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed"


### PR DESCRIPTION
## Summary

Fixes 5 design flaws in the dispatch claim system that caused duplicate worker dispatches, claim comment spam, and same-runner dispatch loops.

Closes #15317

## Root Causes Fixed

### Fix 1: Deterministic "Dispatching worker" comment (pulse-wrapper.sh)
**Problem**: The "Dispatching worker" comment was LLM-posted by the worker session. Workers could crash before posting, leaving no persistent signal for Layer 5 dedup. Without this signal, the issue would be re-dispatched every pulse cycle.

**Fix**: `dispatch_with_dedup()` now posts the comment deterministically after confirming the worker PID is alive. Workers no longer need to post this comment.

**Evidence**: <webapp> #2051 had 29 DISPATCH_CLAIM comments over 6 hours because workers kept dying before posting.

### Fix 2: Remove self-skip in Layer 5 (dispatch-dedup-helper.sh)
**Problem**: `has_dispatch_comment()` skipped comments from `self_login`. The same runner's dispatch comment was invisible to its own dedup check, allowing re-dispatch every cycle.

**Fix**: All dispatch comments block regardless of author. The `self_login` parameter is kept for backward compatibility but no longer filters.

**Evidence**: <webapp> #2040 had alex-solovyev dispatch twice (20:33 and 22:57) because Layer 5 skipped its own dispatch comment.

### Fix 3: Remove self-reclaim from claim protocol (dispatch-claim-helper.sh)
**Problem**: After 30s, the same runner could "reclaim" its own stale claim, enabling re-dispatch loops: claim → dispatch → worker dies → 30s → self-reclaim → dispatch again.

**Fix**: Stale same-runner claims are now treated as lost (exit 1). Both the stale claim and the fresh one are deleted. Re-dispatch requires explicit kill/failure comment from the pulse.

**Evidence**: <webapp> #2051 had 25 claims from alex-solovyev over 6 hours via self-reclaim loop.

### Fix 4: Clean up DISPATCH_CLAIM comment after dispatch (pulse-wrapper.sh)
**Problem**: Winner claim comments persisted forever as "audit trail", producing comment spam on issues.

**Fix**: After posting the deterministic dispatch comment, `dispatch_with_dedup()` deletes the DISPATCH_CLAIM comment. The claim served its purpose (8s consensus window); the dispatch comment is the persistent signal.

### Fix 5: Document automatic dispatch comment posting (pulse.md, pulse-sweep.md, automate.md)
**Problem**: pulse.md instructed the LLM to post "Dispatching worker" manually — could produce duplicates or be skipped entirely.

**Fix**: Updated docs to note that `dispatch_with_dedup()` posts this comment automatically. LLM sessions no longer need to post it.

## Files Changed

- `.agents/scripts/dispatch-claim-helper.sh` — Remove self-reclaim, add stale-self detection
- `.agents/scripts/dispatch-dedup-helper.sh` — Remove self-skip in `has_dispatch_comment()`
- `.agents/scripts/pulse-wrapper.sh` — Post deterministic dispatch comment, clean up claim comment
- `.agents/scripts/commands/pulse.md` — Document automatic dispatch comment
- `.agents/scripts/commands/pulse-sweep.md` — Document automatic dispatch comment
- `.agents/automate.md` — Document automatic dispatch comment
- `.agents/scripts/tests/test-dispatch-claim-helper.sh` — Tests for new self-reclaim behavior

## Runtime Testing

**Risk level**: High (dispatch coordination, state machines, cross-machine locking)

- [x] ShellCheck: zero violations on all modified scripts
- [x] Unit tests: 17/17 pass (`test-dispatch-claim-helper.sh`)
- [x] Logic verified: self-reclaim loop eliminated, Layer 5 now blocks self-dispatches
- [ ] Integration test: requires live multi-runner environment (not available in this session)

## Key Decisions

- **Self-reclaim → exit 1 (not exit 2)**: Treating stale self-claims as errors (fail-open) would recreate the loop. Explicit rejection forces the pulse to use the kill/failure comment flow for re-dispatch.
- **`self_login` kept in `has_dispatch_comment` signature**: Backward compatibility — callers pass it; removing it would require updating all call sites.
- **Claim comment deleted, not minimized**: Minimized comments still appear in the timeline. Deletion keeps the issue clean.

---
[aidevops.sh](https://aidevops.sh) v3.5.580 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispatch comments are now posted automatically after worker launch instead of requiring manual creation.

* **Bug Fixes**
  * Prevents duplicate "Dispatching worker" comments that could interfere with deduplication checks.
  * Improved detection and cleanup of stale dispatch claims.

* **Documentation**
  * Updated dispatch workflow guidelines to reflect automatic comment posting and remove manual posting instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->