### PR TITLE
GH#16558: tighten github-actions.md agent doc

### DIFF
--- a/.agents/tools/git/github-actions.md
+++ b/.agents/tools/git/github-actions.md
@@ -14,18 +14,11 @@ tools:
 
 # GitHub Actions Setup Guide
 
-<!-- AI-CONTEXT-START -->
-
-## Quick Reference
-
 - **Workflow**: `.github/workflows/code-quality.yml`
 - **Triggers**: push to `main`/`develop`; pull requests to `main`
 - **Jobs**: Framework Validation, SonarCloud Analysis, Codacy Analysis
-- **Secrets**: `SONAR_TOKEN` configured; `CODACY_API_TOKEN` needs setup (conditional job); `GITHUB_TOKEN` auto-provided
 - **Dashboards**: [SonarCloud](https://sonarcloud.io/project/overview?id=marcusquinn_aidevops) · [Codacy](https://app.codacy.com/gh/marcusquinn/aidevops) · [Actions](https://github.com/marcusquinn/aidevops/actions)
 - **Add secret**: Repository Settings → Secrets and variables → Actions → New repository secret
-
-<!-- AI-CONTEXT-END -->
 
 ## Secrets
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/git/github-actions.md` per simplification-debt issue GH#16558.

## Changes
- Removed `<!-- AI-CONTEXT-START/END -->` wrapper (decorative noise for a 60-line file)
- Removed `## Quick Reference` heading (bullets stand alone without it)
- Removed duplicate secrets status bullet (fully covered by the Secrets table below with source URLs)
- 67 → 60 lines (10% reduction)

## Preservation Verification
- All code blocks: ✅ (Full retry yaml, Simple yaml)
- All URLs: ✅ (SonarCloud, Codacy, Actions dashboards, token source URLs)
- All operational rules: ✅ (3 bullet points at end)
- Secrets table: ✅ (all 3 rows with status + source)
- Concurrent push patterns table: ✅ (all 4 rows)
- No task IDs or incident refs in original — none to preserve

## Testing
Low-risk doc change. Self-assessed: agent behaviour unchanged — no rules removed, only decorative structure and a duplicate bullet eliminated.

## Issue
Closes #16558

---
[aidevops.sh](https://aidevops.sh) v3.5.840 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6