### PR TITLE
GH#17487: fix empty model in dispatch comments

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6488,9 +6488,10 @@ dispatch_with_dedup() {
 	# Evidence: awardsapp #2051 accumulated 29 DISPATCH_CLAIM comments over 6 hours
 	# because workers kept dying before posting.
 	local dispatch_comment_body
+	local display_model="${selected_model:-auto-select (round-robin)}"
 	dispatch_comment_body="Dispatching worker (deterministic).
 - **Worker PID**: ${worker_pid}
-- **Model**: ${selected_model}
+- **Model**: ${display_model}
 - **Runner**: ${self_login}
 - **Issue**: #${issue_number}"
 	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \


### PR DESCRIPTION
## Summary

After the round-robin fix (PR #17484) removed hardcoded first-model selection from `dispatch_with_dedup`, the dispatch comment shows `Model: ` (empty) because `selected_model` is only set for explicit tier overrides. Shows `auto-select (round-robin)` instead.

Cosmetic fix — the workers themselves correctly auto-select via `choose_model()` in headless-runtime-helper.sh.

Closes #17487


---
[aidevops.sh](https://aidevops.sh) v3.6.106 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 4h 9m and 53,710 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity of worker dispatch information displayed in GitHub comments. The system now shows the selected model name when available, or displays "auto-select (round-robin)" when using automatic model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->