### PR TITLE
GH#15776: schema-validator-helper.sh complexity scan false positive — remove redundant return $?

### DIFF
--- a/.agents/scripts/schema-validator-helper.sh
+++ b/.agents/scripts/schema-validator-helper.sh
@@ -37,7 +37,6 @@ readonly HELP_USAGE_INFO="Use '$0 help' for usage information"
 command_exists() {
 	local cmd="$1"
 	command -v "$cmd" >/dev/null 2>&1
-	return $?
 }
 
 # Install npm dependencies to tool directory


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Closes the false-positive complexity scan for `.agents/scripts/schema-validator-helper.sh`. The automated scan (GH#5628) reported 0 functions exceeding 100 lines — meaning there is nothing to simplify. The file is already well-structured.

Minor cleanup included: remove redundant `return $?` from `command_exists()` — the preceding `command -v` exit status is already the function's return value.

## Issue
Closes #15776

## Files Changed
- `.agents/scripts/schema-validator-helper.sh` — 1 line removed (redundant `return $?`)

## Testing
- `shellcheck .agents/scripts/schema-validator-helper.sh` — 0 violations
- `bash -n .agents/scripts/schema-validator-helper.sh` — syntax OK
- Function size audit: largest function is `_write_js_validator` at 61 lines; all 11 functions are under 100 lines

## Key Decisions
- Issue is a confirmed false positive: scan found 0 violations, so no decomposition was needed
- Included minimal cleanup (redundant `return $?`) to provide a verifiable change rather than a no-op commit

## Runtime Testing
**Risk level:** Low (docs/config/agent prompt equivalent — shell helper with no runtime state)
**Assessment:** `self-assessed` — syntax and lint verified; no runtime environment required for this change

---
[aidevops.sh](https://aidevops.sh) v3.5.732 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 2m and 3,750 tokens on this as a headless worker.