### PR TITLE
GH#17258: tighten Resend color palette doc to consistent table format

### DIFF
--- a/.agents/tools/design/library/brands/resend/02-color-palette.md
+++ b/.agents/tools/design/library/brands/resend/02-color-palette.md
@@ -5,29 +5,26 @@
 
 ## Primary
 
-- **Void Black** (`#000000`): Page background, defining canvas (95% opacity via `--color-black-12`)
-- **Near White** (`#f0f0f0`): Primary text, button text, high-contrast elements
-- **Pure White** (`#ffffff`): `--color-white`, maximum emphasis text, link highlights
+| Name | Hex | CSS Var | Role |
+|------|-----|---------|------|
+| Void Black | `#000000` | `--color-black-12` (95% opacity) | Page background, defining canvas |
+| Near White | `#f0f0f0` | — | Primary text, button text, high-contrast elements |
+| Pure White | `#ffffff` | `--color-white` | Maximum emphasis text, link highlights |
 
 ## Accent Scale
 
-**Orange**
-- **Orange 4** (`#ff5900`): `--color-orange-4`, 22% opacity — subtle warm glow
-- **Orange 10** (`#ff801f`): `--color-orange-10`, primary orange accent
-- **Orange 11** (`#ffa057`): `--color-orange-11`, lighter orange for secondary use
-
-**Green**
-- **Green 3** (`#22ff99`): `--color-green-3`, 12% opacity — faint emerald wash
-- **Green 4** (`#11ff99`): `--color-green-4`, 18% opacity — success indicator glow
-
-**Blue**
-- **Blue 4** (`#0075ff`): `--color-blue-4`, 34% opacity — medium blue accent
-- **Blue 5** (`#0081fd`): `--color-blue-5`, 42% opacity — stronger blue
-- **Blue 10** (`#3b9eff`): `--color-blue-10`, bright blue — links, interactive elements
-
-**Other**
-- **Yellow 9** (`#ffc53d`): `--color-yellow-9`, warm gold — warnings, highlights
-- **Red 5** (`#ff2047`): `--color-red-5`, 34% opacity — error states, destructive actions
+| Name | Hex | CSS Var | Opacity | Role |
+|------|-----|---------|---------|------|
+| Orange 4 | `#ff5900` | `--color-orange-4` | 22% | Subtle warm glow |
+| Orange 10 | `#ff801f` | `--color-orange-10` | — | Primary orange accent |
+| Orange 11 | `#ffa057` | `--color-orange-11` | — | Lighter orange for secondary use |
+| Green 3 | `#22ff99` | `--color-green-3` | 12% | Faint emerald wash |
+| Green 4 | `#11ff99` | `--color-green-4` | 18% | Success indicator glow |
+| Blue 4 | `#0075ff` | `--color-blue-4` | 34% | Medium blue accent |
+| Blue 5 | `#0081fd` | `--color-blue-5` | 42% | Stronger blue |
+| Blue 10 | `#3b9eff` | `--color-blue-10` | — | Bright blue — links, interactive elements |
+| Yellow 9 | `#ffc53d` | `--color-yellow-9` | — | Warm gold — warnings, highlights |
+| Red 5 | `#ff2047` | `--color-red-5` | 34% | Error states, destructive actions |
 
 ## Neutral Scale
 
@@ -45,15 +42,19 @@
 
 ## Surface & Overlay
 
-- **Frost Primary** (`#fcfdff`): Primary color token — slight blue tint, 94% opacity
-- **White Hover** (`rgba(255, 255, 255, 0.28)`): Button hover state on dark
-- **White 60%** (`oklab(0.999994 ... / 0.577)`): Semi-transparent white for muted text
-- **White 64%** (`oklab(0.999994 ... / 0.642)`): Slightly brighter semi-transparent white
+| Name | Value | Role |
+|------|-------|------|
+| Frost Primary | `#fcfdff` | Primary color token — slight blue tint, 94% opacity |
+| White Hover | `rgba(255, 255, 255, 0.28)` | Button hover state on dark |
+| White 60% | `oklab(0.999994 ... / 0.577)` | Semi-transparent white for muted text |
+| White 64% | `oklab(0.999994 ... / 0.642)` | Slightly brighter semi-transparent white |
 
 ## Borders & Shadows
 
-- **Frost Border** (`rgba(214, 235, 253, 0.19)`): Signature icy blue-tinted borders at 19% opacity
-- **Frost Border Alt** (`rgba(217, 237, 254, 0.145)`): Lighter variant for list items
-- **Ring Shadow** (`rgba(176, 199, 217, 0.145) 0px 0px 0px 1px`): Blue-tinted shadow-as-border
-- **Focus Ring** (`rgb(0, 0, 0) 0px 0px 0px 8px`): Heavy black focus ring
-- **Subtle Shadow** (`rgba(0, 0, 0, 0.1) 0px 1px 3px, rgba(0, 0, 0, 0.1) 0px 1px 2px -1px`): Minimal card elevation
+| Name | Value | Role |
+|------|-------|------|
+| Frost Border | `rgba(214, 235, 253, 0.19)` | Signature icy blue-tinted borders at 19% opacity |
+| Frost Border Alt | `rgba(217, 237, 254, 0.145)` | Lighter variant for list items |
+| Ring Shadow | `rgba(176, 199, 217, 0.145) 0px 0px 0px 1px` | Blue-tinted shadow-as-border |
+| Focus Ring | `rgb(0, 0, 0) 0px 0px 0px 8px` | Heavy black focus ring |
+| Subtle Shadow | `rgba(0, 0, 0, 0.1) 0px 1px 3px, rgba(0, 0, 0, 0.1) 0px 1px 2px -1px` | Minimal card elevation |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Converts all bullet-list color sections in `02-color-palette.md` to consistent table format, matching the existing Neutral Scale table style already in the file.

## Issue
Closes #17258

## Files Changed
- `.agents/tools/design/library/brands/resend/02-color-palette.md` — reformatted Primary, Accent Scale, Surface & Overlay, and Borders & Shadows sections from bullet lists to tables

## Changes
- **Primary**: bullet list → table with Name/Hex/CSS Var/Role columns
- **Accent Scale**: 4 sub-grouped bullet lists (Orange/Green/Blue/Other) → single unified table with Opacity column (removes redundant sub-headers)
- **Surface & Overlay**: bullet list → table
- **Borders & Shadows**: bullet list → table

## Content Preservation
All hex values, CSS variable names, opacity values, and role descriptions preserved. Zero content loss — format change only.

## Testing
- `diff` verified: all 10 accent colors, 9 neutral grays, 4 surface tokens, 5 border/shadow tokens present before and after
- File is reference corpus (design system data) — no behavioral change, no agent rules affected
- `self-assessed` (Low risk: docs/formatting only)

## Runtime Testing
**Risk level**: Low — documentation/formatting change only, no code or agent instruction logic modified.
**Verification**: `self-assessed`

---
[aidevops.sh](https://aidevops.sh) v3.6.56 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6