### PR TITLE
GH#14851: tighten remotion-assets.md

### DIFF
--- a/.agents/tools/video/remotion-assets.md
+++ b/.agents/tools/video/remotion-assets.md
@@ -10,19 +10,7 @@ metadata:
 
 ## Local assets: `public/` + `staticFile()`
 
-Place project assets in `public/` and reference them with `staticFile()`. It returns an encoded URL that keeps local asset paths working, including deployments under subdirectories and filenames with characters like `#`, `?`, and `&`.
-
-```tsx
-import {Img, staticFile} from 'remotion';
-
-export const MyComposition = () => {
-  return <Img src={staticFile('logo.png')} />;
-};
-```
-
-## Supported asset types
-
-Use `staticFile()` for local images, videos, audio, and fonts:
+Place assets in `public/` and reference with `staticFile()`. Returns an encoded URL that handles subdirectory deployments and filenames with `#`, `?`, `&`.
 
 ```tsx
 import {Img, staticFile} from 'remotion';
@@ -33,7 +21,7 @@ import {Video, Audio} from '@remotion/media';
 <Audio src={staticFile('music.mp3')} />;
 ```
 
-For fonts, load the file URL returned by `staticFile()`:
+For fonts:
 
 ```tsx
 import {staticFile} from 'remotion';
@@ -45,7 +33,7 @@ document.fonts.add(fontFamily);
 
 ## Remote URLs
 
-Remote URLs can be passed directly without `staticFile()`:
+Pass remote URLs directly without `staticFile()`:
 
 ```tsx
 <Img src="https://example.com/image.png" />
@@ -54,4 +42,4 @@ Remote URLs can be passed directly without `staticFile()`:
 
 ## Why use Remotion components
 
-- Remotion components (`<Img>`, `<Video>`, `<Audio>`) ensure assets are fully loaded before rendering
+Remotion components (`<Img>`, `<Video>`, `<Audio>`) ensure assets are fully loaded before rendering.


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/video/remotion-assets.md` per simplification issue #14851.

**Changes:**
- Merged redundant "Local assets" + "Supported asset types" sections into one (they both covered `staticFile()` usage)
- Removed boilerplate wrapper component (`MyComposition`) from first code example — not needed to illustrate the concept
- Tightened prose throughout (removed filler words)
- Fixed truncated last line (was a dangling list item without closing punctuation/newline)

**Verification:**
- All code blocks preserved: `staticFile()`, Img/Video/Audio, font loading, remote URLs
- All URLs preserved
- No task IDs or GH refs in original — nothing to preserve there
- Line count: 57 → 45 (~21% reduction)

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. Self-assessed.

Closes #14851


---
[aidevops.sh](https://aidevops.sh) v3.5.600 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined local asset guidance with clearer explanation of staticFile() functionality for URL encoding and deployment support.
  * Simplified supported asset types section with concise examples.
  * Enhanced remote URL instructions with improved clarity on direct usage.
  * Improved overall documentation formatting and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->