### PR TITLE
GH#16501: tighten queues-gotchas.md prose

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md
@@ -1,10 +1,10 @@
-# Gotchas
+# Queues Gotchas
 
 See [queues.md](./queues.md), [queues-patterns.md](./queues-patterns.md).
 
 ## Delivery Semantics
 
-Queues are at-least-once; no ordering guarantee. Design for idempotency — ack only after durable success.
+At-least-once; no ordering guarantee. Design for idempotency — ack only after durable success.
 
 ```typescript
 const processed = await env.PROCESSED_KV.get(msg.id);
@@ -24,7 +24,7 @@ await env.MY_QUEUE.send(data, { contentType: 'json' }); // always use json for p
 
 ## Retries and CPU Budget
 
-Handler exits without `ack()` or `retry()` → Cloudflare retries per queue policy. Default CPU budget is 30s; raise for heavier work.
+Handler exits without `ack()` or `retry()` → Cloudflare retries per queue policy. Default CPU budget is 30s; raise for heavier work. Log failures with enough context to replay or diagnose; configure a DLQ for permanent failures.
 
 ```typescript
 async queue(batch: MessageBatch): Promise<void> {
@@ -44,18 +44,14 @@ async queue(batch: MessageBatch): Promise<void> {
 { "limits": { "cpu_ms": 300000 } } // 5 minutes
 ```
 
-Log failures with enough context to replay or diagnose. Configure a DLQ for permanent failures.
-
 ## Cost and Throughput
 
-Each message = 3 ops (write + read + delete). Retries add reads. Cost beyond free tier: `((messages × 3) - 1M) / 1M × $0.40`. Keep messages <64 KB (charged per 64 KB chunk).
+Each message = 3 ops (write + read + delete). Retries add reads. Cost beyond free tier: `((messages × 3) - 1M) / 1M × $0.40`. Keep messages <64 KB (charged per 64 KB chunk). Use `waitUntil()` for non-blocking sends; batch sends when possible.
 
 ```jsonc
 // wrangler.toml [queues.consumers]
 { "max_batch_size": 100, "max_batch_timeout": 30 }
 ```
-
-Use `waitUntil()` for non-blocking sends. Batch sends when possible.
 
 | Limit | Value |
 |-------|-------|
@@ -82,7 +78,7 @@ wrangler tail my-worker                                       # Check logs
 
 ### High DLQ rate
 
-- Review consumer error logs.
-- Check external dependency availability.
-- Verify message format matches expectations.
-- Increase retry delay: `"retry_delay": 300`.
+- Review consumer error logs
+- Check external dependency availability
+- Verify message format matches expectations
+- Increase retry delay: `"retry_delay": 300`


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md` (88 → 84 lines).

## Issue
Closes #16501

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md` — prose tightened, no content removed

## Changes
- `# Gotchas` → `# Queues Gotchas` (more descriptive when viewed standalone)
- Removed redundant subject "Queues are" from Delivery Semantics intro
- Merged orphaned "Log failures..." sentence into Retries section intro
- Merged orphaned "Use `waitUntil()`..." sentence into Cost section intro
- Removed trailing periods from troubleshooting bullet points (consistency)

## Testing
**Risk level:** Low (docs/agent prompt only — no code, no runtime behaviour change)
**Verification:** All code blocks, URLs, command examples, and limits table preserved. `wc -l` before: 88, after: 84. `git diff` reviewed — no knowledge removed.

## Runtime Testing
`self-assessed` — Low risk: agent prompt doc, no executable code changed.

---
[aidevops.sh](https://aidevops.sh) v3.5.837 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6