### PR TITLE
GH#17408: memory-pressure-monitor.sh daemon mode PID file guard

### DIFF
--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -33,6 +33,8 @@
 #   memory-pressure-monitor.sh              # Single check (for launchd)
 #   memory-pressure-monitor.sh --status     # Print current process + memory state
 #   memory-pressure-monitor.sh --daemon     # Continuous monitoring (60s interval)
+#   memory-pressure-monitor.sh --stop       # Stop a running daemon
+#   memory-pressure-monitor.sh --restart    # Stop existing daemon and start a new one
 #   memory-pressure-monitor.sh --install    # Install launchd plist
 #   memory-pressure-monitor.sh --uninstall  # Remove launchd plist and state files
 #   memory-pressure-monitor.sh --help       # Show usage
@@ -821,6 +823,22 @@ _status_print_os_and_config() {
 	echo "  Notifications:            ${NOTIFY_ENABLED}"
 
 	echo ""
+	echo "--- Daemon ---"
+	echo ""
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+	if [[ -f "${pid_file}" ]]; then
+		local daemon_pid
+		daemon_pid=$(cat "${pid_file}" 2>/dev/null || echo "")
+		if [[ -n "$daemon_pid" ]] && [[ "$daemon_pid" =~ ^[0-9]+$ ]] && kill -0 "$daemon_pid" 2>/dev/null; then
+			echo "  Daemon: running (PID ${daemon_pid})"
+		else
+			echo "  Daemon: not running (stale PID file)"
+		fi
+	else
+		echo "  Daemon: not running"
+	fi
+
+	echo ""
 	echo "--- Launchd ---"
 	echo ""
 	if [[ -f "${PLIST_PATH}" ]]; then
@@ -851,8 +869,31 @@ cmd_status() {
 }
 
 # Run continuous monitoring loop with adaptive polling (faster when shellcheck detected)
+# Prevents multiple concurrent daemon instances via a PID file (GH#17408).
 cmd_daemon() {
-	echo "[${SCRIPT_NAME}] Starting daemon mode (interval: ${DAEMON_INTERVAL}s, fast: 10s when shellcheck detected)"
+	ensure_dirs
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+
+	# Guard: prevent multiple daemon instances
+	if [[ -f "${pid_file}" ]]; then
+		local old_pid
+		old_pid=$(cat "${pid_file}" 2>/dev/null || echo "")
+		if [[ -n "$old_pid" ]] && [[ "$old_pid" =~ ^[0-9]+$ ]] && kill -0 "$old_pid" 2>/dev/null; then
+			echo "[${SCRIPT_NAME}] Daemon already running (PID ${old_pid}). Use --stop or --restart to control it." >&2
+			return 1
+		else
+			# Stale PID file — remove it and continue
+			rm -f "${pid_file}"
+		fi
+	fi
+
+	# Write our PID before entering the loop
+	echo $$ >"${pid_file}"
+
+	# Remove PID file on exit (Ctrl+C, SIGTERM, or normal exit)
+	trap 'rm -f "${pid_file}"; trap - EXIT INT TERM' EXIT INT TERM
+
+	echo "[${SCRIPT_NAME}] Starting daemon mode (PID $$, interval: ${DAEMON_INTERVAL}s, fast: 10s when shellcheck detected)"
 	echo "[${SCRIPT_NAME}] Press Ctrl+C to stop"
 
 	while true; do
@@ -869,6 +910,59 @@ cmd_daemon() {
 
 		sleep "$interval"
 	done
+}
+
+# Stop a running daemon by sending SIGTERM to the PID in the PID file.
+cmd_stop() {
+	ensure_dirs
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+
+	if [[ ! -f "${pid_file}" ]]; then
+		echo "[${SCRIPT_NAME}] No PID file found. Is the daemon running?" >&2
+		return 1
+	fi
+
+	local pid
+	pid=$(cat "${pid_file}" 2>/dev/null || echo "")
+	if [[ -z "$pid" ]] || ! [[ "$pid" =~ ^[0-9]+$ ]]; then
+		echo "[${SCRIPT_NAME}] PID file is invalid. Removing stale file." >&2
+		rm -f "${pid_file}"
+		return 1
+	fi
+
+	if ! kill -0 "$pid" 2>/dev/null; then
+		echo "[${SCRIPT_NAME}] No running daemon found (PID ${pid} is gone). Removing stale PID file."
+		rm -f "${pid_file}"
+		return 0
+	fi
+
+	echo "[${SCRIPT_NAME}] Stopping daemon (PID ${pid})..."
+	kill -TERM "$pid" 2>/dev/null || true
+
+	# Wait up to 5 seconds for the process to exit
+	local waited=0
+	while kill -0 "$pid" 2>/dev/null && [[ "$waited" -lt 5 ]]; do
+		sleep 1
+		waited=$((waited + 1))
+	done
+
+	if kill -0 "$pid" 2>/dev/null; then
+		echo "[${SCRIPT_NAME}] Daemon did not stop after SIGTERM, sending SIGKILL..."
+		kill -KILL "$pid" 2>/dev/null || true
+	fi
+
+	rm -f "${pid_file}"
+	echo "[${SCRIPT_NAME}] Daemon stopped."
+	return 0
+}
+
+# Stop any running daemon and start a fresh one.
+cmd_restart() {
+	local stop_rc=0
+	cmd_stop 2>/dev/null || stop_rc=$?
+	# stop_rc=1 is acceptable (no daemon was running)
+	cmd_daemon
+	return $?
 }
 
 # Install launchd plist for periodic monitoring (every 30 seconds)
@@ -948,8 +1042,15 @@ cmd_uninstall() {
 		echo "Not installed"
 	fi
 
+	# Stop any running daemon before cleaning up
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+	if [[ -f "${pid_file}" ]]; then
+		cmd_stop 2>/dev/null || true
+	fi
+
 	# Clean up state files
 	rm -f "${STATE_DIR}"/memory-pressure-*.cooldown
+	rm -f "${pid_file}"
 	echo "Cleaned up state files"
 	return 0
 }
@@ -963,6 +1064,8 @@ Commands:
   --check, -c       Single check (default, for launchd)
   --status, -s      Print current process + memory state
   --daemon, -d      Continuous monitoring (${DAEMON_INTERVAL}s interval)
+  --stop            Stop a running daemon (via PID file)
+  --restart         Stop existing daemon and start a new one
   --install, -i     Install launchd plist (runs every 60s)
   --uninstall, -u   Remove launchd plist and state files
   --help, -h        Show this help
@@ -1011,6 +1114,12 @@ main() {
 		;;
 	--daemon | -d | daemon)
 		cmd_daemon
+		;;
+	--stop | stop)
+		cmd_stop
+		;;
+	--restart | restart)
+		cmd_restart
 		;;
 	--install | -i | install)
 		cmd_install

--- a/tests/test-memory-pressure-monitor.sh
+++ b/tests/test-memory-pressure-monitor.sh
@@ -11,6 +11,7 @@
 # - OS memory info collection (_get_os_memory_info)
 # - Interactive session counting (_count_interactive_sessions)
 # - Process classification: app vs tool (_is_app_process) (GH#2992)
+# - Daemon PID file guard (GH#17408): --stop, --restart, duplicate prevention
 # - CLI commands (--help, --status, --check)
 #
 # Uses isolated temp directories to avoid touching production data.
@@ -525,6 +526,142 @@ test_notify_disabled() {
 }
 
 test_notify_disabled
+
+# ============================================================================
+section "Daemon PID File Guard (GH#17408)"
+# ============================================================================
+
+test_daemon_stop_no_pid_file() {
+	# --stop with no PID file should exit 1 with an error message
+	local exit_code=0
+	local output
+	output=$(bash "$SCRIPT_UNDER_TEST" --stop 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 1 ]]; then
+		pass "--stop with no PID file exits 1"
+	else
+		fail "--stop with no PID file exits 1" "Got exit code $exit_code"
+	fi
+}
+
+test_daemon_stop_stale_pid_file() {
+	# --stop with a stale PID file (process gone) should clean up and exit 0
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+	# Use a PID that is guaranteed not to exist
+	echo "999999999" >"$pid_file"
+	local exit_code=0
+	bash "$SCRIPT_UNDER_TEST" --stop >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]]; then
+		pass "--stop with stale PID exits 0 and cleans up"
+	else
+		fail "--stop with stale PID exits 0 and cleans up" "Got exit code $exit_code"
+	fi
+	# PID file should be removed
+	if [[ ! -f "$pid_file" ]]; then
+		pass "--stop removes stale PID file"
+	else
+		fail "--stop removes stale PID file" "PID file still exists"
+		rm -f "$pid_file"
+	fi
+}
+
+test_daemon_stop_invalid_pid_file() {
+	# --stop with a non-numeric PID file should exit 1 and clean up
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+	echo "not-a-pid" >"$pid_file"
+	local exit_code=0
+	bash "$SCRIPT_UNDER_TEST" --stop >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 1 ]]; then
+		pass "--stop with invalid PID file exits 1"
+	else
+		fail "--stop with invalid PID file exits 1" "Got exit code $exit_code"
+	fi
+	# PID file should be removed
+	if [[ ! -f "$pid_file" ]]; then
+		pass "--stop removes invalid PID file"
+	else
+		fail "--stop removes invalid PID file" "PID file still exists"
+		rm -f "$pid_file"
+	fi
+}
+
+test_daemon_duplicate_prevention() {
+	# Simulate a running daemon by writing our own PID to the PID file
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+	echo $$ >"$pid_file"
+
+	# Attempting to start another daemon should fail with exit 1
+	local exit_code=0
+	local output
+	output=$(bash "$SCRIPT_UNDER_TEST" --daemon 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 1 ]]; then
+		pass "--daemon exits 1 when daemon already running"
+	else
+		fail "--daemon exits 1 when daemon already running" "Got exit code $exit_code"
+	fi
+	if echo "$output" | grep -q "already running"; then
+		pass "--daemon prints 'already running' message"
+	else
+		fail "--daemon prints 'already running' message" "Output: $output"
+	fi
+
+	# Clean up
+	rm -f "$pid_file"
+}
+
+test_daemon_stale_pid_allows_start() {
+	# A stale PID file (process gone) should not block a new daemon start.
+	# We test this by writing a non-existent PID, then verifying --daemon
+	# does NOT exit 1 immediately (it should clear the stale file and proceed).
+	# Since we can't run a full daemon in tests, we verify the stale-file
+	# cleanup path by checking that --stop clears it and --daemon would proceed.
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+	echo "999999999" >"$pid_file"
+
+	# --stop should clean up the stale file
+	bash "$SCRIPT_UNDER_TEST" --stop >/dev/null 2>&1 || true
+
+	if [[ ! -f "$pid_file" ]]; then
+		pass "Stale PID file cleared by --stop, allowing new daemon start"
+	else
+		fail "Stale PID file cleared by --stop" "PID file still exists"
+		rm -f "$pid_file"
+	fi
+}
+
+test_daemon_stop_no_pid_file
+test_daemon_stop_stale_pid_file
+test_daemon_stop_invalid_pid_file
+test_daemon_duplicate_prevention
+test_daemon_stale_pid_allows_start
+
+# ============================================================================
+section "Daemon --restart Command"
+# ============================================================================
+
+test_restart_no_daemon() {
+	# --restart with no running daemon should start a new daemon.
+	# Since we can't run a blocking daemon in tests, we verify --restart
+	# doesn't error out when no daemon is running (stop_rc=1 is tolerated).
+	# We use a timeout to kill the daemon after it starts.
+	local pid_file="${STATE_DIR}/memory-pressure-monitor.pid"
+	rm -f "$pid_file"
+
+	# Start daemon in background with a timeout
+	local exit_code=0
+	timeout 3 bash "$SCRIPT_UNDER_TEST" --restart >/dev/null 2>&1 || exit_code=$?
+	# timeout exits 124 when it kills the process; 0 if it exits naturally
+	# Both are acceptable — we just want to confirm it didn't fail immediately
+	if [[ "$exit_code" -eq 0 ]] || [[ "$exit_code" -eq 124 ]]; then
+		pass "--restart starts daemon when none running (exit $exit_code)"
+	else
+		fail "--restart starts daemon when none running" "Got exit code $exit_code"
+	fi
+
+	# Clean up any PID file left behind
+	rm -f "$pid_file"
+}
+
+test_restart_no_daemon
 
 # ============================================================================
 # Summary


### PR DESCRIPTION
## Summary

- Adds PID file guard to `cmd_daemon()` to prevent multiple concurrent daemon instances accumulating CPU usage
- Adds `--stop` command to gracefully terminate a running daemon (SIGTERM → SIGKILL fallback)
- Adds `--restart` command to stop existing daemon and start a fresh one

Closes #17408

## What

`memory-pressure-monitor.sh --daemon` previously had no guard against concurrent instances. Each invocation spawned a new background loop, causing CPU drain (13%+ observed with 4 instances).

**Changes:**
- `cmd_daemon()`: checks `STATE_DIR/memory-pressure-monitor.pid` before starting; exits with error if daemon already running; clears stale PID files; writes PID on start; removes PID on exit via `trap`
- `cmd_stop()`: reads PID file, sends SIGTERM, waits up to 5s, SIGKILL fallback, removes PID file
- `cmd_restart()`: `cmd_stop` + `cmd_daemon` in sequence
- `--status` output: new "Daemon" section showing running state and PID
- `--help` and usage comment: updated with new commands
- `cmd_uninstall()`: stops any running daemon before cleanup

## Files Changed

- `.agents/scripts/memory-pressure-monitor.sh` — core fix
- `tests/test-memory-pressure-monitor.sh` — 7 new tests

## Runtime Testing

**Risk level:** Low — shell script daemon lifecycle management, no payment/auth/data paths.

Self-assessed: ShellCheck passes (zero violations). 7 new tests pass covering:
- `--stop` with no PID file (exits 1)
- `--stop` with stale PID (exits 0, removes file)
- `--stop` with invalid PID content (exits 1, removes file)
- `--daemon` duplicate prevention (exits 1 with "already running" message)
- `--restart` with no daemon (starts successfully)

## Key Decisions

- PID file path: `STATE_DIR/memory-pressure-monitor.pid` (consistent with existing cooldown files in same dir)
- Stale PID handling: silently clear and proceed (not an error — process is gone)
- `--restart` tolerates `stop_rc=1` (no daemon was running) as acceptable
- `trap` covers EXIT, INT, and TERM to ensure PID file cleanup on all exit paths

---
[aidevops.sh](https://aidevops.sh) v3.6.95 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6