### PR TITLE
t1875: add reopen command to issue-sync and integrate into pulse

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -838,11 +838,69 @@ cmd_reconcile() {
 	[[ $ref_fixed -eq 0 && $stale -eq 0 && $orphans -eq 0 && $reverse_drift -eq 0 ]] && print_success "All refs correct"
 }
 
+# Reopen closed GitHub issues whose TODO entries are still open [ ].
+# TODO.md is the source of truth: if a task is [ ], the work is not done,
+# regardless of whether a commit message prematurely closed the issue.
+# Safety: only reopens issues closed as "COMPLETED" (not "NOT_PLANNED").
+cmd_reopen() {
+	_init_cmd || return 1
+	local repo="$_CMD_REPO" todo_file="$_CMD_TODO"
+
+	# Build set of open issue numbers for fast lookup
+	local open_json
+	open_json=$(gh_list_issues "$repo" "open" 500)
+	local open_numbers
+	open_numbers=$(echo "$open_json" | jq -r '.[].number' 2>/dev/null | sort -n)
+
+	local stripped
+	stripped=$(strip_code_fences <"$todo_file")
+	local reopened=0 skipped=0 not_planned=0
+
+	while IFS= read -r line; do
+		local ref_num
+		ref_num=$(echo "$line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
+		[[ -z "$ref_num" ]] && continue
+
+		# Skip if already open
+		echo "$open_numbers" | grep -qx "$ref_num" && continue
+
+		local tid
+		tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
+
+		# Check closure reason — only reopen "COMPLETED", not "NOT_PLANNED"
+		local reason
+		reason=$(gh issue view "$ref_num" --repo "$repo" --json stateReason --jq '.stateReason' 2>/dev/null || echo "")
+		if [[ "$reason" == "NOT_PLANNED" ]]; then
+			log_verbose "#$ref_num ($tid) closed as NOT_PLANNED — skipping"
+			not_planned=$((not_planned + 1))
+			continue
+		fi
+
+		if [[ "$DRY_RUN" == "true" ]]; then
+			print_info "[DRY-RUN] Would reopen #$ref_num ($tid)"
+			reopened=$((reopened + 1))
+			continue
+		fi
+
+		gh issue reopen "$ref_num" --repo "$repo" \
+			--comment "Reopened: TODO.md still has this as \`[ ]\` (open). The issue was prematurely closed by a commit keyword. TODO.md is the source of truth for task state." 2>/dev/null && {
+			reopened=$((reopened + 1))
+			print_success "Reopened #$ref_num ($tid)"
+		} || {
+			skipped=$((skipped + 1))
+			print_warning "Failed to reopen #$ref_num ($tid)"
+		}
+	done < <(echo "$stripped" | grep -E '^\s*- \[ \] t[0-9]+.*ref:GH#[0-9]+' || true)
+
+	print_info "Reopen: $reopened reopened, $skipped failed, $not_planned skipped (NOT_PLANNED)"
+	return 0
+}
+
 cmd_help() {
 	cat <<'EOF'
 Issue Sync Helper — stateless TODO.md <-> GitHub Issues sync via gh CLI.
 Usage: issue-sync-helper.sh [command] [options]
-Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reconcile | status | help
+Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reopen | reconcile | status | help
 Options: --repo SLUG | --dry-run | --verbose | --force (skip evidence on close)
          --force-push (allow bulk push outside CI — use with caution, risk of duplicates)
 
@@ -850,6 +908,9 @@ Drift detection:
   status    — reports forward drift (open issue, done TODO) and reverse drift
               (open TODO, closed issue) without making changes.
   reconcile — same detection plus ref mismatches, with actionable guidance.
+  reopen    — reopens closed issues whose TODO entry is still [ ] (open).
+              Only reopens issues closed as COMPLETED, not NOT_PLANNED.
+              Safe for automated use in the pulse.
 
 Note: Bulk push (no task ID) is CI-only by default to prevent duplicate issues.
       Use 'push <task_id>' for single tasks, or --force-push to override.
@@ -893,7 +954,7 @@ main() {
 	command="${positional_args[0]:-help}"
 	case "$command" in
 	push) cmd_push "${positional_args[1]:-}" ;; enrich) cmd_enrich "${positional_args[1]:-}" ;;
-	pull) cmd_pull ;; close) cmd_close "${positional_args[1]:-}" ;;
+	pull) cmd_pull ;; close) cmd_close "${positional_args[1]:-}" ;; reopen) cmd_reopen ;;
 	reconcile) cmd_reconcile ;; status) cmd_status ;; help) cmd_help ;;
 	*)
 		print_error "Unknown command: $command"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -9191,6 +9191,7 @@ sync_todo_refs_for_repo() {
 
 	/bin/bash "${script_dir}/issue-sync-helper.sh" pull --repo "$repo_slug" 2>&1 || true
 	/bin/bash "${script_dir}/issue-sync-helper.sh" close --repo "$repo_slug" 2>&1 || true
+	/bin/bash "${script_dir}/issue-sync-helper.sh" reopen --repo "$repo_slug" 2>&1 || true
 	git -C "$repo_path" diff --quiet TODO.md 2>/dev/null || {
 		git -C "$repo_path" add TODO.md &&
 			git -C "$repo_path" commit -m "chore: sync GitHub issue refs to TODO.md [skip ci]" &&


### PR DESCRIPTION
## Summary

- Add `reopen` command to `issue-sync-helper.sh` that reopens closed GitHub issues whose TODO entry is still `[ ]` (open)
- Integrate into pulse via `sync_todo_refs_for_repo()`: pull -> close -> **reopen**
- Fixes systemic drift where `Closes #NNN` in commit messages prematurely closes issues for incomplete work

## Root Cause

Commit messages containing `Closes #NNN` (e.g., in planning commits, partial implementations) close GitHub issues even when the TODO entry remains `[ ]`. This created 76 prematurely closed issues that were invisible until t1874 added reverse drift detection.

## How It Works

1. Fetches all open issues in bulk (reuses existing API call — zero additional list calls)
2. Iterates open TODO `[ ]` entries with `ref:GH#`
3. For each ref NOT in the open set, checks the issue's `stateReason`
4. `COMPLETED` -> reopens with explanatory comment
5. `NOT_PLANNED` -> skips (deliberately closed)

## Pulse Integration

`sync_todo_refs_for_repo()` now runs three steps:
```
pull    → sync issue data to TODO.md
close   → close issues where TODO is [x]
reopen  → reopen issues where TODO is [ ] but issue was closed
```

## Verification

```
# Before (t1874 detection only):
reverse-drift: 76

# After reopen:
=== Sync Status (marcusquinn/aidevops) ===
TODO open: 87 | GitHub open: 94 | drift: 0 | reverse-drift: 0
[SUCCESS] In sync
```

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/issue-sync-helper.sh` | Add `cmd_reopen()`, update help text and command dispatch |
| `.agents/scripts/pulse-wrapper.sh` | Add `reopen` call to `sync_todo_refs_for_repo()` |

Closes #16850


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic GitHub issue reopening now integrated into the issue synchronization workflow. The system intelligently identifies and reopens previously closed issues when appropriate, ensuring better task visibility and accurate tracking of issue states throughout the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->