### PR TITLE
GH#14315: tighten agent doc YouTube Distribution (.agents/content/distribution-youtube-readme.md, 86→82 lines)

### DIFF
--- a/.agents/content/distribution-youtube-readme.md
+++ b/.agents/content/distribution-youtube-readme.md
@@ -17,13 +17,11 @@ subagents:
 
 ## Quick Reference
 
-- **Purpose**: YouTube long-form video distribution within the content pipeline
 - **Main Agent**: `youtube.md` (this directory) - orchestrator for all YouTube operations
 - **Subagents**: `channel-intel`, `topic-research`, `script-writer`, `optimizer`, `pipeline`
 - **Helper**: `youtube-helper.sh` - YouTube Data API v3 wrapper
 - **Commands**: `/youtube setup`, `/youtube research`, `/youtube script`
-
-**This directory is the authoritative location for all YouTube agents.** YouTube is a distribution channel within the content pipeline (`content.md`). The subagents here handle competitor research, topic ideation, script generation, metadata optimization, and automated pipelines.
+- **Pipeline**: YouTube is a distribution channel within `content.md`
 
 <!-- AI-CONTEXT-END -->
 
@@ -78,9 +76,7 @@ From one YouTube video, generate:
 
 ## Related Agents
 
-- `youtube.md` - Full YouTube orchestrator (this directory)
 - `content/production-video.md` - Video generation (Sora 2 Pro, Veo 3.1)
 - `content/production-audio.md` - Voice pipeline
 - `content/story.md` - Narrative design and hook formulas
 - `content/optimization.md` - A/B testing and analytics
-- `youtube-helper.sh` - YouTube Data API v3 wrapper


### PR DESCRIPTION
## Summary

Tighten `.agents/content/distribution-youtube-readme.md` per GH#14315 simplification scan.

**Changes:** 86 → 82 lines (5% reduction)

- Removed redundant `Purpose` bullet from Quick Reference (duplicated frontmatter `description`)
- Removed verbose paragraph restating Quick Reference content
- Removed `youtube.md` and `youtube-helper.sh` from Related Agents (already listed in Quick Reference)
- Converted pipeline context to a concise Quick Reference bullet

**Preserved:** All subagent names, file references, commands, spec values, workflow steps, format rules, cross-channel repurposing links, and related agent references.

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. `self-assessed`.

Verification: all code blocks, URLs, command examples, and file references present before and after (confirmed by line-by-line review).

Closes #14315

---
<!-- MERGE_SUMMARY -->
**What:** Tighten YouTube Distribution agent doc — remove duplicate Quick Reference entries
**Issue:** #14315
**Files changed:** `.agents/content/distribution-youtube-readme.md` (86→82 lines)
**Testing:** self-assessed (doc-only change, no code)
**Key decisions:** Removed only genuine duplicates — content already present in Quick Reference or frontmatter

---
[aidevops.sh](https://aidevops.sh) v3.5.666 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m and 3,644 tokens on this as a headless worker.