### PR TITLE
GH#15937: tighten postgres-drizzle-skill.md index

### DIFF
--- a/.agents/services/database/postgres-drizzle-skill.md
+++ b/.agents/services/database/postgres-drizzle-skill.md
@@ -50,8 +50,6 @@ Slow query?
 | MEDIUM | No partial indexes | Oversized indexes | Partial indexes for filtered subsets |
 | MEDIUM | Random UUIDs for PKs | Poor index locality | UUIDv7 (PG18+) |
 
-See chapter files below for schema, query, and relation patterns.
-
 ## Reference Documentation
 
 | File | Purpose |


### PR DESCRIPTION
## Summary

- Removes redundant prose "See chapter files below for schema, query, and relation patterns." from `postgres-drizzle-skill.md` — the Reference Documentation table immediately following already serves this purpose
- Index reduced from 73 → 71 lines (was 88 at issue creation; prior work had already split content into chapter files)
- All knowledge preserved: decision trees, anti-patterns table, and chapter file references remain intact

## What

Tighten `.agents/services/database/postgres-drizzle-skill.md` per simplification-debt issue GH#15937.

## Issue

Closes #15937

## Files Changed

- `.agents/services/database/postgres-drizzle-skill.md` — 2 lines removed (redundant prose)

## Testing

**Risk level:** Low — documentation-only change, no code or agent logic modified.

**Verification:**
- Content preservation: all code blocks, URLs, task ID references, and command examples present before and after ✓
- No broken internal links — chapter file references unchanged ✓
- Agent behaviour unchanged — index structure and chapter pointers intact ✓
- `wc -l` chapter files total unchanged (no content moved or deleted) ✓

## Runtime Testing

`self-assessed` — docs/comments change, no runtime verification required per risk matrix.

---
<!-- MERGE_SUMMARY -->
**What:** Remove redundant "See chapter files below" prose from postgres-drizzle-skill.md index
**Issue:** Closes #15937
**Files changed:** 1 (`.agents/services/database/postgres-drizzle-skill.md`, -2 lines)
**Testing:** Self-assessed (docs-only, low risk)
**Key decisions:** Kept decision trees and anti-patterns table in index (high-value quick-reference; primacy effect); only removed the redundant transitional sentence

---
[aidevops.sh](https://aidevops.sh) v3.5.793 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6