### PR TITLE
fix: implement deploy_aidevops_agents() — was no-op stub causing script loss

### DIFF
--- a/.agents/scripts/setup/_deployment.sh
+++ b/.agents/scripts/setup/_deployment.sh
@@ -2,9 +2,87 @@
 # Agent deployment functions for setup.sh
 
 # Deploy aidevops agents to ~/.aidevops/agents/
+#
+# Uses atomic swap: deploy to a temp directory first, then rename over the
+# target. If the deploy fails mid-way, the old agents directory remains intact.
+# This prevents the scripts/ directory from disappearing during partial deploys.
 deploy_aidevops_agents() {
-	# TODO: Extract from setup.sh lines 3076-3268
-	:
+	local repo_dir="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+	local source_dir="${repo_dir}/.agents"
+	local target_dir="${HOME}/.aidevops/agents"
+	local staging_dir="${HOME}/.aidevops/.agents-staging-$$"
+
+	if [[ ! -d "$source_dir" ]]; then
+		echo "[deploy] ERROR: Source directory not found: $source_dir"
+		return 1
+	fi
+
+	# Stage: copy to temp directory
+	rm -rf "$staging_dir"
+	mkdir -p "$staging_dir"
+
+	if command -v rsync >/dev/null 2>&1; then
+		# rsync preserves permissions, handles symlinks, and is resumable
+		rsync -a --exclude '.git' --exclude '__pycache__' "$source_dir/" "$staging_dir/" || {
+			echo "[deploy] ERROR: rsync failed — aborting (old agents preserved)"
+			rm -rf "$staging_dir"
+			return 1
+		}
+	else
+		cp -R "$source_dir/." "$staging_dir/" || {
+			echo "[deploy] ERROR: cp failed — aborting (old agents preserved)"
+			rm -rf "$staging_dir"
+			return 1
+		}
+	fi
+
+	# Verify: critical files must exist in staging before swap
+	local critical_files=(
+		"scripts/pulse-wrapper.sh"
+		"scripts/headless-runtime-helper.sh"
+		"scripts/shared-constants.sh"
+		"AGENTS.md"
+	)
+	local missing=0
+	for f in "${critical_files[@]}"; do
+		if [[ ! -f "${staging_dir}/${f}" ]]; then
+			echo "[deploy] ERROR: Critical file missing from staging: ${f}"
+			missing=1
+		fi
+	done
+	if [[ "$missing" -eq 1 ]]; then
+		echo "[deploy] ERROR: Staging verification failed — aborting (old agents preserved)"
+		rm -rf "$staging_dir"
+		return 1
+	fi
+
+	# Preserve user customizations that survive updates
+	for preserve_dir in custom draft; do
+		if [[ -d "${target_dir}/${preserve_dir}" ]]; then
+			cp -R "${target_dir}/${preserve_dir}" "${staging_dir}/${preserve_dir}" 2>/dev/null || true
+		fi
+	done
+
+	# Swap: atomic rename (same filesystem, so this is a single inode operation)
+	local backup_dir="${HOME}/.aidevops/.agents-previous"
+	rm -rf "$backup_dir"
+	if [[ -d "$target_dir" ]]; then
+		mv "$target_dir" "$backup_dir" || {
+			echo "[deploy] ERROR: Failed to move old agents dir — aborting"
+			rm -rf "$staging_dir"
+			return 1
+		}
+	fi
+	mv "$staging_dir" "$target_dir" || {
+		echo "[deploy] ERROR: Failed to move staging to target — restoring backup"
+		mv "$backup_dir" "$target_dir" 2>/dev/null || true
+		return 1
+	}
+
+	# Set permissions on scripts
+	chmod +x "${target_dir}/scripts/"*.sh 2>/dev/null || true
+
+	echo "[deploy] Deployed agents to ${target_dir} ($(find "$target_dir" -type f | wc -l | tr -d ' ') files)"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- `deploy_aidevops_agents()` in `_deployment.sh` was a **no-op stub** since the module refactor — just `: ; return 0`
- When `--clean` ran or the agents tree was replaced, `scripts/` was wiped and never redeployed
- The pulse was dead for ~9 hours today (`No such file or directory` in launchd log) because of this
- **Fix**: Implement atomic deploy — stage → verify critical files → preserve custom/draft → swap via `mv`. Failure at any step preserves the old agents dir.

Also added a self-healing launcher to the launchd plist that recopies scripts from the repo if the deployed script is missing.

## Runtime Testing

Risk: **Critical** — deploy is the only mechanism that puts scripts into production. Verified: ShellCheck clean, tested staging + swap logic review. Critical file verification prevents deploying an empty/broken tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment functionality now performs complete workflows with built-in safeguards including automatic backup creation before updates, critical file validation, and comprehensive error handling for reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->