### PR TITLE
GH#17174: tighten runners-README.md agent doc

### DIFF
--- a/.agents/tools/ai-assistants/runners-README.md
+++ b/.agents/tools/ai-assistants/runners-README.md
@@ -36,8 +36,6 @@ Four required sections — keep under 500 words (runners get the full prompt on 
 
 ## Evolving Runners into Shared Agents
 
-When a runner proves valuable across multiple projects:
-
 1. **Draft** — save to `~/.aidevops/agents/draft/` with `status: draft` in frontmatter
 2. **Custom** — move to `~/.aidevops/agents/custom/` for permanent private use
 3. **Shared** — refine to framework standards and submit a PR to `.agents/` in the aidevops repo
@@ -45,7 +43,4 @@ When a runner proves valuable across multiple projects:
 Log a TODO when a runner has reuse potential: `- [ ] tXXX Review runner {name} for promotion #agent-review`
 
 See `tools/build-agent/build-agent.md` "Agent Lifecycle Tiers" for the full promotion workflow.
-
-## Parallel vs Sequential
-
-See the [decision guide](headless-dispatch.md#parallel-vs-sequential) in headless-dispatch.md.
+Parallel vs sequential dispatch: [decision guide](headless-dispatch.md#parallel-vs-sequential).


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ai-assistants/runners-README.md` per simplification scan (GH#17174).

## Changes
- Removed redundant intro sentence in "Evolving Runners" section (heading is self-explanatory)
- Merged standalone "Parallel vs Sequential" section into a single reference line at end of "Evolving" section
- 51 → 46 lines; all institutional knowledge, links, code blocks, and task ID references preserved

## Issue
Closes #17174

## Files Changed
- `.agents/tools/ai-assistants/runners-README.md`

## Runtime Testing
**Risk level:** Low — docs/agent prompt only, no code changes.
**Verification:** `self-assessed` — markdownlint-cli2 passes (0 errors), content preservation verified manually.

## Key Decisions
- Classified as instruction doc (not reference corpus) — tightened prose, not split into chapters
- No content removed; only redundant/duplicative prose eliminated

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6