### PR TITLE
GH#15142: tighten agent doc Cloudflare Code Mode MCP

### DIFF
--- a/.agents/tools/api/cloudflare-mcp.md
+++ b/.agents/tools/api/cloudflare-mcp.md
@@ -24,6 +24,7 @@ tools:
 - **Setup**: `aidevops/mcp-integrations.md` → Cloudflare Code Mode MCP
 - **Platform reference**: `services/hosting/cloudflare-platform-skill.md`
 - **Capabilities**: Workers, D1, KV, R2, Pages, AI Gateway, DNS, Analytics
+- **Per-agent**: Set `cloudflare-api_*: true` in subagent frontmatter (disabled globally, enabled per agent)
 
 <!-- AI-CONTEXT-END -->
 
@@ -37,7 +38,7 @@ tools:
 
 ## Auth Setup
 
-OAuth 2.0; first tool call opens `dash.cloudflare.com` for authorization.
+First tool call opens `dash.cloudflare.com` for OAuth 2.0 authorization.
 
 **Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`)
 
@@ -51,13 +52,11 @@ OAuth 2.0; first tool call opens `dash.cloudflare.com` for authorization.
 { "mcp": { "cloudflare-api": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp" } } }
 ```
 
-**Claude Code CLI**
+**Claude Code CLI** (`--transport http` is required even with HTTPS endpoint)
 
 ```bash
 claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp
 ```
-
-`--transport http` is the MCP transport type; keep it even with an HTTPS endpoint.
 
 ## Usage Patterns
 
@@ -84,10 +83,6 @@ WHERE date >= date('now', '-7 days') GROUP BY date ORDER BY date DESC
 # Sync to R2
 Upload all files in ./dist/ to R2 "static-assets" under prefix "v2.1.0/". List to confirm.
 ```
-
-## Per-Agent Enablement
-
-Set `cloudflare-api_*: true` in subagent frontmatter. The server stays disabled globally and enabled per agent.
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/api/cloudflare-mcp.md` per issue #15142 (automated simplification scan).

**Classification**: Instruction doc (agent rules, config setup, usage patterns) — not a reference corpus.

**Changes (97 → 92 lines):**
- Fold `## Per-Agent Enablement` section into Quick Reference bullet (saves 4 lines, same discoverability)
- Move `--transport http` note inline with the Claude Code CLI heading (saves 2 lines, note preserved)
- Minor prose tightening in Auth Setup intro

**Verification:**
- All code blocks present: 3 JSON blocks + 1 bash block + 1 text block ✓
- All URLs preserved: `https://mcp.cloudflare.com/mcp`, `dash.cloudflare.com` ✓
- All command examples preserved ✓
- No task IDs or incident references in this file ✓
- Agent behaviour unchanged — same config, same capabilities ✓

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution paths.
Assessment: `self-assessed` — no runtime environment needed.

Closes #15142

---
[aidevops.sh](https://aidevops.sh) v3.5.813 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Cloudflare MCP enablement options and per-subagent configuration requirements.
  * Updated authorization setup wording for improved clarity.
  * Added explicit note about CLI transport requirements.
  * Reorganized documentation structure for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->