### PR TITLE
GH#17438: fix systemd oneshot service kills background workers on exit (KillMode=control-group default)

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -460,6 +460,7 @@ After=network.target
 
 [Service]
 Type=oneshot
+KillMode=process
 ExecStart=/bin/bash ${wrapper_script}
 ${_env_lines}StandardOutput=append:${HOME}/.aidevops/logs/pulse-wrapper.log
 StandardError=append:${HOME}/.aidevops/logs/pulse-wrapper.log


### PR DESCRIPTION
## Summary

Fixes the systemd `KillMode=control-group` default that kills all background workers when `pulse-wrapper.sh` exits.

## What

Added `KillMode=process` to the `[Service]` section in `setup-modules/schedulers.sh` line 463.

## Why

Systemd's default `KillMode=control-group` sends SIGTERM to all processes in the service cgroup when the main process exits. This kills background workers dispatched during the pulse cycle, even if they are actively implementing code. Workers that need >15 minutes (most implementation tasks) can never complete.

`KillMode=process` tells systemd to only terminate the main process and leave background children alive — matching launchd and cron behavior.

## Files Changed

- `setup-modules/schedulers.sh` — added `KillMode=process` to systemd service unit template

## Testing

**Risk level:** Low — single-line config addition to a shell heredoc template. No logic changes.

**Self-assessed:** The change adds one line to a `printf` heredoc that generates a systemd unit file. The fix is documented in `systemd.service(5)` man page. ShellCheck passes with zero violations.

**Verification path for users:** After running `setup.sh --non-interactive && systemctl --user daemon-reload`, background workers dispatched by the pulse will survive past the wrapper exit.

## Runtime Testing

`self-assessed` — Low risk: docs/config change to a shell heredoc. No runtime environment available for systemd service testing in this session.

<!-- MERGE_SUMMARY -->
**What:** Added `KillMode=process` to systemd service unit template in `schedulers.sh`
**Issue:** Closes #17438
**Files changed:** 1 (`setup-modules/schedulers.sh`, +1 line)
**Testing:** ShellCheck clean, self-assessed (low risk config change)
**Key decision:** `KillMode=process` is the correct fix per systemd docs — only kills main process, leaves children alive

Closes #17438

---
[aidevops.sh](https://aidevops.sh) v3.6.100 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration for improved process termination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->