### PR TITLE
GH#14796: tighten aidevops-plugin.md agent doc

### DIFF
--- a/.agents/tools/build-mcp/aidevops-plugin.md
+++ b/.agents/tools/build-mcp/aidevops-plugin.md
@@ -13,15 +13,11 @@ tools:
 
 # aidevops-opencode Plugin Architecture
 
-<!-- AI-CONTEXT-START -->
-
 - **Status**: Implemented (`t008.1` PR #1138, `t008.2` PR #1149, `t008.3` PR #1150)
 - **Purpose**: Native OpenCode plugin wrapper for aidevops
 - **Implementation**: Single-file ESM plugin at `.agents/plugins/opencode-aidevops/index.mjs`
 - **SDK**: `@opencode-ai/plugin` v1.1.56+ (`index.d.ts` on npm)
 - **Boundary**: `generate-opencode-agents.sh` and `setup.sh` own static config; the plugin owns runtime hooks and tools. Shell-generated config wins on conflicts.
-
-<!-- AI-CONTEXT-END -->
 
 ## Runtime surface
 
@@ -37,11 +33,10 @@ tools:
 
 ### `config`
 
-- Loads subagents from `~/.aidevops/agents/`, parses YAML frontmatter, injects them into `config.agent`, and skips shell-generated entries (`t008.1`).
+- Loads subagents from `~/.aidevops/agents/`, parses YAML frontmatter, injects into `config.agent`, skips shell-generated entries (`t008.1`).
 - Registers MCP servers from a data-driven registry instead of re-running `generate-opencode-agents.sh` (`t008.2`).
 - Registry fields: `name`, `type` (`local`/`remote`), `command` or `url`, `eager`, `toolPattern`, `globallyEnabled`, `requiresBinary`, `macOnly`.
-- `AGENT_MCP_TOOLS` maps agents to tool globs, for example `@dataforseo` -> `dataforseo_*`.
-- Startup policy: all 11 MCPs are lazy-loaded, saving ~7K startup tokens.
+- `AGENT_MCP_TOOLS` maps agents to tool globs (e.g. `@dataforseo` → `dataforseo_*`). All 11 MCPs lazy-loaded, saving ~7K startup tokens.
 
 | MCP | Type | Global tools |
 |---|---|---|
@@ -57,7 +52,7 @@ tools:
 | `sentry` | remote | no |
 | `socket` | remote | no |
 
-### Supporting hooks
+### Other hooks
 
 | Hook | Coverage |
 |---|---|


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/build-mcp/aidevops-plugin.md` per the simplification-debt issue.

**Classification:** Instruction doc (agent rules, architecture decisions, hook configurations) — prose tightening applied, not reference-corpus restructuring.

**Changes:**
- Remove `<!-- AI-CONTEXT-START/END -->` wrapper (adds 4 lines of overhead with no functional value in this doc)
- Compress `config` hook prose: merge startup policy sentence into `AGENT_MCP_TOOLS` line (saves 1 line, same information)
- Rename `Supporting hooks` → `Other hooks` (clearer, less redundant under the `Hooks` section)

**Preserved (verified):**
- All task IDs: `t008.1`, `t008.2`, `t008.3`
- All PR refs: `#1138`, `#1149`, `#1150`
- All URLs: `https://opencode.ai/docs/plugins`
- All command examples, file paths, env var names, dependency names
- All 11 MCP entries in the registry table
- All 6 design decision rows

**Result:** 85 → 80 lines. Zero knowledge loss.

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. `self-assessed`.

Closes #14796

---
[aidevops.sh](https://aidevops.sh) v3.5.615 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6