### PR TITLE
GH#15380: decompose create_js_script() into focused section writers

### DIFF
--- a/.agents/scripts/schema-validator-helper.sh
+++ b/.agents/scripts/schema-validator-helper.sh
@@ -90,10 +90,9 @@ install_deps() {
 	return 0
 }
 
-# Create the validation JS script
-create_js_script() {
-	mkdir -p "$TOOL_DIR"
-	cat >"$JS_SCRIPT" <<'JSEOF'
+# Write JS imports and fetch initialisation block
+_write_js_imports() {
+	cat >>"$JS_SCRIPT" <<'JSEOF'
 import Validator from '@adobe/structured-data-validator';
 import WebAutoExtractor from '@marbec/web-auto-extractor';
 import fs from 'fs';
@@ -111,6 +110,13 @@ if (!fetchFn) {
     }
 }
 
+JSEOF
+	return 0
+}
+
+# Write the getSchema() JS function (caches schema.org definition for 24h)
+_write_js_schema_loader() {
+	cat >>"$JS_SCRIPT" <<'JSEOF'
 async function getSchema() {
     const schemaPath = path.join(process.cwd(), 'schemaorg-all-https.jsonld');
 
@@ -140,6 +146,13 @@ async function getSchema() {
     }
 }
 
+JSEOF
+	return 0
+}
+
+# Write the validate() JS function (extracts and validates structured data)
+_write_js_validator() {
+	cat >>"$JS_SCRIPT" <<'JSEOF'
 async function validate(input, isJson) {
     let html = input;
 
@@ -194,6 +207,13 @@ async function validate(input, isJson) {
     }
 }
 
+JSEOF
+	return 0
+}
+
+# Write the CLI entrypoint block (argument parsing and dispatch)
+_write_js_entrypoint() {
+	cat >>"$JS_SCRIPT" <<'JSEOF'
 const args = process.argv.slice(2);
 const command = args[0];
 const target = args[1];
@@ -212,6 +232,17 @@ if (command === 'validate') {
     process.exit(1);
 }
 JSEOF
+	return 0
+}
+
+# Create the validation JS script by composing focused section writers
+create_js_script() {
+	mkdir -p "$TOOL_DIR"
+	: >"$JS_SCRIPT"
+	_write_js_imports || return 1
+	_write_js_schema_loader || return 1
+	_write_js_validator || return 1
+	_write_js_entrypoint || return 1
 	return 0
 }
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Decompose `create_js_script()` in `.agents/scripts/schema-validator-helper.sh` from 125 lines into four focused helper functions, each under 100 lines.

## Issue
Closes #15380

## Files Changed
- `.agents/scripts/schema-validator-helper.sh` — split monolithic JS-script writer into section helpers

## Changes
`create_js_script()` was a 125-line function writing a JavaScript validation script via a single heredoc. Refactored into:

| Function | Lines | Responsibility |
|---|---|---|
| `_write_js_imports()` | 24 | ESM imports + fetch initialisation |
| `_write_js_schema_loader()` | 36 | `getSchema()` — 24h cached schema.org fetch |
| `_write_js_validator()` | 61 | `validate()` — input loading, extraction, validation |
| `_write_js_entrypoint()` | 24 | CLI argument parsing and dispatch |
| `create_js_script()` | 11 | Orchestrator: creates file, calls section writers |

No logic changes — pure structural decomposition. The generated `validate.mjs` output is identical.

## Testing
- `bash -n schema-validator-helper.sh` — syntax clean
- `shellcheck schema-validator-helper.sh` — zero violations
- All functions verified under 100 lines

## Runtime Testing
**Risk level:** Low — docs/scripts/linter config change only. No runtime environment available; `self-assessed`.

## Key Decisions
- Used `_write_js_*` naming convention (leading underscore = private helper) to signal these are not public commands
- Append-mode (`>>`) with empty-file init (`: > "$JS_SCRIPT"`) preserves composability without temp files

---
[aidevops.sh](https://aidevops.sh) v3.5.648 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 6,571 tokens on this as a headless worker.