### PR TITLE
t1853: fix SIGPIPE in worktree-helper.sh cleanup silently aborts with 400+ worktrees

### DIFF
--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -662,8 +662,13 @@ _remove_validate_path() {
 	local path_to_remove="$1"
 
 	# Don't allow removing main worktree
-	local main_worktree
-	main_worktree=$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)
+	# NOTE: avoid piping git worktree list through head — with set -o pipefail
+	# and many worktrees, head closes the pipe early, git gets SIGPIPE (exit 141),
+	# and pipefail propagates the failure causing set -e to abort the script.
+	local _porcelain main_worktree
+	_porcelain=$(git worktree list --porcelain)
+	main_worktree="${_porcelain%%$'\n'*}"      # first line
+	main_worktree="${main_worktree#worktree }" # strip prefix
 	if [[ "$path_to_remove" == "$main_worktree" ]]; then
 		echo -e "${RED}Error: Cannot remove main worktree${NC}"
 		return 1
@@ -1220,8 +1225,12 @@ cmd_clean() {
 
 	# Identify the main worktree path — must never be cleaned up.
 	# The first entry in `git worktree list --porcelain` is always the main worktree.
-	local main_worktree_path
-	main_worktree_path=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+	# NOTE: avoid piping through head — with set -o pipefail and many worktrees,
+	# head closes the pipe early → git SIGPIPE (exit 141) → pipefail → set -e abort.
+	local _porcelain main_worktree_path
+	_porcelain=$(git worktree list --porcelain)
+	main_worktree_path="${_porcelain%%$'\n'*}"           # first line
+	main_worktree_path="${main_worktree_path#worktree }" # strip prefix
 
 	# Fetch to get current remote branch state (detects deleted branches)
 	# Prune all remotes, not just origin (GH#3797)


### PR DESCRIPTION
## Summary

- **Root cause**: `git worktree list --porcelain | head -1` with `set -euo pipefail` causes SIGPIPE (exit 141) when `head` closes the pipe before `git` finishes writing 425 worktree entries. `pipefail` propagates the failure → `set -e` silently aborts the script before the cleanup scan starts.
- **Fix**: Capture full porcelain output into a variable first, then extract the first line using bash string manipulation (`${var%%$'\n'*}`) — no pipes, no SIGPIPE. Two instances fixed.
- **Impact**: 206 stale worktrees (11 GB disk) accumulated because cleanup never ran. Pulse `cleanup_worktrees()` stage was a no-op.

## Runtime Testing

- **Risk**: Medium (cleanup logic, no data creation/deletion in the fix itself)
- **Verification**: `self-assessed` — ran the fixed script in the worktree, confirmed it now detects 206+ eligible worktrees instead of silently aborting with "No merged worktrees to clean up"

Closes #15669


---
[aidevops.sh](https://aidevops.sh) v3.5.629 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 22m and 31,515 tokens on this with the user in an interactive session.