### PR TITLE
GH#17427: parse probe_provider HTTP code correctly

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -822,7 +822,9 @@ probe_provider() {
 
 	# Split response into headers and body
 	local http_code headers body
-	http_code=$(echo "$response" | tail -1)
+	# _probe_build_request appends two trailer lines: http_code then time_total.
+	# The HTTP status is therefore the penultimate line, not the final one.
+	http_code=$(echo "$response" | tail -2 | head -1)
 	headers=$(echo "$response" | sed '/^$/q' | head -50)
 	# head -n -2 is GNU-only (unsupported on macOS); use awk to drop last 2 lines
 	body=$(echo "$response" | sed '1,/^$/d' | awk 'NR>2{print buf[NR%2]} {buf[NR%2]=$0}')

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -475,6 +475,52 @@ else
 fi
 
 # ============================================================
+# SECTION 11: API Probe Parsing Regression (GH#17427)
+# ============================================================
+section "API Probe Parsing Regression (GH#17427)"
+
+# Source a temp copy without the final main "$@" line so helper functions can be
+# called directly while preserving SCRIPT_DIR-relative sourcing.
+probe_helper_copy=$(mktemp "$REPO_DIR/.agents/scripts/model-availability-helper.test.XXXXXX")
+sed '$d' "$HELPER" >"$probe_helper_copy"
+probe_parse_output=$(bash -c '
+	source "$1" 2>/dev/null || exit 1
+	response=$'"'"'HTTP/2 200\ncontent-type: application/json\n\n{"data":[{"id":"m1"},{"id":"m2"}]}\n200\n0.209059'"'"'
+	http_code=$(echo "$response" | tail -2 | head -1)
+	body=$(echo "$response" | sed "1,/^$/d" | awk "NR>2{print buf[NR%2]} {buf[NR%2]=\$0}")
+	parsed=$(_probe_parse_http_response "anthropic" "$http_code" "$body" true)
+	printf "%s\n" "$http_code"
+	printf "%s\n" "$body"
+	printf "%s\n" "$parsed"
+' bash "$probe_helper_copy" 2>/dev/null) || probe_parse_output=""
+rm -f "$probe_helper_copy"
+
+probe_http_code=$(printf '%s\n' "$probe_parse_output" | sed -n '1p')
+probe_body=$(printf '%s\n' "$probe_parse_output" | sed -n '2p')
+probe_status=$(printf '%s\n' "$probe_parse_output" | sed -n '3p')
+probe_models=$(printf '%s\n' "$probe_parse_output" | sed -n '5p')
+probe_exit=$(printf '%s\n' "$probe_parse_output" | sed -n '6p')
+
+if [[ "$probe_http_code" == "200" ]]; then
+	pass "probe_provider parses penultimate line as http_code (GH#17427)"
+else
+	fail "probe_provider parses penultimate line as http_code (GH#17427)" "Got: ${probe_http_code:-<empty>}"
+fi
+
+if [[ "$probe_body" == '{"data":[{"id":"m1"},{"id":"m2"}]}' ]]; then
+	pass "probe_provider body extraction drops curl trailer lines"
+else
+	fail "probe_provider body extraction drops curl trailer lines" "Got: ${probe_body:-<empty>}"
+fi
+
+if [[ "$probe_status" == "healthy" && "$probe_models" == "2" && "$probe_exit" == "0" ]]; then
+	pass "probe_provider parses HTTP 200 API probe as healthy (GH#17427)"
+else
+	fail "probe_provider parses HTTP 200 API probe as healthy (GH#17427)" \
+		"status=${probe_status:-<empty>} models=${probe_models:-<empty>} exit=${probe_exit:-<empty>}"
+fi
+
+# ============================================================
 # SUMMARY
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary
- parse the penultimate curl trailer line as `http_code` in `probe_provider`, preserving the existing body extraction logic
- add a GH#17427 regression test that exercises the API probe parsing path with a mocked `http_code` + `time_total` trailer
- document verification evidence and note pre-existing unrelated failures in the broader helper test suite

## Testing
- `shellcheck -S error .agents/scripts/model-availability-helper.sh tests/test-model-availability.sh`
- targeted probe parsing check using a temp sourced copy of `model-availability-helper.sh` returned `200`, parsed the JSON body, and produced `healthy / 2 / 0`
- `bash tests/test-model-availability.sh --verbose` (GH#17427 regression assertions passed; suite still has pre-existing unrelated failures around missing `supervisor-helper.sh`, opencode help text, and GH#12470 validation expectations)

## Runtime Testing
- Risk: low
- Classification: script bugfix + regression test
- Verification: self-assessed via shellcheck plus targeted parsing execution and verbose regression assertions

Closes #17427

---
[aidevops.sh](https://aidevops.sh) v3.6.97 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.4 spent 2h 15m and 248,012 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP response parsing to correctly interpret API provider availability checks.

* **Tests**
  * Added regression test suite for API probe response parsing to prevent future parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->