### PR TITLE
GH#15679: tighten agents-sdk-patterns.md (reference corpus index)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3,7 +3,7 @@
     "hash": "b7c346582edd627a9ab4f70a7c7e4b8f8d97be32231069f4e10126d2db94062d",
     "issue": "GH#15647",
     "status": "simplified",
-    "note": "Instruction doc tightened: 103 → 90 lines. Merged config code blocks, moved URLs inline, compressed CI/CD prose. Zero content loss."
+    "note": "Instruction doc tightened: 103 \u2192 90 lines. Merged config code blocks, moved URLs inline, compressed CI/CD prose. Zero content loss."
   },
   ".agents/seo/ai-search-kpi-template.md": {
     "hash": "03478debc956ad02835cde5c946e89762351c2c00c836d8c9c24fca3ebd366cc",
@@ -4506,5 +4506,11 @@
     "issue": "GH#14091",
     "status": "simplified",
     "note": "Consolidated 4 fragmented fuzz.* code blocks into 1 cohesive block. 121 -> 104 lines. All content preserved."
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md": {
+    "hash": "3b5aad8cadb464560c0bee6e9adeee54110b13f223f7cb19b1a1bb872c28caab",
+    "issue": "GH#15679",
+    "status": "simplified",
+    "note": "Reference corpus: added navigation index (89 \u2192 91 lines). All code examples preserved verbatim."
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md
@@ -1,5 +1,7 @@
 # Patterns & Use Cases
 
+Patterns: [Chat](#chat) · [AI with Tools](#ai-with-tools) · [Streaming](#streaming) · [Cron / Scheduled](#cron--scheduled) · [Email with AI](#email-with-ai) · [Game](#game)
+
 ## Chat
 
 ```ts


### PR DESCRIPTION
## Summary

- Classified `.agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md` as **reference corpus** (pure TypeScript code examples, no instruction prose)
- Added slim navigation index at top per reference corpus guidance (GH#6432): `Patterns: [Chat] · [AI with Tools] · [Streaming] · [Cron / Scheduled] · [Email with AI] · [Game]`
- All 6 code examples preserved verbatim — zero content loss
- Updated `simplification-state.json` registry with file hash and status

## Issue

Closes #15679

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md` — +2 lines (index added, 89 → 91 lines)
- `.agents/configs/simplification-state.json` — registry entry added

## Runtime Testing

**Risk level: Low** — documentation-only change (agent prompt/reference file). No code execution paths affected.

**Verification:** `self-assessed` — content preservation confirmed by line-by-line diff. All code blocks, section headers, and TypeScript examples present before and after.

## Key Decisions

- **Reference corpus, not instruction doc**: File contains only code examples with no operational rules or decision trees. Compression would lose code fidelity; restructuring into chapters would add overhead for a 89-line file. Navigation index is the proportionate improvement.
- **No content removed**: Per code-simplifier guidance, reference corpora get restructuring (index + chapters), not compression. At 89 lines, a single-file index is sufficient — chapter splitting would be disproportionate overhead.

---
[aidevops.sh](https://aidevops.sh) v3.5.670 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,822 tokens on this as a headless worker.