### PR TITLE
GH#15892: tighten agent-browser.md (158→151 lines)

### DIFF
--- a/.agents/tools/browser/agent-browser.md
+++ b/.agents/tools/browser/agent-browser.md
@@ -26,6 +26,7 @@ tools:
 - **Performance** (warm): navigate+screenshot 1.9s, form fill 1.4s, reliability 0.6s. Cold-start ~3-5s.
 - **iOS** (macOS only): `-p ios --device "iPhone 16 Pro"` — Mobile Safari via Appium
 - **License**: Apache-2.0 | TypeScript (74%), Rust (22%)
+- **Platform**: macOS/Linux ARM64+x64 (native Rust + Node.js fallback); Windows (Node.js only); iOS (macOS only)
 
 **Core workflow** — use refs from `snapshot -i` for deterministic targeting:
 
@@ -78,7 +79,7 @@ agent-browser find first ".item" click | find nth 2 "a" text
 
 ## Sessions, Wait, Storage, Network
 
-Isolated browser per session (cookies, storage, history, auth). Parallel: `--session s1/s2/s3` (3 parallel tested in 2.0s).
+Isolated browser per session (cookies, storage, history, auth). Parallel sessions: `--session s1/s2/s3` (3 parallel tested in 2.0s).
 
 ```bash
 agent-browser --session agent1 open site-a.com         # named session
@@ -117,14 +118,6 @@ agent-browser -p ios --device "iPhone 16 Pro" open https://example.com
 agent-browser -p ios snapshot -i | tap @e1 | swipe up/down/left/right [px]
 agent-browser -p ios screenshot mobile.png | close
 ```
-
-## Platform Support
-
-| Platform | Binary | Fallback | iOS |
-|----------|--------|----------|-----|
-| macOS ARM64/x64 | Native Rust | Node.js | Yes |
-| Linux ARM64/x64 | Native Rust | Node.js | No |
-| Windows | — | Node.js | No |
 
 ## Comparison
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/browser/agent-browser.md` per GH#15892 simplification scan.

**Classification**: Instruction doc (agent rules + CLI command reference) — tighten prose, not restructure.

**Changes**:
- Consolidated standalone "Platform Support" table (7 lines) into a single Quick Reference bullet — zero information loss
- Minor prose tightening: "Parallel sessions:" (clearer than "Parallel:")
- All code blocks, URLs, command examples, and operational knowledge preserved

**Verification**:
- Before: 158 lines | After: 151 lines (7 lines saved, 4.4% reduction)
- All `agent-browser` commands present (62 occurrences)
- GitHub URL preserved: https://github.com/vercel-labs/agent-browser
- All code blocks intact: Core Commands, Selectors, Sessions, Tabs, iOS, Common Patterns

## Runtime Testing

**Risk level**: Low — agent doc only, no code changes.
**Method**: `self-assessed` — content diff verified, no broken references.

Closes #15892

---
[aidevops.sh](https://aidevops.sh) v3.5.730 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 5m and 6,165 tokens on this as a headless worker.