### PR TITLE
GH#15835: tighten agent doc Browser QA (118 → 103 lines)

### DIFF
--- a/.agents/workflows/browser-qa.md
+++ b/.agents/workflows/browser-qa.md
@@ -50,31 +50,19 @@ JSON summary: `{output-dir}/qa-report.json` — visited/passed/failed pages, bro
 
 ## Usage
 
-### Standalone
-
 ```bash
+# Standalone — basic, with flows, with output dir, JSON format, skip links, mission-scoped
 browser-qa-worker.sh --url http://localhost:3000
-browser-qa-worker.sh --url http://localhost:3000 \
-  --flows '["/", "/about", "/login", "/dashboard"]'
-browser-qa-worker.sh --url http://localhost:8080 \
-  --output-dir ~/Git/myproject/todo/missions/m001/assets/qa
-browser-qa-worker.sh --url http://localhost:3000 --format json
-browser-qa-worker.sh --url http://localhost:3000 --no-check-links
-browser-qa-worker.sh --url http://localhost:3000 \
-  --mission-file ~/Git/myproject/todo/missions/m001/mission.md \
-  --milestone 2
-```
+browser-qa-worker.sh --url http://localhost:3000 --flows '["/", "/about", "/login"]'
+browser-qa-worker.sh --url http://localhost:8080 --output-dir ~/Git/myproject/todo/missions/m001/assets/qa
+browser-qa-worker.sh --url http://localhost:3000 --format json --no-check-links
+browser-qa-worker.sh --url http://localhost:3000 --mission-file mission.md --milestone 2
 
-### Via milestone validation
-
-```bash
-milestone-validation-worker.sh mission.md 2 \
-  --browser-qa --browser-url http://localhost:3000
-milestone-validation-worker.sh mission.md 2 \
-  --browser-qa --browser-url http://localhost:3000 \
+# Via milestone validation
+milestone-validation-worker.sh mission.md 2 --browser-qa --browser-url http://localhost:3000
+milestone-validation-worker.sh mission.md 2 --browser-qa --browser-url http://localhost:3000 \
   --browser-qa-flows '["/", "/about", "/api/health"]'
-milestone-validation-worker.sh mission.md 1 \
-  --browser-tests --browser-qa --browser-url http://localhost:3000
+milestone-validation-worker.sh mission.md 1 --browser-tests --browser-qa --browser-url http://localhost:3000
 ```
 
 ### Exit codes
@@ -87,14 +75,11 @@ milestone-validation-worker.sh mission.md 1 \
 
 ## Flows and output
 
+Flows accept a JSON array of path strings or `{url, name}` objects:
+
 ```json
 ["/", "/about", "/contact", "/login"]
-
-[
-  {"url": "/", "name": "homepage"},
-  {"url": "/login", "name": "login-page"},
-  {"url": "/dashboard", "name": "dashboard"}
-]
+[{"url": "/", "name": "homepage"}, {"url": "/dashboard", "name": "dashboard"}]
 ```
 
 With `--mission-file` and `--milestone`, the worker extracts URL-like patterns from the milestone acceptance criteria.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/workflows/browser-qa.md` from 118 → 103 lines (13% reduction) per simplification-debt issue #15835.

## Changes
- Consolidated 6 standalone + 3 milestone usage examples into a single code block with inline comments — same coverage, less repetition
- Condensed flows JSON examples from two separate blocks into one with both formats shown
- Added a one-line prose intro to the flows section for clarity
- All other sections (frontmatter, Quick Reference, When to Use, Checks, Exit codes, Related) unchanged — already tight

## Issue
Closes #15835

## Files changed
- `.agents/workflows/browser-qa.md` (118 → 103 lines, -15 lines)

## Testing
- `markdownlint-cli2`: 0 errors
- Content preservation verified: all command flags (`--flows`, `--format`, `--no-check-links`, `--mission-file`, `--milestone`, `--browser-qa`, `--browser-tests`, `--browser-qa-flows`), output schema fields (`consoleErrors`, `networkErrors`, `linkResults`, `loadTimeMs`), and all related tool references present before and after
- Risk: **Low** (docs-only change, no code, no behaviour change)

## Runtime Testing
`self-assessed` — docs-only change, no executable code modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.758 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6