### PR TITLE
GH#15532: tighten bing-webmaster-tools.md agent doc

### DIFF
--- a/.agents/seo/bing-webmaster-tools.md
+++ b/.agents/seo/bing-webmaster-tools.md
@@ -10,8 +10,6 @@ tools:
   grep: true
 ---
 
-# Bing Webmaster Tools Integration
-
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

Tighten `.agents/seo/bing-webmaster-tools.md` per issue #15532 (agent doc simplification).

**Classification:** Instruction doc (API operations, setup, troubleshooting) — not a reference corpus.

**Changes:**
- Removed redundant `# Bing Webmaster Tools Integration` H1 heading (already captured in frontmatter `description` field)
- 96 → 94 lines
- All code blocks, URLs, command examples, troubleshooting table, and integration note preserved
- Markdownlint clean (0 errors)

**Verification:**
- `npx markdownlint-cli2 .agents/seo/bing-webmaster-tools.md` → 0 errors
- `wc -l` → 94 lines (was 96)
- All operational content intact: 6 API operations, setup steps, troubleshooting table, SEO audit integration note

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. Self-assessed.

Closes #15532

---
[aidevops.sh](https://aidevops.sh) v3.5.647 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 7,185 tokens on this as a headless worker.