### PR TITLE
GH#15456: tighten agent doc Crawl4AI Benchmark Scripts (65→61 lines)

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md
@@ -1,10 +1,6 @@
 # Crawl4AI Benchmark Scripts
 
-Reference implementation for `browser-benchmark-scripts.md`.
-
-- Target: `https://the-internet.herokuapp.com`
-- Coverage: `navigate`, `extract` (no form interaction or multi-step navigation)
-- Sampling: 3 runs per test
+Reference implementation for `browser-benchmark-scripts.md`. Target: `https://the-internet.herokuapp.com`. Tests: `navigate`, `extract` only (no form/multi-step) — 3 runs each.
 
 ## Sequential benchmark
 


### PR DESCRIPTION
## Summary

- Consolidates 3-bullet metadata block into a single inline line, matching the sibling chapter pattern (`browser-benchmark-scripts-01-playwright.md`)
- All code blocks, URLs, and content preserved — zero knowledge loss
- 65 → 61 lines

## Classification

**Reference corpus** (benchmark scripts chapter in a split corpus). Correct action: tighten prose, not restructure into sub-chapters (already a chapter file).

## Verification

- All code blocks present before and after: `wc -l` 65 → 61
- No broken internal links or references
- Agent behaviour unchanged — metadata is informational only
- Sibling consistency: header now matches `browser-benchmark-scripts-01-playwright.md` pattern

## Runtime Testing

**Risk: Low** — docs/formatting only, no code execution paths affected. `self-assessed`.

Closes #15456

---
[aidevops.sh](https://aidevops.sh) v3.5.702 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 2,962 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark configuration documentation to clarify test specifications and improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->