### PR TITLE
GH#17143: tighten Cloudflare Workers KV doc

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/kv.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/kv.md
@@ -3,12 +3,7 @@
 
 # Cloudflare Workers KV
 
-Globally distributed, eventually consistent key-value store for read-heavy, low-latency access.
-
-## Best Fit
-
-- Use for config storage, user sessions, feature flags, caching, and A/B testing.
-- Choose D1 or Durable Objects when you need strong consistency.
+Globally distributed, eventually consistent key-value store for read-heavy, low-latency access. Use for config storage, user sessions, feature flags, caching, and A/B testing. Choose D1 or Durable Objects when you need strong consistency.
 
 ## Core Properties
 


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/cloudflare-platform-skill/kv.md` per the simplification scan in GH#17143.

**Change:** Merged the `## Best Fit` section (header + 2 bullets) into the intro paragraph. Reduces from 52 → 47 lines with zero content loss.

**Preserved:** All use-cases (config storage, sessions, feature flags, caching, A/B testing), consistency guidance (D1/DO recommendation), Core Properties table, Quick Start examples, Core API reference table, and Read Next navigation links.

**Classification:** Instruction doc (not reference corpus) — prose tightening is appropriate per `code-simplifier.md`.

## Runtime Testing

Risk: **Low** — docs-only change, no code or agent behaviour affected. `self-assessed`.

Verification: `markdownlint-cli2` — 0 errors. Content audit: all code blocks, URLs, and API references present before and after.

Closes #17143

---
[aidevops.sh](https://aidevops.sh) v3.6.32 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6