### PR TITLE
GH#16217: tighten llm-tldr.md 68→41 lines

### DIFF
--- a/.agents/tools/context/llm-tldr.md
+++ b/.agents/tools/context/llm-tldr.md
@@ -14,55 +14,28 @@ tools:
 
 # llm-tldr - Semantic Code Analysis
 
-TLDR extracts code structure and semantics, saving ~95% tokens vs raw code.
+TLDR extracts code structure and semantics, saving ~95% tokens vs raw code. Install: `pip install llm-tldr`. Source: [parcadei/llm-tldr](https://github.com/parcadei/llm-tldr). MCP config template: `configs/mcp-templates/llm-tldr.json`.
 
-**Source**: [parcadei/llm-tldr](https://github.com/parcadei/llm-tldr)
-
-## Installation
-
-```bash
-pip install llm-tldr
-```
-
-## MCP Server (OpenCode)
-
-```json
-{
-  "llm-tldr": {
-    "command": "tldr-mcp",
-    "args": ["--project", "${workspaceFolder}"]
-  }
-}
-```
-
-Template: `configs/mcp-templates/llm-tldr.json`
+**vs other tools**: llm-tldr for structure/semantics; rg/Augment for finding code; repomix for full context.
 
 ## Commands
 
 CLI: `tldr <cmd>` — MCP (via `tldr-mcp`): same commands prefixed `tldr_`.
 
-| Command | Usage | Purpose |
-|---------|-------|---------|
-| `tree` | `tldr tree /path/to/project` | File structure with line counts |
-| `structure` | `tldr structure /path/to/file.py` | Classes, functions, imports (no impl) |
-| `context` | `tldr context /path/to/file.py` | Full analysis: imports, signatures, docstrings, types, call graph |
-| `cfg` | `tldr cfg /path/to/file.py fn_name` | Control flow graph for a function |
-| `dfg` | `tldr dfg /path/to/file.py fn_name` | Data flow / variable dependencies |
-| `search` | `tldr search "auth logic" /path` | Semantic search (bge-large-en-v1.5, 1024-dim) |
-| `impact` | `tldr impact /path/to/file.py fn_name` | What would break if this function changes |
-| `dead` | `tldr dead /path/to/project` | Unused functions and classes |
-| `slice` | `tldr slice /path/to/file.py var_name` | Code slice affecting a variable |
-
-## When to Use
-
-- **Before editing**: `tldr context` + `tldr impact` to understand scope
-- **Codebase exploration**: `tldr search` for concepts, `tldr tree` for overview
-- **Code review**: `tldr dead` for unused code, `tldr dfg` for data flow
-
-**vs other tools**: llm-tldr for structure/semantics; rg/Augment for finding code; repomix for full context.
+| Command | When to use | Purpose |
+|---------|-------------|---------|
+| `tree /path` | Codebase overview | File structure with line counts |
+| `structure file.py` | Before editing | Classes, functions, imports (no impl) |
+| `context file.py` | Before editing | Full analysis: imports, signatures, docstrings, types, call graph |
+| `impact file.py fn` | Before editing | What would break if this function changes |
+| `search "auth logic" /path` | Exploration | Semantic search (bge-large-en-v1.5, 1024-dim) |
+| `cfg file.py fn` | Code review | Control flow graph for a function |
+| `dfg file.py fn` | Code review | Data flow / variable dependencies |
+| `dead /path` | Code review | Unused functions and classes |
+| `slice file.py var` | Debugging | Code slice affecting a variable |
 
 ## Troubleshooting
 
 - **First run**: downloads bge-large-en-v1.5 (~1.3GB)
-- **Unsupported language**: supports Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Ruby, PHP, C#, Kotlin, Scala, Lua, Elixir. Others: use `tldr tree` + `tldr context` (basic parsing)
+- **Unsupported language**: supports Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Ruby, PHP, C#, Kotlin, Scala, Lua, Elixir — others fall back to `tldr tree` + `tldr context` (basic parsing)
 - **MCP issues**: `tldr-mcp --project /path/to/project` to test; `ps aux | grep tldr-mcp` to check running


### PR DESCRIPTION
## Summary

- Merge Installation + MCP Server sections into intro paragraph (removes 2 headers + JSON block)
- Add "When to use" column to commands table, replacing the separate "When to Use" section
- Reorder commands table by workflow phase: edit → explore → review → debug
- Tighten unsupported language note prose

All commands, model refs (bge-large-en-v1.5, 1024-dim), supported languages list, MCP config template pointer, and troubleshooting entries preserved.

**Line count**: 68 → 41 (40% reduction)

Closes #16217

<!-- MERGE_SUMMARY -->
**What**: Tighten llm-tldr.md agent doc from 68 to 41 lines
**Issue**: #16217
**Files changed**: `.agents/tools/context/llm-tldr.md`
**Testing**: self-assessed (docs-only change, no runtime behaviour)
**Key decisions**: Merged installation/MCP config into intro; merged "When to Use" section into commands table as a column — no information loss, more scannable

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution paths changed.
Assessment: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.798 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6