### PR TITLE
GH#16752: tighten task-taxonomy.md agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5775,7 +5775,18 @@
       "pr": 16714,
       "passes": 1
     },
-    ".agents/seo/ranking-opportunities.md": {
+  ".agents/reference/task-taxonomy.md": {
+    "at": "2026-04-03T16:50:00Z",
+    "hash": "e5313d0bc4a7e2bf7cb1e807abd6dd33b3da64f901dd1bb6aeca7903b56e7de7",
+    "issue": "GH#16752",
+    "lines_after": 48,
+    "lines_before": 54,
+    "note": "Instruction doc: removed 3 decorative --- horizontal rules and redundant **bold** wrapping on command names in list (backtick code formatting sufficient). All tables, rules, command examples, and references preserved.",
+    "passes": 1,
+    "pr": "pending",
+    "status": "simplified"
+  },
+  ".agents/seo/ranking-opportunities.md": {
       "hash": "b45ae335184c658835328022167c130b09f12e03",
       "at": "2026-04-03T16:35:52Z",
       "pr": 16713,

--- a/.agents/reference/task-taxonomy.md
+++ b/.agents/reference/task-taxonomy.md
@@ -6,8 +6,6 @@ description: Canonical routing taxonomy — domain labels and model tier labels 
 
 Canonical source for `/new-task`, `/save-todo`, `/define`, and `/pulse`. When a domain or tier changes, update **only this file** — command docs point here, not duplicate the tables.
 
----
-
 ## Domain Routing Table
 
 Apply a domain tag only when the task clearly belongs to a specialist agent. Code work stays unlabeled and routes to Build+.
@@ -28,8 +26,6 @@ Apply a domain tag only when the task clearly belongs to a specialist agent. Cod
 
 **Rule:** Omit the domain tag for code tasks. Build+ is the default.
 
----
-
 ## Model Tier Table
 
 Apply a tier tag only when the task needs more or less reasoning than the default (sonnet). `/pulse` resolves labels via `model-availability-helper.sh resolve <tier>`.
@@ -42,13 +38,11 @@ Apply a tier tag only when the task needs more or less reasoning than the defaul
 
 **Rule:** Default to no tier label. Use `thinking` for deeper reasoning, `simple` for lighter work, omit when uncertain.
 
----
-
 ## Command Use
 
-- **`/new-task`** — classify after brief creation; apply labels via `gh issue edit`
-- **`/save-todo`** — classify during dispatch tag evaluation
-- **`/define`** — classify during task type detection
-- **`/pulse`** — consume labels for agent routing and model tier selection
+- `/new-task` — classify after brief creation; apply labels via `gh issue edit`
+- `/save-todo` — classify during dispatch tag evaluation
+- `/define` — classify during task type detection
+- `/pulse` — consume labels for agent routing and model tier selection
 
 See `scripts/commands/pulse.md` "Agent routing from labels" and "Model tier selection" for dispatch behaviour.


### PR DESCRIPTION
## Summary

Tighten `.agents/reference/task-taxonomy.md` per GH#16752 simplification scan.

- Removed 3 decorative `---` horizontal rules (visual noise, no information value)
- Removed redundant `**bold**` wrapping on command names in the "Command Use" list (backtick code formatting is sufficient)
- All tables, `**Rule:**` callouts, command examples, and references preserved verbatim
- 54 → 48 lines (11% reduction)

## What

Instruction doc simplification: prose tightening, decorative formatting removal.

## Issue

Closes #16752

## Files Changed

- `.agents/reference/task-taxonomy.md` — simplified (54→48 lines)
- `.agents/configs/simplification-state.json` — updated hash registry

## Testing

**Risk level:** Low (docs-only, agent prompt file)
**Verification:** All code blocks, command examples, table rows, task ID refs, and `**Rule:**` callouts present before and after. Agent behaviour unchanged — no routing logic modified, only formatting noise removed.

## Runtime Testing

`self-assessed` — docs-only change, no runtime environment needed.

---
[aidevops.sh](https://aidevops.sh) v3.5.884 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6