### PR TITLE
GH#16099: tighten realtimekit.md agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/realtimekit.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtimekit.md
@@ -19,17 +19,14 @@ SDK suite built on Realtime SFU — abstracts WebRTC complexity with pre-built U
 ### 1. Create App & Meeting (Backend)
 
 ```bash
-# Create app
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/apps' \
   -H 'Authorization: Bearer <api_token>' \
   -d '{"name": "My RealtimeKit App"}'
 
-# Create meeting
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/<app_id>/meetings' \
   -H 'Authorization: Bearer <api_token>' \
   -d '{"title": "Team Standup"}'
 
-# Add participant
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/<app_id>/meetings/<meeting_id>/participants' \
   -H 'Authorization: Bearer <api_token>' \
   -d '{"name": "Alice", "preset_name": "host"}'
@@ -42,7 +39,6 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtim
 
 ```tsx
 import { RtkMeeting } from '@cloudflare/realtimekit-react-ui';
-
 function App() {
   return <RtkMeeting authToken="<participant_auth_token>" onLeave={() => {}} />;
 }
@@ -52,23 +48,19 @@ function App() {
 
 ```typescript
 import RealtimeKitClient from '@cloudflare/realtimekit';
-
 const meeting = new RealtimeKitClient({ authToken: '<token>', video: true, audio: true });
 await meeting.join();
 ```
 
-## See Also
+## References
 
-- [Patterns](./realtimekit-patterns.md) - Common workflows, code examples
-- [Gotchas](./realtimekit-gotchas.md) - Common issues, troubleshooting, limits
-- [Workers](../workers/) - Backend integration
-- [D1](../d1/) - Meeting metadata storage
-- [R2](../r2/) - Recording storage
-- [KV](../kv/) - Session management
-
-## Reference Links
-
-- **Official Docs**: https://developers.cloudflare.com/realtime/realtimekit/
-- **API Reference**: https://developers.cloudflare.com/api/resources/realtime_kit/
-- **Examples**: https://github.com/cloudflare/realtimekit-web-examples
-- **Dashboard**: https://dash.cloudflare.com/?to=/:account/realtime/kit
+- [Patterns](./realtimekit-patterns.md) — Common workflows, code examples
+- [Gotchas](./realtimekit-gotchas.md) — Common issues, troubleshooting, limits
+- [Workers](../workers/) — Backend integration
+- [D1](../d1/) — Meeting metadata storage
+- [R2](../r2/) — Recording storage
+- [KV](../kv/) — Session management
+- [Official Docs](https://developers.cloudflare.com/realtime/realtimekit/)
+- [API Reference](https://developers.cloudflare.com/api/resources/realtime_kit/)
+- [Examples](https://github.com/cloudflare/realtimekit-web-examples)
+- [Dashboard](https://dash.cloudflare.com/?to=/:account/realtime/kit)


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/realtimekit.md` from 74 → 66 lines (11% reduction).

## Changes
- Remove redundant bash comments (`# Create app`, `# Create meeting`, `# Add participant`) — the URL paths make the operation self-evident
- Remove blank lines inside code blocks (cosmetic noise)
- Merge `## See Also` + `## Reference Links` into single `## References` section — two sections for the same purpose adds navigation overhead
- Use `—` (em dash) consistently in list items (matches project style)

## Issue
Closes #16099

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/realtimekit.md` (1 file)

## Runtime Testing
**Risk**: Low — agent doc, no code execution path.
**Verification**: `self-assessed`
- `bunx markdownlint-cli2` → 0 errors
- All URLs, code blocks, `authToken` references, and companion file links verified present after edit
- Content preservation: all API endpoints, SDK imports, and navigation links intact

## Key Decisions
- Kept `# Returns: { authToken }` comment — this is informational, not a restatement of the command
- Did not compress Core Concepts — already tight, each bullet encodes distinct knowledge
- Did not merge with companion files — they serve different purposes (patterns, gotchas)

---
[aidevops.sh](https://aidevops.sh) v3.5.770 plugin for [OpenCode](https://opencode.ai) v1.3.13