### PR TITLE
GH#15939: tighten openapi-search.md 85→82 lines

### DIFF
--- a/.agents/tools/context/openapi-search.md
+++ b/.agents/tools/context/openapi-search.md
@@ -38,9 +38,9 @@ mcp:
 
 | Step | Tool | Parameters | Returns |
 |------|------|------------|---------|
-| 0 | `searchAPIs` | `query` (required), `limit` (default 5, max 20) | `apiId`, name, description, relevance score |
-| 1 | `getAPIOverview` | `apiId` — identifier or raw OpenAPI URL | Endpoint list, base URL, auth info |
-| 2 | `getOperationDetails` | `apiId`, `operationId` (e.g. `"POST /mail/send"`) | Parameters, request/response schemas |
+| 1 | `searchAPIs` | `query` (required), `limit` (default 5, max 20) | `apiId`, name, description, relevance score |
+| 2 | `getAPIOverview` | `apiId` — identifier or raw OpenAPI URL | Endpoint list, base URL, auth info |
+| 3 | `getOperationDetails` | `apiId`, `operationId` (e.g. `"POST /mail/send"`) | Parameters, request/response schemas |
 
 ## Configuration
 
@@ -50,20 +50,17 @@ aidevops configures all clients automatically via `setup.sh` / `generate-opencod
 claude mcp add --scope user openapi-search --transport http https://openapi-mcp.openapisearch.com/mcp
 ```
 
-For other clients, add `mcpServers.openapi-search` with `type: http` and `url: https://openapi-mcp.openapisearch.com/mcp` to the client's MCP config file. Exceptions: OpenCode uses `type: remote`; Continue.dev uses `type: sse`; Zed uses `context_servers`.
+For other clients, add `mcpServers.openapi-search` with `type: http` and `url: https://openapi-mcp.openapisearch.com/mcp`. Exceptions: OpenCode uses `type: remote`; Continue.dev uses `type: sse`; Zed uses `context_servers`.
 
 ## Usage
 
 ```text
-# 1. Find APIs for a use case
 searchAPIs(query: "convert currency exchange rates")
 # → [{ apiId: "exchangerate-api", ... }, { apiId: "fixer.io", ... }]
 
-# 2. Explore the best match
 getAPIOverview(apiId: "exchangerate-api")
 # → endpoints list, base URL, auth info
 
-# 3. Get details for the specific operation
 getOperationDetails(apiId: "exchangerate-api", operationId: "GET /latest/{base}")
 # → parameters, response schema, example responses
 ```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/context/openapi-search.md` from 85 → 82 lines. Third automated simplification pass on this file.

## Changes
- Removed 3 redundant step-label comments in Usage code block (`# 1. Find APIs for a use case`, etc.) — these restate the Tools table above
- Dropped `to the client's MCP config file` from Configuration prose (obvious from context)
- Renumbered Tools table steps 0/1/2 → 1/2/3 (natural user-facing numbering; 0-indexed was inconsistent with prose)

## Issue
Closes #15939

## Files Changed
- `.agents/tools/context/openapi-search.md` (85 → 82 lines, -3 lines)

## Testing
- Risk: **Low** (docs-only change, agent prompt)
- All URLs verified present: `openapisearch.com`, `apis.guru`, `janwilmake/openapi-mcp-server`
- All commands preserved: `claude mcp add`, `curl` troubleshooting
- All decision rules preserved: Use/Don't use, Troubleshooting cases
- `self-assessed` (no runtime required for doc changes)

## Key Decisions
- File has been tightened 3 prior times (GH#14263, GH#13944, t10575) — only genuine noise remains
- Kept all `# →` result comments in Usage block (add value showing output format)
- No content loss: every rule, URL, command example, and exception preserved

---
[aidevops.sh](https://aidevops.sh) v3.5.759 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAPI Search MCP documentation workflow steps and usage examples for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->