### PR TITLE
t1894: Ever-NMR provenance gate + PR triage gate

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1075,7 +1075,7 @@ _prefetch_repo_issues() {
 
 	# Remove issues with supervisor, contributor, persistent, or quality-review labels
 	local filtered_json
-	filtered_json=$(echo "$issue_json" | jq '[.[] | select(.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review")) | not)]')
+	filtered_json=$(echo "$issue_json" | jq '[.[] | select(.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review") or index("needs-maintainer-review")) | not)]')
 
 	# GH#10308: Split issues into dispatchable vs quality-sweep-tracked.
 	# The sweep (stats-functions.sh) creates quality-debt and simplification-debt
@@ -3977,6 +3977,67 @@ reconcile_stale_done_issues() {
 }
 
 #######################################
+# Check if an issue was ever labeled needs-maintainer-review (t1894).
+# Uses the immutable GitHub timeline API — label removal does not erase
+# the history. This is the provenance gate: once an issue is tagged NMR,
+# it requires cryptographic approval forever, regardless of current labels.
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug (owner/repo)
+# Returns: 0 if the issue was ever NMR-labeled, 1 otherwise
+#######################################
+issue_was_ever_nmr() {
+	local issue_num="$1"
+	local slug="$2"
+
+	[[ -n "$issue_num" && -n "$slug" ]] || return 1
+
+	local ever_count
+	ever_count=$(gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate \
+		--jq '[.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")] | length' \
+		2>/dev/null) || ever_count=0
+	[[ "$ever_count" =~ ^[0-9]+$ ]] || ever_count=0
+
+	if [[ "$ever_count" -gt 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Check if an issue requires cryptographic approval and has it (t1894).
+# Combines the "ever-NMR" provenance check with signature verification.
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug (owner/repo)
+# Returns: 0 if the issue is approved (or never needed approval), 1 if blocked
+#######################################
+issue_has_required_approval() {
+	local issue_num="$1"
+	local slug="$2"
+
+	# If it was never NMR-labeled, no approval needed
+	if ! issue_was_ever_nmr "$issue_num" "$slug"; then
+		return 0
+	fi
+
+	# It was NMR-labeled at some point — check for cryptographic approval
+	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
+	if [[ -f "$approval_helper" ]]; then
+		local verify_result
+		verify_result=$(bash "$approval_helper" verify "$issue_num" "$slug" 2>/dev/null) || verify_result=""
+		if [[ "$verify_result" == "VERIFIED" ]]; then
+			return 0
+		fi
+	fi
+
+	# Was ever NMR, no signed approval found — blocked
+	return 1
+}
+
+#######################################
 # Auto-approve needs-maintainer-review issues using cryptographic
 # signature verification (t1894, replaces GH#16842 comment-based check).
 #
@@ -6135,6 +6196,13 @@ dispatch_with_dedup() {
 
 	if echo "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review"))' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
+		return 1
+	fi
+
+	# t1894: Cryptographic approval gate — block dispatch for issues that were
+	# ever labeled needs-maintainer-review without a signed approval.
+	if ! issue_has_required_approval "$issue_number" "$repo_slug"; then
+		echo "[pulse-wrapper] dispatch_with_dedup: BLOCKED #${issue_number} in ${repo_slug} — requires cryptographic approval (ever-NMR)" >>"$LOGFILE"
 		return 1
 	fi
 

--- a/.github/workflows/issue-triage-gate.yml
+++ b/.github/workflows/issue-triage-gate.yml
@@ -103,7 +103,7 @@ jobs:
                 `Thanks for the report, @${author}.`,
                 '',
                 'This issue has been queued for maintainer review. A maintainer will review it and either:',
-                '- **Approve** it for the development pipeline (`status:available`)',
+                '- **Approve** it using: `sudo aidevops approve issue ' + issue.number + '`',
                 '- **Ask for more information** if the report needs clarification',
                 '- **Close** it if it\'s a duplicate or out of scope',
                 '',

--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -292,7 +292,7 @@ jobs:
       issues: write
 
     steps:
-      - name: Re-apply label if removed by non-maintainer
+      - name: Re-apply label if no signed approval exists (t1894)
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
@@ -303,31 +303,27 @@ jobs:
         run: |
           echo "Label 'needs-maintainer-review' removed from issue #$ISSUE_NUMBER by $ACTOR"
 
-          # Get the actor's association with the repo
-          # The event's author_association is for the issue author, not the actor
-          # who removed the label. We need to check the actor's permissions.
-          ACTOR_PERMS=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
-            --jq '.permission' 2>/dev/null || echo "none")
-
-          echo "Actor $ACTOR has permission level: $ACTOR_PERMS"
-
-          # Allow maintainers and collaborators with write permission to remove triage labels
-          # write = standard collaborator level (e.g., alex-solovyev) — sufficient
-          # admin/maintain = maintainer level
-          case "$ACTOR_PERMS" in
-            admin|maintain|write)
-              echo "ALLOWED: $ACTOR has $ACTOR_PERMS permission — label removal accepted"
-              exit 0
-              ;;
-          esac
-
-          # Also allow bots (github-actions)
+          # Always allow the bot — the approval-helper.sh removes labels after
+          # posting a signed approval comment, so this is the legitimate path.
           if [[ "$ACTOR" == "github-actions[bot]" ]] || [[ "$ACTOR" == "github-actions" ]]; then
             echo "ALLOWED: GitHub Actions bot — label removal accepted"
             exit 0
           fi
 
-          echo "DENIED: $ACTOR ($ACTOR_PERMS) is not a maintainer — re-applying label"
+          # t1894: Check for a cryptographic signed approval comment.
+          # Even admin/maintainer actors must use the approval command —
+          # manual label removal alone is insufficient because it leaves
+          # no auditable cryptographic proof of approval.
+          SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            --jq '[.[] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
+            2>/dev/null || echo "0")
+
+          if [[ "$SIGNED_APPROVAL" -gt 0 ]]; then
+            echo "ALLOWED: Signed approval comment found — label removal accepted"
+            exit 0
+          fi
+
+          echo "DENIED: No signed approval found — re-applying label (actor: $ACTOR)"
 
           # Re-apply the label
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"
@@ -340,12 +336,13 @@ jobs:
             gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "<!-- label-protection-notice -->
           The \`needs-maintainer-review\` label was re-applied automatically.
 
-          Only repository collaborators with write access or higher (write/maintain/admin permission) can remove triage labels from external issues. This prevents the development pipeline from picking up unreviewed external contributions.
+          Removing this label requires a cryptographic approval — even for maintainers. This ensures every approval is auditable and cannot be forged by automation.
 
-          If you believe this issue is ready for development, ask a maintainer to approve it:
+          To approve this issue, run from your terminal:
           \`\`\`
           sudo aidevops approve issue $ISSUE_NUMBER
-          \`\`\`"
+          \`\`\`
+          This signs the approval with a root-protected key and posts a verifiable comment."
           fi
 
   # =========================================================================

--- a/.github/workflows/pr-triage-gate.yml
+++ b/.github/workflows/pr-triage-gate.yml
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# PR Triage Gate (t1894)
+#
+# Analogous to issue-triage-gate.yml but for pull requests.
+# Applies needs-maintainer-review to PRs from non-collaborators
+# on creation, ensuring the cryptographic approval gate covers PRs
+# regardless of how they were created (web UI, API, fork, etc.).
+#
+# The maintainer-gate.yml enforces this at merge time; this workflow
+# ensures the label exists from the moment the PR is opened.
+
+name: PR Triage Gate
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  triage:
+    name: PR Author Triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    concurrency:
+      group: pr-triage-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Check author association and apply triage label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const association = pr.author_association;
+
+            // Bot accounts always bypass triage
+            if (pr.user.type === 'Bot') {
+              console.log(`Author ${author} is a bot — bypassing triage`);
+              return;
+            }
+
+            // PRs with task ID prefix (t1234: ...) are from internal tooling — bypass
+            const title = pr.title || '';
+            if (/^t\d+/.test(title)) {
+              console.log(`PR "${title}" has task ID prefix — bypassing triage`);
+              return;
+            }
+
+            // PRs with GH# prefix are from internal tooling — bypass
+            if (/^GH#\d+/.test(title)) {
+              console.log(`PR "${title}" has GH# prefix — bypassing triage`);
+              return;
+            }
+
+            // Maintainers and collaborators bypass triage
+            // OWNER, MEMBER, COLLABORATOR are trusted roles
+            // CONTRIBUTOR (has previous merged PRs) is NOT trusted
+            const trustedRoles = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+
+            if (trustedRoles.includes(association)) {
+              console.log(`Author ${author} has role ${association} — bypassing triage`);
+              return;
+            }
+
+            console.log(`Author ${author} has role ${association} — applying triage gate to PR #${pr.number}`);
+
+            // Ensure needs-maintainer-review label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'needs-maintainer-review',
+                description: 'External issue awaiting maintainer review before pipeline pickup',
+                color: 'FBCA04'
+              });
+            } catch (e) {
+              // Label already exists — expected
+            }
+
+            // Apply labels
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['needs-maintainer-review', 'external-contributor']
+            });
+
+            // Remove any auto-dispatch labels
+            for (const label of ['status:available', 'auto-dispatch']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label
+                });
+              } catch (e) {
+                // Label not present — fine
+              }
+            }
+
+            // Post a comment with approval instructions
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                `Thanks for the contribution, @${author}.`,
+                '',
+                'This PR has been queued for maintainer review. A maintainer will review it and either:',
+                '- **Approve** it using: `sudo aidevops approve pr ' + pr.number + '`',
+                '- **Request changes** if modifications are needed',
+                '- **Close** it if it\'s a duplicate or out of scope',
+                '',
+                'The PR cannot be merged until a maintainer provides cryptographic approval.'
+              ].join('\n')
+            });


### PR DESCRIPTION
## Summary

Closes remaining holes in the cryptographic approval gate:

### Hole 1: NMR issues visible to LLM
NMR issues appeared in the LLM's general "Open Issues" list. Added `needs-maintainer-review` to the jq filter in `_prefetch_repo_issues()`.

### Hole 2: Label removal bypass + provenance gate
Even if someone removes the NMR label, the gate now checks the **immutable GitHub timeline** — if the issue was *ever* labeled NMR, it requires crypto-signing forever. New functions: `issue_was_ever_nmr()`, `issue_has_required_approval()`.

### Hole 3: Pre-dispatch guard
`dispatch_with_dedup()` now calls `issue_has_required_approval()` before dispatching. Issues that were ever NMR-labeled are blocked without signed approval.

### Hole 4: No PR triage gate
PRs from non-collaborators had no immediate NMR labeling. **Audit found 2 merged PRs that bypassed the gate** (PR #17424, #17421 from CONTRIBUTOR-association author). New `pr-triage-gate.yml` applies NMR + external-contributor labels on PR creation.

### Hole 5: Label protection weakness
`maintainer-gate.yml` protect-labels job now checks for signed approval comment before allowing label removal, even from admin accounts.

## Audit Results

| PR | Author | Association | Gate Applied? | Outcome |
|----|--------|-------------|-------------|---------|
| #17424 | vRobM | CONTRIBUTOR | No | **MERGED** (bypassed) |
| #17421 | vRobM | CONTRIBUTOR | No | **MERGED** (bypassed) |
| #17412 | milohiss | NONE | No | Closed |
| #17410 | milohiss | NONE | No | Closed |

## Files Changed

- `pulse-wrapper.sh` — NMR prefetch filter, ever-NMR functions, dispatch guard
- `maintainer-gate.yml` — signed-approval label protection
- `issue-triage-gate.yml` — approval command in welcome comment
- `pr-triage-gate.yml` (new) — PR triage gate for non-collaborators

## Runtime Testing

Self-assessed — GitHub Action workflows, shell guard functions. Verified `issue_was_ever_nmr` logic against timeline API manually.

Closes #17448


---
[aidevops.sh](https://aidevops.sh) v3.6.103 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 1h 29m and 70,415 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cryptographic approval requirement for maintainer-flagged issues and pull requests from external contributors.
  * Implemented automated triage gate for external contributor pull requests requiring maintainer review before proceeding.

* **Changes**
  * Modified approval workflow to use cryptographically verified signatures instead of label-based permissions, enhancing security for protected operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->