### PR TITLE
GH#16035: tighten agent-skills.md - remove redundant prose

### DIFF
--- a/.agents/tools/deployment/agent-skills.md
+++ b/.agents/tools/deployment/agent-skills.md
@@ -32,8 +32,6 @@ tools:
 
 ## SKILL.md Layout
 
-Each skill directory contains:
-
 ```text
 skill-name/
   SKILL.md       # Instructions for the agent (required)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.822"
+    "version": "3.5.823"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.822
+# Version: 3.5.823
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.822.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.823.tar.gz"
   sha256 "a04cfc74c44d39ac8d765ab847145a8e891cd5929de2f451ad577be3e5fb52f5"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.822",
+  "version": "3.5.823",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.822
+# Version: 3.5.823
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.822
+sonar.projectVersion=3.5.823
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
## Summary

- Removes redundant "Each skill directory contains:" prose line from `SKILL.md Layout` section — the code block is self-explanatory and the label adds no information
- 76 → 74 lines; zero content loss

## What

Tightened `.agents/tools/deployment/agent-skills.md` per `build-agent.md` guidance. Classified as instruction doc (not reference corpus). Applied "remove decorative noise" principle from `code-simplifier.md`.

## Verification

- All code blocks, URLs, command examples, and institutional knowledge preserved
- `markdownlint-cli2`: 0 errors
- Diff: 2 lines removed (prose label + blank line)

## Runtime Testing

Risk: **Low** — docs-only change, no agent behaviour affected. `self-assessed`.

Closes #16035

---
[aidevops.sh](https://aidevops.sh) v3.5.823 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6