### PR TITLE
GH#15780: tighten encryption-stack.md decision guide

### DIFF
--- a/.agents/tools/credentials/encryption-stack.md
+++ b/.agents/tools/credentials/encryption-stack.md
@@ -20,15 +20,19 @@ tools:
 
 Use the smallest tool that fits the problem:
 
-| Tool | Best for | Scope | Git-safe | AI-safe | Commands | Storage | Docs |
-|------|----------|-------|----------|---------|----------|---------|------|
-| **gopass** | API keys, tokens, passwords | Per secret | No (separate store) | Yes (subprocess injection) | `aidevops secret set NAME` / `aidevops secret run CMD` | `~/.local/share/gopass/stores/root/aidevops/` — fallback: `~/.config/aidevops/credentials.sh` (plaintext, 600 perms) | `tools/credentials/gopass.md` |
-| **SOPS** | Structured config files with secrets | Per file | Yes (encrypted in repo) | Yes (stdout only) | `sops-helper.sh encrypt config.enc.yaml` | Encrypted files committed to git — backends: age (preferred), GPG, AWS KMS, GCP KMS, Azure Key Vault | `tools/credentials/sops.md` |
-| **gocryptfs** | Sensitive directories at rest | Per directory | No (filesystem overlay) | Yes (mount/unmount) | `gocryptfs-helper.sh create vault-name` | `~/.aidevops/.agent-workspace/vaults/` — AES-256-GCM, hardware accelerated | `tools/credentials/gocryptfs.md` |
-
 1. Single secret → `aidevops secret set NAME`
 2. Structured file you must commit → `sops-helper.sh encrypt file.enc.yaml`
 3. Sensitive directory at rest → `gocryptfs-helper.sh create vault-name`
+
+| Tool | Best for | Scope | Git-safe | AI-safe | Docs |
+|------|----------|-------|----------|---------|------|
+| **gopass** | API keys, tokens, passwords | Per secret | No (separate store) | Yes (subprocess injection) | `tools/credentials/gopass.md` |
+| **SOPS** | Structured config files with secrets | Per file | Yes (encrypted in repo) | Yes (stdout only) | `tools/credentials/sops.md` |
+| **gocryptfs** | Sensitive directories at rest | Per directory | No (filesystem overlay) | Yes (mount/unmount) | `tools/credentials/gocryptfs.md` |
+
+**Commands:** `aidevops secret set NAME` / `aidevops secret run CMD` (gopass) · `sops-helper.sh encrypt config.enc.yaml` (SOPS) · `gocryptfs-helper.sh create vault-name` (gocryptfs)
+
+**Storage:** gopass → `~/.local/share/gopass/stores/root/aidevops/` (fallback: `~/.config/aidevops/credentials.sh`, 600 perms) · SOPS → encrypted files in git (age preferred, GPG, AWS/GCP/Azure KMS) · gocryptfs → `~/.aidevops/.agent-workspace/vaults/` (AES-256-GCM)
 
 <!-- AI-CONTEXT-END -->
 
@@ -45,7 +49,6 @@ aidevops secret set API_KEY
 # 2. Initialize SOPS for config files (two options)
 aidevops init sops                    # Project-level: creates .sops.yaml + age key
 sops-helper.sh init                   # Standalone: init without aidevops project config
-# Create and encrypt config files
 sops-helper.sh encrypt config.enc.yaml
 
 # 3. Create encrypted vault for sensitive workspace data
@@ -73,7 +76,6 @@ gopass recipients add teammate@example.com
 gopass sync
 
 # 2. Add teammate's age key to .sops.yaml
-# Edit .sops.yaml to add their public key
 sops updatekeys config.enc.yaml
 
 # 3. gocryptfs vaults are per-machine (no sharing needed)


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Restructured `encryption-stack.md` Quick Reference for improved readability and LLM primacy effect.

## Changes
- Moved decision rule (numbered list) **before** the table — most critical info first (primacy effect)
- Reduced table from 8 to 6 columns by extracting Commands/Storage into compact bullet lines below
- All commands, storage paths, doc references, and security backends fully preserved
- Removed 2 redundant inline comments that duplicated adjacent code

## Issue
Closes #15780

## Files Changed
- `.agents/tools/credentials/encryption-stack.md` (93 → 95 lines; table readability improved)

## Runtime Testing
**Risk level:** Low — agent doc restructuring only, no code or logic changes.
**Self-assessed:** Content preservation verified via diff. All code blocks, URLs, commands, and storage paths present before and after.

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — tighten prose, not split into chapters
- Slightly longer line count (+2) is acceptable trade-off for significantly more readable table structure
- Decision rule promoted to top of Quick Reference section per build-agent.md primacy guidance

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 6,127 tokens on this as a headless worker.