### PR TITLE
GH#16268: tighten toon.md agent doc

### DIFF
--- a/.agents/tools/context/toon.md
+++ b/.agents/tools/context/toon.md
@@ -26,6 +26,7 @@ tools:
 - **Best for**: Tabular data (60%+ savings), config data, API responses
 - **Config**: `configs/toon-config.json` (copy from `configs/toon-config.json.txt`); key options: `default_delimiter`, `key_folding`, `batch_processing`, `ai_prompts`
 - **Resources**: https://toonformat.dev, https://github.com/toon-format/toon
+- **Best practices**: validate input; keep JSON backups; use strict mode in production; monitor actual savings (tabular data benefits most)
 
 <!-- AI-CONTEXT-END -->
 
@@ -61,20 +62,6 @@ toon-helper.sh compare large-dataset.json
 
 ## LLM Integration
 
-**Sending TOON to LLMs** — include this preamble:
+**Sending TOON to LLMs** — include preamble: `Data is in TOON format (2-space indent, arrays show length and fields):`
 
-```
-Data is in TOON format (2-space indent, arrays show length and fields):
-```
-
-**Generating TOON from LLMs:**
-
-- Show expected header format: `users[N]{id,name,role}:`
-- Rules: 2-space indent, no trailing spaces, `[N]` matches row count
-- Request code block output only
-
-## Best Practices
-
-- Validate input before processing; use strict mode in production
-- Keep JSON backups when converting; verify round-trip accuracy
-- Monitor actual token savings — tabular data benefits most
+**Generating TOON from LLMs** — show expected header format: `users[N]{id,name,role}:`. Rules: 2-space indent, no trailing spaces, `[N]` matches row count, request code block output only.


### PR DESCRIPTION
## Summary

- Merged `## Best Practices` section into Quick Reference as a single bullet — eliminates a standalone section for 3 bullets
- Condensed `## LLM Integration` from 12 lines (with fenced code block) to 2 prose lines — all rules preserved
- 80 → 67 lines (16% reduction); all commands, URLs, token efficiency data, use cases, and LLM integration rules intact

Closes #16268

---
[aidevops.sh](https://aidevops.sh) v3.5.809 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6