### PR TITLE
GH#15023: tighten venv-health command doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -251,6 +251,11 @@
             "at": "2026-03-28T03:54:06Z",
             "pr": 11340
         },
+        ".agents/tools/ui/nothing-design-skill.md": {
+            "hash": "0cdbd83c7d6eee6b8552d27b3b05460d275b3bb10fadc1d31e8210fa2401906d",
+            "at": "2026-04-02T06:15:00Z",
+            "pr": 15566
+        },
         ".agents/workflows/preflight.md": {
             "hash": "c4695943d5555314205b87bb88020fb62de14b63",
             "at": "2026-03-28T03:54:08Z",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -251,11 +251,6 @@
             "at": "2026-03-28T03:54:06Z",
             "pr": 11340
         },
-        ".agents/tools/ui/nothing-design-skill.md": {
-            "hash": "0cdbd83c7d6eee6b8552d27b3b05460d275b3bb10fadc1d31e8210fa2401906d",
-            "at": "2026-04-02T06:15:00Z",
-            "pr": 15566
-        },
         ".agents/workflows/preflight.md": {
             "hash": "c4695943d5555314205b87bb88020fb62de14b63",
             "at": "2026-03-28T03:54:08Z",
@@ -3337,9 +3332,9 @@
             "pr": 14943
         },
         ".agents/scripts/commands/venv-health.md": {
-            "hash": "bbcc15a86e165230f04159f127a8dc6a52160b30",
-            "at": "2026-04-01T20:59:35Z",
-            "pr": 14968
+            "hash": "4d7437501f44b30e1a2ba194692f5c437ea144879609ccae12dba08ea6f83e5a",
+            "at": "2026-04-02T09:43:51Z",
+            "pr": 15575
         },
         ".agents/seo/ai-search-kpi-template.md": {
             "hash": "b750815aa689ad99b32c355078ef3d168b489789",

--- a/.agents/scripts/commands/venv-health.md
+++ b/.agents/scripts/commands/venv-health.md
@@ -4,17 +4,11 @@ agent: Build+
 mode: subagent
 ---
 
-Run Python venv smoke tests across managed repos.
-
-Arguments: $ARGUMENTS
-
-## Quick Output
+Run Python venv smoke tests across managed repos. Arguments: $ARGUMENTS
 
 ```bash
 ~/.aidevops/agents/scripts/venv-health-check-helper.sh scan $ARGUMENTS
 ```
-
-Display the helper output directly; formatting is built in.
 
 ## Modes
 
@@ -33,23 +27,19 @@ Display the helper output directly; formatting is built in.
 | Stale editable installs | `.pth` files pointing to deleted paths (e.g., pruned git worktrees) | Error |
 | Missing requirements file | Venvs with no `requirements.txt`, `pyproject.toml`, `setup.py`, `setup.cfg`, or `Pipfile` | Warning |
 
-## Venv Discovery
-
-Looks for `.venv/pyvenv.cfg` (PEP 405 marker) up to 3 levels deep in each registered repo, then deduplicates by realpath.
+Discovery: looks for `.venv/pyvenv.cfg` (PEP 405 marker) up to 3 levels deep in each registered repo, deduplicated by realpath.
 
 ## Automatic Checks
 
-Runs daily via `auto-update-helper.sh` when the user is idle. Results go to `~/.aidevops/logs/auto-update.log`.
+Runs daily via `auto-update-helper.sh` when idle. Results: `~/.aidevops/logs/auto-update.log`.
 
-Disable automatic checks:
+| Config key | Default | Effect |
+|------------|---------|--------|
+| `updates.venv_health_check` | `true` | Set `false` to disable |
+| `updates.venv_health_hours` | `24` | Check interval in hours |
 
 ```bash
 aidevops config set updates.venv_health_check false
-```
-
-Change the interval (default: 24h):
-
-```bash
 aidevops config set updates.venv_health_hours 12
 ```
 


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/venv-health.md` per GH#15023 (simplification-debt).

The file was previously 95 lines when the issue was filed; two prior PRs (#14968, #14725) reduced it to 68 lines. This PR completes the simplification to 58 lines.

### Changes

- Remove `## Quick Output` heading (single-command section needs no heading)
- Remove redundant "Display the helper output directly; formatting is built in." prose
- Fold `## Venv Discovery` section into a single inline note after the Checks table (removes heading overhead, content preserved)
- Add config options table for scanability alongside the existing code examples

### Verification

- All code blocks, URLs, command examples, and table data preserved
- `markdownlint-cli2`: 0 errors
- 68 → 58 lines (−15%)

### Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. `self-assessed`.

Closes #15023

---
[aidevops.sh](https://aidevops.sh) v3.5.611 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.