### PR TITLE
GH#16500: tighten Playwright benchmark scripts doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,4 +1,12 @@
 {
+  ".agents/tools/browser/browser-benchmark-scripts-01-playwright.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "9958f23ad99c271fe00d6abb99241cff82ffae9db2b351bc5a15129693063569",
+    "issue": "GH#16500",
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
+  },
   ".agents/aidevops/api-integrations.md": {
     "at": "2026-04-03T00:00:00Z",
     "hash": "1d9ae72e2a62060ee1524f7440825f1a5539f3ce2e64b691d67d66ea36cf0edb",

--- a/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-01-playwright.md
@@ -53,9 +53,7 @@ async function run() {
 run();
 ```
 
-## Parallel script
-
-Measures multi-context, multi-browser, and multi-page throughput.
+## Parallel script — multi-context, multi-browser, multi-page throughput
 
 ```javascript
 import { chromium } from 'playwright';


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/browser/browser-benchmark-scripts-01-playwright.md` (91→89 lines) per GH#16500.

**Classification:** Reference corpus (benchmark scripts with code blocks) — content not compressed, only prose restructured.

**Change:** Fold standalone parallel script description into section header:
- Before: `## Parallel script` + blank line + `Measures multi-context, multi-browser, and multi-page throughput.`
- After: `## Parallel script — multi-context, multi-browser, multi-page throughput`

**Verification:**
- All code blocks preserved verbatim (sequential + parallel scripts)
- All URLs preserved (`https://the-internet.herokuapp.com`)
- No task ID refs or command examples in this file
- Line count: 91 → 89 (2 lines removed: blank + standalone description)
- `simplification-state.json` updated with new hash

## Runtime Testing

Risk: **Low** — docs-only change, no code execution paths affected. `self-assessed`.

Closes #16500

<!-- MERGE_SUMMARY -->
**What:** Tighten Playwright benchmark scripts chapter doc — fold description into section header.
**Issue:** GH#16500
**Files changed:** `.agents/tools/browser/browser-benchmark-scripts-01-playwright.md`, `.agents/configs/simplification-state.json`
**Testing:** Docs-only, self-assessed. Code blocks verified verbatim.
**Key decisions:** Classified as reference corpus — code not compressed, only redundant prose line removed.

---
[aidevops.sh](https://aidevops.sh) v3.5.836 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6