### PR TITLE
GH#15378: tighten tokens.md — remove redundant labels, compress prose, clean up section headers

### DIFF
--- a/.agents/tools/ui/nothing-design-skill/tokens.md
+++ b/.agents/tools/ui/nothing-design-skill/tokens.md
@@ -10,7 +10,7 @@
 | **Body / UI** | `"Space Grotesk"` | `"DM Sans", system-ui, sans-serif` | Light 300, Regular 400, Medium 500, Bold 700 |
 | **Data / Labels** | `"Space Mono"` | `"JetBrains Mono", "SF Mono", monospace` | Regular 400, Bold 700 |
 
-**Why these fonts:** Doto = variable dot-matrix (closest to NDot 57). Space Grotesk + Space Mono by Colophon Foundry — same foundry as Nothing's actual typefaces. Shared design DNA.
+Doto = variable dot-matrix (closest to NDot 57). Space Grotesk + Space Mono by Colophon Foundry — same foundry as Nothing's actual typefaces.
 
 ### Type Scale
 
@@ -63,7 +63,7 @@
 | `--info` | `#999999` | Uses secondary text color |
 | `--interactive` | `#007AFF` / `#5B9BF6` | Tappable text: links, picker values. Not for buttons. |
 
-**Data status colors:** `--success` = good/in range, `--warning` = moderate/attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply color to **value**, not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
+**Data status:** `--success` = good/in range, `--warning` = moderate/attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply color to **value**, not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
 
 ### Dark / Light Mode
 
@@ -80,10 +80,10 @@
 | `--text-display` | `#FFFFFF` | `#000000` |
 | `--interactive` | `#5B9BF6` | `#007AFF` |
 
-**Identical across modes:** Accent red, status colors, ALL CAPS labels, fonts, type scale, spacing, component shapes.
+Identical across modes: accent red, status colors, ALL CAPS labels, fonts, type scale, spacing, component shapes.
 
-**Dark feel:** Instrument panel in a dark room. OLED black, white data glowing.
-**Light feel:** Printed technical manual. Off-white paper (#F5F5F5), black ink. Cards = `#FFFFFF` on off-white page = subtle elevation without shadows.
+**Dark:** Instrument panel in a dark room — OLED black, white data glowing.
+**Light:** Printed technical manual — off-white paper (#F5F5F5), black ink. Cards = `#FFFFFF` on off-white = subtle elevation without shadows.
 
 ---
 
@@ -126,8 +126,6 @@
 ## 6. DOT-MATRIX MOTIF
 
 **When to use:** Hero typography (Doto), decorative grid backgrounds, dot-grid data viz, loading indicators, empty state illustrations.
-
-### CSS Implementation
 
 ```css
 .dot-grid {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.696"
+    "version": "3.5.697"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.696
+# Version: 3.5.697
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.696.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.697.tar.gz"
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.696",
+  "version": "3.5.697",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.696
+# Version: 3.5.697
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.696
+sonar.projectVersion=3.5.697
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ui/nothing-design-skill/tokens.md` (143 → 141 lines) per GH#15378 simplification scan.

## Issue
Closes #15378

## Classification
**Reference corpus** (design token values, CSS, type scale tables) — content preserved exactly. Only prose rationale compressed.

## Changes
- Removed `**Why these fonts:**` bold label (context is self-evident from table)
- Removed "Shared design DNA." (redundant conclusion)
- Shortened "Data status colors:" → "Data status:"
- Removed bold from "Identical across modes" note (not a rule)
- Tightened "Dark feel/Light feel" labels → "Dark/Light" with em-dash joining
- Removed `### CSS Implementation` subheading (code block is self-evident)

## Files Changed
- `.agents/tools/ui/nothing-design-skill/tokens.md` — 5 insertions, 7 deletions

## Testing
- `markdownlint-cli2`: 0 errors
- All token values, CSS code blocks, typographic rules, and institutional knowledge preserved
- Verified via `git diff` — no token values, hex codes, or CSS removed

## Runtime Testing
**Risk: Low** — docs/agent prompt file only. No runtime verification required. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.693 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,698 tokens on this as a headless worker.