### PR TITLE
GH#17173: tighten nvidia color palette chapter to table format

### DIFF
--- a/.agents/tools/design/library/brands/nvidia/02-color-palette.md
+++ b/.agents/tools/design/library/brands/nvidia/02-color-palette.md
@@ -5,47 +5,61 @@
 
 ## Primary Brand
 
-- **NVIDIA Green** (`#76b900`): The signature — borders, link underlines, CTA outlines, active indicators. Never used as large surface fills.
-- **True Black** (`#000000`): Primary page background, text on light surfaces, dominant tone.
-- **Pure White** (`#ffffff`): Text on dark backgrounds, light section backgrounds, card surfaces.
+| Token | Hex | Role |
+|-------|-----|------|
+| NVIDIA Green | `#76b900` | Signature — borders, link underlines, CTA outlines, active indicators. Never large surface fills. |
+| True Black | `#000000` | Primary page background, text on light surfaces, dominant tone. |
+| Pure White | `#ffffff` | Text on dark backgrounds, light section backgrounds, card surfaces. |
 
-## Extended Brand Palette
+## Extended Brand
 
-- **NVIDIA Green Light** (`#bff230`): Bright lime accent for highlights and hover states.
-- **Orange 400** (`#df6500`): Warm accent for alerts, featured badges, or energy-related contexts.
-- **Yellow 300** (`#ef9100`): Secondary warm accent, product category highlights.
-- **Yellow 050** (`#feeeb2`): Light warm surface for callout backgrounds.
+| Token | Hex | Role |
+|-------|-----|------|
+| NVIDIA Green Light | `#bff230` | Bright lime accent for highlights and hover states. |
+| Orange 400 | `#df6500` | Warm accent for alerts, featured badges, energy-related contexts. |
+| Yellow 300 | `#ef9100` | Secondary warm accent, product category highlights. |
+| Yellow 050 | `#feeeb2` | Light warm surface for callout backgrounds. |
 
 ## Status & Semantic
 
-- **Red 500** (`#e52020`): Error states, destructive actions, critical alerts.
-- **Red 800** (`#650b0b`): Deep red for severe warning backgrounds.
-- **Green 500** (`#3f8500`): Success states, positive indicators (darker than brand green).
-- **Blue 700** (`#0046a4`): Informational accents, link hover alternative.
+| Token | Hex | Role |
+|-------|-----|------|
+| Red 500 | `#e52020` | Error states, destructive actions, critical alerts. |
+| Red 800 | `#650b0b` | Deep red for severe warning backgrounds. |
+| Green 500 | `#3f8500` | Success states, positive indicators (darker than brand green). |
+| Blue 700 | `#0046a4` | Informational accents, link hover alternative. |
 
 ## Decorative
 
-- **Purple 800** (`#4d1368`): Deep purple for gradient ends, premium/AI contexts.
-- **Purple 100** (`#f9d4ff`): Light purple surface tint.
-- **Fuchsia 700** (`#8c1c55`): Rich accent for special promotions or featured content.
+| Token | Hex | Role |
+|-------|-----|------|
+| Purple 800 | `#4d1368` | Deep purple for gradient ends, premium/AI contexts. |
+| Purple 100 | `#f9d4ff` | Light purple surface tint. |
+| Fuchsia 700 | `#8c1c55` | Rich accent for special promotions or featured content. |
 
 ## Neutral Scale
 
-- **Gray 300** (`#a7a7a7`): Muted text, disabled labels.
-- **Gray 400** (`#898989`): Secondary text, metadata.
-- **Gray 500** (`#757575`): Tertiary text, placeholders, footers.
-- **Gray Border** (`#5e5e5e`): Subtle borders, divider lines.
-- **Near Black** (`#1a1a1a`): Dark surfaces, card backgrounds on black pages.
+| Token | Hex | Role |
+|-------|-----|------|
+| Gray 300 | `#a7a7a7` | Muted text, disabled labels. |
+| Gray 400 | `#898989` | Secondary text, metadata. |
+| Gray 500 | `#757575` | Tertiary text, placeholders, footers. |
+| Gray Border | `#5e5e5e` | Subtle borders, divider lines. |
+| Near Black | `#1a1a1a` | Dark surfaces, card backgrounds on black pages. |
 
 ## Interactive States
 
-- **Link Default (dark bg)** (`#ffffff`): White links on dark backgrounds.
-- **Link Default (light bg)** (`#000000`): Black links with green underline on light backgrounds.
-- **Link Hover** (`#3860be`): Blue shift on hover across all link variants.
-- **Button Hover** (`#1eaedb`): Teal highlight for button hover states.
-- **Button Active** (`#007fff`): Bright blue for active/pressed button states.
-- **Focus Ring** (`2px solid #000000`): Black outline for keyboard focus.
+| Token | Value | Role |
+|-------|-------|------|
+| Link Default (dark bg) | `#ffffff` | White links on dark backgrounds. |
+| Link Default (light bg) | `#000000` | Black links with green underline on light backgrounds. |
+| Link Hover | `#3860be` | Blue shift on hover across all link variants. |
+| Button Hover | `#1eaedb` | Teal highlight for button hover states. |
+| Button Active | `#007fff` | Bright blue for active/pressed button states. |
+| Focus Ring | `2px solid #000000` | Black outline for keyboard focus. |
 
 ## Shadows & Depth
 
-- **Card Shadow** (`rgba(0, 0, 0, 0.3) 0px 0px 5px 0px`): Subtle ambient shadow for elevated cards.
+| Token | Value | Role |
+|-------|-------|------|
+| Card Shadow | `rgba(0,0,0,0.3) 0px 0px 5px 0px` | Subtle ambient shadow for elevated cards. |


### PR DESCRIPTION
## Summary

- Converts bullet-list format to structured Markdown tables in `.agents/tools/design/library/brands/nvidia/02-color-palette.md`
- All hex values, token names, and role descriptions preserved — zero content loss
- Section header "Extended Brand Palette" shortened to "Extended Brand" (tighter, consistent with table column naming)
- Table format improves scannability for agent color reference lookups

Closes #17173

## What

Restructured the NVIDIA color palette chapter from verbose bullet-list format to compact tables. Each section (Primary Brand, Extended Brand, Status & Semantic, Decorative, Neutral Scale, Interactive States, Shadows & Depth) now uses a `Token | Hex/Value | Role` table.

## Files Changed

- `.agents/tools/design/library/brands/nvidia/02-color-palette.md` — format restructure (51 → 65 lines; line increase is from table headers, not content expansion)

## Testing

- Content verification: all hex codes, token names, and role descriptions present before and after
- No broken internal links (file is a standalone chapter with no internal refs)
- DESIGN.md index unchanged — chapter file pointer still valid

## Runtime Testing

**Risk level:** Low — docs/agent prompt file, no executable code.
**Verification:** `self-assessed` — content diff reviewed, all values preserved.

<!-- MERGE_SUMMARY -->
**What:** Reformatted NVIDIA color palette chapter from bullet lists to tables for improved agent scannability.
**Issue:** Closes #17173
**Files changed:** 1 (`.agents/tools/design/library/brands/nvidia/02-color-palette.md`)
**Testing:** Content diff verified — all hex values, token names, role descriptions preserved.
**Key decisions:** Table format chosen over bullet list for structured reference data; slight line count increase (51→65) is acceptable as it comes from table headers, not content bloat.

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6