### PR TITLE
GH#14891: tighten cloudron-app-publishing-skill.md

### DIFF
--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -13,8 +13,6 @@ tools:
 
 # Cloudron App Publishing
 
-Distribute Cloudron apps via a `CloudronVersions.json` version catalog. Users add the URL in their dashboard or install via `cloudron install --versions-url <url>`.
-
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
@@ -23,6 +21,7 @@ Distribute Cloudron apps via a `CloudronVersions.json` version catalog. Users ad
 - **Upstream skill**: [git.cloudron.io/docs/skills](https://git.cloudron.io/docs/skills) (`cloudron-app-publishing`)
 - **Prerequisite**: App must be built with `cloudron build` (local or build service) -- on-server builds cannot be published
 - **Key file**: `CloudronVersions.json` -- version catalog hosted at a public URL
+- **Forum**: [App Packaging & Development](https://forum.cloudron.io/category/96/app-packaging-development)
 
 <!-- AI-CONTEXT-END -->
 
@@ -80,7 +79,3 @@ Host `CloudronVersions.json` at any public URL (static host, git repo, web serve
 ## Community Packages (9.1+)
 
 Community packages can be non-free (paid). Publishers keep Docker images private; end users set up a [private Docker registry](https://docs.cloudron.io/docker#private-registry) for access.
-
-## Forum
-
-Post new packages in [App Packaging & Development](https://forum.cloudron.io/category/96/app-packaging-development).


### PR DESCRIPTION
## Summary

- Remove redundant intro paragraph that duplicated the YAML `description` field
- Move Forum link into Quick Reference section for better discoverability
- 86 → 81 lines, zero content loss

## Verification

- All code blocks, URLs, and command examples preserved
- Forum link retained (moved from standalone section to Quick Reference)
- Agent behaviour unchanged — same commands, same rules, same workflow

Closes #14891

---
[aidevops.sh](https://aidevops.sh) v3.5.600 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 49m and 46,243 tokens on this with the user in an interactive session.