### PR TITLE
GH#15376: tighten pilot-results.md comprehension benchmark doc

### DIFF
--- a/.agents/tests/comprehension/pilot-results.md
+++ b/.agents/tests/comprehension/pilot-results.md
@@ -1,22 +1,20 @@
 # Comprehension Benchmark Pilot Results
 
-**Date:** 2026-04-02
-**Files tested:** 15
-**Scenarios:** 38 total (2-3 per file)
-**Method:** Structural pre-filter + predicted tier assignment based on file analysis
+**Date:** 2026-04-02 | **Files:** 15 | **Scenarios:** 38 (2-3/file)
+**Method:** Structural pre-filter + predicted tier assignment
 
 ## Summary
 
-| Predicted Tier | File Count | Percentage |
-|---------------|------------|------------|
-| haiku         | 10         | 67%        |
-| sonnet        | 5          | 33%        |
-| opus          | 0          | 0%         |
+| Predicted Tier | Count | % |
+|---------------|-------|---|
+| haiku | 10 | 67% |
+| sonnet | 5 | 33% |
+| opus | 0 | 0% |
 
 ## Per-File Results
 
-| File | Lines | Cross-refs | Complexity | Predicted Tier | Scenarios |
-|------|-------|-----------|------------|----------------|-----------|
+| File | Lines | Cross-refs | Complexity | Tier | Scenarios |
+|------|-------|-----------|------------|------|-----------|
 | `scripts/commands/code-simplifier.md` | 12 | 2 | simple | haiku | 2 |
 | `aidevops/memory-patterns.md` | 48 | 6 | simple | haiku | 2 |
 | `reference/self-improvement.md` | 59 | 8 | simple | haiku | 2 |
@@ -37,119 +35,63 @@
 
 ### Clarity problem (file needs improvement)
 
-These failures indicate the agent file's instructions are ambiguous or unclear,
-causing the model to misinterpret the intended behavior.
+Model follows a plausible but incorrect interpretation — output addresses the right topic but reaches wrong conclusion; multiple valid readings exist.
 
-**Indicators:**
-- Model follows a plausible but incorrect interpretation
-- Output addresses the right topic but reaches wrong conclusion
-- Multiple valid readings of the same instruction
-
-**Expected examples at haiku tier:**
-- `code-simplifier.md`: "almost never simplify" section requires understanding
-  nuanced categories -- haiku may over-simplify the classification
-- `planning-detail.md`: PR lookup fallback chain has 3 steps with conditional
-  logic -- haiku may skip steps or conflate them
-- `worker-efficiency-protocol.md`: model escalation rule has a decision matrix
-  with 6 rows -- haiku may miss edge cases in the matrix
+**Expected haiku failures:**
+- `code-simplifier.md`: nuanced "almost never simplify" categories → haiku over-simplifies classification
+- `planning-detail.md`: 3-step PR lookup fallback chain with conditional logic → haiku skips or conflates steps
+- `worker-efficiency-protocol.md`: 6-row model escalation decision matrix → haiku misses edge cases
 
 ### Exceeds model capability (file is fine, model too weak)
 
-These failures indicate the model tier lacks the reasoning capacity for the task,
-not that the instructions are unclear.
+Model lacks reasoning capacity for the task; instructions are clear.
 
-**Indicators:**
-- Model refuses or says "I don't understand" (fast-fail: refusal)
-- Model hallucinates file paths or tool names not in context (fast-fail: confabulation)
-- Model violates a core constraint it was explicitly told about (fast-fail: structural_violation)
-- Model gives a minimal response with no engagement (fast-fail: disengagement)
+**Fast-fail indicators:** refusal, confabulation (hallucinated paths/tools), structural_violation (ignores explicit constraint), disengagement (minimal response).
 
-**Expected examples at haiku tier:**
-- `architecture.md`: "intelligence over scripts" principle requires understanding
-  a meta-level design philosophy -- haiku may give a surface-level answer
-- `git-workflow.md`: destructive command safety hooks have allowlist/blocklist
-  logic -- haiku may confuse which commands are blocked vs allowed
-- `planning-detail.md`: task completion rules have multiple interacting
-  constraints (PR evidence, pre-commit hooks, issue-sync cascade) -- haiku
-  may miss the cascade implications
+**Expected haiku failures:**
+- `architecture.md`: "intelligence over scripts" meta-level philosophy → haiku gives surface-level answer
+- `git-workflow.md`: allowlist/blocklist semantics for destructive commands → haiku conflates blocked vs allowed
+- `planning-detail.md`: interacting constraints (PR evidence, pre-commit hooks, issue-sync cascade) → haiku misses cascade
 
-### Known-Bad Cases (benchmark correctly identifies failures)
+### Known-Bad Cases
 
-#### Haiku false-fail (correctly identified as needing sonnet)
+**Haiku false-fails (correctly escalated to sonnet):**
+- `tools/code-review/code-simplifier.md` "classifies safe vs judgment": 4-tier classification (safe/prose-tightening/requires-judgment/almost-never) with nuanced boundaries — haiku collapses to binary; sonnet maintains 4-tier distinction.
+- `workflows/git-workflow.md` "destructive command safety": allowlist vs blocklist + `--force-with-lease` exception — haiku conflates; sonnet distinguishes correctly.
 
-- **`tools/code-review/code-simplifier.md` scenario "classifies safe vs judgment":**
-  Requires distinguishing 4 classification tiers (safe, prose tightening,
-  requires judgment, almost never) with nuanced boundary conditions. Haiku
-  tends to collapse these into binary safe/unsafe. Sonnet correctly maintains
-  the 4-tier distinction.
+**Sonnet false-fails:** None expected. All pilot files within sonnet range. Opus-tier files (e.g., `prompts/build.txt` 400+ lines, deeply nested cross-refs) excluded from pilot.
 
-- **`workflows/git-workflow.md` scenario "destructive command safety":**
-  Requires understanding allowlist vs blocklist semantics and the specific
-  exception for `--force-with-lease`. Haiku may state both are blocked or
-  both are allowed. Sonnet correctly distinguishes them.
+**False-pass risk:** Haiku passes deterministic checks but misunderstands intent. Example: `reference/self-improvement.md` "framework vs project routing" — haiku outputs "framework" (passes `contains` check) with wrong reasoning. Mitigation: adjudication layer (haiku self-check or sonnet judge) catches most; `reference_answer` field enables precise comparison for critical files.
 
-#### Sonnet false-fail (correctly identified as needing opus)
+## Structural Pre-Filter
 
-- No sonnet false-fails expected in this pilot set. The tested files are
-  all within sonnet's comprehension range. Files that would require opus
-  (e.g., `prompts/build.txt` at 400+ lines with deeply nested cross-references)
-  are not included in this pilot.
-
-#### False-pass analysis
-
-- **Risk:** Haiku passes deterministic checks but misunderstands the deeper
-  intent. Example: `reference/self-improvement.md` scenario "framework vs
-  project routing" -- haiku may correctly output "framework" (passing the
-  `contains` check) but give wrong reasoning about why.
-
-- **Mitigation:** The adjudication layer (haiku self-check or sonnet judge)
-  catches most false-passes. For critical files, the reference_answer field
-  enables more precise comparison.
-
-## Structural Pre-Filter Accuracy
-
-The pre-filter uses line count, cross-reference count, code blocks, table rows,
-and heading depth to predict complexity without model calls.
+Uses line count, cross-ref count, code blocks, table rows, heading depth to predict complexity without model calls.
 
 | Complexity | Criteria | Predicted Tier |
 |-----------|----------|----------------|
-| simple | score <= 2 (< 60 lines, few refs) | haiku |
+| simple | score ≤ 2 (< 60 lines, few refs) | haiku |
 | moderate | score 3-5 (60-120 lines, moderate refs) | haiku or sonnet |
 | complex | score > 5 (> 120 lines, many refs) | sonnet |
 
-**Accuracy estimate:** The pre-filter correctly predicts the tier for ~70% of
-files. The remaining 30% are "moderate" files that could go either way --
-these are the ones where the actual model benchmark adds the most value.
+**Accuracy:** ~70% correct. Remaining 30% are "moderate" files where the model benchmark adds most value.
 
 ## Cost Analysis
 
-| Component | Per-file Cost | Notes |
-|-----------|--------------|-------|
+| Component | Per-file | Notes |
+|-----------|---------|-------|
 | Pre-filter (structural) | $0.00 | Pure shell heuristics |
-| Haiku scenario run (2-3 scenarios) | ~$0.003 | ~500 tokens in, ~200 out per scenario |
+| Haiku scenario run (2-3 scenarios) | ~$0.003 | ~500 tokens in, ~200 out/scenario |
 | Deterministic scoring | $0.00 | Regex/string matching |
 | Haiku self-check (if ambiguous) | ~$0.001 | ~200 tokens |
 | Sonnet adjudication (if needed) | ~$0.01 | ~300 tokens |
 | Sonnet scenario run (escalation) | ~$0.01 | Only if haiku fails |
 
-**Total per file (typical):** $0.003-$0.015
-**Full sweep (300 files):** $0.90-$4.50
-**Target:** < $0.02 per file -- **met**
+**Total/file:** $0.003-$0.015 | **Full sweep (300 files):** $0.90-$4.50 | **Target:** < $0.02/file — **met**
 
 ## Recommendations
 
-1. **Run the benchmark** against the 15 pilot files using `comprehension-benchmark-helper.sh sweep`
-   to validate predicted tiers against actual model performance.
-
-2. **Expand to full codebase** after pilot validation. Priority: files in
-   `simplification-state.json` (already tracked for changes).
-
-3. **Integrate with pulse dispatch** by reading `tier_minimum` from state
-   and routing to the cheapest compatible model.
-
-4. **Production feedback loop:** When a task dispatched at the benchmarked tier
-   fails, log `{file, tier_dispatched, failure_reason, task_id}` and downgrade
-   the file's tier_minimum.
-
-5. **Re-benchmark after simplification:** When the code-simplifier modifies a
-   file, re-run its comprehension test to verify the tier didn't regress.
+1. Run benchmark against 15 pilot files via `comprehension-benchmark-helper.sh sweep` to validate predicted tiers.
+2. Expand to full codebase after pilot validation; prioritize files in `simplification-state.json`.
+3. Integrate with pulse dispatch: read `tier_minimum` from state, route to cheapest compatible model.
+4. Production feedback loop: on tier-dispatched task failure, log `{file, tier_dispatched, failure_reason, task_id}` and downgrade `tier_minimum`.
+5. Re-benchmark after simplification: when code-simplifier modifies a file, rerun its comprehension test to verify tier didn't regress.


### PR DESCRIPTION
## Summary

- Tighten prose in `.agents/tests/comprehension/pilot-results.md` per simplification scan (GH#15376)
- 155 → 97 lines (37% reduction) — all data tables, task IDs, command references, and cost figures preserved
- Compressed verbose paragraph descriptions into concise inline summaries; merged redundant indicator lists into single sentences

## What

Simplified the comprehension benchmark pilot results doc. Classification: instruction doc (contains operational guidance — failure mode categories, recommendations, pre-filter rules). Action: tighten prose, not split into chapters.

## Issue

Closes #15376

## Files Changed

- `.agents/tests/comprehension/pilot-results.md` — 155 → 97 lines

## Testing

**Risk level:** Low (docs/agent prompts — no runtime behaviour changed)
**Runtime Testing:** `self-assessed` — doc-only change, no executable code modified

Content preservation verified:
- All data tables intact (summary, per-file results, pre-filter, cost analysis)
- All command references preserved (`comprehension-benchmark-helper.sh sweep`)
- All task ID references preserved (none in this file)
- All cost figures preserved ($0.003-$0.015/file, $0.90-$4.50 full sweep)
- All 5 recommendations preserved

## Key Decisions

- Treated as instruction doc (not reference corpus) — contains operational guidance, not just data
- No chapter splitting at 155 lines — fragmentation overhead exceeds benefit
- Merged "Indicators" bullet lists into inline prose to reduce vertical space without losing information

<!-- MERGE_SUMMARY -->
**What:** Tighten comprehension benchmark pilot results doc (155→97 lines)
**Issue:** GH#15376
**Files:** 1 (`.agents/tests/comprehension/pilot-results.md`)
**Testing:** self-assessed (doc-only)
**Key decisions:** instruction-doc classification, prose compression, no splitting

---
[aidevops.sh](https://aidevops.sh) v3.5.738 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6