### PR TITLE
t1876: add instruction_to_save detection to session miner

### DIFF
--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -250,6 +250,29 @@ if git_summary:
             print(f'  {s[\"title\"][:60]} — {s[\"commits\"]} commits/{s[\"messages\"]} msgs '
                   f'(ratio: {s[\"ratio\"]:.2f}, {s[\"duration_min\"]:.0f}min)')
         print()
+
+# Instruction candidates
+instruction_candidates = data.get('instruction_candidates', {})
+total_candidates = sum(len(v) for v in instruction_candidates.values())
+if total_candidates > 0:
+    print('### Instruction Candidates')
+    print(f'  Total: {total_candidates} candidate(s) detected across sessions')
+    print()
+    for target_file, candidates in sorted(instruction_candidates.items()):
+        if not candidates:
+            continue
+        print(f'  Target: {target_file} ({len(candidates)} candidate(s))')
+        for c in candidates[:5]:
+            conf = c.get('confidence', 0)
+            cat = c.get('category', 'general')
+            text = c.get('text', '')[:120].replace('\n', ' ')
+            session = c.get('session_title', '')[:40]
+            print(f'    [{conf:.0%} {cat}] \"{text}\"')
+            if session:
+                print(f'      (from: {session})')
+        if len(candidates) > 5:
+            print(f'    ... and {len(candidates) - 5} more')
+        print()
 " 2>/dev/null
 	return $?
 }
@@ -432,6 +455,31 @@ if delta_lines:
     lines.extend(delta_lines)
 else:
     lines.append("- No count changes detected from previous pulse")
+
+# Instruction candidates section
+instruction_candidates = data.get("instruction_candidates", {})
+total_candidates = sum(len(v) for v in instruction_candidates.values())
+lines.extend(["", "## Instruction Candidates"])
+if total_candidates > 0:
+    lines.append(f"Total: {total_candidates} candidate(s) detected — review and add to instruction files as appropriate.")
+    lines.append("")
+    for target_file, candidates in sorted(instruction_candidates.items()):
+        if not candidates:
+            continue
+        lines.append(f"### {target_file} ({len(candidates)} candidate(s))")
+        for c in candidates[:10]:
+            conf = c.get("confidence", 0)
+            cat = c.get("category", "general")
+            text = c.get("text", "")[:200].replace("\n", " ")
+            session = c.get("session_title", "")[:60]
+            lines.append(f"- [{conf:.0%} / {cat}] {text}")
+            if session:
+                lines.append(f"  _(from session: {session})_")
+        if len(candidates) > 10:
+            lines.append(f"- ... and {len(candidates) - 10} more (see compressed_signals.json)")
+        lines.append("")
+else:
+    lines.append("- No instruction candidates detected in this pulse")
 
 report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 print(f"Generated {len(actions)} action candidates")

--- a/.agents/scripts/session-miner/compress.py
+++ b/.agents/scripts/session-miner/compress.py
@@ -11,6 +11,7 @@ Compression strategy:
 3. Strip file contents / diffs that were pasted (keep only the user's words)
 4. Group by category with frequency counts
 5. For errors: extract only the pattern (tool + error_category + recovery)
+6. For instruction candidates: deduplicate, group by target file, rank by confidence
 
 Target: <100KB total output that captures all unique signals.
 """
@@ -291,12 +292,57 @@ def compress_git_correlation(chunks_dir: Path) -> dict:
     }
 
 
+def compress_instruction_candidates(chunks_dir: Path) -> dict:
+    """Compress instruction candidate chunks into deduplicated, ranked summaries.
+
+    Groups by target file, deduplicates near-identical texts, and ranks by
+    confidence score. Returns a dict keyed by target file with candidate lists.
+    """
+    by_target: dict[str, list[dict]] = defaultdict(list)
+    seen: set[int] = set()
+
+    for chunk_file in sorted(chunks_dir.glob("instruction_candidate_*.json")):
+        try:
+            chunk = json.loads(chunk_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        for record in chunk.get("records", []):
+            raw_text = record.get("text", "")
+            if not raw_text or len(raw_text) < 20:
+                continue
+
+            # Deduplicate by normalized text
+            norm = re.sub(r"\s+", " ", raw_text.lower().strip())[:200]
+            norm_hash = hash(norm)
+            if norm_hash in seen:
+                continue
+            seen.add(norm_hash)
+
+            target_file = record.get("target_file", ".agents/prompts/build.txt")
+            by_target[target_file].append({
+                "text": raw_text[:800],
+                "confidence": record.get("confidence", 0.5),
+                "category": record.get("category", "general"),
+                "session_title": record.get("session_title", "")[:80],
+            })
+
+    # Sort each target's candidates by confidence descending
+    result: dict[str, list[dict]] = {}
+    for target_file, candidates in sorted(by_target.items()):
+        candidates.sort(key=lambda x: -x["confidence"])
+        result[target_file] = candidates
+
+    return result
+
+
 def main():
     print(f"Compressing chunks from {CHUNKS_DIR}", file=sys.stderr)
 
     steerage = compress_steerage(CHUNKS_DIR)
     errors = compress_errors(CHUNKS_DIR)
     git_correlation = compress_git_correlation(CHUNKS_DIR)
+    instruction_candidates = compress_instruction_candidates(CHUNKS_DIR)
 
     # Load stats
     stats_file = CHUNKS_DIR / "stats.json"
@@ -313,6 +359,8 @@ def main():
         "errors": errors,
         "stats": stats,
         "git_correlation": git_correlation,
+        "instruction_candidates": instruction_candidates,
+        "instruction_candidates_counts": {k: len(v) for k, v in instruction_candidates.items()},
     }
 
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
@@ -320,16 +368,23 @@ def main():
 
     total_steerage = sum(len(v) for v in steerage.values())
     total_errors = len(errors.get("patterns", []))
+    total_candidates = sum(len(v) for v in instruction_candidates.values())
     file_size = OUTPUT.stat().st_size
 
     print(f"Output: {OUTPUT}", file=sys.stderr)
     print(f"  {total_steerage} unique steerage signals", file=sys.stderr)
     print(f"  {total_errors} error patterns", file=sys.stderr)
+    print(f"  {total_candidates} instruction candidates", file=sys.stderr)
     print(f"  {file_size / 1024:.1f} KB", file=sys.stderr)
 
     # Print category breakdown
     for cat, signals in sorted(steerage.items(), key=lambda x: -len(x[1])):
         print(f"  steerage/{cat}: {len(signals)} unique signals", file=sys.stderr)
+
+    # Print instruction candidates breakdown
+    if instruction_candidates:
+        for target_file, candidates in sorted(instruction_candidates.items()):
+            print(f"  instruction_candidates/{target_file}: {len(candidates)} candidates", file=sys.stderr)
 
     # Print git correlation summary
     git_summary = git_correlation.get("summary", {})

--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -2,10 +2,12 @@
 """
 Session Miner — Phase 1: Extract high-signal data from coding assistant sessions.
 
-Extracts three categories of learning signal from local session databases:
+Extracts four categories of learning signal from local session databases:
 1. User steerage: corrections, preferences, guidance, workflow patterns
 2. Model errors: tool failures with surrounding context (what failed, what fixed it)
 3. Git correlation: cross-references sessions with git commit outcomes
+4. Instruction candidates: persistent guidance/corrections that should be saved to
+   instruction files (AGENTS.md, build.txt, style guides)
 
 Output format is tool-agnostic — works with OpenCode now, adaptable to
 Claude Code, Cursor, or any tool that stores session data.
@@ -99,6 +101,198 @@ ERROR_CATEGORIES = {
     "exit_code": re.compile(r"(exit code|exited with|ShellError)", re.IGNORECASE),
     "not_read_first": re.compile(r"must.*read.*before|without.*prior.*read", re.IGNORECASE),
 }
+
+
+# --- Instruction candidate detection ---
+#
+# Design: high precision over recall. Better to miss a candidate than to flood
+# with false positives. Only flag generalizable patterns, not task-specific
+# directions that reference particular files, PRs, or one-off commands.
+
+# Patterns that signal persistent/generalizable guidance
+INSTRUCTION_SIGNAL_PATTERNS = [
+    # Explicit save-to-instructions requests
+    r"\badd\s+(this|that)\s+to\s+(AGENTS\.md|build\.txt|the\s+style\s+guide|the\s+instructions?|the\s+rules?)\b",
+    r"\bupdate\s+(AGENTS\.md|build\.txt|the\s+style\s+guide|the\s+instructions?|the\s+rules?)\b",
+    r"\bremember\s+(this|that)\s+(rule|convention|preference|pattern|going\s+forward)\b",
+    # Persistent directive language
+    r"\bfrom\s+now\s+on\b",
+    r"\bgoing\s+forward\b",
+    r"\bin\s+future\s+sessions?\b",
+    r"\balways\s+(?:use|do|check|run|make|prefer|ensure|include|add|put|write|format|start|end|begin|avoid|skip|omit)\b",
+    r"\bnever\s+(?:use|do|create|make|add|commit|include|put|write|format|start|end|begin|guess|assume|hardcode)\b",
+    r"\bdon'?t\s+ever\s+\w+\b",
+    # Convention/rule declarations
+    r"\bthe\s+(?:rule|convention|standard|pattern|policy|practice)\s+is\b",
+    r"\bour\s+(?:rule|convention|standard|pattern|policy|practice)\s+is\b",
+    r"\bwe\s+(?:always|never|prefer|use|avoid)\b",
+    r"\bprefer\s+\w+\s+over\b",
+    r"\buse\s+\w+\s+instead\s+of\b",
+]
+
+# Patterns that indicate task-specific (non-generalizable) directions — these
+# are strong disqualifiers. If any match, the candidate is suppressed.
+TASK_SPECIFIC_DISQUALIFIERS = [
+    # References to specific files by path
+    r"(?:fix|edit|update|change|revert|delete|remove)\s+(?:the\s+)?(?:file\s+)?['\"]?[\w./\-]+\.\w{1,6}['\"]?",
+    # References to specific PRs, issues, commits
+    r"\b(?:PR|pull\s+request|issue|commit|branch)\s+#?\d+\b",
+    r"\bGH#\d+\b",
+    r"\bt\d{3,}\b",  # task IDs like t1876
+    # Undo/revert commands (one-off, not persistent)
+    r"\b(?:undo|revert|rollback|reset)\s+(?:that|this|the\s+last)\b",
+    # References to "this" specific instance without generalizing
+    r"\bthis\s+(?:specific|particular|one)\b",
+    # Imperative commands about the current task only
+    r"\bfor\s+(?:this|the\s+current)\s+(?:task|issue|PR|commit|session)\b",
+]
+
+# Compiled versions
+_INSTRUCTION_COMPILED = [re.compile(p, re.IGNORECASE) for p in INSTRUCTION_SIGNAL_PATTERNS]
+_DISQUALIFIER_COMPILED = [re.compile(p, re.IGNORECASE) for p in TASK_SPECIFIC_DISQUALIFIERS]
+
+# Target file heuristics — map content keywords to likely instruction files
+_TARGET_FILE_RULES: list[tuple[re.Pattern, str, str]] = [
+    (re.compile(r"\b(?:shell|bash|script|\.sh|shellcheck|function|local\s+var)\b", re.IGNORECASE),
+     ".agents/prompts/build.txt", "code_style"),
+    (re.compile(r"\b(?:AGENTS\.md|agent|subagent|prompt|instruction|build\.txt)\b", re.IGNORECASE),
+     ".agents/prompts/build.txt", "agent_instructions"),
+    (re.compile(r"\b(?:git|commit|branch|PR|worktree|merge|push|pull)\b", re.IGNORECASE),
+     ".agents/prompts/build.txt", "git_workflow"),
+    (re.compile(r"\b(?:style|format|markdown|emoji|tone|concise|verbose)\b", re.IGNORECASE),
+     ".agents/prompts/build.txt", "style"),
+    (re.compile(r"\b(?:security|secret|credential|token|key|password)\b", re.IGNORECASE),
+     ".agents/prompts/build.txt", "security"),
+    (re.compile(r"\b(?:test|lint|quality|verify|check|validate)\b", re.IGNORECASE),
+     ".agents/prompts/build.txt", "quality"),
+    (re.compile(r"\b(?:AGENTS\.md|workflow|process|lifecycle|routine)\b", re.IGNORECASE),
+     ".agents/AGENTS.md", "workflow"),
+]
+_TARGET_FILE_DEFAULT = (".agents/prompts/build.txt", "general")
+
+
+def _infer_target_file(text: str) -> tuple[str, str]:
+    """Infer the most likely instruction file and category for a candidate."""
+    for pattern, target_file, category in _TARGET_FILE_RULES:
+        if pattern.search(text):
+            return target_file, category
+    return _TARGET_FILE_DEFAULT
+
+
+def _score_instruction_candidate(text: str) -> float:
+    """Score a text for instruction-candidate confidence (0.0–1.0).
+
+    Higher score = more likely to be a generalizable persistent instruction.
+    Returns 0.0 if any disqualifier matches (task-specific direction).
+    """
+    # Hard disqualifiers — task-specific, not generalizable
+    for pattern in _DISQUALIFIER_COMPILED:
+        if pattern.search(text):
+            return 0.0
+
+    # Count signal pattern matches
+    signal_count = sum(1 for p in _INSTRUCTION_COMPILED if p.search(text))
+    if signal_count == 0:
+        return 0.0
+
+    # Boost for explicit save-to-instructions requests (first 2 patterns)
+    explicit_save = any(p.search(text) for p in _INSTRUCTION_COMPILED[:2])
+    base_score = min(0.5 + (signal_count * 0.15), 0.95)
+    if explicit_save:
+        base_score = min(base_score + 0.2, 0.99)
+
+    return round(base_score, 2)
+
+
+def classify_instruction_candidate(text: str) -> Optional[dict[str, Any]]:
+    """Classify user text as a potential instruction candidate.
+
+    Returns a dict with confidence and target_file, or None if not a candidate.
+    Conservative: only returns results with confidence >= 0.5.
+    """
+    if not text or len(text) < 20:
+        return None
+
+    confidence = _score_instruction_candidate(text)
+    if confidence < 0.5:
+        return None
+
+    target_file, category = _infer_target_file(text)
+    return {
+        "confidence": confidence,
+        "target_file": target_file,
+        "category": category,
+    }
+
+
+def extract_instruction_candidates(
+    conn: sqlite3.Connection, limit: Optional[int] = None,
+) -> list[dict]:
+    """Extract instruction candidate signals from user messages.
+
+    Identifies user utterances that appear to be persistent rules or conventions
+    that should be captured in instruction files (AGENTS.md, build.txt, etc.).
+
+    Conservative detection: high precision over recall. Task-specific directions
+    (referencing particular files, PRs, or one-off commands) are filtered out.
+
+    Returns:
+        List of instruction candidate records with text, confidence, target_file,
+        session context, and category.
+    """
+    print("Extracting instruction candidates...", file=sys.stderr)
+
+    query = """
+    SELECT
+        s.id as session_id,
+        s.title as session_title,
+        s.directory as session_dir,
+        m.id as message_id,
+        m.time_created as msg_time,
+        json_extract(m.data, '$.role') as role
+    FROM message m
+    JOIN session s ON m.session_id = s.id
+    WHERE json_extract(m.data, '$.role') = 'user'
+    ORDER BY m.time_created ASC
+    """
+    if limit:
+        query += f" LIMIT {int(limit) * 10}"
+
+    candidates: list[dict] = []
+    seen_texts: set[int] = set()
+
+    for row in conn.execute(query):
+        for text in _fetch_text_parts(conn, row["message_id"]):
+            if _is_automated_or_short(text):
+                continue
+
+            text_hash = hash(text[:200])
+            if text_hash in seen_texts:
+                continue
+            seen_texts.add(text_hash)
+
+            classification = classify_instruction_candidate(text)
+            if classification is None:
+                continue
+
+            candidates.append({
+                "type": "instruction_candidate",
+                "session_id": row["session_id"],
+                "session_title": row["session_title"] or "",
+                "session_dir": _sanitize_path(row["session_dir"] or ""),
+                "timestamp": row["msg_time"],
+                "text": text[:2000],
+                "confidence": classification["confidence"],
+                "target_file": classification["target_file"],
+                "category": classification["category"],
+            })
+
+            if limit and len(candidates) >= limit:
+                candidates = candidates[:limit]
+                break
+
+    print(f"  Found {len(candidates)} instruction candidates", file=sys.stderr)
+    return candidates
 
 
 def connect_db(db_path: Path) -> sqlite3.Connection:
@@ -829,6 +1023,7 @@ def _build_git_summary_chunk(git_correlations: list[dict]) -> dict:
 
 def build_chunks(steerage: list[dict], errors: list[dict], stats: dict,
                  git_correlations: Optional[list[dict]] = None,
+                 instruction_candidates: Optional[list[dict]] = None,
                  max_chunk_bytes: int = 80_000) -> list[dict]:
     """Build analysis-ready chunks that fit within model context.
 
@@ -872,6 +1067,16 @@ def build_chunks(steerage: list[dict], errors: list[dict], stats: dict,
 
         for batch_name, batch in [("productive", productive), ("unproductive", unproductive)]:
             _chunk_records(batch, "git", batch_name, chunks, max_chunk_bytes)
+
+    # Chunk instruction candidates by target file
+    if instruction_candidates:
+        by_target: dict[str, list[dict]] = defaultdict(list)
+        for record in instruction_candidates:
+            by_target[record["target_file"]].append(record)
+        for target, records in by_target.items():
+            # Use a safe key: replace path separators with underscores
+            safe_key = target.replace("/", "_").replace(".", "_")
+            _chunk_records(records, "instruction_candidate", safe_key, chunks, max_chunk_bytes)
 
     return chunks
 
@@ -952,14 +1157,18 @@ def main():
         if not args.no_git:
             git_correlations = extract_git_correlation(conn, limit=args.limit)
 
+        # Phase 1e: Extract instruction candidates
+        instruction_candidates = extract_instruction_candidates(conn, limit=args.limit)
+
         # Phase 2: Build chunks for model analysis
         if args.format == "chunks":
-            chunks = build_chunks(steerage, errors, stats, git_correlations)
+            chunks = build_chunks(steerage, errors, stats, git_correlations, instruction_candidates)
             out_path = write_output(chunks, args.output, fmt="chunks")
             print(f"\nOutput: {out_path}/", file=sys.stderr)
             print(f"  {len(chunks)} chunks written", file=sys.stderr)
             print(f"  {len(steerage)} steerage signals", file=sys.stderr)
             print(f"  {len(errors)} error sequences", file=sys.stderr)
+            print(f"  {len(instruction_candidates)} instruction candidates", file=sys.stderr)
             if git_correlations is not None:
                 productive = sum(1 for c in git_correlations if c["commits_count"] > 0)
                 print(f"  {len(git_correlations)} git correlations ({productive} productive)", file=sys.stderr)
@@ -967,14 +1176,16 @@ def main():
             all_records = [{"type": "stats", **stats}] + steerage + errors
             if git_correlations:
                 all_records.extend(git_correlations)
+            all_records.extend(instruction_candidates)
             out_path = write_output(all_records, args.output, fmt="jsonl")
             print(f"\nOutput: {out_path}", file=sys.stderr)
-            print(f"  {len(steerage)} steerage + {len(errors)} errors", file=sys.stderr)
+            print(f"  {len(steerage)} steerage + {len(errors)} errors + {len(instruction_candidates)} instruction candidates", file=sys.stderr)
 
         # Print summary to stdout
         summary = {
             "steerage_count": len(steerage),
             "error_count": len(errors),
+            "instruction_candidates_count": len(instruction_candidates),
             "steerage_categories": dict(
                 sorted(
                     defaultdict(int, {
@@ -995,6 +1206,20 @@ def main():
                 "total_commits": sum(c["commits_count"] for c in git_correlations),
                 "avg_commits_per_message": round(
                     sum(c["commits_per_message"] for c in productive) / max(len(productive), 1), 3,
+                ),
+            }
+        if instruction_candidates:
+            by_target: dict[str, int] = defaultdict(int)
+            by_category: dict[str, int] = defaultdict(int)
+            for c in instruction_candidates:
+                by_target[c["target_file"]] += 1
+                by_category[c["category"]] += 1
+            summary["instruction_candidates"] = {
+                "count": len(instruction_candidates),
+                "by_target_file": dict(sorted(by_target.items(), key=lambda x: -x[1])),
+                "by_category": dict(sorted(by_category.items(), key=lambda x: -x[1])),
+                "avg_confidence": round(
+                    sum(c["confidence"] for c in instruction_candidates) / len(instruction_candidates), 2,
                 ),
             }
         print(json.dumps(summary, indent=2))

--- a/.agents/tools/autoagent/autoagent/signal-mining.md
+++ b/.agents/tools/autoagent/autoagent/signal-mining.md
@@ -93,6 +93,54 @@ markdownlint-cli2 ~/.aidevops/agents/**/*.md 2>&1 | \
   grep -v "^$" | head -30
 ```
 
+### 7. Instruction Candidates (instruction-to-save)
+
+Detects user utterances from session history that appear to be persistent rules or
+conventions that should be captured in instruction files (AGENTS.md, build.txt, etc.).
+
+Sourced from the session miner pipeline — available in `compressed_signals.json` after
+a pulse run, and surfaced in the pulse summary under "Instruction Candidates".
+
+```bash
+# Read instruction candidates from latest compressed signals
+COMPRESSED=$(ls -t ~/.aidevops/.agent-workspace/work/session-miner/pulse_*/compressed_signals.json 2>/dev/null | head -1)
+[[ -n "$COMPRESSED" ]] && python3 -c "
+import json, sys
+from pathlib import Path
+data = json.loads(Path('$COMPRESSED').read_text())
+candidates = data.get('instruction_candidates', {})
+for target, items in candidates.items():
+    for c in items[:5]:
+        print(f'{target} [{c[\"confidence\"]:.0%}] {c[\"text\"][:120]}')
+" 2>/dev/null
+
+# Or read from the feedback report
+cat ~/.aidevops/.agent-workspace/work/session-miner/feedback_actions.md 2>/dev/null | \
+  awk '/## Instruction Candidates/,0'
+```
+
+**Detection criteria (conservative — high precision over recall):**
+
+- Explicit save requests: "add this to AGENTS.md", "update build.txt"
+- Persistent directive language: "from now on", "going forward", "always use X", "never do Y"
+- Convention declarations: "the rule is", "we always", "prefer X over Y"
+- Filtered out: task-specific directions referencing particular files, PRs, commits, or one-off commands
+
+**Finding format for instruction candidates:**
+
+```json
+{
+  "file": ".agents/prompts/build.txt",
+  "issue": "instruction-to-save: 'always use local var=\"$1\" in shell functions' (confidence: 90%)",
+  "source": "instruction-to-save",
+  "priority": "medium",
+  "frequency": 1
+}
+```
+
+Candidates are surfaced as suggestions only — never auto-applied. A human or the
+autoagent hypothesis loop decides whether to act on them.
+
 ## Finding Format
 
 Each source produces findings in this shape:
@@ -105,6 +153,7 @@ Each source produces findings in this shape:
 | Comprehension Tests | `.agents/path/to/agent.md` | test failure description | `comprehension-tests` |
 | Git Churn | `.agents/path/to/file.md` | high churn — N changes in 30 days | `git-churn` |
 | Linter | `.agents/scripts/helper.sh` | shellcheck SC2086: double-quote variable | `linter` |
+| Instruction Candidates | `.agents/prompts/build.txt` | instruction-to-save: user guidance text (confidence: N%) | `instruction-to-save` |
 
 ## Finding Aggregation
 
@@ -117,7 +166,8 @@ SIGNAL_FINDINGS = deduplicate_and_rank([
     error_feedback_findings,
     comprehension_test_findings,
     git_churn_findings,
-    linter_findings
+    linter_findings,
+    instruction_to_save_findings
 ])
 ```
 
@@ -141,6 +191,7 @@ When `SIGNAL_SOURCES` is set in the research program, only run the listed source
 | `comprehension-tests` | Comprehension test results |
 | `git-churn` | Git churn analysis |
 | `linter` | Linter violations |
+| `instruction-to-save` | Instruction candidates from session history |
 | `all` | All sources (default) |
 
 Example: `signal_sources: session-miner,git-churn` runs only those two sources.


### PR DESCRIPTION
## Summary

- Adds `extract_instruction_candidates()` to `extract.py` — conservative detection of user utterances that should be saved to instruction files. Filters task-specific directions (file refs, PR refs, one-off commands). Scores by signal pattern count; infers target file from content keywords.
- Adds `compress_instruction_candidates()` to `compress.py` — deduplicates and groups by target file, ranked by confidence. Adds `instruction_candidates` key to `compressed_signals.json`.
- Updates `session-miner-pulse.sh` — `generate_summary()` and `generate_feedback_actions()` now include an "Instruction Candidates" section when candidates are found.
- Adds source #7 `instruction-to-save` to `signal-mining.md` with detection criteria, finding format, bash query examples, and `SIGNAL_SOURCES` filter key.

## Verification

All acceptance criteria from issue #16896 confirmed:

- `instruction_candidates|instruction_to_save` pattern present in `extract.py` ✓
- `instruction_candidates` key present in `compress.py` output ✓
- `Instruction Candidates|instruction_candidates` present in `session-miner-pulse.sh` ✓
- `instruction-to-save` present in `signal-mining.md` ✓
- Task-specific disqualifiers filter file refs, PR refs, one-off commands ✓
- `shellcheck` zero violations, `python3 -c "import ast; ast.parse()"` clean ✓

Closes #16896

---
[aidevops.sh](https://aidevops.sh) v3.6.9 plugin for Claude Code with claude-sonnet-4-6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extraction and reporting of instruction candidates from session history—persistent user utterances suitable for documentation in instruction files.
  * Instruction candidates now appear in pulse summaries and feedback reports with confidence scoring and categorization.

* **Documentation**
  * Added documentation for the new "Instruction Candidates" signal source in signal mining workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->