### PR TITLE
GH#16868: clarify severity values and --source flag in findings-to-tasks.md

### DIFF
--- a/.agents/scripts/commands/findings-to-tasks.md
+++ b/.agents/scripts/commands/findings-to-tasks.md
@@ -10,7 +10,7 @@ Input file: `$ARGUMENTS`
 
 ## Format
 
-One finding per line — `severity|title|details`. Severity defaults to `medium` if omitted.
+One finding per line — `severity|title|details`. Severity is `critical`, `high`, `medium`, `low`, or `info` (defaults to `medium` if omitted).
 
 ```text
 high|Harden prompt-guard fallback on malformed markdown|Reject malformed HTML comments before rendering summary
@@ -24,7 +24,7 @@ low|Improve stale worker log wording|Clarify blocked vs failed in watchdog outpu
 ~/.aidevops/agents/scripts/findings-to-tasks-helper.sh create \
   --input <path/to/actionable-findings.txt> \
   --repo-path "$(git rev-parse --show-toplevel)" \
-  --source <any-free-form-tag>  # e.g. security-audit, code-review, seo-audit
+  --source <custom-source>  # any free-form tag, not validated — e.g. security-audit, code-review, seo-audit
 ```
 
 Optional flags: `--labels "label1,label2"` · `--tags "tag1,tag2"` · `--dry-run` · `--no-issue` · `--allow-partial`


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Address unactioned CodeRabbit review feedback from PR #16823 on `.agents/scripts/commands/findings-to-tasks.md`.

## Changes
- **Line 13**: Added full list of valid severity values (`critical`, `high`, `medium`, `low`, `info`) inline so readers have a complete operational reference without needing to look elsewhere.
- **Line 27**: Clarified `--source` flag accepts any free-form tag (not a validated enum) by replacing `<any-free-form-tag>` with `<custom-source>` and adding an explicit note: "any free-form tag, not validated".

## Issue
Closes #16868

## Files Changed
- `.agents/scripts/commands/findings-to-tasks.md` (2 lines changed)

## Testing
**Risk level**: Low — documentation-only change, no code logic affected.
**Runtime Testing**: `self-assessed` — doc-only changes, no runtime verification required.

## Key Decisions
- Kept the existing examples (`security-audit`, `code-review`, `seo-audit`) as they remain useful illustrative values.
- The nitpick finding about "Format" vs "Required Format" header was already addressed in PR #16823 (header already reads "Format").

---
[aidevops.sh](https://aidevops.sh) v3.5.906 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6