### PR TITLE
GH#16554: tighten GLM-OCR agent doc

### DIFF
--- a/.agents/tools/ocr/glm-ocr.md
+++ b/.agents/tools/ocr/glm-ocr.md
@@ -24,12 +24,9 @@ tools:
 - **Use when**: Quick OCR of screenshots, photos, scanned docs, receipts, forms — local, no cloud
 - **Limitations**: No JSON output; weak on low-quality images (<150 DPI); needs >=8GB RAM
 
-<!-- AI-CONTEXT-END -->
-
 ## Usage
 
 ```bash
-# Basic
 ollama run glm-ocr "Extract all text from this image" --images /path/to/document.png
 
 # macOS screenshot → OCR
@@ -73,3 +70,5 @@ peekaboo image --mode window --app "Preview" --analyze "Extract document text" -
 | Model not found | `ollama pull glm-ocr` then `ollama list` to verify |
 | Slow performance | Needs >=8GB RAM; process large batches sequentially |
 | Poor OCR quality | Use >=150 DPI (300 for scans); crop to relevant area; try specific prompts |
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ocr/glm-ocr.md` per simplification scan (GH#16554).

## Changes
- Expand `<!-- AI-CONTEXT-START/END -->` markers to wrap the full doc (previously only wrapped Quick Reference, leaving Usage/Alternatives/Troubleshooting outside context hints)
- Remove redundant `# Basic` comment from bash block (self-evident from the command)

## Issue
Closes #16554

## Files Changed
- `.agents/tools/ocr/glm-ocr.md` (75 → 74 lines, -1 net; content fully preserved)

## Testing
- Risk level: **Low** (docs-only change, no code paths affected)
- Self-assessed: all code blocks, URLs, command examples, task IDs, and knowledge preserved
- Verified: `git diff` confirms only structural/marker changes, zero content loss

## Key Decisions
- File classified as **instruction doc** (not reference corpus) — tighten prose, not split into chapters
- AI-CONTEXT marker expansion is the primary value: all sections now included in context window hints for agents loading this doc

---
[aidevops.sh](https://aidevops.sh) v3.5.840 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6