### PR TITLE
GH#14988: tighten 01-aeo-patterns.md

### DIFF
--- a/.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md
+++ b/.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md
@@ -41,9 +41,8 @@ Use these for featured snippets, answer boxes, and spoken-result queries.
 
 ## FAQ Block
 
-Phrase questions the way users search, match "People Also Ask" wording, keep answers to 50-100 words, and put the direct answer first.
-
 ```markdown
+<!-- Phrase questions the way users search; match "People Also Ask" wording; keep answers 50-100 words; direct answer first -->
 ### [Question phrased as users search]?
 [Direct answer first sentence]. [Supporting context in 2-3 sentences].
 ```
@@ -59,4 +58,8 @@ Phrase questions the way users search, match "People Also Ask" wording, keep ans
 
 ## Voice Search Pattern
 
-Target conversational queries like "What is...", "How do I...", "Where can I find...", "Why does...", and "When should I...?" Give the answer in under 30 words, use natural language, avoid jargon unless the audience is expert, and add local context when useful.
+```markdown
+<!-- Target: "What is...", "How do I...", "Where can I find...", "Why does...", "When should I...?" -->
+<!-- Answer in under 30 words; natural language; avoid jargon unless expert audience; add local context when useful -->
+[Direct conversational answer in under 30 words].
+```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md` per GH#14988 simplification scan.

## Issue
Closes #14988

## Files Changed
- `.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md` — prose instructions moved into code block comments; Voice Search Pattern given a template placeholder

## Changes
- FAQ Block: moved standalone prose ("Phrase questions the way users search...") into a markdown comment inside the code block — keeps instructions co-located with the template
- Voice Search Pattern: converted bare prose instructions into a proper code block with markdown comments and a template placeholder `[Direct conversational answer in under 30 words].`

## Testing
- `self-assessed` (Low risk: docs/agent prompts only)
- All content preserved; instructions moved into code block comments, not removed
- No broken internal links or references

## Runtime Testing
`self-assessed` — documentation-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.756 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SEO audit guidance structure, reorganizing instructional content for FAQ and Voice Search patterns to improve clarity and presentation of guidance materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->