### PR TITLE
GH#14627: tighten remotion-extract-frames.md agent doc

### DIFF
--- a/.agents/tools/video/remotion-extract-frames.md
+++ b/.agents/tools/video/remotion-extract-frames.md
@@ -10,7 +10,7 @@ metadata:
 
 Use [Mediabunny](https://mediabunny.dev) to extract frames at specific timestamps for thumbnails, filmstrips, and per-frame processing.
 
-## `extractFrames(props)`
+## API
 
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
@@ -18,6 +18,8 @@ Use [Mediabunny](https://mediabunny.dev) to extract frames at specific timestamp
 | `timestampsInSeconds` | `number[]` \| `(opts) => Promise<number[]>` | Yes | Fixed list or callback receiving `{track, container, durationInSeconds}` |
 | `onVideoSample` | `(sample: VideoSample) => void` | Yes | Called for each decoded frame |
 | `signal` | `AbortSignal` | No | Cancel in-flight extraction |
+
+## Implementation
 
 ```tsx
 import {
@@ -109,7 +111,6 @@ await extractFrames({
     return timestamps;
   },
   onVideoSample: (sample) => {
-    // Render to canvas (see Basic usage above)
     sample.draw(document.createElement("canvas").getContext("2d")!, 0, 0);
   },
 });


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/video/remotion-extract-frames.md` (148 lines) per GH#14627 simplification scan.

**Classification:** Instruction doc (YAML frontmatter, `mode: subagent`). Not a reference corpus — tighten prose, not restructure into chapters.

**Changes:**
- Split ambiguous `## \`extractFrames(props)\`` into `## API` (props table) and `## Implementation` (code block) — clearer section structure, easier to navigate
- Remove "what" comment `// Render to canvas (see Basic usage above)` in filmstrip example — restates the next line and cross-references another section unnecessarily

**Preserved:** All code blocks, URLs, API table, all usage examples (basic, filmstrip, cancellation/timeout), all institutional knowledge.

## Issue
Closes #14627

## Files changed
- `.agents/tools/video/remotion-extract-frames.md` — 3 insertions, 2 deletions (net +1 line for the new `## Implementation` header)

## Testing
- `npx markdownlint-cli2 .agents/tools/video/remotion-extract-frames.md` → 0 errors
- Content preservation verified: all code blocks, URLs, API table, and usage examples present before and after
- Risk: **Low** (docs-only change, agent behaviour unchanged)

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.690 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 5,172 tokens on this as a headless worker.