### PR TITLE
GH#17219: tighten bindings-patterns.md — remove decorative noise

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/bindings-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/bindings-patterns.md
@@ -3,48 +3,44 @@
 
 ## Common Anti-Patterns
 
-### ❌ Hardcoding Credentials
+### Hardcoding Credentials
 
 ```typescript
-// DON'T
 const apiKey = 'sk_live_abc123';
 ```
 
-**✅ Use secrets:**
+Use secrets instead:
 
 ```bash
 npx wrangler secret put API_KEY
 ```
 
-### ❌ Using REST API from Worker
+### Using REST API from Worker
 
 ```typescript
-// DON'T
 await fetch('https://api.cloudflare.com/client/v4/accounts/.../kv/...');
 ```
 
-**✅ Use bindings:**
+Use bindings instead:
 
 ```typescript
 await env.MY_KV.get('key');
 ```
 
-### ❌ Polling KV/D1 for Changes
+### Polling KV/D1 for Changes
 
 ```typescript
-// DON'T
 setInterval(() => {
   const config = await env.KV.get('config');
 }, 1000);
 ```
 
-**✅ Use Durable Objects for real-time state**
+Use Durable Objects for real-time state instead.
 
-### ❌ Storing Large Data in env.vars
+### Storing Large Data in env.vars
 
 ```typescript
-// DON'T
 { "vars": { "HUGE_CONFIG": "..." } } // Max 5KB per var
 ```
 
-**✅ Use KV/R2 for large data**
+Use KV/R2 for large data instead.


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/bindings-patterns.md` per GH#17219.

**Changes:**
- Remove decorative ❌/✅ emojis (no semantic value in agent docs)
- Remove redundant `// DON'T` comments inside code blocks (anti-pattern header makes them redundant)
- Remove `**✅ Use X:**` bold wrappers (replaced with plain prose)
- All 4 anti-patterns and all code examples preserved

**Result:** 50 → 46 lines. Zero knowledge loss.

Closes #17219

## Runtime Testing

**Risk level:** Low — agent doc only, no code execution path.
**Verification:** `self-assessed` — all code blocks, command examples, and anti-pattern descriptions present before and after.

## Files Changed

- `.agents/services/hosting/cloudflare-platform-skill/bindings-patterns.md` — 8 lines removed (decorative noise)

---
[aidevops.sh](https://aidevops.sh) v3.6.42 plugin for [OpenCode](https://opencode.ai) v1.3.13