### PR TITLE
GH#17307: fix broken cross-references in cache-reserve-patterns.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md
+++ b/.agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md
@@ -132,5 +132,5 @@ Origin cost (AWS): ~$0.09/GB vs Cache Reserve: $0.015/GB-month + $0.36/M reads.
 
 ## See Also
 
-- [README](./README.md) - Overview and core concepts
-- [Gotchas](./gotchas.md) - Common issues and troubleshooting
+- [Overview](./cache-reserve.md) - Core concepts, hierarchy, eligibility, setup
+- [Gotchas](./cache-reserve-gotchas.md) - Common issues, troubleshooting, limits


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Fix stale `See Also` links in `cache-reserve-patterns.md` that pointed to non-existent files (`README.md`, `gotchas.md`). Corrected to actual file paths (`cache-reserve.md`, `cache-reserve-gotchas.md`).

## Issue
Closes #17307

## Files Changed
- `.agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md` — fix 2 broken cross-reference links in See Also section

## Classification
File type: **reference corpus** (domain knowledge base). Per issue guidance, reference corpora should NOT have content compressed — only structural issues fixed. The `cache-reserve.md` (51 lines) is already appropriately slim and well-structured with companion files. The only actionable fix was the broken links.

## Testing
- `self-assessed` (docs-only change, low risk per runtime testing gate)
- Verified: `cache-reserve.md` → links to `cache-reserve-patterns.md` ✓ and `cache-reserve-gotchas.md` ✓
- Verified: `cache-reserve-patterns.md` → now links to `cache-reserve.md` ✓ and `cache-reserve-gotchas.md` ✓
- Verified: `cache-reserve-gotchas.md` → links to `cache-reserve.md` ✓ and `cache-reserve-patterns.md` ✓
- All three files form a complete, internally consistent cross-linked set

## Runtime Testing
Risk: **Low** (docs/cross-references only). Self-assessed.

## Key Decisions
- Did not compress `cache-reserve.md` content — it's a reference corpus, already appropriately structured
- Fixed only the broken links, preserving all institutional knowledge

---
[aidevops.sh](https://aidevops.sh) v3.6.64 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6