### PR TITLE
Fix model resolution: head -n -2 macOS bug and triage dispatch fallback

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -661,7 +661,8 @@ probe_provider() {
 	local http_code headers body
 	http_code=$(echo "$response" | tail -1)
 	headers=$(echo "$response" | sed '/^$/q' | head -50)
-	body=$(echo "$response" | sed '1,/^$/d' | head -n -2)
+	# head -n -2 is GNU-only (unsupported on macOS); use awk to drop last 2 lines
+	body=$(echo "$response" | sed '1,/^$/d' | awk 'NR>2{print buf[NR%2]} {buf[NR%2]=$0}')
 
 	_parse_rate_limits "$provider" "$headers"
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8432,16 +8432,13 @@ dispatch_triage_reviews() {
 		return 0
 	}
 
-	# Resolve model: prefer opus, fall back to sonnet for triage reviews
+	# Resolve model: prefer opus, fall back to sonnet, then omit --model
+	# (lets headless-runtime-helper pick its default, same as implementation workers)
 	local resolved_model=""
 	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
 	if [[ -z "$resolved_model" ]]; then
 		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
 	fi
-	[[ -n "$resolved_model" ]] || {
-		printf '%d\n' "$available"
-		return 0
-	}
 
 	# Parse markdown-format state entries:
 	#   ## owner/repo            ← repo slug header
@@ -8475,11 +8472,16 @@ dispatch_triage_reviews() {
 		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
 		[[ "$available" -gt 0 && "$triage_count" -lt "$triage_max" ]] || break
 
+		local model_args=()
+		if [[ -n "$resolved_model" ]]; then
+			model_args=(--model "$resolved_model")
+		fi
+
 		~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
 			--role worker \
 			--session-key "triage-review-${issue_num}" \
 			--dir "$repo_path" \
-			--model "$resolved_model" \
+			"${model_args[@]}" \
 			--title "Triage review: Issue #${issue_num}" \
 			--prompt "/review-issue-pr ${issue_num}" </dev/null >>"/tmp/pulse-triage-${issue_num}.log" 2>&1 &
 		sleep 2


### PR DESCRIPTION
## Summary

Follow-up to #15617 — model resolution has been silently broken on macOS, which is why `dispatch_triage_reviews()` never dispatched despite the parse fix.

**Two bugs fixed:**

1. **`head -n -2` macOS incompatibility** (`model-availability-helper.sh:664`): GNU `head` accepts negative line counts (`head -n -2` = all lines except last 2), macOS does not. Every API probe failed with `head: illegal line count -- -2`, making all models appear unavailable. Replaced with portable `awk`.

2. **Hard gate on model resolution** (`dispatch_triage_reviews`): Function returned early if no model could be resolved. Now omits `--model` flag and lets `headless-runtime-helper.sh` pick its default — same as implementation workers, which use `marcus@evergreen.je` (the account currently within rate limits) without issue.

This also explains why `model-availability-helper.sh resolve opus/sonnet` both reported "No available model" even though 21 workers were actively running on `anthropic/claude-sonnet-4-6`.