### PR TITLE
t1892: docs: add pulse default-on guidance when supervisor_pulse is first enabled

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -815,6 +815,17 @@ cmd_set() {
 	echo "[OK] Set ${dotpath}=${value}" >&2
 	_cmd_set_warn_env_override "$dotpath"
 	echo "  Change takes effect on next setup.sh run or script invocation." >&2
+
+	# Print pulse default-on guidance when supervisor_pulse is first enabled (t1892)
+	if [[ "$dotpath" == "orchestration.supervisor_pulse" ]]; then
+		local lower_val
+		lower_val=$(echo "$value" | tr '[:upper:]' '[:lower:]')
+		if [[ "$lower_val" == "true" ]]; then
+			echo "[INFO] Pulse enabled — runs every ~2 minutes by default (24/7)." >&2
+			echo "[INFO] Run 'aidevops pulse stop' to switch to manual start/stop mode (persistent across reboots)." >&2
+		fi
+	fi
+
 	return 0
 }
 

--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -640,6 +640,7 @@ check_orchestration() {
 
 	if [[ "$pulse_active" == "true" ]]; then
 		print_service "Supervisor Pulse" "ready" "dispatches workers, merges PRs every 2 min"
+		echo "    Runs 24/7 by default. Use 'aidevops pulse stop' for manual start/stop mode." >&2
 	else
 		print_service "Supervisor Pulse" "needs-setup" "see scripts/commands/runners.md for setup"
 	fi


### PR DESCRIPTION
## Summary

- When `aidevops config set orchestration.supervisor_pulse true` succeeds, prints info messages explaining 24/7 default behaviour and `aidevops pulse stop` for manual start/stop mode
- Onboarding status display now shows the same guidance when pulse is detected as active

Closes #17433

## Files Changed

- `.agents/scripts/config-helper.sh` — added pulse-specific guidance in `cmd_set()` after successful write of `orchestration.supervisor_pulse=true`
- `.agents/scripts/onboarding-helper.sh` — added one-liner guidance in `check_orchestration()` when pulse is active

## Runtime Testing

- **Risk level:** Low (docs/UX messaging only, no behaviour change)
- **Verification:** `self-assessed` — ShellCheck clean on both files, no logic changes

---
[aidevops.sh](https://aidevops.sh) v3.6.102 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6