### PR TITLE
GH#14631: tighten code quality setup guide

### DIFF
--- a/.agents/tools/code-review/setup.md
+++ b/.agents/tools/code-review/setup.md
@@ -33,35 +33,6 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Setup Notes
-
-### CodeRabbit
-
-1. Sign in with GitHub.
-2. Add the repository.
-3. Enable automatic PR reviews.
-
-### CodeFactor
-
-1. Sign in with GitHub.
-2. Add the repository.
-3. Enable GitHub Checks so PRs show the grade.
-
-### Codacy
-
-1. Sign in with GitHub.
-2. Import the repository.
-3. Confirm `.codacy.yml` was detected.
-
-### SonarCloud
-
-1. Sign in with GitHub.
-2. Create an organization linked to the GitHub account.
-3. Import the project.
-4. Generate a token from `My Account > Security > Generate Token`.
-5. Add `SONAR_TOKEN` under `Settings > Secrets and variables > Actions`.
-6. Push a commit and confirm the SonarCloud workflow succeeds.
-
 ## README Badges
 
 | Platform | Badge |


### PR DESCRIPTION
## Summary

- Removes the redundant "Setup Notes" section from `.agents/tools/code-review/setup.md`
- All setup steps were already present in the Quick Reference table (same information, different format)
- 81→52 lines (36% reduction), zero knowledge loss

## Changes

- `.agents/tools/code-review/setup.md`: removed 29 lines of duplicated numbered setup steps

## Verification

- All code blocks, URLs, and command references preserved
- Quick Reference table retains full setup flow for all 4 platforms
- Troubleshooting and README Badges sections unchanged

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. Self-assessed.

Closes #14631


---
[aidevops.sh](https://aidevops.sh) v3.5.584 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m on this as a headless worker.