### PR TITLE
t1873.4: headless-runtime-helper.sh: add ollama to provider_auth_available()

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -726,8 +726,8 @@ provider_auth_available() {
 		fi
 		return 1
 		;;
-	local)
-		# Local provider is always considered available (no auth needed)
+	local | ollama)
+		# Local/Ollama providers are always considered available (no auth needed — local daemon)
 		return 0
 		;;
 	*)


### PR DESCRIPTION
## What

Add `ollama` to the `provider_auth_available()` function in `headless-runtime-helper.sh`, alongside the existing `local` case. Ollama is a local daemon provider that requires no auth credentials, identical to the `local` provider.

## Change

```diff
-	local)
-		# Local provider is always considered available (no auth needed)
+	local | ollama)
+		# Local/Ollama providers are always considered available (no auth needed — local daemon)
 		return 0
 		;;
```

## Why

Without this, `provider_auth_available()` falls through to the `*` wildcard case for `ollama`. While the wildcard also returns 0, the explicit case makes the intent clear and consistent with how `local` is handled — both are local daemon providers with no auth requirement.

## Testing

<!-- MERGE_SUMMARY -->
**What:** One-line case pattern extension in `provider_auth_available()` — `local | ollama` replaces `local`.
**Issue:** Closes #16835
**Files changed:** `.agents/scripts/headless-runtime-helper.sh` (1 line)
**Testing:** ShellCheck clean (SC1091 info only — external file, not a violation). Logic: `ollama` now explicitly returns 0 from `provider_auth_available()` without relying on the wildcard fallthrough.
**Key decisions:** Used `local | ollama` pattern (POSIX case alternation) to keep both providers in a single case block — minimal diff, maximum clarity.

**Risk:** Low — docs/config-level change to a case statement. No logic change for any existing provider.

## Runtime Testing

`self-assessed` — Low risk. Single case pattern addition in a shell function. No runtime environment required; the change is structurally identical to the existing `local` case.

Closes #16835

---
[aidevops.sh](https://aidevops.sh) v3.6.9 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6