### PR TITLE
GH#14529: record cro-chapter-11.md as simplified in simplification-state.json

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3385,6 +3385,11 @@
       "hash": "134632d988b4e18e35f9e3c90106391f8461c114",
       "at": "2026-04-01T21:56:13Z",
       "pr": null
+    },
+    ".agents/marketing-sales/cro-chapter-11.md": {
+      "hash": "be3bf907be217b866da1d7990427e4fc1c925971",
+      "at": "2026-04-01T22:00:00Z",
+      "pr": 14514
     }
   }
 }


### PR DESCRIPTION
## Summary

The file `.agents/marketing-sales/cro-chapter-11.md` was already split into 9 chapter files under `cro-chapter-11/` by PR #14514 (merged). The issue was created when the file was 133 lines; it is now 29 lines (slim index) with 125 lines across 9 chapter files.

This PR registers the completed split in `simplification-state.json` so the automated scan does not re-flag it.

## Changes

- `.agents/configs/simplification-state.json` — added entry for `.agents/marketing-sales/cro-chapter-11.md` pointing to PR #14514

## Verification

- File is 29 lines (slim index) ✓
- 9 chapter files exist under `cro-chapter-11/` totaling 125 lines ✓
- All content preserved (zero content loss) ✓
- simplification-state.json entry added with correct hash and PR reference ✓

## Runtime Testing

Risk: **Low** — documentation/config file only, no code execution paths affected.
Level: `self-assessed`

Closes #14529


---
[aidevops.sh](https://aidevops.sh) v3.5.582 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m on this as a headless worker.