### PR TITLE
GH#15044: tighten performance.md command doc

### DIFF
--- a/.agents/scripts/commands/performance.md
+++ b/.agents/scripts/commands/performance.md
@@ -10,6 +10,8 @@ URL/Target: $ARGUMENTS
 
 ## Prerequisites
 
+Verify Chrome DevTools MCP is available:
+
 ```bash
 which npx && npx chrome-devtools-mcp@latest --version || echo "Install: npm i -g chrome-devtools-mcp"
 ```
@@ -49,7 +51,7 @@ Using Chrome DevTools MCP, execute in order:
 | TTFB | Xms | GOOD/NEEDS WORK/POOR | <800ms |
 
 ### Top Issues (Priority Order)
-1. **Issue** — File: `path/to/file:line` — Fix: specific recommendation
+1. **Issue** — File: `path/to/file` — Fix: specific recommendation
 
 ### Network Dependencies
 - X third-party scripts; longest chain: X requests; total blocking time: Xms
@@ -63,10 +65,10 @@ For each issue: **What** (problem), **Where** (file path), **How** (code/config 
 ## Examples
 
 ```bash
-/performance https://example.com                                    # full audit
-/performance http://localhost:3000 --local                          # local dev
-/performance https://example.com --device=mobile                    # mobile only
-/performance https://example.com --compare=baseline.json            # diff baseline
+/performance https://example.com                          # full audit
+/performance http://localhost:3000 --local                # local dev
+/performance https://example.com --device=mobile          # mobile only
+/performance https://example.com --compare=baseline.json  # diff baseline
 /performance https://example.com --categories=performance,accessibility
 ```
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/scripts/commands/performance.md` per simplification-debt issue GH#15044.

## Changes
- Add explicit label "Verify Chrome DevTools MCP is available:" before the prerequisite bash block (addresses the issue's detected topic)
- Remove `file:line` reference in report template (line numbers drift per build-agent guidance; use search patterns instead)
- Remove excessive whitespace alignment in examples (cleaner, no functional change)

## Issue
Closes #15044

## Files Changed
- `.agents/scripts/commands/performance.md` (77→79 lines; net +2 for the prerequisite label)

## Testing
**Risk level**: Low — agent doc/instruction file only, no code execution paths changed.
**Self-assessed**: Content preserved, all code blocks intact, URLs unchanged, no broken references.

## Runtime Testing
`self-assessed` — Low risk: docs/agent prompt file only. No runtime behaviour changed.

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,034 tokens on this as a headless worker.