### PR TITLE
GH#15745: tighten production-video.md index (AI Video Production)

### DIFF
--- a/.agents/content/production-video.md
+++ b/.agents/content/production-video.md
@@ -14,13 +14,7 @@ tools:
 
 # AI Video Production
 
-<!-- CLASSIFICATION: Domain reference material (not agent operational instructions).
-     This file documents video production techniques, API workflows, prompt templates,
-     and tool comparisons. Imperative language ("ALWAYS use ingredients-to-video",
-     "NEVER frame-to-video") describes domain best practices, not agent behaviour
-     directives. The single-source-of-truth policy (AGENTS.md) governs agent routing,
-     tool access, and behavioural rules — not domain knowledge libraries like this.
-     See AGENTS.md Domain Index: Content/Video/Voice for the authoritative pointer. -->
+<!-- Domain reference corpus. Imperative language describes domain best practices, not agent directives. See AGENTS.md Domain Index: Content/Video/Voice. -->
 
 <!-- AI-CONTEXT-START -->
 
@@ -31,6 +25,8 @@ tools:
 - **Seed ranges**: people 1000-1999, action 2000-2999, landscape 3000-3999, product 4000-4999, YouTube 2000-3000
 - **2-Track production**: objects/environments (Midjourney→VEO) vs characters (Freepik→Seedream→VEO)
 - **Veo 3.1**: ALWAYS use ingredients-to-video, NEVER frame-to-video (produces grainy yellow output)
+- **Voice**: NEVER use pre-made ElevenLabs voices (widely recognised as AI)
+- **Frame rate**: Never upconvert 24fps → 60fps for non-action content (soap opera effect)
 
 **Model Selection**:
 
@@ -58,14 +54,6 @@ Full content is split into focused chapter files. Each is self-contained.
 | 07 | [Post-Production](production-video-07-post-production.md) | Upscaling, frame rate conversion, denoising, film grain |
 | 08 | [Talking-Head Pipeline](production-video-08-talking-head-pipeline.md) | Longform 30s+ pipeline: image → script → voice → video → post |
 | 09 | [Tools & Resources](production-video-09-tools-resources.md) | Internal references, helper scripts, external links |
-
-## Key Rules
-
-- **Veo 3.1**: ALWAYS ingredients-to-video, NEVER frame-to-video (grainy yellow output)
-- **Seed bracketing**: Test 10-15 sequential seeds per content type range
-- **Voice**: NEVER use pre-made ElevenLabs voices (widely recognised as AI)
-- **Frame rate**: Never upconvert 24fps → 60fps for non-action content (soap opera effect)
-- **2-Track**: Objects via Midjourney→VEO; Characters via Freepik→Seedream→VEO
 
 ## Helper Scripts
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.717"
+    "version": "3.5.718"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.717
+# Version: 3.5.718
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.717.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.718.tar.gz"
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.717",
+  "version": "3.5.718",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.717
+# Version: 3.5.718
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.717
+sonar.projectVersion=3.5.718
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened the `production-video.md` index file per GH#15745 simplification scan.

## Issue
Closes #15745

## Files Changed
- `.agents/content/production-video.md` — 82 → 70 lines (15% reduction)

## Changes
1. **Compressed classification comment**: 7-line verbose block → 1-line summary (same meaning, less noise)
2. **Eliminated duplicate Key Rules section**: Moved Voice and Frame rate rules to Quick Reference; removed the now-redundant `## Key Rules` section
3. **Zero content loss**: All rules, task IDs, command examples, and chapter links preserved

## Classification
This is a **reference corpus index** (already split into 9 chapter files). The index was tightened per instruction doc guidance — no chapter restructuring needed.

## Testing
- `bunx markdownlint-cli2 ".agents/content/production-video.md"` → 0 errors
- All code blocks, URLs, chapter links, and command examples verified present before and after
- Agent behaviour unchanged (index is a pointer doc; chapters are unchanged)

## Runtime Testing
**Risk level**: Low — docs/agent prompt file only, no code execution paths affected.
**Assessment**: `self-assessed` — no runtime environment needed for markdown doc changes.

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 5,860 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized production video guidelines with updated constraints on voice generation and frame rate handling to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->