### PR TITLE
GH#17093: tighten ElevenLabs component stylings doc (75→43 lines)

### DIFF
--- a/.agents/tools/design/library/brands/elevenlabs/04-components.md
+++ b/.agents/tools/design/library/brands/elevenlabs/04-components.md
@@ -5,71 +5,39 @@
 
 ## Buttons
 
-**Primary Black Pill**
-- Background: `#000000`
-- Text: `#ffffff`
-- Padding: 0px 14px
-- Radius: 9999px (full pill)
-- Use: Primary CTA
+**Primary Black Pill** — bg `#000000`, text `#ffffff`, padding `0px 14px`, radius `9999px`. Use: Primary CTA.
 
-**White Pill (Shadow-bordered)**
-- Background: `#ffffff`
-- Text: `#000000`
-- Radius: 9999px
-- Shadow: `rgba(0,0,0,0.4) 0px 0px 1px, rgba(0,0,0,0.04) 0px 4px 4px`
-- Use: Secondary CTA on white
+**White Pill (Shadow-bordered)** — bg `#ffffff`, text `#000000`, radius `9999px`, shadow `rgba(0,0,0,0.4) 0px 0px 1px, rgba(0,0,0,0.04) 0px 4px 4px`. Use: Secondary CTA on white.
 
-**Warm Stone Pill**
-- Background: `rgba(245, 242, 239, 0.8)` (warm translucent)
-- Text: `#000000`
-- Padding: 12px 20px 12px 14px (asymmetric)
-- Radius: 30px
-- Shadow: `rgba(78, 50, 23, 0.04) 0px 6px 16px` (warm-tinted)
-- Use: Featured CTA, hero action — the signature warm button
+**Warm Stone Pill** — bg `rgba(245,242,239,0.8)`, text `#000000`, padding `12px 20px 12px 14px` (asymmetric), radius `30px`, shadow `rgba(78,50,23,0.04) 0px 6px 16px`. Use: Featured CTA, hero action — the signature warm button.
 
-**Uppercase Waldenburg Button**
-- Font: WaldenburgFH 14px weight 700
-- Text-transform: uppercase
-- Letter-spacing: 0.7px
-- Use: Specific bold CTA labels
+**Uppercase Waldenburg Button** — font WaldenburgFH 14px weight 700, text-transform uppercase, letter-spacing 0.7px. Use: Specific bold CTA labels.
+
+> **Button pattern:** Pill shapes dominate (radius 9999px or 30px). Warm Stone variant creates a physical, tactile quality unique to ElevenLabs via asymmetric padding and warm-tinted shadow.
 
 ## Cards & Containers
 
-- Background: `#ffffff`
-- Border: `1px solid #e5e5e5` or shadow-as-border
-- Radius: 16px–24px
+- bg `#ffffff`; border `1px solid #e5e5e5` or shadow-as-border; radius 16px–24px
 - Shadow: multi-layer stack (inset + outline + elevation)
 - Content: product screenshots, code examples, audio waveform previews
 
 ## Inputs & Forms
 
-- Textarea: padding 12px 20px, transparent text at default
-- Select: white background, standard styling
-- Radio: standard with tw-ring focus
-- Focus: `var(--tw-ring-offset-shadow)` ring system
+- Textarea: padding `12px 20px`, transparent text at default; Select: white bg, standard styling
+- Radio: standard with tw-ring focus; Focus: `var(--tw-ring-offset-shadow)` ring system
 
 ## Navigation
 
-- Clean white sticky header
-- Inter 15px weight 500 for nav links
-- Pill CTAs right-aligned (black primary, white secondary)
+- Sticky white header; Inter 15px weight 500 for nav links; pill CTAs right-aligned (black primary, white secondary)
 - Mobile: hamburger collapse at 1024px
 
-## Image Treatment
+## Images
 
-- Product screenshots and audio waveform visualizations
-- Warm gradient backgrounds in feature sections
-- 20px–24px radius on image containers
-- Full-width sections alternating white and light gray
+- Product screenshots and audio waveform visualizations; warm gradient backgrounds in feature sections
+- 20px–24px radius on image containers; full-width sections alternating white and light gray
 
 ## Distinctive Components
 
-**Audio Waveform Sections**
-- Colorful gradient backgrounds showcasing voice AI capabilities
-- Warm amber, blue, and green gradients behind product demos
-- Screenshots of the ElevenLabs product interface
+**Audio Waveform Sections** — colorful gradient backgrounds (warm amber, blue, green) behind voice AI product demos.
 
-**Warm Stone CTA Block**
-- `rgba(245,242,239,0.8)` background with warm shadow
-- Asymmetric padding (more right padding)
-- Creates a physical, tactile quality unique to ElevenLabs
+**Warm Stone CTA Block** — `rgba(245,242,239,0.8)` bg, warm shadow, asymmetric padding (more right). Creates physical, tactile quality unique to ElevenLabs.


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/design/library/brands/elevenlabs/04-components.md` from 75 to 43 lines (43% reduction) per GH#17093.

Closes #17093

## What

- Converted verbose multi-bullet button variant specs to compact inline format (property: value, property: value)
- Added `> **Button pattern:**` blockquote summarising the dominant pill shape pattern and Warm Stone signature
- Collapsed single-concern bullet groups (Cards, Inputs, Nav, Images) to 1–2 lines each
- Merged Distinctive Components from 3-bullet blocks to single inline descriptions
- Preserved all technical values: hex colours, rgba values, padding specs, shadow strings, font specs, breakpoints

## Classification

**Reference corpus** (CSS values, component specs) — not an instruction doc. Restructured for density, not content reduction.

## Verification

- All code blocks, CSS values, rgba strings, font specs, and breakpoints present before and after
- `wc -l`: 75 → 43 lines
- No broken internal links (file has no cross-references)
- Agent behaviour unchanged (reference data only)

## Runtime Testing

**Risk: Low** — docs-only change, no executable code. `self-assessed`.

<!-- MERGE_SUMMARY -->
**What:** Tighten ElevenLabs 04-components.md reference doc
**Issue:** Closes #17093
**Files changed:** 1 (`.agents/tools/design/library/brands/elevenlabs/04-components.md`)
**Testing:** self-assessed (docs-only)
**Key decisions:** Inline format for button specs; blockquote for pattern summary; all CSS values preserved verbatim

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6