### PR TITLE
GH#15666: tighten tunnel-gotchas.md (96→90 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md
@@ -19,9 +19,7 @@
 
 ## Common Issues & Troubleshooting
 
-### Error 1016 (Origin DNS Error)
-
-Tunnel not running or connected.
+**Error 1016 (Origin DNS Error)** — tunnel not running or connected.
 
 ```bash
 cloudflared tunnel info <tunnel>     # Check status
@@ -29,9 +27,7 @@ ps aux | grep cloudflared             # Verify process
 journalctl -u cloudflared -n 100      # Check logs
 ```
 
-### Certificate Errors
-
-Self-signed certs rejected by default.
+**Certificate Errors** — self-signed certs rejected by default.
 
 ```yaml
 originRequest:
@@ -39,9 +35,7 @@ originRequest:
   caPool: /path/to/ca.pem  # Custom CA
 ```
 
-### Connection Timeouts
-
-Origin slow to respond.
+**Connection Timeouts** — origin slow to respond.
 
 ```yaml
 originRequest:
@@ -50,7 +44,7 @@ originRequest:
   keepAliveTimeout: 120s
 ```
 
-### Tunnel Not Starting
+**Tunnel Not Starting**
 
 ```bash
 cloudflared tunnel ingress validate  # Validate local config
@@ -58,7 +52,7 @@ ls -la ~/.cloudflared/*.json         # Verify credentials
 cloudflared tunnel list              # Verify tunnel exists
 ```
 
-### Debugging
+**Debugging**
 
 ```bash
 cloudflared tunnel --loglevel debug run <tunnel>
@@ -73,7 +67,7 @@ cloudflared tunnel ingress rule https://app.example.com
 
 ## Migration
 
-### From Ngrok (`ngrok http 8000`)
+**From Ngrok** (`ngrok http 8000`)
 
 ```yaml
 ingress:
@@ -82,7 +76,7 @@ ingress:
   - service: http_status:404
 ```
 
-### From VPN (Private Network Routing)
+**From VPN** (Private Network Routing)
 
 ```yaml
 warp-routing:


### PR DESCRIPTION
## Summary

- Converts H3 troubleshooting subheadings to bold inline labels, merging prose descriptions onto the same line (e.g., `### Error 1016 (Origin DNS Error)\n\nTunnel not running or connected.` → `**Error 1016 (Origin DNS Error)** — tunnel not running or connected.`)
- Same treatment applied to Migration section (`### From Ngrok`, `### From VPN`)
- All code blocks, commands, config examples, and institutional knowledge preserved — zero content loss
- 96 → 90 lines (6.25% reduction; file was already lean)

## Verification

- `diff` confirms only structural changes (heading style + blank line removal)
- All `cloudflared` commands, YAML config blocks, and error descriptions present before and after

Closes #15666

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 3,236 tokens on this as a headless worker.