### PR TITLE
GH#17371: add bash32-compat CI check and fix literal \n in schedulers.sh

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -66,6 +66,78 @@ jobs:
         bash .agents/scripts/platform-detect.sh
         echo "Platform detection: OK"
 
+  # Bash 3.2 compatibility: catches "\n"/"\t" in double-quoted strings and other
+  # bash 4+ constructs that break on macOS default bash (GH#17371)
+  bash32-compat:
+    name: Bash 3.2 Compatibility
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Bash 3.2 compatibility check
+      run: |
+        echo "Checking Bash 3.2 compatibility across all shell scripts..."
+
+        # Source shared file-discovery helper (single source of truth for exclusions)
+        source .agents/scripts/lint-file-discovery.sh
+        lint_shell_files
+
+        violations=0
+        # Self-skip: linters-local.sh grep patterns contain the forbidden strings
+        # as search targets, not as bash code.
+        self_skip="linters-local.sh"
+
+        while IFS= read -r file; do
+          [ -n "$file" ] || continue
+          basename_file=$(basename "$file")
+          [ "$basename_file" = "$self_skip" ] && continue
+          [ -f "$file" ] || continue
+
+          # "\t" or "\n" in string concatenation (likely wants $'\t' or $'\n')
+          # Only flag += or = assignments, not awk/sed/printf/echo -e/python contexts
+          matches=$(grep -nE '\+="\\[tn]|="\\[tn]' "$file" 2>/dev/null \
+            | grep -vE '^[0-9]+:[[:space:]]*#' \
+            | grep -vE 'awk|sed|printf|echo.*-e|python|f\.write|gsub|join|split|print |replace|coords|excerpt|delimiter|regex|pattern' \
+            || true)
+          if [ -n "$matches" ]; then
+            while IFS= read -r line; do
+              echo "FAIL $file:$line [\"\\t\"/\"\\n\" — use \$'\\t' or \$'\\n' for actual whitespace]"
+              violations=$((violations + 1))
+            done <<< "$matches"
+          fi
+
+          # Associative arrays (bash 4.0+)
+          assoc=$(grep -nE '^[[:space:]]*(declare|local|typeset)[[:space:]]+-A[[:space:]]' "$file" 2>/dev/null \
+            | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+          if [ -n "$assoc" ]; then
+            while IFS= read -r line; do
+              echo "FAIL $file:$line [associative array — bash 4.0+]"
+              violations=$((violations + 1))
+            done <<< "$assoc"
+          fi
+
+          # Namerefs (bash 4.3+)
+          nameref=$(grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' "$file" 2>/dev/null \
+            | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+          if [ -n "$nameref" ]; then
+            while IFS= read -r line; do
+              echo "FAIL $file:$line [nameref — bash 4.3+]"
+              violations=$((violations + 1))
+            done <<< "$nameref"
+          fi
+        done <<< "$LINT_SH_FILES"
+
+        echo ""
+        if [ "$violations" -gt 0 ]; then
+          echo "::error::Bash 3.2 compatibility: $violations violation(s) found"
+          echo "macOS ships bash 3.2 — these constructs will break on macOS."
+          echo "See .agents/reference/bash-compat.md for alternatives."
+          exit 1
+        fi
+        echo "All shell scripts pass Bash 3.2 compatibility check"
+
   framework-validation:
     name: Framework Validation
     runs-on: ubuntu-latest

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -435,16 +435,16 @@ _install_pulse_systemd() {
 	_configured_headless_models=$(_resolve_headless_models_override)
 	_configured_pulse_model=$(_resolve_pulse_model_override)
 	if [[ -n "$_configured_headless_models" ]]; then
-		_env_lines+="Environment=AIDEVOPS_HEADLESS_MODELS=${_configured_headless_models}\n"
+		_env_lines+="Environment=AIDEVOPS_HEADLESS_MODELS=${_configured_headless_models}"$'\n'
 	fi
 	if [[ -n "$_configured_pulse_model" ]]; then
-		_env_lines+="Environment=PULSE_MODEL=${_configured_pulse_model}\n"
+		_env_lines+="Environment=PULSE_MODEL=${_configured_pulse_model}"$'\n'
 	fi
 	if [[ -n "${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}" ]]; then
-		_env_lines+="Environment=AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST}\n"
+		_env_lines+="Environment=AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST}"$'\n'
 	fi
-	_env_lines+="Environment=PULSE_DIR=${HOME}/.aidevops/.agent-workspace\n"
-	_env_lines+="Environment=HOME=${HOME}\n"
+	_env_lines+="Environment=PULSE_DIR=${HOME}/.aidevops/.agent-workspace"$'\n'
+	_env_lines+="Environment=HOME=${HOME}"$'\n'
 
 	# Write the service unit
 	printf '%s' "[Unit]


### PR DESCRIPTION
## Summary

- Add standalone `bash32-compat` CI job to `code-quality.yml` that blocks PRs introducing bash 4+ constructs (`"\n"`/`"\t"` in double-quoted strings, associative arrays, namerefs)
- Fix 5 instances of `_env_lines+="...\n"` in `setup-modules/schedulers.sh` — literal `\n` instead of actual newlines, producing malformed systemd unit files on Linux

## Context

PR #15430 shipped a recurring production bug (literal `\n` in double-quoted strings) because the `check_bash32_compat()` function exists in `linters-local.sh` but was never called from any CI workflow. This PR closes the gap.

Closes #17371

## Changes

| File | Change |
|------|--------|
| `.github/workflows/code-quality.yml` | New `bash32-compat` job: scans all tracked `.sh` files for `"\n"`/`"\t"` in assignments, associative arrays, and namerefs |
| `setup-modules/schedulers.sh` | Fix 5 `_env_lines+="...\n"` → `_env_lines+="..."$'\n'` |

## Design Decisions

- **Standalone job** (not embedded in Framework Validation): independent pass/fail, cleaner CI signal
- **Uses `lint_shell_files` / `LINT_SH_FILES`** (git ls-files based): consistent with other CI jobs, covers `setup-modules/` since those files are tracked
- **Grep patterns extracted from `_scan_bash32_file()`**: same detection logic as the local linter, with the three most impactful checks (escape quoting, associative arrays, namerefs)
- **Self-skip for `linters-local.sh`**: its grep patterns contain the forbidden strings as search targets, not as bash code

## Runtime Testing

| Risk | Level | Verification |
|------|-------|-------------|
| CI workflow change | Medium | YAML validated (python3 yaml.safe_load), follows existing job patterns |
| Shell string fix | Low | ShellCheck clean, grep confirms no remaining violations |

`self-assessed` — CI job will be verified by the PR's own check run.

---
[aidevops.sh](https://aidevops.sh) v3.6.83 plugin for Claude Code with claude-opus-4-6 spent 5m and 7,653 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented Bash 3.2 compatibility validation in the continuous integration pipeline to automatically scan and detect version incompatibilities across shell scripts
  * Enhanced shell script environment variable handling with improved formatting for better cross-platform compatibility and deployment stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->