### PR TITLE
GH#16671: tighten agent doc Docs Probes (.agents/reference/define-probes/docs.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -62,7 +62,7 @@
     "issue": "GH#16443",
     "lines_after": 111,
     "lines_before": 113,
-    "note": "Pass 2: 113→111 lines. Merged templates link into intro line, moved subject line guidance above table as compact note. Zero content loss.",
+    "note": "Pass 2: 113\u2192111 lines. Merged templates link into intro line, moved subject line guidance above table as compact note. Zero content loss.",
     "passes": 2,
     "status": "simplified"
   },
@@ -164,7 +164,7 @@
     "hash": "d99fc5b67969194e84d7952de9bfa655d26d6d4e9e84b2fcf0ef5790cf413af6",
     "issue": "GH#16497",
     "lines": 67,
-    "note": "tightened: merged Linux Setup into Quick Reference, consolidated When to Use paragraphs (79→67 lines)",
+    "note": "tightened: merged Linux Setup into Quick Reference, consolidated When to Use paragraphs (79\u219267 lines)",
     "status": "simplified"
   },
   ".agents/tools/programming/modern-javascript-skill/immutability.md": {
@@ -1042,7 +1042,7 @@
       "at": "2026-04-02T21:19:54Z",
       "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
       "issue": "GH#14286",
-      "note": "Reference corpus chapter tightened: 92 → 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
+      "note": "Reference corpus chapter tightened: 92 \u2192 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
       "passes": 2
     },
     ".agents/marketing-sales/cro-chapter-20.md": {
@@ -5746,5 +5746,11 @@
       "pr": 16542,
       "passes": 1
     }
+  },
+  ".agents/reference/define-probes/docs.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "42730e6d8c7fb235e7594467232c9ab9d4f69db6e66316c6d6e073ad6d3838f9",
+    "issue": "GH#16671",
+    "status": "simplified"
   }
 }

--- a/.agents/reference/define-probes/docs.md
+++ b/.agents/reference/define-probes/docs.md
@@ -5,9 +5,9 @@ mode: subagent
 
 # Docs Probes
 
-Use for `/define` tasks classified as **docs**: ask the 2 questions below, then select 2 probes.
+Use for `/define` tasks classified as **docs**: ask the 2 required questions, then select 2 probes.
 
-## Default Assumptions
+## Defaults
 
 - Follow existing documentation patterns and style in the project
 - Accurate and verifiable — no speculative claims


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/reference/define-probes/docs.md` (instruction doc for `/define` docs tasks).

## Changes
- Rename `## Default Assumptions` → `## Defaults` (shorter header, same meaning)
- Clarify intro line: "ask the 2 required questions" (was "ask the 2 questions below")
- Update `.agents/configs/simplification-state.json` with file hash for GH#16671

## Issue
Closes #16671

## Files Changed
- `.agents/reference/define-probes/docs.md` — 2 prose tightenings, line count unchanged (65)
- `.agents/configs/simplification-state.json` — hash entry added for this file

## Testing
**Risk level:** Low (docs/agent prompt, no code logic)
**Verification:** Self-assessed — content preservation verified by diff review. All code blocks, URLs, task IDs, and command examples (`/define`) present before and after. Agent behavior unchanged.

## Runtime Testing
`self-assessed` — Low risk: agent prompt doc, no runnable code, no behavioral change.

## Key Decisions
- File classified as **instruction doc** (not reference corpus) — tighten prose, not split into chapters
- Minimal changes only: file was already well-structured at 65 lines; only 2 prose improvements applied
- No content removed; all institutional knowledge preserved

---
[aidevops.sh](https://aidevops.sh) v3.5.869 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6