### PR TITLE
GH#17490: enforce cryptographic approval gate on triage review dispatch

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -10235,6 +10235,18 @@ dispatch_triage_reviews() {
 		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
 		[[ "$available" -gt 0 && "$triage_count" -lt "$triage_max" ]] || break
 
+		# ── Cryptographic approval gate (GH#17490) ──
+		# Triage reviews are sandboxed but their OUTPUT is posted as a GitHub
+		# comment under the maintainer's account. Without this gate, any
+		# external non-contributor issue triggers automated actions (worker
+		# dispatch, comment posting, resource consumption). The same approval
+		# gate enforced by dispatch_with_dedup() must also apply here —
+		# no automated processing of unapproved external issues.
+		if ! issue_has_required_approval "$issue_num" "$repo_slug" "unknown"; then
+			echo "[pulse-wrapper] dispatch_triage_reviews: BLOCKED #${issue_num} in ${repo_slug} — requires cryptographic approval before triage" >>"$LOGFILE"
+			continue
+		fi
+
 		# ── t1894: Sandboxed triage — pre-fetch all GitHub data deterministically ──
 		local prefetch_file=""
 		prefetch_file=$(mktemp)


### PR DESCRIPTION
## Summary

- **Security fix**: `dispatch_triage_reviews()` had no approval gate — any external non-contributor issue with `needs-review` status triggered automated triage (worker dispatch + comment posting under maintainer's account) without cryptographic approval
- **Root cause of GH#17490 incident**: `robstiles` (author_association: NONE) opened issue → pulse dispatched triage worker → worker failed → raw sandbox output posted as maintainer's comment → infrastructure data leaked publicly
- **Fix**: Added `issue_has_required_approval()` check to `dispatch_triage_reviews()`, matching the gate already enforced by `dispatch_with_dedup()` for implementation dispatch. Unapproved external issues are now blocked from ALL automated processing, not just implementation.

## Defense in depth (with PR #17495)

| Layer | What it prevents | PR |
|-------|-----------------|-----|
| Approval gate (this PR) | Unapproved issues triggering any automated processing | This PR |
| Output sanitization (#17495) | Raw sandbox output being posted as comments | Merged |

Both layers are needed — the gate prevents the action, the sanitization prevents the leak if the gate is somehow bypassed.

Closes #17490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated issue triage processing with additional verification requirements. Issues now require cryptographic approval before being processed by the automated triage system. Unapproved issues are prevented from proceeding through the automated dispatch workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->