### PR TITLE
GH#15159: tighten SaaS landing page examples swipe file

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md
+++ b/.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md
@@ -11,14 +11,9 @@ Connect your tools. Automate your tasks. Build the workflows that move your comp
 ✓ Free forever for small teams
 ```
 
-- 4-word headline claims the category (not "a place" — "THE place")
-- Two CTAs for different buyer types; trust signal reduces friction
-
-**Social Proof:** Logos + "Trusted by millions" + G2 rating — three proof types simultaneously.
-
-**Features:** Benefit-led header → 3 features each with outcome. "Already use" reduces friction.
-
-**Why it converts:** Extreme clarity in 5 seconds, low-barrier CTA, features tied to outcomes.
+- 4-word headline claims the category. Dual CTAs serve different buyer types; trust signal reduces friction.
+- Social proof: logos + "Trusted by millions" + G2 rating — three proof types simultaneously.
+- Features: benefit-led header → 3 features each with outcome. "Already use" reduces friction.
 
 ## 2. Notion — "Your Wiki, Docs, & Projects. Together."
 
@@ -31,13 +26,9 @@ Notion is the connected workspace where better, faster work happens.
 [Animated product demo]
 ```
 
-- Headline covers 3 use cases; single CTA reduces decision fatigue; demo shows, not tells
-
-**Social Proof:** `Trusted by: [Figma] [Pixar] [Nike] [Toyota]` + "Join 10M+ teams" — specific number, "teams" signals B2B.
-
-**Use Cases:** Wiki / Docs / Projects each with one-line benefit. "Your way" = flexibility.
-
-**Why it converts:** Multi-use-case without confusion, strong visual demo, free tier removes friction.
+- Headline covers 3 use cases; single CTA reduces decision fatigue; demo shows, not tells.
+- Social proof: `Trusted by: [Figma] [Pixar] [Nike] [Toyota]` + "Join 10M+ teams" — specific number, "teams" signals B2B.
+- Use cases: Wiki / Docs / Projects each with one-line benefit. "Your way" = flexibility.
 
 ## 3. Basecamp — "The All-In-One Toolkit for Working Remotely"
 
@@ -49,7 +40,7 @@ Basecamp's the calm, organized way to manage projects, work with clients, and co
 [Try Basecamp for free]
 ```
 
-- Opens with pain point; "calm, organized" = emotional benefit
+- Opens with pain point; "calm, organized" = emotional benefit.
 
 **Before/After:**
 
@@ -58,9 +49,7 @@ Before: Constant meetings | Lost files | Scattered apps | Anxiety
 After:  One place | Real progress | Everyone in the loop | Calmer teams
 ```
 
-**Pricing:** `$299/month flat. Unlimited users, unlimited projects. No per-user pricing games.` — simple one-tier; anti-competitor positioning.
-
-**Why it converts:** Strong POV, before/after transformation, flat pricing, long-form testimonials.
+- Pricing: `$299/month flat. Unlimited users, unlimited projects. No per-user pricing games.` — one tier; anti-competitor positioning.
 
 ## 4. Mailchimp — "Turn Emails into Revenue"
 
@@ -72,10 +61,6 @@ Grow your business with email marketing and automations that convert.
 [Start Free Trial] — No credit card required
 ```
 
-- Outcome-focused headline (revenue); low-friction CTA
-
-**Features:** Email Builder / Audience Tools / Automations / Analytics — each with action-oriented benefit.
-
-**Stat:** `Generate up to 25x more orders with automations* (*Mailchimp data, 2023)` — specific, sourced, believable.
-
-**Why it converts:** Clear value prop (emails → revenue), free trial + no CC, specific sourced stats.
+- Outcome-focused headline (revenue); low-friction CTA.
+- Features: Email Builder / Audience Tools / Automations / Analytics — each with action-oriented benefit.
+- Stat: `Generate up to 25x more orders with automations* (*Mailchimp data, 2023)` — specific, sourced, believable.


### PR DESCRIPTION
## Summary

- Tighten `.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md` (81 → 66 lines, -19%)
- Remove redundant "Why it converts" summary bullets that restated the preceding per-section analysis
- Preserve all 4 copy examples (Slack, Notion, Basecamp, Mailchimp), hero copy blocks, social proof patterns, and conversion insights

## Classification

Reference corpus (swipe file with concrete examples). At 81 lines, splitting into chapter files would add overhead without benefit. Applied instruction-doc tightening: compress prose, preserve all knowledge.

## Runtime Testing

`self-assessed` — docs-only change, no code paths affected.

## Files Changed

- `.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md`

Closes #15159

---
[aidevops.sh](https://aidevops.sh) v3.5.617 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6