### PR TITLE
GH#17415: add PID file guard to contribution-watch-helper.sh scan mode

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -20,6 +20,8 @@
 #   contribution-watch-helper.sh scan [--auto-draft]       Also create draft replies for items needing attention
 #                                                         Drafts stored in ~/.aidevops/.agent-workspace/draft-responses/
 #                                                         Use draft-response-helper.sh to review and approve (t1555)
+#   contribution-watch-helper.sh stop                      Stop a running scan (via PID file)
+#   contribution-watch-helper.sh restart                   Stop existing scan and start a new one
 #   contribution-watch-helper.sh status                    Show watched items and their state
 #   contribution-watch-helper.sh install                   Install launchd plist
 #   contribution-watch-helper.sh uninstall                 Remove launchd plist
@@ -53,6 +55,7 @@ source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
 STATE_FILE="${HOME}/.aidevops/cache/contribution-watch.json"
 REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 LOGFILE="${HOME}/.aidevops/logs/contribution-watch.log"
+PID_FILE="${HOME}/.aidevops/.pid/contribution-watch.pid"
 PLIST_LABEL="sh.aidevops.contribution-watch"
 PLIST_PATH="${HOME}/Library/LaunchAgents/${PLIST_LABEL}.plist"
 
@@ -144,12 +147,31 @@ _ensure_state_file() {
 	local state_dir
 	state_dir=$(dirname "$STATE_FILE")
 	mkdir -p "$state_dir" 2>/dev/null || true
+	mkdir -p "$(dirname "$PID_FILE")" 2>/dev/null || true
 
 	if [[ ! -f "$STATE_FILE" ]]; then
 		echo '{"last_scan":"","items":{}}' >"$STATE_FILE"
 		_log_info "Created new state file: $STATE_FILE"
 	fi
 	return 0
+}
+
+# Check whether a scan is already running via the PID file.
+# Returns 0 if a scan is running, 1 if not (stale PID file is cleaned up).
+_is_scan_running() {
+	if [[ ! -f "$PID_FILE" ]]; then
+		return 1
+	fi
+
+	local old_pid
+	old_pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
+	if [[ -n "$old_pid" ]] && [[ "$old_pid" =~ ^[0-9]+$ ]] && kill -0 "$old_pid" 2>/dev/null; then
+		return 0
+	fi
+
+	# Stale PID file — remove it
+	rm -f "$PID_FILE"
+	return 1
 }
 
 _read_state() {
@@ -956,12 +978,29 @@ _scan_maybe_auto_backfill() {
 cmd_scan() {
 	_scan_parse_args "$@"
 
+	_ensure_state_file
+
+	# Guard: prevent multiple concurrent scan instances (GH#17415).
+	# Check before prerequisites so the "already running" message is always shown.
+	if _is_scan_running; then
+		local running_pid
+		running_pid=$(cat "$PID_FILE" 2>/dev/null || echo "unknown")
+		echo -e "${YELLOW}[contribution-watch] Scan already running (PID ${running_pid}). Use 'stop' or 'restart' to control it.${NC}" >&2
+		_log_warn "Scan skipped — already running (PID ${running_pid})"
+		return 1
+	fi
+
 	_check_prerequisites || return 1
 
 	local username
 	username=$(_get_username) || return 1
 
-	_ensure_state_file
+	# Write our PID before starting work
+	echo $$ >"$PID_FILE"
+
+	# Remove PID file on exit (normal, Ctrl+C, or SIGTERM)
+	trap 'rm -f "$PID_FILE"; trap - EXIT INT TERM' EXIT INT TERM
+
 	_scan_init_globals
 
 	local last_scan
@@ -989,6 +1028,64 @@ cmd_scan() {
 	_scan_post_actions "$_SCAN_ARG_AUTO_DRAFT" "$_SCAN_ARG_BACKFILL" "$_SCAN_ARG_AUTO_BACKFILL"
 
 	return 0
+}
+
+# =============================================================================
+# Stop: stop a running scan via PID file
+# =============================================================================
+
+cmd_stop() {
+	mkdir -p "$(dirname "$PID_FILE")" 2>/dev/null || true
+
+	if [[ ! -f "$PID_FILE" ]]; then
+		echo "[contribution-watch] No PID file found. Is a scan running?" >&2
+		return 1
+	fi
+
+	local pid
+	pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
+	if [[ -z "$pid" ]] || ! [[ "$pid" =~ ^[0-9]+$ ]]; then
+		echo "[contribution-watch] PID file is invalid. Removing stale file." >&2
+		rm -f "$PID_FILE"
+		return 1
+	fi
+
+	if ! kill -0 "$pid" 2>/dev/null; then
+		echo "[contribution-watch] No running scan found (PID ${pid} is gone). Removing stale PID file."
+		rm -f "$PID_FILE"
+		return 0
+	fi
+
+	echo "[contribution-watch] Stopping scan (PID ${pid})..."
+	kill -TERM "$pid" 2>/dev/null || true
+
+	# Wait up to 5 seconds for the process to exit
+	local waited=0
+	while kill -0 "$pid" 2>/dev/null && [[ "$waited" -lt 5 ]]; do
+		sleep 1
+		waited=$((waited + 1))
+	done
+
+	if kill -0 "$pid" 2>/dev/null; then
+		echo "[contribution-watch] Scan did not stop after SIGTERM, sending SIGKILL..."
+		kill -KILL "$pid" 2>/dev/null || true
+	fi
+
+	rm -f "$PID_FILE"
+	echo "[contribution-watch] Scan stopped."
+	return 0
+}
+
+# =============================================================================
+# Restart: stop any running scan and start a new one
+# =============================================================================
+
+cmd_restart() {
+	local stop_rc=0
+	cmd_stop 2>/dev/null || stop_rc=$?
+	# stop_rc=1 is acceptable (no scan was running)
+	cmd_scan "$@"
+	return $?
 }
 
 # Classify a single status item into activity tiers and check if it needs reply.
@@ -1212,6 +1309,13 @@ cmd_uninstall() {
 	else
 		echo "No plist found at ${PLIST_PATH}"
 	fi
+
+	# Stop any running scan and clean up PID file
+	if [[ -f "$PID_FILE" ]]; then
+		cmd_stop 2>/dev/null || true
+		rm -f "$PID_FILE"
+	fi
+
 	return 0
 }
 
@@ -1229,6 +1333,8 @@ cmd_help() {
 	echo "  contribution-watch-helper.sh scan [--auto-draft]           Also create draft replies for items needing attention"
 	echo "                                                             Drafts stored in ~/.aidevops/.agent-workspace/draft-responses/"
 	echo "                                                             Use draft-response-helper.sh to review and approve"
+	echo "  contribution-watch-helper.sh stop                          Stop a running scan (via PID file)"
+	echo "  contribution-watch-helper.sh restart                       Stop existing scan and start a new one"
 	echo "  contribution-watch-helper.sh status                        Show watched items and their state"
 	echo "  contribution-watch-helper.sh install                       Install launchd plist"
 	echo "  contribution-watch-helper.sh uninstall                     Remove launchd plist"
@@ -1269,6 +1375,8 @@ main() {
 	case "$cmd" in
 	seed) cmd_seed "$@" ;;
 	scan) cmd_scan "$@" ;;
+	stop) cmd_stop "$@" ;;
+	restart) cmd_restart "$@" ;;
 	status) cmd_status "$@" ;;
 	install) cmd_install "$@" ;;
 	uninstall) cmd_uninstall "$@" ;;

--- a/tests/test-contribution-watch-pid-guard.sh
+++ b/tests/test-contribution-watch-pid-guard.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-contribution-watch-pid-guard.sh
+#
+# Unit tests for contribution-watch-helper.sh PID guard (GH#17415):
+# - stop with no PID file
+# - stop with stale PID file
+# - stop with invalid PID file
+# - scan duplicate prevention (PID guard)
+# - stale PID file allows new scan
+# - restart with no running scan
+#
+# Uses isolated temp directories to avoid touching production data.
+#
+# Usage: bash tests/test-contribution-watch-pid-guard.sh [--verbose]
+#
+# Exit codes: 0 = all pass, 1 = failures found
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_DIR/.agents/scripts/contribution-watch-helper.sh"
+
+# --- Test Framework ---
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+TOTAL_COUNT=0
+
+pass() {
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	return 0
+}
+
+fail() {
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
+	return 0
+}
+
+skip() {
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	return 0
+}
+
+section() {
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
+	return 0
+}
+
+# --- Isolated Test Environment ---
+TEST_DIR=$(mktemp -d)
+HOME_BACKUP="$HOME"
+export HOME="$TEST_DIR/home"
+mkdir -p "$HOME/.aidevops/.pid"
+mkdir -p "$HOME/.aidevops/logs"
+mkdir -p "$HOME/.aidevops/cache"
+mkdir -p "$HOME/.config/aidevops"
+
+# Minimal repos.json so the script doesn't error on missing file
+echo '{"initialized_repos":[],"git_parent_dirs":[]}' >"$HOME/.config/aidevops/repos.json"
+
+# Minimal state file so scan doesn't fail on missing state
+echo '{"last_scan":"2026-01-01T00:00:00Z","items":{}}' >"$HOME/.aidevops/cache/contribution-watch.json"
+
+PID_FILE_PATH="$HOME/.aidevops/.pid/contribution-watch.pid"
+
+trap 'HOME="$HOME_BACKUP"; rm -rf "$TEST_DIR"' EXIT
+
+# --- Prerequisite Check ---
+if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
+	echo "ERROR: Script not found or not executable: $SCRIPT_UNDER_TEST"
+	exit 1
+fi
+
+# ============================================================================
+section "Scan PID File Guard (GH#17415)"
+# ============================================================================
+
+test_stop_no_pid_file() {
+	# stop with no PID file should exit 1 with an error message
+	rm -f "$PID_FILE_PATH"
+	local exit_code=0
+	bash "$SCRIPT_UNDER_TEST" stop 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 1 ]]; then
+		pass "stop with no PID file exits 1"
+	else
+		fail "stop with no PID file exits 1" "Got exit code $exit_code"
+	fi
+	return 0
+}
+
+test_stop_stale_pid_file() {
+	# stop with a stale PID file (process gone) should clean up and exit 0
+	# Use a PID that is guaranteed not to exist
+	echo "999999999" >"$PID_FILE_PATH"
+	local exit_code=0
+	bash "$SCRIPT_UNDER_TEST" stop >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 0 ]]; then
+		pass "stop with stale PID exits 0 and cleans up"
+	else
+		fail "stop with stale PID exits 0 and cleans up" "Got exit code $exit_code"
+	fi
+	# PID file should be removed
+	if [[ ! -f "$PID_FILE_PATH" ]]; then
+		pass "stop removes stale PID file"
+	else
+		fail "stop removes stale PID file" "PID file still exists"
+		rm -f "$PID_FILE_PATH"
+	fi
+	return 0
+}
+
+test_stop_invalid_pid_file() {
+	# stop with a non-numeric PID file should exit 1 and clean up
+	echo "not-a-pid" >"$PID_FILE_PATH"
+	local exit_code=0
+	bash "$SCRIPT_UNDER_TEST" stop >/dev/null 2>&1 || exit_code=$?
+	if [[ "$exit_code" -eq 1 ]]; then
+		pass "stop with invalid PID file exits 1"
+	else
+		fail "stop with invalid PID file exits 1" "Got exit code $exit_code"
+	fi
+	# PID file should be removed
+	if [[ ! -f "$PID_FILE_PATH" ]]; then
+		pass "stop removes invalid PID file"
+	else
+		fail "stop removes invalid PID file" "PID file still exists"
+		rm -f "$PID_FILE_PATH"
+	fi
+	return 0
+}
+
+test_scan_duplicate_prevention() {
+	# Simulate a running scan by writing our own PID to the PID file
+	echo $$ >"$PID_FILE_PATH"
+
+	# Attempting to start another scan should fail with exit 1
+	local exit_code=0
+	local output
+	output=$(bash "$SCRIPT_UNDER_TEST" scan 2>&1) || exit_code=$?
+	if [[ "$exit_code" -eq 1 ]]; then
+		pass "scan exits 1 when scan already running"
+	else
+		fail "scan exits 1 when scan already running" "Got exit code $exit_code"
+	fi
+	if echo "$output" | grep -q "already running"; then
+		pass "scan prints 'already running' message"
+	else
+		fail "scan prints 'already running' message" "Output: $output"
+	fi
+
+	# Clean up
+	rm -f "$PID_FILE_PATH"
+	return 0
+}
+
+test_stale_pid_allows_new_scan() {
+	# A stale PID file (process gone) should not block a new scan.
+	# We verify the stale-file cleanup path: stop clears it.
+	echo "999999999" >"$PID_FILE_PATH"
+
+	# stop should clean up the stale file
+	bash "$SCRIPT_UNDER_TEST" stop >/dev/null 2>&1 || true
+
+	if [[ ! -f "$PID_FILE_PATH" ]]; then
+		pass "Stale PID file cleared by stop, allowing new scan start"
+	else
+		fail "Stale PID file cleared by stop" "PID file still exists"
+		rm -f "$PID_FILE_PATH"
+	fi
+	return 0
+}
+
+test_stop_no_pid_file
+test_stop_stale_pid_file
+test_stop_invalid_pid_file
+test_scan_duplicate_prevention
+test_stale_pid_allows_new_scan
+
+# ============================================================================
+section "Restart Command"
+# ============================================================================
+
+test_restart_no_running_scan() {
+	# restart with no running scan should not error on the stop phase
+	# (stop_rc=1 is tolerated). We can't run a full blocking scan in tests,
+	# so we verify restart doesn't fail when no scan is running.
+	rm -f "$PID_FILE_PATH"
+
+	# restart calls stop (which will exit 1 — no PID file) then scan.
+	# scan will fail because gh is not available in test env, but the
+	# important thing is it doesn't fail due to the stop phase.
+	local output
+	output=$(bash "$SCRIPT_UNDER_TEST" restart 2>&1) || true
+
+	# The output should NOT contain "already running" (that would mean
+	# the stop phase failed to clear a stale PID)
+	if ! echo "$output" | grep -q "already running"; then
+		pass "restart does not report 'already running' when no scan is running"
+	else
+		fail "restart does not report 'already running'" "Output: $output"
+	fi
+
+	# Clean up any PID file left by the restart attempt
+	rm -f "$PID_FILE_PATH"
+	return 0
+}
+
+test_restart_no_running_scan
+
+# ============================================================================
+section "Help Output"
+# ============================================================================
+
+test_help_includes_stop_restart() {
+	local output
+	output=$(bash "$SCRIPT_UNDER_TEST" help 2>&1)
+	if echo "$output" | grep -q "stop"; then
+		pass "help output includes 'stop' command"
+	else
+		fail "help output includes 'stop' command" "Output missing 'stop'"
+	fi
+	if echo "$output" | grep -q "restart"; then
+		pass "help output includes 'restart' command"
+	else
+		fail "help output includes 'restart' command" "Output missing 'restart'"
+	fi
+	return 0
+}
+
+test_help_includes_stop_restart
+
+# ============================================================================
+echo ""
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped (${TOTAL_COUNT} total)"
+echo ""
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
<!-- MERGE_SUMMARY -->
## What
Adds a PID file guard to `contribution-watch-helper.sh scan` to prevent multiple concurrent scan instances when launched via launchd `StartInterval`.

## Issue
Closes #17415

## Files Changed
- `.agents/scripts/contribution-watch-helper.sh` — PID guard implementation
- `tests/test-contribution-watch-pid-guard.sh` — 11 new tests (new file)

## Changes
- `PID_FILE` constant: `${HOME}/.aidevops/.pid/contribution-watch.pid`
- `_is_scan_running()`: checks if stored PID is alive; stale files auto-cleaned
- `cmd_scan()`: PID guard runs before prerequisites check so "already running" message is always shown; writes PID on start, trap cleans on EXIT/INT/TERM
- `cmd_stop()`: sends SIGTERM to scan PID, waits up to 5s, SIGKILL fallback
- `cmd_restart()`: stop + start in sequence
- `cmd_uninstall()`: now also stops any running scan and cleans PID file
- `_ensure_state_file()`: creates PID directory alongside state directory
- Updated usage comment, `cmd_help()`, and `main()` dispatch with new commands

## Testing
- **Risk level**: Low (shell script, no external state mutations)
- **Method**: self-assessed + unit tests
- 11 tests covering: stop with no PID file, stop with stale PID, stop with invalid PID, scan duplicate prevention, stale PID allows new scan, restart with no running scan, help output
- All 11 tests pass: `bash tests/test-contribution-watch-pid-guard.sh`
- ShellCheck: zero violations (SC1091 info pre-existing)

## Key Decisions
- PID guard check placed **before** `_check_prerequisites` so the "already running" message is always shown even when `gh` is not authenticated
- PID directory: `~/.aidevops/.pid/` (consistent with issue description; created by `_ensure_state_file`)
- Pattern matches GH#17408 (memory-pressure-monitor.sh) for consistency

---
[aidevops.sh](https://aidevops.sh) v3.6.95 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stop` command to halt a running scan operation.
  * Added `restart` command to restart the scan process.

* **Bug Fixes**
  * Implemented concurrency control to prevent multiple scans from running simultaneously.
  * Improved cleanup of stale state files on scan termination.

* **Tests**
  * Added comprehensive test suite validating scan start/stop/restart behavior and duplicate-scan prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->