### PR TITLE
GH#14336: tighten enpass.md 79→65 lines, zero information loss

### DIFF
--- a/.agents/tools/credentials/enpass.md
+++ b/.agents/tools/credentials/enpass.md
@@ -14,24 +14,20 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Manage credentials via Enpass CLI (`enpass-cli`)
+- **Purpose**: Retrieve credentials via Enpass CLI (`enpass-cli`) for automation when Enpass is the user's primary password manager
 - **Install**: `brew install enpass-cli` or download from https://www.enpass.io/
 - **Docs**: https://www.enpass.io/docs/
-- **Storage**: Local vault (no cloud dependency), optional sync via cloud providers
-
-**When to use**: Retrieving passwords for automation when Enpass is the user's primary password manager. Enpass stores vaults locally (SQLite) with optional cloud sync.
+- **Storage**: Local vault (SQLite + SQLCipher), optional sync via cloud providers
 
 <!-- AI-CONTEXT-END -->
 
 ## Setup
 
 ```bash
-# Install CLI
 brew install enpass-cli
 
-# Or use the community CLI tool
+# Community CLI alternative: https://github.com/hauntedhost/enpass-cli
 pip install enpass-cli
-# https://github.com/hauntedhost/enpass-cli
 
 # Initialize with vault path
 enpass-cli --vault ~/Documents/Enpass/Vaults/primary
@@ -40,35 +36,25 @@ enpass-cli --vault ~/Documents/Enpass/Vaults/primary
 ## Common Commands
 
 ```bash
-# List all items
 enpass-cli list
-
-# Search for items
 enpass-cli search "github"
-
-# Get password for specific item
 enpass-cli get "GitHub Token" --field password
-
-# Copy password to clipboard
 enpass-cli get "GitHub Token" --field password | pbcopy
 ```
 
-## Vault Access
-
-Enpass uses SQLite with SQLCipher encryption:
+## Vault Locations
 
 ```bash
-# Vault location (macOS)
+# macOS
 ~/Library/Containers/in.sinew.Enpass-Desktop/Data/Documents/Walletx/
 
-# Vault location (Linux)
+# Linux
 ~/.local/share/Enpass/Walletx/
 ```
 
 ## Security Notes
 
-- Enpass vaults are local-first (no mandatory cloud)
-- Master password never leaves the device
+- Local-first (no mandatory cloud); master password never leaves the device
 - Sync options: iCloud, Dropbox, Google Drive, OneDrive, WebDAV, Box
 - CLI tools are community-maintained (not official Enpass)
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/credentials/enpass.md` per issue #14336 (simplification-debt scan).

**Classification**: Instruction doc (agent rules, operational procedures) — prose tightening applied, not chapter split.

**Changes**: 79 → 65 lines (18% reduction)

- Merged "When to use" paragraph into Purpose bullet (same information, fewer words)
- Removed redundant inline comments in Common Commands (self-documenting commands)
- Removed `# Install CLI` comment (restated the next line)
- Replaced verbose vault location comments with concise `# macOS` / `# Linux` markers
- Merged SQLCipher encryption note into Quick Reference Storage bullet

**Preserved**: All code blocks, URLs (`https://www.enpass.io/`, `https://www.enpass.io/docs/`, `https://github.com/hauntedhost/enpass-cli`), vault paths (macOS + Linux), security notes, related links — zero information loss.

Closes #14336

## Runtime Testing

**Risk level**: Low — agent doc only, no executable code changed.
**Verification**: `self-assessed` — all code blocks, URLs, vault paths, and security notes verified present before and after.

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,101 tokens on this as a headless worker.