### PR TITLE
GH#15621: tighten cron-triggers-gotchas.md — readability improvements

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md
@@ -50,7 +50,11 @@ export default {
 ```typescript
 export default {
   async scheduled(controller, env, ctx) {
-    console.log("EXECUTED", {time: new Date().toISOString(), scheduledTime: new Date(controller.scheduledTime).toISOString(), cron: controller.cron});
+    console.log("EXECUTED", {
+      time: new Date().toISOString(),
+      scheduledTime: new Date(controller.scheduledTime).toISOString(),
+      cron: controller.cron,
+    });
     ctx.waitUntil(env.KV.put("last_execution", Date.now().toString()));
   },
 };
@@ -80,7 +84,7 @@ export default {
 
 ## Local Testing
 
-Ensure `wrangler dev` runs, `scheduled()` is exported, Wrangler is up to date: `npm i -g wrangler@latest`
+Requires: `wrangler dev` running, `scheduled()` exported, `npm i -g wrangler@latest`
 
 ```bash
 curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"  # URL-encode spaces
@@ -130,4 +134,4 @@ Enable via Dashboard: Workers & Pages → Account details → Compute Setting �
 - [Scheduled Handler API](https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/)
 - [Cloudflare Workflows](https://developers.cloudflare.com/workflows/)
 - [Workers Limits](https://developers.cloudflare.com/workers/platform/limits/)
-- [Crontab Guru](https://crontab.guru/) - Validator
+- [Crontab Guru](https://crontab.guru/)


### PR DESCRIPTION
## Summary

Tighten `cron-triggers-gotchas.md` per GH#15621 simplification scan.

Closes #15621

## What Changed

- **Expanded long `console.log` line** (133 chars) into multi-line object for readability — agents parse structured objects more reliably than single-line blobs
- **Tightened Local Testing prose**: "Ensure X runs, Y is exported, Wrangler is up to date:" → "Requires: X running, Y exported, Z" (same info, fewer words)
- **Removed redundant "- Validator" suffix** from Crontab Guru Resources link — already described as a validator inline in the Debugging section

## Content Preservation

All institutional knowledge preserved:
- All 9 code blocks (18 fence markers) ✓
- All 5 documentation URLs ✓
- All 11 sections ✓
- All key patterns: UTC ONLY, At-least-once, idempotent, waitUntil, AbortController, `/__scheduled`, wrangler secret, Green Compute ✓

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md` (133→137 lines, net +4 from console.log expansion)

## Runtime Testing

**Risk level:** Low — agent doc only, no code execution paths changed.
**Verification:** `self-assessed` — all code blocks, URLs, and key patterns verified present before and after.

<!-- MERGE_SUMMARY -->
**What:** Readability improvements to Cloudflare Cron Triggers gotchas doc — expand long debug log line, tighten prose, remove redundant label
**Issue:** Closes #15621
**Files changed:** 1 (`.agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md`)
**Testing:** Content preservation verified — all code blocks, URLs, sections, and key patterns present
**Key decisions:** Expanded console.log for readability (net +4 lines) rather than compressing further; all institutional knowledge preserved

---
[aidevops.sh](https://aidevops.sh) v3.5.724 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 18m and 6,511 tokens on this as a headless worker.