### PR TITLE
GH#17021: fix CSS property name casing in startup-bold navigation component

### DIFF
--- a/.agents/tools/design/library/styles/startup-bold/04-components.md
+++ b/.agents/tools/design/library/styles/startup-bold/04-components.md
@@ -110,12 +110,12 @@ transition: all 200ms ease-out
 ## Navigation
 
 ```css
-Background: #ffffff
-Border bottom: 1px solid #e5e7eb
-Height: 64px
-Logo: Plus Jakarta Sans 700 wordmark, 20px, #111827
-Nav items: 15px Plus Jakarta Sans, 500, #6b7280
-Active item: #111827, font-weight: 600
-Hover item: #111827
-CTA in nav: small primary button with #4f46e5 background
+background: #ffffff
+border-bottom: 1px solid #e5e7eb
+height: 64px
+logo: Plus Jakarta Sans 700 wordmark, 20px, #111827
+nav-items: 15px Plus Jakarta Sans, 500, #6b7280
+active-item: #111827, font-weight: 600
+hover-item: #111827
+cta-in-nav: small primary button with #4f46e5 background
 ```


### PR DESCRIPTION
## Summary

- Normalise Navigation section CSS property names to lowercase/kebab-case
- Consistent with all other sections in the file (Buttons, Inputs, Links, Cards)
- No content removed — pure formatting fix

## Classification

**Reference corpus** (design library with CSS specifications). The correct action per issue guidance is to fix formatting inconsistencies, not compress content. The file is 121 lines and already well-structured.

## Change

**Before:** Navigation section used Title Case property names (`Background:`, `Border bottom:`, `Height:`, etc.)

**After:** Lowercase/kebab-case consistent with all other sections (`background:`, `border-bottom:`, `height:`, etc.)

## Runtime Testing

**Risk level:** Low — documentation/design reference file only. No executable code, no agent behaviour change.
**Verification:** `self-assessed` — all CSS values, hex colours, and font references preserved verbatim.

## Verification

- All code blocks present before and after ✓
- All CSS values, hex colours, font references unchanged ✓
- No content removed ✓
- Line count unchanged (121 lines) ✓

Closes #17021

---
[aidevops.sh](https://aidevops.sh) v3.6.19 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6