### PR TITLE
GH#16409: tighten prose in heygen video-status rules doc

### DIFF
--- a/.agents/content/heygen-skill/rules-video-status.md
+++ b/.agents/content/heygen-skill/rules-video-status.md
@@ -7,9 +7,9 @@ metadata:
 
 # Video Status and Polling
 
-HeyGen video generation is asynchronous: store the `video_id`, poll until terminal state, then download or hand off to a webhook-driven flow.
+HeyGen video generation is asynchronous: store the `video_id`, poll until terminal state, then download or hand off to a webhook flow.
 
-**Production:** Prefer webhooks over polling to avoid idle connections; see [rules-webhooks.md](rules-webhooks.md). Cache `video_url` values — they expire.
+**Production:** Prefer webhooks over polling; see [rules-webhooks.md](rules-webhooks.md). Cache `video_url` — values expire.
 
 ## Check Status
 
@@ -50,13 +50,13 @@ async function getVideoStatus(videoId: string) {
   "error": "Script too long for selected avatar" } }
 ```
 
-## Timing Guidance
+## Timing
 
-Typical: **5-15 min**. Peak load, long scripts, or 1080p: **20+ min**. Use a timeout of **15-20 min** (`900000-1200000` ms).
+Typical: **5-15 min**. Peak load, long scripts, or 1080p: **20+ min**. Timeout: **15-20 min** (`900000-1200000` ms).
 
 ## Polling Pattern
 
-Poll every few seconds; use exponential backoff for long-running jobs. For UI feedback, add `onProgress?: (status: string, elapsed: number) => void` on each iteration.
+Poll every few seconds with exponential backoff. For UI feedback, add `onProgress?: (status: string, elapsed: number) => void` on each iteration.
 
 ```typescript
 async function waitForVideo(
@@ -77,7 +77,7 @@ async function waitForVideo(
 
 ## Download With Retry
 
-`completed` means metadata is ready; the file URL may still take a moment to serve. Retry with exponential backoff.
+`completed` means metadata is ready; the file URL may still take a moment to serve. Use exponential backoff.
 
 ```typescript
 import fs from "fs";
@@ -99,7 +99,7 @@ async function downloadVideo(videoUrl: string, outputPath: string, maxRetries = 
 
 ## Resumable Workflow
 
-Persist `video_id` and resume later; don't hold an idle process open for long generations.
+Persist `video_id` to disk; don't hold an idle process open for long generations.
 
 ```typescript
 // generate-video.ts — start and exit


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/content/heygen-skill/rules-video-status.md` per issue #16409 simplification scan.

Closes #16409

## What

Compressed redundant wording in 5 prose sections:
- Intro: removed "to avoid idle connections" (implied by webhook preference), tightened `video_url` cache note
- "Timing Guidance" → "Timing" (shorter heading)
- "Use a timeout of" → "Timeout:" (more direct)
- Polling: "use exponential backoff for long-running jobs" → "with exponential backoff"
- Download: "Retry with exponential backoff" → "Use exponential backoff"
- Resumable: "and resume later" → "to disk" (more specific)

## Files Changed

- `.agents/content/heygen-skill/rules-video-status.md` — 7 prose lines tightened, 0 lines removed

## Testing

**Risk level:** Low (docs/agent prompt, no code execution)
**Verification:** `self-assessed`

- All code blocks preserved verbatim (bash curl, TypeScript getVideoStatus, waitForVideo, downloadVideo, resumable workflow)
- All URLs preserved (`https://api.heygen.com/v1/video_status.get`, `rules-webhooks.md`)
- All timing values preserved (5-15 min, 20+ min, 900000-1200000 ms)
- All status values preserved (`pending`, `processing`, `completed`, `failed`)
- All JSON response examples preserved
- Agent behaviour unchanged — same rules, same decisions, tighter prose

## Runtime Testing

`self-assessed` — Low risk: docs-only change, no executable code modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.824 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6