### PR TITLE
GH#16353: tighten headline testing checklist doc

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-checklists-headline-testing.md
+++ b/.agents/marketing-sales/direct-response-copy-checklists-headline-testing.md
@@ -27,28 +27,21 @@
 
 ## Evaluation Criteria
 
-- **Clarity:** Understood in 5 seconds
-- **Benefit:** Clear "what's in it for me"
-- **Specificity:** Concrete numbers/results; avoid "better," "easier," "more"
-- **Believability:** Plausible to a skeptic; no hype
-- **Curiosity:** Creates interest without hiding the offer
-- **Audience fit:** Target customer sees themselves in it
+- **Clarity:** Understood in 5 seconds; target customer sees themselves in it
+- **Benefit:** Clear "what's in it for me"; concrete numbers/results — avoid "better," "easier," "more"
+- **Believability:** Plausible to a skeptic; creates curiosity without hiding the offer
 
 ## Red Flags
 
-- [ ] Vague: "Improve your business"
-- [ ] Clever: wordplay hurting clarity
-- [ ] Long: >15 words
-- [ ] Hypey: "Revolutionary," "Game-changing," "Breakthrough"
-- [ ] Features-only: No payoff
-- [ ] Me-focused: "We're excited to announce..."
-- [ ] Clickbait: promise exceeds delivery
+- [ ] Vague ("Improve your business") or clever (wordplay hurting clarity)
+- [ ] Long (>15 words) or hypey ("Revolutionary," "Game-changing," "Breakthrough")
+- [ ] Features-only (no payoff), me-focused ("We're excited to..."), or clickbait (promise > delivery)
 
 ## Quick Tests
 
-- **5-second test:** "What is this offering and who is it for?"
+- **5-second test:** What is this offering and who is it for?
 - **Would I click?** Imagine beside 10 competing posts.
-- **So what?** "Why should I care?"
+- **So what?** Why should I care?
 
 ## A/B Testing
 
@@ -58,12 +51,14 @@
 
 ## Improvement Tactics
 
-1. **Add specificity:** "Grow list" → "Grow list to 10,000 in 90 days"
-2. **Add urgency:** "Learn copy" → "Learn copy before competitors do"
-3. **Address objection:** "Get fit" → "Get fit without giving up favorite foods"
-4. **Make it personal:** "Improve sales" → "Improve YOUR sales this quarter"
-5. **Add proof:** "Increase conversions" → "Increase conversions 47% (like 500+ others)"
-6. **Open curiosity gap:** "SEO tips" → "The SEO trick that doubled my traffic"
+| Weak | Strong |
+|------|--------|
+| "Grow list" | "Grow list to 10,000 in 90 days" (specificity) |
+| "Learn copy" | "Learn copy before competitors do" (urgency) |
+| "Get fit" | "Get fit without giving up favorite foods" (objection) |
+| "Improve sales" | "Improve YOUR sales this quarter" (personal) |
+| "Increase conversions" | "Increase conversions 47% (like 500+ others)" (proof) |
+| "SEO tips" | "The SEO trick that doubled my traffic" (curiosity gap) |
 
 ## Final Selection
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/marketing-sales/direct-response-copy-checklists-headline-testing.md` per simplification scan (GH#16353).

## Changes
- **Evaluation Criteria**: merged 6 bullet points into 3 (combined related items: clarity+audience fit, benefit+specificity, believability+curiosity)
- **Red Flags**: merged 7 checklist items into 3 grouped lines (vague/clever, long/hypey, features/me-focused/clickbait)
- **Improvement Tactics**: converted numbered list with inline examples to a compact before/after table
- **Quick Tests**: removed redundant quotes around rhetorical questions

## Content Preservation
All formulas, 4 U's scorecard, A/B testing metrics, and improvement examples preserved verbatim. 73→68 lines.

## Testing
- `markdownlint-cli2`: 0 errors
- Risk: **Low** (docs-only change, no code, no agent behaviour change)
- Runtime testing: `self-assessed` (doc-only, no executable logic)

## Runtime Testing
**Risk level:** Low — agent prompt/doc only, no executable logic changed.
**Verification:** markdownlint-cli2 passed, content diff reviewed manually.

Closes #16353

---
[aidevops.sh](https://aidevops.sh) v3.5.814 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6