### PR TITLE
GH#16796: tighten pre-edit.md agent doc

### DIFF
--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -44,23 +44,16 @@ Keep `~/Git/{repo}/` on `main`. Avoids blocked branch switches, parallel session
 
 Stay on `main` only for: docs-only changes (README, CHANGELOG, `docs/`), typos, version bumps, planning files (`TODO.md`, `todo/`). Planning-file commits use `planning-commit-helper.sh "plan: add new task"`.
 
-| Scenario | Script output | Action |
-|----------|---------------|--------|
-| In worktree | `OK - On branch: X (in worktree)` | Proceed |
-| In main repo | `WARNING - MAIN REPO ON FEATURE BRANCH` | Present exit-3 options |
+Continue on current branch only when: task matches branch purpose, finishes this session, no parallel sessions expected.
 
-Continuing on the current branch is acceptable only when the task matches the branch purpose, will be finished in this session, and no parallel sessions are expected.
-
-## Worktree Creation
+**Create worktree:**
 
 ```bash
 wt switch -c {type}/{name}
 ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{name}
 ```
 
-After creating the worktree, call `session-rename_sync_branch`.
-
-Branch types: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
+After creating, call `session-rename_sync_branch`. Branch types: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
 ## Source vs Deployed Copy
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
**What:** Tighten `.agents/workflows/pre-edit.md` per issue #16796 simplification scan.

**Issue:** Closes #16796

**Files changed:** `.agents/workflows/pre-edit.md` (70 → 63 lines, -10 lines)

**Changes:**
- Merged `Worktree Creation` section into `Worktree Default` (same concern, no reason to split)
- Compressed verbose "Continuing on the current branch is acceptable only when..." sentence to a single compact line
- Removed redundant scenario table (duplicated exit code table information)
- All institutional knowledge preserved: exit codes, prompts, loop mode keywords, commands, branch types, source vs deployed distinction

**Testing:** Low-risk docs change. Self-assessed. Agent behaviour unchanged — all decision rules, commands, and references intact.

## Runtime Testing

Risk: **Low** (docs/agent prompt only, no code changes). Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.5.893 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6