### PR TITLE
GH#15924: tighten queues-gotchas.md — merge best practices into sections

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
@@ -4,7 +4,7 @@ See [queues.md](./queues.md), [queues-patterns.md](./queues-patterns.md).
 
 ## Delivery Semantics
 
-Queues are at-least-once. Consumers must tolerate duplicates and should ack only after durable success.
+Queues are at-least-once. Design for idempotency — ack only after durable success.
 
 ```typescript
 const processed = await env.PROCESSED_KV.get(msg.id);
@@ -14,17 +14,19 @@ await env.PROCESSED_KV.put(msg.id, '1', { expirationTtl: 86400 });
 msg.ack();
 ```
 
-## Content Type Visibility
+❌ Don't rely on message ordering.
 
-`json` is dashboard-visible and works with pull consumers. `v8` is not decodable in pull consumers or the dashboard — use `json` for pull.
+## Content Type
+
+`json` is dashboard-visible and works with pull consumers. `v8` is not decodable in pull consumers or the dashboard.
 
 ```typescript
-await env.MY_QUEUE.send(data, { contentType: 'json' });
+await env.MY_QUEUE.send(data, { contentType: 'json' }); // always use json for pull
 ```
 
 ## Retries and CPU Budget
 
-If a handler exits without `ack()` or `retry()`, Cloudflare retries with the queue's configured policy. Default consumer CPU budget is 30s; raise it for heavier work.
+Handler exits without `ack()` or `retry()` → Cloudflare retries per queue policy. Default CPU budget is 30s; raise for heavier work.
 
 ```typescript
 async queue(batch: MessageBatch): Promise<void> {
@@ -33,7 +35,7 @@ async queue(batch: MessageBatch): Promise<void> {
       await processMessage(msg.body);
       msg.ack();
     } catch (error) {
-      msg.retry({ delaySeconds: 600 }); // or omit to auto-retry
+      msg.retry({ delaySeconds: 600 }); // omit to auto-retry
     }
   }
 }
@@ -43,14 +45,18 @@ async queue(batch: MessageBatch): Promise<void> {
 { "limits": { "cpu_ms": 300000 } } // 5 minutes
 ```
 
+Log failures with enough context to replay or diagnose. Configure a DLQ for permanent failures.
+
 ## Cost and Throughput
 
-Each message normally incurs write + read + delete = 3 ops. Retries add reads. Monthly queue cost beyond the free tier is `((messages × 3) - 1M) / 1M × $0.40`.
+Each message = 3 ops (write + read + delete). Retries add reads. Cost beyond free tier: `((messages × 3) - 1M) / 1M × $0.40`.
 
 ```typescript
 // Keep messages <64 KB (charged per 64 KB chunk)
 { "max_batch_size": 100, "max_batch_timeout": 30 }
 ```
+
+Use `waitUntil()` for non-blocking sends. Batch sends when possible.
 
 | Limit | Value |
 |-------|-------|
@@ -81,14 +87,3 @@ wrangler tail my-worker                                       # Check logs
 - Check external dependency availability.
 - Verify message format matches expectations.
 - Increase retry delay: `"retry_delay": 300`.
-
-## Best Practices
-
-- ✅ Design for idempotency.
-- ✅ Use `json` for visibility and pull compatibility.
-- ✅ Log failures with enough context to replay or diagnose.
-- ✅ Configure a DLQ for permanent failures.
-- ✅ Use `waitUntil()` for non-blocking sends.
-- ✅ Batch sends when possible.
-- ❌ Don't use `v8` with pull consumers.
-- ❌ Don't rely on message ordering.


### PR DESCRIPTION
## Summary

- Tightened `.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md` from 94 → 89 lines
- Merged standalone "Best Practices" section into relevant sections (delivery semantics, content type, cost/throughput) — eliminates redundancy without losing knowledge
- All institutional knowledge preserved: idempotency pattern, content type guidance, retry/CPU budget, cost formula, limits table, troubleshooting commands

## Classification

**Instruction doc** (operational gotchas/guidance) — not a reference corpus. Tighten prose approach applied per issue guidance.

## Changes

- `delivery semantics`: added `❌ Don't rely on message ordering` inline (was in Best Practices)
- `content type`: added inline comment `// always use json for pull` (was separate best practice)
- `cost/throughput`: added `waitUntil()` and batch sends guidance inline (was in Best Practices)
- Removed redundant standalone Best Practices section (all content migrated)

## Runtime Testing

**Risk level: Low** — docs/agent prompts only, no code changes. `self-assessed`.

## Verification

- Content preservation: all code blocks, URLs, task ID references, and command examples present before and after ✅
- No broken internal links ✅
- `wc -l`: 89 lines (94 → 89, -5 lines) ✅

Closes #15924

---
[aidevops.sh](https://aidevops.sh) v3.5.767 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6