### PR TITLE
GH#16629: tighten agent-optimization.md prose and redundant lines

### DIFF
--- a/.agents/tools/autoresearch/autoresearch/agent-optimization.md
+++ b/.agents/tools/autoresearch/autoresearch/agent-optimization.md
@@ -1,14 +1,12 @@
 # Autoresearch — Agent Optimization Domain
 
-Sub-doc for `autoresearch.md`. Load when `PROGRAM_NAME == "agent-optimization"` or
-`METRIC_CMD` contains `agent-test-helper.sh`.
+Sub-doc for `autoresearch.md`. Load when `PROGRAM_NAME == "agent-optimization"` or `METRIC_CMD` contains `agent-test-helper.sh`.
 
 ---
 
 ## Security Instruction Exemptions
 
-Before generating any hypothesis, check whether it would remove or weaken any of
-the following categories. If yes, discard without testing:
+Discard any hypothesis that removes or weakens the following — do not test:
 
 | Category | Detection pattern |
 |----------|------------------|
@@ -19,7 +17,7 @@ the following categories. If yes, discard without testing:
 | Prompt injection | `prompt injection`, `adversarial`, `scan` |
 | Destructive operations | `destructive`, `confirm before`, `irreversible` |
 
-Enforced by both the constraint list in the research program and the researcher model's hypothesis generation. Both layers must hold.
+Enforced by both the research program constraint list and the researcher model. Both layers must hold.
 
 ---
 
@@ -35,42 +33,38 @@ TOKEN_RATIO=$(echo "$METRIC_JSON" | jq '.token_ratio')
 Use `COMPOSITE_SCORE` as the primary metric for keep/discard decisions.
 Log `PASS_RATE` and `TOKEN_RATIO` as supplementary columns in results.tsv.
 
-**Formula**: `composite_score = pass_rate * (1 - 0.3 * token_ratio)`
+**Formula**: `composite_score = pass_rate * (1 - 0.3 * token_ratio)` (higher = better)
 
 - `pass_rate`: fraction of tests passing (0–1)
 - `token_ratio`: `avg_response_chars / baseline_chars` — proxy for token usage
-- Higher composite score = better (direction: higher)
 
 ---
 
 ## Baseline Setup
 
-On first run (BASELINE == null), establish the baseline before measuring:
+On first run (`BASELINE == null`), establish baseline before measuring:
 
 ```bash
 agent-test-helper.sh baseline .agents/tests/agent-optimization.test.json
 ```
 
-Sets `baseline_chars`, enabling `token_ratio` computation on subsequent runs. Without this, `token_ratio` defaults to 1.0 (no change).
+Sets `baseline_chars` for `token_ratio` computation. Without this, `token_ratio` defaults to 1.0.
 
 ---
 
 ## Simplification State Integration
 
-Before generating hypotheses, check `.agents/configs/simplification-state.json`:
+Before generating hypotheses, skip unchanged files:
 
 ```bash
-TARGET_FILE=".agents/build-plus.md"  # or whichever file is being optimized
+TARGET_FILE=".agents/build-plus.md"
 CURRENT_HASH=$(md5sum "$TARGET_FILE" | awk '{print $1}')
 STORED_HASH=$(jq -r --arg f "$TARGET_FILE" '.files[$f].hash // empty' \
     .agents/configs/simplification-state.json 2>/dev/null)
-
-if [[ "$CURRENT_HASH" == "$STORED_HASH" ]]; then
-    log "File unchanged since last optimization. Skipping."
-fi
+[[ "$CURRENT_HASH" == "$STORED_HASH" ]] && log "File unchanged. Skipping."
 ```
 
-After a successful session (composite_score improved vs baseline), update the hash:
+After a successful session (`composite_score` improved vs baseline), update the hash:
 
 ```bash
 CURRENT_HASH=$(md5sum "$TARGET_FILE" | awk '{print $1}')
@@ -93,4 +87,4 @@ jq --arg file "$TARGET_FILE" \
 | 16–25 | Shorten verbose phrasing | Replace 3-sentence rule with 1-sentence equivalent |
 | 26–35 | Replace inline code with references | `rg "pattern"` instead of inline code blocks |
 | 36–45 | Merge thin sections | Combine two small sections covering the same topic |
-| 46+ | Simplification | Remove anything that doesn't affect the metric |
+| 46+ | Aggressive removal | Remove anything that doesn't affect the metric |


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/autoresearch/autoresearch/agent-optimization.md` from 96 to 90 lines (-6.25%) per issue #16629 simplification scan.

**Changes:**
- Condense intro line (2 lines → 1)
- Security section: tighten header prose and enforcement note
- Composite metric: merge direction note inline, remove standalone bullet
- Baseline section: tighten explanation prose
- Simplification state: collapse 4-line `if` block to single-line guard; remove redundant inline comment
- Hypothesis types: rename vague `Simplification` → `Aggressive removal`

**Preservation check:** All code blocks, task ID references, command examples, and institutional knowledge present before and after. Agent behaviour unchanged.

Closes #16629

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no executable code changed.
**Verification:** `self-assessed` — content preservation verified via diff review; all code blocks, URLs, and references intact.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten agent-optimization.md prose (96→90 lines)
**Issue:** #16629
**Files changed:** `.agents/tools/autoresearch/autoresearch/agent-optimization.md`
**Testing:** Self-assessed (doc-only change, no runtime impact)
**Key decisions:** Preserved all institutional knowledge; only compressed prose and collapsed verbose if-block

---
[aidevops.sh](https://aidevops.sh) v3.5.861 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6