### PR TITLE
GH#16211: tighten rules-streaming-avatars.md (Streaming Avatars, 71→67 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -15,6 +15,14 @@
     "pr": "pending",
     "status": "simplified"
   },
+  ".agents/content/heygen-skill/rules-streaming-avatars.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "db7582c5895ac7185939740cb16cbe5f72afd9ebad7bb4586b8eee5897af27d3",
+    "issue": "GH#16211",
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
+  },
   ".agents/content/production-video-02-sora-template.md": {
     "at": "2026-04-03T00:00:00Z",
     "hash": "7d18119d4d8ff939a2c5e2f708799a7a2511414b597c5b58a4b36015fe7f322e",
@@ -50,6 +58,11 @@
     "issue": "GH#15076",
     "lines_after": 130,
     "lines_before": 142,
+    "status": "simplified"
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
+    "hash": "1253c92066cfa913e522251a5dc37bd66b8a581483d712f7f3556afbdc2c03cd",
+    "issue": "GH#15840",
     "status": "simplified"
   },
   ".agents/services/hosting/cloudflare-platform-skill/pipelines.md": {

--- a/.agents/content/heygen-skill/rules-streaming-avatars.md
+++ b/.agents/content/heygen-skill/rules-streaming-avatars.md
@@ -1,13 +1,9 @@
 ---
 name: streaming-avatars
-description: Real-time interactive avatar sessions for HeyGen
-metadata:
-  tags: streaming, real-time, interactive, webrtc, live
+description: Real-time interactive avatar sessions for HeyGen via WebRTC — live customer service, virtual assistants, interactive apps
 ---
 
 # Streaming Avatars
-
-Real-time interactive avatar via WebRTC. Use for live customer service, virtual assistants, interactive apps.
 
 ## Create Session
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/content/heygen-skill/rules-streaming-avatars.md` per build-agent simplification principles (GH#16211).

**Changes:**
- Merged redundant intro paragraph into frontmatter `description` field (one source of truth)
- Removed `metadata.tags` block (tags not consumed by any agent tooling)
- Result: 71 → 67 lines, no content loss

## Issue
Closes #16211

## Files Changed
- `.agents/content/heygen-skill/rules-streaming-avatars.md` — tightened frontmatter, removed redundant intro
- `.agents/configs/simplification-state.json` — updated hash registry

## Testing
**Risk level:** Low (docs/agent prompt, no code logic)
**Runtime testing:** `self-assessed` — agent behaviour unchanged; all API endpoints, code blocks, and best practices preserved verbatim. Content verification: all URLs, code examples, and table entries present before and after.

## Key Decisions
- Classified as instruction doc (not reference corpus): tighten prose, not split into chapters
- Tags removed: `metadata.tags` field has no consumer in current agent tooling; description field covers the same ground more concisely

---
[aidevops.sh](https://aidevops.sh) v3.5.836 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6