### PR TITLE
GH#17537: reduce function complexity in validate-version-consistency.sh

### DIFF
--- a/.agents/scripts/validate-version-consistency.sh
+++ b/.agents/scripts/validate-version-consistency.sh
@@ -88,14 +88,12 @@ _check_readme_badge() {
 	return 0
 }
 
-# Check config/build file version references (sonar, setup.sh, aidevops.sh, package.json, homebrew, marketplace)
+# Check sonar-project.properties version
 # Arguments: expected_version, repo_root
 # Outputs: increments _vc_errors or _vc_warnings on mismatch
-_check_config_files() {
+_check_sonar_properties() {
 	local expected_version="$1"
 	local repo_root="$2"
-
-	# Check sonar-project.properties
 	if [[ -f "$repo_root/sonar-project.properties" ]]; then
 		if grep -q "sonar.projectVersion=$expected_version" "$repo_root/sonar-project.properties"; then
 			print_success "sonar-project.properties: $expected_version"
@@ -109,38 +107,38 @@ _check_config_files() {
 		print_warning "sonar-project.properties not found"
 		_vc_warnings=$((_vc_warnings + 1))
 	fi
+	return 0
+}
 
-	# Check setup.sh
-	if [[ -f "$repo_root/setup.sh" ]]; then
-		if grep -q "# Version: $expected_version" "$repo_root/setup.sh"; then
-			print_success "setup.sh: $expected_version"
+# Check version comment in a shell script (setup.sh, aidevops.sh)
+# Arguments: expected_version, file_path, label
+# Outputs: increments _vc_errors or _vc_warnings on mismatch
+_check_shell_script_version() {
+	local expected_version="$1"
+	local file_path="$2"
+	local label="$3"
+	if [[ -f "$file_path" ]]; then
+		if grep -q "# Version: $expected_version" "$file_path"; then
+			print_success "$label: $expected_version"
 		else
-			local current_setup
-			current_setup=$(grep "# Version:" "$repo_root/setup.sh" | cut -d':' -f2 | xargs || echo "not found")
-			print_error "setup.sh shows '$current_setup', expected '$expected_version'"
+			local current_ver
+			current_ver=$(grep "# Version:" "$file_path" | head -1 | cut -d':' -f2 | xargs || echo "not found")
+			print_error "$label shows '$current_ver', expected '$expected_version'"
 			_vc_errors=$((_vc_errors + 1))
 		fi
 	else
-		print_warning "setup.sh not found"
+		print_warning "$label not found"
 		_vc_warnings=$((_vc_warnings + 1))
 	fi
+	return 0
+}
 
-	# Check aidevops.sh
-	if [[ -f "$repo_root/aidevops.sh" ]]; then
-		if grep -q "# Version: $expected_version" "$repo_root/aidevops.sh"; then
-			print_success "aidevops.sh: $expected_version"
-		else
-			local current_aidevops
-			current_aidevops=$(grep "# Version:" "$repo_root/aidevops.sh" | head -1 | cut -d':' -f2 | xargs || echo "not found")
-			print_error "aidevops.sh shows '$current_aidevops', expected '$expected_version'"
-			_vc_errors=$((_vc_errors + 1))
-		fi
-	else
-		print_warning "aidevops.sh not found"
-		_vc_warnings=$((_vc_warnings + 1))
-	fi
-
-	# Check package.json
+# Check package.json version
+# Arguments: expected_version, repo_root
+# Outputs: increments _vc_errors or _vc_warnings on mismatch
+_check_package_json() {
+	local expected_version="$1"
+	local repo_root="$2"
 	if [[ -f "$repo_root/package.json" ]]; then
 		local pkg_version
 		pkg_version=$(jq -r '.version // "not found"' "$repo_root/package.json" 2>/dev/null || echo "not found")
@@ -154,55 +152,89 @@ _check_config_files() {
 		print_warning "package.json not found"
 		_vc_warnings=$((_vc_warnings + 1))
 	fi
+	return 0
+}
 
-	# Check homebrew/aidevops.rb against the referenced released tag, not VERSION.
-	# The source-repo formula intentionally stays on the latest released tarball
-	# until publish-packages.yml updates it after release publication.
-	if [[ -f "$repo_root/homebrew/aidevops.rb" ]]; then
-		local formula_version
-		local formula_tag
-		local formula_sha
-		formula_version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz' "$repo_root/homebrew/aidevops.rb" | head -1 | sed 's/^v//; s/\.tar\.gz$//' || echo "")
-		formula_sha=$(grep -o 'sha256 "[^"]\+"' "$repo_root/homebrew/aidevops.rb" | head -1 | cut -d'"' -f2 || echo "")
+# Check homebrew/aidevops.rb against the referenced released tag, not VERSION.
+# The source-repo formula intentionally stays on the latest released tarball
+# until publish-packages.yml updates it after release publication.
+# Arguments: repo_root
+# Outputs: increments _vc_errors on mismatch
+_check_homebrew_formula() {
+	local repo_root="$1"
+	if [[ ! -f "$repo_root/homebrew/aidevops.rb" ]]; then
+		return 0
+	fi
+	local formula_version
+	local formula_tag
+	local formula_sha
+	formula_version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz' "$repo_root/homebrew/aidevops.rb" | head -1 | sed 's/^v//; s/\.tar\.gz$//' || echo "")
+	formula_sha=$(grep -o 'sha256 "[^"]\+"' "$repo_root/homebrew/aidevops.rb" | head -1 | cut -d'"' -f2 || echo "")
 
-		if [[ -z "$formula_version" ]]; then
-			print_error "homebrew/aidevops.rb version URL not found"
-			_vc_errors=$((_vc_errors + 1))
-		elif [[ -z "$formula_sha" ]]; then
-			print_error "homebrew/aidevops.rb sha256 not found"
-			_vc_errors=$((_vc_errors + 1))
-		else
-			formula_tag="v${formula_version}"
-			if git rev-parse -q --verify "refs/tags/${formula_tag}" >/dev/null 2>&1 || git ls-remote -q --exit-code --tags origin "refs/tags/${formula_tag}" >/dev/null 2>&1; then
-				local release_sha
-				release_sha=$(curl -fsSL "https://github.com/marcusquinn/aidevops/archive/refs/tags/${formula_tag}.tar.gz" | compute_sha256 | cut -d' ' -f1)
-				if [[ -z "$release_sha" ]]; then
-					print_error "homebrew/aidevops.rb checksum lookup failed for ${formula_tag}"
-					_vc_errors=$((_vc_errors + 1))
-				elif [[ "$formula_sha" == "$release_sha" ]]; then
-					print_success "homebrew/aidevops.rb: ${formula_tag} checksum verified"
-				else
-					print_error "homebrew/aidevops.rb checksum mismatch for ${formula_tag}"
-					_vc_errors=$((_vc_errors + 1))
-				fi
-			else
-				print_error "homebrew/aidevops.rb references unreleased tag ${formula_tag}; leave formula pinned to the latest published release"
-				_vc_errors=$((_vc_errors + 1))
-			fi
-		fi
+	if [[ -z "$formula_version" ]]; then
+		print_error "homebrew/aidevops.rb version URL not found"
+		_vc_errors=$((_vc_errors + 1))
+		return 0
+	fi
+	if [[ -z "$formula_sha" ]]; then
+		print_error "homebrew/aidevops.rb sha256 not found"
+		_vc_errors=$((_vc_errors + 1))
+		return 0
 	fi
 
-	# Check .claude-plugin/marketplace.json (optional - only for repos with Claude plugin)
-	if [[ -f "$repo_root/.claude-plugin/marketplace.json" ]]; then
-		local marketplace_version
-		marketplace_version=$(jq -r '.version // .metadata.version // "not found"' "$repo_root/.claude-plugin/marketplace.json" 2>/dev/null || echo "not found")
-		if [[ "$marketplace_version" == "$expected_version" ]]; then
-			print_success ".claude-plugin/marketplace.json: $expected_version"
+	formula_tag="v${formula_version}"
+	if git rev-parse -q --verify "refs/tags/${formula_tag}" >/dev/null 2>&1 || git ls-remote -q --exit-code --tags origin "refs/tags/${formula_tag}" >/dev/null 2>&1; then
+		local release_sha
+		release_sha=$(curl -fsSL "https://github.com/marcusquinn/aidevops/archive/refs/tags/${formula_tag}.tar.gz" | compute_sha256 | cut -d' ' -f1)
+		if [[ -z "$release_sha" ]]; then
+			print_error "homebrew/aidevops.rb checksum lookup failed for ${formula_tag}"
+			_vc_errors=$((_vc_errors + 1))
+		elif [[ "$formula_sha" == "$release_sha" ]]; then
+			print_success "homebrew/aidevops.rb: ${formula_tag} checksum verified"
 		else
-			print_error ".claude-plugin/marketplace.json shows '$marketplace_version', expected '$expected_version'"
+			print_error "homebrew/aidevops.rb checksum mismatch for ${formula_tag}"
 			_vc_errors=$((_vc_errors + 1))
 		fi
+	else
+		print_error "homebrew/aidevops.rb references unreleased tag ${formula_tag}; leave formula pinned to the latest published release"
+		_vc_errors=$((_vc_errors + 1))
 	fi
+	return 0
+}
+
+# Check .claude-plugin/marketplace.json version (optional)
+# Arguments: expected_version, repo_root
+# Outputs: increments _vc_errors on mismatch
+_check_marketplace_json() {
+	local expected_version="$1"
+	local repo_root="$2"
+	if [[ ! -f "$repo_root/.claude-plugin/marketplace.json" ]]; then
+		return 0
+	fi
+	local marketplace_version
+	marketplace_version=$(jq -r '.version // .metadata.version // "not found"' "$repo_root/.claude-plugin/marketplace.json" 2>/dev/null || echo "not found")
+	if [[ "$marketplace_version" == "$expected_version" ]]; then
+		print_success ".claude-plugin/marketplace.json: $expected_version"
+	else
+		print_error ".claude-plugin/marketplace.json shows '$marketplace_version', expected '$expected_version'"
+		_vc_errors=$((_vc_errors + 1))
+	fi
+	return 0
+}
+
+# Check config/build file version references (sonar, setup.sh, aidevops.sh, package.json, homebrew, marketplace)
+# Arguments: expected_version, repo_root
+# Outputs: increments _vc_errors or _vc_warnings on mismatch
+_check_config_files() {
+	local expected_version="$1"
+	local repo_root="$2"
+
+	_check_sonar_properties "$expected_version" "$repo_root"
+	_check_shell_script_version "$expected_version" "$repo_root/setup.sh" "setup.sh"
+	_check_shell_script_version "$expected_version" "$repo_root/aidevops.sh" "aidevops.sh"
+	_check_package_json "$expected_version" "$repo_root"
+	_check_homebrew_formula "$repo_root"
+	_check_marketplace_json "$expected_version" "$repo_root"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Decomposes the 113-line `_check_config_files()` function in `.agents/scripts/validate-version-consistency.sh` into 6 focused helper functions, each under 50 lines.

Closes #17537

## Changes

- **`_check_sonar_properties()`** — sonar-project.properties validation (18 lines)
- **`_check_shell_script_version()`** — reusable checker for setup.sh and aidevops.sh (19 lines)
- **`_check_package_json()`** — package.json version check (18 lines)
- **`_check_homebrew_formula()`** — homebrew formula tag+checksum verification (41 lines)
- **`_check_marketplace_json()`** — Claude plugin marketplace.json check (16 lines)
- **`_check_config_files()`** — now a 12-line dispatcher calling the above helpers

## Runtime Testing

- **Risk level**: Low (refactor-only, no functionality changes)
- **Verification**: `bash -n` syntax check passed, `shellcheck` passed with zero violations
- **Assessment**: `self-assessed` — pure structural refactor with identical output

---
[aidevops.sh](https://aidevops.sh) v3.6.114 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved version validation script by reorganizing checks into modular, focused helper functions for enhanced maintainability and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->