### PR TITLE
GH#17089: tighten Clay component stylings doc (84→53 lines)

### DIFF
--- a/.agents/tools/design/library/brands/clay/04-components.md
+++ b/.agents/tools/design/library/brands/clay/04-components.md
@@ -11,74 +11,43 @@
 - Text: `#000000`
 - Padding: 6.4px 12.8px
 - Border: none (or `1px solid #717989` for outlined variant)
-- Hover: background shifts to swatch color (e.g., `#434346`), text to white, `rotateZ(-8deg)`, `translateY(-80%)`, hard shadow `rgb(0,0,0) -7px 7px`
+- Hover: background → swatch color (e.g., `#434346`), text → white, `rotateZ(-8deg)`, `translateY(-80%)`, hard shadow `rgb(0,0,0) -7px 7px`
 - Focus: `rgb(20, 110, 245) solid 2px` outline
 
 **White Solid**
 
-- Background: `#ffffff`
-- Text: `#000000`
-- Padding: 6.4px
+- Background: `#ffffff`; Text: `#000000`; Padding: 6.4px
 - Hover: oat-200 swatch color, animated rotation + shadow
 - Use: Primary CTA on colored sections
 
 **Ghost Outlined**
 
-- Background: transparent
-- Text: `#000000`
-- Padding: 8px
-- Border: `1px solid #717989`
-- Radius: 4px
+- Background: transparent; Text: `#000000`; Padding: 8px
+- Border: `1px solid #717989`; Radius: 4px
 - Hover: dragonfruit swatch color, white text, animated rotation
+
+> **Hover pattern:** Rotate -8deg + translate upward, hard offset shadow (`-7px 7px`) instead of soft blur, background → contrasting swatch. Creates a physical, toy-like interaction quality.
 
 ## Cards & Containers
 
 - Background: `#ffffff` on cream canvas
-- Border: `1px solid #dad4c8` (warm oat) or `1px dashed #dad4c8`
-- Radius: 12px (standard cards), 24px (feature cards/images), 40px (section containers/footer)
+- Border: `1px solid #dad4c8` (warm oat) or `1px dashed #dad4c8` (secondary/decorative — adds hand-drawn quality)
+- Radius: 12px (standard), 24px (feature cards/images), 40px (section containers/footer)
 - Shadow: `rgba(0,0,0,0.1) 0px 1px 1px, rgba(0,0,0,0.04) 0px -1px 1px inset, rgba(0,0,0,0.05) 0px -0.5px 1px`
-- Colorful section backgrounds using swatch palette (matcha, slushie, ube, lemon)
+- Swatch color sections: full-width backgrounds (matcha green, slushie cyan, ube purple, lemon gold); white text on dark swatches, black on light
 
 ## Inputs & Forms
 
-- Text: `#000000`
-- Border: `1px solid #717989`
-- Radius: 4px
+- Text: `#000000`; Border: `1px solid #717989`; Radius: 4px
 - Focus: `rgb(20, 110, 245) solid 2px` outline
 
 ## Navigation
 
-- Sticky top nav on cream background
-- Roobert 15px weight 500 for nav links
-- Clay logo left-aligned
-- CTA buttons right-aligned with pill radius
-- Border bottom: `1px solid #dad4c8`
+- Sticky top nav on cream background; border-bottom: `1px solid #dad4c8`
+- Roobert 15px weight 500 for nav links; Clay logo left, CTA buttons right (pill radius)
 - Mobile: hamburger collapse at 767px
 
-## Image Treatment
+## Images
 
-- Product screenshots in white cards with oat borders
-- Colorful illustrated sections with swatch background colors
-- 8px–24px radius on images
-- Full-width colorful section backgrounds
-
-## Distinctive Components
-
-**Swatch Color Sections**
-
-- Full-width sections with swatch-colored backgrounds (matcha green, slushie cyan, ube purple, lemon gold)
-- White text on dark swatches, black text on light swatches
-- Each section tells a distinct product story through its color
-
-**Playful Hover Buttons**
-
-- Rotate -8deg + translate upward on hover
-- Hard offset shadow (`-7px 7px`) instead of soft blur
-- Background transitions to contrasting swatch color
-- Creates a physical, toy-like interaction quality
-
-**Dashed Border Elements**
-
-- Dashed borders (`1px dashed #dad4c8`) alongside solid borders
-- Used for secondary containers and decorative elements
-- Adds a hand-drawn, craft-like quality
+- Product screenshots in white cards with oat borders; 8px–24px radius
+- Colorful illustrated sections with swatch background colors; full-width section backgrounds


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/design/library/brands/clay/04-components.md` from 84 to 53 lines (-37%) by consolidating redundant sections.

**Classification:** Reference corpus (CSS values, design specs) — not an instruction doc. Applied reference corpus simplification: consolidate duplicate content, not split into chapters (file is already appropriately sized at 84 lines).

**Changes:**
- Merged `Distinctive Components` section into primary sections (hover animation → Buttons, dashed borders → Cards, swatch sections → Cards)
- Collapsed single-property lines in White Solid and Ghost Outlined buttons onto fewer lines
- Renamed `Image Treatment` → `Images` (shorter, same meaning)
- All CSS values, hex colors, measurements, and design knowledge preserved

Closes #17089

## Runtime Testing

**Risk level:** Low — docs/reference content only, no code changes.
**Verification:** `wc -l` confirms 53 lines (was 84). All CSS values present in diff.

## Files Changed

- `.agents/tools/design/library/brands/clay/04-components.md` (84→53 lines, -37%)

<!-- MERGE_SUMMARY -->
**What:** Tighten Clay component stylings reference doc
**Issue:** #17089
**Files changed:** 1 (docs only)
**Testing:** Self-assessed (low risk — reference corpus)
**Key decisions:** Consolidated Distinctive Components into primary sections; no content loss

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6