### PR TITLE
GH#16810: Add Ollama as first-class local model provider for pulse dispatch

### DIFF
--- a/.agents/configs/fallback-chain-config.json.txt
+++ b/.agents/configs/fallback-chain-config.json.txt
@@ -3,8 +3,13 @@
   "_docs": "See .agents/tools/ai-assistants/fallback-chains.md for full documentation",
 
   "chains": {
-    "_comment": "Per-tier fallback chains. Anthropic ONLY. Never use openrouter, openai, or google providers for worker dispatch.",
+    "_comment": "Per-tier fallback chains. Anthropic preferred for cloud dispatch. Local providers (ollama, local) are zero-cost and tried first in the local tier.",
 
+    "local": [
+      "ollama/auto",
+      "local/llama.cpp",
+      "anthropic/claude-haiku-4-5"
+    ],
     "haiku": [
       "anthropic/claude-haiku-4-5"
     ],

--- a/.agents/configs/model-pricing.json
+++ b/.agents/configs/model-pricing.json
@@ -18,7 +18,9 @@
     "gemini-3-pro":    { "input": 1.25,  "output": 10.0,  "cache_read": 0.3125, "cache_write": 2.50  },
     "gemini-3-flash":  { "input": 0.10,  "output": 0.40,  "cache_read": 0.025,  "cache_write": 0.10  },
     "deepseek-r1":     { "input": 0.55,  "output": 2.19,  "cache_read": 0.14,   "cache_write": 0.55  },
-    "deepseek-v3":     { "input": 0.27,  "output": 1.10,  "cache_read": 0.07,   "cache_write": 0.27  }
+    "deepseek-v3":     { "input": 0.27,  "output": 1.10,  "cache_read": 0.07,   "cache_write": 0.27  },
+    "ollama/":         { "input": 0.0,   "output": 0.0,   "cache_read": 0.0,    "cache_write": 0.0   },
+    "local/":          { "input": 0.0,   "output": 0.0,   "cache_read": 0.0,    "cache_write": 0.0   }
   },
   "default": { "input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75 }
 }

--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -3,7 +3,7 @@
   "_docs": "See .agents/tools/context/model-routing.md for routing rules, .agents/tools/ai-assistants/fallback-chains.md for integration.",
 
   "tiers": {
-    "local":  { "models": ["local/llama.cpp"], "fallback": "haiku", "cost": 0 },
+    "local":  { "models": ["ollama/auto", "local/llama.cpp"], "fallback": "haiku", "cost": 0 },
     "haiku":  { "models": ["anthropic/claude-haiku-4-5"] },
     "flash":  { "models": ["anthropic/claude-haiku-4-5"] },
     "sonnet": { "models": ["anthropic/claude-sonnet-4-6"] },
@@ -21,6 +21,14 @@
       "probe_path": "/v1/models",
       "probe_timeout_seconds": 3,
       "_comment": "llama.cpp or compatible OpenAI-API server. No API key needed. Use local-model-helper.sh status to check."
+    },
+    "ollama": {
+      "endpoint": "http://localhost:11434/v1/chat/completions",
+      "key_env": null,
+      "probe_path": "/api/tags",
+      "probe_timeout_seconds": 3,
+      "min_context_length": 16384,
+      "_comment": "Ollama local inference. CRITICAL: Ollama defaults to 4K context — tool schemas alone consume 4-8K tokens. Set num_ctx >= 32768 in your Modelfile or OLLAMA_CONTEXT_LENGTH env var. Use 'ollama/auto' to use whatever model is currently loaded, or 'ollama/<model>' for a specific model."
     },
     "anthropic": {
       "endpoint": "https://api.anthropic.com/v1/messages",

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -289,6 +289,11 @@ get_auth_signature() {
 		auth_mtime=$(file_mtime "$OPENCODE_AUTH_FILE")
 		auth_material="${auth_material}|mtime=${auth_mtime}"
 		;;
+	ollama | local)
+		# Local providers have no auth material — use a static signature
+		# so backoff state clears only when the provider string changes
+		auth_material="${auth_material}|local=true"
+		;;
 	*)
 		auth_material="${auth_material}|unknown=true"
 		;;
@@ -729,6 +734,13 @@ provider_auth_available() {
 	local)
 		# Local provider is always considered available (no auth needed)
 		return 0
+		;;
+	ollama)
+		# Ollama: no auth needed, just check if server is reachable
+		if curl -sf --max-time 2 "${OLLAMA_HOST:-http://localhost:11434}/api/tags" >/dev/null 2>&1; then
+			return 0
+		fi
+		return 1
 		;;
 	*)
 		# Unknown provider: assume available (don't silently drop unknown providers)

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -55,7 +55,7 @@ readonly DEFAULT_RATELIMIT_TTL=60 # 1 minute for rate limit data
 readonly PROBE_TIMEOUT=10         # HTTP request timeout in seconds
 
 # Known providers list (opencode is a meta-provider routing through its gateway)
-readonly KNOWN_PROVIDERS="anthropic openai google openrouter groq deepseek opencode"
+readonly KNOWN_PROVIDERS="anthropic openai google openrouter groq deepseek opencode ollama"
 
 # OpenCode models cache (from models.dev, refreshed by opencode CLI)
 readonly OPENCODE_MODELS_CACHE="${HOME}/.cache/opencode/models.json"
@@ -74,6 +74,7 @@ get_provider_endpoint() {
 	groq) echo "https://api.groq.com/openai/v1/models" ;;
 	deepseek) echo "https://api.deepseek.com/v1/models" ;;
 	opencode) echo "https://opencode.ai/zen/v1/models" ;;
+	ollama) echo "http://localhost:11434/api/tags" ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -90,6 +91,7 @@ get_provider_key_vars() {
 	groq) echo "GROQ_API_KEY" ;;
 	deepseek) echo "DEEPSEEK_API_KEY" ;;
 	opencode) echo "OPENCODE_API_KEY" ;;
+	ollama) echo "" ;; # No API key needed — local inference
 	*) return 1 ;;
 	esac
 	return 0
@@ -99,7 +101,7 @@ get_provider_key_vars() {
 is_known_provider() {
 	local provider="$1"
 	case "$provider" in
-	anthropic | openai | google | openrouter | groq | deepseek) return 0 ;;
+	anthropic | openai | google | openrouter | groq | deepseek | ollama) return 0 ;;
 	*) return 1 ;;
 	esac
 }
@@ -113,7 +115,7 @@ get_tier_models() {
 	local tier="$1"
 
 	case "$tier" in
-	local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
+	local) echo "ollama/auto|local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 	haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
 	flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
 	sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.3-codex" ;;
@@ -478,6 +480,75 @@ _probe_opencode() {
 	return 1
 }
 
+# Probe Ollama local inference server.
+# Checks: (1) server is running, (2) at least one model is loaded,
+# (3) context length is sufficient for agentic tool use.
+# CRITICAL: Ollama defaults to 4K context. Tool schemas alone consume 4-8K tokens.
+# Agent loops need 32K+. This probe warns if context is below MIN_OLLAMA_CONTEXT.
+_probe_ollama() {
+	local quiet="${1:-false}"
+	local min_context="${MIN_OLLAMA_CONTEXT:-16384}"
+	local ollama_host="${OLLAMA_HOST:-http://localhost:11434}"
+
+	# Check if Ollama server is reachable
+	local response=""
+	response=$(curl -sf --max-time 3 "${ollama_host}/api/tags" 2>/dev/null) || {
+		_record_health "ollama" "unhealthy" 0 0 "Ollama server not reachable at ${ollama_host}" 0
+		[[ "$quiet" != "true" ]] && print_warning "ollama: server not reachable at ${ollama_host}"
+		return 1
+	}
+
+	# Count loaded models
+	local models_count=0
+	models_count=$(echo "$response" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('models',[])))" 2>/dev/null || echo "0")
+
+	if [[ "$models_count" -eq 0 ]]; then
+		_record_health "ollama" "unhealthy" 200 0 "No models loaded (run: ollama pull <model>)" 0
+		[[ "$quiet" != "true" ]] && print_warning "ollama: no models loaded (run: ollama pull <model>)"
+		return 1
+	fi
+
+	# Check context length of the first available model
+	local first_model=""
+	first_model=$(echo "$response" | python3 -c "import json,sys; m=json.load(sys.stdin).get('models',[]); print(m[0]['name'] if m else '')" 2>/dev/null || echo "")
+
+	if [[ -n "$first_model" ]]; then
+		local show_response=""
+		show_response=$(curl -sf --max-time 3 "${ollama_host}/api/show" -d "{\"name\":\"${first_model}\"}" 2>/dev/null) || true
+
+		if [[ -n "$show_response" ]]; then
+			local ctx_length=0
+			ctx_length=$(echo "$show_response" | python3 -c "
+import json, sys, re
+data = json.load(sys.stdin)
+params = data.get('parameters', '')
+match = re.search(r'num_ctx\s+(\d+)', params)
+if match:
+    print(match.group(1))
+else:
+    # Check modelfile for num_ctx
+    mf = data.get('modelfile', '')
+    match2 = re.search(r'num_ctx\s+(\d+)', mf)
+    print(match2.group(1) if match2 else '4096')
+" 2>/dev/null || echo "4096")
+
+			if [[ "$ctx_length" -lt "$min_context" ]]; then
+				_record_health "ollama" "degraded" 200 0 "Context length ${ctx_length} < ${min_context} minimum. Set OLLAMA_CONTEXT_LENGTH=${min_context} or add 'PARAMETER num_ctx ${min_context}' to your Modelfile" "$models_count"
+				[[ "$quiet" != "true" ]] && print_warning "ollama: context length ${ctx_length} is below ${min_context} minimum — agentic tool use will fail. Set OLLAMA_CONTEXT_LENGTH=${min_context} or use a Modelfile with 'PARAMETER num_ctx ${min_context}'"
+				return 2
+			fi
+		fi
+	fi
+
+	_record_health "ollama" "healthy" 200 0 "" "$models_count"
+	[[ "$quiet" != "true" ]] && print_success "ollama: healthy (${models_count} models, context OK)"
+	db_query "
+		INSERT INTO probe_log (provider, action, result, duration_ms, details)
+		VALUES ('ollama', 'api_check', 'healthy', 0, '${models_count} models available');
+	" || true
+	return 0
+}
+
 # Build curl argument array and resolve the final endpoint URL for a provider.
 # Outputs two lines: first the endpoint URL, then the curl args (space-separated).
 # Caller must reconstruct the array from the second line.
@@ -620,6 +691,12 @@ probe_provider() {
 	# OpenCode uses its local models cache — no HTTP probe needed
 	if [[ "$provider" == "opencode" ]]; then
 		_probe_opencode "$quiet"
+		return $?
+	fi
+
+	# Ollama uses its own probe — no API key, checks server + context length
+	if [[ "$provider" == "ollama" ]]; then
+		_probe_ollama "$quiet"
 		return $?
 	fi
 

--- a/.agents/tools/local-models/ollama.md
+++ b/.agents/tools/local-models/ollama.md
@@ -1,0 +1,232 @@
+---
+description: Ollama local inference provider - setup, context length configuration, OpenCode integration, pulse dispatch
+mode: subagent
+model: haiku
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Ollama Provider
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Runtime**: Ollama (Go wrapper around llama.cpp, daemon-based)
+- **Models**: Any model from the Ollama registry (`ollama pull <model>`)
+- **API**: OpenAI-compatible at `http://localhost:11434/v1`
+- **Health probe**: `model-availability-helper.sh check ollama`
+- **Dispatch**: `opencode run --model ollama/<model> "prompt"` or via pulse with `tier:local`
+
+**CRITICAL: Context length.** Ollama defaults to 4K context. Tool schemas alone consume 4-8K tokens. Agentic loops need 32K+. You MUST configure context length before using Ollama for agent dispatch. See [Context Length Configuration](#context-length-configuration) below.
+
+<!-- AI-CONTEXT-END -->
+
+## When to Use Ollama vs llama.cpp
+
+| Criterion | Ollama | llama.cpp |
+|-----------|--------|-----------|
+| Setup | `brew install ollama && ollama pull <model>` | Download binary + GGUF, manual flags |
+| Daemon | Yes (auto-start, auto-restart) | No (manual process management) |
+| Model management | Registry, `ollama pull/rm/list` | Manual GGUF file management |
+| Speed | Same engine (llama.cpp underneath) | Same engine |
+| Memory management | Auto load/unload, configurable keep-alive | Model stays loaded until killed |
+| Control | Abstracted (Modelfile for overrides) | Full flag control |
+| Security | Daemon on localhost, no auth | No daemon, localhost only |
+
+**Use Ollama when**: you want zero-config model management, daemon lifecycle, and the pulse dispatch integration. **Use llama.cpp when**: you need full control over inference parameters, bleeding-edge features, or minimal attack surface.
+
+## Installation
+
+```bash
+# macOS
+brew install ollama
+
+# Linux
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Verify
+ollama --version
+```
+
+Ollama starts automatically as a macOS service after installation.
+
+## Model Setup
+
+```bash
+# Pull a model (example: Gemma 4 26B MoE)
+ollama pull gemma4:26b
+
+# List loaded models
+ollama list
+
+# Test inference
+ollama run gemma4:26b "Hello, what model are you?"
+```
+
+## Context Length Configuration
+
+This is the most common source of silent failures with Ollama agent dispatch.
+
+### Option A: Environment Variable (Quick)
+
+```bash
+# Set before starting ollama serve (or in launchd plist)
+export OLLAMA_CONTEXT_LENGTH=65536
+ollama serve
+```
+
+### Option B: Modelfile (Recommended for Production)
+
+Create a Modelfile that bakes in the context length:
+
+```dockerfile
+# ~/.ollama/Modelfile.gemma4-agent
+FROM gemma4:26b
+PARAMETER num_ctx 65536
+PARAMETER temperature 0.1
+```
+
+Build and use:
+
+```bash
+ollama create gemma4-agent -f ~/.ollama/Modelfile.gemma4-agent
+# Now use ollama/gemma4-agent in your config
+```
+
+### Option C: Per-Request (API Only)
+
+```bash
+curl http://localhost:11434/api/chat -d '{
+  "model": "gemma4:26b",
+  "options": { "num_ctx": 65536 },
+  "messages": [{"role": "user", "content": "Hello"}]
+}'
+```
+
+Note: The OpenAI-compatible endpoint (`/v1/chat/completions`) does not support `num_ctx` per-request. Use Option A or B for OpenCode/pulse dispatch.
+
+### Memory Budget for Context Length
+
+On Apple Silicon, context length directly affects memory usage via the KV cache:
+
+| Context Length | KV Cache (FP16) | KV Cache (TurboQuant 4-bit) | Total with Q6 Weights (~22GB) |
+|---|---|---|---|
+| 4K (default) | ~0.5GB | ~0.1GB | ~22.5GB |
+| 32K | ~4GB | ~1GB | ~26GB |
+| 65K | ~8GB | ~2GB | ~30GB |
+| 128K | ~16GB | ~4GB | ~38GB |
+| 256K | ~32GB | ~8GB | ~54GB |
+
+**Recommendation for 64GB systems**: 65K context with TurboQuant gives ~30GB total, leaving ample headroom for OS and agent stack.
+
+## OpenCode Provider Configuration
+
+Add to your project's `opencode.json` (or global config):
+
+```json
+{
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": {
+        "baseURL": "http://localhost:11434/v1",
+        "timeout": 600000
+      },
+      "models": {
+        "gemma4:26b": {
+          "name": "Gemma 4 26B MoE",
+          "tool_call": true,
+          "attachment": true,
+          "reasoning": false,
+          "temperature": true,
+          "cost": { "input": 0, "output": 0, "cache_read": 0, "cache_write": 0 },
+          "limit": { "context": 65536, "output": 8192 }
+        }
+      }
+    }
+  }
+}
+```
+
+Then dispatch with:
+
+```bash
+opencode run --model ollama/gemma4:26b "Implement feature X"
+```
+
+## Pulse Dispatch
+
+The pulse uses the `local` tier to dispatch to Ollama. The fallback chain is:
+
+```
+ollama/auto -> local/llama.cpp -> anthropic/claude-haiku-4-5
+```
+
+To force a specific Ollama model, set the GitHub issue label `tier:local` or configure `AIDEVOPS_HEADLESS_MODELS=ollama/gemma4:26b`.
+
+### Health Probe
+
+The pulse checks Ollama health before dispatching:
+
+```bash
+# Manual check
+model-availability-helper.sh check ollama
+
+# What it validates:
+# 1. Server is reachable at localhost:11434
+# 2. At least one model is loaded
+# 3. Context length >= 16384 (configurable via MIN_OLLAMA_CONTEXT)
+```
+
+If the context length check fails, the probe returns `degraded` status and the pulse falls back to the next provider in the chain.
+
+## Troubleshooting
+
+### "Ollama server not reachable"
+
+```bash
+# Check if ollama is running
+pgrep -f ollama
+# Restart
+brew services restart ollama
+# Or manually
+ollama serve
+```
+
+### "Context length below minimum"
+
+```bash
+# Check current context length
+curl -s http://localhost:11434/api/show -d '{"name":"gemma4:26b"}' | python3 -c "
+import json, sys, re
+data = json.load(sys.stdin)
+match = re.search(r'num_ctx\s+(\d+)', data.get('parameters', ''))
+print(f'num_ctx: {match.group(1)}' if match else 'num_ctx: 4096 (default)')
+"
+
+# Fix: create a Modelfile with proper context length (see above)
+```
+
+### "Tool calls not working"
+
+Verify the model supports function calling. Not all Ollama models do. Models with native tool-call support include: Gemma 4, Llama 4, Qwen 3, Mistral Large. Check with:
+
+```bash
+ollama show gemma4:26b --modelfile | grep -i tool
+```
+
+### Slow inference
+
+On Apple Silicon, inference is memory-bandwidth-bound. Tips:
+- Use quantized models (Q4_K_M or Q6_K) — smaller weights = faster inference
+- Close memory-heavy apps to reduce memory pressure
+- Monitor with `sudo powermetrics --samplers smc -i 1000 -n 1` for thermal throttling


### PR DESCRIPTION
## Summary

- Adds Ollama as a supported provider in the model routing, availability probing, and dispatch chain
- Enables zero-cost local inference for pulse task dispatch via `ollama/auto` or `ollama/<model>`
- Includes context length validation probe that warns when Ollama's default 4K context is too low for agentic tool use (tool schemas alone consume 4-8K tokens)

## Changes

**Configs (3 files):**
- `model-routing-table.json`: Add `ollama` provider with endpoint, probe path, and `min_context_length: 16384`. Add `ollama/auto` as first choice in `local` tier.
- `fallback-chain-config.json.txt`: Add `local` chain: `ollama/auto` -> `local/llama.cpp` -> `anthropic/claude-haiku-4-5`
- `model-pricing.json`: Add `$0` entries for `ollama/` and `local/` prefixes

**Scripts (2 files):**
- `model-availability-helper.sh`: Add `ollama` to `KNOWN_PROVIDERS`, `get_provider_endpoint()`, `get_provider_key_vars()`, `is_known_provider()`, `get_tier_models()`. New `_probe_ollama()` function checks server health, model availability, and context length >= 16384.
- `headless-runtime-helper.sh`: Add `ollama` case to `provider_auth_available()` (curl health check) and `get_auth_signature()` (static local signature)

**Documentation (1 new file):**
- `.agents/tools/local-models/ollama.md`: Setup guide covering installation, context length configuration (Modelfile, env var, per-request), memory budget table for Apple Silicon, OpenCode provider config, pulse dispatch integration, and troubleshooting

## How It Works

The pulse dispatches to OpenCode with `--model ollama/<model>`. OpenCode uses its existing `@ai-sdk/openai-compatible` adapter to talk to Ollama's OpenAI-compatible API at `localhost:11434/v1`. No new agentic runtime needed — OpenCode handles the tool-calling loop.

Users configure the OpenCode provider in their project's `opencode.json`:

```json
{
  "provider": {
    "ollama": {
      "npm": "@ai-sdk/openai-compatible",
      "name": "Ollama (local)",
      "options": { "baseURL": "http://localhost:11434/v1", "timeout": 600000 },
      "models": {
        "gemma4:26b": {
          "name": "Gemma 4 26B MoE",
          "tool_call": true,
          "cost": { "input": 0, "output": 0, "cache_read": 0, "cache_write": 0 },
          "limit": { "context": 65536, "output": 8192 }
        }
      }
    }
  }
}
```

## Testing

- All 3 JSON configs validate with `python3 -m json.tool`
- ShellCheck clean (only pre-existing SC1091 info on external source)
- `test-model-availability.sh`: 21 passed, 7 failed (same 7 pre-existing failures on main), 15 skipped
- `test-headless-runtime-helper.sh`: passes

Closes #16810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Ollama support as a local model provider, enabling offline model execution with automatic fallback to cloud alternatives.
  * Implemented configurable model fallback chains for improved availability and flexibility.

* **Documentation**
  * Added comprehensive guide for setting up and using the Ollama provider, including installation, configuration options, and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->