### PR TITLE
GH#17320: tighten remotion-charts.md prose

### DIFF
--- a/.agents/tools/video/remotion-charts.md
+++ b/.agents/tools/video/remotion-charts.md
@@ -13,8 +13,6 @@ Use regular React, HTML, SVG, or D3. Disable third-party animation systems — t
 
 ## Bar charts — staggered bars
 
-Animate each bar height with a per-bar delay:
-
 ```tsx
 const STAGGER_DELAY = 5;
 const frame = useCurrentFrame();
@@ -32,9 +30,7 @@ const bars = data.map((item, i) => {
 });
 ```
 
-## Pie charts
-
-Animate segments with `strokeDashoffset` and rotate the circle so drawing starts at 12 o'clock.
+## Pie charts — `strokeDashoffset`, rotated to 12 o'clock
 
 ```tsx
 const frame = useCurrentFrame();


### PR DESCRIPTION
## Summary

- Remove redundant prose lines before code blocks (the section headers are self-explanatory)
- Fold pie chart technique description into section header: `## Pie charts — \`strokeDashoffset\`, rotated to 12 o'clock`
- All code examples, institutional knowledge, and frontmatter preserved
- 50 → 46 lines (8% reduction)

## What

Tighten `.agents/tools/video/remotion-charts.md` per simplification scan. This is an instruction doc (agent patterns), not a reference corpus — prose compression applies.

## Issue

Closes #17320

## Files Changed

- `.agents/tools/video/remotion-charts.md` — 6 lines removed, 1 line modified (section header enriched)

## Testing

**Risk level:** Low (docs/agent prompt, no code logic)
**Verification:** All code blocks present before and after. No URLs, task IDs, or command examples in this file. Section headers preserved with technique detail moved into header.

## Runtime Testing

`self-assessed` — Low risk: agent doc only, no executable code changed.

---
<!-- MERGE_SUMMARY -->
**What:** Tighten remotion-charts.md by removing redundant prose before code blocks and folding technique description into section header.
**Issue:** Closes #17320
**Files changed:** 1 (`.agents/tools/video/remotion-charts.md`)
**Testing:** Self-assessed — docs only, all code blocks preserved
**Key decisions:** Moved "Animate segments with strokeDashoffset and rotate the circle so drawing starts at 12 o'clock" from prose into section header to preserve the knowledge while eliminating the standalone prose line.

---
[aidevops.sh](https://aidevops.sh) v3.6.70 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6