### PR TITLE
GH#15969: tighten es2016-es2017.md (131→122 lines)

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/es2016-es2017.md
+++ b/.agents/tools/programming/modern-javascript-skill/es2016-es2017.md
@@ -75,13 +75,6 @@ const doubled = Object.fromEntries(
 
 const formatId = id => String(id).padStart(6, '0');
 formatId(42);  // '000042'
-
-const items = [['Apple', 1.5], ['Banana', 0.75]];
-for (const [name, price] of items) {
-  console.log(`${name.padEnd(10)}$${price.toFixed(2)}`);
-}
-// Apple     $1.50
-// Banana    $0.75
 ```
 
 ### Object.getOwnPropertyDescriptors()
@@ -108,12 +101,10 @@ Allows trailing commas in parameter lists and arguments for cleaner version-cont
 ```javascript
 function greet(
   name,
-  greeting,
-) {
-  return `${greeting}, ${name}!`;
-}
+  greeting,  // trailing comma allowed
+) { return `${greeting}, ${name}!`; }
 
-greet('Alice', 'Hello',);
+greet('Alice', 'Hello',);  // trailing comma in call too
 ```
 
 ### SharedArrayBuffer and Atomics


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/programming/modern-javascript-skill/es2016-es2017.md` from 131 to 122 lines (7% reduction).

## Issue
Closes #15969

## Changes
- **String Padding**: Remove redundant table-formatting example (lines 79-84 in original). The `formatId` example already demonstrates `padStart` in a real use case; the `items` loop was a secondary illustration of the same concept.
- **Trailing Commas**: Condense example — collapse irrelevant function body to one line, add inline comments clarifying both parameter and call-site trailing commas are allowed.

## Files Changed
- `.agents/tools/programming/modern-javascript-skill/es2016-es2017.md` (131→122 lines, -9 lines)

## Testing
**Risk level:** Low (agent doc / reference corpus — no runtime behaviour)
**Verification:** All code blocks present, NaN-handling note preserved, getter/setter contrast preserved, all ES2016/ES2017 features documented.

**Self-assessed** — no runtime environment required for doc changes.

## Key Decisions
- File classified as reference corpus per code-simplifier guidance (GH#6432); content not compressed, only redundant secondary examples removed.
- Retained `bad`/`good` contrast in `Object.getOwnPropertyDescriptors` — this is the key teaching point for that API.

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 5,109 tokens on this as a headless worker.