### PR TITLE
GH#15168: simplify stream.md - remove duplicate limits table, fix broken links

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md
@@ -83,8 +83,8 @@ async function uploadWithErrorHandling(url: string, file: File) {
 
 ## In This Reference
 
-- [README.md](./README.md) — Overview and quick start
-- [patterns.md](./patterns.md) — Full-stack flows, best practices
+- [stream.md](./stream.md) — Overview and quick start
+- [stream-patterns.md](./stream-patterns.md) — Full-stack flows, best practices
 
 ## See Also
 

--- a/.agents/services/hosting/cloudflare-platform-skill/stream.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/stream.md
@@ -48,16 +48,6 @@ curl -X POST \
   -d '{"recording": {"mode": "automatic"}}'
 ```
 
-## Key Limits and Pricing
-
-| Item | Value |
-|------|-------|
-| Max file size | 30 GB |
-| Max frame rate | 60 fps recommended |
-| Supported formats | MP4, MKV, MOV, AVI, FLV, MPEG-2 TS/PS, MXF, LXF, GXF, 3GP, WebM, MPG, QuickTime |
-| Storage pricing | $5/1000 min stored |
-| Delivery pricing | $1/1000 min delivered |
-
 ## Resources
 
 - Dashboard: https://dash.cloudflare.com/?to=/:account/stream


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `stream.md` (76 → 66 lines) by removing the duplicate "Key Limits and Pricing" table. The same limits data already exists in `stream-gotchas.md` (which is explicitly described as covering "Errors, limits, troubleshooting, and security pitfalls"). Also fix two broken internal links in `stream-gotchas.md`.

## Issue
Closes #15168

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/stream.md` — removed duplicate limits table (10 lines)
- `.agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md` — fixed broken links (`README.md` → `stream.md`, `patterns.md` → `stream-patterns.md`)

## Classification
**Instruction doc** (not reference corpus) — tightened prose by removing duplication. All institutional knowledge preserved: quick start examples, overview bullets, resources, and cross-references remain intact.

## Testing
- Content preservation: all code blocks, URLs, and command examples present before and after
- No broken internal links (fixed 2 pre-existing broken links in gotchas)
- Agent behaviour unchanged — limits data still accessible via `stream-gotchas.md`

## Key Decisions
- Removed limits table from `stream.md` (not from `stream-gotchas.md`) since gotchas has the more comprehensive version with additional rows (token generation, simulcast outputs, webhook retries/timeout, caption/watermark sizes, etc.)
- Fixed broken links as a bonus fix — they were pointing to non-existent `README.md` and `patterns.md` files

---
[aidevops.sh](https://aidevops.sh) v3.5.672 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 4,084 tokens on this as a headless worker.