### PR TITLE
GH#16786: fix simplification scanner state mismatch and permission gate

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,5807 +1,5758 @@
 {
   "files": {
     ".agents/aidevops.md": {
-      "at": "2026-03-29T16:31:51Z",
       "hash": "cf74c159d129be3c0c891b416bd45c0c11a5613b",
+      "at": "2026-03-29T16:31:51Z",
       "passes": 1,
       "pr": 13063
     },
     ".agents/aidevops/add-new-mcp-to-aidevops.md": {
-      "at": "2026-03-28T16:41:22Z",
       "hash": "818de6a118b3981cbc732aace97a1220ad7f27ee",
+      "at": "2026-03-28T16:41:22Z",
       "passes": 1,
       "pr": 12006
     },
     ".agents/aidevops/agent-sources.md": {
-      "at": "2026-03-31T05:32:40Z",
       "hash": "5ecd39be40d1f3ceca20c8be89737b646c3e41be",
+      "at": "2026-03-31T05:32:40Z",
       "passes": 2,
       "pr": 14645
     },
     ".agents/aidevops/api-integrations.md": {
-      "at": "2026-04-03T11:53:46Z",
       "hash": "62214081cdcd977a20980563deac1064715a2367",
+      "at": "2026-04-03T11:53:46Z",
       "passes": 3,
       "pr": 0
     },
     ".agents/aidevops/architecture.md": {
-      "at": "2026-03-29T23:53:47Z",
       "hash": "f1d29dba0c0d676b0d00e4e5adac2d79f9aa2dd1",
+      "at": "2026-03-29T23:53:47Z",
       "passes": 1,
       "pr": 13445
     },
     ".agents/aidevops/configs.md": {
-      "at": "2026-03-28T15:30:49Z",
       "hash": "fecc0e08b16083bdd8f7e82c6f1636c136af3287",
+      "at": "2026-03-28T15:30:49Z",
       "passes": 1,
       "pr": 11897
     },
     ".agents/aidevops/extension.md": {
-      "at": "2026-03-28T08:58:33Z",
       "hash": "6b76dd6fa41470a5d1d4e5ebeea7af1b13b6a1e8",
+      "at": "2026-03-28T08:58:33Z",
       "passes": 1,
       "pr": 11565
     },
     ".agents/aidevops/mcp-integrations.md": {
-      "at": "2026-03-28T03:53:54Z",
       "hash": "199aacfc8608732f5fa0400478da824d5d11cdad",
+      "at": "2026-03-28T03:53:54Z",
       "passes": 2,
       "pr": 11339
     },
     ".agents/aidevops/mcp-troubleshooting.md": {
-      "at": "2026-03-31T08:03:51Z",
       "hash": "d14d5400e4c936f6c89957750c8f843ae8304ec4",
+      "at": "2026-03-31T08:03:51Z",
       "passes": 2,
       "pr": 14740
     },
     ".agents/aidevops/onboarding.md": {
-      "at": "2026-03-29T07:02:21Z",
       "hash": "a5d5e9ffd6e3639b96c0174e747bcb15c2712191",
+      "at": "2026-03-29T07:02:21Z",
       "passes": 2,
       "pr": 12641
     },
     ".agents/aidevops/plugins.md": {
-      "at": "2026-03-28T14:15:43Z",
       "hash": "b6beaa25a6400b7ce7586a389605bb7b5cde0b1c",
+      "at": "2026-03-28T14:15:43Z",
       "passes": 1,
       "pr": 11894
     },
     ".agents/aidevops/providers.md": {
-      "at": "2026-03-27T21:25:09Z",
       "hash": "18b8c2ddd2bb1ee1b0affc02c05ae860b8e902da",
+      "at": "2026-03-27T21:25:09Z",
       "passes": 1,
       "pr": 11003
     },
     ".agents/aidevops/recommendations.md": {
-      "at": "2026-03-28T03:54:11Z",
       "hash": "67c3f660425b669feae3238d7b42589449caa860",
+      "at": "2026-03-28T03:54:11Z",
       "passes": 1,
       "pr": 11343
     },
     ".agents/aidevops/requirements.md": {
-      "at": "2026-03-28T11:52:46Z",
       "hash": "9a75f9e14252e2364ed8ceeb9e24e8df3a95e310",
+      "at": "2026-03-28T11:52:46Z",
       "passes": 1,
       "pr": 11770
     },
     ".agents/aidevops/resources.md": {
-      "at": "2026-03-28T21:58:59Z",
       "hash": "4c8aa012ca51de765daed452692f619d55c701b1",
+      "at": "2026-03-28T21:58:59Z",
       "passes": 1,
       "pr": 12244
     },
     ".agents/aidevops/security-requirements.md": {
-      "at": "2026-03-29T12:37:08Z",
       "hash": "8b86459a5459bd0be5402ca5660bfd99fa54a782",
+      "at": "2026-03-29T12:37:08Z",
       "passes": 1,
       "pr": 12946
     },
     ".agents/aidevops/security.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "40a30044a14e7309b142c11970c87f603e9303d4",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16429
     },
     ".agents/aidevops/self-improving-agents.md": {
-      "at": "2026-04-01T20:59:02Z",
       "hash": "8e8dc0f8fa3a1a502130a64f217de014a5b14161",
+      "at": "2026-04-01T20:59:02Z",
       "passes": 1,
       "pr": 15203
     },
     ".agents/aidevops/service-links.md": {
-      "at": "2026-04-03T11:54:16Z",
       "hash": "41b35c410df5209c3c66a5678e237822f1fa3667",
+      "at": "2026-04-03T11:54:16Z",
       "passes": 1,
       "pr": 16410
     },
     ".agents/aidevops/services.md": {
-      "at": "2026-03-27T21:25:10Z",
       "hash": "0fd05379ebb6a6ab079aaa0011c1dd8a5cca6af1",
+      "at": "2026-03-27T21:25:10Z",
       "passes": 1,
       "pr": 11004
     },
     ".agents/aidevops/troubleshooting.md": {
-      "at": "2026-03-28T16:00:22Z",
       "hash": "9b1e6b69bbb4c48b5d664dbb23d72a25eb867b0f",
+      "at": "2026-03-28T16:00:22Z",
       "passes": 1,
       "pr": 11982
     },
     ".agents/automate.md": {
-      "at": "2026-04-03T01:53:24Z",
       "hash": "b5645f649804240736369a236767485dd7e49b6a",
+      "at": "2026-04-03T01:53:24Z",
       "passes": 1,
       "pr": 15804
     },
     ".agents/build-plus.md": {
-      "at": "2026-03-29T16:10:49Z",
       "hash": "9a8681dd42ae12e35c79f2f2479a29dfc90794f9",
+      "at": "2026-03-29T16:10:49Z",
       "passes": 1,
       "pr": 13101
     },
     ".agents/business.md": {
-      "at": "2026-03-29T16:34:54Z",
       "hash": "359aefa91dc7dcd75049c36dbf54965be0fc9e2c",
+      "at": "2026-03-29T16:34:54Z",
       "passes": 1,
       "pr": 13055
     },
     ".agents/business/accounts-receipt-ocr.md": {
-      "at": "2026-03-28T16:41:24Z",
       "hash": "7500c09629a5e47688af67a6901d684e92b623f2",
+      "at": "2026-03-28T16:41:24Z",
       "passes": 1,
       "pr": 12020
     },
     ".agents/business/accounts-subscription-audit.md": {
-      "at": "2026-03-29T21:43:19Z",
       "hash": "ef31fbb7ef1c8e43fc6f5e6ff3f7bed9b5b0e3a0",
+      "at": "2026-03-29T21:43:19Z",
       "passes": 1,
       "pr": 13235
     },
     ".agents/business/company-runners.md": {
-      "at": "2026-03-28T11:52:25Z",
       "hash": "8c78821205aacf320a7ed32b722b7c646a4e35af",
+      "at": "2026-03-28T11:52:25Z",
       "passes": 1,
       "pr": 11812
     },
     ".agents/content.md": {
-      "at": "2026-03-28T08:58:04Z",
       "hash": "2f71b51f39307e001e3af0bae81c5fc440c2da9b",
+      "at": "2026-03-28T08:58:04Z",
       "passes": 1,
       "pr": 11616
     },
     ".agents/content/VERIFICATION.md": {
-      "at": "2026-03-30T03:34:30Z",
       "hash": "f0090056bf6625c2ce2c676d4cf9ba25a901198e",
+      "at": "2026-03-30T03:34:30Z",
       "passes": 1,
       "pr": 13540
     },
     ".agents/content/content-calendar.md": {
-      "at": "2026-03-29T15:50:25Z",
       "hash": "5bb7dca9397875d571887657d6e92d551536e6cd",
+      "at": "2026-03-29T15:50:25Z",
       "passes": 1,
       "pr": 13052
     },
     ".agents/content/context-templates.md": {
-      "at": "2026-04-02T04:00:00Z",
       "hash": "15506de00a52128f74b711af949c6e56074f3bee",
+      "at": "2026-04-02T04:00:00Z",
       "passes": 2,
       "pr": 14934
     },
     ".agents/content/distribution-blog.md": {
-      "at": "2026-04-03T04:23:06Z",
       "hash": "12a91cbbc019545351d2ee5720a6e995448555bf",
+      "at": "2026-04-03T04:23:06Z",
       "passes": 1,
       "pr": 15909
     },
     ".agents/content/distribution-email.md": {
-      "at": "2026-03-28T16:00:42Z",
       "hash": "d218dc3fdd2a3e501978d431530820ce810b354e",
+      "at": "2026-03-28T16:00:42Z",
       "passes": 1,
       "pr": 11989
     },
     ".agents/content/distribution-podcast.md": {
-      "at": "2026-03-29T07:02:57Z",
       "hash": "0a2c98014bbe0588383437327d0b71e81a574af5",
+      "at": "2026-03-29T07:02:57Z",
       "passes": 1,
       "pr": 12557
     },
     ".agents/content/distribution-short-form.md": {
-      "at": "2026-03-28T20:16:49Z",
       "hash": "8350ba659dc7fbcbecd70b55d52b65d296ce5401",
+      "at": "2026-03-28T20:16:49Z",
       "passes": 1,
       "pr": 12172
     },
     ".agents/content/distribution-social.md": {
-      "at": "2026-03-28T11:20:38Z",
       "hash": "4ca38ce265bdd7a4921aeed56567dd38e5e98c32",
+      "at": "2026-03-28T11:20:38Z",
       "passes": 1,
       "pr": 11733
     },
     ".agents/content/distribution-youtube-channel-intel.md": {
-      "at": "2026-03-29T12:37:24Z",
       "hash": "e7acafaec5e56e608968ecc99a7005352995560c",
+      "at": "2026-03-29T12:37:24Z",
       "passes": 1,
       "pr": 12791
     },
     ".agents/content/distribution-youtube-optimizer.md": {
-      "at": "2026-03-28T11:20:34Z",
       "hash": "08796da4159346de335feb979d6ce0af181bb8ff",
+      "at": "2026-03-28T11:20:34Z",
       "passes": 1,
       "pr": 11731
     },
     ".agents/content/distribution-youtube-pipeline.md": {
-      "at": "2026-04-03T01:11:18Z",
       "hash": "4b11d88aa5e558faf6c672d0c8920f54a7db40f4",
+      "at": "2026-04-03T01:11:18Z",
       "passes": 2,
       "pr": 11763
     },
     ".agents/content/distribution-youtube-readme.md": {
-      "at": "2026-04-03T01:53:22Z",
       "hash": "933a61de442c55e846e4549225c5fe013ce59075",
+      "at": "2026-04-03T01:53:22Z",
       "passes": 1,
       "pr": 15971
     },
     ".agents/content/distribution-youtube-script-writer.md": {
-      "at": "2026-03-28T08:58:46Z",
       "hash": "e7d74dc2884f946d2d3ad41287926a426d0b0edb",
+      "at": "2026-03-28T08:58:46Z",
       "passes": 1,
       "pr": 11603
     },
     ".agents/content/distribution-youtube-topic-research.md": {
-      "at": "2026-03-28T11:20:29Z",
       "hash": "d8d475231eff5b53cf27de5ab31aeedaec403e2f",
+      "at": "2026-03-28T11:20:29Z",
       "passes": 1,
       "pr": 11801
     },
     ".agents/content/distribution-youtube.md": {
-      "at": "2026-03-29T01:03:19Z",
       "hash": "a44106f7677388ea6146e99c5c94de36b9e337ba",
+      "at": "2026-03-29T01:03:19Z",
       "passes": 1,
       "pr": 12386
     },
     ".agents/content/editor.md": {
-      "at": "2026-04-02T16:30:00Z",
       "hash": "1b10ff74a546e869506efa2abe19f9f34eb56ad6",
-      "passes": 1,
-      "pr": null
+      "at": "2026-04-02T16:30:00Z",
+      "passes": 1
     },
     ".agents/content/guidelines.md": {
-      "at": "2026-04-03T12:15:32Z",
       "hash": "b424d0157dd601eef0ea21fbc10b57dd2eb572da",
+      "at": "2026-04-03T12:15:32Z",
       "passes": 1,
       "pr": 16557
     },
     ".agents/content/heygen-skill/rules-assets.md": {
-      "at": "2026-03-29T16:34:55Z",
       "hash": "eed9c26fe6697296ac16fa54421ac1d4f9d6f2fc",
+      "at": "2026-03-29T16:34:55Z",
       "passes": 1,
       "pr": 13054
     },
     ".agents/content/heygen-skill/rules-authentication.md": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "6812919264796812f8cb6b375d01f49664c1af40",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15871
     },
     ".agents/content/heygen-skill/rules-avatars.md": {
-      "at": "2026-03-29T07:02:16Z",
       "hash": "e600865474071a7973fe0ed89b4fd361065e080a",
+      "at": "2026-03-29T07:02:16Z",
       "passes": 1,
       "pr": 12654
     },
     ".agents/content/heygen-skill/rules-backgrounds.md": {
-      "at": "2026-03-28T09:17:34Z",
       "hash": "7abf186ddedbabd5128f34ee918393a187de8cc3",
+      "at": "2026-03-28T09:17:34Z",
       "passes": 1,
       "pr": 11711
     },
     ".agents/content/heygen-skill/rules-captions.md": {
-      "at": "2026-03-28T09:48:53Z",
       "hash": "5e31cf7b1019f79f2f70a450083143cd6704e356",
+      "at": "2026-03-28T09:48:53Z",
       "passes": 1,
       "pr": 11707
     },
     ".agents/content/heygen-skill/rules-dimensions.md": {
-      "at": "2026-03-28T08:18:14Z",
       "hash": "f32c728a54e3edca1d713da0d536cb4b63299882",
+      "at": "2026-03-28T08:18:14Z",
       "passes": 1,
       "pr": 11610
     },
     ".agents/content/heygen-skill/rules-photo-avatars.md": {
-      "at": "2026-03-29T07:03:00Z",
       "hash": "d9a524f977f14c54b44991976651334aafa2e6e4",
+      "at": "2026-03-29T07:03:00Z",
       "passes": 1,
       "pr": 12620
     },
     ".agents/content/heygen-skill/rules-quota.md": {
-      "at": "2026-03-29T07:02:38Z",
       "hash": "defa81f8873250c50ab8a9481e5d6f2b0958946c",
+      "at": "2026-03-29T07:02:38Z",
       "passes": 1,
       "pr": 12592
     },
     ".agents/content/heygen-skill/rules-remotion-integration.md": {
-      "at": "2026-03-28T10:27:14Z",
       "hash": "5ccb546152546cd33344a76d42a4b90c0acd0dbd",
+      "at": "2026-03-28T10:27:14Z",
       "passes": 1,
       "pr": 11740
     },
     ".agents/content/heygen-skill/rules-scripts.md": {
-      "at": "2026-03-30T04:51:44Z",
       "hash": "2e44c72709396aa34cb596ff5ef6426dbc1e96c8",
+      "at": "2026-03-30T04:51:44Z",
       "passes": 2,
       "pr": 13767
     },
     ".agents/content/heygen-skill/rules-templates.md": {
-      "at": "2026-03-29T08:10:46Z",
       "hash": "5d9c85b6e42715ec4914982ce21790312207dacf",
+      "at": "2026-03-29T08:10:46Z",
       "passes": 1,
       "pr": 12738
     },
     ".agents/content/heygen-skill/rules-text-overlays.md": {
-      "at": "2026-04-03T04:23:07Z",
       "hash": "a513e4698b36be4382684340bb40203de9d5073d",
+      "at": "2026-04-03T04:23:07Z",
       "passes": 1,
       "pr": 15821
     },
     ".agents/content/heygen-skill/rules-video-agent.md": {
-      "at": "2026-03-29T07:31:38Z",
       "hash": "1d039d6d91c08e661a96696b19d43edbefe54b0e",
+      "at": "2026-03-29T07:31:38Z",
       "passes": 1,
       "pr": 12706
     },
     ".agents/content/heygen-skill/rules-video-generation.md": {
-      "at": "2026-03-28T10:27:38Z",
       "hash": "929341bdb16beeda9c31e050b53eddbe5badfd72",
+      "at": "2026-03-28T10:27:38Z",
       "passes": 1,
       "pr": 11675
     },
     ".agents/content/heygen-skill/rules-video-status.md": {
-      "at": "2026-04-03T11:54:16Z",
       "hash": "6cfdb227e3fdc94d81c9e877f353d10dd456cec3",
+      "at": "2026-04-03T11:54:16Z",
       "passes": 1,
       "pr": 16409
     },
     ".agents/content/heygen-skill/rules-video-translation.md": {
-      "at": "2026-03-29T03:15:05Z",
       "hash": "16bf014b85cd6ad3c1be9d593a97af8620313cbb",
+      "at": "2026-03-29T03:15:05Z",
       "passes": 1,
       "pr": 12504
     },
     ".agents/content/heygen-skill/rules-voices.md": {
-      "at": "2026-03-29T07:02:36Z",
       "hash": "d3dbb1550c826e13f7c5288b74f72fcff3518efd",
+      "at": "2026-03-29T07:02:36Z",
       "passes": 1,
       "pr": 12577
     },
     ".agents/content/heygen-skill/rules-webhooks.md": {
-      "at": "2026-03-30T06:49:23Z",
       "hash": "c3ba360303dc273741e6f76b2f235b8319f78734",
+      "at": "2026-03-30T06:49:23Z",
       "passes": 1,
       "pr": 13942
     },
     ".agents/content/humanise.md": {
-      "at": "2026-03-30T06:03:20Z",
       "hash": "898870a22cb4b4cf0153c907ab974792857e41c8",
+      "at": "2026-03-30T06:03:20Z",
       "passes": 1,
       "pr": 13836
     },
     ".agents/content/meta-creator.md": {
-      "at": "2026-04-03T01:11:47Z",
       "hash": "6573b67dd99792a8c5870a2850c8fb3bc74d7e3b",
+      "at": "2026-04-03T01:11:47Z",
       "passes": 1,
       "pr": 15781
     },
     ".agents/content/optimization.md": {
-      "at": "2026-03-29T23:18:03Z",
       "hash": "326ff8a42a6e84736e5f70fc2f569119e04c9fa5",
+      "at": "2026-03-29T23:18:03Z",
       "passes": 1,
       "pr": 13425
     },
     ".agents/content/platform-personas.md": {
-      "at": "2026-04-02T21:19:52Z",
       "hash": "b7e19c96eda87359699f528e35bddce57b0ddc2d",
+      "at": "2026-04-02T21:19:52Z",
       "passes": 2,
       "pr": 12167
     },
     ".agents/content/production-audio.md": {
-      "at": "2026-03-30T00:32:17Z",
       "hash": "7e3eb343f808775963edf8007b96029c69ba09bf",
+      "at": "2026-03-30T00:32:17Z",
       "passes": 2,
       "pr": 13478
     },
     ".agents/content/production-characters.md": {
-      "at": "2026-03-28T16:40:48Z",
       "hash": "f26a85f43d79aed7426a749dab9407537412d65b",
+      "at": "2026-03-28T16:40:48Z",
       "passes": 1,
       "pr": 12025
     },
     ".agents/content/production-image.md": {
-      "at": "2026-03-28T16:40:38Z",
       "hash": "b3409136a94a117c8a727fa3e1ca400d77806a36",
+      "at": "2026-03-28T16:40:38Z",
       "passes": 1,
       "pr": 12023
     },
     ".agents/content/production-video-08-talking-head-pipeline.md": {
-      "at": "2026-04-02T04:56:45Z",
       "hash": "cee1bc46bfdf4612fb0560748fe9e7b134ac0086",
+      "at": "2026-04-02T04:56:45Z",
       "passes": 1,
       "pr": 15516
     },
     ".agents/content/production-video.md": {
-      "at": "2026-04-03T04:22:44Z",
       "hash": "0785b8ae4867e7f14163d2b15878254aa4e95645",
+      "at": "2026-04-03T04:22:44Z",
       "passes": 2,
       "pr": 15699
     },
     ".agents/content/production-writing.md": {
-      "at": "2026-03-28T11:20:42Z",
       "hash": "525c4aab766775fa9f92155b85f58bcda67cf3ea",
+      "at": "2026-03-28T11:20:42Z",
       "passes": 1,
       "pr": 11788
     },
     ".agents/content/research.md": {
-      "at": "2026-03-28T08:57:54Z",
       "hash": "0844a394bf378618e923c821a3246e54fead511f",
+      "at": "2026-03-28T08:57:54Z",
       "passes": 1,
       "pr": 11644
     },
     ".agents/content/seo-writer.md": {
-      "at": "2026-04-01T22:10:00Z",
       "hash": "af5154d5e50138d5490ce34d3ab7e8b5f88966a7",
+      "at": "2026-04-01T22:10:00Z",
       "passes": 1,
       "pr": 15339
     },
     ".agents/content/social-bird.md": {
-      "at": "2026-03-28T05:10:07Z",
       "hash": "b2840ebff41ba9b78f7331487d6596373e8436e4",
+      "at": "2026-03-28T05:10:07Z",
       "passes": 1,
       "pr": 11354
     },
     ".agents/content/social-linkedin.md": {
-      "at": "2026-04-03T01:11:19Z",
       "hash": "4df257a29d0b5d2fb67cc260a1ac2d1881a8f8d2",
+      "at": "2026-04-03T01:11:19Z",
       "passes": 2,
       "pr": 15493
     },
     ".agents/content/story.md": {
-      "at": "2026-03-29T17:14:35Z",
       "hash": "b8ccd1b641692175207465ecf2f3a5ea8331fbab",
+      "at": "2026-03-29T17:14:35Z",
       "passes": 1,
       "pr": 13457
     },
     ".agents/content/summarize.md": {
-      "at": "2026-03-29T07:02:30Z",
       "hash": "937ce7f1f86adf1ef8f54d08458ca3421209fd10",
+      "at": "2026-03-29T07:02:30Z",
       "passes": 1,
       "pr": 12578
     },
     ".agents/content/video-director.md": {
-      "at": "2026-03-29T07:02:22Z",
       "hash": "7aa6d199c68cd683f60bf343be15f38db4484a11",
+      "at": "2026-03-29T07:02:22Z",
       "passes": 1,
       "pr": 12608
     },
     ".agents/content/video-enhancor.md": {
-      "at": "2026-03-29T08:49:19Z",
       "hash": "c92832f61d3cd78705b2913a0662b1ecee089aae",
+      "at": "2026-03-29T08:49:19Z",
       "passes": 1,
       "pr": 12796
     },
     ".agents/content/video-higgsfield-ui.md": {
-      "at": "2026-03-30T06:49:12Z",
       "hash": "2ca7fc448a908aa78e4fe010b0ace0aaf9b9de87",
+      "at": "2026-03-30T06:49:12Z",
       "passes": 2,
       "pr": 13932
     },
     ".agents/content/video-higgsfield.md": {
-      "at": "2026-03-28T16:00:37Z",
       "hash": "365b9f6acbaa7e54b14209c7eaee723372e836d6",
+      "at": "2026-03-28T16:00:37Z",
       "passes": 1,
       "pr": 11993
     },
     ".agents/content/video-muapi.md": {
-      "at": "2026-03-28T11:20:21Z",
       "hash": "3deffc1afc21c9cb3daf10a540c802fc70e437df",
+      "at": "2026-03-28T11:20:21Z",
       "passes": 1,
       "pr": 11800
     },
     ".agents/content/video-real-video-enhancer.md": {
-      "at": "2026-03-30T03:34:21Z",
       "hash": "3a1c798089a1fa50288b76e5fd372fe57d4307d5",
+      "at": "2026-03-30T03:34:21Z",
       "passes": 1,
       "pr": 13533
     },
     ".agents/content/video-runway.md": {
-      "at": "2026-03-28T08:58:00Z",
       "hash": "54c5b2fe2d3cdd00e23f192d5f869c927b6e573e",
+      "at": "2026-03-28T08:58:00Z",
       "passes": 1,
       "pr": 11646
     },
     ".agents/content/video-wavespeed.md": {
-      "at": "2026-03-28T14:15:41Z",
       "hash": "ef2bf4d381397992153760c0f74ea060eb5260fc",
+      "at": "2026-03-28T14:15:41Z",
       "passes": 1,
       "pr": 11895
     },
     ".agents/health.md": {
-      "at": "2026-04-01T20:58:58Z",
       "hash": "301b928aef5da6cc3a1dbb353077bfbab47af315",
+      "at": "2026-04-01T20:58:58Z",
       "passes": 1,
       "pr": 15249
     },
     ".agents/legal.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "b2f5c0c595082613b430121ff3e1347f759e0700",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16526
     },
     ".agents/marketing-sales.md": {
-      "at": "2026-03-30T06:03:16Z",
       "hash": "0b4144452b197dae7edbfcf3a5452752d3b2fe10",
+      "at": "2026-03-30T06:03:16Z",
       "passes": 1,
       "pr": 13839
     },
     ".agents/marketing-sales/ad-creative-ai-tools-reference.md": {
-      "at": "2026-03-28T20:56:07Z",
       "hash": "8faff4defc9b64a16a6da7b996a86d29763bb87e",
+      "at": "2026-03-28T20:56:07Z",
       "passes": 1,
       "pr": 12183
     },
     ".agents/marketing-sales/ad-creative-campaign-management.md": {
-      "at": "2026-03-28T16:00:35Z",
       "hash": "cf88e0ca297eabefcb235d1359ee6d2b0e75d576",
+      "at": "2026-03-28T16:00:35Z",
       "passes": 1,
       "pr": 11974
     },
     ".agents/marketing-sales/ad-creative-chapter-01.md": {
-      "at": "2026-03-28T23:05:56Z",
       "hash": "e832ef8eb425956cec38a250eede0227342a4d79",
+      "at": "2026-03-28T23:05:56Z",
       "passes": 1,
       "pr": 12325
     },
     ".agents/marketing-sales/ad-creative-chapter-02.md": {
-      "at": "2026-03-28T07:37:37Z",
       "hash": "810c244d317a3332c74dc2baafb34bf00cf5ab2f",
+      "at": "2026-03-28T07:37:37Z",
       "passes": 1,
       "pr": 11539
     },
     ".agents/marketing-sales/ad-creative-chapter-03.md": {
-      "at": "2026-03-28T15:30:26Z",
       "hash": "f2d79f61b3c28c3e902760bb469c29a465a777c3",
+      "at": "2026-03-28T15:30:26Z",
       "passes": 1,
       "pr": 11936
     },
     ".agents/marketing-sales/ad-creative-chapter-04.md": {
-      "at": "2026-03-29T07:02:10Z",
       "hash": "35b67bea4f7521d18b9a3a75deb4b2508810e83d",
+      "at": "2026-03-29T07:02:10Z",
       "passes": 1,
       "pr": 12662
     },
     ".agents/marketing-sales/ad-creative-chapter-05.md": {
-      "at": "2026-03-28T08:18:28Z",
       "hash": "f8ded271e66b8024f24caa8a841ea58da90a709a",
+      "at": "2026-03-28T08:18:28Z",
       "passes": 1,
       "pr": 11555
     },
     ".agents/marketing-sales/ad-creative-chapter-06.md": {
-      "at": "2026-03-28T05:09:55Z",
       "hash": "3d34a8e028e8905a54af8dd939394d10bdf16d97",
+      "at": "2026-03-28T05:09:55Z",
       "passes": 1,
       "pr": 11414
     },
     ".agents/marketing-sales/ad-creative-chapter-07.md": {
-      "at": "2026-03-29T01:33:56Z",
       "hash": "c79c8baa955bb48f1ce2ded8036ded7940948031",
+      "at": "2026-03-29T01:33:56Z",
       "passes": 1,
       "pr": 12442
     },
     ".agents/marketing-sales/ad-creative-chapter-08.md": {
-      "at": "2026-03-29T01:04:19Z",
       "hash": "cff567e1f6215e9c459e5d97d022a93f34d1c322",
+      "at": "2026-03-29T01:04:19Z",
       "passes": 1,
       "pr": 12398
     },
     ".agents/marketing-sales/ad-creative-chapter-09.md": {
-      "at": "2026-03-29T16:34:21Z",
       "hash": "2bdf7194dc300dd779d03b44a37d35015e9f282d",
+      "at": "2026-03-29T16:34:21Z",
       "passes": 1,
       "pr": 13110
     },
     ".agents/marketing-sales/ad-creative-chapter-10.md": {
-      "at": "2026-03-28T05:10:32Z",
       "hash": "23e33ef44632a4467884d5d9bebf6452adf22160",
+      "at": "2026-03-28T05:10:32Z",
       "passes": 1,
       "pr": 11315
     },
     ".agents/marketing-sales/ad-creative-chapter-11.md": {
-      "at": "2026-03-29T20:54:11Z",
       "hash": "2fbaad774769229326c549e278ffe31d26906d66",
+      "at": "2026-03-29T20:54:11Z",
       "passes": 1,
       "pr": 13222
     },
     ".agents/marketing-sales/ad-creative-chapter-12.md": {
-      "at": "2026-03-29T03:15:08Z",
       "hash": "eca290e31ece1e36762bbf607353ddbdb27aaf52",
+      "at": "2026-03-29T03:15:08Z",
       "passes": 1,
       "pr": 12503
     },
     ".agents/marketing-sales/ad-creative-chapters.md": {
-      "at": "2026-03-28T23:05:56Z",
       "hash": "7389f5acbff5e5b272cc97a5c5285e8a9b735427",
+      "at": "2026-03-28T23:05:56Z",
       "passes": 1,
       "pr": 12325
     },
     ".agents/marketing-sales/ad-creative-copywriting.md": {
-      "at": "2026-03-28T21:14:35Z",
       "hash": "84d60fe17b4cc01ac5bec4ce3363428510a2ece6",
+      "at": "2026-03-28T21:14:35Z",
       "passes": 1,
       "pr": 12018
     },
     ".agents/marketing-sales/ad-creative-offers-landing.md": {
-      "at": "2026-03-28T05:50:34Z",
       "hash": "a16b4767e518eb9f3f35e1b61d3d166390077009",
+      "at": "2026-03-28T05:50:34Z",
       "passes": 1,
       "pr": 11415
     },
     ".agents/marketing-sales/ad-creative-platform-google.md": {
-      "at": "2026-03-28T15:30:26Z",
       "hash": "f64e3f66de660586a2c510e31ce4a942286cf079",
+      "at": "2026-03-28T15:30:26Z",
       "passes": 1,
       "pr": 11936
     },
     ".agents/marketing-sales/ad-creative-platform-meta.md": {
-      "at": "2026-03-28T08:58:35Z",
       "hash": "130ac72c8435b342b5be159ed84ab6633efdf4fa",
+      "at": "2026-03-28T08:58:35Z",
       "passes": 1,
       "pr": 11574
     },
     ".agents/marketing-sales/ad-creative-psychology-targeting.md": {
-      "at": "2026-03-28T10:27:52Z",
       "hash": "c37b3f2fadeaae4f147248efd4fa535e89f1d96b",
+      "at": "2026-03-28T10:27:52Z",
       "passes": 1,
       "pr": 11655
     },
     ".agents/marketing-sales/ad-creative-testing-optimization.md": {
-      "at": "2026-03-28T08:58:01Z",
       "hash": "2f60c87e51dac14c539d02ba1a796a98b995c2c4",
+      "at": "2026-03-28T08:58:01Z",
       "passes": 1,
       "pr": 11614
     },
     ".agents/marketing-sales/ad-creative-video-ugc.md": {
-      "at": "2026-03-30T04:52:01Z",
       "hash": "695a2da0afc79acc4e203ead505b0bc768c6237a",
+      "at": "2026-03-30T04:52:01Z",
       "passes": 1,
       "pr": 13723
     },
     ".agents/marketing-sales/ad-creative.md": {
-      "at": "2026-03-29T03:31:36Z",
       "hash": "0fd2f3ed67a352a6b59ca35f1cb1be0ca62f691f",
+      "at": "2026-03-29T03:31:36Z",
       "passes": 1,
       "pr": 12505
     },
     ".agents/marketing-sales/cro-chapter-01.md": {
-      "at": "2026-03-29T20:54:07Z",
       "hash": "5dad243a2a5744924aeb5b2e39fe94aad887af5e",
+      "at": "2026-03-29T20:54:07Z",
       "passes": 1,
       "pr": 13294
     },
     ".agents/marketing-sales/cro-chapter-02.md": {
-      "at": "2026-04-01T20:59:14Z",
       "hash": "8226a4d2cd57afce1746318203d9c357540010c2",
+      "at": "2026-04-01T20:59:14Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/01-conversion-rate-formulas.md": {
-      "at": "2026-04-01T20:59:14Z",
       "hash": "3ffbf75893700060301c26dd5fd2c63e6743bddc",
+      "at": "2026-04-01T20:59:14Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/02-psychology-of-conversion.md": {
-      "at": "2026-04-01T20:59:14Z",
       "hash": "497b1a2f35082225ace6ac18531c3b83d25fd39f",
+      "at": "2026-04-01T20:59:14Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/03-conversion-funnel.md": {
-      "at": "2026-04-01T20:59:14Z",
       "hash": "20a9a226559ee7acc643d4b1b73a44d3f735e87d",
+      "at": "2026-04-01T20:59:14Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/04-attribution-models.md": {
-      "at": "2026-04-01T20:59:15Z",
       "hash": "48f7749c53ee973531130209345c214c0d77b181",
+      "at": "2026-04-01T20:59:15Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/05-website-elements.md": {
-      "at": "2026-04-01T20:59:15Z",
       "hash": "786c51eec79c4098d2034c43c8dd98c1077043e0",
+      "at": "2026-04-01T20:59:15Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/06-conversion-friction.md": {
-      "at": "2026-04-01T20:59:15Z",
       "hash": "60a0019275f9e3b20f3e9dba68b8d52f6782199c",
+      "at": "2026-04-01T20:59:15Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/07-data-foundation.md": {
-      "at": "2026-04-01T20:59:15Z",
       "hash": "58055a16f3affa58e9372abe6c4108cc7d0b196c",
+      "at": "2026-04-01T20:59:15Z",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-03.md": {
-      "at": "2026-03-29T12:37:09Z",
       "hash": "ac80d924629caf06f25a2c2bf503c1aa2267d8de",
+      "at": "2026-03-29T12:37:09Z",
       "passes": 1,
       "pr": 12954
     },
     ".agents/marketing-sales/cro-chapter-04.md": {
-      "at": "2026-03-29T07:02:12Z",
       "hash": "f893022ded62f04d6ca13b86f839211e4fe8190a",
+      "at": "2026-03-29T07:02:12Z",
       "passes": 1,
       "pr": 12665
     },
     ".agents/marketing-sales/cro-chapter-05.md": {
-      "at": "2026-03-29T09:20:58Z",
       "hash": "2a9c49266d0a50ef42a41c590041ff6aeb62135c",
+      "at": "2026-03-29T09:20:58Z",
       "passes": 1,
       "pr": 12824
     },
     ".agents/marketing-sales/cro-chapter-07.md": {
-      "at": "2026-03-29T02:36:03Z",
       "hash": "faba8a64f3996ee2e5722dd4b7c822d49f79c1b6",
+      "at": "2026-03-29T02:36:03Z",
       "passes": 1,
       "pr": 12463
     },
     ".agents/marketing-sales/cro-chapter-08.md": {
-      "at": "2026-03-30T06:49:54Z",
       "hash": "b17c73481de18eb0ad983703fbcae8b5b7e93c98",
+      "at": "2026-03-30T06:49:54Z",
       "passes": 1,
       "pr": 13773
     },
     ".agents/marketing-sales/cro-chapter-09.md": {
-      "at": "2026-03-28T08:17:36Z",
       "hash": "4d45e94ded75b90ef7e30518e072a5a643167370",
+      "at": "2026-03-28T08:17:36Z",
       "passes": 1,
       "pr": 11561
     },
     ".agents/marketing-sales/cro-chapter-10.md": {
-      "at": "2026-03-27T21:25:12Z",
       "hash": "730bf8258084ccd7a330cc2ac1032f1aedd4a370",
+      "at": "2026-03-27T21:25:12Z",
       "passes": 1,
       "pr": 11005
     },
     ".agents/marketing-sales/cro-chapter-11.md": {
-      "at": "2026-04-01T22:00:00Z",
       "hash": "be3bf907be217b866da1d7990427e4fc1c925971",
+      "at": "2026-04-01T22:00:00Z",
       "passes": 1,
       "pr": 14514
     },
     ".agents/marketing-sales/cro-chapter-12.md": {
-      "at": "2026-03-28T16:00:24Z",
       "hash": "f733b449021696b03a6678fba02aca9940fdeb6a",
+      "at": "2026-03-28T16:00:24Z",
       "passes": 1,
       "pr": 11988
     },
     ".agents/marketing-sales/cro-chapter-13.md": {
-      "at": "2026-03-29T03:15:02Z",
       "hash": "e498cfacef39db0262cc094600055befe786ccfe",
+      "at": "2026-03-29T03:15:02Z",
       "passes": 1,
       "pr": 12499
     },
     ".agents/marketing-sales/cro-chapter-14.md": {
-      "at": "2026-03-28T16:40:42Z",
       "hash": "a15acda5b82f46b01af4961ff5c01fa7483e5cea",
+      "at": "2026-03-28T16:40:42Z",
       "passes": 1,
       "pr": 12027
     },
     ".agents/marketing-sales/cro-chapter-15/01-personalization-types.md": {
-      "at": "2026-04-03T01:53:23Z",
       "hash": "0d4c142ecedde60524690f30e9469cc1819573e2",
+      "at": "2026-04-03T01:53:23Z",
       "passes": 1,
       "pr": 15873
     },
     ".agents/marketing-sales/cro-chapter-16.md": {
-      "at": "2026-03-28T04:30:24Z",
       "hash": "920245116e79b04207fd2b808c5dcbfabea3eb17",
+      "at": "2026-03-28T04:30:24Z",
       "passes": 1,
       "pr": 11374
     },
     ".agents/marketing-sales/cro-chapter-17.md": {
-      "at": "2026-03-29T21:43:12Z",
       "hash": "55117c563ab956b0653eca2c335a7e8c14e15708",
+      "at": "2026-03-29T21:43:12Z",
       "passes": 1,
       "pr": 13339
     },
     ".agents/marketing-sales/cro-chapter-18.md": {
-      "at": "2026-04-01T20:59:11Z",
       "hash": "4111c2a2ec25f39fecd814fc065f58ac91c263b0",
+      "at": "2026-04-01T20:59:11Z",
       "passes": 1,
       "pr": 15220
     },
     ".agents/marketing-sales/cro-chapter-19.md": {
-      "at": "2026-04-02T21:19:54Z",
       "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
-      "issue": "GH#14286",
-      "note": "Reference corpus chapter tightened: 92 → 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
+      "at": "2026-04-02T21:19:54Z",
       "passes": 2
     },
     ".agents/marketing-sales/cro-chapter-20.md": {
-      "at": "2026-03-29T16:34:29Z",
       "hash": "07aa1e83fefdc10d56b044961da2976b1e693895",
+      "at": "2026-03-29T16:34:29Z",
       "passes": 1,
       "pr": 13105
     },
     ".agents/marketing-sales/cro-chapter-21.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "c32a8b9e1fba8691204c235115e53b63866d50f3",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16514
     },
     ".agents/marketing-sales/cro-chapter-22.md": {
-      "at": "2026-04-01T20:58:50Z",
       "hash": "882c97fc64eb63b11312049223c04eaa52882296",
+      "at": "2026-04-01T20:58:50Z",
       "passes": 1,
       "pr": 15257
     },
     ".agents/marketing-sales/cro-chapter-25.md": {
-      "at": "2026-04-03T03:15:07Z",
       "hash": "2c74493ea612ebc2fc0351c5f151f5f6e81234ae",
+      "at": "2026-04-03T03:15:07Z",
       "passes": 3,
       "pr": 15276
     },
     ".agents/marketing-sales/cro-chapters.md": {
-      "at": "2026-03-30T00:32:32Z",
       "hash": "4571100c86a6a93fbd6437d733a360ca53dd4482",
+      "at": "2026-03-30T00:32:32Z",
       "passes": 1,
       "pr": 13457
     },
     ".agents/marketing-sales/cro.md": {
-      "at": "2026-03-29T08:10:36Z",
       "hash": "9a8a0b49c40c42072e982a4dd40761c19c0055ed",
+      "at": "2026-03-29T08:10:36Z",
       "passes": 1,
       "pr": 12753
     },
     ".agents/marketing-sales/direct-response-copy-checklists-offer-optimization.md": {
-      "at": "2026-04-03T01:53:26Z",
       "hash": "5deb96e01280b6ec23ad9c1db17fba7700c949b9",
+      "at": "2026-04-03T01:53:26Z",
       "passes": 1,
       "pr": 15696
     },
     ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
-      "at": "2026-04-01T20:59:28Z",
       "hash": "ab1f9c5d69340fa7acfd756c2ae37710b9fa600c",
+      "at": "2026-04-01T20:59:28Z",
       "passes": 1,
       "pr": 14996
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "b594411242a14e362274593486ec16fdf2862f80",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16443
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-headline-formulas.md": {
-      "at": "2026-03-28T08:58:42Z",
       "hash": "9c23835b93de53e0d6371a5f753c1409e0374d9d",
+      "at": "2026-03-28T08:58:42Z",
       "passes": 1,
       "pr": 11548
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md": {
-      "at": "2026-04-01T21:00:01Z",
       "hash": "4c6d024fd0bd6ab3cbc9881e5cd83bd7dec582e4",
+      "at": "2026-04-01T21:00:01Z",
       "passes": 1,
       "pr": 14853
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
-      "at": "2026-03-28T08:17:37Z",
       "hash": "a80eb99acba160fa0f034a4989c0b886f37a32a0",
+      "at": "2026-03-28T08:17:37Z",
       "passes": 1,
       "pr": 11571
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-offer-construction.md": {
-      "at": "2026-03-28T05:51:09Z",
       "hash": "10d31ffa27d8e38267882e04f099ce38899635f1",
+      "at": "2026-03-28T05:51:09Z",
       "passes": 1,
       "pr": 11363
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-ads.md": {
-      "at": "2026-03-28T05:50:32Z",
       "hash": "8e2f8f2a6620debfe219e09c96cfeb634fb518a7",
+      "at": "2026-03-28T05:50:32Z",
       "passes": 1,
       "pr": 11411
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md": {
-      "at": "2026-03-31T05:42:16Z",
       "hash": "57313942eaf75ad8a1022a5c723b3f2c5d3f76f5",
+      "at": "2026-03-31T05:42:16Z",
       "passes": 2,
       "pr": 14662
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-06-ramit-sethi-launch.md": {
-      "at": "2026-04-01T20:59:17Z",
       "hash": "5f82f7b17f7fde8daeb703ca4c3cdcef53620c2f",
+      "at": "2026-04-01T20:59:17Z",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-07-saas-trial-expiry.md": {
-      "at": "2026-04-01T20:59:17Z",
       "hash": "541a34d7b2649c4e93f494af26bb412731aace9e",
+      "at": "2026-04-01T20:59:17Z",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-08-cart-abandonment.md": {
-      "at": "2026-04-01T20:59:17Z",
       "hash": "2c4d31ad777c8c70b5293c3fd75e4e6af67b4654",
+      "at": "2026-04-01T20:59:17Z",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-09-webinar-invite.md": {
-      "at": "2026-04-01T20:59:17Z",
       "hash": "5dd410cda93d3056b39408c537fb3c9b1e1e06da",
+      "at": "2026-04-01T20:59:17Z",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
-      "at": "2026-04-01T20:59:18Z",
       "hash": "7f8943efbe9c5d05b7ecba869a866d6020b95928",
+      "at": "2026-04-01T20:59:18Z",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md": {
-      "at": "2026-04-02T04:56:54Z",
       "hash": "d662c65c03864c29b198db3a89950538a7949ef2",
+      "at": "2026-04-02T04:56:54Z",
       "passes": 1,
       "pr": 15526
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
-      "at": "2026-03-28T15:30:24Z",
       "hash": "f74ee77c8e774c79829f80e238c09adbe6f3c21e",
+      "at": "2026-03-28T15:30:24Z",
       "passes": 1,
       "pr": 11945
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md": {
-      "at": "2026-04-02T20:39:23Z",
       "hash": "e32cc9a38c9f2b1305595ef393fa64650ed7f0b5",
-      "issue": "GH#15068",
-      "note": "Reference corpus already split into 5 chapter files (01-saas-examples.md through 05-guarantees-and-design-principles.md). Index is 30 lines; chapters total 163 lines. No further action needed.",
-      "passes": 1,
-      "status": "done"
+      "at": "2026-04-02T20:39:23Z",
+      "passes": 1
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-example.md": {
-      "at": "2026-03-28T08:58:28Z",
       "hash": "219b3f24929e0866af7e05c36250a267a5f2e952",
+      "at": "2026-03-28T08:58:28Z",
       "passes": 1,
       "pr": 11597
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-pastor-framework.md": {
-      "at": "2026-03-28T08:58:28Z",
       "hash": "229aaf2fa58645152ccdd4ece9d723068b251f4a",
+      "at": "2026-03-28T08:58:28Z",
       "passes": 1,
       "pr": 11597
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md": {
-      "at": "2026-03-28T08:57:56Z",
       "hash": "816a5f35e7ca6b338deae7db62c3058d317b96d6",
+      "at": "2026-03-28T08:57:56Z",
       "passes": 1,
       "pr": 11647
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-01-facebook-instagram.md": {
-      "at": "2026-03-28T08:17:45Z",
       "hash": "4bfed86699b1e5a25050b85f099ca3fc580574d8",
+      "at": "2026-03-28T08:17:45Z",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-02-google-search.md": {
-      "at": "2026-03-28T08:17:45Z",
       "hash": "f9ecc39136c90a2feb8bc9075f3e95ba23fccddd",
+      "at": "2026-03-28T08:17:45Z",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-03-linkedin.md": {
-      "at": "2026-03-28T08:17:45Z",
       "hash": "a3c8015dc17258f154c7bdd4e4ccf0d4586a06db",
+      "at": "2026-03-28T08:17:45Z",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-04-twitter.md": {
-      "at": "2026-03-28T08:17:45Z",
       "hash": "615623c2156bb8eee3a9409900b33a895768e08d",
+      "at": "2026-03-28T08:17:45Z",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-05-reference.md": {
-      "at": "2026-03-28T08:17:45Z",
       "hash": "d34fe0576cb0cb1c1770a278ad5e149bba1480d0",
+      "at": "2026-03-28T08:17:45Z",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy.md": {
-      "at": "2026-03-28T08:17:45Z",
       "hash": "bfc16d8c1bc4e6a8229cc555eba0d72de8ece0d7",
+      "at": "2026-03-28T08:17:45Z",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "fc8601e1d052f928c023da0917367bb21323b4e4",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "658de751f2d88050b16b810d4606b3d70426e4dd",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "ca0ffbbb9d01a944ca038fd7ffed902dedf0c82c",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "5328e2dd6fd579ca0f648b82f3f94b52f56f3baf",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "d207be0ddb3e721786a9a93447bd0110bda97f67",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "0cf9219a719ff218be50f556ea87fe2c1353fea7",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "8b6cccfab9ec08287f4b54ab1e353f28a94a3cdb",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-landing-page.md": {
-      "at": "2026-03-28T13:37:36Z",
       "hash": "cbaa0cc29c6e3639ea5254866f8fefe1c02a329c",
+      "at": "2026-03-28T13:37:36Z",
       "passes": 1,
       "pr": 11840
     },
     ".agents/marketing-sales/direct-response-copy-templates-readme.md": {
-      "at": "2026-03-28T08:17:38Z",
       "hash": "2717d1e9cb1edfd85d932502b6de7c4765c8a7ec",
+      "at": "2026-03-28T08:17:38Z",
       "passes": 1,
       "pr": 11571
     },
     ".agents/marketing-sales/direct-response-copy-templates-vsl-script.md": {
-      "at": "2026-03-28T08:17:46Z",
       "hash": "c8fa5d2f257f52a1d7c9c49ca9d78e6be247623e",
+      "at": "2026-03-28T08:17:46Z",
       "passes": 1,
       "pr": 11591
     },
     ".agents/marketing-sales/direct-response-copy.md": {
-      "at": "2026-03-30T02:30:17Z",
       "hash": "d08a0d186d3944f01e76fe8c2907c1474a7dad30",
+      "at": "2026-03-30T02:30:17Z",
       "passes": 1,
       "pr": 13597
     },
     ".agents/marketing-sales/meta-ads-audiences-first-party-data.md": {
-      "at": "2026-03-28T08:18:20Z",
       "hash": "1ad15971973eec338e831dc24839609eb1f473e3",
+      "at": "2026-03-28T08:18:20Z",
       "passes": 1,
       "pr": 11536
     },
     ".agents/marketing-sales/meta-ads-audiences-retargeting-setup.md": {
-      "at": "2026-03-29T03:15:24Z",
       "hash": "dedfee9605d04b5a7cf9f5563c0e772f06e44062",
+      "at": "2026-03-29T03:15:24Z",
       "passes": 1,
       "pr": 12514
     },
     ".agents/marketing-sales/meta-ads-audiences-targeting-strategies.md": {
-      "at": "2026-03-28T11:20:14Z",
       "hash": "9802f4e7f19b67d5a8a45f1a137209082a585d4c",
+      "at": "2026-03-28T11:20:14Z",
       "passes": 1,
       "pr": 11791
     },
     ".agents/marketing-sales/meta-ads-campaigns-advantage-plus.md": {
-      "at": "2026-03-30T04:52:40Z",
       "hash": "e2a2dc5e7f15a6ce3fdcf4e477dac3ca7db3056f",
+      "at": "2026-03-30T04:52:40Z",
       "passes": 1,
       "pr": 13779
     },
     ".agents/marketing-sales/meta-ads-campaigns-decision-trees.md": {
-      "at": "2026-03-28T04:30:25Z",
       "hash": "a7bcedab8040e2b400b7c2feca987e09bb0a8477",
+      "at": "2026-03-28T04:30:25Z",
       "passes": 1,
       "pr": 11381
     },
     ".agents/marketing-sales/meta-ads-campaigns-retargeting.md": {
-      "at": "2026-03-28T11:52:21Z",
       "hash": "76a66a236cc7fbeb40d74384e9dbe4bd75a4a155",
+      "at": "2026-03-28T11:52:21Z",
       "passes": 1,
       "pr": 11822
     },
     ".agents/marketing-sales/meta-ads-campaigns-scaling-cbo.md": {
-      "at": "2026-03-29T21:42:59Z",
       "hash": "6fb79b1689e522f77f09f4398f80430c8c727116",
+      "at": "2026-03-29T21:42:59Z",
       "passes": 1,
       "pr": 13263
     },
     ".agents/marketing-sales/meta-ads-campaigns-testing-abo.md": {
-      "at": "2026-03-29T01:04:17Z",
       "hash": "be737a2fe12892ef6479a1939cbe4b6fee46db16",
+      "at": "2026-03-29T01:04:17Z",
       "passes": 1,
       "pr": 12395
     },
     ".agents/marketing-sales/meta-ads-checklists-campaign-launch.md": {
-      "at": "2026-04-01T20:59:20Z",
       "hash": "3f199a8eb517a651781b683ec0d6a723fb16d9b0",
+      "at": "2026-04-01T20:59:20Z",
       "passes": 1,
       "pr": 15149
     },
     ".agents/marketing-sales/meta-ads-checklists-creative-review.md": {
-      "at": "2026-03-30T03:33:54Z",
       "hash": "d3207ef474ba73d95bb9c13864b282ac0b78169e",
+      "at": "2026-03-30T03:33:54Z",
       "passes": 1,
       "pr": 13666
     },
     ".agents/marketing-sales/meta-ads-checklists-scaling-checklist.md": {
-      "at": "2026-04-03T01:11:48Z",
       "hash": "790011746194791c3988c38215a06a333438e040",
+      "at": "2026-04-03T01:11:48Z",
       "passes": 1,
       "pr": 15723
     },
     ".agents/marketing-sales/meta-ads-checklists-weekly-review.md": {
-      "at": "2026-03-29T12:36:27Z",
       "hash": "8ddae4fd98efd953d4ecaa242553ad3eda337a92",
+      "at": "2026-03-29T12:36:27Z",
       "passes": 1,
       "pr": 12947
     },
     ".agents/marketing-sales/meta-ads-creative-briefs-founder-video-brief.md": {
-      "at": "2026-03-31T06:30:29Z",
       "hash": "4663b6f4a18ffba178e090fd696bba98f87535b8",
+      "at": "2026-03-31T06:30:29Z",
       "passes": 2,
       "pr": 14701
     },
     ".agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md": {
-      "at": "2026-03-29T15:50:34Z",
       "hash": "cde8788cbf4bf8376449f26888b4823576649256",
+      "at": "2026-03-29T15:50:34Z",
       "passes": 2,
       "pr": 13064
     },
     ".agents/marketing-sales/meta-ads-creative-briefs-ugc-brief.md": {
-      "at": "2026-03-28T21:27:17Z",
       "hash": "b3cbdabb7633b010839689527b084c198f34bdc9",
+      "at": "2026-03-28T21:27:17Z",
       "passes": 1,
       "pr": 12217
     },
     ".agents/marketing-sales/meta-ads-creative-formats.md": {
-      "at": "2026-03-28T06:39:54Z",
       "hash": "f8a4f095bebc852b9ce58976d3b53e418bbe578e",
+      "at": "2026-03-28T06:39:54Z",
       "passes": 1,
       "pr": 11410
     },
     ".agents/marketing-sales/meta-ads-creative-frameworks.md": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "246a973d66f4a046b7479124fd2fba2fdcc35d8d",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15906
     },
     ".agents/marketing-sales/meta-ads-creative-hooks.md": {
-      "at": "2026-03-27T21:25:06Z",
       "hash": "f7c8e3356361a9ab1941f729337bbf7d0f8447ef",
+      "at": "2026-03-27T21:25:06Z",
       "passes": 1,
       "pr": 11016
     },
     ".agents/marketing-sales/meta-ads-creative-psychology.md": {
-      "at": "2026-03-30T04:52:02Z",
       "hash": "6436f438f568834b0e2062a282cce59cc65ec58d",
+      "at": "2026-03-30T04:52:02Z",
       "passes": 1,
       "pr": 13729
     },
     ".agents/marketing-sales/meta-ads-creative-scripts.md": {
-      "at": "2026-03-28T03:10:39Z",
       "hash": "9455fbf07187de24552aa591a8752fd7b3df2480",
+      "at": "2026-03-28T03:10:39Z",
       "passes": 1,
       "pr": 11297
     },
     ".agents/marketing-sales/meta-ads-foundations-account-structure.md": {
-      "at": "2026-03-29T21:43:00Z",
       "hash": "d8a1a11c970efd832edd47784162978ad05783f0",
+      "at": "2026-03-29T21:43:00Z",
       "passes": 1,
       "pr": 13333
     },
     ".agents/marketing-sales/meta-ads-foundations-algorithm.md": {
-      "at": "2026-04-01T20:59:13Z",
       "hash": "318e59fc49106e5aaeeca2d26e666b87b0353d5c",
+      "at": "2026-04-01T20:59:13Z",
       "passes": 1,
       "pr": 15138
     },
     ".agents/marketing-sales/meta-ads-foundations-attribution.md": {
-      "at": "2026-03-29T11:51:45Z",
       "hash": "7bd8755456129fcd79c106e7e829c6233ae16c42",
+      "at": "2026-03-29T11:51:45Z",
       "passes": 1,
       "pr": 12920
     },
     ".agents/marketing-sales/meta-ads-foundations-glossary.md": {
-      "at": "2026-03-30T03:33:50Z",
       "hash": "f0b0b3b259d7597309af03f39a2f267137dafffe",
+      "at": "2026-03-30T03:33:50Z",
       "passes": 1,
       "pr": 13691
     },
     ".agents/marketing-sales/meta-ads-optimization-automation-rules.md": {
-      "at": "2026-03-29T15:50:44Z",
       "hash": "4e78284e12f62b421b7458d171f79117bc4610e9",
+      "at": "2026-03-29T15:50:44Z",
       "passes": 1,
       "pr": 13078
     },
     ".agents/marketing-sales/meta-ads-optimization-metrics.md": {
-      "at": "2026-03-30T06:49:39Z",
       "hash": "99cca533a9d716bf886a24bffbf8255ca5da96a3",
+      "at": "2026-03-30T06:49:39Z",
       "passes": 1,
       "pr": 13940
     },
     ".agents/marketing-sales/meta-ads-optimization-scaling.md": {
-      "at": "2026-03-28T08:17:40Z",
       "hash": "8034babf9a34b6f09f0cce7817a136ee38be0c1f",
+      "at": "2026-03-28T08:17:40Z",
       "passes": 1,
       "pr": 11564
     },
     ".agents/marketing-sales/meta-ads-optimization-troubleshooting.md": {
-      "at": "2026-03-28T08:17:40Z",
       "hash": "684991a0c73063d140b0cfee3ad73691a479a34f",
+      "at": "2026-03-28T08:17:40Z",
       "passes": 1,
       "pr": 11564
     },
     ".agents/marketing-sales/meta-ads.md": {
-      "at": "2026-03-28T16:40:30Z",
       "hash": "19b4754a783dd4b878bb5cf4032420f1cfab931d",
+      "at": "2026-03-28T16:40:30Z",
       "passes": 1,
       "pr": 12024
     },
     ".agents/product/analytics.md": {
-      "at": "2026-03-29T23:53:58Z",
       "hash": "1ecb5ce4743770c3913fae8f41e526f3ba21c6a0",
+      "at": "2026-03-29T23:53:58Z",
       "passes": 1,
       "pr": 13415
     },
     ".agents/product/growth.md": {
-      "at": "2026-03-28T16:40:15Z",
       "hash": "97246dfba596c1be9241c0b669c611df856e71bc",
+      "at": "2026-03-28T16:40:15Z",
       "passes": 1,
       "pr": 12037
     },
     ".agents/product/monetisation.md": {
-      "at": "2026-04-03T01:52:56Z",
       "hash": "335ecd62068e0bc6a3a1e74b01cd823611ba1d54",
+      "at": "2026-04-03T01:52:56Z",
       "passes": 2,
       "pr": 16017
     },
     ".agents/product/onboarding.md": {
-      "at": "2026-03-29T23:54:00Z",
       "hash": "bc634e70e9bb850181c2c4c0d239a36447560921",
+      "at": "2026-03-29T23:54:00Z",
       "passes": 1,
       "pr": 13399
     },
     ".agents/product/ui-design.md": {
-      "at": "2026-03-30T03:34:29Z",
       "hash": "3a8d0daebe80ebc2f64efe31009dbcba324fe142",
+      "at": "2026-03-30T03:34:29Z",
       "passes": 1,
       "pr": 13539
     },
     ".agents/product/validation.md": {
-      "at": "2026-03-29T12:37:13Z",
       "hash": "74840e4aa9e8d619ae82517ca6a1b43a00f99b56",
+      "at": "2026-03-29T12:37:13Z",
       "passes": 1,
       "pr": 12910
     },
     ".agents/prompts/worker-efficiency-protocol.md": {
-      "at": "2026-04-03T01:11:25Z",
       "hash": "c2131a568a446a0555dbc6491084d79991198379",
+      "at": "2026-04-03T01:11:25Z",
       "passes": 2,
       "pr": 14943
     },
     ".agents/reference/agent-routing.md": {
-      "at": "2026-03-31T05:34:14Z",
       "hash": "83e56233f5c7fc633bc3a64de90d9b5529a0bd33",
+      "at": "2026-03-31T05:34:14Z",
       "passes": 1,
       "pr": 14650
     },
     ".agents/reference/auto-update.md": {
-      "at": "2026-04-01T23:23:47Z",
       "hash": "0db7d0a5ebb60bf53cbeb2d88102be373220981c",
+      "at": "2026-04-01T23:23:47Z",
       "passes": 1,
       "pr": 15301
     },
     ".agents/reference/configuration.md": {
-      "at": "2026-03-28T04:30:48Z",
       "hash": "9502faea512b841b7a239e9e3c9cc0188f4fe855",
+      "at": "2026-03-28T04:30:48Z",
       "passes": 1,
       "pr": 11321
     },
     ".agents/reference/contribution-watch.md": {
-      "at": "2026-04-01T23:23:47Z",
       "hash": "77b53dc6bf630c7451cc69425d06aa11f23e727b",
+      "at": "2026-04-01T23:23:47Z",
       "passes": 1,
       "pr": 15301
     },
     ".agents/reference/define-probes/bugfix.md": {
-      "at": "2026-04-01T23:23:39Z",
       "hash": "88ddddb0fc275f73407b492a820bd0f2bfdada99",
+      "at": "2026-04-01T23:23:39Z",
       "passes": 1,
       "pr": 15334
     },
     ".agents/reference/define-probes/feature.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "74a4d468ffc96d6c402a9e74cd5b8a4e81e0d8a2",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16447
     },
     ".agents/reference/define-probes/research.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "ad3ee2324999918fa0fbfca29e13e16fd0f6bb35",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16538
     },
     ".agents/reference/entity-memory-architecture.md": {
-      "at": "2026-04-02T00:00:00Z",
       "hash": "bbd1c42b7e0eb2b01cb5a193f94c5e9ecf98c540",
+      "at": "2026-04-02T00:00:00Z",
       "passes": 1,
       "pr": 15488
     },
     ".agents/reference/foss-contributions.md": {
-      "at": "2026-03-30T02:30:24Z",
       "hash": "9e043ef67bde2d3feb5e15e844f2701bff8c6339",
+      "at": "2026-03-30T02:30:24Z",
       "passes": 1,
       "pr": 13561
     },
     ".agents/reference/hashline-edit-format.md": {
-      "at": "2026-04-01T23:23:50Z",
       "hash": "2f2019c30b4f9bb5d1947e6b7156833f15973c1e",
+      "at": "2026-04-01T23:23:50Z",
       "passes": 1,
       "pr": 15277
     },
     ".agents/reference/high-stakes-operations.md": {
-      "at": "2026-03-27T21:25:17Z",
       "hash": "ba39668c924d2e2d0137c766053513a98a2f2839",
+      "at": "2026-03-27T21:25:17Z",
       "passes": 1,
       "pr": 11012
     },
     ".agents/reference/memory.md": {
-      "at": "2026-03-28T07:37:36Z",
       "hash": "0a7c4c493f3a825b98e2de3928f718fa9095c966",
+      "at": "2026-03-28T07:37:36Z",
       "passes": 1,
       "pr": 11538
     },
     ".agents/reference/orchestration.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "9cdfd8a8b2ea2122f523b7f8fc7d6e496c968c16",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16427
     },
     ".agents/reference/planning-detail.md": {
-      "at": "2026-03-29T08:49:21Z",
       "hash": "c5c616d56a09198023878a228bbf7311f9bd0212",
+      "at": "2026-03-29T08:49:21Z",
       "passes": 1,
       "pr": 12780
     },
     ".agents/reference/platform-support.md": {
-      "at": "2026-04-03T00:48:09Z",
       "hash": "67f8c07f2072f5b15ffae32c07a9e8930a5f7c49",
+      "at": "2026-04-03T00:48:09Z",
       "passes": 1,
       "pr": "GH#16007"
     },
     ".agents/reference/repo-sync.md": {
-      "at": "2026-04-01T23:23:47Z",
       "hash": "e6c2ddc65a495825740608c7c440f8ba49033db5",
+      "at": "2026-04-01T23:23:47Z",
       "passes": 1,
       "pr": 15301
     },
     ".agents/reference/secret-handling.md": {
-      "at": "2026-04-03T02:08:59Z",
       "hash": "2a6c72740cbc53ba42d8f562bde4af3073574974",
+      "at": "2026-04-03T02:08:59Z",
       "passes": 2,
       "pr": 15664
     },
     ".agents/reference/services.md": {
-      "at": "2026-04-01T23:23:47Z",
       "hash": "85309d5014421182d0c22812ec7bb56f2ccc2ab0",
+      "at": "2026-04-01T23:23:47Z",
       "passes": 1,
       "pr": 15301
     },
     ".agents/reference/session.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "b309fad6b7e022fa0499919d57c53d5796dd11e2",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16417
     },
     ".agents/reference/settings.md": {
-      "at": "2026-03-30T03:34:12Z",
       "hash": "2b2cbc9b8329f0fd0504413c4805a235d0f16962",
+      "at": "2026-03-30T03:34:12Z",
       "passes": 1,
       "pr": 13637
     },
     ".agents/research.md": {
-      "at": "2026-04-01T20:59:28Z",
       "hash": "b509e2fae5168065f0142ae29dca1ec2d410c53b",
+      "at": "2026-04-01T20:59:28Z",
       "passes": 1,
       "pr": 14996
     },
     ".agents/scripts/anti-detect-helper.sh": {
-      "at": "2026-04-03T12:15:33Z",
       "hash": "51caf0d510816996bb82f91e466b32d0760e790b",
+      "at": "2026-04-03T12:15:33Z",
       "passes": 1,
       "pr": 16548
     },
     ".agents/scripts/backfill-origin-labels.sh": {
-      "at": "2026-04-02T21:58:18Z",
       "hash": "01d5281e257d4507215400c7311169fd37a39f6e",
+      "at": "2026-04-02T21:58:18Z",
       "passes": 1,
       "pr": 15661
     },
     ".agents/scripts/browser-qa-helper.sh": {
-      "at": "2026-04-03T03:15:27Z",
       "hash": "25b515a9f2777842519da29fbd097585ca4577cc",
+      "at": "2026-04-03T03:15:27Z",
       "passes": 1,
       "pr": 16086
     },
     ".agents/scripts/budget-analysis-helper.sh": {
-      "at": "2026-04-03T03:15:27Z",
       "hash": "349d6023e95be88974de6ac4be3115d3d90b6c14",
+      "at": "2026-04-03T03:15:27Z",
       "passes": 1,
       "pr": 16085
     },
     ".agents/scripts/commands/budget-analysis.md": {
-      "at": "2026-04-01T20:58:50Z",
       "hash": "ac77aaf850ecc1f9cee81c9e04a026a954fc7359",
+      "at": "2026-04-01T20:58:50Z",
       "passes": 1,
       "pr": 15257
     },
     ".agents/scripts/commands/cross-review.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "6ac59e81458dd68a29d1ba81a5d178679d156fcd",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16528
     },
     ".agents/scripts/commands/dashboard.md": {
-      "at": "2026-03-29T21:43:13Z",
       "hash": "c72021fe5b7c20c340b5a5a1e1b66cf6b3d247f9",
+      "at": "2026-03-29T21:43:13Z",
       "passes": 1,
       "pr": 13338
     },
     ".agents/scripts/commands/define.md": {
-      "at": "2026-03-29T17:15:13Z",
       "hash": "228f38c6d509423d7158cef517bbd601a691923d",
+      "at": "2026-03-29T17:15:13Z",
       "passes": 1,
       "pr": 13131
     },
     ".agents/scripts/commands/email-outreach.md": {
-      "at": "2026-04-02T03:11:10Z",
       "hash": "03c6fbfcdc4ba527948102f9b58f5c9bed557777",
+      "at": "2026-04-02T03:11:10Z",
       "passes": 1,
       "pr": 15480
     },
     ".agents/scripts/commands/full-loop.md": {
-      "at": "2026-04-02T14:41:00Z",
       "hash": "bcf22ce3b332f521d77a911b696ec7375d0eabe8",
+      "at": "2026-04-02T14:41:00Z",
       "passes": 3,
       "pr": 14590
     },
     ".agents/scripts/commands/ip-check.md": {
-      "at": "2026-03-31T02:20:51Z",
       "hash": "157dc866ef64f46a91e761875f5346f372c3da72",
+      "at": "2026-03-31T02:20:51Z",
       "passes": 2,
       "pr": 14484
     },
     ".agents/scripts/commands/list-todo.md": {
-      "at": "2026-04-01T20:59:47Z",
       "hash": "351180b6d47cacee5be38fc9e3ec01f7d1fd8661",
+      "at": "2026-04-01T20:59:47Z",
       "passes": 1,
       "pr": 14898
     },
     ".agents/scripts/commands/list-verify.md": {
-      "at": "2026-04-02T04:56:43Z",
       "hash": "dc43be77f9d72dac6880004350a5b63ce9a326f0",
+      "at": "2026-04-02T04:56:43Z",
       "passes": 1,
       "pr": 15514
     },
     ".agents/scripts/commands/log-issue-aidevops.md": {
-      "at": "2026-03-27T21:25:13Z",
       "hash": "24878e7d7abca4cf0b41a18e5dac1977978ec3c1",
+      "at": "2026-03-27T21:25:13Z",
       "passes": 1,
       "pr": 11007
     },
     ".agents/scripts/commands/memory-log.md": {
-      "at": "2026-04-02T21:58:18Z",
       "hash": "0f3be8d344b9ea22cd796e021e3f049e4ccaa75a",
+      "at": "2026-04-02T21:58:18Z",
       "passes": 1,
       "pr": 15701
     },
     ".agents/scripts/commands/mission.md": {
-      "at": "2026-03-29T12:36:32Z",
       "hash": "e13208184cee9ed81fd7f6bddfef98bbcd41b5f5",
+      "at": "2026-03-29T12:36:32Z",
       "passes": 1,
       "pr": 12959
     },
     ".agents/scripts/commands/neuronwriter.md": {
-      "at": "2026-03-29T07:02:53Z",
       "hash": "233c0b9d671275ad8b68ef45c8afaff33acbec34",
+      "at": "2026-03-29T07:02:53Z",
       "passes": 1,
       "pr": 12588
     },
     ".agents/scripts/commands/new-task.md": {
-      "at": "2026-03-30T02:30:59Z",
       "hash": "5a3ec48ed47e180466403ef9011d5d26d44821e5",
+      "at": "2026-03-30T02:30:59Z",
       "passes": 1,
       "pr": 13489
     },
     ".agents/scripts/commands/performance.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "04ce3fd53b737d4f08b6983075a6acd50de3c9a5",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16527
     },
     ".agents/scripts/commands/postflight-loop.md": {
-      "at": "2026-04-01T20:59:31Z",
       "hash": "37a467bf622640eb6c8d75aa2c1de45c9a27c61c",
+      "at": "2026-04-01T20:59:31Z",
       "passes": 1,
       "pr": 14942
     },
     ".agents/scripts/commands/pr-loop.md": {
-      "at": "2026-04-02T21:58:18Z",
       "hash": "5e3ba8395648167005fdf9b47d469849c80188e5",
+      "at": "2026-04-02T21:58:18Z",
       "passes": 1,
       "pr": 15682
     },
     ".agents/scripts/commands/pulse-sweep.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "7212fe6c0a3ad8b8614d656a3fca67fd80d02cc1",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16472
     },
     ".agents/scripts/commands/pulse.md": {
-      "at": "2026-04-02T14:41:03Z",
       "hash": "338273dcb0c9118b1c7cce9c5ddb236fd9d3b078",
+      "at": "2026-04-02T14:41:03Z",
       "passes": 3,
       "pr": 13117
     },
     ".agents/scripts/commands/recall.md": {
-      "at": "2026-04-02T04:56:44Z",
       "hash": "9b0b04b0aeda1a0436139a205db96efcf0e662ad",
+      "at": "2026-04-02T04:56:44Z",
       "passes": 1,
       "pr": 15515
     },
     ".agents/scripts/commands/remember.md": {
-      "at": "2026-03-29T03:14:59Z",
       "hash": "9b17697bde40499a9feacb7812126a6474b0d5d4",
+      "at": "2026-03-29T03:14:59Z",
       "passes": 1,
       "pr": 12497
     },
     ".agents/scripts/commands/route.md": {
-      "at": "2026-03-31T04:45:56Z",
       "hash": "f95b19c17d85e3ff5ff46e93f7bae3252de01308",
+      "at": "2026-03-31T04:45:56Z",
       "passes": 2,
       "pr": 14604
     },
     ".agents/scripts/commands/routine.md": {
-      "at": "2026-03-31T03:14:22Z",
       "hash": "5e9a21d7bf25494b68d2c080b7a1ba28664488cc",
+      "at": "2026-03-31T03:14:22Z",
       "passes": 2,
       "pr": 14509
     },
     ".agents/scripts/commands/runners-check.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "6c6ee913ac0c1d85160533b60b64502c8fcc9cfe",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16418
     },
     ".agents/scripts/commands/runners.md": {
-      "at": "2026-03-28T23:06:00Z",
       "hash": "34d6abef3517f8c104f651d33d960e5c13afec87",
+      "at": "2026-03-28T23:06:00Z",
       "passes": 2,
       "pr": 12326
     },
     ".agents/scripts/commands/save-todo.md": {
-      "at": "2026-03-29T03:15:15Z",
       "hash": "9b4ef4321b1b93eb8d349dbdae3b6c717838135c",
+      "at": "2026-03-29T03:15:15Z",
       "passes": 1,
       "pr": 12521
     },
     ".agents/scripts/commands/security-deps.md": {
-      "at": "2026-04-01T20:59:27Z",
       "hash": "265f2d26f358ffb425e374dca8aa76a7c20c3565",
+      "at": "2026-04-01T20:59:27Z",
       "passes": 1,
       "pr": 14994
     },
     ".agents/scripts/commands/security-history.md": {
-      "at": "2026-04-02T04:56:52Z",
       "hash": "0c74f125bbb3e299040015ee24fb345e43486ec7",
+      "at": "2026-04-02T04:56:52Z",
       "passes": 1,
       "pr": 15487
     },
     ".agents/scripts/commands/security-review.md": {
-      "at": "2026-04-02T21:58:19Z",
       "hash": "8aeebd043a47a280413cacae8697325574b2d88e",
+      "at": "2026-04-02T21:58:19Z",
       "passes": 1,
       "pr": 15535
     },
     ".agents/scripts/commands/seo-analyze.md": {
-      "at": "2026-04-02T21:58:20Z",
       "hash": "04987b0129baab1ebd5f96cfe316cac9222f1b12",
+      "at": "2026-04-02T21:58:20Z",
       "passes": 1,
       "pr": 15502
     },
     ".agents/scripts/commands/seo-audit.md": {
-      "at": "2026-04-02T03:11:11Z",
       "hash": "d8d6dee50a191d538e032247f78abb02ebb504a8",
+      "at": "2026-04-02T03:11:11Z",
       "passes": 1,
       "pr": 15477
     },
     ".agents/scripts/commands/show-plan.md": {
-      "at": "2026-03-29T20:53:58Z",
       "hash": "a50ab6b6bab142d6f388d385dfa6a525b458cac9",
+      "at": "2026-03-29T20:53:58Z",
       "passes": 1,
       "pr": 13285
     },
     ".agents/scripts/commands/skills.md": {
-      "at": "2026-03-29T08:10:30Z",
       "hash": "b5d46b5e38620ec36852251ec0e4ab4178d9d217",
+      "at": "2026-03-29T08:10:30Z",
       "passes": 1,
       "pr": 12747
     },
     ".agents/scripts/commands/strategic-review.md": {
-      "at": "2026-03-29T08:10:38Z",
       "hash": "321755ff5b42109fb2ed065075b903ecfed76407",
+      "at": "2026-03-29T08:10:38Z",
       "passes": 1,
       "pr": 12756
     },
     ".agents/scripts/commands/tech-stack.md": {
-      "at": "2026-04-03T03:15:10Z",
       "hash": "00340ffd42b01d390af29f476c2cae8c2d6a37e4",
-      "issue": 14163,
-      "passes": 2,
-      "pr": null
+      "at": "2026-04-03T03:15:10Z",
+      "passes": 2
     },
     ".agents/scripts/commands/testing-setup.md": {
-      "at": "2026-03-28T16:40:41Z",
       "hash": "f653aacf0e67efffd18058625b81f790e9c9f741",
+      "at": "2026-03-28T16:40:41Z",
       "passes": 1,
       "pr": 12013
     },
     ".agents/scripts/commands/venv-health.md": {
-      "at": "2026-04-02T09:43:51Z",
       "hash": "4d985fc7dfe983440e133ac132e682303ca928e8",
+      "at": "2026-04-02T09:43:51Z",
       "passes": 1,
       "pr": 15577
     },
     ".agents/scripts/commands/worktree-cleanup.md": {
-      "at": "2026-04-02T02:30:00Z",
       "hash": "110dfc59f9c93f01dbf166827f33fc1560b6a7b9",
-      "passes": 1,
-      "pr": null
+      "at": "2026-04-02T02:30:00Z",
+      "passes": 1
     },
     ".agents/scripts/commands/youtube-research.md": {
-      "at": "2026-03-29T08:10:31Z",
       "hash": "340b914ca94d03a0c78878b9ec28534fc761f352",
+      "at": "2026-03-29T08:10:31Z",
       "passes": 1,
       "pr": 12750
     },
     ".agents/scripts/commands/youtube-setup.md": {
-      "at": "2026-03-29T12:37:14Z",
       "hash": "d3f66f792c780e690b58d7f976c01c3d64f09a52",
+      "at": "2026-03-29T12:37:14Z",
       "passes": 1,
       "pr": 12943
     },
     ".agents/scripts/commands/yt-dlp.md": {
-      "at": "2026-03-30T03:34:31Z",
       "hash": "56c400042f899284be4b65c6480fcac4de404248",
+      "at": "2026-03-30T03:34:31Z",
       "passes": 1,
       "pr": 13544
     },
     ".agents/scripts/compare-models-helper.sh": {
-      "at": "2026-04-03T01:11:46Z",
       "hash": "10e52daaafa5297bc348b088923e28bf767b4e73",
+      "at": "2026-04-03T01:11:46Z",
       "passes": 1,
       "pr": 15946
     },
     ".agents/scripts/config-helper.sh": {
-      "at": "2026-04-03T03:15:27Z",
       "hash": "f3835ea3610ca1031ddce938d81d473ed7009710",
+      "at": "2026-04-03T03:15:27Z",
       "passes": 1,
       "pr": 16084
     },
     ".agents/scripts/cron-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "fee68144def6f04b03f8473a0092455cb7056378",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15920
     },
     ".agents/scripts/dataset-helper.sh": {
-      "at": "2026-04-03T03:15:27Z",
       "hash": "96a800ed0595fe0b974acf1c19d27a029d1c49fe",
+      "at": "2026-04-03T03:15:27Z",
       "passes": 1,
       "pr": 16098
     },
     ".agents/scripts/email-agent-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "9d3095a732abae2b4fa11914b1bab89f8d6bc8ba",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15919
     },
     ".agents/scripts/foss-handlers/generic.sh": {
-      "at": "2026-03-29T03:15:47Z",
       "hash": "45cc10462795e6230b70b2f068bb95b4e53612f2",
+      "at": "2026-03-29T03:15:47Z",
       "passes": 1,
       "pr": 12346
     },
     ".agents/scripts/framework-issue-helper.sh": {
-      "at": "2026-04-02T15:26:33Z",
       "hash": "64247677d8764e3ba8355385495671181569267a",
+      "at": "2026-04-02T15:26:33Z",
       "passes": 2,
       "pr": 12145
     },
     ".agents/scripts/generate-runtime-config.sh": {
-      "at": "2026-04-03T16:35:21Z",
       "hash": "ff56186f220b39343595765da7e418fecb7232c1",
+      "at": "2026-04-03T16:35:21Z",
       "passes": 2,
       "pr": 15933
     },
     ".agents/scripts/gh-signature-helper.sh": {
-      "at": "2026-03-29T16:34:26Z",
       "hash": "3dceb47a39cc1230b0f38f697e8cc54a02c27687",
+      "at": "2026-03-29T16:34:26Z",
       "passes": 2,
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "at": "2026-04-03T03:15:11Z",
       "hash": "aa643d9f5040eb0a939f867546feb9668f196057",
+      "at": "2026-04-03T03:15:11Z",
       "passes": 3,
       "pr": 15086
     },
     ".agents/scripts/issue-sync-lib.sh": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "9f29ed93cd738e7aa49fe3c1448f03bfabebc971",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16471
     },
     ".agents/scripts/matrix-dispatch-helper.sh": {
-      "at": "2026-04-02T03:11:00Z",
       "hash": "d42a4c2129d808e3bf1fe78109163f12f059c723",
+      "at": "2026-04-02T03:11:00Z",
       "passes": 1,
       "pr": 15431
     },
     ".agents/scripts/mission-email-helper.sh": {
-      "at": "2026-04-03T03:15:29Z",
       "hash": "59ee94eb2742602d86611ae48998e14befd606f0",
+      "at": "2026-04-03T03:15:29Z",
       "passes": 1,
       "pr": 15752
     },
     ".agents/scripts/opencode-github-setup-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "a5a9852d4feb2de34839b8bbe4db6375babe83a6",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15918
     },
     ".agents/scripts/platform-detect.sh": {
-      "at": "2026-04-02T04:56:59Z",
       "hash": "a551a07e07c08853c909e7b8141ddddf2de43420",
+      "at": "2026-04-02T04:56:59Z",
       "passes": 1,
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "at": "2026-04-03T11:53:54Z",
       "hash": "39d2af5cabcb66409e3bc79504f2462f4163ce9e",
+      "at": "2026-04-03T11:53:54Z",
       "passes": 7,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
-      "at": "2026-04-03T03:15:29Z",
       "hash": "a1a29c0ed6b6f49f88e0a081d88189ac9cce2d00",
+      "at": "2026-04-03T03:15:29Z",
       "passes": 1,
       "pr": 15776
     },
     ".agents/scripts/secretlint-helper.sh": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "ebb41d9b800015f47e367e09caecda5ee7725ab7",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16537
     },
     ".agents/scripts/seo-analysis-helper.sh": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "fe50f85bb1cb9d24286bb37d183b1eafc25ec541",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16536
     },
     ".agents/scripts/session-checkpoint-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "321474cda29aa78eb9bcd25a639a51fd16c62205",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15917
     },
     ".agents/scripts/settings-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "e8d5d7546c1ccdf728fca2c13ee27fd5a64eb8d1",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15916
     },
     ".agents/scripts/stats-functions.sh": {
-      "at": "2026-04-03T01:11:28Z",
       "hash": "3bd327b19cc722f4ddf43fb1f4724958056e11bb",
+      "at": "2026-04-03T01:11:28Z",
       "passes": 4,
       "pr": 11273
     },
     ".agents/scripts/tests/test-gh-signature-helper.sh": {
-      "at": "2026-03-29T13:19:54Z",
       "hash": "14e07889b9a874db8e98e44d1c5a8ed1ac3687fb",
+      "at": "2026-03-29T13:19:54Z",
       "passes": 2,
       "pr": 12971
     },
     ".agents/scripts/tests/test-quality-feedback-main-verification.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "62205e0ccf0e418c5fa92dc447e11e187923ffcf",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15931
     },
     ".agents/scripts/thumbnail-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "c157536da90b2552920287287e391f75b15ccc94",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15905
     },
     ".agents/scripts/video-gen-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "79f7fcd2afb40f9bf21367af3cbb24107da2a7ba",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15904
     },
     ".agents/scripts/watercrawl-helper.sh": {
-      "at": "2026-04-02T22:43:46Z",
       "hash": "27e5853c455180c533e572d91d47769062d78519",
-      "passes": 1,
-      "status": "simplified"
+      "at": "2026-04-02T22:43:46Z",
+      "passes": 1
     },
     ".agents/seo.md": {
-      "at": "2026-03-30T03:34:16Z",
       "hash": "1dcd30f4590e4b2b7792e538d0a70e7d4979aa8e",
+      "at": "2026-03-30T03:34:16Z",
       "passes": 1,
       "pr": 13526
     },
     ".agents/seo/ahrefs.md": {
-      "at": "2026-04-02T03:11:00Z",
       "hash": "68607c6d5bd42845c1fe21cebb00752f6ff8106d",
+      "at": "2026-04-02T03:11:00Z",
       "passes": 1,
       "pr": 15431
     },
     ".agents/seo/ai-agent-discovery.md": {
-      "at": "2026-04-03T11:54:12Z",
       "hash": "b80db727a51fefd4805ea5a64c203cde01dc6712",
+      "at": "2026-04-03T11:54:12Z",
       "passes": 1,
       "pr": 16541
     },
     ".agents/seo/ai-search-kpi-template.md": {
-      "at": "2026-04-01T20:59:36Z",
       "hash": "292c7a69e131309cd9f0ad3c6459f4af1fcfcff4",
+      "at": "2026-04-01T20:59:36Z",
       "passes": 2,
       "pr": 14969
     },
     ".agents/seo/ai-search-readiness.md": {
-      "at": "2026-04-03T01:11:28Z",
       "hash": "4652d2041fcf22b11419930334a44136a3acefe7",
+      "at": "2026-04-03T01:11:28Z",
       "passes": 2,
       "pr": 15496
     },
     ".agents/seo/analytics-tracking.md": {
-      "at": "2026-03-27T21:25:04Z",
       "hash": "07ff0feec55ad3f8477a6badd724b479c1b09370",
+      "at": "2026-03-27T21:25:04Z",
       "passes": 1,
       "pr": 11015
     },
     ".agents/seo/backlink-checker.md": {
-      "at": "2026-04-02T02:14:59Z",
       "hash": "16c0f1f109b8a8d47222978204b1f7b955abaa7d",
-      "passes": 2,
-      "pr": null
+      "at": "2026-04-02T02:14:59Z",
+      "passes": 2
     },
     ".agents/seo/bing-webmaster-tools.md": {
-      "at": "2026-04-03T01:11:29Z",
       "hash": "fb22f3998fd4903c3ff77c9a664f0edb7fe62d1f",
+      "at": "2026-04-03T01:11:29Z",
       "passes": 2,
       "pr": 15532
     },
     ".agents/seo/content-analyzer.md": {
-      "at": "2026-04-02T04:56:49Z",
       "hash": "7972fdccf29515026f0f710dac5f8e1b792e77c5",
+      "at": "2026-04-02T04:56:49Z",
       "passes": 1,
       "pr": 15478
     },
     ".agents/seo/contentking.md": {
-      "at": "2026-03-28T13:37:31Z",
       "hash": "ce7ecac379f3bc6552cf23ad3bd149902b0ace12",
+      "at": "2026-03-28T13:37:31Z",
       "passes": 1,
       "pr": 11845
     },
     ".agents/seo/data-export.md": {
-      "at": "2026-03-27T21:25:21Z",
       "hash": "196b3c4788803c0b2b8d412752d3d262d7e6f8b2",
+      "at": "2026-03-27T21:25:21Z",
       "passes": 1,
       "pr": 11019
     },
     ".agents/seo/dataforseo.md": {
-      "at": "2026-03-28T17:11:12Z",
       "hash": "8dfaad77d57b706e697ab23a2c8ac8a84cf9c6ed",
+      "at": "2026-03-28T17:11:12Z",
       "passes": 1,
       "pr": 12053
     },
     ".agents/seo/debug-favicon.md": {
-      "at": "2026-03-29T22:09:18Z",
       "hash": "045e2c9b649ddcdfcd71fd207f187edc86071587",
+      "at": "2026-03-29T22:09:18Z",
       "passes": 1,
       "pr": 13323
     },
     ".agents/seo/debug-opengraph.md": {
-      "at": "2026-03-28T14:15:42Z",
       "hash": "7ac97dce072fe9fa2c5cc80526b57b3618883608",
+      "at": "2026-03-28T14:15:42Z",
       "passes": 1,
       "pr": 11898
     },
     ".agents/seo/domain-research-api-reference.md": {
-      "at": "2026-03-28T17:11:07Z",
       "hash": "52e574da550501d13cf7d760d098926843d5260b",
+      "at": "2026-03-28T17:11:07Z",
       "passes": 1,
       "pr": 12056
     },
     ".agents/seo/domain-research.md": {
-      "at": "2026-03-28T17:11:08Z",
       "hash": "18f017104a97c94157077b8fc620e24bad8f86ba",
+      "at": "2026-03-28T17:11:08Z",
       "passes": 1,
       "pr": 12056
     },
     ".agents/seo/eeat-score.md": {
-      "at": "2026-03-28T20:56:08Z",
       "hash": "bb9c0e98f32d0453eb08cbbb4222f06c1a13b007",
+      "at": "2026-03-28T20:56:08Z",
       "passes": 1,
       "pr": 12181
     },
     ".agents/seo/google-search-console.md": {
-      "at": "2026-03-30T06:49:36Z",
       "hash": "525712f74fe9ec13980ef0564a2108481e894038",
+      "at": "2026-03-30T06:49:36Z",
       "passes": 1,
       "pr": 13900
     },
     ".agents/seo/gsc-sitemaps.md": {
-      "at": "2026-03-28T11:52:39Z",
       "hash": "7154caa038f21e800f7b6c5493f2553a9d7e8efb",
+      "at": "2026-03-28T11:52:39Z",
       "passes": 1,
       "pr": 11821
     },
     ".agents/seo/image-seo.md": {
-      "at": "2026-03-30T03:34:23Z",
       "hash": "91991eb82fa32f9ed717213566d5bb49604dfdc4",
+      "at": "2026-03-30T03:34:23Z",
       "passes": 1,
       "pr": 13530
     },
     ".agents/seo/keyword-mapper.md": {
-      "at": "2026-04-02T05:10:00Z",
       "hash": "028f3ad361b1ba3e37e1839edb0dfec17369c3d5",
-      "passes": 1,
-      "pr": null
+      "at": "2026-04-02T05:10:00Z",
+      "passes": 1
     },
     ".agents/seo/keyword-research.md": {
-      "at": "2026-03-28T21:27:18Z",
       "hash": "d00bca2d9a784bfd220b4afd767d384d83bea740",
+      "at": "2026-03-28T21:27:18Z",
       "passes": 1,
       "pr": 12220
     },
     ".agents/seo/mom-test-ux.md": {
-      "at": "2026-03-30T03:34:17Z",
       "hash": "29c796f48c4b581197f9ea36ed95bbe98bb4ae51",
+      "at": "2026-03-30T03:34:17Z",
       "passes": 1,
       "pr": 13524
     },
     ".agents/seo/moondream.md": {
-      "at": "2026-03-30T03:33:44Z",
       "hash": "e6e0bef21020b260c31561b4da9fc0ef1e900be5",
+      "at": "2026-03-30T03:33:44Z",
       "passes": 1,
       "pr": 13663
     },
     ".agents/seo/neuronwriter.md": {
-      "at": "2026-03-28T03:54:21Z",
       "hash": "e6d78a192db4a98186ff9a1f428a07d6455ba42a",
+      "at": "2026-03-28T03:54:21Z",
       "passes": 1,
       "pr": 11350
     },
     ".agents/seo/programmatic-seo.md": {
-      "at": "2026-04-02T21:20:03Z",
       "hash": "cc9aa2cac637f165854122e6b4328e70a7ee3850",
+      "at": "2026-04-02T21:20:03Z",
       "passes": 2,
       "pr": 13301
     },
     ".agents/seo/query-fanout-research.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "314f90ae6018e6e5f2796d7ce877453187bb6c29",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16495
     },
     ".agents/seo/rich-results.md": {
-      "at": "2026-04-02T22:44:04Z",
       "hash": "96226173e887aebf71287a803541f50f5b89d1c8",
+      "at": "2026-04-02T22:44:04Z",
       "passes": 1,
       "pr": 15665
     },
     ".agents/seo/semrush.md": {
-      "at": "2026-03-27T21:25:11Z",
       "hash": "cc61832322267a222c9e557b04459de4a3520086",
+      "at": "2026-03-27T21:25:11Z",
       "passes": 1,
       "pr": 11006
     },
     ".agents/seo/seo-audit-skill.md": {
-      "at": "2026-03-29T12:37:05Z",
       "hash": "d8493f42e8ba01527667d283942af955218a834f",
+      "at": "2026-03-29T12:37:05Z",
       "passes": 1,
       "pr": 12948
     },
     ".agents/seo/seo-audit-skill/aeo-geo-patterns.md": {
-      "at": "2026-04-02T21:20:03Z",
       "hash": "2238ceff37db82a81a9939c6d2217c5b7659a551",
+      "at": "2026-04-02T21:20:03Z",
       "passes": 2,
       "pr": 0
     },
     ".agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md": {
-      "at": "2026-04-02T21:58:19Z",
       "hash": "b7d6d4111324b39cbd5d0615343881696d760822",
+      "at": "2026-04-02T21:58:19Z",
       "passes": 1,
       "pr": 15568
     },
     ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
-      "at": "2026-03-29T23:53:50Z",
       "hash": "b875488af36564292b08b0bcfabae97d18757135",
+      "at": "2026-03-29T23:53:50Z",
       "passes": 1,
       "pr": 13444
     },
     ".agents/seo/seo-regex.md": {
-      "at": "2026-03-29T22:09:17Z",
       "hash": "b38e6b1002b80227940c036badb462c8add23514",
+      "at": "2026-03-29T22:09:17Z",
       "passes": 1,
       "pr": 13325
     },
     ".agents/seo/site-crawler.md": {
-      "at": "2026-03-28T08:58:48Z",
       "hash": "b57ba3a5214383ec97ea5c4838fabcd0ce900a20",
+      "at": "2026-03-28T08:58:48Z",
       "passes": 1,
       "pr": 11598
     },
     ".agents/seo/tech-stack.md": {
-      "at": "2026-03-30T03:34:18Z",
       "hash": "8b3aa2ab4498e38424d9bd911680bf2e6d45d856",
+      "at": "2026-03-30T03:34:18Z",
       "passes": 1,
       "pr": 13531
     },
     ".agents/services/accounting/quickfile.md": {
-      "at": "2026-03-29T07:02:24Z",
       "hash": "db7040cc4f46334177d39ff45c6d4fd3be9698ee",
+      "at": "2026-03-29T07:02:24Z",
       "passes": 1,
       "pr": 12699
     },
     ".agents/services/analytics/google-analytics.md": {
-      "at": "2026-03-29T12:36:33Z",
       "hash": "ee41c3c82de9e7f7dfa997caf2efea635a61fd7f",
+      "at": "2026-03-29T12:36:33Z",
       "passes": 1,
       "pr": 12950
     },
     ".agents/services/communications/bitchat.md": {
-      "at": "2026-03-29T20:53:59Z",
       "hash": "38ac38ee1cb82fb462fc13746fbf560042e6e9a7",
+      "at": "2026-03-29T20:53:59Z",
       "passes": 1,
       "pr": 13287
     },
     ".agents/services/communications/convos-bridge-template.sh": {
-      "at": "2026-03-28T08:57:52Z",
       "hash": "cd850bc9a35a947206c1a4cf2e67313bb90f9644",
+      "at": "2026-03-28T08:57:52Z",
       "passes": 1,
       "pr": 11688
     },
     ".agents/services/communications/convos.md": {
-      "at": "2026-03-28T08:57:52Z",
       "hash": "74e396568b01688f29f86d799f049f5b624b9205",
+      "at": "2026-03-28T08:57:52Z",
       "passes": 1,
       "pr": 11688
     },
     ".agents/services/communications/discord.md": {
-      "at": "2026-03-28T03:53:47Z",
       "hash": "44cce31bf11bd980e6b95270c913477c86348a15",
+      "at": "2026-03-28T03:53:47Z",
       "passes": 1,
       "pr": 11287
     },
     ".agents/services/communications/google-chat.md": {
-      "at": "2026-04-03T01:11:30Z",
       "hash": "10fb2a539fb61865c4a9d813c68d69ea1ded5051",
+      "at": "2026-04-03T01:11:30Z",
       "passes": 2,
       "pr": 13658
     },
     ".agents/services/communications/imessage.md": {
-      "at": "2026-03-30T00:32:20Z",
       "hash": "b16a496c6e98ffbb24f9a833e5b39e9566fb3f6b",
+      "at": "2026-03-30T00:32:20Z",
       "passes": 2,
       "pr": 13468
     },
     ".agents/services/communications/matrix-bot.md": {
-      "at": "2026-04-03T01:11:47Z",
       "hash": "92784be52960e2b9738999d8c725a442cd3d5897",
+      "at": "2026-04-03T01:11:47Z",
       "passes": 1,
       "pr": 15801
     },
     ".agents/services/communications/matterbridge.md": {
-      "at": "2026-03-29T01:04:18Z",
       "hash": "10f123307b4f6919f65b9c46a2e9b5aecf37ef37",
+      "at": "2026-03-29T01:04:18Z",
       "passes": 1,
       "pr": 12399
     },
     ".agents/services/communications/msteams.md": {
-      "at": "2026-03-28T03:54:15Z",
       "hash": "9818d1daccf3f68d103ecba204aa56431dba6514",
+      "at": "2026-03-28T03:54:15Z",
       "passes": 1,
       "pr": 11346
     },
     ".agents/services/communications/nextcloud-talk.md": {
-      "at": "2026-03-28T03:54:35Z",
       "hash": "830399729c8d83ca4263bbf736ea549534989f63",
+      "at": "2026-03-28T03:54:35Z",
       "passes": 1,
       "pr": 11360
     },
     ".agents/services/communications/nostr.md": {
-      "at": "2026-03-28T09:17:35Z",
       "hash": "eacafb8b13831574c6bc570c06903e15e7acd077",
+      "at": "2026-03-28T09:17:35Z",
       "passes": 1,
       "pr": 11715
     },
     ".agents/services/communications/privacy-comparison.md": {
-      "at": "2026-03-28T20:16:54Z",
       "hash": "d36b5a85b507a958a555b6311d3266035d619ba8",
+      "at": "2026-03-28T20:16:54Z",
       "passes": 1,
       "pr": 12169
     },
     ".agents/services/communications/signal.md": {
-      "at": "2026-03-28T08:58:53Z",
       "hash": "652f531e6f54f9fd38da5c5bd61889672eac4acf",
+      "at": "2026-03-28T08:58:53Z",
       "passes": 1,
       "pr": 11620
     },
     ".agents/services/communications/simplex.md": {
-      "at": "2026-03-28T20:16:50Z",
       "hash": "0fae9edf453dabb06fafed112e578d6f45e0f96c",
+      "at": "2026-03-28T20:16:50Z",
       "passes": 1,
       "pr": 12168
     },
     ".agents/services/communications/slack.md": {
-      "at": "2026-03-30T03:34:27Z",
       "hash": "4894b60910b9fe85ce8dcfb7feb5441fca48be44",
+      "at": "2026-03-30T03:34:27Z",
       "passes": 1,
       "pr": 13545
     },
     ".agents/services/communications/telegram.md": {
-      "at": "2026-03-28T21:58:54Z",
       "hash": "96307f35314ef975fc24bfc8ea3098ac307e2373",
+      "at": "2026-03-28T21:58:54Z",
       "passes": 1,
       "pr": 12233
     },
     ".agents/services/communications/telfon.md": {
-      "at": "2026-03-31T04:46:03Z",
       "hash": "bcfbcb400a28970ede2e7ba64abe188935fc887c",
+      "at": "2026-03-31T04:46:03Z",
       "passes": 2,
       "pr": 14595
     },
     ".agents/services/communications/twilio.md": {
-      "at": "2026-03-28T14:15:37Z",
       "hash": "e0541a43f7a10413213681c64f35a4bfd4dd6616",
+      "at": "2026-03-28T14:15:37Z",
       "passes": 1,
       "pr": 11900
     },
     ".agents/services/communications/urbit.md": {
-      "at": "2026-03-29T12:37:15Z",
       "hash": "dc74bf7135da0ba31e070bedbe6be841d6b9588b",
+      "at": "2026-03-29T12:37:15Z",
       "passes": 1,
       "pr": 12911
     },
     ".agents/services/communications/whatsapp.md": {
-      "at": "2026-03-29T12:37:29Z",
       "hash": "dbc5cdbcdc61a880b5ca1c2746408002cc6fa7ac",
+      "at": "2026-03-29T12:37:29Z",
       "passes": 1,
       "pr": 12821
     },
     ".agents/services/communications/xmtp.md": {
-      "at": "2026-03-27T21:25:14Z",
       "hash": "0b5b1bb178865dc7efff9f7578cd26dd9bf82bc9",
+      "at": "2026-03-27T21:25:14Z",
       "passes": 1,
       "pr": 11009
     },
     ".agents/services/crm/fluentcrm.md": {
-      "at": "2026-03-29T15:51:03Z",
       "hash": "9e0e2c55d608f6cc55ceec5f45e845bbbc841b0c",
+      "at": "2026-03-29T15:51:03Z",
       "passes": 1,
       "pr": 13048
     },
     ".agents/services/database/multi-org-isolation.md": {
-      "at": "2026-03-28T21:59:22Z",
       "hash": "2a09353ed9cbb973b0dd0344a938412bcc5b859e",
+      "at": "2026-03-28T21:59:22Z",
       "passes": 1,
       "pr": 12249
     },
     ".agents/services/database/postgres-drizzle-skill.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "9ccc5e6c2d06382573e726d3c7e45799e772c7ab",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16450
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
-      "at": "2026-03-31T00:00:00Z",
       "hash": "a42215bc7cdaff6daffe3ca6b1932ffe029b1507",
+      "at": "2026-03-31T00:00:00Z",
       "passes": 1,
       "pr": 14577
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md": {
-      "at": "2026-03-31T06:23:12Z",
       "hash": "084644aa5375c89ba69717a690c579d6076d532e",
+      "at": "2026-03-31T06:23:12Z",
       "passes": 2,
       "pr": 14691
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md": {
-      "at": "2026-04-02T00:00:00Z",
       "hash": "1aa15519d959c89c0e09c3e30ac0210d6da35134",
+      "at": "2026-04-02T00:00:00Z",
       "passes": 1,
       "pr": 0
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
-      "at": "2026-03-28T10:27:24Z",
       "hash": "2bf913e1887714fccd8b5baaf92a9c4afd0eaf44",
+      "at": "2026-03-28T10:27:24Z",
       "passes": 2,
       "pr": 11709
     },
     ".agents/services/database/postgres-drizzle-skill/migrations.md": {
-      "at": "2026-03-28T16:00:44Z",
       "hash": "1b9f3f2536dd65950e7eec906f4c44467b9619e8",
+      "at": "2026-03-28T16:00:44Z",
       "passes": 1,
       "pr": 11966
     },
     ".agents/services/database/postgres-drizzle-skill/performance-caching.md": {
-      "at": "2026-03-29T15:08:44Z",
       "hash": "8c834b7d97111cfa9897297aa73c2ef3b366bf16",
+      "at": "2026-03-29T15:08:44Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-explain.md": {
-      "at": "2026-03-29T15:08:44Z",
       "hash": "230ed08a521dea04c78c68e8f7e5eab11f68ea65",
+      "at": "2026-03-29T15:08:44Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-indexing.md": {
-      "at": "2026-03-29T15:08:44Z",
       "hash": "982123000c56dcfb6394064ab6d5ad13a0603dbb",
+      "at": "2026-03-29T15:08:44Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-monitoring.md": {
-      "at": "2026-03-29T15:08:44Z",
       "hash": "38276dd264af6fef1c634f2620d188483aec50be",
+      "at": "2026-03-29T15:08:44Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-pagination.md": {
-      "at": "2026-03-29T15:08:44Z",
       "hash": "7e533ff31428e865c8c608139b2835b146164832",
+      "at": "2026-03-29T15:08:44Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-pooling.md": {
-      "at": "2026-03-29T15:08:45Z",
       "hash": "470b2b768f6fff6d4e925000ec0026254511ea0e",
+      "at": "2026-03-29T15:08:45Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-queries.md": {
-      "at": "2026-03-29T15:08:45Z",
       "hash": "3caacdf6f9053841bd7863c9f7dc002a8b784d1e",
+      "at": "2026-03-29T15:08:45Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance.md": {
-      "at": "2026-03-29T15:08:45Z",
       "hash": "8d3a6869182b857eedccac3ed7f13229f52abd06",
+      "at": "2026-03-29T15:08:45Z",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/postgres.md": {
-      "at": "2026-03-28T05:50:57Z",
       "hash": "2633ce6d2343b370a13a3efea1ed735544a6883a",
+      "at": "2026-03-28T05:50:57Z",
       "passes": 1,
       "pr": 11448
     },
     ".agents/services/database/postgres-drizzle-skill/queries.md": {
-      "at": "2026-03-28T06:40:05Z",
       "hash": "0b8efee41f97c3674fd60bda302f1d674e557b07",
+      "at": "2026-03-28T06:40:05Z",
       "passes": 2,
       "pr": 11416
     },
     ".agents/services/database/postgres-drizzle-skill/relations.md": {
-      "at": "2026-03-28T09:48:57Z",
       "hash": "673a7c2abd65766f454b57e79a259a7217463210",
+      "at": "2026-03-28T09:48:57Z",
       "passes": 1,
       "pr": 11717
     },
     ".agents/services/database/postgres-drizzle-skill/schema.md": {
-      "at": "2026-03-28T10:27:24Z",
       "hash": "ed1952db54651cd46710ca9cfa4db950635e42a6",
+      "at": "2026-03-28T10:27:24Z",
       "passes": 1,
       "pr": 11709
     },
     ".agents/services/document-processing/unstract.md": {
-      "at": "2026-03-30T04:51:58Z",
       "hash": "23759f7d870be0bbd07442ac06a3d7b069c8984b",
+      "at": "2026-03-30T04:51:58Z",
       "passes": 1,
       "pr": 13720
     },
     ".agents/services/email/email-actions.md": {
-      "at": "2026-03-28T16:40:11Z",
       "hash": "6e4fd843160e764848c98da37b2234e11ddfa56d",
+      "at": "2026-03-28T16:40:11Z",
       "passes": 1,
       "pr": 12039
     },
     ".agents/services/email/email-agent.md": {
-      "at": "2026-03-28T20:16:44Z",
       "hash": "4c589d1b951ae82f8dbb4a9e7ff05235f5edc6db",
+      "at": "2026-03-28T20:16:44Z",
       "passes": 1,
       "pr": 12163
     },
     ".agents/services/email/email-composition.md": {
-      "at": "2026-03-30T06:03:17Z",
       "hash": "56336d402a38bf2eaa4d3bb6eebb2ad4dd5cfae7",
+      "at": "2026-03-30T06:03:17Z",
       "passes": 1,
       "pr": 13837
     },
     ".agents/services/email/email-delivery-test.md": {
-      "at": "2026-03-28T16:40:17Z",
       "hash": "229f4a8a141175830e0207dbb58b13d9146b22ab",
+      "at": "2026-03-28T16:40:17Z",
       "passes": 1,
       "pr": 12041
     },
     ".agents/services/email/email-design-test.md": {
-      "at": "2026-03-29T22:09:19Z",
       "hash": "216d3927030caa28089c7500c2f6b81c62897d17",
+      "at": "2026-03-29T22:09:19Z",
       "passes": 1,
       "pr": 13324
     },
     ".agents/services/email/email-health-check.md": {
-      "at": "2026-03-30T02:30:20Z",
       "hash": "90bf30c90e853d26d994e61072f794f88aed2547",
+      "at": "2026-03-30T02:30:20Z",
       "passes": 1,
       "pr": 13593
     },
     ".agents/services/email/email-inbound-commands.md": {
-      "at": "2026-04-03T01:11:48Z",
       "hash": "2d55a1a765cc4b287e8e8cdbcf1eabf5d50bb4aa",
+      "at": "2026-04-03T01:11:48Z",
       "passes": 1,
       "pr": 15725
     },
     ".agents/services/email/email-intelligence.md": {
-      "at": "2026-03-29T12:37:18Z",
       "hash": "4046abd7e9e4fffe477b2aa6fedd74cc46fb9708",
+      "at": "2026-03-29T12:37:18Z",
       "passes": 1,
       "pr": 12912
     },
     ".agents/services/email/email-mailbox-search.md": {
-      "at": "2026-03-28T13:37:26Z",
       "hash": "26c7c333d46a5319b598173b36c5c30124126c81",
+      "at": "2026-03-28T13:37:26Z",
       "passes": 1,
       "pr": 11869
     },
     ".agents/services/email/email-mailbox.md": {
-      "at": "2026-03-29T07:02:18Z",
       "hash": "e9ff02135b83557f59c4e444ef2f07607516b341",
+      "at": "2026-03-29T07:02:18Z",
       "passes": 1,
       "pr": 12624
     },
     ".agents/services/email/email-providers.md": {
-      "at": "2026-03-30T06:49:37Z",
       "hash": "db4bc27307dd0943c67b08ac0ae471a009076a72",
+      "at": "2026-03-30T06:49:37Z",
       "passes": 2,
       "pr": 13859
     },
     ".agents/services/email/email-security.md": {
-      "at": "2026-03-29T21:43:14Z",
       "hash": "933383c81c9e820f3d3b80f5dbd3db61d496e0cb",
+      "at": "2026-03-29T21:43:14Z",
       "passes": 1,
       "pr": 13343
     },
     ".agents/services/email/email-testing.md": {
-      "at": "2026-04-03T11:53:57Z",
       "hash": "a1418e2412a8303a5c7aa1cba579a4e1fba0d55b",
+      "at": "2026-04-03T11:53:57Z",
       "passes": 2,
       "pr": 15839
     },
     ".agents/services/email/email-verification.md": {
-      "at": "2026-03-31T09:57:12Z",
       "hash": "b75a2e2fa651e6f7facb266e4d357338c997ced7",
+      "at": "2026-03-31T09:57:12Z",
       "passes": 2,
       "pr": 14757
     },
     ".agents/services/email/google-workspace.md": {
-      "at": "2026-03-28T08:58:52Z",
       "hash": "d25ed82148411a5ce44101400e445cb3293c4e96",
+      "at": "2026-03-28T08:58:52Z",
       "passes": 1,
       "pr": 11613
     },
     ".agents/services/email/letter-post-bridge.md": {
-      "at": "2026-03-31T05:33:36Z",
       "hash": "f6065bec96f8cb306e39fe1862b7bf456e1901d3",
+      "at": "2026-03-31T05:33:36Z",
       "passes": 1,
       "pr": 14646
     },
     ".agents/services/email/microsoft-graph.md": {
-      "at": "2026-03-28T21:27:21Z",
       "hash": "953bb07aef8c8ed23c023cc574b6390196e3b16d",
+      "at": "2026-03-28T21:27:21Z",
       "passes": 1,
       "pr": 12218
     },
     ".agents/services/email/mission-email.md": {
-      "at": "2026-03-28T13:37:15Z",
       "hash": "bf5446200b94e750fce11fc719c2904f47bd67c5",
+      "at": "2026-03-28T13:37:15Z",
       "passes": 1,
       "pr": 11889
     },
     ".agents/services/email/openpgp-setup.md": {
-      "at": "2026-03-28T16:40:18Z",
       "hash": "f893cd98da28874d714707765c45a895d991cede",
+      "at": "2026-03-28T16:40:18Z",
       "passes": 1,
       "pr": 12040
     },
     ".agents/services/email/ses.md": {
-      "at": "2026-04-03T11:53:57Z",
       "hash": "b00aba2448dd10e6ca6ac80203a0497e5d95d02e",
-      "issue": "GH#16498",
+      "at": "2026-04-03T11:53:57Z",
       "passes": 2,
-      "pr": "pending",
-      "status": "simplified"
+      "pr": "pending"
     },
     ".agents/services/email/smime-setup.md": {
-      "at": "2026-03-30T06:50:00Z",
       "hash": "f83bb719e349bb600df046eccc7c1c5603c330f0",
+      "at": "2026-03-30T06:50:00Z",
       "passes": 1,
       "pr": 13915
     },
     ".agents/services/email/thunderbird.md": {
-      "at": "2026-03-29T07:02:32Z",
       "hash": "97b29677f0dc7c7542e4fb7c2e3dc10bc5445489",
+      "at": "2026-03-29T07:02:32Z",
       "passes": 1,
       "pr": 12582
     },
     ".agents/services/hosting/101domains.md": {
-      "at": "2026-03-28T08:18:27Z",
       "hash": "504d151b93c6073272de3fca00e08e6118720cf9",
+      "at": "2026-03-28T08:18:27Z",
       "passes": 1,
       "pr": 11633
     },
     ".agents/services/hosting/closte.md": {
-      "at": "2026-03-28T21:27:23Z",
       "hash": "a9295d1bd4b72a378606ad987d9ea3d5385734c8",
+      "at": "2026-03-28T21:27:23Z",
       "passes": 1,
       "pr": 12219
     },
     ".agents/services/hosting/cloudflare-platform-skill.md": {
-      "at": "2026-03-28T20:16:45Z",
       "hash": "6008b298c541d6b044eb0779f76074b818140d27",
+      "at": "2026-03-28T20:16:45Z",
       "passes": 1,
       "pr": 12162
     },
     ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md": {
-      "at": "2026-04-02T14:41:30Z",
       "hash": "1baef9315a8b2ef04fb8c54a9a13c9490104f568",
+      "at": "2026-04-02T14:41:30Z",
       "passes": 4,
       "pr": 15053
     },
     ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md": {
-      "at": "2026-04-02T21:20:06Z",
       "hash": "b253668b96ea394b289fba6ee03f12b30a041540",
+      "at": "2026-04-02T21:20:06Z",
       "passes": 2,
       "pr": 0
     },
     ".agents/services/hosting/cloudflare-platform-skill/ai-gateway.md": {
-      "at": "2026-03-28T05:50:52Z",
       "hash": "720c2836fca088d027ac637f8c69e97cb3c2764a",
+      "at": "2026-03-28T05:50:52Z",
       "passes": 1,
       "pr": 11443
     },
     ".agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "d023e1ac72a2f29b7e821a93ece163726b419a77",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16481
     },
     ".agents/services/hosting/cloudflare-platform-skill/bot-management-gotchas.md": {
-      "at": "2026-04-02T12:50:00Z",
       "hash": "b2899f138eb2c8f2acfea6aea0d2aa0f274ee4a4",
+      "at": "2026-04-02T12:50:00Z",
       "passes": 1,
       "pr": 15047
     },
     ".agents/services/hosting/cloudflare-platform-skill/c3.md": {
-      "at": "2026-03-28T15:30:18Z",
       "hash": "6ffc77f50024207bbb549b337789b8c9cbd8f475",
+      "at": "2026-03-28T15:30:18Z",
       "passes": 1,
       "pr": 11962
     },
     ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-gotchas.md": {
-      "at": "2026-03-29T22:09:42Z",
       "hash": "2d19b3d0375bc8ceb48e769e353db722cab18283",
+      "at": "2026-03-29T22:09:42Z",
       "passes": 2,
       "pr": 13253
     },
     ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md": {
-      "at": "2026-03-29T08:49:23Z",
       "hash": "dd2e25d9b8dbb4578e676187c9463404feaa3fec",
+      "at": "2026-03-29T08:49:23Z",
       "passes": 1,
       "pr": 12779
     },
     ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md": {
-      "at": "2026-04-03T01:11:32Z",
       "hash": "cf1846a80d91d8b99d83e135da0b5b13c80ef9b7",
+      "at": "2026-04-03T01:11:32Z",
       "passes": 3,
       "pr": 15606
     },
     ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md": {
-      "at": "2026-04-03T00:57:59Z",
       "hash": "61a700349adcfc92119244d456e2e601cbc2f926",
+      "at": "2026-04-03T00:57:59Z",
       "passes": 3,
       "pr": 16020
     },
     ".agents/services/hosting/cloudflare-platform-skill/cron-triggers.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "dfabe33774ae17284c3ede934ec994d82ed3d324",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16445
     },
     ".agents/services/hosting/cloudflare-platform-skill/d1-patterns.md": {
-      "at": "2026-03-29T21:43:01Z",
       "hash": "8e6341f6f72cefdc4c09224910c1c4efe62de068",
+      "at": "2026-03-29T21:43:01Z",
       "passes": 1,
       "pr": 13296
     },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-gotchas.md": {
-      "at": "2026-04-02T21:20:06Z",
       "hash": "f9bc5ae56912b9413ffb35a31dfdca00d42513cb",
+      "at": "2026-04-02T21:20:06Z",
       "passes": 2,
       "pr": 0
     },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-      "at": "2026-03-30T02:30:53Z",
       "hash": "d94a33ca854e976d5ef5819ab6a04b4710d7c710",
+      "at": "2026-03-30T02:30:53Z",
       "passes": 1,
       "pr": 13494
     },
     ".agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md": {
-      "at": "2026-04-03T01:53:26Z",
       "hash": "de83d5b4810ce96bd8858b825346224e73282531",
+      "at": "2026-04-03T01:53:26Z",
       "passes": 1,
       "pr": 15694
     },
     ".agents/services/hosting/cloudflare-platform-skill/do-storage.md": {
-      "at": "2026-04-02T21:58:19Z",
       "hash": "7652036224eb9bb0199c584f61a0a6631902a0ff",
+      "at": "2026-04-02T21:58:19Z",
       "passes": 1,
       "pr": 15569
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects-gotchas.md": {
-      "at": "2026-03-29T11:19:55Z",
       "hash": "befbfbdf1c28bab3d56f52fb86b4a85a7a988da5",
+      "at": "2026-03-29T11:19:55Z",
       "passes": 1,
       "pr": 12890
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md": {
-      "at": "2026-03-28T21:50:53Z",
       "hash": "70f6f1b16aeb637c122232aa75b789bedfbe63a7",
+      "at": "2026-03-28T21:50:53Z",
       "passes": 1,
       "pr": 12192
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects.md": {
-      "at": "2026-04-03T11:53:58Z",
       "hash": "e8ac0cdd603c8c601800af32bfb9edf40918c0f5",
+      "at": "2026-04-03T11:53:58Z",
       "passes": 2,
       "pr": 15663
     },
     ".agents/services/hosting/cloudflare-platform-skill/email-workers.md": {
-      "at": "2026-03-29T03:15:00Z",
       "hash": "d43b669b4be0f3b85ad9b1e95ff67189431eafdc",
+      "at": "2026-03-29T03:15:00Z",
       "passes": 1,
       "pr": 12502
     },
     ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md": {
-      "at": "2026-04-03T04:23:06Z",
       "hash": "1c4911a4c8e9ea1e720fdeddd4bcb9c806e35834",
+      "at": "2026-04-03T04:23:06Z",
       "passes": 1,
       "pr": 15925
     },
     ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "c8ef92c95d372bb1e4aa7a8a4a6a5f4c10f8ea6e",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16441
     },
     ".agents/services/hosting/cloudflare-platform-skill/hyperdrive.md": {
-      "at": "2026-04-02T04:56:50Z",
       "hash": "1a63158e184bf8c3c6ac2f4b5110e44451c5d837",
+      "at": "2026-04-02T04:56:50Z",
       "passes": 1,
       "pr": 15481
     },
     ".agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md": {
-      "at": "2026-04-03T11:53:58Z",
       "hash": "3a79a0d94e7609e38b0135f9dba6400beab1f576",
+      "at": "2026-04-03T11:53:58Z",
       "passes": 2,
       "pr": 15645
     },
     ".agents/services/hosting/cloudflare-platform-skill/kv-patterns.md": {
-      "at": "2026-03-29T22:09:11Z",
       "hash": "7637914de409bb05cee56b57db714972a922dbbb",
+      "at": "2026-03-29T22:09:11Z",
       "passes": 1,
       "pr": 13321
     },
     ".agents/services/hosting/cloudflare-platform-skill/miniflare-gotchas.md": {
-      "at": "2026-03-29T07:02:46Z",
       "hash": "c2a8232a749da0976495eabf4ea541b52bae82f8",
+      "at": "2026-03-29T07:02:46Z",
       "passes": 1,
       "pr": 12586
     },
     ".agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md": {
-      "at": "2026-03-29T14:29:37Z",
       "hash": "304f6cf07b8e1ce2ccf0991e5a1c7a048d898f2b",
+      "at": "2026-03-29T14:29:37Z",
       "passes": 1,
       "pr": 13020
     },
     ".agents/services/hosting/cloudflare-platform-skill/miniflare.md": {
-      "at": "2026-04-02T21:58:19Z",
       "hash": "4471ddd0229e26f2af30d5833d95c9a1f0261dac",
+      "at": "2026-04-02T21:58:19Z",
       "passes": 1,
       "pr": 15561
     },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
-      "at": "2026-03-29T12:36:58Z",
       "hash": "07e97feffa7bc2100478d39e614278ab867ba605",
+      "at": "2026-03-29T12:36:58Z",
       "passes": 1,
       "pr": 12944
     },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-patterns.md": {
-      "at": "2026-03-29T12:37:11Z",
       "hash": "e0498ebcd0125ebedaa97fd88662f8aeff47412a",
+      "at": "2026-03-29T12:37:11Z",
       "passes": 1,
       "pr": 12909
     },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
-      "at": "2026-04-02T23:13:23Z",
       "hash": "dc0ab9b5d1eadafd4faf927c93a89eb11db185eb",
+      "at": "2026-04-02T23:13:23Z",
       "passes": 2,
       "pr": 14916
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
-      "at": "2026-04-03T11:53:58Z",
       "hash": "5042b2b4bff1ba15c9f564f97af842244453029d",
+      "at": "2026-04-03T11:53:58Z",
       "passes": 2,
       "pr": 15646
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
-      "at": "2026-03-30T06:49:10Z",
       "hash": "7025e92856e65bda27000657e17b5696107172f3",
+      "at": "2026-03-30T06:49:10Z",
       "passes": 2,
       "pr": 13929
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md": {
-      "at": "2026-03-30T03:33:53Z",
       "hash": "70e97040812ad2c593e7b451a917560531eb5903",
+      "at": "2026-03-30T03:33:53Z",
       "passes": 1,
       "pr": 13667
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
-      "at": "2026-03-30T02:30:18Z",
       "hash": "3c777975a841690d4f0cdb006cbe218be6259d2d",
+      "at": "2026-03-30T02:30:18Z",
       "passes": 1,
       "pr": 13595
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages.md": {
-      "at": "2026-04-03T01:24:39Z",
       "hash": "a79bdd1a9af96c2204ecd7688f9e373e638fa484",
+      "at": "2026-04-03T01:24:39Z",
       "passes": 1,
       "pr": "16041"
     },
     ".agents/services/hosting/cloudflare-platform-skill/pipelines.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "3e2817c3aa952895211444559e4ebfecbc7da600",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16475
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "6f21e87db5f7073e6e3c7c58bcd200553f1362bd",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "94e4a09c8278ba5e5eb4cb44aeadc6a0eb6a53ad",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "c38803612f71b78dc90e51b279452e6b51f0e383",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "4199ffb5b63b069ddb8b3ad8508dba6b7d72e699",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "197b920049e040bf81b6295e8bf760732130c5a9",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "c32415af75bf1288b0d52d7a8765b4e864292fab",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "79b4e58a49cf10008f774b3dd7f92e1301dae3eb",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "f54dc9504f5d680aa797a4677fa8d6955531aa73",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md": {
-      "at": "2026-03-31T07:50:54Z",
       "hash": "12f54c4e7de2db16e3bed2fc32c1288ad551ef5d",
+      "at": "2026-03-31T07:50:54Z",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-patterns.md": {
-      "at": "2026-03-29T22:09:12Z",
       "hash": "98b6e10081c4b00014ad525bb96a33a62b6f90a0",
+      "at": "2026-03-29T22:09:12Z",
       "passes": 1,
       "pr": 13329
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi.md": {
-      "at": "2026-04-03T01:53:04Z",
       "hash": "4f629687cca43ce53b1643bbcff802c61367c597",
+      "at": "2026-04-03T01:53:04Z",
       "passes": 2,
       "pr": 15823
     },
     ".agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "6980303ffbf4bd1d5bbd434442f7188e298efed8",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16501
     },
     ".agents/services/hosting/cloudflare-platform-skill/queues-patterns.md": {
-      "at": "2026-03-30T04:51:49Z",
       "hash": "5365c2251880bae2876aac89ff39f1dd909a2a0e",
+      "at": "2026-03-30T04:51:49Z",
       "passes": 1,
       "pr": 13735
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md": {
-      "at": "2026-04-02T15:27:02Z",
       "hash": "c4d5ed8a074df52b72e94f16782306bf95098b3b",
+      "at": "2026-04-02T15:27:02Z",
       "passes": 2,
       "pr": 15629
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-patterns.md": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "6db3ad07eef857c00860416a7868a2a42636a888",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15908
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
-      "at": "2026-03-28T16:00:25Z",
       "hash": "3078a83990f41df192998904d47d0641191e7fba",
+      "at": "2026-03-28T16:00:25Z",
       "passes": 1,
       "pr": 11985
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
-      "at": "2026-04-02T23:13:24Z",
       "hash": "5a75b54baf9c39a8298e2ebbbee01c5c1988db13",
+      "at": "2026-04-02T23:13:24Z",
       "passes": 2,
       "pr": 14914
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "1c8265f439e8ac9e4d1a6c0f888d7d7812921c5c",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16502
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "5ddb6520a1364583168350d32784c001f7bcb7c7",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16477
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-gotchas.md": {
-      "at": "2026-04-02T15:00:00Z",
       "hash": "d9ece80ba981cecbe018d046364998faba4503b1",
-      "issue": 14302,
+      "at": "2026-04-02T15:00:00Z",
       "passes": 1,
       "pr": 15651
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-      "at": "2026-03-30T03:33:46Z",
       "hash": "dca9ceb5efbdd602847f9c0030471e543684e1a6",
+      "at": "2026-03-30T03:33:46Z",
       "passes": 1,
       "pr": 13654
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md": {
-      "at": "2026-03-30T06:49:26Z",
       "hash": "a0b18de39a54d95b1d687b669e01308b2333655f",
+      "at": "2026-03-30T06:49:26Z",
       "passes": 1,
       "pr": 13938
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md": {
-      "at": "2026-04-01T23:23:23Z",
       "hash": "664f8b8e3ddeec9637d1647e3daed4495c1f4a96",
+      "at": "2026-04-01T23:23:23Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/01-ai-code-execution.md": {
-      "at": "2026-04-01T23:23:23Z",
       "hash": "01137638b886f973e7f633159da5b9dc457c2416",
+      "at": "2026-04-01T23:23:23Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/02-interactive-dev-environment.md": {
-      "at": "2026-04-01T23:23:23Z",
       "hash": "fc0ae968ea17a236a2c90214346e4470cad649b4",
+      "at": "2026-04-01T23:23:23Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/03-ci-cd-pipeline.md": {
-      "at": "2026-04-01T23:23:24Z",
       "hash": "63d67404bc099cb3243761e2eeb3881a4f969c68",
+      "at": "2026-04-01T23:23:24Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/04-multi-language-code-runner.md": {
-      "at": "2026-04-01T23:23:24Z",
       "hash": "c618c5137724952005c49df413fd5c2170209d83",
+      "at": "2026-04-01T23:23:24Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/05-multi-tenant.md": {
-      "at": "2026-04-01T23:23:24Z",
       "hash": "e1d23e98d87b8e8ae9635d954951a70abe88fd57",
+      "at": "2026-04-01T23:23:24Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/06-jupyter-integration.md": {
-      "at": "2026-04-01T23:23:24Z",
       "hash": "a7a4b85da6e8ebad5549cbb830bf9aa146b9d204",
+      "at": "2026-04-01T23:23:24Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/07-git-operations.md": {
-      "at": "2026-04-01T23:23:24Z",
       "hash": "1610dca7b04c68ad219a4daa34c788dbed864aa2",
+      "at": "2026-04-01T23:23:24Z",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox.md": {
-      "at": "2026-04-02T22:12:27Z",
       "hash": "39c4bb1352aac7d3e10ccb586d162340e7ac0c7e",
-      "passes": 1,
-      "pr": null
+      "at": "2026-04-02T22:12:27Z",
+      "passes": 1
     },
     ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
-      "at": "2026-03-30T02:54:22Z",
       "hash": "91b339029c6582618e5664e5c11ba08bbb75af7e",
+      "at": "2026-03-30T02:54:22Z",
       "passes": 1,
       "pr": 13564
     },
     ".agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md": {
-      "at": "2026-04-02T21:20:07Z",
       "hash": "925bb48a1a5651aca456c9232bf0d79ed9c2bce4",
+      "at": "2026-04-02T21:20:07Z",
       "passes": 2,
       "pr": 13254
     },
     ".agents/services/hosting/cloudflare-platform-skill/stream-patterns.md": {
-      "at": "2026-03-30T06:03:15Z",
       "hash": "f45d2973f1a08cfb71a1b4e0c66e73895737d463",
+      "at": "2026-03-30T06:03:15Z",
       "passes": 1,
       "pr": 13844
     },
     ".agents/services/hosting/cloudflare-platform-skill/tail-workers.md": {
-      "at": "2026-03-28T08:17:39Z",
       "hash": "d909ab39413052950bcfff2d355bb102d17f8421",
+      "at": "2026-03-28T08:17:39Z",
       "passes": 1,
       "pr": 11562
     },
     ".agents/services/hosting/cloudflare-platform-skill/terraform-gotchas.md": {
-      "at": "2026-03-28T23:05:57Z",
       "hash": "2111a2577e4e29eec771f709231f08fa22db2fc0",
+      "at": "2026-03-28T23:05:57Z",
       "passes": 1,
       "pr": 12324
     },
     ".agents/services/hosting/cloudflare-platform-skill/terraform-patterns.md": {
-      "at": "2026-03-30T03:34:24Z",
       "hash": "463f5c3efbf7a6b11c29193e5f6dcbefd1974fc2",
+      "at": "2026-03-30T03:34:24Z",
       "passes": 1,
       "pr": 13534
     },
     ".agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md": {
-      "at": "2026-04-02T22:44:04Z",
       "hash": "1a9ebfb7d88fdd954fa0ca93d3a4dffa7e24c461",
+      "at": "2026-04-02T22:44:04Z",
       "passes": 1,
       "pr": 15666
     },
     ".agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md": {
-      "at": "2026-03-29T12:36:34Z",
       "hash": "b194dbf29525881c1c8296a33806387d7ca7fe7f",
+      "at": "2026-03-29T12:36:34Z",
       "passes": 1,
       "pr": 12955
     },
     ".agents/services/hosting/cloudflare-platform-skill/turn.md": {
-      "at": "2026-03-29T08:50:09Z",
       "hash": "10963e4e50c30efb3918e434ec90cafa0ac2f51a",
+      "at": "2026-03-29T08:50:09Z",
       "passes": 1,
       "pr": 12801
     },
     ".agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md": {
-      "at": "2026-03-28T08:18:21Z",
       "hash": "10d5c38ac748a992e4619c4042a5ac685b009b3f",
+      "at": "2026-03-28T08:18:21Z",
       "passes": 1,
       "pr": 11631
     },
     ".agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md": {
-      "at": "2026-03-28T08:18:21Z",
       "hash": "aa4bc86ba1d820a999ff48479bc7af02bc524485",
+      "at": "2026-03-28T08:18:21Z",
       "passes": 1,
       "pr": 11631
     },
     ".agents/services/hosting/cloudflare-platform-skill/vectorize.md": {
-      "at": "2026-03-28T08:18:21Z",
       "hash": "c1d8339d4d9148d438f87b89220e85fa82e4c859",
+      "at": "2026-03-28T08:18:21Z",
       "passes": 1,
       "pr": 11631
     },
     ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
-      "at": "2026-03-31T03:46:07Z",
       "hash": "c0feb4212f761fd94cc86c49e72e8cbf0be9c42a",
+      "at": "2026-03-31T03:46:07Z",
       "passes": 2,
       "pr": 14541
     },
     ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
-      "at": "2026-03-30T03:34:13Z",
       "hash": "2cbb9c1c836f4b8fce6dbe5b982d8760a75922ce",
+      "at": "2026-03-30T03:34:13Z",
       "passes": 1,
       "pr": 13636
     },
     ".agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md": {
-      "at": "2026-04-03T01:53:23Z",
       "hash": "984e5cfe9a63f157de9eacdac740dd7ca9a4c8dc",
+      "at": "2026-04-03T01:53:23Z",
       "passes": 1,
       "pr": 15869
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-gotchas.md": {
-      "at": "2026-03-29T20:53:54Z",
       "hash": "eb3c145850e0125035e13fd4bd424405fa4efb97",
+      "at": "2026-03-29T20:53:54Z",
       "passes": 1,
       "pr": 13291
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
-      "at": "2026-03-29T07:02:06Z",
       "hash": "309dc7491ce37882539d09c083bc64e97e694fdf",
+      "at": "2026-03-29T07:02:06Z",
       "passes": 1,
       "pr": 12686
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md": {
-      "at": "2026-04-03T12:15:32Z",
       "hash": "d5df86bf28ef23dcadc6de62b8e086978aa68117",
+      "at": "2026-04-03T12:15:32Z",
       "passes": 1,
       "pr": 16556
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-patterns.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "42343be0bc849aed9f1fc3ed5b0e590ccee248d6",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16474
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-vpc.md": {
-      "at": "2026-03-28T08:57:49Z",
       "hash": "fd8d3ba366abc324f0738e2e11fce322d92c654b",
+      "at": "2026-03-28T08:57:49Z",
       "passes": 1,
       "pr": 11677
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
-      "at": "2026-03-31T09:29:58Z",
       "hash": "27842bda8a80f5fb937401fe5224129d2405ad97",
+      "at": "2026-03-31T09:29:58Z",
       "passes": 2,
       "pr": 14792
     },
     ".agents/services/hosting/cloudflare-platform-skill/workflows-gotchas.md": {
-      "at": "2026-03-29T21:43:20Z",
       "hash": "f9b10b21adc0e823054085098ba86a6e8432ade1",
+      "at": "2026-03-29T21:43:20Z",
       "passes": 1,
       "pr": 13342
     },
     ".agents/services/hosting/cloudflare-platform-skill/workflows-patterns.md": {
-      "at": "2026-03-29T21:43:21Z",
       "hash": "7b01531e7d09b10fc7ab3a1706498fd011b6bb1b",
+      "at": "2026-03-29T21:43:21Z",
       "passes": 1,
       "pr": 13342
     },
     ".agents/services/hosting/cloudflare-platform-skill/workflows.md": {
-      "at": "2026-03-29T21:43:21Z",
       "hash": "5faeef07292125f8b45b6b29bc0b24d06d24c1f1",
+      "at": "2026-03-29T21:43:21Z",
       "passes": 1,
       "pr": 13342
     },
     ".agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md": {
-      "at": "2026-04-01T23:23:38Z",
       "hash": "d4f5f41aaab3a18b3ba154884526869bcf0b1efe",
+      "at": "2026-04-01T23:23:38Z",
       "passes": 1,
       "pr": 15335
     },
     ".agents/services/hosting/cloudflare-platform-skill/wrangler.md": {
-      "at": "2026-04-03T11:53:59Z",
       "hash": "9888fe0a3427bb360be2cc3a111064ceff4a863b",
-      "passes": 2,
-      "pr": null
+      "at": "2026-04-03T11:53:59Z",
+      "passes": 2
     },
     ".agents/services/hosting/cloudflare-platform-skill/zaraz.md": {
-      "at": "2026-04-02T21:20:08Z",
       "hash": "e4b79af78576116b33c9947649dffa9f1de19cec",
+      "at": "2026-04-02T21:20:08Z",
       "passes": 2,
       "pr": 0
     },
     ".agents/services/hosting/cloudflare.md": {
-      "at": "2026-03-28T16:00:49Z",
       "hash": "03302cdf932dc93c537c70aa12314ceb8442325e",
+      "at": "2026-03-28T16:00:49Z",
       "passes": 1,
       "pr": 11992
     },
     ".agents/services/hosting/cloudron.md": {
-      "at": "2026-03-28T16:40:22Z",
       "hash": "e9d97dc1a3a3dbe0bb45134f1148c74954fa577c",
+      "at": "2026-03-28T16:40:22Z",
       "passes": 1,
       "pr": 12046
     },
     ".agents/services/hosting/dns-providers.md": {
-      "at": "2026-03-30T03:33:45Z",
       "hash": "979b0b76e50549adb87fc58efdd0b8d4d7cfed49",
+      "at": "2026-03-30T03:33:45Z",
       "passes": 1,
       "pr": 13668
     },
     ".agents/services/hosting/domain-purchasing.md": {
-      "at": "2026-03-29T10:47:23Z",
       "hash": "90b1b455705be948e790ea947fafca8285ca29d9",
+      "at": "2026-03-29T10:47:23Z",
       "passes": 1,
       "pr": 12867
     },
     ".agents/services/hosting/hetzner.md": {
-      "at": "2026-03-29T07:02:07Z",
       "hash": "34c50c3bfd8c86b684e922441da91443f8a22dfd",
+      "at": "2026-03-29T07:02:07Z",
       "passes": 1,
       "pr": 12687
     },
     ".agents/services/hosting/hostinger.md": {
-      "at": "2026-03-28T11:20:19Z",
       "hash": "bdc3391799c0fb32ef11f6d610f48f7debae2194",
+      "at": "2026-03-28T11:20:19Z",
       "passes": 1,
       "pr": 11804
     },
     ".agents/services/hosting/local-hosting.md": {
-      "at": "2026-03-28T16:41:15Z",
       "hash": "ac2a557901e0a9c39b034b664927c37847635345",
+      "at": "2026-03-28T16:41:15Z",
       "passes": 1,
       "pr": 12026
     },
     ".agents/services/hosting/proxmox-full-skill.md": {
-      "at": "2026-03-30T06:49:37Z",
       "hash": "23bcf676fc5edd9dcfebc3fb07b0d4ed6cb61a19",
+      "at": "2026-03-30T06:49:37Z",
       "passes": 1,
       "pr": 13859
     },
     ".agents/services/hosting/spaceship.md": {
-      "at": "2026-04-03T01:11:34Z",
       "hash": "070eeb271be745bf4ce6d0c0a22631229975b71a",
+      "at": "2026-04-03T01:11:34Z",
       "passes": 2,
       "pr": 15494
     },
     ".agents/services/hosting/webhosting.md": {
-      "at": "2026-03-28T03:54:32Z",
       "hash": "fb3877648d049a414407d7f9e6beb747c2f92f1d",
+      "at": "2026-03-28T03:54:32Z",
       "passes": 1,
       "pr": 11352
     },
     ".agents/services/monitoring/langwatch.md": {
-      "at": "2026-03-28T16:00:51Z",
       "hash": "a56ed459849e479aaed06d6ac42bf0d60a28adf9",
+      "at": "2026-03-28T16:00:51Z",
       "passes": 1,
       "pr": 11994
     },
     ".agents/services/monitoring/socket.md": {
-      "at": "2026-04-01T20:59:50Z",
       "hash": "788506798f5a1eedd29bb5d84aaa61a758c1acd8",
+      "at": "2026-04-01T20:59:50Z",
       "passes": 1,
       "pr": 14896
     },
     ".agents/services/networking/netbird.md": {
-      "at": "2026-03-29T01:33:20Z",
       "hash": "824fc7ee7cdc7e08351310bdb9f99dcf91a3848e",
+      "at": "2026-03-29T01:33:20Z",
       "passes": 1,
       "pr": 12453
     },
     ".agents/services/networking/tailscale.md": {
-      "at": "2026-03-29T02:36:04Z",
       "hash": "e930b52dfd40905e93923b036c57b9ffc2bfa011",
+      "at": "2026-03-29T02:36:04Z",
       "passes": 1,
       "pr": 12461
     },
     ".agents/services/outreach/infraforge.md": {
-      "at": "2026-03-31T05:38:33Z",
       "hash": "0d891dd02a90d75779370f3c62f2929df0bdcd31",
+      "at": "2026-03-31T05:38:33Z",
       "passes": 1,
       "pr": 14659
     },
     ".agents/services/outreach/instantly.md": {
-      "at": "2026-03-31T05:36:34Z",
       "hash": "34502711d904e25bc38c009d87b329e818ea0c2c",
+      "at": "2026-03-31T05:36:34Z",
       "passes": 3,
       "pr": 14656
     },
     ".agents/services/outreach/manyreach.md": {
-      "at": "2026-03-29T07:02:27Z",
       "hash": "94a3e08bcf4edafcd9654e8252a1a8851b004217",
+      "at": "2026-03-29T07:02:27Z",
       "passes": 1,
       "pr": 12581
     },
     ".agents/services/outreach/smartlead.md": {
-      "at": "2026-03-28T03:54:38Z",
       "hash": "8171133da8154e590bca4a6baa8a1bbe05051e05",
+      "at": "2026-03-28T03:54:38Z",
       "passes": 1,
       "pr": 11357
     },
     ".agents/services/payments/procurement.md": {
-      "at": "2026-03-28T09:48:49Z",
       "hash": "cd9fc50f3fc0400fc70f712e5b20868aaa9ce293",
+      "at": "2026-03-28T09:48:49Z",
       "passes": 1,
       "pr": 11713
     },
     ".agents/services/payments/revenuecat.md": {
-      "at": "2026-04-02T21:58:18Z",
       "hash": "4a4d2603bb24d79952c3d18b283cd48deafde2d4",
+      "at": "2026-04-02T21:58:18Z",
       "passes": 1,
       "pr": 15693
     },
     ".agents/services/payments/stripe.md": {
-      "at": "2026-03-29T03:15:16Z",
       "hash": "6cbe509351f115869d196a09bc7031bb237d2a41",
+      "at": "2026-03-29T03:15:16Z",
       "passes": 1,
       "pr": 12511
     },
     ".agents/services/payments/superwall.md": {
-      "at": "2026-03-29T12:36:44Z",
       "hash": "1c533274b85654214054f396d45e2b1d09425b85",
+      "at": "2026-03-29T12:36:44Z",
       "passes": 1,
       "pr": 12952
     },
     ".agents/tools/accessibility/accessibility-audit.md": {
-      "at": "2026-03-28T08:18:26Z",
       "hash": "50607e3251694a312978efe741fd95eb6e47de55",
+      "at": "2026-03-28T08:18:26Z",
       "passes": 1,
       "pr": 11634
     },
     ".agents/tools/accessibility/accessibility.md": {
-      "at": "2026-04-03T02:21:04Z",
       "hash": "6a9bb1b64297f0b7d6b06a258edc5a7b951c1f47",
+      "at": "2026-04-03T02:21:04Z",
       "passes": 3,
       "pr": 14053
     },
     ".agents/tools/ai-assistants/agno.md": {
-      "at": "2026-03-29T08:10:32Z",
       "hash": "0e8f56a7ce9681124205e8492ed4878f1a9c73c3",
+      "at": "2026-03-29T08:10:32Z",
       "passes": 1,
       "pr": 12746
     },
     ".agents/tools/ai-assistants/capsolver.md": {
-      "at": "2026-03-29T12:36:41Z",
       "hash": "934e330cfc0b1a30efe5bf139296ae882f868709",
+      "at": "2026-03-29T12:36:41Z",
       "passes": 1,
       "pr": 12953
     },
     ".agents/tools/ai-assistants/claude-code.md": {
-      "at": "2026-04-01T20:59:01Z",
       "hash": "dd9666e19eb7e98df75856dd477ecf7ceebf147a",
+      "at": "2026-04-01T20:59:01Z",
       "passes": 1,
       "pr": 15204
     },
     ".agents/tools/ai-assistants/compare-models.md": {
-      "at": "2026-03-29T14:29:46Z",
       "hash": "4ee54c0d4a2a76b5646c8d5bd3403a6bc744f649",
+      "at": "2026-03-29T14:29:46Z",
       "passes": 1,
       "pr": 13017
     },
     ".agents/tools/ai-assistants/datasets.md": {
-      "at": "2026-04-02T12:00:00Z",
       "hash": "8b525467afaf93fea7539e9f47fabf2159254ae1",
+      "at": "2026-04-02T12:00:00Z",
       "passes": 1,
       "pr": 15336
     },
     ".agents/tools/ai-assistants/fallback-chains.md": {
-      "at": "2026-04-02T21:58:20Z",
       "hash": "04c03d8868c5719bfa209234bcac59f7b997c3f4",
+      "at": "2026-04-02T21:58:20Z",
       "passes": 1,
       "pr": 15534
     },
     ".agents/tools/ai-assistants/headless-dispatch.md": {
-      "at": "2026-03-29T03:15:46Z",
       "hash": "00414f5554e8388ffa17859ef02d718061cd911a",
+      "at": "2026-03-29T03:15:46Z",
       "passes": 1,
       "pr": 12352
     },
     ".agents/tools/ai-assistants/models-README.md": {
-      "at": "2026-04-03T01:11:35Z",
       "hash": "4e2a2bd51c40cb0ce1dd199625f4a2691a818317",
+      "at": "2026-04-03T01:11:35Z",
       "passes": 2,
       "pr": 15227
     },
     ".agents/tools/ai-assistants/models-sonnet.md": {
-      "at": "2026-04-02T23:13:26Z",
       "hash": "64800a1556f7948083c746ea4bda589616a0f19c",
+      "at": "2026-04-02T23:13:26Z",
       "passes": 2,
       "pr": 14913
     },
     ".agents/tools/ai-assistants/openclaw.md": {
-      "at": "2026-03-28T14:15:40Z",
       "hash": "0c4d4c08590b9a3dc260a05d39c76148057c928c",
+      "at": "2026-03-28T14:15:40Z",
       "passes": 1,
       "pr": 11901
     },
     ".agents/tools/ai-assistants/opencode-server.md": {
-      "at": "2026-03-28T03:53:56Z",
       "hash": "15e90e96d742cfe07ffd4cb37c340157d5a8bb74",
+      "at": "2026-03-28T03:53:56Z",
       "passes": 1,
       "pr": 11345
     },
     ".agents/tools/ai-assistants/response-scoring.md": {
-      "at": "2026-03-29T15:50:37Z",
       "hash": "33f943f8dc56e52eee464c193d4b0fce97d1305d",
+      "at": "2026-03-29T15:50:37Z",
       "passes": 2,
       "pr": 13072
     },
     ".agents/tools/ai-assistants/runners-seo-analyst.md": {
-      "at": "2026-04-03T04:23:06Z",
       "hash": "77a9db53132c1496c5f33d07f78d7cf7cd2611f1",
+      "at": "2026-04-03T04:23:06Z",
       "passes": 1,
       "pr": 16010
     },
     ".agents/tools/ai-generation/comfy-cli.md": {
-      "at": "2026-03-27T21:25:22Z",
       "hash": "cec6e1c63f0997e330608cc3610f5a582d7e4d29",
+      "at": "2026-03-27T21:25:22Z",
       "passes": 2,
       "pr": 11014
     },
     ".agents/tools/ai-orchestration/autogen.md": {
-      "at": "2026-03-30T02:54:16Z",
       "hash": "590a04f8f8f9073b304f6538e550f335e08ffd62",
+      "at": "2026-03-30T02:54:16Z",
       "passes": 1,
       "pr": 13600
     },
     ".agents/tools/ai-orchestration/crewai.md": {
-      "at": "2026-03-28T02:50:59Z",
       "hash": "e1ed08282945b0708a6840e1d2bb38d92c3d3698",
+      "at": "2026-03-28T02:50:59Z",
       "passes": 1,
       "pr": 11274
     },
     ".agents/tools/ai-orchestration/langflow.md": {
-      "at": "2026-03-30T06:49:09Z",
       "hash": "8c8c05859cc60d2e341b6cd191075ec540e10c12",
+      "at": "2026-03-30T06:49:09Z",
       "passes": 2,
       "pr": 13930
     },
     ".agents/tools/ai-orchestration/openprose.md": {
-      "at": "2026-03-29T14:29:04Z",
       "hash": "7d17737b91f8878839b3430a51676211744becce",
+      "at": "2026-03-29T14:29:04Z",
       "passes": 1,
       "pr": 13007
     },
     ".agents/tools/ai-orchestration/overview.md": {
-      "at": "2026-04-03T01:53:08Z",
       "hash": "4e97ab8ea80342eabab4b326411f74eaeb88bba0",
+      "at": "2026-04-03T01:53:08Z",
       "passes": 2,
       "pr": 11793
     },
     ".agents/tools/ai-orchestration/packaging.md": {
-      "at": "2026-03-28T03:53:52Z",
       "hash": "4cbea04181622677bff0bdbb611cdd03a3401484",
+      "at": "2026-03-28T03:53:52Z",
       "passes": 1,
       "pr": 11296
     },
     ".agents/tools/animation/animejs.md": {
-      "at": "2026-03-29T08:11:02Z",
       "hash": "3d011c9aa6ae720f1ed6de08663bf78f589237ec",
+      "at": "2026-03-29T08:11:02Z",
       "passes": 1,
       "pr": 12745
     },
     ".agents/tools/api/better-auth.md": {
-      "at": "2026-03-28T08:58:32Z",
       "hash": "8494627274fa59f222b8c19aeb61280ded29e8ec",
+      "at": "2026-03-28T08:58:32Z",
       "passes": 1,
       "pr": 11566
     },
     ".agents/tools/api/cloudflare-mcp.md": {
-      "at": "2026-04-03T12:15:33Z",
       "hash": "1832e77768442f25fde63a70b822d38c0b7b5e13",
+      "at": "2026-04-03T12:15:33Z",
       "passes": 1,
       "pr": 16551
     },
     ".agents/tools/api/drizzle.md": {
-      "at": "2026-03-30T04:52:00Z",
       "hash": "51387eb5d4ff32cccf8469a6ef066f6c2b22fd90",
+      "at": "2026-03-30T04:52:00Z",
       "passes": 2,
       "pr": 13718
     },
     ".agents/tools/api/hono.md": {
-      "at": "2026-03-29T07:02:20Z",
       "hash": "bf496281a1542c460ea880f936ec4d92dd928900",
+      "at": "2026-03-29T07:02:20Z",
       "passes": 1,
       "pr": 12607
     },
     ".agents/tools/api/vercel-ai-sdk.md": {
-      "at": "2026-03-28T11:20:15Z",
       "hash": "e0a51bc87d3615a985b527cfe0265571672e2095",
+      "at": "2026-03-28T11:20:15Z",
       "passes": 1,
       "pr": 11792
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill.md": {
-      "at": "2026-04-03T01:53:26Z",
       "hash": "159f2479cb3aebb3f3d0c437268c5884adc9382c",
+      "at": "2026-04-03T01:53:26Z",
       "passes": 1,
       "pr": 15695
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/cheatsheet.md": {
-      "at": "2026-03-28T05:10:19Z",
       "hash": "7622759c028bec7b85f445a88ab175f13b055133",
+      "at": "2026-03-28T05:10:19Z",
       "passes": 1,
       "pr": 11393
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md": {
-      "at": "2026-03-30T04:51:54Z",
       "hash": "2f665556f02ff70ca7d40efdaa6c45150c3384a1",
+      "at": "2026-03-30T04:51:54Z",
       "passes": 2,
       "pr": 13768
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-strategic.md": {
-      "at": "2026-03-28T11:20:20Z",
       "hash": "61e87ef7f501310f73fbe54da1d9e0a76a38abae",
+      "at": "2026-03-28T11:20:20Z",
       "passes": 1,
       "pr": 11805
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-tactical.md": {
-      "at": "2026-03-28T11:20:40Z",
       "hash": "a53f3400bd5c9142c7f9b186523697b16c1a28e2",
+      "at": "2026-03-28T11:20:40Z",
       "passes": 1,
       "pr": 11734
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
-      "at": "2026-03-30T06:49:15Z",
       "hash": "0cf36c2647ee174ec7e68e1e9119bab9e7d6f644",
+      "at": "2026-03-30T06:49:15Z",
       "passes": 2,
       "pr": 13931
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md": {
-      "at": "2026-03-28T21:58:55Z",
       "hash": "2fde1ee5df8c1bbde677a3198fe1c39df860a6ba",
+      "at": "2026-03-28T21:58:55Z",
       "passes": 1,
       "pr": 12236
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/testing.md": {
-      "at": "2026-03-28T13:38:11Z",
       "hash": "2316ee0b050453056ecc075e712e88b436dd3dd9",
+      "at": "2026-03-28T13:38:11Z",
       "passes": 1,
       "pr": 11790
     },
     ".agents/tools/architecture/feature-slicing-skill.md": {
-      "at": "2026-03-27T21:25:18Z",
       "hash": "bb7e28e69e417b4701428fbc2ec0d0608f09e3e2",
+      "at": "2026-03-27T21:25:18Z",
       "passes": 2,
       "pr": 11010
     },
     ".agents/tools/architecture/feature-slicing-skill/cheatsheet.md": {
-      "at": "2026-03-27T21:25:23Z",
       "hash": "b244fb8417fc27f0de33c83c86092f5bebd736f3",
+      "at": "2026-03-27T21:25:23Z",
       "passes": 1,
       "pr": 11018
     },
     ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
-      "at": "2026-03-28T20:16:39Z",
       "hash": "91baa20a0d8cea7599db1f40f700ec767b4ea44c",
+      "at": "2026-03-28T20:16:39Z",
       "passes": 1,
       "pr": 12160
     },
     ".agents/tools/architecture/feature-slicing-skill/layers.md": {
-      "at": "2026-03-28T08:18:16Z",
       "hash": "aa5a10592a8a28db7e01ce256df9e7aa7ab57c76",
+      "at": "2026-03-28T08:18:16Z",
       "passes": 1,
       "pr": 11537
     },
     ".agents/tools/architecture/feature-slicing-skill/migration.md": {
-      "at": "2026-03-30T00:32:19Z",
       "hash": "8adaf46d6bf7a4a77a17c6578948026e2a64e809",
+      "at": "2026-03-30T00:32:19Z",
       "passes": 2,
       "pr": 13466
     },
     ".agents/tools/architecture/feature-slicing-skill/nextjs.md": {
-      "at": "2026-03-28T06:59:34Z",
       "hash": "0fd2c402556f4d6804ce1a61eeaaaa9c3cecd541",
+      "at": "2026-03-28T06:59:34Z",
       "passes": 1,
       "pr": 11437
     },
     ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
-      "at": "2026-03-28T16:40:13Z",
       "hash": "52069355367fb596967a8aef0bb6ad7f8e9861c3",
+      "at": "2026-03-28T16:40:13Z",
       "passes": 1,
       "pr": 12030
     },
     ".agents/tools/automation/cron-agent.md": {
-      "at": "2026-03-28T20:56:11Z",
       "hash": "fbf1c6bc76acc1436d3da1b0b34296be5193de5a",
+      "at": "2026-03-28T20:56:11Z",
       "passes": 1,
       "pr": 12184
     },
     ".agents/tools/automation/mac.md": {
-      "at": "2026-04-01T20:58:52Z",
       "hash": "1dc19ae4b63343bb6f8a397a6f7e824655e2f986",
+      "at": "2026-04-01T20:58:52Z",
       "passes": 1,
       "pr": 15253
     },
     ".agents/tools/automation/macos-automator.md": {
-      "at": "2026-03-27T21:25:19Z",
       "hash": "f8771a0d1548af0fbdd76f1944d50ce6b1107f13",
+      "at": "2026-03-27T21:25:19Z",
       "passes": 1,
       "pr": 11011
     },
     ".agents/tools/browser/agent-browser.md": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "52400ec344f64870dd6977c9950c80a22d939df5",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15892
     },
     ".agents/tools/browser/anti-detect-browser.md": {
-      "at": "2026-03-27T21:25:25Z",
       "hash": "647081565083b90f27fdce7d25dea9e153fc64a4",
+      "at": "2026-03-27T21:25:25Z",
       "passes": 1,
       "pr": 11017
     },
     ".agents/tools/browser/browser-automation.md": {
-      "at": "2026-03-30T04:51:56Z",
       "hash": "52c1d946fb9062a82e798821f056e58d93ab321f",
+      "at": "2026-03-30T04:51:56Z",
       "passes": 2,
       "pr": 13719
     },
     ".agents/tools/browser/browser-benchmark-scripts-01-playwright.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "491b2958ceab8fcdfe0beafb4d0bf0d168d2199c",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16500
     },
     ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
-      "at": "2026-04-01T12:00:00Z",
       "hash": "8d79ff6b9aa02ab04c5f72924b3a7798ee561893",
+      "at": "2026-04-01T12:00:00Z",
       "passes": 1,
       "pr": 15176
     },
     ".agents/tools/browser/browser-profiles.md": {
-      "at": "2026-04-03T12:15:23Z",
       "hash": "f44c1308d6180eaecb534b715518b5f61f888635",
+      "at": "2026-04-03T12:15:23Z",
       "passes": 2,
       "pr": 12501
     },
     ".agents/tools/browser/browser-qa.md": {
-      "at": "2026-03-28T20:17:06Z",
       "hash": "629aa3a1df673d6e5df7310d173da5d3938aa04e",
+      "at": "2026-03-28T20:17:06Z",
       "passes": 1,
       "pr": 12171
     },
     ".agents/tools/browser/browser-use.md": {
-      "at": "2026-03-29T07:03:02Z",
       "hash": "96d5278ed393a25379da0c21d04db2269219cbf9",
+      "at": "2026-03-29T07:03:02Z",
       "passes": 1,
       "pr": 12616
     },
     ".agents/tools/browser/chrome-devtools.md": {
-      "at": "2026-03-28T22:39:23Z",
       "hash": "13576e2127eccb1c8555a5b12660265ac4ebd8aa",
+      "at": "2026-03-28T22:39:23Z",
       "passes": 1,
       "pr": 12310
     },
     ".agents/tools/browser/chrome-webstore-release.md": {
-      "at": "2026-03-30T06:49:23Z",
       "hash": "7d789fec3b99cc63f2dc9033a798921b9f7f2233",
+      "at": "2026-03-30T06:49:23Z",
       "passes": 1,
       "pr": 13942
     },
     ".agents/tools/browser/chromium-debug-use.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "67ee04fa1b7d6c3c62137e37158e678303224a92",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16473
     },
     ".agents/tools/browser/crawl4ai-integration.md": {
-      "at": "2026-04-02T19:17:13Z",
       "hash": "6839d1c4bd81f04a3f75f075d43d233cbebfdb3e",
+      "at": "2026-04-02T19:17:13Z",
       "passes": 2,
       "pr": 15463
     },
     ".agents/tools/browser/crawl4ai-resources.md": {
-      "at": "2026-03-28T13:37:22Z",
       "hash": "3b91d1b3383285e813ef8eed5303e3a6fa8fa99d",
+      "at": "2026-03-28T13:37:22Z",
       "passes": 1,
       "pr": 11858
     },
     ".agents/tools/browser/crawl4ai-usage.md": {
-      "at": "2026-04-03T01:11:47Z",
       "hash": "46d82b1f632872fa8c59c2a271c79466ced17238",
+      "at": "2026-04-03T01:11:47Z",
       "passes": 1,
       "pr": 15802
     },
     ".agents/tools/browser/crawl4ai.md": {
-      "at": "2026-03-28T08:17:51Z",
       "hash": "967373980ca56ec85cb795eb9426efb91ff23ddb",
+      "at": "2026-03-28T08:17:51Z",
       "passes": 1,
       "pr": 11599
     },
     ".agents/tools/browser/curl-copy.md": {
-      "at": "2026-04-01T21:56:13Z",
       "hash": "5fb61c717fec1b0cbd8a594f7782b0db73cc2eca",
-      "passes": 2,
-      "pr": null
+      "at": "2026-04-01T21:56:13Z",
+      "passes": 2
     },
     ".agents/tools/browser/dev-browser.md": {
-      "at": "2026-03-28T15:30:31Z",
       "hash": "5215652277b228f27d7eddb0cce1a05df09e4a75",
+      "at": "2026-03-28T15:30:31Z",
       "passes": 2,
       "pr": 11921
     },
     ".agents/tools/browser/extension-dev.md": {
-      "at": "2026-03-29T22:09:34Z",
       "hash": "5d6ac2671414bfdce4481294fce9019711d28c01",
+      "at": "2026-03-29T22:09:34Z",
       "passes": 1,
       "pr": 13330
     },
     ".agents/tools/browser/extension-dev/development.md": {
-      "at": "2026-03-30T04:52:04Z",
       "hash": "80547436b58e3fd8fb2ce9ab44cfaecedcb32ec3",
+      "at": "2026-03-30T04:52:04Z",
       "passes": 1,
       "pr": 13722
     },
     ".agents/tools/browser/extension-dev/publishing.md": {
-      "at": "2026-03-29T11:20:06Z",
       "hash": "7fe8e877846c0dc155d639a1b5dd214e47c7e499",
+      "at": "2026-03-29T11:20:06Z",
       "passes": 1,
       "pr": 12884
     },
     ".agents/tools/browser/extension-dev/testing.md": {
-      "at": "2026-03-30T04:51:57Z",
       "hash": "57d5dc456ab9a6e1d10416777117b96a09cc4f14",
+      "at": "2026-03-30T04:51:57Z",
       "passes": 1,
       "pr": 13717
     },
     ".agents/tools/browser/fingerprint-profiles.md": {
-      "at": "2026-03-28T17:30:27Z",
       "hash": "d910625e173f65063d64d51ca549494b97a2ba87",
+      "at": "2026-03-28T17:30:27Z",
       "passes": 1,
       "pr": 12070
     },
     ".agents/tools/browser/pagespeed.md": {
-      "at": "2026-03-28T03:53:49Z",
       "hash": "55b132de0f4ff15dd72cec557bf042cd56b93fec",
+      "at": "2026-03-28T03:53:49Z",
       "passes": 1,
       "pr": 11295
     },
     ".agents/tools/browser/peekaboo.md": {
-      "at": "2026-03-28T03:54:17Z",
       "hash": "294d232e9625b8a855f17cbea4498a4881a6b0bc",
+      "at": "2026-03-28T03:54:17Z",
       "passes": 1,
       "pr": 11348
     },
     ".agents/tools/browser/playwright-cli.md": {
-      "at": "2026-03-28T11:20:22Z",
       "hash": "978be4b5b3043cfee751f9c966ba27ddd7fe5182",
+      "at": "2026-03-28T11:20:22Z",
       "passes": 1,
       "pr": 11802
     },
     ".agents/tools/browser/playwright-emulation.md": {
-      "at": "2026-04-02T22:44:04Z",
       "hash": "1fdc5a4f08a4e9ba8ebc3550ade50c4876b949d7",
+      "at": "2026-04-02T22:44:04Z",
       "passes": 1,
       "pr": 15692
     },
     ".agents/tools/browser/playwright.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "e1ff8edf9424a19c3d3dd1c369d0489e54f7b141",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16512
     },
     ".agents/tools/browser/playwriter.md": {
-      "at": "2026-03-29T03:31:38Z",
       "hash": "98bfa1b0dde9a405a0f3a07aa1ae3eaadc42801a",
+      "at": "2026-03-29T03:31:38Z",
       "passes": 1,
       "pr": 12516
     },
     ".agents/tools/browser/proxy-integration.md": {
-      "at": "2026-03-29T15:08:41Z",
       "hash": "46806f6e0dcec4831dc62abb84c2f5f96326c102",
+      "at": "2026-03-29T15:08:41Z",
       "passes": 1,
       "pr": 13032
     },
     ".agents/tools/browser/skyvern.md": {
-      "at": "2026-03-28T17:11:10Z",
       "hash": "1f2933d4cdf35fd9696301a5743ae2e550a31eb0",
+      "at": "2026-03-28T17:11:10Z",
       "passes": 1,
       "pr": 12055
     },
     ".agents/tools/browser/stagehand-examples.md": {
-      "at": "2026-03-28T14:15:24Z",
       "hash": "3204f26c9d748fd843fe6db79a36a18581e78b49",
+      "at": "2026-03-28T14:15:24Z",
       "passes": 1,
       "pr": 11899
     },
     ".agents/tools/browser/stagehand-python.md": {
-      "at": "2026-03-30T02:31:00Z",
       "hash": "2a7d864c02279238b1f773c390f7ffe011c6f9d6",
+      "at": "2026-03-30T02:31:00Z",
       "passes": 1,
       "pr": 13486
     },
     ".agents/tools/browser/stagehand.md": {
-      "at": "2026-03-29T03:15:18Z",
       "hash": "3702284e297e642ee7e2bb0c65470886fc7c0ffb",
+      "at": "2026-03-29T03:15:18Z",
       "passes": 1,
       "pr": 12513
     },
     ".agents/tools/browser/stealth-patches.md": {
-      "at": "2026-04-03T04:23:06Z",
       "hash": "4e7009fbb71b64fe2ec9b8b952bb056cdcea3078",
+      "at": "2026-04-03T04:23:06Z",
       "passes": 1,
       "pr": 15948
     },
     ".agents/tools/browser/sweet-cookie.md": {
-      "at": "2026-03-29T22:09:35Z",
       "hash": "763a36ee928e5c54bafe10a5659c75c4c73f42df",
+      "at": "2026-03-29T22:09:35Z",
       "passes": 1,
       "pr": 13328
     },
     ".agents/tools/browser/watercrawl.md": {
-      "at": "2026-03-28T19:15:30Z",
       "hash": "c3fc2a3c5ee117daba5dfbfae490dfb406b9e711",
+      "at": "2026-03-28T19:15:30Z",
       "passes": 1,
       "pr": 12117
     },
     ".agents/tools/build-agent/add-skill.md": {
-      "at": "2026-03-29T01:03:17Z",
       "hash": "36065ac3559aa2e929cbb858c8220961454f9dd9",
+      "at": "2026-03-29T01:03:17Z",
       "passes": 1,
       "pr": 12376
     },
     ".agents/tools/build-agent/agent-testing.md": {
-      "at": "2026-04-03T11:54:02Z",
       "hash": "1e58098f926339b4837807611db64d45e8246c91",
+      "at": "2026-04-03T11:54:02Z",
       "passes": 2,
       "pr": 15662
     },
     ".agents/tools/build-agent/build-agent.md": {
-      "at": "2026-03-29T14:29:12Z",
       "hash": "59fa5cde2d2c1b113be43ecdb1a6d8978d3d4f69",
+      "at": "2026-03-29T14:29:12Z",
       "passes": 1,
       "pr": 12957
     },
     ".agents/tools/build-mcp/aidevops-plugin.md": {
-      "at": "2026-04-02T14:42:10Z",
       "hash": "1663a5f374022feab8fbd51387acaf2f02d0f2c8",
+      "at": "2026-04-02T14:42:10Z",
       "passes": 3,
       "pr": 14775
     },
     ".agents/tools/build-mcp/api-wrapper.md": {
-      "at": "2026-03-28T02:51:01Z",
       "hash": "68b6075506f6dc1153fec6d5aa78c05d213b0b73",
+      "at": "2026-03-28T02:51:01Z",
       "passes": 1,
       "pr": 11276
     },
     ".agents/tools/build-mcp/api-wrapper/patterns.md": {
-      "at": "2026-03-28T02:51:01Z",
       "hash": "5aa65e858b380b38b44e647545eda3f1450543b2",
+      "at": "2026-03-28T02:51:01Z",
       "passes": 1,
       "pr": 11276
     },
     ".agents/tools/build-mcp/build-mcp.md": {
-      "at": "2026-03-28T13:37:27Z",
       "hash": "9b3ca67c49dd5bf0af66b01061561502620de8b3",
+      "at": "2026-03-28T13:37:27Z",
       "passes": 1,
       "pr": 11844
     },
     ".agents/tools/build-mcp/deployment.md": {
-      "at": "2026-03-28T22:39:22Z",
       "hash": "0229a7490f42dcf4f3b8c0958fefd7ff53f3b8a2",
+      "at": "2026-03-28T22:39:22Z",
       "passes": 1,
       "pr": 12311
     },
     ".agents/tools/build-mcp/server-patterns.md": {
-      "at": "2026-03-28T10:27:33Z",
       "hash": "c0e5bf0399f60ae53b3b09082ac6ced4debb8c76",
+      "at": "2026-03-28T10:27:33Z",
       "passes": 1,
       "pr": 11679
     },
     ".agents/tools/build-mcp/transports.md": {
-      "at": "2026-03-29T01:04:08Z",
       "hash": "733acaf8682f80a53cd3c2a996c0571adf7ac018",
+      "at": "2026-03-29T01:04:08Z",
       "passes": 1,
       "pr": 12394
     },
     ".agents/tools/code-review/auditing.md": {
-      "at": "2026-04-02T21:20:13Z",
       "hash": "aa7f70c05362b5b00887a152a101c0b6ee7da926",
+      "at": "2026-04-02T21:20:13Z",
       "passes": 2,
       "pr": 0
     },
     ".agents/tools/code-review/best-practices.md": {
-      "at": "2026-03-28T13:38:46Z",
       "hash": "b8f93fd83e04dc301d838178a7b7523e35382166",
+      "at": "2026-03-28T13:38:46Z",
       "passes": 1,
       "pr": 11771
     },
     ".agents/tools/code-review/codacy.md": {
-      "at": "2026-03-29T22:09:31Z",
       "hash": "3f41e7f2f15e10bf934568ea6ff485cd64ce88c3",
+      "at": "2026-03-29T22:09:31Z",
       "passes": 1,
       "pr": 13314
     },
     ".agents/tools/code-review/code-simplifier.md": {
-      "at": "2026-04-02T21:58:07Z",
       "hash": "64ff2a38d1ed0d234fb19fba2a9a6c5117ef7ce9",
-      "passes": 4,
-      "pr": null
+      "at": "2026-04-02T21:58:07Z",
+      "passes": 4
     },
     ".agents/tools/code-review/code-standards.md": {
-      "at": "2026-03-28T15:30:22Z",
       "hash": "88d5b9dc281a4557707da37dee72529d600faaf8",
+      "at": "2026-03-28T15:30:22Z",
       "passes": 1,
       "pr": 11944
     },
     ".agents/tools/code-review/coderabbit.md": {
-      "at": "2026-03-29T07:02:31Z",
       "hash": "3e37a12db3473bf11b36f10e75ede64bb2494e1b",
+      "at": "2026-03-29T07:02:31Z",
       "passes": 1,
       "pr": 12589
     },
     ".agents/tools/code-review/management.md": {
-      "at": "2026-04-03T11:54:03Z",
       "hash": "f3bcdd56d8b720302d905c246e4a5720dc500be5",
-      "issue": 16257,
-      "passes": 1,
-      "status": "simplified"
+      "at": "2026-04-03T11:54:03Z",
+      "passes": 1
     },
     ".agents/tools/code-review/qlty.md": {
-      "at": "2026-03-28T18:36:46Z",
       "hash": "3c3fef1897ddb0b0bb88a35205dfd4d6f715db13",
+      "at": "2026-03-28T18:36:46Z",
       "passes": 1,
       "pr": 12114
     },
     ".agents/tools/code-review/runtime-patterns.md": {
-      "at": "2026-03-28T13:38:47Z",
       "hash": "06e2affe5aaa285c3139fde0d808dc89c0140e31",
+      "at": "2026-03-28T13:38:47Z",
       "passes": 1,
       "pr": 11771
     },
     ".agents/tools/code-review/secretlint.md": {
-      "at": "2026-03-28T16:00:52Z",
       "hash": "54a79997b8c268d6b3942204a8b6e23a251bcfe3",
+      "at": "2026-03-28T16:00:52Z",
       "passes": 1,
       "pr": 11991
     },
     ".agents/tools/code-review/security-analysis.md": {
-      "at": "2026-03-30T00:32:18Z",
       "hash": "9d67a5c1a7278408c78bd6f559e1d43c61040b2e",
+      "at": "2026-03-30T00:32:18Z",
       "passes": 2,
       "pr": 13467
     },
     ".agents/tools/code-review/security-audit.md": {
-      "at": "2026-03-28T17:11:18Z",
       "hash": "bed16a626f218a4a0045edaae30edfa52616f72c",
+      "at": "2026-03-28T17:11:18Z",
       "passes": 1,
       "pr": 12029
     },
     ".agents/tools/code-review/skill-scanner.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "3f8511a2458436c1e8efe28e9c5227428e83da0f",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16525
     },
     ".agents/tools/code-review/snyk.md": {
-      "at": "2026-03-27T21:25:26Z",
       "hash": "e248df7d21db7a21cef8b1e16e1e96f361e3e487",
+      "at": "2026-03-27T21:25:26Z",
       "passes": 1,
       "pr": 11013
     },
     ".agents/tools/code-review/tools.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "f293782edf944eb949b549a368d8c704e26cd789",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16449
     },
     ".agents/tools/containers/remote-dispatch.md": {
-      "at": "2026-03-30T04:52:23Z",
       "hash": "e6936f346e4acde6d0d596c5295e7864fbea5ede",
+      "at": "2026-03-30T04:52:23Z",
       "passes": 2,
       "pr": 13733
     },
     ".agents/tools/context/augment-context-engine.md": {
-      "at": "2026-03-28T16:40:32Z",
       "hash": "bbae0554351a40b90c0df31e139c6391601f3e2b",
+      "at": "2026-03-28T16:40:32Z",
       "passes": 1,
       "pr": 12015
     },
     ".agents/tools/context/context-builder.md": {
-      "at": "2026-03-29T20:54:03Z",
       "hash": "27fb0c83ee803a7eebb4ace6202875b0a844786b",
+      "at": "2026-03-29T20:54:03Z",
       "passes": 1,
       "pr": 13297
     },
     ".agents/tools/context/context-guardrails.md": {
-      "at": "2026-03-30T06:49:16Z",
       "hash": "35328fa309512f8dc6c77afee69bd1f6068b9e45",
+      "at": "2026-03-30T06:49:16Z",
       "passes": 1,
       "pr": 13956
     },
     ".agents/tools/context/context7.md": {
-      "at": "2026-03-28T20:56:05Z",
       "hash": "1d98876794a7dc00b2cd2126492a54302f051af8",
+      "at": "2026-03-28T20:56:05Z",
       "passes": 1,
       "pr": 12182
     },
     ".agents/tools/context/dspy.md": {
-      "at": "2026-03-29T20:53:49Z",
       "hash": "a452d6023063a0eebf04141ae94d61a0867830da",
+      "at": "2026-03-29T20:53:49Z",
       "passes": 1,
       "pr": 13289
     },
     ".agents/tools/context/dspyground.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "cc612715f76465057c9f47363400a203994cbd40",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16494
     },
     ".agents/tools/context/github-search.md": {
-      "at": "2026-03-29T16:34:35Z",
       "hash": "526e968501aef58e8e7676ede7ab1396404a32c5",
+      "at": "2026-03-29T16:34:35Z",
       "passes": 1,
       "pr": 13106
     },
     ".agents/tools/context/mcp-discovery.md": {
-      "at": "2026-03-28T03:53:59Z",
       "hash": "b5851d90484fe52e39f87e3c7af8692778986208",
+      "at": "2026-03-28T03:53:59Z",
       "passes": 1,
       "pr": 11338
     },
     ".agents/tools/context/model-routing.md": {
-      "at": "2026-03-29T22:09:44Z",
       "hash": "b01bb6dd0d6eda73fa3e19439bb36df2f6d0f15f",
+      "at": "2026-03-29T22:09:44Z",
       "passes": 2,
       "pr": 13255
     },
     ".agents/tools/context/openapi-search.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "9b90c34f31571d7df240b6f98e4c3dc9c76f7f2e",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16513
     },
     ".agents/tools/context/prompt-optimization.md": {
-      "at": "2026-03-29T08:10:39Z",
       "hash": "94abbde385ccf494358e17a79a32fdc72d4adb58",
+      "at": "2026-03-29T08:10:39Z",
       "passes": 1,
       "pr": 12749
     },
     ".agents/tools/context/rapidfuzz.md": {
-      "at": "2026-04-03T01:53:12Z",
       "hash": "6cef99c2d59eecce5bd461af579cb44a36997e61",
+      "at": "2026-04-03T01:53:12Z",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/conversion/mineru.md": {
-      "at": "2026-03-28T16:40:36Z",
       "hash": "beeb4a49df5e2a8ea91da9100ae2ba8887cf6b3d",
+      "at": "2026-03-28T16:40:36Z",
       "passes": 1,
       "pr": 12012
     },
     ".agents/tools/conversion/pandoc.md": {
-      "at": "2026-03-28T08:17:47Z",
       "hash": "557667b032774727658d22f6b1c5392ec4a83660",
+      "at": "2026-03-28T08:17:47Z",
       "passes": 1,
       "pr": 11595
     },
     ".agents/tools/credentials/api-key-setup.md": {
-      "at": "2026-03-29T20:53:50Z",
       "hash": "3fe770105e7b4c6edbff6f572b5189e5c2a7ba17",
+      "at": "2026-03-29T20:53:50Z",
       "passes": 1,
       "pr": 13279
     },
     ".agents/tools/credentials/bitwarden.md": {
-      "at": "2026-04-02T04:56:56Z",
       "hash": "808ffa447534e25dd4090033275c4861a8612f2c",
+      "at": "2026-04-02T04:56:56Z",
       "passes": 1,
       "pr": 15468
     },
     ".agents/tools/credentials/encryption-stack.md": {
-      "at": "2026-04-03T01:11:47Z",
       "hash": "2e34e7975b8addfeaa1860db91423c85633b596c",
+      "at": "2026-04-03T01:11:47Z",
       "passes": 1,
       "pr": 15780
     },
     ".agents/tools/credentials/environment-variables.md": {
-      "at": "2026-03-29T08:10:40Z",
       "hash": "4a7ee0834fefdbf424af90c68648ad35716559c7",
+      "at": "2026-03-29T08:10:40Z",
       "passes": 1,
       "pr": 12751
     },
     ".agents/tools/credentials/gocryptfs.md": {
-      "at": "2026-03-28T11:20:36Z",
       "hash": "8e128a21d4783c5499f073213aee1a20491893d5",
+      "at": "2026-03-28T11:20:36Z",
       "passes": 1,
       "pr": 11730
     },
     ".agents/tools/credentials/gopass.md": {
-      "at": "2026-03-27T21:25:05Z",
       "hash": "a59a0077d4d56694894c8cadef6b9c3a294dede0",
+      "at": "2026-03-27T21:25:05Z",
       "passes": 1,
       "pr": 11021
     },
     ".agents/tools/credentials/multi-tenant.md": {
-      "at": "2026-03-27T21:25:16Z",
       "hash": "efa55dc5b3f2f5222982c1c9f0214ad1e2601624",
+      "at": "2026-03-27T21:25:16Z",
       "passes": 1,
       "pr": 11008
     },
     ".agents/tools/credentials/psst.md": {
-      "at": "2026-03-31T06:15:51Z",
       "hash": "73a231518b35816ca652d0a2aa130a21dd2b8f1d",
+      "at": "2026-03-31T06:15:51Z",
       "passes": 2,
       "pr": 14687
     },
     ".agents/tools/credentials/sops.md": {
-      "at": "2026-03-28T08:58:29Z",
       "hash": "927fea51df6b5ed15ee41b1473f26bf7b526ca38",
+      "at": "2026-03-28T08:58:29Z",
       "passes": 1,
       "pr": 11560
     },
     ".agents/tools/credentials/vaultwarden.md": {
-      "at": "2026-03-29T12:36:43Z",
       "hash": "49a473adf85c8382799bc059d99c1693cbea98a9",
+      "at": "2026-03-29T12:36:43Z",
       "passes": 1,
       "pr": 12951
     },
     ".agents/tools/data-extraction/outscraper.md": {
-      "at": "2026-03-28T16:41:16Z",
       "hash": "a3e3c1fee3571f9cfe07e4f90d47e3aa0c2c758a",
+      "at": "2026-03-28T16:41:16Z",
       "passes": 1,
       "pr": 12021
     },
     ".agents/tools/database/pglite-local-first.md": {
-      "at": "2026-03-28T15:30:29Z",
       "hash": "57487b7d3c5e896eaebeeccd458d76e65cae5b8d",
+      "at": "2026-03-28T15:30:29Z",
       "passes": 1,
       "pr": 11920
     },
     ".agents/tools/database/vector-search.md": {
-      "at": "2026-03-28T03:54:19Z",
       "hash": "d365046c212da54c3ab0ede8217cce083de484c5",
+      "at": "2026-03-28T03:54:19Z",
       "passes": 1,
       "pr": 11351
     },
     ".agents/tools/database/vector-search/per-tenant-rag.md": {
-      "at": "2026-03-28T06:40:00Z",
       "hash": "9c0a46c72bbf38115155d5214f0256365a03260b",
+      "at": "2026-03-28T06:40:00Z",
       "passes": 1,
       "pr": 11417
     },
     ".agents/tools/database/vector-search/zvec.md": {
-      "at": "2026-03-28T08:17:41Z",
       "hash": "1929000365507621f52d563ad2b63e9f51feab8d",
+      "at": "2026-03-28T08:17:41Z",
       "passes": 1,
       "pr": 11570
     },
     ".agents/tools/deployment/agent-skills.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "f87f82d19f5adc7267836c963cef8b6ecbc7fb5a",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16540
     },
     ".agents/tools/deployment/cloudron-app-packaging-skill.md": {
-      "at": "2026-04-02T20:39:36Z",
       "hash": "b0b18eb482f60246c0d1961494667f4f06c3a711",
+      "at": "2026-04-02T20:39:36Z",
       "passes": 2,
       "pr": 14880
     },
     ".agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md": {
-      "at": "2026-03-29T10:18:21Z",
       "hash": "0afd51341e71da8060a8a9e2759bf6629a430093",
+      "at": "2026-03-29T10:18:21Z",
       "passes": 1,
       "pr": 12844
     },
     ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
-      "at": "2026-04-02T00:00:00Z",
       "hash": "edecc25afbace885cab2eac01e07629d890a4fad",
+      "at": "2026-04-02T00:00:00Z",
       "passes": 1,
       "pr": 0
     },
     ".agents/tools/deployment/cloudron-app-packaging.md": {
-      "at": "2026-03-28T03:54:01Z",
       "hash": "a6ddd4af870f4445d96eb4bf3c2d109fcb9219b7",
+      "at": "2026-03-28T03:54:01Z",
       "passes": 1,
       "pr": 11344
     },
     ".agents/tools/deployment/cloudron-app-publishing-skill.md": {
-      "at": "2026-04-03T04:22:59Z",
       "hash": "ff5501b9093d7a7509ccbce26b8545169cc71374",
+      "at": "2026-04-03T04:22:59Z",
       "passes": 2,
       "pr": 15497
     },
     ".agents/tools/deployment/cloudron-git-reference.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "76c053a118c8fd08c126bf8a6e54cac3a4eae0c2",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16478
     },
     ".agents/tools/deployment/cloudron-server-ops-skill.md": {
-      "at": "2026-03-30T03:33:52Z",
       "hash": "254ad33e9ddc52578f62584070efe94ef28a6860",
+      "at": "2026-03-30T03:33:52Z",
       "passes": 2,
       "pr": 13678
     },
     ".agents/tools/deployment/coolify-cli.md": {
-      "at": "2026-03-30T04:52:05Z",
       "hash": "bceeb18bd221b65e03b4fa7ec3633091a8ee57e2",
+      "at": "2026-03-30T04:52:05Z",
       "passes": 1,
       "pr": 13734
     },
     ".agents/tools/deployment/coolify-setup.md": {
-      "at": "2026-03-29T15:50:41Z",
       "hash": "2c1d4944a61281731b12ea26d5aad0a44c69740b",
+      "at": "2026-03-29T15:50:41Z",
       "passes": 2,
       "pr": 13067
     },
     ".agents/tools/deployment/coolify.md": {
-      "at": "2026-03-29T08:10:34Z",
       "hash": "c69569ccf737f434c5d2c4c031ab9fb87e3f6125",
+      "at": "2026-03-29T08:10:34Z",
       "passes": 1,
       "pr": 12748
     },
     ".agents/tools/deployment/daytona.md": {
-      "at": "2026-03-28T13:37:28Z",
       "hash": "752d573096d1a59e09ee119494e907e2e17d34ee",
+      "at": "2026-03-28T13:37:28Z",
       "passes": 1,
       "pr": 11846
     },
     ".agents/tools/deployment/fly-io.md": {
-      "at": "2026-03-30T02:30:21Z",
       "hash": "31560e6a9e3aec1733571093c7cc53dd5f530e94",
+      "at": "2026-03-30T02:30:21Z",
       "passes": 1,
       "pr": 13596
     },
     ".agents/tools/deployment/hosting-comparison.md": {
-      "at": "2026-03-29T07:02:09Z",
       "hash": "d29068fa3678e9cf3c2d6709305d5d71e5488dcb",
+      "at": "2026-03-29T07:02:09Z",
       "passes": 1,
       "pr": 12661
     },
     ".agents/tools/deployment/uncloud.md": {
-      "at": "2026-03-28T09:17:40Z",
       "hash": "f0efc54a4b03f1e5a1398d94d063d72218a8de21",
+      "at": "2026-03-28T09:17:40Z",
       "passes": 1,
       "pr": 11712
     },
     ".agents/tools/deployment/vercel.md": {
-      "at": "2026-03-28T08:58:54Z",
       "hash": "c2084ec268e00720815607590f8bab4bc7082c53",
+      "at": "2026-03-28T08:58:54Z",
       "passes": 1,
       "pr": 11615
     },
     ".agents/tools/design/brand-identity.md": {
-      "at": "2026-03-29T16:31:32Z",
       "hash": "38405b39bf138bc9063395546f92ff1634cb96ec",
+      "at": "2026-03-29T16:31:32Z",
       "passes": 1,
       "pr": 13093
     },
     ".agents/tools/design/design-inspiration.md": {
-      "at": "2026-03-29T08:10:43Z",
       "hash": "c45174a87827d85931f259a2e60da60b030b9fef",
+      "at": "2026-03-29T08:10:43Z",
       "passes": 1,
       "pr": 12754
     },
     ".agents/tools/design/ui-ux-inspiration.md": {
-      "at": "2026-03-28T08:17:35Z",
       "hash": "fb4a8985ec3089753355c7a13d0665c878034369",
+      "at": "2026-03-28T08:17:35Z",
       "passes": 1,
       "pr": 11590
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
-      "at": "2026-03-28T15:30:35Z",
       "hash": "97a482f311bb9a1a99a103e7b77f815c8ce8af7e",
+      "at": "2026-03-28T15:30:35Z",
       "passes": 1,
       "pr": 11935
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/advanced.md": {
-      "at": "2026-03-29T11:51:51Z",
       "hash": "66bd6cabafb5379b9b183e5c0721e35852080713",
+      "at": "2026-03-29T11:51:51Z",
       "passes": 1,
       "pr": 12922
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
-      "at": "2026-03-28T16:00:33Z",
       "hash": "9fda0fe135c5d900b529cbf4c9b5095c72c9a79d",
+      "at": "2026-03-28T16:00:33Z",
       "passes": 1,
       "pr": 11987
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md": {
-      "at": "2026-03-29T21:43:04Z",
       "hash": "79456bef17217d0052079264a0c95b59456d5385",
+      "at": "2026-03-29T21:43:04Z",
       "passes": 1,
       "pr": 13300
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/class-er.md": {
-      "at": "2026-03-28T08:17:42Z",
       "hash": "e3929bc050f03d955e21543cfed73a4b69880579",
+      "at": "2026-03-28T08:17:42Z",
       "passes": 1,
       "pr": 11589
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/data-charts.md": {
-      "at": "2026-03-28T08:58:03Z",
       "hash": "ea8a64811a9c35a4274183f1c0c215be8c2a6aec",
+      "at": "2026-03-28T08:58:03Z",
       "passes": 1,
       "pr": 11602
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md": {
-      "at": "2026-03-30T04:52:39Z",
       "hash": "dd47fcc7b562ecb9f085d0d7394553810ecabc8c",
+      "at": "2026-03-30T04:52:39Z",
       "passes": 1,
       "pr": 13784
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/sequence.md": {
-      "at": "2026-03-28T05:10:17Z",
       "hash": "162ba5164f7ffedc3b1d3497beabd56c6d58aaba",
+      "at": "2026-03-28T05:10:17Z",
       "passes": 1,
       "pr": 11392
     },
     ".agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md": {
-      "at": "2026-03-29T08:11:29Z",
       "hash": "2fda89c67e49f210c5079578f56272001edd02d9",
+      "at": "2026-03-29T08:11:29Z",
       "passes": 1,
       "pr": 12755
     },
     ".agents/tools/document/docstrange.md": {
-      "at": "2026-03-29T16:34:31Z",
       "hash": "3982c1885258882161976446bb94216d4e7df262",
+      "at": "2026-03-29T16:34:31Z",
       "passes": 1,
       "pr": 13102
     },
     ".agents/tools/document/document-creation.md": {
-      "at": "2026-03-28T08:17:34Z",
       "hash": "245a303a923bd18c0adc820adb9620f12d636d2b",
+      "at": "2026-03-28T08:17:34Z",
       "passes": 1,
       "pr": 11592
     },
     ".agents/tools/document/document-extraction.md": {
-      "at": "2026-03-28T15:30:30Z",
       "hash": "b0e790ef3e6481f532436eab39cac1d6ec92430b",
+      "at": "2026-03-28T15:30:30Z",
       "passes": 1,
       "pr": 11919
     },
     ".agents/tools/document/extraction-schemas.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "fa0ee1f8e92a38842d98674241507fd0cde43a81",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/01-design-principles.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "c557fde290bb52a65fa91d603c4366fdb0fcf3e7",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/02-purchase-invoice.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "d9c194618044c58a6f3a364bba869683957b26c1",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/03-expense-receipt.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "8c0553d204c9f8e111f7bb211d9b8e99a8fac453",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/04-credit-note.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "c58830493ee6a0ae1b3f77c6fb18a20db5e87ed4",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/05-sales-invoice.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "50c68e48c09eb85c30259361ceadadca01795e5e",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/06-generic-receipt.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "8cd493fef922d42decca280eaaec76c32de7f324",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/07-quickfile-mapping.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "329bb22bc68c98571c6bd075a6458573830bcd99",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/08-vat-handling.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "74ea1c15f941a48b3cb8d0a62dc8fa3ec590dd86",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/09-nominal-codes.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "7210b70a3f8072de3d50be138635dced20594d9d",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/10-classification.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "8822a182e225ee7360107f5e1938e4fc844670e3",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/11-pipeline-integration.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "377abccc10cb93b5f8b51010a48d6d947553b71c",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-schemas/12-validation.md": {
-      "at": "2026-03-28T08:58:45Z",
       "hash": "85fb1862ed295cbba2a8c11ed8ccef35d25fc2c4",
+      "at": "2026-03-28T08:58:45Z",
       "passes": 1,
       "pr": 11601
     },
     ".agents/tools/document/extraction-workflow.md": {
-      "at": "2026-04-01T23:23:22Z",
       "hash": "ff97788918db3fac18f34e7b0f3d18155d449e88",
+      "at": "2026-04-01T23:23:22Z",
       "passes": 1,
       "pr": 15350
     },
     ".agents/tools/git.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "9bc113efe808b36914cead169e86a5282a2d9d0e",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16428
     },
     ".agents/tools/git/authentication.md": {
-      "at": "2026-03-30T02:30:25Z",
       "hash": "4310ee08fa1669b77f15bfa029f5f44d44a38cd2",
+      "at": "2026-03-30T02:30:25Z",
       "passes": 1,
       "pr": 13538
     },
     ".agents/tools/git/conflict-resolution.md": {
-      "at": "2026-03-28T14:15:35Z",
       "hash": "f5933df58340b4ee0c5b329808c991807ed8a047",
+      "at": "2026-03-28T14:15:35Z",
       "passes": 1,
       "pr": 11909
     },
     ".agents/tools/git/git-security.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "7e362c40925cfe604ba484cf3e06993edf41c4ad",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16442
     },
     ".agents/tools/git/gitea-cli.md": {
-      "at": "2026-03-29T07:02:58Z",
       "hash": "9452ee8a8cf48269d5848e1d31384a3df0462ec5",
+      "at": "2026-03-29T07:02:58Z",
       "passes": 1,
       "pr": 12618
     },
     ".agents/tools/git/github-actions.md": {
-      "at": "2026-04-03T12:15:32Z",
       "hash": "9315e263cad3848da2640a0392d82bd02c22b487",
+      "at": "2026-04-03T12:15:32Z",
       "passes": 1,
       "pr": 16558
     },
     ".agents/tools/git/github-cli.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "dbc4e2c3b4140e5631e6e03994c68a941d11b1ad",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16499
     },
     ".agents/tools/git/gitlab-cli.md": {
-      "at": "2026-03-29T03:15:01Z",
       "hash": "de6952c2d9d3316c91c942921113892f89ddd42c",
+      "at": "2026-03-29T03:15:01Z",
       "passes": 1,
       "pr": 12498
     },
     ".agents/tools/git/jujutsu.md": {
-      "at": "2026-04-03T12:15:32Z",
       "hash": "ad5d89b33b790787ec44d8782eb0d3116e94d897",
+      "at": "2026-04-03T12:15:32Z",
       "passes": 1,
       "pr": 16553
     },
     ".agents/tools/git/lumen.md": {
-      "at": "2026-04-01T23:23:19Z",
       "hash": "4a2b4339feef8da5578b029993d870a6416758b7",
+      "at": "2026-04-01T23:23:19Z",
       "passes": 1,
       "pr": 15327
     },
     ".agents/tools/git/opencode-github-security.md": {
-      "at": "2026-03-28T22:39:20Z",
       "hash": "7614267ce5278cc0f8d3e46a9301f179a610b9f3",
+      "at": "2026-03-28T22:39:20Z",
       "passes": 1,
       "pr": 12309
     },
     ".agents/tools/git/opencode-github.md": {
-      "at": "2026-03-28T03:54:27Z",
       "hash": "02c6d675ca2b756817bc639ec03d999e1f3ea58e",
+      "at": "2026-03-28T03:54:27Z",
       "passes": 1,
       "pr": 11349
     },
     ".agents/tools/git/opencode-gitlab.md": {
-      "at": "2026-03-29T20:54:06Z",
       "hash": "dbbdec9a030f52229eab4d047431f4ed5b0de5ca",
+      "at": "2026-03-29T20:54:06Z",
       "passes": 1,
       "pr": 13295
     },
     ".agents/tools/git/worktrunk.md": {
-      "at": "2026-03-28T10:27:11Z",
       "hash": "bafc956a55ed67b84dfc0722955434b85dd6202e",
+      "at": "2026-03-28T10:27:11Z",
       "passes": 1,
       "pr": 11760
     },
     ".agents/tools/infrastructure/cloud-gpu.md": {
-      "at": "2026-03-29T21:43:22Z",
       "hash": "f2b2d82030ffec23c21ca82c2833ba2cbac2dcc9",
+      "at": "2026-03-29T21:43:22Z",
       "passes": 1,
       "pr": 13346
     },
     ".agents/tools/infrastructure/cloudflare-ai.md": {
-      "at": "2026-04-01T20:50:00Z",
       "hash": "3896e5a3b0f6a86223b5def1d491061d8264b671",
+      "at": "2026-04-01T20:50:00Z",
       "passes": 2,
       "pr": 15091
     },
     ".agents/tools/infrastructure/fireworks.md": {
-      "at": "2026-03-28T11:52:26Z",
       "hash": "6025fc8a3ce3cadba1f1d8d00c699c8fe970b015",
+      "at": "2026-03-28T11:52:26Z",
       "passes": 1,
       "pr": 11813
     },
     ".agents/tools/infrastructure/nearai.md": {
-      "at": "2026-03-29T10:47:24Z",
       "hash": "c20f6f36a9c7c2fabc45e4c356d09b3589fb6a64",
+      "at": "2026-03-29T10:47:24Z",
       "passes": 1,
       "pr": 12869
     },
     ".agents/tools/infrastructure/nvidia-cloud.md": {
-      "at": "2026-03-29T08:49:20Z",
       "hash": "3dfae170793fb08c63d93733cd5ad81760d651ee",
+      "at": "2026-03-29T08:49:20Z",
       "passes": 1,
       "pr": 12776
     },
     ".agents/tools/infrastructure/together.md": {
-      "at": "2026-03-29T17:15:24Z",
       "hash": "cb2b6cf6c54db6f97c2bde70675f3c29b30b88fa",
+      "at": "2026-03-29T17:15:24Z",
       "passes": 1,
       "pr": 13113
     },
     ".agents/tools/local-models/huggingface.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "f1cfbf6a979f5b789de3b9a358883ed0c5c57030",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16479
     },
     ".agents/tools/local-models/local-models.md": {
-      "at": "2026-03-29T08:11:30Z",
       "hash": "9809ec0871562ca709e8ef42cf6c3b67d24b69ce",
+      "at": "2026-03-29T08:11:30Z",
       "passes": 1,
       "pr": 12758
     },
     ".agents/tools/mcp-toolkit/mcporter.md": {
-      "at": "2026-03-28T14:16:17Z",
       "hash": "9a7f856e52fb6226b2661e21b00fee79fd906561",
+      "at": "2026-03-28T14:16:17Z",
       "passes": 1,
       "pr": 11906
     },
     ".agents/tools/mcp/cloudflare-code-mode.md": {
-      "at": "2026-03-29T23:54:08Z",
       "hash": "57f7a7876d43b24c1a40f59332c004b5932adae1",
+      "at": "2026-03-29T23:54:08Z",
       "passes": 1,
       "pr": 13428
     },
     ".agents/tools/mobile/agent-device.md": {
-      "at": "2026-03-29T08:49:16Z",
       "hash": "29bde4b26353446f6b35c132fcc1c01a80b71d4c",
+      "at": "2026-03-29T08:49:16Z",
       "passes": 1,
       "pr": 12788
     },
     ".agents/tools/mobile/app-dev-assets.md": {
-      "at": "2026-03-29T16:34:32Z",
       "hash": "7c4254ecd409ec8aa9947d5ac9bb1043f89ee75c",
+      "at": "2026-03-29T16:34:32Z",
       "passes": 1,
       "pr": 13108
     },
     ".agents/tools/mobile/app-dev-backend.md": {
-      "at": "2026-03-29T20:54:10Z",
       "hash": "1521ed7526fbc0fb399a1f5edf01adb4129a08f6",
+      "at": "2026-03-29T20:54:10Z",
       "passes": 1,
       "pr": 13293
     },
     ".agents/tools/mobile/app-dev-expo.md": {
-      "at": "2026-03-30T03:34:14Z",
       "hash": "e0094f52acaa98cc6a2c7aa9aeae6321a204cb27",
+      "at": "2026-03-30T03:34:14Z",
       "passes": 1,
       "pr": 13609
     },
     ".agents/tools/mobile/app-dev-notifications.md": {
-      "at": "2026-03-29T16:34:38Z",
       "hash": "c414024f2e98e68e7f70531095cc1abe49cceccd",
+      "at": "2026-03-29T16:34:38Z",
       "passes": 1,
       "pr": 13111
     },
     ".agents/tools/mobile/app-dev-publishing.md": {
-      "at": "2026-03-29T08:11:31Z",
       "hash": "ceb75a07d39bcfe0be156773a92714fb3bebce23",
+      "at": "2026-03-29T08:11:31Z",
       "passes": 2,
       "pr": 12760
     },
     ".agents/tools/mobile/app-dev-swift.md": {
-      "at": "2026-03-29T07:03:03Z",
       "hash": "15ec4fad109dcdce50f6ed4a70d117caff12f906",
+      "at": "2026-03-29T07:03:03Z",
       "passes": 1,
       "pr": 12506
     },
     ".agents/tools/mobile/app-dev-testing.md": {
-      "at": "2026-04-01T20:59:09Z",
       "hash": "39d2e16ec10aee6ed51d5a9b586e20ac0ba4276a",
+      "at": "2026-04-01T20:59:09Z",
       "passes": 1,
       "pr": 15219
     },
     ".agents/tools/mobile/app-dev.md": {
-      "at": "2026-03-29T08:10:35Z",
       "hash": "5fa80cfb5528478d449196a550ffb263ac4380e0",
+      "at": "2026-03-29T08:10:35Z",
       "passes": 1,
       "pr": 12752
     },
     ".agents/tools/mobile/app-store-connect.md": {
-      "at": "2026-03-29T07:02:17Z",
       "hash": "55340aa49411b8c5faf342ecbd1284bd9b126390",
+      "at": "2026-03-29T07:02:17Z",
       "passes": 1,
       "pr": 12625
     },
     ".agents/tools/mobile/ios-simulator-mcp.md": {
-      "at": "2026-03-29T20:53:56Z",
       "hash": "c671f21c21913d5bc3199aaaf1ad5ea389fa67e7",
+      "at": "2026-03-29T20:53:56Z",
       "passes": 1,
       "pr": 13299
     },
     ".agents/tools/mobile/maestro.md": {
-      "at": "2026-03-30T03:34:20Z",
       "hash": "9cfba2015ca5bd40086f5d15c690910a0a3c6bfd",
+      "at": "2026-03-30T03:34:20Z",
       "passes": 1,
       "pr": 13525
     },
     ".agents/tools/mobile/minisim.md": {
-      "at": "2026-03-29T21:43:16Z",
       "hash": "4e237b094b421f7ff8557426808fd3d6380b4ef1",
+      "at": "2026-03-29T21:43:16Z",
       "passes": 1,
       "pr": 13340
     },
     ".agents/tools/mobile/xcodebuild-mcp.md": {
-      "at": "2026-04-03T11:54:13Z",
       "hash": "7de1a6f27f79e78e4b33ec6a8c81d92342cf0922",
+      "at": "2026-04-03T11:54:13Z",
       "passes": 1,
       "pr": 16539
     },
     ".agents/tools/monorepo/turborepo.md": {
-      "at": "2026-03-30T06:49:45Z",
       "hash": "f7bededd972af841de7b68b6169a00b890078d3e",
+      "at": "2026-03-30T06:49:45Z",
       "passes": 2,
       "pr": 13795
     },
     ".agents/tools/ocr/glm-ocr.md": {
-      "at": "2026-04-03T12:15:32Z",
       "hash": "2f69712b674fe089100c62ae6831cd3bbe329f27",
+      "at": "2026-04-03T12:15:32Z",
       "passes": 1,
       "pr": 16554
     },
     ".agents/tools/ocr/ocr-research.md": {
-      "at": "2026-03-28T13:37:30Z",
       "hash": "667a0af0fe47f5c2c316520d13beb61f1f9d0b7f",
+      "at": "2026-03-28T13:37:30Z",
       "passes": 1,
       "pr": 11857
     },
     ".agents/tools/ocr/paddleocr.md": {
-      "at": "2026-03-30T06:49:51Z",
       "hash": "7e0aaf06abd6c0d64ef0645a3cd58ac02b9e11f4",
+      "at": "2026-03-30T06:49:51Z",
       "passes": 1,
       "pr": 13765
     },
     ".agents/tools/opencode/opencode-anthropic-auth.md": {
-      "at": "2026-03-29T03:15:28Z",
       "hash": "f05464c433b2b8e301af49ac5693cba5662ca6f7",
+      "at": "2026-03-29T03:15:28Z",
       "passes": 1,
       "pr": 12522
     },
     ".agents/tools/opencode/opencode.md": {
-      "at": "2026-03-29T11:20:16Z",
       "hash": "b338bd4964d10e7780deddb27fc48d772a07be3b",
+      "at": "2026-03-29T11:20:16Z",
       "passes": 1,
       "pr": 12843
     },
     ".agents/tools/pdf/libpdf.md": {
-      "at": "2026-03-28T20:16:42Z",
       "hash": "9d4d5fd4651f9132fb47d6467e53683fd7f0553b",
+      "at": "2026-03-28T20:16:42Z",
       "passes": 1,
       "pr": 12161
     },
     ".agents/tools/performance/performance.md": {
-      "at": "2026-03-28T16:00:21Z",
       "hash": "478f1736c9c362f035765d45caddb4eebdec8071",
+      "at": "2026-03-28T16:00:21Z",
       "passes": 1,
       "pr": 11983
     },
     ".agents/tools/performance/webpagetest.md": {
-      "at": "2026-03-28T08:17:50Z",
       "hash": "e0b3e8da23436e916aecd40d37bceeea48f99642",
+      "at": "2026-03-28T08:17:50Z",
       "passes": 1,
       "pr": 11594
     },
     ".agents/tools/productivity/notes.md": {
-      "at": "2026-04-03T12:15:32Z",
       "hash": "8b8bbc3005076b5ccaff84b0a48254a7e2587078",
+      "at": "2026-04-03T12:15:32Z",
       "passes": 1,
       "pr": 16552
     },
     ".agents/tools/programming/modern-javascript-skill.md": {
-      "at": "2026-04-01T20:59:25Z",
       "hash": "3c3730959a3c618e3b3ed96d1ccd5eb95c2bfe3b",
+      "at": "2026-04-01T20:59:25Z",
       "passes": 1,
       "pr": 15131
     },
     ".agents/tools/programming/modern-javascript-skill/01-decision-trees.md": {
-      "at": "2026-04-01T20:59:25Z",
       "hash": "80190196c391d4314e034455e46fe218d57d1c58",
+      "at": "2026-04-01T20:59:25Z",
       "passes": 1,
       "pr": 15131
     },
     ".agents/tools/programming/modern-javascript-skill/02-es-versions.md": {
-      "at": "2026-04-01T20:59:25Z",
       "hash": "8c9215cc4697a3cd21125445386a8315acb42e0d",
+      "at": "2026-04-01T20:59:25Z",
       "passes": 1,
       "pr": 15131
     },
     ".agents/tools/programming/modern-javascript-skill/cheatsheet.md": {
-      "at": "2026-03-28T16:40:20Z",
       "hash": "5043165087af14cf58963d7a76e48ceed463cb6d",
+      "at": "2026-03-28T16:40:20Z",
       "passes": 1,
       "pr": 12042
     },
     ".agents/tools/programming/modern-javascript-skill/composition.md": {
-      "at": "2026-03-28T03:53:07Z",
       "hash": "fe9da3d05db78aac6b072235efe8b74f5c9fcf2b",
+      "at": "2026-03-28T03:53:07Z",
       "passes": 1,
       "pr": 11328
     },
     ".agents/tools/programming/modern-javascript-skill/concurrency.md": {
-      "at": "2026-03-29T22:50:16Z",
       "hash": "ca3483bf9f49a475d7947fa68bb46f12426ef656",
+      "at": "2026-03-29T22:50:16Z",
       "passes": 2,
       "pr": 13349
     },
     ".agents/tools/programming/modern-javascript-skill/es2016-es2017.md": {
-      "at": "2026-04-03T01:11:46Z",
       "hash": "6e238e8d6cd856c6d54aeeda15ded6763fbb7439",
+      "at": "2026-04-03T01:11:46Z",
       "passes": 1,
       "pr": 15969
     },
     ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
-      "at": "2026-03-28T05:50:55Z",
       "hash": "b59a17a028d181e2f55c45e58c371ca999d9a2ee",
+      "at": "2026-03-28T05:50:55Z",
       "passes": 1,
       "pr": 11439
     },
     ".agents/tools/programming/modern-javascript-skill/es2022-es2023.md": {
-      "at": "2026-03-28T03:53:13Z",
       "hash": "5e5dfb7e18557b8e26c5c48c090c8df94eda485c",
+      "at": "2026-03-28T03:53:13Z",
       "passes": 1,
       "pr": 11337
     },
     ".agents/tools/programming/modern-javascript-skill/es2024.md": {
-      "at": "2026-03-27T21:25:08Z",
       "hash": "5ff178dfe9603a724792aaef45d63f4b33fce7ef",
+      "at": "2026-03-27T21:25:08Z",
       "passes": 1,
       "pr": 11002
     },
     ".agents/tools/programming/modern-javascript-skill/es2025.md": {
-      "at": "2026-03-28T21:58:57Z",
       "hash": "e23026c24b61f06282834858aead51f63df3de4d",
+      "at": "2026-03-28T21:58:57Z",
       "passes": 1,
       "pr": 12234
     },
     ".agents/tools/programming/modern-javascript-skill/immutability.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "bfadffb9d971049a407c8c48c2dd4d858da039a6",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16493
     },
     ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
-      "at": "2026-03-29T07:02:28Z",
       "hash": "a2b88a20fedbcbbf37624126551caf4b6a101400",
+      "at": "2026-03-29T07:02:28Z",
       "passes": 1,
       "pr": 12584
     },
     ".agents/tools/research/providers/crft-lookup.md": {
-      "at": "2026-03-30T03:34:28Z",
       "hash": "70a64dd60d9a32431e5c36f75d0ad6aed1865c46",
+      "at": "2026-03-30T03:34:28Z",
       "passes": 1,
       "pr": 13542
     },
     ".agents/tools/research/providers/openexplorer.md": {
-      "at": "2026-04-03T01:53:17Z",
       "hash": "04542bb168595636e4a15f66fbdaafff8c18c327",
+      "at": "2026-04-03T01:53:17Z",
       "passes": 2,
       "pr": 15822
     },
     ".agents/tools/research/providers/unbuilt.md": {
-      "at": "2026-03-29T12:36:25Z",
       "hash": "24d4b4257014273b29b58f5e185f3320e798dad0",
+      "at": "2026-03-29T12:36:25Z",
       "passes": 1,
       "pr": 12945
     },
     ".agents/tools/research/providers/wappalyzer.md": {
-      "at": "2026-03-28T20:17:04Z",
       "hash": "ef665188513a7db11f82af28c6b0440d2b3943d5",
+      "at": "2026-03-28T20:17:04Z",
       "passes": 1,
       "pr": 12115
     },
     ".agents/tools/research/tech-stack-lookup.md": {
-      "at": "2026-03-29T07:02:42Z",
       "hash": "bb8bdd9ccd46c7cc0742a5ba1849bb47746c2110",
+      "at": "2026-03-29T07:02:42Z",
       "passes": 1,
       "pr": 12579
     },
     ".agents/tools/security/cdn-origin-ip.md": {
-      "at": "2026-03-29T20:53:57Z",
       "hash": "0ffd8a94c87de9f75a5515cd4ad4e87ab4b1552b",
+      "at": "2026-03-29T20:53:57Z",
       "passes": 1,
       "pr": 13290
     },
     ".agents/tools/security/ip-reputation.md": {
-      "at": "2026-03-28T03:54:03Z",
       "hash": "a1da2aa2f5e2f454f3c1dbcd3a7a819a72cd80dd",
+      "at": "2026-03-28T03:54:03Z",
       "passes": 1,
       "pr": 11342
     },
     ".agents/tools/security/opsec.md": {
-      "at": "2026-03-29T03:15:14Z",
       "hash": "c0427c90ef2576abbb9115f920944e06ee023080",
+      "at": "2026-03-29T03:15:14Z",
       "passes": 1,
       "pr": 12507
     },
     ".agents/tools/security/privacy-filter.md": {
-      "at": "2026-03-28T16:41:02Z",
       "hash": "20015ffb18e50ebb7071f1b6299b4404bdcd4071",
+      "at": "2026-03-28T16:41:02Z",
       "passes": 1,
       "pr": 12014
     },
     ".agents/tools/security/prompt-injection-defender.md": {
-      "at": "2026-03-28T17:11:06Z",
       "hash": "0ee667b145d5e9aa8e6aefabf4ddc1c717cac0a0",
+      "at": "2026-03-28T17:11:06Z",
       "passes": 1,
       "pr": 12057
     },
     ".agents/tools/security/shannon.md": {
-      "at": "2026-03-28T16:41:03Z",
       "hash": "a48914d21141559b0cf7677395979bd17f429b85",
+      "at": "2026-03-28T16:41:03Z",
       "passes": 1,
       "pr": 12016
     },
     ".agents/tools/security/tamper-evident-audit.md": {
-      "at": "2026-03-29T21:43:17Z",
       "hash": "ef75d5914e0ae15e449ccd4480b0add3eda84c71",
+      "at": "2026-03-29T21:43:17Z",
       "passes": 1,
       "pr": 13316
     },
     ".agents/tools/security/tirith.md": {
-      "at": "2026-04-03T04:23:07Z",
       "hash": "15fcd67ea17b09530a447a2bbff27179a8d063cc",
+      "at": "2026-04-03T04:23:07Z",
       "passes": 1,
       "pr": 15777
     },
     ".agents/tools/task-management/beads.md": {
-      "at": "2026-03-29T09:39:21Z",
       "hash": "f42ad2e963039fd53ee52d1443827cbe4f6158c0",
+      "at": "2026-03-29T09:39:21Z",
       "passes": 1,
       "pr": 12830
     },
     ".agents/tools/terminal/terminal-optimization.md": {
-      "at": "2026-03-29T03:15:29Z",
       "hash": "f33e57108fd87d88906e414ae5caf4d169efb557",
+      "at": "2026-03-29T03:15:29Z",
       "passes": 1,
       "pr": 12526
     },
     ".agents/tools/terminal/terminal-title.md": {
-      "at": "2026-04-03T01:11:48Z",
       "hash": "a159d1374538460666970b226c494586840c5a08",
+      "at": "2026-04-03T01:11:48Z",
       "passes": 1,
       "pr": 15726
     },
     ".agents/tools/ui/ai-chat-sidebar.md": {
-      "at": "2026-04-02T15:28:13Z",
       "hash": "fc9db0532fa56a02b82ccc7692d25933098eb6d4",
+      "at": "2026-04-02T15:28:13Z",
       "passes": 3,
       "pr": 13958
     },
     ".agents/tools/ui/frontend-debugging.md": {
-      "at": "2026-03-28T03:54:06Z",
       "hash": "272d16549c353500a19666d7ace227b34b2ae363",
+      "at": "2026-03-28T03:54:06Z",
       "passes": 1,
       "pr": 11340
     },
     ".agents/tools/ui/i18next.md": {
-      "at": "2026-03-28T10:27:25Z",
       "hash": "ce750937b182da6a4a2cce512b141f16da789fcd",
+      "at": "2026-03-28T10:27:25Z",
       "passes": 1,
       "pr": 11710
     },
     ".agents/tools/ui/nextjs-layouts.md": {
-      "at": "2026-03-28T11:20:37Z",
       "hash": "df90871ad91810f05326405fe711c4ff4be9460b",
+      "at": "2026-03-28T11:20:37Z",
       "passes": 1,
       "pr": 11732
     },
     ".agents/tools/ui/nothing-design-skill.md": {
-      "at": "2026-04-02T13:10:57Z",
       "hash": "79354d8379744c33148bf864cad6dfd666796f48",
+      "at": "2026-04-02T13:10:57Z",
       "passes": 1,
       "pr": 15566
     },
     ".agents/tools/ui/nothing-design-skill/01-philosophy.md": {
-      "at": "2026-04-02T13:10:58Z",
       "hash": "8bc354205fdf54beaf7d172ac0eee06a8b64e976",
+      "at": "2026-04-02T13:10:58Z",
       "passes": 1,
       "pr": 15566
     },
     ".agents/tools/ui/nothing-design-skill/02-craft-rules.md": {
-      "at": "2026-04-02T13:10:58Z",
       "hash": "94d72d92e90419eada4260a7d0b996d620643f11",
+      "at": "2026-04-02T13:10:58Z",
       "passes": 1,
       "pr": 15566
     },
     ".agents/tools/ui/nothing-design-skill/03-anti-patterns.md": {
-      "at": "2026-04-02T13:10:58Z",
       "hash": "916c5faa425da052f819788628e826d489ed10c9",
+      "at": "2026-04-02T13:10:58Z",
       "passes": 1,
       "pr": 15566
     },
     ".agents/tools/ui/nothing-design-skill/04-workflow.md": {
-      "at": "2026-04-02T13:10:58Z",
       "hash": "3a1d2cbabb57f2dabfa60c4fcb1e9659729a53af",
+      "at": "2026-04-02T13:10:58Z",
       "passes": 1,
       "pr": 15566
     },
     ".agents/tools/ui/nothing-design-skill/components.md": {
-      "at": "2026-04-03T03:15:24Z",
       "hash": "c939c537eafaeea9476376e6189ed8f8d28c1ad8",
-      "issue": "GH#15366",
-      "lines_after": 125,
-      "lines_before": 153,
+      "at": "2026-04-03T03:15:24Z",
       "passes": 1
     },
     ".agents/tools/ui/nothing-design-skill/tokens.md": {
-      "at": "2026-04-03T12:15:29Z",
       "hash": "975c918e2fa0546f3635cee13a106dee523d47b4",
+      "at": "2026-04-03T12:15:29Z",
       "passes": 4,
       "pr": 16561
     },
     ".agents/tools/ui/react-context.md": {
-      "at": "2026-03-30T06:49:50Z",
       "hash": "dee0f2d9a70f699ee8e09bc3c855e84eabb9a806",
+      "at": "2026-03-30T06:49:50Z",
       "passes": 1,
       "pr": 13766
     },
     ".agents/tools/ui/react-email.md": {
-      "at": "2026-03-29T07:02:59Z",
       "hash": "44be6e93a23aa087b4b70af9dc49a1c566c47e8c",
+      "at": "2026-03-29T07:02:59Z",
       "passes": 1,
       "pr": 12619
     },
     ".agents/tools/ui/shadcn.md": {
-      "at": "2026-03-29T07:02:41Z",
       "hash": "b65c32526cb52d71c76cead493b7c71147417a78",
+      "at": "2026-03-29T07:02:41Z",
       "passes": 1,
       "pr": 12590
     },
     ".agents/tools/ui/tailwind-css.md": {
-      "at": "2026-03-29T07:02:43Z",
       "hash": "1f3b2d4e3add5cecfe530b8db9addf411a9069fe",
+      "at": "2026-03-29T07:02:43Z",
       "passes": 1,
       "pr": 12576
     },
     ".agents/tools/ui/wxt.md": {
-      "at": "2026-03-28T13:37:50Z",
       "hash": "3705faa0407468fc44819d98501ad0ff13ca1934",
+      "at": "2026-03-28T13:37:50Z",
       "passes": 1,
       "pr": 11870
     },
     ".agents/tools/verification/parallel-verify.md": {
-      "at": "2026-03-29T10:19:07Z",
       "hash": "0abbe9f5d2f2082016fd851080ea1f9a84a03fe9",
+      "at": "2026-03-29T10:19:07Z",
       "passes": 1,
       "pr": 12849
     },
     ".agents/tools/video/remotion-3d.md": {
-      "at": "2026-04-01T20:59:48Z",
       "hash": "054778cef20067cd0e02cbd7b049333f562e6e4a",
+      "at": "2026-04-01T20:59:48Z",
       "passes": 1,
       "pr": 14897
     },
     ".agents/tools/video/remotion-audio.md": {
-      "at": "2026-03-29T12:37:07Z",
       "hash": "c5cce614253505277075e44f178650fab250bd7b",
+      "at": "2026-03-29T12:37:07Z",
       "passes": 1,
       "pr": 12942
     },
     ".agents/tools/video/remotion-calculate-metadata.md": {
-      "at": "2026-04-03T03:37:02Z",
       "hash": "4d9fc5e53279ac48361a627f49e9a6559d104b10",
+      "at": "2026-04-03T03:37:02Z",
       "passes": 1,
       "pr": 16141
     },
     ".agents/tools/video/remotion-compositions.md": {
-      "at": "2026-03-29T23:18:01Z",
       "hash": "6b00afa2299a8d08eaacd114c67804f6d87614b1",
+      "at": "2026-03-29T23:18:01Z",
       "passes": 1,
       "pr": 13427
     },
     ".agents/tools/video/remotion-display-captions.md": {
-      "at": "2026-04-03T11:54:14Z",
       "hash": "d019511525698e04eb9485a13a4ede10ee0c94c3",
+      "at": "2026-04-03T11:54:14Z",
       "passes": 1,
       "pr": 16476
     },
     ".agents/tools/video/remotion-extract-frames.md": {
-      "at": "2026-04-03T03:15:28Z",
       "hash": "cdadd937d6ba36526460ec12feb224e7b3bdc2b8",
+      "at": "2026-04-03T03:15:28Z",
       "passes": 1,
       "pr": 15907
     },
     ".agents/tools/video/remotion-fonts.md": {
-      "at": "2026-04-02T14:42:45Z",
       "hash": "2e12fc37c6a4f8397a9444f522ea88ef9d10285f",
+      "at": "2026-04-02T14:42:45Z",
       "passes": 1,
       "pr": 15615
     },
     ".agents/tools/video/remotion-gifs.md": {
-      "at": "2026-03-29T22:09:13Z",
       "hash": "c87be7656e27afb4f5f23e41571f8428b21345c4",
+      "at": "2026-03-29T22:09:13Z",
       "passes": 1,
       "pr": 13322
     },
     ".agents/tools/video/remotion-images.md": {
-      "at": "2026-03-30T03:34:15Z",
       "hash": "789b0f83404d30882f5f6b24317d4319f95dd107",
+      "at": "2026-03-30T03:34:15Z",
       "passes": 1,
       "pr": 13527
     },
     ".agents/tools/video/remotion-import-srt-captions.md": {
-      "at": "2026-04-02T04:56:51Z",
       "hash": "75f8b0d089b9eaae8a7e08498af9b8c5f1ac4655",
+      "at": "2026-04-02T04:56:51Z",
       "passes": 1,
       "pr": 15490
     },
     ".agents/tools/video/remotion-lottie.md": {
-      "at": "2026-04-02T04:56:53Z",
       "hash": "72d843e6717a28f61294372a6752cb8e9736fe6b",
+      "at": "2026-04-02T04:56:53Z",
       "passes": 1,
       "pr": 15525
     },
     ".agents/tools/video/remotion-measuring-text.md": {
-      "at": "2026-03-29T21:43:06Z",
       "hash": "619d768e114ab99f64b37c93d1628ae5cb7d54a4",
+      "at": "2026-03-29T21:43:06Z",
       "passes": 1,
       "pr": 13315
     },
     ".agents/tools/video/remotion-sequencing.md": {
-      "at": "2026-04-02T21:58:20Z",
       "hash": "0eab4c364cf2ee28b3c16e91d7af50b372717619",
+      "at": "2026-04-02T21:58:20Z",
       "passes": 1,
       "pr": 15533
     },
     ".agents/tools/video/remotion-timing.md": {
-      "at": "2026-04-01T20:59:53Z",
       "hash": "6213ebf1e87a77cab44febc35ec0a3b10fd2db4c",
+      "at": "2026-04-01T20:59:53Z",
       "passes": 1,
       "pr": 14881
     },
     ".agents/tools/video/remotion-transitions.md": {
-      "at": "2026-04-02T20:04:38Z",
       "hash": "01f1530e08f4e93364d68c8451ceeaecd548d511",
+      "at": "2026-04-02T20:04:38Z",
       "passes": 2,
       "pr": 14883
     },
     ".agents/tools/video/remotion-videos.md": {
-      "at": "2026-04-03T01:53:23Z",
       "hash": "782dd910314b807bedb05fbebcae4dc3e1ed84db",
+      "at": "2026-04-03T01:53:23Z",
       "passes": 1,
       "pr": 15852
     },
     ".agents/tools/video/remotion.md": {
-      "at": "2026-03-28T15:30:25Z",
       "hash": "e587ff6f81433c2bcc6b89ee139561849007d27e",
+      "at": "2026-03-28T15:30:25Z",
       "passes": 1,
       "pr": 11961
     },
     ".agents/tools/video/video-prompt-design.md": {
-      "at": "2026-03-28T17:30:25Z",
       "hash": "ba533270f9fe5f9dab9fe60e3a4eef1420e2bd6c",
+      "at": "2026-03-28T17:30:25Z",
       "passes": 1,
       "pr": 12071
     },
     ".agents/tools/video/yt-dlp.md": {
-      "at": "2026-03-28T11:20:27Z",
       "hash": "93855bd751f355d6ef75134ba3322330fcb7d596",
+      "at": "2026-03-28T11:20:27Z",
       "passes": 1,
       "pr": 11752
     },
     ".agents/tools/vision/image-editing.md": {
-      "at": "2026-03-29T21:43:18Z",
       "hash": "1b91142d29e8ff6515be5a6208386de1fcaf383d",
+      "at": "2026-03-29T21:43:18Z",
       "passes": 1,
       "pr": 13236
     },
     ".agents/tools/vision/image-generation.md": {
-      "at": "2026-03-29T19:51:31Z",
       "hash": "68fb24cbb02218008d86f1fb1381347f5ac1e533",
+      "at": "2026-03-29T19:51:31Z",
       "passes": 1,
       "pr": 13249
     },
     ".agents/tools/vision/image-understanding.md": {
-      "at": "2026-03-29T23:53:56Z",
       "hash": "e8a08b674fb1c451c0b3d2ebdc2290f860817199",
+      "at": "2026-03-29T23:53:56Z",
       "passes": 1,
       "pr": 13458
     },
     ".agents/tools/vision/overview.md": {
-      "at": "2026-04-01T20:59:38Z",
       "hash": "5abddf3f89fc529bd3119b8ae147961451728199",
+      "at": "2026-04-01T20:59:38Z",
       "passes": 1,
       "pr": 14932
     },
     ".agents/tools/voice/cloud-tts-apis.md": {
-      "at": "2026-03-28T08:18:23Z",
       "hash": "0a7ff7444bf603ab6328a2248b32bd9faf422b02",
+      "at": "2026-03-28T08:18:23Z",
       "passes": 1,
       "pr": 11637
     },
     ".agents/tools/voice/cloud-voice-agents.md": {
-      "at": "2026-03-28T16:40:25Z",
       "hash": "b389dcd17c677b3e21bc86397670fbf4d8a61b98",
+      "at": "2026-03-28T16:40:25Z",
       "passes": 1,
       "pr": 12005
     },
     ".agents/tools/voice/hyprwhspr.md": {
-      "at": "2026-03-29T16:34:36Z",
       "hash": "cd50b6d85cbb4fe055191de5b27fd60418def072",
+      "at": "2026-03-29T16:34:36Z",
       "passes": 1,
       "pr": 13103
     },
     ".agents/tools/voice/ios-shortcut.md": {
-      "at": "2026-03-29T20:53:52Z",
       "hash": "bf8f2ead853742819aa8ea972f3f39d7e38c58be",
+      "at": "2026-03-29T20:53:52Z",
       "passes": 1,
       "pr": 13286
     },
     ".agents/tools/voice/local-tts-models.md": {
-      "at": "2026-03-28T08:18:24Z",
       "hash": "a2985fa793b132d716e99ec9f9dd6eaf8252485a",
+      "at": "2026-03-28T08:18:24Z",
       "passes": 1,
       "pr": 11637
     },
     ".agents/tools/voice/pipecat-opencode.md": {
-      "at": "2026-03-28T16:40:27Z",
       "hash": "53d34b6a543b30dcbc6141ccea72d1364e7ae07d",
+      "at": "2026-03-28T16:40:27Z",
       "passes": 1,
       "pr": 12019
     },
     ".agents/tools/voice/qwen3-tts.md": {
-      "at": "2026-03-29T19:05:52Z",
       "hash": "5e96cd787b4b8b6ae97d6f3113978c0b334e5484",
+      "at": "2026-03-29T19:05:52Z",
       "passes": 1,
       "pr": 13190
     },
     ".agents/tools/voice/speech-to-speech.md": {
-      "at": "2026-03-29T14:29:05Z",
       "hash": "54c12a6e35c2fd9bdbc1476b98053f3fd40c5580",
+      "at": "2026-03-29T14:29:05Z",
       "passes": 1,
       "pr": 13005
     },
     ".agents/tools/voice/transcription.md": {
-      "at": "2026-03-29T07:02:26Z",
       "hash": "8edf7782bc2f37c48ade8d3b58fd5c611dc8bda5",
+      "at": "2026-03-29T07:02:26Z",
       "passes": 1,
       "pr": 12638
     },
     ".agents/tools/voice/voice-models.md": {
-      "at": "2026-03-28T08:18:24Z",
       "hash": "1048bd3b6ac334dea9f2685aef4b09642f318673",
+      "at": "2026-03-28T08:18:24Z",
       "passes": 1,
       "pr": 11637
     },
     ".agents/tools/voice/voiceink-shortcut.md": {
-      "at": "2026-03-28T16:40:39Z",
       "hash": "1d7af55d9fbf66d24dcb4f1cbba443617f0c992c",
+      "at": "2026-03-28T16:40:39Z",
       "passes": 1,
       "pr": 12017
     },
     ".agents/tools/wordpress/localwp.md": {
-      "at": "2026-03-28T08:58:34Z",
       "hash": "e2a3ea522c2f0a4739825f594f236c92f0eee0fa",
+      "at": "2026-03-28T08:58:34Z",
       "passes": 1,
       "pr": 11563
     },
     ".agents/tools/wordpress/mainwp.md": {
-      "at": "2026-03-28T11:20:17Z",
       "hash": "e16169565844b28fa00ca62439a068eec8dd965f",
+      "at": "2026-03-28T11:20:17Z",
       "passes": 1,
       "pr": 11794
     },
     ".agents/tools/wordpress/scf.md": {
-      "at": "2026-03-28T16:40:07Z",
       "hash": "4c62a3f4c5312a10699889660578437def83e31e",
+      "at": "2026-03-28T16:40:07Z",
       "passes": 1,
       "pr": 12035
     },
     ".agents/tools/wordpress/wp-admin.md": {
-      "at": "2026-03-28T08:17:43Z",
       "hash": "a02a72943cc4820447f81c73216b0f095c3f64e5",
+      "at": "2026-03-28T08:17:43Z",
       "passes": 1,
       "pr": 11587
     },
     ".agents/tools/wordpress/wp-cli-reference.md": {
-      "at": "2026-03-28T08:17:43Z",
       "hash": "0425ba4c94fd45b032e849987736bc4073970a7e",
+      "at": "2026-03-28T08:17:43Z",
       "passes": 1,
       "pr": 11587
     },
     ".agents/tools/wordpress/wp-dev.md": {
-      "at": "2026-03-29T22:09:16Z",
       "hash": "c88f6e0f70e046ce19bf119077cef234636b2f4d",
+      "at": "2026-03-29T22:09:16Z",
       "passes": 1,
       "pr": 13341
     },
     ".agents/tools/wordpress/wp-preferred.md": {
-      "at": "2026-03-28T03:54:25Z",
       "hash": "6664b61850bd5f84a8044f5dea501f4534b9a9d8",
+      "at": "2026-03-28T03:54:25Z",
       "passes": 1,
       "pr": 11353
     },
     ".agents/workflows/branch.md": {
-      "at": "2026-04-03T11:54:15Z",
       "hash": "cd2507f1889283d8b0922a389cb93d803d31945c",
+      "at": "2026-04-03T11:54:15Z",
       "passes": 1,
       "pr": 16416
     },
     ".agents/workflows/branch/bugfix.md": {
-      "at": "2026-04-02T04:56:46Z",
       "hash": "236b78c40f92a6c1b7c36085c0ecdf1ea42058be",
+      "at": "2026-04-02T04:56:46Z",
       "passes": 1,
       "pr": 15517
     },
     ".agents/workflows/branch/experiment.md": {
-      "at": "2026-04-02T21:20:20Z",
       "hash": "c0b292cdf26b8a6a6cbdff05b765a4601adaf875",
+      "at": "2026-04-02T21:20:20Z",
       "passes": 2,
       "pr": 0
     },
     ".agents/workflows/branch/hotfix.md": {
-      "at": "2026-04-01T20:59:04Z",
       "hash": "e1c1f9099b46c798fe473a7c23ff01bfa8e26b70",
+      "at": "2026-04-01T20:59:04Z",
       "passes": 1,
       "pr": 15209
     },
     ".agents/workflows/browser-qa.md": {
-      "at": "2026-04-03T04:23:07Z",
       "hash": "e99cc495cd3d86d49201d85f1f3a4c43523afaa9",
+      "at": "2026-04-03T04:23:07Z",
       "passes": 1,
       "pr": 15835
     },
     ".agents/workflows/bug-fixing.md": {
-      "at": "2026-03-29T16:34:52Z",
       "hash": "40fa82a3220595ff946fdc60ec4a03b193032f58",
+      "at": "2026-03-29T16:34:52Z",
       "passes": 1,
       "pr": 13056
     },
     ".agents/workflows/code-audit-remote.md": {
-      "at": "2026-03-28T15:31:24Z",
       "hash": "2702ee79b7d0f63a13b19d69171f937db3e37064",
+      "at": "2026-03-28T15:31:24Z",
       "passes": 1,
       "pr": 11825
     },
     ".agents/workflows/error-feedback.md": {
-      "at": "2026-04-03T01:11:46Z",
       "hash": "85e9eb0fc79cd4671cdd43c481a13d977775d291",
+      "at": "2026-04-03T01:11:46Z",
       "passes": 1,
       "pr": 15970
     },
     ".agents/workflows/feature-development.md": {
-      "at": "2026-03-29T16:31:49Z",
       "hash": "6b9311970a27d48d12002b62e59c9a6ac2087cc8",
+      "at": "2026-03-29T16:31:49Z",
       "passes": 1,
       "pr": 13065
     },
     ".agents/workflows/git-workflow.md": {
-      "at": "2026-03-29T08:49:32Z",
       "hash": "1ea0b652ceda9126a403a89555e29a02b1c7e3bd",
+      "at": "2026-03-29T08:49:32Z",
       "passes": 1,
       "pr": 12777
     },
     ".agents/workflows/milestone-validation.md": {
-      "at": "2026-03-28T03:53:42Z",
       "hash": "3e8c88a4d98e24993198b7a6cfc0c93b7825bd26",
+      "at": "2026-03-28T03:53:42Z",
       "passes": 1,
       "pr": 11286
     },
     ".agents/workflows/mission-orchestrator.md": {
-      "at": "2026-03-30T06:49:53Z",
       "hash": "930d59836f65199231e8354401053a66b0637281",
+      "at": "2026-03-30T06:49:53Z",
       "passes": 1,
       "pr": 13841
     },
     ".agents/workflows/mission-skill-learning.md": {
-      "at": "2026-04-03T11:54:11Z",
       "hash": "83583db20a5c20a591850f951a067de35398a6d0",
+      "at": "2026-04-03T11:54:11Z",
       "passes": 2,
       "pr": 14996
     },
     ".agents/workflows/multi-repo-workspace.md": {
-      "at": "2026-03-28T16:00:32Z",
       "hash": "00ea218df67c941a8858e0da60f7c252c850db7a",
+      "at": "2026-03-28T16:00:32Z",
       "passes": 1,
       "pr": 11984
     },
     ".agents/workflows/plans.md": {
-      "at": "2026-03-28T21:58:58Z",
       "hash": "d07529f81bc8ce92541f51393632bb2d04ce8fd4",
+      "at": "2026-03-28T21:58:58Z",
       "passes": 1,
       "pr": 12235
     },
     ".agents/workflows/postflight.md": {
-      "at": "2026-03-28T10:27:12Z",
       "hash": "4e10936d7f2007c0c034ff2f2d8f8110bdf3d0dc",
+      "at": "2026-03-28T10:27:12Z",
       "passes": 1,
       "pr": 11739
     },
     ".agents/workflows/pr.md": {
-      "at": "2026-03-29T14:29:47Z",
       "hash": "8f6584d97315d02aa4914a1f26165c57ff873479",
+      "at": "2026-03-29T14:29:47Z",
       "passes": 1,
       "pr": 13014
     },
     ".agents/workflows/preflight.md": {
-      "at": "2026-03-28T03:54:08Z",
       "hash": "c4695943d5555314205b87bb88020fb62de14b63",
+      "at": "2026-03-28T03:54:08Z",
       "passes": 1,
       "pr": 11341
     },
     ".agents/workflows/ralph-loop.md": {
-      "at": "2026-03-28T11:20:12Z",
       "hash": "552b1c4af3571c286790521b4cf26446ab3bb729",
+      "at": "2026-03-28T11:20:12Z",
       "passes": 1,
       "pr": 11789
     },
     ".agents/workflows/readme-create-update.md": {
-      "at": "2026-03-28T16:40:10Z",
       "hash": "f54854963d94f3c9b4e15769c07b3c8c27db1c5a",
+      "at": "2026-03-28T16:40:10Z",
       "passes": 1,
       "pr": 12038
     },
     ".agents/workflows/release.md": {
-      "at": "2026-03-29T22:51:16Z",
       "hash": "829b5d36d0073b1409bf14b5d094c18889989008",
+      "at": "2026-03-29T22:51:16Z",
       "passes": 2,
       "pr": 13318
     },
     ".agents/workflows/review-issue-pr.md": {
-      "at": "2026-03-28T22:39:25Z",
       "hash": "14ac8f78bcfbb8ec23df3e37c021b7cd512c2f5b",
+      "at": "2026-03-28T22:39:25Z",
       "passes": 1,
       "pr": 12308
     },
     ".agents/workflows/session-manager.md": {
-      "at": "2026-03-29T23:53:41Z",
       "hash": "e90fb5dbed96bd48a27404dce7d7b8d60d66a053",
+      "at": "2026-03-29T23:53:41Z",
       "passes": 1,
       "pr": 13443
     },
     ".agents/workflows/session-review.md": {
-      "at": "2026-03-29T11:19:53Z",
       "hash": "0209719f0b5eb68905b4edbdc6bffe1fa8d8a54d",
+      "at": "2026-03-29T11:19:53Z",
       "passes": 1,
       "pr": 12889
     },
     ".agents/workflows/sql-migrations.md": {
-      "at": "2026-03-30T06:03:19Z",
       "hash": "b33b92df6c10b12772797d8d75b314b69698af6e",
+      "at": "2026-03-30T06:03:19Z",
       "passes": 1,
       "pr": 13838
     },
     ".agents/workflows/ui-verification.md": {
-      "at": "2026-03-29T07:31:37Z",
       "hash": "c59b154d588638a381fc14e85f435772cb88e31a",
+      "at": "2026-03-29T07:31:37Z",
       "passes": 1,
       "pr": 12705
     },
     ".agents/workflows/version-bump.md": {
-      "at": "2026-03-28T16:00:36Z",
       "hash": "d4d8c82182a0c0fce47622e76556260a11747ee8",
+      "at": "2026-03-28T16:00:36Z",
       "passes": 1,
       "pr": 11986
     },
     ".agents/workflows/wiki-update.md": {
-      "at": "2026-03-30T02:30:16Z",
       "hash": "383e2e91f87e4008a1f60494b80c152ca7a47877",
+      "at": "2026-03-30T02:30:16Z",
       "passes": 1,
       "pr": 13594
     },
     ".agents/workflows/worktree.md": {
-      "at": "2026-04-03T11:54:16Z",
       "hash": "0be096cde3a0156616f962054fb08c60e38b0938",
+      "at": "2026-04-03T11:54:16Z",
       "passes": 1,
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-03T16:35:50Z",
       "hash": "5352eaa3c4b5c4e282ef1ea2cef107e7076d2484",
+      "at": "2026-04-03T16:35:50Z",
       "passes": 7,
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-03T16:35:50Z",
       "hash": "e158624a4b6cfa0cdf6509633043fb8cdcf5c33f",
+      "at": "2026-04-03T16:35:50Z",
       "passes": 24,
       "pr": 15470
     },
     "setup.sh": {
-      "at": "2026-04-03T16:35:50Z",
       "hash": "ab39d1a2a0a7a5ed6a53adaddb51702ba6defb20",
+      "at": "2026-04-03T16:35:50Z",
       "passes": 24,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
-      "at": "2026-04-02T13:10:59Z",
       "hash": "ca6b623a0dc0d9ae763efd4dd88350ec183c45e9",
+      "at": "2026-04-02T13:10:59Z",
       "passes": 1,
       "pr": 15566
     },
     "todo/tasks/GH-14990-brief.md": {
-      "at": "2026-04-01T20:59:29Z",
       "hash": "05e0636373c9b4574f9b289b7e75180281b462e4",
+      "at": "2026-04-01T20:59:29Z",
       "passes": 1,
       "pr": 14996
     },
     "todo/tasks/t15173-brief.md": {
-      "at": "2026-04-01T20:58:50Z",
       "hash": "41ca6c208c2f6e8349d73a1ec55e0a26fd26f974",
+      "at": "2026-04-01T20:58:50Z",
       "passes": 1,
       "pr": 15257
     },
     "todo/tasks/t15364-brief.md": {
-      "at": "2026-04-02T13:11:00Z",
       "hash": "1231c445c2ac173258f2a0b5baab685d32a3ab64",
+      "at": "2026-04-02T13:11:00Z",
       "passes": 1,
       "pr": 15566
     },
     "todo/tasks/t15448-brief.md": {
-      "at": "2026-04-02T04:56:58Z",
       "hash": "b43fa2d5b0515af1ecbebbc502099ca5e6d0a9c2",
+      "at": "2026-04-02T04:56:58Z",
       "passes": 1,
       "pr": 15463
     },
     "todo/tasks/t15450-brief.md": {
-      "at": "2026-04-02T04:56:56Z",
       "hash": "c0ba871cfce440d57c630e49cd6ba939bf27b261",
+      "at": "2026-04-02T04:56:56Z",
       "passes": 1,
       "pr": 15468
     },
     "todo/tasks/t15472-brief.md": {
-      "at": "2026-04-02T04:56:51Z",
       "hash": "3de8a77d3743c3530c563e9aff8775c22a7edb4b",
+      "at": "2026-04-02T04:56:51Z",
       "passes": 1,
       "pr": 15490
     },
     "todo/tasks/t1727-brief.md": {
-      "at": "2026-04-02T03:11:00Z",
       "hash": "55e4dea0078c0800d4db2336b942014ce25ffbfc",
+      "at": "2026-04-02T03:11:00Z",
       "passes": 1,
       "pr": 15431
     },
     "todo/tasks/t1737-brief.md": {
-      "at": "2026-04-01T20:59:15Z",
       "hash": "e33e6f68fa6cdb89368aa5ec65bd3e1bc880ba67",
+      "at": "2026-04-01T20:59:15Z",
       "passes": 1,
       "pr": 15223
     },
     "todo/tasks/t2052-brief.md": {
-      "at": "2026-04-02T04:56:57Z",
       "hash": "c820f0bd721d4d8ff4fb35dff40ff98c6ba3b71f",
+      "at": "2026-04-02T04:56:57Z",
       "passes": 1,
       "pr": 15470
     },
     ".agents/scripts/commands/email-inbox.md": {
       "hash": "c834b89675d9babc86fd9b822ff9099b6300328e",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16588,
-      "passes": 1
+      "passes": 1,
+      "pr": 16588
     },
     ".agents/services/hosting/cloudflare-platform-skill/bot-management.md": {
       "hash": "47d37cdc4fc66524976e5f21e2ec278a370c5063",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16587,
-      "passes": 1
+      "passes": 1,
+      "pr": 16587
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit.md": {
       "hash": "a5230ae18f0b506e2e74a823e5625cdcc0fb5f26",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16586,
-      "passes": 1
+      "passes": 1,
+      "pr": 16586
     },
     ".agents/services/hosting/cloudflare-platform-skill/stream.md": {
       "hash": "bb96248a35ec333522b4a9ec45d7a3fba613ea3f",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16585,
-      "passes": 1
+      "passes": 1,
+      "pr": 16585
     },
     ".agents/aidevops/orchestration-analysis.md": {
       "hash": "4a3eadd78871833065741bdefa18d6beccc40a62",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16584,
-      "passes": 1
+      "passes": 1,
+      "pr": 16584
     },
     ".agents/tools/ai-assistants/runners-code-reviewer.md": {
       "hash": "f37cf1f077208658bf81d52ba80ce75010c03a65",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16583,
-      "passes": 1
+      "passes": 1,
+      "pr": 16583
     },
     ".agents/tools/credentials/auth-troubleshooting.md": {
       "hash": "f77b40004422a9f18962d680d51520bb9165523e",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16582,
-      "passes": 1
+      "passes": 1,
+      "pr": 16582
     },
     ".agents/content/heygen-skill/rules-streaming-avatars.md": {
       "hash": "761062e7781d4f16fee091fe922e8b4087a6106d",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16581,
-      "passes": 1
+      "passes": 1,
+      "pr": 16581
     },
     ".agents/seo/seo-optimizer.md": {
       "hash": "f72dd3bbe33adda56900c2a71afaaa79d07f01b4",
       "at": "2026-04-03T13:35:13Z",
-      "pr": 16579,
-      "passes": 1
+      "passes": 1,
+      "pr": 16579
     },
     ".agents/services/hosting/cloudflare-platform-skill/smart-placement.md": {
       "hash": "85f83a5f09f49f005c35c0fb00c23e0f49b0c706",
       "at": "2026-04-03T13:35:14Z",
-      "pr": 16573,
-      "passes": 1
+      "passes": 1,
+      "pr": 16573
     },
     ".agents/tools/context/toon.md": {
       "hash": "117beb5997e2e5db9c996cdd7a4acb76f9e615b8",
       "at": "2026-04-03T13:35:14Z",
-      "pr": 16572,
-      "passes": 1
+      "passes": 1,
+      "pr": 16572
     },
     ".agents/reference/define-probes/refactor.md": {
       "hash": "b1295077d7985e87719eeffc9d4b17655e7c43ed",
       "at": "2026-04-03T13:35:14Z",
-      "pr": 16571,
-      "passes": 1
+      "passes": 1,
+      "pr": 16571
     },
     ".agents/tools/autoresearch/autoresearch/loop.md": {
       "hash": "71f120c7036bb38a70cbe943cc313f6f4faa4794",
       "at": "2026-04-03T16:35:36Z",
-      "pr": 16570,
-      "passes": 2
+      "passes": 2,
+      "pr": 16570
     },
     ".agents/scripts/commands/autoresearch.md": {
       "hash": "b75b03de813cc1a458e54dbcb82284166c9095cc",
       "at": "2026-04-03T13:35:14Z",
-      "pr": 16569,
-      "passes": 1
+      "passes": 1,
+      "pr": 16569
     },
     ".agents/tools/productivity/contacts.md": {
       "hash": "c95faae805e12dfb7483f39fd9ccc85ca39d4683",
       "at": "2026-04-03T13:35:15Z",
-      "pr": 16497,
-      "passes": 1
+      "passes": 1,
+      "pr": 16497
     },
     ".agents/scripts/commands/add-skill.md": {
       "hash": "2a72e7cc27b762035eb9d8525e78b3f761853cd0",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16634,
-      "passes": 1
+      "passes": 1,
+      "pr": 16634
     },
     ".agents/scripts/commands/models-pool-check.md": {
       "hash": "39e156bf48cb1867d36633f004d93111dccdc3ef",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16633,
-      "passes": 1
+      "passes": 1,
+      "pr": 16633
     },
     ".agents/tools/browser/browser-benchmark.md": {
       "hash": "2d33b86af2952b122605b493eca8f6fd47c258e3",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16631,
-      "passes": 1
+      "passes": 1,
+      "pr": 16631
     },
     ".agents/tests/comprehension/pilot-results.md": {
       "hash": "9c986cc7690152dad82fc591f29149ae3732123f",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16630,
-      "passes": 1
+      "passes": 1,
+      "pr": 16630
     },
     ".agents/tools/autoresearch/autoresearch/agent-optimization.md": {
       "hash": "73defc2b8f2e877cbe3a0cf5e1e328d4c3b99548",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16629,
-      "passes": 1
+      "passes": 1,
+      "pr": 16629
     },
     ".agents/tools/code-review/automation.md": {
       "hash": "18859d70dfa7015ea85168cf0c83920bd15f967d",
       "at": "2026-04-03T16:35:38Z",
-      "pr": 16628,
-      "passes": 2
+      "passes": 2,
+      "pr": 16628
     },
     ".agents/tools/productivity/apple-reminders.md": {
       "hash": "23e83a5f7a3a1c0a07b3d61302e9f60669b03342",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16613,
-      "passes": 1
+      "passes": 1,
+      "pr": 16613
     },
     ".agents/services/hosting/cloudflare-platform-skill/bot-management-patterns.md": {
       "hash": "8e0d30c97fc85120bd96d02984e6a166f347075c",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16612,
-      "passes": 1
+      "passes": 1,
+      "pr": 16612
     },
     ".agents/tools/autoresearch/autoresearch/logging.md": {
       "hash": "8a498848d7e5a1028bd0e053e64843de9d8bb011",
       "at": "2026-04-03T16:35:36Z",
-      "pr": 16611,
-      "passes": 2
+      "passes": 2,
+      "pr": 16611
     },
     ".agents/tools/autoresearch/autoresearch/completion.md": {
       "hash": "bc8f4ba09593c95c50a82e243f90065ce2146c3d",
       "at": "2026-04-03T14:06:30Z",
-      "pr": 16610,
-      "passes": 1
+      "passes": 1,
+      "pr": 16610
     },
     ".agents/tools/autoresearch/autoresearch.md": {
       "hash": "fe957621f430eeb9d29d107a65338bfe46242fc2",
       "at": "2026-04-03T16:35:36Z",
-      "pr": 16609,
-      "passes": 2
+      "passes": 2,
+      "pr": 16609
     },
     ".agents/reference/bash-compat.md": {
       "hash": "3001b201e2eea2058dfba3971e883bd7cb26c267",
       "at": "2026-04-03T14:06:31Z",
-      "pr": 16580,
-      "passes": 1
+      "passes": 1,
+      "pr": 16580
     },
     ".agents/content/social-reddit.md": {
       "hash": "409bf0e433bf36e90af2e6d18cffc4b3f24f046e",
       "at": "2026-04-03T14:06:32Z",
-      "pr": 16555,
-      "passes": 1
+      "passes": 1,
+      "pr": 16555
     },
     ".agents/tools/containers/orbstack.md": {
       "hash": "60363a2af2d82855d4c3dd96e2c6a9928bc20de0",
       "at": "2026-04-03T14:06:32Z",
-      "pr": 16542,
-      "passes": 1
+      "passes": 1,
+      "pr": 16542
     },
     ".agents/tools/ai-assistants/overview.md": {
       "hash": "319c34fa97d4d8706e8c8d2f4d173bf0a3c14653",
       "at": "2026-04-03T16:35:51Z",
-      "pr": 16716,
-      "passes": 1
+      "passes": 1,
+      "pr": 16716
     },
     ".agents/tools/video/remotion-get-video-dimensions.md": {
       "hash": "5283b1960136852087250875692524c025cf6a0b",
       "at": "2026-04-03T16:35:51Z",
-      "pr": 16715,
-      "passes": 1
+      "passes": 1,
+      "pr": 16715
     },
     ".agents/workflows/conversation-starter.md": {
       "hash": "ae6e19d33d775df926fd9a10b6127a6f33f36ab6",
       "at": "2026-04-03T16:35:51Z",
-      "pr": 16714,
-      "passes": 1
+      "passes": 1,
+      "pr": 16714
     },
     ".agents/reference/task-taxonomy.md": {
-      "at": "2026-04-03T16:50:00Z",
       "hash": "e5313d0bc4a7e2bf7cb1e807abd6dd33b3da64f901dd1bb6aeca7903b56e7de7",
-      "issue": "GH#16752",
-      "lines_after": 48,
-      "lines_before": 54,
-      "note": "Instruction doc: removed 3 decorative --- horizontal rules and redundant **bold** wrapping on command names in list (backtick code formatting sufficient). All tables, rules, command examples, and references preserved.",
+      "at": "2026-04-03T16:50:00Z",
       "passes": 1,
-      "pr": "pending",
-      "status": "simplified"
+      "pr": "pending"
     },
     ".agents/seo/ranking-opportunities.md": {
       "hash": "b45ae335184c658835328022167c130b09f12e03",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16713,
-      "passes": 1
+      "passes": 1,
+      "pr": 16713
     },
     ".agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md": {
       "hash": "11fa0785880389dc4d2637b2b2037a7016de2256",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16712,
-      "passes": 1
+      "passes": 1,
+      "pr": 16712
     },
     ".agents/tools/build-agent/agent-review.md": {
       "hash": "fe9e2b50d005aa62e641b64ce1d3e09aba5aebc5",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16711,
-      "passes": 1
+      "passes": 1,
+      "pr": 16711
     },
     ".agents/services/hosting/cloudflare-platform-skill/terraform.md": {
       "hash": "526e581dee8e010724de0a8b28cb4c259b7f6348",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16710,
-      "passes": 1
+      "passes": 1,
+      "pr": 16710
     },
     ".agents/scripts/commands/email-health-check.md": {
       "hash": "fcf87782dae5b948e39c0558d8c556b09bb77614",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16709,
-      "passes": 1
+      "passes": 1,
+      "pr": 16709
     },
     ".agents/services/outreach/leadsforge.md": {
       "hash": "e9f91a27e1311d0362b30babbffadd2586905430",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16708,
-      "passes": 1
+      "passes": 1,
+      "pr": 16708
     },
     ".agents/tools/autoagent/autoagent/safety.md": {
       "hash": "c0c8bfdc4eb87675a023ef8f2df08f0d81fa6fe8",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16707,
-      "passes": 1
+      "passes": 1,
+      "pr": 16707
     },
     ".agents/scripts/commands/autoagent.md": {
       "hash": "b5cd2b1ae79ad88dd4899d22332b3159170cad7b",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16700,
-      "passes": 1
+      "passes": 1,
+      "pr": 16700
     },
     ".agents/tools/autoagent/autoagent/signal-mining.md": {
       "hash": "5163874bc0bf6baec44bc9dfe8e6672fca5bd447",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16699,
-      "passes": 1
+      "passes": 1,
+      "pr": 16699
     },
     ".agents/tools/autoagent/autoagent/hypothesis-types.md": {
       "hash": "3955d72cb695f14e642fa1b0f774eeb71525869c",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16698,
-      "passes": 1
+      "passes": 1,
+      "pr": 16698
     },
     ".agents/tools/autoagent/autoagent.md": {
       "hash": "adda73211a21c83147485f5ca17d238f70bf2c6e",
       "at": "2026-04-03T16:35:52Z",
-      "pr": 16697,
-      "passes": 1
+      "passes": 1,
+      "pr": 16697
     },
     ".agents/tools/autoagent/autoagent/evaluation.md": {
       "hash": "a650cd68014bd6de18348affc8e8be2fa6b97ecb",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16696,
-      "passes": 1
+      "passes": 1,
+      "pr": 16696
     },
     ".agents/tools/voice/buzz.md": {
       "hash": "973a915a3611fc418a2ce5405d5096d238ee093d",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16677,
-      "passes": 1
+      "passes": 1,
+      "pr": 16677
     },
     ".agents/workflows/branch/refactor.md": {
       "hash": "04e48b26f6776f5ac0649fde30bd58dbfa214793",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16676,
-      "passes": 1
+      "passes": 1,
+      "pr": 16676
     },
     ".agents/workflows/branch/release.md": {
       "hash": "f2f1389229a5b8ff2457ef17896497e2c203e5bd",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16675,
-      "passes": 1
+      "passes": 1,
+      "pr": 16675
     },
     ".agents/content/internal-linker.md": {
       "hash": "3cf59c0694c34b9c76bd58c399ebfe98c1dc49b9",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16674,
-      "passes": 1
+      "passes": 1,
+      "pr": 16674
     },
     ".agents/tools/ui/nothing-design-skill/platform-mapping.md": {
       "hash": "5c3ffaeca4580654c4fa3932402d3a0653cf3d67",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16673,
-      "passes": 1
+      "passes": 1,
+      "pr": 16673
     },
     ".agents/marketing-sales/cro-chapter-23.md": {
       "hash": "e12d4b8e73a0d222d0f9dbed9790035937fb8d99",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16672,
-      "passes": 1
+      "passes": 1,
+      "pr": 16672
     },
     ".agents/reference/define-probes/docs.md": {
       "hash": "11ddcc16ecd1db4b12e7c65bebe35007c13e771d",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16671,
-      "passes": 1
+      "passes": 1,
+      "pr": 16671
     },
     ".agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md": {
       "hash": "d71bb172e6c239aa8e27ae70cfd7c1da9bd67ebd",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16670,
-      "passes": 1
+      "passes": 1,
+      "pr": 16670
     },
     ".agents/services/communications/cross-channel-conversation-continuity.md": {
       "hash": "4198828d2633d852083257ebdb2a0267fbd0be52",
       "at": "2026-04-03T16:35:53Z",
-      "pr": 16669,
-      "passes": 1
+      "passes": 1,
+      "pr": 16669
     },
     ".agents/tools/voice/voice-ai-models.md": {
       "hash": "ec64b51e019fed03a75e38f95290afac2ccfe620",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16668,
-      "passes": 1
+      "passes": 1,
+      "pr": 16668
     },
     ".agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md": {
       "hash": "ab18b3c7563ed38b4994ac3f3421cfd0a5c50bc7",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16655,
-      "passes": 1
+      "passes": 1,
+      "pr": 16655
     },
     ".agents/services/hosting/cloudflare-platform-skill/tunnel.md": {
       "hash": "f6e272d66b97088c5bdcda443c6354fa0993338d",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16654,
-      "passes": 1
+      "passes": 1,
+      "pr": 16654
     },
     ".agents/tools/credentials/enpass.md": {
       "hash": "4d4c71956f1c02027280e33b2de48e55f89f680a",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16653,
-      "passes": 1
+      "passes": 1,
+      "pr": 16653
     },
     ".agents/tools/credentials/list-keys.md": {
       "hash": "06e79e11c7a4d39e8d13a1b7788548639fd25692",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16652,
-      "passes": 1
+      "passes": 1,
+      "pr": 16652
     },
     ".agents/services/monitoring/sentry.md": {
       "hash": "e780dbe6a1e763a8dfaac101fdc6d9c29b6d74f1",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16651,
-      "passes": 1
+      "passes": 1,
+      "pr": 16651
     },
     ".agents/scripts/dispatch-dedup-helper.sh": {
       "hash": "544773f7cd08b71abf20a10dd36a704de5a5100a",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16650,
-      "passes": 1
+      "passes": 1,
+      "pr": 16650
     },
     ".agents/tools/ocr/overview.md": {
       "hash": "ce8b2de54e94192070edfdbdc1c5255d67161462",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16637,
-      "passes": 1
+      "passes": 1,
+      "pr": 16637
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md": {
       "hash": "ed4769075faf5202b4c97db3ba3f2f512da19659",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16636,
-      "passes": 1
+      "passes": 1,
+      "pr": 16636
     },
     ".agents/services/outreach/cold-outreach.md": {
       "hash": "16ede068d03f805ea84e2922fbd11e587e219ca5",
       "at": "2026-04-03T16:35:54Z",
-      "pr": 16635,
-      "passes": 1
+      "passes": 1,
+      "pr": 16635
     },
     ".agents/seo/upscale.md": {
       "hash": "3b0cae5e54f29b64806548f8dff6d05d48e69292",
       "at": "2026-04-03T16:35:55Z",
-      "pr": 16627,
-      "passes": 1
+      "passes": 1,
+      "pr": 16627
     },
     ".agents/content/production-video-02-sora-template.md": {
-      "at": "2026-04-03T00:00:00Z",
       "hash": "7d18119d4d8ff939a2c5e2f708799a7a2511414b597c5b58a4b36015fe7f322e",
-      "issue": "GH#14349",
-      "status": "simplified"
+      "at": "2026-04-03T00:00:00Z"
     },
     ".agents/marketing-sales/direct-response-copy-checklists-headline-testing.md": {
-      "at": "2026-04-03T12:24:52Z",
       "hash": "be06c785ca2ac3c4f6a7c5fd58fd79299e95507b56db7c3ed5f515602f4e556f",
-      "issue": "GH#16380",
+      "at": "2026-04-03T12:24:52Z",
       "passes": 1,
-      "pr": "pending",
-      "status": "simplified"
+      "pr": "pending"
     },
     ".agents/seo/geo-strategy.md": {
-      "at": "2026-04-03T00:00:00Z",
       "hash": "f2c7b8507a0eb39c56689d7ce778518d7e15b27b7da668ef2b2caebdbe5b50df",
-      "issue": "GH#15895",
+      "at": "2026-04-03T00:00:00Z",
       "passes": 1,
-      "pr": "pending",
-      "status": "simplified"
+      "pr": "pending"
     },
     ".agents/seo/serper.md": {
-      "hash": "3d0adf5a1a1e65e20e30d3ba749a1d2fccc090dcdad90dcbc8bbb6a254317e72",
-      "status": "simplified",
-      "issue": "GH#16731",
-      "lines": 60
+      "hash": "3d0adf5a1a1e65e20e30d3ba749a1d2fccc090dcdad90dcbc8bbb6a254317e72"
     },
     ".agents/tools/pdf/overview.md": {
-      "at": "2026-04-03T00:00:00Z",
       "hash": "d8fe67896cf7e6dafe4e6e8c92f37864cf671107860e019b4c78834d544b05b7",
-      "issue": "GH#16748",
-      "lines_before": 57,
-      "lines_after": 43,
-      "action": "tightened"
+      "at": "2026-04-03T00:00:00Z"
     },
     ".agents/tools/ui/ui-skills.md": {
-      "at": "2026-04-03T06:08:00Z",
       "hash": "f75020ffda4b498042577c5888bf9b0aa1efebd4ae355bf4acf33ab10e74137e",
-      "issue": "GH#16179",
-      "lines": 96,
+      "at": "2026-04-03T06:08:00Z",
       "passes": 1,
-      "pr": 16281,
-      "status": "simplified"
+      "pr": 16281
     },
     ".agents/workflows/pre-edit.md": {
-      "hash": "d87135a808a845416e0193a101bef0fd1c0b4a032969d819556ce109c40da4ba",
-      "issue": "GH#15439",
-      "lines_after": 72,
-      "lines_before": 78,
-      "status": "simplified"
+      "hash": "d87135a808a845416e0193a101bef0fd1c0b4a032969d819556ce109c40da4ba"
     }
   }
 }

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,231 +1,4 @@
 {
-  ".agents/seo/ranking-opportunities.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "eb967c184a79c17e51d3eaea892f52fd50faf124aac7161e3aa9fef581237a57",
-    "issue": "GH#16713",
-    "lines_after": 61,
-    "lines_before": 61,
-    "note": "Pass 2: instruction doc at minimum viable size. Previously tightened 82\u219261 lines (GH#15698, PR#16081). All sections necessary: YAML frontmatter, workflow steps, analysis types table, TOON output format. No further compression possible without content loss.",
-    "passes": 2,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "b67f8c428d9457f76f2e6227baaaa46768eccf9604fd1e71ee17c9b002831039",
-    "issue": "GH#16636",
-    "lines_after": 81,
-    "lines_before": 66,
-    "note": "Reference corpus: added intro line and Key Patterns summary table. All original content preserved. 4 SaaS examples (Slack, Notion, Basecamp, Mailchimp) intact.",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/aidevops/api-integrations.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "1d9ae72e2a62060ee1524f7440825f1a5539f3ce2e64b691d67d66ea36cf0edb",
-    "issue": "GH#15818",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/aidevops/service-links.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "1b4d0cbc25fd53ad0a3de4ad3f1b3b8f1b8ab31d",
-    "issue": "GH#14974",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/content/heygen-skill/rules-streaming-avatars.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "db7582c5895ac7185939740cb16cbe5f72afd9ebad7bb4586b8eee5897af27d3",
-    "issue": "GH#16581",
-    "lines_after": 67,
-    "lines_before": 67,
-    "note": "Pass 2: reference corpus (API docs, tables, code examples) at minimum viable size. No further compression possible without content loss. File reviewed and confirmed appropriately structured.",
-    "passes": 2,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/content/production-video-02-sora-template.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "7d18119d4d8ff939a2c5e2f708799a7a2511414b597c5b58a4b36015fe7f322e",
-    "issue": "GH#14349",
-    "status": "simplified"
-  },
-  ".agents/legal.md": {
-    "hash": "544a65fb7a2195dd41e36bafecfa2251b9c2800fae8c8ec7fbef892ff1b03bc4",
-    "issue": 16258,
-    "status": "simplified"
-  },
-  ".agents/marketing-sales/direct-response-copy-checklists-headline-testing.md": {
-    "at": "2026-04-03T12:24:52Z",
-    "hash": "be06c785ca2ac3c4f6a7c5fd58fd79299e95507b56db7c3ed5f515602f4e556f",
-    "issue": "GH#16380",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md": {
-    "at": "2026-04-03T09:30:00Z",
-    "hash": "bbb3ea1df32f53c905d3c8b174a0bd212fc5dd55a168169d06d81542127e8bb3",
-    "issue": "GH#16443",
-    "lines_after": 111,
-    "lines_before": 113,
-    "note": "Pass 2: 113\u2192111 lines. Merged templates link into intro line, moved subject line guidance above table as compact note. Zero content loss.",
-    "passes": 2,
-    "status": "simplified"
-  },
-  ".agents/reference/define-probes/refactor.md": {
-    "hash": "1eb86f1e0b8873942014f1f20414250077bd694a254e6e97537e706199b2460a",
-    "issue": "GH#16350",
-    "status": "simplified"
-  },
-  ".agents/scripts/commands/add-skill.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "ce5f2025958525f3fc2e2e3224b331b5c9ccdd13a5966ad21d5878ba1a9a2067",
-    "issue": "GH#16379",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/seo/geo-strategy.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "f2c7b8507a0eb39c56689d7ce778518d7e15b27b7da668ef2b2caebdbe5b50df",
-    "issue": "GH#15895",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md": {
-    "hash": "289d1ce963a8bfbb69d5199ff47d8368f19a653f67305bafd8940e7a0982c67b",
-    "issue": "GH#15925",
-    "pr": "PR#16125",
-    "status": "simplified"
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md": {
-    "hash": "9f49d8ba3b960d10d7b1638fe98bcb57c26ea9d3",
-    "issue": "GH#15076",
-    "lines_after": 130,
-    "lines_before": 142,
-    "status": "simplified"
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
-    "hash": "1253c92066cfa913e522251a5dc37bd66b8a581483d712f7f3556afbdc2c03cd",
-    "issue": "GH#15840",
-    "status": "simplified"
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/pipelines.md": {
-    "at": "2026-04-03T05:55:25Z",
-    "hash": "7a3d9f5ead63a859a91acd0ebb4dd11a237f4f85",
-    "issue": "GH#13394",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "5df3a339524d800afe6cc2148b7a71c5f898d396d92d30e3949b522955a525a2",
-    "issue": "GH#16320",
-    "lines_after": 88,
-    "lines_before": 89
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/workers-patterns.md": {
-    "action": "tightened",
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "4a94ab9f82abafc568298f41f4913b4e504b962f651338f6dbb20a6fecc984cc",
-    "issue": "GH#16293",
-    "lines_after": 139,
-    "lines_before": 141
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/wrangler.md": {
-    "hash": "3d566d9fbf05fdee08380d0ffbaf538854887e326c9b658e8236d837c8993cb3",
-    "lines": 63,
-    "status": "simplified"
-  },
-  ".agents/tools/ai-orchestration/overview.md": {
-    "hash": "3a63b044317f50c757951158e4e711234d09cd299f8dc557bdc5af9e580735f6",
-    "issue": "GH#15266",
-    "pr": "PR#16047",
-    "status": "simplified"
-  },
-  ".agents/tools/browser/browser-benchmark-scripts-01-playwright.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "9958f23ad99c271fe00d6abb99241cff82ffae9db2b351bc5a15129693063569",
-    "issue": "GH#16500",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/tools/browser/chromium-debug-use.md": {
-    "hash": "fd324c70aff1b6cc040970d3e6c91b2ac714405abedb7838e34f109755c80dd7",
-    "issue": "GH#14962",
-    "lines_after": 238,
-    "lines_before": 316,
-    "status": "simplified"
-  },
-  ".agents/tools/code-review/tools.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "b767318f3046f9a52ff3d31a2f733bb83f4e5475501f57862a874c05e853ad7b",
-    "issue": "GH#16449",
-    "status": "simplified"
-  },
-  ".agents/tools/productivity/contacts.md": {
-    "hash": "d99fc5b67969194e84d7952de9bfa655d26d6d4e9e84b2fcf0ef5790cf413af6",
-    "issue": "GH#16497",
-    "lines": 67,
-    "note": "tightened: merged Linux Setup into Quick Reference, consolidated When to Use paragraphs (79\u219267 lines)",
-    "status": "simplified"
-  },
-  ".agents/tools/programming/modern-javascript-skill/immutability.md": {
-    "hash": "f5453a48a29c9dd411399f4079384edf",
-    "issue": "GH#16493",
-    "status": "simplified"
-  },
-  ".agents/tools/ui/ui-skills.md": {
-    "at": "2026-04-03T06:08:00Z",
-    "hash": "f75020ffda4b498042577c5888bf9b0aa1efebd4ae355bf4acf33ab10e74137e",
-    "issue": "GH#16179",
-    "lines": 96,
-    "passes": 1,
-    "pr": 16281,
-    "status": "simplified"
-  },
-  ".agents/tools/video/remotion-display-captions.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "6dcdc470b94e1e415d3e09b76a06088646364cd9",
-    "issue": "GH#16476",
-    "lines_after": 117,
-    "lines_before": 119,
-    "note": "Removed redundant intro line (exact duplicate of YAML description). Code blocks preserved verbatim. Zero content loss.",
-    "passes": 1,
-    "status": "simplified"
-  },
-  ".agents/tools/video/remotion-get-video-dimensions.md": {
-    "at": "2026-04-03T05:33:46Z",
-    "hash": "c5f36530db3354d5de3048458c3849ec22c1710a",
-    "issue": "GH#14370",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/tools/voice/voice-ai-models.md": {
-    "action": "converted GPU Planning prose to table; clarified VRAM/RAM column header",
-    "hash": "80802e36e4fae1517223fb0553a50f7aa9e01acd908f7d50b6d53f60e3a1dda2",
-    "issue": "GH#15102",
-    "lines_after": 132,
-    "lines_before": 126,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/workflows/pre-edit.md": {
-    "hash": "d87135a808a845416e0193a101bef0fd1c0b4a032969d819556ce109c40da4ba",
-    "issue": "GH#15439",
-    "lines_after": 72,
-    "lines_before": 78,
-    "status": "simplified"
-  },
   "files": {
     ".agents/aidevops.md": {
       "at": "2026-03-29T16:31:51Z",
@@ -1053,7 +826,7 @@
       "at": "2026-04-02T21:19:54Z",
       "hash": "347272e46c7d04f05dd13a4683cf44bef0dd3da7",
       "issue": "GH#14286",
-      "note": "Reference corpus chapter tightened: 92 \u2192 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
+      "note": "Reference corpus chapter tightened: 92 → 90 lines. Removed decorative closing sentence with no information value. Zero content loss.",
       "passes": 2
     },
     ".agents/marketing-sales/cro-chapter-20.md": {
@@ -5775,18 +5548,18 @@
       "pr": 16714,
       "passes": 1
     },
-  ".agents/reference/task-taxonomy.md": {
-    "at": "2026-04-03T16:50:00Z",
-    "hash": "e5313d0bc4a7e2bf7cb1e807abd6dd33b3da64f901dd1bb6aeca7903b56e7de7",
-    "issue": "GH#16752",
-    "lines_after": 48,
-    "lines_before": 54,
-    "note": "Instruction doc: removed 3 decorative --- horizontal rules and redundant **bold** wrapping on command names in list (backtick code formatting sufficient). All tables, rules, command examples, and references preserved.",
-    "passes": 1,
-    "pr": "pending",
-    "status": "simplified"
-  },
-  ".agents/seo/ranking-opportunities.md": {
+    ".agents/reference/task-taxonomy.md": {
+      "at": "2026-04-03T16:50:00Z",
+      "hash": "e5313d0bc4a7e2bf7cb1e807abd6dd33b3da64f901dd1bb6aeca7903b56e7de7",
+      "issue": "GH#16752",
+      "lines_after": 48,
+      "lines_before": 54,
+      "note": "Instruction doc: removed 3 decorative --- horizontal rules and redundant **bold** wrapping on command names in list (backtick code formatting sufficient). All tables, rules, command examples, and references preserved.",
+      "passes": 1,
+      "pr": "pending",
+      "status": "simplified"
+    },
+    ".agents/seo/ranking-opportunities.md": {
       "hash": "b45ae335184c658835328022167c130b09f12e03",
       "at": "2026-04-03T16:35:52Z",
       "pr": 16713,
@@ -5977,26 +5750,58 @@
       "at": "2026-04-03T16:35:55Z",
       "pr": 16627,
       "passes": 1
+    },
+    ".agents/content/production-video-02-sora-template.md": {
+      "at": "2026-04-03T00:00:00Z",
+      "hash": "7d18119d4d8ff939a2c5e2f708799a7a2511414b597c5b58a4b36015fe7f322e",
+      "issue": "GH#14349",
+      "status": "simplified"
+    },
+    ".agents/marketing-sales/direct-response-copy-checklists-headline-testing.md": {
+      "at": "2026-04-03T12:24:52Z",
+      "hash": "be06c785ca2ac3c4f6a7c5fd58fd79299e95507b56db7c3ed5f515602f4e556f",
+      "issue": "GH#16380",
+      "passes": 1,
+      "pr": "pending",
+      "status": "simplified"
+    },
+    ".agents/seo/geo-strategy.md": {
+      "at": "2026-04-03T00:00:00Z",
+      "hash": "f2c7b8507a0eb39c56689d7ce778518d7e15b27b7da668ef2b2caebdbe5b50df",
+      "issue": "GH#15895",
+      "passes": 1,
+      "pr": "pending",
+      "status": "simplified"
+    },
+    ".agents/seo/serper.md": {
+      "hash": "3d0adf5a1a1e65e20e30d3ba749a1d2fccc090dcdad90dcbc8bbb6a254317e72",
+      "status": "simplified",
+      "issue": "GH#16731",
+      "lines": 60
+    },
+    ".agents/tools/pdf/overview.md": {
+      "at": "2026-04-03T00:00:00Z",
+      "hash": "d8fe67896cf7e6dafe4e6e8c92f37864cf671107860e019b4c78834d544b05b7",
+      "issue": "GH#16748",
+      "lines_before": 57,
+      "lines_after": 43,
+      "action": "tightened"
+    },
+    ".agents/tools/ui/ui-skills.md": {
+      "at": "2026-04-03T06:08:00Z",
+      "hash": "f75020ffda4b498042577c5888bf9b0aa1efebd4ae355bf4acf33ab10e74137e",
+      "issue": "GH#16179",
+      "lines": 96,
+      "passes": 1,
+      "pr": 16281,
+      "status": "simplified"
+    },
+    ".agents/workflows/pre-edit.md": {
+      "hash": "d87135a808a845416e0193a101bef0fd1c0b4a032969d819556ce109c40da4ba",
+      "issue": "GH#15439",
+      "lines_after": 72,
+      "lines_before": 78,
+      "status": "simplified"
     }
-  },
-  ".agents/reference/define-probes/docs.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "42730e6d8c7fb235e7594467232c9ab9d4f69db6e66316c6d6e073ad6d3838f9",
-    "issue": "GH#16671",
-    "status": "simplified"
-  },
-  ".agents/seo/serper.md": {
-    "hash": "3d0adf5a1a1e65e20e30d3ba749a1d2fccc090dcdad90dcbc8bbb6a254317e72",
-    "status": "simplified",
-    "issue": "GH#16731",
-    "lines": 60
-  },
-  ".agents/tools/pdf/overview.md": {
-    "at": "2026-04-03T00:00:00Z",
-    "hash": "d8fe67896cf7e6dafe4e6e8c92f37864cf671107860e019b4c78834d544b05b7",
-    "issue": "GH#16748",
-    "lines_before": 57,
-    "lines_after": 43,
-    "action": "tightened"
   }
 }

--- a/.agents/scripts/complexity-scan-helper.sh
+++ b/.agents/scripts/complexity-scan-helper.sh
@@ -128,8 +128,12 @@ check_file_state() {
 		return 0
 	fi
 
+	# Check both .files (canonical) and top-level (legacy) locations.
+	# Legacy entries existed before the .files wrapper was introduced and
+	# caused the scanner to treat already-simplified files as "new",
+	# re-filing duplicate issues every pulse cycle.
 	local recorded_hash
-	recorded_hash=$(jq -r --arg fp "$file_path" '.files[$fp].hash // empty' "$state_file" 2>/dev/null) || recorded_hash=""
+	recorded_hash=$(jq -r --arg fp "$file_path" '(.files[$fp].hash // .[$fp].hash) // empty' "$state_file" 2>/dev/null) || recorded_hash=""
 
 	if [[ -z "$recorded_hash" ]]; then
 		echo "new"
@@ -188,10 +192,19 @@ batch_hash_check() {
 		return 0
 	fi
 
-	# Load state file hashes into an associative-style lookup via jq
+	# Load state file hashes into an associative-style lookup via jq.
+	# Merges both .files (canonical) and top-level (legacy) entries,
+	# with .files taking precedence on overlap.
 	# Output: one line per entry "file_path\thash"
 	local state_hashes
-	state_hashes=$(jq -r '.files | to_entries[] | "\(.key)\t\(.value.hash)"' "$state_file" 2>/dev/null) || state_hashes=""
+	state_hashes=$(jq -r '
+		# Collect legacy top-level entries (keys that look like file paths)
+		([to_entries[] | select(.key != "files" and (.key | startswith("."))) | {key: .key, value: .value.hash}] | from_entries) as $legacy |
+		# Collect canonical .files entries
+		([.files // {} | to_entries[] | {key: .key, value: .value.hash}] | from_entries) as $canonical |
+		# Merge: canonical wins on overlap
+		($legacy + $canonical) | to_entries[] | "\(.key)\t\(.value)"
+	' "$state_file" 2>/dev/null) || state_hashes=""
 
 	# Build a temp file for state lookup (faster than repeated jq calls)
 	local state_tmp

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3810,9 +3810,15 @@ This is an automated stall-detection sweep. The LLM should review the actual iss
 		--tokens 0 --time "$_sweep_elapsed" --session-type routine 2>/dev/null || true)
 	sweep_body="${sweep_body}${sig_footer}"
 
+	# Skip needs-maintainer-review when user is maintainer (GH#16786)
+	local sweep_review_label=""
+	if [[ "${_COMPLEXITY_SCAN_SKIP_REVIEW_GATE:-false}" != "true" ]]; then
+		sweep_review_label="--label needs-maintainer-review"
+	fi
+	# shellcheck disable=SC2086
 	if gh_create_issue --repo "$aidevops_slug" \
 		--title "perf: simplification debt stalled — LLM sweep needed ($(date -u +%Y-%m-%d))" \
-		--label "simplification-debt" --label "needs-maintainer-review" --label "tier:thinking" \
+		--label "simplification-debt" $sweep_review_label --label "tier:thinking" \
 		--assignee "$maintainer" \
 		--body "$sweep_body" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Complexity LLM sweep: created stall-review issue" >>"$LOGFILE"
@@ -4625,17 +4631,25 @@ This file was previously simplified (PR #${prev_pr}) but has since been modified
 		--tokens 0 --time "$_pulse_elapsed" --session-type routine 2>/dev/null || true)
 	issue_body="${issue_body}${sig_footer}"
 
+	# Build label list — skip needs-maintainer-review when user is maintainer (GH#16786)
+	local review_label=""
+	if [[ "${_COMPLEXITY_SCAN_SKIP_REVIEW_GATE:-false}" != "true" ]]; then
+		review_label="--label needs-maintainer-review"
+	fi
+
 	local create_ok=false
 	if [[ "$needs_recheck" == true ]]; then
+		# shellcheck disable=SC2086
 		gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
-			--label "simplification-debt" --label "needs-maintainer-review" --label "tier:simple" --label "recheck-simplicity" \
+			--label "simplification-debt" $review_label --label "tier:simple" --label "recheck-simplicity" \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	else
+		# shellcheck disable=SC2086
 		gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
-			--label "simplification-debt" --label "needs-maintainer-review" --label "tier:simple" \
+			--label "simplification-debt" $review_label --label "tier:simple" \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	fi
@@ -4794,9 +4808,15 @@ This is an automated scan. The function lengths are factual, but the best decomp
 
 		local issue_key="$file_path"
 		local issue_title="simplification: reduce function complexity in ${issue_key} (${violation_count} functions >${COMPLEXITY_FUNC_LINE_THRESHOLD} lines)"
+		# Skip needs-maintainer-review when user is maintainer (GH#16786)
+		local review_label_sh=""
+		if [[ "${_COMPLEXITY_SCAN_SKIP_REVIEW_GATE:-false}" != "true" ]]; then
+			review_label_sh="--label needs-maintainer-review"
+		fi
+		# shellcheck disable=SC2086
 		if gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
-			--label "simplification-debt" --label "needs-maintainer-review" \
+			--label "simplification-debt" $review_label_sh \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1; then
 			_complexity_scan_close_duplicate_issues_by_title "$aidevops_slug" "$issue_title"
@@ -4929,6 +4949,37 @@ run_weekly_complexity_scan() {
 	now_epoch=$(date +%s)
 
 	_complexity_scan_check_interval "$now_epoch" || return 0
+
+	# Permission gate: only collaborators/maintainers/admins may create
+	# simplification issues. Non-collaborator instances running a pulse with
+	# this repo in their repos.json were filing spurious issues (GH#16786).
+	local current_user
+	current_user=$(gh api user --jq '.login' 2>/dev/null) || current_user=""
+	if [[ -n "$current_user" ]]; then
+		local perm_level
+		perm_level=$(gh api "repos/${aidevops_slug}/collaborators/${current_user}/permission" \
+			--jq '.permission' 2>/dev/null) || perm_level=""
+		case "$perm_level" in
+		admin | maintain | write) ;; # allowed
+		*)
+			echo "[pulse-wrapper] Complexity scan: skipped — user '$current_user' has '$perm_level' permission on $aidevops_slug (need write+)" >>"$LOGFILE"
+			return 0
+			;;
+		esac
+	fi
+
+	# When the authenticated user IS the repo maintainer, skip the
+	# needs-maintainer-review label — the standard auto-dispatch + PR
+	# review flow provides sufficient gating (GH#16786).
+	local maintainer_from_config
+	maintainer_from_config=$(jq -r --arg slug "$aidevops_slug" \
+		'.initialized_repos[] | select(.slug == $slug) | .maintainer // empty' \
+		"$REPOS_JSON" 2>/dev/null)
+	[[ -z "$maintainer_from_config" ]] && maintainer_from_config=$(printf '%s' "$aidevops_slug" | cut -d/ -f1)
+	_COMPLEXITY_SCAN_SKIP_REVIEW_GATE=false
+	if [[ "$current_user" == "$maintainer_from_config" ]]; then
+		_COMPLEXITY_SCAN_SKIP_REVIEW_GATE=true
+	fi
 
 	local aidevops_path
 	aidevops_path=$(_complexity_scan_find_repo "$repos_json" "$aidevops_slug" "$now_epoch") || return 0

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -32,7 +32,7 @@ tools:
 
 ## Output Format
 
-Per finding: `### [file:line_range] Category: Brief description` with sections **Current** | **Proposed** | **Preserved** | **Risk** | **Verification** | **Confidence** (high/medium/low). Low-confidence findings: create issues with `simplification-debt` + `needs-maintainer-review` labels, grouped by file.
+Per finding: `### [file:line_range] Category: Brief description` with sections **Current** | **Proposed** | **Preserved** | **Risk** | **Verification** | **Confidence** (high/medium/low). Low-confidence findings: create issues with `simplification-debt` label (+ `needs-maintainer-review` only when the authenticated user is NOT the repo maintainer), grouped by file.
 
 ## Regression Verification
 
@@ -88,34 +88,36 @@ Scope detection: `git diff --name-only HEAD~1` + `git diff --name-only --staged`
 ### Issue creation
 
 1. **Dedup check FIRST (GH#10783)** — search for existing open issues targeting the same file.
-2. Labels: `simplification-debt` + `needs-maintainer-review`, assign to repo maintainer.
+2. Labels: `simplification-debt` always. Add `needs-maintainer-review` only when the authenticated user is NOT the repo maintainer (the label gates changes for external contributors; when you're the maintainer, standard auto-dispatch with PR review provides sufficient gating).
 
 ```bash
 MAINTAINER=$(jq -r '.initialized_repos[] | select(.slug == "<slug>") | .maintainer // empty' ~/.config/aidevops/repos.json)
 [[ -z "$MAINTAINER" ]] && MAINTAINER=$(echo "<slug>" | cut -d/ -f1)
+CURRENT_USER=$(gh api user --jq '.login' 2>/dev/null) || CURRENT_USER=""
 EXISTING=$(gh issue list --repo <slug> --label "simplification-debt" --state open \
   --search "\"<file_path>\" in:title" --json number --jq 'length' 2>/dev/null) || EXISTING="0"
 [[ "$EXISTING" -gt 0 ]] && { echo "Skipping — existing open issue found"; exit 0; }
+LABELS="simplification-debt"
+[[ "$CURRENT_USER" != "$MAINTAINER" ]] && LABELS="$LABELS,needs-maintainer-review"
 SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer 2>/dev/null || echo "")
 gh issue create --repo <slug> \
   --title "simplification: <brief description>" \
-  --label "simplification-debt" --label "needs-maintainer-review" \
+  --label "$LABELS" \
   --assignee "$MAINTAINER" \
   --body "<structured finding>
 ---
-**To approve or decline**, comment on this issue:
-- \`approved\` — removes the review gate and queues for automated dispatch
-- \`declined: <reason>\` — closes this issue
 ${SIG_FOOTER}"
 ```
 
-### Maintainer review
+### Maintainer review (external contributors only)
 
-List pending: `gh issue list --label simplification-debt --label needs-maintainer-review`
+When the authenticated user is NOT the repo maintainer, issues are gated with `needs-maintainer-review`. List pending: `gh issue list --label simplification-debt --label needs-maintainer-review`
 
 - **Approve**: comment `approved` → pulse removes gate, adds `auto-dispatch` → PR → merged → `status:done`
 - **Decline**: comment `declined: <reason>` → pulse closes issue
 - **Defer**: no comment — stays gated
+
+When the authenticated user IS the maintainer, issues skip the review gate and go directly to `auto-dispatch` via the standard pulse flow.
 
 ## Quality Workflow and Pulse Integration (GH#5628, GH#15285)
 

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -113,7 +113,7 @@ ${SIG_FOOTER}"
 
 When the authenticated user is NOT the repo maintainer, issues are gated with `needs-maintainer-review`. List pending: `gh issue list --label simplification-debt --label needs-maintainer-review`
 
-- **Approve**: comment `approved` → pulse removes gate, adds `auto-dispatch` → PR → merged → `status:done`
+- **Approve**: comment `approved` → pulse removes gate, adds `auto-dispatch` → PR → merged → issue closed
 - **Decline**: comment `declined: <reason>` → pulse closes issue
 - **Defer**: no comment — stays gated
 


### PR DESCRIPTION
## Summary

- **State file migration**: 33 entries were stranded at the top level of `simplification-state.json` instead of under `.files`. The scanner only reads `.files`, so these already-simplified files were treated as "new" every pulse cycle, creating duplicate issues indefinitely.
- **Scanner resilience**: `check_file_state()` and `batch_hash_check()` now fall back to top-level lookup if `.files` misses, preventing recurrence.
- **Permission gate**: `run_weekly_complexity_scan()` now checks collaborator permission before creating issues. Non-collaborators (e.g. milohiss) were filing simplification issues on repos they don't have write access to.
- **Conditional `needs-maintainer-review`**: Label is now skipped when the authenticated user IS the repo maintainer — the standard auto-dispatch + PR review flow provides sufficient gating.

Closed 17 spurious issues created by non-collaborator instances.

Closes #16786


---
[aidevops.sh](https://aidevops.sh) v3.5.892 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 13m and 952 tokens on this as a headless worker.