### PR TITLE
GH#17112: tighten agency-feminine colour palette doc

### DIFF
--- a/.agents/tools/design/library/styles/agency-feminine/02-colours.md
+++ b/.agents/tools/design/library/styles/agency-feminine/02-colours.md
@@ -1,14 +1,14 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-# Agency Feminine — Colour Palette
+# Agency Feminine — Colour Palette & Roles
 
 ## Primary
 
 | Role | Hex | Usage |
 |------|-----|-------|
 | Primary | `#d4a5a5` | CTAs, active accents, key links |
-| Primary Hover | `#c79393` | Darker rose for hover states |
+| Primary Hover | `#c79393` | Hover state |
 | Primary Light | `#e8cece` | Soft backgrounds, badges, tag fills |
 | Primary Muted | `#f5ebe7` | Tinted section backgrounds |
 
@@ -17,7 +17,7 @@
 | Role | Hex | Usage |
 |------|-----|-------|
 | Accent | `#9caf88` | Secondary actions, tags, nature/wellness cues |
-| Accent Hover | `#8a9d76` | Darker sage for hover |
+| Accent Hover | `#8a9d76` | Hover state |
 | Accent Light | `#c5d4b8` | Soft accent backgrounds |
 | Tertiary | `#c8a87e` | Gold/honey — sparingly for premium callouts |
 
@@ -47,13 +47,13 @@
 
 | Role | Hex | Usage |
 |------|-----|-------|
-| Success | `#9caf88` | Confirmations, completed states (uses accent) |
+| Success | `#9caf88` | Confirmations, completed (uses accent) |
 | Success Background | `#f0f5ec` | Success message backgrounds |
 | Warning | `#d4a56a` | Gentle warnings, attention needed |
 | Warning Background | `#faf3e8` | Warning message backgrounds |
-| Error | `#c97070` | Errors, required fields (softened red) |
+| Error | `#c97070` | Errors, required fields |
 | Error Background | `#faf0f0` | Error message backgrounds |
-| Info | `#8aacc8` | Informational, help text (soft blue) |
+| Info | `#8aacc8` | Informational, help text |
 | Info Background | `#f0f5fa` | Info message backgrounds |
 
 ## Shadows


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/styles/agency-feminine/02-colours.md` per simplification issue GH#17112.

## Changes
- Add `& Roles` to title for consistency with sibling palette files (e.g., startup-bold)
- Tighten hover state descriptions: "Darker rose for hover states" → "Hover state"
- Remove redundant parenthetical colour qualifiers: "(softened red)", "(soft blue)"
- Remove "states" from "completed states" — redundant with "completed"

## Issue
Closes #17112

## Files Changed
- `.agents/tools/design/library/styles/agency-feminine/02-colours.md` (6 lines tightened, 0 content removed)

## Testing
**Risk level:** Low — reference corpus (colour palette lookup table), no agent behaviour change.
**Verification:** All hex values, role names, section headers, and usage context present before and after. `wc -l` unchanged at 65 lines.

## Runtime Testing
`self-assessed` — docs-only change, no executable code, no agent instructions modified.

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed color palette documentation header to "Colour Palette & Roles"
  * Simplified usage descriptions for semantic color roles and hover states to improve clarity and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->