### PR TITLE
GH#16214: tighten remotion-can-decode.md

### DIFF
--- a/.agents/tools/video/remotion-can-decode.md
+++ b/.agents/tools/video/remotion-can-decode.md
@@ -2,15 +2,13 @@
 name: can-decode
 mode: subagent
 description: Check if a video can be decoded by the browser using Mediabunny
-metadata:
-  tags: decode, validation, video, audio, compatibility, browser
 ---
 
 # Checking if a video can be decoded
 
 Use Mediabunny to check if a video can be decoded by the browser before attempting to play it.
 
-## Shared track-check helper
+## Helper
 
 ```tsx
 import { Input, ALL_FORMATS } from "mediabunny";
@@ -32,7 +30,9 @@ const checkTracks = async (input: Input): Promise<boolean> => {
 };
 ```
 
-## URL source
+## Usage
+
+**URL source:**
 
 ```tsx
 import { UrlSource } from "mediabunny";
@@ -40,11 +40,10 @@ import { UrlSource } from "mediabunny";
 export const canDecode = (src: string) =>
   checkTracks(new Input({ formats: ALL_FORMATS, source: new UrlSource(src, { getRetryDelay: () => null }) }));
 
-// Usage
 const isDecodable = await canDecode("https://remotion.media/video.mp4");
 ```
 
-## Blob source (file uploads / drag-and-drop)
+**Blob source** (file uploads / drag-and-drop):
 
 ```tsx
 import { BlobSource } from "mediabunny";


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/video/remotion-can-decode.md` per simplification issue #16214.

## Changes
- Remove redundant `metadata.tags` frontmatter field (already captured in `description`)
- Rename `## Shared track-check helper` → `## Helper` (shorter, same meaning)
- Consolidate `## URL source` + `## Blob source` under single `## Usage` heading with bold inline labels
- Remove obvious `// Usage` comment

## Issue
Closes #16214

## Files Changed
- `.agents/tools/video/remotion-can-decode.md` (54 → 53 lines)

## Testing
- All code blocks preserved verbatim
- All API patterns intact (UrlSource, BlobSource, checkTracks helper)
- No broken references
- Risk: **Low** (docs-only change, no logic)

## Runtime Testing
`self-assessed` — docs-only change, no executable code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.798 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6