### PR TITLE
GH#16749: tighten setup.md agent doc, remove decorative AI-CONTEXT markers

### DIFF
--- a/.agents/aidevops/setup.md
+++ b/.agents/aidevops/setup.md
@@ -13,8 +13,6 @@ tools:
 
 # Setup Guide - AI Assistant for setup.sh
 
-<!-- AI-CONTEXT-START -->
-
 ## Quick Reference
 
 - **Script**: `~/Git/aidevops/setup.sh`
@@ -25,8 +23,6 @@ tools:
 **What setup.sh does**: checks required deps (`jq`, `curl`, `ssh`, `sqlite3`) and optional deps (`sshpass`, `gh`, `glab`, `tea`); copies `.agents/` → `~/.aidevops/agents/` with timestamped config backups; injects AGENTS.md pointer into `~/.opencode/AGENTS.md`, `~/.cursor/AGENTS.md`, `~/.claude/AGENTS.md`, `~/.config/cursor/AGENTS.md`; updates OpenCode agent paths in `~/.config/opencode/opencode.json`.
 
 **Deployed structure**: `~/.aidevops/agents/` (AGENTS.md, aidevops/, tools/, services/, workflows/, scripts/) + `~/.aidevops/config-backups/[YYYYMMDD_HHMMSS]/`
-
-<!-- AI-CONTEXT-END -->
 
 ## Manual Configuration
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightens `.agents/aidevops/setup.md` (57 → 53 lines) by removing decorative `<!-- AI-CONTEXT-START/END -->` wrapper comments.

## Issue
Closes #16749

## Files Changed
- `.agents/aidevops/setup.md` — removed 4 lines of decorative comment markers

## Testing
**Risk level:** Low (docs-only change, no code, no logic)
**Verification:** `self-assessed`

- All code blocks preserved: `brew install`, `apt-get install`, `chmod` commands intact
- All file paths preserved: `~/Git/aidevops/setup.sh`, `~/.aidevops/agents/`, `~/.config/aidevops/credentials.sh`, etc.
- All cross-references preserved: `tools/opencode/opencode.md`
- Agent behaviour unchanged — content is identical, only comment markers removed
- `wc -l` before: 57, after: 53 (4 lines removed = 2 markers + 2 blank lines)

## Key Decisions
- `<!-- AI-CONTEXT-START/END -->` markers serve a purpose in large files (>100 lines) to delimit context-window-relevant sections for runtime injection. In a 57-line file where the entire content is context-relevant, they are decorative noise per `code-simplifier.md` "Safe (high confidence)" classification.
- No content compression applied — the file was already lean. Only marker removal.

## Runtime Testing
`self-assessed` — docs-only change, no executable code modified.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6