### PR TITLE
GH#14091: tighten rapidfuzz.md — consolidate Core Functions code blocks

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4480,5 +4480,11 @@
       "pr": 15470
     }
   },
-  "status": "done"
+  "status": "done",
+  ".agents/tools/context/rapidfuzz.md": {
+    "hash": "f06e2a2bf6fc561deeaff84f8ec5389eb942307d89902687e82d9c4c31e1c9cf",
+    "issue": "GH#14091",
+    "status": "simplified",
+    "note": "Consolidated 4 fragmented fuzz.* code blocks into 1 cohesive block. 121 -> 104 lines. All content preserved."
+  }
 }

--- a/.agents/tools/context/rapidfuzz.md
+++ b/.agents/tools/context/rapidfuzz.md
@@ -27,31 +27,14 @@ tools:
 
 ## Core Functions
 
-### Simple Ratio (character-level similarity)
-
 ```python
 from rapidfuzz import fuzz
 
-fuzz.ratio("fuzzy wuzzy", "fuzzy wuzzy")       # 100.0
-fuzz.ratio("fuzzy wuzzy", "fzzy wzzy")         # ~84.2
-```
-
-### Partial Ratio (substring matching)
-
-```python
-fuzz.partial_ratio("fuzzy wuzzy", "wuzzy")     # 100.0
-```
-
-### Token Sort Ratio (order-independent)
-
-```python
-fuzz.token_sort_ratio("New York Mets", "Mets New York")  # 100.0
-```
-
-### Token Set Ratio (handles duplicates and extras)
-
-```python
-fuzz.token_set_ratio(
+fuzz.ratio("fuzzy wuzzy", "fuzzy wuzzy")                  # 100.0  — character-level similarity
+fuzz.ratio("fuzzy wuzzy", "fzzy wzzy")                    # ~84.2
+fuzz.partial_ratio("fuzzy wuzzy", "wuzzy")                # 100.0  — substring matching
+fuzz.token_sort_ratio("New York Mets", "Mets New York")   # 100.0  — order-independent
+fuzz.token_set_ratio(                                      # handles duplicates and extras
     "fuzzy wuzzy was a bear",
     "fuzzy fuzzy was a bear"
 )  # High score despite differences


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/context/rapidfuzz.md` per simplification issue GH#14091.

**Classification:** Reference corpus (code examples + API reference). At 121 lines, splitting into chapters would add overhead without benefit. Applied instruction-doc tightening: consolidate fragmented code blocks.

**Change:** Consolidated 4 separate `fuzz.*` code blocks (each with its own H3 heading and standalone code fence) into 1 cohesive block with inline comments. 121 → 104 lines.

## Issue
Closes #14091

## Files Changed
- `.agents/tools/context/rapidfuzz.md` — 121 → 104 lines, Core Functions consolidated
- `.agents/configs/simplification-state.json` — registered simplified hash

## Testing
**Risk level:** Low (docs/agent prompts — no runtime behaviour changed)

**Runtime Testing:** `self-assessed` — agent reference doc, no executable code paths affected. Content preservation verified: all code blocks, URLs, and examples present before and after.

**Verification:**
- All 5 `fuzz.*` function examples preserved (ratio, ratio variant, partial_ratio, token_sort_ratio, token_set_ratio)
- Process module, Distance Functions, Performance Tips, Common Patterns, Related sections unchanged
- No task IDs, incident references, or decision rationale removed

## Key Decisions
- Classified as reference corpus (not instruction doc) — no content compression, only structural consolidation
- Kept `bash: true` in frontmatter (needed for running code examples)
- Did not split into chapters — 104 lines is well under the ~300-line threshold

---
[aidevops.sh](https://aidevops.sh) v3.5.654 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,937 tokens on this as a headless worker.