### PR TITLE
GH#16293: tighten workers-patterns.md (141→139 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5117,5 +5117,13 @@
       "status": "simplified",
       "issue": 16257
     }
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/workers-patterns.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "4a94ab9f82abafc568298f41f4913b4e504b962f651338f6dbb20a6fecc984cc",
+    "issue": "GH#16293",
+    "lines_before": 141,
+    "lines_after": 139,
+    "action": "tightened"
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md
@@ -107,7 +107,7 @@ For `wrangler deploy` and environment-specific deploys, see [workers.md](./worke
 ## Monitoring
 
 ```typescript
-// Analytics Engine — track latency and status per request
+// Track latency and status via Analytics Engine
 const start = Date.now();
 const response = await handleRequest(request, env);
 ctx.waitUntil(env.ANALYTICS.writeDataPoint({
@@ -118,10 +118,8 @@ ctx.waitUntil(env.ANALYTICS.writeDataPoint({
 ## Security
 
 ```typescript
-// Security headers
 const security = { 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'DENY', 'Content-Security-Policy': "default-src 'self'" };
 
-// Bearer auth
 const auth = request.headers.get('Authorization');
 if (!auth?.startsWith('Bearer ')) return new Response('Unauthorized', { status: 401 });
 ```


### PR DESCRIPTION
## Summary

- Remove redundant `// Security headers` and `// Bearer auth` "what" comments — variable names (`security`, `auth`) are self-documenting
- Consolidate `// Analytics Engine — track latency and status per request` → `// Track latency and status via Analytics Engine` (preserves binding reference, removes redundant "what" framing)
- All other comments retained: `// ReadableStream — yield control...` (why), `// Hash-based feature flag — deterministic per user` (why), `// Sequential (slow)` / `// Parallel (fast)` (performance labels), `// Transform pipeline` (structural navigation)

Closes #16293

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/workers-patterns.md` — 141→139 lines
- `.agents/configs/simplification-state.json` — updated hash registry

## Runtime Testing

**Risk level:** Low — agent doc (markdown), no executable code changed.
**Verification:** All code blocks, URLs, cross-references (`workers.md`, `workers-gotchas.md`, `durable-objects-patterns.md`), and task ID refs present before and after. Line count: 141→139 (2 lines removed).

<!-- MERGE_SUMMARY -->
**What:** Tighten workers-patterns.md by removing redundant "what" inline comments in Security and Monitoring sections.
**Issue:** Closes #16293
**Files changed:** 2 (workers-patterns.md, simplification-state.json)
**Testing:** Self-assessed (low risk — doc-only change, no executable code)
**Key decisions:** Kept all "why" comments and structural navigation comments; only removed pure "what" labels where variable names are self-documenting.

---
[aidevops.sh](https://aidevops.sh) v3.5.809 plugin for [OpenCode](https://opencode.ai) v1.3.13