### PR TITLE
GH#14223: tighten ai-search-readiness.md (101→82 lines)

### DIFF
--- a/.agents/seo/ai-search-readiness.md
+++ b/.agents/seo/ai-search-readiness.md
@@ -19,70 +19,59 @@ Run a complete, high-signal workflow to improve AI search citations and answer q
 
 ## Quick Reference
 
-- Purpose: execute a repeatable end-to-end readiness cycle
-- Inputs: target intents, priority pages, fact inventory, competitor set
-- Outputs: prioritized fixes with measurable readiness deltas
-- Scorecard template: `seo/ai-search-kpi-template.md`
-- Cadence: monthly baseline, then sprint-level re-tests after content changes
+- **Inputs**: target intents, priority pages, fact inventory, competitor set
+- **Outputs**: prioritized fixes with measurable readiness deltas
+- **Scorecard**: `seo/ai-search-kpi-template.md`
+- **Cadence**: monthly baseline; sprint-level re-tests after content changes
 
 ## Execution Sequence
 
 ### Phase 0: Grounding eligibility gate
 
-- Classify target queries by likelihood of triggering search grounding
-- Prioritize intents where retrieval can be influenced by SEO changes
-- Validate crawler/bot accessibility so eligible queries can actually fetch content
-- Run site-query readiness checks for critical claims:
-  `site:yourdomain.com [product category] features`,
-  `site:yourdomain.com pricing`,
-  `site:yourdomain.com integrations`
+- Classify queries by likelihood of triggering search grounding; prioritize intents where retrieval can be influenced by SEO changes
+- Validate crawler/bot accessibility so eligible queries can fetch content
+- Run site-query readiness checks: `site:yourdomain.com [product category] features`, `site:yourdomain.com pricing`, `site:yourdomain.com integrations`
 
 ### Phase 1: Query decomposition
 
-- Use `query-fanout-research.md`
-- Outcome: thematic branches and sub-query map per intent
+Use `query-fanout-research.md` → thematic branches and sub-query map per intent
 
 ### Phase 2: Criteria alignment
 
-- Use `geo-strategy.md`
-- Outcome: criteria matrix and page-level strong/partial/missing coverage map
+Use `geo-strategy.md` → criteria matrix and page-level strong/partial/missing coverage map
 
 ### Phase 3: Snippet survivability
 
-- Use `sro-grounding.md`
-- Outcome: top-of-page and sentence-level changes that improve selection likelihood
+Use `sro-grounding.md` → top-of-page and sentence-level changes that improve selection likelihood
 
 ### Phase 4: Integrity hardening
 
-- Use `ai-hallucination-defense.md`
-- Outcome: contradiction fixes, claim-evidence alignment, canonical fact hygiene
+Use `ai-hallucination-defense.md` → contradiction fixes, claim-evidence alignment, canonical fact hygiene
 
 ### Phase 5: Autonomous discoverability
 
-- Use `ai-agent-discovery.md`
-- Outcome: task-completion diagnostics and discoverability gap remediation
+Use `ai-agent-discovery.md` → task-completion diagnostics and discoverability gap remediation
 
 ### Phase 6: Citation and volatility monitoring
 
-- Track citation frequency and confidence by intent cluster
-- Monitor volatility and re-run high-impact intents on schedule
+- Track citation frequency and confidence by intent cluster; monitor volatility and re-run high-impact intents on schedule
 - Keep a rolling benchmark so wins are distinguished from noise
-- Audit third-party citation readiness quarterly: verify G2/Capterra/
-  TrustRadius profiles are current and fact-aligned with canonical site pages
-- Use UTM-tagged profile links and partner citations so citation-driven
-  sessions and conversion contribution are measurable
+- Audit third-party citation readiness quarterly: verify G2/Capterra/TrustRadius profiles are current and fact-aligned with canonical site pages
+- Use UTM-tagged profile links and partner citations so citation-driven sessions and conversion contribution are measurable
 
-## Readiness Scorecard (Recommended)
+## Readiness Scorecard
 
-- Fan-out coverage: percent of high-priority branches fully covered
-- Grounding eligibility: percent of target intents likely to trigger retrieval
-- Criteria coverage: percent of required criteria marked strong
-- Snippet fitness: percent of intents with high-quality selected snippets
-- Fact integrity: count of critical contradictions unresolved
-- Discovery success: percent of tasks completed by autonomous exploration
-- Citation stability: variance in citation frequency over repeated runs
-- Site-query readiness: percent of priority pages retrievable via `site:yourdomain.com [category]` queries
-- Third-party profile currency: percent of review platform profiles updated within the last 90 days
+| Metric | Definition |
+|--------|-----------|
+| Fan-out coverage | % of high-priority branches fully covered |
+| Grounding eligibility | % of target intents likely to trigger retrieval |
+| Criteria coverage | % of required criteria marked strong |
+| Snippet fitness | % of intents with high-quality selected snippets |
+| Fact integrity | Count of critical contradictions unresolved |
+| Discovery success | % of tasks completed by autonomous exploration |
+| Citation stability | Variance in citation frequency over repeated runs |
+| Site-query readiness | % of priority pages retrievable via `site:yourdomain.com [category]` |
+| Third-party profile currency | % of review platform profiles updated within last 90 days |
 
 ## Prioritization Rules
 
@@ -91,11 +80,3 @@ Run a complete, high-signal workflow to improve AI search citations and answer q
 - Prefer focused section updates before creating new URLs
 - Keep evidence traceable for every important claim
 - Re-validate key pages after major model updates or indexing shifts
-
-## Related Subagents
-
-- `query-fanout-research.md`
-- `geo-strategy.md`
-- `sro-grounding.md`
-- `ai-hallucination-defense.md`
-- `ai-agent-discovery.md`


### PR DESCRIPTION
## Summary

Tighten `.agents/seo/ai-search-readiness.md` from 101 to 82 lines (~19% reduction) with zero knowledge loss.

## Changes

- Condense Quick Reference bullets to bold key/value pairs
- Collapse single-concern phases (1–5) to one-liner: `Use X → outcome`
- Convert Readiness Scorecard list to table for scannability
- Merge Phase 6 verbose bullets; preserve UTM tracking, quarterly audit, rolling benchmark detail
- Remove redundant Related Subagents section (all refs preserved inline in phases)

## Content Preservation Verified

- All 5 subagent references present (`query-fanout-research.md`, `geo-strategy.md`, `sro-grounding.md`, `ai-hallucination-defense.md`, `ai-agent-discovery.md`)
- All 7 phases (0–6) present with correct names
- Site-query examples preserved (`site:yourdomain.com` patterns)
- UTM-tagged citations detail preserved
- Quarterly audit cadence preserved
- All 9 scorecard metrics preserved
- All 5 prioritization rules preserved

## Runtime Testing

Risk: **Low** — agent doc only, no code, no scripts. Self-assessed.

Closes #14223


---
[aidevops.sh](https://aidevops.sh) v3.5.601 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6