### PR TITLE
GH#15746: tighten cloudron-app-publishing-skill.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4705,5 +4705,6 @@
     "lines_after": 101,
     "bytes_before": 3340,
     "bytes_after": 3076
-  }
+  },
+  ".agents/tools/deployment/cloudron-app-publishing-skill.md": "0151e8429caa9fe4b9c786443f31688761ce0569051182b9f648d34398cd9f27"
 }

--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -15,12 +15,10 @@ tools:
 
 <!-- AI-CONTEXT-START -->
 
-## Quick Reference
-
 - **Docs**: [docs.cloudron.io/packaging/publishing](https://docs.cloudron.io/packaging/publishing)
 - **Upstream skill**: [git.cloudron.io/docs/skills](https://git.cloudron.io/docs/skills) (`cloudron-app-publishing`)
-- **Prerequisite**: App must be built with `cloudron build` (local or build service) -- on-server builds cannot be published
-- **Key file**: `CloudronVersions.json` -- version catalog hosted at a public URL
+- **Prerequisite**: App must be built with `cloudron build` (local or build service) — on-server builds cannot be published
+- **Key file**: `CloudronVersions.json` — version catalog hosted at a public URL
 - **Forum**: [App Packaging & Development](https://forum.cloudron.io/category/96/app-packaging-development)
 
 <!-- AI-CONTEXT-END -->
@@ -29,7 +27,7 @@ tools:
 
 ```bash
 cloudron versions init       # create CloudronVersions.json + scaffold manifest/stubs
-cloudron build               # build and push image
+cloudron build               # build and push image (first run prompts for Docker repository, e.g. registry/username/myapp — saved for subsequent runs)
 cloudron versions add        # add version to catalog
 # host CloudronVersions.json at a public URL
 ```
@@ -55,8 +53,6 @@ cloudron versions add        # add version to catalog
 | `cloudron build logs --id <id>` | Stream logs for a remote build |
 | `cloudron build push --id <id>` | Push a remote build to a registry |
 | `cloudron build status --id <id>` | Check status of a remote build |
-
-First run prompts for Docker repository (e.g. `registry/username/myapp`) — saved for subsequent runs.
 
 ## Versions Commands
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.717"
+    "version": "3.5.718"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.717
+# Version: 3.5.718
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.717.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.718.tar.gz"
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.717",
+  "version": "3.5.718",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.717
+# Version: 3.5.718
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.717
+sonar.projectVersion=3.5.718
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
## Summary

- Remove redundant `## Quick Reference` heading — bullets are self-describing under the `<!-- AI-CONTEXT -->` wrapper
- Merge the standalone "First run prompts for Docker repository" paragraph inline into the `cloudron build` workflow comment (where it's most actionable)
- Normalize `--` to `—` (em dash) for consistency with the rest of the codebase

**Classification:** Instruction doc (operational procedures, command tables, workflow steps) — content tightened, not restructured.

**Content preservation verified:** All 4 URLs, 27 `cloudron` command references, 8 key file references, and all manifest fields preserved. Line count: 81 → 77.

## Issue

Closes #15746

## Files Changed

- `.agents/tools/deployment/cloudron-app-publishing-skill.md` — tightened (81 → 77 lines)
- `.agents/configs/simplification-state.json` — hash registry updated

## Testing

**Risk level:** Low (docs/agent prompt — no runtime code paths)
**Runtime testing:** `self-assessed` — agent doc change, no executable code modified

## Key Decisions

- Kept all command tables intact — no rows removed
- Kept all manifest field list intact — no fields removed
- Merged "first run" note into workflow block comment rather than deleting it — preserves the institutional knowledge in the most useful location

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 6,604 tokens on this as a headless worker.