### PR TITLE
fix: prevent code-quality badge from showing cancelled runs as failing

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,7 +13,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel in-progress runs on PR branches, not main.
+  # Cancelled runs show as "failing" on the badge — rapid main pushes
+  # (e.g. pulse auto-merges) would keep the badge red indefinitely.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Cross-platform shellcheck: catches macOS-only assumptions in shell scripts


### PR DESCRIPTION
## Summary

- Condition `cancel-in-progress` to only apply on PR branches (`github.ref != 'refs/heads/main'`), not main
- Rapid main pushes (pulse auto-merges) were cancelling in-progress workflow runs; GitHub badges treat "cancelled" as failure, keeping the badge red indefinitely
- PR branch runs still get cancelled when superseded (saves CI minutes); main branch runs now complete for accurate badge status

## Runtime Testing

- **Risk level**: Low (CI config change, no runtime code)
- **Verification**: `self-assessed` — standard GitHub Actions concurrency pattern, no runtime testing needed

---
[aidevops.sh](https://aidevops.sh) v3.5.680 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 4m and 3,904 tokens on this with the user in an interactive session.