### PR TITLE
GH#14261: tighten agent doc Keyword Mapper (.agents/seo/keyword-mapper.md, 97→79 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3087,9 +3087,9 @@
       "pr": 13958
     },
     "TODO.md": {
-      "hash": "b98d88c3e22cc11e57f0bad0024cbd0ec50c494c",
-      "at": "2026-03-30T06:49:22Z",
-      "pr": 18
+      "hash": "9e296aaac5ac00cb7ad14c8de7e5c6b1930b1184",
+      "at": "2026-04-02T04:56:51Z",
+      "pr": 15490
     },
     ".agents/content/heygen-skill/rules-webhooks.md": {
       "hash": "c3ba360303dc273741e6f76b2f235b8319f78734",
@@ -3162,9 +3162,9 @@
       "pr": 15253
     },
     ".agents/scripts/commands/list-verify.md": {
-      "hash": "70b9ea13391fe10fb6a74157f8c68e1c4e784d47b9744d217fc3507d744006c9",
-      "at": "2026-04-01T19:51:55Z",
-      "pr": 15247
+      "hash": "dc43be77f9d72dac6880004350a5b63ce9a326f0",
+      "at": "2026-04-02T04:56:43Z",
+      "pr": 15514
     },
     ".agents/scripts/commands/budget-analysis.md": {
       "hash": "ac77aaf850ecc1f9cee81c9e04a026a954fc7359",
@@ -3477,14 +3477,14 @@
       "pr": 15301
     },
     "aidevops.sh": {
-      "hash": "133623e34d3b54551ae0049f820addfc6bcbbcd1",
-      "at": "2026-04-02T03:11:18Z",
-      "pr": 15277
+      "hash": "612281685856997848a5bf3f023e563a1bb8780c",
+      "at": "2026-04-02T04:56:57Z",
+      "pr": 15470
     },
     "setup.sh": {
-      "hash": "3302da9803a49a23c7e2276e138871a41d8affa1",
-      "at": "2026-04-02T03:11:18Z",
-      "pr": 15277
+      "hash": "6d9dba530ed27ddfbe02cbc469483903f9a706b4",
+      "at": "2026-04-02T04:56:57Z",
+      "pr": 15470
     },
     ".agents/seo/backlink-checker.md": {
       "hash": "aa5038f9569e0d64e563b31a0e2243bd9c2b959c",
@@ -3515,6 +3515,86 @@
       "hash": "d8d6dee50a191d538e032247f78abb02ebb504a8",
       "at": "2026-04-02T03:11:11Z",
       "pr": 15477
+    },
+    ".agents/scripts/commands/recall.md": {
+      "hash": "9b0b04b0aeda1a0436139a205db96efcf0e662ad",
+      "at": "2026-04-02T04:56:44Z",
+      "pr": 15515
+    },
+    ".agents/content/production-video-08-talking-head-pipeline.md": {
+      "hash": "cee1bc46bfdf4612fb0560748fe9e7b134ac0086",
+      "at": "2026-04-02T04:56:45Z",
+      "pr": 15516
+    },
+    ".agents/workflows/branch/bugfix.md": {
+      "hash": "236b78c40f92a6c1b7c36085c0ecdf1ea42058be",
+      "at": "2026-04-02T04:56:46Z",
+      "pr": 15517
+    },
+    ".agents/seo/content-analyzer.md": {
+      "hash": "7972fdccf29515026f0f710dac5f8e1b792e77c5",
+      "at": "2026-04-02T04:56:49Z",
+      "pr": 15478
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/hyperdrive.md": {
+      "hash": "1a63158e184bf8c3c6ac2f4b5110e44451c5d837",
+      "at": "2026-04-02T04:56:50Z",
+      "pr": 15481
+    },
+    ".agents/tools/video/remotion-import-srt-captions.md": {
+      "hash": "75f8b0d089b9eaae8a7e08498af9b8c5f1ac4655",
+      "at": "2026-04-02T04:56:51Z",
+      "pr": 15490
+    },
+    "todo/tasks/t15472-brief.md": {
+      "hash": "3de8a77d3743c3530c563e9aff8775c22a7edb4b",
+      "at": "2026-04-02T04:56:51Z",
+      "pr": 15490
+    },
+    ".agents/scripts/commands/security-history.md": {
+      "hash": "0c74f125bbb3e299040015ee24fb345e43486ec7",
+      "at": "2026-04-02T04:56:52Z",
+      "pr": 15487
+    },
+    ".agents/tools/video/remotion-lottie.md": {
+      "hash": "72d843e6717a28f61294372a6752cb8e9736fe6b",
+      "at": "2026-04-02T04:56:53Z",
+      "pr": 15525
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md": {
+      "hash": "d662c65c03864c29b198db3a89950538a7949ef2",
+      "at": "2026-04-02T04:56:54Z",
+      "pr": 15526
+    },
+    ".agents/tools/credentials/bitwarden.md": {
+      "hash": "808ffa447534e25dd4090033275c4861a8612f2c",
+      "at": "2026-04-02T04:56:56Z",
+      "pr": 15468
+    },
+    "todo/tasks/t15450-brief.md": {
+      "hash": "c0ba871cfce440d57c630e49cd6ba939bf27b261",
+      "at": "2026-04-02T04:56:56Z",
+      "pr": 15468
+    },
+    "todo/tasks/t2052-brief.md": {
+      "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
+      "at": "2026-04-02T04:56:57Z",
+      "pr": 15470
+    },
+    ".agents/tools/browser/crawl4ai-integration.md": {
+      "hash": "5b8849f598a7c31bff13579aedda9586682f6ad7",
+      "at": "2026-04-02T04:56:58Z",
+      "pr": 15463
+    },
+    "todo/tasks/t15448-brief.md": {
+      "hash": "b43fa2d5b0515af1ecbebbc502099ca5e6d0a9c2",
+      "at": "2026-04-02T04:56:58Z",
+      "pr": 15463
+    },
+    ".agents/scripts/platform-detect.sh": {
+      "hash": "a551a07e07c08853c909e7b8141ddddf2de43420",
+      "at": "2026-04-02T04:56:59Z",
+      "pr": 15455
     }
   }
 }

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,3600 +1,3605 @@
 {
-  "_comment": null,
-  "files": {
-    ".agents/scripts/commands/worktree-cleanup.md": {
-      "hash": "f333ce7dce4127c4c2150a07b4c1f50c",
-      "at": "2026-04-02T02:30:00Z",
-      "pr": null
-    },
-    ".agents/content/seo-writer.md": {
-      "hash": "b26db2ddd38996e2ad605d9c79db94f8",
-      "at": "2026-04-01T22:10:00Z",
-      "pr": 15339
-    },
-    ".agents/marketing-sales/cro-chapter-25.md": {
-      "hash": "b74f0ff498c385d2647512d5f68dc6261a0063e3",
-      "at": "2026-04-01T21:00:00Z",
-      "pr": 15276
-    },
-    ".agents/marketing-sales/cro-chapter-22.md": {
-      "hash": "882c97fc64eb63b11312049223c04eaa52882296",
-      "at": "2026-04-01T20:58:50Z",
-      "pr": 15257
-    },
-    ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
-      "hash": "8d79ff6b9aa02ab04c5f72924b3a7798ee561893",
-      "at": "2026-04-01T12:00:00Z",
-      "pr": 15176
-    },
-    ".agents/aidevops/agent-sources.md": {
-      "hash": "86113ed3f6cb39ad363af10d420942cff1af592c",
-      "at": "2026-03-31T05:32:40Z",
-      "pr": 14645
-    },
-    ".agents/seo/analytics-tracking.md": {
-      "hash": "07ff0feec55ad3f8477a6badd724b479c1b09370",
-      "at": "2026-03-27T21:25:04Z",
-      "pr": 11015
-    },
-    ".agents/tools/credentials/gopass.md": {
-      "hash": "a59a0077d4d56694894c8cadef6b9c3a294dede0",
-      "at": "2026-03-27T21:25:05Z",
-      "pr": 11021
-    },
-    ".agents/tools/credentials/psst.md": {
-      "hash": "cbb2379680b3ce35dc2b7ba4e2be3efe46c509c6",
-      "at": "2026-03-31T06:15:51Z",
-      "pr": 14687
-    },
-    ".agents/marketing-sales/meta-ads-creative-hooks.md": {
-      "hash": "f7c8e3356361a9ab1941f729337bbf7d0f8447ef",
-      "at": "2026-03-27T21:25:06Z",
-      "pr": 11016
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2024.md": {
-      "hash": "5ff178dfe9603a724792aaef45d63f4b33fce7ef",
-      "at": "2026-03-27T21:25:08Z",
-      "pr": 11002
-    },
-    ".agents/aidevops/providers.md": {
-      "hash": "18b8c2ddd2bb1ee1b0affc02c05ae860b8e902da",
-      "at": "2026-03-27T21:25:09Z",
-      "pr": 11003
-    },
-    ".agents/aidevops/services.md": {
-      "hash": "0fd05379ebb6a6ab079aaa0011c1dd8a5cca6af1",
-      "at": "2026-03-27T21:25:10Z",
-      "pr": 11004
-    },
-    ".agents/seo/semrush.md": {
-      "hash": "cc61832322267a222c9e557b04459de4a3520086",
-      "at": "2026-03-27T21:25:11Z",
-      "pr": 11006
-    },
-    ".agents/marketing-sales/cro-chapter-10.md": {
-      "hash": "730bf8258084ccd7a330cc2ac1032f1aedd4a370",
-      "at": "2026-03-27T21:25:12Z",
-      "pr": 11005
-    },
-    ".agents/scripts/commands/log-issue-aidevops.md": {
-      "hash": "24878e7d7abca4cf0b41a18e5dac1977978ec3c1",
-      "at": "2026-03-27T21:25:13Z",
-      "pr": 11007
-    },
-    ".agents/services/communications/xmtp.md": {
-      "hash": "0b5b1bb178865dc7efff9f7578cd26dd9bf82bc9",
-      "at": "2026-03-27T21:25:14Z",
-      "pr": 11009
-    },
-    ".agents/tools/credentials/multi-tenant.md": {
-      "hash": "efa55dc5b3f2f5222982c1c9f0214ad1e2601624",
-      "at": "2026-03-27T21:25:16Z",
-      "pr": 11008
-    },
-    ".agents/reference/high-stakes-operations.md": {
-      "hash": "ba39668c924d2e2d0137c766053513a98a2f2839",
-      "at": "2026-03-27T21:25:17Z",
-      "pr": 11012
-    },
-    ".agents/tools/architecture/feature-slicing-skill.md": {
-      "hash": "7a86b72e717f9805c458d44fa69e00b9b845addd",
-      "at": "2026-03-27T21:25:18Z",
-      "pr": 11010
-    },
-    ".agents/tools/automation/macos-automator.md": {
-      "hash": "f8771a0d1548af0fbdd76f1944d50ce6b1107f13",
-      "at": "2026-03-27T21:25:19Z",
-      "pr": 11011
-    },
-    ".agents/seo/data-export.md": {
-      "hash": "196b3c4788803c0b2b8d412752d3d262d7e6f8b2",
-      "at": "2026-03-27T21:25:21Z",
-      "pr": 11019
-    },
-    ".agents/tools/ai-generation/comfy-cli.md": {
-      "hash": "6d885b8f28374a6d71d6f4095a6015f3359a668e",
-      "at": "2026-03-27T21:25:22Z",
-      "pr": 11014
-    },
-    ".agents/tools/architecture/feature-slicing-skill/cheatsheet.md": {
-      "hash": "b244fb8417fc27f0de33c83c86092f5bebd736f3",
-      "at": "2026-03-27T21:25:23Z",
-      "pr": 11018
-    },
-    ".agents/tools/browser/anti-detect-browser.md": {
-      "hash": "647081565083b90f27fdce7d25dea9e153fc64a4",
-      "at": "2026-03-27T21:25:25Z",
-      "pr": 11017
-    },
-    ".agents/tools/code-review/snyk.md": {
-      "hash": "e248df7d21db7a21cef8b1e16e1e96f361e3e487",
-      "at": "2026-03-27T21:25:26Z",
-      "pr": 11013
-    },
-    ".agents/tools/ai-orchestration/crewai.md": {
-      "hash": "e1ed08282945b0708a6840e1d2bb38d92c3d3698",
-      "at": "2026-03-28T02:50:59Z",
-      "pr": 11274
-    },
-    ".agents/tools/build-mcp/api-wrapper.md": {
-      "hash": "68b6075506f6dc1153fec6d5aa78c05d213b0b73",
-      "at": "2026-03-28T02:51:01Z",
-      "pr": 11276
-    },
-    ".agents/tools/build-mcp/api-wrapper/patterns.md": {
-      "hash": "5aa65e858b380b38b44e647545eda3f1450543b2",
-      "at": "2026-03-28T02:51:01Z",
-      "pr": 11276
-    },
-    ".agents/tools/build-mcp/aidevops-plugin.md": {
-      "hash": "c2af34ac248062f83be58abf2e85fabd6e424710",
-      "at": "2026-03-31T09:13:36Z",
-      "pr": 14775
-    },
-    ".agents/aidevops/add-new-mcp-to-aidevops.md": {
-      "hash": "818de6a118b3981cbc732aace97a1220ad7f27ee",
-      "at": "2026-03-28T16:41:22Z",
-      "pr": 12006
-    },
-    ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
-      "hash": "a80eb99acba160fa0f034a4989c0b886f37a32a0",
-      "at": "2026-03-28T08:17:37Z",
-      "pr": 11571
-    },
-    ".agents/reference/configuration.md": {
-      "hash": "9502faea512b841b7a239e9e3c9cc0188f4fe855",
-      "at": "2026-03-28T04:30:48Z",
-      "pr": 11321
-    },
-    ".agents/scripts/stats-functions.sh": {
-      "hash": "500235eb7c29b89a44219c93701d3960837d9dca",
-      "at": "2026-03-28T02:51:08Z",
-      "pr": 11273
-    },
-    ".agents/workflows/plans.md": {
-      "hash": "d07529f81bc8ce92541f51393632bb2d04ce8fd4",
-      "at": "2026-03-28T21:58:58Z",
-      "pr": 12235
-    },
-    ".agents/marketing-sales/meta-ads-creative-scripts.md": {
-      "hash": "9455fbf07187de24552aa591a8752fd7b3df2480",
-      "at": "2026-03-28T03:10:39Z",
-      "pr": 11297
-    },
-    ".agents/content/social-bird.md": {
-      "hash": "b2840ebff41ba9b78f7331487d6596373e8436e4",
-      "at": "2026-03-28T05:10:07Z",
-      "pr": 11354
-    },
-    ".agents/tools/programming/modern-javascript-skill/composition.md": {
-      "hash": "fe9da3d05db78aac6b072235efe8b74f5c9fcf2b",
-      "at": "2026-03-28T03:53:07Z",
-      "pr": 11328
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2022-es2023.md": {
-      "hash": "5e5dfb7e18557b8e26c5c48c090c8df94eda485c",
-      "at": "2026-03-28T03:53:13Z",
-      "pr": 11337
-    },
-    ".agents/workflows/milestone-validation.md": {
-      "hash": "3e8c88a4d98e24993198b7a6cfc0c93b7825bd26",
-      "at": "2026-03-28T03:53:42Z",
-      "pr": 11286
-    },
-    ".agents/services/communications/discord.md": {
-      "hash": "44cce31bf11bd980e6b95270c913477c86348a15",
-      "at": "2026-03-28T03:53:47Z",
-      "pr": 11287
-    },
-    ".agents/tools/browser/pagespeed.md": {
-      "hash": "55b132de0f4ff15dd72cec557bf042cd56b93fec",
-      "at": "2026-03-28T03:53:49Z",
-      "pr": 11295
-    },
-    ".agents/tools/ai-orchestration/packaging.md": {
-      "hash": "4cbea04181622677bff0bdbb611cdd03a3401484",
-      "at": "2026-03-28T03:53:52Z",
-      "pr": 11296
-    },
-    ".agents/aidevops/mcp-integrations.md": {
-      "hash": "8c6204355b9b3ccc09bb3761ac1804e94bf76db2",
-      "at": "2026-03-28T03:53:54Z",
-      "pr": 11339
-    },
-    ".agents/aidevops/mcp-troubleshooting.md": {
-      "hash": "53599e9a3e7d9799a065eb9bc1fe9df2e7dbd1d7",
-      "at": "2026-03-31T08:03:51Z",
-      "pr": 14740
-    },
-    ".agents/tools/ai-assistants/opencode-server.md": {
-      "hash": "15e90e96d742cfe07ffd4cb37c340157d5a8bb74",
-      "at": "2026-03-28T03:53:56Z",
-      "pr": 11345
-    },
-    ".agents/tools/context/mcp-discovery.md": {
-      "hash": "b5851d90484fe52e39f87e3c7af8692778986208",
-      "at": "2026-03-28T03:53:59Z",
-      "pr": 11338
-    },
-    ".agents/tools/deployment/cloudron-app-packaging.md": {
-      "hash": "a6ddd4af870f4445d96eb4bf3c2d109fcb9219b7",
-      "at": "2026-03-28T03:54:01Z",
-      "pr": 11344
-    },
-    ".agents/tools/security/ip-reputation.md": {
-      "hash": "a1da2aa2f5e2f454f3c1dbcd3a7a819a72cd80dd",
-      "at": "2026-03-28T03:54:03Z",
-      "pr": 11342
-    },
-    ".agents/tools/ui/frontend-debugging.md": {
-      "hash": "272d16549c353500a19666d7ace227b34b2ae363",
-      "at": "2026-03-28T03:54:06Z",
-      "pr": 11340
-    },
-    ".agents/workflows/preflight.md": {
-      "hash": "c4695943d5555314205b87bb88020fb62de14b63",
-      "at": "2026-03-28T03:54:08Z",
-      "pr": 11341
-    },
-    ".agents/aidevops/recommendations.md": {
-      "hash": "67c3f660425b669feae3238d7b42589449caa860",
-      "at": "2026-03-28T03:54:11Z",
-      "pr": 11343
-    },
-    ".agents/services/communications/msteams.md": {
-      "hash": "9818d1daccf3f68d103ecba204aa56431dba6514",
-      "at": "2026-03-28T03:54:15Z",
-      "pr": 11346
-    },
-    ".agents/tools/browser/peekaboo.md": {
-      "hash": "294d232e9625b8a855f17cbea4498a4881a6b0bc",
-      "at": "2026-03-28T03:54:17Z",
-      "pr": 11348
-    },
-    ".agents/tools/database/vector-search.md": {
-      "hash": "d365046c212da54c3ab0ede8217cce083de484c5",
-      "at": "2026-03-28T03:54:19Z",
-      "pr": 11351
-    },
-    ".agents/seo/neuronwriter.md": {
-      "hash": "e6d78a192db4a98186ff9a1f428a07d6455ba42a",
-      "at": "2026-03-28T03:54:21Z",
-      "pr": 11350
-    },
-    ".agents/tools/wordpress/wp-preferred.md": {
-      "hash": "6664b61850bd5f84a8044f5dea501f4534b9a9d8",
-      "at": "2026-03-28T03:54:25Z",
-      "pr": 11353
-    },
-    ".agents/tools/git/opencode-github.md": {
-      "hash": "02c6d675ca2b756817bc639ec03d999e1f3ea58e",
-      "at": "2026-03-28T03:54:27Z",
-      "pr": 11349
-    },
-    ".agents/services/hosting/webhosting.md": {
-      "hash": "fb3877648d049a414407d7f9e6beb747c2f92f1d",
-      "at": "2026-03-28T03:54:32Z",
-      "pr": 11352
-    },
-    ".agents/services/communications/nextcloud-talk.md": {
-      "hash": "830399729c8d83ca4263bbf736ea549534989f63",
-      "at": "2026-03-28T03:54:35Z",
-      "pr": 11360
-    },
-    ".agents/services/outreach/smartlead.md": {
-      "hash": "8171133da8154e590bca4a6baa8a1bbe05051e05",
-      "at": "2026-03-28T03:54:38Z",
-      "pr": 11357
-    },
-    ".agents/marketing-sales/cro-chapter-16.md": {
-      "hash": "920245116e79b04207fd2b808c5dcbfabea3eb17",
-      "at": "2026-03-28T04:30:24Z",
-      "pr": 11374
-    },
-    ".agents/marketing-sales/meta-ads-campaigns-decision-trees.md": {
-      "hash": "a7bcedab8040e2b400b7c2feca987e09bb0a8477",
-      "at": "2026-03-28T04:30:25Z",
-      "pr": 11381
-    },
-    ".agents/tools/database/vector-search/per-tenant-rag.md": {
-      "hash": "9c0a46c72bbf38115155d5214f0256365a03260b",
-      "at": "2026-03-28T06:40:00Z",
-      "pr": 11417
-    },
-    ".agents/tools/architecture/feature-slicing-skill/nextjs.md": {
-      "hash": "0fd2c402556f4d6804ce1a61eeaaaa9c3cecd541",
-      "at": "2026-03-28T06:59:34Z",
-      "pr": 11437
-    },
-    ".agents/marketing-sales/meta-ads-creative-formats.md": {
-      "hash": "f8a4f095bebc852b9ce58976d3b53e418bbe578e",
-      "at": "2026-03-28T06:39:54Z",
-      "pr": 11410
-    },
-    ".agents/marketing-sales/ad-creative-chapter-06.md": {
-      "hash": "3d34a8e028e8905a54af8dd939394d10bdf16d97",
-      "at": "2026-03-28T05:09:55Z",
-      "pr": 11414
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-ads.md": {
-      "hash": "8e2f8f2a6620debfe219e09c96cfeb634fb518a7",
-      "at": "2026-03-28T05:50:32Z",
-      "pr": 11411
-    },
-    ".agents/tools/voice/transcription.md": {
-      "hash": "8edf7782bc2f37c48ade8d3b58fd5c611dc8bda5",
-      "at": "2026-03-29T07:02:26Z",
-      "pr": 12638
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/sequence.md": {
-      "hash": "162ba5164f7ffedc3b1d3497beabd56c6d58aaba",
-      "at": "2026-03-28T05:10:17Z",
-      "pr": 11392
-    },
-    ".agents/tools/architecture/clean-ddd-hexagonal-skill/cheatsheet.md": {
-      "hash": "7622759c028bec7b85f445a88ab175f13b055133",
-      "at": "2026-03-28T05:10:19Z",
-      "pr": 11393
-    },
-    ".agents/marketing-sales/ad-creative-chapter-10.md": {
-      "hash": "23e33ef44632a4467884d5d9bebf6452adf22160",
-      "at": "2026-03-28T05:10:32Z",
-      "pr": 11315
-    },
-    ".agents/marketing-sales/ad-creative-offers-landing.md": {
-      "hash": "a16b4767e518eb9f3f35e1b61d3d166390077009",
-      "at": "2026-03-28T05:50:34Z",
-      "pr": 11415
-    },
-    ".agents/services/database/postgres-drizzle-skill/queries.md": {
-      "hash": "2647d7cd620f871bdbc5ca89466f013792b777fd",
-      "at": "2026-03-28T06:40:05Z",
-      "pr": 11416
-    },
-    ".agents/tools/accessibility/accessibility-audit.md": {
-      "hash": "50607e3251694a312978efe741fd95eb6e47de55",
-      "at": "2026-03-28T08:18:26Z",
-      "pr": 11634
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/ai-gateway.md": {
-      "hash": "720c2836fca088d027ac637f8c69e97cb3c2764a",
-      "at": "2026-03-28T05:50:52Z",
-      "pr": 11443
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md": {
-      "hash": "819096c73ef171c0e0e58c2929c5d11f72401931",
-      "at": "2026-03-31T05:38:15Z",
-      "pr": 14658
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
-      "hash": "b59a17a028d181e2f55c45e58c371ca999d9a2ee",
-      "at": "2026-03-28T05:50:55Z",
-      "pr": 11439
-    },
-    ".agents/services/database/postgres-drizzle-skill/postgres.md": {
-      "hash": "2633ce6d2343b370a13a3efea1ed735544a6883a",
-      "at": "2026-03-28T05:50:57Z",
-      "pr": 11448
-    },
-    ".agents/marketing-sales/direct-response-copy-frameworks-offer-construction.md": {
-      "hash": "10d31ffa27d8e38267882e04f099ce38899635f1",
-      "at": "2026-03-28T05:51:09Z",
-      "pr": 11363
-    },
-    ".agents/marketing-sales/meta-ads-audiences-first-party-data.md": {
-      "hash": "1ad15971973eec338e831dc24839609eb1f473e3",
-      "at": "2026-03-28T08:18:20Z",
-      "pr": 11536
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-ad-copy.md": {
-      "hash": "bfc16d8c1bc4e6a8229cc555eba0d72de8ece0d7",
-      "at": "2026-03-28T08:17:45Z",
-      "pr": 11593
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-vsl-script.md": {
-      "hash": "c8fa5d2f257f52a1d7c9c49ca9d78e6be247623e",
-      "at": "2026-03-28T08:17:46Z",
-      "pr": 11591
-    },
-    ".agents/marketing-sales/cro-chapter-09.md": {
-      "hash": "4d45e94ded75b90ef7e30518e072a5a643167370",
-      "at": "2026-03-28T08:17:36Z",
-      "pr": 11561
-    },
-    ".agents/reference/memory.md": {
-      "hash": "0a7c4c493f3a825b98e2de3928f718fa9095c966",
-      "at": "2026-03-28T07:37:36Z",
-      "pr": 11538
-    },
-    ".agents/marketing-sales/ad-creative-chapter-02.md": {
-      "hash": "810c244d317a3332c74dc2baafb34bf00cf5ab2f",
-      "at": "2026-03-28T07:37:37Z",
-      "pr": 11539
-    },
-    ".agents/tools/ai-assistants/headless-dispatch.md": {
-      "hash": "00414f5554e8388ffa17859ef02d718061cd911a",
-      "at": "2026-03-29T03:15:46Z",
-      "pr": 12352
-    },
-    ".agents/tools/document/document-creation.md": {
-      "hash": "245a303a923bd18c0adc820adb9620f12d636d2b",
-      "at": "2026-03-28T08:17:34Z",
-      "pr": 11592
-    },
-    ".agents/tools/design/ui-ux-inspiration.md": {
-      "hash": "fb4a8985ec3089753355c7a13d0665c878034369",
-      "at": "2026-03-28T08:17:35Z",
-      "pr": 11590
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-email-sequences.md": {
-      "hash": "5af4b4e800d180cb185bfa6d14ee93f2fc2661e9",
-      "at": "2026-03-28T13:37:24Z",
-      "pr": 11886
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-readme.md": {
-      "hash": "2717d1e9cb1edfd85d932502b6de7c4765c8a7ec",
-      "at": "2026-03-28T08:17:38Z",
-      "pr": 11571
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/tail-workers.md": {
-      "hash": "d909ab39413052950bcfff2d355bb102d17f8421",
-      "at": "2026-03-28T08:17:39Z",
-      "pr": 11562
-    },
-    ".agents/marketing-sales/meta-ads-optimization-scaling.md": {
-      "hash": "8034babf9a34b6f09f0cce7817a136ee38be0c1f",
-      "at": "2026-03-28T08:17:40Z",
-      "pr": 11564
-    },
-    ".agents/marketing-sales/meta-ads-optimization-troubleshooting.md": {
-      "hash": "684991a0c73063d140b0cfee3ad73691a479a34f",
-      "at": "2026-03-28T08:17:40Z",
-      "pr": 11564
-    },
-    ".agents/tools/database/vector-search/zvec.md": {
-      "hash": "1929000365507621f52d563ad2b63e9f51feab8d",
-      "at": "2026-03-28T08:17:41Z",
-      "pr": 11570
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/class-er.md": {
-      "hash": "e3929bc050f03d955e21543cfed73a4b69880579",
-      "at": "2026-03-28T08:17:42Z",
-      "pr": 11589
-    },
-    ".agents/tools/wordpress/wp-admin.md": {
-      "hash": "a02a72943cc4820447f81c73216b0f095c3f64e5",
-      "at": "2026-03-28T08:17:43Z",
-      "pr": 11587
-    },
-    ".agents/tools/wordpress/wp-cli-reference.md": {
-      "hash": "0425ba4c94fd45b032e849987736bc4073970a7e",
-      "at": "2026-03-28T08:17:43Z",
-      "pr": 11587
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-01-facebook-instagram.md": {
-      "hash": "4bfed86699b1e5a25050b85f099ca3fc580574d8",
-      "at": "2026-03-28T08:17:45Z",
-      "pr": 11593
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-02-google-search.md": {
-      "hash": "f9ecc39136c90a2feb8bc9075f3e95ba23fccddd",
-      "at": "2026-03-28T08:17:45Z",
-      "pr": 11593
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-03-linkedin.md": {
-      "hash": "a3c8015dc17258f154c7bdd4e4ccf0d4586a06db",
-      "at": "2026-03-28T08:17:45Z",
-      "pr": 11593
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-04-twitter.md": {
-      "hash": "615623c2156bb8eee3a9409900b33a895768e08d",
-      "at": "2026-03-28T08:17:45Z",
-      "pr": 11593
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-05-reference.md": {
-      "hash": "d34fe0576cb0cb1c1770a278ad5e149bba1480d0",
-      "at": "2026-03-28T08:17:45Z",
-      "pr": 11593
-    },
-    ".agents/tools/conversion/pandoc.md": {
-      "hash": "557667b032774727658d22f6b1c5392ec4a83660",
-      "at": "2026-03-28T08:17:47Z",
-      "pr": 11595
-    },
-    ".agents/content/research.md": {
-      "hash": "0844a394bf378618e923c821a3246e54fead511f",
-      "at": "2026-03-28T08:57:54Z",
-      "pr": 11644
-    },
-    ".agents/tools/performance/webpagetest.md": {
-      "hash": "e0b3e8da23436e916aecd40d37bceeea48f99642",
-      "at": "2026-03-28T08:17:50Z",
-      "pr": 11594
-    },
-    ".agents/tools/browser/crawl4ai.md": {
-      "hash": "967373980ca56ec85cb795eb9426efb91ff23ddb",
-      "at": "2026-03-28T08:17:51Z",
-      "pr": 11599
-    },
-    ".agents/content/heygen-skill/rules-dimensions.md": {
-      "hash": "f32c728a54e3edca1d713da0d536cb4b63299882",
-      "at": "2026-03-28T08:18:14Z",
-      "pr": 11610
-    },
-    ".agents/services/email/google-workspace.md": {
-      "hash": "d25ed82148411a5ce44101400e445cb3293c4e96",
-      "at": "2026-03-28T08:58:52Z",
-      "pr": 11613
-    },
-    ".agents/tools/architecture/feature-slicing-skill/layers.md": {
-      "hash": "aa5a10592a8a28db7e01ce256df9e7aa7ab57c76",
-      "at": "2026-03-28T08:18:16Z",
-      "pr": 11537
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md": {
-      "hash": "10d5c38ac748a992e4619c4042a5ac685b009b3f",
-      "at": "2026-03-28T08:18:21Z",
-      "pr": 11631
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md": {
-      "hash": "aa4bc86ba1d820a999ff48479bc7af02bc524485",
-      "at": "2026-03-28T08:18:21Z",
-      "pr": 11631
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/vectorize.md": {
-      "hash": "c1d8339d4d9148d438f87b89220e85fa82e4c859",
-      "at": "2026-03-28T08:18:21Z",
-      "pr": 11631
-    },
-    ".agents/tools/voice/cloud-tts-apis.md": {
-      "hash": "0a7ff7444bf603ab6328a2248b32bd9faf422b02",
-      "at": "2026-03-28T08:18:23Z",
-      "pr": 11637
-    },
-    ".agents/tools/voice/local-tts-models.md": {
-      "hash": "a2985fa793b132d716e99ec9f9dd6eaf8252485a",
-      "at": "2026-03-28T08:18:24Z",
-      "pr": 11637
-    },
-    ".agents/tools/voice/voice-models.md": {
-      "hash": "1048bd3b6ac334dea9f2685aef4b09642f318673",
-      "at": "2026-03-28T08:18:24Z",
-      "pr": 11637
-    },
-    ".agents/services/hosting/101domains.md": {
-      "hash": "504d151b93c6073272de3fca00e08e6118720cf9",
-      "at": "2026-03-28T08:18:27Z",
-      "pr": 11633
-    },
-    ".agents/marketing-sales/ad-creative-chapter-05.md": {
-      "hash": "f8ded271e66b8024f24caa8a841ea58da90a709a",
-      "at": "2026-03-28T08:18:28Z",
-      "pr": 11555
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workers-vpc.md": {
-      "hash": "fd8d3ba366abc324f0738e2e11fce322d92c654b",
-      "at": "2026-03-28T08:57:49Z",
-      "pr": 11677
-    },
-    ".agents/marketing-sales/ad-creative-chapter-03.md": {
-      "hash": "f2d79f61b3c28c3e902760bb469c29a465a777c3",
-      "at": "2026-03-28T15:30:26Z",
-      "pr": 11936
-    },
-    ".agents/services/communications/convos-bridge-template.sh": {
-      "hash": "cd850bc9a35a947206c1a4cf2e67313bb90f9644",
-      "at": "2026-03-28T08:57:52Z",
-      "pr": 11688
-    },
-    ".agents/services/communications/convos.md": {
-      "hash": "74e396568b01688f29f86d799f049f5b624b9205",
-      "at": "2026-03-28T08:57:52Z",
-      "pr": 11688
-    },
-    ".agents/tools/voice/cloud-voice-agents.md": {
-      "hash": "b389dcd17c677b3e21bc86397670fbf4d8a61b98",
-      "at": "2026-03-28T16:40:25Z",
-      "pr": 12005
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md": {
-      "hash": "816a5f35e7ca6b338deae7db62c3058d317b96d6",
-      "at": "2026-03-28T08:57:56Z",
-      "pr": 11647
-    },
-    ".agents/content/video-runway.md": {
-      "hash": "54c5b2fe2d3cdd00e23f192d5f869c927b6e573e",
-      "at": "2026-03-28T08:58:00Z",
-      "pr": 11646
-    },
-    ".agents/marketing-sales/ad-creative-testing-optimization.md": {
-      "hash": "2f60c87e51dac14c539d02ba1a796a98b995c2c4",
-      "at": "2026-03-28T08:58:01Z",
-      "pr": 11614
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/data-charts.md": {
-      "hash": "ea8a64811a9c35a4274183f1c0c215be8c2a6aec",
-      "at": "2026-03-28T08:58:03Z",
-      "pr": 11602
-    },
-    ".agents/content.md": {
-      "hash": "2f71b51f39307e001e3af0bae81c5fc440c2da9b",
-      "at": "2026-03-28T08:58:04Z",
-      "pr": 11616
-    },
-    ".agents/marketing-sales/ad-creative-psychology-targeting.md": {
-      "hash": "c37b3f2fadeaae4f147248efd4fa535e89f1d96b",
-      "at": "2026-03-28T10:27:52Z",
-      "pr": 11655
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-example.md": {
-      "hash": "219b3f24929e0866af7e05c36250a267a5f2e952",
-      "at": "2026-03-28T08:58:28Z",
-      "pr": 11597
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-pastor-framework.md": {
-      "hash": "229aaf2fa58645152ccdd4ece9d723068b251f4a",
-      "at": "2026-03-28T08:58:28Z",
-      "pr": 11597
-    },
-    ".agents/tools/credentials/sops.md": {
-      "hash": "927fea51df6b5ed15ee41b1473f26bf7b526ca38",
-      "at": "2026-03-28T08:58:29Z",
-      "pr": 11560
-    },
-    ".agents/tools/api/better-auth.md": {
-      "hash": "8494627274fa59f222b8c19aeb61280ded29e8ec",
-      "at": "2026-03-28T08:58:32Z",
-      "pr": 11566
-    },
-    ".agents/aidevops/extension.md": {
-      "hash": "6b76dd6fa41470a5d1d4e5ebeea7af1b13b6a1e8",
-      "at": "2026-03-28T08:58:33Z",
-      "pr": 11565
-    },
-    ".agents/tools/wordpress/localwp.md": {
-      "hash": "e2a3ea522c2f0a4739825f594f236c92f0eee0fa",
-      "at": "2026-03-28T08:58:34Z",
-      "pr": 11563
-    },
-    ".agents/marketing-sales/ad-creative-platform-meta.md": {
-      "hash": "130ac72c8435b342b5be159ed84ab6633efdf4fa",
-      "at": "2026-03-28T08:58:35Z",
-      "pr": 11574
-    },
-    ".agents/marketing-sales/direct-response-copy-frameworks-headline-formulas.md": {
-      "hash": "9c23835b93de53e0d6371a5f753c1409e0374d9d",
-      "at": "2026-03-28T08:58:42Z",
-      "pr": 11548
-    },
-    ".agents/tools/document/extraction-schemas.md": {
-      "hash": "fa0ee1f8e92a38842d98674241507fd0cde43a81",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/01-design-principles.md": {
-      "hash": "c557fde290bb52a65fa91d603c4366fdb0fcf3e7",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/02-purchase-invoice.md": {
-      "hash": "d9c194618044c58a6f3a364bba869683957b26c1",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/03-expense-receipt.md": {
-      "hash": "8c0553d204c9f8e111f7bb211d9b8e99a8fac453",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/04-credit-note.md": {
-      "hash": "c58830493ee6a0ae1b3f77c6fb18a20db5e87ed4",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/05-sales-invoice.md": {
-      "hash": "50c68e48c09eb85c30259361ceadadca01795e5e",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/06-generic-receipt.md": {
-      "hash": "8cd493fef922d42decca280eaaec76c32de7f324",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/07-quickfile-mapping.md": {
-      "hash": "329bb22bc68c98571c6bd075a6458573830bcd99",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/08-vat-handling.md": {
-      "hash": "74ea1c15f941a48b3cb8d0a62dc8fa3ec590dd86",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/09-nominal-codes.md": {
-      "hash": "7210b70a3f8072de3d50be138635dced20594d9d",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/10-classification.md": {
-      "hash": "8822a182e225ee7360107f5e1938e4fc844670e3",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/11-pipeline-integration.md": {
-      "hash": "377abccc10cb93b5f8b51010a48d6d947553b71c",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/12-validation.md": {
-      "hash": "85fb1862ed295cbba2a8c11ed8ccef35d25fc2c4",
-      "at": "2026-03-28T08:58:45Z",
-      "pr": 11601
-    },
-    ".agents/content/distribution-youtube-script-writer.md": {
-      "hash": "e7d74dc2884f946d2d3ad41287926a426d0b0edb",
-      "at": "2026-03-28T08:58:46Z",
-      "pr": 11603
-    },
-    ".agents/seo/site-crawler.md": {
-      "hash": "b57ba3a5214383ec97ea5c4838fabcd0ce900a20",
-      "at": "2026-03-28T08:58:48Z",
-      "pr": 11598
-    },
-    ".agents/services/communications/signal.md": {
-      "hash": "652f531e6f54f9fd38da5c5bd61889672eac4acf",
-      "at": "2026-03-28T08:58:53Z",
-      "pr": 11620
-    },
-    ".agents/tools/deployment/vercel.md": {
-      "hash": "c2084ec268e00720815607590f8bab4bc7082c53",
-      "at": "2026-03-28T08:58:54Z",
-      "pr": 11615
-    },
-    ".agents/workflows/postflight.md": {
-      "hash": "4e10936d7f2007c0c034ff2f2d8f8110bdf3d0dc",
-      "at": "2026-03-28T10:27:12Z",
-      "pr": 11739
-    },
-    ".agents/content/heygen-skill/rules-backgrounds.md": {
-      "hash": "7abf186ddedbabd5128f34ee918393a187de8cc3",
-      "at": "2026-03-28T09:17:34Z",
-      "pr": 11711
-    },
-    ".agents/services/communications/nostr.md": {
-      "hash": "eacafb8b13831574c6bc570c06903e15e7acd077",
-      "at": "2026-03-28T09:17:35Z",
-      "pr": 11715
-    },
-    ".agents/tools/deployment/uncloud.md": {
-      "hash": "f0efc54a4b03f1e5a1398d94d063d72218a8de21",
-      "at": "2026-03-28T09:17:40Z",
-      "pr": 11712
-    },
-    ".agents/marketing-sales/meta-ads-campaigns-retargeting.md": {
-      "hash": "76a66a236cc7fbeb40d74384e9dbe4bd75a4a155",
-      "at": "2026-03-28T11:52:21Z",
-      "pr": 11822
-    },
-    ".agents/content/heygen-skill/rules-remotion-integration.md": {
-      "hash": "5ccb546152546cd33344a76d42a4b90c0acd0dbd",
-      "at": "2026-03-28T10:27:14Z",
-      "pr": 11740
-    },
-    ".agents/services/payments/procurement.md": {
-      "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
-      "at": "2026-03-28T09:48:49Z",
-      "pr": 11713
-    },
-    ".agents/tools/build-agent/build-agent.md": {
-      "hash": "59fa5cde2d2c1b113be43ecdb1a6d8978d3d4f69",
-      "at": "2026-03-29T14:29:12Z",
-      "pr": 12957
-    },
-    ".agents/content/distribution-youtube-topic-research.md": {
-      "hash": "d8d475231eff5b53cf27de5ab31aeedaec403e2f",
-      "at": "2026-03-28T11:20:29Z",
-      "pr": 11801
-    },
-    ".agents/content/heygen-skill/rules-captions.md": {
-      "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
-      "at": "2026-03-28T09:48:53Z",
-      "pr": 11707
-    },
-    ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
-      "hash": "07b30b06de54ff4544c7f468a6c6ba2d25215784",
-      "at": "2026-03-28T10:27:24Z",
-      "pr": 11709
-    },
-    ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
-      "hash": "8eb705ea0ac51157ecf6c3c93a6f3898b754f1233f3257c3e5e33d65837d71c3",
-      "at": "2026-03-31T00:00:00Z",
-      "pr": 14577
-    },
-    ".agents/services/database/postgres-drizzle-skill/schema.md": {
-      "hash": "ed1952db54651cd46710ca9cfa4db950635e42a6",
-      "at": "2026-03-28T10:27:24Z",
-      "pr": 11709
-    },
-    ".agents/tools/ui/i18next.md": {
-      "hash": "ce750937b182da6a4a2cce512b141f16da789fcd",
-      "at": "2026-03-28T10:27:25Z",
-      "pr": 11710
-    },
-    ".agents/services/database/postgres-drizzle-skill/relations.md": {
-      "hash": "673a7c2abd65766f454b57e79a259a7217463210",
-      "at": "2026-03-28T09:48:57Z",
-      "pr": 11717
-    },
-    ".agents/tools/build-mcp/server-patterns.md": {
-      "hash": "c0e5bf0399f60ae53b3b09082ac6ced4debb8c76",
-      "at": "2026-03-28T10:27:33Z",
-      "pr": 11679
-    },
-    ".agents/tools/git/worktrunk.md": {
-      "hash": "bafc956a55ed67b84dfc0722955434b85dd6202e",
-      "at": "2026-03-28T10:27:11Z",
-      "pr": 11760
-    },
-    ".agents/content/distribution-youtube-pipeline.md": {
-      "hash": "ec344423c7366d10312a8ca44f60ca4232d34097",
-      "at": "2026-03-28T11:20:33Z",
-      "pr": 11763
-    },
-    ".agents/content/heygen-skill/rules-video-generation.md": {
-      "hash": "929341bdb16beeda9c31e050b53eddbe5badfd72",
-      "at": "2026-03-28T10:27:38Z",
-      "pr": 11675
-    },
-    ".agents/tools/code-review/best-practices.md": {
-      "hash": "b8f93fd83e04dc301d838178a7b7523e35382166",
-      "at": "2026-03-28T13:38:46Z",
-      "pr": 11771
-    },
-    ".agents/content/video-muapi.md": {
-      "hash": "3deffc1afc21c9cb3daf10a540c802fc70e437df",
-      "at": "2026-03-28T11:20:21Z",
-      "pr": 11800
-    },
-    ".agents/tools/browser/playwright-cli.md": {
-      "hash": "978be4b5b3043cfee751f9c966ba27ddd7fe5182",
-      "at": "2026-03-28T11:20:22Z",
-      "pr": 11802
-    },
-    ".agents/aidevops/requirements.md": {
-      "hash": "9a75f9e14252e2364ed8ceeb9e24e8df3a95e310",
-      "at": "2026-03-28T11:52:46Z",
-      "pr": 11770
-    },
-    ".agents/tools/video/yt-dlp.md": {
-      "hash": "93855bd751f355d6ef75134ba3322330fcb7d596",
-      "at": "2026-03-28T11:20:27Z",
-      "pr": 11752
-    },
-    ".agents/content/distribution-youtube-optimizer.md": {
-      "hash": "08796da4159346de335feb979d6ce0af181bb8ff",
-      "at": "2026-03-28T11:20:34Z",
-      "pr": 11731
-    },
-    ".agents/tools/credentials/gocryptfs.md": {
-      "hash": "8e128a21d4783c5499f073213aee1a20491893d5",
-      "at": "2026-03-28T11:20:36Z",
-      "pr": 11730
-    },
-    ".agents/tools/ui/nextjs-layouts.md": {
-      "hash": "df90871ad91810f05326405fe711c4ff4be9460b",
-      "at": "2026-03-28T11:20:37Z",
-      "pr": 11732
-    },
-    ".agents/content/distribution-social.md": {
-      "hash": "4ca38ce265bdd7a4921aeed56567dd38e5e98c32",
-      "at": "2026-03-28T11:20:38Z",
-      "pr": 11733
-    },
-    ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-tactical.md": {
-      "hash": "a53f3400bd5c9142c7f9b186523697b16c1a28e2",
-      "at": "2026-03-28T11:20:40Z",
-      "pr": 11734
-    },
-    ".agents/content/production-writing.md": {
-      "hash": "525c4aab766775fa9f92155b85f58bcda67cf3ea",
-      "at": "2026-03-28T11:20:42Z",
-      "pr": 11788
-    },
-    ".agents/tools/architecture/clean-ddd-hexagonal-skill/testing.md": {
-      "hash": "2316ee0b050453056ecc075e712e88b436dd3dd9",
-      "at": "2026-03-28T13:38:11Z",
-      "pr": 11790
-    },
-    ".agents/workflows/ralph-loop.md": {
-      "hash": "552b1c4af3571c286790521b4cf26446ab3bb729",
-      "at": "2026-03-28T11:20:12Z",
-      "pr": 11789
-    },
-    ".agents/marketing-sales/meta-ads-audiences-targeting-strategies.md": {
-      "hash": "9802f4e7f19b67d5a8a45f1a137209082a585d4c",
-      "at": "2026-03-28T11:20:14Z",
-      "pr": 11791
-    },
-    ".agents/tools/api/vercel-ai-sdk.md": {
-      "hash": "e0a51bc87d3615a985b527cfe0265571672e2095",
-      "at": "2026-03-28T11:20:15Z",
-      "pr": 11792
-    },
-    ".agents/tools/ai-orchestration/overview.md": {
-      "hash": "1dca5c066203b5e0a14c4406e64b3f8e06aa3f85",
-      "at": "2026-03-28T11:20:16Z",
-      "pr": 11793
-    },
-    ".agents/tools/wordpress/mainwp.md": {
-      "hash": "e16169565844b28fa00ca62439a068eec8dd965f",
-      "at": "2026-03-28T11:20:17Z",
-      "pr": 11794
-    },
-    ".agents/services/hosting/hostinger.md": {
-      "hash": "bdc3391799c0fb32ef11f6d610f48f7debae2194",
-      "at": "2026-03-28T11:20:19Z",
-      "pr": 11804
-    },
-    ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-strategic.md": {
-      "hash": "61e87ef7f501310f73fbe54da1d9e0a76a38abae",
-      "at": "2026-03-28T11:20:20Z",
-      "pr": 11805
-    },
-    ".agents/aidevops/supervisor-module-map.md": {
-      "hash": "6dc1ff5f9d7243b29d768c024123338d11496a5f",
-      "at": "2026-03-28T11:52:24Z",
-      "pr": 11811
-    },
-    ".agents/business/company-runners.md": {
-      "hash": "8c78821205aacf320a7ed32b722b7c646a4e35af",
-      "at": "2026-03-28T11:52:25Z",
-      "pr": 11812
-    },
-    ".agents/tools/infrastructure/fireworks.md": {
-      "hash": "6025fc8a3ce3cadba1f1d8d00c699c8fe970b015",
-      "at": "2026-03-28T11:52:26Z",
-      "pr": 11813
-    },
-    ".agents/workflows/git-workflow.md": {
-      "hash": "1ea0b652ceda9126a403a89555e29a02b1c7e3bd",
-      "at": "2026-03-29T08:49:32Z",
-      "pr": 12777
-    },
-    ".agents/marketing-sales/ad-creative-copywriting.md": {
-      "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
-      "at": "2026-03-28T21:14:35Z",
-      "pr": 12018
-    },
-    ".agents/marketing-sales/direct-response-copy-templates-landing-page.md": {
-      "hash": "cbaa0cc29c6e3639ea5254866f8fefe1c02a329c",
-      "at": "2026-03-28T13:37:36Z",
-      "pr": 11840
-    },
-    ".agents/seo/gsc-sitemaps.md": {
-      "hash": "7154caa038f21e800f7b6c5493f2553a9d7e8efb",
-      "at": "2026-03-28T11:52:39Z",
-      "pr": 11821
-    },
-    ".agents/services/email/email-mailbox-search.md": {
-      "hash": "26c7c333d46a5319b598173b36c5c30124126c81",
-      "at": "2026-03-28T13:37:26Z",
-      "pr": 11869
-    },
-    ".agents/tools/browser/crawl4ai-resources.md": {
-      "hash": "3b91d1b3383285e813ef8eed5303e3a6fa8fa99d",
-      "at": "2026-03-28T13:37:22Z",
-      "pr": 11858
-    },
-    ".agents/tools/build-mcp/build-mcp.md": {
-      "hash": "9b3ca67c49dd5bf0af66b01061561502620de8b3",
-      "at": "2026-03-28T13:37:27Z",
-      "pr": 11844
-    },
-    ".agents/tools/deployment/daytona.md": {
-      "hash": "752d573096d1a59e09ee119494e907e2e17d34ee",
-      "at": "2026-03-28T13:37:28Z",
-      "pr": 11846
-    },
-    ".agents/tools/ocr/ocr-research.md": {
-      "hash": "667a0af0fe47f5c2c316520d13beb61f1f9d0b7f",
-      "at": "2026-03-28T13:37:30Z",
-      "pr": 11857
-    },
-    ".agents/seo/contentking.md": {
-      "hash": "ce7ecac379f3bc6552cf23ad3bd149902b0ace12",
-      "at": "2026-03-28T13:37:31Z",
-      "pr": 11845
-    },
-    ".agents/services/email/mission-email.md": {
-      "hash": "bf5446200b94e750fce11fc719c2904f47bd67c5",
-      "at": "2026-03-28T13:37:15Z",
-      "pr": 11889
-    },
-    ".agents/tools/mobile/app-store-connect.md": {
-      "hash": "55340aa49411b8c5faf342ecbd1284bd9b126390",
-      "at": "2026-03-29T07:02:17Z",
-      "pr": 12625
-    },
-    ".agents/tools/browser/stagehand-examples.md": {
-      "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
-      "at": "2026-03-28T14:15:24Z",
-      "pr": 11899
-    },
-    ".agents/tools/ui/wxt.md": {
-      "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
-      "at": "2026-03-28T13:37:50Z",
-      "pr": 11870
-    },
-    ".agents/tools/code-review/secretlint.md": {
-      "hash": "54a79997b8c268d6b3942204a8b6e23a251bcfe3",
-      "at": "2026-03-28T16:00:52Z",
-      "pr": 11991
-    },
-    ".agents/tools/database/pglite-local-first.md": {
-      "hash": "57487b7d3c5e896eaebeeccd458d76e65cae5b8d",
-      "at": "2026-03-28T15:30:29Z",
-      "pr": 11920
-    },
-    ".agents/tools/document/document-extraction.md": {
-      "hash": "b0e790ef3e6481f532436eab39cac1d6ec92430b",
-      "at": "2026-03-28T15:30:30Z",
-      "pr": 11919
-    },
-    ".agents/tools/code-review/runtime-patterns.md": {
-      "hash": "06e2affe5aaa285c3139fde0d808dc89c0140e31",
-      "at": "2026-03-28T13:38:47Z",
-      "pr": 11771
-    },
-    ".agents/tools/browser/dev-browser.md": {
-      "hash": "5ff7878823ad9efd84ccc040b7165ca79150f8d4",
-      "at": "2026-03-28T15:30:31Z",
-      "pr": 11921
-    },
-    ".agents/tools/code-review/code-standards.md": {
-      "hash": "88d5b9dc281a4557707da37dee72529d600faaf8",
-      "at": "2026-03-28T15:30:22Z",
-      "pr": 11944
-    },
-    ".agents/scripts/commands/full-loop.md": {
-      "hash": "2721ce269c6727fb5021c0a3f122930366c47a4f",
-      "at": "2026-03-31T04:44:37Z",
-      "pr": 14590
-    },
-    ".agents/scripts/commands/ip-check.md": {
-      "hash": "50712771a5effc6d34ec205c3dd4616540d26311",
-      "at": "2026-03-31T02:20:51Z",
-      "pr": 14484
-    },
-    ".agents/scripts/commands/postflight-loop.md": {
-      "hash": "37a467bf622640eb6c8d75aa2c1de45c9a27c61c",
-      "at": "2026-04-01T20:59:31Z",
-      "pr": 14942
-    },
-    ".agents/scripts/commands/routine.md": {
-      "hash": "3f41b68e706f479c75df03b199f4b7c8a027644d",
-      "at": "2026-03-31T03:14:22Z",
-      "pr": 14509
-    },
-    ".agents/workflows/pr.md": {
-      "hash": "8f6584d97315d02aa4914a1f26165c57ff873479",
-      "at": "2026-03-29T14:29:47Z",
-      "pr": 13014
-    },
-    ".agents/tools/git/conflict-resolution.md": {
-      "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
-      "at": "2026-03-28T14:15:35Z",
-      "pr": 11909
-    },
-    ".agents/aidevops/configs.md": {
-      "hash": "fecc0e08b16083bdd8f7e82c6f1636c136af3287",
-      "at": "2026-03-28T15:30:49Z",
-      "pr": 11897
-    },
-    ".agents/services/communications/telfon.md": {
-      "hash": "02d4e621aff6b2ef17eecba67d3189df35171c09",
-      "at": "2026-03-31T04:46:03Z",
-      "pr": 14595
-    },
-    ".agents/services/communications/twilio.md": {
-      "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
-      "at": "2026-03-28T14:15:37Z",
-      "pr": 11900
-    },
-    ".agents/marketing-sales/ad-creative-platform-google.md": {
-      "hash": "f64e3f66de660586a2c510e31ce4a942286cf079",
-      "at": "2026-03-28T15:30:26Z",
-      "pr": 11936
-    },
-    ".agents/tools/ai-assistants/openclaw.md": {
-      "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
-      "at": "2026-03-28T14:15:40Z",
-      "pr": 11901
-    },
-    ".agents/content/video-wavespeed.md": {
-      "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
-      "at": "2026-03-28T14:15:41Z",
-      "pr": 11895
-    },
-    ".agents/seo/debug-opengraph.md": {
-      "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
-      "at": "2026-03-28T14:15:42Z",
-      "pr": 11898
-    },
-    ".agents/aidevops/plugins.md": {
-      "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
-      "at": "2026-03-28T14:15:43Z",
-      "pr": 11894
-    },
-    ".agents/services/hosting/local-hosting.md": {
-      "hash": "ac2a557901e0a9c39b034b664927c37847635345",
-      "at": "2026-03-28T16:41:15Z",
-      "pr": 12026
-    },
-    ".agents/tools/data-extraction/outscraper.md": {
-      "hash": "a3e3c1fee3571f9cfe07e4f90d47e3aa0c2c758a",
-      "at": "2026-03-28T16:41:16Z",
-      "pr": 12021
-    },
-    ".agents/content/distribution-email.md": {
-      "hash": "d218dc3fdd2a3e501978d431530820ce810b354e",
-      "at": "2026-03-28T16:00:42Z",
-      "pr": 11989
-    },
-    ".agents/services/database/postgres-drizzle-skill/migrations.md": {
-      "hash": "1b9f3f2536dd65950e7eec906f4c44467b9619e8",
-      "at": "2026-03-28T16:00:44Z",
-      "pr": 11966
-    },
-    ".agents/workflows/code-audit-remote.md": {
-      "hash": "2702ee79b7d0f63a13b19d69171f937db3e37064",
-      "at": "2026-03-28T15:31:24Z",
-      "pr": 11825
-    },
-    ".agents/tools/credentials/api-key-setup.md": {
-      "hash": "3fe770105e7b4c6edbff6f572b5189e5c2a7ba17",
-      "at": "2026-03-29T20:53:50Z",
-      "pr": 13279
-    },
-    ".agents/marketing-sales/ad-creative.md": {
-      "hash": "0fd2f3ed67a352a6b59ca35f1cb1be0ca62f691f",
-      "at": "2026-03-29T03:31:36Z",
-      "pr": 12505
-    },
-    ".agents/tools/mcp-toolkit/mcporter.md": {
-      "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
-      "at": "2026-03-28T14:16:17Z",
-      "pr": 11906
-    },
-    ".agents/marketing-sales/ad-creative-campaign-management.md": {
-      "hash": "cf88e0ca297eabefcb235d1359ee6d2b0e75d576",
-      "at": "2026-03-28T16:00:35Z",
-      "pr": 11974
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
-      "hash": "f74ee77c8e774c79829f80e238c09adbe6f3c21e",
-      "at": "2026-03-28T15:30:24Z",
-      "pr": 11945
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
-      "hash": "97a482f311bb9a1a99a103e7b77f815c8ce8af7e",
-      "at": "2026-03-28T15:30:35Z",
-      "pr": 11935
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
-      "hash": "9fda0fe135c5d900b529cbf4c9b5095c72c9a79d",
-      "at": "2026-03-28T16:00:33Z",
-      "pr": 11987
-    },
-    ".agents/tools/video/remotion.md": {
-      "hash": "e587ff6f81433c2bcc6b89ee139561849007d27e",
-      "at": "2026-03-28T15:30:25Z",
-      "pr": 11961
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/c3.md": {
-      "hash": "6ffc77f50024207bbb549b337789b8c9cbd8f475",
-      "at": "2026-03-28T15:30:18Z",
-      "pr": 11962
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
-      "hash": "3078a83990f41df192998904d47d0641191e7fba",
-      "at": "2026-03-28T16:00:25Z",
-      "pr": 11985
-    },
-    ".agents/tools/performance/performance.md": {
-      "hash": "478f1736c9c362f035765d45caddb4eebdec8071",
-      "at": "2026-03-28T16:00:21Z",
-      "pr": 11983
-    },
-    ".agents/aidevops/troubleshooting.md": {
-      "hash": "9b1e6b69bbb4c48b5d664dbb23d72a25eb867b0f",
-      "at": "2026-03-28T16:00:22Z",
-      "pr": 11982
-    },
-    ".agents/marketing-sales/cro-chapter-12.md": {
-      "hash": "f733b449021696b03a6678fba02aca9940fdeb6a",
-      "at": "2026-03-28T16:00:24Z",
-      "pr": 11988
-    },
-    ".agents/content/production-image.md": {
-      "hash": "b3409136a94a117c8a727fa3e1ca400d77806a36",
-      "at": "2026-03-28T16:40:38Z",
-      "pr": 12023
-    },
-    ".agents/tools/voice/voiceink-shortcut.md": {
-      "hash": "1d7af55d9fbf66d24dcb4f1cbba443617f0c992c",
-      "at": "2026-03-28T16:40:39Z",
-      "pr": 12017
-    },
-    ".agents/scripts/commands/testing-setup.md": {
-      "hash": "f653aacf0e67efffd18058625b81f790e9c9f741",
-      "at": "2026-03-28T16:40:41Z",
-      "pr": 12013
-    },
-    ".agents/workflows/multi-repo-workspace.md": {
-      "hash": "00ea218df67c941a8858e0da60f7c252c850db7a",
-      "at": "2026-03-28T16:00:32Z",
-      "pr": 11984
-    },
-    ".agents/workflows/version-bump.md": {
-      "hash": "d4d8c82182a0c0fce47622e76556260a11747ee8",
-      "at": "2026-03-28T16:00:36Z",
-      "pr": 11986
-    },
-    ".agents/content/video-higgsfield.md": {
-      "hash": "365b9f6acbaa7e54b14209c7eaee723372e836d6",
-      "at": "2026-03-28T16:00:37Z",
-      "pr": 11993
-    },
-    ".agents/services/hosting/cloudflare.md": {
-      "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
-      "at": "2026-03-28T16:00:49Z",
-      "pr": 11992
-    },
-    ".agents/services/monitoring/langwatch.md": {
-      "hash": "a56ed459849e479aaed06d6ac42bf0d60a28adf9",
-      "at": "2026-03-28T16:00:51Z",
-      "pr": 11994
-    },
-    ".agents/tools/wordpress/scf.md": {
-      "hash": "4c62a3f4c5312a10699889660578437def83e31e",
-      "at": "2026-03-28T16:40:07Z",
-      "pr": 12035
-    },
-    ".agents/workflows/readme-create-update.md": {
-      "hash": "f54854963d94f3c9b4e15769c07b3c8c27db1c5a",
-      "at": "2026-03-28T16:40:10Z",
-      "pr": 12038
-    },
-    ".agents/services/email/email-actions.md": {
-      "hash": "6e4fd843160e764848c98da37b2234e11ddfa56d",
-      "at": "2026-03-28T16:40:11Z",
-      "pr": 12039
-    },
-    ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
-      "hash": "52069355367fb596967a8aef0bb6ad7f8e9861c3",
-      "at": "2026-03-28T16:40:13Z",
-      "pr": 12030
-    },
-    ".agents/product/growth.md": {
-      "hash": "97246dfba596c1be9241c0b669c611df856e71bc",
-      "at": "2026-03-28T16:40:15Z",
-      "pr": 12037
-    },
-    ".agents/services/email/email-delivery-test.md": {
-      "hash": "229f4a8a141175830e0207dbb58b13d9146b22ab",
-      "at": "2026-03-28T16:40:17Z",
-      "pr": 12041
-    },
-    ".agents/services/email/email-verification.md": {
-      "hash": "d8d5bf1e0ed2feed034371b34ea74d5a572eac25",
-      "at": "2026-03-31T09:57:12Z",
-      "pr": 14757
-    },
-    ".agents/services/email/openpgp-setup.md": {
-      "hash": "f893cd98da28874d714707765c45a895d991cede",
-      "at": "2026-03-28T16:40:18Z",
-      "pr": 12040
-    },
-    ".agents/tools/programming/modern-javascript-skill/cheatsheet.md": {
-      "hash": "5043165087af14cf58963d7a76e48ceed463cb6d",
-      "at": "2026-03-28T16:40:20Z",
-      "pr": 12042
-    },
-    ".agents/services/hosting/cloudron.md": {
-      "hash": "e9d97dc1a3a3dbe0bb45134f1148c74954fa577c",
-      "at": "2026-03-28T16:40:22Z",
-      "pr": 12046
-    },
-    ".agents/tools/voice/pipecat-opencode.md": {
-      "hash": "53d34b6a543b30dcbc6141ccea72d1364e7ae07d",
-      "at": "2026-03-28T16:40:27Z",
-      "pr": 12019
-    },
-    ".agents/marketing-sales/meta-ads.md": {
-      "hash": "19b4754a783dd4b878bb5cf4032420f1cfab931d",
-      "at": "2026-03-28T16:40:30Z",
-      "pr": 12024
-    },
-    ".agents/tools/context/augment-context-engine.md": {
-      "hash": "bbae0554351a40b90c0df31e139c6391601f3e2b",
-      "at": "2026-03-28T16:40:32Z",
-      "pr": 12015
-    },
-    ".agents/tools/conversion/mineru.md": {
-      "hash": "beeb4a49df5e2a8ea91da9100ae2ba8887cf6b3d",
-      "at": "2026-03-28T16:40:36Z",
-      "pr": 12012
-    },
-    ".agents/marketing-sales/cro-chapter-14.md": {
-      "hash": "a15acda5b82f46b01af4961ff5c01fa7483e5cea",
-      "at": "2026-03-28T16:40:42Z",
-      "pr": 12027
-    },
-    ".agents/content/production-characters.md": {
-      "hash": "f26a85f43d79aed7426a749dab9407537412d65b",
-      "at": "2026-03-28T16:40:48Z",
-      "pr": 12025
-    },
-    ".agents/tools/code-review/security-audit.md": {
-      "hash": "bed16a626f218a4a0045edaae30edfa52616f72c",
-      "at": "2026-03-28T17:11:18Z",
-      "pr": 12029
-    },
-    ".agents/tools/security/privacy-filter.md": {
-      "hash": "20015ffb18e50ebb7071f1b6299b4404bdcd4071",
-      "at": "2026-03-28T16:41:02Z",
-      "pr": 12014
-    },
-    ".agents/tools/security/shannon.md": {
-      "hash": "a48914d21141559b0cf7677395979bd17f429b85",
-      "at": "2026-03-28T16:41:03Z",
-      "pr": 12016
-    },
-    ".agents/business/accounts-receipt-ocr.md": {
-      "hash": "7500c09629a5e47688af67a6901d684e92b623f2",
-      "at": "2026-03-28T16:41:24Z",
-      "pr": 12020
-    },
-    ".agents/tools/security/prompt-injection-defender.md": {
-      "hash": "0ee667b145d5e9aa8e6aefabf4ddc1c717cac0a0",
-      "at": "2026-03-28T17:11:06Z",
-      "pr": 12057
-    },
-    ".agents/seo/domain-research-api-reference.md": {
-      "hash": "52e574da550501d13cf7d760d098926843d5260b",
-      "at": "2026-03-28T17:11:07Z",
-      "pr": 12056
-    },
-    ".agents/seo/domain-research.md": {
-      "hash": "18f017104a97c94157077b8fc620e24bad8f86ba",
-      "at": "2026-03-28T17:11:08Z",
-      "pr": 12056
-    },
-    ".agents/scripts/commands/define.md": {
-      "hash": "228f38c6d509423d7158cef517bbd601a691923d",
-      "at": "2026-03-29T17:15:13Z",
-      "pr": 13131
-    },
-    ".agents/tools/browser/skyvern.md": {
-      "hash": "1f2933d4cdf35fd9696301a5743ae2e550a31eb0",
-      "at": "2026-03-28T17:11:10Z",
-      "pr": 12055
-    },
-    ".agents/seo/dataforseo.md": {
-      "hash": "8dfaad77d57b706e697ab23a2c8ac8a84cf9c6ed",
-      "at": "2026-03-28T17:11:12Z",
-      "pr": 12053
-    },
-    ".agents/tools/video/video-prompt-design.md": {
-      "hash": "ba533270f9fe5f9dab9fe60e3a4eef1420e2bd6c",
-      "at": "2026-03-28T17:30:25Z",
-      "pr": 12071
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md": {
-      "hash": "70f6f1b16aeb637c122232aa75b789bedfbe63a7",
-      "at": "2026-03-28T21:50:53Z",
-      "pr": 12192
-    },
-    ".agents/tools/browser/fingerprint-profiles.md": {
-      "hash": "d910625e173f65063d64d51ca549494b97a2ba87",
-      "at": "2026-03-28T17:30:27Z",
-      "pr": 12070
-    },
-    ".agents/tools/code-review/qlty.md": {
-      "hash": "3c3fef1897ddb0b0bb88a35205dfd4d6f715db13",
-      "at": "2026-03-28T18:36:46Z",
-      "pr": 12114
-    },
-    ".agents/tools/research/providers/wappalyzer.md": {
-      "hash": "ef665188513a7db11f82af28c6b0440d2b3943d5",
-      "at": "2026-03-28T20:17:04Z",
-      "pr": 12115
-    },
-    ".agents/services/communications/matterbridge.md": {
-      "hash": "10f123307b4f6919f65b9c46a2e9b5aecf37ef37",
-      "at": "2026-03-29T01:04:18Z",
-      "pr": 12399
-    },
-    ".agents/services/communications/simplex.md": {
-      "hash": "0fae9edf453dabb06fafed112e578d6f45e0f96c",
-      "at": "2026-03-28T20:16:50Z",
-      "pr": 12168
-    },
-    ".agents/tools/browser/watercrawl.md": {
-      "hash": "c3fc2a3c5ee117daba5dfbfae490dfb406b9e711",
-      "at": "2026-03-28T19:15:30Z",
-      "pr": 12117
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md": {
-      "hash": "733d3525cbf26277967990e47a34c41691036be8",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md": {
-      "hash": "785bdeaad722d0f542517cebae0f89e8f6828e73",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md": {
-      "hash": "93baaad7916863404459e50d80bfbba593f30589",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md": {
-      "hash": "97c3a7d841885f7124cda4603bc4f24f25394771",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md": {
-      "hash": "bf9eb0a6805213c30a476ba1a193467d85f8a0b7",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md": {
-      "hash": "eb8f44407cfde984193f403d441a2f080f32db71",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md": {
-      "hash": "1f2ca15e1758f9c72bf63021b81902c746f08a5d",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md": {
-      "hash": "3459fb86214d51707322f38fc1de4c32ca7434a0",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md": {
-      "hash": "8225af6a25a3cbad5d152becfc7be32b66146897",
-      "at": "2026-03-31T07:50:54Z",
-      "pr": 14717
-    },
-    ".agents/scripts/framework-issue-helper.sh": {
-      "hash": "a53fde8f11aabd50fbda03386f967721d987e07a",
-      "at": "2026-03-29T00:24:21Z",
-      "pr": 12145
-    },
-    ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "36aed63a705a997b70c44687e1763e18a70e66b7",
-      "at": "2026-04-02T03:11:26Z",
-      "pr": 15086
-    },
-    ".agents/tools/browser/stagehand-python.md": {
-      "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
-      "at": "2026-03-30T02:31:00Z",
-      "pr": 13486
-    },
-    ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
-      "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
-      "at": "2026-03-28T20:16:39Z",
-      "pr": 12160
-    },
-    ".agents/tools/pdf/libpdf.md": {
-      "hash": "9d4d5fd4651f9132fb47d6467e53683fd7f0553b",
-      "at": "2026-03-28T20:16:42Z",
-      "pr": 12161
-    },
-    ".agents/services/email/email-agent.md": {
-      "hash": "4c589d1b951ae82f8dbb4a9e7ff05235f5edc6db",
-      "at": "2026-03-28T20:16:44Z",
-      "pr": 12163
-    },
-    ".agents/services/email/letter-post-bridge.md": {
-      "hash": "f6065bec96f8cb306e39fe1862b7bf456e1901d3",
-      "at": "2026-03-31T05:33:36Z",
-      "pr": 14646
-    },
-    ".agents/services/hosting/cloudflare-platform-skill.md": {
-      "hash": "6008b298c541d6b044eb0779f76074b818140d27",
-      "at": "2026-03-28T20:16:45Z",
-      "pr": 12162
-    },
-    ".agents/scripts/gh-signature-helper.sh": {
-      "hash": "e735571da002f6ed47f0b43dceaa313e6118204c",
-      "at": "2026-03-29T16:34:26Z",
-      "pr": 13021
-    },
-    ".agents/tools/wordpress/wp-dev.md": {
-      "hash": "c88f6e0f70e046ce19bf119077cef234636b2f4d",
-      "at": "2026-03-29T22:09:16Z",
-      "pr": 13341
-    },
-    ".agents/content/distribution-short-form.md": {
-      "hash": "8350ba659dc7fbcbecd70b55d52b65d296ce5401",
-      "at": "2026-03-28T20:16:49Z",
-      "pr": 12172
-    },
-    ".agents/content/platform-personas.md": {
-      "hash": "b0c32995086af230ae41412dd2dca98054968ce2",
-      "at": "2026-03-28T20:16:53Z",
-      "pr": 12167
-    },
-    ".agents/services/communications/privacy-comparison.md": {
-      "hash": "d36b5a85b507a958a555b6311d3266035d619ba8",
-      "at": "2026-03-28T20:16:54Z",
-      "pr": 12169
-    },
-    ".agents/services/database/multi-org-isolation.md": {
-      "hash": "2a09353ed9cbb973b0dd0344a938412bcc5b859e",
-      "at": "2026-03-28T21:59:22Z",
-      "pr": 12249
-    },
-    ".agents/workflows/review-issue-pr.md": {
-      "hash": "14ac8f78bcfbb8ec23df3e37c021b7cd512c2f5b",
-      "at": "2026-03-28T22:39:25Z",
-      "pr": 12308
-    },
-    ".agents/tools/browser/browser-qa.md": {
-      "hash": "629aa3a1df673d6e5df7310d173da5d3938aa04e",
-      "at": "2026-03-28T20:17:06Z",
-      "pr": 12171
-    },
-    ".agents/tools/mobile/app-dev-swift.md": {
-      "hash": "15ec4fad109dcdce50f6ed4a70d117caff12f906",
-      "at": "2026-03-29T07:03:03Z",
-      "pr": 12506
-    },
-    ".agents/tools/context/context7.md": {
-      "hash": "1d98876794a7dc00b2cd2126492a54302f051af8",
-      "at": "2026-03-28T20:56:05Z",
-      "pr": 12182
-    },
-    ".agents/marketing-sales/ad-creative-ai-tools-reference.md": {
-      "hash": "8faff4defc9b64a16a6da7b996a86d29763bb87e",
-      "at": "2026-03-28T20:56:07Z",
-      "pr": 12183
-    },
-    ".agents/seo/eeat-score.md": {
-      "hash": "bb9c0e98f32d0453eb08cbbb4222f06c1a13b007",
-      "at": "2026-03-28T20:56:08Z",
-      "pr": 12181
-    },
-    ".agents/tools/automation/cron-agent.md": {
-      "hash": "fbf1c6bc76acc1436d3da1b0b34296be5193de5a",
-      "at": "2026-03-28T20:56:11Z",
-      "pr": 12184
-    },
-    ".agents/marketing-sales/meta-ads-creative-briefs-ugc-brief.md": {
-      "hash": "b3cbdabb7633b010839689527b084c198f34bdc9",
-      "at": "2026-03-28T21:27:17Z",
-      "pr": 12217
-    },
-    ".agents/seo/keyword-research.md": {
-      "hash": "d00bca2d9a784bfd220b4afd767d384d83bea740",
-      "at": "2026-03-28T21:27:18Z",
-      "pr": 12220
-    },
-    ".agents/services/email/microsoft-graph.md": {
-      "hash": "953bb07aef8c8ed23c023cc574b6390196e3b16d",
-      "at": "2026-03-28T21:27:21Z",
-      "pr": 12218
-    },
-    ".agents/services/hosting/closte.md": {
-      "hash": "a9295d1bd4b72a378606ad987d9ea3d5385734c8",
-      "at": "2026-03-28T21:27:23Z",
-      "pr": 12219
-    },
-    ".agents/services/communications/telegram.md": {
-      "hash": "96307f35314ef975fc24bfc8ea3098ac307e2373",
-      "at": "2026-03-28T21:58:54Z",
-      "pr": 12233
-    },
-    ".agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md": {
-      "hash": "2fde1ee5df8c1bbde677a3198fe1c39df860a6ba",
-      "at": "2026-03-28T21:58:55Z",
-      "pr": 12236
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2025.md": {
-      "hash": "e23026c24b61f06282834858aead51f63df3de4d",
-      "at": "2026-03-28T21:58:57Z",
-      "pr": 12234
-    },
-    ".agents/aidevops/resources.md": {
-      "hash": "4c8aa012ca51de765daed452692f619d55c701b1",
-      "at": "2026-03-28T21:58:59Z",
-      "pr": 12244
-    },
-    ".agents/tools/git/opencode-github-security.md": {
-      "hash": "7614267ce5278cc0f8d3e46a9301f179a610b9f3",
-      "at": "2026-03-28T22:39:20Z",
-      "pr": 12309
-    },
-    ".agents/tools/animation/animejs.md": {
-      "hash": "3d011c9aa6ae720f1ed6de08663bf78f589237ec",
-      "at": "2026-03-29T08:11:02Z",
-      "pr": 12745
-    },
-    ".agents/tools/build-mcp/deployment.md": {
-      "hash": "0229a7490f42dcf4f3b8c0958fefd7ff53f3b8a2",
-      "at": "2026-03-28T22:39:22Z",
-      "pr": 12311
-    },
-    ".agents/tools/browser/chrome-devtools.md": {
-      "hash": "13576e2127eccb1c8555a5b12660265ac4ebd8aa",
-      "at": "2026-03-28T22:39:23Z",
-      "pr": 12310
-    },
-    ".agents/tools/opencode/opencode.md": {
-      "hash": "b338bd4964d10e7780deddb27fc48d772a07be3b",
-      "at": "2026-03-29T11:20:16Z",
-      "pr": 12843
-    },
-    ".agents/tools/browser/browser-profiles.md": {
-      "hash": "2a2c771f4ff870ad450a92a0f9ad950f3f16e3cb",
-      "at": "2026-03-29T07:03:05Z",
-      "pr": 12501
-    },
-    ".agents/services/networking/netbird.md": {
-      "hash": "824fc7ee7cdc7e08351310bdb9f99dcf91a3848e",
-      "at": "2026-03-29T01:33:20Z",
-      "pr": 12453
-    },
-    ".agents/content/heygen-skill/rules-templates.md": {
-      "hash": "5d9c85b6e42715ec4914982ce21790312207dacf",
-      "at": "2026-03-29T08:10:46Z",
-      "pr": 12738
-    },
-    ".agents/marketing-sales/ad-creative-chapter-01.md": {
-      "hash": "e832ef8eb425956cec38a250eede0227342a4d79",
-      "at": "2026-03-28T23:05:56Z",
-      "pr": 12325
-    },
-    ".agents/marketing-sales/ad-creative-chapters.md": {
-      "hash": "7389f5acbff5e5b272cc97a5c5285e8a9b735427",
-      "at": "2026-03-28T23:05:56Z",
-      "pr": 12325
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/terraform-gotchas.md": {
-      "hash": "2111a2577e4e29eec771f709231f08fa22db2fc0",
-      "at": "2026-03-28T23:05:57Z",
-      "pr": 12324
-    },
-    ".agents/scripts/commands/new-task.md": {
-      "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
-      "at": "2026-03-30T02:30:59Z",
-      "pr": 13489
-    },
-    ".agents/scripts/commands/runners.md": {
-      "hash": "e15f89fc275c14393073efaa842849957733470c",
-      "at": "2026-03-28T23:06:00Z",
-      "pr": 12326
-    },
-    ".agents/scripts/commands/route.md": {
-      "hash": "8167fb30e984e156e02b5fb22c134db28ed8853d",
-      "at": "2026-03-31T04:45:56Z",
-      "pr": 14604
-    },
-    ".agents/seo/debug-favicon.md": {
-      "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",
-      "at": "2026-03-29T22:09:18Z",
-      "pr": 13323
-    },
-    ".agents/tools/code-review/code-simplifier.md": {
-      "hash": "9c62ffdb97ac1d0d44c1bed6c15abc856ee53a9b",
-      "at": "2026-03-30T00:00:00Z",
-      "pr": null
-    },
-    ".agents/tools/build-agent/add-skill.md": {
-      "hash": "36065ac3559aa2e929cbb858c8220961454f9dd9",
-      "at": "2026-03-29T01:03:17Z",
-      "pr": 12376
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md": {
-      "hash": "664f8b8e3ddeec9637d1647e3daed4495c1f4a96",
-      "at": "2026-04-01T23:23:23Z",
-      "pr": 15353
-    },
-    ".agents/content/distribution-youtube.md": {
-      "hash": "a44106f7677388ea6146e99c5c94de36b9e337ba",
-      "at": "2026-03-29T01:03:19Z",
-      "pr": 12386
-    },
-    ".agents/tools/build-mcp/transports.md": {
-      "hash": "733acaf8682f80a53cd3c2a996c0571adf7ac018",
-      "at": "2026-03-29T01:04:08Z",
-      "pr": 12394
-    },
-    ".agents/marketing-sales/meta-ads-campaigns-testing-abo.md": {
-      "hash": "be737a2fe12892ef6479a1939cbe4b6fee46db16",
-      "at": "2026-03-29T01:04:17Z",
-      "pr": 12395
-    },
-    ".agents/marketing-sales/ad-creative-chapter-08.md": {
-      "hash": "cff567e1f6215e9c459e5d97d022a93f34d1c322",
-      "at": "2026-03-29T01:04:19Z",
-      "pr": 12398
-    },
-    ".agents/marketing-sales/cro-chapter-07.md": {
-      "hash": "faba8a64f3996ee2e5722dd4b7c822d49f79c1b6",
-      "at": "2026-03-29T02:36:03Z",
-      "pr": 12463
-    },
-    ".agents/marketing-sales/ad-creative-chapter-07.md": {
-      "hash": "c79c8baa955bb48f1ce2ded8036ded7940948031",
-      "at": "2026-03-29T01:33:56Z",
-      "pr": 12442
-    },
-    ".agents/tools/browser/playwriter.md": {
-      "hash": "98bfa1b0dde9a405a0f3a07aa1ae3eaadc42801a",
-      "at": "2026-03-29T03:31:38Z",
-      "pr": 12516
-    },
-    ".agents/services/networking/tailscale.md": {
-      "hash": "e930b52dfd40905e93923b036c57b9ffc2bfa011",
-      "at": "2026-03-29T02:36:04Z",
-      "pr": 12461
-    },
-    ".agents/scripts/commands/remember.md": {
-      "hash": "9b17697bde40499a9feacb7812126a6474b0d5d4",
-      "at": "2026-03-29T03:14:59Z",
-      "pr": 12497
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/email-workers.md": {
-      "hash": "d43b669b4be0f3b85ad9b1e95ff67189431eafdc",
-      "at": "2026-03-29T03:15:00Z",
-      "pr": 12502
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
-      "hash": "12b23db6429e9400868f947faff09d534d18165d",
-      "at": "2026-03-31T09:29:58Z",
-      "pr": 14792
-    },
-    ".agents/tools/git/gitlab-cli.md": {
-      "hash": "de6952c2d9d3316c91c942921113892f89ddd42c",
-      "at": "2026-03-29T03:15:01Z",
-      "pr": 12498
-    },
-    ".agents/marketing-sales/cro-chapter-13.md": {
-      "hash": "e498cfacef39db0262cc094600055befe786ccfe",
-      "at": "2026-03-29T03:15:02Z",
-      "pr": 12499
-    },
-    ".agents/content/heygen-skill/rules-video-translation.md": {
-      "hash": "16bf014b85cd6ad3c1be9d593a97af8620313cbb",
-      "at": "2026-03-29T03:15:05Z",
-      "pr": 12504
-    },
-    ".agents/content/heygen-skill/rules-voices.md": {
-      "hash": "d3dbb1550c826e13f7c5288b74f72fcff3518efd",
-      "at": "2026-03-29T07:02:36Z",
-      "pr": 12577
-    },
-    ".agents/marketing-sales/ad-creative-chapter-12.md": {
-      "hash": "eca290e31ece1e36762bbf607353ddbdb27aaf52",
-      "at": "2026-03-29T03:15:08Z",
-      "pr": 12503
-    },
-    ".agents/reference/hashline-edit-format.md": {
-      "hash": "2f2019c30b4f9bb5d1947e6b7156833f15973c1e",
-      "at": "2026-04-01T23:23:50Z",
-      "pr": 15277
-    },
-    ".agents/tools/security/opsec.md": {
-      "hash": "c0427c90ef2576abbb9115f920944e06ee023080",
-      "at": "2026-03-29T03:15:14Z",
-      "pr": 12507
-    },
-    ".agents/scripts/commands/save-todo.md": {
-      "hash": "9b4ef4321b1b93eb8d349dbdae3b6c717838135c",
-      "at": "2026-03-29T03:15:15Z",
-      "pr": 12521
-    },
-    ".agents/services/payments/stripe.md": {
-      "hash": "6cbe509351f115869d196a09bc7031bb237d2a41",
-      "at": "2026-03-29T03:15:16Z",
-      "pr": 12511
-    },
-    ".agents/tools/browser/stagehand.md": {
-      "hash": "3702284e297e642ee7e2bb0c65470886fc7c0ffb",
-      "at": "2026-03-29T03:15:18Z",
-      "pr": 12513
-    },
-    ".agents/content/heygen-skill/rules-quota.md": {
-      "hash": "defa81f8873250c50ab8a9481e5d6f2b0958946c",
-      "at": "2026-03-29T07:02:38Z",
-      "pr": 12592
-    },
-    ".agents/tools/ui/tailwind-css.md": {
-      "hash": "1f3b2d4e3add5cecfe530b8db9addf411a9069fe",
-      "at": "2026-03-29T07:02:43Z",
-      "pr": 12576
-    },
-    ".agents/content/video-director.md": {
-      "hash": "7aa6d199c68cd683f60bf343be15f38db4484a11",
-      "at": "2026-03-29T07:02:22Z",
-      "pr": 12608
-    },
-    ".agents/marketing-sales/meta-ads-audiences-retargeting-setup.md": {
-      "hash": "dedfee9605d04b5a7cf9f5563c0e772f06e44062",
-      "at": "2026-03-29T03:15:24Z",
-      "pr": 12514
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/miniflare-gotchas.md": {
-      "hash": "c2a8232a749da0976495eabf4ea541b52bae82f8",
-      "at": "2026-03-29T07:02:46Z",
-      "pr": 12586
-    },
-    ".agents/tools/api/hono.md": {
-      "hash": "bf496281a1542c460ea880f936ec4d92dd928900",
-      "at": "2026-03-29T07:02:20Z",
-      "pr": 12607
-    },
-    ".agents/tools/opencode/opencode-anthropic-auth.md": {
-      "hash": "f05464c433b2b8e301af49ac5693cba5662ca6f7",
-      "at": "2026-03-29T03:15:28Z",
-      "pr": 12522
-    },
-    ".agents/tools/terminal/terminal-optimization.md": {
-      "hash": "f33e57108fd87d88906e414ae5caf4d169efb557",
-      "at": "2026-03-29T03:15:29Z",
-      "pr": 12526
-    },
-    ".agents/tools/ui/shadcn.md": {
-      "hash": "b65c32526cb52d71c76cead493b7c71147417a78",
-      "at": "2026-03-29T07:02:41Z",
-      "pr": 12590
-    },
-    ".agents/scripts/foss-handlers/generic.sh": {
-      "hash": "45cc10462795e6230b70b2f068bb95b4e53612f2",
-      "at": "2026-03-29T03:15:47Z",
-      "pr": 12346
-    },
-    ".agents/reference/foss-contributions.md": {
-      "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
-      "at": "2026-03-30T02:30:24Z",
-      "pr": 13561
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
-      "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
-      "at": "2026-03-29T07:02:06Z",
-      "pr": 12686
-    },
-    ".agents/services/hosting/hetzner.md": {
-      "hash": "34c50c3bfd8c86b684e922441da91443f8a22dfd",
-      "at": "2026-03-29T07:02:07Z",
-      "pr": 12687
-    },
-    ".agents/tools/deployment/hosting-comparison.md": {
-      "hash": "d29068fa3678e9cf3c2d6709305d5d71e5488dcb",
-      "at": "2026-03-29T07:02:09Z",
-      "pr": 12661
-    },
-    ".agents/marketing-sales/ad-creative-chapter-04.md": {
-      "hash": "35b67bea4f7521d18b9a3a75deb4b2508810e83d",
-      "at": "2026-03-29T07:02:10Z",
-      "pr": 12662
-    },
-    ".agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md": {
-      "hash": "0afd51341e71da8060a8a9e2759bf6629a430093",
-      "at": "2026-03-29T10:18:21Z",
-      "pr": 12844
-    },
-    ".agents/marketing-sales/cro-chapter-04.md": {
-      "hash": "f893022ded62f04d6ca13b86f839211e4fe8190a",
-      "at": "2026-03-29T07:02:12Z",
-      "pr": 12665
-    },
-    ".agents/services/communications/whatsapp.md": {
-      "hash": "dbc5cdbcdc61a880b5ca1c2746408002cc6fa7ac",
-      "at": "2026-03-29T12:37:29Z",
-      "pr": 12821
-    },
-    ".agents/tools/ai-orchestration/openprose.md": {
-      "hash": "7d17737b91f8878839b3430a51676211744becce",
-      "at": "2026-03-29T14:29:04Z",
-      "pr": 13007
-    },
-    ".agents/content/heygen-skill/rules-avatars.md": {
-      "hash": "e600865474071a7973fe0ed89b4fd361065e080a",
-      "at": "2026-03-29T07:02:16Z",
-      "pr": 12654
-    },
-    ".agents/services/email/email-mailbox.md": {
-      "hash": "e9ff02135b83557f59c4e444ef2f07607516b341",
-      "at": "2026-03-29T07:02:18Z",
-      "pr": 12624
-    },
-    ".agents/aidevops/onboarding.md": {
-      "hash": "6a88664be533136561cd84696accde70b2db1395",
-      "at": "2026-03-29T07:02:21Z",
-      "pr": 12641
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance.md": {
-      "hash": "8d3a6869182b857eedccac3ed7f13229f52abd06",
-      "at": "2026-03-29T15:08:45Z",
-      "pr": 13034
-    },
-    ".agents/services/accounting/quickfile.md": {
-      "hash": "db7040cc4f46334177d39ff45c6d4fd3be9698ee",
-      "at": "2026-03-29T07:02:24Z",
-      "pr": 12699
-    },
-    ".agents/services/outreach/instantly.md": {
-      "hash": "4d19b6424aa379940ec9b8b60dd80d08e9e472fc",
-      "at": "2026-03-31T05:36:34Z",
-      "pr": 14656
-    },
-    ".agents/services/outreach/manyreach.md": {
-      "hash": "94a3e08bcf4edafcd9654e8252a1a8851b004217",
-      "at": "2026-03-29T07:02:27Z",
-      "pr": 12581
-    },
-    ".agents/services/outreach/infraforge.md": {
-      "hash": "0d891dd02a90d75779370f3c62f2929df0bdcd31",
-      "at": "2026-03-31T05:38:33Z",
-      "pr": 14659
-    },
-    ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
-      "hash": "a2b88a20fedbcbbf37624126551caf4b6a101400",
-      "at": "2026-03-29T07:02:28Z",
-      "pr": 12584
-    },
-    ".agents/content/summarize.md": {
-      "hash": "937ce7f1f86adf1ef8f54d08458ca3421209fd10",
-      "at": "2026-03-29T07:02:30Z",
-      "pr": 12578
-    },
-    ".agents/tools/code-review/coderabbit.md": {
-      "hash": "3e37a12db3473bf11b36f10e75ede64bb2494e1b",
-      "at": "2026-03-29T07:02:31Z",
-      "pr": 12589
-    },
-    ".agents/services/email/thunderbird.md": {
-      "hash": "97b29677f0dc7c7542e4fb7c2e3dc10bc5445489",
-      "at": "2026-03-29T07:02:32Z",
-      "pr": 12582
-    },
-    ".agents/scripts/tests/test-gh-signature-helper.sh": {
-      "hash": "260aaa1fea5e42ba585a4c6cc8996794f9c7c2c6",
-      "at": "2026-03-29T13:19:54Z",
-      "pr": 12971
-    },
-    ".agents/tools/research/tech-stack-lookup.md": {
-      "hash": "bb8bdd9ccd46c7cc0742a5ba1849bb47746c2110",
-      "at": "2026-03-29T07:02:42Z",
-      "pr": 12579
-    },
-    ".agents/scripts/commands/neuronwriter.md": {
-      "hash": "233c0b9d671275ad8b68ef45c8afaff33acbec34",
-      "at": "2026-03-29T07:02:53Z",
-      "pr": 12588
-    },
-    ".agents/content/distribution-podcast.md": {
-      "hash": "0a2c98014bbe0588383437327d0b71e81a574af5",
-      "at": "2026-03-29T07:02:57Z",
-      "pr": 12557
-    },
-    ".agents/tools/git/gitea-cli.md": {
-      "hash": "9452ee8a8cf48269d5848e1d31384a3df0462ec5",
-      "at": "2026-03-29T07:02:58Z",
-      "pr": 12618
-    },
-    ".agents/tools/ui/react-email.md": {
-      "hash": "44be6e93a23aa087b4b70af9dc49a1c566c47e8c",
-      "at": "2026-03-29T07:02:59Z",
-      "pr": 12619
-    },
-    ".agents/content/heygen-skill/rules-photo-avatars.md": {
-      "hash": "d9a524f977f14c54b44991976651334aafa2e6e4",
-      "at": "2026-03-29T07:03:00Z",
-      "pr": 12620
-    },
-    ".agents/tools/browser/browser-use.md": {
-      "hash": "96d5278ed393a25379da0c21d04db2269219cbf9",
-      "at": "2026-03-29T07:03:02Z",
-      "pr": 12616
-    },
-    ".agents/workflows/ui-verification.md": {
-      "hash": "c59b154d588638a381fc14e85f435772cb88e31a",
-      "at": "2026-03-29T07:31:37Z",
-      "pr": 12705
-    },
-    ".agents/content/heygen-skill/rules-video-agent.md": {
-      "hash": "1d039d6d91c08e661a96696b19d43edbefe54b0e",
-      "at": "2026-03-29T07:31:38Z",
-      "pr": 12706
-    },
-    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
-      "hash": "cc7a9cfce528e2d77c1fe2c9b29e09442b5eaf25",
-      "at": "2026-03-30T06:49:15Z",
-      "pr": 13931
-    },
-    ".agents/tools/deployment/cloudron-server-ops-skill.md": {
-      "hash": "ef42b29c1fcb28a5de1fb8be65f21496d5ef10cf",
-      "at": "2026-03-30T03:33:52Z",
-      "pr": 13678
-    },
-    ".agents/scripts/commands/skills.md": {
-      "hash": "b5d46b5e38620ec36852251ec0e4ab4178d9d217",
-      "at": "2026-03-29T08:10:30Z",
-      "pr": 12747
-    },
-    ".agents/scripts/commands/youtube-research.md": {
-      "hash": "340b914ca94d03a0c78878b9ec28534fc761f352",
-      "at": "2026-03-29T08:10:31Z",
-      "pr": 12750
-    },
-    ".agents/tools/ai-assistants/agno.md": {
-      "hash": "0e8f56a7ce9681124205e8492ed4878f1a9c73c3",
-      "at": "2026-03-29T08:10:32Z",
-      "pr": 12746
-    },
-    ".agents/tools/deployment/coolify.md": {
-      "hash": "c69569ccf737f434c5d2c4c031ab9fb87e3f6125",
-      "at": "2026-03-29T08:10:34Z",
-      "pr": 12748
-    },
-    ".agents/tools/mobile/app-dev.md": {
-      "hash": "5fa80cfb5528478d449196a550ffb263ac4380e0",
-      "at": "2026-03-29T08:10:35Z",
-      "pr": 12752
-    },
-    ".agents/marketing-sales/cro.md": {
-      "hash": "9a8a0b49c40c42072e982a4dd40761c19c0055ed",
-      "at": "2026-03-29T08:10:36Z",
-      "pr": 12753
-    },
-    ".agents/scripts/commands/strategic-review.md": {
-      "hash": "321755ff5b42109fb2ed065075b903ecfed76407",
-      "at": "2026-03-29T08:10:38Z",
-      "pr": 12756
-    },
-    ".agents/tools/context/prompt-optimization.md": {
-      "hash": "94abbde385ccf494358e17a79a32fdc72d4adb58",
-      "at": "2026-03-29T08:10:39Z",
-      "pr": 12749
-    },
-    ".agents/tools/credentials/environment-variables.md": {
-      "hash": "4a7ee0834fefdbf424af90c68648ad35716559c7",
-      "at": "2026-03-29T08:10:40Z",
-      "pr": 12751
-    },
-    ".agents/tools/design/design-inspiration.md": {
-      "hash": "c45174a87827d85931f259a2e60da60b030b9fef",
-      "at": "2026-03-29T08:10:43Z",
-      "pr": 12754
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md": {
-      "hash": "2fda89c67e49f210c5079578f56272001edd02d9",
-      "at": "2026-03-29T08:11:29Z",
-      "pr": 12755
-    },
-    ".agents/tools/local-models/local-models.md": {
-      "hash": "9809ec0871562ca709e8ef42cf6c3b67d24b69ce",
-      "at": "2026-03-29T08:11:30Z",
-      "pr": 12758
-    },
-    ".agents/tools/mobile/app-dev-publishing.md": {
-      "hash": "5b8ce6f4b5d555eeef5ee8e3cc8f7a933b405529",
-      "at": "2026-03-29T08:11:31Z",
-      "pr": 12760
-    },
-    ".agents/tools/mobile/agent-device.md": {
-      "hash": "29bde4b26353446f6b35c132fcc1c01a80b71d4c",
-      "at": "2026-03-29T08:49:16Z",
-      "pr": 12788
-    },
-    ".agents/content/context-templates.md": {
-      "hash": "a9fe6ed3b2336078d56022e1ea971da34b97a6db",
-      "at": "2026-04-02T04:00:00Z",
-      "pr": 14934
-    },
-    ".agents/content/video-enhancor.md": {
-      "hash": "c92832f61d3cd78705b2913a0662b1ecee089aae",
-      "at": "2026-03-29T08:49:19Z",
-      "pr": 12796
-    },
-    ".agents/tools/infrastructure/nvidia-cloud.md": {
-      "hash": "3dfae170793fb08c63d93733cd5ad81760d651ee",
-      "at": "2026-03-29T08:49:20Z",
-      "pr": 12776
-    },
-    ".agents/reference/planning-detail.md": {
-      "hash": "c5c616d56a09198023878a228bbf7311f9bd0212",
-      "at": "2026-03-29T08:49:21Z",
-      "pr": 12780
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md": {
-      "hash": "dd2e25d9b8dbb4578e676187c9463404feaa3fec",
-      "at": "2026-03-29T08:49:23Z",
-      "pr": 12779
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/turn.md": {
-      "hash": "10963e4e50c30efb3918e434ec90cafa0ac2f51a",
-      "at": "2026-03-29T08:50:09Z",
-      "pr": 12801
-    },
-    ".agents/tools/task-management/beads.md": {
-      "hash": "f42ad2e963039fd53ee52d1443827cbe4f6158c0",
-      "at": "2026-03-29T09:39:21Z",
-      "pr": 12830
-    },
-    ".agents/tools/verification/parallel-verify.md": {
-      "hash": "0abbe9f5d2f2082016fd851080ea1f9a84a03fe9",
-      "at": "2026-03-29T10:19:07Z",
-      "pr": 12849
-    },
-    ".agents/services/hosting/domain-purchasing.md": {
-      "hash": "90b1b455705be948e790ea947fafca8285ca29d9",
-      "at": "2026-03-29T10:47:23Z",
-      "pr": 12867
-    },
-    ".agents/tools/infrastructure/nearai.md": {
-      "hash": "c20f6f36a9c7c2fabc45e4c356d09b3589fb6a64",
-      "at": "2026-03-29T10:47:24Z",
-      "pr": 12869
-    },
-    ".agents/tools/accessibility/accessibility.md": {
-      "hash": "89e683f33936c408a6b266a13c4291d2794e5eec",
-      "at": "2026-03-29T10:47:27Z",
-      "pr": 12870
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md": {
-      "hash": "304f6cf07b8e1ce2ccf0991e5a1c7a048d898f2b",
-      "at": "2026-03-29T14:29:37Z",
-      "pr": 13020
-    },
-    ".agents/tools/browser/proxy-integration.md": {
-      "hash": "46806f6e0dcec4831dc62abb84c2f5f96326c102",
-      "at": "2026-03-29T15:08:41Z",
-      "pr": 13032
-    },
-    ".agents/tools/ai-assistants/capsolver.md": {
-      "hash": "934e330cfc0b1a30efe5bf139296ae882f868709",
-      "at": "2026-03-29T12:36:41Z",
-      "pr": 12953
-    },
-    ".agents/workflows/session-review.md": {
-      "hash": "0209719f0b5eb68905b4edbdc6bffe1fa8d8a54d",
-      "at": "2026-03-29T11:19:53Z",
-      "pr": 12889
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/durable-objects-gotchas.md": {
-      "hash": "befbfbdf1c28bab3d56f52fb86b4a85a7a988da5",
-      "at": "2026-03-29T11:19:55Z",
-      "pr": 12890
-    },
-    ".agents/tools/credentials/vaultwarden.md": {
-      "hash": "49a473adf85c8382799bc059d99c1693cbea98a9",
-      "at": "2026-03-29T12:36:43Z",
-      "pr": 12951
-    },
-    ".agents/services/payments/superwall.md": {
-      "hash": "1c533274b85654214054f396d45e2b1d09425b85",
-      "at": "2026-03-29T12:36:44Z",
-      "pr": 12952
-    },
-    ".agents/tools/browser/extension-dev/publishing.md": {
-      "hash": "7fe8e877846c0dc155d639a1b5dd214e47c7e499",
-      "at": "2026-03-29T11:20:06Z",
-      "pr": 12884
-    },
-    ".agents/tools/infrastructure/cloudflare-ai.md": {
-      "hash": "e62ec76bd3969af84f0aa5378e1e43dc06ec2674",
-      "at": "2026-04-01T20:50:00Z",
-      "pr": 15091
-    },
-    ".agents/content/heygen-skill/rules-scripts.md": {
-      "hash": "ca533a5f39d9590f0056916b545eeb9338b12976",
-      "at": "2026-03-30T04:51:44Z",
-      "pr": 13767
-    },
-    ".agents/marketing-sales/meta-ads-foundations-attribution.md": {
-      "hash": "7bd8755456129fcd79c106e7e829c6233ae16c42",
-      "at": "2026-03-29T11:51:45Z",
-      "pr": 12920
-    },
-    ".agents/tools/voice/speech-to-speech.md": {
-      "hash": "54c12a6e35c2fd9bdbc1476b98053f3fd40c5580",
-      "at": "2026-03-29T14:29:05Z",
-      "pr": 13005
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/advanced.md": {
-      "hash": "66bd6cabafb5379b9b183e5c0721e35852080713",
-      "at": "2026-03-29T11:51:51Z",
-      "pr": 12922
-    },
-    ".agents/marketing-sales/cro-chapter-05.md": {
-      "hash": "2a9c49266d0a50ef42a41c590041ff6aeb62135c",
-      "at": "2026-03-29T09:20:58Z",
-      "pr": 12824
-    },
-    ".agents/tools/research/providers/unbuilt.md": {
-      "hash": "24d4b4257014273b29b58f5e185f3320e798dad0",
-      "at": "2026-03-29T12:36:25Z",
-      "pr": 12945
-    },
-    ".agents/marketing-sales/meta-ads-checklists-weekly-review.md": {
-      "hash": "8ddae4fd98efd953d4ecaa242553ad3eda337a92",
-      "at": "2026-03-29T12:36:27Z",
-      "pr": 12947
-    },
-    ".agents/scripts/commands/mission.md": {
-      "hash": "e13208184cee9ed81fd7f6bddfef98bbcd41b5f5",
-      "at": "2026-03-29T12:36:32Z",
-      "pr": 12959
-    },
-    ".agents/services/analytics/google-analytics.md": {
-      "hash": "ee41c3c82de9e7f7dfa997caf2efea635a61fd7f",
-      "at": "2026-03-29T12:36:33Z",
-      "pr": 12950
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md": {
-      "hash": "b194dbf29525881c1c8296a33806387d7ca7fe7f",
-      "at": "2026-03-29T12:36:34Z",
-      "pr": 12955
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
-      "hash": "07e97feffa7bc2100478d39e614278ab867ba605",
-      "at": "2026-03-29T12:36:58Z",
-      "pr": 12944
-    },
-    ".agents/seo/seo-audit-skill.md": {
-      "hash": "d8493f42e8ba01527667d283942af955218a834f",
-      "at": "2026-03-29T12:37:05Z",
-      "pr": 12948
-    },
-    ".agents/tools/video/remotion-audio.md": {
-      "hash": "c5cce614253505277075e44f178650fab250bd7b",
-      "at": "2026-03-29T12:37:07Z",
-      "pr": 12942
-    },
-    ".agents/aidevops/security-requirements.md": {
-      "hash": "8b86459a5459bd0be5402ca5660bfd99fa54a782",
-      "at": "2026-03-29T12:37:08Z",
-      "pr": 12946
-    },
-    ".agents/marketing-sales/cro-chapter-03.md": {
-      "hash": "ac80d924629caf06f25a2c2bf503c1aa2267d8de",
-      "at": "2026-03-29T12:37:09Z",
-      "pr": 12954
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-patterns.md": {
-      "hash": "e0498ebcd0125ebedaa97fd88662f8aeff47412a",
-      "at": "2026-03-29T12:37:11Z",
-      "pr": 12909
-    },
-    ".agents/product/validation.md": {
-      "hash": "74840e4aa9e8d619ae82517ca6a1b43a00f99b56",
-      "at": "2026-03-29T12:37:13Z",
-      "pr": 12910
-    },
-    ".agents/scripts/commands/youtube-setup.md": {
-      "hash": "d3f66f792c780e690b58d7f976c01c3d64f09a52",
-      "at": "2026-03-29T12:37:14Z",
-      "pr": 12943
-    },
-    ".agents/services/communications/urbit.md": {
-      "hash": "dc74bf7135da0ba31e070bedbe6be841d6b9588b",
-      "at": "2026-03-29T12:37:15Z",
-      "pr": 12911
-    },
-    ".agents/services/email/email-intelligence.md": {
-      "hash": "4046abd7e9e4fffe477b2aa6fedd74cc46fb9708",
-      "at": "2026-03-29T12:37:18Z",
-      "pr": 12912
-    },
-    ".agents/content/distribution-youtube-channel-intel.md": {
-      "hash": "e7acafaec5e56e608968ecc99a7005352995560c",
-      "at": "2026-03-29T12:37:24Z",
-      "pr": 12791
-    },
-    ".agents/tools/ai-assistants/compare-models.md": {
-      "hash": "4ee54c0d4a2a76b5646c8d5bd3403a6bc744f649",
-      "at": "2026-03-29T14:29:46Z",
-      "pr": 13017
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance-caching.md": {
-      "hash": "8c834b7d97111cfa9897297aa73c2ef3b366bf16",
-      "at": "2026-03-29T15:08:44Z",
-      "pr": 13034
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance-explain.md": {
-      "hash": "230ed08a521dea04c78c68e8f7e5eab11f68ea65",
-      "at": "2026-03-29T15:08:44Z",
-      "pr": 13034
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance-indexing.md": {
-      "hash": "982123000c56dcfb6394064ab6d5ad13a0603dbb",
-      "at": "2026-03-29T15:08:44Z",
-      "pr": 13034
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance-monitoring.md": {
-      "hash": "38276dd264af6fef1c634f2620d188483aec50be",
-      "at": "2026-03-29T15:08:44Z",
-      "pr": 13034
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance-pagination.md": {
-      "hash": "7e533ff31428e865c8c608139b2835b146164832",
-      "at": "2026-03-29T15:08:44Z",
-      "pr": 13034
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance-pooling.md": {
-      "hash": "470b2b768f6fff6d4e925000ec0026254511ea0e",
-      "at": "2026-03-29T15:08:45Z",
-      "pr": 13034
-    },
-    ".agents/services/database/postgres-drizzle-skill/performance-queries.md": {
-      "hash": "3caacdf6f9053841bd7863c9f7dc002a8b784d1e",
-      "at": "2026-03-29T15:08:45Z",
-      "pr": 13034
-    },
-    ".agents/content/content-calendar.md": {
-      "hash": "5bb7dca9397875d571887657d6e92d551536e6cd",
-      "at": "2026-03-29T15:50:25Z",
-      "pr": 13052
-    },
-    ".agents/content/story.md": {
-      "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
-      "at": "2026-03-29T17:14:35Z",
-      "pr": 13457
-    },
-    ".agents/build-plus.md": {
-      "hash": "9a8681dd42ae12e35c79f2f2479a29dfc90794f9",
-      "at": "2026-03-29T16:10:49Z",
-      "pr": 13101
-    },
-    ".agents/services/communications/google-chat.md": {
-      "hash": "af2981e3fd22fa349f051dda8a12615f9fd5d65d",
-      "at": "2026-03-30T03:33:48Z",
-      "pr": 13658
-    },
-    ".agents/tools/deployment/fly-io.md": {
-      "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
-      "at": "2026-03-30T02:30:21Z",
-      "pr": 13596
-    },
-    ".agents/tools/design/brand-identity.md": {
-      "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
-      "at": "2026-03-29T16:31:32Z",
-      "pr": 13093
-    },
-    ".agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md": {
-      "hash": "a641f8d02e933160986b8c49c4f6a5245d325014",
-      "at": "2026-03-29T15:50:34Z",
-      "pr": 13064
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-      "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
-      "at": "2026-03-30T02:30:53Z",
-      "pr": 13494
-    },
-    ".agents/tools/ai-assistants/response-scoring.md": {
-      "hash": "6eadf895b9b3ea1caaf55456d25937d9152c15eb",
-      "at": "2026-03-29T15:50:37Z",
-      "pr": 13072
-    },
-    ".agents/tools/deployment/coolify-setup.md": {
-      "hash": "5041a915d0c96f4651205ed6ca0799a2d190757c",
-      "at": "2026-03-29T15:50:41Z",
-      "pr": 13067
-    },
-    ".agents/tools/vision/image-understanding.md": {
-      "hash": "e8a08b674fb1c451c0b3d2ebdc2290f860817199",
-      "at": "2026-03-29T23:53:56Z",
-      "pr": 13458
-    },
-    ".agents/marketing-sales/meta-ads-optimization-automation-rules.md": {
-      "hash": "4e78284e12f62b421b7458d171f79117bc4610e9",
-      "at": "2026-03-29T15:50:44Z",
-      "pr": 13078
-    },
-    ".agents/services/crm/fluentcrm.md": {
-      "hash": "9e0e2c55d608f6cc55ceec5f45e845bbbc841b0c",
-      "at": "2026-03-29T15:51:03Z",
-      "pr": 13048
-    },
-    ".agents/scripts/commands/pulse.md": {
-      "hash": "17825f98cccc6a5b38ed9877d2c1f493287e7a61",
-      "at": "2026-03-29T16:31:29Z",
-      "pr": 13117
-    },
-    ".agents/workflows/feature-development.md": {
-      "hash": "6b9311970a27d48d12002b62e59c9a6ac2087cc8",
-      "at": "2026-03-29T16:31:49Z",
-      "pr": 13065
-    },
-    ".agents/aidevops.md": {
-      "hash": "cf74c159d129be3c0c891b416bd45c0c11a5613b",
-      "at": "2026-03-29T16:31:51Z",
-      "pr": 13063
-    },
-    ".agents/marketing-sales/ad-creative-chapter-09.md": {
-      "hash": "2bdf7194dc300dd779d03b44a37d35015e9f282d",
-      "at": "2026-03-29T16:34:21Z",
-      "pr": 13110
-    },
-    ".agents/marketing-sales/cro-chapter-20.md": {
-      "hash": "07aa1e83fefdc10d56b044961da2976b1e693895",
-      "at": "2026-03-29T16:34:29Z",
-      "pr": 13105
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-      "hash": "dca9ceb5efbdd602847f9c0030471e543684e1a6",
-      "at": "2026-03-30T03:33:46Z",
-      "pr": 13654
-    },
-    ".agents/tools/document/docstrange.md": {
-      "hash": "3982c1885258882161976446bb94216d4e7df262",
-      "at": "2026-03-29T16:34:31Z",
-      "pr": 13102
-    },
-    ".agents/tools/mobile/app-dev-assets.md": {
-      "hash": "7c4254ecd409ec8aa9947d5ac9bb1043f89ee75c",
-      "at": "2026-03-29T16:34:32Z",
-      "pr": 13108
-    },
-    ".agents/services/communications/imessage.md": {
-      "hash": "6739eea3f16ee84c8d647388816d022bb26c6a22",
-      "at": "2026-03-30T00:32:20Z",
-      "pr": 13468
-    },
-    ".agents/tools/context/github-search.md": {
-      "hash": "526e968501aef58e8e7676ede7ab1396404a32c5",
-      "at": "2026-03-29T16:34:35Z",
-      "pr": 13106
-    },
-    ".agents/tools/voice/hyprwhspr.md": {
-      "hash": "cd50b6d85cbb4fe055191de5b27fd60418def072",
-      "at": "2026-03-29T16:34:36Z",
-      "pr": 13103
-    },
-    ".agents/tools/mobile/app-dev-notifications.md": {
-      "hash": "c414024f2e98e68e7f70531095cc1abe49cceccd",
-      "at": "2026-03-29T16:34:38Z",
-      "pr": 13111
-    },
-    ".agents/workflows/session-manager.md": {
-      "hash": "e90fb5dbed96bd48a27404dce7d7b8d60d66a053",
-      "at": "2026-03-29T23:53:41Z",
-      "pr": 13443
-    },
-    ".agents/aidevops/architecture.md": {
-      "hash": "f1d29dba0c0d676b0d00e4e5adac2d79f9aa2dd1",
-      "at": "2026-03-29T23:53:47Z",
-      "pr": 13445
-    },
-    ".agents/content/production-audio.md": {
-      "hash": "e25e6c20e39bf0e3ddecacd21aa5c1425aa997ef",
-      "at": "2026-03-30T00:32:17Z",
-      "pr": 13478
-    },
-    ".agents/workflows/bug-fixing.md": {
-      "hash": "40fa82a3220595ff946fdc60ec4a03b193032f58",
-      "at": "2026-03-29T16:34:52Z",
-      "pr": 13056
-    },
-    ".agents/business.md": {
-      "hash": "359aefa91dc7dcd75049c36dbf54965be0fc9e2c",
-      "at": "2026-03-29T16:34:54Z",
-      "pr": 13055
-    },
-    ".agents/content/heygen-skill/rules-assets.md": {
-      "hash": "eed9c26fe6697296ac16fa54421ac1d4f9d6f2fc",
-      "at": "2026-03-29T16:34:55Z",
-      "pr": 13054
-    },
-    ".agents/product/onboarding.md": {
-      "hash": "bc634e70e9bb850181c2c4c0d239a36447560921",
-      "at": "2026-03-29T23:54:00Z",
-      "pr": 13399
-    },
-    ".agents/tools/infrastructure/together.md": {
-      "hash": "cb2b6cf6c54db6f97c2bde70675f3c29b30b88fa",
-      "at": "2026-03-29T17:15:24Z",
-      "pr": 13113
-    },
-    ".agents/workflows/sql-migrations.md": {
-      "hash": "b33b92df6c10b12772797d8d75b314b69698af6e",
-      "at": "2026-03-30T06:03:19Z",
-      "pr": 13838
-    },
-    ".agents/tools/voice/qwen3-tts.md": {
-      "hash": "5e96cd787b4b8b6ae97d6f3113978c0b334e5484",
-      "at": "2026-03-29T19:05:52Z",
-      "pr": 13190
-    },
-    ".agents/marketing-sales/ad-creative-chapter-11.md": {
-      "hash": "2fbaad774769229326c549e278ffe31d26906d66",
-      "at": "2026-03-29T20:54:11Z",
-      "pr": 13222
-    },
-    ".agents/tools/vision/image-generation.md": {
-      "hash": "68fb24cbb02218008d86f1fb1381347f5ac1e533",
-      "at": "2026-03-29T19:51:31Z",
-      "pr": 13249
-    },
-    ".agents/tools/context/dspy.md": {
-      "hash": "a452d6023063a0eebf04141ae94d61a0867830da",
-      "at": "2026-03-29T20:53:49Z",
-      "pr": 13289
-    },
-    ".agents/tools/voice/ios-shortcut.md": {
-      "hash": "bf8f2ead853742819aa8ea972f3f39d7e38c58be",
-      "at": "2026-03-29T20:53:52Z",
-      "pr": 13286
-    },
-    ".agents/services/email/email-design-test.md": {
-      "hash": "216d3927030caa28089c7500c2f6b81c62897d17",
-      "at": "2026-03-29T22:09:19Z",
-      "pr": 13324
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-gotchas.md": {
-      "hash": "eb3c145850e0125035e13fd4bd424405fa4efb97",
-      "at": "2026-03-29T20:53:54Z",
-      "pr": 13291
-    },
-    ".agents/tools/mobile/ios-simulator-mcp.md": {
-      "hash": "c671f21c21913d5bc3199aaaf1ad5ea389fa67e7",
-      "at": "2026-03-29T20:53:56Z",
-      "pr": 13299
-    },
-    ".agents/tools/security/cdn-origin-ip.md": {
-      "hash": "0ffd8a94c87de9f75a5515cd4ad4e87ab4b1552b",
-      "at": "2026-03-29T20:53:57Z",
-      "pr": 13290
-    },
-    ".agents/scripts/commands/show-plan.md": {
-      "hash": "a50ab6b6bab142d6f388d385dfa6a525b458cac9",
-      "at": "2026-03-29T20:53:58Z",
-      "pr": 13285
-    },
-    ".agents/services/communications/bitchat.md": {
-      "hash": "38ac38ee1cb82fb462fc13746fbf560042e6e9a7",
-      "at": "2026-03-29T20:53:59Z",
-      "pr": 13287
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/d1-patterns.md": {
-      "hash": "8e6341f6f72cefdc4c09224910c1c4efe62de068",
-      "at": "2026-03-29T21:43:01Z",
-      "pr": 13296
-    },
-    ".agents/tools/context/context-builder.md": {
-      "hash": "27fb0c83ee803a7eebb4ace6202875b0a844786b",
-      "at": "2026-03-29T20:54:03Z",
-      "pr": 13297
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md": {
-      "hash": "79456bef17217d0052079264a0c95b59456d5385",
-      "at": "2026-03-29T21:43:04Z",
-      "pr": 13300
-    },
-    ".agents/tools/git/opencode-gitlab.md": {
-      "hash": "dbbdec9a030f52229eab4d047431f4ed5b0de5ca",
-      "at": "2026-03-29T20:54:06Z",
-      "pr": 13295
-    },
-    ".agents/marketing-sales/cro-chapter-01.md": {
-      "hash": "5dad243a2a5744924aeb5b2e39fe94aad887af5e",
-      "at": "2026-03-29T20:54:07Z",
-      "pr": 13294
-    },
-    ".agents/seo/programmatic-seo.md": {
-      "hash": "246454e374da68bf1dcec5b59e732fac3841e7dd",
-      "at": "2026-03-29T21:43:09Z",
-      "pr": 13301
-    },
-    ".agents/tools/mobile/app-dev-backend.md": {
-      "hash": "1521ed7526fbc0fb399a1f5edf01adb4129a08f6",
-      "at": "2026-03-29T20:54:10Z",
-      "pr": 13293
-    },
-    ".agents/marketing-sales/meta-ads-campaigns-scaling-cbo.md": {
-      "hash": "6fb79b1689e522f77f09f4398f80430c8c727116",
-      "at": "2026-03-29T21:42:59Z",
-      "pr": 13263
-    },
-    ".agents/marketing-sales/meta-ads-foundations-account-structure.md": {
-      "hash": "d8a1a11c970efd832edd47784162978ad05783f0",
-      "at": "2026-03-29T21:43:00Z",
-      "pr": 13333
-    },
-    ".agents/tools/video/remotion-measuring-text.md": {
-      "hash": "619d768e114ab99f64b37c93d1628ae5cb7d54a4",
-      "at": "2026-03-29T21:43:06Z",
-      "pr": 13315
-    },
-    ".agents/marketing-sales/cro-chapter-17.md": {
-      "hash": "55117c563ab956b0653eca2c335a7e8c14e15708",
-      "at": "2026-03-29T21:43:12Z",
-      "pr": 13339
-    },
-    ".agents/scripts/commands/dashboard.md": {
-      "hash": "c72021fe5b7c20c340b5a5a1e1b66cf6b3d247f9",
-      "at": "2026-03-29T21:43:13Z",
-      "pr": 13338
-    },
-    ".agents/services/email/email-security.md": {
-      "hash": "933383c81c9e820f3d3b80f5dbd3db61d496e0cb",
-      "at": "2026-03-29T21:43:14Z",
-      "pr": 13343
-    },
-    ".agents/tools/mobile/minisim.md": {
-      "hash": "4e237b094b421f7ff8557426808fd3d6380b4ef1",
-      "at": "2026-03-29T21:43:16Z",
-      "pr": 13340
-    },
-    ".agents/tools/security/tamper-evident-audit.md": {
-      "hash": "ef75d5914e0ae15e449ccd4480b0add3eda84c71",
-      "at": "2026-03-29T21:43:17Z",
-      "pr": 13316
-    },
-    ".agents/tools/vision/image-editing.md": {
-      "hash": "1b91142d29e8ff6515be5a6208386de1fcaf383d",
-      "at": "2026-03-29T21:43:18Z",
-      "pr": 13236
-    },
-    ".agents/business/accounts-subscription-audit.md": {
-      "hash": "ef31fbb7ef1c8e43fc6f5e6ff3f7bed9b5b0e3a0",
-      "at": "2026-03-29T21:43:19Z",
-      "pr": 13235
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workflows-gotchas.md": {
-      "hash": "f9b10b21adc0e823054085098ba86a6e8432ade1",
-      "at": "2026-03-29T21:43:20Z",
-      "pr": 13342
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workflows-patterns.md": {
-      "hash": "7b01531e7d09b10fc7ab3a1706498fd011b6bb1b",
-      "at": "2026-03-29T21:43:21Z",
-      "pr": 13342
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workflows.md": {
-      "hash": "5faeef07292125f8b45b6b29bc0b24d06d24c1f1",
-      "at": "2026-03-29T21:43:21Z",
-      "pr": 13342
-    },
-    ".agents/tools/infrastructure/cloud-gpu.md": {
-      "hash": "f2b2d82030ffec23c21ca82c2833ba2cbac2dcc9",
-      "at": "2026-03-29T21:43:22Z",
-      "pr": 13346
-    },
-    ".agents/tools/mcp/cloudflare-code-mode.md": {
-      "hash": "57f7a7876d43b24c1a40f59332c004b5932adae1",
-      "at": "2026-03-29T23:54:08Z",
-      "pr": 13428
-    },
-    ".agents/tools/video/remotion-compositions.md": {
-      "hash": "6b00afa2299a8d08eaacd114c67804f6d87614b1",
-      "at": "2026-03-29T23:18:01Z",
-      "pr": 13427
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/kv-patterns.md": {
-      "hash": "7637914de409bb05cee56b57db714972a922dbbb",
-      "at": "2026-03-29T22:09:11Z",
-      "pr": 13321
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi-patterns.md": {
-      "hash": "98b6e10081c4b00014ad525bb96a33a62b6f90a0",
-      "at": "2026-03-29T22:09:12Z",
-      "pr": 13329
-    },
-    ".agents/tools/video/remotion-gifs.md": {
-      "hash": "c87be7656e27afb4f5f23e41571f8428b21345c4",
-      "at": "2026-03-29T22:09:13Z",
-      "pr": 13322
-    },
-    ".agents/seo/seo-regex.md": {
-      "hash": "b38e6b1002b80227940c036badb462c8add23514",
-      "at": "2026-03-29T22:09:17Z",
-      "pr": 13325
-    },
-    ".agents/tools/code-review/codacy.md": {
-      "hash": "3f41e7f2f15e10bf934568ea6ff485cd64ce88c3",
-      "at": "2026-03-29T22:09:31Z",
-      "pr": 13314
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md": {
-      "hash": "213bbe9f8924a85a7f616e9ceb2b50e89fd609d4",
-      "at": "2026-03-31T05:42:16Z",
-      "pr": 14662
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
-      "hash": "7f8943efbe9c5d05b7ecba869a866d6020b95928",
-      "at": "2026-04-01T20:59:18Z",
-      "pr": 15150
-    },
-    ".agents/tools/browser/extension-dev.md": {
-      "hash": "5d6ac2671414bfdce4481294fce9019711d28c01",
-      "at": "2026-03-29T22:09:34Z",
-      "pr": 13330
-    },
-    ".agents/tools/browser/sweet-cookie.md": {
-      "hash": "763a36ee928e5c54bafe10a5659c75c4c73f42df",
-      "at": "2026-03-29T22:09:35Z",
-      "pr": 13328
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-gotchas.md": {
-      "hash": "d41799c696aa6515cb523c0b17316ed13d17d2ee",
-      "at": "2026-03-29T22:09:42Z",
-      "pr": 13253
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md": {
-      "hash": "1e5cf033ce0af2ba18bc9e38ca48bd69cf3455bc",
-      "at": "2026-03-29T22:09:43Z",
-      "pr": 13254
-    },
-    ".agents/tools/context/model-routing.md": {
-      "hash": "43703f91e6cc11180bbf13a86e6d92333b1ca9db",
-      "at": "2026-03-29T22:09:44Z",
-      "pr": 13255
-    },
-    ".agents/product/analytics.md": {
-      "hash": "1ecb5ce4743770c3913fae8f41e526f3ba21c6a0",
-      "at": "2026-03-29T23:53:58Z",
-      "pr": 13415
-    },
-    ".agents/tools/programming/modern-javascript-skill/concurrency.md": {
-      "hash": "deb11f58b2c60571e4a7b98a2bb503f094a0b1e0",
-      "at": "2026-03-29T22:50:16Z",
-      "pr": 13349
-    },
-    ".agents/workflows/release.md": {
-      "hash": "090cc22dc1f270acad6e33d46bef835d457661eb",
-      "at": "2026-03-29T22:51:16Z",
-      "pr": 13318
-    },
-    ".agents/content/optimization.md": {
-      "hash": "326ff8a42a6e84736e5f70fc2f569119e04c9fa5",
-      "at": "2026-03-29T23:18:03Z",
-      "pr": 13425
-    },
-    ".agents/tools/ai-orchestration/autogen.md": {
-      "hash": "590a04f8f8f9073b304f6538e550f335e08ffd62",
-      "at": "2026-03-30T02:54:16Z",
-      "pr": 13600
-    },
-    ".agents/tools/code-review/security-analysis.md": {
-      "hash": "81663c87a7964c1938d704dd3698d51a4910621a",
-      "at": "2026-03-30T00:32:18Z",
-      "pr": 13467
-    },
-    ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
-      "hash": "b875488af36564292b08b0bcfabae97d18757135",
-      "at": "2026-03-29T23:53:50Z",
-      "pr": 13444
-    },
-    ".agents/tools/architecture/feature-slicing-skill/migration.md": {
-      "hash": "b399eacef76e87bedfd8da058f9c0b1707ffde13",
-      "at": "2026-03-30T00:32:19Z",
-      "pr": 13466
-    },
-    ".agents/marketing-sales/cro-chapters.md": {
-      "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
-      "at": "2026-03-30T00:32:32Z",
-      "pr": 13457
-    },
-    ".agents/workflows/wiki-update.md": {
-      "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
-      "at": "2026-03-30T02:30:16Z",
-      "pr": 13594
-    },
-    ".agents/marketing-sales/direct-response-copy.md": {
-      "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
-      "at": "2026-03-30T02:30:17Z",
-      "pr": 13597
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
-      "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
-      "at": "2026-03-30T02:30:18Z",
-      "pr": 13595
-    },
-    ".agents/services/email/email-health-check.md": {
-      "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
-      "at": "2026-03-30T02:30:20Z",
-      "pr": 13593
-    },
-    ".agents/tools/git/authentication.md": {
-      "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
-      "at": "2026-03-30T02:30:25Z",
-      "pr": 13538
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
-      "hash": "91b339029c6582618e5664e5c11ba08bbb75af7e",
-      "at": "2026-03-30T02:54:22Z",
-      "pr": 13564
-    },
-    ".agents/services/hosting/dns-providers.md": {
-      "hash": "979b0b76e50549adb87fc58efdd0b8d4d7cfed49",
-      "at": "2026-03-30T03:33:45Z",
-      "pr": 13668
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/queues-patterns.md": {
-      "hash": "5365c2251880bae2876aac89ff39f1dd909a2a0e",
-      "at": "2026-03-30T04:51:49Z",
-      "pr": 13735
-    },
-    ".agents/seo/moondream.md": {
-      "hash": "e6e0bef21020b260c31561b4da9fc0ef1e900be5",
-      "at": "2026-03-30T03:33:44Z",
-      "pr": 13663
-    },
-    ".agents/marketing-sales/meta-ads-foundations-glossary.md": {
-      "hash": "f0b0b3b259d7597309af03f39a2f267137dafffe",
-      "at": "2026-03-30T03:33:50Z",
-      "pr": 13691
-    },
-    ".agents/services/email/email-providers.md": {
-      "hash": "e8a96e186a02ff72e77c408a3262dfd2b0012d84",
-      "at": "2026-03-30T06:49:37Z",
-      "pr": 13859
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md": {
-      "hash": "70e97040812ad2c593e7b451a917560531eb5903",
-      "at": "2026-03-30T03:33:53Z",
-      "pr": 13667
-    },
-    ".agents/marketing-sales/meta-ads-checklists-creative-review.md": {
-      "hash": "d3207ef474ba73d95bb9c13864b282ac0b78169e",
-      "at": "2026-03-30T03:33:54Z",
-      "pr": 13666
-    },
-    ".agents/marketing-sales.md": {
-      "hash": "0b4144452b197dae7edbfcf3a5452752d3b2fe10",
-      "at": "2026-03-30T06:03:16Z",
-      "pr": 13839
-    },
-    ".agents/services/email/smime-setup.md": {
-      "hash": "f83bb719e349bb600df046eccc7c1c5603c330f0",
-      "at": "2026-03-30T06:50:00Z",
-      "pr": 13915
-    },
-    ".agents/tools/browser/browser-automation.md": {
-      "hash": "cbb6d3a24484eb81a5294657ce14d8737e131243",
-      "at": "2026-03-30T04:51:56Z",
-      "pr": 13719
-    },
-    ".agents/tools/browser/extension-dev/testing.md": {
-      "hash": "57d5dc456ab9a6e1d10416777117b96a09cc4f14",
-      "at": "2026-03-30T04:51:57Z",
-      "pr": 13717
-    },
-    ".agents/reference/settings.md": {
-      "hash": "2b2cbc9b8329f0fd0504413c4805a235d0f16962",
-      "at": "2026-03-30T03:34:12Z",
-      "pr": 13637
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
-      "hash": "2cbb9c1c836f4b8fce6dbe5b982d8760a75922ce",
-      "at": "2026-03-30T03:34:13Z",
-      "pr": 13636
-    },
-    ".agents/tools/mobile/app-dev-expo.md": {
-      "hash": "e0094f52acaa98cc6a2c7aa9aeae6321a204cb27",
-      "at": "2026-03-30T03:34:14Z",
-      "pr": 13609
-    },
-    ".agents/tools/video/remotion-images.md": {
-      "hash": "789b0f83404d30882f5f6b24317d4319f95dd107",
-      "at": "2026-03-30T03:34:15Z",
-      "pr": 13527
-    },
-    ".agents/seo.md": {
-      "hash": "1dcd30f4590e4b2b7792e538d0a70e7d4979aa8e",
-      "at": "2026-03-30T03:34:16Z",
-      "pr": 13526
-    },
-    ".agents/seo/mom-test-ux.md": {
-      "hash": "29c796f48c4b581197f9ea36ed95bbe98bb4ae51",
-      "at": "2026-03-30T03:34:17Z",
-      "pr": 13524
-    },
-    ".agents/seo/tech-stack.md": {
-      "hash": "8b3aa2ab4498e38424d9bd911680bf2e6d45d856",
-      "at": "2026-03-30T03:34:18Z",
-      "pr": 13531
-    },
-    ".agents/tools/mobile/maestro.md": {
-      "hash": "9cfba2015ca5bd40086f5d15c690910a0a3c6bfd",
-      "at": "2026-03-30T03:34:20Z",
-      "pr": 13525
-    },
-    ".agents/content/video-real-video-enhancer.md": {
-      "hash": "3a1c798089a1fa50288b76e5fd372fe57d4307d5",
-      "at": "2026-03-30T03:34:21Z",
-      "pr": 13533
-    },
-    ".agents/seo/image-seo.md": {
-      "hash": "91991eb82fa32f9ed717213566d5bb49604dfdc4",
-      "at": "2026-03-30T03:34:23Z",
-      "pr": 13530
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/terraform-patterns.md": {
-      "hash": "463f5c3efbf7a6b11c29193e5f6dcbefd1974fc2",
-      "at": "2026-03-30T03:34:24Z",
-      "pr": 13534
-    },
-    ".agents/services/communications/slack.md": {
-      "hash": "4894b60910b9fe85ce8dcfb7feb5441fca48be44",
-      "at": "2026-03-30T03:34:27Z",
-      "pr": 13545
-    },
-    ".agents/tools/research/providers/crft-lookup.md": {
-      "hash": "70a64dd60d9a32431e5c36f75d0ad6aed1865c46",
-      "at": "2026-03-30T03:34:28Z",
-      "pr": 13542
-    },
-    ".agents/product/ui-design.md": {
-      "hash": "3a8d0daebe80ebc2f64efe31009dbcba324fe142",
-      "at": "2026-03-30T03:34:29Z",
-      "pr": 13539
-    },
-    ".agents/content/VERIFICATION.md": {
-      "hash": "f0090056bf6625c2ce2c676d4cf9ba25a901198e",
-      "at": "2026-03-30T03:34:30Z",
-      "pr": 13540
-    },
-    ".agents/scripts/commands/yt-dlp.md": {
-      "hash": "56c400042f899284be4b65c6480fcac4de404248",
-      "at": "2026-03-30T03:34:31Z",
-      "pr": 13544
-    },
-    ".agents/tools/monorepo/turborepo.md": {
-      "hash": "06d5be33d317a334e024bd36af9aebe2b84a2a38",
-      "at": "2026-03-30T06:49:45Z",
-      "pr": 13795
-    },
-    ".agents/services/email/email-composition.md": {
-      "hash": "56336d402a38bf2eaa4d3bb6eebb2ad4dd5cfae7",
-      "at": "2026-03-30T06:03:17Z",
-      "pr": 13837
-    },
-    ".agents/marketing-sales/meta-ads-optimization-metrics.md": {
-      "hash": "99cca533a9d716bf886a24bffbf8255ca5da96a3",
-      "at": "2026-03-30T06:49:39Z",
-      "pr": 13940
-    },
-    ".agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md": {
-      "hash": "172840cdbbde2f855e1e9750119b46033ee505c7",
-      "at": "2026-03-30T04:51:54Z",
-      "pr": 13768
-    },
-    ".agents/services/document-processing/unstract.md": {
-      "hash": "23759f7d870be0bbd07442ac06a3d7b069c8984b",
-      "at": "2026-03-30T04:51:58Z",
-      "pr": 13720
-    },
-    ".agents/tools/api/drizzle.md": {
-      "hash": "401b78e13d0649ed4df01e6f3a4ed5a2ffddc55d",
-      "at": "2026-03-30T04:52:00Z",
-      "pr": 13718
-    },
-    ".agents/marketing-sales/ad-creative-video-ugc.md": {
-      "hash": "695a2da0afc79acc4e203ead505b0bc768c6237a",
-      "at": "2026-03-30T04:52:01Z",
-      "pr": 13723
-    },
-    ".agents/marketing-sales/meta-ads-creative-psychology.md": {
-      "hash": "6436f438f568834b0e2062a282cce59cc65ec58d",
-      "at": "2026-03-30T04:52:02Z",
-      "pr": 13729
-    },
-    ".agents/tools/browser/extension-dev/development.md": {
-      "hash": "80547436b58e3fd8fb2ce9ab44cfaecedcb32ec3",
-      "at": "2026-03-30T04:52:04Z",
-      "pr": 13722
-    },
-    ".agents/tools/deployment/coolify-cli.md": {
-      "hash": "bceeb18bd221b65e03b4fa7ec3633091a8ee57e2",
-      "at": "2026-03-30T04:52:05Z",
-      "pr": 13734
-    },
-    ".agents/tools/ui/react-context.md": {
-      "hash": "dee0f2d9a70f699ee8e09bc3c855e84eabb9a806",
-      "at": "2026-03-30T06:49:50Z",
-      "pr": 13766
-    },
-    ".agents/marketing-sales/meta-ads-foundations-algorithm.md": {
-      "hash": "318e59fc49106e5aaeeca2d26e666b87b0353d5c",
-      "at": "2026-04-01T20:59:13Z",
-      "pr": 15138
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md": {
-      "hash": "a0b18de39a54d95b1d687b669e01308b2333655f",
-      "at": "2026-03-30T06:49:26Z",
-      "pr": 13938
-    },
-    ".agents/tools/containers/remote-dispatch.md": {
-      "hash": "10ae5781c8f1ecb06c7d4d562c2f915b32f2deec",
-      "at": "2026-03-30T04:52:23Z",
-      "pr": 13733
-    },
-    ".agents/content/humanise.md": {
-      "hash": "898870a22cb4b4cf0153c907ab974792857e41c8",
-      "at": "2026-03-30T06:03:20Z",
-      "pr": 13836
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md": {
-      "hash": "dd47fcc7b562ecb9f085d0d7394553810ecabc8c",
-      "at": "2026-03-30T04:52:39Z",
-      "pr": 13784
-    },
-    ".agents/marketing-sales/meta-ads-campaigns-advantage-plus.md": {
-      "hash": "e2a2dc5e7f15a6ce3fdcf4e477dac3ca7db3056f",
-      "at": "2026-03-30T04:52:40Z",
-      "pr": 13779
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/stream-patterns.md": {
-      "hash": "f45d2973f1a08cfb71a1b4e0c66e73895737d463",
-      "at": "2026-03-30T06:03:15Z",
-      "pr": 13844
-    },
-    ".agents/tools/ai-orchestration/langflow.md": {
-      "hash": "9010935d83c2b8113ae0c32b3d4f7eb7ee720b06",
-      "at": "2026-03-30T06:49:09Z",
-      "pr": 13930
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
-      "hash": "be2d56c6fe66266362fd66f78066478f683491cf",
-      "at": "2026-03-30T06:49:10Z",
-      "pr": 13929
-    },
-    ".agents/content/video-higgsfield-ui.md": {
-      "hash": "bba81f4fdf2dc1e94cfa231418a3687dc2a2a324",
-      "at": "2026-03-30T06:49:12Z",
-      "pr": 13932
-    },
-    ".agents/tools/context/context-guardrails.md": {
-      "hash": "35328fa309512f8dc6c77afee69bd1f6068b9e45",
-      "at": "2026-03-30T06:49:16Z",
-      "pr": 13956
-    },
-    ".agents/tools/ui/ai-chat-sidebar.md": {
-      "hash": "c01e259c3def32f858b6c96f752a2c21070567e9",
-      "at": "2026-03-30T06:49:20Z",
-      "pr": 13958
-    },
-    "TODO.md": {
-      "hash": "9e296aaac5ac00cb7ad14c8de7e5c6b1930b1184",
-      "at": "2026-04-02T04:56:51Z",
-      "pr": 15490
-    },
-    ".agents/content/heygen-skill/rules-webhooks.md": {
-      "hash": "c3ba360303dc273741e6f76b2f235b8319f78734",
-      "at": "2026-03-30T06:49:23Z",
-      "pr": 13942
-    },
-    ".agents/tools/browser/chrome-webstore-release.md": {
-      "hash": "7d789fec3b99cc63f2dc9033a798921b9f7f2233",
-      "at": "2026-03-30T06:49:23Z",
-      "pr": 13942
-    },
-    ".agents/seo/google-search-console.md": {
-      "hash": "525712f74fe9ec13980ef0564a2108481e894038",
-      "at": "2026-03-30T06:49:36Z",
-      "pr": 13900
-    },
-    ".agents/services/hosting/proxmox-full-skill.md": {
-      "hash": "23bcf676fc5edd9dcfebc3fb07b0d4ed6cb61a19",
-      "at": "2026-03-30T06:49:37Z",
-      "pr": 13859
-    },
-    ".agents/tools/ocr/paddleocr.md": {
-      "hash": "7e0aaf06abd6c0d64ef0645a3cd58ac02b9e11f4",
-      "at": "2026-03-30T06:49:51Z",
-      "pr": 13765
-    },
-    ".agents/workflows/mission-orchestrator.md": {
-      "hash": "930d59836f65199231e8354401053a66b0637281",
-      "at": "2026-03-30T06:49:53Z",
-      "pr": 13841
-    },
-    ".agents/marketing-sales/cro-chapter-08.md": {
-      "hash": "b17c73481de18eb0ad983703fbcae8b5b7e93c98",
-      "at": "2026-03-30T06:49:54Z",
-      "pr": 13773
-    },
-    ".agents/reference/entity-memory-architecture.md": {
-      "hash": "bbd1c42b7e0eb2b01cb5a193f94c5e9ecf98c540",
-      "at": "2026-04-02T00:00:00Z",
-      "pr": 15488
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
-      "hash": "102c82fd40a93f9e219e84ee053645eff00db29b",
-      "at": "2026-03-31T03:46:07Z",
-      "pr": 14541
-    },
-    ".agents/reference/agent-routing.md": {
-      "hash": "83e56233f5c7fc633bc3a64de90d9b5529a0bd33",
-      "at": "2026-03-31T05:34:14Z",
-      "pr": 14650
-    },
-    ".agents/marketing-sales/meta-ads-creative-briefs-founder-video-brief.md": {
-      "hash": "a4bf29e5b45891eeb157e02f740965cd3370cb9d",
-      "at": "2026-03-31T06:30:29Z",
-      "pr": 14701
-    },
-    ".agents/tools/vision/overview.md": {
-      "hash": "5abddf3f89fc529bd3119b8ae147961451728199",
-      "at": "2026-04-01T20:59:38Z",
-      "pr": 14932
-    },
-    ".agents/tools/ai-assistants/datasets.md": {
-      "hash": "8b525467afaf93fea7539e9f47fabf2159254ae1",
-      "at": "2026-04-02T12:00:00Z",
-      "pr": 15336
-    },
-    ".agents/tools/automation/mac.md": {
-      "hash": "1dc19ae4b63343bb6f8a397a6f7e824655e2f986",
-      "at": "2026-04-01T20:58:52Z",
-      "pr": 15253
-    },
-    ".agents/scripts/commands/list-verify.md": {
-      "hash": "dc43be77f9d72dac6880004350a5b63ce9a326f0",
-      "at": "2026-04-02T04:56:43Z",
-      "pr": 15514
-    },
-    ".agents/scripts/commands/budget-analysis.md": {
-      "hash": "ac77aaf850ecc1f9cee81c9e04a026a954fc7359",
-      "at": "2026-04-01T20:58:50Z",
-      "pr": 15257
-    },
-    "todo/tasks/t15173-brief.md": {
-      "hash": "41ca6c208c2f6e8349d73a1ec55e0a26fd26f974",
-      "at": "2026-04-01T20:58:50Z",
-      "pr": 15257
-    },
-    ".agents/health.md": {
-      "hash": "301b928aef5da6cc3a1dbb353077bfbab47af315",
-      "at": "2026-04-01T20:58:58Z",
-      "pr": 15249
-    },
-    ".agents/tools/ai-assistants/models-README.md": {
-      "hash": "0fe4c51c744b0e1ee3081af1b83ca6c66229a4a4",
-      "at": "2026-04-01T20:58:59Z",
-      "pr": 15227
-    },
-    ".agents/tools/ai-assistants/claude-code.md": {
-      "hash": "dd9666e19eb7e98df75856dd477ecf7ceebf147a",
-      "at": "2026-04-01T20:59:01Z",
-      "pr": 15204
-    },
-    ".agents/aidevops/self-improving-agents.md": {
-      "hash": "8e8dc0f8fa3a1a502130a64f217de014a5b14161",
-      "at": "2026-04-01T20:59:02Z",
-      "pr": 15203
-    },
-    ".agents/workflows/branch/hotfix.md": {
-      "hash": "e1c1f9099b46c798fe473a7c23ff01bfa8e26b70",
-      "at": "2026-04-01T20:59:04Z",
-      "pr": 15209
-    },
-    ".agents/tools/mobile/app-dev-testing.md": {
-      "hash": "39d2e16ec10aee6ed51d5a9b586e20ac0ba4276a",
-      "at": "2026-04-01T20:59:09Z",
-      "pr": 15219
-    },
-    ".agents/marketing-sales/cro-chapter-18.md": {
-      "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
-      "at": "2026-04-01T20:59:11Z",
-      "pr": 15220
-    },
-    ".agents/marketing-sales/cro-chapter-02.md": {
-      "hash": "8226a4d2cd57afce1746318203d9c357540010c2",
-      "at": "2026-04-01T20:59:14Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/cro-chapter-02/01-conversion-rate-formulas.md": {
-      "hash": "3ffbf75893700060301c26dd5fd2c63e6743bddc",
-      "at": "2026-04-01T20:59:14Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/cro-chapter-02/02-psychology-of-conversion.md": {
-      "hash": "497b1a2f35082225ace6ac18531c3b83d25fd39f",
-      "at": "2026-04-01T20:59:14Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/cro-chapter-02/03-conversion-funnel.md": {
-      "hash": "20a9a226559ee7acc643d4b1b73a44d3f735e87d",
-      "at": "2026-04-01T20:59:14Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/cro-chapter-02/04-attribution-models.md": {
-      "hash": "48f7749c53ee973531130209345c214c0d77b181",
-      "at": "2026-04-01T20:59:15Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/cro-chapter-02/05-website-elements.md": {
-      "hash": "786c51eec79c4098d2034c43c8dd98c1077043e0",
-      "at": "2026-04-01T20:59:15Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/cro-chapter-02/06-conversion-friction.md": {
-      "hash": "60a0019275f9e3b20f3e9dba68b8d52f6782199c",
-      "at": "2026-04-01T20:59:15Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/cro-chapter-02/07-data-foundation.md": {
-      "hash": "58055a16f3affa58e9372abe6c4108cc7d0b196c",
-      "at": "2026-04-01T20:59:15Z",
-      "pr": 15223
-    },
-    "todo/tasks/t1737-brief.md": {
-      "hash": "e33e6f68fa6cdb89368aa5ec65bd3e1bc880ba67",
-      "at": "2026-04-01T20:59:15Z",
-      "pr": 15223
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-06-ramit-sethi-launch.md": {
-      "hash": "5f82f7b17f7fde8daeb703ca4c3cdcef53620c2f",
-      "at": "2026-04-01T20:59:17Z",
-      "pr": 15150
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-07-saas-trial-expiry.md": {
-      "hash": "541a34d7b2649c4e93f494af26bb412731aace9e",
-      "at": "2026-04-01T20:59:17Z",
-      "pr": 15150
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-08-cart-abandonment.md": {
-      "hash": "2c4d31ad777c8c70b5293c3fd75e4e6af67b4654",
-      "at": "2026-04-01T20:59:17Z",
-      "pr": 15150
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-09-webinar-invite.md": {
-      "hash": "5dd410cda93d3056b39408c537fb3c9b1e1e06da",
-      "at": "2026-04-01T20:59:17Z",
-      "pr": 15150
-    },
-    ".agents/marketing-sales/meta-ads-checklists-campaign-launch.md": {
-      "hash": "3f199a8eb517a651781b683ec0d6a723fb16d9b0",
-      "at": "2026-04-01T20:59:20Z",
-      "pr": 15149
-    },
-    ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "168f91548a0d85a33e1d6ad048ae9f827038c9ec",
-      "at": "2026-04-02T03:11:26Z",
-      "pr": 15086
-    },
-    ".agents/tools/programming/modern-javascript-skill.md": {
-      "hash": "3c3730959a3c618e3b3ed96d1ccd5eb95c2bfe3b",
-      "at": "2026-04-01T20:59:25Z",
-      "pr": 15131
-    },
-    ".agents/tools/programming/modern-javascript-skill/01-decision-trees.md": {
-      "hash": "80190196c391d4314e034455e46fe218d57d1c58",
-      "at": "2026-04-01T20:59:25Z",
-      "pr": 15131
-    },
-    ".agents/tools/programming/modern-javascript-skill/02-es-versions.md": {
-      "hash": "8c9215cc4697a3cd21125445386a8315acb42e0d",
-      "at": "2026-04-01T20:59:25Z",
-      "pr": 15131
-    },
-    ".agents/scripts/commands/security-deps.md": {
-      "hash": "265f2d26f358ffb425e374dca8aa76a7c20c3565",
-      "at": "2026-04-01T20:59:27Z",
-      "pr": 14994
-    },
-    ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
-      "hash": "ab1f9c5d69340fa7acfd756c2ae37710b9fa600c",
-      "at": "2026-04-01T20:59:28Z",
-      "pr": 14996
-    },
-    ".agents/research.md": {
-      "hash": "b509e2fae5168065f0142ae29dca1ec2d410c53b",
-      "at": "2026-04-01T20:59:28Z",
-      "pr": 14996
-    },
-    ".agents/workflows/mission-skill-learning.md": {
-      "hash": "dd665af8ed215a57226bbb176cee5ee5a552ee65",
-      "at": "2026-04-01T20:59:28Z",
-      "pr": 14996
-    },
-    "todo/tasks/GH-14990-brief.md": {
-      "hash": "05e0636373c9b4574f9b289b7e75180281b462e4",
-      "at": "2026-04-01T20:59:29Z",
-      "pr": 14996
-    },
-    ".agents/prompts/worker-efficiency-protocol.md": {
-      "hash": "b601e50f903b0b94e2a1021a296e595f350e85f1",
-      "at": "2026-04-01T20:59:34Z",
-      "pr": 14943
-    },
-    ".agents/scripts/commands/venv-health.md": {
-      "hash": "bbcc15a86e165230f04159f127a8dc6a52160b30",
-      "at": "2026-04-01T20:59:35Z",
-      "pr": 14968
-    },
-    ".agents/seo/ai-search-kpi-template.md": {
-      "hash": "b750815aa689ad99b32c355078ef3d168b489789",
-      "at": "2026-04-01T20:59:36Z",
-      "pr": 14969
-    },
-    ".agents/tools/ai-assistants/models-sonnet.md": {
-      "hash": "035dfbf3d02fc552dd1f4dab55ea1bf70331e2b1",
-      "at": "2026-04-01T20:59:40Z",
-      "pr": 14913
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
-      "hash": "a87bdad3db117a280177a98592d12acba7a2e676",
-      "at": "2026-04-01T20:59:42Z",
-      "pr": 14916
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
-      "hash": "c0c080bb82f1488a996f7cf50c231ac89179bc6f",
-      "at": "2026-04-01T20:59:44Z",
-      "pr": 14914
-    },
-    ".agents/scripts/commands/list-todo.md": {
-      "hash": "351180b6d47cacee5be38fc9e3ec01f7d1fd8661",
-      "at": "2026-04-01T20:59:47Z",
-      "pr": 14898
-    },
-    ".agents/tools/video/remotion-3d.md": {
-      "hash": "054778cef20067cd0e02cbd7b049333f562e6e4a",
-      "at": "2026-04-01T20:59:48Z",
-      "pr": 14897
-    },
-    ".agents/services/monitoring/socket.md": {
-      "hash": "788506798f5a1eedd29bb5d84aaa61a758c1acd8",
-      "at": "2026-04-01T20:59:50Z",
-      "pr": 14896
-    },
-    ".agents/tools/deployment/cloudron-app-packaging-skill.md": {
-      "hash": "0895bca6f21b082551b21fa7765569599eb36e95",
-      "at": "2026-04-01T20:59:51Z",
-      "pr": 14880
-    },
-    ".agents/tools/video/remotion-timing.md": {
-      "hash": "6213ebf1e87a77cab44febc35ec0a3b10fd2db4c",
-      "at": "2026-04-01T20:59:53Z",
-      "pr": 14881
-    },
-    ".agents/tools/video/remotion-transitions.md": {
-      "hash": "f643aa12a96105bd68286a55958c88444a7d235e",
-      "at": "2026-04-01T20:59:54Z",
-      "pr": 14883
-    },
-    ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md": {
-      "hash": "4c6d024fd0bd6ab3cbc9881e5cd83bd7dec582e4",
-      "at": "2026-04-01T21:00:01Z",
-      "pr": 14853
-    },
-    ".agents/tools/browser/curl-copy.md": {
-      "hash": "134632d988b4e18e35f9e3c90106391f8461c114",
-      "at": "2026-04-01T21:56:13Z",
-      "pr": null
-    },
-    ".agents/marketing-sales/cro-chapter-11.md": {
-      "hash": "be3bf907be217b866da1d7990427e4fc1c925971",
-      "at": "2026-04-01T22:00:00Z",
-      "pr": 14514
-    },
-    ".agents/tools/git/lumen.md": {
-      "hash": "4a2b4339feef8da5578b029993d870a6416758b7",
-      "at": "2026-04-01T23:23:19Z",
-      "pr": 15327
-    },
-    ".agents/tools/document/extraction-workflow.md": {
-      "hash": "ff97788918db3fac18f34e7b0f3d18155d449e88",
-      "at": "2026-04-01T23:23:22Z",
-      "pr": 15350
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/01-ai-code-execution.md": {
-      "hash": "01137638b886f973e7f633159da5b9dc457c2416",
-      "at": "2026-04-01T23:23:23Z",
-      "pr": 15353
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/02-interactive-dev-environment.md": {
-      "hash": "fc0ae968ea17a236a2c90214346e4470cad649b4",
-      "at": "2026-04-01T23:23:23Z",
-      "pr": 15353
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/03-ci-cd-pipeline.md": {
-      "hash": "63d67404bc099cb3243761e2eeb3881a4f969c68",
-      "at": "2026-04-01T23:23:24Z",
-      "pr": 15353
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/04-multi-language-code-runner.md": {
-      "hash": "c618c5137724952005c49df413fd5c2170209d83",
-      "at": "2026-04-01T23:23:24Z",
-      "pr": 15353
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/05-multi-tenant.md": {
-      "hash": "e1d23e98d87b8e8ae9635d954951a70abe88fd57",
-      "at": "2026-04-01T23:23:24Z",
-      "pr": 15353
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/06-jupyter-integration.md": {
-      "hash": "a7a4b85da6e8ebad5549cbb830bf9aa146b9d204",
-      "at": "2026-04-01T23:23:24Z",
-      "pr": 15353
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/07-git-operations.md": {
-      "hash": "1610dca7b04c68ad219a4daa34c788dbed864aa2",
-      "at": "2026-04-01T23:23:24Z",
-      "pr": 15353
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md": {
-      "hash": "d4f5f41aaab3a18b3ba154884526869bcf0b1efe",
-      "at": "2026-04-01T23:23:38Z",
-      "pr": 15335
-    },
-    ".agents/reference/define-probes/bugfix.md": {
-      "hash": "88ddddb0fc275f73407b492a820bd0f2bfdada99",
-      "at": "2026-04-01T23:23:39Z",
-      "pr": 15334
-    },
-    ".agents/reference/auto-update.md": {
-      "hash": "0db7d0a5ebb60bf53cbeb2d88102be373220981c",
-      "at": "2026-04-01T23:23:47Z",
-      "pr": 15301
-    },
-    ".agents/reference/contribution-watch.md": {
-      "hash": "77b53dc6bf630c7451cc69425d06aa11f23e727b",
-      "at": "2026-04-01T23:23:47Z",
-      "pr": 15301
-    },
-    ".agents/reference/repo-sync.md": {
-      "hash": "e6c2ddc65a495825740608c7c440f8ba49033db5",
-      "at": "2026-04-01T23:23:47Z",
-      "pr": 15301
-    },
-    ".agents/reference/services.md": {
-      "hash": "85309d5014421182d0c22812ec7bb56f2ccc2ab0",
-      "at": "2026-04-01T23:23:47Z",
-      "pr": 15301
-    },
-    "aidevops.sh": {
-      "hash": "612281685856997848a5bf3f023e563a1bb8780c",
-      "at": "2026-04-02T04:56:57Z",
-      "pr": 15470
-    },
-    "setup.sh": {
-      "hash": "6d9dba530ed27ddfbe02cbc469483903f9a706b4",
-      "at": "2026-04-02T04:56:57Z",
-      "pr": 15470
-    },
-    ".agents/seo/backlink-checker.md": {
-      "hash": "aa5038f9569e0d64e563b31a0e2243bd9c2b959c",
-      "at": "2026-04-02T02:14:59Z",
-      "pr": null
-    },
-    ".agents/scripts/matrix-dispatch-helper.sh": {
-      "hash": "d42a4c2129d808e3bf1fe78109163f12f059c723",
-      "at": "2026-04-02T03:11:00Z",
-      "pr": 15431
-    },
-    ".agents/seo/ahrefs.md": {
-      "hash": "68607c6d5bd42845c1fe21cebb00752f6ff8106d",
-      "at": "2026-04-02T03:11:00Z",
-      "pr": 15431
-    },
-    "todo/tasks/t1727-brief.md": {
-      "hash": "55e4dea0078c0800d4db2336b942014ce25ffbfc",
-      "at": "2026-04-02T03:11:00Z",
-      "pr": 15431
-    },
-    ".agents/scripts/commands/email-outreach.md": {
-      "hash": "03c6fbfcdc4ba527948102f9b58f5c9bed557777",
-      "at": "2026-04-02T03:11:10Z",
-      "pr": 15480
-    },
-    ".agents/scripts/commands/seo-audit.md": {
-      "hash": "d8d6dee50a191d538e032247f78abb02ebb504a8",
-      "at": "2026-04-02T03:11:11Z",
-      "pr": 15477
-    },
-    ".agents/scripts/commands/recall.md": {
-      "hash": "9b0b04b0aeda1a0436139a205db96efcf0e662ad",
-      "at": "2026-04-02T04:56:44Z",
-      "pr": 15515
-    },
-    ".agents/content/production-video-08-talking-head-pipeline.md": {
-      "hash": "cee1bc46bfdf4612fb0560748fe9e7b134ac0086",
-      "at": "2026-04-02T04:56:45Z",
-      "pr": 15516
-    },
-    ".agents/workflows/branch/bugfix.md": {
-      "hash": "236b78c40f92a6c1b7c36085c0ecdf1ea42058be",
-      "at": "2026-04-02T04:56:46Z",
-      "pr": 15517
-    },
-    ".agents/seo/content-analyzer.md": {
-      "hash": "7972fdccf29515026f0f710dac5f8e1b792e77c5",
-      "at": "2026-04-02T04:56:49Z",
-      "pr": 15478
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/hyperdrive.md": {
-      "hash": "1a63158e184bf8c3c6ac2f4b5110e44451c5d837",
-      "at": "2026-04-02T04:56:50Z",
-      "pr": 15481
-    },
-    ".agents/tools/video/remotion-import-srt-captions.md": {
-      "hash": "75f8b0d089b9eaae8a7e08498af9b8c5f1ac4655",
-      "at": "2026-04-02T04:56:51Z",
-      "pr": 15490
-    },
-    "todo/tasks/t15472-brief.md": {
-      "hash": "3de8a77d3743c3530c563e9aff8775c22a7edb4b",
-      "at": "2026-04-02T04:56:51Z",
-      "pr": 15490
-    },
-    ".agents/scripts/commands/security-history.md": {
-      "hash": "0c74f125bbb3e299040015ee24fb345e43486ec7",
-      "at": "2026-04-02T04:56:52Z",
-      "pr": 15487
-    },
-    ".agents/tools/video/remotion-lottie.md": {
-      "hash": "72d843e6717a28f61294372a6752cb8e9736fe6b",
-      "at": "2026-04-02T04:56:53Z",
-      "pr": 15525
-    },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md": {
-      "hash": "d662c65c03864c29b198db3a89950538a7949ef2",
-      "at": "2026-04-02T04:56:54Z",
-      "pr": 15526
-    },
-    ".agents/tools/credentials/bitwarden.md": {
-      "hash": "808ffa447534e25dd4090033275c4861a8612f2c",
-      "at": "2026-04-02T04:56:56Z",
-      "pr": 15468
-    },
-    "todo/tasks/t15450-brief.md": {
-      "hash": "c0ba871cfce440d57c630e49cd6ba939bf27b261",
-      "at": "2026-04-02T04:56:56Z",
-      "pr": 15468
-    },
-    "todo/tasks/t2052-brief.md": {
-      "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
-      "at": "2026-04-02T04:56:57Z",
-      "pr": 15470
-    },
-    ".agents/tools/browser/crawl4ai-integration.md": {
-      "hash": "5b8849f598a7c31bff13579aedda9586682f6ad7",
-      "at": "2026-04-02T04:56:58Z",
-      "pr": 15463
-    },
-    "todo/tasks/t15448-brief.md": {
-      "hash": "b43fa2d5b0515af1ecbebbc502099ca5e6d0a9c2",
-      "at": "2026-04-02T04:56:58Z",
-      "pr": 15463
-    },
-    ".agents/scripts/platform-detect.sh": {
-      "hash": "a551a07e07c08853c909e7b8141ddddf2de43420",
-      "at": "2026-04-02T04:56:59Z",
-      "pr": 15455
+    "_comment": null,
+    "files": {
+        ".agents/scripts/commands/worktree-cleanup.md": {
+            "hash": "f333ce7dce4127c4c2150a07b4c1f50c",
+            "at": "2026-04-02T02:30:00Z",
+            "pr": null
+        },
+        ".agents/content/seo-writer.md": {
+            "hash": "b26db2ddd38996e2ad605d9c79db94f8",
+            "at": "2026-04-01T22:10:00Z",
+            "pr": 15339
+        },
+        ".agents/marketing-sales/cro-chapter-25.md": {
+            "hash": "b74f0ff498c385d2647512d5f68dc6261a0063e3",
+            "at": "2026-04-01T21:00:00Z",
+            "pr": 15276
+        },
+        ".agents/marketing-sales/cro-chapter-22.md": {
+            "hash": "882c97fc64eb63b11312049223c04eaa52882296",
+            "at": "2026-04-01T20:58:50Z",
+            "pr": 15257
+        },
+        ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
+            "hash": "8d79ff6b9aa02ab04c5f72924b3a7798ee561893",
+            "at": "2026-04-01T12:00:00Z",
+            "pr": 15176
+        },
+        ".agents/aidevops/agent-sources.md": {
+            "hash": "86113ed3f6cb39ad363af10d420942cff1af592c",
+            "at": "2026-03-31T05:32:40Z",
+            "pr": 14645
+        },
+        ".agents/seo/analytics-tracking.md": {
+            "hash": "07ff0feec55ad3f8477a6badd724b479c1b09370",
+            "at": "2026-03-27T21:25:04Z",
+            "pr": 11015
+        },
+        ".agents/tools/credentials/gopass.md": {
+            "hash": "a59a0077d4d56694894c8cadef6b9c3a294dede0",
+            "at": "2026-03-27T21:25:05Z",
+            "pr": 11021
+        },
+        ".agents/tools/credentials/psst.md": {
+            "hash": "cbb2379680b3ce35dc2b7ba4e2be3efe46c509c6",
+            "at": "2026-03-31T06:15:51Z",
+            "pr": 14687
+        },
+        ".agents/marketing-sales/meta-ads-creative-hooks.md": {
+            "hash": "f7c8e3356361a9ab1941f729337bbf7d0f8447ef",
+            "at": "2026-03-27T21:25:06Z",
+            "pr": 11016
+        },
+        ".agents/tools/programming/modern-javascript-skill/es2024.md": {
+            "hash": "5ff178dfe9603a724792aaef45d63f4b33fce7ef",
+            "at": "2026-03-27T21:25:08Z",
+            "pr": 11002
+        },
+        ".agents/aidevops/providers.md": {
+            "hash": "18b8c2ddd2bb1ee1b0affc02c05ae860b8e902da",
+            "at": "2026-03-27T21:25:09Z",
+            "pr": 11003
+        },
+        ".agents/aidevops/services.md": {
+            "hash": "0fd05379ebb6a6ab079aaa0011c1dd8a5cca6af1",
+            "at": "2026-03-27T21:25:10Z",
+            "pr": 11004
+        },
+        ".agents/seo/semrush.md": {
+            "hash": "cc61832322267a222c9e557b04459de4a3520086",
+            "at": "2026-03-27T21:25:11Z",
+            "pr": 11006
+        },
+        ".agents/marketing-sales/cro-chapter-10.md": {
+            "hash": "730bf8258084ccd7a330cc2ac1032f1aedd4a370",
+            "at": "2026-03-27T21:25:12Z",
+            "pr": 11005
+        },
+        ".agents/scripts/commands/log-issue-aidevops.md": {
+            "hash": "24878e7d7abca4cf0b41a18e5dac1977978ec3c1",
+            "at": "2026-03-27T21:25:13Z",
+            "pr": 11007
+        },
+        ".agents/services/communications/xmtp.md": {
+            "hash": "0b5b1bb178865dc7efff9f7578cd26dd9bf82bc9",
+            "at": "2026-03-27T21:25:14Z",
+            "pr": 11009
+        },
+        ".agents/tools/credentials/multi-tenant.md": {
+            "hash": "efa55dc5b3f2f5222982c1c9f0214ad1e2601624",
+            "at": "2026-03-27T21:25:16Z",
+            "pr": 11008
+        },
+        ".agents/reference/high-stakes-operations.md": {
+            "hash": "ba39668c924d2e2d0137c766053513a98a2f2839",
+            "at": "2026-03-27T21:25:17Z",
+            "pr": 11012
+        },
+        ".agents/tools/architecture/feature-slicing-skill.md": {
+            "hash": "7a86b72e717f9805c458d44fa69e00b9b845addd",
+            "at": "2026-03-27T21:25:18Z",
+            "pr": 11010
+        },
+        ".agents/tools/automation/macos-automator.md": {
+            "hash": "f8771a0d1548af0fbdd76f1944d50ce6b1107f13",
+            "at": "2026-03-27T21:25:19Z",
+            "pr": 11011
+        },
+        ".agents/seo/data-export.md": {
+            "hash": "196b3c4788803c0b2b8d412752d3d262d7e6f8b2",
+            "at": "2026-03-27T21:25:21Z",
+            "pr": 11019
+        },
+        ".agents/tools/ai-generation/comfy-cli.md": {
+            "hash": "6d885b8f28374a6d71d6f4095a6015f3359a668e",
+            "at": "2026-03-27T21:25:22Z",
+            "pr": 11014
+        },
+        ".agents/tools/architecture/feature-slicing-skill/cheatsheet.md": {
+            "hash": "b244fb8417fc27f0de33c83c86092f5bebd736f3",
+            "at": "2026-03-27T21:25:23Z",
+            "pr": 11018
+        },
+        ".agents/tools/browser/anti-detect-browser.md": {
+            "hash": "647081565083b90f27fdce7d25dea9e153fc64a4",
+            "at": "2026-03-27T21:25:25Z",
+            "pr": 11017
+        },
+        ".agents/tools/code-review/snyk.md": {
+            "hash": "e248df7d21db7a21cef8b1e16e1e96f361e3e487",
+            "at": "2026-03-27T21:25:26Z",
+            "pr": 11013
+        },
+        ".agents/tools/ai-orchestration/crewai.md": {
+            "hash": "e1ed08282945b0708a6840e1d2bb38d92c3d3698",
+            "at": "2026-03-28T02:50:59Z",
+            "pr": 11274
+        },
+        ".agents/tools/build-mcp/api-wrapper.md": {
+            "hash": "68b6075506f6dc1153fec6d5aa78c05d213b0b73",
+            "at": "2026-03-28T02:51:01Z",
+            "pr": 11276
+        },
+        ".agents/tools/build-mcp/api-wrapper/patterns.md": {
+            "hash": "5aa65e858b380b38b44e647545eda3f1450543b2",
+            "at": "2026-03-28T02:51:01Z",
+            "pr": 11276
+        },
+        ".agents/tools/build-mcp/aidevops-plugin.md": {
+            "hash": "c2af34ac248062f83be58abf2e85fabd6e424710",
+            "at": "2026-03-31T09:13:36Z",
+            "pr": 14775
+        },
+        ".agents/aidevops/add-new-mcp-to-aidevops.md": {
+            "hash": "818de6a118b3981cbc732aace97a1220ad7f27ee",
+            "at": "2026-03-28T16:41:22Z",
+            "pr": 12006
+        },
+        ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
+            "hash": "a80eb99acba160fa0f034a4989c0b886f37a32a0",
+            "at": "2026-03-28T08:17:37Z",
+            "pr": 11571
+        },
+        ".agents/reference/configuration.md": {
+            "hash": "9502faea512b841b7a239e9e3c9cc0188f4fe855",
+            "at": "2026-03-28T04:30:48Z",
+            "pr": 11321
+        },
+        ".agents/scripts/stats-functions.sh": {
+            "hash": "500235eb7c29b89a44219c93701d3960837d9dca",
+            "at": "2026-03-28T02:51:08Z",
+            "pr": 11273
+        },
+        ".agents/workflows/plans.md": {
+            "hash": "d07529f81bc8ce92541f51393632bb2d04ce8fd4",
+            "at": "2026-03-28T21:58:58Z",
+            "pr": 12235
+        },
+        ".agents/marketing-sales/meta-ads-creative-scripts.md": {
+            "hash": "9455fbf07187de24552aa591a8752fd7b3df2480",
+            "at": "2026-03-28T03:10:39Z",
+            "pr": 11297
+        },
+        ".agents/content/social-bird.md": {
+            "hash": "b2840ebff41ba9b78f7331487d6596373e8436e4",
+            "at": "2026-03-28T05:10:07Z",
+            "pr": 11354
+        },
+        ".agents/tools/programming/modern-javascript-skill/composition.md": {
+            "hash": "fe9da3d05db78aac6b072235efe8b74f5c9fcf2b",
+            "at": "2026-03-28T03:53:07Z",
+            "pr": 11328
+        },
+        ".agents/tools/programming/modern-javascript-skill/es2022-es2023.md": {
+            "hash": "5e5dfb7e18557b8e26c5c48c090c8df94eda485c",
+            "at": "2026-03-28T03:53:13Z",
+            "pr": 11337
+        },
+        ".agents/workflows/milestone-validation.md": {
+            "hash": "3e8c88a4d98e24993198b7a6cfc0c93b7825bd26",
+            "at": "2026-03-28T03:53:42Z",
+            "pr": 11286
+        },
+        ".agents/services/communications/discord.md": {
+            "hash": "44cce31bf11bd980e6b95270c913477c86348a15",
+            "at": "2026-03-28T03:53:47Z",
+            "pr": 11287
+        },
+        ".agents/tools/browser/pagespeed.md": {
+            "hash": "55b132de0f4ff15dd72cec557bf042cd56b93fec",
+            "at": "2026-03-28T03:53:49Z",
+            "pr": 11295
+        },
+        ".agents/tools/ai-orchestration/packaging.md": {
+            "hash": "4cbea04181622677bff0bdbb611cdd03a3401484",
+            "at": "2026-03-28T03:53:52Z",
+            "pr": 11296
+        },
+        ".agents/aidevops/mcp-integrations.md": {
+            "hash": "8c6204355b9b3ccc09bb3761ac1804e94bf76db2",
+            "at": "2026-03-28T03:53:54Z",
+            "pr": 11339
+        },
+        ".agents/aidevops/mcp-troubleshooting.md": {
+            "hash": "53599e9a3e7d9799a065eb9bc1fe9df2e7dbd1d7",
+            "at": "2026-03-31T08:03:51Z",
+            "pr": 14740
+        },
+        ".agents/tools/ai-assistants/opencode-server.md": {
+            "hash": "15e90e96d742cfe07ffd4cb37c340157d5a8bb74",
+            "at": "2026-03-28T03:53:56Z",
+            "pr": 11345
+        },
+        ".agents/tools/context/mcp-discovery.md": {
+            "hash": "b5851d90484fe52e39f87e3c7af8692778986208",
+            "at": "2026-03-28T03:53:59Z",
+            "pr": 11338
+        },
+        ".agents/tools/deployment/cloudron-app-packaging.md": {
+            "hash": "a6ddd4af870f4445d96eb4bf3c2d109fcb9219b7",
+            "at": "2026-03-28T03:54:01Z",
+            "pr": 11344
+        },
+        ".agents/tools/security/ip-reputation.md": {
+            "hash": "a1da2aa2f5e2f454f3c1dbcd3a7a819a72cd80dd",
+            "at": "2026-03-28T03:54:03Z",
+            "pr": 11342
+        },
+        ".agents/tools/ui/frontend-debugging.md": {
+            "hash": "272d16549c353500a19666d7ace227b34b2ae363",
+            "at": "2026-03-28T03:54:06Z",
+            "pr": 11340
+        },
+        ".agents/workflows/preflight.md": {
+            "hash": "c4695943d5555314205b87bb88020fb62de14b63",
+            "at": "2026-03-28T03:54:08Z",
+            "pr": 11341
+        },
+        ".agents/aidevops/recommendations.md": {
+            "hash": "67c3f660425b669feae3238d7b42589449caa860",
+            "at": "2026-03-28T03:54:11Z",
+            "pr": 11343
+        },
+        ".agents/services/communications/msteams.md": {
+            "hash": "9818d1daccf3f68d103ecba204aa56431dba6514",
+            "at": "2026-03-28T03:54:15Z",
+            "pr": 11346
+        },
+        ".agents/tools/browser/peekaboo.md": {
+            "hash": "294d232e9625b8a855f17cbea4498a4881a6b0bc",
+            "at": "2026-03-28T03:54:17Z",
+            "pr": 11348
+        },
+        ".agents/tools/database/vector-search.md": {
+            "hash": "d365046c212da54c3ab0ede8217cce083de484c5",
+            "at": "2026-03-28T03:54:19Z",
+            "pr": 11351
+        },
+        ".agents/seo/neuronwriter.md": {
+            "hash": "e6d78a192db4a98186ff9a1f428a07d6455ba42a",
+            "at": "2026-03-28T03:54:21Z",
+            "pr": 11350
+        },
+        ".agents/tools/wordpress/wp-preferred.md": {
+            "hash": "6664b61850bd5f84a8044f5dea501f4534b9a9d8",
+            "at": "2026-03-28T03:54:25Z",
+            "pr": 11353
+        },
+        ".agents/tools/git/opencode-github.md": {
+            "hash": "02c6d675ca2b756817bc639ec03d999e1f3ea58e",
+            "at": "2026-03-28T03:54:27Z",
+            "pr": 11349
+        },
+        ".agents/services/hosting/webhosting.md": {
+            "hash": "fb3877648d049a414407d7f9e6beb747c2f92f1d",
+            "at": "2026-03-28T03:54:32Z",
+            "pr": 11352
+        },
+        ".agents/services/communications/nextcloud-talk.md": {
+            "hash": "830399729c8d83ca4263bbf736ea549534989f63",
+            "at": "2026-03-28T03:54:35Z",
+            "pr": 11360
+        },
+        ".agents/services/outreach/smartlead.md": {
+            "hash": "8171133da8154e590bca4a6baa8a1bbe05051e05",
+            "at": "2026-03-28T03:54:38Z",
+            "pr": 11357
+        },
+        ".agents/marketing-sales/cro-chapter-16.md": {
+            "hash": "920245116e79b04207fd2b808c5dcbfabea3eb17",
+            "at": "2026-03-28T04:30:24Z",
+            "pr": 11374
+        },
+        ".agents/marketing-sales/meta-ads-campaigns-decision-trees.md": {
+            "hash": "a7bcedab8040e2b400b7c2feca987e09bb0a8477",
+            "at": "2026-03-28T04:30:25Z",
+            "pr": 11381
+        },
+        ".agents/tools/database/vector-search/per-tenant-rag.md": {
+            "hash": "9c0a46c72bbf38115155d5214f0256365a03260b",
+            "at": "2026-03-28T06:40:00Z",
+            "pr": 11417
+        },
+        ".agents/tools/architecture/feature-slicing-skill/nextjs.md": {
+            "hash": "0fd2c402556f4d6804ce1a61eeaaaa9c3cecd541",
+            "at": "2026-03-28T06:59:34Z",
+            "pr": 11437
+        },
+        ".agents/marketing-sales/meta-ads-creative-formats.md": {
+            "hash": "f8a4f095bebc852b9ce58976d3b53e418bbe578e",
+            "at": "2026-03-28T06:39:54Z",
+            "pr": 11410
+        },
+        ".agents/marketing-sales/ad-creative-chapter-06.md": {
+            "hash": "3d34a8e028e8905a54af8dd939394d10bdf16d97",
+            "at": "2026-03-28T05:09:55Z",
+            "pr": 11414
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-ads.md": {
+            "hash": "8e2f8f2a6620debfe219e09c96cfeb634fb518a7",
+            "at": "2026-03-28T05:50:32Z",
+            "pr": 11411
+        },
+        ".agents/tools/voice/transcription.md": {
+            "hash": "8edf7782bc2f37c48ade8d3b58fd5c611dc8bda5",
+            "at": "2026-03-29T07:02:26Z",
+            "pr": 12638
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/sequence.md": {
+            "hash": "162ba5164f7ffedc3b1d3497beabd56c6d58aaba",
+            "at": "2026-03-28T05:10:17Z",
+            "pr": 11392
+        },
+        ".agents/tools/architecture/clean-ddd-hexagonal-skill/cheatsheet.md": {
+            "hash": "7622759c028bec7b85f445a88ab175f13b055133",
+            "at": "2026-03-28T05:10:19Z",
+            "pr": 11393
+        },
+        ".agents/marketing-sales/ad-creative-chapter-10.md": {
+            "hash": "23e33ef44632a4467884d5d9bebf6452adf22160",
+            "at": "2026-03-28T05:10:32Z",
+            "pr": 11315
+        },
+        ".agents/marketing-sales/ad-creative-offers-landing.md": {
+            "hash": "a16b4767e518eb9f3f35e1b61d3d166390077009",
+            "at": "2026-03-28T05:50:34Z",
+            "pr": 11415
+        },
+        ".agents/services/database/postgres-drizzle-skill/queries.md": {
+            "hash": "2647d7cd620f871bdbc5ca89466f013792b777fd",
+            "at": "2026-03-28T06:40:05Z",
+            "pr": 11416
+        },
+        ".agents/tools/accessibility/accessibility-audit.md": {
+            "hash": "50607e3251694a312978efe741fd95eb6e47de55",
+            "at": "2026-03-28T08:18:26Z",
+            "pr": 11634
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/ai-gateway.md": {
+            "hash": "720c2836fca088d027ac637f8c69e97cb3c2764a",
+            "at": "2026-03-28T05:50:52Z",
+            "pr": 11443
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md": {
+            "hash": "819096c73ef171c0e0e58c2929c5d11f72401931",
+            "at": "2026-03-31T05:38:15Z",
+            "pr": 14658
+        },
+        ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
+            "hash": "b59a17a028d181e2f55c45e58c371ca999d9a2ee",
+            "at": "2026-03-28T05:50:55Z",
+            "pr": 11439
+        },
+        ".agents/services/database/postgres-drizzle-skill/postgres.md": {
+            "hash": "2633ce6d2343b370a13a3efea1ed735544a6883a",
+            "at": "2026-03-28T05:50:57Z",
+            "pr": 11448
+        },
+        ".agents/marketing-sales/direct-response-copy-frameworks-offer-construction.md": {
+            "hash": "10d31ffa27d8e38267882e04f099ce38899635f1",
+            "at": "2026-03-28T05:51:09Z",
+            "pr": 11363
+        },
+        ".agents/marketing-sales/meta-ads-audiences-first-party-data.md": {
+            "hash": "1ad15971973eec338e831dc24839609eb1f473e3",
+            "at": "2026-03-28T08:18:20Z",
+            "pr": 11536
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-ad-copy.md": {
+            "hash": "bfc16d8c1bc4e6a8229cc555eba0d72de8ece0d7",
+            "at": "2026-03-28T08:17:45Z",
+            "pr": 11593
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-vsl-script.md": {
+            "hash": "c8fa5d2f257f52a1d7c9c49ca9d78e6be247623e",
+            "at": "2026-03-28T08:17:46Z",
+            "pr": 11591
+        },
+        ".agents/marketing-sales/cro-chapter-09.md": {
+            "hash": "4d45e94ded75b90ef7e30518e072a5a643167370",
+            "at": "2026-03-28T08:17:36Z",
+            "pr": 11561
+        },
+        ".agents/reference/memory.md": {
+            "hash": "0a7c4c493f3a825b98e2de3928f718fa9095c966",
+            "at": "2026-03-28T07:37:36Z",
+            "pr": 11538
+        },
+        ".agents/marketing-sales/ad-creative-chapter-02.md": {
+            "hash": "810c244d317a3332c74dc2baafb34bf00cf5ab2f",
+            "at": "2026-03-28T07:37:37Z",
+            "pr": 11539
+        },
+        ".agents/tools/ai-assistants/headless-dispatch.md": {
+            "hash": "00414f5554e8388ffa17859ef02d718061cd911a",
+            "at": "2026-03-29T03:15:46Z",
+            "pr": 12352
+        },
+        ".agents/tools/document/document-creation.md": {
+            "hash": "245a303a923bd18c0adc820adb9620f12d636d2b",
+            "at": "2026-03-28T08:17:34Z",
+            "pr": 11592
+        },
+        ".agents/tools/design/ui-ux-inspiration.md": {
+            "hash": "fb4a8985ec3089753355c7a13d0665c878034369",
+            "at": "2026-03-28T08:17:35Z",
+            "pr": 11590
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-email-sequences.md": {
+            "hash": "5af4b4e800d180cb185bfa6d14ee93f2fc2661e9",
+            "at": "2026-03-28T13:37:24Z",
+            "pr": 11886
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-readme.md": {
+            "hash": "2717d1e9cb1edfd85d932502b6de7c4765c8a7ec",
+            "at": "2026-03-28T08:17:38Z",
+            "pr": 11571
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/tail-workers.md": {
+            "hash": "d909ab39413052950bcfff2d355bb102d17f8421",
+            "at": "2026-03-28T08:17:39Z",
+            "pr": 11562
+        },
+        ".agents/marketing-sales/meta-ads-optimization-scaling.md": {
+            "hash": "8034babf9a34b6f09f0cce7817a136ee38be0c1f",
+            "at": "2026-03-28T08:17:40Z",
+            "pr": 11564
+        },
+        ".agents/marketing-sales/meta-ads-optimization-troubleshooting.md": {
+            "hash": "684991a0c73063d140b0cfee3ad73691a479a34f",
+            "at": "2026-03-28T08:17:40Z",
+            "pr": 11564
+        },
+        ".agents/tools/database/vector-search/zvec.md": {
+            "hash": "1929000365507621f52d563ad2b63e9f51feab8d",
+            "at": "2026-03-28T08:17:41Z",
+            "pr": 11570
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/class-er.md": {
+            "hash": "e3929bc050f03d955e21543cfed73a4b69880579",
+            "at": "2026-03-28T08:17:42Z",
+            "pr": 11589
+        },
+        ".agents/tools/wordpress/wp-admin.md": {
+            "hash": "a02a72943cc4820447f81c73216b0f095c3f64e5",
+            "at": "2026-03-28T08:17:43Z",
+            "pr": 11587
+        },
+        ".agents/tools/wordpress/wp-cli-reference.md": {
+            "hash": "0425ba4c94fd45b032e849987736bc4073970a7e",
+            "at": "2026-03-28T08:17:43Z",
+            "pr": 11587
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-01-facebook-instagram.md": {
+            "hash": "4bfed86699b1e5a25050b85f099ca3fc580574d8",
+            "at": "2026-03-28T08:17:45Z",
+            "pr": 11593
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-02-google-search.md": {
+            "hash": "f9ecc39136c90a2feb8bc9075f3e95ba23fccddd",
+            "at": "2026-03-28T08:17:45Z",
+            "pr": 11593
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-03-linkedin.md": {
+            "hash": "a3c8015dc17258f154c7bdd4e4ccf0d4586a06db",
+            "at": "2026-03-28T08:17:45Z",
+            "pr": 11593
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-04-twitter.md": {
+            "hash": "615623c2156bb8eee3a9409900b33a895768e08d",
+            "at": "2026-03-28T08:17:45Z",
+            "pr": 11593
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-05-reference.md": {
+            "hash": "d34fe0576cb0cb1c1770a278ad5e149bba1480d0",
+            "at": "2026-03-28T08:17:45Z",
+            "pr": 11593
+        },
+        ".agents/tools/conversion/pandoc.md": {
+            "hash": "557667b032774727658d22f6b1c5392ec4a83660",
+            "at": "2026-03-28T08:17:47Z",
+            "pr": 11595
+        },
+        ".agents/content/research.md": {
+            "hash": "0844a394bf378618e923c821a3246e54fead511f",
+            "at": "2026-03-28T08:57:54Z",
+            "pr": 11644
+        },
+        ".agents/tools/performance/webpagetest.md": {
+            "hash": "e0b3e8da23436e916aecd40d37bceeea48f99642",
+            "at": "2026-03-28T08:17:50Z",
+            "pr": 11594
+        },
+        ".agents/tools/browser/crawl4ai.md": {
+            "hash": "967373980ca56ec85cb795eb9426efb91ff23ddb",
+            "at": "2026-03-28T08:17:51Z",
+            "pr": 11599
+        },
+        ".agents/content/heygen-skill/rules-dimensions.md": {
+            "hash": "f32c728a54e3edca1d713da0d536cb4b63299882",
+            "at": "2026-03-28T08:18:14Z",
+            "pr": 11610
+        },
+        ".agents/services/email/google-workspace.md": {
+            "hash": "d25ed82148411a5ce44101400e445cb3293c4e96",
+            "at": "2026-03-28T08:58:52Z",
+            "pr": 11613
+        },
+        ".agents/tools/architecture/feature-slicing-skill/layers.md": {
+            "hash": "aa5a10592a8a28db7e01ce256df9e7aa7ab57c76",
+            "at": "2026-03-28T08:18:16Z",
+            "pr": 11537
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md": {
+            "hash": "10d5c38ac748a992e4619c4042a5ac685b009b3f",
+            "at": "2026-03-28T08:18:21Z",
+            "pr": 11631
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md": {
+            "hash": "aa4bc86ba1d820a999ff48479bc7af02bc524485",
+            "at": "2026-03-28T08:18:21Z",
+            "pr": 11631
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/vectorize.md": {
+            "hash": "c1d8339d4d9148d438f87b89220e85fa82e4c859",
+            "at": "2026-03-28T08:18:21Z",
+            "pr": 11631
+        },
+        ".agents/tools/voice/cloud-tts-apis.md": {
+            "hash": "0a7ff7444bf603ab6328a2248b32bd9faf422b02",
+            "at": "2026-03-28T08:18:23Z",
+            "pr": 11637
+        },
+        ".agents/tools/voice/local-tts-models.md": {
+            "hash": "a2985fa793b132d716e99ec9f9dd6eaf8252485a",
+            "at": "2026-03-28T08:18:24Z",
+            "pr": 11637
+        },
+        ".agents/tools/voice/voice-models.md": {
+            "hash": "1048bd3b6ac334dea9f2685aef4b09642f318673",
+            "at": "2026-03-28T08:18:24Z",
+            "pr": 11637
+        },
+        ".agents/services/hosting/101domains.md": {
+            "hash": "504d151b93c6073272de3fca00e08e6118720cf9",
+            "at": "2026-03-28T08:18:27Z",
+            "pr": 11633
+        },
+        ".agents/marketing-sales/ad-creative-chapter-05.md": {
+            "hash": "f8ded271e66b8024f24caa8a841ea58da90a709a",
+            "at": "2026-03-28T08:18:28Z",
+            "pr": 11555
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workers-vpc.md": {
+            "hash": "fd8d3ba366abc324f0738e2e11fce322d92c654b",
+            "at": "2026-03-28T08:57:49Z",
+            "pr": 11677
+        },
+        ".agents/marketing-sales/ad-creative-chapter-03.md": {
+            "hash": "f2d79f61b3c28c3e902760bb469c29a465a777c3",
+            "at": "2026-03-28T15:30:26Z",
+            "pr": 11936
+        },
+        ".agents/services/communications/convos-bridge-template.sh": {
+            "hash": "cd850bc9a35a947206c1a4cf2e67313bb90f9644",
+            "at": "2026-03-28T08:57:52Z",
+            "pr": 11688
+        },
+        ".agents/services/communications/convos.md": {
+            "hash": "74e396568b01688f29f86d799f049f5b624b9205",
+            "at": "2026-03-28T08:57:52Z",
+            "pr": 11688
+        },
+        ".agents/tools/voice/cloud-voice-agents.md": {
+            "hash": "b389dcd17c677b3e21bc86397670fbf4d8a61b98",
+            "at": "2026-03-28T16:40:25Z",
+            "pr": 12005
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md": {
+            "hash": "816a5f35e7ca6b338deae7db62c3058d317b96d6",
+            "at": "2026-03-28T08:57:56Z",
+            "pr": 11647
+        },
+        ".agents/content/video-runway.md": {
+            "hash": "54c5b2fe2d3cdd00e23f192d5f869c927b6e573e",
+            "at": "2026-03-28T08:58:00Z",
+            "pr": 11646
+        },
+        ".agents/marketing-sales/ad-creative-testing-optimization.md": {
+            "hash": "2f60c87e51dac14c539d02ba1a796a98b995c2c4",
+            "at": "2026-03-28T08:58:01Z",
+            "pr": 11614
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/data-charts.md": {
+            "hash": "ea8a64811a9c35a4274183f1c0c215be8c2a6aec",
+            "at": "2026-03-28T08:58:03Z",
+            "pr": 11602
+        },
+        ".agents/content.md": {
+            "hash": "2f71b51f39307e001e3af0bae81c5fc440c2da9b",
+            "at": "2026-03-28T08:58:04Z",
+            "pr": 11616
+        },
+        ".agents/marketing-sales/ad-creative-psychology-targeting.md": {
+            "hash": "c37b3f2fadeaae4f147248efd4fa535e89f1d96b",
+            "at": "2026-03-28T10:27:52Z",
+            "pr": 11655
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-example.md": {
+            "hash": "219b3f24929e0866af7e05c36250a267a5f2e952",
+            "at": "2026-03-28T08:58:28Z",
+            "pr": 11597
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-pastor-framework.md": {
+            "hash": "229aaf2fa58645152ccdd4ece9d723068b251f4a",
+            "at": "2026-03-28T08:58:28Z",
+            "pr": 11597
+        },
+        ".agents/tools/credentials/sops.md": {
+            "hash": "927fea51df6b5ed15ee41b1473f26bf7b526ca38",
+            "at": "2026-03-28T08:58:29Z",
+            "pr": 11560
+        },
+        ".agents/tools/api/better-auth.md": {
+            "hash": "8494627274fa59f222b8c19aeb61280ded29e8ec",
+            "at": "2026-03-28T08:58:32Z",
+            "pr": 11566
+        },
+        ".agents/aidevops/extension.md": {
+            "hash": "6b76dd6fa41470a5d1d4e5ebeea7af1b13b6a1e8",
+            "at": "2026-03-28T08:58:33Z",
+            "pr": 11565
+        },
+        ".agents/tools/wordpress/localwp.md": {
+            "hash": "e2a3ea522c2f0a4739825f594f236c92f0eee0fa",
+            "at": "2026-03-28T08:58:34Z",
+            "pr": 11563
+        },
+        ".agents/marketing-sales/ad-creative-platform-meta.md": {
+            "hash": "130ac72c8435b342b5be159ed84ab6633efdf4fa",
+            "at": "2026-03-28T08:58:35Z",
+            "pr": 11574
+        },
+        ".agents/marketing-sales/direct-response-copy-frameworks-headline-formulas.md": {
+            "hash": "9c23835b93de53e0d6371a5f753c1409e0374d9d",
+            "at": "2026-03-28T08:58:42Z",
+            "pr": 11548
+        },
+        ".agents/tools/document/extraction-schemas.md": {
+            "hash": "fa0ee1f8e92a38842d98674241507fd0cde43a81",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/01-design-principles.md": {
+            "hash": "c557fde290bb52a65fa91d603c4366fdb0fcf3e7",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/02-purchase-invoice.md": {
+            "hash": "d9c194618044c58a6f3a364bba869683957b26c1",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/03-expense-receipt.md": {
+            "hash": "8c0553d204c9f8e111f7bb211d9b8e99a8fac453",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/04-credit-note.md": {
+            "hash": "c58830493ee6a0ae1b3f77c6fb18a20db5e87ed4",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/05-sales-invoice.md": {
+            "hash": "50c68e48c09eb85c30259361ceadadca01795e5e",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/06-generic-receipt.md": {
+            "hash": "8cd493fef922d42decca280eaaec76c32de7f324",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/07-quickfile-mapping.md": {
+            "hash": "329bb22bc68c98571c6bd075a6458573830bcd99",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/08-vat-handling.md": {
+            "hash": "74ea1c15f941a48b3cb8d0a62dc8fa3ec590dd86",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/09-nominal-codes.md": {
+            "hash": "7210b70a3f8072de3d50be138635dced20594d9d",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/10-classification.md": {
+            "hash": "8822a182e225ee7360107f5e1938e4fc844670e3",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/11-pipeline-integration.md": {
+            "hash": "377abccc10cb93b5f8b51010a48d6d947553b71c",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/tools/document/extraction-schemas/12-validation.md": {
+            "hash": "85fb1862ed295cbba2a8c11ed8ccef35d25fc2c4",
+            "at": "2026-03-28T08:58:45Z",
+            "pr": 11601
+        },
+        ".agents/content/distribution-youtube-script-writer.md": {
+            "hash": "e7d74dc2884f946d2d3ad41287926a426d0b0edb",
+            "at": "2026-03-28T08:58:46Z",
+            "pr": 11603
+        },
+        ".agents/seo/site-crawler.md": {
+            "hash": "b57ba3a5214383ec97ea5c4838fabcd0ce900a20",
+            "at": "2026-03-28T08:58:48Z",
+            "pr": 11598
+        },
+        ".agents/services/communications/signal.md": {
+            "hash": "652f531e6f54f9fd38da5c5bd61889672eac4acf",
+            "at": "2026-03-28T08:58:53Z",
+            "pr": 11620
+        },
+        ".agents/tools/deployment/vercel.md": {
+            "hash": "c2084ec268e00720815607590f8bab4bc7082c53",
+            "at": "2026-03-28T08:58:54Z",
+            "pr": 11615
+        },
+        ".agents/workflows/postflight.md": {
+            "hash": "4e10936d7f2007c0c034ff2f2d8f8110bdf3d0dc",
+            "at": "2026-03-28T10:27:12Z",
+            "pr": 11739
+        },
+        ".agents/content/heygen-skill/rules-backgrounds.md": {
+            "hash": "7abf186ddedbabd5128f34ee918393a187de8cc3",
+            "at": "2026-03-28T09:17:34Z",
+            "pr": 11711
+        },
+        ".agents/services/communications/nostr.md": {
+            "hash": "eacafb8b13831574c6bc570c06903e15e7acd077",
+            "at": "2026-03-28T09:17:35Z",
+            "pr": 11715
+        },
+        ".agents/tools/deployment/uncloud.md": {
+            "hash": "f0efc54a4b03f1e5a1398d94d063d72218a8de21",
+            "at": "2026-03-28T09:17:40Z",
+            "pr": 11712
+        },
+        ".agents/marketing-sales/meta-ads-campaigns-retargeting.md": {
+            "hash": "76a66a236cc7fbeb40d74384e9dbe4bd75a4a155",
+            "at": "2026-03-28T11:52:21Z",
+            "pr": 11822
+        },
+        ".agents/content/heygen-skill/rules-remotion-integration.md": {
+            "hash": "5ccb546152546cd33344a76d42a4b90c0acd0dbd",
+            "at": "2026-03-28T10:27:14Z",
+            "pr": 11740
+        },
+        ".agents/services/payments/procurement.md": {
+            "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
+            "at": "2026-03-28T09:48:49Z",
+            "pr": 11713
+        },
+        ".agents/tools/build-agent/build-agent.md": {
+            "hash": "59fa5cde2d2c1b113be43ecdb1a6d8978d3d4f69",
+            "at": "2026-03-29T14:29:12Z",
+            "pr": 12957
+        },
+        ".agents/content/distribution-youtube-topic-research.md": {
+            "hash": "d8d475231eff5b53cf27de5ab31aeedaec403e2f",
+            "at": "2026-03-28T11:20:29Z",
+            "pr": 11801
+        },
+        ".agents/content/heygen-skill/rules-captions.md": {
+            "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
+            "at": "2026-03-28T09:48:53Z",
+            "pr": 11707
+        },
+        ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
+            "hash": "07b30b06de54ff4544c7f468a6c6ba2d25215784",
+            "at": "2026-03-28T10:27:24Z",
+            "pr": 11709
+        },
+        ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
+            "hash": "8eb705ea0ac51157ecf6c3c93a6f3898b754f1233f3257c3e5e33d65837d71c3",
+            "at": "2026-03-31T00:00:00Z",
+            "pr": 14577
+        },
+        ".agents/services/database/postgres-drizzle-skill/schema.md": {
+            "hash": "ed1952db54651cd46710ca9cfa4db950635e42a6",
+            "at": "2026-03-28T10:27:24Z",
+            "pr": 11709
+        },
+        ".agents/tools/ui/i18next.md": {
+            "hash": "ce750937b182da6a4a2cce512b141f16da789fcd",
+            "at": "2026-03-28T10:27:25Z",
+            "pr": 11710
+        },
+        ".agents/services/database/postgres-drizzle-skill/relations.md": {
+            "hash": "673a7c2abd65766f454b57e79a259a7217463210",
+            "at": "2026-03-28T09:48:57Z",
+            "pr": 11717
+        },
+        ".agents/tools/build-mcp/server-patterns.md": {
+            "hash": "c0e5bf0399f60ae53b3b09082ac6ced4debb8c76",
+            "at": "2026-03-28T10:27:33Z",
+            "pr": 11679
+        },
+        ".agents/tools/git/worktrunk.md": {
+            "hash": "bafc956a55ed67b84dfc0722955434b85dd6202e",
+            "at": "2026-03-28T10:27:11Z",
+            "pr": 11760
+        },
+        ".agents/content/distribution-youtube-pipeline.md": {
+            "hash": "ec344423c7366d10312a8ca44f60ca4232d34097",
+            "at": "2026-03-28T11:20:33Z",
+            "pr": 11763
+        },
+        ".agents/content/heygen-skill/rules-video-generation.md": {
+            "hash": "929341bdb16beeda9c31e050b53eddbe5badfd72",
+            "at": "2026-03-28T10:27:38Z",
+            "pr": 11675
+        },
+        ".agents/tools/code-review/best-practices.md": {
+            "hash": "b8f93fd83e04dc301d838178a7b7523e35382166",
+            "at": "2026-03-28T13:38:46Z",
+            "pr": 11771
+        },
+        ".agents/content/video-muapi.md": {
+            "hash": "3deffc1afc21c9cb3daf10a540c802fc70e437df",
+            "at": "2026-03-28T11:20:21Z",
+            "pr": 11800
+        },
+        ".agents/tools/browser/playwright-cli.md": {
+            "hash": "978be4b5b3043cfee751f9c966ba27ddd7fe5182",
+            "at": "2026-03-28T11:20:22Z",
+            "pr": 11802
+        },
+        ".agents/aidevops/requirements.md": {
+            "hash": "9a75f9e14252e2364ed8ceeb9e24e8df3a95e310",
+            "at": "2026-03-28T11:52:46Z",
+            "pr": 11770
+        },
+        ".agents/tools/video/yt-dlp.md": {
+            "hash": "93855bd751f355d6ef75134ba3322330fcb7d596",
+            "at": "2026-03-28T11:20:27Z",
+            "pr": 11752
+        },
+        ".agents/content/distribution-youtube-optimizer.md": {
+            "hash": "08796da4159346de335feb979d6ce0af181bb8ff",
+            "at": "2026-03-28T11:20:34Z",
+            "pr": 11731
+        },
+        ".agents/tools/credentials/gocryptfs.md": {
+            "hash": "8e128a21d4783c5499f073213aee1a20491893d5",
+            "at": "2026-03-28T11:20:36Z",
+            "pr": 11730
+        },
+        ".agents/tools/ui/nextjs-layouts.md": {
+            "hash": "df90871ad91810f05326405fe711c4ff4be9460b",
+            "at": "2026-03-28T11:20:37Z",
+            "pr": 11732
+        },
+        ".agents/content/distribution-social.md": {
+            "hash": "4ca38ce265bdd7a4921aeed56567dd38e5e98c32",
+            "at": "2026-03-28T11:20:38Z",
+            "pr": 11733
+        },
+        ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-tactical.md": {
+            "hash": "a53f3400bd5c9142c7f9b186523697b16c1a28e2",
+            "at": "2026-03-28T11:20:40Z",
+            "pr": 11734
+        },
+        ".agents/content/production-writing.md": {
+            "hash": "525c4aab766775fa9f92155b85f58bcda67cf3ea",
+            "at": "2026-03-28T11:20:42Z",
+            "pr": 11788
+        },
+        ".agents/tools/architecture/clean-ddd-hexagonal-skill/testing.md": {
+            "hash": "2316ee0b050453056ecc075e712e88b436dd3dd9",
+            "at": "2026-03-28T13:38:11Z",
+            "pr": 11790
+        },
+        ".agents/workflows/ralph-loop.md": {
+            "hash": "552b1c4af3571c286790521b4cf26446ab3bb729",
+            "at": "2026-03-28T11:20:12Z",
+            "pr": 11789
+        },
+        ".agents/marketing-sales/meta-ads-audiences-targeting-strategies.md": {
+            "hash": "9802f4e7f19b67d5a8a45f1a137209082a585d4c",
+            "at": "2026-03-28T11:20:14Z",
+            "pr": 11791
+        },
+        ".agents/tools/api/vercel-ai-sdk.md": {
+            "hash": "e0a51bc87d3615a985b527cfe0265571672e2095",
+            "at": "2026-03-28T11:20:15Z",
+            "pr": 11792
+        },
+        ".agents/tools/ai-orchestration/overview.md": {
+            "hash": "1dca5c066203b5e0a14c4406e64b3f8e06aa3f85",
+            "at": "2026-03-28T11:20:16Z",
+            "pr": 11793
+        },
+        ".agents/tools/wordpress/mainwp.md": {
+            "hash": "e16169565844b28fa00ca62439a068eec8dd965f",
+            "at": "2026-03-28T11:20:17Z",
+            "pr": 11794
+        },
+        ".agents/services/hosting/hostinger.md": {
+            "hash": "bdc3391799c0fb32ef11f6d610f48f7debae2194",
+            "at": "2026-03-28T11:20:19Z",
+            "pr": 11804
+        },
+        ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-strategic.md": {
+            "hash": "61e87ef7f501310f73fbe54da1d9e0a76a38abae",
+            "at": "2026-03-28T11:20:20Z",
+            "pr": 11805
+        },
+        ".agents/aidevops/supervisor-module-map.md": {
+            "hash": "6dc1ff5f9d7243b29d768c024123338d11496a5f",
+            "at": "2026-03-28T11:52:24Z",
+            "pr": 11811
+        },
+        ".agents/business/company-runners.md": {
+            "hash": "8c78821205aacf320a7ed32b722b7c646a4e35af",
+            "at": "2026-03-28T11:52:25Z",
+            "pr": 11812
+        },
+        ".agents/tools/infrastructure/fireworks.md": {
+            "hash": "6025fc8a3ce3cadba1f1d8d00c699c8fe970b015",
+            "at": "2026-03-28T11:52:26Z",
+            "pr": 11813
+        },
+        ".agents/workflows/git-workflow.md": {
+            "hash": "1ea0b652ceda9126a403a89555e29a02b1c7e3bd",
+            "at": "2026-03-29T08:49:32Z",
+            "pr": 12777
+        },
+        ".agents/marketing-sales/ad-creative-copywriting.md": {
+            "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
+            "at": "2026-03-28T21:14:35Z",
+            "pr": 12018
+        },
+        ".agents/marketing-sales/direct-response-copy-templates-landing-page.md": {
+            "hash": "cbaa0cc29c6e3639ea5254866f8fefe1c02a329c",
+            "at": "2026-03-28T13:37:36Z",
+            "pr": 11840
+        },
+        ".agents/seo/gsc-sitemaps.md": {
+            "hash": "7154caa038f21e800f7b6c5493f2553a9d7e8efb",
+            "at": "2026-03-28T11:52:39Z",
+            "pr": 11821
+        },
+        ".agents/services/email/email-mailbox-search.md": {
+            "hash": "26c7c333d46a5319b598173b36c5c30124126c81",
+            "at": "2026-03-28T13:37:26Z",
+            "pr": 11869
+        },
+        ".agents/tools/browser/crawl4ai-resources.md": {
+            "hash": "3b91d1b3383285e813ef8eed5303e3a6fa8fa99d",
+            "at": "2026-03-28T13:37:22Z",
+            "pr": 11858
+        },
+        ".agents/tools/build-mcp/build-mcp.md": {
+            "hash": "9b3ca67c49dd5bf0af66b01061561502620de8b3",
+            "at": "2026-03-28T13:37:27Z",
+            "pr": 11844
+        },
+        ".agents/tools/deployment/daytona.md": {
+            "hash": "752d573096d1a59e09ee119494e907e2e17d34ee",
+            "at": "2026-03-28T13:37:28Z",
+            "pr": 11846
+        },
+        ".agents/tools/ocr/ocr-research.md": {
+            "hash": "667a0af0fe47f5c2c316520d13beb61f1f9d0b7f",
+            "at": "2026-03-28T13:37:30Z",
+            "pr": 11857
+        },
+        ".agents/seo/contentking.md": {
+            "hash": "ce7ecac379f3bc6552cf23ad3bd149902b0ace12",
+            "at": "2026-03-28T13:37:31Z",
+            "pr": 11845
+        },
+        ".agents/services/email/mission-email.md": {
+            "hash": "bf5446200b94e750fce11fc719c2904f47bd67c5",
+            "at": "2026-03-28T13:37:15Z",
+            "pr": 11889
+        },
+        ".agents/tools/mobile/app-store-connect.md": {
+            "hash": "55340aa49411b8c5faf342ecbd1284bd9b126390",
+            "at": "2026-03-29T07:02:17Z",
+            "pr": 12625
+        },
+        ".agents/tools/browser/stagehand-examples.md": {
+            "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
+            "at": "2026-03-28T14:15:24Z",
+            "pr": 11899
+        },
+        ".agents/tools/ui/wxt.md": {
+            "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
+            "at": "2026-03-28T13:37:50Z",
+            "pr": 11870
+        },
+        ".agents/tools/code-review/secretlint.md": {
+            "hash": "54a79997b8c268d6b3942204a8b6e23a251bcfe3",
+            "at": "2026-03-28T16:00:52Z",
+            "pr": 11991
+        },
+        ".agents/tools/database/pglite-local-first.md": {
+            "hash": "57487b7d3c5e896eaebeeccd458d76e65cae5b8d",
+            "at": "2026-03-28T15:30:29Z",
+            "pr": 11920
+        },
+        ".agents/tools/document/document-extraction.md": {
+            "hash": "b0e790ef3e6481f532436eab39cac1d6ec92430b",
+            "at": "2026-03-28T15:30:30Z",
+            "pr": 11919
+        },
+        ".agents/tools/code-review/runtime-patterns.md": {
+            "hash": "06e2affe5aaa285c3139fde0d808dc89c0140e31",
+            "at": "2026-03-28T13:38:47Z",
+            "pr": 11771
+        },
+        ".agents/tools/browser/dev-browser.md": {
+            "hash": "5ff7878823ad9efd84ccc040b7165ca79150f8d4",
+            "at": "2026-03-28T15:30:31Z",
+            "pr": 11921
+        },
+        ".agents/tools/code-review/code-standards.md": {
+            "hash": "88d5b9dc281a4557707da37dee72529d600faaf8",
+            "at": "2026-03-28T15:30:22Z",
+            "pr": 11944
+        },
+        ".agents/scripts/commands/full-loop.md": {
+            "hash": "2721ce269c6727fb5021c0a3f122930366c47a4f",
+            "at": "2026-03-31T04:44:37Z",
+            "pr": 14590
+        },
+        ".agents/scripts/commands/ip-check.md": {
+            "hash": "50712771a5effc6d34ec205c3dd4616540d26311",
+            "at": "2026-03-31T02:20:51Z",
+            "pr": 14484
+        },
+        ".agents/scripts/commands/postflight-loop.md": {
+            "hash": "37a467bf622640eb6c8d75aa2c1de45c9a27c61c",
+            "at": "2026-04-01T20:59:31Z",
+            "pr": 14942
+        },
+        ".agents/scripts/commands/routine.md": {
+            "hash": "3f41b68e706f479c75df03b199f4b7c8a027644d",
+            "at": "2026-03-31T03:14:22Z",
+            "pr": 14509
+        },
+        ".agents/workflows/pr.md": {
+            "hash": "8f6584d97315d02aa4914a1f26165c57ff873479",
+            "at": "2026-03-29T14:29:47Z",
+            "pr": 13014
+        },
+        ".agents/tools/git/conflict-resolution.md": {
+            "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
+            "at": "2026-03-28T14:15:35Z",
+            "pr": 11909
+        },
+        ".agents/aidevops/configs.md": {
+            "hash": "fecc0e08b16083bdd8f7e82c6f1636c136af3287",
+            "at": "2026-03-28T15:30:49Z",
+            "pr": 11897
+        },
+        ".agents/services/communications/telfon.md": {
+            "hash": "02d4e621aff6b2ef17eecba67d3189df35171c09",
+            "at": "2026-03-31T04:46:03Z",
+            "pr": 14595
+        },
+        ".agents/services/communications/twilio.md": {
+            "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
+            "at": "2026-03-28T14:15:37Z",
+            "pr": 11900
+        },
+        ".agents/marketing-sales/ad-creative-platform-google.md": {
+            "hash": "f64e3f66de660586a2c510e31ce4a942286cf079",
+            "at": "2026-03-28T15:30:26Z",
+            "pr": 11936
+        },
+        ".agents/tools/ai-assistants/openclaw.md": {
+            "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
+            "at": "2026-03-28T14:15:40Z",
+            "pr": 11901
+        },
+        ".agents/content/video-wavespeed.md": {
+            "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
+            "at": "2026-03-28T14:15:41Z",
+            "pr": 11895
+        },
+        ".agents/seo/debug-opengraph.md": {
+            "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
+            "at": "2026-03-28T14:15:42Z",
+            "pr": 11898
+        },
+        ".agents/aidevops/plugins.md": {
+            "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
+            "at": "2026-03-28T14:15:43Z",
+            "pr": 11894
+        },
+        ".agents/services/hosting/local-hosting.md": {
+            "hash": "ac2a557901e0a9c39b034b664927c37847635345",
+            "at": "2026-03-28T16:41:15Z",
+            "pr": 12026
+        },
+        ".agents/tools/data-extraction/outscraper.md": {
+            "hash": "a3e3c1fee3571f9cfe07e4f90d47e3aa0c2c758a",
+            "at": "2026-03-28T16:41:16Z",
+            "pr": 12021
+        },
+        ".agents/content/distribution-email.md": {
+            "hash": "d218dc3fdd2a3e501978d431530820ce810b354e",
+            "at": "2026-03-28T16:00:42Z",
+            "pr": 11989
+        },
+        ".agents/services/database/postgres-drizzle-skill/migrations.md": {
+            "hash": "1b9f3f2536dd65950e7eec906f4c44467b9619e8",
+            "at": "2026-03-28T16:00:44Z",
+            "pr": 11966
+        },
+        ".agents/workflows/code-audit-remote.md": {
+            "hash": "2702ee79b7d0f63a13b19d69171f937db3e37064",
+            "at": "2026-03-28T15:31:24Z",
+            "pr": 11825
+        },
+        ".agents/tools/credentials/api-key-setup.md": {
+            "hash": "3fe770105e7b4c6edbff6f572b5189e5c2a7ba17",
+            "at": "2026-03-29T20:53:50Z",
+            "pr": 13279
+        },
+        ".agents/marketing-sales/ad-creative.md": {
+            "hash": "0fd2f3ed67a352a6b59ca35f1cb1be0ca62f691f",
+            "at": "2026-03-29T03:31:36Z",
+            "pr": 12505
+        },
+        ".agents/tools/mcp-toolkit/mcporter.md": {
+            "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
+            "at": "2026-03-28T14:16:17Z",
+            "pr": 11906
+        },
+        ".agents/marketing-sales/ad-creative-campaign-management.md": {
+            "hash": "cf88e0ca297eabefcb235d1359ee6d2b0e75d576",
+            "at": "2026-03-28T16:00:35Z",
+            "pr": 11974
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
+            "hash": "f74ee77c8e774c79829f80e238c09adbe6f3c21e",
+            "at": "2026-03-28T15:30:24Z",
+            "pr": 11945
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
+            "hash": "97a482f311bb9a1a99a103e7b77f815c8ce8af7e",
+            "at": "2026-03-28T15:30:35Z",
+            "pr": 11935
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
+            "hash": "9fda0fe135c5d900b529cbf4c9b5095c72c9a79d",
+            "at": "2026-03-28T16:00:33Z",
+            "pr": 11987
+        },
+        ".agents/tools/video/remotion.md": {
+            "hash": "e587ff6f81433c2bcc6b89ee139561849007d27e",
+            "at": "2026-03-28T15:30:25Z",
+            "pr": 11961
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/c3.md": {
+            "hash": "6ffc77f50024207bbb549b337789b8c9cbd8f475",
+            "at": "2026-03-28T15:30:18Z",
+            "pr": 11962
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
+            "hash": "3078a83990f41df192998904d47d0641191e7fba",
+            "at": "2026-03-28T16:00:25Z",
+            "pr": 11985
+        },
+        ".agents/tools/performance/performance.md": {
+            "hash": "478f1736c9c362f035765d45caddb4eebdec8071",
+            "at": "2026-03-28T16:00:21Z",
+            "pr": 11983
+        },
+        ".agents/aidevops/troubleshooting.md": {
+            "hash": "9b1e6b69bbb4c48b5d664dbb23d72a25eb867b0f",
+            "at": "2026-03-28T16:00:22Z",
+            "pr": 11982
+        },
+        ".agents/marketing-sales/cro-chapter-12.md": {
+            "hash": "f733b449021696b03a6678fba02aca9940fdeb6a",
+            "at": "2026-03-28T16:00:24Z",
+            "pr": 11988
+        },
+        ".agents/content/production-image.md": {
+            "hash": "b3409136a94a117c8a727fa3e1ca400d77806a36",
+            "at": "2026-03-28T16:40:38Z",
+            "pr": 12023
+        },
+        ".agents/tools/voice/voiceink-shortcut.md": {
+            "hash": "1d7af55d9fbf66d24dcb4f1cbba443617f0c992c",
+            "at": "2026-03-28T16:40:39Z",
+            "pr": 12017
+        },
+        ".agents/scripts/commands/testing-setup.md": {
+            "hash": "f653aacf0e67efffd18058625b81f790e9c9f741",
+            "at": "2026-03-28T16:40:41Z",
+            "pr": 12013
+        },
+        ".agents/workflows/multi-repo-workspace.md": {
+            "hash": "00ea218df67c941a8858e0da60f7c252c850db7a",
+            "at": "2026-03-28T16:00:32Z",
+            "pr": 11984
+        },
+        ".agents/workflows/version-bump.md": {
+            "hash": "d4d8c82182a0c0fce47622e76556260a11747ee8",
+            "at": "2026-03-28T16:00:36Z",
+            "pr": 11986
+        },
+        ".agents/content/video-higgsfield.md": {
+            "hash": "365b9f6acbaa7e54b14209c7eaee723372e836d6",
+            "at": "2026-03-28T16:00:37Z",
+            "pr": 11993
+        },
+        ".agents/services/hosting/cloudflare.md": {
+            "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
+            "at": "2026-03-28T16:00:49Z",
+            "pr": 11992
+        },
+        ".agents/services/monitoring/langwatch.md": {
+            "hash": "a56ed459849e479aaed06d6ac42bf0d60a28adf9",
+            "at": "2026-03-28T16:00:51Z",
+            "pr": 11994
+        },
+        ".agents/tools/wordpress/scf.md": {
+            "hash": "4c62a3f4c5312a10699889660578437def83e31e",
+            "at": "2026-03-28T16:40:07Z",
+            "pr": 12035
+        },
+        ".agents/workflows/readme-create-update.md": {
+            "hash": "f54854963d94f3c9b4e15769c07b3c8c27db1c5a",
+            "at": "2026-03-28T16:40:10Z",
+            "pr": 12038
+        },
+        ".agents/services/email/email-actions.md": {
+            "hash": "6e4fd843160e764848c98da37b2234e11ddfa56d",
+            "at": "2026-03-28T16:40:11Z",
+            "pr": 12039
+        },
+        ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
+            "hash": "52069355367fb596967a8aef0bb6ad7f8e9861c3",
+            "at": "2026-03-28T16:40:13Z",
+            "pr": 12030
+        },
+        ".agents/product/growth.md": {
+            "hash": "97246dfba596c1be9241c0b669c611df856e71bc",
+            "at": "2026-03-28T16:40:15Z",
+            "pr": 12037
+        },
+        ".agents/services/email/email-delivery-test.md": {
+            "hash": "229f4a8a141175830e0207dbb58b13d9146b22ab",
+            "at": "2026-03-28T16:40:17Z",
+            "pr": 12041
+        },
+        ".agents/services/email/email-verification.md": {
+            "hash": "d8d5bf1e0ed2feed034371b34ea74d5a572eac25",
+            "at": "2026-03-31T09:57:12Z",
+            "pr": 14757
+        },
+        ".agents/services/email/openpgp-setup.md": {
+            "hash": "f893cd98da28874d714707765c45a895d991cede",
+            "at": "2026-03-28T16:40:18Z",
+            "pr": 12040
+        },
+        ".agents/tools/programming/modern-javascript-skill/cheatsheet.md": {
+            "hash": "5043165087af14cf58963d7a76e48ceed463cb6d",
+            "at": "2026-03-28T16:40:20Z",
+            "pr": 12042
+        },
+        ".agents/services/hosting/cloudron.md": {
+            "hash": "e9d97dc1a3a3dbe0bb45134f1148c74954fa577c",
+            "at": "2026-03-28T16:40:22Z",
+            "pr": 12046
+        },
+        ".agents/tools/voice/pipecat-opencode.md": {
+            "hash": "53d34b6a543b30dcbc6141ccea72d1364e7ae07d",
+            "at": "2026-03-28T16:40:27Z",
+            "pr": 12019
+        },
+        ".agents/marketing-sales/meta-ads.md": {
+            "hash": "19b4754a783dd4b878bb5cf4032420f1cfab931d",
+            "at": "2026-03-28T16:40:30Z",
+            "pr": 12024
+        },
+        ".agents/tools/context/augment-context-engine.md": {
+            "hash": "bbae0554351a40b90c0df31e139c6391601f3e2b",
+            "at": "2026-03-28T16:40:32Z",
+            "pr": 12015
+        },
+        ".agents/tools/conversion/mineru.md": {
+            "hash": "beeb4a49df5e2a8ea91da9100ae2ba8887cf6b3d",
+            "at": "2026-03-28T16:40:36Z",
+            "pr": 12012
+        },
+        ".agents/marketing-sales/cro-chapter-14.md": {
+            "hash": "a15acda5b82f46b01af4961ff5c01fa7483e5cea",
+            "at": "2026-03-28T16:40:42Z",
+            "pr": 12027
+        },
+        ".agents/content/production-characters.md": {
+            "hash": "f26a85f43d79aed7426a749dab9407537412d65b",
+            "at": "2026-03-28T16:40:48Z",
+            "pr": 12025
+        },
+        ".agents/tools/code-review/security-audit.md": {
+            "hash": "bed16a626f218a4a0045edaae30edfa52616f72c",
+            "at": "2026-03-28T17:11:18Z",
+            "pr": 12029
+        },
+        ".agents/tools/security/privacy-filter.md": {
+            "hash": "20015ffb18e50ebb7071f1b6299b4404bdcd4071",
+            "at": "2026-03-28T16:41:02Z",
+            "pr": 12014
+        },
+        ".agents/tools/security/shannon.md": {
+            "hash": "a48914d21141559b0cf7677395979bd17f429b85",
+            "at": "2026-03-28T16:41:03Z",
+            "pr": 12016
+        },
+        ".agents/business/accounts-receipt-ocr.md": {
+            "hash": "7500c09629a5e47688af67a6901d684e92b623f2",
+            "at": "2026-03-28T16:41:24Z",
+            "pr": 12020
+        },
+        ".agents/tools/security/prompt-injection-defender.md": {
+            "hash": "0ee667b145d5e9aa8e6aefabf4ddc1c717cac0a0",
+            "at": "2026-03-28T17:11:06Z",
+            "pr": 12057
+        },
+        ".agents/seo/domain-research-api-reference.md": {
+            "hash": "52e574da550501d13cf7d760d098926843d5260b",
+            "at": "2026-03-28T17:11:07Z",
+            "pr": 12056
+        },
+        ".agents/seo/domain-research.md": {
+            "hash": "18f017104a97c94157077b8fc620e24bad8f86ba",
+            "at": "2026-03-28T17:11:08Z",
+            "pr": 12056
+        },
+        ".agents/scripts/commands/define.md": {
+            "hash": "228f38c6d509423d7158cef517bbd601a691923d",
+            "at": "2026-03-29T17:15:13Z",
+            "pr": 13131
+        },
+        ".agents/tools/browser/skyvern.md": {
+            "hash": "1f2933d4cdf35fd9696301a5743ae2e550a31eb0",
+            "at": "2026-03-28T17:11:10Z",
+            "pr": 12055
+        },
+        ".agents/seo/dataforseo.md": {
+            "hash": "8dfaad77d57b706e697ab23a2c8ac8a84cf9c6ed",
+            "at": "2026-03-28T17:11:12Z",
+            "pr": 12053
+        },
+        ".agents/tools/video/video-prompt-design.md": {
+            "hash": "ba533270f9fe5f9dab9fe60e3a4eef1420e2bd6c",
+            "at": "2026-03-28T17:30:25Z",
+            "pr": 12071
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md": {
+            "hash": "70f6f1b16aeb637c122232aa75b789bedfbe63a7",
+            "at": "2026-03-28T21:50:53Z",
+            "pr": 12192
+        },
+        ".agents/tools/browser/fingerprint-profiles.md": {
+            "hash": "d910625e173f65063d64d51ca549494b97a2ba87",
+            "at": "2026-03-28T17:30:27Z",
+            "pr": 12070
+        },
+        ".agents/tools/code-review/qlty.md": {
+            "hash": "3c3fef1897ddb0b0bb88a35205dfd4d6f715db13",
+            "at": "2026-03-28T18:36:46Z",
+            "pr": 12114
+        },
+        ".agents/tools/research/providers/wappalyzer.md": {
+            "hash": "ef665188513a7db11f82af28c6b0440d2b3943d5",
+            "at": "2026-03-28T20:17:04Z",
+            "pr": 12115
+        },
+        ".agents/services/communications/matterbridge.md": {
+            "hash": "10f123307b4f6919f65b9c46a2e9b5aecf37ef37",
+            "at": "2026-03-29T01:04:18Z",
+            "pr": 12399
+        },
+        ".agents/services/communications/simplex.md": {
+            "hash": "0fae9edf453dabb06fafed112e578d6f45e0f96c",
+            "at": "2026-03-28T20:16:50Z",
+            "pr": 12168
+        },
+        ".agents/tools/browser/watercrawl.md": {
+            "hash": "c3fc2a3c5ee117daba5dfbfae490dfb406b9e711",
+            "at": "2026-03-28T19:15:30Z",
+            "pr": 12117
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md": {
+            "hash": "733d3525cbf26277967990e47a34c41691036be8",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md": {
+            "hash": "785bdeaad722d0f542517cebae0f89e8f6828e73",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md": {
+            "hash": "93baaad7916863404459e50d80bfbba593f30589",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md": {
+            "hash": "97c3a7d841885f7124cda4603bc4f24f25394771",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md": {
+            "hash": "bf9eb0a6805213c30a476ba1a193467d85f8a0b7",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md": {
+            "hash": "eb8f44407cfde984193f403d441a2f080f32db71",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md": {
+            "hash": "1f2ca15e1758f9c72bf63021b81902c746f08a5d",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md": {
+            "hash": "3459fb86214d51707322f38fc1de4c32ca7434a0",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md": {
+            "hash": "8225af6a25a3cbad5d152becfc7be32b66146897",
+            "at": "2026-03-31T07:50:54Z",
+            "pr": 14717
+        },
+        ".agents/scripts/framework-issue-helper.sh": {
+            "hash": "a53fde8f11aabd50fbda03386f967721d987e07a",
+            "at": "2026-03-29T00:24:21Z",
+            "pr": 12145
+        },
+        ".agents/scripts/pulse-wrapper.sh": {
+            "hash": "36aed63a705a997b70c44687e1763e18a70e66b7",
+            "at": "2026-04-02T03:11:26Z",
+            "pr": 15086
+        },
+        ".agents/tools/browser/stagehand-python.md": {
+            "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
+            "at": "2026-03-30T02:31:00Z",
+            "pr": 13486
+        },
+        ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
+            "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
+            "at": "2026-03-28T20:16:39Z",
+            "pr": 12160
+        },
+        ".agents/tools/pdf/libpdf.md": {
+            "hash": "9d4d5fd4651f9132fb47d6467e53683fd7f0553b",
+            "at": "2026-03-28T20:16:42Z",
+            "pr": 12161
+        },
+        ".agents/services/email/email-agent.md": {
+            "hash": "4c589d1b951ae82f8dbb4a9e7ff05235f5edc6db",
+            "at": "2026-03-28T20:16:44Z",
+            "pr": 12163
+        },
+        ".agents/services/email/letter-post-bridge.md": {
+            "hash": "f6065bec96f8cb306e39fe1862b7bf456e1901d3",
+            "at": "2026-03-31T05:33:36Z",
+            "pr": 14646
+        },
+        ".agents/services/hosting/cloudflare-platform-skill.md": {
+            "hash": "6008b298c541d6b044eb0779f76074b818140d27",
+            "at": "2026-03-28T20:16:45Z",
+            "pr": 12162
+        },
+        ".agents/scripts/gh-signature-helper.sh": {
+            "hash": "e735571da002f6ed47f0b43dceaa313e6118204c",
+            "at": "2026-03-29T16:34:26Z",
+            "pr": 13021
+        },
+        ".agents/tools/wordpress/wp-dev.md": {
+            "hash": "c88f6e0f70e046ce19bf119077cef234636b2f4d",
+            "at": "2026-03-29T22:09:16Z",
+            "pr": 13341
+        },
+        ".agents/content/distribution-short-form.md": {
+            "hash": "8350ba659dc7fbcbecd70b55d52b65d296ce5401",
+            "at": "2026-03-28T20:16:49Z",
+            "pr": 12172
+        },
+        ".agents/content/platform-personas.md": {
+            "hash": "b0c32995086af230ae41412dd2dca98054968ce2",
+            "at": "2026-03-28T20:16:53Z",
+            "pr": 12167
+        },
+        ".agents/services/communications/privacy-comparison.md": {
+            "hash": "d36b5a85b507a958a555b6311d3266035d619ba8",
+            "at": "2026-03-28T20:16:54Z",
+            "pr": 12169
+        },
+        ".agents/services/database/multi-org-isolation.md": {
+            "hash": "2a09353ed9cbb973b0dd0344a938412bcc5b859e",
+            "at": "2026-03-28T21:59:22Z",
+            "pr": 12249
+        },
+        ".agents/workflows/review-issue-pr.md": {
+            "hash": "14ac8f78bcfbb8ec23df3e37c021b7cd512c2f5b",
+            "at": "2026-03-28T22:39:25Z",
+            "pr": 12308
+        },
+        ".agents/tools/browser/browser-qa.md": {
+            "hash": "629aa3a1df673d6e5df7310d173da5d3938aa04e",
+            "at": "2026-03-28T20:17:06Z",
+            "pr": 12171
+        },
+        ".agents/tools/mobile/app-dev-swift.md": {
+            "hash": "15ec4fad109dcdce50f6ed4a70d117caff12f906",
+            "at": "2026-03-29T07:03:03Z",
+            "pr": 12506
+        },
+        ".agents/tools/context/context7.md": {
+            "hash": "1d98876794a7dc00b2cd2126492a54302f051af8",
+            "at": "2026-03-28T20:56:05Z",
+            "pr": 12182
+        },
+        ".agents/marketing-sales/ad-creative-ai-tools-reference.md": {
+            "hash": "8faff4defc9b64a16a6da7b996a86d29763bb87e",
+            "at": "2026-03-28T20:56:07Z",
+            "pr": 12183
+        },
+        ".agents/seo/eeat-score.md": {
+            "hash": "bb9c0e98f32d0453eb08cbbb4222f06c1a13b007",
+            "at": "2026-03-28T20:56:08Z",
+            "pr": 12181
+        },
+        ".agents/tools/automation/cron-agent.md": {
+            "hash": "fbf1c6bc76acc1436d3da1b0b34296be5193de5a",
+            "at": "2026-03-28T20:56:11Z",
+            "pr": 12184
+        },
+        ".agents/marketing-sales/meta-ads-creative-briefs-ugc-brief.md": {
+            "hash": "b3cbdabb7633b010839689527b084c198f34bdc9",
+            "at": "2026-03-28T21:27:17Z",
+            "pr": 12217
+        },
+        ".agents/seo/keyword-research.md": {
+            "hash": "d00bca2d9a784bfd220b4afd767d384d83bea740",
+            "at": "2026-03-28T21:27:18Z",
+            "pr": 12220
+        },
+        ".agents/services/email/microsoft-graph.md": {
+            "hash": "953bb07aef8c8ed23c023cc574b6390196e3b16d",
+            "at": "2026-03-28T21:27:21Z",
+            "pr": 12218
+        },
+        ".agents/services/hosting/closte.md": {
+            "hash": "a9295d1bd4b72a378606ad987d9ea3d5385734c8",
+            "at": "2026-03-28T21:27:23Z",
+            "pr": 12219
+        },
+        ".agents/services/communications/telegram.md": {
+            "hash": "96307f35314ef975fc24bfc8ea3098ac307e2373",
+            "at": "2026-03-28T21:58:54Z",
+            "pr": 12233
+        },
+        ".agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md": {
+            "hash": "2fde1ee5df8c1bbde677a3198fe1c39df860a6ba",
+            "at": "2026-03-28T21:58:55Z",
+            "pr": 12236
+        },
+        ".agents/tools/programming/modern-javascript-skill/es2025.md": {
+            "hash": "e23026c24b61f06282834858aead51f63df3de4d",
+            "at": "2026-03-28T21:58:57Z",
+            "pr": 12234
+        },
+        ".agents/aidevops/resources.md": {
+            "hash": "4c8aa012ca51de765daed452692f619d55c701b1",
+            "at": "2026-03-28T21:58:59Z",
+            "pr": 12244
+        },
+        ".agents/tools/git/opencode-github-security.md": {
+            "hash": "7614267ce5278cc0f8d3e46a9301f179a610b9f3",
+            "at": "2026-03-28T22:39:20Z",
+            "pr": 12309
+        },
+        ".agents/tools/animation/animejs.md": {
+            "hash": "3d011c9aa6ae720f1ed6de08663bf78f589237ec",
+            "at": "2026-03-29T08:11:02Z",
+            "pr": 12745
+        },
+        ".agents/tools/build-mcp/deployment.md": {
+            "hash": "0229a7490f42dcf4f3b8c0958fefd7ff53f3b8a2",
+            "at": "2026-03-28T22:39:22Z",
+            "pr": 12311
+        },
+        ".agents/tools/browser/chrome-devtools.md": {
+            "hash": "13576e2127eccb1c8555a5b12660265ac4ebd8aa",
+            "at": "2026-03-28T22:39:23Z",
+            "pr": 12310
+        },
+        ".agents/tools/opencode/opencode.md": {
+            "hash": "b338bd4964d10e7780deddb27fc48d772a07be3b",
+            "at": "2026-03-29T11:20:16Z",
+            "pr": 12843
+        },
+        ".agents/tools/browser/browser-profiles.md": {
+            "hash": "2a2c771f4ff870ad450a92a0f9ad950f3f16e3cb",
+            "at": "2026-03-29T07:03:05Z",
+            "pr": 12501
+        },
+        ".agents/services/networking/netbird.md": {
+            "hash": "824fc7ee7cdc7e08351310bdb9f99dcf91a3848e",
+            "at": "2026-03-29T01:33:20Z",
+            "pr": 12453
+        },
+        ".agents/content/heygen-skill/rules-templates.md": {
+            "hash": "5d9c85b6e42715ec4914982ce21790312207dacf",
+            "at": "2026-03-29T08:10:46Z",
+            "pr": 12738
+        },
+        ".agents/marketing-sales/ad-creative-chapter-01.md": {
+            "hash": "e832ef8eb425956cec38a250eede0227342a4d79",
+            "at": "2026-03-28T23:05:56Z",
+            "pr": 12325
+        },
+        ".agents/marketing-sales/ad-creative-chapters.md": {
+            "hash": "7389f5acbff5e5b272cc97a5c5285e8a9b735427",
+            "at": "2026-03-28T23:05:56Z",
+            "pr": 12325
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/terraform-gotchas.md": {
+            "hash": "2111a2577e4e29eec771f709231f08fa22db2fc0",
+            "at": "2026-03-28T23:05:57Z",
+            "pr": 12324
+        },
+        ".agents/scripts/commands/new-task.md": {
+            "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
+            "at": "2026-03-30T02:30:59Z",
+            "pr": 13489
+        },
+        ".agents/scripts/commands/runners.md": {
+            "hash": "e15f89fc275c14393073efaa842849957733470c",
+            "at": "2026-03-28T23:06:00Z",
+            "pr": 12326
+        },
+        ".agents/scripts/commands/route.md": {
+            "hash": "8167fb30e984e156e02b5fb22c134db28ed8853d",
+            "at": "2026-03-31T04:45:56Z",
+            "pr": 14604
+        },
+        ".agents/seo/debug-favicon.md": {
+            "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",
+            "at": "2026-03-29T22:09:18Z",
+            "pr": 13323
+        },
+        ".agents/tools/code-review/code-simplifier.md": {
+            "hash": "9c62ffdb97ac1d0d44c1bed6c15abc856ee53a9b",
+            "at": "2026-03-30T00:00:00Z",
+            "pr": null
+        },
+        ".agents/tools/build-agent/add-skill.md": {
+            "hash": "36065ac3559aa2e929cbb858c8220961454f9dd9",
+            "at": "2026-03-29T01:03:17Z",
+            "pr": 12376
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md": {
+            "hash": "664f8b8e3ddeec9637d1647e3daed4495c1f4a96",
+            "at": "2026-04-01T23:23:23Z",
+            "pr": 15353
+        },
+        ".agents/content/distribution-youtube.md": {
+            "hash": "a44106f7677388ea6146e99c5c94de36b9e337ba",
+            "at": "2026-03-29T01:03:19Z",
+            "pr": 12386
+        },
+        ".agents/tools/build-mcp/transports.md": {
+            "hash": "733acaf8682f80a53cd3c2a996c0571adf7ac018",
+            "at": "2026-03-29T01:04:08Z",
+            "pr": 12394
+        },
+        ".agents/marketing-sales/meta-ads-campaigns-testing-abo.md": {
+            "hash": "be737a2fe12892ef6479a1939cbe4b6fee46db16",
+            "at": "2026-03-29T01:04:17Z",
+            "pr": 12395
+        },
+        ".agents/marketing-sales/ad-creative-chapter-08.md": {
+            "hash": "cff567e1f6215e9c459e5d97d022a93f34d1c322",
+            "at": "2026-03-29T01:04:19Z",
+            "pr": 12398
+        },
+        ".agents/marketing-sales/cro-chapter-07.md": {
+            "hash": "faba8a64f3996ee2e5722dd4b7c822d49f79c1b6",
+            "at": "2026-03-29T02:36:03Z",
+            "pr": 12463
+        },
+        ".agents/marketing-sales/ad-creative-chapter-07.md": {
+            "hash": "c79c8baa955bb48f1ce2ded8036ded7940948031",
+            "at": "2026-03-29T01:33:56Z",
+            "pr": 12442
+        },
+        ".agents/tools/browser/playwriter.md": {
+            "hash": "98bfa1b0dde9a405a0f3a07aa1ae3eaadc42801a",
+            "at": "2026-03-29T03:31:38Z",
+            "pr": 12516
+        },
+        ".agents/services/networking/tailscale.md": {
+            "hash": "e930b52dfd40905e93923b036c57b9ffc2bfa011",
+            "at": "2026-03-29T02:36:04Z",
+            "pr": 12461
+        },
+        ".agents/scripts/commands/remember.md": {
+            "hash": "9b17697bde40499a9feacb7812126a6474b0d5d4",
+            "at": "2026-03-29T03:14:59Z",
+            "pr": 12497
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/email-workers.md": {
+            "hash": "d43b669b4be0f3b85ad9b1e95ff67189431eafdc",
+            "at": "2026-03-29T03:15:00Z",
+            "pr": 12502
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
+            "hash": "12b23db6429e9400868f947faff09d534d18165d",
+            "at": "2026-03-31T09:29:58Z",
+            "pr": 14792
+        },
+        ".agents/tools/git/gitlab-cli.md": {
+            "hash": "de6952c2d9d3316c91c942921113892f89ddd42c",
+            "at": "2026-03-29T03:15:01Z",
+            "pr": 12498
+        },
+        ".agents/marketing-sales/cro-chapter-13.md": {
+            "hash": "e498cfacef39db0262cc094600055befe786ccfe",
+            "at": "2026-03-29T03:15:02Z",
+            "pr": 12499
+        },
+        ".agents/content/heygen-skill/rules-video-translation.md": {
+            "hash": "16bf014b85cd6ad3c1be9d593a97af8620313cbb",
+            "at": "2026-03-29T03:15:05Z",
+            "pr": 12504
+        },
+        ".agents/content/heygen-skill/rules-voices.md": {
+            "hash": "d3dbb1550c826e13f7c5288b74f72fcff3518efd",
+            "at": "2026-03-29T07:02:36Z",
+            "pr": 12577
+        },
+        ".agents/marketing-sales/ad-creative-chapter-12.md": {
+            "hash": "eca290e31ece1e36762bbf607353ddbdb27aaf52",
+            "at": "2026-03-29T03:15:08Z",
+            "pr": 12503
+        },
+        ".agents/reference/hashline-edit-format.md": {
+            "hash": "2f2019c30b4f9bb5d1947e6b7156833f15973c1e",
+            "at": "2026-04-01T23:23:50Z",
+            "pr": 15277
+        },
+        ".agents/tools/security/opsec.md": {
+            "hash": "c0427c90ef2576abbb9115f920944e06ee023080",
+            "at": "2026-03-29T03:15:14Z",
+            "pr": 12507
+        },
+        ".agents/scripts/commands/save-todo.md": {
+            "hash": "9b4ef4321b1b93eb8d349dbdae3b6c717838135c",
+            "at": "2026-03-29T03:15:15Z",
+            "pr": 12521
+        },
+        ".agents/services/payments/stripe.md": {
+            "hash": "6cbe509351f115869d196a09bc7031bb237d2a41",
+            "at": "2026-03-29T03:15:16Z",
+            "pr": 12511
+        },
+        ".agents/tools/browser/stagehand.md": {
+            "hash": "3702284e297e642ee7e2bb0c65470886fc7c0ffb",
+            "at": "2026-03-29T03:15:18Z",
+            "pr": 12513
+        },
+        ".agents/content/heygen-skill/rules-quota.md": {
+            "hash": "defa81f8873250c50ab8a9481e5d6f2b0958946c",
+            "at": "2026-03-29T07:02:38Z",
+            "pr": 12592
+        },
+        ".agents/tools/ui/tailwind-css.md": {
+            "hash": "1f3b2d4e3add5cecfe530b8db9addf411a9069fe",
+            "at": "2026-03-29T07:02:43Z",
+            "pr": 12576
+        },
+        ".agents/content/video-director.md": {
+            "hash": "7aa6d199c68cd683f60bf343be15f38db4484a11",
+            "at": "2026-03-29T07:02:22Z",
+            "pr": 12608
+        },
+        ".agents/marketing-sales/meta-ads-audiences-retargeting-setup.md": {
+            "hash": "dedfee9605d04b5a7cf9f5563c0e772f06e44062",
+            "at": "2026-03-29T03:15:24Z",
+            "pr": 12514
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/miniflare-gotchas.md": {
+            "hash": "c2a8232a749da0976495eabf4ea541b52bae82f8",
+            "at": "2026-03-29T07:02:46Z",
+            "pr": 12586
+        },
+        ".agents/tools/api/hono.md": {
+            "hash": "bf496281a1542c460ea880f936ec4d92dd928900",
+            "at": "2026-03-29T07:02:20Z",
+            "pr": 12607
+        },
+        ".agents/tools/opencode/opencode-anthropic-auth.md": {
+            "hash": "f05464c433b2b8e301af49ac5693cba5662ca6f7",
+            "at": "2026-03-29T03:15:28Z",
+            "pr": 12522
+        },
+        ".agents/tools/terminal/terminal-optimization.md": {
+            "hash": "f33e57108fd87d88906e414ae5caf4d169efb557",
+            "at": "2026-03-29T03:15:29Z",
+            "pr": 12526
+        },
+        ".agents/tools/ui/shadcn.md": {
+            "hash": "b65c32526cb52d71c76cead493b7c71147417a78",
+            "at": "2026-03-29T07:02:41Z",
+            "pr": 12590
+        },
+        ".agents/scripts/foss-handlers/generic.sh": {
+            "hash": "45cc10462795e6230b70b2f068bb95b4e53612f2",
+            "at": "2026-03-29T03:15:47Z",
+            "pr": 12346
+        },
+        ".agents/reference/foss-contributions.md": {
+            "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
+            "at": "2026-03-30T02:30:24Z",
+            "pr": 13561
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
+            "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
+            "at": "2026-03-29T07:02:06Z",
+            "pr": 12686
+        },
+        ".agents/services/hosting/hetzner.md": {
+            "hash": "34c50c3bfd8c86b684e922441da91443f8a22dfd",
+            "at": "2026-03-29T07:02:07Z",
+            "pr": 12687
+        },
+        ".agents/tools/deployment/hosting-comparison.md": {
+            "hash": "d29068fa3678e9cf3c2d6709305d5d71e5488dcb",
+            "at": "2026-03-29T07:02:09Z",
+            "pr": 12661
+        },
+        ".agents/marketing-sales/ad-creative-chapter-04.md": {
+            "hash": "35b67bea4f7521d18b9a3a75deb4b2508810e83d",
+            "at": "2026-03-29T07:02:10Z",
+            "pr": 12662
+        },
+        ".agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md": {
+            "hash": "0afd51341e71da8060a8a9e2759bf6629a430093",
+            "at": "2026-03-29T10:18:21Z",
+            "pr": 12844
+        },
+        ".agents/marketing-sales/cro-chapter-04.md": {
+            "hash": "f893022ded62f04d6ca13b86f839211e4fe8190a",
+            "at": "2026-03-29T07:02:12Z",
+            "pr": 12665
+        },
+        ".agents/services/communications/whatsapp.md": {
+            "hash": "dbc5cdbcdc61a880b5ca1c2746408002cc6fa7ac",
+            "at": "2026-03-29T12:37:29Z",
+            "pr": 12821
+        },
+        ".agents/tools/ai-orchestration/openprose.md": {
+            "hash": "7d17737b91f8878839b3430a51676211744becce",
+            "at": "2026-03-29T14:29:04Z",
+            "pr": 13007
+        },
+        ".agents/content/heygen-skill/rules-avatars.md": {
+            "hash": "e600865474071a7973fe0ed89b4fd361065e080a",
+            "at": "2026-03-29T07:02:16Z",
+            "pr": 12654
+        },
+        ".agents/services/email/email-mailbox.md": {
+            "hash": "e9ff02135b83557f59c4e444ef2f07607516b341",
+            "at": "2026-03-29T07:02:18Z",
+            "pr": 12624
+        },
+        ".agents/aidevops/onboarding.md": {
+            "hash": "6a88664be533136561cd84696accde70b2db1395",
+            "at": "2026-03-29T07:02:21Z",
+            "pr": 12641
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance.md": {
+            "hash": "8d3a6869182b857eedccac3ed7f13229f52abd06",
+            "at": "2026-03-29T15:08:45Z",
+            "pr": 13034
+        },
+        ".agents/services/accounting/quickfile.md": {
+            "hash": "db7040cc4f46334177d39ff45c6d4fd3be9698ee",
+            "at": "2026-03-29T07:02:24Z",
+            "pr": 12699
+        },
+        ".agents/services/outreach/instantly.md": {
+            "hash": "4d19b6424aa379940ec9b8b60dd80d08e9e472fc",
+            "at": "2026-03-31T05:36:34Z",
+            "pr": 14656
+        },
+        ".agents/services/outreach/manyreach.md": {
+            "hash": "94a3e08bcf4edafcd9654e8252a1a8851b004217",
+            "at": "2026-03-29T07:02:27Z",
+            "pr": 12581
+        },
+        ".agents/services/outreach/infraforge.md": {
+            "hash": "0d891dd02a90d75779370f3c62f2929df0bdcd31",
+            "at": "2026-03-31T05:38:33Z",
+            "pr": 14659
+        },
+        ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
+            "hash": "a2b88a20fedbcbbf37624126551caf4b6a101400",
+            "at": "2026-03-29T07:02:28Z",
+            "pr": 12584
+        },
+        ".agents/content/summarize.md": {
+            "hash": "937ce7f1f86adf1ef8f54d08458ca3421209fd10",
+            "at": "2026-03-29T07:02:30Z",
+            "pr": 12578
+        },
+        ".agents/tools/code-review/coderabbit.md": {
+            "hash": "3e37a12db3473bf11b36f10e75ede64bb2494e1b",
+            "at": "2026-03-29T07:02:31Z",
+            "pr": 12589
+        },
+        ".agents/services/email/thunderbird.md": {
+            "hash": "97b29677f0dc7c7542e4fb7c2e3dc10bc5445489",
+            "at": "2026-03-29T07:02:32Z",
+            "pr": 12582
+        },
+        ".agents/scripts/tests/test-gh-signature-helper.sh": {
+            "hash": "260aaa1fea5e42ba585a4c6cc8996794f9c7c2c6",
+            "at": "2026-03-29T13:19:54Z",
+            "pr": 12971
+        },
+        ".agents/tools/research/tech-stack-lookup.md": {
+            "hash": "bb8bdd9ccd46c7cc0742a5ba1849bb47746c2110",
+            "at": "2026-03-29T07:02:42Z",
+            "pr": 12579
+        },
+        ".agents/scripts/commands/neuronwriter.md": {
+            "hash": "233c0b9d671275ad8b68ef45c8afaff33acbec34",
+            "at": "2026-03-29T07:02:53Z",
+            "pr": 12588
+        },
+        ".agents/content/distribution-podcast.md": {
+            "hash": "0a2c98014bbe0588383437327d0b71e81a574af5",
+            "at": "2026-03-29T07:02:57Z",
+            "pr": 12557
+        },
+        ".agents/tools/git/gitea-cli.md": {
+            "hash": "9452ee8a8cf48269d5848e1d31384a3df0462ec5",
+            "at": "2026-03-29T07:02:58Z",
+            "pr": 12618
+        },
+        ".agents/tools/ui/react-email.md": {
+            "hash": "44be6e93a23aa087b4b70af9dc49a1c566c47e8c",
+            "at": "2026-03-29T07:02:59Z",
+            "pr": 12619
+        },
+        ".agents/content/heygen-skill/rules-photo-avatars.md": {
+            "hash": "d9a524f977f14c54b44991976651334aafa2e6e4",
+            "at": "2026-03-29T07:03:00Z",
+            "pr": 12620
+        },
+        ".agents/tools/browser/browser-use.md": {
+            "hash": "96d5278ed393a25379da0c21d04db2269219cbf9",
+            "at": "2026-03-29T07:03:02Z",
+            "pr": 12616
+        },
+        ".agents/workflows/ui-verification.md": {
+            "hash": "c59b154d588638a381fc14e85f435772cb88e31a",
+            "at": "2026-03-29T07:31:37Z",
+            "pr": 12705
+        },
+        ".agents/content/heygen-skill/rules-video-agent.md": {
+            "hash": "1d039d6d91c08e661a96696b19d43edbefe54b0e",
+            "at": "2026-03-29T07:31:38Z",
+            "pr": 12706
+        },
+        ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
+            "hash": "cc7a9cfce528e2d77c1fe2c9b29e09442b5eaf25",
+            "at": "2026-03-30T06:49:15Z",
+            "pr": 13931
+        },
+        ".agents/tools/deployment/cloudron-server-ops-skill.md": {
+            "hash": "ef42b29c1fcb28a5de1fb8be65f21496d5ef10cf",
+            "at": "2026-03-30T03:33:52Z",
+            "pr": 13678
+        },
+        ".agents/scripts/commands/skills.md": {
+            "hash": "b5d46b5e38620ec36852251ec0e4ab4178d9d217",
+            "at": "2026-03-29T08:10:30Z",
+            "pr": 12747
+        },
+        ".agents/scripts/commands/youtube-research.md": {
+            "hash": "340b914ca94d03a0c78878b9ec28534fc761f352",
+            "at": "2026-03-29T08:10:31Z",
+            "pr": 12750
+        },
+        ".agents/tools/ai-assistants/agno.md": {
+            "hash": "0e8f56a7ce9681124205e8492ed4878f1a9c73c3",
+            "at": "2026-03-29T08:10:32Z",
+            "pr": 12746
+        },
+        ".agents/tools/deployment/coolify.md": {
+            "hash": "c69569ccf737f434c5d2c4c031ab9fb87e3f6125",
+            "at": "2026-03-29T08:10:34Z",
+            "pr": 12748
+        },
+        ".agents/tools/mobile/app-dev.md": {
+            "hash": "5fa80cfb5528478d449196a550ffb263ac4380e0",
+            "at": "2026-03-29T08:10:35Z",
+            "pr": 12752
+        },
+        ".agents/marketing-sales/cro.md": {
+            "hash": "9a8a0b49c40c42072e982a4dd40761c19c0055ed",
+            "at": "2026-03-29T08:10:36Z",
+            "pr": 12753
+        },
+        ".agents/scripts/commands/strategic-review.md": {
+            "hash": "321755ff5b42109fb2ed065075b903ecfed76407",
+            "at": "2026-03-29T08:10:38Z",
+            "pr": 12756
+        },
+        ".agents/tools/context/prompt-optimization.md": {
+            "hash": "94abbde385ccf494358e17a79a32fdc72d4adb58",
+            "at": "2026-03-29T08:10:39Z",
+            "pr": 12749
+        },
+        ".agents/tools/credentials/environment-variables.md": {
+            "hash": "4a7ee0834fefdbf424af90c68648ad35716559c7",
+            "at": "2026-03-29T08:10:40Z",
+            "pr": 12751
+        },
+        ".agents/tools/design/design-inspiration.md": {
+            "hash": "c45174a87827d85931f259a2e60da60b030b9fef",
+            "at": "2026-03-29T08:10:43Z",
+            "pr": 12754
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md": {
+            "hash": "2fda89c67e49f210c5079578f56272001edd02d9",
+            "at": "2026-03-29T08:11:29Z",
+            "pr": 12755
+        },
+        ".agents/tools/local-models/local-models.md": {
+            "hash": "9809ec0871562ca709e8ef42cf6c3b67d24b69ce",
+            "at": "2026-03-29T08:11:30Z",
+            "pr": 12758
+        },
+        ".agents/tools/mobile/app-dev-publishing.md": {
+            "hash": "5b8ce6f4b5d555eeef5ee8e3cc8f7a933b405529",
+            "at": "2026-03-29T08:11:31Z",
+            "pr": 12760
+        },
+        ".agents/tools/mobile/agent-device.md": {
+            "hash": "29bde4b26353446f6b35c132fcc1c01a80b71d4c",
+            "at": "2026-03-29T08:49:16Z",
+            "pr": 12788
+        },
+        ".agents/content/context-templates.md": {
+            "hash": "a9fe6ed3b2336078d56022e1ea971da34b97a6db",
+            "at": "2026-04-02T04:00:00Z",
+            "pr": 14934
+        },
+        ".agents/content/video-enhancor.md": {
+            "hash": "c92832f61d3cd78705b2913a0662b1ecee089aae",
+            "at": "2026-03-29T08:49:19Z",
+            "pr": 12796
+        },
+        ".agents/tools/infrastructure/nvidia-cloud.md": {
+            "hash": "3dfae170793fb08c63d93733cd5ad81760d651ee",
+            "at": "2026-03-29T08:49:20Z",
+            "pr": 12776
+        },
+        ".agents/reference/planning-detail.md": {
+            "hash": "c5c616d56a09198023878a228bbf7311f9bd0212",
+            "at": "2026-03-29T08:49:21Z",
+            "pr": 12780
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md": {
+            "hash": "dd2e25d9b8dbb4578e676187c9463404feaa3fec",
+            "at": "2026-03-29T08:49:23Z",
+            "pr": 12779
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/turn.md": {
+            "hash": "10963e4e50c30efb3918e434ec90cafa0ac2f51a",
+            "at": "2026-03-29T08:50:09Z",
+            "pr": 12801
+        },
+        ".agents/tools/task-management/beads.md": {
+            "hash": "f42ad2e963039fd53ee52d1443827cbe4f6158c0",
+            "at": "2026-03-29T09:39:21Z",
+            "pr": 12830
+        },
+        ".agents/tools/verification/parallel-verify.md": {
+            "hash": "0abbe9f5d2f2082016fd851080ea1f9a84a03fe9",
+            "at": "2026-03-29T10:19:07Z",
+            "pr": 12849
+        },
+        ".agents/services/hosting/domain-purchasing.md": {
+            "hash": "90b1b455705be948e790ea947fafca8285ca29d9",
+            "at": "2026-03-29T10:47:23Z",
+            "pr": 12867
+        },
+        ".agents/tools/infrastructure/nearai.md": {
+            "hash": "c20f6f36a9c7c2fabc45e4c356d09b3589fb6a64",
+            "at": "2026-03-29T10:47:24Z",
+            "pr": 12869
+        },
+        ".agents/tools/accessibility/accessibility.md": {
+            "hash": "89e683f33936c408a6b266a13c4291d2794e5eec",
+            "at": "2026-03-29T10:47:27Z",
+            "pr": 12870
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md": {
+            "hash": "304f6cf07b8e1ce2ccf0991e5a1c7a048d898f2b",
+            "at": "2026-03-29T14:29:37Z",
+            "pr": 13020
+        },
+        ".agents/tools/browser/proxy-integration.md": {
+            "hash": "46806f6e0dcec4831dc62abb84c2f5f96326c102",
+            "at": "2026-03-29T15:08:41Z",
+            "pr": 13032
+        },
+        ".agents/tools/ai-assistants/capsolver.md": {
+            "hash": "934e330cfc0b1a30efe5bf139296ae882f868709",
+            "at": "2026-03-29T12:36:41Z",
+            "pr": 12953
+        },
+        ".agents/workflows/session-review.md": {
+            "hash": "0209719f0b5eb68905b4edbdc6bffe1fa8d8a54d",
+            "at": "2026-03-29T11:19:53Z",
+            "pr": 12889
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/durable-objects-gotchas.md": {
+            "hash": "befbfbdf1c28bab3d56f52fb86b4a85a7a988da5",
+            "at": "2026-03-29T11:19:55Z",
+            "pr": 12890
+        },
+        ".agents/tools/credentials/vaultwarden.md": {
+            "hash": "49a473adf85c8382799bc059d99c1693cbea98a9",
+            "at": "2026-03-29T12:36:43Z",
+            "pr": 12951
+        },
+        ".agents/services/payments/superwall.md": {
+            "hash": "1c533274b85654214054f396d45e2b1d09425b85",
+            "at": "2026-03-29T12:36:44Z",
+            "pr": 12952
+        },
+        ".agents/tools/browser/extension-dev/publishing.md": {
+            "hash": "7fe8e877846c0dc155d639a1b5dd214e47c7e499",
+            "at": "2026-03-29T11:20:06Z",
+            "pr": 12884
+        },
+        ".agents/tools/infrastructure/cloudflare-ai.md": {
+            "hash": "e62ec76bd3969af84f0aa5378e1e43dc06ec2674",
+            "at": "2026-04-01T20:50:00Z",
+            "pr": 15091
+        },
+        ".agents/content/heygen-skill/rules-scripts.md": {
+            "hash": "ca533a5f39d9590f0056916b545eeb9338b12976",
+            "at": "2026-03-30T04:51:44Z",
+            "pr": 13767
+        },
+        ".agents/marketing-sales/meta-ads-foundations-attribution.md": {
+            "hash": "7bd8755456129fcd79c106e7e829c6233ae16c42",
+            "at": "2026-03-29T11:51:45Z",
+            "pr": 12920
+        },
+        ".agents/tools/voice/speech-to-speech.md": {
+            "hash": "54c12a6e35c2fd9bdbc1476b98053f3fd40c5580",
+            "at": "2026-03-29T14:29:05Z",
+            "pr": 13005
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/advanced.md": {
+            "hash": "66bd6cabafb5379b9b183e5c0721e35852080713",
+            "at": "2026-03-29T11:51:51Z",
+            "pr": 12922
+        },
+        ".agents/marketing-sales/cro-chapter-05.md": {
+            "hash": "2a9c49266d0a50ef42a41c590041ff6aeb62135c",
+            "at": "2026-03-29T09:20:58Z",
+            "pr": 12824
+        },
+        ".agents/tools/research/providers/unbuilt.md": {
+            "hash": "24d4b4257014273b29b58f5e185f3320e798dad0",
+            "at": "2026-03-29T12:36:25Z",
+            "pr": 12945
+        },
+        ".agents/marketing-sales/meta-ads-checklists-weekly-review.md": {
+            "hash": "8ddae4fd98efd953d4ecaa242553ad3eda337a92",
+            "at": "2026-03-29T12:36:27Z",
+            "pr": 12947
+        },
+        ".agents/scripts/commands/mission.md": {
+            "hash": "e13208184cee9ed81fd7f6bddfef98bbcd41b5f5",
+            "at": "2026-03-29T12:36:32Z",
+            "pr": 12959
+        },
+        ".agents/services/analytics/google-analytics.md": {
+            "hash": "ee41c3c82de9e7f7dfa997caf2efea635a61fd7f",
+            "at": "2026-03-29T12:36:33Z",
+            "pr": 12950
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md": {
+            "hash": "b194dbf29525881c1c8296a33806387d7ca7fe7f",
+            "at": "2026-03-29T12:36:34Z",
+            "pr": 12955
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
+            "hash": "07e97feffa7bc2100478d39e614278ab867ba605",
+            "at": "2026-03-29T12:36:58Z",
+            "pr": 12944
+        },
+        ".agents/seo/seo-audit-skill.md": {
+            "hash": "d8493f42e8ba01527667d283942af955218a834f",
+            "at": "2026-03-29T12:37:05Z",
+            "pr": 12948
+        },
+        ".agents/tools/video/remotion-audio.md": {
+            "hash": "c5cce614253505277075e44f178650fab250bd7b",
+            "at": "2026-03-29T12:37:07Z",
+            "pr": 12942
+        },
+        ".agents/aidevops/security-requirements.md": {
+            "hash": "8b86459a5459bd0be5402ca5660bfd99fa54a782",
+            "at": "2026-03-29T12:37:08Z",
+            "pr": 12946
+        },
+        ".agents/marketing-sales/cro-chapter-03.md": {
+            "hash": "ac80d924629caf06f25a2c2bf503c1aa2267d8de",
+            "at": "2026-03-29T12:37:09Z",
+            "pr": 12954
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-patterns.md": {
+            "hash": "e0498ebcd0125ebedaa97fd88662f8aeff47412a",
+            "at": "2026-03-29T12:37:11Z",
+            "pr": 12909
+        },
+        ".agents/product/validation.md": {
+            "hash": "74840e4aa9e8d619ae82517ca6a1b43a00f99b56",
+            "at": "2026-03-29T12:37:13Z",
+            "pr": 12910
+        },
+        ".agents/scripts/commands/youtube-setup.md": {
+            "hash": "d3f66f792c780e690b58d7f976c01c3d64f09a52",
+            "at": "2026-03-29T12:37:14Z",
+            "pr": 12943
+        },
+        ".agents/services/communications/urbit.md": {
+            "hash": "dc74bf7135da0ba31e070bedbe6be841d6b9588b",
+            "at": "2026-03-29T12:37:15Z",
+            "pr": 12911
+        },
+        ".agents/services/email/email-intelligence.md": {
+            "hash": "4046abd7e9e4fffe477b2aa6fedd74cc46fb9708",
+            "at": "2026-03-29T12:37:18Z",
+            "pr": 12912
+        },
+        ".agents/content/distribution-youtube-channel-intel.md": {
+            "hash": "e7acafaec5e56e608968ecc99a7005352995560c",
+            "at": "2026-03-29T12:37:24Z",
+            "pr": 12791
+        },
+        ".agents/tools/ai-assistants/compare-models.md": {
+            "hash": "4ee54c0d4a2a76b5646c8d5bd3403a6bc744f649",
+            "at": "2026-03-29T14:29:46Z",
+            "pr": 13017
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance-caching.md": {
+            "hash": "8c834b7d97111cfa9897297aa73c2ef3b366bf16",
+            "at": "2026-03-29T15:08:44Z",
+            "pr": 13034
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance-explain.md": {
+            "hash": "230ed08a521dea04c78c68e8f7e5eab11f68ea65",
+            "at": "2026-03-29T15:08:44Z",
+            "pr": 13034
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance-indexing.md": {
+            "hash": "982123000c56dcfb6394064ab6d5ad13a0603dbb",
+            "at": "2026-03-29T15:08:44Z",
+            "pr": 13034
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance-monitoring.md": {
+            "hash": "38276dd264af6fef1c634f2620d188483aec50be",
+            "at": "2026-03-29T15:08:44Z",
+            "pr": 13034
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance-pagination.md": {
+            "hash": "7e533ff31428e865c8c608139b2835b146164832",
+            "at": "2026-03-29T15:08:44Z",
+            "pr": 13034
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance-pooling.md": {
+            "hash": "470b2b768f6fff6d4e925000ec0026254511ea0e",
+            "at": "2026-03-29T15:08:45Z",
+            "pr": 13034
+        },
+        ".agents/services/database/postgres-drizzle-skill/performance-queries.md": {
+            "hash": "3caacdf6f9053841bd7863c9f7dc002a8b784d1e",
+            "at": "2026-03-29T15:08:45Z",
+            "pr": 13034
+        },
+        ".agents/content/content-calendar.md": {
+            "hash": "5bb7dca9397875d571887657d6e92d551536e6cd",
+            "at": "2026-03-29T15:50:25Z",
+            "pr": 13052
+        },
+        ".agents/content/story.md": {
+            "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
+            "at": "2026-03-29T17:14:35Z",
+            "pr": 13457
+        },
+        ".agents/build-plus.md": {
+            "hash": "9a8681dd42ae12e35c79f2f2479a29dfc90794f9",
+            "at": "2026-03-29T16:10:49Z",
+            "pr": 13101
+        },
+        ".agents/services/communications/google-chat.md": {
+            "hash": "af2981e3fd22fa349f051dda8a12615f9fd5d65d",
+            "at": "2026-03-30T03:33:48Z",
+            "pr": 13658
+        },
+        ".agents/tools/deployment/fly-io.md": {
+            "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
+            "at": "2026-03-30T02:30:21Z",
+            "pr": 13596
+        },
+        ".agents/tools/design/brand-identity.md": {
+            "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
+            "at": "2026-03-29T16:31:32Z",
+            "pr": 13093
+        },
+        ".agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md": {
+            "hash": "a641f8d02e933160986b8c49c4f6a5245d325014",
+            "at": "2026-03-29T15:50:34Z",
+            "pr": 13064
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
+            "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
+            "at": "2026-03-30T02:30:53Z",
+            "pr": 13494
+        },
+        ".agents/tools/ai-assistants/response-scoring.md": {
+            "hash": "6eadf895b9b3ea1caaf55456d25937d9152c15eb",
+            "at": "2026-03-29T15:50:37Z",
+            "pr": 13072
+        },
+        ".agents/tools/deployment/coolify-setup.md": {
+            "hash": "5041a915d0c96f4651205ed6ca0799a2d190757c",
+            "at": "2026-03-29T15:50:41Z",
+            "pr": 13067
+        },
+        ".agents/tools/vision/image-understanding.md": {
+            "hash": "e8a08b674fb1c451c0b3d2ebdc2290f860817199",
+            "at": "2026-03-29T23:53:56Z",
+            "pr": 13458
+        },
+        ".agents/marketing-sales/meta-ads-optimization-automation-rules.md": {
+            "hash": "4e78284e12f62b421b7458d171f79117bc4610e9",
+            "at": "2026-03-29T15:50:44Z",
+            "pr": 13078
+        },
+        ".agents/services/crm/fluentcrm.md": {
+            "hash": "9e0e2c55d608f6cc55ceec5f45e845bbbc841b0c",
+            "at": "2026-03-29T15:51:03Z",
+            "pr": 13048
+        },
+        ".agents/scripts/commands/pulse.md": {
+            "hash": "17825f98cccc6a5b38ed9877d2c1f493287e7a61",
+            "at": "2026-03-29T16:31:29Z",
+            "pr": 13117
+        },
+        ".agents/workflows/feature-development.md": {
+            "hash": "6b9311970a27d48d12002b62e59c9a6ac2087cc8",
+            "at": "2026-03-29T16:31:49Z",
+            "pr": 13065
+        },
+        ".agents/aidevops.md": {
+            "hash": "cf74c159d129be3c0c891b416bd45c0c11a5613b",
+            "at": "2026-03-29T16:31:51Z",
+            "pr": 13063
+        },
+        ".agents/marketing-sales/ad-creative-chapter-09.md": {
+            "hash": "2bdf7194dc300dd779d03b44a37d35015e9f282d",
+            "at": "2026-03-29T16:34:21Z",
+            "pr": 13110
+        },
+        ".agents/marketing-sales/cro-chapter-20.md": {
+            "hash": "07aa1e83fefdc10d56b044961da2976b1e693895",
+            "at": "2026-03-29T16:34:29Z",
+            "pr": 13105
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
+            "hash": "dca9ceb5efbdd602847f9c0030471e543684e1a6",
+            "at": "2026-03-30T03:33:46Z",
+            "pr": 13654
+        },
+        ".agents/tools/document/docstrange.md": {
+            "hash": "3982c1885258882161976446bb94216d4e7df262",
+            "at": "2026-03-29T16:34:31Z",
+            "pr": 13102
+        },
+        ".agents/tools/mobile/app-dev-assets.md": {
+            "hash": "7c4254ecd409ec8aa9947d5ac9bb1043f89ee75c",
+            "at": "2026-03-29T16:34:32Z",
+            "pr": 13108
+        },
+        ".agents/services/communications/imessage.md": {
+            "hash": "6739eea3f16ee84c8d647388816d022bb26c6a22",
+            "at": "2026-03-30T00:32:20Z",
+            "pr": 13468
+        },
+        ".agents/tools/context/github-search.md": {
+            "hash": "526e968501aef58e8e7676ede7ab1396404a32c5",
+            "at": "2026-03-29T16:34:35Z",
+            "pr": 13106
+        },
+        ".agents/tools/voice/hyprwhspr.md": {
+            "hash": "cd50b6d85cbb4fe055191de5b27fd60418def072",
+            "at": "2026-03-29T16:34:36Z",
+            "pr": 13103
+        },
+        ".agents/tools/mobile/app-dev-notifications.md": {
+            "hash": "c414024f2e98e68e7f70531095cc1abe49cceccd",
+            "at": "2026-03-29T16:34:38Z",
+            "pr": 13111
+        },
+        ".agents/workflows/session-manager.md": {
+            "hash": "e90fb5dbed96bd48a27404dce7d7b8d60d66a053",
+            "at": "2026-03-29T23:53:41Z",
+            "pr": 13443
+        },
+        ".agents/aidevops/architecture.md": {
+            "hash": "f1d29dba0c0d676b0d00e4e5adac2d79f9aa2dd1",
+            "at": "2026-03-29T23:53:47Z",
+            "pr": 13445
+        },
+        ".agents/content/production-audio.md": {
+            "hash": "e25e6c20e39bf0e3ddecacd21aa5c1425aa997ef",
+            "at": "2026-03-30T00:32:17Z",
+            "pr": 13478
+        },
+        ".agents/workflows/bug-fixing.md": {
+            "hash": "40fa82a3220595ff946fdc60ec4a03b193032f58",
+            "at": "2026-03-29T16:34:52Z",
+            "pr": 13056
+        },
+        ".agents/business.md": {
+            "hash": "359aefa91dc7dcd75049c36dbf54965be0fc9e2c",
+            "at": "2026-03-29T16:34:54Z",
+            "pr": 13055
+        },
+        ".agents/content/heygen-skill/rules-assets.md": {
+            "hash": "eed9c26fe6697296ac16fa54421ac1d4f9d6f2fc",
+            "at": "2026-03-29T16:34:55Z",
+            "pr": 13054
+        },
+        ".agents/product/onboarding.md": {
+            "hash": "bc634e70e9bb850181c2c4c0d239a36447560921",
+            "at": "2026-03-29T23:54:00Z",
+            "pr": 13399
+        },
+        ".agents/tools/infrastructure/together.md": {
+            "hash": "cb2b6cf6c54db6f97c2bde70675f3c29b30b88fa",
+            "at": "2026-03-29T17:15:24Z",
+            "pr": 13113
+        },
+        ".agents/workflows/sql-migrations.md": {
+            "hash": "b33b92df6c10b12772797d8d75b314b69698af6e",
+            "at": "2026-03-30T06:03:19Z",
+            "pr": 13838
+        },
+        ".agents/tools/voice/qwen3-tts.md": {
+            "hash": "5e96cd787b4b8b6ae97d6f3113978c0b334e5484",
+            "at": "2026-03-29T19:05:52Z",
+            "pr": 13190
+        },
+        ".agents/marketing-sales/ad-creative-chapter-11.md": {
+            "hash": "2fbaad774769229326c549e278ffe31d26906d66",
+            "at": "2026-03-29T20:54:11Z",
+            "pr": 13222
+        },
+        ".agents/tools/vision/image-generation.md": {
+            "hash": "68fb24cbb02218008d86f1fb1381347f5ac1e533",
+            "at": "2026-03-29T19:51:31Z",
+            "pr": 13249
+        },
+        ".agents/tools/context/dspy.md": {
+            "hash": "a452d6023063a0eebf04141ae94d61a0867830da",
+            "at": "2026-03-29T20:53:49Z",
+            "pr": 13289
+        },
+        ".agents/tools/voice/ios-shortcut.md": {
+            "hash": "bf8f2ead853742819aa8ea972f3f39d7e38c58be",
+            "at": "2026-03-29T20:53:52Z",
+            "pr": 13286
+        },
+        ".agents/services/email/email-design-test.md": {
+            "hash": "216d3927030caa28089c7500c2f6b81c62897d17",
+            "at": "2026-03-29T22:09:19Z",
+            "pr": 13324
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-gotchas.md": {
+            "hash": "eb3c145850e0125035e13fd4bd424405fa4efb97",
+            "at": "2026-03-29T20:53:54Z",
+            "pr": 13291
+        },
+        ".agents/tools/mobile/ios-simulator-mcp.md": {
+            "hash": "c671f21c21913d5bc3199aaaf1ad5ea389fa67e7",
+            "at": "2026-03-29T20:53:56Z",
+            "pr": 13299
+        },
+        ".agents/tools/security/cdn-origin-ip.md": {
+            "hash": "0ffd8a94c87de9f75a5515cd4ad4e87ab4b1552b",
+            "at": "2026-03-29T20:53:57Z",
+            "pr": 13290
+        },
+        ".agents/scripts/commands/show-plan.md": {
+            "hash": "a50ab6b6bab142d6f388d385dfa6a525b458cac9",
+            "at": "2026-03-29T20:53:58Z",
+            "pr": 13285
+        },
+        ".agents/services/communications/bitchat.md": {
+            "hash": "38ac38ee1cb82fb462fc13746fbf560042e6e9a7",
+            "at": "2026-03-29T20:53:59Z",
+            "pr": 13287
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/d1-patterns.md": {
+            "hash": "8e6341f6f72cefdc4c09224910c1c4efe62de068",
+            "at": "2026-03-29T21:43:01Z",
+            "pr": 13296
+        },
+        ".agents/tools/context/context-builder.md": {
+            "hash": "27fb0c83ee803a7eebb4ace6202875b0a844786b",
+            "at": "2026-03-29T20:54:03Z",
+            "pr": 13297
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md": {
+            "hash": "79456bef17217d0052079264a0c95b59456d5385",
+            "at": "2026-03-29T21:43:04Z",
+            "pr": 13300
+        },
+        ".agents/tools/git/opencode-gitlab.md": {
+            "hash": "dbbdec9a030f52229eab4d047431f4ed5b0de5ca",
+            "at": "2026-03-29T20:54:06Z",
+            "pr": 13295
+        },
+        ".agents/marketing-sales/cro-chapter-01.md": {
+            "hash": "5dad243a2a5744924aeb5b2e39fe94aad887af5e",
+            "at": "2026-03-29T20:54:07Z",
+            "pr": 13294
+        },
+        ".agents/seo/programmatic-seo.md": {
+            "hash": "246454e374da68bf1dcec5b59e732fac3841e7dd",
+            "at": "2026-03-29T21:43:09Z",
+            "pr": 13301
+        },
+        ".agents/tools/mobile/app-dev-backend.md": {
+            "hash": "1521ed7526fbc0fb399a1f5edf01adb4129a08f6",
+            "at": "2026-03-29T20:54:10Z",
+            "pr": 13293
+        },
+        ".agents/marketing-sales/meta-ads-campaigns-scaling-cbo.md": {
+            "hash": "6fb79b1689e522f77f09f4398f80430c8c727116",
+            "at": "2026-03-29T21:42:59Z",
+            "pr": 13263
+        },
+        ".agents/marketing-sales/meta-ads-foundations-account-structure.md": {
+            "hash": "d8a1a11c970efd832edd47784162978ad05783f0",
+            "at": "2026-03-29T21:43:00Z",
+            "pr": 13333
+        },
+        ".agents/tools/video/remotion-measuring-text.md": {
+            "hash": "619d768e114ab99f64b37c93d1628ae5cb7d54a4",
+            "at": "2026-03-29T21:43:06Z",
+            "pr": 13315
+        },
+        ".agents/marketing-sales/cro-chapter-17.md": {
+            "hash": "55117c563ab956b0653eca2c335a7e8c14e15708",
+            "at": "2026-03-29T21:43:12Z",
+            "pr": 13339
+        },
+        ".agents/scripts/commands/dashboard.md": {
+            "hash": "c72021fe5b7c20c340b5a5a1e1b66cf6b3d247f9",
+            "at": "2026-03-29T21:43:13Z",
+            "pr": 13338
+        },
+        ".agents/services/email/email-security.md": {
+            "hash": "933383c81c9e820f3d3b80f5dbd3db61d496e0cb",
+            "at": "2026-03-29T21:43:14Z",
+            "pr": 13343
+        },
+        ".agents/tools/mobile/minisim.md": {
+            "hash": "4e237b094b421f7ff8557426808fd3d6380b4ef1",
+            "at": "2026-03-29T21:43:16Z",
+            "pr": 13340
+        },
+        ".agents/tools/security/tamper-evident-audit.md": {
+            "hash": "ef75d5914e0ae15e449ccd4480b0add3eda84c71",
+            "at": "2026-03-29T21:43:17Z",
+            "pr": 13316
+        },
+        ".agents/tools/vision/image-editing.md": {
+            "hash": "1b91142d29e8ff6515be5a6208386de1fcaf383d",
+            "at": "2026-03-29T21:43:18Z",
+            "pr": 13236
+        },
+        ".agents/business/accounts-subscription-audit.md": {
+            "hash": "ef31fbb7ef1c8e43fc6f5e6ff3f7bed9b5b0e3a0",
+            "at": "2026-03-29T21:43:19Z",
+            "pr": 13235
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workflows-gotchas.md": {
+            "hash": "f9b10b21adc0e823054085098ba86a6e8432ade1",
+            "at": "2026-03-29T21:43:20Z",
+            "pr": 13342
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workflows-patterns.md": {
+            "hash": "7b01531e7d09b10fc7ab3a1706498fd011b6bb1b",
+            "at": "2026-03-29T21:43:21Z",
+            "pr": 13342
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workflows.md": {
+            "hash": "5faeef07292125f8b45b6b29bc0b24d06d24c1f1",
+            "at": "2026-03-29T21:43:21Z",
+            "pr": 13342
+        },
+        ".agents/tools/infrastructure/cloud-gpu.md": {
+            "hash": "f2b2d82030ffec23c21ca82c2833ba2cbac2dcc9",
+            "at": "2026-03-29T21:43:22Z",
+            "pr": 13346
+        },
+        ".agents/tools/mcp/cloudflare-code-mode.md": {
+            "hash": "57f7a7876d43b24c1a40f59332c004b5932adae1",
+            "at": "2026-03-29T23:54:08Z",
+            "pr": 13428
+        },
+        ".agents/tools/video/remotion-compositions.md": {
+            "hash": "6b00afa2299a8d08eaacd114c67804f6d87614b1",
+            "at": "2026-03-29T23:18:01Z",
+            "pr": 13427
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/kv-patterns.md": {
+            "hash": "7637914de409bb05cee56b57db714972a922dbbb",
+            "at": "2026-03-29T22:09:11Z",
+            "pr": 13321
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pulumi-patterns.md": {
+            "hash": "98b6e10081c4b00014ad525bb96a33a62b6f90a0",
+            "at": "2026-03-29T22:09:12Z",
+            "pr": 13329
+        },
+        ".agents/tools/video/remotion-gifs.md": {
+            "hash": "c87be7656e27afb4f5f23e41571f8428b21345c4",
+            "at": "2026-03-29T22:09:13Z",
+            "pr": 13322
+        },
+        ".agents/seo/seo-regex.md": {
+            "hash": "b38e6b1002b80227940c036badb462c8add23514",
+            "at": "2026-03-29T22:09:17Z",
+            "pr": 13325
+        },
+        ".agents/tools/code-review/codacy.md": {
+            "hash": "3f41e7f2f15e10bf934568ea6ff485cd64ce88c3",
+            "at": "2026-03-29T22:09:31Z",
+            "pr": 13314
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md": {
+            "hash": "213bbe9f8924a85a7f616e9ceb2b50e89fd609d4",
+            "at": "2026-03-31T05:42:16Z",
+            "pr": 14662
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
+            "hash": "7f8943efbe9c5d05b7ecba869a866d6020b95928",
+            "at": "2026-04-01T20:59:18Z",
+            "pr": 15150
+        },
+        ".agents/tools/browser/extension-dev.md": {
+            "hash": "5d6ac2671414bfdce4481294fce9019711d28c01",
+            "at": "2026-03-29T22:09:34Z",
+            "pr": 13330
+        },
+        ".agents/tools/browser/sweet-cookie.md": {
+            "hash": "763a36ee928e5c54bafe10a5659c75c4c73f42df",
+            "at": "2026-03-29T22:09:35Z",
+            "pr": 13328
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-gotchas.md": {
+            "hash": "d41799c696aa6515cb523c0b17316ed13d17d2ee",
+            "at": "2026-03-29T22:09:42Z",
+            "pr": 13253
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md": {
+            "hash": "1e5cf033ce0af2ba18bc9e38ca48bd69cf3455bc",
+            "at": "2026-03-29T22:09:43Z",
+            "pr": 13254
+        },
+        ".agents/tools/context/model-routing.md": {
+            "hash": "43703f91e6cc11180bbf13a86e6d92333b1ca9db",
+            "at": "2026-03-29T22:09:44Z",
+            "pr": 13255
+        },
+        ".agents/product/analytics.md": {
+            "hash": "1ecb5ce4743770c3913fae8f41e526f3ba21c6a0",
+            "at": "2026-03-29T23:53:58Z",
+            "pr": 13415
+        },
+        ".agents/tools/programming/modern-javascript-skill/concurrency.md": {
+            "hash": "deb11f58b2c60571e4a7b98a2bb503f094a0b1e0",
+            "at": "2026-03-29T22:50:16Z",
+            "pr": 13349
+        },
+        ".agents/workflows/release.md": {
+            "hash": "090cc22dc1f270acad6e33d46bef835d457661eb",
+            "at": "2026-03-29T22:51:16Z",
+            "pr": 13318
+        },
+        ".agents/content/optimization.md": {
+            "hash": "326ff8a42a6e84736e5f70fc2f569119e04c9fa5",
+            "at": "2026-03-29T23:18:03Z",
+            "pr": 13425
+        },
+        ".agents/tools/ai-orchestration/autogen.md": {
+            "hash": "590a04f8f8f9073b304f6538e550f335e08ffd62",
+            "at": "2026-03-30T02:54:16Z",
+            "pr": 13600
+        },
+        ".agents/tools/code-review/security-analysis.md": {
+            "hash": "81663c87a7964c1938d704dd3698d51a4910621a",
+            "at": "2026-03-30T00:32:18Z",
+            "pr": 13467
+        },
+        ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
+            "hash": "b875488af36564292b08b0bcfabae97d18757135",
+            "at": "2026-03-29T23:53:50Z",
+            "pr": 13444
+        },
+        ".agents/tools/architecture/feature-slicing-skill/migration.md": {
+            "hash": "b399eacef76e87bedfd8da058f9c0b1707ffde13",
+            "at": "2026-03-30T00:32:19Z",
+            "pr": 13466
+        },
+        ".agents/marketing-sales/cro-chapters.md": {
+            "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
+            "at": "2026-03-30T00:32:32Z",
+            "pr": 13457
+        },
+        ".agents/workflows/wiki-update.md": {
+            "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
+            "at": "2026-03-30T02:30:16Z",
+            "pr": 13594
+        },
+        ".agents/marketing-sales/direct-response-copy.md": {
+            "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
+            "at": "2026-03-30T02:30:17Z",
+            "pr": 13597
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
+            "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
+            "at": "2026-03-30T02:30:18Z",
+            "pr": 13595
+        },
+        ".agents/services/email/email-health-check.md": {
+            "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
+            "at": "2026-03-30T02:30:20Z",
+            "pr": 13593
+        },
+        ".agents/tools/git/authentication.md": {
+            "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
+            "at": "2026-03-30T02:30:25Z",
+            "pr": 13538
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
+            "hash": "91b339029c6582618e5664e5c11ba08bbb75af7e",
+            "at": "2026-03-30T02:54:22Z",
+            "pr": 13564
+        },
+        ".agents/services/hosting/dns-providers.md": {
+            "hash": "979b0b76e50549adb87fc58efdd0b8d4d7cfed49",
+            "at": "2026-03-30T03:33:45Z",
+            "pr": 13668
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/queues-patterns.md": {
+            "hash": "5365c2251880bae2876aac89ff39f1dd909a2a0e",
+            "at": "2026-03-30T04:51:49Z",
+            "pr": 13735
+        },
+        ".agents/seo/moondream.md": {
+            "hash": "e6e0bef21020b260c31561b4da9fc0ef1e900be5",
+            "at": "2026-03-30T03:33:44Z",
+            "pr": 13663
+        },
+        ".agents/marketing-sales/meta-ads-foundations-glossary.md": {
+            "hash": "f0b0b3b259d7597309af03f39a2f267137dafffe",
+            "at": "2026-03-30T03:33:50Z",
+            "pr": 13691
+        },
+        ".agents/services/email/email-providers.md": {
+            "hash": "e8a96e186a02ff72e77c408a3262dfd2b0012d84",
+            "at": "2026-03-30T06:49:37Z",
+            "pr": 13859
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md": {
+            "hash": "70e97040812ad2c593e7b451a917560531eb5903",
+            "at": "2026-03-30T03:33:53Z",
+            "pr": 13667
+        },
+        ".agents/marketing-sales/meta-ads-checklists-creative-review.md": {
+            "hash": "d3207ef474ba73d95bb9c13864b282ac0b78169e",
+            "at": "2026-03-30T03:33:54Z",
+            "pr": 13666
+        },
+        ".agents/marketing-sales.md": {
+            "hash": "0b4144452b197dae7edbfcf3a5452752d3b2fe10",
+            "at": "2026-03-30T06:03:16Z",
+            "pr": 13839
+        },
+        ".agents/services/email/smime-setup.md": {
+            "hash": "f83bb719e349bb600df046eccc7c1c5603c330f0",
+            "at": "2026-03-30T06:50:00Z",
+            "pr": 13915
+        },
+        ".agents/tools/browser/browser-automation.md": {
+            "hash": "cbb6d3a24484eb81a5294657ce14d8737e131243",
+            "at": "2026-03-30T04:51:56Z",
+            "pr": 13719
+        },
+        ".agents/tools/browser/extension-dev/testing.md": {
+            "hash": "57d5dc456ab9a6e1d10416777117b96a09cc4f14",
+            "at": "2026-03-30T04:51:57Z",
+            "pr": 13717
+        },
+        ".agents/reference/settings.md": {
+            "hash": "2b2cbc9b8329f0fd0504413c4805a235d0f16962",
+            "at": "2026-03-30T03:34:12Z",
+            "pr": 13637
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
+            "hash": "2cbb9c1c836f4b8fce6dbe5b982d8760a75922ce",
+            "at": "2026-03-30T03:34:13Z",
+            "pr": 13636
+        },
+        ".agents/tools/mobile/app-dev-expo.md": {
+            "hash": "e0094f52acaa98cc6a2c7aa9aeae6321a204cb27",
+            "at": "2026-03-30T03:34:14Z",
+            "pr": 13609
+        },
+        ".agents/tools/video/remotion-images.md": {
+            "hash": "789b0f83404d30882f5f6b24317d4319f95dd107",
+            "at": "2026-03-30T03:34:15Z",
+            "pr": 13527
+        },
+        ".agents/seo.md": {
+            "hash": "1dcd30f4590e4b2b7792e538d0a70e7d4979aa8e",
+            "at": "2026-03-30T03:34:16Z",
+            "pr": 13526
+        },
+        ".agents/seo/mom-test-ux.md": {
+            "hash": "29c796f48c4b581197f9ea36ed95bbe98bb4ae51",
+            "at": "2026-03-30T03:34:17Z",
+            "pr": 13524
+        },
+        ".agents/seo/tech-stack.md": {
+            "hash": "8b3aa2ab4498e38424d9bd911680bf2e6d45d856",
+            "at": "2026-03-30T03:34:18Z",
+            "pr": 13531
+        },
+        ".agents/tools/mobile/maestro.md": {
+            "hash": "9cfba2015ca5bd40086f5d15c690910a0a3c6bfd",
+            "at": "2026-03-30T03:34:20Z",
+            "pr": 13525
+        },
+        ".agents/content/video-real-video-enhancer.md": {
+            "hash": "3a1c798089a1fa50288b76e5fd372fe57d4307d5",
+            "at": "2026-03-30T03:34:21Z",
+            "pr": 13533
+        },
+        ".agents/seo/image-seo.md": {
+            "hash": "91991eb82fa32f9ed717213566d5bb49604dfdc4",
+            "at": "2026-03-30T03:34:23Z",
+            "pr": 13530
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/terraform-patterns.md": {
+            "hash": "463f5c3efbf7a6b11c29193e5f6dcbefd1974fc2",
+            "at": "2026-03-30T03:34:24Z",
+            "pr": 13534
+        },
+        ".agents/services/communications/slack.md": {
+            "hash": "4894b60910b9fe85ce8dcfb7feb5441fca48be44",
+            "at": "2026-03-30T03:34:27Z",
+            "pr": 13545
+        },
+        ".agents/tools/research/providers/crft-lookup.md": {
+            "hash": "70a64dd60d9a32431e5c36f75d0ad6aed1865c46",
+            "at": "2026-03-30T03:34:28Z",
+            "pr": 13542
+        },
+        ".agents/product/ui-design.md": {
+            "hash": "3a8d0daebe80ebc2f64efe31009dbcba324fe142",
+            "at": "2026-03-30T03:34:29Z",
+            "pr": 13539
+        },
+        ".agents/content/VERIFICATION.md": {
+            "hash": "f0090056bf6625c2ce2c676d4cf9ba25a901198e",
+            "at": "2026-03-30T03:34:30Z",
+            "pr": 13540
+        },
+        ".agents/scripts/commands/yt-dlp.md": {
+            "hash": "56c400042f899284be4b65c6480fcac4de404248",
+            "at": "2026-03-30T03:34:31Z",
+            "pr": 13544
+        },
+        ".agents/tools/monorepo/turborepo.md": {
+            "hash": "06d5be33d317a334e024bd36af9aebe2b84a2a38",
+            "at": "2026-03-30T06:49:45Z",
+            "pr": 13795
+        },
+        ".agents/services/email/email-composition.md": {
+            "hash": "56336d402a38bf2eaa4d3bb6eebb2ad4dd5cfae7",
+            "at": "2026-03-30T06:03:17Z",
+            "pr": 13837
+        },
+        ".agents/marketing-sales/meta-ads-optimization-metrics.md": {
+            "hash": "99cca533a9d716bf886a24bffbf8255ca5da96a3",
+            "at": "2026-03-30T06:49:39Z",
+            "pr": 13940
+        },
+        ".agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md": {
+            "hash": "172840cdbbde2f855e1e9750119b46033ee505c7",
+            "at": "2026-03-30T04:51:54Z",
+            "pr": 13768
+        },
+        ".agents/services/document-processing/unstract.md": {
+            "hash": "23759f7d870be0bbd07442ac06a3d7b069c8984b",
+            "at": "2026-03-30T04:51:58Z",
+            "pr": 13720
+        },
+        ".agents/tools/api/drizzle.md": {
+            "hash": "401b78e13d0649ed4df01e6f3a4ed5a2ffddc55d",
+            "at": "2026-03-30T04:52:00Z",
+            "pr": 13718
+        },
+        ".agents/marketing-sales/ad-creative-video-ugc.md": {
+            "hash": "695a2da0afc79acc4e203ead505b0bc768c6237a",
+            "at": "2026-03-30T04:52:01Z",
+            "pr": 13723
+        },
+        ".agents/marketing-sales/meta-ads-creative-psychology.md": {
+            "hash": "6436f438f568834b0e2062a282cce59cc65ec58d",
+            "at": "2026-03-30T04:52:02Z",
+            "pr": 13729
+        },
+        ".agents/tools/browser/extension-dev/development.md": {
+            "hash": "80547436b58e3fd8fb2ce9ab44cfaecedcb32ec3",
+            "at": "2026-03-30T04:52:04Z",
+            "pr": 13722
+        },
+        ".agents/tools/deployment/coolify-cli.md": {
+            "hash": "bceeb18bd221b65e03b4fa7ec3633091a8ee57e2",
+            "at": "2026-03-30T04:52:05Z",
+            "pr": 13734
+        },
+        ".agents/tools/ui/react-context.md": {
+            "hash": "dee0f2d9a70f699ee8e09bc3c855e84eabb9a806",
+            "at": "2026-03-30T06:49:50Z",
+            "pr": 13766
+        },
+        ".agents/marketing-sales/meta-ads-foundations-algorithm.md": {
+            "hash": "318e59fc49106e5aaeeca2d26e666b87b0353d5c",
+            "at": "2026-04-01T20:59:13Z",
+            "pr": 15138
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md": {
+            "hash": "a0b18de39a54d95b1d687b669e01308b2333655f",
+            "at": "2026-03-30T06:49:26Z",
+            "pr": 13938
+        },
+        ".agents/tools/containers/remote-dispatch.md": {
+            "hash": "10ae5781c8f1ecb06c7d4d562c2f915b32f2deec",
+            "at": "2026-03-30T04:52:23Z",
+            "pr": 13733
+        },
+        ".agents/content/humanise.md": {
+            "hash": "898870a22cb4b4cf0153c907ab974792857e41c8",
+            "at": "2026-03-30T06:03:20Z",
+            "pr": 13836
+        },
+        ".agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md": {
+            "hash": "dd47fcc7b562ecb9f085d0d7394553810ecabc8c",
+            "at": "2026-03-30T04:52:39Z",
+            "pr": 13784
+        },
+        ".agents/marketing-sales/meta-ads-campaigns-advantage-plus.md": {
+            "hash": "e2a2dc5e7f15a6ce3fdcf4e477dac3ca7db3056f",
+            "at": "2026-03-30T04:52:40Z",
+            "pr": 13779
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/stream-patterns.md": {
+            "hash": "f45d2973f1a08cfb71a1b4e0c66e73895737d463",
+            "at": "2026-03-30T06:03:15Z",
+            "pr": 13844
+        },
+        ".agents/tools/ai-orchestration/langflow.md": {
+            "hash": "9010935d83c2b8113ae0c32b3d4f7eb7ee720b06",
+            "at": "2026-03-30T06:49:09Z",
+            "pr": 13930
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
+            "hash": "be2d56c6fe66266362fd66f78066478f683491cf",
+            "at": "2026-03-30T06:49:10Z",
+            "pr": 13929
+        },
+        ".agents/content/video-higgsfield-ui.md": {
+            "hash": "bba81f4fdf2dc1e94cfa231418a3687dc2a2a324",
+            "at": "2026-03-30T06:49:12Z",
+            "pr": 13932
+        },
+        ".agents/tools/context/context-guardrails.md": {
+            "hash": "35328fa309512f8dc6c77afee69bd1f6068b9e45",
+            "at": "2026-03-30T06:49:16Z",
+            "pr": 13956
+        },
+        ".agents/tools/ui/ai-chat-sidebar.md": {
+            "hash": "c01e259c3def32f858b6c96f752a2c21070567e9",
+            "at": "2026-03-30T06:49:20Z",
+            "pr": 13958
+        },
+        "TODO.md": {
+            "hash": "9e296aaac5ac00cb7ad14c8de7e5c6b1930b1184",
+            "at": "2026-04-02T04:56:51Z",
+            "pr": 15490
+        },
+        ".agents/content/heygen-skill/rules-webhooks.md": {
+            "hash": "c3ba360303dc273741e6f76b2f235b8319f78734",
+            "at": "2026-03-30T06:49:23Z",
+            "pr": 13942
+        },
+        ".agents/tools/browser/chrome-webstore-release.md": {
+            "hash": "7d789fec3b99cc63f2dc9033a798921b9f7f2233",
+            "at": "2026-03-30T06:49:23Z",
+            "pr": 13942
+        },
+        ".agents/seo/google-search-console.md": {
+            "hash": "525712f74fe9ec13980ef0564a2108481e894038",
+            "at": "2026-03-30T06:49:36Z",
+            "pr": 13900
+        },
+        ".agents/services/hosting/proxmox-full-skill.md": {
+            "hash": "23bcf676fc5edd9dcfebc3fb07b0d4ed6cb61a19",
+            "at": "2026-03-30T06:49:37Z",
+            "pr": 13859
+        },
+        ".agents/tools/ocr/paddleocr.md": {
+            "hash": "7e0aaf06abd6c0d64ef0645a3cd58ac02b9e11f4",
+            "at": "2026-03-30T06:49:51Z",
+            "pr": 13765
+        },
+        ".agents/workflows/mission-orchestrator.md": {
+            "hash": "930d59836f65199231e8354401053a66b0637281",
+            "at": "2026-03-30T06:49:53Z",
+            "pr": 13841
+        },
+        ".agents/marketing-sales/cro-chapter-08.md": {
+            "hash": "b17c73481de18eb0ad983703fbcae8b5b7e93c98",
+            "at": "2026-03-30T06:49:54Z",
+            "pr": 13773
+        },
+        ".agents/reference/entity-memory-architecture.md": {
+            "hash": "bbd1c42b7e0eb2b01cb5a193f94c5e9ecf98c540",
+            "at": "2026-04-02T00:00:00Z",
+            "pr": 15488
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
+            "hash": "102c82fd40a93f9e219e84ee053645eff00db29b",
+            "at": "2026-03-31T03:46:07Z",
+            "pr": 14541
+        },
+        ".agents/reference/agent-routing.md": {
+            "hash": "83e56233f5c7fc633bc3a64de90d9b5529a0bd33",
+            "at": "2026-03-31T05:34:14Z",
+            "pr": 14650
+        },
+        ".agents/marketing-sales/meta-ads-creative-briefs-founder-video-brief.md": {
+            "hash": "a4bf29e5b45891eeb157e02f740965cd3370cb9d",
+            "at": "2026-03-31T06:30:29Z",
+            "pr": 14701
+        },
+        ".agents/tools/vision/overview.md": {
+            "hash": "5abddf3f89fc529bd3119b8ae147961451728199",
+            "at": "2026-04-01T20:59:38Z",
+            "pr": 14932
+        },
+        ".agents/tools/ai-assistants/datasets.md": {
+            "hash": "8b525467afaf93fea7539e9f47fabf2159254ae1",
+            "at": "2026-04-02T12:00:00Z",
+            "pr": 15336
+        },
+        ".agents/tools/automation/mac.md": {
+            "hash": "1dc19ae4b63343bb6f8a397a6f7e824655e2f986",
+            "at": "2026-04-01T20:58:52Z",
+            "pr": 15253
+        },
+        ".agents/scripts/commands/list-verify.md": {
+            "hash": "dc43be77f9d72dac6880004350a5b63ce9a326f0",
+            "at": "2026-04-02T04:56:43Z",
+            "pr": 15514
+        },
+        ".agents/scripts/commands/budget-analysis.md": {
+            "hash": "ac77aaf850ecc1f9cee81c9e04a026a954fc7359",
+            "at": "2026-04-01T20:58:50Z",
+            "pr": 15257
+        },
+        "todo/tasks/t15173-brief.md": {
+            "hash": "41ca6c208c2f6e8349d73a1ec55e0a26fd26f974",
+            "at": "2026-04-01T20:58:50Z",
+            "pr": 15257
+        },
+        ".agents/health.md": {
+            "hash": "301b928aef5da6cc3a1dbb353077bfbab47af315",
+            "at": "2026-04-01T20:58:58Z",
+            "pr": 15249
+        },
+        ".agents/tools/ai-assistants/models-README.md": {
+            "hash": "0fe4c51c744b0e1ee3081af1b83ca6c66229a4a4",
+            "at": "2026-04-01T20:58:59Z",
+            "pr": 15227
+        },
+        ".agents/tools/ai-assistants/claude-code.md": {
+            "hash": "dd9666e19eb7e98df75856dd477ecf7ceebf147a",
+            "at": "2026-04-01T20:59:01Z",
+            "pr": 15204
+        },
+        ".agents/aidevops/self-improving-agents.md": {
+            "hash": "8e8dc0f8fa3a1a502130a64f217de014a5b14161",
+            "at": "2026-04-01T20:59:02Z",
+            "pr": 15203
+        },
+        ".agents/workflows/branch/hotfix.md": {
+            "hash": "e1c1f9099b46c798fe473a7c23ff01bfa8e26b70",
+            "at": "2026-04-01T20:59:04Z",
+            "pr": 15209
+        },
+        ".agents/tools/mobile/app-dev-testing.md": {
+            "hash": "39d2e16ec10aee6ed51d5a9b586e20ac0ba4276a",
+            "at": "2026-04-01T20:59:09Z",
+            "pr": 15219
+        },
+        ".agents/marketing-sales/cro-chapter-18.md": {
+            "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
+            "at": "2026-04-01T20:59:11Z",
+            "pr": 15220
+        },
+        ".agents/marketing-sales/cro-chapter-02.md": {
+            "hash": "8226a4d2cd57afce1746318203d9c357540010c2",
+            "at": "2026-04-01T20:59:14Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/cro-chapter-02/01-conversion-rate-formulas.md": {
+            "hash": "3ffbf75893700060301c26dd5fd2c63e6743bddc",
+            "at": "2026-04-01T20:59:14Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/cro-chapter-02/02-psychology-of-conversion.md": {
+            "hash": "497b1a2f35082225ace6ac18531c3b83d25fd39f",
+            "at": "2026-04-01T20:59:14Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/cro-chapter-02/03-conversion-funnel.md": {
+            "hash": "20a9a226559ee7acc643d4b1b73a44d3f735e87d",
+            "at": "2026-04-01T20:59:14Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/cro-chapter-02/04-attribution-models.md": {
+            "hash": "48f7749c53ee973531130209345c214c0d77b181",
+            "at": "2026-04-01T20:59:15Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/cro-chapter-02/05-website-elements.md": {
+            "hash": "786c51eec79c4098d2034c43c8dd98c1077043e0",
+            "at": "2026-04-01T20:59:15Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/cro-chapter-02/06-conversion-friction.md": {
+            "hash": "60a0019275f9e3b20f3e9dba68b8d52f6782199c",
+            "at": "2026-04-01T20:59:15Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/cro-chapter-02/07-data-foundation.md": {
+            "hash": "58055a16f3affa58e9372abe6c4108cc7d0b196c",
+            "at": "2026-04-01T20:59:15Z",
+            "pr": 15223
+        },
+        "todo/tasks/t1737-brief.md": {
+            "hash": "e33e6f68fa6cdb89368aa5ec65bd3e1bc880ba67",
+            "at": "2026-04-01T20:59:15Z",
+            "pr": 15223
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-06-ramit-sethi-launch.md": {
+            "hash": "5f82f7b17f7fde8daeb703ca4c3cdcef53620c2f",
+            "at": "2026-04-01T20:59:17Z",
+            "pr": 15150
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-07-saas-trial-expiry.md": {
+            "hash": "541a34d7b2649c4e93f494af26bb412731aace9e",
+            "at": "2026-04-01T20:59:17Z",
+            "pr": 15150
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-08-cart-abandonment.md": {
+            "hash": "2c4d31ad777c8c70b5293c3fd75e4e6af67b4654",
+            "at": "2026-04-01T20:59:17Z",
+            "pr": 15150
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-09-webinar-invite.md": {
+            "hash": "5dd410cda93d3056b39408c537fb3c9b1e1e06da",
+            "at": "2026-04-01T20:59:17Z",
+            "pr": 15150
+        },
+        ".agents/marketing-sales/meta-ads-checklists-campaign-launch.md": {
+            "hash": "3f199a8eb517a651781b683ec0d6a723fb16d9b0",
+            "at": "2026-04-01T20:59:20Z",
+            "pr": 15149
+        },
+        ".agents/scripts/headless-runtime-helper.sh": {
+            "hash": "168f91548a0d85a33e1d6ad048ae9f827038c9ec",
+            "at": "2026-04-02T03:11:26Z",
+            "pr": 15086
+        },
+        ".agents/tools/programming/modern-javascript-skill.md": {
+            "hash": "3c3730959a3c618e3b3ed96d1ccd5eb95c2bfe3b",
+            "at": "2026-04-01T20:59:25Z",
+            "pr": 15131
+        },
+        ".agents/tools/programming/modern-javascript-skill/01-decision-trees.md": {
+            "hash": "80190196c391d4314e034455e46fe218d57d1c58",
+            "at": "2026-04-01T20:59:25Z",
+            "pr": 15131
+        },
+        ".agents/tools/programming/modern-javascript-skill/02-es-versions.md": {
+            "hash": "8c9215cc4697a3cd21125445386a8315acb42e0d",
+            "at": "2026-04-01T20:59:25Z",
+            "pr": 15131
+        },
+        ".agents/scripts/commands/security-deps.md": {
+            "hash": "265f2d26f358ffb425e374dca8aa76a7c20c3565",
+            "at": "2026-04-01T20:59:27Z",
+            "pr": 14994
+        },
+        ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
+            "hash": "ab1f9c5d69340fa7acfd756c2ae37710b9fa600c",
+            "at": "2026-04-01T20:59:28Z",
+            "pr": 14996
+        },
+        ".agents/research.md": {
+            "hash": "b509e2fae5168065f0142ae29dca1ec2d410c53b",
+            "at": "2026-04-01T20:59:28Z",
+            "pr": 14996
+        },
+        ".agents/workflows/mission-skill-learning.md": {
+            "hash": "dd665af8ed215a57226bbb176cee5ee5a552ee65",
+            "at": "2026-04-01T20:59:28Z",
+            "pr": 14996
+        },
+        "todo/tasks/GH-14990-brief.md": {
+            "hash": "05e0636373c9b4574f9b289b7e75180281b462e4",
+            "at": "2026-04-01T20:59:29Z",
+            "pr": 14996
+        },
+        ".agents/prompts/worker-efficiency-protocol.md": {
+            "hash": "b601e50f903b0b94e2a1021a296e595f350e85f1",
+            "at": "2026-04-01T20:59:34Z",
+            "pr": 14943
+        },
+        ".agents/scripts/commands/venv-health.md": {
+            "hash": "bbcc15a86e165230f04159f127a8dc6a52160b30",
+            "at": "2026-04-01T20:59:35Z",
+            "pr": 14968
+        },
+        ".agents/seo/ai-search-kpi-template.md": {
+            "hash": "b750815aa689ad99b32c355078ef3d168b489789",
+            "at": "2026-04-01T20:59:36Z",
+            "pr": 14969
+        },
+        ".agents/tools/ai-assistants/models-sonnet.md": {
+            "hash": "035dfbf3d02fc552dd1f4dab55ea1bf70331e2b1",
+            "at": "2026-04-01T20:59:40Z",
+            "pr": 14913
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
+            "hash": "a87bdad3db117a280177a98592d12acba7a2e676",
+            "at": "2026-04-01T20:59:42Z",
+            "pr": 14916
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
+            "hash": "c0c080bb82f1488a996f7cf50c231ac89179bc6f",
+            "at": "2026-04-01T20:59:44Z",
+            "pr": 14914
+        },
+        ".agents/scripts/commands/list-todo.md": {
+            "hash": "351180b6d47cacee5be38fc9e3ec01f7d1fd8661",
+            "at": "2026-04-01T20:59:47Z",
+            "pr": 14898
+        },
+        ".agents/tools/video/remotion-3d.md": {
+            "hash": "054778cef20067cd0e02cbd7b049333f562e6e4a",
+            "at": "2026-04-01T20:59:48Z",
+            "pr": 14897
+        },
+        ".agents/services/monitoring/socket.md": {
+            "hash": "788506798f5a1eedd29bb5d84aaa61a758c1acd8",
+            "at": "2026-04-01T20:59:50Z",
+            "pr": 14896
+        },
+        ".agents/tools/deployment/cloudron-app-packaging-skill.md": {
+            "hash": "0895bca6f21b082551b21fa7765569599eb36e95",
+            "at": "2026-04-01T20:59:51Z",
+            "pr": 14880
+        },
+        ".agents/tools/video/remotion-timing.md": {
+            "hash": "6213ebf1e87a77cab44febc35ec0a3b10fd2db4c",
+            "at": "2026-04-01T20:59:53Z",
+            "pr": 14881
+        },
+        ".agents/tools/video/remotion-transitions.md": {
+            "hash": "f643aa12a96105bd68286a55958c88444a7d235e",
+            "at": "2026-04-01T20:59:54Z",
+            "pr": 14883
+        },
+        ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md": {
+            "hash": "4c6d024fd0bd6ab3cbc9881e5cd83bd7dec582e4",
+            "at": "2026-04-01T21:00:01Z",
+            "pr": 14853
+        },
+        ".agents/tools/browser/curl-copy.md": {
+            "hash": "134632d988b4e18e35f9e3c90106391f8461c114",
+            "at": "2026-04-01T21:56:13Z",
+            "pr": null
+        },
+        ".agents/marketing-sales/cro-chapter-11.md": {
+            "hash": "be3bf907be217b866da1d7990427e4fc1c925971",
+            "at": "2026-04-01T22:00:00Z",
+            "pr": 14514
+        },
+        ".agents/tools/git/lumen.md": {
+            "hash": "4a2b4339feef8da5578b029993d870a6416758b7",
+            "at": "2026-04-01T23:23:19Z",
+            "pr": 15327
+        },
+        ".agents/tools/document/extraction-workflow.md": {
+            "hash": "ff97788918db3fac18f34e7b0f3d18155d449e88",
+            "at": "2026-04-01T23:23:22Z",
+            "pr": 15350
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/01-ai-code-execution.md": {
+            "hash": "01137638b886f973e7f633159da5b9dc457c2416",
+            "at": "2026-04-01T23:23:23Z",
+            "pr": 15353
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/02-interactive-dev-environment.md": {
+            "hash": "fc0ae968ea17a236a2c90214346e4470cad649b4",
+            "at": "2026-04-01T23:23:23Z",
+            "pr": 15353
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/03-ci-cd-pipeline.md": {
+            "hash": "63d67404bc099cb3243761e2eeb3881a4f969c68",
+            "at": "2026-04-01T23:23:24Z",
+            "pr": 15353
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/04-multi-language-code-runner.md": {
+            "hash": "c618c5137724952005c49df413fd5c2170209d83",
+            "at": "2026-04-01T23:23:24Z",
+            "pr": 15353
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/05-multi-tenant.md": {
+            "hash": "e1d23e98d87b8e8ae9635d954951a70abe88fd57",
+            "at": "2026-04-01T23:23:24Z",
+            "pr": 15353
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/06-jupyter-integration.md": {
+            "hash": "a7a4b85da6e8ebad5549cbb830bf9aa146b9d204",
+            "at": "2026-04-01T23:23:24Z",
+            "pr": 15353
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/07-git-operations.md": {
+            "hash": "1610dca7b04c68ad219a4daa34c788dbed864aa2",
+            "at": "2026-04-01T23:23:24Z",
+            "pr": 15353
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md": {
+            "hash": "d4f5f41aaab3a18b3ba154884526869bcf0b1efe",
+            "at": "2026-04-01T23:23:38Z",
+            "pr": 15335
+        },
+        ".agents/reference/define-probes/bugfix.md": {
+            "hash": "88ddddb0fc275f73407b492a820bd0f2bfdada99",
+            "at": "2026-04-01T23:23:39Z",
+            "pr": 15334
+        },
+        ".agents/reference/auto-update.md": {
+            "hash": "0db7d0a5ebb60bf53cbeb2d88102be373220981c",
+            "at": "2026-04-01T23:23:47Z",
+            "pr": 15301
+        },
+        ".agents/reference/contribution-watch.md": {
+            "hash": "77b53dc6bf630c7451cc69425d06aa11f23e727b",
+            "at": "2026-04-01T23:23:47Z",
+            "pr": 15301
+        },
+        ".agents/reference/repo-sync.md": {
+            "hash": "e6c2ddc65a495825740608c7c440f8ba49033db5",
+            "at": "2026-04-01T23:23:47Z",
+            "pr": 15301
+        },
+        ".agents/reference/services.md": {
+            "hash": "85309d5014421182d0c22812ec7bb56f2ccc2ab0",
+            "at": "2026-04-01T23:23:47Z",
+            "pr": 15301
+        },
+        "aidevops.sh": {
+            "hash": "612281685856997848a5bf3f023e563a1bb8780c",
+            "at": "2026-04-02T04:56:57Z",
+            "pr": 15470
+        },
+        "setup.sh": {
+            "hash": "6d9dba530ed27ddfbe02cbc469483903f9a706b4",
+            "at": "2026-04-02T04:56:57Z",
+            "pr": 15470
+        },
+        ".agents/seo/backlink-checker.md": {
+            "hash": "aa5038f9569e0d64e563b31a0e2243bd9c2b959c",
+            "at": "2026-04-02T02:14:59Z",
+            "pr": null
+        },
+        ".agents/scripts/matrix-dispatch-helper.sh": {
+            "hash": "d42a4c2129d808e3bf1fe78109163f12f059c723",
+            "at": "2026-04-02T03:11:00Z",
+            "pr": 15431
+        },
+        ".agents/seo/ahrefs.md": {
+            "hash": "68607c6d5bd42845c1fe21cebb00752f6ff8106d",
+            "at": "2026-04-02T03:11:00Z",
+            "pr": 15431
+        },
+        "todo/tasks/t1727-brief.md": {
+            "hash": "55e4dea0078c0800d4db2336b942014ce25ffbfc",
+            "at": "2026-04-02T03:11:00Z",
+            "pr": 15431
+        },
+        ".agents/scripts/commands/email-outreach.md": {
+            "hash": "03c6fbfcdc4ba527948102f9b58f5c9bed557777",
+            "at": "2026-04-02T03:11:10Z",
+            "pr": 15480
+        },
+        ".agents/scripts/commands/seo-audit.md": {
+            "hash": "d8d6dee50a191d538e032247f78abb02ebb504a8",
+            "at": "2026-04-02T03:11:11Z",
+            "pr": 15477
+        },
+        ".agents/scripts/commands/recall.md": {
+            "hash": "9b0b04b0aeda1a0436139a205db96efcf0e662ad",
+            "at": "2026-04-02T04:56:44Z",
+            "pr": 15515
+        },
+        ".agents/content/production-video-08-talking-head-pipeline.md": {
+            "hash": "cee1bc46bfdf4612fb0560748fe9e7b134ac0086",
+            "at": "2026-04-02T04:56:45Z",
+            "pr": 15516
+        },
+        ".agents/workflows/branch/bugfix.md": {
+            "hash": "236b78c40f92a6c1b7c36085c0ecdf1ea42058be",
+            "at": "2026-04-02T04:56:46Z",
+            "pr": 15517
+        },
+        ".agents/seo/content-analyzer.md": {
+            "hash": "7972fdccf29515026f0f710dac5f8e1b792e77c5",
+            "at": "2026-04-02T04:56:49Z",
+            "pr": 15478
+        },
+        ".agents/services/hosting/cloudflare-platform-skill/hyperdrive.md": {
+            "hash": "1a63158e184bf8c3c6ac2f4b5110e44451c5d837",
+            "at": "2026-04-02T04:56:50Z",
+            "pr": 15481
+        },
+        ".agents/tools/video/remotion-import-srt-captions.md": {
+            "hash": "75f8b0d089b9eaae8a7e08498af9b8c5f1ac4655",
+            "at": "2026-04-02T04:56:51Z",
+            "pr": 15490
+        },
+        "todo/tasks/t15472-brief.md": {
+            "hash": "3de8a77d3743c3530c563e9aff8775c22a7edb4b",
+            "at": "2026-04-02T04:56:51Z",
+            "pr": 15490
+        },
+        ".agents/scripts/commands/security-history.md": {
+            "hash": "0c74f125bbb3e299040015ee24fb345e43486ec7",
+            "at": "2026-04-02T04:56:52Z",
+            "pr": 15487
+        },
+        ".agents/tools/video/remotion-lottie.md": {
+            "hash": "72d843e6717a28f61294372a6752cb8e9736fe6b",
+            "at": "2026-04-02T04:56:53Z",
+            "pr": 15525
+        },
+        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md": {
+            "hash": "d662c65c03864c29b198db3a89950538a7949ef2",
+            "at": "2026-04-02T04:56:54Z",
+            "pr": 15526
+        },
+        ".agents/tools/credentials/bitwarden.md": {
+            "hash": "808ffa447534e25dd4090033275c4861a8612f2c",
+            "at": "2026-04-02T04:56:56Z",
+            "pr": 15468
+        },
+        "todo/tasks/t15450-brief.md": {
+            "hash": "c0ba871cfce440d57c630e49cd6ba939bf27b261",
+            "at": "2026-04-02T04:56:56Z",
+            "pr": 15468
+        },
+        "todo/tasks/t2052-brief.md": {
+            "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
+            "at": "2026-04-02T04:56:57Z",
+            "pr": 15470
+        },
+        ".agents/tools/browser/crawl4ai-integration.md": {
+            "hash": "5b8849f598a7c31bff13579aedda9586682f6ad7",
+            "at": "2026-04-02T04:56:58Z",
+            "pr": 15463
+        },
+        "todo/tasks/t15448-brief.md": {
+            "hash": "b43fa2d5b0515af1ecbebbc502099ca5e6d0a9c2",
+            "at": "2026-04-02T04:56:58Z",
+            "pr": 15463
+        },
+        ".agents/scripts/platform-detect.sh": {
+            "hash": "a551a07e07c08853c909e7b8141ddddf2de43420",
+            "at": "2026-04-02T04:56:59Z",
+            "pr": 15455
+        },
+        ".agents/seo/keyword-mapper.md": {
+            "hash": "f5e9b332c7d9f5f572063df15d295f19",
+            "at": "2026-04-02T05:10:00Z",
+            "pr": null
+        }
     }
-  }
 }

--- a/.agents/seo/keyword-mapper.md
+++ b/.agents/seo/keyword-mapper.md
@@ -17,16 +17,10 @@ tools:
 
 Analyses keyword placement, distribution, and integration quality across content sections.
 
-## Quick Reference
+**Input**: article content, primary keyword, secondary keywords  
+**Script**: `seo-content-analyzer.py keywords`
 
-- **Purpose**: Map keyword distribution, identify gaps, detect stuffing
-- **Input**: Article content, primary keyword, secondary keywords
-- **Output**: Distribution heatmap, gap analysis, revision suggestions
-- **Script**: `seo-content-analyzer.py keywords`
-
-## Analysis
-
-### Run Keyword Analysis
+## Run Analysis
 
 ```bash
 python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py keywords article.md \
@@ -34,9 +28,7 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py keywords article.md \
   --secondary "secondary1,secondary2,secondary3"
 ```
 
-### Output Interpretation
-
-#### Density Status
+## Density Status
 
 | Status | Density | Action |
 |--------|---------|--------|
@@ -46,7 +38,7 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py keywords article.md \
 | `slightly_high` | 1.8-2.25% | Replace some with synonyms |
 | `too_high` | > 2.25% | Remove instances, risk of stuffing |
 
-#### Critical Placements
+## Critical Placements
 
 | Location | Priority | Why |
 |----------|----------|-----|
@@ -57,30 +49,20 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py keywords article.md \
 | Meta title | Critical | SERP display |
 | Meta description | High | SERP display, bold matching |
 
-#### Distribution Heatmap
+## Distribution
 
-The script outputs per-section keyword density. Ideal distribution:
+Ideal per-section density from script output:
 
 - **Introduction**: Higher density (establish topic)
 - **Body sections**: Even distribution (1-2 mentions per section)
 - **Conclusion**: Moderate density (reinforce topic)
 - **No section**: Zero mentions (gap to fill)
 
-### Keyword Stuffing Detection
-
-The script checks for:
-
-- Overall density > 2.5% (medium risk) or > 3% (high risk)
-- Per-paragraph density > 5% (concentrated stuffing)
-- 3+ consecutive sentences with keyword (unnatural repetition)
+**Stuffing detection** — script flags: overall > 2.5% (medium risk) or > 3% (high risk); per-paragraph > 5%; 3+ consecutive sentences with keyword.
 
 ## LSI Keywords
 
-The script discovers semantically related terms (LSI keywords) from content. Use these to:
-
-- Replace some primary keyword instances with variations
-- Add topical depth without increasing primary density
-- Cover related search queries
+Script discovers semantically related terms. Use to replace primary keyword instances with variations, add topical depth, and cover related queries.
 
 ## Revision Workflow
 
@@ -88,7 +70,7 @@ The script discovers semantically related terms (LSI keywords) from content. Use
 2. Fix critical placement gaps first
 3. Adjust density if outside 1-2% range
 4. Add LSI keywords for topical coverage
-5. Re-run analysis to verify
+5. Re-run to verify
 
 ## Integration
 


### PR DESCRIPTION
## Summary

Tightens `.agents/seo/keyword-mapper.md` from 97 to 79 lines (18.6% reduction) per the simplification scan in GH#14261.

**Classification**: Instruction doc (agent rules, workflows, decision tables) — not a reference corpus.

**Changes made:**
- Removed redundant "Quick Reference" section (duplicated frontmatter description and script name already in the command block)
- Collapsed "Output Interpretation" subsections — flattened heading hierarchy, merged "Distribution Heatmap" prose and "Stuffing Detection" into tighter form
- Condensed "LSI Keywords" section from 5 lines to 1 inline sentence
- Preserved all institutional knowledge: density thresholds, placement priorities, stuffing detection rules, LSI guidance, revision workflow, integration pointers

**Verification:**
- All code blocks, URLs, task ID references, and command examples present before and after
- No broken internal links or references
- Agent behaviour unchanged — all decision tables and thresholds intact

## Runtime Testing

**Risk level**: Low — docs/agent prompt only, no code changes.  
**Assessment**: `self-assessed` — no runtime testing required per risk table.

Closes #14261

---
[aidevops.sh](https://aidevops.sh) v3.5.611 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 10m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined keyword mapping documentation structure for better clarity and usability.
  * Consolidated related sections including keyword analysis and detection procedures.
  * Simplified workflow instructions and reduced overall content length while preserving essential information.
  * Enhanced readability for faster navigation and understanding of analysis procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->