### PR TITLE
GH#17318: tighten Lovable 04-components — cross-reference Button Inset shadow

### DIFF
--- a/.agents/tools/design/library/brands/lovable/04-components.md
+++ b/.agents/tools/design/library/brands/lovable/04-components.md
@@ -9,7 +9,7 @@ All variants: Padding 8px 16px · Radius 6px · Active opacity 0.8 · Focus `rgb
 
 **Primary Dark (Inset Shadow)**
 - Background: `#1c1c1c` · Text: `#fcfbf8`
-- Shadow: `rgba(0,0,0,0) 0px 0px 0px 0px, rgba(0,0,0,0) 0px 0px 0px 0px, rgba(255,255,255,0.2) 0px 0.5px 0px 0px inset, rgba(0,0,0,0.2) 0px 0px 0px 0.5px inset, rgba(0,0,0,0.05) 0px 1px 2px 0px`
+- Shadow: see `02-color-palette.md` "Button Inset"
 - Use: Primary CTA ("Start Building", "Get Started")
 
 **Ghost / Outline**


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/lovable/04-components.md` — replace verbose inline shadow value with cross-reference to `02-color-palette.md`.

## Issue
Closes #17318

## Changes
- Primary Dark button shadow: replaced 196-char inline CSS value with `see \`02-color-palette.md\` "Button Inset"` — the value is already defined in the color palette chapter, consistent with how Pill/Icon Button already uses "same inset pattern as Primary Dark"

## Files Changed
- `.agents/tools/design/library/brands/lovable/04-components.md` (74 lines, shadow line 196→50 chars)

## Testing
**Classification:** Reference corpus (design system CSS values/specs). File is already a chapter in a 9-chapter system — restructuring not applicable. Applied targeted deduplication: shadow value defined once in `02-color-palette.md`, referenced from components chapter.

**Verification:**
- All section headings intact
- All `Use:` annotations preserved
- All hex color values preserved (`#1c1c1c`, `#fcfbf8`, `#f7f4ed`, `#eceae4`, `rgba(...)`)
- Shadow value still accessible via `02-color-palette.md` "Button Inset" cross-reference
- No code blocks in this file (N/A)
- No task ID refs in this file (N/A)
- Pill/Icon Button already used cross-reference pattern ("same inset pattern as Primary Dark") — this change is consistent

**Risk:** Low — docs-only change, no agent behaviour affected.

## Runtime Testing
`self-assessed` — Low risk (docs/reference file, no executable code)

---
[aidevops.sh](https://aidevops.sh) v3.6.70 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6