### PR TITLE
GH#17343: tighten code-review setup.md Quick Reference

### DIFF
--- a/.agents/tools/code-review/setup.md
+++ b/.agents/tools/code-review/setup.md
@@ -16,18 +16,16 @@ tools:
 
 ## Quick Reference
 
-- Platforms: CodeRabbit (AI PR review), CodeFactor (grade/trends), Codacy (quality/security), SonarCloud (quality gate)
-- Setup time: ~5 min per platform via GitHub OAuth
-- Config files: `.codacy.yml`, `sonar-project.properties`
-- Targets: CodeFactor A+, Codacy A, SonarCloud passed gate, CodeRabbit useful PR feedback
-- Deep dives: `coderabbit.md`, `codacy.md`, `tools.md`, `.agents/scripts/sonarcloud-cli.sh`
+Setup time: ~5 min per platform via GitHub OAuth. Targets: CodeFactor A+, Codacy A, SonarCloud passed gate, CodeRabbit useful PR feedback.
 
-| Platform | Setup | Coverage |
-|---|---|---|
-| CodeRabbit | <https://coderabbit.ai/> → add repo → enable automatic PR reviews | AI review, security, best practices, performance |
-| CodeFactor | <https://www.codefactor.io/> → add repo → enable GitHub Checks | A-F grade, cyclomatic complexity, technical debt, trends |
-| Codacy | <https://app.codacy.com/> → import repo; uses `.codacy.yml` | Security scanning, quality metrics, test coverage, standards |
-| SonarCloud | <https://sonarcloud.io/> → create org → import project → add `SONAR_TOKEN` GitHub secret | Security hotspots, bugs, code smells, duplication, quality gate |
+| Platform | Setup | Coverage | Config |
+|---|---|---|---|
+| CodeRabbit | <https://coderabbit.ai/> → add repo → enable automatic PR reviews | AI review, security, best practices, performance | — |
+| CodeFactor | <https://www.codefactor.io/> → add repo → enable GitHub Checks | A-F grade, cyclomatic complexity, technical debt, trends | — |
+| Codacy | <https://app.codacy.com/> → import repo | Security scanning, quality metrics, test coverage, standards | `.codacy.yml` |
+| SonarCloud | <https://sonarcloud.io/> → create org → import project → add `SONAR_TOKEN` GitHub secret | Security hotspots, bugs, code smells, duplication, quality gate | `sonar-project.properties` |
+
+Deep dives: `coderabbit.md`, `codacy.md`, `tools.md`, `.agents/scripts/sonarcloud-cli.sh`
 
 <!-- AI-CONTEXT-END -->
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Tighten `.agents/tools/code-review/setup.md` Quick Reference section by merging a redundant bullet list + platform table into a single consolidated table with a Config column.

## Issue
Closes #17343

## Files Changed
- `.agents/tools/code-review/setup.md` — 52 → 50 lines; Quick Reference section restructured

## Testing
- **Risk level:** Low (docs/agent prompt only — no code, no scripts, no runtime behaviour)
- **Verification:** `self-assessed` — content preservation verified via diff; all URLs, task IDs, config file references, and command examples present before and after
- Content preserved: all 4 platforms, setup steps, coverage descriptions, config files (`.codacy.yml`, `sonar-project.properties`), targets, deep-dive links, README badges, troubleshooting table

## Key Decisions
- Classified as **instruction doc** (not reference corpus) — tighten prose, not split into chapters
- Config files moved into table as a `Config` column — eliminates separate bullet point while keeping the info co-located with the platform it applies to
- Targets + setup time condensed to a single prose line above the table (was 2 separate bullets)
- Deep dives line moved below the table (was above, now after the table for better flow)

## Runtime Testing
`self-assessed` — Low risk: agent prompt doc only, no executable code changed.

---
[aidevops.sh](https://aidevops.sh) v3.6.76 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6