### PR TITLE
t1878: feat: ratchet pattern for code quality regression prevention

### DIFF
--- a/.agents/configs/ratchet-exceptions/bare_positional_params.txt
+++ b/.agents/configs/ratchet-exceptions/bare_positional_params.txt
@@ -1,0 +1,6 @@
+# Ratchet exceptions: bare_positional_params
+# Format: file:line reason
+# Lines starting with # are comments.
+# Each entry subtracts 1 from the raw count for this pattern.
+# Example:
+#   .agents/scripts/some-helper.sh:42 awk field reference, not positional param

--- a/.agents/configs/ratchet-exceptions/broad_catch_or_true.txt
+++ b/.agents/configs/ratchet-exceptions/broad_catch_or_true.txt
@@ -1,0 +1,6 @@
+# Ratchet exceptions: broad_catch_or_true
+# Format: file:line reason
+# Lines starting with # are comments.
+# Each entry subtracts 1 from the raw count for this pattern.
+# Example:
+#   .agents/scripts/some-helper.sh:88 intentional: non-critical cleanup step

--- a/.agents/configs/ratchet-exceptions/hardcoded_aidevops_path.txt
+++ b/.agents/configs/ratchet-exceptions/hardcoded_aidevops_path.txt
@@ -1,0 +1,6 @@
+# Ratchet exceptions: hardcoded_aidevops_path
+# Format: file:line reason
+# Lines starting with # are comments.
+# Each entry subtracts 1 from the raw count for this pattern.
+# Example:
+#   .agents/scripts/setup.sh:15 intentional default path definition

--- a/.agents/configs/ratchet-exceptions/missing_return_files.txt
+++ b/.agents/configs/ratchet-exceptions/missing_return_files.txt
@@ -1,0 +1,6 @@
+# Ratchet exceptions: missing_return_files
+# Format: file reason
+# Lines starting with # are comments.
+# Each entry subtracts 1 from the raw count for this pattern.
+# Example:
+#   .agents/scripts/some-helper.sh utility-only script, no functions need explicit return

--- a/.agents/configs/ratchet-exceptions/silent_errors.txt
+++ b/.agents/configs/ratchet-exceptions/silent_errors.txt
@@ -1,0 +1,6 @@
+# Ratchet exceptions: silent_errors
+# Format: file:line reason
+# Lines starting with # are comments.
+# Each entry subtracts 1 from the raw count for this pattern.
+# Example:
+#   .agents/scripts/some-helper.sh:22 intentional: optional tool check

--- a/.agents/configs/ratchets.json
+++ b/.agents/configs/ratchets.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "updated": "2026-04-04T00:00:00Z",
+  "description": "Ratchet baselines for code quality regression prevention. Counts can only stay the same or decrease — never increase. Run linters-local.sh --update-baseline to lock in improvements.",
+  "ratchets": {
+    "bare_positional_params": {
+      "count": 4687,
+      "description": "$1/$2 etc. used directly in function bodies (should use local var=\"$1\")",
+      "pattern": "\\$[1-9]",
+      "exclude": "local.*=.*\\$[1-9]"
+    },
+    "hardcoded_aidevops_path": {
+      "count": 309,
+      "description": "Literal ~/.aidevops or /Users/ instead of ${HOME}/.aidevops or variable",
+      "pattern": "~/.aidevops|/Users/"
+    },
+    "broad_catch_or_true": {
+      "count": 2233,
+      "description": "|| true used to suppress errors without specific handling",
+      "pattern": "\\|\\| true"
+    },
+    "silent_errors": {
+      "count": 5589,
+      "description": "2>/dev/null used to silently discard errors without handling",
+      "pattern": "2>/dev/null"
+    },
+    "missing_return_files": {
+      "count": 2,
+      "description": "Files containing functions without explicit return 0 or return 1",
+      "pattern": "functions_without_return"
+    }
+  }
+}

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -12,9 +12,15 @@
 #   - Pattern validation (return statements, positional parameters)
 #   - Markdown formatting
 #   - Skill frontmatter validation (name field matches skill-sources.json)
+#   - Ratchet quality checks (anti-pattern regression prevention)
 #
 # For remote auditing (CodeRabbit, Codacy, SonarCloud), use:
 #   /code-audit-remote or code-audit-helper.sh
+#
+# Ratchet flags:
+#   --update-baseline   Re-count all patterns and write new ratchets.json baseline
+#   --init-baseline     Same as --update-baseline (alias for first-time setup)
+#   --strict            Make ratchet failures blocking (default: advisory)
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
@@ -1304,6 +1310,280 @@ check_bash32_compat() {
 }
 
 # =============================================================================
+# Ratchet Quality Check (t1878)
+# =============================================================================
+# Tracks anti-pattern counts against a stored baseline. Counts can only stay
+# the same or decrease — never increase. Prevents gradual quality regression
+# without requiring zero violations immediately.
+#
+# Baseline: .agents/configs/ratchets.json
+# Exceptions: .agents/configs/ratchet-exceptions/{pattern}.txt
+#
+# Usage:
+#   linters-local.sh                  # advisory ratchet check
+#   linters-local.sh --strict         # blocking ratchet check
+#   linters-local.sh --update-baseline # re-count and write new baseline
+
+# _ratchet_count_bare_positional: count $1-$9 in function bodies (not local assignments)
+# Returns: count via stdout
+_ratchet_count_bare_positional() {
+	local scripts_dir="$1"
+	local count=0
+	count=$(rg '\$[1-9]' --type sh "$scripts_dir" 2>/dev/null |
+		grep -v 'local.*=.*\$[1-9]' |
+		grep -v '^\s*#' |
+		wc -l | tr -d '[:space:]') || count=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	echo "$count"
+	return 0
+}
+
+# _ratchet_count_hardcoded_path: count literal ~/.aidevops or /Users/ in scripts
+# Returns: count via stdout
+_ratchet_count_hardcoded_path() {
+	local scripts_dir="$1"
+	local count=0
+	# Tilde is intentional: we search for the literal string ~/.aidevops in scripts
+	# shellcheck disable=SC2088
+	count=$(rg '~/.aidevops|/Users/' --type sh "$scripts_dir" 2>/dev/null |
+		grep -v '^\s*#' |
+		grep -v '# ' |
+		wc -l | tr -d '[:space:]') || count=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	echo "$count"
+	return 0
+}
+
+# _ratchet_count_broad_catch: count || true usage
+# Returns: count via stdout
+_ratchet_count_broad_catch() {
+	local scripts_dir="$1"
+	local count=0
+	count=$(rg '\|\| true' --type sh "$scripts_dir" 2>/dev/null |
+		wc -l | tr -d '[:space:]') || count=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	echo "$count"
+	return 0
+}
+
+# _ratchet_count_silent_errors: count 2>/dev/null usage
+# Returns: count via stdout
+_ratchet_count_silent_errors() {
+	local scripts_dir="$1"
+	local count=0
+	count=$(rg '2>/dev/null' --type sh "$scripts_dir" 2>/dev/null |
+		wc -l | tr -d '[:space:]') || count=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	echo "$count"
+	return 0
+}
+
+# _ratchet_count_missing_return: count files with functions but fewer return statements
+# Returns: count via stdout
+_ratchet_count_missing_return() {
+	local missing_files=0
+	local file funcs returns
+	for file in "${ALL_SH_FILES[@]}"; do
+		[[ -f "$file" ]] || continue
+		funcs=$(grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {$" "$file" 2>/dev/null || echo "0")
+		returns=$(grep -cE "return [0-9]+|return \\\$" "$file" 2>/dev/null || echo "0")
+		funcs=$(echo "$funcs" | tr -d '[:space:]')
+		returns=$(echo "$returns" | tr -d '[:space:]')
+		[[ "$funcs" =~ ^[0-9]+$ ]] || funcs=0
+		[[ "$returns" =~ ^[0-9]+$ ]] || returns=0
+		if [[ "$returns" -lt "$funcs" ]]; then
+			missing_files=$((missing_files + 1))
+		fi
+	done
+	echo "$missing_files"
+	return 0
+}
+
+# _ratchet_load_exceptions: count non-comment lines in an exceptions file
+# Arguments: $1=exceptions_file
+# Returns: exception count via stdout
+_ratchet_load_exceptions() {
+	local exceptions_file="$1"
+	local count=0
+	if [[ -f "$exceptions_file" ]]; then
+		count=$(grep -cv '^[[:space:]]*#\|^[[:space:]]*$' "$exceptions_file" 2>/dev/null || echo "0")
+		[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	fi
+	echo "$count"
+	return 0
+}
+
+# _ratchet_check_pattern: compare current count against baseline for one pattern
+# Arguments: $1=name $2=current $3=baseline $4=exceptions $5=strict_mode
+# Returns: 0=pass, 1=regressed
+_ratchet_check_pattern() {
+	local name="$1"
+	local current="$2"
+	local baseline="$3"
+	local exceptions="$4"
+	local strict_mode="$5"
+
+	local effective_current=$((current - exceptions))
+	local effective_baseline=$((baseline - exceptions))
+	[[ "$effective_current" -lt 0 ]] && effective_current=0
+	[[ "$effective_baseline" -lt 0 ]] && effective_baseline=0
+
+	if [[ "$effective_current" -lt "$effective_baseline" ]]; then
+		local improvement=$((effective_baseline - effective_current))
+		print_success "  PASS: ${name} ${effective_baseline} -> ${effective_current} (improved by ${improvement})"
+		return 0
+	elif [[ "$effective_current" -eq "$effective_baseline" ]]; then
+		print_success "  PASS: ${name} ${effective_current} (no change)"
+		return 0
+	else
+		local regression=$((effective_current - effective_baseline))
+		if [[ "$strict_mode" == "true" ]]; then
+			print_error "  FAIL: ${name} ${effective_baseline} -> ${effective_current} (regressed by ${regression}) — run --update-baseline after fixing"
+		else
+			print_warning "  WARN: ${name} ${effective_baseline} -> ${effective_current} (regressed by ${regression}) — advisory only (use --strict to block)"
+		fi
+		return 1
+	fi
+}
+
+# check_ratchets: main ratchet check function
+# Arguments: none (reads RATCHET_UPDATE_BASELINE and RATCHET_STRICT from env)
+# Returns: 0 if all ratchets pass, 1 if any regressed (only blocks in strict mode)
+check_ratchets() {
+	echo -e "${BLUE}Checking Ratchet Quality Gates (t1878)...${NC}"
+
+	local scripts_dir
+	scripts_dir="$(git rev-parse --show-toplevel 2>/dev/null)/.agents/scripts" || scripts_dir=".agents/scripts"
+	local baseline_file
+	baseline_file="$(git rev-parse --show-toplevel 2>/dev/null)/.agents/configs/ratchets.json" || baseline_file=".agents/configs/ratchets.json"
+	local exceptions_dir
+	exceptions_dir="$(git rev-parse --show-toplevel 2>/dev/null)/.agents/configs/ratchet-exceptions" || exceptions_dir=".agents/configs/ratchet-exceptions"
+
+	if ! command -v rg &>/dev/null; then
+		print_warning "Ratchets: rg (ripgrep) not installed — skipping (install: brew install ripgrep)"
+		return 0
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		print_warning "Ratchets: jq not installed — skipping (install: brew install jq)"
+		return 0
+	fi
+
+	# Count current values for all patterns
+	local count_bare count_hardcoded count_broad count_silent count_missing
+	count_bare=$(_ratchet_count_bare_positional "$scripts_dir")
+	count_hardcoded=$(_ratchet_count_hardcoded_path "$scripts_dir")
+	count_broad=$(_ratchet_count_broad_catch "$scripts_dir")
+	count_silent=$(_ratchet_count_silent_errors "$scripts_dir")
+	count_missing=$(_ratchet_count_missing_return)
+
+	# --update-baseline / --init-baseline: write new baseline and exit
+	if [[ "${RATCHET_UPDATE_BASELINE:-false}" == "true" ]]; then
+		local now
+		now=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
+		local new_json
+		new_json=$(jq -n \
+			--arg updated "$now" \
+			--argjson bare "$count_bare" \
+			--argjson hardcoded "$count_hardcoded" \
+			--argjson broad "$count_broad" \
+			--argjson silent "$count_silent" \
+			--argjson missing "$count_missing" \
+			'{
+				version: 1,
+				updated: $updated,
+				description: "Ratchet baselines for code quality regression prevention. Counts can only stay the same or decrease — never increase. Run linters-local.sh --update-baseline to lock in improvements.",
+				ratchets: {
+					bare_positional_params: {
+						count: $bare,
+						description: "$1/$2 etc. used directly in function bodies (should use local var=\"$1\")",
+						pattern: "\\$[1-9]",
+						exclude: "local.*=.*\\$[1-9]"
+					},
+					hardcoded_aidevops_path: {
+						count: $hardcoded,
+						description: "Literal ~/.aidevops or /Users/ instead of \${HOME}/.aidevops or variable",
+						pattern: "~/.aidevops|/Users/"
+					},
+					broad_catch_or_true: {
+						count: $broad,
+						description: "|| true used to suppress errors without specific handling",
+						pattern: "\\|\\| true"
+					},
+					silent_errors: {
+						count: $silent,
+						description: "2>/dev/null used to silently discard errors without handling",
+						pattern: "2>/dev/null"
+					},
+					missing_return_files: {
+						count: $missing,
+						description: "Files containing functions without explicit return 0 or return 1",
+						pattern: "functions_without_return"
+					}
+				}
+			}') || {
+			print_error "Ratchets: failed to generate baseline JSON"
+			return 1
+		}
+
+		if [[ "${RATCHET_DRY_RUN:-false}" == "true" ]]; then
+			print_info "Ratchets: --dry-run mode, would write baseline:"
+			echo "$new_json" | jq '.ratchets | to_entries[] | "  \(.key): \(.value.count)"' -r
+			return 0
+		fi
+
+		echo "$new_json" >"$baseline_file"
+		print_success "Ratchets: baseline updated in $baseline_file"
+		echo "$new_json" | jq '.ratchets | to_entries[] | "  \(.key): \(.value.count)"' -r
+		return 0
+	fi
+
+	# Check baseline file exists
+	if [[ ! -f "$baseline_file" ]]; then
+		print_warning "Ratchets: no baseline found at $baseline_file — run --init-baseline to create"
+		return 0
+	fi
+
+	# Load baselines
+	local baseline_bare baseline_hardcoded baseline_broad baseline_silent baseline_missing
+	baseline_bare=$(jq -r '.ratchets.bare_positional_params.count // 0' "$baseline_file" 2>/dev/null) || baseline_bare=0
+	baseline_hardcoded=$(jq -r '.ratchets.hardcoded_aidevops_path.count // 0' "$baseline_file" 2>/dev/null) || baseline_hardcoded=0
+	baseline_broad=$(jq -r '.ratchets.broad_catch_or_true.count // 0' "$baseline_file" 2>/dev/null) || baseline_broad=0
+	baseline_silent=$(jq -r '.ratchets.silent_errors.count // 0' "$baseline_file" 2>/dev/null) || baseline_silent=0
+	baseline_missing=$(jq -r '.ratchets.missing_return_files.count // 0' "$baseline_file" 2>/dev/null) || baseline_missing=0
+
+	# Load exceptions
+	local exc_bare exc_hardcoded exc_broad exc_silent exc_missing
+	exc_bare=$(_ratchet_load_exceptions "${exceptions_dir}/bare_positional_params.txt")
+	exc_hardcoded=$(_ratchet_load_exceptions "${exceptions_dir}/hardcoded_aidevops_path.txt")
+	exc_broad=$(_ratchet_load_exceptions "${exceptions_dir}/broad_catch_or_true.txt")
+	exc_silent=$(_ratchet_load_exceptions "${exceptions_dir}/silent_errors.txt")
+	exc_missing=$(_ratchet_load_exceptions "${exceptions_dir}/missing_return_files.txt")
+
+	local strict_mode="${RATCHET_STRICT:-false}"
+	local ratchet_failures=0
+
+	_ratchet_check_pattern "bare_positional_params" "$count_bare" "$baseline_bare" "$exc_bare" "$strict_mode" || ratchet_failures=$((ratchet_failures + 1))
+	_ratchet_check_pattern "hardcoded_aidevops_path" "$count_hardcoded" "$baseline_hardcoded" "$exc_hardcoded" "$strict_mode" || ratchet_failures=$((ratchet_failures + 1))
+	_ratchet_check_pattern "broad_catch_or_true" "$count_broad" "$baseline_broad" "$exc_broad" "$strict_mode" || ratchet_failures=$((ratchet_failures + 1))
+	_ratchet_check_pattern "silent_errors" "$count_silent" "$baseline_silent" "$exc_silent" "$strict_mode" || ratchet_failures=$((ratchet_failures + 1))
+	_ratchet_check_pattern "missing_return_files" "$count_missing" "$baseline_missing" "$exc_missing" "$strict_mode" || ratchet_failures=$((ratchet_failures + 1))
+
+	if [[ "$ratchet_failures" -eq 0 ]]; then
+		print_success "Ratchets: all ${5:-5} patterns passing (no regressions)"
+		return 0
+	fi
+
+	if [[ "$strict_mode" == "true" ]]; then
+		print_error "Ratchets: ${ratchet_failures} pattern(s) regressed — fix violations or run --update-baseline to accept"
+		return 1
+	fi
+
+	print_warning "Ratchets: ${ratchet_failures} pattern(s) regressed (advisory — use --strict to block, --update-baseline to accept)"
+	return 0
+}
+
+# =============================================================================
 # Bundle-Aware Gate Filtering (t1364.6)
 # =============================================================================
 # Resolves the project bundle and checks whether a gate should be skipped.
@@ -1422,6 +1702,11 @@ _run_gate_checks_static() {
 		echo ""
 	fi
 
+	if ! should_skip_gate "ratchets"; then
+		check_ratchets || exit_code=1
+		echo ""
+	fi
+
 	return $exit_code
 }
 
@@ -1470,6 +1755,22 @@ _run_gate_checks() {
 }
 
 main() {
+	# Parse ratchet flags before running checks
+	local arg
+	for arg in "$@"; do
+		case "$arg" in
+		--update-baseline | --init-baseline)
+			export RATCHET_UPDATE_BASELINE=true
+			;;
+		--strict)
+			export RATCHET_STRICT=true
+			;;
+		--dry-run)
+			export RATCHET_DRY_RUN=true
+			;;
+		esac
+	done
+
 	print_header
 
 	# Collect shell files once (includes modularised subdirectories, excludes _archive/)
@@ -1477,6 +1778,12 @@ main() {
 
 	# Load bundle config for gate filtering (t1364.6)
 	load_bundle_gates
+
+	# If --update-baseline, run only the ratchet check (which handles baseline update)
+	if [[ "${RATCHET_UPDATE_BASELINE:-false}" == "true" ]]; then
+		check_ratchets
+		return $?
+	fi
 
 	# Run all local quality checks (respecting bundle skip_gates)
 	local exit_code=0


### PR DESCRIPTION
## Summary

Implements the ratchet quality check pattern (inspired by imbue-ai/mngr `test_ratchets.py`) to prevent gradual code quality regression in `.agents/scripts/`.

Ratchets track anti-pattern counts against a stored baseline. Counts can only stay the same or decrease — never increase. This prevents regression without requiring zero violations immediately.

## What Changed

- **`.agents/scripts/linters-local.sh`**: Added `check_ratchets()` function and supporting helpers, integrated into `_run_gate_checks_static()`, added `--update-baseline`/`--strict`/`--dry-run` flag parsing to `main()`
- **`.agents/configs/ratchets.json`**: New baseline file with 5 anti-pattern counts
- **`.agents/configs/ratchet-exceptions/`**: New directory with per-pattern exception files (subtract known false positives from counts)

## Patterns Tracked (5)

| Pattern | Baseline | Description |
|---------|----------|-------------|
| `bare_positional_params` | 4687 | `$1`/`$2` used directly in function bodies |
| `hardcoded_aidevops_path` | 309 | Literal `~/.aidevops` or `/Users/` paths |
| `broad_catch_or_true` | 2233 | `\|\| true` error suppression |
| `silent_errors` | 5589 | `2>/dev/null` without specific handling |
| `missing_return_files` | 2 | Files with functions lacking explicit `return` |

## Usage

```bash
# Advisory check (default — warns but doesn't block)
.agents/scripts/linters-local.sh

# Blocking check (for CI)
.agents/scripts/linters-local.sh --strict

# Lock in improvements after fixing violations
.agents/scripts/linters-local.sh --update-baseline

# Preview what would be written (no changes)
.agents/scripts/linters-local.sh --update-baseline --dry-run
```

## Output Format

```
PASS: bare_positional_params 4687 -> 4680 (improved by 7)
PASS: broad_catch_or_true 2233 (no change)
WARN: silent_errors 5589 -> 5592 (regressed by 3) — advisory only (use --strict to block)
```

## Runtime Testing

**Risk level:** Low — linter/CI config change, no runtime dependencies.

Self-assessed: all acceptance criteria verified via direct bash execution:
- `test -f .agents/configs/ratchets.json && jq .version .agents/configs/ratchets.json` → `1`
- `grep -c "ratchet" .agents/scripts/linters-local.sh` → `57`
- `jq '.ratchets | length' .agents/configs/ratchets.json` → `5`
- `shellcheck --severity=warning .agents/scripts/linters-local.sh` → exit 0

## Key Decisions

- **Advisory by default**: `--strict` required to block. Avoids disrupting productivity for existing violations.
- **Exception files**: Per-pattern `.txt` files subtract known false positives from raw counts.
- **5 patterns**: Chosen based on actual anti-patterns in build.txt error prevention rules.
- **Baseline set from current state**: No immediate failures — ratchets only prevent new regressions.

Closes #16898

---
[aidevops.sh](https://aidevops.sh) v3.6.1 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6