### PR TITLE
GH#15871: tighten heygen authentication doc (120→113 lines)

### DIFF
--- a/.agents/content/heygen-skill/rules-authentication.md
+++ b/.agents/content/heygen-skill/rules-authentication.md
@@ -28,16 +28,12 @@ export HEYGEN_API_KEY="your-api-key-here"   # shell
 
 ## Request Pattern
 
-Send `X-Api-Key` on every request:
-
-### curl
+Send `X-Api-Key` on every request (curl / TypeScript / Python):
 
 ```bash
 curl -X GET "https://api.heygen.com/v2/avatars" \
   -H "X-Api-Key: $HEYGEN_API_KEY"
 ```
-
-### TypeScript (fetch)
 
 ```typescript
 const response = await fetch("https://api.heygen.com/v2/avatars", {
@@ -45,8 +41,6 @@ const response = await fetch("https://api.heygen.com/v2/avatars", {
 });
 const { data } = await response.json();
 ```
-
-### Python
 
 ```python
 import os, requests
@@ -82,7 +76,6 @@ class HeyGenClient {
   }
 }
 
-// Usage
 const client = new HeyGenClient(process.env.HEYGEN_API_KEY!);
 const avatars = await client.get("/v2/avatars");
 ```
@@ -106,7 +99,7 @@ interface ApiResponse<T> {
 | 403 | Forbidden | Insufficient permissions |
 | 429 | Rate limit exceeded | Too many requests — use exponential backoff |
 
-Rate limits apply per API key; video generation endpoints are stricter. Retry 429 with exponential backoff:
+Video generation endpoints have stricter rate limits. Retry 429 with exponential backoff:
 
 ```typescript
 async function requestWithRetry(fn: () => Promise<Response>, maxRetries = 3): Promise<Response> {


### PR DESCRIPTION
## Summary

Tighten `.agents/content/heygen-skill/rules-authentication.md` per GH#15871 simplification scan.

**Changes (120→113 lines, -7 lines):**
- Collapsed `### curl` / `### TypeScript (fetch)` / `### Python` sub-headers into a single inline label on the section intro — the code blocks are self-evident by syntax
- Removed `// Usage` comment (decorative "what" comment restating the next line)
- Tightened one prose sentence: "Rate limits apply per API key; video generation endpoints are stricter" → "Video generation endpoints have stricter rate limits" (the per-key context is implicit)

**Preserved:** all code blocks, URLs, security rules (4), error table (3 rows), retry logic, YAML frontmatter, all command examples.

Closes #15871

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution path.
**Verification:** `self-assessed` — all code blocks, URLs, task ID refs, and command examples present before and after (verified via diff).

---
<!-- MERGE_SUMMARY -->
**What:** Tighten HeyGen authentication agent doc — remove redundant sub-headers and a decorative comment.
**Issue:** Closes #15871
**Files changed:** `.agents/content/heygen-skill/rules-authentication.md` (120→113 lines)
**Testing:** Self-assessed (docs-only change, zero knowledge loss verified via diff)
**Key decisions:** Classified as instruction doc (not reference corpus) — tightened prose, not restructured into chapters.

---
[aidevops.sh](https://aidevops.sh) v3.5.727 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 9m and 4,757 tokens on this as a headless worker.