### PR TITLE
GH#16677: tighten buzz.md agent doc (63→47 lines)

### DIFF
--- a/.agents/tools/voice/buzz.md
+++ b/.agents/tools/voice/buzz.md
@@ -11,7 +11,7 @@ tools:
 # Buzz - Offline Transcription
 
 <!-- AI-CONTEXT-START -->
-Local audio/video transcription with Whisper-family models; no cloud API required. Use for privacy-sensitive transcription, subtitle export, offline batch work. For provider comparison and cloud options, see `tools/voice/transcription.md`. Repo: https://github.com/chidiwilliams/buzz (Python, MIT). Backends: Whisper, `faster-whisper`, `whisper.cpp`.
+Local audio/video transcription with Whisper-family models; no cloud API required. Use for privacy-sensitive transcription, subtitle export, offline batch work. Input: MP3, WAV, FLAC, OGG, M4A, WMA, MP4, MKV, AVI, MOV, WebM. Output: TXT, SRT, VTT, JSON. 100+ languages. Speaker diarization supported. Repo: https://github.com/chidiwilliams/buzz (Python, MIT). Backends: Whisper, `faster-whisper`, `whisper.cpp`. For cloud options, see `tools/voice/transcription.md`.
 <!-- AI-CONTEXT-END -->
 
 ## Install
@@ -21,43 +21,27 @@ brew install --cask buzz          # macOS GUI
 pip install buzz-captions         # CLI
 ```
 
-## Capabilities
-
-- **Input**: MP3, WAV, FLAC, OGG, M4A, WMA, MP4, MKV, AVI, MOV, WebM
-- **Output**: TXT, SRT, VTT, JSON
-- **Languages**: 100+ via Whisper language support
-- **Extras**: Speaker diarization, subtitle export, automatic audio extraction from video
-
 ## CLI
 
 ```bash
-# Transcribe to text
 buzz transcribe meeting.mp4 --model medium --output-format txt > notes.txt
-
-# Generate subtitles
 buzz transcribe video.mp4 --model large-v3 --output-format srt > subtitles.srt
-
-# Translate foreign audio
 buzz transcribe foreign-audio.mp3 --task translate --language auto
-
-# Batch
-for f in recordings/*.mp3; do
-  buzz transcribe "$f" --model medium --output-format txt > "${f%.mp3}.txt"
-done
+for f in recordings/*.mp3; do buzz transcribe "$f" --model medium --output-format txt > "${f%.mp3}.txt"; done
 ```
 
-## Model and backend choices
+## Models
 
 | Option | Best for | Trade-off |
 |--------|----------|-----------|
 | `tiny` / `base` (39–74MB) | Quick drafts | Lower accuracy |
-| `medium` (769MB) | Default choice | Slower than small models |
-| `large-v3` (1.5GB) | Accuracy-critical transcripts | Highest VRAM (10GB) and latency |
-| `faster-whisper` | Faster, lower-memory runs | Different backend/runtime |
-| `whisper.cpp` | CPU-first local use | Fewer ecosystem conveniences |
+| `medium` (769MB) | Default | Slower than small |
+| `large-v3` (1.5GB) | Accuracy-critical | 10GB VRAM, high latency |
+| `faster-whisper` | Speed + low memory | Different runtime |
+| `whisper.cpp` | CPU-first | Fewer conveniences |
 
 ## Related
 
-- `tools/voice/transcription.md` - local vs cloud transcription options
+- `tools/voice/transcription.md` - local vs cloud options
 - `tools/voice/speech-to-speech.md` - real-time speech pipeline
-- `tools/video/remotion.md` - video workflows that consume transcripts
+- `tools/video/remotion.md` - video workflows consuming transcripts


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/voice/buzz.md` from 63 to 47 lines (25% reduction) per GH#16677 simplification scan.

Closes #16677

## What

- Merged `Capabilities` section into `AI-CONTEXT-START` block (all key facts preserved: input formats, output formats, language count, diarization support)
- Removed redundant inline comments from CLI examples (self-evident from commands)
- Condensed batch loop to single line
- Shortened model table prose (same information, fewer words)
- Renamed `Model and backend choices` → `Models` (shorter, equally clear)
- Tightened Related section link descriptions

## Testing

**Risk level:** Low — docs/agent prompt only, no code changes.

**Runtime Testing:** `self-assessed` — instruction doc, no executable logic. All code blocks, URLs, task ID references, and command examples verified present before and after. Agent behaviour unchanged.

**Content preservation check:**
- All CLI commands: ✓
- All model options with sizes: ✓
- All input/output formats: ✓
- All Related links: ✓
- Repo URL: ✓
- Backend list: ✓

## Files Changed

- `.agents/tools/voice/buzz.md` — 63 → 47 lines

---
<!-- MERGE_SUMMARY -->
**What:** Tighten buzz.md agent doc per simplification scan (GH#16677)
**Issue:** #16677
**Files changed:** 1 (`.agents/tools/voice/buzz.md`)
**Testing:** Self-assessed (docs-only, low risk)
**Key decisions:** Capabilities section merged into AI-CONTEXT-START block to preserve all facts while eliminating redundant section header and bullet formatting

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Buzz voice transcription tool documentation with explicit support for 100+ languages, audio formats (MP3, WAV, FLAC, OGG, M4A, WMA, MP4, MKV, AVI, MOV, WebM), output formats (TXT, SRT, VTT, JSON), and diarization capabilities. Simplified CLI examples and reorganized model/backend documentation.

* **Chores**
  * Released version 3.5.883.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->