### PR TITLE
GH#16431: tighten cold-outreach.md (75→70 lines)

### DIFF
--- a/.agents/services/outreach/cold-outreach.md
+++ b/.agents/services/outreach/cold-outreach.md
@@ -3,13 +3,9 @@ description: Cold outreach strategy playbook - warmup, compliance, infrastructur
 mode: subagent
 tools:
   read: true
-  bash: true
-  grep: true
 ---
 
 # Cold Outreach Strategy
-
-<!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
@@ -38,10 +34,7 @@ tools:
 
 Scale above 20/day only after 7+ days of stable inbox health. Plan: `target_daily_volume / 100 = minimum active mailboxes`. Add 20-30% headroom for pauses and deliverability degradation.
 
-**Multi-mailbox rotation:**
-1. Group by reputation tier (new, warming, stable); route high-priority accounts through stable first
-2. Distribute sequence steps evenly — no mailbox peaks at one hour/daypart
-3. Pause on anomaly signals (bounce spike, spam-folder drift, complaints); rebalance to healthy mailboxes
+**Multi-mailbox rotation:** Group by reputation tier (new, warming, stable); route high-priority accounts through stable first. Distribute sequence steps evenly — no mailbox peaks at one hour/daypart. Pause on anomaly signals (bounce spike, spam-folder drift, complaints); rebalance to healthy mailboxes.
 
 ## Platform Selection
 
@@ -62,7 +55,11 @@ Scale above 20/day only after 7+ days of stable inbox health. Plan: `target_dail
 
 ## Messaging Quality
 
-Avoid mass-templated openings ("just circling back," "quick question," "hope this finds you well"). Use context-grounded observations tied to recipient's role, timing, or initiative. Trigger from verifiable business signals (hiring, launch, stack changes, expansion). One problem hypothesis + one clear CTA per email. One relevant case/metric matching the prospect segment. Vary openings and CTAs to reduce template fingerprinting.
+- No mass-templated openings ("just circling back," "quick question," "hope this finds you well")
+- Use context-grounded observations tied to recipient's role, timing, or initiative
+- Trigger from verifiable business signals (hiring, launch, stack changes, expansion)
+- One problem hypothesis + one clear CTA per email; one relevant case/metric per prospect segment
+- Vary openings and CTAs to reduce template fingerprinting
 
 ## Reply Detection and Handoff
 
@@ -71,5 +68,3 @@ Avoid mass-templated openings ("just circling back," "quick question," "hope thi
 3. Route positive/high-intent neutral replies to human owner with SLA
 4. Track handoff latency and outcome in CRM for loop closure
 5. Feed objection patterns back into copy and segmentation weekly
-
-<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

Tighten `.agents/services/outreach/cold-outreach.md` per simplification issue GH#16431.

Closes #16431

## What changed

- Remove unused `bash: true` and `grep: true` tool declarations — this is a reference/strategy doc, not an executor agent
- Remove `<!-- AI-CONTEXT-START/END -->` wrapper tags (not needed for this doc type)
- Condense multi-mailbox rotation from 3-item numbered list to inline prose (same content, less vertical space)
- Convert messaging quality dense paragraph to scannable bullet list

## Content preservation

All institutional knowledge preserved:
- Compliance baseline (CAN-SPAM, GDPR) — unchanged
- Warmup schedule table — unchanged
- Volume formula and headroom guidance — unchanged
- Platform selection tables (Smartlead, Instantly, ManyReach, infrastructure options) — unchanged
- Reply detection and handoff steps — unchanged

## Line count

75 → 70 lines (7% reduction)

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution paths.
Assessment: `self-assessed` — content verified against original line-by-line.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten cold-outreach.md agent doc (75→70 lines)
**Issue:** Closes #16431
**Files changed:** `.agents/services/outreach/cold-outreach.md`
**Testing:** Self-assessed (doc-only change, no runtime paths)
**Key decisions:** Removed AI-CONTEXT tags (not needed for strategy docs); converted paragraph to bullets for scannability

---
[aidevops.sh](https://aidevops.sh) v3.5.852 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6