### PR TITLE
GH#17123: tighten stripe color palette doc

### DIFF
--- a/.agents/tools/design/library/brands/stripe/02-color-palette.md
+++ b/.agents/tools/design/library/brands/stripe/02-color-palette.md
@@ -5,50 +5,50 @@
 
 ## Primary
 
-- **Stripe Purple** (`#533afd`): Primary brand color, CTA backgrounds, link text, interactive highlights. A saturated blue-violet that anchors the entire system.
-- **Deep Navy** (`#061b31`): `--hds-color-heading-solid`. Primary heading color. Not black, not gray -- a very dark blue that adds warmth and depth to text.
+- **Stripe Purple** (`#533afd`): Primary brand color, CTA backgrounds, link text, interactive highlights.
+- **Deep Navy** (`#061b31`): `--hds-color-heading-solid`. Primary heading color.
 - **Pure White** (`#ffffff`): Page background, card surfaces, button text on dark backgrounds.
 
 ## Brand & Dark
 
-- **Brand Dark** (`#1c1e54`): `--hds-color-util-brand-900`. Deep indigo for dark sections, footer backgrounds, and immersive brand moments.
-- **Dark Navy** (`#0d253d`): `--hds-color-core-neutral-975`. The darkest neutral -- almost-black with a blue undertone for maximum depth without harshness.
+- **Brand Dark** (`#1c1e54`): `--hds-color-util-brand-900`. Dark sections, footer backgrounds, immersive brand moments.
+- **Dark Navy** (`#0d253d`): `--hds-color-core-neutral-975`. Darkest neutral for maximum depth.
 
 ## Accent Colors
 
-- **Ruby** (`#ea2261`): `--hds-color-accentColorMode-ruby-icon-solid`. Warm red-pink for icons, alerts, and accent elements.
-- **Magenta** (`#f96bee`): `--hds-color-accentColorMode-magenta-icon-gradientMiddle`. Vivid pink-purple for gradients and decorative highlights.
-- **Magenta Light** (`#ffd7ef`): `--hds-color-util-accent-magenta-100`. Tinted surface for magenta-themed cards and badges.
+- **Ruby** (`#ea2261`): `--hds-color-accentColorMode-ruby-icon-solid`. Icons, alerts, accent elements.
+- **Magenta** (`#f96bee`): `--hds-color-accentColorMode-magenta-icon-gradientMiddle`. Gradients and decorative highlights.
+- **Magenta Light** (`#ffd7ef`): `--hds-color-util-accent-magenta-100`. Magenta-themed cards and badges.
 
 ## Interactive
 
 - **Primary Purple** (`#533afd`): Primary link color, active states, selected elements.
-- **Purple Hover** (`#4434d4`): Darker purple for hover states on primary elements.
-- **Purple Deep** (`#2e2b8c`): `--hds-color-button-ui-iconHover`. Dark purple for icon hover states.
-- **Purple Light** (`#b9b9f9`): `--hds-color-action-bg-subduedHover`. Soft lavender for subdued hover backgrounds.
-- **Purple Mid** (`#665efd`): `--hds-color-input-selector-text-range`. Range selector and input highlight color.
+- **Purple Hover** (`#4434d4`): Hover states on primary elements.
+- **Purple Deep** (`#2e2b8c`): `--hds-color-button-ui-iconHover`. Icon hover states.
+- **Purple Light** (`#b9b9f9`): `--hds-color-action-bg-subduedHover`. Subdued hover backgrounds.
+- **Purple Mid** (`#665efd`): `--hds-color-input-selector-text-range`. Range selector and input highlight.
 
 ## Neutral Scale
 
 - **Heading** (`#061b31`): Primary headings, nav text, strong labels.
 - **Label** (`#273951`): `--hds-color-input-text-label`. Form labels, secondary headings.
 - **Body** (`#64748d`): Secondary text, descriptions, captions.
-- **Success Green** (`#15be53`): Status badges, success indicators (with 0.2-0.4 alpha for backgrounds/borders).
-- **Success Text** (`#108c3d`): Success badge text color.
+- **Success Green** (`#15be53`): Status badges, success indicators (0.2–0.4 alpha for backgrounds/borders).
+- **Success Text** (`#108c3d`): Success badge text.
 - **Lemon** (`#9b6829`): `--hds-color-core-lemon-500`. Warning and highlight accent.
 
 ## Surface & Borders
 
-- **Border Default** (`#e5edf5`): Standard border color for cards, dividers, and containers.
+- **Border Default** (`#e5edf5`): Cards, dividers, containers.
 - **Border Purple** (`#b9b9f9`): Active/selected state borders on buttons and inputs.
-- **Border Soft Purple** (`#d6d9fc`): Subtle purple-tinted borders for secondary elements.
-- **Border Magenta** (`#ffd7ef`): Pink-tinted borders for magenta-themed elements.
-- **Border Dashed** (`#362baa`): Dashed borders for drop zones and placeholder elements.
+- **Border Soft Purple** (`#d6d9fc`): Secondary elements with subtle purple tint.
+- **Border Magenta** (`#ffd7ef`): Magenta-themed elements.
+- **Border Dashed** (`#362baa`): Drop zones and placeholder elements.
 
 ## Shadow Colors
 
-- **Shadow Blue** (`rgba(50,50,93,0.25)`): The signature -- blue-tinted primary shadow color.
-- **Shadow Dark Blue** (`rgba(3,3,39,0.25)`): Deeper blue shadow for elevated elements.
-- **Shadow Black** (`rgba(0,0,0,0.1)`): Secondary shadow layer for depth reinforcement.
-- **Shadow Ambient** (`rgba(23,23,23,0.08)`): Soft ambient shadow for subtle elevation.
-- **Shadow Soft** (`rgba(23,23,23,0.06)`): Minimal ambient shadow for light lift.
+- **Shadow Blue** (`rgba(50,50,93,0.25)`): Primary shadow, blue-tinted.
+- **Shadow Dark Blue** (`rgba(3,3,39,0.25)`): Elevated elements.
+- **Shadow Black** (`rgba(0,0,0,0.1)`): Secondary shadow layer for depth.
+- **Shadow Ambient** (`rgba(23,23,23,0.08)`): Subtle elevation.
+- **Shadow Soft** (`rgba(23,23,23,0.06)`): Minimal ambient lift.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/stripe/02-color-palette.md` by removing decorative prose from reference corpus entries.

## Issue
Closes #17123

## Files Changed
- `.agents/tools/design/library/brands/stripe/02-color-palette.md` — 22 lines changed (same line count, reduced character count)

## Changes
- Removed subjective/decorative descriptions that add no actionable information (e.g., "A saturated blue-violet that anchors the entire system", "Not black, not gray -- a very dark blue that adds warmth and depth to text", "The signature --")
- Preserved all hex values, CSS variable names (`--hds-color-*`), and usage roles
- Tightened redundant phrasing ("Standard border color for" → direct usage, "Darker purple for hover states on" → "Hover states on")
- Fixed typography: `0.2-0.4` → `0.2–0.4` (en-dash for ranges)

## Classification
Reference corpus chapter (already split into chapters 01–09). Not an instruction doc — no compression of rules or decision rationale. Only decorative prose removed.

## Testing
- All hex values present before and after: verified via diff
- All CSS variable names (`--hds-color-*`) present before and after: verified via diff
- All usage roles preserved: verified via diff
- Line count: 54 → 54 (unchanged)

## Runtime Testing
**Risk level:** Low — docs-only change, no code, no agent rules, no task IDs or incident references.
**Verification:** `self-assessed` — diff review confirms zero knowledge loss.

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6