### PR TITLE
GH#17414: revert script preservation from deploy pipeline (PR #17421)

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -250,8 +250,9 @@ _deploy_agents_post_copy() {
 
 # _warn_deployed_script_drift source_dir target_dir
 # Compares deployed scripts against canonical source and warns if any differ.
-# Local edits in ~/.aidevops/agents/scripts/ are PRESERVED on next deploy (GH#17414).
-# This warning is informational only — deployment proceeds regardless.
+# This catches the case where someone edited ~/.aidevops/agents/scripts/ directly
+# (those edits are overwritten by every deploy). Emits a warning listing drifted
+# files and the canonical source path to edit instead.
 # Non-fatal: always returns 0 so deployment proceeds.
 _warn_deployed_script_drift() {
 	local source_dir="$1"
@@ -279,12 +280,12 @@ _warn_deployed_script_drift() {
 	done
 
 	if [[ ${#drifted[@]} -gt 0 ]]; then
-		print_warning "Deployed scripts differ from canonical source (local edits are preserved on next deploy):"
+		print_warning "Deployed scripts differ from canonical source (local edits will be overwritten):"
 		for bn in "${drifted[@]}"; do
 			print_warning "  $target_scripts/$bn"
 			print_warning "    → canonical: $source_scripts/$bn"
 		done
-		print_warning "Local edits survive auto-update. To push edits upstream: PR to canonical source."
+		print_warning "To preserve changes: edit the canonical source and re-run setup.sh --non-interactive"
 	fi
 	return 0
 }
@@ -376,16 +377,6 @@ deploy_aidevops_agents() {
 			cp -a "$target_dir/$pdir" "$staging_dir/$pdir" 2>/dev/null || true
 		fi
 	done
-
-	# Restore local script edits: only copy scripts where the old target's version
-	# is NEWER (user edited them) AND the script still exists in the canonical
-	# source (--existing prevents resurrecting deleted scripts). Skip entirely
-	# in clean mode — the user explicitly wants a fresh deployment. (GH#17414)
-	if [[ "${CLEAN_MODE:-false}" != "true" && -d "$target_dir/scripts" && -d "$staging_dir/scripts" ]]; then
-		if command -v rsync &>/dev/null; then
-			rsync -a --update --existing "$target_dir/scripts/" "$staging_dir/scripts/" 2>/dev/null || true
-		fi
-	fi
 
 	# Atomic swap: mv is atomic on the same filesystem (POSIX rename())
 	if [[ -d "$target_dir" ]]; then


### PR DESCRIPTION
## Summary

- Reverts the `rsync --update --existing` script preservation logic added in PR #17421
- Restores the deploy pipeline's core invariant: **deployed = canonical source, always**
- Retains the legitimate `INSTALL_DIR` path fix for OpenCode from the same PR

## Why

PR #17421 implemented an approach that the maintainer-approved triage on GH#17414 explicitly rejected. The issue was already correctly resolved by PR #17417 (documentation + drift warnings).

The script preservation approach:
1. Breaks the deploy pipeline's contract (deployed copy should always match canonical)
2. Uses mtime-based `rsync --update` which is fragile (clock skew, `touch`, silent drift)
3. Has no conflict resolution when canonical updates AND local edits exist
4. Contradicts the designed extension point (`custom/` directory) for user scripts

## What's kept

The `INSTALL_DIR` path fix for OpenCode (lines 31, 43) is a legitimate bugfix and is retained.

Closes #17421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified deployment process to overwrite locally edited scripts in the deployment directory. Users should now edit scripts at the canonical source location and re-run `setup.sh --non-interactive` to apply changes, as local modifications will be replaced during the next deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->