### PR TITLE
GH#16475: tighten pipelines.md - remove redundant JSON qualifier in schema description

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pipelines.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pipelines.md
@@ -37,7 +37,7 @@ npx wrangler pipelines create my-pipeline --sql "INSERT INTO my_sink SELECT * FR
 # Deleting a stream also deletes dependent pipelines and buffered events
 ```
 
-**Schema (structured streams):** JSON with `name`, `type`, `required`; optional `items` (list) or `fields` (struct). Omit `--schema-file` for unstructured streams (no validation, single `value` column).
+**Schema (structured streams):** Fields with `name`, `type`, `required`; optional `items` (list) or `fields` (struct). Omit `--schema-file` for unstructured streams (no validation, single `value` column).
 
 ```json
 {


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/cloudflare-platform-skill/pipelines.md` per GH#16475.

**Classification**: Reference corpus (Cloudflare Pipelines skill content). File was already well-optimized at 131 lines — mostly tables and code blocks with minimal prose overhead.

**Change**: Removed redundant "JSON with" qualifier from schema description on line 40. The JSON code block immediately below makes the format self-evident; the qualifier added no information.

- Before: `JSON with \`name\`, \`type\`, \`required\`; optional \`items\` (list) or \`fields\` (struct).`
- After: `Fields with \`name\`, \`type\`, \`required\`; optional \`items\` (list) or \`fields\` (struct).`

**Preserved**: All code blocks, URLs, command examples, tables, type lists, troubleshooting entries, and resource links intact. Zero content loss.

## Verification

- All code blocks present before and after ✓
- All URLs preserved ✓
- All command examples preserved ✓
- `markdownlint-cli2`: 0 errors ✓
- Line count: 131 → 131 (no structural change needed — file was already compact)

## Runtime Testing

**Risk**: Low (docs-only change, no executable code modified)
**Assessment**: `self-assessed` — markdown lint clean, content preservation verified by diff review.

Closes #16475

---
[aidevops.sh](https://aidevops.sh) v3.5.835 plugin for [OpenCode](https://opencode.ai) v1.3.13