### PR TITLE
GH#15568: tighten agent doc GEO Patterns (02-geo-patterns.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4425,5 +4425,10 @@
   ".agents/workflows/branch/experiment.md": {
     "hash": "3a37ba8edc24966b9bc8ee7dd979c7349d455abec0dd31d72cd78b30f4e58c6d",
     "status": "simplified"
+  },
+  ".agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md": {
+    "hash": "b4cf936475f4834fd541b14c6173969e",
+    "issue": "GH#15568",
+    "status": "simplified"
   }
 }

--- a/.agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md
@@ -37,7 +37,7 @@ Use for `site:yourdomain.com [category] features [year]` queries.
 - G2: [profile URL with UTM]  |  Capterra: [profile URL with UTM]
 ```
 
-Mirror facts across product page and third-party profiles. UTM: `utm_source=g2&utm_medium=referral&utm_campaign=ai_citation`. Review freshness monthly.
+Mirror facts across product page and third-party profiles. UTM: `utm_source=g2&utm_medium=referral&utm_campaign=ai_citation`. Review monthly.
 
 ### Site-Searchable Variant
 


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md` (51 lines)
- Remove redundant word "freshness" from review cadence note: "Review freshness monthly" → "Review monthly"
- Update `simplification-state.json` with new file hash

## Classification

Reference corpus (content pattern templates). At 51 lines, well below the 300-line split threshold. No restructuring needed — targeted prose tightening only.

## What changed

- `.agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md`: 1-word prose tightening, all templates preserved
- `.agents/configs/simplification-state.json`: new entry for this file

## Runtime Testing

Risk: **Low** — docs/agent prompts only. `self-assessed`.

Closes #15568

---
[aidevops.sh](https://aidevops.sh) v3.5.623 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 11m and 10,170 tokens on this as a headless worker.