### PR TITLE
GH#14108: tighten crawl4ai-usage.md (167→142 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -32,6 +32,11 @@
     "issue": "GH#15033",
     "status": "simplified"
   },
+  ".agents/tools/browser/crawl4ai-usage.md": {
+    "hash": "067ef0de4d0805ad316a0693c50dd2f6823fa63dc704b66db88d758db34119a3",
+    "issue": "GH#14108",
+    "status": "simplified"
+  },
   ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
     "hash": "edecc25afbace885cab2eac01e07629d890a4fad",
     "issue": "GH#15700",

--- a/.agents/tools/browser/crawl4ai-usage.md
+++ b/.agents/tools/browser/crawl4ai-usage.md
@@ -30,16 +30,16 @@ tools:
 
 ## Setup
 
-\`\`\`bash
+```bash
 ./.agents/scripts/crawl4ai-helper.sh install
 ./.agents/scripts/crawl4ai-helper.sh docker-setup
 ./.agents/scripts/crawl4ai-helper.sh docker-start
 ./.agents/scripts/crawl4ai-helper.sh mcp-setup   # MCP server for AI assistants
-\`\`\`
+```
 
 ## Core Operations
 
-\`\`\`bash
+```bash
 # Crawl (markdown or html)
 ./.agents/scripts/crawl4ai-helper.sh crawl https://example.com markdown output.json
 ./.agents/scripts/crawl4ai-helper.sh crawl https://example.com html output.json
@@ -64,13 +64,18 @@ for url in "${urls[@]}"; do
     ./.agents/scripts/crawl4ai-helper.sh crawl "$url" markdown "output-$(date +%s).json"
     sleep 2
 done
-\`\`\`
+
+# Crawl → PDF via pandoc (write to temp file; pandoc-helper.sh requires a real file path)
+./.agents/scripts/crawl4ai-helper.sh crawl https://docs.com markdown docs.json
+jq -r '.results[0].markdown' docs.json > /tmp/docs-crawl.md
+./.agents/scripts/pandoc-helper.sh convert /tmp/docs-crawl.md pdf docs.pdf
+```
 
 ## AI Assistant Integration
 
 ### MCP (Claude Desktop)
 
-\`\`\`json
+```json
 {
   "mcpServers": {
     "crawl4ai": {
@@ -79,47 +84,28 @@ done
     }
   }
 }
-\`\`\`
+```
 
 ### REST API (other assistants)
 
-\`\`\`python
-import requests
-response = requests.post("http://localhost:11235/crawl", json={
-    "urls": ["https://example.com"],
-    "crawler_config": {
-        "type": "CrawlerRunConfig",
-        "params": {"cache_mode": "bypass"}
-    }
-})
-\`\`\`
+```bash
+curl -s -X POST http://localhost:11235/crawl \
+  -H "Content-Type: application/json" \
+  -d '{"urls":["https://example.com"],"crawler_config":{"type":"CrawlerRunConfig","params":{"cache_mode":"bypass"}}}' \
+  | jq -r '.results[0].markdown'
+```
 
 ## Output Processing
 
-\`\`\`json
-{
-  "success": true,
-  "results": [{
-    "url": "https://example.com",
-    "markdown": "# Page Title\n\nContent...",
-    "html": "<html>...</html>",
-    "extracted_content": {},
-    "links": {},
-    "media": {},
-    "metadata": {}
-  }]
-}
-\`\`\`
-
-\`\`\`bash
+```bash
 jq -r '.results[0].markdown' output.json > content.md
 jq '.results[0].extracted_content' output.json > data.json
 jq -r '.results[0].links.internal[]' output.json
-\`\`\`
+```
 
 ## Configuration
 
-\`\`\`bash
+```bash
 # Performance (high-volume)
 export CRAWL4AI_CONCURRENT_REQUESTS=5
 export CRAWL4AI_BROWSER_POOL_SIZE=3
@@ -129,7 +115,7 @@ export CRAWL4AI_MEMORY_THRESHOLD=90
 export LLM_PROVIDER=openai/gpt-4o-mini
 export CRAWL4AI_MAX_PAGES=50
 export CRAWL4AI_TIMEOUT=60
-\`\`\`
+```
 
 ## Security
 
@@ -141,11 +127,9 @@ export CRAWL4AI_TIMEOUT=60
 
 ## Monitoring & Debugging
 
-\`\`\`bash
+```bash
 ./.agents/scripts/crawl4ai-helper.sh status
-docker ps | grep crawl4ai
 curl -s http://localhost:11235/health | jq '.'
-
 docker logs crawl4ai --tail 50
 ./.agents/scripts/crawl4ai-helper.sh docker-stop && ./.agents/scripts/crawl4ai-helper.sh docker-start
 
@@ -153,15 +137,6 @@ docker logs crawl4ai --tail 50
 curl -X POST http://localhost:11235/crawl \
   -H "Content-Type: application/json" \
   -d '{"urls": ["https://httpbin.org/html"]}'
-\`\`\`
+```
 
 Endpoints: `/dashboard` | `/playground` | `/schema` | `/metrics`
-
-## Integration
-
-\`\`\`bash
-# Crawl → PDF via pandoc (write to temp file; pandoc-helper.sh requires a real file path)
-./.agents/scripts/crawl4ai-helper.sh crawl https://docs.com markdown docs.json
-jq -r '.results[0].markdown' docs.json > /tmp/docs-crawl.md
-./.agents/scripts/pandoc-helper.sh convert /tmp/docs-crawl.md pdf docs.pdf
-\`\`\`


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
**What:** Tighten `.agents/tools/browser/crawl4ai-usage.md` from 167 → 142 lines (-15%)

**Issue:** Closes #14108

**Files changed:** `.agents/tools/browser/crawl4ai-usage.md`, `.agents/configs/simplification-state.json`

**Changes:**
- Fold Integration section into Core Operations (pandoc note preserved with rationale)
- Replace Python REST example with bash curl (same information, fewer lines)
- Remove illustrative JSON output schema (bash jq examples cover the same ground)
- Remove redundant `docker ps | grep crawl4ai` (status command covers it)
- Update `simplification-state.json` with new hash

**Testing Evidence:**
All key references verified present: `crawl4ai-helper.sh`, `pandoc-helper.sh`, `aidevops secret set`, `crawl4ai-integration.md`, `docs.crawl4ai.com`, `crawl4ai-mcp-server`, `crawl4ai-config.json.txt`, `crawl4ai-mcp-config.json`, `OPENAI_API_KEY`, `redis-cli FLUSHALL`, `httpbin.org`

**Runtime Testing:** Risk: **Low** — docs/agent prompt only, no code changes. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.654 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,545 tokens on this as a headless worker.