### PR TITLE
GH#17443: fix PULSE_STALE_THRESHOLD missing from systemd/cron schedulers

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -401,7 +401,7 @@ _install_pulse_cron() {
 	fi
 	(
 		crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse' || true
-		echo "*/2 * * * * PULSE_DIR=${_cron_pulse_dir}${_cron_headless_env} /bin/bash ${_cron_wrapper_script} >> \"\$HOME/.aidevops/logs/pulse-wrapper.log\" 2>&1 # aidevops: supervisor-pulse"
+		echo "*/2 * * * * PULSE_DIR=${_cron_pulse_dir} PULSE_STALE_THRESHOLD=1800${_cron_headless_env} /bin/bash ${_cron_wrapper_script} >> \"\$HOME/.aidevops/logs/pulse-wrapper.log\" 2>&1 # aidevops: supervisor-pulse"
 	) | crontab - || true
 	if crontab -l 2>/dev/null | grep -qF "aidevops: supervisor-pulse"; then
 		print_info "Supervisor pulse enabled (cron, every 2 min). Disable: crontab -e and remove the supervisor-pulse line"
@@ -650,6 +650,10 @@ _install_pulse_systemd() {
 		_env_lines+="Environment=AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=$(_systemd_escape "$AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST")"$'\n'
 	fi
 	_env_lines+="Environment=PULSE_DIR=$(_systemd_escape "${HOME}/.aidevops/.agent-workspace")"$'\n'
+	# Match launchd plist threshold (GH#17443): without this, systemd workers
+	# default to 900s (15 min) while macOS gets 1800s (30 min), silently killing
+	# legitimate opus-tier dispatches that need 20+ minutes.
+	_env_lines+="Environment=PULSE_STALE_THRESHOLD=$(_systemd_escape "1800")"$'\n'
 	_env_lines+="Environment=HOME=$(_systemd_escape "$HOME")"$'\n'
 	# Capture setup-time PATH so systemd workers find user-installed binaries
 	# (e.g. ~/.npm-global/bin/opencode, ~/.local/bin/claude). Systemd user


### PR DESCRIPTION
## Summary

- Add `PULSE_STALE_THRESHOLD=1800` to the systemd service unit (`_install_pulse_systemd()`) and cron entry (`_install_pulse_cron()`) to match the existing launchd plist value
- Fixes silent 15min vs 30min kill threshold divergence between macOS and Linux pulse workers

## Problem

The launchd plist explicitly sets `PULSE_STALE_THRESHOLD=1800` (30 min), but neither systemd nor cron backends set this variable. The pulse-wrapper defaults to `900` (15 min), so Linux workers get killed after 15 minutes while macOS workers get 30 minutes. Legitimate opus-tier dispatches needing 20+ minutes succeed on macOS but get killed on Linux.

## Changes

| File | Change |
|------|--------|
| `setup-modules/schedulers.sh` | Added `Environment=PULSE_STALE_THRESHOLD="1800"` to systemd env lines |
| `setup-modules/schedulers.sh` | Added `PULSE_STALE_THRESHOLD=1800` to cron inline env vars |

## Runtime Testing

| Risk | Level | Verification |
|------|-------|-------------|
| Config/env vars | Low | `self-assessed` — env var injection follows identical patterns already used for `PULSE_DIR`, `PULSE_MODEL`, etc. in the same functions |

ShellCheck: clean (zero violations).

Closes #17443

---
[aidevops.sh](https://aidevops.sh) v3.6.102 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent stale threshold configuration across cron and systemd scheduler installations, with both now explicitly applying the same timeout value for worker dispatch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->