### PR TITLE
GH#16064: tighten llm-tldr.md - remove redundant token savings table

### DIFF
--- a/.agents/tools/context/llm-tldr.md
+++ b/.agents/tools/context/llm-tldr.md
@@ -53,14 +53,6 @@ CLI: `tldr <cmd>` — MCP (via `tldr-mcp`): same commands prefixed `tldr_`.
 | `dead` | `tldr dead /path/to/project` | Unused functions and classes |
 | `slice` | `tldr slice /path/to/file.py var_name` | Code slice affecting a variable |
 
-## Token Savings
-
-| Content Type | Raw Tokens | TLDR Tokens | Savings |
-|--------------|------------|-------------|---------|
-| 1000-line file | ~15,000 | ~750 | 95% |
-| Class definition | ~500 | ~50 | 90% |
-| Function body | ~200 | ~20 | 90% |
-
 ## When to Use
 
 - **Before editing**: `tldr context` + `tldr impact` to understand scope


### PR DESCRIPTION
## Summary

- Removes the redundant `## Token Savings` table (8 lines) from `.agents/tools/context/llm-tldr.md`
- The table duplicated information already stated in the file headline (`95% token savings`) and description line (`saving ~95% tokens vs raw code`)
- All commands, usage examples, troubleshooting notes, and institutional knowledge preserved
- 76 → 68 lines

## What

Tighten `.agents/tools/context/llm-tldr.md` per automated simplification scan (GH#16064).

## Files Changed

- `.agents/tools/context/llm-tldr.md` — removed 8-line token savings table

## Testing

**Risk level:** Low (docs/agent prompt only — no code, no runtime behaviour change)

**Verification:**
- Content preservation: all code blocks, URLs, command examples, troubleshooting notes present ✓
- No broken internal links or references ✓
- Agent behaviour unchanged — token savings info still conveyed via headline ✓

## Runtime Testing

`self-assessed` — docs-only change, no runtime behaviour affected.

Closes #16064

---
[aidevops.sh](https://aidevops.sh) v3.5.765 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6