### PR TITLE
GH#16583: tighten runners-code-reviewer.md structure

### DIFF
--- a/.agents/tools/ai-assistants/runners-code-reviewer.md
+++ b/.agents/tools/ai-assistants/runners-code-reviewer.md
@@ -1,17 +1,9 @@
 ---
-description: Example runner template - security and quality code reviewer
+description: Runner template - security and quality code reviewer
 mode: reference
 ---
 
 # Code Reviewer
-
-```bash
-runner-helper.sh create code-reviewer
-runner-helper.sh edit code-reviewer  # paste template below
-runner-helper.sh run code-reviewer "Review these files: src/auth.ts src/api.ts"
-runner-helper.sh run code-reviewer "Review the changes in PR #42: $(gh pr diff 42)"
-runner-helper.sh run code-reviewer "Review src/auth/" --attach http://localhost:4096
-```
 
 ```markdown
 # Code Reviewer
@@ -63,4 +55,14 @@ Review provided files or diffs and return structured findings.
 - Check that all API endpoints have authentication middleware
 - Verify error responses don't leak internal details
 - Note missing tests but don't block for them unless critical path
+```
+
+## Usage
+
+```bash
+runner-helper.sh create code-reviewer
+runner-helper.sh edit code-reviewer  # paste template above
+runner-helper.sh run code-reviewer "Review these files: src/auth.ts src/api.ts"
+runner-helper.sh run code-reviewer "Review the changes in PR #42: $(gh pr diff 42)"
+runner-helper.sh run code-reviewer "Review src/auth/" --attach http://localhost:4096
 ```


### PR DESCRIPTION
## Summary

- Move usage bash block from top to `## Usage` section at bottom, consistent with `runners-seo-analyst.md` sibling pattern
- Tighten frontmatter description (remove redundant "Example")
- Update comment from "paste template below" → "paste template above" (accurate after move)
- All template content preserved verbatim — zero knowledge loss

## What

Structural alignment of `runners-code-reviewer.md` with the established `runners-seo-analyst.md` pattern: template first, usage examples at the bottom.

## Issue

Closes #16583

## Files Changed

- `.agents/tools/ai-assistants/runners-code-reviewer.md` — 66→68 lines (added `## Usage` heading)

## Testing

- `markdownlint-cli2`: 0 errors
- Content preservation: all code blocks, template content, and command examples present before and after
- Structural consistency: matches `runners-seo-analyst.md` pattern

## Runtime Testing

**Risk level:** Low (docs/reference file, no executable logic)
**Verification:** `self-assessed` — markdownlint clean, content diff verified

<!-- MERGE_SUMMARY -->
**What:** Structural tidy of runners-code-reviewer.md — usage examples moved to bottom section
**Issue:** GH#16583
**Files changed:** 1
**Testing:** markdownlint 0 errors, content preserved
**Key decisions:** Classified as reference corpus (not instruction doc); restructured for consistency, not compressed

---
[aidevops.sh](https://aidevops.sh) v3.5.846 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6