### PR TITLE
GH#17251: tighten Claude layout doc — border radius to table, prose cleanup

### DIFF
--- a/.agents/tools/design/library/brands/claude/05-layout.md
+++ b/.agents/tools/design/library/brands/claude/05-layout.md
@@ -21,19 +21,21 @@
 
 ## Whitespace Philosophy
 
-- **Editorial pacing**: Generous top/bottom margins create natural reading pauses between sections.
-- **Serif-driven rhythm**: Serif headings demand more whitespace than sans-serif designs.
-- **Content island approach**: Sections alternate light/dark environments, creating distinct visual rooms.
+- **Editorial pacing**: Generous top/bottom margins create natural reading pauses between sections
+- **Serif-driven rhythm**: Serif headings demand more whitespace than sans-serif designs
+- **Content island approach**: Sections alternate light/dark environments, creating distinct visual rooms
 
 ## Border Radius Scale
 
-- Sharp (4px): Minimal inline elements
-- Subtly rounded (6–7.5px): Small buttons, secondary interactive elements
-- Comfortably rounded (8–8.5px): Standard buttons, cards, containers
-- Generously rounded (12px): Primary buttons, input fields, nav elements
-- Very rounded (16px): Featured containers, video players, tab lists
-- Highly rounded (24px): Tag-like elements, highlighted containers
-- Maximum rounded (32px): Hero containers, embedded media, large cards
+| Name | Value | Usage |
+|------|-------|-------|
+| Sharp | 4px | Minimal inline elements |
+| Subtly rounded | 6–7.5px | Small buttons, secondary interactive elements |
+| Comfortably rounded | 8–8.5px | Standard buttons, cards, containers |
+| Generously rounded | 12px | Primary buttons, input fields, nav elements |
+| Very rounded | 16px | Featured containers, video players, tab lists |
+| Highly rounded | 24px | Tag-like elements, highlighted containers |
+| Maximum rounded | 32px | Hero containers, embedded media, large cards |
 
 ## Responsive Behavior
 
@@ -49,10 +51,9 @@
 
 ### Touch Targets
 
-- Buttons: 8–16px vertical padding minimum
+- Buttons: 8–16px vertical padding minimum (44×44px overall minimum)
 - Navigation links: spaced for thumb navigation
 - Card surfaces: large touch targets
-- Minimum: 44x44px
 
 ### Collapsing Strategy
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/claude/05-layout.md` (71→72 lines).

**Classification**: Reference corpus (design system chapter file) — already split, appropriately sized. Applied targeted structural improvements rather than content compression.

**Changes:**
- Border radius section converted from bullet list to table (consistent with breakpoints table format)
- Whitespace philosophy: removed trailing periods for consistency with rest of file
- Touch targets: consolidated "Minimum: 44×44px" into button line (no content loss)

## Issue
Closes #17251

## Files Changed
- `.agents/tools/design/library/brands/claude/05-layout.md`

## Testing
- All 7 border radius values preserved (4px, 6–7.5px, 8–8.5px, 12px, 16px, 24px, 32px) ✓
- All breakpoints preserved ✓
- All spacing values preserved ✓
- Touch target 44×44px preserved (consolidated) ✓
- No URLs, task IDs, or command examples in this file ✓
- Risk: Low (docs-only, reference corpus)

## Runtime Testing
**Self-assessed** — docs-only change, no runtime required per risk table.

---
[aidevops.sh](https://aidevops.sh) v3.6.55 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6