### PR TITLE
GH#15959: skip health issue creation for idle repos

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -1051,6 +1051,26 @@ _update_health_issue_for_repo() {
 	local health_issue_file="${cache_dir}/health-issue-${runner_user}-${role_label}-${slug_safe}"
 	mkdir -p "$cache_dir"
 
+	# Guard: skip health issue creation for repos with no activity (GH#15959).
+	# Only applies when no cached issue exists (i.e. this would CREATE a new one).
+	# Existing health issues are still updated normally so the dashboard shows idle state.
+	if [[ ! -f "$health_issue_file" ]]; then
+		local guard_pr_count guard_assigned_count guard_worker_output guard_worker_count
+		guard_pr_count=$(gh pr list --repo "$repo_slug" --state open \
+			--json number --jq 'length' 2>/dev/null || echo "0")
+		guard_assigned_count=$(gh issue list --repo "$repo_slug" \
+			--assignee "$runner_user" --state open \
+			--json number --jq 'length' 2>/dev/null || echo "0")
+		guard_worker_output=$(_scan_active_workers "${repo_path:-}")
+		guard_worker_count="${guard_worker_output##*$'\n'}"
+
+		if [[ "${guard_pr_count:-0}" -eq 0 && "${guard_assigned_count:-0}" -eq 0 && "${guard_worker_count:-0}" -eq 0 ]]; then
+			echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, issues, or workers" \
+				>>"${LOGFILE:-/dev/null}"
+			return 0
+		fi
+	fi
+
 	local health_issue_number
 	health_issue_number=$(_resolve_health_issue_number \
 		"$repo_slug" "$runner_user" "$runner_role" "$runner_prefix" \


### PR DESCRIPTION
## Summary

- Adds an activity guard in `_update_health_issue_for_repo()` that checks open PRs, assigned issues, and active workers before creating a new health issue
- Repos with zero activity no longer get noisy empty dashboard issues (e.g. "0 PRs, 0 assigned, 0 workers")
- Existing health issues are still updated normally so idle dashboards reflect current state

Closes #15959

## Changes

**`.agents/scripts/stats-functions.sh`** (~line 1054):
- Before calling `_resolve_health_issue_number` (which unconditionally creates if not found), check if a cached health issue already exists
- If no cache file → pre-compute counts via `gh pr list`, `gh issue list`, and `_scan_active_workers`
- If all three counts are zero → `return 0` early, skipping creation entirely
- If cache file exists (issue was previously created) → proceed normally to update

## Runtime Testing

| Risk | Level | Verification |
|------|-------|-------------|
| Health issue creation | Low | `self-assessed` — conditional guard, no new external calls on existing code paths |

The guard only adds API calls on the *new issue creation* path (repos without a cached health issue), and those same calls are already made later in the body assembly. Zero-activity repos skip both the guard calls AND the heavier body assembly + issue create calls — net reduction in API usage for idle repos.

---
[aidevops.sh](https://aidevops.sh) v3.5.702 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 5m and 6,699 tokens on this with the user in an interactive session.