### PR TITLE
GH#16800: fix invalid jq selectors in signal-mining.md

### DIFF
--- a/.agents/tools/autoagent/autoagent/signal-mining.md
+++ b/.agents/tools/autoagent/autoagent/signal-mining.md
@@ -53,8 +53,13 @@ rg "observed|recurring|failure rate|%" ~/.aidevops/agents/prompts/build.txt 2>/d
 
 ```bash
 # Run comprehension tests and capture failures
+# --json emits composite metric only (pass_rate, failed, passed, total)
 agent-test-helper.sh run --suite agent-optimization --json 2>/dev/null | \
-  jq -r '.failures[]? | {file: .agent_file, issue: .failure_reason, source: "comprehension-tests"}'
+  jq '{failed: .failed, pass_rate: .pass_rate, source: "comprehension-tests"}'
+
+# List individual failed tests from the latest result file
+latest=$(ls -t ~/.aidevops/.agent-workspace/agent-tests/results/agent-optimization-*.json 2>/dev/null | head -1)
+[[ -n "$latest" ]] && jq -r '.results[] | select(.status == "fail") | {id: .id, status: .status}' "$latest"
 
 # Check which test suites exist
 ls ~/.aidevops/agents/tests/*.test.json 2>/dev/null | head -10


### PR DESCRIPTION
## Summary

Fixes invalid jq selectors in `.agents/tools/autoagent/autoagent/signal-mining.md` identified by CodeRabbit review on PR #16718.

The `--json` flag of `agent-test-helper.sh run` emits a composite metric object with fields: `pass_rate`, `token_ratio`, `composite_score`, `avg_response_chars`, `baseline_chars`, `passed`, `failed`, `total`. There is no `failures[]` array at the top level, and no `agent_file` or `failure_reason` fields exist anywhere in the output.

## Changes

**`.agents/tools/autoagent/autoagent/signal-mining.md`** (line 57):
- Replaced `.failures[]? | {file: .agent_file, issue: .failure_reason, ...}` with correct field references
- Added composite metric summary using `.failed` and `.pass_rate` (actual schema fields)
- Added separate command reading the result file's `.results[]` array filtered by `status == "fail"` for individual failure details (result files are at `~/.aidevops/.agent-workspace/agent-tests/results/`)

## Testing

- Risk level: **Low** (docs/agent prompt only — no executable code changed)
- Verified actual `--json` output schema from `agent-test-helper.sh` source (lines 772–789)
- Verified result file schema from `_cmd_run_save_results` (lines 612–651)
- `markdownlint-cli2`: 0 errors
- No remaining occurrences of `.baseline_pass_rate` or `.failures[]?` in `.agents/`

## Runtime Testing

`self-assessed` — Low risk: agent prompt doc change only. No runtime environment required.

Closes #16800

---
[aidevops.sh](https://aidevops.sh) v3.5.892 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6