### PR TITLE
t1872: add repos.json structural docs + write-time jq validation

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -128,7 +128,11 @@ Planning files go direct to main. Code changes need worktree + PR. Workers NEVER
 
 **Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture. Repos with `"local_only": true` have no GitHub remote — skip `gh` operations on them. Repo paths may be nested (e.g., `~/Git/cloudron/netbird-app`), not just `~/Git/<name>`.
 
-**Repo registration**: When you create or clone a new repo (via `gh repo create`, `git clone`, `git init`, etc.), add it to `~/.config/aidevops/repos.json` immediately. Every repo the user works with should be registered — unregistered repos are invisible to cross-repo tools (pulse, health dashboard, session time, contributor stats). Set fields based on the repo's purpose:
+**Repo registration**: When you create or clone a new repo (via `gh repo create`, `git clone`, `git init`, etc.), add it to `~/.config/aidevops/repos.json` immediately. Every repo the user works with should be registered — unregistered repos are invisible to cross-repo tools (pulse, health dashboard, session time, contributor stats).
+
+**repos.json structure (CRITICAL):** The file is `{"initialized_repos": [...], "git_parent_dirs": [...]}`. New repo entries MUST be appended inside the `initialized_repos` array — NEVER as top-level keys. After ANY write, validate: `jq . ~/.config/aidevops/repos.json > /dev/null`. A malformed file silently breaks the pulse for ALL repos.
+
+Set fields based on the repo's purpose:
 - `pulse: true` — repos with active development, tasks, and issues (most repos)
 - `pulse: false` — repos that exist but don't need task management (profile READMEs, forks for reference, archived projects)
 - `pulse_hours` — optional object `{"start": N, "end": N}` (24h local time). When set, the pulse only dispatches for this repo during the specified window. Overnight windows are supported (e.g., `{"start": 17, "end": 5}` runs 17:00–05:00). Repos without this field run 24/7 (default). Example: `"pulse_hours": {"start": 17, "end": 5}` to avoid conflicts with daytime work.

--- a/.agents/scripts/detect-app-type.sh
+++ b/.agents/scripts/detect-app-type.sh
@@ -163,9 +163,15 @@ write_cache_to_repos_json() {
 	# Write app_type into the matching entry
 	local tmp_file
 	tmp_file="$(mktemp)"
-	jq --arg slug "$slug" --arg app_type "$app_type" \
+	if jq --arg slug "$slug" --arg app_type "$app_type" \
 		'map(if .slug == $slug then . + {"app_type": $app_type} else . end)' \
-		"$repos_json" >"$tmp_file" && mv "$tmp_file" "$repos_json"
+		"$repos_json" >"$tmp_file" && jq empty "$tmp_file" 2>/dev/null; then
+		mv "$tmp_file" "$repos_json"
+	else
+		echo "ERROR: repos.json write produced invalid JSON — aborting (GH#16746)" >&2
+		rm -f "$tmp_file"
+		return 1
+	fi
 
 	printf "${GREEN}Cached app_type=%s for %s in repos.json${NC}\n" "$app_type" "$slug" >&2
 	return 0

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -63,7 +63,7 @@ _resolve_profile_repo() {
 		if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
 			local tmp_json
 			tmp_json=$(mktemp)
-			jq --arg path "$convention_path" --arg slug "${gh_user}/${gh_user}" '
+			if jq --arg path "$convention_path" --arg slug "${gh_user}/${gh_user}" '
 				.initialized_repos += [{
 					"path": $path,
 					"slug": $slug,
@@ -71,7 +71,12 @@ _resolve_profile_repo() {
 					"pulse": false,
 					"maintainer": ($slug | split("/")[0])
 				}]
-			' "$repos_json" >"$tmp_json" && mv "$tmp_json" "$repos_json"
+			' "$repos_json" >"$tmp_json" && jq empty "$tmp_json" 2>/dev/null; then
+				mv "$tmp_json" "$repos_json"
+			else
+				echo "ERROR: repos.json write produced invalid JSON — aborting (GH#16746)" >&2
+				rm -f "$tmp_json"
+			fi
 		fi
 		echo "$convention_path"
 		return 0
@@ -1548,7 +1553,7 @@ _init_register_repos_json() {
 	tmp_json=$(mktemp)
 	if [[ "$already_registered" == "0" ]]; then
 		echo "Registering profile repo in repos.json"
-		jq --arg path "$repo_dir" --arg slug "$repo_slug" '
+		if jq --arg path "$repo_dir" --arg slug "$repo_slug" '
 			.initialized_repos += [{
 				"path": $path,
 				"slug": $slug,
@@ -1556,14 +1561,24 @@ _init_register_repos_json() {
 				"pulse": false,
 				"maintainer": ($slug | split("/")[0])
 			}]
-		' "$repos_json" >"$tmp_json" && mv "$tmp_json" "$repos_json"
+		' "$repos_json" >"$tmp_json" && jq empty "$tmp_json" 2>/dev/null; then
+			mv "$tmp_json" "$repos_json"
+		else
+			echo "ERROR: repos.json write produced invalid JSON — aborting (GH#16746)" >&2
+			rm -f "$tmp_json"
+		fi
 	else
 		# Ensure priority is set to "profile"
-		jq --arg path "$repo_dir" '
+		if jq --arg path "$repo_dir" '
 			.initialized_repos |= map(
 				if .path == $path then .priority = "profile" else . end
 			)
-		' "$repos_json" >"$tmp_json" && mv "$tmp_json" "$repos_json"
+		' "$repos_json" >"$tmp_json" && jq empty "$tmp_json" 2>/dev/null; then
+			mv "$tmp_json" "$repos_json"
+		else
+			echo "ERROR: repos.json write produced invalid JSON — aborting (GH#16746)" >&2
+			rm -f "$tmp_json"
+		fi
 	fi
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1317,12 +1317,12 @@ check_repo_pulse_schedule() {
 					.initialized_repos |= map(
 						if .slug == $slug then .pulse = false else . end
 					)
-				' "$repos_json" >"$tmp_json" 2>/dev/null; then
+				' "$repos_json" >"$tmp_json" 2>/dev/null && jq empty "$tmp_json" 2>/dev/null; then
 					mv "$tmp_json" "$repos_json"
 					echo "[pulse-wrapper] Set pulse:false for ${slug} in repos.json (expiry auto-disable)" >>"$LOGFILE"
 				else
 					rm -f "$tmp_json"
-					echo "[pulse-wrapper] WARNING: jq failed to update repos.json for ${slug} expiry — skipping this cycle only" >>"$LOGFILE"
+					echo "[pulse-wrapper] WARNING: jq produced invalid JSON for ${slug} expiry — aborting write (GH#16746)" >>"$LOGFILE"
 				fi
 			fi
 			return 1


### PR DESCRIPTION
## Summary

- Documents `initialized_repos` array structure in AGENTS.md — entries MUST go inside the array, not as top-level keys
- Adds `jq empty` validation at all 5 repos.json write sites (detect-app-type.sh, profile-readme-helper.sh x3, pulse-wrapper.sh)
- Invalid JSON is caught before `mv` overwrites the live file, with error message and `rm` of the bad temp file

## Problem

A malformed repos.json entry (bare object without a key, outside the `initialized_repos` array) caused `jq` to fail silently in the pulse wrapper. The pulse saw zero repos in schedule window and stopped dispatching entirely — 17+ minute outage with zero workers despite 24 available slots.

Root cause: no validation existed at any write site. The AGENTS.md docs listed fields but never specified the array structure.

## Files changed

| File | Change |
|------|--------|
| `.agents/AGENTS.md` | Added structural note to repo registration section |
| `.agents/scripts/detect-app-type.sh` | Added `jq empty` validation before `mv` |
| `.agents/scripts/profile-readme-helper.sh` | Added `jq empty` validation at 3 write sites |
| `.agents/scripts/pulse-wrapper.sh` | Added `jq empty` validation before `mv` |

## Runtime Testing

Risk: **Low** (docs + defensive validation guards, no behavior change on valid JSON). Assessment: `self-assessed` — ShellCheck clean, validation pattern is standard jq idiom.

Closes #16746


---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 13h 42m and 4,859 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration schema documentation with new optional fields: `pulse_expires` (for automatic pulse scheduling) and `contributed` (for monitoring-only behavior).

* **Bug Fixes**
  * Enhanced JSON validation across configuration file write operations to prevent data corruption and ensure integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->