### PR TITLE
GH#16062: tighten remotion-can-decode.md agent doc

### DIFF
--- a/.agents/tools/video/remotion-can-decode.md
+++ b/.agents/tools/video/remotion-can-decode.md
@@ -10,19 +10,12 @@ metadata:
 
 Use Mediabunny to check if a video can be decoded by the browser before attempting to play it.
 
-## The `canDecode()` function
+## Shared track-check helper
 
 ```tsx
-import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+import { Input, ALL_FORMATS } from "mediabunny";
 
-export const canDecode = async (src: string) => {
-  const input = new Input({
-    formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
-  });
-
+const checkTracks = async (input: Input): Promise<boolean> => {
   try {
     await input.getFormat();
   } catch {
@@ -30,61 +23,32 @@ export const canDecode = async (src: string) => {
   }
 
   const videoTrack = await input.getPrimaryVideoTrack();
-  if (videoTrack && !(await videoTrack.canDecode())) {
-    return false;
-  }
+  if (videoTrack && !(await videoTrack.canDecode())) return false;
 
   const audioTrack = await input.getPrimaryAudioTrack();
-  if (audioTrack && !(await audioTrack.canDecode())) {
-    return false;
-  }
+  if (audioTrack && !(await audioTrack.canDecode())) return false;
 
   return true;
 };
 ```
 
-## Usage
+## URL source
 
 ```tsx
-const src = "https://remotion.media/video.mp4";
-const isDecodable = await canDecode(src);
+import { UrlSource } from "mediabunny";
 
-if (isDecodable) {
-  console.log("Video can be decoded");
-} else {
-  console.log("Video cannot be decoded by this browser");
-}
+export const canDecode = (src: string) =>
+  checkTracks(new Input({ formats: ALL_FORMATS, source: new UrlSource(src, { getRetryDelay: () => null }) }));
+
+// Usage
+const isDecodable = await canDecode("https://remotion.media/video.mp4");
 ```
 
-## Using with Blob
-
-For file uploads or drag-and-drop, use `BlobSource`:
+## Blob source (file uploads / drag-and-drop)
 
 ```tsx
-import { Input, ALL_FORMATS, BlobSource } from "mediabunny";
+import { BlobSource } from "mediabunny";
 
-export const canDecodeBlob = async (blob: Blob) => {
-  const input = new Input({
-    formats: ALL_FORMATS,
-    source: new BlobSource(blob),
-  });
-
-  try {
-    await input.getFormat();
-  } catch {
-    return false;
-  }
-
-  const videoTrack = await input.getPrimaryVideoTrack();
-  if (videoTrack && !(await videoTrack.canDecode())) {
-    return false;
-  }
-
-  const audioTrack = await input.getPrimaryAudioTrack();
-  if (audioTrack && !(await audioTrack.canDecode())) {
-    return false;
-  }
-
-  return true;
-};
+export const canDecodeBlob = (blob: Blob) =>
+  checkTracks(new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) }));
 ```


### PR DESCRIPTION
## Summary

- Extract shared `checkTracks` helper to eliminate duplicated track-check logic between `canDecode` (URL) and `canDecodeBlob` (Blob) variants
- 90→54 lines (40% reduction) — all code blocks, imports, and function signatures preserved
- Inline usage example into URL source section; remove redundant verbose `if/return` blocks

## Issue

Closes #16062

## Files changed

- `.agents/tools/video/remotion-can-decode.md` — tightened from 90 to 54 lines

## Testing

**Risk level:** Low — docs/agent prompt only, no runtime code changed.

All code blocks verified present before and after:
- `canDecode` (URL source) ✓
- `canDecodeBlob` (Blob source) ✓
- `ALL_FORMATS`, `UrlSource`, `BlobSource`, `getRetryDelay: () => null` ✓
- Track-check logic (video + audio) ✓
- Frontmatter unchanged ✓

## Runtime Testing

`self-assessed` — Low risk: agent doc only, no executable code changed.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten `remotion-can-decode.md` by extracting shared track-check helper, eliminating duplicated logic between URL and Blob variants.
**Issue:** #16062
**Files changed:** 1 (`.agents/tools/video/remotion-can-decode.md`)
**Testing:** Self-assessed (docs-only change)
**Key decisions:** Extracted `checkTracks` helper rather than just compressing prose — the duplication was structural, not stylistic.

---
[aidevops.sh](https://aidevops.sh) v3.5.765 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6