### PR TITLE
GH#14391: tighten miniflare.md agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/miniflare.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/miniflare.md
@@ -1,22 +1,14 @@
 # Miniflare
 
-Local simulator for Cloudflare Workers development/testing. Runs Workers in workerd sandbox implementing runtime APIs - no internet required.
+Local simulator for Cloudflare Workers. Runs Workers in workerd sandbox with full runtime API support — no internet required.
 
-## Features
-
-- Full-featured: KV, Durable Objects, R2, D1, WebSockets, Queues
-- Fully-local: test without internet, instant reload
-- TypeScript-native: detailed logging, source maps
-- Advanced testing: dispatch events without HTTP, simulate Worker connections
+> **Most users should use Wrangler (`wrangler dev`).** Use Miniflare for advanced testing requiring programmatic control.
 
 ## When to Use
 
-- Integration tests for Workers
-- Advanced use cases requiring fine-grained control
-- Testing bindings/storage locally
+- Integration tests for Workers with bindings (KV, DO, R2, D1, Queues, WebSockets)
+- Fine-grained test control: dispatch events without HTTP, simulate Worker connections
 - Multiple Workers with service bindings
-
-**Note:** Most users should use Wrangler. Miniflare for advanced testing.
 
 ## Setup
 
@@ -24,11 +16,7 @@ Local simulator for Cloudflare Workers development/testing. Runs Workers in work
 npm i -D miniflare
 ```
 
-Requires ES modules in `package.json`:
-
-```json
-{"type": "module"}
-```
+Requires ES modules (`"type": "module"` in `package.json`).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Tighten  per the simplification issue.

**Classification:** Instruction doc (not reference corpus) — prose tightening applies.

## Changes

- 63 → 51 lines (19% reduction)
- Promoted Wrangler-first note to top-level blockquote callout (most important guidance first)
- Consolidated Features list into When to Use section (removes duplicate section)
- Inlined ES modules requirement into prose (removes redundant JSON code block)
- All code blocks, URLs, See Also links, and Resources preserved

## Content Preservation Checklist

- [x] Quick Start JS code block preserved
- [x] npm install bash block preserved
- [x] All 3 resource URLs preserved (Miniflare Docs, GitHub, Vitest Integration)
- [x] See Also links preserved (patterns.md, gotchas.md)
- [x] All use cases preserved (KV, DO, R2, D1, Queues, WebSockets, service bindings)
- [x] No task IDs or GH refs in original (none to preserve)

## Runtime Testing

**Risk level:** Low — agent doc only, no code changes, no runtime behaviour affected.
**Verification:** Self-assessed. Content diff reviewed line-by-line against original.

Closes #14391


---
[aidevops.sh](https://aidevops.sh) v3.5.590 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 10m on this as a headless worker.