### PR TITLE
GH#16411: tighten agent-optimization.md (105→96 lines)

### DIFF
--- a/.agents/tools/autoresearch/autoresearch/agent-optimization.md
+++ b/.agents/tools/autoresearch/autoresearch/agent-optimization.md
@@ -5,9 +5,25 @@ Sub-doc for `autoresearch.md`. Load when `PROGRAM_NAME == "agent-optimization"` 
 
 ---
 
-## Composite Metric Parsing
+## Security Instruction Exemptions
 
-The metric command outputs a JSON object. Parse it as follows:
+Before generating any hypothesis, check whether it would remove or weaken any of
+the following categories. If yes, discard without testing:
+
+| Category | Detection pattern |
+|----------|------------------|
+| Credential/secret handling | `credentials`, `NEVER expose`, `gopass`, `secret` |
+| File operation safety | `Read before Edit`, `pre-edit-check`, `verify path` |
+| Git safety | `pre-edit-check.sh`, `never edit on main`, `worktree` |
+| Traceability | `PR title MUST`, `task ID`, `Closes #` |
+| Prompt injection | `prompt injection`, `adversarial`, `scan` |
+| Destructive operations | `destructive`, `confirm before`, `irreversible` |
+
+Enforced by both the constraint list in the research program and the researcher model's hypothesis generation. Both layers must hold.
+
+---
+
+## Composite Metric Parsing
 
 ```bash
 METRIC_JSON=$(eval "$METRIC_CMD")
@@ -16,7 +32,7 @@ PASS_RATE=$(echo "$METRIC_JSON" | jq '.pass_rate')
 TOKEN_RATIO=$(echo "$METRIC_JSON" | jq '.token_ratio')
 ```
 
-Use `COMPOSITE_SCORE` as the primary metric value for keep/discard decisions.
+Use `COMPOSITE_SCORE` as the primary metric for keep/discard decisions.
 Log `PASS_RATE` and `TOKEN_RATIO` as supplementary columns in results.tsv.
 
 **Formula**: `composite_score = pass_rate * (1 - 0.3 * token_ratio)`
@@ -29,40 +45,19 @@ Log `PASS_RATE` and `TOKEN_RATIO` as supplementary columns in results.tsv.
 
 ## Baseline Setup
 
-On first run (BASELINE == null), save the current test results as the baseline
-before measuring the baseline metric:
+On first run (BASELINE == null), establish the baseline before measuring:
 
 ```bash
 agent-test-helper.sh baseline .agents/tests/agent-optimization.test.json
 ```
 
-This sets `baseline_chars` in the baseline file, enabling `token_ratio` computation
-on subsequent runs. Without this step, `token_ratio` defaults to 1.0 (no change).
-
----
-
-## Security Instruction Exemptions
-
-Before generating any hypothesis, check whether it would remove or weaken any of
-the following instruction categories. If yes, discard the hypothesis without testing:
-
-| Category | Detection pattern |
-|----------|------------------|
-| Credential/secret handling | `credentials`, `NEVER expose`, `gopass`, `secret` |
-| File operation safety | `Read before Edit`, `pre-edit-check`, `verify path` |
-| Git safety | `pre-edit-check.sh`, `never edit on main`, `worktree` |
-| Traceability | `PR title MUST`, `task ID`, `Closes #` |
-| Prompt injection | `prompt injection`, `adversarial`, `scan` |
-| Destructive operations | `destructive`, `confirm before`, `irreversible` |
-
-These exemptions are enforced by the constraint list in the research program AND
-by the researcher model's hypothesis generation. Both layers must hold.
+Sets `baseline_chars`, enabling `token_ratio` computation on subsequent runs. Without this, `token_ratio` defaults to 1.0 (no change).
 
 ---
 
 ## Simplification State Integration
 
-Before generating hypotheses for a target file, check `.agents/configs/simplification-state.json`:
+Before generating hypotheses, check `.agents/configs/simplification-state.json`:
 
 ```bash
 TARGET_FILE=".agents/build-plus.md"  # or whichever file is being optimized
@@ -72,8 +67,6 @@ STORED_HASH=$(jq -r --arg f "$TARGET_FILE" '.files[$f].hash // empty' \
 
 if [[ "$CURRENT_HASH" == "$STORED_HASH" ]]; then
     log "File unchanged since last optimization. Skipping."
-    # If this is the only target, exit with "no work needed"
-    # If there are multiple targets, move to the next one
 fi
 ```
 
@@ -101,5 +94,3 @@ jq --arg file "$TARGET_FILE" \
 | 26–35 | Replace inline code with references | `rg "pattern"` instead of inline code blocks |
 | 36–45 | Merge thin sections | Combine two small sections covering the same topic |
 | 46+ | Simplification | Remove anything that doesn't affect the metric |
-
-Always check security exemptions before testing any hypothesis.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/autoresearch/autoresearch/agent-optimization.md` from 105 to 96 lines per issue #16411 simplification scan.

## Changes
- **Reordered**: Security Exemptions moved to first position (highest priority — must be checked before any hypothesis generation)
- **Removed redundant prose**: Composite Metric section intro ("The metric command outputs a JSON object. Parse it as follows:") — code block is self-explanatory
- **Tightened Baseline Setup prose**: "save the current test results as the baseline before measuring the baseline metric" → "establish the baseline before measuring"
- **Removed redundant inline comments** from Simplification State code block (the "If this is the only target..." guidance was already implied by the prose)
- **Removed redundant closing line**: "Always check security exemptions before testing any hypothesis" — already stated in the Security Exemptions section

## Issue
Closes #16411

## Files Changed
- `.agents/tools/autoresearch/autoresearch/agent-optimization.md` (105→96 lines, -9 lines)

## Testing
- All code blocks, formulas, tables, task IDs, and command examples preserved
- Security exemption table intact with all 6 categories
- Composite score formula preserved
- Simplification state hash check/update code blocks preserved
- Hypothesis types table preserved with all 6 phases

## Runtime Testing
Risk: **Low** — docs/agent prompt only, no executable code changed. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.856 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6