### PR TITLE
t1875: reopen marks TODO [x] when merged PR found — complete the sync loop

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -902,12 +902,18 @@ cmd_reopen() {
 		fi
 
 		# Check if a merged PR exists for this task — if so, the closure is
-		# legitimate (work done) even though TODO is still [ ]. Skip reopen;
-		# the TODO needs marking [x] via task-complete-helper.sh, not reopening.
+		# legitimate (work done). Mark TODO [x] with pr:# instead of reopening.
 		local pr_info
 		pr_info=$(gh_find_merged_pr "$repo" "$tid" 2>/dev/null || echo "")
 		if [[ -n "$pr_info" ]]; then
-			log_verbose "#$ref_num ($tid) has merged PR — closure legitimate, skipping"
+			local pr_num="${pr_info%%|*}"
+			if [[ "$DRY_RUN" == "true" ]]; then
+				print_info "[DRY-RUN] Would mark $tid [x] (merged PR #$pr_num)"
+			else
+				add_pr_ref_to_todo "$tid" "$pr_num" "$todo_file" 2>/dev/null || true
+				_mark_todo_done "$tid" "$todo_file"
+				log_verbose "#$ref_num ($tid) has merged PR #$pr_num — marked TODO [x]"
+			fi
 			has_pr=$((has_pr + 1))
 			continue
 		fi


### PR DESCRIPTION
## Summary

- `cmd_reopen()` now marks TODO `[x]` with `pr:#NNN` and `completed:` date when a merged PR exists, instead of silently skipping
- Completes the sync loop: closed issues with merged PRs get their TODOs updated, eliminating persistent reverse-drift

## Problem

After #16874, `cmd_reopen()` correctly identified 76 closed issues with merged PRs but just logged "closure legitimate, skipping" and did nothing to TODO.md. These 76 entries stayed `[ ]` forever — no code path would ever mark them done.

## Fix

When `gh_find_merged_pr()` finds a matching PR:
1. `add_pr_ref_to_todo()` adds `pr:#NNN` to the TODO line
2. `_mark_todo_done()` flips `[ ]` → `[x]` with `completed:` date

| Condition | Before | After |
|-----------|--------|-------|
| Closed + merged PR | Skip silently (TODO stays `[ ]`) | Mark `[x]` + `pr:#NNN` |
| Closed + NOT_PLANNED | Skip | Skip (unchanged) |
| Closed + no PR | Reopen | Reopen (unchanged) |

## Verification (dry-run)

```
[DRY-RUN] Would mark t1660 [x] (merged PR #5612)
... (76 items)
Reopen: 3 reopened, 0 failed, 0 not-planned, 76 have-merged-pr
```

Related to #16850
