### PR TITLE
GH#14069: tighten cloudron-git-reference.md

### DIFF
--- a/.agents/tools/deployment/cloudron-git-reference.md
+++ b/.agents/tools/deployment/cloudron-git-reference.md
@@ -9,7 +9,7 @@ tools:
 
 # Using git.cloudron.io as Reference
 
-The Cloudron GitLab instance at https://git.cloudron.io/ hosts all official app packages and is the authoritative source for packaging patterns. Use it to study real-world implementations when packaging new apps.
+https://git.cloudron.io/ hosts all official Cloudron app packages — the authoritative source for real-world packaging patterns.
 
 ## Repository Structure
 
@@ -23,8 +23,6 @@ The Cloudron GitLab instance at https://git.cloudron.io/ hosts all official app 
 | `utils` | https://git.cloudron.io/utils | Tools and utilities |
 
 ## Finding Reference Apps by Technology
-
-Browse apps by topic/tag to find packages using similar technology stacks:
 
 | Technology | URL | Count |
 |------------|-----|-------|
@@ -41,8 +39,6 @@ Browse apps by topic/tag to find packages using similar technology stacks:
 **All topics**: https://git.cloudron.io/explore/projects/topics
 
 ## GitLab API for Programmatic Access
-
-The GitLab API enables searching and fetching package code programmatically:
 
 ```bash
 # List all packages group projects
@@ -63,8 +59,6 @@ curl -s "https://git.cloudron.io/api/v4/projects/packages%2Fghost-app/search?sco
 
 ## Recommended Reference Apps by Use Case
 
-When packaging a new app, study these well-maintained packages as templates:
-
 | Use Case | Reference App | Why |
 |----------|---------------|-----|
 | **Node.js + nginx** | [ghost-app](https://git.cloudron.io/packages/ghost-app) | Clean supervisor setup, nginx proxy |
@@ -80,7 +74,7 @@ When packaging a new app, study these well-maintained packages as templates:
 
 ## What to Study in Reference Apps
 
-When examining a reference package, focus on these files:
+Focus on these files in any reference package:
 
 1. **CloudronManifest.json** - Addon requirements, memory limits, health check path
 2. **Dockerfile** - Base image choice, build steps, file permissions
@@ -92,18 +86,15 @@ When examining a reference package, focus on these files:
 ## Cloning for Local Study
 
 ```bash
-# Clone a reference app for local study
 git clone https://git.cloudron.io/packages/ghost-app.git
 
-# Or use sparse checkout for specific files
+# Sparse checkout for specific files only
 git clone --filter=blob:none --sparse https://git.cloudron.io/packages/ghost-app.git
 cd ghost-app
 git sparse-checkout set start.sh Dockerfile CloudronManifest.json
 ```
 
 ## Finding Solutions to Specific Problems
-
-When facing a specific packaging challenge, search across all packages:
 
 ```bash
 # Find apps using supervisord
@@ -112,8 +103,7 @@ curl -s "https://git.cloudron.io/api/v4/projects?topic=supervisor"
 # Find apps with proxyAuth (Cloudron handles auth)
 curl -s "https://git.cloudron.io/api/v4/projects?topic=proxyAuth"
 
-# Browse recently updated packages (most active/maintained)
-# Visit: https://git.cloudron.io/explore/projects?sort=latest_activity_desc
+# Browse recently updated packages: https://git.cloudron.io/explore/projects?sort=latest_activity_desc
 ```
 
 **Common patterns to search for**:


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/deployment/cloudron-git-reference.md` (124 → 114 lines, 8% reduction).

## Issue
Closes #14069

## Files Changed
- `.agents/tools/deployment/cloudron-git-reference.md` — removed redundant section intro sentences and "what" comments that restate the next line

## Changes Made
- Condensed verbose intro paragraph to a single line
- Removed "Browse apps by topic/tag to find packages using similar technology stacks:" (redundant with section title)
- Removed "The GitLab API enables searching and fetching package code programmatically:" (redundant with section title)
- Removed "When packaging a new app, study these well-maintained packages as templates:" (redundant with section title)
- Tightened "When examining a reference package, focus on these files:" → "Focus on these files in any reference package:"
- Removed "# Clone a reference app for local study" comment (restates the next line)
- Removed "# Or use sparse checkout for specific files" comment (restates the next line)
- Removed "When facing a specific packaging challenge, search across all packages:" (redundant with section title)
- Converted "# Browse recently updated packages (most active/maintained)\n# Visit: URL" to inline comment with URL

## Content Preservation
All tables, code blocks, URLs, API examples, and common patterns preserved verbatim.

## Testing
- Risk: **Low** (docs/agent prompt, no code changes)
- Self-assessed: content verified line-by-line against original

## Runtime Testing
`self-assessed` — documentation-only change, no executable code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.680 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 6,833 tokens on this as a headless worker.