### PR TITLE
GH#14401: tighten worktree-cleanup.md (60→56 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,6 +1,11 @@
 {
   "_comment": null,
   "files": {
+    ".agents/scripts/commands/worktree-cleanup.md": {
+      "hash": "f333ce7dce4127c4c2150a07b4c1f50c",
+      "at": "2026-04-02T02:30:00Z",
+      "pr": null
+    },
     ".agents/content/seo-writer.md": {
       "hash": "b26db2ddd38996e2ad605d9c79db94f8",
       "at": "2026-04-01T22:10:00Z",

--- a/.agents/scripts/commands/worktree-cleanup.md
+++ b/.agents/scripts/commands/worktree-cleanup.md
@@ -4,7 +4,7 @@ After a PR is merged, clean up the linked worktree and return the canonical repo
 
 ## Automated Cleanup (workers — GH#6740)
 
-Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (Step 4.8). This prevents worktree accumulation during batch dispatch.
+Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (Step 4.9). The pulse `cleanup_worktrees()` stage acts as a safety net, but workers must not rely on it — self-cleanup prevents accumulation during batch dispatch.
 
 ```bash
 # After gh pr merge --squash succeeds:
@@ -12,7 +12,6 @@ WORKTREE_PATH="$(pwd)"
 BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 CANONICAL_DIR="${WORKTREE_PATH%%.*}"
 
-# Return to canonical repo, pull, remove worktree
 cd "$CANONICAL_DIR" || cd "$HOME"
 git pull origin main 2>/dev/null || true
 
@@ -28,33 +27,30 @@ git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
 git branch -D "$BRANCH_NAME" 2>/dev/null || true
 ```
 
-Cleanup failures are non-fatal — the PR is already merged. The pulse `cleanup_worktrees()` stage acts as a safety net for any worktrees workers fail to clean up.
+Cleanup failures are non-fatal — the PR is already merged.
 
 ## Manual Cleanup (interactive sessions)
 
 ```bash
-# Merge the PR without --delete-branch (required when working from a worktree)
+# Merge without --delete-branch (required from inside a worktree)
 gh pr merge --squash
 
-# Return to the canonical repo directory
+# Return to canonical repo and pull
 cd ~/Git/$(basename "$PWD" | cut -d. -f1)
-
-# Pull the merged changes into main
 git pull origin main
 
 # Remove merged worktrees
 wt prune
 ```
 
-## Notes
+## Key Rules
 
-- **Do not use `--delete-branch`** with `gh pr merge` when running from inside a worktree — it will fail because the branch is checked out in the worktree, not the canonical repo.
-- `wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run it from the canonical repo directory (on `main`), not from inside the worktree.
-- If `wt prune` is unavailable, use `git worktree prune` to remove stale worktree entries, then manually delete the worktree directory.
-- The pulse runs `cleanup_worktrees()` every cycle as a safety net, but workers should not rely on it — self-cleanup prevents accumulation during batch operations.
+- **Do not use `--delete-branch`** with `gh pr merge` from inside a worktree — the branch is checked out there, not in the canonical repo.
+- `wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run from the canonical repo (on `main`).
+- If `wt prune` is unavailable, use `git worktree prune` then manually delete the worktree directory.
 
 ## See Also
 
 - `workflows/git-workflow.md` — full worktree lifecycle
 - `reference/session.md` — session and worktree conventions
-- `full-loop.md` Step 4.8 — worker self-cleanup specification
+- `full-loop.md` Step 4.9 — worker self-cleanup specification


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/worktree-cleanup.md` from 60 → 56 lines (7% reduction)
- Merge Notes section into Key Rules — eliminates redundancy, improves scannability
- Remove duplicate pulse safety net mention (was in both intro paragraph and Notes)
- Fix Step reference 4.8 → 4.9 to match current `full-loop.md`
- Consolidate manual cleanup inline comments for brevity

## Runtime Testing

- **Risk level:** Low (docs/agent prompts only)
- **Verification:** `self-assessed` — content-only restructuring, no runtime behavior change
- **Content preservation:** GH#6740 task ID, all code blocks, `--delete-branch` warning, cross-references all present

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/commands/worktree-cleanup.md` | Tightened prose, merged Notes → Key Rules, fixed step ref |
| `.agents/configs/simplification-state.json` | Registered post-simplification hash |

Closes #14401

---
[aidevops.sh](https://aidevops.sh) v3.5.601 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6