### PR TITLE
GH#17442: increase activity watchdog timeout from 90s to 300s

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1362,8 +1362,8 @@ _run_activity_watchdog() {
 	local output_file="$1"
 	local worker_pid="$2"
 	local exit_code_file="$3"
-	local timeout="${HEADLESS_ACTIVITY_TIMEOUT_SECONDS:-90}"
-	[[ "$timeout" =~ ^[0-9]+$ ]] || timeout=90
+	local timeout="${HEADLESS_ACTIVITY_TIMEOUT_SECONDS:-300}"
+	[[ "$timeout" =~ ^[0-9]+$ ]] || timeout=300
 
 	local elapsed=0
 	local poll_interval=5


### PR DESCRIPTION
The activity watchdog killed workers before OpenCode could produce first model output. With 335 agents in the system prompt, OpenCode needs 60-120s to initialize. The 90s timeout caused the 306-byte log pattern: dispatch, timeout kill, redispatch — in a loop. 300s gives headroom. Still overridable via env var. Closes #17442