### PR TITLE
GH#17340: tighten Uber Design component stylings doc

### DIFF
--- a/.agents/tools/design/library/brands/uber/04-components.md
+++ b/.agents/tools/design/library/brands/uber/04-components.md
@@ -5,41 +5,27 @@
 
 ## Buttons
 
-**Primary Black (CTA)**
+All buttons: `999px` radius (full pill).
 
-- Background: Uber Black (`#000000`)
-- Text: Pure White (`#ffffff`)
-- Padding: 10px 12px
-- Radius: 999px (full pill)
-- Outline: none
+**Primary Black (CTA)**
+- Background: Uber Black (`#000000`); Text: Pure White (`#ffffff`)
+- Padding: 10px 12px; Outline: none
 - Focus: inset ring `rgb(255,255,255) 0px 0px 0px 2px`
 
 **Secondary White**
-
-- Background: Pure White (`#ffffff`)
-- Text: Uber Black (`#000000`)
+- Background: Pure White (`#ffffff`); Text: Uber Black (`#000000`)
 - Padding: 10px 12px
-- Radius: 999px (full pill)
-- Hover: background shifts to Hover Gray (`#e2e2e2`)
-- Focus: background shifts to Hover Gray, inset ring appears
+- Hover: background → Hover Gray (`#e2e2e2`); Focus: same + inset ring
 
 **Chip / Filter**
-
-- Background: Chip Gray (`#efefef`)
-- Text: Uber Black (`#000000`)
+- Background: Chip Gray (`#efefef`); Text: Uber Black (`#000000`)
 - Padding: 14px 16px
-- Radius: 999px (full pill)
 - Active: inset shadow `rgba(0,0,0,0.08)`
 
 **Floating Action**
-
-- Background: Pure White (`#ffffff`)
-- Text: Uber Black (`#000000`)
-- Padding: 14px
-- Radius: 999px (full pill)
-- Shadow: `rgba(0,0,0,0.16) 0px 2px 8px 0px`
-- Transform: `translateY(2px)` slight offset
-- Hover: background shifts to `#f3f3f3`
+- Background: Pure White (`#ffffff`); Text: Uber Black (`#000000`)
+- Padding: 14px; Shadow: `rgba(0,0,0,0.16) 0px 2px 8px 0px`
+- Transform: `translateY(2px)` slight offset; Hover: background → `#f3f3f3`
 
 ## Cards & Containers
 
@@ -52,12 +38,9 @@
 
 ## Inputs & Forms
 
-- Text: Uber Black (`#000000`)
-- Background: Pure White (`#ffffff`)
-- Border: 1px solid Black (`#000000`)
-- Radius: 8px
-- Padding: standard comfortable spacing
-- Focus: standard browser focus ring
+- Text: Uber Black (`#000000`); Background: Pure White (`#ffffff`)
+- Border: 1px solid Black (`#000000`); Radius: 8px
+- Padding: standard comfortable spacing; Focus: standard browser focus ring
 
 ## Navigation
 
@@ -65,32 +48,27 @@
 - Logo: Uber wordmark/icon at 24x24px in black
 - Links: UberMoveText 14-18px, weight 500, Uber Black
 - Pill-shaped nav chips: Chip Gray (`#efefef`) background — see [Category Pill Navigation](#distinctive-components)
-- Menu toggle: circular button, 50% border-radius
-- Mobile: hamburger menu
+- Menu toggle: circular button, 50% border-radius; Mobile: hamburger menu
 
 ## Image Treatment
 
 - Warm, hand-illustrated scenes for feature sections (not photographs)
 - Hero sections: bold photography or illustration, full-width
-- QR codes for app download CTAs
-- Contained imagery: 8px or 12px border-radius
+- QR codes for app download CTAs; Contained imagery: 8px or 12px border-radius
 
 ## Distinctive Components
 
 **Category Pill Navigation**
-
 - Horizontal row of pill-shaped buttons ("Ride", "Drive", "Business", "Uber Eats", "About")
 - Each pill: Chip Gray background, black text, 999px radius
 - Active: black background, white text (inversion)
 
 **Hero with Dual Action**
-
 - Split hero: text/CTA left, map/illustration right
 - Two input fields side by side for pickup/destination
 - "See prices" CTA: black pill button
 
 **Plan-Ahead Cards**
-
 - Cards for "Uber Reserve" and trip planning features
 - Illustration-heavy, warm human-centric imagery
 - Black CTA buttons with white text at bottom


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/design/library/brands/uber/04-components.md` from 96 → 74 lines (23% reduction).

## Issue
Closes #17340

## Files Changed
- `.agents/tools/design/library/brands/uber/04-components.md` — 96 → 74 lines

## Changes Made
- Factored out repeated `999px radius (full pill)` into a shared note at the top of the Buttons section
- Combined related single-value properties onto shared lines (e.g., Background + Text on one line)
- Removed blank lines between bold headers and their first list item in Distinctive Components
- Combined short adjacent list items (e.g., Menu toggle + Mobile, QR codes + Contained imagery)

## Content Preservation
All CSS values, hex codes, pixel values, shadow values, transform values, and component descriptions are preserved verbatim. No knowledge loss.

## Classification
Reference corpus (design knowledge base) — restructuring not warranted at 74 lines. Prose tightening applied per code-simplifier guidance.

## Runtime Testing
**Risk level:** Low — agent prompt/doc file only, no executable code.
**Verification:** All code blocks, CSS values, hex codes, and component specs present before and after. `wc -l` confirms 96 → 74 lines.

---
[aidevops.sh](https://aidevops.sh) v3.6.76 plugin for [OpenCode](https://opencode.ai) v1.3.13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated Uber design library button component styling documentation with unified global rules and standards
  * Centralized button radius specification to `999px` (full pill style) to reduce repetitive styling requirements across individual button component types
  * Reformatted component documentation entries for enhanced readability across button, input field, form, navigation, and image treatment sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->