### PR TITLE
GH#15921: tighten pulse-sweep.md (447 → 441 lines)

### DIFF
--- a/.agents/scripts/commands/pulse-sweep.md
+++ b/.agents/scripts/commands/pulse-sweep.md
@@ -20,11 +20,7 @@ Session runs up to 60 minutes. Each monitoring cycle is ~3K tokens. Dispatch →
 
 This session is unattended. Never ask for permission, confirmation, or input. Never stop after a single dispatch pass unless an exit condition is met. After each cycle, immediately continue.
 
-Exit only when:
-
-1. Elapsed runtime ≥ 55 minutes
-2. Circuit breaker or stop flag is active
-3. No dispatchable work remains AND all worker slots are full
+Exit only when: (1) elapsed runtime ≥ 55 minutes; (2) circuit breaker or stop flag is active; (3) no dispatchable work remains AND all worker slots are full.
 
 If `AVAILABLE > 0` and `WORKER_COUNT == 0`, MUST attempt dispatch before sleeping. If no worker launches, log `NO_DISPATCHABLE_EVIDENCE` with counts/reasons, sleep 60s, continue.
 
@@ -96,14 +92,12 @@ relabel_needs_info_replies
 
 ### 4.6. Dispatch FOSS contribution workers when idle capacity exists (t1702)
 
-Lowest priority — only when all managed-repo work is dispatched and slots remain.
+Lowest priority — only when all managed-repo work is dispatched and slots remain. Skip when: managed-repo slots occupied, daily budget exhausted, or no eligible FOSS repos.
 
 ```bash
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 AVAILABLE=$(dispatch_foss_workers "$AVAILABLE")
 ```
-
-Skip when: managed-repo slots occupied, daily budget exhausted, or no eligible FOSS repos.
 
 ### 5. Record initial dispatch success
 


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/pulse-sweep.md` per simplification-debt issue GH#15921.

Closes #15921

## What

- Compressed exit condition list from numbered block to inline sentence (saves 4 lines)
- Moved FOSS dispatch skip-when condition inline with the section intro (saves 2 lines)
- 447 → 441 lines (1.3% reduction)

## Preservation Verification

- All code blocks: 38/38 preserved
- All task IDs: t1545, t1702, t1408, GH#10308, GH#15317, GH#5149 — all present
- All command examples, URLs, and decision rules unchanged
- Agent behaviour unchanged — same logic, tighter prose

## Runtime Testing

**Risk level:** Low — agent doc only, no shell scripts, no executable code changed.
**Verification:** Content diff confirms zero rule loss; all code blocks, task IDs, and command examples present before and after.

<!-- MERGE_SUMMARY -->
**What:** Tighten prose in pulse-sweep.md agent doc (exit conditions inline, FOSS skip-when inline)
**Issue:** Closes #15921
**Files changed:** 1 (.agents/scripts/commands/pulse-sweep.md)
**Testing:** Content preservation verified — all 38 code blocks, 6 task IDs, all command examples intact
**Key decisions:** File is already well-structured; only genuine noise removed (list → inline for 3-item exit conditions)


---
[aidevops.sh](https://aidevops.sh) v3.5.762 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6