### PR TITLE
GH#16675: tighten release branch doc

### DIFF
--- a/.agents/workflows/branch/release.md
+++ b/.agents/workflows/branch/release.md
@@ -10,8 +10,6 @@ tools:
 
 # Release Branch
 
-<!-- AI-CONTEXT-START -->
-
 | Aspect | Value |
 |--------|-------|
 | **Prefix** | `release/` |
@@ -25,16 +23,14 @@ git checkout main && git pull origin main
 git checkout -b release/1.2.0
 ```
 
-<!-- AI-CONTEXT-END -->
-
 ## When to Create
 
-| Scenario | Branch | Bump | vs Hotfix |
-|----------|--------|------|-----------|
-| Bug fixes accumulated | `release/X.Y.Z` | Patch | Planned; full test cycle |
-| New features ready | `release/X.Y.0` | Minor | Planned; full test cycle |
-| Breaking changes | `release/X+1.0.0` | Major | Planned; full test cycle |
-| Urgent critical fix | Use `hotfix/` | — | Urgent; minimal testing |
+| Scenario | Bump | Note |
+|----------|------|------|
+| Bug fixes accumulated | Patch | Planned; full test cycle |
+| New features ready | Minor | Planned; full test cycle |
+| Breaking changes | Major | Planned; full test cycle |
+| Urgent critical fix | — | Use `hotfix/` instead |
 
 ## Release Lifecycle
 
@@ -46,7 +42,7 @@ version-manager.sh bump {patch|minor|major}
 # 2. Run final checks
 linters-local.sh
 
-# 3. PR to main, merge, then tag and publish
+# 3. PR to main, merge, tag and publish
 git checkout main && git pull
 git tag -a v{VERSION} -m "Release v{VERSION}"
 git push origin v{VERSION}


### PR DESCRIPTION
## Summary

- Remove `AI-CONTEXT` wrapper (unnecessary in a subagent doc — it's already loaded directly)
- Simplify "When to Create" table: drop redundant `Branch` and `vs Hotfix` columns
- Tighten prose in lifecycle step 3 comment
- All commands, references, task IDs, and institutional knowledge preserved
- 63 → 59 lines

## What

Tighten `.agents/workflows/branch/release.md` per simplification-debt scan (GH#16675).

## Testing

- `markdownlint-cli2`: 0 errors
- Content preservation verified: all code blocks, commands (`version-manager.sh`, `linters-local.sh`, `gh release create`), and related-doc links present before and after
- Agent behaviour unchanged — no rules or decision logic removed

## Runtime Testing

Risk: **Low** (docs/agent prompt only — no code, no scripts, no runtime behaviour)
Verification: `self-assessed`

Closes #16675

---
[aidevops.sh](https://aidevops.sh) v3.5.876 plugin for [Claude Code](https://claude.ai/code) spent 5m on this as a headless worker.