### PR TITLE
GH#14773: tighten email-health-check.md (74→66 lines)

### DIFF
--- a/.agents/scripts/commands/email-health-check.md
+++ b/.agents/scripts/commands/email-health-check.md
@@ -10,30 +10,22 @@ Arguments: `$ARGUMENTS`
 
 ## Workflow
 
-### Step 1: Select the helper
+**Step 1: Select the helper** based on argument type:
 
-- `example.com` → infrastructure: `email-health-check-helper.sh check "$DOMAIN"`
-- `newsletter.html` → content: `email-health-check-helper.sh content-check "$FILE"`
-- `example.com newsletter.html` → combined: `email-health-check-helper.sh precheck "$DOMAIN" "$FILE"`
-- Extra selector/check arg (`example.com spf`, `newsletter.html check-links`) → targeted check
+| Input | Command |
+|-------|---------|
+| `example.com` | `email-health-check-helper.sh check "$DOMAIN"` |
+| `newsletter.html` | `email-health-check-helper.sh content-check "$FILE"` |
+| `example.com newsletter.html` | `email-health-check-helper.sh precheck "$DOMAIN" "$FILE"` |
+| Extra selector/check arg (`example.com spf`, `newsletter.html check-links`) | Targeted check |
 
-```bash
-# Domain
-~/.aidevops/agents/scripts/email-health-check-helper.sh check "$DOMAIN"
+All scripts: `~/.aidevops/agents/scripts/email-health-check-helper.sh`
 
-# HTML file
-~/.aidevops/agents/scripts/email-health-check-helper.sh content-check "$FILE"
+**Step 2: Format the report** — keep helper findings verbatim, end with actionable recommendations:
 
-# Domain + HTML file
-~/.aidevops/agents/scripts/email-health-check-helper.sh precheck "$DOMAIN" "$FILE"
-```
-
-### Step 2: Format the report
-
-- Infrastructure: score out of 15 for SPF, DKIM, DMARC, MX, blacklist
-- Content: score out of 10 for subject, preheader, accessibility, links, images, spam words
-- Combined runs: score out of 25 with a letter grade
-- Keep helper findings verbatim and end with actionable recommendations
+- Infrastructure: score out of 15 (SPF, DKIM, DMARC, MX, blacklist)
+- Content: score out of 10 (subject, preheader, accessibility, links, images, spam words)
+- Combined: score out of 25 with letter grade
 
 ## Options
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.717"
+    "version": "3.5.718"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.717
+# Version: 3.5.718
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.717.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.718.tar.gz"
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.717",
+  "version": "3.5.718",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.717
+# Version: 3.5.718
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.717
+sonar.projectVersion=3.5.718
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/scripts/commands/email-health-check.md` from 74 to 66 lines by merging the redundant bullet list + code block into a single decision table.

## Issue
Closes #14773

## Files Changed
- `.agents/scripts/commands/email-health-check.md` (74→66 lines, -11%)

## Changes Made
- Merged the "Step 1" bullet list and the duplicate bash code block into a single compact decision table
- Consolidated scoring info into a tighter format under Step 2
- All 8 command options, 5 Related links, example output block, and script path preserved verbatim

## Testing
**Risk level:** Low (docs/agent prompt — no runtime behaviour change)
**Verification:** `self-assessed` — content preservation confirmed by diff review:
- All command examples present in Options table
- All Related links intact
- Example output block unchanged
- Scoring values (15/10/25) preserved
- Script path `~/.aidevops/agents/scripts/email-health-check-helper.sh` preserved

## Runtime Testing
Low-risk doc change. Agent behaviour unchanged — same commands, same workflow, same output format.

## Key Decisions
- Kept the Options table as primary reference (most useful for users)
- Merged redundant bullet+code block into decision table (eliminates duplication without losing info)
- Preserved all institutional knowledge: scoring, targeted checks, accessibility audit option

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 4,077 tokens on this as a headless worker.