### PR TITLE
GH#15389: tighten agent doc Git Tools (.agents/tools/git.md)

### DIFF
--- a/.agents/tools/git.md
+++ b/.agents/tools/git.md
@@ -74,15 +74,12 @@ git push all main
 
 ## OpenCode Integration
 
-GitHub setup and common commands:
-
 ```bash
 ~/.aidevops/agents/scripts/opencode-github-setup-helper.sh check
 opencode github install
 ```
 
-Issue or PR comments:
 - GitHub: `/oc explain this issue`, `/oc fix this bug`, `/opencode review this PR`
-- GitLab: add OpenCode to `.gitlab-ci.yml`, then use `@opencode explain this issue` and `@opencode fix this`
+- GitLab: add OpenCode to `.gitlab-ci.yml`, then `@opencode explain this issue` / `@opencode fix this`
 
-See `git/opencode-github.md`, `git/opencode-gitlab.md`, and `git/opencode-github-security.md` for workflow and hardening details.
+Full workflow and hardening: `git/opencode-github.md`, `git/opencode-gitlab.md`, `git/opencode-github-security.md`.


### PR DESCRIPTION
## What

Tighten `.agents/tools/git.md` per simplification-debt issue GH#15389.

## Changes

- Remove redundant prose intro `GitHub setup and common commands:` (section heading is sufficient)
- Remove redundant `Issue or PR comments:` label before bullet list
- Remove duplicate `See git/opencode-github.md...` pointer (already listed in Quick Reference automation bullet)
- Tighten GitLab bullet prose (`then use @opencode` → `then @opencode`)
- Result: 88 → 85 lines

## Preservation Verification

All preserved:
- All code blocks (`opencode-github-setup-helper.sh check`, `opencode github install`)
- All doc pointers (`git/opencode-github.md`, `git/opencode-gitlab.md`, `git/opencode-github-security.md`)
- All command examples (`/oc explain this issue`, `/oc fix this bug`, `/opencode review this PR`)
- All task IDs and issue refs: none in this file

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. `self-assessed`.

Closes #15389

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated OpenCode Integration usage instructions for improved clarity
  * Simplified GitLab command guidance formatting in issue and PR comments
  * Streamlined references to workflow and hardening documentation resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->