### PR TITLE
GH#16088: tighten skill-scanner.md - fix duplicate configs path in audit log reference

### DIFF
--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -57,7 +57,7 @@ Keys: `~/.config/aidevops/credentials.sh` (600 perms) or `aidevops secret set <K
 - **Import gate**: `add-skill-helper.sh` — `CRITICAL`/`HIGH` blocks unless `--skip-security` (or explicit interactive override)
 - **Batch scans**: `aidevops skill scan`, `security-helper.sh skill-scan all`
 - **Update path**: `setup.sh` scans all skills during `aidevops update` (non-blocking); `skill-update-helper.sh update` re-imports with `--force`
-- **Audit log**: `.agents/configs/configs/SKILL-SCAN-RESULTS.md`
+- **Audit log**: `.agents/configs/SKILL-SCAN-RESULTS.md`
 
 ## CLI
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/code-review/skill-scanner.md` per GH#16088 simplification scan.

**Key fix**: Corrected duplicate path in audit log reference:
- Before: `.agents/configs/configs/SKILL-SCAN-RESULTS.md`
- After: `.agents/configs/SKILL-SCAN-RESULTS.md`

The file is already well-structured (91 lines, dense tables, operational rules). The only genuine improvement was fixing the broken path reference — the double `configs/configs/` was a bug that would cause agents to look in the wrong location for scan results.

## Issue
Closes #16088

## Files Changed
- `.agents/tools/code-review/skill-scanner.md` — fixed audit log path (1 line)

## Testing
- **Risk level**: Low (docs-only, path reference fix)
- **Verification**: `ls .agents/configs/SKILL-SCAN-RESULTS.md` confirms the correct path exists
- Content preservation: all code blocks, URLs, task ID refs, command examples unchanged
- No broken internal links

## Runtime Testing
`self-assessed` — docs-only change, no runtime behavior affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.769 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected formatting in skill scanner documentation to properly display audit log information under the aidevops Integration section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->