### PR TITLE
GH#16415: tighten agent doc Git Worktree Workflow (.agents/workflows/worktree.md)

### DIFF
--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -22,7 +22,6 @@ tools:
 - **Core principle**: Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`. **Never `git checkout -b` in the main repo** — the next session inherits wrong state.
 - **Preferred tool**: [Worktrunk](https://worktrunk.dev) (`brew install max-sixty/worktrunk/wt`) — full docs: `tools/git/worktrunk.md`
 - **Fallback**: `~/.aidevops/agents/scripts/worktree-helper.sh`
-- **Paths**: `~/Git/myrepo/` (main) | `~/Git/myrepo-feature-auth/` (linked) | `~/Git/myrepo-bugfix-login/` (linked)
 
 <!-- AI-CONTEXT-END -->
 
@@ -54,7 +53,7 @@ worktree-helper.sh clean                            # Batch cleanup merged branc
 
 `pre-edit-check.sh` works in any worktree — main or linked.
 
-**Localdev (t1224.8):** Worktree creation auto-sets branch-specific subdomain routing (`https://feature-auth.myapp.local`) for `localdev add` projects. Removal auto-cleans the route.
+**Localdev (t1224.8):** Worktree creation auto-sets branch-specific subdomain routing (`https://feature-auth.myapp.local`). Removal auto-cleans the route.
 
 **Session recovery:** Run `session-rename_sync_branch` after creating branches. Check `worktree-sessions.sh list` before closing PRs or deleting branches.
 


### PR DESCRIPTION
## Summary

- Remove redundant `Paths` bullet from Quick Reference — the path pattern (`~/Git/{repo}-feature-my-feature/`) is already shown in the Commands section, making the bullet duplicate information
- Trim localdev note prose: `for \`localdev add\` projects` removed — implied by the t1224.8 reference and surrounding context

## What

Tighten `.agents/workflows/worktree.md` per GH#16415 automated scan. File classified as **instruction doc** (agent rules, workflow, decision trees) — prose compression, not content reduction.

## Issue

Closes #16415

## Files Changed

- `.agents/workflows/worktree.md` — 95 → 94 lines (1 line net reduction, 2 lines removed)

## Testing

**Risk level:** Low — docs/agent prompt only, no code changes.

**Runtime Testing:** `self-assessed` — agent doc edit with no behavioural change. All task IDs (t1224.8, GH#6740, t189), command examples, URLs, and institutional knowledge verified present before and after.

**Content preservation check:**
- All code blocks: ✓ preserved
- Task ID references (t1224.8, t189, GH#6740): ✓ preserved
- Command examples: ✓ preserved
- Troubleshooting table: ✓ preserved
- Related table: ✓ preserved

## Key Decisions

- File was already well-structured at 95 lines; only genuinely redundant content removed
- Did not compress the Commands section (authoritative reference, needs full examples)
- Did not compress Troubleshooting table (each row is a distinct failure mode)

---
<!-- MERGE_SUMMARY -->
**What:** Tighten worktree.md agent doc — remove 2 redundant lines
**Issue:** Closes #16415
**Files changed:** `.agents/workflows/worktree.md`
**Testing:** self-assessed (docs-only, low risk)
**Key decisions:** Minimal change — file was already tight; only genuinely duplicate content removed

---
[aidevops.sh](https://aidevops.sh) v3.5.825 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6