### PR TITLE
GH#16787: tighten ui-skills.md — merge Stack+Components and Layout+Design sections

### DIFF
--- a/.agents/tools/ui/ui-skills.md
+++ b/.agents/tools/ui/ui-skills.md
@@ -25,15 +25,12 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## Stack
+## Stack & Components
 
 - MUST use Tailwind defaults (spacing, radius, shadows) before custom values
 - MUST use `motion/react` (formerly `framer-motion`) for JavaScript animation
 - SHOULD use `tw-animate-css` for Tailwind entrance and micro-animations
 - MUST use `cn` (`clsx` + `tailwind-merge`) for class logic
-
-## Components
-
 - MUST use accessible component primitives for keyboard/focus behavior (`Base UI`, `React Aria`, `Radix`)
 - MUST use the project's existing component primitives first; NEVER mix primitive systems on the same surface
 - SHOULD prefer [`Base UI`](https://base-ui.com/react/components) for new primitives if compatible
@@ -71,13 +68,10 @@ tools:
 - SHOULD use `truncate` or `line-clamp` for dense UI
 - NEVER modify `letter-spacing` (`tracking-`) unless explicitly requested
 
-## Layout
+## Layout & Design
 
 - MUST use a fixed `z-index` scale (`z-10`, `z-20`) — no arbitrary values (`z-[99]`)
 - SHOULD use `size-*` for square elements instead of `w-*` + `h-*`
-
-## Design
-
 - NEVER use gradients unless explicitly requested; prefer subtle single-hue gradients when allowed
 - NEVER use glow effects as primary affordances
 - SHOULD use Tailwind default shadow scale unless explicitly requested


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tightens `.agents/tools/ui/ui-skills.md` from 96 → 90 lines by merging two pairs of small adjacent sections with high semantic overlap:
- `## Stack` + `## Components` → `## Stack & Components`
- `## Layout` + `## Design` → `## Layout & Design`

## Issue
Closes #16787

## Files Changed
- `.agents/tools/ui/ui-skills.md` — 2 section headers removed, all rules preserved

## Testing
- All MUST/SHOULD/NEVER constraints verified present before and after
- All URLs verified present: ui-skills.com, base-ui.com, react-spectrum.adobe.com, radix-ui.com, motion.dev, github.com/Wombosvideo, ui.shadcn.com
- No code blocks, task IDs, or GH refs in this file — N/A
- Agent behaviour unchanged: zero rule loss, zero content loss

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — tightening is correct action per code-simplifier.md
- Merged only sections with clear semantic overlap; `## Interaction`, `## Animation & Performance`, `## Typography` kept separate (distinct concerns)
- No prose compression applied — all rule text preserved verbatim

## Runtime Testing
Risk: **Low** — agent prompt doc, no code execution paths. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.892 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6