### PR TITLE
GH#14350: tighten PDF tools overview (.agents/tools/pdf/overview.md, 74→57 lines)

### DIFF
--- a/.agents/tools/pdf/overview.md
+++ b/.agents/tools/pdf/overview.md
@@ -19,9 +19,11 @@ tools:
 ## Quick Reference
 
 - **Purpose**: PDF processing - parsing, modification, form filling, signing
-- **Primary Tool**: LibPDF (`@libpdf/core`) - TypeScript-native, full-featured
+- **Primary Tool**: LibPDF (`@libpdf/core`) - TypeScript-native; only library with incremental saves that preserve signatures
 - **Install**: `npm install @libpdf/core` | `bun add @libpdf/core` | `pnpm add @libpdf/core`
 - **Docs**: https://libpdf.dev
+- **Why not pdf-lib**: no incremental saves, no signatures, poor malformed-PDF handling
+- **Why not pdf.js**: read-only (no modify/generate/sign)
 
 **Tool Selection**:
 
@@ -46,28 +48,9 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Why LibPDF Over Alternatives
-
-| Feature | LibPDF | pdf-lib | pdf.js |
-|---------|--------|---------|--------|
-| Parse existing PDFs | Yes | Limited | Yes |
-| Modify existing PDFs | Yes | Yes | No |
-| Generate new PDFs | Yes | Yes | No |
-| Incremental saves | Yes | No | No |
-| Digital signatures | Yes | No | No |
-| Encrypted PDFs | Yes | No | Yes |
-| Form filling | Yes | Yes | No |
-| Text extraction | Yes | No | Yes |
-| Render to image | No | No | Yes |
-| Malformed PDF handling | Excellent | Poor | Excellent |
-
-LibPDF is preferred because it combines pdf-lib's API with pdf.js's parsing, is the only library with incremental saves that preserve signatures, and is TypeScript-native with minimal dependencies (Node.js, Bun, browsers).
-
 ## Related
 
-- `libpdf.md` - Detailed LibPDF usage guide with code examples
 - `../document/document-creation.md` - Unified document format conversion and creation
-- `../conversion/mineru.md` - PDF to markdown/JSON (layout-aware, OCR)
 - `../ocr/overview.md` - OCR tool selection guide (PaddleOCR, GLM-OCR, MinerU)
 - `../ocr/paddleocr.md` - PaddleOCR scene text OCR for scanned PDFs and images
 - `../conversion/pandoc.md` - General document format conversion


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/pdf/overview.md` from 74 to 57 lines (~23% reduction) per GH#14350.

**Changes:**
- Replace 10-row feature comparison table with 2 inline decision bullets in Quick Reference (same rationale, less space)
- Inline the key LibPDF differentiators into the Primary Tool bullet: "only library with incremental saves that preserve signatures"
- Add "Why not pdf-lib" and "Why not pdf.js" bullets — captures the decision rationale without a full table
- Remove duplicate Related links (`libpdf.md`, `../conversion/mineru.md`) already covered by the Subagents table

## Issue
Closes #14350

## Files Changed
- `.agents/tools/pdf/overview.md` — 74→57 lines, 1 file

## Testing
- `self-assessed` (Low risk: agent doc, no code, no runtime behaviour change)
- All tool selection entries preserved: LibPDF, MinerU, PaddleOCR, pdf.js
- All URLs, task IDs, and command examples verified present
- Subagent pointers unchanged

## Key Decisions
- Kept the tool selection table intact (it's the primary decision aid)
- Replaced comparison table with inline bullets — same information density, fewer tokens
- Removed Related links that duplicate Subagents table (DRY)

## Runtime Testing
`self-assessed` — doc-only change, no executable code

---
[aidevops.sh](https://aidevops.sh) v3.5.732 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,675 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Refined LibPDF overview with updated positioning and specific feature highlights
  * Added clarifications on why alternative libraries are not used
  * Streamlined documentation structure for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->