### PR TITLE
GH#15292: tighten agent doc datasets.md (92→61 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3142,9 +3142,9 @@
       "pr": 14932
     },
     ".agents/tools/ai-assistants/datasets.md": {
-      "hash": "4d6b7f27d34a145fddf6bc662ce9fe4ca289f7e6b78f29add65726d7bae2db3f",
-      "at": "2026-04-01T00:00:00Z",
-      "pr": 14823
+      "hash": "8b525467afaf93fea7539e9f47fabf2159254ae1",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15336
     },
     ".agents/tools/automation/mac.md": {
       "hash": "1dc19ae4b63343bb6f8a397a6f7e824655e2f986",

--- a/.agents/tools/ai-assistants/datasets.md
+++ b/.agents/tools/ai-assistants/datasets.md
@@ -1,92 +1,61 @@
 # Evaluation Datasets
 
-Standardised JSONL format and storage convention for LLM evaluation cases. Used by bench and evaluator workflows.
+JSONL format and storage for LLM evaluation cases. Used by bench and evaluator workflows.
 
 ## Format
 
-One JSON object per line. Required fields: `id`, `input`.
+One JSON object per line. Required: `id`, `input`. Full schema: `dataset-helper.sh schema`
 
 ```jsonl
 {"id":"001","input":"What is the capital of France?","expected":"Paris","context":"France is in Western Europe.","tags":["geography","factual"],"source":"manual"}
-{"id":"002","input":"Summarize this PR","expected":null,"context":"PR #123 adds auth middleware...","tags":["code-review","summarization"],"source":"trace:abc123"}
 ```
 
 | Field | Type | Required | Meaning |
 |-------|------|----------|---------|
 | `id` | string | Yes | Unique identifier; auto-generated on `add` |
-| `input` | string | Yes | Prompt or input sent to the model |
+| `input` | string | Yes | Prompt sent to the model |
 | `expected` | string/null | No | Expected output; `null` for open-ended evals |
 | `context` | string/null | No | Grounding context for faithfulness checks |
 | `tags` | string[] | No | Scenario, domain, or difficulty filters |
 | `source` | string | No | Provenance: `manual`, `trace:<id>`, `generated:<model>` |
 | `metadata` | object/null | No | Extra key-value pairs |
 
-Full schema: `dataset-helper.sh schema`
-
 ## Storage
 
-```text
-~/.aidevops/.agent-workspace/datasets/    # Global, cross-project
-~/Git/myproject/datasets/                 # Project-local, version-controlled
-```
+- **Global**: `~/.aidevops/.agent-workspace/datasets/`
+- **Project-local**: `~/Git/<project>/datasets/` (version-controlled)
 
 ## CLI
 
 ```bash
-DATASET_DIR="$HOME/.aidevops/.agent-workspace/datasets"
+D="$HOME/.aidevops/.agent-workspace/datasets"
 
-# Create
 dataset-helper.sh create golden-prompts                    # Global
 dataset-helper.sh create api-tests --project ~/Git/myapp   # Project-local
-
-# Add entry
-dataset-helper.sh add "$DATASET_DIR/golden-prompts.jsonl" \
-  --input "What is the capital of France?" \
-  --expected "Paris" \
-  --context "France is in Western Europe." \
-  --tags "geography,factual" \
-  --source "manual"
-
-# Validate
-dataset-helper.sh validate "$DATASET_DIR/golden-prompts.jsonl"            # Basic
-dataset-helper.sh validate "$DATASET_DIR/golden-prompts.jsonl" --strict   # + type checking
-
-# List and stats
+dataset-helper.sh add "$D/golden-prompts.jsonl" \
+  --input "What is the capital of France?" --expected "Paris" \
+  --context "France is in Western Europe." --tags "geography,factual" --source "manual"
+dataset-helper.sh validate "$D/golden-prompts.jsonl"            # Basic
+dataset-helper.sh validate "$D/golden-prompts.jsonl" --strict   # + type checking
 dataset-helper.sh list                                     # Global only
 dataset-helper.sh list --project ~/Git/myapp               # Global + project
-dataset-helper.sh stats "$DATASET_DIR/golden-prompts.jsonl"
-
-# Promote trace to dataset entry
-dataset-helper.sh promote --trace-id abc123
-dataset-helper.sh promote --trace-id abc123 -o "$DATASET_DIR/regression.jsonl" --tags "regression"
-
-# Merge (dedup by ID; file2 wins on conflict)
-dataset-helper.sh merge dataset1.jsonl dataset2.jsonl -o merged.jsonl
+dataset-helper.sh stats "$D/golden-prompts.jsonl"
+dataset-helper.sh promote --trace-id abc123 -o "$D/regression.jsonl" --tags "regression"
+dataset-helper.sh merge dataset1.jsonl dataset2.jsonl -o merged.jsonl  # Dedup by ID; file2 wins
 ```
 
 ## Workflows
 
-### Golden dataset
+**Golden dataset**: Add manual entries for known cases. Run evaluations; add failures with tags. Re-run after prompt changes to catch regressions.
 
-1. Add manual entries for known cases.
-2. Run evaluations; add failures with tags.
-3. Re-run after prompt changes to catch regressions.
+**Promote from traces**: Find trace ID via `jq '.request_id' ~/.aidevops/.agent-workspace/observability/metrics.jsonl | tail`, then `dataset-helper.sh promote --trace-id <id> --tags "edge-case"`. Edit the promoted entry with expected output.
 
-### Promote from traces
-
-1. Find trace ID: `jq '.request_id' ~/.aidevops/.agent-workspace/observability/metrics.jsonl | tail`
-2. Promote: `dataset-helper.sh promote --trace-id <id> --tags "edge-case"`
-3. Edit the promoted entry with expected output and cleaner input.
-
-### Integrations
-
-- Bench (t1393): `compare-models-helper.sh bench --dataset golden-prompts.jsonl`
-- Evaluators (t1394): `ai-judgment-helper.sh evaluate --dataset golden-prompts.jsonl`
+**Integrations**: Bench (t1393): `compare-models-helper.sh bench --dataset golden-prompts.jsonl` | Evaluators (t1394): `ai-judgment-helper.sh evaluate --dataset golden-prompts.jsonl`
 
 ## Design decisions
 
-- **JSONL**: Streamable, append-friendly, grep/wc-friendly; consistent with observability-helper.sh.
-- **`id` required**: Enables dedup, trace-back, and merges.
-- **`expected` optional**: Some evals have no single correct answer.
-- **`source`**: Distinguishes manual, promoted, and generated cases.
-- **`tags`**: Supports subsets by scenario, domain, or difficulty.
+- **JSONL**: Streamable, append-friendly, grep/wc-friendly; consistent with observability-helper.sh
+- **`id` required**: Enables dedup, trace-back, and merges
+- **`expected` optional**: Some evals have no single correct answer
+- **`source`**: Distinguishes manual, promoted, and generated cases
+- **`tags`**: Supports subsets by scenario, domain, or difficulty


### PR DESCRIPTION
## Summary

Recheck simplification of `.agents/tools/ai-assistants/datasets.md` — file was modified since last simplification (PR #14823).

- **92 → 61 lines** (34% reduction)
- Removed redundant second JSONL example entry
- Consolidated CLI section with shorter variable name and inline comments
- Converted Storage from code block to compact bullet list
- Merged Workflows subsections into inline paragraphs

## Content Preservation

All institutional knowledge preserved:
- Task IDs: t1393, t1394
- All 7 CLI commands (`create`, `add`, `validate`, `list`, `stats`, `promote`, `merge`)
- Complete field definition table (7 fields)
- All 5 design decisions
- Both integration commands (bench, evaluator)
- Storage paths (global + project-local)

## Runtime Testing

- **Risk**: Low (docs-only change, agent prompt)
- **Level**: `self-assessed`
- No code blocks changed in meaning, only formatting

Closes #15292

---
[aidevops.sh](https://aidevops.sh) v3.5.585 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6