### PR TITLE
GH#16866: canonicalize --file path before allowlist check to prevent traversal bypass

### DIFF
--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -98,29 +98,94 @@ done
 #   TODO.md            — task backlog
 #   todo/**            — plans, briefs, task files
 #
+# Usage: _canonicalize_repo_relative_path <file_path> <repo_root>
+# Returns: canonical repo-relative path on stdout, or "OUTSIDE_REPO" if path escapes root
+# Resolves ./ and ../ segments without requiring the path to exist on disk.
+_canonicalize_repo_relative_path() {
+	local file_path="$1"
+	local repo_root="$2"
+
+	# Resolve to absolute path (relative paths are resolved from repo_root)
+	local abs_path
+	if [[ "$file_path" == /* ]]; then
+		abs_path="$file_path"
+	else
+		abs_path="${repo_root}/${file_path}"
+	fi
+
+	# Use python3 for portable normpath (resolves ./ and ../ without filesystem access)
+	if command -v python3 &>/dev/null; then
+		python3 - "$abs_path" "$repo_root" <<'PYEOF'
+import os, sys
+abs_path = sys.argv[1]
+repo_root = sys.argv[2]
+canonical = os.path.normpath(abs_path)
+if canonical.startswith(repo_root + os.sep) or canonical == repo_root:
+    print(os.path.relpath(canonical, repo_root))
+else:
+    print("OUTSIDE_REPO")
+PYEOF
+		return 0
+	fi
+
+	# Fallback: pure bash normalization (handles common cases without python3)
+	# Remove double slashes
+	abs_path="${abs_path//\/\//\/}"
+	# Resolve embedded ./ segments
+	while [[ "$abs_path" == *"/./"* ]]; do
+		abs_path="${abs_path//\/.\//\/}"
+	done
+	# Resolve ../ segments iteratively
+	while [[ "$abs_path" == *"/../"* ]]; do
+		abs_path=$(echo "$abs_path" | sed 's|[^/]*/\.\./||')
+	done
+	# Check if within repo root
+	if [[ "$abs_path" == "${repo_root}/"* ]] || [[ "$abs_path" == "$repo_root" ]]; then
+		echo "${abs_path#"${repo_root}/"}"
+	else
+		echo "OUTSIDE_REPO"
+	fi
+	return 0
+}
+
 # Usage: is_main_allowlisted_path <file_path>
 # Returns: 0 if path is allowlisted, 1 if not
+# Canonicalizes the path to a repo-relative form before evaluating the allowlist,
+# preventing path traversal bypasses (e.g. todo/../secret.py).
 is_main_allowlisted_path() {
 	local file_path="$1"
 
-	# Normalise: strip leading ./ to get a repo-relative path
+	# Resolve repo root for canonicalization
+	local repo_root
+	repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
 	local normalised
-	normalised=$(echo "$file_path" | sed 's|^\./||')
+	if [[ -n "$repo_root" ]]; then
+		# Canonicalize: resolve ./ and ../ segments, reject paths outside repo root
+		normalised="$(_canonicalize_repo_relative_path "$file_path" "$repo_root")"
+		# Reject paths that escape the repo root
+		if [[ "$normalised" == "OUTSIDE_REPO" ]]; then
+			return 1
+		fi
+	else
+		# No git repo context: fall back to simple normalization
+		# Strip leading ./ to get a repo-relative path
+		normalised=$(echo "$file_path" | sed 's|^\./||')
 
-	# Reject path traversal: any path containing .. segments is not allowlisted.
-	# This prevents todo/../secret.py from matching the todo/ prefix.
-	case "$normalised" in
-	*..*)
-		return 1
-		;;
-	esac
+		# Reject path traversal: any path containing .. segments is not allowlisted.
+		case "$normalised" in
+		*..*)
+			return 1
+			;;
+		esac
 
-	# Reject absolute paths that escape the repo root
-	case "$normalised" in
-	/*)
-		return 1
-		;;
-	esac
+		# Reject absolute paths
+		case "$normalised" in
+		/*)
+			return 1
+			;;
+		esac
+	fi
 
 	# Exact matches
 	case "$normalised" in

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -165,6 +165,75 @@ test_blocks_when_linked_worktree_owned_by_another_live_process() {
 	return 0
 }
 
+test_allowlisted_path_allows_edit_on_main() {
+	# Ensure repo is on main for this test
+	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --file "README.md" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=stay"* ]]; then
+		print_result "allowlisted path (README.md) allows edit on main in loop mode" 0
+		return 0
+	fi
+
+	print_result "allowlisted path (README.md) allows edit on main in loop mode" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_path_traversal_blocked_on_main() {
+	# Ensure repo is on main for this test
+	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --file "todo/../secret.py" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"LOOP_DECISION=worktree"* ]]; then
+		print_result "path traversal (todo/../secret.py) blocked on main" 0
+		return 0
+	fi
+
+	print_result "path traversal (todo/../secret.py) blocked on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_absolute_path_outside_repo_blocked_on_main() {
+	# Ensure repo is on main for this test
+	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --file "/etc/passwd" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"LOOP_DECISION=worktree"* ]]; then
+		print_result "absolute path outside repo (/etc/passwd) blocked on main" 0
+		return 0
+	fi
+
+	print_result "absolute path outside repo (/etc/passwd) blocked on main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_todo_subdir_path_allows_edit_on_main() {
+	# Ensure repo is on main for this test
+	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+	mkdir -p "${TEST_ROOT}/todo"
+
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --file "todo/tasks/t001-brief.md" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=stay"* ]]; then
+		print_result "todo/ subdir path allows edit on main in loop mode" 0
+		return 0
+	fi
+
+	print_result "todo/ subdir path allows edit on main in loop mode" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
 main() {
 	trap teardown_test_repo EXIT
 	setup_test_repo
@@ -173,6 +242,10 @@ main() {
 	test_allows_linked_worktree_edits
 	test_warns_when_canonical_repo_is_off_main
 	test_blocks_when_linked_worktree_owned_by_another_live_process
+	test_allowlisted_path_allows_edit_on_main
+	test_path_traversal_blocked_on_main
+	test_absolute_path_outside_repo_blocked_on_main
+	test_todo_subdir_path_allows_edit_on_main
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

- Add `_canonicalize_repo_relative_path()` helper to `pre-edit-check.sh` that resolves `./` and `../` segments to a canonical repo-relative form, rejecting paths that escape the repo root
- Update `is_main_allowlisted_path()` to canonicalize the input path before evaluating `case` patterns — paths like `todo/../secret.py` now resolve to `src/secret.py` and are correctly denied rather than matching `todo/*`
- Add 4 new shell unit tests covering: allowlisted path on main, path traversal bypass attempt, absolute path outside repo, and `todo/` subdir path

## Changes

**`.agents/scripts/pre-edit-check.sh`**
- New `_canonicalize_repo_relative_path()` function: uses `python3` (portable, no filesystem access needed) with a pure-bash fallback; resolves `./ ` and `../` segments, rejects paths outside repo root with `OUTSIDE_REPO` sentinel
- Updated `is_main_allowlisted_path()`: calls `_canonicalize_repo_relative_path()` when git repo context is available; falls back to the existing `..` rejection + absolute path rejection when no git context
- Fallback path (no git context) retains the existing defense-in-depth `*..* → return 1` and `/* → return 1` guards

**`.agents/scripts/tests/test-pre-edit-check.sh`**
- 4 new tests: `allowlisted path (README.md) allows edit on main in loop mode`, `path traversal (todo/../secret.py) blocked on main`, `absolute path outside repo (/etc/passwd) blocked on main`, `todo/ subdir path allows edit on main in loop mode`
- Each new test resets the repo to `main` to avoid state leakage from the off-main test

## Runtime Testing

Risk: **Low** — shell script logic change, no runtime services involved.

- All 8 shell unit tests pass (`bash .agents/scripts/tests/test-pre-edit-check.sh`)
- ShellCheck zero violations on both modified files

## Key Decisions

- Used `python3` for canonicalization (available on all supported platforms) rather than `realpath -m` (GNU-only, not available on macOS BSD realpath)
- Pure-bash fallback handles the case where `python3` is unavailable
- Canonicalization happens inside `is_main_allowlisted_path()` so callers don't need to pre-process paths

Closes #16866

---
[aidevops.sh](https://aidevops.sh) v3.5.906 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite covering file path validation scenarios including standard paths, traversal attempts, absolute paths, and subdirectory paths.

* **Chores**
  * Enhanced path validation with improved canonicalization capabilities for more robust repository-relative path resolution and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->