### PR TITLE
GH#16668: tighten voice-ai-models.md agent doc

### DIFF
--- a/.agents/tools/voice/voice-ai-models.md
+++ b/.agents/tools/voice/voice-ai-models.md
@@ -5,8 +5,6 @@ tools:
   read: true
 ---
 
-# Voice AI Models
-
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
@@ -40,8 +38,6 @@ Need voice AI?
     └── Default → speech-to-speech.md cascaded pipeline
 ```
 
-<!-- AI-CONTEXT-END -->
-
 ## TTS (Text-to-Speech)
 
 ### Cloud
@@ -64,7 +60,7 @@ Need voice AI?
 | Coqui TTS | varies | MPL-2.0 | 20+ | Yes | 2-6GB | |
 | Piper | <100M | MIT | 30+ | No | CPU only | |
 
-Also available: EdgeTTS (free, 300+ voices), macOS Say (zero deps), FacebookMMS (1100+ languages). See `voice-models.md`.
+Also: EdgeTTS (free, 300+ voices), macOS Say (zero deps), FacebookMMS (1100+ languages) — see `voice-models.md`.
 
 ## STT (Speech-to-Text)
 
@@ -91,7 +87,7 @@ Also available: EdgeTTS (free, 300+ voices), macOS Say (zero deps), FacebookMMS 
 | NVIDIA Parakeet V3 | 0.6B | 9.6 | Fastest | 2GB (25 langs) |
 | Apple Speech | Built-in | 9.0 | Fast | On-device (macOS 26+) |
 
-Backends: `faster-whisper` (4x speed, recommended), `whisper.cpp` (C++ native, Apple Silicon optimized). See `transcription.md`.
+Backends: `faster-whisper` (4x speed, recommended), `whisper.cpp` (C++ native, Apple Silicon optimized) — see `transcription.md`.
 
 ## S2S (Speech-to-Speech)
 
@@ -117,7 +113,9 @@ Backends: `faster-whisper` (4x speed, recommended), `whisper.cpp` (C++ native, A
 | Enhancement | StudioVoice | Any | Yes |
 | Translation | Riva Translate | 36 | Yes |
 
-Pipeline: `Audio -> [Parakeet ASR] -> [Any LLM] -> [Magpie TTS] -> Audio`. See `cloud-voice-agents.md`. Cascaded S2S (VAD+STT+LLM+TTS): see `speech-to-speech.md`.
+Pipeline: `Audio -> [Parakeet ASR] -> [Any LLM] -> [Magpie TTS] -> Audio` — see `cloud-voice-agents.md`.
+
+Cascaded S2S (VAD+STT+LLM+TTS): see `speech-to-speech.md`.
 
 ## GPU Planning
 
@@ -129,4 +127,6 @@ Pipeline: `Audio -> [Parakeet ASR] -> [Any LLM] -> [Magpie TTS] -> Audio`. See `
 | Full cascaded pipeline | 4GB | 12GB |
 | CPU-only (Piper + whisper.cpp) | 0 (no GPU) | 8GB RAM |
 
-Apple Silicon: MPS for PyTorch models; `whisper-mlx` or `mlx-audio-whisper` for optimized macOS inference.
+Apple Silicon: MPS for PyTorch; `whisper-mlx` or `mlx-audio-whisper` for optimized macOS inference.
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/voice/voice-ai-models.md` per the simplification scan in GH#16668.

**Classification:** Instruction doc (decision tree + model selection reference) — tighten prose, not restructure into chapters.

## What changed

- Removed redundant `# Voice AI Models` h1 heading (duplicates frontmatter `description` field)
- Extended `<!-- AI-CONTEXT-START/END -->` block to wrap the full file — the model tables below the decision flow are equally useful context for agents
- Tightened 3 inline prose notes using em-dash for cleaner flow (`Also available:` → `Also:`, `.` + `See` → `— see`)
- Split run-on pipeline sentence into two lines for readability

## Content preservation

- All model data, accuracy scores, VRAM requirements, pricing, and URLs preserved
- All cross-references (`voice-models.md`, `transcription.md`, `cloud-voice-agents.md`, `speech-to-speech.md`) preserved
- Decision flow tree unchanged
- No task IDs or incident references in this file — nothing to preserve there

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code execution path.
**Verification:** `self-assessed` — file renders correctly, all cross-references intact, no broken links.

Closes #16668

<!-- MERGE_SUMMARY -->
**What:** Tighten voice-ai-models.md agent doc (remove redundant h1, extend AI-CONTEXT block, tighten 3 prose notes)
**Issue:** GH#16668
**Files changed:** 1 (`.agents/tools/voice/voice-ai-models.md`)
**Testing:** Self-assessed (docs-only change, low risk)
**Key decisions:** Classified as instruction doc (not reference corpus) — tighten prose, not split into chapters

---
[aidevops.sh](https://aidevops.sh) v3.5.869 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6