### PR TITLE
GH#17221: fix manual pagination null check in api-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/api-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/api-patterns.md
@@ -60,9 +60,8 @@ for await (const zone of client.zones.list()) {
 
 // Manual pagination
 let page = await client.zones.list({ per_page: 50 });
-while (page.result.length > 0) {
+while (page != null && typeof page === "object") {
   // process page.result
-  if (!page.result_info?.next_page) break;
   page = await page.getNextPage();
 }
 ```


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Fix the manual pagination example in `.agents/services/hosting/cloudflare-platform-skill/api-patterns.md`. The original code used `page.result.length > 0` as the loop condition with a `result_info?.next_page` break — but the Cloudflare SDK's `getNextPage()` returns `null` when exhausted, not an empty `result_info`. This makes the loop condition unreliable.

## Issue
Closes #17221

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/api-patterns.md` — fix manual pagination loop condition

## Testing
- Self-assessed (Low risk: doc-only change, no runtime code)
- Addresses gemini-code-assist review comment on PR #17236 (merged without fix)

## Key Decisions
- Used `page != null && typeof page === "object"` per bot suggestion — explicit null check is more robust against falsy values from external API objects
- Removed the `result_info?.next_page` break which relied on a field that may not exist

## Runtime Testing
`self-assessed` — documentation change only, no executable code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.6.46 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6