### PR TITLE
GH#16241: tighten github-actions.md agent doc

### DIFF
--- a/.agents/tools/git/github-actions.md
+++ b/.agents/tools/git/github-actions.md
@@ -21,9 +21,9 @@ tools:
 - **Workflow**: `.github/workflows/code-quality.yml`
 - **Triggers**: push to `main`/`develop`; pull requests to `main`
 - **Jobs**: Framework Validation, SonarCloud Analysis, Codacy Analysis
-- **Secrets**: `SONAR_TOKEN` configured; `CODACY_API_TOKEN` still needed; `GITHUB_TOKEN` is auto-provided
-- **Dashboards**: SonarCloud https://sonarcloud.io/project/overview?id=marcusquinn_aidevops · Codacy https://app.codacy.com/gh/marcusquinn/aidevops · Actions https://github.com/marcusquinn/aidevops/actions
-- **Secret management**: Repository Settings → Secrets and variables → Actions
+- **Secrets**: `SONAR_TOKEN` configured; `CODACY_API_TOKEN` needs setup (conditional job); `GITHUB_TOKEN` auto-provided
+- **Dashboards**: [SonarCloud](https://sonarcloud.io/project/overview?id=marcusquinn_aidevops) · [Codacy](https://app.codacy.com/gh/marcusquinn/aidevops) · [Actions](https://github.com/marcusquinn/aidevops/actions)
+- **Add secret**: Repository Settings → Secrets and variables → Actions → New repository secret
 
 <!-- AI-CONTEXT-END -->
 
@@ -34,8 +34,6 @@ tools:
 | `SONAR_TOKEN` | Configured | https://sonarcloud.io/account/security |
 | `CODACY_API_TOKEN` | Needs setup | https://app.codacy.com/account/api-tokens |
 | `GITHUB_TOKEN` | Auto-provided | GitHub |
-
-To add `CODACY_API_TOKEN`: Repository Settings → Secrets and variables → Actions → **New repository secret**. `Codacy Analysis` job is conditional on this token being present.
 
 ## Concurrent Push Patterns
 


### PR DESCRIPTION
## Summary

- Convert verbose dashboard URLs to named markdown links (shorter, scannable)
- Merge redundant `CODACY_API_TOKEN` setup prose into Quick Reference line
- Consolidate "Secret management" + "New repository secret" into one actionable bullet

## What

Tightened `.agents/tools/git/github-actions.md` from 69 → 67 lines. Instruction doc classification (not reference corpus) — prose compression, not restructuring.

## Issue

Closes #16241

## Files Changed

- `.agents/tools/git/github-actions.md` — 3 insertions, 5 deletions

## Testing

**Risk level:** Low (docs/agent prompt only — no code, no runtime behaviour)
**Verification:** `self-assessed`

Content preservation verified via `diff`:
- All code blocks intact (full retry + simple push patterns)
- All URLs preserved (converted to named links, same destinations)
- All commands preserved
- All task ID references: none in this file
- Agent behaviour unchanged

## Runtime Testing

`self-assessed` — docs-only change, no runtime behaviour affected.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten github-actions.md agent doc per simplification scan (GH#16241)
**Issue:** #16241
**Files changed:** 1 (`.agents/tools/git/github-actions.md`)
**Testing:** self-assessed (docs-only)
**Key decisions:** Instruction doc (not reference corpus) → prose compression; zero content loss

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6