### PR TITLE
GH#17111: simplify startup-bold 02-colours.md — add section index line

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6345,6 +6345,12 @@
       "at": "2026-04-04T05:30:00Z",
       "lines": 82,
       "issue": "GH#17088"
+    },
+    ".agents/tools/design/library/styles/startup-bold/02-colours.md": {
+      "hash": "e4c5926cee4fea5695a2a9d909f71f09f1f95162",
+      "at": "2026-04-04T00:00:00Z",
+      "passes": 1,
+      "pr": 0
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/styles/startup-bold/02-colours.md
+++ b/.agents/tools/design/library/styles/startup-bold/02-colours.md
@@ -3,6 +3,8 @@
 
 # Startup Bold — Colour Palette & Roles
 
+Design tokens for the Startup Bold style. Six groups: Primary, Accent, Text, Surface, Semantic, Shadows.
+
 ## Primary
 
 | Role | Hex | Usage |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Adds a one-line section index to `.agents/tools/design/library/styles/startup-bold/02-colours.md` so agents can orient to the file structure without scanning all tables. Updates `simplification-state.json` to record this file as reviewed (pass 1).

## Classification
**Reference corpus** (design token tables — hex values, roles, usage). Not an instruction doc. At 68 lines, already compact and well-structured. No splitting needed. Minimal improvement applied: added context line listing the six token groups.

## Issue
Closes #17111

## Files Changed
- `.agents/tools/design/library/styles/startup-bold/02-colours.md` — added section index line (+1 line)
- `.agents/configs/simplification-state.json` — recorded file as reviewed

## Testing
- Content preservation: all hex values, rgba values, role names, and usage descriptions present before and after
- No broken references (file has no internal links)
- Agent behaviour unchanged — tables are identical, only a context line added

## Runtime Testing
**Risk: Low** — docs-only change, no code, no agent rules modified. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6