### PR TITLE
GH#17126: tighten remotion-get-audio-duration.md

### DIFF
--- a/.agents/tools/video/remotion-get-audio-duration.md
+++ b/.agents/tools/video/remotion-get-audio-duration.md
@@ -15,30 +15,24 @@ description: Get audio file duration in seconds using Mediabunny's Input.compute
 
 ```tsx
 import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+import { staticFile } from "remotion";
 
 export const getAudioDuration = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src, { getRetryDelay: () => null }),
   });
-
-  const durationInSeconds = await input.computeDuration();
-  return durationInSeconds;
+  return input.computeDuration();
 };
-```
 
-```tsx
-import { staticFile } from "remotion";
-
+// Remote URL or Remotion staticFile()
 const remoteDuration = await getAudioDuration("https://remotion.media/audio.mp3");
 const staticDuration = await getAudioDuration(staticFile("audio.mp3"));
 ```
 
-## Local files
+## Local files (`FileSource`)
 
-Use `FileSource` for browser uploads or drag-and-drop:
+Browser uploads or drag-and-drop:
 
 ```tsx
 import { Input, ALL_FORMATS, FileSource } from "mediabunny";
@@ -47,6 +41,5 @@ const input = new Input({
   formats: ALL_FORMATS,
   source: new FileSource(file), // File object from input or drag-drop
 });
-
 const durationInSeconds = await input.computeDuration();
 ```


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/video/remotion-get-audio-duration.md` per GH#17126 simplification scan.

- Merge two separate code blocks in the URL section into one (eliminates redundant fence pair)
- Inline `getRetryDelay` option (single-property object → inline)
- Remove intermediate `durationInSeconds` variable in helper function (direct return)
- Move `FileSource` class name into section heading for scannability
- Tighten prose: "Use `FileSource` for browser uploads or drag-and-drop:" → "Browser uploads or drag-and-drop:"

**Result:** 52 → 45 lines. All code, imports, URLs, and functionality preserved.

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no executable code changed.
Assessment: `self-assessed` — content-identical transformation, no logic changes.

Closes #17126

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6