### PR TITLE
GH#16156: tighten contacts.md agent doc

### DIFF
--- a/.agents/tools/productivity/contacts.md
+++ b/.agents/tools/productivity/contacts.md
@@ -19,27 +19,26 @@ tools:
 ## Quick Reference
 
 - **Helper**: `~/.aidevops/agents/scripts/contacts-helper.sh [command] [args]`
-- **macOS backend**: `osascript` via Contacts.app (JXA for reads, AppleScript for writes)
-- **Linux backend**: `khard` + `vdirsyncer` (CardDAV)
-- **Setup**: `contacts-helper.sh setup` — macOS: grant access in System Settings > Privacy & Security > Contacts; Linux: install `khard` + `vdirsyncer`
+- **macOS**: `osascript` via Contacts.app (JXA reads, AppleScript writes) — grant access: System Settings > Privacy & Security > Contacts
+- **Linux**: `khard` + `vdirsyncer` (CardDAV) — run `contacts-helper.sh setup`
 - **Related**: `tools/productivity/calendar.md`, `tools/productivity/apple-reminders.md`, `tools/productivity/notes.md`
 
 <!-- AI-CONTEXT-END -->
 
 ## Field Coverage
 
-| Field | macOS | Linux | Notes |
-|---|---|---|---|
-| Name, Org, Job title, Email, Phone, Notes | osascript | khard | full read/write |
-| Postal addresses, URLs, Birthday | osascript (read) | khard | read-only on macOS |
-| Social profiles | limited | khard | Linux has better support |
-| Photos, Relationships | — | — | no CLI support |
+| Field | macOS | Linux |
+|---|---|---|
+| Name, Org, Job title, Email, Phone, Notes | read/write | read/write |
+| Postal addresses, URLs, Birthday | read-only | read/write |
+| Social profiles | limited | full |
+| Photos, Relationships | — | — |
 
-## When to Use Contacts
+## When to Use
 
-**Look up** when: user needs email/phone/address, composing email, creating a calendar event, or a workflow needs to reach someone.
+**Look up**: user needs email/phone/address, composing email, creating a calendar event, or a workflow needs to reach someone.
 
-**Create** when: user explicitly asks, a new business relationship is established, or an agent workflow discovers contact info to keep. Always require user confirmation — contacts sync to all devices.
+**Create**: user explicitly asks, new business relationship established, or agent discovers contact info to keep. Always require user confirmation — contacts sync to all devices.
 
 **Do NOT create** for temporary interactions or info already in a CRM.
 
@@ -61,10 +60,9 @@ contacts-helper.sh add --first Jane --last Doe \
   --notes "Met at DevOps conference 2026"
 ```
 
-## Setup
+## Linux Setup
 
-- **macOS**: no install needed. Grant access: System Settings > Privacy & Security > Contacts. All accounts from Internet Accounts appear automatically.
-- **Linux**: requires `khard` + `vdirsyncer`. Run `contacts-helper.sh setup`. Example `~/.config/khard/khard.conf`:
+`contacts-helper.sh setup`. Example `~/.config/khard/khard.conf`:
 
 ```ini
 [addressbooks]
@@ -75,10 +73,7 @@ path = ~/.local/share/contacts/
 ## Cross-tool Workflow
 
 ```bash
-# 1. Look up contact
 contacts-helper.sh show "Andrew"
-# 2. Create a reminder to call them
 reminders-helper.sh add "Call Andrew" --due tomorrow --priority medium
-# 3. Block calendar time for the call
 calendar-helper.sh add "Call with Andrew" --start "tomorrow 10:00" --end "tomorrow 10:30"
 ```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/productivity/contacts.md` per simplification scan (GH#16156). 84 → 79 lines.

## Changes
- Merged macOS/Linux backend info into Quick Reference (removes duplicate Setup section prose)
- Simplified Field Coverage table (removed redundant Notes column)
- Condensed "When to Use Contacts" → "When to Use"
- Removed self-evident inline comments from Cross-tool Workflow code block
- Renamed "Setup" → "Linux Setup" (macOS requires no install)

## Content Preservation
- All command examples preserved verbatim
- All field coverage data preserved
- macOS privacy settings path preserved
- Linux khard config example preserved
- Cross-tool workflow commands preserved

## Testing
- Self-assessed (Low risk: docs-only change, no code, no agent behaviour change)
- `wc -l` before: 84, after: 79
- All code blocks, URLs, and command examples verified present

Closes #16156

---
[aidevops.sh](https://aidevops.sh) v3.5.833 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6