### PR TITLE
GH#17525: restore POSIX close-pattern matching

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -745,8 +745,8 @@ has_open_pr() {
 				# would falsely match issue #670. Post-filter with exact regex.
 				local pr_body
 				pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null) || pr_body=""
-				# Match: keyword + optional whitespace + #NNN or owner/repo#NNN at word boundary
-				local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}\b"
+				# Match: keyword + optional whitespace + #NNN or owner/repo#NNN followed by a non-word char or end
+				local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
 				if ! printf '%s' "$pr_body" | grep -iqE "$close_pattern"; then
 					continue
 				fi


### PR DESCRIPTION
## Summary
- replace the non-portable \b close-reference suffix with a POSIX ERE character-boundary check in dispatch dedup detection
- keep exact issue-reference matching so PR bodies like #1234 or #123a do not falsely satisfy issue #123

## What
- update `has_open_pr()` in `.agents/scripts/dispatch-dedup-helper.sh` to use `([^[:alnum:]_]|$)` after the issue number
- refresh the inline comment to describe the portable suffix check

## Why
- BSD grep on macOS does not support `\b` in ERE mode, so the merged change from PR #17478 was not portable
- this restores cross-platform matching without reintroducing false positives

## Files Changed
- `.agents/scripts/dispatch-dedup-helper.sh`

## Testing
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh`
- sample-case validation with BSD `grep -E` for matching and non-matching close references

## Runtime Testing
**Risk level**: Low — one regex change in a shell helper.
**Self-assessed**: Verified the pattern against representative matching and non-matching close-reference strings using the local grep implementation.

Closes #17525

---

---
[aidevops.sh](https://aidevops.sh) v3.6.113 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.4
