### PR TITLE
GH#15260: tighten programmatic-seo.md agent doc

### DIFF
--- a/.agents/seo/programmatic-seo.md
+++ b/.agents/seo/programmatic-seo.md
@@ -18,7 +18,7 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Build SEO-optimized pages at scale using templates, keyword clustering, and automated generation
+- **Purpose**: Build SEO-optimized pages at scale via templates, keyword clustering, and automated generation
 - **Related**: `keyword-research.md`, `site-crawler.md`, `eeat-score.md`, `schema-markup`, `ranking-opportunities.md`, `google-search-console.md`
 - **Input**: Keyword lists, data sources, page templates
 - **Output**: Template definitions, page content, internal linking maps, sitemap entries
@@ -41,7 +41,7 @@ tools:
 
 ### 1. Keyword Research and Clustering
 
-Run `/keyword-research-extended "seed keyword"`. Cluster signals: same head term + varying modifier, consistent volume, similar SERP intent, low difficulty.
+Run `/keyword-research-extended "seed keyword"`. Cluster by: same head term + varying modifier, consistent volume, similar SERP intent, low difficulty.
 
 ### 2. Template Design
 
@@ -60,7 +60,7 @@ Sections:
   6. CTA                (static or segment-specific)
 ```
 
-**Quality gates** — each page MUST have unique, substantive content (not just variable substitution). Minimum 300 words unique content with real data points per variation. Must add value beyond a single parent page.
+**Quality gates** — each page MUST have unique, substantive content (not just variable substitution): ≥300 words unique content with real data points per variation; must add value beyond a single parent page.
 
 ### 3. Data Collection
 
@@ -102,11 +102,19 @@ For each {modifier} in data_source:
 
 ### 6. Quality Assurance
 
-**Technical**: All URLs resolve (no 404s) · Self-referencing canonicals · No duplicate titles/meta descriptions · Structured data validates (`rich-results.md`) · Pages in XML sitemap, robots.txt allows crawling · Load time <3s (`pagespeed.md`)
+**Technical**:
+- All URLs resolve (no 404s); self-referencing canonicals; no duplicate titles/meta descriptions
+- Structured data validates (`rich-results.md`); pages in XML sitemap; robots.txt allows crawling
+- Load time <3s (`pagespeed.md`)
 
-**Content**: >300 words unique per page · No duplicate content across variations (`site-crawler`) · Accurate, current data · Grammar/readability pass · E-E-A-T signals present (`eeat-score.md`)
+**Content**:
+- >300 words unique per page; no duplicate content across variations (`site-crawler`)
+- Accurate, current data; grammar/readability pass; E-E-A-T signals present (`eeat-score.md`)
 
-**SEO**: Target keyword in title, H1, first paragraph · Descriptive anchor text on internal links · Image alt text with relevant keywords · Schema markup matches page type
+**SEO**:
+- Target keyword in title, H1, first paragraph
+- Descriptive anchor text on internal links; image alt text with relevant keywords
+- Schema markup matches page type
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Summary

- Tighten prose in Quick Reference and workflow sections
- Reformat QA section (§6) from three dense run-on lines using `·` separators into structured bullet lists under Technical/Content/SEO headings — improves readability and LLM context weighting
- All content, code blocks, command references, and institutional knowledge preserved

## What

Simplification of `.agents/seo/programmatic-seo.md` per automated scan flagged in GH#15260. File classified as **instruction doc** (not reference corpus) — prose tightening applied, not chapter splitting.

## Files Changed

- `.agents/seo/programmatic-seo.md`: 128 → 136 lines (net increase due to QA section reformatting from 3 dense lines to 9 readable bullet lines)

## Testing

- `self-assessed` (Low risk: agent doc, no code changes)
- `markdownlint-cli2`: 0 errors
- Content preservation verified: all code blocks, URLs, command references, and task ID references present before and after

## Runtime Testing

Risk: **Low** — agent doc only, no executable code changes.

Closes #15260

---
[aidevops.sh](https://aidevops.sh) v3.5.674 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 5,006 tokens on this as a headless worker.