### PR TITLE
GH#14344: tighten remotion-can-decode.md (complete canDecodeBlob stub)

### DIFF
--- a/.agents/tools/video/remotion-can-decode.md
+++ b/.agents/tools/video/remotion-can-decode.md
@@ -12,8 +12,6 @@ Use Mediabunny to check if a video can be decoded by the browser before attempti
 
 ## The `canDecode()` function
 
-This function can be copy-pasted into any project.
-
 ```tsx
 import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
 
@@ -71,6 +69,22 @@ export const canDecodeBlob = async (blob: Blob) => {
     source: new BlobSource(blob),
   });
 
-  // Same validation logic as above
+  try {
+    await input.getFormat();
+  } catch {
+    return false;
+  }
+
+  const videoTrack = await input.getPrimaryVideoTrack();
+  if (videoTrack && !(await videoTrack.canDecode())) {
+    return false;
+  }
+
+  const audioTrack = await input.getPrimaryAudioTrack();
+  if (audioTrack && !(await audioTrack.canDecode())) {
+    return false;
+  }
+
+  return true;
 };
 ```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/video/remotion-can-decode.md` per simplification-debt issue GH#14344.

**Classification:** Reference corpus (code examples for Mediabunny decode validation).

**Changes:**
- Remove decorative prose: `This function can be copy-pasted into any project.` (no informational value)
- Complete the incomplete `canDecodeBlob` function: replace `// Same validation logic as above` stub with the actual track validation logic (matching `canDecode()`)

The stub comment was actively harmful — it left the function body empty, meaning any agent or developer copying it would get a broken implementation that always returns `undefined` instead of `true`/`false`.

## Issue
Closes #14344

## Files Changed
- `.agents/tools/video/remotion-can-decode.md` (76→90 lines; net +14 lines due to completing the stub)

## Testing
**Risk level:** Low — agent doc, no runtime execution path.

**Verification:**
- All code blocks present before and after ✓
- No URLs or task ID refs in original file ✓
- `canDecodeBlob` now has complete, correct implementation matching `canDecode()` ✓
- No broken internal links ✓

## Runtime Testing
`self-assessed` — Low risk (agent doc, no executable code paths in this repo)

## Key Decisions
- File is a reference corpus (code examples), not an instruction doc — no content compression applied
- Completed the stub rather than removing the Blob section, as it's a valid use case (file uploads/drag-and-drop)
- Line count increased (76→90) because completing the stub adds more value than removing it

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 5,050 tokens on this as a headless worker.