### PR TITLE
GH#15040: record workers-ai.md simplification in state

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4461,6 +4461,12 @@
       "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
       "passes": 1,
       "pr": 15470
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workers-ai.md": {
+      "at": "2026-03-31T21:50:56Z",
+      "hash": "2058e3a56f898cc7c88fa9b3aef16261c9f7030a",
+      "passes": 1,
+      "pr": 14806
     }
   },
   "status": "done",


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## Summary

- `workers-ai.md` was already simplified from 116 → 15 lines in PR #14806 (merged 2026-03-31), but the `simplification-state.json` entry was never recorded.
- This PR adds the missing state entry so the complexity scanner recognises the file as converged and stops re-flagging it for re-dispatch.
- No content changes — state bookkeeping only.

## What

Added `.agents/services/hosting/cloudflare-platform-skill/workers-ai.md` to `simplification-state.json` with `passes: 1`, `pr: 14806`, and the current file hash.

## Issue

Closes #15040

## Files Changed

- `.agents/configs/simplification-state.json` — added 1 entry (6 lines)

## Testing

- Verified `workers-ai.md` is 15 lines (already simplified)
- Verified git history: `cad3c0db6` — "docs: tighten workers-ai.md (116 -> 15 lines, 87% reduction)"
- Verified PR #14806 merged 2026-03-31
- State entry format matches all neighbouring entries

## Runtime Testing

**Risk level:** Low — state JSON bookkeeping, no executable code changed.
**Verification:** `self-assessed` — JSON structure validated, hash matches current file.

## Key Decisions

- Recorded `at` timestamp as the PR #14806 merge date (2026-03-31T21:50:56Z) for accurate history.
- Used `passes: 1` (not 3/converged) since the file is at 15 lines and genuinely done — the scanner will see it as simplified and skip it.

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 5,461 tokens on this as a headless worker.