### PR TITLE
GH#17305: tighten ai-search-patterns.md prose and structure

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6514,5 +6514,11 @@
     "lines": 66,
     "status": "simplified",
     "issue": "GH#17279"
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md": {
+    "hash": "867d8ff77f341ac99f155db719644f2190031e9faa7e6668a79b05468b0eae0f",
+    "lines": 80,
+    "status": "simplified",
+    "issue": "GH#17305"
   }
 }

--- a/.agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md
@@ -1,38 +1,24 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-## Common Use Cases
+# AutoRAG AI Search Patterns
 
-1. **Enterprise search**: Natural language search over company docs
-2. **Customer support**: AI-powered chat with product documentation
-3. **Knowledge bases**: Semantic search over technical content
-4. **Multitenancy SaaS**: Per-tenant data isolation with folder filters
-5. **Content discovery**: Finding relevant content across large datasets
+Use cases: enterprise search, customer support chat, knowledge bases, multitenancy SaaS (folder filters), content discovery.
 
 ## Workers Binding (Recommended)
 
-### Configuration
-
-**wrangler.toml:**
+**wrangler.toml** or **wrangler.jsonc:**
 
 ```toml
 [ai]
 binding = "AI"
 ```
 
-**wrangler.jsonc:**
-
 ```jsonc
-{
-  "ai": {
-    "binding": "AI"
-  }
-}
+{ "ai": { "binding": "AI" } }
 ```
 
-### Code Patterns
-
-#### AI Search with Generation
+### AI Search with Generation
 
 ```typescript
 const answer = await env.AI.autorag("my-autorag").aiSearch({
@@ -40,18 +26,13 @@ const answer = await env.AI.autorag("my-autorag").aiSearch({
   model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
   rewrite_query: true,
   max_num_results: 10,
-  ranking_options: {
-    score_threshold: 0.3
-  },
-  reranking: {
-    enabled: true,
-    model: "@cf/baai/bge-reranker-base"
-  },
+  ranking_options: { score_threshold: 0.3 },
+  reranking: { enabled: true, model: "@cf/baai/bge-reranker-base" },
   stream: true
 });
 ```
 
-#### Search Only (no generation)
+### Search Only (no generation)
 
 ```typescript
 const results = await env.AI.autorag("my-autorag").search({
@@ -63,7 +44,7 @@ const results = await env.AI.autorag("my-autorag").search({
 // results.data[].content, results.data[].filename, results.data[].score
 ```
 
-#### Folder Filter (multitenancy)
+### Folder Filter (multitenancy)
 
 ```typescript
 const answer = await env.AI.autorag("my-autorag").aiSearch({
@@ -96,4 +77,4 @@ const response = await fetch(
 const { result } = await response.json();
 ```
 
-**Token permissions required:** `AI Search - Read` (search/aiSearch), `AI Search Edit` (index management).
+**Token permissions:** `AI Search - Read` (search/aiSearch), `AI Search Edit` (index management).


### PR DESCRIPTION
## Summary

Tighten `.agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md` per simplification scan (GH#17305).

**Changes:**
- Add file title heading for context
- Compress 5-item use cases list to single descriptive line (removed generic marketing prose)
- Merge redundant wrangler.toml + wrangler.jsonc config blocks into compact side-by-side form
- Flatten section hierarchy (removed nested `###` under `##` for code patterns)
- Tighten token permissions note (removed redundant "required")
- All code blocks, URLs, API patterns, and technical content preserved

**Result:** 99 → 80 lines (19% reduction). Zero content loss — all institutional knowledge retained.

## Classification

Reference corpus (code patterns, API examples, config snippets) — restructured for compactness, not compressed for content.

## Runtime Testing

Risk: **Low** — docs/agent prompts only. No runtime verification required. `self-assessed`.

Closes #17305

---
[aidevops.sh](https://aidevops.sh) v3.6.64 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6