### PR TITLE
GH#15922: tighten workers-patterns.md agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md
@@ -62,7 +62,7 @@ const [user, posts] = await Promise.all([fetch('/api/user/1'), fetch('/api/posts
 ## Streaming
 
 ```typescript
-// ReadableStream — yield control every N items to avoid CPU limit
+// ReadableStream — yield control every N items to avoid CPU time limit
 const stream = new ReadableStream({
   async start(controller) {
     for (let i = 0; i < 1000; i++) {


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Precision fix in `workers-patterns.md`: corrected streaming comment from "CPU limit" to "CPU time limit" — Workers enforces a CPU *time* limit (not wall-clock), so the distinction matters for agent accuracy.

## Issue
Closes #15922

## Classification
This file is a **reference corpus** (TypeScript code patterns, not instruction prose). At 141 lines it was already well-optimized. The automated scan flagged it at medium confidence; the correct action per the issue guidance is minimal precision improvement, not forced compression.

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md` — 1 line changed (comment precision fix)

## Testing
- Content preservation: all code blocks, URLs, task ID references intact
- No broken internal links
- Line count unchanged: 141 → 141
- `wc -l` verified

## Runtime Testing
**Risk: Low** — docs/agent prompt change only. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.778 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6