### PR TITLE
GH#15725: tighten agent doc Inbound Email Commands (91→76 lines)

### DIFF
--- a/.agents/services/email/email-inbound-commands.md
+++ b/.agents/services/email/email-inbound-commands.md
@@ -22,10 +22,13 @@ tools:
 - **Config**: `~/.config/aidevops/email-inbound-commands.conf`
 - **Dedup state**: `~/.aidevops/.agent-workspace/email-inbound-commands/processed-message-ids.txt`
 - **Reply path**: `email-compose-helper.sh` if present, otherwise `apple-mail-helper.sh send`
+- **Platform**: Apple Mail integration (macOS only)
+- **Task requests**: parse inbound email, create task with `claim-task-id.sh`, reply with task ID
+- **Question requests**: return bounded, deterministic status/help responses
 
 <!-- AI-CONTEXT-END -->
 
-Security-first interface: sender allowlist, prompt-injection scanning, executable attachment blocking, and audit logging.
+Security-first: sender allowlist, prompt-injection scanning, executable attachment blocking, audit logging.
 
 ## Security Gates
 
@@ -52,29 +55,11 @@ Permissions: `admin` (full privileged sender), `operator` (operational requests)
 ## Commands
 
 ```bash
-# Poll and process newest messages
 scripts/email-inbound-command-helper.sh poll --mailbox INBOX --limit 10
-
-# Poll a mailbox in a specific account
 scripts/email-inbound-command-helper.sh poll --mailbox INBOX --account "Work" --limit 20
-
-# Dry run (no task creation, no send)
 scripts/email-inbound-command-helper.sh poll --mailbox INBOX --limit 5 --dry-run
-
-# Check sender allowlist status
 scripts/email-inbound-command-helper.sh sender-check user@example.com
 ```
-
-## Request Handling
-
-- **Task requests**: parse inbound email content, create tasks with `claim-task-id.sh`, and reply with the task ID.
-- **Question requests**: return bounded, deterministic status/help responses for lightweight operational query and acknowledgement flows.
-
-## Operational Notes
-
-- Polling uses Apple Mail integration on macOS.
-- Dedup: processed message IDs tracked in `~/.aidevops/.agent-workspace/email-inbound-commands/processed-message-ids.txt`.
-- Replies: `email-compose-helper.sh` preferred; fallback `apple-mail-helper.sh send`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Tighten `.agents/services/email/email-inbound-commands.md` from 91 to 76 lines (~16% reduction).

## Changes

- Merged "Request Handling" and "Operational Notes" sections into the `AI-CONTEXT-START` block — both sections duplicated information already partially present in the context block
- Removed redundant inline comments from Commands section (flags are self-documenting)
- Tightened intro prose (removed "Security-first interface:" → "Security-first:")

## Content Preservation

All institutional knowledge preserved:
- All 4 security gates (allowlist, injection scan, attachment block, audit trail)
- Full configuration format and permission levels
- All 4 CLI commands
- All 4 troubleshooting entries
- All related file references
- Task ID references and command examples intact

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code changes.
**Verification:** `self-assessed` — line count confirmed 91→76, content diff reviewed.

Closes #15725

---
[aidevops.sh](https://aidevops.sh) v3.5.711 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,599 tokens on this as a headless worker.