### PR TITLE
GH#17124: tighten NVIDIA responsive behavior doc

### DIFF
--- a/.agents/tools/design/library/brands/nvidia/08-responsive.md
+++ b/.agents/tools/design/library/brands/nvidia/08-responsive.md
@@ -7,48 +7,49 @@
 
 | Name | Width | Key Changes |
 |------|-------|-------------|
-| Mobile Small | &lt;375px | Compact single-column, reduced padding |
-| Mobile | 375-425px | Standard mobile layout |
-| Mobile Large | 425-600px | Wider mobile, some 2-col hints |
-| Tablet Small | 600-768px | 2-column grids begin |
-| Tablet | 768-1024px | Full card grids, expanded nav |
-| Desktop | 1024-1350px | Standard desktop layout |
-| Large Desktop | &gt;1350px | Maximum content width, generous margins |
+| Mobile Small | <375px | Compact single-column, reduced padding |
+| Mobile | 375–425px | Standard mobile layout |
+| Mobile Large | 425–600px | Wider mobile, 2-col hints |
+| Tablet Small | 600–768px | 2-column grids begin |
+| Tablet | 768–1024px | Full card grids, expanded nav |
+| Desktop | 1024–1350px | Standard desktop layout |
+| Large Desktop | >1350px | Max content width, generous margins |
 
 ## Touch Targets
 
-- Buttons use 11px 13px padding for comfortable tap targets
-- Navigation links at 14px uppercase with adequate spacing
-- Green-bordered buttons provide high-contrast touch targets on dark backgrounds
-- Mobile: hamburger menu collapse with full-screen overlay
+- Buttons: 11px 13px padding
+- Nav links: 14px uppercase, adequate spacing
+- Green-bordered buttons: high-contrast on dark backgrounds
+- Mobile: hamburger menu with full-screen overlay
 
 ## Collapsing Strategy
 
-- Hero: 36px heading scales down proportionally
-- Navigation: full horizontal nav collapses to hamburger menu at ~1024px
-- Product cards: 3-column to 2-column to single column stacked
-- Footer: multi-column grid collapses to single stacked column
-- Section spacing: 64-80px reduces to 32-48px on mobile
+- Hero heading: 36px → proportional scale-down
+- Nav: horizontal → hamburger at ~1024px
+- Product cards: 3-col → 2-col → single-col
+- Footer: multi-col → single stacked column
+- Section spacing: 64–80px → 32–48px on mobile
 - Images: maintain aspect ratio, scale to container width
 
 ## Image Behavior
 
-- GPU/product renders maintain high resolution at all sizes
-- Hero images scale proportionally with viewport
-- Card images use consistent aspect ratios
-- Full-bleed dark sections maintain edge-to-edge treatment
+- GPU/product renders: high resolution at all sizes
+- Hero images: scale proportionally with viewport
+- Card images: consistent aspect ratios
+- Full-bleed dark sections: edge-to-edge treatment
 
 ## Typography Scaling
 
-- Display 36px scales to ~24px on mobile
-- Section headings 24px scale to ~20px on mobile
-- Body text maintains 15-16px across all breakpoints
-- Button text maintains 16px for consistent tap targets
+- Display: 36px → ~24px on mobile
+- Section headings: 24px → ~20px on mobile
+- Body: 15–16px (unchanged across breakpoints)
+- Button text: 16px (unchanged)
 
 ## Dark/Light Section Strategy
 
-- Dark sections (black bg, white text) alternate with light sections (white bg, black text)
-- The green accent remains consistent across both surface types
-- On dark: links are white, underlines are green
-- On light: links are black, underlines are green
-- This alternation creates natural scroll rhythm and content grouping
+See `01-visual-theme.md` for full surface philosophy. Responsive behavior:
+
+- Dark (black bg, white text) alternates with light (white bg, black text)
+- Green accent consistent across both surface types
+- Dark: links white, underlines green
+- Light: links black, underlines green


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/nvidia/08-responsive.md` (54 lines) per simplification scan GH#17124.

## Issue
Closes #17124

## Files Changed
- `.agents/tools/design/library/brands/nvidia/08-responsive.md` — 1 file, prose tightened

## Changes
- Convert verbose prose to spec-style entries (e.g., "Buttons use 11px 13px padding for comfortable tap targets" → "Buttons: 11px 13px padding")
- Replace HTML entities (`&lt;`, `&gt;`) with literal `<`, `>` characters
- Use en-dashes and arrow notation for ranges/scaling relationships
- Add cross-reference to `01-visual-theme.md` for dark/light surface philosophy (avoids duplication)
- Remove redundant explanatory text already covered in other chapters

## Classification
Reference corpus (domain knowledge base). No content removed — all spec values, breakpoints, and behavioral rules preserved. Prose compressed only.

## Testing
- `self-assessed` (Low risk: docs-only change, no code, no agent behavior change)
- Content preservation verified: all breakpoint values, px values, and behavioral rules present before and after
- No broken internal references

## Runtime Testing
Risk: **Low** — documentation-only change. No agent behavior affected.

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6