### PR TITLE
GH#16445: tighten cron-triggers.md — replace duplicate curl with pointer to gotchas

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md
@@ -24,7 +24,7 @@ export default {
 };
 ```
 
-**Test locally:** `npx wrangler dev` then `curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"`
+**Test locally:** `npx wrangler dev` — see [gotchas.md](./cron-triggers-gotchas.md) "Local Testing" for curl commands and alternative paths.
 
 ## Cron Syntax
 


### PR DESCRIPTION
## Summary

- Replaces the duplicate `curl` test command in Quick Start with a pointer to `cron-triggers-gotchas.md` "Local Testing" section
- Eliminates duplication: the full curl commands (including alternative paths) are already documented in gotchas.md
- Zero content loss — all information preserved via progressive disclosure pointer

## Classification

Reference corpus (domain knowledge base). File is already well-structured at 74 lines. The companion files (`cron-triggers-patterns.md`, `cron-triggers-gotchas.md`) already contain the detailed content; the main file is the entry-point index.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/cron-triggers.md` — 1 line changed (74 lines, unchanged count)

## Runtime Testing

**Risk level:** Low — docs-only change, no code execution paths affected.
**Verification:** `self-assessed` — content preserved, pointer links to correct section in gotchas.md.

## Closes

Closes #16445

---
<!-- MERGE_SUMMARY -->
**What:** Tighten cron-triggers.md by replacing a duplicated curl test command with a pointer to the canonical gotchas.md "Local Testing" section.
**Issue:** #16445
**Files changed:** 1 (docs only)
**Testing:** Self-assessed (docs change)
**Key decisions:** Kept the `npx wrangler dev` note (entry-point context), replaced only the curl command which is fully covered in gotchas.md with 3 curl variants.

---
[aidevops.sh](https://aidevops.sh) v3.5.826 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6