### PR TITLE
feat: integrate PIM tools into setup wizard and subagent index

### DIFF
--- a/.agents/scripts/setup/_tools.sh
+++ b/.agents/scripts/setup/_tools.sh
@@ -63,3 +63,95 @@ check_tool_updates() {
 	:
 	return 0
 }
+
+# Setup PIM tools (Reminders, Calendar, Contacts)
+# macOS: remindctl (Reminders), osascript (Calendar, Contacts — no install)
+# Linux: todoman, khal, khard + vdirsyncer (CalDAV/CardDAV)
+setup_pim_tools() {
+	local os
+	os="$(uname -s)"
+
+	print_info "Setting up PIM tools (Reminders, Calendar, Contacts)..."
+
+	if [[ "$os" == "Darwin" ]]; then
+		# macOS: Calendar and Contacts use osascript (no install needed)
+		print_success "Calendar: uses Calendar.app via osascript (no install needed)"
+		print_success "Contacts: uses Contacts.app via osascript (no install needed)"
+
+		# Reminders needs remindctl
+		if command -v remindctl >/dev/null 2>&1; then
+			print_success "Reminders: remindctl installed"
+		else
+			print_info "Reminders: installing remindctl..."
+			if command -v brew >/dev/null 2>&1; then
+				brew install steipete/tap/remindctl 2>&1 || print_warning "remindctl install failed"
+				if command -v remindctl >/dev/null 2>&1; then
+					print_success "remindctl installed"
+					print_info "Run 'remindctl authorize' to grant Reminders access"
+				fi
+			else
+				print_warning "Homebrew not found. Install remindctl manually: brew install steipete/tap/remindctl"
+			fi
+		fi
+	else
+		# Linux: todoman, khal, khard via pipx/brew; vdirsyncer for sync
+		local missing=()
+
+		if ! command -v todo >/dev/null 2>&1; then
+			missing+=("todoman")
+		else
+			print_success "Reminders: todoman installed"
+		fi
+
+		if ! command -v khal >/dev/null 2>&1; then
+			missing+=("khal")
+		else
+			print_success "Calendar: khal installed"
+		fi
+
+		if ! command -v khard >/dev/null 2>&1; then
+			missing+=("khard")
+		else
+			print_success "Contacts: khard installed"
+		fi
+
+		if ! command -v vdirsyncer >/dev/null 2>&1; then
+			missing+=("vdirsyncer")
+		else
+			print_success "CalDAV/CardDAV sync: vdirsyncer installed"
+		fi
+
+		if [[ ${#missing[@]} -gt 0 ]]; then
+			local pkg_list
+			pkg_list="$(printf '%s ' "${missing[@]}")"
+			print_info "Installing missing PIM tools: ${pkg_list}"
+			if command -v pipx >/dev/null 2>&1; then
+				local pkg
+				for pkg in "${missing[@]}"; do
+					pipx install "$pkg" 2>&1 || print_warning "Failed to install ${pkg}"
+				done
+			elif command -v brew >/dev/null 2>&1; then
+				brew install "${missing[@]}" 2>&1 || print_warning "Some PIM tools failed to install"
+			else
+				print_warning "Install manually with pipx or brew: ${pkg_list}"
+			fi
+		fi
+
+		# Check configs
+		if [[ ! -f "${HOME}/.config/vdirsyncer/config" ]]; then
+			print_warning "vdirsyncer not configured. Run: reminders-helper.sh help (for CalDAV config example)"
+		fi
+		if [[ ! -f "${HOME}/.config/khal/config" ]]; then
+			print_warning "khal not configured. Run: khal configure"
+		fi
+		if [[ ! -f "${HOME}/.config/khard/khard.conf" ]]; then
+			print_warning "khard not configured. See: contacts-helper.sh help"
+		fi
+		if [[ ! -f "${HOME}/.config/todoman/config.py" ]]; then
+			print_warning "todoman not configured. See: reminders-helper.sh help"
+		fi
+	fi
+
+	print_success "PIM tools setup complete. Use *-helper.sh setup for per-tool verification."
+	return 0
+}

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -20,7 +20,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[65]{folder,purpose,key_files}:
+<!--TOON:subagents[66]{folder,purpose,key_files}:
 product/,Universal product concerns - validation onboarding monetisation growth UI design and analytics for all app types,validation|onboarding|monetisation|growth|ui-design|analytics
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 business/,Company orchestration - runner configs for company functions,company-runners
@@ -34,6 +34,7 @@ tools/build-mcp/,MCP development - creating MCP servers and plugins,build-mcp|se
 tools/mcp-toolkit/,MCP runtime toolkit - discover call compose and generate CLIs/typed clients for MCP servers,mcporter
 tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
+tools/productivity/,PIM - reminders calendar contacts across macOS and Linux with CalDAV CardDAV,apple-reminders|calendar|contacts|caldav-calendar-skill
 tools/browser/,Browser automation - scraping testing and QA,agent-browser|browser-automation|browser-qa|browser-use|chromium-debug-use|skyvern|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release
 tools/mobile/,Mobile development - iOS/macOS build test simulator App Store Connect and emulator automation,app-store-connect|agent-device|xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
 tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf

--- a/setup.sh
+++ b/setup.sh
@@ -826,6 +826,7 @@ _setup_run_interactive() {
 	confirm_step "Check optional dependencies (bun, node, python)" && check_optional_deps
 	confirm_step "Check Python version (recommend upgrade if outdated)" && check_python_upgrade_available
 	confirm_step "Setup recommended tools (Tabby, Zed, etc.)" && setup_recommended_tools
+	confirm_step "Setup PIM tools (Reminders, Calendar, Contacts)" && setup_pim_tools
 	confirm_step "Setup MiniSim (iOS/Android emulator launcher)" && setup_minisim
 	confirm_step "Setup ClaudeBar (AI quota monitor in menu bar)" && setup_claudebar
 	confirm_step "Setup Git CLIs (gh, glab, tea)" && setup_git_clis


### PR DESCRIPTION
## Summary

- Add `setup_pim_tools()` to `_tools.sh` — platform-aware installation of Reminders/Calendar/Contacts dependencies
- Add `confirm_step` entry in `setup.sh` interactive path (between recommended tools and MiniSim)
- Add `tools/productivity/` entry to `subagent-index.toon` (65 -> 66 subagents)

## Behavior

**macOS**: Installs `remindctl` via Homebrew if missing. Calendar and Contacts need no install (pure osascript). Prompts user to run `remindctl authorize` for Reminders access.

**Linux**: Installs `todoman`, `khal`, `khard`, `vdirsyncer` via pipx (preferred) or brew. Warns about missing config files with pointers to the helper scripts for examples.

**Non-interactive mode**: Skipped (not in `_setup_run_non_interactive`). PIM tools are optional productivity features, not core dependencies.

---
[aidevops.sh](https://aidevops.sh) v3.5.596 plugin for Claude Code with claude-opus-4-6 in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup and configuration support for Personal Information Management (PIM) tools including reminders, calendars, and contacts.
  * Enabled cross-platform compatibility for macOS and Linux with native platform integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->