### PR TITLE
GH#16240: tighten api-shield-patterns.md — context header and table alignment

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md
@@ -1,4 +1,6 @@
-# Patterns & Use Cases
+# API Shield — Patterns & Use Cases
+
+Practical patterns for securing APIs with Cloudflare API Shield. See `api-shield.md` for concepts and `api-shield-gotchas.md` for known issues.
 
 ## Protect API with Schema + JWT
 
@@ -46,7 +48,7 @@ PUT /zones/{zone_id}/api_gateway/settings/schema_validation
 ## Architecture Patterns
 
 | Pattern | Edge Stack |
-|---------|-----------|
+|---------|------------|
 | **Public API** (high security) | Discovery → Schema Validation → JWT → Rate Limiting → Bot Management → Origin |
 | **Partner API** (mTLS + schema) | mTLS → Schema Validation → Sequence Mitigation → Origin |
 | **Internal API** (discovery + monitoring) | Discovery → Schema Learning → Auth Posture → Origin |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md` per GH#16240.

**Classification:** Reference corpus (code examples, tables, domain knowledge) — content preserved in full, no compression applied per `code-simplifier.md` "Reference corpora" policy.

**Changes made:**
- Added descriptive title `# API Shield — Patterns & Use Cases` (was generic `# Patterns & Use Cases`)
- Added brief intro line with cross-references to `api-shield.md` and `api-shield-gotchas.md` for navigation context
- Fixed inconsistent table column separator in Architecture Patterns table (`|---------|-----------|` → `|---------|------------|`)

**Not changed:** All code blocks, OWASP mapping table, availability table, monitoring fields, and all domain knowledge preserved verbatim.

## Issue
Closes #16240

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md` (87→89 lines, +4/-2)

## Testing
- `npx markdownlint-cli2` — 0 errors
- Content verification: all code blocks, URLs, command examples present before and after
- No task ID refs or GH# refs in this file (none to preserve)

## Key Decisions
- Classified as reference corpus, not instruction doc — restructuring into chapters not warranted at 87 lines
- Minimal changes only: title clarity + navigation cross-refs + table alignment fix
- Zero content loss

## Runtime Testing
**Risk level:** Low (docs/agent prompts only)
**Verification:** `self-assessed` — markdownlint clean, content diff reviewed

---
[aidevops.sh](https://aidevops.sh) v3.5.801 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6