### PR TITLE
GH#14323: tighten manifest-ref.md prose without content loss

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md
@@ -1,6 +1,6 @@
 # Manifest Reference
 
-Full field reference for `CloudronManifest.json`. See the [Cloudron docs](https://docs.cloudron.io/packaging/manifest/) for detailed examples.
+`CloudronManifest.json` field reference. See the [Cloudron docs](https://docs.cloudron.io/packaging/manifest/) for examples.
 
 ## Required fields
 
@@ -8,7 +8,7 @@ Full field reference for `CloudronManifest.json`. See the [Cloudron docs](https:
 |-------|------|-------------|
 | `manifestVersion` | integer | Always `2` |
 | `version` | semver string | Package version (e.g. `"1.0.0"`) |
-| `healthCheckPath` | URL path | Path returning 2xx when app is healthy (e.g. `"/"`) |
+| `healthCheckPath` | URL path | Path returning 2xx when healthy (e.g. `"/"`) |
 | `httpPort` | integer | HTTP port the app listens on (e.g. `8000`) |
 
 ## Ports
@@ -16,11 +16,11 @@ Full field reference for `CloudronManifest.json`. See the [Cloudron docs](https:
 | Field | Type | Description |
 |-------|------|-------------|
 | `httpPort` | integer | Primary HTTP port |
-| `httpPorts` | object | Additional HTTP services on secondary domains. Keys are env var names. Values: `{ title, description, containerPort, defaultValue }` |
-| `tcpPorts` | object | Non-HTTP TCP ports. Keys are env var names. Values: `{ title, description, defaultValue, containerPort, portCount, readOnly, enabledByDefault }` |
+| `httpPorts` | object | Additional HTTP services on secondary domains. Keys: env var names. Values: `{ title, description, containerPort, defaultValue }` |
+| `tcpPorts` | object | Non-HTTP TCP ports. Keys: env var names. Values: `{ title, description, defaultValue, containerPort, portCount, readOnly, enabledByDefault }` |
 | `udpPorts` | object | UDP ports. Same structure as `tcpPorts` |
 
-The `containerPort` is the port inside the container. `defaultValue` is the suggested external port shown during install. Disabled ports remove their env var at runtime — apps must handle this.
+`containerPort`: port inside the container. `defaultValue`: suggested external port shown at install. Disabled ports remove their env var — apps must handle absence.
 
 ## Addons
 
@@ -55,22 +55,22 @@ The `containerPort` is the port inside the container. `defaultValue` is the sugg
 | Field | Type | Description |
 |-------|------|-------------|
 | `memoryLimit` | integer (bytes) | Max RAM + swap (default 256 MB / `268435456`) |
-| `multiDomain` | boolean | Allow alias domains. Sets `CLOUDRON_ALIAS_DOMAINS` env var |
-| `optionalSso` | boolean | Allow install without user management. Auth addon env vars are absent when SSO is off |
+| `multiDomain` | boolean | Allow alias domains. Sets `CLOUDRON_ALIAS_DOMAINS` |
+| `optionalSso` | boolean | Allow install without user management. Auth addon env vars absent when SSO is off |
 | `configurePath` | URL path | Admin panel path shown in dashboard (e.g. `/wp-admin/`) |
-| `logPaths` | string array | Log file paths when stdout is not possible |
+| `logPaths` | string array | Log file paths when stdout is unavailable |
 | `capabilities` | string array | Extra Linux capabilities: `net_admin`, `mlock`, `ping`, `vaapi` |
-| `runtimeDirs` | string array | Writable subdirs of `/app/code` (not backed up, not persisted across updates) |
-| `persistentDirs` | string array | Writable dirs persisted across updates but not in filesystem backup. Use with `backupCommand`. Requires `minBoxVersion: 9.1.0` |
-| `backupCommand` | string | Shell command run during backup to dump persistent data into `/app/data`. Requires `minBoxVersion: 9.1.0` |
-| `restoreCommand` | string | Shell command run during restore to populate `persistentDirs` from `/app/data`. Requires `minBoxVersion: 9.1.0` |
+| `runtimeDirs` | string array | Writable subdirs of `/app/code` — not backed up, not persisted across updates |
+| `persistentDirs` | string array | Writable dirs persisted across updates but excluded from filesystem backup. Use with `backupCommand`. Requires `minBoxVersion: 9.1.0` |
+| `backupCommand` | string | Command run at backup to dump persistent data into `/app/data`. Requires `minBoxVersion: 9.1.0` |
+| `restoreCommand` | string | Command run at restore to populate `persistentDirs` from `/app/data`. Requires `minBoxVersion: 9.1.0` |
 
 ## Post-install
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `postInstallMessage` | markdown string | Shown after install. Supports `file://POSTINSTALL.md`. Tags: `<sso>...</sso>`, `<nosso>...</nosso>`. Variables: `$CLOUDRON-APP-DOMAIN`, `$CLOUDRON-APP-FQDN`, `$CLOUDRON-APP-ORIGIN`, `$CLOUDRON-USERNAME`, `$CLOUDRON-APP-ID` |
-| `checklist` | object | Post-install todo items. Keys are item IDs. Values: `{ message, sso }`. `sso: true` = shown only with auth, `sso: false` = shown only without auth |
+| `postInstallMessage` | markdown string | Shown after install. Supports `file://POSTINSTALL.md`. Tags: `<sso>`, `<nosso>`. Variables: `$CLOUDRON-APP-DOMAIN`, `$CLOUDRON-APP-FQDN`, `$CLOUDRON-APP-ORIGIN`, `$CLOUDRON-USERNAME`, `$CLOUDRON-APP-ID` |
+| `checklist` | object | Post-install todo items. Keys: item IDs. Values: `{ message, sso }`. `sso: true` = auth only, `sso: false` = no-auth only |
 
 ## Versioning
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Prose-only tightening of `.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md` (81 lines, reference corpus).

## Issue
Closes #14323

## Files changed
- `.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md` — 14 lines changed (same line count, prose compressed)

## Changes made
- Intro line: removed redundant "Full field reference for" prefix
- Ports section: tightened `containerPort`/`defaultValue` prose note
- Behavior section: minor wording compression (`Sets CLOUDRON_ALIAS_DOMAINS env var` → `Sets CLOUDRON_ALIAS_DOMAINS`, `when stdout is not possible` → `when stdout is unavailable`, etc.)
- Post-install: tightened `postInstallMessage` and `checklist` descriptions

## Preserved
All field names, types, example values, behavioral notes, version requirements (`minBoxVersion: 9.1.0`), URLs, and code references intact. No knowledge removed.

## Classification
Reference corpus (field reference table) — prose tightening only, no restructuring needed at 81 lines.

## Testing
- `wc -l` before and after: 81 lines (unchanged)
- All field names, types, and values verified present
- Risk: **Low** (docs-only change, no code or agent behavior affected)

## Runtime Testing
`self-assessed` — docs-only change per risk table (Low risk pattern).

---
[aidevops.sh](https://aidevops.sh) v3.5.630 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,845 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced manifest configuration reference documentation with clarified and refined field descriptions, including improved guidance on health check paths, port configuration and environment variable handling, domain settings, backup/restore commands, and post-installation messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->