### PR TITLE
GH#14144: tighten email-delivery-test.md command doc (114→40 lines)

### DIFF
--- a/.agents/scripts/commands/email-delivery-test.md
+++ b/.agents/scripts/commands/email-delivery-test.md
@@ -8,107 +8,33 @@ Run email deliverability testing — spam content analysis, provider-specific ch
 
 Arguments: $ARGUMENTS
 
-## Workflow
+## Dispatch
 
-### Step 1: Determine Test Type
+Parse `$ARGUMENTS` and call the appropriate helper:
 
-Parse `$ARGUMENTS` to determine what to test:
+| Argument type | Command |
+|---------------|---------|
+| HTML/text file path | `email-delivery-test-helper.sh spam-check "$ARGUMENTS"` |
+| Domain | `email-delivery-test-helper.sh providers "$ARGUMENTS"` |
+| `warmup <domain>` | `email-delivery-test-helper.sh report "$ARGUMENTS"` (warm-up guidance) |
+| `seed-test <domain>` | `email-delivery-test-helper.sh report "$ARGUMENTS"` (seed-list guide) |
+| `gmail <domain>` | `email-delivery-test-helper.sh providers gmail "$ARGUMENTS"` |
+| empty / `help` | Show options table below |
 
-- If argument is an HTML/text file path: run spam content analysis
-- If argument is a domain: run provider deliverability checks
-- If argument is "warmup": show warm-up guidance
-- If argument is "seed-test": show seed-list testing guide
-- If argument is "help" or empty: show available commands
+All helpers live at `~/.aidevops/agents/scripts/email-delivery-test-helper.sh`.
 
-### Step 2: Run Appropriate Tests
+## Present Results
 
-**For email content (spam analysis):**
-
-```bash
-~/.aidevops/agents/scripts/email-delivery-test-helper.sh spam-check "$ARGUMENTS"
-```
-
-**For domains (provider deliverability):**
-
-```bash
-~/.aidevops/agents/scripts/email-delivery-test-helper.sh providers "$ARGUMENTS"
-```
-
-**For full report:**
-
-```bash
-~/.aidevops/agents/scripts/email-delivery-test-helper.sh report "$ARGUMENTS"
-```
-
-### Step 3: Present Results
-
-Format the output as a clear report with:
-
+Format output as:
 - Spam score and risk rating
 - Provider-specific scores (Gmail, Outlook, Yahoo)
 - Actionable recommendations
 - Links to monitoring services
 
-### Step 4: Offer Follow-up Actions
-
-```text
-Actions:
-1. Run full deliverability report
-2. Check specific provider (Gmail/Outlook/Yahoo)
-3. Analyze email content for spam triggers
-4. View warm-up schedule
-5. Run seed-list placement test
-```
-
-## Options
-
-| Command | Purpose |
-|---------|---------|
-| `/email-delivery-test newsletter.html` | Spam content analysis |
-| `/email-delivery-test example.com` | All-provider deliverability check |
-| `/email-delivery-test gmail example.com` | Gmail-specific check |
-| `/email-delivery-test warmup example.com` | Warm-up guidance |
-| `/email-delivery-test seed-test example.com` | Seed-list testing guide |
-
-## Examples
-
-**Spam content analysis:**
-
-```text
-User: /email-delivery-test newsletter.html
-AI: Running spam content analysis on newsletter.html...
-
-    Subject Line: 2 issues (excessive caps, exclamation marks)
-    Body Content: 3 high-risk phrases, 5 medium-risk phrases
-    Structural: Low text-to-image ratio, missing physical address
-
-    Spam Score: 45/100 - MEDIUM RISK
-    Content may trigger spam filters in some providers
-
-    Top Issues:
-    1. "Act now" and "Limited time" are high-risk phrases
-    2. Image-heavy with little text content
-    3. Missing physical address (CAN-SPAM requirement)
-```
-
-**Provider deliverability check:**
-
-```text
-User: /email-delivery-test example.com
-AI: Checking deliverability across major providers...
-
-    Gmail:   7/8 - Excellent
-    Outlook: 5/7 - Good
-    Yahoo:   4/5 - Good
-
-    All providers require:
-    - SPF + DKIM + DMARC enforcement
-    - One-click unsubscribe headers
-    - Spam rate < 0.3%
-```
+Then offer follow-up: full report · specific provider · spam content analysis · warm-up schedule · seed-list test.
 
 ## Related
 
-- `services/email/email-delivery-test.md` - Full documentation
-- `services/email/email-health-check.md` - DNS authentication checks
-- `services/email/email-testing.md` - Design rendering tests
+- `services/email/email-delivery-test.md` — full documentation
+- `services/email/email-health-check.md` — DNS authentication checks
+- `services/email/email-testing.md` — design rendering tests


### PR DESCRIPTION
## Summary

Tightens `.agents/scripts/commands/email-delivery-test.md` from 114 to 40 lines (65% reduction) per agent doc simplification guidelines.

**Changes:**
- Collapsed 4-step workflow into a single dispatch table (argument type → helper command)
- Removed redundant `## Options` table (duplicated dispatch logic)
- Removed `## Examples` section (36 lines of illustrative output that the helper script already produces at runtime)
- Condensed follow-up actions to a single inline line
- All institutional knowledge preserved: helper script path, all command variants, result format, related links

**Classification:** Instruction doc (not reference corpus) — prose compression appropriate.

Closes #14144

<!-- MERGE_SUMMARY -->
**What:** Tighten email-delivery-test.md slash command doc from 114→40 lines
**Issue:** GH#14144
**Files changed:** `.agents/scripts/commands/email-delivery-test.md`
**Testing:** Self-assessed (Low risk — docs/agent prompt only, no code changes)
**Key decisions:** Removed illustrative example output blocks (runtime-generated by helper) and duplicate options table; preserved all command dispatch logic and helper paths

## Runtime Testing

Risk: **Low** — agent prompt/docs only, no code execution paths changed.
Assessment: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.636 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,120 tokens on this as a headless worker.