### PR TITLE
fix: reduce pulse stale threshold from 60m to 15m

### DIFF
--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -142,7 +142,13 @@
     // external contributor triage, semantic dedup, stale coaching).
     // Lower = more LLM sessions (higher token cost), higher = more autonomous.
     // Env override: PULSE_LLM_STALL_THRESHOLD
-    "llm_stall_threshold": 3600
+    "llm_stall_threshold": 3600,
+
+    // Hard ceiling in seconds for a single pulse cycle (LLM session + preflight).
+    // The LLM supervisor should complete within 15 minutes — longer runs block
+    // the deterministic fill floor from dispatching new workers.
+    // Env override: PULSE_STALE_THRESHOLD
+    "pulse_stale_threshold": 900
   },
 
   // ---------------------------------------------------------------------------

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -115,7 +115,7 @@ fi
 #######################################
 # Configuration
 #######################################
-PULSE_STALE_THRESHOLD="${PULSE_STALE_THRESHOLD:-3600}"                                      # 60 min hard ceiling (raised from 30 min — GH#2958)
+PULSE_STALE_THRESHOLD="${PULSE_STALE_THRESHOLD:-900}"                                       # 15 min hard ceiling (was 60 min; deterministic fill floor handles dispatch every 2-min cycle)
 PULSE_IDLE_TIMEOUT="${PULSE_IDLE_TIMEOUT:-600}"                                             # 10 min idle before kill (reduces false positives during active triage)
 PULSE_IDLE_CPU_THRESHOLD="${PULSE_IDLE_CPU_THRESHOLD:-5}"                                   # CPU% below this = idle (0-100 scale)
 PULSE_PROGRESS_TIMEOUT="${PULSE_PROGRESS_TIMEOUT:-600}"                                     # 10 min no log output = stuck (GH#2958)


### PR DESCRIPTION
## Summary

- Reduce `PULSE_STALE_THRESHOLD` default from 3600s (60m) to 900s (15m)
- Add `orchestration.pulse_stale_threshold` config key
- A stuck LLM session blocked all pulse operations for 60+ minutes tonight, preventing worker dispatch, PR merging, and zombie reaping

Closes #15489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system timeout configuration to reduce pulse stale threshold from 60 minutes to 15 minutes, enabling faster detection and termination of unresponsive processes.
  * Added new configurable pulse stale threshold setting with environment variable override capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->