### PR TITLE
GH#16581: tighten streaming-avatars agent doc (reference corpus at minimum viable size)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -18,8 +18,11 @@
   ".agents/content/heygen-skill/rules-streaming-avatars.md": {
     "at": "2026-04-03T00:00:00Z",
     "hash": "db7582c5895ac7185939740cb16cbe5f72afd9ebad7bb4586b8eee5897af27d3",
-    "issue": "GH#16211",
-    "passes": 1,
+    "issue": "GH#16581",
+    "lines_after": 67,
+    "lines_before": 67,
+    "note": "Pass 2: reference corpus (API docs, tables, code examples) at minimum viable size. No further compression possible without content loss. File reviewed and confirmed appropriately structured.",
+    "passes": 2,
     "pr": "pending",
     "status": "simplified"
   },


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Update simplification state for `.agents/content/heygen-skill/rules-streaming-avatars.md` to reflect pass 2 review. File confirmed at minimum viable size — no further compression possible without content loss.

## Issue
Closes #16581

## Analysis
This file is a **reference corpus** (HeyGen Streaming Avatars API documentation):
- Contains API endpoint tables, field definitions, TypeScript code examples, and best practices
- Already simplified 3× prior: GH#14242 → GH#16211 → now GH#16581
- Current size: 67 lines (down from original ~86 lines)
- Hash unchanged since last merge (PR #16504): `db7582c5...`

Per the issue's own guidance: "Reference corpus (SKILL.md, domain knowledge bases) need restructuring into chapters, not content reduction." At 67 lines, splitting into chapter files would add index overhead without benefit — total line count would increase.

## Files Changed
- `.agents/configs/simplification-state.json` — updated issue ref GH#16211→GH#16581, incremented passes 1→2, added review note and line counts

## Testing
- Content preservation: file unchanged, all API endpoints, tables, and code examples intact
- No broken references
- Simplification state hash matches current file hash

## Runtime Testing
**Risk level:** Low (docs/config only, no code changes)
**Assessment:** self-assessed — state file update only, no functional changes

---
[aidevops.sh](https://aidevops.sh) v3.5.846 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6