### PR TITLE
GH#17081: tighten Claude component stylings doc (96→76 lines)

### DIFF
--- a/.agents/tools/design/library/brands/claude/04-components.md
+++ b/.agents/tools/design/library/brands/claude/04-components.md
@@ -6,91 +6,71 @@
 ## Buttons
 
 **Warm Sand (Secondary)**
-- Background: Warm Sand (`#e8e6dc`)
-- Text: Charcoal Warm (`#4d4c48`)
+- Background: Warm Sand (`#e8e6dc`) · Text: Charcoal Warm (`#4d4c48`)
 - Padding: 0px 12px 0px 8px (asymmetric — icon-first layout)
-- Radius: comfortably rounded (8px)
-- Shadow: ring-based (`#e8e6dc 0px 0px 0px 0px, #d1cfc5 0px 0px 0px 1px`)
-- The workhorse button — warm, unassuming, clearly interactive
+- Radius: 8px · Shadow: `#e8e6dc 0px 0px 0px 0px, #d1cfc5 0px 0px 0px 1px`
 
 **White Surface**
-- Background: Pure White (`#ffffff`)
-- Text: Anthropic Near Black (`#141413`)
-- Padding: 8px 16px 8px 12px
-- Radius: generously rounded (12px)
+- Background: Pure White (`#ffffff`) · Text: Anthropic Near Black (`#141413`)
+- Padding: 8px 16px 8px 12px · Radius: 12px
 - Hover: shifts to secondary background color
-- Clean, elevated button for light surfaces
 
 **Dark Charcoal**
-- Background: Dark Surface (`#30302e`)
-- Text: Ivory (`#faf9f5`)
-- Padding: 0px 12px 0px 8px
-- Radius: comfortably rounded (8px)
-- Shadow: ring-based (`#30302e 0px 0px 0px 0px, ring 0px 0px 0px 1px`)
-- The inverted variant for dark-on-light emphasis
+- Background: Dark Surface (`#30302e`) · Text: Ivory (`#faf9f5`)
+- Padding: 0px 12px 0px 8px · Radius: 8px
+- Shadow: `#30302e 0px 0px 0px 0px, ring 0px 0px 0px 1px`
 
-**Brand Terracotta**
-- Background: Terracotta Brand (`#c96442`)
-- Text: Ivory (`#faf9f5`)
-- Radius: 8–12px
-- Shadow: ring-based (`#c96442 0px 0px 0px 0px, #c96442 0px 0px 0px 1px`)
-- The primary CTA — the only button with chromatic color
+**Brand Terracotta** — primary CTA; only chromatic button
+- Background: Terracotta Brand (`#c96442`) · Text: Ivory (`#faf9f5`)
+- Radius: 8–12px · Shadow: `#c96442 0px 0px 0px 0px, #c96442 0px 0px 0px 1px`
 
 **Dark Primary**
-- Background: Anthropic Near Black (`#141413`)
-- Text: Warm Silver (`#b0aea5`)
-- Padding: 9.6px 16.8px
-- Radius: generously rounded (12px)
-- Border: thin solid Dark Surface (`1px solid #30302e`)
-- Used on dark theme surfaces
+- Background: Anthropic Near Black (`#141413`) · Text: Warm Silver (`#b0aea5`)
+- Padding: 9.6px 16.8px · Radius: 12px
+- Border: `1px solid #30302e` (dark theme surfaces)
 
 ## Cards & Containers
 
-- Background: Ivory (`#faf9f5`) or Pure White (`#ffffff`) on light surfaces; Dark Surface (`#30302e`) on dark
-- Border: thin solid Border Cream (`1px solid #f0eee6`) on light; `1px solid #30302e` on dark
-- Radius: comfortably rounded (8px) for standard cards; generously rounded (16px) for featured; very rounded (32px) for hero containers and embedded media
-- Shadow: whisper-soft (`rgba(0,0,0,0.05) 0px 4px 24px`) for elevated content
-- Ring shadow: `0px 0px 0px 1px` patterns for interactive card states
+- Background: Ivory (`#faf9f5`) or Pure White (`#ffffff`) on light; Dark Surface (`#30302e`) on dark
+- Border: `1px solid #f0eee6` on light; `1px solid #30302e` on dark
+- Radius: 8px standard · 16px featured · 32px hero/embedded media
+- Shadow: `rgba(0,0,0,0.05) 0px 4px 24px` (elevated content)
+- Ring shadow: `0px 0px 0px 1px` for interactive card states
 - Section borders: `1px 0px 0px` (top-only) for list item separators
 
 ## Inputs & Forms
 
-- Text: Anthropic Near Black (`#141413`)
-- Padding: 1.6px 12px (very compact vertical)
+- Text: Anthropic Near Black (`#141413`) · Padding: 1.6px 12px · Radius: 12px
 - Border: standard warm borders
-- Focus: ring with Focus Blue (`#3898ec`) border-color — the only cool color moment
-- Radius: generously rounded (12px)
+- Focus: Focus Blue (`#3898ec`) border-color — only cool color in system
 
 ## Navigation
 
 - Sticky top nav with warm background
 - Logo: Claude wordmark in Anthropic Near Black
-- Links: mix of Near Black (`#141413`), Olive Gray (`#5e5d59`), and Dark Warm (`#3d3d3a`)
+- Links: Near Black (`#141413`), Olive Gray (`#5e5d59`), Dark Warm (`#3d3d3a`)
 - Nav border: `1px solid #30302e` (dark) or `1px solid #f0eee6` (light)
 - CTA: Terracotta Brand button or White Surface button
 - Hover: text shifts to foreground-primary, no decoration
 
 ## Image Treatment
 
-- Product screenshots showing the Claude chat interface
-- Generous border-radius on media (16–32px)
+- Product screenshots of Claude chat interface; generous border-radius (16–32px)
 - Embedded video players with rounded corners
-- Dark UI screenshots provide contrast against warm light canvas
+- Dark UI screenshots contrast against warm light canvas
 - Organic, hand-drawn illustrations for conceptual sections
 
 ## Distinctive Components
 
 **Model Comparison Cards**
-- Opus 4.5, Sonnet 4.5, Haiku 4.5 presented in a clean card grid
-- Each model gets a bordered card with name, description, and capability badges
+- Opus 4.5, Sonnet 4.5, Haiku 4.5 in bordered card grid
+- Name, description, capability badges per card
 - Border Warm (`#e8e6dc`) separation between items
 
 **Organic Illustrations**
-- Hand-drawn-feeling vector illustrations in terracotta, black, and muted green
-- Abstract, conceptual rather than literal product diagrams
-- The primary visual personality — no other AI company uses this style
+- Hand-drawn-feeling vector illustrations: terracotta, black, muted green
+- Abstract/conceptual (not literal product diagrams)
 
 **Dark/Light Section Alternation**
-- The page alternates between Parchment light and Near Black dark sections
-- Creates a reading rhythm like chapters in a book
-- Each section feels like a distinct environment
+- Page alternates Parchment light and Near Black dark sections
+- Each section is a distinct visual environment


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/claude/04-components.md` from 96 to 76 lines (21% reduction) by removing decorative commentary and consolidating related properties onto single lines.

## Issue
Closes #17081

## Classification
Reference corpus (design spec data). Applied prose tightening per code-simplifier guidance — not content compression.

## Changes
- Removed decorative commentary (e.g. "The workhorse button — warm, unassuming, clearly interactive", "Creates a reading rhythm like chapters in a book")
- Consolidated background/text pairs onto single lines using `·` separator (consistent with opencode.ai/04-components.md style)
- Removed redundant adjectives from spec values ("comfortably rounded" → `8px`, "whisper-soft" → removed, "generously rounded" → `12px`)
- Preserved all hex values, measurements, padding, radius, shadow specs, component names, and structural data

## Files Changed
- `.agents/tools/design/library/brands/claude/04-components.md` (96→76 lines)

## Runtime Testing
**Risk level:** Low — documentation/reference file, no executable code.
**Verification:** `self-assessed` — all hex values, measurements, and spec data verified present in diff.

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6