### PR TITLE
GH#17086: tighten OpenCode component stylings doc

### DIFF
--- a/.agents/tools/design/library/brands/opencode.ai/04-components.md
+++ b/.agents/tools/design/library/brands/opencode.ai/04-components.md
@@ -6,63 +6,42 @@
 ## Buttons
 
 **Primary (Dark Fill)**
-- Background: `#201d1d` (OpenCode Dark)
-- Text: `#fdfcfc` (OpenCode Light)
-- Padding: 4px 20px
-- Radius: 4px
-- Font: 16px Berkeley Mono, weight 500, line-height 2.00 (relaxed)
+- Background: `#201d1d` · Text: `#fdfcfc`
+- Padding: 4px 20px · Radius: 4px
+- Font: 16px Berkeley Mono, weight 500, line-height 2.00
 - Outline: `rgb(253, 252, 252) none 0px`
-- Use: Primary CTAs, main actions
 
 ## Inputs
 
-**Email Input**
-- Background: `#f8f7f7` (light neutral)
-- Text: `#201d1d`
+**Text/Email**
+- Background: `#f8f7f7` · Text: `#201d1d`
 - Border: `1px solid rgba(15, 0, 0, 0.12)`
-- Padding: 20px
-- Radius: 6px
-- Font: Berkeley Mono, standard size
-- Use: Form fields, email capture
+- Padding: 20px · Radius: 6px · Font: Berkeley Mono
 
 ## Links
 
-**Default Link**
-- Color: `#201d1d`
-- Decoration: underline 1px
-- Font-weight: 500
-- Use: Primary text links in body content
+**Default** — `#201d1d`, underline 1px, weight 500
 
-**Light Link**
-- Color: `#fdfcfc`
-- Decoration: none
-- Use: Links on dark backgrounds, navigation
+**Light** — `#fdfcfc`, no decoration (dark backgrounds, nav)
 
-**Muted Link**
-- Color: `#9a9898`
-- Decoration: none
-- Use: Footer links, secondary navigation
+**Muted** — `#9a9898`, no decoration (footer, secondary nav)
 
 ## Tabs
 
 **Tab Navigation**
-- Border-bottom: `2px solid #9a9898` (active tab indicator)
+- Border-bottom: `2px solid #9a9898` (active indicator)
 - Font: 16px, weight 500, line-height 1.00
-- Use: Section switching, content filtering
 
 ## Navigation
 
-- Clean horizontal layout with Berkeley Mono throughout
-- Brand logotype left-aligned in monospace
-- Links at 16px weight 500 with underline decoration
-- Dark background matching page background
-- No backdrop blur or transparency -- solid surfaces only
+- Horizontal layout, Berkeley Mono throughout
+- Brand logotype left-aligned; links 16px weight 500 with underline
+- Solid dark background — no blur or transparency
 
 ## Image Treatment
 
 - Terminal/code screenshots as hero imagery
-- Dark terminal aesthetic with monospace type
-- Minimal borders, content speaks for itself
+- Dark terminal aesthetic, monospace type, minimal borders
 
 ## Distinctive Components
 
@@ -70,16 +49,12 @@
 - Full-width dark terminal window as hero element
 - ASCII art / stylized logo within terminal frame
 - Monospace command examples with syntax highlighting
-- Reinforces the CLI-first identity of the product
 
 **Feature List**
-- Bulleted feature items with Berkeley Mono text
 - Weight 500 for feature names, 400 for descriptions
-- Tight vertical spacing between items
-- No cards or borders -- pure text layout
+- Tight vertical spacing; no cards or borders
 
 **Email Capture**
-- Light background input (`#f8f7f7`) contrasting dark page
-- Generous 20px padding for comfortable typing
-- 6px radius -- the roundest element in the system
+- Light input (`#f8f7f7`) contrasting dark page
+- 20px padding · 6px radius (roundest element in system)
 - Newsletter/waitlist pattern


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/design/library/brands/opencode.ai/04-components.md` from 85 to 60 lines (29% reduction).

Closes #17086

## What changed

- Removed redundant `Use:` labels where context is self-evident from section heading
- Removed `(OpenCode Dark)` / `(OpenCode Light)` color name annotations (defined in `02-color-palette.md`)
- Consolidated related properties onto single lines using `·` separator
- Removed editorial commentary ("Reinforces the CLI-first identity", "content speaks for itself")
- Renamed "Email Input" → "Text/Email" to reflect broader applicability

## Content preserved

All design tokens, component specs, and structural content intact:
- All hex/rgba color values: `#201d1d`, `#fdfcfc`, `#f8f7f7`, `#9a9898`, `rgba(15, 0, 0, 0.12)`, `rgb(253, 252, 252) none 0px`
- All sizing/spacing: 4px/20px padding, 4px/6px radius, 16px font, weight 500/400, line-height 2.00/1.00
- All 7 component sections and 9 component variants

## Classification

**Reference corpus** (design token specs) — restructuring into further chapters not warranted at 85 lines. Prose tightening applied per `code-simplifier.md` guidance.

## Runtime Testing

**Risk: Low** — docs-only change, no executable code. `self-assessed`.

---
<!-- MERGE_SUMMARY -->
**What**: Tighten OpenCode component stylings chapter doc (85→60 lines, 29% reduction)
**Issue**: #17086
**Files changed**: 1 (`.agents/tools/design/library/brands/opencode.ai/04-components.md`)
**Testing**: Docs-only, self-assessed. All tokens and specs verified present before and after.
**Key decisions**: Classified as reference corpus chapter; prose tightening (not further splitting) is correct action at 85 lines.

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6