### PR TITLE
t1751: reap zombie workers with merged PRs, fix empty worker logs

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1279,7 +1279,7 @@ _invoke_opencode() {
 			timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${cmd[@]}" 2>&1 | tee "$output_file"
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		fi
-	) >/dev/null 2>&1 &
+	) &
 	local worker_pid=$!
 
 	# Activity watchdog: monitor the output file for LLM activity.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4952,6 +4952,67 @@ prefetch_gh_failure_notifications() {
 }
 
 #######################################
+# Reap zombie workers whose PRs have already been merged (t1751/GH#15489)
+#
+# Workers don't detect when the deterministic merge pass merges their PR.
+# This function runs each pulse cycle (before worker counting) to kill
+# workers that are still running after their work is done.
+#
+# Uses the dispatch ledger session keys (issue-{N}) to find the issue
+# number, then checks if a merged PR exists for that issue. If so,
+# sends SIGTERM to the worker process tree.
+#
+# Returns: 0 always (best-effort, never breaks the pulse)
+#######################################
+reap_zombie_workers() {
+	local reaped=0
+	local worker_pids worker_key issue_number
+
+	# Get unique session keys from active worker processes
+	local session_keys
+	session_keys=$(ps aux | grep '[h]eadless-runtime.*--role worker' | grep -v grep |
+		sed 's/.*--session-key //' | awk '{print $1}' | sort -u) || return 0
+
+	while IFS= read -r worker_key; do
+		[[ -z "$worker_key" ]] && continue
+		issue_number="${worker_key#issue-}"
+		[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
+
+		# Check dispatch ledger for the repo slug
+		local repo_slug=""
+		local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+		if [[ -x "$_ledger_helper" ]]; then
+			repo_slug=$("$_ledger_helper" get-repo --session-key "$worker_key" 2>/dev/null) || repo_slug=""
+		fi
+		# Fallback: check all pulse-enabled repos
+		if [[ -z "$repo_slug" ]]; then
+			repo_slug=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | .slug' "$REPOS_JSON" 2>/dev/null | head -1) || continue
+		fi
+		[[ -n "$repo_slug" ]] || continue
+
+		# Check if a merged PR exists that closes this issue
+		local merged_pr
+		merged_pr=$(gh pr list --repo "$repo_slug" --state merged --search "closes #${issue_number} OR Closes #${issue_number}" \
+			--limit 1 --json number --jq '.[0].number' 2>/dev/null) || merged_pr=""
+
+		if [[ -n "$merged_pr" && "$merged_pr" != "null" ]]; then
+			# Kill the worker process tree
+			worker_pids=$(ps aux | grep "[h]eadless-runtime.*--session-key ${worker_key}" | grep -v grep | awk '{print $2}')
+			if [[ -n "$worker_pids" ]]; then
+				echo "[pulse-wrapper] Reaping zombie worker ${worker_key}: PR #${merged_pr} already merged in ${repo_slug}" >>"$LOGFILE"
+				echo "$worker_pids" | xargs kill 2>/dev/null || true
+				reaped=$((reaped + 1))
+			fi
+		fi
+	done <<<"$session_keys"
+
+	if [[ "$reaped" -gt 0 ]]; then
+		echo "[pulse-wrapper] Reaped ${reaped} zombie worker(s) with merged PRs (t1751)" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+#######################################
 # Count active worker processes
 # Returns: count via stdout
 #######################################
@@ -7082,6 +7143,10 @@ _run_preflight_stages() {
 	run_stage_with_timeout "cleanup_stalled_workers" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stalled_workers || true
 	run_stage_with_timeout "cleanup_worktrees" "$PRE_RUN_STAGE_TIMEOUT" cleanup_worktrees || true
 	run_stage_with_timeout "cleanup_stashes" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stashes || true
+
+	# t1751: Reap zombie workers whose PRs have been merged by the deterministic merge pass.
+	# Runs before worker counting so count_active_workers sees accurate slot availability.
+	run_stage_with_timeout "reap_zombie_workers" "$PRE_RUN_STAGE_TIMEOUT" reap_zombie_workers || true
 
 	# GH#6696: Expire stale in-flight ledger entries and prune old completed/failed ones.
 	# This runs before worker counting so count_active_workers sees accurate ledger state.


### PR DESCRIPTION
## Summary

- **Zombie workers**: Workers don't exit when the deterministic merge pass merges their PR. New `reap_zombie_workers()` function runs each pulse cycle to detect and kill workers whose issues already have merged PRs.
- **Empty worker logs**: The `_invoke_opencode()` subshell redirected stdout to `/dev/null`, preventing worker output from reaching `/tmp/pulse-*.log`. Remove the redirect so output flows through.

**Evidence**: 5 of 11 workers were zombies with merged PRs. All 11 worker logs were 0 bytes.

Closes #15489

## Runtime Testing

Risk: **Medium** — pulse infrastructure, no user-facing changes. Self-assessed: ShellCheck clean, logic review of process lifecycle.


---
[aidevops.sh](https://aidevops.sh) v3.5.601 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 1h 30m and 70,374 tokens on this with the user in an interactive session.