### PR TITLE
GH#14435: tighten findings-to-tasks.md — remove redundant prose labels

### DIFF
--- a/.agents/scripts/commands/findings-to-tasks.md
+++ b/.agents/scripts/commands/findings-to-tasks.md
@@ -4,19 +4,17 @@ agent: Build+
 mode: subagent
 ---
 
-Convert deferred actionable findings from an audit/review report into tracked TODO tasks and linked GitHub issues.
+Convert actionable findings from an audit/review report into tracked TODO tasks and linked GitHub issues.
 
 Input file: `$ARGUMENTS`
 
 ## Required Format
 
-Create a text file with one actionable finding per line:
+One finding per line:
 
 ```text
 severity|title|details
 ```
-
-Examples:
 
 ```text
 high|Harden prompt-guard fallback on malformed markdown|Reject malformed HTML comments before rendering summary
@@ -27,8 +25,6 @@ low|Improve stale worker log wording|Clarify blocked vs failed in watchdog outpu
 If severity is omitted, it defaults to `medium`.
 
 ## Command
-
-Run:
 
 ```bash
 ~/.aidevops/agents/scripts/findings-to-tasks-helper.sh create \


### PR DESCRIPTION
## Summary

- Removed "deferred" qualifier from intro (ambiguous — not reflected in the helper command)
- Replaced "Create a text file with one actionable finding per line:" with "One finding per line:" (tighter)
- Removed "Examples:" label before code block (self-evident from context)
- Removed "Run:" label before command block (redundant)

56 → 52 lines. All code blocks, command examples, flags, completion rule, and task ID references preserved verbatim.

Closes #14435

---
[aidevops.sh](https://aidevops.sh) v3.5.691 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 2,738 tokens on this as a headless worker.