### PR TITLE
GH#17250: tighten corporate-traditional 02-colours.md — 94→28 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6419,6 +6419,12 @@
       "at": "2026-04-04T09:40:00Z",
       "passes": 1,
       "pr": 0
+    },
+    ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
+      "hash": "81b7218f66e89d210394785fcb422116ad69fbab1332339321046d97cdbea863",
+      "simplified_at": "2026-04-04T09:17:13Z",
+      "issue": "GH#17250",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)"
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/tools/design/library/styles/corporate-traditional/02-colours.md
+++ b/.agents/tools/design/library/styles/corporate-traditional/02-colours.md
@@ -3,92 +3,26 @@
 
 # Design System: Corporate Traditional — Colour Palette & Roles
 
-## Primary
-
-| Role | Hex | Usage |
-|------|-----|-------|
-| Primary | `#1B365D` | Headers, primary buttons, navigation background |
-| Primary Light | `#2A4A7F` | Hover states, secondary elements |
-| Primary Dark | `#0F2341` | Active states, footer background |
-
-## Accent
-
-| Role | Hex | Usage |
-|------|-----|-------|
-| Gold | `#B8860B` | CTAs, highlights, award badges, key links |
-| Gold Light | `#D4A843` | Hover on gold elements |
-| Gold Muted | `#C9B97A` | Decorative borders, subtle highlights |
-
-## Text
-
-| Role | Hex | Usage |
-|------|-----|-------|
-| Heading | `#1B365D` | All headings h1–h6 |
-| Body | `#333333` | Paragraph text, descriptions |
-| Secondary | `#6B7280` | Captions, metadata, timestamps |
-| Inverse | `#FFFFFF` | Text on dark backgrounds |
-
-## Surface
-
-| Role | Hex | Usage |
-|------|-----|-------|
-| Background | `#FFFFFF` | Page background |
-| Surface Alt | `#F5F5F0` | Alternating sections, sidebar |
-| Surface Accent | `#EEF0F4` | Card backgrounds, table headers |
-| Border | `#D1D5DB` | Dividers, table borders, input borders |
-| Border Strong | `#9CA3AF` | Active input borders |
-
-## Semantic
-
-| Role | Hex | Usage |
-|------|-----|-------|
-| Success | `#166534` | Confirmations, positive indicators |
-| Warning | `#92400E` | Caution messages |
-| Error | `#991B1B` | Error states, required fields |
-| Info | `#1E40AF` | Informational callouts |
-
-## Shadows
-
-| Role | Value | Usage |
-|------|-------|-------|
-| Shadow colour | `rgba(27, 54, 93, 0.08)` | All shadow definitions |
-| Shadow strong | `rgba(27, 54, 93, 0.15)` | Elevated elements |
-
-## CSS Variables
-
-```css
-:root {
-  /* Primary */
-  --color-primary: #1B365D;
-  --color-primary-light: #2A4A7F;
-  --color-primary-dark: #0F2341;
-
-  /* Accent */
-  --color-gold: #B8860B;
-  --color-gold-light: #D4A843;
-  --color-gold-muted: #C9B97A;
-
-  /* Text */
-  --color-text-heading: #1B365D;
-  --color-text-body: #333333;
-  --color-text-secondary: #6B7280;
-  --color-text-inverse: #FFFFFF;
-
-  /* Surface */
-  --color-bg: #FFFFFF;
-  --color-surface-alt: #F5F5F0;
-  --color-surface-accent: #EEF0F4;
-  --color-border: #D1D5DB;
-  --color-border-strong: #9CA3AF;
-
-  /* Semantic */
-  --color-success: #166534;
-  --color-warning: #92400E;
-  --color-error: #991B1B;
-  --color-info: #1E40AF;
-
-  /* Shadows */
-  --shadow-color: rgba(27, 54, 93, 0.08);
-  --shadow-color-strong: rgba(27, 54, 93, 0.15);
-}
-```
+| Group | Role | Hex | CSS Variable | Usage |
+|-------|------|-----|--------------|-------|
+| Primary | Primary | `#1B365D` | `--color-primary` | Headers, primary buttons, navigation background |
+| Primary | Primary Light | `#2A4A7F` | `--color-primary-light` | Hover states, secondary elements |
+| Primary | Primary Dark | `#0F2341` | `--color-primary-dark` | Active states, footer background |
+| Accent | Gold | `#B8860B` | `--color-gold` | CTAs, highlights, award badges, key links |
+| Accent | Gold Light | `#D4A843` | `--color-gold-light` | Hover on gold elements |
+| Accent | Gold Muted | `#C9B97A` | `--color-gold-muted` | Decorative borders, subtle highlights |
+| Text | Heading | `#1B365D` | `--color-text-heading` | All headings h1–h6 |
+| Text | Body | `#333333` | `--color-text-body` | Paragraph text, descriptions |
+| Text | Secondary | `#6B7280` | `--color-text-secondary` | Captions, metadata, timestamps |
+| Text | Inverse | `#FFFFFF` | `--color-text-inverse` | Text on dark backgrounds |
+| Surface | Background | `#FFFFFF` | `--color-bg` | Page background |
+| Surface | Surface Alt | `#F5F5F0` | `--color-surface-alt` | Alternating sections, sidebar |
+| Surface | Surface Accent | `#EEF0F4` | `--color-surface-accent` | Card backgrounds, table headers |
+| Surface | Border | `#D1D5DB` | `--color-border` | Dividers, table borders, input borders |
+| Surface | Border Strong | `#9CA3AF` | `--color-border-strong` | Active input borders |
+| Semantic | Success | `#166534` | `--color-success` | Confirmations, positive indicators |
+| Semantic | Warning | `#92400E` | `--color-warning` | Caution messages |
+| Semantic | Error | `#991B1B` | `--color-error` | Error states, required fields |
+| Semantic | Info | `#1E40AF` | `--color-info` | Informational callouts |
+| Shadows | Shadow | `rgba(27, 54, 93, 0.08)` | `--shadow-color` | All shadow definitions |
+| Shadows | Shadow Strong | `rgba(27, 54, 93, 0.15)` | `--shadow-color-strong` | Elevated elements |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/styles/corporate-traditional/02-colours.md` by consolidating 6 separate group tables and a CSS variables block into a single unified table with Group/Role/Hex/CSS Variable/Usage columns.

## Issue
Closes #17250

## Files Changed
- `.agents/tools/design/library/styles/corporate-traditional/02-colours.md` — 94 → 28 lines (70% reduction)
- `.agents/configs/simplification-state.json` — updated hash registry

## Testing
- All 21 colour tokens preserved with hex values, CSS variable names, and usage roles
- JSON validity of simplification-state.json verified (`python3 -c "import json; json.load(...)"`)
- No broken internal links or references
- Agent behaviour unchanged — reference data is identical, only presentation consolidated

## Key Decisions
- Merged 6 group tables (Primary, Accent, Text, Surface, Semantic, Shadows) into one unified table
- Added Group column to preserve grouping context without separate table headers
- CSS variables block eliminated — variables now inline in the table as a dedicated column
- Zero content loss: all hex values, variable names, and usage descriptions retained

## Runtime Testing
Risk: **Low** — documentation/reference file only, no code logic. Self-assessed.

---
[aidevops.sh](https://aidevops.sh) v3.6.56 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6