### PR TITLE
t17069: fix: strip SPDX comment headers before validating .json.txt templates

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -145,12 +145,14 @@ jobs:
         done < <(git ls-files '*.json')
 
         # Also validate .json.txt template files
+        # These files may contain SPDX license header comments (lines starting with #)
+        # which are stripped before JSON validation.
         while IFS= read -r file; do
-          if python3 -m json.tool "$file" > /dev/null 2>&1; then
+          if grep -v '^#' "$file" | python3 -m json.tool > /dev/null 2>&1; then
             echo "✅ $file"
           else
             echo "❌ $file - invalid JSON"
-            python3 -m json.tool "$file" 2>&1 | head -5
+            grep -v '^#' "$file" | python3 -m json.tool 2>&1 | head -5
             errors=$((errors + 1))
           fi
         done < <(git ls-files '*.json.txt')


### PR DESCRIPTION
## Summary

- JSON config template files (`.json.txt`) contain SPDX license header comments (`# SPDX-License-Identifier: MIT`) which are valid for template files but not valid JSON
- The CI `JSON Config Validation` step was passing these files directly to `python3 -m json.tool` without stripping comments, causing 69 failures
- Fix: pipe through `grep -v '^#'` before validation to strip comment-only lines while preserving the SPDX headers in the actual files

## Root Cause

`.github/workflows/code-quality.yml` line 148-156: the `.json.txt` validation loop used `python3 -m json.tool "$file"` directly. All 57 `configs/*.json.txt` and 12 `.agents/configs/*.json.txt` files have SPDX headers, making them fail JSON parsing.

## Verification

Tested locally: all 69 `.json.txt` files pass with the comment-stripping fix applied.

Closes #17069

---

---
[aidevops.sh](https://aidevops.sh) v3.6.25 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6