### PR TITLE
GH#17121: tighten startup-minimal colours doc, defer shadows to elevation

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6345,6 +6345,12 @@
       "at": "2026-04-04T05:30:00Z",
       "lines": 82,
       "issue": "GH#17088"
+    },
+    ".agents/tools/design/library/styles/startup-minimal/02-colours.md": {
+      "hash": "885ec9ad79069e537f48619a23e870eb856f862a63fbb029acd1433de461825d",
+      "at": "2026-04-04T06:10:00Z",
+      "passes": 1,
+      "pr": 0
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/styles/startup-minimal/02-colours.md
+++ b/.agents/tools/design/library/styles/startup-minimal/02-colours.md
@@ -50,8 +50,4 @@
 
 ## Shadows
 
-| Role | Value | Usage |
-|------|-------|-------|
-| Subtle | `0 1px 2px rgba(0, 0, 0, 0.04)` | Barely-there lift for inputs |
-| Medium | `0 2px 8px rgba(0, 0, 0, 0.06)` | Dropdowns, popovers |
-| Overlay | `0 4px 16px rgba(0, 0, 0, 0.08)` | Modals, command palette |
+See [06-elevation.md](06-elevation.md) — shadow values are defined there alongside elevation principles.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Remove duplicate `## Shadows` table from `02-colours.md` and replace with a pointer to `06-elevation.md`, where shadow values are already defined with full elevation principles.

## Issue
Closes #17121

## Files Changed
- `.agents/tools/design/library/styles/startup-minimal/02-colours.md` — 57 → 53 lines (removed 4 duplicate shadow rows, added 1-line pointer)
- `.agents/configs/simplification-state.json` — updated hash for processed file

## Classification
Reference corpus (colour palette data tables). Per issue guidance: do NOT compress content. The only genuine simplification was deduplication — the Shadows section existed in both `02-colours.md` and `06-elevation.md` with the same values. Removed from colours, kept in elevation (which also has the principles).

## Testing
- Content preservation: all hex values, usage descriptions, and section structure intact
- No broken internal links — pointer to `06-elevation.md` is a valid relative link within the same directory
- Agent behaviour unchanged — colour data is still accessible via the pointer
- Risk: **Low** (docs-only change, no code, no agent rules)

## Runtime Testing
`self-assessed` — docs-only change, no runtime environment needed.

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized color and shadow documentation to consolidate design specifications and centralize elevation-related guidance.

* **Chores**
  * Updated internal configuration tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->