### PR TITLE
GH#15069: tighten es2016-es2017.md (135→131 lines)

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/es2016-es2017.md
+++ b/.agents/tools/programming/modern-javascript-skill/es2016-es2017.md
@@ -49,8 +49,6 @@ const obj = { async getData() { return await fetchSomething(); } };
 
 ### Object.values() and Object.entries()
 
-Extract object values or key-value pairs as arrays for iteration and transformation.
-
 ```javascript
 const user = { name: 'Alice', age: 30, city: 'NYC' };
 Object.values(user);   // ['Alice', 30, 'NYC']
@@ -66,8 +64,6 @@ const doubled = Object.fromEntries(
 ```
 
 ### String Padding
-
-Pad strings to a target length for alignment and formatting.
 
 ```javascript
 '5'.padStart(3, '0');   // '005'


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/programming/modern-javascript-skill/es2016-es2017.md` per simplification issue GH#15069.

## Changes
- Removed 2 redundant "what" descriptions that restate their section headings (`Object.values/entries`, `String Padding`)
- All code blocks preserved intact
- All behavioral notes preserved (NaN handling, `Object.assign` getter loss, trailing comma rationale, Web Workers context)
- 135 → 131 lines (3% reduction)

## Issue
Closes #15069

## Files Changed
- `.agents/tools/programming/modern-javascript-skill/es2016-es2017.md`

## Testing
**Risk level:** Low (docs/reference corpus, no executable code changed)
**Verification:** All code blocks present before and after; no URLs or task ID refs in this file; agent behaviour unchanged.

## Runtime Testing
`self-assessed` — Low risk: reference corpus doc, no agent instructions modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.702 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,673 tokens on this as a headless worker.