### PR TITLE
GH#15870: tighten email-sequences framework doc 120→114 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -18,6 +18,12 @@
       "passes": 2,
       "pr": 14645
     },
+    ".agents/aidevops/api-integrations.md": {
+      "at": "2026-04-02T21:19:50Z",
+      "hash": "9ed830efd42c0b7901229915ff9fe70d6f50fdac",
+      "passes": 2,
+      "pr": 0
+    },
     ".agents/aidevops/architecture.md": {
       "at": "2026-03-29T23:53:47Z",
       "hash": "f1d29dba0c0d676b0d00e4e5adac2d79f9aa2dd1",
@@ -324,6 +330,12 @@
       "passes": 1,
       "pr": 13836
     },
+    ".agents/content/meta-creator.md": {
+      "at": "2026-04-03T01:11:47Z",
+      "hash": "6573b67dd99792a8c5870a2850c8fb3bc74d7e3b",
+      "passes": 1,
+      "pr": 15781
+    },
     ".agents/content/optimization.md": {
       "at": "2026-03-29T23:18:03Z",
       "hash": "326ff8a42a6e84736e5f70fc2f569119e04c9fa5",
@@ -360,6 +372,12 @@
       "passes": 1,
       "pr": 15516
     },
+    ".agents/content/production-video.md": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "b8dc424d6b0000d6bbdba29b25849344ca198a71",
+      "passes": 1,
+      "pr": 15699
+    },
     ".agents/content/production-writing.md": {
       "at": "2026-03-28T11:20:42Z",
       "hash": "525c4aab766775fa9f92155b85f58bcda67cf3ea",
@@ -383,6 +401,12 @@
       "hash": "b2840ebff41ba9b78f7331487d6596373e8436e4",
       "passes": 1,
       "pr": 11354
+    },
+    ".agents/content/social-linkedin.md": {
+      "at": "2026-04-03T01:11:19Z",
+      "hash": "4df257a29d0b5d2fb67cc260a1ac2d1881a8f8d2",
+      "passes": 2,
+      "pr": 15493
     },
     ".agents/content/story.md": {
       "at": "2026-03-29T17:14:35Z",
@@ -736,8 +760,8 @@
       "at": "2026-04-02T21:19:54Z",
       "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
       "issue": "GH#14286",
-      "passes": 2,
-      "note": "Reference corpus chapter tightened: 92 → 90 lines. Removed decorative closing sentence with no information value. Zero content loss."
+      "note": "Reference corpus chapter tightened: 92 \u2192 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
+      "passes": 2
     },
     ".agents/marketing-sales/cro-chapter-20.md": {
       "at": "2026-03-29T16:34:29Z",
@@ -769,19 +793,17 @@
       "passes": 1,
       "pr": 12753
     },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md": {
-      "hash": "e32cc9a38c9f2b1305595ef393fa64650ed7f0b5",
-      "issue": "GH#15068",
-      "note": "Reference corpus already split into 5 chapter files (01-saas-examples.md through 05-guarantees-and-design-principles.md). Index is 30 lines; chapters total 163 lines. No further action needed.",
-      "status": "done",
-      "at": "2026-04-02T20:39:23Z",
-      "passes": 1
-    },
     ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
       "at": "2026-04-01T20:59:28Z",
       "hash": "ab1f9c5d69340fa7acfd756c2ae37710b9fa600c",
       "passes": 1,
       "pr": 14996
+    },
+    ".agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md": {
+      "at": "2026-04-03T00:00:00Z",
+      "hash": "c189628fe77893ebad02f185a3e732b4e71dd2a6",
+      "passes": 1,
+      "pr": 15870
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-headline-formulas.md": {
       "at": "2026-03-28T08:58:42Z",
@@ -860,6 +882,14 @@
       "hash": "f74ee77c8e774c79829f80e238c09adbe6f3c21e",
       "passes": 1,
       "pr": 11945
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md": {
+      "at": "2026-04-02T20:39:23Z",
+      "hash": "e32cc9a38c9f2b1305595ef393fa64650ed7f0b5",
+      "issue": "GH#15068",
+      "note": "Reference corpus already split into 5 chapter files (01-saas-examples.md through 05-guarantees-and-design-principles.md). Index is 30 lines; chapters total 163 lines. No further action needed.",
+      "passes": 1,
+      "status": "done"
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-example.md": {
       "at": "2026-03-28T08:58:28Z",
@@ -1040,6 +1070,12 @@
       "hash": "d3207ef474ba73d95bb9c13864b282ac0b78169e",
       "passes": 1,
       "pr": 13666
+    },
+    ".agents/marketing-sales/meta-ads-checklists-scaling-checklist.md": {
+      "at": "2026-04-03T01:11:48Z",
+      "hash": "790011746194791c3988c38215a06a333438e040",
+      "passes": 1,
+      "pr": 15723
     },
     ".agents/marketing-sales/meta-ads-checklists-weekly-review.md": {
       "at": "2026-03-29T12:36:27Z",
@@ -1251,11 +1287,23 @@
       "passes": 1,
       "pr": 12780
     },
+    ".agents/reference/platform-support.md": {
+      "at": "2026-04-03T00:48:09Z",
+      "hash": "67f8c07f2072f5b15ffae32c07a9e8930a5f7c49",
+      "passes": 1,
+      "pr": "GH#16007"
+    },
     ".agents/reference/repo-sync.md": {
       "at": "2026-04-01T23:23:47Z",
       "hash": "e6c2ddc65a495825740608c7c440f8ba49033db5",
       "passes": 1,
       "pr": 15301
+    },
+    ".agents/reference/secret-handling.md": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "110d5344e0ea1856b8646e0d7099a5ed3efccbe2",
+      "passes": 1,
+      "pr": 15664
     },
     ".agents/reference/services.md": {
       "at": "2026-04-01T23:23:47Z",
@@ -1274,6 +1322,12 @@
       "hash": "b509e2fae5168065f0142ae29dca1ec2d410c53b",
       "passes": 1,
       "pr": 14996
+    },
+    ".agents/scripts/backfill-origin-labels.sh": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "01d5281e257d4507215400c7311169fd37a39f6e",
+      "passes": 1,
+      "pr": 15661
     },
     ".agents/scripts/commands/budget-analysis.md": {
       "at": "2026-04-01T20:58:50Z",
@@ -1329,6 +1383,12 @@
       "passes": 1,
       "pr": 11007
     },
+    ".agents/scripts/commands/memory-log.md": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "0f3be8d344b9ea22cd796e021e3f049e4ccaa75a",
+      "passes": 1,
+      "pr": 15701
+    },
     ".agents/scripts/commands/mission.md": {
       "at": "2026-03-29T12:36:32Z",
       "hash": "e13208184cee9ed81fd7f6bddfef98bbcd41b5f5",
@@ -1352,6 +1412,12 @@
       "hash": "37a467bf622640eb6c8d75aa2c1de45c9a27c61c",
       "passes": 1,
       "pr": 14942
+    },
+    ".agents/scripts/commands/pr-loop.md": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "5e3ba8395648167005fdf9b47d469849c80188e5",
+      "passes": 1,
+      "pr": 15682
     },
     ".agents/scripts/commands/pulse.md": {
       "at": "2026-04-02T14:41:03Z",
@@ -1406,6 +1472,18 @@
       "hash": "0c74f125bbb3e299040015ee24fb345e43486ec7",
       "passes": 1,
       "pr": 15487
+    },
+    ".agents/scripts/commands/security-review.md": {
+      "at": "2026-04-02T21:58:19Z",
+      "hash": "8aeebd043a47a280413cacae8697325574b2d88e",
+      "passes": 1,
+      "pr": 15535
+    },
+    ".agents/scripts/commands/seo-analyze.md": {
+      "at": "2026-04-02T21:58:20Z",
+      "hash": "04987b0129baab1ebd5f96cfe316cac9222f1b12",
+      "passes": 1,
+      "pr": 15502
     },
     ".agents/scripts/commands/seo-audit.md": {
       "at": "2026-04-02T03:11:11Z",
@@ -1467,6 +1545,12 @@
       "passes": 1,
       "pr": 13544
     },
+    ".agents/scripts/compare-models-helper.sh": {
+      "at": "2026-04-03T01:11:46Z",
+      "hash": "10e52daaafa5297bc348b088923e28bf767b4e73",
+      "passes": 1,
+      "pr": 15946
+    },
     ".agents/scripts/foss-handlers/generic.sh": {
       "at": "2026-03-29T03:15:47Z",
       "hash": "45cc10462795e6230b70b2f068bb95b4e53612f2",
@@ -1521,6 +1605,12 @@
       "passes": 2,
       "pr": 12971
     },
+    ".agents/scripts/watercrawl-helper.sh": {
+      "at": "2026-04-02T22:43:46Z",
+      "hash": "27e5853c455180c533e572d91d47769062d78519",
+      "passes": 1,
+      "status": "simplified"
+    },
     ".agents/seo.md": {
       "at": "2026-03-30T03:34:16Z",
       "hash": "1dcd30f4590e4b2b7792e538d0a70e7d4979aa8e",
@@ -1539,6 +1629,12 @@
       "passes": 2,
       "pr": 14969
     },
+    ".agents/seo/ai-search-readiness.md": {
+      "at": "2026-04-03T01:11:28Z",
+      "hash": "4652d2041fcf22b11419930334a44136a3acefe7",
+      "passes": 2,
+      "pr": 15496
+    },
     ".agents/seo/analytics-tracking.md": {
       "at": "2026-03-27T21:25:04Z",
       "hash": "07ff0feec55ad3f8477a6badd724b479c1b09370",
@@ -1550,6 +1646,12 @@
       "hash": "16c0f1f109b8a8d47222978204b1f7b955abaa7d",
       "passes": 2,
       "pr": null
+    },
+    ".agents/seo/bing-webmaster-tools.md": {
+      "at": "2026-04-03T01:11:29Z",
+      "hash": "fb22f3998fd4903c3ff77c9a664f0edb7fe62d1f",
+      "passes": 2,
+      "pr": 15532
     },
     ".agents/seo/content-analyzer.md": {
       "at": "2026-04-02T04:56:49Z",
@@ -1659,6 +1761,12 @@
       "passes": 2,
       "pr": 13301
     },
+    ".agents/seo/rich-results.md": {
+      "at": "2026-04-02T22:44:04Z",
+      "hash": "96226173e887aebf71287a803541f50f5b89d1c8",
+      "passes": 1,
+      "pr": 15665
+    },
     ".agents/seo/semrush.md": {
       "at": "2026-03-27T21:25:11Z",
       "hash": "cc61832322267a222c9e557b04459de4a3520086",
@@ -1670,6 +1778,18 @@
       "hash": "d8493f42e8ba01527667d283942af955218a834f",
       "passes": 1,
       "pr": 12948
+    },
+    ".agents/seo/seo-audit-skill/aeo-geo-patterns.md": {
+      "at": "2026-04-02T21:20:03Z",
+      "hash": "2238ceff37db82a81a9939c6d2217c5b7659a551",
+      "passes": 2,
+      "pr": 0
+    },
+    ".agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md": {
+      "at": "2026-04-02T21:58:19Z",
+      "hash": "b7d6d4111324b39cbd5d0615343881696d760822",
+      "passes": 1,
+      "pr": 15568
     },
     ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
       "at": "2026-03-29T23:53:50Z",
@@ -1742,6 +1862,12 @@
       "hash": "b16a496c6e98ffbb24f9a833e5b39e9566fb3f6b",
       "passes": 2,
       "pr": 13468
+    },
+    ".agents/services/communications/matrix-bot.md": {
+      "at": "2026-04-03T01:11:47Z",
+      "hash": "92784be52960e2b9738999d8c725a442cd3d5897",
+      "passes": 1,
+      "pr": 15801
     },
     ".agents/services/communications/matterbridge.md": {
       "at": "2026-03-29T01:04:18Z",
@@ -1850,6 +1976,12 @@
       "hash": "084644aa5375c89ba69717a690c579d6076d532e",
       "passes": 2,
       "pr": 14691
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md": {
+      "at": "2026-04-02T00:00:00Z",
+      "hash": "1aa15519d959c89c0e09c3e30ac0210d6da35134",
+      "passes": 1,
+      "pr": 0
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
       "at": "2026-03-28T10:27:24Z",
@@ -1977,6 +2109,12 @@
       "passes": 1,
       "pr": 13593
     },
+    ".agents/services/email/email-inbound-commands.md": {
+      "at": "2026-04-03T01:11:48Z",
+      "hash": "2d55a1a765cc4b287e8e8cdbcf1eabf5d50bb4aa",
+      "passes": 1,
+      "pr": 15725
+    },
     ".agents/services/email/email-intelligence.md": {
       "at": "2026-03-29T12:37:18Z",
       "hash": "4046abd7e9e4fffe477b2aa6fedd74cc46fb9708",
@@ -2079,6 +2217,12 @@
       "passes": 4,
       "pr": 15053
     },
+    ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md": {
+      "at": "2026-04-02T21:20:06Z",
+      "hash": "b253668b96ea394b289fba6ee03f12b30a041540",
+      "passes": 2,
+      "pr": 0
+    },
     ".agents/services/hosting/cloudflare-platform-skill/ai-gateway.md": {
       "at": "2026-03-28T05:50:52Z",
       "hash": "720c2836fca088d027ac637f8c69e97cb3c2764a",
@@ -2109,17 +2253,41 @@
       "passes": 1,
       "pr": 12779
     },
+    ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md": {
+      "at": "2026-04-03T01:11:32Z",
+      "hash": "cf1846a80d91d8b99d83e135da0b5b13c80ef9b7",
+      "passes": 3,
+      "pr": 15606
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md": {
+      "at": "2026-04-03T00:57:59Z",
+      "hash": "61a700349adcfc92119244d456e2e601cbc2f926",
+      "passes": 3,
+      "pr": 16020
+    },
     ".agents/services/hosting/cloudflare-platform-skill/d1-patterns.md": {
       "at": "2026-03-29T21:43:01Z",
       "hash": "8e6341f6f72cefdc4c09224910c1c4efe62de068",
       "passes": 1,
       "pr": 13296
     },
+    ".agents/services/hosting/cloudflare-platform-skill/ddos-gotchas.md": {
+      "at": "2026-04-02T21:20:06Z",
+      "hash": "f9bc5ae56912b9413ffb35a31dfdca00d42513cb",
+      "passes": 2,
+      "pr": 0
+    },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
       "at": "2026-03-30T02:30:53Z",
       "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
       "passes": 1,
       "pr": 13494
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/do-storage.md": {
+      "at": "2026-04-02T21:58:19Z",
+      "hash": "7652036224eb9bb0199c584f61a0a6631902a0ff",
+      "passes": 1,
+      "pr": 15569
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects-gotchas.md": {
       "at": "2026-03-29T11:19:55Z",
@@ -2133,6 +2301,12 @@
       "passes": 1,
       "pr": 12192
     },
+    ".agents/services/hosting/cloudflare-platform-skill/durable-objects.md": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "7a4852a2f3e454c5962f11cefa855b6e4a1555b4",
+      "passes": 1,
+      "pr": 15663
+    },
     ".agents/services/hosting/cloudflare-platform-skill/email-workers.md": {
       "at": "2026-03-29T03:15:00Z",
       "hash": "d43b669b4be0f3b85ad9b1e95ff67189431eafdc",
@@ -2144,6 +2318,12 @@
       "hash": "1a63158e184bf8c3c6ac2f4b5110e44451c5d837",
       "passes": 1,
       "pr": 15481
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md": {
+      "at": "2026-04-02T21:58:19Z",
+      "hash": "839f69b3a40ac4728392bc8bf8396b643274c96c",
+      "passes": 1,
+      "pr": 15645
     },
     ".agents/services/hosting/cloudflare-platform-skill/kv-patterns.md": {
       "at": "2026-03-29T22:09:11Z",
@@ -2163,6 +2343,12 @@
       "passes": 1,
       "pr": 13020
     },
+    ".agents/services/hosting/cloudflare-platform-skill/miniflare.md": {
+      "at": "2026-04-02T21:58:19Z",
+      "hash": "4471ddd0229e26f2af30d5833d95c9a1f0261dac",
+      "passes": 1,
+      "pr": 15561
+    },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
       "at": "2026-03-29T12:36:58Z",
       "hash": "07e97feffa7bc2100478d39e614278ab867ba605",
@@ -2180,6 +2366,12 @@
       "hash": "dc0ab9b5d1eadafd4faf927c93a89eb11db185eb",
       "passes": 2,
       "pr": 14916
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
+      "at": "2026-04-02T21:58:19Z",
+      "hash": "67350510852f0967a6591a03b13812ae2c7899d1",
+      "passes": 1,
+      "pr": 15646
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
       "at": "2026-03-30T06:49:10Z",
@@ -2258,6 +2450,12 @@
       "hash": "98b6e10081c4b00014ad525bb96a33a62b6f90a0",
       "passes": 1,
       "pr": 13329
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi.md": {
+      "at": "2026-04-02T21:58:17Z",
+      "hash": "187f420fb21cc23e7fdc54f897b8afd4f739f80e",
+      "passes": 1,
+      "pr": 15823
     },
     ".agents/services/hosting/cloudflare-platform-skill/queues-patterns.md": {
       "at": "2026-03-30T04:51:49Z",
@@ -2392,6 +2590,12 @@
       "passes": 1,
       "pr": 13534
     },
+    ".agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md": {
+      "at": "2026-04-02T22:44:04Z",
+      "hash": "1a9ebfb7d88fdd954fa0ca93d3a4dffa7e24c461",
+      "passes": 1,
+      "pr": 15666
+    },
     ".agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md": {
       "at": "2026-03-29T12:36:34Z",
       "hash": "b194dbf29525881c1c8296a33806387d7ca7fe7f",
@@ -2482,6 +2686,12 @@
       "passes": 1,
       "pr": 15335
     },
+    ".agents/services/hosting/cloudflare-platform-skill/zaraz.md": {
+      "at": "2026-04-02T21:20:08Z",
+      "hash": "e4b79af78576116b33c9947649dffa9f1de19cec",
+      "passes": 2,
+      "pr": 0
+    },
     ".agents/services/hosting/cloudflare.md": {
       "at": "2026-03-28T16:00:49Z",
       "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
@@ -2529,6 +2739,12 @@
       "hash": "23bcf676fc5edd9dcfebc3fb07b0d4ed6cb61a19",
       "passes": 1,
       "pr": 13859
+    },
+    ".agents/services/hosting/spaceship.md": {
+      "at": "2026-04-03T01:11:34Z",
+      "hash": "070eeb271be745bf4ce6d0c0a22631229975b71a",
+      "passes": 2,
+      "pr": 15494
     },
     ".agents/services/hosting/webhosting.md": {
       "at": "2026-03-28T03:54:32Z",
@@ -2590,6 +2806,12 @@
       "passes": 1,
       "pr": 11713
     },
+    ".agents/services/payments/revenuecat.md": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "4a4d2603bb24d79952c3d18b283cd48deafde2d4",
+      "passes": 1,
+      "pr": 15693
+    },
     ".agents/services/payments/stripe.md": {
       "at": "2026-03-29T03:15:16Z",
       "hash": "6cbe509351f115869d196a09bc7031bb237d2a41",
@@ -2643,6 +2865,12 @@
       "hash": "8b525467afaf93fea7539e9f47fabf2159254ae1",
       "passes": 1,
       "pr": 15336
+    },
+    ".agents/tools/ai-assistants/fallback-chains.md": {
+      "at": "2026-04-02T21:58:20Z",
+      "hash": "04c03d8868c5719bfa209234bcac59f7b997c3f4",
+      "passes": 1,
+      "pr": 15534
     },
     ".agents/tools/ai-assistants/headless-dispatch.md": {
       "at": "2026-03-29T03:15:46Z",
@@ -2914,6 +3142,12 @@
       "passes": 1,
       "pr": 11858
     },
+    ".agents/tools/browser/crawl4ai-usage.md": {
+      "at": "2026-04-03T01:11:47Z",
+      "hash": "46d82b1f632872fa8c59c2a271c79466ced17238",
+      "passes": 1,
+      "pr": 15802
+    },
     ".agents/tools/browser/crawl4ai.md": {
       "at": "2026-03-28T08:17:51Z",
       "hash": "967373980ca56ec85cb795eb9426efb91ff23ddb",
@@ -2980,6 +3214,12 @@
       "passes": 1,
       "pr": 11802
     },
+    ".agents/tools/browser/playwright-emulation.md": {
+      "at": "2026-04-02T22:44:04Z",
+      "hash": "1fdc5a4f08a4e9ba8ebc3550ade50c4876b949d7",
+      "passes": 1,
+      "pr": 15692
+    },
     ".agents/tools/browser/playwriter.md": {
       "at": "2026-03-29T03:31:38Z",
       "hash": "98bfa1b0dde9a405a0f3a07aa1ae3eaadc42801a",
@@ -3034,6 +3274,12 @@
       "passes": 1,
       "pr": 12376
     },
+    ".agents/tools/build-agent/agent-testing.md": {
+      "at": "2026-04-02T21:58:18Z",
+      "hash": "cc7b9b5e44e530964c79af624de3408b1076cbe3",
+      "passes": 1,
+      "pr": 15662
+    },
     ".agents/tools/build-agent/build-agent.md": {
       "at": "2026-03-29T14:29:12Z",
       "hash": "59fa5cde2d2c1b113be43ecdb1a6d8978d3d4f69",
@@ -3081,6 +3327,12 @@
       "hash": "733acaf8682f80a53cd3c2a996c0571adf7ac018",
       "passes": 1,
       "pr": 12394
+    },
+    ".agents/tools/code-review/auditing.md": {
+      "at": "2026-04-02T21:20:13Z",
+      "hash": "aa7f70c05362b5b00887a152a101c0b6ee7da926",
+      "passes": 2,
+      "pr": 0
     },
     ".agents/tools/code-review/best-practices.md": {
       "at": "2026-03-28T13:38:46Z",
@@ -3208,6 +3460,12 @@
       "passes": 1,
       "pr": 12749
     },
+    ".agents/tools/context/rapidfuzz.md": {
+      "at": "2026-04-02T21:20:14Z",
+      "hash": "aa9697dab445dd988e21cf2cd29a5065bd821808",
+      "passes": 2,
+      "pr": 0
+    },
     ".agents/tools/conversion/mineru.md": {
       "at": "2026-03-28T16:40:36Z",
       "hash": "beeb4a49df5e2a8ea91da9100ae2ba8887cf6b3d",
@@ -3231,6 +3489,12 @@
       "hash": "808ffa447534e25dd4090033275c4861a8612f2c",
       "passes": 1,
       "pr": 15468
+    },
+    ".agents/tools/credentials/encryption-stack.md": {
+      "at": "2026-04-03T01:11:47Z",
+      "hash": "2e34e7975b8addfeaa1860db91423c85633b596c",
+      "passes": 1,
+      "pr": 15780
     },
     ".agents/tools/credentials/environment-variables.md": {
       "at": "2026-03-29T08:10:40Z",
@@ -3316,11 +3580,23 @@
       "passes": 1,
       "pr": 12844
     },
+    ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
+      "at": "2026-04-02T00:00:00Z",
+      "hash": "edecc25afbace885cab2eac01e07629d890a4fad",
+      "passes": 1,
+      "pr": 0
+    },
     ".agents/tools/deployment/cloudron-app-packaging.md": {
       "at": "2026-03-28T03:54:01Z",
       "hash": "a6ddd4af870f4445d96eb4bf3c2d109fcb9219b7",
       "passes": 1,
       "pr": 11344
+    },
+    ".agents/tools/deployment/cloudron-app-publishing-skill.md": {
+      "at": "2026-04-02T21:58:20Z",
+      "hash": "b78c7c2bff3ffbd13eb8b068699f5672cf21d922",
+      "passes": 1,
+      "pr": 15497
     },
     ".agents/tools/deployment/cloudron-server-ops-skill.md": {
       "at": "2026-03-30T03:33:52Z",
@@ -3820,6 +4096,12 @@
       "passes": 2,
       "pr": 13349
     },
+    ".agents/tools/programming/modern-javascript-skill/es2016-es2017.md": {
+      "at": "2026-04-03T01:11:46Z",
+      "hash": "6e238e8d6cd856c6d54aeeda15ded6763fbb7439",
+      "passes": 1,
+      "pr": 15969
+    },
     ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
       "at": "2026-03-28T05:50:55Z",
       "hash": "b59a17a028d181e2f55c45e58c371ca999d9a2ee",
@@ -3855,6 +4137,12 @@
       "hash": "70a64dd60d9a32431e5c36f75d0ad6aed1865c46",
       "passes": 1,
       "pr": 13542
+    },
+    ".agents/tools/research/providers/openexplorer.md": {
+      "at": "2026-04-02T21:58:17Z",
+      "hash": "90affb8aeffa94f67ed47a1399ec4220de2947cf",
+      "passes": 1,
+      "pr": 15822
     },
     ".agents/tools/research/providers/unbuilt.md": {
       "at": "2026-03-29T12:36:25Z",
@@ -3927,6 +4215,12 @@
       "hash": "f33e57108fd87d88906e414ae5caf4d169efb557",
       "passes": 1,
       "pr": 12526
+    },
+    ".agents/tools/terminal/terminal-title.md": {
+      "at": "2026-04-03T01:11:48Z",
+      "hash": "a159d1374538460666970b226c494586840c5a08",
+      "passes": 1,
+      "pr": 15726
     },
     ".agents/tools/ui/ai-chat-sidebar.md": {
       "at": "2026-04-02T15:28:13Z",
@@ -4071,6 +4365,12 @@
       "hash": "619d768e114ab99f64b37c93d1628ae5cb7d54a4",
       "passes": 1,
       "pr": 13315
+    },
+    ".agents/tools/video/remotion-sequencing.md": {
+      "at": "2026-04-02T21:58:20Z",
+      "hash": "0eab4c364cf2ee28b3c16e91d7af50b372717619",
+      "passes": 1,
+      "pr": 15533
     },
     ".agents/tools/video/remotion-timing.md": {
       "at": "2026-04-01T20:59:53Z",
@@ -4240,6 +4540,12 @@
       "passes": 1,
       "pr": 15517
     },
+    ".agents/workflows/branch/experiment.md": {
+      "at": "2026-04-02T21:20:20Z",
+      "hash": "c0b292cdf26b8a6a6cbdff05b765a4601adaf875",
+      "passes": 2,
+      "pr": 0
+    },
     ".agents/workflows/branch/hotfix.md": {
       "at": "2026-04-01T20:59:04Z",
       "hash": "e1c1f9099b46c798fe473a7c23ff01bfa8e26b70",
@@ -4257,6 +4563,12 @@
       "hash": "2702ee79b7d0f63a13b19d69171f937db3e37064",
       "passes": 1,
       "pr": 11825
+    },
+    ".agents/workflows/error-feedback.md": {
+      "at": "2026-04-03T01:11:46Z",
+      "hash": "85e9eb0fc79cd4671cdd43c481a13d977775d291",
+      "passes": 1,
+      "pr": 15970
     },
     ".agents/workflows/feature-development.md": {
       "at": "2026-03-29T16:31:49Z",
@@ -4455,312 +4767,6 @@
       "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
       "passes": 1,
       "pr": 15470
-    },
-    ".agents/aidevops/api-integrations.md": {
-      "hash": "9ed830efd42c0b7901229915ff9fe70d6f50fdac",
-      "at": "2026-04-02T21:19:50Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/seo/seo-audit-skill/aeo-geo-patterns.md": {
-      "hash": "2238ceff37db82a81a9939c6d2217c5b7659a551",
-      "at": "2026-04-02T21:20:03Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md": {
-      "hash": "1aa15519d959c89c0e09c3e30ac0210d6da35134",
-      "at": "2026-04-02T00:00:00Z",
-      "pr": 0,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md": {
-      "hash": "b253668b96ea394b289fba6ee03f12b30a041540",
-      "at": "2026-04-02T21:20:06Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md": {
-      "hash": "cf1846a80d91d8b99d83e135da0b5b13c80ef9b7",
-      "at": "2026-04-03T01:11:32Z",
-      "pr": 15606,
-      "passes": 3
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/ddos-gotchas.md": {
-      "hash": "f9bc5ae56912b9413ffb35a31dfdca00d42513cb",
-      "at": "2026-04-02T21:20:06Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/zaraz.md": {
-      "hash": "e4b79af78576116b33c9947649dffa9f1de19cec",
-      "at": "2026-04-02T21:20:08Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/tools/code-review/auditing.md": {
-      "hash": "aa7f70c05362b5b00887a152a101c0b6ee7da926",
-      "at": "2026-04-02T21:20:13Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/tools/context/rapidfuzz.md": {
-      "hash": "aa9697dab445dd988e21cf2cd29a5065bd821808",
-      "at": "2026-04-02T21:20:14Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
-      "hash": "edecc25afbace885cab2eac01e07629d890a4fad",
-      "at": "2026-04-02T00:00:00Z",
-      "pr": 0,
-      "passes": 1
-    },
-    ".agents/workflows/branch/experiment.md": {
-      "hash": "c0b292cdf26b8a6a6cbdff05b765a4601adaf875",
-      "at": "2026-04-02T21:20:20Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pulumi.md": {
-      "hash": "187f420fb21cc23e7fdc54f897b8afd4f739f80e",
-      "at": "2026-04-02T21:58:17Z",
-      "pr": 15823,
-      "passes": 1
-    },
-    ".agents/tools/research/providers/openexplorer.md": {
-      "hash": "90affb8aeffa94f67ed47a1399ec4220de2947cf",
-      "at": "2026-04-02T21:58:17Z",
-      "pr": 15822,
-      "passes": 1
-    },
-    ".agents/scripts/commands/memory-log.md": {
-      "hash": "0f3be8d344b9ea22cd796e021e3f049e4ccaa75a",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15701,
-      "passes": 1
-    },
-    ".agents/content/production-video.md": {
-      "hash": "b8dc424d6b0000d6bbdba29b25849344ca198a71",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15699,
-      "passes": 1
-    },
-    ".agents/services/payments/revenuecat.md": {
-      "hash": "4a4d2603bb24d79952c3d18b283cd48deafde2d4",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15693,
-      "passes": 1
-    },
-    ".agents/scripts/commands/pr-loop.md": {
-      "hash": "5e3ba8395648167005fdf9b47d469849c80188e5",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15682,
-      "passes": 1
-    },
-    ".agents/reference/secret-handling.md": {
-      "hash": "110d5344e0ea1856b8646e0d7099a5ed3efccbe2",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15664,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/durable-objects.md": {
-      "hash": "7a4852a2f3e454c5962f11cefa855b6e4a1555b4",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15663,
-      "passes": 1
-    },
-    ".agents/tools/build-agent/agent-testing.md": {
-      "hash": "cc7b9b5e44e530964c79af624de3408b1076cbe3",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15662,
-      "passes": 1
-    },
-    ".agents/scripts/backfill-origin-labels.sh": {
-      "hash": "01d5281e257d4507215400c7311169fd37a39f6e",
-      "at": "2026-04-02T21:58:18Z",
-      "pr": 15661,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
-      "hash": "67350510852f0967a6591a03b13812ae2c7899d1",
-      "at": "2026-04-02T21:58:19Z",
-      "pr": 15646,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md": {
-      "hash": "839f69b3a40ac4728392bc8bf8396b643274c96c",
-      "at": "2026-04-02T21:58:19Z",
-      "pr": 15645,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/do-storage.md": {
-      "hash": "7652036224eb9bb0199c584f61a0a6631902a0ff",
-      "at": "2026-04-02T21:58:19Z",
-      "pr": 15569,
-      "passes": 1
-    },
-    ".agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md": {
-      "hash": "b7d6d4111324b39cbd5d0615343881696d760822",
-      "at": "2026-04-02T21:58:19Z",
-      "pr": 15568,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/miniflare.md": {
-      "hash": "4471ddd0229e26f2af30d5833d95c9a1f0261dac",
-      "at": "2026-04-02T21:58:19Z",
-      "pr": 15561,
-      "passes": 1
-    },
-    ".agents/scripts/commands/security-review.md": {
-      "hash": "8aeebd043a47a280413cacae8697325574b2d88e",
-      "at": "2026-04-02T21:58:19Z",
-      "pr": 15535,
-      "passes": 1
-    },
-    ".agents/tools/ai-assistants/fallback-chains.md": {
-      "hash": "04c03d8868c5719bfa209234bcac59f7b997c3f4",
-      "at": "2026-04-02T21:58:20Z",
-      "pr": 15534,
-      "passes": 1
-    },
-    ".agents/tools/video/remotion-sequencing.md": {
-      "hash": "0eab4c364cf2ee28b3c16e91d7af50b372717619",
-      "at": "2026-04-02T21:58:20Z",
-      "pr": 15533,
-      "passes": 1
-    },
-    ".agents/seo/bing-webmaster-tools.md": {
-      "hash": "fb22f3998fd4903c3ff77c9a664f0edb7fe62d1f",
-      "at": "2026-04-03T01:11:29Z",
-      "pr": 15532,
-      "passes": 2
-    },
-    ".agents/scripts/commands/seo-analyze.md": {
-      "hash": "04987b0129baab1ebd5f96cfe316cac9222f1b12",
-      "at": "2026-04-02T21:58:20Z",
-      "pr": 15502,
-      "passes": 1
-    },
-    ".agents/tools/deployment/cloudron-app-publishing-skill.md": {
-      "hash": "b78c7c2bff3ffbd13eb8b068699f5672cf21d922",
-      "at": "2026-04-02T21:58:20Z",
-      "pr": 15497,
-      "passes": 1
-    },
-    ".agents/seo/ai-search-readiness.md": {
-      "hash": "4652d2041fcf22b11419930334a44136a3acefe7",
-      "at": "2026-04-03T01:11:28Z",
-      "pr": 15496,
-      "passes": 2
-    },
-    ".agents/services/hosting/spaceship.md": {
-      "hash": "070eeb271be745bf4ce6d0c0a22631229975b71a",
-      "at": "2026-04-03T01:11:34Z",
-      "pr": 15494,
-      "passes": 2
-    },
-    ".agents/content/social-linkedin.md": {
-      "hash": "4df257a29d0b5d2fb67cc260a1ac2d1881a8f8d2",
-      "at": "2026-04-03T01:11:19Z",
-      "pr": 15493,
-      "passes": 2
-    },
-    ".agents/scripts/watercrawl-helper.sh": {
-      "hash": "27e5853c455180c533e572d91d47769062d78519",
-      "status": "simplified",
-      "at": "2026-04-02T22:43:46Z",
-      "passes": 1
-    },
-    ".agents/tools/browser/playwright-emulation.md": {
-      "hash": "1fdc5a4f08a4e9ba8ebc3550ade50c4876b949d7",
-      "at": "2026-04-02T22:44:04Z",
-      "pr": 15692,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md": {
-      "hash": "1a9ebfb7d88fdd954fa0ca93d3a4dffa7e24c461",
-      "at": "2026-04-02T22:44:04Z",
-      "pr": 15666,
-      "passes": 1
-    },
-    ".agents/seo/rich-results.md": {
-      "hash": "96226173e887aebf71287a803541f50f5b89d1c8",
-      "at": "2026-04-02T22:44:04Z",
-      "pr": 15665,
-      "passes": 1
-    },
-    ".agents/reference/platform-support.md": {
-      "hash": "67f8c07f2072f5b15ffae32c07a9e8930a5f7c49",
-      "at": "2026-04-03T00:48:09Z",
-      "pr": "GH#16007",
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md": {
-      "hash": "61a700349adcfc92119244d456e2e601cbc2f926",
-      "at": "2026-04-03T00:57:59Z",
-      "pr": 16020,
-      "passes": 3
-    },
-    ".agents/workflows/error-feedback.md": {
-      "hash": "85e9eb0fc79cd4671cdd43c481a13d977775d291",
-      "at": "2026-04-03T01:11:46Z",
-      "pr": 15970,
-      "passes": 1
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2016-es2017.md": {
-      "hash": "6e238e8d6cd856c6d54aeeda15ded6763fbb7439",
-      "at": "2026-04-03T01:11:46Z",
-      "pr": 15969,
-      "passes": 1
-    },
-    ".agents/scripts/compare-models-helper.sh": {
-      "hash": "10e52daaafa5297bc348b088923e28bf767b4e73",
-      "at": "2026-04-03T01:11:46Z",
-      "pr": 15946,
-      "passes": 1
-    },
-    ".agents/tools/browser/crawl4ai-usage.md": {
-      "hash": "46d82b1f632872fa8c59c2a271c79466ced17238",
-      "at": "2026-04-03T01:11:47Z",
-      "pr": 15802,
-      "passes": 1
-    },
-    ".agents/services/communications/matrix-bot.md": {
-      "hash": "92784be52960e2b9738999d8c725a442cd3d5897",
-      "at": "2026-04-03T01:11:47Z",
-      "pr": 15801,
-      "passes": 1
-    },
-    ".agents/content/meta-creator.md": {
-      "hash": "6573b67dd99792a8c5870a2850c8fb3bc74d7e3b",
-      "at": "2026-04-03T01:11:47Z",
-      "pr": 15781,
-      "passes": 1
-    },
-    ".agents/tools/credentials/encryption-stack.md": {
-      "hash": "2e34e7975b8addfeaa1860db91423c85633b596c",
-      "at": "2026-04-03T01:11:47Z",
-      "pr": 15780,
-      "passes": 1
-    },
-    ".agents/tools/terminal/terminal-title.md": {
-      "hash": "a159d1374538460666970b226c494586840c5a08",
-      "at": "2026-04-03T01:11:48Z",
-      "pr": 15726,
-      "passes": 1
-    },
-    ".agents/services/email/email-inbound-commands.md": {
-      "hash": "2d55a1a765cc4b287e8e8cdbcf1eabf5d50bb4aa",
-      "at": "2026-04-03T01:11:48Z",
-      "pr": 15725,
-      "passes": 1
-    },
-    ".agents/marketing-sales/meta-ads-checklists-scaling-checklist.md": {
-      "hash": "790011746194791c3988c38215a06a333438e040",
-      "at": "2026-04-03T01:11:48Z",
-      "pr": 15723,
-      "passes": 1
     }
   }
 }

--- a/.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md
+++ b/.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md
@@ -4,8 +4,6 @@ Email converts 2-5x vs social, ~$36 ROI per $1. Works for acquisition, nurturing
 
 **Templates**: [Email Sequence Templates](direct-response-copy-templates-email-sequences.md)
 
----
-
 ## High-Converting Email Anatomy
 
 ### Subject Line Formulas
@@ -43,8 +41,6 @@ But here's the thing... [Solution + brief explanation + social proof]
 [CTA]
 [P.S. - Urgency or bonus reminder]
 ```
-
----
 
 ## Core Sequences
 
@@ -103,8 +99,6 @@ But here's the thing... [Solution + brief explanation + social proof]
 | 5 | Day 9 | Show hidden value | Underutilized feature |
 | 6 | Day 12 | Create urgency | Loss aversion (what they'll lose) |
 | 7 | Day 14 | Final conversion | Discount code, guarantee |
-
----
 
 ## Best Practices
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md` from 120 to 114 lines by removing 3 decorative `---` horizontal rules and their surrounding blank lines. The `##` section headers already provide visual separation, making the rules redundant noise.

## Issue
Closes #15870

## Files Changed
- `.agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md` — 120→114 lines (5% reduction)
- `.agents/configs/simplification-state.json` — updated hash registry for this file

## Testing
**Risk level**: Low (docs/agent prompts — no runtime behaviour)
**Verification**: All code blocks, URLs, table content, and knowledge preserved. `wc -l` confirms 114 lines. Content diff shows only blank lines and `---` separators removed.

## Key Decisions
- Classified as instruction doc (not reference corpus) per issue guidance — tighten prose, not restructure into chapters
- Removed only decorative separators; all substantive content (tables, PAS template, sequence data, best practices) is intact
- No task IDs, GH refs, or command examples in this file — nothing to protect from compression

## Runtime Testing
`self-assessed` — Low risk: docs-only change, no code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 8m and 6,386 tokens on this as a headless worker.