### PR TITLE
GH#16035: tighten agent doc Vercel Agent Skills (agent-skills.md, 76→70 lines)

### DIFF
--- a/.agents/tools/deployment/agent-skills.md
+++ b/.agents/tools/deployment/agent-skills.md
@@ -8,8 +8,6 @@ tools:
 
 # Vercel Agent Skills
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 - **Repo**: [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills)
@@ -17,8 +15,6 @@ tools:
 - **Install**: `npx skills add vercel-labs/agent-skills`
 - **Registry**: [skills.sh](https://skills.sh/vercel-labs/agent-skills)
 - **Related**: `vercel.md` (CLI deployment), `add-skill.md` (import system)
-
-<!-- AI-CONTEXT-END -->
 
 ## Available Skills
 
@@ -31,8 +27,6 @@ tools:
 | `composition-patterns` | Refactoring components with boolean props | Compound component patterns |
 
 ## SKILL.md Layout
-
-Each skill directory contains:
 
 ```text
 skill-name/
@@ -61,7 +55,7 @@ aidevops skill add vercel-labs/agent-skills       # aidevops (preferred)
 /add-skill vercel-labs/agent-skills --name vercel-deploy  # With custom name
 ```
 
-Installed skills are auto-detected. Relevant requests trigger them automatically (for example, "deploy my app" → `vercel-deploy`).
+Installed skills are auto-detected; relevant requests trigger them automatically ("deploy my app" → `vercel-deploy`).
 
 ## aidevops Import Flow
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/deployment/agent-skills.md` prose per instruction doc simplification guidelines (GH#16035).

## Changes
- Removed `<!-- AI-CONTEXT-START/END -->` wrapper from Quick Reference (the wrapper covered only that section, inconsistent with file scope — the whole file is context)
- Removed redundant prose "Each skill directory contains:" before the `text` code block (code block is self-explanatory)
- Tightened auto-detect sentence: removed redundant "for example" wrapper
- 76 → 70 lines (8% reduction)

## Issue
Closes #16035

## Files Changed
- `.agents/tools/deployment/agent-skills.md` — 1 file, -6 net lines

## Testing
- `npx markdownlint-cli2 .agents/tools/deployment/agent-skills.md` → 0 errors
- All URLs, command examples, skill table entries, and import flow steps verified present before and after
- Agent behaviour unchanged: all operational content preserved

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — prose tightening is appropriate, not chapter splitting
- "Minimal frontmatter:" label retained — it introduces the yaml block and aids scannability
- No content removed, only decorative/redundant prose

## Runtime Testing
Risk: **Low** — docs/agent prompt only, no code execution paths. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.824 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up technical documentation by removing internal markup
  * Simplified documentation structure and wording for clarity
  * Improved documentation accessibility with more direct phrasing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->