### PR TITLE
GH#17176: tighten agent doc Cloudflare Cache Reserve

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cache-reserve.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cache-reserve.md
@@ -47,5 +47,5 @@ curl -I https://example.com/asset.jpg | grep -i cache
 
 ## See Also
 
-- [Patterns](./patterns.md) - Best practices and architecture patterns
-- [Gotchas](./gotchas.md) - Common issues, troubleshooting, limits
+- [Patterns](./cache-reserve-patterns.md) - Best practices and architecture patterns
+- [Gotchas](./cache-reserve-gotchas.md) - Common issues, troubleshooting, limits


### PR DESCRIPTION
## Summary

Fix broken `See Also` links in `.agents/services/hosting/cloudflare-platform-skill/cache-reserve.md`. The links pointed to `./patterns.md` and `./gotchas.md` which don't exist — the correct filenames are `cache-reserve-patterns.md` and `cache-reserve-gotchas.md`.

The file is already well-structured at 51 lines (reference corpus per `code-simplifier.md` classification). No content compression was applied — the issue guidance correctly notes that reference corpora should be restructured into chapters, not compressed, and this file is already appropriately sized.

## What Changed

- Fixed `See Also` link: `./patterns.md` → `./cache-reserve-patterns.md`
- Fixed `See Also` link: `./gotchas.md` → `./cache-reserve-gotchas.md`

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/cache-reserve.md` (2 lines changed)

## Testing

**Risk level:** Low (docs/links only, no logic changes)
**Verification:** Confirmed target files exist: `cache-reserve-patterns.md` (136 lines) and `cache-reserve-gotchas.md` (132 lines) — both present in the same directory.

## Runtime Testing

`self-assessed` — link-only fix, no runtime behaviour affected.

Closes #17176

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6