### PR TITLE
t1865: add TTL + process liveness check to dispatch-comment dedup guard

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -807,7 +807,7 @@ has_dispatch_comment() {
 		return 1
 	fi
 
-	local max_age="${DISPATCH_COMMENT_MAX_AGE:-14400}" # 4 hours
+	local max_age="${DISPATCH_COMMENT_MAX_AGE:-3600}" # 1 hour (reduced from 4h — GH#16626)
 
 	local now_epoch
 	now_epoch=$(date -u '+%s')
@@ -868,6 +868,35 @@ has_dispatch_comment() {
 				printf '%s' "0")
 			local age=$((now_epoch - comment_epoch))
 			if [[ "$age" -lt "$max_age" ]]; then
+				# GH#16626: Process liveness check — if the dispatch comment is
+				# within TTL but no worker process is running for this issue on
+				# the local machine, the previous worker completed or crashed
+				# without cleanup. Treat the comment as stale and allow re-dispatch.
+				#
+				# This fixes a throughput bottleneck where 10/24 worker slots sat
+				# idle because stale dispatch comments from dead workers blocked
+				# re-dispatch for up to 4 hours. The comment TTL alone is insufficient
+				# because it can't distinguish "worker in-flight" from "worker dead,
+				# comment left behind". Process check resolves this for same-machine
+				# scenarios; cross-machine is covered by the assignee guard (Layer 6)
+				# which has its own stale recovery (GH#15060).
+				#
+				# Grace period: comments <5 min old skip the liveness check to avoid
+				# racing with worker startup (process may not be visible yet).
+				local grace_period="${DISPATCH_COMMENT_GRACE_SECONDS:-300}" # 5 minutes
+				if [[ "$age" -gt "$grace_period" ]]; then
+					# Check if any local worker process is running for this issue
+					local has_local_worker=""
+					has_local_worker=$(pgrep -f "issue.${issue_number}" 2>/dev/null | head -1 || true)
+					if [[ -z "$has_local_worker" ]]; then
+						has_local_worker=$(pgrep -f "#${issue_number}" 2>/dev/null | head -1 || true)
+					fi
+					if [[ -z "$has_local_worker" ]]; then
+						# No local worker running — dispatch comment is orphaned
+						# Allow re-dispatch by skipping this comment
+						continue
+					fi
+				fi
 				printf 'dispatch comment by %s posted %ds ago on issue #%s\n' "$author" "$age" "$issue_number"
 				return 0
 			fi


### PR DESCRIPTION
## Summary

- Reduces `DISPATCH_COMMENT_MAX_AGE` from 4h to 1h — aligns with `STALE_ASSIGNMENT_THRESHOLD_SECONDS` used by Layer 6
- Adds process liveness check after a 5-min grace period: if a dispatch comment is within the TTL but no worker process is running for that issue, the comment is treated as stale and re-dispatch is allowed
- Configurable via `DISPATCH_COMMENT_GRACE_SECONDS` env var (default 300s)

## Problem

Worker throughput was capped at ~10/24 slots because stale dispatch comments from dead workers blocked re-dispatch for up to 4 hours. The dedup guard (Layer 5) couldn't distinguish "worker in-flight" from "worker dead, comment left behind".

Evidence from this session: 7 open issues (#16529, #16516, #16515, #16496, #16480, #16414, #15262) were blocked solely by stale dispatch comments from workers that had completed 2-4h ago.

## Testing

**Before fix (original script):**
```
#16529: BLOCKED — dispatch comment by marcusquinn posted 8884s ago
#16516: BLOCKED — dispatch comment by marcusquinn posted 9951s ago
#16480: BLOCKED — dispatch comment by marcusquinn posted 12323s ago
```

**After fix (modified script):**
```
#16529: CLEAR — safe to dispatch
#16516: CLEAR — safe to dispatch
#16480: CLEAR — safe to dispatch
```

All 7 previously-blocked issues now clear. ShellCheck clean.

## Runtime Testing

Risk: **Medium** (dispatch infrastructure, no data loss risk). Assessment: `self-assessed` — tested with real production issues and confirmed correct behavior for both stale and active scenarios.

## Key decisions

- 1h TTL chosen to align with the existing stale assignment threshold (Layer 6), providing consistent behavior across dedup layers
- 5-min grace period avoids racing with worker startup (process may not be visible in `pgrep` immediately after dispatch)
- Process liveness check is same-machine only; cross-machine dedup is handled by Layer 6 (assignee guard with stale recovery)

Closes #16626

---
[aidevops.sh](https://aidevops.sh) v3.5.860 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 10h 43m and 4,859 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dispatch comment expiration time reduced from 4 hours to 1 hour, enabling faster reprocessing cycles
  * Enhanced stale dispatch detection with process liveness verification to quickly identify and re-dispatch abandoned work items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->