### PR TITLE
t1712: enforce main-branch file allowlist in edit guards

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -41,7 +41,7 @@ New to aidevops? Type `/onboarding`.
 
 Rules: `prompts/build.txt`. Details: `workflows/pre-edit.md`.
 
-Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. All other writes → proposed edits in a worktree.
+Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `README.md`, `TODO.md`, and `todo/**`. All other writes → proposed edits in a worktree. This is enforced by path-based allowlist in `pre-edit-check.sh` and `git_safety_guard.py` (t1712).
 
 ---
 

--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -3,7 +3,10 @@
 Git/filesystem safety guard for Claude Code (PreToolUse hook).
 
 Blocks destructive commands that can lose uncommitted work or delete files.
-This hook runs before Bash commands execute and can deny dangerous operations.
+Also enforces the main-branch file allowlist: only README.md, TODO.md, and
+todo/** are writable on main/master without a linked worktree (t1712).
+
+This hook runs before Bash/Edit/Write tool calls and can deny dangerous operations.
 
 Installed by: aidevops setup (setup.sh) or install-hooks-helper.sh
 Location: ~/.aidevops/hooks/git_safety_guard.py
@@ -17,7 +20,9 @@ Exit behavior:
   - Exit 0 with no output = allow
 """
 import json
+import os
 import re
+import subprocess
 import sys
 
 # Destructive patterns to block - tuple of (regex, reason)
@@ -162,8 +167,167 @@ def _normalize_absolute_paths(cmd):
     return result
 
 
+# =============================================================================
+# Main-Branch File Allowlist (t1712)
+# =============================================================================
+# Allowlisted paths that may be written on main/master without a linked worktree.
+# All other file writes on main/master are blocked.
+#
+# Allowlist:
+#   README.md   — top-level readme
+#   TODO.md     — top-level task list
+#   todo/       — planning directory (all files under it)
+_MAIN_BRANCH_ALLOWLIST = ("README.md", "TODO.md")
+_MAIN_BRANCH_ALLOWLIST_PREFIXES = ("todo/", "todo")
+
+
+def _get_git_branch(cwd=None):
+    """Return the current git branch name, or None if not in a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _get_git_root(cwd=None):
+    """Return the absolute path of the git repo root, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _is_linked_worktree(cwd=None):
+    """Return True if the current directory is a linked worktree (not the main worktree)."""
+    try:
+        git_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        git_common_dir = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        if git_dir.returncode == 0 and git_common_dir.returncode == 0:
+            gd = git_dir.stdout.strip()
+            gcd = git_common_dir.stdout.strip()
+            # In a linked worktree, git-dir != git-common-dir
+            # In the main worktree, git-dir == git-common-dir (or git-dir == ".git")
+            return gd != gcd and gd != ".git"
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return False
+
+
+def _normalize_file_path(file_path, repo_root=None):
+    """Normalise a file path to a repo-relative path for allowlist matching."""
+    if not file_path:
+        return ""
+    # Strip leading ./
+    rel = file_path.lstrip("./") if file_path.startswith("./") else file_path
+    # Strip absolute repo root prefix
+    if repo_root and rel.startswith(repo_root + "/"):
+        rel = rel[len(repo_root) + 1:]
+    elif repo_root and rel == repo_root:
+        rel = ""
+    return rel
+
+
+def _is_allowlisted_main_path(file_path, repo_root=None):
+    """Return True if file_path is in the main-branch write allowlist.
+
+    Allowlisted: README.md, TODO.md, todo/ (and all files under it).
+    """
+    rel = _normalize_file_path(file_path, repo_root)
+    if rel in _MAIN_BRANCH_ALLOWLIST:
+        return True
+    for prefix in _MAIN_BRANCH_ALLOWLIST_PREFIXES:
+        if rel == prefix or rel.startswith(prefix + "/") or rel.startswith(prefix):
+            return True
+    return False
+
+
+def _check_main_branch_allowlist(file_path, cwd=None):
+    """Block Edit/Write to non-allowlisted paths on main/master.
+
+    Returns a denial reason string if the write should be blocked, or None to allow.
+    """
+    if not file_path:
+        return None
+
+    branch = _get_git_branch(cwd=cwd)
+    if branch not in ("main", "master"):
+        return None  # Not on a protected branch — allow
+
+    # Linked worktrees are always allowed (they're on a feature branch by design,
+    # but even if somehow on main, the worktree isolation is the primary guard)
+    if _is_linked_worktree(cwd=cwd):
+        return None
+
+    repo_root = _get_git_root(cwd=cwd)
+    if _is_allowlisted_main_path(file_path, repo_root=repo_root):
+        return None  # Allowlisted — allow
+
+    return (
+        f"Path '{file_path}' is not in the main-branch write allowlist.\n\n"
+        "Only README.md, TODO.md, and todo/** are writable on main/master "
+        "without a linked worktree.\n\n"
+        "Create a linked worktree for this task:\n"
+        "  wt switch -c feature/<description>\n"
+        "  # or: ~/.aidevops/agents/scripts/worktree-helper.sh add feature/<description>"
+    )
+
+
+def _deny(reason, original_input=None):
+    """Return a deny JSON response."""
+    context = ""
+    if original_input:
+        context = f"\n\nInput: {original_input}"
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"BLOCKED by git_safety_guard.py (aidevops)\n\n"
+                f"Reason: {reason}{context}\n\n"
+                f"If this operation is truly needed, ask the user "
+                f"for explicit permission and have them run the "
+                f"command manually."
+            ),
+        }
+    }
+    return output
+
+
 def main():
-    """Check stdin for destructive Bash commands and block them."""
+    """Check stdin for destructive Bash commands and block them.
+
+    Also enforces the main-branch file allowlist for Edit/Write tool calls.
+    """
     try:
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError:
@@ -171,6 +335,26 @@ def main():
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input") or {}
+
+    # Resolve cwd from tool context if available (Claude Code passes session cwd)
+    cwd = input_data.get("cwd") or os.getcwd()
+
+    # -------------------------------------------------------------------------
+    # Main-branch file allowlist check (t1712)
+    # Applies to Edit and Write tool calls on main/master.
+    # -------------------------------------------------------------------------
+    if tool_name in ("Edit", "Write"):
+        file_path = tool_input.get("filePath", "")
+        denial_reason = _check_main_branch_allowlist(file_path, cwd=cwd)
+        if denial_reason:
+            print(json.dumps(_deny(denial_reason, original_input=file_path)))
+            sys.exit(0)
+        # Allowlisted or not on main — fall through to allow
+        sys.exit(0)
+
+    # -------------------------------------------------------------------------
+    # Destructive Bash command check
+    # -------------------------------------------------------------------------
     command = tool_input.get("command", "")
 
     if tool_name != "Bash" or not isinstance(command, str) or not command:
@@ -187,21 +371,7 @@ def main():
     # Check destructive patterns
     for pattern, reason in DESTRUCTIVE_PATTERNS:
         if re.search(pattern, command):
-            output = {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": (
-                        f"BLOCKED by git_safety_guard.py (aidevops)\n\n"
-                        f"Reason: {reason}\n\n"
-                        f"Command: {original_command}\n\n"
-                        f"If this operation is truly needed, ask the user "
-                        f"for explicit permission and have them run the "
-                        f"command manually."
-                    ),
-                }
-            }
-            print(json.dumps(output))
+            print(json.dumps(_deny(reason, original_input=original_command)))
             sys.exit(0)
 
     # Allow all other commands

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -8,14 +8,20 @@
 # Usage:
 #   ~/.aidevops/agents/scripts/pre-edit-check.sh
 #   ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "description"
+#   ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "description" --file "path/to/file"
 #   ~/.aidevops/agents/scripts/pre-edit-check.sh --check-command "git push --force origin main"
 #   ~/.aidevops/agents/scripts/pre-edit-check.sh --verify-op "git push --force origin main"
 #
 # Exit codes:
-#   0 - OK to proceed (in a linked worktree, or docs-only on main)
+#   0 - OK to proceed (in a linked worktree, or allowlisted path on main)
 #   1 - STOP (on protected main/master, interactive mode)
-#   2 - Create worktree (loop mode detected code task on main)
+#   2 - Create worktree (loop mode detected non-allowlisted edit on main)
 #   3 - WARNING (canonical repo directory is not on main - move it back and continue from a linked worktree)
+#
+# Main-branch file allowlist (--file, t1712):
+#   When --file is passed, the script enforces a hard path-based allowlist on main/master.
+#   Only README.md, TODO.md, and todo/** are writable without a linked worktree.
+#   This is stronger than the task-description heuristic and takes precedence when provided.
 #
 # High-stakes detection (--check-command):
 #   When --check-command is passed, the script checks the command against
@@ -47,6 +53,7 @@ LOOP_MODE=false
 TASK_DESC=""
 CHECK_COMMAND=""
 VERIFY_OP=""
+FILE_PATH=""
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -66,13 +73,64 @@ while [[ $# -gt 0 ]]; do
 		VERIFY_OP="$2"
 		shift 2
 		;;
+	--file)
+		FILE_PATH="$2"
+		shift 2
+		;;
 	*)
 		shift
 		;;
 	esac
 done
 
-# Function to detect if task is docs-only
+# =============================================================================
+# Path-Based Main-Branch Allowlist (t1712)
+# =============================================================================
+# Returns 0 (true) if the given file path is allowed to be written on main/master.
+# Allowlisted paths: README.md, TODO.md, todo/** (planning files only).
+# All other paths require a linked worktree.
+#
+# This is a hard file-level gate — it does NOT rely on task description heuristics.
+# It is the primary enforcement mechanism for the main-branch write policy when
+# a --file argument is provided.
+#
+# Usage:
+#   is_allowlisted_main_path "/abs/path/to/file"
+#   is_allowlisted_main_path "relative/path/to/file"
+is_allowlisted_main_path() {
+	local file_path="$1"
+
+	if [[ -z "$file_path" ]]; then
+		return 1 # No path provided — not allowlisted
+	fi
+
+	# Normalise: strip leading ./ so we match on relative paths consistently.
+	local rel_path
+	rel_path="${file_path#./}"
+
+	# Strip absolute repo root prefix if present (e.g. /home/user/Git/repo/)
+	local repo_root=""
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+	if [[ -n "$repo_root" ]]; then
+		rel_path="${rel_path#"${repo_root}/"}"
+	fi
+
+	# Allowlist (case-sensitive, exact or prefix match):
+	#   README.md          — top-level readme
+	#   TODO.md            — top-level task list
+	#   todo/              — planning directory (all files under it)
+	case "$rel_path" in
+	README.md | TODO.md | todo | todo/*)
+		return 0 # Allowlisted
+		;;
+	*)
+		return 1 # Not allowlisted — requires worktree
+		;;
+	esac
+}
+
+# Function to detect if task is docs-only (task-description heuristic).
+# Used as a fallback when no --file path is provided.
 is_docs_only() {
 	local task="$1"
 	# Use tr for lowercase (portable across bash versions including macOS default bash 3.x)
@@ -287,8 +345,23 @@ fi
 
 # Check if on main or master
 if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
-	# Loop mode: auto-decide based on task description
+	# Loop mode: auto-decide based on file path (preferred) or task description (fallback)
 	if [[ "$LOOP_MODE" == "true" ]]; then
+		# Path-based allowlist check (t1712): takes precedence over task-description heuristic
+		if [[ -n "$FILE_PATH" ]]; then
+			if is_allowlisted_main_path "$FILE_PATH"; then
+				echo -e "${YELLOW}LOOP-AUTO${NC}: Allowlisted path '$FILE_PATH', staying on $current_branch"
+				echo "LOOP_DECISION=stay"
+				echo "ALLOWLIST_MATCH=true"
+				exit 0
+			else
+				echo -e "${YELLOW}LOOP-AUTO${NC}: Path '$FILE_PATH' not in main-branch allowlist, worktree required"
+				echo "LOOP_DECISION=worktree"
+				echo "ALLOWLIST_MATCH=false"
+				exit 2 # Special exit code for "create worktree"
+			fi
+		fi
+		# Fallback: task-description heuristic (used when no --file is provided)
 		if is_docs_only "$TASK_DESC"; then
 			echo -e "${YELLOW}LOOP-AUTO${NC}: Docs-only task detected, staying on $current_branch"
 			echo "LOOP_DECISION=stay"
@@ -298,6 +371,43 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
 			echo -e "${YELLOW}LOOP-AUTO${NC}: Code task detected, worktree required"
 			echo "LOOP_DECISION=worktree"
 			exit 2 # Special exit code for "create worktree"
+		fi
+	fi
+
+	# Non-loop mode: path-based allowlist check for headless/interactive with --file
+	if [[ -n "$FILE_PATH" ]]; then
+		if is_allowlisted_main_path "$FILE_PATH"; then
+			# Allowlisted path — allow even on main (headless or interactive)
+			echo -e "${GREEN}OK${NC} - Allowlisted path on $current_branch: ${BOLD}$FILE_PATH${NC}"
+			echo "ALLOWLIST_MATCH=true"
+			exit 0
+		else
+			# Non-allowlisted path on main — block with worktree guidance
+			if [[ ! -t 0 ]] || [[ "${FULL_LOOP_HEADLESS:-false}" == "true" ]]; then
+				echo -e "${RED}BLOCKED${NC}: Path '$FILE_PATH' is not in the main-branch write allowlist."
+				echo "HEADLESS_BLOCKED=true"
+				echo "ACTION_REQUIRED=create_worktree"
+				echo "ALLOWLIST_MATCH=false"
+				echo "HINT: Only README.md, TODO.md, and todo/** are writable on main without a worktree."
+				exit 2
+			fi
+			echo ""
+			echo -e "${RED}${BOLD}======================================================${NC}"
+			echo -e "${RED}${BOLD}  STOP - PATH NOT IN MAIN-BRANCH ALLOWLIST${NC}"
+			echo -e "${RED}${BOLD}======================================================${NC}"
+			echo ""
+			echo -e "Path: ${BOLD}$FILE_PATH${NC}"
+			echo ""
+			echo -e "${YELLOW}Only README.md, TODO.md, and todo/** are writable on main without a linked worktree.${NC}"
+			echo -e "${YELLOW}Create a linked worktree before editing this file.${NC}"
+			echo ""
+			if command -v wt &>/dev/null; then
+				echo "    wt switch -c {type}/{description}"
+			else
+				echo "    ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{description}"
+			fi
+			echo ""
+			exit 1
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -123,6 +123,9 @@ test_warns_when_canonical_repo_is_off_main() {
 	local exit_code=0
 	output=$(run_helper "$TEST_ROOT" 2>&1) || exit_code=$?
 
+	# Restore main branch for subsequent tests
+	git -C "$TEST_ROOT" switch main >/dev/null 2>&1
+
 	if [[ "$exit_code" -eq 3 ]] && [[ "$output" == *"WARNING - MAIN REPO DIRECTORY IS OFF MAIN"* ]] && [[ "$output" == *"MAIN_REPO_OFF_MAIN_WARNING=bugfix/off-main"* ]]; then
 		print_result "warns when canonical repo directory is off main" 0
 		return 0
@@ -165,6 +168,100 @@ test_blocks_when_linked_worktree_owned_by_another_live_process() {
 	return 0
 }
 
+# =============================================================================
+# Path-based allowlist tests (t1712)
+# =============================================================================
+
+test_loop_mode_allows_allowlisted_file_on_main() {
+	# README.md is in the allowlist — should stay on main (exit 0)
+	local output=""
+	local exit_code=0
+	output=$(run_helper "$TEST_ROOT" --loop-mode --task "update readme" --file "README.md" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=stay"* ]] && [[ "$output" == *"ALLOWLIST_MATCH=true"* ]]; then
+		print_result "loop-mode allows allowlisted file (README.md) on main" 0
+		return 0
+	fi
+
+	print_result "loop-mode allows allowlisted file (README.md) on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_loop_mode_allows_todo_md_on_main() {
+	# TODO.md is in the allowlist — should stay on main (exit 0)
+	local output=""
+	local exit_code=0
+	output=$(run_helper "$TEST_ROOT" --loop-mode --task "add task" --file "TODO.md" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=stay"* ]] && [[ "$output" == *"ALLOWLIST_MATCH=true"* ]]; then
+		print_result "loop-mode allows allowlisted file (TODO.md) on main" 0
+		return 0
+	fi
+
+	print_result "loop-mode allows allowlisted file (TODO.md) on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_loop_mode_allows_todo_subdir_on_main() {
+	# todo/tasks/t001-brief.md is under todo/ — should stay on main (exit 0)
+	local output=""
+	local exit_code=0
+	output=$(run_helper "$TEST_ROOT" --loop-mode --task "add brief" --file "todo/tasks/t001-brief.md" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=stay"* ]] && [[ "$output" == *"ALLOWLIST_MATCH=true"* ]]; then
+		print_result "loop-mode allows todo/ subdirectory file on main" 0
+		return 0
+	fi
+
+	print_result "loop-mode allows todo/ subdirectory file on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_loop_mode_blocks_non_allowlisted_file_on_main() {
+	# .agents/scripts/foo.sh is NOT in the allowlist — should require worktree (exit 2)
+	local output=""
+	local exit_code=0
+	output=$(run_helper "$TEST_ROOT" --loop-mode --task "implement feature" --file ".agents/scripts/foo.sh" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"LOOP_DECISION=worktree"* ]] && [[ "$output" == *"ALLOWLIST_MATCH=false"* ]]; then
+		print_result "loop-mode blocks non-allowlisted file (.agents/scripts/foo.sh) on main" 0
+		return 0
+	fi
+
+	print_result "loop-mode blocks non-allowlisted file (.agents/scripts/foo.sh) on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_headless_blocks_non_allowlisted_file_on_main() {
+	# Headless mode with --file pointing to a non-allowlisted path — should block (exit 2)
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --file ".agents/hooks/git_safety_guard.py" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"HEADLESS_BLOCKED=true"* ]] && [[ "$output" == *"ALLOWLIST_MATCH=false"* ]]; then
+		print_result "headless mode blocks non-allowlisted file on main" 0
+		return 0
+	fi
+
+	print_result "headless mode blocks non-allowlisted file on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_headless_allows_allowlisted_file_on_main() {
+	# Headless mode with --file pointing to TODO.md — should allow (exit 0)
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --file "TODO.md" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"ALLOWLIST_MATCH=true"* ]]; then
+		print_result "headless mode allows allowlisted file (TODO.md) on main" 0
+		return 0
+	fi
+
+	print_result "headless mode allows allowlisted file (TODO.md) on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
 main() {
 	trap teardown_test_repo EXIT
 	setup_test_repo
@@ -173,6 +270,14 @@ main() {
 	test_allows_linked_worktree_edits
 	test_warns_when_canonical_repo_is_off_main
 	test_blocks_when_linked_worktree_owned_by_another_live_process
+
+	# Path-based allowlist tests (t1712)
+	test_loop_mode_allows_allowlisted_file_on_main
+	test_loop_mode_allows_todo_md_on_main
+	test_loop_mode_allows_todo_subdir_on_main
+	test_loop_mode_blocks_non_allowlisted_file_on_main
+	test_headless_blocks_non_allowlisted_file_on_main
+	test_headless_allows_allowlisted_file_on_main
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -10,6 +10,7 @@ Run before any file edits:
 ```bash
 ~/.aidevops/agents/scripts/pre-edit-check.sh
 ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "task description"
+~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "description" --file "path/to/file"
 ```
 
 ## Exit Codes
@@ -25,7 +26,7 @@ Run before any file edits:
 > On `main`. Suggested branch: `{type}/{suggested-name}`
 > 1. Create worktree (recommended)
 > 2. Use different branch name
-> 3. Stay on `main` (docs-only)
+> 3. Stay on `main` (allowlisted path only)
 
 **Exit 3 prompt:**
 > On branch: `{branch}` (main repo, not worktree)
@@ -33,7 +34,19 @@ Run before any file edits:
 > 2. Continue on current branch
 > 3. Switch to `main`, then create worktree
 
-## Loop Mode Keywords
+## Main-Branch File Allowlist (t1712)
+
+When `--file <path>` is provided, the script enforces a **path-based** allowlist instead of task-description heuristics. Only these paths are writable on `main`/`master` without a linked worktree:
+
+- `README.md`
+- `TODO.md`
+- `todo/**` (all files under the planning directory)
+
+All other paths require a linked worktree. This is also enforced by `git_safety_guard.py` for Edit/Write tool calls in Claude Code.
+
+## Loop Mode Keywords (fallback, no --file)
+
+When no `--file` is provided, the script falls back to task-description heuristics:
 
 - **Docs-only** (`readme`, `changelog`, `documentation`, `docs/`, `typo`, `spelling`) → stay on `main`
 - **Code** (`feature`, `fix`, `bug`, `implement`, `refactor`, `add`, `update`, `enhance`, `port`, `ssl`, `helper`) → create worktree; code keywords override docs keywords
@@ -42,7 +55,7 @@ Run before any file edits:
 
 Keep `~/Git/{repo}/` on `main`. Avoids blocked branch switches, parallel sessions inheriting the wrong branch, and `local changes would be overwritten` errors.
 
-Stay on `main` only for: docs-only changes (README, CHANGELOG, `docs/`), typos, version bumps, planning files (`TODO.md`, `todo/`). Planning-file commits use `planning-commit-helper.sh "plan: add new task"`.
+Stay on `main` only for: `README.md`, `TODO.md`, and `todo/**` (planning files). Planning-file commits use `planning-commit-helper.sh "plan: add new task"`.
 
 Continue on current branch only when: task matches branch purpose, finishes this session, no parallel sessions expected.
 


### PR DESCRIPTION
## Summary

- Replace task-description heuristics with a hard path-based allowlist for main/master write protection
- Only `README.md`, `TODO.md`, and `todo/**` are writable on main without a linked worktree
- Enforce the same restriction in both `pre-edit-check.sh` (shell guard) and `git_safety_guard.py` (Claude Code PreToolUse hook)

## What changed

**`pre-edit-check.sh`**
- Added `is_allowlisted_main_path()` function: case-based path matching against `README.md`, `TODO.md`, `todo/**`
- Added `--file <path>` argument: when provided, path check takes precedence over task-description heuristic
- Loop mode, headless mode, and interactive mode all enforce the allowlist when `--file` is given
- Task-description heuristic (`is_docs_only`) retained as fallback when no `--file` is provided

**`git_safety_guard.py`**
- Extended PreToolUse hook to cover `Edit` and `Write` tool calls (previously only `Bash`)
- Added `_is_allowlisted_main_path()`, `_get_git_branch()`, `_get_git_root()`, `_is_linked_worktree()` helpers
- Blocks non-allowlisted file writes on main/master; linked worktrees are always allowed
- Refactored denial output into `_deny()` helper for consistency

**`test-pre-edit-check.sh`**
- Added 6 new tests covering allowlist allow/block cases for loop-mode and headless mode
- Fixed branch state leak between tests (restore main after off-main test)

**`AGENTS.md`** + **`pre-edit.md`**
- Updated subagent write restrictions to reflect `todo/**` allowlist (was `todo/PLANS.md, todo/tasks/*`)
- Documented `--file` flag, path-based allowlist, and task-description fallback

## Testing

```
Ran 10 tests, 0 failed
```

ShellCheck: zero violations on changed files. Python syntax check: pass.

## Runtime Testing

Risk: **Low** — agent prompt/docs changes + shell/Python guard scripts. No runtime environment required. Verified via unit tests.

Closes #15022

---
[aidevops.sh](https://aidevops.sh) v3.5.903 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a path-based write allowlist for the main branch, restricting direct edits to documentation and planning files.

* **Tests**
  * Added test coverage for allowlist enforcement and file-blocking behavior.

* **Documentation**
  * Updated workflow documentation to reflect new file-based restrictions on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->