### PR TITLE
GH#17379: fix AGENTS_DIR unbound variable crash in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -919,8 +919,8 @@ _setup_post_setup_steps() {
 	print_success "Setup complete!"
 
 	# Cache client request format constants if CLI is installed (~50ms)
-	if command -v claude &>/dev/null && [[ -x "${AGENTS_DIR}/scripts/cch-extract.sh" ]]; then
-		"${AGENTS_DIR}/scripts/cch-extract.sh" --cache >/dev/null 2>&1 || true
+	if command -v claude &>/dev/null && [[ -x "${INSTALL_DIR}/.agents/scripts/cch-extract.sh" ]]; then
+		"${INSTALL_DIR}/.agents/scripts/cch-extract.sh" --cache >/dev/null 2>&1 || true
 	else
 		echo ""
 		echo -e "${YELLOW}[TIP]${NC} Install Claude CLI for automatic request format alignment:"


### PR DESCRIPTION
## Summary

- Replaces undefined `AGENTS_DIR` with `${INSTALL_DIR}/.agents` on lines 922-923 of `setup.sh`
- `AGENTS_DIR` was never defined in `setup.sh`, causing an unbound variable crash under `set -u` that prevented `setup_supervisor_pulse` and all subsequent post-setup steps from executing
- This blocked GH#17369 fixes (corrected systemd `Environment=` quoting) from being deployed — the fixed `_install_pulse_systemd()` was never reached

## Changes

Two-line variable name fix in `_setup_post_setup_steps()`:
- `${AGENTS_DIR}/scripts/cch-extract.sh` → `${INSTALL_DIR}/.agents/scripts/cch-extract.sh` (lines 922-923)

## Verification

- ShellCheck: zero violations
- No remaining `AGENTS_DIR` references in `setup.sh`
- `INSTALL_DIR` is defined at line 58 and used consistently throughout the file

Closes #17379

---
[aidevops.sh](https://aidevops.sh) v3.6.87 plugin for [OpenCode](https://opencode.ai) v1.3.14 with claude-opus-4-6 spent 2m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration path references in the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->