### PR TITLE
GH#17441: fix approval signature verification — unblock external contributor issues

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -312,18 +312,23 @@ _extract_fenced_block() {
 	local body="$1"
 	local target_block="$2"
 
+	# Fenced code blocks have OPENING and CLOSING fence lines (``` pairs).
+	# Count pairs (not individual fence lines) to identify block N.
+	# Block 1 = content between fence pair 1, block 2 = content between pair 2, etc.
 	printf '%s\n' "$body" | awk -v target="$target_block" '
-		/^```$/ {
-			block++
-			if (block == target) {
-				capture = 1
+		/^```/ {
+			if (inside) {
+				inside = 0
+				if (capture) { exit }
+			} else {
+				pair++
+				inside = 1
+				if (pair == target) { capture = 1 }
 				next
 			}
-			if (capture) {
-				exit
-			}
+			next
 		}
-		capture { print }
+		capture && inside { print }
 	'
 	return 0
 }


### PR DESCRIPTION
## Summary

`_extract_fenced_block()` in approval-helper.sh counted every backtick-fence line as a new block boundary instead of tracking open/close pairs. With the approval comment format (2 fenced blocks: payload + signature), "block 2" resolved to the empty line between the blocks instead of the signature content. All `ssh-keygen -Y verify` calls failed, and the ever-NMR cache permanently blocked these issues.

**Impact:** Issues #17441, #17442, #17447 (all cryptographically approved by maintainer) were blocked on every pulse cycle with "requires cryptographic approval (ever-NMR)" despite valid signed approvals.

**Fix:** Track inside/outside fence state and count pairs, not individual fence lines.

Also cleared the stale NMR cache entries so these issues are immediately eligible for dispatch.

Closes #17441


---
[aidevops.sh](https://aidevops.sh) v3.6.106 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 4h 4m and 53,710 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction and identification of fenced code blocks to handle fence-pair positions more accurately, ensuring better parsing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->