### PR TITLE
GH#15158: tighten agent doc Content Editor (.agents/content/editor.md)

### DIFF
--- a/.agents/content/editor.md
+++ b/.agents/content/editor.md
@@ -32,8 +32,6 @@ Transform technically accurate content into human-sounding, engaging articles. C
 
 ### 4. Robotic vs Human Patterns
 
-Detect and flag:
-
 - **AI vocabulary**: delve, tapestry, landscape, leverage, utilize, facilitate
 - **Filler phrases**: "It's worth noting that", "In today's digital age"
 - **Rule of three**: Excessive use of three-item lists


### PR DESCRIPTION
## Summary

- Removes redundant "Detect and flag:" sentence from section 4 — the heading "Robotic vs Human Patterns" already implies detection/flagging
- 83 → 81 lines; zero content loss (all code blocks, URLs, pattern lists, output format template preserved)
- markdownlint-cli2 clean (0 errors)

## What

Tighten `.agents/content/editor.md` per simplification-debt scan (GH#15158). File classified as **instruction doc** (agent rules, output format, analysis dimensions) — prose tightening applied, not restructuring.

## Testing

- `bunx markdownlint-cli2 ".agents/content/editor.md"` → 0 errors
- `diff` confirms only 2 lines removed: decorative "Detect and flag:" sentence + trailing blank line
- All substantive content preserved: code blocks, URLs, pattern lists, output format template, related links

## Files Changed

- `.agents/content/editor.md` — 2 lines removed (83→81)

Closes #15158

---
<!-- MERGE_SUMMARY -->
**What**: Removed redundant "Detect and flag:" sentence from Content Editor agent doc section 4.
**Issue**: Closes #15158
**Files changed**: `.agents/content/editor.md` (83→81 lines)
**Testing**: markdownlint-cli2 0 errors; diff confirms zero content loss
**Key decisions**: Classified as instruction doc (not reference corpus) — prose tightening applied. Blank lines after headings preserved (MD022 requirement).

---
[aidevops.sh](https://aidevops.sh) v3.5.618 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m and 6,366 tokens on this as a headless worker.