### PR TITLE
GH#16978: fix headless dispatch bugs — --cwd flag, session-not-found retry, claim comment leak

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1407,9 +1407,10 @@ _build_claude_cmd() {
 
 	# claude -p runs headless and prints output. --output-format stream-json
 	# gives structured output compatible with our result parsing.
+	# GH#16978: Claude CLI uses --cwd, not --directory (--directory is not a valid flag).
 	printf '%s\0' "claude" "-p" "$prompt" "--output-format" "stream-json" "--verbose"
 	if [[ -n "$work_dir" ]]; then
-		printf '%s\0' "--directory" "$work_dir"
+		printf '%s\0' "--cwd" "$work_dir"
 	fi
 	if [[ -n "$agent_name" ]]; then
 		printf '%s\0' "--agent" "$agent_name"
@@ -1621,6 +1622,38 @@ _execute_run_attempt() {
 		rm -f "${exit_code_file}.watchdog_killed"
 	fi
 	rm -f "$exit_code_file"
+
+	# GH#16978 Bug B: Stale session ID causes "Session not found" on OpenCode.
+	# When a persisted session ID is stale (e.g., from a previous OpenCode version
+	# or a different machine), OpenCode exits non-zero with "Session not found"
+	# instead of creating a new session. Detect this, clear the stale ID, and
+	# retry once without --session so a fresh session is created.
+	if [[ "$exit_code" -ne 0 && "$runtime" != "claude" && -n "$persisted_session" ]]; then
+		local output_text=""
+		output_text=$(cat "$output_file" 2>/dev/null || true)
+		if [[ "$output_text" == *"Session not found"* ]]; then
+			print_warning "Stale session ID detected for ${session_key} — clearing and retrying without --session (GH#16978)"
+			clear_session_id "$provider" "$session_key"
+			persisted_session=""
+			rm -f "$output_file"
+			output_file=$(mktemp)
+			exit_code_file=$(mktemp)
+			exit_code=0
+			# Rebuild command without the stale --session flag
+			cmd=()
+			while IFS= read -r -d '' arg; do
+				cmd+=("$arg")
+			done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
+				"$agent_name" "" "${extra_args[@]+"${extra_args[@]}"}")
+			_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
+			exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
+			if [[ -f "${exit_code_file}.watchdog_killed" ]]; then
+				exit_code=124
+				rm -f "${exit_code_file}.watchdog_killed"
+			fi
+			rm -f "$exit_code_file"
+		fi
+	fi
 
 	local handle_exit=0
 	if _handle_run_result "$exit_code" "$output_file" "$role" "$provider" "$session_key" "$selected_model"; then

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6058,6 +6058,19 @@ dispatch_with_dedup() {
 	# SIGTERM-ing all active workers.
 	local _claim_comment_id=""
 
+	# GH#16978 Bug C: Helper to clean up the DISPATCH_CLAIM comment on any
+	# early-return path after the claim succeeds. Previously the cleanup only
+	# ran on successful dispatch (line 6192), so any failure between claim and
+	# worker launch left a stale claim comment that accumulated over pulse cycles.
+	_cleanup_claim_comment() {
+		if [[ -n "$_claim_comment_id" ]]; then
+			gh api "repos/${repo_slug}/issues/comments/${_claim_comment_id}" \
+				--method DELETE >/dev/null 2>>"$LOGFILE" || true
+			_claim_comment_id=""
+		fi
+		return 0
+	}
+
 	# Hard stop for supervisor/telemetry issues (t1702 pulse guard).
 	# The pulse prompt should already avoid these, but this deterministic
 	# gate prevents dispatch when prompt fallback logic is too permissive.
@@ -6144,6 +6157,8 @@ dispatch_with_dedup() {
 		echo "[dispatch_with_dedup] No models configured — skipping dispatch for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--remove-assignee "$self_login" --remove-label "status:queued" 2>/dev/null || true
+		# GH#16978 Bug C: clean up claim comment on this early-return path
+		_cleanup_claim_comment
 		return 1
 	fi
 
@@ -6189,10 +6204,8 @@ dispatch_with_dedup() {
 	# dispatch comment is posted. The claim served its purpose (optimistic lock
 	# during the 8s consensus window). Leaving it pollutes the issue timeline —
 	# awardsapp #2051 had 29 stale claim comments.
-	if [[ -n "$_claim_comment_id" ]]; then
-		gh api "repos/${repo_slug}/issues/comments/${_claim_comment_id}" \
-			--method DELETE >/dev/null 2>>"$LOGFILE" || true
-	fi
+	# GH#16978: Use _cleanup_claim_comment helper (also called on early-return paths).
+	_cleanup_claim_comment
 
 	echo "[dispatch_with_dedup] Dispatched worker PID ${worker_pid} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 	return 0


### PR DESCRIPTION
## Summary

Three confirmed bugs in the headless dispatch pipeline, all identified in the issue review comment by @alex-solovyev.

### Bug A: `_build_claude_cmd` uses `--directory` (invalid Claude CLI flag)

**File**: `.agents/scripts/headless-runtime-helper.sh:1412`

The Claude CLI uses `--cwd` to set the working directory, not `--directory`. Every `--runtime claude` dispatch attempt failed immediately with `error: unknown option '--directory'`.

**Fix**: Replace `--directory` with `--cwd`.

### Bug B: Stale session IDs cause "Session not found" on OpenCode

**File**: `.agents/scripts/headless-runtime-helper.sh:_execute_run_attempt`

When a persisted session ID in the provider DB is stale (e.g., from a previous OpenCode version or a different machine), OpenCode exits non-zero with "Session not found" instead of creating a new session. The stale ID was never cleared, so every subsequent attempt also failed.

**Fix**: In `_execute_run_attempt`, after a non-zero exit from OpenCode when a persisted session was used, check the output for "Session not found". If detected: clear the stale session ID from the DB, rebuild the command without `--session`, and retry once. A fresh session is created on the retry.

### Bug C: DISPATCH_CLAIM comment leak on blocked dispatch

**File**: `.agents/scripts/pulse-wrapper.sh:dispatch_with_dedup`

The DISPATCH_CLAIM comment cleanup (GH#15317) only ran on the successful dispatch path (after the worker launched). If dispatch was blocked after the claim succeeded — specifically the "no models configured" early return — the claim comment was never deleted. Over multiple pulse cycles this accumulated stale claim comments on the issue.

**Fix**: Add `_cleanup_claim_comment()` helper inside `dispatch_with_dedup` that deletes the claim comment if `_claim_comment_id` is set. Call it at the "no models configured" early-return path, and replace the inline cleanup on the success path with the same helper.

## Files Changed

- `.agents/scripts/headless-runtime-helper.sh` — Bug A (--cwd) + Bug B (session-not-found retry)
- `.agents/scripts/pulse-wrapper.sh` — Bug C (claim comment leak)

## Runtime Testing

**Risk level**: Medium (dispatch infrastructure, no payment/auth/deletion paths)

- Bug A: Verified `claude --help` confirms `--cwd` is the correct flag; `--directory` is not listed.
- Bug B: Logic verified by code review — `clear_session_id` + retry path is consistent with existing `clear_session_id` usage for pulse role (line 1577).
- Bug C: Logic verified by code review — `_cleanup_claim_comment` is idempotent (clears `_claim_comment_id` after deletion), consistent with existing GH#15317 cleanup pattern.

No runtime environment available for end-to-end dispatch testing. Self-assessed.

Closes #16978

---
[aidevops.sh](https://aidevops.sh) v3.6.19 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6