### PR TITLE
Replace head -n -N GNU-isms with portable alternatives (7 scripts)

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -854,7 +854,7 @@ cmd_run() {
 			"$test_json" "$i" "$test_count" \
 			"$suite_agent" "$suite_model" "$suite_timeout" \
 			"$results")
-		results=$(echo "$exec_output" | head -n -1)
+		results=$(echo "$exec_output" | sed '$d')
 		outcome=$(echo "$exec_output" | tail -n 1)
 
 		case "$outcome" in

--- a/.agents/scripts/email-design-test-helper.sh
+++ b/.agents/scripts/email-design-test-helper.sh
@@ -476,7 +476,7 @@ eoa_auth() {
 	local http_code
 	http_code=$(echo "$response" | tail -1)
 	local body
-	body=$(echo "$response" | head -n -1)
+	body=$(echo "$response" | sed '$d')
 
 	if [[ "$http_code" == "200" ]]; then
 		print_success "EOA API authentication successful"
@@ -645,7 +645,7 @@ eoa_create_test() {
 	local http_code
 	http_code=$(echo "$response" | tail -1)
 	local body
-	body=$(echo "$response" | head -n -1)
+	body=$(echo "$response" | sed '$d')
 
 	if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
 		local test_id

--- a/.agents/scripts/mail-helper.sh
+++ b/.agents/scripts/mail-helper.sh
@@ -1336,7 +1336,7 @@ cmd_prune() {
 	prunable="${prunable% archivable=*}"
 	archivable="${counts_line##* archivable=}"
 	# Print the report (all lines except the last counts line)
-	printf '%s\n' "$report_output" | head -n -1
+	printf '%s\n' "$report_output" | sed '$d'
 
 	if [[ "$force" != true ]]; then
 		if [[ "$prunable" -gt 0 || "$archivable" -gt 0 ]]; then

--- a/.agents/scripts/microsoft-graph-helper.sh
+++ b/.agents/scripts/microsoft-graph-helper.sh
@@ -506,7 +506,7 @@ graph_request() {
 	local response http_code
 	response=$(curl "${curl_args[@]}" -w "\n%{http_code}" 2>/dev/null)
 	http_code=$(echo "$response" | tail -1)
-	response=$(echo "$response" | head -n -1)
+	response=$(echo "$response" | sed '$d')
 
 	if [[ "$http_code" -ge 400 ]]; then
 		local error_msg

--- a/.agents/scripts/mission-skill-learner.sh
+++ b/.agents/scripts/mission-skill-learner.sh
@@ -746,10 +746,10 @@ cmd_scan() {
 	lesson_out=$(_scan_lessons "$mission_file" "$mission_id")
 
 	# Print buffered output (all display lines except the trailing count)
-	echo "$agent_out" | head -n -1
-	echo "$script_out" | head -n -1
-	echo "$decision_out" | head -n -1
-	echo "$lesson_out" | head -n -1
+	echo "$agent_out" | sed '$d'
+	echo "$script_out" | sed '$d'
+	echo "$decision_out" | sed '$d'
+	echo "$lesson_out" | sed '$d'
 
 	# Sum counts (last line of each output block)
 	local agent_count script_count decision_count lesson_count found_count

--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -686,7 +686,8 @@ output_results() {
 
 cleanup_old_pulses() {
 	local old_dirs
-	old_dirs=$(find "${MINER_DIR}" -maxdepth 1 -type d -name "pulse_*" | sort | head -n -7 2>/dev/null || true)
+	# head -n -7 is GNU-only; use awk to keep all except the last 7 (newest) entries
+	old_dirs=$(find "${MINER_DIR}" -maxdepth 1 -type d -name "pulse_*" | sort | awk -v n=7 '{a[NR]=$0} END{for(i=1;i<=NR-n;i++) print a[i]}' 2>/dev/null || true)
 	if [[ -n "${old_dirs}" ]]; then
 		echo "${old_dirs}" | while read -r dir; do
 			rm -rf "${dir}"

--- a/.agents/scripts/voice-pipeline-helper.sh
+++ b/.agents/scripts/voice-pipeline-helper.sh
@@ -891,7 +891,7 @@ cmd_status() {
 		local http_code
 		http_code=$(echo "$response" | tail -1)
 		local body
-		body=$(echo "$response" | head -n -1)
+		body=$(echo "$response" | sed '$d')
 
 		if [[ "$http_code" == "200" ]]; then
 			local char_count char_limit tier


### PR DESCRIPTION
## Summary

`head -n -N` (negative line count) is GNU-only — macOS `head` rejects it with `illegal line count`. This silently broke `model-availability-helper.sh` (fixed in #15631) and affects 7 other scripts.

**Replacements:**
- `head -n -1` → `sed '$d'` (POSIX portable, deletes last line) — 10 occurrences across 6 files
- `head -n -7` → `awk -v n=7 '{a[NR]=$0} END{for(i=1;i<=NR-n;i++) print a[i]}'` — 1 occurrence in session-miner-pulse.sh

**Files changed:** agent-test-helper.sh, email-design-test-helper.sh, mail-helper.sh, microsoft-graph-helper.sh, mission-skill-learner.sh, session-miner-pulse.sh, voice-pipeline-helper.sh

All pass ShellCheck.