### PR TITLE
GH#15837: tighten agent doc Agent Testing Framework (.agents/tools/build-agent/agent-testing.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -3177,7 +3177,17 @@
       "passes": 1,
       "pr": 13007
     },
-    ".agents/tools/ai-orchestration/overview.md": {
+  ".agents/tools/build-agent/agent-testing.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "e278c97958eb036c31006dd67f82708b6b4caf411c6e9e52ccaae9f67935972d",
+    "issue": "GH#15837",
+    "lines_after": 106,
+    "lines_before": 116,
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
+  },
+  ".agents/tools/ai-orchestration/overview.md": {
       "at": "2026-04-03T01:53:08Z",
       "hash": "4e97ab8ea80342eabab4b326411f74eaeb88bba0",
       "passes": 2,

--- a/.agents/tools/build-agent/agent-testing.md
+++ b/.agents/tools/build-agent/agent-testing.md
@@ -35,7 +35,6 @@ tools:
 ```json
 {
   "name": "build-agent-tests",
-  "description": "Validates build-agent subagent knowledge",
   "agent": "Build+",
   "model": "anthropic/claude-sonnet-4-6",
   "timeout": 120,
@@ -51,7 +50,7 @@ tools:
 }
 ```
 
-Per-test fields (`agent`, `model`, `timeout`) override suite-level defaults.
+Per-test `agent`, `model`, `timeout` override suite-level defaults.
 
 ### Validation Fields
 
@@ -68,25 +67,16 @@ Per-test fields (`agent`, `model`, `timeout`) override suite-level defaults.
 ## Commands
 
 ```bash
-# Run suites
 agent-test-helper.sh run path/to/suite.json
 agent-test-helper.sh run smoke-test
-
-# Quick single-prompt test
 agent-test-helper.sh run-one "What is your primary purpose?"
 agent-test-helper.sh run-one "List your tools" --expect "bash"
 agent-test-helper.sh run-one "Explain git workflow" --agent "Build+" --model "anthropic/claude-sonnet-4-6" --timeout 60
-
-# Before/after comparison
 agent-test-helper.sh baseline smoke-test
 agent-test-helper.sh compare smoke-test
-
-# Manage suites
 agent-test-helper.sh create my-new-tests
 agent-test-helper.sh list
 agent-test-helper.sh results [suite-name]
-
-# CI/CD
 agent-test-helper.sh run agents-md-knowledge || { echo "Agent tests failed"; exit 1; }
 ```
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `agent-testing.md` from 116 → 106 lines (~9% reduction) per simplification-debt issue.

## Issue
Closes #15837

## Files Changed
- `.agents/tools/build-agent/agent-testing.md` — prose compression
- `.agents/configs/simplification-state.json` — record simplification pass

## Changes
- Removed self-evident `"description"` field from JSON suite example
- Tightened "Per-test fields override" sentence (verbose → direct)
- Removed redundant comment headers (`# Run suites`, `# Quick single-prompt test`, etc.) from Commands bash block — commands are self-documenting

## Content Preservation
All commands, validation field table, environment variables table, shipped suites table, and related links preserved verbatim. Zero knowledge loss.

## Testing
- `markdownlint-cli2`: 0 errors
- `diff` verified: only prose/comment removals, no functional content removed
- Risk: **Low** (docs-only change, agent prompt file)
- Runtime testing: `self-assessed` (doc change, no runtime behaviour affected)

## Runtime Testing
**Risk: Low** — documentation-only change to an agent instruction file. No code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.778 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6