### PR TITLE
GH#16586: tighten realtimekit.md index, defer client examples to patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/realtimekit.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/realtimekit.md
@@ -35,22 +35,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtim
 
 ### 2. Client Integration
 
-**React**:
-
-```tsx
-import { RtkMeeting } from '@cloudflare/realtimekit-react-ui';
-function App() {
-  return <RtkMeeting authToken="<participant_auth_token>" onLeave={() => {}} />;
-}
-```
-
-**Core SDK**:
-
-```typescript
-import RealtimeKitClient from '@cloudflare/realtimekit';
-const meeting = new RealtimeKitClient({ authToken: '<token>', video: true, audio: true });
-await meeting.join();
-```
+See [Patterns](./realtimekit-patterns.md) — React UI Kit, Core SDK, Angular, Web Components, custom hooks.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Removes duplicate client integration code blocks (React UI Kit, Core SDK) from the index file
- These examples are already fully covered in `realtimekit-patterns.md` (UI Kit section)
- Replaces with a single pointer line referencing patterns.md
- 66 → 51 lines; all knowledge preserved

## What

Tighten `.agents/services/hosting/cloudflare-platform-skill/realtimekit.md` per issue guidance. File classified as **reference corpus index** — already slim, companion chapter files exist. The only genuine duplication was the Client Integration code blocks.

## Issue

Closes #16586

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/realtimekit.md` — 1 file, -16 lines

## Testing

**Risk level**: Low (docs/agent prompts — self-assessed per runtime testing gate)

Content preservation verified:
- All URLs present before and after
- Backend curl commands preserved (essential Quick Start flow)
- All Core Concepts definitions preserved
- All References links preserved
- Removed code is fully present in `realtimekit-patterns.md` (lines 5-18)

## Runtime Testing

`self-assessed` — docs-only change, no runtime behaviour affected.

<!-- MERGE_SUMMARY -->
**What**: Slim realtimekit.md index by removing client code duplicated in patterns.md
**Issue**: #16586
**Files changed**: 1 (realtimekit.md, -16 lines)
**Testing**: self-assessed, content preservation verified
**Key decisions**: Kept backend curl commands (not duplicated elsewhere); removed React/Core SDK blocks (fully in patterns.md)

---
[aidevops.sh](https://aidevops.sh) v3.5.848 plugin for [OpenCode](https://opencode.ai) v1.3.13