### PR TITLE
GH#16252: tighten calendar.md agent doc

### DIFF
--- a/.agents/tools/productivity/calendar.md
+++ b/.agents/tools/productivity/calendar.md
@@ -28,19 +28,13 @@ tools:
 
 ## When to Create Events
 
-**Do** create a calendar event when:
-- User explicitly asks ("schedule a meeting", "add to my calendar")
-- A routine produces a time-bound commitment (meeting, deadline, appointment)
-- Coordinating availability across people or projects
+Create when: user explicitly asks, routine produces a time-bound commitment, or coordinating availability.
 
-**Do NOT** create events for:
-- Tasks/reminders with no specific time block → use `reminders-helper.sh`
-- Things tracked in TODO.md / GitHub issues
-- Tentative plans the user hasn't confirmed
+Skip events for: tasks/reminders with no time block (→ `reminders-helper.sh`), TODO.md/GitHub issues, unconfirmed tentative plans.
 
 ## Field Coverage
 
-Core fields (title, start/end, location, notes, URL, calendar, all-day) are supported on both platforms. Linux-only extras: recurrence (`--repeat`), alarms (`--alarms`), categories (`--categories`). Invitees, travel time, and availability have no CLI support on either platform.
+Both platforms: title, start/end, location, notes, URL, calendar, all-day. Linux-only: `--repeat`, `--alarms`, `--categories`. No CLI support for invitees, travel time, or availability.
 
 ## Usage
 
@@ -84,5 +78,5 @@ calendar-helper.sh add "Client dinner" \
 calendar-helper.sh setup
 ```
 
-- **macOS**: No install needed. May need: System Settings > Privacy & Security > Calendars. All accounts from System Settings > Internet Accounts appear automatically.
-- **Linux**: Requires `khal` + `vdirsyncer` with CalDAV config. See `caldav-calendar-skill.md` for vdirsyncer configuration.
+- **macOS**: No install needed. Grant access: System Settings > Privacy & Security > Calendars. Accounts from System Settings > Internet Accounts appear automatically.
+- **Linux**: Requires `khal` + `vdirsyncer`. See `caldav-calendar-skill.md` for CalDAV config.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/productivity/calendar.md` per issue #16252 simplification scan.

## Changes
- **When to Create Events**: Compressed verbose bullet lists to direct rule sentences
- **Field Coverage**: Condensed single paragraph, removed redundant phrasing
- **Setup**: Tightened macOS/Linux notes, removed filler words
- 88 → 82 lines; all commands, rules, task IDs, and knowledge preserved

## Issue
Closes #16252

## Files Changed
- `.agents/tools/productivity/calendar.md`

## Testing
- `bunx markdownlint-cli2 ".agents/tools/productivity/calendar.md"` → 0 errors
- Content preservation verified: all code blocks, command examples, decision rules intact
- Agent behaviour unchanged: same routing logic, same helper commands

## Runtime Testing
Risk: **Low** — docs/agent prompt only, no code execution paths changed. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.802 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6