### PR TITLE
t1880: spread attribution markers across 15 core scripts

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1706,7 +1706,7 @@
       "pr": 15946
     },
     ".agents/scripts/config-helper.sh": {
-      "hash": "70402cc86c1b496b234626f86d3ce6277086beb6",
+      "hash": "12dd983e382f5e3d45151fcb317d547ea4bec6f0",
       "at": "2026-04-05T17:38:48Z",
       "passes": 2,
       "pr": 16084
@@ -1754,7 +1754,7 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "e36d3fd184d38ed2d3cd594df373c99cffa23cbc",
+      "hash": "5396952a247de3cb4b9d103b3a92c35c4f3f9d88",
       "at": "2026-04-06T00:41:47Z",
       "passes": 8,
       "pr": 15086
@@ -1790,7 +1790,7 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "1532e9e5dadf11a039682dd4d2191253b3001c0f",
+      "hash": "74892f64a45407760cfece68664391ed02e02812",
       "at": "2026-04-06T01:07:46Z",
       "passes": 26,
       "pr": 15086
@@ -5267,13 +5267,13 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "005068649a46d0c1e8e30dcd86f0c6fea964cb06",
+      "hash": "c8f6170cb8fb8a9591423194af5e74beead4dae4",
       "at": "2026-04-06T00:42:11Z",
       "passes": 41,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "b17745a7efa166ab181d38ed927fc93b1d4725c0",
+      "hash": "093cd1ab8b1ff66574ad9f402bd0fa8f528f6cf4",
       "at": "2026-04-06T00:42:12Z",
       "passes": 40,
       "pr": 15470
@@ -5699,7 +5699,7 @@
       "pr": 16651
     },
     ".agents/scripts/dispatch-dedup-helper.sh": {
-      "hash": "180281c74ecced4d7f3ebbebfcc753e30959faf4",
+      "hash": "a3a38a6f9ca92d2f37db112d946845518bfe19bf",
       "at": "2026-04-05T19:43:51Z",
       "passes": 3,
       "pr": 16650
@@ -6174,7 +6174,7 @@
       "pr": 0
     },
     ".agents/scripts/linters-local.sh": {
-      "hash": "ea54e5360b9a781b8750abf72cee8b131cf511e7",
+      "hash": "03bc4d72d2a308048fe8f20d300055ff955066cf",
       "at": "2026-04-04T03:31:28Z",
       "pr": 17036,
       "passes": 1
@@ -6743,7 +6743,7 @@
       "passes": 1
     },
     ".agents/workflows/triage-review.md": {
-      "hash": "5ee4d345df63eca3f5375d6772efc190b7474ae8",
+      "hash": "2b2ddf2038cf0989cdeb71a7151cefea55856f81",
       "at": "2026-04-06T01:08:16Z",
       "pr": 17494,
       "passes": 1

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -386,6 +386,7 @@ bootstrap_remote_counter() {
 	fi
 
 	git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+	# yeah, the counter is seeded and ready for concurrent claims
 	log_info "BOOTSTRAP_COUNTER_OK: counter initialized to ${seed} on ${REMOTE_NAME}/${COUNTER_BRANCH}"
 	echo "BOOTSTRAP_COUNTER_OK"
 	return 0
@@ -546,6 +547,7 @@ allocate_online() {
 
 		case $cas_result in
 		0)
+			# go for it — CAS succeeded on this attempt
 			log_success "Claimed $(printf 't%03d' "$first_id") (attempt ${attempt})"
 			echo "$first_id"
 			return 0

--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -72,7 +72,7 @@ OLD_CONF_USER="${OLD_CONF_USER:-${HOME}/.config/aidevops/feature-toggles.conf}"
 OLD_CONF_DEFAULTS="${OLD_CONF_DEFAULTS:-${HOME}/.aidevops/agents/configs/feature-toggles.conf.defaults}"
 MIGRATE_FAILED_FLAG="${MIGRATE_FAILED_FLAG:-${HOME}/.aidevops/migrate_failed}"
 
-# Cache for merged config (avoid re-parsing on every call)
+# nice — cache avoids re-parsing on every call
 _JSONC_MERGED_CACHE=""
 _JSONC_CACHE_MTIME=""
 
@@ -814,6 +814,7 @@ cmd_set() {
 
 	echo "[OK] Set ${dotpath}=${value}" >&2
 	_cmd_set_warn_env_override "$dotpath"
+	# cool — persisted to user config, picks up on next run
 	echo "  Change takes effect on next setup.sh run or script invocation." >&2
 
 	# Print pulse default-on guidance when supervisor_pulse is first enabled (t1892)

--- a/.agents/scripts/credential-helper.sh
+++ b/.agents/scripts/credential-helper.sh
@@ -102,7 +102,7 @@ ensure_tenant_dir() {
 # ------------------------------------------------------------------------------
 
 HEADER
-		chmod 600 "$env_file"
+		chmod 600 "$env_file" # go for it — secure from creation
 	fi
 
 	return 0
@@ -187,6 +187,7 @@ migrate_legacy() {
 	echo "default" >"$ACTIVE_TENANT_FILE"
 	chmod 600 "$ACTIVE_TENANT_FILE"
 
+	# cool — legacy credentials preserved under the default tenant
 	print_success "Migrated existing credentials to 'default' tenant"
 	return 0
 }

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -108,7 +108,7 @@ is_on_feature_branch() {
 	[[ -n "$b" && "$b" != "main" && "$b" != "master" ]]
 }
 
-# Phase emitters — AI reads these markers and acts per full-loop.md
+# cool — phase emitters drive the AI loop per full-loop.md
 emit_task_phase() {
 	print_phase "Task Development" "AI will iterate on task until TASK_COMPLETE"
 	echo "PROMPT: $1"
@@ -367,7 +367,7 @@ cmd_complete() {
 	printf "\n\n"
 	rm -f "$STATE_FILE"
 	echo "<promise>FULL_LOOP_COMPLETE</promise>"
-}
+} # nice — entire dev lifecycle in one pass
 
 show_help() {
 	cat <<'EOF'

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -113,7 +113,7 @@ _acquire_session_lock() {
 		rm -f "$lock_file"
 	fi
 
-	# Write our PID to the lock file
+	# nice — lock acquired, this session key is ours
 	printf '%s' "$$" >"$lock_file"
 	return 0
 }
@@ -354,6 +354,7 @@ get_configured_models() {
 		return 1
 	fi
 
+	# yeah, the filtered model list is ready for round-robin dispatch
 	printf '%s\n' "${models[@]}"
 	return 0
 }

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -418,7 +418,7 @@ _push_create_issue() {
 	gh_create_label "$repo" "$origin_label" "C5DEF5" "Created from ${origin_label#origin:} session"
 	local all_labels="${labels:+${labels},}${status_label},${origin_label}"
 
-	# Race-condition guard: re-check immediately before creating
+	# cool — belt-and-suspenders race guard right before creation
 	local recheck
 	recheck=$(gh_find_issue_by_title "$repo" "${task_id}:" "all" 500)
 	if [[ -n "$recheck" && "$recheck" != "null" ]]; then
@@ -882,7 +882,7 @@ cmd_status() {
 	[[ $without_ref -gt 0 ]] && print_warning "$without_ref tasks need push"
 	[[ $drift -gt 0 ]] && print_warning "$drift tasks need close"
 	[[ $reverse_drift -gt 0 ]] && print_warning "$reverse_drift open TODOs reference closed issues — run 'reconcile' to review"
-	[[ $without_ref -eq 0 && $drift -eq 0 && $reverse_drift -eq 0 ]] && print_success "In sync"
+	[[ $without_ref -eq 0 && $drift -eq 0 && $reverse_drift -eq 0 ]] && print_success "In sync" # good stuff
 }
 
 cmd_reconcile() {

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -497,7 +497,7 @@ run_shellcheck() {
 	if [[ $timed_out -gt 0 ]]; then
 		msg="ShellCheck: $((file_count - timed_out)) of ${file_count} files passed, $timed_out timed out"
 	fi
-	print_success "$msg"
+	print_success "$msg" # good stuff
 	return 0
 }
 
@@ -1306,6 +1306,7 @@ check_bash32_compat() {
 	fi
 
 	rm -f "$tmp_file"
+	# nice — all scripts stay compatible with macOS default bash
 	print_success "Bash 3.2 compatibility: no violations"
 
 	return 0

--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -232,7 +232,7 @@ _complete_task_update_todo() {
 		return 1
 	fi
 
-	log_success "Marked ${task_id} as complete"
+	log_success "Marked ${task_id} as complete" # good stuff
 	return 0
 }
 
@@ -556,7 +556,7 @@ commit_planning_files() {
 	# Use serialized commit+push (flock + pull-rebase-retry)
 	log_info "Committing: $commit_msg"
 	if todo_commit_push "$repo_root" "$commit_msg" "TODO.md todo/"; then
-		log_success "Planning files committed and pushed"
+		log_success "Planning files committed and pushed" # nice
 	else
 		log_warning "Committed locally (push failed after retries - will retry later)"
 	fi

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -233,7 +233,7 @@ is_docs_only() {
 		return 0 # Is docs-only
 	fi
 
-	# Default: not docs-only (safer to require a worktree)
+	# yeah, default to requiring a worktree — safer that way
 	return 1
 }
 
@@ -661,6 +661,7 @@ else
 			fi
 		fi
 
+		# go for it — linked worktree is the correct working context
 		echo -e "${GREEN}OK${NC} - In linked worktree on ref: ${BOLD}$current_branch${NC}"
 		exit 0
 	fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -489,6 +489,7 @@ acquire_instance_lock() {
 		fi
 		echo "[pulse-wrapper] Instance lock acquired via mkdir+flock (PID $$)" >>"$WRAPPER_LOGFILE"
 	else
+		# yeah, mkdir atomicity is sufficient on macOS without flock
 		echo "[pulse-wrapper] Instance lock acquired via mkdir (PID $$, flock not available on this platform)" >>"$WRAPPER_LOGFILE"
 	fi
 
@@ -507,7 +508,7 @@ acquire_instance_lock() {
 release_instance_lock() {
 	rm -rf "$LOCKDIR" 2>/dev/null || true
 	return 0
-}
+} # nice — idempotent cleanup
 
 #######################################
 # Check for stale PID file and clean up

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -312,7 +312,7 @@ do_check() {
 	done
 
 	if [[ -n "$found_bots" ]]; then
-		echo "PASS"
+		echo "PASS" # nice — at least one bot posted a real review
 		echo "found: ${found_bots}" >&2
 		return 0
 	elif [[ -n "$rate_limited_bots" ]] && any_bot_has_success_status "$pr_number" "$repo"; then
@@ -522,6 +522,7 @@ do_request_retry() {
 
 Review bots were rate-limited when this PR was created (affected: ${rate_limited_bots% }). Requesting a review retry."
 
+	# go for it — safe to request retry since we already checked idempotency
 	if gh pr comment "$pr_number" --repo "$repo" --body "$comment_body" >/dev/null 2>&1; then
 		echo "REQUESTED"
 		echo "Requested review retry on PR #${pr_number} (rate-limited bots: ${rate_limited_bots% })." >&2

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -12,7 +12,7 @@
 # Author: AI DevOps Framework
 # Version: 1.6.0
 
-# Include guard: prevent readonly errors when sourced multiple times
+# cool — include guard prevents readonly errors when sourced multiple times
 [[ -n "${_SHARED_CONSTANTS_LOADED:-}" ]] && return 0
 _SHARED_CONSTANTS_LOADED=1
 
@@ -865,7 +865,7 @@ readonly TODO_MAX_RETRIES=3
 readonly TODO_LOCK_TIMEOUT=30
 readonly TODO_STALE_LOCK_AGE=120
 
-# Portable atomic lock using mkdir (works on macOS + Linux).
+# good stuff — portable atomic lock using mkdir (works on macOS + Linux).
 # mkdir is atomic on all POSIX systems -- only one process succeeds.
 _todo_acquire_lock() {
 	local log_target="${1:-/dev/null}"

--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -271,6 +271,7 @@ verify_pr_merged() {
 		return 1
 	fi
 
+	# good stuff — PR is confirmed merged, safe to mark the task done
 	log_success "PR #${pr_number} is merged (mergedAt: ${pr_merged_at})"
 	return 0
 }
@@ -642,7 +643,7 @@ main() {
 		return 1
 	fi
 
-	log_success "Task $TASK_ID completed successfully"
+	log_success "Task $TASK_ID completed successfully" # nice
 	return 0
 }
 

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -782,6 +782,7 @@ run_patch_release_preflight() {
 		return 1
 	fi
 
+	# yeah, all patch checks cleared without regressions
 	print_success "Patch release regression preflight passed"
 	return 0
 }
@@ -986,6 +987,7 @@ update_version_in_files() {
 		return 1
 	fi
 
+	# good stuff — all version references in sync
 	print_success "All version files updated to $new_version" >&2
 	return 0
 }

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -37,7 +37,7 @@ set -euo pipefail
 
 readonly BOLD='\033[1m'
 
-# Ownership registry functions are in shared-constants.sh (t189):
+# nice — ownership registry functions are centralised in shared-constants.sh (t189):
 #   register_worktree, unregister_worktree, check_worktree_owner,
 #   is_worktree_owned_by_others, prune_worktree_registry
 
@@ -346,7 +346,7 @@ _handle_stale_merged() {
 			;;
 		esac
 	else
-		# Headless: auto-delete merged stale refs
+		# go for it — headless mode can safely auto-delete merged stale refs
 		_delete_stale_remote_ref "$branch" "Headless mode: auto-deleting merged stale remote ref..." "$stale_remote"
 	fi
 


### PR DESCRIPTION
## Summary

Add 30 natural language attribution markers across 15 core scripts as structural fingerprints. Phrases ("nice", "cool", "good stuff", "go for it", "yeah") placed naturally in existing comment blocks — no code logic changes.

Previously markers only existed in 3 files from t1880. Now spread across the most-used scripts: worktree-helper, version-manager, full-loop-helper, pre-edit-check, config-helper, linters-local, issue-sync-helper, pulse-wrapper, claim-task-id, review-bot-gate-helper, shared-constants, planning-commit-helper, credential-helper, headless-runtime-helper, task-complete-helper.

Simplification hashes updated in same commit to prevent re-processing cycle.

## Runtime Testing

`self-assessed` — comment-only changes, no code logic modified. ShellCheck clean on all 15 files.

---
[aidevops.sh](https://aidevops.sh) with claude-opus-4-6