### PR TITLE
GH#17296: tighten nvidia 02-color-palette.md — convert single-row shadow table to bullet

### DIFF
--- a/.agents/tools/design/library/brands/nvidia/02-color-palette.md
+++ b/.agents/tools/design/library/brands/nvidia/02-color-palette.md
@@ -60,6 +60,4 @@
 
 ## Shadows & Depth
 
-| Token | Value | Role |
-|-------|-------|------|
-| Card Shadow | `rgba(0,0,0,0.3) 0px 0px 5px 0px` | Subtle ambient shadow for elevated cards. |
+- **Card Shadow** (`rgba(0,0,0,0.3) 0px 0px 5px 0px`): Subtle ambient shadow for elevated cards.


### PR DESCRIPTION
## Summary

Simplification of `.agents/tools/design/library/brands/nvidia/02-color-palette.md` (GH#17296).

The Shadows & Depth section had a single-row table (header + separator + one data row). A single-entry table adds formatting overhead without clarity benefit — converted to a bullet point.

Closes #17296

## What

- Converted single-row `Shadows & Depth` table to a bullet point
- 65 → 63 lines (−2 lines)
- All token names, hex values, and role descriptions preserved

## Files Changed

- `.agents/tools/design/library/brands/nvidia/02-color-palette.md`

## Runtime Testing

**Risk level:** Low — documentation/agent prompt file, no executable code.
**Verification:** `self-assessed` — all color tokens, hex values, and role descriptions present before and after. No code blocks, URLs, or task ID references in this file.

<!-- MERGE_SUMMARY -->
**What:** Convert single-row shadow table to bullet in nvidia color palette doc
**Issue:** Closes #17296
**Files changed:** 1 (`.agents/tools/design/library/brands/nvidia/02-color-palette.md`)
**Testing:** Self-assessed (low-risk doc change)
**Key decisions:** Single-entry tables are formatting overhead; bullet is cleaner and equivalent

---
[aidevops.sh](https://aidevops.sh) v3.6.65 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the design specification formatting in the color palette guide for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->