### PR TITLE
GH#17503: make dispatch claim comments persistent and respected as primary dedup lock

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -41,7 +41,9 @@ DISPATCH_CLAIM_WINDOW="${DISPATCH_CLAIM_WINDOW:-8}"
 
 # Maximum age (seconds) of a claim comment to consider it active.
 # Claims older than this are stale and ignored by the lock check.
-DISPATCH_CLAIM_MAX_AGE="${DISPATCH_CLAIM_MAX_AGE:-120}"
+# GH#17503: Increased from 120s to 1800s (30 min) — claim comments are never
+# deleted (audit trail), so the TTL must cover a full worker lifecycle.
+DISPATCH_CLAIM_MAX_AGE="${DISPATCH_CLAIM_MAX_AGE:-1800}"
 
 # GH#15317: Self-reclaim removed. Previously, same-runner stale claims were
 # "reclaimed" after this threshold, creating dispatch loops. Now stale self-
@@ -312,39 +314,22 @@ cmd_claim() {
 		return 0
 	fi
 
-	# GH#15317: Self-reclaim removed. Previously, if the oldest claim belonged to
-	# the same runner and was >30s old, the runner would "reclaim" — allowing
-	# re-dispatch. This created same-runner dispatch loops: claim → dispatch →
-	# worker dies → 30s passes → self-reclaim → dispatch again. Evidence:
-	# awardsapp #2051 had 25 claims from alex-solovyev over 6 hours.
+	# GH#17503: Claim comments are NEVER deleted — they form the audit trail
+	# of every dispatch attempt. The claim TTL (DISPATCH_CLAIM_MAX_AGE=1800s)
+	# controls how long a claim blocks re-dispatch; after expiry the comment
+	# stays but no longer locks the issue.
 	#
-	# The dispatch_with_dedup() caller now posts a deterministic "Dispatching
-	# worker" comment and cleans up claim comments after dispatch. If a worker
-	# needs to be re-dispatched, the pulse must first post a kill/failure comment
-	# and remove the dispatch comment — making the re-dispatch explicit, not
-	# an implicit side effect of stale claims.
-	#
-	# If the oldest claim is from the same runner, treat as a lost claim (stale
-	# from a previous cycle that wasn't cleaned up). Delete both claims.
+	# Same-runner stale claim: another claim from this runner already exists.
+	# The existing claim is still blocking (within TTL), so back off.
 	if [[ "$oldest_runner" == "$runner" && "$oldest_nonce" != "$nonce" ]]; then
-		printf 'CLAIM_STALE_SELF: runner=%s found own stale claim on issue #%s (stale_age_s=%s) — cleaning up\n' \
+		printf 'CLAIM_STALE_SELF: runner=%s found own prior claim on issue #%s (age=%ss) — backing off (claim retained for audit)\n' \
 			"$runner" "$issue_number" "$oldest_age_seconds"
-		# Delete both the stale claim and the fresh one we just posted
-		local stale_comment_id
-		stale_comment_id=$(printf '%s' "$claims" | jq -r '.[0].id // ""' 2>/dev/null) || stale_comment_id=""
-		if [[ -n "$stale_comment_id" ]]; then
-			_delete_comment "$repo_slug" "$stale_comment_id" 2>/dev/null || true
-		fi
-		_delete_comment "$repo_slug" "$comment_id" 2>/dev/null || true
 		return 1
 	fi
 
 	# Step 5: We lost — another runner's claim is older
-	printf 'CLAIM_LOST: runner=%s lost to %s on issue #%s — backing off\n' \
+	printf 'CLAIM_LOST: runner=%s lost to %s on issue #%s — backing off (both claims retained for audit)\n' \
 		"$runner" "$oldest_runner" "$issue_number"
-
-	# Clean up our losing claim
-	_delete_comment "$repo_slug" "$comment_id" 2>/dev/null || true
 
 	return 1
 }
@@ -420,10 +405,7 @@ Usage:
 
 Environment:
   DISPATCH_CLAIM_WINDOW    Consensus window in seconds (default: 8)
-  DISPATCH_CLAIM_MAX_AGE   Max age of claim comments in seconds (default: 120)
-  DISPATCH_CLAIM_SELF_RECLAIM_AGE
-                           Same-runner stale-claim reclaim threshold in
-                           seconds (default: 30)
+  DISPATCH_CLAIM_MAX_AGE   Max age of claim comments in seconds (default: 1800 = 30 min)
 
 Protocol:
   1. Runner posts plain-text claim comment with unique nonce
@@ -431,8 +413,8 @@ Protocol:
   2. Waits DISPATCH_CLAIM_WINDOW seconds for other runners
   3. Fetches all claim comments on the issue
   4. Oldest active claim wins (claims older than DISPATCH_CLAIM_MAX_AGE are ignored)
-     — others back off and delete their claims
-  5. Winner proceeds with dispatch; claim comment persists as audit trail
+     — others back off; ALL claim comments are retained as audit trail (GH#17503)
+  5. Winner proceeds with dispatch; claim blocks re-dispatch for TTL duration
 
 Examples:
   # Claim before dispatching (in pulse dedup guard)

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -847,51 +847,48 @@ _is_dispatch_comment_active() {
 		printf '%s' "0")
 	local age=$((now_epoch - comment_epoch))
 
+	# GH#17503: Straight TTL check — no pgrep escape hatch, no grace period.
+	# The dispatch comment blocks re-dispatch for the full TTL duration.
+	# Comments are never deleted (audit trail); they just stop blocking
+	# after max_age expires, allowing a fresh dispatch attempt.
 	[[ "$age" -ge "$max_age" ]] && return 1
 
-	local grace_period="${DISPATCH_COMMENT_GRACE_SECONDS:-300}" # 5 minutes
-	if [[ "$age" -gt "$grace_period" ]]; then
-		# Check if any local worker process is running for this issue
-		local has_local_worker=""
-		has_local_worker=$(pgrep -f "issue.${issue_number}" 2>/dev/null | head -1 || true)
-		if [[ -z "$has_local_worker" ]]; then
-			has_local_worker=$(pgrep -f "#${issue_number}" 2>/dev/null | head -1 || true)
-		fi
-		if [[ -z "$has_local_worker" ]]; then
-			# No local worker running — dispatch comment is orphaned; allow re-dispatch
-			return 1
-		fi
-	fi
-
-	printf 'dispatch comment by %s posted %ds ago on issue #%s\n' "$author" "$age" "$issue_number"
+	printf 'dispatch comment by %s posted %ds ago on issue #%s (TTL: %ds remaining)\n' \
+		"$author" "$age" "$issue_number" "$((max_age - age))"
 	return 0
 }
 
 #######################################
-# Check whether an issue has a recent "Dispatching worker" comment
-# from another runner (GH#11141).
+# Check whether an issue has a recent "Dispatching worker" comment (GH#11141).
 #
-# The pulse agent posts a "Dispatching worker." comment on every issue
+# The pulse agent posts a "Dispatching worker" comment on every issue
 # it dispatches. This is a persistent, cross-machine signal that a
 # worker is in-flight — unlike the dispatch ledger (local-only) or
 # the claim lock (8-second window). Checking for this comment catches
 # the gap between dispatch and PR creation across machines.
 #
-# A comment is considered active if it was posted within the last
-# DISPATCH_COMMENT_MAX_AGE seconds (default 1 hour — GH#16626).
+# GH#17503: This is now the PRIMARY dedup guard. Dispatch comments are
+# never deleted (audit trail). A dispatch comment blocks re-dispatch for
+# DISPATCH_COMMENT_MAX_AGE seconds (default 1800 = 30 min). After that,
+# the comment stays for audit but no longer blocks — allowing a fresh
+# dispatch attempt.
 #
-# Additional guard (t1702): dispatch comments only block when the issue is
-# still actively claimed (OPEN + assigned + status:queued/in-progress).
-# If the claim state has been cleared, old dispatch comments are treated as
-# stale breadcrumbs and must not block redispatch.
+# A completion or failure comment posted AFTER the dispatch comment
+# cancels the lock early — the worker is done, re-dispatch is safe.
+# Recognised completion signals: "TASK_COMPLETE", "FULL_LOOP_COMPLETE",
+# "Worker failed", "BLOCKED", "Stale assignment recovered",
+# "Kill signal sent", "gh pr merge", "Closes #".
+#
+# No active-claim-state gate (removed GH#17503) — the dispatch comment
+# itself IS the claim. Labels and assignees are secondary signals.
 #
 # Args:
 #   $1 = issue number
 #   $2 = repo slug (owner/repo)
 #   $3 = self login (unused; kept for backward compatibility — GH#15317)
 # Returns:
-#   exit 0 if a recent dispatch comment from another runner exists (do NOT dispatch)
-#   exit 1 if no recent dispatch comment (safe to dispatch)
+#   exit 0 if a recent dispatch comment exists (do NOT dispatch)
+#   exit 1 if no recent dispatch comment or superseded by completion (safe to dispatch)
 # Outputs:
 #   single-line reason when evidence is found
 #######################################
@@ -904,44 +901,76 @@ has_dispatch_comment() {
 		return 1
 	fi
 
-	# Only treat dispatch comments as active when issue is actively claimed.
-	# This prevents stale historical comments from blocking fresh dispatches.
-	if ! _get_active_claim_meta "$issue_number" "$repo_slug"; then
-		return 1
-	fi
+	# GH#17503: No active-claim-state gate — dispatch comment IS the claim.
+	# Removed the _get_active_claim_meta() check that required OPEN + assigned +
+	# status:queued/in-progress. That gate allowed stale recovery to destroy the
+	# claim state and bypass this check entirely.
 
-	local max_age="${DISPATCH_COMMENT_MAX_AGE:-3600}" # 1 hour (reduced from 4h — GH#16626)
+	local max_age="${DISPATCH_COMMENT_MAX_AGE:-1800}" # 30 min (GH#17503, was 3600)
 	local now_epoch
 	now_epoch=$(date -u '+%s')
 
-	# Fetch recent comments and look for "Dispatching worker" comments.
-	# GH#15317: Check ALL dispatch comments regardless of author — self-posted
-	# comments are no longer skipped (self_login param kept for compat only).
+	# Fetch ALL comments — we need both dispatch and completion signals.
+	# Extract type, author, and timestamp for each relevant comment.
 	local comments_json
 	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq '[.[] | select(.body | startswith("Dispatching worker")) | {author: .user.login, created_at: .created_at}]' \
+		--jq '[.[] | {
+			body_start: (.body[:300]),
+			author: .user.login,
+			created_at: .created_at
+		}]' \
 		2>/dev/null) || comments_json="[]"
 
 	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
 		return 1
 	fi
 
-	# Check each dispatch comment — any recent active dispatch blocks
-	local count
-	count=$(printf '%s' "$comments_json" | jq 'length' 2>/dev/null) || count=0
+	# Find the most recent dispatch comment (newest first)
+	local last_dispatch_json
+	last_dispatch_json=$(printf '%s' "$comments_json" | jq -c '
+		[.[] | select(.body_start | startswith("Dispatching worker"))]
+		| sort_by(.created_at) | reverse | first // empty
+	' 2>/dev/null) || last_dispatch_json=""
 
-	local i
-	for i in $(seq 0 $((count - 1))); do
-		local created_at author
-		created_at=$(printf '%s' "$comments_json" | jq -r ".[$i].created_at // \"\"" 2>/dev/null) || created_at=""
-		author=$(printf '%s' "$comments_json" | jq -r ".[$i].author // \"\"" 2>/dev/null) || author=""
+	if [[ -z "$last_dispatch_json" || "$last_dispatch_json" == "null" ]]; then
+		return 1
+	fi
 
-		if _is_dispatch_comment_active "$created_at" "$author" "$issue_number" "$now_epoch" "$max_age"; then
-			return 0
-		fi
-	done
+	local dispatch_created_at dispatch_author
+	dispatch_created_at=$(printf '%s' "$last_dispatch_json" | jq -r '.created_at // ""' 2>/dev/null) || dispatch_created_at=""
+	dispatch_author=$(printf '%s' "$last_dispatch_json" | jq -r '.author // ""' 2>/dev/null) || dispatch_author=""
 
-	return 1
+	# Check if the dispatch comment is within TTL
+	if ! _is_dispatch_comment_active "$dispatch_created_at" "$dispatch_author" "$issue_number" "$now_epoch" "$max_age"; then
+		return 1
+	fi
+
+	# GH#17503: Check for completion/failure comments posted AFTER the dispatch.
+	# If found, the worker is done — the dispatch comment no longer blocks.
+	local has_completion
+	has_completion=$(printf '%s' "$comments_json" | jq -r --arg dispatch_ts "$dispatch_created_at" '
+		[.[] | select(
+			.created_at > $dispatch_ts and (
+				(.body_start | test("TASK_COMPLETE"; "i")) or
+				(.body_start | test("FULL_LOOP_COMPLETE"; "i")) or
+				(.body_start | test("Worker failed"; "i")) or
+				(.body_start | test("BLOCKED"; "i")) or
+				(.body_start | test("Kill signal sent"; "i")) or
+				(.body_start | test("Closes #"; "i")) or
+				(.body_start | test("gh pr merge"; "i")) or
+				(.body_start | test("MERGE_SUMMARY"; "i")) or
+				(.body_start | test("Stale assignment recovered"; "i"))
+			)
+		)] | length
+	' 2>/dev/null) || has_completion=0
+
+	if [[ "$has_completion" -gt 0 ]]; then
+		# Worker completed or failed — dispatch comment superseded, safe to re-dispatch
+		return 1
+	fi
+
+	# Dispatch comment is active and not superseded — block re-dispatch
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6354,16 +6354,13 @@ dispatch_with_dedup() {
 	# SIGTERM-ing all active workers.
 	local _claim_comment_id=""
 
-	# GH#16978 Bug C: Helper to clean up the DISPATCH_CLAIM comment on any
-	# early-return path after the claim succeeds. Previously the cleanup only
-	# ran on successful dispatch (line 6192), so any failure between claim and
-	# worker launch left a stale claim comment that accumulated over pulse cycles.
+	# GH#17503: Claim comments are NEVER deleted — they form the audit trail.
+	# The _cleanup_claim_comment function is retained as a no-op for backward
+	# compatibility (callers may still reference it on early-return paths).
 	_cleanup_claim_comment() {
-		if [[ -n "$_claim_comment_id" ]]; then
-			gh api "repos/${repo_slug}/issues/comments/${_claim_comment_id}" \
-				--method DELETE >/dev/null 2>>"$LOGFILE" || true
-			_claim_comment_id=""
-		fi
+		# No-op: claim comments are persistent audit trail (GH#17503).
+		# Previously deleted DISPATCH_CLAIM comments, which destroyed both
+		# the lock and the audit trail — causing duplicate dispatches.
 		return 0
 	}
 
@@ -6500,27 +6497,15 @@ dispatch_with_dedup() {
 		echo "[dispatch_with_dedup] Warning: failed to post deterministic dispatch comment for #${issue_number}" >>"$LOGFILE"
 	}
 
-	# GH#17497: Defer claim comment cleanup to prevent TOCTOU race condition.
-	# Previously (GH#15317/GH#16978), the claim was deleted synchronously here.
-	# Race: Runner A wins claim → deletes it → Runner B (still inside 8s consensus
-	# window) sees only its own claim → incorrectly "wins" → duplicate dispatch.
-	# Evidence: #17497 — alex-solovyev and marcusquinn both dispatched 7s apart.
-	#
-	# Fix: defer deletion by one consensus window after the dispatch comment is
-	# posted. This keeps the claim visible long enough for any concurrent claimant
-	# to see it during their consensus check. The background subshell avoids
-	# blocking dispatch throughput. Early-return paths still use synchronous
-	# _cleanup_claim_comment (no race — dispatch was blocked, no concurrent claim
-	# to protect against).
+	# GH#17503: Claim comments are NEVER deleted — they form the persistent
+	# audit trail and are respected as the primary dedup lock for 30 minutes.
+	# The deferred deletion that previously ran here (GH#17497) was the root
+	# cause of duplicate dispatches: deleting the claim removed the lock,
+	# allowing subsequent pulse cycles and other runners to re-dispatch.
+	# Evidence: GH#17503 — 6 dispatches from marcusquinn + 1 from alex-solovyev,
+	# producing 2 duplicate PRs (#17512, #17513).
 	if [[ -n "$_claim_comment_id" ]]; then
-		local __deferred_cid="$_claim_comment_id" __deferred_slug="$repo_slug"
-		local __deferred_issue="$issue_number" __deferred_logfile="$LOGFILE"
-		(
-			sleep "${DISPATCH_CLAIM_WINDOW:-8}"
-			gh api "repos/${__deferred_slug}/issues/comments/${__deferred_cid}" \
-				--method DELETE >/dev/null 2>&1 || true
-			echo "[dispatch_with_dedup] Deferred claim cleanup: deleted comment ${__deferred_cid} for #${__deferred_issue}" >>"$__deferred_logfile"
-		) &
+		echo "[dispatch_with_dedup] Claim comment ${_claim_comment_id} retained for audit trail on #${issue_number} (GH#17503)" >>"$LOGFILE"
 		_claim_comment_id=""
 	fi
 


### PR DESCRIPTION
## Summary

Fixes the root cause of duplicate dispatches on GH#17503 where 6 workers were dispatched to the same issue and 2 duplicate PRs were created (#17512, #17513).

**Root cause:** Dispatch claim comments were deleted after the consensus window, destroying both the mutex lock and the audit trail. Every escape hatch (pgrep grace period, active-claim-state gate, self-login bypass) fired faster than the 10-minute pulse cycle, leaving no persistent signal that a worker was active.

**Fix:** Claim comments are never deleted. They serve as both the primary dedup lock (30-min TTL) and a permanent audit trail of every dispatch attempt.

## Changes

- **Never delete claim comments** — `DISPATCH_CLAIM` and "Dispatching worker" comments are retained permanently as audit trail
- **30-min TTL** — `DISPATCH_CLAIM_MAX_AGE` increased from 120s to 1800s to cover a full worker lifecycle
- **Remove active-claim-state gate** — dispatch comment blocks regardless of label/assignee state (labels were being destroyed by stale recovery, bypassing the check)
- **Remove pgrep escape hatch** — straight TTL check, no 5-min grace period that allowed re-dispatch when workers exited
- **Completion-comment awareness** — worker done signals (TASK_COMPLETE, BLOCKED, MERGE_SUMMARY, etc.) cancel the lock early so re-dispatch can proceed after legitimate completion
- **Neutralize deferred cleanup** — `_cleanup_claim_comment` is now a no-op; deferred deletion subshell removed

## Files changed

- `.agents/scripts/dispatch-claim-helper.sh` — persistent claims, 30-min TTL
- `.agents/scripts/dispatch-dedup-helper.sh` — primary dedup guard rewrite
- `.agents/scripts/pulse-wrapper.sh` — remove claim deletion

## Runtime Testing

- Risk: **Medium** (dispatch pipeline, no UI/API endpoints)
- Self-assessed: ShellCheck clean on all 3 files. Logic verified by tracing the GH#17503 timeline against the new code paths.

Closes #17503

---
[aidevops.sh](https://aidevops.sh) v3.6.112 plugin for Claude Code with claude-opus-4-6 spent 21m and 30,417 tokens on this with the user in an interactive session.