### PR TITLE
GH#16711: tighten agent-review.md (61→50 lines)

### DIFF
--- a/.agents/tools/build-agent/agent-review.md
+++ b/.agents/tools/build-agent/agent-review.md
@@ -16,14 +16,9 @@ tools:
 
 <!-- AI-CONTEXT-START -->
 
-## Quick Reference
-
-- **Purpose**: Systematic review and improvement of agent instructions
-- **Trigger**: Session end, user correction, observable failure, periodic maintenance
-- **Output**: Proposed improvements with evidence and scope
-- **Checklist**: Instruction count · Universal applicability · Duplicate detection · Code examples · AI-CONTEXT block · Slash commands (see table below)
-- **Self-Assessment**: User correction, command/path failure, contradiction, staleness → complete task → cite evidence → `rg "pattern" .agents/` → propose fix → ask permission
-- **Write Restrictions (MANDATORY)**: On `main`/`master` — ALLOWED: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. BLOCKED: all other files. Code changes → return proposed edits for worktree application.
+**Trigger**: Session end, user correction, observable failure, periodic maintenance.
+**Self-Assessment**: Observe failure → complete task → cite evidence → `rg "pattern" .agents/` → propose fix → ask permission.
+**Write Restrictions (MANDATORY)**: On `main`/`master` — ALLOWED: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. BLOCKED: all other files. Code changes → return proposed edits for worktree application.
 
 <!-- AI-CONTEXT-END -->
 
@@ -34,7 +29,7 @@ tools:
 | 1 | **Instruction count** (~50-100 main, <100 subagent) | Consolidate, move to subagent, or remove |
 | 2 | **Universal applicability** (>80% tasks) | Extract task-specific content to subagents |
 | 3 | **Duplicate detection** (`rg "pattern" .agents/`) | Single authoritative source per concept |
-| 4 | **Code examples** (authoritative/working) | Keep authoritative examples; search-pattern reference as supplement only |
+| 4 | **Code examples** (authoritative/working) | Keep; supplement with `rg "pattern" .agents/scripts/` references |
 | 5 | **AI-CONTEXT block** (standalone essentials) | Rewrite if an AI would get stuck with only this |
 | 6 | **Slash commands** | Move to `scripts/commands/` or domain subagent |
 
@@ -49,12 +44,6 @@ tools:
 **Proposed Change**: [Specific before/after]
 **Impact**: [ ] No conflicts [ ] Instruction count: [+/- N] [ ] Tested
 ```
-
-## Common Improvement Patterns
-
-- **Consolidating**: Merge redundant rules (e.g., `local var="$1"` for all parameters).
-- **Moving to subagent**: Replace inline rules with pointers (e.g., `See aidevops/architecture.md`).
-- **Replacing code with reference**: Pair `rg "pattern" .agents/scripts/` with minimal authoritative examples, not as a full replacement.
 
 ## Contributing
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/build-agent/agent-review.md` from 61 to 50 lines (18% reduction) by removing redundant content in the AI-CONTEXT Quick Reference block.

## Issue
Closes #16711

## Files Changed
- `.agents/tools/build-agent/agent-review.md` — 4 insertions, 15 deletions

## Changes
- Removed "Quick Reference" heading and Purpose/Output/Checklist bullets — already covered by YAML frontmatter `description` field and the Review Checklist table directly below
- Merged "Common Improvement Patterns" section into checklist row 4 action column (the code-examples pattern is the most actionable; consolidating/moving-to-subagent are implied by rows 1-3)
- Kept all institutional knowledge: MANDATORY write restrictions, self-assessment workflow, improvement proposal template, contributing workflow

## Testing
- `markdownlint-cli2`: 0 errors
- Content preservation verified: all `rg` commands, `linters-local.sh` reference, MANDATORY write restrictions, proposal format template intact
- Risk: **Low** (docs/agent prompt only, no code changes)

## Runtime Testing
`self-assessed` — docs-only change, no runtime environment needed.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined agent review documentation by simplifying the AI-CONTEXT block and removing redundant guidance sections.
  * Updated code reference guidelines for improved clarity and focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->