### PR TITLE
GH#14892: tighten feature branch doc, remove redundant guidance bullets

### DIFF
--- a/.agents/workflows/branch/feature.md
+++ b/.agents/workflows/branch/feature.md
@@ -37,9 +37,7 @@ git checkout -b feature/{description}
 
 ## Guidance
 
-- Branch names use `feature/{description}`.
-- Commits use `feat:`.
-- Minor-version guidance applies when the branch ships user-visible capability, not internal-only maintenance.
+- Minor-version bump applies when the branch ships user-visible capability, not internal-only maintenance.
 - For implementation patterns, see `workflows/feature-development.md`.
 
 ## Examples
@@ -48,8 +46,6 @@ git checkout -b feature/{description}
 feature/user-dashboard
 feature/export-to-csv
 ```
-
-## Commit Example
 
 ```bash
 feat: add user authentication


### PR DESCRIPTION
## Summary

- Removed two guidance bullets that repeated info already in the quick-reference table (prefix `feature/`, commits use `feat:`)
- Merged separate "Commit Example" section into "Examples" for consistency with other branch docs (hotfix.md pattern)
- All institutional knowledge preserved: version bump rule, `feature-development.md` pointer, when-to-use criteria

## Changes

- **File**: `.agents/workflows/branch/feature.md`
- **Before**: 56 lines
- **After**: 52 lines (4 lines removed, no content loss)

## Verification

- `markdownlint-cli2`: 0 errors
- Content preservation: all code blocks, task ID references, command examples present before and after
- Agent behaviour unchanged: quick-reference table, when-to-use, and implementation pointer all intact

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code changes. Self-assessed.

Closes #14892


---
[aidevops.sh](https://aidevops.sh) v3.5.600 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.