### PR TITLE
GH#14286: tighten cro-chapter-19.md (Advanced CRO Tactics)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -782,13 +782,20 @@
       "passes": 1,
       "pr": 13339
     },
-    ".agents/marketing-sales/cro-chapter-18.md": {
-      "at": "2026-04-01T20:59:11Z",
-      "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
-      "passes": 1,
-      "pr": 15220
-    },
-    ".agents/marketing-sales/cro-chapter-20.md": {
+  ".agents/marketing-sales/cro-chapter-18.md": {
+    "at": "2026-04-01T20:59:11Z",
+    "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
+    "passes": 1,
+    "pr": 15220
+  },
+  ".agents/marketing-sales/cro-chapter-19.md": {
+    "at": "2026-04-02T20:51:07Z",
+    "hash": "57c88fea52a008b1e08e1e4427f363ea9a9ddbdc56e86c36655bf8da7fd59f3e",
+    "issue": "GH#14286",
+    "passes": 1,
+    "note": "Reference corpus chapter tightened: 92 → 90 lines. Removed decorative closing sentence with no information value. Zero content loss."
+  },
+  ".agents/marketing-sales/cro-chapter-20.md": {
       "at": "2026-03-29T16:34:29Z",
       "hash": "07aa1e83fefdc10d56b044961da2976b1e693895",
       "passes": 1,

--- a/.agents/marketing-sales/cro-chapter-19.md
+++ b/.agents/marketing-sales/cro-chapter-19.md
@@ -88,5 +88,3 @@ Place primary actions in easy-to-reach areas.
 - Preview video
 - Ratings and reviews
 - App description
-
-This chapter covers advanced tactics for sophisticated CRO programs.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/marketing-sales/cro-chapter-19.md` per simplification issue GH#14286.

**Change:** Remove decorative closing sentence ("This chapter covers advanced tactics for sophisticated CRO programs.") — adds zero information value and is inconsistent with adjacent chapters (cro-chapter-18.md, cro-chapter-20.md which don't have such sentences).

**Result:** 92 → 90 lines. Zero content loss.

## Issue
Closes #14286

## Files Changed
- `.agents/marketing-sales/cro-chapter-19.md` — removed 2 lines (decorative closing sentence + blank line)
- `.agents/configs/simplification-state.json` — recorded file as processed with hash, issue ref, and note

## Testing
**Risk level:** Low (docs/reference corpus, no agent rules or operational procedures)
**Verification:** All code blocks, URLs, task ID refs, and command examples present before and after (none existed — pure domain knowledge content). Content preserved: behavioral economics section (19.1), advanced personalization section (19.2), mobile CRO deep dive section (19.3) — all intact.

## Key Decisions
- **Classification:** Reference corpus chapter (domain knowledge, not agent rules). Issue title says "tighten" — applied minimal tightening (remove decorative noise only, no content compression).
- **Scope:** Only removed the decorative closing sentence. The bold-header-with-colon format is consistent with the rest of the CRO corpus and was preserved.

---
[aidevops.sh](https://aidevops.sh) v3.5.670 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 5,586 tokens on this as a headless worker.