### PR TITLE
GH#17094: tighten prose in Claude layout design chapter

### DIFF
--- a/.agents/tools/design/library/brands/claude/05-layout.md
+++ b/.agents/tools/design/library/brands/claude/05-layout.md
@@ -21,9 +21,9 @@
 
 ## Whitespace Philosophy
 
-- **Editorial pacing**: Each section breathes like a magazine spread — generous top/bottom margins create natural reading pauses.
-- **Serif-driven rhythm**: The serif headings establish a literary cadence that demands more whitespace than sans-serif designs.
-- **Content island approach**: Sections alternate between light and dark environments, creating distinct "rooms" for each message.
+- **Editorial pacing**: Generous top/bottom margins create natural reading pauses between sections.
+- **Serif-driven rhythm**: Serif headings demand more whitespace than sans-serif designs.
+- **Content island approach**: Sections alternate light/dark environments, creating distinct visual rooms.
 
 ## Border Radius Scale
 
@@ -49,10 +49,10 @@
 
 ### Touch Targets
 
-- Buttons use generous padding (8–16px vertical minimum)
-- Navigation links adequately spaced for thumb navigation
-- Card surfaces serve as large touch targets
-- Minimum recommended: 44x44px
+- Buttons: 8–16px vertical padding minimum
+- Navigation links: spaced for thumb navigation
+- Card surfaces: large touch targets
+- Minimum: 44x44px
 
 ### Collapsing Strategy
 


### PR DESCRIPTION
## Summary

Tighten verbose prose in `.agents/tools/design/library/brands/claude/05-layout.md` per simplification issue GH#17094.

**Classification:** Reference corpus chapter (already split). Action: light prose tightening only — no content removal.

**Changes:**
- Whitespace Philosophy: removed decorative metaphors ("breathes like a magazine spread", "literary cadence") while preserving the design intent
- Touch Targets: converted verbose sentences to concise bullet format

**Preserved:** All reference values (px values, breakpoints, aspect ratios, border radius scale, spacing scale) unchanged.

Closes #17094

## Runtime Testing

**Risk level:** Low — documentation/reference file, no executable code.
**Verification:** `self-assessed` — all code blocks, URLs, and reference values present before and after.

---
<!-- MERGE_SUMMARY -->
**What:** Prose tightening in Claude design system layout chapter
**Issue:** GH#17094
**Files changed:** `.agents/tools/design/library/brands/claude/05-layout.md` (1 file, 7 lines changed)
**Testing:** Self-assessed — reference data preserved, no functional changes
**Key decisions:** Classified as reference corpus chapter; applied prose-only tightening, not content reduction

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6