### PR TITLE
GH#14971: tighten models-opus.md agent doc (53 → 50 lines)

### DIFF
--- a/.agents/tools/ai-assistants/models-opus.md
+++ b/.agents/tools/ai-assistants/models-opus.md
@@ -24,21 +24,18 @@ tools:
 
 Highest-capability tier for tasks where stronger reasoning materially changes the outcome.
 
-## Use For
+## When to Use
+
+Use opus only when the task genuinely needs extra reasoning depth:
 
 - Architecture and system design decisions
-- Novel problems with no established pattern to follow
-- Security audits that require deep reasoning
+- Novel problems with no established pattern
+- Security audits requiring deep reasoning
 - Multi-step plans with hard dependencies
 - Trade-off analysis across many variables
 - Evaluating other models' outputs
 
-## Routing Rules
-
-- Use opus only when the task genuinely needs the extra reasoning depth.
-- Default most implementation work to sonnet.
-- Use pro when the main constraint is large context, not judgment.
-- Justify the spend: opus costs about 1.7x sonnet ($5/$25 vs $3/$15 per 1M input/output tokens).
+Do not use for routine implementation — route to sonnet. For large-context tasks (100K+ tokens), route to pro.
 
 ## Model Details
 


### PR DESCRIPTION
## Summary

- Merged redundant `Use For` + `Routing Rules` sections into a single `When to Use` section
- Eliminated inline cost ratio (redundant with Model Details table)
- Tightened bullet prose without removing any use-case or routing knowledge
- 53 → 50 lines (6% reduction)

## Verification

- All 6 use-case bullets preserved
- Routing rules preserved: sonnet default, pro for large-context
- Cost data retained in Model Details table
- Frontmatter unchanged
- Consistent structure with sibling files (models-haiku.md, models-sonnet.md)

Closes #14971

---
[aidevops.sh](https://aidevops.sh) v3.5.756 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6