### PR TITLE
GH#16412: tighten pilot-results.md (97→95 lines)

### DIFF
--- a/.agents/tests/comprehension/pilot-results.md
+++ b/.agents/tests/comprehension/pilot-results.md
@@ -35,7 +35,7 @@
 
 ### Clarity problem (file needs improvement)
 
-Plausible but incorrect interpretation — right topic, wrong conclusion; multiple valid readings exist.
+Right topic, wrong conclusion — multiple valid readings exist.
 
 **Expected haiku failures:**
 - `code-simplifier.md`: nuanced "almost never simplify" categories → haiku over-simplifies classification
@@ -43,8 +43,6 @@ Plausible but incorrect interpretation — right topic, wrong conclusion; multip
 - `worker-efficiency-protocol.md`: 6-row model escalation decision matrix → haiku misses edge cases
 
 ### Exceeds model capability (file is fine, model too weak)
-
-Insufficient reasoning capacity; instructions are clear.
 
 **Fast-fail indicators:** refusal, confabulation (hallucinated paths/tools), structural_violation (ignores explicit constraint), disengagement (minimal response).
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tests/comprehension/pilot-results.md` from 97 to 95 lines by removing redundant prose in the Failure Mode Categories section.

## Issue
Closes #16412

## Changes
- Removed redundant lead-in sentence "Plausible but incorrect interpretation —" (already captured by "right topic, wrong conclusion")
- Removed standalone sentence "Insufficient reasoning capacity; instructions are clear." under "Exceeds model capability" (redundant with the section heading)

## Files Changed
- `.agents/tests/comprehension/pilot-results.md`: 97 → 95 lines

## Testing
**Risk level:** Low — docs/reference file, no code paths affected.
**Runtime Testing:** `self-assessed` — documentation-only change. All content preserved: tables, task IDs, command examples, URLs, cross-references intact. No broken internal links.

## Key Decisions
- File classified as reference corpus (benchmark results data with tables). Content not compressed — only redundant prose removed.
- All institutional knowledge preserved: tier assignments, cost analysis, failure mode categories, recommendations.

---
[aidevops.sh](https://aidevops.sh) v3.5.856 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test documentation descriptions for improved clarity and conciseness.
  * Refined wording in assessment criteria to better reflect evaluation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->