### PR TITLE
GH#17171: tighten vercel color palette doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6415,5 +6415,10 @@
     "lines": 30,
     "status": "simplified",
     "issue": "GH#17125"
+  },
+  ".agents/tools/design/library/brands/vercel/02-color-palette.md": {
+    "hash": "fff9407e385c159cda7e8381b09bb8a3503ffff2855189216f25bafef834fe78",
+    "status": "simplified",
+    "issue": 17171
   }
 }

--- a/.agents/tools/design/library/brands/vercel/02-color-palette.md
+++ b/.agents/tools/design/library/brands/vercel/02-color-palette.md
@@ -45,4 +45,6 @@
 
 ## Shadows & Depth
 
-See `06-depth-elevation.md` for the full shadow system and philosophy.
+See [`06-depth-elevation.md`](06-depth-elevation.md) for the full shadow system and philosophy.
+
+Legacy token → level mapping: Border Shadow = Ring (Level 1), Subtle Elevation = Subtle Card (Level 2), Card Stack = Full Card (Level 3), Ring Border = Light Ring (Level 1b).

--- a/.agents/tools/design/library/brands/vercel/02-color-palette.md
+++ b/.agents/tools/design/library/brands/vercel/02-color-palette.md
@@ -45,7 +45,4 @@
 
 ## Shadows & Depth
 
-- **Border Shadow** (`rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`): The signature — replaces traditional borders.
-- **Subtle Elevation** (`rgba(0, 0, 0, 0.04) 0px 2px 2px`): Minimal lift for cards.
-- **Card Stack** (`rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, rgba(0,0,0,0.04) 0px 8px 8px -8px, #fafafa 0px 0px 0px 1px`): Full multi-layer card shadow.
-- **Ring Border** (`rgb(235, 235, 235) 0px 0px 0px 1px`): Light gray ring-border for tabs and images.
+See `06-depth-elevation.md` for the full shadow system and philosophy.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Remove duplicate Shadows & Depth content from `.agents/tools/design/library/brands/vercel/02-color-palette.md`. The shadow values were already fully documented in `06-depth-elevation.md` with a better table format and philosophy explanation. Replace the 4-item duplicate list with a single pointer line.

## Issue
Closes #17171

## Files Changed
- `.agents/tools/design/library/brands/vercel/02-color-palette.md` — removed duplicate shadow section, added pointer to `06-depth-elevation.md`
- `.agents/configs/simplification-state.json` — updated hash for processed file

## Testing
- Content preservation: all color values, CSS variables, and hex codes present before and after ✓
- No broken internal references — pointer to `06-depth-elevation.md` is valid ✓
- Shadow data fully preserved in `06-depth-elevation.md` (Level 1, 1b, 2, 3 table) ✓
- Line count: 51 → 48 (removed 4 duplicate lines, added 1 pointer)

## Key Decisions
- File classified as **reference corpus** (color palette data), not instruction doc
- Correct action per issue: eliminate duplication, not compress content
- Shadow section removed from color palette file because it belongs in the depth/elevation file — separation of concerns

## Runtime Testing
`self-assessed` — docs-only change, no runtime behavior affected

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated shadow and depth token documentation by moving references to a dedicated design resource file.

* **Chores**
  * Updated internal tracking configuration for design documentation simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->