### PR TITLE
GH#16712: tighten Crawl4AI benchmark scripts doc

### DIFF
--- a/.agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md
+++ b/.agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md
@@ -1,6 +1,6 @@
 # Crawl4AI Benchmark Scripts
 
-Reference implementation for `browser-benchmark-scripts.md`. Target: `https://the-internet.herokuapp.com`. Tests: `navigate`, `extract` only (no form/multi-step) — 3 runs each.
+Crawl4AI benchmark scripts. Target: `https://the-internet.herokuapp.com`. Tests: `navigate`, `extract` only (no form/multi-step) — 3 runs each. See [`browser-benchmark-scripts.md`](browser-benchmark-scripts.md) for the full suite index.
 
 ## Sequential benchmark
 
@@ -37,7 +37,7 @@ async def run():
 asyncio.run(run())
 ```
 
-## Parallel benchmark — sequential vs parallel
+## Parallel benchmark
 
 ```python
 import asyncio, time


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md` per simplification scan (GH#16712).

## Changes
- Replace vague "Reference implementation for..." intro with descriptive text matching sibling file pattern
- Add relative link to parent index `browser-benchmark-scripts.md` (consistent with `browser-benchmark-scripts-01-playwright.md`)
- Remove redundant "sequential vs parallel" from "Parallel benchmark" section header

## Issue
Closes #16712

## Files changed
- `.agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md` (2 lines changed, 61 total preserved)

## Testing
- All code blocks preserved verbatim (verified by diff)
- All URLs preserved
- No task ID refs or command examples in this file — N/A
- Content: zero knowledge loss (only prose/header tightening)

## Runtime Testing
Risk: **Low** — docs-only change, no executable code modified.
Assessment: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13