### PR TITLE
GH#17414: warn when deployed scripts differ from canonical source

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -96,6 +96,7 @@ Rules: `prompts/build.txt`.
 
 - **CLI**: `aidevops [init|update|status|repos|skills|features]`
 - **Scripts**: `~/.aidevops/agents/scripts/[service]-helper.sh [command] [account] [target]`
+- **Scripts (editing)**: `~/.aidevops/agents/scripts/` is a **deployed copy** — edits there are overwritten by `aidevops update` (every ~10 min). Edit the canonical source at `~/Git/aidevops/.agents/scripts/<name>.sh`, then run `cd ~/Git/aidevops && bash setup.sh --non-interactive` to deploy.
 - **Secrets**: `aidevops secret` (gopass preferred) or `~/.config/aidevops/credentials.sh` (600 perms)
 - **Subagent Index**: `subagent-index.toon`
 - **Domain Index**: `reference/domain-index.md` (30+ domain-to-subagent mappings; read on demand)

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -248,6 +248,48 @@ _deploy_agents_post_copy() {
 	return 0
 }
 
+# _warn_deployed_script_drift source_dir target_dir
+# Compares deployed scripts against canonical source and warns if any differ.
+# This catches the case where someone edited ~/.aidevops/agents/scripts/ directly
+# (those edits are overwritten by every deploy). Emits a warning listing drifted
+# files and the canonical source path to edit instead.
+# Non-fatal: always returns 0 so deployment proceeds.
+_warn_deployed_script_drift() {
+	local source_dir="$1"
+	local target_dir="$2"
+	local source_scripts="$source_dir/scripts"
+	local target_scripts="$target_dir/scripts"
+
+	# Only check if both directories exist and diff is available
+	if [[ ! -d "$source_scripts" || ! -d "$target_scripts" ]]; then
+		return 0
+	fi
+	if ! command -v diff &>/dev/null; then
+		return 0
+	fi
+
+	local -a drifted=()
+	local f bn
+	for f in "$target_scripts"/*.sh; do
+		[[ -f "$f" ]] || continue
+		bn=$(basename "$f")
+		local src="$source_scripts/$bn"
+		if [[ -f "$src" ]] && ! diff -q "$src" "$f" &>/dev/null; then
+			drifted+=("$bn")
+		fi
+	done
+
+	if [[ ${#drifted[@]} -gt 0 ]]; then
+		print_warning "Deployed scripts differ from canonical source (local edits will be overwritten):"
+		for bn in "${drifted[@]}"; do
+			print_warning "  $target_scripts/$bn"
+			print_warning "    → canonical: $source_scripts/$bn"
+		done
+		print_warning "To preserve changes: edit the canonical source and re-run setup.sh --non-interactive"
+	fi
+	return 0
+}
+
 deploy_aidevops_agents() {
 	print_info "Deploying aidevops agents to ~/.aidevops/agents/..."
 
@@ -278,6 +320,12 @@ deploy_aidevops_agents() {
 				plugin_namespaces+=("$safe_ns")
 			fi
 		done < <(jq -r '.plugins[].namespace // empty' "$plugins_file" 2>/dev/null)
+	fi
+
+	# Warn if deployed scripts have been locally modified (GH#17414).
+	# These edits will be overwritten — users must edit the canonical source.
+	if [[ -d "$target_dir" ]]; then
+		_warn_deployed_script_drift "$source_dir" "$target_dir"
 	fi
 
 	# Create backup if target exists (with rotation)


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What

Implements GH#17414 — two-layer fix to prevent silent loss of edits made to deployed scripts in `~/.aidevops/agents/scripts/`:

1. **Drift detection** (`setup-modules/agent-deploy.sh`): new `_warn_deployed_script_drift()` function runs before every deploy. Compares deployed `~/.aidevops/agents/scripts/*.sh` against canonical source `~/Git/aidevops/.agents/scripts/`. If any differ, emits a warning listing each drifted file and its canonical path, with instructions to edit the source instead.

2. **Documentation** (`.agents/AGENTS.md`): adds a "Scripts (editing)" bullet to the Quick Reference section, making the deployed-copy constraint visible to AI assistants and users reading the guide.

## Issue

Closes #17414

## Files Changed

- `setup-modules/agent-deploy.sh` — add `_warn_deployed_script_drift()` + call site in `deploy_aidevops_agents()`
- `.agents/AGENTS.md` — add canonical source note to Quick Reference

## Testing

**Risk level**: Low (docs + non-fatal warning path, no logic changes to deployment flow)

- ShellCheck: zero new violations (pre-existing SC2154 warnings from `setup_prompt` variables are unchanged)
- `_warn_deployed_script_drift` is non-fatal (always returns 0) — deployment proceeds regardless
- Guard conditions: skips if either scripts dir missing, or `diff` not available

## Runtime Testing

`self-assessed` — warning-only path, no state changes, no destructive operations.

---
[aidevops.sh](https://aidevops.sh) v3.6.95 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed agent scripts now generate warnings when they diverge from canonical source versions, alerting users to out-of-sync deployments.

* **Documentation**
  * Updated agent helper script guidance with explicit instructions on editing canonical sources and redeploying changes to avoid deployment overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->