### PR TITLE
GH#16502: tighten realtime-sfu-gotchas.md prose

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md
@@ -2,7 +2,7 @@
 
 ## Security
 
-❌ Never expose App Secret client-side (use backend env vars, Wrangler secrets)
+Never expose App Secret client-side (use backend env vars, Wrangler secrets)
 Track IDs = capabilities, authz required:
 
 ```ts


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md` per GH#16502.

Removed decorative `❌` emoji from the Security section rule. The emoji adds no information — the imperative prose ("Never expose...") is self-sufficient. All other content unchanged.

## Issue
Closes #16502

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md` — 1 line changed (emoji removed)

## Classification
Reference corpus (domain knowledge base). At 83 lines, already compact — no restructuring needed. Only decorative noise removed per code-simplifier "Safe (high confidence)" category.

## Content Preservation Verification
- All code blocks present: 3 TypeScript blocks + 1 bash block ✓
- All URLs present: `chrome://webrtc-internals` ✓
- All command examples present: POST/PUT API endpoints ✓
- All knowledge preserved: security rules, checklists, debug patterns, pricing, comparison table ✓
- No task IDs or GH# refs in this file ✓

## Runtime Testing
Risk: **Low** — docs/agent prompt file only. No runtime verification required (`self-assessed`).

---
[aidevops.sh](https://aidevops.sh) v3.5.838 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved readability of security guidance documentation by clarifying formatting of best practices for credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->