### PR TITLE
GH#14411: fix youtube-research.md channel recall key mismatch

### DIFF
--- a/.agents/scripts/commands/youtube-research.md
+++ b/.agents/scripts/commands/youtube-research.md
@@ -24,7 +24,7 @@ Target: $ARGUMENTS
 ### Step 2: Load Configuration
 
 ```bash
-~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "channel"
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "channel voice"
 ```
 
 ### Step 3: Execute Research

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "3.5.899"
+    "version": "3.5.903"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 3.5.899
+# Version: 3.5.903
 
 set -euo pipefail
 

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.899.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.5.903.tar.gz"
   sha256 "a04cfc74c44d39ac8d765ab847145a8e891cd5929de2f451ad577be3e5fb52f5"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "3.5.899",
+  "version": "3.5.903",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "bin": {

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ shopt -s inherit_errexit 2>/dev/null || true
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 3.5.899
+# Version: 3.5.903
 #
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=3.5.899
+sonar.projectVersion=3.5.903
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agents,configs,templates


### PR DESCRIPTION
## Summary

- Fix `memory-helper.sh recall` key in `youtube-research.md` Step 2 from `\"channel\"` to `\"channel voice\"`
- Aligns with the key used by `youtube-setup.md` store and `distribution-youtube-script-writer.md` recall
- Ensures channel voice lookup succeeds when running `/youtube research`

## Root Cause

PR #14334 (GH#14265) simplified `youtube-script.md` and correctly used `\"channel voice\"`, but `youtube-research.md` was not updated — it retained the old mismatched key `\"channel\"` that would silently return no results.

## Verification

All `memory-helper.sh recall --namespace youtube "channel*"` calls now consistently use `"channel voice"`:
- `.agents/scripts/commands/youtube-research.md` ✓ (fixed)
- `.agents/scripts/commands/youtube-script.md` ✓ (already correct)
- `.agents/content/distribution-youtube-script-writer.md` ✓ (canonical)

markdownlint: clean.

Closes #14411

---
[aidevops.sh](https://aidevops.sh) v3.5.902 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6