### PR TITLE
GH#15839: tighten email-testing.md agent doc (108 → 107 lines)

### DIFF
--- a/.agents/services/email/email-testing.md
+++ b/.agents/services/email/email-testing.md
@@ -69,7 +69,7 @@ email-health-check-helper.sh accessibility newsletter.html # 5. Standalone a11y
 | Outlook (iOS/Android) | Full inversion; ignores `prefers-color-scheme` |
 | Yahoo | No dark mode support |
 
-Implementation: `<meta name="color-scheme" content="light dark">` + `@media (prefers-color-scheme: dark)`. Avoid hardcoded white backgrounds. Test logos on light/dark. Use borders/shadows on transparent PNGs.
+Use `<meta name="color-scheme" content="light dark">` + `@media (prefers-color-scheme: dark)`. Avoid hardcoded white backgrounds; test logos on light/dark; use borders/shadows on transparent PNGs.
 
 ## Inbox Placement Scoring
 
@@ -100,9 +100,8 @@ Implementation: `<meta name="color-scheme" content="light dark">` + `@media (pre
 ## Related
 
 - `services/email/email-design-test.md` — Playwright rendering + Email on Acid API
-- `tools/accessibility/accessibility-audit.md` — email WCAG compliance
 - `services/email/email-health-check.md` — DNS authentication
 - `services/email/ses.md` — Amazon SES
 - `content/distribution-email.md` — email content strategy
-- `tools/accessibility/accessibility.md` — WCAG reference
+- `tools/accessibility/accessibility-audit.md` — email WCAG compliance
 - `tools/browser/browser-automation.md` — automated rendering tests


### PR DESCRIPTION
## Summary

Tighten `.agents/services/email/email-testing.md` per issue #15839 (agent doc simplification scan).

**Classification:** Instruction doc (agent rules, commands, workflow) — prose tightening, not chapter restructure.

**Changes:**
- Dark Mode implementation note: merged 3 separate sentences into one compact sentence with semicolons; removed redundant `Implementation:` label prefix
- Related section: removed `tools/accessibility/accessibility.md` (WCAG reference — redundant with `accessibility-audit.md` which already covers email WCAG compliance); reordered remaining entries for logical grouping (email services first, then tools)

**Preserved:** All code blocks, command examples, URLs, table data, scoring thresholds, client compatibility matrix, inbox placement scoring factors.

**Line count:** 108 → 107 lines

Closes #15839

## Runtime Testing

Risk: **Low** (agent doc, no code changes) — `self-assessed`.

Verification: All code blocks, URLs, command examples, and table data present before and after. Agent behaviour unchanged.

---
[aidevops.sh](https://aidevops.sh) v3.5.758 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6