### PR TITLE
GH#14305: tighten tools.md - remove redundant sections

### DIFF
--- a/.agents/tools/code-review/tools.md
+++ b/.agents/tools/code-review/tools.md
@@ -24,15 +24,6 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Linter Manager
-
-```bash
-bash .agents/scripts/linter-manager.sh detect            # detect languages
-bash .agents/scripts/linter-manager.sh install-detected  # install for detected langs
-bash .agents/scripts/linter-manager.sh install-all       # install all supported
-bash .agents/scripts/linter-manager.sh install python    # install for specific lang
-```
-
 ## Language-Specific Linters
 
 | Language | Tools | Config |
@@ -71,13 +62,6 @@ Reference: [CodeFactor Analysis Tools](https://docs.codefactor.io/bootcamp/analy
 | CodeFactor | Web only | No | Reference collection for tool selection |
 
 **ESLint** auto-fix: 60-80% (JS/TS style + best practices)
-
-## Workflow Integration
-
-- **Pre-commit hooks**: run linters before commits
-- **CI/CD pipeline**: integrate with build process
-- **IDE plugins**: configure editor integration
-- **Quality gates**: block merges on violations
 
 ## Additional Resources
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/code-review/tools.md` from 88 → 72 lines by removing two redundant sections.

## Issue
Closes #14305

## Changes
- Removed `## Linter Manager` code block — exact duplicate of the Quick Reference bullet already inside `<!-- AI-CONTEXT -->` markers
- Removed `## Workflow Integration` section — generic boilerplate ("run linters before commits", "integrate with CI/CD") with no actionable specifics not already implied by the tool

## Preserved
- All linter version numbers and config file references
- All external URLs (CodeFactor, ESLint, Pylint, ShellCheck, Stylelint, Awesome Static Analysis)
- Quality platforms table with auto-fix percentages
- Quick Reference section (inside AI-CONTEXT markers)
- YAML frontmatter unchanged

## Testing
**Risk level:** Low (agent doc, no code)
**Verification:** `self-assessed` — content preservation verified by line-by-line review. All code blocks, URLs, and table data present before and after.

## Runtime Testing
`self-assessed` — documentation change only, no executable code modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.622 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 6m and 2,947 tokens on this as a headless worker.