### PR TITLE
GH#15925: tighten hyperdrive-gotchas.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,4 +1,9 @@
 {
+  ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md": {
+    "hash": "c954d270144237464f87a86245f051a45e963c9b14df2e026f6fa64132f21895",
+    "issue": "GH#15925",
+    "status": "simplified"
+  },
   ".agents/tools/ai-orchestration/overview.md": {
     "hash": "3a63b044317f50c757951158e4e711234d09cd299f8dc557bdc5af9e580735f6",
     "issue": "GH#15266",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,7 +1,8 @@
 {
   ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md": {
-    "hash": "c954d270144237464f87a86245f051a45e963c9b14df2e026f6fa64132f21895",
+    "hash": "289d1ce963a8bfbb69d5199ff47d8368f19a653f67305bafd8940e7a0982c67b",
     "issue": "GH#15925",
+    "pr": "PR#16125",
     "status": "simplified"
   },
   ".agents/tools/ai-orchestration/overview.md": {

--- a/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md
@@ -70,7 +70,7 @@ WHERE application_name = 'Cloudflare Hyperdrive';
 - Write-heavy workloads (limited cache benefit)
 - Real-time data requirements (<1s freshness)
 - Single-region apps close to DB
-- Very simple apps (overhead unjustified)
+- Minimal applications (overhead unjustified)
 - DB with strict connection limits already exceeded
 
 Alternatives: D1 (Cloudflare native SQL), Durable Objects (stateful Workers), KV (global key-value), R2 (object storage).

--- a/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md
@@ -50,8 +50,6 @@ WHERE application_name = 'Cloudflare Hyperdrive';
 | Query | Max duration | 60s | 60s |
 | Query | Max cached response | 50MB | 50MB |
 
-Queries >60s are terminated. Responses >50MB are returned but not cached.
-
 ## Migration Checklist
 
 - [ ] Create config via Wrangler
@@ -69,11 +67,11 @@ Queries >60s are terminated. Responses >50MB are returned but not cached.
 
 ## When NOT to Use
 
-❌ Write-heavy workloads (limited cache benefit)
-❌ Real-time data requirements (<1s freshness)
-❌ Single-region apps close to DB
-❌ Very simple apps (overhead unjustified)
-❌ DB with strict connection limits already exceeded
+- Write-heavy workloads (limited cache benefit)
+- Real-time data requirements (<1s freshness)
+- Single-region apps close to DB
+- Very simple apps (overhead unjustified)
+- DB with strict connection limits already exceeded
 
 Alternatives: D1 (Cloudflare native SQL), Durable Objects (stateful Workers), KV (global key-value), R2 (object storage).
 


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md` per GH#15925.

**Changes (93 → 91 lines):**
- Removed redundant prose note below Limits table: "Queries >60s are terminated. Responses >50MB are returned but not cached." — this data is already present in the table rows (Max duration: 60s, Max cached response: 50MB)
- Replaced decorative ❌ emoji bullets with standard list items in "When NOT to Use" — emojis add no semantic value in this context

**Preserved:** all code blocks, URLs, command examples, table data, troubleshooting steps, migration checklist, supported database versions, resource links.

**Classification:** Reference corpus (gotchas/troubleshooting). At 93 lines, splitting into chapters would add overhead without benefit. Tightening applied to genuine noise only.

Closes #15925

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. `self-assessed`.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten hyperdrive-gotchas.md — remove redundant prose, replace decorative emojis with standard bullets
**Issue:** #15925
**Files changed:** `.agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md`, `.agents/configs/simplification-state.json`
**Testing:** Doc-only change; content preservation verified by manual review
**Key decisions:** Kept both Common Errors table and Troubleshooting section (complementary: table has HTTP status codes, troubleshooting has step-by-step flows)

---
[aidevops.sh](https://aidevops.sh) v3.5.746 plugin for [OpenCode](https://opencode.ai) v1.3.13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Hyperdrive documentation with simplified formatting and clearer guidance.
  * Removed explicit statements about query timeouts and response-size caching behavior.
  * Replaced ❌-prefixed “When NOT to Use” items with plain bullets for cleaner presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->