### PR TITLE
GH#17082: tighten clickhouse 04-components.md

### DIFF
--- a/.agents/tools/design/library/brands/clickhouse/04-components.md
+++ b/.agents/tools/design/library/brands/clickhouse/04-components.md
@@ -63,7 +63,7 @@
 
 - Dark nav on black background
 - Logo: ClickHouse wordmark + icon in yellow/neon
-- Links: white text, hover to Neon Volt (#faff69)
+- Links: white text, hover to Neon Volt (`#faff69`)
 - CTA: Neon Volt button or Forest Green button
 - Uppercase labels for categories
 
@@ -76,9 +76,7 @@
 - The primary visual proof of performance claims
 
 ### Neon-Highlighted Card
-- Standard dark card with neon yellow-green border highlight
-- Creates "selected" or "featured" treatment
-- The accent border makes the card pop against the dark canvas
+- Standard dark card with neon yellow-green border highlight — "selected" or "featured" treatment
 
 ### Code Blocks
 - Dark surface with Inconsolata at weight 600


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/clickhouse/04-components.md` per simplification scan (GH#17082).

**Classification:** Reference corpus (brand design library chapter) — restructure/tighten formatting, do NOT compress content.

**Changes (91 → 89 lines):**
- Fix hex color formatting inconsistency: `#faff69` → `` `#faff69` `` in Navigation section (all other hex values in file use backtick formatting)
- Merge 3 redundant Neon-Highlighted Card bullets into 1 (no content loss — "selected/featured treatment" and "accent border pops against dark canvas" describe the same visual effect)

## Issue
Closes #17082

## Files Changed
- `.agents/tools/design/library/brands/clickhouse/04-components.md` (91 → 89 lines)

## Testing
**Risk level:** Low (docs/reference corpus, no code)
**Verification:** All component specs, hex values, shadow values, and design intent notes present before and after. No broken references. Agent behaviour unchanged.

## Runtime Testing
`self-assessed` — Low risk: reference corpus doc, no executable code, no agent instruction changes.

## Key Decisions
- File classified as **reference corpus** (brand design library chapter), not instruction doc — content not compressed, only formatting noise removed
- Retained all design intent notes ("The eye-catching CTA", "The standard action button", etc.) — these carry intentional design rationale
- Only removed genuinely redundant bullet (same visual effect described twice) and fixed formatting inconsistency

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6