### PR TITLE
GH#17370: wire haiku fallback-chain to resolver and add openrouter provider

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -4,7 +4,7 @@
 
   "tiers": {
     "local":  { "models": ["local/llama.cpp"], "fallback": "haiku", "cost": 0 },
-    "haiku":  { "models": ["anthropic/claude-haiku-4-5", "google/gemini-2.5-flash-preview-05-20", "openrouter/anthropic/claude-haiku-4-5"] },
+    "haiku":  { "models": ["anthropic/claude-haiku-4-5-20251001", "google/gemini-2.5-flash-preview-05-20", "openrouter/anthropic/claude-haiku-4-5"] },
     "flash":  { "models": ["anthropic/claude-haiku-4-5"] },
     "sonnet": { "models": ["anthropic/claude-sonnet-4-6"] },
     "pro":    { "models": ["anthropic/claude-sonnet-4-6"] },
@@ -43,6 +43,13 @@
       "probe_path": "/v1/models",
       "probe_timeout_seconds": 10,
       "_comment": "API key OR OpenCode OAuth subscription (includes Codex). Auth checked via OPENAI_API_KEY env var or opencode auth.json."
+    },
+    "openrouter": {
+      "endpoint": "https://openrouter.ai/api/v1/chat/completions",
+      "key_env": "OPENROUTER_API_KEY",
+      "probe_path": "/api/v1/models",
+      "probe_timeout_seconds": 10,
+      "_comment": "OpenRouter aggregator — routes to multiple providers. Use openrouter/provider/model-id format."
     },
     "ollama": {
       "endpoint": "http://localhost:11434/v1/chat/completions",

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -90,6 +90,7 @@ is_model_available() {
 	anthropic) key_var="ANTHROPIC_API_KEY" ;;
 	openai) key_var="OPENAI_API_KEY" ;;
 	google) key_var="GOOGLE_API_KEY" ;;
+	openrouter) key_var="OPENROUTER_API_KEY" ;;
 	*) key_var="" ;;
 	esac
 


### PR DESCRIPTION
## Summary

- Fixes the haiku fallback-chain added in PR #17366 not being exercised by the resolver
- Updates `model-routing-table.json` haiku tier to use versioned model ID `anthropic/claude-haiku-4-5-20251001` (matching `models-haiku.md` fallback-chain)
- Adds `openrouter` provider entry to the `providers` section of `model-routing-table.json` with `OPENROUTER_API_KEY`
- Adds `openrouter` case to the lightweight provider check in `fallback-chain-helper.sh` so `openrouter/anthropic/claude-haiku-4-5` is recognized and not skipped

## What

Two files changed to wire the haiku fallback-chain to the actual resolver path:

1. `.agents/configs/model-routing-table.json` — haiku tier model ID corrected to versioned form; `openrouter` provider added to providers section
2. `.agents/scripts/fallback-chain-helper.sh` — `openrouter` case added to lightweight provider key check

## Issue

Closes #17370

## Files Changed

- `.agents/configs/model-routing-table.json` (+8 lines, -1 line)
- `.agents/scripts/fallback-chain-helper.sh` (+1 line)

## Testing

**Risk level:** Low — config and lightweight availability check only; no runtime logic changed.

**Self-assessed:**
- JSON validated: `jq . model-routing-table.json` exits 0
- ShellCheck at warning severity: 0 violations (SC1091 info-level pre-existing, not introduced)
- Resolver logic unchanged — only the model list and provider key mapping extended

## Runtime Testing

`self-assessed` — docs/config/availability-check change only; no payment, auth, state machine, or API endpoint logic touched.

---
<!-- MERGE_SUMMARY -->
**What:** Wire haiku fallback-chain to resolver; add openrouter provider support
**Issue:** #17370 (quality-debt from PR #17366 review)
**Files:** 2 files, 9 insertions, 1 deletion
**Testing:** JSON valid, shellcheck clean (warning level), self-assessed low risk
**Key decisions:** Used versioned model ID `anthropic/claude-haiku-4-5-20251001` to match `models-haiku.md`; added full `openrouter` provider entry to routing table for consistency with other providers

---
[aidevops.sh](https://aidevops.sh) v3.6.84 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6