### PR TITLE
GH#14321: fix broken chapter links in production-video.md

### DIFF
--- a/.agents/content/production-video.md
+++ b/.agents/content/production-video.md
@@ -49,15 +49,15 @@ Full content is split into focused chapter files. Each is self-contained.
 
 | # | Chapter | Description |
 |---|---------|-------------|
-| 01 | [Model Selection](video/01-model-selection.md) | Decision tree, model comparison table, content type presets |
-| 02 | [Sora 2 Pro Template](video/02-sora-template.md) | 6-section master template with UGC product demo example |
-| 03 | [Veo 3.1 Workflow](video/03-veo-workflow.md) | 7-component prompting framework, ingredients-to-video (mandatory) |
-| 04 | [Seed Bracketing](video/04-seed-bracketing.md) | Systematic seed testing (15% → 70%+ success), scoring, automation |
-| 05 | [Camera & Shot Reference](video/05-camera-shot-reference.md) | 8K camera models, lens characteristics, shot types, angles, movements |
-| 06 | [2-Track Production](video/06-two-track-production.md) | Objects/environments (Track 1) vs characters/people (Track 2) |
-| 07 | [Post-Production](video/07-post-production.md) | Upscaling, frame rate conversion, denoising, film grain |
-| 08 | [Talking-Head Pipeline](video/08-talking-head-pipeline.md) | Longform 30s+ pipeline: image → script → voice → video → post |
-| 09 | [Tools & Resources](video/09-tools-resources.md) | Internal references, helper scripts, external links |
+| 01 | [Model Selection](production-video-01-model-selection.md) | Decision tree, model comparison table, content type presets |
+| 02 | [Sora 2 Pro Template](production-video-02-sora-template.md) | 6-section master template with UGC product demo example |
+| 03 | [Veo 3.1 Workflow](production-video-03-veo-workflow.md) | 7-component prompting framework, ingredients-to-video (mandatory) |
+| 04 | [Seed Bracketing](production-video-04-seed-bracketing.md) | Systematic seed testing (15% → 70%+ success), scoring, automation |
+| 05 | [Camera & Shot Reference](production-video-05-camera-shot-reference.md) | 8K camera models, lens characteristics, shot types, angles, movements |
+| 06 | [2-Track Production](production-video-06-two-track-production.md) | Objects/environments (Track 1) vs characters/people (Track 2) |
+| 07 | [Post-Production](production-video-07-post-production.md) | Upscaling, frame rate conversion, denoising, film grain |
+| 08 | [Talking-Head Pipeline](production-video-08-talking-head-pipeline.md) | Longform 30s+ pipeline: image → script → voice → video → post |
+| 09 | [Tools & Resources](production-video-09-tools-resources.md) | Internal references, helper scripts, external links |
 
 ## Key Rules
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Fix 9 broken chapter links in `.agents/content/production-video.md` index.

## Issue
Closes #14321

## Root Cause
Chapter files were previously split from a monolithic doc into flat-named files (`production-video-NN-*.md`) in the same `content/` directory. The index was updated to reference a `video/` subdirectory (`video/01-model-selection.md`) that was never created — all 9 chapter links were broken.

## Files Changed
- `.agents/content/production-video.md` — corrected all 9 chapter link paths from `video/NN-*.md` → `production-video-NN-*.md`

## Testing
- All 9 chapter files verified to exist at the corrected paths
- `wc -l` total of chapter files (396 lines) >= original minus index overhead ✓
- No content removed — index structure and all key rules preserved ✓
- Risk: **Low** (docs-only, no code, no agent behaviour change)

## Key Decisions
- No content compression applied — file is already a slim index (82 lines) with content in chapter files
- Classification: reference corpus (already correctly restructured); only the link paths needed fixing

---
[aidevops.sh](https://aidevops.sh) v3.5.630 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 4,686 tokens on this as a headless worker.