### PR TITLE
GH#16026: tighten agent doc Immutability and Pure Functions

### DIFF
--- a/.agents/tools/programming/modern-javascript-skill/immutability.md
+++ b/.agents/tools/programming/modern-javascript-skill/immutability.md
@@ -96,10 +96,8 @@ const newState = setIn(state, ['users', 'u1', 'profile', 'name'], 'Alice');
 
 ## Best Practices
 
-1. **`const` by default** — prevent accidental reassignment
-2. **ES2023 methods** — `.toSorted()`, `.toReversed()`, `.toSpliced()`, `.with()`
-3. **Spread for shallow** — `{ ...obj }`, `[...arr]`; `structuredClone()` for deep
-4. **Never mutate parameters** — always return new objects
-5. **Separate pure logic from I/O** — extract side effects to boundaries
-6. **Inject non-determinism** — pass `Date.now`, `Math.random` as params for testability
-7. **Optional chaining** — `obj?.nested?.value` instead of manual guards
+- **`const` by default** — prevent accidental reassignment
+- **Never mutate parameters** — always return new objects
+- **Separate pure logic from I/O** — extract side effects to boundaries
+- **Inject non-determinism** — pass `Date.now`, `Math.random` as params for testability
+- **Optional chaining** — `obj?.nested?.value` instead of manual guards


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/programming/modern-javascript-skill/immutability.md` per GH#16026.

**Changes:**
- Remove 2 Best Practices items already covered by the Quick Reference table (ES2023 methods, spread/structuredClone)
- Convert numbered list to bullets — numbered ordering implied priority that didn't exist
- 105 → 103 lines

**Preserved:** All code blocks, all unique rules, all inline comments, all ES2023 method examples.

**Classification:** Reference corpus (skill doc). At 105 lines, well under the 300-line split threshold — tightening applied, not restructuring.

Closes #16026

## Runtime Testing

Risk: **Low** — docs-only change, no code execution paths affected. Self-assessed.

---

<!-- MERGE_SUMMARY -->
**What:** Remove redundant Best Practices items from immutability.md skill doc
**Issue:** Closes #16026
**Files changed:** 1 (`.agents/tools/programming/modern-javascript-skill/immutability.md`)
**Testing:** Docs-only, self-assessed (low risk)
**Key decisions:** Removed items 2 and 3 (ES2023 methods, spread/structuredClone) as they duplicate Quick Reference table; converted numbered list to bullets

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.13