### PR TITLE
GH#15135: tighten agent doc Google Rich Results Test (.agents/seo/rich-results.md)

### DIFF
--- a/.agents/seo/rich-results.md
+++ b/.agents/seo/rich-results.md
@@ -16,15 +16,14 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Validate structured data and preview rich snippets
 - **URL**: `https://search.google.com/test/rich-results`
-- **API Status**: **Deprecated** (standalone API removed) -- browser automation required
-- **Alternative**: Schema.org Validator (`https://validator.schema.org/`) -- faster, no CAPTCHA, no Google-specific eligibility
-- **Rich result types**: [Google's structured data gallery](https://developers.google.com/search/docs/appearance/structured-data/search-gallery)
+- **API**: Deprecated — browser automation required
+- **Alternative**: `https://validator.schema.org/` — faster, no CAPTCHA, no Google eligibility gate
+- **Rich result types**: [Google structured data gallery](https://developers.google.com/search/docs/appearance/structured-data/search-gallery)
 
 ## Browser Automation (Playwright)
 
-Primary method. Run `node rich-results-test.js <url>`:
+Run `node rich-results-test.js <url>`:
 
 ```javascript
 // rich-results-test.js


### PR DESCRIPTION
## Summary

Tighten `.agents/seo/rich-results.md` per simplification issue GH#15135.

**Classification**: Instruction doc (operational procedures, browser automation script) — not a reference corpus. Prose compression applied, not chapter splitting.

**Changes:**
- Removed redundant `Purpose` bullet from Quick Reference (already implied by heading)
- Compressed `API Status` line: verbose double-dash prose → single terse entry
- Compressed `Alternative` line: removed redundant phrasing
- Removed `Primary method.` sentence before code block (implied by section heading)
- All code blocks, URLs, task IDs, and functional content preserved

**Verification:**
- 103 → 102 lines (net -1 line; 4 insertions, 5 deletions)
- `bunx markdownlint-cli2`: 0 errors
- All key URLs, code blocks, and Related links confirmed present via `rg`

Closes #15135

## Runtime Testing

Risk: **Low** — docs-only change, no code execution paths affected. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.622 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 7m and 4,315 tokens on this as a headless worker.