### PR TITLE
GH#15027: tighten models-sonnet.md agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -743,7 +743,7 @@
       "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
       "issue": "GH#14286",
       "passes": 2,
-      "note": "Reference corpus chapter tightened: 92 → 90 lines. Removed decorative closing sentence with no information value. Zero content loss."
+      "note": "Reference corpus chapter tightened: 92 \u2192 90 lines. Removed decorative closing sentence with no information value. Zero content loss."
     },
     ".agents/marketing-sales/cro-chapter-20.md": {
       "at": "2026-03-29T16:34:29Z",
@@ -4690,5 +4690,12 @@
       "pr": 15665,
       "passes": 1
     }
+  },
+  ".agents/tools/ai-assistants/models-sonnet.md": {
+    "hash": "0c05100e46a64137b6b5ac05c49b6460b8393e773942fdeffd4b10ebfca75af9",
+    "simplified": true,
+    "issue": "GH#15027",
+    "lines_before": 54,
+    "lines_after": 56
   }
 }

--- a/.agents/tools/ai-assistants/models-sonnet.md
+++ b/.agents/tools/ai-assistants/models-sonnet.md
@@ -22,22 +22,25 @@ tools:
 
 # Sonnet Tier Model (Default)
 
-Default tier for most development work: balanced capability, cost, and speed for implementation-heavy tasks.
+Default tier for most development work: balanced capability, cost, and speed.
 
 ## Use For
 
-- Writing and modifying code
-- Debugging, implementation reasoning, and code review
-- Test writing and execution
+- Code writing, debugging, review, and test authoring
 - Documentation derived from code
 - Interactive development tasks
 
 ## Routing Rules
 
-- Use sonnet unless the task clearly needs less, more, or much larger context.
-- Route simple classification and formatting to haiku.
-- Route architecture decisions and novel problems to opus.
-- Route very large context needs (100K+ tokens) to pro.
+- Default: use sonnet unless the task clearly needs less, more, or much larger context.
+- Route simple classification and formatting → haiku.
+- Route architecture decisions and novel problems → opus.
+- Route very large context needs (100K+ tokens) → pro.
+
+## Constraints
+
+- Do not use for tasks that are purely classification or reformatting — route to haiku.
+- Do not use for novel architecture decisions or complex trade-offs — route to opus.
 
 ## Model Details
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ai-assistants/models-sonnet.md` per build-agent guidance (GH#15027).

## Changes
- Merged 5 "Use For" bullets → 3 (no information lost, just consolidated)
- Added "Constraints" section (parallel to `models-haiku.md` pattern) — explicit negative routing rules
- Tightened "Routing Rules" prose with arrow notation for scannability
- Updated `simplification-state.json` registry with new hash

## Issue
Closes #15027

## Files Changed
- `.agents/tools/ai-assistants/models-sonnet.md` — 54→56 lines (added Constraints section)
- `.agents/configs/simplification-state.json` — registry updated

## Testing
- `self-assessed` (Low risk: agent doc, no code paths changed)
- All code blocks, task IDs, model details, and fallback chain preserved
- Verified against `models-haiku.md` for structural consistency

## Runtime Testing
Risk: **Low** — documentation-only change, no executable code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.698 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 6,505 tokens on this as a headless worker.