### PR TITLE
GH#15034: tighten agent doc email-design-test.md (53 → 41 lines)

### DIFF
--- a/.agents/scripts/commands/email-design-test.md
+++ b/.agents/scripts/commands/email-design-test.md
@@ -4,31 +4,19 @@ agent: Build+
 mode: subagent
 ---
 
-Run local email design tests (HTML, CSS, accessibility, images, links) and optionally submit to Email on Acid (EOA) for real-client rendering.
-
 Arguments: $ARGUMENTS
 
 ## Dispatch
 
 Parse `$ARGUMENTS`: HTML file path → local tests; `eoa` prefix → EOA API commands; empty/help → show usage.
 
-**Local tests (no API key):**
+| Mode | Command |
+|------|---------|
+| Local tests (no API key) | `email-design-test-helper.sh test "$ARGUMENTS"` |
+| Full EOA test (local + API rendering) | `email-design-test-helper.sh eoa-test "$ARGUMENTS"` |
+| Sandbox mode (no API key) | `email-design-test-helper.sh eoa-sandbox "$ARGUMENTS"` |
 
-```bash
-~/.aidevops/agents/scripts/email-design-test-helper.sh test "$ARGUMENTS"
-```
-
-**Full EOA test (local + API rendering):**
-
-```bash
-~/.aidevops/agents/scripts/email-design-test-helper.sh eoa-test "$ARGUMENTS"
-```
-
-**Sandbox mode (no API key):**
-
-```bash
-~/.aidevops/agents/scripts/email-design-test-helper.sh eoa-sandbox "$ARGUMENTS"
-```
+All scripts at `~/.aidevops/agents/scripts/`.
 
 ## Output
 


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/email-design-test.md` per GH#15034 simplification scan.

- Consolidate 3 separate labeled dispatch code blocks into a single dispatch table (12 lines → 5 lines)
- Remove intro paragraph that duplicated the frontmatter `description` field
- All command examples, script paths, URLs, and functional content preserved

**Line count:** 53 → 41 (23% reduction)

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution paths changed. `self-assessed`.

## Files Changed

- `.agents/scripts/commands/email-design-test.md`

Closes #15034

---
[aidevops.sh](https://aidevops.sh) v3.5.756 plugin for [OpenCode](https://opencode.ai) v1.3.13