### PR TITLE
GH#16550: tighten orchestration-analysis.md prose

### DIFF
--- a/.agents/aidevops/orchestration-analysis.md
+++ b/.agents/aidevops/orchestration-analysis.md
@@ -57,7 +57,7 @@ When `historical_context.has_yesterday_report` or `has_week_ago_report` is true:
 3. Direction: `↑ improved`, `↓ degraded`, `→ stable` (±5% = stable)
 4. Flag regressions (degraded vs yesterday AND vs week-ago) as additional findings
 
-Note: `historical_context.week_ago_report_path` is a point-in-time snapshot, not a rolling average.
+`historical_context.week_ago_report_path` is a point-in-time snapshot, not a rolling average.
 
 ## Meta-Assessment
 


### PR DESCRIPTION
## Summary

Tighten prose in `.agents/aidevops/orchestration-analysis.md` per GH#16550 simplification scan.

**Change:** Remove redundant `Note:` prefix on line 60 — the sentence is self-evidently a note and the prefix adds no information.

**Scope:** The file was already well-structured and tight. All institutional knowledge preserved:
- Metric thresholds table (10 rows, all severity levels)
- Finding format template
- Trend analysis steps
- Meta-assessment criteria
- Auto-filing bash command block
- Output format template
- Scheduling context and skip thresholds

**Verification:** All code blocks, task ID refs, command examples, and URLs present before and after. Agent behaviour unchanged.

Closes #16550

<!-- MERGE_SUMMARY -->
**What:** Remove decorative `Note:` prefix from trend analysis section
**Issue:** GH#16550 — simplification scan flagged file for review
**Files changed:** `.agents/aidevops/orchestration-analysis.md` (1 line)
**Testing:** self-assessed (docs-only, low risk per runtime testing gate)
**Key decisions:** File was already optimally structured; only genuine noise removed

---
[aidevops.sh](https://aidevops.sh) v3.5.846 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in trend analysis documentation with refined wording and formatting adjustments for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->