### PR TITLE
GH#16753: tighten remotion-can-decode.md agent doc

### DIFF
--- a/.agents/tools/video/remotion-can-decode.md
+++ b/.agents/tools/video/remotion-can-decode.md
@@ -2,13 +2,15 @@
 name: can-decode
 mode: subagent
 description: Check if a video can be decoded by the browser using Mediabunny
+metadata:
+  tags: decode, video, audio, mediabunny, canDecode, browser, compatibility
 ---
 
 # Checking if a video can be decoded
 
-Use Mediabunny to check if a video can be decoded by the browser before attempting to play it.
+Use `canDecode()` from Mediabunny to check browser decode support before playback.
 
-## Helper
+## Shared helper
 
 ```tsx
 import { Input, ALL_FORMATS } from "mediabunny";
@@ -30,9 +32,7 @@ const checkTracks = async (input: Input): Promise<boolean> => {
 };
 ```
 
-## Usage
-
-**URL source:**
+## URL source
 
 ```tsx
 import { UrlSource } from "mediabunny";
@@ -43,7 +43,7 @@ export const canDecode = (src: string) =>
 const isDecodable = await canDecode("https://remotion.media/video.mp4");
 ```
 
-**Blob source** (file uploads / drag-and-drop):
+## Blob source (file uploads / drag-and-drop)
 
 ```tsx
 import { BlobSource } from "mediabunny";


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/video/remotion-can-decode.md` per GH#16753 simplification scan.

## Issue
Closes #16753

## Changes
- Added `metadata: tags:` to YAML frontmatter (consistent with `remotion-get-video-duration.md` and sibling files)
- Tightened intro prose: "Use `canDecode()` from Mediabunny to check browser decode support before playback." (shorter, more direct)
- Renamed `## Helper` → `## Shared helper` (clearer purpose)
- Promoted `**URL source:**` and `**Blob source**` bold labels to proper `##` section headings (consistent with sibling file pattern)
- All code blocks, URLs, and content preserved — zero content loss

## Classification
**Reference corpus** (code examples, not instruction doc). File was already compact at 53 lines. Restructuring for consistency with sibling files, not compression.

## Files changed
- `.agents/tools/video/remotion-can-decode.md` (6 insertions, 6 deletions — same line count)

## Testing
- `markdownlint-cli2`: 0 errors
- Content preservation verified: all code blocks, imports, function signatures, and example URLs present before and after

## Runtime Testing
**Risk: Low** — docs/agent prompt file only. No runtime verification required. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6