### PR TITLE
Fix dispatch_triage_reviews: parser and model fallback bugs

### DIFF
--- a/.agents/scripts/commands/pulse-sweep.md
+++ b/.agents/scripts/commands/pulse-sweep.md
@@ -83,6 +83,19 @@ gh pr merge NUMBER --repo SLUG --squash
 `CHANGES_REQUESTED` → dispatch fix worker. `APPROVED` → merge directly.
 Check external contributor gate before ANY approve/merge (see Pre-merge checks below).
 
+### 3.5. Dispatch triage reviews for needs-maintainer-review issues
+
+**Before implementation workers.** External contributor issues deserve fast feedback —
+dispatch opus-tier triage reviews first so the community isn't left waiting. Max 2 per cycle.
+Uses pre-fetched triage status.
+
+```bash
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
+```
+
+Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
+
 ### 4. Dispatch workers for open issues
 
 ```bash
@@ -96,19 +109,7 @@ dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER
 
 Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
 
-### 4.5. Dispatch triage reviews for needs-maintainer-review issues
-
-After filling implementation slots, dispatch opus-tier triage reviews for unreviewed
-`needs-maintainer-review` issues. Max 2 per cycle. Uses pre-fetched triage status.
-
-```bash
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
-```
-
-Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
-
-### 4.6. Scan status:needs-info issues for contributor replies
+### 4.5. Scan status:needs-info issues for contributor replies
 
 Transition replied issues to `needs-maintainer-review` so they re-enter the triage pipeline.
 No worker dispatch, no slots consumed.
@@ -118,7 +119,7 @@ source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 relabel_needs_info_replies
 ```
 
-### 4.7. Dispatch FOSS contribution workers when idle capacity exists (t1702)
+### 4.6. Dispatch FOSS contribution workers when idle capacity exists (t1702)
 
 Lowest priority — only when all managed-repo work is dispatched and slots remain.
 
@@ -167,8 +168,8 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    ```
 
 4. **If slots are open**: check for mergeable PRs (free), dispatch workers for highest-priority
-   open issues, dispatch triage reviews (step 4.5), scan needs-info replies (step 4.6), dispatch
-   FOSS workers if idle (step 4.7). Use the same dedup guards and dispatch commands as the
+   open issues, dispatch triage reviews (step 3.5), scan needs-info replies (step 4.5), dispatch
+   FOSS workers if idle (step 4.6). Use the same dedup guards and dispatch commands as the
    initial dispatch. Re-fetch issue state with targeted `gh` calls only for repos where you
    need to dispatch.
 
@@ -208,14 +209,15 @@ your best call and move on — the next monitoring cycle is 60 seconds away.
 
 1. PRs with green CI → merge (free — no worker slot needed)
 2. PRs with failing CI or review feedback → fix (uses a slot, but closer to done)
-3. Issues labelled `priority:high` or `bug`
-4. Active mission features (keeps multi-day projects moving)
-5. Product repos over tooling — enforced by priority-class reservations
-6. Smaller/simpler tasks over large ones (faster throughput)
-7. `quality-debt` issues — use worktree dispatch (see below)
-8. `simplification-debt` issues (human-approved)
-9. Oldest issues
-10. FOSS contributions — only when all managed-repo work is dispatched
+3. Triage reviews for `needs-maintainer-review` issues → community responsiveness (step 3.5)
+4. Issues labelled `priority:high` or `bug`
+5. Active mission features (keeps multi-day projects moving)
+6. Product repos over tooling — enforced by priority-class reservations
+7. Smaller/simpler tasks over large ones (faster throughput)
+8. `quality-debt` issues — use worktree dispatch (see below)
+9. `simplification-debt` issues (human-approved)
+10. Oldest issues
+11. FOSS contributions — only when all managed-repo work is dispatched
 
 ## PRs — Merge, Fix, or Flag
 
@@ -261,8 +263,8 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Duplicate issues** → keep the one referenced by `ref:GH#` in TODO.md, close others.
 - **Too large** → `task-decompose-helper.sh classify`. If composite, decompose into subtask issues.
 - **`status:queued`/`status:in-progress`** → if updated within 3h, skip. If 3+ hours with no PR/worker, relabel `status:available`, unassign, comment recovery.
-- **`needs-maintainer-review`** → dispatch triage review worker (step 4.5), NOT implementation worker.
-- **`status:needs-info`** → check pre-fetched reply status (step 4.6).
+- **`needs-maintainer-review`** → dispatch triage review worker (step 3.5), NOT implementation worker.
+- **`status:needs-info`** → check pre-fetched reply status (step 4.5).
 - **`status:available` or no status** → dispatch implementation worker.
 
 ### Maintainer review gate (t1545)

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -87,6 +87,19 @@ gh pr merge NUMBER --repo SLUG --squash
 `CHANGES_REQUESTED` → dispatch fix worker. `APPROVED` → merge directly.
 Check external contributor gate before ANY approve/merge (see Pre-merge checks below).
 
+### 3.5. Dispatch triage reviews for needs-maintainer-review issues
+
+**Before implementation workers.** External contributor issues deserve fast feedback —
+dispatch opus-tier triage reviews first so the community isn't left waiting. Max 2 per cycle.
+Uses pre-fetched triage status.
+
+```bash
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
+```
+
+Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
+
 ### 4. Dispatch workers for open issues
 
 ```bash
@@ -100,19 +113,7 @@ dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER
 
 Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
 
-### 4.5. Dispatch triage reviews for needs-maintainer-review issues
-
-After filling implementation slots, dispatch opus-tier triage reviews for unreviewed
-`needs-maintainer-review` issues. Max 2 per cycle. Uses pre-fetched triage status.
-
-```bash
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
-```
-
-Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
-
-### 4.6. Scan status:needs-info issues for contributor replies
+### 4.5. Scan status:needs-info issues for contributor replies
 
 Transition replied issues to `needs-maintainer-review` so they re-enter the triage pipeline.
 No worker dispatch, no slots consumed.
@@ -122,7 +123,7 @@ source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 relabel_needs_info_replies
 ```
 
-### 4.7. Dispatch FOSS contribution workers when idle capacity exists (t1702)
+### 4.6. Dispatch FOSS contribution workers when idle capacity exists (t1702)
 
 Lowest priority — only when all managed-repo work is dispatched and slots remain.
 
@@ -171,8 +172,8 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    ```
 
 4. **If slots are open**: check for mergeable PRs (free), dispatch workers for highest-priority
-   open issues, dispatch triage reviews (step 4.5), scan needs-info replies (step 4.6), dispatch
-   FOSS workers if idle (step 4.7). Use the same dedup guards and dispatch commands as the
+   open issues, dispatch triage reviews (step 3.5), scan needs-info replies (step 4.5), dispatch
+   FOSS workers if idle (step 4.6). Use the same dedup guards and dispatch commands as the
    initial dispatch. Re-fetch issue state with targeted `gh` calls only for repos where you
    need to dispatch.
 
@@ -212,14 +213,15 @@ your best call and move on — the next monitoring cycle is 60 seconds away.
 
 1. PRs with green CI → merge (free — no worker slot needed)
 2. PRs with failing CI or review feedback → fix (uses a slot, but closer to done)
-3. Issues labelled `priority:high` or `bug`
-4. Active mission features (keeps multi-day projects moving)
-5. Product repos over tooling — enforced by priority-class reservations
-6. Smaller/simpler tasks over large ones (faster throughput)
-7. `quality-debt` issues — use worktree dispatch (see below)
-8. `simplification-debt` issues (human-approved)
-9. Oldest issues
-10. FOSS contributions — only when all managed-repo work is dispatched
+3. Triage reviews for `needs-maintainer-review` issues → community responsiveness (step 3.5)
+4. Issues labelled `priority:high` or `bug`
+5. Active mission features (keeps multi-day projects moving)
+6. Product repos over tooling — enforced by priority-class reservations
+7. Smaller/simpler tasks over large ones (faster throughput)
+8. `quality-debt` issues — use worktree dispatch (see below)
+9. `simplification-debt` issues (human-approved)
+10. Oldest issues
+11. FOSS contributions — only when all managed-repo work is dispatched
 
 ## PRs — Merge, Fix, or Flag
 
@@ -255,8 +257,8 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Has merged PR** → comment linking PR, then close.
 - **`status:blocked` but blockers resolved** → remove label, add `status:available`, comment.
 - **`status:queued`/`status:in-progress`** → if updated within 3h, skip. If 3+ hours with no PR/worker, relabel `status:available`, unassign, comment recovery.
-- **`needs-maintainer-review`** → dispatch triage review worker (step 4.5), NOT implementation worker.
-- **`status:needs-info`** → check pre-fetched reply status (step 4.6).
+- **`needs-maintainer-review`** → dispatch triage review worker (step 3.5), NOT implementation worker.
+- **`status:needs-info`** → check pre-fetched reply status (step 4.5).
 - **`status:available` or no status** → dispatch implementation worker.
 
 NEVER dispatch a worker for an issue with `needs-maintainer-review`. Maintainer must remove it

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6445,6 +6445,17 @@ dispatch_deterministic_fill_floor() {
 
 	echo "[pulse-wrapper] Deterministic fill floor: available=${available_slots}, runnable=${runnable_count}, queued_without_worker=${queued_without_worker}, candidates=${candidate_count}" >>"$LOGFILE"
 
+	# Triage reviews first — community responsiveness before implementation backlog.
+	# dispatch_triage_reviews returns the remaining available count via stdout.
+	local triage_remaining
+	triage_remaining=$(dispatch_triage_reviews "$available_slots" 2>>"$LOGFILE") || triage_remaining="$available_slots"
+	[[ "$triage_remaining" =~ ^[0-9]+$ ]] || triage_remaining="$available_slots"
+	local triage_dispatched=$((available_slots - triage_remaining))
+	if [[ "$triage_dispatched" -gt 0 ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: dispatched ${triage_dispatched} triage review(s), ${triage_remaining} slots remaining for implementation" >>"$LOGFILE"
+	fi
+	available_slots="$triage_remaining"
+
 	local dispatched_count=0
 	while IFS= read -r candidate_json; do
 		[[ -n "$candidate_json" ]] || continue
@@ -6491,8 +6502,9 @@ dispatch_deterministic_fill_floor() {
 		dispatched_count=$((dispatched_count + 1))
 	done < <(printf '%s' "$candidates_json" | jq -c '.[]' 2>/dev/null)
 
-	echo "[pulse-wrapper] Deterministic fill floor complete: dispatched=${dispatched_count}, target_available=${available_slots}" >>"$LOGFILE"
-	echo "$dispatched_count"
+	local total_dispatched=$((dispatched_count + triage_dispatched))
+	echo "[pulse-wrapper] Deterministic fill floor complete: dispatched=${total_dispatched} (${triage_dispatched} triage + ${dispatched_count} implementation), target_available=${available_slots}" >>"$LOGFILE"
+	echo "$total_dispatched"
 	return 0
 }
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8351,14 +8351,56 @@ dispatch_triage_reviews() {
 	local triage_max=2
 
 	[[ "$available" =~ ^[0-9]+$ ]] || available=0
+	[[ "$available" -gt 0 ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
 
 	# Parse needs-review items from pre-fetched state
 	local state_file="${STATE_FILE:-}"
-	[[ -f "$state_file" ]] || return 0
+	[[ -f "$state_file" ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
 
-	local resolved_model
+	# Resolve model: prefer opus, fall back to sonnet for triage reviews
+	local resolved_model=""
 	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
-	[[ -n "$resolved_model" ]] || return 0
+	if [[ -z "$resolved_model" ]]; then
+		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
+	fi
+	[[ -n "$resolved_model" ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
+
+	# Parse markdown-format state entries:
+	#   ## owner/repo            ← repo slug header
+	#   - Issue #NNN: ... [status: **needs-review**] ...
+	# Build pipe-separated list: issue_num|repo_slug|repo_path
+	local current_slug="" current_path="" candidates=""
+	while IFS= read -r line; do
+		# Match repo slug headers: "## owner/repo"
+		if [[ "$line" =~ ^##[[:space:]]+([^[:space:]]+/[^[:space:]]+) ]]; then
+			current_slug="${BASH_REMATCH[1]}"
+			current_path=$(jq -r --arg s "$current_slug" '.initialized_repos[]? | select(.slug == $s) | .path' "$repos_json" 2>/dev/null || echo "")
+			# Expand ~ in path
+			current_path="${current_path/#\~/$HOME}"
+			continue
+		fi
+		# Match needs-review issue lines
+		if [[ "$line" == *"**needs-review**"* && "$line" =~ Issue\ #([0-9]+) ]]; then
+			local issue_num="${BASH_REMATCH[1]}"
+			if [[ -n "$current_slug" && -n "$current_path" ]]; then
+				candidates="${candidates}${issue_num}|${current_slug}|${current_path}"$'\n'
+			fi
+		fi
+	done <"$state_file"
+
+	[[ -n "$candidates" ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
 
 	while IFS='|' read -r issue_num repo_slug repo_path; do
 		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
@@ -8375,8 +8417,7 @@ dispatch_triage_reviews() {
 
 		triage_count=$((triage_count + 1))
 		available=$((available - 1))
-	done < <(grep -A1 'needs-review' "$state_file" 2>/dev/null |
-		grep -oP '\d+\|[^|]+\|[^\n]+' || true)
+	done <<<"$candidates"
 
 	printf '%d\n' "$available"
 	return 0


### PR DESCRIPTION
## Summary

Follow-up to #15614 — testing revealed `dispatch_triage_reviews()` has **never worked**. Three bugs:

1. **macOS grep -P**: Function used `grep -oP` (PCRE) which doesn't exist on macOS. Replaced with bash regex parsing.
2. **State file format mismatch**: Function expected pipe-separated `num|slug|path` but `prefetch_triage_review_status()` outputs markdown (`- Issue #NNN: ... [status: **needs-review**]`). Rewrote parser to match actual format.
3. **No model fallback**: If opus is rate-limited (common), function silently returned. Now falls back to sonnet.
4. **Wrong jq path**: Used `.[]` instead of `.initialized_repos[]` for repos.json lookup.

Verified: parse now correctly extracts all 3 pending issues (#15545, #15544, #15543) from the state file.