### PR TITLE
GH#17337: tighten remotion-charts.md agent doc

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6430,7 +6430,7 @@
       "hash": "81b7218f66e89d210394785fcb422116ad69fbab1332339321046d97cdbea863",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)"
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)"
     },
     ".agents/tools/ui/nothing-design-skill/tokens/02-color.md": {
       "hash": "c8765e9bc3b5994ef76050aa2dc4dd83f99636143806678c19c2564ad43b00c6",
@@ -6441,6 +6441,12 @@
     ".agents/scripts/attribution-detection-helper.sh": {
       "hash": "4037b27a1ca451750e419a0d4c46c64511691ab2e5f82df87730fe3fa7066f1a",
       "at": "2026-04-04T13:41:00Z",
+      "passes": 1,
+      "pr": 0
+    },
+    ".agents/tools/video/remotion-charts.md": {
+      "hash": "4e0b0ad31abf1be3fbe31516d4dc386120dec1a1",
+      "at": "2026-04-04T00:00:00Z",
       "passes": 1,
       "pr": 0
     }

--- a/.agents/tools/video/remotion-charts.md
+++ b/.agents/tools/video/remotion-charts.md
@@ -1,13 +1,11 @@
 ---
 name: charts
 mode: subagent
-description: Chart and data visualization patterns for Remotion. Use when creating bar charts, pie charts, histograms, progress bars, or any data-driven animations.
+description: Chart and data visualization patterns for Remotion — bar, pie, and data-driven animations.
 ---
 
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
-
-# Charts in Remotion
 
 Use regular React, HTML, SVG, or D3. Disable third-party animation systems — they flicker during render. Drive all chart motion from `useCurrentFrame()`.
 
@@ -20,12 +18,7 @@ const {fps} = useVideoConfig();
 
 const bars = data.map((item, i) => {
   const delay = i * STAGGER_DELAY;
-  const height = spring({
-    frame,
-    fps,
-    delay,
-    config: {damping: 200},
-  });
+  const height = spring({frame, fps, delay, config: {damping: 200}});
   return <div style={{height: height * item.value}} />;
 });
 ```
@@ -37,10 +30,15 @@ const frame = useCurrentFrame();
 const {fps} = useVideoConfig();
 
 const progress = interpolate(frame, [0, 100], [0, 1]);
-
 const circumference = 2 * Math.PI * radius;
 const segmentLength = (value / total) * circumference;
 const offset = interpolate(progress, [0, 1], [segmentLength, 0]);
 
-<circle r={radius} cx={center} cy={center} fill="none" stroke={color} strokeWidth={strokeWidth} strokeDasharray={`${segmentLength} ${circumference}`} strokeDashoffset={offset} transform={`rotate(-90 ${center} ${center})`} />;
+<circle
+  r={radius} cx={center} cy={center}
+  fill="none" stroke={color} strokeWidth={strokeWidth}
+  strokeDasharray={`${segmentLength} ${circumference}`}
+  strokeDashoffset={offset}
+  transform={`rotate(-90 ${center} ${center})`}
+/>;
 ```


### PR DESCRIPTION
## Summary

- Tighten frontmatter `description` — remove verbose chart type enumeration
- Remove redundant `# Charts in Remotion` title heading (frontmatter `name`+`description` serve this purpose)
- Collapse `spring()` call to single line for conciseness
- Break long `<circle>` JSX element into multi-line for readability
- Register file in `simplification-state.json` with SHA1 hash

## What

Simplification of `.agents/tools/video/remotion-charts.md` per issue #17337 automated scan. File reduced from 46 → 44 lines. All code blocks, patterns, and institutional knowledge preserved.

## Classification

**Instruction doc** (subagent with operational patterns). Not a reference corpus — no self-contained sections or textbook-style content. Tightening approach applied (not chapter split).

## Files Changed

- `.agents/tools/video/remotion-charts.md` — tightened (46 → 44 lines)
- `.agents/configs/simplification-state.json` — added file entry with hash

## Runtime Testing

**Risk: Low** — docs/agent prompt change only. No code execution paths affected. `self-assessed`.

Closes #17337

---
[aidevops.sh](https://aidevops.sh) v3.6.74 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated video animation tool description with clearer, concise phrasing.
  * Reformatted code examples for improved readability.

* **Chores**
  * Updated configuration to include new video animation tool entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->