### PR TITLE
t1748: feat: add Linux/WSL2 platform support

### DIFF
--- a/.agents/reference/platform-support.md
+++ b/.agents/reference/platform-support.md
@@ -1,0 +1,179 @@
+# Platform Support
+
+aidevops runs on macOS (primary) and Linux (including WSL2 on Windows).
+
+## Supported Platforms
+
+| Platform | Status | Scheduler | Notes |
+|----------|--------|-----------|-------|
+| macOS 12+ | Full | launchd | Primary development platform |
+| Ubuntu 22.04+ | Full | systemd / cron | Native Linux and WSL2 |
+| Debian 11+ | Full | systemd / cron | |
+| Fedora 38+ | Full | systemd / cron | |
+| Arch Linux | Full | systemd / cron | |
+| WSL2 (Ubuntu) | Full | systemd / cron | Recommended Windows path |
+| Windows (native) | Not supported | — | Use WSL2 instead |
+
+## WSL2 Getting Started (Windows)
+
+WSL2 runs a real Linux kernel inside Windows. It is the recommended path for Windows users — native Windows (PowerShell) is not supported.
+
+### 1. Install WSL2
+
+Open PowerShell as Administrator:
+
+```powershell
+wsl --install
+```
+
+This installs Ubuntu by default. Restart when prompted.
+
+### 2. Open a WSL2 terminal
+
+Launch "Ubuntu" from the Start menu, or run `wsl` in PowerShell.
+
+### 3. Install Homebrew (recommended) or use apt
+
+Homebrew on Linux provides the same package names as macOS:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Follow the post-install instructions to add brew to your PATH.
+
+Alternatively, use apt directly — aidevops detects and uses it automatically.
+
+### 4. Install aidevops
+
+```bash
+# Via npm (recommended)
+npm install -g aidevops && aidevops update
+
+# Via Homebrew tap
+brew install marcusquinn/tap/aidevops && aidevops update
+
+# Manual
+bash <(curl -fsSL https://aidevops.sh/install)
+```
+
+### 5. Run setup
+
+```bash
+./setup.sh
+```
+
+Setup detects Linux/WSL2 automatically and uses the appropriate scheduler.
+
+---
+
+## Platform Detection
+
+aidevops includes a platform detection helper at `.agents/scripts/platform-detect.sh`.
+
+Source it to get platform-specific variables:
+
+```bash
+source ~/.aidevops/agents/scripts/platform-detect.sh
+
+echo "$AIDEVOPS_PLATFORM"   # macos | linux | wsl2 | windows-native
+echo "$AIDEVOPS_SCHEDULER"  # launchd | systemd | cron
+```
+
+### Exported variables
+
+| Variable | macOS | Linux (systemd) | Linux (no systemd) | WSL2 |
+|----------|-------|-----------------|-------------------|------|
+| `AIDEVOPS_PLATFORM` | `macos` | `linux` | `linux` | `wsl2` |
+| `AIDEVOPS_SCHEDULER` | `launchd` | `systemd` | `cron` | `systemd` or `cron` |
+| `AIDEVOPS_CLIPBOARD_COPY` | `pbcopy` | `xclip -selection clipboard` | `xclip ...` or empty | `clip.exe` |
+| `AIDEVOPS_CLIPBOARD_PASTE` | `pbpaste` | `xclip -selection clipboard -o` | ... | `powershell.exe -c Get-Clipboard` |
+| `AIDEVOPS_OPEN_CMD` | `open` | `xdg-open` | `xdg-open` | `wslview` |
+| `AIDEVOPS_FILE_SEARCH` | `mdfind` | `fd` | `fd` or `locate` | `fd` |
+| `AIDEVOPS_PKG_INSTALL` | `brew install` | `sudo apt-get install -y` | varies | `sudo apt-get install -y` |
+
+---
+
+## Scheduler Backends
+
+### macOS — launchd
+
+The pulse and other scheduled tasks run as LaunchAgents in `~/Library/LaunchAgents/`.
+
+- Label prefix: `com.aidevops.*`
+- Manage: `launchctl list | grep aidevops`
+- Disable pulse: `aidevops config set orchestration.supervisor_pulse false && ./setup.sh`
+
+### Linux — systemd user services (preferred)
+
+When `systemctl --user status` succeeds, aidevops installs systemd user timers:
+
+- Service files: `~/.config/systemd/user/aidevops-*.{service,timer}`
+- List: `systemctl --user list-timers | grep aidevops`
+- Disable pulse: `systemctl --user disable --now aidevops-supervisor-pulse.timer`
+
+systemd is preferred over cron because it supports `Restart=on-failure`, journal logging, and dependency ordering.
+
+### Linux — cron (fallback)
+
+Used when systemd user services are unavailable (containers, older distros, WSL2 without systemd).
+
+- List: `crontab -l | grep aidevops`
+- Disable pulse: `crontab -e` and remove the `supervisor-pulse` line
+
+---
+
+## Known Limitations on Linux/WSL2
+
+| Feature | macOS | Linux | Notes |
+|---------|-------|-------|-------|
+| Clipboard auto-copy | pbcopy | xclip / xsel / wl-copy | Install `xclip` for clipboard support |
+| Open URL | `open` | `xdg-open` | Works in desktop Linux; no-op in headless |
+| Spotlight search | mdfind | fd / locate | `fd` recommended |
+| Apple Mail integration | Full | Not available | macOS-only (Contacts.app, Calendar.app) |
+| osascript / AppleScript | Full | Not available | macOS-only |
+| Reminders.app | Full | todoman (via caldav) | Different backend |
+| Calendar.app | Full | khal (via caldav) | Different backend |
+| Contacts.app | Full | khard (via carddav) | Different backend |
+| OrbStack VMs | macOS only | N/A | Use native Docker on Linux |
+| MiniSim | macOS only | N/A | iOS/Android emulator launcher |
+| ClaudeBar | macOS only | N/A | Menu bar quota monitor |
+
+---
+
+## Installing Clipboard Tools on Linux
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install -y xclip
+
+# Fedora
+sudo dnf install -y xclip
+
+# Arch
+sudo pacman -S xclip
+
+# Wayland (use wl-clipboard instead)
+sudo apt-get install -y wl-clipboard
+```
+
+---
+
+## Enabling systemd in WSL2
+
+By default, WSL2 Ubuntu 22.04+ supports systemd. Enable it if not already active:
+
+```bash
+# Check if systemd is running
+systemctl --user status
+
+# If not running, enable it in /etc/wsl.conf
+echo -e "[boot]\nsystemd=true" | sudo tee /etc/wsl.conf
+# Then restart WSL: wsl --shutdown (from PowerShell), then reopen Ubuntu
+```
+
+---
+
+## CI/CD
+
+The GitHub Actions CI runs on both `ubuntu-latest` and `macos-latest` to catch platform regressions. See `.github/workflows/code-quality.yml`.

--- a/.agents/scripts/context-builder-helper.sh
+++ b/.agents/scripts/context-builder-helper.sh
@@ -25,7 +25,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly SCRIPT_DIR
-export SCRIPT_DIR  # Available for sourced scripts
+export SCRIPT_DIR # Available for sourced scripts
 declare SCRIPT_NAME
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
@@ -39,54 +39,54 @@ readonly DEFAULT_OUTPUT_DIR="$HOME/.aidevops/.agent-workspace/work/context"
 # =============================================================================
 
 print_header() {
-    echo -e "${CYAN}========================================${NC}"
-    echo -e "${CYAN}  Context Builder - Token-Efficient AI Context${NC}"
-    echo -e "${CYAN}========================================${NC}"
-    echo ""
-    return 0
+	echo -e "${CYAN}========================================${NC}"
+	echo -e "${CYAN}  Context Builder - Token-Efficient AI Context${NC}"
+	echo -e "${CYAN}========================================${NC}"
+	echo ""
+	return 0
 }
 
 # Check if repomix is available
 check_repomix() {
-    if ! command -v npx &>/dev/null; then
-        print_error "npx not found - please install Node.js"
-        return 1
-    fi
-    return 0
+	if ! command -v npx &>/dev/null; then
+		print_error "npx not found - please install Node.js"
+		return 1
+	fi
+	return 0
 }
 
 # Ensure output directory exists
 ensure_output_dir() {
-    if [[ ! -d "$DEFAULT_OUTPUT_DIR" ]]; then
-        mkdir -p "$DEFAULT_OUTPUT_DIR"
-        print_info "Created output directory: $DEFAULT_OUTPUT_DIR"
-    fi
-    return 0
+	if [[ ! -d "$DEFAULT_OUTPUT_DIR" ]]; then
+		mkdir -p "$DEFAULT_OUTPUT_DIR"
+		print_info "Created output directory: $DEFAULT_OUTPUT_DIR"
+	fi
+	return 0
 }
 
 # Generate timestamped output filename
 generate_output_name() {
-    local base_path="$1"
-    local style="${2:-xml}"
-    local suffix="${3:-}"
-    local base_name
-    
-    # Get directory name for output file
-    if [[ "$base_path" == "." ]]; then
-        base_name=$(basename "$(pwd)")
-    else
-        base_name=$(basename "$base_path")
-    fi
-    
-    local timestamp
-    timestamp=$(date +%Y%m%d-%H%M%S)
-    
-    if [[ -n "$suffix" ]]; then
-        echo "${DEFAULT_OUTPUT_DIR}/${base_name}-${suffix}-${timestamp}.${style}"
-    else
-        echo "${DEFAULT_OUTPUT_DIR}/${base_name}-${timestamp}.${style}"
-    fi
-    return 0
+	local base_path="$1"
+	local style="${2:-xml}"
+	local suffix="${3:-}"
+	local base_name
+
+	# Get directory name for output file
+	if [[ "$base_path" == "." ]]; then
+		base_name=$(basename "$(pwd)")
+	else
+		base_name=$(basename "$base_path")
+	fi
+
+	local timestamp
+	timestamp=$(date +%Y%m%d-%H%M%S)
+
+	if [[ -n "$suffix" ]]; then
+		echo "${DEFAULT_OUTPUT_DIR}/${base_name}-${suffix}-${timestamp}.${style}"
+	else
+		echo "${DEFAULT_OUTPUT_DIR}/${base_name}-${timestamp}.${style}"
+	fi
+	return 0
 }
 
 # =============================================================================
@@ -95,270 +95,290 @@ generate_output_name() {
 
 # Pack repository with smart defaults
 cmd_pack() {
-    local target_path="${1:-.}"
-    local style="${2:-xml}"
-    local output_file
-    
-    check_repomix || return 1
-    ensure_output_dir
-    
-    output_file=$(generate_output_name "$target_path" "$style" "full")
-    
-    print_info "Packing repository: $target_path"
-    print_info "Output format: $style"
-    print_info "Output file: $output_file"
-    echo ""
-    
-    npx repomix@latest "$target_path" \
-        --output "$output_file" \
-        --style "$style" \
-        --output-show-line-numbers \
-        --top-files-len 10
-    
-    if [[ -f "$output_file" ]]; then
-        local size
-        size=$(du -h "$output_file" | cut -f1)
-        print_success "Context file generated: $output_file ($size)"
-        print_info "Copy to clipboard: cat '$output_file' | pbcopy"
-    fi
-    
-    return 0
+	local target_path="${1:-.}"
+	local style="${2:-xml}"
+	local output_file
+
+	check_repomix || return 1
+	ensure_output_dir
+
+	output_file=$(generate_output_name "$target_path" "$style" "full")
+
+	print_info "Packing repository: $target_path"
+	print_info "Output format: $style"
+	print_info "Output file: $output_file"
+	echo ""
+
+	npx repomix@latest "$target_path" \
+		--output "$output_file" \
+		--style "$style" \
+		--output-show-line-numbers \
+		--top-files-len 10
+
+	if [[ -f "$output_file" ]]; then
+		local size
+		size=$(du -h "$output_file" | cut -f1)
+		print_success "Context file generated: $output_file ($size)"
+		# Platform-agnostic clipboard hint
+		local _clip_cmd="pbcopy"
+		if [[ "$(uname -s)" != "Darwin" ]]; then
+			if command -v xclip &>/dev/null; then
+				_clip_cmd="xclip -selection clipboard"
+			elif command -v xsel &>/dev/null; then
+				_clip_cmd="xsel --clipboard --input"
+			elif command -v wl-copy &>/dev/null; then
+				_clip_cmd="wl-copy"
+			fi
+		fi
+		print_info "Copy to clipboard: cat '$output_file' | $_clip_cmd"
+	fi
+
+	return 0
 }
 
 # Pack with Tree-sitter compression (Code Maps equivalent)
 cmd_compress() {
-    local target_path="${1:-.}"
-    local style="${2:-xml}"
-    local output_file
-    
-    check_repomix || return 1
-    ensure_output_dir
-    
-    output_file=$(generate_output_name "$target_path" "$style" "compressed")
-    
-    print_info "Compressing repository with Tree-sitter (Code Maps mode)"
-    print_info "This extracts code structure (classes, functions, interfaces)"
-    print_info "Expected token reduction: ~80%"
-    print_info "Target: $target_path"
-    print_info "Output: $output_file"
-    echo ""
-    
-    npx repomix@latest "$target_path" \
-        --output "$output_file" \
-        --style "$style" \
-        --compress \
-        --remove-comments \
-        --remove-empty-lines \
-        --top-files-len 10
-    
-    if [[ -f "$output_file" ]]; then
-        local size
-        size=$(du -h "$output_file" | cut -f1)
-        print_success "Compressed context file: $output_file ($size)"
-        print_info "This contains code structure only - ideal for architecture understanding"
-    fi
-    
-    return 0
+	local target_path="${1:-.}"
+	local style="${2:-xml}"
+	local output_file
+
+	check_repomix || return 1
+	ensure_output_dir
+
+	output_file=$(generate_output_name "$target_path" "$style" "compressed")
+
+	print_info "Compressing repository with Tree-sitter (Code Maps mode)"
+	print_info "This extracts code structure (classes, functions, interfaces)"
+	print_info "Expected token reduction: ~80%"
+	print_info "Target: $target_path"
+	print_info "Output: $output_file"
+	echo ""
+
+	npx repomix@latest "$target_path" \
+		--output "$output_file" \
+		--style "$style" \
+		--compress \
+		--remove-comments \
+		--remove-empty-lines \
+		--top-files-len 10
+
+	if [[ -f "$output_file" ]]; then
+		local size
+		size=$(du -h "$output_file" | cut -f1)
+		print_success "Compressed context file: $output_file ($size)"
+		print_info "This contains code structure only - ideal for architecture understanding"
+	fi
+
+	return 0
 }
 
 # Quick pack for focused small contexts
 cmd_quick() {
-    local target_path="${1:-.}"
-    local include_pattern="${2:-}"
-    local output_file
-    
-    check_repomix || return 1
-    ensure_output_dir
-    
-    output_file=$(generate_output_name "$target_path" "md" "quick")
-    
-    print_info "Quick pack mode (minimal output)"
-    print_info "Target: $target_path"
-    
-    local include_args=()
-    if [[ -n "$include_pattern" ]]; then
-        include_args=("--include" "$include_pattern")
-        print_info "Include pattern: $include_pattern"
-    fi
-    
-    echo ""
-    
-    npx repomix@latest "$target_path" \
-        --output "$output_file" \
-        --style markdown \
-        --no-file-summary \
-        --remove-comments \
-        --remove-empty-lines \
-        "${include_args[@]}"
-    
-    if [[ -f "$output_file" ]]; then
-        local size
-        size=$(du -h "$output_file" | cut -f1)
-        print_success "Quick context: $output_file ($size)"
-        
-        # Copy to clipboard on macOS
-        if command -v pbcopy &>/dev/null; then
-            cat "$output_file" | pbcopy
-            print_success "Copied to clipboard!"
-        fi
-    fi
-    
-    return 0
+	local target_path="${1:-.}"
+	local include_pattern="${2:-}"
+	local output_file
+
+	check_repomix || return 1
+	ensure_output_dir
+
+	output_file=$(generate_output_name "$target_path" "md" "quick")
+
+	print_info "Quick pack mode (minimal output)"
+	print_info "Target: $target_path"
+
+	local include_args=()
+	if [[ -n "$include_pattern" ]]; then
+		include_args=("--include" "$include_pattern")
+		print_info "Include pattern: $include_pattern"
+	fi
+
+	echo ""
+
+	npx repomix@latest "$target_path" \
+		--output "$output_file" \
+		--style markdown \
+		--no-file-summary \
+		--remove-comments \
+		--remove-empty-lines \
+		"${include_args[@]}"
+
+	if [[ -f "$output_file" ]]; then
+		local size
+		size=$(du -h "$output_file" | cut -f1)
+		print_success "Quick context: $output_file ($size)"
+
+		# Copy to clipboard (platform-agnostic)
+		if command -v pbcopy &>/dev/null; then
+			pbcopy <"$output_file"
+			print_success "Copied to clipboard!"
+		elif command -v xclip &>/dev/null; then
+			xclip -selection clipboard <"$output_file"
+			print_success "Copied to clipboard!"
+		elif command -v xsel &>/dev/null; then
+			xsel --clipboard --input <"$output_file"
+			print_success "Copied to clipboard!"
+		elif command -v wl-copy &>/dev/null; then
+			wl-copy <"$output_file"
+			print_success "Copied to clipboard!"
+		fi
+	fi
+
+	return 0
 }
 
 # Analyze token usage without generating full output
 cmd_analyze() {
-    local target_path="${1:-.}"
-    local threshold="${2:-100}"
-    
-    check_repomix || return 1
-    
-    print_info "Analyzing token usage in: $target_path"
-    print_info "Showing files with >= $threshold tokens"
-    echo ""
-    
-    npx repomix@latest "$target_path" \
-        --token-count-tree "$threshold" \
-        --no-files \
-        --quiet 2>/dev/null || npx repomix@latest "$target_path" --token-count-tree "$threshold"
-    
-    return 0
+	local target_path="${1:-.}"
+	local threshold="${2:-100}"
+
+	check_repomix || return 1
+
+	print_info "Analyzing token usage in: $target_path"
+	print_info "Showing files with >= $threshold tokens"
+	echo ""
+
+	npx repomix@latest "$target_path" \
+		--token-count-tree "$threshold" \
+		--no-files \
+		--quiet 2>/dev/null || npx repomix@latest "$target_path" --token-count-tree "$threshold"
+
+	return 0
 }
 
 # Pack a remote GitHub repository
 cmd_remote() {
-    local repo_url="$1"
-    local branch="${2:-}"
-    local style="${3:-xml}"
-    local output_file
-    
-    if [[ -z "$repo_url" ]]; then
-        print_error "Repository URL required"
-        print_info "Usage: $SCRIPT_NAME remote <github-url|user/repo> [branch] [style]"
-        return 1
-    fi
-    
-    check_repomix || return 1
-    ensure_output_dir
-    
-    # Extract repo name for output file
-    local repo_name
-    repo_name=$(echo "$repo_url" | sed 's|.*/||' | sed 's|\.git$||')
-    output_file="${DEFAULT_OUTPUT_DIR}/${repo_name}-remote-$(date +%Y%m%d-%H%M%S).${style}"
-    
-    print_info "Packing remote repository: $repo_url"
-    if [[ -n "$branch" ]]; then
-        print_info "Branch: $branch"
-    fi
-    print_info "Output: $output_file"
-    echo ""
-    
-    local branch_args=()
-    if [[ -n "$branch" ]]; then
-        branch_args=("--remote-branch" "$branch")
-    fi
-    
-    npx repomix@latest \
-        --remote "$repo_url" \
-        "${branch_args[@]}" \
-        --output "$output_file" \
-        --style "$style" \
-        --compress \
-        --top-files-len 10
-    
-    if [[ -f "$output_file" ]]; then
-        local size
-        size=$(du -h "$output_file" | cut -f1)
-        print_success "Remote context file: $output_file ($size)"
-    fi
-    
-    return 0
+	local repo_url="$1"
+	local branch="${2:-}"
+	local style="${3:-xml}"
+	local output_file
+
+	if [[ -z "$repo_url" ]]; then
+		print_error "Repository URL required"
+		print_info "Usage: $SCRIPT_NAME remote <github-url|user/repo> [branch] [style]"
+		return 1
+	fi
+
+	check_repomix || return 1
+	ensure_output_dir
+
+	# Extract repo name for output file
+	local repo_name
+	repo_name=$(echo "$repo_url" | sed 's|.*/||' | sed 's|\.git$||')
+	output_file="${DEFAULT_OUTPUT_DIR}/${repo_name}-remote-$(date +%Y%m%d-%H%M%S).${style}"
+
+	print_info "Packing remote repository: $repo_url"
+	if [[ -n "$branch" ]]; then
+		print_info "Branch: $branch"
+	fi
+	print_info "Output: $output_file"
+	echo ""
+
+	local branch_args=()
+	if [[ -n "$branch" ]]; then
+		branch_args=("--remote-branch" "$branch")
+	fi
+
+	npx repomix@latest \
+		--remote "$repo_url" \
+		"${branch_args[@]}" \
+		--output "$output_file" \
+		--style "$style" \
+		--compress \
+		--top-files-len 10
+
+	if [[ -f "$output_file" ]]; then
+		local size
+		size=$(du -h "$output_file" | cut -f1)
+		print_success "Remote context file: $output_file ($size)"
+	fi
+
+	return 0
 }
 
 # Compare full vs compressed token usage
 cmd_compare() {
-    local target_path="${1:-.}"
-    
-    check_repomix || return 1
-    ensure_output_dir
-    
-    print_header
-    print_info "Comparing full vs compressed context for: $target_path"
-    echo ""
-    
-    # Generate both versions
-    local full_output
-    local compressed_output
-    full_output=$(generate_output_name "$target_path" "xml" "full-compare")
-    compressed_output=$(generate_output_name "$target_path" "xml" "compressed-compare")
-    
-    print_info "Generating full context..."
-    npx repomix@latest "$target_path" \
-        --output "$full_output" \
-        --style xml \
-        --quiet 2>/dev/null || true
-    
-    print_info "Generating compressed context..."
-    npx repomix@latest "$target_path" \
-        --output "$compressed_output" \
-        --style xml \
-        --compress \
-        --remove-comments \
-        --remove-empty-lines \
-        --quiet 2>/dev/null || true
-    
-    if [[ -f "$full_output" ]] && [[ -f "$compressed_output" ]]; then
-        local full_size
-        local compressed_size
-        local full_lines
-        local compressed_lines
-        
-        full_size=$(du -h "$full_output" | cut -f1)
-        compressed_size=$(du -h "$compressed_output" | cut -f1)
-        full_lines=$(wc -l < "$full_output" | tr -d ' ')
-        compressed_lines=$(wc -l < "$compressed_output" | tr -d ' ')
-        
-        echo ""
-        echo "┌─────────────────────────────────────────────────┐"
-        echo "│              Context Comparison                 │"
-        echo "├─────────────────────────────────────────────────┤"
-        printf "│ %-20s │ %10s │ %10s │\n" "Metric" "Full" "Compressed"
-        echo "├─────────────────────────────────────────────────┤"
-        printf "│ %-20s │ %10s │ %10s │\n" "File Size" "$full_size" "$compressed_size"
-        printf "│ %-20s │ %10s │ %10s │\n" "Lines" "$full_lines" "$compressed_lines"
-        echo "└─────────────────────────────────────────────────┘"
-        echo ""
-        
-        # Calculate reduction percentage
-        local full_bytes
-        local compressed_bytes
-        full_bytes=$(wc -c < "$full_output" | tr -d ' ')
-        compressed_bytes=$(wc -c < "$compressed_output" | tr -d ' ')
-        
-        if [[ "$full_bytes" -gt 0 ]]; then
-            local reduction
-            reduction=$(echo "scale=1; (1 - $compressed_bytes / $full_bytes) * 100" | bc)
-            print_success "Size reduction: ${reduction}%"
-        fi
-        
-        print_info "Full output: $full_output"
-        print_info "Compressed output: $compressed_output"
-    fi
-    
-    return 0
+	local target_path="${1:-.}"
+
+	check_repomix || return 1
+	ensure_output_dir
+
+	print_header
+	print_info "Comparing full vs compressed context for: $target_path"
+	echo ""
+
+	# Generate both versions
+	local full_output
+	local compressed_output
+	full_output=$(generate_output_name "$target_path" "xml" "full-compare")
+	compressed_output=$(generate_output_name "$target_path" "xml" "compressed-compare")
+
+	print_info "Generating full context..."
+	npx repomix@latest "$target_path" \
+		--output "$full_output" \
+		--style xml \
+		--quiet 2>/dev/null || true
+
+	print_info "Generating compressed context..."
+	npx repomix@latest "$target_path" \
+		--output "$compressed_output" \
+		--style xml \
+		--compress \
+		--remove-comments \
+		--remove-empty-lines \
+		--quiet 2>/dev/null || true
+
+	if [[ -f "$full_output" ]] && [[ -f "$compressed_output" ]]; then
+		local full_size
+		local compressed_size
+		local full_lines
+		local compressed_lines
+
+		full_size=$(du -h "$full_output" | cut -f1)
+		compressed_size=$(du -h "$compressed_output" | cut -f1)
+		full_lines=$(wc -l <"$full_output" | tr -d ' ')
+		compressed_lines=$(wc -l <"$compressed_output" | tr -d ' ')
+
+		echo ""
+		echo "┌─────────────────────────────────────────────────┐"
+		echo "│              Context Comparison                 │"
+		echo "├─────────────────────────────────────────────────┤"
+		printf "│ %-20s │ %10s │ %10s │\n" "Metric" "Full" "Compressed"
+		echo "├─────────────────────────────────────────────────┤"
+		printf "│ %-20s │ %10s │ %10s │\n" "File Size" "$full_size" "$compressed_size"
+		printf "│ %-20s │ %10s │ %10s │\n" "Lines" "$full_lines" "$compressed_lines"
+		echo "└─────────────────────────────────────────────────┘"
+		echo ""
+
+		# Calculate reduction percentage
+		local full_bytes
+		local compressed_bytes
+		full_bytes=$(wc -c <"$full_output" | tr -d ' ')
+		compressed_bytes=$(wc -c <"$compressed_output" | tr -d ' ')
+
+		if [[ "$full_bytes" -gt 0 ]]; then
+			local reduction
+			reduction=$(echo "scale=1; (1 - $compressed_bytes / $full_bytes) * 100" | bc)
+			print_success "Size reduction: ${reduction}%"
+		fi
+
+		print_info "Full output: $full_output"
+		print_info "Compressed output: $compressed_output"
+	fi
+
+	return 0
 }
 
 # Start MCP server mode
 cmd_mcp() {
-    check_repomix || return 1
-    
-    print_info "Starting Context Builder MCP server..."
-    print_info "This allows AI assistants to directly call context building tools"
-    echo ""
-    
-    npx repomix@latest --mcp
-    
-    return 0
+	check_repomix || return 1
+
+	print_info "Starting Context Builder MCP server..."
+	print_info "This allows AI assistants to directly call context building tools"
+	echo ""
+
+	npx repomix@latest --mcp
+
+	return 0
 }
 
 # =============================================================================
@@ -366,7 +386,7 @@ cmd_mcp() {
 # =============================================================================
 
 show_help() {
-    cat << 'HELP_EOF'
+	cat <<'HELP_EOF'
 Context Builder - Token-Efficient AI Context Generation
 =========================================================
 
@@ -439,7 +459,7 @@ For more information:
   https://github.com/marcusquinn/aidevops
 
 HELP_EOF
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -447,46 +467,46 @@ HELP_EOF
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
-    
-    case "$command" in
-        pack)
-            cmd_pack "$@"
-            ;;
-        compress)
-            cmd_compress "$@"
-            ;;
-        quick)
-            cmd_quick "$@"
-            ;;
-        analyze)
-            cmd_analyze "$@"
-            ;;
-        remote)
-            cmd_remote "$@"
-            ;;
-        compare)
-            cmd_compare "$@"
-            ;;
-        mcp)
-            cmd_mcp "$@"
-            ;;
-        help|--help|-h)
-            show_help
-            ;;
-        version|--version|-v)
-            echo "context-builder-helper.sh version $VERSION"
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            echo ""
-            show_help
-            return 1
-            ;;
-    esac
-    
-    return 0
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	pack)
+		cmd_pack "$@"
+		;;
+	compress)
+		cmd_compress "$@"
+		;;
+	quick)
+		cmd_quick "$@"
+		;;
+	analyze)
+		cmd_analyze "$@"
+		;;
+	remote)
+		cmd_remote "$@"
+		;;
+	compare)
+		cmd_compare "$@"
+		;;
+	mcp)
+		cmd_mcp "$@"
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	version | --version | -v)
+		echo "context-builder-helper.sh version $VERSION"
+		;;
+	*)
+		print_error "Unknown command: $command"
+		echo ""
+		show_help
+		return 1
+		;;
+	esac
+
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/platform-detect.sh
+++ b/.agents/scripts/platform-detect.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# platform-detect.sh — OS/platform detection and abstraction layer
+#
+# Usage (source this file):
+#   source "$(dirname "${BASH_SOURCE[0]}")/platform-detect.sh"
+#   echo "$AIDEVOPS_PLATFORM"   # macos | linux | wsl2 | windows-native
+#   echo "$AIDEVOPS_SCHEDULER"  # launchd | systemd | cron
+#
+# Exported variables:
+#   AIDEVOPS_PLATFORM         — macos | linux | wsl2 | windows-native
+#   AIDEVOPS_SCHEDULER        — launchd | systemd | cron
+#   AIDEVOPS_CLIPBOARD_COPY   — command to copy stdin to clipboard
+#   AIDEVOPS_CLIPBOARD_PASTE  — command to paste clipboard to stdout
+#   AIDEVOPS_OPEN_CMD         — command to open a URL or file
+#   AIDEVOPS_FILE_SEARCH      — preferred file search command
+#   AIDEVOPS_PKG_INSTALL      — package install command prefix (e.g. "brew install")
+#
+# Part of t1748: Linux/WSL2 platform support
+
+# Shell safety baseline (guard against sourcing in strict-mode scripts)
+# shellcheck disable=SC2034  # Variables are used by callers
+
+_aidevops_detect_platform() {
+	local _kernel
+	_kernel="$(uname -s 2>/dev/null || echo "unknown")"
+
+	case "$_kernel" in
+	Darwin)
+		AIDEVOPS_PLATFORM="macos"
+		AIDEVOPS_SCHEDULER="launchd"
+		AIDEVOPS_CLIPBOARD_COPY="pbcopy"
+		AIDEVOPS_CLIPBOARD_PASTE="pbpaste"
+		AIDEVOPS_OPEN_CMD="open"
+		AIDEVOPS_FILE_SEARCH="mdfind"
+		AIDEVOPS_PKG_INSTALL="brew install"
+		;;
+	Linux)
+		# Distinguish WSL2 from native Linux
+		if grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null; then
+			AIDEVOPS_PLATFORM="wsl2"
+		else
+			AIDEVOPS_PLATFORM="linux"
+		fi
+
+		# Scheduler: prefer systemd user services; fall back to cron
+		if command -v systemctl >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
+			AIDEVOPS_SCHEDULER="systemd"
+		else
+			AIDEVOPS_SCHEDULER="cron"
+		fi
+
+		# Clipboard: prefer xclip, then xsel, then wl-copy (Wayland), then clip.exe (WSL2)
+		if command -v xclip >/dev/null 2>&1; then
+			AIDEVOPS_CLIPBOARD_COPY="xclip -selection clipboard"
+			AIDEVOPS_CLIPBOARD_PASTE="xclip -selection clipboard -o"
+		elif command -v xsel >/dev/null 2>&1; then
+			AIDEVOPS_CLIPBOARD_COPY="xsel --clipboard --input"
+			AIDEVOPS_CLIPBOARD_PASTE="xsel --clipboard --output"
+		elif command -v wl-copy >/dev/null 2>&1; then
+			AIDEVOPS_CLIPBOARD_COPY="wl-copy"
+			AIDEVOPS_CLIPBOARD_PASTE="wl-paste"
+		elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v clip.exe >/dev/null 2>&1; then
+			AIDEVOPS_CLIPBOARD_COPY="clip.exe"
+			AIDEVOPS_CLIPBOARD_PASTE="powershell.exe -c Get-Clipboard"
+		else
+			AIDEVOPS_CLIPBOARD_COPY=""
+			AIDEVOPS_CLIPBOARD_PASTE=""
+		fi
+
+		# Open URL/file: prefer xdg-open, then wslview (WSL2 bridge)
+		if command -v xdg-open >/dev/null 2>&1; then
+			AIDEVOPS_OPEN_CMD="xdg-open"
+		elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v wslview >/dev/null 2>&1; then
+			AIDEVOPS_OPEN_CMD="wslview"
+		else
+			AIDEVOPS_OPEN_CMD=""
+		fi
+
+		# File search: prefer fd, then locate, then find
+		if command -v fd >/dev/null 2>&1; then
+			AIDEVOPS_FILE_SEARCH="fd"
+		elif command -v locate >/dev/null 2>&1; then
+			AIDEVOPS_FILE_SEARCH="locate"
+		else
+			AIDEVOPS_FILE_SEARCH="find"
+		fi
+
+		# Package manager
+		if command -v apt-get >/dev/null 2>&1; then
+			AIDEVOPS_PKG_INSTALL="sudo apt-get install -y"
+		elif command -v brew >/dev/null 2>&1; then
+			AIDEVOPS_PKG_INSTALL="brew install"
+		elif command -v dnf >/dev/null 2>&1; then
+			AIDEVOPS_PKG_INSTALL="sudo dnf install -y"
+		elif command -v pacman >/dev/null 2>&1; then
+			AIDEVOPS_PKG_INSTALL="sudo pacman -S --noconfirm"
+		elif command -v apk >/dev/null 2>&1; then
+			AIDEVOPS_PKG_INSTALL="sudo apk add"
+		else
+			AIDEVOPS_PKG_INSTALL=""
+		fi
+		;;
+	MINGW* | MSYS* | CYGWIN*)
+		AIDEVOPS_PLATFORM="windows-native"
+		AIDEVOPS_SCHEDULER="cron"
+		AIDEVOPS_CLIPBOARD_COPY="clip"
+		AIDEVOPS_CLIPBOARD_PASTE="powershell -c Get-Clipboard"
+		AIDEVOPS_OPEN_CMD="start"
+		AIDEVOPS_FILE_SEARCH="find"
+		AIDEVOPS_PKG_INSTALL=""
+		;;
+	*)
+		AIDEVOPS_PLATFORM="unknown"
+		AIDEVOPS_SCHEDULER="cron"
+		AIDEVOPS_CLIPBOARD_COPY=""
+		AIDEVOPS_CLIPBOARD_PASTE=""
+		AIDEVOPS_OPEN_CMD=""
+		AIDEVOPS_FILE_SEARCH="find"
+		AIDEVOPS_PKG_INSTALL=""
+		;;
+	esac
+
+	export AIDEVOPS_PLATFORM AIDEVOPS_SCHEDULER
+	export AIDEVOPS_CLIPBOARD_COPY AIDEVOPS_CLIPBOARD_PASTE
+	export AIDEVOPS_OPEN_CMD AIDEVOPS_FILE_SEARCH AIDEVOPS_PKG_INSTALL
+	return 0
+}
+
+# Run detection immediately on source
+_aidevops_detect_platform
+
+# Clipboard helper: copy stdin to clipboard (platform-agnostic)
+# Usage: echo "text" | aidevops_clipboard_copy
+# Returns 0 on success, 1 if no clipboard tool available
+aidevops_clipboard_copy() {
+	if [[ -z "$AIDEVOPS_CLIPBOARD_COPY" ]]; then
+		return 1
+	fi
+	# shellcheck disable=SC2086  # intentional word splitting for multi-word commands
+	$AIDEVOPS_CLIPBOARD_COPY
+	return $?
+}
+
+# Clipboard helper: paste clipboard to stdout (platform-agnostic)
+# Usage: aidevops_clipboard_paste
+# Returns 0 on success, 1 if no clipboard tool available
+aidevops_clipboard_paste() {
+	if [[ -z "$AIDEVOPS_CLIPBOARD_PASTE" ]]; then
+		return 1
+	fi
+	# shellcheck disable=SC2086  # intentional word splitting for multi-word commands
+	$AIDEVOPS_CLIPBOARD_PASTE
+	return $?
+}
+
+# Open a URL or file (platform-agnostic)
+# Usage: aidevops_open "https://example.com"
+# Returns 0 on success, 1 if no open command available
+aidevops_open() {
+	local target="$1"
+	if [[ -z "$AIDEVOPS_OPEN_CMD" ]]; then
+		return 1
+	fi
+	# shellcheck disable=SC2086  # intentional word splitting for multi-word commands
+	$AIDEVOPS_OPEN_CMD "$target"
+	return $?
+}
+
+# When run directly (not sourced), print detected platform info
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	echo "AIDEVOPS_PLATFORM=$AIDEVOPS_PLATFORM"
+	echo "AIDEVOPS_SCHEDULER=$AIDEVOPS_SCHEDULER"
+	echo "AIDEVOPS_CLIPBOARD_COPY=$AIDEVOPS_CLIPBOARD_COPY"
+	echo "AIDEVOPS_CLIPBOARD_PASTE=$AIDEVOPS_CLIPBOARD_PASTE"
+	echo "AIDEVOPS_OPEN_CMD=$AIDEVOPS_OPEN_CMD"
+	echo "AIDEVOPS_FILE_SEARCH=$AIDEVOPS_FILE_SEARCH"
+	echo "AIDEVOPS_PKG_INSTALL=$AIDEVOPS_PKG_INSTALL"
+fi

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,6 +16,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Cross-platform shellcheck: catches macOS-only assumptions in shell scripts
+  # (t1748: Linux/WSL2 platform support)
+  cross-platform-shellcheck:
+    name: ShellCheck (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Install ShellCheck (macOS)
+      if: runner.os == 'macOS'
+      run: brew install shellcheck
+
+    - name: ShellCheck (cross-platform)
+      run: |
+        echo "Running ShellCheck on ${{ matrix.os }}..."
+        source .agents/scripts/lint-file-discovery.sh
+        lint_shell_files
+        errors=0
+        while IFS= read -r file; do
+          [ -n "$file" ] || continue
+          if shellcheck -S error "$file" > /dev/null 2>&1; then
+            echo "OK $file"
+          else
+            echo "FAIL $file"
+            shellcheck -S error -f gcc "$file" 2>&1
+            errors=$((errors + 1))
+          fi
+        done <<< "$LINT_SH_FILES"
+        if [ "$errors" -gt 0 ]; then
+          echo ""
+          echo "$errors script(s) failed ShellCheck on ${{ matrix.os }}"
+          exit 1
+        fi
+        echo "All shell scripts passed ShellCheck on ${{ matrix.os }}"
+
+    - name: Platform detection smoke test
+      run: |
+        echo "Testing platform-detect.sh on ${{ matrix.os }}..."
+        bash .agents/scripts/platform-detect.sh
+        echo "Platform detection: OK"
+
   framework-validation:
     name: Framework Validation
     runs-on: ubuntu-latest

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -195,6 +195,8 @@ setup_supervisor_pulse() {
 
 		if [[ "$_os" == "Darwin" ]]; then
 			_install_pulse_launchd "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed"
+		elif _systemd_user_available; then
+			_install_pulse_systemd "aidevops-supervisor-pulse" "$wrapper_script"
 		else
 			_install_pulse_cron "$wrapper_script"
 		fi
@@ -406,6 +408,78 @@ _install_pulse_cron() {
 	return 0
 }
 
+# Check if systemd user services are available on this Linux system.
+# Returns 0 if systemd --user is functional, 1 otherwise.
+_systemd_user_available() {
+	command -v systemctl >/dev/null 2>&1 || return 1
+	systemctl --user status >/dev/null 2>&1 || return 1
+	return 0
+}
+
+# Install supervisor pulse via systemd user service (Linux with systemd)
+# Args: $1=service_name (e.g. "aidevops-supervisor-pulse"), $2=wrapper_script
+_install_pulse_systemd() {
+	local service_name="$1"
+	local wrapper_script="$2"
+	local service_dir="$HOME/.config/systemd/user"
+	local service_file="${service_dir}/${service_name}.service"
+	local timer_file="${service_dir}/${service_name}.timer"
+
+	mkdir -p "$service_dir"
+
+	# Build environment overrides for the service
+	local _env_lines=""
+	local _configured_headless_models _configured_pulse_model
+	_configured_headless_models=$(_resolve_headless_models_override)
+	_configured_pulse_model=$(_resolve_pulse_model_override)
+	if [[ -n "$_configured_headless_models" ]]; then
+		_env_lines+="Environment=AIDEVOPS_HEADLESS_MODELS=${_configured_headless_models}\n"
+	fi
+	if [[ -n "$_configured_pulse_model" ]]; then
+		_env_lines+="Environment=PULSE_MODEL=${_configured_pulse_model}\n"
+	fi
+	if [[ -n "${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}" ]]; then
+		_env_lines+="Environment=AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST}\n"
+	fi
+	_env_lines+="Environment=PULSE_DIR=${HOME}/.aidevops/.agent-workspace\n"
+	_env_lines+="Environment=HOME=${HOME}\n"
+
+	# Write the service unit
+	printf '%s' "[Unit]
+Description=aidevops Supervisor Pulse
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash ${wrapper_script}
+${_env_lines}StandardOutput=append:${HOME}/.aidevops/logs/pulse-wrapper.log
+StandardError=append:${HOME}/.aidevops/logs/pulse-wrapper.log
+" >"$service_file"
+
+	# Write the timer unit (every 2 minutes)
+	printf '%s' "[Unit]
+Description=aidevops Supervisor Pulse Timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+" >"$timer_file"
+
+	systemctl --user daemon-reload 2>/dev/null || true
+	if systemctl --user enable --now "${service_name}.timer" 2>/dev/null; then
+		print_info "Supervisor pulse enabled (systemd user timer, every 2 min)"
+		print_info "Disable: systemctl --user disable --now ${service_name}.timer"
+	else
+		print_warning "Failed to enable systemd timer — falling back to cron"
+		_install_pulse_cron "$wrapper_script"
+	fi
+	return 0
+}
+
 # Uninstall supervisor pulse (user explicitly disabled)
 _uninstall_pulse() {
 	local _os="$1"
@@ -417,6 +491,15 @@ _uninstall_pulse() {
 			rm -f "$pulse_plist"
 			pkill -f 'Supervisor Pulse' 2>/dev/null || true
 			print_info "Supervisor pulse disabled (launchd agent removed per config)"
+		fi
+	elif _systemd_user_available; then
+		local service_name="aidevops-supervisor-pulse"
+		if systemctl --user is-enabled "${service_name}.timer" >/dev/null 2>&1; then
+			systemctl --user disable --now "${service_name}.timer" 2>/dev/null || true
+			rm -f "$HOME/.config/systemd/user/${service_name}.service"
+			rm -f "$HOME/.config/systemd/user/${service_name}.timer"
+			systemctl --user daemon-reload 2>/dev/null || true
+			print_info "Supervisor pulse disabled (systemd timer removed per config)"
 		fi
 	else
 		if crontab -l 2>/dev/null | grep -qF "pulse-wrapper"; then

--- a/setup.sh
+++ b/setup.sh
@@ -40,6 +40,15 @@ PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
 PLATFORM_ARM64=$([[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]] && echo true || echo false)
 export PLATFORM_MACOS PLATFORM_ARM64
 readonly PLATFORM_MACOS PLATFORM_ARM64
+# Extended platform detection (t1748: Linux/WSL2 support).
+# Sources platform-detect.sh when available to export AIDEVOPS_PLATFORM,
+# AIDEVOPS_SCHEDULER, AIDEVOPS_CLIPBOARD_COPY, etc.
+_platform_detect_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.agents/scripts/platform-detect.sh"
+if [[ -f "$_platform_detect_script" ]]; then
+	# shellcheck disable=SC1090  # dynamic path, exists at runtime
+	source "$_platform_detect_script"
+fi
+unset _platform_detect_script
 # Repo constants — exported; consumed by setup-modules/core.sh, agent-deploy.sh
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
 # INSTALL_DIR: resolve from the directory where setup.sh is executed (supports worktrees)


### PR DESCRIPTION
## Summary

Implements full Linux/WSL2 platform support for aidevops (t1748). The framework was previously macOS-only due to hardcoded launchd, pbcopy, mdfind, and osascript dependencies.

## Changes

### New: `.agents/scripts/platform-detect.sh`
Platform detection abstraction layer. Source it to get:
- `AIDEVOPS_PLATFORM` — `macos` | `linux` | `wsl2` | `windows-native`
- `AIDEVOPS_SCHEDULER` — `launchd` | `systemd` | `cron`
- `AIDEVOPS_CLIPBOARD_COPY/PASTE` — platform-appropriate clipboard commands
- `AIDEVOPS_OPEN_CMD` — `open` / `xdg-open` / `wslview`
- `AIDEVOPS_FILE_SEARCH` — `mdfind` / `fd` / `locate`
- `AIDEVOPS_PKG_INSTALL` — `brew install` / `sudo apt-get install -y` / etc.

Detection: `uname -s` for Darwin/Linux, `/proc/version` for WSL2 vs native Linux.

### Updated: `setup-modules/schedulers.sh`
- Added `_systemd_user_available()` — checks if `systemctl --user` is functional
- Added `_install_pulse_systemd()` — installs supervisor pulse as a systemd user timer (every 2 min) with service + timer unit files in `~/.config/systemd/user/`
- Updated `setup_supervisor_pulse()` — prefers systemd over cron on Linux when available
- Updated `_uninstall_pulse()` — handles systemd cleanup on Linux

### Updated: `setup.sh`
- Sources `platform-detect.sh` on startup to export `AIDEVOPS_PLATFORM` and related vars alongside existing `PLATFORM_MACOS`/`PLATFORM_ARM64`

### Updated: `.agents/scripts/context-builder-helper.sh`
- Replaced `pbcopy`-only clipboard with platform-agnostic fallback chain: `pbcopy` → `xclip` → `xsel` → `wl-copy`
- Fixed `cat file | pbcopy` anti-pattern to `pbcopy < file`

### New: `.agents/reference/platform-support.md`
WSL2 getting-started guide covering: WSL2 install, Homebrew on Linux, aidevops install, scheduler backends (launchd/systemd/cron), known limitations table, clipboard tool install instructions.

### Updated: `.github/workflows/code-quality.yml`
- Added `cross-platform-shellcheck` job running on both `ubuntu-latest` and `macos-latest`
- Includes platform-detect.sh smoke test on each runner

## Acceptance Criteria

- [x] `platform-detect.sh` exists with `AIDEVOPS_PLATFORM` detection
- [x] Pulse scheduler uses systemd user service on Linux, launchd on macOS
- [x] `context-builder-helper.sh` clipboard is platform-agnostic (pbcopy/xclip/xsel/wl-copy)
- [x] `reference/platform-support.md` exists with WSL2 setup instructions
- [x] CI runs on both macOS and Ubuntu (`cross-platform-shellcheck` matrix job)
- [x] ShellCheck clean on all modified scripts

## Runtime Testing

Risk: **Low** — no payment, auth, or data deletion paths. Changes are additive (new detection script, new systemd backend, new docs). Existing macOS paths unchanged.

- ShellCheck: all modified scripts pass `shellcheck -S error`
- Platform detection: smoke-tested on Linux (this CI environment)
- YAML: validated with `python3 -m yaml`
- Existing macOS launchd path: unchanged, no regression risk

Closes #15391

---
[aidevops.sh](https://aidevops.sh) v3.5.598 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comprehensive platform support documentation covering macOS, Linux distributions, and WSL2 with detailed setup instructions
  * Improved Linux scheduler support using systemd user services as primary option with cron fallback

* **Documentation**
  * Platform compatibility matrix and reference guide for supported operating systems and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->