### PR TITLE
GH#17130: tighten pages-functions.md — remove redundant file path comments (52→50 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pages-functions.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pages-functions.md
@@ -25,7 +25,6 @@ Serverless functions on Cloudflare Pages using Workers runtime. File-based routi
 **Single segment** `[param]` → string:
 
 ```js
-// /functions/users/[user].js
 export function onRequest(context) {
   return new Response(`Hello ${context.params.user}`);
 }
@@ -35,7 +34,6 @@ export function onRequest(context) {
 **Multi-segment** `[[param]]` → array:
 
 ```js
-// /functions/users/[[catchall]].js
 export function onRequest(context) {
   return new Response(JSON.stringify(context.params.catchall));
 }


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/services/hosting/cloudflare-platform-skill/pages-functions.md` from 52 to 50 lines by removing redundant file path comments from code blocks. The routing tree diagram above already shows these paths (`/functions/users/[user].js`, `/functions/users/[[catchall]].js`), making the inline comments in code blocks redundant.

## Issue
Closes #17130

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/pages-functions.md` — 52→50 lines (2 lines removed)

## Testing
- All code blocks preserved intact
- All `// Matches:` comments retained (valuable — show runtime behavior)
- Routing tree diagram unchanged
- Key Features and See Also sections unchanged
- No URLs, task IDs, or command examples affected
- Risk: **Low** (docs-only, no logic change) — `self-assessed`

## Key Decisions
- Removed only the file path comments that duplicate the routing tree (lines 28, 38 in original)
- Retained `// Matches:` comments — these show runtime behavior not visible in the tree
- No content compression beyond genuine noise removal

---
[aidevops.sh](https://aidevops.sh) v3.6.32 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6