### PR TITLE
GH#15083: tighten playwright-emulation.md — co-locate reference data in code block

### DIFF
--- a/.agents/tools/browser/playwright-emulation.md
+++ b/.agents/tools/browser/playwright-emulation.md
@@ -71,13 +71,17 @@ await browser.newContext({ viewport: { width: 2560, height: 1440 }, deviceScaleF
 use: { geolocation: { longitude: -122.4194, latitude: 37.7749 }, permissions: ['geolocation'] }
 await context.setGeolocation({ longitude: 48.8584, latitude: 2.2945 });
 
-// Locale / Timezone
+// Locale / Timezone — pairs: en-US/America/Los_Angeles, en-US/America/New_York,
+//   en-GB/Europe/London, de-DE/Europe/Berlin, fr-FR/Europe/Paris, ja-JP/Asia/Tokyo,
+//   zh-CN/Asia/Shanghai, hi-IN/Asia/Kolkata, pt-BR/America/Sao_Paulo, en-AU/Australia/Sydney
 use: { locale: 'en-GB', timezoneId: 'Europe/London' }
 
 // Color scheme / media
 await page.emulateMedia({ colorScheme: 'dark', reducedMotion: 'reduce', forcedColors: 'active', media: 'print' });
 
-// Permissions
+// Permissions: geolocation, midi, midi-sysex, notifications, camera, microphone,
+//   background-sync, ambient-light-sensor, accelerometer, gyroscope, magnetometer,
+//   accessibility-events, clipboard-read, clipboard-write, payment-handler
 await context.grantPermissions(['geolocation'], { origin: 'https://example.com' });
 await context.clearPermissions();
 
@@ -90,10 +94,6 @@ const ctx = await browser.newContext({ ...devices['iPhone 13'], hasTouch: true }
 await page.tap('.button');
 await page.touchscreen.tap(200, 300);
 ```
-
-**Permissions**: `geolocation`, `midi`, `midi-sysex`, `notifications`, `camera`, `microphone`, `background-sync`, `ambient-light-sensor`, `accelerometer`, `gyroscope`, `magnetometer`, `accessibility-events`, `clipboard-read`, `clipboard-write`, `payment-handler`
-
-**Locale/timezone pairs**: `en-US`/`America/Los_Angeles`, `en-US`/`America/New_York`, `en-GB`/`Europe/London`, `de-DE`/`Europe/Berlin`, `fr-FR`/`Europe/Paris`, `ja-JP`/`Asia/Tokyo`, `zh-CN`/`Asia/Shanghai`, `hi-IN`/`Asia/Kolkata`, `pt-BR`/`America/Sao_Paulo`, `en-AU`/`Australia/Sydney`
 
 ## Recipes
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/browser/playwright-emulation.md` per GH#15083 simplification scan.

**Classification**: Instruction doc (not reference corpus) — prose tightening applies.

**Change**: Moved the standalone bold reference paragraphs (permissions list and locale/timezone pairs) from after the `Emulation Options` code block into inline comments within the code block itself. This co-locates reference data with the code that uses it, removing the visual disconnect between the code and its reference lists.

## Issue
Closes #15083

## Files Changed
- `.agents/tools/browser/playwright-emulation.md` — 6 insertions, 6 deletions (net zero line count change)

## Testing
**Risk level**: Low (docs/agent prompt, no code execution)
**Verification**: All code blocks, URLs, task ID references (t096, t097), command examples, permissions list, and locale/timezone pairs present before and after. Content preservation confirmed via `grep` checks.

## Key Decisions
- File classified as **instruction doc** (not reference corpus) — prose tightening applies per `code-simplifier.md`
- Reference data (permissions, locale pairs) moved into code block comments rather than deleted — zero content loss
- Line count unchanged (153 lines) — the improvement is structural co-location, not compression

## Runtime Testing
`self-assessed` — docs-only change, no runtime required

---
[aidevops.sh](https://aidevops.sh) v3.5.634 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m and 8,048 tokens on this as a headless worker.