### PR TITLE
GH#15820: tighten huggingface.md agent doc

### DIFF
--- a/.agents/tools/local-models/huggingface.md
+++ b/.agents/tools/local-models/huggingface.md
@@ -15,8 +15,6 @@ tools:
 
 # HuggingFace Model Discovery
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 - **Purpose**: Find, evaluate, and download GGUF models from HuggingFace for local inference via llama.cpp
@@ -25,8 +23,6 @@ tools:
 - **Helper**: `local-model-helper.sh search|download|models|recommend|setup`
 - **Trusted publishers**: bartowski (first choice), lmstudio-community, ggml-org, unsloth; official authors (Qwen, meta-llama, deepseek-ai, mistralai, google) preferred when available. **Avoid**: few downloads, no README, unclear quant labels.
 - **See also**: `tools/local-models/local-models.md` (runtime), `tools/context/model-routing.md` (routing), `tools/infrastructure/cloud-gpu.md` (cloud GPU)
-
-<!-- AI-CONTEXT-END -->
 
 ## Quantization
 
@@ -45,17 +41,15 @@ RAM tight → Q4_K_M or IQ4_XS. RAM available → Q5_K_M or Q6_K.
 
 ## Hardware-Tier Recommendations
 
-Reserve ≥4 GB for OS.
+Reserve ≥4 GB for OS. Higher-quant options in parentheses.
 
-| RAM | Example Hardware | Budget | Recommended |
-|-----|-----------------|--------|-------------|
+| RAM | Example Hardware | Budget | Recommended (higher-quant) |
+|-----|-----------------|--------|---------------------------|
 | 8 GB | MacBook Air M2, GTX 1070 | ≤4 GB | Qwen3-4B Q4_K_M (~2.5 GB), Phi-4-mini Q4_K_M (~2.3 GB) |
 | 16 GB | MacBook Pro M3, RTX 3060 12GB | ≤10 GB | Qwen3-8B Q4_K_M (~5 GB), Llama-3.1-8B Q4_K_M (~4.7 GB) |
-| 32 GB | MacBook Pro M3 Pro, RTX 4090 | ≤20 GB | Qwen3-14B Q4_K_M (~8.5 GB), DeepSeek-R1-Distill-Qwen-14B Q4_K_M (~8.5 GB) |
-| 64 GB | MacBook Pro M3 Max, dual RTX 4090 | ≤45 GB | Qwen3-32B Q4_K_M (~19 GB), Qwen3-32B Q5_K_M (~24 GB) |
-| 128 GB+ | Mac Studio M2 Ultra, multi-GPU | 70B+ | Qwen3-72B Q4_K_M (~42 GB), Llama-3.1-70B Q4_K_M (~40 GB) |
-
-Higher-quant options: 32 GB → 8B Q6_K (~6.2–6.6 GB); 64 GB → 14B Q8_0 (~15 GB); 128 GB+ → 32B Q8_0 (~34 GB).
+| 32 GB | MacBook Pro M3 Pro, RTX 4090 | ≤20 GB | Qwen3-14B Q4_K_M (~8.5 GB), DeepSeek-R1-Distill-Qwen-14B Q4_K_M (~8.5 GB) (8B Q6_K ~6.5 GB) |
+| 64 GB | MacBook Pro M3 Max, dual RTX 4090 | ≤45 GB | Qwen3-32B Q4_K_M (~19 GB), Qwen3-32B Q5_K_M (~24 GB) (14B Q8_0 ~15 GB) |
+| 128 GB+ | Mac Studio M2 Ultra, multi-GPU | 70B+ | Qwen3-72B Q4_K_M (~42 GB), Llama-3.1-70B Q4_K_M (~40 GB) (32B Q8_0 ~34 GB) |
 
 ## Model Families
 
@@ -69,6 +63,8 @@ Higher-quant options: 32 GB → 8B Q6_K (~6.2–6.6 GB); 64 GB → 14B Q8_0 (~15
 | **Phi 4** (Microsoft) | 3.8B–14B | Capable for size, good reasoning in constrained environments. | `microsoft/phi-4-gguf`, `bartowski/phi-4-GGUF` |
 
 ## Download
+
+Install CLI: `pip install huggingface_hub[cli]` (or pipx). Token: `~/.cache/huggingface/token`. Web: `https://huggingface.co/models?library=gguf&sort=trending`.
 
 ```bash
 # Helper (recommended)
@@ -84,8 +80,6 @@ huggingface-cli login
 huggingface-cli download meta-llama/Llama-3.1-8B-Instruct-GGUF \
   llama-3.1-8b-instruct-q4_k_m.gguf --local-dir ~/.aidevops/local-models/models/
 ```
-
-Install CLI: `pip install huggingface_hub[cli]` (or pipx). Token stored at `~/.cache/huggingface/token`. Web: `https://huggingface.co/models?library=gguf&sort=trending`.
 
 ## Troubleshooting
 

--- a/.agents/tools/local-models/huggingface.md
+++ b/.agents/tools/local-models/huggingface.md
@@ -64,7 +64,7 @@ Reserve ≥4 GB for OS. Higher-quant options in parentheses.
 
 ## Download
 
-Install CLI: `pip install huggingface_hub[cli]` (or pipx). Token: `~/.cache/huggingface/token`. Web: `https://huggingface.co/models?library=gguf&sort=trending`.
+Install CLI: `pip install "huggingface_hub[cli]"` (or pipx). Token: `~/.cache/huggingface/token`. Web: `https://huggingface.co/models?library=gguf&sort=trending`.
 
 ```bash
 # Helper (recommended)


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/local-models/huggingface.md` per GH#15820 (agent doc simplification scan).

**Classification:** Instruction doc (agent rules, decision tables, operational procedures) — not a reference corpus. Content compression applies.

**Changes (99 → 93 lines):**
- Remove `<!-- AI-CONTEXT-START/END -->` wrappers — no functional value for a subagent doc
- Merge "Higher-quant options" prose line into hardware table rows — all data preserved, better scannability
- Move install CLI line before code block — improves reading flow; minor prose tightening ("Token stored at" → "Token:")

**Verification:**
- All code blocks, URLs, command examples, and model recommendations preserved (verified via diff)
- No task IDs or incident references in this file — nothing to lose
- Agent behaviour unchanged: same decision tables, same commands, same publisher trust rules

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. `self-assessed`.

Closes #15820

---
[aidevops.sh](https://aidevops.sh) v3.5.767 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved hardware-tier recommendation table presentation with higher-quant options clearly integrated within recommended configurations
  * Reorganized Download section for enhanced clarity and navigability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->