### PR TITLE
GH#15412: tighten cron-triggers.md — merge Key Features into intro, collapse test command inline (84→75 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md
@@ -1,12 +1,6 @@
 # Cloudflare Cron Triggers
 
-Schedule Workers execution using cron expressions. Runs on Cloudflare's global network during underutilized periods.
-
-## Key Features
-
-- **5-field cron syntax** - Quartz scheduler extensions (L, W, #)
-- **At-least-once delivery** - Rare duplicate executions possible
-- **Workflow integration** - Trigger long-running multi-step tasks
+Schedule Workers execution using cron expressions. Runs on Cloudflare's global network during underutilized periods. Uses 5-field cron syntax with Quartz extensions (L, W, #). At-least-once delivery — rare duplicate executions possible. Supports Workflow integration for long-running multi-step tasks.
 
 ## Cron Syntax
 
@@ -58,23 +52,20 @@ export default {
   ): Promise<void> {
     console.log("Cron:", controller.cron);
     console.log("Time:", new Date(controller.scheduledTime));
-    
     ctx.waitUntil(asyncTask(env)); // Non-blocking
   },
 };
 ```
 
-**Test locally:**
-
-```bash
-npx wrangler dev
-curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"
-```
+**Test locally:** `npx wrangler dev` then `curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"`
 
 ## Limits
 
-- **Free:** 3 triggers/worker, 10ms CPU
-- **Paid:** Unlimited triggers, 50ms CPU
+| Plan | Triggers/worker | CPU |
+|------|----------------|-----|
+| Free | 3 | 10ms |
+| Paid | Unlimited | 50ms |
+
 - **Propagation:** 15min global deployment
 - **Timezone:** UTC only
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md` per agent doc simplification guidelines. Reduces from 84 to 75 lines (11% reduction).

## Changes
- Merged `## Key Features` 3-bullet section into the intro paragraph — eliminates a redundant section header and 5 lines
- Collapsed "Test locally:" bash code block into a single inline command line — saves 4 lines
- Converted Limits bullets to a table for improved scannability
- Removed trailing whitespace in handler example

## Content Preservation
- All code blocks preserved (wrangler.jsonc, TypeScript handler, cron syntax diagram)
- All cron schedule examples preserved
- All limits values preserved (Free: 3 triggers/10ms CPU, Paid: unlimited/50ms CPU)
- All See Also links preserved
- No task IDs, incident references, or command examples removed

## Testing
- Risk: **Low** (docs-only change, no code logic)
- Self-assessed: content verified line-by-line against original

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

Closes #15412

---
[aidevops.sh](https://aidevops.sh) v3.5.698 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,325 tokens on this as a headless worker.