### PR TITLE
GH#17403: allow first-time pulse install in update

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+SETUP_SCRIPT="${REPO_ROOT}/setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+load_setup_functions() {
+	local helper_definition=""
+	helper_definition="$(awk '
+		/^_should_setup_noninteractive_supervisor_pulse\(\) \{/ { in_fn=1 }
+		in_fn { print }
+		in_fn && /^}/ { exit }
+	' "$SETUP_SCRIPT")"
+
+	if [[ -z "$helper_definition" ]]; then
+		printf 'failed to load helper from %s\n' "$SETUP_SCRIPT" >&2
+		return 1
+	fi
+
+	eval "$helper_definition"
+	return 0
+}
+
+test_uses_existing_installation_signal() {
+	local output=""
+
+	output=$(
+		load_setup_functions
+		_scheduler_detect_installed() { return 0; }
+		config_enabled() { return 1; }
+
+		if _should_setup_noninteractive_supervisor_pulse; then
+			printf 'result=true\n'
+		else
+			printf 'result=false\n'
+		fi
+	) || true
+
+	if [[ "$output" == *"result=true"* ]]; then
+		print_result "non-interactive pulse setup regenerates existing scheduler" 0
+		return 0
+	fi
+
+	print_result "non-interactive pulse setup regenerates existing scheduler" 1 "output=${output}"
+	return 0
+}
+
+test_uses_explicit_config_consent_for_first_install() {
+	local output=""
+
+	output=$(
+		load_setup_functions
+		_scheduler_detect_installed() { return 1; }
+		config_enabled() {
+			local key="$1"
+			[[ "$key" == "orchestration.supervisor_pulse" ]]
+			return $?
+		}
+
+		if _should_setup_noninteractive_supervisor_pulse; then
+			printf 'result=true\n'
+		else
+			printf 'result=false\n'
+		fi
+	) || true
+
+	if [[ "$output" == *"result=true"* ]]; then
+		print_result "non-interactive pulse setup honors explicit config consent" 0
+		return 0
+	fi
+
+	print_result "non-interactive pulse setup honors explicit config consent" 1 "output=${output}"
+	return 0
+}
+
+test_skips_without_existing_install_or_config_consent() {
+	local output=""
+
+	output=$(
+		load_setup_functions
+		_scheduler_detect_installed() { return 1; }
+		config_enabled() { return 1; }
+
+		if _should_setup_noninteractive_supervisor_pulse; then
+			printf 'result=true\n'
+		else
+			printf 'result=false\n'
+		fi
+	) || true
+
+	if [[ "$output" == *"result=false"* ]]; then
+		print_result "non-interactive pulse setup preserves consent gate" 0
+		return 0
+	fi
+
+	print_result "non-interactive pulse setup preserves consent gate" 1 "output=${output}"
+	return 0
+}
+
+main() {
+	test_uses_existing_installation_signal
+	test_uses_explicit_config_consent_for_first_install
+	test_skips_without_existing_install_or_config_consent
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -283,6 +283,29 @@ _scheduler_detect_installed() {
 
 	return 1
 }
+
+_should_setup_noninteractive_supervisor_pulse() {
+	local pulse_label="com.aidevops.aidevops-supervisor-pulse"
+
+	if _scheduler_detect_installed \
+		"Supervisor pulse" \
+		"$pulse_label" \
+		"" \
+		"pulse-wrapper" \
+		"" \
+		"" \
+		"" \
+		"aidevops-supervisor-pulse"; then
+		return 0
+	fi
+
+	if type config_enabled &>/dev/null && config_enabled "orchestration.supervisor_pulse"; then
+		return 0
+	fi
+
+	return 1
+}
+
 # Spinner for long-running operations
 # Usage: run_with_spinner "Installing package..." command arg1 arg2
 run_with_spinner() {
@@ -941,21 +964,10 @@ _setup_post_setup_steps() {
 	# services, and optional post-setup work (CI/agent shells don't need them).
 	# Tabby profile sync runs in both modes (has its own non-interactive path).
 	#
-	# Exception (GH#17381): if a scheduler is already installed (user previously
-	# consented), regenerate it so fixes to service files reach existing installs.
-	# This preserves the consent model — no new scheduler is installed without
-	# interactive consent; only already-consented schedulers are regenerated.
+	# Exceptions: regenerate existing schedulers (GH#17381) and allow first-time
+	# install when config consent is explicitly true (GH#17403).
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
-		local _pulse_label="com.aidevops.aidevops-supervisor-pulse"
-		if _scheduler_detect_installed \
-			"Supervisor pulse" \
-			"$_pulse_label" \
-			"" \
-			"pulse-wrapper" \
-			"" \
-			"" \
-			"" \
-			"aidevops-supervisor-pulse"; then
+		if _should_setup_noninteractive_supervisor_pulse; then
 			setup_supervisor_pulse "$os"
 		fi
 		setup_tabby


### PR DESCRIPTION
## Summary
- install the supervisor pulse scheduler during non-interactive `aidevops update` when config consent is already explicitly enabled
- keep the existing regeneration path for already-installed schedulers and preserve the consent gate when config consent is absent
- add a shell regression test covering existing-install, explicit-consent, and no-consent paths

## Testing
- `bash .agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh`
- `bash .agents/scripts/tests/test-setup-common-noninteractive-guard.sh`
- `shellcheck setup.sh .agents/scripts/tests/test-setup-noninteractive-supervisor-pulse.sh`

## Runtime Testing
- self-assessed: no Linux/systemd first-install environment is available in this session, so verification is limited to targeted shell regression coverage and static linting

## Why
`aidevops update` currently regenerates only already-installed pulse schedulers in non-interactive mode, so users who later enable `orchestration.supervisor_pulse=true` never get a first-time install. This restores the expected install path without bypassing consent.

Closes #17403

Overall, this change makes non-interactive updates honor explicit pulse consent for first-time scheduler installation while keeping the prior regeneration behavior intact.


---
[aidevops.sh](https://aidevops.sh) v3.6.94 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.4
