### PR TITLE
GH#17095: tighten MongoDB components doc

### DIFF
--- a/.agents/tools/design/library/brands/mongodb/04-components.md
+++ b/.agents/tools/design/library/brands/mongodb/04-components.md
@@ -52,9 +52,7 @@
 
 ## Image Treatment
 
-- Dashboard screenshots on dark backgrounds
-- Green-accented UI elements in screenshots
-- 30px–32px radius on image containers
+- Dashboard screenshots on dark backgrounds with green-accented UI elements
 - Full-width dark sections for product showcases
 
 ## Distinctive Components


### PR DESCRIPTION
## Summary

- Remove duplicate `30px–32px radius` mention from Image Treatment (already present in Cards & Containers)
- Merge redundant image treatment bullets into one line
- 70 → 68 lines; all CSS values, colors, radii, and distinctive component details preserved

## What

Tighten `.agents/tools/design/library/brands/mongodb/04-components.md` per simplification scan.

## Issue

Closes #17095

## Files Changed

- `.agents/tools/design/library/brands/mongodb/04-components.md` — 2 lines removed (duplicate + redundant)

## Testing

- All code blocks, CSS values, color hex codes, and command examples verified present before and after
- No broken internal links or references
- Agent behaviour unchanged (reference corpus, no procedural rules)
- Risk: **Low** (docs-only change)

## Runtime Testing

`self-assessed` — docs-only, no runtime required

<!-- MERGE_SUMMARY -->
**What:** Remove duplicate image container radius and merge redundant image treatment bullets in MongoDB design system component doc.
**Issue:** #17095
**Files changed:** 1 (`.agents/tools/design/library/brands/mongodb/04-components.md`)
**Testing:** Self-assessed — docs-only, all values preserved
**Key decisions:** Classified as reference corpus; tightened only genuine duplicates, no content compression

---
[aidevops.sh](https://aidevops.sh) v3.6.30 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6