### PR TITLE
GH#16074: tighten security-analysis.md (75→46 lines)

### DIFF
--- a/.agents/scripts/commands/security-analysis.md
+++ b/.agents/scripts/commands/security-analysis.md
@@ -14,44 +14,15 @@ Target: $ARGUMENTS
 
 ## Process
 
-1. **Determine scope** from $ARGUMENTS:
-   - Empty or `diff` → Analyze uncommitted changes
-   - `staged` → Analyze staged changes only
-   - `branch` → Analyze all commits on current branch vs main
-   - `full` → Scan entire codebase
-   - Path (e.g., `src/`) → Scan specific directory
+1. **Determine scope** from $ARGUMENTS: empty/`diff` → uncommitted changes; `staged` → staged only; `branch` → current branch vs main; `full` → entire codebase; path → specific directory.
 
-2. **Run security analysis**:
+2. **Run analysis**: `./.agents/scripts/security-helper.sh analyze [$ARGUMENTS]`
 
-   ```bash
-   # Default: analyze git diff
-   ./.agents/scripts/security-helper.sh analyze
+3. **Review findings** by severity (critical > high > medium > low). For each: verify true positive, trace data flow source→sink, propose remediation with code fix.
 
-   # Full codebase scan
-   ./.agents/scripts/security-helper.sh analyze full
+4. **Generate report**: `./.agents/scripts/security-helper.sh report`
 
-   # Specific scope
-   ./.agents/scripts/security-helper.sh analyze $ARGUMENTS
-   ```
-
-3. **Review findings** by severity (critical > high > medium > low)
-
-4. **For each finding**:
-   - Verify it's a true positive (not false positive)
-   - Trace data flow from source to sink (reconnaissance → investigation)
-   - Propose remediation with code fix
-
-5. **Generate report**:
-
-   ```bash
-   ./.agents/scripts/security-helper.sh report
-   ```
-
-6. **Provide output**:
-   - Summary: total findings by severity
-   - Critical/High findings: detailed with file:line, CWE, and remediation
-   - Recommendations: prioritized action items
-   - Report location: path to generated reports
+5. **Output**: summary by severity; critical/high with file:line, CWE, remediation; prioritized recommendations; report path.
 
 ## Vulnerability Categories
 


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/security-analysis.md` from 75 to 46 lines (39% reduction) by condensing the Process section prose without removing any knowledge.

## What changed

- Collapsed verbose multi-line scope mapping into a single inline sentence
- Merged the bash code block (3 near-identical variants) into one inline command
- Condensed "For each finding" and "Provide output" steps into compact prose
- All vulnerability categories, related commands, scope options, helper references, and full-doc pointer preserved

## Files changed

- `.agents/scripts/commands/security-analysis.md`: 75 → 46 lines

## Testing

- Content preservation verified: all code references, scope options, commands, categories, and task IDs (none existed) present before and after
- Agent behaviour unchanged: same decision tree, same commands, same output spec
- Risk: Low (docs/agent prompt only)

## Runtime Testing

`self-assessed` — docs-only change, no runtime environment needed.

Closes #16074

---
[aidevops.sh](https://aidevops.sh) v3.5.824 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6