### PR TITLE
GH#17281: tighten Cloudflare Pages Functions doc (50→46 lines)

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/pages-functions.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/pages-functions.md
@@ -22,22 +22,18 @@ Serverless functions on Cloudflare Pages using Workers runtime. File-based routi
 
 ## Dynamic Routes
 
-**Single segment** `[param]` → string:
+`[param]` → single segment (string) · `[[param]]` → multi-segment (array):
 
 ```js
+// /users/[user].js — context.params.user = "nevi"
 export function onRequest(context) {
   return new Response(`Hello ${context.params.user}`);
 }
-// Matches: /users/nevi
-```
 
-**Multi-segment** `[[param]]` → array:
-
-```js
+// /users/[[catchall]].js — context.params.catchall = ["nevi", "foobar"]
 export function onRequest(context) {
   return new Response(JSON.stringify(context.params.catchall));
 }
-// Matches: /users/nevi/foobar → ["nevi", "foobar"]
 ```
 
 ## Key Features


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/cloudflare-platform-skill/pages-functions.md` from 50 to 46 lines per simplification-debt issue GH#17281.

**Classification:** Instruction doc (agent reference, not reference corpus) — prose tightening applied.

**Changes:**
- Merged two separate dynamic route code blocks (single-segment and multi-segment) into one combined example
- Replaced redundant `**Single segment**`/`**Multi-segment**` prose headers with a single inline summary line
- Added file path comments to code examples for clarity (`/users/[user].js`, `/users/[[catchall]].js`)
- All knowledge preserved: routing tree, both param types, examples, key features, see-also links

**Verification:**
- All code blocks present before and after ✓
- No broken internal links ✓
- No task ID references in this file ✓
- Agent behaviour unchanged ✓

## Runtime Testing

Risk: **Low** — docs/agent prompt only, no code execution paths.
Assessment: `self-assessed`

Closes #17281

---
[aidevops.sh](https://aidevops.sh) v3.6.56 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6