### PR TITLE
GH#17442: fix systemd pulse TimeoutStartSec — use PULSE_STALE_THRESHOLD_SECONDS

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -229,7 +229,7 @@ PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}"
 				"true" \
 				"false" \
 				"" \
-				"120"
+				"${PULSE_STALE_THRESHOLD_SECONDS}"
 		fi
 	elif [[ "$_pulse_lower" == "false" && "$_pulse_installed" == "true" ]]; then
 		# User explicitly disabled but pulse is still installed — clean up


### PR DESCRIPTION
## Summary

- The systemd service unit for the supervisor pulse was using `TimeoutStartSec=120` (the 2-minute timer interval), which would SIGTERM a legitimately running pulse worker mid-dispatch
- A pulse worker can run for up to `PULSE_STALE_THRESHOLD_SECONDS` (1800s) before the wrapper's own watchdog kills it; the systemd timeout must be at least as large
- Fix: pass `PULSE_STALE_THRESHOLD_SECONDS` as `timeout_sec` so the generated `.service` file contains `TimeoutStartSec=1800`, matching the wrapper's stale threshold

## Root Cause

`setup_supervisor_pulse()` called `_install_scheduler_linux` with `timeout_sec="120"` (arg 13). This propagated through `_install_scheduler_systemd` to `TimeoutStartSec=120` in the generated unit file. The `_install_scheduler_systemd` function already supports `TimeoutStartSec` correctly — the bug was the wrong value being passed at the call site.

## Files Changed

- `setup-modules/schedulers.sh`: line 232 — `"120"` → `"${PULSE_STALE_THRESHOLD_SECONDS}"`

## Runtime Testing

**Risk level**: Low — single-line change to a shell variable substitution in a scheduler setup function. No logic change; only the timeout value written to the generated `.service` file changes. The fix is self-assessed: the variable `PULSE_STALE_THRESHOLD_SECONDS=1800` is defined at line 10 of the same file and already passed as an env var to the service, so the substitution is guaranteed to resolve correctly.

## Key Decisions

- Used `${PULSE_STALE_THRESHOLD_SECONDS}` (the existing constant) rather than hardcoding `900` or `1800`, keeping the timeout in sync with the constant definition at the top of the file
- Did not change `interval_sec` (arg 5 = `"120"`) — the 2-minute timer interval is correct and unrelated to the service timeout

Closes #17442

---
[aidevops.sh](https://aidevops.sh) v3.6.110 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scheduler installation process now dynamically uses a configurable stale threshold parameter instead of a hardcoded fixed value. This enhancement provides improved flexibility during system deployment and configuration, allowing administrators to adjust staleness detection mechanisms for different operational environments while maintaining consistent monitoring behavior across installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->