### PR TITLE
t1891: add customization guide and contribution boundary routing

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -96,7 +96,7 @@ Rules: `prompts/build.txt`.
 
 - **CLI**: `aidevops [init|update|status|repos|skills|features]`
 - **Scripts**: `~/.aidevops/agents/scripts/[service]-helper.sh [command] [account] [target]`
-- **Scripts (editing)**: `~/.aidevops/agents/scripts/` is a **deployed copy** — edits there are overwritten by `aidevops update` (every ~10 min). Edit the canonical source at `~/Git/aidevops/.agents/scripts/<name>.sh`, then run `cd ~/Git/aidevops && bash setup.sh --non-interactive` to deploy.
+- **Scripts (editing)**: `~/.aidevops/agents/scripts/` is a **deployed copy** — edits there are overwritten by `aidevops update` (every ~10 min). For personal scripts, use `~/.aidevops/agents/custom/scripts/` (survives updates). To fix framework scripts, edit `~/Git/aidevops/.agents/scripts/<name>.sh` and run `setup.sh --non-interactive`. See `reference/customization.md`.
 - **Secrets**: `aidevops secret` (gopass preferred) or `~/.config/aidevops/credentials.sh` (600 perms)
 - **Subagent Index**: `subagent-index.toon`
 - **Domain Index**: `reference/domain-index.md` (30+ domain-to-subagent mappings; read on demand)
@@ -240,9 +240,11 @@ Rules: `prompts/build.txt`. Secrets: `gopass` preferred; `credentials.sh` plaint
 ## Working Directories
 
 Tree: `prompts/build.txt`. Agent tiers:
-- `custom/` — user's permanent private agents (survives updates)
+- `custom/` — user's permanent private agents and scripts (survives updates)
 - `draft/` — R&D, experimental (survives updates)
 - root — shared agents (overwritten on update)
+
+**Do not edit deployed scripts or agents directly** — use `custom/` for personal tooling. Full guide: `reference/customization.md`.
 
 Lifecycle: `tools/build-agent/build-agent.md`.
 

--- a/.agents/reference/customization.md
+++ b/.agents/reference/customization.md
@@ -1,0 +1,128 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Customization Guide
+
+aidevops is an opinionated framework. The deployed directory (`~/.aidevops/agents/`) is a build artifact that is overwritten on every update. This guide explains how to customize without fighting the update cycle.
+
+## Extension Points
+
+| Directory | Purpose | Survives updates | Survives clean mode |
+|-----------|---------|:---:|:---:|
+| `~/.aidevops/agents/custom/` | Your permanent personal agents and scripts | Yes | Yes |
+| `~/.aidevops/agents/draft/` | R&D, experimental agents (may be promoted) | Yes | Yes |
+| `~/.aidevops/agents/` (root) | Shared framework agents | No | No |
+| `~/.aidevops/agents/scripts/` | Deployed framework scripts | No | No |
+
+## Custom Scripts
+
+To add a personal script that survives updates:
+
+```bash
+mkdir -p ~/.aidevops/agents/custom/scripts
+cp my-script.sh ~/.aidevops/agents/custom/scripts/
+chmod +x ~/.aidevops/agents/custom/scripts/my-script.sh
+```
+
+Run it: `~/.aidevops/agents/custom/scripts/my-script.sh`
+
+To override a framework script's behaviour without modifying the original, create a wrapper in `custom/scripts/` that calls the framework script with your preferred options or pre/post-processing.
+
+## Custom Agents
+
+To add a personal agent:
+
+```bash
+mkdir -p ~/.aidevops/agents/custom
+```
+
+Create `~/.aidevops/agents/custom/my-agent.md` with standard frontmatter:
+
+```yaml
+---
+name: my-agent
+description: My personal agent for X
+tools:
+  read: true
+  bash: true
+---
+
+Your agent instructions here.
+```
+
+Custom agents are discoverable by the framework like any other agent.
+
+## Draft Agents
+
+`draft/` is for experimental work — agents you're developing or testing before deciding whether to contribute upstream:
+
+```bash
+mkdir -p ~/.aidevops/agents/draft
+```
+
+The difference from `custom/` is intent: `custom/` is permanent personal tooling; `draft/` is work-in-progress that may be promoted to the shared framework or discarded.
+
+## What NOT to Do
+
+**Do not edit files in `~/.aidevops/agents/scripts/`** — these are deployed copies overwritten by every `aidevops update` (runs automatically every ~10 minutes). Your edits will be silently lost.
+
+**Do not edit files in `~/.aidevops/agents/` (root level)** — same reason. These are framework agents deployed from the canonical source.
+
+If you see a drift warning during deployment:
+
+```text
+Deployed scripts differ from canonical source (local edits will be overwritten):
+  ~/.aidevops/agents/scripts/some-script.sh
+    -> canonical: ~/Git/aidevops/.agents/scripts/some-script.sh
+```
+
+This means someone (or an AI session) edited the deployed copy. The fix is:
+
+1. **Personal need?** Move your version to `custom/scripts/`
+2. **Bug fix?** Edit the canonical source at `~/Git/aidevops/.agents/scripts/` and run `setup.sh --non-interactive`
+3. **Framework improvement?** Fork, edit canonical source, open a PR (see "Contributing vs Customizing" below)
+
+## Contributing vs Customizing
+
+Before filing an issue or opening a PR, ask: **is this a personal preference or a framework gap?**
+
+| Signal | Action |
+|--------|--------|
+| "I want this script to work differently for my workflow" | Customize locally (`custom/`) |
+| "This script has a bug that affects everyone" | File a bug report or fix via PR |
+| "The framework should support X" | File a feature request (maintainers assess fit) |
+| "The framework's architecture should change" | Discuss in an issue first — architectural decisions require maintainer approval |
+
+### What the framework accepts from everyone
+
+- Bug reports (especially destructive behaviour)
+- Bug fixes via PR
+- Documentation improvements
+
+### What requires maintainer approval before implementation
+
+- Adding integrations with third-party tools
+- Changing default behaviours or configuration structure
+- Adding new dependencies
+- Modifying the agent framework architecture (deploy pipeline, update cycle, directory structure)
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#scope-of-contributions) for the full policy.
+
+### For AI sessions
+
+If your AI assistant encounters a limitation or unexpected behaviour:
+
+1. **Check if `custom/` solves it** — most "I want it to work differently" needs are customization, not bugs
+2. **Use `/log-issue-aidevops`** — it includes an architectural alignment check that routes customization needs away from the issue tracker
+3. **Do not implement architectural changes** without maintainer approval, even if the change seems obviously beneficial
+
+## Configuration Files
+
+User configuration files (`~/.config/aidevops/`) are never overwritten by updates:
+
+- `repos.json` — registered repositories
+- `credentials.sh` — secrets (600 permissions)
+- `plugins.json` — enabled plugins
+- `settings.json` — user preferences
+
+These are the correct place for per-user settings. See `reference/configuration.md` and `reference/settings.md`.

--- a/.agents/scripts/commands/log-issue-aidevops.md
+++ b/.agents/scripts/commands/log-issue-aidevops.md
@@ -49,7 +49,21 @@ gh issue list -R marcusquinn/aidevops --state all --search "KEYWORDS" --limit 10
 
 If duplicates found, present them and ask: add comment to existing / create new / review first.
 
-### Step 3.5: Architectural Alignment (enhancements only)
+### Step 3.5: Customization Routing
+
+Before filing, check whether this is a customization need rather than a framework issue:
+
+| User says | Likely route |
+|-----------|-------------|
+| "My script edits get overwritten" | Customization — use `~/.aidevops/agents/custom/scripts/` |
+| "I want X to behave differently" | Customization — create a wrapper in `custom/` |
+| "I added an agent but it disappeared" | Customization — use `custom/` or `draft/` (root agents are overwritten) |
+| "This script is broken for everyone" | Bug — file an issue |
+| "The framework should support X" | Enhancement — file an issue (maintainers assess fit) |
+
+If the need is customization, explain the `custom/` directory and link to `reference/customization.md`. Do not file an issue.
+
+### Step 3.6: Architectural Alignment (enhancements only)
 
 Skip for bugs with clear reproduction steps — bugs are observed failures and belong in the tracker.
 

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -285,7 +285,8 @@ _warn_deployed_script_drift() {
 			print_warning "  $target_scripts/$bn"
 			print_warning "    → canonical: $source_scripts/$bn"
 		done
-		print_warning "To preserve changes: edit the canonical source and re-run setup.sh --non-interactive"
+		print_warning "To keep personal scripts: use ~/.aidevops/agents/custom/scripts/"
+		print_warning "To fix the canonical source: edit ~/Git/aidevops/.agents/scripts/ and re-run setup.sh"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

- Add `reference/customization.md` — explains `custom/`, `draft/`, custom scripts, and when to customize locally vs. propose upstream
- Update drift warning in `agent-deploy.sh` to point users to `custom/scripts/` instead of just saying "edits will be overwritten"
- Revert PR #17421 rsync script preservation logic (supersedes PR #17429)
- Add customization routing step to `/log-issue-aidevops` (Step 3.5) that triages "my edits got lost" as a customization need, not a bug
- Update AGENTS.md Quick Reference and Working Directories sections with pointers to the new guide

## Why

PR #17421 changed the deploy pipeline architecture to preserve user-edited scripts. This was the wrong fix — the root cause was that users (and their AI sessions) didn't know about `custom/` as the designed extension point. This PR fills that documentation gap so the issue doesn't recur.

The chain that led to PR #17421:
1. User's AI edited deployed scripts (no guidance pointing to `custom/`)
2. Edits got overwritten → filed as bug (no routing from "my edits are lost" to "use `custom/`")
3. Non-collaborator's AI implemented a "fix" (`/log-issue-aidevops` didn't route as customization need)

Each of these gaps is now addressed.

## Files changed

| File | Change |
|------|--------|
| `.agents/reference/customization.md` | **New** — full customization guide |
| `setup-modules/agent-deploy.sh` | Revert #17421 + improved drift warning mentioning `custom/` |
| `.agents/scripts/commands/log-issue-aidevops.md` | New Step 3.5 customization routing table |
| `.agents/AGENTS.md` | Quick Reference and Working Directories updated |

## Runtime Testing

- **Testing level**: `self-assessed` — documentation + deploy script messaging changes, no runtime behaviour change

## Supersedes

This PR supersedes PR #17429 (the standalone revert). If this merges first, #17429 can be closed.

Closes #17432


---
[aidevops.sh](https://aidevops.sh) v3.6.97 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 14m and 17,796 tokens on this with the user in an interactive session.