### PR TITLE
GH#15547: tighten xcodebuild-mcp.md agent doc

### DIFF
--- a/.agents/tools/mobile/xcodebuild-mcp.md
+++ b/.agents/tools/mobile/xcodebuild-mcp.md
@@ -16,9 +16,6 @@ tools:
 
 <!-- AI-CONTEXT-START -->
 
-## Quick Reference
-
-- **Purpose**: MCP server + CLI providing xcodebuild tools for iOS/macOS development
 - **Install**: `npx -y xcodebuildmcp@beta mcp` (MCP server mode)
 - **CLI**: `npm install -g xcodebuildmcp@beta` then `xcodebuildmcp --help`
 - **Requirements**: macOS 14.5+, Xcode 16+, Node.js 18+
@@ -33,34 +30,27 @@ tools:
 2. `build_sim --scheme MyApp` -- build for simulator
 3. `test_sim --scheme MyApp` -- run XCTest suite
 4. `build_run_sim --scheme MyApp` -- deploy and launch with logs
-5. `screenshot` / `snapshot_ui` -- verify UI state
+5. `screenshot` / `snapshot_ui` -- verify UI state (returns view hierarchy with coordinates)
 6. `maestro test flows/login.yaml` -- E2E tests on running simulator
 
 ## Tool Groups (76 tools, 15 workflow groups)
 
-| Group | Key Tools | Purpose |
-|-------|-----------|---------|
-| **simulator** | `build_sim`, `build_run_sim`, `test_sim`, `launch_app_sim` | iOS simulator build/test/run |
-| **device** | `build_device`, `test_device`, `install_app_device`, `launch_app_device` | Physical device deployment |
-| **macos** | `build_macos`, `build_run_macos`, `test_macos`, `launch_mac_app` | macOS app development |
-| **swift-package** | `swift_package_build`, `swift_package_test`, `swift_package_run` | SPM project workflows |
-| **debugging** | `debug_attach_sim`, `debug_breakpoint_add`, `debug_variables`, `debug_stack` | LLDB debugger integration |
-| **ui-automation** | `tap`, `swipe`, `type_text`, `screenshot`, `snapshot_ui` | UI testing and interaction |
-| **simulator-management** | `boot_sim`, `list_sims`, `set_sim_location`, `erase_sims` | Simulator lifecycle |
-| **logging** | `start_sim_log_cap`, `stop_sim_log_cap` | Log capture |
-| **project-discovery** | `discover_projs`, `list_schemes`, `show_build_settings` | Project analysis |
-| **project-scaffolding** | `scaffold_ios_project`, `scaffold_macos_project` | New project creation |
-| **session-management** | `session_set_defaults`, `sync_xcode_defaults` | Persistent session config |
-| **doctor** | `doctor` | Environment diagnostics |
-
 Only simulator tools enabled by default. Use `manage-workflows` to enable other groups.
 
-## Notes
-
-- **Device tools**: require code signing configured in Xcode.
-- **Swift Macros**: validation skipped automatically to avoid build errors.
-- **UI Automation**: `snapshot_ui` returns view hierarchy with coordinates.
-- **Persistence**: Session defaults persist scheme/simulator/device across calls.
+| Group | Key Tools | Notes |
+|-------|-----------|-------|
+| **simulator** | `build_sim`, `build_run_sim`, `test_sim`, `launch_app_sim` | |
+| **device** | `build_device`, `test_device`, `install_app_device`, `launch_app_device` | Requires code signing in Xcode |
+| **macos** | `build_macos`, `build_run_macos`, `test_macos`, `launch_mac_app` | |
+| **swift-package** | `swift_package_build`, `swift_package_test`, `swift_package_run` | Swift Macros validation skipped automatically |
+| **debugging** | `debug_attach_sim`, `debug_breakpoint_add`, `debug_variables`, `debug_stack` | |
+| **ui-automation** | `tap`, `swipe`, `type_text`, `screenshot`, `snapshot_ui` | |
+| **simulator-management** | `boot_sim`, `list_sims`, `set_sim_location`, `erase_sims` | |
+| **logging** | `start_sim_log_cap`, `stop_sim_log_cap` | |
+| **project-discovery** | `discover_projs`, `list_schemes`, `show_build_settings` | |
+| **project-scaffolding** | `scaffold_ios_project`, `scaffold_macos_project` | |
+| **session-management** | `session_set_defaults`, `sync_xcode_defaults` | Persists scheme/simulator/device across calls |
+| **doctor** | `doctor` | Environment diagnostics |
 
 ## MCP Configuration
 
@@ -83,17 +73,11 @@ claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@beta mcp
 }
 ```
 
-## Mobile Stack Integration
-
-| Tool | Role |
-|------|------|
-| **Maestro** | E2E UI test flows -- run after `build_run_sim` |
-| **iOS Simulator MCP** | Complementary simulator control |
-| **AXe** | Accessibility testing -- use with `snapshot_ui` output |
-| **MiniSim** | GUI simulator/emulator launcher |
-
 ## Related
 
-- `tools/mobile/minisim.md` -- Simulator/emulator GUI launcher
+- `tools/mobile/minisim.md` -- Simulator/emulator GUI launcher (MiniSim)
 - `tools/browser/playwright.md` -- Cross-platform testing (web)
 - `services/hosting/localhost.md` -- Local dev environment
+- **Maestro** -- E2E UI test flows; run after `build_run_sim`
+- **iOS Simulator MCP** -- Complementary simulator control
+- **AXe** -- Accessibility testing; use with `snapshot_ui` output


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/mobile/xcodebuild-mcp.md` per simplification-debt issue GH#15547.

## Changes
- Merged separate "Notes" section into Tool Groups table (device code signing, Swift Macros, session persistence notes now inline)
- Consolidated "Mobile Stack Integration" table into "Related" section (eliminates duplicate table)
- Inlined `snapshot_ui` coordinate note into workflow step 5
- Removed redundant "Purpose" bullet (already in frontmatter description and H1 title)
- Removed unnecessary "Quick Reference" heading wrapper
- Result: 99 → 83 lines (16% reduction), zero knowledge loss

## Issue
Closes #15547

## Files Changed
- `.agents/tools/mobile/xcodebuild-mcp.md` — 1 file, -16 net lines

## Testing
- `self-assessed` (Low risk: docs/agent prompt only, no code changes)
- All code blocks, URLs, tool names, and command examples preserved
- All institutional knowledge (code signing requirement, Swift Macros behavior, session persistence) retained in table Notes column

## Key Decisions
- Kept "Purpose" column values as Notes only where they add non-obvious information; omitted for self-evident groups (simulator, macos, logging, etc.)
- Merged Mobile Stack Integration into Related rather than deleting — the integration context is valuable for agent routing

## Runtime Testing
Risk: **Low** — agent prompt doc only, no executable code changes.
Verification: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.720 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,823 tokens on this as a headless worker.