### PR TITLE
GH#17128: tighten chromium-debug-use SKILL.md

### DIFF
--- a/.agents/tools/browser/chromium-debug-use/SKILL.md
+++ b/.agents/tools/browser/chromium-debug-use/SKILL.md
@@ -15,24 +15,22 @@ Read `tools/browser/chromium-debug-use.md` first.
 
 - The user wants help with something already open in Chrome, Brave, Edge, Vivaldi, Chromium, or a compatible Chromium build.
 - The goal is to inspect current browser state before choosing a heavier automation tool.
-- Aidevops needs a local-only, low-dependency path without requiring Playwright, Puppeteer, or a browser extension.
 
 ## Workflow
 
 1. Confirm this is an explicit, user-approved live-session investigation.
-2. Have the user launch the browser with the debug flag from `tools/browser/chromium-debug-use.md` if the endpoint is not already available.
+2. Have the user launch the browser with the debug flag from `tools/browser/chromium-debug-use.md` if not already available.
 3. Use `.agents/scripts/chromium-debug-use-helper.sh version` and `list` to confirm access.
 4. Prefer `snapshot`, `html`, and `eval` to understand the page before using `click`, `type`, `navigate`, or `screenshot`.
 5. Once the flow is understood, hand off to the best-fit longer-term tool:
-   - `tools/browser/playwright.md` for repeatable isolated automation
-   - `tools/browser/dev-browser.md` for an aidevops-managed persistent profile
-   - `tools/browser/playwriter.md` for per-tab extension consent in the user's normal browser
-   - `tools/browser/chrome-devtools.md` for performance, network, and console inspection
+   - `tools/browser/playwright.md` — repeatable isolated automation
+   - `tools/browser/dev-browser.md` — aidevops-managed persistent profile
+   - `tools/browser/playwriter.md` — per-tab extension consent in the user's normal browser
+   - `tools/browser/chrome-devtools.md` — performance, network, and console inspection
 
 ## Safety Rules
 
-- Treat this access as local-only and temporary.
-- Do not assume ambient access; the user must have enabled the debug path for this investigation.
+- Local-only and temporary; the user must have enabled the debug path for this investigation.
 - Prefer loopback endpoints and temporary profiles.
 - Do not use this path for unrelated tabs or long-lived background control.
 


### PR DESCRIPTION
## Summary

Tightens `.agents/tools/browser/chromium-debug-use/SKILL.md` (52 → 50 lines) per simplification scan issue #17128.

**Changes:**
- Removed redundant "Use This Skill When" bullet 3 — safety info already covered in Safety Rules section
- Merged two overlapping safety rules ("local-only and temporary" + "do not assume ambient access") into one
- Tightened workflow step 2 prose ("if the endpoint is not already available" → "if not already available")
- Reformatted handoff list to use `—` separator (consistent with project style)

**Preserved:** all code blocks, command examples, file references, URLs, and all functional rules.

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code changes. Self-assessed.

Closes #17128

---
[aidevops.sh](https://aidevops.sh) v3.6.32 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6