### PR TITLE
t1852: simplification: tighten agent doc Feature Branch

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,6 +1,11 @@
 {
     "_comment": null,
     "files": {
+        ".agents/workflows/branch/feature.md": {
+            "hash": "1316d72ee54f00be656cb942a010b1a1",
+            "at": "2026-04-02T05:30:00Z",
+            "pr": 15550
+        },
         ".agents/scripts/commands/worktree-cleanup.md": {
             "hash": "f333ce7dce4127c4c2150a07b4c1f50c",
             "at": "2026-04-02T02:30:00Z",

--- a/.agents/workflows/branch/feature.md
+++ b/.agents/workflows/branch/feature.md
@@ -19,7 +19,7 @@ tools:
 | **Prefix** | `feature/` |
 | **Commit** | `feat: description` |
 | **Version** | Minor bump (1.0.0 → 1.1.0) |
-| **Create from** | `main` |
+| **Source** | `main` |
 
 ```bash
 git checkout main && git pull origin main
@@ -28,17 +28,12 @@ git checkout -b feature/{description}
 
 <!-- AI-CONTEXT-END -->
 
-## When to Use
+## Usage
 
-- New functionality or integrations
-- Significant capability expansion
-
-**Not for** bug fixes, refactors, or docs/config-only work.
-
-## Guidance
-
-- Minor-version bump applies when the branch ships user-visible capability, not internal-only maintenance.
-- For implementation patterns, see `workflows/feature-development.md`.
+- **Use for**: New functionality, integrations, significant capability expansion.
+- **Not for**: Bug fixes, refactors, docs, or config-only work.
+- **Version**: Minor bump applies to user-visible capabilities, not internal maintenance.
+- **Patterns**: See `workflows/feature-development.md`.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
Tighten and restructure the agent doc for Feature Branch (.agents/workflows/branch/feature.md).
- Reduced line count from 52 to 47 lines.
- Reordered by importance: Usage first, then Examples.
- Tightened prose while preserving all institutional knowledge (task IDs, URLs, command examples).
- Updated simplification state registry.

Closes #15550

---
[aidevops.sh](https://aidevops.sh) v3.5.611 plugin for [OpenCode](https://opencode.ai) v1.3.13 with gemini-3-flash spent 11m and 836,044 tokens on this as a headless worker.