### PR TITLE
GH#14110: tighten kv-gotchas.md agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md
@@ -3,15 +3,15 @@
 ## Eventual Consistency
 
 ```typescript
-// ❌ BAD: Read immediately after write (may see stale globally)
+// ❌ Read immediately after write (may see stale globally)
 await env.MY_KV.put("key", "value");
 const value = await env.MY_KV.get("key"); // May be null in other regions
 
-// ✅ GOOD: Return confirmation without reading
+// ✅ Return confirmation without reading
 await env.MY_KV.put("key", "value");
 return new Response("Updated", { status: 200 });
 
-// ✅ GOOD: Use local value
+// ✅ Use local value
 const newValue = "updated";
 await env.MY_KV.put("key", newValue);
 return new Response(newValue);
@@ -22,22 +22,22 @@ return new Response(newValue);
 ## Concurrent Writes
 
 ```typescript
-// ❌ BAD: Concurrent writes to same key (429 rate limit)
+// ❌ Concurrent writes to same key (429 rate limit)
 await Promise.all([
   env.MY_KV.put("counter", "1"),
   env.MY_KV.put("counter", "2")
 ]); // 429 error
 
-// ✅ GOOD: Sequential writes
+// ✅ Sequential writes
 await env.MY_KV.put("counter", "3");
 
-// ✅ GOOD: Unique keys for concurrent writes
+// ✅ Unique keys for concurrent writes
 await Promise.all([
   env.MY_KV.put("counter:1", "1"),
   env.MY_KV.put("counter:2", "2")
 ]);
 
-// ✅ GOOD: Retry with backoff
+// ✅ Retry with backoff
 async function putWithRetry(kv: KVNamespace, key: string, value: string) {
   let delay = 1000;
   for (let i = 0; i < 5; i++) {
@@ -59,12 +59,12 @@ async function putWithRetry(kv: KVNamespace, key: string, value: string) {
 ## Bulk Operations
 
 ```typescript
-// ❌ BAD: Multiple individual gets (uses 3 operations)
+// ❌ Multiple individual gets (uses 3 operations)
 const user1 = await env.USERS.get("user:1");
 const user2 = await env.USERS.get("user:2");
 const user3 = await env.USERS.get("user:3");
 
-// ✅ GOOD: Single bulk get (uses 1 operation)
+// ✅ Single bulk get (uses 1 operation)
 const users = await env.USERS.get(["user:1", "user:2", "user:3"]);
 ```
 
@@ -73,45 +73,38 @@ const users = await env.USERS.get(["user:1", "user:2", "user:3"]);
 ## Null Handling
 
 ```typescript
-// ❌ BAD: No null check
+// ❌ No null check
 const value = await env.MY_KV.get("key");
 const result = value.toUpperCase(); // Error if null
 
-// ✅ GOOD: Check for null
+// ✅ Check for null
 const value = await env.MY_KV.get("key");
 if (value === null) return new Response("Not found", { status: 404 });
 return new Response(value);
 
-// ✅ GOOD: Provide default
+// ✅ Provide default
 const value = (await env.MY_KV.get("config")) ?? "default-config";
 ```
 
-## Value Limits
+## Limits & Pricing
 
-- Key size: 512 bytes max
-- Value size: 25 MiB max
-- Metadata: 1024 bytes max
-- cacheTtl: 60s minimum
+| | |
+|---|---|
+| Key size | 512 bytes max |
+| Value size | 25 MiB max |
+| Metadata | 1024 bytes max |
+| cacheTtl | 60s minimum |
+| Reads | $0.50 per 10M |
+| Writes | $5.00 per 1M |
+| Deletes | $5.00 per 1M |
+| Storage | $0.50 per GB-month |
 
-## Pricing
+## When to Use
 
-- **Reads:** $0.50 per 10M
-- **Writes:** $5.00 per 1M
-- **Deletes:** $5.00 per 1M
-- **Storage:** $0.50 per GB-month
-
-## When NOT to Use
-
-- ❌ Strong consistency required → Durable Objects
-- ❌ Write-heavy workloads → D1 or Durable Objects
-- ❌ Relational queries → D1
-- ❌ Large files (>25 MiB) → R2
-- ❌ Atomic operations → Durable Objects
-
-## When TO Use
-
-- ✅ Read-heavy workloads
-- ✅ Global distribution needed
-- ✅ Eventually consistent acceptable
-- ✅ Key-value access patterns
-- ✅ Low-latency reads critical
+| Use KV | Use Instead |
+|--------|-------------|
+| Read-heavy, globally distributed, eventually consistent | Strong consistency → Durable Objects |
+| Low-latency reads, key-value access | Write-heavy → D1 or Durable Objects |
+| | Relational queries → D1 |
+| | Large files (>25 MiB) → R2 |
+| | Atomic operations → Durable Objects |


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md` per `build-agent.md` guidance.

**Changes:**
- Trim verbose inline comment labels in code blocks (keep ❌/✅ symbols, drop redundant "BAD:" / "GOOD:" text)
- Merge "Value Limits" + "Pricing" sections into single "Limits & Pricing" table
- Merge "When NOT to Use" + "When TO Use" into single comparison table
- 117 → 110 lines, 0 markdownlint errors

**Preserved:** All code blocks, API patterns, limits, pricing data, routing guidance (Durable Objects, D1, R2), and the `putWithRetry` implementation.

**Classification:** Instruction doc (gotchas/troubleshooting patterns) — tighten prose, not restructure into chapters.

## Runtime Testing

Risk: **Low** — agent doc only, no code execution paths. Self-assessed.

- [x] markdownlint-cli2: 0 errors
- [x] Content preservation verified: all code blocks, limits, pricing, routing guidance intact

Closes #14110

---
[aidevops.sh](https://aidevops.sh) v3.5.614 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.