### PR TITLE
GH#15068: simplification review — landing-pages swipe file index already done

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -812,7 +812,13 @@
       "passes": 1,
       "pr": 12753
     },
-    ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
+    ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md": {
+    "hash": "08f939130363372a3f8667c083bb0d46e0cfed5b619406b76d42730490934237",
+    "issue": "GH#15068",
+    "note": "Reference corpus already split into 5 chapter files (01-saas-examples.md through 05-guarantees-and-design-principles.md). Index is 30 lines; chapters total 163 lines. No further action needed.",
+    "status": "done"
+  },
+  ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
       "at": "2026-04-01T20:59:28Z",
       "hash": "ab1f9c5d69340fa7acfd756c2ae37710b9fa600c",
       "passes": 1,


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What

Reviewed `.agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md` for simplification per GH#15068.

**Finding:** The file was already a 30-line slim index pointing to 5 chapter files before this issue was created. No content changes were needed.

- Index: 30 lines
- Chapter files: 163 lines total across 5 files
- Total: 193 lines (well-structured reference corpus split)

## Action Taken

Registered the file in `.agents/configs/simplification-state.json` with `status: done` and a note explaining the split is already complete. This prevents the automated scanner from re-flagging this file in future runs.

## Files Changed

- `.agents/configs/simplification-state.json` — added entry for landing-pages index

## Testing

- `markdownlint` passes on all 6 files (index + 5 chapters) — zero violations
- JSON validated with `python3 -m json.tool`
- `wc -l` confirms: index 30 lines, chapters 163 lines total

## Runtime Testing

Risk: **Low** — documentation/config only, no code changes.
Assessment: `self-assessed`

Closes #15068

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 6,041 tokens on this as a headless worker.