### PR TITLE
GH#15743: tighten agent doc Git Worktree Workflow (.agents/workflows/worktree.md)

### DIFF
--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -35,6 +35,11 @@ wt switch -c feature/my-feature   # Create worktree + cd into it
 wt list                           # List worktrees with CI status
 wt merge                          # Squash/rebase/merge + cleanup
 wt remove                         # Remove current worktree
+# Hotfix without leaving feature work — existing worktrees unaffected
+wt switch -c hotfix/security-patch
+# Multiple AI sessions on separate worktrees
+opencode ~/Git/myrepo-feature-auth/    # Session 1
+opencode ~/Git/myrepo-bugfix-login/    # Session 2
 ```
 
 **worktree-helper.sh** (fallback — no cd support):
@@ -50,24 +55,13 @@ worktree-helper.sh clean                            # Batch cleanup merged branc
 
 Full Worktrunk docs: `tools/git/worktrunk.md`.
 
-## Workflow Patterns
-
-```bash
-# Hotfix without leaving feature work
-worktree-helper.sh add hotfix/security-patch  # ~/Git/myrepo-hotfix-security-patch/ — feature worktree unchanged
-
-# Multiple AI sessions on separate worktrees
-opencode ~/Git/myrepo-feature-auth/    # Session 1
-opencode ~/Git/myrepo-bugfix-login/    # Session 2
-```
-
 ## Integration
 
 `pre-edit-check.sh` works in any worktree — main or linked.
 
 **Localdev (t1224.8):** Worktree creation auto-sets branch-specific subdomain routing (`https://feature-auth.myapp.local`) for `localdev add` projects. Removal auto-cleans the route.
 
-**Session recovery:** Use `session-rename_sync_branch` after creating branches. Check `worktree-sessions.sh list` before closing PRs or deleting branches.
+**Session recovery:** Run `session-rename_sync_branch` after creating branches. Check `worktree-sessions.sh list` before closing PRs or deleting branches.
 
 ```bash
 worktree-sessions.sh list   # List worktrees with matching sessions


### PR DESCRIPTION
## Summary

- Folds the separate 'Workflow Patterns' section into the Commands block — the patterns were just command examples, not a distinct concern
- Reduces line count from 106 to 100 while preserving all institutional knowledge (t1224.8, GH#6740, t189 refs, all command examples, troubleshooting table)
- No behaviour change: all rules, commands, and cross-references intact

## What

Tighten `.agents/workflows/worktree.md` per `tools/build-agent/build-agent.md` guidance. This is an instruction doc (not a reference corpus), so the correct action is prose compression, not chapter splitting.

## Files Changed

- `.agents/workflows/worktree.md` — 106 → 100 lines (-6 net, 12 deleted / 6 inserted)

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution paths changed.
**Verification:** `self-assessed` — content preservation confirmed by diff review; all task IDs, command examples, and cross-references present before and after.

## Key Decisions

- Kept `wt switch` as the hotfix example (preferred tool) rather than `worktree-helper.sh add` — consistent with Quick Reference preference ordering
- Preserved all task ID references (t1224.8, GH#6740, t189) verbatim — these are institutional knowledge, not prose to compress

Closes #15743

---
[aidevops.sh](https://aidevops.sh) v3.5.746 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6