### PR TITLE
GH#16154: tighten agent doc Voice AI Models (.agents/tools/voice/voice-ai-models.md)

### DIFF
--- a/.agents/tools/voice/voice-ai-models.md
+++ b/.agents/tools/voice/voice-ai-models.md
@@ -19,8 +19,6 @@ tools:
 - **Offline tool**: `tools/voice/buzz.md` (Buzz GUI/CLI for Whisper)
 - **CLI**: `voice-helper.sh`
 
-<!-- AI-CONTEXT-END -->
-
 ## Decision Flow
 
 ```text
@@ -42,6 +40,8 @@ Need voice AI?
     └── Default → speech-to-speech.md cascaded pipeline
 ```
 
+<!-- AI-CONTEXT-END -->
+
 ## TTS (Text-to-Speech)
 
 ### Cloud
@@ -56,13 +56,13 @@ Need voice AI?
 
 ### Local
 
-| Model | Params | License | Languages | Voice Clone | VRAM |
-|-------|--------|---------|-----------|-------------|------|
-| Qwen3-TTS 0.6B | 0.6B | Apache-2.0 | 10 | Yes (5s ref) | 2GB |
-| Qwen3-TTS 1.7B | 1.7B | Apache-2.0 | 10 | Yes (5s ref) | 4GB |
-| Bark (Suno) | 1.0B | MIT | 13+ | Yes (prompt) | 6GB (stale, expressive: laughter/music) |
-| Coqui TTS | varies | MPL-2.0 | 20+ | Yes | 2-6GB |
-| Piper | <100M | MIT | 30+ | No | CPU only |
+| Model | Params | License | Languages | Voice Clone | VRAM | Notes |
+|-------|--------|---------|-----------|-------------|------|-------|
+| Qwen3-TTS 0.6B | 0.6B | Apache-2.0 | 10 | Yes (5s ref) | 2GB | |
+| Qwen3-TTS 1.7B | 1.7B | Apache-2.0 | 10 | Yes (5s ref) | 4GB | |
+| Bark (Suno) | 1.0B | MIT | 13+ | Yes (prompt) | 6GB | Expressive (laughter/music); stale |
+| Coqui TTS | varies | MPL-2.0 | 20+ | Yes | 2-6GB | |
+| Piper | <100M | MIT | 30+ | No | CPU only | |
 
 Also available: EdgeTTS (free, 300+ voices), macOS Say (zero deps), FacebookMMS (1100+ languages). See `voice-models.md`.
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/voice/voice-ai-models.md` per GH#16154 simplification scan.

## Changes
- **Decision Flow moved inside `<!-- AI-CONTEXT-START/END -->`** — the decision tree is the most actionable instruction in this doc; it was previously outside the context block and would be excluded from context injection. Now included alongside Quick Reference.
- **Bark table entry fixed** — VRAM column had a parenthetical note `(stale, expressive: laughter/music)` mixed into the cell value. Extracted to a proper `Notes` column for all local TTS models.

## Issue
Closes #16154

## Files Changed
- `.agents/tools/voice/voice-ai-models.md` (132 lines → 132 lines; structural improvement, no content loss)

## Testing
- Self-assessed (Low risk: docs-only change, no code, no agent logic)
- Content preservation verified: all code blocks, URLs, task ID references, and command examples present before and after
- No broken internal links or references
- Agent behaviour unchanged (decision tree and all table data preserved verbatim)

## Runtime Testing
`self-assessed` — docs-only change, no runtime environment required.

## Key Decisions
- File classified as **hybrid** (instruction + reference corpus): Quick Reference + Decision Flow are instruction-like; tables are reference corpus. At 132 lines, no split needed.
- Decision Flow inclusion in AI context block is the highest-value structural fix — LLMs weight earlier context more heavily (primacy effect), and the decision tree is the primary routing instruction.
- Table data, model specs, pricing, and all cross-references preserved without compression.

---
[aidevops.sh](https://aidevops.sh) v3.5.860 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6