### PR TITLE
GH#15505: tighten warmforge.md agent doc

### DIFF
--- a/.agents/services/outreach/warmforge.md
+++ b/.agents/services/outreach/warmforge.md
@@ -9,8 +9,6 @@ tools:
 
 # WarmForge
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 - Monitor domain-level deliverability signals; automate mailbox warmup state transitions
@@ -19,7 +17,7 @@ tools:
 - Auto-pause on anomaly thresholds (bounce spike, complaint spike, inbox-placement drop)
 - Resume with reduced profile after remediation — never jump back to prior peak volume
 
-### Operational Policy
+## Operational Policy
 
 1. Check `health` and `domains` before any orchestration command.
 2. Pull `deliverability` metrics for the active domain window (default `7d`).
@@ -27,9 +25,9 @@ tools:
 4. Degraded metrics → `warmup-pause`; open incident note with root-cause hypothesis.
 5. After remediation → resume with lower profile before re-scaling.
 
-### Helper Script
+## Helper Script
 
-Use `.agents/scripts/warmforge-helper.sh` for API access.
+`.agents/scripts/warmforge-helper.sh` — commands:
 
 - `warmforge-helper.sh health`
 - `warmforge-helper.sh domains`
@@ -41,15 +39,10 @@ Use `.agents/scripts/warmforge-helper.sh` for API access.
 - `warmforge-helper.sh warmup-resume <mailbox_id>`
 - `warmforge-helper.sh raw <METHOD> <PATH> [JSON_BODY]`
 
-### Required Environment
+**Env:** `WARMFORGE_API_KEY` (required); `WARMFORGE_API_BASE_URL` (optional, defaults to `https://api.warmforge.ai/v1`)
 
-- `WARMFORGE_API_KEY` (required)
-- `WARMFORGE_API_BASE_URL` (optional, defaults to `https://api.warmforge.ai/v1`)
-
-### Failure Handling
+## Failure Handling
 
 - HTTP 4xx → configuration/auth problem (token scope, mailbox ID, domain ID)
 - HTTP 5xx → provider-side incident; retry with backoff, preserve request context
 - API keys: terminal-local only; never paste into chat or issue comments
-
-<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

Tighten `.agents/services/outreach/warmforge.md` per simplification scan (GH#15505).

**Changes:**
- Remove `<!-- AI-CONTEXT-START/END -->` wrapper comments (structural overhead, not content)
- Collapse `### Required Environment` section into inline `**Env:**` line (saves 3 lines)
- Collapse `### Helper Script` intro sentence into heading (saves 1 line)
- Demote `###` sub-headings to `##` for consistent hierarchy

**Preservation:** All institutional knowledge intact — profiles (`conservative`/`standard`/`aggressive`), 7-day stability threshold, anomaly thresholds, 5-step operational policy, all 9 helper commands, env vars, HTTP error codes, API key security rule.

**Result:** 55 → 48 lines (13% reduction). Instruction doc classification confirmed (not reference corpus).

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. Self-assessed.

Closes #15505

---
<!-- MERGE_SUMMARY -->
**What:** Structural tightening of warmforge.md agent doc — remove wrapper comments, collapse env section inline, normalize heading levels.
**Issue:** GH#15505
**Files changed:** `.agents/services/outreach/warmforge.md` (1 file, -7 net lines)
**Testing:** Self-assessed (low-risk doc change). Content diff verified — all commands, thresholds, policy steps preserved.
**Key decisions:** Classified as instruction doc (not reference corpus) — prose compression appropriate, no chapter splitting needed.

---
[aidevops.sh](https://aidevops.sh) v3.5.746 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6