### PR TITLE
GH#16028: tighten xcodebuild-mcp.md agent doc

### DIFF
--- a/.agents/tools/mobile/xcodebuild-mcp.md
+++ b/.agents/tools/mobile/xcodebuild-mcp.md
@@ -12,8 +12,6 @@ tools:
   task: false
 ---
 
-# XcodeBuildMCP - Xcode Integration for AI Agents
-
 <!-- AI-CONTEXT-START -->
 
 - **Install**: `npx -y xcodebuildmcp@beta mcp` (MCP server mode)
@@ -54,13 +52,13 @@ Only simulator tools enabled by default. Use `manage-workflows` to enable other 
 
 ## MCP Configuration
 
-### Claude Code
+**Claude Code:**
 
 ```bash
 claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@beta mcp
 ```
 
-### JSON Config (Cursor, VS Code, Claude Desktop, OpenCode)
+**JSON (Cursor, VS Code, Claude Desktop, OpenCode):**
 
 ```json
 {


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/mobile/xcodebuild-mcp.md` per simplification-debt scan (GH#16028).

**Changes (83 → 81 lines):**
- Remove redundant H1 heading that duplicated the frontmatter `description` field
- Convert `### Claude Code` and `### JSON Config (...)` subsection headings to inline bold labels — reduces unnecessary heading hierarchy in a short config block

**Preserved:** all tool names, tool groups, URLs, code blocks, command examples, and `<!-- AI-CONTEXT-START/END -->` block.

## Issue
Closes #16028

## Files Changed
- `.agents/tools/mobile/xcodebuild-mcp.md` — 2 lines removed, 0 content lost

## Testing
- **Risk level:** Low (docs/agent prompt, no executable code)
- **Verification:** `wc -l` before=83, after=81; all code blocks, URLs, tool names, and command examples present before and after (verified with grep counts)
- **Runtime testing:** `self-assessed` (low-risk doc change)

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — tighten prose, not restructure into chapters
- Kept `<!-- AI-CONTEXT-START/END -->` wrapper (serves context injection purpose)
- No content compression — only structural noise removed

---
[aidevops.sh](https://aidevops.sh) v3.5.759 plugin for [OpenCode](https://opencode.ai) v1.3.13