### PR TITLE
GH#14532: tighten stealth-patches.md - remove redundant sub-headers

### DIFF
--- a/.agents/tools/browser/stealth-patches.md
+++ b/.agents/tools/browser/stealth-patches.md
@@ -31,15 +31,11 @@ pip install rebrowser-playwright          # Drop-in replacement (Python)
 npx rebrowser-patches@latest unpatch     # Restore original
 ```
 
-**Node.js:**
-
 ```javascript
 import { chromium } from 'rebrowser-playwright';  // or 'playwright' after patching
 const browser = await chromium.launch({ headless: true, args: ['--disable-blink-features=AutomationControlled'] });
 const context = await browser.newContext({ viewport: { width: 1920, height: 1080 }, userAgent: '<realistic UA string>' });
 ```
-
-**Python:**
 
 ```python
 from rebrowser_playwright.sync_api import sync_playwright  # or playwright after patching
@@ -48,7 +44,7 @@ with sync_playwright() as p:
     context = browser.new_context(viewport={'width': 1920, 'height': 1080}, user_agent='<realistic UA string>')
 ```
 
-## playwright-stealth (Python)
+## playwright-stealth
 
 JS-level evasions cover `navigator.webdriver`, plugins, languages, `chrome.runtime`, `window.chrome`, Permissions API, iframe detection, WebGL, and `hardwareConcurrency`.
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/browser/stealth-patches.md` per build-agent principles (GH#14532).

**Changes:**
- Removed `**Node.js:**` and `**Python:**` sub-headers — code blocks are self-documenting (language is visible from import syntax)
- Removed `(Python)` qualifier from `## playwright-stealth` section header — redundant given the code block content

**Preserved:** All code blocks, URLs, command examples, task ID references, and institutional knowledge intact. 117 → 113 lines.

**Classification:** Instruction doc (not reference corpus). Safe/high-confidence simplification — decorative sub-headers with no informational value.

## Runtime Testing

Risk: **Low** — agent doc only, no executable code changed. `self-assessed`.

## Verification

- All code blocks present before and after ✓
- All URLs present before and after ✓  
- No command examples removed ✓
- Agent behaviour unchanged ✓

Closes #14532

---
[aidevops.sh](https://aidevops.sh) v3.5.698 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,071 tokens on this as a headless worker.