### PR TITLE
GH#16091: tighten list-keys.md agent doc (74→66 lines)

### DIFF
--- a/.agents/tools/credentials/list-keys.md
+++ b/.agents/tools/credentials/list-keys.md
@@ -20,8 +20,7 @@ tools:
 
 - **Command**: `/list-keys` or `@list-keys` or `api-keys list`
 - **Script**: `~/.aidevops/agents/scripts/list-keys-helper.sh`
-- **Purpose**: Show available API key names plus source paths — never values
-- **Security**: Names and locations only — never values
+- **Security**: Names and locations only — never values. To confirm a specific key exists: `echo "${KEY_NAME:0:10}..."`. Credential files must have 600 permissions.
 
 **Key sources** (checked in order):
 1. `~/.config/aidevops/credentials.sh` — primary credential store (600 perms)
@@ -60,15 +59,7 @@ Total: 7 keys from 4 sources
 
 | Status | Meaning |
 |--------|---------|
-| `[loaded]` | Valid value is loaded in the session |
-| `[placeholder]` | Placeholder value such as `YOUR_KEY_HERE`, `changeme`, or `xxx` |
-| `[not loaded]` | Defined but not loaded in the current session |
+| `[loaded]` | Valid value loaded in session |
+| `[placeholder]` | Placeholder detected: `YOUR_*_HERE`, `REPLACE_*`, `CHANGEME`, `FIXME`, `TODO`, `example`, `sample`, `test-key`, `dummy`, `fake`, `xxx`/`yyy`/`zzz`, `placeholder`, `none`, `null`, template markers (`<...>`, `{...}`, `[...]`), repeated chars (`xxxx`, `0000`) |
+| `[not loaded]` | Defined but not loaded in current session |
 | `[configured]` | Present in a config file |
-
-Placeholder detection covers: `YOUR_*_HERE`, `REPLACE_*`, `CHANGEME`, `FIXME`, `TODO`, `example`, `sample`, `test-key`, `dummy`, `fake`, `xxx`/`yyy`/`zzz`, `placeholder`, `none`, `null`, template markers (`<...>`, `{...}`, `[...]`), repeated characters (`xxxx`, `0000`).
-
-## Security Notes
-
-- Never displays actual key values — only names and storage locations
-- Use `echo "${KEY_NAME:0:10}..."` only to confirm a specific key exists
-- Credential files must have 600 permissions


### PR DESCRIPTION
## Summary

- Merge duplicate Purpose/Security bullets into single Security line with 600-perms rule
- Fold verbose placeholder detection list inline with `[placeholder]` table row (no content loss)
- Fold Security Notes section into Quick Reference (primacy effect — security rules load first)
- Preserve all institutional knowledge: commands, key sources, placeholder patterns, 600-perms rule, key-confirm tip

## What

Tighten `.agents/tools/credentials/list-keys.md` from 74 → 66 lines per simplification scan.

## Issue

Closes #16091

## Files Changed

- `.agents/tools/credentials/list-keys.md` — 74 → 66 lines (-11%)

## Testing

- `self-assessed` (Low risk: docs-only change, no code paths affected)
- Content preservation verified: all code blocks, commands, placeholder patterns, and security rules present before and after
- Agent behaviour unchanged: same key sources, same status indicators, same security constraints

## Runtime Testing

Risk: **Low** — documentation-only change. No scripts, no logic, no API calls modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.770 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6