### PR TITLE
GH#16027: tighten xcodebuild-mcp.md agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,4 +1,12 @@
 {
+  ".agents/aidevops/service-links.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "1b4d0cbc25fd53ad0a3de4ad3f1b3b8f1b8ab31d",
+    "issue": "GH#14974",
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
+  },
   ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md": {
     "hash": "289d1ce963a8bfbb69d5199ff47d8368f19a653f67305bafd8940e7a0982c67b",
     "issue": "GH#15925",
@@ -18,6 +26,12 @@
     "lines_before": 316,
     "status": "simplified"
   },
+  ".agents/tools/mobile/xcodebuild-mcp.md": {
+    "hash": "f2c99f905efb245964c670a3c29fa54a241c010c0b427ac38a313b4efed715b3",
+    "issue": "GH#16027",
+    "pr": "pending",
+    "status": "simplified"
+  },
   ".agents/tools/voice/voice-ai-models.md": {
     "action": "converted GPU Planning prose to table; clarified VRAM/RAM column header",
     "hash": "80802e36e4fae1517223fb0553a50f7aa9e01acd908f7d50b6d53f60e3a1dda2",
@@ -25,6 +39,13 @@
     "lines_after": 132,
     "lines_before": 126,
     "pr": "pending",
+    "status": "simplified"
+  },
+  ".agents/workflows/pre-edit.md": {
+    "hash": "d87135a808a845416e0193a101bef0fd1c0b4a032969d819556ce109c40da4ba",
+    "issue": "GH#15439",
+    "lines_after": 72,
+    "lines_before": 78,
     "status": "simplified"
   },
   "files": {
@@ -279,6 +300,12 @@
       "hash": "eed9c26fe6697296ac16fa54421ac1d4f9d6f2fc",
       "passes": 1,
       "pr": 13054
+    },
+    ".agents/content/heygen-skill/rules-authentication.md": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "6812919264796812f8cb6b375d01f49664c1af40",
+      "passes": 1,
+      "pr": 15871
     },
     ".agents/content/heygen-skill/rules-avatars.md": {
       "at": "2026-03-29T07:02:16Z",
@@ -1153,6 +1180,12 @@
       "passes": 1,
       "pr": 11410
     },
+    ".agents/marketing-sales/meta-ads-creative-frameworks.md": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "246a973d66f4a046b7479124fd2fba2fdcc35d8d",
+      "passes": 1,
+      "pr": 15906
+    },
     ".agents/marketing-sales/meta-ads-creative-hooks.md": {
       "at": "2026-03-27T21:25:06Z",
       "hash": "f7c8e3356361a9ab1941f729337bbf7d0f8447ef",
@@ -1374,6 +1407,18 @@
       "hash": "01d5281e257d4507215400c7311169fd37a39f6e",
       "passes": 1,
       "pr": 15661
+    },
+    ".agents/scripts/browser-qa-helper.sh": {
+      "at": "2026-04-03T03:15:27Z",
+      "hash": "25b515a9f2777842519da29fbd097585ca4577cc",
+      "passes": 1,
+      "pr": 16086
+    },
+    ".agents/scripts/budget-analysis-helper.sh": {
+      "at": "2026-04-03T03:15:27Z",
+      "hash": "349d6023e95be88974de6ac4be3115d3d90b6c14",
+      "passes": 1,
+      "pr": 16085
     },
     ".agents/scripts/commands/budget-analysis.md": {
       "at": "2026-04-01T20:58:50Z",
@@ -1604,6 +1649,30 @@
       "passes": 1,
       "pr": 15946
     },
+    ".agents/scripts/config-helper.sh": {
+      "at": "2026-04-03T03:15:27Z",
+      "hash": "f3835ea3610ca1031ddce938d81d473ed7009710",
+      "passes": 1,
+      "pr": 16084
+    },
+    ".agents/scripts/cron-helper.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "fee68144def6f04b03f8473a0092455cb7056378",
+      "passes": 1,
+      "pr": 15920
+    },
+    ".agents/scripts/dataset-helper.sh": {
+      "at": "2026-04-03T03:15:27Z",
+      "hash": "96a800ed0595fe0b974acf1c19d27a029d1c49fe",
+      "passes": 1,
+      "pr": 16098
+    },
+    ".agents/scripts/email-agent-helper.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "9d3095a732abae2b4fa11914b1bab89f8d6bc8ba",
+      "passes": 1,
+      "pr": 15919
+    },
     ".agents/scripts/foss-handlers/generic.sh": {
       "at": "2026-03-29T03:15:47Z",
       "hash": "45cc10462795e6230b70b2f068bb95b4e53612f2",
@@ -1615,6 +1684,12 @@
       "hash": "64247677d8764e3ba8355385495671181569267a",
       "passes": 2,
       "pr": 12145
+    },
+    ".agents/scripts/generate-runtime-config.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "5fa2222625d83c338a8ae68782a665f2f0ccc35b",
+      "passes": 1,
+      "pr": 15933
     },
     ".agents/scripts/gh-signature-helper.sh": {
       "at": "2026-03-29T16:34:26Z",
@@ -1634,6 +1709,18 @@
       "passes": 1,
       "pr": 15431
     },
+    ".agents/scripts/mission-email-helper.sh": {
+      "at": "2026-04-03T03:15:29Z",
+      "hash": "59ee94eb2742602d86611ae48998e14befd606f0",
+      "passes": 1,
+      "pr": 15752
+    },
+    ".agents/scripts/opencode-github-setup-helper.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "a5a9852d4feb2de34839b8bbe4db6375babe83a6",
+      "passes": 1,
+      "pr": 15918
+    },
     ".agents/scripts/platform-detect.sh": {
       "at": "2026-04-02T04:56:59Z",
       "hash": "a551a07e07c08853c909e7b8141ddddf2de43420",
@@ -1646,6 +1733,24 @@
       "passes": 6,
       "pr": 15086
     },
+    ".agents/scripts/schema-validator-helper.sh": {
+      "at": "2026-04-03T03:15:29Z",
+      "hash": "a1a29c0ed6b6f49f88e0a081d88189ac9cce2d00",
+      "passes": 1,
+      "pr": 15776
+    },
+    ".agents/scripts/session-checkpoint-helper.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "321474cda29aa78eb9bcd25a639a51fd16c62205",
+      "passes": 1,
+      "pr": 15917
+    },
+    ".agents/scripts/settings-helper.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "e8d5d7546c1ccdf728fca2c13ee27fd5a64eb8d1",
+      "passes": 1,
+      "pr": 15916
+    },
     ".agents/scripts/stats-functions.sh": {
       "at": "2026-04-03T01:11:28Z",
       "hash": "3bd327b19cc722f4ddf43fb1f4724958056e11bb",
@@ -1657,6 +1762,24 @@
       "hash": "14e07889b9a874db8e98e44d1c5a8ed1ac3687fb",
       "passes": 2,
       "pr": 12971
+    },
+    ".agents/scripts/tests/test-quality-feedback-main-verification.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "62205e0ccf0e418c5fa92dc447e11e187923ffcf",
+      "passes": 1,
+      "pr": 15931
+    },
+    ".agents/scripts/thumbnail-helper.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "c157536da90b2552920287287e391f75b15ccc94",
+      "passes": 1,
+      "pr": 15905
+    },
+    ".agents/scripts/video-gen-helper.sh": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "79f7fcd2afb40f9bf21367af3cbb24107da2a7ba",
+      "passes": 1,
+      "pr": 15904
     },
     ".agents/scripts/watercrawl-helper.sh": {
       "at": "2026-04-02T22:43:46Z",
@@ -2534,6 +2657,12 @@
       "passes": 2,
       "pr": 15629
     },
+    ".agents/services/hosting/cloudflare-platform-skill/r2-patterns.md": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "6db3ad07eef857c00860416a7868a2a42636a888",
+      "passes": 1,
+      "pr": 15908
+    },
     ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
       "at": "2026-03-28T16:00:25Z",
       "hash": "3078a83990f41df192998904d47d0641191e7fba",
@@ -3158,6 +3287,12 @@
       "hash": "f8771a0d1548af0fbdd76f1944d50ce6b1107f13",
       "passes": 1,
       "pr": 11011
+    },
+    ".agents/tools/browser/agent-browser.md": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "52400ec344f64870dd6977c9950c80a22d939df5",
+      "passes": 1,
+      "pr": 15892
     },
     ".agents/tools/browser/anti-detect-browser.md": {
       "at": "2026-03-27T21:25:25Z",
@@ -4409,11 +4544,23 @@
       "passes": 1,
       "pr": 12942
     },
+    ".agents/tools/video/remotion-calculate-metadata.md": {
+      "at": "2026-04-03T03:37:02Z",
+      "hash": "4d9fc5e53279ac48361a627f49e9a6559d104b10",
+      "passes": 1,
+      "pr": 16141
+    },
     ".agents/tools/video/remotion-compositions.md": {
       "at": "2026-03-29T23:18:01Z",
       "hash": "6b00afa2299a8d08eaacd114c67804f6d87614b1",
       "passes": 1,
       "pr": 13427
+    },
+    ".agents/tools/video/remotion-extract-frames.md": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "cdadd937d6ba36526460ec12feb224e7b3bdc2b8",
+      "passes": 1,
+      "pr": 15907
     },
     ".agents/tools/video/remotion-fonts.md": {
       "at": "2026-04-02T14:42:45Z",
@@ -4858,147 +5005,6 @@
       "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
       "passes": 1,
       "pr": 15470
-    },
-    ".agents/scripts/dataset-helper.sh": {
-      "hash": "96a800ed0595fe0b974acf1c19d27a029d1c49fe",
-      "at": "2026-04-03T03:15:27Z",
-      "pr": 16098,
-      "passes": 1
-    },
-    ".agents/scripts/browser-qa-helper.sh": {
-      "hash": "25b515a9f2777842519da29fbd097585ca4577cc",
-      "at": "2026-04-03T03:15:27Z",
-      "pr": 16086,
-      "passes": 1
-    },
-    ".agents/scripts/budget-analysis-helper.sh": {
-      "hash": "349d6023e95be88974de6ac4be3115d3d90b6c14",
-      "at": "2026-04-03T03:15:27Z",
-      "pr": 16085,
-      "passes": 1
-    },
-    ".agents/scripts/config-helper.sh": {
-      "hash": "f3835ea3610ca1031ddce938d81d473ed7009710",
-      "at": "2026-04-03T03:15:27Z",
-      "pr": 16084,
-      "passes": 1
-    },
-    ".agents/scripts/generate-runtime-config.sh": {
-      "hash": "5fa2222625d83c338a8ae68782a665f2f0ccc35b",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15933,
-      "passes": 1
-    },
-    ".agents/scripts/tests/test-quality-feedback-main-verification.sh": {
-      "hash": "62205e0ccf0e418c5fa92dc447e11e187923ffcf",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15931,
-      "passes": 1
-    },
-    ".agents/scripts/cron-helper.sh": {
-      "hash": "fee68144def6f04b03f8473a0092455cb7056378",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15920,
-      "passes": 1
-    },
-    ".agents/scripts/email-agent-helper.sh": {
-      "hash": "9d3095a732abae2b4fa11914b1bab89f8d6bc8ba",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15919,
-      "passes": 1
-    },
-    ".agents/scripts/opencode-github-setup-helper.sh": {
-      "hash": "a5a9852d4feb2de34839b8bbe4db6375babe83a6",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15918,
-      "passes": 1
-    },
-    ".agents/scripts/session-checkpoint-helper.sh": {
-      "hash": "321474cda29aa78eb9bcd25a639a51fd16c62205",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15917,
-      "passes": 1
-    },
-    ".agents/scripts/settings-helper.sh": {
-      "hash": "e8d5d7546c1ccdf728fca2c13ee27fd5a64eb8d1",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15916,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/r2-patterns.md": {
-      "hash": "6db3ad07eef857c00860416a7868a2a42636a888",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15908,
-      "passes": 1
-    },
-    ".agents/tools/video/remotion-extract-frames.md": {
-      "hash": "cdadd937d6ba36526460ec12feb224e7b3bdc2b8",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15907,
-      "passes": 1
-    },
-    ".agents/marketing-sales/meta-ads-creative-frameworks.md": {
-      "hash": "246a973d66f4a046b7479124fd2fba2fdcc35d8d",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15906,
-      "passes": 1
-    },
-    ".agents/scripts/thumbnail-helper.sh": {
-      "hash": "c157536da90b2552920287287e391f75b15ccc94",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15905,
-      "passes": 1
-    },
-    ".agents/scripts/video-gen-helper.sh": {
-      "hash": "79f7fcd2afb40f9bf21367af3cbb24107da2a7ba",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15904,
-      "passes": 1
-    },
-    ".agents/tools/browser/agent-browser.md": {
-      "hash": "52400ec344f64870dd6977c9950c80a22d939df5",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15892,
-      "passes": 1
-    },
-    ".agents/content/heygen-skill/rules-authentication.md": {
-      "hash": "6812919264796812f8cb6b375d01f49664c1af40",
-      "at": "2026-04-03T03:15:28Z",
-      "pr": 15871,
-      "passes": 1
-    },
-    ".agents/scripts/schema-validator-helper.sh": {
-      "hash": "a1a29c0ed6b6f49f88e0a081d88189ac9cce2d00",
-      "at": "2026-04-03T03:15:29Z",
-      "pr": 15776,
-      "passes": 1
-    },
-    ".agents/scripts/mission-email-helper.sh": {
-      "hash": "59ee94eb2742602d86611ae48998e14befd606f0",
-      "at": "2026-04-03T03:15:29Z",
-      "pr": 15752,
-      "passes": 1
-    },
-    ".agents/tools/video/remotion-calculate-metadata.md": {
-      "hash": "4d9fc5e53279ac48361a627f49e9a6559d104b10",
-      "at": "2026-04-03T03:37:02Z",
-      "pr": 16141,
-      "passes": 1
     }
-  },
-  ".agents/workflows/pre-edit.md": {
-    "hash": "d87135a808a845416e0193a101bef0fd1c0b4a032969d819556ce109c40da4ba",
-    "issue": "GH#15439",
-    "lines_before": 78,
-    "lines_after": 72,
-    "status": "simplified"
-  },
-  ".agents/aidevops/service-links.md": {
-    "hash": "1b4d0cbc25fd53ad0a3de4ad3f1b3b8f1b8ab31d",
-    "issue": "GH#14974",
-    "pr": "pending",
-    "passes": 1,
-    "at": "2026-04-03T00:00:00Z",
-    "status": "simplified"
   }
 }

--- a/.agents/tools/mobile/xcodebuild-mcp.md
+++ b/.agents/tools/mobile/xcodebuild-mcp.md
@@ -54,13 +54,9 @@ Only simulator tools enabled by default. Use `manage-workflows` to enable other 
 
 ## MCP Configuration
 
-### Claude Code
+Claude Code: `claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@beta mcp`
 
-```bash
-claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@beta mcp
-```
-
-### JSON Config (Cursor, VS Code, Claude Desktop, OpenCode)
+JSON (Cursor, VS Code, Claude Desktop, OpenCode):
 
 ```json
 {


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/mobile/xcodebuild-mcp.md` per simplification scan (GH#16027).

Collapsed the `## MCP Configuration` section: replaced the `### Claude Code` subsection (heading + bash code block) with a single inline note, removing 4 lines of structural overhead. All content preserved.

**Before:** 83 lines | **After:** 79 lines

## Issue
Closes #16027

## Files Changed
- `.agents/tools/mobile/xcodebuild-mcp.md` — 83→79 lines, MCP config section tightened
- `.agents/configs/simplification-state.json` — hash registered for GH#16027

## Testing
- `markdownlint-cli2`: 0 errors
- Content preservation verified: all code blocks, URLs, tool group table, workflow steps, and related links present before and after
- Risk: **Low** (docs-only change, no code, no agent behaviour change)

## Runtime Testing
`self-assessed` — docs-only change, no runtime verification required per risk matrix.

## Key Decisions
- Classified as **instruction doc** (not reference corpus): tighten prose, not split into chapters
- Preserved all tool group table rows and notes (reference data, not compressible)
- Inline note for Claude Code config is clearer than a subsection heading for a one-liner

---
[aidevops.sh](https://aidevops.sh) v3.5.759 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6