### PR TITLE
GH#14736: tighten agent doc Cloudflare Wrangler (wrangler.md)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler.md
@@ -5,12 +5,9 @@ Primary CLI for Cloudflare Workers: scaffold projects, run local/remote dev, man
 ## Install
 
 ```bash
-npm install -D wrangler
-# or globally
-npm install -g wrangler
+npm install -D wrangler   # dev dependency (npx wrangler <cmd>)
+npm install -g wrangler   # global
 ```
-
-Run with `npx wrangler <command>` (or your package manager's wrapper).
 
 ## Core Commands
 
@@ -56,7 +53,7 @@ wrangler r2 object put BUCKET/key --file path
 wrangler r2 object get BUCKET/key
 ```
 
-### Other Platform Resources
+### Other
 
 ```bash
 wrangler queues create NAME


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/hosting/cloudflare-platform-skill/wrangler.md` per GH#14736 simplification scan
- Removed redundant prose line (`Run with npx wrangler <command>...`) — install commands already show this
- Removed redundant `# or globally` comment — `-g` flag is self-documenting; inlined as inline comment instead
- Renamed `### Other Platform Resources` → `### Other` — shorter, same meaning in context
- 78 → 75 lines; all commands, URLs, and cross-references preserved

## Classification

**Instruction doc** (command reference with cross-links). Not a reference corpus — no restructuring needed.

## Content Preservation Verification

- All `wrangler` commands present: ✓
- All code blocks intact: ✓
- Cross-references to `wrangler-patterns.md` and `wrangler-gotchas.md`: ✓
- No task IDs, incident refs, or decision rationale removed: ✓

## Runtime Testing

**Risk: Low** — agent doc (markdown only). No runtime execution required. Self-assessed.

Closes #14736


---
[aidevops.sh](https://aidevops.sh) v3.5.590 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.