### PR TITLE
GH#16670: tighten AEO patterns doc headers

### DIFF
--- a/.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md
+++ b/.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md
@@ -1,15 +1,15 @@
 # AEO Patterns
 
-Use these for featured snippets, answer boxes, and spoken-result queries.
+Templates for featured snippets, answer boxes, and spoken-result queries.
 
-## Definition Block
+## Definition
 
 ```markdown
 ## What is [Term]?
 [Term] is [1-sentence definition]. [Key characteristics]. [Why it matters].
 ```
 
-## Step-by-Step Block
+## Step-by-Step
 
 ```markdown
 ## How to [Action/Goal]
@@ -30,7 +30,7 @@ Use these for featured snippets, answer boxes, and spoken-result queries.
 **Bottom line**: [1-2 sentence recommendation]
 ```
 
-## Pros/Cons Block
+## Pros/Cons
 
 ```markdown
 ## Advantages and Disadvantages of [Topic]
@@ -39,7 +39,7 @@ Use these for featured snippets, answer boxes, and spoken-result queries.
 **Verdict**: [Balanced conclusion with recommendation]
 ```
 
-## FAQ Block
+## FAQ
 
 ```markdown
 <!-- Phrase questions the way users search; match "People Also Ask" wording; keep answers 50-100 words; direct answer first -->
@@ -47,7 +47,7 @@ Use these for featured snippets, answer boxes, and spoken-result queries.
 [Direct answer first sentence]. [Supporting context in 2-3 sentences].
 ```
 
-## Listicle Block
+## Listicle
 
 ```markdown
 ## [Number] Best [Items] for [Goal/Purpose]
@@ -56,7 +56,7 @@ Use these for featured snippets, answer boxes, and spoken-result queries.
 [Why included -- 2-3 sentences with specific benefits]
 ```
 
-## Voice Search Pattern
+## Voice Search
 
 ```markdown
 <!-- Target: "What is...", "How do I...", "Where can I find...", "Why does...", "When should I...?" -->


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten section headers in `.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md` by removing redundant `Block`/`Pattern` suffix and tightening intro prose.

## Issue
Closes #16670

## Files Changed
- `.agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md` — 7 header/prose changes, zero content loss

## Classification
Reference corpus (template library). File is already appropriately sized at 65 lines. Applied targeted prose tightening only:
- `"Use these for..."` → `"Templates for..."` (more direct)
- `"Definition Block"` → `"Definition"` (redundant suffix removed)
- `"Step-by-Step Block"` → `"Step-by-Step"`
- `"Pros/Cons Block"` → `"Pros/Cons"`
- `"FAQ Block"` → `"FAQ"`
- `"Listicle Block"` → `"Listicle"`
- `"Voice Search Pattern"` → `"Voice Search"`

## Testing
- All 6 template code blocks preserved verbatim
- All inline comments preserved
- All template placeholder text preserved
- No URLs, task IDs, or command examples in this file — N/A
- `wc -l`: 65 lines before and after (same count, cleaner headers)

## Runtime Testing
**Risk level**: Low (docs/agent prompts — no runtime behaviour change)
**Verification**: `self-assessed` — template content unchanged, headers are cosmetic

---
[aidevops.sh](https://aidevops.sh) v3.5.869 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6