### PR TITLE
GH#15251: tighten workerd-patterns.md agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
@@ -40,7 +40,7 @@ const config :Workerd.Config = (
 
 ## Durable Objects
 
-Add as a service entry in the `services` list (see Multi-Service Architecture for full config structure):
+Add as a service entry in the `services` list:
 
 ```capnp
 (name = "app", worker = (
@@ -74,7 +74,7 @@ Run with: `API_URL=http://localhost:3000 DEBUG=true workerd serve dev.capnp`
 
 ## HTTP Reverse Proxy
 
-Service-worker syntax with external backend (add to `services`/`sockets`):
+Service-worker syntax with external backend (add to `services`/`sockets` blocks):
 
 ```capnp
 (name = "proxy", worker = (
@@ -115,10 +115,9 @@ workerd test config.capnp --test-only=test.js
 
 ### Systemd
 
-`/etc/systemd/system/workerd.service` + `workerd.socket`:
+`/etc/systemd/system/workerd.service`:
 
 ```ini
-# workerd.service
 [Unit]
 Description=workerd runtime
 After=network-online.target
@@ -133,8 +132,11 @@ NoNewPrivileges=true
 
 [Install]
 WantedBy=multi-user.target
+```
 
-# workerd.socket
+`/etc/systemd/system/workerd.socket`:
+
+```ini
 [Socket]
 ListenStream=0.0.0.0:80
 


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md` per GH#15251.

Closes #15251

## What

- Remove redundant cross-reference in Durable Objects intro (section heading is self-evident)
- Split systemd service+socket into two separate labeled code blocks (removes inline `# workerd.service` / `# workerd.socket` comments, improves clarity)
- Minor prose tightening in HTTP Reverse Proxy intro

## Classification

Reference corpus (domain knowledge base with self-contained sections). At 164 lines, splitting into chapter files would add overhead without benefit — tightening prose and improving code block clarity is the correct action.

## Verification

- All code blocks preserved: capnp (multi-service, Durable Objects, dev/prod, proxy), bash (testing, compiled binary), ini (systemd service + socket), dockerfile
- All URLs preserved: `workerd-gotchas.md` link
- No task IDs or GH refs to preserve in this file
- Zero content removed — only prose tightened and systemd split for clarity
- Line count: 164 → 166 (systemd split adds 2 lines, net improvement in readability)

## Runtime Testing

Risk: **Low** — docs/agent prompt file only, no code execution path. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.670 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 4,892 tokens on this as a headless worker.