### PR TITLE
GH#16733: tighten changelog.md agent doc (59→53 lines)

### DIFF
--- a/.agents/workflows/changelog.md
+++ b/.agents/workflows/changelog.md
@@ -6,10 +6,6 @@ tools: { read: true, write: true, edit: true, bash: true, glob: true, grep: true
 
 # Changelog Workflow
 
-<!-- AI-CONTEXT-START -->
-
-## Quick Reference
-
 - **Format**: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **Sections**: Added, Changed, Fixed, Removed, Security, Deprecated
 - **Trigger**: Called by @versioning before version bump completes
@@ -20,8 +16,6 @@ tools: { read: true, write: true, edit: true, bash: true, glob: true, grep: true
 .agents/scripts/version-manager.sh changelog-check      # validate changelog matches VERSION
 .agents/scripts/version-manager.sh release [major|minor|patch]  # full release (includes validation)
 ```
-
-<!-- AI-CONTEXT-END -->
 
 ## Format
 


### PR DESCRIPTION
## Summary

- Remove `<!-- AI-CONTEXT-START/END -->` wrapper (4 lines) — unnecessary in a subagent doc
- Remove `## Quick Reference` heading (2 lines) — promote content directly under title for LLM primacy
- All knowledge preserved: format link, sections list, trigger, related agents, CLI commands, format template, entry rules, release checklist, related docs

**Result**: 59 → 53 lines (10% reduction)

## What

Tighten `.agents/workflows/changelog.md` per simplification scan (GH#16733). This is an instruction doc (not a reference corpus), so the correct action is prose tightening, not chapter splitting.

## Files Changed

- `.agents/workflows/changelog.md` — 6 lines removed, structure flattened

## Testing

- `self-assessed` (Low risk: docs/agent prompt only)
- Content preservation verified: all code blocks, URLs, task references, and command examples present before and after
- Agent behaviour unchanged — same instructions, tighter structure

## Runtime Testing

Risk: **Low** — agent prompt doc, no runtime behaviour change.

Closes #16733

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6