### PR TITLE
GH#16631: tighten browser-benchmark.md agent doc

### DIFF
--- a/.agents/tools/browser/browser-benchmark.md
+++ b/.agents/tools/browser/browser-benchmark.md
@@ -13,7 +13,7 @@ tools:
 
 # Browser Tool Benchmarking Agent
 
-Run standardised benchmarks across all browser automation tools and update `browser-automation.md` with results.
+Runs standardised benchmarks across all browser automation tools and updates `browser-automation.md` with results. Scripts in `browser-benchmark-scripts.md`.
 
 ```bash
 /browser-benchmark              # Run all benchmarks
@@ -24,7 +24,7 @@ Run standardised benchmarks across all browser automation tools and update `brow
 
 ## Test Matrix
 
-Target: `https://the-internet.herokuapp.com`. Run each test 3 times per tool, report median.
+Target: `https://the-internet.herokuapp.com`. 3 runs per tool, report median. Network variance ~0.2-0.5s.
 
 | Test | Measures |
 |------|----------|
@@ -47,24 +47,22 @@ Target: `https://the-internet.herokuapp.com`. Run each test 3 times per tool, re
 
 ## Running Benchmarks
 
-Scripts: `~/.aidevops/.agent-workspace/work/browser-bench/`. Full source: `browser-benchmark-scripts.md`. Network variance ~0.2-0.5s — use median of 3 runs.
-
 ```bash
 cd ~/.aidevops/.agent-workspace/work/browser-bench/
 node bench-playwright.mjs | tee results-playwright.json
 bash bench-agent-browser.sh | tee results-agent-browser.txt
 source ~/.aidevops/crawl4ai-venv/bin/activate && python bench-crawl4ai.py | tee results-crawl4ai.json
 OPENAI_API_KEY=... node bench-stagehand.mjs | tee results-stagehand.json
-# dev-browser: cd ~/.aidevops/dev-browser/skills/dev-browser && bun x tsx bench.ts | tee ~/results-dev-browser.json
+# dev-browser: bun x tsx ~/.aidevops/dev-browser/skills/dev-browser/bench.ts | tee ~/results-dev-browser.json
 ```
 
 ## Updating Documentation
 
-After benchmarks, update the Performance Benchmarks table in `browser-automation.md`:
+Update the Performance Benchmarks table in `browser-automation.md`:
 
 1. Median of 3 runs per test; bold fastest time per row
 2. Update "Key insight" section if relative performance changed
-3. Note date and environment: `date && uname -a && node --version && python3 --version`
+3. Record environment: `date && uname -a && node --version && python3 --version`
 
 ## Adding New Tools
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened prose in `.agents/tools/browser/browser-benchmark.md` per simplification scan (GH#16631). 73 → 71 lines.

## Changes
- Merged `browser-benchmark-scripts.md` reference into intro (was buried in "Running Benchmarks" section)
- Consolidated network variance note into Test Matrix header (was in a separate prose line)
- Removed redundant "Scripts: ..." prose line before the bash block (the `cd` command already shows the path)
- Tightened "After benchmarks, update..." → "Update..." (implied)
- "Note date and environment" → "Record environment" (shorter, same meaning)
- Shortened dev-browser comment path (removed redundant `cd` prefix)

## Preservation check
All institutional knowledge retained: all command examples, all URLs, all tool setup commands, all table data, all file references. No task IDs or incident references in this file.

## Testing
- `self-assessed` (Low risk: docs/agent prompt only, no code changes)
- Content verified: all code blocks, URLs, and command examples present before and after

## Runtime Testing
Risk: **Low** — agent prompt doc only, no executable code changed.
Verification: `self-assessed`

Closes #16631

---
[aidevops.sh](https://aidevops.sh) v3.5.861 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6