### PR TITLE
GH#16348: tighten xcodebuild-mcp.md MCP config section (81→70 lines)

### DIFF
--- a/.agents/tools/mobile/xcodebuild-mcp.md
+++ b/.agents/tools/mobile/xcodebuild-mcp.md
@@ -52,23 +52,12 @@ Only simulator tools enabled by default. Use `manage-workflows` to enable other 
 
 ## MCP Configuration
 
-**Claude Code:**
+**Claude Code:** `claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@beta mcp`
 
-```bash
-claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@beta mcp
-```
-
-**JSON (Cursor, VS Code, Claude Desktop, OpenCode):**
+**JSON** (Cursor, VS Code, Claude Desktop, OpenCode):
 
 ```json
-{
-  "mcpServers": {
-    "XcodeBuildMCP": {
-      "command": "npx",
-      "args": ["-y", "xcodebuildmcp@beta", "mcp"]
-    }
-  }
-}
+{ "mcpServers": { "XcodeBuildMCP": { "command": "npx", "args": ["-y", "xcodebuildmcp@beta", "mcp"] } } }
 ```
 
 ## Related


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/mobile/xcodebuild-mcp.md` from 81 to 70 lines (14% reduction) by compressing the MCP Configuration section.

## Issue
Closes #16348

## Files Changed
- `.agents/tools/mobile/xcodebuild-mcp.md` — MCP config section condensed: Claude Code config moved to inline code, JSON config collapsed to single line

## Testing
- Content preservation verified: all tool names, URLs, code examples, workflow steps, and related links present before and after
- No broken internal links or references
- Agent behaviour unchanged — reference data intact

## Key Decisions
- File classified as **instruction doc** (not reference corpus) — prose compression appropriate
- MCP Configuration section was the only meaningful compression target; other sections (workflow, tool groups table, related) were already optimal
- JSON config collapsed to single line — valid JSON, readable for copy-paste use

## Runtime Testing
Risk: **Low** — docs-only change, no code paths affected. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.814 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6