### PR TITLE
GH#16514: tighten cro-chapter-21.md prose

### DIFF
--- a/.agents/marketing-sales/cro-chapter-21.md
+++ b/.agents/marketing-sales/cro-chapter-21.md
@@ -21,16 +21,11 @@ Structure: **IF** [change], **THEN** [expected result], **BECAUSE** [reasoning]
 
 Test multiple variables simultaneously to detect interaction effects. Example (2×2×2 = 8 variations): Headline A/B × Image X/Y × CTA Red/Blue
 
-| | |
-|---|---|
-| **Benefits** | Interaction effects, sample-efficient when interactions matter |
-| **Challenges** | Complex analysis, more traffic required, implementation complexity |
+**Benefits:** Interaction effects, sample-efficient when interactions matter. **Challenges:** Complex analysis, more traffic required, implementation complexity.
 
 ### Bandit Algorithms
 
-Dynamic traffic allocation to winning variations during the test.
-
-**Epsilon-Greedy:** 90% traffic to current best, 10% exploration, adapts in real-time. Use for continuous optimization, long-running campaigns, seasonal adjustments.
+**Epsilon-Greedy:** Dynamically allocates 90% traffic to current best, 10% exploration, adapts in real-time. Use for continuous optimization, long-running campaigns, seasonal adjustments.
 
 ## 21.3 Statistical Rigor
 


### PR DESCRIPTION
## Summary

Tighten `.agents/marketing-sales/cro-chapter-21.md` per simplification-debt issue GH#16514.

**Classification:** Reference corpus (CRO domain knowledge). At 78 lines, splitting into chapter files is not warranted. Applied prose tightening only.

**Changes:**
- Replace headerless 2-column table (Benefits/Challenges) with inline bold labels — eliminates empty header cells
- Merge redundant "Dynamic traffic allocation" intro sentence into Epsilon-Greedy description
- 78 → 73 lines, zero knowledge loss

**Verification:**
- All code blocks preserved (SQL segment analysis query intact)
- All statistical methods preserved (Type I/II errors, sequential testing methods)
- All dimensions preserved (segment, cohort analysis)
- No task IDs, issue refs, or URLs in original — none to verify

## Runtime Testing

Risk: **Low** — documentation-only change, no code paths affected. Self-assessed.

Closes #16514

---
<!-- MERGE_SUMMARY -->
**What:** Tighten CRO chapter 21 prose — fix headerless table, merge redundant sentence. 78→73 lines.
**Issue:** GH#16514
**Files changed:** `.agents/marketing-sales/cro-chapter-21.md`
**Testing:** Self-assessed (docs-only, low risk)
**Key decisions:** Reference corpus classification → prose tighten only, no chapter split needed at 78 lines

---
[aidevops.sh](https://aidevops.sh) v3.5.837 plugin for [OpenCode](https://opencode.ai) v1.3.13