### PR TITLE
GH#17111: tighten startup-bold colour palette doc — add section index line

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6351,6 +6351,12 @@
       "at": "2026-04-04T06:10:00Z",
       "passes": 1,
       "pr": 0
+    },
+    ".agents/tools/design/library/styles/startup-bold/02-colours.md": {
+      "hash": "e4c5926cee4fea5695a2a9d909f71f09f1f95162",
+      "at": "2026-04-04T00:00:00Z",
+      "passes": 1,
+      "pr": 0
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/styles/startup-bold/02-colours.md
+++ b/.agents/tools/design/library/styles/startup-bold/02-colours.md
@@ -3,6 +3,8 @@
 
 # Startup Bold — Colour Palette & Roles
 
+Design tokens for the Startup Bold style. Six groups: Primary, Accent, Text, Surface, Semantic, Shadows.
+
 ## Primary
 
 | Role | Hex | Usage |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Adds a one-line section index to `.agents/tools/design/library/styles/startup-bold/02-colours.md`, improving agent navigability by summarising the file's six colour groups upfront.

## Issue
Closes #17111

## Files Changed
- `.agents/tools/design/library/styles/startup-bold/02-colours.md` — added summary line (68→70 lines)
- `.agents/configs/simplification-state.json` — registered file as processed

## Testing
**Risk level:** Low (docs-only change — agent prompt reference file, no code)
**Verification:** `self-assessed` — content preservation confirmed: all hex values, usage descriptions, section headers, and code blocks present before and after. No broken references.

## Key Decisions
- File classified as **reference corpus** (colour palette table), not instruction doc — content was not compressed per GH#6432 guidance
- Added summary index line as the only structural improvement: helps agents skip to relevant section without scanning all 68 lines
- All 30 colour tokens preserved verbatim

---
[aidevops.sh](https://aidevops.sh) v3.6.32 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6