### PR TITLE
GH#14630: tighten agent doc Git Tools (.agents/tools/git.md)

### DIFF
--- a/.agents/tools/git.md
+++ b/.agents/tools/git.md
@@ -86,12 +86,3 @@ Issue or PR comments:
 - GitLab: add OpenCode to `.gitlab-ci.yml`, then use `@opencode explain this issue` and `@opencode fix this`
 
 See `git/opencode-github.md`, `git/opencode-gitlab.md`, and `git/opencode-github-security.md` for workflow and hardening details.
-
-## Related
-
-- `workflows/branch.md` — branching workflow
-- `workflows/pr.md` — pull requests
-- `workflows/version-bump.md` — version management
-- `workflows/release.md` — releases
-- `git/github-actions.md` — CI/CD
-- `git/git-security.md` — git security rules


### PR DESCRIPTION
## Summary

Remove the duplicate `## Related` section from `.agents/tools/git.md`. All 6 links in that section were already present in the `## Quick Reference` section at the top of the file.

**Change:** 97 → 88 lines (9 lines removed, zero content loss)

## What was done

- Identified that the `## Related` section (lines 90-97) was a pure duplicate of links already in `## Quick Reference` (lines 27-30)
- Removed the redundant section
- Verified with `markdownlint-cli2`: 0 errors

## Verification

- [x] All code blocks, URLs, task ID references, and command examples preserved
- [x] No broken internal links — all links remain in Quick Reference
- [x] `markdownlint-cli2`: 0 errors
- [x] Agent behaviour unchanged — Quick Reference is loaded first and contains all the same pointers

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code changes.
**Level:** self-assessed

## Files Changed

- `.agents/tools/git.md` — removed duplicate Related section

Closes #14630

---

---
[aidevops.sh](https://aidevops.sh) v3.5.584 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m on this as a headless worker.