### PR TITLE
GH#16630: tighten comprehension benchmark pilot results doc

### DIFF
--- a/.agents/tests/comprehension/pilot-results.md
+++ b/.agents/tests/comprehension/pilot-results.md
@@ -1,7 +1,6 @@
 # Comprehension Benchmark Pilot Results
 
-**Date:** 2026-04-02 | **Files:** 15 | **Scenarios:** 38 (2-3/file)
-**Method:** Structural pre-filter + predicted tier assignment
+**Date:** 2026-04-02 | **Files:** 15 | **Scenarios:** 38 (2-3/file) | **Method:** Structural pre-filter + predicted tier assignment
 
 ## Summary
 
@@ -37,7 +36,7 @@
 
 Right topic, wrong conclusion — multiple valid readings exist.
 
-**Expected haiku failures:**
+**Expected haiku failures (ambiguous docs):**
 - `code-simplifier.md`: nuanced "almost never simplify" categories → haiku over-simplifies classification
 - `planning-detail.md`: 3-step PR lookup fallback chain with conditional logic → haiku skips or conflates steps
 - `worker-efficiency-protocol.md`: 6-row model escalation decision matrix → haiku misses edge cases
@@ -59,11 +58,11 @@ Right topic, wrong conclusion — multiple valid readings exist.
 
 **Sonnet false-fails:** None expected. Opus-tier files (e.g., `prompts/build.txt` 400+ lines, deeply nested cross-refs) excluded from pilot.
 
-**False-pass risk:** Haiku passes deterministic checks but misunderstands intent. Example: `reference/self-improvement.md` "framework vs project routing" — haiku outputs "framework" (passes `contains` check) with wrong reasoning. Mitigation: adjudication layer (haiku self-check or sonnet judge); `reference_answer` field enables precise comparison for critical files.
+**False-pass risk:** Haiku passes deterministic checks but misunderstands intent (e.g., `reference/self-improvement.md` "framework vs project routing" — outputs "framework" but with wrong reasoning). Mitigation: adjudication layer (haiku self-check or sonnet judge); `reference_answer` field enables precise comparison for critical files.
 
 ## Structural Pre-Filter
 
-Predicts complexity from line count, cross-ref count, code blocks, table rows, heading depth — no model calls.
+Predicts complexity from line count, cross-refs, code blocks, table rows, heading depth — no model calls.
 
 | Complexity | Criteria | Predicted Tier |
 |-----------|----------|----------------|


### PR DESCRIPTION
## Summary

- Merge 2-line header metadata into single pipe-delimited line
- Tighten false-pass risk paragraph (remove redundant "Example:" prefix, inline the example)
- Clarify failure category label: "Expected haiku failures" → "Expected haiku failures (ambiguous docs)"
- Shorten structural pre-filter intro: "cross-ref count" → "cross-refs"
- 95 → 94 lines; all data, tables, task IDs (`tNNN`, `GH#NNN`), command examples, and institutional knowledge preserved

**Classification:** Reference corpus (benchmark results data) — prose tightening only, no content reduction.

## Issue

Closes #16630

## Files Changed

- `.agents/tests/comprehension/pilot-results.md` — 4 prose edits, -1 line

## Testing

**Risk level:** Low (docs-only, no code, no agent instructions changed)
**Runtime Testing:** `self-assessed` — markdown file with no executable logic

## Runtime Testing

self-assessed: docs-only change, no agent behaviour affected

---
[aidevops.sh](https://aidevops.sh) v3.5.861 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6