### PR TITLE
GH#14211: tighten agent doc Backlink & Expired Domain Checker

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3480,6 +3480,11 @@
       "hash": "d49896c8e032eb61689a15c73ce2b97b2e049315",
       "at": "2026-04-02T00:19:59Z",
       "pr": 15277
+    },
+    ".agents/seo/backlink-checker.md": {
+      "hash": "aa5038f9569e0d64e563b31a0e2243bd9c2b959c",
+      "at": "2026-04-02T02:14:59Z",
+      "pr": null
     }
   }
 }

--- a/.agents/seo/backlink-checker.md
+++ b/.agents/seo/backlink-checker.md
@@ -88,18 +88,9 @@ done
    - Registration cost vs. link value
 5. **Output ranked list** of purchase candidates
 
-The full reclamation pipeline combines backlink export with WHOIS checks. Use the Ahrefs or DataForSEO export scripts to get lost backlinks, then pipe through WHOIS lookups above.
-
-## Integration with aidevops
-
-- Pairs with `seo/ahrefs.md` for API access
-- Pairs with `seo/dataforseo.md` for alternative data source
-- Pairs with `seo/domain-research.md` for DNS intelligence on candidates
-- Results can feed into `seo/link-building.md` workflows
-
 ## Related
 
-- `seo/ahrefs.md` - Ahrefs API integration
-- `seo/dataforseo.md` - DataForSEO API integration
-- `seo/domain-research.md` - DNS reconnaissance
+- `seo/ahrefs.md` - Ahrefs API (primary data source)
+- `seo/dataforseo.md` - DataForSEO API (alternative data source)
+- `seo/domain-research.md` - DNS reconnaissance on candidates
 - `seo/link-building.md` - Link-building strategies


### PR DESCRIPTION
## Summary

Tighten `.agents/seo/backlink-checker.md` per issue #14211.

**Changes:**
- Merged duplicate "Integration with aidevops" and "Related" sections into a single "Related" section (7 lines removed)
- Removed trailing prose paragraph in "Reclamation Workflow" that restated the numbered list above it (2 lines removed)
- Updated `simplification-state.json` to record the new file hash

**Result:** 105 → 96 lines (9% reduction). All code blocks, URLs, API endpoints, command examples, and file references preserved.

## Verification

- All 6 API endpoints preserved (`/v3/...`)
- Both code blocks preserved (WHOIS single + batch check)
- Both GitHub URLs preserved
- All 4 `seo/` file references preserved
- All 3 `scripts/` references preserved
- Agent behaviour unchanged — same workflow, same data sources, same tools

## Runtime Testing

**Risk level:** Low — agent doc only (no shell scripts, no code, no config changes)
**Assessment:** self-assessed

Closes #14211


---
[aidevops.sh](https://aidevops.sh) v3.5.601 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m on this as a headless worker.