### PR TITLE
GH#16635: tighten cold-outreach.md prose for clarity and concision

### DIFF
--- a/.agents/services/outreach/cold-outreach.md
+++ b/.agents/services/outreach/cold-outreach.md
@@ -32,9 +32,9 @@ tools:
 | 3 | 13-16 | Increase follow-ups; keep copy variation high |
 | 4 | 17-20 | Stable warm baseline; reply handling human-in-loop |
 
-Scale above 20/day only after 7+ days of stable inbox health. Plan: `target_daily_volume / 100 = minimum active mailboxes`. Add 20-30% headroom for pauses and deliverability degradation.
+Scale above 20/day only after 7+ days of stable inbox health. Formula: `target_daily_volume / 100 = minimum active mailboxes` (+20-30% headroom for pauses and deliverability degradation).
 
-**Multi-mailbox rotation:** Group by reputation tier (new, warming, stable); route high-priority accounts through stable first. Distribute sequence steps evenly — no mailbox peaks at one hour/daypart. Pause on anomaly signals (bounce spike, spam-folder drift, complaints); rebalance to healthy mailboxes.
+**Multi-mailbox rotation:** Group by reputation tier (new, warming, stable). Route high-priority accounts through stable mailboxes first. Distribute sequence steps evenly across dayparts. Pause on anomaly signals (bounce spike, spam-folder drift, complaints); rebalance to healthy mailboxes.
 
 ## Platform Selection
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened prose in `.agents/services/outreach/cold-outreach.md` per simplification scan (GH#16635).

## Issue
Closes #16635

## Files Changed
- `.agents/services/outreach/cold-outreach.md` — 2 lines changed (prose tightening only)

## Changes
- Consolidated warmup formula and headroom note into a single sentence (removed redundant "Add" sentence)
- Replaced ambiguous `Plan:` label with precise `Formula:` for the mailbox calculation
- Clarified multi-mailbox rotation paragraph with cleaner sentence structure (semicolons → periods, "no mailbox peaks at one hour/daypart" → "evenly across dayparts")

## Testing
**Risk level:** Low — docs/agent prompt only, no code or logic changes.
**Runtime Testing:** `self-assessed` — agent behaviour unchanged; all content preserved, no rules removed.

## Content Preservation Verification
- All code blocks present: ✓ (`target_daily_volume / 100 = minimum active mailboxes`)
- All task ID references: ✓ (none in this file)
- All URLs: ✓ (none in this file)
- All compliance requirements: ✓ (CAN-SPAM, GDPR unchanged)
- All platform/infrastructure options: ✓ (tables unchanged)
- Line count: 70 → 70 (lateral improvement, not line reduction)

---
[aidevops.sh](https://aidevops.sh) v3.5.864 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6