### PR TITLE
GH#14303: tighten agents-sdk-patterns.md section headings

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md
@@ -20,7 +20,7 @@ export class ChatAgent extends Agent<Env, ChatState> {
 }
 ```
 
-## AI w/Tools
+## AI with Tools
 
 ```ts
 import {tool} from "ai"; import {z} from "zod";
@@ -48,7 +48,7 @@ export class StreamingAgent extends Agent<Env> {
 }
 ```
 
-## Cron/Scheduled
+## Cron / Scheduled
 
 ```ts
 export class TaskAgent extends Agent<Env> {
@@ -58,7 +58,7 @@ export class TaskAgent extends Agent<Env> {
 }
 ```
 
-## Email+AI
+## Email with AI
 
 ```ts
 export class EmailAgent extends Agent<Env> {


### PR DESCRIPTION
## Summary

Normalize section heading style in `agents-sdk-patterns.md` for consistency:

- `## AI w/Tools` → `## AI with Tools`
- `## Email+AI` → `## Email with AI`
- `## Cron/Scheduled` → `## Cron / Scheduled`

Zero content loss — all 6 code blocks, TypeScript examples, and structure preserved. Line count unchanged (89 lines).

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md` — 3 heading normalizations

## Testing

**Risk level:** Low (docs-only, no code logic)
**Verification:** All code blocks, URLs, and examples present before and after. `wc -l` unchanged (89 lines).

## Runtime Testing

`self-assessed` — docs-only change, no runtime behaviour affected.

Closes #14303

---
[aidevops.sh](https://aidevops.sh) v3.5.624 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 4,911 tokens on this as a headless worker.