### PR TITLE
GH#17524: keep Homebrew formula checksum valid

### DIFF
--- a/.agents/scripts/validate-version-consistency.sh
+++ b/.agents/scripts/validate-version-consistency.sh
@@ -27,6 +27,17 @@ get_current_version() {
 	return 0
 }
 
+compute_sha256() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256
+	else
+		return 1
+	fi
+	return 0
+}
+
 # Check VERSION file consistency
 # Arguments: expected_version
 # Outputs: increments _vc_errors on mismatch
@@ -144,15 +155,40 @@ _check_config_files() {
 		_vc_warnings=$((_vc_warnings + 1))
 	fi
 
-	# Check homebrew/aidevops.rb (version URL only - SHA256 is updated by CI)
+	# Check homebrew/aidevops.rb against the referenced released tag, not VERSION.
+	# The source-repo formula intentionally stays on the latest released tarball
+	# until publish-packages.yml updates it after release publication.
 	if [[ -f "$repo_root/homebrew/aidevops.rb" ]]; then
-		if grep -q "v${expected_version}.tar.gz" "$repo_root/homebrew/aidevops.rb"; then
-			print_success "homebrew/aidevops.rb: v$expected_version"
-		else
-			local current_formula_version
-			current_formula_version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz' "$repo_root/homebrew/aidevops.rb" | head -1 || echo "not found")
-			print_error "homebrew/aidevops.rb shows '$current_formula_version', expected 'v${expected_version}.tar.gz'"
+		local formula_version
+		local formula_tag
+		local formula_sha
+		formula_version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz' "$repo_root/homebrew/aidevops.rb" | head -1 | sed 's/^v//; s/\.tar\.gz$//' || echo "")
+		formula_sha=$(grep -o 'sha256 "[^"]\+"' "$repo_root/homebrew/aidevops.rb" | head -1 | cut -d'"' -f2 || echo "")
+
+		if [[ -z "$formula_version" ]]; then
+			print_error "homebrew/aidevops.rb version URL not found"
 			_vc_errors=$((_vc_errors + 1))
+		elif [[ -z "$formula_sha" ]]; then
+			print_error "homebrew/aidevops.rb sha256 not found"
+			_vc_errors=$((_vc_errors + 1))
+		else
+			formula_tag="v${formula_version}"
+			if git rev-parse -q --verify "refs/tags/${formula_tag}" >/dev/null 2>&1 || git ls-remote -q --exit-code --tags origin "refs/tags/${formula_tag}" >/dev/null 2>&1; then
+				local release_sha
+				release_sha=$(curl -fsSL "https://github.com/marcusquinn/aidevops/archive/refs/tags/${formula_tag}.tar.gz" | compute_sha256 | cut -d' ' -f1)
+				if [[ -z "$release_sha" ]]; then
+					print_error "homebrew/aidevops.rb checksum lookup failed for ${formula_tag}"
+					_vc_errors=$((_vc_errors + 1))
+				elif [[ "$formula_sha" == "$release_sha" ]]; then
+					print_success "homebrew/aidevops.rb: ${formula_tag} checksum verified"
+				else
+					print_error "homebrew/aidevops.rb checksum mismatch for ${formula_tag}"
+					_vc_errors=$((_vc_errors + 1))
+				fi
+			else
+				print_error "homebrew/aidevops.rb references unreleased tag ${formula_tag}; leave formula pinned to the latest published release"
+				_vc_errors=$((_vc_errors + 1))
+			fi
 		fi
 	fi
 

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -861,25 +861,21 @@ _update_readme_version_badge() {
 	return 0
 }
 
-# Update the Homebrew formula URL to the new version.
-# SHA256 is updated separately by CI publish-packages.yml.
+# Keep the source-repo Homebrew formula pinned to the last released tag.
+# The release workflow updates both the version and SHA256 after the tag exists,
+# then syncs the corrected formula back into the repo and tap.
 # All output goes to stderr. Returns 0 on success, 1 on failure.
 _update_homebrew_formula() {
 	local new_version="$1"
-	local formula_file="$REPO_ROOT/homebrew/aidevops.rb"
 
-	if [[ ! -f "$formula_file" ]]; then
-		return 0
+	# The GitHub-generated release tarball checksum cannot be known until the tag
+	# exists remotely. Do not rewrite the formula during the pre-release bump or
+	# we leave the repo with a broken URL/SHA pair that review bots correctly flag.
+	# The publish-packages workflow performs the post-release formula update.
+	if [[ -n "$new_version" ]]; then
+		print_info "Leaving homebrew/aidevops.rb unchanged until release tarball exists" >&2
 	fi
-
-	sed_inplace "s|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.tar\.gz\"|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v${new_version}.tar.gz\"|" "$formula_file"
-
-	if grep -q "v${new_version}.tar.gz" "$formula_file"; then
-		print_success "Updated homebrew/aidevops.rb version URL" >&2
-	else
-		print_error "Failed to update homebrew/aidevops.rb"
-		return 1
-	fi
+	unset new_version
 	return 0
 }
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -109,7 +109,21 @@ jobs:
           # Update the formula with new version and SHA
           sed -i "s|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v.*\.tar\.gz\"|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v${RELEASE_VERSION}.tar.gz\"|" homebrew/aidevops.rb
           sed -i "s|sha256 \".*\"|sha256 \"${RELEASE_SHA256}\"|" homebrew/aidevops.rb
-      
+
+      - name: Sync Homebrew formula back to repo
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet -- homebrew/aidevops.rb; then
+            echo "Homebrew formula already current"
+            exit 0
+          fi
+
+          git add homebrew/aidevops.rb
+          git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" commit -m "chore: sync homebrew formula for v${RELEASE_VERSION}"
+          git push origin HEAD:main
+
       - name: Push to homebrew-tap repo
         # Pinned to commit SHA for security
         uses: dmnemec/copy_file_to_another_repo_action@bbebd3da22e4a37d04dca5f782edd5201cb97083

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -6,7 +6,7 @@ class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
   url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v3.6.113.tar.gz"
-  sha256 "b0254325bf752ed6142973b69c913d34471d03154f6b5c577842d71b2b3e3f13"
+  sha256 "f01f343db6b3a8d77bc126d1d9fcd9798d24dff3f7d8387721aaadf98b7d6096"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"
 


### PR DESCRIPTION
## Summary
- correct `homebrew/aidevops.rb` to use the published v3.6.113 tarball checksum
- stop prerelease version bumps from writing unreleased Homebrew URL/SHA pairs into the source repo
- sync the corrected formula back to `main` during package publishing and validate checksums against published tags

## Runtime Testing
- Risk level: Low
- Verification: self-assessed

## Testing
- `shellcheck .agents/scripts/version-manager.sh .agents/scripts/validate-version-consistency.sh`
- `./.agents/scripts/validate-version-consistency.sh`

Closes #17524

---
[aidevops.sh](https://aidevops.sh) v3.6.113 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.4