### PR TITLE
GH#17125: simplify Startup Bold agent prompts doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6345,6 +6345,12 @@
       "at": "2026-04-04T05:30:00Z",
       "lines": 82,
       "issue": "GH#17088"
+    },
+    ".agents/tools/design/library/styles/startup-bold/09-agent-prompts.md": {
+      "hash": "1b9cf446793ee167529b914a5438353e97c92f4a",
+      "at": "2026-04-04T00:00:00Z",
+      "passes": 1,
+      "pr": null
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/styles/startup-bold/09-agent-prompts.md
+++ b/.agents/tools/design/library/styles/startup-bold/09-agent-prompts.md
@@ -3,30 +3,7 @@
 
 # Startup Bold — Agent Prompt Guide
 
-## Quick Colour Reference
-
-| CSS Variable | Hex | Role |
-|-------------|-----|------|
-| `--color-primary` | `#4f46e5` | Indigo — primary actions |
-| `--color-primary-hover` | `#4338ca` | Primary hover |
-| `--color-primary-light` | `#e0e7ff` | Primary tinted backgrounds |
-| `--color-accent` | `#10b981` | Emerald — secondary CTA |
-| `--color-accent-hover` | `#059669` | Accent hover |
-| `--color-accent-light` | `#d1fae5` | Accent tinted backgrounds |
-| `--color-bg` | `#ffffff` | Page background |
-| `--color-surface-1` | `#f9fafb` | Alternating section bg |
-| `--color-surface-2` | `#f3f4f6` | Input backgrounds |
-| `--color-text` | `#111827` | Primary text |
-| `--color-text-secondary` | `#6b7280` | Secondary text |
-| `--color-text-tertiary` | `#9ca3af` | Placeholder text |
-| `--color-border` | `#e5e7eb` | Default borders |
-| `--color-success` | `#10b981` | Success |
-| `--color-warning` | `#f59e0b` | Warning |
-| `--color-error` | `#ef4444` | Error |
-| `--font-sans` | `'Plus Jakarta Sans', 'Inter', sans-serif` | All text |
-| `--font-mono` | `'JetBrains Mono', monospace` | Code |
-| `--radius-default` | `12px` | Standard radius |
-| `--radius-card` | `16px` | Card radius |
+Colour tokens: see `02-colours.md`.
 
 ## Ready-to-Use Prompts
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Simplified `.agents/tools/design/library/styles/startup-bold/09-agent-prompts.md` from 53 → 30 lines by removing the redundant Quick Colour Reference table.

## Why
The colour table duplicated data already present (and more completely) in `02-colours.md`. The agent prompts file's unique value is the 4 ready-to-use design prompts — those are preserved intact.

## Changes
- Removed 24-line colour token table (redundant with `02-colours.md`)
- Added single-line pointer: `Colour tokens: see \`02-colours.md\`.`
- Updated `simplification-state.json` with new file hash
- All 4 prompts preserved verbatim

## Testing
- `self-assessed` (docs-only change, no runtime behaviour)
- Content verification: all 4 prompts present before and after
- No broken references — `02-colours.md` exists in same directory

## Runtime Testing
`self-assessed` — docs/reference file, low risk per t1660.7 table.

Closes #17125

---
[aidevops.sh](https://aidevops.sh) v3.6.31 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6