### PR TITLE
GH#17088: tighten Expo component stylings doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6334,6 +6334,12 @@
       "at": "2026-04-04T04:52:51Z",
       "pr": "17061",
       "passes": 1
+    },
+    ".agents/tools/design/library/brands/expo/04-components.md": {
+      "hash": "69b5856bf958e6587dd25a9bca62ba877ff7714df446912582046d4903abd6f9",
+      "at": "2026-04-04T05:30:00Z",
+      "lines": 82,
+      "issue": "GH#17088"
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/brands/expo/04-components.md
+++ b/.agents/tools/design/library/brands/expo/04-components.md
@@ -13,13 +13,11 @@
 - Border: thin solid Input Border (`1px solid #d9d9e0`)
 - Radius: subtly rounded (6px)
 - Shadow: subtle combined shadow on hover
-- The understated default — clean, professional, unheroic
 
 **Primary Pill**
 
 - Same as Primary but with pill-shaped radius (9999px)
 - Used for hero CTAs and high-emphasis actions
-- The extra roundness signals "start here"
 
 **Dark Primary**
 
@@ -27,15 +25,14 @@
 - Text: Pure White (`#ffffff`)
 - Pill-shaped (9999px) or generously rounded (32–36px)
 - No border (black IS the border)
-- The maximum-emphasis CTA — reserved for primary conversion actions
 
 ## Cards & Containers
 
-- Background: Pure White (`#ffffff`) — clearly lifted from Cloud Gray page
+- Background: Pure White (`#ffffff`)
 - Border: thin solid Border Lavender (`1px solid #e0e1e6`) for standard cards
 - Radius: comfortably rounded (8px) for standard cards; generously rounded (16–24px) for featured containers
-- Shadow Level 1: Whisper (`rgba(0,0,0,0.08) 0px 3px 6px, rgba(0,0,0,0.07) 0px 2px 4px`) — barely perceptible lift
-- Shadow Level 2: Standard (`rgba(0,0,0,0.1) 0px 10px 20px, rgba(0,0,0,0.05) 0px 3px 6px`) — clear floating elevation
+- Shadow Level 1: Whisper (`rgba(0,0,0,0.08) 0px 3px 6px, rgba(0,0,0,0.07) 0px 2px 4px`)
+- Shadow Level 2: Standard (`rgba(0,0,0,0.1) 0px 10px 20px, rgba(0,0,0,0.05) 0px 3px 6px`)
 - Hover: likely subtle shadow deepening or background shift
 
 ## Inputs & Forms


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/expo/04-components.md` by removing decorative commentary that adds no actionable information for agents using this as a design reference.

## Issue
Closes #17088

## Files Changed
- `.agents/tools/design/library/brands/expo/04-components.md` — 85 → 82 lines (-3 decorative lines)
- `.agents/configs/simplification-state.json` — updated hash registry

## Changes Made
Removed 3 decorative commentary lines:
- "The understated default — clean, professional, unheroic"
- "The extra roundness signals 'start here'"
- "The maximum-emphasis CTA — reserved for primary conversion actions"

Also cleaned 2 inline decorative suffixes from Cards & Containers section ("clearly lifted from Cloud Gray page", "barely perceptible lift", "clear floating elevation").

All technical specs preserved: colors (`#ffffff`, `#000000`, `#1c2024`, `#60646c`, `#d9d9e0`, `#e0e1e6`), sizes (6px, 8px, 16–24px, 9999px, 32–36px), shadow values, padding, typography, and behavioral notes.

## Classification
Reference corpus (design knowledge base) — restructure/tighten, not content reduction. File is 82 lines, well below the ~300-line split threshold. No chapter splitting needed.

## Runtime Testing
**Risk level:** Low — documentation-only change, no code, no agent behavior change.
**Verification:** `wc -l` confirms 82 lines. All code blocks, color values, and size specs present before and after.

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6