### PR TITLE
GH#16087: tighten ses.md — move security note to Quick Reference

### DIFF
--- a/.agents/services/email/ses.md
+++ b/.agents/services/email/ses.md
@@ -24,6 +24,7 @@ tools:
 - **Test addresses**: success@simulator.amazonses.com, bounce@simulator.amazonses.com
 - **DKIM**: Enable for all domains | **Prerequisite**: `awscli` installed
 - **IAM permissions**: ses:GetSendQuota, ses:SendEmail, sesv2:ListSuppressedDestinations
+- **Security**: Rotate IAM keys regularly; separate AWS accounts for prod/staging
 
 <!-- AI-CONTEXT-END -->
 
@@ -59,7 +60,7 @@ tools:
 ses-helper.sh accounts
 ses-helper.sh quota production
 ses-helper.sh stats production
-ses-helper.sh monitor production   # bounce, complaint, quota, reputation
+ses-helper.sh monitor production  # bounce, complaint, quota, reputation
 ses-helper.sh verified-emails production
 ses-helper.sh verified-domains production
 ses-helper.sh verify-email production newuser@yourdomain.com
@@ -82,8 +83,6 @@ ses-helper.sh audit production
 ```
 
 ## IAM Policy
-
-Rotate keys regularly. Separate AWS accounts for prod/staging.
 
 ```json
 {


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/email/ses.md` (131→130 lines) per GH#16087.

- Moved security note ("Rotate IAM keys regularly; separate AWS accounts for prod/staging") from standalone prose in `## IAM Policy` into the Quick Reference block where it belongs as a quick-reference item
- Removed the now-redundant standalone prose line from the IAM Policy section (section now goes directly to the JSON block)
- Fixed minor comment alignment in Commands block

## Classification
Instruction doc (not reference corpus) — prose tightening applied, no content removed.

## Verification
- All code blocks, command examples, URLs, and IAM permissions preserved
- `bunx markdownlint-cli2` → 0 errors
- Agent behaviour unchanged: all commands, thresholds, test addresses, DKIM note, IAM policy JSON intact

## Runtime Testing
**Risk**: Low (docs-only change)
**Assessment**: self-assessed — no runtime environment needed for doc tightening

Closes #16087

---
[aidevops.sh](https://aidevops.sh) v3.5.769 plugin for [OpenCode](https://opencode.ai) v1.3.13