### PR TITLE
GH#17436: hotfix bash 3.2 syntax error + enable model round-robin

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1197,12 +1197,12 @@ Mandatory behavior:
 5. If merge/close cannot complete, exit only with a clear BLOCKED outcome and evidence (failing check, missing permission, unresolved conflict, or explicit policy gate).
 6. Model escalation before BLOCKED (GH#14964): BLOCKED is only valid after exhausting all autonomous solution paths. Before exiting BLOCKED, attempt model escalation — retry with the next tier (sonnet -> opus via --model anthropic/claude-opus-4-6). Review-policy metadata, nominal GitHub states, and lower-tier model limits are NOT valid blockers on their own.
 
-Pre-exit self-check (MANDATORY):
+Pre-exit self-check -- MANDATORY:
 Before ending your session, verify ALL of these:
-  a) At least one commit with implementation changes exists on your branch.
-  b) A PR exists: `gh pr list --head "$(git rev-parse --abbrev-ref HEAD)"` returns a result.
-  c) If either (a) or (b) is missing, you are NOT done — continue working.
-  d) The only valid exit states are FULL_LOOP_COMPLETE or BLOCKED with evidence.
+  - At least one commit with implementation changes exists on your branch.
+  - A PR exists for your branch: run gh pr list --head YOUR_BRANCH_NAME
+  - If either check fails, you are NOT done -- continue working.
+  - The only valid exit states are FULL_LOOP_COMPLETE or BLOCKED with evidence.
 EOF
 	)
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6403,30 +6403,23 @@ dispatch_with_dedup() {
 	# If a model_override is requested (e.g., tier:thinking → opus), we
 	# validate it against backoff first and fall back to auto-selection if
 	# it's currently backed off.
-	# Model selection: use the first available model from AIDEVOPS_HEADLESS_MODELS.
-	# The headless-runtime-helper.sh handles backoff checks and model rotation
-	# internally when it launches the worker — we don't need to pre-validate
-	# here. The previous approach of calling `select` as a subprocess failed
-	# because the subprocess couldn't resolve provider auth in the launchd context
-	# (reported "No direct provider models configured" despite correct env vars).
+	# GH#17436: Model selection — let headless-runtime-helper.sh round-robin.
+	# Previously this always took cut -d',' -f1 (first model), bypassing the
+	# runtime helper's round-robin rotation. This caused every worker to use
+	# the same model (openai/gpt-5.4 via OpenCode default) instead of rotating
+	# between anthropic and openai.
 	#
-	# Simply pass the model to the worker launcher and let it handle selection.
+	# Now: only pass --model when there's an explicit override (e.g., tier:thinking).
+	# When no override, omit --model entirely so choose_model() in the runtime
+	# helper picks the next available model via round-robin with backoff awareness.
 	local selected_model=""
 	if [[ -n "$model_override" ]]; then
 		selected_model="$model_override"
-	else
-		# Use the first model from the configured list
-		selected_model=$(printf '%s' "${AIDEVOPS_HEADLESS_MODELS:-}" | cut -d',' -f1 | tr -d ' ')
-		# Fallback to config if env not set
-		if [[ -z "$selected_model" ]] && type config_get >/dev/null 2>&1; then
-			selected_model=$(config_get "orchestration.headless_models" "" | cut -d',' -f1 | tr -d ' ')
-		fi
 	fi
 
-	# Launch worker — headless-runtime-helper.sh handles model fallback
-	# when no model is specified (uses DEFAULT_HEADLESS_MODELS internally).
-	# Do NOT early-return on empty selected_model; the helper's
-	# get_configured_models() has the authoritative fallback chain (GH#17369).
+	# Launch worker — headless-runtime-helper.sh handles model selection
+	# via round-robin when no --model is specified. Its choose_model() reads
+	# AIDEVOPS_HEADLESS_MODELS, checks backoff/auth, and rotates providers.
 	local -a worker_cmd=("$HEADLESS_RUNTIME_HELPER" run
 		--role worker
 		--session-key "$session_key"


### PR DESCRIPTION
## Summary

**CRITICAL hotfix** — the previous PR (#17462) introduced a bash 3.2 parse error that breaks the entire headless-runtime-helper.sh, preventing ALL worker dispatch.

### Fix 1: Bash 3.2 heredoc parse error
The V2 contract text contained `a)` `b)` `c)` `d)` list markers and `$(git rev-parse ...)` inside a `contract=$(cat <<'EOF' ... EOF)` block. Bash 3.2 treats `)` as closing the outer `$(...)` — the script fails to parse at line 1203. Replaced with dash-style list markers.

### Fix 2: Model round-robin was disabled
`dispatch_with_dedup` always selected `cut -d',' -f1` from `AIDEVOPS_HEADLESS_MODELS` and passed it as `--model` to the runtime helper. This bypassed `choose_model()` round-robin entirely, causing every worker to use the same model. Now: only pass `--model` for explicit tier overrides; otherwise the runtime helper auto-selects via round-robin with backoff awareness.

This also answers why GPT-5.4 was used for every dispatch — model round-robin was bypassed.

Closes #17436


---
[aidevops.sh](https://aidevops.sh) v3.6.105 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 2h 36m and 53,710 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker session validation instructions with improved formatting, clearer checklist structure, and simplified guidance for performing branch-specific verification operations.

* **Refactor**
  * Improved worker model selection and dispatch mechanism to optimize load distribution across available models, enhancing request routing efficiency and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->