### PR TITLE
GH#16410: normalize Browser Automation table to 3-column format in service-links.md

### DIFF
--- a/.agents/aidevops/service-links.md
+++ b/.agents/aidevops/service-links.md
@@ -51,11 +51,11 @@ tools:
 
 ## Browser Automation
 
-| Tool | Docs |
-|------|------|
-| [Playwright](https://playwright.dev/) | [playwright.dev/docs/intro](https://playwright.dev/docs/intro) |
-| [Selenium](https://www.selenium.dev/) | [selenium.dev](https://www.selenium.dev/) |
-| [Puppeteer](https://pptr.dev/) | [pptr.dev](https://pptr.dev/) |
+| Tool | Console | Docs |
+|------|---------|------|
+| [Playwright](https://playwright.dev/) | — | [playwright.dev/docs/intro](https://playwright.dev/docs/intro) |
+| [Selenium](https://www.selenium.dev/) | — | [selenium.dev](https://www.selenium.dev/) |
+| [Puppeteer](https://pptr.dev/) | — | [pptr.dev](https://pptr.dev/) |
 
 ## Security & Quality
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Normalize the Browser Automation section in `.agents/aidevops/service-links.md` to use the same 3-column `Service/Console/Docs` format as all other sections. Previously it used a 2-column `Tool/Docs` format, creating an inconsistency.

## Issue
Closes #16410

## Files Changed
- `.agents/aidevops/service-links.md` — Browser Automation table: 2-column → 3-column (added Console column with `—` placeholders)

## Testing
- `markdownlint-cli2`: 0 errors
- All URLs preserved (zero content loss)
- Line count unchanged (112 lines)
- Agent behaviour unchanged (reference corpus, no instruction logic modified)

## Key Decisions
- File classified as **reference corpus** (service links directory, not instruction doc)
- At 112 lines, splitting into chapter files would add overhead without value (threshold is ~300 lines per build-agent.md)
- Only structural normalization applied — no content removed or compressed

## Runtime Testing
Risk: **Low** — docs/formatting change only. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.824 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6