### PR TITLE
GH#17490: enforce review-bot-gate in deterministic merge pass

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -107,7 +107,7 @@ Changelog: `feat:` → Added, `fix:` → Fixed, `docs:`/`perf:`/`refactor:` → 
 
 **4.3 Label `status:in-review` (t1343):** check issue is `OPEN` first.
 
-**4.4 Review Bot Gate (t1382):** `review-bot-gate-helper.sh check "$PR_NUMBER" "$REPO"`. Poll 60s up to 10 min.
+**4.4 Review Bot Gate (t1382):** `review-bot-gate-helper.sh wait "$PR_NUMBER" "$REPO"`. Polls every 60s, up to 10 min timeout. Do NOT use `check` with ad-hoc polling — `wait` handles the retry loop.
 
 **4.5 Merge:** `gh pr merge --squash` (no `--delete-branch` from inside worktree).
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8199,6 +8199,27 @@ _merge_ready_prs_for_repo() {
 			fi
 		fi
 
+		# ── Review bot gate (GH#17490) ──
+		# The deterministic merge pass uses --admin which bypasses branch
+		# protection (including the review-bot-gate required status check).
+		# Enforce the gate in code so PRs cannot be merged without bot review.
+		local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
+		if [[ -f "$rbg_helper" ]]; then
+			local rbg_result=""
+			rbg_result=$(bash "$rbg_helper" check "$pr_number" "$repo_slug" 2>/dev/null) || rbg_result=""
+			local rbg_status=""
+			rbg_status=$(printf '%s' "$rbg_result" | grep -oE '^(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | head -1)
+			case "$rbg_status" in
+			PASS | SKIP | PASS_RATE_LIMITED)
+				echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+				;;
+			*)
+				echo "[pulse-wrapper] Review bot gate: ${rbg_status:-UNKNOWN} for PR #${pr_number} in ${repo_slug} — skipping merge" >>"$LOGFILE"
+				continue
+				;;
+			esac
+		fi
+
 		# Approve (satisfies REVIEW_REQUIRED for collaborator PRs)
 		approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

The deterministic merge pass in `pulse-wrapper.sh` uses `gh pr merge --admin` which bypasses all branch protection including the `review-bot-gate` required status check. Every PR merged through this path got zero bot review — not a race condition but a complete bypass.

### Changes

1. **Critical — review-bot-gate enforcement in merge pass** (`pulse-wrapper.sh`):
   - Added `review-bot-gate-helper.sh check` before `gh pr merge` in `_merge_ready_prs_for_repo()`
   - PRs with `WAITING` or unknown status are skipped (retried next cycle)
   - Only `PASS`, `PASS_RATE_LIMITED`, or `SKIP` proceed to merge
   - Graceful degradation: if helper script missing, merge proceeds (backward compat)

2. **Doc fix — full-loop.md step 4.4** (`full-loop.md`):
   - Changed from `review-bot-gate-helper.sh check` + ad-hoc polling to `review-bot-gate-helper.sh wait`
   - The `wait` subcommand already exists and handles polling properly (60s interval, 10 min timeout)

### Defense in depth (complete GH#17490 resolution)

| PR | Fix | Layer |
|----|-----|-------|
| #17495 | Sandbox output sanitisation | Output safety |
| #17496 | Cryptographic approval gate on triage | Dispatch safety |
| This PR | Review-bot-gate in deterministic merge | Merge safety |

## Runtime Testing

`self-assessed` — agent prompt and shell script changes. ShellCheck clean. No runtime environment needed.

## Files changed
- `.agents/scripts/pulse-wrapper.sh` — review-bot-gate check in `_merge_ready_prs_for_repo()`
- `.agents/scripts/commands/full-loop.md` — step 4.4 uses `wait` instead of `check`

Closes #17490


---
[aidevops.sh](https://aidevops.sh) v3.6.107 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 1h 10m and 25,139 tokens on this with the user in an interactive session.