### PR TITLE
GH#15252: tighten email sequences framework doc

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md
@@ -118,6 +118,3 @@ But here's the thing... [Solution + brief explanation + social proof]
 
 **Subject line checklist**: Would I open this? · Under 50 chars? · Preview text complements? · Curiosity/urgency/benefit? · Matches content? · No spam triggers? · Tested on mobile?
 
----
-
-**Further reading**: [Templates](direct-response-copy-templates-email-sequences.md)


### PR DESCRIPTION
## Summary

- Removes duplicate 'Further reading' footer link (line 123) — already present at top of file (line 5)
- Removes the redundant `---` separator preceding the duplicate footer
- All content preserved: tables, code block, formulas, best practices, sequence templates

Closes #15252

## What

Tightened `.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md` from 123 → 120 lines by removing 3 lines of pure redundancy (duplicate link + separator).

## Classification

Reference corpus (domain knowledge base with self-contained sections). Per code-simplifier guidance (GH#6432), reference corpora should not be compressed — content was preserved in full. Only decorative/duplicate noise removed.

## Files Changed

- `.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md` — 3 lines removed (duplicate footer + separator)

## Runtime Testing

Risk: **Low** — docs-only change, no code, no agent behavior change. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.670 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,535 tokens on this as a headless worker.