### PR TITLE
GH#15747: tighten models-pool-check.md prose

### DIFF
--- a/.agents/scripts/commands/models-pool-check.md
+++ b/.agents/scripts/commands/models-pool-check.md
@@ -4,25 +4,25 @@ agent: Build+
 mode: subagent
 ---
 
-Entry point for provider-account setup and troubleshooting. Diagnose first, then give exactly one next step. Assume the user knows nothing about OAuth or pools.
+Entry point for provider-account setup and troubleshooting. Diagnose first, give exactly one next step. Assume the user knows nothing about OAuth or pools.
 
 ## Core rules
 
-- **One step at a time.** Give one command or action, not branches.
+- **One step at a time.** One command or action, not branches.
 - **Diagnose before advising.** Run checks first, then choose the path.
 - **Separate terminal for auth commands.** Never ask for tokens or codes in chat.
 - **Explain what, not internals.** Do not mention pool.json, PKCE, token endpoints, or auth hooks.
 - **After any add/import:** remind them to restart the app, then press Ctrl+T to choose a model.
-- **Any model can run this.** `oauth-pool-helper.sh` works even on free models with no paid provider configured.
+- **Any model can run this.** `oauth-pool-helper.sh` works even on free models.
 
 ## Workflow
 
 ### Step 1: Diagnose
 
-Run both in parallel via Bash:
+Run both in parallel:
 
 1. `oauth-pool-helper.sh check` — current pool state
-2. `claude auth status --json 2>/dev/null` — whether Claude CLI is already authenticated
+2. `claude auth status --json 2>/dev/null` — whether Claude CLI is authenticated
 
 ### Step 2: Choose the path
 
@@ -52,15 +52,14 @@ Then give exactly one command in a separate terminal:
 | Cursor | `opencode auth login --provider cursor` |
 | Google | `oauth-pool-helper.sh add google` |
 
-Anthropic/OpenAI/Google: browser opens → authorize → paste code back → restart app. Cursor: browser opens → authorize → tokens saved automatically → restart app.
+Anthropic/OpenAI/Google: browser opens → authorize → paste code → restart app. Cursor: browser opens → authorize → tokens saved automatically → restart app.
 
 #### Path B — accounts exist and are healthy
 
 Show a summary table, then: "Everything looks good. Your pool has N account(s) and will auto-rotate if one hits rate limits."
 
-If only one account: "Consider adding a second for automatic failover. Run `oauth-pool-helper.sh add <provider>` in a separate terminal."
-
-If Claude CLI has a logged-in account not in the pool: "I noticed a Claude {subscriptionType} account ({email}) in the CLI that isn't in your pool. Run `oauth-pool-helper.sh import claude-cli` in a separate terminal to add it."
+- One account only: "Consider adding a second for automatic failover. Run `oauth-pool-helper.sh add <provider>` in a separate terminal."
+- Claude CLI account not in pool: "I noticed a Claude {subscriptionType} account ({email}) in the CLI that isn't in your pool. Run `oauth-pool-helper.sh import claude-cli` in a separate terminal to add it."
 
 #### Path C — accounts exist but have problems
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.717"
+    "version": "3.5.718"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.717
+# Version: 3.5.718
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.717.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.718.tar.gz"
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.717",
+  "version": "3.5.718",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.717
+# Version: 3.5.718
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.717
+sonar.projectVersion=3.5.718
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
**What:** Terse pass on `.agents/scripts/commands/models-pool-check.md` per build-agent.md guidance.

**Issue:** Closes #15747

**Files changed:** `.agents/scripts/commands/models-pool-check.md` (81→80 lines, prose compression only)

**Testing:** `bunx markdownlint-cli2` — 0 errors. Content diff verified: all commands, code blocks, URLs, and institutional knowledge preserved.

**Key decisions:**
- Classified as instruction doc (not reference corpus) — prose tightening is correct action
- Converted Path B paragraphs to bullet list for improved scannability
- Removed redundant words (then, already, back, via Bash) without semantic loss
- Zero rule/knowledge removal

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m on this as a headless worker.