### PR TITLE
GH#15507: tighten bugfix branch doc

### DIFF
--- a/.agents/workflows/branch/bugfix.md
+++ b/.agents/workflows/branch/bugfix.md
@@ -12,48 +12,37 @@ tools:
 
 # Bugfix Branch
 
-<!-- AI-CONTEXT-START -->
-
 | Aspect | Value |
 |--------|-------|
 | **Prefix** | `bugfix/` |
 | **Commit** | `fix: description` |
 | **Version** | Patch bump (1.0.0 → 1.0.1) |
 | **Create from** | `main` |
+| **Examples** | `bugfix/login-timeout`, `bugfix/123-null-pointer` |
 
 ```bash
 git checkout main && git pull origin main
 git checkout -b bugfix/{description}
 ```
 
-<!-- AI-CONTEXT-END -->
-
 ## When to Use
 
 - Non-urgent bug fixes (can wait for release cycle) or bugs found in dev/staging.
 - **Not for** urgent production issues (use `hotfix/`).
 
-## Guidance
+## Rules
 
 - **Regression test**: MANDATORY to prevent recurrence.
 - **Scope**: Minimal changes only — no new features or refactoring.
 - **Investigation**: See `workflows/bug-fixing.md`.
 
-## Examples
+## Commit Format
 
-```bash
-bugfix/login-timeout
-bugfix/123-null-pointer
 ```
-
-## Commit Example
-
-```bash
 fix: resolve login timeout on slow connections
 
 - Increase timeout from 5s to 30s
 - Add retry logic with exponential backoff
-- Improve error message for users
 
 Fixes #123
 ```


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/branch/bugfix.md` per build-agent principles (GH#15507).

- Remove redundant `<!-- AI-CONTEXT-START/END -->` markers (unnecessary for a 59-line file)
- Merge `## Examples` section into the reference table (eliminates duplication)
- Rename `## Guidance` → `## Rules` (more precise)
- Rename `## Commit Example` → `## Commit Format` (more precise)
- Trim one redundant bullet from commit example
- Result: 59 → 48 lines, all institutional knowledge preserved

## Verification

- All rules preserved: regression test MANDATORY, scope constraint, investigation pointer, hotfix redirect
- All code blocks, command examples, and references intact
- No broken internal links

## Runtime Testing

Risk: **Low** — doc-only change, no code paths affected. `self-assessed`.

Closes #15507

---
[aidevops.sh](https://aidevops.sh) v3.5.606 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6