### PR TITLE
GH#15101: tighten cron-triggers-patterns.md — remove redundant intro sentence (128→126 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md
@@ -1,7 +1,5 @@
 # Cron Triggers Patterns
 
-Common scheduled-worker patterns for sync jobs, cleanup, reporting, health checks, and monitoring.
-
 ## Scheduled API Sync
 Refresh external data on a schedule and cache the result for reads between runs.
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
**What:** Remove redundant intro sentence from `cron-triggers-patterns.md` that restated what the section headers already enumerate.

**Issue:** Closes #15101

**Files changed:** `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md` (128→126 lines, -2)

**Testing:** All code blocks, URLs, task ID references, and command examples verified present before and after. Section headers, cross-references (`./cron-triggers.md`, `./cron-triggers-gotchas.md`), and all pattern content unchanged.

**Key decisions:**
- File classified as reference corpus (pattern library). Per code-simplifier rules (GH#6432), reference corpora should not be compressed — but at 128 lines, splitting into chapters adds overhead without value.
- Only genuine noise removed: the intro sentence on line 3 ("Common scheduled-worker patterns for sync jobs, cleanup, reporting, health checks, and monitoring.") restates what the 6 section headers already communicate. No knowledge lost.
- All 6 patterns, observability section, and See Also links preserved intact.

## Runtime Testing

Risk: **Low** — docs/markdown only, no code execution paths. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.698 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,336 tokens on this as a headless worker.