### PR TITLE
GH#14239: tighten cross-review.md agent doc

### DIFF
--- a/.agents/scripts/commands/cross-review.md
+++ b/.agents/scripts/commands/cross-review.md
@@ -10,44 +10,20 @@ Target: $ARGUMENTS
 
 ## Instructions
 
-1. Parse the user's arguments. Common forms:
-
-   ```bash
-   /cross-review "review this PR diff" --models sonnet,opus
-   /cross-review "audit this code" --models sonnet,gemini-pro,gpt-4.1 --score
-   /cross-review "design this API" --score --judge opus
-   ```
+1. Parse `$ARGUMENTS` — extract `--prompt`, `--models`, `--score`, `--judge`, `--timeout`.
 
 2. Run the cross-review:
 
    ```bash
-   # Basic cross-review (diff only)
-   ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
-     --prompt "your prompt here" \
-     --models "sonnet,opus"
-
-   # With auto-scoring via judge model (default judge: opus)
-   ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
-     --prompt "your prompt here" \
-     --models "sonnet,gemini-pro,gpt-4.1" \
-     --score
-
-   # With custom judge model
    ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
      --prompt "your prompt here" \
      --models "sonnet,opus" \
-     --score --judge sonnet
+     [--score] [--judge sonnet]
    ```
 
-3. Present the results:
-   - Show each model's response summary
-   - Show the diff between responses (for 2-model comparisons)
-   - If `--score` was used, show the judge's structured scores and winner declaration
-   - Note any models that failed to respond
+3. Present results: each model's response summary, diff (2-model comparisons), judge scores and winner if `--score` used, note any failures.
 
-4. If `--score` was used, scores are automatically:
-   - Recorded in the model-comparisons SQLite DB
-   - Fed into the pattern tracker for model routing (`/route`, `/patterns`)
+4. If `--score` used, scores are recorded in the model-comparisons SQLite DB and fed into the pattern tracker (`/route`, `/patterns`).
 
 ## Options
 


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/cross-review.md` per `build-agent.md` principles. Removes decorative noise (redundant inline examples in step 1, three separate bash blocks with "what" comments) while preserving all functional content.

- 99 → 75 lines (~24% reduction)
- Consolidates three separate bash invocation blocks into one canonical example with optional flags shown inline
- Removes step 1 inline examples (duplicated by the Examples section)
- All options table, scoring criteria, examples, and related links unchanged

Closes #14239

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution paths changed.
**Verification:** `self-assessed` — content preservation verified by line-by-line review: all code blocks, command examples, option flags, task ID refs, and related links present before and after.

<!-- MERGE_SUMMARY -->
**What:** Tighten cross-review.md slash command doc (99→75 lines)
**Issue:** #14239
**Files changed:** `.agents/scripts/commands/cross-review.md`
**Testing:** Self-assessed (docs-only change, low risk)
**Key decisions:** Collapsed three bash blocks into one; removed redundant step-1 examples already covered by Examples section

---
[aidevops.sh](https://aidevops.sh) v3.5.618 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 3,456 tokens on this as a headless worker.