### PR TITLE
GH#16710: tighten terraform.md (62→50 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5752,5 +5752,11 @@
     "hash": "42730e6d8c7fb235e7594467232c9ab9d4f69db6e66316c6d6e073ad6d3838f9",
     "issue": "GH#16671",
     "status": "simplified"
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/terraform.md": {
+    "hash": "b3b7cc3348760d9cb54eac8897a109fb8868c05f3e5088ba71ad29172d8b6c27",
+    "lines": 50,
+    "status": "simplified",
+    "issue": "GH#16710"
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/terraform.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/terraform.md
@@ -32,18 +32,6 @@ provider "cloudflare" {
 2. **Global API Key** (legacy): `api_key` + `api_email` / `CLOUDFLARE_API_KEY` + `CLOUDFLARE_EMAIL` — less secure
 3. **User Service Key**: `user_service_key` — Origin CA certificates only
 
-### Remote State Backend
-
-```hcl
-terraform {
-  backend "s3" {
-    bucket = "terraform-state"
-    key    = "cloudflare/terraform.tfstate"
-    region = "us-east-1"
-  }
-}
-```
-
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/terraform.md` per GH#16710 simplification scan.

**Change:** Remove duplicated Remote State Backend HCL block (lines 35-45 in original). This block is already fully covered in `terraform-gotchas.md` Best Practice #6 (with locking, encryption, and DynamoDB). Keeping it in the entry point created maintenance drift risk.

**Result:** 62 → 50 lines. All unique knowledge preserved. No broken references.

## Issue
Closes #16710

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/terraform.md` — removed duplicated Remote State Backend block
- `.agents/configs/simplification-state.json` — updated hash registry

## Testing
- `self-assessed` (Low risk: docs-only change, no code paths affected)
- Content preservation verified: all code blocks, URLs, auth priority list, commands, and See Also links present before and after
- No broken internal references (companion files `terraform-gotchas.md` and `terraform-patterns.md` unchanged)

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — tighten prose, don't split into chapters
- Removed only the duplicated block; kept all unique content (Core Principles, Provider Setup, Auth priority, Common Commands, See Also)
- Remote state backend detail belongs in `terraform-gotchas.md` Best Practice #6 where it already lives with full context (locking, encryption)

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6