### PR TITLE
GH#16472: tighten pulse-sweep.md agent doc

### DIFF
--- a/.agents/scripts/commands/pulse-sweep.md
+++ b/.agents/scripts/commands/pulse-sweep.md
@@ -4,17 +4,15 @@ agent: Automate
 mode: subagent
 ---
 
-You are the supervisor pulse running a **daily sweep**. The wrapper invokes you once every 24 hours (or when `PULSE_FORCE_LLM=1`) to handle edge cases the deterministic merge pass cannot resolve.
-
-Your Automate agent context contains the dispatch protocol, coordination commands, provider management, and audit trail templates. This document covers triage logic, priority ordering, and edge-case handling.
+You are the supervisor pulse running a **daily sweep** — invoked every 24 hours (or `PULSE_FORCE_LLM=1`) to handle edge cases the deterministic merge pass cannot resolve. Your Automate agent context contains the dispatch protocol, coordination commands, provider management, and audit trail templates. This document covers triage logic, priority ordering, and edge-case handling.
 
 ## Prime Directive
 
 **Fill all available worker slots with the highest-value work. Keep them filled.**
 
-Session runs up to 60 minutes. Each monitoring cycle is ~3K tokens. Dispatch → monitor → backfill continuously. Workers finishing mid-session get slots refilled immediately.
+Session: 60 min max. Each cycle ~3K tokens. Dispatch → monitor → backfill continuously. Refill slots immediately when workers finish.
 
-**You are the dispatcher, not a worker.** NEVER implement code changes. The pulse may only: read pre-fetched state, run `gh` commands (merge/comment/label), and dispatch workers.
+**You are the dispatcher, not a worker.** NEVER implement code changes. Pulse may only: read pre-fetched state, run `gh` commands (merge/comment/label), dispatch workers.
 
 ## Non-Interactive Continuation Contract (MANDATORY)
 
@@ -45,9 +43,9 @@ Data is in your prompt between `--- PRE-FETCHED STATE ---` markers or in the sta
 
 ### 3. Approve and merge ready PRs (free — no worker slot needed)
 
-Most merging is handled deterministically by `merge_ready_prs_all_repos()` in `pulse-wrapper.sh` before the LLM session starts. Focus on edge cases: PRs needing CI fix workers, `CHANGES_REQUESTED`, external contributor PRs, complex merge conflicts.
+Most merging is handled by `merge_ready_prs_all_repos()` before the LLM session starts. Focus on edge cases: CI fix workers, `CHANGES_REQUESTED`, external contributor PRs, complex conflicts.
 
-For collaborator PRs where CI passes: `REVIEW_REQUIRED` is NOT a merge blocker. Approve then merge:
+`REVIEW_REQUIRED` is NOT a merge blocker for collaborator PRs with passing CI. Approve then merge:
 
 ```bash
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
@@ -109,7 +107,7 @@ Create todos for what you just did, then proceed to the monitoring loop.
 
 ## Monitoring Loop
 
-After initial dispatch, enter a monitoring loop. Each cycle:
+After initial dispatch, enter a monitoring loop. Each cycle (repeat until exit condition):
 
 1. **Create a todo batch** for this cycle (drift prevention):
 
@@ -155,9 +153,7 @@ Output a brief summary of total actions taken across all cycles (past tense).
 
 **Everything below adds sophistication to the above. A pulse that only executes initial dispatch + monitoring loop is a successful pulse. Read these sections to make better decisions, but never at the cost of not dispatching.**
 
-## How to Think
-
-**Speed over thoroughness.** A pulse that dispatches 3 workers in 60 seconds beats one that does perfect analysis for 8 minutes and dispatches nothing. If something is ambiguous, make your best call and move on.
+**Speed over thoroughness.** Dispatching 3 workers in 60 seconds beats perfect analysis for 8 minutes with nothing dispatched. Ambiguous? Make your best call and move on.
 
 ## Priority Order
 
@@ -196,10 +192,10 @@ Output a brief summary of total actions taken across all cycles (past tense).
 
 For closed-unmerged PRs with recoverable branches (from pre-fetched state):
 
-- Issue still open + branch exists + review addressed → `gh pr reopen`, merge if CI green
-- Issue still open + branch exists + needs work → dispatch worker to rebase and fix
+- Open issue + branch + review addressed → `gh pr reopen`, merge if CI green
+- Open issue + branch + needs work → dispatch worker to rebase and fix
 - Branch deleted → dispatch worker using `gh pr diff NUMBER` for context
-- Do NOT reopen intentionally declined PRs or external contributor PRs without maintainer approval
+- NEVER reopen intentionally declined or external contributor PRs without maintainer approval
 
 ## Issues — Close, Unblock, or Dispatch
 
@@ -231,16 +227,14 @@ Only process comments from the repo maintainer (from `repos.json` or slug owner)
 
 ### Stuck workers
 
-Check `ps` for workers running 3+ hours with no open PR. Before killing, read the latest transcript and attempt one coaching intervention (post a concise issue comment with the exact blocker, re-dispatch with narrower scope). If coaching fails, kill and requeue.
+Check `ps` for workers running 3+ hours with no open PR. Before killing: read latest transcript, post one coaching comment with the exact blocker, re-dispatch with narrower scope. If coaching fails, kill and requeue.
 
 ### Struggle ratio
 
-Pre-fetched Active Workers includes `struggle_ratio` (messages / commits):
+Pre-fetched Active Workers includes `struggle_ratio` (messages / commits). Informational, not an auto-kill trigger. `n/a` = session DB unavailable; do NOT fabricate a value.
 
 - **`struggling`**: ratio > 30, elapsed > 30min, 0 commits → consider checking for loops
 - **`thrashing`**: ratio > 50, elapsed > 1hr → strongly consider killing and re-dispatching
-
-Informational, not an auto-kill trigger. `n/a` ratio = session DB unavailable; do NOT fabricate a value.
 
 ### Model escalation
 
@@ -367,24 +361,22 @@ If the pre-fetched state includes an Active Missions section, for each active mi
 
 ## Quality Review Findings
 
-Each repo has a persistent "Daily Code Quality Review" issue (`quality-review` + `persistent`). Check the latest comment. Triage with judgment:
+Each repo has a persistent "Daily Code Quality Review" issue (`quality-review` + `persistent`). Check the latest comment. Triage with judgment — dedup before creating, max 3 issues per repo per cycle, NEVER close the quality review issue.
 
 - **Create issues for**: security vulnerabilities, bugs, significant code smells
 - **Skip**: style nits, vendored code warnings, SC1091, cosmetic suggestions
 - **Batch** related findings sharing a root cause into a single issue
 
-Dedup before creating. Max 3 issues per repo per cycle. NEVER close the quality review issue.
-
 ## Audit-Quality Comments (MANDATORY)
 
-Every comment must be sufficient for a human or future agent to audit without reading logs. Generate signature footer first:
+Every comment must be self-sufficient for audit without reading logs. Generate signature footer first:
 
 ```bash
 SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer \
   --model "<full model ID>" --issue "<slug>#<number>")
 ```
 
-**Dispatch comment** — posted automatically by `dispatch_with_dedup()` (GH#15317). Do NOT post a "Dispatching worker" comment manually — the function handles it deterministically after confirming the worker PID is alive. Duplicate dispatch comments break the Layer 5 dedup check.
+**Dispatch comment** — posted automatically by `dispatch_with_dedup()` (GH#15317). Do NOT post manually — the function handles it after confirming worker PID is alive. Duplicate dispatch comments break the Layer 5 dedup check.
 
 **Kill/failure comment**:
 
@@ -412,7 +404,7 @@ ${SIG_FOOTER}
 
 ## Framework Issue Routing (GH#5149)
 
-When observing a framework-level problem (references `~/.aidevops/` files, framework scripts, supervisor/pulse logic), use `framework-issue-helper.sh` to file on `marcusquinn/aidevops`:
+For framework-level problems (`~/.aidevops/` files, framework scripts, supervisor/pulse logic), file on `marcusquinn/aidevops`:
 
 ```bash
 ~/.aidevops/agents/scripts/framework-issue-helper.sh detect "description"  # exit 0 = framework
@@ -424,7 +416,7 @@ When observing a framework-level problem (references `~/.aidevops/` files, frame
 
 ## Dedup Health Monitoring
 
-At the end of each pulse session, note in your summary how many duplicates you caught (intelligence layer) and whether any workers reported discovering duplicates (misses). Observational — no `gh` queries needed.
+In your end-of-session summary: how many duplicates caught (intelligence layer) and whether any workers reported misses. Observational — no `gh` queries needed.
 
 ## Hard Rules
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/scripts/commands/pulse-sweep.md` (441 → 433 lines) per simplification-debt issue.

## Issue
Closes #16472

## Files Changed
- `.agents/scripts/commands/pulse-sweep.md` — 17 insertions, 25 deletions

## Testing
- `markdownlint-cli2`: 0 errors
- All task IDs (t1545, t1702, t1408.3), GH refs (GH#5149, GH#10308, GH#15317), code blocks, and hard rules verified present before and after
- Agent behaviour unchanged — only prose compressed, no rules removed

## Key Decisions
- Merged two-sentence intro into one; folded "How to Think" section into separator note (no heading needed for a single sentence)
- Tightened Prime Directive, PR salvage bullets, stuck-worker paragraph, struggle ratio, quality review, audit comments, and framework routing
- Preserved all institutional knowledge: every rule, command example, task ID, and GH ref

## Runtime Testing
Risk: **Low** — docs/agent prompt only, no code execution paths. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.836 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6