### PR TITLE
GH#16131: tighten agent doc Git Tools (.agents/tools/git.md)

### DIFF
--- a/.agents/tools/git.md
+++ b/.agents/tools/git.md
@@ -29,8 +29,6 @@ tools:
 - Security and auth: `git/authentication.md`, `git/git-security.md`
 - Automation: `git/github-actions.md`, `git/opencode-github.md`, `git/opencode-gitlab.md`, `git/opencode-github-security.md`
 
-<!-- AI-CONTEXT-END -->
-
 ## Common Operations
 
 | Operation | GitHub (`gh`) | GitLab (`glab`) | Gitea (`tea`) |
@@ -46,26 +44,23 @@ tools:
 
 ## Authentication
 
-CLI auth stores tokens in the system keyring; prefer that over plaintext config. Export tokens only when a script requires them:
+Prefer system keyring over plaintext config. Export tokens only when scripts require them:
 
 ```bash
 export GITHUB_TOKEN=$(gh auth token)
 export GITLAB_TOKEN=$(glab auth token)
 ```
 
-Detailed token setup and safety rules: `git/authentication.md`.
+Token setup and safety rules: `git/authentication.md`.
 
 ## Multi-Platform Remotes
-
-Use named remotes when a repo mirrors across platforms:
 
 ```bash
 git remote add github git@github.com:user/repo.git
 git remote add gitlab git@gitlab.com:user/repo.git
-git push github main
-git push gitlab main
+git push github main && git push gitlab main
 
-# Combined remote (push to both)
+# Push to both with a combined remote
 git remote add all git@github.com:user/repo.git
 git remote set-url --add --push all git@github.com:user/repo.git
 git remote set-url --add --push all git@gitlab.com:user/repo.git
@@ -83,3 +78,5 @@ opencode github install
 - GitLab: add OpenCode to `.gitlab-ci.yml`, then `@opencode explain this issue` / `@opencode fix this`
 
 Full workflow and hardening: `git/opencode-github.md`, `git/opencode-gitlab.md`, `git/opencode-github-security.md`.
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/git.md` per build-agent.md simplification principles.

## Changes
- Extend `AI-CONTEXT-END` to wrap all content (was only Quick Reference section)
- Compress Authentication section: remove redundant narrative sentence
- Remove self-evident intro sentence from Multi-Platform Remotes
- Combine sequential push commands into single line
- 85 → 82 lines; zero content loss

## Issue
Closes #16131

## Files Changed
- `.agents/tools/git.md` — prose tightening, AI-CONTEXT scope fix

## Testing
- `bunx markdownlint-cli2` → 0 errors
- Content preservation verified: all code blocks, doc pointers, command examples present before and after

## Runtime Testing
Risk: **Low** — docs/agent prompt only. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.802 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6