### PR TITLE
GH#16730: tighten d1.md agent doc (Cloudflare D1 Database)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/d1.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/d1.md
@@ -19,14 +19,6 @@ Managed SQLite for Workers. Use it for relational queries and stronger consisten
 | Limits | 1 MB row, 30s query timeout, 10,000-statement batch |
 | Pricing | Query and storage based |
 
-## Quick Start
-
-```bash
-wrangler d1 create <database-name>
-wrangler d1 execute <db-name> --remote --file=./migrations/0001_schema.sql
-wrangler dev
-```
-
 ## Query API
 
 ```typescript
@@ -36,17 +28,21 @@ const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userI
 
 Methods: `.all()` rows, `.first()` / `.first(col)` single value, `.run()` writes, `.raw()` array rows. Use `batch()` for multiple independent statements in one round trip — the main transaction primitive. See [d1-patterns.md](./d1-patterns.md) for batch examples.
 
-## Essential Commands
+## Commands
 
 ```bash
+# Setup: create → apply migrations → dev
 wrangler d1 create <db-name>
-wrangler d1 list
-wrangler d1 delete <db-name>
-wrangler d1 execute <db-name> --remote --command="SELECT * FROM users"
 wrangler d1 execute <db-name> --local --file=./migrations/0001_schema.sql
+wrangler d1 execute <db-name> --remote --file=./migrations/0001_schema.sql
+wrangler dev --persist-to=./.wrangler/state
+
+# Inspect / manage
+wrangler d1 list
+wrangler d1 execute <db-name> --remote --command="SELECT * FROM users"
 wrangler d1 export <db-name> --remote --output=./backup.sql
 wrangler d1 time-travel restore <db-name> --timestamp="2024-01-15T14:30:00Z"
-wrangler dev --persist-to=./.wrangler/state
+wrangler d1 delete <db-name>
 ```
 
 ## Read Next


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/d1.md` per GH#16730.

**Classification:** Instruction doc (agent-facing operational reference, not a reference corpus).

**Change:** Merged redundant `Quick Start` section into `Commands` section. The Quick Start was a 3-command subset of Essential Commands — identical commands duplicated. Reorganised Commands with an inline setup-flow comment so the quick-start path remains visible without a separate section.

## Issue
Closes #16730

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/d1.md` — 60 → 56 lines

## Testing
**Risk level:** Low (docs/agent prompt, no runtime behaviour)
**Verification:** All code blocks, URLs, command examples, and links present before and after. Zero content loss — all commands preserved, setup sequence now annotated inline.

## Key Decisions
- Kept `Best Fit`, `Core Properties`, `Query API`, and `Read Next` sections unchanged — all carry distinct value.
- Did not compress the `Core Properties` table — limits data (1 MB row, 30s timeout, 10k batch) is design-critical.
- Merged only the genuinely duplicated commands; no prose compression applied.

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6