### PR TITLE
GH#15175: mark cheatsheet-mutations.md as converged in simplification state

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1836,6 +1836,12 @@
       "passes": 1,
       "pr": 14577
     },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md": {
+      "at": "2026-03-31T06:23:12Z",
+      "hash": "084644aa5375c89ba69717a690c579d6076d532e",
+      "passes": 2,
+      "pr": 14691
+    },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
       "at": "2026-03-28T10:27:24Z",
       "hash": "2bf913e1887714fccd8b5baaf92a9c4afd0eaf44",
@@ -2250,6 +2256,12 @@
       "passes": 1,
       "pr": 13735
     },
+    ".agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md": {
+      "hash": "c4d5ed8a074df52b72e94f16782306bf95098b3b",
+      "at": "2026-04-02T15:27:02Z",
+      "pr": 15629,
+      "passes": 2
+    },
     ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
       "at": "2026-03-28T16:00:25Z",
       "hash": "3078a83990f41df192998904d47d0641191e7fba",
@@ -2261,6 +2273,13 @@
       "hash": "c0c080bb82f1488a996f7cf50c231ac89179bc6f",
       "passes": 1,
       "pr": 14914
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/realtimekit-gotchas.md": {
+      "at": "2026-04-02T15:00:00Z",
+      "hash": "d9ece80ba981cecbe018d046364998faba4503b1",
+      "passes": 1,
+      "pr": 15651,
+      "issue": 14302
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
       "at": "2026-03-30T03:33:46Z",
@@ -4421,19 +4440,6 @@
       "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
       "passes": 1,
       "pr": 15470
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md": {
-      "hash": "c4d5ed8a074df52b72e94f16782306bf95098b3b",
-      "at": "2026-04-02T15:27:02Z",
-      "pr": 15629,
-      "passes": 2
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/realtimekit-gotchas.md": {
-      "at": "2026-04-02T15:00:00Z",
-      "hash": "d9ece80ba981cecbe018d046364998faba4503b1",
-      "passes": 1,
-      "pr": 15651,
-      "issue": 14302
     }
   },
   ".agents/workflows/branch/experiment.md": {


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Adds `.agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md` to `simplification-state.json` with `passes=2`, marking it as converged and preventing the scanner from re-flagging it on future pulse cycles.

## Issue
Closes #15175

## Context
The file was already simplified twice:
- PR #14657 (GH#14358): first pass, reduced from 65→56 lines
- PR #14691 (GH#14679): second pass, further tightened

The automated scanner kept re-flagging the file because it was never recorded in `simplification-state.json`. This PR fixes the convergence tracking gap.

## Files Changed
- `.agents/configs/simplification-state.json` — added entry for `cheatsheet-mutations.md` with `passes=2`, `pr=14691`, `at=2026-03-31T06:23:12Z`

## Testing
- Verified file hash matches current content: `084644aa5375c89ba69717a690c579d6076d532e`
- JSON is valid (parsed with Python)
- Entry follows existing schema pattern in the state file

## Runtime Testing
**Risk level: Low** — config file update only, no code execution path affected.
`self-assessed`: JSON config change with no runtime execution risk.

---
[aidevops.sh](https://aidevops.sh) v3.5.630 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 6,017 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation configuration and metadata organization.

---

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->