### PR TITLE
GH#14849: tighten remotion-get-video-duration.md (59→50 lines)

### DIFF
--- a/.agents/tools/video/remotion-get-video-duration.md
+++ b/.agents/tools/video/remotion-get-video-duration.md
@@ -28,13 +28,6 @@ export const getVideoDuration = async (src: string) => {
 };
 ```
 
-Example:
-
-```tsx
-const duration = await getVideoDuration("https://remotion.media/video.mp4");
-console.log(duration); // e.g. 10.5 (seconds)
-```
-
 ## Local file source
 
 ```tsx
@@ -47,8 +40,6 @@ const input = new Input({
 
 const durationInSeconds = await input.computeDuration();
 ```
-
-Use `FileSource` instead of `UrlSource` when `file` comes from an input or drag-and-drop handler.
 
 ## Remotion `staticFile()`
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/video/remotion-get-video-duration.md` per `build-agent.md` principles. 59 → 50 lines (-15%).

Closes #14849

## What changed

- Removed redundant `Example:` code block (lines 31-36): the `getVideoDuration` function definition immediately above already demonstrates usage; the separate example block added no new information
- Removed redundant prose (line 51): "Use `FileSource` instead of `UrlSource` when `file` comes from an input or drag-and-drop handler" — this restated the inline comment `// File object from input or drag-drop` already in the code

## Content preservation

- All 3 code blocks: preserved
- All imports (`mediabunny`, `remotion`): preserved
- All key APIs (`Input.computeDuration()`, `UrlSource`, `FileSource`, `staticFile`): preserved
- No task IDs or GH refs existed in the file

## Runtime Testing

**Risk level:** Low — agent doc only, no executable code changed.
**Verification:** `self-assessed` — content preservation verified by line-by-line comparison before/after.

<!-- MERGE_SUMMARY -->
**What:** Tighten agent doc by removing redundant example and redundant prose
**Issue:** #14849
**Files changed:** `.agents/tools/video/remotion-get-video-duration.md` (59→50 lines)
**Testing:** Content preservation verified — all code blocks, imports, APIs present
**Key decisions:** Classified as instruction doc (not reference corpus); removed only genuinely redundant content

---
[aidevops.sh](https://aidevops.sh) v3.5.702 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,765 tokens on this as a headless worker.