### PR TITLE
GH#16321: tighten realtime-sfu-gotchas.md, promote Security section to top

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md
@@ -1,5 +1,20 @@
 # Gotchas & Troubleshooting
 
+## Security
+
+❌ Never expose App Secret client-side (use backend env vars, Wrangler secrets)
+Track IDs = capabilities, authz required:
+
+```ts
+app.post('/api/sessions/:sid/tracks', async (req, res) => {
+  for (const t of req.body.tracks)
+    if (!await canAccessTrack(req.user.id, t.trackName)) return res.status(403).json({error: 'Unauth'});
+  // CF API call
+});
+```
+
+Validate session ownership, timeouts, cleanup abandoned sessions.
+
 ## Common Issues
 
 **Slow connect (~1.8s):** First STUN delayed (consensus forming), normal, subsequent faster
@@ -38,21 +53,6 @@ setInterval(async () => {
   });
 }, 1000);
 ```
-
-## Security
-
-❌ Never expose App Secret client-side (use backend env vars, Wrangler secrets)
-Track IDs = capabilities, authz required:
-
-```ts
-app.post('/api/sessions/:sid/tracks', async (req, res) => {
-  for (const t of req.body.tracks)
-    if (!await canAccessTrack(req.user.id, t.trackName)) return res.status(403).json({error: 'Unauth'});
-  // CF API call
-});
-```
-
-Validate session ownership, timeouts, cleanup abandoned sessions.
 
 ## Pricing & Limits
 


### PR DESCRIPTION
## Summary

- Reorders sections by importance: Security promoted to top (primacy effect — LLMs weight earlier context more heavily; security rules are the most critical instruction)
- All content preserved, zero knowledge loss
- File remains 83 lines (already compact; no prose warranted removal)

## Verification

- All code blocks, URLs, and command examples present before and after
- No broken internal links or references
- `wc -l` unchanged at 83 lines

Closes #16321

---
[aidevops.sh](https://aidevops.sh) v3.5.810 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6