### PR TITLE
GH#17168: tighten agency-creative layout doc (51→46 lines)

### DIFF
--- a/.agents/tools/design/library/styles/agency-creative/05-layout.md
+++ b/.agents/tools/design/library/styles/agency-creative/05-layout.md
@@ -28,16 +28,11 @@
 
 ## Breakpoints
 
-| Name | Width | Columns | Gutter |
-|------|-------|---------|--------|
-| Mobile | 0–767px | 4 | 16px |
-| Tablet | 768–1023px | 8 | 24px |
-| Desktop | 1024–1439px | 12 | 40px |
-| Wide | 1440px+ | 12 | 40px |
+See `08-responsive.md` for breakpoint definitions and layout behaviour per viewport.
 
 ## Whitespace Philosophy
 
-Whitespace is a design element. Generous space around large type and hero content creates drama and draws the eye. Use visual weight contrast — dense information areas next to open breathing room — to create rhythm down the page.
+Whitespace is a design element. Use generous space around large type and hero content for drama. Contrast dense information areas with open breathing room to create page rhythm.
 
 ## Border Radius Scale
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Simplifies `.agents/tools/design/library/styles/agency-creative/05-layout.md` from 51 to 46 lines.

## Issue
Closes #17168

## Changes
- **Breakpoints section**: Replaced duplicate 4-row table with a single cross-reference to `08-responsive.md` (which already contains the canonical breakpoint definitions and layout behaviour)
- **Whitespace Philosophy**: Tightened 2 verbose sentences into 2 concise sentences — same meaning, fewer words

## Files Changed
- `.agents/tools/design/library/styles/agency-creative/05-layout.md` (51→46 lines, -5 lines)

## Testing
**Risk level:** Low — docs-only change, no code, no agent logic.

**Verification:**
- All design tokens (spacing scale, grid, border radius) preserved verbatim
- No broken internal references — `08-responsive.md` exists and contains the breakpoint data
- No task IDs, incident references, or command examples in this file to preserve

## Runtime Testing
`self-assessed` — docs-only change, no runtime behaviour affected.

## Key Decisions
- **Reference corpus classification**: File contains design system tokens (structured tables), not agent instruction rules. Appropriate action is cross-referencing duplicated data, not content compression.
- **Breakpoints deduplication**: The table in `05-layout.md` was a subset of `08-responsive.md` — removing it eliminates maintenance drift risk.

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6