### PR TITLE
GH#16216: tighten performance.md Run Analysis section

### DIFF
--- a/.agents/scripts/commands/performance.md
+++ b/.agents/scripts/commands/performance.md
@@ -22,7 +22,12 @@ URL/Target: $ARGUMENTS
 
 ## Run Analysis
 
-Execute in order: (1) **Lighthouse Audit** — performance, accessibility, best practices, SEO; (2) **Core Web Vitals** — FCP, LCP, CLS, FID, TTFB; (3) **Network Analysis** — third-party scripts, request chains, bundle sizes; (4) **Accessibility** — WCAG compliance issues.
+Execute in order:
+
+1. **Lighthouse Audit** — performance, accessibility, best practices, SEO
+2. **Core Web Vitals** — FCP, LCP, CLS, FID, TTFB
+3. **Network Analysis** — third-party scripts, request chains, bundle sizes
+4. **Accessibility** — WCAG compliance issues
 
 ## Report Format
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Restructures the dense run-on sentence in the `## Run Analysis` section of `.agents/scripts/commands/performance.md` into a numbered list for improved readability and agent scanning.

## Issue
Closes #16216

## Files Changed
- `.agents/scripts/commands/performance.md` — Run Analysis section reformatted (1 section, no content loss)

## Testing
- Content preservation verified: all 4 analysis steps present before and after
- No broken references or internal links
- Agent behaviour unchanged — same steps, clearer format

## Key Decisions
- Expanded from 66→71 lines: the run-on sentence was harder to scan; numbered list is the correct format for sequential steps
- Zero content removed — this is a format-only change

## Runtime Testing
**Risk level:** Low (docs/agent prompt only)
**Assessment:** self-assessed — no runtime verification required for doc formatting changes

---
[aidevops.sh](https://aidevops.sh) v3.5.798 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6