### PR TITLE
GH#16318: tighten orbstack.md agent doc (92→68 lines)

### DIFF
--- a/.agents/tools/containers/orbstack.md
+++ b/.agents/tools/containers/orbstack.md
@@ -29,7 +29,7 @@ tools:
 
 ## Core Commands
 
-Standard `docker` and `docker compose` commands work unchanged. Use `orb` for OrbStack-specific management:
+`docker` and `docker compose` commands work unchanged. Use `orb` for OrbStack-specific management:
 
 ```bash
 orb list                          # List containers and VMs
@@ -50,35 +50,11 @@ orb stop / orb start my-ubuntu    # Stop / start VM
 orb delete my-ubuntu              # Delete VM
 ```
 
-## OpenClaw Workflows
-
-```bash
-# Setup
-git clone https://github.com/openclaw/openclaw.git && cd openclaw
-./docker-setup.sh                 # Build image, run onboarding, start gateway
-open http://127.0.0.1:18789/      # Access Control UI
-
-# Routine management
-docker compose ps                                     # Status
-docker compose logs -f openclaw-gateway               # Logs
-docker compose restart openclaw-gateway               # Restart gateway
-docker compose run --rm openclaw-cli doctor           # Health check
-docker compose run --rm openclaw-cli security audit   # Security audit
-docker compose run --rm openclaw-cli channels login   # Channel setup
-```
-
-Persistent host data: `~/.openclaw/{openclaw.json,workspace,credentials/,agents/<agentId>/sessions/}`
-
 ## Common Use Cases
 
 ```bash
 # Isolated dev database (postgres.orb.local or localhost:5432)
 docker run -d --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=dev postgres:16
-
-# OpenClaw sandbox images for agent-tool isolation
-scripts/sandbox-setup.sh           # Base sandbox
-scripts/sandbox-common-setup.sh    # Adds build tools
-scripts/sandbox-browser-setup.sh   # Adds Chromium
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/containers/orbstack.md` from 92 to 68 lines (26% reduction) by removing project-specific content that doesn't belong in a general OrbStack agent doc.

## Issue
Closes #16318

## Files Changed
- `.agents/tools/containers/orbstack.md` — 92→68 lines

## Changes
- **Removed**: OpenClaw Workflows section (18 lines) — project-specific `docker compose` commands for a third-party tool; these are not OrbStack-specific and belong in an OpenClaw-specific doc if needed
- **Removed**: OpenClaw sandbox script references from Common Use Cases (3 lines) — same reason
- **Preserved**: All OrbStack-specific content — Quick Reference, Core Commands, Linux VMs, generic Common Use Cases (postgres example), Troubleshooting, destructive ops warning
- **Tightened**: Core Commands intro prose (minor)

## Testing
- Self-assessed (Low risk: docs-only change)
- All code blocks, URLs, command examples verified present after edit
- No broken internal links or references

## Key Decisions
The OpenClaw section was added as project-specific convenience content but violates the principle that agent docs should be focused on their named tool. Any project-specific docker compose workflows belong in a project-specific doc, not in the OrbStack agent.

---
[aidevops.sh](https://aidevops.sh) v3.5.810 plugin for [OpenCode](https://opencode.ai) v1.3.13