### PR TITLE
GH#14402: tighten seo-optimize.md agent doc

### DIFF
--- a/.agents/scripts/commands/seo-optimize.md
+++ b/.agents/scripts/commands/seo-optimize.md
@@ -4,38 +4,26 @@ agent: Build+
 mode: subagent
 ---
 
-Optimize content for SEO performance.
-
-Target: $ARGUMENTS
+Target: $ARGUMENTS (file path + optional keyword)
 
 ## Workflow
 
-1. **Identify target**: Parse $ARGUMENTS for file path and optional keyword
-
-2. **Run analysis**:
+1. **Analyze**:
 
    ```bash
    python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py analyze "$FILE" \
      --keyword "$KEYWORD" --secondary "$SECONDARY"
    ```
 
-3. **Review results**: Check each category:
-   - Readability score and grade
-   - Keyword density and placement
-   - SEO quality score (target 80+)
-   - Critical issues (must fix)
-   - Warnings (should fix)
-   - Suggestions (nice to have)
+2. **Review results** — SEO quality score (target 80+), readability grade, keyword density, critical issues, warnings, suggestions.
 
-4. **Apply fixes** in priority order:
+3. **Apply fixes** in priority order:
    - Critical: Missing H1 keyword, no meta elements, content too short
    - High: Low keyword density, missing internal links
    - Medium: Reading level, paragraph length
    - Low: External links, transition words
 
-5. **Re-analyze**: Run analysis again to verify improvements
-
-6. **Generate report**: Summarize changes made and final scores
+4. **Re-analyze and report**: Verify improvements, summarize changes and final scores.
 
 ## Quick Commands
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/scripts/commands/seo-optimize.md` from 60 to 48 lines (20% reduction)
- Merge trivial single-line steps (steps 5+6 → single step), collapse redundant preamble
- Preserve all command examples, priority categories, file paths, and related links
- Zero markdownlint errors

## What

Instruction doc simplification per `tools/build-agent/build-agent.md` guidance. Classified as instruction doc (workflow/slash command), not reference corpus — prose tightening is appropriate.

## Files Changed

- `.agents/scripts/commands/seo-optimize.md` — 60 → 48 lines

## Testing

- `bunx markdownlint-cli2 ".agents/scripts/commands/seo-optimize.md"` → 0 errors
- All command examples verified present: `seo-content-analyzer.py analyze`, `quality`, `readability`, `keywords`
- All priority levels preserved: Critical, High, Medium, Low
- All related links preserved: `seo-optimizer.md`, `content-analyzer.md`, `meta-creator.md`, `internal-linker.md`

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution path changed. Self-assessed.

Closes #14402

---
[aidevops.sh](https://aidevops.sh) v3.5.798 plugin for [OpenCode](https://opencode.ai) v1.3.13