### PR TITLE
GH#17465: fix hardcoded paths and improve drift warning messages in agent-deploy.sh

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -280,13 +280,13 @@ _warn_deployed_script_drift() {
 	done
 
 	if [[ ${#drifted[@]} -gt 0 ]]; then
-		print_warning "Deployed scripts differ from canonical source (local edits will be overwritten):"
+		print_warning "Deployed scripts differ from canonical source (local edits will be overwritten; backup will be created):"
 		for bn in "${drifted[@]}"; do
 			print_warning "  $target_scripts/$bn"
 			print_warning "    → canonical: $source_scripts/$bn"
 		done
-		print_warning "To keep personal scripts: use ~/.aidevops/agents/custom/scripts/"
-		print_warning "To fix the canonical source: edit ~/Git/aidevops/.agents/scripts/ and re-run setup.sh"
+		print_warning "To keep personal scripts: use $target_dir/custom/scripts/"
+		print_warning "To fix the canonical source: edit $source_scripts/ and re-run setup.sh"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Addresses unactioned review feedback from PRs #17434 and #17429 on `setup-modules/agent-deploy.sh`.

### Changes

- **Line 283**: Clarify drift warning to mention backup will be created before overwriting (`local edits will be overwritten; backup will be created`)
- **Lines 288-289**: Replace hardcoded `~/.aidevops/agents/custom/scripts/` and `~/Git/aidevops/.agents/scripts/` with `$target_dir/custom/scripts/` and `$source_scripts/` variables — ensures warnings are accurate for non-standard install locations and git worktrees

### Findings Addressed

| Severity | Source PR | Finding |
|----------|-----------|---------|
| MEDIUM | #17434 | Hardcoded paths in warning messages (lines 288-289) |
| MEDIUM | #17429 | Warning doesn't mention backup will be created (line 283) |
| HIGH | #17421 | rsync restoration logic issues — already resolved by revert in #17429 |

### Runtime Testing

**Risk level**: Low — documentation/warning message changes only. No logic changes, no new code paths.
**Verification**: `self-assessed` — changes are string literals in warning messages; no runtime behavior affected.

Closes #17465

---
<!-- MERGE_SUMMARY -->
**What**: Fix hardcoded paths in `_warn_deployed_script_drift()` warning messages; clarify backup note.
**Issue**: #17465
**Files changed**: `setup-modules/agent-deploy.sh` (3 lines)
**Testing**: Self-assessed (low-risk string changes)
**Key decisions**: Used existing `$target_dir` and `$source_scripts` variables already in scope within the function.

---
[aidevops.sh](https://aidevops.sh) v3.6.104 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment script drift warning messages to provide clearer guidance when script conflicts occur, including better backup creation clarity and more flexible script path instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->