### PR TITLE
GH#14459: output UPDATE_AVAILABLE to stdout and add auto-update awareness

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -228,6 +228,21 @@ _build_output_line() {
 }
 
 # -----------------------------------------------------------------------------
+# _is_auto_update_active: check if the auto-update scheduler is running.
+# Returns 0 if launchd (macOS) or cron (Linux) auto-update job is active.
+# -----------------------------------------------------------------------------
+_is_auto_update_active() {
+	local launchd_label="com.aidevops.aidevops-auto-update"
+	if launchctl list "$launchd_label" &>/dev/null; then
+		return 0
+	fi
+	if crontab -l 2>/dev/null | grep -q 'aidevops-auto-update'; then
+		return 0
+	fi
+	return 1
+}
+
+# -----------------------------------------------------------------------------
 # _get_runtime_hint: emit a runtime config hint for the AI model, if known.
 # -----------------------------------------------------------------------------
 _get_runtime_hint() {
@@ -447,6 +462,12 @@ main() {
 	# Build version string — returns 1 and prints UPDATE_AVAILABLE if update found
 	local version_str
 	if ! version_str=$(_build_version_str "$current" "$remote" "$app_name" "$cache_dir"); then
+		# Output the UPDATE_AVAILABLE line so the AI sees it via stdout
+		echo "$version_str"
+		# Append auto-update status so the AI can reassure the user
+		if _is_auto_update_active; then
+			echo "AUTO_UPDATE_ENABLED"
+		fi
 		return 0
 	fi
 

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -47,7 +47,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash) and greet with: "Hi!\n\n{content of file}.\n\nWhat would you like to work on?". If the file doesn't exist, read `~/.aidevops/agents/VERSION` to get the `{version}` and greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 3. Then respond to the user's actual message
 
-If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." This check does not apply when falling back to reading the cache or VERSION file (step 2).
+If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." If the output also contains a line `AUTO_UPDATE_ENABLED`, replace the manual update instruction with: "Auto-update is enabled and will apply this within ~10 minutes." This check does not apply when falling back to reading the cache or VERSION file (step 2).
 
 ## Pre-Edit Git Check
 

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -727,7 +727,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash) and greet with: "Hi!\n\n{content of file}.\n\nWhat would you like to work on?". If the file doesn't exist, read `~/.aidevops/agents/VERSION` to get the `{version}` and greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 3. Then respond to the user's actual message
 
-If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." This check does not apply when falling back to reading the cache or VERSION file (step 2).
+If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." If the output also contains a line `AUTO_UPDATE_ENABLED`, replace the manual update instruction with: "Auto-update is enabled and will apply this within ~10 minutes." This check does not apply when falling back to reading the cache or VERSION file (step 2).
 
 ## Pre-Edit Git Check
 

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -8,7 +8,7 @@
 3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version} in {app} v{app_version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
-If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." This check does not apply when falling back to reading the cache or VERSION file (step 2).
+If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." If the output also contains a line `AUTO_UPDATE_ENABLED`, replace the manual update instruction with: "Auto-update is enabled and will apply this within ~10 minutes." This check does not apply when falling back to reading the cache or VERSION file (step 2).
 
 ## Pre-Edit Git Check
 


### PR DESCRIPTION
## Summary

- **Fix**: `UPDATE_AVAILABLE` string was captured by `$()` command substitution into a variable but never echoed to stdout — AI agents running step 1 of the update check got empty output. Now echoed before early return.
- **Feature**: Detects whether the auto-update scheduler (launchd on macOS, cron on Linux) is active and appends `AUTO_UPDATE_ENABLED` to the output, so the AI tells users "Auto-update is enabled and will apply this within ~10 minutes" instead of prompting manual update.
- Updated instruction text in all 3 locations: `templates/opencode-config-agents.md`, `generate-runtime-config.sh`, `generate-opencode-agents.sh`.

Closes #14459

---
[aidevops.sh](https://aidevops.sh) v3.5.883 with claude-opus-4-6 in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-update status detection to identify when automatic updates are enabled on your system.

* **Improvements**
  * Enhanced update notifications with dynamic messaging: users with auto-update enabled now see a confirmation that updates will apply automatically within ~10 minutes, while others receive manual update instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->