### PR TITLE
GH#17381: fix: regenerate existing scheduler in non-interactive mode

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -164,7 +164,7 @@ setup_supervisor_pulse() {
 	_pulse_lower=$(echo "$_pulse_user_config" | tr '[:upper:]' '[:lower:]')
 
 	# Detect if pulse is already installed (for upgrade messaging)
-	# Uses shared helper to check both launchd and cron consistently
+	# Uses shared helper to check launchd, cron, and systemd (GH#17381)
 	local _pulse_installed=false
 	if _scheduler_detect_installed \
 		"Supervisor pulse" \
@@ -173,7 +173,8 @@ setup_supervisor_pulse() {
 		"pulse-wrapper" \
 		"" \
 		"" \
-		""; then
+		"" \
+		"aidevops-supervisor-pulse"; then
 		_pulse_installed=true
 	fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -235,8 +235,11 @@ _launchd_install_if_changed() {
 	return 0
 }
 
-# Detect whether a scheduler is already installed via launchd or cron.
+# Detect whether a scheduler is already installed via launchd, cron, or systemd.
 # Optionally migrates legacy launchd labels / cron entries to launchd on macOS.
+# Args: $1=scheduler_name, $2=launchd_label, $3=legacy_launchd_label,
+#       $4=cron_marker, $5=migrate_script, $6=migrate_arg, $7=migrate_hint
+#       $8=systemd_unit (optional — base name without .timer suffix, e.g. "aidevops-supervisor-pulse")
 _scheduler_detect_installed() {
 	local scheduler_name="$1"
 	local launchd_label="$2"
@@ -245,6 +248,7 @@ _scheduler_detect_installed() {
 	local migrate_script="$5"
 	local migrate_arg="$6"
 	local migrate_hint="$7"
+	local systemd_unit="${8:-}"
 	local installed=false
 
 	if _launchd_has_agent "$launchd_label"; then
@@ -266,6 +270,10 @@ _scheduler_detect_installed() {
 				print_warning "$scheduler_name cron->launchd migration failed. Run: $migrate_hint"
 			fi
 		fi
+		installed=true
+	elif [[ -n "$systemd_unit" ]] && command -v systemctl >/dev/null 2>&1 &&
+		systemctl --user is-enabled "${systemd_unit}.timer" >/dev/null 2>&1; then
+		# Systemd user timer detected (GH#17381 — Linux systemd path was missing)
 		installed=true
 	fi
 
@@ -930,7 +938,24 @@ _setup_post_setup_steps() {
 	# Non-interactive mode: deploy + migrations only — skip schedulers,
 	# services, and optional post-setup work (CI/agent shells don't need them).
 	# Tabby profile sync runs in both modes (has its own non-interactive path).
+	#
+	# Exception (GH#17381): if a scheduler is already installed (user previously
+	# consented), regenerate it so fixes to service files reach existing installs.
+	# This preserves the consent model — no new scheduler is installed without
+	# interactive consent; only already-consented schedulers are regenerated.
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
+		local _pulse_label="com.aidevops.aidevops-supervisor-pulse"
+		if _scheduler_detect_installed \
+			"Supervisor pulse" \
+			"$_pulse_label" \
+			"" \
+			"pulse-wrapper" \
+			"" \
+			"" \
+			"" \
+			"aidevops-supervisor-pulse"; then
+			setup_supervisor_pulse "$os"
+		fi
 		setup_tabby
 		return 0
 	fi


### PR DESCRIPTION
## Summary

`aidevops update` runs `setup.sh --non-interactive`, which returned before `setup_supervisor_pulse`, leaving broken systemd service files unreachable by the GH#17369 fix (PR #17374). Users who installed before the fix and ran `aidevops update` got new scripts but the old broken service file persisted indefinitely.

## Changes

### `setup.sh` — `_scheduler_detect_installed`
Added optional `$8=systemd_unit` parameter. When provided, checks `systemctl --user is-enabled "${systemd_unit}.timer"` after the launchd and cron checks. Previously this function only detected launchd and cron schedulers, missing Linux/systemd installs entirely.

### `setup-modules/schedulers.sh` — `setup_supervisor_pulse`
Updated the `_scheduler_detect_installed` call to pass `"aidevops-supervisor-pulse"` as the new `systemd_unit` argument, so Linux systemd timer detection works correctly.

### `setup.sh` — `_setup_post_setup_steps` non-interactive block
Before `setup_tabby` and `return 0`, added a conditional check: if a scheduler is already installed (any backend — launchd, cron, or systemd), call `setup_supervisor_pulse "$os"` to regenerate it. This is the core fix.

**Consent model preserved:** No new scheduler is installed without interactive consent. Only already-consented schedulers (where the timer/cron/plist already exists) are regenerated.

## Acceptance Criteria

- [x] `aidevops update` regenerates the systemd service file when a scheduler is already installed
- [x] `aidevops update` does NOT install a new scheduler if one was never installed (consent model preserved — `_scheduler_detect_installed` returns false when no timer exists)
- [x] After `aidevops update`, `cat -A` of the service file shows properly separated `Environment=` directives (regenerated by `_install_pulse_systemd` which uses ANSI-C quoting from PR #17374)

## Runtime Testing

**Risk level:** Low — installer/scheduler setup code, no runtime services affected. Changes are conditional on existing scheduler detection; no-op on systems without a pulse timer installed.

**Self-assessed:** ShellCheck passes with zero violations on both modified files. Logic verified by code review: the `_scheduler_detect_installed` function returns 1 (false) when no timer exists, so the `setup_supervisor_pulse` call is skipped on fresh installs.

## Files Changed

- `setup.sh` (+26/-1): `_scheduler_detect_installed` systemd detection, non-interactive regeneration block
- `setup-modules/schedulers.sh` (+3/-2): pass systemd_unit arg to `_scheduler_detect_installed`

Closes #17381

---
[aidevops.sh](https://aidevops.sh) v3.6.88 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of existing scheduler installations to support launchd, cron, and systemd environments, ensuring correct installation status tracking and upgrade messaging.

* **Chores**
  * Enhanced non-interactive setup flow to properly regenerate existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->