### PR TITLE
GH#16804: tighten email-campaign.md agent doc (51→41 lines)

### DIFF
--- a/.agents/scripts/commands/email-campaign.md
+++ b/.agents/scripts/commands/email-campaign.md
@@ -4,34 +4,24 @@ agent: Build+
 mode: subagent
 ---
 
-Manage newsletter and broadcast campaigns: list setup, send workflow, and analytics review.
-
 Arguments: $ARGUMENTS
 
 ## Workflow
 
-**Step 1 — Parse intent:** Extract campaign type (`newsletter`, `broadcast`, `sequence`), action (`create`, `schedule`, `send`, `pause`, `status`, `analytics`), and optional audience segment. If type is missing, request it.
-
-**Step 2 — Validate inputs:** For create/schedule/send confirm: subject + preview text, audience segment, single primary CTA, send window/timezone, compliance footer + unsubscribe handling.
-
-**Step 3 — Execute:**
+1. **Parse intent:** Extract campaign type (`newsletter`, `broadcast`, `sequence`), action (`create`, `schedule`, `send`, `pause`, `status`, `analytics`), and optional audience segment. Missing type → request it.
+2. **Validate:** For create/schedule/send confirm: subject + preview text, audience segment, single primary CTA, send window/timezone, compliance footer + unsubscribe handling.
+3. **Execute:**
 
 ```bash
-# Create campaign draft
 ~/.aidevops/agents/scripts/email-agent-helper.sh send --mission "$MISSION_ID" --template "$TEMPLATE"
-
-# Content and infrastructure preflight
 ~/.aidevops/agents/scripts/email-health-check-helper.sh precheck "$DOMAIN" "$HTML_FILE"
-
-# Delivery readiness
 ~/.aidevops/agents/scripts/email-delivery-test-helper.sh report "$DOMAIN"
 ```
 
 CRM-first operations (segmentation, automations, broadcasts) → route to configured CRM tooling flow.
 
-**Step 4 — Report:** campaign type/ID/state, segment size + send count, send window/cadence, key metrics (open, click, reply, unsubscribe, spam complaint), recommended optimization action.
-
-**Step 5 — Follow-up options:** A/B test subject lines · re-segment non-openers · tune CTA · schedule next in sequence · export performance summary.
+4. **Report:** campaign type/ID/state, segment size + send count, send window/cadence, key metrics (open, click, reply, unsubscribe, spam complaint), recommended optimization action.
+5. **Follow-up:** A/B test subject lines · re-segment non-openers · tune CTA · schedule next in sequence · export performance summary.
 
 ## Commands
 
@@ -45,7 +35,7 @@ CRM-first operations (segmentation, automations, broadcasts) → route to config
 
 ## Related
 
-- `content/distribution-email.md` - Newsletter and sequence strategy
-- `services/email/email-testing.md` - Design and delivery testing workflow
-- `services/email/email-delivery-test.md` - Inbox placement and spam scoring
-- `services/email/email-health-check.md` - DNS and content precheck
+- `content/distribution-email.md` — Newsletter and sequence strategy
+- `services/email/email-testing.md` — Design and delivery testing workflow
+- `services/email/email-delivery-test.md` — Inbox placement and spam scoring
+- `services/email/email-health-check.md` — DNS and content precheck


### PR DESCRIPTION
## Summary

- Tighten `email-campaign.md` from 51 to 41 lines (~20% reduction) per build-agent.md terse pass guidance
- Convert verbose `**Step N —**` headers to numbered list format; compress prose to direct rules
- Zero content loss: all 3 script commands, 5 command examples, 4 related links preserved

## What

Simplified `.agents/scripts/commands/email-campaign.md` — an instruction doc (not a reference corpus). Applied terse pass: removed redundant intro sentence, compressed step headers, removed inline comments from code block.

## Issue

Closes #16804

## Files Changed

- `.agents/scripts/commands/email-campaign.md` — 51→41 lines

## Testing

- `bunx markdownlint-cli2` — 0 errors
- Content verification: all code blocks, URLs, command examples present before and after
- Risk: **Low** (docs-only change, no executable code modified) — `self-assessed`

## Runtime Testing

Risk level: **Low** (agent doc, no executable code). Self-assessed per t1660.7 low-risk criteria.

## Key Decisions

- Kept `Arguments: $ARGUMENTS` — required for slash command argument passing
- Removed redundant intro sentence (duplicated frontmatter description)
- Preserved all institutional knowledge; only prose style compressed

<!-- MERGE_SUMMARY -->
**What:** Tighten email-campaign.md agent doc prose (51→41 lines, 20% reduction)
**Issue:** Closes #16804
**Files:** `.agents/scripts/commands/email-campaign.md`
**Testing:** markdownlint 0 errors, content verified
**Key decisions:** Zero content loss, prose-only compression

---
[aidevops.sh](https://aidevops.sh) v3.5.898 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6