### PR TITLE
GH#15282: tighten cross-channel-conversation-continuity.md

### DIFF
--- a/.agents/services/communications/cross-channel-conversation-continuity.md
+++ b/.agents/services/communications/cross-channel-conversation-continuity.md
@@ -24,33 +24,21 @@ Use the entity ID in `memory.db` as the continuity key:
 
 ## Core Rule
 
-Resolve identity first, then continue the conversation.
-
-Never infer continuity from display name alone. Require explicit channel mapping and an explicit confidence level.
+Resolve identity first, then continue the conversation. Never infer continuity from display name alone — require explicit channel mapping and an explicit confidence level.
 
 ## Workflow
 
 1. Resolve the incoming sender and channel to an entity.
 2. If unresolved, suggest candidates and require confirmation.
-3. Reuse an existing conversation when topic and participants still align.
-4. Start a new conversation when topic or audience changed.
-5. Log the interaction to Layer 0 with channel metadata.
-6. Load context from the same entity before replying.
+3. Reuse an existing conversation when topic and participants still align; start a new one when topic or audience changed.
+4. Log the interaction to Layer 0 with channel metadata.
+5. Load context from the same entity before replying.
 
 ## Email Identity Rules
 
-Use `entity-helper.sh` email normalization for stable matching:
+Use `entity-helper.sh` email normalization for stable matching: trim whitespace, lowercase, strip plus aliases from the local part.
 
-- trim whitespace
-- lowercase the address
-- strip plus aliases from the local part
-
-Examples:
-
-- ` User+alerts@Example.COM ` -> `user@example.com`
-- `sales+q1@company.com` -> `sales@company.com`
-
-This preserves continuity when the same person uses tagged aliases for filtering.
+Example: ` User+alerts@Example.COM ` → `user@example.com`
 
 ## Command Pattern
 
@@ -80,17 +68,10 @@ entity-helper.sh context <entity_id> --channel email --limit 20 --privacy-filter
 
 ## Threading Guide
 
-Reply in the existing thread when:
-
-- topic is the same
-- history is recent (roughly <= 30 days)
-- recipient set is stable
-
-Start a new thread when:
-
-- the decision or request topic is new
-- the thread is long dormant
-- the audience changed materially
+| Condition | Action |
+|-----------|--------|
+| Same topic, recent history (≤30 days), stable recipients | Reply in existing thread |
+| New topic, dormant thread, or audience changed | Start new thread |
 
 When starting a new thread, reference the old thread in the first line for continuity.
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/communications/cross-channel-conversation-continuity.md` from 102 to 83 lines per simplification scan.

## Issue
Closes #15282

## Files Changed
- `.agents/services/communications/cross-channel-conversation-continuity.md` — 102 → 83 lines (-19 lines)

## Changes Made
- Merged two-sentence Core Rule into one
- Condensed 6-step workflow to 5 by combining related steps
- Reduced Email Identity Rules: one example instead of two (same pattern, redundant)
- Converted Threading Guide from two separate bullet lists to a compact table
- All commands, guardrails, task IDs, and institutional knowledge preserved

## Testing
**Risk level:** Low (docs/agent prompt only — no code, no runtime behaviour change)
**Verification:** `wc -l` confirms 83 lines. Content diff reviewed — all `entity-helper.sh` commands, guardrails, and decision logic intact.

## Runtime Testing
`self-assessed` — Low risk: agent prompt doc, no executable code paths.

---
[aidevops.sh](https://aidevops.sh) v3.5.682 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,470 tokens on this as a headless worker.