### PR TITLE
GH#14800: tighten seo-opportunities.md (67→42 lines)

### DIFF
--- a/.agents/scripts/commands/seo-opportunities.md
+++ b/.agents/scripts/commands/seo-opportunities.md
@@ -4,50 +4,25 @@ agent: SEO
 mode: subagent
 ---
 
-Run the complete SEO export + analysis workflow.
+Run the complete SEO export + analysis workflow. Combines `/seo-export all` + `/seo-analyze`. Default range: 90 days.
 
 Target: $ARGUMENTS
-
-## Quick Reference
-
-- **Combines**: `/seo-export all` + `/seo-analyze`
-- **Default range**: 90 days
-- **Outputs**: Platform export TOON files plus one analysis report
 
 ## Usage
 
 ```bash
-# Full workflow with default 90 days
-/seo-opportunities example.com
-
-# Custom date range
+/seo-opportunities example.com          # 90-day default
 /seo-opportunities example.com --days 30
 ```
 
 ## Workflow
 
-1. Parse `$ARGUMENTS` for the domain and options.
-2. Export all configured platforms:
-
-```bash
-~/.aidevops/agents/scripts/seo-export-helper.sh all $DOMAIN --days $DAYS
-```
-
-3. Run full analysis:
-
-```bash
-~/.aidevops/agents/scripts/seo-analysis-helper.sh $DOMAIN
-```
-
-4. Summarize:
-   - Top 10 quick wins
-   - Top 10 striking-distance opportunities
-   - Low-CTR pages needing optimization
-   - Content cannibalization issues
+1. Parse `$ARGUMENTS` for domain and options.
+2. Export all configured platforms: `~/.aidevops/agents/scripts/seo-export-helper.sh all $DOMAIN --days $DAYS`
+3. Run full analysis: `~/.aidevops/agents/scripts/seo-analysis-helper.sh $DOMAIN`
+4. Summarize: top 10 quick wins, top 10 striking-distance opportunities, low-CTR pages, content cannibalization issues.
 
 ## Outputs
-
-Created files:
 
 ```text
 ~/.aidevops/.agent-workspace/work/seo-data/{domain}/{platform}-{start}-{end}.toon


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/scripts/commands/seo-opportunities.md` per simplification-debt issue GH#14800.

## Changes
- Merged "Quick Reference" section into the intro paragraph (eliminated redundant section header)
- Collapsed workflow code blocks into inline backtick commands (steps 2 and 3)
- Collapsed "Outputs" section label into the code block directly
- Removed redundant Usage comments (the description already says "default 90 days")
- Result: 67 → 42 lines (37% reduction)

## Content Preservation
- All command examples preserved: `seo-export-helper.sh`, `seo-analysis-helper.sh`
- All output paths preserved
- All 4 recommendation categories with descriptions preserved
- Documentation links preserved
- `$ARGUMENTS`, `$DOMAIN`, `$DAYS` variables preserved
- Frontmatter unchanged

## Testing
Risk: **Low** (docs/agent prompt only — no code, no runtime behaviour change). `self-assessed`.

## Files Changed
- `.agents/scripts/commands/seo-opportunities.md` (67→42 lines)

Closes #14800

---
[aidevops.sh](https://aidevops.sh) v3.5.702 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 2,737 tokens on this as a headless worker.