### PR TITLE
GH#17428: fix has_open_pr() false positives from version strings

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -740,6 +740,16 @@ has_open_pr() {
 		if [[ "$pr_count" -gt 0 ]]; then
 			pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
 			if [[ -n "$pr_number" ]]; then
+				# Verify the PR body contains an exact close reference for this issue.
+				# GitHub search is full-text: a PR with "Closes #621" and "v3.5.670"
+				# would falsely match issue #670. Post-filter with exact regex.
+				local pr_body
+				pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null) || pr_body=""
+				# Match: keyword + optional whitespace + #NNN or owner/repo#NNN at word boundary
+				local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^0-9]|$)"
+				if ! printf '%s' "$pr_body" | grep -iqE "$close_pattern"; then
+					continue
+				fi
 				printf 'merged PR #%s references issue #%s via "%s" keyword\n' "$pr_number" "$issue_number" "$keyword"
 			else
 				printf 'merged PR references issue #%s via "%s" keyword\n' "$issue_number" "$keyword"


### PR DESCRIPTION
## Summary

- **Bug**: `has_open_pr()` in `dispatch-dedup-helper.sh` uses GitHub full-text search (`in:body`) which matches version strings (e.g., `v3.5.670`) as issue references (`#670`), causing false-positive dedup blocks that silently prevent legitimate dispatch.
- **Fix**: After finding a candidate merged PR via search, fetches the PR body and verifies it contains an exact close reference (e.g., `Closes #670`) using a case-insensitive regex. False positives fall through to the next keyword iteration instead of returning early.
- **Scope**: +10 lines in a single function — no architectural changes.

## Test scenario

A PR body containing `Closes #621` and `v3.5.670` should **not** match as evidence for issue `#670`. Before this fix, it would. After this fix, the regex requires the close keyword to be immediately adjacent to `#670`.

Closes #17428

---
[aidevops.sh](https://aidevops.sh) v3.6.99 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 2m and 4,147 tokens on this with the user in an interactive session.