### PR TITLE
GH#17277: tighten Nothing Design System color doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6431,6 +6431,12 @@
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
       "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)"
+    },
+    ".agents/tools/ui/nothing-design-skill/tokens/02-color.md": {
+      "hash": "c8765e9bc3b5994ef76050aa2dc4dd83f99636143806678c19c2564ad43b00c6",
+      "at": "2026-04-04T10:15:00Z",
+      "passes": 1,
+      "pr": null
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {


### PR DESCRIPTION
## Summary

- Tighten `02-color.md` (Nothing Design System — Color System) per simplification scan
- Merge Mode Philosophy two-sentence paragraph into one compact line
- All token tables, hex values, contrast ratios, and decision rules preserved verbatim
- 55 → 53 lines

## Classification

**Reference corpus** (color token tables). Per issue guidance: tables cannot be compressed without data loss. Only prose section tightened.

## Files Changed

- `.agents/tools/ui/nothing-design-skill/tokens/02-color.md` — 55 → 53 lines
- `.agents/configs/simplification-state.json` — added entry for this file

## Runtime Testing

**Risk: Low** — docs/agent prompt change only. No code paths affected. `self-assessed`.

## Key Decisions

- Tables preserved verbatim (reference data, not compressible)
- "Identical" → "Invariant" (more precise term for design invariants)
- Two Mode Philosophy sentences merged into one line

Closes #17277

---
[aidevops.sh](https://aidevops.sh) v3.6.56 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6