### PR TITLE
GH#17388: fix aidevops init worktree lifecycle on protected branch

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -504,17 +504,26 @@ check_protected_branch() {
 	repo_name=$(basename "$project_root")
 	local suggested_branch="$branch_type/$branch_suffix"
 
-	echo ""
-	print_warning "On protected branch '$current_branch'"
-	echo ""
-	echo "Options:"
-	echo "  1. Create worktree: $suggested_branch (recommended)"
-	echo "  2. Continue on $current_branch (commits directly to main)"
-	echo "  3. Cancel"
-	echo ""
 	local choice
-	read -r -p "Choice [1]: " choice
-	choice="${choice:-1}"
+	# In non-interactive (non-TTY) contexts, auto-select option 1 (create worktree)
+	# without prompting. This prevents read from blocking or getting EOF in CI/AI
+	# assistant environments, which could cause silent script termination with set -e.
+	if [[ -t 0 ]]; then
+		echo ""
+		print_warning "On protected branch '$current_branch'"
+		echo ""
+		echo "Options:"
+		echo "  1. Create worktree: $suggested_branch (recommended)"
+		echo "  2. Continue on $current_branch (commits directly to main)"
+		echo "  3. Cancel"
+		echo ""
+		read -r -p "Choice [1]: " choice
+		choice="${choice:-1}"
+	else
+		# Non-interactive: auto-create worktree (safest default)
+		choice="1"
+		print_info "Non-interactive mode: auto-selecting worktree creation for '$suggested_branch'"
+	fi
 
 	case "$choice" in
 	1)
@@ -524,34 +533,33 @@ check_protected_branch() {
 
 		print_info "Creating worktree at $worktree_dir..."
 
+		local worktree_created=false
 		if [[ -f "$AGENTS_DIR/scripts/worktree-helper.sh" ]]; then
-			if bash "$AGENTS_DIR/scripts/worktree-helper.sh" add "$suggested_branch" 2>/dev/null; then
-				export WORKTREE_PATH="$worktree_dir"
-				echo ""
-				print_success "Worktree created!"
-				print_info "Switching to: $worktree_dir"
-				echo ""
-				# Change to worktree directory
-				cd "$worktree_dir" || return 1
-				return 0
+			if bash "$AGENTS_DIR/scripts/worktree-helper.sh" add "$suggested_branch"; then
+				worktree_created=true
 			else
-				print_error "Failed to create worktree"
+				print_error "Failed to create worktree via worktree-helper.sh"
 				return 1
 			fi
 		else
 			# Fallback without helper script
-			if git worktree add -b "$suggested_branch" "$worktree_dir" 2>/dev/null; then
-				export WORKTREE_PATH="$worktree_dir"
-				echo ""
-				print_success "Worktree created!"
-				print_info "Switching to: $worktree_dir"
-				echo ""
-				cd "$worktree_dir" || return 1
-				return 0
+			if git worktree add -b "$suggested_branch" "$worktree_dir"; then
+				worktree_created=true
 			else
 				print_error "Failed to create worktree"
 				return 1
 			fi
+		fi
+
+		if [[ "$worktree_created" == "true" ]]; then
+			export WORKTREE_PATH="$worktree_dir"
+			echo ""
+			print_success "Worktree created at: $worktree_dir"
+			print_info "Switching to: $worktree_dir"
+			echo ""
+			# Change to worktree directory for the remainder of this process
+			cd "$worktree_dir" || return 1
+			return 0
 		fi
 		;;
 	2)
@@ -2079,8 +2087,21 @@ GITATTRSEOF
 	[[ "$enable_security" == "true" ]] && features_list="${features_list}security,"
 	features_list="${features_list%,}" # Remove trailing comma
 
-	# Register repo in repos.json
-	register_repo "$project_root" "$aidevops_version" "$features_list"
+	# Register the *main* repo path (not the worktree path) in repos.json.
+	# When check_protected_branch creates a worktree and cd's into it,
+	# $project_root (resolved via git rev-parse --show-toplevel) points to the
+	# worktree directory. We must register the canonical main worktree path so
+	# that pulse and cleanup processes don't treat the worktree as a standalone repo.
+	local register_path="$project_root"
+	if [[ -n "${WORKTREE_PATH:-}" ]]; then
+		# We're inside a worktree — resolve the main worktree path from git metadata
+		local main_wt_path
+		main_wt_path=$(git -C "$project_root" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+		if [[ -n "$main_wt_path" ]] && [[ "$main_wt_path" != "$project_root" ]]; then
+			register_path="$main_wt_path"
+		fi
+	fi
+	register_repo "$register_path" "$aidevops_version" "$features_list"
 
 	# Auto-commit initialized files so they don't linger as mystery unstaged
 	# changes (#2570 bug 2). Collect all files that cmd_init creates/modifies.
@@ -2135,6 +2156,22 @@ GITATTRSEOF
 	[[ "$enable_security" == "true" ]] && echo "  ✓ Security (per-repo posture assessment)"
 	[[ -f "$project_root/MODELS.md" ]] && echo "  ✓ MODELS.md (per-repo model performance leaderboard)"
 	echo ""
+	# When init ran inside a worktree (check_protected_branch created one),
+	# print explicit instructions so the user knows where to find their work.
+	# Without this, the user's shell is back in the main repo after aidevops exits
+	# and the worktree appears to have "disappeared".
+	if [[ -n "${WORKTREE_PATH:-}" ]]; then
+		local worktree_branch
+		worktree_branch=$(git branch --show-current 2>/dev/null || echo "chore/aidevops-init")
+		echo "Worktree location:"
+		echo "  $WORKTREE_PATH"
+		echo ""
+		echo "Your init commit is in the worktree above. To continue:"
+		echo "  cd $WORKTREE_PATH"
+		echo "  git push -u origin ${worktree_branch}"
+		echo "  gh pr create --fill"
+		echo ""
+	fi
 	echo "Next steps:"
 	local step=1
 	if [[ "$committed" != "true" ]]; then


### PR DESCRIPTION
## Summary

Fixes four confirmed bugs in the `aidevops init` worktree lifecycle when run on `main`/`master`.

## Root Causes Fixed

### 1. Non-interactive TTY detection (`check_protected_branch`)
`read -r -p` was called without a `[[ -t 0 ]]` guard. In non-TTY contexts (CI, AI assistants like OpenCode), `read` receives EOF. With `set -e`, this can cause silent script termination before the worktree is created. Now auto-selects option 1 (create worktree) in non-interactive mode.

### 2. Stderr suppression hiding worktree failures
`worktree-helper.sh add` was called with `2>/dev/null`, silently swallowing any worktree creation errors. Removed the suppression so failures are visible.

### 3. `register_repo` registering worktree path instead of main repo path
After `check_protected_branch` calls `cd "$worktree_dir"`, `git rev-parse --show-toplevel` in `cmd_init` resolves to the worktree path. `register_repo` was then registering the worktree as a standalone repo in `repos.json`, making it visible to pulse/cleanup processes as an independent repo. Now resolves the main worktree path via `git worktree list --porcelain` when `WORKTREE_PATH` is set.

### 4. No next-steps message after worktree init
After `aidevops init` exits, the user's shell is back in the main repo. Without an explicit message, the worktree appears to have "disappeared". Now prints the worktree path and push/PR commands at the end of init when a worktree was created.

## Files Changed

- `aidevops.sh`: `check_protected_branch()` (lines 484–574), `cmd_init()` register_repo call and next-steps output

## Testing

**Risk level**: Medium (init workflow, non-destructive)

Self-assessed: changes are additive/defensive. The TTY check uses standard `[[ -t 0 ]]` pattern. The `register_repo` fix uses `git worktree list --porcelain` which is stable. ShellCheck passes with zero violations.

Reproducing the original bug requires a non-TTY environment (AI assistant or CI) running `aidevops init` on `main` — the TTY fix addresses the primary failure mode.

## Runtime Testing

`self-assessed` — Low/Medium risk. No payment, auth, or data deletion paths. ShellCheck: zero violations.

Closes #17388

---
[aidevops.sh](https://aidevops.sh) v3.6.89 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI/automation compatibility by removing interactive prompts in non-TTY environments.
  * Enhanced worktree creation reliability with better error handling and validation.

* **Documentation**
  * Added explicit on-screen instructions for worktree-based workflows, including branch push and pull request creation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->