### PR TITLE
GH#16755: tighten WordPress orchestrator doc (52→34 lines)

### DIFF
--- a/.agents/tools/wordpress.md
+++ b/.agents/tools/wordpress.md
@@ -10,26 +10,8 @@ mode: subagent
 
 ## Quick Reference
 
-- **Purpose**: Route WordPress work to the right specialist doc
-- **Local dev**: LocalWP + `localwp.md`
-- **Fleet ops**: MainWP + `mainwp.md`
-- **Plugin curation**: `wp-preferred.md` (127+ plugins across 19 categories — performance, security, SEO, forms, e-commerce, membership, backup, staging, dev tooling)
-- **Custom fields**: `scf.md` for Secure Custom Fields / ACF
-
-**Platform integrations**
-
-- LocalWP MCP — direct database access for local sites
-- MainWP REST API — fleet operations across multiple sites
-
-**Key commands**
-
-```bash
-# LocalWP sites
-.agents/scripts/wordpress-mcp-helper.sh list-sites
-
-# MainWP operations
-.agents/scripts/mainwp-helper.sh [command] [site]
-```
+- **LocalWP MCP** — direct DB access for local sites: `.agents/scripts/wordpress-mcp-helper.sh list-sites`
+- **MainWP REST API** — fleet ops: `.agents/scripts/mainwp-helper.sh [command] [site]`
 
 <!-- AI-CONTEXT-END -->
 
@@ -41,7 +23,7 @@ mode: subagent
 | Manage content or routine upkeep | `wp-admin.md` | Admin tasks and site maintenance |
 | Inspect a local site or database | `localwp.md` | LocalWP setup and MCP-backed local DB access |
 | Update many sites | `mainwp.md` | Centralized MainWP operations |
-| Choose plugins | `wp-preferred.md` | Curated, reliability-first recommendations |
+| Choose plugins | `wp-preferred.md` | 127+ curated plugins across 19 categories |
 | Work with custom fields | `scf.md` | Field modeling and SCF/ACF guidance |
 
 ## Default workflow


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightened `.agents/tools/wordpress.md` from 52 to 34 lines (35% reduction).

## Changes
- Collapsed Quick Reference: removed doc pointers that duplicate the routing table below; merged platform integrations + key commands into two inline bullet points
- Routing table: preserved intact; tightened `wp-preferred.md` description to inline the plugin count
- Default workflow: preserved intact

## Issue
Closes #16755

## Files changed
- `.agents/tools/wordpress.md` — 52→34 lines

## Testing
- `bunx markdownlint-cli2 ".agents/tools/wordpress.md"` → 0 errors
- Content preservation verified: all doc references, helper scripts, routing table, and default workflow present
- Classification: instruction doc (orchestrator/router) — prose tightening applied, not corpus restructuring

## Key decisions
- Removed redundant Quick Reference doc pointers (localwp.md, mainwp.md, wp-preferred.md, scf.md) — all present in routing table
- Inlined key commands into Quick Reference bullets (no separate code block needed for 2 commands)
- Preserved all institutional knowledge: routing logic, platform integrations, default workflow

## Runtime Testing
Risk: **Low** — docs/agent prompt only. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.883 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6