### PR TITLE
GH#15414: tighten axe-cli.md (82→80 lines)

### DIFF
--- a/.agents/tools/mobile/axe-cli.md
+++ b/.agents/tools/mobile/axe-cli.md
@@ -8,15 +8,13 @@ tools:
 
 # AXe - iOS Simulator Automation CLI
 
-## Quick Reference
-
 - **Install**: `brew install cameroncooke/axe/axe`
 - **Requirements**: macOS with Xcode and iOS Simulator
 - **GitHub**: https://github.com/cameroncooke/AXe (MIT, by XcodeBuildMCP author)
 - **vs idb**: Single binary (no daemon), complete HID coverage, gesture presets, timing controls
 - All commands require `--udid SIMULATOR_UDID`. Get UDIDs: `axe list-simulators`.
 
-## Core Commands
+## Commands
 
 ### Touch, Gestures, and Input
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/mobile/axe-cli.md` per issue #15414 simplification scan.

- Removed redundant `## Quick Reference` section header (content is already at top of file, no section label needed)
- Renamed `## Core Commands` → `## Commands` (removes redundant "Core" qualifier)

## Issue
Closes #15414

## Files Changed
- `.agents/tools/mobile/axe-cli.md`: 82 → 80 lines

## Testing
**Risk level**: Low (docs-only change — agent prompt file, no code)
**Verification**: `self-assessed`
- All code blocks preserved verbatim
- All URLs, command examples, and comparison table intact
- No content removed — structural labels only

## Key Decisions
- File is already compact; only non-destructive structural tightening applied
- Code blocks and all institutional knowledge preserved per issue guidance
- Did not adopt changes from existing `chore/GH-14136-tighten-axe-cli` worktree (that branch expanded the file, not tightened it)

## Runtime Testing
`self-assessed` — docs-only change, no runtime environment required.

---
[aidevops.sh](https://aidevops.sh) v3.5.746 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6