### PR TITLE
GH#16751: tighten api-key-management.md — security rules first, consistent arrows

### DIFF
--- a/.agents/tools/credentials/api-key-management.md
+++ b/.agents/tools/credentials/api-key-management.md
@@ -22,19 +22,10 @@ tools:
 - **CI/CD**: GitHub Secrets (`SONAR_TOKEN`, `CODACY_API_TOKEN`, `GITHUB_TOKEN`)
 - **Verify**: `setup-local-api-keys.sh list` (redacted) or `echo "${VAR:0:10}..."` (partial)
 - **Rotate**: every 90 days, minimal-scope tokens, revoke old immediately
-- **Compromised**: Revoke at provider -> regenerate -> update local + GitHub secrets -> verify
+- **Compromised**: Revoke at provider → regenerate → update local + GitHub secrets → verify
 - **Setup details**: `api-key-setup.md` | **Encrypted storage**: `gopass.md`
 
 <!-- AI-CONTEXT-END -->
-
-## Storage Hierarchy
-
-| Tier | Location | Use |
-|------|----------|-----|
-| **Encrypted** (preferred) | gopass (`aidevops secret`) | All secrets — see `gopass.md` |
-| **Plaintext fallback** | `~/.config/aidevops/credentials.sh` (600) | When gopass unavailable — see `api-key-setup.md` |
-| **CI/CD** | GitHub Repository Secrets | `SONAR_TOKEN`, `CODACY_API_TOKEN`, `GITHUB_TOKEN` (auto) |
-| **Local config** (gitignored) | `configs/*-config.json`, `~/.config/coderabbit/api_key` | Service-specific config |
 
 ## Security Rules
 
@@ -44,6 +35,15 @@ tools:
 4. **Minimal scope** — request only required permissions per token
 5. **Monitor** token usage and access logs at provider dashboards
 6. **Document** token sources and regeneration procedures
+
+## Storage Hierarchy
+
+| Tier | Location | Use |
+|------|----------|-----|
+| **Encrypted** (preferred) | gopass (`aidevops secret`) | All secrets — see `gopass.md` |
+| **Plaintext fallback** | `~/.config/aidevops/credentials.sh` (600) | When gopass unavailable — see `api-key-setup.md` |
+| **CI/CD** | GitHub Repository Secrets | `SONAR_TOKEN`, `CODACY_API_TOKEN`, `GITHUB_TOKEN` (auto) |
+| **Local config** (gitignored) | `configs/*-config.json`, `~/.config/coderabbit/api_key` | Service-specific config |
 
 ## Emergency: Compromised Key
 


### PR DESCRIPTION
## Summary

- Reorder sections by importance: Security Rules moved before Storage Hierarchy (primacy principle — LLMs weight earlier context more heavily)
- Replace ASCII `->` arrows with Unicode `→` for consistency
- Zero content loss — all institutional knowledge, commands, and references preserved

## What

Tighten `.agents/tools/credentials/api-key-management.md` per issue #16751 guidance. File classified as **instruction doc** (agent rules, operational procedures) — content compression approach applied, not reference corpus splitting.

## Files Changed

- `.agents/tools/credentials/api-key-management.md` — reordered sections, consistent arrows (54 lines → 54 lines)

## Runtime Testing

**Risk level: Low** — docs/agent prompt only, no code changes.
`self-assessed`: markdownlint-cli2 passes with 0 errors.

## Key Decisions

- Kept YAML frontmatter unchanged (follows build-agent.md template exactly)
- Security Rules first: most critical instructions for LLM context weighting
- Storage Hierarchy second: reference data, less urgent than rules
- Emergency section last: infrequent but complete

Closes #16751

---
[aidevops.sh](https://aidevops.sh) v3.5.884 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6