### PR TITLE
GH#17405: fix _install_pulse_systemd missing PATH env and timer OnActiveSec

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -446,6 +446,12 @@ _install_pulse_systemd() {
 	fi
 	_env_lines+="Environment=PULSE_DIR=${HOME}/.aidevops/.agent-workspace"$'\n'
 	_env_lines+="Environment=HOME=${HOME}"$'\n'
+	# Capture setup-time PATH so systemd workers find user-installed binaries
+	# (e.g. ~/.npm-global/bin/opencode, ~/.local/bin/claude). Systemd user
+	# services inherit only a minimal default PATH; without this, headless
+	# runtime binaries are not found and workers exit 127. Matches launchd
+	# plist behaviour (GH#17405).
+	_env_lines+="Environment=PATH=${PATH}"$'\n'
 
 	# Write the service unit
 	printf '%s' "[Unit]
@@ -460,10 +466,14 @@ StandardError=append:${HOME}/.aidevops/logs/pulse-wrapper.log
 " >"$service_file"
 
 	# Write the timer unit (every 2 minutes)
+	# OnActiveSec=10s fires 10 seconds after the timer is enabled, bootstrapping
+	# the first service run on mid-session installs where OnBootSec has already
+	# elapsed and OnUnitActiveSec has no prior activation to anchor to (GH#17405).
 	printf '%s' "[Unit]
 Description=aidevops Supervisor Pulse Timer
 
 [Timer]
+OnActiveSec=10s
 OnBootSec=2min
 OnUnitActiveSec=2min
 Persistent=true


### PR DESCRIPTION
## Summary

- **Bug 1 (exit 127):** Add `Environment=PATH=...` to the generated systemd service unit, capturing the setup-time PATH so workers find user-installed binaries (`opencode`, `claude`) at `~/.npm-global/bin/`, `~/.local/bin/`, etc. Systemd user services inherit a minimal default PATH that excludes these locations. Matches the launchd plist behaviour (lines 322–326).
- **Bug 2 (timer stalls):** Add `OnActiveSec=10s` to the timer unit so the first service run is bootstrapped on mid-session installs. Without it, `OnBootSec` has already elapsed and `OnUnitActiveSec` has no prior activation to anchor to, leaving `Trigger: n/a` until the next reboot or manual kick.

## Files Changed

- `setup-modules/schedulers.sh` — `_install_pulse_systemd()`: +7 lines (PATH env line + comment, OnActiveSec + comment)

## Runtime Testing

Risk: **Low** — scheduler configuration generation only; no runtime logic changed. The generated unit files are text; correctness is verified by code inspection against the launchd plist (PATH) and systemd timer documentation (OnActiveSec). No dev environment required for this change tier.

Self-assessed: the fix is a direct port of the launchd PATH pattern and a standard systemd timer bootstrap pattern documented in `systemd.timer(5)`.

## Key Decisions

- PATH captured at setup time (not hardcoded) — matches launchd plist and picks up any user-configured binary locations present when `setup.sh` runs.
- `OnActiveSec=10s` chosen to be short enough to bootstrap quickly but not so short it races with `daemon-reload`. After first activation, `OnUnitActiveSec=2min` takes over.

Closes #17405

---
[aidevops.sh](https://aidevops.sh) v3.6.93 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system service configuration to ensure runtime binaries are properly discoverable in headless environments.
  * Improved service activation timing for installations initiated during an active session, allowing faster initial startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->