### PR TITLE
GH#14528: tighten curl-copy.md agent doc (133→123 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3380,6 +3380,11 @@
       "hash": "4c6d024fd0bd6ab3cbc9881e5cd83bd7dec582e4",
       "at": "2026-04-01T21:00:01Z",
       "pr": 14853
+    },
+    ".agents/tools/browser/curl-copy.md": {
+      "hash": "134632d988b4e18e35f9e3c90106391f8461c114",
+      "at": "2026-04-01T21:56:13Z",
+      "pr": null
     }
   }
 }

--- a/.agents/tools/browser/curl-copy.md
+++ b/.agents/tools/browser/curl-copy.md
@@ -16,13 +16,11 @@ tools:
 
 <!-- AI-CONTEXT-START -->
 
-## Quick Reference
-
-- **Purpose**: Extract data from authenticated pages with the browser's live session cookies
+- **Purpose**: Extract data from authenticated pages using the browser's live session cookies
 - **Setup**: Browser DevTools + `curl` (built into macOS/Linux)
 - **Best for**: Dashboards, gated content, private APIs, admin panels, one-off debugging
 - **Use when**: one-off extraction from an authenticated page or internal API
-- **Don't use when**: repeated jobs -> `sweet-cookie`; interaction required -> Playwright/Stagehand; bulk crawling -> Crawl4AI; long-lived sessions -> persistent browser tooling
+- **Don't use when**: repeated jobs → `sweet-cookie`; interaction required → Playwright/Stagehand; bulk crawling → Crawl4AI
 
 ```text
 Need data from an authenticated page?
@@ -36,21 +34,13 @@ Need data from an authenticated page?
 
 ## Workflow
 
-### 1. Copy a real request from DevTools
-
-1. Open the target page in Chrome, Firefox, Edge, or Safari.
-2. Open DevTools (`Cmd+Option+I` on macOS, `F12` on Windows/Linux).
-3. In **Network**, filter to `Fetch/XHR`.
-4. Reload or repeat the action that loads the data.
-5. Right-click the request -> **Copy** -> **Copy as cURL**.
-
-- Chrome/Edge: `Copy as cURL (bash)`
-- Firefox: `Copy Value -> Copy as cURL`
-- Safari: `Copy as cURL`
-
-### 2. Execute and reshape the response
-
-Paste the copied command into a terminal or local AI assistant. It already contains the active headers, cookies, and auth state.
+1. Open the target page; open DevTools (`Cmd+Option+I` / `F12`).
+2. In **Network**, filter to `Fetch/XHR`; reload or repeat the action.
+3. Right-click the request → **Copy** → **Copy as cURL**:
+   - Chrome/Edge: `Copy as cURL (bash)`
+   - Firefox: `Copy Value → Copy as cURL`
+   - Safari: `Copy as cURL`
+4. Paste into a terminal or local AI assistant — the command already contains active headers, cookies, and auth state.
 
 ```bash
 # Example copied command (headers truncated)
@@ -99,7 +89,7 @@ curl 'https://app.example.com/graphql' \
 ## Operating Notes
 
 | Topic | Guidance |
-|------|----------|
+|-------|----------|
 | Find the right request | Stay in `Fetch/XHR`, inspect **Response/Preview**, search by URL path |
 | Session lifetime | Keep the tab open if possible; copy a fresh command after `401/403` |
 | Sharing safely | Strip `cookie`, `authorization`, and `x-csrf-token` before sharing |


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/browser/curl-copy.md` per issue #14528 (agent doc simplification scan).

**Classification:** Instruction doc (agent rules, workflow, decision tree) — not a reference corpus. Correct action: tighten prose, not split into chapters.

## Changes

- Removed redundant `## Quick Reference` subheader — content preserved inline under `<!-- AI-CONTEXT-START -->`
- Merged 5-step DevTools workflow + browser-specific bullet list into a single 4-step numbered flow
- Removed redundant `### Execute and reshape the response` subheader and its intro sentence (content follows immediately in the code block)
- Removed redundant "long-lived sessions → persistent browser tooling" from Don't-use-when (already covered by the decision tree)
- Unicode arrows (`→`) for consistency
- 133 → 123 lines (8% reduction)

## Verification

- All code blocks preserved (curl examples, transforms, practical patterns)
- All tables preserved (Operating Notes, Method Comparison, Troubleshooting)
- All Related links preserved
- Decision tree preserved
- No task IDs or incident references in this file (none to preserve)
- Agent behaviour unchanged — same instructions, tighter prose

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution paths changed.
**Assessment:** self-assessed (no runtime required for doc-only changes)

Closes #14528

---
[aidevops.sh](https://aidevops.sh) v3.5.582 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m on this as a headless worker.