### PR TITLE
GH#14224: tighten pr-loop.md agent doc

### DIFF
--- a/.agents/scripts/commands/pr-loop.md
+++ b/.agents/scripts/commands/pr-loop.md
@@ -14,25 +14,23 @@ Arguments: $ARGUMENTS
 /pr-loop [--pr N] [--wait-for-ci] [--max-iterations N] [--no-auto-trigger]
 ```
 
-## Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--pr <n>` | PR number (auto-detects from current branch if omitted) | auto |
-| `--wait-for-ci` | Wait for CI checks before checking review status | false |
-| `--max-iterations <n>` | Max check iterations | 10 |
-| `--no-auto-trigger` | Disable automatic re-review trigger for stale reviews | false |
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--pr <n>` | auto | PR number (auto-detects from current branch) |
+| `--wait-for-ci` | false | Wait for CI before checking review status |
+| `--max-iterations <n>` | 10 | Max check iterations |
+| `--no-auto-trigger` | false | Disable auto re-review for stale reviews |
 
 ## Workflow
 
 Each iteration checks:
 
 1. **CI Status** — all GitHub Actions workflows
-2. **Review Bot Gate (t1382)** — verify AI review bots have posted (see below)
+2. **Review Bot Gate (t1382)** — verify AI review bots have posted
 3. **Review Status** — approvals or change requests
 4. **Merge Readiness** — verify PR can be merged
 
-**On issues:** CI failures → report and wait. Changes requested → verify before acting, then address valid feedback. Stale review → auto-trigger re-review (unless `--no-auto-trigger`).
+**On issues:** CI failures → report and wait. Changes requested → verify, then address valid feedback. Stale review → auto-trigger re-review (unless `--no-auto-trigger`).
 
 **COMMENTED reviews:** Some bots (e.g., Gemini Code Assist) post as `COMMENTED` not `CHANGES_REQUESTED`, so `reviewDecision` stays `NONE`. The loop detects unresolved review threads and surfaces them.
 
@@ -47,11 +45,11 @@ RESULT=$(~/.aidevops/agents/scripts/review-bot-gate-helper.sh check "$PR_NUMBER"
 
 | Result | Action |
 |--------|--------|
-| `WAITING` | Continue polling (most bots post within 2-5 min). `review-bot-gate` CI check also blocks at GitHub level. |
+| `WAITING` | Poll (most bots post within 2-5 min). `review-bot-gate` CI check also blocks at GitHub level. |
 | `PASS` | Read bot reviews; address critical/security findings before merge. Non-critical → follow-up. |
 | `SKIP` | PR has `skip-review-gate` label — proceed. |
 
-**AI review verification:** See `Bot Reviewer Feedback` in `.agents/reference/session.md` and `AI Suggestion Verification` in `.agents/prompts/build.txt`.
+AI review verification: `Bot Reviewer Feedback` in `.agents/reference/session.md` and `AI Suggestion Verification` in `.agents/prompts/build.txt`.
 
 ## Completion Promises
 
@@ -61,40 +59,29 @@ RESULT=$(~/.aidevops/agents/scripts/review-bot-gate-helper.sh check "$PR_NUMBER"
 | PR merged | `<promise>PR_MERGED</promise>` |
 | Max iterations reached | Exit with status report |
 
-## Intelligent Timing
+## Timing
 
-| Service Category | Initial Wait | Poll Interval |
-|------------------|--------------|---------------|
+| Service | Initial Wait | Poll Interval |
+|---------|--------------|---------------|
 | Fast (CodeFactor, Version) | 10s | 5s |
 | Medium (SonarCloud, Codacy, Qlty) | 60s | 15s |
 | Slow (CodeRabbit) | 120s | 30s |
 
-## Examples
+## Recovery
 
-```bash
-/pr-loop                              # Monitor current branch's PR
-/pr-loop --pr 123 --wait-for-ci       # Specific PR, wait for CI
-/pr-loop --pr 123 --max-iterations 20 # Extended monitoring
-/pr-loop --no-auto-trigger            # Disable auto re-review
-```
-
-## State Tracking
-
-Progress tracked in `.agents/loop-state/quality-loop.local.state` (PR number, iteration count, check results).
-
-## Timeout Recovery
+State tracked in `.agents/loop-state/quality-loop.local.state`.
 
 ```bash
 gh pr view --json state,reviewDecision,statusCheckRollup  # Check current status
 ```
 
-Common blockers: CI still running (wait), review not completed (ping reviewer), failing checks (manual fix). Resume with `/pr review` (single cycle) or `/pr-loop` (restart loop).
+Common blockers: CI running (wait), review pending (ping reviewer), failing checks (fix). Resume: `/pr review` (single cycle) or `/pr-loop` (restart).
 
-## Related Commands
+## Related
 
 | Command | Purpose |
 |---------|---------|
-| `/pr review` | Single PR review (no loop) |
+| `/pr review` | Single PR review cycle |
 | `/pr create` | Create PR with pre-checks |
 | `/preflight-loop` | Iterative preflight until passing |
 | `/postflight-loop` | Monitor release health |


### PR DESCRIPTION
## Summary

Tighten and restructure `pr-loop.md` per build-agent.md guidance. This is an instruction doc (not a reference corpus), so the action is prose compression and section merging — not splitting into chapters.

## Changes

- Merged `## Options` heading into the Usage section (removed redundant heading)
- Reordered options table columns: Default before Description (more scannable)
- Removed `## Examples` section — examples are self-evident from the Usage line and add no new information
- Merged `## State Tracking` + `## Timeout Recovery` into single `## Recovery` section
- Compressed prose throughout (e.g., "Continue polling" → "Poll", "CI still running (wait)" → "CI running (wait)")
- Renamed `## Related Commands` → `## Related` (shorter)
- Renamed `## Intelligent Timing` → `## Timing` (shorter)

## Preservation Verification

All institutional knowledge preserved:
- Task IDs: `t1382` ✓
- Code blocks: `review-bot-gate-helper.sh` command ✓
- Completion promises: `PR_APPROVED`, `PR_MERGED` ✓
- State file path: `quality-loop.local.state` ✓
- Bot names: CodeRabbit, SonarCloud, Codacy, Qlty, CodeFactor ✓
- All result values: `WAITING`, `PASS`, `SKIP` ✓
- Cross-references: `session.md`, `build.txt` ✓

## Metrics

- Before: 101 lines
- After: 88 lines
- Reduction: 13 lines (13%)

## Testing

- `self-assessed` (Low risk: docs/agent prompts only)
- Content preservation verified via `rg` on all key references

## Runtime Testing

Risk: **Low** (docs-only change, no code). Self-assessed.

Closes #14224

---
[aidevops.sh](https://aidevops.sh) v3.5.617 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m on this as a headless worker.