### PR TITLE
GH#15777: tighten agent doc tirith.md (107 → 105 lines)

### DIFF
--- a/.agents/tools/security/tirith.md
+++ b/.agents/tools/security/tirith.md
@@ -23,8 +23,6 @@ tools:
 - **Coverage**: 30 rules across 7 categories
 - **Activation**: Add the shell hook once; every later command is checked automatically
 
-Browsers guard homograph attacks, ANSI injection, and suspicious URLs. Terminals usually don't. Tirith adds that check before command execution.
-
 <!-- AI-CONTEXT-END -->
 
 ## Install and activate
@@ -36,7 +34,7 @@ cargo install tirith               # from source
 mise use -g tirith                 # mise
 ```
 
-Also available via Nix, deb, rpm, AUR, Scoop, and Chocolatey. Add one shell hook to activate:
+Also available via Nix, deb, rpm, AUR, Scoop, and Chocolatey. Add one shell hook:
 
 ```bash
 eval "$(tirith init --shell zsh)"   # ~/.zshrc
@@ -88,16 +86,16 @@ fail_mode: open  # or "closed" for strict environments
 
 Set `allow_bypass: false` to prevent per-command bypass in org environments.
 
-## Bypass
+Bypass (one command only, does not persist):
 
 ```bash
-TIRITH=0 curl -L https://known-safe.example.com | bash  # one command only, does not persist
+TIRITH=0 curl -L https://known-safe.example.com | bash
 ```
 
 ## Integration with aidevops
 
 - **setup.sh**: checks for Tirith and suggests installation if missing
-- **Auto-guard**: once `eval "$(tirith init)"` is in the shell profile, all terminal commands spawned by aidevops scripts are guarded automatically
+- **Auto-guard**: `eval "$(tirith init)"` in shell profile guards all commands spawned by aidevops scripts
 - **Audit log**: `~/.local/share/tirith/log.jsonl` (timestamp, action, rule ID, redacted preview); disable with `TIRITH_LOG=0`
 
 ## Related


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/security/tirith.md` per issue #15777 (agent doc simplification scan).

**Changes:**
- Remove redundant intro sentence in Quick Reference (already covered by frontmatter `description`)
- Fold standalone `## Bypass` section into `## Configuration` (eliminate heading, inline the comment)
- Tighten Auto-guard bullet: remove verbose "once...is in the shell profile, all terminal commands" phrasing
- Minor: "Add one shell hook" (drop "to activate")

**Preservation check:** All code blocks, URLs, command examples, rule descriptions, task IDs, and institutional knowledge intact. No content removed — prose only.

**Line count:** 107 → 105 lines (net -2, heading elimination + prose compression)

Closes #15777

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.746 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6