### PR TITLE
GH#17463: fix close_pattern regex word boundary in dispatch-dedup-helper.sh

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -746,7 +746,7 @@ has_open_pr() {
 				local pr_body
 				pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null) || pr_body=""
 				# Match: keyword + optional whitespace + #NNN or owner/repo#NNN at word boundary
-				local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^0-9]|$)"
+				local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}\b"
 				if ! printf '%s' "$pr_body" | grep -iqE "$close_pattern"; then
 					continue
 				fi


### PR DESCRIPTION
## Summary

- Replace `([^0-9]|$)` with `\b` in `close_pattern` regex in `dispatch-dedup-helper.sh:749`
- The old construct could produce false positives — e.g. `#123a` would match for issue `#123`
- `\b` is the idiomatic POSIX ERE word boundary and is more precise

## What

Fix the `close_pattern` regex in `_check_issue_closed_by_merged_pr()` to use `\b` (word boundary) instead of `([^0-9]|$)` for the trailing anchor after the issue number.

## Why

The `([^0-9]|$)` construct is not a true word boundary — it only checks that the next character is not a digit or is end-of-string. This allows false positives like `#123a` matching for issue `#123`. Using `\b` is more idiomatic and precise.

## Files Changed

- `.agents/scripts/dispatch-dedup-helper.sh` — line 749: regex fix

## Runtime Testing

**Risk level**: Low — regex change in a shell script utility function, no runtime environment needed.
**Self-assessed**: Pattern change is mechanically correct; `\b` in POSIX ERE matches at word/non-word character boundaries, which correctly excludes `#123a` while still matching `#123` followed by whitespace, punctuation, or end-of-string.

Closes #17463

---
[aidevops.sh](https://aidevops.sh) v3.6.104 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pull request issue-closure detection by improving validation of issue references in pull request bodies. The system now more precisely identifies valid issue closures, preventing false matches when additional characters follow issue numbers. This ensures more reliable issue tracking and reduces unintended issue closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->