### PR TITLE
GH#15569: tighten do-storage.md prose and See Also descriptions

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage.md
@@ -1,6 +1,6 @@
 # Cloudflare Durable Objects Storage
 
-Persistent storage API for Durable Objects — SQLite/KV backends, PITR, automatic concurrency gates. Use cases: stateful coordination, real-time collaboration, counters, sessions, rate limiters.
+Persistent storage for Durable Objects — SQLite (recommended) or KV backend, 30-day PITR, automatic concurrency gates. Suited for counters, sessions, rate limiters, real-time collaboration.
 
 ## Storage Backends
 
@@ -43,8 +43,8 @@ export class Counter extends DurableObject {
 
 ## See Also
 
-- [do-storage-patterns.md](./do-storage-patterns.md) — schema migrations, caching, rate limiting, batch processing
-- [do-storage-gotchas.md](./do-storage-gotchas.md) — concurrency gates, transaction rules, SQL limits, async pitfalls
+- [do-storage-patterns.md](./do-storage-patterns.md) — migrations, caching, rate limiting, batch
+- [do-storage-gotchas.md](./do-storage-gotchas.md) — concurrency gates, transaction rules, SQL limits
 - [durable-objects.md](./durable-objects.md) — DO fundamentals and coordination patterns
 - [workers.md](./workers.md) — Worker runtime for DO stubs
 - [d1.md](./d1.md) — shared database alternative to per-DO storage

--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage.md
@@ -1,6 +1,6 @@
 # Cloudflare Durable Objects Storage
 
-Persistent storage for Durable Objects — SQLite (recommended) or KV backend, 30-day PITR, automatic concurrency gates. Suited for counters, sessions, rate limiters, real-time collaboration.
+Persistent storage for Durable Objects — SQLite (recommended, with 30-day PITR) or KV (legacy), automatic concurrency gates. Suited for counters, sessions, rate limiters, real-time collaboration.
 
 ## Storage Backends
 
@@ -43,7 +43,7 @@ export class Counter extends DurableObject {
 
 ## See Also
 
-- [do-storage-patterns.md](./do-storage-patterns.md) — migrations, caching, rate limiting, batch
+- [do-storage-patterns.md](./do-storage-patterns.md) — migrations, caching, rate limiting, batching
 - [do-storage-gotchas.md](./do-storage-gotchas.md) — concurrency gates, transaction rules, SQL limits
 - [durable-objects.md](./durable-objects.md) — DO fundamentals and coordination patterns
 - [workers.md](./workers.md) — Worker runtime for DO stubs


### PR DESCRIPTION
## Summary

- Tightened description line: removed "API for" redundancy, merged "Use cases" into flowing prose, added "30-day" qualifier to PITR for clarity
- Shortened See Also link descriptions: removed verbose phrases ("schema migrations" → "migrations", "async pitfalls" removed as covered by gotchas title)
- Line count unchanged at 50 (file is at structural floor given code block + tables)

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code changes.
**Verification:** `self-assessed` — content preservation confirmed via diff review. All code blocks, URLs, task ID references, and command examples preserved.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/do-storage.md`

Closes #15569

---
[aidevops.sh](https://aidevops.sh) v3.5.611 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6