### PR TITLE
GH#17527: clarify dispatch_with_dedup owns round-robin model selection

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -102,7 +102,12 @@ Skip when: all slots occupied, issue created <5 min ago, or maintainer already c
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 list_dispatchable_issue_candidates SLUG 100
 
-# Atomic dispatch — runs all 7 dedup layers, assigns, launches, records ledger
+# Atomic dispatch — runs all 7 dedup layers, assigns, launches, records ledger.
+# DO NOT pass a 9th parameter (model override) here. dispatch_with_dedup owns
+# the round-robin: it calls headless-runtime-helper.sh select --role worker to
+# rotate between configured providers (e.g., anthropic ↔ openai) and records
+# the resolved model in the dispatch comment. Passing your own model bypasses
+# the round-robin and causes all workers to land on a single provider.
 dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER_USER" PATH \
   "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" || continue
 ```
@@ -277,13 +282,22 @@ workers attempted.
 
 ### Model tier selection
 
+`dispatch_with_dedup` handles model selection automatically via round-robin across
+configured providers (AIDEVOPS_HEADLESS_MODELS). The resolved model is recorded in
+the dispatch comment. **Do NOT pass a model override (9th parameter) for default
+dispatches** — this bypasses the round-robin and causes provider imbalance.
+
+Only pass a model override when tier escalation is needed:
+
 ```bash
+# ONLY for tier-labeled issues or failure escalation — NOT for default dispatches
 RESOLVED_MODEL=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve <tier>)
-# Pass: --model "$RESOLVED_MODEL"
+dispatch_with_dedup NUMBER SLUG ... "$RESOLVED_MODEL"
 ```
 
 Precedence: (1) failure escalation (2+ failures → opus) > (2) issue labels (`tier:thinking`
-→ opus, `tier:simple` → haiku) > (3) bundle defaults > (4) omit (default round-robin).
+→ opus, `tier:simple` → haiku) > (3) **omit the 9th parameter** (round-robin selects from
+configured providers and records the model in the dispatch comment).
 
 ### Agent routing from labels
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6431,20 +6431,26 @@ dispatch_with_dedup() {
 	: >"$worker_log"
 	ln -s "$worker_log" "$worker_log_fallback" 2>/dev/null || true
 
-	# Pre-dispatch model selection: check provider backoff BEFORE launching.
-	# Previously, the wrapper dispatched blindly with whatever model was
-	# configured, wasting an assign/claim/launch cycle when the provider was
-	# rate-limited. Now we ask headless-runtime-helper.sh to select the best
-	# available model (respects backoff DB, auth availability, round-robin).
-	# If a model_override is requested (e.g., tier:thinking → opus), we
-	# validate it against backoff first and fall back to auto-selection if
-	# it's currently backed off.
-	# GH#17503: Resolve the actual model name BEFORE dispatch so the comment
-	# shows which model the worker will use (e.g., "anthropic/claude-sonnet-4-6")
-	# instead of "auto-select (round-robin)". The runtime helper's `select`
-	# command runs choose_model() with round-robin, backoff, and auth checks —
-	# the same logic that cmd_run uses — so the model in the comment matches
-	# what the worker actually gets.
+	# ROUND-ROBIN MODEL SELECTION (owned by this function, NOT the caller).
+	#
+	# When model_override (param 9) is EMPTY, this function calls
+	# headless-runtime-helper.sh select --role worker, which runs the
+	# round-robin across AIDEVOPS_HEADLESS_MODELS (respects backoff DB,
+	# auth availability, and provider rotation). The resolved model name
+	# is shown in the dispatch comment so the audit trail records exactly
+	# which provider/model the worker used.
+	#
+	# IMPORTANT: Callers (including the pulse AI) MUST NOT pass a model
+	# override for default dispatches. Only pass model_override when a
+	# specific tier is required (e.g., tier:thinking → opus escalation,
+	# tier:simple → haiku). Passing an arbitrary model here bypasses the
+	# round-robin and causes provider imbalance — e.g., all workers end
+	# up on a single provider instead of alternating between anthropic
+	# and openai as configured.
+	#
+	# History: GH#17503 moved model resolution here (from the worker) so
+	# the dispatch comment shows the actual model. Prior to that fix, the
+	# comment showed "auto-select (round-robin)" which was unhelpful.
 	local selected_model=""
 	if [[ -n "$model_override" ]]; then
 		selected_model="$model_override"


### PR DESCRIPTION
## Summary

- Added code comments to `dispatch_with_dedup()` explaining it owns the round-robin model selection — callers must NOT pass a model override for default dispatches
- Updated `pulse.md` dispatch example and model tier section to reinforce that the 9th parameter is only for tier escalation (opus/haiku), not default dispatches
- Fixed `~/.config/aidevops/config.jsonc` to include both `anthropic/claude-sonnet-4-6` and `openai/gpt-5.3-codex` in `headless_models` (was anthropic-only, making round-robin a no-op under launchd)

## Root Cause

The pulse AI was passing `openai/gpt-5.4` as an explicit model override on every `dispatch_with_dedup` call, bypassing the built-in round-robin. Metrics showed 46 consecutive openai dispatches with zero anthropic dispatches in 23+ hours, despite 3 healthy anthropic accounts in the OAuth pool and no backoff entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dispatch documentation to clarify round-robin model selection behavior across configured providers and explain when model overrides should be used for escalations.

* **Bug Fixes**
  * Enhanced dispatch model selection to apply round-robin rotation across configured providers by default when no override is specified, improving load balancing and ensuring accurate model resolution is recorded in dispatch records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->