### PR TITLE
GH#17402: issue-sync enrich — reconcile tag-derived labels on remove

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -114,6 +114,63 @@ _gh_edit_labels() {
 	[[ ${#args[@]} -gt 0 ]] && gh issue edit "$num" --repo "$repo" "${args[@]}" 2>/dev/null || true
 }
 
+# _is_protected_label: returns 0 if the label must NOT be removed by enrich reconciliation.
+# Protected labels are managed by other workflows (lifecycle, closure hygiene, PR labeler)
+# and must not be touched by tag-derived label reconciliation.
+# Arguments:
+#   $1 - label name
+_is_protected_label() {
+	local lbl="$1"
+	# Prefix-protected namespaces
+	case "$lbl" in
+	status:* | origin:* | tier:*) return 0 ;;
+	esac
+	# Exact-match protected labels
+	case "$lbl" in
+	persistent | needs-maintainer-review | not-planned | duplicate | wontfix | \
+		already-fixed | "good first issue" | "help wanted")
+		return 0
+		;;
+	esac
+	return 1
+}
+
+# _reconcile_labels: remove tag-derived labels from a GitHub issue that are no
+# longer present in the desired label set. Protected labels are never removed.
+# Arguments:
+#   $1 - repo slug (owner/repo)
+#   $2 - issue number
+#   $3 - desired labels (comma-separated, already mapped via map_tags_to_labels)
+_reconcile_labels() {
+	local repo="$1" num="$2" desired_labels="$3"
+	local current_labels
+	current_labels=$(gh issue view "$num" --repo "$repo" --json labels \
+		--jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+	[[ -z "$current_labels" ]] && return 0
+
+	local to_remove=""
+	local _saved_ifs="$IFS"
+	IFS=','
+	for lbl in $current_labels; do
+		[[ -z "$lbl" ]] && continue
+		# Skip protected labels — they are not in the tag-derived domain
+		_is_protected_label "$lbl" && continue
+		# Check if this label is in the desired set
+		local found=false
+		for desired in $desired_labels; do
+			[[ "$lbl" == "$desired" ]] && {
+				found=true
+				break
+			}
+		done
+		[[ "$found" == "false" ]] && to_remove="${to_remove:+$to_remove,}$lbl"
+	done
+	IFS="$_saved_ifs"
+
+	[[ -n "$to_remove" ]] && _gh_edit_labels "remove" "$repo" "$num" "$to_remove"
+	return 0
+}
+
 gh_create_label() {
 	local repo="$1" name="$2" color="$3" desc="$4"
 	gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force 2>/dev/null || true
@@ -550,7 +607,7 @@ cmd_enrich() {
 		body=$(compose_issue_body "$task_id" "$project_root")
 
 		if [[ "$DRY_RUN" == "true" ]]; then
-			print_info "[DRY-RUN] Would enrich #$num ($task_id)"
+			print_info "[DRY-RUN] Would enrich #$num ($task_id) labels=$labels"
 			enriched=$((enriched + 1))
 			continue
 		fi
@@ -558,6 +615,8 @@ cmd_enrich() {
 			ensure_labels_exist "$labels" "$repo"
 			_gh_edit_labels "add" "$repo" "$num" "$labels"
 		}
+		# Reconcile: remove tag-derived labels no longer in desired set (GH#17402)
+		_reconcile_labels "$repo" "$num" "$labels"
 		if gh issue edit "$num" --repo "$repo" --title "$title" --body "$body" 2>/dev/null; then
 			print_success "Enriched #$num ($task_id)"
 			# Sync relationships (blocked-by, sub-issues) after enrichment (t1889)

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -123,7 +123,7 @@ _is_protected_label() {
 	local lbl="$1"
 	# Prefix-protected namespaces
 	case "$lbl" in
-	status:* | origin:* | tier:*) return 0 ;;
+	status:* | origin:* | tier:* | source:*) return 0 ;;
 	esac
 	# Exact-match protected labels
 	case "$lbl" in
@@ -611,12 +611,24 @@ cmd_enrich() {
 			enriched=$((enriched + 1))
 			continue
 		fi
-		[[ -n "$labels" ]] && {
+		local add_ok=true
+		if [[ -n "$labels" ]]; then
 			ensure_labels_exist "$labels" "$repo"
-			_gh_edit_labels "add" "$repo" "$num" "$labels"
-		}
-		# Reconcile: remove tag-derived labels no longer in desired set (GH#17402)
-		_reconcile_labels "$repo" "$num" "$labels"
+			# Build add args and check exit status — _gh_edit_labels masks failures via || true,
+			# so we call gh issue edit directly here to gate reconciliation (GH#17402 CR fix).
+			local -a add_args=()
+			local _saved_ifs_add="$IFS"
+			IFS=','
+			for _lbl in $labels; do [[ -n "$_lbl" ]] && add_args+=("--add-label" "$_lbl"); done
+			IFS="$_saved_ifs_add"
+			if [[ ${#add_args[@]} -gt 0 ]]; then
+				gh issue edit "$num" --repo "$repo" "${add_args[@]}" 2>/dev/null || add_ok=false
+			fi
+		fi
+		# Reconcile: remove tag-derived labels no longer in desired set (GH#17402).
+		# Only run when add succeeded (or no labels to add) to avoid destructive removal
+		# after a transient add failure.
+		[[ "$add_ok" == "true" ]] && _reconcile_labels "$repo" "$num" "$labels"
 		if gh issue edit "$num" --repo "$repo" --title "$title" --body "$body" 2>/dev/null; then
 			print_success "Enriched #$num ($task_id)"
 			# Sync relationships (blocked-by, sub-issues) after enrichment (t1889)

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -135,8 +135,23 @@ _is_protected_label() {
 	return 1
 }
 
+# _is_tag_derived_label: returns 0 if a label is in the tag-derived domain.
+# Tag-derived labels are simple words (no ':' separator). All system/workflow
+# labels use ':' namespacing (status:*, origin:*, tier:*, source:*, etc.).
+# This prevents reconciliation from removing manually-added or system labels
+# that happen to not be in the protected prefix list.
+# Arguments:
+#   $1 - label name
+_is_tag_derived_label() {
+	local lbl="$1"
+	# Labels with ':' are namespace-scoped — not tag-derived
+	[[ "$lbl" == *:* ]] && return 1
+	return 0
+}
+
 # _reconcile_labels: remove tag-derived labels from a GitHub issue that are no
-# longer present in the desired label set. Protected labels are never removed.
+# longer present in the desired label set. Only labels in the tag-derived domain
+# (no ':' separator, not protected) are candidates for removal.
 # Arguments:
 #   $1 - repo slug (owner/repo)
 #   $2 - issue number
@@ -155,6 +170,8 @@ _reconcile_labels() {
 		[[ -z "$lbl" ]] && continue
 		# Skip protected labels — they are not in the tag-derived domain
 		_is_protected_label "$lbl" && continue
+		# Skip labels outside the tag-derived domain (namespaced labels with ':')
+		_is_tag_derived_label "$lbl" || continue
 		# Check if this label is in the desired set
 		local found=false
 		for desired in $desired_labels; do
@@ -167,7 +184,17 @@ _reconcile_labels() {
 	done
 	IFS="$_saved_ifs"
 
-	[[ -n "$to_remove" ]] && _gh_edit_labels "remove" "$repo" "$num" "$to_remove"
+	if [[ -n "$to_remove" ]]; then
+		local -a rm_args=()
+		local _saved_ifs_rm="$IFS"
+		IFS=','
+		for _lbl in $to_remove; do [[ -n "$_lbl" ]] && rm_args+=("--remove-label" "$_lbl"); done
+		IFS="$_saved_ifs_rm"
+		if [[ ${#rm_args[@]} -gt 0 ]]; then
+			gh issue edit "$num" --repo "$repo" "${rm_args[@]}" 2>/dev/null ||
+				print_warning "label reconcile: failed to remove stale labels ($to_remove) from #$num in $repo"
+		fi
+	fi
 	return 0
 }
 


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Adds label reconciliation to `cmd_enrich()` in `issue-sync-helper.sh`. When `enrich` runs, it now removes tag-derived labels from a GitHub issue that are no longer present in the TODO.md task line, in addition to adding new ones.

## Issue
Closes #17402

## Files Changed
- `.agents/scripts/issue-sync-helper.sh` — added `_is_protected_label()`, `_reconcile_labels()`, and call site in `cmd_enrich()`

## Implementation
Two new helpers:
- `_is_protected_label(lbl)` — returns 0 for labels in protected namespaces (`status:*`, `origin:*`, `tier:*`) and exact-match system labels (`persistent`, `needs-maintainer-review`, `not-planned`, `duplicate`, `wontfix`, `already-fixed`, `good first issue`, `help wanted`). These are managed by other workflows and must not be touched.
- `_reconcile_labels(repo, num, desired_labels)` — fetches current issue labels via `gh issue view --json labels`, skips protected ones, and removes any non-protected label not in the desired set via the existing `_gh_edit_labels "remove"` path.

The call is inserted in `cmd_enrich()` immediately after the `_gh_edit_labels "add"` call, so the sequence is: add new → reconcile (remove stale).

## Testing
- Risk level: **Low** (shell script, no runtime/auth/payment paths)
- ShellCheck: zero warnings at `--severity=warning`
- Logic verified: `_is_protected_label` correctly gates `status:*`, `origin:*`, `tier:*` prefixes and named system labels; `_reconcile_labels` only removes labels not in the desired set and not protected

## Runtime Testing
`self-assessed` — Low risk: shell script logic change with no external side effects beyond the existing `gh issue edit` call already used by enrich.

## Key Decisions
- Only remove labels in the tag-derived domain; protected labels are never touched (matches issue spec exactly)
- `_gh_edit_labels "remove"` was already implemented — no new API surface needed
- Dry-run path updated to log `labels=` for observability

---
[aidevops.sh](https://aidevops.sh) v3.6.94 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic removal of obsolete labels: issues now reconcile labels to match the computed desired set, while protecting essential label namespaces and specific labels from accidental removal.
  * Improved dry-run transparency: simulated runs now include the computed label set in logs and label-add actions are gated so reconciliation only proceeds when additions succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->