### PR TITLE
fix: improve detect_default_shell() with reliable system query

### DIFF
--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -26,17 +26,18 @@ detect_running_shell() {
 # Detect the user's default login shell from the system (not $SHELL env var,
 # which reflects the current shell, not the system default).
 detect_default_shell() {
+	local shell_path
+	shell_path=""
+
 	if [[ "$(uname)" == "Darwin" ]]; then
-		dscl . -read "/Users/$(whoami)" UserShell 2>/dev/null | awk '{print $2}'
+		shell_path=$(dscl . -read "/Users/$(whoami)" UserShell 2>/dev/null | awk 'NR==1 {print $2}' || true)
 	else
-		getent passwd "$(whoami)" 2>/dev/null | cut -d: -f7
-	fi | while IFS= read -r shell; do
-		[[ -n "$shell" ]] && basename "$shell" && break
-	done
-	# Fallback to $SHELL if system query failed
-	if [[ -z "${shell:-}" ]]; then
-		basename "${SHELL:-/bin/bash}"
+		shell_path=$(getent passwd "$(whoami)" 2>/dev/null | cut -d: -f7 || true)
 	fi
+
+	# Fallback to $SHELL if system query returned empty
+	[[ -z "$shell_path" ]] && shell_path="${SHELL:-/bin/bash}"
+	basename "$shell_path"
 	return 0
 }
 

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -23,9 +23,20 @@ detect_running_shell() {
 	return 0
 }
 
-# Detect the user's default login shell from $SHELL
+# Detect the user's default login shell from the system (not $SHELL env var,
+# which reflects the current shell, not the system default).
 detect_default_shell() {
-	basename "${SHELL:-/bin/bash}"
+	if [[ "$(uname)" == "Darwin" ]]; then
+		dscl . -read "/Users/$(whoami)" UserShell 2>/dev/null | awk '{print $2}'
+	else
+		getent passwd "$(whoami)" 2>/dev/null | cut -d: -f7
+	fi | while IFS= read -r shell; do
+		[[ -n "$shell" ]] && basename "$shell" && break
+	done
+	# Fallback to $SHELL if system query failed
+	if [[ -z "${shell:-}" ]]; then
+		basename "${SHELL:-/bin/bash}"
+	fi
 	return 0
 }
 


### PR DESCRIPTION
## Summary

`detect_default_shell()` used `$SHELL` env var which reflects the *current* shell, not the system default. This could be stale or wrong after terminal config changes.

Fix: query the system directly instead:
- macOS: `dscl . -read "/Users/$(whoami)" UserShell`
- Linux: `getent passwd "$(whoami)" | cut -d: -f7`
- Falls back to `$SHELL` if system query fails

## Testing

- [x] ShellCheck: zero violations
- [x] `dscl` returns `/bin/bash` correctly on this system
- [ ] Verify detection matches `dscl`/`getent` output on your system

---
[aidevops.sh](https://aidevops.sh) v3.6.96 plugin for [OpenCode](https://opencode.ai) v1.3.15 with big-pickle spent 7d 4h and 10,737 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell detection during setup: the installer now queries the system account configuration (with platform-aware lookups) to determine the user's configured login shell, falling back to environment-based values if needed. This yields more accurate shell selection on macOS and Linux during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->