### PR TITLE
GH#15560: tighten wrangler-gotchas.md doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -806,7 +806,7 @@
       "at": "2026-04-02T21:19:54Z",
       "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
       "issue": "GH#14286",
-      "note": "Reference corpus chapter tightened: 92 → 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
+      "note": "Reference corpus chapter tightened: 92 \u2192 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
       "passes": 2
     },
     ".agents/marketing-sales/cro-chapter-20.md": {
@@ -5048,5 +5048,11 @@
     "passes": 1,
     "at": "2026-04-03T00:00:00Z",
     "status": "simplified"
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md": {
+    "hash": "fe14a1e366f4bf8824657cdcd36e6bb1abb934a7a8219a33d577d5295dcef5b7",
+    "lines": 37,
+    "status": "simplified",
+    "issue": "GH#15560"
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md
@@ -1,34 +1,20 @@
 # Wrangler Common Issues
 
-Pitfalls and troubleshooting for the Wrangler CLI.
-
 ## Gotchas
 
 **Binding IDs vs Names** — `binding` = code name; `id`/`database_id`/`bucket_name` = resource ID. Preview bindings need separate IDs: `preview_id`, `preview_database_id`.
 
 **Environment Inheritance** — Non-inheritable (bindings, vars): must redeclare per env. Inheritable (routes, `compatibility_date`): can override.
 
-**Compatibility Dates** — Always set; omitting causes unexpected runtime changes:
+**Compatibility Dates** — Always set; omitting causes unexpected runtime changes. Example: `{ "compatibility_date": "2025-01-01" }`.
+
+**Durable Objects Need `script_name`** — With `getPlatformProxy`, always specify `script_name` in the binding:
 
 ```jsonc
-{ "compatibility_date": "2025-01-01" }
+{ "durable_objects": { "bindings": [{ "name": "MY_DO", "class_name": "MyDO", "script_name": "my-worker" }] } }
 ```
 
-**Durable Objects Need `script_name`** — With `getPlatformProxy`, always specify:
-
-```jsonc
-{
-  "durable_objects": {
-    "bindings": [{ "name": "MY_DO", "class_name": "MyDO", "script_name": "my-worker" }]
-  }
-}
-```
-
-**Node.js Compatibility** — Some bindings (e.g., Hyperdrive with `pg`) require:
-
-```jsonc
-{ "compatibility_flags": ["nodejs_compat_v2"] }
-```
+**Node.js Compatibility** — Some bindings (e.g., Hyperdrive with `pg`) require `{ "compatibility_flags": ["nodejs_compat_v2"] }`.
 
 **Secrets in Local Dev** — `wrangler secret put` only works deployed. Use `.dev.vars` locally. See [wrangler-patterns.md](./wrangler-patterns.md).
 


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md` from 51 to 37 lines (27% reduction).

Closes #15560

## What changed

- Removed redundant intro sentence ("Pitfalls and troubleshooting for the Wrangler CLI.") — the heading is self-explanatory
- Inlined single-line JSON examples (`compatibility_date`, `compatibility_flags`) as inline code instead of fenced blocks
- Collapsed multi-line Durable Objects JSON to a single-line fenced block

## Knowledge preservation

All content preserved:
- All 5 gotcha rules intact
- Troubleshooting table (5 rows) unchanged
- All URLs and cross-references intact
- Durable Objects `script_name` example preserved (kept as code block since it's the key pattern)

## Runtime Testing

**Risk level:** Low — agent doc/prompt file only, no runtime code.
**Verification:** `self-assessed` — content diff reviewed line-by-line; all knowledge present before and after.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten wrangler-gotchas.md instruction doc (51→37 lines)
**Issue:** #15560
**Files changed:** `.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md`, `.agents/configs/simplification-state.json`
**Testing:** Self-assessed (doc-only change, low risk)
**Key decisions:** Kept Durable Objects example as code block (multi-key JSON, inline would be unreadable); inlined single-value examples

---
[aidevops.sh](https://aidevops.sh) v3.5.759 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6