### PR TITLE
GH#16553: tighten agent doc jujutsu.md (76 lines)

### DIFF
--- a/.agents/tools/git/jujutsu.md
+++ b/.agents/tools/git/jujutsu.md
@@ -28,11 +28,11 @@ tools:
 
 | Feature | Behaviour | Agent benefit |
 |---------|-----------|--------------|
-| **Working-copy-as-commit** | File changes auto-recorded; no staging area. `jj describe` sets message anytime. | No `git add` errors; file writes auto-commit |
-| **Operation log + undo** | `jj op log` full history; `jj undo` reverses last op; `jj op restore <id>` any state. | Safe rollback; complete audit trail for headless debugging |
-| **First-class conflicts** | Conflicts stored in commits, not blocking errors. Resolutions propagate to descendants (subsumes `git rerere`). | Overlapping edits produce committed conflicts, not blocking errors |
-| **Auto-rebase descendants** | Modifying any commit rebases all descendants in place. | One object type vs git's working tree + index + HEAD + stash |
-| **Anonymous branches** | All visible heads tracked — commits never lost. Named bookmarks only needed for remotes. | Safe experimentation without branch management overhead |
+| **Working-copy-as-commit** | File changes auto-recorded; no staging area; `jj describe` sets message anytime. | No `git add` errors; file writes auto-commit |
+| **Operation log + undo** | `jj op log` full history; `jj undo` reverses last op; `jj op restore <id>` any state. | Safe rollback; complete audit trail |
+| **First-class conflicts** | Conflicts stored in commits, not blocking errors; resolutions propagate to descendants (subsumes `git rerere`). | Overlapping edits produce committed conflicts, not blocking errors |
+| **Auto-rebase descendants** | Modifying any commit rebases all descendants in place. | Simpler object model vs git's working tree + index + HEAD + stash |
+| **Anonymous branches** | All visible heads tracked — commits never lost; named bookmarks only needed for remotes. | Safe experimentation without branch management overhead |
 
 ## Essential Commands
 
@@ -64,7 +64,7 @@ jj bookmark set main         # Set a bookmark (branch) on current commit
 
 ## aidevops Worktree Integration
 
-Colocated mode (`jj init --git-repo=.`) works with `wt` (Worktrunk) worktrees. `jj git push` replaces `git push`; bookmarks map to git branches. Team members can continue using git unchanged.
+Colocated mode (`jj init --git-repo=.`) works with `wt` worktrees. `jj git push` replaces `git push`; bookmarks map to git branches. Team members can continue using git unchanged.
 
 **See also**: `tools/git/github-cli.md` (PR/remote workflows), `tools/git/conflict-resolution.md` (conflict strategies), `tools/git/worktrunk.md` (worktree management)
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/git/jujutsu.md` per simplification scan (GH#16553).

## Changes
- Key Advantages table: compress verbose "Agent benefit" and "Behaviour" cells — semicolons replace mid-sentence periods, "for headless debugging" trimmed, "One object type" → "Simpler object model"
- Worktree Integration: remove redundant parenthetical "(Worktrunk)"
- All code blocks, URLs, command examples, and task ID references preserved
- Line count unchanged (76 lines) — prose-level tightening only

## Issue
Closes #16553

## Files Changed
- `.agents/tools/git/jujutsu.md` — 6 lines changed (prose compression, no knowledge removed)

## Testing
- `self-assessed` (Low risk: docs/agent prompt, no runtime behaviour changed)
- Content preservation verified: all code blocks, URLs, `jj` commands, and cross-references intact

## Runtime Testing
Risk: **Low** — agent prompt doc, no code execution paths affected.
Verification: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.840 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6