### PR TITLE
GH#16158: tighten CRO Testing Masterclass chapter 21

### DIFF
--- a/.agents/marketing-sales/cro-chapter-21.md
+++ b/.agents/marketing-sales/cro-chapter-21.md
@@ -4,16 +4,16 @@
 
 Structure: **IF** [change], **THEN** [expected result], **BECAUSE** [reasoning]
 
-**Data Sources:** Analytics drop-off points, heatmap clicks/scrolls, session recordings, user surveys, support tickets, competitor benchmarking
+**Data sources:** Analytics drop-off points, heatmap clicks/scrolls, session recordings, user surveys, support tickets, competitor benchmarking
 
-**Prioritization Matrix:**
+**Prioritization matrix:**
 
 | Factor | Weight |
 |--------|--------|
 | Potential Impact | 30% |
-| Confidence | 20% |
 | Ease of Implementation | 25% |
 | Resource Requirements | 25% |
+| Confidence | 20% |
 
 ## 21.2 Advanced Test Design
 
@@ -21,17 +21,16 @@ Structure: **IF** [change], **THEN** [expected result], **BECAUSE** [reasoning]
 
 Test multiple variables simultaneously to detect interaction effects. Example (2×2×2 = 8 variations): Headline A/B × Image X/Y × CTA Red/Blue
 
-**Benefits:** Interaction effects, sample-efficient when interactions matter
-
-**Challenges:** Complex analysis, more traffic required, implementation complexity
+| | |
+|---|---|
+| **Benefits** | Interaction effects, sample-efficient when interactions matter |
+| **Challenges** | Complex analysis, more traffic required, implementation complexity |
 
 ### Bandit Algorithms
 
 Dynamic traffic allocation to winning variations during the test.
 
-**Epsilon-Greedy:** 90% traffic to current best, 10% exploration, adapts in real-time
-
-**Use cases:** Continuous optimization, long-running campaigns, seasonal adjustments
+**Epsilon-Greedy:** 90% traffic to current best, 10% exploration, adapts in real-time. Use for continuous optimization, long-running campaigns, seasonal adjustments.
 
 ## 21.3 Statistical Rigor
 
@@ -59,7 +58,7 @@ Stop tests early **only with pre-specified stopping rules** — ad-hoc stopping 
 **Dimensions:** Device type, traffic source, new vs returning, geography, browser
 
 ```sql
-SELECT 
+SELECT
   device_type,
   variation,
   COUNT(*) as users,


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What

Tighten `.agents/marketing-sales/cro-chapter-21.md` (79 → 78 lines) per simplification issue GH#16158.

**Classification:** Reference corpus (domain knowledge base). Prose tightening applied — no splitting needed at 79 lines.

**Changes:**
- Consolidate `**Benefits:**` / `**Challenges:**` separate paragraphs into a compact 2-row table
- Merge `**Epsilon-Greedy:**` and `**Use cases:**` into a single paragraph (removes redundant label)
- Normalize label casing (`Data Sources:` → `Data sources:`, `Prioritization Matrix:` → `Prioritization matrix:`)
- Reorder prioritization matrix rows by weight descending (30%, 25%, 25%, 20%)
- Fix trailing whitespace in SQL `SELECT` line

## Issue

Closes #16158

## Files Changed

- `.agents/marketing-sales/cro-chapter-21.md` (1 file, 9 insertions, 10 deletions)

## Testing

**Risk level:** Low (docs-only, no code, no agent instruction rules)

**Verification:**
- All code blocks present: SQL block preserved verbatim (minus trailing space)
- All task/issue refs: none in this file (N/A)
- All URLs: none in this file (N/A)
- All command examples: none in this file (N/A)
- Knowledge preserved: all 4 sections, all tables, all lists, all statistical methods, all stopping rules

**Runtime testing:** `self-assessed` — docs-only change, no runtime required.

## Key Decisions

- Did not split into sub-files: at 79 lines, splitting would create more overhead than value (comparable chapters cro-chapter-23.md=65 lines, cro-chapter-24.md=48 lines are single files)
- Kept all statistical content verbatim — no compression of domain knowledge

---
[aidevops.sh](https://aidevops.sh) v3.5.834 plugin for [OpenCode](https://opencode.ai) v1.3.13