### PR TITLE
GH#16449: tighten code-review tools.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5142,5 +5142,11 @@
     "hash": "3d566d9fbf05fdee08380d0ffbaf538854887e326c9b658e8236d837c8993cb3",
     "status": "simplified",
     "lines": 63
+  },
+  ".agents/tools/code-review/tools.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "b767318f3046f9a52ff3d31a2f733bb83f4e5475501f57862a874c05e853ad7b",
+    "issue": "GH#16449",
+    "status": "simplified"
   }
 }

--- a/.agents/tools/code-review/tools.md
+++ b/.agents/tools/code-review/tools.md
@@ -14,13 +14,11 @@ tools:
 
 # Code Review Tools
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 - Linter manager: `linter-manager.sh detect|install-detected|install-all|install [lang]`
 - Config files: `.eslintrc.*`, `.pylintrc`, `.shellcheckrc`, `.hadolint.yaml`, `.stylelintrc.*`
-- Best practices: start conservative, customize gradually, version control configs
+- Rule refs: [ESLint](https://eslint.org/docs/rules/) · [Pylint](https://pylint.pycqa.org/en/latest/technical_reference/features.html) · [ShellCheck](https://github.com/koalaman/shellcheck/wiki) · [Stylelint](https://stylelint.io/user-guide/rules/list) · [Awesome Static Analysis](https://github.com/analysis-tools-dev/static-analysis)
 
 ## Language Linters
 
@@ -47,8 +45,6 @@ tools:
 | PowerShell | PSScriptAnalyzer 1.24.0 | `PSScriptAnalyzerSettings.psd1` |
 | Security | Trivy 0.67.2 | `trivy.yaml` |
 
-Reference: [CodeFactor Analysis Tools](https://docs.codefactor.io/bootcamp/analysis-tools/)
-
 ## Quality Platforms
 
 | Platform | Integration | Auto-Fix | Notes |
@@ -57,15 +53,5 @@ Reference: [CodeFactor Analysis Tools](https://docs.codefactor.io/bootcamp/analy
 | Codacy | CLI + Web | Yes (70-90%) | 40+ langs, style/best-practices/security |
 | SonarCloud | CLI + Web | No | Enterprise analysis, security vuln detection, tech debt |
 | Qlty | CLI | Yes (80-95%) | 70+ tools, 40+ langs, auto-formatting |
-| CodeFactor | Web only | No | Reference collection for tool selection |
+| CodeFactor | Web only | No | [Tool reference](https://docs.codefactor.io/bootcamp/analysis-tools/) for tool selection |
 | ESLint | CLI | Yes (60-80%) | JS/TS style + best practices |
-
-## Rule References
-
-- [ESLint Rules](https://eslint.org/docs/rules/)
-- [Pylint Messages](https://pylint.pycqa.org/en/latest/technical_reference/features.html)
-- [ShellCheck Wiki](https://github.com/koalaman/shellcheck/wiki)
-- [Stylelint Rules](https://stylelint.io/user-guide/rules/list)
-- [Awesome Static Analysis](https://github.com/analysis-tools-dev/static-analysis)
-
-<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/code-review/tools.md` from 71 to 57 lines (20% reduction) per simplification-debt scan.

## Issue
Closes #16449

## Files Changed
- `.agents/tools/code-review/tools.md` — simplified instruction doc
- `.agents/configs/simplification-state.json` — updated hash registry

## Changes Made
- Removed `<!-- AI-CONTEXT-START/END -->` wrappers (no value in a 71-line file)
- Removed generic best-practices line ("start conservative, customize gradually, version control configs")
- Consolidated standalone "Rule References" section into Quick Reference as inline links (saves 8 lines)
- Moved CodeFactor URL inline to Quality Platforms table Notes column

## Content Preservation
All institutional knowledge preserved:
- All 20 language linters with version numbers and config file references ✓
- All 6 quality platforms with integration/auto-fix/notes ✓
- All 5 rule reference URLs (ESLint, Pylint, ShellCheck, Stylelint, Awesome Static Analysis) ✓
- CodeFactor analysis tools URL ✓

## Classification
**Instruction doc** (not reference corpus) — agent subagent doc with YAML frontmatter, quick reference, and lookup tables. Prose tightening applied per `build-agent.md` guidance.

## Runtime Testing
**Risk: Low** — agent doc only, no code execution paths. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.826 plugin for [OpenCode](https://opencode.ai) v1.3.13