### PR TITLE
feat: add Calendar and Contacts agents with cross-platform support

### DIFF
--- a/.agents/scripts/calendar-helper.sh
+++ b/.agents/scripts/calendar-helper.sh
@@ -1,0 +1,593 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+set -euo pipefail
+
+# Calendar Helper — cross-platform CLI for agent use
+#
+# Backends:
+#   macOS:  icalBuddy (read) + osascript (write) via Calendar.app / EventKit
+#   Linux:  khal + vdirsyncer (CalDAV)
+#
+# Usage: ./calendar-helper.sh [command] [args] [options]
+# Commands:
+#   setup                - Check/install backend, verify access
+#   calendars            - List all calendars
+#   today                - Show today's events
+#   show [filter]        - Show events (today|tomorrow|week|DATE|DATE..DATE)
+#   add <title> [opts]   - Create an event
+#   search <query>       - Search events
+#   sync                 - Sync CalDAV (Linux; macOS syncs automatically)
+#   help                 - Show this help
+#
+# Author: AI DevOps Framework
+# Version: 1.0.0
+# License: MIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+init_log_file
+
+# =============================================================================
+# Platform Detection
+# =============================================================================
+
+detect_platform() {
+	local os
+	os="$(uname -s)"
+	case "$os" in
+	Darwin) echo "macos" ;;
+	Linux) echo "linux" ;;
+	*)
+		print_error "Unsupported platform: ${os}"
+		return 1
+		;;
+	esac
+	return 0
+}
+
+PLATFORM="$(detect_platform)" || exit 1
+
+# =============================================================================
+# macOS Backend (icalBuddy + osascript)
+# =============================================================================
+
+macos_check_ready() {
+	# Calendar.app is always available on macOS; osascript handles access
+	return 0
+}
+
+macos_setup() {
+	print_info "Checking Calendar access (macOS)..."
+	local count
+	count="$(osascript -e 'tell application "Calendar" to count of calendars' 2>&1)" || true
+	if [[ "$count" =~ ^[0-9]+$ ]]; then
+		print_success "Calendar access: authorized (${count} calendars)"
+		print_info "Available calendars:"
+		osascript -e 'tell application "Calendar" to get name of every calendar' 2>&1 || true
+	else
+		print_warning "Calendar access may need authorization."
+		print_info "System Settings > Privacy & Security > Calendars > enable your terminal app"
+		return 1
+	fi
+	print_success "macOS calendar setup complete."
+	return 0
+}
+
+macos_calendars() {
+	osascript -e 'tell application "Calendar" to get name of every calendar' 2>&1
+	return 0
+}
+
+macos_show() {
+	local filter="$1"
+	local calendar="$2"
+
+	local cal_filter=""
+	if [[ -n "$calendar" ]]; then
+		cal_filter="of calendar \"${calendar}\""
+	fi
+
+	# Calculate date range based on filter
+	local script=""
+	case "$filter" in
+	today)
+		script="
+set startDate to current date
+set time of startDate to 0
+set endDate to startDate + 1 * days"
+		;;
+	tomorrow)
+		script="
+set startDate to (current date) + 1 * days
+set time of startDate to 0
+set endDate to startDate + 1 * days"
+		;;
+	week)
+		script="
+set startDate to current date
+set time of startDate to 0
+set endDate to startDate + 7 * days"
+		;;
+	*)
+		# For specific dates, fall back to a wide range
+		script="
+set startDate to current date
+set time of startDate to 0
+set endDate to startDate + 30 * days"
+		;;
+	esac
+
+	osascript -e "
+tell application \"Calendar\"
+	${script}
+	set output to {}
+	repeat with cal in calendars
+		if \"${calendar}\" is \"\" or name of cal is \"${calendar}\" then
+			repeat with evt in (events of cal)
+				try
+					if start date of evt >= startDate and start date of evt < endDate then
+						set evtLine to (start date of evt as text) & \" | \" & summary of evt
+						if location of evt is not missing value and location of evt is not \"\" then
+							set evtLine to evtLine & \" @ \" & location of evt
+						end if
+						set end of output to evtLine
+					end if
+				end try
+			end repeat
+		end if
+	end repeat
+	if (count of output) = 0 then return \"No events found.\"
+	return output as text
+end tell" 2>&1
+	return 0
+}
+
+macos_add() {
+	local title="$1" calendar="$2" start_dt="$3" end_dt="$4"
+	local location="$5" notes="$6" url="$7" allday="$8"
+
+	local cal_clause=""
+	if [[ -n "$calendar" ]]; then
+		cal_clause="of calendar \"${calendar}\""
+	fi
+
+	local props="set summary of newEvent to \"${title}\""
+	[[ -n "$location" ]] && props="${props}
+set location of newEvent to \"${location}\""
+	[[ -n "$notes" ]] && props="${props}
+set description of newEvent to \"${notes}\""
+	[[ -n "$url" ]] && props="${props}
+set url of newEvent to \"${url}\""
+
+	local date_setup=""
+	if [[ "$allday" == "true" ]]; then
+		date_setup="set allday event of newEvent to true
+set start date of newEvent to date \"${start_dt}\""
+	else
+		date_setup="set start date of newEvent to date \"${start_dt}\""
+		if [[ -n "$end_dt" ]]; then
+			date_setup="${date_setup}
+set end date of newEvent to date \"${end_dt}\""
+		fi
+	fi
+
+	osascript -e "
+tell application \"Calendar\"
+	set newEvent to make new event at end of events ${cal_clause} with properties {summary:\"${title}\"}
+	${date_setup}
+	${props}
+end tell" 2>&1
+
+	return $?
+}
+
+macos_search() {
+	local query="$1"
+	local calendar="$2"
+
+	local cal_filter=""
+	if [[ -n "$calendar" ]]; then
+		cal_filter="of calendar \"${calendar}\""
+	fi
+
+	osascript -e "
+tell application \"Calendar\"
+	set startDate to current date
+	set endDate to startDate + 90 * days
+	set output to {}
+	repeat with cal in calendars
+		if \"${calendar}\" is \"\" or name of cal is \"${calendar}\" then
+			repeat with evt in (events of cal)
+				try
+					if start date of evt >= startDate and start date of evt < endDate then
+						if summary of evt contains \"${query}\" then
+							set evtLine to (start date of evt as text) & \" | \" & summary of evt
+							set end of output to evtLine
+						end if
+					end if
+				end try
+			end repeat
+		end if
+	end repeat
+	if (count of output) = 0 then return \"No matching events found.\"
+	return output as text
+end tell" 2>&1
+	return 0
+}
+
+macos_sync() {
+	print_info "macOS syncs calendars automatically via EventKit."
+	return 0
+}
+
+# =============================================================================
+# Linux Backend (khal + vdirsyncer)
+# =============================================================================
+
+linux_check_ready() {
+	if ! command -v khal >/dev/null 2>&1; then
+		print_error "khal not found. Install: brew install khal (or pipx install khal)"
+		return 1
+	fi
+	if ! command -v vdirsyncer >/dev/null 2>&1; then
+		print_error "vdirsyncer not found. Install: pipx install vdirsyncer"
+		return 1
+	fi
+	return 0
+}
+
+linux_setup() {
+	print_info "Checking Calendar CLI setup (Linux)..."
+
+	if command -v khal >/dev/null 2>&1; then
+		print_success "khal installed: $(khal --version 2>&1)"
+	else
+		print_warning "khal not installed. Install: brew install khal (or pipx install khal)"
+		return 1
+	fi
+
+	if command -v vdirsyncer >/dev/null 2>&1; then
+		print_success "vdirsyncer installed: $(vdirsyncer --version 2>&1)"
+	else
+		print_warning "vdirsyncer not installed. Install: pipx install vdirsyncer"
+		return 1
+	fi
+
+	if [[ -f "${HOME}/.config/khal/config" ]]; then
+		print_success "khal config found"
+	else
+		print_warning "khal not configured: ~/.config/khal/config"
+		print_info "Run: khal configure"
+		return 1
+	fi
+
+	print_info "Available calendars:"
+	khal printcalendars 2>&1 || true
+	print_success "Linux calendar setup complete."
+	return 0
+}
+
+linux_calendars() {
+	khal printcalendars 2>&1
+	return 0
+}
+
+linux_show() {
+	local filter="$1"
+	local calendar="$2"
+
+	local args=()
+	[[ -n "$calendar" ]] && args+=(-a "$calendar")
+
+	case "$filter" in
+	today) khal list "${args[@]}" today today 2>&1 ;;
+	tomorrow) khal list "${args[@]}" tomorrow tomorrow 2>&1 ;;
+	week) khal list "${args[@]}" today 7d 2>&1 ;;
+	*)
+		if [[ "$filter" == *..* ]]; then
+			local from="${filter%..*}"
+			local to="${filter#*..}"
+			khal list "${args[@]}" "$from" "$to" 2>&1
+		else
+			khal list "${args[@]}" "$filter" "$filter" 2>&1
+		fi
+		;;
+	esac
+	return 0
+}
+
+linux_add() {
+	local title="$1" calendar="$2" start_dt="$3" end_dt="$4"
+	local location="$5" notes="$6" url="$7" allday="$8"
+
+	local args=()
+	[[ -n "$calendar" ]] && args+=(-a "$calendar")
+	[[ -n "$location" ]] && args+=(-l "$location")
+	[[ -n "$url" ]] && args+=(--url "$url")
+
+	if [[ "$allday" == "true" ]]; then
+		args+=("$start_dt" "$title")
+	else
+		args+=("$start_dt")
+		[[ -n "$end_dt" ]] && args+=("$end_dt")
+		args+=("$title")
+	fi
+
+	if [[ -n "$notes" ]]; then
+		args+=(:: "$notes")
+	fi
+
+	khal new "${args[@]}" 2>&1
+	return $?
+}
+
+linux_search() {
+	local query="$1"
+	local calendar="$2"
+
+	local args=()
+	[[ -n "$calendar" ]] && args+=(-a "$calendar")
+
+	khal search "${args[@]}" "$query" 2>&1
+	return 0
+}
+
+linux_sync() {
+	print_info "Syncing CalDAV..."
+	vdirsyncer sync 2>&1
+	local rc=$?
+	if [[ $rc -eq 0 ]]; then
+		print_success "CalDAV sync complete"
+	else
+		print_warning "CalDAV sync had issues (exit ${rc})"
+	fi
+	return $rc
+}
+
+# =============================================================================
+# Platform-Dispatching Commands
+# =============================================================================
+
+cmd_setup() {
+	print_info "Platform: ${PLATFORM}"
+	case "$PLATFORM" in
+	macos) macos_setup ;;
+	linux) linux_setup ;;
+	esac
+}
+
+cmd_calendars() {
+	case "$PLATFORM" in
+	macos)
+		macos_check_ready || return 1
+		macos_calendars
+		;;
+	linux)
+		linux_check_ready || return 1
+		linux_calendars
+		;;
+	esac
+}
+
+cmd_show() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local filter="${1:-today}"
+	shift || true
+
+	local calendar=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--calendar | -a)
+			calendar="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	case "$PLATFORM" in
+	macos) macos_show "$filter" "$calendar" ;;
+	linux) linux_show "$filter" "$calendar" ;;
+	esac
+}
+
+cmd_add() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local title="" calendar="" start_dt="" end_dt=""
+	local location="" notes="" url="" allday=""
+
+	# First positional arg is title if not a flag
+	if [[ $# -gt 0 && ! "$1" =~ ^-- ]]; then
+		title="$1"
+		shift
+	fi
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--title | -t)
+			title="$2"
+			shift 2
+			;;
+		--calendar | -a)
+			calendar="$2"
+			shift 2
+			;;
+		--start | -s)
+			start_dt="$2"
+			shift 2
+			;;
+		--end | -e)
+			end_dt="$2"
+			shift 2
+			;;
+		--location | -l)
+			location="$2"
+			shift 2
+			;;
+		--notes | -n)
+			notes="$2"
+			shift 2
+			;;
+		--url | -u)
+			url="$2"
+			shift 2
+			;;
+		--allday)
+			allday="true"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$title" ]]; then
+		print_error "Title required. Usage: calendar-helper.sh add \"Meeting\" --start \"2026-04-05 14:00\" --end \"2026-04-05 15:00\""
+		return 1
+	fi
+	if [[ -z "$start_dt" ]]; then
+		print_error "Start date/time required (--start)"
+		return 1
+	fi
+
+	local rc=0
+	case "$PLATFORM" in
+	macos)
+		macos_add "$title" "$calendar" "$start_dt" "$end_dt" \
+			"$location" "$notes" "$url" "$allday"
+		rc=$?
+		;;
+	linux)
+		linux_add "$title" "$calendar" "$start_dt" "$end_dt" \
+			"$location" "$notes" "$url" "$allday"
+		rc=$?
+		;;
+	esac
+
+	if [[ $rc -eq 0 ]]; then
+		print_success "Event created: ${title}"
+	else
+		print_error "Failed to create event: ${title}"
+	fi
+	return $rc
+}
+
+cmd_search() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local query="${1:-}"
+	if [[ -z "$query" ]]; then
+		print_error "Search query required."
+		return 1
+	fi
+	shift || true
+
+	local calendar=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--calendar | -a)
+			calendar="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	case "$PLATFORM" in
+	macos) macos_search "$query" "$calendar" ;;
+	linux) linux_search "$query" "$calendar" ;;
+	esac
+}
+
+cmd_sync() {
+	case "$PLATFORM" in
+	macos) macos_sync ;;
+	linux)
+		linux_check_ready || return 1
+		linux_sync
+		;;
+	esac
+}
+
+cmd_help() {
+	cat <<'HELP'
+Calendar Helper — cross-platform CLI for agent use
+
+Backends: icalBuddy + osascript (macOS) | khal + vdirsyncer (Linux)
+
+Usage: calendar-helper.sh <command> [args] [options]
+
+Commands:
+  setup                    Check/install backend, verify access
+  calendars                List all calendars
+  show [filter] [options]  Show events
+  add <title> [options]    Create an event
+  search <query> [options] Search events
+  sync                     Sync CalDAV (Linux; macOS syncs automatically)
+  help                     Show this help
+
+Show filters: today, tomorrow, week, DATE, DATE..DATE
+
+Add options:
+  --calendar, -a <name>    Target calendar
+  --start, -s <datetime>   Start date/time (required)
+  --end, -e <datetime>     End date/time
+  --location, -l <text>    Location
+  --notes, -n <text>       Description/notes
+  --url, -u <url>          Event URL
+  --allday                 All-day event (no time needed)
+
+Examples:
+  calendar-helper.sh setup
+  calendar-helper.sh calendars
+  calendar-helper.sh show today
+  calendar-helper.sh show week --calendar Work
+  calendar-helper.sh show 2026-04-10..2026-04-15
+  calendar-helper.sh add "Team standup" --start "2026-04-05 09:00" --end "2026-04-05 09:30" --calendar Work
+  calendar-helper.sh add "Holiday" --start "2026-04-10" --allday --calendar Personal
+  calendar-helper.sh add "Dinner" --start "2026-04-05 19:00" --location "The Restaurant" --notes "Reservation for 4"
+  calendar-helper.sh search "standup" --calendar Work
+  calendar-helper.sh sync
+
+Setup — macOS: No install needed (uses Calendar.app). May need Privacy authorization.
+Setup — Linux: brew install khal && pipx install vdirsyncer, then configure CalDAV
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	setup) cmd_setup "$@" ;;
+	calendars | cals) cmd_calendars "$@" ;;
+	show | today) cmd_show "$command" "$@" ;;
+	add | new) cmd_add "$@" ;;
+	search | find) cmd_search "$@" ;;
+	sync) cmd_sync "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		print_error "${ERROR_UNKNOWN_COMMAND}: ${command}"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/contacts-helper.sh
+++ b/.agents/scripts/contacts-helper.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+set -euo pipefail
+
+# Contacts Helper — cross-platform CLI for agent use
+#
+# Backends:
+#   macOS:  osascript via Contacts.app
+#   Linux:  khard + vdirsyncer (CardDAV)
+#
+# Usage: ./contacts-helper.sh [command] [args] [options]
+# Commands:
+#   setup                - Check/install backend, verify access
+#   books                - List addressbooks
+#   search <query>       - Search contacts by name/email/phone
+#   show <name>          - Show full contact details
+#   add [options]        - Create a new contact
+#   email <query>        - List email addresses matching query
+#   phone <query>        - List phone numbers matching query
+#   sync                 - Sync CardDAV (Linux; macOS syncs automatically)
+#   help                 - Show this help
+#
+# Author: AI DevOps Framework
+# Version: 1.0.0
+# License: MIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+init_log_file
+
+# =============================================================================
+# Platform Detection
+# =============================================================================
+
+detect_platform() {
+	local os
+	os="$(uname -s)"
+	case "$os" in
+	Darwin) echo "macos" ;;
+	Linux) echo "linux" ;;
+	*)
+		print_error "Unsupported platform: ${os}"
+		return 1
+		;;
+	esac
+	return 0
+}
+
+PLATFORM="$(detect_platform)" || exit 1
+
+# =============================================================================
+# macOS Backend (osascript / Contacts.app)
+# =============================================================================
+
+macos_check_ready() {
+	# Contacts.app is always available on macOS
+	return 0
+}
+
+macos_setup() {
+	print_info "Checking Contacts access (macOS)..."
+	# Test access by listing a small number
+	local count
+	count="$(osascript -e 'tell application "Contacts" to count of people' 2>&1)" || true
+	if [[ "$count" =~ ^[0-9]+$ ]]; then
+		print_success "Contacts access: authorized (${count} contacts)"
+	else
+		print_warning "Contacts access may need authorization."
+		print_info "System Settings > Privacy & Security > Contacts > enable your terminal app"
+		return 1
+	fi
+	print_success "macOS contacts setup complete."
+	return 0
+}
+
+macos_books() {
+	osascript -e 'tell application "Contacts" to get name of every group' 2>&1
+	return 0
+}
+
+macos_search() {
+	local query="$1"
+	# Fast approach: get all names, filter in bash (avoids slow AppleScript whose)
+	osascript -e 'tell application "Contacts" to get name of every person' 2>&1 |
+		tr ',' '\n' | sed 's/^ //' | grep -i "$query" || echo "No contacts found matching: ${query}"
+	return 0
+}
+
+macos_show() {
+	local name="$1"
+	osascript -e "
+tell application \"Contacts\"
+	set matchList to every person whose name is \"${name}\"
+	if (count of matchList) = 0 then
+		set matchList to every person whose name contains \"${name}\"
+	end if
+	if (count of matchList) = 0 then return \"No contact found matching: ${name}\"
+	set p to item 1 of matchList
+	set output to {\"Name: \" & name of p}
+	try
+		if organization of p is not missing value then set end of output to \"Organization: \" & organization of p
+	end try
+	try
+		if job title of p is not missing value then set end of output to \"Job Title: \" & job title of p
+	end try
+	repeat with e in emails of p
+		set end of output to \"Email (\" & label of e & \"): \" & value of e
+	end repeat
+	repeat with ph in phones of p
+		set end of output to \"Phone (\" & label of ph & \"): \" & value of ph
+	end repeat
+	try
+		if note of p is not missing value then set end of output to \"Notes: \" & note of p
+	end try
+	return output as text
+end tell" 2>&1
+	return 0
+}
+
+macos_add() {
+	local first="$1" last="$2" org="$3" email="$4" phone="$5"
+	local notes="$6" jobtitle="$7"
+
+	local props="first name:\"${first}\""
+	[[ -n "$last" ]] && props="${props}, last name:\"${last}\""
+	[[ -n "$org" ]] && props="${props}, organization:\"${org}\""
+	[[ -n "$jobtitle" ]] && props="${props}, job title:\"${jobtitle}\""
+	[[ -n "$notes" ]] && props="${props}, note:\"${notes}\""
+
+	local extra_cmds=""
+	if [[ -n "$email" ]]; then
+		extra_cmds="${extra_cmds}
+make new email at end of emails of newPerson with properties {label:\"work\", value:\"${email}\"}"
+	fi
+	if [[ -n "$phone" ]]; then
+		extra_cmds="${extra_cmds}
+make new phone at end of phones of newPerson with properties {label:\"mobile\", value:\"${phone}\"}"
+	fi
+
+	osascript -e "
+tell application \"Contacts\"
+	set newPerson to make new person with properties {${props}}
+	${extra_cmds}
+	save
+end tell" 2>&1
+
+	return $?
+}
+
+macos_email() {
+	local query="$1"
+	# Get matching names first (fast), then pull emails for matches
+	local names
+	names="$(osascript -e 'tell application "Contacts" to get name of every person' 2>&1 |
+		tr ',' '\n' | sed 's/^ //' | grep -i "$query")" || true
+	if [[ -z "$names" ]]; then
+		echo "No contacts found matching: ${query}"
+		return 0
+	fi
+	# Get email for the first match (detailed lookup)
+	local first_match
+	first_match="$(echo "$names" | head -1 | sed 's/^[[:space:]]*//')"
+	macos_show "$first_match" 2>&1 | grep -i "Email" || echo "No email found for: ${first_match}"
+	return 0
+}
+
+macos_phone() {
+	local query="$1"
+	local names
+	names="$(osascript -e 'tell application "Contacts" to get name of every person' 2>&1 |
+		tr ',' '\n' | sed 's/^ //' | grep -i "$query")" || true
+	if [[ -z "$names" ]]; then
+		echo "No contacts found matching: ${query}"
+		return 0
+	fi
+	local first_match
+	first_match="$(echo "$names" | head -1 | sed 's/^[[:space:]]*//')"
+	macos_show "$first_match" 2>&1 | grep -i "Phone" || echo "No phone found for: ${first_match}"
+	return 0
+}
+
+macos_sync() {
+	print_info "macOS syncs contacts automatically via iCloud/CardDAV."
+	return 0
+}
+
+# =============================================================================
+# Linux Backend (khard + vdirsyncer)
+# =============================================================================
+
+KHARD_BIN="khard"
+
+linux_check_ready() {
+	if ! command -v "$KHARD_BIN" >/dev/null 2>&1; then
+		print_error "khard not found. Install: brew install khard (or pipx install khard)"
+		return 1
+	fi
+	if ! command -v vdirsyncer >/dev/null 2>&1; then
+		print_error "vdirsyncer not found. Install: pipx install vdirsyncer"
+		return 1
+	fi
+	if [[ ! -f "${HOME}/.config/khard/khard.conf" ]]; then
+		print_error "khard not configured: ~/.config/khard/khard.conf"
+		return 1
+	fi
+	return 0
+}
+
+linux_setup() {
+	print_info "Checking Contacts CLI setup (Linux)..."
+
+	if command -v "$KHARD_BIN" >/dev/null 2>&1; then
+		print_success "khard installed: $("$KHARD_BIN" --version 2>&1)"
+	else
+		print_warning "khard not installed. Install: brew install khard"
+		return 1
+	fi
+
+	if command -v vdirsyncer >/dev/null 2>&1; then
+		print_success "vdirsyncer installed"
+	else
+		print_warning "vdirsyncer not installed. Install: pipx install vdirsyncer"
+		return 1
+	fi
+
+	if [[ -f "${HOME}/.config/khard/khard.conf" ]]; then
+		print_success "khard config found"
+	else
+		print_warning "khard not configured: ~/.config/khard/khard.conf"
+		return 1
+	fi
+
+	print_info "Addressbooks:"
+	"$KHARD_BIN" addressbooks 2>&1 || true
+	print_success "Linux contacts setup complete."
+	return 0
+}
+
+linux_books() {
+	"$KHARD_BIN" addressbooks 2>&1
+	return 0
+}
+
+linux_search() {
+	local query="$1"
+	"$KHARD_BIN" list "$query" 2>&1
+	return 0
+}
+
+linux_show() {
+	local name="$1"
+	"$KHARD_BIN" show "$name" 2>&1
+	return 0
+}
+
+linux_add() {
+	local first="$1" last="$2" org="$3" email="$4" phone="$5"
+	local notes="$6" jobtitle="$7"
+
+	# Build a YAML template and pipe to khard
+	local yaml="First name: ${first}"
+	[[ -n "$last" ]] && yaml="${yaml}
+Last name: ${last}"
+	[[ -n "$org" ]] && yaml="${yaml}
+Organisation: ${org}"
+	[[ -n "$jobtitle" ]] && yaml="${yaml}
+Title: ${jobtitle}"
+	[[ -n "$notes" ]] && yaml="${yaml}
+Note: ${notes}"
+	[[ -n "$email" ]] && yaml="${yaml}
+Email:
+    work: ${email}"
+	[[ -n "$phone" ]] && yaml="${yaml}
+Phone:
+    cell: ${phone}"
+
+	echo "$yaml" | "$KHARD_BIN" new --skip-unparsable 2>&1
+	return $?
+}
+
+linux_email() {
+	local query="$1"
+	"$KHARD_BIN" email "$query" 2>&1
+	return 0
+}
+
+linux_phone() {
+	local query="$1"
+	"$KHARD_BIN" phone "$query" 2>&1
+	return 0
+}
+
+linux_sync() {
+	print_info "Syncing CardDAV..."
+	vdirsyncer sync 2>&1
+	local rc=$?
+	if [[ $rc -eq 0 ]]; then
+		print_success "CardDAV sync complete"
+	else
+		print_warning "CardDAV sync had issues (exit ${rc})"
+	fi
+	return $rc
+}
+
+# =============================================================================
+# Platform-Dispatching Commands
+# =============================================================================
+
+cmd_setup() {
+	print_info "Platform: ${PLATFORM}"
+	case "$PLATFORM" in
+	macos) macos_setup ;;
+	linux) linux_setup ;;
+	esac
+}
+
+cmd_books() {
+	case "$PLATFORM" in
+	macos)
+		macos_check_ready || return 1
+		macos_books
+		;;
+	linux)
+		linux_check_ready || return 1
+		linux_books
+		;;
+	esac
+}
+
+cmd_search() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local query="${1:-}"
+	if [[ -z "$query" ]]; then
+		print_error "Search query required."
+		return 1
+	fi
+
+	case "$PLATFORM" in
+	macos) macos_search "$query" ;;
+	linux) linux_search "$query" ;;
+	esac
+}
+
+cmd_show() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local name="${1:-}"
+	if [[ -z "$name" ]]; then
+		print_error "Contact name required."
+		return 1
+	fi
+
+	case "$PLATFORM" in
+	macos) macos_show "$name" ;;
+	linux) linux_show "$name" ;;
+	esac
+}
+
+cmd_add() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local first="" last="" org="" email="" phone="" notes="" jobtitle=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--first | -f)
+			first="$2"
+			shift 2
+			;;
+		--last | -l)
+			last="$2"
+			shift 2
+			;;
+		--org | -o)
+			org="$2"
+			shift 2
+			;;
+		--email | -e)
+			email="$2"
+			shift 2
+			;;
+		--phone | -p)
+			phone="$2"
+			shift 2
+			;;
+		--notes | -n)
+			notes="$2"
+			shift 2
+			;;
+		--title | -t)
+			jobtitle="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$first" && -z "$org" ]]; then
+		print_error "First name (--first) or organization (--org) required."
+		return 1
+	fi
+
+	local rc=0
+	case "$PLATFORM" in
+	macos)
+		macos_add "$first" "$last" "$org" "$email" "$phone" "$notes" "$jobtitle"
+		rc=$?
+		;;
+	linux)
+		linux_add "$first" "$last" "$org" "$email" "$phone" "$notes" "$jobtitle"
+		rc=$?
+		;;
+	esac
+
+	if [[ $rc -eq 0 ]]; then
+		print_success "Contact created: ${first} ${last}"
+	else
+		print_error "Failed to create contact"
+	fi
+	return $rc
+}
+
+cmd_email() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local query="${1:-}"
+	if [[ -z "$query" ]]; then
+		print_error "Search query required."
+		return 1
+	fi
+
+	case "$PLATFORM" in
+	macos) macos_email "$query" ;;
+	linux) linux_email "$query" ;;
+	esac
+}
+
+cmd_phone() {
+	case "$PLATFORM" in
+	macos) macos_check_ready || return 1 ;;
+	linux) linux_check_ready || return 1 ;;
+	esac
+
+	local query="${1:-}"
+	if [[ -z "$query" ]]; then
+		print_error "Search query required."
+		return 1
+	fi
+
+	case "$PLATFORM" in
+	macos) macos_phone "$query" ;;
+	linux) linux_phone "$query" ;;
+	esac
+}
+
+cmd_sync() {
+	case "$PLATFORM" in
+	macos) macos_sync ;;
+	linux)
+		linux_check_ready || return 1
+		linux_sync
+		;;
+	esac
+}
+
+cmd_help() {
+	cat <<'HELP'
+Contacts Helper — cross-platform CLI for agent use
+
+Backends: osascript/Contacts.app (macOS) | khard + vdirsyncer (Linux/CardDAV)
+
+Usage: contacts-helper.sh <command> [args] [options]
+
+Commands:
+  setup                  Check/install backend, verify access
+  books                  List addressbooks/groups
+  search <query>         Search contacts by name
+  show <name>            Show full contact details
+  add [options]          Create a new contact
+  email <query>          List email addresses matching name
+  phone <query>          List phone numbers matching name
+  sync                   Sync CardDAV (Linux; macOS syncs automatically)
+  help                   Show this help
+
+Add options:
+  --first, -f <name>     First name
+  --last, -l <name>      Last name
+  --org, -o <company>    Organization/company
+  --email, -e <addr>     Email address
+  --phone, -p <number>   Phone number
+  --title, -t <title>    Job title
+  --notes, -n <text>     Notes
+
+Examples:
+  contacts-helper.sh setup
+  contacts-helper.sh search "John"
+  contacts-helper.sh show "John Smith"
+  contacts-helper.sh email "Smith"
+  contacts-helper.sh phone "Smith"
+  contacts-helper.sh add --first John --last Smith --email john@example.com --phone "+44123456789"
+  contacts-helper.sh add --first Jane --org "Acme Corp" --title "CTO" --notes "Met at conference"
+  contacts-helper.sh sync
+
+Setup — macOS: No install needed (uses Contacts.app). May need Privacy authorization.
+Setup — Linux: brew install khard && pipx install vdirsyncer, then configure CardDAV.
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	setup) cmd_setup "$@" ;;
+	books | addressbooks | groups) cmd_books "$@" ;;
+	search | find) cmd_search "$@" ;;
+	show | details) cmd_show "$@" ;;
+	add | new) cmd_add "$@" ;;
+	email | emails) cmd_email "$@" ;;
+	phone | phones) cmd_phone "$@" ;;
+	sync) cmd_sync "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		print_error "${ERROR_UNKNOWN_COMMAND}: ${command}"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/tools/productivity/calendar.md
+++ b/.agents/tools/productivity/calendar.md
@@ -1,0 +1,131 @@
+---
+description: Create and query calendar events from agent sessions (macOS + Linux)
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+  task: false
+---
+
+# Calendar
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Helper**: `~/.aidevops/agents/scripts/calendar-helper.sh [command] [args]`
+- **macOS backend**: `osascript` via Calendar.app (no install needed)
+- **Linux backend**: `khal` + `vdirsyncer` (CalDAV)
+- **Setup**: `calendar-helper.sh setup`
+- **Related**: `tools/productivity/apple-reminders.md` (tasks/reminders, not events)
+
+<!-- AI-CONTEXT-END -->
+
+## Field Coverage
+
+| Calendar field | macOS | Linux | Notes |
+|---|---|---|---|
+| Title/summary | osascript | khal | core |
+| Start date/time | osascript | khal | core |
+| End date/time | osascript | khal | core |
+| Location | osascript | khal `--location` | core |
+| Notes/description | osascript | khal `:: desc` | core |
+| URL | osascript | khal `--url` | core |
+| Calendar selection | osascript | khal `-a` | core |
+| All-day event | osascript | khal (date only) | core |
+| Recurrence | not yet | khal `--repeat` | Linux only |
+| Alarms | not yet | khal `--alarms` | Linux only |
+| Categories/tags | not yet | khal `--categories` | Linux only |
+| Invitees/attendees | not available | not available | no CLI support |
+| Travel time | not available | N/A | macOS-only UI |
+| Availability | not available | not available | no CLI support |
+
+## When Agents Should Create Events
+
+Create a calendar event when:
+
+- User explicitly asks ("schedule a meeting", "add to my calendar")
+- A routine produces a time-bound commitment (meeting, deadline, appointment)
+- Coordinating availability across people or projects
+- A reminder isn't sufficient -- the event blocks time on the calendar
+
+Do NOT create events for:
+
+- Tasks/reminders with no specific time block (use `reminders-helper.sh`)
+- Things tracked in TODO.md / GitHub issues
+- Tentative plans the user hasn't confirmed
+
+## Usage
+
+### View events
+
+```bash
+calendar-helper.sh show today
+calendar-helper.sh show tomorrow
+calendar-helper.sh show week --calendar Work
+calendar-helper.sh show 2026-04-10..2026-04-15
+```
+
+### Create an event
+
+```bash
+# Timed event
+calendar-helper.sh add "Team standup" \
+  --start "2026-04-05 09:00" --end "2026-04-05 09:30" --calendar Work
+
+# All-day event
+calendar-helper.sh add "Company holiday" --start "2026-04-10" --allday
+
+# With location, notes, URL
+calendar-helper.sh add "Client dinner" \
+  --start "2026-04-05 19:00" --end "2026-04-05 21:00" \
+  --location "The Restaurant, High St" \
+  --notes "Reservation for 4" \
+  --url "https://restaurant.example.com"
+```
+
+### Search and list calendars
+
+```bash
+calendar-helper.sh calendars
+calendar-helper.sh search "standup" --calendar Work
+```
+
+## Setup
+
+### macOS (one-time)
+
+```bash
+calendar-helper.sh setup
+# No install needed. May need: System Settings > Privacy & Security > Calendars
+```
+
+All accounts from System Settings > Internet Accounts appear automatically.
+
+### Linux (one-time)
+
+```bash
+calendar-helper.sh setup
+# Requires: khal + vdirsyncer with CalDAV config
+# See caldav-calendar-skill.md for vdirsyncer configuration
+```
+
+## Integration with Other Agents
+
+```bash
+# From any agent with bash access:
+~/.aidevops/agents/scripts/calendar-helper.sh add "Sprint review" \
+  --start "2026-04-05 14:00" --end "2026-04-05 15:00" \
+  --calendar Work --notes "Demo new features"
+```
+
+Check availability before scheduling:
+
+```bash
+calendar-helper.sh show "2026-04-05" --calendar Work
+```

--- a/.agents/tools/productivity/contacts.md
+++ b/.agents/tools/productivity/contacts.md
@@ -1,0 +1,152 @@
+---
+description: Search and manage contacts from agent sessions (macOS + Linux)
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+  task: false
+---
+
+# Contacts
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Helper**: `~/.aidevops/agents/scripts/contacts-helper.sh [command] [args]`
+- **macOS backend**: `osascript` via Contacts.app (JXA for reads, AppleScript for writes)
+- **Linux backend**: `khard` + `vdirsyncer` (CardDAV)
+- **Setup**: `contacts-helper.sh setup`
+- **Related**: `tools/productivity/calendar.md`, `tools/productivity/apple-reminders.md`
+
+<!-- AI-CONTEXT-END -->
+
+## Field Coverage
+
+| Contacts field | macOS | Linux | Notes |
+|---|---|---|---|
+| First/Last name | osascript | khard | core |
+| Organization | osascript | khard | core |
+| Job title | osascript | khard | core |
+| Email addresses | osascript | khard | core |
+| Phone numbers | osascript | khard | core |
+| Postal addresses | osascript (read) | khard | read on macOS, full on Linux |
+| Notes | osascript | khard | core |
+| URLs/websites | osascript (read) | khard | read on macOS, full on Linux |
+| Birthday | osascript (read) | khard | read on macOS, full on Linux |
+| Social profiles | limited | khard | Linux has better support |
+| Photos | not available | not available | no CLI support |
+| Relationships | not available | not available | no CLI support |
+
+## When Agents Should Use Contacts
+
+Look up a contact when:
+
+- User mentions a person by name and needs their email/phone/address
+- Composing an email and need the recipient's address
+- Creating a calendar event with a person (look up their details)
+- A workflow needs to reach someone (outreach, follow-up)
+
+Create a contact when:
+
+- User explicitly asks ("save this contact", "add them to my contacts")
+- A new business relationship is established and user wants it recorded
+- An agent workflow discovers contact info the user should keep
+
+Do NOT create contacts for:
+
+- Temporary or one-off interactions
+- Information already in a CRM (use the CRM instead)
+- Without user confirmation (contacts sync to all devices)
+
+## Usage
+
+### Search and look up
+
+```bash
+# Search by name
+contacts-helper.sh search "John"
+
+# Full details for a contact
+contacts-helper.sh show "John Smith"
+
+# Quick email lookup
+contacts-helper.sh email "Smith"
+
+# Quick phone lookup
+contacts-helper.sh phone "Smith"
+```
+
+### Create a contact
+
+```bash
+# Basic contact
+contacts-helper.sh add --first John --last Smith --email john@example.com
+
+# Full contact
+contacts-helper.sh add --first Jane --last Doe \
+  --org "Acme Corp" --title "CTO" \
+  --email jane@acme.com --phone "+44123456789" \
+  --notes "Met at DevOps conference 2026"
+```
+
+### List addressbooks
+
+```bash
+contacts-helper.sh books
+```
+
+## Setup
+
+### macOS (one-time)
+
+```bash
+contacts-helper.sh setup
+# No install needed. May need: System Settings > Privacy & Security > Contacts
+```
+
+All accounts from System Settings > Internet Accounts appear automatically.
+
+### Linux (one-time)
+
+```bash
+contacts-helper.sh setup
+# Requires: khard + vdirsyncer with CardDAV config
+```
+
+Example `~/.config/khard/khard.conf`:
+
+```ini
+[addressbooks]
+[[contacts]]
+path = ~/.local/share/contacts/
+```
+
+## Integration with Other Agents
+
+```bash
+# Look up a contact's email for outreach:
+~/.aidevops/agents/scripts/contacts-helper.sh email "Client Name"
+
+# Create a contact after a business interaction:
+~/.aidevops/agents/scripts/contacts-helper.sh add \
+  --first "New" --last "Client" \
+  --org "Their Company" --email "client@company.com" \
+  --notes "Referred by existing client, interested in consulting"
+```
+
+### Cross-tool workflow
+
+```bash
+# 1. Look up contact
+contacts-helper.sh show "Andrew"
+# 2. Create a reminder to call them
+reminders-helper.sh add "Call Andrew" --due tomorrow --priority medium
+# 3. Block calendar time for the call
+calendar-helper.sh add "Call with Andrew" --start "2026-04-05 10:00" --end "2026-04-05 10:30"
+```


### PR DESCRIPTION
## Summary

- Add `calendar-helper.sh` for reading/writing calendar events (osascript on macOS, khal+vdirsyncer on Linux)
- Add `contacts-helper.sh` for searching/creating contacts (osascript on macOS, khard+vdirsyncer on Linux)
- Add subagent docs `calendar.md` and `contacts.md` with field coverage tables and agent integration guidance

## Design

- **macOS**: Pure osascript — zero dependencies, uses existing System Settings accounts. Dropped `icalBuddy` (needs separate TCC permission). Contacts search uses fast get-all+grep pattern instead of slow AppleScript `whose` clause (instant on 2K+ contacts).
- **Linux**: `khal`/`khard` + `vdirsyncer` — standard CalDAV/CardDAV stack.
- Same pattern as reminders-helper.sh: OS auto-detection, unified CLI interface, both platforms.

## Tested

- `calendar-helper.sh setup` — authorized, lists calendars
- `calendar-helper.sh show today` — returns events (or "No events found")
- `contacts-helper.sh setup` — authorized (2131 contacts)
- `contacts-helper.sh search "Andrew"` — instant results
- `contacts-helper.sh show "Andrew Duquemin"` — full contact details
- ShellCheck clean, markdownlint clean

---
[aidevops.sh](https://aidevops.sh) v3.5.594 plugin for Claude Code with claude-opus-4-6 in an interactive session.