### PR TITLE
GH#14325: tighten agent doc Cloudflare RealtimeKit

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/realtimekit.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtimekit.md
@@ -1,10 +1,6 @@
 # Cloudflare RealtimeKit
 
-Expert guidance for building real-time video and audio applications using **Cloudflare RealtimeKit** - a comprehensive SDK suite for adding customizable live video and voice to web or mobile applications.
-
-## Overview
-
-RealtimeKit is Cloudflare's SDK suite built on Realtime SFU, abstracting WebRTC complexity with fast integration, pre-built UI components, global performance (300+ cities), and production features (recording, transcription, chat, polls).
+SDK suite built on Realtime SFU — abstracts WebRTC complexity with pre-built UI components, global performance (300+ cities), and production features (recording, transcription, chat, polls).
 
 **Use cases**: Team meetings, webinars, social video, audio calls, interactive plugins
 
@@ -61,13 +57,10 @@ const meeting = new RealtimeKitClient({ authToken: '<token>', video: true, audio
 await meeting.join();
 ```
 
-## In This Reference
-
-- [Patterns](./patterns.md) - Common workflows, code examples
-- [Gotchas](./gotchas.md) - Common issues, troubleshooting
-
 ## See Also
 
+- [Patterns](./realtimekit-patterns.md) - Common workflows, code examples
+- [Gotchas](./realtimekit-gotchas.md) - Common issues, troubleshooting, limits
 - [Workers](../workers/) - Backend integration
 - [D1](../d1/) - Meeting metadata storage
 - [R2](../r2/) - Recording storage


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/cloudflare-platform-skill/realtimekit.md` per GH#14325.

**Changes:**
- Merged redundant intro paragraph + Overview section into a single tight description (both said the same thing)
- Removed "In This Reference" section — cross-links already exist in `realtimekit-patterns.md` and `realtimekit-gotchas.md`
- Added patterns/gotchas links to "See Also" for discoverability (replacing the removed section)
- 81 → 74 lines; all code blocks, URLs, API endpoints, and institutional knowledge preserved

**Classification:** Reference corpus index — restructured for clarity, not content-compressed.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/realtimekit.md`

## Runtime Testing

Risk: **Low** — documentation-only change, no code or agent logic modified.
Verification: `self-assessed` — markdownlint clean, all links and code blocks intact.

Closes #14325

<!-- aidevops.sh -->