### PR TITLE
GH#16379: tighten add-skill.md command doc (75→71 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -49,6 +49,14 @@
     "issue": "GH#16350",
     "status": "simplified"
   },
+  ".agents/scripts/commands/add-skill.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "ce5f2025958525f3fc2e2e3224b331b5c9ccdd13a5966ad21d5878ba1a9a2067",
+    "issue": "GH#16379",
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
+  },
   ".agents/seo/geo-strategy.md": {
     "at": "2026-04-03T00:00:00Z",
     "hash": "f2c7b8507a0eb39c56689d7ce778518d7e15b27b7da668ef2b2caebdbe5b50df",

--- a/.agents/scripts/commands/add-skill.md
+++ b/.agents/scripts/commands/add-skill.md
@@ -4,9 +4,7 @@ agent: Build+
 mode: subagent
 ---
 
-Import an external skill, convert to aidevops format, and register for update tracking.
-
-URL/Repo: $ARGUMENTS
+Import an external skill, convert to aidevops format, and register for update tracking. URL/Repo: `$ARGUMENTS`
 
 ## Quick Reference
 
@@ -62,14 +60,12 @@ URL/Repo: $ARGUMENTS
 
 ## Update Tracking
 
-Tracked in `.agents/configs/skill-sources.json` (`name`, `upstream_url`, `upstream_commit`/`upstream_hash`, `local_path`, `format_detected`, `imported_at`, `last_checked`, `merge_strategy`). URL sources use SHA-256 content hashing instead of git commit comparison.
-
-Run `/add-skill check-updates` periodically.
+Tracked in `.agents/configs/skill-sources.json`: `name`, `upstream_url`, `upstream_commit`/`upstream_hash`, `local_path`, `format_detected`, `imported_at`, `last_checked`, `merge_strategy`. URL sources use SHA-256 content hashing instead of git commit comparison. Run `/add-skill check-updates` periodically.
 
 ## Related
 
-- `tools/build-agent/add-skill.md` - Detailed conversion logic and merge strategies
-- `scripts/add-skill-helper.sh` - Main import implementation
-- `scripts/clawdhub-helper.sh` - ClawdHub browser-based fetcher (Playwright)
-- `scripts/skill-update-helper.sh` - Automated update checking
-- `scripts/generate-skills.sh` - SKILL.md stub generation for aidevops agents
+- `tools/build-agent/add-skill.md` — Detailed conversion logic and merge strategies
+- `scripts/add-skill-helper.sh` — Main import implementation
+- `scripts/clawdhub-helper.sh` — ClawdHub browser-based fetcher (Playwright)
+- `scripts/skill-update-helper.sh` — Automated update checking
+- `scripts/generate-skills.sh` — SKILL.md stub generation for aidevops agents


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/scripts/commands/add-skill.md` per simplification-debt scan (GH#16379).

## Changes
- Merged standalone `URL/Repo: $ARGUMENTS` line into intro sentence (saves 2 lines)
- Condensed Update Tracking section: inline JSON field list + merged `check-updates` reminder into same paragraph (saves 2 lines)
- Standardised Related section list separators from ` - ` to ` — ` (em-dash, consistent with other docs)
- Updated `simplification-state.json` to mark file as `simplified`

## Issue
Closes #16379

## Files Changed
- `.agents/scripts/commands/add-skill.md` (75 → 71 lines, -5.3%)
- `.agents/configs/simplification-state.json` (state entry added)

## Testing
- `diff` verified: all code blocks, URLs, command examples, and institutional knowledge preserved
- No broken internal links or references
- Risk: **Low** (docs-only change, no executable code modified)

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.846 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6