### PR TITLE
t1894: Deterministic NMR gate — exclude needs-maintainer-review from LLM state

### DIFF
--- a/.agents/scripts/commands/pulse-sweep.md
+++ b/.agents/scripts/commands/pulse-sweep.md
@@ -58,16 +58,9 @@ gh pr merge NUMBER --repo SLUG --squash
 
 **Merge criteria:** CI all PASS (or NONE/PENDING) + collaborator → approve and merge. `CHANGES_REQUESTED` → dispatch fix worker. `APPROVED` → merge directly. Check external contributor gate before ANY approve/merge.
 
-### 3.5. Dispatch triage reviews for needs-maintainer-review issues
+### 3.5. Triage reviews for needs-maintainer-review issues (DETERMINISTIC — handled by shell)
 
-Before implementation workers. Max 2 per cycle. Uses pre-fetched triage status.
-
-```bash
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
-```
-
-Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
+Triage review dispatch is handled deterministically by `dispatch_triage_reviews()` in `pulse-wrapper.sh` BEFORE the LLM session starts. NMR issues are NOT included in the LLM state file (t1894 security gate). The LLM MUST NOT attempt to list, fetch, comment on, relabel, or dispatch workers for NMR issues. Approval is cryptographic — only `sudo aidevops approve issue <number>` can unlock the gate.
 
 ### 4. Dispatch workers for open issues
 
@@ -214,17 +207,13 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **`status:needs-info`** → check pre-fetched reply status (step 4.5).
 - **`status:available` or no status** → dispatch implementation worker.
 
-### Maintainer review gate (t1545)
+### Maintainer review gate (t1545, t1894)
 
-NEVER dispatch a worker for an issue with `needs-maintainer-review`. Applied by `issue-triage-gate.yml` to all non-collaborator issues. Maintainer must remove it and add `auto-dispatch` before the issue is dispatchable.
+NEVER dispatch a worker for an issue with `needs-maintainer-review`. Applied by `issue-triage-gate.yml` to all non-collaborator issues.
 
-**Comment-based approval:** Each cycle, check maintainer's most recent comment on `needs-maintainer-review` items:
+**Cryptographic approval required (t1894):** Approval uses SSH-signed comments posted via `sudo aidevops approve issue <number>`. The deterministic `auto_approve_maintainer_issues()` in `pulse-wrapper.sh` verifies the signature each cycle — do NOT attempt to approve issues by commenting, removing labels, or calling `gh issue edit`. Only the cryptographic approval command (which requires sudo + interactive TTY + root-protected signing key) can unlock the gate. Workers CANNOT and MUST NOT attempt to forge or bypass this gate.
 
-- **"approved"** → remove `needs-maintainer-review`, add `auto-dispatch` (issues) or allow merge (PRs)
-- **"declined"** → close with the maintainer's reason
-- **Further direction** → dispatch a follow-up triage review incorporating the feedback
-
-Only process comments from the repo maintainer (from `repos.json` or slug owner).
+The only exception: maintainer-authored issues are auto-approved (the maintainer wouldn't gate their own issues).
 
 ## Worker Management
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -90,16 +90,9 @@ gh pr merge NUMBER --repo SLUG --squash
 `CHANGES_REQUESTED` → dispatch fix worker. `APPROVED` → merge directly.
 Check external contributor gate before ANY approve/merge (see Pre-merge checks below).
 
-### 3.5. Dispatch triage reviews for needs-maintainer-review issues
+### 3.5. Triage reviews for needs-maintainer-review issues (DETERMINISTIC — handled by shell)
 
-**Before implementation workers.** External contributor issues deserve fast feedback —
-dispatch opus-tier triage reviews first so the community isn't left waiting. Max 2 per cycle.
-Uses pre-fetched triage status.
-
-```bash
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-AVAILABLE=$(dispatch_triage_reviews "$AVAILABLE")
-```
+Triage review dispatch is handled deterministically by `dispatch_triage_reviews()` BEFORE the LLM session. NMR issues are NOT in the LLM state file (t1894 security gate). The LLM MUST NOT list, fetch, comment on, relabel, or dispatch workers for NMR issues. Approval requires `sudo aidevops approve issue <number>` — a cryptographic gate that workers cannot bypass.
 
 Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
 
@@ -264,8 +257,7 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **`status:needs-info`** → check pre-fetched reply status (step 4.5).
 - **`status:available` or no status** → dispatch implementation worker.
 
-NEVER dispatch a worker for an issue with `needs-maintainer-review`. Maintainer must remove it
-and add `auto-dispatch` before the issue is dispatchable.
+NEVER dispatch a worker for an issue with `needs-maintainer-review`. NEVER attempt to remove this label, comment on these issues, or bypass the gate. Approval is cryptographic (t1894) — only `sudo aidevops approve issue <number>` can unlock it. NMR issues are excluded from the LLM state file; if you encounter one, skip it.
 
 ## Worker Management
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1321,13 +1321,17 @@ _append_prefetch_sub_helpers() {
 	cat "$ghfail_tmp" >>"$STATE_FILE"
 	rm -f "$ghfail_tmp"
 
-	# Append needs-maintainer-review triage status for automated review dispatch
+	# Write needs-maintainer-review triage status to a SEPARATE file (t1894).
+	# This data is used only by the deterministic dispatch_triage_reviews()
+	# function — it must NOT appear in the LLM's STATE_FILE. NMR issues are
+	# a security gate; the LLM should never see or act on them.
 	local triage_tmp
 	triage_tmp=$(mktemp)
 	run_cmd_with_timeout 30 prefetch_triage_review_status "$repo_entries" >"$triage_tmp" 2>/dev/null || {
 		echo "[pulse-wrapper] prefetch_triage_review_status timed out after 30s (non-fatal)" >>"$LOGFILE"
 	}
-	cat "$triage_tmp" >>"$STATE_FILE"
+	TRIAGE_STATE_FILE="${STATE_FILE%.txt}-triage.txt"
+	cat "$triage_tmp" >"$TRIAGE_STATE_FILE"
 	rm -f "$triage_tmp"
 
 	# Append status:needs-info contributor reply status
@@ -9909,13 +9913,15 @@ dispatch_triage_reviews() {
 		return 0
 	}
 
-	# Parse needs-review items from pre-fetched state
-	local state_file="${STATE_FILE:-}"
-	[[ -f "$state_file" ]] || {
-		echo "[pulse-wrapper] dispatch_triage_reviews: no state file" >>"$LOGFILE"
+	# Parse needs-review items from the dedicated triage state file (t1894).
+	# NMR data is written to a separate file, not the LLM's STATE_FILE.
+	local triage_file="${TRIAGE_STATE_FILE:-${STATE_FILE%.txt}-triage.txt}"
+	[[ -f "$triage_file" ]] || {
+		echo "[pulse-wrapper] dispatch_triage_reviews: no triage state file" >>"$LOGFILE"
 		printf '%d\n' "$available"
 		return 0
 	}
+	local state_file="$triage_file"
 
 	# Resolve model: prefer opus, fall back to sonnet, then omit --model
 	# (lets headless-runtime-helper pick its default, same as implementation workers)


### PR DESCRIPTION
## Summary

Follow-up to #17449. The cryptographic approval gate protected the deterministic layer, but the LLM pulse still received NMR issue data in its state file — an LLM could attempt to bypass the gate by commenting, relabeling, or dispatching workers.

**Fix**: NMR triage data is now written to a separate `TRIAGE_STATE_FILE` that only the deterministic `dispatch_triage_reviews()` reads. The LLM never sees NMR issues.

## Changes

- `pulse-wrapper.sh`: NMR triage data → separate file, not LLM STATE_FILE
- `pulse-wrapper.sh`: `dispatch_triage_reviews()` reads from triage-specific file
- `pulse-sweep.md`: Removed "Comment-based approval" section, replaced with deterministic gate notice
- `pulse.md`: Updated NMR instructions — LLM MUST NOT interact with NMR issues

## Runtime Testing

Self-assessed (low risk — data routing change in shell scripts, no new logic)

Closes #17448


---
[aidevops.sh](https://aidevops.sh) v3.6.102 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 1h and 52,695 tokens on this with the user in an interactive session.