### PR TITLE
GH#17172: tighten Raycast component stylings doc

### DIFF
--- a/.agents/tools/design/library/brands/raycast/04-components.md
+++ b/.agents/tools/design/library/brands/raycast/04-components.md
@@ -9,14 +9,14 @@
 - **Secondary Button**: Transparent background, white text, 6px radius, `1px solid rgba(255, 255, 255, 0.1)` border, subtle drop shadow (`rgba(0, 0, 0, 0.03) 0px 7px 3px`). Hover: opacity 0.6
 - **Ghost Button**: No background or border, gray text (`#6a6b6c`), 86px radius, same inset shadow. Hover: opacity 0.6, text brightens to white
 - **CTA (Download)**: Semi-transparent white background (`hsla(0, 0%, 100%, 0.815)`), dark text (`#18191a`), pill shape. Hover: full white background (`hsl(0, 0%, 100%)`)
-- **Transition**: All buttons use opacity transition for hover rather than background-color change — a signature Raycast interaction pattern
+- **Transition**: All buttons use opacity transition on hover, not background-color — signature Raycast pattern
 
 ## Cards & Containers
 
 - **Standard Card**: `#101111` surface, `1px solid rgba(255, 255, 255, 0.06)` border, 12px–16px border-radius
 - **Elevated Card**: Ring shadow `rgb(27, 28, 30) 0px 0px 0px 1px` outer + `rgb(7, 8, 10) 0px 0px 0px 1px inset` inner — creates a double-ring containment
 - **Feature Card**: 16px–20px border-radius, subtle warm glow (`rgba(215, 201, 175, 0.05) 0px 0px 20px 5px`) behind hero elements
-- **Hover**: Cards brighten slightly via border opacity increase or subtle shadow enhancement
+- **Hover**: Border opacity increase or subtle shadow enhancement
 
 ## Inputs & Forms
 
@@ -47,5 +47,4 @@
 
 ## Badges & Tags
 
-- **Neutral badge**: `#1b1c1e` background, white text, 6px radius, 14px font at weight 500, `0px 6px` padding
-- Compact, pill-like treatment for categorization
+- **Neutral badge**: `#1b1c1e` background, white text, 6px radius, 14px/500 font, `0px 6px` padding — compact pill for categorization

--- a/.agents/tools/design/library/brands/raycast/04-components.md
+++ b/.agents/tools/design/library/brands/raycast/04-components.md
@@ -47,4 +47,4 @@
 
 ## Badges & Tags
 
-- **Neutral badge**: `#1b1c1e` background, white text, 6px radius, 14px/500 font, `0px 6px` padding — compact pill for categorization
+- **Neutral badge**: `#1b1c1e` background, white text, 6px radius, 14px weight 500, `0px 6px` padding — compact pill for categorization


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/design/library/brands/raycast/04-components.md` (51 → 50 lines).

## Issue
Closes #17172

## Classification
**Reference corpus** (design system component specs with CSS values, colors, shadows). At 51 lines, chapter splitting would add overhead without benefit — prose tightening is the correct action.

## Files Changed
- `.agents/tools/design/library/brands/raycast/04-components.md` — 3 prose compressions, zero content loss

## Changes
- Button transition note: removed "rather than background-color change" redundancy, shortened "a signature Raycast interaction pattern" → "signature Raycast pattern"
- Card hover: removed "Cards brighten slightly via" prefix (implied by context)
- Badge entry: merged two-line entry into one, shortened "14px font at weight 500" → "14px/500 font"

## Testing
**Risk: Low** (docs-only change, no code). Self-assessed.

- All CSS values preserved: `rgba(255, 255, 255, 0.1)`, `hsla(0, 0%, 100%, 0.815)`, `#101111`, `rgb(27, 28, 30)`, `rgba(215, 201, 175, 0.05)`, `#07080a`, `hsla(202, 100%, 67%, 0.15)`, `#f9f9f9`, `#6a6b6c`, `#9c9c9d`, `#121212`, `#0d0d0d`, `rgba(0, 0, 0, 0.4)`, `#1b1c1e`, `#18191a`
- All section headings preserved: Buttons, Cards & Containers, Inputs & Forms, Navigation, Image Treatment, Keyboard Shortcut Keys, Badges & Tags
- No broken references

## Runtime Testing
`self-assessed` — docs-only, no runtime required

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6