### PR TITLE
GH#15370: fix invalid JSON in stagehand-setup.sh heredocs

### DIFF
--- a/.agents/scripts/stagehand-setup.sh
+++ b/.agents/scripts/stagehand-setup.sh
@@ -16,13 +16,13 @@ readonly STAGEHAND_TEMPLATES_DIR="${STAGEHAND_CONFIG_DIR}/templates"
 
 # Create advanced example scripts
 create_advanced_examples() {
-    print_info "Creating advanced Stagehand example scripts..."
-    
-    mkdir -p "$STAGEHAND_EXAMPLES_DIR"
-    mkdir -p "$STAGEHAND_TEMPLATES_DIR"
-    
-    # E-commerce automation example
-    cat > "${STAGEHAND_EXAMPLES_DIR}/ecommerce-automation.js" << 'EOF'
+	print_info "Creating advanced Stagehand example scripts..."
+
+	mkdir -p "$STAGEHAND_EXAMPLES_DIR"
+	mkdir -p "$STAGEHAND_TEMPLATES_DIR"
+
+	# E-commerce automation example
+	cat >"${STAGEHAND_EXAMPLES_DIR}/ecommerce-automation.js" <<'EOF'
 // E-commerce Automation with Stagehand
 // Product research and price comparison
 
@@ -103,8 +103,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 export { searchProducts };
 EOF
 
-    # Social media automation example
-    cat > "${STAGEHAND_EXAMPLES_DIR}/social-media-automation.js" << 'EOF'
+	# Social media automation example
+	cat >"${STAGEHAND_EXAMPLES_DIR}/social-media-automation.js" <<'EOF'
 // Social Media Automation with Stagehand
 // Ethical LinkedIn engagement automation
 
@@ -202,8 +202,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 export { analyzeLinkedInFeed };
 EOF
 
-    # Web scraping template
-    cat > "${STAGEHAND_TEMPLATES_DIR}/web-scraping-template.js" << 'EOF'
+	# Web scraping template
+	cat >"${STAGEHAND_TEMPLATES_DIR}/web-scraping-template.js" <<'EOF'
 // Web Scraping Template with Stagehand
 // Adaptable template for various websites
 
@@ -281,15 +281,15 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 export { scrapeWebsite };
 EOF
 
-    print_success "Created advanced Stagehand examples"
-    return 0
+	print_success "Created advanced Stagehand examples"
+	return 0
 }
 
 # Create package.json template
 create_package_template() {
-    local package_file="${STAGEHAND_TEMPLATES_DIR}/package.json"
-    
-    cat > "$package_file" << 'EOF'
+	local package_file="${STAGEHAND_TEMPLATES_DIR}/package.json"
+
+	cat >"$package_file" <<'EOF'
 {
   "name": "stagehand-automation-project",
   "version": "1.0.0",
@@ -319,23 +319,22 @@ create_package_template() {
   ],
   "author": "AI DevOps Framework",
   "license": "MIT"
-    return 0
 }
 EOF
 
-    print_success "Created package.json template"
-    return 0
+	print_success "Created package.json template"
+	return 0
 }
 
 # Setup MCP integration for Stagehand
 setup_mcp_integration() {
-    print_info "Setting up Stagehand MCP integration..."
-    
-    # Create MCP configuration for Stagehand
-    local mcp_config="${HOME}/.aidevops/mcp/stagehand-config.json"
-    mkdir -p "$(dirname "$mcp_config")"
-    
-    cat > "$mcp_config" << 'EOF'
+	print_info "Setting up Stagehand MCP integration..."
+
+	# Create MCP configuration for Stagehand
+	local mcp_config="${HOME}/.aidevops/mcp/stagehand-config.json"
+	mkdir -p "$(dirname "$mcp_config")"
+
+	cat >"$mcp_config" <<'EOF'
 {
   "mcpServers": {
     "stagehand": {
@@ -350,38 +349,37 @@ setup_mcp_integration() {
       }
     }
   }
-    return 0
 }
 EOF
 
-    print_success "Created Stagehand MCP configuration"
-    return 0
+	print_success "Created Stagehand MCP configuration"
+	return 0
 }
 
 # Main setup function
 main() {
-    local command="${1:-setup}"
-    
-    case "$command" in
-        "setup")
-            print_info "Setting up Stagehand advanced configuration..."
-            create_advanced_examples
-            create_package_template
-            setup_mcp_integration
-            print_success "Stagehand advanced setup completed!"
-            print_info "Next steps:"
-            print_info "1. Run: bash .agents/scripts/stagehand-helper.sh install"
-            print_info "2. Configure API keys in ~/.aidevops/stagehand/.env"
-            print_info "3. Try examples: cd ~/.aidevops/stagehand && npm run search-products" || exit
-            ;;
-        "examples")
-            create_advanced_examples
-            ;;
-        "mcp")
-            setup_mcp_integration
-            ;;
-        "help")
-            cat << EOF
+	local command="${1:-setup}"
+
+	case "$command" in
+	"setup")
+		print_info "Setting up Stagehand advanced configuration..."
+		create_advanced_examples
+		create_package_template
+		setup_mcp_integration
+		print_success "Stagehand advanced setup completed!"
+		print_info "Next steps:"
+		print_info "1. Run: bash .agents/scripts/stagehand-helper.sh install"
+		print_info "2. Configure API keys in ~/.aidevops/stagehand/.env"
+		print_info "3. Try examples: cd ~/.aidevops/stagehand && npm run search-products" || exit
+		;;
+	"examples")
+		create_advanced_examples
+		;;
+	"mcp")
+		setup_mcp_integration
+		;;
+	"help")
+		cat <<EOF
 Stagehand Setup Script
 
 USAGE:
@@ -394,14 +392,14 @@ COMMANDS:
     help        Show this help
 
 EOF
-            ;;
-        *)
-            print_error "$ERROR_UNKNOWN_COMMAND $command"
-            return 1
-            ;;
-    esac
-    
-    return 0
+		;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND $command"
+		return 1
+		;;
+	esac
+
+	return 0
 }
 
 # Execute main function


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Removed two misplaced `return 0` statements that were embedded inside heredoc content in `.agents/scripts/stagehand-setup.sh`, causing the generated `package.json` and `stagehand-config.json` files to contain literal `    return 0` text — making them invalid JSON.

## Issue
Closes #15370

## Files Changed
- `.agents/scripts/stagehand-setup.sh` — removed `return 0` from inside heredoc JSON in `create_package_template` (line 322) and `setup_mcp_integration` (line 353)

## Testing
- `bash -n .agents/scripts/stagehand-setup.sh` — syntax OK
- `shellcheck` — only SC1091 info (pre-existing, sourced file path)
- Function complexity: all functions remain under 100 lines (largest: `create_advanced_examples` at 83 lines)

## Key Decisions
- The issue title stated "0 functions >100 lines" (false-positive complexity scan). During investigation, two genuine bugs were found: `return 0` embedded in heredoc JSON content. Fixed both.
- Indentation reformatted from spaces to tabs by linter (consistent with shellcheck/shfmt conventions).

## Runtime Testing
Risk: **Low** — script generates template files; no auth, payments, or state machines. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.737 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6