### PR TITLE
hotfix: remove opencode/* gateway models from worker/pulse fallback chains

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -7,7 +7,7 @@
 #   - Persists OpenCode session IDs per provider + session key
 #   - Records backoff state per model (rate limits) or per provider (auth errors)
 #   - Clears backoff automatically when auth changes or retry windows expire
-#   - Supports opencode/* gateway models when explicitly configured
+#   - NOTE: opencode/* gateway models are NOT used (per-token billing, too expensive)
 
 set -euo pipefail
 
@@ -1972,7 +1972,7 @@ Defaults:
   AIDEVOPS_HEADLESS_MODELS defaults to anthropic/claude-sonnet-4-6,openai/gpt-4o
   AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST can restrict selection to providers like: openai
   AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 disables worker /full-loop contract injection
-  Gateway models (opencode/*) are supported when explicitly configured.
+  NOTE: opencode/* gateway models are NOT used — per-token billing is too expensive.
 EOF
 	return 0
 }

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -99,48 +99,31 @@ get_provider_key_vars() {
 is_known_provider() {
 	local provider="$1"
 	case "$provider" in
-	anthropic | openai | google | openrouter | groq | deepseek | opencode) return 0 ;;
+	anthropic | openai | google | openrouter | groq | deepseek) return 0 ;;
 	*) return 1 ;;
 	esac
 }
 
 # Tier to primary/fallback model mapping
 # Format: primary_provider/model|fallback_provider/model
-# When OpenCode is available, Anthropic models are routed through OpenCode's
-# gateway using the anthropic/ provider prefix (not opencode/). OpenCode uses
-# anthropic/ as the provider prefix for all Anthropic models — using opencode/
-# causes ProviderModelNotFoundError at dispatch time (GH#7633).
+# NEVER use opencode/* gateway models as fallbacks — they route through
+# OpenCode's per-token billing and are far more expensive than direct
+# provider API keys or subscription accounts.
 get_tier_models() {
 	local tier="$1"
 
-	# Check if OpenCode is available (CLI installed and models cache exists)
-	if _is_opencode_available; then
-		case "$tier" in
-		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
-		haiku) echo "anthropic/claude-haiku-4-5|opencode/gemini-3-flash" ;;
-		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
-		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.3-codex" ;;
-		pro) echo "google/gemini-2.5-pro|opencode/gemini-3.1-pro" ;;
-		opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
-		health) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		eval) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		coding) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
-		*) return 1 ;;
-		esac
-	else
-		case "$tier" in
-		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
-		haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
-		flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
-		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.3-codex" ;;
-		pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
-		opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
-		health) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		eval) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
-		coding) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
-		*) return 1 ;;
-		esac
-	fi
+	case "$tier" in
+	local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
+	haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
+	flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
+	sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.3-codex" ;;
+	pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
+	opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
+	health) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+	eval) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+	coding) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
+	*) return 1 ;;
+	esac
 	return 0
 }
 
@@ -197,45 +180,6 @@ _opencode_model_exists() {
 			'[.[] | .models[$m] // empty] | length > 0' "$OPENCODE_MODELS_CACHE" >/dev/null 2>&1
 		return $?
 	fi
-}
-
-# Validate an opencode/ model ID against the models cache (GH#12470).
-# If the model ID is stale (not in cache), logs a warning and returns 1.
-# This catches hardcoded model IDs that drift from the actual registry.
-# Usage: _validate_opencode_model_id "opencode/gemini-3.1-pro"
-# Returns: 0 if valid or non-opencode model, 1 if stale opencode model ID
-_validate_opencode_model_id() {
-	local model_spec="$1"
-	local provider="${model_spec%%/*}"
-
-	# Only validate opencode/ prefixed models
-	if [[ "$provider" != "opencode" ]]; then
-		return 0
-	fi
-
-	# Skip validation if opencode is not available
-	if ! _is_opencode_available; then
-		return 0
-	fi
-
-	if _opencode_model_exists "$model_spec"; then
-		return 0
-	fi
-
-	# Model not found in cache — it's stale
-	local model_id="${model_spec#*/}"
-	print_warning "Stale opencode model ID: $model_spec not found in models cache (GH#12470)"
-
-	# Try to suggest the correct ID by fuzzy-matching in the opencode provider
-	local suggestion
-	suggestion=$(jq -r --arg m "$model_id" \
-		'.opencode.models | keys[] | select(contains($m) or ($m | contains(.)))' \
-		"$OPENCODE_MODELS_CACHE" 2>/dev/null | head -1)
-	if [[ -n "$suggestion" ]]; then
-		print_info "Did you mean: opencode/$suggestion?"
-	fi
-
-	return 1
 }
 
 # =============================================================================
@@ -1045,18 +989,6 @@ resolve_tier() {
 	primary="${tier_spec%%|*}"
 	fallback="${tier_spec#*|}"
 
-	# Validate opencode model IDs against the models cache (GH#12470).
-	# If a hardcoded opencode/ model ID is stale, skip it rather than
-	# dispatching workers with an invalid ID that fails at startup.
-	if ! _validate_opencode_model_id "$primary"; then
-		[[ "$quiet" != "true" ]] && print_warning "Skipping stale primary model: $primary"
-		primary=""
-	fi
-	if ! _validate_opencode_model_id "$fallback"; then
-		[[ "$quiet" != "true" ]] && print_warning "Skipping stale fallback model: $fallback"
-		fallback=""
-	fi
-
 	# Rate limit check (t1330): if primary provider is at throttle risk,
 	# try fallback first to avoid hitting rate limits
 	local primary_provider
@@ -1658,15 +1590,12 @@ cmd_help() {
 	echo "  coding  - Best SOTA coding model"
 	echo ""
 	echo "Providers:"
-	echo "  anthropic, openai, google, openrouter, groq, deepseek, opencode"
-	echo "  The 'opencode' provider uses the OpenCode models cache (~/.cache/opencode/models.json)"
-	echo "  instead of direct API probing. When OpenCode is available, tier resolution"
-	echo "  prefers opencode/* model IDs (routed through OpenCode's gateway)."
+	echo "  anthropic, openai, google, openrouter, groq, deepseek"
+	echo "  NOTE: opencode/* gateway models are NOT used for dispatch — they route"
+	echo "  through per-token billing and are far more expensive than direct API keys."
 	echo ""
 	echo "Examples:"
 	echo "  model-availability-helper.sh check anthropic"
-	echo "  model-availability-helper.sh check opencode"
-	echo "  model-availability-helper.sh check opencode/claude-sonnet-4-6"
 	echo "  model-availability-helper.sh check anthropic/claude-sonnet-4-6"
 	echo "  model-availability-helper.sh check sonnet"
 	echo "  model-availability-helper.sh probe --all"


### PR DESCRIPTION
## Summary

- Removed `opencode/*` gateway model IDs from all worker/pulse dispatch fallback chains in `model-availability-helper.sh`
- Collapsed dual-branch `get_tier_models()` (opencode-available vs not) into single set using direct provider API keys (anthropic/, google/, openai/)
- Removed `_validate_opencode_model_id()` function and its call sites (no longer needed)
- Removed `opencode` from known providers list
- Updated help text to warn against opencode/* gateway usage
- Updated `headless-runtime-helper.sh` comments

## Why

The `opencode/*` model prefix routes requests through OpenCode's per-token billing gateway, which is significantly more expensive than direct provider API keys or Anthropic subscription accounts. Workers dispatched by the pulse were falling back to these models and driving up costs (observed via alex-solovyev API usage).

## Files Changed

- `.agents/scripts/model-availability-helper.sh` — core fix (tier mappings, provider list, validation, help text)
- `.agents/scripts/headless-runtime-helper.sh` — comment updates

## Verification

- `shellcheck --severity=error` passes on both files
- `bash -n` syntax check passes
- No dangling `_validate_opencode_model_id` references remain
- `rg 'opencode/'` confirms only cache path references remain (not model dispatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that OpenCode gateway models are not used or supported due to per-token billing cost considerations.

* **Refactoring**
  * Removed OpenCode gateway models from provider discovery, validation, and selection logic. Simplified routing by eliminating unsupported fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->