### PR TITLE
GH#14389: tighten caldav-calendar-skill.md 64→56 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5102,5 +5102,11 @@
     "pr": 16281,
     "status": "simplified",
     "issue": "GH#16179"
+  },
+  ".agents/tools/productivity/caldav-calendar-skill.md": {
+    "hash": "1c5dfa3f56efc691d015c99e736c248cad1fd65b547302ab20484ba9bc0524c9",
+    "lines": 56,
+    "last_simplified": "2026-04-03",
+    "issue": "GH#14389"
   }
 }

--- a/.agents/tools/productivity/caldav-calendar-skill.md
+++ b/.agents/tools/productivity/caldav-calendar-skill.md
@@ -2,9 +2,6 @@
 name: caldav-calendar
 description: "Sync and query CalDAV calendars (iCloud, Google, Fastmail, Nextcloud, etc.) using vdirsyncer + khal"
 mode: subagent
-imported_from: clawdhub
-clawdhub_slug: "caldav-calendar"
-clawdhub_version: "1.0.1"
 ---
 # CalDAV Calendar (vdirsyncer + khal)
 
@@ -42,14 +39,7 @@ khal new 2026-01-15 10:00 11:00 "With notes" :: Description goes here
 
 ## Edit Events
 
-Interactive (requires TTY):
-- `s` — edit summary
-- `d` — description
-- `t` — datetime
-- `l` — location
-- `D` — delete
-- `n` — skip
-- `q` — quit
+`khal edit` — interactive (requires TTY): `s` summary, `d` description, `t` datetime, `l` location, `D` delete, `n` skip, `q` quit
 
 ## Output Formats
 


### PR DESCRIPTION
## Summary

- Remove stale clawdhub import metadata (`imported_from`, `clawdhub_slug`, `clawdhub_version`) — 3 lines of dead frontmatter
- Collapse Edit Events keystrokes list (8 lines) into single inline line; add missing `khal edit` invocation command
- All commands, placeholders, setup steps, and cross-references preserved

## What

Tighten `.agents/tools/productivity/caldav-calendar-skill.md` from 64 to 56 lines (12.5% reduction).

## Issue

Closes #14389

## Files Changed

- `.agents/tools/productivity/caldav-calendar-skill.md` — 64→56 lines
- `.agents/configs/simplification-state.json` — updated hash registry

## Testing

**Risk level:** Low (docs/agent prompt, no code logic)
**Verification:** `self-assessed` — all code blocks, commands, placeholders, and cross-references present before and after. `khal edit` command added (was missing from Edit Events section).

## Runtime Testing

`self-assessed` — Low risk: agent doc with no executable code. Content preservation verified by line-by-line diff review.

---
[aidevops.sh](https://aidevops.sh) v3.5.798 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6