### PR TITLE
GH#17295: tighten Corporate Friendly colour palette — merge CSS variables inline

### DIFF
--- a/.agents/tools/design/library/styles/corporate-friendly/02-colour-palette.md
+++ b/.agents/tools/design/library/styles/corporate-friendly/02-colour-palette.md
@@ -5,78 +5,47 @@
 
 ## Primary
 
-| Role | Hex | Usage |
-|------|-----|-------|
-| Primary | `#3b82f6` | Primary buttons, active links, selected states |
-| Primary Light | `#60a5fa` | Hover accents, progress indicators |
-| Primary Dark | `#2563eb` | Active/pressed states |
-| Primary Subtle | `#eff6ff` | Tinted backgrounds, info banners, selected rows |
+| Role | Hex | CSS Variable | Usage |
+|------|-----|-------------|-------|
+| Primary | `#3b82f6` | `--color-primary` | Primary buttons, active links, selected states |
+| Primary Light | `#60a5fa` | `--color-primary-light` | Hover accents, progress indicators |
+| Primary Dark | `#2563eb` | `--color-primary-dark` | Active/pressed states |
+| Primary Subtle | `#eff6ff` | `--color-primary-subtle` | Tinted backgrounds, info banners, selected rows |
 
 ## Accent
 
-| Role | Hex | Usage |
-|------|-----|-------|
-| Accent | `#f97316` | Secondary CTAs, highlights, badges, notifications |
-| Accent Light | `#fb923c` | Hover on accent elements |
-| Accent Dark | `#ea580c` | Active/pressed accent states |
-| Accent Subtle | `#fff7ed` | Accent-tinted backgrounds, feature callouts |
+| Role | Hex | CSS Variable | Usage |
+|------|-----|-------------|-------|
+| Accent | `#f97316` | `--color-accent` | Secondary CTAs, highlights, badges, notifications |
+| Accent Light | `#fb923c` | `--color-accent-light` | Hover on accent elements |
+| Accent Dark | `#ea580c` | `--color-accent-dark` | Active/pressed accent states |
+| Accent Subtle | `#fff7ed` | `--color-accent-subtle` | Accent-tinted backgrounds, feature callouts |
 
 ## Text
 
-| Role | Hex | Usage |
-|------|-----|-------|
-| Heading | `#111827` | All headings h1–h6 |
-| Body | `#374151` | Paragraph text, descriptions |
-| Secondary | `#6b7280` | Captions, helper text, metadata |
-| Tertiary | `#9ca3af` | Placeholders, disabled text |
-| Inverse | `#FFFFFF` | Text on dark/coloured backgrounds |
+| Role | Hex | CSS Variable | Usage |
+|------|-----|-------------|-------|
+| Heading | `#111827` | `--color-text` | All headings h1–h6 |
+| Body | `#374151` | `--color-text-body` | Paragraph text, descriptions |
+| Secondary | `#6b7280` | `--color-text-secondary` | Captions, helper text, metadata |
+| Tertiary | `#9ca3af` | `--color-text-tertiary` | Placeholders, disabled text |
+| Inverse | `#FFFFFF` | `--color-text-inverse` | Text on dark/coloured backgrounds |
 
 ## Surface
 
-| Role | Hex | Usage |
-|------|-----|-------|
-| Background | `#FFFFFF` | Primary page background |
-| Surface | `#F9FAFB` | Alternate sections, sidebar, card backgrounds |
-| Surface Warm | `#FFFBF5` | Testimonial sections, callout areas |
-| Border | `#E5E7EB` | Default borders, dividers |
-| Border Strong | `#D1D5DB` | Input focus borders, active separators |
+| Role | Hex | CSS Variable | Usage |
+|------|-----|-------------|-------|
+| Background | `#FFFFFF` | `--color-surface` | Primary page background |
+| Surface | `#F9FAFB` | `--color-surface-alt` | Alternate sections, sidebar, card backgrounds |
+| Surface Warm | `#FFFBF5` | `--color-surface-warm` | Testimonial sections, callout areas |
+| Border | `#E5E7EB` | `--color-border` | Default borders, dividers |
+| Border Strong | `#D1D5DB` | `--color-border-strong` | Input focus borders, active separators |
 
 ## Semantic
 
-| Role | Hex | Background | Usage |
-|------|-----|-----------|-------|
-| Success | `#16a34a` | `#f0fdf4` | Completion, positive feedback |
-| Warning | `#eab308` | `#fefce8` | Caution, pending review |
-| Error | `#ef4444` | `#fef2f2` | Validation errors, destructive actions |
-| Info | `#3b82f6` | `#eff6ff` | Tips, informational messages |
-
-## CSS Variables
-
-| CSS Variable | Hex |
-|-------------|-----|
-| `--color-primary` | `#3b82f6` |
-| `--color-primary-light` | `#60a5fa` |
-| `--color-primary-dark` | `#2563eb` |
-| `--color-primary-subtle` | `#eff6ff` |
-| `--color-accent` | `#f97316` |
-| `--color-accent-light` | `#fb923c` |
-| `--color-accent-dark` | `#ea580c` |
-| `--color-accent-subtle` | `#fff7ed` |
-| `--color-text` | `#111827` |
-| `--color-text-body` | `#374151` |
-| `--color-text-secondary` | `#6b7280` |
-| `--color-text-tertiary` | `#9ca3af` |
-| `--color-text-inverse` | `#FFFFFF` |
-| `--color-surface` | `#FFFFFF` |
-| `--color-surface-alt` | `#F9FAFB` |
-| `--color-surface-warm` | `#FFFBF5` |
-| `--color-border` | `#E5E7EB` |
-| `--color-border-strong` | `#D1D5DB` |
-| `--color-success` | `#16a34a` |
-| `--color-success-bg` | `#f0fdf4` |
-| `--color-warning` | `#eab308` |
-| `--color-warning-bg` | `#fefce8` |
-| `--color-error` | `#ef4444` |
-| `--color-error-bg` | `#fef2f2` |
-| `--color-info` | `#3b82f6` |
-| `--color-info-bg` | `#eff6ff` |
+| Role | Hex | Background | CSS Variable | Background Variable | Usage |
+|------|-----|-----------|-------------|-------------------|-------|
+| Success | `#16a34a` | `#f0fdf4` | `--color-success` | `--color-success-bg` | Completion, positive feedback |
+| Warning | `#eab308` | `#fefce8` | `--color-warning` | `--color-warning-bg` | Caution, pending review |
+| Error | `#ef4444` | `#fef2f2` | `--color-error` | `--color-error-bg` | Validation errors, destructive actions |
+| Info | `#3b82f6` | `#eff6ff` | `--color-info` | `--color-info-bg` | Tips, informational messages |


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Merge the separate CSS Variables section into each colour palette table as an additional column. Eliminates 31 lines of redundant structure while preserving all 26 CSS variable names co-located with their hex values and usage context.

## Issue
Closes #17295

## Classification
Reference corpus (design system colour palette). Per issue guidance: restructure, do not compress content. The CSS Variables section was a structural redundancy — same hex values listed twice. Merging inline is the correct restructure action.

## Files Changed
- `.agents/tools/design/library/styles/corporate-friendly/02-colour-palette.md`: 82→51 lines

## Testing
- All 26 CSS variable names present before and after (verified by inspection)
- All hex values preserved in their original semantic sections
- No broken references (file is self-contained reference data)
- `wc -l` before: 82, after: 51

## Runtime Testing
**Risk level:** Low — docs/reference data only, no code execution paths.
**Verification:** `self-assessed` — content preservation confirmed by diff review.

## Key Decisions
- Merged CSS Variables into each section's table rather than keeping as separate section — eliminates the need to cross-reference two tables to get role→hex→variable mapping
- Semantic section retains Background column alongside new CSS Variable + Background Variable columns for completeness

---
[aidevops.sh](https://aidevops.sh) v3.6.65 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6