### PR TITLE
GH#17490: prevent raw sandbox output from leaking as GitHub comments

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -10332,16 +10332,34 @@ PREFETCH_EOF
 		rm -f "$review_output_file"
 
 		if [[ -n "$review_text" && ${#review_text} -gt 50 ]]; then
+			# ── Safety filter: NEVER post raw sandbox/infrastructure output ──
+			# If the LLM failed (quota, timeout, garbled), the output contains
+			# sandbox startup logs, execution metadata, or internal paths.
+			# These MUST be discarded — posting them leaks sensitive infra data.
+			local has_infra_markers="false"
+			if echo "$review_text" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper|/opt/homebrew/|opencode run '; then
+				has_infra_markers="true"
+			fi
+
 			# Extract just the review portion (starts with ## Review:)
 			local clean_review=""
 			clean_review=$(echo "$review_text" | sed -n '/^## Review:/,$ p')
-			if [[ -z "$clean_review" ]]; then
-				clean_review="$review_text"
-			fi
 
-			gh issue comment "$issue_num" --repo "$repo_slug" \
-				--body "$clean_review" >/dev/null 2>&1 || true
-			echo "[pulse-wrapper] Posted sandboxed triage review for #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+			if [[ -n "$clean_review" ]]; then
+				# Re-check extracted review for infra leaks (belt-and-suspenders)
+				if echo "$clean_review" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper'; then
+					echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} contained infrastructure markers after extraction — suppressed" >>"$LOGFILE"
+				else
+					gh issue comment "$issue_num" --repo "$repo_slug" \
+						--body "$clean_review" >/dev/null 2>&1 || true
+					echo "[pulse-wrapper] Posted sandboxed triage review for #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+				fi
+			elif [[ "$has_infra_markers" == "true" ]]; then
+				# No ## Review: header AND infra markers present — raw sandbox output, discard entirely
+				echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} was raw sandbox output — suppressed (${#review_text} chars)" >>"$LOGFILE"
+			else
+				echo "[pulse-wrapper] Triage review for #${issue_num} had no ## Review: header and no infra markers — suppressed to be safe (${#review_text} chars)" >>"$LOGFILE"
+			fi
 		else
 			echo "[pulse-wrapper] Triage review for #${issue_num} produced no usable output (${#review_text} chars)" >>"$LOGFILE"
 		fi


### PR DESCRIPTION
## Summary

- **Security fix**: The triage review fallback in `pulse-wrapper.sh` posted raw worker output (sandbox startup logs, internal paths, execution metadata) as GitHub comments when the LLM failed to produce a `## Review:` header
- **Root cause**: Line 10339 fell through to `clean_review="$review_text"` — posting the entire unfiltered output including `[SANDBOX] [INFO] Executing (timeout=3600s, network_blocked=false...)` lines
- **Fix**: Never post when `## Review:` extraction fails. Added infrastructure-marker detection (`[SANDBOX]`, `[INFO] Executing`, internal paths) as belt-and-suspenders defense. Suppressed output logged locally instead of posted publicly.

## Evidence

Three comments were posted publicly on #17490 containing sandbox execution logs and bot quota warnings. All deleted manually during incident response.

Closes #17490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content validation and safety filtering for review comments posted to issues. The system now detects and suppresses sandbox and infrastructure-related markers in review feedback, ensuring only relevant content is shared. Comments are suppressed when they contain infrastructure details or lack actual review content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->