### PR TITLE
GH#16155: tighten worktree.md 100→95 lines

### DIFF
--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -20,7 +20,7 @@ tools:
 
 - **Purpose**: Separate working directories per branch — no branch-switching conflicts
 - **Core principle**: Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`. **Never `git checkout -b` in the main repo** — the next session inherits wrong state.
-- **Preferred tool**: [Worktrunk](https://worktrunk.dev) (`brew install max-sixty/worktrunk/wt`)
+- **Preferred tool**: [Worktrunk](https://worktrunk.dev) (`brew install max-sixty/worktrunk/wt`) — full docs: `tools/git/worktrunk.md`
 - **Fallback**: `~/.aidevops/agents/scripts/worktree-helper.sh`
 - **Paths**: `~/Git/myrepo/` (main) | `~/Git/myrepo-feature-auth/` (linked) | `~/Git/myrepo-bugfix-login/` (linked)
 
@@ -31,15 +31,12 @@ tools:
 **Worktrunk** (preferred — shell cd, hooks, CI status, merge workflow):
 
 ```bash
-wt switch -c feature/my-feature   # Create worktree + cd into it
-wt list                           # List worktrees with CI status
-wt merge                          # Squash/rebase/merge + cleanup
-wt remove                         # Remove current worktree
-# Hotfix without leaving feature work — existing worktrees unaffected
-wt switch -c hotfix/security-patch
-# Multiple AI sessions on separate worktrees
-opencode ~/Git/myrepo-feature-auth/    # Session 1
-opencode ~/Git/myrepo-bugfix-login/    # Session 2
+wt switch -c feature/my-feature        # Create worktree + cd into it
+wt list                                # List worktrees with CI status
+wt merge                               # Squash/rebase/merge + cleanup
+wt remove                              # Remove current worktree
+wt switch -c hotfix/security-patch     # Hotfix without leaving feature work
+opencode ~/Git/myrepo-feature-auth/    # Multiple AI sessions on separate worktrees
 ```
 
 **worktree-helper.sh** (fallback — no cd support):
@@ -52,8 +49,6 @@ worktree-helper.sh status                           # Status overview
 worktree-helper.sh remove feature/auth              # Removes directory, NOT the branch
 worktree-helper.sh clean                            # Batch cleanup merged branches (interactive, runs git fetch --prune)
 ```
-
-Full Worktrunk docs: `tools/git/worktrunk.md`.
 
 ## Integration
 


### PR DESCRIPTION
## Summary

- Tightens `.agents/workflows/worktree.md` from 100→95 lines (5% reduction)
- Moves Worktrunk docs reference into Quick Reference bullet (eliminates standalone line)
- Consolidates Worktrunk bash block: inline comments replace standalone comment lines, removes duplicate `opencode` example
- Zero information loss: all task IDs (t1224.8, t189, GH#6740), command examples, and institutional knowledge preserved

Closes #16155

## What changed

- `tools/git/worktrunk.md` reference moved from standalone line to Quick Reference bullet
- Worktrunk bash block: 9 lines → 6 lines (comment-only lines folded into inline comments)
- Removed redundant second `opencode` example (one example sufficient)

## Runtime Testing

Risk: **Low** — agent doc only, no code execution paths changed.
Self-assessed: content preservation verified by line-by-line diff review.

<!-- MERGE_SUMMARY -->
**What**: Prose tightening of worktree.md agent doc (100→95 lines)
**Issue**: Closes #16155
**Files changed**: `.agents/workflows/worktree.md`
**Testing**: Self-assessed (doc-only change, no runtime paths)
**Key decisions**: Moved docs reference to Quick Reference rather than deleting; consolidated bash block comments rather than removing examples

---
[aidevops.sh](https://aidevops.sh) v3.5.784 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6