### PR TITLE
t1875: mark TODO [x] when _do_close succeeds — close the sync loop

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -224,6 +224,26 @@ _close_comment() {
 	fi
 }
 
+# Mark a TODO entry as done: [ ] → [x] with completed: date.
+# Also handles [-] (cancelled/declined) entries — leaves marker as [-].
+_mark_todo_done() {
+	local task_id="$1" todo_file="$2"
+	local task_id_ere
+	task_id_ere=$(_escape_ere "$task_id")
+	local today
+	today=$(date -u +%Y-%m-%d)
+
+	# Only flip [ ] → [x]; skip if already [x] or [-]
+	# Use [[:space:]] not \s for macOS sed compatibility (bash 3.2)
+	if grep -qE "^[[:space:]]*- \[ \] ${task_id_ere} " "$todo_file" 2>/dev/null; then
+		# Flip checkbox and append completed: date
+		sed -i.bak -E "s/^([[:space:]]*- )\[ \] (${task_id_ere} .*)/\1[x] \2 completed:${today}/" "$todo_file"
+		rm -f "${todo_file}.bak"
+		log_verbose "Marked $task_id as [x] in TODO.md"
+	fi
+	return 0
+}
+
 _do_close() {
 	local task_id="$1" issue_number="$2" todo_file="$3" repo="$4"
 	local task_id_ere
@@ -265,6 +285,7 @@ _do_close() {
 			_gh_edit_labels "add" "$repo" "$issue_number" "not-planned"
 		fi
 		_mark_issue_done "$repo" "$issue_number"
+		_mark_todo_done "$task_id" "$todo_file"
 		print_success "Closed #$issue_number ($task_id)"
 	else
 		print_error "Failed to close #$issue_number ($task_id)"


### PR DESCRIPTION
## Summary

- Add `_mark_todo_done()` to flip `[ ]` → `[x]` with `completed:` date when `_do_close()` succeeds
- Closes the TODO/GitHub sync loop that caused 74 completed tasks to remain `[ ]` in TODO.md

## Root Cause

`_do_close()` did three things after closing a GitHub issue:
1. Added `pr:#NNN` to the TODO line
2. Applied `status:done` label on GitHub
3. Called `_mark_issue_done()` for GitHub label cleanup

It never did the fourth: mark the TODO checkbox as `[x]`. This left completed tasks as `[ ]` in TODO.md, which:
- Made `status` report inflated open counts (87 open TODOs vs 23 open issues)
- Caused `reopen` to fight with `close` in a loop (t1875)
- Made the pulse re-dispatch already-completed work

## Fix

New `_mark_todo_done()` function:
- Flips `[ ]` → `[x]` and appends `completed:YYYY-MM-DD`
- Uses `[[:space:]]` not `\s` for macOS sed compatibility
- Skips entries already `[x]` or `[-]` (idempotent)
- Called from `_do_close()` after successful `gh issue close`

## The Full Fix Chain (this session)

| PR | Layer | What |
|---|---|---|
| #16841 | Detect | Reverse drift detection in `status`/`reconcile` |
| #16852 | Act | `reopen` command + pulse integration |
| #16874 | Smart | Check PR evidence before reopening |
| **This PR** | **Root cause** | **Mark TODO `[x]` when closing — prevents drift from occurring** |

Related to #16850
