### PR TITLE
GH#16272: tighten smart-placement.md prose and section naming

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/smart-placement.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/smart-placement.md
@@ -8,7 +8,7 @@ Enable when: multiple backend round-trips, geographically concentrated backend, 
 
 **Do NOT enable for:** static/cached content, Workers without backend calls, pure edge logic (auth, redirects, transforms), Workers without fetch handlers.
 
-**Requirements:** Wrangler 2.20.0+, consistent traffic from multiple global locations. Only affects fetch handlers (not RPC methods or named entrypoints). Available on all plans. Analysis takes up to 15 min; Worker runs at edge during analysis.
+**Requirements:** Wrangler 2.20.0+, consistent traffic from multiple global locations. Only affects fetch handlers (not RPC methods or named entrypoints). Available on all plans. Analysis takes up to 15 min; Worker runs at edge until analysis completes.
 
 ## Architecture: Frontend/Backend Split
 
@@ -31,7 +31,7 @@ mode = "smart"
 hint = "wnam"  # Optional: West North America
 ```
 
-Deploy and wait 15 min for analysis. Check status via API or dashboard.
+Deploy and wait 15 min for analysis.
 
 ## Placement Status
 
@@ -45,7 +45,7 @@ type PlacementStatus =
 
 1% of requests always route without optimization (baseline comparison) — expected behaviour.
 
-## CLI
+## Status Check
 
 ```bash
 # Check placement status

--- a/.agents/services/hosting/cloudflare-platform-skill/smart-placement.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/smart-placement.md
@@ -31,7 +31,7 @@ mode = "smart"
 hint = "wnam"  # Optional: West North America
 ```
 
-Deploy and wait 15 min for analysis.
+Deploy and wait up to 15 min for analysis.
 
 ## Placement Status
 


### PR DESCRIPTION
## Summary

- Clarify ambiguous phrasing: 'runs at edge during analysis' → 'runs at edge until analysis completes'
- Remove redundant sentence 'Check status via API or dashboard' (the Status Check section immediately follows)
- Rename `## CLI` → `## Status Check` for better scannability and alignment with section content

## What

Prose tightening of `.agents/services/hosting/cloudflare-platform-skill/smart-placement.md` (67 lines). No content removed — only clarity improvements and removal of one genuinely redundant sentence.

## Issue

Closes #16272

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/smart-placement.md` — 3 line changes

## Testing

<!-- MERGE_SUMMARY -->
**Risk:** Low — docs-only change, no code or agent logic modified.

**Verification:** All code blocks, URLs, TypeScript type definition, CLI commands, and See Also links preserved. `wc -l` unchanged at 67 lines.

**Classification:** Instruction doc (not reference corpus) — prose tightening is appropriate per `code-simplifier.md` "Safe (high confidence)" category.

## Runtime Testing

`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.809 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Clarified Cloudflare Workers Smart Placement documentation regarding the timing of analysis completion relative to edge execution.
- Reorganized status monitoring guidance with improved section structure for better discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->