### PR TITLE
Prioritise triage reviews for needs-maintainer-review issues

### DIFF
--- a/.agents/scripts/commands/pulse-sweep.md
+++ b/.agents/scripts/commands/pulse-sweep.md
@@ -83,6 +83,19 @@ gh pr merge NUMBER --repo SLUG --squash
 `CHANGES_REQUESTED` → dispatch fix worker. `APPROVED` → merge directly.
 Check external contributor gate before ANY approve/merge (see Pre-merge checks below).
 
+### 3.5. Dispatch triage reviews for needs-maintainer-review issues
+
+**Before implementation workers.** External contributor issues deserve fast feedback —
+dispatch opus-tier triage reviews first so the community isn't left waiting. Max 2 per cycle.
+Uses pre-fetched triage status.
+
+```bash
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
+```
+
+Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
+
 ### 4. Dispatch workers for open issues
 
 ```bash
@@ -96,19 +109,7 @@ dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER
 
 Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
 
-### 4.5. Dispatch triage reviews for needs-maintainer-review issues
-
-After filling implementation slots, dispatch opus-tier triage reviews for unreviewed
-`needs-maintainer-review` issues. Max 2 per cycle. Uses pre-fetched triage status.
-
-```bash
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
-```
-
-Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
-
-### 4.6. Scan status:needs-info issues for contributor replies
+### 4.5. Scan status:needs-info issues for contributor replies
 
 Transition replied issues to `needs-maintainer-review` so they re-enter the triage pipeline.
 No worker dispatch, no slots consumed.
@@ -118,7 +119,7 @@ source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 relabel_needs_info_replies
 ```
 
-### 4.7. Dispatch FOSS contribution workers when idle capacity exists (t1702)
+### 4.6. Dispatch FOSS contribution workers when idle capacity exists (t1702)
 
 Lowest priority — only when all managed-repo work is dispatched and slots remain.
 
@@ -167,8 +168,8 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    ```
 
 4. **If slots are open**: check for mergeable PRs (free), dispatch workers for highest-priority
-   open issues, dispatch triage reviews (step 4.5), scan needs-info replies (step 4.6), dispatch
-   FOSS workers if idle (step 4.7). Use the same dedup guards and dispatch commands as the
+   open issues, dispatch triage reviews (step 3.5), scan needs-info replies (step 4.5), dispatch
+   FOSS workers if idle (step 4.6). Use the same dedup guards and dispatch commands as the
    initial dispatch. Re-fetch issue state with targeted `gh` calls only for repos where you
    need to dispatch.
 
@@ -208,14 +209,15 @@ your best call and move on — the next monitoring cycle is 60 seconds away.
 
 1. PRs with green CI → merge (free — no worker slot needed)
 2. PRs with failing CI or review feedback → fix (uses a slot, but closer to done)
-3. Issues labelled `priority:high` or `bug`
-4. Active mission features (keeps multi-day projects moving)
-5. Product repos over tooling — enforced by priority-class reservations
-6. Smaller/simpler tasks over large ones (faster throughput)
-7. `quality-debt` issues — use worktree dispatch (see below)
-8. `simplification-debt` issues (human-approved)
-9. Oldest issues
-10. FOSS contributions — only when all managed-repo work is dispatched
+3. Triage reviews for `needs-maintainer-review` issues → community responsiveness (step 3.5)
+4. Issues labelled `priority:high` or `bug`
+5. Active mission features (keeps multi-day projects moving)
+6. Product repos over tooling — enforced by priority-class reservations
+7. Smaller/simpler tasks over large ones (faster throughput)
+8. `quality-debt` issues — use worktree dispatch (see below)
+9. `simplification-debt` issues (human-approved)
+10. Oldest issues
+11. FOSS contributions — only when all managed-repo work is dispatched
 
 ## PRs — Merge, Fix, or Flag
 
@@ -261,8 +263,8 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Duplicate issues** → keep the one referenced by `ref:GH#` in TODO.md, close others.
 - **Too large** → `task-decompose-helper.sh classify`. If composite, decompose into subtask issues.
 - **`status:queued`/`status:in-progress`** → if updated within 3h, skip. If 3+ hours with no PR/worker, relabel `status:available`, unassign, comment recovery.
-- **`needs-maintainer-review`** → dispatch triage review worker (step 4.5), NOT implementation worker.
-- **`status:needs-info`** → check pre-fetched reply status (step 4.6).
+- **`needs-maintainer-review`** → dispatch triage review worker (step 3.5), NOT implementation worker.
+- **`status:needs-info`** → check pre-fetched reply status (step 4.5).
 - **`status:available` or no status** → dispatch implementation worker.
 
 ### Maintainer review gate (t1545)

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -87,6 +87,19 @@ gh pr merge NUMBER --repo SLUG --squash
 `CHANGES_REQUESTED` → dispatch fix worker. `APPROVED` → merge directly.
 Check external contributor gate before ANY approve/merge (see Pre-merge checks below).
 
+### 3.5. Dispatch triage reviews for needs-maintainer-review issues
+
+**Before implementation workers.** External contributor issues deserve fast feedback —
+dispatch opus-tier triage reviews first so the community isn't left waiting. Max 2 per cycle.
+Uses pre-fetched triage status.
+
+```bash
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
+```
+
+Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
+
 ### 4. Dispatch workers for open issues
 
 ```bash
@@ -100,19 +113,7 @@ dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER
 
 Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
 
-### 4.5. Dispatch triage reviews for needs-maintainer-review issues
-
-After filling implementation slots, dispatch opus-tier triage reviews for unreviewed
-`needs-maintainer-review` issues. Max 2 per cycle. Uses pre-fetched triage status.
-
-```bash
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
-```
-
-Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
-
-### 4.6. Scan status:needs-info issues for contributor replies
+### 4.5. Scan status:needs-info issues for contributor replies
 
 Transition replied issues to `needs-maintainer-review` so they re-enter the triage pipeline.
 No worker dispatch, no slots consumed.
@@ -122,7 +123,7 @@ source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 relabel_needs_info_replies
 ```
 
-### 4.7. Dispatch FOSS contribution workers when idle capacity exists (t1702)
+### 4.6. Dispatch FOSS contribution workers when idle capacity exists (t1702)
 
 Lowest priority — only when all managed-repo work is dispatched and slots remain.
 
@@ -171,8 +172,8 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    ```
 
 4. **If slots are open**: check for mergeable PRs (free), dispatch workers for highest-priority
-   open issues, dispatch triage reviews (step 4.5), scan needs-info replies (step 4.6), dispatch
-   FOSS workers if idle (step 4.7). Use the same dedup guards and dispatch commands as the
+   open issues, dispatch triage reviews (step 3.5), scan needs-info replies (step 4.5), dispatch
+   FOSS workers if idle (step 4.6). Use the same dedup guards and dispatch commands as the
    initial dispatch. Re-fetch issue state with targeted `gh` calls only for repos where you
    need to dispatch.
 
@@ -212,14 +213,15 @@ your best call and move on — the next monitoring cycle is 60 seconds away.
 
 1. PRs with green CI → merge (free — no worker slot needed)
 2. PRs with failing CI or review feedback → fix (uses a slot, but closer to done)
-3. Issues labelled `priority:high` or `bug`
-4. Active mission features (keeps multi-day projects moving)
-5. Product repos over tooling — enforced by priority-class reservations
-6. Smaller/simpler tasks over large ones (faster throughput)
-7. `quality-debt` issues — use worktree dispatch (see below)
-8. `simplification-debt` issues (human-approved)
-9. Oldest issues
-10. FOSS contributions — only when all managed-repo work is dispatched
+3. Triage reviews for `needs-maintainer-review` issues → community responsiveness (step 3.5)
+4. Issues labelled `priority:high` or `bug`
+5. Active mission features (keeps multi-day projects moving)
+6. Product repos over tooling — enforced by priority-class reservations
+7. Smaller/simpler tasks over large ones (faster throughput)
+8. `quality-debt` issues — use worktree dispatch (see below)
+9. `simplification-debt` issues (human-approved)
+10. Oldest issues
+11. FOSS contributions — only when all managed-repo work is dispatched
 
 ## PRs — Merge, Fix, or Flag
 
@@ -255,8 +257,8 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Has merged PR** → comment linking PR, then close.
 - **`status:blocked` but blockers resolved** → remove label, add `status:available`, comment.
 - **`status:queued`/`status:in-progress`** → if updated within 3h, skip. If 3+ hours with no PR/worker, relabel `status:available`, unassign, comment recovery.
-- **`needs-maintainer-review`** → dispatch triage review worker (step 4.5), NOT implementation worker.
-- **`status:needs-info`** → check pre-fetched reply status (step 4.6).
+- **`needs-maintainer-review`** → dispatch triage review worker (step 3.5), NOT implementation worker.
+- **`status:needs-info`** → check pre-fetched reply status (step 4.5).
 - **`status:available` or no status** → dispatch implementation worker.
 
 NEVER dispatch a worker for an issue with `needs-maintainer-review`. Maintainer must remove it

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6445,6 +6445,17 @@ dispatch_deterministic_fill_floor() {
 
 	echo "[pulse-wrapper] Deterministic fill floor: available=${available_slots}, runnable=${runnable_count}, queued_without_worker=${queued_without_worker}, candidates=${candidate_count}" >>"$LOGFILE"
 
+	# Triage reviews first — community responsiveness before implementation backlog.
+	# dispatch_triage_reviews returns the remaining available count via stdout.
+	local triage_remaining
+	triage_remaining=$(dispatch_triage_reviews "$available_slots" 2>>"$LOGFILE") || triage_remaining="$available_slots"
+	[[ "$triage_remaining" =~ ^[0-9]+$ ]] || triage_remaining="$available_slots"
+	local triage_dispatched=$((available_slots - triage_remaining))
+	if [[ "$triage_dispatched" -gt 0 ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: dispatched ${triage_dispatched} triage review(s), ${triage_remaining} slots remaining for implementation" >>"$LOGFILE"
+	fi
+	available_slots="$triage_remaining"
+
 	local dispatched_count=0
 	while IFS= read -r candidate_json; do
 		[[ -n "$candidate_json" ]] || continue
@@ -6491,8 +6502,9 @@ dispatch_deterministic_fill_floor() {
 		dispatched_count=$((dispatched_count + 1))
 	done < <(printf '%s' "$candidates_json" | jq -c '.[]' 2>/dev/null)
 
-	echo "[pulse-wrapper] Deterministic fill floor complete: dispatched=${dispatched_count}, target_available=${available_slots}" >>"$LOGFILE"
-	echo "$dispatched_count"
+	local total_dispatched=$((dispatched_count + triage_dispatched))
+	echo "[pulse-wrapper] Deterministic fill floor complete: dispatched=${total_dispatched} (${triage_dispatched} triage + ${dispatched_count} implementation), target_available=${available_slots}" >>"$LOGFILE"
+	echo "$total_dispatched"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `dispatch_triage_reviews()` was never called because `dispatch_deterministic_fill_floor()` filled all worker slots with implementation workers before the LLM session started. 3 external contributor issues (#15545, #15544, #15543) sat with `needs-review` status but zero triage workers were ever dispatched.
- **Fix**: Call `dispatch_triage_reviews()` at the top of the deterministic fill floor, before the implementation candidate loop. Triage reviews now consume slots first (max 2/cycle), then implementation workers fill the rest.
- **Doc alignment**: Reorder pulse step sequence (4.5 → 3.5) and priority list (#3) in both `pulse.md` and `pulse-sweep.md` so the LLM layer also treats community triage as higher priority than backlog implementation.

## Files changed

| File | Change |
|------|--------|
| `.agents/scripts/pulse-wrapper.sh` | Call `dispatch_triage_reviews()` before implementation fill loop |
| `.agents/scripts/commands/pulse.md` | Move triage to step 3.5, priority #3 |
| `.agents/scripts/commands/pulse-sweep.md` | Same reordering |