### PR TITLE
GH#15229: tighten meta-ads-creative-frameworks.md heading structure

### DIFF
--- a/.agents/marketing-sales/meta-ads-creative-frameworks.md
+++ b/.agents/marketing-sales/meta-ads-creative-frameworks.md
@@ -23,7 +23,9 @@
 | 30s video | `[HOOK 3s] + [PROBLEM 7s] + [SOLUTION 10s] + [PROOF 5s] + [CTA 5s]` |
 | 60s video | `[HOOK 5s] + [PROBLEM 10s] + [AGITATE 10s] + [SOLUTION 15s] + [PROOF 10s] + [CTA 10s]` |
 
-## PAS — static
+## PAS
+
+### Static
 
 ```text
 PRIMARY TEXT:
@@ -41,7 +43,7 @@ HEADLINE: Automate Data Entry in 5 Minutes
 CTA: Try Free
 ```
 
-## PAS — video 25s
+### Video 25s
 
 ```text
 [0-3s]   "If you're still manually entering data, I need to talk to you."


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Consolidate split PAS sections under a single `## PAS` heading with `### Static` and `### Video 25s` subsections. Fixes inconsistent heading structure where the same framework (PAS) was split across two `##` headings.

## Issue
Closes #15229

## Files Changed
- `.agents/marketing-sales/meta-ads-creative-frameworks.md` — 1 file, structural heading fix only

## Classification
Reference corpus (ad copy templates). At 162 lines, under the ~300-line split threshold. Correct action: structural tightening, not content compression or chapter splitting.

## Change Detail
- `## PAS — static` + `## PAS — video 25s` → `## PAS` with `### Static` and `### Video 25s` subsections
- Consistent with `## Proof Frameworks` pattern (uses `###` for subsections)
- Zero content loss: all code blocks, templates, formulas, and navigation link preserved

## Testing
- Content preservation verified: all code blocks, URLs, command examples present before and after
- No broken internal links (navigation link to `meta-ads-creative-production.md` unchanged)
- Agent behaviour unchanged — structural heading change only, no semantic content modified

## Runtime Testing
**Risk: Low** — docs/agent prompt file, heading structure change only. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,961 tokens on this as a headless worker.