### PR TITLE
GH#17369: fix Linux pulse — systemd env lines, model fallback, scheduler detection

### DIFF
--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -151,14 +151,22 @@ get_pulse_repo_count() {
 
 #######################################
 # Get OS-appropriate scheduler name
-# Returns: "launchd" on macOS, "cron" on Linux
+# Returns: "launchd" on macOS, "systemd" or "cron" on Linux
 #######################################
 get_scheduler_name() {
 	local os_type
 	os_type=$(uname -s)
 	case "$os_type" in
 	Darwin) echo "launchd" ;;
-	*) echo "cron" ;;
+	*)
+		# Detect systemd user services (GH#17369)
+		if command -v systemctl >/dev/null 2>&1 &&
+			systemctl --user status >/dev/null 2>&1; then
+			echo "systemd"
+		else
+			echo "cron"
+		fi
+		;;
 	esac
 	return 0
 }
@@ -184,7 +192,12 @@ is_scheduler_installed() {
 		return 1
 		;;
 	*)
-		# Check for cron entry
+		# Check for systemd user timer first (GH#17369)
+		if command -v systemctl >/dev/null 2>&1 &&
+			systemctl --user is-enabled aidevops-supervisor-pulse.timer >/dev/null 2>&1; then
+			return 0
+		fi
+		# Fall back to cron entry check
 		if crontab -l 2>/dev/null | grep -qF "aidevops-supervisor-pulse"; then
 			return 0
 		fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6107,23 +6107,19 @@ dispatch_with_dedup() {
 		fi
 	fi
 
-	if [[ -z "$selected_model" ]]; then
-		echo "[dispatch_with_dedup] No models configured — skipping dispatch for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
-		gh issue edit "$issue_number" --repo "$repo_slug" \
-			--remove-assignee "$self_login" --remove-label "status:queued" 2>/dev/null || true
-		# GH#16978 Bug C: clean up claim comment on this early-return path
-		_cleanup_claim_comment
-		return 1
-	fi
-
-	# Launch worker with the pre-validated model
+	# Launch worker — headless-runtime-helper.sh handles model fallback
+	# when no model is specified (uses DEFAULT_HEADLESS_MODELS internally).
+	# Do NOT early-return on empty selected_model; the helper's
+	# get_configured_models() has the authoritative fallback chain (GH#17369).
 	local -a worker_cmd=("$HEADLESS_RUNTIME_HELPER" run
 		--role worker
 		--session-key "$session_key"
 		--dir "$repo_path"
 		--title "$dispatch_title"
-		--prompt "$prompt"
-		--model "$selected_model")
+		--prompt "$prompt")
+	if [[ -n "$selected_model" ]]; then
+		worker_cmd+=(--model "$selected_model")
+	fi
 	"${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 &
 	local worker_pid="$!"
 	sleep 2

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -435,16 +435,16 @@ _install_pulse_systemd() {
 	_configured_headless_models=$(_resolve_headless_models_override)
 	_configured_pulse_model=$(_resolve_pulse_model_override)
 	if [[ -n "$_configured_headless_models" ]]; then
-		_env_lines+="Environment=AIDEVOPS_HEADLESS_MODELS=${_configured_headless_models}\n"
+		_env_lines+="Environment=AIDEVOPS_HEADLESS_MODELS=${_configured_headless_models}"$'\n'
 	fi
 	if [[ -n "$_configured_pulse_model" ]]; then
-		_env_lines+="Environment=PULSE_MODEL=${_configured_pulse_model}\n"
+		_env_lines+="Environment=PULSE_MODEL=${_configured_pulse_model}"$'\n'
 	fi
 	if [[ -n "${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}" ]]; then
-		_env_lines+="Environment=AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST}\n"
+		_env_lines+="Environment=AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST}"$'\n'
 	fi
-	_env_lines+="Environment=PULSE_DIR=${HOME}/.aidevops/.agent-workspace\n"
-	_env_lines+="Environment=HOME=${HOME}\n"
+	_env_lines+="Environment=PULSE_DIR=${HOME}/.aidevops/.agent-workspace"$'\n'
+	_env_lines+="Environment=HOME=${HOME}"$'\n'
 
 	# Write the service unit
 	printf '%s' "[Unit]


### PR DESCRIPTION
## Summary

Fixes three bugs preventing the pulse from working on Linux systems with systemd.

- **Bug 1**: Replace literal `"\n"` with `$'\n'` (ANSI-C quoting) in systemd service `Environment=` lines so each directive gets its own line instead of collapsing into one malformed line
- **Bug 2**: Remove early-return in `dispatch_with_dedup()` when no model is configured — `headless-runtime-helper.sh` already has the authoritative fallback chain (`DEFAULT_HEADLESS_MODELS`)
- **Bug 3**: Add systemd user timer detection to `is_scheduler_installed()` and `get_scheduler_name()` so `aidevops pulse status` correctly reports the scheduler on Linux

Closes #17369

## Files Changed

| File | Change |
|------|--------|
| `setup-modules/schedulers.sh` | `"\n"` → `$'\n'` in `_env_lines+=` statements |
| `.agents/scripts/pulse-wrapper.sh` | Remove model pre-check early-return, conditionally pass `--model` |
| `.agents/scripts/pulse-session-helper.sh` | Add `systemctl --user` checks to `get_scheduler_name()` and `is_scheduler_installed()` |

## Runtime Testing

| Risk | Assessment |
|------|------------|
| Level | **Low** — agent prompt/config, no runtime-critical paths |
| Method | `self-assessed` — changes are to shell logic in scheduler setup and dispatch; no dev environment available for Linux systemd testing |
| Verification | ShellCheck clean on `schedulers.sh` and `pulse-session-helper.sh`; `pulse-wrapper.sh` OOMs ShellCheck at 9.8k lines (pre-existing) |

## Key Decisions

1. **Bug 2 — Option B chosen**: Removed the pre-check block entirely rather than duplicating the fallback default. `headless-runtime-helper.sh:get_configured_models()` (line 310-326) is the single source of truth for model fallback.
2. **Bug 3 — Reused existing pattern**: The systemd detection mirrors `_systemd_user_available()` from `schedulers.sh:415-419` rather than sourcing it, since `pulse-session-helper.sh` is independently executable.


---
[aidevops.sh](https://aidevops.sh) v3.6.83 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6 spent 8m and 11,062 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added systemd user timer support for scheduler management on non-macOS platforms, with automatic fallback to cron-based scheduling.

* **Bug Fixes**
  * Fixed environment variable formatting in scheduler initialization.
  * Improved model selection fallback behavior during worker process dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->