### PR TITLE
GH#16180: tighten session reference doc

### DIFF
--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -4,7 +4,7 @@ Loaded on-demand for session management, browser automation, localhost, or quali
 
 ## Terminal Capabilities
 
-Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers, `opencode -p "subtask"`).
+Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers).
 
 - Long-running processes: use `&`, `nohup`, or `tmux`.
 - Parallel AI dispatch: `tools/ai-assistants/opencode-server.md`.
@@ -39,7 +39,6 @@ worktree-helper.sh add feature/x  # Fallback
 ```
 
 - After switching to a worktree, re-read files at the worktree path before editing. Edit tracking is path-specific.
-- After completing changes, offer: 1) Preflight checks 2) Skip preflight 3) Continue editing.
 - Worktree ownership: remove only if you created it this session, it's deployed/complete, or user asked. Ownership enforced by `worktree-helper.sh registry list`; `remove`/`clean` refuse live worktrees owned by other processes.
 - Safety hooks block destructive commands (`git reset --hard`, `rm -rf`). Verify with `install-hooks.sh --test`. See `workflows/git-workflow.md` "Destructive Command Safety Hooks".
 - Full docs: `workflows/git-workflow.md`, `tools/git/worktrunk.md`.
@@ -69,8 +68,7 @@ Quick commands: `linters-local.sh` (pre-commit), `/pr review` (full), `version-m
 
 ## Agents & Subagents
 
-- Full inventory: `subagent-index.toon`.
-- Strategy: load subagents only when domain expertise is needed.
+Full inventory: `subagent-index.toon`. Load subagents only when domain expertise is needed.
 
 | Tier | Location | Purpose |
 |------|----------|---------|


### PR DESCRIPTION
## Summary

Tighten `.agents/reference/session.md` per GH#16180 simplification scan.

**Classification:** Instruction doc (agent rules, workflows, operational procedures) — prose tightening applied, not restructuring.

**Changes:**
- Remove runtime-specific `opencode -p "subtask"` example from Terminal Capabilities (runtime-agnostic doc)
- Remove interactive "offer: 1) Preflight 2) Skip 3) Continue" prompt pattern — not appropriate for a reference doc loaded by headless workers
- Compress Agents & Subagents intro from 2 bullets to 1 line (same information, less noise)
- 87 → 85 lines

**Preserved:** All code blocks, URLs, task IDs, command examples, safety rules, and institutional knowledge.

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. `self-assessed`.

Verification: `npx markdownlint-cli2 .agents/reference/session.md` → 0 errors.

Closes #16180

---
[aidevops.sh](https://aidevops.sh) v3.5.791 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6