### PR TITLE
GH#15560: tighten wrangler-gotchas.md agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md
@@ -4,15 +4,15 @@ Pitfalls and troubleshooting for the Wrangler CLI.
 
 ## Gotchas
 
-**Binding IDs vs Names** — `binding` = code name; `id`/`database_id`/`bucket_name` = resource ID. Preview bindings need separate IDs: `preview_id`, `preview_database_id`.
-
-**Environment Inheritance** — Non-inheritable (bindings, vars): must redeclare per env. Inheritable (routes, `compatibility_date`): can override.
-
 **Compatibility Dates** — Always set; omitting causes unexpected runtime changes:
 
 ```jsonc
 { "compatibility_date": "2025-01-01" }
 ```
+
+**Binding IDs vs Names** — `binding` = code name; `id`/`database_id`/`bucket_name` = resource ID. Preview bindings need separate IDs: `preview_id`, `preview_database_id`.
+
+**Environment Inheritance** — Non-inheritable (bindings, vars): must redeclare per env. Inheritable (routes, `compatibility_date`): can override.
 
 **Durable Objects Need `script_name`** — With `getPlatformProxy`, always specify:
 
@@ -24,7 +24,7 @@ Pitfalls and troubleshooting for the Wrangler CLI.
 }
 ```
 
-**Node.js Compatibility** — Some bindings (e.g., Hyperdrive with `pg`) require:
+**Node.js Compatibility** — Bindings using Node APIs (e.g., Hyperdrive with `pg`) require:
 
 ```jsonc
 { "compatibility_flags": ["nodejs_compat_v2"] }


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md` per issue #15560 (instruction doc simplification).

## Changes
- Reorder gotchas by importance: `Compatibility Dates` moved first (highest-impact silent failure — omitting causes unexpected runtime changes)
- Tighten Node.js Compatibility prose: "Some bindings (e.g., Hyperdrive with `pg`) require" → "Bindings using Node APIs (e.g., Hyperdrive with `pg`) require" (more precise)
- All code blocks, URLs, task ID references, and command examples preserved
- Zero content loss — same 51 lines

## Classification
**Instruction doc** (operational rules, gotchas, troubleshooting table) — tightened prose and reordered by importance per `build-agent.md` guidance.

## Testing
- `bunx markdownlint-cli2` → 0 errors
- Content preservation verified: all code blocks, URLs, and references present before and after

## Runtime Testing
**Risk: Low** — docs-only change, no code execution paths affected. `self-assessed`.

Closes #15560

---
[aidevops.sh](https://aidevops.sh) v3.5.796 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6