### PR TITLE
GH#16429: tighten security.md SSH section (77→76 lines)

### DIFF
--- a/.agents/aidevops/security.md
+++ b/.agents/aidevops/security.md
@@ -44,8 +44,9 @@ chmod 600 ~/.ssh/id_ed25519 && chmod 644 ~/.ssh/id_ed25519.pub
 ssh-keygen -p -f ~/.ssh/id_ed25519
 ```
 
+`~/.ssh/config` hardening — disable root login, non-standard port, fail2ban on server:
+
 ```text
-# ~/.ssh/config hardening
 Host *
     PasswordAuthentication no
     KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group16-sha512
@@ -54,8 +55,6 @@ Host *
     ForwardX11 no
     ConnectTimeout 10
 ```
-
-- Server: disable root login, non-standard SSH port, fail2ban
 
 ## Script Security
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/aidevops/security.md` per GH#16429 simplification scan. Folded orphaned trailing bullet (`- Server: disable root login, non-standard SSH port, fail2ban`) into a prose label before the `~/.ssh/config` code block. Removes the awkward post-code-block bullet pattern while preserving all institutional knowledge.

## Issue
Closes #16429

## Files Changed
- `.agents/aidevops/security.md` — 77→76 lines, 2 insertions, 3 deletions

## Testing
- Content preservation verified: all code blocks, URLs, task ID references, and command examples present before and after
- No broken internal links or references
- Agent behaviour unchanged (read-only subagent, no executable logic)
- Risk: **Low** (docs/agent prompt only)

## Runtime Testing
`self-assessed` — Low risk: agent prompt doc, no executable code, no API endpoints, no state changes.

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — prose tightening is correct action
- Minimal change: only restructured the SSH section's trailing bullet into a prose label; all other sections already tight
- Zero content loss: server hardening note (`disable root login, non-standard port, fail2ban`) preserved in prose label

---
[aidevops.sh](https://aidevops.sh) v3.5.825 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6