### PR TITLE
GH#16063: tighten performance.md 79→66 lines

### DIFF
--- a/.agents/scripts/commands/performance.md
+++ b/.agents/scripts/commands/performance.md
@@ -8,15 +8,7 @@ Analyze web performance for the specified URL using Chrome DevTools MCP.
 
 URL/Target: $ARGUMENTS
 
-## Prerequisites
-
-Verify Chrome DevTools MCP is available:
-
-```bash
-which npx && npx chrome-devtools-mcp@latest --version || echo "Install: npm i -g chrome-devtools-mcp"
-```
-
-Read `~/.aidevops/agents/tools/performance/performance.md` for CWV thresholds, common issues, and fix patterns.
+**Prerequisites:** Verify Chrome DevTools MCP: `which npx && npx chrome-devtools-mcp@latest --version || echo "Install: npm i -g chrome-devtools-mcp"`. Read `~/.aidevops/agents/tools/performance/performance.md` for CWV thresholds, common issues, and fix patterns.
 
 ## Options
 
@@ -30,12 +22,7 @@ Read `~/.aidevops/agents/tools/performance/performance.md` for CWV thresholds, c
 
 ## Run Analysis
 
-Using Chrome DevTools MCP, execute in order:
-
-1. **Lighthouse Audit** — performance, accessibility, best practices, SEO scores
-2. **Core Web Vitals** — FCP, LCP, CLS, FID, TTFB measurements
-3. **Network Analysis** — third-party scripts, request chains, bundle sizes
-4. **Accessibility** — WCAG compliance issues
+Execute in order: (1) **Lighthouse Audit** — performance, accessibility, best practices, SEO; (2) **Core Web Vitals** — FCP, LCP, CLS, FID, TTFB; (3) **Network Analysis** — third-party scripts, request chains, bundle sizes; (4) **Accessibility** — WCAG compliance issues.
 
 ## Report Format
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/performance.md` from 79 to 66 lines (16% reduction)
- Merge Prerequisites section from H2 heading + code block into a single bold inline line
- Condense Run Analysis numbered list into a single inline sentence
- All content preserved: options table, CWV report template, examples, related links

## What

Prose tightening of the `/performance` slash command doc. No content removed — prerequisites, analysis steps, report format, examples, and related links all intact.

## Issue

Closes #16063

## Files Changed

- `.agents/scripts/commands/performance.md` — 79→66 lines

## Testing

- `wc -l` confirms 66 lines post-edit
- Diff reviewed: only prose consolidation, no knowledge loss
- All code blocks, URLs, and command examples present before and after

## Runtime Testing

Risk: **Low** — docs/agent prompt only. Self-assessed.

<!-- MERGE_SUMMARY -->
**What:** Tighten performance.md slash command doc (79→66 lines)
**Issue:** Closes #16063
**Files changed:** 1 (`.agents/scripts/commands/performance.md`)
**Testing:** wc -l verified, diff reviewed
**Key decisions:** Merged Prerequisites H2+code-block into inline bold; condensed Run Analysis list into single sentence

---
[aidevops.sh](https://aidevops.sh) v3.5.765 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6