### PR TITLE
GH#16715: tighten remotion-get-video-dimensions.md (60→47 lines)

### DIFF
--- a/.agents/tools/video/remotion-get-video-dimensions.md
+++ b/.agents/tools/video/remotion-get-video-dimensions.md
@@ -16,28 +16,20 @@ import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
 export const getVideoDimensions = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src, { getRetryDelay: () => null }),
   });
-
   const videoTrack = await input.getPrimaryVideoTrack();
-  if (!videoTrack) {
-    throw new Error("No video track found");
-  }
-
-  return {
-    width: videoTrack.displayWidth,
-    height: videoTrack.displayHeight,
-  };
+  if (!videoTrack) throw new Error("No video track found");
+  return { width: videoTrack.displayWidth, height: videoTrack.displayHeight };
 };
+```
 
-// Usage
-const dimensions = await getVideoDimensions("https://remotion.media/video.mp4");
-console.log(dimensions.width);  // e.g. 1920
-console.log(dimensions.height); // e.g. 1080
+URL or `staticFile`:
 
-// With staticFile in Remotion
+```tsx
+const { width, height } = await getVideoDimensions("https://remotion.media/video.mp4");
+// width: 1920, height: 1080
+
 import { staticFile } from "remotion";
 const dims = await getVideoDimensions(staticFile("video.mp4"));
 ```
@@ -49,12 +41,7 @@ Use `FileSource` instead of `UrlSource` for `File` objects (input or drag-drop):
 ```tsx
 import { Input, ALL_FORMATS, FileSource } from "mediabunny";
 
-const input = new Input({
-  formats: ALL_FORMATS,
-  source: new FileSource(file),
-});
-
+const input = new Input({ formats: ALL_FORMATS, source: new FileSource(file) });
 const videoTrack = await input.getPrimaryVideoTrack();
-const width = videoTrack.displayWidth;
-const height = videoTrack.displayHeight;
+const { displayWidth: width, displayHeight: height } = videoTrack;
 ```


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/video/remotion-get-video-dimensions.md` per GH#16715 simplification scan.

**60 → 47 lines (22% reduction)**

### Changes

- Inline `UrlSource` options onto one line (no semantic change)
- Collapse `return` statement to single line
- Split usage examples into a separate code block with a prose label (`URL or \`staticFile\`:`)
- Use destructuring in local-files example for brevity
- Remove `// Usage` and `// With staticFile in Remotion` inline comments (replaced by prose)

### Preservation check

- All imports preserved
- `getVideoDimensions` function logic unchanged (error guard intact)
- Both URL and `staticFile` usage examples present
- `FileSource` local-files example present
- No task IDs, issue refs, or command examples in original — nothing to preserve

### Runtime Testing

Risk: **Low** — docs/agent prompt only, no executable code changed.
Self-assessed: content verified line-by-line against original.

Closes #16715

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13