### PR TITLE
GH#17129: tighten workers-for-platforms.md — merge Key Features into Architecture

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/workers-for-platforms.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/workers-for-platforms.md
@@ -5,6 +5,8 @@
 
 Multi-tenant platform with isolated customer code execution at scale.
 
+**NOT for general Workers** — only for Workers for Platforms architecture.
+
 ## Use Cases
 
 - Multi-tenant SaaS running customer code
@@ -12,41 +14,27 @@ Multi-tenant platform with isolated customer code execution at scale.
 - Programmable platforms with isolated compute
 - Edge functions/serverless platforms
 - Website builders with static + dynamic content
-- Unlimited app deployment at scale
-
-**NOT for general Workers** - only for Workers for Platforms architecture.
 
 ## Architecture
 
 **4 Components:**
-1. **Dispatch Namespace** - Container for unlimited customer Workers, automatic isolation, untrusted mode
-2. **Dynamic Dispatch Worker** - Entry point, routes requests, enforces platform logic (auth, limits, validation)
-3. **User Workers** - Customer code in isolated sandboxes, API-deployed, optional bindings (KV/D1/R2/DO)
-4. **Outbound Worker** (optional) - Intercepts external fetch, controls egress, logs subrequests
+1. **Dispatch Namespace** — Container for unlimited customer Workers; automatic isolation; untrusted mode
+2. **Dynamic Dispatch Worker** — Entry point; routes requests; enforces platform logic (auth, limits, validation)
+3. **User Workers** — Customer code in isolated sandboxes; API-deployed; optional bindings (KV/D1/R2/DO)
+4. **Outbound Worker** (optional) — Intercepts external fetch; controls egress; logs subrequests
 
 **Request Flow:**
 
 ```
-Request → Dispatch Worker → Determines user Worker → env.DISPATCHER.get("customer") 
-→ User Worker executes (Outbound Worker for external fetch) → Response → Dispatch Worker → Client
+Request → Dispatch Worker → env.DISPATCHER.get("customer") → User Worker
+→ (Outbound Worker for external fetch) → Response → Dispatch Worker → Client
 ```
 
-## Key Features
-
-- Unlimited Workers per namespace (no script limits)
-- Automatic tenant isolation
-- Custom CPU/subrequest limits per customer
-- Hostname routing (subdomains/vanity domains)
-- Egress/ingress control
-- Static assets support
-- Tags for bulk operations
-
-## Quick Start
-
-See [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)
+**Key capabilities:** unlimited Workers per namespace, custom CPU/subrequest limits per customer, hostname routing (subdomains/vanity domains), egress/ingress control, static assets, tags for bulk operations.
 
 ## Refs
 
 - [Docs](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/)
 - [Starter Kit](https://github.com/cloudflare/templates/tree/main/worker-publisher-template)
 - [VibeSDK](https://github.com/cloudflare/vibesdk)
+- [patterns.md](./workers-for-platforms-patterns.md), [gotchas.md](./workers-for-platforms-gotchas.md)


### PR DESCRIPTION
## Summary

- Move `NOT for general Workers` warning to top (primacy effect — LLMs weight earlier context more heavily)
- Merge redundant Key Features bullet list into Architecture section as inline summary
- Merge Quick Start pointer into Refs section (was just a link, not a section)
- Fix broken relative links (`gotchas.md` → `workers-for-platforms-gotchas.md`, `patterns.md` → `workers-for-platforms-patterns.md`)
- 52 → 40 lines; all knowledge preserved

## Issue

Closes #17129

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/workers-for-platforms.md` — 52 → 40 lines

## Testing

**Risk level:** Low (docs/agent prompt only — no code, no runtime behaviour)
**Verification:** `self-assessed` — content preservation confirmed by diff review; all code blocks, URLs, and key concepts present before and after.

## Key Decisions

- Classified as **instruction doc** (not reference corpus): architecture overview + decision rules, not textbook-style content. Correct action: tighten prose, not split into chapters.
- Key Features section was pure duplication of Architecture content — merged rather than kept separate.
- Broken relative links fixed as part of the pass (companion files use full filename, not short aliases).

<!-- MERGE_SUMMARY -->

---
[aidevops.sh](https://aidevops.sh) v3.6.32 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6