### PR TITLE
GH#16697: tighten autoagent.md prose (233→225 lines)

### DIFF
--- a/.agents/tools/autoagent/autoagent.md
+++ b/.agents/tools/autoagent/autoagent.md
@@ -27,7 +27,7 @@ Arguments: `--program <path>` (required)
 - **Results file**: `todo/research/{name}-results.tsv`
 - **Worktree**: `experiment/{name}` (created at session start)
 - **State**: git HEAD of experiment branch = current best; results.tsv = full history
-- **Resume**: re-run with same `--program` — reads results.tsv to reconstruct state
+- **Resume**: re-run with same `--program` — reads results.tsv to reconstruct state; uncommitted changes discarded via `git reset --hard HEAD`
 - **Memory**: `aidevops-memory` — cross-session finding persistence
 - **Metric command**: `autoagent-metric-helper.sh` — composite score for framework quality
 - **Sub-docs**: `autoagent/signal-mining.md` · `autoagent/hypothesis-types.md` · `autoagent/safety.md` · `autoagent/evaluation.md`
@@ -91,17 +91,15 @@ else:
 
 **1.4 Recall cross-session memory:** `aidevops-memory recall "autoagent $PROGRAM_NAME" --limit 10` → store as MEMORY_CONTEXT.
 
-**1.5 Mine signals from enabled sources:** Load `autoagent/signal-mining.md`. Run signal extraction for each source in `SIGNAL_SOURCES`. Store as `SIGNAL_FINDINGS` — list of `{file, issue, source}` objects.
+**1.5 Mine signals:** Load `autoagent/signal-mining.md`. Run signal extraction for each source in `SIGNAL_SOURCES`. Store as `SIGNAL_FINDINGS` — list of `{file, issue, source}` objects.
 
-**1.6 Load safety constraints:** Load `autoagent/safety.md`. Apply `SAFETY_LEVEL` to determine which files are modifiable and which require elevated approval.
+**1.6 Load safety constraints:** Load `autoagent/safety.md`. Apply `SAFETY_LEVEL` to determine modifiable files and elevated-approval requirements.
 
 **1.7 Measure baseline (first run only):** If `BASELINE == null`: run all constraints (fail → exit); run METRIC_CMD → `BASELINE = BEST_METRIC`; update program file `baseline: {value}`; append baseline row to results.tsv.
 
 ## Step 2: Experiment Loop
 
-See `autoagent/hypothesis-types.md` for the 6 hypothesis types, progression strategy, and overfitting test.
-
-See `autoagent/evaluation.md` for multi-trial evaluation pseudocode, trajectory recording, and failure analysis.
+See `autoagent/hypothesis-types.md` (6 hypothesis types, progression, overfitting test) and `autoagent/evaluation.md` (multi-trial pseudocode, trajectory recording, failure analysis).
 
 Loop exits when any budget condition is met (timeout / max_iterations / goal_reached).
 
@@ -221,12 +219,6 @@ aidevops-memory store \
   "autoagent {PROGRAM_NAME} PR created: {pr_url}. Best: {METRIC_NAME}={BEST_METRIC}. Key finding: {top_hypothesis}" \
   --confidence high
 ```
-
-## Crash Recovery
-
-Worktree, results.tsv, and branch HEAD persist across crashes. On resume, uncommitted changes are discarded via `git reset --hard HEAD`.
-
-Resume: re-run `/autoagent --program {program_path}`. The subagent detects the existing worktree and results.tsv and continues from where it left off.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/autoagent/autoagent.md` from 233 to 225 lines per the simplification scan in GH#16697.

**Changes:**
- Merged standalone "Crash Recovery" section into Quick Reference `Resume` bullet (content preserved, section eliminated)
- Combined two separate sub-doc reference sentences in Step 2 into one line
- Tightened step 1.5 header: "Mine signals from enabled sources" → "Mine signals"
- Tightened step 1.6 body: "determine which files are modifiable and which require elevated approval" → "determine modifiable files and elevated-approval requirements"

**Verification:**
- All code blocks, task IDs, command examples, and decision rationale present before and after
- No broken internal links or references
- Agent behaviour unchanged — all procedural steps intact, sub-doc pointers preserved
- Line count: 233 → 225 (−8 lines, −3.4%)

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no executable code changed. `self-assessed`.

Closes #16697

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6