### PR TITLE
GH#15169: tighten d1-gotchas.md - remove redundant Operating Rules summary

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md
@@ -35,7 +35,7 @@ EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?;  -- Check for "USING IND
 CREATE INDEX idx_users_email ON users(email);  -- Add if missing
 ```
 
-Monitor query performance via `meta.duration`, add indexes on frequently queried columns, and break long work into smaller queries instead of long transactions.
+Monitor query performance via `meta.duration`, add indexes on frequently queried columns, and split long transactions into smaller queries.
 
 ## Common Errors
 
@@ -52,7 +52,7 @@ Monitor query performance via `meta.duration`, add indexes on frequently queried
 | Query timeout | 30s | Break long queries into smaller chunks |
 | Batch size | 10,000 statements | Split large batches |
 
-Avoid a single large database when horizontal partitioning fits the workload better.
+Prefer horizontal partitioning (multiple small DBs per tenant) over a single large database.
 
 ## Local vs Remote
 
@@ -63,14 +63,3 @@ Local D1 uses `.wrangler/state/v3/d1/<database-id>.sqlite`. Test migrations loca
 - **Boolean:** SQLite uses `INTEGER` (`0`/`1`), not a native boolean. Bind `1` or `0`, not `true`/`false`.
 - **Date/time:** Use `TEXT` (ISO 8601) or `INTEGER` (Unix timestamp), not native `DATE`/`TIME`.
 
-## Operating Rules
-
-- ✅ Use prepared statements with `bind()`.
-- ✅ Create indexes on frequently queried columns.
-- ✅ Use `batch()` for multiple queries to reduce latency.
-- ✅ Design for horizontal scaling with multiple small DBs when needed.
-- ✅ Test migrations locally before applying remotely.
-- ✅ Monitor query performance via `meta.duration`.
-- ❌ Don't store binary data directly in D1; use R2 for blobs.
-- ❌ Don't rely on a single large database as the default scaling plan.
-- ❌ Don't run long transactions; the timeout is `30s`.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightens `.agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md` by removing the redundant "Operating Rules" checklist section and tightening two prose sentences.

## Issue
Closes #15169

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md` — 76 → 65 lines

## Testing
**Risk level:** Low (agent doc, no code)
**Verification:** Self-assessed

Content preservation check:
- All code blocks present ✓
- SQL examples (`EXPLAIN QUERY PLAN`, `CREATE INDEX`) ✓
- Error messages (`no such table`, `UNIQUE constraint failed`, query timeout) ✓
- Limits table (all 4 rows) ✓
- `meta.duration`, `batch()`, `bind()` references ✓
- R2 for blobs (in limits table) ✓
- Horizontal partitioning guidance ✓
- Local vs Remote section ✓
- Data type gotchas ✓

## Key Decisions
The "Operating Rules" section (original lines 66-76) was a checklist that restated content already covered in the preceding sections:
- `bind()` → "Critical: Bind Parameters" section
- indexes → "Missing Indexes" section
- `batch()` → N+1 section
- horizontal scaling → "Limits That Change Design" table + prose
- test migrations locally → "Local vs Remote" section
- `meta.duration` → "Query Performance Pitfalls" section
- no binary data in D1 → limits table (Row size → R2)
- no single large DB → limits table + prose
- no long transactions → limits table (Query timeout)

Removing it reduces noise without losing any knowledge. The sections themselves are the rules.

## Runtime Testing
`self-assessed` — agent doc change, no runtime required.

---
[aidevops.sh](https://aidevops.sh) v3.5.629 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,157 tokens on this as a headless worker.