### PR TITLE
t1873.1: model-routing-table.json: add ollama provider entry

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -35,6 +35,14 @@
       "probe_path": "/v1/models",
       "probe_timeout_seconds": 10,
       "_comment": "API key OR OpenCode OAuth subscription (includes Codex). Auth checked via OPENAI_API_KEY env var or opencode auth.json."
+    },
+    "ollama": {
+      "endpoint": "http://localhost:11434/v1/chat/completions",
+      "key_env": null,
+      "probe_path": "/api/tags",
+      "probe_timeout_seconds": 3,
+      "min_context_length": 16384,
+      "_comment": "Ollama local model server. No API key needed. OpenAI-compatible API at /v1/. Use local-model-helper.sh status to check."
     }
   },
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Add `ollama` provider entry to `.agents/configs/model-routing-table.json` with:
- `endpoint`: `http://localhost:11434/v1/chat/completions` (Ollama's OpenAI-compatible API)
- `probe_path`: `/api/tags` (Ollama's native health/model-list endpoint)
- `probe_timeout_seconds`: `3` (local, fast timeout matching `local` provider)
- `min_context_length`: `16384`
- `key_env`: `null` (no API key required)

## Issue
Closes #16832

## Files Changed
- `.agents/configs/model-routing-table.json` — added `ollama` provider block (8 lines)

## Testing
**Risk level:** Low — config-only change, no executable code paths modified.

**Runtime Testing:** `self-assessed` — JSON validated with `jq`, no runtime required.

```
jq . .agents/configs/model-routing-table.json  # exit 0, valid JSON
```

## Key Decisions
- Placed `ollama` after `openai` in providers object (alphabetical proximity, logical grouping of local/cloud)
- Used `/api/tags` as probe path — this is Ollama's native endpoint that lists available models; more reliable than `/v1/models` which is an OpenAI-compat shim
- `probe_timeout_seconds: 3` matches the `local` provider (both are localhost, fast fail expected)
- `min_context_length: 16384` as specified in issue

---
[aidevops.sh](https://aidevops.sh) v3.6.9 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6