### PR TITLE
GH#16417: tighten agent doc session.md (85→77 lines)

### DIFF
--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -4,10 +4,7 @@ Loaded on-demand for session management, browser automation, localhost, or quali
 
 ## Terminal Capabilities
 
-Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers).
-
-- Long-running processes: use `&`, `nohup`, or `tmux`.
-- Parallel AI dispatch: `tools/ai-assistants/opencode-server.md`.
+Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers). Long-running processes: use `&`, `nohup`, or `tmux`. Parallel AI dispatch: `tools/ai-assistants/opencode-server.md`.
 
 ## Session Lifecycle
 
@@ -46,17 +43,12 @@ worktree-helper.sh add feature/x  # Fallback
 ## Browser Automation
 
 - Use a browser proactively for dev-server verification, form testing, deployment checks, and frontend debugging.
-- Tool selection: `tools/browser/browser-automation.md`.
-- Quick default: Playwright for dev testing, dev-browser for persistent login.
-- Never use curl or raw HTTP to verify frontend fixes. A server can return 200 while React fails during hydration; browser screenshots are the required proof.
+- Tool selection: `tools/browser/browser-automation.md`. Quick default: Playwright for dev testing, dev-browser for persistent login.
+- Never use curl or raw HTTP to verify frontend fixes — a server can return 200 while React fails during hydration; browser screenshots are the required proof.
 
 ## Localhost Standards
 
 Use `.local` domains with SSL via Traefik + mkcert. Primary doc: `services/hosting/local-hosting.md`. Legacy doc: `services/hosting/localhost.md`.
-
-## Bot Reviewer Feedback
-
-Follow `prompts/build.txt` for AI suggestion verification. Dismiss incorrect suggestions with evidence; address valid ones.
 
 ## Quality Workflow
 
@@ -64,7 +56,7 @@ Follow `prompts/build.txt` for AI suggestion verification. Dismiss incorrect sug
 Development → @code-standards → /code-simplifier → /linters-local → /pr review → /postflight
 ```
 
-Quick commands: `linters-local.sh` (pre-commit), `/pr review` (full), `version-manager.sh release [type]`.
+Quick commands: `linters-local.sh` (pre-commit), `/pr review` (full), `version-manager.sh release [type]`. Bot reviewer feedback: follow `prompts/build.txt` — dismiss incorrect suggestions with evidence; address valid ones.
 
 ## Agents & Subagents
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/reference/session.md` per simplification scan (GH#16417). Instruction doc classification — content compressed, not restructured.

## Changes
- Merged 3-line "Terminal Capabilities" bullet list into the section paragraph
- Absorbed standalone "Bot Reviewer Feedback" section into "Quality Workflow" (logical grouping, no content loss)
- Combined browser tool-selection lines into single bullet
- 85 → 77 lines (9.4% reduction)

## Issue
Closes #16417

## Files Changed
- `.agents/reference/session.md`

## Testing
- `markdownlint-cli2`: 0 errors
- All references verified present: `workflows/session-manager.md`, `prompts/build.txt` (×3), `worktree-helper.sh`, `install-hooks.sh`, `workflows/git-workflow.md`, `tools/git/worktrunk.md`, `browser-automation.md`, `local-hosting.md`, `localhost.md`, `linters-local.sh`, `version-manager.sh`, `subagent-index.toon`, `build-agent.md`, `gopass.md`, `api-key-setup.md`, `opencode-server.md`, `session-checkpoint-helper.sh`
- All code blocks, task IDs, and command examples preserved

## Runtime Testing
Risk: **Low** — docs/agent prompt only. Self-assessed.

## Key Decisions
- Classified as instruction doc (not reference corpus): tighten prose, not split into chapters
- "Bot Reviewer Feedback" merged into "Quality Workflow" — same domain, reduces section fragmentation
- No content removed; all institutional knowledge preserved

---
[aidevops.sh](https://aidevops.sh) v3.5.825 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6