### PR TITLE
fix: worker sessions not persisted to shared DB (auth isolation side effect)

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1250,6 +1250,11 @@ _invoke_opencode() {
 	# a new token to the shared file, invalidating the interactive session's
 	# in-flight request and crashing it.
 	#
+	# IMPORTANT: XDG_DATA_HOME redirection moves the ENTIRE opencode data dir,
+	# including the session database. We set OPENCODE_DB to point back to the
+	# shared DB so worker sessions are visible to stats/session-time queries
+	# while auth remains isolated.
+	#
 	# The isolated dir is per-PID and cleaned up after the worker exits.
 	local isolated_data_dir=""
 	if [[ "${AIDEVOPS_HEADLESS_AUTH_ISOLATION:-1}" == "1" ]]; then
@@ -1260,6 +1265,11 @@ _invoke_opencode() {
 			cp "$OPENCODE_AUTH_FILE" "${isolated_data_dir}/opencode/auth.json" 2>/dev/null || true
 			chmod 600 "${isolated_data_dir}/opencode/auth.json" 2>/dev/null || true
 		fi
+		# Preserve the shared session DB path before redirecting XDG_DATA_HOME.
+		# OPENCODE_DB tells opencode to use the shared DB for session/message
+		# persistence even when XDG_DATA_HOME points to an isolated temp dir.
+		local real_data_home="${XDG_DATA_HOME:-${HOME}/.local/share}"
+		export OPENCODE_DB="${real_data_home}/opencode/opencode.db"
 		export XDG_DATA_HOME="$isolated_data_dir"
 	fi
 


### PR DESCRIPTION
## Summary

- Worker sessions since April 1 have been invisible to session-time stats because `XDG_DATA_HOME` redirection for auth isolation inadvertently moved the entire OpenCode data directory to a per-worker temp dir
- Each worker created a disposable `opencode.db` in `/tmp/aidevops-worker-auth.XXXXXX/opencode/` that was discarded on exit
- This caused "AI worker hours" to show 0.0h for 24h on the profile README despite active worker dispatches

## Root Cause

`headless-runtime-helper.sh:1263` sets `XDG_DATA_HOME` to isolate OAuth `auth.json` per worker. OpenCode uses `XDG_DATA_HOME/opencode/opencode.db` for session persistence, so the isolation also redirected the session DB.

## Fix

Set `OPENCODE_DB` (supported by OpenCode) to point to the shared DB before redirecting `XDG_DATA_HOME`. Auth stays isolated, sessions go to the shared DB. `OPENCODE_DB` is already in the `OPENCODE_*` sandbox passthrough pattern.

## Impact

- ~2 days of worker session data lost (April 1-3) -- sessions ran successfully but weren't recorded
- Worker hours will resume tracking immediately after merge + deploy
- No data recovery needed; the headless-runtime-metrics.jsonl has the activity data as a secondary source