### PR TITLE
GH#15896: tighten orbstack.md 95→92 lines

### DIFF
--- a/.agents/tools/containers/orbstack.md
+++ b/.agents/tools/containers/orbstack.md
@@ -18,15 +18,12 @@ tools:
 
 ## Quick Reference
 
-| Item | Details |
-|------|---------|
-| Purpose | Fast, lightweight Docker and Linux VM runtime for macOS; Docker Desktop replacement |
-| Install | `brew install orbstack` · verify: `orb status` and `docker --version` |
-| CLI | `orb` for OrbStack management; `docker` / `docker compose` for container workflows |
-| Docs | https://docs.orbstack.dev · https://orbstack.dev · https://github.com/orbstack/orbstack |
-| Pricing | Free for personal use, paid for teams |
-
-Prefer OrbStack for lower memory use, faster startup, native macOS integration, `.orb.local` DNS, built-in Linux VMs, or Rosetta x86 emulation on Apple Silicon.
+- **Purpose**: Fast, lightweight Docker and Linux VM runtime for macOS; Docker Desktop replacement
+- **Install**: `brew install orbstack` · verify: `orb status` and `docker --version`
+- **CLI**: `orb` (management) + `docker` / `docker compose` (container workflows — all existing commands work unchanged)
+- **Docs**: https://docs.orbstack.dev · https://orbstack.dev · https://github.com/orbstack/orbstack
+- **Pricing**: Free for personal use, paid for teams
+- **When to use**: Lower memory, faster startup, native macOS integration, `.orb.local` DNS, built-in Linux VMs, Rosetta x86 emulation on Apple Silicon
 
 <!-- AI-CONTEXT-END -->
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/containers/orbstack.md` from 95 to 92 lines (~3% reduction).

Closes #15896

## Changes

- Convert Quick Reference table to bullet list (saves 2 lines: table header + separator row)
- Merge standalone "Prefer OrbStack for..." line into bullet list as "When to use" item (saves 1 line)
- All content preserved: URLs, commands, OpenClaw workflows, destructive ops warning

## Content Preservation Verification

- All code blocks present ✓
- All URLs present (docs.orbstack.dev, orbstack.dev, github.com/orbstack/orbstack) ✓
- All command examples present (orb list, orb shell, orb create, docker compose, etc.) ✓
- OpenClaw workflows unchanged ✓
- Destructive ops warning unchanged ✓
- No task IDs or GH# refs in this file ✓

## Runtime Testing

Risk: **Low** — documentation-only change, no code or agent logic modified.
Assessment: `self-assessed` — no runtime verification required per testing gate.

<!-- MERGE_SUMMARY -->
**What**: Tighten OrbStack agent doc by converting table to bullet list
**Issue**: Closes #15896
**Files changed**: `.agents/tools/containers/orbstack.md` (95→92 lines)
**Testing**: Self-assessed (docs-only)
**Key decisions**: Preserved OpenClaw section (maintainer explicitly restored it in f6843ab1b); only restructured Quick Reference format

---
[aidevops.sh](https://aidevops.sh) v3.5.784 plugin for [OpenCode](https://opencode.ai) v1.3.13