### PR TITLE
GH#16526: tighten legal.md prose

### DIFF
--- a/.agents/legal.md
+++ b/.agents/legal.md
@@ -19,7 +19,7 @@ subagents:
 
 ## Role
 
-Legal compliance, contract review, privacy policies, terms of service, GDPR/data protection, regulatory guidance, compliance checklists, case building, litigation support, and legal communications. Own all legal work — never redirect to other agents. Answer directly with structured, actionable guidance.
+Legal compliance, contract review, privacy policies, terms of service, GDPR/data protection, regulatory guidance, compliance checklists, case building, litigation support, and legal communications. Own all legal work — never redirect to other agents.
 
 **Disclaimer**: AI legal assistance is informational only. Consult qualified legal professionals for binding advice. All AI-generated citations must be manually verified before use in filings or proceedings.
 
@@ -27,7 +27,7 @@ Legal compliance, contract review, privacy policies, terms of service, GDPR/data
 
 ## Pre-flight Questions
 
-Before generating legal-adjacent output, verify:
+Verify before generating legal-adjacent output:
 
 | # | Question |
 |---|----------|
@@ -49,7 +49,7 @@ Before generating legal-adjacent output, verify:
 
 ### Case Building and Management
 
-Persistent case memory with citation-level precision. Every case needs a dedicated document store (filings, depositions, correspondence, evidence).
+Persistent case memory with citation-level precision. Each case requires a dedicated document store (filings, depositions, correspondence, evidence).
 
 | Capability | Detail |
 |------------|--------|
@@ -60,7 +60,7 @@ Persistent case memory with citation-level precision. Every case needs a dedicat
 
 ### Opposing Counsel Profiling
 
-Maintain separate analysis notebooks per opposing counsel.
+Maintain separate analysis notebooks per counsel.
 
 | Analysis target | Focus |
 |-----------------|-------|


### PR DESCRIPTION
## Summary

- Remove redundant instruction in Role section ("Answer directly with structured, actionable guidance" is implied by "Own all legal work")
- Tighten pre-flight header from passive to active voice
- Minor prose compression in Case Building and Opposing Counsel sections
- All institutional knowledge, task IDs, command examples, and table content preserved

## What

Prose tightening of `.agents/legal.md` per simplification scan (GH#16526). File classified as **instruction doc** — content compressed, not restructured.

## Testing

- `wc -l`: 81 lines (unchanged — changes are prose-level, not structural)
- All code blocks, URLs, and table content verified present before and after
- Agent behaviour unchanged: same workflows, same pre-flight questions, same capabilities

## Runtime Testing

**Risk level**: Low (docs/agent prompts only — no code, no runtime behaviour)
**Verification**: `self-assessed` — no runtime environment required for doc changes

Closes #16526

---
<!-- MERGE_SUMMARY -->
**What**: Tighten prose in `.agents/legal.md` instruction doc
**Issue**: GH#16526
**Files changed**: `.agents/legal.md` (4 lines changed, no content loss)
**Testing**: Self-assessed (low-risk doc change)
**Key decisions**: Classified as instruction doc (not reference corpus) — prose compression applied, not chapter splitting

---
[aidevops.sh](https://aidevops.sh) v3.5.838 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6