### PR TITLE
GH#16350: tighten Refactor Probes doc to code-block format

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5132,5 +5132,10 @@
     "issue": "GH#16320",
     "lines_before": 89,
     "lines_after": 88
+  },
+  ".agents/reference/define-probes/refactor.md": {
+    "hash": "1eb86f1e0b8873942014f1f20414250077bd694a254e6e97537e706199b2460a",
+    "status": "simplified",
+    "issue": "GH#16350"
   }
 }

--- a/.agents/reference/define-probes/refactor.md
+++ b/.agents/reference/define-probes/refactor.md
@@ -16,54 +16,75 @@ Use 2 probes from this file during `/define` for tasks classified as **refactor*
 
 ## Required Questions
 
-**Primary Goal** — What's the main reason for this refactor?
+### Primary Goal
 
+```text
+What's the main reason for this refactor?
 1. Readability — code is hard to understand or maintain (recommended)
 2. Performance — current implementation is too slow
 3. Extensibility — need to add features and current structure blocks it
 4. Duplication — same logic exists in multiple places
 5. Let me explain
+```
 
-**Scope Boundary** — How far should this refactor go?
+### Scope Boundary
 
+```text
+How far should this refactor go?
 1. Minimal — only the specific file/function mentioned (recommended)
 2. Module-level — refactor the entire module for consistency
 3. Cross-cutting — follow the pattern change across the codebase
 4. Let me specify the boundary
+```
 
 ## Probes (select 2)
 
-**Behaviour Preservation** — How will you verify that behaviour hasn't changed?
+### Behaviour Preservation
 
+```text
+How will you verify that behaviour hasn't changed?
 1. Existing tests cover it — they must all pass (recommended)
 2. No tests exist — I'll add them before refactoring
 3. Manual testing against specific scenarios
 4. Type system / compiler will catch regressions
+```
 
-**Outside View** — Refactors of this scope in this codebase typically follow [detected pattern]. Should this refactor:
+### Outside View
 
+```text
+Refactors of this scope in this codebase typically follow [detected pattern]. Should this refactor:
 1. Follow the same approach (recommended — consistency)
 2. Establish a new pattern — here's why: [user explains]
 3. I'm not sure what the existing pattern is
+```
 
-**Pre-mortem** — Refactor is merged and something breaks in production. Most likely cause?
+### Pre-mortem
 
+```text
+Refactor is merged and something breaks in production. Most likely cause?
 1. A code path that wasn't covered by tests (recommended)
 2. Subtle behaviour change in edge cases
 3. Performance regression under load
 4. Downstream consumers that depend on internal implementation details
+```
 
-**Assumption Surfacing** — This refactor should NOT change the public API / interface. Correct?
+### Assumption Surfacing
 
+```text
+This refactor should NOT change the public API / interface. Correct?
 1. Correct — internal changes only (recommended)
 2. No — the API should change too (this might be a feature, not a refactor)
 3. The API can change if callers are updated in the same PR
+```
 
-**Domain Grounding** — The [language/framework] community typically recommends [pattern] for this kind of restructuring. Does that apply here?
+### Domain Grounding
 
+```text
+The [language/framework] community typically recommends [pattern] for this kind of restructuring. Does that apply here?
 1. Yes — follow the standard approach (recommended)
 2. Partially — adapt it because [reason]
 3. No — this codebase has its own conventions
+```
 
 ## Sufficiency Test
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Restructure `.agents/reference/define-probes/refactor.md` to use code-block option format, consistent with the `bugfix.md` sibling file in the same directory.

## Issue
Closes #16350

## Files Changed
- `.agents/reference/define-probes/refactor.md` — restructured probe options into `\`\`\`text` code blocks with `###` subheadings; all content preserved
- `.agents/configs/simplification-state.json` — updated hash registry for this file

## Testing
- **Risk level**: Low (docs/agent prompts only — no code execution paths)
- **Lint**: `markdownlint-cli2` — 0 errors (down from 14 in intermediate draft)
- **Content preservation**: `diff` verified all options, questions, and probe text present before and after
- **Self-assessed**: No runtime testing required for agent doc restructuring

## Key Decisions
- Used `###` subheadings + `\`\`\`text` code blocks to match `bugfix.md` pattern (established sibling convention)
- Zero content removed — all 5 probes, 2 required questions, default assumptions, and sufficiency test preserved
- Fixed lint violations in new version (MD022, MD031) that exist in `bugfix.md` but were not introduced here

---
[aidevops.sh](https://aidevops.sh) v3.5.814 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6