### PR TITLE
GH#16713: mark ranking-opportunities.md as converged (pass 2, 61 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,4 +1,15 @@
 {
+  ".agents/seo/ranking-opportunities.md": {
+    "at": "2026-04-03T00:00:00Z",
+    "hash": "eb967c184a79c17e51d3eaea892f52fd50faf124aac7161e3aa9fef581237a57",
+    "issue": "GH#16713",
+    "lines_after": 61,
+    "lines_before": 61,
+    "note": "Pass 2: instruction doc at minimum viable size. Previously tightened 82→61 lines (GH#15698, PR#16081). All sections necessary: YAML frontmatter, workflow steps, analysis types table, TOON output format. No further compression possible without content loss.",
+    "passes": 2,
+    "pr": "pending",
+    "status": "simplified"
+  },
   ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md": {
     "at": "2026-04-03T00:00:00Z",
     "hash": "b67f8c428d9457f76f2e6227baaaa46768eccf9604fd1e71ee17c9b002831039",


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Mark `.agents/seo/ranking-opportunities.md` as converged in simplification-state.json (pass 2).

## Issue
Closes #16713

## Analysis
The file was previously tightened from 82→61 lines in GH#15698 (PR #16081). This automated scan re-flagged it at 61 lines.

**Classification: instruction doc** — not a reference corpus. All sections are necessary:
- YAML frontmatter (11 lines) — required for agent tooling
- AI-CONTEXT block (4 lines) — quick reference commands
- Workflow section (8 lines) — 5-step operational procedure
- Analysis Types table (7 lines) — 4 analysis types with criteria/actions/scoring
- Output Format TOON example (21 lines) — concrete format reference

No further compression is possible without content loss. File is at minimum viable size.

## Files Changed
- `.agents/configs/simplification-state.json` — added pass 2 entry for ranking-opportunities.md

## Testing
- `self-assessed` (Low risk: docs/config only)
- Content preservation verified: all code blocks, commands, task ID refs present
- No broken references

## Runtime Testing
**Risk level: Low** — documentation and config file only. No executable code changed.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6