### PR TITLE
GH#17083: tighten Vercel component stylings doc (88→74 lines)

### DIFF
--- a/.agents/tools/design/library/brands/vercel/04-components.md
+++ b/.agents/tools/design/library/brands/vercel/04-components.md
@@ -6,64 +6,54 @@
 ## Buttons
 
 **Primary White (Shadow-bordered)**
-- Background: `#ffffff`
-- Text: `#171717`
-- Padding: 0px 6px (minimal — content-driven width)
-- Radius: 6px (subtly rounded)
-- Shadow: `rgb(235, 235, 235) 0px 0px 0px 1px` (ring-border)
-- Hover: background shifts to `var(--ds-gray-1000)` (dark)
-- Focus: `2px solid var(--ds-focus-color)` outline + `var(--ds-focus-ring)` shadow
+- Background: `#ffffff` / Text: `#171717`
+- Padding: 0px 6px (content-driven width) / Radius: 6px
+- Shadow: `rgb(235, 235, 235) 0px 0px 0px 1px`
+- Hover: background → `var(--ds-gray-1000)` (dark)
+- Focus: `2px solid var(--ds-focus-color)` + `var(--ds-focus-ring)` shadow
 - Use: Standard secondary button
 
-**Primary Dark (Inferred from Geist system)**
-- Background: `#171717`
-- Text: `#ffffff`
-- Padding: 8px 16px
-- Radius: 6px
+**Primary Dark (Geist system)**
+- Background: `#171717` / Text: `#ffffff`
+- Padding: 8px 16px / Radius: 6px
 - Use: Primary CTA ("Start Deploying", "Get Started")
 
 **Pill Button / Badge**
-- Background: `#ebf5ff` (tinted blue)
-- Text: `#0068d6`
-- Padding: 0px 10px
-- Radius: 9999px (full pill)
-- Font: 12px weight 500
+- Background: `#ebf5ff` / Text: `#0068d6`
+- Padding: 0px 10px / Radius: 9999px / Font: 12px weight 500
 - Use: Status badges, tags, feature labels
 
 **Large Pill (Navigation)**
-- Background: transparent or `#171717`
-- Radius: 64px–100px
+- Background: transparent or `#171717` / Radius: 64px–100px
 - Use: Tab navigation, section selectors
 
 ## Cards & Containers
 
 - Background: `#ffffff`
-- Border: via shadow — `rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`
+- Border: shadow — `rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`
 - Radius: 8px (standard), 12px (featured/image cards)
 - Shadow stack: `rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, #fafafa 0px 0px 0px 1px`
-- Image cards: `1px solid #ebebeb` with 12px top radius
+- Image cards: `1px solid #ebebeb` / top radius 12px
 - Hover: subtle shadow intensification
 
 ## Inputs & Forms
 
-- Radio: standard styling with focus `var(--ds-gray-200)` background
+- Radio: focus background `var(--ds-gray-200)`
 - Focus shadow: `1px 0 0 0 var(--ds-gray-alpha-600)`
-- Focus outline: `2px solid var(--ds-focus-color)` — consistent blue focus ring
-- Border: via shadow technique, not traditional border
+- Focus outline: `2px solid var(--ds-focus-color)` (blue focus ring)
+- Border: shadow technique, not traditional border
 
 ## Navigation
 
-- Clean horizontal nav on white, sticky
+- Horizontal nav, white, sticky
 - Vercel logotype left-aligned, 262x52px
-- Links: Geist 14px weight 500, `#171717` text
-- Active: weight 600 or underline
+- Links: Geist 14px weight 500, `#171717`; active: weight 600 or underline
 - CTA: dark pill buttons ("Start Deploying", "Contact Sales")
-- Mobile: hamburger menu collapse
-- Product dropdowns with multi-level menus
+- Mobile: hamburger collapse / product dropdowns with multi-level menus
 
 ## Image Treatment
 
-- Product screenshots with `1px solid #ebebeb` border
+- Product screenshots: `1px solid #ebebeb` border
 - Top-rounded images: `12px 12px 0px 0px` radius
 - Dashboard/code preview screenshots dominate feature sections
 - Soft gradient backgrounds behind hero images (pastel multi-color)
@@ -71,18 +61,14 @@
 ## Distinctive Components
 
 **Workflow Pipeline**
-- Three-step horizontal pipeline: Develop → Preview → Ship
-- Each step has its own accent color: Blue → Pink → Red
-- Connected with lines/arrows
-- The visual metaphor for Vercel's core value proposition
+- Three-step horizontal: Develop → Preview → Ship
+- Accent colors: Blue → Pink → Red; connected with lines/arrows
+- Visual metaphor for Vercel's core value proposition
 
 **Trust Bar / Logo Grid**
 - Company logos (Perplexity, ChatGPT, Cursor, etc.) in grayscale
-- Horizontal scroll or grid layout
-- Subtle `#ebebeb` border separation
+- Horizontal scroll or grid / `#ebebeb` border separation
 
 **Metric Cards**
-- Large number display (e.g., "10x faster")
-- Geist 48px weight 600 for the metric
-- Description below in gray body text
-- Shadow-bordered card container
+- Large number display (e.g., "10x faster") — Geist 48px weight 600
+- Description below in gray body text / shadow-bordered card container


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/vercel/04-components.md` from 88 to 74 lines by compressing prose and consolidating related bullet points.

## Issue
Closes #17083

## Classification
Reference corpus (design system specs). Per issue guidance: preserve all content, tighten prose. File is appropriately structured — no chapter split needed at 74 lines.

## Changes
- Consolidated related properties onto single lines (background/text, padding/radius)
- Removed redundant parenthetical descriptions ("subtly rounded", "minimal —", "Inferred from", "ring-border", "full pill", "standard styling with")
- Merged sequential single-property bullets into compound lines
- Preserved all spec values: every color, radius, padding, shadow, font size, and component description

## Files Changed
- `.agents/tools/design/library/brands/vercel/04-components.md` (88→74 lines, -16%)

## Runtime Testing
**Risk: Low** — docs-only change, no code execution paths affected. `self-assessed`.

## Verification
- All code blocks present: ✓
- All hex colors preserved: ✓ (`#ffffff`, `#171717`, `#ebf5ff`, `#0068d6`, `#ebebeb`, `#fafafa`)
- All CSS variables preserved: ✓ (`--ds-gray-1000`, `--ds-focus-color`, `--ds-focus-ring`, `--ds-gray-200`, `--ds-gray-alpha-600`)
- All component sections present: ✓ (Buttons, Cards, Inputs, Navigation, Images, Distinctive Components)
- No broken references: ✓

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6