### PR TITLE
GH#16672: tighten cro-chapter-23.md SaaS CRO Optimization

### DIFF
--- a/.agents/marketing-sales/cro-chapter-23.md
+++ b/.agents/marketing-sales/cro-chapter-23.md
@@ -26,29 +26,16 @@
 
 ## 23.2 Pricing Page Optimization
 
-### Core structure
-
 - Plan structure: 3-4 plans max; clear differentiation; recommended plan highlighted; annual discount visible
-
-### Pricing psychology
-
-- Decoy pricing — middle plan most popular
-- Anchoring — enterprise price makes other plans look reasonable
-- Charm pricing — $99 vs $100
-- Free trial emphasis
-
-### Interactive pricing tools
-
-- Calculators — ROI, savings estimators, cost comparison
-- Sliders — usage-based pricing, team size, feature toggles
+- Decoy pricing — middle plan most popular; anchoring — enterprise price makes others look reasonable
+- Charm pricing — $99 vs $100; free trial emphasis
+- Calculators — ROI, savings estimators, cost comparison; sliders — usage-based pricing, team size, feature toggles
 
 ## 23.3 Product-Led Growth CRO
 
 - Self-serve onboarding: no sales required; immediate value delivery; in-app education; viral sharing mechanisms
 - Viral loops: team invites, shareable content, public profiles, social proof
 - Freemium optimization: clear upgrade triggers; feature limitations; usage quotas; watermarks/removal
-
-**In-app conversion:**
 
 | Tactic | Examples |
 |--------|---------|


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/marketing-sales/cro-chapter-23.md` (SaaS CRO Optimization) per simplification issue #16672.

## Changes
- Removed redundant `### Core structure` subsection header (single-bullet section merged into parent `## 23.2`)
- Removed redundant `### Pricing psychology` and `### Interactive pricing tools` subsection headers — content consolidated into flat bullet list under `## 23.2`
- Removed decorative `**In-app conversion:**` bold label before table in `## 23.3` (table is self-explanatory)
- All knowledge preserved: trial design constraints, onboarding milestones, trial length table, pricing psychology tactics, interactive tools, PLG tactics, B2B specifics table

## Classification
Reference corpus (domain knowledge base). Per GH#6432: restructure, do not compress. At 65 lines the file was already compact — tightening removed structural noise only.

## Files Changed
- `.agents/marketing-sales/cro-chapter-23.md`: 65 → 52 lines (-20%)

## Testing
- Self-assessed (Low risk: docs/formatting only)
- All content verified present before and after: trial design, onboarding milestones, pricing psychology, interactive tools, PLG tactics, B2B specifics
- No code blocks, URLs, task IDs, or GH refs in file — nothing to break

## Runtime Testing
`self-assessed` — documentation-only change, no executable code.

Closes #16672

---
[aidevops.sh](https://aidevops.sh) v3.5.869 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6