### PR TITLE
GH#16797: tighten findings-to-tasks.md (52→45 lines)

### DIFF
--- a/.agents/scripts/commands/findings-to-tasks.md
+++ b/.agents/scripts/commands/findings-to-tasks.md
@@ -10,19 +10,14 @@ Input file: `$ARGUMENTS`
 
 ## Required Format
 
-One finding per line:
-
 ```text
 severity|title|details
-```
-
-```text
 high|Harden prompt-guard fallback on malformed markdown|Reject malformed HTML comments before rendering summary
 medium|Add retries for Codacy API timeout|Use capped exponential backoff in codacy-cli.sh
 low|Improve stale worker log wording|Clarify blocked vs failed in watchdog output
 ```
 
-If severity is omitted, it defaults to `medium`.
+Severity defaults to `medium` if omitted.
 
 ## Command
 
@@ -33,17 +28,15 @@ If severity is omitted, it defaults to `medium`.
   --source <security-audit|code-review|seo-audit|accessibility|performance>
 ```
 
-Optional flags:
-
-- `--labels "label1,label2"` add extra issue labels
-- `--tags "tag1,tag2"` add extra TODO hashtags
-- `--dry-run` preview without allocating task IDs
-- `--no-issue` allocate task IDs without creating GitHub issues
-- `--allow-partial` allow non-100% conversion (normally treated as failure)
+- `--labels "label1,label2"` — add extra issue labels
+- `--tags "tag1,tag2"` — add extra TODO hashtags
+- `--dry-run` — preview without allocating task IDs
+- `--no-issue` — allocate task IDs without creating GitHub issues
+- `--allow-partial` — allow non-100% conversion (normally treated as failure)
 
 ## Completion Rule
 
-A multi-finding report is complete only when helper output confirms full conversion coverage:
+Complete only when helper output confirms full conversion coverage:
 
 - `actionable_findings_total=<N>`
 - `deferred_tasks_created=<N>`


### PR DESCRIPTION
## Summary

Tighten `.agents/scripts/commands/findings-to-tasks.md` per GH#16797 simplification scan.

**Changes:**
- Merge two separate code blocks (schema + example) into one — they were split unnecessarily
- Remove redundant "One finding per line:" prose (shown by the code block itself)
- Remove "Optional flags:" header (list is self-evident after the command block)
- Remove "A multi-finding report is" preamble → "Complete only when..."
- Add em-dash separators to flag list for consistency with other command docs

**Preserved:** all code blocks, command examples, all flags with descriptions, completion rule with all three output fields, `coverage=100%` requirement.

**Line count:** 52 → 45 (−7 lines, 13% reduction)

## Runtime Testing

Risk: **Low** — agent doc only, no executable code changed. Self-assessed.

Closes #16797

---
[aidevops.sh](https://aidevops.sh) v3.5.899 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6