### PR TITLE
GH#14907: tighten remotion-get-audio-duration.md

### DIFF
--- a/.agents/tools/video/remotion-get-audio-duration.md
+++ b/.agents/tools/video/remotion-get-audio-duration.md
@@ -1,14 +1,12 @@
 ---
 name: get-audio-duration
 mode: subagent
-description: Getting the duration of an audio file in seconds with Mediabunny
-metadata:
-  tags: duration, audio, length, time, seconds, mp3, wav
+description: Get audio file duration in seconds using Mediabunny's Input.computeDuration()
 ---
 
 # Getting audio duration with Mediabunny
 
-Use `Input.computeDuration()` to get audio length in seconds. This works in browser, Node.js, and Bun.
+`Input.computeDuration()` returns audio length in seconds. Works in browser, Node.js, and Bun.
 
 ## URLs and `staticFile()`
 
@@ -37,7 +35,7 @@ const staticDuration = await getAudioDuration(staticFile("audio.mp3"));
 
 ## Local files
 
-Use `FileSource` for browser uploads or drag-and-drop files:
+Use `FileSource` for browser uploads or drag-and-drop:
 
 ```tsx
 import { Input, ALL_FORMATS, FileSource } from "mediabunny";


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/video/remotion-get-audio-duration.md` (51→49 lines) per simplification scan.

## Changes
- Removed non-standard `metadata.tags` frontmatter field
- Tightened `description` to be more precise and action-oriented
- Prose: "Use X to get Y" → "`X` returns Y" (direct)
- Removed redundant "files:" from "drag-and-drop files:"
- All code blocks preserved verbatim

## Issue
Closes #14907

## Testing
- All code blocks, URLs, and command examples present before and after (verified via diff)
- No broken internal links or references
- Agent behaviour unchanged — purely prose/metadata tightening
- Risk: **Low** (docs only, no logic change)

## Runtime Testing
`self-assessed` — docs-only change, no runtime verification required per risk matrix.

---
[aidevops.sh](https://aidevops.sh) v3.5.648 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,248 tokens on this as a headless worker.