### PR TITLE
GH#15620: tighten ses.md (134→131 lines)

### DIFF
--- a/.agents/services/email/ses.md
+++ b/.agents/services/email/ses.md
@@ -18,7 +18,7 @@ tools:
 ## Quick Reference
 
 - **Type**: AWS cloud email service | **Auth**: IAM credentials (access key + secret)
-- **Config**: `configs/ses-config.json` | **Regions**: us-east-1, eu-west-1, etc.
+- **Config**: `cp configs/ses-config.json.txt configs/ses-config.json` | **Regions**: us-east-1, eu-west-1, etc.
 - **Commands**: `ses-helper.sh [accounts|quota|stats|monitor|verified-emails|verified-domains|verify-email|verify-domain|dkim|reputation|suppressed|send-test|audit] [account] [args]`
 - **Thresholds**: Bounce < 5%, Complaint < 0.1%
 - **Test addresses**: success@simulator.amazonses.com, bounce@simulator.amazonses.com
@@ -28,8 +28,6 @@ tools:
 <!-- AI-CONTEXT-END -->
 
 ## Configuration
-
-Template: `cp configs/ses-config.json.txt configs/ses-config.json`
 
 ```json
 {
@@ -124,8 +122,7 @@ Rotate keys regularly. Separate AWS accounts for prod/staging.
 
 ## Compliance & Backup
 
-- Configure SPF, DKIM, DMARC. Process bounces/complaints promptly; maintain suppression list.
-- Provide unsubscribe mechanisms; follow GDPR/CAN-SPAM. Warm up new IPs; clean lists regularly.
+Configure SPF, DKIM, DMARC; process bounces/complaints promptly; maintain suppression list; provide unsubscribe mechanisms; follow GDPR/CAN-SPAM; warm up new IPs; clean lists regularly.
 
 ```bash
 ses-helper.sh audit production > ses-config-backup-$(date +%Y%m%d).txt


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/email/ses.md` from 134 to 131 lines per GH#15620.

## Changes
- Moved config template command (`cp configs/ses-config.json.txt configs/ses-config.json`) into Quick Reference **Config** bullet — eliminates redundant `Template:` line and saves 2 lines
- Merged two compliance bullet points into a single prose sentence — saves 1 line
- All code blocks, IAM policy JSON, command examples, URLs, and operational knowledge preserved

## Issue
Closes #15620

## Files Changed
- `.agents/services/email/ses.md` (134→131 lines, -3 lines)

## Testing
- Content preservation verified: all code blocks, URLs, command examples, IAM policy present before and after
- Risk: Low (agent doc, no executable code)

## Runtime Testing
`self-assessed` — agent doc edit, no runtime required per risk table

---
[aidevops.sh](https://aidevops.sh) v3.5.732 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 4,980 tokens on this as a headless worker.