### PR TITLE
GH#14351: tighten agent doc Cloudflare Terraform Provider (terraform.md)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/terraform.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/terraform.md
@@ -1,7 +1,5 @@
 # Cloudflare Terraform Provider
 
-**Expert guidance for Cloudflare Terraform Provider - infrastructure as code for Cloudflare resources.**
-
 ## Core Principles
 
 - **Provider-first**: Use Terraform provider for ALL infrastructure - never mix with wrangler.toml for the same resources
@@ -70,5 +68,5 @@ terraform validate      # Validate configuration
 
 ## See Also
 
-- [Patterns & Use Cases](./patterns.md) - Architecture patterns, multi-env setup, CI/CD integration
-- [Troubleshooting & Best Practices](./gotchas.md) - Common issues, security, best practices
+- [Patterns & Use Cases](./terraform-patterns.md) — multi-env, CI/CD, worker bindings, load balancing
+- [Troubleshooting & Best Practices](./terraform-gotchas.md) — common errors, security, state management


### PR DESCRIPTION
## Summary

- Remove redundant subtitle on line 3 (restated the H1 verbatim, zero information gain)
- Fix broken `See Also` links: `./patterns.md` → `./terraform-patterns.md` and `./gotchas.md` → `./terraform-gotchas.md` (short-form files do not exist in the directory)
- Tighten `See Also` descriptions to add context not already in the link text

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/terraform.md` — 74 → 72 lines

## Verification

- All code blocks, command examples, and institutional knowledge preserved
- `markdownlint` passes with zero violations
- Broken links corrected (verified with `ls` — `patterns.md` and `gotchas.md` do not exist; `terraform-patterns.md` and `terraform-gotchas.md` do)

## Runtime Testing

Risk: **Low** — agent doc only, no code or shell scripts. Self-assessed.

Closes #14351

---
[aidevops.sh](https://aidevops.sh) v3.5.732 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,036 tokens on this as a headless worker.