### PR TITLE
t1870: multi-trial evaluation extension for autoresearch loop

### DIFF
--- a/.agents/templates/research-program-template.md
+++ b/.agents/templates/research-program-template.md
@@ -81,7 +81,10 @@ Model tiers: `haiku` (fast/cheap), `sonnet` (balanced), `opus` (best quality).
 timeout: 7200          # required: total wall-clock seconds (default: 2h)
 max_iterations: 50     # required: max experiment count
 per_experiment: 300    # optional: max seconds per single experiment (default: 5min)
+trials: 1              # optional: evaluations per hypothesis (default: 1, use 2-3 for noisy metrics)
 ```
+
+Multi-trial evaluation reduces noise from stochastic metrics (e.g., LLM-scored tests). Each trial re-runs the full metric command. The median result is used for keep/discard. Set to 2-3 for LLM-based metrics, 1 for deterministic metrics (build time, file size).
 
 ## Hints
 

--- a/.agents/tools/autoresearch/autoresearch.md
+++ b/.agents/tools/autoresearch/autoresearch.md
@@ -52,13 +52,14 @@ Extract `--program <path>`; exit with error if missing or file not found. Extrac
 | `METRIC_DIR` | `## Metric` section, `direction:` line (`lower` \| `higher`) |
 | `BASELINE` | `## Metric` section, `baseline:` line (`null` = not yet measured) |
 | `GOAL` | `## Metric` section, `goal:` line (`null` = no goal) |
-| `CONSTRAINTS` | `## Constraints` section, each `- ` bullet as a shell command |
+| `CONSTRAINTS` | `## Constraints` section, each bullet as a shell command |
 | `RESEARCHER` | `## Models` section, `researcher:` line |
 | `EVALUATOR` | `## Models` section, `evaluator:` line (optional) |
 | `TARGET_MODEL` | `## Models` section, `target:` line (optional) |
 | `TIMEOUT` | `## Budget` section, `timeout:` line (seconds) |
 | `MAX_ITER` | `## Budget` section, `max_iterations:` line |
 | `PER_EXPERIMENT` | `## Budget` section, `per_experiment:` line |
+| `TRIALS` | `## Budget` section, `trials:` line (default: 1) |
 | `HINTS` | `## Hints` section, all bullet lines |
 
 ## Step 1: Setup
@@ -87,7 +88,7 @@ if RESUMING and RESULTS_FILE exists:
 else:
     ITERATION_COUNT=0; BEST_METRIC=null; BASELINE=null; FAILED_HYPOTHESES=[]; TOTAL_TOKENS=0
     mkdir -p $(dirname RESULTS_FILE)
-    Write TSV header: iteration\tcommit\tmetric_name\tmetric_value\tbaseline\tdelta\tstatus\thypothesis\ttimestamp\ttokens_used
+    Write TSV header: iteration\tcommit\tmetric_name\tmetric_value\tbaseline\tdelta\tstatus\thypothesis\ttimestamp\ttokens_used\tpass_rate\ttoken_ratio\ttrials\ttrial_variance
 ```
 
 **1.4 Recall cross-session memory:** `aidevops-memory recall "autoresearch $PROGRAM_NAME" --limit 10` → store as MEMORY_CONTEXT.

--- a/.agents/tools/autoresearch/autoresearch/logging.md
+++ b/.agents/tools/autoresearch/autoresearch/logging.md
@@ -7,7 +7,7 @@ Sub-doc for `autoresearch.md`. Loaded on demand.
 Append to `todo/research/{name}-results.tsv`:
 
 ```text
-{iteration}\t{commit_sha_or_dash}\t{metric_name}\t{metric_value_or_dash}\t{baseline}\t{delta_or_dash}\t{status}\t{hypothesis}\t{ISO_timestamp}\t{tokens_used}\t{pass_rate_or_dash}\t{token_ratio_or_dash}
+{iteration}\t{commit_sha_or_dash}\t{metric_name}\t{metric_value_or_dash}\t{baseline}\t{delta_or_dash}\t{status}\t{hypothesis}\t{ISO_timestamp}\t{tokens_used}\t{pass_rate_or_dash}\t{token_ratio_or_dash}\t{trials}\t{trial_variance_or_dash}
 ```
 
 | Column | Type | Notes |
@@ -15,23 +15,27 @@ Append to `todo/research/{name}-results.tsv`:
 | `iteration` | int | Sequential (0 = baseline) |
 | `commit` | string | Short SHA or `-` for crashes/discards |
 | `metric_name` | string | From research program `name:` field |
-| `metric_value` | float\|`-` | `-` for crashes/constraint fails |
+| `metric_value` | float\|`-` | `-` for crashes/constraint fails; median when TRIALS > 1 |
 | `baseline` | float | Original value (same for all rows) |
 | `delta` | float\|`-` | `metric_value - baseline` (signed); `-` for crashes |
-| `status` | string | `baseline`, `keep`, `discard`, `constraint_fail`, `crash` |
+| `status` | string | `baseline`, `keep`, `discard`, `discard_inconsistent`, `constraint_fail`, `crash` |
 | `hypothesis` | string | One line, no tabs |
 | `timestamp` | ISO 8601 | UTC |
 | `tokens_used` | int | Approximate tokens for this iteration |
 | `pass_rate` | float\|`-` | 0–1; agent-optimization only |
 | `token_ratio` | float\|`-` | `avg_response_chars / baseline_chars`; agent-optimization only |
+| `trials` | int | Number of evaluation trials run (1 if single-shot) |
+| `trial_variance` | float\|`-` | `max - min` of trial results; `-` for single trial or crashes |
 
 Example:
 
 ```tsv
-iteration	commit	metric_name	metric_value	baseline	delta	status	hypothesis	timestamp	tokens_used	pass_rate	token_ratio
-0	(baseline)	build_time_s	12.4	12.4	0.0	baseline	(initial measurement)	2026-04-01T10:00:00Z	0	-	-
-1	a1b2c3d	build_time_s	11.1	12.4	-1.3	keep	remove unused lodash import	2026-04-01T10:12:00Z	2340	-	-
-2	-	build_time_s	12.8	12.4	0.4	discard	switch to esbuild (breaks API)	2026-04-01T10:24:00Z	3100	-	-
+iteration	commit	metric_name	metric_value	baseline	delta	status	hypothesis	timestamp	tokens_used	pass_rate	token_ratio	trials	trial_variance
+0	(baseline)	build_time_s	12.4	12.4	0.0	baseline	(initial measurement)	2026-04-01T10:00:00Z	0	-	-	1	-
+1	a1b2c3d	build_time_s	11.1	12.4	-1.3	keep	remove unused lodash import	2026-04-01T10:12:00Z	2340	-	-	1	-
+2	-	build_time_s	12.8	12.4	0.4	discard	switch to esbuild (breaks API)	2026-04-01T10:24:00Z	3100	-	-	1	-
+3	b3c4d5e	avg_tokens_per_task	85.2	92.0	-6.8	keep	remove redundant constraint examples	2026-04-01T10:36:00Z	4200	0.94	0.92	3	2.1
+4	-	avg_tokens_per_task	91.5	92.0	-0.5	discard_inconsistent	merge hints into single bullet	2026-04-01T10:48:00Z	3800	0.93	0.91	3	4.7
 ```
 
 ## Memory Storage

--- a/.agents/tools/autoresearch/autoresearch/loop.md
+++ b/.agents/tools/autoresearch/autoresearch/loop.md
@@ -29,30 +29,48 @@ while true:
     if constraint_result == FAIL:
         git -C WORKTREE_PATH reset --hard HEAD
         track_tokens(ITER_START_TOKENS)
-        log_result(ITERATION_COUNT, null, null, "constraint_fail", hypothesis, ITER_TOKENS)
+        log_result(ITERATION_COUNT, null, null, "constraint_fail", hypothesis, ITER_TOKENS, 0, "-")
         continue
 
-    metric_result = run_metric()
+    if TRIALS > 1:
+        (metric_result, variance, trial_results) = multi_trial_evaluate(METRIC_CMD, TRIALS, PER_EXPERIMENT)
+    else:
+        metric_result = run_metric()
+        variance = 0
+        trial_results = [metric_result]
+
     if metric_result == ERROR:
         git -C WORKTREE_PATH reset --hard HEAD
         track_tokens(ITER_START_TOKENS)
-        log_result(ITERATION_COUNT, null, null, "crash", hypothesis, ITER_TOKENS)
+        log_result(ITERATION_COUNT, null, null, "crash", hypothesis, ITER_TOKENS, 0, "-")
         continue
 
     track_tokens(ITER_START_TOKENS)
 
     if is_improvement(metric_result, BEST_METRIC, METRIC_DIR):
+        # Multi-trial consistency check: median improved but require majority of trials to improve
+        if TRIALS > 1:
+            improvement_count = count(r for r in trial_results if is_improvement(r, BEST_METRIC, METRIC_DIR))
+            if improvement_count <= TRIALS / 2:
+                # Median improved but not consistently — treat as noise
+                git -C WORKTREE_PATH reset --hard HEAD
+                FAILED_HYPOTHESES.append(hypothesis)
+                log_result(ITERATION_COUNT, null, metric_result, "discard_inconsistent", hypothesis, ITER_TOKENS, TRIALS, variance)
+                store_memory(hypothesis, metric_result, "discard_inconsistent")
+                send_discovery(hypothesis, metric_result, "discard_inconsistent", null)
+                continue
+
         git -C WORKTREE_PATH add -A
         git -C WORKTREE_PATH commit -m "experiment: {hypothesis[:60]} ({METRIC_NAME}: {metric_result})"
         HEAD_SHA = git -C WORKTREE_PATH rev-parse --short HEAD
         BEST_METRIC = metric_result
-        log_result(ITERATION_COUNT, HEAD_SHA, metric_result, "keep", hypothesis, ITER_TOKENS)
+        log_result(ITERATION_COUNT, HEAD_SHA, metric_result, "keep", hypothesis, ITER_TOKENS, TRIALS, variance)
         store_memory(hypothesis, metric_result, "keep")
         send_discovery(hypothesis, metric_result, "keep", HEAD_SHA)
     else:
         git -C WORKTREE_PATH reset --hard HEAD
         FAILED_HYPOTHESES.append(hypothesis)
-        log_result(ITERATION_COUNT, null, metric_result, "discard", hypothesis, ITER_TOKENS)
+        log_result(ITERATION_COUNT, null, metric_result, "discard", hypothesis, ITER_TOKENS, TRIALS, variance)
         store_memory(hypothesis, metric_result, "discard")
         send_discovery(hypothesis, metric_result, "discard", null)
 
@@ -104,11 +122,34 @@ timeout PER_EXPERIMENT bash -c "{constraint_command}"
 # exit_code != 0 → return FAIL; all constraints must pass (first failure short-circuits)
 ```
 
-**Metric measurement:**
+**Metric measurement (single trial):**
 
 ```bash
 timeout PER_EXPERIMENT bash -c "{METRIC_CMD}" 2>/dev/null
 # Parse last non-empty stdout line as float. Parsing failure or non-zero exit → ERROR.
+```
+
+**Multi-trial evaluation (when TRIALS > 1):**
+
+```text
+multi_trial_evaluate(metric_cmd, n_trials, per_experiment_timeout):
+    results = []
+    for i in 1..n_trials:
+        result = timeout per_experiment_timeout bash -c "{metric_cmd}" 2>/dev/null
+        # Parse last non-empty stdout line as float
+        if parse_error or non_zero_exit:
+            return ERROR  # Any trial failure = overall failure (infrastructure problem, not noise)
+        results.append(parsed_float)
+
+    # Sort and take median (robust to outliers)
+    sorted_results = sort(results)
+    if n_trials is odd:
+        median = sorted_results[n_trials / 2]
+    else:
+        median = (sorted_results[n_trials/2 - 1] + sorted_results[n_trials/2]) / 2
+
+    variance = max(results) - min(results)  # range as variance proxy
+    return (median, variance, results)
 ```
 
 **Improvement check:**


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Extends the autoresearch loop infrastructure to support multi-trial evaluation, reducing noise from stochastic metrics (e.g., LLM-scored tests). Changes 4 existing files.

## Issue
Closes #16660

## Files Changed
- `.agents/tools/autoresearch/autoresearch/loop.md` — added `multi_trial_evaluate` function, integrated into main loop, added consistency check
- `.agents/tools/autoresearch/autoresearch/logging.md` — added `trials` and `trial_variance` columns to TSV schema and examples
- `.agents/templates/research-program-template.md` — added `trials:` field to `## Budget` section with documentation
- `.agents/tools/autoresearch/autoresearch.md` — added `TRIALS` to Step 0 variable table, updated TSV header, fixed pre-existing MD038 lint error

## Key Changes

### loop.md
- `multi_trial_evaluate(metric_cmd, n_trials, per_experiment_timeout)` — runs metric N times, returns `(median, variance, trial_results)`. Any trial execution failure = overall ERROR (infrastructure problem, not noise).
- Main loop: when `TRIALS > 1`, calls `multi_trial_evaluate`; otherwise falls back to single-shot `run_metric()`.
- Consistency check: if median improves but `improvement_count <= TRIALS / 2`, logs `discard_inconsistent` and continues. Prevents false positives from lucky single trials.
- `log_result` calls updated to pass `TRIALS` and `variance` arguments.

### logging.md
- TSV format extended with `trials` (int) and `trial_variance` (float|`-`) columns.
- `status` column now includes `discard_inconsistent` as a valid value.
- Example rows updated to show both single-trial (`-` variance) and multi-trial rows.

### research-program-template.md
- `trials: 1` added to `## Budget` section with inline comment and explanatory paragraph.
- Default `1` preserves backward compatibility with all existing research programs.

### autoresearch.md
- `TRIALS` row added to Step 0 variable table (source: `## Budget` section, `trials:` line, default: 1).
- TSV header in Step 1.3 updated to include `pass_rate`, `token_ratio`, `trials`, `trial_variance` (was missing `pass_rate` and `token_ratio` too).

## Testing
- All 6 acceptance criteria verified via `grep -E` pattern matching against modified files.
- `markdownlint` passes clean on all 4 modified files (also fixed pre-existing MD038 error in autoresearch.md).
- Risk level: **Low** (documentation/pseudocode only — no executable code changed).

## Key Decisions
- **Median not mean**: robust to outliers; a single anomalous trial (e.g., LLM timeout → 0 score) doesn't drag down the result.
- **Fail on any trial error**: execution failure = infrastructure problem, not measurement noise. Fail fast.
- **Majority consistency check**: `improvement_count > TRIALS / 2` required. A 1-of-3 improvement is noise; 2-of-3 is signal.
- **Default trials:1**: zero behavior change for existing programs. Multi-trial is opt-in.

---
[aidevops.sh](https://aidevops.sh) v3.5.869 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6