### PR TITLE
GH#17194: tighten memory-patterns.md

### DIFF
--- a/.agents/aidevops/memory-patterns.md
+++ b/.agents/aidevops/memory-patterns.md
@@ -21,7 +21,7 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Persistent memory files that instruct AI CLI tools to read `~/AGENTS.md`
-- **Config script**: `.agents/scripts/ai-cli-config.sh`
+- **Config script**: `.agents/scripts/ai-cli-config.sh` — `configure_qwen_cli()`, `create_ai_memory_files()`, `create_project_memory_files()`
 - **Setup**: `setup.sh` auto-creates all memory files (detects installed tools, preserves existing)
 - **Warp AI / Amp Code**: Use project context only (no memory files)
 
@@ -39,13 +39,3 @@ All files contain: `At the beginning of each session, read ~/AGENTS.md to get ad
 | Cursor AI | `~/.cursorrules` | `.cursorrules` |
 | GitHub Copilot | `~/.github/copilot-instructions.md` | -- |
 | Factory.ai Droid | `~/.factory/DROID.md` | -- |
-
-## Setup Integration
-
-`ai-cli-config.sh` functions:
-
-- `configure_qwen_cli()` -- QWEN.md creation/verification
-- `create_ai_memory_files()` -- all home directory memory files
-- `create_project_memory_files()` -- all project-level memory files
-
-Detection is automatic: checks for installed tools, creates appropriate files, preserves existing content.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/aidevops/memory-patterns.md` per simplification-debt scan (GH#17194).

## Changes
- Merged "Setup Integration" section (3 function names + trailing sentence) inline into the Quick Reference bullet for `ai-cli-config.sh`
- Removed redundant standalone section and trailing explanatory sentence
- 51 → 41 lines; all institutional knowledge preserved

## Issue
Closes #17194

## Files Changed
- `.agents/aidevops/memory-patterns.md`

## Testing
**Risk level:** Low (docs/agent prompt only — no code, no runtime behaviour change)
**Runtime Testing:** `self-assessed` — content preservation verified by diff; all tool paths, file locations, function names, and setup behaviour intact.

## Key Decisions
- Classified as instruction doc (not reference corpus): correct action is prose tightening, not chapter splitting
- Function names moved inline rather than deleted — they remain discoverable without a separate section

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6