### PR TITLE
t1889: sync GitHub issue relationships (blocked-by, sub-issues) from TODO.md

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -445,6 +445,8 @@ _push_process_task() {
 	if [[ $rc -eq 0 && -n "$_PUSH_CREATED_NUM" ]]; then
 		print_success "Created #${_PUSH_CREATED_NUM}: $title"
 		add_gh_ref_to_todo "$task_id" "$_PUSH_CREATED_NUM" "$todo_file"
+		# Sync relationships (blocked-by, sub-issues) after creation (t1889)
+		sync_relationships_for_task "$task_id" "$todo_file" "$repo"
 		echo "CREATED"
 	elif [[ $rc -eq 1 ]]; then
 		echo "SKIPPED"
@@ -558,6 +560,8 @@ cmd_enrich() {
 		}
 		if gh issue edit "$num" --repo "$repo" --title "$title" --body "$body" 2>/dev/null; then
 			print_success "Enriched #$num ($task_id)"
+			# Sync relationships (blocked-by, sub-issues) after enrichment (t1889)
+			sync_relationships_for_task "$task_id" "$todo_file" "$repo"
 			enriched=$((enriched + 1))
 		else print_error "Failed to enrich #$num ($task_id)"; fi
 	done
@@ -940,11 +944,353 @@ cmd_reopen() {
 	return 0
 }
 
+# =============================================================================
+# Relationships — GitHub Issue Dependencies & Hierarchy (t1889)
+# =============================================================================
+# Syncs TODO.md blocked-by:/blocks: and subtask hierarchy to GitHub's native
+# issue relationships via GraphQL mutations.
+
+# Node ID cache: avoids repeated API calls for the same issue number.
+# Uses a temp file (bash 3.2 compatible — no associative arrays).
+# Format: one "number=node_id" per line. Populated by _cached_node_id().
+_NODE_ID_CACHE_FILE=""
+
+_init_node_id_cache() {
+	if [[ -z "$_NODE_ID_CACHE_FILE" ]]; then
+		_NODE_ID_CACHE_FILE=$(mktemp /tmp/aidevops-node-cache.XXXXXX)
+		# shellcheck disable=SC2064
+		trap "rm -f '$_NODE_ID_CACHE_FILE'" EXIT
+	fi
+	return 0
+}
+
+_cached_node_id() {
+	local num="$1" repo="$2"
+	[[ -z "$num" ]] && return 0
+	_init_node_id_cache
+
+	# Check cache file
+	local cached
+	cached=$(grep -m1 "^${num}=" "$_NODE_ID_CACHE_FILE" 2>/dev/null | cut -d= -f2- || echo "")
+	if [[ -n "$cached" ]]; then
+		echo "$cached"
+		return 0
+	fi
+
+	local nid
+	nid=$(resolve_gh_node_id "$num" "$repo")
+	if [[ -n "$nid" ]]; then
+		echo "${num}=${nid}" >>"$_NODE_ID_CACHE_FILE"
+		echo "$nid"
+	fi
+	return 0
+}
+
+# Add a blocked-by relationship between two issues.
+# issueId = the blocked issue, blockingIssueId = the blocker.
+# Suppresses "already taken" errors (idempotent semantics).
+# Arguments:
+#   $1 - blocked_node_id (the issue that IS blocked)
+#   $2 - blocking_node_id (the issue that BLOCKS)
+# Returns: 0=success/already-exists, 1=error
+_gh_add_blocked_by() {
+	local blocked_id="$1" blocking_id="$2"
+	local result
+	result=$(gh api graphql -f query='
+mutation($blocked:ID!,$blocking:ID!) {
+  addBlockedBy(input: {issueId:$blocked, blockingIssueId:$blocking}) {
+    issue { number }
+  }
+}' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1)
+
+	# Success or already-exists are both fine
+	if echo "$result" | grep -q '"number"'; then
+		return 0
+	fi
+	if echo "$result" | grep -qi 'already been taken'; then
+		log_verbose "  blocked-by relationship already exists"
+		return 0
+	fi
+	log_verbose "  addBlockedBy error: ${result:0:200}"
+	return 1
+}
+
+# Add a sub-issue (parent-child) relationship.
+# Suppresses "duplicate sub-issues" and "only have one parent" errors.
+# Arguments:
+#   $1 - parent_node_id
+#   $2 - child_node_id
+# Returns: 0=success/already-exists, 1=error
+_gh_add_sub_issue() {
+	local parent_id="$1" child_id="$2"
+	local result
+	result=$(gh api graphql -f query='
+mutation($parent:ID!,$child:ID!) {
+  addSubIssue(input: {issueId:$parent, subIssueId:$child}) {
+    issue { number }
+  }
+}' -f parent="$parent_id" -f child="$child_id" 2>&1)
+
+	if echo "$result" | grep -q '"number"'; then
+		return 0
+	fi
+	if echo "$result" | grep -qi 'duplicate sub-issues\|only have one parent'; then
+		log_verbose "  sub-issue relationship already exists"
+		return 0
+	fi
+	log_verbose "  addSubIssue error: ${result:0:200}"
+	return 1
+}
+
+# Sync blocked-by and blocks relationships for a single task.
+# Parses the task line for blocked-by: and blocks: fields, resolves each
+# referenced task to a GitHub node ID, and creates the relationship.
+# Arguments:
+#   $1 - task_id
+#   $2 - todo_file path
+#   $3 - repo slug
+# Returns: number of relationships set (via stdout "RELS:N")
+_sync_blocked_by_for_task() {
+	local task_id="$1" todo_file="$2" repo="$3"
+	local task_id_ere
+	task_id_ere=$(_escape_ere "$task_id")
+	local task_line
+	task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+	[[ -z "$task_line" ]] && return 0
+
+	local parsed
+	parsed=$(parse_task_line "$task_line")
+	local blocked_by="" blocks=""
+	while IFS='=' read -r key value; do
+		case "$key" in
+		blocked_by) blocked_by="$value" ;;
+		blocks) blocks="$value" ;;
+		esac
+	done <<<"$parsed"
+
+	[[ -z "$blocked_by" && -z "$blocks" ]] && return 0
+
+	# Resolve this task's node ID
+	local this_gh_num
+	this_gh_num=$(resolve_task_gh_number "$task_id" "$todo_file")
+	[[ -z "$this_gh_num" ]] && {
+		log_verbose "$task_id: no ref:GH# — skipping relationships"
+		return 0
+	}
+	local this_node_id
+	this_node_id=$(_cached_node_id "$this_gh_num" "$repo")
+	[[ -z "$this_node_id" ]] && {
+		log_verbose "$task_id: could not resolve node ID for #$this_gh_num"
+		return 0
+	}
+
+	local rels_set=0
+
+	# Process blocked-by: this task IS blocked BY each listed task
+	if [[ -n "$blocked_by" ]]; then
+		local _saved_ifs="$IFS"
+		IFS=','
+		for dep_task_id in $blocked_by; do
+			dep_task_id="${dep_task_id// /}"
+			[[ -z "$dep_task_id" ]] && continue
+			local dep_gh_num
+			dep_gh_num=$(resolve_task_gh_number "$dep_task_id" "$todo_file")
+			[[ -z "$dep_gh_num" ]] && {
+				log_verbose "$task_id: blocked-by $dep_task_id has no ref:GH#"
+				continue
+			}
+			local dep_node_id
+			dep_node_id=$(_cached_node_id "$dep_gh_num" "$repo")
+			[[ -z "$dep_node_id" ]] && continue
+
+			if [[ "$DRY_RUN" == "true" ]]; then
+				print_info "[DRY-RUN] Would set #$this_gh_num blocked-by #$dep_gh_num ($task_id <- $dep_task_id)"
+				rels_set=$((rels_set + 1))
+			elif _gh_add_blocked_by "$this_node_id" "$dep_node_id"; then
+				log_verbose "$task_id (#$this_gh_num) blocked-by $dep_task_id (#$dep_gh_num) ✓"
+				rels_set=$((rels_set + 1))
+			fi
+		done
+		IFS="$_saved_ifs"
+	fi
+
+	# Process blocks: this task BLOCKS each listed task
+	# Inverse of blocked-by: call addBlockedBy with roles swapped
+	if [[ -n "$blocks" ]]; then
+		local _saved_ifs="$IFS"
+		IFS=','
+		for dep_task_id in $blocks; do
+			dep_task_id="${dep_task_id// /}"
+			[[ -z "$dep_task_id" ]] && continue
+			local dep_gh_num
+			dep_gh_num=$(resolve_task_gh_number "$dep_task_id" "$todo_file")
+			[[ -z "$dep_gh_num" ]] && {
+				log_verbose "$task_id: blocks $dep_task_id has no ref:GH#"
+				continue
+			}
+			local dep_node_id
+			dep_node_id=$(_cached_node_id "$dep_gh_num" "$repo")
+			[[ -z "$dep_node_id" ]] && continue
+
+			if [[ "$DRY_RUN" == "true" ]]; then
+				print_info "[DRY-RUN] Would set #$dep_gh_num blocked-by #$this_gh_num ($dep_task_id <- $task_id)"
+				rels_set=$((rels_set + 1))
+			elif _gh_add_blocked_by "$dep_node_id" "$this_node_id"; then
+				log_verbose "$dep_task_id (#$dep_gh_num) blocked-by $task_id (#$this_gh_num) ✓"
+				rels_set=$((rels_set + 1))
+			fi
+		done
+		IFS="$_saved_ifs"
+	fi
+
+	echo "RELS:$rels_set"
+	return 0
+}
+
+# Sync parent-child (sub-issue) relationship for a subtask.
+# Detects if task_id has a dot (e.g., t1873.2) and sets the parent relationship.
+# Arguments:
+#   $1 - task_id
+#   $2 - todo_file path
+#   $3 - repo slug
+# Returns: "RELS:1" if set, "RELS:0" if skipped
+_sync_subtask_hierarchy_for_task() {
+	local task_id="$1" todo_file="$2" repo="$3"
+
+	local parent_id
+	parent_id=$(detect_parent_task_id "$task_id")
+	[[ -z "$parent_id" ]] && return 0
+
+	# Resolve both task IDs to GitHub issue numbers
+	local child_gh_num
+	child_gh_num=$(resolve_task_gh_number "$task_id" "$todo_file")
+	[[ -z "$child_gh_num" ]] && {
+		log_verbose "$task_id: no ref:GH# — skipping sub-issue"
+		return 0
+	}
+	local parent_gh_num
+	parent_gh_num=$(resolve_task_gh_number "$parent_id" "$todo_file")
+	[[ -z "$parent_gh_num" ]] && {
+		log_verbose "$task_id: parent $parent_id has no ref:GH# — skipping sub-issue"
+		return 0
+	}
+
+	# Resolve to node IDs
+	local child_node_id
+	child_node_id=$(_cached_node_id "$child_gh_num" "$repo")
+	[[ -z "$child_node_id" ]] && return 0
+	local parent_node_id
+	parent_node_id=$(_cached_node_id "$parent_gh_num" "$repo")
+	[[ -z "$parent_node_id" ]] && return 0
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[DRY-RUN] Would set #$child_gh_num as sub-issue of #$parent_gh_num ($task_id -> $parent_id)"
+		echo "RELS:1"
+		return 0
+	fi
+
+	if _gh_add_sub_issue "$parent_node_id" "$child_node_id"; then
+		log_verbose "$task_id (#$child_gh_num) sub-issue of $parent_id (#$parent_gh_num) ✓"
+		echo "RELS:1"
+	else
+		echo "RELS:0"
+	fi
+	return 0
+}
+
+# Sync all relationships for a single task (blocked-by + subtask hierarchy).
+# Convenience wrapper called after push/enrich operations.
+# Arguments:
+#   $1 - task_id
+#   $2 - todo_file path
+#   $3 - repo slug
+sync_relationships_for_task() {
+	local task_id="$1" todo_file="$2" repo="$3"
+	_sync_blocked_by_for_task "$task_id" "$todo_file" "$repo" >/dev/null 2>&1 || true
+	_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" >/dev/null 2>&1 || true
+	return 0
+}
+
+# Bulk relationship sync command.
+# Scans TODO.md for all tasks with blocked-by:/blocks: or subtask patterns,
+# resolves to GitHub node IDs, and sets relationships via GraphQL.
+# Arguments:
+#   $1 - optional target task_id (if empty, processes all)
+cmd_relationships() {
+	local target_task="${1:-}"
+	_init_cmd || return 1
+	local repo="$_CMD_REPO" todo_file="$_CMD_TODO"
+
+	local tasks=()
+	if [[ -n "$target_task" ]]; then
+		tasks=("$target_task")
+	else
+		# Collect tasks with blocked-by:, blocks:, or subtask IDs (contain a dot)
+		while IFS= read -r line; do
+			local tid
+			tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
+			[[ -z "$tid" ]] && continue
+			# Include if it has dependencies or is a subtask
+			local dominated=false
+			echo "$line" | grep -qE 'blocked-by:|blocks:' && dominated=true
+			[[ "$tid" == *"."* ]] && dominated=true
+			[[ "$dominated" == "true" ]] && tasks+=("$tid")
+		done < <(strip_code_fences <"$todo_file" | grep -E '^\s*- \[.\] t[0-9]+.*ref:GH#[0-9]+' || true)
+	fi
+
+	[[ ${#tasks[@]} -eq 0 ]] && {
+		print_info "No tasks with relationships to sync"
+		return 0
+	}
+
+	# Deduplicate (bash 3.2 compatible — no associative arrays)
+	local seen_list=""
+	local unique_tasks=()
+	local t
+	for t in "${tasks[@]}"; do
+		if ! echo "$seen_list" | grep -qx "$t"; then
+			unique_tasks+=("$t")
+			seen_list="${seen_list}${t}"$'\n'
+		fi
+	done
+
+	local total="${#unique_tasks[@]}"
+	print_info "Syncing relationships for $total task(s) in $repo"
+
+	local blocked_set=0 sub_set=0 processed=0
+	for task_id in "${unique_tasks[@]}"; do
+		processed=$((processed + 1))
+		# Progress indicator every 25 tasks
+		if [[ $((processed % 25)) -eq 0 || $processed -eq $total ]]; then
+			printf "\r  Progress: %d/%d tasks..." "$processed" "$total" >&2
+		fi
+
+		local result
+
+		# Blocked-by / blocks
+		result=$(_sync_blocked_by_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0")
+		local n
+		n=$(echo "$result" | grep -oE 'RELS:[0-9]+' | head -1 | sed 's/RELS://' || echo "0")
+		blocked_set=$((blocked_set + n))
+
+		# Sub-issue hierarchy
+		result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0")
+		n=$(echo "$result" | grep -oE 'RELS:[0-9]+' | head -1 | sed 's/RELS://' || echo "0")
+		sub_set=$((sub_set + n))
+	done
+	[[ $total -gt 25 ]] && printf "\n" >&2
+
+	printf "\n=== Relationships Sync ===\nBlocked-by: %d | Sub-issues: %d | Tasks processed: %d\n" \
+		"$blocked_set" "$sub_set" "${#unique_tasks[@]}"
+	return 0
+}
+
 cmd_help() {
 	cat <<'EOF'
 Issue Sync Helper — stateless TODO.md <-> GitHub Issues sync via gh CLI.
 Usage: issue-sync-helper.sh [command] [options]
-Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reopen | reconcile | status | help
+Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reopen
+          reconcile | relationships [tNNN] | status | help
 Options: --repo SLUG | --dry-run | --verbose | --force (skip evidence on close)
          --force-push (allow bulk push outside CI — use with caution, risk of duplicates)
 
@@ -955,6 +1301,12 @@ Drift detection:
   reopen    — reopens closed issues whose TODO entry is still [ ] (open).
               Only reopens issues closed as COMPLETED, not NOT_PLANNED.
               Safe for automated use in the pulse.
+
+Relationships (t1889):
+  relationships [tNNN] — sync blocked-by/blocks and subtask hierarchy to GitHub
+                         issue relationships. Without tNNN, processes all tasks
+                         that have ref:GH# plus blocked-by:/blocks: or subtask IDs.
+                         Use --dry-run to preview. Idempotent (skips existing).
 
 Note: Bulk push (no task ID) is CI-only by default to prevent duplicate issues.
       Use 'push <task_id>' for single tasks, or --force-push to override.
@@ -999,7 +1351,8 @@ main() {
 	case "$command" in
 	push) cmd_push "${positional_args[1]:-}" ;; enrich) cmd_enrich "${positional_args[1]:-}" ;;
 	pull) cmd_pull ;; close) cmd_close "${positional_args[1]:-}" ;; reopen) cmd_reopen ;;
-	reconcile) cmd_reconcile ;; status) cmd_status ;; help) cmd_help ;;
+	reconcile) cmd_reconcile ;; relationships) cmd_relationships "${positional_args[1]:-}" ;;
+	status) cmd_status ;; help) cmd_help ;;
 	*)
 		print_error "Unknown command: $command"
 		cmd_help

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -1190,3 +1190,66 @@ add_pr_ref_to_todo() {
 	log_verbose "Added pr:#$pr_number to $task_id (t280: backfill proof-log)"
 	return 0
 }
+
+# =============================================================================
+# Relationships — GitHub Issue Relationships (t1889)
+# =============================================================================
+# Syncs TODO.md dependency metadata (blocked-by:, blocks:, subtask hierarchy)
+# to GitHub's native issue relationships via GraphQL mutations:
+#   - addBlockedBy / removeBlockedBy — dependency tracking
+#   - addSubIssue / removeSubIssue — parent-child hierarchy
+#
+# These mutations are NOT idempotent — duplicates return validation errors.
+# All functions suppress "already taken" / "duplicate sub-issues" errors.
+
+# Resolve a task ID to its GitHub issue number from TODO.md.
+# Looks up the ref:GH#NNN field for the given task ID.
+# Arguments:
+#   $1 - task_id (e.g. t1873.1)
+#   $2 - todo_file path
+# Returns: issue number on stdout, or empty string if not found
+resolve_task_gh_number() {
+	local task_id="$1"
+	local todo_file="$2"
+	local task_id_ere
+	task_id_ere=$(_escape_ere "$task_id")
+
+	local ref
+	ref=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 |
+		grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
+	echo "$ref"
+	return 0
+}
+
+# Resolve a GitHub issue number to its GraphQL node ID.
+# Arguments:
+#   $1 - issue_number
+#   $2 - repo slug (owner/repo)
+# Returns: node ID on stdout, or empty string on failure
+resolve_gh_node_id() {
+	local issue_number="$1"
+	local repo="$2"
+	local owner="${repo%%/*}"
+	local name="${repo##*/}"
+
+	local node_id
+	node_id=$(gh api graphql \
+		-f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){issue(number:$num){id}}}' \
+		-f owner="$owner" -f name="$name" -F num="$issue_number" \
+		--jq '.data.repository.issue.id' 2>/dev/null || echo "")
+	echo "$node_id"
+	return 0
+}
+
+# Detect the parent task ID from a subtask ID.
+# t1873.2 → t1873, t1873.2.1 → t1873.2, t1873 → "" (no parent)
+# Arguments:
+#   $1 - task_id
+# Returns: parent task ID on stdout, or empty string if top-level
+detect_parent_task_id() {
+	local task_id="$1"
+	if [[ "$task_id" == *"."* ]]; then
+		echo "${task_id%.*}"
+	fi
+	return 0
+}

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -1236,3 +1236,105 @@ migrate_orphaned_supervisor() {
 
 	return 0
 }
+
+# Backfill GitHub issue relationships from TODO.md metadata (t1889)
+# One-time migration: reads blocked-by:/blocks: and subtask hierarchy from
+# TODO.md in each pulse-enabled repo, and sets the corresponding GitHub
+# issue relationships (blocked-by, sub-issues) via the GraphQL API.
+#
+# Uses marker file to ensure it runs only once per install.
+# Safe to re-run — the GraphQL mutations are idempotent (duplicates are skipped).
+backfill_issue_relationships() {
+	local marker_file="$HOME/.aidevops/.migrations/t1889-relationships-backfill"
+	local marker_dir
+	marker_dir=$(dirname "$marker_file")
+
+	# Skip if already done
+	if [[ -f "$marker_file" ]]; then
+		return 0
+	fi
+
+	# Require gh CLI and authentication
+	if ! command -v gh &>/dev/null; then
+		print_warning "gh CLI not installed — skipping issue relationships backfill"
+		return 0
+	fi
+	if ! gh auth status &>/dev/null 2>&1; then
+		print_warning "gh CLI not authenticated — skipping issue relationships backfill"
+		return 0
+	fi
+
+	# Require jq for repos.json parsing
+	if ! command -v jq &>/dev/null; then
+		print_warning "jq not installed — skipping issue relationships backfill"
+		return 0
+	fi
+
+	local repos_file="$HOME/.config/aidevops/repos.json"
+	if [[ ! -f "$repos_file" ]]; then
+		print_info "No repos.json — skipping issue relationships backfill"
+		mkdir -p "$marker_dir"
+		touch "$marker_file"
+		return 0
+	fi
+
+	local sync_script="$HOME/.aidevops/agents/scripts/issue-sync-helper.sh"
+	if [[ ! -x "$sync_script" ]]; then
+		print_warning "issue-sync-helper.sh not found — skipping relationships backfill"
+		return 0
+	fi
+
+	print_info "Backfilling GitHub issue relationships (blocked-by, sub-issues) from TODO.md..."
+
+	local total_repos=0 total_rels=0 failed_repos=0
+	local repo_path repo_slug local_only
+
+	while IFS=$'\t' read -r repo_path repo_slug local_only; do
+		[[ -z "$repo_path" ]] && continue
+		local expanded_path="${repo_path/#\~/$HOME}"
+
+		# Skip local-only repos (no GitHub remote)
+		[[ "$local_only" == "true" ]] && continue
+
+		# Skip repos without TODO.md
+		[[ ! -f "$expanded_path/TODO.md" ]] && continue
+
+		# Skip repos with no ref:GH# entries
+		if ! grep -qE 'ref:GH#[0-9]+' "$expanded_path/TODO.md" 2>/dev/null; then
+			continue
+		fi
+
+		# Skip repos with no blocked-by:/blocks: or subtask entries
+		local has_deps=false
+		grep -qE 'blocked-by:|blocks:' "$expanded_path/TODO.md" 2>/dev/null && has_deps=true
+		grep -qE '^\s+- \[.\] t[0-9]+\.[0-9]+.*ref:GH#' "$expanded_path/TODO.md" 2>/dev/null && has_deps=true
+		[[ "$has_deps" == "false" ]] && continue
+
+		total_repos=$((total_repos + 1))
+		local repo_arg=""
+		[[ -n "$repo_slug" ]] && repo_arg="--repo $repo_slug"
+
+		print_info "  $(basename "$expanded_path"): syncing relationships..."
+		# shellcheck disable=SC2086
+		if (cd "$expanded_path" && bash "$sync_script" relationships $repo_arg --verbose 2>&1 | tail -3); then
+			true
+		else
+			print_warning "  $(basename "$expanded_path"): relationships sync had errors"
+			failed_repos=$((failed_repos + 1))
+		fi
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true) | [.path, .slug, (.local_only // false | tostring)] | @tsv' "$repos_file" 2>/dev/null)
+
+	# Create marker directory and file
+	mkdir -p "$marker_dir"
+	date -u +%Y-%m-%dT%H:%M:%SZ >"$marker_file"
+
+	if [[ $total_repos -eq 0 ]]; then
+		print_info "No repos with relationship data to backfill"
+	elif [[ $failed_repos -eq 0 ]]; then
+		print_success "Issue relationships backfilled for $total_repos repo(s)"
+	else
+		print_warning "Backfilled $total_repos repo(s), $failed_repos had errors"
+	fi
+
+	return 0
+}

--- a/setup.sh
+++ b/setup.sh
@@ -781,6 +781,7 @@ _setup_run_non_interactive() {
 	migrate_pulse_repos_to_repos_json
 	cleanup_deprecated_paths
 	migrate_orphaned_supervisor
+	backfill_issue_relationships
 	cleanup_deprecated_mcps
 	cleanup_stale_bun_opencode
 	validate_opencode_config
@@ -872,6 +873,7 @@ _setup_run_interactive() {
 	confirm_step "Migrate pulse-repos.json into repos.json" && migrate_pulse_repos_to_repos_json
 	confirm_step "Cleanup deprecated agent paths" && cleanup_deprecated_paths
 	confirm_step "Migrate orphaned supervisor to pulse-wrapper" && migrate_orphaned_supervisor
+	confirm_step "Backfill GitHub issue relationships (blocked-by, sub-issues)" && backfill_issue_relationships
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
 	confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config


### PR DESCRIPTION
## Summary

Adds native GitHub issue relationship sync to issue-sync-helper.sh, mapping TODO.md dependency metadata to GitHub's Relationships feature (blocked-by, sub-issues).

## What

- **`addBlockedBy`** mutations: syncs `blocked-by:` and `blocks:` fields from TODO.md to GitHub's native blocking relationships
- **`addSubIssue`** mutations: maps subtask hierarchy (`tNNN.N` IDs) to parent/child sub-issue relationships
- **New `relationships` command**: `issue-sync-helper.sh relationships [tNNN]` for targeted or bulk sync with `--dry-run` support
- **Auto-sync on push/enrich**: relationship sync runs automatically when issues are created or enriched
- **One-time backfill migration**: added to `setup.sh` — runs on `aidevops update` for all pulse-enabled repos in `repos.json`, with marker file to ensure single execution
- **Bash 3.2 compatible**: file-based node ID cache instead of associative arrays

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/issue-sync-lib.sh` | Added `resolve_task_gh_number()`, `resolve_gh_node_id()`, `detect_parent_task_id()` |
| `.agents/scripts/issue-sync-helper.sh` | Added relationship sync functions, `cmd_relationships` command, integration into push/enrich |
| `setup-modules/migrations.sh` | Added `backfill_issue_relationships()` one-time migration |
| `setup.sh` | Added backfill call to both interactive and non-interactive paths |

## Runtime Testing

- **Risk level**: Medium (API mutations, but idempotent with error suppression)
- **Verified**: Tested live on t1873 family (7 subtasks with blocked-by chains). All blocked-by and sub-issue relationships confirmed via GraphQL query.
- **Idempotency**: Re-running on already-set relationships correctly skips (suppresses "already taken" / "duplicate sub-issues" errors)
- **Bash 3.2**: Fixed `declare -A` incompatibility — uses temp file cache instead

## Key Decisions

1. **Error suppression over pre-check**: GitHub mutations aren't idempotent (return validation errors on duplicates). Rather than querying existing relationships first (2x API calls), we attempt the mutation and suppress known "already exists" errors.
2. **File-based cache**: Node ID resolution requires a GraphQL call per issue number. Cache avoids redundant calls when the same issue appears in multiple dependency chains.
3. **Backfill as migration**: One-time backfill runs via `setup.sh` with a marker file (`~/.aidevops/.migrations/t1889-relationships-backfill`), so it only executes once per install but can be manually re-triggered by deleting the marker.

Closes #17391


---
[aidevops.sh](https://aidevops.sh) v3.6.89 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 36m and 30,909 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic GitHub issue relationship syncing (blocked-by dependencies and sub-issue hierarchies) now triggers after issue creation and enrichment.
  * New `relationships` CLI command enables bulk scanning and synchronization of issue relationships across tasks.
  * One-time migration backfills existing issue relationships in pulse-enabled repositories during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->