### PR TITLE
GH#14359: tighten seo-export.md agent doc (74→45 lines)

### DIFF
--- a/.agents/scripts/commands/seo-export.md
+++ b/.agents/scripts/commands/seo-export.md
@@ -8,67 +8,38 @@ Export SEO ranking data from configured platforms to a common TOON format for an
 
 Target: $ARGUMENTS
 
-## Quick Reference
-
-- **Purpose**: Export SEO data for analysis
-- **Platforms**: GSC, Bing, Ahrefs, DataForSEO
-- **Output**: `~/.aidevops/.agent-workspace/work/seo-data/{domain}/`
-
 ## Usage
 
 ```bash
-# Export from all platforms
 /seo-export all example.com
-
-# Export from specific platform
 /seo-export gsc example.com
 /seo-export bing example.com
 /seo-export ahrefs example.com
 /seo-export dataforseo example.com
-
-# With date range
 /seo-export all example.com --days 30
-
-# List available platforms
 /seo-export list
-
-# List exports for a domain
 /seo-export exports example.com
 ```
 
+Output: `~/.aidevops/.agent-workspace/work/seo-data/{domain}/`
+
 ## Process
 
-1. Parse $ARGUMENTS to extract platform, domain, and options
-2. Run the appropriate export script:
-
-```bash
-~/.aidevops/agents/scripts/seo-export-helper.sh $ARGUMENTS
-```
-
-3. Report results including:
-   - Number of rows exported
-   - Output file location
-   - Any errors or warnings
+1. Parse `$ARGUMENTS` for platform, domain, and options
+2. Run: `~/.aidevops/agents/scripts/seo-export-helper.sh $ARGUMENTS`
+3. Report: rows exported, output file path, errors/warnings
 
 ## Platform Requirements
 
-| Platform | Credential | Location |
-|----------|------------|----------|
+| Platform | Credential | Env var |
+|----------|------------|---------|
 | GSC | Service account JSON | `GOOGLE_APPLICATION_CREDENTIALS` |
 | Bing | API key | `BING_WEBMASTER_API_KEY` |
 | Ahrefs | API key | `AHREFS_API_KEY` |
 | DataForSEO | Username/password | `DATAFORSEO_USERNAME`, `DATAFORSEO_PASSWORD` |
 
-All credentials should be set in `~/.config/aidevops/credentials.sh`.
+Credentials: `~/.config/aidevops/credentials.sh`
 
 ## Next Steps
 
-After export, suggest running analysis:
-
-```bash
-/seo-analyze example.com
-```
-
-## Documentation
-
-For full documentation, read `seo/data-export.md`.
+Run `/seo-analyze example.com` after export. Full docs: `seo/data-export.md`.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/scripts/commands/seo-export.md` from 74 to 45 lines (39% reduction) per simplification scan GH#14359.

## Changes
- Removed redundant Quick Reference section (purpose already in frontmatter description and opening body line)
- Tightened Process section: numbered steps → compact inline format
- Consolidated Next Steps + Documentation into a single line
- Preserved all 8 command examples, all 4 platform credential env vars, helper script reference, output path, and doc pointer

## Issue
Closes #14359

## Files Changed
- `.agents/scripts/commands/seo-export.md`: 74→45 lines

## Testing
**Risk level:** Low (agent doc, no code logic)
**Verification:** All code blocks, command examples, credential env vars, and file references present before and after (verified with grep).

## Runtime Testing
`self-assessed` — Low risk: agent doc only, no executable code changed.

---
[aidevops.sh](https://aidevops.sh) v3.5.690 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,405 tokens on this as a headless worker.