### PR TITLE
GH#15951: tighten research probes doc

### DIFF
--- a/.agents/reference/define-probes/research.md
+++ b/.agents/reference/define-probes/research.md
@@ -7,26 +7,22 @@ mode: subagent
 
 Use 2 probes during `/define` for tasks classified as **research**.
 
-## Default Assumptions
-
-Apply unless user overrides:
+## Defaults (apply unless overridden)
 
 - Time-boxed — research without a deadline expands indefinitely
 - Deliverable is a written recommendation, not code
 - Compare at least 2 options before recommending one
 - Include cost or effort estimates for each option
 
-## Required Questions (always ask)
+## Required Questions (always ask both)
 
 **Time Box** — How much time should be spent on this research?
-
 1. 30 minutes — quick comparison (recommended for simple evaluations)
 2. 1-2 hours — thorough analysis with examples
 3. Half day — deep dive with prototypes
 4. Let me specify
 
 **Deliverable** — What should the research produce?
-
 1. Written recommendation with pros/cons table (recommended)
 2. Prototype / proof of concept
 3. Decision document for team review
@@ -35,7 +31,6 @@ Apply unless user overrides:
 ## Probes (select 2)
 
 **Decision Criteria** — What matters most when choosing between options?
-
 1. Cost (monetary or compute) (recommended if comparing services/tools)
 2. Developer experience / ease of integration
 3. Performance / scalability
@@ -43,28 +38,24 @@ Apply unless user overrides:
 5. Let me rank my priorities
 
 **Decision Owner** — Who needs to be convinced?
-
 1. Just me — I'll decide based on the research (recommended)
 2. The team — needs to be presentable
 3. A specific stakeholder — needs to address their concerns
 4. No decision needed — this is exploratory
 
 **Outside View** — Have you or the team evaluated similar options before?
-
 1. Yes — we chose [X] last time, checking if it's still the best option
 2. Yes — we rejected [X] last time, want to reconsider
 3. No — this is a new area for us
 4. Not sure — I'll check
 
 **Pre-mortem** — Imagine you pick an option and regret it 3 months later. Most likely reason?
-
 1. Hidden costs or limitations that weren't obvious during evaluation (recommended)
 2. The chosen option doesn't scale as expected
 3. A better option emerged after the decision
 4. The evaluation criteria were wrong
 
 **Backcasting** — After this research is done, what's the next concrete action?
-
 1. Implement the recommended option (recommended)
 2. Present findings and get approval
 3. Create a task/brief for the implementation
@@ -73,7 +64,6 @@ Apply unless user overrides:
 ## Sufficiency Test
 
 Before generating the brief, verify you can answer:
-
 - What's the time box?
 - What deliverable is expected?
 - What are the ranked decision criteria?


### PR DESCRIPTION
## Summary

- Tighten `.agents/reference/define-probes/research.md` from 82 → 72 lines (12% reduction)
- Compress section headers: "Default Assumptions" → "Defaults (apply unless overridden)", "Required Questions (always ask)" → "Required Questions (always ask both)"
- Remove redundant blank lines between question headers and their numbered option lists
- All content preserved: numbered options, decision criteria, sufficiency test, institutional knowledge

## What

Prose tightening of the Research Probes instruction doc. No content removed — only blank lines and verbose header phrasing compressed.

## Testing

- `wc -l`: 82 → 72 lines confirmed
- All numbered option lists intact (5 probe sections × 4-5 options each)
- Sufficiency test checklist preserved
- Default assumptions preserved
- Agent behaviour unchanged — same questions, same options, same flow

## Files Changed

- `.agents/reference/define-probes/research.md` — tightened prose, removed redundant blank lines

## Runtime Testing

**Risk level:** Low — docs/agent prompts only, no code changes.
**Assessment:** self-assessed. No runtime verification required per testing gate.

Closes #15951

---
[aidevops.sh](https://aidevops.sh) v3.5.759 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6