### PR TITLE
GH#15322: fix exhaustion wait loop missing normalizeExpiredCooldowns

### DIFF
--- a/.agents/plugins/opencode-aidevops/provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth.mjs
@@ -221,6 +221,9 @@ export function createProviderAuthHook(client) {
               while (Date.now() - waitStart < MAX_EXHAUSTION_WAIT_MS) {
                 const now = Date.now();
                 const freshAccounts = getAccounts("anthropic");
+                // Normalize expired cooldowns so rate-limited accounts whose
+                // cooldownUntil has passed are reset to "idle" (same fix as 429 path).
+                normalizeExpiredCooldowns("anthropic", freshAccounts);
                 // Find an account whose cooldown has expired
                 const recovered = freshAccounts.find(
                   (a) => a.status !== "auth-error" && (!a.cooldownUntil || a.cooldownUntil <= now),
@@ -699,8 +702,13 @@ export function createProviderAuthHook(client) {
               while (Date.now() - waitStart < MAX_EXHAUSTION_WAIT_MS) {
                 const now = Date.now();
                 const freshAccounts = getAccounts("anthropic");
+                // Normalize expired cooldowns so rate-limited accounts whose
+                // cooldownUntil has passed are reset to "idle" (GH#15322 fix).
+                // Without this, short cooldowns (e.g. 5s per-minute limits)
+                // that expire mid-loop are invisible to the status filter below.
+                normalizeExpiredCooldowns("anthropic", freshAccounts);
                 const recovered = freshAccounts.find(
-                  (a) => (a.status === "active" || a.status === "idle") &&
+                  (a) => a.status !== "auth-error" &&
                     (!a.cooldownUntil || a.cooldownUntil <= now),
                 );
                 if (recovered) {


### PR DESCRIPTION
## Summary

- **Bug**: The 429 and startup exhaustion wait loops in `provider-auth.mjs` re-read accounts from disk each iteration but never called `normalizeExpiredCooldowns()`. Accounts with short cooldowns (e.g. 5s per-minute rate limits) that expired mid-loop stayed `status: "rate-limited"` and were invisible to the recovery check — causing a full 120s stall before force-clearing.
- **Fix**: Added `normalizeExpiredCooldowns("anthropic", freshAccounts)` inside both wait loops. Aligned the 429 loop's status filter with the startup loop's more lenient `status !== "auth-error"` (instead of requiring `active || idle`).
- **Impact**: Sessions hitting a transient per-minute 429 now recover in ~5s instead of stalling for 120s when other accounts have long (daily) cooldowns.

## Root Cause

When `evergreen.je` hit a per-minute 429 (5s cooldown) but the other two accounts had legitimate daily limit cooldowns (24h+), the wait loop polled every 5s but never normalized the expired short cooldown back to `idle`. The `recovered` finder required `active || idle` status, so the expired rate-limited account was skipped every iteration.

## Testing

- Reset pool cooldowns — all 3 accounts now available
- Deployed fix to live plugin at `~/.aidevops/agents/plugins/opencode-aidevops/provider-auth.mjs`
- Next 429 event will validate recovery happens in seconds, not 120s

---
[aidevops.sh](https://aidevops.sh) v3.5.597 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 57m and 16,244 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account availability management during rate limit recovery scenarios. Accounts whose cooldown periods have expired are now correctly restored to available state more promptly, enhancing system resilience during high-demand periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->