### PR TITLE
GH#17209: simplify code-review setup.md — replace hardcoded repo slug with generic placeholder

### DIFF
--- a/.agents/tools/code-review/setup.md
+++ b/.agents/tools/code-review/setup.md
@@ -33,12 +33,14 @@ tools:
 
 ## README Badges
 
+Replace `{owner}/{repo}` with your repository slug.
+
 | Platform | Badge |
 |---|---|
 | CodeRabbit | `[![CodeRabbit](https://img.shields.io/badge/CodeRabbit-AI%20Reviews-blue)](https://coderabbit.ai)` |
-| CodeFactor | `[![CodeFactor](https://www.codefactor.io/repository/github/marcusquinn/aidevops/badge)](https://www.codefactor.io/repository/github/marcusquinn/aidevops)` |
-| Codacy | `[![Codacy Badge](https://app.codacy.com/project/badge/Grade/[PROJECT_ID])](https://app.codacy.com/gh/marcusquinn/aidevops/dashboard)` |
-| SonarCloud | `[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_aidevops&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_aidevops)` |
+| CodeFactor | `[![CodeFactor](https://www.codefactor.io/repository/github/{owner}/{repo}/badge)](https://www.codefactor.io/repository/github/{owner}/{repo})` |
+| Codacy | `[![Codacy Badge](https://app.codacy.com/project/badge/Grade/[PROJECT_ID])](https://app.codacy.com/gh/{owner}/{repo}/dashboard)` |
+| SonarCloud | `[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project={owner}_{repo}&metric=alert_status)](https://sonarcloud.io/summary/new_code?id={owner}_{repo})` |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded `marcusquinn/aidevops` slug in README badge examples with `{owner}/{repo}` placeholder
- Adds a usage note directing users to substitute their own slug
- File is an instruction doc (not a reference corpus); content is already lean at 50 lines — no prose compression needed beyond this fix

## What

Tighten `.agents/tools/code-review/setup.md` per GH#17209 simplification scan. The file was flagged at 50 lines; classification is **instruction doc**. The only genuine improvement identified: badge examples contained a hardcoded project-specific slug, making the framework doc misleading when used in other repos.

## Files Changed

- `.agents/tools/code-review/setup.md` — 3 badge URLs updated to `{owner}/{repo}` placeholder; usage note added

## Runtime Testing

**Risk level:** Low (docs/agent prompt only — no code, no scripts, no config)
**Verification:** `self-assessed` — content preserved, no broken references, no code blocks affected

## Key Decisions

- No content compression applied: file was already at minimum viable size; compressing further would lose institutional knowledge
- Placeholder format `{owner}/{repo}` matches convention used elsewhere in framework docs

Closes #17209

---
[aidevops.sh](https://aidevops.sh) v3.6.42 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6