### PR TITLE
GH#15869: tighten workerd-patterns.md, remove redundant prose, normalize code blocks

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md
@@ -40,8 +40,6 @@ const config :Workerd.Config = (
 
 ## Durable Objects
 
-Add as a service entry in the `services` list:
-
 ```capnp
 (name = "app", worker = (
   modules = [
@@ -57,7 +55,7 @@ Add as a service entry in the `services` list:
 
 ## Dev vs Prod Configs
 
-Named configs per environment; override bindings via `fromEnvironment`:
+Named configs per environment; bindings via `fromEnvironment`:
 
 ```capnp
 const devWorker :Workerd.Worker = (
@@ -70,11 +68,13 @@ const devWorker :Workerd.Worker = (
 );
 ```
 
-Run with: `API_URL=http://localhost:3000 DEBUG=true workerd serve dev.capnp`
+```bash
+API_URL=http://localhost:3000 DEBUG=true workerd serve dev.capnp
+```
 
 ## HTTP Reverse Proxy
 
-Service-worker syntax with external backend (add to `services`/`sockets` blocks):
+Service-worker syntax with external backend (add to `services`/`sockets`):
 
 ```capnp
 (name = "proxy", worker = (
@@ -115,7 +115,7 @@ workerd test config.capnp --test-only=test.js
 
 ### Systemd
 
-`/etc/systemd/system/workerd.service`:
+`/etc/systemd/system/workerd.service`
 
 ```ini
 [Unit]
@@ -134,7 +134,7 @@ NoNewPrivileges=true
 WantedBy=multi-user.target
 ```
 
-`/etc/systemd/system/workerd.socket`:
+`/etc/systemd/system/workerd.socket`
 
 ```ini
 [Socket]


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightens `workerd-patterns.md` (166 lines) by removing redundant prose and normalizing code block formatting. Zero information loss — all code examples, URLs, and knowledge preserved.

## Changes
- Remove "Add as a service entry in the `services` list:" (redundant — code is self-explanatory)
- Tighten "override bindings via `fromEnvironment`" → "bindings via `fromEnvironment`"
- Convert inline `Run with: \`...\`` to proper bash code block (consistent with other sections)
- Tighten "add to `services`/`sockets` blocks" → "add to `services`/`sockets`"
- Remove trailing colons from file path references (`workerd.service:` → `workerd.service`)

## Issue
Closes #15869

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md` — 7 insertions, 7 deletions

## Testing
- **Risk level**: Low (docs-only, no code logic)
- **Verification**: All code blocks, URLs, and command examples present before and after
- `wc -l` unchanged at 166 lines (prose removal offset by bash code block normalization)
- Content preservation: all capnp examples, deployment configs, and operational patterns intact

## Runtime Testing
`self-assessed` — docs-only change, no runtime behavior affected.

## Key Decisions
- Classified as reference corpus (domain knowledge base with code examples), not instruction doc
- At 166 lines (under 300-line threshold), splitting into chapters would add overhead without benefit
- Tightened prose where redundant; preserved all technical content

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,606 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and clarity in platform documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->