### PR TITLE
GH#16756: tighten context7-cli.md agent doc (52→39 lines)

### DIFF
--- a/.agents/tools/context/context7-cli.md
+++ b/.agents/tools/context/context7-cli.md
@@ -25,28 +25,15 @@ tools:
 - **Order**: resolve library ID with `ctx7 library` → query docs with `ctx7 docs` → only fall back to web docs if Context7 has no coverage
 - **Telemetry**: `export CTX7_TELEMETRY_DISABLED=1`
 - **Backend**: prefer `@context7` for interactive flows; `@context7-cli` for shell/scripting/MCP fallback; pass normalized outputs (library ID + doc snippet) to keep prompts backend-agnostic
+- **Verify**: `@context7-cli Find the React library ID and return docs for useEffect dependency arrays.` → expect valid library ID + doc excerpts
 
 <!-- AI-CONTEXT-END -->
 
 ## Usage
 
 ```bash
-# Resolve a library ID
-npx -y ctx7 library react --json
-
-# Query focused docs
-npx -y ctx7 docs /facebook/react "useEffect examples" --json
-
-# One-shot lookup from name + question
+# One-shot lookup: resolve library ID then query docs (with error handling)
 LIB_ID=$(npx -y ctx7 library react --json | jq -r '.library.id // empty')
 [ -n "$LIB_ID" ] && npx -y ctx7 docs "$LIB_ID" "how to memoize expensive renders" --json \
   || echo "Error: Library 'react' not found." >&2
 ```
-
-## Verification
-
-```text
-@context7-cli Find the React library ID and return docs for useEffect dependency arrays.
-```
-
-Expected: a valid Context7 library ID plus relevant documentation excerpts returned via CLI calls.


### PR DESCRIPTION
## Summary

- Consolidate three Usage code examples into one (the one-shot pattern with error handling is the most instructive; the first two just repeat Quick Reference bullets)
- Move Verification section into Quick Reference as a single bullet — same information, less structure overhead
- Result: 52 → 39 lines, zero content loss, all commands/URLs/task refs preserved

## Issue

Closes #16756

## Files Changed

- `.agents/tools/context/context7-cli.md` — 2 insertions, 15 deletions

## Testing

- `markdownlint-cli2`: 0 errors
- Content preservation: all commands, library IDs, error handling, and verification query present before and after
- Classification: instruction doc (not reference corpus) — prose compression is correct action

## Runtime Testing

**Risk level**: Low (docs/agent prompt only, no code execution path changed)
**Verification**: `self-assessed` — markdownlint clean, content diff reviewed

---
[aidevops.sh](https://aidevops.sh) v3.5.889 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6