### PR TITLE
GH#16611: tighten autoresearch logging.md (109→103 lines)

### DIFF
--- a/.agents/tools/autoresearch/autoresearch/logging.md
+++ b/.agents/tools/autoresearch/autoresearch/logging.md
@@ -2,8 +2,6 @@
 
 Sub-doc for `autoresearch.md`. Loaded on demand.
 
----
-
 ## Results Logging
 
 Append to `todo/research/{name}-results.tsv`:
@@ -36,8 +34,6 @@ iteration	commit	metric_name	metric_value	baseline	delta	status	hypothesis	times
 2	-	build_time_s	12.8	12.4	0.4	discard	switch to esbuild (breaks API)	2026-04-01T10:24:00Z	3100	-	-
 ```
 
----
-
 ## Memory Storage
 
 After each **keep** or **discard** (medium confidence):
@@ -63,8 +59,6 @@ aidevops-memory store \
   "autoresearch {PROGRAM_NAME} session complete: {ITERATION_COUNT} iterations, best {METRIC_NAME}={BEST_METRIC} (baseline={BASELINE}, improvement={improvement_pct:.1f}%), total_tokens={TOTAL_TOKENS}" \
   --confidence high
 ```
-
----
 
 ## Mailbox Discovery Integration
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/autoresearch/autoresearch/logging.md` from 109 to 103 lines by removing 3 redundant horizontal rule separators (`---`) and their surrounding blank lines.

## Issue
Closes #16611

## Files Changed
- `.agents/tools/autoresearch/autoresearch/logging.md` — 109→103 lines (6 lines removed)

## Classification
**Instruction doc** (not reference corpus) — operational procedures with command templates. Content is already well-structured; only visual noise removed.

## Changes Made
- Removed 3 `---` horizontal rules between sections (Results Logging, Memory Storage, Mailbox Discovery Integration)
- Removed associated blank lines
- All content, command examples, column definitions, and TSV example preserved verbatim

## Testing
**Risk level: Low** (docs-only change, no code, no logic)
- `self-assessed`: content diff verified — only whitespace/separator lines removed, zero content loss
- All code blocks, command templates, and column definitions intact

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.856 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6