### PR TITLE
GH#17147: tighten nothing-design-skill color token doc structure

### DIFF
--- a/.agents/tools/ui/nothing-design-skill/tokens/02-color.md
+++ b/.agents/tools/ui/nothing-design-skill/tokens/02-color.md
@@ -25,11 +25,13 @@
 | `--accent-subtle` | `rgba(215,25,33,0.15)` | Accent tint backgrounds |
 | `--success` | `#4A9E5C` | Confirmed, completed, connected |
 | `--warning` | `#D4A843` | Caution, pending, degraded |
-| `--error` | `#D71921` | Shares accent red -- errors ARE the accent moment |
+| `--error` | `#D71921` | Shares accent red — errors ARE the accent moment |
 | `--info` | `#999999` | Uses secondary text color |
 | `--interactive` | `#007AFF` / `#5B9BF6` | Tappable text: links, picker values. Not for buttons. |
 
-Data status: `--success` = good, `--warning` = attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply color to **value**, not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
+### Data Status Rules
+
+`--success` = good, `--warning` = attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply color to **value**, not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
 
 ## Dark / Light Mode
 
@@ -46,6 +48,8 @@ Data status: `--success` = good, `--warning` = attention, `--accent` = bad/over 
 | `--text-display` | `#FFFFFF` | `#000000` |
 | `--interactive` | `#5B9BF6` | `#007AFF` |
 
+### Mode Philosophy
+
 Identical across modes: accent red, status colors, ALL CAPS labels, fonts, type scale, spacing, component shapes.
 
-Dark: OLED black, white data glowing (instrument panel). Light: off-white paper (#F5F5F5), black ink; cards `#FFFFFF` = subtle elevation without shadows.
+Dark: OLED black, white data glowing (instrument panel). Light: off-white paper (`#F5F5F5`), black ink; cards `#FFFFFF` = subtle elevation without shadows.


### PR DESCRIPTION
## Summary

Structural improvements to `.agents/tools/ui/nothing-design-skill/tokens/02-color.md` (reference corpus, 51 lines).

**Classification:** Reference corpus (design token tables with hex values, contrast ratios, usage rules). Not an instruction doc — content compression would lose information. Applied structural improvements instead.

**Changes:**
- Promote inline prose after Accent & Status Colors table to `### Data Status Rules` subsection
- Promote trailing inline prose to `### Mode Philosophy` subsection
- Fix `--` double-dash to em-dash `—` in error token description
- Wrap bare `#F5F5F5` hex value in backticks in Mode Philosophy

**Content preservation:** All token values, contrast ratios, usage rules, and design rationale preserved. Zero information loss.

## Runtime Testing

**Risk level:** Low — docs/reference corpus only, no code changes.
**Verification:** `self-assessed` — file renders correctly as Markdown, all tables intact, all content present.

## Files Changed

- `.agents/tools/ui/nothing-design-skill/tokens/02-color.md` (51 → 55 lines, structural only)

Closes #17147

---
[aidevops.sh](https://aidevops.sh) v3.6.32 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6