### PR TITLE
GH#14894: tighten heygen-skill.md index

### DIFF
--- a/.agents/content/heygen-skill.md
+++ b/.agents/content/heygen-skill.md
@@ -11,46 +11,24 @@ Load when working with HeyGen API code — avatar videos, video generation workf
 
 ## Rule Files
 
-### Foundation
-
-| Rule | Covers |
-|------|--------|
-| [rules-authentication.md](heygen-skill/rules-authentication.md) | API key setup, X-Api-Key header, auth patterns |
-| [rules-quota.md](heygen-skill/rules-quota.md) | Credit system, usage limits, remaining quota |
-| [rules-video-status.md](heygen-skill/rules-video-status.md) | Polling patterns, status types, download URLs |
-| [rules-assets.md](heygen-skill/rules-assets.md) | Uploading images, videos, audio for generation |
-
-### Core Video Creation
-
-| Rule | Covers |
-|------|--------|
-| [rules-avatars.md](heygen-skill/rules-avatars.md) | Avatar listing, styles, avatar_id selection |
-| [rules-voices.md](heygen-skill/rules-voices.md) | Voice listing, locales, speed/pitch config |
-| [rules-scripts.md](heygen-skill/rules-scripts.md) | Script writing, pauses/breaks, pacing, templates |
-| [rules-video-generation.md](heygen-skill/rules-video-generation.md) | POST /v2/video/generate, multi-scene videos |
-| [rules-video-agent.md](heygen-skill/rules-video-agent.md) | One-shot prompt generation via Video Agent API |
-| [rules-dimensions.md](heygen-skill/rules-dimensions.md) | Resolution (720p/1080p), aspect ratios |
-
-### Video Customization
-
-| Rule | Covers |
-|------|--------|
-| [rules-backgrounds.md](heygen-skill/rules-backgrounds.md) | Solid colors, images, video backgrounds |
-| [rules-text-overlays.md](heygen-skill/rules-text-overlays.md) | Text with fonts and positioning |
-| [rules-captions.md](heygen-skill/rules-captions.md) | Auto-generated captions, subtitle options |
-
-### Advanced Features
-
-| Rule | Covers |
-|------|--------|
-| [rules-templates.md](heygen-skill/rules-templates.md) | Template listing, variable replacement |
-| [rules-video-translation.md](heygen-skill/rules-video-translation.md) | Translation, quality/fast modes, dubbing |
-| [rules-streaming-avatars.md](heygen-skill/rules-streaming-avatars.md) | Real-time interactive avatar sessions |
-| [rules-photo-avatars.md](heygen-skill/rules-photo-avatars.md) | Avatars from photos (talking photos) |
-| [rules-webhooks.md](heygen-skill/rules-webhooks.md) | Webhook endpoints, event types |
-
-### Integration
-
-| Rule | Covers |
-|------|--------|
-| [rules-remotion-integration.md](heygen-skill/rules-remotion-integration.md) | HeyGen avatar videos in Remotion compositions |
+| Rule | Category | Covers |
+|------|----------|--------|
+| [rules-authentication.md](heygen-skill/rules-authentication.md) | Foundation | API key setup, X-Api-Key header, auth patterns |
+| [rules-quota.md](heygen-skill/rules-quota.md) | Foundation | Credit system, usage limits, remaining quota |
+| [rules-video-status.md](heygen-skill/rules-video-status.md) | Foundation | Polling patterns, status types, download URLs |
+| [rules-assets.md](heygen-skill/rules-assets.md) | Foundation | Uploading images, videos, audio for generation |
+| [rules-avatars.md](heygen-skill/rules-avatars.md) | Core | Avatar listing, styles, avatar_id selection |
+| [rules-voices.md](heygen-skill/rules-voices.md) | Core | Voice listing, locales, speed/pitch config |
+| [rules-scripts.md](heygen-skill/rules-scripts.md) | Core | Script writing, pauses/breaks, pacing, templates |
+| [rules-video-generation.md](heygen-skill/rules-video-generation.md) | Core | POST /v2/video/generate, multi-scene videos |
+| [rules-video-agent.md](heygen-skill/rules-video-agent.md) | Core | One-shot prompt generation via Video Agent API |
+| [rules-dimensions.md](heygen-skill/rules-dimensions.md) | Core | Resolution (720p/1080p), aspect ratios |
+| [rules-backgrounds.md](heygen-skill/rules-backgrounds.md) | Customization | Solid colors, images, video backgrounds |
+| [rules-text-overlays.md](heygen-skill/rules-text-overlays.md) | Customization | Text with fonts and positioning |
+| [rules-captions.md](heygen-skill/rules-captions.md) | Customization | Auto-generated captions, subtitle options |
+| [rules-templates.md](heygen-skill/rules-templates.md) | Advanced | Template listing, variable replacement |
+| [rules-video-translation.md](heygen-skill/rules-video-translation.md) | Advanced | Translation, quality/fast modes, dubbing |
+| [rules-streaming-avatars.md](heygen-skill/rules-streaming-avatars.md) | Advanced | Real-time interactive avatar sessions |
+| [rules-photo-avatars.md](heygen-skill/rules-photo-avatars.md) | Advanced | Avatars from photos (talking photos) |
+| [rules-webhooks.md](heygen-skill/rules-webhooks.md) | Advanced | Webhook endpoints, event types |
+| [rules-remotion-integration.md](heygen-skill/rules-remotion-integration.md) | Integration | HeyGen avatar videos in Remotion compositions |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Consolidate 4 separate grouped tables in `.agents/content/heygen-skill.md` into a single flat table with a `Category` column.

**56 → 34 lines (39% reduction).** All 19 rule file links, all `Covers` descriptions, and all category groupings preserved.

## Issue
Closes #14894

## Files Changed
- `.agents/content/heygen-skill.md` — 4 tables → 1 table with Category column

## Testing
- All 19 rule file links verified present before and after
- All `Covers` descriptions preserved verbatim
- Category groupings (Foundation, Core, Customization, Advanced, Integration) preserved as table column
- No broken internal links — all paths relative to `heygen-skill/` unchanged

## Key Decisions
- Flat table with Category column preferred over section headers + repeated table headers — same information, fewer lines, easier to scan
- File classified as instruction doc index (not reference corpus) — prose tightening appropriate per code-simplifier guidance

## Runtime Testing
Risk: **Low** — agent doc index only, no code, no commands, no executable content. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.648 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 4,388 tokens on this as a headless worker.