### PR TITLE
t1866: register autoagent in subagent-index.toon and domain-index.md

### DIFF
--- a/.agents/reference/domain-index.md
+++ b/.agents/reference/domain-index.md
@@ -38,7 +38,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Upstream watch | `scripts/upstream-watch-helper.sh`, `.agents/configs/upstream-watch.json` |
 | Testing | `scripts/commands/testing-setup.md`, `tools/build-agent/agent-testing.md`, `scripts/testing-setup-helper.sh` |
 | Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md`, `tools/mcp-toolkit/mcporter.md` |
-| Self-Improvement | `reference/self-improvement.md` |
+| Self-Improvement | `reference/self-improvement.md`, `tools/autoagent/autoagent.md`, `scripts/commands/autoagent.md` |
 | Framework | `aidevops/architecture.md`, `scripts/commands/skills.md` |
 
 **Creating agents**: When a user asks to create, build, or design an agent — regardless of which primary agent is active — always read `tools/build-agent/build-agent.md` first. It contains the tier prompt (draft/custom/shared), design checklist, and lifecycle rules.

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -20,7 +20,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[107]{folder,purpose,key_files}:
+<!--TOON:subagents[108]{folder,purpose,key_files}:
 aidevops/,aidevops subagents,add-new-mcp-to-aidevops|agent-sources|api-integrations|architecture|claude-flow-comparison|configs|docs|extension|graduated-learnings|mcp-integrations|mcp-troubleshooting|memory-patterns|onboarding|orchestration-analysis|plugins|providers|recommendations|requirements|resources|security|security-requirements|self-improving-agents|service-links|services|setup|supervisor-module-map|troubleshooting
 content/,content subagents,content-calendar|context-templates|distribution-blog|distribution-email|distribution-podcast|distribution-short-form|distribution-social|distribution-youtube-channel-intel|distribution-youtube|distribution-youtube-optimizer|distribution-youtube-pipeline|distribution-youtube-readme|distribution-youtube-script-writer|distribution-youtube-topic-research|editor|guidelines
 content/heygen-skill/,content/heygen-skill subagents,rules-assets|rules-authentication|rules-avatars|rules-backgrounds|rules-captions|rules-dimensions|rules-photo-avatars|rules-quota|rules-remotion-integration|rules-scripts|rules-streaming-avatars|rules-templates|rules-text-overlays|rules-video-agent|rules-video-generation|rules-video-status|rules-video-translation|rules-voices|rules-webhooks
@@ -63,6 +63,7 @@ tools/architecture/clean-ddd-hexagonal-skill/hexagonal/,tools/architecture/clean
 tools/architecture/clean-ddd-hexagonal-skill/,tools/architecture/clean-ddd-hexagonal-skill subagents,hexagonal|layers|testing
 tools/architecture/feature-slicing-skill/,tools/architecture/feature-slicing-skill subagents,cheatsheet|implementation|layers|migration|nextjs|public-api
 tools/automation/,tools/automation subagents,cron-agent|mac|macos-automator|objective-runner
+tools/autoagent/,tools/autoagent subagents,autoagent
 tools/autoresearch/,tools/autoresearch subagents,autoresearch
 tools/browser/,tools/browser subagents,agent-browser|anti-detect-browser|browser-automation|browser-benchmark|browser-benchmark-scripts-01-playwright|browser-benchmark-scripts-02-dev-browser|browser-benchmark-scripts-03-agent-browser|browser-benchmark-scripts-04-crawl4ai|browser-benchmark-scripts-05-stagehand|browser-benchmark-scripts-06-visual-verification|browser-benchmark-scripts|browser-profiles|browser-qa|browser-use|chrome-devtools|chrome-webstore-release|chromium-debug-use|crawl4ai-integration|crawl4ai|crawl4ai-resources|crawl4ai-usage|curl-copy|dev-browser
 tools/browser/extension-dev/,tools/browser/extension-dev subagents,development


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What

Closes the parent t1866 issue by registering the autoagent subagent in the framework discovery indexes. All 5 subtasks (t1867–t1871) were implemented and merged via individual PRs; the parent issue remained open because the original PR #16679 was closed without merging.

## Issue

Closes #16656

## Files Changed

| File | Change |
|------|--------|
| `.agents/subagent-index.toon` | Add `tools/autoagent/` entry (count 107→108) |
| `.agents/reference/domain-index.md` | Add autoagent to Self-Improvement routing row |

## Testing

**Risk level:** Low — documentation index updates only. No runtime state changes.

**Acceptance criteria verified (all on main):**

- [x] `/autoagent` command exists: `.agents/scripts/commands/autoagent.md` ✓
- [x] Autoagent subagent + 4 subdocs: all 5 files present ✓
- [x] `autoagent-metric-helper.sh` passes `shellcheck -S warning` (zero violations) ✓
- [x] Research program template contains `safety` pattern ✓
- [x] Multi-trial evaluation documented in `autoresearch/loop.md` (`trials:` pattern) ✓

**Verification commands:**

```bash
test -f .agents/scripts/commands/autoagent.md && echo "PASS"
test -f .agents/tools/autoagent/autoagent.md && echo "PASS"
shellcheck -S warning .agents/scripts/autoagent-metric-helper.sh && echo "PASS"
grep -qE "safety" .agents/templates/autoagent-program-template.md && echo "PASS"
grep -qE "multi.trial|trials:" .agents/tools/autoresearch/autoresearch/loop.md && echo "PASS"
grep -q "tools/autoagent/" .agents/subagent-index.toon && echo "PASS"
```

## Key Decisions

- All substantive work was already merged via subtask PRs (t1867 #16685, t1868 #2254e7aa2, t1869 #16680, t1870 #16682, t1871 #16681)
- The original parent PR #16679 was closed without merging (branch conflicts with individual subtask merges)
- This PR adds the missing discovery index entries that were not part of any subtask scope

## Runtime Testing

Self-assessed (Low risk). Index file updates only — no executable code changed.

---
[aidevops.sh](https://aidevops.sh) v3.6.1 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Self-Improvement domain index with additional reference materials.

* **Chores**
  * Added autoagent tools component to system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->