### PR TITLE
GH#17193: tighten developer-dark component stylings to CSS block format

### DIFF
--- a/.agents/tools/design/library/styles/developer-dark/04-components.md
+++ b/.agents/tools/design/library/styles/developer-dark/04-components.md
@@ -1,72 +1,91 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
 # Design System: Developer Dark — Component Stylings
 
 ## Buttons
 
-**Primary (Green)**
+```css
+/* Primary (Green) */
+background: #4ade80
+color: #111827
+border: none
+border-radius: 4px
+padding: 8px 16px
+font: JetBrains Mono 13px/1 600; text-transform: uppercase; letter-spacing: 0.5px
 
-- Background: `#4ade80`
-- Text: `#111827` (dark on green for contrast)
-- Border: none
-- Radius: 4px
-- Padding: 8px 16px
-- Font: JetBrains Mono, 13px, weight 600, uppercase, letter-spacing 0.5px
-- Hover: background `#22c55e`
-- Focus: outline `2px solid #4ade80`, outline-offset `2px`
-- Active: background `#16a34a`
-- Disabled: opacity 0.4, cursor not-allowed
+:hover    → background: #22c55e
+:focus    → outline: 2px solid #4ade80; outline-offset: 2px
+:active   → background: #16a34a
+:disabled → opacity: 0.4; cursor: not-allowed
 
-**Secondary (Ghost)**
+/* Secondary (Ghost) */
+background: transparent
+color: #f9fafb
+border: 1px solid #374151
+border-radius: 4px
+padding: 8px 16px
 
-- Background: transparent
-- Text: `#f9fafb`
-- Border: `1px solid #374151`
-- Radius: 4px
-- Padding: 8px 16px
-- Hover: background `#1f2937`, border-color `#4b5563`
-- Focus: outline `2px solid #4ade80`, outline-offset `2px`
+:hover    → background: #1f2937; border-color: #4b5563
+:focus    → outline: 2px solid #4ade80; outline-offset: 2px
 
-**Danger**
+/* Danger */
+background: #ef4444
+color: #ffffff
+border: none
+border-radius: 4px
 
-- Background: `#ef4444`
-- Text: `#ffffff`
-- Border: none
-- Radius: 4px
-- Hover: background `#dc2626`
+:hover    → background: #dc2626
+```
 
 ## Inputs
 
-**Text Input**
+```css
+/* Text Input */
+background: #0d1117
+color: #f9fafb
+border: 1px solid #374151
+border-radius: 4px
+padding: 8px 12px
+font: JetBrains Mono 14px/1 400
+placeholder-color: #6b7280
 
-- Background: `#0d1117`
-- Text: `#f9fafb`
-- Border: `1px solid #374151`
-- Radius: 4px
-- Padding: 8px 12px
-- Font: JetBrains Mono, 14px, weight 400
-- Placeholder: `#6b7280`
-- Focus: border-color `#4ade80`, box-shadow `0 0 0 2px rgba(74, 222, 128, 0.2)`
-- Error: border-color `#ef4444`, box-shadow `0 0 0 2px rgba(239, 68, 68, 0.2)`
+:focus → border-color: #4ade80; box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.2)
+:error → border-color: #ef4444; box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2)
+```
 
 ## Links
 
-- Default: `#3b82f6`, underline (body text links — accessibility requirement; see 07-dos-donts.md)
-- Hover: `#60a5fa`, underline
-- Active: `#2563eb`
-- Code links: `#4ade80`, hover `#22c55e`
+```css
+color: #3b82f6; text-decoration: underline  /* body text — accessibility requirement; see 07-dos-donts.md */
+:hover  → color: #60a5fa
+:active → color: #2563eb
+/* code links */ color: #4ade80; :hover → color: #22c55e
+```
 
 ## Cards & Containers
 
-- Background: `#1f2937`
-- Border: `1px solid #374151`
-- Radius: 4px
-- Padding: 16px
-- Shadow: none (border-driven depth)
-- Hover: border-color `#4b5563`
+```css
+background: #1f2937
+border: 1px solid #374151
+border-radius: 4px
+padding: 16px
+box-shadow: none  /* border-driven depth */
+
+:hover → border-color: #4b5563
+```
 
 ## Navigation
 
-- Sticky top bar, background `#111827` with border-bottom `1px solid #1f2937`
-- Nav links: JetBrains Mono 13px, weight 500, `#9ca3af`
-- Active link: `#4ade80`
-- Hover: `#f9fafb`
-- Logo/brand: JetBrains Mono 15px, weight 700, `#f9fafb`
+```css
+/* Top bar */
+position: sticky; top: 0
+background: #111827
+border-bottom: 1px solid #1f2937
+
+/* Nav links */ font: JetBrains Mono 13px/1 500; color: #9ca3af
+:active → color: #4ade80
+:hover  → color: #f9fafb
+
+/* Logo/brand */ font: JetBrains Mono 15px/1 700; color: #f9fafb
+```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Convert `.agents/tools/design/library/styles/developer-dark/04-components.md` from verbose bullet-list property format to CSS code blocks, matching the established pattern used across the design library (startup-bold, corporate-modern, etc.).

## Issue
Closes #17193

## Files Changed
- `.agents/tools/design/library/styles/developer-dark/04-components.md` — 72→91 lines (net +19 due to SPDX header + CSS block structure; content density improved)

## Testing
**Risk level:** Low (docs/reference corpus — no executable code)
**Verification:** All color values, states (hover/focus/active/disabled/error), font specs, and the accessibility note (`07-dos-donts.md` reference) are present before and after. Format matches sibling files in the design library.

## Key Decisions
- Used CSS code block format (not compression) — this is a reference corpus per code-simplifier classification
- Added SPDX header for consistency with other files in the library
- Preserved accessibility note inline in Links section

## Runtime Testing
`self-assessed` — docs-only change, no runtime environment needed

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13