### PR TITLE
GH#16072: tighten wrangler.md (75→73 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler.md
@@ -1,6 +1,6 @@
 # Cloudflare Wrangler
 
-Primary CLI for Cloudflare Workers: scaffold projects, run local/remote dev, manage bindings, deploy, and inspect versions.
+Primary CLI for Workers: scaffold, dev, deploy, manage bindings.
 
 ## Install
 
@@ -12,18 +12,16 @@ npm install -g wrangler   # global
 ## Core Commands
 
 ```bash
-wrangler init [name]                  # Create project
-wrangler dev                          # Local dev server
-wrangler dev --remote                 # Remote dev with real bindings
-wrangler deploy                       # Deploy production
-wrangler deploy --env staging         # Deploy named environment
-wrangler versions list                # List deployed versions
-wrangler rollback [id]                # Roll back deployment
-wrangler login                        # OAuth login
-wrangler whoami                       # Check auth/account
-wrangler tail                         # Stream logs
-wrangler tail --env production        # Tail specific environment
-wrangler tail --status error          # Show only errors
+wrangler init [name]           # Create project
+wrangler dev                   # Local dev server
+wrangler dev --remote          # Remote dev with real bindings
+wrangler deploy                # Deploy production
+wrangler deploy --env staging  # Deploy named environment
+wrangler versions list         # List deployed versions
+wrangler rollback [id]         # Roll back deployment
+wrangler login                 # OAuth login
+wrangler whoami                # Check auth/account
+wrangler tail [--env ENV] [--status error]  # Stream logs (filter by env/status)
 ```
 
 ## Resource Commands


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/wrangler.md` per issue #16072.

**Classification:** Reference corpus (command reference) — prose tightening applied, not chapter split. At 75 lines the file is already minimal; splitting would increase total line count.

**Changes:**
- Compress verbose description line (removes redundant "Cloudflare" prefix and wordy enumeration)
- Consolidate 3 `wrangler tail` variants into 1 with inline parameter docs (`[--env ENV] [--status error]`)
- Align column spacing in Core Commands block for readability

**Preservation check:**
- All code blocks present ✓
- All command examples present ✓
- All resource sections (KV, D1, R2, Queues, Vectorize, Hyperdrive, Secrets) present ✓
- See Also links intact ✓
- No task IDs or GH refs in original to preserve ✓

**Line count:** 75 → 73 (−2 lines, −2.7%)

Closes #16072

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no executable code changed.
**Verification:** `self-assessed` — content preservation verified by diff review above.

---
[aidevops.sh](https://aidevops.sh) v3.5.824 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6