### PR TITLE
GH#14123: tighten experiment branch agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4421,5 +4421,9 @@
       "passes": 1,
       "pr": 15470
     }
+  },
+  ".agents/workflows/branch/experiment.md": {
+    "hash": "3a37ba8edc24966b9bc8ee7dd979c7349d455abec0dd31d72cd78b30f4e58c6d",
+    "status": "simplified"
   }
 }

--- a/.agents/workflows/branch/experiment.md
+++ b/.agents/workflows/branch/experiment.md
@@ -31,72 +31,37 @@ git checkout -b experiment/{description}
 
 ## When to Use
 
-- Proof of concept (POC)
-- Technical spikes
-- Exploring new approaches
-- Testing third-party integrations
-- Performance experiments
-- Architecture exploration
-- "What if we tried..." investigations
+POC, technical spikes, exploring new approaches, testing third-party integrations, performance experiments, architecture exploration. May never merge — that's a valid outcome.
 
-**Key difference**: Experiments may never merge, and that's a valid outcome.
-
-## The Experiment Mindset
-
-Experiments are about **learning**, not shipping:
-
-- **Success** = You learned something valuable
-- **Failure** = You learned what doesn't work (also valuable)
-- **Abandoned** = Priorities changed (document why)
-
-## Unique Guidance
+## Guidance
 
 ### Document the Hypothesis
 
-Before starting, document what you're testing:
+Before starting, record what you're testing and the expected outcome in the first commit message:
 
-```bash
+```
 experiment: test GraphQL for API layer
 
 Hypothesis: GraphQL could reduce API calls by 60%
-
-Testing:
-- Set up Apollo Server
-- Migrate 3 endpoints
-- Measure performance
+Testing: Apollo Server, migrate 3 endpoints, measure performance
 ```
 
 ### Document Results (Even If Not Merging)
 
-When experiment concludes, document in PR:
+When the experiment concludes, document in the PR regardless of outcome:
 
 ```markdown
-## Experiment: GraphQL Migration
-
-### Hypothesis
-GraphQL could reduce API calls by 60%
-
-### What We Tried
-- Migrated user, posts, and comments endpoints
-- Implemented DataLoader for batching
-
-### Results
-- API calls reduced by 45% (not 60%)
-- Complexity increased significantly
-- Team learning curve is steep
-
-### Conclusion
-**Not proceeding** - benefits don't outweigh costs.
-
-### Learnings
-- GraphQL works well for complex nested data
-- Our API is mostly flat, so benefit is limited
-- Consider for future mobile app API
+## Experiment: {name}
+**Hypothesis**: {what you expected}
+**What we tried**: {approach}
+**Results**: {what actually happened}
+**Conclusion**: Proceeding / Not proceeding — {reason}
+**Learnings**: {what to carry forward}
 ```
 
 ### Transitioning to Feature
 
-If experiment succeeds and should be productionized:
+If the experiment succeeds:
 
 1. **Don't merge experiment directly**
 2. Create new `feature/` branch from `main`
@@ -106,10 +71,4 @@ If experiment succeeds and should be productionized:
 
 ## Examples
 
-```bash
-experiment/graphql-migration
-experiment/redis-caching
-experiment/serverless-functions
-experiment/lazy-loading-images
-experiment/microservices-split
-```
+`experiment/graphql-migration`, `experiment/redis-caching`, `experiment/serverless-functions`, `experiment/lazy-loading-images`, `experiment/microservices-split`


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/branch/experiment.md` from 115 to 74 lines (-35%) per GH#14123 simplification scan.

**Classification:** Instruction doc (agent rules, workflow guidance) — content compression applied, not chapter split.

**Changes:**
- Merge 7-item "When to Use" list + "Experiment Mindset" section into single prose line (preserves all use cases)
- Replace verbose 23-line GraphQL example with reusable `{placeholder}` template structure
- Fix misleading `bash` fence on commit message example (it's not a bash command)
- Inline examples list — removes unnecessary code block overhead

**Preserved:** quick-reference table, bash setup command, hypothesis documentation pattern, results template structure, all 5 feature-transition steps, branch name examples.

Closes #14123

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution paths.
**Verification:** `self-assessed` — content preservation verified via diff review. All code blocks, task IDs, command examples, and structural patterns present before and after.

<!-- MERGE_SUMMARY -->
**What:** Tighten experiment.md agent doc (115→74 lines)
**Issue:** GH#14123
**Files changed:** `.agents/workflows/branch/experiment.md`, `.agents/configs/simplification-state.json`
**Testing:** Self-assessed (doc-only change)
**Key decisions:** Template structure replaces verbose GraphQL example — preserves the pattern without domain-specific noise

---
[aidevops.sh](https://aidevops.sh) v3.5.618 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 3,946 tokens on this as a headless worker.