### PR TITLE
GH#16270: tighten internal-linker.md agent doc

### DIFF
--- a/.agents/content/internal-linker.md
+++ b/.agents/content/internal-linker.md
@@ -1,6 +1,6 @@
 ---
 name: internal-linker
-description: Strategic internal linking recommendations for SEO content
+description: Suggest 3-5 internal links per article — placement, anchor text, SEO rationale
 mode: subagent
 tools:
   read: true
@@ -15,9 +15,7 @@ tools:
 
 # Internal Linker
 
-- **Purpose**: Suggest 3-5 internal links per article with placement and anchor text
-- **Input**: Article content, internal links map, site structure
-- **Output**: Specific link suggestions with placement, anchor text, and SEO rationale
+**Input**: Article content, `context/internal-links-map.md`, `context/target-keywords.md`, sitemap/crawl data
 
 ## Link Types
 
@@ -30,8 +28,8 @@ tools:
 
 ## Rules
 
-- 3-5 internal links per 2000-word article
-- Descriptive anchor text using destination page's target keyword — never "click here", "read more", or "this article"
+- 3-5 links per 2000-word article
+- Anchor text = destination page's target keyword — never "click here", "read more", "this article"
 - Vary anchor text — no identical anchors for same destination
 - Place important links in first half of content
 - Deep links — specific pages, not homepage/categories
@@ -39,7 +37,7 @@ tools:
 
 ## Workflow
 
-1. **Gather context** — check `context/internal-links-map.md`, `context/target-keywords.md`, sitemap/crawl data
+1. **Gather context** — `context/internal-links-map.md`, `context/target-keywords.md`, sitemap/crawl data
 2. **Analyse content** — identify topics matching existing pages, find natural anchor opportunities, map user journey
 3. **Output**:
 
@@ -51,9 +49,6 @@ tools:
 - **Destination**: /blog/keyword-research-guide
 - **Placement**: Paragraph 3, after "When choosing keywords..."
 - **Rationale**: Supports pillar-cluster model, passes authority to key page
-
-### Link 2
-...
 
 ### Summary
 - Total links suggested: X


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/content/internal-linker.md` per simplification scan (GH#16270). Instruction doc — prose compression, not content removal.

## Issue
Closes #16270

## Changes
- Merged redundant Purpose/Input/Output header section into frontmatter description + single Input line
- Removed `### Link 2 ...` placeholder from output example (noise, not knowledge)
- Compressed anchor text rule and link count rule prose
- Removed redundant "check" verb from workflow step 1
- 69 → 64 lines; all rules, link types, workflow steps, and integration references preserved

## Files Changed
- `.agents/content/internal-linker.md` — 5 lines removed, prose tightened

## Testing
- Content preservation verified: all code blocks, command examples, link type table, rules, workflow steps, integration references present before and after
- No broken internal references (file paths unchanged)
- Agent behaviour unchanged — same instructions, tighter prose

## Runtime Testing
**Risk level**: Low — docs/agent prompt only, no code execution paths
**Verification**: `self-assessed` — doc-only change, no runtime required

---
[aidevops.sh](https://aidevops.sh) v3.5.809 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6