### PR TITLE
GH#16370: fix shellcheck violations in anti-detect-helper.sh

### DIFF
--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -12,6 +12,7 @@ VENV_DIR="$HOME/.aidevops/anti-detect-venv"
 # shellcheck disable=SC2034
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 show_help() {
@@ -117,6 +118,7 @@ setup_camoufox() {
 	fi
 
 	# Install camoufox + browserforge
+	# shellcheck source=/dev/null
 	source "$VENV_DIR/bin/activate"
 	pip install --quiet --upgrade camoufox browserforge 2>/dev/null || {
 		echo -e "${YELLOW}Warning: pip install failed. Trying with --break-system-packages...${NC}"
@@ -615,6 +617,7 @@ launch_camoufox() {
 	local url="$3"
 	local disposable="$4"
 
+	# shellcheck source=/dev/null
 	source "$VENV_DIR/bin/activate" 2>/dev/null || {
 		echo -e "${RED}Error: Camoufox venv not found. Run: anti-detect-helper.sh setup${NC}" >&2
 		return 1
@@ -751,7 +754,9 @@ launch_chromium_stealth() {
 		fi
 		if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
 			proxy_server=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('server',''))" 2>/dev/null)
+			local proxy_username
 			proxy_username=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('username',''))" 2>/dev/null)
+			local proxy_password
 			proxy_password=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('password',''))" 2>/dev/null)
 		fi
 	fi
@@ -951,6 +956,7 @@ test_detection() {
 
 	echo -e "${BLUE}Testing bot detection (engine: $engine)...${NC}"
 
+	# shellcheck source=/dev/null
 	source "$VENV_DIR/bin/activate" 2>/dev/null || true
 
 	if [[ "$engine" == "firefox" ]]; then
@@ -1000,6 +1006,7 @@ warmup_build_config() {
 		return 1
 	fi
 
+	# shellcheck source=/dev/null
 	source "$VENV_DIR/bin/activate" 2>/dev/null || {
 		echo -e "${RED}Error: Camoufox venv not found. Run: anti-detect-helper.sh setup${NC}" >&2
 		return 1


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Fix shellcheck violations in `.agents/scripts/anti-detect-helper.sh` (GH#16370 complexity scan finding).

The automated scan found 0 functions exceeding 100 lines (false-positive trigger), but shellcheck reveals real quality issues:
- `proxy_username` and `proxy_password` in `launch_chromium_stealth` were assigned without `local` declarations (leaking into global scope)
- 4 dynamic `source "$VENV_DIR/bin/activate"` calls lacked `# shellcheck source=/dev/null` directives
- 1 `source "${SCRIPT_DIR}/shared-constants.sh"` call lacked the directive

## Issue
Closes #16370

## Files Changed
- `.agents/scripts/anti-detect-helper.sh` — 7 lines added (local declarations + shellcheck directives)

## Testing
- `bash -n`: SYNTAX OK
- `shellcheck`: zero violations (was 5 SC1091 infos + 2 missing local declarations)

## Key Decisions
- No functional changes — purely quality/lint fixes
- `proxy_username`/`proxy_password` local declarations prevent variable leakage between function calls
- `shellcheck source=/dev/null` is the correct pattern for dynamic venv paths that shellcheck cannot follow statically
- Fresh branch from current main (prior PR #16388 was closed due to merge conflicts)

## Runtime Testing
Risk: **Low** — lint/quality fix only, no logic changes. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.823 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6