### PR TITLE
GH#17059: add cache-health command to observability-helper

### DIFF
--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -542,11 +542,122 @@ cmd_rate_limits() {
 	return 0
 }
 
+# =============================================================================
+# Cache Health Check (t1858)
+# =============================================================================
+# Queries the SQLite DB for prompt cache hit rates per model over a time window.
+# Flags models where cache_read / (cache_read + input) drops below a threshold.
+# Designed for: manual spot-checks, pulse integration, and session greeting.
+
+readonly DEFAULT_CACHE_THRESHOLD=90
+readonly DEFAULT_CACHE_WINDOW_HOURS=24
+
+cmd_cache_health() {
+	local json_flag=false threshold="$DEFAULT_CACHE_THRESHOLD" window_hours="$DEFAULT_CACHE_WINDOW_HOURS"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		--threshold)
+			threshold="${2:-$DEFAULT_CACHE_THRESHOLD}"
+			shift 2
+			;;
+		--window)
+			window_hours="${2:-$DEFAULT_CACHE_WINDOW_HOURS}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	local obs_db="${OBS_DIR}/llm-requests.db"
+	[[ -f "$obs_db" ]] || {
+		print_error "SQLite DB not found at $obs_db"
+		return 1
+	}
+	command -v sqlite3 &>/dev/null || {
+		print_error "sqlite3 required"
+		return 1
+	}
+
+	# Single query: per-model cache stats over the window, only for providers
+	# with Anthropic-style prompt caching (cache_read > 0 somewhere).
+	local result
+	result=$(sqlite3 -separator '|' "$obs_db" "
+		SELECT
+			model_id,
+			COUNT(*) AS requests,
+			SUM(tokens_cache_read) AS cache_read,
+			SUM(tokens_cache_write) AS cache_write,
+			SUM(tokens_input) AS uncached_input,
+			ROUND(
+				CAST(SUM(tokens_cache_read) AS REAL)
+				/ NULLIF(SUM(tokens_cache_read) + SUM(tokens_input), 0) * 100, 1
+			) AS cache_pct
+		FROM llm_requests
+		WHERE timestamp > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${window_hours} hours')
+		GROUP BY model_id
+		HAVING SUM(tokens_cache_read) + SUM(tokens_cache_write) > 0
+		ORDER BY requests DESC;
+	" 2>/dev/null) || result=""
+
+	[[ -z "$result" ]] && {
+		if [[ "$json_flag" == "true" ]]; then
+			echo '{"status":"ok","models":[],"message":"No cacheable requests in window"}'
+		else
+			print_info "No cacheable requests in the last ${window_hours}h"
+		fi
+		return 0
+	}
+
+	local overall_status="ok" degraded_models=""
+
+	if [[ "$json_flag" == "true" ]]; then
+		local json_arr="[" first=true
+		while IFS='|' read -r model reqs cr cw ui pct; do
+			[[ -z "$model" ]] && continue
+			local status="ok"
+			if [[ -n "$pct" ]] && awk "BEGIN { exit !($pct < $threshold) }"; then
+				status="degraded"
+				overall_status="degraded"
+			fi
+			[[ "$first" == "true" ]] || json_arr="${json_arr},"
+			first=false
+			json_arr="${json_arr}{\"model\":\"${model}\",\"requests\":${reqs:-0},\"cache_read\":${cr:-0},\"cache_write\":${cw:-0},\"uncached_input\":${ui:-0},\"cache_pct\":${pct:-0},\"status\":\"${status}\"}"
+		done <<<"$result"
+		echo "{\"status\":\"${overall_status}\",\"threshold\":${threshold},\"window_hours\":${window_hours},\"models\":${json_arr}]}"
+	else
+		printf "\nPrompt Cache Health (%sh window, threshold %s%%)\n" "$window_hours" "$threshold"
+		printf "  %-30s %8s %12s %12s %7s %s\n" "Model" "Requests" "Cache Read" "Uncached" "Hit %" "Status"
+		while IFS='|' read -r model reqs cr cw ui pct; do
+			[[ -z "$model" ]] && continue
+			local status="${GREEN}ok${NC}"
+			if [[ -n "$pct" ]] && awk "BEGIN { exit !($pct < $threshold) }"; then
+				status="${YELLOW}DEGRADED${NC}"
+				overall_status="degraded"
+				degraded_models="${degraded_models}${model} (${pct}%), "
+			fi
+			printf "  %-30s %8s %12s %12s %6s%% %b\n" "$model" "$reqs" "$cr" "$ui" "$pct" "$status"
+		done <<<"$result"
+		echo ""
+		if [[ "$overall_status" == "degraded" ]]; then
+			print_warning "Cache degradation: ${degraded_models%, }"
+		else
+			print_success "All models above ${threshold}% cache hit rate"
+		fi
+	fi
+
+	[[ "$overall_status" == "ok" ]] && return 0
+	return 1
+}
+
 cmd_help() {
 	cat <<EOF
 Observability Helper — LLM request tracking via JSONL log
 Usage: observability-helper.sh [command] [options]
-Commands: ingest | record (--model X) | rate-limits (--json, --provider, --window) | help
+Commands: ingest | record (--model X) | rate-limits (--json, --provider, --window) | cache-health (--json, --threshold, --window) | help
 
 Record options:
   --model MODEL          Model name (required)
@@ -573,6 +684,7 @@ main() {
 	case "$command" in
 	ingest | parse | import) cmd_ingest "$@" ;; record | r) cmd_record "$@" ;;
 	rate-limits | rate_limits | ratelimits | rl) cmd_rate_limits "$@" ;;
+	cache-health | cache_health | ch) cmd_cache_health "$@" ;;
 	help | --help | -h) cmd_help ;; *)
 		print_error "Unknown: $command"
 		cmd_help


### PR DESCRIPTION
## Summary

- Adds `cache-health` command to `observability-helper.sh` for monitoring prompt cache hit rates per model
- Queries existing SQLite observability DB — zero new dependencies, ~80 lines
- Flags models dropping below configurable threshold (default 90%), exit code 1 on degradation for alerting integration

## Motivation

Prompted by three prompt-cache stability PRs merged in openclaw (Claude Code) today:
- [openclaw#58037](https://github.com/openclaw/openclaw/pull/58037) — sort MCP tools deterministically
- [openclaw#58036](https://github.com/openclaw/openclaw/pull/58036) — compact newest tool results first
- [openclaw#58038](https://github.com/openclaw/openclaw/pull/58038) — delay image pruning to preserve prefix

Our cache rates are currently excellent (100% 24h / 94% 7d), but we had no way to detect regressions. This command provides that.

Also commented on [OpenCode PR #14743](https://github.com/anomalyco/opencode/pull/14743#issuecomment-4186284607) noting that MCP tool ordering (`mcp/index.ts:603`) has the same nondeterminism bug that the PR fixes for skill tools.

## Usage

```bash
observability-helper.sh cache-health                    # table, 90% threshold, 24h
observability-helper.sh cache-health --json             # machine-readable
observability-helper.sh cache-health --threshold 95     # stricter threshold
observability-helper.sh cache-health --window 168       # 7-day window
observability-helper.sh ch                              # alias
```

## Verification

- Tested against live DB: table output, JSON output, threshold triggering, empty-window handling
- ShellCheck clean (only SC1091 for external source, expected)
- Exit code 0 when healthy, 1 when degraded


---
[aidevops.sh](https://aidevops.sh) v3.6.21 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 25m and 7,783 tokens on this as a headless worker.