### PR TITLE
GH#15157: tighten r2-gotchas.md — reorder by importance, security first

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4420,6 +4420,12 @@
       "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
       "passes": 1,
       "pr": 15470
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md": {
+      "hash": "15664c439e4f42388852766e353f09c3d2ff0773405f329109ce47c293e3aff1",
+      "at": "2026-04-02T14:18:00Z",
+      "pr": 15629,
+      "passes": 1
     }
   },
   ".agents/workflows/branch/experiment.md": {

--- a/.agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md
@@ -1,8 +1,22 @@
 # R2 Gotchas & Troubleshooting
 
+## Key Validation
+
+Unsanitized keys allow path traversal:
+
+```typescript
+// DANGEROUS
+const key = url.pathname.slice(1); // could be ../../../etc/passwd
+
+// SAFE
+if (!key || key.includes('..') || key.startsWith('/')) {
+  return new Response('Invalid key', { status: 400 });
+}
+```
+
 ## List Truncation
 
-`include` with metadata may return fewer objects per page. Always paginate via `truncated`, never `objects.length`:
+`include` with metadata may return fewer objects per page. Paginate via `truncated`, not `objects.length`:
 
 ```typescript
 // WRONG — breaks when include reduces page size
@@ -15,6 +29,18 @@ while (listed.truncated) {
 ```
 
 Requires `compatibility_date >= 2022-08-04` or `r2_list_honor_include` flag.
+
+## Conditional Operations
+
+Precondition failure returns the object WITHOUT body (not null):
+
+```typescript
+const object = await env.MY_BUCKET.get(key, {
+  onlyIf: { etagMatches: '"wrong"' }
+});
+if (!object) return new Response('Not found', { status: 404 });
+if (!object.body) return new Response(null, { status: 304 }); // precondition failed
+```
 
 ## ETag Format
 
@@ -38,32 +64,6 @@ await env.MY_BUCKET.put(key, data, { sha256: hash }); // not { md5: h1, sha256: 
 - Part numbers start at 1 (not 0)
 - Uncompleted uploads auto-abort after 7 days
 - `resumeMultipartUpload` doesn't validate uploadId existence
-
-## Conditional Operations
-
-Precondition failure returns the object WITHOUT body (not null):
-
-```typescript
-const object = await env.MY_BUCKET.get(key, {
-  onlyIf: { etagMatches: '"wrong"' }
-});
-if (!object) return new Response('Not found', { status: 404 });
-if (!object.body) return new Response(null, { status: 304 }); // precondition failed
-```
-
-## Key Validation
-
-Unsanitized keys allow path traversal:
-
-```typescript
-// DANGEROUS
-const key = url.pathname.slice(1); // could be ../../../etc/passwd
-
-// SAFE
-if (!key || key.includes('..') || key.startsWith('/')) {
-  return new Response('Invalid key', { status: 400 });
-}
-```
 
 ## Storage Class (InfrequentAccess)
 


### PR DESCRIPTION
## Summary

- Reorder sections in `r2-gotchas.md` by importance: security-critical Key Validation (path traversal) moved to first position
- Tighten prose in List Truncation section (remove redundant "Always")
- Move Conditional Operations before ETag/Checksum (more common gotcha)
- All code blocks, technical content, and institutional knowledge preserved
- Update `simplification-state.json` registry to mark file as processed

## Changes

- `.agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md` — reordered sections, tightened prose
- `.agents/configs/simplification-state.json` — registered file hash and status

## Runtime Testing

**Risk level**: Low (docs/agent prompt only, no code execution)
**Verification**: `self-assessed` — all code blocks, URLs, and technical content verified present before and after. Line count unchanged (83 lines).

## Content Preservation Checklist

- [x] All code blocks present
- [x] All TypeScript examples intact
- [x] Compatibility date requirement preserved
- [x] Security warning (path traversal) preserved and promoted to first position
- [x] Limits table unchanged
- [x] No task IDs or GH refs to preserve in this file

Closes #15157

---
[aidevops.sh](https://aidevops.sh) v3.5.617 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Reorganized troubleshooting guide to improve content discoverability and readability.
* Key Validation section now prominently featured for easier reference.
* Conditional Operations guidance moved earlier in the documentation.
* Clarified pagination guidance for list operations to emphasize proper handling of truncated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->