### PR TITLE
GH#17260: tighten stripe color palette doc, remove duplicate entries

### DIFF
--- a/.agents/tools/design/library/brands/stripe/02-color-palette.md
+++ b/.agents/tools/design/library/brands/stripe/02-color-palette.md
@@ -5,8 +5,8 @@
 
 ## Primary
 
-- **Stripe Purple** (`#533afd`): Primary brand color, CTA backgrounds, link text, interactive highlights.
-- **Deep Navy** (`#061b31`): `--hds-color-heading-solid`. Primary heading color.
+- **Stripe Purple** (`#533afd`): Primary brand color, CTA backgrounds, link text, interactive highlights, active states, selected elements.
+- **Deep Navy** (`#061b31`): `--hds-color-heading-solid`. Primary headings, nav text, strong labels.
 - **Pure White** (`#ffffff`): Page background, card surfaces, button text on dark backgrounds.
 
 ## Brand & Dark
@@ -20,19 +20,20 @@
 - **Magenta** (`#f96bee`): `--hds-color-accentColorMode-magenta-icon-gradientMiddle`. Gradients and decorative highlights.
 - **Magenta Light** (`#ffd7ef`): `--hds-color-util-accent-magenta-100`. Magenta-themed cards and badges.
 
-## Interactive
+## Interactive (Purple Scale)
 
-- **Primary Purple** (`#533afd`): Primary link color, active states, selected elements.
 - **Purple Hover** (`#4434d4`): Hover states on primary elements.
+- **Purple Mid** (`#665efd`): `--hds-color-input-selector-text-range`. Range selector and input highlight.
 - **Purple Deep** (`#2e2b8c`): `--hds-color-button-ui-iconHover`. Icon hover states.
 - **Purple Light** (`#b9b9f9`): `--hds-color-action-bg-subduedHover`. Subdued hover backgrounds.
-- **Purple Mid** (`#665efd`): `--hds-color-input-selector-text-range`. Range selector and input highlight.
 
-## Neutral Scale
+## Text Scale
 
-- **Heading** (`#061b31`): Primary headings, nav text, strong labels.
 - **Label** (`#273951`): `--hds-color-input-text-label`. Form labels, secondary headings.
 - **Body** (`#64748d`): Secondary text, descriptions, captions.
+
+## Status
+
 - **Success Green** (`#15be53`): Status badges, success indicators (0.2–0.4 alpha for backgrounds/borders).
 - **Success Text** (`#108c3d`): Success badge text.
 - **Lemon** (`#9b6829`): `--hds-color-core-lemon-500`. Warning and highlight accent.


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/design/library/brands/stripe/02-color-palette.md` per simplification scan (GH#17260).

**Classification:** Reference corpus (domain knowledge base, not instruction doc). Approach: remove genuine redundancy, improve section organization — no content compression.

**Changes:**
- Merged duplicate `#533afd` entries: "Primary Purple" (Interactive) folded into "Stripe Purple" (Primary) — same hex, roles combined
- Merged duplicate `#061b31` entries: "Heading" (Neutral Scale) folded into "Deep Navy" (Primary) — same hex, roles combined
- Split "Neutral Scale" → "Text Scale" + "Status" for clearer semantic grouping
- Renamed "Interactive" → "Interactive (Purple Scale)" for specificity
- Reordered purple scale entries by lightness (hover → mid → deep → light)

**Verification:**
- All 20 unique hex values preserved (before: 20, after: 20)
- All 5 rgba shadow values preserved
- All 11 CSS variable references preserved
- Zero knowledge loss — only structural deduplication

Closes #17260

## Runtime Testing

Risk: **Low** — documentation-only change, no code, no agent behavior affected. `self-assessed`.

---
[aidevops.sh](https://aidevops.sh) v3.6.55 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Stripe brand color palette guidance with expanded usage contexts for primary colors
  * Reorganized color role sections and added new color mappings to the design system reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->