### PR TITLE
GH#15905: reduce function complexity in thumbnail-helper.sh

### DIFF
--- a/.agents/scripts/thumbnail-helper.sh
+++ b/.agents/scripts/thumbnail-helper.sh
@@ -132,15 +132,14 @@ EOF
 	return 0
 }
 
-# Get template JSON for a given style
-get_template_json() {
-	local template_name="$1"
-	local subject="$2"
-	local concept="$3"
+# =============================================================================
+# Template JSON Builders (one function per template)
+# =============================================================================
 
-	case "$template_name" in
-	high-contrast-face)
-		cat <<EOF
+_template_high_contrast_face() {
+	local subject="$1"
+	local concept="$2"
+	cat <<EOF
 {
   "subject": "$subject",
   "concept": "$concept",
@@ -181,9 +180,13 @@ get_template_json() {
   "negative": "blurry, low quality, distorted, watermark, text overlay, multiple faces, cluttered background"
 }
 EOF
-		;;
-	text-heavy)
-		cat <<EOF
+	return 0
+}
+
+_template_text_heavy() {
+	local subject="$1"
+	local concept="$2"
+	cat <<EOF
 {
   "subject": "$subject",
   "concept": "$concept",
@@ -224,9 +227,13 @@ EOF
   "negative": "cluttered, busy background, text overlay, watermark, low contrast"
 }
 EOF
-		;;
-	before-after)
-		cat <<EOF
+	return 0
+}
+
+_template_before_after() {
+	local subject="$1"
+	local concept="$2"
+	cat <<EOF
 {
   "subject": "$subject",
   "concept": "$concept - split screen comparison",
@@ -267,9 +274,13 @@ EOF
   "negative": "blurry, low quality, distorted, watermark, text overlay, cluttered"
 }
 EOF
-		;;
-	curiosity-gap)
-		cat <<EOF
+	return 0
+}
+
+_template_curiosity_gap() {
+	local subject="$1"
+	local concept="$2"
+	cat <<EOF
 {
   "subject": "$subject with surprised or shocked expression",
   "concept": "$concept",
@@ -310,9 +321,13 @@ EOF
   "negative": "blurry, low quality, neutral expression, boring, text overlay, watermark"
 }
 EOF
-		;;
-	product-showcase)
-		cat <<EOF
+	return 0
+}
+
+_template_product_showcase() {
+	local subject="$1"
+	local concept="$2"
+	cat <<EOF
 {
   "subject": "$subject centered on clean background",
   "concept": "$concept",
@@ -353,6 +368,30 @@ EOF
   "negative": "blurry, low quality, cluttered background, text overlay, watermark, multiple products"
 }
 EOF
+	return 0
+}
+
+# Dispatch to the appropriate template builder function
+get_template_json() {
+	local template_name="$1"
+	local subject="$2"
+	local concept="$3"
+
+	case "$template_name" in
+	high-contrast-face)
+		_template_high_contrast_face "$subject" "$concept"
+		;;
+	text-heavy)
+		_template_text_heavy "$subject" "$concept"
+		;;
+	before-after)
+		_template_before_after "$subject" "$concept"
+		;;
+	curiosity-gap)
+		_template_curiosity_gap "$subject" "$concept"
+		;;
+	product-showcase)
+		_template_product_showcase "$subject" "$concept"
 		;;
 	*)
 		print_error "Unknown template: $template_name"
@@ -367,45 +406,25 @@ EOF
 # Thumbnail Generation
 # =============================================================================
 
-cmd_generate() {
+# Generate variant prompt JSON files into output_dir
+_generate_variant_prompts() {
 	local topic="$1"
-	local count="${2:-5}"
-	local template="${3:-high-contrast-face}"
+	local count="$2"
+	local template="$3"
+	local output_dir="$4"
 
-	validate_required_param "topic" "$topic" || return 1
-	load_image_gen_credentials || return 1
-
-	if [[ -z "${HIGGSFIELD_API_KEY:-}" ]] || [[ -z "${HIGGSFIELD_SECRET:-}" ]]; then
-		print_error "Higgsfield credentials not configured. Run: aidevops secret set higgsfield-api-key"
-		return 1
-	fi
-
-	print_info "Generating $count thumbnail variants for: $topic"
-	print_info "Using template: $template"
-
-	# Create output directory
-	local output_dir="$THUMBNAIL_CACHE_DIR/$(date +%Y%m%d_%H%M%S)_${topic// /_}"
-	mkdir -p "$output_dir"
-
-	# Generate variants
 	for i in $(seq 1 "$count"); do
 		print_info "Generating variant $i/$count..."
 
-		# Create variant-specific subject and concept
 		local subject="Person discussing $topic"
 		local concept="YouTube thumbnail for video about $topic - variant $i"
 
-		# Get template JSON
 		local template_json
 		template_json=$(get_template_json "$template" "$subject" "$concept") || return 1
 
-		# Save template JSON
 		local json_file="$output_dir/variant_${i}_prompt.json"
 		echo "$template_json" >"$json_file"
 
-		# Call Nanobanana Pro API via Higgsfield
-		# Note: This is a placeholder - actual API integration would go here
-		# For now, we'll create a marker file
 		print_info "  → Prompt saved to: $json_file"
 		print_warning "  → API integration pending - use Higgsfield UI to generate from this JSON"
 
@@ -426,6 +445,30 @@ cmd_generate() {
 		#
 		# echo "$job_id" > "$output_dir/variant_${i}_job_id.txt"
 	done
+
+	return 0
+}
+
+cmd_generate() {
+	local topic="$1"
+	local count="${2:-5}"
+	local template="${3:-high-contrast-face}"
+
+	validate_required_param "topic" "$topic" || return 1
+	load_image_gen_credentials || return 1
+
+	if [[ -z "${HIGGSFIELD_API_KEY:-}" ]] || [[ -z "${HIGGSFIELD_SECRET:-}" ]]; then
+		print_error "Higgsfield credentials not configured. Run: aidevops secret set higgsfield-api-key"
+		return 1
+	fi
+
+	print_info "Generating $count thumbnail variants for: $topic"
+	print_info "Using template: $template"
+
+	local output_dir="$THUMBNAIL_CACHE_DIR/$(date +%Y%m%d_%H%M%S)_${topic// /_}"
+	mkdir -p "$output_dir"
+
+	_generate_variant_prompts "$topic" "$count" "$template" "$output_dir" || return 1
 
 	print_success "Generated $count thumbnail variant prompts in: $output_dir"
 	print_info "Next steps:"
@@ -502,18 +545,16 @@ _score_collect_criteria() {
 	return 0
 }
 
-# Calculate weighted score, display result, and save score report to file
-_score_calculate_and_save() {
-	local image_path="$1"
-	local face_score="$2"
-	local contrast_score="$3"
-	local text_space_score="$4"
-	local brand_score="$5"
-	local emotion_score="$6"
-	local clarity_score="$7"
+# Compute weighted score from individual criteria scores
+_score_calculate_weighted() {
+	local face_score="$1"
+	local contrast_score="$2"
+	local text_space_score="$3"
+	local brand_score="$4"
+	local emotion_score="$5"
+	local clarity_score="$6"
 
-	local weighted_score
-	weighted_score=$(awk "BEGIN {
+	awk "BEGIN {
         score = ($face_score * 0.25) + \
                 ($contrast_score * 0.20) + \
                 ($text_space_score * 0.15) + \
@@ -521,19 +562,29 @@ _score_calculate_and_save() {
                 ($emotion_score * 0.15) + \
                 ($clarity_score * 0.10);
         printf \"%.2f\", score
-    }")
+    }"
+	return 0
+}
 
-	echo ""
-	print_info "Weighted Score: $weighted_score / 10"
-
-	if (($(echo "$weighted_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
-		print_success "✓ PASS - Score meets threshold (>= $MIN_SCORE_THRESHOLD)"
-	else
-		print_warning "✗ FAIL - Score below threshold (< $MIN_SCORE_THRESHOLD) - regenerate recommended"
-	fi
+# Write score report file alongside the image
+_score_save_report() {
+	local image_path="$1"
+	local weighted_score="$2"
+	local face_score="$3"
+	local contrast_score="$4"
+	local text_space_score="$5"
+	local brand_score="$6"
+	local emotion_score="$7"
+	local clarity_score="$8"
 
 	local score_file="${image_path%.png}_score.txt"
 	score_file="${score_file%.jpg}_score.txt"
+
+	local status="FAIL"
+	if (($(echo "$weighted_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
+		status="PASS"
+	fi
+
 	cat >"$score_file" <<EOF
 Thumbnail Score Report
 ======================
@@ -550,10 +601,40 @@ Criteria Scores:
 
 Weighted Score: $weighted_score / 10
 Threshold: $MIN_SCORE_THRESHOLD
-Status: $(if (($(echo "$weighted_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then echo "PASS"; else echo "FAIL"; fi)
+Status: $status
 EOF
 
 	print_info "Score saved to: $score_file"
+	return 0
+}
+
+# Calculate weighted score, display result, and save score report to file
+_score_calculate_and_save() {
+	local image_path="$1"
+	local face_score="$2"
+	local contrast_score="$3"
+	local text_space_score="$4"
+	local brand_score="$5"
+	local emotion_score="$6"
+	local clarity_score="$7"
+
+	local weighted_score
+	weighted_score=$(_score_calculate_weighted \
+		"$face_score" "$contrast_score" "$text_space_score" \
+		"$brand_score" "$emotion_score" "$clarity_score")
+
+	echo ""
+	print_info "Weighted Score: $weighted_score / 10"
+
+	if (($(echo "$weighted_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
+		print_success "✓ PASS - Score meets threshold (>= $MIN_SCORE_THRESHOLD)"
+	else
+		print_warning "✗ FAIL - Score below threshold (< $MIN_SCORE_THRESHOLD) - regenerate recommended"
+	fi
+
+	_score_save_report "$image_path" "$weighted_score" \
+		"$face_score" "$contrast_score" "$text_space_score" \
+		"$brand_score" "$emotion_score" "$clarity_score"
 
 	return 0
 }
@@ -601,7 +682,6 @@ cmd_batch_score() {
 		echo ""
 		print_info "=== Image $image_count: $(basename "$image_file") ==="
 
-		# Check if already scored
 		local score_file="${image_file%.png}_score.txt"
 		score_file="${score_file%.jpg}_score.txt"
 
@@ -618,10 +698,8 @@ cmd_batch_score() {
 				print_warning "✗ FAIL"
 			fi
 		else
-			# Score interactively
 			cmd_score "$image_file"
 
-			# Check if passed
 			local new_score
 			new_score=$(grep "Weighted Score:" "$score_file" | awk '{print $3}')
 			if (($(echo "$new_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
@@ -666,6 +744,45 @@ cmd_upload() {
 	return 0
 }
 
+# Collect passing thumbnail paths from a scored directory into a named array ref
+_ab_collect_passing_thumbnails() {
+	local dir="$1"
+	local -n _passing_ref="$2"
+
+	while IFS= read -r -d '' score_file; do
+		local status
+		status=$(grep "Status:" "$score_file" | awk '{print $2}')
+
+		if [[ "$status" == "PASS" ]]; then
+			local image_file="${score_file%_score.txt}.png"
+			if [[ ! -f "$image_file" ]]; then
+				image_file="${score_file%_score.txt}.jpg"
+			fi
+
+			if [[ -f "$image_file" ]]; then
+				_passing_ref+=("$image_file")
+			fi
+		fi
+	done < <(find "$dir" -type f -name "*_score.txt" -print0)
+
+	return 0
+}
+
+# Upload all passing thumbnails with rate limiting
+_ab_upload_passing() {
+	local video_id="$1"
+	shift
+	local thumbnails=("$@")
+
+	for thumb in "${thumbnails[@]}"; do
+		print_info "Uploading: $(basename "$thumb")"
+		cmd_upload "$video_id" "$thumb"
+		sleep "$THUMBNAIL_RATE_LIMIT_DELAY"
+	done
+
+	return 0
+}
+
 cmd_ab_test() {
 	local video_id="$1"
 	local dir="$2"
@@ -681,25 +798,8 @@ cmd_ab_test() {
 	print_info "Setting up A/B test for video: $video_id"
 	print_info "Thumbnail directory: $dir"
 
-	# Find all passing thumbnails
 	local passing_thumbnails=()
-	while IFS= read -r -d '' score_file; do
-		local score
-		score=$(grep "Weighted Score:" "$score_file" | awk '{print $3}')
-		local status
-		status=$(grep "Status:" "$score_file" | awk '{print $2}')
-
-		if [[ "$status" == "PASS" ]]; then
-			local image_file="${score_file%_score.txt}.png"
-			if [[ ! -f "$image_file" ]]; then
-				image_file="${score_file%_score.txt}.jpg"
-			fi
-
-			if [[ -f "$image_file" ]]; then
-				passing_thumbnails+=("$image_file")
-			fi
-		fi
-	done < <(find "$dir" -type f -name "*_score.txt" -print0)
+	_ab_collect_passing_thumbnails "$dir" passing_thumbnails
 
 	if [[ ${#passing_thumbnails[@]} -eq 0 ]]; then
 		print_error "No passing thumbnails found in directory"
@@ -709,7 +809,6 @@ cmd_ab_test() {
 
 	print_success "Found ${#passing_thumbnails[@]} passing thumbnails"
 
-	# YouTube's A/B testing (via YouTube Studio)
 	print_info ""
 	print_info "YouTube A/B Testing Setup:"
 	print_info "1. Upload all passing thumbnails to YouTube Studio"
@@ -721,15 +820,10 @@ cmd_ab_test() {
 		print_info "  - $(basename "$thumb")"
 	done
 
-	# Optionally upload all thumbnails
 	echo ""
 	read -r -p "Upload all passing thumbnails now? (y/n): " upload_choice
 	if [[ "$upload_choice" == "y" ]]; then
-		for thumb in "${passing_thumbnails[@]}"; do
-			print_info "Uploading: $(basename "$thumb")"
-			cmd_upload "$video_id" "$thumb"
-			sleep "$THUMBNAIL_RATE_LIMIT_DELAY"
-		done
+		_ab_upload_passing "$video_id" "${passing_thumbnails[@]}"
 	fi
 
 	return 0


### PR DESCRIPTION
## Summary

Refactors `.agents/scripts/thumbnail-helper.sh` to reduce function complexity by extracting focused helper functions from the monolithic `get_template_json` function and other large functions.

Closes #15905

## What changed

- Extracted 5 per-template JSON builder functions (`_template_high_contrast_face`, `_template_text_heavy`, `_template_before_after`, `_template_curiosity_gap`, `_template_product_showcase`) from the 233-line `get_template_json` case block
- `get_template_json` reduced from 233 → 34 lines (pure dispatcher)
- Extracted `_generate_variant_prompts` from `cmd_generate`
- Extracted `_score_calculate_weighted` and `_score_save_report` from `_score_calculate_and_save`
- Extracted `_ab_collect_passing_thumbnails` and `_ab_upload_passing` from `cmd_ab_test`
- All functions now ≤88 lines (largest: `cmd_help` heredoc)

## Files changed

- `.agents/scripts/thumbnail-helper.sh` — 187 insertions, 93 deletions (net +94 lines for clarity)

## Testing

- `bash -n`: SYNTAX OK
- `shellcheck`: SC1091 info only (pre-existing, sourced file not followed — same as original)
- No functional changes; all logic preserved

## Runtime Testing

Risk: **Low** — shell script refactor, no logic changes, no external API calls modified. `self-assessed`.

---

[aidevops.sh](https://aidevops.sh) v3.5.738 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6