### PR TITLE
GH#15971: tighten distribution-youtube-readme.md agent doc

### DIFF
--- a/.agents/content/distribution-youtube-readme.md
+++ b/.agents/content/distribution-youtube-readme.md
@@ -17,8 +17,6 @@ subagents:
 
 ## Quick Reference
 
-- **Main Agent**: `youtube.md` (this directory) - orchestrator for all YouTube operations
-- **Subagents**: `channel-intel`, `topic-research`, `script-writer`, `optimizer`, `pipeline`
 - **Helper**: `youtube-helper.sh` - YouTube Data API v3 wrapper
 - **Commands**: `/youtube setup`, `/youtube research`, `/youtube script`
 - **Pipeline**: YouTube is a distribution channel within `content.md`
@@ -36,8 +34,6 @@ subagents:
 | `pipeline.md` | End-to-end cron-driven automation pipeline |
 
 ## Distribution Workflow
-
-When the content pipeline fans out to YouTube:
 
 1. **Receive story and production assets** from upstream pipeline stages
 2. **Adapt to YouTube format** using `script-writer.md`
@@ -66,17 +62,19 @@ When the content pipeline fans out to YouTube:
 
 ## Cross-Channel Repurposing
 
-From one YouTube video, generate:
-
-- **YouTube Short** - Best 30-60s clip, 9:16 reformat (`content/distribution-short-form.md`)
-- **Blog post** - Transcript-based SEO article (`content/distribution-blog.md`)
-- **Social posts** - Key insights as X thread, LinkedIn post, Reddit discussion (`content/distribution-social.md`)
-- **Email** - Newsletter featuring video + key takeaways (`content/distribution-email.md`)
-- **Podcast** - Audio-only version with show notes (`content/distribution-podcast.md`)
+| Output | Format | Agent |
+|--------|--------|-------|
+| YouTube Short | Best 30-60s clip, 9:16 reformat | `content/distribution-short-form.md` |
+| Blog post | Transcript-based SEO article | `content/distribution-blog.md` |
+| Social posts | X thread, LinkedIn post, Reddit discussion | `content/distribution-social.md` |
+| Email | Newsletter featuring video + key takeaways | `content/distribution-email.md` |
+| Podcast | Audio-only version with show notes | `content/distribution-podcast.md` |
 
 ## Related Agents
 
-- `content/production-video.md` - Video generation (Sora 2 Pro, Veo 3.1)
-- `content/production-audio.md` - Voice pipeline
-- `content/story.md` - Narrative design and hook formulas
-- `content/optimization.md` - A/B testing and analytics
+| Agent | Purpose |
+|-------|---------|
+| `content/production-video.md` | Video generation (Sora 2 Pro, Veo 3.1) |
+| `content/production-audio.md` | Voice pipeline |
+| `content/story.md` | Narrative design and hook formulas |
+| `content/optimization.md` | A/B testing and analytics |


### PR DESCRIPTION
## Summary

Tightens `.agents/content/distribution-youtube-readme.md` per the simplification-debt issue. File classified as an **instruction doc** (not a reference corpus), so prose compression applies.

## Changes

- Removed 2 Quick Reference lines that duplicated the YAML frontmatter subagent list (redundant)
- Removed redundant prose intro in Distribution Workflow section ("When the content pipeline fans out to YouTube:")
- Converted Cross-Channel Repurposing bullet list → table (consistent with other sections in the file)
- Converted Related Agents bullet list → table (consistent with other sections in the file)
- 82 → 80 lines; all institutional knowledge, commands, file refs, and format specs preserved

## Content Preservation Verification

- All 5 cross-channel distribution agent refs present ✓
- All 4 related agent refs present ✓
- All YouTube format specs (16:9, 1080p, 1280x720, 8-20 min, etc.) present ✓
- All 3 slash commands (`/youtube setup`, `/youtube research`, `/youtube script`) present ✓
- All 5 subagent refs present ✓

## Runtime Testing

**Risk level**: Low (agent doc — no code, no runtime behaviour change)
**Verification**: `self-assessed` — content preservation verified via grep checks before/after

Closes #15971

---
[aidevops.sh](https://aidevops.sh) v3.5.718 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 4m and 4,292 tokens on this as a headless worker.