### PR TITLE
GH#15254: tighten heygen authentication doc

### DIFF
--- a/.agents/content/heygen-skill/rules-authentication.md
+++ b/.agents/content/heygen-skill/rules-authentication.md
@@ -7,12 +7,19 @@ metadata:
 
 # HeyGen Authentication
 
-All requests require an API key in the `X-Api-Key` header. Keep it server-side, load it from an environment variable, and never expose it in client code.
+All requests require an API key in the `X-Api-Key` header. Keep it server-side, load it from an environment variable, never expose it in client code.
+
+## Security Rules
+
+1. **Keep keys server-side** — route requests through a backend service
+2. **Use environment variables** — never hardcode keys in source
+3. **Rotate keys periodically** — replace old keys on a regular schedule
+4. **Monitor usage** — review the HeyGen dashboard for unusual activity
 
 ## Setup
 
 1. Log in at https://app.heygen.com → Settings > API and copy the key.
-2. Store it as an environment variable:
+2. Store as an environment variable:
 
 ```bash
 export HEYGEN_API_KEY="your-api-key-here"   # shell
@@ -20,6 +27,8 @@ export HEYGEN_API_KEY="your-api-key-here"   # shell
 ```
 
 ## Request Pattern
+
+Send `X-Api-Key` on every request:
 
 ### curl
 
@@ -48,8 +57,6 @@ response = requests.get(
 )
 data = response.json()
 ```
-
-The pattern is the same in every HTTP client: send `X-Api-Key` on each request.
 
 ## Reusable API Client
 
@@ -82,7 +89,7 @@ const avatars = await client.get("/v2/avatars");
 
 ## Response Shape
 
-Successful responses return `{ error: null, data: ... }`; auth failures return `{ "error": "Invalid API key", "data": null }`.
+`{ error: null, data: ... }` on success; `{ error: "Invalid API key", data: null }` on auth failure.
 
 ```typescript
 interface ApiResponse<T> {
@@ -91,7 +98,7 @@ interface ApiResponse<T> {
 }
 ```
 
-## Common Auth Errors
+## Errors & Rate Limits
 
 | Status | Error | Cause |
 |--------|-------|-------|
@@ -99,9 +106,7 @@ interface ApiResponse<T> {
 | 403 | Forbidden | Insufficient permissions |
 | 429 | Rate limit exceeded | Too many requests — use exponential backoff |
 
-## Rate Limits
-
-Rate limits apply per API key; video generation endpoints are stricter. Retry 429 responses with exponential backoff:
+Rate limits apply per API key; video generation endpoints are stricter. Retry 429 with exponential backoff:
 
 ```typescript
 async function requestWithRetry(fn: () => Promise<Response>, maxRetries = 3): Promise<Response> {
@@ -113,10 +118,3 @@ async function requestWithRetry(fn: () => Promise<Response>, maxRetries = 3): Pr
   throw new Error("Max retries exceeded");
 }
 ```
-
-## Security Best Practices
-
-1. **Keep keys server-side** — route requests through a backend service
-2. **Use environment variables** — never hardcode keys in source
-3. **Rotate keys periodically** — replace old keys on a regular schedule
-4. **Monitor usage** — review the HeyGen dashboard for unusual activity


### PR DESCRIPTION
## Summary

Tightens `.agents/content/heygen-skill/rules-authentication.md` (122 → 120 lines) per the simplification-debt scan flagged in GH#15254.

**Classification:** Instruction doc with reference corpus elements (code examples). Correct action: tighten prose, reorder by importance, preserve all code blocks.

**Changes:**
- Security rules moved to top (primacy effect — LLMs weight earlier context more heavily)
- Merged "Common Auth Errors" + "Rate Limits" into single "Errors & Rate Limits" section (reduces section count, 429 was already in both)
- Removed redundant prose line ("The pattern is the same in every HTTP client")
- Tightened response shape description (one line instead of two)
- All code blocks, URLs, error tables, and institutional knowledge preserved

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code changes.
**Verification:** `self-assessed` — markdownlint clean, content preservation verified by diff.

## Files Changed

- `.agents/content/heygen-skill/rules-authentication.md` — 14 insertions, 16 deletions

Closes #15254

---
[aidevops.sh](https://aidevops.sh) v3.5.670 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,544 tokens on this as a headless worker.