### PR TITLE
GH#16652: tighten list-keys.md agent doc (65→56 lines)

### DIFF
--- a/.agents/tools/credentials/list-keys.md
+++ b/.agents/tools/credentials/list-keys.md
@@ -36,23 +36,14 @@ tools:
 ```text
 API Keys Available in Session
 =============================
-
 Source: ~/.config/aidevops/credentials.sh
   OPENAI_API_KEY          [loaded]
   ANTHROPIC_API_KEY       [loaded]
-  CLOUDFLARE_API_KEY      [loaded]
-
-Source: Shell configs (~/.zshrc, ~/.bashrc, etc.)
-  CUSTOM_API_KEY          [loaded]
-
 Source: Environment (shell session)
   GITHUB_TOKEN            [loaded]
-  NPM_TOKEN               [loaded]
-
 Source: ~/.config/coderabbit/api_key
   CODERABBIT_API_KEY      [loaded]
-
-Total: 7 keys from 4 sources
+Total: 4 keys from 3 sources
 ```
 
 ## Status Indicators
@@ -60,6 +51,6 @@ Total: 7 keys from 4 sources
 | Status | Meaning |
 |--------|---------|
 | `[loaded]` | Valid value loaded in session |
-| `[placeholder]` | Placeholder detected: `YOUR_*_HERE`, `REPLACE_*`, `CHANGEME`, `FIXME`, `TODO`, `example`, `sample`, `test-key`, `dummy`, `fake`, `xxx`/`yyy`/`zzz`, `placeholder`, `none`, `null`, template markers (`<...>`, `{...}`, `[...]`), repeated chars (`xxxx`, `0000`) |
+| `[placeholder]` | Placeholder detected: `YOUR_*_HERE`, `CHANGEME`, `example`, `dummy`, `fake`, template markers (`<...>`, `{...}`), repeated chars (`xxxx`, `0000`) |
 | `[not loaded]` | Defined but not loaded in current session |
 | `[configured]` | Present in a config file |


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/credentials/list-keys.md` from 65 to 56 lines (14% reduction) per simplification scan.

**Changes:**
- Compress output example: remove blank lines between sources, trim to 3-source representative example (all 5 sources still documented in Quick Reference)
- Condense `[placeholder]` status row: keep representative patterns, remove exhaustive list of synonyms

**Preserved:**
- All 5 key sources in Quick Reference
- Security rule (names/locations only, never values)
- All 4 status indicator rows
- All command/script references

**Classification:** Instruction doc (not reference corpus) — prose compression applied, not chapter split.

Closes #16652

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution paths changed.
**Verification:** `self-assessed` — file content reviewed, all institutional knowledge confirmed present.

<!-- MERGE_SUMMARY -->
**What:** Tighten list-keys.md agent doc from 65→56 lines
**Issue:** #16652
**Files changed:** `.agents/tools/credentials/list-keys.md`
**Testing:** Self-assessed (docs-only change)
**Key decisions:** Compressed output example and placeholder pattern list; all key sources preserved in Quick Reference

---
[aidevops.sh](https://aidevops.sh) v3.5.868 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6