### PR TITLE
GH#15678: tighten api-shield-patterns.md monitoring section

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md
@@ -68,11 +68,9 @@ PUT /zones/{zone_id}/api_gateway/settings/schema_validation
 
 ## Monitoring
 
-Security Events: Security > Events — filter Action=block, Service=API Shield
-
-Firewall Analytics: Analytics > Security — filter by `cf.api_gateway.*` fields
-
-Logpush fields: `APIGatewayAuthIDPresent`, `APIGatewayRequestViolatesSchema`, `APIGatewayFallthroughDetected`, `JWTValidationResult`, `ClientCertFingerprint`
+- **Security Events**: Security > Events — filter Action=block, Service=API Shield
+- **Firewall Analytics**: Analytics > Security — filter by `cf.api_gateway.*` fields
+- **Logpush fields**: `APIGatewayAuthIDPresent`, `APIGatewayRequestViolatesSchema`, `APIGatewayFallthroughDetected`, `JWTValidationResult`, `ClientCertFingerprint`
 
 ## Availability
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten the Monitoring section of `api-shield-patterns.md` (GH#15678). Consolidates 3 separate paragraphs into a compact bullet list with bold labels for scannability.

## Issue
Closes #15678

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md` — 89 → 87 lines

## Classification
Reference corpus (domain knowledge, self-contained sections). File is already well under the ~300-line subdivision threshold. Applied prose tightening only — no content removed.

## Testing
- All code blocks preserved verbatim
- All tables preserved verbatim
- All Logpush field names preserved
- All URLs and references intact
- `wc -l` before: 89, after: 87 (2 blank lines removed, replaced with bullet structure)

## Runtime Testing
**Risk: Low** — agent doc / reference corpus. No executable code changed. `self-assessed`.

## Key Decisions
- Classified as reference corpus → no content compression, prose tightening only
- Monitoring section: 3 loose paragraphs → 3 bullet items with bold labels (consistent with gotchas.md style)
- No other sections changed (already tight)

---
[aidevops.sh](https://aidevops.sh) v3.5.767 plugin for [OpenCode](https://opencode.ai) v1.3.13