### PR TITLE
GH#16253: tighten realtime-sfu-patterns.md — add context header, improve section names

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md
@@ -1,5 +1,7 @@
 # Patterns & Use Cases
 
+Cloudflare Calls SFU — WebRTC session patterns, backend integration, and advanced media controls.
+
 ## Architecture
 
 ```
@@ -9,7 +11,7 @@ Client (WebRTC) <---> CF Edge <---> Backend (HTTP)
                            |
                     Other Edges <---> Other Clients
 
-# Anycast: Last-mile <50ms (95%), no region select, NACK shield, distributed consensus
+# Anycast: last-mile <50ms (95%), no region select, NACK shield, distributed consensus
 # Cascading trees auto-scale to millions:
 
 Publisher -> Edge A -> Edge B -> Sub1
@@ -21,9 +23,9 @@ Publisher -> Edge A -> Edge B -> Sub1
 **1:1:** A creates session+publishes, B creates+subscribes to A+publishes, A subscribes to B
 **N:N:** All create session+publish, backend broadcasts track IDs, all subscribe to others
 **1:N:** Publisher creates+publishes, viewers each create+subscribe (no fan-out limit)
-**Breakout:** Same PeerConnection! Backend closes/adds tracks, no recreation
+**Breakout:** Same PeerConnection — backend closes/adds tracks, no recreation
 
-## Backend
+## Session API
 
 **Express:**
 
@@ -71,7 +73,7 @@ export class Room {
 }
 ```
 
-## Advanced
+## Advanced Patterns
 
 **Bandwidth mgmt:**
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md` per simplification issue #16253.

**Changes:**
- Added context header (2 lines) explaining the file's purpose (Cloudflare Calls SFU patterns)
- Renamed `## Backend` → `## Session API` (more descriptive)
- Renamed `## Advanced` → `## Advanced Patterns` (more descriptive)
- Normalized `Last-mile` casing in architecture comment
- Replaced `Same PeerConnection!` with `Same PeerConnection —` (consistent punctuation)

**Preserved:** All code blocks (Express, Workers, DO Presence, bandwidth mgmt, simulcast, DataChannel), all performance numbers (100-250ms connect, ~50ms latency, 200-400ms glass-to-glass), all URLs, all technical content.

## Issue
Closes #16253

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md` (106→108 lines, +2 context header)

## Testing
- Risk level: **Low** (docs/agent prompt, no code logic)
- Verification: All code blocks, URLs, task ID refs, and command examples present before and after (diff verified)
- `self-assessed` — no runtime required for doc-only changes

## Key Decisions
- File classified as **reference corpus** (domain knowledge base with code examples) — content not compressed, only prose/labels improved
- Context header added per build-agent.md guidance (progressive disclosure, explain what the file is)
- Section renames improve discoverability without losing any content


---
[aidevops.sh](https://aidevops.sh) v3.5.807 plugin for [OpenCode](https://opencode.ai) v1.3.13