### PR TITLE
GH#16654: tighten Cloudflare Tunnel agent doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/tunnel.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/tunnel.md
@@ -1,6 +1,6 @@
 # Cloudflare Tunnel
 
-Use Cloudflare Tunnel when you need outbound-only connectivity from an origin to Cloudflare with no inbound ports, direct firewall exposure, or public IP on the service host.
+Outbound-only connectivity from origin to Cloudflare — no inbound ports, no firewall exposure, no public IP required.
 
 ## Architecture
 
@@ -13,9 +13,9 @@ Use Cloudflare Tunnel when you need outbound-only connectivity from an origin to
 ## Quick start
 
 ```bash
-brew install cloudflared               # macOS; use your package manager elsewhere
-cloudflared tunnel login               # authorizes this machine
-cloudflared tunnel create my-tunnel    # creates named tunnel + credentials
+brew install cloudflared               # macOS; use distro package manager elsewhere
+cloudflared tunnel login               # authorize this machine
+cloudflared tunnel create my-tunnel    # creates named tunnel + credentials file
 cloudflared tunnel route dns my-tunnel app.example.com
 cloudflared tunnel run my-tunnel
 ```
@@ -54,10 +54,10 @@ ingress:
 
 ## Operating notes
 
-- Run multiple connectors against the same named tunnel for HA; Cloudflare load-balances them automatically.
-- Ingress rules are first-match-wins; always keep a final catch-all such as `http_status:404`.
-- Long-lived connections can drop during connector restarts or replica replacements.
 - Prefer remotely managed tunnels and Access policies for sensitive services.
+- Multiple connectors per named tunnel = HA; Cloudflare load-balances automatically.
+- Ingress rules are first-match-wins; always end with a catch-all (`http_status:404`).
+- Long-lived connections may drop on connector restart or replica replacement.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/tunnel.md` per automated simplification scan (GH#16654).

**Classification:** Instruction doc (agent rules, quick-start, operational procedures) — not a reference corpus. Prose compression applied, no content split required.

**Changes:**
- Opening sentence compressed: leads with the key constraint (outbound-only, no inbound ports)
- Operating notes reordered: security/Access policy note moved first (primacy effect — LLMs weight earlier context more heavily)
- HA connector note tightened: "Run multiple connectors against the same named tunnel for HA; Cloudflare load-balances them automatically." → "Multiple connectors per named tunnel = HA; Cloudflare load-balances automatically."
- Catch-all rule phrasing tightened
- Quick-start comments made more precise

**Preservation check:** All code blocks, URLs, command examples, and operational rules present before and after. Zero content removed.

Closes #16654

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code changes.
**Verification:** `self-assessed` — markdownlint-cli2 passes (0 errors), content diff reviewed line-by-line.

---
[aidevops.sh](https://aidevops.sh) v3.5.868 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6