### PR TITLE
GH#16188: tighten agent doc pre-edit.md

### DIFF
--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -12,7 +12,7 @@ Run before any file edits:
 ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "task description"
 ```
 
-## Exit Codes and Actions
+## Exit Codes
 
 | Code | Meaning | Action |
 |------|---------|--------|
@@ -38,13 +38,11 @@ Run before any file edits:
 - **Docs-only** (`readme`, `changelog`, `documentation`, `docs/`, `typo`, `spelling`) → stay on `main`
 - **Code** (`feature`, `fix`, `bug`, `implement`, `refactor`, `add`, `update`, `enhance`, `port`, `ssl`, `helper`) → create worktree; code keywords override docs keywords
 
-## Why Worktrees Are Default
+## Worktree Default
 
 Keep `~/Git/{repo}/` on `main`. Avoids blocked branch switches, parallel sessions inheriting the wrong branch, and `local changes would be overwritten` errors.
 
 Stay on `main` only for: docs-only changes (README, CHANGELOG, `docs/`), typos, version bumps, planning files (`TODO.md`, `todo/`). Planning-file commits use `planning-commit-helper.sh "plan: add new task"`.
-
-## Feature-Branch Cases
 
 | Scenario | Script output | Action |
 |----------|---------------|--------|
@@ -64,7 +62,7 @@ After creating the worktree, call `session-rename_sync_branch`.
 
 Branch types: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
-## aidevops Source vs Deployed Copy
+## Source vs Deployed Copy
 
 - Source: `~/Git/aidevops/.agents/` — git-tracked, branch matters
 - Deployed: `~/.aidevops/agents/` — copied output, not a git repo


### PR DESCRIPTION
## Summary

- Consolidate `Feature-Branch Cases` table into `Worktree Default` section (removes redundant section header)
- Shorten section headers: `Exit Codes and Actions` → `Exit Codes`, `Why Worktrees Are Default` → `Worktree Default`, `aidevops Source vs Deployed Copy` → `Source vs Deployed Copy`
- All institutional knowledge preserved; 72 → 70 lines

## What

Tighten `.agents/workflows/pre-edit.md` per simplification-debt scan. File classified as **instruction doc** (not reference corpus) — prose compression applied, no content removed.

## Issue

Closes #16188

## Files Changed

- `.agents/workflows/pre-edit.md` — 3 insertions, 5 deletions

## Testing

**Risk level:** Low (docs-only, agent prompt file)
**Runtime Testing:** `self-assessed` — no executable code changed; agent behaviour unchanged (same exit codes, same prompts, same decision logic).

## Key Decisions

- Kept all task IDs, command examples, and decision rationale intact
- Merged Feature-Branch Cases table directly under Worktree Default — logically belongs there, no information lost
- Did not compress further: remaining content is all load-bearing (exit code table, prompts, keyword lists, worktree commands)

---
[aidevops.sh](https://aidevops.sh) v3.5.791 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6