### PR TITLE
GH#14203: tighten multimodal-evaluation.md (t132)

### DIFF
--- a/.agents/tools/multimodal-evaluation.md
+++ b/.agents/tools/multimodal-evaluation.md
@@ -1,14 +1,20 @@
 # Multimodal Architecture Evaluation (t132)
 
-## Summary
+## Decision
 
-**Recommendation: Do NOT create `tools/multimodal/` directory.**
+**Do NOT create `tools/multimodal/` directory.** Keep the current per-modality structure.
 
-The current per-modality structure (`tools/voice/`, `tools/video/`, `tools/browser/peekaboo.md`, `tools/ocr/`) is the correct architecture. Cross-references between modalities are already well-maintained. A `tools/multimodal/` directory would create duplication, routing ambiguity, and violate the framework's progressive disclosure pattern.
+The framework organizes by task intent, not model capability. Route by what the user is doing, not what the underlying model can do:
 
-## Current State
+- `tools/browser/` — not `tools/chromium/`
+- `tools/voice/` — not `tools/audio-models/`
+- `tools/video/` — not `tools/generative-media/`
 
-### Modality Directories
+A `tools/multimodal/` directory would: (1) violate progressive disclosure — "transcribe this audio" belongs in `tools/voice/transcription.md`, not `tools/multimodal/`; (2) create routing ambiguity — Peekaboo is a browser/desktop tool that uses vision; HeyGen is a video tool that uses voice; (3) duplicate content already in `voice-ai-models.md`; (4) break the cross-references that already work.
+
+Revisit if a dedicated multimodal orchestration pipeline (voice+vision+video in a single workflow) emerges. The cross-reference pattern is sufficient until then.
+
+## Modality Directories
 
 | Directory | Files | Purpose |
 |-----------|-------|---------|
@@ -18,88 +24,33 @@ The current per-modality structure (`tools/voice/`, `tools/video/`, `tools/brows
 | `tools/ocr/` | 1 file | Local document OCR (GLM-OCR via Ollama) |
 | `tools/mobile/` | 6 files | iOS/macOS device automation |
 
-### Models Spanning Voice + Vision
+## Models Spanning Multiple Modalities
 
-These models handle multiple modalities natively (not cascaded pipelines):
+Documented where their primary use case lives, not in a separate directory:
 
 | Model | Modalities | Where Documented |
 |-------|-----------|-----------------|
-| GPT-4o / GPT-4o Realtime | Text + Vision + Voice (S2S) | `voice-ai-models.md:88`, `pipecat-opencode.md:62` |
-| Gemini 2.0 Live / 2.5 | Text + Vision + Voice (streaming) | `voice-ai-models.md:89`, `pipecat-opencode.md:62` |
-| MiniCPM-o 4.5 | Text + Vision + Voice (S2S, open weights) | `voice-ai-models.md:90` |
-| Ultravox | Audio + Text (multimodal) | `voice-ai-models.md:91`, `pipecat-opencode.md:65` |
+| GPT-4o / GPT-4o Realtime | Text + Vision + Voice (S2S) | `voice-ai-models.md` S2S section, `pipecat-opencode.md` |
+| Gemini 2.0 Live / 2.5 | Text + Vision + Voice (streaming) | `voice-ai-models.md` S2S section, `pipecat-opencode.md` |
+| MiniCPM-o 4.5 | Text + Vision + Voice (S2S, open weights) | `voice-ai-models.md` S2S section |
+| Ultravox | Audio + Text (multimodal) | `voice-ai-models.md` S2S section, `pipecat-opencode.md` |
 | HeyGen Streaming Avatars | Voice + Video (avatar) | `heygen-skill/rules-streaming-avatars.md` |
-| Higgsfield API | Image + Video + Voice + Audio (unified API) | `higgsfield.md:1-18` |
+| Higgsfield API | Image + Video + Voice + Audio (unified API) | `higgsfield.md` |
 
-### Existing Cross-References (Already Working)
+"Multimodal" appears in only 2 files (`voice-ai-models.md`, `compare-models.md`) — confirming it is a model capability, not a workflow category.
 
-The framework already links modalities where they intersect:
+## Existing Cross-References (Healthy)
 
-1. **Voice -> Video**: `speech-to-speech.md:236-240` links to `tools/video/remotion.md` for video narration
-2. **Voice -> Video**: `voice-models.md:308` links to `heygen-skill/rules-voices.md` for AI voice cloning
+1. **Voice -> Video**: `speech-to-speech.md` links to `tools/video/remotion.md` for video narration
+2. **Voice -> Video**: `voice-models.md` links to `heygen-skill/rules-voices.md` for AI voice cloning
 3. **Video -> Voice**: `heygen-skill.md` references voice selection for avatar videos
-4. **Vision -> OCR**: `peekaboo.md:517` links to `tools/ocr/glm-ocr.md` for OCR workflows
-5. **OCR -> Vision**: `glm-ocr.md:37` links back to Peekaboo for screen capture + OCR
-6. **Voice -> Infrastructure**: `speech-to-speech.md:244` links to `tools/infrastructure/cloud-gpu.md`
+4. **Vision -> OCR**: `peekaboo.md` links to `tools/ocr/glm-ocr.md` for OCR workflows
+5. **OCR -> Vision**: `glm-ocr.md` links back to Peekaboo for screen capture + OCR
+6. **Voice -> Infrastructure**: `speech-to-speech.md` links to `tools/infrastructure/cloud-gpu.md`
 7. **AGENTS.md routing**: Progressive disclosure table routes Voice and Video as separate domains
 
-### Where "Multimodal" Appears
+## Optional Improvements (No New Directory Required)
 
-Only 2 files use the word "multimodal":
-
-- `voice-ai-models.md:1` — in the S2S section describing models like Ultravox
-- `compare-models.md:1` — in model capability comparison
-
-This confirms multimodal is a model capability, not a workflow category.
-
-## Analysis: Why `tools/multimodal/` Would Be Wrong
-
-### 1. Violates Progressive Disclosure
-
-The framework's core pattern is: route by task intent, not by model capability. A user asking "transcribe this audio" should land in `tools/voice/transcription.md`, not `tools/multimodal/`. The fact that the underlying model (Whisper) could theoretically do other things is irrelevant to the user's task.
-
-### 2. Creates Routing Ambiguity
-
-Where would Peekaboo go? It's a screen capture tool (browser/desktop) that happens to use vision models. Where would HeyGen go? It's a video tool that uses voice. A `tools/multimodal/` directory would force every cross-modal tool into an ambiguous category, making discovery harder.
-
-### 3. Duplicates Existing Content
-
-The S2S models (GPT-4o Realtime, Gemini Live, MiniCPM-o) are already documented in `voice-ai-models.md` with their multimodal capabilities noted. Moving them to `tools/multimodal/` would either duplicate content or leave broken references.
-
-### 4. The Cross-References Already Work
-
-The "See Also" sections in voice, video, and vision files already link to each other where workflows cross modality boundaries. This is the correct pattern — keep content where the primary use case lives, cross-reference where workflows intersect.
-
-### 5. Framework Precedent
-
-The framework organizes by task domain, not by technology capability:
-
-- `tools/browser/` — not `tools/chromium/`
-- `tools/voice/` — not `tools/audio-models/`
-- `tools/video/` — not `tools/generative-media/`
-
-## What Could Be Improved (Without a New Directory)
-
-### A. Add a "Multimodal Models" Section to `voice-ai-models.md`
-
-The S2S section at `voice-ai-models.md:82-93` already covers multimodal models but could be expanded with a clearer "Multimodal Model Landscape" heading that explicitly maps which models span which modalities. This is the natural home since voice is the most common entry point for multimodal interaction.
-
-### B. Add Cross-References to `compare-models.md`
-
-The model comparison tool could gain a `--multimodal` filter to surface models that span voice+vision+text. This is a capability filter on existing data, not a new directory.
-
-### C. Ensure AGENTS.md Routing Covers Multimodal Queries
-
-The progressive disclosure table in AGENTS.md could add a note:
-
-```text
-| Multimodal | See Voice (S2S models), Video (HeyGen, Higgsfield), Browser (Peekaboo vision) |
-```
-
-This routes users to the right domain-specific docs without creating a new directory.
-
-## Decision
-
-**Keep the current per-modality structure.** The cross-references are healthy. The models that span modalities are documented where their primary use case lives. No `tools/multimodal/` directory is needed.
-
-If multimodal workflows grow significantly (e.g., a dedicated multimodal orchestration pipeline that combines voice+vision+video in a single workflow), revisit this decision. For now, the cross-reference pattern is sufficient and avoids the duplication/routing problems a new directory would create.
+- **`voice-ai-models.md`**: Add a "Multimodal Model Landscape" heading to the S2S section to make cross-modal coverage explicit
+- **`compare-models.md`**: Add `--multimodal` filter to surface models spanning voice+vision+text
+- **AGENTS.md routing table**: Add `| Multimodal | See Voice (S2S models), Video (HeyGen, Higgsfield), Browser (Peekaboo vision) |`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.899"
+    "version": "3.5.903"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.899
+# Version: 3.5.903
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.899.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.903.tar.gz"
   sha256 "a04cfc74c44d39ac8d765ab847145a8e891cd5929de2f451ad577be3e5fb52f5"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.899",
+  "version": "3.5.903",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.899
+# Version: 3.5.903
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.899
+sonar.projectVersion=3.5.903
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/multimodal-evaluation.md` per simplification-debt issue #14203.

- Decision moved first (primacy effect — LLMs weight earlier context more heavily)
- Analysis compressed from 5 verbose sections to inline bullet rationale
- "What Could Be Improved" merged into decision section as actionable follow-ups
- All cross-references, task IDs (t132), file paths, and institutional knowledge preserved
- 105 → 56 lines (-47%)

## Files Changed

- `.agents/tools/multimodal-evaluation.md` — tightened instruction doc

## Runtime Testing

**Risk level: Low** — docs/agent prompt change only. No code, no commands, no API calls.
Self-assessed: content preservation verified via `rg` check on all key references (t132, voice-ai-models.md, peekaboo, heygen, higgsfield, glm-ocr, pipecat, Ultravox, MiniCPM, GPT-4o, Gemini, progressive disclosure).

## Key Decisions

- File classified as **instruction doc** (architectural decision record), not reference corpus — compression appropriate
- Line-number references in original (e.g., `voice-ai-models.md:88`) replaced with section references per build-agent guidance (line numbers drift on every edit)
- No content removed — all rationale, cross-references, and optional improvements retained

Closes #14203

---
[aidevops.sh](https://aidevops.sh) v3.5.902 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6