### PR TITLE
GH#17241: tighten Claude component stylings doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6394,6 +6394,12 @@
       "at": "2026-04-04T08:33:25Z",
       "pr": "17227",
       "passes": 1
+    },
+    ".agents/tools/design/library/brands/claude/04-components.md": {
+      "hash": "a1750dd7a1a809a0ea2991169772b764ec271d0a",
+      "at": "2026-04-04T00:00:00Z",
+      "passes": 1,
+      "pr": 0
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/brands/claude/04-components.md
+++ b/.agents/tools/design/library/brands/claude/04-components.md
@@ -5,29 +5,13 @@
 
 ## Buttons
 
-**Warm Sand (Secondary)**
-- Background: Warm Sand (`#e8e6dc`) · Text: Charcoal Warm (`#4d4c48`)
-- Padding: 0px 12px 0px 8px (asymmetric — icon-first layout)
-- Radius: 8px · Shadow: `#e8e6dc 0px 0px 0px 0px, #d1cfc5 0px 0px 0px 1px`
-
-**White Surface**
-- Background: Pure White (`#ffffff`) · Text: Anthropic Near Black (`#141413`)
-- Padding: 8px 16px 8px 12px · Radius: 12px
-- Hover: shifts to secondary background color
-
-**Dark Charcoal**
-- Background: Dark Surface (`#30302e`) · Text: Ivory (`#faf9f5`)
-- Padding: 0px 12px 0px 8px · Radius: 8px
-- Shadow: `#30302e 0px 0px 0px 0px, ring 0px 0px 0px 1px`
-
-**Brand Terracotta** — primary CTA; only chromatic button
-- Background: Terracotta Brand (`#c96442`) · Text: Ivory (`#faf9f5`)
-- Radius: 8–12px · Shadow: `#c96442 0px 0px 0px 0px, #c96442 0px 0px 0px 1px`
-
-**Dark Primary**
-- Background: Anthropic Near Black (`#141413`) · Text: Warm Silver (`#b0aea5`)
-- Padding: 9.6px 16.8px · Radius: 12px
-- Border: `1px solid #30302e` (dark theme surfaces)
+| Variant | Background | Text | Padding | Radius | Notes |
+|---------|-----------|------|---------|--------|-------|
+| Warm Sand (Secondary) | `#e8e6dc` | `#4d4c48` | `0px 12px 0px 8px` | 8px | Asymmetric — icon-first layout; shadow: `#e8e6dc 0px 0px 0px 0px, #d1cfc5 0px 0px 0px 1px` |
+| White Surface | `#ffffff` | `#141413` | `8px 16px 8px 12px` | 12px | Hover: shifts to secondary background |
+| Dark Charcoal | `#30302e` | `#faf9f5` | `0px 12px 0px 8px` | 8px | Shadow: `#30302e 0px 0px 0px 0px, ring 0px 0px 0px 1px` |
+| Brand Terracotta | `#c96442` | `#faf9f5` | — | 8–12px | Primary CTA; only chromatic button; shadow: `#c96442 0px 0px 0px 0px, #c96442 0px 0px 0px 1px` |
+| Dark Primary | `#141413` | `#b0aea5` | `9.6px 16.8px` | 12px | Border: `1px solid #30302e` (dark theme surfaces) |
 
 ## Cards & Containers
 
@@ -62,15 +46,8 @@
 
 ## Distinctive Components
 
-**Model Comparison Cards**
-- Opus 4.5, Sonnet 4.5, Haiku 4.5 in bordered card grid
-- Name, description, capability badges per card
-- Border Warm (`#e8e6dc`) separation between items
+**Model Comparison Cards** — Opus 4.5, Sonnet 4.5, Haiku 4.5 in bordered card grid; name, description, capability badges per card; Border Warm (`#e8e6dc`) separation
 
-**Organic Illustrations**
-- Hand-drawn-feeling vector illustrations: terracotta, black, muted green
-- Abstract/conceptual (not literal product diagrams)
+**Organic Illustrations** — hand-drawn-feeling vector illustrations: terracotta, black, muted green; abstract/conceptual (not literal product diagrams)
 
-**Dark/Light Section Alternation**
-- Page alternates Parchment light and Near Black dark sections
-- Each section is a distinct visual environment
+**Dark/Light Section Alternation** — page alternates Parchment light and Near Black dark sections; each section is a distinct visual environment


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/claude/04-components.md` from 76 to 53 lines (30% reduction).

## Changes
- Convert 5 verbose button bullet-list variants to a compact table (matching Linear design system pattern)
- Consolidate Distinctive Components section from multi-bullet to single-line entries
- All spec values preserved: hex colors, padding, radius, shadow strings, component names

## Issue
Closes #17241

## Files Changed
- `.agents/tools/design/library/brands/claude/04-components.md` (76→53 lines)
- `.agents/configs/simplification-state.json` (hash registered)

## Testing
- Content preservation verified: all hex values, padding specs, shadow strings, component names present before and after
- No broken references (no internal links in this file)
- Risk: Low (design reference corpus, no agent behavior change)

## Runtime Testing
`self-assessed` — Low risk: design reference doc, no agent rules or workflows affected.

## Key Decisions
- Classified as reference corpus (design spec), not instruction doc — no content compression, only structural tightening
- Table format chosen for buttons (5 variants × 5 properties) — consistent with Linear design system pattern already in codebase
- Distinctive Components consolidated to single lines — all information preserved, reduced visual noise

---
[aidevops.sh](https://aidevops.sh) v3.6.52 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6