### PR TITLE
GH#17396: fix stall-detection false positive when simplification debt is zero

### DIFF
--- a/.agents/scripts/complexity-scan-helper.sh
+++ b/.agents/scripts/complexity-scan-helper.sh
@@ -515,6 +515,12 @@ cmd_sweep_check() {
 		local snapshot_age=$((now_epoch - snapshot_epoch))
 
 		if [[ "$snapshot_age" -ge "$stall_seconds" ]]; then
+			# No sweep needed when debt is already zero — nothing to act on (GH#17396)
+			if [[ "$current_debt" -eq 0 ]]; then
+				echo "${now_epoch}|0" >"$SWEEP_DEBT_SNAPSHOT"
+				echo "not-needed|debt is zero, no sweep required"
+				return 1
+			fi
 			if [[ "$current_debt" -ge "$snapshot_count" ]]; then
 				# Debt hasn't decreased — sweep needed
 				echo "needed|debt stalled at ${current_debt} for ${stall_hours}h+ (was ${snapshot_count})"
@@ -533,8 +539,12 @@ cmd_sweep_check() {
 		fi
 	fi
 
-	# No snapshot exists — create one, sweep needed for initial baseline
+	# No snapshot exists — create one. Skip sweep if debt is already zero (GH#17396).
 	echo "${now_epoch}|${current_debt}" >"$SWEEP_DEBT_SNAPSHOT"
+	if [[ "$current_debt" -eq 0 ]]; then
+		echo "not-needed|initial snapshot created, debt is zero"
+		return 1
+	fi
 	echo "needed|initial sweep (no prior snapshot, current debt: ${current_debt})"
 	return 0
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `sweep-check` used `current_debt >= snapshot_count` to detect stalls. When both values are 0 (debt cleared), `0 >= 0 = true` incorrectly triggered an LLM sweep.
- **Fix**: Added early-exit guard in `cmd_sweep_check`: if `current_debt == 0`, return `not-needed` immediately — nothing to sweep.
- **Also fixed**: Initial-snapshot path (no prior snapshot + debt=0) now also skips the sweep instead of triggering one.

## Issue

Closes #17396

## Files Changed

- `.agents/scripts/complexity-scan-helper.sh` — 11 lines added, 1 changed

## Testing

- ShellCheck: zero violations
- Manual test: `sweep-check` with old snapshot (7h) and debt=0 → returns `not-needed` (exit 1) ✓
- Non-zero debt path unchanged — stall detection still works for debt > 0

## Key Decisions

- Guard placed before the `>=` stall check so it short-circuits cleanly
- Snapshot is still updated to current timestamp when debt=0 (prevents repeated checks)
- No change to the 24h sweep-interval check (first guard in the function)

## Runtime Testing

Risk: **Low** — shell script logic fix, no runtime environment required. Self-assessed.

<!-- MERGE_SUMMARY -->
**What**: Fix false-positive stall detection in `complexity-scan-helper.sh` when simplification debt is zero
**Issue**: #17396
**Files**: `.agents/scripts/complexity-scan-helper.sh`
**Testing**: ShellCheck clean, manual verification of zero-debt path
**Key decision**: Early-exit guard when `current_debt == 0` before stall comparison

---
[aidevops.sh](https://aidevops.sh) v3.6.92 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed debt checking logic to correctly identify when no debt processing is required, preventing unnecessary operations and improving system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->