### PR TITLE
GH#16354: tighten research probes doc header labels

### DIFF
--- a/.agents/reference/define-probes/research.md
+++ b/.agents/reference/define-probes/research.md
@@ -7,14 +7,14 @@ mode: subagent
 
 Use 2 probes during `/define` for tasks classified as **research**.
 
-## Defaults (apply unless overridden)
+## Defaults
 
 - Time-boxed — research without a deadline expands indefinitely
 - Deliverable is a written recommendation, not code
 - Compare at least 2 options before recommending one
 - Include cost or effort estimates for each option
 
-## Required Questions (always ask both)
+## Required Questions (ask both)
 
 **Time Box** — How much time should be spent on this research?
 1. 30 minutes — quick comparison (recommended for simple evaluations)
@@ -28,7 +28,7 @@ Use 2 probes during `/define` for tasks classified as **research**.
 3. Decision document for team review
 4. Just a verbal summary in this conversation
 
-## Probes (select 2)
+## Probes (pick 2)
 
 **Decision Criteria** — What matters most when choosing between options?
 1. Cost (monetary or compute) (recommended if comparing services/tools)


### PR DESCRIPTION
## Summary

Tightens section header labels in `.agents/reference/define-probes/research.md` by removing redundant parentheticals that restate what is already clear from context.

**Changes:**
- `Defaults (apply unless overridden)` → `Defaults`
- `Required Questions (always ask both)` → `Required Questions (ask both)`
- `Probes (select 2)` → `Probes (pick 2)`

All probe content, numbered options, `(recommended)` annotations, and the Sufficiency Test are fully preserved. Line count unchanged (72) — the file was already at minimum; the content is structured data (numbered option lists) that cannot be compressed without information loss.

Closes #16354

## Runtime Testing

**Risk level:** Low — agent doc, no code, no commands, no URLs, no task ID refs.
**Verification:** All 6 `(recommended)` annotations present, all 5 probes present, Sufficiency Test intact.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten 3 section header labels in research probes doc
**Issue:** #16354
**Files changed:** `.agents/reference/define-probes/research.md`
**Testing:** Content preservation verified — all options, recommendations, and sufficiency test intact
**Key decisions:** File is already minimal; only header prose tightened, no content removed

---
[aidevops.sh](https://aidevops.sh) v3.5.814 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6