### PR TITLE
GH#15777: tighten tirith.md (107→101 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -4689,6 +4689,12 @@
       "at": "2026-04-02T22:44:04Z",
       "pr": 15665,
       "passes": 1
+    },
+    ".agents/tools/security/tirith.md": {
+      "at": "2026-04-03T00:11:49Z",
+      "hash": "c3167839453b147ffc0fa1927ea7cba5d0880503b38645c88c39422479b0ed1d",
+      "passes": 1,
+      "pr": null
     }
   },
   ".agents/tools/ai-assistants/models-sonnet.md": {

--- a/.agents/tools/security/tirith.md
+++ b/.agents/tools/security/tirith.md
@@ -20,12 +20,25 @@ tools:
 - **Purpose**: Pre-execution security guard for terminal commands
 - **Repo**: [github.com/sheeki03/tirith](https://github.com/sheeki03/tirith) (1.5k stars, Rust, AGPL-3.0)
 - **Key trait**: Sub-millisecond overhead, fully local, no network calls, no telemetry
-- **Coverage**: 30 rules across 7 categories
+- **Coverage**: 30 rules across 7 categories; critical rules block, medium rules warn
 - **Activation**: Add the shell hook once; every later command is checked automatically
-
-Browsers guard homograph attacks, ANSI injection, and suspicious URLs. Terminals usually don't. Tirith adds that check before command execution.
+- **aidevops**: setup.sh suggests install if missing; audit log at `~/.local/share/tirith/log.jsonl`
 
 <!-- AI-CONTEXT-END -->
+
+## What it catches
+
+| Category | What it stops |
+|----------|---------------|
+| **Homograph attacks** | Cyrillic/Greek lookalikes in hostnames, punycode domains, mixed-script labels |
+| **Terminal injection** | ANSI escape sequences that rewrite display, bidi overrides, zero-width characters |
+| **Pipe-to-shell** | `curl \| bash`, `wget \| sh`, `python <(curl ...)`, `eval $(wget ...)` |
+| **Dotfile attacks** | Downloads targeting `~/.bashrc`, `~/.ssh/authorized_keys`, `~/.gitconfig` |
+| **Insecure transport** | Plain HTTP piped to shell, `curl -k`, disabled TLS verification |
+| **Ecosystem threats** | Git clone typosquats, untrusted Docker registries, pip/npm URL installs |
+| **Credential exposure** | `http://user:pass@host` userinfo tricks, shortened URLs hiding destinations |
+
+Critical rules (homograph, dotfile) **block** execution. Medium rules (pipe-to-shell with clean URL) **warn** but allow.
 
 ## Install and activate
 
@@ -44,20 +57,6 @@ eval "$(tirith init --shell bash)"  # ~/.bashrc
 tirith init --shell fish | source   # ~/.config/fish/config.fish
 ```
 
-## What it catches
-
-| Category | What it stops |
-|----------|---------------|
-| **Homograph attacks** | Cyrillic/Greek lookalikes in hostnames, punycode domains, mixed-script labels |
-| **Terminal injection** | ANSI escape sequences that rewrite display, bidi overrides, zero-width characters |
-| **Pipe-to-shell** | `curl \| bash`, `wget \| sh`, `python <(curl ...)`, `eval $(wget ...)` |
-| **Dotfile attacks** | Downloads targeting `~/.bashrc`, `~/.ssh/authorized_keys`, `~/.gitconfig` |
-| **Insecure transport** | Plain HTTP piped to shell, `curl -k`, disabled TLS verification |
-| **Ecosystem threats** | Git clone typosquats, untrusted Docker registries, pip/npm URL installs |
-| **Credential exposure** | `http://user:pass@host` userinfo tricks, shortened URLs hiding destinations |
-
-Critical rules (homograph, dotfile) **block** execution. Medium rules (pipe-to-shell with clean URL) **warn** but allow.
-
 ## Commands
 
 ```bash
@@ -68,6 +67,7 @@ tirith run <url>               # Safe curl|bash replacement (download, review, c
 tirith receipt list            # Audit trail of scripts run via tirith run
 tirith why                     # Explain last triggered rule
 tirith doctor                  # Diagnostic check (shell, hooks, policy)
+TIRITH=0 <cmd>                 # One-command bypass (does not persist)
 ```
 
 ## Configuration
@@ -87,12 +87,6 @@ fail_mode: open  # or "closed" for strict environments
 ```
 
 Set `allow_bypass: false` to prevent per-command bypass in org environments.
-
-## Bypass
-
-```bash
-TIRITH=0 curl -L https://known-safe.example.com | bash  # one command only, does not persist
-```
 
 ## Integration with aidevops
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/security/tirith.md` from 107 to 101 lines per the simplification scan in GH#15777.

## Issue
Closes #15777

## Changes
- Moved "What it catches" section before "Install and activate" (importance ordering — agents need to know what it does before how to install)
- Merged standalone `## Bypass` section into `## Commands` as a single inline entry (`TIRITH=0 <cmd>`)
- Added block/warn behavior summary to Quick Reference coverage bullet
- Added aidevops integration summary to Quick Reference (surfacing key operational info)
- Removed redundant context-setting prose sentence ("Browsers guard homograph attacks...")
- All code blocks, URLs, command examples, and institutional knowledge preserved

## Files changed
- `.agents/tools/security/tirith.md` — 107→101 lines
- `.agents/configs/simplification-state.json` — registered new hash

## Testing
**Risk level**: Low (docs/agent prompt, no executable code)
**Self-assessed**: Content preservation verified — all 7 threat categories, all 7 commands, configuration YAML, bypass mechanism, and Related links present before and after.

## Key decisions
- Classified as **instruction doc** (not reference corpus): operational procedures, commands, config guidance — appropriate for prose tightening, not chapter splitting
- Bypass command merged into Commands rather than deleted — the information is preserved, just co-located with other commands for discoverability

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 6,007 tokens on this as a headless worker.