### PR TITLE
t1897: Include subagent token counts in signature footers via runtime-agnostic ledger

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -12,8 +12,8 @@
 #   [OpenCode CLI](https://opencode.ai) v1.3.3, [aidevops.sh](https://aidevops.sh) v3.5.6, anthropic/opus-4-6, 1,234 tokens
 #
 # Usage:
-#   gh-signature-helper.sh generate [--model MODEL] [--tokens N] [--cli NAME] [--cli-version VER]
-#   gh-signature-helper.sh footer   [--model MODEL] [--tokens N] [--cli NAME] [--cli-version VER]
+#   gh-signature-helper.sh generate [--model MODEL] [--tokens N] [--subagent-tokens N] [--cli NAME] [--cli-version VER]
+#   gh-signature-helper.sh footer   [--model MODEL] [--tokens N] [--subagent-tokens N] [--cli NAME] [--cli-version VER]
 #   gh-signature-helper.sh help
 #
 # The "generate" command outputs just the signature line (no leading ---).
@@ -25,7 +25,8 @@
 #   AIDEVOPS_SIG_MODEL        Model ID (e.g., "anthropic/opus-4-6")
 #   AIDEVOPS_SIG_TOKENS       Token count (e.g., "1234")
 #
-# Dependencies: lib/version.sh (aidevops version), aidevops-update-check.sh (CLI detection)
+# Dependencies: lib/version.sh (aidevops version), aidevops-update-check.sh (CLI detection),
+#   token-ledger-helper.sh (subagent token counts, optional)
 
 set -euo pipefail
 
@@ -525,6 +526,35 @@ _detect_issue_scoped_tokens() {
 }
 
 # =============================================================================
+# Detect subagent tokens from the runtime-agnostic token ledger
+# =============================================================================
+# Reads the token-ledger-helper.sh JSONL ledger for the current session and
+# returns the total subagent token count. Returns empty string if no ledger
+# exists or no entries are found.
+#
+# The ledger is written by subagents via token-ledger-helper.sh record.
+# This function is the read-side integration for signature footers.
+
+_detect_subagent_tokens() {
+	local ledger_helper="${SCRIPT_DIR}/token-ledger-helper.sh"
+
+	if [[ ! -x "$ledger_helper" ]]; then
+		echo ""
+		return 0
+	fi
+
+	local total
+	total=$("$ledger_helper" sum 2>/dev/null || echo "")
+
+	if [[ -n "$total" ]] && [[ "$total" =~ ^[0-9]+$ ]] && [[ "$total" -gt 0 ]]; then
+		echo "$total"
+	else
+		echo ""
+	fi
+	return 0
+}
+
+# =============================================================================
 # Detect model from runtime DB
 # =============================================================================
 # Queries the OpenCode session DB for the model used in the current session.
@@ -826,7 +856,7 @@ _format_number() {
 # =============================================================================
 # _parse_generate_args — parse CLI args for cmd_generate
 # =============================================================================
-# Outputs pipe-separated: model|tokens|cli_name|cli_version|issue_ref|issue_created|solved|no_session|session_type_override|time_secs
+# Outputs pipe-separated: model|tokens|cli_name|cli_version|issue_ref|issue_created|solved|no_session|session_type_override|time_secs|subagent_tokens
 
 _parse_generate_args() {
 	local model="${AIDEVOPS_SIG_MODEL:-}"
@@ -834,7 +864,7 @@ _parse_generate_args() {
 	local cli_name="${AIDEVOPS_SIG_CLI:-}"
 	local cli_version="${AIDEVOPS_SIG_CLI_VERSION:-}"
 	local issue_ref="" issue_created="" solved="false" no_session="false"
-	local session_type_override="" time_secs=""
+	local session_type_override="" time_secs="" subagent_tokens=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -878,14 +908,18 @@ _parse_generate_args() {
 			time_secs="$2"
 			shift 2
 			;;
+		--subagent-tokens)
+			subagent_tokens="$2"
+			shift 2
+			;;
 		*) shift ;;
 		esac
 	done
 
-	printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+	printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
 		"$model" "$tokens" "$cli_name" "$cli_version" \
 		"$issue_ref" "$issue_created" "$solved" "$no_session" \
-		"$session_type_override" "$time_secs"
+		"$session_type_override" "$time_secs" "$subagent_tokens"
 	return 0
 }
 
@@ -948,7 +982,7 @@ _collect_time_metrics() {
 # =============================================================================
 # _build_signature — assemble the natural-language signature string
 # =============================================================================
-# Args: model cli_name cli_version tokens session_time_str total_time_str solved issue_total_tokens session_type
+# Args: model cli_name cli_version tokens session_time_str total_time_str solved issue_total_tokens session_type subagent_tokens
 
 _build_signature() {
 	local model="$1"
@@ -960,6 +994,7 @@ _build_signature() {
 	local solved="$7"
 	local issue_total_tokens="${8:-}"
 	local session_type="${9:-}"
+	local subagent_tokens="${10:-}"
 
 	local aidevops_version
 	aidevops_version=$(aidevops_find_version)
@@ -992,10 +1027,11 @@ _build_signature() {
 		sig="${sig} with ${display_model}"
 	fi
 
-	# "spent Xm and N tokens on this." — time first, tokens second
-	local has_time="" has_tokens=""
+	# "spent Xm and N tokens (incl. M subagent) on this." — time first, tokens second
+	local has_time="" has_tokens="" has_subagent_tokens=""
 	if [[ -n "$session_time_str" ]]; then has_time="true"; fi
 	if [[ -n "$tokens" ]] && [[ "$tokens" != "0" ]]; then has_tokens="true"; fi
+	if [[ -n "$subagent_tokens" ]] && [[ "$subagent_tokens" != "0" ]]; then has_subagent_tokens="true"; fi
 
 	if [[ -n "$has_time" ]] || [[ -n "$has_tokens" ]]; then
 		sig="${sig} spent"
@@ -1009,6 +1045,12 @@ _build_signature() {
 			local formatted
 			formatted=$(_format_number "$tokens")
 			sig="${sig} ${formatted} tokens"
+			# Append subagent breakdown when subagent tokens are present
+			if [[ -n "$has_subagent_tokens" ]]; then
+				local formatted_subagent
+				formatted_subagent=$(_format_number "$subagent_tokens")
+				sig="${sig} (incl. ${formatted_subagent} subagent)"
+			fi
 		fi
 		if [[ "$session_type" == "interactive" ]]; then
 			sig="${sig} on this with the user in an interactive session."
@@ -1061,9 +1103,9 @@ cmd_generate() {
 	local parsed
 	parsed=$(_parse_generate_args "$@")
 	local model tokens cli_name cli_version issue_ref issue_created solved no_session
-	local session_type_override time_secs
+	local session_type_override time_secs subagent_tokens
 	IFS='|' read -r model tokens cli_name cli_version issue_ref issue_created solved no_session \
-		session_type_override time_secs <<<"$parsed"
+		session_type_override time_secs subagent_tokens <<<"$parsed"
 
 	# Auto-detect CLI name/version
 	local cli_resolved
@@ -1092,6 +1134,22 @@ cmd_generate() {
 			if [[ -z "$tokens" ]]; then
 				tokens=$(_detect_session_tokens)
 			fi
+		fi
+
+		# Auto-detect subagent tokens from the runtime-agnostic ledger (GH#17507).
+		# Only auto-detect if not explicitly provided via --subagent-tokens.
+		if [[ -z "$subagent_tokens" ]]; then
+			subagent_tokens=$(_detect_subagent_tokens)
+		fi
+
+		# Add subagent tokens to the main token total so the signature shows
+		# the combined count. The original subagent_tokens value is preserved
+		# for the breakdown annotation.
+		if [[ -n "$subagent_tokens" ]] && [[ "$subagent_tokens" =~ ^[0-9]+$ ]] && [[ "$subagent_tokens" -gt 0 ]]; then
+			local main_tokens="${tokens:-0}"
+			main_tokens=$(printf '%s' "$main_tokens" | tr -cd '0-9')
+			main_tokens="${main_tokens:-0}"
+			tokens=$((main_tokens + subagent_tokens))
 		fi
 
 		# Collect time metrics
@@ -1128,7 +1186,8 @@ cmd_generate() {
 	# Build and emit the signature
 	_build_signature \
 		"$model" "$cli_name" "$cli_version" "$tokens" \
-		"$session_time_str" "$total_time_str" "$solved" "$issue_total_tokens" "$session_type"
+		"$session_time_str" "$total_time_str" "$solved" "$issue_total_tokens" "$session_type" \
+		"$subagent_tokens"
 	return 0
 }
 
@@ -1185,6 +1244,7 @@ Commands:
 Options:
   --model MODEL             Model ID (e.g., anthropic/claude-opus-4-6)
   --tokens N                Token count (auto-detected from OpenCode DB if omitted)
+  --subagent-tokens N       Subagent token count (auto-detected from ledger if omitted)
   --cli NAME                CLI name override (e.g., "OpenCode CLI")
   --cli-version VER         CLI version override (e.g., "1.3.3")
   --issue OWNER/REPO#NUM    GitHub issue ref for total time and token summing
@@ -1194,6 +1254,7 @@ Options:
 Auto-detected fields (OpenCode sessions):
   - CLI name and version
   - Token count (input+output from session DB)
+  - Subagent token count (from token-ledger-helper.sh JSONL ledger)
   - Session time (duration since session start)
   - Issue total tokens (sum of all signature footers by the authenticated
     GitHub user on the issue's comments, plus current session tokens).

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -308,10 +308,100 @@ fi
 rm -rf "$tmp_home"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Test 15: help command exits cleanly
+# Test 15: explicit --subagent-tokens adds to total and shows breakdown
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 15: help command"
+echo "Test 15: explicit --subagent-tokens"
+result=$("$HELPER" generate --cli "Test" --model "m" --tokens 1000 --subagent-tokens 500)
+assert_contains "combined total" "1,500 tokens" "$result"
+assert_contains "subagent breakdown" "(incl. 500 subagent)" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 16: --subagent-tokens 0 does not show breakdown
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 16: --subagent-tokens 0 omits breakdown"
+result=$("$HELPER" generate --cli "Test" --model "m" --tokens 1000 --subagent-tokens 0)
+assert_contains "tokens present" "1,000 tokens" "$result"
+assert_not_contains "no subagent breakdown" "subagent" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 17: subagent tokens with comma formatting
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 17: subagent tokens comma formatting"
+result=$("$HELPER" generate --cli "Test" --model "m" --tokens 10000 --subagent-tokens 5000)
+assert_contains "combined total formatted" "15,000 tokens" "$result"
+assert_contains "subagent formatted" "(incl. 5,000 subagent)" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 18: token-ledger-helper.sh record and sum
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 18: token-ledger-helper.sh record and sum"
+LEDGER_HELPER="${SCRIPT_DIR}/../token-ledger-helper.sh"
+if [[ -x "$LEDGER_HELPER" ]]; then
+	tmp_ledger_dir=$(mktemp -d 2>/dev/null || mktemp -d -t ledgertest)
+
+	# Record some entries
+	AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="test-session-1" \
+		"$LEDGER_HELPER" record --agent explore --tokens 500 --model haiku
+	AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="test-session-1" \
+		"$LEDGER_HELPER" record --agent pr --tokens 2000 --model sonnet
+	AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="test-session-1" \
+		"$LEDGER_HELPER" record --agent general --tokens 300
+
+	# Sum should be 2800
+	sum_result=$(AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="test-session-1" \
+		"$LEDGER_HELPER" sum)
+	assert_eq "ledger sum is 2800" "2800" "$sum_result"
+
+	# Different session should be 0
+	sum_other=$(AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="test-session-2" \
+		"$LEDGER_HELPER" sum)
+	assert_eq "different session sum is 0" "0" "$sum_other"
+
+	# Reset should clear
+	AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="test-session-1" \
+		"$LEDGER_HELPER" reset >/dev/null
+	sum_after_reset=$(AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="test-session-1" \
+		"$LEDGER_HELPER" sum)
+	assert_eq "sum after reset is 0" "0" "$sum_after_reset"
+
+	rm -rf "$tmp_ledger_dir"
+else
+	echo "  SKIP: token-ledger-helper.sh not found"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 19: auto-detect subagent tokens from ledger
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 19: auto-detect subagent tokens from ledger"
+if [[ -x "$LEDGER_HELPER" ]]; then
+	tmp_ledger_dir=$(mktemp -d 2>/dev/null || mktemp -d -t ledgertest2)
+	test_session_id="sig-test-$$"
+
+	# Record subagent tokens
+	AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="$test_session_id" \
+		"$LEDGER_HELPER" record --agent explore --tokens 750
+
+	# Generate signature with ledger auto-detection
+	result=$(AIDEVOPS_LEDGER_DIR="$tmp_ledger_dir" AIDEVOPS_SESSION_ID="$test_session_id" \
+		"$HELPER" generate --cli "Test" --model "m" --tokens 1000)
+	assert_contains "auto-detected subagent tokens in total" "1,750 tokens" "$result"
+	assert_contains "auto-detected subagent breakdown" "(incl. 750 subagent)" "$result"
+
+	rm -rf "$tmp_ledger_dir"
+else
+	echo "  SKIP: token-ledger-helper.sh not found"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 20: help command exits cleanly
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 20: help command"
 result=$("$HELPER" help 2>&1)
 assert_contains "help shows usage" "Usage:" "$result"
 assert_contains "help shows examples" "Examples:" "$result"

--- a/.agents/scripts/token-ledger-helper.sh
+++ b/.agents/scripts/token-ledger-helper.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# token-ledger-helper.sh — Runtime-agnostic token usage ledger for subagents
+# =============================================================================
+#
+# Records token usage from subagent calls into a JSONL ledger file so that
+# signature footers can include total token counts across all subagents in a
+# session. The ledger is a plain file — any runtime (Claude Code, OpenCode,
+# custom agents) can write to it without runtime-specific DB access.
+#
+# Ledger location:
+#   ~/.aidevops/.agent-workspace/tmp/token-ledger-{session_id}.jsonl
+#
+# Each line is a JSON object:
+#   {"ts":"ISO","agent":"explore","tokens":1234,"model":"haiku","task_id":"abc"}
+#
+# Usage:
+#   token-ledger-helper.sh record --agent NAME --tokens N [--model MODEL] [--task-id ID] [--session-id SID]
+#   token-ledger-helper.sh sum    [--session-id SID]
+#   token-ledger-helper.sh show   [--session-id SID]
+#   token-ledger-helper.sh reset  [--session-id SID]
+#   token-ledger-helper.sh help
+#
+# Environment variables:
+#   AIDEVOPS_SESSION_ID   Override session ID for ledger file naming
+#   AIDEVOPS_LEDGER_DIR   Override ledger directory (default: ~/.aidevops/.agent-workspace/tmp)
+
+set -euo pipefail
+
+LEDGER_DIR="${AIDEVOPS_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+LEDGER_PREFIX="token-ledger-"
+LEDGER_SUFFIX=".jsonl"
+
+# =============================================================================
+# Session ID resolution
+# =============================================================================
+# Determines a stable session identifier for the ledger filename.
+# Priority: explicit --session-id > AIDEVOPS_SESSION_ID env > PPID chain.
+
+_resolve_session_id() {
+	local explicit_id="$1"
+
+	if [[ -n "$explicit_id" ]]; then
+		printf '%s' "$explicit_id"
+		return 0
+	fi
+
+	if [[ -n "${AIDEVOPS_SESSION_ID:-}" ]]; then
+		printf '%s' "$AIDEVOPS_SESSION_ID"
+		return 0
+	fi
+
+	# Fallback: use the top-level parent PID as a stable session anchor.
+	# Walk up the process tree to find the outermost non-init process,
+	# capped at 10 levels to avoid infinite loops.
+	local pid="${PPID:-$$}"
+	local prev_pid="$pid"
+	local depth=0
+	while [[ "$pid" -gt 1 ]] && [[ "$depth" -lt 10 ]] 2>/dev/null; do
+		prev_pid="$pid"
+		pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ' || echo "1")
+		depth=$((depth + 1))
+	done
+
+	printf 'pid-%s' "$prev_pid"
+	return 0
+}
+
+# =============================================================================
+# Ledger file path
+# =============================================================================
+
+_ledger_path() {
+	local session_id="$1"
+	printf '%s/%s%s%s' "$LEDGER_DIR" "$LEDGER_PREFIX" "$session_id" "$LEDGER_SUFFIX"
+	return 0
+}
+
+# =============================================================================
+# record — append a token usage entry to the ledger
+# =============================================================================
+
+cmd_record() {
+	local agent="" tokens="" model="" task_id="" session_id=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--agent | -a)
+			agent="$2"
+			shift 2
+			;;
+		--tokens | -t)
+			tokens="$2"
+			shift 2
+			;;
+		--model | -m)
+			model="$2"
+			shift 2
+			;;
+		--task-id)
+			task_id="$2"
+			shift 2
+			;;
+		--session-id | -s)
+			session_id="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$agent" ]]; then
+		echo "Error: --agent is required" >&2
+		return 1
+	fi
+
+	if [[ -z "$tokens" ]] || ! [[ "$tokens" =~ ^[0-9]+$ ]]; then
+		echo "Error: --tokens must be a positive integer" >&2
+		return 1
+	fi
+
+	local sid
+	sid=$(_resolve_session_id "$session_id")
+
+	local ledger
+	ledger=$(_ledger_path "$sid")
+
+	mkdir -p "$(dirname "$ledger")"
+
+	local ts
+	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+	# Build JSON line — use printf for Bash 3.2 compat (no jq dependency)
+	local json_line
+	json_line=$(printf '{"ts":"%s","agent":"%s","tokens":%s' "$ts" "$agent" "$tokens")
+	if [[ -n "$model" ]]; then
+		json_line=$(printf '%s,"model":"%s"' "$json_line" "$model")
+	fi
+	if [[ -n "$task_id" ]]; then
+		json_line=$(printf '%s,"task_id":"%s"' "$json_line" "$task_id")
+	fi
+	json_line="${json_line}}"
+
+	printf '%s\n' "$json_line" >>"$ledger"
+	return 0
+}
+
+# =============================================================================
+# sum — total tokens across all ledger entries for a session
+# =============================================================================
+
+cmd_sum() {
+	local session_id=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-id | -s)
+			session_id="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local sid
+	sid=$(_resolve_session_id "$session_id")
+
+	local ledger
+	ledger=$(_ledger_path "$sid")
+
+	if [[ ! -f "$ledger" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	# Sum tokens field from each JSONL line.
+	# Use grep + awk for portability (no jq dependency).
+	local total=0
+	local line
+	while IFS= read -r line; do
+		# Extract tokens value: match "tokens":NNNN
+		local val
+		val=$(printf '%s' "$line" | grep -oE '"tokens":[0-9]+' | grep -oE '[0-9]+' || echo "0")
+		if [[ -n "$val" ]] && [[ "$val" =~ ^[0-9]+$ ]]; then
+			total=$((total + val))
+		fi
+	done <"$ledger"
+
+	printf '%d\n' "$total"
+	return 0
+}
+
+# =============================================================================
+# show — display all ledger entries for a session
+# =============================================================================
+
+cmd_show() {
+	local session_id=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-id | -s)
+			session_id="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local sid
+	sid=$(_resolve_session_id "$session_id")
+
+	local ledger
+	ledger=$(_ledger_path "$sid")
+
+	if [[ ! -f "$ledger" ]]; then
+		echo "No ledger entries for session: ${sid}"
+		return 0
+	fi
+
+	echo "Session: ${sid}"
+	echo "Ledger: ${ledger}"
+	echo "---"
+	cat "$ledger"
+	echo "---"
+
+	local total
+	total=$(cmd_sum --session-id "$sid")
+	echo "Total: ${total} tokens"
+	return 0
+}
+
+# =============================================================================
+# reset — delete the ledger file for a session
+# =============================================================================
+
+cmd_reset() {
+	local session_id=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-id | -s)
+			session_id="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local sid
+	sid=$(_resolve_session_id "$session_id")
+
+	local ledger
+	ledger=$(_ledger_path "$sid")
+
+	if [[ -f "$ledger" ]]; then
+		rm -f "$ledger"
+		echo "Ledger reset for session: ${sid}"
+	else
+		echo "No ledger to reset for session: ${sid}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# help
+# =============================================================================
+
+cmd_help() {
+	cat <<'EOF'
+token-ledger-helper.sh — Runtime-agnostic token usage ledger for subagents
+
+Usage:
+  token-ledger-helper.sh record --agent NAME --tokens N [--model MODEL] [--task-id ID] [--session-id SID]
+  token-ledger-helper.sh sum    [--session-id SID]
+  token-ledger-helper.sh show   [--session-id SID]
+  token-ledger-helper.sh reset  [--session-id SID]
+  token-ledger-helper.sh help
+
+Commands:
+  record    Append a token usage entry to the session ledger
+  sum       Print total tokens for the session (integer)
+  show      Display all ledger entries and total
+  reset     Delete the ledger file for the session
+  help      Show this help
+
+Options:
+  --agent NAME       Subagent name (e.g., "explore", "pr", "general")
+  --tokens N         Token count (positive integer)
+  --model MODEL      Model used (e.g., "haiku", "sonnet", "opus")
+  --task-id ID       Task ID from the Task tool invocation
+  --session-id SID   Override session ID (default: auto-detected from env/PID)
+
+Environment:
+  AIDEVOPS_SESSION_ID   Override session ID for ledger file naming
+  AIDEVOPS_LEDGER_DIR   Override ledger directory
+
+Ledger format (JSONL):
+  {"ts":"2025-01-15T10:30:00Z","agent":"explore","tokens":1234,"model":"haiku","task_id":"abc"}
+
+Integration with gh-signature-helper.sh:
+  The signature helper reads the ledger via --subagent-tokens flag or
+  auto-detects it when generating footers. Subagent tokens are added to
+  the session total and shown as a breakdown in the signature.
+
+Example:
+  # Record subagent usage
+  token-ledger-helper.sh record --agent explore --tokens 500 --model haiku
+  token-ledger-helper.sh record --agent pr --tokens 2000 --model sonnet
+
+  # Check total
+  token-ledger-helper.sh sum
+  # Output: 2500
+
+  # Show breakdown
+  token-ledger-helper.sh show
+EOF
+	return 0
+}
+
+# =============================================================================
+# main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	record) cmd_record "$@" ;;
+	sum) cmd_sum "$@" ;;
+	show) cmd_show "$@" ;;
+	reset) cmd_reset "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		echo "Error: Unknown command: $command" >&2
+		cmd_help >&2
+		return 1
+		;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `token-ledger-helper.sh` — a runtime-agnostic JSONL ledger for recording subagent token usage across any runtime (Claude Code, OpenCode, custom agents)
- Integrates the ledger into `gh-signature-helper.sh` so signature footers automatically include subagent token counts with a breakdown annotation (e.g., "1,750 tokens (incl. 750 subagent)")
- Adds `--subagent-tokens` CLI flag for explicit override when auto-detection isn't available

## Changes

### New: `.agents/scripts/token-ledger-helper.sh`
- JSONL-based ledger file per session at `~/.aidevops/.agent-workspace/tmp/token-ledger-{session_id}.jsonl`
- Commands: `record` (append entry), `sum` (total tokens), `show` (display all), `reset` (clear)
- Session ID resolution: explicit flag > `AIDEVOPS_SESSION_ID` env > PID chain
- No jq dependency — uses grep/awk for portability

### Modified: `.agents/scripts/gh-signature-helper.sh`
- New `_detect_subagent_tokens()` function reads the ledger via `token-ledger-helper.sh sum`
- Auto-detection in `cmd_generate()`: reads ledger, adds subagent tokens to main total
- `_build_signature()` shows breakdown: "N tokens (incl. M subagent)"
- New `--subagent-tokens N` CLI flag in `_parse_generate_args()`
- Updated help text and header comments

### Modified: `.agents/scripts/tests/test-gh-signature-helper.sh`
- Tests 15-17: explicit `--subagent-tokens` flag (combined total, zero omission, comma formatting)
- Test 18: `token-ledger-helper.sh` record/sum/reset lifecycle
- Test 19: auto-detection integration (ledger → signature footer)
- Test 20: help command (renumbered from 15)

## Runtime Testing

| Risk | Assessment |
|------|-----------|
| Level | Low — agent prompts, shell scripts, no runtime state changes |
| Verification | `self-assessed` — all 55 tests pass, 2 pre-existing env-dependent failures unchanged |

```
=== Results: 55 passed, 2 failed ===
```

The 2 failures (Tests 10, 14) are pre-existing and environment-dependent (require OpenCode session DB). Confirmed identical on `main`.

## Key Decisions

1. **JSONL over SQLite**: Chose append-only JSONL for the ledger because it requires no dependencies, is trivially concurrent-safe for appends, and is human-readable for debugging.
2. **Additive token display**: Subagent tokens are added to the main total (not shown separately) with a parenthetical breakdown, keeping the signature compact.
3. **Graceful degradation**: If no ledger exists or `token-ledger-helper.sh` isn't available, the signature works exactly as before.

Closes #17507

---
[aidevops.sh](https://aidevops.sh) v3.6.111 with claude-opus-4-6 as a headless worker. Overall, 13m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added subagent token support with automatic detection and tracking
  * Token count display now includes subagent breakdown information when applicable
  * New token ledger system tracks usage per session with record, sum, show, and reset operations
  * New `--subagent-tokens` CLI flag for manual token specification

* **Tests**
  * Added comprehensive test coverage for token tracking and signature generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->