### PR TITLE
GH#17259: tighten nvidia responsive behavior doc (55→47 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,5 +1,11 @@
 {
   "files": {
+    ".agents/tools/design/library/brands/nvidia/08-responsive.md": {
+      "hash": "96c3efbd674eb1018e98362eb46728faf459e014",
+      "at": "2026-04-04T00:00:00Z",
+      "passes": 1,
+      "pr": 0
+    },
     ".agents/aidevops.md": {
       "hash": "6c034fc8cc954d733a8666b295a66fb3d8c291f5",
       "at": "2026-03-29T16:31:51Z",

--- a/.agents/tools/design/library/brands/nvidia/08-responsive.md
+++ b/.agents/tools/design/library/brands/nvidia/08-responsive.md
@@ -17,26 +17,18 @@
 
 ## Touch Targets
 
-- Buttons: 11px 13px padding
-- Nav links: 14px uppercase, adequate spacing
+- Buttons: 11px 13px padding; nav links: 14px uppercase, adequate spacing
 - Green-bordered buttons: high-contrast on dark backgrounds
 - Mobile: hamburger menu with full-screen overlay
 
 ## Collapsing Strategy
 
-- Hero heading: 36px → proportional scale-down
+- Hero heading: 36px → proportional scale-down; images maintain aspect ratio, scale to container
 - Nav: horizontal → hamburger at ~1024px
-- Product cards: 3-col → 2-col → single-col
-- Footer: multi-col → single stacked column
+- Product cards: 3-col → 2-col → single-col; GPU/product renders high resolution at all sizes
+- Hero images: scale proportionally with viewport; card images consistent aspect ratios
+- Footer: multi-col → single stacked column; full-bleed dark sections edge-to-edge
 - Section spacing: 64–80px → 32–48px on mobile
-- Images: maintain aspect ratio, scale to container width
-
-## Image Behavior
-
-- GPU/product renders: high resolution at all sizes
-- Hero images: scale proportionally with viewport
-- Card images: consistent aspect ratios
-- Full-bleed dark sections: edge-to-edge treatment
 
 ## Typography Scaling
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/nvidia/08-responsive.md` from 55 to 47 lines (15% reduction) by consolidating overlapping sections without content loss.

## Issue
Closes #17259

## Changes
- Merged "Image Behavior" section into "Collapsing Strategy" — both describe element adaptation across breakpoints; no duplication, just co-location
- Consolidated "Touch Targets" from 4 bullets to 3 by combining button padding and nav link specs on one line
- All breakpoints table, typography scaling, dark/light strategy, and cross-references preserved intact
- Updated `simplification-state.json` with file hash and pass count

## Files Changed
- `.agents/tools/design/library/brands/nvidia/08-responsive.md` (55→47 lines)
- `.agents/configs/simplification-state.json` (state registry updated)

## Runtime Testing
**Risk level:** Low — agent prompt/doc file, no runtime behavior.
**Verification:** `self-assessed` — content preservation confirmed by line-by-line review; all code blocks, URLs, and references present before and after.

## Key Decisions
- Classified as reference corpus (domain knowledge base), not instruction doc — no prose compression, only structural consolidation
- Image behavior merged into collapsing strategy (not deleted) — all 4 image bullets present in merged section

---
[aidevops.sh](https://aidevops.sh) v3.6.56 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6