### PR TITLE
GH#15695: tighten clean-ddd-hexagonal-skill.md 86→47 lines

### DIFF
--- a/.agents/tools/architecture/clean-ddd-hexagonal-skill.md
+++ b/.agents/tools/architecture/clean-ddd-hexagonal-skill.md
@@ -22,48 +22,9 @@ Infrastructure → Application → Domain
 
 **Design validation:** If you can run domain logic from tests with no infrastructure, your boundaries are correct.
 
-## Directory Structure
+Directory structure and layer specifications: [layers.md](clean-ddd-hexagonal-skill/layers.md).
 
-```text
-src/
-├── domain/                    # Core business logic (NO external dependencies)
-│   ├── {aggregate}/
-│   │   ├── entity              # Aggregate root + child entities
-│   │   ├── value_objects       # Immutable value types
-│   │   ├── events              # Domain events
-│   │   ├── repository          # Repository interface (DRIVEN PORT)
-│   │   └── services            # Domain services (stateless logic)
-│   └── shared/
-│       └── errors              # Domain errors
-├── application/               # Use cases / Application services
-│   ├── {use-case}/
-│   │   ├── command             # Command/Query DTOs
-│   │   ├── handler             # Use case implementation
-│   │   └── port                # Driver port interface
-│   └── shared/
-│       └── unit_of_work        # Transaction abstraction
-├── infrastructure/            # Adapters (external concerns)
-│   ├── persistence/           # Database adapters
-│   ├── messaging/             # Message broker adapters
-│   ├── http/                  # REST/GraphQL adapters (DRIVER)
-│   └── config/
-│       └── di                  # Dependency injection / composition root
-└── main                        # Bootstrap / entry point
-```
-
-## DDD Building Blocks
-
-| Pattern | Purpose | Layer | Key Rule |
-|---------|---------|-------|----------|
-| **Entity** | Identity + behavior | Domain | Equality by ID |
-| **Value Object** | Immutable data | Domain | Equality by value, no setters |
-| **Aggregate** | Consistency boundary | Domain | Only root is referenced externally |
-| **Domain Event** | Record of change | Domain | Past tense naming (`OrderPlaced`) |
-| **Repository** | Persistence abstraction | Domain (port) | Per aggregate, not per table |
-| **Domain Service** | Stateless logic | Domain | When logic doesn't fit an entity |
-| **Application Service** | Orchestration | Application | Coordinates domain + infra |
-
-Anti-patterns (anemic domain, leaking infrastructure, god aggregate): [cheatsheet.md](clean-ddd-hexagonal-skill/cheatsheet.md#common-anti-patterns).
+DDD building blocks (Entity, Value Object, Aggregate, Domain Event, Repository, Domain Service, Application Service) and anti-patterns (anemic domain, leaking infrastructure, god aggregate): [ddd-tactical.md](clean-ddd-hexagonal-skill/ddd-tactical.md) · [cheatsheet.md](clean-ddd-hexagonal-skill/cheatsheet.md#common-anti-patterns).
 
 ## Implementation Order
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/tools/architecture/clean-ddd-hexagonal-skill.md` from 86 to 47 lines (45% reduction)
- Replace inline Directory Structure code block (28 lines) with pointer to `layers.md`
- Replace inline DDD Building Blocks table (13 lines) with pointer to `ddd-tactical.md`
- Zero information loss — all content preserved in existing chapter files

## What

Slim index now focuses on the three highest-value quick-reference items:
1. **CRITICAL: The Dependency Rule** — the most important architectural constraint
2. **Implementation Order** — the 5-step workflow
3. **Reference Documentation** — table of chapter files

Inline content that duplicated chapter files has been replaced with prose pointers.

## Issue

Closes #15695

## Files Changed

- `.agents/tools/architecture/clean-ddd-hexagonal-skill.md` — 86→47 lines

## Testing

**Risk level:** Low (docs/agent prompt, no code changes)
**Verification:** `self-assessed`

- All chapter file links verified present and unchanged
- All code blocks preserved (dependency rule diagram retained)
- No task ID references or command examples in this file
- Chapter files untouched: `layers.md` (204 lines), `ddd-tactical.md` (269 lines), `cheatsheet.md` (233 lines)

## Runtime Testing

Risk: Low — agent doc tightening only. No runtime verification required per testing gate.

## Key Decisions

- Kept the Dependency Rule section inline (most critical, highest primacy value)
- Kept Implementation Order inline (useful quick-reference, not duplicated in chapters)
- Replaced Directory Structure and DDD Building Blocks with prose pointers (fully covered in chapters)

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 3m and 4,989 tokens on this as a headless worker.