### PR TITLE
GH#14055: tighten r2-patterns.md - remove boilerplate wrapper, clarify S3 SDK usage

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/r2-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2-patterns.md
@@ -95,8 +95,9 @@ const valid = object.checksums.sha256 && arrayBuffersEqual(retrievedHash, object
 
 ## Storage Class Transitions
 
+Uses S3-compatible API (not Workers binding):
+
 ```typescript
-// Use S3 SDK CopyObject to transition
 const s3 = new S3Client({...});
 await s3.send(new CopyObjectCommand({
   Bucket: 'my-bucket',
@@ -108,20 +109,18 @@ await s3.send(new CopyObjectCommand({
 
 ## Public Bucket with Custom Domain
 
+Extends the streaming pattern with CORS and long-lived cache headers:
+
 ```typescript
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const key = new URL(request.url).pathname.slice(1);
-    const object = await env.MY_BUCKET.get(key);
-    if (!object) return new Response('Not found', { status: 404 });
+const key = new URL(request.url).pathname.slice(1);
+const object = await env.MY_BUCKET.get(key);
+if (!object) return new Response('Not found', { status: 404 });
 
-    const headers = new Headers();
-    object.writeHttpMetadata(headers);
-    headers.set('etag', object.httpEtag);
-    headers.set('access-control-allow-origin', '*');
-    headers.set('cache-control', 'public, max-age=31536000, immutable');
+const headers = new Headers();
+object.writeHttpMetadata(headers);
+headers.set('etag', object.httpEtag);
+headers.set('access-control-allow-origin', '*');
+headers.set('cache-control', 'public, max-age=31536000, immutable');
 
-    return new Response(object.body, { headers });
-  }
-};
+return new Response(object.body, { headers });
 ```


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/cloudflare-platform-skill/r2-patterns.md` (127 → 126 lines) per simplification issue GH#14055.

### Changes

- **Public Bucket with Custom Domain**: Removed redundant `export default { async fetch(...) }` wrapper boilerplate. The unique value of this section is the CORS (`access-control-allow-origin: *`) and long-lived cache (`cache-control: public, max-age=31536000, immutable`) headers — not the standard Worker fetch handler already shown in every other example.
- **Storage Class Transitions**: Replaced inline code comment `// Use S3 SDK CopyObject to transition` with a prose note above the block: "Uses S3-compatible API (not Workers binding)". This is a meaningful distinction — agents choosing between Workers binding and S3 SDK need to know this section uses the latter.

### Preservation check

All code blocks, patterns, URLs, and knowledge preserved. No task IDs or incident references in this file. Line count reduction is 1 line (boilerplate removal net of added prose).

## Runtime Testing

**Risk level**: Low — agent doc (`.md`), no executable code changed.
**Verification**: `self-assessed` — all code blocks present before and after, no broken references.

Closes #14055

---
[aidevops.sh](https://aidevops.sh) v3.5.690 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,632 tokens on this as a headless worker.