### PR TITLE
GH#14275: tighten do-storage-gotchas.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md
@@ -70,9 +70,8 @@ await this.ctx.storage.deleteAll();
 ## Auto Caching & Bypass
 
 ```typescript
-// Built-in cache makes simple code fast
 async getUniqueNumber() {
-  let val = await this.ctx.storage.get("counter"); // Cached after first
+  let val = await this.ctx.storage.get("counter"); // Cached after first read
   await this.ctx.storage.put("counter", val + 1);  // Instant cache write
   return val;
 }
@@ -81,13 +80,9 @@ async getUniqueNumber() {
 await this.ctx.storage.get("key", { allowConcurrency: true, noCache: true });
 ```
 
-## Common Errors & Best Practices
+## Common Errors
 
 **Slow perf:** Use sync KV API (`ctx.storage.kv`) vs async  
-**Races:** Check concurrent calls from same event (not protected)  
 **High billing:** Check `rowsRead`/`rowsWritten`; verify unused objects call `deleteAll()`  
-**Overload:** Single DO soft limit ~1K req/sec; shard
-
-**Do:** Use SQLite-backed; sync KV for simple key-value; don't await writes unnecessarily (output gate protects); use `blockConcurrencyWhile()` for init; delete alarms AND storage when cleaning
-
-**Don't:** Use SQL transaction statements directly; initiate concurrent storage ops from same event; assume TypeScript types validate at runtime
+**Overload:** Single DO soft limit ~1K req/sec; shard  
+**Init races:** Use `blockConcurrencyWhile()` for initialization


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md` per GH#14275 simplification issue.

## Changes
- Removed redundant "what" comment in Auto Caching section (restated what the code already showed)
- Removed Do/Don't block that duplicated rules already demonstrated in ✅/❌ code examples
- Moved `blockConcurrencyWhile()` init guidance into Common Errors as a concrete actionable item
- 93 → 88 lines (5.4% reduction)

## Preservation Verification
- All code blocks: ✅ preserved
- All limit values (SQL/Storage): ✅ preserved
- All ✅/❌ patterns: ✅ preserved
- All constraint rules (concurrency gates, transaction rules, alarm persistence): ✅ preserved
- No URLs or task ID refs in original: N/A

## Testing
Risk: **Low** (agent doc, no code changes). Self-assessed per runtime testing gate.

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md`

Closes #14275

---
[aidevops.sh](https://aidevops.sh) v3.5.630 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 3,663 tokens on this as a headless worker.