### PR TITLE
GH#15061: tighten landing page structure agent doc

### DIFF
--- a/.agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md
+++ b/.agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md
@@ -12,7 +12,7 @@ One goal, one CTA, one path.
 | Problem Aware | Long (2000-4000) | Hero, Problem, Agitate, Solution, Proof, Offer, CTA |
 | Unaware | Very Long (4000+) | Story-driven full education |
 
-Less awareness = more education. Cold traffic needs longer pages.
+Less awareness = more education.
 
 ## Universal Framework
 
@@ -63,4 +63,3 @@ Test headline value props, CTA text/color, social proof type/placement, page len
 
 - [Headline Formulas](headline-formulas.md) for hero section headlines
 - [Offer Construction](offer-construction.md) for pricing sections
-- [Templates](direct-response-copy-templates-landing-page.md) for copy-paste templates


### PR DESCRIPTION
## Summary

- Remove redundant sentence "Cold traffic needs longer pages." — already implied by the awareness-level table (Unaware = Very Long = cold traffic)
- Remove duplicate link to `direct-response-copy-templates-landing-page.md` in Related section — already linked in the Templates by Use Case section (line 41)
- 66 → 65 lines

## Verification

All links, formulas, code blocks, and task refs present before and after. No information loss.

Closes #15061

---
[aidevops.sh](https://aidevops.sh) v3.5.904 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6