### PR TITLE
GH#15039: tighten agent doc dspyground.md

### DIFF
--- a/.agents/tools/context/dspyground.md
+++ b/.agents/tools/context/dspyground.md
@@ -39,14 +39,12 @@ Voice feedback: hold spacebar in feedback dialogs to record; auto-transcribed.
 ```bash
 ./.agents/scripts/dspyground-helper.sh install
 cp configs/dspyground-config.json.txt configs/dspyground-config.json
-
-# Create project and start dev server
 ./.agents/scripts/dspyground-helper.sh init my-agent
 ./.agents/scripts/dspyground-helper.sh dev my-agent
 # or from project dir: dspyground dev
 ```
 
-**Environment (`.env`):**
+`.env`:
 
 ```bash
 AI_GATEWAY_API_KEY=your_key_here


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/context/dspyground.md` per GH#15039 simplification scan.

## Changes
- Removed redundant `# Create project and start dev server` comment (obvious from context)
- Replaced `**Environment (.env):**` decorative bold header with plain `` `.env`: `` label

## Preservation check
- All code blocks: present ✓
- All URLs (GitHub, docs, arxiv): present ✓
- All command examples: present ✓
- All functional content: present ✓
- Line count: 105 → 103 (−2 lines)

## Issue
Closes #15039

## Testing
**Risk level:** Low — docs/agent prompt only, no executable code changed.
**Runtime Testing:** `self-assessed` — markdown-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.652 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,422 tokens on this as a headless worker.