### PR TITLE
GH#16441: tighten Hyperdrive Patterns agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md
@@ -67,25 +67,15 @@ return Response.json({user, serverRegion: req.cf?.colo});
 Transaction mode: connection acquired per transaction, `RESET` on return. SET statements must stay within a single transaction or compound statement; keep transactions short.
 
 ```typescript
-// ✅ SET within transaction (RESET after COMMIT)
+// ✅ SET within transaction or as compound statement
 await client.query("BEGIN");
-await client.query("SET work_mem = '256MB'");
+await client.query("SET LOCAL work_mem = '256MB'");  // SET LOCAL preferred — scoped to transaction
 await client.query("SELECT * FROM large_table");
 await client.query("COMMIT");
-// ✅ Compound statement
-await client.query("SET work_mem = '256MB'; SELECT * FROM large_table");
+await client.query("SET work_mem = '256MB'; SELECT * FROM large_table");  // compound also works
 // ❌ Across queries — may get different connection
 await client.query("SET work_mem = '256MB'");
 await client.query("SELECT * FROM large_table");  // SET not applied
-// ✅ Short transaction
-await client.query("BEGIN");
-await client.query("UPDATE users SET status = $1 WHERE id = $2", [status, id]);
-await client.query("COMMIT");
-// ✅ SET LOCAL scoped to transaction
-await client.query("BEGIN");
-await client.query("SET LOCAL work_mem = '256MB'");
-await client.query("SELECT * FROM large_table");
-await client.query("COMMIT");
 // ❌ Long transaction holds connection
 await client.query("BEGIN");
 await processThousands();


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md` per simplification scan (GH#16441).

**Classification:** Reference corpus (code examples by use-case pattern, already a chapter file — not an instruction doc).

**Change:** Consolidated redundant SET examples in the Connection Pooling section. The original had 4 ✅ examples (SET within transaction, compound statement, short transaction, SET LOCAL) — the "short transaction" was generic (not Hyperdrive-specific) and the two SET forms were merged into one annotated example showing both. Both ❌ anti-patterns preserved.

**Result:** 125 → 115 lines (-8%). All code blocks, URLs, task ID references, and Hyperdrive-specific knowledge preserved.

## Issue
Closes #16441

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md` — 3 insertions, 13 deletions

## Testing
- `self-assessed` (Low risk: docs-only change, no executable code modified)
- Content preservation verified: all code blocks, URLs, and knowledge present before and after
- Line count: 125 → 115 (within expected range for prose tightening)

## Runtime Testing
**Risk level:** Low — documentation file only, no executable code.
**Verification:** `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.825 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6