### PR TITLE
GH#16552: simplify notes.md agent doc

### DIFF
--- a/.agents/tools/productivity/notes.md
+++ b/.agents/tools/productivity/notes.md
@@ -19,9 +19,8 @@ tools:
 ## Quick Reference
 
 - **Helper**: `~/.aidevops/agents/scripts/notes-helper.sh [command] [args]`
-- **macOS backend**: `osascript` via Notes.app (no install needed)
-- **Linux/Windows backend**: `nb` (CLI notebook, `brew install nb`)
-- **Setup**: `notes-helper.sh setup`
+- **macOS**: `osascript` via Notes.app — no install needed; `notes-helper.sh setup` for Automation permission
+- **Linux/Windows**: `nb` CLI — `brew install nb`; `notes-helper.sh setup`; optional `nb remote set <url>` for git sync
 - **Folders**: Notes (default), Work, Personal, Research — ask user if unclear
 - **Related**: `tools/productivity/apple-reminders.md`, `tools/productivity/calendar.md`, `tools/productivity/contacts.md`
 
@@ -35,37 +34,24 @@ tools:
 
 ## Usage
 
-### Create
-
 ```bash
+# Create
 notes-helper.sh add "Project ideas" --body "Feature X, integration Y"
 notes-helper.sh add "Sprint retrospective" --body "What went well: ..." --folder Work
 notes-helper.sh add "Read later: distributed systems paper"   # title only
-```
 
-### View and search
-
-```bash
+# View and search
 notes-helper.sh folders                          # List folders/notebooks
 notes-helper.sh show today                       # Notes modified today
 notes-helper.sh show week --folder Work          # This week's work notes
 notes-helper.sh view "Sprint retrospective"      # View specific note
 notes-helper.sh search "distributed systems"     # Full-text search
 notes-helper.sh search "API" --folder Work       # Search within folder
-```
 
-### Manage
-
-```bash
+# Manage
 notes-helper.sh delete "Old draft"
 notes-helper.sh sync                             # nb only; macOS is automatic
 ```
-
-## Setup
-
-**macOS** (no install needed): `notes-helper.sh setup` — may need System Settings > Privacy & Security > Automation. All Internet Accounts appear as folders automatically.
-
-**Linux/Windows**: `notes-helper.sh setup` — requires `nb` (`brew install nb`). Optional: `nb remote set <url>` for git sync.
 
 ## Platform Differences
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/productivity/notes.md` instruction doc from 81 to 67 lines (17% reduction).

## Changes
- Merged Setup section into Quick Reference (saves 6 lines, reduces section count)
- Collapsed Usage subsections (Create/View/Manage) into a single code block (saves ~8 lines)
- Preserved all commands, examples, platform differences table, and institutional knowledge

## Issue
Closes #16552

## Files Changed
- `.agents/tools/productivity/notes.md` — 81 → 67 lines

## Testing
**Risk level**: Low (docs/agent prompt only — no code, no runtime behaviour change)
**Runtime Testing**: `self-assessed` — agent prompt change; no executable code modified

## Key Decisions
- File classified as **instruction doc** (not reference corpus): tighten prose, not split into chapters
- Platform differences table retained as-is — it's genuinely useful reference data
- All command examples preserved verbatim

---
[aidevops.sh](https://aidevops.sh) v3.5.840 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick reference guide with more explicit setup instructions and workflow details for macOS and Linux/Windows environments
  * Streamlined documentation formatting for improved readability
  * Consolidated command examples while preserving all available commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->