### PR TITLE
GH#15644: tighten remotion-display-captions.md prose

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4504,5 +4504,10 @@
     "issue": "GH#14091",
     "status": "simplified",
     "note": "Consolidated 4 fragmented fuzz.* code blocks into 1 cohesive block. 121 -> 104 lines. All content preserved."
+  },
+  ".agents/tools/video/remotion-display-captions.md": {
+    "hash": "310c035b5a283b7d2998bcfc657d3d425840ca2aedeb0a4c3651eacc7c0aafd3",
+    "simplified": true,
+    "lines": 121
   }
 }

--- a/.agents/tools/video/remotion-display-captions.md
+++ b/.agents/tools/video/remotion-display-captions.md
@@ -10,27 +10,24 @@ metadata:
 
 Display `Caption[]` data with TikTok-style pages and per-word highlighting.
 
-## Install `@remotion/captions`
+## Install
 
 ```bash
-npx remotion add @remotion/captions # If project uses npm
-bunx remotion add @remotion/captions # If project uses bun
-yarn remotion add @remotion/captions # If project uses yarn
-pnpm exec remotion add @remotion/captions # If project uses pnpm
+npx remotion add @remotion/captions  # npm
+bunx remotion add @remotion/captions  # bun
+yarn remotion add @remotion/captions  # yarn
+pnpm exec remotion add @remotion/captions  # pnpm
 ```
 
 ## 1. Group captions into pages
 
-Use `createTikTokStyleCaptions()` to batch words into timed pages. `combineTokensWithinMilliseconds` controls how many words appear at once.
+`createTikTokStyleCaptions()` batches words into timed pages. `combineTokensWithinMilliseconds` controls words per page (higher = more words, lower = word-by-word).
 
 ```tsx
 import {useMemo} from 'react';
 import {createTikTokStyleCaptions} from '@remotion/captions';
 import type {Caption} from '@remotion/captions';
 
-// How often captions should switch (in milliseconds)
-// Higher values = more words per page
-// Lower values = fewer words (more word-by-word)
 const SWITCH_CAPTIONS_EVERY_MS = 1200;
 
 const CaptionedContent: React.FC<{captions: Caption[]}> = ({captions}) => {
@@ -45,7 +42,7 @@ const CaptionedContent: React.FC<{captions: Caption[]}> = ({captions}) => {
 
 ## 2. Render each page in a `<Sequence>`
 
-Map over `pages` and derive each sequence from the page timing.
+Map over `pages` and derive each sequence from page timing.
 
 ```tsx
 import {Sequence, useVideoConfig, AbsoluteFill} from 'remotion';
@@ -86,7 +83,7 @@ const CaptionedContent: React.FC<{pages: TikTokPage[]}> = ({pages}) => {
 
 ## 3. Highlight the active word
 
-Each page exposes `tokens`, so you can compare the current playback time against `fromMs` and `toMs`.
+Each page exposes `tokens` with `fromMs`/`toMs` — compare against current playback time.
 
 ```tsx
 import {AbsoluteFill, useCurrentFrame, useVideoConfig} from 'remotion';


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/video/remotion-display-captions.md` (124→121 lines). Compress install section header and prose intros while preserving all code blocks, API references, and institutional knowledge.

## Issue
Closes #15644

## Files changed
- `.agents/tools/video/remotion-display-captions.md` — prose tightened, install section header simplified
- `.agents/configs/simplification-state.json` — hash registry updated for this file

## Classification
**Reference corpus** (how-to guide with self-contained code examples). Not an instruction doc. Action: tighten prose, not split or restructure. File is already lean — most lines are code blocks that must be preserved verbatim.

## Changes made
- `## Install \`@remotion/captions\`` → `## Install` (redundant package name in heading)
- Install comments: `# If project uses npm` → `# npm` (inline, concise)
- Section 1 prose: reworded to single sentence with both directions of `combineTokensWithinMilliseconds`
- Section 2 prose: "Map over `pages` and derive each sequence from the page timing" → "Map over `pages` and derive each sequence from page timing" (remove redundant "the")
- Section 3 prose: reworded to reference `fromMs`/`toMs` directly
- Removed verbose inline comments from code (the constant name is self-documenting)

## Testing
**Risk level:** Low (docs/agent prompts only — no runtime behaviour change)
**Verification:** All code blocks present before and after. All API names (`createTikTokStyleCaptions`, `TikTokPage`, `HIGHLIGHT_COLOR`, `fromMs`, `toMs`) preserved. No broken references.

## Runtime Testing
`self-assessed` — docs-only change, no executable code modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 4,866 tokens on this as a headless worker.