### PR TITLE
GH#16371: tighten prose in nothing-design-skill/tokens.md

### DIFF
--- a/.agents/tools/ui/nothing-design-skill/tokens.md
+++ b/.agents/tools/ui/nothing-design-skill/tokens.md
@@ -10,7 +10,7 @@
 | **Body / UI** | `"Space Grotesk"` | `"DM Sans", system-ui, sans-serif` | Light 300, Regular 400, Medium 500, Bold 700 |
 | **Data / Labels** | `"Space Mono"` | `"JetBrains Mono", "SF Mono", monospace` | Regular 400, Bold 700 |
 
-Doto = variable dot-matrix (closest to NDot 57). Space Grotesk + Space Mono by Colophon Foundry — same foundry as Nothing's actual typefaces.
+Doto = variable dot-matrix (closest to NDot 57). Space Grotesk + Space Mono: Colophon Foundry — same foundry as Nothing's actual typefaces.
 
 ### Type Scale
 
@@ -63,7 +63,7 @@ Doto = variable dot-matrix (closest to NDot 57). Space Grotesk + Space Mono by C
 | `--info` | `#999999` | Uses secondary text color |
 | `--interactive` | `#007AFF` / `#5B9BF6` | Tappable text: links, picker values. Not for buttons. |
 
-Data status: `--success` = good/in range, `--warning` = moderate/attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply color to **value**, not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
+Data status: `--success` = good, `--warning` = attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply color to **value**, not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
 
 ### Dark / Light Mode
 
@@ -80,10 +80,9 @@ Data status: `--success` = good/in range, `--warning` = moderate/attention, `--a
 | `--text-display` | `#FFFFFF` | `#000000` |
 | `--interactive` | `#5B9BF6` | `#007AFF` |
 
-Identical across modes: Accent red, status colors, ALL CAPS labels, fonts, type scale, spacing, component shapes.
+Identical across modes: accent red, status colors, ALL CAPS labels, fonts, type scale, spacing, component shapes.
 
-Dark: Instrument panel in a dark room — OLED black, white data glowing.
-Light: Printed technical manual — off-white paper (#F5F5F5), black ink. Cards = `#FFFFFF` on off-white = subtle elevation without shadows.
+Dark: OLED black, white data glowing (instrument panel). Light: off-white paper (#F5F5F5), black ink; cards `#FFFFFF` = subtle elevation without shadows.
 
 ---
 


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/tools/ui/nothing-design-skill/tokens.md` per GH#16371.

**Classification:** Reference corpus (design tokens, CSS values, type scales). File is 141 lines — already compact, no splitting needed. Applied targeted prose compression only.

**Changes:**
- Typography: compress foundry attribution note (`by` → `:`)
- Color: shorten data status descriptions (`good/in range` → `good`, `moderate/attention` → `attention`)
- Mode descriptions: merge 2-line dark/light prose into 1 line; lowercase `Accent` → `accent`

**Preserved:** All token names, hex values, CSS snippets, contrast ratios, typographic rules, spacing scale, motion values, iconography rules, dot-matrix CSS.

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution path.
Assessment: `self-assessed` — content verified line-by-line against original.

## Files Changed

- `.agents/tools/ui/nothing-design-skill/tokens.md`: 141 → 140 lines (4 insertions, 5 deletions)

Closes #16371

---
<!-- MERGE_SUMMARY -->
**What:** Prose tightening of Nothing Design System tokens reference doc
**Issue:** #16371
**Files changed:** 1 (`.agents/tools/ui/nothing-design-skill/tokens.md`)
**Testing:** Self-assessed (docs-only change, all token values preserved)
**Key decisions:** Classified as reference corpus; prose-only compression, no splitting (141 lines is already compact)

---
[aidevops.sh](https://aidevops.sh) v3.5.818 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6