### PR TITLE
GH#16673: tighten platform-mapping.md nothing-design-skill

### DIFF
--- a/.agents/tools/ui/nothing-design-skill/platform-mapping.md
+++ b/.agents/tools/ui/nothing-design-skill/platform-mapping.md
@@ -1,6 +1,6 @@
 # Nothing Design System — Platform Mapping
 
-## 1. HTML / CSS / WEB
+## HTML / CSS / WEB
 
 Load fonts via Google Fonts `<link>` or `@import`. Use CSS custom properties, `rem` for type, `px` for spacing/borders. Dark/light via `prefers-color-scheme` or class toggle.
 
@@ -31,11 +31,9 @@ Load fonts via Google Fonts `<link>` or `@import`. Use CSS custom properties, `r
 }
 ```
 
----
+## SWIFTUI / iOS
 
-## 2. SWIFTUI / iOS
-
-Register fonts in Info.plist, bundle `.ttf` files. Use `@Environment(\.colorScheme)` for mode switching.
+Register fonts in Info.plist, bundle `.ttf` files. Use `@Environment(\.colorScheme)` for mode switching. Light mode values: tokens.md Dark/Light table. Font extension: `.custom("Doto"/"SpaceGrotesk-Regular"/"SpaceMono-Regular", size:)`.
 
 ```swift
 extension Color {
@@ -55,10 +53,6 @@ extension Color {
 }
 ```
 
-Light mode values in tokens.md Dark/Light table. Derive Font extension from font stack table (trivial: `.custom("Doto"/"SpaceGrotesk-Regular"/"SpaceMono-Regular", size:)`).
-
----
-
-## 3. PAPER (DESIGN TOOL)
+## PAPER (DESIGN TOOL)
 
 Use `get_font_family_info` to verify fonts before writing styles. Direct hex values (no CSS variables). Dark mode as default canvas, light mode as separate artboard.


### PR DESCRIPTION
## Summary

- Remove decorative section numbering (`## 1.`, `## 2.`, `## 3.`) — headings are self-identifying
- Remove decorative `---` horizontal rules between sections — headings already provide visual separation
- Consolidate SwiftUI post-code note into prose intro (moved from after code block to before it)
- 64 → 58 lines; all code blocks, hex values, and technical content preserved

## Classification

Reference corpus (platform-specific code snippets). Not an instruction doc. No content compression applied — only structural noise removed.

## Verification

- All CSS custom properties present: ✓
- All SwiftUI Color extensions present: ✓
- Font/light-mode reference preserved (moved inline): ✓
- Paper design tool instructions preserved: ✓
- No broken references: ✓

## Runtime Testing

**Risk: Low** — docs-only change, no executable code modified. Self-assessed.

Closes #16673

---
[aidevops.sh](https://aidevops.sh) v3.5.869 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6