### PR TITLE
GH#15723: tighten meta-ads scaling checklist

### DIFF
--- a/.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md
+++ b/.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md
@@ -31,14 +31,7 @@
 
 ## 2. Go / No-Go Gate
 
-All Section 1 boxes must be checked. Key gates:
-
-- CPA below target for 5+ days
-- 50+ conversions recorded
-- Frequency under 3
-- Business can handle more volume
-
-Fix any unchecked bottleneck before increasing budget.
+All Section 1 boxes must be checked. Fix any unchecked bottleneck before increasing budget.
 
 ## 3. Choose the Scaling Method
 
@@ -102,12 +95,8 @@ Stop scaling if any box is checked:
 | Date | Action | Budget Before | Budget After | CPA Before | CPA After | Notes |
 |------|--------|---------------|--------------|------------|-----------|-------|
 | | | $ | $ | $ | $ | |
-| | | $ | $ | $ | $ | |
-| | | $ | $ | $ | $ | |
 
 ## 8. Record the Ceiling
-
-Document current limits before the next increase:
 
 - [ ] Maximum efficient daily spend before diminishing returns
 - [ ] Maximum daily business capacity


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md` per issue #15723 (agent doc simplification).

## Changes
- Removed redundant Go/No-Go bullet list (Section 2) — it duplicated 4 of the 17 Section 1 criteria verbatim with no additional information
- Collapsed Section 2 to a single actionable line: "All Section 1 boxes must be checked. Fix any unchecked bottleneck before increasing budget."
- Removed Section 8 intro prose "Document current limits before the next increase:" — redundant given the checklist items immediately below
- Reduced tracking table template rows from 3 to 1 (header + one row is sufficient as a template)
- 122 → 111 lines (-11 lines, -9%)

## Issue
Closes #15723

## Files Changed
- `.agents/marketing-sales/meta-ads-checklists-scaling-checklist.md`

## Testing
**Risk level:** Low (docs/agent prompt, no code)
**Verification:** All operational content preserved — checklist items, tables, thresholds, code block. No broken references. Agent behaviour unchanged.

## Runtime Testing
`self-assessed` — Low risk: docs-only change, no code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.711 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 3,858 tokens on this as a headless worker.