### PR TITLE
GH#14998: tighten bing-webmaster-tools.md

### DIFF
--- a/.agents/seo/bing-webmaster-tools.md
+++ b/.agents/seo/bing-webmaster-tools.md
@@ -29,7 +29,7 @@ tools:
 
 ## API Operations
 
-Base: `BASE="https://ssl.bing.com/webmaster/api.svc/json"`
+Set once per session: `BASE="https://ssl.bing.com/webmaster/api.svc/json"`
 
 ### Submit URL
 
@@ -89,8 +89,8 @@ curl -s -G "$BASE/GetFeedStats" \
 | HTTP 500 | Transient — retry |
 | Quota exceeded | 10,000 URLs/day/site limit |
 
-<!-- AI-CONTEXT-END -->
-
 ## Integration with SEO Audit
 
 Used by `seo-audit-skill` for cross-engine verification: check GSC index status, check Bing index status, compare for engine-specific issues.
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

- Moves the "Integration with SEO Audit" section inside the `<!-- AI-CONTEXT-END -->` marker so agents see it in context (it was previously outside, making it invisible to context-windowed reads)
- Clarifies the `BASE` variable prose from `Base:` to `Set once per session:` to make it actionable
- Zero content loss — all code blocks, URLs, and operational knowledge preserved

## Verification

- `wc -l` unchanged (96 lines)
- All curl examples, error table, and URLs present before and after
- SEO audit integration note now within AI-CONTEXT markers

Closes #14998

---
[aidevops.sh](https://aidevops.sh) v3.5.606 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,489 tokens on this as a headless worker.