### PR TITLE
GH#16115: reduce setup_pim_tools complexity in _tools.sh

### DIFF
--- a/.agents/scripts/setup/_tools.sh
+++ b/.agents/scripts/setup/_tools.sh
@@ -64,6 +64,112 @@ check_tool_updates() {
 	return 0
 }
 
+# macOS PIM: Calendar/Contacts/Notes use osascript; Reminders needs remindctl
+_setup_pim_tools_macos() {
+	print_success "Calendar: uses Calendar.app via osascript (no install needed)"
+	print_success "Contacts: uses Contacts.app via osascript (no install needed)"
+	print_success "Notes: uses Notes.app via osascript (no install needed)"
+
+	if command -v remindctl >/dev/null 2>&1; then
+		print_success "Reminders: remindctl installed"
+		return 0
+	fi
+
+	print_info "Reminders: installing remindctl..."
+	if command -v brew >/dev/null 2>&1; then
+		brew install steipete/tap/remindctl 2>&1 || print_warning "remindctl install failed"
+		if command -v remindctl >/dev/null 2>&1; then
+			print_success "remindctl installed"
+			print_info "Run 'remindctl authorize' to grant Reminders access"
+		fi
+	else
+		print_warning "Homebrew not found. Install remindctl manually: brew install steipete/tap/remindctl"
+	fi
+	return 0
+}
+
+# Linux PIM: detect missing tools and populate missing[] array
+# Sets missing array in caller scope via nameref-compatible output
+_setup_pim_tools_linux_check() {
+	local -n _missing_ref="$1"
+
+	if ! command -v todo >/dev/null 2>&1; then
+		_missing_ref+=("todoman")
+	else
+		print_success "Reminders: todoman installed"
+	fi
+
+	if ! command -v khal >/dev/null 2>&1; then
+		_missing_ref+=("khal")
+	else
+		print_success "Calendar: khal installed"
+	fi
+
+	if ! command -v khard >/dev/null 2>&1; then
+		_missing_ref+=("khard")
+	else
+		print_success "Contacts: khard installed"
+	fi
+
+	if ! command -v vdirsyncer >/dev/null 2>&1; then
+		_missing_ref+=("vdirsyncer")
+	else
+		print_success "CalDAV/CardDAV sync: vdirsyncer installed"
+	fi
+	return 0
+}
+
+# Linux PIM: install nb (notes) and any missing tools via pipx or brew
+_setup_pim_tools_linux_install() {
+	local -n _missing_install_ref="$1"
+
+	# Notes: nb (not in pipx — brew or direct install)
+	if ! command -v nb >/dev/null 2>&1; then
+		print_info "Notes: nb not installed"
+		if command -v brew >/dev/null 2>&1; then
+			print_info "Notes: installing nb..."
+			brew install nb 2>&1 || print_warning "nb install failed"
+			command -v nb >/dev/null 2>&1 && print_success "nb installed"
+		else
+			print_warning "Notes: install nb manually — brew install nb (or see https://xwmx.github.io/nb/)"
+		fi
+	else
+		print_success "Notes: nb installed"
+	fi
+
+	if [[ ${#_missing_install_ref[@]} -eq 0 ]]; then
+		return 0
+	fi
+
+	local pkg_list
+	pkg_list="$(printf '%s ' "${_missing_install_ref[@]}")"
+	print_info "Installing missing PIM tools: ${pkg_list}"
+	if command -v pipx >/dev/null 2>&1; then
+		local pkg
+		for pkg in "${_missing_install_ref[@]}"; do
+			pipx install "$pkg" 2>&1 || print_warning "Failed to install ${pkg}"
+		done
+	elif command -v brew >/dev/null 2>&1; then
+		brew install "${_missing_install_ref[@]}" 2>&1 || print_warning "Some PIM tools failed to install"
+	else
+		print_warning "Install manually with pipx or brew: ${pkg_list}"
+	fi
+	return 0
+}
+
+# Linux PIM: warn about missing config files
+_setup_pim_tools_linux_configs() {
+	[[ ! -f "${HOME}/.config/vdirsyncer/config" ]] &&
+		print_warning "vdirsyncer not configured. Run: reminders-helper.sh help (for CalDAV config example)"
+	[[ ! -f "${HOME}/.config/khal/config" ]] &&
+		print_warning "khal not configured. Run: khal configure"
+	[[ ! -f "${HOME}/.config/khard/khard.conf" ]] &&
+		print_warning "khard not configured. See: contacts-helper.sh help"
+	[[ ! -f "${HOME}/.config/todoman/config.py" ]] &&
+		print_warning "todoman not configured. See: reminders-helper.sh help"
+	return 0
+}
+
 # Setup PIM tools (Reminders, Calendar, Contacts, Notes)
 # macOS: remindctl (Reminders), osascript (Calendar, Contacts, Notes — no install)
 # Linux: todoman, khal, khard + vdirsyncer (CalDAV/CardDAV), nb (notes)
@@ -74,99 +180,12 @@ setup_pim_tools() {
 	print_info "Setting up PIM tools (Reminders, Calendar, Contacts, Notes)..."
 
 	if [[ "$os" == "Darwin" ]]; then
-		# macOS: Calendar, Contacts, Notes use osascript (no install needed)
-		print_success "Calendar: uses Calendar.app via osascript (no install needed)"
-		print_success "Contacts: uses Contacts.app via osascript (no install needed)"
-		print_success "Notes: uses Notes.app via osascript (no install needed)"
-
-		# Reminders needs remindctl
-		if command -v remindctl >/dev/null 2>&1; then
-			print_success "Reminders: remindctl installed"
-		else
-			print_info "Reminders: installing remindctl..."
-			if command -v brew >/dev/null 2>&1; then
-				brew install steipete/tap/remindctl 2>&1 || print_warning "remindctl install failed"
-				if command -v remindctl >/dev/null 2>&1; then
-					print_success "remindctl installed"
-					print_info "Run 'remindctl authorize' to grant Reminders access"
-				fi
-			else
-				print_warning "Homebrew not found. Install remindctl manually: brew install steipete/tap/remindctl"
-			fi
-		fi
+		_setup_pim_tools_macos
 	else
-		# Linux: todoman, khal, khard via pipx/brew; vdirsyncer for sync; nb for notes
 		local missing=()
-
-		if ! command -v todo >/dev/null 2>&1; then
-			missing+=("todoman")
-		else
-			print_success "Reminders: todoman installed"
-		fi
-
-		if ! command -v khal >/dev/null 2>&1; then
-			missing+=("khal")
-		else
-			print_success "Calendar: khal installed"
-		fi
-
-		if ! command -v khard >/dev/null 2>&1; then
-			missing+=("khard")
-		else
-			print_success "Contacts: khard installed"
-		fi
-
-		if ! command -v vdirsyncer >/dev/null 2>&1; then
-			missing+=("vdirsyncer")
-		else
-			print_success "CalDAV/CardDAV sync: vdirsyncer installed"
-		fi
-
-		# Notes: nb (not in pipx — brew or direct install)
-		if ! command -v nb >/dev/null 2>&1; then
-			print_info "Notes: nb not installed"
-			if command -v brew >/dev/null 2>&1; then
-				print_info "Notes: installing nb..."
-				brew install nb 2>&1 || print_warning "nb install failed"
-				if command -v nb >/dev/null 2>&1; then
-					print_success "nb installed"
-				fi
-			else
-				print_warning "Notes: install nb manually — brew install nb (or see https://xwmx.github.io/nb/)"
-			fi
-		else
-			print_success "Notes: nb installed"
-		fi
-
-		if [[ ${#missing[@]} -gt 0 ]]; then
-			local pkg_list
-			pkg_list="$(printf '%s ' "${missing[@]}")"
-			print_info "Installing missing PIM tools: ${pkg_list}"
-			if command -v pipx >/dev/null 2>&1; then
-				local pkg
-				for pkg in "${missing[@]}"; do
-					pipx install "$pkg" 2>&1 || print_warning "Failed to install ${pkg}"
-				done
-			elif command -v brew >/dev/null 2>&1; then
-				brew install "${missing[@]}" 2>&1 || print_warning "Some PIM tools failed to install"
-			else
-				print_warning "Install manually with pipx or brew: ${pkg_list}"
-			fi
-		fi
-
-		# Check configs
-		if [[ ! -f "${HOME}/.config/vdirsyncer/config" ]]; then
-			print_warning "vdirsyncer not configured. Run: reminders-helper.sh help (for CalDAV config example)"
-		fi
-		if [[ ! -f "${HOME}/.config/khal/config" ]]; then
-			print_warning "khal not configured. Run: khal configure"
-		fi
-		if [[ ! -f "${HOME}/.config/khard/khard.conf" ]]; then
-			print_warning "khard not configured. See: contacts-helper.sh help"
-		fi
-		if [[ ! -f "${HOME}/.config/todoman/config.py" ]]; then
-			print_warning "todoman not configured. See: reminders-helper.sh help"
-		fi
+		_setup_pim_tools_linux_check missing
+		_setup_pim_tools_linux_install missing
+		_setup_pim_tools_linux_configs
 	fi
 
 	print_success "PIM tools setup complete. Use *-helper.sh setup for per-tool verification."


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Decompose the 104-line `setup_pim_tools()` function in `.agents/scripts/setup/_tools.sh` into 4 focused helper functions, each under 100 lines.

## Issue
Closes #16115

## Files Changed
- `.agents/scripts/setup/_tools.sh` — refactored `setup_pim_tools()` into helpers

## Decomposition
| Function | Lines | Responsibility |
|---|---|---|
| `_setup_pim_tools_macos()` | 22 | macOS: osascript notice + remindctl install |
| `_setup_pim_tools_linux_check()` | 28 | Detect missing Linux PIM tools (nameref output) |
| `_setup_pim_tools_linux_install()` | 36 | Install nb + missing tools via pipx/brew |
| `_setup_pim_tools_linux_configs()` | 11 | Warn on missing config files |
| `setup_pim_tools()` | 18 | Orchestrator (was 104 lines) |

## Testing
- `bash -n .agents/scripts/setup/_tools.sh` — PASS (syntax clean)
- `shellcheck .agents/scripts/setup/_tools.sh` — PASS (zero violations)
- No functionality removed; all logic preserved in helpers

## Runtime Testing
**Risk level:** Low — shell script refactor only, no logic changes, no runtime execution paths altered.
**Assessment:** self-assessed. Syntax and lint verified. No dev environment execution required for pure structural refactor.

## Key Decisions
- Used bash nameref (`local -n`) for `missing[]` array passing — avoids subshell scope loss, compatible with bash 4.3+. The shebang is `#!/usr/bin/env bash` so bash 4+ is assumed.
- Helper functions prefixed with `_` to signal internal/private use within the module.
- No logic changes — pure structural decomposition.

---
[aidevops.sh](https://aidevops.sh) v3.5.774 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6