### PR TITLE
GH#14970: tighten agent doc Entity Memory Architecture (.agents/reference/entity-memory-architecture.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3122,9 +3122,9 @@
       "pr": 13773
     },
     ".agents/reference/entity-memory-architecture.md": {
-      "hash": "f459c108bb4697a61a23da603c732273ea6b8fb6",
-      "at": "2026-03-31T02:26:11Z",
-      "pr": 14489
+      "hash": "6474aafdada78c67373c6ab679e427f0f97f531b75c895245b2a8df6254fabc2",
+      "at": "2026-04-02T00:00:00Z",
+      "pr": null
     },
     ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
       "hash": "102c82fd40a93f9e219e84ee053645eff00db29b",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3122,9 +3122,9 @@
       "pr": 13773
     },
     ".agents/reference/entity-memory-architecture.md": {
-      "hash": "6474aafdada78c67373c6ab679e427f0f97f531b75c895245b2a8df6254fabc2",
+      "hash": "bbd1c42b7e0eb2b01cb5a193f94c5e9ecf98c540",
       "at": "2026-04-02T00:00:00Z",
-      "pr": null
+      "pr": 15488
     },
     ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
       "hash": "102c82fd40a93f9e219e84ee053645eff00db29b",

--- a/.agents/reference/entity-memory-architecture.md
+++ b/.agents/reference/entity-memory-architecture.md
@@ -18,7 +18,7 @@ tools:
 
 ## Purpose
 
-Provide cross-channel relationship continuity for agents on Matrix, SimpleX, email, CLI, and similar channels. Core loop: interaction patterns → gap detection → auto TODO → system upgrade. The model should evolve from observed user needs, not fixed assumptions.
+Cross-channel relationship continuity for agents on Matrix, SimpleX, email, CLI, and similar channels. Core loop: interaction patterns → gap detection → auto TODO → system upgrade. Model evolves from observed user needs, not fixed assumptions.
 
 ## Core Decisions
 
@@ -40,7 +40,7 @@ Provide cross-channel relationship continuity for agents on Matrix, SimpleX, ema
 | **1: Conversation context** | Active threads, immutable summaries, tone profile, pending actions | conversations, conversation_summaries | `conversation-helper.sh` |
 | **0: Raw interaction log** | Immutable source of truth; FTS5 indexed; privacy-filtered on write | interactions, interactions_fts | `entity-helper.sh log-interaction` |
 
-**Immutability:** Layer 0 is INSERT-only except privacy deletion. Layers 1-2 use `supersedes_id` chains: new rows supersede old rows, never edit in place. The current record is the row whose `id` is not referenced by another row's `supersedes_id`. This preserves a full audit trail and avoids concurrent-write conflicts.
+**Immutability:** Layer 0 is INSERT-only (except privacy deletion). Layers 1-2 use `supersedes_id` chains — new rows supersede old, never edit in place. Current record = row whose `id` is not referenced by another row's `supersedes_id`. Preserves full audit trail; avoids concurrent-write conflicts.
 
 ## Database Schema
 
@@ -92,13 +92,13 @@ All tables live in `~/.aidevops/.agent-workspace/memory/memory.db` alongside `le
 
 1. **Suggest, don't assume.** `entity-helper.sh suggest` may propose matches; linking requires `entity-helper.sh link` or `verify`.
 2. **Confidence levels:** `confirmed` (user verified), `suggested` (name or pattern match), `inferred` (display-name match).
-3. **Primary key on `(channel, channel_id)`** means each channel identity maps to exactly one entity.
+3. **Primary key on `(channel, channel_id)`** — each channel identity maps to exactly one entity.
 
 ## Self-Evolution Loop
 
 Flow: Layer 0 interactions → AI pattern detection (haiku, ~$0.001/call) → deduped gap identification with frequency tracking → TODO creation with interaction-ID evidence → normal task lifecycle (dispatch → PR → merge) → updated Layer 2 model.
 
-Gap lifecycle: `detected` → `todo_created` → `resolved` | `wont_fix`. Auto-TODO creation starts at frequency ≥ 3 (configurable) and preserves the evidence trail.
+Gap lifecycle: `detected` → `todo_created` → `resolved` | `wont_fix`. Auto-TODO creation starts at frequency ≥ 3 (configurable).
 
 ## Intelligent Threshold Replacement
 
@@ -112,7 +112,7 @@ Gap lifecycle: `detected` → `todo_created` → `resolved` | `wont_fix`. Auto-T
 ## Integration
 
 ```bash
-# Memory system cross-queries
+# Cross-queries
 memory-helper.sh store --content "Prefers concise responses" --entity ent_xxx --type USER_PREFERENCE
 memory-helper.sh recall --query "deployment" --entity ent_xxx --project ~/Git/myproject
 
@@ -141,10 +141,10 @@ self-evolution-helper.sh pulse-scan --auto-todo-threshold 3 --repo-path ~/Git/ai
 └── preferences/                       # Optional: markdown preference files
 
 .agents/scripts/
-├── entity-helper.sh                   # Layer 0 + 2
-├── conversation-helper.sh             # Layer 1
-├── self-evolution-helper.sh           # Self-evolution loop
-├── memory-helper.sh                   # Existing memory system
+├── entity-helper.sh
+├── conversation-helper.sh
+├── self-evolution-helper.sh
+├── memory-helper.sh
 └── memory/                            # Modules: _common, store, recall, maintenance
 
 tests/


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/reference/entity-memory-architecture.md` (155 lines) per issue #14970 simplification scan.

**Classification:** Instruction doc (agent rules, architecture decisions, operational procedures) — prose tightening, not restructuring.

## Changes

- **Purpose:** Remove filler opener ("Provide"), tighten "The model should evolve" → "Model evolves"
- **Immutability:** Condense 3-sentence paragraph into tighter prose (same content, fewer words)
- **Identity Resolution #3:** Replace "means each" with em-dash (cleaner)
- **Self-Evolution:** Remove trailing "and preserves the evidence trail" (already described in the flow sentence above)
- **Integration:** Shorten code comment "Memory system cross-queries" → "Cross-queries"
- **File Locations:** Remove inline script comments (Layer 0+2, Layer 1, etc.) — fully covered by Script Responsibilities table above
- **simplification-state.json:** Update hash for `.agents/reference/entity-memory-architecture.md` to clear `recheck-simplicity` label

## Verification

- All task IDs preserved: t1363.1–t1363.7
- All GH refs preserved: none in this file
- All schema tables intact (Layer 0, 1, 2 columns/fields)
- All command examples intact (entity-helper.sh, conversation-helper.sh, self-evolution-helper.sh, memory-helper.sh)
- All code blocks intact
- Line count: 155 → 155 (prose compression within lines, not line removal)
- No broken internal links or references

## Runtime Testing

**Risk level:** Low — agent doc only, no code changes. Self-assessed.

Closes #14970


---
[aidevops.sh](https://aidevops.sh) v3.5.601 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference documentation with refined wording and clarifications for improved clarity.

* **Chores**
  * Updated configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->