### PR TITLE
GH#15497: tighten cloudron-app-publishing-skill.md prose

### DIFF
--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -56,7 +56,7 @@ cloudron versions add        # add version to catalog
 | `cloudron build push --id <id>` | Push a remote build to a registry |
 | `cloudron build status --id <id>` | Check status of a remote build |
 
-On first run, prompts for the Docker repository (e.g. `registry/username/myapp`). Remembers it for subsequent runs.
+First run prompts for Docker repository (e.g. `registry/username/myapp`) — saved for subsequent runs.
 
 ## Versions Commands
 
@@ -71,10 +71,10 @@ On first run, prompts for the Docker repository (e.g. `registry/username/myapp`)
 
 ## Distribution
 
-Host `CloudronVersions.json` at any public URL (static host, git repo, web server).
+Host `CloudronVersions.json` at any public URL (static host, git repo, web server):
 
-- **Dashboard** -- Add URL under Community apps in dashboard settings. Updates appear automatically.
-- **CLI** -- `cloudron install --versions-url <url>`
+- **Dashboard**: add URL under Community apps in dashboard settings — updates appear automatically
+- **CLI**: `cloudron install --versions-url <url>`
 
 ## Community Packages (9.1+)
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/deployment/cloudron-app-publishing-skill.md` per `build-agent.md` guidance.

## Issue
Closes #15497

## Files Changed
- `.agents/tools/deployment/cloudron-app-publishing-skill.md` — 4 lines changed

## Changes
- Distribution section: colon after intro sentence (leads into list), merged "Updates appear automatically" into the Dashboard bullet, consistent `--` → `:` dash style
- Build Commands note: tightened from 2 sentences to 1 (same information, less words)

## Classification
Instruction doc (not reference corpus) — prose tightening applied, no content removed.

## Testing
- All code blocks, URLs, command examples, and manifest field list preserved
- No task IDs or issue refs in this file — N/A
- Agent behaviour unchanged: same commands, same rules, same workflow

## Runtime Testing
Risk: **Low** — docs/agent prompt only. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.636 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,102 tokens on this as a headless worker.