### PR TITLE
GH#16799: tighten zaraz-patterns.md (51→44 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/zaraz-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/zaraz-patterns.md
@@ -5,11 +5,7 @@
 ```javascript
 zaraz.ecommerce('Product Viewed', { product_id: 'SKU123', name: 'Blue Widget', price: 49.99, currency: 'USD' });
 zaraz.ecommerce('Product Added', { product_id: 'SKU123', quantity: 2, price: 49.99 });
-zaraz.ecommerce('Order Completed', {
-  order_id: 'ORD-789', total: 149.98, revenue: 149.98,
-  shipping: 10.00, tax: 12.50, currency: 'USD',
-  products: [{ product_id: 'SKU123', quantity: 2, price: 49.99 }]
-});
+zaraz.ecommerce('Order Completed', { order_id: 'ORD-789', total: 149.98, revenue: 149.98, shipping: 10.00, tax: 12.50, currency: 'USD', products: [{ product_id: 'SKU123', quantity: 2, price: 49.99 }] });
 ```
 
 ## SPA Route Tracking
@@ -31,17 +27,14 @@ zaraz.track('login', { method: 'password' });
 if (zaraz.consent.getAll().analytics) { zaraz.track('page_view'); }
 zaraz.consent.modal = true;
 zaraz.consent.setAll({ analytics: true, marketing: false, preferences: true });
-zaraz.consent.addEventListener('consentChanged', () => {
-  console.log('Consent updated:', zaraz.consent.getAll());
-});
+zaraz.consent.addEventListener('consentChanged', () => { /* re-fire events based on zaraz.consent.getAll() */ });
 ```
 
 ## Custom Managed Components
 
 ```javascript
 export default class CustomAnalytics {
-  async handleEvent(event) {
-    const { type, payload } = event;
+  async handleEvent({ type, payload }) {
     await fetch('https://analytics.example.com/track', {
       method: 'POST',
       body: JSON.stringify({ event: type, properties: payload, timestamp: Date.now() })


### PR DESCRIPTION
## Summary

- Condense `Order Completed` ecommerce call to single line (removes 3 lines of multi-line formatting)
- Replace debug `console.log` in consent change handler with descriptive comment
- Inline destructuring in custom component `handleEvent` (removes intermediate variable)
- All 5 pattern sections preserved with zero content loss

## What

Tighten `.agents/services/hosting/cloudflare-platform-skill/zaraz-patterns.md` from 51 to 44 lines (14% reduction). This is a reference corpus of code patterns — no prose to compress, so changes target code verbosity only.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/zaraz-patterns.md` (51→44 lines)

## Testing

Self-assessed (Low risk: docs/reference patterns only). All code blocks, section headers, and pattern coverage verified present before and after.

## Runtime Testing

**Risk level:** Low — agent doc / reference patterns only  
**Verification:** `self-assessed` — no runtime required

Closes #16799

---
[aidevops.sh](https://aidevops.sh) v3.5.897 plugin for [Claude Code](https://claude.ai/code) spent <1m on this as a headless worker session.