### PR TITLE
GH#15656: add logging to dispatch_triage_reviews at each early-return point

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8428,6 +8428,7 @@ dispatch_triage_reviews() {
 	# Parse needs-review items from pre-fetched state
 	local state_file="${STATE_FILE:-}"
 	[[ -f "$state_file" ]] || {
+		echo "[pulse-wrapper] dispatch_triage_reviews: no state file" >>"$LOGFILE"
 		printf '%d\n' "$available"
 		return 0
 	}
@@ -8438,6 +8439,9 @@ dispatch_triage_reviews() {
 	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
 	if [[ -z "$resolved_model" ]]; then
 		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
+	fi
+	if [[ -z "$resolved_model" ]]; then
+		echo "[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)" >>"$LOGFILE"
 	fi
 
 	# Parse markdown-format state entries:
@@ -8463,7 +8467,14 @@ dispatch_triage_reviews() {
 		fi
 	done <"$state_file"
 
+	local candidate_count=0
+	if [[ -n "$candidates" ]]; then
+		candidate_count=$(printf '%s' "$candidates" | grep -c '|' 2>/dev/null || echo 0)
+	fi
+	echo "[pulse-wrapper] dispatch_triage_reviews: parsed ${candidate_count} candidates from state file" >>"$LOGFILE"
+
 	[[ -n "$candidates" ]] || {
+		echo "[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file" >>"$LOGFILE"
 		printf '%d\n' "$available"
 		return 0
 	}
@@ -8493,6 +8504,9 @@ dispatch_triage_reviews() {
 		triage_count=$((triage_count + 1))
 		available=$((available - 1))
 	done <<<"$candidates"
+
+	local slots_remaining="$available"
+	echo "[pulse-wrapper] dispatch_triage_reviews: dispatched ${triage_count} triage workers (${slots_remaining} slots remaining)" >>"$LOGFILE"
 
 	printf '%d\n' "$available"
 	return 0


### PR DESCRIPTION
## Summary

`dispatch_triage_reviews()` had multiple failure modes that returned exit code 0 and wrote nothing to `$LOGFILE`, giving the pulse zero signal that triage was broken. This PR adds log lines at every early-return point, matching the pattern used by `dispatch_deterministic_fill_floor()`.

## Changes

**File:** `.agents/scripts/pulse-wrapper.sh`

Log lines added at each early-return point:

- `[pulse-wrapper] dispatch_triage_reviews: no state file` — when `STATE_FILE` is missing
- `[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)` — when both model tiers are unavailable (continues rather than returning, matching issue spec)
- `[pulse-wrapper] dispatch_triage_reviews: parsed N candidates from state file` — after parse completes
- `[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file` — when parse finds nothing (early-return path)
- `[pulse-wrapper] dispatch_triage_reviews: dispatched N triage workers (M slots remaining)` — after dispatch loop completes

## Testing

**Risk level:** Low — logging additions only, no logic changes.

`shellcheck -S warning .agents/scripts/pulse-wrapper.sh` — zero violations.

Verified: every early-return path now writes a log line. The `parsed N candidates` line fires unconditionally after parse; the `0 candidates found` line fires only on the empty-candidates early-return path. The `dispatched N triage workers` line fires after the dispatch loop, covering the success path.

## Runtime Testing

`self-assessed` — logging-only change, no runtime state affected.

Closes #15656

---
[aidevops.sh](https://aidevops.sh) v3.5.629 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,786 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system logging and observability for internal dispatch operations, including improved error tracking and diagnostic metrics for resource allocation status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->