### PR TITLE
GH#16709: tighten email-health-check.md (63→57 lines)

### DIFF
--- a/.agents/scripts/commands/email-health-check.md
+++ b/.agents/scripts/commands/email-health-check.md
@@ -4,10 +4,6 @@ agent: Build+
 mode: subagent
 ---
 
-Check email authentication, deliverability, and content quality.
-
-Arguments: `$ARGUMENTS`
-
 ## Workflow
 
 Select and run the helper based on arguments:
@@ -37,21 +33,19 @@ Format the report from helper output:
 | `/email-health-check newsletter.html check-subject` | Subject line check only |
 | `/email-health-check accessibility newsletter.html` | Email accessibility audit |
 
-## Example
+## Example output (`/email-health-check example.com`)
 
 ```text
-User: /email-health-check example.com
-AI:
-    Email Health Check: example.com
-    SPF: OK - v=spf1 include:_spf.google.com ~all
-    DKIM: OK - Found: google, selector1
-    DMARC: WARN - p=none (monitoring only)
-    MX: OK - 2 records (redundant)
-    Blacklist: OK - Not listed
-    Score: 12/15 (80%) - Grade: B
-    Recommendations:
-    1. Upgrade DMARC policy from p=none to p=quarantine
-    2. Consider adding rua= for DMARC reports
+Email Health Check: example.com
+SPF: OK - v=spf1 include:_spf.google.com ~all
+DKIM: OK - Found: google, selector1
+DMARC: WARN - p=none (monitoring only)
+MX: OK - 2 records (redundant)
+Blacklist: OK - Not listed
+Score: 12/15 (80%) - Grade: B
+Recommendations:
+1. Upgrade DMARC policy from p=none to p=quarantine
+2. Consider adding rua= for DMARC reports
 ```
 
 ## Related


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/scripts/commands/email-health-check.md` from 63 to 57 lines per automated simplification scan (GH#16709).

## Changes
- Removed redundant intro sentence (duplicates frontmatter `description` field)
- Removed boilerplate `Arguments: $ARGUMENTS` line (not needed in command docs)
- Removed verbose `User:/AI:` wrapper in Example section; example output now shown directly under a descriptive heading

## Preservation
All institutional knowledge retained: helper command routing, scoring rubrics (15/10/25 point scales), all 8 option variants, full example output, and all 5 related links.

## Testing
- `self-assessed` (Low risk: docs-only change, no code or behaviour change)
- File renders correctly; all code blocks, task IDs, and command examples present before and after

## Files changed
- `.agents/scripts/commands/email-health-check.md` (63→57 lines, -10%)

Closes #16709

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6