### PR TITLE
GH#16319: tighten playwright benchmark scripts chapter intro

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
@@ -1,6 +1,6 @@
 # Playwright Benchmark Scripts
 
-Reference implementation for `browser-benchmark-scripts.md`. Target: `https://the-internet.herokuapp.com`. Tests: `navigate`, `formFill`, `extract`, `multiStep` — 3 runs each, median reported.
+Sequential and parallel Playwright benchmark scripts. Target: `https://the-internet.herokuapp.com`. See [`browser-benchmark-scripts.md`](browser-benchmark-scripts.md) for the full suite index.
 
 ## Sequential script
 


### PR DESCRIPTION
## Summary

Tighten the intro line of `.agents/tools/browser/browser-benchmark-scripts-01-playwright.md` (GH#16319).

**Classification:** Reference corpus chapter — already appropriately structured at 91 lines. Code blocks cannot be compressed.

**Change:** Replace verbose intro that enumerated test names (redundant with code) with a descriptive summary and proper markdown hyperlink to the parent index.

- Before: `Reference implementation for 'browser-benchmark-scripts.md'. Target: '...'. Tests: 'navigate', 'formFill', 'extract', 'multiStep' — 3 runs each, median reported.`
- After: `Sequential and parallel Playwright benchmark scripts. Target: '...'. See [browser-benchmark-scripts.md](browser-benchmark-scripts.md) for the full suite index.`

## Verification

- All code blocks preserved (sequential + parallel scripts intact)
- All URLs preserved (`https://the-internet.herokuapp.com`)
- No task IDs or incident references in this file — none to preserve
- Line count: 91 (unchanged — intro line same length)
- Parent index (`browser-benchmark-scripts.md`) unchanged

## Runtime Testing

**Risk level:** Low — docs/formatting only, no code execution paths affected.
**Assessment:** self-assessed

Closes #16319

---
[aidevops.sh](https://aidevops.sh) v3.5.810 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6