### PR TITLE
GH#17262: tighten Clay Design System component stylings doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6407,6 +6407,12 @@
       "at": "2026-04-04T09:30:00Z",
       "pr": 0,
       "passes": 1
+    },
+    ".agents/tools/design/library/brands/clay/04-components.md": {
+      "hash": "3318a6f67225b0283a146bba148a8541ce146057",
+      "at": "2026-04-04T09:20:00Z",
+      "passes": 1,
+      "pr": 17267
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/brands/clay/04-components.md
+++ b/.agents/tools/design/library/brands/clay/04-components.md
@@ -5,28 +5,22 @@
 
 ## Buttons
 
-**Primary (Transparent with Hover Animation)**
+**Primary (Transparent)**
 
-- Background: transparent (`rgba(239, 241, 243, 0)`)
-- Text: `#000000`
-- Padding: 6.4px 12.8px
+- Background: transparent (`rgba(239, 241, 243, 0)`); Text: `#000000`; Padding: 6.4px 12.8px
 - Border: none (or `1px solid #717989` for outlined variant)
 - Hover: background → swatch color (e.g., `#434346`), text → white, `rotateZ(-8deg)`, `translateY(-80%)`, hard shadow `rgb(0,0,0) -7px 7px`
 - Focus: `rgb(20, 110, 245) solid 2px` outline
 
-**White Solid**
+**White Solid** — Primary CTA on colored sections
 
 - Background: `#ffffff`; Text: `#000000`; Padding: 6.4px
-- Hover: oat-200 swatch color, animated rotation + shadow
-- Use: Primary CTA on colored sections
+- Hover: oat-200 swatch, animated rotation + shadow
 
 **Ghost Outlined**
 
-- Background: transparent; Text: `#000000`; Padding: 8px
-- Border: `1px solid #717989`; Radius: 4px
-- Hover: dragonfruit swatch color, white text, animated rotation
-
-> **Hover pattern:** Rotate -8deg + translate upward, hard offset shadow (`-7px 7px`) instead of soft blur, background → contrasting swatch. Creates a physical, toy-like interaction quality.
+- Background: transparent; Text: `#000000`; Padding: 8px; Border: `1px solid #717989`; Radius: 4px
+- Hover: dragonfruit swatch, white text, animated rotation
 
 ## Cards & Containers
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/clay/04-components.md` from 53 → 47 lines.

## Issue
Closes #17262

## Changes
- Removed redundant hover pattern blockquote (duplicated content already in `01-visual-theme.md`)
- Compacted Primary button spec: merged background/text/padding onto one line
- Moved White Solid "Use:" label inline with heading
- Compacted Ghost Outlined spec from 3 lines to 2
- All CSS values, color codes, and component specs preserved verbatim

## Files Changed
- `.agents/tools/design/library/brands/clay/04-components.md` — 53 → 47 lines
- `.agents/configs/simplification-state.json` — registered new hash for this file

## Testing
**Risk level:** Low (docs-only, no agent instructions changed)
**Verification:** `self-assessed` — reference corpus, no agent behaviour affected. All CSS values, color codes, and component specs present before and after.

## Key Decisions
- Classified as **reference corpus** (CSS values, color codes, component specs) — not an instruction doc
- Removed hover blockquote as it duplicates `01-visual-theme.md:17-18` exactly
- No content split needed at 47 lines (well within single-file threshold)

---
[aidevops.sh](https://aidevops.sh) v3.6.55 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6