### PR TITLE
GH#17122: tighten corporate-traditional colours doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6356,7 +6356,7 @@
       "hash": "9cf792c996d2328f52a21dfb666dc2d7e545aa2e55165d6a043a3938792cd024",
       "at": "2026-04-04T06:02:52Z",
       "passes": 1,
-      "pr": 0
+      "pr": 17132
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6351,6 +6351,12 @@
       "at": "2026-04-04T06:10:00Z",
       "passes": 1,
       "pr": 0
+    },
+    ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
+      "hash": "9cf792c996d2328f52a21dfb666dc2d7e545aa2e55165d6a043a3938792cd024",
+      "at": "2026-04-04T06:02:52Z",
+      "passes": 1,
+      "pr": 0
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/styles/corporate-traditional/02-colours.md
+++ b/.agents/tools/design/library/styles/corporate-traditional/02-colours.md
@@ -3,6 +3,8 @@
 
 # Design System: Corporate Traditional — Colour Palette & Roles
 
+Navy-and-gold palette conveying authority and trust. All hex values are exact; do not substitute.
+
 ## Primary
 
 | Role | Hex | Usage |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Add a one-line palette description to `.agents/tools/design/library/styles/corporate-traditional/02-colours.md` to give agents context before the tables. Update `simplification-state.json` to mark the file as processed.

## Issue
Closes #17122

## Classification
**Reference corpus** (colour palette data tables, not instruction doc). At 55 lines with 6 clean tables, the file is already well-structured. The appropriate action per the issue guidance is to verify structure and add context, not compress or split.

## Files Changed
- `.agents/tools/design/library/styles/corporate-traditional/02-colours.md` — added palette context line (55→57 lines)
- `.agents/configs/simplification-state.json` — registered file as processed (passes: 1)

## Testing
- Content preservation: all hex values, roles, and usage notes present before and after ✓
- No broken internal links or references ✓
- Agent behaviour unchanged (reference corpus, no instruction logic modified) ✓
- `wc -l` after: 57 lines (2 lines added, no content removed) ✓

## Runtime Testing
Risk: **Low** — docs/reference corpus change only. `self-assessed`.

## Key Decisions
- File classified as reference corpus (colour palette data), not instruction doc
- At 55 lines, splitting into chapter files would add overhead without benefit
- Added palette description line to give agents context before diving into tables

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated color palette documentation to clarify the Navy-and-gold design scheme and specification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->