### PR TITLE
GH#17199: tighten Lovable component stylings doc

### DIFF
--- a/.agents/tools/design/library/brands/lovable/04-components.md
+++ b/.agents/tools/design/library/brands/lovable/04-components.md
@@ -5,7 +5,7 @@
 
 ## Buttons
 
-Shared across all button variants: Padding 8px 16px · Radius 6px · Active opacity 0.8 · Focus `rgba(0,0,0,0.1) 0px 4px 12px` shadow
+All variants: Padding 8px 16px · Radius 6px · Active opacity 0.8 · Focus `rgba(0,0,0,0.1) 0px 4px 12px` shadow
 
 **Primary Dark (Inset Shadow)**
 - Background: `#1c1c1c` · Text: `#fcfbf8`
@@ -13,8 +13,7 @@ Shared across all button variants: Padding 8px 16px · Radius 6px · Active opac
 - Use: Primary CTA ("Start Building", "Get Started")
 
 **Ghost / Outline**
-- Background: transparent · Text: `#1c1c1c`
-- Border: `1px solid rgba(28,28,28,0.4)`
+- Background: transparent · Text: `#1c1c1c` · Border: `1px solid rgba(28,28,28,0.4)`
 - Use: Secondary actions ("Log In", "Documentation")
 
 **Cream Surface**
@@ -22,9 +21,8 @@ Shared across all button variants: Padding 8px 16px · Radius 6px · Active opac
 - Use: Tertiary actions, toolbar buttons
 
 **Pill / Icon Button**
-- Background: `#f7f4ed` · Text: `#1c1c1c` · Radius: 9999px (full pill)
+- Background: `#f7f4ed` · Text: `#1c1c1c` · Radius: 9999px (full pill) · Opacity: 0.5 (default), 0.8 (active)
 - Shadow: same inset pattern as Primary Dark
-- Opacity: 0.5 (default), 0.8 (active)
 - Use: Additional actions, plan mode toggle, voice recording
 
 ## Cards & Containers


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/lovable/04-components.md` from 76 → 74 lines.

## Issue
Closes #17199

## Changes
- `All variants:` replaces verbose `Shared across all button variants:` label
- Ghost/Outline: merged Background/Text/Border onto single properties line
- Pill/Icon Button: consolidated Opacity onto properties line (was separate line)

## Files Changed
- `.agents/tools/design/library/brands/lovable/04-components.md` (76 → 74 lines)

## Testing
**Classification:** Reference corpus (design system CSS values/specs). Correct action per `code-simplifier.md` "Reference corpora" is restructure-not-compress for large files; at 76 lines this is already compact — prose tightening applied instead.

**Verification:**
- All CSS values preserved: hex codes (`#1c1c1c`, `#fcfbf8`, `#f7f4ed`, `#eceae4`, `rgba(...)` values), pixel measurements, border specs
- All section headings intact
- All `Use:` annotations preserved
- No code blocks in this file (N/A)
- No task ID refs in this file (N/A)

**Risk:** Low — docs-only change, no agent behaviour affected.

## Runtime Testing
`self-assessed` — Low risk (docs/reference file, no executable code)

---
[aidevops.sh](https://aidevops.sh) v3.6.42 plugin for [OpenCode](https://opencode.ai) v1.3.13