### PR TITLE
GH#17447: increase continuation retry default from 3 to 10

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -2019,7 +2019,7 @@ cmd_run() {
 	# When a worker exits prematurely (activity but no completion signal),
 	# resume the session with a "continue" prompt instead of starting fresh.
 	# This catches the GPT-5.4 failure mode of stopping after investigation/setup.
-	local max_continuation_retries="${HEADLESS_CONTINUATION_MAX_RETRIES:-3}"
+	local max_continuation_retries="${HEADLESS_CONTINUATION_MAX_RETRIES:-10}"
 	local continuation_count=0
 	local original_prompt="$prompt"
 


### PR DESCRIPTION
One-line change: HEADLESS_CONTINUATION_MAX_RETRIES default 3 to 10. The full-loop lifecycle has ~6 natural phase boundaries where a model may stop. 3 retries was too conservative — workers exhaust attempts before reaching merge. 10 gives headroom. Still overridable via env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased retry attempts for process recovery from 3 to 10, improving resilience for continuation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->