### PR TITLE
GH#16493: tighten immutability.md Best Practices prose

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5177,5 +5177,10 @@
     "hash": "b767318f3046f9a52ff3d31a2f733bb83f4e5475501f57862a874c05e853ad7b",
     "issue": "GH#16449",
     "status": "simplified"
+  },
+  ".agents/tools/programming/modern-javascript-skill/immutability.md": {
+    "hash": "f5453a48a29c9dd411399f4079384edf",
+    "status": "simplified",
+    "issue": "GH#16493"
   }
 }

--- a/.agents/tools/programming/modern-javascript-skill/immutability.md
+++ b/.agents/tools/programming/modern-javascript-skill/immutability.md
@@ -96,6 +96,6 @@ const newState = setIn(state, ['users', 'u1', 'profile', 'name'], 'Alice');
 
 ## Best Practices
 
-- **`const` by default; never mutate parameters** — prevent reassignment, always return new objects
-- **Separate pure logic from I/O** — extract side effects to boundaries
+- **`const` by default; never mutate parameters** — always return new values
+- **Separate pure logic from I/O** — push side effects to the edges
 - **Inject non-determinism** — pass `Date.now`, `Math.random` as params for testability


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
**What:** Tighten prose in the Best Practices section of `immutability.md` — remove redundant explanatory clauses while preserving all code examples and knowledge.

**Issue:** Closes #16493

**Files changed:** `.agents/tools/programming/modern-javascript-skill/immutability.md`, `.agents/configs/simplification-state.json`

**Classification:** Reference corpus (domain knowledge base with code examples). At 101 lines, already compact — no chapter splitting needed. Prose tightening applied to Best Practices section only.

**Changes:**
- `'prevent reassignment, always return new objects'` → `'always return new values'` (removes redundancy with `const` and "never mutate parameters")
- `'extract side effects to boundaries'` → `'push side effects to the edges'` (aligns with intro line's "push I/O to the edge" — consistent terminology)

**Testing:** All code blocks, URLs, Quick Reference table, and examples verified present before and after. Line count unchanged (101). Agent behaviour unchanged.

**Key decisions:** File classified as reference corpus per issue guidance. Prose-only tightening applied (not chapter splitting) since file is already within the ~300-line threshold.

## Runtime Testing

Risk: **Low** — docs/agent prompts only. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.836 plugin for [OpenCode](https://opencode.ai) v1.3.13