### PR TITLE
GH#15510: tighten list-verify.md (53→48 lines)

### DIFF
--- a/.agents/scripts/commands/list-verify.md
+++ b/.agents/scripts/commands/list-verify.md
@@ -8,18 +8,13 @@ List `todo/VERIFY.md` verification queue with status filtering.
 
 Arguments: $ARGUMENTS
 
-## Default
+## Run
 
 ```bash
 ~/.aidevops/agents/scripts/list-verify-helper.sh $ARGUMENTS
 ```
 
-## Fallback (Script Unavailable)
-
-1. Read `todo/VERIFY.md`
-2. Parse entries between `<!-- VERIFY-QUEUE-START -->` and `<!-- VERIFY-QUEUE-END -->`
-3. Group by status: failed `[!]`, pending `[ ]`, passed `[x]`
-4. Format as Markdown tables
+**Fallback (script unavailable):** Read `todo/VERIFY.md`, parse entries between `<!-- VERIFY-QUEUE-START -->` and `<!-- VERIFY-QUEUE-END -->`, group by status: failed `[!]`, pending `[ ]`, passed `[x]`, format as Markdown tables.
 
 ## Arguments
 


### PR DESCRIPTION
## Summary

- Merged redundant "Default" section header into "Run" (shorter, clearer label)
- Collapsed 4-step fallback numbered list into a single inline sentence — no knowledge lost
- All code blocks, examples, arguments, task ID refs, and command examples preserved

53 → 48 lines (-5 lines, -9%).

Closes #15510

---
[aidevops.sh](https://aidevops.sh) v3.5.606 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 2,070 tokens on this as a headless worker.