### PR TITLE
t1896: Resolve specific model name in dispatch comments instead of auto-select (round-robin)

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6450,9 +6450,16 @@ dispatch_with_dedup() {
 	# Now: only pass --model when there's an explicit override (e.g., tier:thinking).
 	# When no override, omit --model entirely so choose_model() in the runtime
 	# helper picks the next available model via round-robin with backoff awareness.
+	#
+	# t1896: Pre-resolve the round-robin model so we can display it in the dispatch
+	# comment AND pass it to the worker (ensuring comment matches reality).
 	local selected_model=""
 	if [[ -n "$model_override" ]]; then
 		selected_model="$model_override"
+	else
+		# Pre-resolve the round-robin model using the same logic as the worker.
+		# This gives us the specific model name for the dispatch comment.
+		selected_model=$(HEADLESS_RUNTIME_HELPER="$HEADLESS_RUNTIME_HELPER" "$HEADLESS_RUNTIME_HELPER" select --role worker 2>/dev/null) || selected_model=""
 	fi
 
 	# t1894: Lock external contributor issues during worker execution
@@ -6488,8 +6495,11 @@ dispatch_with_dedup() {
 	# nothing to find, and the issue would be re-dispatched every pulse cycle.
 	# Evidence: awardsapp #2051 accumulated 29 DISPATCH_CLAIM comments over 6 hours
 	# because workers kept dying before posting.
+	#
+	# t1896: selected_model is now always resolved (either from override or pre-selection).
+	# Only falls back if select failed (all models backed off).
 	local dispatch_comment_body
-	local display_model="${selected_model:-auto-select (round-robin)}"
+	local display_model="${selected_model:-all models backed off}"
 	dispatch_comment_body="Dispatching worker (deterministic).
 - **Worker PID**: ${worker_pid}
 - **Model**: ${display_model}


### PR DESCRIPTION
## Summary

Dispatch comments now show the specific model ID (e.g., `anthropic/claude-sonnet-4-6`) instead of the generic `auto-select (round-robin)` string. This enables correlation of worker success/failure with the actual model used.

## Changes

- Pre-resolve the round-robin model using `headless-runtime-helper.sh select` before launching the worker
- Pass the resolved model to the worker via `--model` flag, ensuring dispatch comment matches reality
- Update fallback message to `all models backed off` (only shown if select fails)
- Maintains round-robin rotation state correctly

## Acceptance Criteria

- [x] Dispatch comments show specific model ID instead of `auto-select (round-robin)`
- [x] Syntax check passes (bash -n)
- [x] When all models are backed off, comment shows `all models backed off`
- [x] Round-robin rotation still works correctly

Closes #17503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Enhanced model selection process to pre-determine the selected model before dispatch execution
* Improved error messaging to clearly communicate when model selection fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->