### PR TITLE
GH#14163: tighten tech-stack.md agent doc (112→90 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,4826 +1,4833 @@
 {
-    "files": {
-        ".agents/aidevops.md": {
-            "at": "2026-03-29T16:31:51Z",
-            "hash": "cf74c159d129be3c0c891b416bd45c0c11a5613b",
-            "passes": 1,
-            "pr": 13063
-        },
-        ".agents/aidevops/add-new-mcp-to-aidevops.md": {
-            "at": "2026-03-28T16:41:22Z",
-            "hash": "818de6a118b3981cbc732aace97a1220ad7f27ee",
-            "passes": 1,
-            "pr": 12006
-        },
-        ".agents/aidevops/agent-sources.md": {
-            "at": "2026-03-31T05:32:40Z",
-            "hash": "5ecd39be40d1f3ceca20c8be89737b646c3e41be",
-            "passes": 2,
-            "pr": 14645
-        },
-        ".agents/aidevops/architecture.md": {
-            "at": "2026-03-29T23:53:47Z",
-            "hash": "f1d29dba0c0d676b0d00e4e5adac2d79f9aa2dd1",
-            "passes": 1,
-            "pr": 13445
-        },
-        ".agents/aidevops/configs.md": {
-            "at": "2026-03-28T15:30:49Z",
-            "hash": "fecc0e08b16083bdd8f7e82c6f1636c136af3287",
-            "passes": 1,
-            "pr": 11897
-        },
-        ".agents/aidevops/extension.md": {
-            "at": "2026-03-28T08:58:33Z",
-            "hash": "6b76dd6fa41470a5d1d4e5ebeea7af1b13b6a1e8",
-            "passes": 1,
-            "pr": 11565
-        },
-        ".agents/aidevops/mcp-integrations.md": {
-            "at": "2026-03-28T03:53:54Z",
-            "hash": "199aacfc8608732f5fa0400478da824d5d11cdad",
-            "passes": 2,
-            "pr": 11339
-        },
-        ".agents/aidevops/mcp-troubleshooting.md": {
-            "at": "2026-03-31T08:03:51Z",
-            "hash": "d14d5400e4c936f6c89957750c8f843ae8304ec4",
-            "passes": 2,
-            "pr": 14740
-        },
-        ".agents/aidevops/onboarding.md": {
-            "at": "2026-03-29T07:02:21Z",
-            "hash": "a5d5e9ffd6e3639b96c0174e747bcb15c2712191",
-            "passes": 2,
-            "pr": 12641
-        },
-        ".agents/aidevops/plugins.md": {
-            "at": "2026-03-28T14:15:43Z",
-            "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
-            "passes": 1,
-            "pr": 11894
-        },
-        ".agents/aidevops/providers.md": {
-            "at": "2026-03-27T21:25:09Z",
-            "hash": "18b8c2ddd2bb1ee1b0affc02c05ae860b8e902da",
-            "passes": 1,
-            "pr": 11003
-        },
-        ".agents/aidevops/recommendations.md": {
-            "at": "2026-03-28T03:54:11Z",
-            "hash": "67c3f660425b669feae3238d7b42589449caa860",
-            "passes": 1,
-            "pr": 11343
-        },
-        ".agents/aidevops/requirements.md": {
-            "at": "2026-03-28T11:52:46Z",
-            "hash": "9a75f9e14252e2364ed8ceeb9e24e8df3a95e310",
-            "passes": 1,
-            "pr": 11770
-        },
-        ".agents/aidevops/resources.md": {
-            "at": "2026-03-28T21:58:59Z",
-            "hash": "4c8aa012ca51de765daed452692f619d55c701b1",
-            "passes": 1,
-            "pr": 12244
-        },
-        ".agents/aidevops/security-requirements.md": {
-            "at": "2026-03-29T12:37:08Z",
-            "hash": "8b86459a5459bd0be5402ca5660bfd99fa54a782",
-            "passes": 1,
-            "pr": 12946
-        },
-        ".agents/aidevops/self-improving-agents.md": {
-            "at": "2026-04-01T20:59:02Z",
-            "hash": "8e8dc0f8fa3a1a502130a64f217de014a5b14161",
-            "passes": 1,
-            "pr": 15203
-        },
-        ".agents/aidevops/services.md": {
-            "at": "2026-03-27T21:25:10Z",
-            "hash": "0fd05379ebb6a6ab079aaa0011c1dd8a5cca6af1",
-            "passes": 1,
-            "pr": 11004
-        },
-        ".agents/aidevops/troubleshooting.md": {
-            "at": "2026-03-28T16:00:22Z",
-            "hash": "9b1e6b69bbb4c48b5d664dbb23d72a25eb867b0f",
-            "passes": 1,
-            "pr": 11982
-        },
-        ".agents/build-plus.md": {
-            "at": "2026-03-29T16:10:49Z",
-            "hash": "9a8681dd42ae12e35c79f2f2479a29dfc90794f9",
-            "passes": 1,
-            "pr": 13101
-        },
-        ".agents/business.md": {
-            "at": "2026-03-29T16:34:54Z",
-            "hash": "359aefa91dc7dcd75049c36dbf54965be0fc9e2c",
-            "passes": 1,
-            "pr": 13055
-        },
-        ".agents/business/accounts-receipt-ocr.md": {
-            "at": "2026-03-28T16:41:24Z",
-            "hash": "7500c09629a5e47688af67a6901d684e92b623f2",
-            "passes": 1,
-            "pr": 12020
-        },
-        ".agents/business/accounts-subscription-audit.md": {
-            "at": "2026-03-29T21:43:19Z",
-            "hash": "ef31fbb7ef1c8e43fc6f5e6ff3f7bed9b5b0e3a0",
-            "passes": 1,
-            "pr": 13235
-        },
-        ".agents/business/company-runners.md": {
-            "at": "2026-03-28T11:52:25Z",
-            "hash": "8c78821205aacf320a7ed32b722b7c646a4e35af",
-            "passes": 1,
-            "pr": 11812
-        },
-        ".agents/content.md": {
-            "at": "2026-03-28T08:58:04Z",
-            "hash": "2f71b51f39307e001e3af0bae81c5fc440c2da9b",
-            "passes": 1,
-            "pr": 11616
-        },
-        ".agents/content/VERIFICATION.md": {
-            "at": "2026-03-30T03:34:30Z",
-            "hash": "f0090056bf6625c2ce2c676d4cf9ba25a901198e",
-            "passes": 1,
-            "pr": 13540
-        },
-        ".agents/content/content-calendar.md": {
-            "at": "2026-03-29T15:50:25Z",
-            "hash": "5bb7dca9397875d571887657d6e92d551536e6cd",
-            "passes": 1,
-            "pr": 13052
-        },
-        ".agents/content/context-templates.md": {
-            "at": "2026-04-02T04:00:00Z",
-            "hash": "15506de00a52128f74b711af949c6e56074f3bee",
-            "passes": 2,
-            "pr": 14934
-        },
-        ".agents/content/distribution-email.md": {
-            "at": "2026-03-28T16:00:42Z",
-            "hash": "d218dc3fdd2a3e501978d431530820ce810b354e",
-            "passes": 1,
-            "pr": 11989
-        },
-        ".agents/content/distribution-podcast.md": {
-            "at": "2026-03-29T07:02:57Z",
-            "hash": "0a2c98014bbe0588383437327d0b71e81a574af5",
-            "passes": 1,
-            "pr": 12557
-        },
-        ".agents/content/distribution-short-form.md": {
-            "at": "2026-03-28T20:16:49Z",
-            "hash": "8350ba659dc7fbcbecd70b55d52b65d296ce5401",
-            "passes": 1,
-            "pr": 12172
-        },
-        ".agents/content/distribution-social.md": {
-            "at": "2026-03-28T11:20:38Z",
-            "hash": "4ca38ce265bdd7a4921aeed56567dd38e5e98c32",
-            "passes": 1,
-            "pr": 11733
-        },
-        ".agents/content/distribution-youtube-channel-intel.md": {
-            "at": "2026-03-29T12:37:24Z",
-            "hash": "e7acafaec5e56e608968ecc99a7005352995560c",
-            "passes": 1,
-            "pr": 12791
-        },
-        ".agents/content/distribution-youtube-optimizer.md": {
-            "at": "2026-03-28T11:20:34Z",
-            "hash": "08796da4159346de335feb979d6ce0af181bb8ff",
-            "passes": 1,
-            "pr": 11731
-        },
-        ".agents/content/distribution-youtube-pipeline.md": {
-            "at": "2026-04-03T01:11:18Z",
-            "hash": "4b11d88aa5e558faf6c672d0c8920f54a7db40f4",
-            "passes": 2,
-            "pr": 11763
-        },
-        ".agents/content/distribution-youtube-script-writer.md": {
-            "at": "2026-03-28T08:58:46Z",
-            "hash": "e7d74dc2884f946d2d3ad41287926a426d0b0edb",
-            "passes": 1,
-            "pr": 11603
-        },
-        ".agents/content/distribution-youtube-topic-research.md": {
-            "at": "2026-03-28T11:20:29Z",
-            "hash": "d8d475231eff5b53cf27de5ab31aeedaec403e2f",
-            "passes": 1,
-            "pr": 11801
-        },
-        ".agents/content/distribution-youtube.md": {
-            "at": "2026-03-29T01:03:19Z",
-            "hash": "a44106f7677388ea6146e99c5c94de36b9e337ba",
-            "passes": 1,
-            "pr": 12386
-        },
-        ".agents/content/editor.md": {
-            "at": "2026-04-02T16:30:00Z",
-            "hash": "1b10ff74a546e869506efa2abe19f9f34eb56ad6",
-            "passes": 1,
-            "pr": null
-        },
-        ".agents/content/heygen-skill/rules-assets.md": {
-            "at": "2026-03-29T16:34:55Z",
-            "hash": "eed9c26fe6697296ac16fa54421ac1d4f9d6f2fc",
-            "passes": 1,
-            "pr": 13054
-        },
-        ".agents/content/heygen-skill/rules-avatars.md": {
-            "at": "2026-03-29T07:02:16Z",
-            "hash": "e600865474071a7973fe0ed89b4fd361065e080a",
-            "passes": 1,
-            "pr": 12654
-        },
-        ".agents/content/heygen-skill/rules-backgrounds.md": {
-            "at": "2026-03-28T09:17:34Z",
-            "hash": "7abf186ddedbabd5128f34ee918393a187de8cc3",
-            "passes": 1,
-            "pr": 11711
-        },
-        ".agents/content/heygen-skill/rules-captions.md": {
-            "at": "2026-03-28T09:48:53Z",
-            "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
-            "passes": 1,
-            "pr": 11707
-        },
-        ".agents/content/heygen-skill/rules-dimensions.md": {
-            "at": "2026-03-28T08:18:14Z",
-            "hash": "f32c728a54e3edca1d713da0d536cb4b63299882",
-            "passes": 1,
-            "pr": 11610
-        },
-        ".agents/content/heygen-skill/rules-photo-avatars.md": {
-            "at": "2026-03-29T07:03:00Z",
-            "hash": "d9a524f977f14c54b44991976651334aafa2e6e4",
-            "passes": 1,
-            "pr": 12620
-        },
-        ".agents/content/heygen-skill/rules-quota.md": {
-            "at": "2026-03-29T07:02:38Z",
-            "hash": "defa81f8873250c50ab8a9481e5d6f2b0958946c",
-            "passes": 1,
-            "pr": 12592
-        },
-        ".agents/content/heygen-skill/rules-remotion-integration.md": {
-            "at": "2026-03-28T10:27:14Z",
-            "hash": "5ccb546152546cd33344a76d42a4b90c0acd0dbd",
-            "passes": 1,
-            "pr": 11740
-        },
-        ".agents/content/heygen-skill/rules-scripts.md": {
-            "at": "2026-03-30T04:51:44Z",
-            "hash": "2e44c72709396aa34cb596ff5ef6426dbc1e96c8",
-            "passes": 2,
-            "pr": 13767
-        },
-        ".agents/content/heygen-skill/rules-templates.md": {
-            "at": "2026-03-29T08:10:46Z",
-            "hash": "5d9c85b6e42715ec4914982ce21790312207dacf",
-            "passes": 1,
-            "pr": 12738
-        },
-        ".agents/content/heygen-skill/rules-video-agent.md": {
-            "at": "2026-03-29T07:31:38Z",
-            "hash": "1d039d6d91c08e661a96696b19d43edbefe54b0e",
-            "passes": 1,
-            "pr": 12706
-        },
-        ".agents/content/heygen-skill/rules-video-generation.md": {
-            "at": "2026-03-28T10:27:38Z",
-            "hash": "929341bdb16beeda9c31e050b53eddbe5badfd72",
-            "passes": 1,
-            "pr": 11675
-        },
-        ".agents/content/heygen-skill/rules-video-translation.md": {
-            "at": "2026-03-29T03:15:05Z",
-            "hash": "16bf014b85cd6ad3c1be9d593a97af8620313cbb",
-            "passes": 1,
-            "pr": 12504
-        },
-        ".agents/content/heygen-skill/rules-voices.md": {
-            "at": "2026-03-29T07:02:36Z",
-            "hash": "d3dbb1550c826e13f7c5288b74f72fcff3518efd",
-            "passes": 1,
-            "pr": 12577
-        },
-        ".agents/content/heygen-skill/rules-webhooks.md": {
-            "at": "2026-03-30T06:49:23Z",
-            "hash": "c3ba360303dc273741e6f76b2f235b8319f78734",
-            "passes": 1,
-            "pr": 13942
-        },
-        ".agents/content/humanise.md": {
-            "at": "2026-03-30T06:03:20Z",
-            "hash": "898870a22cb4b4cf0153c907ab974792857e41c8",
-            "passes": 1,
-            "pr": 13836
-        },
-        ".agents/content/optimization.md": {
-            "at": "2026-03-29T23:18:03Z",
-            "hash": "326ff8a42a6e84736e5f70fc2f569119e04c9fa5",
-            "passes": 1,
-            "pr": 13425
-        },
-        ".agents/content/platform-personas.md": {
-            "at": "2026-04-02T21:19:52Z",
-            "hash": "b7e19c96eda87359699f528e35bddce57b0ddc2d",
-            "passes": 2,
-            "pr": 12167
-        },
-        ".agents/content/production-audio.md": {
-            "at": "2026-03-30T00:32:17Z",
-            "hash": "7e3eb343f808775963edf8007b96029c69ba09bf",
-            "passes": 2,
-            "pr": 13478
-        },
-        ".agents/content/production-characters.md": {
-            "at": "2026-03-28T16:40:48Z",
-            "hash": "f26a85f43d79aed7426a749dab9407537412d65b",
-            "passes": 1,
-            "pr": 12025
-        },
-        ".agents/content/production-image.md": {
-            "at": "2026-03-28T16:40:38Z",
-            "hash": "b3409136a94a117c8a727fa3e1ca400d77806a36",
-            "passes": 1,
-            "pr": 12023
-        },
-        ".agents/content/production-video-08-talking-head-pipeline.md": {
-            "at": "2026-04-02T04:56:45Z",
-            "hash": "cee1bc46bfdf4612fb0560748fe9e7b134ac0086",
-            "passes": 1,
-            "pr": 15516
-        },
-        ".agents/content/production-writing.md": {
-            "at": "2026-03-28T11:20:42Z",
-            "hash": "525c4aab766775fa9f92155b85f58bcda67cf3ea",
-            "passes": 1,
-            "pr": 11788
-        },
-        ".agents/content/research.md": {
-            "at": "2026-03-28T08:57:54Z",
-            "hash": "0844a394bf378618e923c821a3246e54fead511f",
-            "passes": 1,
-            "pr": 11644
-        },
-        ".agents/content/seo-writer.md": {
-            "at": "2026-04-01T22:10:00Z",
-            "hash": "af5154d5e50138d5490ce34d3ab7e8b5f88966a7",
-            "passes": 1,
-            "pr": 15339
-        },
-        ".agents/content/social-bird.md": {
-            "at": "2026-03-28T05:10:07Z",
-            "hash": "b2840ebff41ba9b78f7331487d6596373e8436e4",
-            "passes": 1,
-            "pr": 11354
-        },
-        ".agents/content/story.md": {
-            "at": "2026-03-29T17:14:35Z",
-            "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
-            "passes": 1,
-            "pr": 13457
-        },
-        ".agents/content/summarize.md": {
-            "at": "2026-03-29T07:02:30Z",
-            "hash": "937ce7f1f86adf1ef8f54d08458ca3421209fd10",
-            "passes": 1,
-            "pr": 12578
-        },
-        ".agents/content/video-director.md": {
-            "at": "2026-03-29T07:02:22Z",
-            "hash": "7aa6d199c68cd683f60bf343be15f38db4484a11",
-            "passes": 1,
-            "pr": 12608
-        },
-        ".agents/content/video-enhancor.md": {
-            "at": "2026-03-29T08:49:19Z",
-            "hash": "c92832f61d3cd78705b2913a0662b1ecee089aae",
-            "passes": 1,
-            "pr": 12796
-        },
-        ".agents/content/video-higgsfield-ui.md": {
-            "at": "2026-03-30T06:49:12Z",
-            "hash": "2ca7fc448a908aa78e4fe010b0ace0aaf9b9de87",
-            "passes": 2,
-            "pr": 13932
-        },
-        ".agents/content/video-higgsfield.md": {
-            "at": "2026-03-28T16:00:37Z",
-            "hash": "365b9f6acbaa7e54b14209c7eaee723372e836d6",
-            "passes": 1,
-            "pr": 11993
-        },
-        ".agents/content/video-muapi.md": {
-            "at": "2026-03-28T11:20:21Z",
-            "hash": "3deffc1afc21c9cb3daf10a540c802fc70e437df",
-            "passes": 1,
-            "pr": 11800
-        },
-        ".agents/content/video-real-video-enhancer.md": {
-            "at": "2026-03-30T03:34:21Z",
-            "hash": "3a1c798089a1fa50288b76e5fd372fe57d4307d5",
-            "passes": 1,
-            "pr": 13533
-        },
-        ".agents/content/video-runway.md": {
-            "at": "2026-03-28T08:58:00Z",
-            "hash": "54c5b2fe2d3cdd00e23f192d5f869c927b6e573e",
-            "passes": 1,
-            "pr": 11646
-        },
-        ".agents/content/video-wavespeed.md": {
-            "at": "2026-03-28T14:15:41Z",
-            "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
-            "passes": 1,
-            "pr": 11895
-        },
-        ".agents/health.md": {
-            "at": "2026-04-01T20:58:58Z",
-            "hash": "301b928aef5da6cc3a1dbb353077bfbab47af315",
-            "passes": 1,
-            "pr": 15249
-        },
-        ".agents/marketing-sales.md": {
-            "at": "2026-03-30T06:03:16Z",
-            "hash": "0b4144452b197dae7edbfcf3a5452752d3b2fe10",
-            "passes": 1,
-            "pr": 13839
-        },
-        ".agents/marketing-sales/ad-creative-ai-tools-reference.md": {
-            "at": "2026-03-28T20:56:07Z",
-            "hash": "8faff4defc9b64a16a6da7b996a86d29763bb87e",
-            "passes": 1,
-            "pr": 12183
-        },
-        ".agents/marketing-sales/ad-creative-campaign-management.md": {
-            "at": "2026-03-28T16:00:35Z",
-            "hash": "cf88e0ca297eabefcb235d1359ee6d2b0e75d576",
-            "passes": 1,
-            "pr": 11974
-        },
-        ".agents/marketing-sales/ad-creative-chapter-01.md": {
-            "at": "2026-03-28T23:05:56Z",
-            "hash": "e832ef8eb425956cec38a250eede0227342a4d79",
-            "passes": 1,
-            "pr": 12325
-        },
-        ".agents/marketing-sales/ad-creative-chapter-02.md": {
-            "at": "2026-03-28T07:37:37Z",
-            "hash": "810c244d317a3332c74dc2baafb34bf00cf5ab2f",
-            "passes": 1,
-            "pr": 11539
-        },
-        ".agents/marketing-sales/ad-creative-chapter-03.md": {
-            "at": "2026-03-28T15:30:26Z",
-            "hash": "f2d79f61b3c28c3e902760bb469c29a465a777c3",
-            "passes": 1,
-            "pr": 11936
-        },
-        ".agents/marketing-sales/ad-creative-chapter-04.md": {
-            "at": "2026-03-29T07:02:10Z",
-            "hash": "35b67bea4f7521d18b9a3a75deb4b2508810e83d",
-            "passes": 1,
-            "pr": 12662
-        },
-        ".agents/marketing-sales/ad-creative-chapter-05.md": {
-            "at": "2026-03-28T08:18:28Z",
-            "hash": "f8ded271e66b8024f24caa8a841ea58da90a709a",
-            "passes": 1,
-            "pr": 11555
-        },
-        ".agents/marketing-sales/ad-creative-chapter-06.md": {
-            "at": "2026-03-28T05:09:55Z",
-            "hash": "3d34a8e028e8905a54af8dd939394d10bdf16d97",
-            "passes": 1,
-            "pr": 11414
-        },
-        ".agents/marketing-sales/ad-creative-chapter-07.md": {
-            "at": "2026-03-29T01:33:56Z",
-            "hash": "c79c8baa955bb48f1ce2ded8036ded7940948031",
-            "passes": 1,
-            "pr": 12442
-        },
-        ".agents/marketing-sales/ad-creative-chapter-08.md": {
-            "at": "2026-03-29T01:04:19Z",
-            "hash": "cff567e1f6215e9c459e5d97d022a93f34d1c322",
-            "passes": 1,
-            "pr": 12398
-        },
-        ".agents/marketing-sales/ad-creative-chapter-09.md": {
-            "at": "2026-03-29T16:34:21Z",
-            "hash": "2bdf7194dc300dd779d03b44a37d35015e9f282d",
-            "passes": 1,
-            "pr": 13110
-        },
-        ".agents/marketing-sales/ad-creative-chapter-10.md": {
-            "at": "2026-03-28T05:10:32Z",
-            "hash": "23e33ef44632a4467884d5d9bebf6452adf22160",
-            "passes": 1,
-            "pr": 11315
-        },
-        ".agents/marketing-sales/ad-creative-chapter-11.md": {
-            "at": "2026-03-29T20:54:11Z",
-            "hash": "2fbaad774769229326c549e278ffe31d26906d66",
-            "passes": 1,
-            "pr": 13222
-        },
-        ".agents/marketing-sales/ad-creative-chapter-12.md": {
-            "at": "2026-03-29T03:15:08Z",
-            "hash": "eca290e31ece1e36762bbf607353ddbdb27aaf52",
-            "passes": 1,
-            "pr": 12503
-        },
-        ".agents/marketing-sales/ad-creative-chapters.md": {
-            "at": "2026-03-28T23:05:56Z",
-            "hash": "7389f5acbff5e5b272cc97a5c5285e8a9b735427",
-            "passes": 1,
-            "pr": 12325
-        },
-        ".agents/marketing-sales/ad-creative-copywriting.md": {
-            "at": "2026-03-28T21:14:35Z",
-            "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
-            "passes": 1,
-            "pr": 12018
-        },
-        ".agents/marketing-sales/ad-creative-offers-landing.md": {
-            "at": "2026-03-28T05:50:34Z",
-            "hash": "a16b4767e518eb9f3f35e1b61d3d166390077009",
-            "passes": 1,
-            "pr": 11415
-        },
-        ".agents/marketing-sales/ad-creative-platform-google.md": {
-            "at": "2026-03-28T15:30:26Z",
-            "hash": "f64e3f66de660586a2c510e31ce4a942286cf079",
-            "passes": 1,
-            "pr": 11936
-        },
-        ".agents/marketing-sales/ad-creative-platform-meta.md": {
-            "at": "2026-03-28T08:58:35Z",
-            "hash": "130ac72c8435b342b5be159ed84ab6633efdf4fa",
-            "passes": 1,
-            "pr": 11574
-        },
-        ".agents/marketing-sales/ad-creative-psychology-targeting.md": {
-            "at": "2026-03-28T10:27:52Z",
-            "hash": "c37b3f2fadeaae4f147248efd4fa535e89f1d96b",
-            "passes": 1,
-            "pr": 11655
-        },
-        ".agents/marketing-sales/ad-creative-testing-optimization.md": {
-            "at": "2026-03-28T08:58:01Z",
-            "hash": "2f60c87e51dac14c539d02ba1a796a98b995c2c4",
-            "passes": 1,
-            "pr": 11614
-        },
-        ".agents/marketing-sales/ad-creative-video-ugc.md": {
-            "at": "2026-03-30T04:52:01Z",
-            "hash": "695a2da0afc79acc4e203ead505b0bc768c6237a",
-            "passes": 1,
-            "pr": 13723
-        },
-        ".agents/marketing-sales/ad-creative.md": {
-            "at": "2026-03-29T03:31:36Z",
-            "hash": "0fd2f3ed67a352a6b59ca35f1cb1be0ca62f691f",
-            "passes": 1,
-            "pr": 12505
-        },
-        ".agents/marketing-sales/cro-chapter-01.md": {
-            "at": "2026-03-29T20:54:07Z",
-            "hash": "5dad243a2a5744924aeb5b2e39fe94aad887af5e",
-            "passes": 1,
-            "pr": 13294
-        },
-        ".agents/marketing-sales/cro-chapter-02.md": {
-            "at": "2026-04-01T20:59:14Z",
-            "hash": "8226a4d2cd57afce1746318203d9c357540010c2",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-02/01-conversion-rate-formulas.md": {
-            "at": "2026-04-01T20:59:14Z",
-            "hash": "3ffbf75893700060301c26dd5fd2c63e6743bddc",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-02/02-psychology-of-conversion.md": {
-            "at": "2026-04-01T20:59:14Z",
-            "hash": "497b1a2f35082225ace6ac18531c3b83d25fd39f",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-02/03-conversion-funnel.md": {
-            "at": "2026-04-01T20:59:14Z",
-            "hash": "20a9a226559ee7acc643d4b1b73a44d3f735e87d",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-02/04-attribution-models.md": {
-            "at": "2026-04-01T20:59:15Z",
-            "hash": "48f7749c53ee973531130209345c214c0d77b181",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-02/05-website-elements.md": {
-            "at": "2026-04-01T20:59:15Z",
-            "hash": "786c51eec79c4098d2034c43c8dd98c1077043e0",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-02/06-conversion-friction.md": {
-            "at": "2026-04-01T20:59:15Z",
-            "hash": "60a0019275f9e3b20f3e9dba68b8d52f6782199c",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-02/07-data-foundation.md": {
-            "at": "2026-04-01T20:59:15Z",
-            "hash": "58055a16f3affa58e9372abe6c4108cc7d0b196c",
-            "passes": 1,
-            "pr": 15223
-        },
-        ".agents/marketing-sales/cro-chapter-03.md": {
-            "at": "2026-03-29T12:37:09Z",
-            "hash": "ac80d924629caf06f25a2c2bf503c1aa2267d8de",
-            "passes": 1,
-            "pr": 12954
-        },
-        ".agents/marketing-sales/cro-chapter-04.md": {
-            "at": "2026-03-29T07:02:12Z",
-            "hash": "f893022ded62f04d6ca13b86f839211e4fe8190a",
-            "passes": 1,
-            "pr": 12665
-        },
-        ".agents/marketing-sales/cro-chapter-05.md": {
-            "at": "2026-03-29T09:20:58Z",
-            "hash": "2a9c49266d0a50ef42a41c590041ff6aeb62135c",
-            "passes": 1,
-            "pr": 12824
-        },
-        ".agents/marketing-sales/cro-chapter-07.md": {
-            "at": "2026-03-29T02:36:03Z",
-            "hash": "faba8a64f3996ee2e5722dd4b7c822d49f79c1b6",
-            "passes": 1,
-            "pr": 12463
-        },
-        ".agents/marketing-sales/cro-chapter-08.md": {
-            "at": "2026-03-30T06:49:54Z",
-            "hash": "b17c73481de18eb0ad983703fbcae8b5b7e93c98",
-            "passes": 1,
-            "pr": 13773
-        },
-        ".agents/marketing-sales/cro-chapter-09.md": {
-            "at": "2026-03-28T08:17:36Z",
-            "hash": "4d45e94ded75b90ef7e30518e072a5a643167370",
-            "passes": 1,
-            "pr": 11561
-        },
-        ".agents/marketing-sales/cro-chapter-10.md": {
-            "at": "2026-03-27T21:25:12Z",
-            "hash": "730bf8258084ccd7a330cc2ac1032f1aedd4a370",
-            "passes": 1,
-            "pr": 11005
-        },
-        ".agents/marketing-sales/cro-chapter-11.md": {
-            "at": "2026-04-01T22:00:00Z",
-            "hash": "be3bf907be217b866da1d7990427e4fc1c925971",
-            "passes": 1,
-            "pr": 14514
-        },
-        ".agents/marketing-sales/cro-chapter-12.md": {
-            "at": "2026-03-28T16:00:24Z",
-            "hash": "f733b449021696b03a6678fba02aca9940fdeb6a",
-            "passes": 1,
-            "pr": 11988
-        },
-        ".agents/marketing-sales/cro-chapter-13.md": {
-            "at": "2026-03-29T03:15:02Z",
-            "hash": "e498cfacef39db0262cc094600055befe786ccfe",
-            "passes": 1,
-            "pr": 12499
-        },
-        ".agents/marketing-sales/cro-chapter-14.md": {
-            "at": "2026-03-28T16:40:42Z",
-            "hash": "a15acda5b82f46b01af4961ff5c01fa7483e5cea",
-            "passes": 1,
-            "pr": 12027
-        },
-        ".agents/marketing-sales/cro-chapter-16.md": {
-            "at": "2026-03-28T04:30:24Z",
-            "hash": "920245116e79b04207fd2b808c5dcbfabea3eb17",
-            "passes": 1,
-            "pr": 11374
-        },
-        ".agents/marketing-sales/cro-chapter-17.md": {
-            "at": "2026-03-29T21:43:12Z",
-            "hash": "55117c563ab956b0653eca2c335a7e8c14e15708",
-            "passes": 1,
-            "pr": 13339
-        },
-        ".agents/marketing-sales/cro-chapter-18.md": {
-            "at": "2026-04-01T20:59:11Z",
-            "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
-            "passes": 1,
-            "pr": 15220
-        },
-        ".agents/marketing-sales/cro-chapter-19.md": {
-            "at": "2026-04-02T21:19:54Z",
-            "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
-            "issue": "GH#14286",
-            "passes": 2,
-            "note": "Reference corpus chapter tightened: 92 \u2192 90 lines. Removed decorative closing sentence with no information value. Zero content loss."
-        },
-        ".agents/marketing-sales/cro-chapter-20.md": {
-            "at": "2026-03-29T16:34:29Z",
-            "hash": "07aa1e83fefdc10d56b044961da2976b1e693895",
-            "passes": 1,
-            "pr": 13105
-        },
-        ".agents/marketing-sales/cro-chapter-22.md": {
-            "at": "2026-04-01T20:58:50Z",
-            "hash": "882c97fc64eb63b11312049223c04eaa52882296",
-            "passes": 1,
-            "pr": 15257
-        },
-        ".agents/marketing-sales/cro-chapter-25.md": {
-            "at": "2026-04-01T21:00:00Z",
-            "hash": "076db4b43144a19221004451da2ab384161bcb17",
-            "passes": 2,
-            "pr": 15276
-        },
-        ".agents/marketing-sales/cro-chapters.md": {
-            "at": "2026-03-30T00:32:32Z",
-            "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
-            "passes": 1,
-            "pr": 13457
-        },
-        ".agents/marketing-sales/cro.md": {
-            "at": "2026-03-29T08:10:36Z",
-            "hash": "9a8a0b49c40c42072e982a4dd40761c19c0055ed",
-            "passes": 1,
-            "pr": 12753
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md": {
-            "hash": "e32cc9a38c9f2b1305595ef393fa64650ed7f0b5",
-            "issue": "GH#15068",
-            "note": "Reference corpus already split into 5 chapter files (01-saas-examples.md through 05-guarantees-and-design-principles.md). Index is 30 lines; chapters total 163 lines. No further action needed.",
-            "status": "done",
-            "at": "2026-04-02T20:39:23Z",
-            "passes": 1
-        },
-        ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
-            "at": "2026-04-01T20:59:28Z",
-            "hash": "ab1f9c5d69340fa7acfd756c2ae37710b9fa600c",
-            "passes": 1,
-            "pr": 14996
-        },
-        ".agents/marketing-sales/direct-response-copy-frameworks-headline-formulas.md": {
-            "at": "2026-03-28T08:58:42Z",
-            "hash": "9c23835b93de53e0d6371a5f753c1409e0374d9d",
-            "passes": 1,
-            "pr": 11548
-        },
-        ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md": {
-            "at": "2026-04-01T21:00:01Z",
-            "hash": "4c6d024fd0bd6ab3cbc9881e5cd83bd7dec582e4",
-            "passes": 1,
-            "pr": 14853
-        },
-        ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
-            "at": "2026-03-28T08:17:37Z",
-            "hash": "a80eb99acba160fa0f034a4989c0b886f37a32a0",
-            "passes": 1,
-            "pr": 11571
-        },
-        ".agents/marketing-sales/direct-response-copy-frameworks-offer-construction.md": {
-            "at": "2026-03-28T05:51:09Z",
-            "hash": "10d31ffa27d8e38267882e04f099ce38899635f1",
-            "passes": 1,
-            "pr": 11363
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-ads.md": {
-            "at": "2026-03-28T05:50:32Z",
-            "hash": "8e2f8f2a6620debfe219e09c96cfeb634fb518a7",
-            "passes": 1,
-            "pr": 11411
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md": {
-            "at": "2026-03-31T05:42:16Z",
-            "hash": "57313942eaf75ad8a1022a5c723b3f2c5d3f76f5",
-            "passes": 2,
-            "pr": 14662
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-06-ramit-sethi-launch.md": {
-            "at": "2026-04-01T20:59:17Z",
-            "hash": "5f82f7b17f7fde8daeb703ca4c3cdcef53620c2f",
-            "passes": 1,
-            "pr": 15150
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-07-saas-trial-expiry.md": {
-            "at": "2026-04-01T20:59:17Z",
-            "hash": "541a34d7b2649c4e93f494af26bb412731aace9e",
-            "passes": 1,
-            "pr": 15150
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-08-cart-abandonment.md": {
-            "at": "2026-04-01T20:59:17Z",
-            "hash": "2c4d31ad777c8c70b5293c3fd75e4e6af67b4654",
-            "passes": 1,
-            "pr": 15150
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-09-webinar-invite.md": {
-            "at": "2026-04-01T20:59:17Z",
-            "hash": "5dd410cda93d3056b39408c537fb3c9b1e1e06da",
-            "passes": 1,
-            "pr": 15150
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
-            "at": "2026-04-01T20:59:18Z",
-            "hash": "7f8943efbe9c5d05b7ecba869a866d6020b95928",
-            "passes": 1,
-            "pr": 15150
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md": {
-            "at": "2026-04-02T04:56:54Z",
-            "hash": "d662c65c03864c29b198db3a89950538a7949ef2",
-            "passes": 1,
-            "pr": 15526
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
-            "at": "2026-03-28T15:30:24Z",
-            "hash": "f74ee77c8e774c79829f80e238c09adbe6f3c21e",
-            "passes": 1,
-            "pr": 11945
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-example.md": {
-            "at": "2026-03-28T08:58:28Z",
-            "hash": "219b3f24929e0866af7e05c36250a267a5f2e952",
-            "passes": 1,
-            "pr": 11597
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-pastor-framework.md": {
-            "at": "2026-03-28T08:58:28Z",
-            "hash": "229aaf2fa58645152ccdd4ece9d723068b251f4a",
-            "passes": 1,
-            "pr": 11597
-        },
-        ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md": {
-            "at": "2026-03-28T08:57:56Z",
-            "hash": "816a5f35e7ca6b338deae7db62c3058d317b96d6",
-            "passes": 1,
-            "pr": 11647
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-01-facebook-instagram.md": {
-            "at": "2026-03-28T08:17:45Z",
-            "hash": "4bfed86699b1e5a25050b85f099ca3fc580574d8",
-            "passes": 1,
-            "pr": 11593
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-02-google-search.md": {
-            "at": "2026-03-28T08:17:45Z",
-            "hash": "f9ecc39136c90a2feb8bc9075f3e95ba23fccddd",
-            "passes": 1,
-            "pr": 11593
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-03-linkedin.md": {
-            "at": "2026-03-28T08:17:45Z",
-            "hash": "a3c8015dc17258f154c7bdd4e4ccf0d4586a06db",
-            "passes": 1,
-            "pr": 11593
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-04-twitter.md": {
-            "at": "2026-03-28T08:17:45Z",
-            "hash": "615623c2156bb8eee3a9409900b33a895768e08d",
-            "passes": 1,
-            "pr": 11593
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-ad-copy-05-reference.md": {
-            "at": "2026-03-28T08:17:45Z",
-            "hash": "d34fe0576cb0cb1c1770a278ad5e149bba1480d0",
-            "passes": 1,
-            "pr": 11593
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-ad-copy.md": {
-            "at": "2026-03-28T08:17:45Z",
-            "hash": "bfc16d8c1bc4e6a8229cc555eba0d72de8ece0d7",
-            "passes": 1,
-            "pr": 11593
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "fc8601e1d052f928c023da0917367bb21323b4e4",
-            "passes": 2,
-            "pr": 15046
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "658de751f2d88050b16b810d4606b3d70426e4dd",
-            "passes": 2,
-            "pr": 15046
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "ca0ffbbb9d01a944ca038fd7ffed902dedf0c82c",
-            "passes": 2,
-            "pr": 15046
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "5328e2dd6fd579ca0f648b82f3f94b52f56f3baf",
-            "passes": 2,
-            "pr": 15046
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "d207be0ddb3e721786a9a93447bd0110bda97f67",
-            "passes": 2,
-            "pr": 15046
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "0cf9219a719ff218be50f556ea87fe2c1353fea7",
-            "passes": 2,
-            "pr": 15046
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-email-sequences.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "8b6cccfab9ec08287f4b54ab1e353f28a94a3cdb",
-            "passes": 2,
-            "pr": 15046
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-landing-page.md": {
-            "at": "2026-03-28T13:37:36Z",
-            "hash": "cbaa0cc29c6e3639ea5254866f8fefe1c02a329c",
-            "passes": 1,
-            "pr": 11840
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-readme.md": {
-            "at": "2026-03-28T08:17:38Z",
-            "hash": "2717d1e9cb1edfd85d932502b6de7c4765c8a7ec",
-            "passes": 1,
-            "pr": 11571
-        },
-        ".agents/marketing-sales/direct-response-copy-templates-vsl-script.md": {
-            "at": "2026-03-28T08:17:46Z",
-            "hash": "c8fa5d2f257f52a1d7c9c49ca9d78e6be247623e",
-            "passes": 1,
-            "pr": 11591
-        },
-        ".agents/marketing-sales/direct-response-copy.md": {
-            "at": "2026-03-30T02:30:17Z",
-            "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
-            "passes": 1,
-            "pr": 13597
-        },
-        ".agents/marketing-sales/meta-ads-audiences-first-party-data.md": {
-            "at": "2026-03-28T08:18:20Z",
-            "hash": "1ad15971973eec338e831dc24839609eb1f473e3",
-            "passes": 1,
-            "pr": 11536
-        },
-        ".agents/marketing-sales/meta-ads-audiences-retargeting-setup.md": {
-            "at": "2026-03-29T03:15:24Z",
-            "hash": "dedfee9605d04b5a7cf9f5563c0e772f06e44062",
-            "passes": 1,
-            "pr": 12514
-        },
-        ".agents/marketing-sales/meta-ads-audiences-targeting-strategies.md": {
-            "at": "2026-03-28T11:20:14Z",
-            "hash": "9802f4e7f19b67d5a8a45f1a137209082a585d4c",
-            "passes": 1,
-            "pr": 11791
-        },
-        ".agents/marketing-sales/meta-ads-campaigns-advantage-plus.md": {
-            "at": "2026-03-30T04:52:40Z",
-            "hash": "e2a2dc5e7f15a6ce3fdcf4e477dac3ca7db3056f",
-            "passes": 1,
-            "pr": 13779
-        },
-        ".agents/marketing-sales/meta-ads-campaigns-decision-trees.md": {
-            "at": "2026-03-28T04:30:25Z",
-            "hash": "a7bcedab8040e2b400b7c2feca987e09bb0a8477",
-            "passes": 1,
-            "pr": 11381
-        },
-        ".agents/marketing-sales/meta-ads-campaigns-retargeting.md": {
-            "at": "2026-03-28T11:52:21Z",
-            "hash": "76a66a236cc7fbeb40d74384e9dbe4bd75a4a155",
-            "passes": 1,
-            "pr": 11822
-        },
-        ".agents/marketing-sales/meta-ads-campaigns-scaling-cbo.md": {
-            "at": "2026-03-29T21:42:59Z",
-            "hash": "6fb79b1689e522f77f09f4398f80430c8c727116",
-            "passes": 1,
-            "pr": 13263
-        },
-        ".agents/marketing-sales/meta-ads-campaigns-testing-abo.md": {
-            "at": "2026-03-29T01:04:17Z",
-            "hash": "be737a2fe12892ef6479a1939cbe4b6fee46db16",
-            "passes": 1,
-            "pr": 12395
-        },
-        ".agents/marketing-sales/meta-ads-checklists-campaign-launch.md": {
-            "at": "2026-04-01T20:59:20Z",
-            "hash": "3f199a8eb517a651781b683ec0d6a723fb16d9b0",
-            "passes": 1,
-            "pr": 15149
-        },
-        ".agents/marketing-sales/meta-ads-checklists-creative-review.md": {
-            "at": "2026-03-30T03:33:54Z",
-            "hash": "d3207ef474ba73d95bb9c13864b282ac0b78169e",
-            "passes": 1,
-            "pr": 13666
-        },
-        ".agents/marketing-sales/meta-ads-checklists-weekly-review.md": {
-            "at": "2026-03-29T12:36:27Z",
-            "hash": "8ddae4fd98efd953d4ecaa242553ad3eda337a92",
-            "passes": 1,
-            "pr": 12947
-        },
-        ".agents/marketing-sales/meta-ads-creative-briefs-founder-video-brief.md": {
-            "at": "2026-03-31T06:30:29Z",
-            "hash": "4663b6f4a18ffba178e090fd696bba98f87535b8",
-            "passes": 2,
-            "pr": 14701
-        },
-        ".agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md": {
-            "at": "2026-03-29T15:50:34Z",
-            "hash": "cde8788cbf4bf8376449f26888b4823576649256",
-            "passes": 2,
-            "pr": 13064
-        },
-        ".agents/marketing-sales/meta-ads-creative-briefs-ugc-brief.md": {
-            "at": "2026-03-28T21:27:17Z",
-            "hash": "b3cbdabb7633b010839689527b084c198f34bdc9",
-            "passes": 1,
-            "pr": 12217
-        },
-        ".agents/marketing-sales/meta-ads-creative-formats.md": {
-            "at": "2026-03-28T06:39:54Z",
-            "hash": "f8a4f095bebc852b9ce58976d3b53e418bbe578e",
-            "passes": 1,
-            "pr": 11410
-        },
-        ".agents/marketing-sales/meta-ads-creative-hooks.md": {
-            "at": "2026-03-27T21:25:06Z",
-            "hash": "f7c8e3356361a9ab1941f729337bbf7d0f8447ef",
-            "passes": 1,
-            "pr": 11016
-        },
-        ".agents/marketing-sales/meta-ads-creative-psychology.md": {
-            "at": "2026-03-30T04:52:02Z",
-            "hash": "6436f438f568834b0e2062a282cce59cc65ec58d",
-            "passes": 1,
-            "pr": 13729
-        },
-        ".agents/marketing-sales/meta-ads-creative-scripts.md": {
-            "at": "2026-03-28T03:10:39Z",
-            "hash": "9455fbf07187de24552aa591a8752fd7b3df2480",
-            "passes": 1,
-            "pr": 11297
-        },
-        ".agents/marketing-sales/meta-ads-foundations-account-structure.md": {
-            "at": "2026-03-29T21:43:00Z",
-            "hash": "d8a1a11c970efd832edd47784162978ad05783f0",
-            "passes": 1,
-            "pr": 13333
-        },
-        ".agents/marketing-sales/meta-ads-foundations-algorithm.md": {
-            "at": "2026-04-01T20:59:13Z",
-            "hash": "318e59fc49106e5aaeeca2d26e666b87b0353d5c",
-            "passes": 1,
-            "pr": 15138
-        },
-        ".agents/marketing-sales/meta-ads-foundations-attribution.md": {
-            "at": "2026-03-29T11:51:45Z",
-            "hash": "7bd8755456129fcd79c106e7e829c6233ae16c42",
-            "passes": 1,
-            "pr": 12920
-        },
-        ".agents/marketing-sales/meta-ads-foundations-glossary.md": {
-            "at": "2026-03-30T03:33:50Z",
-            "hash": "f0b0b3b259d7597309af03f39a2f267137dafffe",
-            "passes": 1,
-            "pr": 13691
-        },
-        ".agents/marketing-sales/meta-ads-optimization-automation-rules.md": {
-            "at": "2026-03-29T15:50:44Z",
-            "hash": "4e78284e12f62b421b7458d171f79117bc4610e9",
-            "passes": 1,
-            "pr": 13078
-        },
-        ".agents/marketing-sales/meta-ads-optimization-metrics.md": {
-            "at": "2026-03-30T06:49:39Z",
-            "hash": "99cca533a9d716bf886a24bffbf8255ca5da96a3",
-            "passes": 1,
-            "pr": 13940
-        },
-        ".agents/marketing-sales/meta-ads-optimization-scaling.md": {
-            "at": "2026-03-28T08:17:40Z",
-            "hash": "8034babf9a34b6f09f0cce7817a136ee38be0c1f",
-            "passes": 1,
-            "pr": 11564
-        },
-        ".agents/marketing-sales/meta-ads-optimization-troubleshooting.md": {
-            "at": "2026-03-28T08:17:40Z",
-            "hash": "684991a0c73063d140b0cfee3ad73691a479a34f",
-            "passes": 1,
-            "pr": 11564
-        },
-        ".agents/marketing-sales/meta-ads.md": {
-            "at": "2026-03-28T16:40:30Z",
-            "hash": "19b4754a783dd4b878bb5cf4032420f1cfab931d",
-            "passes": 1,
-            "pr": 12024
-        },
-        ".agents/product/analytics.md": {
-            "at": "2026-03-29T23:53:58Z",
-            "hash": "1ecb5ce4743770c3913fae8f41e526f3ba21c6a0",
-            "passes": 1,
-            "pr": 13415
-        },
-        ".agents/product/growth.md": {
-            "at": "2026-03-28T16:40:15Z",
-            "hash": "97246dfba596c1be9241c0b669c611df856e71bc",
-            "passes": 1,
-            "pr": 12037
-        },
-        ".agents/product/monetisation.md": {
-            "at": "2026-04-03T01:52:56Z",
-            "hash": "335ecd62068e0bc6a3a1e74b01cd823611ba1d54",
-            "passes": 2,
-            "pr": 16017
-        },
-        ".agents/product/onboarding.md": {
-            "at": "2026-03-29T23:54:00Z",
-            "hash": "bc634e70e9bb850181c2c4c0d239a36447560921",
-            "passes": 1,
-            "pr": 13399
-        },
-        ".agents/product/ui-design.md": {
-            "at": "2026-03-30T03:34:29Z",
-            "hash": "3a8d0daebe80ebc2f64efe31009dbcba324fe142",
-            "passes": 1,
-            "pr": 13539
-        },
-        ".agents/product/validation.md": {
-            "at": "2026-03-29T12:37:13Z",
-            "hash": "74840e4aa9e8d619ae82517ca6a1b43a00f99b56",
-            "passes": 1,
-            "pr": 12910
-        },
-        ".agents/prompts/worker-efficiency-protocol.md": {
-            "at": "2026-04-03T01:11:25Z",
-            "hash": "c2131a568a446a0555dbc6491084d79991198379",
-            "passes": 2,
-            "pr": 14943
-        },
-        ".agents/reference/agent-routing.md": {
-            "at": "2026-03-31T05:34:14Z",
-            "hash": "83e56233f5c7fc633bc3a64de90d9b5529a0bd33",
-            "passes": 1,
-            "pr": 14650
-        },
-        ".agents/reference/auto-update.md": {
-            "at": "2026-04-01T23:23:47Z",
-            "hash": "0db7d0a5ebb60bf53cbeb2d88102be373220981c",
-            "passes": 1,
-            "pr": 15301
-        },
-        ".agents/reference/configuration.md": {
-            "at": "2026-03-28T04:30:48Z",
-            "hash": "9502faea512b841b7a239e9e3c9cc0188f4fe855",
-            "passes": 1,
-            "pr": 11321
-        },
-        ".agents/reference/contribution-watch.md": {
-            "at": "2026-04-01T23:23:47Z",
-            "hash": "77b53dc6bf630c7451cc69425d06aa11f23e727b",
-            "passes": 1,
-            "pr": 15301
-        },
-        ".agents/reference/define-probes/bugfix.md": {
-            "at": "2026-04-01T23:23:39Z",
-            "hash": "88ddddb0fc275f73407b492a820bd0f2bfdada99",
-            "passes": 1,
-            "pr": 15334
-        },
-        ".agents/reference/entity-memory-architecture.md": {
-            "at": "2026-04-02T00:00:00Z",
-            "hash": "bbd1c42b7e0eb2b01cb5a193f94c5e9ecf98c540",
-            "passes": 1,
-            "pr": 15488
-        },
-        ".agents/reference/foss-contributions.md": {
-            "at": "2026-03-30T02:30:24Z",
-            "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
-            "passes": 1,
-            "pr": 13561
-        },
-        ".agents/reference/hashline-edit-format.md": {
-            "at": "2026-04-01T23:23:50Z",
-            "hash": "2f2019c30b4f9bb5d1947e6b7156833f15973c1e",
-            "passes": 1,
-            "pr": 15277
-        },
-        ".agents/reference/high-stakes-operations.md": {
-            "at": "2026-03-27T21:25:17Z",
-            "hash": "ba39668c924d2e2d0137c766053513a98a2f2839",
-            "passes": 1,
-            "pr": 11012
-        },
-        ".agents/reference/memory.md": {
-            "at": "2026-03-28T07:37:36Z",
-            "hash": "0a7c4c493f3a825b98e2de3928f718fa9095c966",
-            "passes": 1,
-            "pr": 11538
-        },
-        ".agents/reference/planning-detail.md": {
-            "at": "2026-03-29T08:49:21Z",
-            "hash": "c5c616d56a09198023878a228bbf7311f9bd0212",
-            "passes": 1,
-            "pr": 12780
-        },
-        ".agents/reference/repo-sync.md": {
-            "at": "2026-04-01T23:23:47Z",
-            "hash": "e6c2ddc65a495825740608c7c440f8ba49033db5",
-            "passes": 1,
-            "pr": 15301
-        },
-        ".agents/reference/services.md": {
-            "at": "2026-04-01T23:23:47Z",
-            "hash": "85309d5014421182d0c22812ec7bb56f2ccc2ab0",
-            "passes": 1,
-            "pr": 15301
-        },
-        ".agents/reference/settings.md": {
-            "at": "2026-03-30T03:34:12Z",
-            "hash": "2b2cbc9b8329f0fd0504413c4805a235d0f16962",
-            "passes": 1,
-            "pr": 13637
-        },
-        ".agents/research.md": {
-            "at": "2026-04-01T20:59:28Z",
-            "hash": "b509e2fae5168065f0142ae29dca1ec2d410c53b",
-            "passes": 1,
-            "pr": 14996
-        },
-        ".agents/scripts/commands/budget-analysis.md": {
-            "at": "2026-04-01T20:58:50Z",
-            "hash": "ac77aaf850ecc1f9cee81c9e04a026a954fc7359",
-            "passes": 1,
-            "pr": 15257
-        },
-        ".agents/scripts/commands/dashboard.md": {
-            "at": "2026-03-29T21:43:13Z",
-            "hash": "c72021fe5b7c20c340b5a5a1e1b66cf6b3d247f9",
-            "passes": 1,
-            "pr": 13338
-        },
-        ".agents/scripts/commands/define.md": {
-            "at": "2026-03-29T17:15:13Z",
-            "hash": "228f38c6d509423d7158cef517bbd601a691923d",
-            "passes": 1,
-            "pr": 13131
-        },
-        ".agents/scripts/commands/email-outreach.md": {
-            "at": "2026-04-02T03:11:10Z",
-            "hash": "03c6fbfcdc4ba527948102f9b58f5c9bed557777",
-            "passes": 1,
-            "pr": 15480
-        },
-        ".agents/scripts/commands/full-loop.md": {
-            "at": "2026-04-02T14:41:00Z",
-            "hash": "bcf22ce3b332f521d77a911b696ec7375d0eabe8",
-            "passes": 3,
-            "pr": 14590
-        },
-        ".agents/scripts/commands/ip-check.md": {
-            "at": "2026-03-31T02:20:51Z",
-            "hash": "157dc866ef64f46a91e761875f5346f372c3da72",
-            "passes": 2,
-            "pr": 14484
-        },
-        ".agents/scripts/commands/list-todo.md": {
-            "at": "2026-04-01T20:59:47Z",
-            "hash": "351180b6d47cacee5be38fc9e3ec01f7d1fd8661",
-            "passes": 1,
-            "pr": 14898
-        },
-        ".agents/scripts/commands/list-verify.md": {
-            "at": "2026-04-02T04:56:43Z",
-            "hash": "dc43be77f9d72dac6880004350a5b63ce9a326f0",
-            "passes": 1,
-            "pr": 15514
-        },
-        ".agents/scripts/commands/log-issue-aidevops.md": {
-            "at": "2026-03-27T21:25:13Z",
-            "hash": "24878e7d7abca4cf0b41a18e5dac1977978ec3c1",
-            "passes": 1,
-            "pr": 11007
-        },
-        ".agents/scripts/commands/mission.md": {
-            "at": "2026-03-29T12:36:32Z",
-            "hash": "e13208184cee9ed81fd7f6bddfef98bbcd41b5f5",
-            "passes": 1,
-            "pr": 12959
-        },
-        ".agents/scripts/commands/neuronwriter.md": {
-            "at": "2026-03-29T07:02:53Z",
-            "hash": "233c0b9d671275ad8b68ef45c8afaff33acbec34",
-            "passes": 1,
-            "pr": 12588
-        },
-        ".agents/scripts/commands/new-task.md": {
-            "at": "2026-03-30T02:30:59Z",
-            "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
-            "passes": 1,
-            "pr": 13489
-        },
-        ".agents/scripts/commands/postflight-loop.md": {
-            "at": "2026-04-01T20:59:31Z",
-            "hash": "37a467bf622640eb6c8d75aa2c1de45c9a27c61c",
-            "passes": 1,
-            "pr": 14942
-        },
-        ".agents/scripts/commands/pulse.md": {
-            "at": "2026-04-02T14:41:03Z",
-            "hash": "338273dcb0c9118b1c7cce9c5ddb236fd9d3b078",
-            "passes": 3,
-            "pr": 13117
-        },
-        ".agents/scripts/commands/recall.md": {
-            "at": "2026-04-02T04:56:44Z",
-            "hash": "9b0b04b0aeda1a0436139a205db96efcf0e662ad",
-            "passes": 1,
-            "pr": 15515
-        },
-        ".agents/scripts/commands/remember.md": {
-            "at": "2026-03-29T03:14:59Z",
-            "hash": "9b17697bde40499a9feacb7812126a6474b0d5d4",
-            "passes": 1,
-            "pr": 12497
-        },
-        ".agents/scripts/commands/route.md": {
-            "at": "2026-03-31T04:45:56Z",
-            "hash": "f95b19c17d85e3ff5ff46e93f7bae3252de01308",
-            "passes": 2,
-            "pr": 14604
-        },
-        ".agents/scripts/commands/routine.md": {
-            "at": "2026-03-31T03:14:22Z",
-            "hash": "5e9a21d7bf25494b68d2c080b7a1ba28664488cc",
-            "passes": 2,
-            "pr": 14509
-        },
-        ".agents/scripts/commands/runners.md": {
-            "at": "2026-03-28T23:06:00Z",
-            "hash": "34d6abef3517f8c104f651d33d960e5c13afec87",
-            "passes": 2,
-            "pr": 12326
-        },
-        ".agents/scripts/commands/save-todo.md": {
-            "at": "2026-03-29T03:15:15Z",
-            "hash": "9b4ef4321b1b93eb8d349dbdae3b6c717838135c",
-            "passes": 1,
-            "pr": 12521
-        },
-        ".agents/scripts/commands/security-deps.md": {
-            "at": "2026-04-01T20:59:27Z",
-            "hash": "265f2d26f358ffb425e374dca8aa76a7c20c3565",
-            "passes": 1,
-            "pr": 14994
-        },
-        ".agents/scripts/commands/security-history.md": {
-            "at": "2026-04-02T04:56:52Z",
-            "hash": "0c74f125bbb3e299040015ee24fb345e43486ec7",
-            "passes": 1,
-            "pr": 15487
-        },
-        ".agents/scripts/commands/seo-audit.md": {
-            "at": "2026-04-02T03:11:11Z",
-            "hash": "d8d6dee50a191d538e032247f78abb02ebb504a8",
-            "passes": 1,
-            "pr": 15477
-        },
-        ".agents/scripts/commands/show-plan.md": {
-            "at": "2026-03-29T20:53:58Z",
-            "hash": "a50ab6b6bab142d6f388d385dfa6a525b458cac9",
-            "passes": 1,
-            "pr": 13285
-        },
-        ".agents/scripts/commands/skills.md": {
-            "at": "2026-03-29T08:10:30Z",
-            "hash": "b5d46b5e38620ec36852251ec0e4ab4178d9d217",
-            "passes": 1,
-            "pr": 12747
-        },
-        ".agents/scripts/commands/strategic-review.md": {
-            "at": "2026-03-29T08:10:38Z",
-            "hash": "321755ff5b42109fb2ed065075b903ecfed76407",
-            "passes": 1,
-            "pr": 12756
-        },
-        ".agents/scripts/commands/testing-setup.md": {
-            "at": "2026-03-28T16:40:41Z",
-            "hash": "f653aacf0e67efffd18058625b81f790e9c9f741",
-            "passes": 1,
-            "pr": 12013
-        },
-        ".agents/scripts/commands/venv-health.md": {
-            "at": "2026-04-02T09:43:51Z",
-            "hash": "4d985fc7dfe983440e133ac132e682303ca928e8",
-            "passes": 1,
-            "pr": 15577
-        },
-        ".agents/scripts/commands/worktree-cleanup.md": {
-            "at": "2026-04-02T02:30:00Z",
-            "hash": "110dfc59f9c93f01dbf166827f33fc1560b6a7b9",
-            "passes": 1,
-            "pr": null
-        },
-        ".agents/scripts/commands/youtube-research.md": {
-            "at": "2026-03-29T08:10:31Z",
-            "hash": "340b914ca94d03a0c78878b9ec28534fc761f352",
-            "passes": 1,
-            "pr": 12750
-        },
-        ".agents/scripts/commands/youtube-setup.md": {
-            "at": "2026-03-29T12:37:14Z",
-            "hash": "d3f66f792c780e690b58d7f976c01c3d64f09a52",
-            "passes": 1,
-            "pr": 12943
-        },
-        ".agents/scripts/commands/yt-dlp.md": {
-            "at": "2026-03-30T03:34:31Z",
-            "hash": "56c400042f899284be4b65c6480fcac4de404248",
-            "passes": 1,
-            "pr": 13544
-        },
-        ".agents/scripts/foss-handlers/generic.sh": {
-            "at": "2026-03-29T03:15:47Z",
-            "hash": "45cc10462795e6230b70b2f068bb95b4e53612f2",
-            "passes": 1,
-            "pr": 12346
-        },
-        ".agents/scripts/framework-issue-helper.sh": {
-            "at": "2026-04-02T15:26:33Z",
-            "hash": "64247677d8764e3ba8355385495671181569267a",
-            "passes": 2,
-            "pr": 12145
-        },
-        ".agents/scripts/gh-signature-helper.sh": {
-            "at": "2026-03-29T16:34:26Z",
-            "hash": "3dceb47a39cc1230b0f38f697e8cc54a02c27687",
-            "passes": 2,
-            "pr": 13021
-        },
-        ".agents/scripts/headless-runtime-helper.sh": {
-            "at": "2026-04-02T03:11:26Z",
-            "hash": "afbddbc0f8e639803f170b9d8557c01f8c4ba212",
-            "passes": 2,
-            "pr": 15086
-        },
-        ".agents/scripts/matrix-dispatch-helper.sh": {
-            "at": "2026-04-02T03:11:00Z",
-            "hash": "d42a4c2129d808e3bf1fe78109163f12f059c723",
-            "passes": 1,
-            "pr": 15431
-        },
-        ".agents/scripts/platform-detect.sh": {
-            "at": "2026-04-02T04:56:59Z",
-            "hash": "a551a07e07c08853c909e7b8141ddddf2de43420",
-            "passes": 1,
-            "pr": 15455
-        },
-        ".agents/scripts/pulse-wrapper.sh": {
-            "at": "2026-04-02T21:57:56Z",
-            "hash": "0a1b0e22b71d7c37bca0d17c5c476b053ff76b06",
-            "passes": 6,
-            "pr": 15086
-        },
-        ".agents/scripts/stats-functions.sh": {
-            "at": "2026-04-03T01:11:28Z",
-            "hash": "3bd327b19cc722f4ddf43fb1f4724958056e11bb",
-            "passes": 4,
-            "pr": 11273
-        },
-        ".agents/scripts/tests/test-gh-signature-helper.sh": {
-            "at": "2026-03-29T13:19:54Z",
-            "hash": "14e07889b9a874db8e98e44d1c5a8ed1ac3687fb",
-            "passes": 2,
-            "pr": 12971
-        },
-        ".agents/seo.md": {
-            "at": "2026-03-30T03:34:16Z",
-            "hash": "1dcd30f4590e4b2b7792e538d0a70e7d4979aa8e",
-            "passes": 1,
-            "pr": 13526
-        },
-        ".agents/seo/ahrefs.md": {
-            "at": "2026-04-02T03:11:00Z",
-            "hash": "68607c6d5bd42845c1fe21cebb00752f6ff8106d",
-            "passes": 1,
-            "pr": 15431
-        },
-        ".agents/seo/ai-search-kpi-template.md": {
-            "at": "2026-04-01T20:59:36Z",
-            "hash": "292c7a69e131309cd9f0ad3c6459f4af1fcfcff4",
-            "passes": 2,
-            "pr": 14969
-        },
-        ".agents/seo/analytics-tracking.md": {
-            "at": "2026-03-27T21:25:04Z",
-            "hash": "07ff0feec55ad3f8477a6badd724b479c1b09370",
-            "passes": 1,
-            "pr": 11015
-        },
-        ".agents/seo/backlink-checker.md": {
-            "at": "2026-04-02T02:14:59Z",
-            "hash": "16c0f1f109b8a8d47222978204b1f7b955abaa7d",
-            "passes": 2,
-            "pr": null
-        },
-        ".agents/seo/content-analyzer.md": {
-            "at": "2026-04-02T04:56:49Z",
-            "hash": "7972fdccf29515026f0f710dac5f8e1b792e77c5",
-            "passes": 1,
-            "pr": 15478
-        },
-        ".agents/seo/contentking.md": {
-            "at": "2026-03-28T13:37:31Z",
-            "hash": "ce7ecac379f3bc6552cf23ad3bd149902b0ace12",
-            "passes": 1,
-            "pr": 11845
-        },
-        ".agents/seo/data-export.md": {
-            "at": "2026-03-27T21:25:21Z",
-            "hash": "196b3c4788803c0b2b8d412752d3d262d7e6f8b2",
-            "passes": 1,
-            "pr": 11019
-        },
-        ".agents/seo/dataforseo.md": {
-            "at": "2026-03-28T17:11:12Z",
-            "hash": "8dfaad77d57b706e697ab23a2c8ac8a84cf9c6ed",
-            "passes": 1,
-            "pr": 12053
-        },
-        ".agents/seo/debug-favicon.md": {
-            "at": "2026-03-29T22:09:18Z",
-            "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",
-            "passes": 1,
-            "pr": 13323
-        },
-        ".agents/seo/debug-opengraph.md": {
-            "at": "2026-03-28T14:15:42Z",
-            "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
-            "passes": 1,
-            "pr": 11898
-        },
-        ".agents/seo/domain-research-api-reference.md": {
-            "at": "2026-03-28T17:11:07Z",
-            "hash": "52e574da550501d13cf7d760d098926843d5260b",
-            "passes": 1,
-            "pr": 12056
-        },
-        ".agents/seo/domain-research.md": {
-            "at": "2026-03-28T17:11:08Z",
-            "hash": "18f017104a97c94157077b8fc620e24bad8f86ba",
-            "passes": 1,
-            "pr": 12056
-        },
-        ".agents/seo/eeat-score.md": {
-            "at": "2026-03-28T20:56:08Z",
-            "hash": "bb9c0e98f32d0453eb08cbbb4222f06c1a13b007",
-            "passes": 1,
-            "pr": 12181
-        },
-        ".agents/seo/google-search-console.md": {
-            "at": "2026-03-30T06:49:36Z",
-            "hash": "525712f74fe9ec13980ef0564a2108481e894038",
-            "passes": 1,
-            "pr": 13900
-        },
-        ".agents/seo/gsc-sitemaps.md": {
-            "at": "2026-03-28T11:52:39Z",
-            "hash": "7154caa038f21e800f7b6c5493f2553a9d7e8efb",
-            "passes": 1,
-            "pr": 11821
-        },
-        ".agents/seo/image-seo.md": {
-            "at": "2026-03-30T03:34:23Z",
-            "hash": "91991eb82fa32f9ed717213566d5bb49604dfdc4",
-            "passes": 1,
-            "pr": 13530
-        },
-        ".agents/seo/keyword-mapper.md": {
-            "at": "2026-04-02T05:10:00Z",
-            "hash": "028f3ad361b1ba3e37e1839edb0dfec17369c3d5",
-            "passes": 1,
-            "pr": null
-        },
-        ".agents/seo/keyword-research.md": {
-            "at": "2026-03-28T21:27:18Z",
-            "hash": "d00bca2d9a784bfd220b4afd767d384d83bea740",
-            "passes": 1,
-            "pr": 12220
-        },
-        ".agents/seo/mom-test-ux.md": {
-            "at": "2026-03-30T03:34:17Z",
-            "hash": "29c796f48c4b581197f9ea36ed95bbe98bb4ae51",
-            "passes": 1,
-            "pr": 13524
-        },
-        ".agents/seo/moondream.md": {
-            "at": "2026-03-30T03:33:44Z",
-            "hash": "e6e0bef21020b260c31561b4da9fc0ef1e900be5",
-            "passes": 1,
-            "pr": 13663
-        },
-        ".agents/seo/neuronwriter.md": {
-            "at": "2026-03-28T03:54:21Z",
-            "hash": "e6d78a192db4a98186ff9a1f428a07d6455ba42a",
-            "passes": 1,
-            "pr": 11350
-        },
-        ".agents/seo/programmatic-seo.md": {
-            "at": "2026-04-02T21:20:03Z",
-            "hash": "cc9aa2cac637f165854122e6b4328e70a7ee3850",
-            "passes": 2,
-            "pr": 13301
-        },
-        ".agents/seo/semrush.md": {
-            "at": "2026-03-27T21:25:11Z",
-            "hash": "cc61832322267a222c9e557b04459de4a3520086",
-            "passes": 1,
-            "pr": 11006
-        },
-        ".agents/seo/seo-audit-skill.md": {
-            "at": "2026-03-29T12:37:05Z",
-            "hash": "d8493f42e8ba01527667d283942af955218a834f",
-            "passes": 1,
-            "pr": 12948
-        },
-        ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
-            "at": "2026-03-29T23:53:50Z",
-            "hash": "b875488af36564292b08b0bcfabae97d18757135",
-            "passes": 1,
-            "pr": 13444
-        },
-        ".agents/seo/seo-regex.md": {
-            "at": "2026-03-29T22:09:17Z",
-            "hash": "b38e6b1002b80227940c036badb462c8add23514",
-            "passes": 1,
-            "pr": 13325
-        },
-        ".agents/seo/site-crawler.md": {
-            "at": "2026-03-28T08:58:48Z",
-            "hash": "b57ba3a5214383ec97ea5c4838fabcd0ce900a20",
-            "passes": 1,
-            "pr": 11598
-        },
-        ".agents/seo/tech-stack.md": {
-            "at": "2026-03-30T03:34:18Z",
-            "hash": "8b3aa2ab4498e38424d9bd911680bf2e6d45d856",
-            "passes": 1,
-            "pr": 13531
-        },
-        ".agents/services/accounting/quickfile.md": {
-            "at": "2026-03-29T07:02:24Z",
-            "hash": "db7040cc4f46334177d39ff45c6d4fd3be9698ee",
-            "passes": 1,
-            "pr": 12699
-        },
-        ".agents/services/analytics/google-analytics.md": {
-            "at": "2026-03-29T12:36:33Z",
-            "hash": "ee41c3c82de9e7f7dfa997caf2efea635a61fd7f",
-            "passes": 1,
-            "pr": 12950
-        },
-        ".agents/services/communications/bitchat.md": {
-            "at": "2026-03-29T20:53:59Z",
-            "hash": "38ac38ee1cb82fb462fc13746fbf560042e6e9a7",
-            "passes": 1,
-            "pr": 13287
-        },
-        ".agents/services/communications/convos-bridge-template.sh": {
-            "at": "2026-03-28T08:57:52Z",
-            "hash": "cd850bc9a35a947206c1a4cf2e67313bb90f9644",
-            "passes": 1,
-            "pr": 11688
-        },
-        ".agents/services/communications/convos.md": {
-            "at": "2026-03-28T08:57:52Z",
-            "hash": "74e396568b01688f29f86d799f049f5b624b9205",
-            "passes": 1,
-            "pr": 11688
-        },
-        ".agents/services/communications/discord.md": {
-            "at": "2026-03-28T03:53:47Z",
-            "hash": "44cce31bf11bd980e6b95270c913477c86348a15",
-            "passes": 1,
-            "pr": 11287
-        },
-        ".agents/services/communications/google-chat.md": {
-            "at": "2026-04-03T01:11:30Z",
-            "hash": "10fb2a539fb61865c4a9d813c68d69ea1ded5051",
-            "passes": 2,
-            "pr": 13658
-        },
-        ".agents/services/communications/imessage.md": {
-            "at": "2026-03-30T00:32:20Z",
-            "hash": "b16a496c6e98ffbb24f9a833e5b39e9566fb3f6b",
-            "passes": 2,
-            "pr": 13468
-        },
-        ".agents/services/communications/matterbridge.md": {
-            "at": "2026-03-29T01:04:18Z",
-            "hash": "10f123307b4f6919f65b9c46a2e9b5aecf37ef37",
-            "passes": 1,
-            "pr": 12399
-        },
-        ".agents/services/communications/msteams.md": {
-            "at": "2026-03-28T03:54:15Z",
-            "hash": "9818d1daccf3f68d103ecba204aa56431dba6514",
-            "passes": 1,
-            "pr": 11346
-        },
-        ".agents/services/communications/nextcloud-talk.md": {
-            "at": "2026-03-28T03:54:35Z",
-            "hash": "830399729c8d83ca4263bbf736ea549534989f63",
-            "passes": 1,
-            "pr": 11360
-        },
-        ".agents/services/communications/nostr.md": {
-            "at": "2026-03-28T09:17:35Z",
-            "hash": "eacafb8b13831574c6bc570c06903e15e7acd077",
-            "passes": 1,
-            "pr": 11715
-        },
-        ".agents/services/communications/privacy-comparison.md": {
-            "at": "2026-03-28T20:16:54Z",
-            "hash": "d36b5a85b507a958a555b6311d3266035d619ba8",
-            "passes": 1,
-            "pr": 12169
-        },
-        ".agents/services/communications/signal.md": {
-            "at": "2026-03-28T08:58:53Z",
-            "hash": "652f531e6f54f9fd38da5c5bd61889672eac4acf",
-            "passes": 1,
-            "pr": 11620
-        },
-        ".agents/services/communications/simplex.md": {
-            "at": "2026-03-28T20:16:50Z",
-            "hash": "0fae9edf453dabb06fafed112e578d6f45e0f96c",
-            "passes": 1,
-            "pr": 12168
-        },
-        ".agents/services/communications/slack.md": {
-            "at": "2026-03-30T03:34:27Z",
-            "hash": "4894b60910b9fe85ce8dcfb7feb5441fca48be44",
-            "passes": 1,
-            "pr": 13545
-        },
-        ".agents/services/communications/telegram.md": {
-            "at": "2026-03-28T21:58:54Z",
-            "hash": "96307f35314ef975fc24bfc8ea3098ac307e2373",
-            "passes": 1,
-            "pr": 12233
-        },
-        ".agents/services/communications/telfon.md": {
-            "at": "2026-03-31T04:46:03Z",
-            "hash": "bcfbcb400a28970ede2e7ba64abe188935fc887c",
-            "passes": 2,
-            "pr": 14595
-        },
-        ".agents/services/communications/twilio.md": {
-            "at": "2026-03-28T14:15:37Z",
-            "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
-            "passes": 1,
-            "pr": 11900
-        },
-        ".agents/services/communications/urbit.md": {
-            "at": "2026-03-29T12:37:15Z",
-            "hash": "dc74bf7135da0ba31e070bedbe6be841d6b9588b",
-            "passes": 1,
-            "pr": 12911
-        },
-        ".agents/services/communications/whatsapp.md": {
-            "at": "2026-03-29T12:37:29Z",
-            "hash": "dbc5cdbcdc61a880b5ca1c2746408002cc6fa7ac",
-            "passes": 1,
-            "pr": 12821
-        },
-        ".agents/services/communications/xmtp.md": {
-            "at": "2026-03-27T21:25:14Z",
-            "hash": "0b5b1bb178865dc7efff9f7578cd26dd9bf82bc9",
-            "passes": 1,
-            "pr": 11009
-        },
-        ".agents/services/crm/fluentcrm.md": {
-            "at": "2026-03-29T15:51:03Z",
-            "hash": "9e0e2c55d608f6cc55ceec5f45e845bbbc841b0c",
-            "passes": 1,
-            "pr": 13048
-        },
-        ".agents/services/database/multi-org-isolation.md": {
-            "at": "2026-03-28T21:59:22Z",
-            "hash": "2a09353ed9cbb973b0dd0344a938412bcc5b859e",
-            "passes": 1,
-            "pr": 12249
-        },
-        ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
-            "at": "2026-03-31T00:00:00Z",
-            "hash": "a42215bc7cdaff6daffe3ca6b1932ffe029b1507",
-            "passes": 1,
-            "pr": 14577
-        },
-        ".agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md": {
-            "at": "2026-03-31T06:23:12Z",
-            "hash": "084644aa5375c89ba69717a690c579d6076d532e",
-            "passes": 2,
-            "pr": 14691
-        },
-        ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
-            "at": "2026-03-28T10:27:24Z",
-            "hash": "2bf913e1887714fccd8b5baaf92a9c4afd0eaf44",
-            "passes": 2,
-            "pr": 11709
-        },
-        ".agents/services/database/postgres-drizzle-skill/migrations.md": {
-            "at": "2026-03-28T16:00:44Z",
-            "hash": "1b9f3f2536dd65950e7eec906f4c44467b9619e8",
-            "passes": 1,
-            "pr": 11966
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance-caching.md": {
-            "at": "2026-03-29T15:08:44Z",
-            "hash": "8c834b7d97111cfa9897297aa73c2ef3b366bf16",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance-explain.md": {
-            "at": "2026-03-29T15:08:44Z",
-            "hash": "230ed08a521dea04c78c68e8f7e5eab11f68ea65",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance-indexing.md": {
-            "at": "2026-03-29T15:08:44Z",
-            "hash": "982123000c56dcfb6394064ab6d5ad13a0603dbb",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance-monitoring.md": {
-            "at": "2026-03-29T15:08:44Z",
-            "hash": "38276dd264af6fef1c634f2620d188483aec50be",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance-pagination.md": {
-            "at": "2026-03-29T15:08:44Z",
-            "hash": "7e533ff31428e865c8c608139b2835b146164832",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance-pooling.md": {
-            "at": "2026-03-29T15:08:45Z",
-            "hash": "470b2b768f6fff6d4e925000ec0026254511ea0e",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance-queries.md": {
-            "at": "2026-03-29T15:08:45Z",
-            "hash": "3caacdf6f9053841bd7863c9f7dc002a8b784d1e",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/performance.md": {
-            "at": "2026-03-29T15:08:45Z",
-            "hash": "8d3a6869182b857eedccac3ed7f13229f52abd06",
-            "passes": 1,
-            "pr": 13034
-        },
-        ".agents/services/database/postgres-drizzle-skill/postgres.md": {
-            "at": "2026-03-28T05:50:57Z",
-            "hash": "2633ce6d2343b370a13a3efea1ed735544a6883a",
-            "passes": 1,
-            "pr": 11448
-        },
-        ".agents/services/database/postgres-drizzle-skill/queries.md": {
-            "at": "2026-03-28T06:40:05Z",
-            "hash": "0b8efee41f97c3674fd60bda302f1d674e557b07",
-            "passes": 2,
-            "pr": 11416
-        },
-        ".agents/services/database/postgres-drizzle-skill/relations.md": {
-            "at": "2026-03-28T09:48:57Z",
-            "hash": "673a7c2abd65766f454b57e79a259a7217463210",
-            "passes": 1,
-            "pr": 11717
-        },
-        ".agents/services/database/postgres-drizzle-skill/schema.md": {
-            "at": "2026-03-28T10:27:24Z",
-            "hash": "ed1952db54651cd46710ca9cfa4db950635e42a6",
-            "passes": 1,
-            "pr": 11709
-        },
-        ".agents/services/document-processing/unstract.md": {
-            "at": "2026-03-30T04:51:58Z",
-            "hash": "23759f7d870be0bbd07442ac06a3d7b069c8984b",
-            "passes": 1,
-            "pr": 13720
-        },
-        ".agents/services/email/email-actions.md": {
-            "at": "2026-03-28T16:40:11Z",
-            "hash": "6e4fd843160e764848c98da37b2234e11ddfa56d",
-            "passes": 1,
-            "pr": 12039
-        },
-        ".agents/services/email/email-agent.md": {
-            "at": "2026-03-28T20:16:44Z",
-            "hash": "4c589d1b951ae82f8dbb4a9e7ff05235f5edc6db",
-            "passes": 1,
-            "pr": 12163
-        },
-        ".agents/services/email/email-composition.md": {
-            "at": "2026-03-30T06:03:17Z",
-            "hash": "56336d402a38bf2eaa4d3bb6eebb2ad4dd5cfae7",
-            "passes": 1,
-            "pr": 13837
-        },
-        ".agents/services/email/email-delivery-test.md": {
-            "at": "2026-03-28T16:40:17Z",
-            "hash": "229f4a8a141175830e0207dbb58b13d9146b22ab",
-            "passes": 1,
-            "pr": 12041
-        },
-        ".agents/services/email/email-design-test.md": {
-            "at": "2026-03-29T22:09:19Z",
-            "hash": "216d3927030caa28089c7500c2f6b81c62897d17",
-            "passes": 1,
-            "pr": 13324
-        },
-        ".agents/services/email/email-health-check.md": {
-            "at": "2026-03-30T02:30:20Z",
-            "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
-            "passes": 1,
-            "pr": 13593
-        },
-        ".agents/services/email/email-intelligence.md": {
-            "at": "2026-03-29T12:37:18Z",
-            "hash": "4046abd7e9e4fffe477b2aa6fedd74cc46fb9708",
-            "passes": 1,
-            "pr": 12912
-        },
-        ".agents/services/email/email-mailbox-search.md": {
-            "at": "2026-03-28T13:37:26Z",
-            "hash": "26c7c333d46a5319b598173b36c5c30124126c81",
-            "passes": 1,
-            "pr": 11869
-        },
-        ".agents/services/email/email-mailbox.md": {
-            "at": "2026-03-29T07:02:18Z",
-            "hash": "e9ff02135b83557f59c4e444ef2f07607516b341",
-            "passes": 1,
-            "pr": 12624
-        },
-        ".agents/services/email/email-providers.md": {
-            "at": "2026-03-30T06:49:37Z",
-            "hash": "db4bc27307dd0943c67b08ac0ae471a009076a72",
-            "passes": 2,
-            "pr": 13859
-        },
-        ".agents/services/email/email-security.md": {
-            "at": "2026-03-29T21:43:14Z",
-            "hash": "933383c81c9e820f3d3b80f5dbd3db61d496e0cb",
-            "passes": 1,
-            "pr": 13343
-        },
-        ".agents/services/email/email-verification.md": {
-            "at": "2026-03-31T09:57:12Z",
-            "hash": "b75a2e2fa651e6f7facb266e4d357338c997ced7",
-            "passes": 2,
-            "pr": 14757
-        },
-        ".agents/services/email/google-workspace.md": {
-            "at": "2026-03-28T08:58:52Z",
-            "hash": "d25ed82148411a5ce44101400e445cb3293c4e96",
-            "passes": 1,
-            "pr": 11613
-        },
-        ".agents/services/email/letter-post-bridge.md": {
-            "at": "2026-03-31T05:33:36Z",
-            "hash": "f6065bec96f8cb306e39fe1862b7bf456e1901d3",
-            "passes": 1,
-            "pr": 14646
-        },
-        ".agents/services/email/microsoft-graph.md": {
-            "at": "2026-03-28T21:27:21Z",
-            "hash": "953bb07aef8c8ed23c023cc574b6390196e3b16d",
-            "passes": 1,
-            "pr": 12218
-        },
-        ".agents/services/email/mission-email.md": {
-            "at": "2026-03-28T13:37:15Z",
-            "hash": "bf5446200b94e750fce11fc719c2904f47bd67c5",
-            "passes": 1,
-            "pr": 11889
-        },
-        ".agents/services/email/openpgp-setup.md": {
-            "at": "2026-03-28T16:40:18Z",
-            "hash": "f893cd98da28874d714707765c45a895d991cede",
-            "passes": 1,
-            "pr": 12040
-        },
-        ".agents/services/email/smime-setup.md": {
-            "at": "2026-03-30T06:50:00Z",
-            "hash": "f83bb719e349bb600df046eccc7c1c5603c330f0",
-            "passes": 1,
-            "pr": 13915
-        },
-        ".agents/services/email/thunderbird.md": {
-            "at": "2026-03-29T07:02:32Z",
-            "hash": "97b29677f0dc7c7542e4fb7c2e3dc10bc5445489",
-            "passes": 1,
-            "pr": 12582
-        },
-        ".agents/services/hosting/101domains.md": {
-            "at": "2026-03-28T08:18:27Z",
-            "hash": "504d151b93c6073272de3fca00e08e6118720cf9",
-            "passes": 1,
-            "pr": 11633
-        },
-        ".agents/services/hosting/closte.md": {
-            "at": "2026-03-28T21:27:23Z",
-            "hash": "a9295d1bd4b72a378606ad987d9ea3d5385734c8",
-            "passes": 1,
-            "pr": 12219
-        },
-        ".agents/services/hosting/cloudflare-platform-skill.md": {
-            "at": "2026-03-28T20:16:45Z",
-            "hash": "6008b298c541d6b044eb0779f76074b818140d27",
-            "passes": 1,
-            "pr": 12162
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md": {
-            "at": "2026-04-02T14:41:30Z",
-            "hash": "1baef9315a8b2ef04fb8c54a9a13c9490104f568",
-            "passes": 4,
-            "pr": 15053
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/ai-gateway.md": {
-            "at": "2026-03-28T05:50:52Z",
-            "hash": "720c2836fca088d027ac637f8c69e97cb3c2764a",
-            "passes": 1,
-            "pr": 11443
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/bot-management-gotchas.md": {
-            "at": "2026-04-02T12:50:00Z",
-            "hash": "b2899f138eb2c8f2acfea6aea0d2aa0f274ee4a4",
-            "passes": 1,
-            "pr": 15047
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/c3.md": {
-            "at": "2026-03-28T15:30:18Z",
-            "hash": "6ffc77f50024207bbb549b337789b8c9cbd8f475",
-            "passes": 1,
-            "pr": 11962
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-gotchas.md": {
-            "at": "2026-03-29T22:09:42Z",
-            "hash": "2d19b3d0375bc8ceb48e769e353db722cab18283",
-            "passes": 2,
-            "pr": 13253
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md": {
-            "at": "2026-03-29T08:49:23Z",
-            "hash": "dd2e25d9b8dbb4578e676187c9463404feaa3fec",
-            "passes": 1,
-            "pr": 12779
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/d1-patterns.md": {
-            "at": "2026-03-29T21:43:01Z",
-            "hash": "8e6341f6f72cefdc4c09224910c1c4efe62de068",
-            "passes": 1,
-            "pr": 13296
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-            "at": "2026-03-30T02:30:53Z",
-            "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
-            "passes": 1,
-            "pr": 13494
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/durable-objects-gotchas.md": {
-            "at": "2026-03-29T11:19:55Z",
-            "hash": "befbfbdf1c28bab3d56f52fb86b4a85a7a988da5",
-            "passes": 1,
-            "pr": 12890
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md": {
-            "at": "2026-03-28T21:50:53Z",
-            "hash": "70f6f1b16aeb637c122232aa75b789bedfbe63a7",
-            "passes": 1,
-            "pr": 12192
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/email-workers.md": {
-            "at": "2026-03-29T03:15:00Z",
-            "hash": "d43b669b4be0f3b85ad9b1e95ff67189431eafdc",
-            "passes": 1,
-            "pr": 12502
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/hyperdrive.md": {
-            "at": "2026-04-02T04:56:50Z",
-            "hash": "1a63158e184bf8c3c6ac2f4b5110e44451c5d837",
-            "passes": 1,
-            "pr": 15481
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/kv-patterns.md": {
-            "at": "2026-03-29T22:09:11Z",
-            "hash": "7637914de409bb05cee56b57db714972a922dbbb",
-            "passes": 1,
-            "pr": 13321
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/miniflare-gotchas.md": {
-            "at": "2026-03-29T07:02:46Z",
-            "hash": "c2a8232a749da0976495eabf4ea541b52bae82f8",
-            "passes": 1,
-            "pr": 12586
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md": {
-            "at": "2026-03-29T14:29:37Z",
-            "hash": "304f6cf07b8e1ce2ccf0991e5a1c7a048d898f2b",
-            "passes": 1,
-            "pr": 13020
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
-            "at": "2026-03-29T12:36:58Z",
-            "hash": "07e97feffa7bc2100478d39e614278ab867ba605",
-            "passes": 1,
-            "pr": 12944
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-patterns.md": {
-            "at": "2026-03-29T12:37:11Z",
-            "hash": "e0498ebcd0125ebedaa97fd88662f8aeff47412a",
-            "passes": 1,
-            "pr": 12909
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
-            "at": "2026-04-02T23:13:23Z",
-            "hash": "dc0ab9b5d1eadafd4faf927c93a89eb11db185eb",
-            "passes": 2,
-            "pr": 14916
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
-            "at": "2026-03-30T06:49:10Z",
-            "hash": "7025e92856e65bda27000657e17b5696107172f3",
-            "passes": 2,
-            "pr": 13929
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md": {
-            "at": "2026-03-30T03:33:53Z",
-            "hash": "70e97040812ad2c593e7b451a917560531eb5903",
-            "passes": 1,
-            "pr": 13667
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
-            "at": "2026-03-30T02:30:18Z",
-            "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
-            "passes": 1,
-            "pr": 13595
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "6f21e87db5f7073e6e3c7c58bcd200553f1362bd",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "94e4a09c8278ba5e5eb4cb44aeadc6a0eb6a53ad",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "c38803612f71b78dc90e51b279452e6b51f0e383",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "4199ffb5b63b069ddb8b3ad8508dba6b7d72e699",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "197b920049e040bf81b6295e8bf760732130c5a9",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "c32415af75bf1288b0d52d7a8765b4e864292fab",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "79b4e58a49cf10008f774b3dd7f92e1301dae3eb",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "f54dc9504f5d680aa797a4677fa8d6955531aa73",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md": {
-            "at": "2026-03-31T07:50:54Z",
-            "hash": "12f54c4e7de2db16e3bed2fc32c1288ad551ef5d",
-            "passes": 2,
-            "pr": 14717
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi-patterns.md": {
-            "at": "2026-03-29T22:09:12Z",
-            "hash": "98b6e10081c4b00014ad525bb96a33a62b6f90a0",
-            "passes": 1,
-            "pr": 13329
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/queues-patterns.md": {
-            "at": "2026-03-30T04:51:49Z",
-            "hash": "5365c2251880bae2876aac89ff39f1dd909a2a0e",
-            "passes": 1,
-            "pr": 13735
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md": {
-            "at": "2026-04-02T15:27:02Z",
-            "hash": "c4d5ed8a074df52b72e94f16782306bf95098b3b",
-            "passes": 2,
-            "pr": 15629
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
-            "at": "2026-03-28T16:00:25Z",
-            "hash": "3078a83990f41df192998904d47d0641191e7fba",
-            "passes": 1,
-            "pr": 11985
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
-            "at": "2026-04-02T23:13:24Z",
-            "hash": "5a75b54baf9c39a8298e2ebbbee01c5c1988db13",
-            "passes": 2,
-            "pr": 14914
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/realtimekit-gotchas.md": {
-            "at": "2026-04-02T15:00:00Z",
-            "hash": "d9ece80ba981cecbe018d046364998faba4503b1",
-            "issue": 14302,
-            "passes": 1,
-            "pr": 15651
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-            "at": "2026-03-30T03:33:46Z",
-            "hash": "dca9ceb5efbdd602847f9c0030471e543684e1a6",
-            "passes": 1,
-            "pr": 13654
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md": {
-            "at": "2026-03-30T06:49:26Z",
-            "hash": "a0b18de39a54d95b1d687b669e01308b2333655f",
-            "passes": 1,
-            "pr": 13938
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md": {
-            "at": "2026-04-01T23:23:23Z",
-            "hash": "664f8b8e3ddeec9637d1647e3daed4495c1f4a96",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/01-ai-code-execution.md": {
-            "at": "2026-04-01T23:23:23Z",
-            "hash": "01137638b886f973e7f633159da5b9dc457c2416",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/02-interactive-dev-environment.md": {
-            "at": "2026-04-01T23:23:23Z",
-            "hash": "fc0ae968ea17a236a2c90214346e4470cad649b4",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/03-ci-cd-pipeline.md": {
-            "at": "2026-04-01T23:23:24Z",
-            "hash": "63d67404bc099cb3243761e2eeb3881a4f969c68",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/04-multi-language-code-runner.md": {
-            "at": "2026-04-01T23:23:24Z",
-            "hash": "c618c5137724952005c49df413fd5c2170209d83",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/05-multi-tenant.md": {
-            "at": "2026-04-01T23:23:24Z",
-            "hash": "e1d23e98d87b8e8ae9635d954951a70abe88fd57",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/06-jupyter-integration.md": {
-            "at": "2026-04-01T23:23:24Z",
-            "hash": "a7a4b85da6e8ebad5549cbb830bf9aa146b9d204",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/07-git-operations.md": {
-            "at": "2026-04-01T23:23:24Z",
-            "hash": "1610dca7b04c68ad219a4daa34c788dbed864aa2",
-            "passes": 1,
-            "pr": 15353
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/sandbox.md": {
-            "at": "2026-04-02T22:12:27Z",
-            "hash": "39c4bb1352aac7d3e10ccb586d162340e7ac0c7e",
-            "passes": 1,
-            "pr": null
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
-            "at": "2026-03-30T02:54:22Z",
-            "hash": "91b339029c6582618e5664e5c11ba08bbb75af7e",
-            "passes": 1,
-            "pr": 13564
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md": {
-            "at": "2026-04-02T21:20:07Z",
-            "hash": "925bb48a1a5651aca456c9232bf0d79ed9c2bce4",
-            "passes": 2,
-            "pr": 13254
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/stream-patterns.md": {
-            "at": "2026-03-30T06:03:15Z",
-            "hash": "f45d2973f1a08cfb71a1b4e0c66e73895737d463",
-            "passes": 1,
-            "pr": 13844
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/tail-workers.md": {
-            "at": "2026-03-28T08:17:39Z",
-            "hash": "d909ab39413052950bcfff2d355bb102d17f8421",
-            "passes": 1,
-            "pr": 11562
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/terraform-gotchas.md": {
-            "at": "2026-03-28T23:05:57Z",
-            "hash": "2111a2577e4e29eec771f709231f08fa22db2fc0",
-            "passes": 1,
-            "pr": 12324
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/terraform-patterns.md": {
-            "at": "2026-03-30T03:34:24Z",
-            "hash": "463f5c3efbf7a6b11c29193e5f6dcbefd1974fc2",
-            "passes": 1,
-            "pr": 13534
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md": {
-            "at": "2026-03-29T12:36:34Z",
-            "hash": "b194dbf29525881c1c8296a33806387d7ca7fe7f",
-            "passes": 1,
-            "pr": 12955
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/turn.md": {
-            "at": "2026-03-29T08:50:09Z",
-            "hash": "10963e4e50c30efb3918e434ec90cafa0ac2f51a",
-            "passes": 1,
-            "pr": 12801
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md": {
-            "at": "2026-03-28T08:18:21Z",
-            "hash": "10d5c38ac748a992e4619c4042a5ac685b009b3f",
-            "passes": 1,
-            "pr": 11631
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md": {
-            "at": "2026-03-28T08:18:21Z",
-            "hash": "aa4bc86ba1d820a999ff48479bc7af02bc524485",
-            "passes": 1,
-            "pr": 11631
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/vectorize.md": {
-            "at": "2026-03-28T08:18:21Z",
-            "hash": "c1d8339d4d9148d438f87b89220e85fa82e4c859",
-            "passes": 1,
-            "pr": 11631
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
-            "at": "2026-03-31T03:46:07Z",
-            "hash": "c0feb4212f761fd94cc86c49e72e8cbf0be9c42a",
-            "passes": 2,
-            "pr": 14541
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
-            "at": "2026-03-30T03:34:13Z",
-            "hash": "2cbb9c1c836f4b8fce6dbe5b982d8760a75922ce",
-            "passes": 1,
-            "pr": 13636
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-gotchas.md": {
-            "at": "2026-03-29T20:53:54Z",
-            "hash": "eb3c145850e0125035e13fd4bd424405fa4efb97",
-            "passes": 1,
-            "pr": 13291
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
-            "at": "2026-03-29T07:02:06Z",
-            "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
-            "passes": 1,
-            "pr": 12686
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workers-vpc.md": {
-            "at": "2026-03-28T08:57:49Z",
-            "hash": "fd8d3ba366abc324f0738e2e11fce322d92c654b",
-            "passes": 1,
-            "pr": 11677
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
-            "at": "2026-03-31T09:29:58Z",
-            "hash": "27842bda8a80f5fb937401fe5224129d2405ad97",
-            "passes": 2,
-            "pr": 14792
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workflows-gotchas.md": {
-            "at": "2026-03-29T21:43:20Z",
-            "hash": "f9b10b21adc0e823054085098ba86a6e8432ade1",
-            "passes": 1,
-            "pr": 13342
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workflows-patterns.md": {
-            "at": "2026-03-29T21:43:21Z",
-            "hash": "7b01531e7d09b10fc7ab3a1706498fd011b6bb1b",
-            "passes": 1,
-            "pr": 13342
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workflows.md": {
-            "at": "2026-03-29T21:43:21Z",
-            "hash": "5faeef07292125f8b45b6b29bc0b24d06d24c1f1",
-            "passes": 1,
-            "pr": 13342
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md": {
-            "at": "2026-04-01T23:23:38Z",
-            "hash": "d4f5f41aaab3a18b3ba154884526869bcf0b1efe",
-            "passes": 1,
-            "pr": 15335
-        },
-        ".agents/services/hosting/cloudflare.md": {
-            "at": "2026-03-28T16:00:49Z",
-            "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
-            "passes": 1,
-            "pr": 11992
-        },
-        ".agents/services/hosting/cloudron.md": {
-            "at": "2026-03-28T16:40:22Z",
-            "hash": "e9d97dc1a3a3dbe0bb45134f1148c74954fa577c",
-            "passes": 1,
-            "pr": 12046
-        },
-        ".agents/services/hosting/dns-providers.md": {
-            "at": "2026-03-30T03:33:45Z",
-            "hash": "979b0b76e50549adb87fc58efdd0b8d4d7cfed49",
-            "passes": 1,
-            "pr": 13668
-        },
-        ".agents/services/hosting/domain-purchasing.md": {
-            "at": "2026-03-29T10:47:23Z",
-            "hash": "90b1b455705be948e790ea947fafca8285ca29d9",
-            "passes": 1,
-            "pr": 12867
-        },
-        ".agents/services/hosting/hetzner.md": {
-            "at": "2026-03-29T07:02:07Z",
-            "hash": "34c50c3bfd8c86b684e922441da91443f8a22dfd",
-            "passes": 1,
-            "pr": 12687
-        },
-        ".agents/services/hosting/hostinger.md": {
-            "at": "2026-03-28T11:20:19Z",
-            "hash": "bdc3391799c0fb32ef11f6d610f48f7debae2194",
-            "passes": 1,
-            "pr": 11804
-        },
-        ".agents/services/hosting/local-hosting.md": {
-            "at": "2026-03-28T16:41:15Z",
-            "hash": "ac2a557901e0a9c39b034b664927c37847635345",
-            "passes": 1,
-            "pr": 12026
-        },
-        ".agents/services/hosting/proxmox-full-skill.md": {
-            "at": "2026-03-30T06:49:37Z",
-            "hash": "23bcf676fc5edd9dcfebc3fb07b0d4ed6cb61a19",
-            "passes": 1,
-            "pr": 13859
-        },
-        ".agents/services/hosting/webhosting.md": {
-            "at": "2026-03-28T03:54:32Z",
-            "hash": "fb3877648d049a414407d7f9e6beb747c2f92f1d",
-            "passes": 1,
-            "pr": 11352
-        },
-        ".agents/services/monitoring/langwatch.md": {
-            "at": "2026-03-28T16:00:51Z",
-            "hash": "a56ed459849e479aaed06d6ac42bf0d60a28adf9",
-            "passes": 1,
-            "pr": 11994
-        },
-        ".agents/services/monitoring/socket.md": {
-            "at": "2026-04-01T20:59:50Z",
-            "hash": "788506798f5a1eedd29bb5d84aaa61a758c1acd8",
-            "passes": 1,
-            "pr": 14896
-        },
-        ".agents/services/networking/netbird.md": {
-            "at": "2026-03-29T01:33:20Z",
-            "hash": "824fc7ee7cdc7e08351310bdb9f99dcf91a3848e",
-            "passes": 1,
-            "pr": 12453
-        },
-        ".agents/services/networking/tailscale.md": {
-            "at": "2026-03-29T02:36:04Z",
-            "hash": "e930b52dfd40905e93923b036c57b9ffc2bfa011",
-            "passes": 1,
-            "pr": 12461
-        },
-        ".agents/services/outreach/infraforge.md": {
-            "at": "2026-03-31T05:38:33Z",
-            "hash": "0d891dd02a90d75779370f3c62f2929df0bdcd31",
-            "passes": 1,
-            "pr": 14659
-        },
-        ".agents/services/outreach/instantly.md": {
-            "at": "2026-03-31T05:36:34Z",
-            "hash": "34502711d904e25bc38c009d87b329e818ea0c2c",
-            "passes": 3,
-            "pr": 14656
-        },
-        ".agents/services/outreach/manyreach.md": {
-            "at": "2026-03-29T07:02:27Z",
-            "hash": "94a3e08bcf4edafcd9654e8252a1a8851b004217",
-            "passes": 1,
-            "pr": 12581
-        },
-        ".agents/services/outreach/smartlead.md": {
-            "at": "2026-03-28T03:54:38Z",
-            "hash": "8171133da8154e590bca4a6baa8a1bbe05051e05",
-            "passes": 1,
-            "pr": 11357
-        },
-        ".agents/services/payments/procurement.md": {
-            "at": "2026-03-28T09:48:49Z",
-            "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
-            "passes": 1,
-            "pr": 11713
-        },
-        ".agents/services/payments/stripe.md": {
-            "at": "2026-03-29T03:15:16Z",
-            "hash": "6cbe509351f115869d196a09bc7031bb237d2a41",
-            "passes": 1,
-            "pr": 12511
-        },
-        ".agents/services/payments/superwall.md": {
-            "at": "2026-03-29T12:36:44Z",
-            "hash": "1c533274b85654214054f396d45e2b1d09425b85",
-            "passes": 1,
-            "pr": 12952
-        },
-        ".agents/tools/accessibility/accessibility-audit.md": {
-            "at": "2026-03-28T08:18:26Z",
-            "hash": "50607e3251694a312978efe741fd95eb6e47de55",
-            "passes": 1,
-            "pr": 11634
-        },
-        ".agents/tools/accessibility/accessibility.md": {
-            "at": "2026-04-03T02:21:04Z",
-            "hash": "6a9bb1b64297f0b7d6b06a258edc5a7b951c1f47",
-            "passes": 3,
-            "pr": 14053
-        },
-        ".agents/tools/ai-assistants/agno.md": {
-            "at": "2026-03-29T08:10:32Z",
-            "hash": "0e8f56a7ce9681124205e8492ed4878f1a9c73c3",
-            "passes": 1,
-            "pr": 12746
-        },
-        ".agents/tools/ai-assistants/capsolver.md": {
-            "at": "2026-03-29T12:36:41Z",
-            "hash": "934e330cfc0b1a30efe5bf139296ae882f868709",
-            "passes": 1,
-            "pr": 12953
-        },
-        ".agents/tools/ai-assistants/claude-code.md": {
-            "at": "2026-04-01T20:59:01Z",
-            "hash": "dd9666e19eb7e98df75856dd477ecf7ceebf147a",
-            "passes": 1,
-            "pr": 15204
-        },
-        ".agents/tools/ai-assistants/compare-models.md": {
-            "at": "2026-03-29T14:29:46Z",
-            "hash": "4ee54c0d4a2a76b5646c8d5bd3403a6bc744f649",
-            "passes": 1,
-            "pr": 13017
-        },
-        ".agents/tools/ai-assistants/datasets.md": {
-            "at": "2026-04-02T12:00:00Z",
-            "hash": "8b525467afaf93fea7539e9f47fabf2159254ae1",
-            "passes": 1,
-            "pr": 15336
-        },
-        ".agents/tools/ai-assistants/headless-dispatch.md": {
-            "at": "2026-03-29T03:15:46Z",
-            "hash": "00414f5554e8388ffa17859ef02d718061cd911a",
-            "passes": 1,
-            "pr": 12352
-        },
-        ".agents/tools/ai-assistants/models-README.md": {
-            "at": "2026-04-03T01:11:35Z",
-            "hash": "4e2a2bd51c40cb0ce1dd199625f4a2691a818317",
-            "passes": 2,
-            "pr": 15227
-        },
-        ".agents/tools/ai-assistants/models-sonnet.md": {
-            "at": "2026-04-02T23:13:26Z",
-            "hash": "64800a1556f7948083c746ea4bda589616a0f19c",
-            "passes": 2,
-            "pr": 14913
-        },
-        ".agents/tools/ai-assistants/openclaw.md": {
-            "at": "2026-03-28T14:15:40Z",
-            "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
-            "passes": 1,
-            "pr": 11901
-        },
-        ".agents/tools/ai-assistants/opencode-server.md": {
-            "at": "2026-03-28T03:53:56Z",
-            "hash": "15e90e96d742cfe07ffd4cb37c340157d5a8bb74",
-            "passes": 1,
-            "pr": 11345
-        },
-        ".agents/tools/ai-assistants/response-scoring.md": {
-            "at": "2026-03-29T15:50:37Z",
-            "hash": "33f943f8dc56e52eee464c193d4b0fce97d1305d",
-            "passes": 2,
-            "pr": 13072
-        },
-        ".agents/tools/ai-generation/comfy-cli.md": {
-            "at": "2026-03-27T21:25:22Z",
-            "hash": "cec6e1c63f0997e330608cc3610f5a582d7e4d29",
-            "passes": 2,
-            "pr": 11014
-        },
-        ".agents/tools/ai-orchestration/autogen.md": {
-            "at": "2026-03-30T02:54:16Z",
-            "hash": "590a04f8f8f9073b304f6538e550f335e08ffd62",
-            "passes": 1,
-            "pr": 13600
-        },
-        ".agents/tools/ai-orchestration/crewai.md": {
-            "at": "2026-03-28T02:50:59Z",
-            "hash": "e1ed08282945b0708a6840e1d2bb38d92c3d3698",
-            "passes": 1,
-            "pr": 11274
-        },
-        ".agents/tools/ai-orchestration/langflow.md": {
-            "at": "2026-03-30T06:49:09Z",
-            "hash": "8c8c05859cc60d2e341b6cd191075ec540e10c12",
-            "passes": 2,
-            "pr": 13930
-        },
-        ".agents/tools/ai-orchestration/openprose.md": {
-            "at": "2026-03-29T14:29:04Z",
-            "hash": "7d17737b91f8878839b3430a51676211744becce",
-            "passes": 1,
-            "pr": 13007
-        },
-        ".agents/tools/ai-orchestration/overview.md": {
-            "at": "2026-04-03T01:53:08Z",
-            "hash": "4e97ab8ea80342eabab4b326411f74eaeb88bba0",
-            "passes": 2,
-            "pr": 11793
-        },
-        ".agents/tools/ai-orchestration/packaging.md": {
-            "at": "2026-03-28T03:53:52Z",
-            "hash": "4cbea04181622677bff0bdbb611cdd03a3401484",
-            "passes": 1,
-            "pr": 11296
-        },
-        ".agents/tools/animation/animejs.md": {
-            "at": "2026-03-29T08:11:02Z",
-            "hash": "3d011c9aa6ae720f1ed6de08663bf78f589237ec",
-            "passes": 1,
-            "pr": 12745
-        },
-        ".agents/tools/api/better-auth.md": {
-            "at": "2026-03-28T08:58:32Z",
-            "hash": "8494627274fa59f222b8c19aeb61280ded29e8ec",
-            "passes": 1,
-            "pr": 11566
-        },
-        ".agents/tools/api/drizzle.md": {
-            "at": "2026-03-30T04:52:00Z",
-            "hash": "51387eb5d4ff32cccf8469a6ef066f6c2b22fd90",
-            "passes": 2,
-            "pr": 13718
-        },
-        ".agents/tools/api/hono.md": {
-            "at": "2026-03-29T07:02:20Z",
-            "hash": "bf496281a1542c460ea880f936ec4d92dd928900",
-            "passes": 1,
-            "pr": 12607
-        },
-        ".agents/tools/api/vercel-ai-sdk.md": {
-            "at": "2026-03-28T11:20:15Z",
-            "hash": "e0a51bc87d3615a985b527cfe0265571672e2095",
-            "passes": 1,
-            "pr": 11792
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill/cheatsheet.md": {
-            "at": "2026-03-28T05:10:19Z",
-            "hash": "7622759c028bec7b85f445a88ab175f13b055133",
-            "passes": 1,
-            "pr": 11393
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md": {
-            "at": "2026-03-30T04:51:54Z",
-            "hash": "2f665556f02ff70ca7d40efdaa6c45150c3384a1",
-            "passes": 2,
-            "pr": 13768
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-strategic.md": {
-            "at": "2026-03-28T11:20:20Z",
-            "hash": "61e87ef7f501310f73fbe54da1d9e0a76a38abae",
-            "passes": 1,
-            "pr": 11805
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-tactical.md": {
-            "at": "2026-03-28T11:20:40Z",
-            "hash": "a53f3400bd5c9142c7f9b186523697b16c1a28e2",
-            "passes": 1,
-            "pr": 11734
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
-            "at": "2026-03-30T06:49:15Z",
-            "hash": "0cf36c2647ee174ec7e68e1e9119bab9e7d6f644",
-            "passes": 2,
-            "pr": 13931
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md": {
-            "at": "2026-03-28T21:58:55Z",
-            "hash": "2fde1ee5df8c1bbde677a3198fe1c39df860a6ba",
-            "passes": 1,
-            "pr": 12236
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill/testing.md": {
-            "at": "2026-03-28T13:38:11Z",
-            "hash": "2316ee0b050453056ecc075e712e88b436dd3dd9",
-            "passes": 1,
-            "pr": 11790
-        },
-        ".agents/tools/architecture/feature-slicing-skill.md": {
-            "at": "2026-03-27T21:25:18Z",
-            "hash": "bb7e28e69e417b4701428fbc2ec0d0608f09e3e2",
-            "passes": 2,
-            "pr": 11010
-        },
-        ".agents/tools/architecture/feature-slicing-skill/cheatsheet.md": {
-            "at": "2026-03-27T21:25:23Z",
-            "hash": "b244fb8417fc27f0de33c83c86092f5bebd736f3",
-            "passes": 1,
-            "pr": 11018
-        },
-        ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
-            "at": "2026-03-28T20:16:39Z",
-            "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
-            "passes": 1,
-            "pr": 12160
-        },
-        ".agents/tools/architecture/feature-slicing-skill/layers.md": {
-            "at": "2026-03-28T08:18:16Z",
-            "hash": "aa5a10592a8a28db7e01ce256df9e7aa7ab57c76",
-            "passes": 1,
-            "pr": 11537
-        },
-        ".agents/tools/architecture/feature-slicing-skill/migration.md": {
-            "at": "2026-03-30T00:32:19Z",
-            "hash": "8adaf46d6bf7a4a77a17c6578948026e2a64e809",
-            "passes": 2,
-            "pr": 13466
-        },
-        ".agents/tools/architecture/feature-slicing-skill/nextjs.md": {
-            "at": "2026-03-28T06:59:34Z",
-            "hash": "0fd2c402556f4d6804ce1a61eeaaaa9c3cecd541",
-            "passes": 1,
-            "pr": 11437
-        },
-        ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
-            "at": "2026-03-28T16:40:13Z",
-            "hash": "52069355367fb596967a8aef0bb6ad7f8e9861c3",
-            "passes": 1,
-            "pr": 12030
-        },
-        ".agents/tools/automation/cron-agent.md": {
-            "at": "2026-03-28T20:56:11Z",
-            "hash": "fbf1c6bc76acc1436d3da1b0b34296be5193de5a",
-            "passes": 1,
-            "pr": 12184
-        },
-        ".agents/tools/automation/mac.md": {
-            "at": "2026-04-01T20:58:52Z",
-            "hash": "1dc19ae4b63343bb6f8a397a6f7e824655e2f986",
-            "passes": 1,
-            "pr": 15253
-        },
-        ".agents/tools/automation/macos-automator.md": {
-            "at": "2026-03-27T21:25:19Z",
-            "hash": "f8771a0d1548af0fbdd76f1944d50ce6b1107f13",
-            "passes": 1,
-            "pr": 11011
-        },
-        ".agents/tools/browser/anti-detect-browser.md": {
-            "at": "2026-03-27T21:25:25Z",
-            "hash": "647081565083b90f27fdce7d25dea9e153fc64a4",
-            "passes": 1,
-            "pr": 11017
-        },
-        ".agents/tools/browser/browser-automation.md": {
-            "at": "2026-03-30T04:51:56Z",
-            "hash": "52c1d946fb9062a82e798821f056e58d93ab321f",
-            "passes": 2,
-            "pr": 13719
-        },
-        ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
-            "at": "2026-04-01T12:00:00Z",
-            "hash": "8d79ff6b9aa02ab04c5f72924b3a7798ee561893",
-            "passes": 1,
-            "pr": 15176
-        },
-        ".agents/tools/browser/browser-profiles.md": {
-            "at": "2026-03-29T07:03:05Z",
-            "hash": "2a2c771f4ff870ad450a92a0f9ad950f3f16e3cb",
-            "passes": 1,
-            "pr": 12501
-        },
-        ".agents/tools/browser/browser-qa.md": {
-            "at": "2026-03-28T20:17:06Z",
-            "hash": "629aa3a1df673d6e5df7310d173da5d3938aa04e",
-            "passes": 1,
-            "pr": 12171
-        },
-        ".agents/tools/browser/browser-use.md": {
-            "at": "2026-03-29T07:03:02Z",
-            "hash": "96d5278ed393a25379da0c21d04db2269219cbf9",
-            "passes": 1,
-            "pr": 12616
-        },
-        ".agents/tools/browser/chrome-devtools.md": {
-            "at": "2026-03-28T22:39:23Z",
-            "hash": "13576e2127eccb1c8555a5b12660265ac4ebd8aa",
-            "passes": 1,
-            "pr": 12310
-        },
-        ".agents/tools/browser/chrome-webstore-release.md": {
-            "at": "2026-03-30T06:49:23Z",
-            "hash": "7d789fec3b99cc63f2dc9033a798921b9f7f2233",
-            "passes": 1,
-            "pr": 13942
-        },
-        ".agents/tools/browser/crawl4ai-integration.md": {
-            "at": "2026-04-02T19:17:13Z",
-            "hash": "6839d1c4bd81f04a3f75f075d43d233cbebfdb3e",
-            "passes": 2,
-            "pr": 15463
-        },
-        ".agents/tools/browser/crawl4ai-resources.md": {
-            "at": "2026-03-28T13:37:22Z",
-            "hash": "3b91d1b3383285e813ef8eed5303e3a6fa8fa99d",
-            "passes": 1,
-            "pr": 11858
-        },
-        ".agents/tools/browser/crawl4ai.md": {
-            "at": "2026-03-28T08:17:51Z",
-            "hash": "967373980ca56ec85cb795eb9426efb91ff23ddb",
-            "passes": 1,
-            "pr": 11599
-        },
-        ".agents/tools/browser/curl-copy.md": {
-            "at": "2026-04-01T21:56:13Z",
-            "hash": "5fb61c717fec1b0cbd8a594f7782b0db73cc2eca",
-            "passes": 2,
-            "pr": null
-        },
-        ".agents/tools/browser/dev-browser.md": {
-            "at": "2026-03-28T15:30:31Z",
-            "hash": "5215652277b228f27d7eddb0cce1a05df09e4a75",
-            "passes": 2,
-            "pr": 11921
-        },
-        ".agents/tools/browser/extension-dev.md": {
-            "at": "2026-03-29T22:09:34Z",
-            "hash": "5d6ac2671414bfdce4481294fce9019711d28c01",
-            "passes": 1,
-            "pr": 13330
-        },
-        ".agents/tools/browser/extension-dev/development.md": {
-            "at": "2026-03-30T04:52:04Z",
-            "hash": "80547436b58e3fd8fb2ce9ab44cfaecedcb32ec3",
-            "passes": 1,
-            "pr": 13722
-        },
-        ".agents/tools/browser/extension-dev/publishing.md": {
-            "at": "2026-03-29T11:20:06Z",
-            "hash": "7fe8e877846c0dc155d639a1b5dd214e47c7e499",
-            "passes": 1,
-            "pr": 12884
-        },
-        ".agents/tools/browser/extension-dev/testing.md": {
-            "at": "2026-03-30T04:51:57Z",
-            "hash": "57d5dc456ab9a6e1d10416777117b96a09cc4f14",
-            "passes": 1,
-            "pr": 13717
-        },
-        ".agents/tools/browser/fingerprint-profiles.md": {
-            "at": "2026-03-28T17:30:27Z",
-            "hash": "d910625e173f65063d64d51ca549494b97a2ba87",
-            "passes": 1,
-            "pr": 12070
-        },
-        ".agents/tools/browser/pagespeed.md": {
-            "at": "2026-03-28T03:53:49Z",
-            "hash": "55b132de0f4ff15dd72cec557bf042cd56b93fec",
-            "passes": 1,
-            "pr": 11295
-        },
-        ".agents/tools/browser/peekaboo.md": {
-            "at": "2026-03-28T03:54:17Z",
-            "hash": "294d232e9625b8a855f17cbea4498a4881a6b0bc",
-            "passes": 1,
-            "pr": 11348
-        },
-        ".agents/tools/browser/playwright-cli.md": {
-            "at": "2026-03-28T11:20:22Z",
-            "hash": "978be4b5b3043cfee751f9c966ba27ddd7fe5182",
-            "passes": 1,
-            "pr": 11802
-        },
-        ".agents/tools/browser/playwriter.md": {
-            "at": "2026-03-29T03:31:38Z",
-            "hash": "98bfa1b0dde9a405a0f3a07aa1ae3eaadc42801a",
-            "passes": 1,
-            "pr": 12516
-        },
-        ".agents/tools/browser/proxy-integration.md": {
-            "at": "2026-03-29T15:08:41Z",
-            "hash": "46806f6e0dcec4831dc62abb84c2f5f96326c102",
-            "passes": 1,
-            "pr": 13032
-        },
-        ".agents/tools/browser/skyvern.md": {
-            "at": "2026-03-28T17:11:10Z",
-            "hash": "1f2933d4cdf35fd9696301a5743ae2e550a31eb0",
-            "passes": 1,
-            "pr": 12055
-        },
-        ".agents/tools/browser/stagehand-examples.md": {
-            "at": "2026-03-28T14:15:24Z",
-            "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
-            "passes": 1,
-            "pr": 11899
-        },
-        ".agents/tools/browser/stagehand-python.md": {
-            "at": "2026-03-30T02:31:00Z",
-            "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
-            "passes": 1,
-            "pr": 13486
-        },
-        ".agents/tools/browser/stagehand.md": {
-            "at": "2026-03-29T03:15:18Z",
-            "hash": "3702284e297e642ee7e2bb0c65470886fc7c0ffb",
-            "passes": 1,
-            "pr": 12513
-        },
-        ".agents/tools/browser/sweet-cookie.md": {
-            "at": "2026-03-29T22:09:35Z",
-            "hash": "763a36ee928e5c54bafe10a5659c75c4c73f42df",
-            "passes": 1,
-            "pr": 13328
-        },
-        ".agents/tools/browser/watercrawl.md": {
-            "at": "2026-03-28T19:15:30Z",
-            "hash": "c3fc2a3c5ee117daba5dfbfae490dfb406b9e711",
-            "passes": 1,
-            "pr": 12117
-        },
-        ".agents/tools/build-agent/add-skill.md": {
-            "at": "2026-03-29T01:03:17Z",
-            "hash": "36065ac3559aa2e929cbb858c8220961454f9dd9",
-            "passes": 1,
-            "pr": 12376
-        },
-        ".agents/tools/build-agent/build-agent.md": {
-            "at": "2026-03-29T14:29:12Z",
-            "hash": "59fa5cde2d2c1b113be43ecdb1a6d8978d3d4f69",
-            "passes": 1,
-            "pr": 12957
-        },
-        ".agents/tools/build-mcp/aidevops-plugin.md": {
-            "at": "2026-04-02T14:42:10Z",
-            "hash": "1663a5f374022feab8fbd51387acaf2f02d0f2c8",
-            "passes": 3,
-            "pr": 14775
-        },
-        ".agents/tools/build-mcp/api-wrapper.md": {
-            "at": "2026-03-28T02:51:01Z",
-            "hash": "68b6075506f6dc1153fec6d5aa78c05d213b0b73",
-            "passes": 1,
-            "pr": 11276
-        },
-        ".agents/tools/build-mcp/api-wrapper/patterns.md": {
-            "at": "2026-03-28T02:51:01Z",
-            "hash": "5aa65e858b380b38b44e647545eda3f1450543b2",
-            "passes": 1,
-            "pr": 11276
-        },
-        ".agents/tools/build-mcp/build-mcp.md": {
-            "at": "2026-03-28T13:37:27Z",
-            "hash": "9b3ca67c49dd5bf0af66b01061561502620de8b3",
-            "passes": 1,
-            "pr": 11844
-        },
-        ".agents/tools/build-mcp/deployment.md": {
-            "at": "2026-03-28T22:39:22Z",
-            "hash": "0229a7490f42dcf4f3b8c0958fefd7ff53f3b8a2",
-            "passes": 1,
-            "pr": 12311
-        },
-        ".agents/tools/build-mcp/server-patterns.md": {
-            "at": "2026-03-28T10:27:33Z",
-            "hash": "c0e5bf0399f60ae53b3b09082ac6ced4debb8c76",
-            "passes": 1,
-            "pr": 11679
-        },
-        ".agents/tools/build-mcp/transports.md": {
-            "at": "2026-03-29T01:04:08Z",
-            "hash": "733acaf8682f80a53cd3c2a996c0571adf7ac018",
-            "passes": 1,
-            "pr": 12394
-        },
-        ".agents/tools/code-review/best-practices.md": {
-            "at": "2026-03-28T13:38:46Z",
-            "hash": "b8f93fd83e04dc301d838178a7b7523e35382166",
-            "passes": 1,
-            "pr": 11771
-        },
-        ".agents/tools/code-review/codacy.md": {
-            "at": "2026-03-29T22:09:31Z",
-            "hash": "3f41e7f2f15e10bf934568ea6ff485cd64ce88c3",
-            "passes": 1,
-            "pr": 13314
-        },
-        ".agents/tools/code-review/code-simplifier.md": {
-            "at": "2026-04-02T21:58:07Z",
-            "hash": "64ff2a38d1ed0d234fb19fba2a9a6c5117ef7ce9",
-            "passes": 4,
-            "pr": null
-        },
-        ".agents/tools/code-review/code-standards.md": {
-            "at": "2026-03-28T15:30:22Z",
-            "hash": "88d5b9dc281a4557707da37dee72529d600faaf8",
-            "passes": 1,
-            "pr": 11944
-        },
-        ".agents/tools/code-review/coderabbit.md": {
-            "at": "2026-03-29T07:02:31Z",
-            "hash": "3e37a12db3473bf11b36f10e75ede64bb2494e1b",
-            "passes": 1,
-            "pr": 12589
-        },
-        ".agents/tools/code-review/qlty.md": {
-            "at": "2026-03-28T18:36:46Z",
-            "hash": "3c3fef1897ddb0b0bb88a35205dfd4d6f715db13",
-            "passes": 1,
-            "pr": 12114
-        },
-        ".agents/tools/code-review/runtime-patterns.md": {
-            "at": "2026-03-28T13:38:47Z",
-            "hash": "06e2affe5aaa285c3139fde0d808dc89c0140e31",
-            "passes": 1,
-            "pr": 11771
-        },
-        ".agents/tools/code-review/secretlint.md": {
-            "at": "2026-03-28T16:00:52Z",
-            "hash": "54a79997b8c268d6b3942204a8b6e23a251bcfe3",
-            "passes": 1,
-            "pr": 11991
-        },
-        ".agents/tools/code-review/security-analysis.md": {
-            "at": "2026-03-30T00:32:18Z",
-            "hash": "9d67a5c1a7278408c78bd6f559e1d43c61040b2e",
-            "passes": 2,
-            "pr": 13467
-        },
-        ".agents/tools/code-review/security-audit.md": {
-            "at": "2026-03-28T17:11:18Z",
-            "hash": "bed16a626f218a4a0045edaae30edfa52616f72c",
-            "passes": 1,
-            "pr": 12029
-        },
-        ".agents/tools/code-review/snyk.md": {
-            "at": "2026-03-27T21:25:26Z",
-            "hash": "e248df7d21db7a21cef8b1e16e1e96f361e3e487",
-            "passes": 1,
-            "pr": 11013
-        },
-        ".agents/tools/containers/remote-dispatch.md": {
-            "at": "2026-03-30T04:52:23Z",
-            "hash": "e6936f346e4acde6d0d596c5295e7864fbea5ede",
-            "passes": 2,
-            "pr": 13733
-        },
-        ".agents/tools/context/augment-context-engine.md": {
-            "at": "2026-03-28T16:40:32Z",
-            "hash": "bbae0554351a40b90c0df31e139c6391601f3e2b",
-            "passes": 1,
-            "pr": 12015
-        },
-        ".agents/tools/context/context-builder.md": {
-            "at": "2026-03-29T20:54:03Z",
-            "hash": "27fb0c83ee803a7eebb4ace6202875b0a844786b",
-            "passes": 1,
-            "pr": 13297
-        },
-        ".agents/tools/context/context-guardrails.md": {
-            "at": "2026-03-30T06:49:16Z",
-            "hash": "35328fa309512f8dc6c77afee69bd1f6068b9e45",
-            "passes": 1,
-            "pr": 13956
-        },
-        ".agents/tools/context/context7.md": {
-            "at": "2026-03-28T20:56:05Z",
-            "hash": "1d98876794a7dc00b2cd2126492a54302f051af8",
-            "passes": 1,
-            "pr": 12182
-        },
-        ".agents/tools/context/dspy.md": {
-            "at": "2026-03-29T20:53:49Z",
-            "hash": "a452d6023063a0eebf04141ae94d61a0867830da",
-            "passes": 1,
-            "pr": 13289
-        },
-        ".agents/tools/context/github-search.md": {
-            "at": "2026-03-29T16:34:35Z",
-            "hash": "526e968501aef58e8e7676ede7ab1396404a32c5",
-            "passes": 1,
-            "pr": 13106
-        },
-        ".agents/tools/context/mcp-discovery.md": {
-            "at": "2026-03-28T03:53:59Z",
-            "hash": "b5851d90484fe52e39f87e3c7af8692778986208",
-            "passes": 1,
-            "pr": 11338
-        },
-        ".agents/tools/context/model-routing.md": {
-            "at": "2026-03-29T22:09:44Z",
-            "hash": "b01bb6dd0d6eda73fa3e19439bb36df2f6d0f15f",
-            "passes": 2,
-            "pr": 13255
-        },
-        ".agents/tools/context/prompt-optimization.md": {
-            "at": "2026-03-29T08:10:39Z",
-            "hash": "94abbde385ccf494358e17a79a32fdc72d4adb58",
-            "passes": 1,
-            "pr": 12749
-        },
-        ".agents/tools/conversion/mineru.md": {
-            "at": "2026-03-28T16:40:36Z",
-            "hash": "beeb4a49df5e2a8ea91da9100ae2ba8887cf6b3d",
-            "passes": 1,
-            "pr": 12012
-        },
-        ".agents/tools/conversion/pandoc.md": {
-            "at": "2026-03-28T08:17:47Z",
-            "hash": "557667b032774727658d22f6b1c5392ec4a83660",
-            "passes": 1,
-            "pr": 11595
-        },
-        ".agents/tools/credentials/api-key-setup.md": {
-            "at": "2026-03-29T20:53:50Z",
-            "hash": "3fe770105e7b4c6edbff6f572b5189e5c2a7ba17",
-            "passes": 1,
-            "pr": 13279
-        },
-        ".agents/tools/credentials/bitwarden.md": {
-            "at": "2026-04-02T04:56:56Z",
-            "hash": "808ffa447534e25dd4090033275c4861a8612f2c",
-            "passes": 1,
-            "pr": 15468
-        },
-        ".agents/tools/credentials/environment-variables.md": {
-            "at": "2026-03-29T08:10:40Z",
-            "hash": "4a7ee0834fefdbf424af90c68648ad35716559c7",
-            "passes": 1,
-            "pr": 12751
-        },
-        ".agents/tools/credentials/gocryptfs.md": {
-            "at": "2026-03-28T11:20:36Z",
-            "hash": "8e128a21d4783c5499f073213aee1a20491893d5",
-            "passes": 1,
-            "pr": 11730
-        },
-        ".agents/tools/credentials/gopass.md": {
-            "at": "2026-03-27T21:25:05Z",
-            "hash": "a59a0077d4d56694894c8cadef6b9c3a294dede0",
-            "passes": 1,
-            "pr": 11021
-        },
-        ".agents/tools/credentials/multi-tenant.md": {
-            "at": "2026-03-27T21:25:16Z",
-            "hash": "efa55dc5b3f2f5222982c1c9f0214ad1e2601624",
-            "passes": 1,
-            "pr": 11008
-        },
-        ".agents/tools/credentials/psst.md": {
-            "at": "2026-03-31T06:15:51Z",
-            "hash": "73a231518b35816ca652d0a2aa130a21dd2b8f1d",
-            "passes": 2,
-            "pr": 14687
-        },
-        ".agents/tools/credentials/sops.md": {
-            "at": "2026-03-28T08:58:29Z",
-            "hash": "927fea51df6b5ed15ee41b1473f26bf7b526ca38",
-            "passes": 1,
-            "pr": 11560
-        },
-        ".agents/tools/credentials/vaultwarden.md": {
-            "at": "2026-03-29T12:36:43Z",
-            "hash": "49a473adf85c8382799bc059d99c1693cbea98a9",
-            "passes": 1,
-            "pr": 12951
-        },
-        ".agents/tools/data-extraction/outscraper.md": {
-            "at": "2026-03-28T16:41:16Z",
-            "hash": "a3e3c1fee3571f9cfe07e4f90d47e3aa0c2c758a",
-            "passes": 1,
-            "pr": 12021
-        },
-        ".agents/tools/database/pglite-local-first.md": {
-            "at": "2026-03-28T15:30:29Z",
-            "hash": "57487b7d3c5e896eaebeeccd458d76e65cae5b8d",
-            "passes": 1,
-            "pr": 11920
-        },
-        ".agents/tools/database/vector-search.md": {
-            "at": "2026-03-28T03:54:19Z",
-            "hash": "d365046c212da54c3ab0ede8217cce083de484c5",
-            "passes": 1,
-            "pr": 11351
-        },
-        ".agents/tools/database/vector-search/per-tenant-rag.md": {
-            "at": "2026-03-28T06:40:00Z",
-            "hash": "9c0a46c72bbf38115155d5214f0256365a03260b",
-            "passes": 1,
-            "pr": 11417
-        },
-        ".agents/tools/database/vector-search/zvec.md": {
-            "at": "2026-03-28T08:17:41Z",
-            "hash": "1929000365507621f52d563ad2b63e9f51feab8d",
-            "passes": 1,
-            "pr": 11570
-        },
-        ".agents/tools/deployment/cloudron-app-packaging-skill.md": {
-            "at": "2026-04-02T20:39:36Z",
-            "hash": "b0b18eb482f60246c0d1961494667f4f06c3a711",
-            "passes": 2,
-            "pr": 14880
-        },
-        ".agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md": {
-            "at": "2026-03-29T10:18:21Z",
-            "hash": "0afd51341e71da8060a8a9e2759bf6629a430093",
-            "passes": 1,
-            "pr": 12844
-        },
-        ".agents/tools/deployment/cloudron-app-packaging.md": {
-            "at": "2026-03-28T03:54:01Z",
-            "hash": "a6ddd4af870f4445d96eb4bf3c2d109fcb9219b7",
-            "passes": 1,
-            "pr": 11344
-        },
-        ".agents/tools/deployment/cloudron-server-ops-skill.md": {
-            "at": "2026-03-30T03:33:52Z",
-            "hash": "254ad33e9ddc52578f62584070efe94ef28a6860",
-            "passes": 2,
-            "pr": 13678
-        },
-        ".agents/tools/deployment/coolify-cli.md": {
-            "at": "2026-03-30T04:52:05Z",
-            "hash": "bceeb18bd221b65e03b4fa7ec3633091a8ee57e2",
-            "passes": 1,
-            "pr": 13734
-        },
-        ".agents/tools/deployment/coolify-setup.md": {
-            "at": "2026-03-29T15:50:41Z",
-            "hash": "2c1d4944a61281731b12ea26d5aad0a44c69740b",
-            "passes": 2,
-            "pr": 13067
-        },
-        ".agents/tools/deployment/coolify.md": {
-            "at": "2026-03-29T08:10:34Z",
-            "hash": "c69569ccf737f434c5d2c4c031ab9fb87e3f6125",
-            "passes": 1,
-            "pr": 12748
-        },
-        ".agents/tools/deployment/daytona.md": {
-            "at": "2026-03-28T13:37:28Z",
-            "hash": "752d573096d1a59e09ee119494e907e2e17d34ee",
-            "passes": 1,
-            "pr": 11846
-        },
-        ".agents/tools/deployment/fly-io.md": {
-            "at": "2026-03-30T02:30:21Z",
-            "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
-            "passes": 1,
-            "pr": 13596
-        },
-        ".agents/tools/deployment/hosting-comparison.md": {
-            "at": "2026-03-29T07:02:09Z",
-            "hash": "d29068fa3678e9cf3c2d6709305d5d71e5488dcb",
-            "passes": 1,
-            "pr": 12661
-        },
-        ".agents/tools/deployment/uncloud.md": {
-            "at": "2026-03-28T09:17:40Z",
-            "hash": "f0efc54a4b03f1e5a1398d94d063d72218a8de21",
-            "passes": 1,
-            "pr": 11712
-        },
-        ".agents/tools/deployment/vercel.md": {
-            "at": "2026-03-28T08:58:54Z",
-            "hash": "c2084ec268e00720815607590f8bab4bc7082c53",
-            "passes": 1,
-            "pr": 11615
-        },
-        ".agents/tools/design/brand-identity.md": {
-            "at": "2026-03-29T16:31:32Z",
-            "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
-            "passes": 1,
-            "pr": 13093
-        },
-        ".agents/tools/design/design-inspiration.md": {
-            "at": "2026-03-29T08:10:43Z",
-            "hash": "c45174a87827d85931f259a2e60da60b030b9fef",
-            "passes": 1,
-            "pr": 12754
-        },
-        ".agents/tools/design/ui-ux-inspiration.md": {
-            "at": "2026-03-28T08:17:35Z",
-            "hash": "fb4a8985ec3089753355c7a13d0665c878034369",
-            "passes": 1,
-            "pr": 11590
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
-            "at": "2026-03-28T15:30:35Z",
-            "hash": "97a482f311bb9a1a99a103e7b77f815c8ce8af7e",
-            "passes": 1,
-            "pr": 11935
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/advanced.md": {
-            "at": "2026-03-29T11:51:51Z",
-            "hash": "66bd6cabafb5379b9b183e5c0721e35852080713",
-            "passes": 1,
-            "pr": 12922
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
-            "at": "2026-03-28T16:00:33Z",
-            "hash": "9fda0fe135c5d900b529cbf4c9b5095c72c9a79d",
-            "passes": 1,
-            "pr": 11987
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md": {
-            "at": "2026-03-29T21:43:04Z",
-            "hash": "79456bef17217d0052079264a0c95b59456d5385",
-            "passes": 1,
-            "pr": 13300
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/class-er.md": {
-            "at": "2026-03-28T08:17:42Z",
-            "hash": "e3929bc050f03d955e21543cfed73a4b69880579",
-            "passes": 1,
-            "pr": 11589
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/data-charts.md": {
-            "at": "2026-03-28T08:58:03Z",
-            "hash": "ea8a64811a9c35a4274183f1c0c215be8c2a6aec",
-            "passes": 1,
-            "pr": 11602
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md": {
-            "at": "2026-03-30T04:52:39Z",
-            "hash": "dd47fcc7b562ecb9f085d0d7394553810ecabc8c",
-            "passes": 1,
-            "pr": 13784
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/sequence.md": {
-            "at": "2026-03-28T05:10:17Z",
-            "hash": "162ba5164f7ffedc3b1d3497beabd56c6d58aaba",
-            "passes": 1,
-            "pr": 11392
-        },
-        ".agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md": {
-            "at": "2026-03-29T08:11:29Z",
-            "hash": "2fda89c67e49f210c5079578f56272001edd02d9",
-            "passes": 1,
-            "pr": 12755
-        },
-        ".agents/tools/document/docstrange.md": {
-            "at": "2026-03-29T16:34:31Z",
-            "hash": "3982c1885258882161976446bb94216d4e7df262",
-            "passes": 1,
-            "pr": 13102
-        },
-        ".agents/tools/document/document-creation.md": {
-            "at": "2026-03-28T08:17:34Z",
-            "hash": "245a303a923bd18c0adc820adb9620f12d636d2b",
-            "passes": 1,
-            "pr": 11592
-        },
-        ".agents/tools/document/document-extraction.md": {
-            "at": "2026-03-28T15:30:30Z",
-            "hash": "b0e790ef3e6481f532436eab39cac1d6ec92430b",
-            "passes": 1,
-            "pr": 11919
-        },
-        ".agents/tools/document/extraction-schemas.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "fa0ee1f8e92a38842d98674241507fd0cde43a81",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/01-design-principles.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "c557fde290bb52a65fa91d603c4366fdb0fcf3e7",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/02-purchase-invoice.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "d9c194618044c58a6f3a364bba869683957b26c1",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/03-expense-receipt.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "8c0553d204c9f8e111f7bb211d9b8e99a8fac453",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/04-credit-note.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "c58830493ee6a0ae1b3f77c6fb18a20db5e87ed4",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/05-sales-invoice.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "50c68e48c09eb85c30259361ceadadca01795e5e",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/06-generic-receipt.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "8cd493fef922d42decca280eaaec76c32de7f324",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/07-quickfile-mapping.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "329bb22bc68c98571c6bd075a6458573830bcd99",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/08-vat-handling.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "74ea1c15f941a48b3cb8d0a62dc8fa3ec590dd86",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/09-nominal-codes.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "7210b70a3f8072de3d50be138635dced20594d9d",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/10-classification.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "8822a182e225ee7360107f5e1938e4fc844670e3",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/11-pipeline-integration.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "377abccc10cb93b5f8b51010a48d6d947553b71c",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-schemas/12-validation.md": {
-            "at": "2026-03-28T08:58:45Z",
-            "hash": "85fb1862ed295cbba2a8c11ed8ccef35d25fc2c4",
-            "passes": 1,
-            "pr": 11601
-        },
-        ".agents/tools/document/extraction-workflow.md": {
-            "at": "2026-04-01T23:23:22Z",
-            "hash": "ff97788918db3fac18f34e7b0f3d18155d449e88",
-            "passes": 1,
-            "pr": 15350
-        },
-        ".agents/tools/git/authentication.md": {
-            "at": "2026-03-30T02:30:25Z",
-            "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
-            "passes": 1,
-            "pr": 13538
-        },
-        ".agents/tools/git/conflict-resolution.md": {
-            "at": "2026-03-28T14:15:35Z",
-            "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
-            "passes": 1,
-            "pr": 11909
-        },
-        ".agents/tools/git/gitea-cli.md": {
-            "at": "2026-03-29T07:02:58Z",
-            "hash": "9452ee8a8cf48269d5848e1d31384a3df0462ec5",
-            "passes": 1,
-            "pr": 12618
-        },
-        ".agents/tools/git/gitlab-cli.md": {
-            "at": "2026-03-29T03:15:01Z",
-            "hash": "de6952c2d9d3316c91c942921113892f89ddd42c",
-            "passes": 1,
-            "pr": 12498
-        },
-        ".agents/tools/git/lumen.md": {
-            "at": "2026-04-01T23:23:19Z",
-            "hash": "4a2b4339feef8da5578b029993d870a6416758b7",
-            "passes": 1,
-            "pr": 15327
-        },
-        ".agents/tools/git/opencode-github-security.md": {
-            "at": "2026-03-28T22:39:20Z",
-            "hash": "7614267ce5278cc0f8d3e46a9301f179a610b9f3",
-            "passes": 1,
-            "pr": 12309
-        },
-        ".agents/tools/git/opencode-github.md": {
-            "at": "2026-03-28T03:54:27Z",
-            "hash": "02c6d675ca2b756817bc639ec03d999e1f3ea58e",
-            "passes": 1,
-            "pr": 11349
-        },
-        ".agents/tools/git/opencode-gitlab.md": {
-            "at": "2026-03-29T20:54:06Z",
-            "hash": "dbbdec9a030f52229eab4d047431f4ed5b0de5ca",
-            "passes": 1,
-            "pr": 13295
-        },
-        ".agents/tools/git/worktrunk.md": {
-            "at": "2026-03-28T10:27:11Z",
-            "hash": "bafc956a55ed67b84dfc0722955434b85dd6202e",
-            "passes": 1,
-            "pr": 11760
-        },
-        ".agents/tools/infrastructure/cloud-gpu.md": {
-            "at": "2026-03-29T21:43:22Z",
-            "hash": "f2b2d82030ffec23c21ca82c2833ba2cbac2dcc9",
-            "passes": 1,
-            "pr": 13346
-        },
-        ".agents/tools/infrastructure/cloudflare-ai.md": {
-            "at": "2026-04-01T20:50:00Z",
-            "hash": "3896e5a3b0f6a86223b5def1d491061d8264b671",
-            "passes": 2,
-            "pr": 15091
-        },
-        ".agents/tools/infrastructure/fireworks.md": {
-            "at": "2026-03-28T11:52:26Z",
-            "hash": "6025fc8a3ce3cadba1f1d8d00c699c8fe970b015",
-            "passes": 1,
-            "pr": 11813
-        },
-        ".agents/tools/infrastructure/nearai.md": {
-            "at": "2026-03-29T10:47:24Z",
-            "hash": "c20f6f36a9c7c2fabc45e4c356d09b3589fb6a64",
-            "passes": 1,
-            "pr": 12869
-        },
-        ".agents/tools/infrastructure/nvidia-cloud.md": {
-            "at": "2026-03-29T08:49:20Z",
-            "hash": "3dfae170793fb08c63d93733cd5ad81760d651ee",
-            "passes": 1,
-            "pr": 12776
-        },
-        ".agents/tools/infrastructure/together.md": {
-            "at": "2026-03-29T17:15:24Z",
-            "hash": "cb2b6cf6c54db6f97c2bde70675f3c29b30b88fa",
-            "passes": 1,
-            "pr": 13113
-        },
-        ".agents/tools/local-models/local-models.md": {
-            "at": "2026-03-29T08:11:30Z",
-            "hash": "9809ec0871562ca709e8ef42cf6c3b67d24b69ce",
-            "passes": 1,
-            "pr": 12758
-        },
-        ".agents/tools/mcp-toolkit/mcporter.md": {
-            "at": "2026-03-28T14:16:17Z",
-            "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
-            "passes": 1,
-            "pr": 11906
-        },
-        ".agents/tools/mcp/cloudflare-code-mode.md": {
-            "at": "2026-03-29T23:54:08Z",
-            "hash": "57f7a7876d43b24c1a40f59332c004b5932adae1",
-            "passes": 1,
-            "pr": 13428
-        },
-        ".agents/tools/mobile/agent-device.md": {
-            "at": "2026-03-29T08:49:16Z",
-            "hash": "29bde4b26353446f6b35c132fcc1c01a80b71d4c",
-            "passes": 1,
-            "pr": 12788
-        },
-        ".agents/tools/mobile/app-dev-assets.md": {
-            "at": "2026-03-29T16:34:32Z",
-            "hash": "7c4254ecd409ec8aa9947d5ac9bb1043f89ee75c",
-            "passes": 1,
-            "pr": 13108
-        },
-        ".agents/tools/mobile/app-dev-backend.md": {
-            "at": "2026-03-29T20:54:10Z",
-            "hash": "1521ed7526fbc0fb399a1f5edf01adb4129a08f6",
-            "passes": 1,
-            "pr": 13293
-        },
-        ".agents/tools/mobile/app-dev-expo.md": {
-            "at": "2026-03-30T03:34:14Z",
-            "hash": "e0094f52acaa98cc6a2c7aa9aeae6321a204cb27",
-            "passes": 1,
-            "pr": 13609
-        },
-        ".agents/tools/mobile/app-dev-notifications.md": {
-            "at": "2026-03-29T16:34:38Z",
-            "hash": "c414024f2e98e68e7f70531095cc1abe49cceccd",
-            "passes": 1,
-            "pr": 13111
-        },
-        ".agents/tools/mobile/app-dev-publishing.md": {
-            "at": "2026-03-29T08:11:31Z",
-            "hash": "ceb75a07d39bcfe0be156773a92714fb3bebce23",
-            "passes": 2,
-            "pr": 12760
-        },
-        ".agents/tools/mobile/app-dev-swift.md": {
-            "at": "2026-03-29T07:03:03Z",
-            "hash": "15ec4fad109dcdce50f6ed4a70d117caff12f906",
-            "passes": 1,
-            "pr": 12506
-        },
-        ".agents/tools/mobile/app-dev-testing.md": {
-            "at": "2026-04-01T20:59:09Z",
-            "hash": "39d2e16ec10aee6ed51d5a9b586e20ac0ba4276a",
-            "passes": 1,
-            "pr": 15219
-        },
-        ".agents/tools/mobile/app-dev.md": {
-            "at": "2026-03-29T08:10:35Z",
-            "hash": "5fa80cfb5528478d449196a550ffb263ac4380e0",
-            "passes": 1,
-            "pr": 12752
-        },
-        ".agents/tools/mobile/app-store-connect.md": {
-            "at": "2026-03-29T07:02:17Z",
-            "hash": "55340aa49411b8c5faf342ecbd1284bd9b126390",
-            "passes": 1,
-            "pr": 12625
-        },
-        ".agents/tools/mobile/ios-simulator-mcp.md": {
-            "at": "2026-03-29T20:53:56Z",
-            "hash": "c671f21c21913d5bc3199aaaf1ad5ea389fa67e7",
-            "passes": 1,
-            "pr": 13299
-        },
-        ".agents/tools/mobile/maestro.md": {
-            "at": "2026-03-30T03:34:20Z",
-            "hash": "9cfba2015ca5bd40086f5d15c690910a0a3c6bfd",
-            "passes": 1,
-            "pr": 13525
-        },
-        ".agents/tools/mobile/minisim.md": {
-            "at": "2026-03-29T21:43:16Z",
-            "hash": "4e237b094b421f7ff8557426808fd3d6380b4ef1",
-            "passes": 1,
-            "pr": 13340
-        },
-        ".agents/tools/monorepo/turborepo.md": {
-            "at": "2026-03-30T06:49:45Z",
-            "hash": "f7bededd972af841de7b68b6169a00b890078d3e",
-            "passes": 2,
-            "pr": 13795
-        },
-        ".agents/tools/ocr/ocr-research.md": {
-            "at": "2026-03-28T13:37:30Z",
-            "hash": "667a0af0fe47f5c2c316520d13beb61f1f9d0b7f",
-            "passes": 1,
-            "pr": 11857
-        },
-        ".agents/tools/ocr/paddleocr.md": {
-            "at": "2026-03-30T06:49:51Z",
-            "hash": "7e0aaf06abd6c0d64ef0645a3cd58ac02b9e11f4",
-            "passes": 1,
-            "pr": 13765
-        },
-        ".agents/tools/opencode/opencode-anthropic-auth.md": {
-            "at": "2026-03-29T03:15:28Z",
-            "hash": "f05464c433b2b8e301af49ac5693cba5662ca6f7",
-            "passes": 1,
-            "pr": 12522
-        },
-        ".agents/tools/opencode/opencode.md": {
-            "at": "2026-03-29T11:20:16Z",
-            "hash": "b338bd4964d10e7780deddb27fc48d772a07be3b",
-            "passes": 1,
-            "pr": 12843
-        },
-        ".agents/tools/pdf/libpdf.md": {
-            "at": "2026-03-28T20:16:42Z",
-            "hash": "9d4d5fd4651f9132fb47d6467e53683fd7f0553b",
-            "passes": 1,
-            "pr": 12161
-        },
-        ".agents/tools/performance/performance.md": {
-            "at": "2026-03-28T16:00:21Z",
-            "hash": "478f1736c9c362f035765d45caddb4eebdec8071",
-            "passes": 1,
-            "pr": 11983
-        },
-        ".agents/tools/performance/webpagetest.md": {
-            "at": "2026-03-28T08:17:50Z",
-            "hash": "e0b3e8da23436e916aecd40d37bceeea48f99642",
-            "passes": 1,
-            "pr": 11594
-        },
-        ".agents/tools/programming/modern-javascript-skill.md": {
-            "at": "2026-04-01T20:59:25Z",
-            "hash": "3c3730959a3c618e3b3ed96d1ccd5eb95c2bfe3b",
-            "passes": 1,
-            "pr": 15131
-        },
-        ".agents/tools/programming/modern-javascript-skill/01-decision-trees.md": {
-            "at": "2026-04-01T20:59:25Z",
-            "hash": "80190196c391d4314e034455e46fe218d57d1c58",
-            "passes": 1,
-            "pr": 15131
-        },
-        ".agents/tools/programming/modern-javascript-skill/02-es-versions.md": {
-            "at": "2026-04-01T20:59:25Z",
-            "hash": "8c9215cc4697a3cd21125445386a8315acb42e0d",
-            "passes": 1,
-            "pr": 15131
-        },
-        ".agents/tools/programming/modern-javascript-skill/cheatsheet.md": {
-            "at": "2026-03-28T16:40:20Z",
-            "hash": "5043165087af14cf58963d7a76e48ceed463cb6d",
-            "passes": 1,
-            "pr": 12042
-        },
-        ".agents/tools/programming/modern-javascript-skill/composition.md": {
-            "at": "2026-03-28T03:53:07Z",
-            "hash": "fe9da3d05db78aac6b072235efe8b74f5c9fcf2b",
-            "passes": 1,
-            "pr": 11328
-        },
-        ".agents/tools/programming/modern-javascript-skill/concurrency.md": {
-            "at": "2026-03-29T22:50:16Z",
-            "hash": "ca3483bf9f49a475d7947fa68bb46f12426ef656",
-            "passes": 2,
-            "pr": 13349
-        },
-        ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
-            "at": "2026-03-28T05:50:55Z",
-            "hash": "b59a17a028d181e2f55c45e58c371ca999d9a2ee",
-            "passes": 1,
-            "pr": 11439
-        },
-        ".agents/tools/programming/modern-javascript-skill/es2022-es2023.md": {
-            "at": "2026-03-28T03:53:13Z",
-            "hash": "5e5dfb7e18557b8e26c5c48c090c8df94eda485c",
-            "passes": 1,
-            "pr": 11337
-        },
-        ".agents/tools/programming/modern-javascript-skill/es2024.md": {
-            "at": "2026-03-27T21:25:08Z",
-            "hash": "5ff178dfe9603a724792aaef45d63f4b33fce7ef",
-            "passes": 1,
-            "pr": 11002
-        },
-        ".agents/tools/programming/modern-javascript-skill/es2025.md": {
-            "at": "2026-03-28T21:58:57Z",
-            "hash": "e23026c24b61f06282834858aead51f63df3de4d",
-            "passes": 1,
-            "pr": 12234
-        },
-        ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
-            "at": "2026-03-29T07:02:28Z",
-            "hash": "a2b88a20fedbcbbf37624126551caf4b6a101400",
-            "passes": 1,
-            "pr": 12584
-        },
-        ".agents/tools/research/providers/crft-lookup.md": {
-            "at": "2026-03-30T03:34:28Z",
-            "hash": "70a64dd60d9a32431e5c36f75d0ad6aed1865c46",
-            "passes": 1,
-            "pr": 13542
-        },
-        ".agents/tools/research/providers/unbuilt.md": {
-            "at": "2026-03-29T12:36:25Z",
-            "hash": "24d4b4257014273b29b58f5e185f3320e798dad0",
-            "passes": 1,
-            "pr": 12945
-        },
-        ".agents/tools/research/providers/wappalyzer.md": {
-            "at": "2026-03-28T20:17:04Z",
-            "hash": "ef665188513a7db11f82af28c6b0440d2b3943d5",
-            "passes": 1,
-            "pr": 12115
-        },
-        ".agents/tools/research/tech-stack-lookup.md": {
-            "at": "2026-03-29T07:02:42Z",
-            "hash": "bb8bdd9ccd46c7cc0742a5ba1849bb47746c2110",
-            "passes": 1,
-            "pr": 12579
-        },
-        ".agents/tools/security/cdn-origin-ip.md": {
-            "at": "2026-03-29T20:53:57Z",
-            "hash": "0ffd8a94c87de9f75a5515cd4ad4e87ab4b1552b",
-            "passes": 1,
-            "pr": 13290
-        },
-        ".agents/tools/security/ip-reputation.md": {
-            "at": "2026-03-28T03:54:03Z",
-            "hash": "a1da2aa2f5e2f454f3c1dbcd3a7a819a72cd80dd",
-            "passes": 1,
-            "pr": 11342
-        },
-        ".agents/tools/security/opsec.md": {
-            "at": "2026-03-29T03:15:14Z",
-            "hash": "c0427c90ef2576abbb9115f920944e06ee023080",
-            "passes": 1,
-            "pr": 12507
-        },
-        ".agents/tools/security/privacy-filter.md": {
-            "at": "2026-03-28T16:41:02Z",
-            "hash": "20015ffb18e50ebb7071f1b6299b4404bdcd4071",
-            "passes": 1,
-            "pr": 12014
-        },
-        ".agents/tools/security/prompt-injection-defender.md": {
-            "at": "2026-03-28T17:11:06Z",
-            "hash": "0ee667b145d5e9aa8e6aefabf4ddc1c717cac0a0",
-            "passes": 1,
-            "pr": 12057
-        },
-        ".agents/tools/security/shannon.md": {
-            "at": "2026-03-28T16:41:03Z",
-            "hash": "a48914d21141559b0cf7677395979bd17f429b85",
-            "passes": 1,
-            "pr": 12016
-        },
-        ".agents/tools/security/tamper-evident-audit.md": {
-            "at": "2026-03-29T21:43:17Z",
-            "hash": "ef75d5914e0ae15e449ccd4480b0add3eda84c71",
-            "passes": 1,
-            "pr": 13316
-        },
-        ".agents/tools/task-management/beads.md": {
-            "at": "2026-03-29T09:39:21Z",
-            "hash": "f42ad2e963039fd53ee52d1443827cbe4f6158c0",
-            "passes": 1,
-            "pr": 12830
-        },
-        ".agents/tools/terminal/terminal-optimization.md": {
-            "at": "2026-03-29T03:15:29Z",
-            "hash": "f33e57108fd87d88906e414ae5caf4d169efb557",
-            "passes": 1,
-            "pr": 12526
-        },
-        ".agents/tools/ui/ai-chat-sidebar.md": {
-            "at": "2026-04-02T15:28:13Z",
-            "hash": "fc9db0532fa56a02b82ccc7692d25933098eb6d4",
-            "passes": 3,
-            "pr": 13958
-        },
-        ".agents/tools/ui/frontend-debugging.md": {
-            "at": "2026-03-28T03:54:06Z",
-            "hash": "272d16549c353500a19666d7ace227b34b2ae363",
-            "passes": 1,
-            "pr": 11340
-        },
-        ".agents/tools/ui/i18next.md": {
-            "at": "2026-03-28T10:27:25Z",
-            "hash": "ce750937b182da6a4a2cce512b141f16da789fcd",
-            "passes": 1,
-            "pr": 11710
-        },
-        ".agents/tools/ui/nextjs-layouts.md": {
-            "at": "2026-03-28T11:20:37Z",
-            "hash": "df90871ad91810f05326405fe711c4ff4be9460b",
-            "passes": 1,
-            "pr": 11732
-        },
-        ".agents/tools/ui/nothing-design-skill.md": {
-            "at": "2026-04-02T13:10:57Z",
-            "hash": "79354d8379744c33148bf864cad6dfd666796f48",
-            "passes": 1,
-            "pr": 15566
-        },
-        ".agents/tools/ui/nothing-design-skill/01-philosophy.md": {
-            "at": "2026-04-02T13:10:58Z",
-            "hash": "8bc354205fdf54beaf7d172ac0eee06a8b64e976",
-            "passes": 1,
-            "pr": 15566
-        },
-        ".agents/tools/ui/nothing-design-skill/02-craft-rules.md": {
-            "at": "2026-04-02T13:10:58Z",
-            "hash": "94d72d92e90419eada4260a7d0b996d620643f11",
-            "passes": 1,
-            "pr": 15566
-        },
-        ".agents/tools/ui/nothing-design-skill/03-anti-patterns.md": {
-            "at": "2026-04-02T13:10:58Z",
-            "hash": "916c5faa425da052f819788628e826d489ed10c9",
-            "passes": 1,
-            "pr": 15566
-        },
-        ".agents/tools/ui/nothing-design-skill/04-workflow.md": {
-            "at": "2026-04-02T13:10:58Z",
-            "hash": "3a1d2cbabb57f2dabfa60c4fcb1e9659729a53af",
-            "passes": 1,
-            "pr": 15566
-        },
-        ".agents/tools/ui/react-context.md": {
-            "at": "2026-03-30T06:49:50Z",
-            "hash": "dee0f2d9a70f699ee8e09bc3c855e84eabb9a806",
-            "passes": 1,
-            "pr": 13766
-        },
-        ".agents/tools/ui/react-email.md": {
-            "at": "2026-03-29T07:02:59Z",
-            "hash": "44be6e93a23aa087b4b70af9dc49a1c566c47e8c",
-            "passes": 1,
-            "pr": 12619
-        },
-        ".agents/tools/ui/shadcn.md": {
-            "at": "2026-03-29T07:02:41Z",
-            "hash": "b65c32526cb52d71c76cead493b7c71147417a78",
-            "passes": 1,
-            "pr": 12590
-        },
-        ".agents/tools/ui/tailwind-css.md": {
-            "at": "2026-03-29T07:02:43Z",
-            "hash": "1f3b2d4e3add5cecfe530b8db9addf411a9069fe",
-            "passes": 1,
-            "pr": 12576
-        },
-        ".agents/tools/ui/wxt.md": {
-            "at": "2026-03-28T13:37:50Z",
-            "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
-            "passes": 1,
-            "pr": 11870
-        },
-        ".agents/tools/verification/parallel-verify.md": {
-            "at": "2026-03-29T10:19:07Z",
-            "hash": "0abbe9f5d2f2082016fd851080ea1f9a84a03fe9",
-            "passes": 1,
-            "pr": 12849
-        },
-        ".agents/tools/video/remotion-3d.md": {
-            "at": "2026-04-01T20:59:48Z",
-            "hash": "054778cef20067cd0e02cbd7b049333f562e6e4a",
-            "passes": 1,
-            "pr": 14897
-        },
-        ".agents/tools/video/remotion-audio.md": {
-            "at": "2026-03-29T12:37:07Z",
-            "hash": "c5cce614253505277075e44f178650fab250bd7b",
-            "passes": 1,
-            "pr": 12942
-        },
-        ".agents/tools/video/remotion-compositions.md": {
-            "at": "2026-03-29T23:18:01Z",
-            "hash": "6b00afa2299a8d08eaacd114c67804f6d87614b1",
-            "passes": 1,
-            "pr": 13427
-        },
-        ".agents/tools/video/remotion-fonts.md": {
-            "at": "2026-04-02T14:42:45Z",
-            "hash": "2e12fc37c6a4f8397a9444f522ea88ef9d10285f",
-            "passes": 1,
-            "pr": 15615
-        },
-        ".agents/tools/video/remotion-gifs.md": {
-            "at": "2026-03-29T22:09:13Z",
-            "hash": "c87be7656e27afb4f5f23e41571f8428b21345c4",
-            "passes": 1,
-            "pr": 13322
-        },
-        ".agents/tools/video/remotion-images.md": {
-            "at": "2026-03-30T03:34:15Z",
-            "hash": "789b0f83404d30882f5f6b24317d4319f95dd107",
-            "passes": 1,
-            "pr": 13527
-        },
-        ".agents/tools/video/remotion-import-srt-captions.md": {
-            "at": "2026-04-02T04:56:51Z",
-            "hash": "75f8b0d089b9eaae8a7e08498af9b8c5f1ac4655",
-            "passes": 1,
-            "pr": 15490
-        },
-        ".agents/tools/video/remotion-lottie.md": {
-            "at": "2026-04-02T04:56:53Z",
-            "hash": "72d843e6717a28f61294372a6752cb8e9736fe6b",
-            "passes": 1,
-            "pr": 15525
-        },
-        ".agents/tools/video/remotion-measuring-text.md": {
-            "at": "2026-03-29T21:43:06Z",
-            "hash": "619d768e114ab99f64b37c93d1628ae5cb7d54a4",
-            "passes": 1,
-            "pr": 13315
-        },
-        ".agents/tools/video/remotion-timing.md": {
-            "at": "2026-04-01T20:59:53Z",
-            "hash": "6213ebf1e87a77cab44febc35ec0a3b10fd2db4c",
-            "passes": 1,
-            "pr": 14881
-        },
-        ".agents/tools/video/remotion-transitions.md": {
-            "at": "2026-04-02T20:04:38Z",
-            "hash": "01f1530e08f4e93364d68c8451ceeaecd548d511",
-            "passes": 2,
-            "pr": 14883
-        },
-        ".agents/tools/video/remotion.md": {
-            "at": "2026-03-28T15:30:25Z",
-            "hash": "e587ff6f81433c2bcc6b89ee139561849007d27e",
-            "passes": 1,
-            "pr": 11961
-        },
-        ".agents/tools/video/video-prompt-design.md": {
-            "at": "2026-03-28T17:30:25Z",
-            "hash": "ba533270f9fe5f9dab9fe60e3a4eef1420e2bd6c",
-            "passes": 1,
-            "pr": 12071
-        },
-        ".agents/tools/video/yt-dlp.md": {
-            "at": "2026-03-28T11:20:27Z",
-            "hash": "93855bd751f355d6ef75134ba3322330fcb7d596",
-            "passes": 1,
-            "pr": 11752
-        },
-        ".agents/tools/vision/image-editing.md": {
-            "at": "2026-03-29T21:43:18Z",
-            "hash": "1b91142d29e8ff6515be5a6208386de1fcaf383d",
-            "passes": 1,
-            "pr": 13236
-        },
-        ".agents/tools/vision/image-generation.md": {
-            "at": "2026-03-29T19:51:31Z",
-            "hash": "68fb24cbb02218008d86f1fb1381347f5ac1e533",
-            "passes": 1,
-            "pr": 13249
-        },
-        ".agents/tools/vision/image-understanding.md": {
-            "at": "2026-03-29T23:53:56Z",
-            "hash": "e8a08b674fb1c451c0b3d2ebdc2290f860817199",
-            "passes": 1,
-            "pr": 13458
-        },
-        ".agents/tools/vision/overview.md": {
-            "at": "2026-04-01T20:59:38Z",
-            "hash": "5abddf3f89fc529bd3119b8ae147961451728199",
-            "passes": 1,
-            "pr": 14932
-        },
-        ".agents/tools/voice/cloud-tts-apis.md": {
-            "at": "2026-03-28T08:18:23Z",
-            "hash": "0a7ff7444bf603ab6328a2248b32bd9faf422b02",
-            "passes": 1,
-            "pr": 11637
-        },
-        ".agents/tools/voice/cloud-voice-agents.md": {
-            "at": "2026-03-28T16:40:25Z",
-            "hash": "b389dcd17c677b3e21bc86397670fbf4d8a61b98",
-            "passes": 1,
-            "pr": 12005
-        },
-        ".agents/tools/voice/hyprwhspr.md": {
-            "at": "2026-03-29T16:34:36Z",
-            "hash": "cd50b6d85cbb4fe055191de5b27fd60418def072",
-            "passes": 1,
-            "pr": 13103
-        },
-        ".agents/tools/voice/ios-shortcut.md": {
-            "at": "2026-03-29T20:53:52Z",
-            "hash": "bf8f2ead853742819aa8ea972f3f39d7e38c58be",
-            "passes": 1,
-            "pr": 13286
-        },
-        ".agents/tools/voice/local-tts-models.md": {
-            "at": "2026-03-28T08:18:24Z",
-            "hash": "a2985fa793b132d716e99ec9f9dd6eaf8252485a",
-            "passes": 1,
-            "pr": 11637
-        },
-        ".agents/tools/voice/pipecat-opencode.md": {
-            "at": "2026-03-28T16:40:27Z",
-            "hash": "53d34b6a543b30dcbc6141ccea72d1364e7ae07d",
-            "passes": 1,
-            "pr": 12019
-        },
-        ".agents/tools/voice/qwen3-tts.md": {
-            "at": "2026-03-29T19:05:52Z",
-            "hash": "5e96cd787b4b8b6ae97d6f3113978c0b334e5484",
-            "passes": 1,
-            "pr": 13190
-        },
-        ".agents/tools/voice/speech-to-speech.md": {
-            "at": "2026-03-29T14:29:05Z",
-            "hash": "54c12a6e35c2fd9bdbc1476b98053f3fd40c5580",
-            "passes": 1,
-            "pr": 13005
-        },
-        ".agents/tools/voice/transcription.md": {
-            "at": "2026-03-29T07:02:26Z",
-            "hash": "8edf7782bc2f37c48ade8d3b58fd5c611dc8bda5",
-            "passes": 1,
-            "pr": 12638
-        },
-        ".agents/tools/voice/voice-models.md": {
-            "at": "2026-03-28T08:18:24Z",
-            "hash": "1048bd3b6ac334dea9f2685aef4b09642f318673",
-            "passes": 1,
-            "pr": 11637
-        },
-        ".agents/tools/voice/voiceink-shortcut.md": {
-            "at": "2026-03-28T16:40:39Z",
-            "hash": "1d7af55d9fbf66d24dcb4f1cbba443617f0c992c",
-            "passes": 1,
-            "pr": 12017
-        },
-        ".agents/tools/wordpress/localwp.md": {
-            "at": "2026-03-28T08:58:34Z",
-            "hash": "e2a3ea522c2f0a4739825f594f236c92f0eee0fa",
-            "passes": 1,
-            "pr": 11563
-        },
-        ".agents/tools/wordpress/mainwp.md": {
-            "at": "2026-03-28T11:20:17Z",
-            "hash": "e16169565844b28fa00ca62439a068eec8dd965f",
-            "passes": 1,
-            "pr": 11794
-        },
-        ".agents/tools/wordpress/scf.md": {
-            "at": "2026-03-28T16:40:07Z",
-            "hash": "4c62a3f4c5312a10699889660578437def83e31e",
-            "passes": 1,
-            "pr": 12035
-        },
-        ".agents/tools/wordpress/wp-admin.md": {
-            "at": "2026-03-28T08:17:43Z",
-            "hash": "a02a72943cc4820447f81c73216b0f095c3f64e5",
-            "passes": 1,
-            "pr": 11587
-        },
-        ".agents/tools/wordpress/wp-cli-reference.md": {
-            "at": "2026-03-28T08:17:43Z",
-            "hash": "0425ba4c94fd45b032e849987736bc4073970a7e",
-            "passes": 1,
-            "pr": 11587
-        },
-        ".agents/tools/wordpress/wp-dev.md": {
-            "at": "2026-03-29T22:09:16Z",
-            "hash": "c88f6e0f70e046ce19bf119077cef234636b2f4d",
-            "passes": 1,
-            "pr": 13341
-        },
-        ".agents/tools/wordpress/wp-preferred.md": {
-            "at": "2026-03-28T03:54:25Z",
-            "hash": "6664b61850bd5f84a8044f5dea501f4534b9a9d8",
-            "passes": 1,
-            "pr": 11353
-        },
-        ".agents/workflows/branch/bugfix.md": {
-            "at": "2026-04-02T04:56:46Z",
-            "hash": "236b78c40f92a6c1b7c36085c0ecdf1ea42058be",
-            "passes": 1,
-            "pr": 15517
-        },
-        ".agents/workflows/branch/hotfix.md": {
-            "at": "2026-04-01T20:59:04Z",
-            "hash": "e1c1f9099b46c798fe473a7c23ff01bfa8e26b70",
-            "passes": 1,
-            "pr": 15209
-        },
-        ".agents/workflows/bug-fixing.md": {
-            "at": "2026-03-29T16:34:52Z",
-            "hash": "40fa82a3220595ff946fdc60ec4a03b193032f58",
-            "passes": 1,
-            "pr": 13056
-        },
-        ".agents/workflows/code-audit-remote.md": {
-            "at": "2026-03-28T15:31:24Z",
-            "hash": "2702ee79b7d0f63a13b19d69171f937db3e37064",
-            "passes": 1,
-            "pr": 11825
-        },
-        ".agents/workflows/feature-development.md": {
-            "at": "2026-03-29T16:31:49Z",
-            "hash": "6b9311970a27d48d12002b62e59c9a6ac2087cc8",
-            "passes": 1,
-            "pr": 13065
-        },
-        ".agents/workflows/git-workflow.md": {
-            "at": "2026-03-29T08:49:32Z",
-            "hash": "1ea0b652ceda9126a403a89555e29a02b1c7e3bd",
-            "passes": 1,
-            "pr": 12777
-        },
-        ".agents/workflows/milestone-validation.md": {
-            "at": "2026-03-28T03:53:42Z",
-            "hash": "3e8c88a4d98e24993198b7a6cfc0c93b7825bd26",
-            "passes": 1,
-            "pr": 11286
-        },
-        ".agents/workflows/mission-orchestrator.md": {
-            "at": "2026-03-30T06:49:53Z",
-            "hash": "930d59836f65199231e8354401053a66b0637281",
-            "passes": 1,
-            "pr": 13841
-        },
-        ".agents/workflows/mission-skill-learning.md": {
-            "at": "2026-04-01T20:59:28Z",
-            "hash": "dd665af8ed215a57226bbb176cee5ee5a552ee65",
-            "passes": 1,
-            "pr": 14996
-        },
-        ".agents/workflows/multi-repo-workspace.md": {
-            "at": "2026-03-28T16:00:32Z",
-            "hash": "00ea218df67c941a8858e0da60f7c252c850db7a",
-            "passes": 1,
-            "pr": 11984
-        },
-        ".agents/workflows/plans.md": {
-            "at": "2026-03-28T21:58:58Z",
-            "hash": "d07529f81bc8ce92541f51393632bb2d04ce8fd4",
-            "passes": 1,
-            "pr": 12235
-        },
-        ".agents/workflows/postflight.md": {
-            "at": "2026-03-28T10:27:12Z",
-            "hash": "4e10936d7f2007c0c034ff2f2d8f8110bdf3d0dc",
-            "passes": 1,
-            "pr": 11739
-        },
-        ".agents/workflows/pr.md": {
-            "at": "2026-03-29T14:29:47Z",
-            "hash": "8f6584d97315d02aa4914a1f26165c57ff873479",
-            "passes": 1,
-            "pr": 13014
-        },
-        ".agents/workflows/preflight.md": {
-            "at": "2026-03-28T03:54:08Z",
-            "hash": "c4695943d5555314205b87bb88020fb62de14b63",
-            "passes": 1,
-            "pr": 11341
-        },
-        ".agents/workflows/ralph-loop.md": {
-            "at": "2026-03-28T11:20:12Z",
-            "hash": "552b1c4af3571c286790521b4cf26446ab3bb729",
-            "passes": 1,
-            "pr": 11789
-        },
-        ".agents/workflows/readme-create-update.md": {
-            "at": "2026-03-28T16:40:10Z",
-            "hash": "f54854963d94f3c9b4e15769c07b3c8c27db1c5a",
-            "passes": 1,
-            "pr": 12038
-        },
-        ".agents/workflows/release.md": {
-            "at": "2026-03-29T22:51:16Z",
-            "hash": "829b5d36d0073b1409bf14b5d094c18889989008",
-            "passes": 2,
-            "pr": 13318
-        },
-        ".agents/workflows/review-issue-pr.md": {
-            "at": "2026-03-28T22:39:25Z",
-            "hash": "14ac8f78bcfbb8ec23df3e37c021b7cd512c2f5b",
-            "passes": 1,
-            "pr": 12308
-        },
-        ".agents/workflows/session-manager.md": {
-            "at": "2026-03-29T23:53:41Z",
-            "hash": "e90fb5dbed96bd48a27404dce7d7b8d60d66a053",
-            "passes": 1,
-            "pr": 13443
-        },
-        ".agents/workflows/session-review.md": {
-            "at": "2026-03-29T11:19:53Z",
-            "hash": "0209719f0b5eb68905b4edbdc6bffe1fa8d8a54d",
-            "passes": 1,
-            "pr": 12889
-        },
-        ".agents/workflows/sql-migrations.md": {
-            "at": "2026-03-30T06:03:19Z",
-            "hash": "b33b92df6c10b12772797d8d75b314b69698af6e",
-            "passes": 1,
-            "pr": 13838
-        },
-        ".agents/workflows/ui-verification.md": {
-            "at": "2026-03-29T07:31:37Z",
-            "hash": "c59b154d588638a381fc14e85f435772cb88e31a",
-            "passes": 1,
-            "pr": 12705
-        },
-        ".agents/workflows/version-bump.md": {
-            "at": "2026-03-28T16:00:36Z",
-            "hash": "d4d8c82182a0c0fce47622e76556260a11747ee8",
-            "passes": 1,
-            "pr": 11986
-        },
-        ".agents/workflows/wiki-update.md": {
-            "at": "2026-03-30T02:30:16Z",
-            "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
-            "passes": 1,
-            "pr": 13594
-        },
-        "TODO.md": {
-            "at": "2026-04-03T01:53:21Z",
-            "hash": "d9184740229a6ef4e90a4309638f3fa4948d511b",
-            "passes": 6,
-            "pr": 15490
-        },
-        "aidevops.sh": {
-            "at": "2026-04-03T02:09:24Z",
-            "hash": "0562e51f78407a765633920ee1d05218053856ad",
-            "passes": 17,
-            "pr": 15470
-        },
-        "setup.sh": {
-            "at": "2026-04-03T02:09:24Z",
-            "hash": "b2f66c702293d628a153902fdfba321b0530478c",
-            "passes": 17,
-            "pr": 15470
-        },
-        "todo/tasks/GH#15363-brief.md": {
-            "at": "2026-04-02T13:10:59Z",
-            "hash": "ca6b623a0dc0d9ae763efd4dd88350ec183c45e9",
-            "passes": 1,
-            "pr": 15566
-        },
-        "todo/tasks/GH-14990-brief.md": {
-            "at": "2026-04-01T20:59:29Z",
-            "hash": "05e0636373c9b4574f9b289b7e75180281b462e4",
-            "passes": 1,
-            "pr": 14996
-        },
-        "todo/tasks/t15173-brief.md": {
-            "at": "2026-04-01T20:58:50Z",
-            "hash": "41ca6c208c2f6e8349d73a1ec55e0a26fd26f974",
-            "passes": 1,
-            "pr": 15257
-        },
-        "todo/tasks/t15364-brief.md": {
-            "at": "2026-04-02T13:11:00Z",
-            "hash": "1231c445c2ac173258f2a0b5baab685d32a3ab64",
-            "passes": 1,
-            "pr": 15566
-        },
-        "todo/tasks/t15448-brief.md": {
-            "at": "2026-04-02T04:56:58Z",
-            "hash": "b43fa2d5b0515af1ecbebbc502099ca5e6d0a9c2",
-            "passes": 1,
-            "pr": 15463
-        },
-        "todo/tasks/t15450-brief.md": {
-            "at": "2026-04-02T04:56:56Z",
-            "hash": "c0ba871cfce440d57c630e49cd6ba939bf27b261",
-            "passes": 1,
-            "pr": 15468
-        },
-        "todo/tasks/t15472-brief.md": {
-            "at": "2026-04-02T04:56:51Z",
-            "hash": "3de8a77d3743c3530c563e9aff8775c22a7edb4b",
-            "passes": 1,
-            "pr": 15490
-        },
-        "todo/tasks/t1727-brief.md": {
-            "at": "2026-04-02T03:11:00Z",
-            "hash": "55e4dea0078c0800d4db2336b942014ce25ffbfc",
-            "passes": 1,
-            "pr": 15431
-        },
-        "todo/tasks/t1737-brief.md": {
-            "at": "2026-04-01T20:59:15Z",
-            "hash": "e33e6f68fa6cdb89368aa5ec65bd3e1bc880ba67",
-            "passes": 1,
-            "pr": 15223
-        },
-        "todo/tasks/t2052-brief.md": {
-            "at": "2026-04-02T04:56:57Z",
-            "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
-            "passes": 1,
-            "pr": 15470
-        },
-        ".agents/aidevops/api-integrations.md": {
-            "hash": "9ed830efd42c0b7901229915ff9fe70d6f50fdac",
-            "at": "2026-04-02T21:19:50Z",
-            "pr": 0,
-            "passes": 2
-        },
-        ".agents/seo/seo-audit-skill/aeo-geo-patterns.md": {
-            "hash": "2238ceff37db82a81a9939c6d2217c5b7659a551",
-            "at": "2026-04-02T21:20:03Z",
-            "pr": 0,
-            "passes": 2
-        },
-        ".agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md": {
-            "hash": "1aa15519d959c89c0e09c3e30ac0210d6da35134",
-            "at": "2026-04-02T00:00:00Z",
-            "pr": 0,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md": {
-            "hash": "b253668b96ea394b289fba6ee03f12b30a041540",
-            "at": "2026-04-02T21:20:06Z",
-            "pr": 0,
-            "passes": 2
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md": {
-            "hash": "cf1846a80d91d8b99d83e135da0b5b13c80ef9b7",
-            "at": "2026-04-03T01:11:32Z",
-            "pr": 15606,
-            "passes": 3
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/ddos-gotchas.md": {
-            "hash": "f9bc5ae56912b9413ffb35a31dfdca00d42513cb",
-            "at": "2026-04-02T21:20:06Z",
-            "pr": 0,
-            "passes": 2
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/zaraz.md": {
-            "hash": "e4b79af78576116b33c9947649dffa9f1de19cec",
-            "at": "2026-04-02T21:20:08Z",
-            "pr": 0,
-            "passes": 2
-        },
-        ".agents/tools/code-review/auditing.md": {
-            "hash": "aa7f70c05362b5b00887a152a101c0b6ee7da926",
-            "at": "2026-04-02T21:20:13Z",
-            "pr": 0,
-            "passes": 2
-        },
-        ".agents/tools/context/rapidfuzz.md": {
-            "hash": "6cef99c2d59eecce5bd461af579cb44a36997e61",
-            "at": "2026-04-03T01:53:12Z",
-            "pr": 0,
-            "passes": 3
-        },
-        ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
-            "hash": "edecc25afbace885cab2eac01e07629d890a4fad",
-            "at": "2026-04-02T00:00:00Z",
-            "pr": 0,
-            "passes": 1
-        },
-        ".agents/workflows/branch/experiment.md": {
-            "hash": "c0b292cdf26b8a6a6cbdff05b765a4601adaf875",
-            "at": "2026-04-02T21:20:20Z",
-            "pr": 0,
-            "passes": 2
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pulumi.md": {
-            "hash": "4f629687cca43ce53b1643bbcff802c61367c597",
-            "at": "2026-04-03T01:53:04Z",
-            "pr": 15823,
-            "passes": 2
-        },
-        ".agents/tools/research/providers/openexplorer.md": {
-            "hash": "04542bb168595636e4a15f66fbdaafff8c18c327",
-            "at": "2026-04-03T01:53:17Z",
-            "pr": 15822,
-            "passes": 2
-        },
-        ".agents/scripts/commands/memory-log.md": {
-            "hash": "0f3be8d344b9ea22cd796e021e3f049e4ccaa75a",
-            "at": "2026-04-02T21:58:18Z",
-            "pr": 15701,
-            "passes": 1
-        },
-        ".agents/content/production-video.md": {
-            "hash": "b8dc424d6b0000d6bbdba29b25849344ca198a71",
-            "at": "2026-04-02T21:58:18Z",
-            "pr": 15699,
-            "passes": 1
-        },
-        ".agents/services/payments/revenuecat.md": {
-            "hash": "4a4d2603bb24d79952c3d18b283cd48deafde2d4",
-            "at": "2026-04-02T21:58:18Z",
-            "pr": 15693,
-            "passes": 1
-        },
-        ".agents/scripts/commands/pr-loop.md": {
-            "hash": "5e3ba8395648167005fdf9b47d469849c80188e5",
-            "at": "2026-04-02T21:58:18Z",
-            "pr": 15682,
-            "passes": 1
-        },
-        ".agents/reference/secret-handling.md": {
-            "hash": "2a6c72740cbc53ba42d8f562bde4af3073574974",
-            "at": "2026-04-03T02:08:59Z",
-            "pr": 15664,
-            "passes": 2
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/durable-objects.md": {
-            "hash": "7a4852a2f3e454c5962f11cefa855b6e4a1555b4",
-            "at": "2026-04-02T21:58:18Z",
-            "pr": 15663,
-            "passes": 1
-        },
-        ".agents/tools/build-agent/agent-testing.md": {
-            "hash": "cc7b9b5e44e530964c79af624de3408b1076cbe3",
-            "at": "2026-04-02T21:58:18Z",
-            "pr": 15662,
-            "passes": 1
-        },
-        ".agents/scripts/backfill-origin-labels.sh": {
-            "hash": "01d5281e257d4507215400c7311169fd37a39f6e",
-            "at": "2026-04-02T21:58:18Z",
-            "pr": 15661,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
-            "hash": "67350510852f0967a6591a03b13812ae2c7899d1",
-            "at": "2026-04-02T21:58:19Z",
-            "pr": 15646,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md": {
-            "hash": "839f69b3a40ac4728392bc8bf8396b643274c96c",
-            "at": "2026-04-02T21:58:19Z",
-            "pr": 15645,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/do-storage.md": {
-            "hash": "7652036224eb9bb0199c584f61a0a6631902a0ff",
-            "at": "2026-04-02T21:58:19Z",
-            "pr": 15569,
-            "passes": 1
-        },
-        ".agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md": {
-            "hash": "b7d6d4111324b39cbd5d0615343881696d760822",
-            "at": "2026-04-02T21:58:19Z",
-            "pr": 15568,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/miniflare.md": {
-            "hash": "4471ddd0229e26f2af30d5833d95c9a1f0261dac",
-            "at": "2026-04-02T21:58:19Z",
-            "pr": 15561,
-            "passes": 1
-        },
-        ".agents/scripts/commands/security-review.md": {
-            "hash": "8aeebd043a47a280413cacae8697325574b2d88e",
-            "at": "2026-04-02T21:58:19Z",
-            "pr": 15535,
-            "passes": 1
-        },
-        ".agents/tools/ai-assistants/fallback-chains.md": {
-            "hash": "04c03d8868c5719bfa209234bcac59f7b997c3f4",
-            "at": "2026-04-02T21:58:20Z",
-            "pr": 15534,
-            "passes": 1
-        },
-        ".agents/tools/video/remotion-sequencing.md": {
-            "hash": "0eab4c364cf2ee28b3c16e91d7af50b372717619",
-            "at": "2026-04-02T21:58:20Z",
-            "pr": 15533,
-            "passes": 1
-        },
-        ".agents/seo/bing-webmaster-tools.md": {
-            "hash": "fb22f3998fd4903c3ff77c9a664f0edb7fe62d1f",
-            "at": "2026-04-03T01:11:29Z",
-            "pr": 15532,
-            "passes": 2
-        },
-        ".agents/scripts/commands/seo-analyze.md": {
-            "hash": "04987b0129baab1ebd5f96cfe316cac9222f1b12",
-            "at": "2026-04-02T21:58:20Z",
-            "pr": 15502,
-            "passes": 1
-        },
-        ".agents/tools/deployment/cloudron-app-publishing-skill.md": {
-            "hash": "b78c7c2bff3ffbd13eb8b068699f5672cf21d922",
-            "at": "2026-04-02T21:58:20Z",
-            "pr": 15497,
-            "passes": 1
-        },
-        ".agents/seo/ai-search-readiness.md": {
-            "hash": "4652d2041fcf22b11419930334a44136a3acefe7",
-            "at": "2026-04-03T01:11:28Z",
-            "pr": 15496,
-            "passes": 2
-        },
-        ".agents/services/hosting/spaceship.md": {
-            "hash": "070eeb271be745bf4ce6d0c0a22631229975b71a",
-            "at": "2026-04-03T01:11:34Z",
-            "pr": 15494,
-            "passes": 2
-        },
-        ".agents/content/social-linkedin.md": {
-            "hash": "4df257a29d0b5d2fb67cc260a1ac2d1881a8f8d2",
-            "at": "2026-04-03T01:11:19Z",
-            "pr": 15493,
-            "passes": 2
-        },
-        ".agents/scripts/watercrawl-helper.sh": {
-            "hash": "27e5853c455180c533e572d91d47769062d78519",
-            "status": "simplified",
-            "at": "2026-04-02T22:43:46Z",
-            "passes": 1
-        },
-        ".agents/tools/browser/playwright-emulation.md": {
-            "hash": "1fdc5a4f08a4e9ba8ebc3550ade50c4876b949d7",
-            "at": "2026-04-02T22:44:04Z",
-            "pr": 15692,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md": {
-            "hash": "1a9ebfb7d88fdd954fa0ca93d3a4dffa7e24c461",
-            "at": "2026-04-02T22:44:04Z",
-            "pr": 15666,
-            "passes": 1
-        },
-        ".agents/seo/rich-results.md": {
-            "hash": "96226173e887aebf71287a803541f50f5b89d1c8",
-            "at": "2026-04-02T22:44:04Z",
-            "pr": 15665,
-            "passes": 1
-        },
-        ".agents/reference/platform-support.md": {
-            "hash": "67f8c07f2072f5b15ffae32c07a9e8930a5f7c49",
-            "at": "2026-04-03T00:48:09Z",
-            "pr": "GH#16007",
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md": {
-            "hash": "61a700349adcfc92119244d456e2e601cbc2f926",
-            "at": "2026-04-03T00:57:59Z",
-            "pr": 16020,
-            "passes": 3
-        },
-        ".agents/workflows/error-feedback.md": {
-            "hash": "85e9eb0fc79cd4671cdd43c481a13d977775d291",
-            "at": "2026-04-03T01:11:46Z",
-            "pr": 15970,
-            "passes": 1
-        },
-        ".agents/tools/programming/modern-javascript-skill/es2016-es2017.md": {
-            "hash": "6e238e8d6cd856c6d54aeeda15ded6763fbb7439",
-            "at": "2026-04-03T01:11:46Z",
-            "pr": 15969,
-            "passes": 1
-        },
-        ".agents/scripts/compare-models-helper.sh": {
-            "hash": "10e52daaafa5297bc348b088923e28bf767b4e73",
-            "at": "2026-04-03T01:11:46Z",
-            "pr": 15946,
-            "passes": 1
-        },
-        ".agents/tools/browser/crawl4ai-usage.md": {
-            "hash": "46d82b1f632872fa8c59c2a271c79466ced17238",
-            "at": "2026-04-03T01:11:47Z",
-            "pr": 15802,
-            "passes": 1
-        },
-        ".agents/services/communications/matrix-bot.md": {
-            "hash": "92784be52960e2b9738999d8c725a442cd3d5897",
-            "at": "2026-04-03T01:11:47Z",
-            "pr": 15801,
-            "passes": 1
-        },
-        ".agents/content/meta-creator.md": {
-            "hash": "6573b67dd99792a8c5870a2850c8fb3bc74d7e3b",
-            "at": "2026-04-03T01:11:47Z",
-            "pr": 15781,
-            "passes": 1
-        },
-        ".agents/tools/credentials/encryption-stack.md": {
-            "hash": "2e34e7975b8addfeaa1860db91423c85633b596c",
-            "at": "2026-04-03T01:11:47Z",
-            "pr": 15780,
-            "passes": 1
-        },
-        ".agents/tools/terminal/terminal-title.md": {
-            "hash": "a159d1374538460666970b226c494586840c5a08",
-            "at": "2026-04-03T01:11:48Z",
-            "pr": 15726,
-            "passes": 1
-        },
-        ".agents/services/email/email-inbound-commands.md": {
-            "hash": "2d55a1a765cc4b287e8e8cdbcf1eabf5d50bb4aa",
-            "at": "2026-04-03T01:11:48Z",
-            "pr": 15725,
-            "passes": 1
-        },
-        ".agents/marketing-sales/meta-ads-checklists-scaling-checklist.md": {
-            "hash": "790011746194791c3988c38215a06a333438e040",
-            "at": "2026-04-03T01:11:48Z",
-            "pr": 15723,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/pages.md": {
-            "hash": "a79bdd1a9af96c2204ecd7688f9e373e638fa484",
-            "at": "2026-04-03T01:24:39Z",
-            "pr": "16041",
-            "passes": 1
-        },
-        ".agents/content/distribution-youtube-readme.md": {
-            "hash": "933a61de442c55e846e4549225c5fe013ce59075",
-            "at": "2026-04-03T01:53:22Z",
-            "pr": 15971,
-            "passes": 1
-        },
-        ".agents/marketing-sales/cro-chapter-15/01-personalization-types.md": {
-            "hash": "0d4c142ecedde60524690f30e9469cc1819573e2",
-            "at": "2026-04-03T01:53:23Z",
-            "pr": 15873,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md": {
-            "hash": "984e5cfe9a63f157de9eacdac740dd7ca9a4c8dc",
-            "at": "2026-04-03T01:53:23Z",
-            "pr": 15869,
-            "passes": 1
-        },
-        ".agents/tools/video/remotion-videos.md": {
-            "hash": "782dd910314b807bedb05fbebcae4dc3e1ed84db",
-            "at": "2026-04-03T01:53:23Z",
-            "pr": 15852,
-            "passes": 1
-        },
-        ".agents/automate.md": {
-            "hash": "b5645f649804240736369a236767485dd7e49b6a",
-            "at": "2026-04-03T01:53:24Z",
-            "pr": 15804,
-            "passes": 1
-        },
-        ".agents/marketing-sales/direct-response-copy-checklists-offer-optimization.md": {
-            "hash": "5deb96e01280b6ec23ad9c1db17fba7700c949b9",
-            "at": "2026-04-03T01:53:26Z",
-            "pr": 15696,
-            "passes": 1
-        },
-        ".agents/tools/architecture/clean-ddd-hexagonal-skill.md": {
-            "hash": "159f2479cb3aebb3f3d0c437268c5884adc9382c",
-            "at": "2026-04-03T01:53:26Z",
-            "pr": 15695,
-            "passes": 1
-        },
-        ".agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md": {
-            "hash": "de83d5b4810ce96bd8858b825346224e73282531",
-            "at": "2026-04-03T01:53:26Z",
-            "pr": 15694,
-            "passes": 1
-        }
+  "files": {
+    ".agents/aidevops.md": {
+      "at": "2026-03-29T16:31:51Z",
+      "hash": "cf74c159d129be3c0c891b416bd45c0c11a5613b",
+      "passes": 1,
+      "pr": 13063
+    },
+    ".agents/aidevops/add-new-mcp-to-aidevops.md": {
+      "at": "2026-03-28T16:41:22Z",
+      "hash": "818de6a118b3981cbc732aace97a1220ad7f27ee",
+      "passes": 1,
+      "pr": 12006
+    },
+    ".agents/aidevops/agent-sources.md": {
+      "at": "2026-03-31T05:32:40Z",
+      "hash": "5ecd39be40d1f3ceca20c8be89737b646c3e41be",
+      "passes": 2,
+      "pr": 14645
+    },
+    ".agents/aidevops/architecture.md": {
+      "at": "2026-03-29T23:53:47Z",
+      "hash": "f1d29dba0c0d676b0d00e4e5adac2d79f9aa2dd1",
+      "passes": 1,
+      "pr": 13445
+    },
+    ".agents/aidevops/configs.md": {
+      "at": "2026-03-28T15:30:49Z",
+      "hash": "fecc0e08b16083bdd8f7e82c6f1636c136af3287",
+      "passes": 1,
+      "pr": 11897
+    },
+    ".agents/aidevops/extension.md": {
+      "at": "2026-03-28T08:58:33Z",
+      "hash": "6b76dd6fa41470a5d1d4e5ebeea7af1b13b6a1e8",
+      "passes": 1,
+      "pr": 11565
+    },
+    ".agents/aidevops/mcp-integrations.md": {
+      "at": "2026-03-28T03:53:54Z",
+      "hash": "199aacfc8608732f5fa0400478da824d5d11cdad",
+      "passes": 2,
+      "pr": 11339
+    },
+    ".agents/aidevops/mcp-troubleshooting.md": {
+      "at": "2026-03-31T08:03:51Z",
+      "hash": "d14d5400e4c936f6c89957750c8f843ae8304ec4",
+      "passes": 2,
+      "pr": 14740
+    },
+    ".agents/aidevops/onboarding.md": {
+      "at": "2026-03-29T07:02:21Z",
+      "hash": "a5d5e9ffd6e3639b96c0174e747bcb15c2712191",
+      "passes": 2,
+      "pr": 12641
+    },
+    ".agents/aidevops/plugins.md": {
+      "at": "2026-03-28T14:15:43Z",
+      "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
+      "passes": 1,
+      "pr": 11894
+    },
+    ".agents/aidevops/providers.md": {
+      "at": "2026-03-27T21:25:09Z",
+      "hash": "18b8c2ddd2bb1ee1b0affc02c05ae860b8e902da",
+      "passes": 1,
+      "pr": 11003
+    },
+    ".agents/aidevops/recommendations.md": {
+      "at": "2026-03-28T03:54:11Z",
+      "hash": "67c3f660425b669feae3238d7b42589449caa860",
+      "passes": 1,
+      "pr": 11343
+    },
+    ".agents/aidevops/requirements.md": {
+      "at": "2026-03-28T11:52:46Z",
+      "hash": "9a75f9e14252e2364ed8ceeb9e24e8df3a95e310",
+      "passes": 1,
+      "pr": 11770
+    },
+    ".agents/aidevops/resources.md": {
+      "at": "2026-03-28T21:58:59Z",
+      "hash": "4c8aa012ca51de765daed452692f619d55c701b1",
+      "passes": 1,
+      "pr": 12244
+    },
+    ".agents/aidevops/security-requirements.md": {
+      "at": "2026-03-29T12:37:08Z",
+      "hash": "8b86459a5459bd0be5402ca5660bfd99fa54a782",
+      "passes": 1,
+      "pr": 12946
+    },
+    ".agents/aidevops/self-improving-agents.md": {
+      "at": "2026-04-01T20:59:02Z",
+      "hash": "8e8dc0f8fa3a1a502130a64f217de014a5b14161",
+      "passes": 1,
+      "pr": 15203
+    },
+    ".agents/aidevops/services.md": {
+      "at": "2026-03-27T21:25:10Z",
+      "hash": "0fd05379ebb6a6ab079aaa0011c1dd8a5cca6af1",
+      "passes": 1,
+      "pr": 11004
+    },
+    ".agents/aidevops/troubleshooting.md": {
+      "at": "2026-03-28T16:00:22Z",
+      "hash": "9b1e6b69bbb4c48b5d664dbb23d72a25eb867b0f",
+      "passes": 1,
+      "pr": 11982
+    },
+    ".agents/build-plus.md": {
+      "at": "2026-03-29T16:10:49Z",
+      "hash": "9a8681dd42ae12e35c79f2f2479a29dfc90794f9",
+      "passes": 1,
+      "pr": 13101
+    },
+    ".agents/business.md": {
+      "at": "2026-03-29T16:34:54Z",
+      "hash": "359aefa91dc7dcd75049c36dbf54965be0fc9e2c",
+      "passes": 1,
+      "pr": 13055
+    },
+    ".agents/business/accounts-receipt-ocr.md": {
+      "at": "2026-03-28T16:41:24Z",
+      "hash": "7500c09629a5e47688af67a6901d684e92b623f2",
+      "passes": 1,
+      "pr": 12020
+    },
+    ".agents/business/accounts-subscription-audit.md": {
+      "at": "2026-03-29T21:43:19Z",
+      "hash": "ef31fbb7ef1c8e43fc6f5e6ff3f7bed9b5b0e3a0",
+      "passes": 1,
+      "pr": 13235
+    },
+    ".agents/business/company-runners.md": {
+      "at": "2026-03-28T11:52:25Z",
+      "hash": "8c78821205aacf320a7ed32b722b7c646a4e35af",
+      "passes": 1,
+      "pr": 11812
+    },
+    ".agents/content.md": {
+      "at": "2026-03-28T08:58:04Z",
+      "hash": "2f71b51f39307e001e3af0bae81c5fc440c2da9b",
+      "passes": 1,
+      "pr": 11616
+    },
+    ".agents/content/VERIFICATION.md": {
+      "at": "2026-03-30T03:34:30Z",
+      "hash": "f0090056bf6625c2ce2c676d4cf9ba25a901198e",
+      "passes": 1,
+      "pr": 13540
+    },
+    ".agents/content/content-calendar.md": {
+      "at": "2026-03-29T15:50:25Z",
+      "hash": "5bb7dca9397875d571887657d6e92d551536e6cd",
+      "passes": 1,
+      "pr": 13052
+    },
+    ".agents/content/context-templates.md": {
+      "at": "2026-04-02T04:00:00Z",
+      "hash": "15506de00a52128f74b711af949c6e56074f3bee",
+      "passes": 2,
+      "pr": 14934
+    },
+    ".agents/content/distribution-email.md": {
+      "at": "2026-03-28T16:00:42Z",
+      "hash": "d218dc3fdd2a3e501978d431530820ce810b354e",
+      "passes": 1,
+      "pr": 11989
+    },
+    ".agents/content/distribution-podcast.md": {
+      "at": "2026-03-29T07:02:57Z",
+      "hash": "0a2c98014bbe0588383437327d0b71e81a574af5",
+      "passes": 1,
+      "pr": 12557
+    },
+    ".agents/content/distribution-short-form.md": {
+      "at": "2026-03-28T20:16:49Z",
+      "hash": "8350ba659dc7fbcbecd70b55d52b65d296ce5401",
+      "passes": 1,
+      "pr": 12172
+    },
+    ".agents/content/distribution-social.md": {
+      "at": "2026-03-28T11:20:38Z",
+      "hash": "4ca38ce265bdd7a4921aeed56567dd38e5e98c32",
+      "passes": 1,
+      "pr": 11733
+    },
+    ".agents/content/distribution-youtube-channel-intel.md": {
+      "at": "2026-03-29T12:37:24Z",
+      "hash": "e7acafaec5e56e608968ecc99a7005352995560c",
+      "passes": 1,
+      "pr": 12791
+    },
+    ".agents/content/distribution-youtube-optimizer.md": {
+      "at": "2026-03-28T11:20:34Z",
+      "hash": "08796da4159346de335feb979d6ce0af181bb8ff",
+      "passes": 1,
+      "pr": 11731
+    },
+    ".agents/content/distribution-youtube-pipeline.md": {
+      "at": "2026-04-03T01:11:18Z",
+      "hash": "4b11d88aa5e558faf6c672d0c8920f54a7db40f4",
+      "passes": 2,
+      "pr": 11763
+    },
+    ".agents/content/distribution-youtube-script-writer.md": {
+      "at": "2026-03-28T08:58:46Z",
+      "hash": "e7d74dc2884f946d2d3ad41287926a426d0b0edb",
+      "passes": 1,
+      "pr": 11603
+    },
+    ".agents/content/distribution-youtube-topic-research.md": {
+      "at": "2026-03-28T11:20:29Z",
+      "hash": "d8d475231eff5b53cf27de5ab31aeedaec403e2f",
+      "passes": 1,
+      "pr": 11801
+    },
+    ".agents/content/distribution-youtube.md": {
+      "at": "2026-03-29T01:03:19Z",
+      "hash": "a44106f7677388ea6146e99c5c94de36b9e337ba",
+      "passes": 1,
+      "pr": 12386
+    },
+    ".agents/content/editor.md": {
+      "at": "2026-04-02T16:30:00Z",
+      "hash": "1b10ff74a546e869506efa2abe19f9f34eb56ad6",
+      "passes": 1,
+      "pr": null
+    },
+    ".agents/content/heygen-skill/rules-assets.md": {
+      "at": "2026-03-29T16:34:55Z",
+      "hash": "eed9c26fe6697296ac16fa54421ac1d4f9d6f2fc",
+      "passes": 1,
+      "pr": 13054
+    },
+    ".agents/content/heygen-skill/rules-avatars.md": {
+      "at": "2026-03-29T07:02:16Z",
+      "hash": "e600865474071a7973fe0ed89b4fd361065e080a",
+      "passes": 1,
+      "pr": 12654
+    },
+    ".agents/content/heygen-skill/rules-backgrounds.md": {
+      "at": "2026-03-28T09:17:34Z",
+      "hash": "7abf186ddedbabd5128f34ee918393a187de8cc3",
+      "passes": 1,
+      "pr": 11711
+    },
+    ".agents/content/heygen-skill/rules-captions.md": {
+      "at": "2026-03-28T09:48:53Z",
+      "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
+      "passes": 1,
+      "pr": 11707
+    },
+    ".agents/content/heygen-skill/rules-dimensions.md": {
+      "at": "2026-03-28T08:18:14Z",
+      "hash": "f32c728a54e3edca1d713da0d536cb4b63299882",
+      "passes": 1,
+      "pr": 11610
+    },
+    ".agents/content/heygen-skill/rules-photo-avatars.md": {
+      "at": "2026-03-29T07:03:00Z",
+      "hash": "d9a524f977f14c54b44991976651334aafa2e6e4",
+      "passes": 1,
+      "pr": 12620
+    },
+    ".agents/content/heygen-skill/rules-quota.md": {
+      "at": "2026-03-29T07:02:38Z",
+      "hash": "defa81f8873250c50ab8a9481e5d6f2b0958946c",
+      "passes": 1,
+      "pr": 12592
+    },
+    ".agents/content/heygen-skill/rules-remotion-integration.md": {
+      "at": "2026-03-28T10:27:14Z",
+      "hash": "5ccb546152546cd33344a76d42a4b90c0acd0dbd",
+      "passes": 1,
+      "pr": 11740
+    },
+    ".agents/content/heygen-skill/rules-scripts.md": {
+      "at": "2026-03-30T04:51:44Z",
+      "hash": "2e44c72709396aa34cb596ff5ef6426dbc1e96c8",
+      "passes": 2,
+      "pr": 13767
+    },
+    ".agents/content/heygen-skill/rules-templates.md": {
+      "at": "2026-03-29T08:10:46Z",
+      "hash": "5d9c85b6e42715ec4914982ce21790312207dacf",
+      "passes": 1,
+      "pr": 12738
+    },
+    ".agents/content/heygen-skill/rules-video-agent.md": {
+      "at": "2026-03-29T07:31:38Z",
+      "hash": "1d039d6d91c08e661a96696b19d43edbefe54b0e",
+      "passes": 1,
+      "pr": 12706
+    },
+    ".agents/content/heygen-skill/rules-video-generation.md": {
+      "at": "2026-03-28T10:27:38Z",
+      "hash": "929341bdb16beeda9c31e050b53eddbe5badfd72",
+      "passes": 1,
+      "pr": 11675
+    },
+    ".agents/content/heygen-skill/rules-video-translation.md": {
+      "at": "2026-03-29T03:15:05Z",
+      "hash": "16bf014b85cd6ad3c1be9d593a97af8620313cbb",
+      "passes": 1,
+      "pr": 12504
+    },
+    ".agents/content/heygen-skill/rules-voices.md": {
+      "at": "2026-03-29T07:02:36Z",
+      "hash": "d3dbb1550c826e13f7c5288b74f72fcff3518efd",
+      "passes": 1,
+      "pr": 12577
+    },
+    ".agents/content/heygen-skill/rules-webhooks.md": {
+      "at": "2026-03-30T06:49:23Z",
+      "hash": "c3ba360303dc273741e6f76b2f235b8319f78734",
+      "passes": 1,
+      "pr": 13942
+    },
+    ".agents/content/humanise.md": {
+      "at": "2026-03-30T06:03:20Z",
+      "hash": "898870a22cb4b4cf0153c907ab974792857e41c8",
+      "passes": 1,
+      "pr": 13836
+    },
+    ".agents/content/optimization.md": {
+      "at": "2026-03-29T23:18:03Z",
+      "hash": "326ff8a42a6e84736e5f70fc2f569119e04c9fa5",
+      "passes": 1,
+      "pr": 13425
+    },
+    ".agents/content/platform-personas.md": {
+      "at": "2026-04-02T21:19:52Z",
+      "hash": "b7e19c96eda87359699f528e35bddce57b0ddc2d",
+      "passes": 2,
+      "pr": 12167
+    },
+    ".agents/content/production-audio.md": {
+      "at": "2026-03-30T00:32:17Z",
+      "hash": "7e3eb343f808775963edf8007b96029c69ba09bf",
+      "passes": 2,
+      "pr": 13478
+    },
+    ".agents/content/production-characters.md": {
+      "at": "2026-03-28T16:40:48Z",
+      "hash": "f26a85f43d79aed7426a749dab9407537412d65b",
+      "passes": 1,
+      "pr": 12025
+    },
+    ".agents/content/production-image.md": {
+      "at": "2026-03-28T16:40:38Z",
+      "hash": "b3409136a94a117c8a727fa3e1ca400d77806a36",
+      "passes": 1,
+      "pr": 12023
+    },
+    ".agents/content/production-video-08-talking-head-pipeline.md": {
+      "at": "2026-04-02T04:56:45Z",
+      "hash": "cee1bc46bfdf4612fb0560748fe9e7b134ac0086",
+      "passes": 1,
+      "pr": 15516
+    },
+    ".agents/content/production-writing.md": {
+      "at": "2026-03-28T11:20:42Z",
+      "hash": "525c4aab766775fa9f92155b85f58bcda67cf3ea",
+      "passes": 1,
+      "pr": 11788
+    },
+    ".agents/content/research.md": {
+      "at": "2026-03-28T08:57:54Z",
+      "hash": "0844a394bf378618e923c821a3246e54fead511f",
+      "passes": 1,
+      "pr": 11644
+    },
+    ".agents/content/seo-writer.md": {
+      "at": "2026-04-01T22:10:00Z",
+      "hash": "af5154d5e50138d5490ce34d3ab7e8b5f88966a7",
+      "passes": 1,
+      "pr": 15339
+    },
+    ".agents/content/social-bird.md": {
+      "at": "2026-03-28T05:10:07Z",
+      "hash": "b2840ebff41ba9b78f7331487d6596373e8436e4",
+      "passes": 1,
+      "pr": 11354
+    },
+    ".agents/content/story.md": {
+      "at": "2026-03-29T17:14:35Z",
+      "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
+      "passes": 1,
+      "pr": 13457
+    },
+    ".agents/content/summarize.md": {
+      "at": "2026-03-29T07:02:30Z",
+      "hash": "937ce7f1f86adf1ef8f54d08458ca3421209fd10",
+      "passes": 1,
+      "pr": 12578
+    },
+    ".agents/content/video-director.md": {
+      "at": "2026-03-29T07:02:22Z",
+      "hash": "7aa6d199c68cd683f60bf343be15f38db4484a11",
+      "passes": 1,
+      "pr": 12608
+    },
+    ".agents/content/video-enhancor.md": {
+      "at": "2026-03-29T08:49:19Z",
+      "hash": "c92832f61d3cd78705b2913a0662b1ecee089aae",
+      "passes": 1,
+      "pr": 12796
+    },
+    ".agents/content/video-higgsfield-ui.md": {
+      "at": "2026-03-30T06:49:12Z",
+      "hash": "2ca7fc448a908aa78e4fe010b0ace0aaf9b9de87",
+      "passes": 2,
+      "pr": 13932
+    },
+    ".agents/content/video-higgsfield.md": {
+      "at": "2026-03-28T16:00:37Z",
+      "hash": "365b9f6acbaa7e54b14209c7eaee723372e836d6",
+      "passes": 1,
+      "pr": 11993
+    },
+    ".agents/content/video-muapi.md": {
+      "at": "2026-03-28T11:20:21Z",
+      "hash": "3deffc1afc21c9cb3daf10a540c802fc70e437df",
+      "passes": 1,
+      "pr": 11800
+    },
+    ".agents/content/video-real-video-enhancer.md": {
+      "at": "2026-03-30T03:34:21Z",
+      "hash": "3a1c798089a1fa50288b76e5fd372fe57d4307d5",
+      "passes": 1,
+      "pr": 13533
+    },
+    ".agents/content/video-runway.md": {
+      "at": "2026-03-28T08:58:00Z",
+      "hash": "54c5b2fe2d3cdd00e23f192d5f869c927b6e573e",
+      "passes": 1,
+      "pr": 11646
+    },
+    ".agents/content/video-wavespeed.md": {
+      "at": "2026-03-28T14:15:41Z",
+      "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
+      "passes": 1,
+      "pr": 11895
+    },
+    ".agents/health.md": {
+      "at": "2026-04-01T20:58:58Z",
+      "hash": "301b928aef5da6cc3a1dbb353077bfbab47af315",
+      "passes": 1,
+      "pr": 15249
+    },
+    ".agents/marketing-sales.md": {
+      "at": "2026-03-30T06:03:16Z",
+      "hash": "0b4144452b197dae7edbfcf3a5452752d3b2fe10",
+      "passes": 1,
+      "pr": 13839
+    },
+    ".agents/marketing-sales/ad-creative-ai-tools-reference.md": {
+      "at": "2026-03-28T20:56:07Z",
+      "hash": "8faff4defc9b64a16a6da7b996a86d29763bb87e",
+      "passes": 1,
+      "pr": 12183
+    },
+    ".agents/marketing-sales/ad-creative-campaign-management.md": {
+      "at": "2026-03-28T16:00:35Z",
+      "hash": "cf88e0ca297eabefcb235d1359ee6d2b0e75d576",
+      "passes": 1,
+      "pr": 11974
+    },
+    ".agents/marketing-sales/ad-creative-chapter-01.md": {
+      "at": "2026-03-28T23:05:56Z",
+      "hash": "e832ef8eb425956cec38a250eede0227342a4d79",
+      "passes": 1,
+      "pr": 12325
+    },
+    ".agents/marketing-sales/ad-creative-chapter-02.md": {
+      "at": "2026-03-28T07:37:37Z",
+      "hash": "810c244d317a3332c74dc2baafb34bf00cf5ab2f",
+      "passes": 1,
+      "pr": 11539
+    },
+    ".agents/marketing-sales/ad-creative-chapter-03.md": {
+      "at": "2026-03-28T15:30:26Z",
+      "hash": "f2d79f61b3c28c3e902760bb469c29a465a777c3",
+      "passes": 1,
+      "pr": 11936
+    },
+    ".agents/marketing-sales/ad-creative-chapter-04.md": {
+      "at": "2026-03-29T07:02:10Z",
+      "hash": "35b67bea4f7521d18b9a3a75deb4b2508810e83d",
+      "passes": 1,
+      "pr": 12662
+    },
+    ".agents/marketing-sales/ad-creative-chapter-05.md": {
+      "at": "2026-03-28T08:18:28Z",
+      "hash": "f8ded271e66b8024f24caa8a841ea58da90a709a",
+      "passes": 1,
+      "pr": 11555
+    },
+    ".agents/marketing-sales/ad-creative-chapter-06.md": {
+      "at": "2026-03-28T05:09:55Z",
+      "hash": "3d34a8e028e8905a54af8dd939394d10bdf16d97",
+      "passes": 1,
+      "pr": 11414
+    },
+    ".agents/marketing-sales/ad-creative-chapter-07.md": {
+      "at": "2026-03-29T01:33:56Z",
+      "hash": "c79c8baa955bb48f1ce2ded8036ded7940948031",
+      "passes": 1,
+      "pr": 12442
+    },
+    ".agents/marketing-sales/ad-creative-chapter-08.md": {
+      "at": "2026-03-29T01:04:19Z",
+      "hash": "cff567e1f6215e9c459e5d97d022a93f34d1c322",
+      "passes": 1,
+      "pr": 12398
+    },
+    ".agents/marketing-sales/ad-creative-chapter-09.md": {
+      "at": "2026-03-29T16:34:21Z",
+      "hash": "2bdf7194dc300dd779d03b44a37d35015e9f282d",
+      "passes": 1,
+      "pr": 13110
+    },
+    ".agents/marketing-sales/ad-creative-chapter-10.md": {
+      "at": "2026-03-28T05:10:32Z",
+      "hash": "23e33ef44632a4467884d5d9bebf6452adf22160",
+      "passes": 1,
+      "pr": 11315
+    },
+    ".agents/marketing-sales/ad-creative-chapter-11.md": {
+      "at": "2026-03-29T20:54:11Z",
+      "hash": "2fbaad774769229326c549e278ffe31d26906d66",
+      "passes": 1,
+      "pr": 13222
+    },
+    ".agents/marketing-sales/ad-creative-chapter-12.md": {
+      "at": "2026-03-29T03:15:08Z",
+      "hash": "eca290e31ece1e36762bbf607353ddbdb27aaf52",
+      "passes": 1,
+      "pr": 12503
+    },
+    ".agents/marketing-sales/ad-creative-chapters.md": {
+      "at": "2026-03-28T23:05:56Z",
+      "hash": "7389f5acbff5e5b272cc97a5c5285e8a9b735427",
+      "passes": 1,
+      "pr": 12325
+    },
+    ".agents/marketing-sales/ad-creative-copywriting.md": {
+      "at": "2026-03-28T21:14:35Z",
+      "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
+      "passes": 1,
+      "pr": 12018
+    },
+    ".agents/marketing-sales/ad-creative-offers-landing.md": {
+      "at": "2026-03-28T05:50:34Z",
+      "hash": "a16b4767e518eb9f3f35e1b61d3d166390077009",
+      "passes": 1,
+      "pr": 11415
+    },
+    ".agents/marketing-sales/ad-creative-platform-google.md": {
+      "at": "2026-03-28T15:30:26Z",
+      "hash": "f64e3f66de660586a2c510e31ce4a942286cf079",
+      "passes": 1,
+      "pr": 11936
+    },
+    ".agents/marketing-sales/ad-creative-platform-meta.md": {
+      "at": "2026-03-28T08:58:35Z",
+      "hash": "130ac72c8435b342b5be159ed84ab6633efdf4fa",
+      "passes": 1,
+      "pr": 11574
+    },
+    ".agents/marketing-sales/ad-creative-psychology-targeting.md": {
+      "at": "2026-03-28T10:27:52Z",
+      "hash": "c37b3f2fadeaae4f147248efd4fa535e89f1d96b",
+      "passes": 1,
+      "pr": 11655
+    },
+    ".agents/marketing-sales/ad-creative-testing-optimization.md": {
+      "at": "2026-03-28T08:58:01Z",
+      "hash": "2f60c87e51dac14c539d02ba1a796a98b995c2c4",
+      "passes": 1,
+      "pr": 11614
+    },
+    ".agents/marketing-sales/ad-creative-video-ugc.md": {
+      "at": "2026-03-30T04:52:01Z",
+      "hash": "695a2da0afc79acc4e203ead505b0bc768c6237a",
+      "passes": 1,
+      "pr": 13723
+    },
+    ".agents/marketing-sales/ad-creative.md": {
+      "at": "2026-03-29T03:31:36Z",
+      "hash": "0fd2f3ed67a352a6b59ca35f1cb1be0ca62f691f",
+      "passes": 1,
+      "pr": 12505
+    },
+    ".agents/marketing-sales/cro-chapter-01.md": {
+      "at": "2026-03-29T20:54:07Z",
+      "hash": "5dad243a2a5744924aeb5b2e39fe94aad887af5e",
+      "passes": 1,
+      "pr": 13294
+    },
+    ".agents/marketing-sales/cro-chapter-02.md": {
+      "at": "2026-04-01T20:59:14Z",
+      "hash": "8226a4d2cd57afce1746318203d9c357540010c2",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-02/01-conversion-rate-formulas.md": {
+      "at": "2026-04-01T20:59:14Z",
+      "hash": "3ffbf75893700060301c26dd5fd2c63e6743bddc",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-02/02-psychology-of-conversion.md": {
+      "at": "2026-04-01T20:59:14Z",
+      "hash": "497b1a2f35082225ace6ac18531c3b83d25fd39f",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-02/03-conversion-funnel.md": {
+      "at": "2026-04-01T20:59:14Z",
+      "hash": "20a9a226559ee7acc643d4b1b73a44d3f735e87d",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-02/04-attribution-models.md": {
+      "at": "2026-04-01T20:59:15Z",
+      "hash": "48f7749c53ee973531130209345c214c0d77b181",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-02/05-website-elements.md": {
+      "at": "2026-04-01T20:59:15Z",
+      "hash": "786c51eec79c4098d2034c43c8dd98c1077043e0",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-02/06-conversion-friction.md": {
+      "at": "2026-04-01T20:59:15Z",
+      "hash": "60a0019275f9e3b20f3e9dba68b8d52f6782199c",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-02/07-data-foundation.md": {
+      "at": "2026-04-01T20:59:15Z",
+      "hash": "58055a16f3affa58e9372abe6c4108cc7d0b196c",
+      "passes": 1,
+      "pr": 15223
+    },
+    ".agents/marketing-sales/cro-chapter-03.md": {
+      "at": "2026-03-29T12:37:09Z",
+      "hash": "ac80d924629caf06f25a2c2bf503c1aa2267d8de",
+      "passes": 1,
+      "pr": 12954
+    },
+    ".agents/marketing-sales/cro-chapter-04.md": {
+      "at": "2026-03-29T07:02:12Z",
+      "hash": "f893022ded62f04d6ca13b86f839211e4fe8190a",
+      "passes": 1,
+      "pr": 12665
+    },
+    ".agents/marketing-sales/cro-chapter-05.md": {
+      "at": "2026-03-29T09:20:58Z",
+      "hash": "2a9c49266d0a50ef42a41c590041ff6aeb62135c",
+      "passes": 1,
+      "pr": 12824
+    },
+    ".agents/marketing-sales/cro-chapter-07.md": {
+      "at": "2026-03-29T02:36:03Z",
+      "hash": "faba8a64f3996ee2e5722dd4b7c822d49f79c1b6",
+      "passes": 1,
+      "pr": 12463
+    },
+    ".agents/marketing-sales/cro-chapter-08.md": {
+      "at": "2026-03-30T06:49:54Z",
+      "hash": "b17c73481de18eb0ad983703fbcae8b5b7e93c98",
+      "passes": 1,
+      "pr": 13773
+    },
+    ".agents/marketing-sales/cro-chapter-09.md": {
+      "at": "2026-03-28T08:17:36Z",
+      "hash": "4d45e94ded75b90ef7e30518e072a5a643167370",
+      "passes": 1,
+      "pr": 11561
+    },
+    ".agents/marketing-sales/cro-chapter-10.md": {
+      "at": "2026-03-27T21:25:12Z",
+      "hash": "730bf8258084ccd7a330cc2ac1032f1aedd4a370",
+      "passes": 1,
+      "pr": 11005
+    },
+    ".agents/marketing-sales/cro-chapter-11.md": {
+      "at": "2026-04-01T22:00:00Z",
+      "hash": "be3bf907be217b866da1d7990427e4fc1c925971",
+      "passes": 1,
+      "pr": 14514
+    },
+    ".agents/marketing-sales/cro-chapter-12.md": {
+      "at": "2026-03-28T16:00:24Z",
+      "hash": "f733b449021696b03a6678fba02aca9940fdeb6a",
+      "passes": 1,
+      "pr": 11988
+    },
+    ".agents/marketing-sales/cro-chapter-13.md": {
+      "at": "2026-03-29T03:15:02Z",
+      "hash": "e498cfacef39db0262cc094600055befe786ccfe",
+      "passes": 1,
+      "pr": 12499
+    },
+    ".agents/marketing-sales/cro-chapter-14.md": {
+      "at": "2026-03-28T16:40:42Z",
+      "hash": "a15acda5b82f46b01af4961ff5c01fa7483e5cea",
+      "passes": 1,
+      "pr": 12027
+    },
+    ".agents/marketing-sales/cro-chapter-16.md": {
+      "at": "2026-03-28T04:30:24Z",
+      "hash": "920245116e79b04207fd2b808c5dcbfabea3eb17",
+      "passes": 1,
+      "pr": 11374
+    },
+    ".agents/marketing-sales/cro-chapter-17.md": {
+      "at": "2026-03-29T21:43:12Z",
+      "hash": "55117c563ab956b0653eca2c335a7e8c14e15708",
+      "passes": 1,
+      "pr": 13339
+    },
+    ".agents/marketing-sales/cro-chapter-18.md": {
+      "at": "2026-04-01T20:59:11Z",
+      "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
+      "passes": 1,
+      "pr": 15220
+    },
+    ".agents/marketing-sales/cro-chapter-19.md": {
+      "at": "2026-04-02T21:19:54Z",
+      "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
+      "issue": "GH#14286",
+      "passes": 2,
+      "note": "Reference corpus chapter tightened: 92 \u2192 90 lines. Removed decorative closing sentence with no information value. Zero content loss."
+    },
+    ".agents/marketing-sales/cro-chapter-20.md": {
+      "at": "2026-03-29T16:34:29Z",
+      "hash": "07aa1e83fefdc10d56b044961da2976b1e693895",
+      "passes": 1,
+      "pr": 13105
+    },
+    ".agents/marketing-sales/cro-chapter-22.md": {
+      "at": "2026-04-01T20:58:50Z",
+      "hash": "882c97fc64eb63b11312049223c04eaa52882296",
+      "passes": 1,
+      "pr": 15257
+    },
+    ".agents/marketing-sales/cro-chapter-25.md": {
+      "at": "2026-04-01T21:00:00Z",
+      "hash": "076db4b43144a19221004451da2ab384161bcb17",
+      "passes": 2,
+      "pr": 15276
+    },
+    ".agents/marketing-sales/cro-chapters.md": {
+      "at": "2026-03-30T00:32:32Z",
+      "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
+      "passes": 1,
+      "pr": 13457
+    },
+    ".agents/marketing-sales/cro.md": {
+      "at": "2026-03-29T08:10:36Z",
+      "hash": "9a8a0b49c40c42072e982a4dd40761c19c0055ed",
+      "passes": 1,
+      "pr": 12753
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md": {
+      "hash": "e32cc9a38c9f2b1305595ef393fa64650ed7f0b5",
+      "issue": "GH#15068",
+      "note": "Reference corpus already split into 5 chapter files (01-saas-examples.md through 05-guarantees-and-design-principles.md). Index is 30 lines; chapters total 163 lines. No further action needed.",
+      "status": "done",
+      "at": "2026-04-02T20:39:23Z",
+      "passes": 1
+    },
+    ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
+      "at": "2026-04-01T20:59:28Z",
+      "hash": "ab1f9c5d69340fa7acfd756c2ae37710b9fa600c",
+      "passes": 1,
+      "pr": 14996
+    },
+    ".agents/marketing-sales/direct-response-copy-frameworks-headline-formulas.md": {
+      "at": "2026-03-28T08:58:42Z",
+      "hash": "9c23835b93de53e0d6371a5f753c1409e0374d9d",
+      "passes": 1,
+      "pr": 11548
+    },
+    ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md": {
+      "at": "2026-04-01T21:00:01Z",
+      "hash": "4c6d024fd0bd6ab3cbc9881e5cd83bd7dec582e4",
+      "passes": 1,
+      "pr": 14853
+    },
+    ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
+      "at": "2026-03-28T08:17:37Z",
+      "hash": "a80eb99acba160fa0f034a4989c0b886f37a32a0",
+      "passes": 1,
+      "pr": 11571
+    },
+    ".agents/marketing-sales/direct-response-copy-frameworks-offer-construction.md": {
+      "at": "2026-03-28T05:51:09Z",
+      "hash": "10d31ffa27d8e38267882e04f099ce38899635f1",
+      "passes": 1,
+      "pr": 11363
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-ads.md": {
+      "at": "2026-03-28T05:50:32Z",
+      "hash": "8e2f8f2a6620debfe219e09c96cfeb634fb518a7",
+      "passes": 1,
+      "pr": 11411
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md": {
+      "at": "2026-03-31T05:42:16Z",
+      "hash": "57313942eaf75ad8a1022a5c723b3f2c5d3f76f5",
+      "passes": 2,
+      "pr": 14662
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-06-ramit-sethi-launch.md": {
+      "at": "2026-04-01T20:59:17Z",
+      "hash": "5f82f7b17f7fde8daeb703ca4c3cdcef53620c2f",
+      "passes": 1,
+      "pr": 15150
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-07-saas-trial-expiry.md": {
+      "at": "2026-04-01T20:59:17Z",
+      "hash": "541a34d7b2649c4e93f494af26bb412731aace9e",
+      "passes": 1,
+      "pr": 15150
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-08-cart-abandonment.md": {
+      "at": "2026-04-01T20:59:17Z",
+      "hash": "2c4d31ad777c8c70b5293c3fd75e4e6af67b4654",
+      "passes": 1,
+      "pr": 15150
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-09-webinar-invite.md": {
+      "at": "2026-04-01T20:59:17Z",
+      "hash": "5dd410cda93d3056b39408c537fb3c9b1e1e06da",
+      "passes": 1,
+      "pr": 15150
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
+      "at": "2026-04-01T20:59:18Z",
+      "hash": "7f8943efbe9c5d05b7ecba869a866d6020b95928",
+      "passes": 1,
+      "pr": 15150
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md": {
+      "at": "2026-04-02T04:56:54Z",
+      "hash": "d662c65c03864c29b198db3a89950538a7949ef2",
+      "passes": 1,
+      "pr": 15526
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
+      "at": "2026-03-28T15:30:24Z",
+      "hash": "f74ee77c8e774c79829f80e238c09adbe6f3c21e",
+      "passes": 1,
+      "pr": 11945
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-example.md": {
+      "at": "2026-03-28T08:58:28Z",
+      "hash": "219b3f24929e0866af7e05c36250a267a5f2e952",
+      "passes": 1,
+      "pr": 11597
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-pastor-framework.md": {
+      "at": "2026-03-28T08:58:28Z",
+      "hash": "229aaf2fa58645152ccdd4ece9d723068b251f4a",
+      "passes": 1,
+      "pr": 11597
+    },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md": {
+      "at": "2026-03-28T08:57:56Z",
+      "hash": "816a5f35e7ca6b338deae7db62c3058d317b96d6",
+      "passes": 1,
+      "pr": 11647
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-01-facebook-instagram.md": {
+      "at": "2026-03-28T08:17:45Z",
+      "hash": "4bfed86699b1e5a25050b85f099ca3fc580574d8",
+      "passes": 1,
+      "pr": 11593
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-02-google-search.md": {
+      "at": "2026-03-28T08:17:45Z",
+      "hash": "f9ecc39136c90a2feb8bc9075f3e95ba23fccddd",
+      "passes": 1,
+      "pr": 11593
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-03-linkedin.md": {
+      "at": "2026-03-28T08:17:45Z",
+      "hash": "a3c8015dc17258f154c7bdd4e4ccf0d4586a06db",
+      "passes": 1,
+      "pr": 11593
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-04-twitter.md": {
+      "at": "2026-03-28T08:17:45Z",
+      "hash": "615623c2156bb8eee3a9409900b33a895768e08d",
+      "passes": 1,
+      "pr": 11593
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-ad-copy-05-reference.md": {
+      "at": "2026-03-28T08:17:45Z",
+      "hash": "d34fe0576cb0cb1c1770a278ad5e149bba1480d0",
+      "passes": 1,
+      "pr": 11593
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-ad-copy.md": {
+      "at": "2026-03-28T08:17:45Z",
+      "hash": "bfc16d8c1bc4e6a8229cc555eba0d72de8ece0d7",
+      "passes": 1,
+      "pr": 11593
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "fc8601e1d052f928c023da0917367bb21323b4e4",
+      "passes": 2,
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "658de751f2d88050b16b810d4606b3d70426e4dd",
+      "passes": 2,
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "ca0ffbbb9d01a944ca038fd7ffed902dedf0c82c",
+      "passes": 2,
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "5328e2dd6fd579ca0f648b82f3f94b52f56f3baf",
+      "passes": 2,
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "d207be0ddb3e721786a9a93447bd0110bda97f67",
+      "passes": 2,
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "0cf9219a719ff218be50f556ea87fe2c1353fea7",
+      "passes": 2,
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-email-sequences.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "8b6cccfab9ec08287f4b54ab1e353f28a94a3cdb",
+      "passes": 2,
+      "pr": 15046
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-landing-page.md": {
+      "at": "2026-03-28T13:37:36Z",
+      "hash": "cbaa0cc29c6e3639ea5254866f8fefe1c02a329c",
+      "passes": 1,
+      "pr": 11840
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-readme.md": {
+      "at": "2026-03-28T08:17:38Z",
+      "hash": "2717d1e9cb1edfd85d932502b6de7c4765c8a7ec",
+      "passes": 1,
+      "pr": 11571
+    },
+    ".agents/marketing-sales/direct-response-copy-templates-vsl-script.md": {
+      "at": "2026-03-28T08:17:46Z",
+      "hash": "c8fa5d2f257f52a1d7c9c49ca9d78e6be247623e",
+      "passes": 1,
+      "pr": 11591
+    },
+    ".agents/marketing-sales/direct-response-copy.md": {
+      "at": "2026-03-30T02:30:17Z",
+      "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
+      "passes": 1,
+      "pr": 13597
+    },
+    ".agents/marketing-sales/meta-ads-audiences-first-party-data.md": {
+      "at": "2026-03-28T08:18:20Z",
+      "hash": "1ad15971973eec338e831dc24839609eb1f473e3",
+      "passes": 1,
+      "pr": 11536
+    },
+    ".agents/marketing-sales/meta-ads-audiences-retargeting-setup.md": {
+      "at": "2026-03-29T03:15:24Z",
+      "hash": "dedfee9605d04b5a7cf9f5563c0e772f06e44062",
+      "passes": 1,
+      "pr": 12514
+    },
+    ".agents/marketing-sales/meta-ads-audiences-targeting-strategies.md": {
+      "at": "2026-03-28T11:20:14Z",
+      "hash": "9802f4e7f19b67d5a8a45f1a137209082a585d4c",
+      "passes": 1,
+      "pr": 11791
+    },
+    ".agents/marketing-sales/meta-ads-campaigns-advantage-plus.md": {
+      "at": "2026-03-30T04:52:40Z",
+      "hash": "e2a2dc5e7f15a6ce3fdcf4e477dac3ca7db3056f",
+      "passes": 1,
+      "pr": 13779
+    },
+    ".agents/marketing-sales/meta-ads-campaigns-decision-trees.md": {
+      "at": "2026-03-28T04:30:25Z",
+      "hash": "a7bcedab8040e2b400b7c2feca987e09bb0a8477",
+      "passes": 1,
+      "pr": 11381
+    },
+    ".agents/marketing-sales/meta-ads-campaigns-retargeting.md": {
+      "at": "2026-03-28T11:52:21Z",
+      "hash": "76a66a236cc7fbeb40d74384e9dbe4bd75a4a155",
+      "passes": 1,
+      "pr": 11822
+    },
+    ".agents/marketing-sales/meta-ads-campaigns-scaling-cbo.md": {
+      "at": "2026-03-29T21:42:59Z",
+      "hash": "6fb79b1689e522f77f09f4398f80430c8c727116",
+      "passes": 1,
+      "pr": 13263
+    },
+    ".agents/marketing-sales/meta-ads-campaigns-testing-abo.md": {
+      "at": "2026-03-29T01:04:17Z",
+      "hash": "be737a2fe12892ef6479a1939cbe4b6fee46db16",
+      "passes": 1,
+      "pr": 12395
+    },
+    ".agents/marketing-sales/meta-ads-checklists-campaign-launch.md": {
+      "at": "2026-04-01T20:59:20Z",
+      "hash": "3f199a8eb517a651781b683ec0d6a723fb16d9b0",
+      "passes": 1,
+      "pr": 15149
+    },
+    ".agents/marketing-sales/meta-ads-checklists-creative-review.md": {
+      "at": "2026-03-30T03:33:54Z",
+      "hash": "d3207ef474ba73d95bb9c13864b282ac0b78169e",
+      "passes": 1,
+      "pr": 13666
+    },
+    ".agents/marketing-sales/meta-ads-checklists-weekly-review.md": {
+      "at": "2026-03-29T12:36:27Z",
+      "hash": "8ddae4fd98efd953d4ecaa242553ad3eda337a92",
+      "passes": 1,
+      "pr": 12947
+    },
+    ".agents/marketing-sales/meta-ads-creative-briefs-founder-video-brief.md": {
+      "at": "2026-03-31T06:30:29Z",
+      "hash": "4663b6f4a18ffba178e090fd696bba98f87535b8",
+      "passes": 2,
+      "pr": 14701
+    },
+    ".agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md": {
+      "at": "2026-03-29T15:50:34Z",
+      "hash": "cde8788cbf4bf8376449f26888b4823576649256",
+      "passes": 2,
+      "pr": 13064
+    },
+    ".agents/marketing-sales/meta-ads-creative-briefs-ugc-brief.md": {
+      "at": "2026-03-28T21:27:17Z",
+      "hash": "b3cbdabb7633b010839689527b084c198f34bdc9",
+      "passes": 1,
+      "pr": 12217
+    },
+    ".agents/marketing-sales/meta-ads-creative-formats.md": {
+      "at": "2026-03-28T06:39:54Z",
+      "hash": "f8a4f095bebc852b9ce58976d3b53e418bbe578e",
+      "passes": 1,
+      "pr": 11410
+    },
+    ".agents/marketing-sales/meta-ads-creative-hooks.md": {
+      "at": "2026-03-27T21:25:06Z",
+      "hash": "f7c8e3356361a9ab1941f729337bbf7d0f8447ef",
+      "passes": 1,
+      "pr": 11016
+    },
+    ".agents/marketing-sales/meta-ads-creative-psychology.md": {
+      "at": "2026-03-30T04:52:02Z",
+      "hash": "6436f438f568834b0e2062a282cce59cc65ec58d",
+      "passes": 1,
+      "pr": 13729
+    },
+    ".agents/marketing-sales/meta-ads-creative-scripts.md": {
+      "at": "2026-03-28T03:10:39Z",
+      "hash": "9455fbf07187de24552aa591a8752fd7b3df2480",
+      "passes": 1,
+      "pr": 11297
+    },
+    ".agents/marketing-sales/meta-ads-foundations-account-structure.md": {
+      "at": "2026-03-29T21:43:00Z",
+      "hash": "d8a1a11c970efd832edd47784162978ad05783f0",
+      "passes": 1,
+      "pr": 13333
+    },
+    ".agents/marketing-sales/meta-ads-foundations-algorithm.md": {
+      "at": "2026-04-01T20:59:13Z",
+      "hash": "318e59fc49106e5aaeeca2d26e666b87b0353d5c",
+      "passes": 1,
+      "pr": 15138
+    },
+    ".agents/marketing-sales/meta-ads-foundations-attribution.md": {
+      "at": "2026-03-29T11:51:45Z",
+      "hash": "7bd8755456129fcd79c106e7e829c6233ae16c42",
+      "passes": 1,
+      "pr": 12920
+    },
+    ".agents/marketing-sales/meta-ads-foundations-glossary.md": {
+      "at": "2026-03-30T03:33:50Z",
+      "hash": "f0b0b3b259d7597309af03f39a2f267137dafffe",
+      "passes": 1,
+      "pr": 13691
+    },
+    ".agents/marketing-sales/meta-ads-optimization-automation-rules.md": {
+      "at": "2026-03-29T15:50:44Z",
+      "hash": "4e78284e12f62b421b7458d171f79117bc4610e9",
+      "passes": 1,
+      "pr": 13078
+    },
+    ".agents/marketing-sales/meta-ads-optimization-metrics.md": {
+      "at": "2026-03-30T06:49:39Z",
+      "hash": "99cca533a9d716bf886a24bffbf8255ca5da96a3",
+      "passes": 1,
+      "pr": 13940
+    },
+    ".agents/marketing-sales/meta-ads-optimization-scaling.md": {
+      "at": "2026-03-28T08:17:40Z",
+      "hash": "8034babf9a34b6f09f0cce7817a136ee38be0c1f",
+      "passes": 1,
+      "pr": 11564
+    },
+    ".agents/marketing-sales/meta-ads-optimization-troubleshooting.md": {
+      "at": "2026-03-28T08:17:40Z",
+      "hash": "684991a0c73063d140b0cfee3ad73691a479a34f",
+      "passes": 1,
+      "pr": 11564
+    },
+    ".agents/marketing-sales/meta-ads.md": {
+      "at": "2026-03-28T16:40:30Z",
+      "hash": "19b4754a783dd4b878bb5cf4032420f1cfab931d",
+      "passes": 1,
+      "pr": 12024
+    },
+    ".agents/product/analytics.md": {
+      "at": "2026-03-29T23:53:58Z",
+      "hash": "1ecb5ce4743770c3913fae8f41e526f3ba21c6a0",
+      "passes": 1,
+      "pr": 13415
+    },
+    ".agents/product/growth.md": {
+      "at": "2026-03-28T16:40:15Z",
+      "hash": "97246dfba596c1be9241c0b669c611df856e71bc",
+      "passes": 1,
+      "pr": 12037
+    },
+    ".agents/product/monetisation.md": {
+      "at": "2026-04-03T01:52:56Z",
+      "hash": "335ecd62068e0bc6a3a1e74b01cd823611ba1d54",
+      "passes": 2,
+      "pr": 16017
+    },
+    ".agents/product/onboarding.md": {
+      "at": "2026-03-29T23:54:00Z",
+      "hash": "bc634e70e9bb850181c2c4c0d239a36447560921",
+      "passes": 1,
+      "pr": 13399
+    },
+    ".agents/product/ui-design.md": {
+      "at": "2026-03-30T03:34:29Z",
+      "hash": "3a8d0daebe80ebc2f64efe31009dbcba324fe142",
+      "passes": 1,
+      "pr": 13539
+    },
+    ".agents/product/validation.md": {
+      "at": "2026-03-29T12:37:13Z",
+      "hash": "74840e4aa9e8d619ae82517ca6a1b43a00f99b56",
+      "passes": 1,
+      "pr": 12910
+    },
+    ".agents/prompts/worker-efficiency-protocol.md": {
+      "at": "2026-04-03T01:11:25Z",
+      "hash": "c2131a568a446a0555dbc6491084d79991198379",
+      "passes": 2,
+      "pr": 14943
+    },
+    ".agents/reference/agent-routing.md": {
+      "at": "2026-03-31T05:34:14Z",
+      "hash": "83e56233f5c7fc633bc3a64de90d9b5529a0bd33",
+      "passes": 1,
+      "pr": 14650
+    },
+    ".agents/reference/auto-update.md": {
+      "at": "2026-04-01T23:23:47Z",
+      "hash": "0db7d0a5ebb60bf53cbeb2d88102be373220981c",
+      "passes": 1,
+      "pr": 15301
+    },
+    ".agents/reference/configuration.md": {
+      "at": "2026-03-28T04:30:48Z",
+      "hash": "9502faea512b841b7a239e9e3c9cc0188f4fe855",
+      "passes": 1,
+      "pr": 11321
+    },
+    ".agents/reference/contribution-watch.md": {
+      "at": "2026-04-01T23:23:47Z",
+      "hash": "77b53dc6bf630c7451cc69425d06aa11f23e727b",
+      "passes": 1,
+      "pr": 15301
+    },
+    ".agents/reference/define-probes/bugfix.md": {
+      "at": "2026-04-01T23:23:39Z",
+      "hash": "88ddddb0fc275f73407b492a820bd0f2bfdada99",
+      "passes": 1,
+      "pr": 15334
+    },
+    ".agents/reference/entity-memory-architecture.md": {
+      "at": "2026-04-02T00:00:00Z",
+      "hash": "bbd1c42b7e0eb2b01cb5a193f94c5e9ecf98c540",
+      "passes": 1,
+      "pr": 15488
+    },
+    ".agents/reference/foss-contributions.md": {
+      "at": "2026-03-30T02:30:24Z",
+      "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
+      "passes": 1,
+      "pr": 13561
+    },
+    ".agents/reference/hashline-edit-format.md": {
+      "at": "2026-04-01T23:23:50Z",
+      "hash": "2f2019c30b4f9bb5d1947e6b7156833f15973c1e",
+      "passes": 1,
+      "pr": 15277
+    },
+    ".agents/reference/high-stakes-operations.md": {
+      "at": "2026-03-27T21:25:17Z",
+      "hash": "ba39668c924d2e2d0137c766053513a98a2f2839",
+      "passes": 1,
+      "pr": 11012
+    },
+    ".agents/reference/memory.md": {
+      "at": "2026-03-28T07:37:36Z",
+      "hash": "0a7c4c493f3a825b98e2de3928f718fa9095c966",
+      "passes": 1,
+      "pr": 11538
+    },
+    ".agents/reference/planning-detail.md": {
+      "at": "2026-03-29T08:49:21Z",
+      "hash": "c5c616d56a09198023878a228bbf7311f9bd0212",
+      "passes": 1,
+      "pr": 12780
+    },
+    ".agents/reference/repo-sync.md": {
+      "at": "2026-04-01T23:23:47Z",
+      "hash": "e6c2ddc65a495825740608c7c440f8ba49033db5",
+      "passes": 1,
+      "pr": 15301
+    },
+    ".agents/reference/services.md": {
+      "at": "2026-04-01T23:23:47Z",
+      "hash": "85309d5014421182d0c22812ec7bb56f2ccc2ab0",
+      "passes": 1,
+      "pr": 15301
+    },
+    ".agents/reference/settings.md": {
+      "at": "2026-03-30T03:34:12Z",
+      "hash": "2b2cbc9b8329f0fd0504413c4805a235d0f16962",
+      "passes": 1,
+      "pr": 13637
+    },
+    ".agents/research.md": {
+      "at": "2026-04-01T20:59:28Z",
+      "hash": "b509e2fae5168065f0142ae29dca1ec2d410c53b",
+      "passes": 1,
+      "pr": 14996
+    },
+    ".agents/scripts/commands/budget-analysis.md": {
+      "at": "2026-04-01T20:58:50Z",
+      "hash": "ac77aaf850ecc1f9cee81c9e04a026a954fc7359",
+      "passes": 1,
+      "pr": 15257
+    },
+    ".agents/scripts/commands/dashboard.md": {
+      "at": "2026-03-29T21:43:13Z",
+      "hash": "c72021fe5b7c20c340b5a5a1e1b66cf6b3d247f9",
+      "passes": 1,
+      "pr": 13338
+    },
+    ".agents/scripts/commands/define.md": {
+      "at": "2026-03-29T17:15:13Z",
+      "hash": "228f38c6d509423d7158cef517bbd601a691923d",
+      "passes": 1,
+      "pr": 13131
+    },
+    ".agents/scripts/commands/email-outreach.md": {
+      "at": "2026-04-02T03:11:10Z",
+      "hash": "03c6fbfcdc4ba527948102f9b58f5c9bed557777",
+      "passes": 1,
+      "pr": 15480
+    },
+    ".agents/scripts/commands/full-loop.md": {
+      "at": "2026-04-02T14:41:00Z",
+      "hash": "bcf22ce3b332f521d77a911b696ec7375d0eabe8",
+      "passes": 3,
+      "pr": 14590
+    },
+    ".agents/scripts/commands/ip-check.md": {
+      "at": "2026-03-31T02:20:51Z",
+      "hash": "157dc866ef64f46a91e761875f5346f372c3da72",
+      "passes": 2,
+      "pr": 14484
+    },
+    ".agents/scripts/commands/list-todo.md": {
+      "at": "2026-04-01T20:59:47Z",
+      "hash": "351180b6d47cacee5be38fc9e3ec01f7d1fd8661",
+      "passes": 1,
+      "pr": 14898
+    },
+    ".agents/scripts/commands/list-verify.md": {
+      "at": "2026-04-02T04:56:43Z",
+      "hash": "dc43be77f9d72dac6880004350a5b63ce9a326f0",
+      "passes": 1,
+      "pr": 15514
+    },
+    ".agents/scripts/commands/log-issue-aidevops.md": {
+      "at": "2026-03-27T21:25:13Z",
+      "hash": "24878e7d7abca4cf0b41a18e5dac1977978ec3c1",
+      "passes": 1,
+      "pr": 11007
+    },
+    ".agents/scripts/commands/mission.md": {
+      "at": "2026-03-29T12:36:32Z",
+      "hash": "e13208184cee9ed81fd7f6bddfef98bbcd41b5f5",
+      "passes": 1,
+      "pr": 12959
+    },
+    ".agents/scripts/commands/neuronwriter.md": {
+      "at": "2026-03-29T07:02:53Z",
+      "hash": "233c0b9d671275ad8b68ef45c8afaff33acbec34",
+      "passes": 1,
+      "pr": 12588
+    },
+    ".agents/scripts/commands/new-task.md": {
+      "at": "2026-03-30T02:30:59Z",
+      "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
+      "passes": 1,
+      "pr": 13489
+    },
+    ".agents/scripts/commands/postflight-loop.md": {
+      "at": "2026-04-01T20:59:31Z",
+      "hash": "37a467bf622640eb6c8d75aa2c1de45c9a27c61c",
+      "passes": 1,
+      "pr": 14942
+    },
+    ".agents/scripts/commands/pulse.md": {
+      "at": "2026-04-02T14:41:03Z",
+      "hash": "338273dcb0c9118b1c7cce9c5ddb236fd9d3b078",
+      "passes": 3,
+      "pr": 13117
+    },
+    ".agents/scripts/commands/recall.md": {
+      "at": "2026-04-02T04:56:44Z",
+      "hash": "9b0b04b0aeda1a0436139a205db96efcf0e662ad",
+      "passes": 1,
+      "pr": 15515
+    },
+    ".agents/scripts/commands/remember.md": {
+      "at": "2026-03-29T03:14:59Z",
+      "hash": "9b17697bde40499a9feacb7812126a6474b0d5d4",
+      "passes": 1,
+      "pr": 12497
+    },
+    ".agents/scripts/commands/route.md": {
+      "at": "2026-03-31T04:45:56Z",
+      "hash": "f95b19c17d85e3ff5ff46e93f7bae3252de01308",
+      "passes": 2,
+      "pr": 14604
+    },
+    ".agents/scripts/commands/routine.md": {
+      "at": "2026-03-31T03:14:22Z",
+      "hash": "5e9a21d7bf25494b68d2c080b7a1ba28664488cc",
+      "passes": 2,
+      "pr": 14509
+    },
+    ".agents/scripts/commands/runners.md": {
+      "at": "2026-03-28T23:06:00Z",
+      "hash": "34d6abef3517f8c104f651d33d960e5c13afec87",
+      "passes": 2,
+      "pr": 12326
+    },
+    ".agents/scripts/commands/save-todo.md": {
+      "at": "2026-03-29T03:15:15Z",
+      "hash": "9b4ef4321b1b93eb8d349dbdae3b6c717838135c",
+      "passes": 1,
+      "pr": 12521
+    },
+    ".agents/scripts/commands/security-deps.md": {
+      "at": "2026-04-01T20:59:27Z",
+      "hash": "265f2d26f358ffb425e374dca8aa76a7c20c3565",
+      "passes": 1,
+      "pr": 14994
+    },
+    ".agents/scripts/commands/security-history.md": {
+      "at": "2026-04-02T04:56:52Z",
+      "hash": "0c74f125bbb3e299040015ee24fb345e43486ec7",
+      "passes": 1,
+      "pr": 15487
+    },
+    ".agents/scripts/commands/seo-audit.md": {
+      "at": "2026-04-02T03:11:11Z",
+      "hash": "d8d6dee50a191d538e032247f78abb02ebb504a8",
+      "passes": 1,
+      "pr": 15477
+    },
+    ".agents/scripts/commands/show-plan.md": {
+      "at": "2026-03-29T20:53:58Z",
+      "hash": "a50ab6b6bab142d6f388d385dfa6a525b458cac9",
+      "passes": 1,
+      "pr": 13285
+    },
+    ".agents/scripts/commands/skills.md": {
+      "at": "2026-03-29T08:10:30Z",
+      "hash": "b5d46b5e38620ec36852251ec0e4ab4178d9d217",
+      "passes": 1,
+      "pr": 12747
+    },
+    ".agents/scripts/commands/strategic-review.md": {
+      "at": "2026-03-29T08:10:38Z",
+      "hash": "321755ff5b42109fb2ed065075b903ecfed76407",
+      "passes": 1,
+      "pr": 12756
+    },
+    ".agents/scripts/commands/testing-setup.md": {
+      "at": "2026-03-28T16:40:41Z",
+      "hash": "f653aacf0e67efffd18058625b81f790e9c9f741",
+      "passes": 1,
+      "pr": 12013
+    },
+    ".agents/scripts/commands/venv-health.md": {
+      "at": "2026-04-02T09:43:51Z",
+      "hash": "4d985fc7dfe983440e133ac132e682303ca928e8",
+      "passes": 1,
+      "pr": 15577
+    },
+    ".agents/scripts/commands/worktree-cleanup.md": {
+      "at": "2026-04-02T02:30:00Z",
+      "hash": "110dfc59f9c93f01dbf166827f33fc1560b6a7b9",
+      "passes": 1,
+      "pr": null
+    },
+    ".agents/scripts/commands/youtube-research.md": {
+      "at": "2026-03-29T08:10:31Z",
+      "hash": "340b914ca94d03a0c78878b9ec28534fc761f352",
+      "passes": 1,
+      "pr": 12750
+    },
+    ".agents/scripts/commands/youtube-setup.md": {
+      "at": "2026-03-29T12:37:14Z",
+      "hash": "d3f66f792c780e690b58d7f976c01c3d64f09a52",
+      "passes": 1,
+      "pr": 12943
+    },
+    ".agents/scripts/commands/yt-dlp.md": {
+      "at": "2026-03-30T03:34:31Z",
+      "hash": "56c400042f899284be4b65c6480fcac4de404248",
+      "passes": 1,
+      "pr": 13544
+    },
+    ".agents/scripts/foss-handlers/generic.sh": {
+      "at": "2026-03-29T03:15:47Z",
+      "hash": "45cc10462795e6230b70b2f068bb95b4e53612f2",
+      "passes": 1,
+      "pr": 12346
+    },
+    ".agents/scripts/framework-issue-helper.sh": {
+      "at": "2026-04-02T15:26:33Z",
+      "hash": "64247677d8764e3ba8355385495671181569267a",
+      "passes": 2,
+      "pr": 12145
+    },
+    ".agents/scripts/gh-signature-helper.sh": {
+      "at": "2026-03-29T16:34:26Z",
+      "hash": "3dceb47a39cc1230b0f38f697e8cc54a02c27687",
+      "passes": 2,
+      "pr": 13021
+    },
+    ".agents/scripts/headless-runtime-helper.sh": {
+      "at": "2026-04-02T03:11:26Z",
+      "hash": "afbddbc0f8e639803f170b9d8557c01f8c4ba212",
+      "passes": 2,
+      "pr": 15086
+    },
+    ".agents/scripts/matrix-dispatch-helper.sh": {
+      "at": "2026-04-02T03:11:00Z",
+      "hash": "d42a4c2129d808e3bf1fe78109163f12f059c723",
+      "passes": 1,
+      "pr": 15431
+    },
+    ".agents/scripts/platform-detect.sh": {
+      "at": "2026-04-02T04:56:59Z",
+      "hash": "a551a07e07c08853c909e7b8141ddddf2de43420",
+      "passes": 1,
+      "pr": 15455
+    },
+    ".agents/scripts/pulse-wrapper.sh": {
+      "at": "2026-04-02T21:57:56Z",
+      "hash": "0a1b0e22b71d7c37bca0d17c5c476b053ff76b06",
+      "passes": 6,
+      "pr": 15086
+    },
+    ".agents/scripts/stats-functions.sh": {
+      "at": "2026-04-03T01:11:28Z",
+      "hash": "3bd327b19cc722f4ddf43fb1f4724958056e11bb",
+      "passes": 4,
+      "pr": 11273
+    },
+    ".agents/scripts/tests/test-gh-signature-helper.sh": {
+      "at": "2026-03-29T13:19:54Z",
+      "hash": "14e07889b9a874db8e98e44d1c5a8ed1ac3687fb",
+      "passes": 2,
+      "pr": 12971
+    },
+    ".agents/seo.md": {
+      "at": "2026-03-30T03:34:16Z",
+      "hash": "1dcd30f4590e4b2b7792e538d0a70e7d4979aa8e",
+      "passes": 1,
+      "pr": 13526
+    },
+    ".agents/seo/ahrefs.md": {
+      "at": "2026-04-02T03:11:00Z",
+      "hash": "68607c6d5bd42845c1fe21cebb00752f6ff8106d",
+      "passes": 1,
+      "pr": 15431
+    },
+    ".agents/seo/ai-search-kpi-template.md": {
+      "at": "2026-04-01T20:59:36Z",
+      "hash": "292c7a69e131309cd9f0ad3c6459f4af1fcfcff4",
+      "passes": 2,
+      "pr": 14969
+    },
+    ".agents/seo/analytics-tracking.md": {
+      "at": "2026-03-27T21:25:04Z",
+      "hash": "07ff0feec55ad3f8477a6badd724b479c1b09370",
+      "passes": 1,
+      "pr": 11015
+    },
+    ".agents/seo/backlink-checker.md": {
+      "at": "2026-04-02T02:14:59Z",
+      "hash": "16c0f1f109b8a8d47222978204b1f7b955abaa7d",
+      "passes": 2,
+      "pr": null
+    },
+    ".agents/seo/content-analyzer.md": {
+      "at": "2026-04-02T04:56:49Z",
+      "hash": "7972fdccf29515026f0f710dac5f8e1b792e77c5",
+      "passes": 1,
+      "pr": 15478
+    },
+    ".agents/seo/contentking.md": {
+      "at": "2026-03-28T13:37:31Z",
+      "hash": "ce7ecac379f3bc6552cf23ad3bd149902b0ace12",
+      "passes": 1,
+      "pr": 11845
+    },
+    ".agents/seo/data-export.md": {
+      "at": "2026-03-27T21:25:21Z",
+      "hash": "196b3c4788803c0b2b8d412752d3d262d7e6f8b2",
+      "passes": 1,
+      "pr": 11019
+    },
+    ".agents/seo/dataforseo.md": {
+      "at": "2026-03-28T17:11:12Z",
+      "hash": "8dfaad77d57b706e697ab23a2c8ac8a84cf9c6ed",
+      "passes": 1,
+      "pr": 12053
+    },
+    ".agents/seo/debug-favicon.md": {
+      "at": "2026-03-29T22:09:18Z",
+      "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",
+      "passes": 1,
+      "pr": 13323
+    },
+    ".agents/seo/debug-opengraph.md": {
+      "at": "2026-03-28T14:15:42Z",
+      "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
+      "passes": 1,
+      "pr": 11898
+    },
+    ".agents/seo/domain-research-api-reference.md": {
+      "at": "2026-03-28T17:11:07Z",
+      "hash": "52e574da550501d13cf7d760d098926843d5260b",
+      "passes": 1,
+      "pr": 12056
+    },
+    ".agents/seo/domain-research.md": {
+      "at": "2026-03-28T17:11:08Z",
+      "hash": "18f017104a97c94157077b8fc620e24bad8f86ba",
+      "passes": 1,
+      "pr": 12056
+    },
+    ".agents/seo/eeat-score.md": {
+      "at": "2026-03-28T20:56:08Z",
+      "hash": "bb9c0e98f32d0453eb08cbbb4222f06c1a13b007",
+      "passes": 1,
+      "pr": 12181
+    },
+    ".agents/seo/google-search-console.md": {
+      "at": "2026-03-30T06:49:36Z",
+      "hash": "525712f74fe9ec13980ef0564a2108481e894038",
+      "passes": 1,
+      "pr": 13900
+    },
+    ".agents/seo/gsc-sitemaps.md": {
+      "at": "2026-03-28T11:52:39Z",
+      "hash": "7154caa038f21e800f7b6c5493f2553a9d7e8efb",
+      "passes": 1,
+      "pr": 11821
+    },
+    ".agents/seo/image-seo.md": {
+      "at": "2026-03-30T03:34:23Z",
+      "hash": "91991eb82fa32f9ed717213566d5bb49604dfdc4",
+      "passes": 1,
+      "pr": 13530
+    },
+    ".agents/seo/keyword-mapper.md": {
+      "at": "2026-04-02T05:10:00Z",
+      "hash": "028f3ad361b1ba3e37e1839edb0dfec17369c3d5",
+      "passes": 1,
+      "pr": null
+    },
+    ".agents/seo/keyword-research.md": {
+      "at": "2026-03-28T21:27:18Z",
+      "hash": "d00bca2d9a784bfd220b4afd767d384d83bea740",
+      "passes": 1,
+      "pr": 12220
+    },
+    ".agents/seo/mom-test-ux.md": {
+      "at": "2026-03-30T03:34:17Z",
+      "hash": "29c796f48c4b581197f9ea36ed95bbe98bb4ae51",
+      "passes": 1,
+      "pr": 13524
+    },
+    ".agents/seo/moondream.md": {
+      "at": "2026-03-30T03:33:44Z",
+      "hash": "e6e0bef21020b260c31561b4da9fc0ef1e900be5",
+      "passes": 1,
+      "pr": 13663
+    },
+    ".agents/seo/neuronwriter.md": {
+      "at": "2026-03-28T03:54:21Z",
+      "hash": "e6d78a192db4a98186ff9a1f428a07d6455ba42a",
+      "passes": 1,
+      "pr": 11350
+    },
+    ".agents/seo/programmatic-seo.md": {
+      "at": "2026-04-02T21:20:03Z",
+      "hash": "cc9aa2cac637f165854122e6b4328e70a7ee3850",
+      "passes": 2,
+      "pr": 13301
+    },
+    ".agents/seo/semrush.md": {
+      "at": "2026-03-27T21:25:11Z",
+      "hash": "cc61832322267a222c9e557b04459de4a3520086",
+      "passes": 1,
+      "pr": 11006
+    },
+    ".agents/seo/seo-audit-skill.md": {
+      "at": "2026-03-29T12:37:05Z",
+      "hash": "d8493f42e8ba01527667d283942af955218a834f",
+      "passes": 1,
+      "pr": 12948
+    },
+    ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
+      "at": "2026-03-29T23:53:50Z",
+      "hash": "b875488af36564292b08b0bcfabae97d18757135",
+      "passes": 1,
+      "pr": 13444
+    },
+    ".agents/seo/seo-regex.md": {
+      "at": "2026-03-29T22:09:17Z",
+      "hash": "b38e6b1002b80227940c036badb462c8add23514",
+      "passes": 1,
+      "pr": 13325
+    },
+    ".agents/seo/site-crawler.md": {
+      "at": "2026-03-28T08:58:48Z",
+      "hash": "b57ba3a5214383ec97ea5c4838fabcd0ce900a20",
+      "passes": 1,
+      "pr": 11598
+    },
+    ".agents/seo/tech-stack.md": {
+      "at": "2026-03-30T03:34:18Z",
+      "hash": "8b3aa2ab4498e38424d9bd911680bf2e6d45d856",
+      "passes": 1,
+      "pr": 13531
+    },
+    ".agents/services/accounting/quickfile.md": {
+      "at": "2026-03-29T07:02:24Z",
+      "hash": "db7040cc4f46334177d39ff45c6d4fd3be9698ee",
+      "passes": 1,
+      "pr": 12699
+    },
+    ".agents/services/analytics/google-analytics.md": {
+      "at": "2026-03-29T12:36:33Z",
+      "hash": "ee41c3c82de9e7f7dfa997caf2efea635a61fd7f",
+      "passes": 1,
+      "pr": 12950
+    },
+    ".agents/services/communications/bitchat.md": {
+      "at": "2026-03-29T20:53:59Z",
+      "hash": "38ac38ee1cb82fb462fc13746fbf560042e6e9a7",
+      "passes": 1,
+      "pr": 13287
+    },
+    ".agents/services/communications/convos-bridge-template.sh": {
+      "at": "2026-03-28T08:57:52Z",
+      "hash": "cd850bc9a35a947206c1a4cf2e67313bb90f9644",
+      "passes": 1,
+      "pr": 11688
+    },
+    ".agents/services/communications/convos.md": {
+      "at": "2026-03-28T08:57:52Z",
+      "hash": "74e396568b01688f29f86d799f049f5b624b9205",
+      "passes": 1,
+      "pr": 11688
+    },
+    ".agents/services/communications/discord.md": {
+      "at": "2026-03-28T03:53:47Z",
+      "hash": "44cce31bf11bd980e6b95270c913477c86348a15",
+      "passes": 1,
+      "pr": 11287
+    },
+    ".agents/services/communications/google-chat.md": {
+      "at": "2026-04-03T01:11:30Z",
+      "hash": "10fb2a539fb61865c4a9d813c68d69ea1ded5051",
+      "passes": 2,
+      "pr": 13658
+    },
+    ".agents/services/communications/imessage.md": {
+      "at": "2026-03-30T00:32:20Z",
+      "hash": "b16a496c6e98ffbb24f9a833e5b39e9566fb3f6b",
+      "passes": 2,
+      "pr": 13468
+    },
+    ".agents/services/communications/matterbridge.md": {
+      "at": "2026-03-29T01:04:18Z",
+      "hash": "10f123307b4f6919f65b9c46a2e9b5aecf37ef37",
+      "passes": 1,
+      "pr": 12399
+    },
+    ".agents/services/communications/msteams.md": {
+      "at": "2026-03-28T03:54:15Z",
+      "hash": "9818d1daccf3f68d103ecba204aa56431dba6514",
+      "passes": 1,
+      "pr": 11346
+    },
+    ".agents/services/communications/nextcloud-talk.md": {
+      "at": "2026-03-28T03:54:35Z",
+      "hash": "830399729c8d83ca4263bbf736ea549534989f63",
+      "passes": 1,
+      "pr": 11360
+    },
+    ".agents/services/communications/nostr.md": {
+      "at": "2026-03-28T09:17:35Z",
+      "hash": "eacafb8b13831574c6bc570c06903e15e7acd077",
+      "passes": 1,
+      "pr": 11715
+    },
+    ".agents/services/communications/privacy-comparison.md": {
+      "at": "2026-03-28T20:16:54Z",
+      "hash": "d36b5a85b507a958a555b6311d3266035d619ba8",
+      "passes": 1,
+      "pr": 12169
+    },
+    ".agents/services/communications/signal.md": {
+      "at": "2026-03-28T08:58:53Z",
+      "hash": "652f531e6f54f9fd38da5c5bd61889672eac4acf",
+      "passes": 1,
+      "pr": 11620
+    },
+    ".agents/services/communications/simplex.md": {
+      "at": "2026-03-28T20:16:50Z",
+      "hash": "0fae9edf453dabb06fafed112e578d6f45e0f96c",
+      "passes": 1,
+      "pr": 12168
+    },
+    ".agents/services/communications/slack.md": {
+      "at": "2026-03-30T03:34:27Z",
+      "hash": "4894b60910b9fe85ce8dcfb7feb5441fca48be44",
+      "passes": 1,
+      "pr": 13545
+    },
+    ".agents/services/communications/telegram.md": {
+      "at": "2026-03-28T21:58:54Z",
+      "hash": "96307f35314ef975fc24bfc8ea3098ac307e2373",
+      "passes": 1,
+      "pr": 12233
+    },
+    ".agents/services/communications/telfon.md": {
+      "at": "2026-03-31T04:46:03Z",
+      "hash": "bcfbcb400a28970ede2e7ba64abe188935fc887c",
+      "passes": 2,
+      "pr": 14595
+    },
+    ".agents/services/communications/twilio.md": {
+      "at": "2026-03-28T14:15:37Z",
+      "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
+      "passes": 1,
+      "pr": 11900
+    },
+    ".agents/services/communications/urbit.md": {
+      "at": "2026-03-29T12:37:15Z",
+      "hash": "dc74bf7135da0ba31e070bedbe6be841d6b9588b",
+      "passes": 1,
+      "pr": 12911
+    },
+    ".agents/services/communications/whatsapp.md": {
+      "at": "2026-03-29T12:37:29Z",
+      "hash": "dbc5cdbcdc61a880b5ca1c2746408002cc6fa7ac",
+      "passes": 1,
+      "pr": 12821
+    },
+    ".agents/services/communications/xmtp.md": {
+      "at": "2026-03-27T21:25:14Z",
+      "hash": "0b5b1bb178865dc7efff9f7578cd26dd9bf82bc9",
+      "passes": 1,
+      "pr": 11009
+    },
+    ".agents/services/crm/fluentcrm.md": {
+      "at": "2026-03-29T15:51:03Z",
+      "hash": "9e0e2c55d608f6cc55ceec5f45e845bbbc841b0c",
+      "passes": 1,
+      "pr": 13048
+    },
+    ".agents/services/database/multi-org-isolation.md": {
+      "at": "2026-03-28T21:59:22Z",
+      "hash": "2a09353ed9cbb973b0dd0344a938412bcc5b859e",
+      "passes": 1,
+      "pr": 12249
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
+      "at": "2026-03-31T00:00:00Z",
+      "hash": "a42215bc7cdaff6daffe3ca6b1932ffe029b1507",
+      "passes": 1,
+      "pr": 14577
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md": {
+      "at": "2026-03-31T06:23:12Z",
+      "hash": "084644aa5375c89ba69717a690c579d6076d532e",
+      "passes": 2,
+      "pr": 14691
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
+      "at": "2026-03-28T10:27:24Z",
+      "hash": "2bf913e1887714fccd8b5baaf92a9c4afd0eaf44",
+      "passes": 2,
+      "pr": 11709
+    },
+    ".agents/services/database/postgres-drizzle-skill/migrations.md": {
+      "at": "2026-03-28T16:00:44Z",
+      "hash": "1b9f3f2536dd65950e7eec906f4c44467b9619e8",
+      "passes": 1,
+      "pr": 11966
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance-caching.md": {
+      "at": "2026-03-29T15:08:44Z",
+      "hash": "8c834b7d97111cfa9897297aa73c2ef3b366bf16",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance-explain.md": {
+      "at": "2026-03-29T15:08:44Z",
+      "hash": "230ed08a521dea04c78c68e8f7e5eab11f68ea65",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance-indexing.md": {
+      "at": "2026-03-29T15:08:44Z",
+      "hash": "982123000c56dcfb6394064ab6d5ad13a0603dbb",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance-monitoring.md": {
+      "at": "2026-03-29T15:08:44Z",
+      "hash": "38276dd264af6fef1c634f2620d188483aec50be",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance-pagination.md": {
+      "at": "2026-03-29T15:08:44Z",
+      "hash": "7e533ff31428e865c8c608139b2835b146164832",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance-pooling.md": {
+      "at": "2026-03-29T15:08:45Z",
+      "hash": "470b2b768f6fff6d4e925000ec0026254511ea0e",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance-queries.md": {
+      "at": "2026-03-29T15:08:45Z",
+      "hash": "3caacdf6f9053841bd7863c9f7dc002a8b784d1e",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/performance.md": {
+      "at": "2026-03-29T15:08:45Z",
+      "hash": "8d3a6869182b857eedccac3ed7f13229f52abd06",
+      "passes": 1,
+      "pr": 13034
+    },
+    ".agents/services/database/postgres-drizzle-skill/postgres.md": {
+      "at": "2026-03-28T05:50:57Z",
+      "hash": "2633ce6d2343b370a13a3efea1ed735544a6883a",
+      "passes": 1,
+      "pr": 11448
+    },
+    ".agents/services/database/postgres-drizzle-skill/queries.md": {
+      "at": "2026-03-28T06:40:05Z",
+      "hash": "0b8efee41f97c3674fd60bda302f1d674e557b07",
+      "passes": 2,
+      "pr": 11416
+    },
+    ".agents/services/database/postgres-drizzle-skill/relations.md": {
+      "at": "2026-03-28T09:48:57Z",
+      "hash": "673a7c2abd65766f454b57e79a259a7217463210",
+      "passes": 1,
+      "pr": 11717
+    },
+    ".agents/services/database/postgres-drizzle-skill/schema.md": {
+      "at": "2026-03-28T10:27:24Z",
+      "hash": "ed1952db54651cd46710ca9cfa4db950635e42a6",
+      "passes": 1,
+      "pr": 11709
+    },
+    ".agents/services/document-processing/unstract.md": {
+      "at": "2026-03-30T04:51:58Z",
+      "hash": "23759f7d870be0bbd07442ac06a3d7b069c8984b",
+      "passes": 1,
+      "pr": 13720
+    },
+    ".agents/services/email/email-actions.md": {
+      "at": "2026-03-28T16:40:11Z",
+      "hash": "6e4fd843160e764848c98da37b2234e11ddfa56d",
+      "passes": 1,
+      "pr": 12039
+    },
+    ".agents/services/email/email-agent.md": {
+      "at": "2026-03-28T20:16:44Z",
+      "hash": "4c589d1b951ae82f8dbb4a9e7ff05235f5edc6db",
+      "passes": 1,
+      "pr": 12163
+    },
+    ".agents/services/email/email-composition.md": {
+      "at": "2026-03-30T06:03:17Z",
+      "hash": "56336d402a38bf2eaa4d3bb6eebb2ad4dd5cfae7",
+      "passes": 1,
+      "pr": 13837
+    },
+    ".agents/services/email/email-delivery-test.md": {
+      "at": "2026-03-28T16:40:17Z",
+      "hash": "229f4a8a141175830e0207dbb58b13d9146b22ab",
+      "passes": 1,
+      "pr": 12041
+    },
+    ".agents/services/email/email-design-test.md": {
+      "at": "2026-03-29T22:09:19Z",
+      "hash": "216d3927030caa28089c7500c2f6b81c62897d17",
+      "passes": 1,
+      "pr": 13324
+    },
+    ".agents/services/email/email-health-check.md": {
+      "at": "2026-03-30T02:30:20Z",
+      "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
+      "passes": 1,
+      "pr": 13593
+    },
+    ".agents/services/email/email-intelligence.md": {
+      "at": "2026-03-29T12:37:18Z",
+      "hash": "4046abd7e9e4fffe477b2aa6fedd74cc46fb9708",
+      "passes": 1,
+      "pr": 12912
+    },
+    ".agents/services/email/email-mailbox-search.md": {
+      "at": "2026-03-28T13:37:26Z",
+      "hash": "26c7c333d46a5319b598173b36c5c30124126c81",
+      "passes": 1,
+      "pr": 11869
+    },
+    ".agents/services/email/email-mailbox.md": {
+      "at": "2026-03-29T07:02:18Z",
+      "hash": "e9ff02135b83557f59c4e444ef2f07607516b341",
+      "passes": 1,
+      "pr": 12624
+    },
+    ".agents/services/email/email-providers.md": {
+      "at": "2026-03-30T06:49:37Z",
+      "hash": "db4bc27307dd0943c67b08ac0ae471a009076a72",
+      "passes": 2,
+      "pr": 13859
+    },
+    ".agents/services/email/email-security.md": {
+      "at": "2026-03-29T21:43:14Z",
+      "hash": "933383c81c9e820f3d3b80f5dbd3db61d496e0cb",
+      "passes": 1,
+      "pr": 13343
+    },
+    ".agents/services/email/email-verification.md": {
+      "at": "2026-03-31T09:57:12Z",
+      "hash": "b75a2e2fa651e6f7facb266e4d357338c997ced7",
+      "passes": 2,
+      "pr": 14757
+    },
+    ".agents/services/email/google-workspace.md": {
+      "at": "2026-03-28T08:58:52Z",
+      "hash": "d25ed82148411a5ce44101400e445cb3293c4e96",
+      "passes": 1,
+      "pr": 11613
+    },
+    ".agents/services/email/letter-post-bridge.md": {
+      "at": "2026-03-31T05:33:36Z",
+      "hash": "f6065bec96f8cb306e39fe1862b7bf456e1901d3",
+      "passes": 1,
+      "pr": 14646
+    },
+    ".agents/services/email/microsoft-graph.md": {
+      "at": "2026-03-28T21:27:21Z",
+      "hash": "953bb07aef8c8ed23c023cc574b6390196e3b16d",
+      "passes": 1,
+      "pr": 12218
+    },
+    ".agents/services/email/mission-email.md": {
+      "at": "2026-03-28T13:37:15Z",
+      "hash": "bf5446200b94e750fce11fc719c2904f47bd67c5",
+      "passes": 1,
+      "pr": 11889
+    },
+    ".agents/services/email/openpgp-setup.md": {
+      "at": "2026-03-28T16:40:18Z",
+      "hash": "f893cd98da28874d714707765c45a895d991cede",
+      "passes": 1,
+      "pr": 12040
+    },
+    ".agents/services/email/smime-setup.md": {
+      "at": "2026-03-30T06:50:00Z",
+      "hash": "f83bb719e349bb600df046eccc7c1c5603c330f0",
+      "passes": 1,
+      "pr": 13915
+    },
+    ".agents/services/email/thunderbird.md": {
+      "at": "2026-03-29T07:02:32Z",
+      "hash": "97b29677f0dc7c7542e4fb7c2e3dc10bc5445489",
+      "passes": 1,
+      "pr": 12582
+    },
+    ".agents/services/hosting/101domains.md": {
+      "at": "2026-03-28T08:18:27Z",
+      "hash": "504d151b93c6073272de3fca00e08e6118720cf9",
+      "passes": 1,
+      "pr": 11633
+    },
+    ".agents/services/hosting/closte.md": {
+      "at": "2026-03-28T21:27:23Z",
+      "hash": "a9295d1bd4b72a378606ad987d9ea3d5385734c8",
+      "passes": 1,
+      "pr": 12219
+    },
+    ".agents/services/hosting/cloudflare-platform-skill.md": {
+      "at": "2026-03-28T20:16:45Z",
+      "hash": "6008b298c541d6b044eb0779f76074b818140d27",
+      "passes": 1,
+      "pr": 12162
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md": {
+      "at": "2026-04-02T14:41:30Z",
+      "hash": "1baef9315a8b2ef04fb8c54a9a13c9490104f568",
+      "passes": 4,
+      "pr": 15053
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/ai-gateway.md": {
+      "at": "2026-03-28T05:50:52Z",
+      "hash": "720c2836fca088d027ac637f8c69e97cb3c2764a",
+      "passes": 1,
+      "pr": 11443
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/bot-management-gotchas.md": {
+      "at": "2026-04-02T12:50:00Z",
+      "hash": "b2899f138eb2c8f2acfea6aea0d2aa0f274ee4a4",
+      "passes": 1,
+      "pr": 15047
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/c3.md": {
+      "at": "2026-03-28T15:30:18Z",
+      "hash": "6ffc77f50024207bbb549b337789b8c9cbd8f475",
+      "passes": 1,
+      "pr": 11962
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-gotchas.md": {
+      "at": "2026-03-29T22:09:42Z",
+      "hash": "2d19b3d0375bc8ceb48e769e353db722cab18283",
+      "passes": 2,
+      "pr": 13253
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md": {
+      "at": "2026-03-29T08:49:23Z",
+      "hash": "dd2e25d9b8dbb4578e676187c9463404feaa3fec",
+      "passes": 1,
+      "pr": 12779
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/d1-patterns.md": {
+      "at": "2026-03-29T21:43:01Z",
+      "hash": "8e6341f6f72cefdc4c09224910c1c4efe62de068",
+      "passes": 1,
+      "pr": 13296
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
+      "at": "2026-03-30T02:30:53Z",
+      "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
+      "passes": 1,
+      "pr": 13494
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/durable-objects-gotchas.md": {
+      "at": "2026-03-29T11:19:55Z",
+      "hash": "befbfbdf1c28bab3d56f52fb86b4a85a7a988da5",
+      "passes": 1,
+      "pr": 12890
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md": {
+      "at": "2026-03-28T21:50:53Z",
+      "hash": "70f6f1b16aeb637c122232aa75b789bedfbe63a7",
+      "passes": 1,
+      "pr": 12192
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/email-workers.md": {
+      "at": "2026-03-29T03:15:00Z",
+      "hash": "d43b669b4be0f3b85ad9b1e95ff67189431eafdc",
+      "passes": 1,
+      "pr": 12502
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/hyperdrive.md": {
+      "at": "2026-04-02T04:56:50Z",
+      "hash": "1a63158e184bf8c3c6ac2f4b5110e44451c5d837",
+      "passes": 1,
+      "pr": 15481
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/kv-patterns.md": {
+      "at": "2026-03-29T22:09:11Z",
+      "hash": "7637914de409bb05cee56b57db714972a922dbbb",
+      "passes": 1,
+      "pr": 13321
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/miniflare-gotchas.md": {
+      "at": "2026-03-29T07:02:46Z",
+      "hash": "c2a8232a749da0976495eabf4ea541b52bae82f8",
+      "passes": 1,
+      "pr": 12586
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md": {
+      "at": "2026-03-29T14:29:37Z",
+      "hash": "304f6cf07b8e1ce2ccf0991e5a1c7a048d898f2b",
+      "passes": 1,
+      "pr": 13020
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
+      "at": "2026-03-29T12:36:58Z",
+      "hash": "07e97feffa7bc2100478d39e614278ab867ba605",
+      "passes": 1,
+      "pr": 12944
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-patterns.md": {
+      "at": "2026-03-29T12:37:11Z",
+      "hash": "e0498ebcd0125ebedaa97fd88662f8aeff47412a",
+      "passes": 1,
+      "pr": 12909
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
+      "at": "2026-04-02T23:13:23Z",
+      "hash": "dc0ab9b5d1eadafd4faf927c93a89eb11db185eb",
+      "passes": 2,
+      "pr": 14916
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
+      "at": "2026-03-30T06:49:10Z",
+      "hash": "7025e92856e65bda27000657e17b5696107172f3",
+      "passes": 2,
+      "pr": 13929
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md": {
+      "at": "2026-03-30T03:33:53Z",
+      "hash": "70e97040812ad2c593e7b451a917560531eb5903",
+      "passes": 1,
+      "pr": 13667
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
+      "at": "2026-03-30T02:30:18Z",
+      "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
+      "passes": 1,
+      "pr": 13595
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "6f21e87db5f7073e6e3c7c58bcd200553f1362bd",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "94e4a09c8278ba5e5eb4cb44aeadc6a0eb6a53ad",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "c38803612f71b78dc90e51b279452e6b51f0e383",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "4199ffb5b63b069ddb8b3ad8508dba6b7d72e699",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "197b920049e040bf81b6295e8bf760732130c5a9",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "c32415af75bf1288b0d52d7a8765b4e864292fab",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "79b4e58a49cf10008f774b3dd7f92e1301dae3eb",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "f54dc9504f5d680aa797a4677fa8d6955531aa73",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md": {
+      "at": "2026-03-31T07:50:54Z",
+      "hash": "12f54c4e7de2db16e3bed2fc32c1288ad551ef5d",
+      "passes": 2,
+      "pr": 14717
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi-patterns.md": {
+      "at": "2026-03-29T22:09:12Z",
+      "hash": "98b6e10081c4b00014ad525bb96a33a62b6f90a0",
+      "passes": 1,
+      "pr": 13329
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/queues-patterns.md": {
+      "at": "2026-03-30T04:51:49Z",
+      "hash": "5365c2251880bae2876aac89ff39f1dd909a2a0e",
+      "passes": 1,
+      "pr": 13735
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md": {
+      "at": "2026-04-02T15:27:02Z",
+      "hash": "c4d5ed8a074df52b72e94f16782306bf95098b3b",
+      "passes": 2,
+      "pr": 15629
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
+      "at": "2026-03-28T16:00:25Z",
+      "hash": "3078a83990f41df192998904d47d0641191e7fba",
+      "passes": 1,
+      "pr": 11985
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
+      "at": "2026-04-02T23:13:24Z",
+      "hash": "5a75b54baf9c39a8298e2ebbbee01c5c1988db13",
+      "passes": 2,
+      "pr": 14914
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/realtimekit-gotchas.md": {
+      "at": "2026-04-02T15:00:00Z",
+      "hash": "d9ece80ba981cecbe018d046364998faba4503b1",
+      "issue": 14302,
+      "passes": 1,
+      "pr": 15651
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
+      "at": "2026-03-30T03:33:46Z",
+      "hash": "dca9ceb5efbdd602847f9c0030471e543684e1a6",
+      "passes": 1,
+      "pr": 13654
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md": {
+      "at": "2026-03-30T06:49:26Z",
+      "hash": "a0b18de39a54d95b1d687b669e01308b2333655f",
+      "passes": 1,
+      "pr": 13938
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md": {
+      "at": "2026-04-01T23:23:23Z",
+      "hash": "664f8b8e3ddeec9637d1647e3daed4495c1f4a96",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/01-ai-code-execution.md": {
+      "at": "2026-04-01T23:23:23Z",
+      "hash": "01137638b886f973e7f633159da5b9dc457c2416",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/02-interactive-dev-environment.md": {
+      "at": "2026-04-01T23:23:23Z",
+      "hash": "fc0ae968ea17a236a2c90214346e4470cad649b4",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/03-ci-cd-pipeline.md": {
+      "at": "2026-04-01T23:23:24Z",
+      "hash": "63d67404bc099cb3243761e2eeb3881a4f969c68",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/04-multi-language-code-runner.md": {
+      "at": "2026-04-01T23:23:24Z",
+      "hash": "c618c5137724952005c49df413fd5c2170209d83",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/05-multi-tenant.md": {
+      "at": "2026-04-01T23:23:24Z",
+      "hash": "e1d23e98d87b8e8ae9635d954951a70abe88fd57",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/06-jupyter-integration.md": {
+      "at": "2026-04-01T23:23:24Z",
+      "hash": "a7a4b85da6e8ebad5549cbb830bf9aa146b9d204",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/07-git-operations.md": {
+      "at": "2026-04-01T23:23:24Z",
+      "hash": "1610dca7b04c68ad219a4daa34c788dbed864aa2",
+      "passes": 1,
+      "pr": 15353
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/sandbox.md": {
+      "at": "2026-04-02T22:12:27Z",
+      "hash": "39c4bb1352aac7d3e10ccb586d162340e7ac0c7e",
+      "passes": 1,
+      "pr": null
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
+      "at": "2026-03-30T02:54:22Z",
+      "hash": "91b339029c6582618e5664e5c11ba08bbb75af7e",
+      "passes": 1,
+      "pr": 13564
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md": {
+      "at": "2026-04-02T21:20:07Z",
+      "hash": "925bb48a1a5651aca456c9232bf0d79ed9c2bce4",
+      "passes": 2,
+      "pr": 13254
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/stream-patterns.md": {
+      "at": "2026-03-30T06:03:15Z",
+      "hash": "f45d2973f1a08cfb71a1b4e0c66e73895737d463",
+      "passes": 1,
+      "pr": 13844
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/tail-workers.md": {
+      "at": "2026-03-28T08:17:39Z",
+      "hash": "d909ab39413052950bcfff2d355bb102d17f8421",
+      "passes": 1,
+      "pr": 11562
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/terraform-gotchas.md": {
+      "at": "2026-03-28T23:05:57Z",
+      "hash": "2111a2577e4e29eec771f709231f08fa22db2fc0",
+      "passes": 1,
+      "pr": 12324
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/terraform-patterns.md": {
+      "at": "2026-03-30T03:34:24Z",
+      "hash": "463f5c3efbf7a6b11c29193e5f6dcbefd1974fc2",
+      "passes": 1,
+      "pr": 13534
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md": {
+      "at": "2026-03-29T12:36:34Z",
+      "hash": "b194dbf29525881c1c8296a33806387d7ca7fe7f",
+      "passes": 1,
+      "pr": 12955
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/turn.md": {
+      "at": "2026-03-29T08:50:09Z",
+      "hash": "10963e4e50c30efb3918e434ec90cafa0ac2f51a",
+      "passes": 1,
+      "pr": 12801
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md": {
+      "at": "2026-03-28T08:18:21Z",
+      "hash": "10d5c38ac748a992e4619c4042a5ac685b009b3f",
+      "passes": 1,
+      "pr": 11631
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md": {
+      "at": "2026-03-28T08:18:21Z",
+      "hash": "aa4bc86ba1d820a999ff48479bc7af02bc524485",
+      "passes": 1,
+      "pr": 11631
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/vectorize.md": {
+      "at": "2026-03-28T08:18:21Z",
+      "hash": "c1d8339d4d9148d438f87b89220e85fa82e4c859",
+      "passes": 1,
+      "pr": 11631
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
+      "at": "2026-03-31T03:46:07Z",
+      "hash": "c0feb4212f761fd94cc86c49e72e8cbf0be9c42a",
+      "passes": 2,
+      "pr": 14541
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
+      "at": "2026-03-30T03:34:13Z",
+      "hash": "2cbb9c1c836f4b8fce6dbe5b982d8760a75922ce",
+      "passes": 1,
+      "pr": 13636
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-gotchas.md": {
+      "at": "2026-03-29T20:53:54Z",
+      "hash": "eb3c145850e0125035e13fd4bd424405fa4efb97",
+      "passes": 1,
+      "pr": 13291
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
+      "at": "2026-03-29T07:02:06Z",
+      "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
+      "passes": 1,
+      "pr": 12686
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workers-vpc.md": {
+      "at": "2026-03-28T08:57:49Z",
+      "hash": "fd8d3ba366abc324f0738e2e11fce322d92c654b",
+      "passes": 1,
+      "pr": 11677
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
+      "at": "2026-03-31T09:29:58Z",
+      "hash": "27842bda8a80f5fb937401fe5224129d2405ad97",
+      "passes": 2,
+      "pr": 14792
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workflows-gotchas.md": {
+      "at": "2026-03-29T21:43:20Z",
+      "hash": "f9b10b21adc0e823054085098ba86a6e8432ade1",
+      "passes": 1,
+      "pr": 13342
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workflows-patterns.md": {
+      "at": "2026-03-29T21:43:21Z",
+      "hash": "7b01531e7d09b10fc7ab3a1706498fd011b6bb1b",
+      "passes": 1,
+      "pr": 13342
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workflows.md": {
+      "at": "2026-03-29T21:43:21Z",
+      "hash": "5faeef07292125f8b45b6b29bc0b24d06d24c1f1",
+      "passes": 1,
+      "pr": 13342
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md": {
+      "at": "2026-04-01T23:23:38Z",
+      "hash": "d4f5f41aaab3a18b3ba154884526869bcf0b1efe",
+      "passes": 1,
+      "pr": 15335
+    },
+    ".agents/services/hosting/cloudflare.md": {
+      "at": "2026-03-28T16:00:49Z",
+      "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
+      "passes": 1,
+      "pr": 11992
+    },
+    ".agents/services/hosting/cloudron.md": {
+      "at": "2026-03-28T16:40:22Z",
+      "hash": "e9d97dc1a3a3dbe0bb45134f1148c74954fa577c",
+      "passes": 1,
+      "pr": 12046
+    },
+    ".agents/services/hosting/dns-providers.md": {
+      "at": "2026-03-30T03:33:45Z",
+      "hash": "979b0b76e50549adb87fc58efdd0b8d4d7cfed49",
+      "passes": 1,
+      "pr": 13668
+    },
+    ".agents/services/hosting/domain-purchasing.md": {
+      "at": "2026-03-29T10:47:23Z",
+      "hash": "90b1b455705be948e790ea947fafca8285ca29d9",
+      "passes": 1,
+      "pr": 12867
+    },
+    ".agents/services/hosting/hetzner.md": {
+      "at": "2026-03-29T07:02:07Z",
+      "hash": "34c50c3bfd8c86b684e922441da91443f8a22dfd",
+      "passes": 1,
+      "pr": 12687
+    },
+    ".agents/services/hosting/hostinger.md": {
+      "at": "2026-03-28T11:20:19Z",
+      "hash": "bdc3391799c0fb32ef11f6d610f48f7debae2194",
+      "passes": 1,
+      "pr": 11804
+    },
+    ".agents/services/hosting/local-hosting.md": {
+      "at": "2026-03-28T16:41:15Z",
+      "hash": "ac2a557901e0a9c39b034b664927c37847635345",
+      "passes": 1,
+      "pr": 12026
+    },
+    ".agents/services/hosting/proxmox-full-skill.md": {
+      "at": "2026-03-30T06:49:37Z",
+      "hash": "23bcf676fc5edd9dcfebc3fb07b0d4ed6cb61a19",
+      "passes": 1,
+      "pr": 13859
+    },
+    ".agents/services/hosting/webhosting.md": {
+      "at": "2026-03-28T03:54:32Z",
+      "hash": "fb3877648d049a414407d7f9e6beb747c2f92f1d",
+      "passes": 1,
+      "pr": 11352
+    },
+    ".agents/services/monitoring/langwatch.md": {
+      "at": "2026-03-28T16:00:51Z",
+      "hash": "a56ed459849e479aaed06d6ac42bf0d60a28adf9",
+      "passes": 1,
+      "pr": 11994
+    },
+    ".agents/services/monitoring/socket.md": {
+      "at": "2026-04-01T20:59:50Z",
+      "hash": "788506798f5a1eedd29bb5d84aaa61a758c1acd8",
+      "passes": 1,
+      "pr": 14896
+    },
+    ".agents/services/networking/netbird.md": {
+      "at": "2026-03-29T01:33:20Z",
+      "hash": "824fc7ee7cdc7e08351310bdb9f99dcf91a3848e",
+      "passes": 1,
+      "pr": 12453
+    },
+    ".agents/services/networking/tailscale.md": {
+      "at": "2026-03-29T02:36:04Z",
+      "hash": "e930b52dfd40905e93923b036c57b9ffc2bfa011",
+      "passes": 1,
+      "pr": 12461
+    },
+    ".agents/services/outreach/infraforge.md": {
+      "at": "2026-03-31T05:38:33Z",
+      "hash": "0d891dd02a90d75779370f3c62f2929df0bdcd31",
+      "passes": 1,
+      "pr": 14659
+    },
+    ".agents/services/outreach/instantly.md": {
+      "at": "2026-03-31T05:36:34Z",
+      "hash": "34502711d904e25bc38c009d87b329e818ea0c2c",
+      "passes": 3,
+      "pr": 14656
+    },
+    ".agents/services/outreach/manyreach.md": {
+      "at": "2026-03-29T07:02:27Z",
+      "hash": "94a3e08bcf4edafcd9654e8252a1a8851b004217",
+      "passes": 1,
+      "pr": 12581
+    },
+    ".agents/services/outreach/smartlead.md": {
+      "at": "2026-03-28T03:54:38Z",
+      "hash": "8171133da8154e590bca4a6baa8a1bbe05051e05",
+      "passes": 1,
+      "pr": 11357
+    },
+    ".agents/services/payments/procurement.md": {
+      "at": "2026-03-28T09:48:49Z",
+      "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
+      "passes": 1,
+      "pr": 11713
+    },
+    ".agents/services/payments/stripe.md": {
+      "at": "2026-03-29T03:15:16Z",
+      "hash": "6cbe509351f115869d196a09bc7031bb237d2a41",
+      "passes": 1,
+      "pr": 12511
+    },
+    ".agents/services/payments/superwall.md": {
+      "at": "2026-03-29T12:36:44Z",
+      "hash": "1c533274b85654214054f396d45e2b1d09425b85",
+      "passes": 1,
+      "pr": 12952
+    },
+    ".agents/tools/accessibility/accessibility-audit.md": {
+      "at": "2026-03-28T08:18:26Z",
+      "hash": "50607e3251694a312978efe741fd95eb6e47de55",
+      "passes": 1,
+      "pr": 11634
+    },
+    ".agents/tools/accessibility/accessibility.md": {
+      "at": "2026-04-03T02:21:04Z",
+      "hash": "6a9bb1b64297f0b7d6b06a258edc5a7b951c1f47",
+      "passes": 3,
+      "pr": 14053
+    },
+    ".agents/tools/ai-assistants/agno.md": {
+      "at": "2026-03-29T08:10:32Z",
+      "hash": "0e8f56a7ce9681124205e8492ed4878f1a9c73c3",
+      "passes": 1,
+      "pr": 12746
+    },
+    ".agents/tools/ai-assistants/capsolver.md": {
+      "at": "2026-03-29T12:36:41Z",
+      "hash": "934e330cfc0b1a30efe5bf139296ae882f868709",
+      "passes": 1,
+      "pr": 12953
+    },
+    ".agents/tools/ai-assistants/claude-code.md": {
+      "at": "2026-04-01T20:59:01Z",
+      "hash": "dd9666e19eb7e98df75856dd477ecf7ceebf147a",
+      "passes": 1,
+      "pr": 15204
+    },
+    ".agents/tools/ai-assistants/compare-models.md": {
+      "at": "2026-03-29T14:29:46Z",
+      "hash": "4ee54c0d4a2a76b5646c8d5bd3403a6bc744f649",
+      "passes": 1,
+      "pr": 13017
+    },
+    ".agents/tools/ai-assistants/datasets.md": {
+      "at": "2026-04-02T12:00:00Z",
+      "hash": "8b525467afaf93fea7539e9f47fabf2159254ae1",
+      "passes": 1,
+      "pr": 15336
+    },
+    ".agents/tools/ai-assistants/headless-dispatch.md": {
+      "at": "2026-03-29T03:15:46Z",
+      "hash": "00414f5554e8388ffa17859ef02d718061cd911a",
+      "passes": 1,
+      "pr": 12352
+    },
+    ".agents/tools/ai-assistants/models-README.md": {
+      "at": "2026-04-03T01:11:35Z",
+      "hash": "4e2a2bd51c40cb0ce1dd199625f4a2691a818317",
+      "passes": 2,
+      "pr": 15227
+    },
+    ".agents/tools/ai-assistants/models-sonnet.md": {
+      "at": "2026-04-02T23:13:26Z",
+      "hash": "64800a1556f7948083c746ea4bda589616a0f19c",
+      "passes": 2,
+      "pr": 14913
+    },
+    ".agents/tools/ai-assistants/openclaw.md": {
+      "at": "2026-03-28T14:15:40Z",
+      "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
+      "passes": 1,
+      "pr": 11901
+    },
+    ".agents/tools/ai-assistants/opencode-server.md": {
+      "at": "2026-03-28T03:53:56Z",
+      "hash": "15e90e96d742cfe07ffd4cb37c340157d5a8bb74",
+      "passes": 1,
+      "pr": 11345
+    },
+    ".agents/tools/ai-assistants/response-scoring.md": {
+      "at": "2026-03-29T15:50:37Z",
+      "hash": "33f943f8dc56e52eee464c193d4b0fce97d1305d",
+      "passes": 2,
+      "pr": 13072
+    },
+    ".agents/tools/ai-generation/comfy-cli.md": {
+      "at": "2026-03-27T21:25:22Z",
+      "hash": "cec6e1c63f0997e330608cc3610f5a582d7e4d29",
+      "passes": 2,
+      "pr": 11014
+    },
+    ".agents/tools/ai-orchestration/autogen.md": {
+      "at": "2026-03-30T02:54:16Z",
+      "hash": "590a04f8f8f9073b304f6538e550f335e08ffd62",
+      "passes": 1,
+      "pr": 13600
+    },
+    ".agents/tools/ai-orchestration/crewai.md": {
+      "at": "2026-03-28T02:50:59Z",
+      "hash": "e1ed08282945b0708a6840e1d2bb38d92c3d3698",
+      "passes": 1,
+      "pr": 11274
+    },
+    ".agents/tools/ai-orchestration/langflow.md": {
+      "at": "2026-03-30T06:49:09Z",
+      "hash": "8c8c05859cc60d2e341b6cd191075ec540e10c12",
+      "passes": 2,
+      "pr": 13930
+    },
+    ".agents/tools/ai-orchestration/openprose.md": {
+      "at": "2026-03-29T14:29:04Z",
+      "hash": "7d17737b91f8878839b3430a51676211744becce",
+      "passes": 1,
+      "pr": 13007
     },
     ".agents/tools/ai-orchestration/overview.md": {
-        "hash": "3a63b044317f50c757951158e4e711234d09cd299f8dc557bdc5af9e580735f6",
-        "status": "simplified",
-        "issue": "GH#15266",
-        "pr": "PR#16047"
+      "at": "2026-04-03T01:53:08Z",
+      "hash": "4e97ab8ea80342eabab4b326411f74eaeb88bba0",
+      "passes": 2,
+      "pr": 11793
+    },
+    ".agents/tools/ai-orchestration/packaging.md": {
+      "at": "2026-03-28T03:53:52Z",
+      "hash": "4cbea04181622677bff0bdbb611cdd03a3401484",
+      "passes": 1,
+      "pr": 11296
+    },
+    ".agents/tools/animation/animejs.md": {
+      "at": "2026-03-29T08:11:02Z",
+      "hash": "3d011c9aa6ae720f1ed6de08663bf78f589237ec",
+      "passes": 1,
+      "pr": 12745
+    },
+    ".agents/tools/api/better-auth.md": {
+      "at": "2026-03-28T08:58:32Z",
+      "hash": "8494627274fa59f222b8c19aeb61280ded29e8ec",
+      "passes": 1,
+      "pr": 11566
+    },
+    ".agents/tools/api/drizzle.md": {
+      "at": "2026-03-30T04:52:00Z",
+      "hash": "51387eb5d4ff32cccf8469a6ef066f6c2b22fd90",
+      "passes": 2,
+      "pr": 13718
+    },
+    ".agents/tools/api/hono.md": {
+      "at": "2026-03-29T07:02:20Z",
+      "hash": "bf496281a1542c460ea880f936ec4d92dd928900",
+      "passes": 1,
+      "pr": 12607
+    },
+    ".agents/tools/api/vercel-ai-sdk.md": {
+      "at": "2026-03-28T11:20:15Z",
+      "hash": "e0a51bc87d3615a985b527cfe0265571672e2095",
+      "passes": 1,
+      "pr": 11792
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/cheatsheet.md": {
+      "at": "2026-03-28T05:10:19Z",
+      "hash": "7622759c028bec7b85f445a88ab175f13b055133",
+      "passes": 1,
+      "pr": 11393
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md": {
+      "at": "2026-03-30T04:51:54Z",
+      "hash": "2f665556f02ff70ca7d40efdaa6c45150c3384a1",
+      "passes": 2,
+      "pr": 13768
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-strategic.md": {
+      "at": "2026-03-28T11:20:20Z",
+      "hash": "61e87ef7f501310f73fbe54da1d9e0a76a38abae",
+      "passes": 1,
+      "pr": 11805
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-tactical.md": {
+      "at": "2026-03-28T11:20:40Z",
+      "hash": "a53f3400bd5c9142c7f9b186523697b16c1a28e2",
+      "passes": 1,
+      "pr": 11734
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
+      "at": "2026-03-30T06:49:15Z",
+      "hash": "0cf36c2647ee174ec7e68e1e9119bab9e7d6f644",
+      "passes": 2,
+      "pr": 13931
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md": {
+      "at": "2026-03-28T21:58:55Z",
+      "hash": "2fde1ee5df8c1bbde677a3198fe1c39df860a6ba",
+      "passes": 1,
+      "pr": 12236
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill/testing.md": {
+      "at": "2026-03-28T13:38:11Z",
+      "hash": "2316ee0b050453056ecc075e712e88b436dd3dd9",
+      "passes": 1,
+      "pr": 11790
+    },
+    ".agents/tools/architecture/feature-slicing-skill.md": {
+      "at": "2026-03-27T21:25:18Z",
+      "hash": "bb7e28e69e417b4701428fbc2ec0d0608f09e3e2",
+      "passes": 2,
+      "pr": 11010
+    },
+    ".agents/tools/architecture/feature-slicing-skill/cheatsheet.md": {
+      "at": "2026-03-27T21:25:23Z",
+      "hash": "b244fb8417fc27f0de33c83c86092f5bebd736f3",
+      "passes": 1,
+      "pr": 11018
+    },
+    ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
+      "at": "2026-03-28T20:16:39Z",
+      "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
+      "passes": 1,
+      "pr": 12160
+    },
+    ".agents/tools/architecture/feature-slicing-skill/layers.md": {
+      "at": "2026-03-28T08:18:16Z",
+      "hash": "aa5a10592a8a28db7e01ce256df9e7aa7ab57c76",
+      "passes": 1,
+      "pr": 11537
+    },
+    ".agents/tools/architecture/feature-slicing-skill/migration.md": {
+      "at": "2026-03-30T00:32:19Z",
+      "hash": "8adaf46d6bf7a4a77a17c6578948026e2a64e809",
+      "passes": 2,
+      "pr": 13466
+    },
+    ".agents/tools/architecture/feature-slicing-skill/nextjs.md": {
+      "at": "2026-03-28T06:59:34Z",
+      "hash": "0fd2c402556f4d6804ce1a61eeaaaa9c3cecd541",
+      "passes": 1,
+      "pr": 11437
+    },
+    ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
+      "at": "2026-03-28T16:40:13Z",
+      "hash": "52069355367fb596967a8aef0bb6ad7f8e9861c3",
+      "passes": 1,
+      "pr": 12030
+    },
+    ".agents/tools/automation/cron-agent.md": {
+      "at": "2026-03-28T20:56:11Z",
+      "hash": "fbf1c6bc76acc1436d3da1b0b34296be5193de5a",
+      "passes": 1,
+      "pr": 12184
+    },
+    ".agents/tools/automation/mac.md": {
+      "at": "2026-04-01T20:58:52Z",
+      "hash": "1dc19ae4b63343bb6f8a397a6f7e824655e2f986",
+      "passes": 1,
+      "pr": 15253
+    },
+    ".agents/tools/automation/macos-automator.md": {
+      "at": "2026-03-27T21:25:19Z",
+      "hash": "f8771a0d1548af0fbdd76f1944d50ce6b1107f13",
+      "passes": 1,
+      "pr": 11011
+    },
+    ".agents/tools/browser/anti-detect-browser.md": {
+      "at": "2026-03-27T21:25:25Z",
+      "hash": "647081565083b90f27fdce7d25dea9e153fc64a4",
+      "passes": 1,
+      "pr": 11017
+    },
+    ".agents/tools/browser/browser-automation.md": {
+      "at": "2026-03-30T04:51:56Z",
+      "hash": "52c1d946fb9062a82e798821f056e58d93ab321f",
+      "passes": 2,
+      "pr": 13719
+    },
+    ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
+      "at": "2026-04-01T12:00:00Z",
+      "hash": "8d79ff6b9aa02ab04c5f72924b3a7798ee561893",
+      "passes": 1,
+      "pr": 15176
+    },
+    ".agents/tools/browser/browser-profiles.md": {
+      "at": "2026-03-29T07:03:05Z",
+      "hash": "2a2c771f4ff870ad450a92a0f9ad950f3f16e3cb",
+      "passes": 1,
+      "pr": 12501
+    },
+    ".agents/tools/browser/browser-qa.md": {
+      "at": "2026-03-28T20:17:06Z",
+      "hash": "629aa3a1df673d6e5df7310d173da5d3938aa04e",
+      "passes": 1,
+      "pr": 12171
+    },
+    ".agents/tools/browser/browser-use.md": {
+      "at": "2026-03-29T07:03:02Z",
+      "hash": "96d5278ed393a25379da0c21d04db2269219cbf9",
+      "passes": 1,
+      "pr": 12616
+    },
+    ".agents/tools/browser/chrome-devtools.md": {
+      "at": "2026-03-28T22:39:23Z",
+      "hash": "13576e2127eccb1c8555a5b12660265ac4ebd8aa",
+      "passes": 1,
+      "pr": 12310
+    },
+    ".agents/tools/browser/chrome-webstore-release.md": {
+      "at": "2026-03-30T06:49:23Z",
+      "hash": "7d789fec3b99cc63f2dc9033a798921b9f7f2233",
+      "passes": 1,
+      "pr": 13942
+    },
+    ".agents/tools/browser/crawl4ai-integration.md": {
+      "at": "2026-04-02T19:17:13Z",
+      "hash": "6839d1c4bd81f04a3f75f075d43d233cbebfdb3e",
+      "passes": 2,
+      "pr": 15463
+    },
+    ".agents/tools/browser/crawl4ai-resources.md": {
+      "at": "2026-03-28T13:37:22Z",
+      "hash": "3b91d1b3383285e813ef8eed5303e3a6fa8fa99d",
+      "passes": 1,
+      "pr": 11858
+    },
+    ".agents/tools/browser/crawl4ai.md": {
+      "at": "2026-03-28T08:17:51Z",
+      "hash": "967373980ca56ec85cb795eb9426efb91ff23ddb",
+      "passes": 1,
+      "pr": 11599
+    },
+    ".agents/tools/browser/curl-copy.md": {
+      "at": "2026-04-01T21:56:13Z",
+      "hash": "5fb61c717fec1b0cbd8a594f7782b0db73cc2eca",
+      "passes": 2,
+      "pr": null
+    },
+    ".agents/tools/browser/dev-browser.md": {
+      "at": "2026-03-28T15:30:31Z",
+      "hash": "5215652277b228f27d7eddb0cce1a05df09e4a75",
+      "passes": 2,
+      "pr": 11921
+    },
+    ".agents/tools/browser/extension-dev.md": {
+      "at": "2026-03-29T22:09:34Z",
+      "hash": "5d6ac2671414bfdce4481294fce9019711d28c01",
+      "passes": 1,
+      "pr": 13330
+    },
+    ".agents/tools/browser/extension-dev/development.md": {
+      "at": "2026-03-30T04:52:04Z",
+      "hash": "80547436b58e3fd8fb2ce9ab44cfaecedcb32ec3",
+      "passes": 1,
+      "pr": 13722
+    },
+    ".agents/tools/browser/extension-dev/publishing.md": {
+      "at": "2026-03-29T11:20:06Z",
+      "hash": "7fe8e877846c0dc155d639a1b5dd214e47c7e499",
+      "passes": 1,
+      "pr": 12884
+    },
+    ".agents/tools/browser/extension-dev/testing.md": {
+      "at": "2026-03-30T04:51:57Z",
+      "hash": "57d5dc456ab9a6e1d10416777117b96a09cc4f14",
+      "passes": 1,
+      "pr": 13717
+    },
+    ".agents/tools/browser/fingerprint-profiles.md": {
+      "at": "2026-03-28T17:30:27Z",
+      "hash": "d910625e173f65063d64d51ca549494b97a2ba87",
+      "passes": 1,
+      "pr": 12070
+    },
+    ".agents/tools/browser/pagespeed.md": {
+      "at": "2026-03-28T03:53:49Z",
+      "hash": "55b132de0f4ff15dd72cec557bf042cd56b93fec",
+      "passes": 1,
+      "pr": 11295
+    },
+    ".agents/tools/browser/peekaboo.md": {
+      "at": "2026-03-28T03:54:17Z",
+      "hash": "294d232e9625b8a855f17cbea4498a4881a6b0bc",
+      "passes": 1,
+      "pr": 11348
+    },
+    ".agents/tools/browser/playwright-cli.md": {
+      "at": "2026-03-28T11:20:22Z",
+      "hash": "978be4b5b3043cfee751f9c966ba27ddd7fe5182",
+      "passes": 1,
+      "pr": 11802
+    },
+    ".agents/tools/browser/playwriter.md": {
+      "at": "2026-03-29T03:31:38Z",
+      "hash": "98bfa1b0dde9a405a0f3a07aa1ae3eaadc42801a",
+      "passes": 1,
+      "pr": 12516
+    },
+    ".agents/tools/browser/proxy-integration.md": {
+      "at": "2026-03-29T15:08:41Z",
+      "hash": "46806f6e0dcec4831dc62abb84c2f5f96326c102",
+      "passes": 1,
+      "pr": 13032
+    },
+    ".agents/tools/browser/skyvern.md": {
+      "at": "2026-03-28T17:11:10Z",
+      "hash": "1f2933d4cdf35fd9696301a5743ae2e550a31eb0",
+      "passes": 1,
+      "pr": 12055
+    },
+    ".agents/tools/browser/stagehand-examples.md": {
+      "at": "2026-03-28T14:15:24Z",
+      "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
+      "passes": 1,
+      "pr": 11899
+    },
+    ".agents/tools/browser/stagehand-python.md": {
+      "at": "2026-03-30T02:31:00Z",
+      "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
+      "passes": 1,
+      "pr": 13486
+    },
+    ".agents/tools/browser/stagehand.md": {
+      "at": "2026-03-29T03:15:18Z",
+      "hash": "3702284e297e642ee7e2bb0c65470886fc7c0ffb",
+      "passes": 1,
+      "pr": 12513
+    },
+    ".agents/tools/browser/sweet-cookie.md": {
+      "at": "2026-03-29T22:09:35Z",
+      "hash": "763a36ee928e5c54bafe10a5659c75c4c73f42df",
+      "passes": 1,
+      "pr": 13328
+    },
+    ".agents/tools/browser/watercrawl.md": {
+      "at": "2026-03-28T19:15:30Z",
+      "hash": "c3fc2a3c5ee117daba5dfbfae490dfb406b9e711",
+      "passes": 1,
+      "pr": 12117
+    },
+    ".agents/tools/build-agent/add-skill.md": {
+      "at": "2026-03-29T01:03:17Z",
+      "hash": "36065ac3559aa2e929cbb858c8220961454f9dd9",
+      "passes": 1,
+      "pr": 12376
+    },
+    ".agents/tools/build-agent/build-agent.md": {
+      "at": "2026-03-29T14:29:12Z",
+      "hash": "59fa5cde2d2c1b113be43ecdb1a6d8978d3d4f69",
+      "passes": 1,
+      "pr": 12957
+    },
+    ".agents/tools/build-mcp/aidevops-plugin.md": {
+      "at": "2026-04-02T14:42:10Z",
+      "hash": "1663a5f374022feab8fbd51387acaf2f02d0f2c8",
+      "passes": 3,
+      "pr": 14775
+    },
+    ".agents/tools/build-mcp/api-wrapper.md": {
+      "at": "2026-03-28T02:51:01Z",
+      "hash": "68b6075506f6dc1153fec6d5aa78c05d213b0b73",
+      "passes": 1,
+      "pr": 11276
+    },
+    ".agents/tools/build-mcp/api-wrapper/patterns.md": {
+      "at": "2026-03-28T02:51:01Z",
+      "hash": "5aa65e858b380b38b44e647545eda3f1450543b2",
+      "passes": 1,
+      "pr": 11276
+    },
+    ".agents/tools/build-mcp/build-mcp.md": {
+      "at": "2026-03-28T13:37:27Z",
+      "hash": "9b3ca67c49dd5bf0af66b01061561502620de8b3",
+      "passes": 1,
+      "pr": 11844
+    },
+    ".agents/tools/build-mcp/deployment.md": {
+      "at": "2026-03-28T22:39:22Z",
+      "hash": "0229a7490f42dcf4f3b8c0958fefd7ff53f3b8a2",
+      "passes": 1,
+      "pr": 12311
+    },
+    ".agents/tools/build-mcp/server-patterns.md": {
+      "at": "2026-03-28T10:27:33Z",
+      "hash": "c0e5bf0399f60ae53b3b09082ac6ced4debb8c76",
+      "passes": 1,
+      "pr": 11679
+    },
+    ".agents/tools/build-mcp/transports.md": {
+      "at": "2026-03-29T01:04:08Z",
+      "hash": "733acaf8682f80a53cd3c2a996c0571adf7ac018",
+      "passes": 1,
+      "pr": 12394
+    },
+    ".agents/tools/code-review/best-practices.md": {
+      "at": "2026-03-28T13:38:46Z",
+      "hash": "b8f93fd83e04dc301d838178a7b7523e35382166",
+      "passes": 1,
+      "pr": 11771
+    },
+    ".agents/tools/code-review/codacy.md": {
+      "at": "2026-03-29T22:09:31Z",
+      "hash": "3f41e7f2f15e10bf934568ea6ff485cd64ce88c3",
+      "passes": 1,
+      "pr": 13314
+    },
+    ".agents/tools/code-review/code-simplifier.md": {
+      "at": "2026-04-02T21:58:07Z",
+      "hash": "64ff2a38d1ed0d234fb19fba2a9a6c5117ef7ce9",
+      "passes": 4,
+      "pr": null
+    },
+    ".agents/tools/code-review/code-standards.md": {
+      "at": "2026-03-28T15:30:22Z",
+      "hash": "88d5b9dc281a4557707da37dee72529d600faaf8",
+      "passes": 1,
+      "pr": 11944
+    },
+    ".agents/tools/code-review/coderabbit.md": {
+      "at": "2026-03-29T07:02:31Z",
+      "hash": "3e37a12db3473bf11b36f10e75ede64bb2494e1b",
+      "passes": 1,
+      "pr": 12589
+    },
+    ".agents/tools/code-review/qlty.md": {
+      "at": "2026-03-28T18:36:46Z",
+      "hash": "3c3fef1897ddb0b0bb88a35205dfd4d6f715db13",
+      "passes": 1,
+      "pr": 12114
+    },
+    ".agents/tools/code-review/runtime-patterns.md": {
+      "at": "2026-03-28T13:38:47Z",
+      "hash": "06e2affe5aaa285c3139fde0d808dc89c0140e31",
+      "passes": 1,
+      "pr": 11771
+    },
+    ".agents/tools/code-review/secretlint.md": {
+      "at": "2026-03-28T16:00:52Z",
+      "hash": "54a79997b8c268d6b3942204a8b6e23a251bcfe3",
+      "passes": 1,
+      "pr": 11991
+    },
+    ".agents/tools/code-review/security-analysis.md": {
+      "at": "2026-03-30T00:32:18Z",
+      "hash": "9d67a5c1a7278408c78bd6f559e1d43c61040b2e",
+      "passes": 2,
+      "pr": 13467
+    },
+    ".agents/tools/code-review/security-audit.md": {
+      "at": "2026-03-28T17:11:18Z",
+      "hash": "bed16a626f218a4a0045edaae30edfa52616f72c",
+      "passes": 1,
+      "pr": 12029
+    },
+    ".agents/tools/code-review/snyk.md": {
+      "at": "2026-03-27T21:25:26Z",
+      "hash": "e248df7d21db7a21cef8b1e16e1e96f361e3e487",
+      "passes": 1,
+      "pr": 11013
+    },
+    ".agents/tools/containers/remote-dispatch.md": {
+      "at": "2026-03-30T04:52:23Z",
+      "hash": "e6936f346e4acde6d0d596c5295e7864fbea5ede",
+      "passes": 2,
+      "pr": 13733
+    },
+    ".agents/tools/context/augment-context-engine.md": {
+      "at": "2026-03-28T16:40:32Z",
+      "hash": "bbae0554351a40b90c0df31e139c6391601f3e2b",
+      "passes": 1,
+      "pr": 12015
+    },
+    ".agents/tools/context/context-builder.md": {
+      "at": "2026-03-29T20:54:03Z",
+      "hash": "27fb0c83ee803a7eebb4ace6202875b0a844786b",
+      "passes": 1,
+      "pr": 13297
+    },
+    ".agents/tools/context/context-guardrails.md": {
+      "at": "2026-03-30T06:49:16Z",
+      "hash": "35328fa309512f8dc6c77afee69bd1f6068b9e45",
+      "passes": 1,
+      "pr": 13956
+    },
+    ".agents/tools/context/context7.md": {
+      "at": "2026-03-28T20:56:05Z",
+      "hash": "1d98876794a7dc00b2cd2126492a54302f051af8",
+      "passes": 1,
+      "pr": 12182
+    },
+    ".agents/tools/context/dspy.md": {
+      "at": "2026-03-29T20:53:49Z",
+      "hash": "a452d6023063a0eebf04141ae94d61a0867830da",
+      "passes": 1,
+      "pr": 13289
+    },
+    ".agents/tools/context/github-search.md": {
+      "at": "2026-03-29T16:34:35Z",
+      "hash": "526e968501aef58e8e7676ede7ab1396404a32c5",
+      "passes": 1,
+      "pr": 13106
+    },
+    ".agents/tools/context/mcp-discovery.md": {
+      "at": "2026-03-28T03:53:59Z",
+      "hash": "b5851d90484fe52e39f87e3c7af8692778986208",
+      "passes": 1,
+      "pr": 11338
+    },
+    ".agents/tools/context/model-routing.md": {
+      "at": "2026-03-29T22:09:44Z",
+      "hash": "b01bb6dd0d6eda73fa3e19439bb36df2f6d0f15f",
+      "passes": 2,
+      "pr": 13255
+    },
+    ".agents/tools/context/prompt-optimization.md": {
+      "at": "2026-03-29T08:10:39Z",
+      "hash": "94abbde385ccf494358e17a79a32fdc72d4adb58",
+      "passes": 1,
+      "pr": 12749
+    },
+    ".agents/tools/conversion/mineru.md": {
+      "at": "2026-03-28T16:40:36Z",
+      "hash": "beeb4a49df5e2a8ea91da9100ae2ba8887cf6b3d",
+      "passes": 1,
+      "pr": 12012
+    },
+    ".agents/tools/conversion/pandoc.md": {
+      "at": "2026-03-28T08:17:47Z",
+      "hash": "557667b032774727658d22f6b1c5392ec4a83660",
+      "passes": 1,
+      "pr": 11595
+    },
+    ".agents/tools/credentials/api-key-setup.md": {
+      "at": "2026-03-29T20:53:50Z",
+      "hash": "3fe770105e7b4c6edbff6f572b5189e5c2a7ba17",
+      "passes": 1,
+      "pr": 13279
+    },
+    ".agents/tools/credentials/bitwarden.md": {
+      "at": "2026-04-02T04:56:56Z",
+      "hash": "808ffa447534e25dd4090033275c4861a8612f2c",
+      "passes": 1,
+      "pr": 15468
+    },
+    ".agents/tools/credentials/environment-variables.md": {
+      "at": "2026-03-29T08:10:40Z",
+      "hash": "4a7ee0834fefdbf424af90c68648ad35716559c7",
+      "passes": 1,
+      "pr": 12751
+    },
+    ".agents/tools/credentials/gocryptfs.md": {
+      "at": "2026-03-28T11:20:36Z",
+      "hash": "8e128a21d4783c5499f073213aee1a20491893d5",
+      "passes": 1,
+      "pr": 11730
+    },
+    ".agents/tools/credentials/gopass.md": {
+      "at": "2026-03-27T21:25:05Z",
+      "hash": "a59a0077d4d56694894c8cadef6b9c3a294dede0",
+      "passes": 1,
+      "pr": 11021
+    },
+    ".agents/tools/credentials/multi-tenant.md": {
+      "at": "2026-03-27T21:25:16Z",
+      "hash": "efa55dc5b3f2f5222982c1c9f0214ad1e2601624",
+      "passes": 1,
+      "pr": 11008
+    },
+    ".agents/tools/credentials/psst.md": {
+      "at": "2026-03-31T06:15:51Z",
+      "hash": "73a231518b35816ca652d0a2aa130a21dd2b8f1d",
+      "passes": 2,
+      "pr": 14687
+    },
+    ".agents/tools/credentials/sops.md": {
+      "at": "2026-03-28T08:58:29Z",
+      "hash": "927fea51df6b5ed15ee41b1473f26bf7b526ca38",
+      "passes": 1,
+      "pr": 11560
+    },
+    ".agents/tools/credentials/vaultwarden.md": {
+      "at": "2026-03-29T12:36:43Z",
+      "hash": "49a473adf85c8382799bc059d99c1693cbea98a9",
+      "passes": 1,
+      "pr": 12951
+    },
+    ".agents/tools/data-extraction/outscraper.md": {
+      "at": "2026-03-28T16:41:16Z",
+      "hash": "a3e3c1fee3571f9cfe07e4f90d47e3aa0c2c758a",
+      "passes": 1,
+      "pr": 12021
+    },
+    ".agents/tools/database/pglite-local-first.md": {
+      "at": "2026-03-28T15:30:29Z",
+      "hash": "57487b7d3c5e896eaebeeccd458d76e65cae5b8d",
+      "passes": 1,
+      "pr": 11920
+    },
+    ".agents/tools/database/vector-search.md": {
+      "at": "2026-03-28T03:54:19Z",
+      "hash": "d365046c212da54c3ab0ede8217cce083de484c5",
+      "passes": 1,
+      "pr": 11351
+    },
+    ".agents/tools/database/vector-search/per-tenant-rag.md": {
+      "at": "2026-03-28T06:40:00Z",
+      "hash": "9c0a46c72bbf38115155d5214f0256365a03260b",
+      "passes": 1,
+      "pr": 11417
+    },
+    ".agents/tools/database/vector-search/zvec.md": {
+      "at": "2026-03-28T08:17:41Z",
+      "hash": "1929000365507621f52d563ad2b63e9f51feab8d",
+      "passes": 1,
+      "pr": 11570
+    },
+    ".agents/tools/deployment/cloudron-app-packaging-skill.md": {
+      "at": "2026-04-02T20:39:36Z",
+      "hash": "b0b18eb482f60246c0d1961494667f4f06c3a711",
+      "passes": 2,
+      "pr": 14880
+    },
+    ".agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md": {
+      "at": "2026-03-29T10:18:21Z",
+      "hash": "0afd51341e71da8060a8a9e2759bf6629a430093",
+      "passes": 1,
+      "pr": 12844
+    },
+    ".agents/tools/deployment/cloudron-app-packaging.md": {
+      "at": "2026-03-28T03:54:01Z",
+      "hash": "a6ddd4af870f4445d96eb4bf3c2d109fcb9219b7",
+      "passes": 1,
+      "pr": 11344
+    },
+    ".agents/tools/deployment/cloudron-server-ops-skill.md": {
+      "at": "2026-03-30T03:33:52Z",
+      "hash": "254ad33e9ddc52578f62584070efe94ef28a6860",
+      "passes": 2,
+      "pr": 13678
+    },
+    ".agents/tools/deployment/coolify-cli.md": {
+      "at": "2026-03-30T04:52:05Z",
+      "hash": "bceeb18bd221b65e03b4fa7ec3633091a8ee57e2",
+      "passes": 1,
+      "pr": 13734
+    },
+    ".agents/tools/deployment/coolify-setup.md": {
+      "at": "2026-03-29T15:50:41Z",
+      "hash": "2c1d4944a61281731b12ea26d5aad0a44c69740b",
+      "passes": 2,
+      "pr": 13067
+    },
+    ".agents/tools/deployment/coolify.md": {
+      "at": "2026-03-29T08:10:34Z",
+      "hash": "c69569ccf737f434c5d2c4c031ab9fb87e3f6125",
+      "passes": 1,
+      "pr": 12748
+    },
+    ".agents/tools/deployment/daytona.md": {
+      "at": "2026-03-28T13:37:28Z",
+      "hash": "752d573096d1a59e09ee119494e907e2e17d34ee",
+      "passes": 1,
+      "pr": 11846
+    },
+    ".agents/tools/deployment/fly-io.md": {
+      "at": "2026-03-30T02:30:21Z",
+      "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
+      "passes": 1,
+      "pr": 13596
+    },
+    ".agents/tools/deployment/hosting-comparison.md": {
+      "at": "2026-03-29T07:02:09Z",
+      "hash": "d29068fa3678e9cf3c2d6709305d5d71e5488dcb",
+      "passes": 1,
+      "pr": 12661
+    },
+    ".agents/tools/deployment/uncloud.md": {
+      "at": "2026-03-28T09:17:40Z",
+      "hash": "f0efc54a4b03f1e5a1398d94d063d72218a8de21",
+      "passes": 1,
+      "pr": 11712
+    },
+    ".agents/tools/deployment/vercel.md": {
+      "at": "2026-03-28T08:58:54Z",
+      "hash": "c2084ec268e00720815607590f8bab4bc7082c53",
+      "passes": 1,
+      "pr": 11615
+    },
+    ".agents/tools/design/brand-identity.md": {
+      "at": "2026-03-29T16:31:32Z",
+      "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
+      "passes": 1,
+      "pr": 13093
+    },
+    ".agents/tools/design/design-inspiration.md": {
+      "at": "2026-03-29T08:10:43Z",
+      "hash": "c45174a87827d85931f259a2e60da60b030b9fef",
+      "passes": 1,
+      "pr": 12754
+    },
+    ".agents/tools/design/ui-ux-inspiration.md": {
+      "at": "2026-03-28T08:17:35Z",
+      "hash": "fb4a8985ec3089753355c7a13d0665c878034369",
+      "passes": 1,
+      "pr": 11590
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
+      "at": "2026-03-28T15:30:35Z",
+      "hash": "97a482f311bb9a1a99a103e7b77f815c8ce8af7e",
+      "passes": 1,
+      "pr": 11935
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/advanced.md": {
+      "at": "2026-03-29T11:51:51Z",
+      "hash": "66bd6cabafb5379b9b183e5c0721e35852080713",
+      "passes": 1,
+      "pr": 12922
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
+      "at": "2026-03-28T16:00:33Z",
+      "hash": "9fda0fe135c5d900b529cbf4c9b5095c72c9a79d",
+      "passes": 1,
+      "pr": 11987
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md": {
+      "at": "2026-03-29T21:43:04Z",
+      "hash": "79456bef17217d0052079264a0c95b59456d5385",
+      "passes": 1,
+      "pr": 13300
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/class-er.md": {
+      "at": "2026-03-28T08:17:42Z",
+      "hash": "e3929bc050f03d955e21543cfed73a4b69880579",
+      "passes": 1,
+      "pr": 11589
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/data-charts.md": {
+      "at": "2026-03-28T08:58:03Z",
+      "hash": "ea8a64811a9c35a4274183f1c0c215be8c2a6aec",
+      "passes": 1,
+      "pr": 11602
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md": {
+      "at": "2026-03-30T04:52:39Z",
+      "hash": "dd47fcc7b562ecb9f085d0d7394553810ecabc8c",
+      "passes": 1,
+      "pr": 13784
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/sequence.md": {
+      "at": "2026-03-28T05:10:17Z",
+      "hash": "162ba5164f7ffedc3b1d3497beabd56c6d58aaba",
+      "passes": 1,
+      "pr": 11392
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md": {
+      "at": "2026-03-29T08:11:29Z",
+      "hash": "2fda89c67e49f210c5079578f56272001edd02d9",
+      "passes": 1,
+      "pr": 12755
+    },
+    ".agents/tools/document/docstrange.md": {
+      "at": "2026-03-29T16:34:31Z",
+      "hash": "3982c1885258882161976446bb94216d4e7df262",
+      "passes": 1,
+      "pr": 13102
+    },
+    ".agents/tools/document/document-creation.md": {
+      "at": "2026-03-28T08:17:34Z",
+      "hash": "245a303a923bd18c0adc820adb9620f12d636d2b",
+      "passes": 1,
+      "pr": 11592
+    },
+    ".agents/tools/document/document-extraction.md": {
+      "at": "2026-03-28T15:30:30Z",
+      "hash": "b0e790ef3e6481f532436eab39cac1d6ec92430b",
+      "passes": 1,
+      "pr": 11919
+    },
+    ".agents/tools/document/extraction-schemas.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "fa0ee1f8e92a38842d98674241507fd0cde43a81",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/01-design-principles.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "c557fde290bb52a65fa91d603c4366fdb0fcf3e7",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/02-purchase-invoice.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "d9c194618044c58a6f3a364bba869683957b26c1",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/03-expense-receipt.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "8c0553d204c9f8e111f7bb211d9b8e99a8fac453",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/04-credit-note.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "c58830493ee6a0ae1b3f77c6fb18a20db5e87ed4",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/05-sales-invoice.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "50c68e48c09eb85c30259361ceadadca01795e5e",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/06-generic-receipt.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "8cd493fef922d42decca280eaaec76c32de7f324",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/07-quickfile-mapping.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "329bb22bc68c98571c6bd075a6458573830bcd99",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/08-vat-handling.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "74ea1c15f941a48b3cb8d0a62dc8fa3ec590dd86",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/09-nominal-codes.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "7210b70a3f8072de3d50be138635dced20594d9d",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/10-classification.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "8822a182e225ee7360107f5e1938e4fc844670e3",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/11-pipeline-integration.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "377abccc10cb93b5f8b51010a48d6d947553b71c",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/12-validation.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "85fb1862ed295cbba2a8c11ed8ccef35d25fc2c4",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-workflow.md": {
+      "at": "2026-04-01T23:23:22Z",
+      "hash": "ff97788918db3fac18f34e7b0f3d18155d449e88",
+      "passes": 1,
+      "pr": 15350
+    },
+    ".agents/tools/git/authentication.md": {
+      "at": "2026-03-30T02:30:25Z",
+      "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
+      "passes": 1,
+      "pr": 13538
+    },
+    ".agents/tools/git/conflict-resolution.md": {
+      "at": "2026-03-28T14:15:35Z",
+      "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
+      "passes": 1,
+      "pr": 11909
+    },
+    ".agents/tools/git/gitea-cli.md": {
+      "at": "2026-03-29T07:02:58Z",
+      "hash": "9452ee8a8cf48269d5848e1d31384a3df0462ec5",
+      "passes": 1,
+      "pr": 12618
+    },
+    ".agents/tools/git/gitlab-cli.md": {
+      "at": "2026-03-29T03:15:01Z",
+      "hash": "de6952c2d9d3316c91c942921113892f89ddd42c",
+      "passes": 1,
+      "pr": 12498
+    },
+    ".agents/tools/git/lumen.md": {
+      "at": "2026-04-01T23:23:19Z",
+      "hash": "4a2b4339feef8da5578b029993d870a6416758b7",
+      "passes": 1,
+      "pr": 15327
+    },
+    ".agents/tools/git/opencode-github-security.md": {
+      "at": "2026-03-28T22:39:20Z",
+      "hash": "7614267ce5278cc0f8d3e46a9301f179a610b9f3",
+      "passes": 1,
+      "pr": 12309
+    },
+    ".agents/tools/git/opencode-github.md": {
+      "at": "2026-03-28T03:54:27Z",
+      "hash": "02c6d675ca2b756817bc639ec03d999e1f3ea58e",
+      "passes": 1,
+      "pr": 11349
+    },
+    ".agents/tools/git/opencode-gitlab.md": {
+      "at": "2026-03-29T20:54:06Z",
+      "hash": "dbbdec9a030f52229eab4d047431f4ed5b0de5ca",
+      "passes": 1,
+      "pr": 13295
+    },
+    ".agents/tools/git/worktrunk.md": {
+      "at": "2026-03-28T10:27:11Z",
+      "hash": "bafc956a55ed67b84dfc0722955434b85dd6202e",
+      "passes": 1,
+      "pr": 11760
+    },
+    ".agents/tools/infrastructure/cloud-gpu.md": {
+      "at": "2026-03-29T21:43:22Z",
+      "hash": "f2b2d82030ffec23c21ca82c2833ba2cbac2dcc9",
+      "passes": 1,
+      "pr": 13346
+    },
+    ".agents/tools/infrastructure/cloudflare-ai.md": {
+      "at": "2026-04-01T20:50:00Z",
+      "hash": "3896e5a3b0f6a86223b5def1d491061d8264b671",
+      "passes": 2,
+      "pr": 15091
+    },
+    ".agents/tools/infrastructure/fireworks.md": {
+      "at": "2026-03-28T11:52:26Z",
+      "hash": "6025fc8a3ce3cadba1f1d8d00c699c8fe970b015",
+      "passes": 1,
+      "pr": 11813
+    },
+    ".agents/tools/infrastructure/nearai.md": {
+      "at": "2026-03-29T10:47:24Z",
+      "hash": "c20f6f36a9c7c2fabc45e4c356d09b3589fb6a64",
+      "passes": 1,
+      "pr": 12869
+    },
+    ".agents/tools/infrastructure/nvidia-cloud.md": {
+      "at": "2026-03-29T08:49:20Z",
+      "hash": "3dfae170793fb08c63d93733cd5ad81760d651ee",
+      "passes": 1,
+      "pr": 12776
+    },
+    ".agents/tools/infrastructure/together.md": {
+      "at": "2026-03-29T17:15:24Z",
+      "hash": "cb2b6cf6c54db6f97c2bde70675f3c29b30b88fa",
+      "passes": 1,
+      "pr": 13113
+    },
+    ".agents/tools/local-models/local-models.md": {
+      "at": "2026-03-29T08:11:30Z",
+      "hash": "9809ec0871562ca709e8ef42cf6c3b67d24b69ce",
+      "passes": 1,
+      "pr": 12758
+    },
+    ".agents/tools/mcp-toolkit/mcporter.md": {
+      "at": "2026-03-28T14:16:17Z",
+      "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
+      "passes": 1,
+      "pr": 11906
+    },
+    ".agents/tools/mcp/cloudflare-code-mode.md": {
+      "at": "2026-03-29T23:54:08Z",
+      "hash": "57f7a7876d43b24c1a40f59332c004b5932adae1",
+      "passes": 1,
+      "pr": 13428
+    },
+    ".agents/tools/mobile/agent-device.md": {
+      "at": "2026-03-29T08:49:16Z",
+      "hash": "29bde4b26353446f6b35c132fcc1c01a80b71d4c",
+      "passes": 1,
+      "pr": 12788
+    },
+    ".agents/tools/mobile/app-dev-assets.md": {
+      "at": "2026-03-29T16:34:32Z",
+      "hash": "7c4254ecd409ec8aa9947d5ac9bb1043f89ee75c",
+      "passes": 1,
+      "pr": 13108
+    },
+    ".agents/tools/mobile/app-dev-backend.md": {
+      "at": "2026-03-29T20:54:10Z",
+      "hash": "1521ed7526fbc0fb399a1f5edf01adb4129a08f6",
+      "passes": 1,
+      "pr": 13293
+    },
+    ".agents/tools/mobile/app-dev-expo.md": {
+      "at": "2026-03-30T03:34:14Z",
+      "hash": "e0094f52acaa98cc6a2c7aa9aeae6321a204cb27",
+      "passes": 1,
+      "pr": 13609
+    },
+    ".agents/tools/mobile/app-dev-notifications.md": {
+      "at": "2026-03-29T16:34:38Z",
+      "hash": "c414024f2e98e68e7f70531095cc1abe49cceccd",
+      "passes": 1,
+      "pr": 13111
+    },
+    ".agents/tools/mobile/app-dev-publishing.md": {
+      "at": "2026-03-29T08:11:31Z",
+      "hash": "ceb75a07d39bcfe0be156773a92714fb3bebce23",
+      "passes": 2,
+      "pr": 12760
+    },
+    ".agents/tools/mobile/app-dev-swift.md": {
+      "at": "2026-03-29T07:03:03Z",
+      "hash": "15ec4fad109dcdce50f6ed4a70d117caff12f906",
+      "passes": 1,
+      "pr": 12506
+    },
+    ".agents/tools/mobile/app-dev-testing.md": {
+      "at": "2026-04-01T20:59:09Z",
+      "hash": "39d2e16ec10aee6ed51d5a9b586e20ac0ba4276a",
+      "passes": 1,
+      "pr": 15219
+    },
+    ".agents/tools/mobile/app-dev.md": {
+      "at": "2026-03-29T08:10:35Z",
+      "hash": "5fa80cfb5528478d449196a550ffb263ac4380e0",
+      "passes": 1,
+      "pr": 12752
+    },
+    ".agents/tools/mobile/app-store-connect.md": {
+      "at": "2026-03-29T07:02:17Z",
+      "hash": "55340aa49411b8c5faf342ecbd1284bd9b126390",
+      "passes": 1,
+      "pr": 12625
+    },
+    ".agents/tools/mobile/ios-simulator-mcp.md": {
+      "at": "2026-03-29T20:53:56Z",
+      "hash": "c671f21c21913d5bc3199aaaf1ad5ea389fa67e7",
+      "passes": 1,
+      "pr": 13299
+    },
+    ".agents/tools/mobile/maestro.md": {
+      "at": "2026-03-30T03:34:20Z",
+      "hash": "9cfba2015ca5bd40086f5d15c690910a0a3c6bfd",
+      "passes": 1,
+      "pr": 13525
+    },
+    ".agents/tools/mobile/minisim.md": {
+      "at": "2026-03-29T21:43:16Z",
+      "hash": "4e237b094b421f7ff8557426808fd3d6380b4ef1",
+      "passes": 1,
+      "pr": 13340
+    },
+    ".agents/tools/monorepo/turborepo.md": {
+      "at": "2026-03-30T06:49:45Z",
+      "hash": "f7bededd972af841de7b68b6169a00b890078d3e",
+      "passes": 2,
+      "pr": 13795
+    },
+    ".agents/tools/ocr/ocr-research.md": {
+      "at": "2026-03-28T13:37:30Z",
+      "hash": "667a0af0fe47f5c2c316520d13beb61f1f9d0b7f",
+      "passes": 1,
+      "pr": 11857
+    },
+    ".agents/tools/ocr/paddleocr.md": {
+      "at": "2026-03-30T06:49:51Z",
+      "hash": "7e0aaf06abd6c0d64ef0645a3cd58ac02b9e11f4",
+      "passes": 1,
+      "pr": 13765
+    },
+    ".agents/tools/opencode/opencode-anthropic-auth.md": {
+      "at": "2026-03-29T03:15:28Z",
+      "hash": "f05464c433b2b8e301af49ac5693cba5662ca6f7",
+      "passes": 1,
+      "pr": 12522
+    },
+    ".agents/tools/opencode/opencode.md": {
+      "at": "2026-03-29T11:20:16Z",
+      "hash": "b338bd4964d10e7780deddb27fc48d772a07be3b",
+      "passes": 1,
+      "pr": 12843
+    },
+    ".agents/tools/pdf/libpdf.md": {
+      "at": "2026-03-28T20:16:42Z",
+      "hash": "9d4d5fd4651f9132fb47d6467e53683fd7f0553b",
+      "passes": 1,
+      "pr": 12161
+    },
+    ".agents/tools/performance/performance.md": {
+      "at": "2026-03-28T16:00:21Z",
+      "hash": "478f1736c9c362f035765d45caddb4eebdec8071",
+      "passes": 1,
+      "pr": 11983
+    },
+    ".agents/tools/performance/webpagetest.md": {
+      "at": "2026-03-28T08:17:50Z",
+      "hash": "e0b3e8da23436e916aecd40d37bceeea48f99642",
+      "passes": 1,
+      "pr": 11594
+    },
+    ".agents/tools/programming/modern-javascript-skill.md": {
+      "at": "2026-04-01T20:59:25Z",
+      "hash": "3c3730959a3c618e3b3ed96d1ccd5eb95c2bfe3b",
+      "passes": 1,
+      "pr": 15131
+    },
+    ".agents/tools/programming/modern-javascript-skill/01-decision-trees.md": {
+      "at": "2026-04-01T20:59:25Z",
+      "hash": "80190196c391d4314e034455e46fe218d57d1c58",
+      "passes": 1,
+      "pr": 15131
+    },
+    ".agents/tools/programming/modern-javascript-skill/02-es-versions.md": {
+      "at": "2026-04-01T20:59:25Z",
+      "hash": "8c9215cc4697a3cd21125445386a8315acb42e0d",
+      "passes": 1,
+      "pr": 15131
+    },
+    ".agents/tools/programming/modern-javascript-skill/cheatsheet.md": {
+      "at": "2026-03-28T16:40:20Z",
+      "hash": "5043165087af14cf58963d7a76e48ceed463cb6d",
+      "passes": 1,
+      "pr": 12042
+    },
+    ".agents/tools/programming/modern-javascript-skill/composition.md": {
+      "at": "2026-03-28T03:53:07Z",
+      "hash": "fe9da3d05db78aac6b072235efe8b74f5c9fcf2b",
+      "passes": 1,
+      "pr": 11328
+    },
+    ".agents/tools/programming/modern-javascript-skill/concurrency.md": {
+      "at": "2026-03-29T22:50:16Z",
+      "hash": "ca3483bf9f49a475d7947fa68bb46f12426ef656",
+      "passes": 2,
+      "pr": 13349
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
+      "at": "2026-03-28T05:50:55Z",
+      "hash": "b59a17a028d181e2f55c45e58c371ca999d9a2ee",
+      "passes": 1,
+      "pr": 11439
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2022-es2023.md": {
+      "at": "2026-03-28T03:53:13Z",
+      "hash": "5e5dfb7e18557b8e26c5c48c090c8df94eda485c",
+      "passes": 1,
+      "pr": 11337
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2024.md": {
+      "at": "2026-03-27T21:25:08Z",
+      "hash": "5ff178dfe9603a724792aaef45d63f4b33fce7ef",
+      "passes": 1,
+      "pr": 11002
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2025.md": {
+      "at": "2026-03-28T21:58:57Z",
+      "hash": "e23026c24b61f06282834858aead51f63df3de4d",
+      "passes": 1,
+      "pr": 12234
+    },
+    ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
+      "at": "2026-03-29T07:02:28Z",
+      "hash": "a2b88a20fedbcbbf37624126551caf4b6a101400",
+      "passes": 1,
+      "pr": 12584
+    },
+    ".agents/tools/research/providers/crft-lookup.md": {
+      "at": "2026-03-30T03:34:28Z",
+      "hash": "70a64dd60d9a32431e5c36f75d0ad6aed1865c46",
+      "passes": 1,
+      "pr": 13542
+    },
+    ".agents/tools/research/providers/unbuilt.md": {
+      "at": "2026-03-29T12:36:25Z",
+      "hash": "24d4b4257014273b29b58f5e185f3320e798dad0",
+      "passes": 1,
+      "pr": 12945
+    },
+    ".agents/tools/research/providers/wappalyzer.md": {
+      "at": "2026-03-28T20:17:04Z",
+      "hash": "ef665188513a7db11f82af28c6b0440d2b3943d5",
+      "passes": 1,
+      "pr": 12115
+    },
+    ".agents/tools/research/tech-stack-lookup.md": {
+      "at": "2026-03-29T07:02:42Z",
+      "hash": "bb8bdd9ccd46c7cc0742a5ba1849bb47746c2110",
+      "passes": 1,
+      "pr": 12579
+    },
+    ".agents/tools/security/cdn-origin-ip.md": {
+      "at": "2026-03-29T20:53:57Z",
+      "hash": "0ffd8a94c87de9f75a5515cd4ad4e87ab4b1552b",
+      "passes": 1,
+      "pr": 13290
+    },
+    ".agents/tools/security/ip-reputation.md": {
+      "at": "2026-03-28T03:54:03Z",
+      "hash": "a1da2aa2f5e2f454f3c1dbcd3a7a819a72cd80dd",
+      "passes": 1,
+      "pr": 11342
+    },
+    ".agents/tools/security/opsec.md": {
+      "at": "2026-03-29T03:15:14Z",
+      "hash": "c0427c90ef2576abbb9115f920944e06ee023080",
+      "passes": 1,
+      "pr": 12507
+    },
+    ".agents/tools/security/privacy-filter.md": {
+      "at": "2026-03-28T16:41:02Z",
+      "hash": "20015ffb18e50ebb7071f1b6299b4404bdcd4071",
+      "passes": 1,
+      "pr": 12014
+    },
+    ".agents/tools/security/prompt-injection-defender.md": {
+      "at": "2026-03-28T17:11:06Z",
+      "hash": "0ee667b145d5e9aa8e6aefabf4ddc1c717cac0a0",
+      "passes": 1,
+      "pr": 12057
+    },
+    ".agents/tools/security/shannon.md": {
+      "at": "2026-03-28T16:41:03Z",
+      "hash": "a48914d21141559b0cf7677395979bd17f429b85",
+      "passes": 1,
+      "pr": 12016
+    },
+    ".agents/tools/security/tamper-evident-audit.md": {
+      "at": "2026-03-29T21:43:17Z",
+      "hash": "ef75d5914e0ae15e449ccd4480b0add3eda84c71",
+      "passes": 1,
+      "pr": 13316
+    },
+    ".agents/tools/task-management/beads.md": {
+      "at": "2026-03-29T09:39:21Z",
+      "hash": "f42ad2e963039fd53ee52d1443827cbe4f6158c0",
+      "passes": 1,
+      "pr": 12830
+    },
+    ".agents/tools/terminal/terminal-optimization.md": {
+      "at": "2026-03-29T03:15:29Z",
+      "hash": "f33e57108fd87d88906e414ae5caf4d169efb557",
+      "passes": 1,
+      "pr": 12526
+    },
+    ".agents/tools/ui/ai-chat-sidebar.md": {
+      "at": "2026-04-02T15:28:13Z",
+      "hash": "fc9db0532fa56a02b82ccc7692d25933098eb6d4",
+      "passes": 3,
+      "pr": 13958
+    },
+    ".agents/tools/ui/frontend-debugging.md": {
+      "at": "2026-03-28T03:54:06Z",
+      "hash": "272d16549c353500a19666d7ace227b34b2ae363",
+      "passes": 1,
+      "pr": 11340
+    },
+    ".agents/tools/ui/i18next.md": {
+      "at": "2026-03-28T10:27:25Z",
+      "hash": "ce750937b182da6a4a2cce512b141f16da789fcd",
+      "passes": 1,
+      "pr": 11710
+    },
+    ".agents/tools/ui/nextjs-layouts.md": {
+      "at": "2026-03-28T11:20:37Z",
+      "hash": "df90871ad91810f05326405fe711c4ff4be9460b",
+      "passes": 1,
+      "pr": 11732
+    },
+    ".agents/tools/ui/nothing-design-skill.md": {
+      "at": "2026-04-02T13:10:57Z",
+      "hash": "79354d8379744c33148bf864cad6dfd666796f48",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/01-philosophy.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "8bc354205fdf54beaf7d172ac0eee06a8b64e976",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/02-craft-rules.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "94d72d92e90419eada4260a7d0b996d620643f11",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/03-anti-patterns.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "916c5faa425da052f819788628e826d489ed10c9",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/04-workflow.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "3a1d2cbabb57f2dabfa60c4fcb1e9659729a53af",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/react-context.md": {
+      "at": "2026-03-30T06:49:50Z",
+      "hash": "dee0f2d9a70f699ee8e09bc3c855e84eabb9a806",
+      "passes": 1,
+      "pr": 13766
+    },
+    ".agents/tools/ui/react-email.md": {
+      "at": "2026-03-29T07:02:59Z",
+      "hash": "44be6e93a23aa087b4b70af9dc49a1c566c47e8c",
+      "passes": 1,
+      "pr": 12619
+    },
+    ".agents/tools/ui/shadcn.md": {
+      "at": "2026-03-29T07:02:41Z",
+      "hash": "b65c32526cb52d71c76cead493b7c71147417a78",
+      "passes": 1,
+      "pr": 12590
+    },
+    ".agents/tools/ui/tailwind-css.md": {
+      "at": "2026-03-29T07:02:43Z",
+      "hash": "1f3b2d4e3add5cecfe530b8db9addf411a9069fe",
+      "passes": 1,
+      "pr": 12576
+    },
+    ".agents/tools/ui/wxt.md": {
+      "at": "2026-03-28T13:37:50Z",
+      "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
+      "passes": 1,
+      "pr": 11870
+    },
+    ".agents/tools/verification/parallel-verify.md": {
+      "at": "2026-03-29T10:19:07Z",
+      "hash": "0abbe9f5d2f2082016fd851080ea1f9a84a03fe9",
+      "passes": 1,
+      "pr": 12849
+    },
+    ".agents/tools/video/remotion-3d.md": {
+      "at": "2026-04-01T20:59:48Z",
+      "hash": "054778cef20067cd0e02cbd7b049333f562e6e4a",
+      "passes": 1,
+      "pr": 14897
+    },
+    ".agents/tools/video/remotion-audio.md": {
+      "at": "2026-03-29T12:37:07Z",
+      "hash": "c5cce614253505277075e44f178650fab250bd7b",
+      "passes": 1,
+      "pr": 12942
+    },
+    ".agents/tools/video/remotion-compositions.md": {
+      "at": "2026-03-29T23:18:01Z",
+      "hash": "6b00afa2299a8d08eaacd114c67804f6d87614b1",
+      "passes": 1,
+      "pr": 13427
+    },
+    ".agents/tools/video/remotion-fonts.md": {
+      "at": "2026-04-02T14:42:45Z",
+      "hash": "2e12fc37c6a4f8397a9444f522ea88ef9d10285f",
+      "passes": 1,
+      "pr": 15615
+    },
+    ".agents/tools/video/remotion-gifs.md": {
+      "at": "2026-03-29T22:09:13Z",
+      "hash": "c87be7656e27afb4f5f23e41571f8428b21345c4",
+      "passes": 1,
+      "pr": 13322
+    },
+    ".agents/tools/video/remotion-images.md": {
+      "at": "2026-03-30T03:34:15Z",
+      "hash": "789b0f83404d30882f5f6b24317d4319f95dd107",
+      "passes": 1,
+      "pr": 13527
+    },
+    ".agents/tools/video/remotion-import-srt-captions.md": {
+      "at": "2026-04-02T04:56:51Z",
+      "hash": "75f8b0d089b9eaae8a7e08498af9b8c5f1ac4655",
+      "passes": 1,
+      "pr": 15490
+    },
+    ".agents/tools/video/remotion-lottie.md": {
+      "at": "2026-04-02T04:56:53Z",
+      "hash": "72d843e6717a28f61294372a6752cb8e9736fe6b",
+      "passes": 1,
+      "pr": 15525
+    },
+    ".agents/tools/video/remotion-measuring-text.md": {
+      "at": "2026-03-29T21:43:06Z",
+      "hash": "619d768e114ab99f64b37c93d1628ae5cb7d54a4",
+      "passes": 1,
+      "pr": 13315
+    },
+    ".agents/tools/video/remotion-timing.md": {
+      "at": "2026-04-01T20:59:53Z",
+      "hash": "6213ebf1e87a77cab44febc35ec0a3b10fd2db4c",
+      "passes": 1,
+      "pr": 14881
+    },
+    ".agents/tools/video/remotion-transitions.md": {
+      "at": "2026-04-02T20:04:38Z",
+      "hash": "01f1530e08f4e93364d68c8451ceeaecd548d511",
+      "passes": 2,
+      "pr": 14883
+    },
+    ".agents/tools/video/remotion.md": {
+      "at": "2026-03-28T15:30:25Z",
+      "hash": "e587ff6f81433c2bcc6b89ee139561849007d27e",
+      "passes": 1,
+      "pr": 11961
+    },
+    ".agents/tools/video/video-prompt-design.md": {
+      "at": "2026-03-28T17:30:25Z",
+      "hash": "ba533270f9fe5f9dab9fe60e3a4eef1420e2bd6c",
+      "passes": 1,
+      "pr": 12071
+    },
+    ".agents/tools/video/yt-dlp.md": {
+      "at": "2026-03-28T11:20:27Z",
+      "hash": "93855bd751f355d6ef75134ba3322330fcb7d596",
+      "passes": 1,
+      "pr": 11752
+    },
+    ".agents/tools/vision/image-editing.md": {
+      "at": "2026-03-29T21:43:18Z",
+      "hash": "1b91142d29e8ff6515be5a6208386de1fcaf383d",
+      "passes": 1,
+      "pr": 13236
+    },
+    ".agents/tools/vision/image-generation.md": {
+      "at": "2026-03-29T19:51:31Z",
+      "hash": "68fb24cbb02218008d86f1fb1381347f5ac1e533",
+      "passes": 1,
+      "pr": 13249
+    },
+    ".agents/tools/vision/image-understanding.md": {
+      "at": "2026-03-29T23:53:56Z",
+      "hash": "e8a08b674fb1c451c0b3d2ebdc2290f860817199",
+      "passes": 1,
+      "pr": 13458
+    },
+    ".agents/tools/vision/overview.md": {
+      "at": "2026-04-01T20:59:38Z",
+      "hash": "5abddf3f89fc529bd3119b8ae147961451728199",
+      "passes": 1,
+      "pr": 14932
+    },
+    ".agents/tools/voice/cloud-tts-apis.md": {
+      "at": "2026-03-28T08:18:23Z",
+      "hash": "0a7ff7444bf603ab6328a2248b32bd9faf422b02",
+      "passes": 1,
+      "pr": 11637
+    },
+    ".agents/tools/voice/cloud-voice-agents.md": {
+      "at": "2026-03-28T16:40:25Z",
+      "hash": "b389dcd17c677b3e21bc86397670fbf4d8a61b98",
+      "passes": 1,
+      "pr": 12005
+    },
+    ".agents/tools/voice/hyprwhspr.md": {
+      "at": "2026-03-29T16:34:36Z",
+      "hash": "cd50b6d85cbb4fe055191de5b27fd60418def072",
+      "passes": 1,
+      "pr": 13103
+    },
+    ".agents/tools/voice/ios-shortcut.md": {
+      "at": "2026-03-29T20:53:52Z",
+      "hash": "bf8f2ead853742819aa8ea972f3f39d7e38c58be",
+      "passes": 1,
+      "pr": 13286
+    },
+    ".agents/tools/voice/local-tts-models.md": {
+      "at": "2026-03-28T08:18:24Z",
+      "hash": "a2985fa793b132d716e99ec9f9dd6eaf8252485a",
+      "passes": 1,
+      "pr": 11637
+    },
+    ".agents/tools/voice/pipecat-opencode.md": {
+      "at": "2026-03-28T16:40:27Z",
+      "hash": "53d34b6a543b30dcbc6141ccea72d1364e7ae07d",
+      "passes": 1,
+      "pr": 12019
+    },
+    ".agents/tools/voice/qwen3-tts.md": {
+      "at": "2026-03-29T19:05:52Z",
+      "hash": "5e96cd787b4b8b6ae97d6f3113978c0b334e5484",
+      "passes": 1,
+      "pr": 13190
+    },
+    ".agents/tools/voice/speech-to-speech.md": {
+      "at": "2026-03-29T14:29:05Z",
+      "hash": "54c12a6e35c2fd9bdbc1476b98053f3fd40c5580",
+      "passes": 1,
+      "pr": 13005
+    },
+    ".agents/tools/voice/transcription.md": {
+      "at": "2026-03-29T07:02:26Z",
+      "hash": "8edf7782bc2f37c48ade8d3b58fd5c611dc8bda5",
+      "passes": 1,
+      "pr": 12638
+    },
+    ".agents/tools/voice/voice-models.md": {
+      "at": "2026-03-28T08:18:24Z",
+      "hash": "1048bd3b6ac334dea9f2685aef4b09642f318673",
+      "passes": 1,
+      "pr": 11637
+    },
+    ".agents/tools/voice/voiceink-shortcut.md": {
+      "at": "2026-03-28T16:40:39Z",
+      "hash": "1d7af55d9fbf66d24dcb4f1cbba443617f0c992c",
+      "passes": 1,
+      "pr": 12017
+    },
+    ".agents/tools/wordpress/localwp.md": {
+      "at": "2026-03-28T08:58:34Z",
+      "hash": "e2a3ea522c2f0a4739825f594f236c92f0eee0fa",
+      "passes": 1,
+      "pr": 11563
+    },
+    ".agents/tools/wordpress/mainwp.md": {
+      "at": "2026-03-28T11:20:17Z",
+      "hash": "e16169565844b28fa00ca62439a068eec8dd965f",
+      "passes": 1,
+      "pr": 11794
+    },
+    ".agents/tools/wordpress/scf.md": {
+      "at": "2026-03-28T16:40:07Z",
+      "hash": "4c62a3f4c5312a10699889660578437def83e31e",
+      "passes": 1,
+      "pr": 12035
+    },
+    ".agents/tools/wordpress/wp-admin.md": {
+      "at": "2026-03-28T08:17:43Z",
+      "hash": "a02a72943cc4820447f81c73216b0f095c3f64e5",
+      "passes": 1,
+      "pr": 11587
+    },
+    ".agents/tools/wordpress/wp-cli-reference.md": {
+      "at": "2026-03-28T08:17:43Z",
+      "hash": "0425ba4c94fd45b032e849987736bc4073970a7e",
+      "passes": 1,
+      "pr": 11587
+    },
+    ".agents/tools/wordpress/wp-dev.md": {
+      "at": "2026-03-29T22:09:16Z",
+      "hash": "c88f6e0f70e046ce19bf119077cef234636b2f4d",
+      "passes": 1,
+      "pr": 13341
+    },
+    ".agents/tools/wordpress/wp-preferred.md": {
+      "at": "2026-03-28T03:54:25Z",
+      "hash": "6664b61850bd5f84a8044f5dea501f4534b9a9d8",
+      "passes": 1,
+      "pr": 11353
+    },
+    ".agents/workflows/branch/bugfix.md": {
+      "at": "2026-04-02T04:56:46Z",
+      "hash": "236b78c40f92a6c1b7c36085c0ecdf1ea42058be",
+      "passes": 1,
+      "pr": 15517
+    },
+    ".agents/workflows/branch/hotfix.md": {
+      "at": "2026-04-01T20:59:04Z",
+      "hash": "e1c1f9099b46c798fe473a7c23ff01bfa8e26b70",
+      "passes": 1,
+      "pr": 15209
+    },
+    ".agents/workflows/bug-fixing.md": {
+      "at": "2026-03-29T16:34:52Z",
+      "hash": "40fa82a3220595ff946fdc60ec4a03b193032f58",
+      "passes": 1,
+      "pr": 13056
+    },
+    ".agents/workflows/code-audit-remote.md": {
+      "at": "2026-03-28T15:31:24Z",
+      "hash": "2702ee79b7d0f63a13b19d69171f937db3e37064",
+      "passes": 1,
+      "pr": 11825
+    },
+    ".agents/workflows/feature-development.md": {
+      "at": "2026-03-29T16:31:49Z",
+      "hash": "6b9311970a27d48d12002b62e59c9a6ac2087cc8",
+      "passes": 1,
+      "pr": 13065
+    },
+    ".agents/workflows/git-workflow.md": {
+      "at": "2026-03-29T08:49:32Z",
+      "hash": "1ea0b652ceda9126a403a89555e29a02b1c7e3bd",
+      "passes": 1,
+      "pr": 12777
+    },
+    ".agents/workflows/milestone-validation.md": {
+      "at": "2026-03-28T03:53:42Z",
+      "hash": "3e8c88a4d98e24993198b7a6cfc0c93b7825bd26",
+      "passes": 1,
+      "pr": 11286
+    },
+    ".agents/workflows/mission-orchestrator.md": {
+      "at": "2026-03-30T06:49:53Z",
+      "hash": "930d59836f65199231e8354401053a66b0637281",
+      "passes": 1,
+      "pr": 13841
+    },
+    ".agents/workflows/mission-skill-learning.md": {
+      "at": "2026-04-01T20:59:28Z",
+      "hash": "dd665af8ed215a57226bbb176cee5ee5a552ee65",
+      "passes": 1,
+      "pr": 14996
+    },
+    ".agents/workflows/multi-repo-workspace.md": {
+      "at": "2026-03-28T16:00:32Z",
+      "hash": "00ea218df67c941a8858e0da60f7c252c850db7a",
+      "passes": 1,
+      "pr": 11984
+    },
+    ".agents/workflows/plans.md": {
+      "at": "2026-03-28T21:58:58Z",
+      "hash": "d07529f81bc8ce92541f51393632bb2d04ce8fd4",
+      "passes": 1,
+      "pr": 12235
+    },
+    ".agents/workflows/postflight.md": {
+      "at": "2026-03-28T10:27:12Z",
+      "hash": "4e10936d7f2007c0c034ff2f2d8f8110bdf3d0dc",
+      "passes": 1,
+      "pr": 11739
+    },
+    ".agents/workflows/pr.md": {
+      "at": "2026-03-29T14:29:47Z",
+      "hash": "8f6584d97315d02aa4914a1f26165c57ff873479",
+      "passes": 1,
+      "pr": 13014
+    },
+    ".agents/workflows/preflight.md": {
+      "at": "2026-03-28T03:54:08Z",
+      "hash": "c4695943d5555314205b87bb88020fb62de14b63",
+      "passes": 1,
+      "pr": 11341
+    },
+    ".agents/workflows/ralph-loop.md": {
+      "at": "2026-03-28T11:20:12Z",
+      "hash": "552b1c4af3571c286790521b4cf26446ab3bb729",
+      "passes": 1,
+      "pr": 11789
+    },
+    ".agents/workflows/readme-create-update.md": {
+      "at": "2026-03-28T16:40:10Z",
+      "hash": "f54854963d94f3c9b4e15769c07b3c8c27db1c5a",
+      "passes": 1,
+      "pr": 12038
+    },
+    ".agents/workflows/release.md": {
+      "at": "2026-03-29T22:51:16Z",
+      "hash": "829b5d36d0073b1409bf14b5d094c18889989008",
+      "passes": 2,
+      "pr": 13318
+    },
+    ".agents/workflows/review-issue-pr.md": {
+      "at": "2026-03-28T22:39:25Z",
+      "hash": "14ac8f78bcfbb8ec23df3e37c021b7cd512c2f5b",
+      "passes": 1,
+      "pr": 12308
+    },
+    ".agents/workflows/session-manager.md": {
+      "at": "2026-03-29T23:53:41Z",
+      "hash": "e90fb5dbed96bd48a27404dce7d7b8d60d66a053",
+      "passes": 1,
+      "pr": 13443
+    },
+    ".agents/workflows/session-review.md": {
+      "at": "2026-03-29T11:19:53Z",
+      "hash": "0209719f0b5eb68905b4edbdc6bffe1fa8d8a54d",
+      "passes": 1,
+      "pr": 12889
+    },
+    ".agents/workflows/sql-migrations.md": {
+      "at": "2026-03-30T06:03:19Z",
+      "hash": "b33b92df6c10b12772797d8d75b314b69698af6e",
+      "passes": 1,
+      "pr": 13838
+    },
+    ".agents/workflows/ui-verification.md": {
+      "at": "2026-03-29T07:31:37Z",
+      "hash": "c59b154d588638a381fc14e85f435772cb88e31a",
+      "passes": 1,
+      "pr": 12705
+    },
+    ".agents/workflows/version-bump.md": {
+      "at": "2026-03-28T16:00:36Z",
+      "hash": "d4d8c82182a0c0fce47622e76556260a11747ee8",
+      "passes": 1,
+      "pr": 11986
+    },
+    ".agents/workflows/wiki-update.md": {
+      "at": "2026-03-30T02:30:16Z",
+      "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
+      "passes": 1,
+      "pr": 13594
+    },
+    "TODO.md": {
+      "at": "2026-04-03T01:53:21Z",
+      "hash": "d9184740229a6ef4e90a4309638f3fa4948d511b",
+      "passes": 6,
+      "pr": 15490
+    },
+    "aidevops.sh": {
+      "at": "2026-04-03T02:09:24Z",
+      "hash": "0562e51f78407a765633920ee1d05218053856ad",
+      "passes": 17,
+      "pr": 15470
+    },
+    "setup.sh": {
+      "at": "2026-04-03T02:09:24Z",
+      "hash": "b2f66c702293d628a153902fdfba321b0530478c",
+      "passes": 17,
+      "pr": 15470
+    },
+    "todo/tasks/GH#15363-brief.md": {
+      "at": "2026-04-02T13:10:59Z",
+      "hash": "ca6b623a0dc0d9ae763efd4dd88350ec183c45e9",
+      "passes": 1,
+      "pr": 15566
+    },
+    "todo/tasks/GH-14990-brief.md": {
+      "at": "2026-04-01T20:59:29Z",
+      "hash": "05e0636373c9b4574f9b289b7e75180281b462e4",
+      "passes": 1,
+      "pr": 14996
+    },
+    "todo/tasks/t15173-brief.md": {
+      "at": "2026-04-01T20:58:50Z",
+      "hash": "41ca6c208c2f6e8349d73a1ec55e0a26fd26f974",
+      "passes": 1,
+      "pr": 15257
+    },
+    "todo/tasks/t15364-brief.md": {
+      "at": "2026-04-02T13:11:00Z",
+      "hash": "1231c445c2ac173258f2a0b5baab685d32a3ab64",
+      "passes": 1,
+      "pr": 15566
+    },
+    "todo/tasks/t15448-brief.md": {
+      "at": "2026-04-02T04:56:58Z",
+      "hash": "b43fa2d5b0515af1ecbebbc502099ca5e6d0a9c2",
+      "passes": 1,
+      "pr": 15463
+    },
+    "todo/tasks/t15450-brief.md": {
+      "at": "2026-04-02T04:56:56Z",
+      "hash": "c0ba871cfce440d57c630e49cd6ba939bf27b261",
+      "passes": 1,
+      "pr": 15468
+    },
+    "todo/tasks/t15472-brief.md": {
+      "at": "2026-04-02T04:56:51Z",
+      "hash": "3de8a77d3743c3530c563e9aff8775c22a7edb4b",
+      "passes": 1,
+      "pr": 15490
+    },
+    "todo/tasks/t1727-brief.md": {
+      "at": "2026-04-02T03:11:00Z",
+      "hash": "55e4dea0078c0800d4db2336b942014ce25ffbfc",
+      "passes": 1,
+      "pr": 15431
+    },
+    "todo/tasks/t1737-brief.md": {
+      "at": "2026-04-01T20:59:15Z",
+      "hash": "e33e6f68fa6cdb89368aa5ec65bd3e1bc880ba67",
+      "passes": 1,
+      "pr": 15223
+    },
+    "todo/tasks/t2052-brief.md": {
+      "at": "2026-04-02T04:56:57Z",
+      "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
+      "passes": 1,
+      "pr": 15470
+    },
+    ".agents/aidevops/api-integrations.md": {
+      "hash": "9ed830efd42c0b7901229915ff9fe70d6f50fdac",
+      "at": "2026-04-02T21:19:50Z",
+      "pr": 0,
+      "passes": 2
+    },
+    ".agents/seo/seo-audit-skill/aeo-geo-patterns.md": {
+      "hash": "2238ceff37db82a81a9939c6d2217c5b7659a551",
+      "at": "2026-04-02T21:20:03Z",
+      "pr": 0,
+      "passes": 2
+    },
+    ".agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md": {
+      "hash": "1aa15519d959c89c0e09c3e30ac0210d6da35134",
+      "at": "2026-04-02T00:00:00Z",
+      "pr": 0,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md": {
+      "hash": "b253668b96ea394b289fba6ee03f12b30a041540",
+      "at": "2026-04-02T21:20:06Z",
+      "pr": 0,
+      "passes": 2
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md": {
+      "hash": "cf1846a80d91d8b99d83e135da0b5b13c80ef9b7",
+      "at": "2026-04-03T01:11:32Z",
+      "pr": 15606,
+      "passes": 3
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/ddos-gotchas.md": {
+      "hash": "f9bc5ae56912b9413ffb35a31dfdca00d42513cb",
+      "at": "2026-04-02T21:20:06Z",
+      "pr": 0,
+      "passes": 2
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/zaraz.md": {
+      "hash": "e4b79af78576116b33c9947649dffa9f1de19cec",
+      "at": "2026-04-02T21:20:08Z",
+      "pr": 0,
+      "passes": 2
+    },
+    ".agents/tools/code-review/auditing.md": {
+      "hash": "aa7f70c05362b5b00887a152a101c0b6ee7da926",
+      "at": "2026-04-02T21:20:13Z",
+      "pr": 0,
+      "passes": 2
+    },
+    ".agents/tools/context/rapidfuzz.md": {
+      "hash": "6cef99c2d59eecce5bd461af579cb44a36997e61",
+      "at": "2026-04-03T01:53:12Z",
+      "pr": 0,
+      "passes": 3
+    },
+    ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
+      "hash": "edecc25afbace885cab2eac01e07629d890a4fad",
+      "at": "2026-04-02T00:00:00Z",
+      "pr": 0,
+      "passes": 1
+    },
+    ".agents/workflows/branch/experiment.md": {
+      "hash": "c0b292cdf26b8a6a6cbdff05b765a4601adaf875",
+      "at": "2026-04-02T21:20:20Z",
+      "pr": 0,
+      "passes": 2
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pulumi.md": {
+      "hash": "4f629687cca43ce53b1643bbcff802c61367c597",
+      "at": "2026-04-03T01:53:04Z",
+      "pr": 15823,
+      "passes": 2
+    },
+    ".agents/tools/research/providers/openexplorer.md": {
+      "hash": "04542bb168595636e4a15f66fbdaafff8c18c327",
+      "at": "2026-04-03T01:53:17Z",
+      "pr": 15822,
+      "passes": 2
+    },
+    ".agents/scripts/commands/memory-log.md": {
+      "hash": "0f3be8d344b9ea22cd796e021e3f049e4ccaa75a",
+      "at": "2026-04-02T21:58:18Z",
+      "pr": 15701,
+      "passes": 1
+    },
+    ".agents/content/production-video.md": {
+      "hash": "b8dc424d6b0000d6bbdba29b25849344ca198a71",
+      "at": "2026-04-02T21:58:18Z",
+      "pr": 15699,
+      "passes": 1
+    },
+    ".agents/services/payments/revenuecat.md": {
+      "hash": "4a4d2603bb24d79952c3d18b283cd48deafde2d4",
+      "at": "2026-04-02T21:58:18Z",
+      "pr": 15693,
+      "passes": 1
+    },
+    ".agents/scripts/commands/pr-loop.md": {
+      "hash": "5e3ba8395648167005fdf9b47d469849c80188e5",
+      "at": "2026-04-02T21:58:18Z",
+      "pr": 15682,
+      "passes": 1
+    },
+    ".agents/reference/secret-handling.md": {
+      "hash": "2a6c72740cbc53ba42d8f562bde4af3073574974",
+      "at": "2026-04-03T02:08:59Z",
+      "pr": 15664,
+      "passes": 2
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/durable-objects.md": {
+      "hash": "7a4852a2f3e454c5962f11cefa855b6e4a1555b4",
+      "at": "2026-04-02T21:58:18Z",
+      "pr": 15663,
+      "passes": 1
+    },
+    ".agents/tools/build-agent/agent-testing.md": {
+      "hash": "cc7b9b5e44e530964c79af624de3408b1076cbe3",
+      "at": "2026-04-02T21:58:18Z",
+      "pr": 15662,
+      "passes": 1
+    },
+    ".agents/scripts/backfill-origin-labels.sh": {
+      "hash": "01d5281e257d4507215400c7311169fd37a39f6e",
+      "at": "2026-04-02T21:58:18Z",
+      "pr": 15661,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
+      "hash": "67350510852f0967a6591a03b13812ae2c7899d1",
+      "at": "2026-04-02T21:58:19Z",
+      "pr": 15646,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md": {
+      "hash": "839f69b3a40ac4728392bc8bf8396b643274c96c",
+      "at": "2026-04-02T21:58:19Z",
+      "pr": 15645,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/do-storage.md": {
+      "hash": "7652036224eb9bb0199c584f61a0a6631902a0ff",
+      "at": "2026-04-02T21:58:19Z",
+      "pr": 15569,
+      "passes": 1
+    },
+    ".agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md": {
+      "hash": "b7d6d4111324b39cbd5d0615343881696d760822",
+      "at": "2026-04-02T21:58:19Z",
+      "pr": 15568,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/miniflare.md": {
+      "hash": "4471ddd0229e26f2af30d5833d95c9a1f0261dac",
+      "at": "2026-04-02T21:58:19Z",
+      "pr": 15561,
+      "passes": 1
+    },
+    ".agents/scripts/commands/security-review.md": {
+      "hash": "8aeebd043a47a280413cacae8697325574b2d88e",
+      "at": "2026-04-02T21:58:19Z",
+      "pr": 15535,
+      "passes": 1
+    },
+    ".agents/tools/ai-assistants/fallback-chains.md": {
+      "hash": "04c03d8868c5719bfa209234bcac59f7b997c3f4",
+      "at": "2026-04-02T21:58:20Z",
+      "pr": 15534,
+      "passes": 1
+    },
+    ".agents/tools/video/remotion-sequencing.md": {
+      "hash": "0eab4c364cf2ee28b3c16e91d7af50b372717619",
+      "at": "2026-04-02T21:58:20Z",
+      "pr": 15533,
+      "passes": 1
+    },
+    ".agents/seo/bing-webmaster-tools.md": {
+      "hash": "fb22f3998fd4903c3ff77c9a664f0edb7fe62d1f",
+      "at": "2026-04-03T01:11:29Z",
+      "pr": 15532,
+      "passes": 2
+    },
+    ".agents/scripts/commands/seo-analyze.md": {
+      "hash": "04987b0129baab1ebd5f96cfe316cac9222f1b12",
+      "at": "2026-04-02T21:58:20Z",
+      "pr": 15502,
+      "passes": 1
+    },
+    ".agents/tools/deployment/cloudron-app-publishing-skill.md": {
+      "hash": "b78c7c2bff3ffbd13eb8b068699f5672cf21d922",
+      "at": "2026-04-02T21:58:20Z",
+      "pr": 15497,
+      "passes": 1
+    },
+    ".agents/seo/ai-search-readiness.md": {
+      "hash": "4652d2041fcf22b11419930334a44136a3acefe7",
+      "at": "2026-04-03T01:11:28Z",
+      "pr": 15496,
+      "passes": 2
+    },
+    ".agents/services/hosting/spaceship.md": {
+      "hash": "070eeb271be745bf4ce6d0c0a22631229975b71a",
+      "at": "2026-04-03T01:11:34Z",
+      "pr": 15494,
+      "passes": 2
+    },
+    ".agents/content/social-linkedin.md": {
+      "hash": "4df257a29d0b5d2fb67cc260a1ac2d1881a8f8d2",
+      "at": "2026-04-03T01:11:19Z",
+      "pr": 15493,
+      "passes": 2
+    },
+    ".agents/scripts/watercrawl-helper.sh": {
+      "hash": "27e5853c455180c533e572d91d47769062d78519",
+      "status": "simplified",
+      "at": "2026-04-02T22:43:46Z",
+      "passes": 1
+    },
+    ".agents/tools/browser/playwright-emulation.md": {
+      "hash": "1fdc5a4f08a4e9ba8ebc3550ade50c4876b949d7",
+      "at": "2026-04-02T22:44:04Z",
+      "pr": 15692,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md": {
+      "hash": "1a9ebfb7d88fdd954fa0ca93d3a4dffa7e24c461",
+      "at": "2026-04-02T22:44:04Z",
+      "pr": 15666,
+      "passes": 1
+    },
+    ".agents/seo/rich-results.md": {
+      "hash": "96226173e887aebf71287a803541f50f5b89d1c8",
+      "at": "2026-04-02T22:44:04Z",
+      "pr": 15665,
+      "passes": 1
+    },
+    ".agents/reference/platform-support.md": {
+      "hash": "67f8c07f2072f5b15ffae32c07a9e8930a5f7c49",
+      "at": "2026-04-03T00:48:09Z",
+      "pr": "GH#16007",
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md": {
+      "hash": "61a700349adcfc92119244d456e2e601cbc2f926",
+      "at": "2026-04-03T00:57:59Z",
+      "pr": 16020,
+      "passes": 3
+    },
+    ".agents/workflows/error-feedback.md": {
+      "hash": "85e9eb0fc79cd4671cdd43c481a13d977775d291",
+      "at": "2026-04-03T01:11:46Z",
+      "pr": 15970,
+      "passes": 1
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2016-es2017.md": {
+      "hash": "6e238e8d6cd856c6d54aeeda15ded6763fbb7439",
+      "at": "2026-04-03T01:11:46Z",
+      "pr": 15969,
+      "passes": 1
+    },
+    ".agents/scripts/compare-models-helper.sh": {
+      "hash": "10e52daaafa5297bc348b088923e28bf767b4e73",
+      "at": "2026-04-03T01:11:46Z",
+      "pr": 15946,
+      "passes": 1
+    },
+    ".agents/tools/browser/crawl4ai-usage.md": {
+      "hash": "46d82b1f632872fa8c59c2a271c79466ced17238",
+      "at": "2026-04-03T01:11:47Z",
+      "pr": 15802,
+      "passes": 1
+    },
+    ".agents/services/communications/matrix-bot.md": {
+      "hash": "92784be52960e2b9738999d8c725a442cd3d5897",
+      "at": "2026-04-03T01:11:47Z",
+      "pr": 15801,
+      "passes": 1
+    },
+    ".agents/content/meta-creator.md": {
+      "hash": "6573b67dd99792a8c5870a2850c8fb3bc74d7e3b",
+      "at": "2026-04-03T01:11:47Z",
+      "pr": 15781,
+      "passes": 1
+    },
+    ".agents/tools/credentials/encryption-stack.md": {
+      "hash": "2e34e7975b8addfeaa1860db91423c85633b596c",
+      "at": "2026-04-03T01:11:47Z",
+      "pr": 15780,
+      "passes": 1
+    },
+    ".agents/tools/terminal/terminal-title.md": {
+      "hash": "a159d1374538460666970b226c494586840c5a08",
+      "at": "2026-04-03T01:11:48Z",
+      "pr": 15726,
+      "passes": 1
+    },
+    ".agents/services/email/email-inbound-commands.md": {
+      "hash": "2d55a1a765cc4b287e8e8cdbcf1eabf5d50bb4aa",
+      "at": "2026-04-03T01:11:48Z",
+      "pr": 15725,
+      "passes": 1
+    },
+    ".agents/marketing-sales/meta-ads-checklists-scaling-checklist.md": {
+      "hash": "790011746194791c3988c38215a06a333438e040",
+      "at": "2026-04-03T01:11:48Z",
+      "pr": 15723,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/pages.md": {
+      "hash": "a79bdd1a9af96c2204ecd7688f9e373e638fa484",
+      "at": "2026-04-03T01:24:39Z",
+      "pr": "16041",
+      "passes": 1
+    },
+    ".agents/content/distribution-youtube-readme.md": {
+      "hash": "933a61de442c55e846e4549225c5fe013ce59075",
+      "at": "2026-04-03T01:53:22Z",
+      "pr": 15971,
+      "passes": 1
+    },
+    ".agents/marketing-sales/cro-chapter-15/01-personalization-types.md": {
+      "hash": "0d4c142ecedde60524690f30e9469cc1819573e2",
+      "at": "2026-04-03T01:53:23Z",
+      "pr": 15873,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md": {
+      "hash": "984e5cfe9a63f157de9eacdac740dd7ca9a4c8dc",
+      "at": "2026-04-03T01:53:23Z",
+      "pr": 15869,
+      "passes": 1
+    },
+    ".agents/tools/video/remotion-videos.md": {
+      "hash": "782dd910314b807bedb05fbebcae4dc3e1ed84db",
+      "at": "2026-04-03T01:53:23Z",
+      "pr": 15852,
+      "passes": 1
+    },
+    ".agents/automate.md": {
+      "hash": "b5645f649804240736369a236767485dd7e49b6a",
+      "at": "2026-04-03T01:53:24Z",
+      "pr": 15804,
+      "passes": 1
+    },
+    ".agents/marketing-sales/direct-response-copy-checklists-offer-optimization.md": {
+      "hash": "5deb96e01280b6ec23ad9c1db17fba7700c949b9",
+      "at": "2026-04-03T01:53:26Z",
+      "pr": 15696,
+      "passes": 1
+    },
+    ".agents/tools/architecture/clean-ddd-hexagonal-skill.md": {
+      "hash": "159f2479cb3aebb3f3d0c437268c5884adc9382c",
+      "at": "2026-04-03T01:53:26Z",
+      "pr": 15695,
+      "passes": 1
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md": {
+      "hash": "de83d5b4810ce96bd8858b825346224e73282531",
+      "at": "2026-04-03T01:53:26Z",
+      "pr": 15694,
+      "passes": 1
+    },
+    ".agents/scripts/commands/tech-stack.md": {
+      "at": "2026-04-03T02:32:23Z",
+      "hash": "9bf2bb063f1d99e2a8de56dab74bf2e910ddbbc4",
+      "passes": 1,
+      "pr": null,
+      "issue": 14163
     }
+  },
+  ".agents/tools/ai-orchestration/overview.md": {
+    "hash": "3a63b044317f50c757951158e4e711234d09cd299f8dc557bdc5af9e580735f6",
+    "status": "simplified",
+    "issue": "GH#15266",
+    "pr": "PR#16047"
+  }
 }

--- a/.agents/scripts/commands/tech-stack.md
+++ b/.agents/scripts/commands/tech-stack.md
@@ -53,17 +53,11 @@ cmd_array=(~/.aidevops/agents/scripts/tech-stack-helper.sh reverse "$tech_name")
 ~/.aidevops/agents/scripts/tech-stack-helper.sh cache-clear --older-than 7
 ```
 
-### Step 3: Present Results
+### Step 3: Present Results and Offer Follow-ups
 
-Format output by operation type:
+Format output by operation type: **Single-site** — technologies grouped by category (Frontend, Backend, Analytics, CDN, etc.) with confidence scores and provider counts. **Reverse** — sites using the technology with traffic tier, industry, and related technologies. **Cache stats** — total entries, cache size, hit rate, top cached domains.
 
-- **Single-site**: technologies grouped by category (Frontend, Backend, Analytics, CDN, etc.) with confidence scores and provider counts
-- **Reverse**: sites using the technology with traffic tier, industry, and related technologies
-- **Cache stats**: total entries, cache size, hit rate, top cached domains
-
-### Step 4: Follow-up Actions
-
-Offer: export to JSON/CSV, reverse lookup for detected technologies, competitor comparison, periodic monitoring, detailed provider reports.
+Offer follow-ups: export to JSON/CSV, reverse lookup for detected technologies, competitor comparison, periodic monitoring, detailed provider reports.
 
 ## Usage
 
@@ -78,30 +72,14 @@ Offer: export to JSON/CSV, reverse lookup for detected technologies, competitor 
 
 ## Provider Configuration
 
-### Wappalyzer (free, open source)
+| Provider | Cost | Install |
+|----------|------|---------|
+| Wappalyzer | Free, open source | `npm install -g wappalyzer` |
+| httpx | Free, open source | `go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest` |
+| nuclei | Free, open source | `go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest` |
+| BuiltWith API | $295/month; free tier: 100 lookups/month | `aidevops secret set BUILTWITH_API_KEY` |
 
-No API key needed.
-
-```bash
-npm install -g wappalyzer
-```
-
-### httpx + nuclei (free, open source)
-
-No API key needed.
-
-```bash
-go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
-go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest
-```
-
-### BuiltWith API (commercial, optional)
-
-For reverse lookup and historical data. $295/month API access; free tier: 100 lookups/month.
-
-```bash
-aidevops secret set BUILTWITH_API_KEY
-```
+BuiltWith is optional — required for reverse lookup and historical data.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Tightened `.agents/scripts/commands/tech-stack.md` from 112 to 90 lines (20% reduction)
- Merged Steps 3-4 (Present Results + Follow-up Actions) into a single concise paragraph
- Collapsed Provider Configuration from three subsections with code blocks into a single table
- All code blocks, task IDs, and security rules preserved verbatim

Closes #14163

## Runtime Testing

- **Risk level:** Low (docs/agent prompt only)
- **Verification:** `self-assessed` — no runtime behaviour change, markdown structure intact

## Content Preservation Checklist

- [x] All task IDs preserved (t1064, t1065, t1066, t1067)
- [x] All code blocks preserved (lookup, reverse, cache commands)
- [x] Security rule preserved (no eval, array-based command construction)
- [x] Multi-word tech name parsing rationale preserved (awk delimiter comment)
- [x] All Related links preserved
- [x] All Usage examples preserved
- [x] Provider install commands preserved (in table format)
- [x] BuiltWith pricing and free tier info preserved
- [x] simplification-state.json updated

---
[aidevops.sh](https://aidevops.sh) v3.5.732 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 5,516 tokens on this as a headless worker.