### PR TITLE
GH#16798: tighten remotion-trimming.md agent doc (51→47 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5753,6 +5753,13 @@
     },
     ".agents/workflows/pre-edit.md": {
       "hash": "d87135a808a845416e0193a101bef0fd1c0b4a032969d819556ce109c40da4ba"
+    },
+    ".agents/tools/video/remotion-trimming.md": {
+      "hash": "6acbeb3fd83234e7ff428ba8a75bb7578054e80a084ff6a0438ef256e2184026",
+      "at": "2026-04-03T00:00:00Z",
+      "passes": 1,
+      "pr": null,
+      "issue": 16798
     }
   }
 }

--- a/.agents/tools/video/remotion-trimming.md
+++ b/.agents/tools/video/remotion-trimming.md
@@ -8,7 +8,7 @@ metadata:
 
 ## Trim the beginning
 
-A negative `from` value shifts time backwards — the sequence starts partway through its local timeline:
+A negative `from` value skips that many frames from the start of the animation's local timeline:
 
 ```tsx
 import {Sequence, useVideoConfig} from 'remotion';
@@ -20,8 +20,7 @@ const {fps} = useVideoConfig();
 </Sequence>
 ```
 
-- The animation appears 15 frames into its progress, so the first 15 frames are skipped.
-- Inside `<MyAnimation>`, `useCurrentFrame()` starts at 15 instead of 0.
+Inside `<MyAnimation>`, `useCurrentFrame()` starts at `0.5 * fps` instead of 0.
 
 ## Trim the end
 
@@ -32,8 +31,6 @@ Use `durationInFrames` to unmount content after a fixed duration:
   <MyAnimation />
 </Sequence>
 ```
-
-- The animation plays for 45 frames, then the component unmounts.
 
 ## Trim and delay
 
@@ -47,5 +44,4 @@ Nest sequences to trim the beginning and delay when the result appears:
 </Sequence>
 ```
 
-- The inner sequence trims 15 frames from the start.
-- The outer sequence delays the trimmed result by 30 frames.
+The inner sequence trims 15 frames from the start; the outer delays the result by 30 frames.


### PR DESCRIPTION
## Summary

- Tightens prose in `.agents/tools/video/remotion-trimming.md` without removing any institutional knowledge
- Removes redundant frame-count calculations (fps-relative expressions in code already convey the same info)
- Consolidates bullet points into single inline notes; merges two bullets in "Trim and delay" into one sentence
- Updates `simplification-state.json` with file hash and issue reference

## What

Simplified `.agents/tools/video/remotion-trimming.md` from 51 → 47 lines per automated simplification scan (GH#16798).

## Issue

Closes #16798

## Files Changed

- `.agents/tools/video/remotion-trimming.md` — prose tightened, redundant frame counts removed
- `.agents/configs/simplification-state.json` — hash registered for this file

## Testing

**Risk level:** Low (docs-only change, no code logic)
**Runtime Testing:** `self-assessed` — agent doc with no executable code paths

Content preservation verified:
- All 3 code blocks present (trim beginning, trim end, trim+delay)
- All `Sequence`, `from`, `durationInFrames`, `useCurrentFrame()` references preserved
- No task IDs or incident references in original file
- Agent behaviour unchanged

## Key Decisions

- Classified as instruction doc (not reference corpus) — 51 lines is well under 300-line split threshold
- Removed fps-specific frame counts (15, 45) as they assume 30fps and are redundant with the fps-relative expressions in code
- Kept all three sections intact; no structural changes

---
[aidevops.sh](https://aidevops.sh) v3.5.899 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6