### PR TITLE
Fix unbound variable in dispatch_triage_reviews

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8472,18 +8472,22 @@ dispatch_triage_reviews() {
 		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
 		[[ "$available" -gt 0 && "$triage_count" -lt "$triage_max" ]] || break
 
-		local model_args=()
 		if [[ -n "$resolved_model" ]]; then
-			model_args=(--model "$resolved_model")
+			~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+				--role worker \
+				--session-key "triage-review-${issue_num}" \
+				--dir "$repo_path" \
+				--model "$resolved_model" \
+				--title "Triage review: Issue #${issue_num}" \
+				--prompt "/review-issue-pr ${issue_num}" </dev/null >>"/tmp/pulse-triage-${issue_num}.log" 2>&1 &
+		else
+			~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+				--role worker \
+				--session-key "triage-review-${issue_num}" \
+				--dir "$repo_path" \
+				--title "Triage review: Issue #${issue_num}" \
+				--prompt "/review-issue-pr ${issue_num}" </dev/null >>"/tmp/pulse-triage-${issue_num}.log" 2>&1 &
 		fi
-
-		~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-			--role worker \
-			--session-key "triage-review-${issue_num}" \
-			--dir "$repo_path" \
-			"${model_args[@]}" \
-			--title "Triage review: Issue #${issue_num}" \
-			--prompt "/review-issue-pr ${issue_num}" </dev/null >>"/tmp/pulse-triage-${issue_num}.log" 2>&1 &
 		sleep 2
 
 		triage_count=$((triage_count + 1))


### PR DESCRIPTION
## Summary

Fix `model_args[@]: unbound variable` error in `dispatch_triage_reviews()`.

Empty bash arrays fail under `set -u` (nounset) when expanded via `"${model_args[@]}"`. The function was silently consuming slots without actually launching workers. Replaced with explicit if/else branches for the `--model` flag.