### PR TITLE
GH#16065: tighten ocr/overview.md 75→66 lines

### DIFF
--- a/.agents/tools/ocr/overview.md
+++ b/.agents/tools/ocr/overview.md
@@ -18,17 +18,15 @@ tools:
 
 ## Quick Reference
 
-**Tool selection:**
-
-| Input | Tool | Output | Use when |
-|-------|------|--------|----------|
-| Screenshot / photo / sign | PaddleOCR | Raw text + bounding boxes | Scene-text accuracy, UI capture, varied lighting / angles |
-| Complex PDF (tables, columns, formulas) | MinerU | Markdown / JSON | LLM-ready document conversion |
-| Invoice / receipt / form | Docling + ExtractThinker | Structured JSON | Schema validation or PII redaction |
-| Any image (quick, local) | GLM-OCR (Ollama) | Plain text | Private local fallback, minimal setup |
-| PDF text + positions | LibPDF | Text with coordinates | Form filling, signing, or PDF manipulation |
-| Simple text PDF | Pandoc | Markdown | Fastest text-only conversion |
-| Document understanding (VLM) | PaddleOCR-VL | Structured understanding | Local document understanding, not plain OCR |
+| Input | Tool | Fit | Limits | Avoid when |
+|-------|------|-----|--------|------------|
+| Screenshot / photo / sign | **PaddleOCR** (Baidu, 71k, Apache-2.0) | Best scene-text accuracy; bounding boxes; PP-StructureV3 tables; PaddleOCR-VL (0.9B); MCP server (v3.1.0+); 100+ languages | ~500MB PaddlePaddle dependency; not for doc-to-markdown | PDF-to-markdown → MinerU; structured invoices → Docling; PDF forms → LibPDF |
+| Complex PDF (tables, columns, formulas) | **MinerU** (OpenDataLab, 53k, AGPL-3.0) | Layout-aware multi-column, tables, formulas; LaTeX; strips headers/footers; 109 languages; JSON with reading order; pipeline/hybrid/VLM backends | PDF-only; AGPL copyleft; heavier hybrid/VLM backends | Screenshot OCR → PaddleOCR; schema extraction → Docling; simple text PDFs → Pandoc |
+| Invoice / receipt / form | **Docling + ExtractThinker** (IBM, 52.7k, MIT) | Schema-mapped Pydantic output; PDF/DOCX/PPTX/XLSX/HTML/images; PII redaction (Presidio); local/edge/cloud privacy modes; UK VAT + QuickFile; MCP server | Requires an LLM; three-component setup; slower than pure OCR | Simple screenshot text → PaddleOCR/GLM-OCR; PDF-to-markdown → MinerU; PDF manipulation → LibPDF |
+| Any image (quick, local) | **GLM-OCR** (THUDM/Ollama, MIT) | Zero-config via `ollama pull glm-ocr`; fully local; Peekaboo screen capture integration | No bounding boxes; no structured JSON; weaker on scene text; ~2GB model | Bounding boxes or max scene accuracy → PaddleOCR; structured extraction → Docling |
+| PDF text + positions | **LibPDF** (Commercial) | Text with coordinate positions; form filling; digital signatures (PAdES); handles malformed PDFs; ~5MB, no Python/GPU | PDF-only; cannot OCR scanned/image PDFs; no layout-aware markdown | Scanned PDFs → MinerU; image OCR → PaddleOCR; structured extraction → Docling |
+| Simple text PDF | **Pandoc** | Fastest text-only conversion | No layout awareness; no OCR | Complex layouts → MinerU |
+| Document understanding (VLM) | **PaddleOCR-VL** | Local document understanding, structured understanding | Not plain OCR | Plain text extraction → PaddleOCR |
 
 **Subagents:**
 
@@ -42,16 +40,6 @@ tools:
 | `tools/pdf/overview.md` | LibPDF — PDF manipulation and text extraction |
 
 <!-- AI-CONTEXT-END -->
-
-## Tool Profiles
-
-| Tool | Fit | Limits | Avoid when |
-|------|-----|--------|------------|
-| **PaddleOCR** (Baidu, 71k, Apache-2.0) | Best scene-text accuracy; bounding boxes; PP-StructureV3 tables; PaddleOCR-VL (0.9B); native MCP server (v3.1.0+); 100+ languages | ~500MB PaddlePaddle dependency; not for doc-to-markdown | PDF-to-markdown → MinerU; structured invoices → Docling; PDF forms → LibPDF |
-| **MinerU** (OpenDataLab, 53k, AGPL-3.0) | Layout-aware multi-column, tables, formulas; LaTeX conversion; strips headers/footers; 109 languages; JSON with reading order; pipeline / hybrid / VLM backends | PDF-only; AGPL copyleft; heavier hybrid/VLM backends | Screenshot OCR → PaddleOCR; schema extraction → Docling; simple text PDFs → Pandoc |
-| **Docling + ExtractThinker** (IBM, 52.7k, MIT) | Schema-mapped Pydantic output; PDF/DOCX/PPTX/XLSX/HTML/images; PII redaction (Presidio); local/edge/cloud privacy modes; UK VAT schemas + QuickFile; MCP server | Requires an LLM; three-component setup; slower than pure OCR | Simple screenshot text → PaddleOCR/GLM-OCR; PDF-to-markdown → MinerU; PDF manipulation → LibPDF |
-| **GLM-OCR** (THUDM/Ollama, MIT) | Zero-config via `ollama pull glm-ocr`; fully local; Peekaboo screen capture integration | No bounding boxes; no structured JSON; weaker on scene text; ~2GB model | Bounding boxes or max scene accuracy → PaddleOCR; structured extraction → Docling |
-| **LibPDF** (Commercial) | Text with coordinate positions; form filling; digital signatures (PAdES); handles malformed PDFs; ~5MB, no Python/GPU | PDF-only; cannot OCR scanned/image PDFs; no layout-aware markdown | Scanned PDFs → MinerU; image OCR → PaddleOCR; structured extraction → Docling |
 
 ## Common Workflows
 
@@ -70,6 +58,9 @@ document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --pr
 # Batch image OCR
 for img in ./images/*.png; do paddleocr-helper.sh ocr "$img"; done             # PaddleOCR (100+ languages, bounding boxes)
 for img in ./images/*.png; do ollama run glm-ocr "Extract all text" --images "$img"; done  # GLM-OCR (simpler)
-```
 
-**Pipelines:** image → PaddleOCR → raw text or ExtractThinker → structured JSON; PDF → MinerU → markdown → LLM; PDF → Docling → ExtractThinker → structured JSON → QuickFile. PaddleOCR and Docling MCP servers plug into Claude Desktop / the agent framework.
+# Pipelines: image → PaddleOCR → raw text or ExtractThinker → structured JSON
+#            PDF → MinerU → markdown → LLM
+#            PDF → Docling → ExtractThinker → structured JSON → QuickFile
+# PaddleOCR and Docling MCP servers plug into Claude Desktop / the agent framework.
+```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ocr/overview.md` from 75 to 66 lines (12% reduction).

- Merged the redundant "Tool Profiles" table into the Quick Reference table, adding Fit/Limits/Avoid columns inline with the input-based selection rows
- Moved the standalone "Pipelines" paragraph into the Common Workflows code block as comments
- All knowledge preserved: tool names, GitHub stars, licenses, fit/limits/avoid criteria, subagent pointers, workflow commands, pipeline descriptions

## Issue
Closes #16065

## Files changed
- `.agents/tools/ocr/overview.md`: 75 → 66 lines

## Testing
- Self-assessed (Low risk: docs-only change, no code or agent logic)
- Content preservation verified: all tool names, task IDs, command examples, URLs present before and after
- No broken internal references (subagent pointers unchanged)

## Runtime Testing
Risk: **Low** — documentation restructuring only, no agent logic or code changed.
Verification: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.766 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6