### PR TITLE
GH#16237: tighten hyperdrive-patterns.md Connection Pooling section

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md
@@ -64,28 +64,19 @@ return Response.json({user, serverRegion: req.cf?.colo});
 ```
 
 ## Connection Pooling
-Transaction mode: connection acquired per transaction, `RESET` on return.
+Transaction mode: connection acquired per transaction, `RESET` on return. SET statements must stay within a single transaction or compound statement; keep transactions short.
 
-**SET statements** — must stay within a single transaction or statement:
 ```typescript
-// ✅ Within transaction
+// ✅ SET within transaction (RESET after COMMIT)
 await client.query("BEGIN");
 await client.query("SET work_mem = '256MB'");
 await client.query("SELECT * FROM large_table");
-await client.query("COMMIT");  // RESET after
-// ✅ Single compound statement
+await client.query("COMMIT");
+// ✅ Compound statement
 await client.query("SET work_mem = '256MB'; SELECT * FROM large_table");
 // ❌ Across queries — may get different connection
 await client.query("SET work_mem = '256MB'");
 await client.query("SELECT * FROM large_table");  // SET not applied
-```
-
-**Transaction discipline** — keep transactions short; long ones block pooling:
-```typescript
-// ❌ Long transaction holds connection
-await client.query("BEGIN");
-await processThousands();
-await client.query("COMMIT");
 // ✅ Short transaction
 await client.query("BEGIN");
 await client.query("UPDATE users SET status = $1 WHERE id = $2", [status, id]);
@@ -94,6 +85,10 @@ await client.query("COMMIT");
 await client.query("BEGIN");
 await client.query("SET LOCAL work_mem = '256MB'");
 await client.query("SELECT * FROM large_table");
+await client.query("COMMIT");
+// ❌ Long transaction holds connection
+await client.query("BEGIN");
+await processThousands();
 await client.query("COMMIT");
 ```
 


### PR DESCRIPTION
## Summary

- Merges two separate SET/transaction code blocks into one unified block with inline comments
- Collapses redundant bold-header prose into a single sentence
- 130 → 125 lines; all code examples, URLs, and knowledge preserved

## What

Tightened `.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md` per simplification-debt issue. The Connection Pooling section had two separate code blocks (SET statements, transaction discipline) with redundant bold-header prose that could be merged without losing any content.

## Issue

Closes #16237

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md` (130 → 125 lines)

## Runtime Testing

**Risk level:** Low — agent doc (markdown), no executable code changed.
**Verification:** All code blocks, inline comments, and cross-references (`hyperdrive-gotchas.md`) present before and after. `wc -l` confirms 125 lines (5 lines removed, zero content lost).

## Key Decisions

- Classified as instruction doc (not reference corpus) — prose tightening appropriate, not chapter splitting
- Merged two code blocks into one unified block ordered: SET-within-transaction, compound, cross-query (bad), short-tx, SET LOCAL, long-tx (bad) — logical flow preserved
- No arbitrary line target; stopped after removing genuine redundancy

<!-- MERGE_SUMMARY -->
**What:** Tighten Connection Pooling section in hyperdrive-patterns.md
**Issue:** Closes #16237
**Files:** 1 file, 130→125 lines
**Testing:** self-assessed (low risk, doc-only)
**Key decisions:** Merged redundant code blocks; prose collapsed to single sentence

---
[aidevops.sh](https://aidevops.sh) v3.5.799 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6