### PR TITLE
GH#14371: tighten bot-management.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/bot-management.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/bot-management.md
@@ -1,10 +1,7 @@
 # Cloudflare Bot Management
 
-Enterprise-grade bot detection, protection, and mitigation using ML/heuristics, bot scores, JavaScript detections, and verified bot handling.
+Multi-tier bot detection and mitigation using ML/heuristics, bot scores, JavaScript detections, and verified bot handling.
 
-## Overview
-
-Bot Management provides multi-tier protection:
 - **Free (Bot Fight Mode)**: Auto-blocks definite bots, no config
 - **Pro/Business (Super Bot Fight Mode)**: Configurable actions, static resource protection, analytics groupings
 - **Enterprise (Bot Management)**: Granular 1-99 scores, WAF integration, JA3/JA4 fingerprinting, Workers API, Advanced Analytics
@@ -22,7 +19,7 @@ Bot Management provides multi-tier protection:
 
 **Bot Scores**: 1-99 (1 = definitely automated, 99 = definitely human). Threshold: <30 indicates bot traffic. Enterprise gets granular 1-99; Pro/Business get groupings only.
 
-**Detection Engines**: Heuristics (known fingerprints, assigns score=1), ML (majority of detections, supervised learning on billions of requests), Anomaly Detection (optional, baseline traffic analysis), JavaScript Detections (headless browser detection).
+**Detection Engines**: Heuristics (known fingerprints → score=1), ML (supervised learning on billions of requests), Anomaly Detection (optional, baseline analysis), JavaScript Detections (headless browser detection).
 
 **Verified Bots**: Allowlisted good bots (search engines, AI crawlers) verified via reverse DNS or Web Bot Auth. Access via `cf.bot_management.verified_bot` or `cf.verified_bot_category`.
 
@@ -37,7 +34,7 @@ Bot Management provides multi-tier protection:
 ## Basic Patterns
 
 ```typescript
-// Workers: Check bot score
+// Workers API
 export default {
   async fetch(request: Request): Promise<Response> {
     const botScore = request.cf?.botManagement?.score;


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/cloudflare-platform-skill/bot-management.md` (69 → 66 lines) per instruction-doc simplification guidelines.

**Changes:**
- Removed redundant `## Overview` header — merged tier list directly under intro (the header added no value; the list is the content)
- Tightened intro sentence: "Enterprise-grade bot detection, protection, and mitigation using ML/heuristics, bot scores, JavaScript detections, and verified bot handling" → "Multi-tier bot detection and mitigation using ML/heuristics, bot scores, JavaScript detections, and verified bot handling"
- Tightened Detection Engines run-on: replaced "assigns score=1" with `→ score=1` and "majority of detections, supervised learning" with "supervised learning" (the "majority" claim is implicit in the ML description)
- Replaced "what" comment `// Workers: Check bot score` with `// Workers API` (the section heading already provides context)

**Preserved:** all code blocks, WAF rule expressions, API field names (`cf.bot_management.score`, `cf.bot_management.verified_bot`, `cf.verified_bot_category`), platform limits table, all internal/external links, task IDs, and decision rationale.

## Testing

- Risk level: **Low** (agent doc, no executable code changed)
- Verification: all code blocks, URLs, command examples, and field references present before and after (`self-assessed`)

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/bot-management.md` (69 → 66 lines, -4.3%)

Closes #14371

---
[aidevops.sh](https://aidevops.sh) v3.5.691 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,287 tokens on this as a headless worker.