### PR TITLE
GH#14010: tighten agent-testing.md (133→128 lines)

### DIFF
--- a/.agents/tools/build-agent/agent-testing.md
+++ b/.agents/tools/build-agent/agent-testing.md
@@ -26,8 +26,7 @@ tools:
 - **CLI**: Auto-detects `opencode` (override with `AGENT_TEST_CLI`)
 - **Flow**: Loads JSON suite → sends prompts via `opencode run --format json` (CLI) or `opencode serve` (HTTP) → validates responses
 - **Server mode**: `POST /session` → `POST /session/:id/message` → extract text → delete. Override host/port with `OPENCODE_HOST`/`OPENCODE_PORT`
-
-**When to use**: Validate agent changes before merging, regression-test after AGENTS.md/subagent edits, compare behavior across models, smoke-test after framework updates.
+- **When to use**: Validate agent changes before merging, regression-test after AGENTS.md/subagent edits, compare behavior across models, smoke-test after framework updates
 
 <!-- AI-CONTEXT-END -->
 
@@ -97,6 +96,9 @@ agent-test-helper.sh compare smoke-test          # 3. compare — non-zero exit 
 agent-test-helper.sh create my-new-tests         # create template in user suites dir
 agent-test-helper.sh list                        # list all suites (user + shipped)
 agent-test-helper.sh results [suite-name]        # view recent results
+
+# CI/CD (requires opencode CLI with API credentials)
+agent-test-helper.sh run agents-md-knowledge || { echo "Agent tests failed"; exit 1; }
 ```
 
 ## Shipped Test Suites
@@ -106,13 +108,6 @@ agent-test-helper.sh results [suite-name]        # view recent results
 | `smoke-test` | 3 | Quick agent responsiveness and identity check |
 | `agents-md-knowledge` | 5 | Core AGENTS.md instruction absorption |
 | `git-workflow` | 4 | Git workflow knowledge validation |
-
-## CI/CD Integration
-
-```bash
-# Requires opencode CLI in CI with API credentials
-agent-test-helper.sh run agents-md-knowledge || { echo "Agent tests failed"; exit 1; }
-```
 
 ## Environment Variables
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/build-agent/agent-testing.md` per simplification-debt issue GH#14010.

## Changes
- Fold standalone CI/CD section into Commands block (removes redundant heading + code fence)
- Merge "When to use" paragraph into Quick Reference bullet list (removes standalone paragraph)
- 133 → 128 lines; 0 markdownlint errors; all content preserved

## Issue
Closes #14010

## Files Changed
- `.agents/tools/build-agent/agent-testing.md`

## Testing
- `wc -l`: 128 (was 133)
- `bunx markdownlint-cli2`: 0 errors
- Content preservation: all code blocks, field tables, env var table, shipped suites table, task IDs, and command examples present before and after

## Key Decisions
- **Instruction doc** classification (not reference corpus): file contains agent rules, commands, and operational procedures — correct action is prose tightening, not chapter splitting
- No content removed — only structural consolidation (CI/CD folded into Commands, "When to use" moved to Quick Reference)

## Runtime Testing
Risk: **Low** — docs/agent prompt only, no code execution paths changed. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.622 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 4,089 tokens on this as a headless worker.