### PR TITLE
GH#16795: tighten axe-cli.md agent doc

### DIFF
--- a/.agents/tools/mobile/axe-cli.md
+++ b/.agents/tools/mobile/axe-cli.md
@@ -9,43 +9,39 @@ tools:
 # AXe - iOS Simulator Automation CLI
 
 - **Install**: `brew install cameroncooke/axe/axe`
-- **Requirements**: macOS with Xcode and iOS Simulator
+- **Requirements**: macOS + Xcode + iOS Simulator
 - **GitHub**: https://github.com/cameroncooke/AXe (MIT, by XcodeBuildMCP author)
 - **vs idb**: Single binary (no daemon), complete HID coverage, gesture presets, timing controls
-- All commands require `--udid SIMULATOR_UDID`. Get UDIDs: `axe list-simulators`.
+- All commands require `--udid $UDID`. Get UDIDs: `axe list-simulators`.
 
 ## Commands
 
-### Touch, Gestures, and Input
-
 ```bash
+# Touch & gestures
 axe tap -x 100 -y 200 --udid $UDID                # coordinates
 axe tap --id "Safari" --udid $UDID                  # accessibility ID
 axe tap --label "Submit" --udid $UDID               # label
+axe tap -x 100 -y 200 --pre-delay 1.0 --post-delay 0.5 --udid $UDID  # timing on any touch/gesture
 axe swipe --start-x 100 --start-y 300 --end-x 300 --end-y 100 --udid $UDID
 axe gesture scroll-down --udid $UDID               # presets: scroll-up/down/left/right, swipe-from-{left,right,top,bottom}-edge
 axe type 'Hello World!' --udid $UDID               # direct text; echo "text" | axe type --stdin --udid $UDID
-axe tap -x 100 -y 200 --pre-delay 1.0 --post-delay 0.5 --udid $UDID  # timing on any touch/gesture
-```
 
-### Keyboard, Buttons, and Media
-
-```bash
-axe key 40 --udid $UDID                                        # HID keycode (40=Enter, 42=Backspace)
-axe key 42 --duration 1.0 --udid $UDID
+# Keyboard & buttons
+axe key 40 --udid $UDID                            # HID keycode (40=Enter, 42=Backspace); --duration N for hold
 axe key-sequence --keycodes 11,8,15,15,18 --udid $UDID         # type "hello" by keycodes
 axe key-combo --modifiers 227 --key 4 --udid $UDID             # Cmd+A (227=Cmd, 225=Shift)
 axe key-combo --modifiers 227,225 --key 4 --udid $UDID         # Cmd+Shift+A
-axe button home --udid $UDID                                   # hardware: home, lock, side-button, siri, apple-pay
-axe button lock --duration 2.0 --udid $UDID
+axe button home --udid $UDID                       # hardware: home, lock, side-button, siri, apple-pay; --duration N
+
+# Media & UI inspection
 axe screenshot --output ~/Desktop/capture.png --udid $UDID
 axe record-video --udid $UDID --fps 15 --output recording.mp4  # H.264 MP4; flags: --fps, --quality, --scale
 axe stream-video --udid $UDID --fps 30 --format ffmpeg | \     # stream formats: mjpeg, ffmpeg, raw, bgra
   ffmpeg -f image2pipe -framerate 30 -i - -c:v libx264 output.mp4
-axe describe-ui --udid $UDID                                   # accessibility tree (full screen or --point 100,200)
+axe describe-ui --udid $UDID                       # accessibility tree (full screen or --point 100,200)
 ```
 
-### Common Patterns
+## Common Patterns
 
 ```bash
 # Accessibility audit: dump UI tree + screenshot


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/mobile/axe-cli.md` per issue #16795 (automated simplification scan).

**Classification**: Instruction doc (agent rules + command reference) — not a reference corpus. Compression applied, not restructuring.

**Changes:**
- Merged "Touch, Gestures, and Input" and "Keyboard, Buttons, and Media" subsections into a single `## Commands` block with inline `# section` comments
- Collapsed `axe key` + `axe key --duration` into one line with `--duration N for hold` note
- Collapsed `axe button home` + `axe button lock --duration` into one line with `--duration N` note
- Tightened "Requirements" bullet (removed redundant "with")
- Changed `--udid SIMULATOR_UDID` to `--udid $UDID` (consistent with usage in examples)
- Result: 74 → 70 lines (5.4% reduction)

**Preservation check:**
- All commands present: tap, swipe, gesture, type, key, key-sequence, key-combo, button, screenshot, record-video, stream-video, describe-ui
- All flags preserved: --pre-delay, --post-delay, --duration, --fps, --quality, --scale, --format, --point, --stdin, --keycodes, --modifiers
- Comparison table unchanged
- Related links unchanged
- GitHub URL, MIT license note, XcodeBuildMCP author attribution preserved

## Runtime Testing

**Risk level**: Low (docs-only change, no code)
**Verification**: `self-assessed` — markdownlint-cli2 reports 0 errors on modified file

## Files Changed

- `.agents/tools/mobile/axe-cli.md` (74 → 70 lines)

Closes #16795

---
[aidevops.sh](https://aidevops.sh) v3.5.893 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tool requirements specification with clearer formatting
  * Reorganized command documentation for improved readability
  * Added new examples demonstrating timing control options
  * Enhanced clarity of existing command usage instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->