### PR TITLE
t1899: fix placeholder issue bodies, add signature footers, gate dispatch on body quality

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -684,14 +684,34 @@ create_github_issue() {
 		fi
 	fi
 
-	# Fallback: bare issue creation (no labels, minimal body)
+	# Fallback: bare issue creation with structured body
 	local gh_args=(issue create --title "$title")
 
+	# t1899: Compose a structured body from available context when no
+	# --description was provided, instead of an opaque placeholder string.
+	# Also warn at claim time so callers notice the gap.
+	local body=""
 	if [[ -n "$description" ]]; then
-		gh_args+=(--body "$description")
+		body="$description"
 	else
-		gh_args+=(--body "Task created via claim-task-id.sh")
+		log_warn "No --description provided — issue body will lack detail. Pass --description for rich issue content."
+		local desc_part
+		desc_part=$(printf '%s' "$title" | sed 's/^t[0-9]*: *//')
+		body="## Task"
+		body="$body"$'\n\n'"$desc_part"
+		body="$body"$'\n\n'"---"
+		body="$body"$'\n'"*Created by claim-task-id.sh (no description provided — enrich before dispatch)*"
 	fi
+
+	# t1899: Append provenance signature footer (build.txt rule #8)
+	local sig_helper="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/gh-signature-helper.sh"
+	if [[ -x "$sig_helper" ]]; then
+		local sig_footer
+		sig_footer=$("$sig_helper" footer --body "$body" 2>/dev/null || echo "")
+		[[ -n "$sig_footer" ]] && body="$body"$'\n'"$sig_footer"
+	fi
+
+	gh_args+=(--body "$body")
 
 	# Append session origin label (origin:worker or origin:interactive)
 	local origin_label

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -907,6 +907,16 @@ _compose_issue_html_notes_and_footer() {
 	[[ -n "$html_comments" ]] && body="$body"$'\n\n'"## Implementation Notes"$'\n\n'"$html_comments"
 
 	body="$body"$'\n\n'"---"$'\n'"*Synced from TODO.md by issue-sync-helper.sh*"
+
+	# t1899: Append provenance signature footer (build.txt rule #8)
+	local sig_helper
+	sig_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gh-signature-helper.sh"
+	if [[ -x "$sig_helper" ]]; then
+		local sig_footer
+		sig_footer=$("$sig_helper" footer --body "$body" 2>/dev/null || echo "")
+		[[ -n "$sig_footer" ]] && body="$body"$'\n'"$sig_footer"
+	fi
+
 	echo "$body"
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8002,6 +8002,16 @@ dispatch_deterministic_fill_floor() {
 			continue
 		fi
 
+		# t1899: Skip issues with placeholder/empty bodies — dispatching a
+		# worker to an undescribed issue wastes a session. The body check is
+		# a single API call cached for the candidate loop iteration.
+		local issue_body
+		issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body -q '.body' 2>/dev/null || echo "")
+		if [[ -z "$issue_body" || "$issue_body" == "Task created via claim-task-id.sh" || "$issue_body" == "null" ]]; then
+			echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — placeholder/empty issue body, needs enrichment before dispatch" >>"$LOGFILE"
+			continue
+		fi
+
 		dispatch_title="Issue #${issue_number}"
 		prompt="/full-loop Implement issue #${issue_number}"
 		if [[ -n "$issue_url" ]]; then


### PR DESCRIPTION
## Summary

- **claim-task-id.sh**: Replaced opaque placeholder body (`Task created via claim-task-id.sh`) with a structured body composed from the task title, plus a warning when `--description` is omitted
- **claim-task-id.sh + issue-sync-lib.sh**: Both now append `gh-signature-helper.sh footer` to every created issue (build.txt rule #8 compliance)
- **pulse-wrapper.sh**: Deterministic fill floor now skips issues with placeholder/empty bodies, preventing wasted worker dispatch

Root cause: `claim-task-id.sh` delegates to `issue-sync-helper.sh push` (which composes rich bodies from TODO.md), but this structurally fails for new tasks because the TODO.md entry doesn't exist yet when the ID is first claimed. The fallback path used a hardcoded string with no signature. Three workers were dispatched to #17511 with this undescribed body.

Closes #17520

---
[aidevops.sh](https://aidevops.sh) v3.6.113 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 11m and 10,516 tokens on this with the user in an interactive session. Overall, 7m since this issue was created.