### PR TITLE
GH#17277: tighten nothing-design-skill 02-color.md (55→49 lines)

### DIFF
--- a/.agents/tools/ui/nothing-design-skill/tokens/02-color.md
+++ b/.agents/tools/ui/nothing-design-skill/tokens/02-color.md
@@ -29,9 +29,7 @@
 | `--info` | `#999999` | Uses secondary text color |
 | `--interactive` | `#007AFF` / `#5B9BF6` | Tappable text: links, picker values. Not for buttons. |
 
-### Data Status Rules
-
-`--success` = good, `--warning` = attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply color to **value**, not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
+**Data status:** `--success` = good, `--warning` = attention, `--accent` = bad/over limit, `--text-primary` = neutral. Apply to **value** only — not label or background. Labels stay `--text-secondary`. Trend arrows inherit value color.
 
 ## Dark / Light Mode
 
@@ -48,8 +46,4 @@
 | `--text-display` | `#FFFFFF` | `#000000` |
 | `--interactive` | `#5B9BF6` | `#007AFF` |
 
-### Mode Philosophy
-
-Identical across modes: accent red, status colors, ALL CAPS labels, fonts, type scale, spacing, component shapes.
-
-Dark: OLED black, white data glowing (instrument panel). Light: off-white paper (`#F5F5F5`), black ink; cards `#FFFFFF` = subtle elevation without shadows.
+**Identical across modes:** accent red, status colors, ALL CAPS labels, fonts, type scale, spacing, component shapes. Dark: OLED black, white data glowing (instrument panel). Light: off-white paper (`#F5F5F5`), black ink; cards `#FFFFFF` = subtle elevation without shadows.


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/ui/nothing-design-skill/tokens/02-color.md` from 55 to 49 lines (11% reduction).

## Issue
Closes #17277

## Files Changed
- `.agents/tools/ui/nothing-design-skill/tokens/02-color.md` (55→49 lines)

## Changes
- Demoted `### Data Status Rules` sub-heading to bold inline label `**Data status:**` — saves 2 lines (heading + preceding blank line)
- Demoted `### Mode Philosophy` sub-heading to bold inline label `**Identical across modes:**` and merged the two sentences into one paragraph — saves 4 lines

## Content Preservation
All token data preserved: hex values, contrast ratios, role descriptions, dark/light mode values, data status rules, and mode philosophy. Zero content removed.

## Classification
Reference corpus (design token tables). File is already compact; splitting into chapter files would add overhead without benefit at this size.

## Testing
- `wc -l` before: 55, after: 49
- All code blocks, token names, hex values, and usage rules present before and after
- No broken internal links or references

## Runtime Testing
`self-assessed` — docs-only change, no runtime required.

---
[aidevops.sh](https://aidevops.sh) v3.6.56 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6