### PR TITLE
GH#15269: tighten queues-gotchas.md (110→94 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
@@ -7,7 +7,6 @@ See [queues.md](./queues.md), [queues-patterns.md](./queues-patterns.md).
 Queues are at-least-once. Consumers must tolerate duplicates and should ack only after durable success.
 
 ```typescript
-// ✅ GOOD: Track processed messages
 const processed = await env.PROCESSED_KV.get(msg.id);
 if (processed) { msg.ack(); continue; }
 await processMessage(msg.body);
@@ -17,16 +16,10 @@ msg.ack();
 
 ## Content Type Visibility
 
-- `json` is dashboard-visible and works with pull consumers.
-- `v8` is not decodable in pull consumers or the dashboard.
-- For pull consumers, send `json`.
+`json` is dashboard-visible and works with pull consumers. `v8` is not decodable in pull consumers or the dashboard — use `json` for pull.
 
 ```typescript
-// ✅ For pull consumers
 await env.MY_QUEUE.send(data, { contentType: 'json' });
-
-// ❌ Avoid v8 with pull
-await env.MY_QUEUE.send(new Date(), { contentType: 'v8' }); // Can't decode
 ```
 
 ## Retries and CPU Budget
@@ -34,16 +27,13 @@ await env.MY_QUEUE.send(new Date(), { contentType: 'v8' }); // Can't decode
 If a handler exits without `ack()` or `retry()`, Cloudflare retries with the queue's configured policy. Default consumer CPU budget is 30s; raise it for heavier work.
 
 ```typescript
-// If you DON'T call ack() or retry(), message retries automatically
 async queue(batch: MessageBatch): Promise<void> {
   for (const msg of batch.messages) {
     try {
       await processMessage(msg.body);
-      msg.ack(); // Explicit success
+      msg.ack();
     } catch (error) {
-      // Don't call retry() - auto-retries with configured delay
-      // OR call retry() with custom delay
-      msg.retry({ delaySeconds: 600 });
+      msg.retry({ delaySeconds: 600 }); // or omit to auto-retry
     }
   }
 }
@@ -59,7 +49,6 @@ Each message normally incurs write + read + delete = 3 ops. Retries add reads. M
 
 ```typescript
 // Keep messages <64 KB (charged per 64 KB chunk)
-// Batch aggressively to reduce frequency
 { "max_batch_size": 100, "max_batch_timeout": 30 }
 ```
 
@@ -80,15 +69,10 @@ Each message normally incurs write + read + delete = 3 ops. Retries add reads. M
 ### Message not delivered
 
 ```bash
-# Check queue paused
-wrangler queues list
-
-# Verify consumer configured
-wrangler queues consumer worker remove my-queue my-worker
+wrangler queues list                                          # Check queue paused
+wrangler queues consumer worker remove my-queue my-worker    # Verify consumer
 wrangler queues consumer add my-queue my-worker
-
-# Check logs for errors
-wrangler tail my-worker
+wrangler tail my-worker                                       # Check logs
 ```
 
 ### High DLQ rate


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md` per GH#15269 simplification scan.

**Changes (110→94 lines, 15% reduction):**
- Removed `// ✅ GOOD:` prefix comment in idempotency example (redundant — only example shown)
- Consolidated Content Type Visibility prose from 3 bullets to 1 sentence
- Removed counter-example `v8` code block (prose rule is sufficient; the positive example remains)
- Removed inline comments in retry handler that duplicated the section prose
- Consolidated bash troubleshooting block: inline comments replace blank-line-separated comment headers
- Removed `// Batch aggressively to reduce frequency` (duplicates the config key name)

**Preserved:** all code blocks, limits table, all URLs/links, all operational rules, troubleshooting commands, Best Practices list.

Closes #15269

<!-- MERGE_SUMMARY -->
**What:** Prose/comment tightening of queues-gotchas.md instruction doc
**Issue:** GH#15269
**Files changed:** 1 (`.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md`)
**Testing:** Self-assessed (Low risk — docs-only, no code logic changed)
**Key decisions:** Kept ✅/❌ in Best Practices (functional do/don't markers, not decorative); kept v8 rule in prose and Best Practices list; removed only comments that duplicated adjacent prose

## Runtime Testing

Risk: **Low** — documentation-only change, no code logic, no agent behaviour altered.
Verification: `self-assessed` — all code blocks, URLs, and operational rules verified present before and after.

---
[aidevops.sh](https://aidevops.sh) v3.5.680 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 4,048 tokens on this as a headless worker.