### PR TITLE
GH#16031: tighten security.md (79 → 76 lines)

### DIFF
--- a/.agents/aidevops/security.md
+++ b/.agents/aidevops/security.md
@@ -30,9 +30,6 @@ chmod 600 configs/.*.json ~/.ssh/id_* ~/.ssh/config ~/.ssh/*_password
 chmod 644 ~/.ssh/id_*.pub
 chmod 700 ~/.ssh/
 chmod 755 *.sh .agents/scripts/*.sh
-```
-
-```bash
 # .gitignore entries
 printf "configs/.*.json\n*.password\n.env\n*.key\n*.pem\n" >> .gitignore
 ```
@@ -46,7 +43,7 @@ chmod 600 ~/.ssh/id_ed25519 && chmod 644 ~/.ssh/id_ed25519.pub
 ssh-keygen -p -f ~/.ssh/id_ed25519
 ```
 
-```bash
+```text
 # ~/.ssh/config hardening
 Host *
     PasswordAuthentication no


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/aidevops/security.md` per issue #16031 (automated simplification scan).

- Merged two separate `bash` code blocks in `## File Permissions` into one (removes redundant fence markers)
- Fixed SSH config block language tag from `bash` to `text` (it's a config file, not executable bash)
- All content, code blocks, command examples, and institutional knowledge preserved

## Issue
Closes #16031

## Files Changed
- `.agents/aidevops/security.md`: 79 → 76 lines (-3 lines)

## Testing
**Risk level:** Low — docs/agent prompt only, no executable code changed.
**Runtime testing:** `self-assessed` — agent prompt file, no runtime verification required per t1660.7 risk table.

Content preservation verified: all code blocks, command examples, and section structure present before and after.

## Key Decisions
- Merged code blocks rather than removing content — the `.gitignore` entries belong with the `chmod` commands as a single setup block
- Changed `bash` → `text` for SSH config block since `Host *` config syntax is not bash and syntax highlighting was misleading

---
[aidevops.sh](https://aidevops.sh) v3.5.786 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6