### PR TITLE
GH#17497: fix TOCTOU race in dispatch claim comment cleanup

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6132,13 +6132,14 @@ has_worker_for_repo_issue() {
 #######################################
 # Check if dispatching a worker would be a duplicate (GH#4400, GH#5210, GH#6696, GH#11086)
 #
-# Six-layer dedup:
+# Seven-layer dedup:
 #   1. dispatch-ledger-helper.sh check-issue — in-flight ledger (GH#6696)
 #   2. has_worker_for_repo_issue() — exact repo+issue process match
 #   3. dispatch-dedup-helper.sh is-duplicate — normalized title key match
 #   4. dispatch-dedup-helper.sh has-open-pr — merged PR evidence for issue/task
-#   5. dispatch-dedup-helper.sh is-assigned — cross-machine assignee guard (GH#6891)
-#   6. dispatch-dedup-helper.sh claim — cross-machine optimistic lock (GH#11086)
+#   5. dispatch-dedup-helper.sh has-dispatch-comment — cross-machine dispatch comment (GH#11141)
+#   6. dispatch-dedup-helper.sh is-assigned — cross-machine assignee guard (GH#6891)
+#   7. dispatch-dedup-helper.sh claim — cross-machine optimistic lock (GH#11086)
 #
 # Layer 1 (ledger) is checked first because it's the fastest (local file
 # read, no process scanning or GitHub API calls) and catches the primary
@@ -6500,12 +6501,29 @@ dispatch_with_dedup() {
 		echo "[dispatch_with_dedup] Warning: failed to post deterministic dispatch comment for #${issue_number}" >>"$LOGFILE"
 	}
 
-	# GH#15317: Clean up the DISPATCH_CLAIM comment now that the persistent
-	# dispatch comment is posted. The claim served its purpose (optimistic lock
-	# during the 8s consensus window). Leaving it pollutes the issue timeline —
-	# awardsapp #2051 had 29 stale claim comments.
-	# GH#16978: Use _cleanup_claim_comment helper (also called on early-return paths).
-	_cleanup_claim_comment
+	# GH#17497: Defer claim comment cleanup to prevent TOCTOU race condition.
+	# Previously (GH#15317/GH#16978), the claim was deleted synchronously here.
+	# Race: Runner A wins claim → deletes it → Runner B (still inside 8s consensus
+	# window) sees only its own claim → incorrectly "wins" → duplicate dispatch.
+	# Evidence: #17497 — alex-solovyev and marcusquinn both dispatched 7s apart.
+	#
+	# Fix: defer deletion by one consensus window after the dispatch comment is
+	# posted. This keeps the claim visible long enough for any concurrent claimant
+	# to see it during their consensus check. The background subshell avoids
+	# blocking dispatch throughput. Early-return paths still use synchronous
+	# _cleanup_claim_comment (no race — dispatch was blocked, no concurrent claim
+	# to protect against).
+	if [[ -n "$_claim_comment_id" ]]; then
+		local __deferred_cid="$_claim_comment_id" __deferred_slug="$repo_slug"
+		local __deferred_issue="$issue_number" __deferred_logfile="$LOGFILE"
+		(
+			sleep "${DISPATCH_CLAIM_WINDOW:-8}"
+			gh api "repos/${__deferred_slug}/issues/comments/${__deferred_cid}" \
+				--method DELETE >/dev/null 2>&1 || true
+			echo "[dispatch_with_dedup] Deferred claim cleanup: deleted comment ${__deferred_cid} for #${__deferred_issue}" >>"$__deferred_logfile"
+		) &
+		_claim_comment_id=""
+	fi
 
 	echo "[dispatch_with_dedup] Dispatched worker PID ${worker_pid} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 	return 0


### PR DESCRIPTION
## Summary

Fixes a TOCTOU race condition in `dispatch_with_dedup()` where two runners can both "win" the optimistic claim lock and dispatch duplicate workers for the same issue.

Closes #17497

## Root Cause

The dispatch claim protocol uses an optimistic lock: post a `DISPATCH_CLAIM` comment → sleep 8s → oldest claim wins. After winning, the dispatcher:
1. Assigns the issue
2. Launches the worker
3. Posts a persistent "Dispatching worker" comment
4. **Deletes the claim comment** ← race window

If Runner B posted its claim during Runner A's consensus window but checks claims AFTER Runner A deletes its winning claim (steps 1-4 take ~5s), Runner B sees only its own claim and incorrectly "wins".

Timeline from #17497 (dispatch comments 7s apart):
- **T+5s**: Runner A posts claim
- **T+12s**: Runner B posts claim; Runner B's Layer 5/6 checks pass (no dispatch comment or assignee yet)
- **T+13s**: Runner A wins claim, begins dispatch sequence
- **T+18s**: Runner A deletes claim after posting dispatch comment
- **T+20s**: Runner B checks claims → only sees its own → "wins" → duplicate dispatch

## Fix

Replace synchronous `_cleanup_claim_comment` on the success path with a deferred background cleanup that waits one consensus window (8s) after the dispatch comment is posted. This keeps the winning claim visible to concurrent claimants during their consensus check.

Early-return cleanup paths (blocked dispatches) remain synchronous — no race exists there.

Also corrects the dedup layer count comment (6 → 7) to include the `has-dispatch-comment` layer from GH#11141.

## Files Changed

- `.agents/scripts/pulse-wrapper.sh` — deferred claim cleanup + comment fix

## Runtime Testing

- **Risk**: Low (agent prompt/script, no runtime state affected)
- **Verification**: `self-assessed` — `bash -n` syntax check passed, shellcheck clean on changed region
- **Blast radius**: Single function (`dispatch_with_dedup`), no behavioural change except timing of comment deletion

## Key Decisions

- Background subshell (`(sleep 8 && gh api DELETE) &`) chosen over synchronous sleep to avoid adding 8s to every dispatch cycle
- `DISPATCH_CLAIM_WINDOW` variable reused for the deferral period — keeps the two windows in sync

---
[aidevops.sh](https://aidevops.sh) v3.6.108 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 35m and 16,413 tokens on this with the user in an interactive session.