### PR TITLE
GH#14676: tighten wordpress.md agent doc (72→52 lines)

### DIFF
--- a/.agents/tools/wordpress.md
+++ b/.agents/tools/wordpress.md
@@ -13,17 +13,8 @@ mode: subagent
 - **Purpose**: Route WordPress work to the right specialist doc
 - **Local dev**: LocalWP + `localwp.md`
 - **Fleet ops**: MainWP + `mainwp.md`
-- **Plugin curation**: `wp-preferred.md` (127+ plugins across 19 categories)
+- **Plugin curation**: `wp-preferred.md` (127+ plugins across 19 categories — performance, security, SEO, forms, e-commerce, membership, backup, staging, dev tooling)
 - **Custom fields**: `scf.md` for Secure Custom Fields / ACF
-
-**Subagents**
-
-- `wp-dev.md` — theme/plugin development, debugging, test patterns
-- `wp-admin.md` — content management and maintenance
-- `localwp.md` — LocalWP development and MCP-backed database access
-- `mainwp.md` — multi-site fleet operations via MainWP
-- `wp-preferred.md` — curated plugin list by category
-- `scf.md` — Secure Custom Fields / ACF guidance
 
 **Platform integrations**
 
@@ -53,20 +44,9 @@ mode: subagent
 | Choose plugins | `wp-preferred.md` | Curated, reliability-first recommendations |
 | Work with custom fields | `scf.md` | Field modeling and SCF/ACF guidance |
 
-## Operating model
-
-- **Local development**: Use LocalWP for WordPress development and local database access.
-- **Fleet management**: Use MainWP for bulk updates, backups, monitoring, and security scans.
-- **Plugin selection**: Prefer the curated list in `wp-preferred.md` for reliability.
-
 ## Default workflow
 
 1. **Local** — develop in a LocalWP environment.
 2. **Test** — follow `wp-dev.md` patterns.
 3. **Deploy** — push via MainWP or the hosting provider.
 4. **Manage** — handle ongoing operations via `wp-admin.md`.
-
-## Notes
-
-- `wp-preferred.md` covers performance, security, SEO, forms, e-commerce, membership, backup, staging, and development tooling.
-- Use this file as the router; keep detailed procedures in the specialist docs.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/wordpress.md` from 72 to 52 lines (28% reduction) by removing redundant sections.

## Issue
Closes #14676

## Changes
- Merged plugin category list from "Notes" section into Quick Reference plugin curation line
- Removed "Subagents" subsection (fully covered by the routing table below)
- Removed "Operating model" section (redundant with routing table and Default workflow)
- Removed "Notes" section (content merged into Quick Reference)

## Files Changed
- `.agents/tools/wordpress.md` — 72→52 lines, 1 file

## Testing
**Risk level**: Low (agent doc, no code)
**Verification**: `self-assessed`
- All routing entries preserved in the routing table
- All subagent references preserved (wp-dev.md, wp-admin.md, localwp.md, mainwp.md, wp-preferred.md, scf.md)
- All command examples preserved
- Plugin categories (127+ plugins, 19 categories) preserved in Quick Reference
- No broken internal references

## Runtime Testing
`self-assessed` — doc-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.732 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 2,474 tokens on this as a headless worker.