### PR TITLE
GH#16177: tighten rules-video-status.md — merge timing table, promote production note

### DIFF
--- a/.agents/content/heygen-skill/rules-video-status.md
+++ b/.agents/content/heygen-skill/rules-video-status.md
@@ -9,6 +9,8 @@ metadata:
 
 HeyGen video generation is asynchronous: store the `video_id`, poll until terminal state, then download or hand off to a webhook-driven flow.
 
+**Production:** Prefer webhooks over polling to avoid idle connections; see [rules-webhooks.md](rules-webhooks.md). Cache `video_url` values — they expire.
+
 ## Check Status
 
 ```bash
@@ -50,13 +52,7 @@ async function getVideoStatus(videoId: string) {
 
 ## Timing Guidance
 
-Typical generation time is **5-15 min**. At peak load, with long scripts, or at higher resolution, expect **20+ min**. Use a timeout of **15-20 min** (`900000-1200000` ms).
-
-| Factor | Effect |
-|--------|--------|
-| Script length | Longer scripts take significantly more time |
-| Resolution | 1080p is slower than 720p |
-| Queue load | Peak hours can add 15-20+ min |
+Typical: **5-15 min**. Peak load, long scripts, or 1080p: **20+ min**. Use a timeout of **15-20 min** (`900000-1200000` ms).
 
 ## Polling Pattern
 
@@ -118,7 +114,3 @@ if (process.argv.includes("--wait")) {
   console.log("Status:", status.status, status.video_url ?? "");
 }
 ```
-
-## Production Note
-
-Prefer webhooks over polling in production to avoid idle connections; see [rules-webhooks.md](rules-webhooks.md). Cache `video_url` values because they expire.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/content/heygen-skill/rules-video-status.md` per simplification issue GH#16177.

## Changes
- Promote production webhook/cache note to top of file (primacy effect — most critical rule first)
- Merge 5-line timing table into a single prose line (no information loss — all 3 factors retained)
- Remove now-redundant "Production Note" section at bottom
- 124 → 116 lines (-8 lines); all code blocks, URLs, and knowledge preserved

## Issue
Closes #16177

## Files Changed
- `.agents/content/heygen-skill/rules-video-status.md`

## Testing
**Risk level:** Low (docs/agent prompt — no runtime behaviour changed)
**Verification:** `self-assessed` — content preservation confirmed: all code blocks, URLs, timing values, and status table present before and after. Agent behaviour unchanged.

## Runtime Testing
Risk: Low — agent instruction doc, no executable code paths changed.

---
[aidevops.sh](https://aidevops.sh) v3.5.788 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6