### PR TITLE
GH#15694: tighten do-storage-gotchas.md 88→84 lines

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md
@@ -69,13 +69,9 @@ await this.ctx.storage.deleteAll();
 
 ## Auto Caching & Bypass
 
-```typescript
-async getUniqueNumber() {
-  let val = await this.ctx.storage.get("counter"); // Cached after first read
-  await this.ctx.storage.put("counter", val + 1);  // Instant cache write
-  return val;
-}
+Storage reads are cached after first access; writes update cache instantly.
 
+```typescript
 // Bypass opts: allowConcurrency, noCache, allowUnconfirmed
 await this.ctx.storage.get("key", { allowConcurrency: true, noCache: true });
 ```


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md` per GH#15694.

**Change:** Removed redundant `getUniqueNumber` TypeScript function from the `Auto Caching & Bypass` section — it was a verbatim duplicate of the same function already shown in the `Concurrency Gates` section. Replaced with a one-line prose description of the caching behaviour. All other code blocks, limits, command examples, and institutional knowledge preserved.

**Result:** 88 → 84 lines (5% reduction). Zero knowledge loss.

Closes #15694

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md` — removed 4 lines of duplicate code, added 1-line prose summary

## Runtime Testing

**Risk level:** Low — agent doc (`.md`), no executable code changed.
**Verification:** All code blocks, URLs, task ID refs, and command examples present before and after. `wc -l` confirms 84 lines (original 88).

## Key Decisions

- Classified as instruction doc (not reference corpus) — prose tightening appropriate
- Redundant function in `Auto Caching & Bypass` was the only genuine duplication; all other sections are unique
- No content reordering needed — sections already ordered by importance

<!-- MERGE_SUMMARY -->
**What:** Remove duplicate `getUniqueNumber` code block from Auto Caching section
**Issue:** GH#15694
**Files changed:** 1 (`.agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md`)
**Testing:** Self-assessed (low-risk doc change)
**Key decisions:** Replaced 6-line duplicate function with 1-line prose description

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,079 tokens on this as a headless worker.