### PR TITLE
t1851: reduce function complexity in .agents/scripts/platform-detect.sh

### DIFF
--- a/.agents/scripts/platform-detect.sh
+++ b/.agents/scripts/platform-detect.sh
@@ -20,103 +20,143 @@
 # Shell safety baseline (guard against sourcing in strict-mode scripts)
 # shellcheck disable=SC2034  # Variables are used by callers
 
+_detect_linux_platform() {
+	# Distinguish WSL2 from native Linux
+	if grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null; then
+		AIDEVOPS_PLATFORM="wsl2"
+	else
+		AIDEVOPS_PLATFORM="linux"
+	fi
+	return 0
+}
+
+_detect_linux_scheduler() {
+	# Scheduler: prefer systemd user services; fall back to cron
+	if command -v systemctl >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
+		AIDEVOPS_SCHEDULER="systemd"
+	else
+		AIDEVOPS_SCHEDULER="cron"
+	fi
+	return 0
+}
+
+_detect_linux_clipboard() {
+	# Clipboard: prefer xclip, then xsel, then wl-copy (Wayland), then clip.exe (WSL2)
+	if command -v xclip >/dev/null 2>&1; then
+		AIDEVOPS_CLIPBOARD_COPY="xclip -selection clipboard"
+		AIDEVOPS_CLIPBOARD_PASTE="xclip -selection clipboard -o"
+	elif command -v xsel >/dev/null 2>&1; then
+		AIDEVOPS_CLIPBOARD_COPY="xsel --clipboard --input"
+		AIDEVOPS_CLIPBOARD_PASTE="xsel --clipboard --output"
+	elif command -v wl-copy >/dev/null 2>&1; then
+		AIDEVOPS_CLIPBOARD_COPY="wl-copy"
+		AIDEVOPS_CLIPBOARD_PASTE="wl-paste"
+	elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v clip.exe >/dev/null 2>&1; then
+		AIDEVOPS_CLIPBOARD_COPY="clip.exe"
+		AIDEVOPS_CLIPBOARD_PASTE="powershell.exe -c Get-Clipboard"
+	else
+		AIDEVOPS_CLIPBOARD_COPY=""
+		AIDEVOPS_CLIPBOARD_PASTE=""
+	fi
+	return 0
+}
+
+_detect_linux_open_cmd() {
+	# Open URL/file: prefer xdg-open, then wslview (WSL2 bridge)
+	if command -v xdg-open >/dev/null 2>&1; then
+		AIDEVOPS_OPEN_CMD="xdg-open"
+	elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v wslview >/dev/null 2>&1; then
+		AIDEVOPS_OPEN_CMD="wslview"
+	else
+		AIDEVOPS_OPEN_CMD=""
+	fi
+	return 0
+}
+
+_detect_linux_file_search() {
+	# File search: prefer fd, then locate, then find
+	if command -v fd >/dev/null 2>&1; then
+		AIDEVOPS_FILE_SEARCH="fd"
+	elif command -v locate >/dev/null 2>&1; then
+		AIDEVOPS_FILE_SEARCH="locate"
+	else
+		AIDEVOPS_FILE_SEARCH="find"
+	fi
+	return 0
+}
+
+_detect_linux_pkg_manager() {
+	# Package manager
+	if command -v apt-get >/dev/null 2>&1; then
+		AIDEVOPS_PKG_INSTALL="sudo apt-get install -y"
+	elif command -v brew >/dev/null 2>&1; then
+		AIDEVOPS_PKG_INSTALL="brew install"
+	elif command -v dnf >/dev/null 2>&1; then
+		AIDEVOPS_PKG_INSTALL="sudo dnf install -y"
+	elif command -v pacman >/dev/null 2>&1; then
+		AIDEVOPS_PKG_INSTALL="sudo pacman -S --noconfirm"
+	elif command -v apk >/dev/null 2>&1; then
+		AIDEVOPS_PKG_INSTALL="sudo apk add"
+	else
+		AIDEVOPS_PKG_INSTALL=""
+	fi
+	return 0
+}
+
+_detect_macos() {
+	AIDEVOPS_PLATFORM="macos"
+	AIDEVOPS_SCHEDULER="launchd"
+	AIDEVOPS_CLIPBOARD_COPY="pbcopy"
+	AIDEVOPS_CLIPBOARD_PASTE="pbpaste"
+	AIDEVOPS_OPEN_CMD="open"
+	AIDEVOPS_FILE_SEARCH="mdfind"
+	AIDEVOPS_PKG_INSTALL="brew install"
+	return 0
+}
+
+_detect_windows() {
+	AIDEVOPS_PLATFORM="windows-native"
+	AIDEVOPS_SCHEDULER="cron"
+	AIDEVOPS_CLIPBOARD_COPY="clip"
+	AIDEVOPS_CLIPBOARD_PASTE="powershell -c Get-Clipboard"
+	AIDEVOPS_OPEN_CMD="start"
+	AIDEVOPS_FILE_SEARCH="find"
+	AIDEVOPS_PKG_INSTALL=""
+	return 0
+}
+
+_detect_unknown() {
+	AIDEVOPS_PLATFORM="unknown"
+	AIDEVOPS_SCHEDULER="cron"
+	AIDEVOPS_CLIPBOARD_COPY=""
+	AIDEVOPS_CLIPBOARD_PASTE=""
+	AIDEVOPS_OPEN_CMD=""
+	AIDEVOPS_FILE_SEARCH="find"
+	AIDEVOPS_PKG_INSTALL=""
+	return 0
+}
+
 _aidevops_detect_platform() {
 	local _kernel
 	_kernel="$(uname -s 2>/dev/null || echo "unknown")"
 
 	case "$_kernel" in
 	Darwin)
-		AIDEVOPS_PLATFORM="macos"
-		AIDEVOPS_SCHEDULER="launchd"
-		AIDEVOPS_CLIPBOARD_COPY="pbcopy"
-		AIDEVOPS_CLIPBOARD_PASTE="pbpaste"
-		AIDEVOPS_OPEN_CMD="open"
-		AIDEVOPS_FILE_SEARCH="mdfind"
-		AIDEVOPS_PKG_INSTALL="brew install"
+		_detect_macos
 		;;
 	Linux)
-		# Distinguish WSL2 from native Linux
-		if grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null; then
-			AIDEVOPS_PLATFORM="wsl2"
-		else
-			AIDEVOPS_PLATFORM="linux"
-		fi
-
-		# Scheduler: prefer systemd user services; fall back to cron
-		if command -v systemctl >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
-			AIDEVOPS_SCHEDULER="systemd"
-		else
-			AIDEVOPS_SCHEDULER="cron"
-		fi
-
-		# Clipboard: prefer xclip, then xsel, then wl-copy (Wayland), then clip.exe (WSL2)
-		if command -v xclip >/dev/null 2>&1; then
-			AIDEVOPS_CLIPBOARD_COPY="xclip -selection clipboard"
-			AIDEVOPS_CLIPBOARD_PASTE="xclip -selection clipboard -o"
-		elif command -v xsel >/dev/null 2>&1; then
-			AIDEVOPS_CLIPBOARD_COPY="xsel --clipboard --input"
-			AIDEVOPS_CLIPBOARD_PASTE="xsel --clipboard --output"
-		elif command -v wl-copy >/dev/null 2>&1; then
-			AIDEVOPS_CLIPBOARD_COPY="wl-copy"
-			AIDEVOPS_CLIPBOARD_PASTE="wl-paste"
-		elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v clip.exe >/dev/null 2>&1; then
-			AIDEVOPS_CLIPBOARD_COPY="clip.exe"
-			AIDEVOPS_CLIPBOARD_PASTE="powershell.exe -c Get-Clipboard"
-		else
-			AIDEVOPS_CLIPBOARD_COPY=""
-			AIDEVOPS_CLIPBOARD_PASTE=""
-		fi
-
-		# Open URL/file: prefer xdg-open, then wslview (WSL2 bridge)
-		if command -v xdg-open >/dev/null 2>&1; then
-			AIDEVOPS_OPEN_CMD="xdg-open"
-		elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v wslview >/dev/null 2>&1; then
-			AIDEVOPS_OPEN_CMD="wslview"
-		else
-			AIDEVOPS_OPEN_CMD=""
-		fi
-
-		# File search: prefer fd, then locate, then find
-		if command -v fd >/dev/null 2>&1; then
-			AIDEVOPS_FILE_SEARCH="fd"
-		elif command -v locate >/dev/null 2>&1; then
-			AIDEVOPS_FILE_SEARCH="locate"
-		else
-			AIDEVOPS_FILE_SEARCH="find"
-		fi
-
-		# Package manager
-		if command -v apt-get >/dev/null 2>&1; then
-			AIDEVOPS_PKG_INSTALL="sudo apt-get install -y"
-		elif command -v brew >/dev/null 2>&1; then
-			AIDEVOPS_PKG_INSTALL="brew install"
-		elif command -v dnf >/dev/null 2>&1; then
-			AIDEVOPS_PKG_INSTALL="sudo dnf install -y"
-		elif command -v pacman >/dev/null 2>&1; then
-			AIDEVOPS_PKG_INSTALL="sudo pacman -S --noconfirm"
-		elif command -v apk >/dev/null 2>&1; then
-			AIDEVOPS_PKG_INSTALL="sudo apk add"
-		else
-			AIDEVOPS_PKG_INSTALL=""
-		fi
+		_detect_linux_platform
+		_detect_linux_scheduler
+		_detect_linux_clipboard
+		_detect_linux_open_cmd
+		_detect_linux_file_search
+		_detect_linux_pkg_manager
 		;;
 	MINGW* | MSYS* | CYGWIN*)
-		AIDEVOPS_PLATFORM="windows-native"
-		AIDEVOPS_SCHEDULER="cron"
-		AIDEVOPS_CLIPBOARD_COPY="clip"
-		AIDEVOPS_CLIPBOARD_PASTE="powershell -c Get-Clipboard"
-		AIDEVOPS_OPEN_CMD="start"
-		AIDEVOPS_FILE_SEARCH="find"
-		AIDEVOPS_PKG_INSTALL=""
+		_detect_windows
 		;;
 	*)
-		AIDEVOPS_PLATFORM="unknown"
-		AIDEVOPS_SCHEDULER="cron"
-		AIDEVOPS_CLIPBOARD_COPY=""
-		AIDEVOPS_CLIPBOARD_PASTE=""
-		AIDEVOPS_OPEN_CMD=""
-		AIDEVOPS_FILE_SEARCH="find"
-		AIDEVOPS_PKG_INSTALL=""
+		_detect_unknown
 		;;
 	esac
 


### PR DESCRIPTION
## Summary
- Refactored `_aidevops_detect_platform` in `.agents/scripts/platform-detect.sh` to reduce its complexity.
- Extracted platform-specific detection logic into helper functions:
  - `_detect_macos`
  - `_detect_linux_platform`
  - `_detect_linux_scheduler`
  - `_detect_linux_clipboard`
  - `_detect_linux_open_cmd`
  - `_detect_linux_file_search`
  - `_detect_linux_pkg_manager`
  - `_detect_windows`
  - `_detect_unknown`
- The main `_aidevops_detect_platform` function is now much shorter and easier to read.
- Verified with `shellcheck` and by running the script on Linux.

Closes #15446