### PR TITLE
GH#17253: tighten nvidia 04-components.md, remove redundant blank lines

### DIFF
--- a/.agents/tools/design/library/brands/nvidia/04-components.md
+++ b/.agents/tools/design/library/brands/nvidia/04-components.md
@@ -6,7 +6,6 @@
 ## Buttons
 
 ### Primary (Green Border)
-
 - Background: `transparent` · Text: `#ffffff` (dark) / `#000000` (light)
 - Padding: 11px 13px · Border: `2px solid #76b900` · Radius: 2px
 - Font: 16px weight 700
@@ -16,37 +15,31 @@
 - Use: Primary CTA ("Learn More", "Explore Solutions")
 
 ### Secondary (Green Border Thin)
-
 - Background: transparent · Border: `1px solid #76b900` · Radius: 2px
 - Use: Secondary actions, alternative CTAs
 
 ### Compact / Inline
-
 - Font: 14.4px weight 700 · Letter-spacing: 0.144px · Line-height: 1.00
 - Use: Inline CTAs, compact navigation
 
 ## Cards & Containers
-
 - Background: `#ffffff` (light) or `#1a1a1a` (dark sections)
 - Border: none or `1px solid #5e5e5e` · Radius: 2px
 - Shadow: `rgba(0, 0, 0, 0.3) 0px 0px 5px 0px` for elevated cards
 - Hover: shadow intensification · Padding: 16-24px internal
 
 ## Links
-
 - **On Dark Background**: `#ffffff`, no underline, hover `#3860be`
 - **On Light Background**: `#000000` or `#1a1a1a`, underline `2px solid #76b900`, hover `#3860be` (underline removed)
 - **Green Links**: `#76b900`, hover `#3860be`
 - **Muted Links**: `#666666`, hover `#3860be`
 
 ## Navigation
-
 - Dark black background (`#000000`), logo left-aligned
 - Links: NVIDIA-EMEA 14px weight 700 uppercase, `#ffffff`; hover color shift, no underline change
 - Mega-menu dropdowns for product categories; sticky on scroll with backdrop
 
 ## Image Treatment
-
 - Product/GPU renders as hero images, often full-width
 - Screenshot images with subtle shadow; green gradient overlays on dark hero sections
 - Circular avatar containers with 50% radius
@@ -54,15 +47,12 @@
 ## Distinctive Components
 
 ### Product Cards
-
 - Clean white or dark card, 2px radius · Green accent border or underline on title
 - Bold heading + lighter description · CTA with green border at bottom
 
 ### Tech Spec Tables
-
 - Industrial grid layouts · Alternating row backgrounds (subtle gray shift)
 - Bold labels, regular values · Green highlights for key metrics
 
 ### Cookie/Consent Banner
-
 - Fixed bottom positioning · Rounded buttons (2px radius) · Gray border treatments


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/nvidia/04-components.md` by removing redundant blank lines between section headings and their list items. 68 → 58 lines (15% reduction).

## Issue
Closes #17253

## Classification
Reference corpus chapter (already part of a 9-chapter library). File was appropriately structured — no content splitting needed. Applied density improvement only: removed blank lines between `###` headings and their bullet lists, and between `##` headings and their bullet lists.

## Files Changed
- `.agents/tools/design/library/brands/nvidia/04-components.md`: 10 lines removed (blank lines only)

## Testing
- All code blocks, color values, CSS properties, and structural content preserved verbatim
- `wc -l` before: 68, after: 58
- `git diff` confirms only blank line removals — no content changes

## Key Decisions
- Classified as reference corpus (design library chapter), not instruction doc
- No content compression or reordering — only whitespace tightening
- No chapter splitting needed at 58 lines in an already-split library

## Runtime Testing
**Risk level:** Low (docs/agent prompts — no code, no runtime behaviour)
**Verification:** self-assessed

---
[aidevops.sh](https://aidevops.sh) v3.6.55 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up markdown formatting by removing unnecessary whitespace in documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->