### PR TITLE
GH#14906: tighten kv.md Quick Start section (52→49 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/kv.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/kv.md
@@ -24,12 +24,9 @@ wrangler kv namespace create MY_NAMESPACE
 ```
 
 ```typescript
-// Write
-await env.MY_KV.put("key", "value", { expirationTtl: 300 });
-
-// Read
-const value = await env.MY_KV.get("key");
-const json = await env.MY_KV.get<Config>("config", "json");
+await env.MY_KV.put("key", "value", { expirationTtl: 300 }); // Write
+const value = await env.MY_KV.get("key");                     // Read string
+const json = await env.MY_KV.get<Config>("config", "json");   // Read typed JSON
 ```
 
 ## Core API


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/kv.md` from 52 to 49 lines, clearing the 50-line simplification scanner threshold.

**Classification:** Reference corpus (slim index). Chapter files `kv-patterns.md` and `kv-gotchas.md` already exist and are comprehensive. No content splitting needed.

**Change:** Merged the Quick Start TypeScript code block — removed redundant blank-line separator and standalone comment lines (`// Write`, `// Read`), replaced with inline comments on each statement. All code, URLs, and API table entries preserved.

**Verification:**
- All code blocks present before and after ✓
- All "Read Next" links intact ✓
- No task IDs or GH# refs in this file (none to preserve) ✓
- Line count: 52 → 49 (below 50-line threshold) ✓

## Runtime Testing

Risk: **Low** — agent doc tightening only. No logic, scripts, or executable code changed. Self-assessed.

Closes #14906

---

---
[aidevops.sh](https://aidevops.sh) v3.5.606 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6