### PR TITLE
GH#15264: tighten cro-chapter-25 §25.6 checklist to multi-line bullets

### DIFF
--- a/.agents/marketing-sales/cro-chapter-25.md
+++ b/.agents/marketing-sales/cro-chapter-25.md
@@ -93,13 +93,35 @@ Recovery sequence: 1h pre-filled cart → 24h FAQ+testimonials → 72h 10% disco
 
 ## 25.6 Monetization CRO Checklist
 
-**Pre-launch:** Define primary metric (RPV/ARPU/LTV) + guardrails (CR, churn, NPS) · Calculate MDE + sample size · Document full journey impact · Set up cohort-level revenue tracking · Confirm legal compliance · Brief support · Establish rollback criteria
+**Pre-launch:**
+- Define primary metric (RPV/ARPU/LTV) + guardrails (CR, churn, NPS)
+- Calculate MDE + sample size
+- Document full journey impact
+- Set up cohort-level revenue tracking
+- Confirm legal compliance
+- Brief support
+- Establish rollback criteria
 
-**During:** Monitor daily revenue + conversion · Track pricing-related tickets · Watch segment effects (new/returning, mobile/desktop, geo) · Verify allocation balance
+**During:**
+- Monitor daily revenue + conversion
+- Track pricing-related tickets
+- Watch segment effects (new/returning, mobile/desktop, geo)
+- Verify allocation balance
 
-**Post-test:** Statistical significance on revenue (not just CR) · Project 12-month LTV using cohort curves · Analyze qualitative signals · Document learnings · Update roadmap · Archive results
+**Post-test:**
+- Statistical significance on revenue (not just CR)
+- Project 12-month LTV using cohort curves
+- Analyze qualitative signals
+- Document learnings
+- Update roadmap
+- Archive results
 
-**Ongoing cadence:** Monthly: RPV vs benchmarks · Quarterly: competitive analysis + ≥1 experiment · Semi-annually: WTP survey · Annually: pricing update · Seasonally (e-com): recalibrate bundles
+**Ongoing cadence:**
+- Monthly: RPV vs benchmarks
+- Quarterly: competitive analysis + ≥1 experiment
+- Semi-annually: WTP survey
+- Annually: pricing update
+- Seasonally (e-com): recalibrate bundles
 
 ### Revenue Optimization Maturity Model
 


### PR DESCRIPTION
## Summary

- Convert dot-separated run-on prose in §25.6 (Pre-launch, During, Post-test, Ongoing cadence) to multi-line bullet lists
- All content preserved; no knowledge removed; all items, stats, and references intact
- Addresses CodeRabbit nitpick from PR #15859 (long lines exceeding 150 chars in §25.6)

## Issue

Closes #15264

## Files Changed

- `.agents/marketing-sales/cro-chapter-25.md` — 115 → 137 lines (bullet expansion, no content loss)

## Classification

Reference corpus (textbook-style chapter with self-contained sections). At 115 lines, below split threshold. Action: prose structure improvement only, no content compression.

## Testing

- Content preservation verified: all checklist items present before and after
- No broken internal references
- Agent behaviour unchanged (reference corpus — no decision logic modified)
- Line length: all lines now within readable limits

## Runtime Testing

**Risk level:** Low — docs/agent prompts only, no code execution paths.
**Verification:** `self-assessed` — content diff reviewed, all checklist items confirmed present.

<!-- MERGE_SUMMARY -->
**What:** Convert §25.6 checklist from dot-separated run-on prose to multi-line bullet format in cro-chapter-25.md
**Issue:** #15264
**Files changed:** 1 (`.agents/marketing-sales/cro-chapter-25.md`)
**Testing:** Content preservation verified; all 4 checklist sections (Pre-launch, During, Post-test, Ongoing cadence) confirmed intact
**Key decisions:** Multi-line bullets over inline pipe separators; mirrors §25.3 cancellation flow format; addresses CodeRabbit nitpick from PR #15859

---
[aidevops.sh](https://aidevops.sh) v3.5.735 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6 spent 1m and 3,181 tokens on this as a headless worker.