### PR TITLE
GH#17442: align systemd pulse timeout with watchdog

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -202,6 +202,9 @@ setup_supervisor_pulse() {
 		if [[ "$_os" == "Darwin" ]]; then
 			_install_pulse_launchd "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed"
 		else
+			# Keep systemd as a hard-stop fallback above the wrapper watchdog.
+			# Timeout must exceed PULSE_STALE_THRESHOLD to avoid racing it.
+			local _pulse_timeout_sec=$((PULSE_STALE_THRESHOLD_SECONDS + 60))
 			local _pulse_env="PULSE_DIR=${HOME}/.aidevops/.agent-workspace
 PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}"
 			local _configured_headless_models _configured_pulse_model
@@ -229,7 +232,7 @@ PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}"
 				"true" \
 				"false" \
 				"" \
-				"${PULSE_STALE_THRESHOLD_SECONDS}"
+				"${_pulse_timeout_sec}"
 		fi
 	elif [[ "$_pulse_lower" == "false" && "$_pulse_installed" == "true" ]]; then
 		# User explicitly disabled but pulse is still installed — clean up

--- a/tests/test-pulse-systemd-timeout.sh
+++ b/tests/test-pulse-systemd-timeout.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCHEDULERS_SCRIPT="${REPO_ROOT}/setup-modules/schedulers.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+print_info() {
+	return 0
+}
+
+print_warning() {
+	return 0
+}
+
+_ensure_cron_path() {
+	return 0
+}
+
+_scheduler_detect_installed() {
+	return 1
+}
+
+_systemd_user_available() {
+	return 0
+}
+
+systemctl() {
+	local scope="${1:-}"
+	local action="${2:-}"
+	local target="${3:-}"
+
+	if [[ "$scope" != "--user" ]]; then
+		return 1
+	fi
+
+	if [[ "$action" == "daemon-reload" ]]; then
+		return 0
+	fi
+
+	if [[ "$action" == "enable" && "$target" == "--now" ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+export HOME="${TMP_DIR}/home"
+export PATH="/usr/bin:/bin"
+export NON_INTERACTIVE="true"
+export AIDEVOPS_SUPERVISOR_PULSE="true"
+mkdir -p "$HOME/.aidevops/agents/scripts" "$HOME/.aidevops/logs"
+
+WRAPPER_SCRIPT="$HOME/.aidevops/agents/scripts/pulse-wrapper.sh"
+touch "$WRAPPER_SCRIPT"
+chmod +x "$WRAPPER_SCRIPT"
+
+# shellcheck source=setup-modules/schedulers.sh
+source "$SCHEDULERS_SCRIPT"
+
+# Override sourced helpers for deterministic unit behavior.
+_scheduler_detect_installed() {
+	return 1
+}
+
+_systemd_user_available() {
+	return 0
+}
+
+setup_supervisor_pulse "Linux"
+
+SERVICE_FILE="$HOME/.config/systemd/user/aidevops-supervisor-pulse.service"
+
+if ! grep -q '^TimeoutStartSec=1860$' "$SERVICE_FILE"; then
+	echo "expected TimeoutStartSec=1860 in ${SERVICE_FILE}" >&2
+	exit 1
+fi
+
+if ! grep -q '^Environment=PULSE_STALE_THRESHOLD="1800"$' "$SERVICE_FILE"; then
+	echo "expected Environment=PULSE_STALE_THRESHOLD=1800 in ${SERVICE_FILE}" >&2
+	exit 1
+fi
+
+printf 'PASS %s\n' "pulse systemd service timeout exceeds watchdog threshold"


### PR DESCRIPTION
## Summary
- compute a dedicated pulse systemd timeout as `PULSE_STALE_THRESHOLD_SECONDS + 60` so systemd acts as a hard ceiling after the wrapper watchdog window
- pass that derived timeout into Linux supervisor-pulse scheduler installation instead of reusing the 120s run interval
- add a regression test that generates the systemd unit and asserts `TimeoutStartSec=1860` with `PULSE_STALE_THRESHOLD=1800`

## Testing
- shellcheck setup-modules/schedulers.sh tests/test-pulse-systemd-timeout.sh
- bash tests/test-pulse-systemd-timeout.sh

## Runtime Testing
- self-assessed: low-risk scheduler config change; validated generated unit content in an isolated test harness

Closes #17442


---
[aidevops.sh](https://aidevops.sh) v3.6.110 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.3-codex