### PR TITLE
GH#16502: tighten agent doc Gotchas & Troubleshooting (realtime-sfu-gotchas.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5198,5 +5198,13 @@
     "hash": "f5453a48a29c9dd411399f4079384edf",
     "status": "simplified",
     "issue": "GH#16493"
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "b2dcaa7150cdce0316c029f0c91a10e471e081141e07d60441620219c128c154",
+    "issue": "GH#16502",
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md
@@ -2,7 +2,7 @@
 
 ## Security
 
-❌ Never expose App Secret client-side (use backend env vars, Wrangler secrets)
+Never expose App Secret client-side (use backend env vars, Wrangler secrets).
 Track IDs = capabilities, authz required:
 
 ```ts


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md` per simplification scan (GH#16502).

**Change:** Remove decorative `❌` emoji from security rule line. All technical content, code blocks, checklists, comparison table, and quick reference preserved.

**Classification:** Instruction doc (gotchas/troubleshooting), not a reference corpus — tightening is appropriate. File was already compact at 83 lines; minimal change required.

## Issue
Closes #16502

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md` — remove decorative emoji, add period for consistency
- `.agents/configs/simplification-state.json` — record simplification state entry

## Testing

**Risk level:** Low (docs/agent prompts — no runtime behaviour)

**Verification:**
- `markdownlint-cli2` → 0 errors
- All code blocks present: 3 TypeScript blocks + 1 bash block ✓
- All URLs preserved: `chrome://webrtc-internals` ✓
- All command examples preserved: POST/PUT API endpoints ✓
- No task IDs or GH# refs in original file (none to preserve) ✓
- Line count: 83 → 83 (no content removed, only emoji replaced with period)

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.837 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6