### PR TITLE
GH#17503: restore MERGE_SUMMARY compliance — executable template, contract V3, continuation prompt

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -103,7 +103,20 @@ Changelog: `feat:` → Added, `fix:` → Fixed, `docs:`/`perf:`/`refactor:` → 
 
 **Signature footer (GH#12805 — MANDATORY):** append `gh-signature-helper.sh footer` output. Verify: `gh pr view --json body | jq -e '.body | (contains("aidevops.sh") and (contains("spent") or contains("Overall,")))'`.
 
-**4.2.1 Merge Summary Comment (MANDATORY):** post immediately after PR creation. Must contain `<!-- MERGE_SUMMARY -->` on first line. Include: What, Issue, Files changed, Testing, Key decisions.
+**4.2.1 Merge Summary Comment (MANDATORY):** post immediately after PR creation. The deterministic merge pass (`pulse-wrapper.sh`) reads this comment to build closing comments on the linked issue. Without it, issues get a generic "no worker summary" message. Run this exact command:
+
+```bash
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body "<!-- MERGE_SUMMARY -->
+## Completion Summary
+
+- **What**: <1-line description of what was done>
+- **Issue**: #<issue_number>
+- **Files changed**: <comma-separated list of key files>
+- **Testing**: <what was verified — linter, build, manual, etc.>
+- **Key decisions**: <any notable trade-offs or choices made>"
+```
+
+Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[] | select(.body | test("MERGE_SUMMARY"))] | length'` must return `1`.
 
 **4.3 Label `status:in-review` (t1343):** check issue is `OPEN` first.
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1185,7 +1185,7 @@ append_worker_headless_contract() {
 	local contract
 	contract=$(
 		cat <<'EOF'
-[HEADLESS_CONTINUATION_CONTRACT_V2]
+[HEADLESS_CONTINUATION_CONTRACT_V3]
 This is a HEADLESS worker session. No user is present. No user input is available.
 You must drive autonomously to completion or an evidence-backed BLOCKED outcome.
 
@@ -1201,7 +1201,8 @@ Pre-exit self-check -- MANDATORY:
 Before ending your session, verify ALL of these:
   - At least one commit with implementation changes exists on your branch.
   - A PR exists for your branch: run gh pr list --head YOUR_BRANCH_NAME
-  - If either check fails, you are NOT done -- continue working.
+  - A MERGE_SUMMARY comment exists on the PR (full-loop step 4.2.1). Verify: gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[] | select(.body | test("MERGE_SUMMARY"))] | length' returns 1. If 0, post it now — the merge pass uses it for closing comments.
+  - If any check fails, you are NOT done -- continue working.
   - The only valid exit states are FULL_LOOP_COMPLETE or BLOCKED with evidence.
 EOF
 	)
@@ -2063,7 +2064,7 @@ cmd_run() {
 			# Swap to a continuation prompt that reinforces headless completion.
 			# The session ID is already stored; _execute_run_attempt will use
 			# --session <id> --continue to resume the existing conversation.
-			prompt="Continue through to completion. This is a headless session — no user is present and no user input is available to assist. You have set up the environment but have not yet completed the task. Check your todo list, implement the required code changes, commit, push, and create a PR. Do not stop until the outcome is FULL_LOOP_COMPLETE or BLOCKED with evidence."
+			prompt="Continue through to completion. This is a headless session — no user is present and no user input is available to assist. You have set up the environment but have not yet completed the task. Check your todo list, implement the required code changes, commit, push, and create a PR. After PR creation, you MUST post the MERGE_SUMMARY comment (full-loop step 4.2.1) — the merge pass needs it for closing comments. Then continue through review, merge, and closing comments. Do not stop until the outcome is FULL_LOOP_COMPLETE or BLOCKED with evidence."
 
 			# Continuation retries don't consume provider-rotation attempts
 			# since the provider isn't at fault — the model stopped early.


### PR DESCRIPTION
## Summary

- Restores the executable `gh pr comment` template in full-loop.md step 4.2.1 (removed by simplification commit `738e4ca49`)
- Adds MERGE_SUMMARY to the headless contract V3 pre-exit self-check with exact verification command
- Adds MERGE_SUMMARY reminder to the continuation prompt sent when workers stop prematurely

## Root Cause

Two-factor regression causing 65% MERGE_SUMMARY miss rate (13 of 20 recent PRs):

1. **Simplification** (`738e4ca49`) compressed a full executable code block with template into a single prose line. Workers went from having a copy-paste command to a compressed instruction competing with 15+ other mandatory steps.

2. **Continuation gap**: Neither the headless contract pre-exit check nor the continuation prompt mentioned MERGE_SUMMARY. Workers that stop after PR creation (natural model stopping point) are never reminded about this step.

**Evidence**: PRs before simplification (17030, 17017, 17324) had 100% MERGE_SUMMARY rate. Post-simplification rate dropped to ~35%.

## Changes

- `.agents/scripts/commands/full-loop.md` — restore `gh pr comment` code block with template + add verification command
- `.agents/scripts/headless-runtime-helper.sh` — contract V2→V3 (add MERGE_SUMMARY to pre-exit checklist), continuation prompt (add MERGE_SUMMARY reminder)

## Defense in Depth

This PR complements #17517 (already merged) which added PR body text as a fallback source for `_extract_merge_summary`. Together:

| Layer | What | Coverage |
|-------|------|----------|
| **Instruction** (this PR) | Executable template + pre-exit check + continuation reminder | Targets 100% compliance |
| **Fallback** (#17517) | Extract from PR body when comment missing | Catches remaining misses |
| **Generic** (existing) | "Neither MERGE_SUMMARY comment nor PR body text was available" | Near-zero expected |

Closes #17503