### PR TITLE
GH#17122: add CSS variables section to corporate-traditional colours doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6371,5 +6371,11 @@
     "lines": 82,
     "status": "simplified",
     "issue": "GH#17080"
+  },
+  ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
+    "hash": "83084b6d85338c961b19752ae5c0e7842d88b14fe7be78121b6d049f2fbf4c3c",
+    "simplified_at": "2026-04-04T06:22:35Z",
+    "issue": "GH#17122",
+    "action": "added CSS variables quick-reference section"
   }
 }

--- a/.agents/tools/design/library/styles/corporate-traditional/02-colours.md
+++ b/.agents/tools/design/library/styles/corporate-traditional/02-colours.md
@@ -53,3 +53,42 @@
 |------|-------|-------|
 | Shadow colour | `rgba(27, 54, 93, 0.08)` | All shadow definitions |
 | Shadow strong | `rgba(27, 54, 93, 0.15)` | Elevated elements |
+
+## CSS Variables
+
+```css
+:root {
+  /* Primary */
+  --color-primary: #1B365D;
+  --color-primary-light: #2A4A7F;
+  --color-primary-dark: #0F2341;
+
+  /* Accent */
+  --color-gold: #B8860B;
+  --color-gold-light: #D4A843;
+  --color-gold-muted: #C9B97A;
+
+  /* Text */
+  --color-text-heading: #1B365D;
+  --color-text-body: #333333;
+  --color-text-secondary: #6B7280;
+  --color-text-inverse: #FFFFFF;
+
+  /* Surface */
+  --color-bg: #FFFFFF;
+  --color-surface-alt: #F5F5F0;
+  --color-surface-accent: #EEF0F4;
+  --color-border: #D1D5DB;
+  --color-border-strong: #9CA3AF;
+
+  /* Semantic */
+  --color-success: #166534;
+  --color-warning: #92400E;
+  --color-error: #991B1B;
+  --color-info: #1E40AF;
+
+  /* Shadows */
+  --shadow-color: rgba(27, 54, 93, 0.08);
+  --shadow-color-strong: rgba(27, 54, 93, 0.15);
+}
+```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Added a CSS variables quick-reference section to `.agents/tools/design/library/styles/corporate-traditional/02-colours.md`. Updated `simplification-state.json` to mark the file as processed.

## Issue
Closes #17122

## Classification
**Reference corpus chapter** — not an instruction doc. The file is already well-structured at 55 lines with clean data tables. No content compression was appropriate.

The correct action for a reference corpus chapter that is already split: verify structure and add value where possible. Added a `## CSS Variables` section mapping all colour roles to CSS custom properties, making the palette directly usable for CSS implementation without cross-referencing `09-agent-prompts.md`.

## Files Changed
- `.agents/tools/design/library/styles/corporate-traditional/02-colours.md` — added CSS variables block (55 → 94 lines, all new content)
- `.agents/configs/simplification-state.json` — marked file as processed with hash + action metadata

## Testing
- Content preservation: all original tables intact, no removals
- No broken references (file is self-contained)
- CSS variables match all hex/rgba values in the tables above them
- `wc -l` before: 55, after: 94 (39 lines added, 0 removed)

## Runtime Testing
**Risk: Low** — docs-only change, no executable code. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.6.32 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6