### PR TITLE
GH#14276: tighten schema-validator.md — remove redundant sections

### DIFF
--- a/.agents/seo/schema-validator.md
+++ b/.agents/seo/schema-validator.md
@@ -45,22 +45,6 @@ schema-validator-helper.sh help
 
 <!-- AI-CONTEXT-END -->
 
-## Features
-
-- **Multi-format extraction**: Parses JSON-LD, Microdata, and RDFa from HTML pages
-- **Schema.org compliance**: Validates against the latest Schema.org vocabulary (auto-fetched, cached 24h)
-- **Google Rich Results**: Checks for compliance with Google's structured data requirements
-- **URL and file support**: Validates live URLs or local HTML/JSON files
-- **Detailed reporting**: JSON output with error severity, location, and description
-
-## Validation Workflow
-
-1. **Input**: URL, local HTML file, or raw JSON-LD file
-2. **Extract**: Parse structured data from HTML using `@marbec/web-auto-extractor`
-3. **Fetch schema**: Download/cache latest Schema.org definition
-4. **Validate**: Run `@adobe/structured-data-validator` against extracted data
-5. **Report**: Output validation results as JSON (errors, warnings, info)
-
 ## Common Schema Types
 
 | Type | Use Case |
@@ -74,15 +58,11 @@ schema-validator-helper.sh help
 | `BreadcrumbList` | Navigation breadcrumbs |
 | `WebSite` | Sitelinks search box |
 
-## Integration with SEO Audit
+## SEO Audit Integration
 
-This subagent is referenced by the SEO audit workflow (`seo-audit-skill.md`) under "Tools Referenced > Free Tools > Schema Validator". Use it during the **Technical SEO Audit** phase to validate structured data implementation.
+Use during the **Technical SEO Audit** phase (`seo-audit-skill.md` → "Tools Referenced > Free Tools > Schema Validator").
 
-**Complementary tools**:
-
-- `seo/schema-markup.md` - Schema.org implementation templates (t092)
-- `seo/seo-audit-skill.md` - Full SEO audit framework
-- Google Rich Results Test - Online validation (t084)
+**Complementary tools**: `seo/schema-markup.md` (templates, t092) · `seo/seo-audit-skill.md` (full audit) · Google Rich Results Test (t084)
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/seo/schema-validator.md` per `build-agent.md` principles. Removed two redundant sections that duplicated information already present in the Quick Reference and frontmatter description.

## Changes
- Removed `## Features` section (5 bullets duplicating Quick Reference + frontmatter)
- Removed `## Validation Workflow` section (implementation detail not needed for agent usage)
- Tightened `## Integration with SEO Audit` prose (3 lines → 2 lines, same information)
- Result: 93 → 73 lines (21% reduction)

## Preservation Verification
- All commands: ✓ (bash block intact)
- Task ID refs (t092, t084): ✓
- File paths and dependencies: ✓
- Troubleshooting section: ✓ (unchanged)
- Common Schema Types table: ✓ (unchanged)
- Agent behaviour unchanged: ✓ (no rules or constraints removed)

## Testing
Risk: **Low** (docs-only change, agent prompt). Self-assessed per runtime testing gate.

Closes #14276

---
[aidevops.sh](https://aidevops.sh) v3.5.630 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 3,883 tokens on this as a headless worker.