### PR TITLE
GH#15460: tighten screaming-frog.md agent doc

### DIFF
--- a/.agents/seo/screaming-frog.md
+++ b/.agents/seo/screaming-frog.md
@@ -22,13 +22,9 @@ tools:
 
 ## Usage
 
-### Basic Crawl
-
 ```bash
 screamingfrogseospider --crawl https://example.com --headless --output-folder ./reports
 ```
-
-### Configuration & Export
 
 - **Load Config**: `--config profile.seospiderconfig` (save from GUI first).
 - **Export Tabs**: `--export-tabs "Internal:All,Response Codes:All"`


### PR DESCRIPTION
## Summary

Remove redundant subsection headers (`### Basic Crawl`, `### Configuration & Export`) from the Usage section of `.agents/seo/screaming-frog.md`. The code block and bullet list are self-documenting; the headers added noise without adding meaning.

- 40 lines, down from 44 (originally 62 before prior simplification passes in #15492 and #15311)
- All content preserved — no knowledge loss
- Agent behaviour unchanged

## Files Changed

- `.agents/seo/screaming-frog.md` — 4 lines removed (2 subsection headers + 2 blank lines)

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution paths changed.
**Verification:** `self-assessed` — content diff reviewed, all CLI flags, URLs, and task references present before and after.

Closes #15460

---
[aidevops.sh](https://aidevops.sh) v3.5.636 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 2,818 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined Screaming Frog SEO Spider CLI documentation by removing redundant section headers, while preserving all examples and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->