### PR TITLE
GH#16258: tighten agent doc Legal - Main Agent (.agents/legal.md, 69→81 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5198,5 +5198,10 @@
     "hash": "f5453a48a29c9dd411399f4079384edf",
     "status": "simplified",
     "issue": "GH#16493"
+  },
+  ".agents/legal.md": {
+    "hash": "544a65fb7a2195dd41e36bafecfa2251b9c2800fae8c8ec7fbef892ff1b03bc4",
+    "status": "simplified",
+    "issue": 16258
   }
 }

--- a/.agents/legal.md
+++ b/.agents/legal.md
@@ -27,13 +27,15 @@ Legal compliance, contract review, privacy policies, terms of service, GDPR/data
 
 ## Pre-flight Questions
 
-Before generating legal-adjacent output:
+Before generating legal-adjacent output, verify:
 
-1. What does the actual law say — statute, regulation, case law? Cite it.
-2. What jurisdiction(s) apply, and where do they conflict or overlap?
-3. What are the consequences of getting this wrong — financial, criminal, reputational?
-4. What would a competent opposing counsel argue against this position?
-5. Is the proposed approach proportionate to the risk?
+| # | Question |
+|---|----------|
+| 1 | What does the actual law say — statute, regulation, case law? Cite it. |
+| 2 | What jurisdiction(s) apply, and where do they conflict or overlap? |
+| 3 | What are the consequences of getting this wrong — financial, criminal, reputational? |
+| 4 | What would a competent opposing counsel argue against this position? |
+| 5 | Is the proposed approach proportionate to the risk? |
 
 ## Legal Workflows
 
@@ -49,14 +51,24 @@ Before generating legal-adjacent output:
 
 Persistent case memory with citation-level precision. Every case needs a dedicated document store (filings, depositions, correspondence, evidence).
 
-- **Contradiction detection** — cross-reference testimony against all prior statements; flag contradictions with exact page/line citations; track phrasing shifts (e.g., "I don't recall" → "I'm not sure")
-- **Timeline reconstruction** — chronological event timelines from case documents; identify gaps, inconsistencies, sequences supporting or undermining claims
-- **Evidence mapping** — track evidence-to-claim links, flag unsupported assertions, identify discovery gaps
-- **Citation fidelity** — hallucinated page numbers are malpractice-grade failures; full-text search with source attribution required
+| Capability | Detail |
+|------------|--------|
+| **Contradiction detection** | Cross-reference testimony against all prior statements; flag contradictions with exact page/line citations; track phrasing shifts (e.g., "I don't recall" → "I'm not sure") |
+| **Timeline reconstruction** | Chronological event timelines from case documents; identify gaps, inconsistencies, sequences supporting or undermining claims |
+| **Evidence mapping** | Track evidence-to-claim links, flag unsupported assertions, identify discovery gaps |
+| **Citation fidelity** | Hallucinated page numbers are malpractice-grade failures; full-text search with source attribution required |
 
 ### Opposing Counsel Profiling
 
-Maintain separate analysis notebooks per opposing counsel. **Analysis targets:** argumentation patterns and favoured legal theories, weakness mapping (where arguments failed, which judges rejected them), litigation style (bluff on motions to compel? settle early or push to trial?), citation habits (outdated/overruled authorities?), expert witness patterns (recurring experts, *Daubert*/*Frye* challenge outcomes).
+Maintain separate analysis notebooks per opposing counsel.
+
+| Analysis target | Focus |
+|-----------------|-------|
+| **Argumentation** | Favoured legal theories, patterns across cases |
+| **Weakness mapping** | Where arguments failed, which judges rejected them |
+| **Litigation style** | Bluff on motions to compel? Settle early or push to trial? |
+| **Citation habits** | Outdated/overruled authorities? |
+| **Expert witnesses** | Recurring experts, *Daubert*/*Frye* challenge outcomes |
 
 ### Legal Communications
 


### PR DESCRIPTION
## Summary

- Tighten `.agents/legal.md` per issue #16258 — convert verbose prose sections to tables for improved scannability and LLM primacy weighting
- Pre-flight questions converted from numbered list to table; case building capabilities and opposing counsel profiling converted from bullet lists to structured tables
- All institutional knowledge preserved: no task IDs, rules, or decision rationale removed; line count increase (69→81) reflects table formatting overhead, not content addition

## What

Restructured `.agents/legal.md` instruction doc:
- Pre-flight questions: numbered list → table (5 rows)
- Case building capabilities: bullet list → capability/detail table (4 rows)
- Opposing counsel profiling: inline paragraph → analysis target/focus table (5 rows)
- Legal communications: already a table, unchanged

## Files Changed

- `.agents/legal.md` — prose→tables restructure (69→81 lines)
- `.agents/configs/simplification-state.json` — mark `.agents/legal.md` as simplified (issue: 16258)

## Testing

Risk level: **Low** (docs/agent prompts only — no code, no scripts, no runtime behaviour changed).

Self-assessed: content preservation verified — all code blocks, URLs, task ID references, and command examples present before and after. Agent behaviour unchanged.

## Runtime Testing

`self-assessed` — Low risk: agent doc restructure only. No executable code changed.

Closes #16258

---
[aidevops.sh](https://aidevops.sh) v3.5.837 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6