### PR TITLE
GH#15656: dispatch_triage_reviews should log failures instead of silently returning

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8428,6 +8428,7 @@ dispatch_triage_reviews() {
 	# Parse needs-review items from pre-fetched state
 	local state_file="${STATE_FILE:-}"
 	[[ -f "$state_file" ]] || {
+		echo "[pulse-wrapper] dispatch_triage_reviews: no state file" >>"$LOGFILE"
 		printf '%d\n' "$available"
 		return 0
 	}
@@ -8438,6 +8439,9 @@ dispatch_triage_reviews() {
 	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
 	if [[ -z "$resolved_model" ]]; then
 		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
+	fi
+	if [[ -z "$resolved_model" ]]; then
+		echo "[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)" >>"$LOGFILE"
 	fi
 
 	# Parse markdown-format state entries:
@@ -8463,10 +8467,15 @@ dispatch_triage_reviews() {
 		fi
 	done <"$state_file"
 
-	[[ -n "$candidates" ]] || {
+	local candidate_count
+	candidate_count=$(printf '%s' "$candidates" | grep -c '[^[:space:]]' 2>/dev/null || echo 0)
+	if [[ -n "$candidates" ]]; then
+		echo "[pulse-wrapper] dispatch_triage_reviews: parsed ${candidate_count} candidates from state file" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file" >>"$LOGFILE"
 		printf '%d\n' "$available"
 		return 0
-	}
+	fi
 
 	while IFS='|' read -r issue_num repo_slug repo_path; do
 		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
@@ -8494,6 +8503,7 @@ dispatch_triage_reviews() {
 		available=$((available - 1))
 	done <<<"$candidates"
 
+	echo "[pulse-wrapper] dispatch_triage_reviews: dispatched ${triage_count} triage workers (${available} slots remaining)" >>"$LOGFILE"
 	printf '%d\n' "$available"
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8421,6 +8421,7 @@ dispatch_triage_reviews() {
 
 	[[ "$available" =~ ^[0-9]+$ ]] || available=0
 	[[ "$available" -gt 0 ]] || {
+		echo "[pulse-wrapper] dispatch_triage_reviews: no available worker slots" >>"$WRAPPER_LOGFILE"
 		printf '%d\n' "$available"
 		return 0
 	}
@@ -8428,7 +8429,7 @@ dispatch_triage_reviews() {
 	# Parse needs-review items from pre-fetched state
 	local state_file="${STATE_FILE:-}"
 	[[ -f "$state_file" ]] || {
-		echo "[pulse-wrapper] dispatch_triage_reviews: no state file" >>"$LOGFILE"
+		echo "[pulse-wrapper] dispatch_triage_reviews: no state file" >>"$WRAPPER_LOGFILE"
 		printf '%d\n' "$available"
 		return 0
 	}
@@ -8441,7 +8442,7 @@ dispatch_triage_reviews() {
 		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
 	fi
 	if [[ -z "$resolved_model" ]]; then
-		echo "[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)" >>"$LOGFILE"
+		echo "[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)" >>"$WRAPPER_LOGFILE"
 	fi
 
 	# Parse markdown-format state entries:
@@ -8470,9 +8471,9 @@ dispatch_triage_reviews() {
 	local candidate_count
 	candidate_count=$(printf '%s' "$candidates" | grep -c '[^[:space:]]' 2>/dev/null || echo 0)
 	if [[ -n "$candidates" ]]; then
-		echo "[pulse-wrapper] dispatch_triage_reviews: parsed ${candidate_count} candidates from state file" >>"$LOGFILE"
+		echo "[pulse-wrapper] dispatch_triage_reviews: parsed ${candidate_count} candidates from state file" >>"$WRAPPER_LOGFILE"
 	else
-		echo "[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file" >>"$LOGFILE"
+		echo "[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file" >>"$WRAPPER_LOGFILE"
 		printf '%d\n' "$available"
 		return 0
 	fi
@@ -8503,7 +8504,7 @@ dispatch_triage_reviews() {
 		available=$((available - 1))
 	done <<<"$candidates"
 
-	echo "[pulse-wrapper] dispatch_triage_reviews: dispatched ${triage_count} triage workers (${available} slots remaining)" >>"$LOGFILE"
+	echo "[pulse-wrapper] dispatch_triage_reviews: dispatched ${triage_count} triage workers (${available} slots remaining)" >>"$WRAPPER_LOGFILE"
 	printf '%d\n' "$available"
 	return 0
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.628"
+    "version": "3.5.629"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.628
+# Version: 3.5.629
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.628.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.629.tar.gz"
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.628",
+  "version": "3.5.629",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.628
+# Version: 3.5.629
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.628
+sonar.projectVersion=3.5.629
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Adds logging to `dispatch_triage_reviews()` at each early-return point so the pulse log shows activity on every cycle and failures are diagnosable.

## Issue
Closes #15656

## Files Changed
- `.agents/scripts/pulse-wrapper.sh` — 12 lines added to `dispatch_triage_reviews()`

## Changes
Five log lines added matching the pattern used by `dispatch_deterministic_fill_floor()`:

1. `[pulse-wrapper] dispatch_triage_reviews: no state file` — when `STATE_FILE` is missing
2. `[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)` — when both models unavailable (non-fatal, continues with no `--model` flag)
3. `[pulse-wrapper] dispatch_triage_reviews: parsed N candidates from state file` — after successful parse
4. `[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file` — when parse finds nothing
5. `[pulse-wrapper] dispatch_triage_reviews: dispatched N triage workers (M slots remaining)` — after dispatch loop

## Testing
- Risk level: **Low** (logging-only change, no logic altered)
- ShellCheck: zero violations on the modified function
- Self-assessed: no runtime environment needed; change is additive log writes only

## Key Decisions
- Model resolution failure is logged but non-fatal — the function continues and dispatches without `--model` (letting headless-runtime-helper pick its default), consistent with the existing code intent
- `candidate_count` uses `grep -c '[^[:space:]]'` to count non-blank lines, matching the pipe-separated format of `$candidates`

---
[aidevops.sh](https://aidevops.sh) v3.5.629 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,752 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved operational logging and error handling in the dispatch process
  * Enhanced robustness when handling missing data and model unavailability
  * Added detailed tracking logs for candidate processing and worker dispatch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->