### PR TITLE
GH#16750: tighten caldav-calendar-skill.md - reorder by importance, remove redundant intro

### DIFF
--- a/.agents/tools/productivity/caldav-calendar-skill.md
+++ b/.agents/tools/productivity/caldav-calendar-skill.md
@@ -5,11 +5,15 @@ mode: subagent
 ---
 # CalDAV Calendar (vdirsyncer + khal)
 
-vdirsyncer syncs CalDAV calendars to local .ics files. khal reads and writes them.
+**For reminders/tasks** (not events): see `tools/productivity/apple-reminders.md`.
 
-**For reminders/tasks** (not calendar events): see `tools/productivity/apple-reminders.md`.
+**Sync first** — always sync before querying or after changes: `vdirsyncer sync`
 
-**Sync First** — Always sync before querying or after making changes: `vdirsyncer sync`
+## Initial Setup
+
+1. Configure vdirsyncer (`~/.config/vdirsyncer/config`) — supports iCloud, Google, Fastmail, Nextcloud
+2. Configure khal (`~/.config/khal/config`)
+3. Run: `vdirsyncer discover && vdirsyncer sync`
 
 ## View Events
 
@@ -48,9 +52,3 @@ Placeholders: `{title}`, `{description}`, `{start}`, `{end}`, `{start-date}`, `{
 ## Caching
 
 Remove stale cache: `rm ~/.local/share/khal/khal.db`
-
-## Initial Setup
-
-1. Configure vdirsyncer (`~/.config/vdirsyncer/config`) — supports iCloud, Google, Fastmail, Nextcloud
-2. Configure khal (`~/.config/khal/config`)
-3. Run: `vdirsyncer discover && vdirsyncer sync`


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/productivity/caldav-calendar-skill.md` per simplification scan (GH#16750).

**Changes:**
- Moved `Initial Setup` section before operational commands (prerequisite ordering — you need setup before you can use it)
- Removed redundant intro line (`vdirsyncer syncs CalDAV calendars to local .ics files. khal reads and writes them.` — already captured in frontmatter description)
- Tightened "Sync First" rule: lowercase, shorter prose
- Tightened reminders cross-ref: removed redundant "calendar" qualifier
- Net: 56 → 54 lines, all content preserved

**Classification:** Instruction doc (not reference corpus) — prose tightening is correct action.

## Issue
Closes #16750

## Files Changed
- `.agents/tools/productivity/caldav-calendar-skill.md` — 56 → 54 lines

## Testing
- `self-assessed` (Low risk: docs/agent prompt only, no code paths)
- All code blocks, URLs, command examples preserved
- No broken internal links
- Agent behaviour unchanged — same commands, same structure, better ordering

## Runtime Testing
**Risk level:** Low (docs/agent prompt change only)
**Verification:** Content diff reviewed — all institutional knowledge preserved, no commands removed

---
[aidevops.sh](https://aidevops.sh) v3.5.884 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6