### PR TITLE
GH#17039: tighten Agency Techie component stylings doc

### DIFF
--- a/.agents/tools/design/library/styles/agency-techie/04-components.md
+++ b/.agents/tools/design/library/styles/agency-techie/04-components.md
@@ -5,67 +5,43 @@
 
 ## Buttons
 
-**Primary Button**
+Shared base: `font: 14px/1 Inter, 500` · `padding: 10px 20px` · `border-radius: 4px` · `:focus → outline: 2px solid #22d3ee; outline-offset: 2px`
+
+**Primary**
 
 ```css
-background: #22d3ee
-color: #0d1117
-font: 14px/1 Inter, 500
-padding: 10px 20px
-border: none
-border-radius: 4px
+background: #22d3ee; color: #0d1117; border: none
 transition: all 150ms ease-out
-
-:hover    → background: #06b6d4; box-shadow: 0 0 12px rgba(34, 211, 238, 0.2)
+:hover    → background: #06b6d4; box-shadow: 0 0 12px rgba(34,211,238,0.2)
 :active   → background: #0891b2; transform: translateY(1px)
-:focus    → outline: 2px solid #22d3ee; outline-offset: 2px
 :disabled → background: #164e63; color: #475569; cursor: not-allowed
 ```
 
-**Secondary Button**
+**Secondary**
 
 ```css
-background: transparent
-color: #e2e8f0
-font: 14px/1 Inter, 500
-padding: 10px 20px
-border: 1px solid #1e293b
-border-radius: 4px
-
+background: transparent; color: #e2e8f0; border: 1px solid #1e293b
 :hover    → border-color: #334155; background: rgba(255,255,255,0.03)
 :active   → background: rgba(255,255,255,0.06)
-:focus    → outline: 2px solid #22d3ee; outline-offset: 2px
 :disabled → color: #475569; border-color: #162032; cursor: not-allowed
 ```
 
-**Ghost Button**
+**Ghost**
 
 ```css
-background: transparent
-color: #94a3b8
-font: 14px/1 Inter, 500
-padding: 10px 20px
-border: none
-border-radius: 4px
-
-:hover    → color: #e2e8f0; background: rgba(34, 211, 238, 0.08)
-:active   → background: rgba(34, 211, 238, 0.12)
-:focus    → outline: 2px solid #22d3ee; outline-offset: 2px
+background: transparent; color: #94a3b8; border: none
+:hover  → color: #e2e8f0; background: rgba(34,211,238,0.08)
+:active → background: rgba(34,211,238,0.12)
 ```
 
 ## Inputs
 
 ```css
-background: #161b22
-color: #e2e8f0
-font: 14px JetBrains Mono (for code inputs) or Inter (for text inputs)
-padding: 10px 14px
-border: 1px solid #1e293b
-border-radius: 4px
-
+background: #161b22; color: #e2e8f0; border: 1px solid #1e293b
+font: 14px JetBrains Mono (code) or Inter (text); padding: 10px 14px; border-radius: 4px
 ::placeholder → color: #475569
 :hover        → border-color: #334155
-:focus        → border-color: #22d3ee; box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.1)
+:focus        → border-color: #22d3ee; box-shadow: 0 0 0 3px rgba(34,211,238,0.1)
 :invalid      → border-color: #f87171
 :disabled     → background: #0d1117; color: #475569
 ```
@@ -73,10 +49,7 @@ border-radius: 4px
 ## Links
 
 ```css
-color: #22d3ee
-text-decoration: none
-transition: color 150ms ease-out
-
+color: #22d3ee; text-decoration: none; transition: color 150ms ease-out
 :hover  → color: #67e8f9; text-decoration: underline
 :active → color: #06b6d4
 ```
@@ -84,22 +57,16 @@ transition: color 150ms ease-out
 ## Cards
 
 ```css
-background: #161b22
-border: 1px solid #1e293b
-border-radius: 6px
-padding: 20px
-transition: border-color 150ms ease-out
-
+background: #161b22; border: 1px solid #1e293b; border-radius: 6px
+padding: 20px; transition: border-color 150ms ease-out
 :hover → border-color: #334155
 ```
 
 ## Navigation
 
 ```css
-Background: #0d1117
-Border bottom: 1px solid #1e293b
-Height: 56px
-Logo: left-aligned, 24px mono wordmark
-Nav items: 14px Inter, 500, #94a3b8
-Active item: #e2e8f0, border-bottom: 2px solid #22d3ee
+background: #0d1117; border-bottom: 1px solid #1e293b; height: 56px
+logo: left-aligned, 24px mono wordmark
+nav items: 14px Inter, 500, #94a3b8
+active item: #e2e8f0; border-bottom: 2px solid #22d3ee
 ```


### PR DESCRIPTION
## Summary

- Consolidate shared button base properties (font, padding, border-radius, focus) into a single prose line above the three button variants
- Inline single-property CSS declarations to reduce vertical whitespace
- Remove redundant blank lines between state pseudo-selectors

## Changes

- `.agents/tools/design/library/styles/agency-techie/04-components.md`: 105 → 72 lines (31% reduction)

## Content Preservation

All CSS values, color codes (`#22d3ee`, `#0d1117`, `#161b22`, etc.), state variants (`:hover`, `:active`, `:focus`, `:disabled`, `::placeholder`, `:invalid`), and component specs (Buttons, Inputs, Links, Cards, Navigation) are preserved verbatim.

## Classification

Reference corpus (CSS design token spec) — not an instruction doc. Tightened prose/whitespace, not content.

## Runtime Testing

Risk: **Low** — documentation-only change, no executable code modified.
Assessment: `self-assessed` — no runtime environment required.

Closes #17039

---
<!-- MERGE_SUMMARY -->
**What:** Tighten Agency Techie component stylings reference doc (04-components.md)
**Issue:** #17039
**Files changed:** 1 (`.agents/tools/design/library/styles/agency-techie/04-components.md`)
**Testing:** Documentation-only, self-assessed
**Key decisions:** Classified as reference corpus; consolidated shared button base into prose header; inlined single-line CSS blocks

---
[aidevops.sh](https://aidevops.sh) v3.6.25 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6