### PR TITLE
GH#17461: fix Homebrew checksum for v3.6.104 archive

### DIFF
--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -6,7 +6,7 @@ class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
   url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.6.104.tar.gz"
-  sha256 "a04cfc74c44d39ac8d765ab847145a8e891cd5929de2f451ad577be3e5fb52f5"
+  sha256 "b0254325bf752ed6142973b69c913d34471d03154f6b5c577842d71b2b3e3f13"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"
 


### PR DESCRIPTION
## Summary
- update `homebrew/aidevops.rb` to use the SHA256 for the current `v3.6.104` source tarball
- restore Homebrew installs/upgrades that would fail because the formula checksum no longer matched the tagged archive

## Runtime Testing
- self-assessed: config/package fix

## Verification
- `curl -L https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.6.104.tar.gz -o \"$tmpfile\" && shasum -a 256 \"$tmpfile\"`
- `ruby -c ./homebrew/aidevops.rb`

Closes #17461

---
[aidevops.sh](https://aidevops.sh) v3.6.104 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.4