### PR TITLE
GH#14360: tighten overview.md AI Coding Tools doc (73→71 lines)

### DIFF
--- a/.agents/tools/ai-assistants/overview.md
+++ b/.agents/tools/ai-assistants/overview.md
@@ -27,8 +27,6 @@ tools:
 
 ## Supported Tools
 
-aidevops is developed, tested, and supported exclusively with OpenCode and the claude-code CLI.
-
 ### OpenCode (Primary)
 
 | Variant | Description |
@@ -46,7 +44,7 @@ aidevops is developed, tested, and supported exclusively with OpenCode and the c
 
 ### claude-code CLI (Companion)
 
-The `claude` CLI from Anthropic is used as a companion tool, called from within OpenCode for sub-tasks and headless dispatch.
+Called from within OpenCode for sub-tasks and headless dispatch.
 
 - **Usage**: `claude -p "subtask"` (spawns from OpenCode)
 - **Config**: `~/.claude/`, `~/.config/Claude/`
@@ -61,7 +59,7 @@ Personal AI assistant accessible via WhatsApp, Telegram, Slack, Discord, Signal,
 
 ## Collaborator Compatibility
 
-aidevops generates lightweight pointer files (`.cursorrules`, `.windsurfrules`, etc.) in projects initialized with `aidevops init`. These contain a single reference to `AGENTS.md`, helping collaborators using other editors find the project context. aidevops does not install into, configure, or manage those tools.
+`aidevops init` generates lightweight pointer files (`.cursorrules`, `.windsurfrules`, etc.) containing a single reference to `AGENTS.md`. aidevops does not install into, configure, or manage those tools.
 
 ## Related
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ai-assistants/overview.md` (73→71 lines) per simplification issue GH#14360.

## Issue
Closes #14360

## Changes
- Removed redundant prose sentence under `## Supported Tools` (already stated in Quick Reference)
- Tightened claude-code CLI section prose (removed restatement of section header)
- Tightened Collaborator Compatibility paragraph (merged two sentences, removed implied context)

## Files Changed
- `.agents/tools/ai-assistants/overview.md` — 73→71 lines (-2 lines net, -4 added +2)

## Testing
**Risk level:** Low — docs/agent prompt only, no code, no commands changed.
**Verification:** All code blocks, URLs, file references, command examples preserved. `diff` confirms only decorative/redundant prose removed. Agent behaviour unchanged.

## Runtime Testing
`self-assessed` — Low risk: docs-only change, no executable code, no commands modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.690 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,738 tokens on this as a headless worker.