### PR TITLE
GH#15947: tighten cron-triggers-patterns.md — sharpen section descriptions

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md
@@ -1,7 +1,7 @@
 # Cron Triggers Patterns
 
 ## Scheduled API Sync
-Refresh external data on a schedule and cache the result for reads between runs.
+Fetch external data on a schedule and cache in KV for reads between runs.
 
 ```typescript
 export default {
@@ -14,7 +14,7 @@ export default {
 ```
 
 ## Database Cleanup
-Delete expired rows during off-peak windows, then defer maintenance work with `ctx.waitUntil()`.
+Delete expired rows during off-peak windows; defer VACUUM with `ctx.waitUntil()`.
 
 ```typescript
 export default {
@@ -27,7 +27,7 @@ export default {
 ```
 
 ## Report Generation
-Build periodic summaries, store them in R2, and notify downstream systems after upload.
+Build periodic summaries, store in R2, and notify downstream systems after upload.
 
 ```typescript
 export default {
@@ -82,7 +82,7 @@ export default {
 ```
 
 ## Operational Monitoring
-Capture start, success, and failure events with enough context to debug slow or failing runs.
+Log start, success, and failure events with timing context to debug slow or failing runs.
 
 ```typescript
 export default {


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose descriptions in `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md` — sharpen 4 section one-liners for precision and conciseness without removing any knowledge or code.

## Changes
- **Scheduled API Sync**: "Refresh external data on a schedule and cache the result for reads between runs" → "Fetch external data on a schedule and cache in KV for reads between runs" (more specific: names KV, uses active verb)
- **Database Cleanup**: "Delete expired rows during off-peak windows, then defer maintenance work with `ctx.waitUntil()`" → "Delete expired rows during off-peak windows; defer VACUUM with `ctx.waitUntil()`" (names the deferred operation explicitly)
- **Report Generation**: "store them in R2" → "store in R2" (removes redundant pronoun)
- **Operational Monitoring**: "Capture start, success, and failure events with enough context to debug slow or failing runs" → "Log start, success, and failure events with timing context to debug slow or failing runs" (more precise: "Log" over "Capture", "timing context" over "enough context")

## Issue
Closes #15947

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md` (4 lines changed, 0 lines added/removed)

## Testing
**Risk level:** Low — documentation/prose only, no code logic changed.
**Verification:** All code blocks, URLs, task ID references, and command examples preserved unchanged. `wc -l` = 126 (unchanged).

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

## Key Decisions
- File classified as reference corpus (code patterns); restructuring into chapters not warranted at 126 lines
- Prose tightening only — all code blocks and structural content preserved verbatim
- Previous simplifications: GH#14080 (→126 lines), GH#15101 (→126 lines); this pass targets prose quality

---
[aidevops.sh](https://aidevops.sh) v3.5.720 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 13m and 6,365 tokens on this as a headless worker.