### PR TITLE
t1901: require code skeletons in briefs for code tasks

### DIFF
--- a/.agents/scripts/commands/define.md
+++ b/.agents/scripts/commands/define.md
@@ -78,6 +78,8 @@ Read `templates/brief-template.md` and populate from interview answers:
 | Pre-mortem / negative space | **Acceptance Criteria** (negative criteria) |
 | Files mentioned | **Relevant Files** |
 
+**Code scaffolding (t1901 — MANDATORY for code tasks):** For each file listed in Files to Modify, read the reference pattern file and draft a code skeleton or diff showing the structure of the change. Include these in the Implementation Steps as fenced code blocks. The goal is that the implementing worker can copy the skeleton and fill in details, not invent structure from scratch. For new files: provide a complete skeleton with imports, function signatures, and inline comments marking where logic goes. For edits: provide the exact code block to insert and the surrounding context showing where it goes.
+
 ### Step 6: Present and Confirm
 
 Show the generated brief in full, then offer:

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -75,7 +75,7 @@ fi
 | **Origin** | Created date, session ID, author (human/ai-supervisor/ai-interactive), parent task |
 | **What** | Clear deliverable — what it must produce, not just "implement X" |
 | **Why** | Problem, user need, business value, or dependency |
-| **How** | Files to Modify (`NEW:`/`EDIT:` with paths), Implementation Steps (numbered, concrete), Verification (commands to confirm). See `templates/brief-template.md` for structured format. A brief without file paths produces vague issues that waste worker tokens — search the codebase (`git ls-files`, `rg`) to find them if unknown. |
+| **How** | Files to Modify (`NEW:`/`EDIT:` with paths), Implementation Steps (numbered, concrete), Verification (commands to confirm). See `templates/brief-template.md` for structured format. A brief without file paths produces vague issues that waste worker tokens — search the codebase (`git ls-files`, `rg`) to find them if unknown. **Code scaffolding (t1901):** For each file in Files to Modify, read the reference pattern and draft a code skeleton or diff. New files: complete skeleton with imports, function signatures, and inline comments. Edits: exact code block to insert with surrounding context. The worker should copy and fill in, not invent structure. |
 | **Acceptance** | Specific testable criteria + "Tests pass" + "Lint clean" |
 | **Context** | Key decisions, constraints, things ruled out |
 

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -37,8 +37,21 @@ mode: subagent
 
 ### Implementation Steps
 
-1. {Concrete step with file reference — e.g., "Copy `hooks/git_safety_guard.py` structure, filter for tool_name == mcp_task"}
-2. {Next step — e.g., "Add registration entry in `install-hooks-helper.sh:register_hooks()`"}
+<!-- For each file above, read the reference pattern and include a code skeleton
+     or diff as a fenced code block. New files: complete skeleton with imports,
+     function signatures, and inline comments marking where logic goes.
+     Edits: exact code block to insert with surrounding context.
+     The implementing worker should copy and fill in, not invent structure. -->
+
+1. {Concrete step with code skeleton:}
+
+```{language}
+{Code skeleton for new file — or exact diff block for edits.
+ Include imports, function signatures, inline comments for logic.
+ The worker copies this and fills in implementation details.}
+```
+
+2. {Next step with code skeleton if applicable}
 3. {Final step — e.g., "Run `shellcheck` on new file, verify hook fires with test harness"}
 
 ### Verification


### PR DESCRIPTION
## Summary

Close the gap between "structured implementation plan" and "mentor-level code scaffolding" — the brief-writing agent must now read reference files and draft code skeletons, not just list file paths.

## Changes

| File | Change |
|------|--------|
| `commands/define.md` | Step 5: mandatory code scaffolding for each file in Files to Modify |
| `commands/new-task.md` | Step 3 How row: same instruction in compact form |
| `templates/brief-template.md` | Implementation Steps now includes skeleton placeholder with guidance comment |

## Why

The t1900/t1901 changes got file paths into briefs, but "model on git_safety_guard.py" still requires reading 388 lines. When I hand-wrote a complete Python skeleton into #17511's body, the implementation became copy-paste. This change instructs the brief-writing agent to do what I did manually — read the reference, draft the skeleton, include it in the brief.

Closes #17534

---
[aidevops.sh](https://aidevops.sh) v3.6.113 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 1h 10m and 64,157 tokens on this with the user in an interactive session.