### PR TITLE
t15146: simplify headline testing checklist agent doc

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-checklists-headline-testing.md
+++ b/.agents/marketing-sales/direct-response-copy-checklists-headline-testing.md
@@ -2,32 +2,20 @@
 
 ## Before Writing
 
-- [ ] Specific target audience defined
-- [ ] Audience awareness level known
-- [ ] Primary pain point identified
-- [ ] Desired outcome identified
-- [ ] Unique offer value identified
-- [ ] Swipe file reviewed for inspiration
+- [ ] Define target audience & awareness level
+- [ ] Identify pain point, outcome, & unique value
+- [ ] Review swipe file for inspiration
 
 ## Drafting Pass
 
-- [ ] Write at least 25 variations
-- [ ] Try these formulas:
-  - [ ] How to [Outcome]
-  - [ ] [Number] Ways to [Benefit]
-  - [ ] The [Adjective] Guide to [Topic]
-  - [ ] Why [Common Belief] Is Wrong
-  - [ ] [Outcome] Without [Objection]
-  - [ ] Warning: [Negative Outcome]
-  - [ ] Are You Making These [Topic] Mistakes?
-  - [ ] Who Else Wants [Desired Outcome]?
-  - [ ] The Secret of [Desirable Group]
-  - [ ] [Question about their problem]
-- [ ] Try these angles: benefit-focused, problem-focused, curiosity-driven, social proof, urgency/scarcity, contrarian
+- [ ] Write 25+ variations using these formulas:
+  - How to [Outcome] | [Number] Ways to [Benefit] | The [Adjective] Guide to [Topic]
+  - Why [Common Belief] Is Wrong | [Outcome] Without [Objection] | Warning: [Negative Outcome]
+  - Are You Making These [Topic] Mistakes? | Who Else Wants [Desired Outcome]?
+  - The Secret of [Desirable Group] | [Question about their problem]
+- [ ] Try angles: benefit, problem, curiosity, social proof, urgency, contrarian
 
-## 4 U's Scorecard
-
-Score each headline 1-4 per dimension. Aim for 12+.
+## 4 U's Scorecard (Aim for 12+)
 
 | Criteria | Score (1-4) |
 |----------|-------------|
@@ -37,52 +25,50 @@ Score each headline 1-4 per dimension. Aim for 12+.
 | **Unique:** Different from competitors? | ___ |
 | **Total** | ___ / 16 |
 
-## Evaluate the Shortlist
+## Evaluation Criteria
 
-- **Clarity:** Understood in 5 seconds by an unfamiliar reader
+- **Clarity:** Understood in 5 seconds
 - **Benefit:** Clear "what's in it for me"
-- **Specificity:** Concrete numbers, results, or timeframes; avoid vague words like "better," "easier," and "more"
-- **Believability:** Plausible to a skeptic; not hypey
+- **Specificity:** Concrete numbers/results; avoid "better," "easier," "more"
+- **Believability:** Plausible to a skeptic; no hype
 - **Curiosity:** Creates interest without hiding the offer
 - **Audience fit:** Target customer sees themselves in it
 
 ## Red Flags
 
-- [ ] Too vague: "Improve your business"
-- [ ] Too clever: wordplay hurts clarity
-- [ ] Too long: over 15 words
-- [ ] Too hypey: "Revolutionary," "Game-changing," "Breakthrough"
-- [ ] Features-only: "128-bit encryption" with no payoff
+- [ ] Vague: "Improve your business"
+- [ ] Clever: wordplay hurting clarity
+- [ ] Long: >15 words
+- [ ] Hypey: "Revolutionary," "Game-changing," "Breakthrough"
+- [ ] Features-only: No payoff
 - [ ] Me-focused: "We're excited to announce..."
 - [ ] Clickbait: promise exceeds delivery
 
-## Quick Tests Before Publishing
+## Quick Tests
 
-- **5-second test:** Show it for 5 seconds and ask, "What is this offering and who is it for?" If they cannot answer, revise.
-- **Would I click?** Imagine it beside 10 competing posts. If you would not stop scrolling, revise.
-- **So what?** Read it aloud and ask, "Why should I care?" If the answer is unclear, revise.
+- **5-second test:** "What is this offering and who is it for?"
+- **Would I click?** Imagine beside 10 competing posts.
+- **So what?** "Why should I care?"
 
-## A/B Testing After Publishing
+## A/B Testing
 
-- **Test:** different benefits, question vs. statement, number vs. no number, short vs. long
-- **Sample size:** 100 impressions minimum per variation; 500+ for statistical significance; run for at least 48 hours
-- **Metrics:** click-through rate (primary), time on page (secondary), conversion rate (ultimate)
+- **Test:** benefits, question vs. statement, number vs. no number, length
+- **Sample:** 100+ impressions (500+ for significance); run 48h+
+- **Metrics:** CTR (primary), time on page, conversion rate
 
 ## Improvement Tactics
 
-1. **Add specificity:** "Grow your email list" → "Grow your email list to 10,000 in 90 days"
-2. **Add urgency:** "Learn copywriting" → "Learn copywriting before your competitors do"
-3. **Address objection:** "Get fit" → "Get fit without giving up your favorite foods"
-4. **Make it personal:** "How to improve sales" → "How to improve YOUR sales this quarter"
+1. **Add specificity:** "Grow list" → "Grow list to 10,000 in 90 days"
+2. **Add urgency:** "Learn copy" → "Learn copy before competitors do"
+3. **Address objection:** "Get fit" → "Get fit without giving up favorite foods"
+4. **Make it personal:** "Improve sales" → "Improve YOUR sales this quarter"
 5. **Add proof:** "Increase conversions" → "Increase conversions 47% (like 500+ others)"
-6. **Open a curiosity gap:** "SEO tips" → "The SEO trick I learned that doubled my traffic"
+6. **Open curiosity gap:** "SEO tips" → "The SEO trick that doubled my traffic"
 
 ## Final Selection
 
-- [ ] Passes the 4 U's test (12+)
-- [ ] Matches the audience's awareness level
-- [ ] Clearly beats the alternatives
-- [ ] Matches the content or offer that follows
+- [ ] Passes 4 U's (12+) & matches awareness level
+- [ ] Beats alternatives & matches following offer
 - [ ] Strong enough to stop scrolling
 - [ ] Approved by fresh eyes
 


### PR DESCRIPTION
## Summary
- Tightened prose and restructured the Headline Testing Checklist agent doc.
- Reduced line count from 93 to 79 while preserving all core instructions and formulas.
- Improved readability by grouping related items and using more concise language.

## Runtime Testing
- [x] self-assessed (Low risk: documentation-only change)

Closes #15146

$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model gemini-3-flash --issue marcusquinn/aidevops#15146 --session-type worker)