### PR TITLE
GH#17378: auto-escalate issue model tier after repeated worker failures

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -202,10 +202,11 @@ GH_FAILURE_MAX_RUN_LOGS="${GH_FAILURE_MAX_RUN_LOGS:-6}"                         
 FOSS_SCAN_TIMEOUT="${FOSS_SCAN_TIMEOUT:-30}"                                                               # Timeout for FOSS contribution scan prefetch (t1702)
 FOSS_MAX_DISPATCH_PER_CYCLE="${FOSS_MAX_DISPATCH_PER_CYCLE:-2}"                                            # Max FOSS contribution workers per pulse cycle (t1702)
 
-# Per-issue fast-fail counter (t1888)
-# Tracks consecutive launch deaths per issue. After FAST_FAIL_SKIP_THRESHOLD
-# consecutive failures the issue is skipped for FAST_FAIL_EXPIRY_SECS seconds.
-# Only affects deterministic dispatch — LLM pulse is unaffected.
+# Per-issue fast-fail counter (t1888, GH#2076)
+# Tracks consecutive worker failures (launch AND execution) per issue.
+# After FAST_FAIL_SKIP_THRESHOLD consecutive failures the issue is skipped
+# for FAST_FAIL_EXPIRY_SECS seconds. At ESCALATION_FAILURE_THRESHOLD (default 2)
+# the issue is auto-escalated to tier:thinking (opus) for the next dispatch.
 FAST_FAIL_SKIP_THRESHOLD="${FAST_FAIL_SKIP_THRESHOLD:-3}" # Skip after N consecutive failures
 FAST_FAIL_EXPIRY_SECS="${FAST_FAIL_EXPIRY_SECS:-14400}"   # 4h expiry on skip state
 
@@ -7050,9 +7051,10 @@ recover_failed_launch_state() {
 #######################################
 # Per-issue fast-fail counter (t1888)
 #
-# Tracks consecutive launch deaths per issue. After FAST_FAIL_SKIP_THRESHOLD
-# consecutive failures the issue is skipped by the deterministic fill floor
-# for FAST_FAIL_EXPIRY_SECS seconds. The LLM pulse is unaffected.
+# Tracks consecutive worker failures (launch AND execution) per issue.
+# After FAST_FAIL_SKIP_THRESHOLD consecutive failures the issue is skipped
+# for FAST_FAIL_EXPIRY_SECS seconds. At ESCALATION_FAILURE_THRESHOLD (default 2)
+# failures, the issue is auto-escalated to tier:thinking (opus). (GH#2076)
 #
 # State file: FAST_FAIL_STATE_FILE (JSON, < 1KB per entry)
 # Format: { "slug/number": { "count": N, "ts": epoch, "reason": "..." } }
@@ -7154,11 +7156,21 @@ fast_fail_record() {
 
 	_ff_save "$updated_state"
 	echo "[pulse-wrapper] fast_fail_record: #${issue_number} (${repo_slug}) count=${new_count} reason=${reason}" >>"$LOGFILE"
+
+	# Trigger tier escalation when failure count reaches threshold (GH#2076)
+	escalate_issue_tier "$issue_number" "$repo_slug" "$new_count" "$reason" || true
+
 	return 0
 }
 
 #######################################
-# Reset the fast-fail counter for an issue (on successful launch).
+# Reset the fast-fail counter for an issue.
+#
+# Called when an issue is confirmed resolved (PR merged, issue closed) —
+# NOT on launch success. Previously this was called on launch, which
+# defeated the counter entirely since every launch reset it before the
+# worker could fail. (GH#2076, GH#17378)
+#
 # Arguments: $1 issue_number, $2 repo_slug
 #######################################
 fast_fail_reset() {
@@ -7181,7 +7193,7 @@ fast_fail_reset() {
 
 	updated_state=$(printf '%s' "$state" | jq --arg k "$key" 'del(.[$k])' 2>/dev/null) || return 0
 	_ff_save "$updated_state"
-	echo "[pulse-wrapper] fast_fail_reset: #${issue_number} (${repo_slug}) counter cleared on successful launch" >>"$LOGFILE"
+	echo "[pulse-wrapper] fast_fail_reset: #${issue_number} (${repo_slug}) counter cleared" >>"$LOGFILE"
 	return 0
 }
 
@@ -7291,8 +7303,12 @@ check_worker_launch() {
 					return 1
 				fi
 			done
-			# Successful launch — reset fast-fail counter (t1888)
-			fast_fail_reset "$issue_number" "$repo_slug" || true
+			# Launch confirmed — do NOT reset fast-fail counter here.
+			# A successful launch does not mean successful completion.
+			# The counter is reset only when the issue is closed or a PR
+			# is confirmed. Resetting on launch defeated the counter
+			# entirely — workers that launched but died during execution
+			# were invisible. (GH#2076, GH#17378)
 			return 0
 		fi
 		sleep "$poll_seconds"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -7094,6 +7094,33 @@ _ff_load() {
 }
 
 #######################################
+# Acquire an exclusive lock for fast-fail state read-modify-write.
+# Uses mkdir atomicity (same pattern as circuit-breaker-helper.sh).
+# Both pulse-wrapper.sh and worker-watchdog.sh write to the same
+# state file — this prevents lost increments from concurrent updates.
+# (GH#2076, CodeRabbit review)
+#
+# Arguments: command and arguments to run under lock
+# Returns: exit code of the wrapped command
+#######################################
+_ff_with_lock() {
+	local lock_dir="${FAST_FAIL_STATE_FILE}.lockdir"
+	local retries=0
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		retries=$((retries + 1))
+		if [[ "$retries" -ge 50 ]]; then
+			echo "[pulse-wrapper] _ff_with_lock: lock acquisition timed out" >>"$LOGFILE"
+			return 1
+		fi
+		sleep 0.1
+	done
+	local rc=0
+	"$@" || rc=$?
+	rmdir "$lock_dir" 2>/dev/null || true
+	return "$rc"
+}
+
+#######################################
 # Write updated state atomically (tmp + mv).
 # Arguments: $1 JSON string
 #######################################
@@ -7118,9 +7145,16 @@ _ff_save() {
 
 #######################################
 # Increment the fast-fail counter for an issue.
+# Acquires a file lock to prevent lost updates from concurrent
+# pulse-wrapper and worker-watchdog writes. (GH#2076)
 # Arguments: $1 issue_number, $2 repo_slug, $3 reason
 #######################################
 fast_fail_record() {
+	_ff_with_lock _fast_fail_record_locked "$@" || return 0
+	return 0
+}
+
+_fast_fail_record_locked() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local reason="${3:-launch_failure}"
@@ -7174,6 +7208,11 @@ fast_fail_record() {
 # Arguments: $1 issue_number, $2 repo_slug
 #######################################
 fast_fail_reset() {
+	_ff_with_lock _fast_fail_reset_locked "$@" || return 0
+	return 0
+}
+
+_fast_fail_reset_locked() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
@@ -7726,6 +7765,8 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). No worker summary was av
 				gh issue comment "$linked_issue" --repo "$repo_slug" \
 					--body "$closing_comment" 2>/dev/null || true
 				gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null || true
+				# Reset fast-fail counter now that the issue is resolved (GH#2076)
+				fast_fail_reset "$linked_issue" "$repo_slug" || true
 			fi
 		else
 			failed=$((failed + 1))

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -900,6 +900,84 @@ list_active_worker_processes() {
 }
 
 #######################################
+# Escalate issue model tier after repeated worker failures.
+#
+# After ESCALATION_FAILURE_THRESHOLD (default 2) failures at the current
+# tier, adds tier:thinking label to route the next dispatch to opus.
+# If already at tier:thinking, no further escalation — the issue stays
+# for the fast-fail skip/needs-human path.
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug (owner/repo)
+#   $3 - failure count (current fast-fail count AFTER increment)
+#   $4 - kill/failure reason (for the comment)
+# Returns: 0 always (best-effort, never fatal)
+#######################################
+ESCALATION_FAILURE_THRESHOLD="${ESCALATION_FAILURE_THRESHOLD:-2}"
+
+escalate_issue_tier() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local failure_count="$3"
+	local reason="${4:-repeated_failure}"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
+	[[ -n "$repo_slug" ]] || return 0
+
+	# Validate threshold
+	local threshold="$ESCALATION_FAILURE_THRESHOLD"
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=2
+	[[ "$threshold" -ge 1 ]] || threshold=2
+
+	# Only escalate at the threshold boundary (not on every subsequent failure)
+	if [[ "$failure_count" -ne "$threshold" ]]; then
+		return 0
+	fi
+
+	# Check current labels — skip if already at tier:thinking
+	local current_labels
+	current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || current_labels=""
+
+	case ",$current_labels," in
+	*,tier:thinking,*)
+		# Already at highest auto-escalation tier
+		return 0
+		;;
+	esac
+
+	# Add tier:thinking label (creates label if needed)
+	gh label create "tier:thinking" \
+		--repo "$repo_slug" \
+		--description "Route to opus-tier model for dispatch" \
+		--color "7057FF" \
+		--force 2>/dev/null || true
+
+	gh issue edit "$issue_number" --repo "$repo_slug" \
+		--add-label "tier:thinking" \
+		--remove-label "tier:simple" 2>/dev/null || {
+		return 0
+	}
+
+	# Post escalation comment
+	local comment_body="## Model Tier Escalation
+
+**Trigger:** ${failure_count} consecutive worker failures (threshold: ${threshold})
+**Action:** Added \`tier:thinking\` label — next dispatch will use opus-tier model.
+**Reason:** ${reason}
+
+Previous attempts at the default model tier failed to produce a PR. Escalating to a more capable model.
+
+_Automated by \`escalate_issue_tier()\` in worker-lifecycle-common.sh_"
+
+	gh issue comment "$issue_number" --repo "$repo_slug" \
+		--body "$comment_body" 2>/dev/null || true
+
+	return 0
+}
+
+#######################################
 # Count active worker processes
 # Returns: count via stdout
 #######################################

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -925,6 +925,9 @@ escalate_issue_tier() {
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
 
+	# Validate failure_count is numeric (CodeRabbit review)
+	[[ "$failure_count" =~ ^[0-9]+$ ]] || return 0
+
 	# Validate threshold
 	local threshold="$ESCALATION_FAILURE_THRESHOLD"
 	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=2
@@ -960,12 +963,14 @@ escalate_issue_tier() {
 		return 0
 	}
 
-	# Post escalation comment
+	# Post escalation comment (sanitize reason to prevent markdown injection)
+	local safe_reason
+	safe_reason=$(_sanitize_markdown "$reason")
 	local comment_body="## Model Tier Escalation
 
 **Trigger:** ${failure_count} consecutive worker failures (threshold: ${threshold})
 **Action:** Added \`tier:thinking\` label — next dispatch will use opus-tier model.
-**Reason:** ${reason}
+**Reason:** ${safe_reason}
 
 Previous attempts at the default model tier failed to produce a PR. Escalating to a more capable model.
 

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -963,6 +963,89 @@ post_kill_github_update() {
 		"$duration" "$evidence_summary" \
 		"$destination_status" "$destination_text"
 
+	# Record failure in the fast-fail counter and escalate tier if threshold reached.
+	# The fast-fail state file is shared with pulse-wrapper.sh — both use the same
+	# JSON file so pulse can skip issues that the watchdog has flagged. (GH#2076)
+	_watchdog_record_failure_and_escalate "$issue_number" "$repo_slug" "$reason" || true
+
+	return 0
+}
+
+#######################################
+# Record a watchdog kill in the shared fast-fail counter and trigger
+# tier escalation when threshold is reached.
+#
+# Uses the same state file as pulse-wrapper.sh's fast_fail_record() so
+# both systems share a single failure count per issue. This closes the
+# gap where workers launched successfully (resetting the pulse's counter)
+# but died during execution without producing a PR. (GH#2076, GH#17378)
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug
+#   $3 - kill reason
+#######################################
+_watchdog_record_failure_and_escalate() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local reason="$3"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
+	[[ -n "$repo_slug" ]] || return 0
+
+	local state_file="${HOME}/.aidevops/.agent-workspace/supervisor/fast-fail-counter.json"
+	local state_dir
+	state_dir=$(dirname "$state_file")
+	mkdir -p "$state_dir" 2>/dev/null || true
+
+	local key now state existing_ts existing_count new_count
+	key="${repo_slug}/${issue_number}"
+	now=$(date +%s)
+
+	# Load state (same format as pulse-wrapper.sh)
+	if [[ -f "$state_file" ]]; then
+		state=$(cat "$state_file" 2>/dev/null) || state="{}"
+		printf '%s' "$state" | jq empty 2>/dev/null || state="{}"
+	else
+		state="{}"
+	fi
+
+	# Read current count, reset if expired (4h default, matches pulse FAST_FAIL_EXPIRY_SECS)
+	local expiry_secs="${FAST_FAIL_EXPIRY_SECS:-14400}"
+	existing_ts=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].ts // 0' 2>/dev/null) || existing_ts=0
+	existing_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].count // 0' 2>/dev/null) || existing_count=0
+	[[ "$existing_ts" =~ ^[0-9]+$ ]] || existing_ts=0
+	[[ "$existing_count" =~ ^[0-9]+$ ]] || existing_count=0
+
+	local age=$((now - existing_ts))
+	if [[ "$age" -ge "$expiry_secs" ]]; then
+		existing_count=0
+	fi
+
+	new_count=$((existing_count + 1))
+
+	# Write updated state atomically
+	local updated_state
+	updated_state=$(printf '%s' "$state" | jq \
+		--arg k "$key" \
+		--argjson count "$new_count" \
+		--argjson ts "$now" \
+		--arg reason "$reason" \
+		'.[$k] = {"count": $count, "ts": $ts, "reason": $reason}' 2>/dev/null) || return 0
+
+	local tmp_file
+	tmp_file=$(mktemp "${state_dir}/.fast-fail-counter.XXXXXX" 2>/dev/null) || return 0
+	if printf '%s\n' "$updated_state" >"$tmp_file"; then
+		mv "$tmp_file" "$state_file" || rm -f "$tmp_file"
+	else
+		rm -f "$tmp_file"
+	fi
+
+	log_msg "Fast-fail recorded: #${issue_number} (${repo_slug}) count=${new_count} reason=${reason}"
+
+	# Trigger tier escalation (from worker-lifecycle-common.sh)
+	escalate_issue_tier "$issue_number" "$repo_slug" "$new_count" "$reason"
+
 	return 0
 }
 

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -998,6 +998,18 @@ _watchdog_record_failure_and_escalate() {
 	state_dir=$(dirname "$state_file")
 	mkdir -p "$state_dir" 2>/dev/null || true
 
+	# Acquire lock (shared with pulse-wrapper.sh's _ff_with_lock)
+	local lock_dir="${state_file}.lockdir"
+	local retries=0
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		retries=$((retries + 1))
+		if [[ "$retries" -ge 50 ]]; then
+			log_msg "Fast-fail lock timeout for #${issue_number} (${repo_slug})"
+			return 0
+		fi
+		sleep 0.1
+	done
+
 	local key now state existing_ts existing_count new_count
 	key="${repo_slug}/${issue_number}"
 	now=$(date +%s)
@@ -1031,15 +1043,24 @@ _watchdog_record_failure_and_escalate() {
 		--argjson count "$new_count" \
 		--argjson ts "$now" \
 		--arg reason "$reason" \
-		'.[$k] = {"count": $count, "ts": $ts, "reason": $reason}' 2>/dev/null) || return 0
+		'.[$k] = {"count": $count, "ts": $ts, "reason": $reason}' 2>/dev/null) || {
+		rmdir "$lock_dir" 2>/dev/null || true
+		return 0
+	}
 
 	local tmp_file
-	tmp_file=$(mktemp "${state_dir}/.fast-fail-counter.XXXXXX" 2>/dev/null) || return 0
+	tmp_file=$(mktemp "${state_dir}/.fast-fail-counter.XXXXXX" 2>/dev/null) || {
+		rmdir "$lock_dir" 2>/dev/null || true
+		return 0
+	}
 	if printf '%s\n' "$updated_state" >"$tmp_file"; then
 		mv "$tmp_file" "$state_file" || rm -f "$tmp_file"
 	else
 		rm -f "$tmp_file"
 	fi
+
+	# Release lock
+	rmdir "$lock_dir" 2>/dev/null || true
 
 	log_msg "Fast-fail recorded: #${issue_number} (${repo_slug}) count=${new_count} reason=${reason}"
 


### PR DESCRIPTION
## Summary

- **Root cause**: Workers that launched successfully but died during execution were invisible to the fast-fail counter — it reset on launch detection, not on outcome. This caused infinite dispatch loops (10+ attempts in ~1.5 hours) where sonnet-tier workers were re-dispatched every ~8 minutes without producing a PR.
- **Fix**: Add `escalate_issue_tier()` to worker-lifecycle-common.sh — after 2 consecutive failures, auto-adds `tier:thinking` label so the next dispatch routes to opus. Wire watchdog kills into the fast-fail counter. Stop resetting the counter on launch (only reset on confirmed resolution).
- **Immediate**: Applied `tier:thinking` to both currently-looping issues (#17378, <webapp>/<webapp>#2076).

## Changes

| File | Change |
|------|--------|
| `worker-lifecycle-common.sh` | New `escalate_issue_tier()` shared function |
| `worker-watchdog.sh` | New `_watchdog_record_failure_and_escalate()` — records kills in fast-fail counter |
| `pulse-wrapper.sh` | Call `escalate_issue_tier()` from `fast_fail_record()`; remove premature counter reset on launch success |

## How it works

1. Worker dispatched at default tier (sonnet) → launches successfully → fast-fail counter NOT reset
2. Worker dies (rate limit, context overflow, etc.) → watchdog kills → `_watchdog_record_failure_and_escalate()` increments fast-fail counter
3. Counter hits `ESCALATION_FAILURE_THRESHOLD` (default 2) → `escalate_issue_tier()` adds `tier:thinking` label + posts escalation comment
4. Next pulse dispatch reads `tier:thinking` via existing `resolve_dispatch_model_for_labels()` → routes to opus
5. If opus also fails → fast-fail skip threshold (default 3) blocks further dispatch for 4 hours

## Config

- `ESCALATION_FAILURE_THRESHOLD` (default 2) — failures before tier escalation
- `FAST_FAIL_SKIP_THRESHOLD` (default 3) — failures before skipping entirely
- `FAST_FAIL_EXPIRY_SECS` (default 14400) — 4h expiry on skip state

Closes #17378

---
[aidevops.sh](https://aidevops.sh) v3.6.88 plugin for [OpenCode](https://opencode.ai) v1.3.14 with claude-opus-4-6 spent 15m and 21,689 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issues with repeated failures are now automatically escalated to a higher investigation tier after reaching a configurable threshold.
  * Expanded failure tracking to cover the entire worker lifecycle, not just launch phase.

* **Bug Fixes**
  * Failure counters now persist until issues are resolved, improving reliability of failure tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->