### PR TITLE
GH#14072: tighten agent doc Automate - Scheduling & Orchestration Agent

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -47,9 +47,8 @@ Never use raw `opencode run` or `claude` CLI — always use the headless runtime
   --title "Issue #NUMBER: TITLE" \
   --prompt "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" &
 sleep 2  # between dispatches
-# Do NOT add --model unless escalating after 2+ failures (then: --model anthropic/claude-opus-4-6)
-# Helper handles round-robin, backoff, session persistence
-# Validate launch after each dispatch; re-dispatch immediately on failure
+# --model only for escalation after 2+ failures: --model anthropic/claude-opus-4-6
+# Helper handles round-robin, backoff, session persistence; validate launch, re-dispatch on failure
 ```
 
 ## Agent Routing
@@ -113,7 +112,7 @@ export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-code
 ```
 
 **Backoff:** `headless-runtime-helper.sh backoff status` / `backoff clear PROVIDER`. Exit code 75 = all providers backed off.
-**Escalation:** After 2+ failed attempts on same issue, use `--model anthropic/claude-opus-4-6`. One opus dispatch (~3x cost) is cheaper than 5+ failed sonnet dispatches.
+**Escalation:** After 2+ failed attempts, use `--model anthropic/claude-opus-4-6`. One opus dispatch (~3x cost) is cheaper than 5+ failed sonnet dispatches.
 
 ## Audit Trail
 


### PR DESCRIPTION
## Summary

Tighten `.agents/automate.md` per simplification issue GH#14072.

- Merged 3 dispatch code block comments into 2 (no information loss)
- Removed redundant "on same issue" qualifier from escalation rule (context is already per-issue)
- 124 → 123 lines

All institutional knowledge preserved: GH#15317 reference, struggle/thrashing ratios, escalation cost rationale, env var gotcha, `config_get()` key, external contributor merge gate.

Closes #14072

## Runtime Testing

**Risk level:** Low — agent doc only, no code changes.
**Verification:** All code blocks, URLs, task ID refs (GH#15317), and command examples present before and after (verified via `grep`).

---
[aidevops.sh](https://aidevops.sh) v3.5.654 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 4,978 tokens on this as a headless worker.