### PR TITLE
GH#16178: tighten Email Testing Suite doc

### DIFF
--- a/.agents/services/email/email-testing.md
+++ b/.agents/services/email/email-testing.md
@@ -53,21 +53,12 @@ email-health-check-helper.sh accessibility newsletter.html # 5. Standalone a11y
 
 ## Client Compatibility
 
-| Engine | Clients | Flexbox/Grid | Media Queries | Custom Fonts | Notes |
-|--------|---------|-------------|---------------|-------------|-------|
-| **WebKit** | Apple Mail, iOS Mail, Outlook macOS | Yes | Yes | Yes | Best CSS support |
-| **Blink** | Gmail Web, Gmail Android | Yes | Partial | No | Strips `<style>` blocks |
-| **Word** | Outlook 2016+, Outlook 365 | No | No | No | VML for backgrounds; no `border-radius` on images |
-| **Custom** | Yahoo, AOL, Thunderbird | Yes/Partial | Partial | No | Partial media query support |
-
-## Dark Mode
-
-| Client | Behavior |
-|--------|----------|
-| Apple Mail | Full inversion; `prefers-color-scheme` supported |
-| Gmail (iOS) | Partial inversion; respects `color-scheme` meta |
-| Outlook (iOS/Android) | Full inversion; ignores `prefers-color-scheme` |
-| Yahoo | No dark mode support |
+| Engine | Clients | Flexbox/Grid | Media Queries | Custom Fonts | Dark Mode | Notes |
+|--------|---------|-------------|---------------|-------------|-----------|-------|
+| **WebKit** | Apple Mail, iOS Mail, Outlook macOS | Yes | Yes | Yes | Full inversion; `prefers-color-scheme` supported | Best CSS support |
+| **Blink** | Gmail Web, Gmail Android | Yes | Partial | No | Partial inversion (iOS); respects `color-scheme` meta | Strips `<style>` blocks |
+| **Word** | Outlook 2016+, Outlook 365 | No | No | No | Full inversion (iOS/Android); ignores `prefers-color-scheme` | VML for backgrounds; no `border-radius` on images |
+| **Custom** | Yahoo, AOL, Thunderbird | Yes/Partial | Partial | No | No dark mode support (Yahoo) | Partial media query support |
 
 Use `<meta name="color-scheme" content="light dark">` + `@media (prefers-color-scheme: dark)`. Avoid hardcoded white backgrounds; test logos on light/dark; use borders/shadows on transparent PNGs.
 


### PR DESCRIPTION
## Summary

- Merge standalone Dark Mode section into Client Compatibility table as a new column
- All per-client dark mode behavior preserved (Apple Mail full inversion, Gmail partial, Outlook full inversion, Yahoo none)
- Dark mode implementation note retained below the table
- 107 → 98 lines (9 lines removed, zero information lost)

## What

Tighten `.agents/services/email/email-testing.md` per simplification issue. The Dark Mode section was a separate table covering the same clients as Client Compatibility — merging them eliminates the redundant section header, table header row, and separator lines while keeping all knowledge.

## Issue

Closes #16178

## Files Changed

- `.agents/services/email/email-testing.md` — 1 file, 6 insertions, 15 deletions

## Testing

**Risk level:** Low — docs/agent prompt only, no code execution paths changed.

**Runtime Testing:** `self-assessed` — agent prompt file, no runtime verification required per testing gate (Low risk pattern).

**Verification:**
- All command examples present before and after ✓
- All URLs preserved ✓
- All task ID / GH# references preserved (none in this file) ✓
- Dark mode behavior per client preserved in table column ✓
- `wc -l` before: 107, after: 98 ✓

## Key Decisions

- Merged Dark Mode into Client Compatibility rather than deleting — zero information loss
- Kept dark mode implementation note (the `<meta>` tag guidance) as prose below the table — it applies across all clients, not per-client

<!-- MERGE_SUMMARY -->

---
[aidevops.sh](https://aidevops.sh) v3.5.835 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated dark mode compatibility information into the main Client Compatibility table for improved readability.
  * Refined dark mode behavior descriptions across email clients to provide clearer support details.
  * Streamlined documentation structure by merging separate dark mode sections for a more cohesive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->