### PR TITLE
GH#17110: tighten clay color palette doc — promote bold sub-headers to ### headings

### DIFF
--- a/.agents/tools/design/library/brands/clay/02-color-palette.md
+++ b/.agents/tools/design/library/brands/clay/02-color-palette.md
@@ -11,35 +11,35 @@
 
 ## Swatch Palette — Named Colors
 
-**Matcha (Green)**
+### Matcha (Green)
 
 - **Matcha 300** (`#84e7a5`): `--_swatches---color--matcha-300`, light green accent
 - **Matcha 600** (`#078a52`): `--_swatches---color--matcha-600`, mid green
 - **Matcha 800** (`#02492a`): `--_swatches---color--matcha-800`, deep green for dark sections
 
-**Slushie (Cyan)**
+### Slushie (Cyan)
 
 - **Slushie 500** (`#3bd3fd`): `--_swatches---color--slushie-500`, bright cyan accent
 - **Slushie 800** (`#0089ad`): `--_swatches---color--slushie-800`, deep teal
 
-**Lemon (Gold)**
+### Lemon (Gold)
 
 - **Lemon 400** (`#f8cc65`): `--_swatches---color--lemon-400`, warm pale gold
 - **Lemon 500** (`#fbbd41`): `--_swatches---color--lemon-500`, primary gold
 - **Lemon 700** (`#d08a11`): `--_swatches---color--lemon-700`, deep amber
 - **Lemon 800** (`#9d6a09`): `--_swatches---color--lemon-800`, dark amber
 
-**Ube (Purple)**
+### Ube (Purple)
 
 - **Ube 300** (`#c1b0ff`): `--_swatches---color--ube-300`, soft lavender
 - **Ube 800** (`#43089f`): `--_swatches---color--ube-800`, deep purple
 - **Ube 900** (`#32037d`): `--_swatches---color--ube-900`, darkest purple
 
-**Pomegranate (Pink/Red)**
+### Pomegranate (Pink/Red)
 
 - **Pomegranate 400** (`#fc7981`): `--_swatches---color--pomegranate-400`, warm coral-pink
 
-**Blueberry (Navy Blue)**
+### Blueberry (Navy Blue)
 
 - **Blueberry 800** (`#01418d`): `--_swatches---color--blueberry-800`, deep navy
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Structural tightening of `.agents/tools/design/library/brands/clay/02-color-palette.md`. Converts 6 informal bold paragraphs (`**Matcha (Green)**`) used as sub-headers in the Swatch Palette section to proper `###` Markdown headings.

## Issue
Closes #17110

## Files Changed
- `.agents/tools/design/library/brands/clay/02-color-palette.md` — 6 bold paragraphs → `###` sub-headers (structural only)

## Testing
- Risk level: **Low** (docs/formatting change only — no logic, no commands, no URLs)
- Self-assessed: all hex values, CSS variable names (`--_swatches---color--*`), and semantic descriptions preserved verbatim
- Line count unchanged: 69 lines before and after
- Content preservation verified: `wc -l` and visual diff confirm zero data loss

## Runtime Testing
`self-assessed` — docs/formatting change, no runtime behaviour affected.

## Key Decisions
- **Reference corpus classification**: file is design system color data, not an instruction doc. Per code-simplifier guidance (GH#6432), reference corpora should not be compressed — only restructured if needed.
- **Structural fix only**: the bold paragraphs were acting as informal sub-headers without proper Markdown heading semantics. Promoting to `###` improves document structure and scannability without any content change.
- **No content removed**: all implementation tokens (CSS vars, hex values) preserved — these are needed by agents referencing the palette in code.

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6