### PR TITLE
GH#16294: tighten cloudron-git-reference.md (110→99 lines)

### DIFF
--- a/.agents/tools/deployment/cloudron-git-reference.md
+++ b/.agents/tools/deployment/cloudron-git-reference.md
@@ -1,6 +1,6 @@
 ---
 description: Reference guide for using git.cloudron.io to study Cloudron app packaging patterns
-mode: subagent
+mode: reference
 tools:
   read: true
   bash: true
@@ -9,7 +9,7 @@ tools:
 
 # Using git.cloudron.io as Reference
 
-https://git.cloudron.io/ — authoritative source for real-world Cloudron packaging patterns (200+ official app packages).
+https://git.cloudron.io/ — 200+ official Cloudron app packages; authoritative source for real-world packaging patterns.
 
 ## Recommended Reference Apps
 
@@ -53,12 +53,7 @@ In any reference package:
 
 All topics: https://git.cloudron.io/explore/projects/topics
 
-**Common patterns to search for**:
-- `gosu cloudron:cloudron` — privilege dropping
-- `ln -sfn /app/data` — symlink patterns for writable paths
-- `CLOUDRON_POSTGRESQL_` — database configuration
-- `supervisord.conf` — multi-process setup
-- `envsubst` — template-based config injection
+**Common patterns**: `gosu cloudron:cloudron` (privilege drop) · `ln -sfn /app/data` (writable symlinks) · `CLOUDRON_POSTGRESQL_` (DB config) · `supervisord.conf` (multi-process) · `envsubst` (config templating)
 
 ## Repository Groups
 
@@ -85,25 +80,19 @@ git sparse-checkout set start.sh Dockerfile CloudronManifest.json
 ## GitLab API
 
 ```bash
-# List all packages group projects
+# List all packages
 curl -s "https://git.cloudron.io/api/v4/groups/packages/projects?per_page=100"
 
-# Search projects by topic
+# Filter by topic
 curl -s "https://git.cloudron.io/api/v4/projects?topic=php&per_page=20"
-
-# Find apps using supervisord
 curl -s "https://git.cloudron.io/api/v4/projects?topic=supervisor"
-
-# Find apps with proxyAuth (Cloudron handles auth)
 curl -s "https://git.cloudron.io/api/v4/projects?topic=proxyAuth"
 
-# Get repository file tree
+# File tree and raw content
 curl -s "https://git.cloudron.io/api/v4/projects/packages%2Fghost-app/repository/tree"
-
-# Get raw file content
 curl -s "https://git.cloudron.io/api/v4/projects/packages%2Fghost-app/repository/files/start.sh/raw?ref=master"
 
-# Search for code patterns across repos (requires auth for some endpoints)
+# Code search within a repo (auth required for some endpoints)
 curl -s "https://git.cloudron.io/api/v4/projects/packages%2Fghost-app/search?scope=blobs&search=supervisord"
 
 # Browse recently updated: https://git.cloudron.io/explore/projects?sort=latest_activity_desc


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/deployment/cloudron-git-reference.md` from 110 to 99 lines (10% reduction) per simplification issue #16294.

## Classification
**Reference corpus** (not instruction doc) — domain knowledge base with tables, URLs, and code examples. Per issue guidance: do not compress content; tighten prose only.

## Changes
- Fix frontmatter `mode: subagent` → `mode: reference` (correct type for a reference corpus)
- Consolidate 5-item "Common patterns" bullet list into single inline line (saves 5 lines, same information)
- Merge redundant GitLab API section comments — grouped related curl commands under shared headings (saves 6 lines)
- Tighten intro line (reorder for scannability, same content)

## Verification
- All URLs preserved: git.cloudron.io links, API endpoints, topic URLs
- All code blocks intact: git clone, sparse checkout, curl commands
- All table rows preserved: 10 reference apps, 9 technology topics, 6 repository groups, 6 key files
- Zero content loss — only prose/comment compression

## Runtime Testing
Risk: **Low** (docs-only change, no code). Self-assessed per runtime testing gate.

## Files Changed
- `.agents/tools/deployment/cloudron-git-reference.md` (110→99 lines)

Closes #16294


---
[aidevops.sh](https://aidevops.sh) v3.5.809 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6