### PR TITLE
GH#14222: tighten spaceship.md agent doc

### DIFF
--- a/.agents/services/hosting/spaceship.md
+++ b/.agents/services/hosting/spaceship.md
@@ -34,8 +34,6 @@ tools:
 cp configs/spaceship-config.json.txt configs/spaceship-config.json
 ```
 
-Config structure (`configs/spaceship-config.json`):
-
 ```json
 {
   "accounts": {
@@ -50,7 +48,7 @@ Config structure (`configs/spaceship-config.json`):
 }
 ```
 
-API credentials: Login → Spaceship Dashboard → API Settings → Generate Key + Secret. Store with `setup-local-api-keys.sh set spaceship YOUR_API_KEY`. Test: `spaceship-helper.sh accounts`.
+Credentials: Spaceship Dashboard → API Settings → Generate Key + Secret. Store: `setup-local-api-keys.sh set spaceship YOUR_API_KEY`. Test: `spaceship-helper.sh accounts`.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/spaceship.md` per GH#14222 simplification scan.

**Changes (101 → 99 lines):**
- Remove redundant "Config structure (`configs/spaceship-config.json`):" label — path already shown in the bash command above it and in Quick Reference
- Compress credential setup prose: "API credentials: Login → Spaceship Dashboard..." → "Credentials: Spaceship Dashboard..."

**Preserved:** All code blocks, command examples, JSON config template, security rules, troubleshooting table, task IDs, and all institutional knowledge.

**Verification:** `markdownlint-cli2` — 0 errors. Content diff reviewed: zero knowledge loss.

Closes #14222

## Runtime Testing

Risk: **Low** — agent doc only, no code or scripts changed. Self-assessed.


---
[aidevops.sh](https://aidevops.sh) v3.5.601 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6