### PR TITLE
GH#15165: tighten buzz.md — compress Quick Reference, remove redundant section header

### DIFF
--- a/.agents/tools/voice/buzz.md
+++ b/.agents/tools/voice/buzz.md
@@ -11,23 +11,15 @@ tools:
 # Buzz - Offline Transcription
 
 <!-- AI-CONTEXT-START -->
-
-## Quick Reference
-
-- **Purpose**: Local audio/video transcription with Whisper-family models; no cloud API required
-- **Install**: `brew install --cask buzz` (macOS GUI), `pip install buzz-captions` (CLI), or build from source
-- **Repo**: https://github.com/chidiwilliams/buzz (Python, MIT)
-- **Backends**: Whisper, `faster-whisper`, `whisper.cpp`
-- **When to use**: Privacy-sensitive transcription, subtitle export, offline batch work, quick GUI workflow on macOS
-
+Local audio/video transcription with Whisper-family models; no cloud API required. Use for privacy-sensitive transcription, subtitle export, offline batch work. Repo: https://github.com/chidiwilliams/buzz (Python, MIT). Backends: Whisper, `faster-whisper`, `whisper.cpp`.
 <!-- AI-CONTEXT-END -->
 
 ## Install
 
 ```bash
-brew install --cask buzz
-pip install buzz-captions
-git clone https://github.com/chidiwilliams/buzz && cd buzz && pip install -e .
+brew install --cask buzz          # macOS GUI
+pip install buzz-captions         # CLI
+git clone https://github.com/chidiwilliams/buzz && cd buzz && pip install -e .  # from source
 ```
 
 ## Capabilities
@@ -37,7 +29,7 @@ git clone https://github.com/chidiwilliams/buzz && cd buzz && pip install -e .
 - **Languages**: 100+ via Whisper language support
 - **Extras**: Speaker diarization, subtitle export, automatic audio extraction from video
 
-Use `Buzz` when the requirement is local/private transcription. For provider comparison and cloud options, see `tools/voice/transcription.md`.
+Use Buzz when the requirement is local/private transcription. For provider comparison and cloud options, see `tools/voice/transcription.md`.
 
 ## CLI
 
@@ -60,7 +52,7 @@ buzz transcribe audio.mp3 --model-type faster-whisper --model large-v3
 
 Approximate Whisper model sizes: `tiny` 39MB, `base` 74MB, `small` 244MB, `medium` 769MB, `large-v3` 1.5GB. Typical VRAM: 1GB, 1GB, 2GB, 5GB, 10GB respectively.
 
-## aidevops examples
+## Examples
 
 ```bash
 buzz transcribe meeting.mp4 --model medium --output-format txt > meeting-notes.txt


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/voice/buzz.md` (78 → 70 lines, -10%) per simplification guidelines in GH#15165.

**Changes:**
- Compressed `<!-- AI-CONTEXT-START/END -->` Quick Reference block from 7 lines to 1 inline sentence — eliminates duplication with Install/Capabilities sections below
- Renamed `## aidevops examples` → `## Examples` — "aidevops" prefix is redundant noise in a file that is already an aidevops agent doc
- Added inline comments to Install code block to distinguish the three install methods without a separate prose line
- Removed backtick around `Buzz` in prose (it's a proper noun, not a command)

**Preserved:** All code blocks, URLs, model sizes, VRAM data, CLI examples, Related links, model/backend table.

## Issue
Closes #15165

## Files changed
- `.agents/tools/voice/buzz.md` (78 → 70 lines)

## Testing
- Content preservation verified: all code blocks, URLs, command examples, model sizes present before and after
- Agent behaviour unchanged — same capabilities, install methods, CLI flags, model choices documented

## Key decisions
- Did not remove the model/backend table or VRAM data — this is reference data with clear value
- Did not compress the CLI examples section — each example demonstrates a distinct flag combination
- Kept build-from-source install method — valid use case for contributors

## Runtime Testing
Risk: **Low** (docs/agent prompt only). Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 4,756 tokens on this as a headless worker.