### PR TITLE
GH#17422: fix zero-debt guard missing from _complexity_llm_sweep_due in pulse-wrapper.sh

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4148,6 +4148,13 @@ _complexity_llm_sweep_due() {
 	# Always update the count file
 	printf '%s\n' "$current_count" >"$COMPLEXITY_DEBT_COUNT_FILE"
 
+	# No sweep needed when debt is already zero — nothing to act on (GH#17422)
+	if [[ "$current_count" -eq 0 ]]; then
+		echo "[pulse-wrapper] Complexity LLM sweep: debt is zero, no sweep required" >>"$LOGFILE"
+		printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+		return 1
+	fi
+
 	# Sweep is due if debt count has not decreased (stalled or growing)
 	if [[ -n "$prev_count" && "$prev_count" =~ ^[0-9]+$ ]]; then
 		if [[ "$current_count" -lt "$prev_count" ]]; then


### PR DESCRIPTION
## Summary

- **Root cause**: `_complexity_llm_sweep_due()` in `pulse-wrapper.sh` was missing the zero-debt guard added to `complexity-scan-helper.sh` in GH#17396. When `current_count == 0` and `prev_count == 0`, the condition `0 < 0` is false, so the function falls through to "sweep due" — triggering a stall issue even though debt is fully cleared.
- **Fix**: Added early-exit guard after updating the count file: if `current_count == 0`, log "debt is zero, no sweep required" and return 1. Also updates `COMPLEXITY_LLM_SWEEP_LAST_RUN` to prevent immediate re-trigger on the next pulse cycle.
- **Scope**: Single function in `pulse-wrapper.sh`. The parallel fix in `complexity-scan-helper.sh sweep-check` (GH#17396) was correct but not propagated here.

## What

Added zero-debt guard to `_complexity_llm_sweep_due` in `.agents/scripts/pulse-wrapper.sh` (line ~4151):

```bash
# No sweep needed when debt is already zero — nothing to act on (GH#17422)
if [[ "$current_count" -eq 0 ]]; then
    echo "[pulse-wrapper] Complexity LLM sweep: debt is zero, no sweep required" >>"$LOGFILE"
    printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
    return 1
fi
```

## Issue

Closes #17422

## Files Changed

- `.agents/scripts/pulse-wrapper.sh` — 7 lines added

## Testing

- **Risk level**: Low (docs/config/agent prompt pattern — logic-only change in sweep detection)
- **Self-assessed**: ShellCheck clean on the modified function section (full file OOMs ShellCheck due to size)
- **Logic verification**: `current_count=0` → guard fires → returns 1 (not needed). `current_count=5, prev=5` → guard skipped → falls through to "sweep due". `current_count=3, prev=5` → guard skipped → "debt reduced" path returns 1.

## Key Decisions

- Placed the zero-debt guard **after** `printf '%s\n' "$current_count" >"$COMPLEXITY_DEBT_COUNT_FILE"` so the count file is always updated even when returning early. This matches the pattern in `complexity-scan-helper.sh`.
- Updated `COMPLEXITY_LLM_SWEEP_LAST_RUN` in the zero-debt path to reset the 6h interval, preventing the guard from being bypassed on the very next pulse cycle.

---
[aidevops.sh](https://aidevops.sh) v3.6.96 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized the automated code complexity analysis system to prevent unnecessary processing cycles when there is no pending work. This improvement reduces system resource consumption and enhances overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->