### PR TITLE
GH#15025: tighten r2.md — merge Storage Classes into Quick Reference table

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/r2.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/r2.md
@@ -9,7 +9,7 @@ Use R2 for assets, uploads, backups, and dataset blobs when you want S3 compatib
 | API surface | Workers binding and S3-compatible REST API |
 | Consistency | Strong consistency for writes and deletes |
 | Cost model | Zero egress fees; Infrequent Access adds retrieval and minimum-duration costs |
-| Storage classes | `Standard`, `InfrequentAccess` |
+| Storage classes | `Standard` (frequent access); `InfrequentAccess` (lower cost, 30-day min + retrieval fees) |
 | Encryption | SSE-C supported |
 
 ## Quick Start
@@ -37,11 +37,6 @@ if (object) return new Response(object.body);
 | `head(key)` | Read metadata without the body |
 | `delete(keys)` | Delete one key or a batch |
 | `list(options?)` | Page through objects by prefix/cursor |
-
-## Storage Classes
-
-- **Standard**: frequent access, low-latency reads.
-- **InfrequentAccess**: lower storage cost, but 30-day minimum billing and retrieval fees.
 
 ## Read Next
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/r2.md` (53 → 48 lines) by eliminating the redundant `## Storage Classes` section. The billing detail (30-day minimum, retrieval fees) is folded into the existing Quick Reference table row, preserving all knowledge in a single location.

## Issue
Closes #15025

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/r2.md` — 1 insertion, 6 deletions

## Testing
**Risk level:** Low (agent doc, no code, no commands changed)
**Verification:** All code blocks, URLs, command examples, and storage class billing detail present before and after. No broken internal links. `wc -l` reduced from 53 to 48.

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — content compression appropriate
- Storage Classes section was pure duplication of Quick Reference table row, with only the billing detail as additive — merged inline rather than deleted
- No task IDs, incident refs, or decision rationale removed

## Runtime Testing
`self-assessed` — Low risk: doc-only change, no executable code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.698 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 3,360 tokens on this as a headless worker.