### PR TITLE
GH#14930: tighten seo-write.md agent doc (51→45 lines)

### DIFF
--- a/.agents/scripts/commands/seo-write.md
+++ b/.agents/scripts/commands/seo-write.md
@@ -4,8 +4,6 @@ agent: Build+
 mode: subagent
 ---
 
-Write an SEO-optimized article on the given topic.
-
 Topic/Keyword: $ARGUMENTS
 
 ## Workflow
@@ -16,16 +14,14 @@ Topic/Keyword: $ARGUMENTS
    python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py intent "$ARGUMENTS"
    ```
 
-2. **Context**: Check for project context files
+2. **Context**: Check for project context files; read any that exist before writing
 
    ```bash
    ls context/brand-voice.md context/style-guide.md context/internal-links-map.md context/target-keywords.md 2>/dev/null
    ls .aidevops/context/brand-voice.md .aidevops/context/style-guide.md 2>/dev/null
    ```
 
-   If context files exist, read them before writing.
-
-3. **Write**: Follow `content/seo-writer.md` guidelines to create the article:
+3. **Write**: Follow `content/seo-writer.md` guidelines:
    - 2,000-3,000+ words
    - Primary keyword in H1, first 100 words, 2-3 H2s
    - 1-2% keyword density
@@ -33,19 +29,17 @@ Topic/Keyword: $ARGUMENTS
    - Meta title (50-60 chars) and description (150-160 chars)
    - Grade 8-10 reading level
 
-4. **Analyze**: Run content analysis on the draft
+4. **Analyze**: Run content analysis and fix any critical issues
 
    ```bash
    python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py analyze draft.md \
      --keyword "primary keyword" --secondary "kw1,kw2"
    ```
 
-5. **Fix**: Address any critical issues from the analysis
-
-6. **Output**: Save to `drafts/[topic]-[date].md` or current directory
+5. **Output**: Save to `drafts/[topic]-[date].md` or current directory
 
 ## Related
 
-- `content/seo-writer.md` - Writing guidelines
-- `content/humanise.md` - Remove AI patterns after writing
-- `seo/content-analyzer.md` - Analysis details
+- `content/seo-writer.md` — Writing guidelines
+- `content/humanise.md` — Remove AI patterns after writing
+- `seo/content-analyzer.md` — Analysis details


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/seo-write.md` per GH#14930 simplification scan. 51 → 45 lines (12% reduction), zero knowledge loss.

**Changes:**
- Remove redundant opening sentence (duplicates frontmatter `description` field)
- Merge "read context files" instruction inline with step 2 (was a separate trailing sentence)
- Fold trivial "Fix" step into "Analyze" step (step 5 was "Address any critical issues from the analysis" — obvious follow-on, not a distinct step)
- Renumber steps 1-5 (was 1-6)
- Standardize Related section separators: ` - ` → ` — ` (em-dash, project standard)

**Verification:**
- All code blocks preserved: `seo-content-analyzer.py intent`, `seo-content-analyzer.py analyze`
- All file path references preserved: `content/seo-writer.md`, `content/humanise.md`, `seo/content-analyzer.md`
- All command flags preserved: `--keyword`, `--secondary`
- Workflow logic unchanged: research → context → write → analyze → output

## Runtime Testing

Risk: **Low** — agent doc only, no executable code changed. `self-assessed`.

Closes #14930

---
[aidevops.sh](https://aidevops.sh) v3.5.680 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,574 tokens on this as a headless worker.