### PR TITLE
GH#15873: tighten personalization-types.md 94→90 lines

### DIFF
--- a/.agents/marketing-sales/cro-chapter-15/01-personalization-types.md
+++ b/.agents/marketing-sales/cro-chapter-15/01-personalization-types.md
@@ -6,11 +6,7 @@ Dynamic content adapts per visitor based on attributes, behavior, or context —
 
 Customize by visitor location (country, state, city): shipping messaging, currency display, local store/event references, language auto-detection.
 
-**Implementation**:
-- **Client-side**: IP geolocation API (ipapi.co, MaxMind GeoIP) → JS conditional rendering
-- **Server-side** (better for SEO): detect IP on server, render appropriate content
-- **Edge**: Cloudflare Workers for zero-latency personalization
-- **Platforms**: AB Tasty, Optimizely, VWO (with geo-targeting)
+**Implementation**: Client-side IP geolocation (ipapi.co, MaxMind GeoIP) → JS conditional rendering. Server-side (better for SEO): detect IP, render appropriate content. Edge: Cloudflare Workers for zero-latency. Platforms: AB Tasty, Optimizely, VWO.
 
 **Benchmark**: Booking.com — 20-30% higher conversion from local currency + nearby properties + local payment methods.
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/marketing-sales/cro-chapter-15/01-personalization-types.md` from 94 to 90 lines by collapsing the Section 1 (Geo-Based) Implementation bullet list into a single prose line. Zero information loss.

## Issue
Closes #15873

## Files Changed
- `.agents/marketing-sales/cro-chapter-15/01-personalization-types.md` — 94→90 lines (-4 lines, -4%)

## Testing
- Content preservation verified: all benchmarks, URLs, implementation details, tables, and examples present before and after
- All 8 personalization types intact
- All tool references (ipapi.co, MaxMind GeoIP, Cloudflare Workers, AB Tasty, Optimizely, VWO, Amazon Personalize, Google Recommendations AI, Dynamic Yield, Nosto) preserved
- All benchmark data preserved (Booking.com 20-30%, Amazon 15-25%, Shopify 30-50%, Netflix 80%, HubSpot 200%+, segmented A/B 23% vs 8%)

## Key Decisions
- File classified as reference corpus (domain knowledge with benchmarks and examples)
- Only change: Section 1 Implementation block collapsed from 4-bullet list to single prose line — same content, more compact format
- No content removed; all institutional knowledge preserved

## Runtime Testing
**Risk level**: Low (docs-only change, no code)
**Verification**: `self-assessed` — agent doc with no executable code

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 7m and 5,222 tokens on this as a headless worker.