### PR TITLE
GH#17402: issue-sync enrich: reconcile labels — remove stale tag-derived labels when tags removed from TODO.md

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -114,6 +114,23 @@ _gh_edit_labels() {
 	[[ ${#args[@]} -gt 0 ]] && gh issue edit "$num" --repo "$repo" "${args[@]}" 2>/dev/null || true
 }
 
+# _is_protected_label — returns 0 (true) if a label is system-managed and must
+# not be removed by the tag-reconciliation logic in cmd_enrich().
+# Protected: prefix patterns status:*, origin:*, tier:*; and a set of exact
+# matches for lifecycle/maintainer workflow labels.
+_is_protected_label() {
+	local lbl="$1"
+	case "$lbl" in
+	status:* | origin:* | tier:*)
+		return 0
+		;;
+	persistent | needs-maintainer-review | not-planned | duplicate | wontfix | already-fixed | "good first issue" | "help wanted")
+		return 0
+		;;
+	esac
+	return 1
+}
+
 gh_create_label() {
 	local repo="$1" name="$2" color="$3" desc="$4"
 	gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force 2>/dev/null || true
@@ -558,6 +575,35 @@ cmd_enrich() {
 			ensure_labels_exist "$labels" "$repo"
 			_gh_edit_labels "add" "$repo" "$num" "$labels"
 		}
+		# Label reconciliation (GH#17402): remove stale tag-derived labels.
+		# Fetch current labels, skip protected ones, remove any that are no
+		# longer in the desired set derived from TODO.md tags.
+		local current_labels
+		current_labels=$(gh issue view "$num" --repo "$repo" --json labels \
+			--jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+		if [[ -n "$current_labels" ]]; then
+			local stale_labels=""
+			local _saved_ifs="$IFS"
+			IFS=','
+			for cur_lbl in $current_labels; do
+				[[ -z "$cur_lbl" ]] && continue
+				_is_protected_label "$cur_lbl" && continue
+				# Check if cur_lbl is in the desired labels set
+				local found=0
+				for desired_lbl in $labels; do
+					[[ "$cur_lbl" == "$desired_lbl" ]] && {
+						found=1
+						break
+					}
+				done
+				[[ "$found" -eq 0 ]] && stale_labels="${stale_labels:+$stale_labels,}$cur_lbl"
+			done
+			IFS="$_saved_ifs"
+			if [[ -n "$stale_labels" ]]; then
+				print_info "Removing stale labels from #$num: $stale_labels"
+				_gh_edit_labels "remove" "$repo" "$num" "$stale_labels"
+			fi
+		fi
 		if gh issue edit "$num" --repo "$repo" --title "$title" --body "$body" 2>/dev/null; then
 			print_success "Enriched #$num ($task_id)"
 			# Sync relationships (blocked-by, sub-issues) after enrichment (t1889)


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Add label reconciliation to `cmd_enrich()` in `issue-sync-helper.sh` so stale tag-derived labels are removed when tags are removed from TODO.md.

## Issue
Closes #17402

## Files Changed
- `.agents/scripts/issue-sync-helper.sh` — added `_is_protected_label()` helper and label reconciliation step in `cmd_enrich()`

## Implementation
Two changes to `issue-sync-helper.sh`:

1. **`_is_protected_label(lbl)`** (new helper, line ~117): Returns 0 if a label is system-managed and must not be touched by tag reconciliation. Protected patterns: `status:*`, `origin:*`, `tier:*` prefixes; exact matches: `persistent`, `needs-maintainer-review`, `not-planned`, `duplicate`, `wontfix`, `already-fixed`, `good first issue`, `help wanted`.

2. **Label reconciliation in `cmd_enrich()`** (after the existing `_gh_edit_labels "add"` call): Fetches current issue labels via `gh issue view --json labels`, iterates them, skips protected ones, and removes any that are not in the desired label set derived from `map_tags_to_labels()`. Uses the existing `_gh_edit_labels "remove"` path — no new helper needed.

## Testing
- Risk level: **Low** (shell script, no runtime state, no auth/payment/data paths)
- Self-assessed: logic verified by code review
- `shellcheck` passes with zero new errors or warnings (pre-existing SC1091/SC2016 info-level findings unchanged)

## Runtime Testing
`self-assessed` — shell script change with no runtime dependencies. The reconciliation path only calls `gh issue view` (read) and `_gh_edit_labels "remove"` (existing, tested path). No new API surface.

## Key Decisions
- `bug` is NOT in the protected list — it is tag-derived (`#bugfix` → `bug` via `map_tags_to_labels`) and should be reconcilable
- Protected list matches the issue spec exactly: prefix patterns + exact lifecycle/maintainer labels
- Reconciliation runs even when `$labels` is empty (task has no tags) — this correctly removes all non-protected labels if all tags are removed

---
[aidevops.sh](https://aidevops.sh) v3.6.94 plugin for [OpenCode](https://opencode.ai) v1.3.13 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automatic GitHub issue label management to preserve system-managed labels while removing stale, outdated labels during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->