### PR TITLE
GH#16669: tighten cross-channel-conversation-continuity agent doc

### DIFF
--- a/.agents/services/communications/cross-channel-conversation-continuity.md
+++ b/.agents/services/communications/cross-channel-conversation-continuity.md
@@ -14,21 +14,17 @@ tools:
 
 # Cross-Channel Conversation Continuity
 
-One relationship history per person across email, Matrix, SimpleX, Slack, CLI, and similar channels — no private context leaks between unrelated identities.
+One relationship history per person across email, Matrix, SimpleX, Slack, CLI, and similar channels — no private context leaks between unrelated identities. Resolve identity first, then continue the conversation. Never infer continuity from display name alone — require explicit channel mapping and explicit confidence level.
 
 Continuity key: entity ID in `memory.db` (Layer 2: `entities`+`entity_channels` → Layer 1: `conversations` → Layer 0: `interactions`).
-
-## Core Rule
-
-Resolve identity first, then continue the conversation. Never infer continuity from display name alone — require explicit channel mapping and explicit confidence level.
 
 ## Workflow
 
 1. Resolve incoming sender and channel to an entity.
-2. If unresolved, suggest candidates and require confirmation.
+2. If unresolved, suggest candidates and require confirmation. Never merge entities automatically; keep confidence explicit (`suggested` until verified).
 3. Reuse existing conversation when topic and participants still align; start new when topic or audience changed.
 4. Log interaction to Layer 0 with channel metadata.
-5. Load context from same entity before replying.
+5. Load context from same entity before replying. Use `--privacy-filter` for shared or lower-trust channels. Keep irreversible decisions (identity merges, external sends) human-verifiable.
 
 **Email normalization** (`entity-helper.sh`): trim whitespace, lowercase, strip plus aliases. Example: ` User+alerts@Example.COM ` → `user@example.com`
 
@@ -41,12 +37,6 @@ entity-helper.sh link <entity_id> --channel email --channel-id "sender@example.c
 entity-helper.sh log-interaction <entity_id> --channel email --channel-id "sender@example.com" --content "..."
 entity-helper.sh context <entity_id> --channel email --limit 20 --privacy-filter
 ```
-
-## Guardrails
-
-- Never merge entities automatically; keep confidence explicit (`suggested` until verified).
-- Use `--privacy-filter` when rendering context to shared or lower-trust channels.
-- Keep irreversible decisions (identity merges, external sends) human-verifiable.
 
 ## Threading
 


### PR DESCRIPTION
## Summary

Tighten `.agents/services/communications/cross-channel-conversation-continuity.md` per issue #16669 simplification scan.

**Classification:** Instruction doc (agent rules, workflow, operational procedures) — not a reference corpus.

**Changes:**
- Merged "Core Rule" section into the intro paragraph (eliminates redundant section header)
- Inlined "Guardrails" bullet points into workflow steps 2 and 5 where they are contextually relevant
- Removed the now-empty "Guardrails" section header
- 65 → 55 lines (15% reduction)

**Preservation check:**
- All commands intact
- All task ID references preserved
- Threading table unchanged
- Verification checklist unchanged
- Email normalization example preserved
- Agent behaviour unchanged — same rules, same workflow, same guardrails

Closes #16669

## Runtime Testing

**Risk level:** Low — docs/agent prompt only, no code changes.
**Assessment:** self-assessed — no runtime verification required for doc-only changes.

<!-- MERGE_SUMMARY -->
**What:** Tighten agent doc by merging Core Rule into intro and inlining Guardrails into workflow steps.
**Issue:** #16669
**Files changed:** `.agents/services/communications/cross-channel-conversation-continuity.md`
**Testing:** Doc-only change, self-assessed. Content preservation verified by manual diff.
**Key decisions:** Classified as instruction doc (not reference corpus) — compress prose, not split into chapters.

---
[aidevops.sh](https://aidevops.sh) v3.5.869 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6