### PR TITLE
GH#17299: simplification: tighten vercel color palette doc

### DIFF
--- a/.agents/tools/design/library/brands/vercel/02-color-palette.md
+++ b/.agents/tools/design/library/brands/vercel/02-color-palette.md
@@ -47,4 +47,9 @@
 
 See [`06-depth-elevation.md`](06-depth-elevation.md) for the full shadow system and philosophy.
 
-Legacy token → level mapping: Border Shadow = Ring (Level 1), Subtle Elevation = Subtle Card (Level 2), Card Stack = Full Card (Level 3), Ring Border = Light Ring (Level 1b).
+| Legacy Token | Level Name | Level |
+|---|---|---|
+| Border Shadow | Ring | Level 1 |
+| Subtle Elevation | Subtle Card | Level 2 |
+| Card Stack | Full Card | Level 3 |
+| Ring Border | Light Ring | Level 1b |


### PR DESCRIPTION
## Summary

- Restructures the inline legacy token → level mapping sentence in `02-color-palette.md` into a proper markdown table for improved readability and scannability
- Zero content loss — all four legacy token mappings preserved
- File classified as reference corpus (color values, CSS tokens, design system data); no content compression applied per GH#6432 guidance

## Changes

- `.agents/tools/design/library/brands/vercel/02-color-palette.md`: converted trailing inline mapping to 4-row table

## Testing

- `markdownlint-cli2` passes with 0 errors
- Content verification: all 4 legacy token entries (Border Shadow, Subtle Elevation, Card Stack, Ring Border) present before and after
- No broken internal links — `06-depth-elevation.md` reference unchanged

## Runtime Testing

Risk: **Low** — docs-only change, no code, no agent behavior affected. `self-assessed`.

Closes #17299

---
[aidevops.sh](https://aidevops.sh) v3.6.63 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of design token mapping documentation for enhanced readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->