### PR TITLE
GH#15388: tighten browser-benchmark-scripts-01-playwright.md — remove redundant intro table

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
@@ -1,15 +1,6 @@
 # Playwright Benchmark Scripts
 
-Reference implementation for `browser-benchmark-scripts.md`.
-
-- Target: `https://the-internet.herokuapp.com`
-- Coverage: `navigate`, `formFill`, `extract`, `multiStep`
-- Sampling: 3 runs per test, median reported
-
-| Script | What it measures |
-|--------|-----------------|
-| Sequential | Per-test latency: navigate, formFill, extract, multiStep — one page at a time |
-| Parallel | Throughput: 5 contexts, 3 browsers, 10 pages — concurrent load |
+Reference implementation for `browser-benchmark-scripts.md`. Target: `https://the-internet.herokuapp.com`. Tests: `navigate`, `formFill`, `extract`, `multiStep` — 3 runs each, median reported.
 
 ## Sequential script
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/browser/browser-benchmark-scripts-01-playwright.md` per GH#15388.

**Classification:** Reference corpus (code scripts, not instruction doc). Content must not be compressed — only prose overhead reduced.

**Change:** Removed the redundant intro table (which duplicated what the `## Sequential script` and `## Parallel script` section headers already convey) and consolidated the 3-line header into a single inline sentence. All code blocks, URLs, test names, and sampling methodology preserved verbatim.

**Result:** 100 → 91 lines (9% reduction in token overhead, zero knowledge loss).

Closes #15388

## Runtime Testing

Risk: **Low** — docs/agent prompt file only, no executable code paths changed. Self-assessed.

## Files Changed

- `.agents/tools/browser/browser-benchmark-scripts-01-playwright.md` — remove redundant table, tighten intro prose

---
<!-- MERGE_SUMMARY -->
**What:** Tighten Playwright benchmark scripts doc — remove redundant intro table, consolidate header prose.
**Issue:** Closes #15388
**Files changed:** 1 (`.agents/tools/browser/browser-benchmark-scripts-01-playwright.md`)
**Testing:** Self-assessed (low-risk docs change; all code blocks and URLs verified intact)
**Key decisions:** Classified as reference corpus → no content compression; only prose overhead removed

---
[aidevops.sh](https://aidevops.sh) v3.5.693 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,750 tokens on this as a headless worker.