### PR TITLE
GH#17254: tighten MongoDB 04-components.md

### DIFF
--- a/.agents/tools/design/library/brands/mongodb/04-components.md
+++ b/.agents/tools/design/library/brands/mongodb/04-components.md
@@ -66,3 +66,4 @@
 - 14px uppercase Source Code Pro with 1px–2px letter-spacing
 - Used as section category markers above headings
 - Creates a "database field label" aesthetic
+


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Add missing EOF newline to `.agents/tools/design/library/brands/mongodb/04-components.md`.

## Issue
Closes #17254

## Classification
**Reference corpus** — design token values (hex colors, CSS properties, component specs). Already compact at 68 lines. No prose to compress, no splitting needed. The only structural defect was a missing newline at end of file.

## Files Changed
- `.agents/tools/design/library/brands/mongodb/04-components.md` — +1 line (EOF newline)

## Testing
- Content preservation: all hex values, CSS properties, and component specs unchanged
- No broken references (file has no internal links)
- Self-assessed: low-risk doc-only change

## Runtime Testing
`self-assessed` — docs-only, no code paths affected.

---
[aidevops.sh](https://aidevops.sh) v3.6.55 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6