### PR TITLE
GH#14464: tighten agent doc patterns.md (44→34 lines)

### DIFF
--- a/.agents/scripts/commands/patterns.md
+++ b/.agents/scripts/commands/patterns.md
@@ -1,17 +1,19 @@
 ---
-description: Show success/failure patterns from memory to guide task approach and model routing
+description: Show cross-session success/failure patterns to guide task approach and model routing
 agent: Build+
 mode: subagent
 model: haiku
 ---
 
-Show cross-session success/failure patterns relevant to the current task.
+Query cross-session patterns from memory, filter to `$ARGUMENTS` if provided, and present:
 
-Arguments: `$ARGUMENTS`
+- **What works:** approaches with repeated success in similar tasks
+- **What fails:** approaches with repeated failure or regressions
+- **Recommended tier:** best model tier with rationale from pattern evidence
 
-## Instructions
+**Mode** (from arguments): `recommend` → prioritize tier recommendation. `report` → full summary. Default → concise task-focused suggestions.
 
-1. Query memory for all pattern types:
+Query all pattern types:
 
 ```bash
 ~/.aidevops/agents/scripts/memory-helper.sh recall "success pattern" --type SUCCESS_PATTERN --limit 20
@@ -20,19 +22,7 @@ Arguments: `$ARGUMENTS`
 ~/.aidevops/agents/scripts/memory-helper.sh recall "failed approach" --type FAILED_APPROACH --limit 10
 ```
 
-2. Apply mode from arguments:
-   - Contains `recommend` → prioritize model-tier recommendation from observed outcomes.
-   - Contains `report` → return full pattern summary.
-   - Otherwise → return concise task-focused suggestions.
-
-3. If arguments are provided, filter findings to task-relevant patterns.
-
-4. Present output in this order:
-   - **What works:** approaches with repeated success in similar tasks
-   - **What fails:** approaches with repeated failure or regressions
-   - **Recommended tier:** best model tier with short rationale from pattern evidence
-
-5. If no patterns exist, return:
+If no patterns exist, return:
 
 ```text
 No patterns recorded yet. Patterns are recorded automatically by the pulse supervisor after observing outcomes, or manually with:


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/patterns.md` from 44 to 34 lines (23% reduction)
- Restructure for primacy: output format first, mode switching inline, commands block last
- All institutional knowledge preserved verbatim (4 memory-helper commands, 3 output sections, 3 modes, empty-state message)
- Zero markdownlint errors

## What

Instruction doc simplification per `tools/build-agent/build-agent.md` guidance. Removed redundant boilerplate (`Arguments: $ARGUMENTS`, `## Instructions` header, numbered step scaffolding). Merged mode-switching and filtering into a single inline line. Reordered: output format → mode → commands → empty-state.

## Issue

Closes #14464

## Files Changed

- `.agents/scripts/commands/patterns.md` — 8 insertions, 18 deletions

## Runtime Testing

**Risk level:** Low (docs/agent prompt only — no code, no scripts, no runtime behaviour changed)
**Verification:** `self-assessed` — agent behaviour unchanged; output format, commands, and empty-state message all preserved verbatim. Markdownlint: 0 errors.

## Key Decisions

- Classified as instruction doc (not reference corpus) — content compression appropriate
- Kept empty-state code block verbatim — it's user-facing output, not prose
- Kept all 4 memory-helper.sh commands with exact flags — authoritative CLI syntax

---
[aidevops.sh](https://aidevops.sh) v3.5.737 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6