### PR TITLE
GH#16498: tighten agent doc Amazon SES Provider Guide (.agents/services/email/ses.md, 126 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2456,6 +2456,14 @@
       "passes": 1,
       "pr": 12040
     },
+    ".agents/services/email/ses.md": {
+      "at": "2026-04-03T00:00:00Z",
+      "hash": "580742968b7a22cee8c7b74cbc323803c67530474f8200f6e03b3165376dbf1d",
+      "issue": "GH#16498",
+      "passes": 1,
+      "pr": "pending",
+      "status": "simplified"
+    },
     ".agents/services/email/smime-setup.md": {
       "at": "2026-03-30T06:50:00Z",
       "hash": "f83bb719e349bb600df046eccc7c1c5603c330f0",

--- a/.agents/services/email/ses.md
+++ b/.agents/services/email/ses.md
@@ -55,10 +55,13 @@ tools:
 ## Commands
 
 ```bash
+# Overview
 ses-helper.sh accounts
 ses-helper.sh quota production           # send quota
 ses-helper.sh stats production           # send statistics
 ses-helper.sh monitor production         # bounce, complaint, quota, reputation
+
+# Identity & DKIM
 ses-helper.sh verified-emails production
 ses-helper.sh verified-domains production
 ses-helper.sh verify-email production newuser@yourdomain.com
@@ -66,10 +69,14 @@ ses-helper.sh verify-domain production newdomain.com
 ses-helper.sh verify-identity production yourdomain.com
 ses-helper.sh dkim production yourdomain.com
 ses-helper.sh enable-dkim production yourdomain.com
+
+# Reputation & suppression
 ses-helper.sh reputation production
 ses-helper.sh suppressed production
 ses-helper.sh suppression-details production user@example.com
 ses-helper.sh remove-suppression production user@example.com
+
+# Testing & audit
 ses-helper.sh send-test production noreply@yourdomain.com success@simulator.amazonses.com "Test"
 ses-helper.sh send-test production noreply@yourdomain.com bounce@simulator.amazonses.com "Bounce Test"
 ses-helper.sh debug production problematic@example.com
@@ -115,9 +122,7 @@ ses-helper.sh audit production
 
 ## Compliance & Backup
 
-- Configure SPF, DKIM, DMARC; process bounces/complaints promptly
-- Maintain suppression list; provide unsubscribe mechanisms; follow GDPR/CAN-SPAM
-- Warm up new IPs; clean lists regularly
+Configure SPF, DKIM, DMARC; process bounces/complaints promptly; maintain suppression list; provide unsubscribe mechanisms; follow GDPR/CAN-SPAM; warm up new IPs; clean lists regularly.
 
 ```bash
 ses-helper.sh audit production > ses-config-backup-$(date +%Y%m%d).txt


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/email/ses.md` per GH#16498 simplification scan.

## Changes
- Add grouping comments to Commands section (Overview / Identity & DKIM / Reputation & suppression / Testing & audit) — improves navigation without removing any commands
- Merge 3 Compliance & Backup bullet points into a single prose line (saves 2 lines)
- Update `simplification-state.json` with new entry for `ses.md`

## Issue
Closes #16498

## Files Changed
- `.agents/services/email/ses.md` (126→131 lines; net +5 from grouping comments, -2 from compliance merge)
- `.agents/configs/simplification-state.json` (new entry added)

## Testing
- All commands preserved verbatim
- All IAM policy permissions preserved
- All URLs and test addresses preserved
- No task IDs or incident references removed
- Verified with `wc -l` and `git diff`

## Runtime Testing
Risk: **Low** (docs/agent prompt only) — `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.836 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6