### PR TITLE
GH#15046: tighten email sequence templates index and chapters

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -447,9 +447,39 @@
       "pr": 11590
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences.md": {
-      "hash": "5af4b4e800d180cb185bfa6d14ee93f2fc2661e9",
-      "at": "2026-03-28T13:37:24Z",
-      "pr": 11886
+      "hash": "b8583de58a62ecbaa78945857ece8c1a839e113a",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md": {
+      "hash": "778bb2596f4b6132271132a551456786eacd363f",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md": {
+      "hash": "2ba03ea97152c5008676168ed6738612b4e06d13",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md": {
+      "hash": "0870d62a357aa39b2fe3c27f7f015a311632b392",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md": {
+      "hash": "3ef0903a0a078642916595766be93ecf24dd40b1",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md": {
+      "hash": "6c6fa923a9613c26ce2cba7fee7400506a878093",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md": {
+      "hash": "887e0cc6c8f5689ae1d4a3b571db2d73e8e84420",
+      "at": "2026-04-02T12:00:00Z",
+      "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-readme.md": {
       "hash": "2717d1e9cb1edfd85d932502b6de7c4765c8a7ec",

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md
@@ -2,8 +2,6 @@
 
 Reusable defaults and snippets referenced across the email sequence templates.
 
-Source: split from `direct-response-copy-templates-email-sequences.md` to keep the index slim without dropping any template content.
-
 ## Shared Conventions
 
 **Defaults** (don't repeat per email):

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md
@@ -1,7 +1,5 @@
 # Welcome Sequence (5 Emails)
 
-Source: split from `direct-response-copy-templates-email-sequences.md`.
-
 ## E1 — Welcome + Delivery (Day 0)
 
 **Subject:** `Welcome to [Brand] + Your [Resource] Is Here`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md
@@ -1,7 +1,5 @@
 # Cart Abandonment (3 Emails)
 
-Source: split from `direct-response-copy-templates-email-sequences.md`.
-
 ## E1 — Reminder (1h)
 
 **Subject:** `Did something go wrong?`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md
@@ -1,7 +1,5 @@
 # SaaS Trial (7 Emails)
 
-Source: split from `direct-response-copy-templates-email-sequences.md`.
-
 ## E1 — Welcome + Quick Start (Day 0)
 
 **Subject:** `Welcome to [Product]! Here's how to start`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md
@@ -1,7 +1,5 @@
 # Launch Sequence (7 Emails)
 
-Source: split from `direct-response-copy-templates-email-sequences.md`.
-
 ## E1 — Teaser (Day -3)
 
 **Subject:** `Something new is coming...`

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md
@@ -1,7 +1,5 @@
 # Subject Line Quick Reference
 
-Source: split from `direct-response-copy-templates-email-sequences.md`.
-
 | Category | Templates |
 |----------|-----------|
 | **Value** | `[Number] [things] to [result] this week` · `The [adj] way to [outcome]` · `How I [result] (finally)` |

--- a/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-templates-email-sequences.md
@@ -15,22 +15,7 @@ Copy-paste templates for common sequences. Strategy/planning: [Email Sequences F
 
 ## How to Use
 
-1. Pick the sequence that matches the funnel stage.
-2. Reuse the shared patterns instead of rewriting them per email.
-3. Replace every bracketed placeholder with product-, audience-, and offer-specific detail.
-4. Adjust timing, CTA strength, and urgency to fit the campaign.
-
-This file is now the index for the email-sequence reference set. The chapter files retain the original template content.
-
-## Selection Guide
-
-- **Welcome**: New lead, subscriber, or download opt-in.
-- **Cart abandonment**: Checkout started but not completed.
-- **SaaS trial**: Product activation and upgrade conversion.
-- **Launch**: Timed launch, bonus window, or price-rise campaign.
-
-## Preservation Notes
-
-- All original templates now live in the chapter files above.
-- Shared defaults and reusable patterns moved to the shared-patterns chapter.
-- Subject line formulas moved to the subject-lines chapter.
+1. **Select sequence** matching the funnel stage.
+2. **Reuse patterns** from [Shared Patterns](direct-response-copy-templates-email-sequences-01-shared-patterns.md).
+3. **Customize** all bracketed placeholders with product/audience details.
+4. **Adjust** timing and CTA strength for the specific campaign.


### PR DESCRIPTION
## Summary
- Tightened the index file for email sequence templates.
- Cleaned up meta-info ("Source: split from...") in all chapter files.
- Updated the simplification state registry.

Closes #15046

---
[aidevops.sh](https://aidevops.sh) v3.5.611 plugin for [OpenCode](https://opencode.ai) v1.3.13 with gemini-3-flash spent 6m and 717,846 tokens on this as a headless worker.