### PR TITLE
GH#16476: tighten remotion-display-captions.md (119→117 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -82,6 +82,16 @@
     "status": "simplified",
     "issue": "GH#16179"
   },
+  ".agents/tools/video/remotion-display-captions.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "6dcdc470b94e1e415d3e09b76a06088646364cd9",
+    "issue": "GH#16476",
+    "lines_before": 119,
+    "lines_after": 117,
+    "passes": 1,
+    "note": "Removed redundant intro line (exact duplicate of YAML description). Code blocks preserved verbatim. Zero content loss.",
+    "status": "simplified"
+  },
   ".agents/tools/video/remotion-get-video-dimensions.md": {
     "at": "2026-04-03T05:33:46Z",
     "hash": "c5f36530db3354d5de3048458c3849ec22c1710a",

--- a/.agents/tools/video/remotion-display-captions.md
+++ b/.agents/tools/video/remotion-display-captions.md
@@ -8,8 +8,6 @@ metadata:
 
 # Displaying captions in Remotion
 
-Display `Caption[]` data with TikTok-style pages and per-word highlighting.
-
 ## Install
 
 ```bash


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/video/remotion-display-captions.md` per simplification issue GH#16476.

**Change:** Removed the redundant intro line (line 11) that was an exact duplicate of the YAML `description` field. All code blocks, section headers, and prose preserved verbatim.

## Issue
Closes #16476

## Files changed
- `.agents/tools/video/remotion-display-captions.md` — 119→117 lines (-2)
- `.agents/configs/simplification-state.json` — added entry for this file

## Testing
**Risk level:** Low (docs-only, no code logic)
**Verification:** `self-assessed` — agent doc simplification, no runtime behaviour change.
- All code blocks present before and after (verified by diff)
- All section headers preserved
- No task IDs, GH refs, or command examples in this file — nothing to lose
- `wc -l` confirms 117 lines post-edit

## Key decisions
- File classified as **instruction doc** (not reference corpus) — prose tightening applies
- Only genuine noise removed: the intro line was a verbatim copy of the YAML description, adding zero information
- No further reduction possible without losing meaningful content (code blocks are the primary value)

---
[aidevops.sh](https://aidevops.sh) v3.5.835 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6