### PR TITLE
GH#14370: tighten remotion-get-video-dimensions.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -41,6 +41,14 @@
     "lines_before": 316,
     "status": "simplified"
   },
+  ".agents/tools/video/remotion-get-video-dimensions.md": {
+    "at": "2026-04-03T05:33:46Z",
+    "hash": "c5f36530db3354d5de3048458c3849ec22c1710a",
+    "issue": "GH#14370",
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
+  },
   ".agents/tools/voice/voice-ai-models.md": {
     "action": "converted GPU Planning prose to table; clarified VRAM/RAM column header",
     "hash": "80802e36e4fae1517223fb0553a50f7aa9e01acd908f7d50b6d53f60e3a1dda2",

--- a/.agents/tools/video/remotion-get-video-dimensions.md
+++ b/.agents/tools/video/remotion-get-video-dimensions.md
@@ -8,9 +8,7 @@ metadata:
 
 # Getting video dimensions with Mediabunny
 
-Mediabunny can extract the width and height of a video file. It works in browser, Node.js, and Bun environments.
-
-## Getting video dimensions
+Mediabunny extracts width and height from video files. Works in browser, Node.js, and Bun.
 
 ```tsx
 import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
@@ -33,37 +31,30 @@ export const getVideoDimensions = async (src: string) => {
     height: videoTrack.displayHeight,
   };
 };
-```
 
-## Usage
-
-```tsx
+// Usage
 const dimensions = await getVideoDimensions("https://remotion.media/video.mp4");
 console.log(dimensions.width);  // e.g. 1920
 console.log(dimensions.height); // e.g. 1080
+
+// With staticFile in Remotion
+import { staticFile } from "remotion";
+const dims = await getVideoDimensions(staticFile("video.mp4"));
 ```
 
-## Using with local files
+## Local files
 
-For local files, use `FileSource` instead of `UrlSource`:
+Use `FileSource` instead of `UrlSource` for `File` objects (input or drag-drop):
 
 ```tsx
 import { Input, ALL_FORMATS, FileSource } from "mediabunny";
 
 const input = new Input({
   formats: ALL_FORMATS,
-  source: new FileSource(file), // File object from input or drag-drop
+  source: new FileSource(file),
 });
 
 const videoTrack = await input.getPrimaryVideoTrack();
 const width = videoTrack.displayWidth;
 const height = videoTrack.displayHeight;
-```
-
-## Using with staticFile in Remotion
-
-```tsx
-import { staticFile } from "remotion";
-
-const dimensions = await getVideoDimensions(staticFile("video.mp4"));
 ```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/video/remotion-get-video-dimensions.md` from 69 → 60 lines (13% reduction).

## Issue
Closes #14370

## Changes
- Removed redundant `## Getting video dimensions` section header (duplicated file title)
- Merged `## Usage` and `## Using with staticFile in Remotion` examples into the main code block as inline comments
- Tightened intro prose (removed redundant "can extract the width and height of a video file")
- Renamed `## Using with local files` → `## Local files` (shorter, same meaning)
- Moved `File object from input or drag-drop` comment from inline to section prose

## Files changed
- `.agents/tools/video/remotion-get-video-dimensions.md` — simplified
- `.agents/configs/simplification-state.json` — updated hash/state for this file

## Testing
**Risk level:** Low (docs/agent prompt, no runtime behaviour)
**Verification:** All code blocks present before and after — `UrlSource`, `FileSource`, `staticFile`, `getPrimaryVideoTrack`, `displayWidth`, `displayHeight`, `ALL_FORMATS`, error throw, usage example URL. No broken references.

## Runtime Testing
`self-assessed` — Low risk: agent doc only, no executable code changed.


---
[aidevops.sh](https://aidevops.sh) v3.5.778 plugin for [OpenCode](https://opencode.ai) v1.3.13