### PR TITLE
GH#14025: tighten cron-triggers-gotchas.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md
@@ -2,7 +2,7 @@
 
 ## Timezone Issues
 
-**⚠️ UTC ONLY** - No timezone configuration
+**UTC ONLY** — no timezone configuration supported.
 
 ```typescript
 // ❌ Wrong: "0 9 * * *" // 9am UTC, not local
@@ -12,7 +12,7 @@
 
 ## Propagation Delay
 
-**Changes take up to 15 minutes**. Verify: Dashboard → Workers → Select Worker → Settings → Triggers
+**Changes take up to 15 minutes.** Verify: Dashboard → Workers → Select Worker → Settings → Triggers
 
 ## Limits
 
@@ -29,7 +29,7 @@
 
 ## Duplicate Executions
 
-**At-least-once delivery** - duplicates possible. Make idempotent:
+**At-least-once delivery** — duplicates possible. Make handlers idempotent:
 
 ```typescript
 export default {
@@ -58,7 +58,7 @@ export default {
 
 ## Execution Failures
 
-**Common:** CPU exceeded, unhandled exceptions, network timeouts, binding misconfiguration
+**Common causes:** CPU exceeded, unhandled exceptions, network timeouts, binding misconfiguration
 
 ```typescript
 export default {
@@ -72,23 +72,25 @@ export default {
       await processData(await response.json(), env);
     } catch (error) {
       console.error("Failed", {error: error.message, cron: controller.cron});
-      // Don't re-throw to mark success despite errors
+      // Don't re-throw — marks success despite errors
     }
   },
 };
 ```
 
-## Local Testing Issues
+## Local Testing
 
-Ensure `wrangler dev` runs, `scheduled()` exists, update Wrangler: `npm i -g wrangler@latest`
+Ensure `wrangler dev` runs, `scheduled()` is exported, Wrangler is up to date: `npm i -g wrangler@latest`
 
 ```bash
-curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*" # URL encode spaces
-curl "http://localhost:8787/__scheduled" # No params = default
-# Python: curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*/5+*+*+*+*"
+curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"  # URL-encode spaces
+curl "http://localhost:8787/__scheduled"                    # No params = default cron
+curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*/5+*+*+*+*"  # Alternative path
 ```
 
 ## Security
+
+Block `/__scheduled` in production to prevent external trigger abuse:
 
 ```typescript
 export default {
@@ -118,7 +120,9 @@ npx wrangler secret put API_KEY
 
 ## Green Compute
 
-Dashboard: Workers & Pages → Account details → Compute Setting → Green Compute. Tradeoffs: fewer locations, higher latency, ideal for non-time-critical jobs
+Enable via Dashboard: Workers & Pages → Account details → Compute Setting → Green Compute.
+
+**Tradeoffs:** fewer locations, higher latency — ideal for non-time-critical jobs.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md` per GH#14025.

**Classification:** Instruction doc (gotchas/decision rules with code examples) — tighten prose, not restructure.

### Changes

- Remove decorative `⚠️` emoji from Timezone Issues (safe per code-simplifier)
- Fix misleading `# Python:` comment → `# Alternative path` (the alternative URL path is not Python-specific)
- Add prose intro to Security section explaining *why* to block `/__scheduled` in production
- Split Green Compute single long line into two readable lines
- Minor prose tightening: em-dashes, clearer wording, "Local Testing Issues" → "Local Testing"

### Verification

- All code blocks preserved ✓
- All URLs preserved ✓
- All command examples preserved ✓
- No task IDs or GH refs in original to preserve ✓
- `markdownlint` clean ✓
- Line count: 129 → 133 (slightly longer due to Security prose intro + Green Compute split — both clarity improvements)

## Runtime Testing

**Risk level:** Low — agent doc (markdown only, no executable code changed)
**Assessment:** self-assessed — no runtime environment needed for markdown doc changes

Closes #14025

---
[aidevops.sh](https://aidevops.sh) v3.5.612 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6