### PR TITLE
fix: worker launch failures from deploy race and tight validation timeout

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -162,7 +162,7 @@ if [[ -z "${AIDEVOPS_HEADLESS_MODELS:-}" ]]; then
 	fi
 fi
 PULSE_BACKFILL_MAX_ATTEMPTS="${PULSE_BACKFILL_MAX_ATTEMPTS:-3}"                                            # Additional pulse passes when below utilization target (t1453)
-PULSE_LAUNCH_GRACE_SECONDS="${PULSE_LAUNCH_GRACE_SECONDS:-20}"                                             # Grace window for worker process to appear after dispatch (t1453)
+PULSE_LAUNCH_GRACE_SECONDS="${PULSE_LAUNCH_GRACE_SECONDS:-35}"                                             # Grace window for worker process to appear after dispatch (t1453) — raised from 20s to 35s: sandbox-exec + opencode cold-start takes ~25-30s
 PRE_RUN_STAGE_TIMEOUT="${PRE_RUN_STAGE_TIMEOUT:-600}"                                                      # 10 min cap per pre-run stage (cleanup/prefetch)
 PULSE_PREFETCH_PR_LIMIT="${PULSE_PREFETCH_PR_LIMIT:-200}"                                                  # Open PR list window per repo for pre-fetched state
 PULSE_PREFETCH_ISSUE_LIMIT="${PULSE_PREFETCH_ISSUE_LIMIT:-200}"                                            # Open issue list window for pulse prompt payload (keep compact)
@@ -209,7 +209,7 @@ if [[ "$QUALITY_DEBT_CAP_PCT" -gt 100 ]]; then
 	QUALITY_DEBT_CAP_PCT=100
 fi
 PULSE_BACKFILL_MAX_ATTEMPTS=$(_validate_int PULSE_BACKFILL_MAX_ATTEMPTS "$PULSE_BACKFILL_MAX_ATTEMPTS" 3 0)
-PULSE_LAUNCH_GRACE_SECONDS=$(_validate_int PULSE_LAUNCH_GRACE_SECONDS "$PULSE_LAUNCH_GRACE_SECONDS" 20 5)
+PULSE_LAUNCH_GRACE_SECONDS=$(_validate_int PULSE_LAUNCH_GRACE_SECONDS "$PULSE_LAUNCH_GRACE_SECONDS" 35 5)
 PRE_RUN_STAGE_TIMEOUT=$(_validate_int PRE_RUN_STAGE_TIMEOUT "$PRE_RUN_STAGE_TIMEOUT" 600 30)
 PULSE_PREFETCH_PR_LIMIT=$(_validate_int PULSE_PREFETCH_PR_LIMIT "$PULSE_PREFETCH_PR_LIMIT" 200 1)
 PULSE_PREFETCH_ISSUE_LIMIT=$(_validate_int PULSE_PREFETCH_ISSUE_LIMIT "$PULSE_PREFETCH_ISSUE_LIMIT" 200 1)

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -286,38 +286,57 @@ deploy_aidevops_agents() {
 	# Create target directory
 	mkdir -p "$target_dir"
 
-	# Always clean stale files from previous deployments. Files that were
-	# moved or deleted in the source repo would otherwise persist in the
-	# deployed directory indefinitely (rsync without --delete is additive).
-	# Preserves user directories (custom/, draft/) and plugin namespaces.
+	# Atomic deploy: build a staging directory, then swap it into place.
+	# Previously, clean + copy happened in-place, creating a window where
+	# scripts were missing. The pulse could dispatch workers mid-deploy,
+	# hitting "No such file or directory" errors. Now we:
+	#   1. rsync into a staging dir (target_dir.staging)
+	#   2. Move preserved dirs (custom/, draft/, plugins) from live to staging
+	#   3. mv live → .old, mv staging → live (atomic on same filesystem)
+	#   4. rm .old
+	local staging_dir="${target_dir}.staging"
+	local old_dir="${target_dir}.old"
+	rm -rf "$staging_dir" "$old_dir"
+	mkdir -p "$staging_dir"
+
+	# Copy source into staging
+	local copy_rc
+	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
+		_deploy_agents_copy "$source_dir" "$staging_dir" "${plugin_namespaces[@]}"
+		copy_rc=$?
+	else
+		_deploy_agents_copy "$source_dir" "$staging_dir"
+		copy_rc=$?
+	fi
+	if [[ "$copy_rc" -ne 0 ]]; then
+		print_error "Failed to deploy agents to staging directory"
+		rm -rf "$staging_dir"
+		return 1
+	fi
+
+	# Carry over preserved directories from live target to staging
 	local -a preserved_dirs=("custom" "draft")
 	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
 		for pns in "${plugin_namespaces[@]}"; do
 			preserved_dirs+=("$pns")
 		done
 	fi
-	_deploy_agents_clean_mode "$target_dir" "${preserved_dirs[@]}" || return 1
+	for pdir in "${preserved_dirs[@]}"; do
+		if [[ -d "$target_dir/$pdir" ]]; then
+			# Move user dirs into staging so they survive the swap
+			cp -a "$target_dir/$pdir" "$staging_dir/$pdir" 2>/dev/null || true
+		fi
+	done
 
-	# Copy all agent files and folders, excluding:
-	# - loop-state/ (local runtime state, not agents)
-	# - custom/ (user's private agents, never overwritten)
-	# - draft/ (user's experimental agents, never overwritten)
-	# - plugin namespace directories (managed separately)
-	local copy_rc
-	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
-		_deploy_agents_copy "$source_dir" "$target_dir" "${plugin_namespaces[@]}"
-		copy_rc=$?
-	else
-		_deploy_agents_copy "$source_dir" "$target_dir"
-		copy_rc=$?
+	# Atomic swap: mv is atomic on the same filesystem (POSIX rename())
+	if [[ -d "$target_dir" ]]; then
+		mv "$target_dir" "$old_dir"
 	fi
-	if [[ "$copy_rc" -eq 0 ]]; then
-		print_success "Deployed agents to $target_dir"
-		_deploy_agents_post_copy "$target_dir" "$repo_dir" "$source_dir" "$plugins_file"
-	else
-		print_error "Failed to deploy agents"
-		return 1
-	fi
+	mv "$staging_dir" "$target_dir"
+	rm -rf "$old_dir"
+
+	print_success "Deployed agents to $target_dir"
+	_deploy_agents_post_copy "$target_dir" "$repo_dir" "$source_dir" "$plugins_file"
 
 	return 0
 }


### PR DESCRIPTION
## Summary

- **Atomic deploy**: `setup.sh` now deploys to a staging directory then atomically swaps via `mv`, eliminating the window where scripts are missing mid-deploy. Previously clean+copy in-place caused `headless-runtime-helper.sh: No such file or directory` when the pulse dispatched workers during an update.
- **Launch timeout**: Raised `PULSE_LAUNCH_GRACE_SECONDS` from 20s to 35s. Sandbox-exec + opencode cold-start takes ~25-30s; the old 20s window caused false-positive launch failures for workers that started successfully.

Root cause analysis from worker logs:
- `/tmp/pulse-marcusquinn-aidevops-16797.log` (171 bytes): `No such file or directory` — deploy race
- `/tmp/pulse-marcusquinn-aidevops-16802.log` (306 bytes): output truncated mid-sentence — timeout too tight


---
[aidevops.sh](https://aidevops.sh) v3.5.899 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 54m and 952 tokens on this as a headless worker.