### PR TITLE
GH#14101: tighten agent doc Cloudflare Pulumi Provider (119→94 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pulumi.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pulumi.md
@@ -1,18 +1,8 @@
 # Cloudflare Pulumi Provider
 
-Expert guidance for Cloudflare Pulumi Provider (@pulumi/cloudflare).
+Programmatic management of Cloudflare resources via `@pulumi/cloudflare` v6.x: Workers, Pages, D1, KV, R2, DNS, Queues, etc.
 
-## Overview
-
-Programmatic management of Cloudflare resources: Workers, Pages, D1, KV, R2, DNS, Queues, etc.
-
-**Packages:**
-- TypeScript/JS: `@pulumi/cloudflare`
-- Python: `pulumi-cloudflare`
-- Go: `github.com/pulumi/pulumi-cloudflare/sdk/v6/go/cloudflare`
-- .NET: `Pulumi.Cloudflare`
-
-**Version:** v6.x
+**Packages:** TypeScript/JS: `@pulumi/cloudflare` | Python: `pulumi-cloudflare` | Go: `github.com/pulumi/pulumi-cloudflare/sdk/v6/go/cloudflare` | .NET: `Pulumi.Cloudflare`
 
 ## Core Principles
 
@@ -24,40 +14,31 @@ Programmatic management of Cloudflare resources: Workers, Pages, D1, KV, R2, DNS
 
 ## Authentication
 
-Three methods (mutually exclusive):
+Three methods (mutually exclusive). Preferred: API Token.
 
-**1. API Token (Recommended)**
+| Method | Env vars |
+|--------|----------|
+| API Token (recommended) | `CLOUDFLARE_API_TOKEN` |
+| API Key (legacy) | `CLOUDFLARE_API_KEY`, `CLOUDFLARE_EMAIL` |
+| API User Service Key | `CLOUDFLARE_API_USER_SERVICE_KEY` |
 
 ```typescript
-import * as cloudflare from "@pulumi/cloudflare";
-
+// API Token (recommended)
 const provider = new cloudflare.Provider("cf", {
     apiToken: process.env.CLOUDFLARE_API_TOKEN,
 });
-```
 
-Env: `CLOUDFLARE_API_TOKEN`
-
-**2. API Key (Legacy)**
-
-```typescript
+// API Key (legacy)
 const provider = new cloudflare.Provider("cf", {
     apiKey: process.env.CLOUDFLARE_API_KEY,
     email: process.env.CLOUDFLARE_EMAIL,
 });
-```
 
-Env: `CLOUDFLARE_API_KEY`, `CLOUDFLARE_EMAIL`
-
-**3. API User Service Key**
-
-```typescript
+// API User Service Key
 const provider = new cloudflare.Provider("cf", {
     apiUserServiceKey: process.env.CLOUDFLARE_API_USER_SERVICE_KEY,
 });
 ```
-
-Env: `CLOUDFLARE_API_USER_SERVICE_KEY`
 
 ## Setup
 
@@ -71,7 +52,7 @@ config:
     value: ${CLOUDFLARE_API_TOKEN}
 ```
 
-**Pulumi.<stack>.yaml:**
+**Pulumi.\<stack\>.yaml:**
 
 ```yaml
 config:
@@ -86,13 +67,6 @@ import * as cloudflare from "@pulumi/cloudflare";
 
 const config = new pulumi.Config("cloudflare");
 const accountId = config.require("accountId");
-```
-
-## Essential Imports
-
-```typescript
-import * as pulumi from "@pulumi/pulumi";
-import * as cloudflare from "@pulumi/cloudflare";
 ```
 
 ## Common Resource Types
@@ -116,4 +90,5 @@ import * as cloudflare from "@pulumi/cloudflare";
 - `*Bindings` - Connect resources to Workers
 
 ---
+
 See: [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/pulumi.md` from 119 to 94 lines (21% reduction) with zero content loss.

## Issue
Closes #14101

## Changes
- Remove redundant `## Overview` header (intro line already covers it)
- Consolidate 4-line packages list to single pipe-separated line
- Add auth method table for quick env var reference
- Merge 3 separate auth code blocks (each with duplicate `import` statement) into one block with inline comments
- Remove standalone `## Essential Imports` section (imports already shown in Setup's `index.ts` block)

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/pulumi.md` (119→94 lines)

## Testing
**Risk level:** Low — agent doc only, no code execution paths.

All content verified present before and after:
- All 3 auth methods with env vars ✓
- All code blocks ✓
- All resource types (10 items) ✓
- All key properties (4 items) ✓
- Links to `patterns.md` and `gotchas.md` ✓
- Core principles (5 items) ✓
- `markdownlint-cli2`: 0 errors ✓

## Runtime Testing
`self-assessed` — Low risk (docs only, no runtime execution).

---
[aidevops.sh](https://aidevops.sh) v3.5.654 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 4,420 tokens on this as a headless worker.