### PR TITLE
GH#15104: tighten cloudron-app-packaging-skill.md — compress start.sh conventions

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill.md
@@ -60,12 +60,11 @@ CMD [ "/app/code/start.sh" ]
 
 ### `start.sh` Conventions
 
-- Starts as root; drop privileges with `exec gosu cloudron:cloudron <cmd>`
+- Drop privileges: `exec gosu cloudron:cloudron <cmd>` (e.g. `exec gosu cloudron:cloudron node /app/code/server.js`)
 - Reset ownership on every start: `chown -R cloudron:cloudron /app/data`
-- Forward SIGTERM with `exec`, for example `exec gosu cloudron:cloudron node /app/code/server.js`
-- Gate first-run setup with a marker: `if [[ ! -f /app/data/.initialized ]]; then ...; touch /app/data/.initialized; fi`
-- Log to stdout/stderr; fallback logs go under `/run/<subdir>/*.log` (two levels deep, autorotated)
-- For multiple processes use `supervisor` or `pm2`; see `cloudron-app-packaging.md` "start.sh Architecture"
+- Gate first-run setup: `if [[ ! -f /app/data/.initialized ]]; then ...; touch /app/data/.initialized; fi`
+- Log to stdout/stderr; fallback logs: `/run/<subdir>/*.log` (two levels deep, autorotated)
+- Multiple processes: use `supervisor` or `pm2`; see `cloudron-app-packaging.md` "start.sh Architecture"
 
 ## Manifest Essentials
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/deployment/cloudron-app-packaging-skill.md` (125→124 lines) per GH#15104 simplification scan.

## Changes
- Merged redundant privilege-drop bullets: lines 63 (`Starts as root; drop privileges`) and 65 (`Forward SIGTERM with exec`) both described `exec gosu` — combined into one concrete example
- Compressed `start.sh` bullet preambles: removed verbose lead-ins
- All code blocks, URLs, command examples, env vars, and file references preserved

## Issue
Closes #15104

## Files Changed
- `.agents/tools/deployment/cloudron-app-packaging-skill.md` (1 file, 4 insertions, 5 deletions)

## Testing
**Risk level**: Low — docs/agent prompt only, no runtime behaviour.
**Verification**: All code blocks, URLs (`git.cloudron.io`, `docs.cloudron.io`), command examples (`cloudron logs/exec/debug`), addon env vars, and file references (`manifest-ref.md`, `addons-ref.md`) present before and after. `wc -l` 125→124.

## Key Decisions
- Classified as instruction doc (not reference corpus): file has operational guidance (start.sh conventions, debugging) alongside reference tables; prose tightening is appropriate
- Did not restructure into chapters — file already delegates detail to `manifest-ref.md` and `addons-ref.md`; 124 lines is well within threshold

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 4,121 tokens on this as a headless worker.