### PR TITLE
GH#17384: call fast_fail_reset() in issue close paths

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3832,6 +3832,9 @@ close_issues_with_merged_prs() {
 					--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup helper)"}. Issue was open but dedup guard was blocking re-dispatch." \
 					>/dev/null 2>&1 || continue
 
+				# Reset fast-fail counter now that the issue is confirmed resolved (GH#17384)
+				fast_fail_reset "$issue_num" "$slug" || true
+
 				echo "[pulse-wrapper] Auto-closed #${issue_num} in ${slug} — merged PR evidence: ${dedup_output:-"found"}" >>"$LOGFILE"
 				total_closed=$((total_closed + 1))
 			fi
@@ -3914,6 +3917,10 @@ reconcile_stale_done_issues() {
 				gh issue close "$issue_num" --repo "$slug" \
 					--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup)"}." \
 					>/dev/null 2>&1 || continue
+
+				# Reset fast-fail counter now that the issue is confirmed resolved (GH#17384)
+				fast_fail_reset "$issue_num" "$slug" || true
+
 				echo "[pulse-wrapper] Reconcile done: closed #${issue_num} in ${slug} — merged PR: ${dedup_output:-"found"}" >>"$LOGFILE"
 				total_closed=$((total_closed + 1))
 			else


### PR DESCRIPTION
## Summary

- Addresses CodeRabbit review feedback from PR #17384 (merged): `fast_fail_reset()` was defined but only called in the deterministic merge path
- Adds `fast_fail_reset()` calls in `close_issues_with_merged_prs()` and `reconcile_stale_done_issues()` — the two other code paths where issues are confirmed resolved via merged PRs
- Without these calls, the fast-fail counter persists after issue resolution, potentially blocking future dispatch

## Changes

| File | Change |
|------|--------|
| `pulse-wrapper.sh:3835-3836` | Add `fast_fail_reset` after issue close in `close_issues_with_merged_prs()` |
| `pulse-wrapper.sh:3921-3922` | Add `fast_fail_reset` after issue close in `reconcile_stale_done_issues()` |

## Context

PR #17384 introduced the fast-fail counter and `fast_fail_reset()` function but only wired the reset into the deterministic merge path (line 7776). CodeRabbit flagged this as a critical issue — the function was defined but not called in all resolution paths. The other 3 fixes from the review (inter-process locking, markdown sanitization, numeric validation) were already applied in the merged PR.

Closes #17384

---
[aidevops.sh](https://aidevops.sh) v3.6.89 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-opus-4-6