### PR TITLE
GH#16254: tighten agent doc HuggingFace Model Discovery

### DIFF
--- a/.agents/tools/local-models/huggingface.md
+++ b/.agents/tools/local-models/huggingface.md
@@ -41,7 +41,7 @@ RAM tight → Q4_K_M or IQ4_XS. RAM available → Q5_K_M or Q6_K.
 
 ## Hardware-Tier Recommendations
 
-Reserve ≥4 GB for OS. Higher-quant options in parentheses.
+Reserve ≥4 GB for OS.
 
 | RAM | Example Hardware | Budget | Recommended (higher-quant) |
 |-----|-----------------|--------|---------------------------|
@@ -64,7 +64,7 @@ Reserve ≥4 GB for OS. Higher-quant options in parentheses.
 
 ## Download
 
-Install CLI: `pip install "huggingface_hub[cli]"` (or pipx). Token: `~/.cache/huggingface/token`. Web: `https://huggingface.co/models?library=gguf&sort=trending`.
+Install: `pip install "huggingface_hub[cli]"` (or pipx). Token: `~/.cache/huggingface/token`. Browse: `https://huggingface.co/models?library=gguf&sort=trending`.
 
 ```bash
 # Helper (recommended)


### PR DESCRIPTION
## Summary

Prose compression of `.agents/tools/local-models/huggingface.md` per issue #16254.

**Changes:**
- Removed redundant "Higher-quant options in parentheses." sentence (already conveyed by the column header `Recommended (higher-quant)`)
- Tightened "Install CLI:" → "Install:" and "Web:" → "Browse:" for conciseness

**Preserved:** All code blocks, URLs, command examples, model families, quantization table, hardware-tier recommendations, troubleshooting table — zero knowledge loss.

Closes #16254

## Runtime Testing

Risk: **Low** — docs-only change, no code paths affected.
Verification: `self-assessed` — all code blocks, URLs, and command examples present before and after.

---
[aidevops.sh](https://aidevops.sh) v3.5.807 plugin for [OpenCode](https://opencode.ai) v1.3.13