### PR TITLE
fix: skip self-approval in merge pass — unblocks admin merge

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1823,6 +1823,14 @@ approve_collaborator_pr() {
 	current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
 
 	if [[ -n "$current_user" ]]; then
+		# Skip self-approval — GitHub rejects it and the failed review state
+		# blocks subsequent --admin merge. Admin bypass works without approval
+		# when the PR author is the authenticated user (repo admin).
+		if [[ "$current_user" == "$pr_author" ]]; then
+			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number is self-authored ($current_user) — skipping approval (--admin handles it)" >>"$LOGFILE"
+			return 0
+		fi
+
 		local existing_approval
 		existing_approval=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
 			--jq "[.[] | select(.user.login == \"${current_user}\" and .state == \"APPROVED\")] | length" 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary

- `approve_collaborator_pr()` tried to self-approve PRs authored by the authenticated user
- GitHub rejects self-approval, and the failed review state blocks `--admin` merge
- Fix: skip approval when `pr_author == current_user` — `--admin` alone handles it for repo admins
- The review gate remains in place for external contributors (different author)

14 PRs were stuck unmergeable because of this.