### PR TITLE
GH#16731: tighten serper.md — extend AI-CONTEXT block to cover endpoints section

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5,7 +5,7 @@
     "issue": "GH#16713",
     "lines_after": 61,
     "lines_before": 61,
-    "note": "Pass 2: instruction doc at minimum viable size. Previously tightened 82→61 lines (GH#15698, PR#16081). All sections necessary: YAML frontmatter, workflow steps, analysis types table, TOON output format. No further compression possible without content loss.",
+    "note": "Pass 2: instruction doc at minimum viable size. Previously tightened 82\u219261 lines (GH#15698, PR#16081). All sections necessary: YAML frontmatter, workflow steps, analysis types table, TOON output format. No further compression possible without content loss.",
     "passes": 2,
     "pr": "pending",
     "status": "simplified"
@@ -5763,5 +5763,11 @@
     "hash": "42730e6d8c7fb235e7594467232c9ab9d4f69db6e66316c6d6e073ad6d3838f9",
     "issue": "GH#16671",
     "status": "simplified"
+  },
+  ".agents/seo/serper.md": {
+    "hash": "3d0adf5a1a1e65e20e30d3ba749a1d2fccc090dcdad90dcbc8bbb6a254317e72",
+    "status": "simplified",
+    "issue": "GH#16731",
+    "lines": 60
   }
 }

--- a/.agents/seo/serper.md
+++ b/.agents/seo/serper.md
@@ -23,8 +23,6 @@ source ~/.config/aidevops/credentials.sh
 SERPER_CURL=(-s -X POST -H "X-API-KEY: $SERPER_API_KEY" -H "Content-Type: application/json")
 ```
 
-<!-- AI-CONTEXT-END -->
-
 ## Endpoints
 
 Common params: `gl` (country: `"us"`,`"gb"`,`"de"`), `hl` (lang: `"en"`), `num` (results: 10–100), `tbs` (time: `"qdr:h/d/w/m"`), `page`.
@@ -58,3 +56,5 @@ curl "${SERPER_CURL[@]}" https://google.serper.dev/scholar \
 curl "${SERPER_CURL[@]}" https://google.serper.dev/autocomplete \
   -d '{"q": "partial query"}'
 ```
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

- Extends `<!-- AI-CONTEXT-START/END -->` block in `.agents/seo/serper.md` to wrap the full file content (setup + endpoints), so all operational context is available in the context window
- Removes the misplaced `<!-- AI-CONTEXT-END -->` that prematurely closed the context block after the setup snippet, leaving the endpoints section outside it
- Updates `.agents/configs/simplification-state.json` with hash and status for this file

## What changed

**`.agents/seo/serper.md`** (60 lines, unchanged count):
- Moved `<!-- AI-CONTEXT-END -->` from line 26 (after setup block) to line 60 (end of file)
- All content preserved: frontmatter, auth setup, curl template, all 7 endpoint examples, common params

**`.agents/configs/simplification-state.json`**:
- Added entry for `.agents/seo/serper.md` with hash, status `simplified`, and `issue: GH#16731`

## Testing

Risk level: **Low** — docs/agent prompt only, no code execution paths changed.

Self-assessed: content preservation verified by line-by-line diff. All code blocks, URLs, command examples, and task references intact. Agent behaviour unchanged.

## Runtime Testing

`self-assessed` — doc-only change, no runtime paths affected.

Closes #16731

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6