### PR TITLE
GH#15821: tighten agent doc Text Overlays (.agents/content/heygen-skill/rules-text-overlays.md, 95 lines)

### DIFF
--- a/.agents/content/heygen-skill/rules-text-overlays.md
+++ b/.agents/content/heygen-skill/rules-text-overlays.md
@@ -31,9 +31,9 @@ interface TextOverlay {
 
 ## Positioning
 
-**Coordinate system:** Origin top-left (0,0). X increases right, Y increases down. Units: pixels or percentage.
+Origin top-left (0,0). X increases right, Y increases down. Units: pixels or percentage.
 
-### Common Positions (1920×1080)
+**Common positions (1920×1080):**
 
 | Position | X | Y |
 |----------|---|---|


### PR DESCRIPTION
## Summary

- Tightened structure of `.agents/content/heygen-skill/rules-text-overlays.md`
- Removed sub-header nesting in Positioning section: demoted `### Common Positions (1920×1080)` to inline bold label
- Simplified coordinate system note from bold-wrapped prose to plain text
- Zero knowledge loss; all code blocks, URLs, and command examples preserved

Closes #15821

<!-- MERGE_SUMMARY -->
**What**: Structural tightening of HeyGen Text Overlays agent doc — removed one level of heading nesting in the Positioning section and simplified prose formatting.
**Issue**: #15821
**Files changed**: `.agents/content/heygen-skill/rules-text-overlays.md`
**Testing**: `markdownlint` clean (zero violations). Self-assessed as Low risk (documentation-only change).
**Key decisions**: File is already compact at 95 lines; only structural noise removed (sub-header → inline bold label). No content compressed or removed.

## Runtime Testing

- [x] self-assessed (docs-only, Low risk)

---
[aidevops.sh](https://aidevops.sh) v3.5.757 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6