### PR TITLE
GH#17477: fix readonly variable conflict in circuit-breaker-helper.sh

### DIFF
--- a/.agents/scripts/circuit-breaker-helper.sh
+++ b/.agents/scripts/circuit-breaker-helper.sh
@@ -56,12 +56,18 @@ CB_REPO="${SUPERVISOR_CIRCUIT_BREAKER_REPO:-}"
 # ============================================================
 # COLOURS (stderr output)
 # ============================================================
+# Colour constants are provided by shared-constants.sh (RED, GREEN, YELLOW,
+# BLUE, NC). Reassigning them here would fail with "readonly variable" when
+# shared-constants.sh has already been sourced (GH#17477). Only declare
+# them when shared-constants.sh was not available (no include guard set).
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+if [[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]; then
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	YELLOW='\033[1;33m'
+	BLUE='\033[0;34m'
+	NC='\033[0m'
+fi
 
 # ============================================================
 # STATE FILE


### PR DESCRIPTION
## Summary

- `circuit-breaker-helper.sh` sourced `shared-constants.sh` which declares `RED`, `GREEN`, `YELLOW`, `BLUE`, `NC` as `readonly`
- The script then unconditionally reassigned those same variables, causing `readonly variable` error and aborting before any state evaluation
- Fix: guard the local colour declarations with `[[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]` so they only run when `shared-constants.sh` was not sourced

## Root Cause

`shared-constants.sh` has an include guard (`_SHARED_CONSTANTS_LOADED`) and exports colour constants as `readonly`. `circuit-breaker-helper.sh` sourced it then immediately tried to reassign the same names, which bash rejects with a fatal error under `set -euo pipefail`.

## Testing

- `circuit-breaker-helper.sh check` now returns exit 0 (was: `readonly variable` error, exit 1)
- `circuit-breaker-helper.sh status` outputs correct state
- Standalone mode (without `shared-constants.sh`) still works — fallback declarations run when `_SHARED_CONSTANTS_LOADED` is unset

## Files Changed

- `.agents/scripts/circuit-breaker-helper.sh` — guard colour var declarations

## Runtime Testing

**Risk level:** Low — shell script fix, no runtime environment needed.
**Method:** `self-assessed` — executed both `check` and `status` commands directly, confirmed exit 0 and correct output.

Closes #17477

---
[aidevops.sh](https://aidevops.sh) v3.6.104 plugin for [OpenCode](https://opencode.ai) v1.3.15