### PR TITLE
t1741.2: /autoresearch command doc with interactive setup

### DIFF
--- a/.agents/scripts/commands/autoresearch.md
+++ b/.agents/scripts/commands/autoresearch.md
@@ -1,0 +1,244 @@
+---
+description: Autonomous experiment loop — optimize code, agents, or standalone research programs
+agent: autoresearch
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+---
+
+Run an autonomous experiment loop that modifies code, measures a metric, and keeps only improvements.
+
+Arguments: $ARGUMENTS
+
+---
+
+## Invocation Patterns
+
+| Pattern | Example | Behaviour |
+|---------|---------|-----------|
+| **Full program** | `/autoresearch --program todo/research/optimize-build.md` | Skip interview, run directly |
+| **One-liner** | `/autoresearch "reduce build time"` | Infer defaults, short confirmation |
+| **Bare** | `/autoresearch` | Full interactive setup interview |
+| **Init** | `/autoresearch init "name"` | Scaffold new standalone research repo |
+
+---
+
+## Step 1: Resolve Invocation Pattern
+
+```text
+if $ARGUMENTS starts with "init ":
+    → go to Init Mode
+elif $ARGUMENTS contains "--program ":
+    → extract program path, skip to Step 3
+elif $ARGUMENTS is non-empty (one-liner):
+    → go to One-Liner Mode
+else:
+    → go to Interactive Setup
+```
+
+---
+
+## Step 2a: Interactive Setup (bare invocation)
+
+Ask questions sequentially. Each question shows the inferred default as option 1. Accept Enter to use default.
+
+### Q1 — What are you researching?
+
+Suggest based on repo context:
+
+| Signal | Suggestion |
+|--------|-----------|
+| Repo is aidevops | "agent instruction optimization (reduce tokens, improve pass rate)" |
+| `package.json` exists | "build time reduction" or "test suite speed" |
+| `pyproject.toml` / `setup.py` | "pytest suite speed" or "import time" |
+| `Cargo.toml` | "cargo build time" or "benchmark regression" |
+| `Makefile` / `CMakeLists.txt` | "build time" |
+| No signal | "code quality improvement" |
+
+### Q2 — Where does the work happen?
+
+```text
+1. This repo (.)                    [default]
+2. Another managed repo (which?)
+3. New standalone repo
+```
+
+If option 2: ask for repo path or name. Validate it exists in `~/.config/aidevops/repos.json`.
+If option 3: go to Init Mode after interview.
+
+### Q3 — What files can be modified?
+
+Suggest based on Q1 answer:
+
+| Q1 answer contains | Suggestion |
+|--------------------|-----------|
+| "agent" / "instruction" / "prompt" | `.agents/**/*.md, .agents/prompts/*.txt` |
+| "build" / "webpack" / "bundle" | `webpack.config.js, tsconfig.json, src/**/*.ts` |
+| "test" / "pytest" / "jest" | `tests/**/*.py, conftest.py` or `tests/**/*.ts, jest.config.js` |
+| "performance" / "speed" | `src/**/*.{ts,js,py}` |
+| default | `src/**/*` |
+
+### Q4 — What's the success metric?
+
+Suggest based on repo type and Q1:
+
+| Context | Metric command | Name | Direction |
+|---------|---------------|------|-----------|
+| aidevops + "agent" | `agent-test-helper.sh run --json \| jq '.pass_rate - 0.3 * .token_ratio'` | `composite_score` | higher |
+| aidevops + "token" | `agent-test-helper.sh run --json \| jq '.avg_tokens'` | `avg_tokens` | lower |
+| Node + "build" | `npm run build 2>&1 \| grep 'Time:' \| awk '{print $2}'` | `build_time_seconds` | lower |
+| Node + "test" | `npm test -- --json 2>/dev/null \| jq '.numPassedTests'` | `tests_passed` | higher |
+| Python + "test" | `pytest --tb=no -q 2>&1 \| grep passed \| awk '{print $1}'` | `tests_passed` | higher |
+| Python + "speed" | `hyperfine --runs 3 'python main.py' --export-json /tmp/bench.json && jq '.results[0].mean' /tmp/bench.json` | `execution_seconds` | lower |
+| Cargo + "bench" | `cargo bench 2>&1 \| grep 'time:' \| awk '{print $5}'` | `bench_ns` | lower |
+| default | ask user to provide command | — | — |
+
+If no suggestion matches: ask user for the metric command, name, and direction.
+
+### Q5 — Any constraints?
+
+Auto-detect test command and pre-fill:
+
+```text
+Detected test command: npm test
+Suggested constraints:
+  1. Tests must pass: npm test                    [default: include]
+  2. No new dependencies                          [default: include]
+  3. Keep public API unchanged                    [default: skip]
+  4. Lint clean                                   [default: skip]
+  5. Custom constraint
+```
+
+### Q6 — Budget?
+
+```text
+Time limit:       [2h]
+Max iterations:   [50]
+Per-experiment:   [5m]
+Goal (optional):  [none]
+```
+
+### Q7 — Models?
+
+```text
+Researcher model: [sonnet]
+Evaluator model:  [haiku]   (optional — for LLM-as-judge metrics)
+Target model:     [sonnet]  (only for agent optimization)
+```
+
+Only ask about Target model if Q1 mentions "agent" or "instruction".
+
+---
+
+## Step 2b: One-Liner Mode
+
+Given a short description (e.g., "reduce build time"):
+
+1. Detect repo type and infer all fields using the tables in Step 2a.
+2. Generate a draft research program.
+3. Show a compact summary:
+
+```text
+Research program: optimize-build-time
+  Mode:       in-repo (.)
+  Files:      webpack.config.js, tsconfig.json, src/**/*.ts
+  Metric:     build_time_seconds (lower is better)
+              npm run build 2>&1 | grep 'Time:' | awk '{print $2}'
+  Constraints: npm test
+  Budget:     2h / 50 iterations
+  Models:     researcher=sonnet
+
+[Enter] to confirm, [e] to edit, [q] to quit
+```
+
+If headless (no TTY): proceed without confirmation.
+
+---
+
+## Step 3: Write Research Program
+
+After interview or one-liner confirmation, write the program to `todo/research/{name}.md`.
+
+Use the schema from `.agents/templates/research-program-template.md`. The file must have:
+
+- YAML frontmatter with `name`, `mode`, `target_repo`
+- `## Target` section with `files:` and `branch:`
+- `## Metric` section with `command:`, `name:`, `direction:`, `baseline: null`
+- `## Constraints` section (may be empty)
+- `## Models` section
+- `## Budget` section
+
+Confirm: "Research program written to `todo/research/{name}.md`."
+
+---
+
+## Step 4: Dispatch Decision
+
+```text
+Begin now or queue for later?
+  1. Begin now (dispatch to autoresearch subagent)    [default]
+  2. Queue for later (add to TODO.md)
+  3. Show program file and exit
+```
+
+If headless: begin now (option 1).
+
+**If begin now:** dispatch to `.agents/tools/autoresearch/autoresearch.md` with `--program todo/research/{name}.md`.
+
+**If queue:** add to TODO.md:
+
+```text
+- [ ] t{next_id} autoresearch: {name} — {one-line description} #auto-dispatch ~{budget.timeout/3600}h ref:GH#{issue}
+```
+
+---
+
+## Init Mode (`/autoresearch init "name"`)
+
+Scaffold a new standalone research repo at `~/Git/autoresearch-{name}/`.
+
+```bash
+# 1. Create directory and git init
+mkdir -p ~/Git/autoresearch-{name}
+git -C ~/Git/autoresearch-{name} init
+
+# 2. Run aidevops init
+aidevops init --path ~/Git/autoresearch-{name} --non-interactive
+
+# 3. Create baseline program
+mkdir -p ~/Git/autoresearch-{name}/todo/research
+# Write program.md from template with mode: standalone
+
+# 4. Register in repos.json
+# Add entry: { "slug": "local/autoresearch-{name}", "path": "~/Git/autoresearch-{name}", "local_only": true, "pulse": false }
+
+# 5. Optional: create GitHub remote
+# Ask: "Create GitHub remote? [y/N]"
+# If yes: gh repo create autoresearch-{name} --private --source ~/Git/autoresearch-{name} --push
+# Update repos.json: remove local_only, set slug to "owner/autoresearch-{name}"
+```
+
+After scaffolding: "Repo ready at `~/Git/autoresearch-{name}/`. Edit `todo/research/program.md` to define your experiment, then run `/autoresearch --program todo/research/program.md`."
+
+---
+
+## Context Detection Reference
+
+| File present | Repo type | Default metric category |
+|-------------|-----------|------------------------|
+| `package.json` | Node.js | build time or test count |
+| `pyproject.toml` / `setup.py` | Python | pytest pass rate or execution time |
+| `Cargo.toml` | Rust | cargo bench or build time |
+| `Makefile` | C/C++/generic | make time |
+| `.agents/` directory | aidevops | agent pass rate + token count |
+| `go.mod` | Go | go test or go build time |
+
+---
+
+## Related
+
+`.agents/templates/research-program-template.md` · `.agents/tools/autoresearch/autoresearch.md` · `todo/research/`

--- a/.agents/tools/autoresearch/autoresearch.md
+++ b/.agents/tools/autoresearch/autoresearch.md
@@ -1,0 +1,365 @@
+---
+description: Autonomous experiment loop runner — reads a research program, generates hypotheses, modifies code, measures results, and keeps only improvements
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: false
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Autoresearch Subagent
+
+Autonomous experiment loop runner. Reads a research program file, runs the
+setup → hypothesis → modify → constrain → measure → keep/discard → log → repeat
+loop until the budget is exhausted or the goal is reached.
+
+Arguments: `--program <path>` (required)
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Program format**: `.agents/templates/research-program-template.md`
+- **Results file**: `todo/research/{name}-results.tsv`
+- **Worktree**: `experiment/{name}` (created at session start)
+- **State**: git HEAD of experiment branch = current best; results.tsv = full history
+- **Resume**: re-run with same `--program` — reads results.tsv to reconstruct state
+
+<!-- AI-CONTEXT-END -->
+
+---
+
+## Step 0: Parse Arguments
+
+Extract `--program <path>` from arguments. If missing or file not found: exit with error.
+
+Read the program file. Extract:
+
+```text
+PROGRAM_NAME   ← frontmatter `name`
+MODE           ← frontmatter `mode` (in-repo | cross-repo | standalone)
+TARGET_REPO    ← frontmatter `target_repo` (path or ".")
+FILES          ← ## Target section, `files:` line
+BRANCH         ← ## Target section, `branch:` line (default: experiment/{name})
+METRIC_CMD     ← ## Metric section, `command:` line
+METRIC_NAME    ← ## Metric section, `name:` line
+METRIC_DIR     ← ## Metric section, `direction:` line (lower | higher)
+BASELINE       ← ## Metric section, `baseline:` line (null = not yet measured)
+GOAL           ← ## Metric section, `goal:` line (null = no goal)
+CONSTRAINTS    ← ## Constraints section, each `- ` bullet as a shell command
+RESEARCHER     ← ## Models section, `researcher:` line
+EVALUATOR      ← ## Models section, `evaluator:` line (optional)
+TARGET_MODEL   ← ## Models section, `target:` line (optional)
+TIMEOUT        ← ## Budget section, `timeout:` line (seconds)
+MAX_ITER       ← ## Budget section, `max_iterations:` line
+PER_EXPERIMENT ← ## Budget section, `per_experiment:` line
+HINTS          ← ## Hints section, all bullet lines
+```
+
+---
+
+## Step 1: Setup
+
+### 1.1 Resolve target repo
+
+```bash
+if MODE == "in-repo" or TARGET_REPO == ".":
+    REPO_ROOT = current working directory
+else:
+    REPO_ROOT = TARGET_REPO (expand ~)
+    verify it exists and is a git repo
+```
+
+### 1.2 Create or resume experiment worktree
+
+```bash
+WORKTREE_PATH="$REPO_ROOT/../$(basename $REPO_ROOT)-$BRANCH"
+# Replace / with - in branch name for path
+
+if worktree already exists at WORKTREE_PATH:
+    cd WORKTREE_PATH
+    git reset --hard HEAD  # discard any uncommitted changes from prior crash
+    RESUMING=true
+else:
+    git -C REPO_ROOT worktree add WORKTREE_PATH -b BRANCH
+    RESUMING=false
+```
+
+### 1.3 Load prior results (resume mode)
+
+```text
+RESULTS_FILE = "$REPO_ROOT/todo/research/{name}-results.tsv"
+
+if RESUMING and RESULTS_FILE exists:
+    Read results.tsv to reconstruct:
+    - ITERATION_COUNT = number of rows
+    - BEST_METRIC = best metric value seen (per direction)
+    - BASELINE = first row's metric value
+    - FAILED_HYPOTHESES = list of hypothesis descriptions that were discarded
+    Log: "Resuming from iteration N, best metric: X"
+else:
+    ITERATION_COUNT = 0
+    BEST_METRIC = null
+    BASELINE = null
+    FAILED_HYPOTHESES = []
+    mkdir -p $(dirname RESULTS_FILE)
+    Write TSV header: iteration\tcommit\tmetric\tstatus\thypothesis\ttimestamp\ttokens
+```
+
+### 1.4 Recall cross-session memory
+
+```text
+aidevops-memory recall "autoresearch $PROGRAM_NAME" --limit 10
+```
+
+Store recalled findings as MEMORY_CONTEXT for hypothesis generation.
+
+### 1.5 Measure baseline (first run only)
+
+```text
+if BASELINE == null:
+    Run all constraints. If any fail: exit with error (baseline environment is broken).
+    Run METRIC_CMD. Parse numeric output.
+    BASELINE = result
+    BEST_METRIC = result
+    Update program file: set `baseline: {value}`
+    Log: "Baseline: {METRIC_NAME} = {BASELINE}"
+    Append to results.tsv: 0\t(baseline)\t{BASELINE}\tbaseline\t(initial measurement)\t{timestamp}\t0
+```
+
+---
+
+## Step 2: Experiment Loop
+
+Repeat until any budget condition is met:
+
+```text
+SESSION_START = current time
+while true:
+    # Budget checks
+    elapsed = now - SESSION_START
+    if elapsed >= TIMEOUT: break with reason "timeout"
+    if ITERATION_COUNT >= MAX_ITER: break with reason "max_iterations"
+    if GOAL is set and goal_met(BEST_METRIC, GOAL, METRIC_DIR): break with reason "goal_reached"
+
+    ITERATION_COUNT += 1
+    Log: "--- Iteration {ITERATION_COUNT} ---"
+
+    # Generate hypothesis
+    hypothesis = generate_hypothesis(...)
+
+    # Modify files
+    apply_modification(hypothesis)
+
+    # Constraint check
+    constraint_result = run_constraints()
+    if constraint_result == FAIL:
+        git -C WORKTREE_PATH reset --hard HEAD
+        log_result(ITERATION_COUNT, null, "constraint_fail", hypothesis)
+        continue
+
+    # Measure metric
+    metric_result = run_metric()
+    if metric_result == ERROR:
+        git -C WORKTREE_PATH reset --hard HEAD
+        log_result(ITERATION_COUNT, null, "crash", hypothesis)
+        continue
+
+    # Keep or discard
+    if is_improvement(metric_result, BEST_METRIC, METRIC_DIR):
+        git -C WORKTREE_PATH add -A
+        git -C WORKTREE_PATH commit -m "experiment: {hypothesis[:60]} ({METRIC_NAME}: {metric_result})"
+        BEST_METRIC = metric_result
+        log_result(ITERATION_COUNT, HEAD_SHA, metric_result, "keep", hypothesis)
+        store_memory(hypothesis, metric_result, "keep")
+    else:
+        git -C WORKTREE_PATH reset --hard HEAD
+        FAILED_HYPOTHESES.append(hypothesis)
+        log_result(ITERATION_COUNT, null, metric_result, "discard", hypothesis)
+        store_memory(hypothesis, metric_result, "discard")
+```
+
+---
+
+## Hypothesis Generation
+
+Called at the start of each iteration. Uses the researcher model's reasoning to
+generate the next modification to try.
+
+### Input context (provide all of these)
+
+1. **Program hints** — from `## Hints` section
+2. **Memory context** — recalled findings from prior sessions
+3. **Failed hypotheses** — what was tried and discarded this session
+4. **Current best** — metric value and which commit achieved it
+5. **Current code state** — read the target files (FILES glob)
+6. **Iteration number** — to guide progression strategy
+
+### Progression strategy
+
+Follow this order across iterations:
+
+| Phase | Iterations | Strategy |
+|-------|-----------|---------|
+| **Low-hanging fruit** | 1–5 | Apply hints directly; obvious improvements from code reading |
+| **Systematic** | 6–20 | Vary one parameter at a time; measure effect of each change |
+| **Combination** | 21–35 | Combine two individually-successful changes |
+| **Radical** | 36–45 | Try fundamentally different approaches if incremental gains stall |
+| **Simplification** | 46+ | Remove things; equal-or-better with less code is a win |
+
+### Rules
+
+- Never repeat a hypothesis that was already discarded (check FAILED_HYPOTHESES)
+- Prefer changes with high expected impact and low risk of constraint failure
+- For agent optimization: shorter instructions with higher information density > longer verbose instructions
+- For build optimization: structural changes (tree-shaking, module boundaries) > config tweaks
+- Simplification is always valid: removing code that doesn't affect the metric is a win
+
+---
+
+## Constraint Checking
+
+For each constraint in CONSTRAINTS:
+
+```bash
+timeout PER_EXPERIMENT bash -c "{constraint_command}"
+exit_code=$?
+if exit_code != 0:
+    return FAIL with constraint_command and exit_code
+```
+
+All constraints must pass. First failure short-circuits (don't run remaining constraints).
+
+---
+
+## Metric Measurement
+
+```bash
+timeout PER_EXPERIMENT bash -c "{METRIC_CMD}" 2>/dev/null
+output=$?
+```
+
+Parse the last non-empty line of stdout as a float. If parsing fails or command
+exits non-zero: return ERROR.
+
+---
+
+## Improvement Check
+
+```text
+is_improvement(new_value, best_value, direction):
+    if best_value == null: return true  # first measurement is always an improvement
+    if direction == "lower": return new_value < best_value
+    if direction == "higher": return new_value > best_value
+```
+
+---
+
+## Results Logging
+
+Append to `todo/research/{name}-results.tsv`:
+
+```text
+{iteration}\t{commit_sha_or_null}\t{metric_value_or_null}\t{status}\t{hypothesis}\t{ISO_timestamp}\t{tokens_used}
+```
+
+Status values: `baseline`, `keep`, `discard`, `constraint_fail`, `crash`
+
+---
+
+## Memory Storage
+
+After each iteration:
+
+```text
+aidevops-memory store "autoresearch {PROGRAM_NAME}: iteration {N} — {hypothesis[:80]} → {status} ({metric})"
+```
+
+At session end, store a summary:
+
+```text
+aidevops-memory store "autoresearch {PROGRAM_NAME} session complete: {ITERATION_COUNT} iterations, best {METRIC_NAME}={BEST_METRIC} (baseline={BASELINE}, improvement={improvement_pct}%)"
+```
+
+---
+
+## Step 3: Completion
+
+### 3.1 Write results summary
+
+```markdown
+## Autoresearch Results: {PROGRAM_NAME}
+
+- **Iterations**: {ITERATION_COUNT}
+- **Baseline**: {METRIC_NAME} = {BASELINE}
+- **Best**: {METRIC_NAME} = {BEST_METRIC} ({improvement_pct}% improvement)
+- **Exit reason**: {timeout | max_iterations | goal_reached}
+- **Kept**: {kept_count} experiments
+- **Discarded**: {discarded_count} experiments
+- **Constraint failures**: {constraint_fail_count}
+- **Crashes**: {crash_count}
+
+### Key findings
+
+{List top 3-5 kept hypotheses with their metric improvements}
+
+### Failed approaches
+
+{List top 3-5 discarded hypotheses — useful for future sessions to avoid}
+```
+
+### 3.2 Create PR from experiment branch
+
+```bash
+git -C WORKTREE_PATH push -u origin BRANCH
+
+gh pr create \
+  --repo {REPO_SLUG} \
+  --head BRANCH \
+  --base main \
+  --title "experiment({PROGRAM_NAME}): {improvement_pct}% improvement in {METRIC_NAME}" \
+  --body "{results_summary}\n\nCloses #{issue_number_if_any}"
+```
+
+### 3.3 Store final memory
+
+```text
+aidevops-memory store "autoresearch {PROGRAM_NAME} PR created: {pr_url}. Best: {METRIC_NAME}={BEST_METRIC}. Key finding: {top_hypothesis}"
+```
+
+---
+
+## Crash Recovery
+
+If the subagent session crashes mid-loop:
+
+1. The experiment worktree persists at `WORKTREE_PATH`
+2. The results.tsv persists at `RESULTS_FILE`
+3. The experiment branch HEAD is always the last known-good state
+4. Any uncommitted changes are discarded on resume via `git reset --hard HEAD`
+
+To resume: re-run `/autoresearch --program {program_path}`. The subagent detects
+the existing worktree and results.tsv and continues from where it left off.
+
+---
+
+## Budget Enforcement
+
+| Condition | Check | Action |
+|-----------|-------|--------|
+| Wall-clock timeout | `elapsed >= TIMEOUT` | Break loop, proceed to completion |
+| Max iterations | `ITERATION_COUNT >= MAX_ITER` | Break loop, proceed to completion |
+| Goal reached | `goal_met(BEST_METRIC, GOAL)` | Break loop, proceed to completion |
+| Per-experiment timeout | `timeout PER_EXPERIMENT cmd` | Treat as crash, revert, continue |
+
+---
+
+## Related
+
+`.agents/templates/research-program-template.md` · `.agents/scripts/commands/autoresearch.md` · `todo/research/`


### PR DESCRIPTION
## Summary

- Add `.agents/scripts/commands/autoresearch.md` — the `/autoresearch` slash command doc (t1741.2)
- Add `.agents/tools/autoresearch/autoresearch.md` — the autoresearch subagent (t1741.3)
- Handles 4 invocation patterns: `--program` (skip interview), one-liner (infer defaults), bare (full interview), `init` (scaffold standalone repo)
- Context-aware defaults: detects aidevops, Node.js, Python, Rust, Go repos and suggests appropriate metrics
- Every interview question has a sensible default; headless mode skips all prompts
- Subagent implements full loop: setup → hypothesis → modify → constrain → measure → keep/discard → log → repeat
- Budget enforcement: wall-clock, iteration count, and goal-based termination
- Crash recovery via worktree + results.tsv state; resume with same `--program` flag
- Cross-session memory integration (store and recall per experiment)
- Lint clean (markdownlint, 0 errors on both files)

## Testing

- `markdownlint-cli2 .agents/scripts/commands/autoresearch.md` → 0 errors
- `markdownlint-cli2 .agents/tools/autoresearch/autoresearch.md` → 0 errors

## Runtime Testing

Risk level: **Low** (docs/agent instructions only, no executable code)
Assessment: `self-assessed` — no runtime environment required

## Files Changed

- `.agents/scripts/commands/autoresearch.md` (new, 244 lines) — slash command doc
- `.agents/tools/autoresearch/autoresearch.md` (new, 365 lines) — autonomous loop subagent

Closes #15342
Closes #15343

---

---
[aidevops.sh](https://aidevops.sh) v3.5.593 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6