### PR TITLE
GH#17217: tighten agency-feminine 04-components.md

### DIFF
--- a/.agents/tools/design/library/styles/agency-feminine/04-components.md
+++ b/.agents/tools/design/library/styles/agency-feminine/04-components.md
@@ -8,21 +8,26 @@
 Shared base: `font: 14px/1 Lato, 500 · padding: 14px 32px · border-radius: 999px · letter-spacing: 0.04em`
 
 **Primary** `background: #d4a5a5 · color: #ffffff · border: none · transition: all 400ms ease-in-out`
-```
+
+```css
 :hover    → background: #c79393; box-shadow: 0 4px 16px rgba(212, 165, 165, 0.25)
 :active   → background: #b88282; transform: scale(0.98)
 :focus    → outline: 2px solid #d4a5a5; outline-offset: 3px
 :disabled → background: #e8cece; color: #b0a59c; cursor: not-allowed
 ```
+
 **Secondary** `background: transparent · color: #3d3530 · border: 1.5px solid #d4a5a5`
-```
+
+```css
 :hover    → background: #f5ebe7; border-color: #c79393
 :active   → background: #f0e6d8
 :focus    → outline: 2px solid #d4a5a5; outline-offset: 3px
 :disabled → color: #b0a59c; border-color: #e8ddd0
 ```
+
 **Ghost** `background: transparent · color: #7a6e65 · font-weight: 400 · border: none`
-```
+
+```css
 :hover  → color: #3d3530; background: rgba(212, 165, 165, 0.08)
 :active → background: rgba(212, 165, 165, 0.12)
 ```


### PR DESCRIPTION
## Summary

- Add `css` language tags to button state code blocks for consistency with Inputs/Links/Cards sections
- Add blank lines around fenced code blocks (MD031 compliance)
- Zero content loss — all design tokens, hex values, and state specs preserved

## What

Tightened `.agents/tools/design/library/styles/agency-feminine/04-components.md` (66→71 lines, increase due to MD031 blank lines). File classified as **reference corpus** (CSS design token specs, not instruction doc) — content not compressed, only structural consistency improved.

## Issue

Closes #17217

## Files Changed

- `.agents/tools/design/library/styles/agency-feminine/04-components.md`

## Runtime Testing

**Risk level:** Low — docs/reference file, no executable code, no agent behaviour change.
**Verification:** `self-assessed` — all code blocks, hex values, and state specs present before and after. `wc -l` confirms 71 lines (66 original + 5 blank lines for MD031).

## Key Decisions

- Classified as reference corpus → no content compression, structural consistency only
- Added `css` language tag to button state blocks (Primary/Secondary/Ghost) to match existing Inputs/Links/Cards/Navigation blocks
- MD031 blank lines added around fenced blocks (markdownlint compliance)

<!-- MERGE_SUMMARY -->
**What:** Structural consistency fix for agency-feminine component spec doc
**Issue:** #17217
**Files changed:** 1
**Testing:** self-assessed (docs-only, low risk)
**Key decisions:** Reference corpus classification → structure-only changes, zero content loss

---
[aidevops.sh](https://aidevops.sh) v3.6.42 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6