### PR TITLE
GH#16803: tighten wrangler-gotchas.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md
@@ -1,9 +1,5 @@
 # Wrangler Common Issues
 
-Pitfalls and troubleshooting for the Wrangler CLI.
-
-## Gotchas
-
 **Compatibility Dates** — Always set; omitting causes unexpected runtime changes:
 
 ```jsonc


### PR DESCRIPTION
## Summary

- Remove redundant intro line ("Pitfalls and troubleshooting for the Wrangler CLI.") — duplicates the title
- Remove superfluous `## Gotchas` heading — adds no navigational value at this file size
- All content preserved; 51 → 47 lines

## Verification

- All code blocks, URLs, and cross-references intact
- `wc -l` before: 51, after: 47 (4 lines removed: blank line + intro + blank line + heading)
- No broken internal links

Closes #16803

---
[aidevops.sh](https://aidevops.sh) v3.5.898 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the Wrangler troubleshooting guide by removing redundant header text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->