### PR TITLE
GH#15663: tighten durable-objects.md — merge nav sections, compress prose

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/durable-objects.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/durable-objects.md
@@ -4,7 +4,7 @@ Globally-unique compute + storage: single-threaded, strongly-consistent, co-loca
 
 ## When to Use DOs
 
-Use for **stateful coordination** — serialized access to shared state:
+Stateful coordination — serialized access to shared state:
 - **Coordination**: Shared state across clients (chat rooms, multiplayer games)
 - **Strong consistency**: Serialized operations (booking systems, inventory)
 - **Per-entity storage**: Isolated database per user/tenant/resource (multi-tenant SaaS)
@@ -29,7 +29,7 @@ Use for **stateful coordination** — serialized access to shared state:
 
 Model each DO around the **atom of coordination** — the unit needing serialized access (user, room, document, session).
 
-| Characteristic | Feels Right | Question It | Reconsider |
+| Metric | Feels Right | Question It | Reconsider |
 |----------------|-------------|-------------|------------|
 | Requests/sec (sustained) | < 100 | 100-500 | > 500 |
 | Storage keys | < 100 | 100-1000 | > 1000 |
@@ -46,7 +46,7 @@ Model each DO around the **atom of coordination** — the unit needing serialize
 
 **ID generation**: `idFromName()` deterministic/named; `newUniqueId()` random/sharding; `idFromString()` derive from existing; jurisdiction option for data locality.
 
-**Storage**: SQLite (recommended, 10GB/DO, transactions); Synchronous KV API (simple key-value on SQLite); Asynchronous KV API (legacy/advanced).
+**Storage**: SQLite (default, 10GB/DO, transactions); Synchronous KV API (simple key-value on SQLite); Asynchronous KV API (legacy/advanced).
 
 **Special features**: Alarms (per-DO scheduled execution); WebSocket Hibernation (zero-cost idle); Point-in-Time Recovery (30-day window).
 
@@ -87,16 +87,13 @@ npx wrangler deploy           # Deploy + auto-apply migrations
 
 ## Resources
 
-**Docs**: https://developers.cloudflare.com/durable-objects/  
-**API Reference**: https://developers.cloudflare.com/durable-objects/api/  
-**Examples**: https://developers.cloudflare.com/durable-objects/examples/
-
-## In This Reference
-
-- [Patterns](./durable-objects-patterns.md) - Rate limiting, locks, real-time collab, sessions
-- [Gotchas](./durable-objects-gotchas.md) - Limits, common issues, troubleshooting
+- [Docs](https://developers.cloudflare.com/durable-objects/)
+- [API Reference](https://developers.cloudflare.com/durable-objects/api/)
+- [Examples](https://developers.cloudflare.com/durable-objects/examples/)
 
 ## See Also
 
-- [Workers](./workers.md) - Core Workers runtime
-- [DO Storage](./do-storage.md) - Deep dive on storage APIs
+- [Patterns](./durable-objects-patterns.md) — Rate limiting, locks, real-time collab, sessions
+- [Gotchas](./durable-objects-gotchas.md) — Limits, common issues, troubleshooting
+- [Workers](./workers.md) — Core Workers runtime
+- [DO Storage](./do-storage.md) — Deep dive on storage APIs


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/durable-objects.md` per simplification-debt issue GH#15663.

## Changes (102 → 99 lines)
- Remove redundant "Use for **stateful coordination**" prefix from "When to Use" section (header already conveys this)
- "Characteristic" → "Metric" in Design Heuristics table (shorter, same meaning)
- "recommended" → "default" for SQLite storage (more accurate — it is the default engine)
- Convert Resources from bold-label format to list format (consistent with rest of file)
- Merge "In This Reference" + "See Also" into single "See Also" section (eliminates one header)
- Standardise ` - ` → ` — ` separators in See Also (consistent with file style)

## Issue
Closes #15663

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/durable-objects.md`

## Runtime Testing
**Risk level**: Low — agent doc (`.md`), no code execution paths.
**Verification**: All code blocks, URLs (3), cross-references (4), table data, and task ID refs preserved. `wc -l` confirms 99 lines (down from 102). No broken internal links.

## Key Decisions
- File classified as instruction doc (not reference corpus) — prose compression appropriate
- No content removed — only redundant formatting and duplicate navigation sections merged
- "default" preferred over "recommended" for SQLite as it reflects Cloudflare's actual default storage engine choice

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 5,531 tokens on this as a headless worker.