### PR TITLE
feat: cross-platform reminders with extended field support

### DIFF
--- a/.agents/scripts/reminders-helper.sh
+++ b/.agents/scripts/reminders-helper.sh
@@ -2,23 +2,25 @@
 # shellcheck disable=SC2034
 set -euo pipefail
 
-# Apple Reminders Helper — CLI wrapper around remindctl for agent use
+# Reminders Helper — cross-platform CLI for agent use
+#
+# Backends:
+#   macOS:  remindctl (EventKit, brew install steipete/tap/remindctl)
+#   Linux:  todoman + vdirsyncer (CalDAV, pipx install todoman vdirsyncer)
 #
 # Usage: ./reminders-helper.sh [command] [args] [options]
 # Commands:
-#   setup                          - Check/install remindctl, verify authorization
-#   lists                          - List all reminder lists (with account info)
+#   setup                          - Check/install backend, verify access
+#   lists                          - List all reminder lists
 #   show [filter]                  - Show reminders (today|tomorrow|week|overdue|upcoming|all)
 #   add <title> [options]          - Create a reminder
 #   complete <id>                  - Mark a reminder complete
 #   edit <id> [options]            - Edit a reminder
+#   sync                           - Sync CalDAV (Linux only; macOS is automatic)
 #   help                           - Show this help
 #
-# Requires: remindctl (brew install steipete/tap/remindctl)
-# Authorization: System Settings > Privacy & Security > Reminders
-#
 # Author: AI DevOps Framework
-# Version: 1.0.0
+# Version: 2.0.0
 # License: MIT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
@@ -27,50 +29,51 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 init_log_file
 
 # =============================================================================
-# Dependencies
+# Platform Detection
+# =============================================================================
+
+detect_platform() {
+	local os
+	os="$(uname -s)"
+	case "$os" in
+	Darwin) echo "macos" ;;
+	Linux) echo "linux" ;;
+	*)
+		print_error "Unsupported platform: ${os}"
+		return 1
+		;;
+	esac
+	return 0
+}
+
+PLATFORM="$(detect_platform)" || exit 1
+
+# =============================================================================
+# macOS Backend (remindctl)
 # =============================================================================
 
 REMINDCTL_BIN="remindctl"
 REMINDCTL_TAP="steipete/tap/remindctl"
 
-check_remindctl() {
+macos_check_ready() {
 	if ! command -v "$REMINDCTL_BIN" >/dev/null 2>&1; then
 		print_error "remindctl not found. Install: brew install ${REMINDCTL_TAP}"
 		return 1
 	fi
-	return 0
-}
-
-check_authorization() {
 	local status
 	status="$("$REMINDCTL_BIN" status 2>&1)" || true
-	if echo "$status" | grep -qi "authorized"; then
-		return 0
-	fi
 	if echo "$status" | grep -qi "denied\|not determined"; then
 		print_error "Reminders access not granted."
 		print_info "Run: remindctl authorize"
 		print_info "Then: System Settings > Privacy & Security > Reminders > enable your terminal app"
 		return 1
 	fi
-	# Unknown status — try anyway
 	return 0
 }
 
-require_ready() {
-	check_remindctl || return 1
-	check_authorization || return 1
-	return 0
-}
+macos_setup() {
+	print_info "Checking remindctl (macOS backend)..."
 
-# =============================================================================
-# Commands
-# =============================================================================
-
-cmd_setup() {
-	print_info "Checking Apple Reminders CLI setup..."
-
-	# Step 1: remindctl installed?
 	if command -v "$REMINDCTL_BIN" >/dev/null 2>&1; then
 		local ver
 		ver="$("$REMINDCTL_BIN" --help 2>&1 | head -1)"
@@ -93,7 +96,6 @@ cmd_setup() {
 		fi
 	fi
 
-	# Step 2: Authorization
 	local status
 	status="$("$REMINDCTL_BIN" status 2>&1)" || true
 	if echo "$status" | grep -qi "authorized"; then
@@ -106,19 +108,14 @@ cmd_setup() {
 		return 1
 	fi
 
-	# Step 3: Show available lists
 	print_info "Available reminder lists:"
 	"$REMINDCTL_BIN" list --no-color 2>&1 || true
-
-	print_success "Setup complete. Ready to use."
+	print_success "macOS setup complete."
 	return 0
 }
 
-cmd_lists() {
-	require_ready || return 1
-
-	local use_json="${JSON_OUTPUT:-false}"
-
+macos_lists() {
+	local use_json="${1:-false}"
 	if [[ "$use_json" == "true" ]]; then
 		"$REMINDCTL_BIN" list --json --no-input 2>&1
 	else
@@ -127,8 +124,356 @@ cmd_lists() {
 	return 0
 }
 
+macos_show() {
+	local filter="$1"
+	local list_name="$2"
+	local use_json="$3"
+
+	local args=("$filter" --no-input --no-color)
+	[[ -n "$list_name" ]] && args+=(--list "$list_name")
+	[[ "$use_json" == "true" ]] && args+=(--json)
+
+	"$REMINDCTL_BIN" show "${args[@]}" 2>&1
+	return 0
+}
+
+macos_add() {
+	local title="$1" list_name="$2" due_date="$3" notes="$4" priority="$5" use_json="$6"
+	local url="$7" flag="$8" tags="$9" location="${10:-}"
+
+	# Prepend URL to notes (remindctl has no native URL field)
+	if [[ -n "$url" ]]; then
+		if [[ -n "$notes" ]]; then
+			notes="${url}
+${notes}"
+		else
+			notes="$url"
+		fi
+	fi
+
+	local args=("$title" --no-input --no-color)
+	[[ -n "$list_name" ]] && args+=(--list "$list_name")
+	[[ -n "$due_date" ]] && args+=(--due "$due_date")
+	[[ -n "$notes" ]] && args+=(--notes "$notes")
+	[[ -n "$priority" ]] && args+=(--priority "$priority")
+	[[ "$use_json" == "true" ]] && args+=(--json)
+
+	"$REMINDCTL_BIN" add "${args[@]}" 2>&1
+	local rc=$?
+
+	# Post-creation: set fields remindctl doesn't support via osascript
+	if [[ $rc -eq 0 ]]; then
+		local target_list="${list_name:-Reminders}"
+		# Set flagged status
+		if [[ "$flag" == "true" ]]; then
+			osascript -e "
+				tell application \"Reminders\"
+					set rl to list \"${target_list}\"
+					set r to (last reminder of rl whose name is \"${title}\")
+					set flagged of r to true
+				end tell" 2>/dev/null || print_warning "Could not set flag (osascript)"
+		fi
+		# Tags: not available via AppleScript or remindctl — log limitation
+		if [[ -n "$tags" ]]; then
+			print_warning "Tags not supported on macOS CLI. Tags: ${tags}"
+		fi
+		# Location: not available via AppleScript or remindctl
+		if [[ -n "$location" ]]; then
+			print_warning "Location not supported on macOS CLI. Location: ${location}"
+		fi
+	fi
+
+	return $rc
+}
+
+macos_complete() {
+	local id="$1"
+	"$REMINDCTL_BIN" complete "$id" --no-input --no-color 2>&1
+	return $?
+}
+
+macos_edit() {
+	local id="$1"
+	shift
+	"$REMINDCTL_BIN" edit "$id" --no-input --no-color "$@" 2>&1
+	return $?
+}
+
+macos_sync() {
+	print_info "macOS syncs automatically via EventKit. No manual sync needed."
+	return 0
+}
+
+# =============================================================================
+# Linux Backend (todoman + vdirsyncer)
+# =============================================================================
+
+TODOMAN_BIN="todo"
+VDIRSYNCER_BIN="vdirsyncer"
+
+linux_check_ready() {
+	if ! command -v "$TODOMAN_BIN" >/dev/null 2>&1; then
+		print_error "todoman not found. Install: pipx install todoman"
+		return 1
+	fi
+	if ! command -v "$VDIRSYNCER_BIN" >/dev/null 2>&1; then
+		print_error "vdirsyncer not found. Install: pipx install vdirsyncer"
+		return 1
+	fi
+	if [[ ! -f "${HOME}/.config/todoman/config.py" ]]; then
+		print_error "todoman not configured. See: reminders-helper.sh help"
+		return 1
+	fi
+	if [[ ! -f "${HOME}/.config/vdirsyncer/config" ]]; then
+		print_error "vdirsyncer not configured. See: reminders-helper.sh help"
+		return 1
+	fi
+	return 0
+}
+
+linux_setup() {
+	print_info "Checking todoman + vdirsyncer (Linux backend)..."
+
+	# todoman
+	if command -v "$TODOMAN_BIN" >/dev/null 2>&1; then
+		local ver
+		ver="$("$TODOMAN_BIN" --version 2>&1)"
+		print_success "todoman installed: ${ver}"
+	else
+		print_warning "todoman not installed"
+		if command -v pipx >/dev/null 2>&1; then
+			read -r -p "Install todoman now? [y/N] " answer
+			if [[ "$answer" =~ ^[Yy] ]]; then
+				pipx install todoman
+				print_success "todoman installed"
+			else
+				print_info "Install manually: pipx install todoman"
+				return 1
+			fi
+		else
+			print_info "Install with: pipx install todoman (or pip install --user todoman)"
+			return 1
+		fi
+	fi
+
+	# vdirsyncer
+	if command -v "$VDIRSYNCER_BIN" >/dev/null 2>&1; then
+		local vver
+		vver="$("$VDIRSYNCER_BIN" --version 2>&1)"
+		print_success "vdirsyncer installed: ${vver}"
+	else
+		print_warning "vdirsyncer not installed"
+		print_info "Install with: pipx install vdirsyncer"
+		return 1
+	fi
+
+	# Config check
+	if [[ -f "${HOME}/.config/vdirsyncer/config" ]]; then
+		print_success "vdirsyncer config found"
+	else
+		print_warning "vdirsyncer config missing: ~/.config/vdirsyncer/config"
+		print_info "See 'reminders-helper.sh help' for configuration guide"
+		return 1
+	fi
+
+	if [[ -f "${HOME}/.config/todoman/config.py" ]]; then
+		print_success "todoman config found"
+	else
+		print_warning "todoman config missing: ~/.config/todoman/config.py"
+		print_info "See 'reminders-helper.sh help' for configuration guide"
+		return 1
+	fi
+
+	# Show lists
+	print_info "Available reminder lists:"
+	"$TODOMAN_BIN" list --porcelain 2>&1 || "$TODOMAN_BIN" list 2>&1 || true
+
+	print_success "Linux setup complete."
+	return 0
+}
+
+linux_sync() {
+	print_info "Syncing CalDAV..."
+	"$VDIRSYNCER_BIN" sync 2>&1
+	local rc=$?
+	if [[ $rc -eq 0 ]]; then
+		print_success "CalDAV sync complete"
+	else
+		print_warning "CalDAV sync had issues (exit ${rc}). Check vdirsyncer config."
+	fi
+	return $rc
+}
+
+linux_lists() {
+	local use_json="${1:-false}"
+	if [[ "$use_json" == "true" ]]; then
+		"$TODOMAN_BIN" list --porcelain 2>&1
+	else
+		"$TODOMAN_BIN" list 2>&1
+	fi
+	return 0
+}
+
+linux_show() {
+	local filter="$1"
+	local list_name="$2"
+	local use_json="$3"
+
+	local args=()
+
+	# Translate remindctl-style filters to todoman equivalents
+	case "$filter" in
+	today) args+=(--due 24) ;;
+	tomorrow) args+=(--due 48) ;;
+	week) args+=(--due 168) ;;
+	overdue) args+=(--due 0) ;;
+	completed) args+=(--status COMPLETED) ;;
+	all) args+=(--status ANY) ;;
+	upcoming | *) ;; # no filter = all incomplete
+	esac
+
+	[[ -n "$list_name" ]] && args+=("$list_name")
+	[[ "$use_json" == "true" ]] && args+=(--porcelain)
+
+	"$TODOMAN_BIN" list "${args[@]}" 2>&1
+	return 0
+}
+
+# Map priority names to todoman values.
+# VTODO spec: 1-4=high, 5=medium, 6-9=low, 0=none.
+# todoman accepts the words directly since v4.4.
+linux_map_priority() {
+	local pri="$1"
+	case "$pri" in
+	high) echo "high" ;;
+	medium) echo "medium" ;;
+	low) echo "low" ;;
+	none | "") echo "" ;;
+	*) echo "$pri" ;;
+	esac
+	return 0
+}
+
+linux_add() {
+	local title="$1" list_name="$2" due_date="$3" notes="$4" priority="$5" use_json="$6"
+	local url="$7" flag="$8" tags="$9" location="${10:-}"
+
+	# Prepend URL to notes (todoman has no native URL field)
+	if [[ -n "$url" ]]; then
+		if [[ -n "$notes" ]]; then
+			notes="${url}
+${notes}"
+		else
+			notes="$url"
+		fi
+	fi
+
+	local args=("$title")
+	[[ -n "$list_name" ]] && args+=(--list "$list_name")
+	[[ -n "$due_date" ]] && args+=(--due "$due_date")
+	[[ -n "$location" ]] && args+=(--location "$location")
+
+	# Tags via --category (can be repeated)
+	if [[ -n "$tags" ]]; then
+		local IFS=','
+		local tag
+		for tag in $tags; do
+			tag="$(echo "$tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+			[[ -n "$tag" ]] && args+=(--category "$tag")
+		done
+		unset IFS
+	fi
+
+	local mapped_pri=""
+	if [[ -n "$priority" ]]; then
+		mapped_pri="$(linux_map_priority "$priority")"
+		[[ -n "$mapped_pri" ]] && args+=(--priority "$mapped_pri")
+	fi
+
+	# Flag: not natively supported by todoman, add to notes
+	if [[ "$flag" == "true" ]]; then
+		if [[ -n "$notes" ]]; then
+			notes="[FLAGGED]
+${notes}"
+		else
+			notes="[FLAGGED]"
+		fi
+	fi
+
+	if [[ -n "$notes" ]]; then
+		echo "$notes" | "$TODOMAN_BIN" new "${args[@]}" --read-description 2>&1
+	else
+		"$TODOMAN_BIN" new "${args[@]}" 2>&1
+	fi
+	return $?
+}
+
+linux_complete() {
+	local id="$1"
+	local subcmd="done"
+	"$TODOMAN_BIN" "$subcmd" "$id" 2>&1
+	return $?
+}
+
+linux_edit() {
+	local id="$1"
+	shift
+	# Translate common flags: --title is not supported by todoman edit,
+	# but --due, --priority, --location are.
+	"$TODOMAN_BIN" edit "$id" "$@" 2>&1
+	return $?
+}
+
+# =============================================================================
+# Platform-Dispatching Commands
+# =============================================================================
+
+cmd_setup() {
+	print_info "Platform detected: ${PLATFORM}"
+	case "$PLATFORM" in
+	macos) macos_setup ;;
+	linux) linux_setup ;;
+	esac
+}
+
+cmd_sync() {
+	case "$PLATFORM" in
+	macos) macos_sync ;;
+	linux)
+		linux_check_ready || return 1
+		linux_sync
+		;;
+	esac
+}
+
+cmd_lists() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local use_json="${JSON_OUTPUT:-false}"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json | -j)
+			use_json="true"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	case "$PLATFORM" in
+	macos) macos_lists "$use_json" ;;
+	linux) linux_lists "$use_json" ;;
+	esac
+}
+
 cmd_show() {
-	require_ready || return 1
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
 
 	local filter="${1:-today}"
 	shift || true
@@ -146,32 +491,24 @@ cmd_show() {
 			use_json="true"
 			shift
 			;;
-		*)
-			shift
-			;;
+		*) shift ;;
 		esac
 	done
 
-	local args=("$filter" --no-input --no-color)
-	if [[ -n "$list_name" ]]; then
-		args+=(--list "$list_name")
-	fi
-	if [[ "$use_json" == "true" ]]; then
-		args+=(--json)
-	fi
-
-	"$REMINDCTL_BIN" show "${args[@]}" 2>&1
-	return 0
+	case "$PLATFORM" in
+	macos) macos_show "$filter" "$list_name" "$use_json" ;;
+	linux) linux_show "$filter" "$list_name" "$use_json" ;;
+	esac
 }
 
 cmd_add() {
-	require_ready || return 1
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
 
-	local title=""
-	local list_name=""
-	local due_date=""
-	local notes=""
-	local priority=""
+	local title="" list_name="" due_date="" notes="" priority=""
+	local url="" flag="" tags="" location=""
 	local use_json="${JSON_OUTPUT:-false}"
 
 	# First positional arg is title if not a flag
@@ -202,13 +539,27 @@ cmd_add() {
 			priority="$2"
 			shift 2
 			;;
+		--url | -u)
+			url="$2"
+			shift 2
+			;;
+		--flag | -f)
+			flag="true"
+			shift
+			;;
+		--tags)
+			tags="$2"
+			shift 2
+			;;
+		--location)
+			location="$2"
+			shift 2
+			;;
 		--json | -j)
 			use_json="true"
 			shift
 			;;
-		*)
-			shift
-			;;
+		*) shift ;;
 		esac
 	done
 
@@ -217,25 +568,19 @@ cmd_add() {
 		return 1
 	fi
 
-	local args=("$title" --no-input --no-color)
-	if [[ -n "$list_name" ]]; then
-		args+=(--list "$list_name")
-	fi
-	if [[ -n "$due_date" ]]; then
-		args+=(--due "$due_date")
-	fi
-	if [[ -n "$notes" ]]; then
-		args+=(--notes "$notes")
-	fi
-	if [[ -n "$priority" ]]; then
-		args+=(--priority "$priority")
-	fi
-	if [[ "$use_json" == "true" ]]; then
-		args+=(--json)
-	fi
-
-	"$REMINDCTL_BIN" add "${args[@]}" 2>&1
-	local rc=$?
+	local rc=0
+	case "$PLATFORM" in
+	macos)
+		macos_add "$title" "$list_name" "$due_date" "$notes" "$priority" "$use_json" \
+			"$url" "$flag" "$tags" "$location"
+		rc=$?
+		;;
+	linux)
+		linux_add "$title" "$list_name" "$due_date" "$notes" "$priority" "$use_json" \
+			"$url" "$flag" "$tags" "$location"
+		rc=$?
+		;;
+	esac
 
 	if [[ $rc -eq 0 ]]; then
 		print_success "Reminder created: ${title}"
@@ -246,17 +591,30 @@ cmd_add() {
 }
 
 cmd_complete() {
-	require_ready || return 1
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
 
-	local id="$1"
+	local id="${1:-}"
 	if [[ -z "$id" ]]; then
 		print_error "Reminder ID required. Use 'show' to find IDs."
 		return 1
 	fi
 	shift
 
-	"$REMINDCTL_BIN" complete "$id" --no-input --no-color 2>&1
-	local rc=$?
+	local rc=0
+	case "$PLATFORM" in
+	macos)
+		macos_complete "$id"
+		rc=$?
+		;;
+	linux)
+		linux_complete "$id"
+		rc=$?
+		;;
+	esac
+
 	if [[ $rc -eq 0 ]]; then
 		print_success "Reminder completed: ${id}"
 	else
@@ -266,7 +624,10 @@ cmd_complete() {
 }
 
 cmd_edit() {
-	require_ready || return 1
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
 
 	local id=""
 	if [[ $# -gt 0 && ! "$1" =~ ^-- ]]; then
@@ -279,33 +640,41 @@ cmd_edit() {
 		return 1
 	fi
 
-	# Pass remaining args through to remindctl edit
-	"$REMINDCTL_BIN" edit "$id" --no-input --no-color "$@" 2>&1
-	return $?
+	case "$PLATFORM" in
+	macos) macos_edit "$id" "$@" ;;
+	linux) linux_edit "$id" "$@" ;;
+	esac
 }
 
 cmd_help() {
 	cat <<'HELP'
-Apple Reminders Helper — CLI wrapper for agent use
+Reminders Helper — cross-platform CLI for agent use
+
+Backends: remindctl (macOS/EventKit) | todoman + vdirsyncer (Linux/CalDAV)
 
 Usage: reminders-helper.sh <command> [args] [options]
 
 Commands:
-  setup                    Check/install remindctl, verify authorization
+  setup                    Check/install backend, verify access
   lists                    List all reminder lists
   show [filter] [options]  Show reminders
   add <title> [options]    Create a reminder
   complete <id>            Mark a reminder complete
   edit <id> [options]      Edit a reminder
+  sync                     Sync CalDAV (Linux; macOS syncs automatically)
   help                     Show this help
 
-Show filters: today, tomorrow, week, overdue, upcoming, completed, all, <date>
+Show filters: today, tomorrow, week, overdue, upcoming, completed, all
 
 Add options:
   --list, -l <name>        Target list (e.g., "Shopping", "Work")
-  --due, -d <date>         Due date (e.g., "tomorrow", "2026-01-15", "in 3 days")
+  --due, -d <date>         Due date (e.g., "tomorrow", "2026-01-15")
   --notes, -n <text>       Notes/description
   --priority, -p <level>   none, low, medium, high
+  --url, -u <url>          URL (prepended to notes)
+  --flag, -f               Flag the reminder (macOS only)
+  --tags <a,b,c>           Comma-separated tags (Linux only)
+  --location <text>        Location text (Linux only)
   --json, -j               JSON output (for agent consumption)
 
 Environment:
@@ -317,15 +686,42 @@ Examples:
   reminders-helper.sh show today
   reminders-helper.sh show overdue --list Work
   reminders-helper.sh add "Buy milk" --list Shopping --due tomorrow
-  reminders-helper.sh add "Review PR" --list Work --due "in 2 hours" --priority high
-  reminders-helper.sh add "Call dentist" --due "next Monday" --notes "Ask about cleaning"
+  reminders-helper.sh add "Review PR" --list Work --due "2026-04-05" --priority high
+  reminders-helper.sh add "Call dentist" --notes "Ask about cleaning"
   reminders-helper.sh complete 1
   reminders-helper.sh edit 2 --priority high --due tomorrow
+  reminders-helper.sh sync
 
-Setup (one-time):
+Setup — macOS (one-time):
   1. brew install steipete/tap/remindctl
   2. remindctl authorize
   3. System Settings > Privacy & Security > Reminders > enable terminal app
+
+Setup — Linux (one-time):
+  1. pipx install todoman vdirsyncer
+  2. Configure vdirsyncer: ~/.config/vdirsyncer/config
+     [general]
+     status_path = "~/.local/share/vdirsyncer/status/"
+     [pair reminders]
+     a = "reminders_local"
+     b = "reminders_remote"
+     collections = ["from a", "from b"]
+     [storage reminders_local]
+     type = "filesystem"
+     path = "~/.local/share/calendars/"
+     fileext = ".ics"
+     [storage reminders_remote]
+     type = "caldav"
+     url = "https://caldav.icloud.com/"
+     username = "your@icloud.com"
+     password.fetch = ["command", "gopass", "show", "icloud/app-password"]
+  3. Configure todoman: ~/.config/todoman/config.py
+     path = "~/.local/share/calendars/*"
+     date_format = "%Y-%m-%d"
+     time_format = "%H:%M"
+     default_list = "Reminders"
+  4. vdirsyncer discover && vdirsyncer sync
+  5. Verify: todo list
 HELP
 	return 0
 }
@@ -339,27 +735,14 @@ main() {
 	shift || true
 
 	case "$command" in
-	setup)
-		cmd_setup "$@"
-		;;
-	lists | list)
-		cmd_lists "$@"
-		;;
-	show)
-		cmd_show "$@"
-		;;
-	add)
-		cmd_add "$@"
-		;;
-	complete | done)
-		cmd_complete "$@"
-		;;
-	edit)
-		cmd_edit "$@"
-		;;
-	help | --help | -h)
-		cmd_help
-		;;
+	setup) cmd_setup "$@" ;;
+	lists | list) cmd_lists "$@" ;;
+	show) cmd_show "$@" ;;
+	add) cmd_add "$@" ;;
+	complete | done) cmd_complete "$@" ;;
+	edit) cmd_edit "$@" ;;
+	sync) cmd_sync "$@" ;;
+	help | --help | -h) cmd_help ;;
 	*)
 		print_error "${ERROR_UNKNOWN_COMMAND}: ${command}"
 		cmd_help

--- a/.agents/tools/productivity/apple-reminders.md
+++ b/.agents/tools/productivity/apple-reminders.md
@@ -1,5 +1,5 @@
 ---
-description: Create and manage Apple Reminders from agent sessions
+description: Create and manage reminders from agent sessions (macOS + Linux)
 mode: subagent
 tools:
   read: true
@@ -12,19 +12,39 @@ tools:
   task: false
 ---
 
-# Apple Reminders
+# Reminders
 
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
 - **Helper**: `~/.aidevops/agents/scripts/reminders-helper.sh [command] [args]`
-- **Underlying tool**: `remindctl` (`brew install steipete/tap/remindctl`)
-- **Setup**: `reminders-helper.sh setup` (install + authorize)
+- **macOS backend**: `remindctl` (`brew install steipete/tap/remindctl`) + osascript for flag
+- **Linux backend**: `todoman` + `vdirsyncer` (`pipx install todoman vdirsyncer`)
+- **Setup**: `reminders-helper.sh setup` (install + authorize/configure)
 - **Related**: `tools/productivity/caldav-calendar-skill.md` (calendar events, not tasks)
-- **macOS only** — uses EventKit via `remindctl`
 
 <!-- AI-CONTEXT-END -->
+
+## Field Coverage
+
+| Reminders field | macOS | Linux | Flag |
+|---|---|---|---|
+| Title | `--title` | `--title` | core |
+| Notes | `--notes` | `--notes` | core |
+| URL | `--url` (in notes) | `--url` (in notes) | workaround |
+| Date + Time | `--due` | `--due` | core |
+| List | `--list` | `--list` | core |
+| Tags | warn only | `--tags` | Linux only |
+| Flag | `--flag` (osascript) | `--flag` (in notes) | macOS native |
+| Priority | `--priority` | `--priority` | core |
+| Location | warn only | `--location` | Linux only |
+| When Messaging | not available | N/A | iOS-only trigger |
+| Assign Reminder | not available | N/A | no CLI support |
+| Add Image | not available | N/A | no CLI support |
+
+URL is prepended to notes as a clickable line (no CLI exposes the native URL field).
+Flag uses osascript post-creation on macOS; prepended as `[FLAGGED]` in notes on Linux.
 
 ## When Agents Should Create Reminders
 
@@ -59,79 +79,84 @@ If the user has configured a default list mapping in their config, use it. Other
 
 ## Usage
 
-### List available lists
-
-```bash
-reminders-helper.sh lists
-```
-
 ### Create a reminder
 
 ```bash
 # Simple
 reminders-helper.sh add "Buy milk" --list Shopping
 
-# With due date and priority
-reminders-helper.sh add "Review quarterly report" --list Work --due "next Friday" --priority high
+# With due date, priority, and flag
+reminders-helper.sh add "Review quarterly report" --list Work \
+  --due "next Friday" --priority high --flag
 
-# With notes
-reminders-helper.sh add "Call dentist" --due "Monday 9am" --notes "Ask about cleaning schedule"
+# With notes and URL
+reminders-helper.sh add "Read article on CalDAV" \
+  --url "https://example.com/article" --notes "Found via RSS feed"
 
-# Natural date expressions (handled by remindctl)
-reminders-helper.sh add "Submit tax return" --due "April 15" --priority high --list Personal
+# With tags (Linux) and location (Linux)
+reminders-helper.sh add "Pick up package" --list Personal \
+  --location "Post Office" --tags "errands,urgent"
+
+# Full example
+reminders-helper.sh add "Call dentist" --list Personal \
+  --due "Monday 9am" --priority medium --flag \
+  --notes "Ask about cleaning schedule" --url "https://dentist.example.com"
 ```
 
-### View reminders
+### Other commands
 
 ```bash
-reminders-helper.sh show today
-reminders-helper.sh show overdue --list Work
-reminders-helper.sh show week
-reminders-helper.sh show upcoming
-```
-
-### Complete a reminder
-
-```bash
-# Use index from show output
-reminders-helper.sh complete 1
-```
-
-### JSON output (for agent parsing)
-
-```bash
-JSON_OUTPUT=true reminders-helper.sh lists
-reminders-helper.sh show today --json
+reminders-helper.sh lists                          # List all lists
+reminders-helper.sh show today                     # Today's reminders
+reminders-helper.sh show overdue --list Work       # Overdue in Work
+reminders-helper.sh show week                      # This week
+reminders-helper.sh complete 1                     # Complete by index
+reminders-helper.sh edit 2 --priority high         # Edit fields
+reminders-helper.sh sync                           # CalDAV sync (Linux)
+JSON_OUTPUT=true reminders-helper.sh show today    # JSON for agents
 ```
 
 ## Due Date Formats
 
-`remindctl` accepts natural language dates:
+macOS (`remindctl`) accepts natural language: `today`, `tomorrow`, `next Monday`, `in 2 hours`, `in 3 days`, `April 15`, `end of month`.
 
-- `today`, `tomorrow`, `next Monday`
-- `in 2 hours`, `in 3 days`
-- `2026-04-15`, `April 15`
-- `next week`, `end of month`
+Linux (`todoman`) uses the configured date format (default `%Y-%m-%d`): `2026-04-15`.
 
-## Setup (One-Time)
+## Setup
 
-Run `reminders-helper.sh setup` or manually:
+### macOS (one-time)
 
-1. `brew install steipete/tap/remindctl`
-2. `remindctl authorize` (triggers macOS permission prompt)
-3. System Settings > Privacy & Security > Reminders > enable your terminal app
-4. Verify: `remindctl list` (should show your reminder lists)
+```bash
+reminders-helper.sh setup
+# Or manually:
+# 1. brew install steipete/tap/remindctl
+# 2. remindctl authorize
+# 3. System Settings > Privacy & Security > Reminders > enable terminal app
+```
 
-If using multiple accounts (iCloud + other CalDAV), all accounts configured in System Settings > Internet Accounts appear automatically — no extra setup per account.
+All accounts from System Settings > Internet Accounts (iCloud, CalDAV, Google, etc.) appear automatically.
+
+### Linux (one-time)
+
+```bash
+reminders-helper.sh setup
+# Or manually:
+# 1. pipx install todoman vdirsyncer
+# 2. Configure ~/.config/vdirsyncer/config (CalDAV credentials)
+# 3. Configure ~/.config/todoman/config.py (point to synced calendars)
+# 4. vdirsyncer discover && vdirsyncer sync
+```
+
+See `reminders-helper.sh help` for example vdirsyncer/todoman configs.
 
 ## Integration with Routines and Missions
 
-Other agents should create reminders by calling the helper script directly:
+Other agents call the helper script directly:
 
 ```bash
 # From any agent with bash access:
 ~/.aidevops/agents/scripts/reminders-helper.sh add "Follow up with client" \
-  --list Work --due "in 3 days" --priority medium \
+  --list Work --due "in 3 days" --priority medium --flag \
   --notes "Re: proposal sent on $(date +%Y-%m-%d)"
 ```
 
@@ -155,6 +180,6 @@ reminders-helper.sh add "MISSION: ${mission_name} — ${action_needed}" \
 
 ## Accounts
 
-All accounts configured in macOS System Settings > Internet Accounts (iCloud, Google, Fastmail, CalDAV, etc.) are accessible. `remindctl` sees every list across all accounts. The list name is the selector — no need to specify the account explicitly.
+**macOS**: All accounts configured in System Settings > Internet Accounts are accessible. List name is the selector -- no account specification needed. If two accounts share a list name, rename one to disambiguate.
 
-If two accounts have lists with the same name, `remindctl` uses the default account's list. Rename one list to disambiguate.
+**Linux**: Each CalDAV account needs a `[pair]` + `[storage]` block in `~/.config/vdirsyncer/config`. After `vdirsyncer discover && vdirsyncer sync`, all lists appear as directories under the todoman path.


### PR DESCRIPTION
## Summary

- Add Linux backend (`todoman` + `vdirsyncer`) alongside macOS (`remindctl`) with OS auto-detection
- Add `--url`, `--flag`, `--tags`, `--location` options to cover more Reminders fields
- Rename subagent from "Apple Reminders" to "Reminders" reflecting cross-platform support

## Field Coverage

| Field | macOS | Linux |
|---|---|---|
| Title, Notes, Due, List, Priority | native | native |
| URL | prepended to notes | prepended to notes |
| Flag | osascript post-creation | `[FLAGGED]` in notes |
| Tags | warn (no CLI support) | `--category` via todoman |
| Location | warn (no CLI support) | `--location` via todoman |
| Messaging/Assignment/Image | not available (iOS-only or no CLI) | N/A |

---
[aidevops.sh](https://aidevops.sh) v3.5.593 plugin for Claude Code with claude-opus-4-6 spent 22m and 39,703 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended reminders functionality to support both macOS and Linux (previously macOS-only)
  * New `sync` command for reminders synchronization
  * New options when adding reminders: `--url`, `--flag`, `--tags`, and `--location`

* **Documentation**
  * Updated documentation with platform-specific setup, field coverage, and usage examples for both macOS and Linux
  * Version bumped to 2.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->