### PR TITLE
GH#16821: tighten models-opus.md — restructure to Use For/Routing Rules/Constraints pattern

### DIFF
--- a/.agents/tools/ai-assistants/models-opus.md
+++ b/.agents/tools/ai-assistants/models-opus.md
@@ -24,9 +24,7 @@ tools:
 
 Highest-capability tier for tasks where stronger reasoning materially changes the outcome.
 
-## When to Use
-
-Use opus only when the task genuinely needs extra reasoning depth:
+## Use For
 
 - Architecture and system design decisions
 - Novel problems with no established pattern
@@ -35,7 +33,16 @@ Use opus only when the task genuinely needs extra reasoning depth:
 - Trade-off analysis across many variables
 - Evaluating other models' outputs
 
-Do not use for routine implementation — route to sonnet. For large-context tasks (100K+ tokens), route to pro.
+## Routing Rules
+
+- Default to sonnet unless the task genuinely needs extra reasoning depth.
+- Route routine implementation, code review, and docs → sonnet.
+- Route very large context needs (100K+ tokens) → pro.
+
+## Constraints
+
+- Do not use for tasks solvable by sonnet — opus costs 5× more per output token.
+- Do not use for simple classification or formatting — route to haiku.
 
 ## Model Details
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Restructures `models-opus.md` to match the consistent pattern used by sibling model docs (`models-haiku.md`, `models-sonnet.md`): **Use For / Routing Rules / Constraints / Model Details**.

## Changes
- Renames "When to Use" → "Use For" (consistent with haiku/sonnet)
- Extracts routing rules into dedicated **Routing Rules** section (explicit: default to sonnet, route to pro for large context)
- Adds **Constraints** section with explicit cost rationale (opus costs 5× more per output token vs sonnet)
- Preserves all 6 use-case bullet points and all model detail fields

## Issue
Closes #16821

## Files Changed
- `.agents/tools/ai-assistants/models-opus.md` (50 → 57 lines; net +7 lines for added routing/constraints sections)

## Testing
- Self-assessed (Low risk: agent doc restructure, no code changes)
- All task IDs, model IDs, cost figures, and use-case bullets preserved
- Structure now consistent with haiku and sonnet tier docs

## Key Decisions
- Added lines rather than cutting — the issue asks to "tighten" but the primary goal is `build-agent.md` compliance (explicit routing rules, ordered by importance). The haiku/sonnet pattern is the reference; matching it is the correct outcome.

---
[aidevops.sh](https://aidevops.sh) v3.5.900 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6