### PR TITLE
GH#17427: fix probe_provider http_code extraction reading time_total

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -641,7 +641,7 @@ _probe_build_request() {
 		return 1
 	fi
 
-	local curl_args="-s -w '\n%{http_code}\n%{time_total}' --max-time $PROBE_TIMEOUT -D -"
+	local curl_args="-s -w '\n%{http_code}' --max-time $PROBE_TIMEOUT -D -"
 	case "$provider" in
 	anthropic)
 		curl_args="$curl_args -H 'x-api-key: ${api_key}' -H 'anthropic-version: 2023-06-01'"
@@ -824,8 +824,8 @@ probe_provider() {
 	local http_code headers body
 	http_code=$(echo "$response" | tail -1)
 	headers=$(echo "$response" | sed '/^$/q' | head -50)
-	# head -n -2 is GNU-only (unsupported on macOS); use awk to drop last 2 lines
-	body=$(echo "$response" | sed '1,/^$/d' | awk 'NR>2{print buf[NR%2]} {buf[NR%2]=$0}')
+	# Drop the last line (http_code) from the body after the blank-line header separator
+	body=$(echo "$response" | sed '1,/^$/d' | awk 'NR>1{print prev} {prev=$0}')
 
 	_parse_rate_limits "$provider" "$headers"
 

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -475,6 +475,74 @@ else
 fi
 
 # ============================================================
+# SECTION 11: Curl write-out format / http_code extraction (GH#17427)
+# ============================================================
+section "Curl Write-Out Format (GH#17427)"
+
+# Verify _probe_build_request uses only %{http_code} (no %{time_total})
+# The bug was: -w '\n%{http_code}\n%{time_total}' caused tail -1 to read
+# time_total (e.g. 0.209059) as the http_code, making all API probes unhealthy.
+if grep -q 'time_total' "$HELPER"; then
+	fail "curl write-out still contains time_total (GH#17427)" \
+		"_probe_build_request should use -w '\\n%{http_code}' only"
+else
+	pass "curl write-out does not contain time_total (GH#17427)"
+fi
+
+# Verify the write-out format is exactly '\n%{http_code}' (single value)
+if grep -q "\\\\n%{http_code}'" "$HELPER"; then
+	pass "curl write-out ends with http_code (no trailing values)"
+else
+	fail "curl write-out format unexpected" \
+		"Expected -w '\\n%{http_code}' in _probe_build_request"
+fi
+
+# Verify body extraction drops exactly 1 trailing line (not 2)
+# After removing time_total, only http_code is appended, so body awk
+# should drop 1 line. The old pattern was NR>2 (dropping 2 lines).
+if grep -q 'NR>2{print buf' "$HELPER"; then
+	fail "body extraction still drops 2 trailing lines (GH#17427)" \
+		"Should drop 1 line now that time_total is removed"
+else
+	pass "body extraction does not use old 2-line drop pattern"
+fi
+
+if grep -q "NR>1{print prev}" "$HELPER"; then
+	pass "body extraction uses 1-line drop pattern (GH#17427)"
+else
+	fail "body extraction missing 1-line drop awk pattern" \
+		"Expected: awk 'NR>1{print prev} {prev=\$0}'"
+fi
+
+# Simulate the http_code extraction logic to verify correctness.
+# Build a mock curl response: headers + blank line + JSON body + http_code.
+# Use plain \n (no \r) to match how the production sed patterns work.
+mock_response=$(printf 'HTTP/1.1 200 OK\nContent-Type: application/json\n\n{"data":[{"id":"model-1"}]}\n200')
+mock_http_code=$(echo "$mock_response" | tail -1)
+if [[ "$mock_http_code" == "200" ]]; then
+	pass "mock: tail -1 extracts http_code correctly (got 200)"
+else
+	fail "mock: tail -1 extracts wrong value" "Expected 200, got: $mock_http_code"
+fi
+
+# Verify body extraction with the new awk pattern
+mock_body=$(echo "$mock_response" | sed '1,/^$/d' | awk 'NR>1{print prev} {prev=$0}')
+if echo "$mock_body" | grep -q '"data"'; then
+	pass "mock: body extraction preserves JSON content"
+else
+	fail "mock: body extraction lost JSON content" "Got: $mock_body"
+fi
+
+# Verify the old bug scenario: if time_total were still present, tail -1 would get it
+mock_old_response=$(printf 'HTTP/1.1 200 OK\n\n{"data":[]}\n200\n0.209059')
+mock_old_code=$(echo "$mock_old_response" | tail -1)
+if [[ "$mock_old_code" == "0.209059" ]]; then
+	pass "mock: confirms old format would read time_total as http_code (bug scenario)"
+else
+	fail "mock: old format test unexpected" "Got: $mock_old_code"
+fi
+
+# ============================================================
 # SUMMARY
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

- **Bug**: `_probe_build_request()` appended both `%{http_code}` and `%{time_total}` to curl's write-out format, but `probe_provider()` used `tail -1` to extract the HTTP status code — which returned `time_total` (e.g. `0.209059`) instead of `http_code` (`200`). This caused all API-backed providers (anthropic, openai, google, etc.) to always report `unhealthy`.
- **Fix**: Removed `%{time_total}` from the `-w` format string (duration is already computed via `date +%s%N`), and updated the body extraction awk to drop 1 trailing line instead of 2.
- **Tests**: Added 7 new tests in Section 11 validating the curl write-out format, http_code extraction, body preservation, and the old bug scenario.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/model-availability-helper.sh:644` | Remove `%{time_total}` from curl `-w` format |
| `.agents/scripts/model-availability-helper.sh:828` | Update awk to drop 1 line instead of 2 |
| `tests/test-model-availability.sh` | Add Section 11: Curl Write-Out Format (GH#17427) |

Closes #17427

---
[aidevops.sh](https://aidevops.sh) v3.6.97 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of model availability detection by fixing HTTP status code extraction.

* **Tests**
  * Added comprehensive tests for model availability detection functionality to ensure reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->