### PR TITLE
GH#16710: tighten Cloudflare Terraform Provider agent doc (62→55 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/terraform.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/terraform.md
@@ -1,12 +1,6 @@
 # Cloudflare Terraform Provider
 
-## Core Principles
-
-- **Provider-first**: Use for ALL infrastructure — never mix with wrangler.toml for the same resources
-- **Remote state**: Always use remote state (S3, Terraform Cloud) for team environments
-- **Modular**: Create reusable modules for common patterns (zones, workers, pages)
-- **Version pinning**: Pin provider with `~>` for predictable upgrades
-- **Secrets**: Use variables + env vars — never hardcode API tokens
+**Rules:** Provider-first (never mix with wrangler.toml for same resources) · Remote state always (S3/Terraform Cloud) · Modular (zones, workers, pages) · Pin with `~>` · Secrets via env vars, never hardcoded
 
 ## Provider Setup
 
@@ -26,13 +20,12 @@ provider "cloudflare" {
 }
 ```
 
-### Authentication (priority order)
-
+**Auth (priority order):**
 1. **API Token** (recommended): `api_token` / `CLOUDFLARE_API_TOKEN` — Dashboard → My Profile → API Tokens; scope to specific accounts/zones
 2. **Global API Key** (legacy): `api_key` + `api_email` / `CLOUDFLARE_API_KEY` + `CLOUDFLARE_EMAIL` — less secure
 3. **User Service Key**: `user_service_key` — Origin CA certificates only
 
-### Remote State Backend
+**Remote state backend:**
 
 ```hcl
 terraform {


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/terraform.md` per instruction-doc simplification guidelines (GH#16710).

**Changes:**
- Consolidated 5-bullet "Core Principles" section into a single compact rule line
- Converted `### Authentication (priority order)` subsection to bold inline header
- Converted `### Remote State Backend` subsection to bold inline header
- Removed redundant blank lines and section heading overhead

**Content preservation verified:**
- All 3 auth methods with env var names intact
- HCL provider setup block unchanged
- Remote state backend HCL block unchanged
- All 7 common commands unchanged
- Both See Also links unchanged

**Line count:** 62 → 55 (11% reduction)

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes.
Assessment: `self-assessed` — content verified line-by-line against original.

Closes #16710

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6