### PR TITLE
GH#14768: simplification: tighten Playwright Benchmark Scripts chapter

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
@@ -6,6 +6,11 @@ Reference implementation for `browser-benchmark-scripts.md`.
 - Coverage: `navigate`, `formFill`, `extract`, `multiStep`
 - Sampling: 3 runs per test, median reported
 
+| Script | What it measures |
+|--------|-----------------|
+| Sequential | Per-test latency: navigate, formFill, extract, multiStep — one page at a time |
+| Parallel | Throughput: 5 contexts, 3 browsers, 10 pages — concurrent load |
+
 ## Sequential script
 
 ```javascript


### PR DESCRIPTION
## Summary

- Classified `.agents/tools/browser/browser-benchmark-scripts-01-playwright.md` as a **reference corpus chapter** (already part of a split corpus with `browser-benchmark-scripts.md` as the slim index)
- Per reference corpus rules (GH#6432): no content compression applied — code blocks are the content
- Added a navigation summary table (5 lines) showing what each script measures, improving discoverability without removing any content

## Changes

- `.agents/tools/browser/browser-benchmark-scripts-01-playwright.md` — added 2-row summary table

## Testing

- `bunx markdownlint-cli2` — 0 errors
- Content preservation verified: all code blocks, URLs, and structure intact
- Line count: 95 → 100 (net +5 lines from summary table addition)

## Runtime Testing

Risk: **Low** — documentation-only change, no executable code modified. Self-assessed.

Closes #14768

---
[aidevops.sh](https://aidevops.sh) v3.5.590 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6