### PR TITLE
GH#17202: tighten IBM Design Component Stylings doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6422,5 +6422,13 @@
     "lines": 30,
     "status": "simplified",
     "issue": "GH#17125"
+  },
+  ".agents/tools/design/library/brands/ibm/04-components.md": {
+    "hash": "b402836b6b2f4ba9d95da181a22d3ce596d62b74",
+    "at": "2026-04-04T08:10:00Z",
+    "passes": 1,
+    "lines": 67,
+    "status": "simplified",
+    "issue": "GH#17202"
   }
 }

--- a/.agents/tools/design/library/brands/ibm/04-components.md
+++ b/.agents/tools/design/library/brands/ibm/04-components.md
@@ -21,8 +21,8 @@
 
 ## Cards & Containers
 
-- Background: `#ffffff` (white theme) or `#f4f4f4` Gray 10 (elevated)
-- Hover (clickable): background → `#e8e8e8` Gray 10 Hover
+- Background: `#ffffff` (white) or `#f4f4f4` Gray 10 (elevated)
+- Hover: background → `#e8e8e8` Gray 10 Hover
 - Content padding: 16px; separation via background layering (white → gray 10 → white)
 
 ## Inputs & Forms
@@ -53,15 +53,15 @@
 
 **Content Block (Hero/Feature)**
 - Full-width alternating white/gray-10 bands; headline left-aligned 60px or 48px display type
-- CTA: blue primary button with arrow icon; image right-aligned or below on mobile
+- CTA: blue primary button + arrow icon; image right-aligned or below on mobile
 
 **Tile (Clickable Card)**
-- Background: `#f4f4f4` or `#ffffff`; hover: bottom-border or background-shift
-- Arrow icon bottom-right on hover; no shadow
+- Background: `#f4f4f4` or `#ffffff`; hover: bottom-border or background-shift; no shadow
+- Arrow icon bottom-right on hover
 
 **Tag / Label**
 - Background: contextual color 10% opacity (Blue 10, Red 10); text: 60-grade color
 - Padding: 4px 8px; border-radius: 24px (pill); font: 12px weight 400
 
 **Notification Banner**
-- Full-width bar, Blue 60 or Gray 100 background; white text 14px; close icon right-aligned
+- Full-width bar; Blue 60 or Gray 100 background; white text 14px; close icon right-aligned


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/design/library/brands/ibm/04-components.md` (IBM Carbon Design System component reference, 67 lines).

## Changes
- **Cards & Containers**: Remove redundant qualifier "(white theme)" → "(white)"; remove "(clickable)" from Hover label — already implied
- **Content Block**: Tighten "with arrow icon" → "+ arrow icon" (saves 2 chars, same meaning)
- **Tile**: Consolidate "no shadow" onto the hover line; remove redundant trailing line
- **Notification Banner**: Fix comma-separated clause to semicolon for consistency with rest of file

## Issue
Closes #17202

## Files Changed
- `.agents/tools/design/library/brands/ibm/04-components.md` — prose tightening (no content loss)
- `.agents/configs/simplification-state.json` — mark file as simplified (GH#17202)

## Testing
- Content preservation verified: all code blocks, color tokens (`#0f62fe`, `#f4f4f4`, etc.), CSS custom properties (`--cds-*`), and structural data intact
- JSON validity: `jq . simplification-state.json` passes
- Risk: **Low** — docs/reference corpus, no agent behavior change

## Runtime Testing
`self-assessed` — Low risk: reference corpus doc, no executable code, no agent instruction changes.

## Key Decisions
- File classified as **reference corpus** (IBM Carbon Design System domain knowledge), not instruction doc — prose tightening only, no content compression
- Line count unchanged (67 → 67): all technical data preserved

---
[aidevops.sh](https://aidevops.sh) v3.6.40 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6