### PR TITLE
GH#16033: tighten workers-gotchas.md (78→68 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md
@@ -1,56 +1,46 @@
 # Workers Gotchas
 
-## Design Constraints
+## Runtime Constraints
 
 **CPU Budget:** Standard 10ms, Unbound 30ms. Use `ctx.waitUntil()` for background work, Durable Objects for heavy compute, Workers AI for ML.
 
-**No Persistent State:** Workers are stateless between requests. Module-level variables reset unpredictably — store persistent state in KV, D1, or Durable Objects.
+**No Persistent State:** Workers are stateless between requests. Module-level variables reset unpredictably — store state in KV, D1, or Durable Objects.
 
-**Response Bodies Are Streams:**
+**Response Bodies Are Streams:** Body can only be read once — clone before reuse.
 
 ```typescript
-// ❌ BAD
+// ❌ BAD — body consumed before return
 const response = await fetch(url);
-await logBody(response.text());  // First read
-return response;  // Body already consumed!
+await logBody(response.text());
+return response;
 
 // ✅ GOOD
-const response = await fetch(url);
 const text = await response.text();
 await logBody(text);
 return new Response(text, response);
 ```
 
-**No Node.js Built-ins by Default:**
+**No Node.js Built-ins by Default:** Use Workers APIs or enable compat flag.
 
 ```typescript
 // ❌ BAD
-import fs from 'fs';  // Not available
+import fs from 'fs';
 
-// ✅ GOOD - use Workers APIs
+// ✅ GOOD — Workers API
 const data = await env.MY_BUCKET.get('file.txt');
-
-// OR enable Node.js compat
-{ "compatibility_flags": ["nodejs_compat_v2"] }
+// OR: { "compatibility_flags": ["nodejs_compat_v2"] }
 ```
 
-**Fetch in Global Scope Is Forbidden:**
+**Fetch in Global Scope Is Forbidden:** Move all `fetch()` calls inside handler functions.
 
 ```typescript
-// ❌ BAD
-const config = await fetch('/config.json');  // Error!
+// ❌ BAD — top-level fetch errors at startup
+const config = await fetch('/config.json');
 
-export default {
-  async fetch() { return new Response('OK'); },
-};
-
-// ✅ GOOD
-export default {
-  async fetch() {
-    const config = await fetch('/config.json');  // OK
-    return new Response('OK');
-  },
-};
+// ✅ GOOD — fetch inside handler
+async fetch(req) {
+  const config = await fetch('/config.json');
+}
 ```
 
 ## Runtime Limits

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.822"
+    "version": "3.5.823"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.822
+# Version: 3.5.823
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.822.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.823.tar.gz"
   sha256 "a04cfc74c44d39ac8d765ab847145a8e891cd5929de2f451ad577be3e5fb52f5"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.822",
+  "version": "3.5.823",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.822
+# Version: 3.5.823
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.822
+sonar.projectVersion=3.5.823
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
## Summary

Tighten `workers-gotchas.md` from 78 → 68 lines (instruction doc, not reference corpus).

**Changes:**
- Rename section `Design Constraints` → `Runtime Constraints` (more accurate)
- Add inline summary sentence before each code block (reduces need to read full example to understand the rule)
- Condense `Response Bodies Are Streams` example: remove redundant variable declaration
- Condense `No Node.js Built-ins` example: collapse compat flag to inline comment
- Condense `Fetch in Global Scope` example: remove repeated `export default` wrapper boilerplate

**Preserved:** All ❌/✅ code patterns, runtime limits table, common errors table, all task IDs and references.

## Runtime Testing

Risk: **Low** — docs-only change, no code execution paths affected. `self-assessed`.

Closes #16033

---
[aidevops.sh](https://aidevops.sh) v3.5.823 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6