### PR TITLE
GH#17200: tighten agency-techie 04-components.md (72→65 lines)

### DIFF
--- a/.agents/tools/design/library/styles/agency-techie/04-components.md
+++ b/.agents/tools/design/library/styles/agency-techie/04-components.md
@@ -7,28 +7,21 @@
 
 Shared base: `font: 14px/1 Inter, 500` · `padding: 10px 20px` · `border-radius: 4px` · `:focus → outline: 2px solid #22d3ee; outline-offset: 2px`
 
-**Primary**
-
 ```css
+/* Primary */
 background: #22d3ee; color: #0d1117; border: none
 transition: all 150ms ease-out
 :hover    → background: #06b6d4; box-shadow: 0 0 12px rgba(34,211,238,0.2)
 :active   → background: #0891b2; transform: translateY(1px)
 :disabled → background: #164e63; color: #475569; cursor: not-allowed
-```
 
-**Secondary**
-
-```css
+/* Secondary */
 background: transparent; color: #e2e8f0; border: 1px solid #1e293b
 :hover    → border-color: #334155; background: rgba(255,255,255,0.03)
 :active   → background: rgba(255,255,255,0.06)
 :disabled → color: #475569; border-color: #162032; cursor: not-allowed
-```
 
-**Ghost**
-
-```css
+/* Ghost */
 background: transparent; color: #94a3b8; border: none
 :hover  → color: #e2e8f0; background: rgba(34,211,238,0.08)
 :active → background: rgba(34,211,238,0.12)


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/design/library/styles/agency-techie/04-components.md` per GH#17200.

**Change:** Consolidate three separate button variant code blocks (Primary, Secondary, Ghost) into a single CSS code block with `/* comment */` separators. Eliminates 7 lines of structural overhead (blank lines + bold labels) while preserving all CSS values, states, and properties.

- Before: 72 lines (3 separate code blocks with bold labels)
- After: 65 lines (1 unified code block with CSS comments)
- Content loss: none — all hex values, pseudo-states, transitions preserved

Closes #17200

## Runtime Testing

**Risk level:** Low — documentation/reference file only. No executable code, no agent behaviour change.
**Assessment:** self-assessed

## Files Changed

- `.agents/tools/design/library/styles/agency-techie/04-components.md` (72→65 lines)

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved button variants documentation layout for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->