### PR TITLE
feat: configurable LLM stall threshold (default 1h)

### DIFF
--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -134,7 +134,15 @@
     // Empty string keeps the shared round-robin/default behavior.
     // Example local opt-in: "openai/gpt-5.4"
     // Env override: AIDEVOPS_HEADLESS_MODELS
-    "headless_models": ""
+    "headless_models": "",
+
+    // Seconds of unchanged backlog before triggering an LLM supervisor session.
+    // The deterministic fill floor handles routine dispatch every 2-min cycle;
+    // the LLM supervisor only adds value for edge cases (CHANGES_REQUESTED PRs,
+    // external contributor triage, semantic dedup, stale coaching).
+    // Lower = more LLM sessions (higher token cost), higher = more autonomous.
+    // Env override: PULSE_LLM_STALL_THRESHOLD
+    "llm_stall_threshold": 3600
   },
 
   // ---------------------------------------------------------------------------

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6786,8 +6786,8 @@ _Closed by deterministic merge pass (pulse-wrapper.sh)._" 2>/dev/null || true
 #   ${PULSE_DIR}/backlog_snapshot.txt    — "epoch issues_count prs_count"
 #   ${PULSE_DIR}/llm_trigger_mode        — last trigger reason (daily_sweep|stall|first_run)
 #######################################
-PULSE_LLM_STALL_THRESHOLD="${PULSE_LLM_STALL_THRESHOLD:-1800}" # 30 min
-PULSE_LLM_DAILY_INTERVAL="${PULSE_LLM_DAILY_INTERVAL:-86400}"  # 24h
+PULSE_LLM_STALL_THRESHOLD="${PULSE_LLM_STALL_THRESHOLD:-$(config_get "orchestration.llm_stall_threshold" "3600")}" # 1h (was 30 min; deterministic fill floor handles routine dispatch)
+PULSE_LLM_DAILY_INTERVAL="${PULSE_LLM_DAILY_INTERVAL:-86400}"                                                      # 24h
 
 _should_run_llm_supervisor() {
 	local now_epoch


### PR DESCRIPTION
## Summary

- Raise default `PULSE_LLM_STALL_THRESHOLD` from 30m to 1h — the deterministic fill floor handles routine dispatch every 2-min cycle, so LLM supervisor sessions are only needed for edge cases
- Add `orchestration.llm_stall_threshold` config key so users can tune it via `config.jsonc`
- ~50% reduction in supervisor token spend with no impact on dispatch throughput

Closes #15317