### PR TITLE
GH#17201: tighten agency-feminine 04-components.md (68→66 lines)

### DIFF
--- a/.agents/tools/design/library/styles/agency-feminine/04-components.md
+++ b/.agents/tools/design/library/styles/agency-feminine/04-components.md
@@ -14,7 +14,6 @@ Shared base: `font: 14px/1 Lato, 500 · padding: 14px 32px · border-radius: 999
 :focus    → outline: 2px solid #d4a5a5; outline-offset: 3px
 :disabled → background: #e8cece; color: #b0a59c; cursor: not-allowed
 ```
-
 **Secondary** `background: transparent · color: #3d3530 · border: 1.5px solid #d4a5a5`
 ```
 :hover    → background: #f5ebe7; border-color: #c79393
@@ -22,7 +21,6 @@ Shared base: `font: 14px/1 Lato, 500 · padding: 14px 32px · border-radius: 999
 :focus    → outline: 2px solid #d4a5a5; outline-offset: 3px
 :disabled → color: #b0a59c; border-color: #e8ddd0
 ```
-
 **Ghost** `background: transparent · color: #7a6e65 · font-weight: 400 · border: none`
 ```
 :hover  → color: #3d3530; background: rgba(212, 165, 165, 0.08)


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/styles/agency-feminine/04-components.md` from 68 to 66 lines by removing blank lines between button variant blocks.

## Issue
Closes #17201

## Files Changed
- `.agents/tools/design/library/styles/agency-feminine/04-components.md` (68→66 lines, -2)

## Testing
**Risk level:** Low — docs/formatting only, no logic or agent behaviour changed.
**Runtime Testing:** `self-assessed` — reference corpus with no executable code.

All CSS values, pseudo-class states, and design tokens verified present before and after. Content preservation confirmed via diff.

## Key Decisions
- **Classification:** Reference corpus (pure CSS token data), not instruction doc. Applied formatting tightening (remove inter-variant blank lines) rather than content compression.
- **Scope:** Minimal change — only blank lines between button variants removed. File was already tightened from 108→65 lines in #17055; this addresses the 3 lines added by SPDX header commit plus removes 2 more blank lines.
- **No content loss:** All pseudo-class states, color tokens, and layout values preserved.

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release contains no user-visible changes. The updates consist of minor internal documentation formatting adjustments only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->