### PR TITLE
chore: mark multimodal-evaluation.md as converged in simplification state (GH#16864)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6369,6 +6369,12 @@
       "at": "2026-04-04T00:00:00Z",
       "passes": 1,
       "pr": 17146
+    },
+    ".agents/tools/multimodal-evaluation.md": {
+      "hash": "da3da79d8c549978225657036561d1a67fed9b71",
+      "at": "2026-04-04T06:18:00Z",
+      "passes": 1,
+      "pr": 17142
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {


### PR DESCRIPTION
Mark `.agents/tools/multimodal-evaluation.md` as converged in simplification-state.json following PR #17142 (GH#16864).

This prevents the simplification scanner from re-flagging the file in future sweeps.

<!-- MERGE_SUMMARY -->
**What**: Update simplification-state.json to track multimodal-evaluation.md as converged
**Issue**: GH#16864 (via PR #17142)
**Files changed**: 1 (.agents/configs/simplification-state.json)
**Testing**: Self-assessed (config-only change)
**Key decisions**: Required to prevent re-flagging of already-simplified file


---
[aidevops.sh](https://aidevops.sh) v3.6.39 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6