### PR TITLE
GH#17280: tighten chromium-debug-use SKILL.md

### DIFF
--- a/.agents/tools/browser/chromium-debug-use/SKILL.md
+++ b/.agents/tools/browser/chromium-debug-use/SKILL.md
@@ -13,13 +13,12 @@ Read `tools/browser/chromium-debug-use.md` first.
 
 ## Use This Skill When
 
-- The user wants help with something already open in Chrome, Brave, Edge, Vivaldi, Chromium, or a compatible Chromium build.
-- The goal is to inspect current browser state before choosing a heavier automation tool.
+The user wants to inspect or lightly interact with something already open in a Chromium-family browser (Chrome, Brave, Edge, Vivaldi, Chromium) before committing to a heavier automation tool.
 
 ## Workflow
 
-1. Confirm this is an explicit, user-approved live-session investigation.
-2. Have the user launch the browser with the debug flag from `tools/browser/chromium-debug-use.md` if not already available.
+1. Confirm explicit, user-approved live-session investigation.
+2. If the debug port is not yet open, have the user launch with the flag from `tools/browser/chromium-debug-use.md`.
 3. Use `.agents/scripts/chromium-debug-use-helper.sh version` and `list` to confirm access.
 4. Prefer `snapshot`, `html`, and `eval` to understand the page before using `click`, `type`, `navigate`, or `screenshot`.
 5. Once the flow is understood, hand off to the best-fit longer-term tool:
@@ -28,13 +27,13 @@ Read `tools/browser/chromium-debug-use.md` first.
    - `tools/browser/playwriter.md` — per-tab extension consent in the user's normal browser
    - `tools/browser/chrome-devtools.md` — performance, network, and console inspection
 
-## Safety Rules
+## Safety
 
 - Local-only and temporary; the user must have enabled the debug path for this investigation.
 - Prefer loopback endpoints and temporary profiles.
 - Do not use this path for unrelated tabs or long-lived background control.
 
-## Helper Commands
+## Commands
 
 ```bash
 .agents/scripts/chromium-debug-use-helper.sh version


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten prose in `.agents/tools/browser/chromium-debug-use/SKILL.md` (instruction doc, 50→49 lines).

## Issue
Closes #17280

## Changes
- Merge two-bullet "Use This Skill When" into a single sentence (removes redundant split)
- Tighten workflow steps 1–2 (remove "this is an" / "if not already available" padding)
- Rename `## Safety Rules` → `## Safety` and `## Helper Commands` → `## Commands` (shorter, consistent with other docs)

## Files Changed
- `.agents/tools/browser/chromium-debug-use/SKILL.md` (1 file, -1 net line)

## Testing
**Risk level:** Low (agent doc, no code, no shell scripts)
**Verification method:** self-assessed

Content preservation check:
- All code blocks: ✓
- All 8 helper commands: ✓
- All 4 handoff doc references: ✓
- All 3 safety rules: ✓
- All 5 workflow steps: ✓
- `--browser-url` note: ✓
- No task IDs or incident refs in original to preserve

## Runtime Testing
Low-risk doc change. No runtime verification required per testing gate.

---
[aidevops.sh](https://aidevops.sh) v3.6.56 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6