### PR TITLE
GH#16320: tighten queues-gotchas.md — merge ordering note, clarify jsonc context

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5125,5 +5125,12 @@
     "lines_before": 141,
     "lines_after": 139,
     "action": "tightened"
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "5df3a339524d800afe6cc2148b7a71c5f898d396d92d30e3949b522955a525a2",
+    "issue": "GH#16320",
+    "lines_before": 89,
+    "lines_after": 88
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
@@ -4,7 +4,7 @@ See [queues.md](./queues.md), [queues-patterns.md](./queues-patterns.md).
 
 ## Delivery Semantics
 
-Queues are at-least-once. Design for idempotency — ack only after durable success.
+Queues are at-least-once; no ordering guarantee. Design for idempotency — ack only after durable success.
 
 ```typescript
 const processed = await env.PROCESSED_KV.get(msg.id);
@@ -13,8 +13,6 @@ await processMessage(msg.body);
 await env.PROCESSED_KV.put(msg.id, '1', { expirationTtl: 86400 });
 msg.ack();
 ```
-
-❌ Don't rely on message ordering.
 
 ## Content Type
 
@@ -42,6 +40,7 @@ async queue(batch: MessageBatch): Promise<void> {
 ```
 
 ```jsonc
+// wrangler.toml [limits]
 { "limits": { "cpu_ms": 300000 } } // 5 minutes
 ```
 
@@ -49,10 +48,10 @@ Log failures with enough context to replay or diagnose. Configure a DLQ for perm
 
 ## Cost and Throughput
 
-Each message = 3 ops (write + read + delete). Retries add reads. Cost beyond free tier: `((messages × 3) - 1M) / 1M × $0.40`.
+Each message = 3 ops (write + read + delete). Retries add reads. Cost beyond free tier: `((messages × 3) - 1M) / 1M × $0.40`. Keep messages <64 KB (charged per 64 KB chunk).
 
-```typescript
-// Keep messages <64 KB (charged per 64 KB chunk)
+```jsonc
+// wrangler.toml [queues.consumers]
 { "max_batch_size": 100, "max_batch_timeout": 30 }
 ```
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md` (89 → 88 lines) per GH#16320.

**Changes:**
- Merged standalone `❌ Don't rely on message ordering.` line into Delivery Semantics prose: "Queues are at-least-once; no ordering guarantee."
- Moved `<64 KB` note inline into Cost prose, removing a comment-only code block
- Added `wrangler.toml` context comments to both `jsonc` blocks for clarity (previously looked like TypeScript)

**Classification:** Instruction doc (not reference corpus) — prose tightening is correct action.

## Issue
Closes #16320

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md` — tightened
- `.agents/configs/simplification-state.json` — state updated with new hash

## Testing
- All code blocks, URLs, and command examples preserved
- No broken internal links (cross-refs to `queues.md`, `queues-patterns.md` intact)
- Agent behaviour unchanged — all operational rules present

## Runtime Testing
**Risk level:** Low (docs/agent prompts only)
**Verification:** `self-assessed` — no runtime environment needed for doc changes

---
[aidevops.sh](https://aidevops.sh) v3.5.811 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6