### PR TITLE
t1755: Fix signature gate false positives in OpenCode plugin

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -698,16 +698,28 @@ async function toolExecuteBefore(input, output) {
     }
   }
 
-  // Signature footer gate (GH#12805): warn when gh pr create / gh issue create
-  // / gh issue comment is called without the aidevops.sh signature footer.
-  // This is the systemic enforcement — prompt instructions alone are insufficient.
+  // Signature footer gate (GH#12805, t1755): warn when gh pr create / gh issue
+  // create / gh issue comment is called without the aidevops.sh signature footer.
+  // Systemic enforcement — prompt instructions alone are insufficient.
+  // t1755: Reduce false positives — accept footer variable references and exclude
+  // machine protocol comments (DISPATCH_CLAIM, KILL_WORKER, etc.).
   if (isBashTool(input.tool)) {
     const cmd = output.args?.command || "";
     if (/gh\s+(pr\s+create|issue\s+(create|comment))/.test(cmd)) {
-      if (!cmd.includes("aidevops.sh") && !cmd.includes("gh-signature-helper")) {
+      // Machine protocol comments are internal signals, not user-facing content
+      const isMachineProtocol =
+        /DISPATCH_CLAIM|KILL_WORKER|DISPATCH_ACK|<!-- MERGE_SUMMARY -->/.test(cmd);
+      // Direct footer text or helper invocation in the command
+      const hasDirectFooter =
+        cmd.includes("aidevops.sh") || cmd.includes("gh-signature-helper");
+      // Footer stored in a shell variable from a prior command (unexpanded at hook time)
+      const hasFooterVar =
+        /\$\{?(?:SIG_FOOTER|FOOTER|footer|sig_footer|SIGNATURE|signature)\}?/.test(cmd);
+
+      if (!isMachineProtocol && !hasDirectFooter && !hasFooterVar) {
         console.error(
           "[aidevops] SIGNATURE GATE: gh pr/issue command missing aidevops.sh signature footer. " +
-          "Generate with: gh-signature-helper.sh footer --model <model-id>",
+            "Generate with: gh-signature-helper.sh footer --model <model-id>",
         );
         qualityLog("WARN", `Signature footer missing in: ${cmd.substring(0, 120)}`);
       }


### PR DESCRIPTION
## Summary

- Reduce false positives in the signature footer gate (`.agents/plugins/opencode-aidevops/index.mjs`)
- Accept footer variable references (\$FOOTER, \$SIG_FOOTER, etc.) that are expanded at runtime but unexpanded when the plugin hook inspects the raw command string
- Exclude machine protocol comments (DISPATCH_CLAIM, KILL_WORKER, DISPATCH_ACK, MERGE_SUMMARY) from the gate — these are internal signals, not user-facing content

## Problem

The signature gate was firing false positives on every headless worker session because:
1. Workers call `gh-signature-helper.sh` first, store the output in a variable, then reference \$FOOTER in the `gh` command. The hook saw the unexpanded variable name, not the literal `aidevops.sh` string.
2. Machine protocol comments (DISPATCH_CLAIM, etc.) are internal dispatch signals that don't need human-readable signature footers.

All recent issues (15620-15622) had correct footers — the warnings were noise.

## Testing

- 9/9 logic test cases pass (variable refs, machine protocol, direct footer, genuinely missing)
- `node -c` syntax check passes
- Risk: **Low** — warning-only gate, no blocking behavior changed

## Runtime Testing

`self-assessed` — agent prompt/plugin config change, no runtime server to test against.

Closes #15638


---
[aidevops.sh](https://aidevops.sh) v3.5.623 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 10m and 5,896 tokens on this with the user in an interactive session. Overall, 3m since this issue was created.