### PR TITLE
GH#17298: tighten Startup Bold layout principles prose

### DIFF
--- a/.agents/tools/design/library/styles/startup-bold/05-layout.md
+++ b/.agents/tools/design/library/styles/startup-bold/05-layout.md
@@ -38,7 +38,7 @@
 
 ## Whitespace Philosophy
 
-Space creates confidence. Consistent, rhythmic spacing communicates reliability and polish. Every spacing decision should reinforce the grid — no arbitrary values. Tight where elements are related, open where sections need separation.
+Consistent, rhythmic spacing reinforces the grid and communicates reliability. Tight where elements are related; open where sections need separation. No arbitrary values.
 
 ## Border Radius Scale
 


### PR DESCRIPTION
## Summary

- Tightens whitespace philosophy paragraph in `.agents/tools/design/library/styles/startup-bold/05-layout.md`
- Condenses 2 verbose sentences into 3 concise statements; same meaning, fewer words
- All token tables, values, and reference data preserved verbatim (zero content loss)

## Classification

**Reference corpus** (design token spec). Per issue guidance: do NOT compress content tables. The file is already well-structured at 51 lines. Only the prose section was eligible for tightening.

## Files Changed

- `.agents/tools/design/library/styles/startup-bold/05-layout.md` — 1 line changed (prose only)

## Runtime Testing

**Risk: Low** — docs/agent prompt change only. No code paths affected. `self-assessed`.

## Verification

- Content preservation: all code blocks, token values, URLs, task IDs present before and after ✓
- No broken internal links or references ✓
- Agent behaviour unchanged (reference corpus, not instruction doc) ✓

Closes #17298

---
[aidevops.sh](https://aidevops.sh) v3.6.63 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6