### PR TITLE
GH#16677: tighten buzz.md agent doc (63→47 lines)

### DIFF
--- a/.agents/tools/voice/buzz.md
+++ b/.agents/tools/voice/buzz.md
@@ -11,7 +11,7 @@ tools:
 # Buzz - Offline Transcription
 
 <!-- AI-CONTEXT-START -->
-Local audio/video transcription with Whisper-family models; no cloud API required. Use for privacy-sensitive transcription, subtitle export, offline batch work. For provider comparison and cloud options, see `tools/voice/transcription.md`. Repo: https://github.com/chidiwilliams/buzz (Python, MIT). Backends: Whisper, `faster-whisper`, `whisper.cpp`.
+Local audio/video transcription with Whisper-family models; no cloud API required. Use for privacy-sensitive transcription, subtitle export, offline batch work. Input: MP3, WAV, FLAC, OGG, M4A, WMA, MP4, MKV, AVI, MOV, WebM. Output: TXT, SRT, VTT, JSON. 100+ languages. Speaker diarization supported. Repo: https://github.com/chidiwilliams/buzz (Python, MIT). Backends: Whisper, `faster-whisper`, `whisper.cpp`. For cloud options, see `tools/voice/transcription.md`.
 <!-- AI-CONTEXT-END -->
 
 ## Install
@@ -21,43 +21,27 @@ brew install --cask buzz          # macOS GUI
 pip install buzz-captions         # CLI
 ```
 
-## Capabilities
-
-- **Input**: MP3, WAV, FLAC, OGG, M4A, WMA, MP4, MKV, AVI, MOV, WebM
-- **Output**: TXT, SRT, VTT, JSON
-- **Languages**: 100+ via Whisper language support
-- **Extras**: Speaker diarization, subtitle export, automatic audio extraction from video
-
 ## CLI
 
 ```bash
-# Transcribe to text
 buzz transcribe meeting.mp4 --model medium --output-format txt > notes.txt
-
-# Generate subtitles
 buzz transcribe video.mp4 --model large-v3 --output-format srt > subtitles.srt
-
-# Translate foreign audio
 buzz transcribe foreign-audio.mp3 --task translate --language auto
-
-# Batch
-for f in recordings/*.mp3; do
-  buzz transcribe "$f" --model medium --output-format txt > "${f%.mp3}.txt"
-done
+for f in recordings/*.mp3; do buzz transcribe "$f" --model medium --output-format txt > "${f%.mp3}.txt"; done
 ```
 
-## Model and backend choices
+## Models
 
 | Option | Best for | Trade-off |
 |--------|----------|-----------|
 | `tiny` / `base` (39–74MB) | Quick drafts | Lower accuracy |
-| `medium` (769MB) | Default choice | Slower than small models |
-| `large-v3` (1.5GB) | Accuracy-critical transcripts | Highest VRAM (10GB) and latency |
-| `faster-whisper` | Faster, lower-memory runs | Different backend/runtime |
-| `whisper.cpp` | CPU-first local use | Fewer ecosystem conveniences |
+| `medium` (769MB) | Default | Slower than small |
+| `large-v3` (1.5GB) | Accuracy-critical | 10GB VRAM, high latency |
+| `faster-whisper` | Speed + low memory | Different runtime |
+| `whisper.cpp` | CPU-first | Fewer conveniences |
 
 ## Related
 
-- `tools/voice/transcription.md` - local vs cloud transcription options
+- `tools/voice/transcription.md` - local vs cloud options
 - `tools/voice/speech-to-speech.md` - real-time speech pipeline
-- `tools/video/remotion.md` - video workflows that consume transcripts
+- `tools/video/remotion.md` - video workflows consuming transcripts

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.882"
+    "version": "3.5.883"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.882
+# Version: 3.5.883
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,8 +5,8 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.882.tar.gz"
-  sha256 "a04cfc74c44d39ac8d765ab847145a8e891cd5929de2f451ad577be3e5fb52f5"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.883.tar.gz"
+  sha256 "6bc0fc634f00f237fdc3abcf392061b53f89db3d0e278d803e58c6778e9387e6"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.882",
+  "version": "3.5.883",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.882
+# Version: 3.5.883
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.882
+sonar.projectVersion=3.5.883
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/voice/buzz.md` from 63 to 47 lines (25% reduction) per simplification scan GH#16677.

## Changes
- Merged `## Capabilities` section into `<!-- AI-CONTEXT-START -->` block — capabilities are context, not instructions
- Removed redundant inline CLI comments (commands are self-documenting)
- Collapsed multi-line batch loop to single line
- Tightened model table descriptions (no information loss)
- Tightened Related section link descriptions

## Issue
Closes #16677

## Files Changed
- `.agents/tools/voice/buzz.md`: 63→47 lines, 9 insertions, 25 deletions

## Testing
- All code blocks, URLs, task ID references, and command examples verified present before and after
- Agent behaviour unchanged — all capabilities, model choices, and CLI patterns preserved
- Risk: **Low** (docs-only change, no executable logic)

## Runtime Testing
`self-assessed` — docs-only change, no runtime required.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized voice transcription documentation with inlined capabilities details for improved clarity.
  * Simplified CLI examples by removing unnecessary comments and condensing code snippets.
  * Refined section descriptions and updated terminology for better readability.
  * Enhanced wording consistency throughout for more concise content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->