### PR TITLE
GH#17403: fix first-time pulse install skipped in non-interactive mode when consent set

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -945,6 +945,11 @@ _setup_post_setup_steps() {
 	# consented), regenerate it so fixes to service files reach existing installs.
 	# This preserves the consent model — no new scheduler is installed without
 	# interactive consent; only already-consented schedulers are regenerated.
+	#
+	# Exception (GH#17403): if the scheduler is NOT installed but the user has
+	# explicitly set orchestration.supervisor_pulse=true in config, install it.
+	# The interactive prompt exists to capture consent — if the user has already
+	# set the config value, that consent is already recorded. No prompt needed.
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
 		local _pulse_label="com.aidevops.aidevops-supervisor-pulse"
 		if _scheduler_detect_installed \
@@ -956,6 +961,11 @@ _setup_post_setup_steps() {
 			"" \
 			"" \
 			"aidevops-supervisor-pulse"; then
+			setup_supervisor_pulse "$os"
+		elif [[ "$(_resolve_pulse_consent | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+			# Explicit config consent — user already gave permission via
+			# `aidevops config set orchestration.supervisor_pulse true`.
+			# No interactive prompt needed; install the scheduler now.
 			setup_supervisor_pulse "$os"
 		fi
 		setup_tabby


### PR DESCRIPTION
## Summary

- Adds an `elif` branch in the non-interactive path of `setup_post` (setup.sh) that checks `_resolve_pulse_consent` when the scheduler is not already installed
- When `orchestration.supervisor_pulse=true` is set in config, `aidevops update` now installs the pulse scheduler instead of silently skipping it
- Consent model is fully preserved: no scheduler is installed without explicit consent; the config value written by the interactive prompt or `aidevops config set` is the consent record

## Problem

GH#17381 (PR #17382) fixed regeneration of existing schedulers in non-interactive mode. But it missed the case where the scheduler was never installed and the user has since enabled consent via config:

```bash
# setup.sh non-interactive path (before this fix)
if _scheduler_detect_installed ...; then
    setup_supervisor_pulse "$os"   # ← only if ALREADY installed
fi
setup_tabby
return 0   # ← exits; no first-time install path
```

`_scheduler_detect_installed` returns false → `setup_supervisor_pulse` never called → scheduler not installed.

## Fix

```bash
if _scheduler_detect_installed ...; then
    setup_supervisor_pulse "$os"
elif [[ "$(_resolve_pulse_consent | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
    # Explicit config consent — install the scheduler now.
    setup_supervisor_pulse "$os"
fi
```

`_resolve_pulse_consent` already exists in `schedulers.sh` (sourced at line 676). It reads from `config.jsonc`, legacy `.conf`, and `$AIDEVOPS_SUPERVISOR_PULSE` env var in priority order.

## Files Changed

- `setup.sh`: lines 948–970 — added `elif` branch with `_resolve_pulse_consent` check

## Runtime Testing

**Risk level:** Low — shell script logic change, no new functions introduced, no side effects on existing paths.

- `shellcheck setup.sh` → 0 violations
- `shellcheck setup-modules/schedulers.sh` → 0 violations
- Logic verified: `_resolve_pulse_consent` is defined in `schedulers.sh` (line 19), sourced at `setup.sh:676`, available in the non-interactive block at line 953

## Closes

Closes #17403

---
[aidevops.sh](https://aidevops.sh) v3.6.94 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-interactive setup to properly install the scheduler component when consent is obtained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->