### PR TITLE
GH#16373: tighten cloudflare-mcp.md prose (92→89 lines)

### DIFF
--- a/.agents/tools/api/cloudflare-mcp.md
+++ b/.agents/tools/api/cloudflare-mcp.md
@@ -28,12 +28,12 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Security Model
+## Security
 
 - **Scopes**: Access matches Cloudflare dashboard permissions
 - **Secrets**: No tokens in config; MCP client stores OAuth token
 - **Revocation**: `dash.cloudflare.com` → My Profile → API Tokens → OAuth Apps
-- **Least privilege**: For tighter scope, use a sub-account or scoped API token; see `services/hosting/cloudflare.md`
+- **Least privilege**: Use a sub-account or scoped API token for tighter scope; see `services/hosting/cloudflare.md`
 - **Audit trail**: Actions appear in the Cloudflare audit log
 
 ## Auth Setup
@@ -41,19 +41,16 @@ tools:
 First tool call opens `dash.cloudflare.com` for OAuth 2.0 authorization.
 
 **Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`)
-
 ```json
 { "mcpServers": { "cloudflare-api": { "url": "https://mcp.cloudflare.com/mcp" } } }
 ```
 
 **OpenCode** (`~/.config/opencode/config.json`)
-
 ```json
 { "mcp": { "cloudflare-api": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp" } } }
 ```
 
-**Claude Code CLI** (`--transport http` is required even with HTTPS endpoint)
-
+**Claude Code CLI** (`--transport http` required even with HTTPS endpoint)
 ```bash
 claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp
 ```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/api/cloudflare-mcp.md` per simplification scan (GH#16373).

## Changes
- `## Security Model` → `## Security` (shorter heading, no info lost)
- Tightened "For tighter scope, use..." → active voice "Use...for tighter scope"
- Removed blank lines between config blocks (3 lines saved)
- `is required` → `required` in Claude Code CLI note

## Files Changed
- `.agents/tools/api/cloudflare-mcp.md` (92 → 89 lines, -3)

## Testing
- Self-assessed (Low risk: docs/prose only, no logic or commands changed)
- All code blocks, URLs, command examples, and config snippets preserved
- No broken internal links or references

## Runtime Testing
`self-assessed` — docs-only change, no executable code modified.

Closes #16373

---
[aidevops.sh](https://aidevops.sh) v3.5.820 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6