### PR TITLE
fix: consolidate worker counting for health issue accuracy

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2050,107 +2050,12 @@ This PR modifies \`.github/workflows/\` files but the GitHub OAuth token used by
 #
 # Output: worker summary to stdout (appended to STATE_FILE by caller)
 #######################################
-list_active_worker_processes() {
-	# t5072: Count logical workers (one per session/issue), not OS process tree nodes.
-	# A single opencode worker spawns a 3-process chain:
-	#   bash sandbox-exec-helper.sh run ... -- opencode run ...  (top-level launcher)
-	#   node /opt/homebrew/bin/opencode run ...                  (node child)
-	#   /path/to/.opencode run ...                               (binary grandchild)
-	# All three contain /full-loop (or /review-issue-pr) and opencode in their command line.
-	#
-	# GH#12361 / GH#14944: Workers may appear either as direct opencode
-	# processes or as headless-runtime-helper.sh wrappers around sandbox +
-	# opencode children. Counting must treat the whole wrapper/process tree as
-	# one logical worker. New approach:
-	#   1. Match worker processes launched via opencode OR
-	#      headless-runtime-helper.sh run --role worker.
-	#   2. Deduplicate by issue+dir key: when multiple processes share the
-	#      same issue AND --dir path, prefer the outermost launcher
-	#      (headless-runtime-helper.sh wrapper > sandbox launcher > child).
-	#      Different --dir paths = different logical workers even with the
-	#      same issue number.
-	#
-	# GH#6413: Process state filtering — exclude zombie (Z) and stopped (T)
-	# processes. These are dead/stuck processes that hold no useful work but
-	# appear as "active" in worker counts, inflating struggle ratios and
-	# preventing the pulse from dispatching replacements. The stat column is
-	# used for filtering only; output format remains pid,etime,command for
-	# backward compatibility with all consumers.
-	ps axo pid,stat,etime,command | awk '
-		{
-			is_headless_wrapper = ($0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/ && $0 ~ /(^|[[:space:]])run([[:space:]]|$)/ && $0 ~ /--role[[:space:]]+worker/)
-			has_worker_prompt = ($0 ~ /\/full-loop/ || $0 ~ /\/review-issue-pr/)
-			has_worker_binary = ($0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ || $0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/)
-
-			if (!(has_worker_prompt || is_headless_wrapper)) next
-			if ($0 ~ /(^|[[:space:]])\/pulse([[:space:]]|$)/) next
-			if ($0 ~ /Supervisor Pulse/) next
-			if (!has_worker_binary) next
-
-			# $2 is the stat column (e.g., S, SN, Ss, Z, Zs, T, TN)
-			stat = $2
-			# Exclude zombies (Z*) and stopped processes (T*)
-			if (stat ~ /^[ZT]/) next
-			# Build output line: pid, etime, command (skip stat)
-			line = $1 " " $3
-			for (i = 4; i <= NF; i++) line = line " " $i
-			# Extract issue number for dedup (matches "Issue #NNN" or "issue-NNN")
-			issue = ""
-			if (match($0, /[Ii]ssue[[:space:]]*#([0-9]+)/) || match($0, /issue-([0-9]+)/)) {
-				rest = substr($0, RSTART, RLENGTH)
-				gsub(/[^0-9]/, "", rest)
-				issue = rest
-			}
-			# Fallback: extract from --session-key issue-NNN when no Issue #/issue- marker
-			if (issue == "" && match($0, /--session-key[[:space:]]+issue-([0-9]+)/)) {
-				rest = substr($0, RSTART, RLENGTH)
-				gsub(/[^0-9]/, "", rest)
-				issue = rest
-			}
-			# Extract --dir path for dedup key (same issue in different repos
-			# = different logical workers)
-			dir = ""
-			if (match($0, /--dir[[:space:]]+[^[:space:]]+/)) {
-				dir = substr($0, RSTART, RLENGTH)
-				sub(/--dir[[:space:]]+/, "", dir)
-			}
-			dedup_key = issue "|" dir
-			# Prefer outer launchers over child processes for same issue+dir.
-			launcher_rank = 0
-			if ($0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/ && $0 ~ /--role[[:space:]]+worker/) {
-				launcher_rank = 2
-			} else if ($0 ~ /sandbox-exec-helper\.sh/) {
-				launcher_rank = 1
-			}
-			if (issue != "" && dedup_key in seen) {
-				# Already have a line for this issue+dir
-				if (launcher_rank > seen_launcher_rank[dedup_key]) {
-					# Replace inner child with outer launcher
-					seen_lines[dedup_key] = line
-					seen_launcher_rank[dedup_key] = launcher_rank
-				}
-				# Otherwise skip (lower-rank child of existing launcher, or duplicate)
-			} else if (issue != "") {
-				seen[dedup_key] = 1
-				seen_lines[dedup_key] = line
-				seen_launcher_rank[dedup_key] = launcher_rank
-				key_order[++key_count] = dedup_key
-			} else {
-				# No issue number found — print directly (edge case)
-				no_issue_lines[++no_issue_count] = line
-			}
-		}
-		END {
-			for (i = 1; i <= key_count; i++) {
-				print seen_lines[key_order[i]]
-			}
-			for (i = 1; i <= no_issue_count; i++) {
-				print no_issue_lines[i]
-			}
-		}
-	'
-	return 0
-}
+# list_active_worker_processes: now provided by worker-lifecycle-common.sh (sourced above).
+# Removed from pulse-wrapper.sh to eliminate divergence with stats-functions.sh.
+# See worker-lifecycle-common.sh for the canonical implementation with:
+#   - process chain deduplication (t5072)
+#   - headless-runtime-helper.sh wrapper support (GH#12361, GH#14944)
+#   - zombie/stopped process filtering (GH#6413)
 
 prefetch_active_workers() {
 	local worker_lines
@@ -2594,32 +2499,9 @@ guard_child_processes() {
 	return 0
 }
 
-#######################################
-# Check concurrent session count and warn (t1398)
-#
-# Counts running opencode/claude interactive sessions (those with a TTY).
-# If count exceeds SESSION_COUNT_WARN, logs a warning. This is informational
-# — the pulse doesn't kill user sessions, but the health issue will show it.
-#
-# Returns: session count via stdout
-#######################################
-check_session_count() {
-	local interactive_count=0
-
-	# Count opencode processes with a real TTY (interactive sessions).
-	# Filter both '?' (Linux) and '??' (macOS) headless TTY entries.
-	interactive_count=$(ps axo tty,command | awk '
-		/(\.(opencode|claude)|opencode-ai|claude-ai)/ && !/awk/ && $1 != "?" && $1 != "??" { count++ }
-		END { print count + 0 }
-	') || interactive_count=0
-
-	if [[ "$interactive_count" -gt "$SESSION_COUNT_WARN" ]]; then
-		echo "[pulse-wrapper] Session warning: $interactive_count interactive sessions open (threshold: $SESSION_COUNT_WARN). Each consumes 100-440MB + language servers. Consider closing unused tabs." >>"$LOGFILE"
-	fi
-
-	echo "$interactive_count"
-	return 0
-}
+# check_session_count: now provided by worker-lifecycle-common.sh (sourced above).
+# Removed from pulse-wrapper.sh to eliminate the duplicate. The shared version
+# returns the count; callers handle warning logs independently.
 
 #######################################
 # Run a command with a per-call timeout (t1482)
@@ -5634,16 +5516,8 @@ reap_zombie_workers() {
 	return 0
 }
 
-#######################################
-# Count active worker processes
-# Returns: count via stdout
-#######################################
-count_active_workers() {
-	local count
-	count=$(list_active_worker_processes | wc -l | tr -d ' ') || count=0
-	echo "$count"
-	return 0
-}
+# count_active_workers: now provided by worker-lifecycle-common.sh (sourced above).
+# Removed from pulse-wrapper.sh to eliminate divergence with stats-functions.sh.
 
 #######################################
 # Resolve managed repo path from slug
@@ -7975,7 +7849,11 @@ _run_preflight_stages() {
 
 	calculate_max_workers
 	calculate_priority_allocations
-	check_session_count >/dev/null
+	local _session_ct
+	_session_ct=$(check_session_count)
+	if [[ "${_session_ct:-0}" -gt "$SESSION_COUNT_WARN" ]]; then
+		echo "[pulse-wrapper] Session warning: $_session_ct interactive sessions open (threshold: $SESSION_COUNT_WARN). Each consumes 100-440MB + language servers. Consider closing unused tabs." >>"$LOGFILE"
+	fi
 
 	# Daily complexity scan (GH#5628): creates simplification-debt issues
 	# for .sh files with complex functions and .md agent docs exceeding size

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -67,31 +67,9 @@ _validate_repo_slug() {
 	return 1
 }
 
-#######################################
-# Count interactive AI sessions (duplicate of pulse-wrapper's check_session_count)
-#
-# Duplicated here (17 lines) rather than cross-sourcing pulse-wrapper.sh,
-# which would defeat the purpose of the extraction. See t1431 brief.
-#
-# Returns: session count via stdout
-#######################################
-check_session_count() {
-	local interactive_count=0
-
-	# Count opencode processes with a real TTY (interactive sessions).
-	# Filter both '?' (Linux) and '??' (macOS headless TTY entries.
-	interactive_count=$(ps axo tty,command | awk '
-		/(\.(opencode|claude)|opencode-ai|claude-ai)/ && !/awk/ && $1 != "?" && $1 != "??" { count++ }
-		END { print count + 0 }
-	') || interactive_count=0
-
-	if [[ "$interactive_count" -gt "$SESSION_COUNT_WARN" ]]; then
-		echo "[stats] Session warning: $interactive_count interactive sessions open (threshold: $SESSION_COUNT_WARN)" >>"$LOGFILE"
-	fi
-
-	echo "$interactive_count"
-	return 0
-}
+# check_session_count: now provided by worker-lifecycle-common.sh (sourced by caller).
+# Previously duplicated here (17 lines) — see t1431. Consolidated to eliminate
+# divergence risk and ensure single source of truth.
 
 #######################################
 # Determine runner role for a repo: supervisor or contributor
@@ -354,43 +332,46 @@ _resolve_health_issue_number() {
 #######################################
 # Scan active headless worker processes for a repo.
 #
+# Uses the shared list_active_worker_processes (worker-lifecycle-common.sh)
+# as the single source of truth for worker discovery, then filters by
+# repo path and formats as markdown for the health issue body.
+#
 # Arguments:
 #   $1 - repo path (used to filter workers by --dir)
-# Output: "workers_md|worker_count" (newline-delimited fields)
+# Output: NUL-delimited "workers_md\0worker_count\0"
 #######################################
 _scan_active_workers() {
 	local repo_path="$1"
 
 	local workers_md=""
 	local worker_count=0
+
+	# Get deduplicated, zombie-filtered worker list from shared function
 	local worker_lines
-	worker_lines=$(ps axo pid,tty,etime,command | grep '[.]opencode' | grep -v 'bash-language-server' || true)
+	worker_lines=$(list_active_worker_processes || true)
 
 	if [[ -n "$worker_lines" ]]; then
 		local worker_table=""
 		while IFS= read -r line; do
-			local w_pid w_tty w_etime w_cmd
-			read -r w_pid w_tty w_etime w_cmd <<<"$line"
+			[[ -z "$line" ]] && continue
+			local w_pid w_etime w_cmd
+			read -r w_pid w_etime w_cmd <<<"$line"
 
-			# Only count headless workers (no TTY).
-			# Exclude both '?' (Linux headless) and '??' (macOS headless).
-			[[ "$w_tty" != "?" && "$w_tty" != "??" ]] && continue
-
-			# Extract title if present (--title "...")
-			local w_title="headless"
-			if [[ "$w_cmd" =~ --title[[:space:]]+\"([^\"]+)\" ]] || [[ "$w_cmd" =~ --title[[:space:]]+([^[:space:]]+) ]]; then
-				w_title="${BASH_REMATCH[1]}"
-			fi
-
-			# Extract dir if present
+			# Extract dir if present — filter to this repo only
 			local w_dir=""
 			if [[ "$w_cmd" =~ --dir[[:space:]]+([^[:space:]]+) ]]; then
 				w_dir="${BASH_REMATCH[1]}"
 			fi
 
 			# Only include workers for this repo (or all if dir not detectable)
-			if [[ -n "$w_dir" && "$w_dir" != "$repo_path"* ]]; then
+			if [[ -n "$w_dir" && -n "$repo_path" && "$w_dir" != "$repo_path"* ]]; then
 				continue
+			fi
+
+			# Extract title if present (--title "...")
+			local w_title="headless"
+			if [[ "$w_cmd" =~ --title[[:space:]]+\"([^\"]+)\" ]] || [[ "$w_cmd" =~ --title[[:space:]]+([^[:space:]]+) ]]; then
+				w_title="${BASH_REMATCH[1]}"
 			fi
 
 			local w_title_short="${w_title:0:60}"
@@ -411,7 +392,8 @@ ${worker_table}"
 		workers_md="_No active workers_"
 	fi
 
-	printf '%s\n%s\n' "$workers_md" "$worker_count"
+	# NUL-delimited output preserves multiline workers_md markdown
+	printf '%s\0%s\0' "$workers_md" "$worker_count"
 	return 0
 }
 
@@ -504,27 +486,38 @@ _gather_health_stats() {
 	local repo_path="$2"
 	local runner_user="$3"
 
-	# Open PRs
+	# Open PRs — limit 100 for accurate count + table display.
+	# Previously --limit 20 capped the count at 20 for repos with more open PRs.
 	local pr_json
 	pr_json=$(gh pr list --repo "$repo_slug" --state open \
 		--json number,title,headRefName,updatedAt,reviewDecision,statusCheckRollup \
-		--limit 20 2>/dev/null) || pr_json="[]"
+		--limit 100 2>/dev/null) || pr_json="[]"
 	local pr_count
 	pr_count=$(echo "$pr_json" | jq 'length')
 
-	# Open issues — assigned to this runner (actionable) vs total
+	# Open issues — assigned to this runner (actionable) vs total.
+	# --limit 500: gh defaults to 30, which undercounts for active repos.
 	local assigned_issue_count
 	assigned_issue_count=$(gh issue list --repo "$repo_slug" --state open \
-		--assignee "$runner_user" --json number --jq 'length' 2>/dev/null || echo "0")
+		--assignee "$runner_user" --limit 500 \
+		--json number --jq 'length' 2>/dev/null || echo "0")
 	local total_issue_count
 	total_issue_count=$(gh issue list --repo "$repo_slug" --state open \
+		--limit 500 \
 		--json number,labels --jq '[.[] | select(.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review")) | not)] | length' 2>/dev/null || echo "0")
 
-	# Active headless workers
-	local worker_raw workers_md worker_count
-	worker_raw=$(_scan_active_workers "$repo_path")
-	workers_md=$(printf '%s\n' "$worker_raw" | head -1)
-	worker_count=$(printf '%s\n' "$worker_raw" | tail -1)
+	# Active headless workers — parse NUL-delimited output from _scan_active_workers.
+	# Previously used head -1 / tail -1 on newline-delimited output, which truncated
+	# the multiline workers_md markdown table to just its header row.
+	local workers_md="" worker_count=0
+	{
+		local _worker_fields=()
+		while IFS= read -r -d '' _wf; do
+			_worker_fields+=("$_wf")
+		done < <(_scan_active_workers "$repo_path")
+		workers_md="${_worker_fields[0]:-_No active workers_}"
+		worker_count="${_worker_fields[1]:-0}"
+	}
 
 	# System resources
 	local sys_raw sys_load_ratio sys_cpu_cores sys_load_1m sys_load_5m sys_memory sys_procs
@@ -537,19 +530,23 @@ _gather_health_stats() {
 		wt_count=$(git -C "$repo_path" worktree list 2>/dev/null | wc -l | tr -d ' ')
 	fi
 
-	# Max workers
+	# Max workers — validate as integer (matches pulse-wrapper's get_max_workers_target).
+	# Previously read raw file content without validation, risking garbage display.
 	local max_workers="?"
 	local max_workers_file="${HOME}/.aidevops/logs/pulse-max-workers"
 	if [[ -f "$max_workers_file" ]]; then
 		max_workers=$(cat "$max_workers_file" 2>/dev/null || echo "?")
+		[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers="?"
 	fi
 
-	# Interactive session count (t1398)
+	# Interactive session count (t1398) — uses shared check_session_count
+	# from worker-lifecycle-common.sh
 	local session_count
 	session_count=$(check_session_count)
 	local session_warning=""
 	if [[ "$session_count" -gt "$SESSION_COUNT_WARN" ]]; then
 		session_warning=" **WARNING: exceeds threshold of ${SESSION_COUNT_WARN}**"
+		echo "[stats] Session warning: $session_count interactive sessions open (threshold: $SESSION_COUNT_WARN)" >>"$LOGFILE"
 	fi
 
 	# PRs table
@@ -1063,8 +1060,12 @@ _update_health_issue_for_repo() {
 		guard_assigned_count=$(gh issue list --repo "$repo_slug" \
 			--assignee "$runner_user" --state open \
 			--json number --jq 'length' 2>/dev/null || echo "0")
-		guard_worker_output=$(_scan_active_workers "${repo_path:-}")
-		guard_worker_count="${guard_worker_output##*$'\n'}"
+		# Parse NUL-delimited output: workers_md\0worker_count\0
+		local _guard_fields=()
+		while IFS= read -r -d '' _gf; do
+			_guard_fields+=("$_gf")
+		done < <(_scan_active_workers "${repo_path:-}")
+		local guard_worker_count="${_guard_fields[1]:-0}"
 
 		if [[ "${guard_pr_count:-0}" -eq 0 && "${guard_assigned_count:-0}" -eq 0 && "${guard_worker_count:-0}" -eq 0 ]]; then
 			echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, issues, or workers" \

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -736,3 +736,141 @@ _format_duration() {
 	fi
 	return 0
 }
+
+#######################################
+# List active worker processes (logical, deduplicated).
+#
+# Moved here from pulse-wrapper.sh so that both pulse-wrapper.sh and
+# stats-functions.sh (via stats-wrapper.sh) use the same counting logic.
+# Previously, stats-functions.sh had a simpler _scan_active_workers that
+# missed headless-runtime-helper workers, didn't deduplicate process chains,
+# and didn't filter zombie/stopped processes — producing wrong worker counts
+# on the pinned health issue dashboards.
+#
+# t5072: Count logical workers (one per session/issue), not OS process tree nodes.
+# A single opencode worker spawns a 3-process chain:
+#   bash sandbox-exec-helper.sh run ... -- opencode run ...  (top-level launcher)
+#   node /opt/homebrew/bin/opencode run ...                  (node child)
+#   /path/to/.opencode run ...                               (binary grandchild)
+# All three contain /full-loop (or /review-issue-pr) and opencode in their command line.
+#
+# GH#12361 / GH#14944: Workers may appear either as direct opencode
+# processes or as headless-runtime-helper.sh wrappers around sandbox +
+# opencode children. Counting must treat the whole wrapper/process tree as
+# one logical worker.
+#
+# GH#6413: Process state filtering — exclude zombie (Z) and stopped (T)
+# processes.
+#
+# Output: one line per logical worker: "pid etime command..."
+#######################################
+list_active_worker_processes() {
+	ps axo pid,stat,etime,command | awk '
+		{
+			is_headless_wrapper = ($0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/ && $0 ~ /(^|[[:space:]])run([[:space:]]|$)/ && $0 ~ /--role[[:space:]]+worker/)
+			has_worker_prompt = ($0 ~ /\/full-loop/ || $0 ~ /\/review-issue-pr/)
+			has_worker_binary = ($0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ || $0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/)
+
+			if (!(has_worker_prompt || is_headless_wrapper)) next
+			if ($0 ~ /(^|[[:space:]])\/pulse([[:space:]]|$)/) next
+			if ($0 ~ /Supervisor Pulse/) next
+			if (!has_worker_binary) next
+
+			# $2 is the stat column (e.g., S, SN, Ss, Z, Zs, T, TN)
+			stat = $2
+			# Exclude zombies (Z*) and stopped processes (T*)
+			if (stat ~ /^[ZT]/) next
+			# Build output line: pid, etime, command (skip stat)
+			line = $1 " " $3
+			for (i = 4; i <= NF; i++) line = line " " $i
+			# Extract issue number for dedup (matches "Issue #NNN" or "issue-NNN")
+			issue = ""
+			if (match($0, /[Ii]ssue[[:space:]]*#([0-9]+)/) || match($0, /issue-([0-9]+)/)) {
+				rest = substr($0, RSTART, RLENGTH)
+				gsub(/[^0-9]/, "", rest)
+				issue = rest
+			}
+			# Fallback: extract from --session-key issue-NNN when no Issue #/issue- marker
+			if (issue == "" && match($0, /--session-key[[:space:]]+issue-([0-9]+)/)) {
+				rest = substr($0, RSTART, RLENGTH)
+				gsub(/[^0-9]/, "", rest)
+				issue = rest
+			}
+			# Extract --dir path for dedup key (same issue in different repos
+			# = different logical workers)
+			dir = ""
+			if (match($0, /--dir[[:space:]]+[^[:space:]]+/)) {
+				dir = substr($0, RSTART, RLENGTH)
+				sub(/--dir[[:space:]]+/, "", dir)
+			}
+			dedup_key = issue "|" dir
+			# Prefer outer launchers over child processes for same issue+dir.
+			launcher_rank = 0
+			if ($0 ~ /(^|[[:space:]\/])headless-runtime-helper\.sh([[:space:]]|$)/ && $0 ~ /--role[[:space:]]+worker/) {
+				launcher_rank = 2
+			} else if ($0 ~ /sandbox-exec-helper\.sh/) {
+				launcher_rank = 1
+			}
+			if (issue != "" && dedup_key in seen) {
+				# Already have a line for this issue+dir
+				if (launcher_rank > seen_launcher_rank[dedup_key]) {
+					# Replace inner child with outer launcher
+					seen_lines[dedup_key] = line
+					seen_launcher_rank[dedup_key] = launcher_rank
+				}
+				# Otherwise skip (lower-rank child of existing launcher, or duplicate)
+			} else if (issue != "") {
+				seen[dedup_key] = 1
+				seen_lines[dedup_key] = line
+				seen_launcher_rank[dedup_key] = launcher_rank
+				key_order[++key_count] = dedup_key
+			} else {
+				# No issue number found — print directly (edge case)
+				no_issue_lines[++no_issue_count] = line
+			}
+		}
+		END {
+			for (i = 1; i <= key_count; i++) {
+				print seen_lines[key_order[i]]
+			}
+			for (i = 1; i <= no_issue_count; i++) {
+				print no_issue_lines[i]
+			}
+		}
+	'
+	return 0
+}
+
+#######################################
+# Count active worker processes
+# Returns: count via stdout
+#######################################
+count_active_workers() {
+	local count
+	count=$(list_active_worker_processes | wc -l | tr -d ' ') || count=0
+	echo "$count"
+	return 0
+}
+
+#######################################
+# Count interactive AI sessions (t1398)
+#
+# Counts opencode/claude processes with a real TTY (interactive sessions).
+# Shared between pulse-wrapper.sh and stats-functions.sh.
+#
+# Arguments: none
+# Returns: session count via stdout
+#######################################
+check_session_count() {
+	local interactive_count=0
+
+	# Count opencode processes with a real TTY (interactive sessions).
+	# Filter both '?' (Linux) and '??' (macOS) headless TTY entries.
+	interactive_count=$(ps axo tty,command | awk '
+		/(\.(opencode|claude)|opencode-ai|claude-ai)/ && !/awk/ && $1 != "?" && $1 != "??" { count++ }
+		END { print count + 0 }
+	') || interactive_count=0
+
+	echo "$interactive_count"
+	return 0
+}


### PR DESCRIPTION
## Summary

- Consolidates `list_active_worker_processes`, `count_active_workers`, and `check_session_count` into `worker-lifecycle-common.sh` as single source of truth — eliminates divergence between pulse dispatch counts and health issue dashboard counts
- Fixes workers markdown table truncation (`head -1` on multiline output only showed the header row)
- Raises `gh issue list` limit from default 30 to 500 and `gh pr list` from 20 to 100 for accurate counts on active repos
- Adds integer validation for max_workers file read (matching pulse-wrapper's `get_max_workers_target`)

## Bugs Fixed

| # | Stat | Bug | Severity |
|---|---|---|---|
| 1 | Active Workers count | `_scan_active_workers` triple-counted process chains, missed headless-runtime-helper workers, included zombies | Critical |
| 2 | Active Workers table | `head -1` on multiline markdown table only captured header row | High |
| 3 | Assigned/Total Issues | `gh issue list` default `--limit 30` undercounted for active repos | Medium |
| 4 | Max Workers | Read file without integer validation, could display garbage | Low |
| 5 | Duplicated functions | 3 functions duplicated between pulse-wrapper.sh and stats-functions.sh | Low/debt |

## Testing

- 48/48 existing tests pass (worker-count + worker-detection suites)
- ShellCheck clean on all 3 modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated worker process detection logic into shared utilities for improved consistency.
  * Enhanced health statistics gathering with better process accuracy and deduplication.
  * Increased data collection limits for more comprehensive health monitoring.
  * Improved validation of worker configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->