### PR TITLE
GH#15854: tighten secret-handling.md (reorder sections 8.1-8.4 by logical priority)

### DIFF
--- a/.agents/reference/secret-handling.md
+++ b/.agents/reference/secret-handling.md
@@ -6,6 +6,18 @@ Rules for preventing credential exposure in AI agent sessions. Extracted from `p
 
 ---
 
+## 8.1 Session Transcript Exposure (t1457)
+
+**Threat:** AI tool inputs and outputs are captured in session transcripts and may be sent to a remote model provider.
+
+- Treat command input + stdout/stderr as transcript-visible. If printing it would leak a secret in chat, it leaks in tool output too.
+- When giving secret setup instructions, start with: `WARNING: Never paste secret values into AI chat. Run the command in your terminal and enter the value at the hidden prompt.`
+- Prefer secret-safe patterns: key-name listings, masked previews, one-way fingerprints, exit-code checks.
+- Avoid writing raw secrets to temp files (e.g., `/tmp/*.json`); prefer in-memory piping. If unavoidable, clean up immediately.
+- If a command can expose secrets and no safe alternative exists, do not run it via AI tools — instruct the user to run it locally.
+
+---
+
 ## 8.2 Never Run Commands That Print Secret Values (t2846)
 
 **Threat:** Agent runs commands whose output contains secret values, exposing credentials in the transcript. Once a secret appears in conversation, it must be rotated.
@@ -37,18 +49,6 @@ Rules for preventing credential exposure in AI agent sessions. Extracted from `p
   - Immediately warn: "That looks like a credential. Conversation transcripts are stored on disk — treat this value as compromised. Rotate it and store the new value via `aidevops secret set NAME` in your terminal."
   - Do NOT repeat, echo, or reference the pasted value in your response
   - Continue with a placeholder like `<YOUR_API_KEY>` instead
-
----
-
-## 8.1 Session Transcript Exposure (t1457)
-
-**Threat:** Commands run by AI tools and their output are captured in session transcripts and may be sent to a remote model provider.
-
-- Treat command input + stdout/stderr as transcript-visible. If printing it would leak a secret in chat, it leaks in tool output too.
-- When giving secret setup instructions, start with: `WARNING: Never paste secret values into AI chat. Run the command in your terminal and enter the value at the hidden prompt.`
-- Prefer secret-safe patterns: key-name listings, masked previews, one-way fingerprints, exit-code checks.
-- Avoid writing raw secrets to temp files (e.g., `/tmp/*.json`); prefer in-memory piping. If unavoidable, clean up immediately.
-- If a command can expose secrets and no safe alternative exists, do not run it via AI tools — instruct the user to run it locally.
 
 ---
 


### PR DESCRIPTION
## Summary

Reorders sections in `.agents/reference/secret-handling.md` from the original out-of-order sequence (8.2→8.1→8.3→8.4) to logical numeric order (8.1→8.2→8.3→8.4). Section 8.1 (Session Transcript Exposure) is the foundational rule that all other sections build on — it belongs first. Also tightens the 8.1 threat description for precision.

## What changed

- Moved section 8.1 (Session Transcript Exposure, t1457) before 8.2 — it's the foundational rule
- Tightened 8.1 threat description: "Commands run by AI tools and their output are captured" → "AI tool inputs and outputs are captured"
- All content, task IDs (t1457, t2846, t4939, t4954), incident references, and code examples preserved

## Files changed

- `.agents/reference/secret-handling.md` — 97 lines before and after (reorder only, no content loss)

## Testing

- `wc -l` confirms 97 lines before and after
- `git diff` confirms only section reordering and one prose tightening
- All task IDs and incident references present: t1457, t2846, t4939, t4954, ILDS t006, qs-agency, FluentForms

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. Self-assessed.

Closes #15854

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,053 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized security documentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->