### PR TITLE
GH#17197: tighten whitespace philosophy prose in playful-vibrant 05-layout.md

### DIFF
--- a/.agents/tools/design/library/styles/playful-vibrant/05-layout.md
+++ b/.agents/tools/design/library/styles/playful-vibrant/05-layout.md
@@ -36,7 +36,7 @@
 
 ## Whitespace Philosophy
 
-Whitespace prevents visual overload in a colourful system. Without it, bold colours and rounded shapes become chaotic. Sections need 48–64px breathing room. Cards need 24px internal padding. The colourful palette earns trust through organisation — every element has a clear place and enough space around it to be understood independently.
+Whitespace prevents visual overload in a colourful system — bold colours and rounded shapes become chaotic without it. Sections need 48–64px breathing room; cards need 24px internal padding. Organisation earns trust: every element needs enough space to be understood independently.
 
 ## Border-Radius Scale
 


### PR DESCRIPTION
## Summary

Tightens the Whitespace Philosophy prose in `.agents/tools/design/library/styles/playful-vibrant/05-layout.md` (50 lines).

**Classification:** Reference corpus chapter file — prose tightening only, no content removal.

**Change:** Single paragraph rewritten for concision. All technical values preserved (48–64px breathing room, 24px card padding). Meaning unchanged.

Before:
> Whitespace prevents visual overload in a colourful system. Without it, bold colours and rounded shapes become chaotic. Sections need 48–64px breathing room. Cards need 24px internal padding. The colourful palette earns trust through organisation — every element has a clear place and enough space around it to be understood independently.

After:
> Whitespace prevents visual overload in a colourful system — bold colours and rounded shapes become chaotic without it. Sections need 48–64px breathing room; cards need 24px internal padding. Organisation earns trust: every element needs enough space to be understood independently.

## Runtime Testing

**Risk level:** Low — docs/formatting only, no code or agent behaviour change.
**Method:** self-assessed — all technical values (48–64px, 24px) present before and after; no code blocks, URLs, or task ID refs in this file.

## Files Changed

- `.agents/tools/design/library/styles/playful-vibrant/05-layout.md` — prose tightening (1 line changed)

Closes #17197

---
[aidevops.sh](https://aidevops.sh) v3.6.42 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6