### PR TITLE
GH#14847: tighten chore branch workflow doc

### DIFF
--- a/.agents/workflows/branch/chore.md
+++ b/.agents/workflows/branch/chore.md
@@ -36,38 +36,21 @@ git checkout -b chore/{description}
 
 **Not for** behavior changes; use `feature/`, `bugfix/`, or `refactor/` instead.
 
-## Guidance
+## Commit Prefixes
 
-Pick the narrowest commit prefix for the change:
+Pick the narrowest prefix for the change:
 
-| Prefix | Use for |
-|--------|---------|
-| `chore:` | General maintenance |
-| `docs:` | Documentation |
-| `ci:` | CI/CD changes |
-| `build:` | Build system |
+| Prefix | Use for | Example |
+|--------|---------|---------|
+| `chore:` | General maintenance | `chore: update dependencies` |
+| `docs:` | Documentation | `docs: improve installation instructions` |
+| `ci:` | CI/CD changes | `ci: add dependency caching` |
+| `build:` | Build system | `build: switch bundler to esbuild` |
 
-## Commit Examples
+## Branch Examples
 
-```bash
-chore: update dependencies
-
-docs: improve installation instructions
-
-ci: optimize GitHub Actions workflow
-
-- Add dependency caching
-- Run tests in parallel
-
-build: switch bundler to esbuild
 ```
-
-## Examples
-
-```bash
 chore/update-dependencies
 chore/fix-github-actions
-chore/add-codecov
-chore/update-readme
 chore/configure-eslint
 ```


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/branch/chore.md` per GH#14847 simplification scan.

**Changes:**
- Merged "Guidance" + "Commit Examples" sections into single "Commit Prefixes" table with inline examples — eliminates the separate verbose code block
- Renamed "Examples" → "Branch Examples" for clarity
- Trimmed branch name examples from 5 to 3 representative ones (no information loss)
- 73 → 56 lines (23% reduction)

**Preserved:**
- All 4 commit prefixes (`chore:`, `docs:`, `ci:`, `build:`) with use cases
- Branch creation command and quick-reference table
- "When to Use" use cases and "Not for" rule
- YAML frontmatter unchanged

**Classification:** Instruction doc (workflow guide) — tightened prose, not reference corpus.

Closes #14847

## Runtime Testing

**Risk level:** Low — documentation-only change, no code or scripts modified.
**Verification:** Content audit — all commit prefixes, use cases, and branch creation command present before and after. No broken references (no internal links in original).


---
[aidevops.sh](https://aidevops.sh) v3.5.599 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal developer documentation with improved commit prefix examples and clearer branch naming guidance.

---

**Note:** This PR contains updates to internal development workflows only and does not affect end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->