### PR TITLE
GH#14708: tighten bot-management-patterns.md prose and section headers

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/bot-management-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/bot-management-patterns.md
@@ -1,8 +1,8 @@
 # Bot Management Patterns
 
-WAF custom rules, rate limiting, and Workers patterns for Cloudflare Bot Management. Enterprise-only features such as granular scores and JA3/JA4 are noted inline.
+WAF custom rules, rate limiting, and Workers patterns for Cloudflare Bot Management. Enterprise-only features (granular scores, JA3/JA4) are noted inline.
 
-## Rule Patterns
+## WAF Rule Patterns
 
 ### Sensitive flows
 
@@ -11,7 +11,7 @@ WAF custom rules, rate limiting, and Workers patterns for Cloudflare Bot Managem
 Action: Managed Challenge
 ```
 
-### APIs (score + JavaScript Detections)
+### APIs
 
 ```txt
 (http.request.uri.path matches "^/api/" and (cf.bot_management.score lt 30 or not cf.bot_management.js_detection.passed) and not cf.bot_management.verified_bot)
@@ -75,7 +75,7 @@ Rate limiting > Custom rules
 - Additional condition: cf.bot_management.score lt 50
 ```
 
-## Workers Pattern
+## Workers
 
 ```typescript
 export default {


### PR DESCRIPTION
## Summary

Tightens prose and section headers in `.agents/services/hosting/cloudflare-platform-skill/bot-management-patterns.md` per the simplification scan flagged in GH#14708.

**Changes:**
- Intro line: compressed "such as granular scores and JA3/JA4" → "(granular scores, JA3/JA4)"
- `## Rule Patterns` → `## WAF Rule Patterns` (more specific, consistent with Integration Points naming)
- `### APIs (score + JavaScript Detections)` → `### APIs` (conditions are visible in the code block below)
- `## Workers Pattern` → `## Workers` (consistent section naming style)

**Preserved:** all code blocks, threshold table, layering order, zero-trust baseline note, dashboard alternative, Enterprise annotation, all technical content.

Closes #14708


---
[aidevops.sh](https://aidevops.sh) v3.5.851 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6