### PR TITLE
GH#16570: tighten autoresearch loop.md (141→122 lines)

### DIFF
--- a/.agents/tools/autoresearch/autoresearch/loop.md
+++ b/.agents/tools/autoresearch/autoresearch/loop.md
@@ -8,7 +8,6 @@ Sub-doc for `autoresearch.md`. Loaded on demand during Step 2.
 
 ```text
 SESSION_START = current time
-ITER_TOKENS = 0
 
 while true:
     elapsed = now - SESSION_START
@@ -29,22 +28,18 @@ while true:
     constraint_result = run_constraints()
     if constraint_result == FAIL:
         git -C WORKTREE_PATH reset --hard HEAD
-        ITER_TOKENS = current_token_estimate() - ITER_START_TOKENS
-        TOTAL_TOKENS += ITER_TOKENS
+        track_tokens(ITER_START_TOKENS)
         log_result(ITERATION_COUNT, null, null, "constraint_fail", hypothesis, ITER_TOKENS)
         continue
 
     metric_result = run_metric()
     if metric_result == ERROR:
         git -C WORKTREE_PATH reset --hard HEAD
-        ITER_TOKENS = current_token_estimate() - ITER_START_TOKENS
-        TOTAL_TOKENS += ITER_TOKENS
+        track_tokens(ITER_START_TOKENS)
         log_result(ITERATION_COUNT, null, null, "crash", hypothesis, ITER_TOKENS)
         continue
 
-    delta = metric_result - BASELINE
-    ITER_TOKENS = current_token_estimate() - ITER_START_TOKENS
-    TOTAL_TOKENS += ITER_TOKENS
+    track_tokens(ITER_START_TOKENS)
 
     if is_improvement(metric_result, BEST_METRIC, METRIC_DIR):
         git -C WORKTREE_PATH add -A
@@ -60,6 +55,10 @@ while true:
         log_result(ITERATION_COUNT, null, metric_result, "discard", hypothesis, ITER_TOKENS)
         store_memory(hypothesis, metric_result, "discard")
         send_discovery(hypothesis, metric_result, "discard", null)
+
+# track_tokens helper (called above):
+#   ITER_TOKENS = current_token_estimate() - ITER_START_TOKENS
+#   TOTAL_TOKENS += ITER_TOKENS
 ```
 
 ---
@@ -88,54 +87,36 @@ while true:
 
 ### Rules
 
-- Never repeat a hypothesis that was already discarded (check FAILED_HYPOTHESES)
-- Prefer changes with high expected impact and low risk of constraint failure
-- For agent optimization: shorter instructions with higher information density > longer verbose instructions
-- For build optimization: structural changes (tree-shaking, module boundaries) > config tweaks
-- Simplification is always valid: removing code that doesn't affect the metric is a win
+- Never repeat a discarded hypothesis (check FAILED_HYPOTHESES)
+- Prefer high-impact changes with low constraint-failure risk
+- Agent optimization: higher information density > longer verbose instructions
+- Build optimization: structural changes (tree-shaking, module boundaries) > config tweaks
+- Simplification is always valid: less code with equal-or-better metric is a win
 
 ---
 
-## Constraint Checking
+## Helpers
+
+**Constraint check:**
 
 ```bash
 timeout PER_EXPERIMENT bash -c "{constraint_command}"
-exit_code=$?
-if exit_code != 0:
-    return FAIL with constraint_command and exit_code
+# exit_code != 0 → return FAIL; all constraints must pass (first failure short-circuits)
 ```
 
-All constraints must pass. First failure short-circuits.
-
----
-
-## Metric Measurement
+**Metric measurement:**
 
 ```bash
 timeout PER_EXPERIMENT bash -c "{METRIC_CMD}" 2>/dev/null
+# Parse last non-empty stdout line as float. Parsing failure or non-zero exit → ERROR.
 ```
 
-Parse the last non-empty line of stdout as a float. If parsing fails or command exits non-zero: return ERROR.
-
----
-
-## Improvement Check
+**Improvement check:**
 
 ```text
-is_improvement(new_value, best_value, direction):
-    if best_value == null: return true  # first measurement is always an improvement
-    if direction == "lower": return new_value < best_value
-    if direction == "higher": return new_value > best_value
+is_improvement(new, best, dir):
+    if best == null: return true   # first measurement always keeps
+    return new < best if dir=="lower" else new > best
 ```
 
----
-
-## Token Estimation
-
-```text
-current_token_estimate():
-    # chars-per-token ratio ~4; use API response token counts if available
-    return estimated_tokens
-```
-
-If the runtime exposes token counts in API responses, use those directly. Otherwise estimate from character count of tool calls and responses.
+**Token estimation:** Use API response token counts if available; otherwise estimate from character count (~4 chars/token).


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/autoresearch/autoresearch/loop.md` from 141 to 122 lines (13.5% reduction) per simplification scan.

## Issue
Closes #16570

## Files Changed
- `.agents/tools/autoresearch/autoresearch/loop.md` — 141→122 lines

## Changes
- Factor repeated token-tracking boilerplate (3 identical blocks) into a `track_tokens` helper comment
- Remove unused `delta` variable (computed but never referenced in any branch)
- Consolidate four small sections (Constraint Checking, Metric Measurement, Improvement Check, Token Estimation) into a single `## Helpers` section — same content, less heading overhead
- Tighten rules prose (remove filler words, preserve all decision logic)

## Content Preservation
All pseudocode, task IDs, operational rules, and command examples verified present after edit:
- All 19 key terms (constraint_fail, crash, keep, discard, FAILED_HYPOTHESES, BEST_METRIC, CAMPAIGN_ID, peer_discoveries, store_memory, send_discovery, generate_hypothesis, apply_modification, log_result, is_improvement, METRIC_DIR, TIMEOUT, MAX_ITER, goal_met, ITERATION_COUNT) — 28 occurrences confirmed

## Runtime Testing
**Risk level:** Low — docs/agent prompt only, no code execution paths changed.
**Assessment:** self-assessed. No runtime verification required per testing gate.

---
[aidevops.sh](https://aidevops.sh) v3.5.856 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6