### PR TITLE
GH#14289: tighten agent doc Reddit CLI/API Integration (91→89 lines)

### DIFF
--- a/.agents/content/social-reddit.md
+++ b/.agents/content/social-reddit.md
@@ -26,8 +26,6 @@ tools:
 
 ## Quick Access (No Auth)
 
-Reddit exposes JSON endpoints by appending `.json` to any URL:
-
 ```bash
 # Subreddit posts
 curl -s "https://www.reddit.com/r/devops/hot.json?limit=10" | jq '.data.children[].data | {title, score, url}'


### PR DESCRIPTION
## Summary

Tighten `.agents/content/social-reddit.md` per simplification issue GH#14289.

Closes #14289

## What

Removed one redundant prose sentence before the Quick Access code block. The sentence `Reddit exposes JSON endpoints by appending .json to any URL:` restates what the code examples already demonstrate — it's a "what" comment with no additional information.

## Files Changed

- `.agents/content/social-reddit.md`: 91 → 89 lines (2 lines removed)

## Content Preservation Verification

- All code blocks preserved: ✅ (bash, python ×2)
- All URLs preserved: ✅ (reddit.com, praw.readthedocs.io, github.com/praw-dev/praw)
- All command examples preserved: ✅ (curl, jq, praw, aidevops secret set)
- Rate limit values preserved: ✅ (96/10min, 996/10min)
- No task IDs or GH# refs in original: ✅

## Runtime Testing

Risk level: **Low** — docs/agent prompt only, no code execution path. `self-assessed`.

---
<!-- MERGE_SUMMARY -->
**What**: Removed redundant "what" comment prose from Reddit CLI/API Integration doc
**Issue**: GH#14289
**Files changed**: `.agents/content/social-reddit.md` (91→89 lines)
**Testing**: Content preservation verified — all code blocks, URLs, commands intact
**Key decisions**: Kept all code block comments (they provide "why" context, not "what" restatement)

---
[aidevops.sh](https://aidevops.sh) v3.5.732 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,393 tokens on this as a headless worker.