### PR TITLE
GH#15747: tighten models-pool-check.md agent doc (81 → 77 lines)

### DIFF
--- a/.agents/scripts/commands/models-pool-check.md
+++ b/.agents/scripts/commands/models-pool-check.md
@@ -4,13 +4,13 @@ agent: Build+
 mode: subagent
 ---
 
-Entry point for provider-account setup and troubleshooting. Diagnose first, then give exactly one next step. Assume the user knows nothing about OAuth or pools.
+Entry point for provider-account setup and troubleshooting. Diagnose first, give exactly one next step. Assume the user knows nothing about OAuth or pools.
 
 ## Core rules
 
 - **One step at a time.** Give one command or action, not branches.
 - **Diagnose before advising.** Run checks first, then choose the path.
-- **Separate terminal for auth commands.** Never ask for tokens or codes in chat.
+- **Auth commands go in a separate terminal.** Never ask for tokens or codes in chat.
 - **Explain what, not internals.** Do not mention pool.json, PKCE, token endpoints, or auth hooks.
 - **After any add/import:** remind them to restart the app, then press Ctrl+T to choose a model.
 - **Any model can run this.** `oauth-pool-helper.sh` works even on free models with no paid provider configured.
@@ -28,13 +28,9 @@ Run both in parallel via Bash:
 
 #### Path A — no accounts exist
 
-If `claude auth status --json` shows `loggedIn: true` with `pro` or `max`, import it:
+If `claude auth status --json` shows `loggedIn: true` with `pro` or `max`:
 
-> You're already logged into Claude CLI with a **{subscriptionType}** account ({email}). Run this in a separate terminal to connect it:
->
-> ```bash
-> oauth-pool-helper.sh import claude-cli
-> ```
+> You're already logged into Claude CLI with a **{subscriptionType}** account ({email}). Run in a separate terminal: `oauth-pool-helper.sh import claude-cli`
 
 Otherwise, ask which provider they have a subscription with:
 
@@ -52,7 +48,7 @@ Then give exactly one command in a separate terminal:
 | Cursor | `opencode auth login --provider cursor` |
 | Google | `oauth-pool-helper.sh add google` |
 
-Anthropic/OpenAI/Google: browser opens → authorize → paste code back → restart app. Cursor: browser opens → authorize → tokens saved automatically → restart app.
+Anthropic/OpenAI/Google: browser opens → authorize → paste code → restart app. Cursor: browser opens → authorize → tokens saved automatically → restart app.
 
 #### Path B — accounts exist and are healthy
 


### PR DESCRIPTION
## Summary

- Tightened `models-pool-check.md` from 81 to 77 lines (5% reduction)
- Collapsed 5-line blockquote with fenced code block into 1-line inline command (Path A)
- Removed redundant "then" in intro and "back" in auth flow description
- Reworded core rule bullet for clarity without changing meaning
- All institutional knowledge preserved: commands, paths, Cursor exception, provider list, tool names

Closes #15747

---
[aidevops.sh](https://aidevops.sh) v3.5.750 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6