### PR TITLE
GH#14794: tighten product monetisation agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3670,6 +3670,11 @@
       "hash": "23966f40446ab560b3d8837fbe851615d372bf809b321725ae58ab70d57dc181",
       "at": "2026-04-02T12:50:00Z",
       "pr": 15047
+    },
+    ".agents/product/monetisation.md": {
+      "hash": "45e90e4a5ea84ee64c7c83125716b656",
+      "at": "2026-04-02T13:53:12Z",
+      "pr": null
     }
   },
   ".agents/seo/ai-search-kpi-template.md": {

--- a/.agents/product/monetisation.md
+++ b/.agents/product/monetisation.md
@@ -38,8 +38,6 @@ Can recommend relevant products?   -> Affiliate links + optional premium tier
 
 ## Choose Model
 
-Use the decision tree first, then match the model to product shape:
-
 | Model | Best for | Notes |
 |-------|---------|-------|
 | Subscription | Recurring problems, ongoing value | Weekly/monthly/annual plans; 7-day trial is the default |
@@ -62,7 +60,7 @@ Superwall handles remote paywall config and price/layout/copy A/B testing (`serv
 
 ## Define Entitlements
 
-Products → entitlements → feature gates (platform-agnostic):
+Products → entitlements → feature gates:
 
 ```text
 ├── Monthly ($4.99/mo)        -> "premium" entitlement
@@ -72,8 +70,6 @@ Products → entitlements → feature gates (platform-agnostic):
 ```
 
 ## Design Paywall
-
-Rules:
 
 - Show at moment of highest intent (after user tries a premium feature)
 - Display value proposition, not price
@@ -103,7 +99,7 @@ A/B test price points, paywall designs, trial lengths, and feature gates with Re
 
 ## Set Pricing
 
-Process: check competitor pricing -> survey target users on willingness to pay -> start competitive -> adjust on data. Annual plans usually land at a 15-40% discount vs monthly.
+Process: competitor pricing → user WTP survey → start competitive → adjust on data. Annual plans: 15-40% discount vs monthly.
 
 | Model | Typical Range |
 |-------|--------------|


### PR DESCRIPTION
## Summary

Tighten `.agents/product/monetisation.md` per GH#14794 simplification request.

**Classification**: Instruction doc (agent rules, decision trees, operational procedures) — prose tightening applied, not reference corpus restructuring.

**Changes** (130 → 126 lines):
- Remove redundant intro sentence in "Choose Model" (decision tree already in Quick Reference above)
- Remove `Rules:` label before paywall rules list (list is self-evident)
- Remove `(platform-agnostic)` from entitlements intro (obvious from context)
- Tighten pricing process sentence (same meaning, fewer words)

**Preserved**: all code blocks, file references (`services/payments/revenuecat.md`, `services/payments/stripe.md`, `services/payments/superwall.md`, `product/onboarding.md`, `product/analytics.md`, `product/growth.md`), all pricing data, all legal requirements, agent behaviour unchanged.

## Runtime Testing

**Risk level**: Low — agent doc only, no shell scripts or code.
**Verification**: `self-assessed` — content preservation verified via diff review.

Closes #14794

---
[aidevops.sh](https://aidevops.sh) v3.5.615 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6