### PR TITLE
t15051: simplify memory-log.md agent doc

### DIFF
--- a/.agents/scripts/commands/memory-log.md
+++ b/.agents/scripts/commands/memory-log.md
@@ -10,12 +10,7 @@ Arguments: `$ARGUMENTS`
 
 ## Workflow
 
-1. Run the log command:
-
-```bash
-~/.aidevops/agents/scripts/memory-helper.sh log
-```
-
+1. Run the log command: `~/.aidevops/agents/scripts/memory-helper.sh log`
 2. Apply requested filters:
 
 | Argument | Command |
@@ -52,8 +47,7 @@ Auto-capture stores memories when AI agents detect:
   - Architecture decisions
   - Tool configurations
 
-Trigger auto-capture with:
-  memory-helper.sh store --auto --content "..."
+Trigger auto-capture with: memory-helper.sh store --auto --content "..."
 ```
 
 ## Auto-capture triggers
@@ -72,7 +66,6 @@ Agents store memories with `--auto` when they detect:
 ## Privacy
 
 Apply privacy filters before storage:
-
 - `<private>...</private>` tags are stripped before storage
 - Content matching secret patterns (API keys, tokens) is rejected
 - Use `privacy-filter-helper.sh scan` for comprehensive scanning


### PR DESCRIPTION
## Summary
- Tightened prose and removed redundant code blocks in `.agents/scripts/commands/memory-log.md`.
- Improved context efficiency by following `tools/build-agent/build-agent.md` guidance.
- Preserved all institutional knowledge and command examples.

## Runtime Testing
- Self-assessed: Changes are documentation-only (agent instructions) and do not affect runtime logic.
- Verified that all command examples and triggers are still present.

Closes #15051

---
$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model anthropic/claude-3-5-sonnet-20241022 --issue marcusquinn/aidevops#15051 --no-session --session-type worker --time 600)