### PR TITLE
GH#17464: restore portable curl probe timing

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -495,17 +495,13 @@ _probe_local() {
 	local endpoint
 	endpoint=$(get_provider_endpoint "local" 2>/dev/null) || endpoint="http://localhost:8080/v1/models"
 
-	local start_ms response http_code body models_count=0 duration_ms=0
-	start_ms=$(date +%s%N 2>/dev/null || echo "0")
-	response=$(curl -s -w "\n%{http_code}" --max-time "$PROBE_TIMEOUT" "$endpoint" 2>/dev/null) || true
-	local end_ms
-	end_ms=$(date +%s%N 2>/dev/null || echo "0")
-	if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
-		duration_ms=$(((end_ms - start_ms) / 1000000))
-	fi
+	local response http_code body models_count=0 duration_ms=0 time_total
+	response=$(curl -s -w "\n%{http_code}\n%{time_total}" --max-time "$PROBE_TIMEOUT" "$endpoint" 2>/dev/null) || true
+	time_total=$(echo "$response" | tail -1)
+	duration_ms=$(_probe_duration_ms_from_curl "$time_total") || duration_ms=0
 
-	http_code=$(echo "$response" | tail -1)
-	body=$(echo "$response" | sed '$d')
+	http_code=$(echo "$response" | tail -2 | head -1)
+	body=$(echo "$response" | sed '$d' | sed '$d')
 
 	if [[ "$http_code" == "200" ]]; then
 		models_count=$(echo "$body" | jq -r '.data | length' 2>/dev/null || echo "0")
@@ -532,17 +528,13 @@ _probe_ollama() {
 	local endpoint
 	endpoint=$(get_provider_endpoint "ollama" 2>/dev/null) || endpoint="http://localhost:11434/api/tags"
 
-	local start_ms response http_code body models_count=0 duration_ms=0
-	start_ms=$(date +%s%N 2>/dev/null || echo "0")
-	response=$(curl -s -w "\n%{http_code}" --max-time "$PROBE_TIMEOUT" "$endpoint" 2>/dev/null) || true
-	local end_ms
-	end_ms=$(date +%s%N 2>/dev/null || echo "0")
-	if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
-		duration_ms=$(((end_ms - start_ms) / 1000000))
-	fi
+	local response http_code body models_count=0 duration_ms=0 time_total
+	response=$(curl -s -w "\n%{http_code}\n%{time_total}" --max-time "$PROBE_TIMEOUT" "$endpoint" 2>/dev/null) || true
+	time_total=$(echo "$response" | tail -1)
+	duration_ms=$(_probe_duration_ms_from_curl "$time_total") || duration_ms=0
 
-	http_code=$(echo "$response" | tail -1)
-	body=$(echo "$response" | sed '$d')
+	http_code=$(echo "$response" | tail -2 | head -1)
+	body=$(echo "$response" | sed '$d' | sed '$d')
 
 	if [[ "$http_code" == "200" ]]; then
 		# Ollama /api/tags returns {"models": [...]}
@@ -631,6 +623,24 @@ _probe_ollama_context_length() {
 # Outputs two lines: first the endpoint URL, then the curl args (space-separated).
 # Caller must reconstruct the array from the second line.
 # Sets REPLY_ENDPOINT and REPLY_CURL_ARGS (space-separated) in caller scope via stdout.
+_probe_duration_ms_from_curl() {
+	local time_total="$1"
+
+	if [[ -z "$time_total" ]]; then
+		printf '0\n'
+		return 1
+	fi
+
+	awk -v seconds="$time_total" 'BEGIN {
+		ms = int((seconds + 0) * 1000 + 0.5)
+		if (ms < 0) {
+			ms = 0
+		}
+		print ms
+	}'
+	return 0
+}
+
 _probe_build_request() {
 	local provider="$1"
 	local api_key="$2"
@@ -641,7 +651,7 @@ _probe_build_request() {
 		return 1
 	fi
 
-	local curl_args="-s -w '\n%{http_code}' --max-time $PROBE_TIMEOUT -D -"
+	local curl_args="-s -w '\n%{http_code}\n%{time_total}' --max-time $PROBE_TIMEOUT -D -"
 	case "$provider" in
 	anthropic)
 		curl_args="$curl_args -H 'x-api-key: ${api_key}' -H 'anthropic-version: 2023-06-01'"
@@ -811,22 +821,19 @@ probe_provider() {
 	curl_extra=$(echo "$request_info" | tail -1)
 
 	# Execute probe (eval is safe: curl_extra is built from controlled provider strings)
-	local start_ms response end_ms duration_ms=0
-	start_ms=$(date +%s%N 2>/dev/null || echo "0")
+	local response duration_ms=0 time_total
 	# shellcheck disable=SC2086
 	response=$(eval curl $curl_extra "$endpoint" 2>/dev/null) || true
-	end_ms=$(date +%s%N 2>/dev/null || echo "0")
-	if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
-		duration_ms=$(((end_ms - start_ms) / 1000000))
-	fi
+	time_total=$(echo "$response" | tail -1)
+	duration_ms=$(_probe_duration_ms_from_curl "$time_total") || duration_ms=0
 
 	# Split response into headers and body
 	local http_code headers body
-	# _probe_build_request appends one trailer line: http_code.
-	http_code=$(echo "$response" | tail -1)
+	# _probe_build_request appends two trailer lines: http_code and time_total.
+	http_code=$(echo "$response" | tail -2 | head -1)
 	headers=$(echo "$response" | sed '/^$/q' | head -50)
-	# Drop the last line (http_code) from the body after the blank-line header separator
-	body=$(echo "$response" | sed '1,/^$/d' | awk 'NR>1{print prev} {prev=$0}')
+	# Drop the last two lines (http_code and time_total) from the body after the blank-line header separator.
+	body=$(echo "$response" | sed '1,/^$/d' | awk 'NR>2{print prev_prev} {prev_prev=prev; prev=$0}')
 
 	_parse_rate_limits "$provider" "$headers"
 

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -461,71 +461,55 @@ else
 fi
 
 # ============================================================
-# SECTION 11: Curl write-out format / http_code extraction (GH#17427)
+# SECTION 11: Curl write-out format / portable duration extraction (GH#17464)
 # ============================================================
-section "Curl Write-Out Format (GH#17427)"
+section "Curl Write-Out Format (GH#17464)"
 
-# Verify _probe_build_request uses only %{http_code} (no %{time_total})
-# The bug was: -w '\n%{http_code}\n%{time_total}' caused tail -1 to read
-# time_total (e.g. 0.209059) as the http_code, making all API probes unhealthy.
+# Verify the helper restores curl's native duration output for portable timing.
 if grep -q 'time_total' "$HELPER"; then
-	fail "curl write-out still contains time_total (GH#17427)" \
-		"_probe_build_request should use -w '\\n%{http_code}' only"
+	pass "curl write-out includes time_total for portable timing (GH#17464)"
 else
-	pass "curl write-out does not contain time_total (GH#17427)"
+	fail "curl write-out missing time_total (GH#17464)" \
+		"Expected -w to include '\\n%{http_code}\\n%{time_total}'"
 fi
 
-# Verify the write-out format is exactly '\n%{http_code}' (single value)
-if grep -q "\\\\n%{http_code}'" "$HELPER"; then
-	pass "curl write-out ends with http_code (no trailing values)"
+# Verify the helper function exists to convert curl's seconds value to ms.
+if grep -q '_probe_duration_ms_from_curl()' "$HELPER"; then
+	pass "curl duration helper present (GH#17464)"
 else
-	fail "curl write-out format unexpected" \
-		"Expected -w '\\n%{http_code}' in _probe_build_request"
+	fail "curl duration helper missing" \
+		"Expected _probe_duration_ms_from_curl() in $HELPER"
 fi
 
-# Verify body extraction drops exactly 1 trailing line (not 2)
-# After removing time_total, only http_code is appended, so body awk
-# should drop 1 line. The old pattern was NR>2 (dropping 2 lines).
-if grep -q 'NR>2{print buf' "$HELPER"; then
-	fail "body extraction still drops 2 trailing lines (GH#17427)" \
-		"Should drop 1 line now that time_total is removed"
+# Verify body extraction drops exactly 2 trailing lines (http_code + time_total).
+if grep -q "NR>2{print prev_prev}" "$HELPER"; then
+	pass "body extraction drops http_code and time_total trailers"
 else
-	pass "body extraction does not use old 2-line drop pattern"
+	fail "body extraction missing 2-line drop awk pattern" \
+		"Expected: awk 'NR>2{print prev_prev} {prev_prev=prev; prev=\$0}'"
 fi
 
-if grep -q "NR>1{print prev}" "$HELPER"; then
-	pass "body extraction uses 1-line drop pattern (GH#17427)"
-else
-	fail "body extraction missing 1-line drop awk pattern" \
-		"Expected: awk 'NR>1{print prev} {prev=\$0}'"
-fi
-
-# Simulate the http_code extraction logic to verify correctness.
-# Build a mock curl response: headers + blank line + JSON body + http_code.
-# Use plain \n (no \r) to match how the production sed patterns work.
-mock_response=$(printf 'HTTP/1.1 200 OK\nContent-Type: application/json\n\n{"data":[{"id":"model-1"}]}\n200')
-mock_http_code=$(echo "$mock_response" | tail -1)
+# Simulate the response parsing logic for API-backed providers.
+mock_response=$(printf 'HTTP/1.1 200 OK\nContent-Type: application/json\n\n{"data":[{"id":"model-1"}]}\n200\n0.209059')
+mock_http_code=$(echo "$mock_response" | tail -2 | head -1)
 if [[ "$mock_http_code" == "200" ]]; then
-	pass "mock: tail -1 extracts http_code correctly (got 200)"
+	pass "mock: tail -2 | head -1 extracts http_code correctly"
 else
-	fail "mock: tail -1 extracts wrong value" "Expected 200, got: $mock_http_code"
+	fail "mock: http_code extraction wrong" "Expected 200, got: $mock_http_code"
 fi
 
-# Verify body extraction with the new awk pattern
-mock_body=$(echo "$mock_response" | sed '1,/^$/d' | awk 'NR>1{print prev} {prev=$0}')
+mock_body=$(echo "$mock_response" | sed '1,/^$/d' | awk 'NR>2{print prev_prev} {prev_prev=prev; prev=$0}')
 if echo "$mock_body" | grep -q '"data"'; then
-	pass "mock: body extraction preserves JSON content"
+	pass "mock: body extraction preserves JSON content with two trailers"
 else
 	fail "mock: body extraction lost JSON content" "Got: $mock_body"
 fi
 
-# Verify the old bug scenario: if time_total were still present, tail -1 would get it
-mock_old_response=$(printf 'HTTP/1.1 200 OK\n\n{"data":[]}\n200\n0.209059')
-mock_old_code=$(echo "$mock_old_response" | tail -1)
-if [[ "$mock_old_code" == "0.209059" ]]; then
-	pass "mock: confirms old format would read time_total as http_code (bug scenario)"
+mock_duration_ms=$(awk 'BEGIN { print int((0.209059 + 0) * 1000 + 0.5) }')
+if [[ "$mock_duration_ms" == "209" ]]; then
+	pass "mock: curl duration converts seconds to milliseconds"
 else
-	fail "mock: old format test unexpected" "Got: $mock_old_code"
+	fail "mock: curl duration conversion unexpected" "Expected 209, got: $mock_duration_ms"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary
- restore curl `%{time_total}` parsing so probe durations remain portable on macOS and no longer depend on `date +%s%N`
- update local, Ollama, and API-backed probe parsing to read `http_code` and `time_total` trailers consistently
- refresh regression coverage for the restored trailer format and millisecond conversion path

## Testing
- `bash tests/test-model-availability.sh`
- `shellcheck -e SC1091 .agents/scripts/model-availability-helper.sh tests/test-model-availability.sh`

## Runtime Testing
- self-assessed: exercised via repository regression tests for probe response parsing; no live provider credentials were used in this session

Closes #17464

---
[aidevops.sh](https://aidevops.sh) v3.6.104 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.4