### PR TITLE
GH#14170: tighten refactor probes doc

### DIFF
--- a/.agents/reference/define-probes/refactor.md
+++ b/.agents/reference/define-probes/refactor.md
@@ -9,95 +9,63 @@ Use 2 probes from this file during `/define` for tasks classified as **refactor*
 
 ## Default Assumptions
 
-Apply these unless the user overrides during interview:
+Apply unless user overrides:
 
 - Zero behaviour changes — all existing tests must pass unchanged
 - No new dependencies
 - Improve readability, maintainability, or performance (pick one primary goal)
 - If tests don't exist for the refactored code, add them before refactoring
 
-## Structured Questions
+## Required Questions
 
-### Primary Goal
-
-```text
-What's the main reason for this refactor?
+**Primary Goal** — What's the main reason for this refactor?
 
 1. Readability — code is hard to understand or maintain (recommended)
 2. Performance — current implementation is too slow
 3. Extensibility — need to add features and current structure blocks it
 4. Duplication — same logic exists in multiple places
 5. Let me explain
-```
 
-### Scope Boundary
-
-```text
-How far should this refactor go?
+**Scope Boundary** — How far should this refactor go?
 
 1. Minimal — only the specific file/function mentioned (recommended)
 2. Module-level — refactor the entire module for consistency
 3. Cross-cutting — follow the pattern change across the codebase
 4. Let me specify the boundary
-```
 
 ## Probes (select 2)
 
-### Behaviour Preservation
-
-```text
-How will you verify that behaviour hasn't changed?
+**Behaviour Preservation** — How will you verify that behaviour hasn't changed?
 
 1. Existing tests cover it — they must all pass (recommended)
 2. No tests exist — I'll add them before refactoring
 3. Manual testing against specific scenarios
 4. Type system / compiler will catch regressions
-```
 
-### Outside View
-
-```text
-Refactors of this scope in this codebase typically follow [detected pattern].
-Should this refactor:
+**Outside View** — Refactors of this scope in this codebase typically follow [detected pattern]. Should this refactor:
 
 1. Follow the same approach (recommended — consistency)
 2. Establish a new pattern — here's why: [user explains]
 3. I'm not sure what the existing pattern is
-```
 
-### Pre-mortem
-
-```text
-Imagine this refactor is merged and something breaks in production.
-What's the most likely cause?
+**Pre-mortem** — Refactor is merged and something breaks in production. Most likely cause?
 
 1. A code path that wasn't covered by tests (recommended)
 2. Subtle behaviour change in edge cases
 3. Performance regression under load
 4. Downstream consumers that depend on internal implementation details
-```
 
-### Assumption Surfacing
-
-```text
-I'm assuming this refactor should NOT change the public API / interface.
-Is that correct?
+**Assumption Surfacing** — This refactor should NOT change the public API / interface. Correct?
 
 1. Correct — internal changes only (recommended)
 2. No — the API should change too (this might be a feature, not a refactor)
 3. The API can change if callers are updated in the same PR
-```
 
-### Domain Grounding
-
-```text
-The [language/framework] community typically recommends [pattern] for this kind of restructuring.
-Does that apply here?
+**Domain Grounding** — The [language/framework] community typically recommends [pattern] for this kind of restructuring. Does that apply here?
 
 1. Yes — follow the standard approach (recommended)
 2. Partially — adapt it because [reason]
 3. No — this codebase has its own conventions
-```
 
 ## Sufficiency Test
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/reference/define-probes/refactor.md` (111 → 79 lines, 29% reduction) by aligning structure with sibling files `feature.md` and `docs.md`.

## Issue
Closes #14170

## Files Changed
- `.agents/reference/define-probes/refactor.md` — prose tightened, structure aligned

## Changes Made
- Renamed `## Structured Questions` → `## Required Questions` (consistent with `feature.md`, `docs.md`)
- Converted `text` fenced code blocks to inline bold format for required questions and probes
- Tightened probe framing: removed verbose setup sentences ("Imagine this refactor is merged and..."), kept questions direct
- Tightened "Apply these unless the user overrides during interview" → "Apply unless user overrides"

## Content Preservation
All institutional knowledge preserved:
- All 5 probes: Behaviour Preservation, Outside View, Pre-mortem, Assumption Surfacing, Domain Grounding
- All options within each probe (including recommended markers)
- Default Assumptions (4 rules) unchanged
- Sufficiency Test (4 questions) unchanged
- Required Questions: Primary Goal (5 options) + Scope Boundary (4 options) unchanged

## Testing
Risk: **Low** — docs/agent prompt only, no code execution paths. Agent behaviour unchanged: same questions, same options, same structure. `self-assessed`.

## Runtime Testing
`self-assessed` — Low risk: agent prompt file, no runnable code, no API endpoints, no state changes.

---
[aidevops.sh](https://aidevops.sh) v3.5.636 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 4,258 tokens on this as a headless worker.