### PR TITLE
GH#16513: tighten openapi-search.md (80→78 lines)

### DIFF
--- a/.agents/tools/context/openapi-search.md
+++ b/.agents/tools/context/openapi-search.md
@@ -24,9 +24,7 @@ mcp:
 ## Quick Reference
 
 - **Purpose**: Navigate any API's OpenAPI spec without loading full docs into context
-- **Install**: Zero install — remote Cloudflare Worker at `https://openapi-mcp.openapisearch.com/mcp`
-- **Auth**: None required
-- **Backend**: `https://search.apis.guru/v1` (override via `OPENAPI_SEARCH_URL`)
+- **Install**: Zero install — remote Cloudflare Worker, no auth required; backend `https://search.apis.guru/v1` (override via `OPENAPI_SEARCH_URL`)
 - **Workflow**: `searchAPIs` → `getAPIOverview` → `getOperationDetails`
 - **Enabled for**: `@openapi-search` subagent only (lazy-loaded — zero install overhead)
 - **Docs**: <https://github.com/janwilmake/openapi-mcp-server> | **Directory**: <https://openapisearch.com/search>
@@ -52,7 +50,7 @@ Auto-configured by `setup.sh` / `generate-opencode-agents.sh`. Manual (Claude Co
 claude mcp add --scope user openapi-search --transport http https://openapi-mcp.openapisearch.com/mcp
 ```
 
-Other clients: add `mcpServers.openapi-search` with `type: http`, `url: https://openapi-mcp.openapisearch.com/mcp`. Exceptions: OpenCode → `type: remote`; Continue.dev → `type: sse`; Zed → `context_servers`.
+Other clients: `mcpServers.openapi-search` with `type: http`, `url: https://openapi-mcp.openapisearch.com/mcp`. Exceptions: OpenCode → `type: remote`; Continue.dev → `type: sse`; Zed → `context_servers`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Merged `Install` + `Auth` bullet points into one line (both describe zero-setup remote access)
- Dropped redundant `add` prefix in other-clients setup sentence
- All institutional knowledge preserved: URLs, command examples, decision rules, task IDs

## What

Tighten `.agents/tools/context/openapi-search.md` from 80 → 78 lines per automated simplification scan.

## Issue

Closes #16513

## Files Changed

- `.agents/tools/context/openapi-search.md` — 2 lines removed, no content loss

## Testing

- `npx markdownlint-cli2`: 0 errors
- Content preservation verified: all code blocks, URLs, and command examples present before and after
- Agent behaviour unchanged (instruction doc, no logic altered)

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code logic changed.
**Assessment:** `self-assessed` — no runtime verification required per testing gate.

<!-- MERGE_SUMMARY -->
**What:** Tighten openapi-search.md prose (80→78 lines) — merge redundant install/auth bullets, drop verbose prefix in setup sentence.
**Issue:** Closes #16513
**Files changed:** 1 (`.agents/tools/context/openapi-search.md`)
**Testing:** markdownlint 0 errors; content preservation verified
**Key decisions:** Classified as instruction doc (not reference corpus) — prose compression appropriate

---
[aidevops.sh](https://aidevops.sh) v3.5.837 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6