### PR TITLE
GH#15441: simplification: tighten agent doc Cloudflare Wrangler (wrangler.md)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler.md
@@ -53,7 +53,7 @@ wrangler r2 object put BUCKET/key --file path
 wrangler r2 object get BUCKET/key
 ```
 
-### Other
+### Queues / Vectorize / Hyperdrive
 
 ```bash
 wrangler queues create NAME


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Rename vague `### Other` section heading to `### Queues / Vectorize / Hyperdrive` in `.agents/services/hosting/cloudflare-platform-skill/wrangler.md`.

## Issue
Closes #15441

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/wrangler.md` — 1 line changed (section heading)

## Testing
- All code blocks, commands, URLs, and references preserved (verified by diff)
- File classification: instruction doc (CLI command reference), not reference corpus — tighten prose, not restructure
- Content preservation: all command examples, `See Also` links, and structure intact
- Risk: low — single heading rename, no functional content changed

## Runtime Testing
**Risk level: Low** — docs-only change (agent prompt file, no code). Self-assessed.

## Key Decisions
- File is already lean at 75 lines; the only genuine noise was the vague `### Other` heading
- Renamed to `### Queues / Vectorize / Hyperdrive` to match the three commands it contains
- No content removed — all institutional knowledge preserved

---
[aidevops.sh](https://aidevops.sh) v3.5.702 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,027 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized section headers for improved resource categorization and clarity in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->