### PR TITLE
GH#14973: tighten rules-video-status.md prose

### DIFF
--- a/.agents/content/heygen-skill/rules-video-status.md
+++ b/.agents/content/heygen-skill/rules-video-status.md
@@ -60,7 +60,7 @@ Typical generation time is **5-15 min**. At peak load, with long scripts, or at 
 
 ## Polling Pattern
 
-Poll every few seconds at first, then use exponential backoff for long-running jobs. For UI feedback, call `onProgress?: (status: string, elapsed: number) => void` on each iteration.
+Poll every few seconds; use exponential backoff for long-running jobs. For UI feedback, add `onProgress?: (status: string, elapsed: number) => void` on each iteration.
 
 ```typescript
 async function waitForVideo(
@@ -81,7 +81,7 @@ async function waitForVideo(
 
 ## Download With Retry
 
-`completed` means the metadata is ready; the file URL may still take a moment to serve. Retry downloads with exponential backoff.
+`completed` means metadata is ready; the file URL may still take a moment to serve. Retry with exponential backoff.
 
 ```typescript
 import fs from "fs";
@@ -103,7 +103,7 @@ async function downloadVideo(videoUrl: string, outputPath: string, maxRetries = 
 
 ## Resumable Workflow
 
-For long generations, persist the `video_id` and resume later instead of holding an idle process open.
+Persist `video_id` and resume later; don't hold an idle process open for long generations.
 
 ```typescript
 // generate-video.ts — start and exit


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/content/heygen-skill/rules-video-status.md` per GH#14973 simplification scan.

## Issue
Closes #14973

## Files Changed
- `.agents/content/heygen-skill/rules-video-status.md` — 3 prose lines tightened; all code examples, URLs, and institutional knowledge preserved

## Changes
- Polling Pattern: "Poll every few seconds at first, then use exponential backoff" → "Poll every few seconds; use exponential backoff" (removed redundant "at first")
- Download With Retry: "the metadata is ready; the file URL may still take a moment to serve. Retry downloads with exponential backoff" → "metadata is ready; the file URL may still take a moment to serve. Retry with exponential backoff" (removed redundant article and word)
- Resumable Workflow: "For long generations, persist the `video_id` and resume later instead of holding an idle process open" → "Persist `video_id` and resume later; don't hold an idle process open for long generations" (reordered for primacy, compressed)

## Testing
- `self-assessed` (Low risk: docs/agent prompts only)
- All code blocks, URLs, task ID references, and command examples verified present before and after
- No broken internal links or references

## Runtime Testing
`self-assessed` — documentation-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.756 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6