### PR TITLE
GH#14291: tighten context-builder-agent.md entry point

### DIFF
--- a/.agents/tools/context/context-builder-agent.md
+++ b/.agents/tools/context/context-builder-agent.md
@@ -13,78 +13,28 @@ note: Uses repomix CLI directly (not MCP) for better control and reliability
 
 # Context Builder Agent
 
-Specialized agent for generating token-efficient context for AI coding assistants.
+Generates token-efficient repository context using Repomix CLI with Tree-sitter compression (~80% token reduction).
 
-## Purpose
+**Full operational guidance:** `tools/context/context-builder.md`
 
-Generate optimized repository context using Repomix CLI with Tree-sitter compression.
-Achieves ~80% token reduction while preserving code structure understanding.
-
-## Reference Documentation
-
-Read `tools/context/context-builder.md` for complete operational guidance.
-
-## Available Commands
-
-**Helper Script** (preferred):
+## Quick Start
 
 ```bash
-# Helper script location
-~/.aidevops/agents/scripts/context-builder-helper.sh
+# Recommended: compressed pack (~80% token reduction)
+context-builder-helper.sh compress [path]
 
-# Compress mode (recommended) - ~80% token reduction
-context-builder-helper.sh compress [path] [style]
-
-# Full pack with smart defaults
+# Full pack
 context-builder-helper.sh pack [path] [xml|markdown|json]
 
-# Quick mode - auto-copies to clipboard
-context-builder-helper.sh quick [path] [pattern]
-
-# Analyze token usage per file
-context-builder-helper.sh analyze [path] [threshold]
-
-# Pack remote GitHub repo
+# Remote repo
 context-builder-helper.sh remote user/repo [branch]
-
-# Compare full vs compressed
-context-builder-helper.sh compare [path]
 ```
 
-**Direct CLI** (when helper unavailable):
+Output: `~/.aidevops/.agent-workspace/work/context/`
 
-```bash
-# Pack with compression (recommended)
-npx repomix@latest . --compress --output context.xml
+## Workflow
 
-# Pack remote repository
-npx repomix@latest --remote user/repo --compress --output context.xml
-
-# Pack with patterns
-npx repomix@latest . --include "src/**/*.ts" --ignore "**/*.test.ts"
-
-# Token analysis
-npx repomix@latest . --token-count-tree 100
-
-# Output to stdout
-npx repomix@latest . --stdout | pbcopy
-```
-
-## When to Use
-
-| Scenario | Command | Token Impact |
-|----------|---------|--------------|
-| Architecture review | `compress` or `--compress` | ~80% reduction |
-| Full implementation details | `pack` | Full tokens |
-| Quick file subset | `quick . "**/*.ts"` | Minimal |
-| External repo analysis | `remote user/repo` | Compressed |
-
-## Output Location
-
-All context files are saved to: `~/.aidevops/.agent-workspace/work/context/`
-
-## Workflow Integration
-
-1. **Before complex tasks**: Generate compressed context first
-2. **For debugging**: Use full pack mode for specific directories
-3. **For external repos**: Use remote mode with compression
+1. Before complex tasks → `compress` mode
+2. Debugging specific dirs → `pack` mode
+3. External repos → `remote` mode with compression
+4. **Remote repos:** fetch README + check size before packing — see `tools/context/context-builder.md` "Remote Repository Guardrails"


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Slim `context-builder-agent.md` from 90 to 40 lines (56% reduction) by removing duplicated command tables that already exist in the reference doc `context-builder.md`.

## Issue
Closes #14291

## Files Changed
- `.agents/tools/context/context-builder-agent.md` — removed duplicated "Available Commands" and "When to Use" tables; kept YAML frontmatter, purpose, quick-start commands, and pointer to reference doc

## Testing
- `bunx markdownlint-cli2` — 0 errors
- Content preservation verified: all commands/knowledge accessible via `tools/context/context-builder.md` pointer
- Agent behaviour unchanged: entry point still provides quick-start commands and delegates full reference to `context-builder.md`

## Key Decisions
- Classified as instruction doc (not reference corpus) — tighten prose, not split into chapters
- Kept 3 most common commands in quick-start block; full command table lives in reference doc
- Added explicit "Remote repos" guardrail pointer (safety-critical, must not be lost)

---
[aidevops.sh](https://aidevops.sh) v3.5.624 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,024 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Completely restructured agent documentation for improved clarity, conciseness, and usability
  * Streamlined command interface emphasizing essential workflows and core operational features
  * Simplified integration guidance focused on common use cases with clearer instructions
  * Enhanced remote repository management guidelines with improved safety protocols

<!-- end of auto-generated comment: release notes by coderabbit.ai -->