### PR TITLE
GH#16637: tighten OCR tools overview agent doc

### DIFF
--- a/.agents/tools/ocr/overview.md
+++ b/.agents/tools/ocr/overview.md
@@ -12,11 +12,7 @@ tools:
   task: true
 ---
 
-# OCR Tools Overview
-
 <!-- AI-CONTEXT-START -->
-
-## Quick Reference
 
 | Input | Tool | Strengths | Limits |
 |-------|------|-----------|--------|
@@ -28,7 +24,7 @@ tools:
 | Simple text PDF | **Pandoc** | Fastest text-only conversion | No layout awareness; no OCR → MinerU for complex layouts |
 | Document understanding (VLM) | **PaddleOCR-VL** | Local document/structured understanding | Not plain OCR → PaddleOCR for text extraction |
 
-**Subagents:**
+## Subagents
 
 | File | Purpose |
 |------|---------|
@@ -38,8 +34,6 @@ tools:
 | `tools/conversion/mineru.md` | MinerU — PDF to markdown/JSON |
 | `tools/document/document-extraction.md` | Docling + ExtractThinker — structured extraction |
 | `tools/pdf/overview.md` | LibPDF — PDF manipulation and text extraction |
-
-<!-- AI-CONTEXT-END -->
 
 ## Common Workflows
 
@@ -63,3 +57,5 @@ for img in ./images/*.png; do paddleocr-helper.sh ocr "$img"; done
 #            PDF → Docling → ExtractThinker → structured JSON → QuickFile
 # PaddleOCR and Docling MCP servers plug into Claude Desktop / the agent framework.
 ```
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ocr/overview.md` per build-agent.md guidance. Instruction doc classification — content compressed, not restructured.

## Issue
Closes #16637

## Changes
- Remove redundant `# OCR Tools Overview` H1 (duplicates frontmatter `description` field)
- Remove superfluous `## Quick Reference` heading (the selection table is self-evident)
- Promote `**Subagents:**` bold label to proper `## Subagents` H2 heading
- Extend `<!-- AI-CONTEXT -->` block to include Common Workflows (workflows are critical context, previously excluded from the block)
- 65 → 61 lines; zero content loss; all code blocks, URLs, tool names, and command examples preserved

## Testing
Risk: **Low** — docs/agent prompt only, no code paths. Self-assessed.

All content verified present before and after:
- Selection table: 7 tools × 4 columns ✓
- Subagent index: 6 entries ✓
- Common Workflows bash block: all 6 examples ✓
- No broken internal references ✓

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.865 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6