### PR TITLE
GH#15317: fix _claim_comment_id unbound variable crashing pulse dispatcher

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5312,8 +5312,10 @@ check_dispatch_dedup() {
 	# duplicate than to block all dispatch on a transient GitHub API failure.
 	#
 	# GH#15317: Capture claim output to extract comment_id for cleanup after
-	# the deterministic dispatch comment is posted.
-	local _claim_comment_id=""
+	# the deterministic dispatch comment is posted. Uses the caller's
+	# _claim_comment_id variable (declared in dispatch_with_dedup) via bash
+	# dynamic scoping — do NOT declare local here or the value is lost on return.
+	_claim_comment_id=""
 	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
 		local claim_exit=0 claim_output=""
 		claim_output=$("$dedup_helper" claim "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE") || claim_exit=$?
@@ -5369,6 +5371,11 @@ dispatch_with_dedup() {
 	local prompt="$7"
 	local session_key="${8:-issue-${issue_number}}"
 	local model_override="${9:-}"
+	# GH#15317 fix: _claim_comment_id is set by check_dispatch_dedup() via
+	# bash dynamic scoping, but must be declared in the calling function's
+	# scope first. Without this, set -u crashes the wrapper on every dispatch,
+	# SIGTERM-ing all active workers.
+	local _claim_comment_id=""
 
 	# Hard stop for supervisor/telemetry issues (t1702 pulse guard).
 	# The pulse prompt should already avoid these, but this deterministic


### PR DESCRIPTION
## Summary

- **Root cause**: GH#15317 declared `_claim_comment_id` as `local` inside `check_dispatch_dedup()` but referenced it in `dispatch_with_dedup()` — a sibling scope, not a child scope. With `set -euo pipefail`, every dispatch attempt crashed the pulse wrapper with `unbound variable`, SIGTERM-ing all active workers.
- **Impact**: Workers were dispatched in 2-minute bursts (launchd cycle) then killed. System could never sustain concurrency — 1/24 workers running instead of 24/24.
- **Fix**: Declare `_claim_comment_id` in `dispatch_with_dedup()` (the caller) and remove `local` from `check_dispatch_dedup()` so bash dynamic scoping flows the value back correctly.

## Evidence

Every pulse cycle in the log shows the crash:
```
pulse-wrapper.sh: line 5504: _claim_comment_id: unbound variable
```
Followed by 12 workers `Terminated: 15` (SIGTERM from parent exit).

## Testing

- ShellCheck passes (no new violations)
- Variable is now declared in the correct scope and flows via bash dynamic scoping

---
[aidevops.sh](https://aidevops.sh) v3.5.599 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 17m and 30,284 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crash in the pulse wrapper script when processing dispatch deduplication operations
  * Enhanced claim comment identification and deletion system to ensure proper cleanup and removal of all dispatch-related comments
  * Improved overall script stability and reliability to prevent crashes when strict shell options are enabled in the execution environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->