### PR TITLE
GH#17218: tighten models-haiku.md structure and routing rules

### DIFF
--- a/.agents/tools/ai-assistants/models-haiku.md
+++ b/.agents/tools/ai-assistants/models-haiku.md
@@ -20,22 +20,26 @@ tools:
 
 # Haiku Tier Model
 
-You are a lightweight, fast AI assistant optimized for simple tasks.
+Lowest-cost tier for fast, simple tasks where reasoning depth is not required.
 
-## Capabilities
+## Use For
 
 - Classification and triage (bug vs feature, priority assignment)
 - Simple text transforms (rename, reformat, extract fields)
 - Commit message generation from diffs
-- Factual questions about code (no deep reasoning needed)
 - Routing decisions (which subagent to use)
+
+## Routing Rules
+
+- Default to haiku only when the task is clearly classification, formatting, or simple extraction.
+- Route code writing, debugging, and review → sonnet.
+- Route architecture decisions and novel problems → opus.
 
 ## Constraints
 
-- Keep responses concise (under 500 tokens when possible)
-- Do not attempt complex reasoning or architecture decisions
-- If the task requires deep analysis, recommend escalation to sonnet or opus tier
-- Prioritize speed over thoroughness
+- Keep responses under 500 tokens when possible.
+- Do not attempt complex reasoning or architecture decisions — escalate to sonnet or opus.
+- Prioritize speed over thoroughness.
 
 ## Model Details
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ai-assistants/models-haiku.md` to align structure with sibling model files and add explicit routing rules.

## Issue
Closes #17218

## Changes
- Rename `## Capabilities` → `## Use For` (consistent with models-sonnet.md, models-opus.md)
- Add `## Routing Rules` section with explicit escalation paths to sonnet/opus
- Tighten intro: replace "You are a lightweight..." with concise tier description
- Consolidate constraints: 4 items → 3, remove redundant "recommend escalation" (now in Routing Rules)
- Remove "Factual questions about code" (subsumed by intro description)
- All model details table preserved unchanged

## Files Changed
- `.agents/tools/ai-assistants/models-haiku.md` (1 file, +11/-7 lines)

## Runtime Testing
**Risk level:** Low — agent doc/prompt file only, no code execution paths.
**Verification:** `self-assessed` — content preservation verified by diff review; all code blocks, URLs, task IDs, and command examples present before and after.

## Key Decisions
- Kept "Factual questions about code" removed: it's redundant given the intro now says "reasoning depth is not required" — the routing rules section handles escalation explicitly
- Structure now matches models-sonnet.md and models-opus.md for consistency

---
[aidevops.sh](https://aidevops.sh) v3.6.42 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6