### PR TITLE
GH#15702: tighten Content Editor agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -177,6 +177,12 @@
       "passes": 1,
       "pr": 11616
     },
+    ".agents/content/editor.md": {
+      "at": "2026-04-02T16:30:00Z",
+      "hash": "1b10ff74a546e869506efa2abe19f9f34eb56ad6",
+      "passes": 1,
+      "pr": null
+    },
     ".agents/content/VERIFICATION.md": {
       "at": "2026-03-30T03:34:30Z",
       "hash": "f0090056bf6625c2ce2c676d4cf9ba25a901198e",

--- a/.agents/content/editor.md
+++ b/.agents/content/editor.md
@@ -15,37 +15,30 @@ Transform technically accurate content into human-sounding, engaging articles. C
 
 ### 1. Voice and Personality (0-100)
 
-- Consistent tone; author personality showing through
-- Conversational elements (questions, asides); unique perspective
-- Avoidance of generic filler
+Consistent tone with author personality; conversational elements (questions, asides); unique perspective; avoidance of generic filler.
 
 ### 2. Specificity (0-100)
 
-- Concrete examples vs vague claims; real data with sources
-- Named tools, companies, or people
-- Specific numbers ("40% increase" not "significant improvement")
+Concrete examples vs vague claims; real data with sources; named tools/companies/people; specific numbers ("40% increase" not "significant improvement").
 
 ### 3. Readability and Flow (0-100)
 
-- Varied sentence length; smooth transitions; logical progression
-- Active voice predominance; paragraph rhythm
+Varied sentence length; smooth transitions; logical progression; active voice predominance; paragraph rhythm.
 
 ### 4. Robotic vs Human Patterns
 
 - **AI vocabulary**: delve, tapestry, landscape, leverage, utilize, facilitate
 - **Filler phrases**: "It's worth noting that", "In today's digital age"
-- **Rule of three**: Excessive use of three-item lists
-- **Em dash overuse**: More than 2-3 per article
+- **Rule of three**: Excessive three-item lists
+- **Em dash overuse**: >2-3 per article
 - **Hedging**: "might", "could potentially", "it's possible that"
 - **Promotional language**: "game-changer", "revolutionary", "cutting-edge"
 
-See `content/humanise.md` for the complete pattern list.
+See `content/humanise.md` for complete patterns.
 
 ### 5. Engagement and Storytelling
 
-- Hook in the introduction; anecdotes or real-world examples
-- Questions that engage the reader; surprising or counterintuitive points
-- Strong conclusion with clear takeaway
+Hook in introduction; anecdotes or real-world examples; reader-engaging questions; surprising/counterintuitive points; strong conclusion with clear takeaway.
 
 ## Output Format
 
@@ -60,7 +53,7 @@ See `content/humanise.md` for the complete pattern list.
    **Why**: [explanation]
 
 ### Pattern Analysis
-- AI vocabulary found: [list]
+- AI vocabulary: [list]
 - Filler phrases: [count]
 - Passive voice: [percentage]
 - Hedging instances: [count]
@@ -68,10 +61,9 @@ See `content/humanise.md` for the complete pattern list.
 ### Section-by-Section Notes
 - Introduction: [feedback]
 - Section 2: [feedback]
-- ...
 
 ### Specific Rewrites
-[3-5 before/after examples targeting the weakest sections]
+[3-5 before/after examples targeting weakest sections]
 ```
 
 ## Related


### PR DESCRIPTION
Simplified .agents/content/editor.md (81→73 lines, 10% reduction) by tightening prose while preserving all institutional knowledge.

## Changes

- **Analysis Dimensions**: Converted verbose bullet lists to concise prose (dimensions 1-3, 5)
- **Robotic Patterns**: Simplified descriptions (e.g., 'More than 2-3 per article' → '>2-3 per article')
- **Output Format**: Removed redundant placeholder text and tightened section descriptions

## Verification

✓ All content preserved:
- All 5 analysis dimensions intact
- All AI vocabulary patterns listed
- All filler phrases and hedging examples present
- Output format template complete
- Related links unchanged

✓ No functionality loss — agent behavior unchanged

Closes #15702