### PR TITLE
GH#17205: tighten uber 04-components.md cross-reference

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6436,5 +6436,11 @@
     "lines": 67,
     "status": "simplified",
     "issue": "GH#17202"
+  },
+  ".agents/tools/design/library/brands/uber/04-components.md": {
+    "hash": "4147e5ab87509d6727816c032f7148b2408c5b8b305e041a853ba1e80cbd0344",
+    "status": "simplified",
+    "action": "tighten-cross-reference",
+    "issue": "GH#17205"
   }
 }

--- a/.agents/tools/design/library/brands/uber/04-components.md
+++ b/.agents/tools/design/library/brands/uber/04-components.md
@@ -64,7 +64,7 @@
 - Sticky top, white background
 - Logo: Uber wordmark/icon at 24x24px in black
 - Links: UberMoveText 14-18px, weight 500, Uber Black
-- Pill-shaped nav chips: Chip Gray (`#efefef`) background ("Ride", "Drive", "Business", "Uber Eats")
+- Pill-shaped nav chips: Chip Gray (`#efefef`) background — see [Category Pill Navigation](#distinctive-components)
 - Menu toggle: circular button, 50% border-radius
 - Mobile: hamburger menu
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/uber/04-components.md` per simplification scan (GH#17205).

**Classification:** Reference corpus (design library, self-contained sections) — already split into chapter files. Content compression not appropriate; structural improvement applied instead.

**Change:** Navigation section had a redundant description of pill-shaped nav chips that duplicated the canonical spec in the Distinctive Components section. Replaced with a cross-reference pointer to eliminate the duplication while preserving all content.

Also updated `simplification-state.json` to record this file as processed with its current hash.

## Issue
Closes #17205

## Files Changed
- `.agents/tools/design/library/brands/uber/04-components.md` — replace duplicate pill nav description with cross-reference
- `.agents/configs/simplification-state.json` — record GH#17205 as processed

## Testing
**Risk level:** Low (docs/markdown only, no code, no scripts)
**Verification:** `self-assessed` — content preserved, cross-reference accurate, no broken links within the file structure.

## Runtime Testing
Risk: Low — documentation change only. No runtime verification required per testing gate.

---
[aidevops.sh](https://aidevops.sh) v3.6.42 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6