### PR TITLE
GH#15972: tighten glm-ocr.md workflow pattern comments

### DIFF
--- a/.agents/tools/ocr/glm-ocr.md
+++ b/.agents/tools/ocr/glm-ocr.md
@@ -30,7 +30,7 @@ tools:
 
 ```bash
 ollama run glm-ocr "Extract all text from this image" --images /path/to/document.png
-base64 -i document.png | ollama run glm-ocr "Extract all text" --images -  # scripts
+base64 -i document.png | ollama run glm-ocr "Extract all text" --images -  # pipe in scripts
 ```
 
 | Task | Prompt |
@@ -44,19 +44,19 @@ base64 -i document.png | ollama run glm-ocr "Extract all text" --images -  # scr
 ## Workflow Patterns
 
 ```bash
-# Screenshot (macOS)
+# macOS screenshot → OCR
 screencapture -i /tmp/capture.png && ollama run glm-ocr "Extract all text" --images /tmp/capture.png
 
-# Batch
+# Batch directory
 for img in ~/Documents/scans/*.png; do
   echo "=== $img ===" && ollama run glm-ocr "Extract all text" --images "$img"
 done > extracted_text.txt
 
-# PDF (requires ImageMagick)
+# PDF via ImageMagick
 convert -density 300 document.pdf -quality 90 /tmp/page-%03d.png
 for page in /tmp/page-*.png; do ollama run glm-ocr "Extract all text" --images "$page"; done
 
-# Peekaboo integration
+# Peekaboo (screen/window capture)
 peekaboo image --mode screen --analyze "What text is visible?" --model ollama/glm-ocr
 peekaboo image --mode window --app "Preview" --analyze "Extract document text" --model ollama/glm-ocr
 ```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten inline bash comments in `.agents/tools/ocr/glm-ocr.md` workflow patterns section for conciseness.

## Issue
Closes #15972

## Files Changed
- `.agents/tools/ocr/glm-ocr.md` — 5 comment lines tightened (same line count: 79)

## Changes
- `# scripts` → `# pipe in scripts` (clarifies the base64 pipe usage)
- `# Screenshot (macOS)` → `# macOS screenshot → OCR` (more descriptive)
- `# Batch` → `# Batch directory` (clarifies scope)
- `# PDF (requires ImageMagick)` → `# PDF via ImageMagick` (tighter)
- `# Peekaboo integration` → `# Peekaboo (screen/window capture)` (describes what it does)

## Classification
**Instruction doc** (not reference corpus) — prose tightened, zero content loss. All code blocks, URLs, command examples, and institutional knowledge preserved.

## Testing
- `self-assessed` (Low risk: doc-only change, no code paths affected)
- Line count unchanged: 79 lines before and after
- All code blocks, URLs, and command examples verified present

---
[aidevops.sh](https://aidevops.sh) v3.5.759 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6