### PR TITLE
GH#15948: tighten stealth-patches.md prose

### DIFF
--- a/.agents/tools/browser/stealth-patches.md
+++ b/.agents/tools/browser/stealth-patches.md
@@ -46,7 +46,7 @@ with sync_playwright() as p:
 
 ## playwright-stealth
 
-JS-level evasions cover `navigator.webdriver`, plugins, languages, `chrome.runtime`, `window.chrome`, Permissions API, iframe detection, WebGL, and `hardwareConcurrency`.
+JS-level evasions: `navigator.webdriver`, plugins, languages, `chrome.runtime`, `window.chrome`, Permissions API, iframe detection, WebGL, `hardwareConcurrency`.
 
 ```python
 from playwright.sync_api import sync_playwright
@@ -103,7 +103,7 @@ const { browser, context, page } = await createStealthContext({
 - **rebrowser-patches**: Chromium only; re-patch after Playwright updates.
 - **playwright-stealth**: JS-level only; sophisticated anti-bots still detect it.
 - **Neither** handles fingerprint rotation or WebRTC/font spoofing.
-- **Full anti-detect**: use Camoufox (`fingerprint-profiles.md`) for C++-level fingerprint spoofing on Firefox, with `pip upgrade` maintenance.
+- **Full anti-detect**: use Camoufox (`fingerprint-profiles.md`) for C++-level fingerprint spoofing on Firefox; requires `pip upgrade` maintenance.
 
 | Aspect | rebrowser-patches | Camoufox |
 |--------|------------------|----------|


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/tools/browser/stealth-patches.md` per `build-agent.md` guidance (GH#15948).

**Classification**: Instruction doc (decision trees, tool selection, operational procedures) — prose tightening, not restructuring.

**Changes** (2 lines):
- `playwright-stealth` section: removed redundant "cover" verb and trailing "and" from list intro
- `Limitations` section: replaced `, with \`pip upgrade\` maintenance` with `; requires \`pip upgrade\` maintenance` — cleaner punctuation, same meaning

**Content preservation verified**:
- All 7 code blocks intact
- All 6 detection site URLs present
- All key commands preserved (rebrowser-patches, playwright-stealth, anti-detect-helper, fingerprint-profiles)
- No task IDs in original (none to preserve)

## Runtime Testing

Risk: **Low** — docs-only change, no code, no agent behaviour change. `self-assessed`.

Closes #15948

---
<!-- MERGE_SUMMARY -->
**What**: Prose tightening of stealth-patches.md (2 lines changed, 113 lines total unchanged)
**Issue**: #15948
**Files changed**: `.agents/tools/browser/stealth-patches.md`
**Testing**: Content preservation verified — all code blocks, URLs, commands present before and after
**Key decisions**: File was already lean; only 2 genuine prose improvements found without content loss

---
[aidevops.sh](https://aidevops.sh) v3.5.750 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6