### PR TITLE
GH#17541: enforce review-bot-gate in code for worker merge path

### DIFF
--- a/.agents/reference/review-bot-gate.md
+++ b/.agents/reference/review-bot-gate.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-# Review Bot Gate (t1382, GH#3827)
+# Review Bot Gate (t1382, GH#3827, GH#17541)
 
 Before merging any PR, wait for AI code review bots (CodeRabbit, Gemini Code Assist,
 etc.) to post their reviews. PRs merged before bots post lose security findings.
@@ -9,8 +9,19 @@ etc.) to post their reviews. PRs merged before bots post lose security findings.
 ## Enforcement Layers
 
 1. **CI**: `.github/workflows/review-bot-gate.yml` — required status check
-2. **Agent**: `review-bot-gate-helper.sh check <PR> [REPO]` — returns PASS/PASS_RATE_LIMITED/WAITING/SKIP
-3. **Branch protection**: add `review-bot-gate` as required check per repo
+2. **Pulse merge path**: `pulse-wrapper.sh` line 8243 — `review-bot-gate-helper.sh check` before merge (code-enforced since GH#17490)
+3. **Worker merge path**: `full-loop-helper.sh merge` — `review-bot-gate-helper.sh wait` before merge (code-enforced since GH#17541)
+4. **Branch protection**: add `review-bot-gate` as required check per repo
+
+## Merge Commands
+
+| Context | Command | Gate |
+|---------|---------|------|
+| Worker (full-loop) | `full-loop-helper.sh merge <PR> [REPO]` | Code-enforced `wait` |
+| Pulse (deterministic) | Internal `_merge_ready_prs_for_repo` | Code-enforced `check` |
+| Manual (interactive) | `review-bot-gate-helper.sh wait <PR> [REPO]` then `gh pr merge` | Prompt-level |
+
+Workers MUST use `full-loop-helper.sh merge` — direct `gh pr merge` bypasses the gate (GH#17541).
 
 ## Workflow
 

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -18,9 +18,9 @@ Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NO
 | # | Step | Signal |
 |---|------|--------|
 | 0 | Commit+PR gate — all changes committed, PR exists | `TASK_COMPLETE` |
-| 1 | Review bot gate — wait for bots (poll ≤10 min) | |
+| 1 | Review bot gate — code-enforced via `full-loop-helper.sh merge` (GH#17541) | |
 | 2 | Address critical bot review findings | |
-| 3 | Merge — `gh pr merge --squash` (no `--delete-branch` in worktrees) | |
+| 3 | Merge — `full-loop-helper.sh merge` (enforces gate + squash, no `--delete-branch`) | |
 | 4 | Auto-release — bump patch + GitHub release (aidevops repo only) | |
 | 5 | Issue closing comment — structured comment on every linked issue | |
 | 6 | Postflight + deploy — verify release health, run setup.sh | `FULL_LOOP_COMPLETE` |
@@ -122,9 +122,17 @@ Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[
 
 **4.3 Label `status:in-review` (t1343):** check issue is `OPEN` first.
 
-**4.4 Review Bot Gate (t1382):** `review-bot-gate-helper.sh wait "$PR_NUMBER" "$REPO"`. Polls every 60s, up to 10 min timeout. Do NOT use `check` with ad-hoc polling — `wait` handles the retry loop.
+**4.4 Review Bot Gate (t1382 + GH#17541 — CODE-ENFORCED):** The gate is enforced in code, not just prompt instructions. Use the merge wrapper which runs the gate automatically:
 
-**4.5 Merge:** `gh pr merge --squash` (no `--delete-branch` from inside worktree).
+```bash
+full-loop-helper.sh merge "$PR_NUMBER" "$REPO"
+```
+
+This calls `review-bot-gate-helper.sh wait` (polls every 60s, up to 10 min) then `gh pr merge --squash`. If the gate fails, merge is blocked. Do NOT call `gh pr merge` directly — the wrapper is the only sanctioned merge path for workers.
+
+If you need to check the gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$REPO"`.
+
+**4.5 Merge (via wrapper only):** Workers MUST use `full-loop-helper.sh merge` (step 4.4 above). Direct `gh pr merge --squash` bypasses the review bot gate and is a bug (GH#17541). The wrapper enforces: (1) review-bot-gate wait, (2) squash merge, (3) no `--delete-branch` from inside worktree.
 
 **4.6 Auto-Release (aidevops only):** `version-manager.sh bump patch`, tag, push, `gh release create`, `setup.sh --non-interactive`.
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -359,6 +359,115 @@ cmd_logs() {
 	tail -n "$lines" "$log_file"
 }
 
+# Pre-merge gate (GH#17541) — deterministic enforcement of review-bot-gate
+# before any PR merge. Workers MUST call this before `gh pr merge`.
+# Models the pulse-wrapper.sh pattern (line 8243-8262) for the worker merge path.
+#
+# Usage: full-loop-helper.sh pre-merge-gate <PR_NUMBER> [REPO]
+# Exit codes: 0 = safe to merge, 1 = gate failed (do NOT merge)
+cmd_pre_merge_gate() {
+	local pr_number="${1:-}"
+	local repo="${2:-}"
+
+	if [[ -z "$pr_number" ]]; then
+		print_error "Usage: full-loop-helper.sh pre-merge-gate <PR_NUMBER> [REPO]"
+		return 1
+	fi
+
+	# Auto-detect repo from git remote if not provided
+	if [[ -z "$repo" ]]; then
+		repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+		if [[ -z "$repo" ]]; then
+			print_error "Cannot detect repo. Pass REPO as second argument."
+			return 1
+		fi
+	fi
+
+	local rbg_helper="${SCRIPT_DIR}/review-bot-gate-helper.sh"
+	if [[ ! -f "$rbg_helper" ]]; then
+		# Fallback to deployed location
+		rbg_helper="${HOME}/.aidevops/agents/scripts/review-bot-gate-helper.sh"
+	fi
+
+	if [[ ! -f "$rbg_helper" ]]; then
+		print_warning "review-bot-gate-helper.sh not found — skipping gate (degraded mode)"
+		return 0
+	fi
+
+	print_info "Running review bot gate for PR #${pr_number} in ${repo}..."
+
+	# Use 'wait' mode (polls up to 600s) — same as full-loop.md step 4.4 instructs,
+	# but now enforced in code rather than relying on prompt compliance.
+	local rbg_result=""
+	rbg_result=$(bash "$rbg_helper" wait "$pr_number" "$repo" 2>&1) || true
+
+	local rbg_status=""
+	rbg_status=$(printf '%s' "$rbg_result" | grep -oE '^(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | head -1)
+
+	case "$rbg_status" in
+	PASS | SKIP | PASS_RATE_LIMITED)
+		print_success "Review bot gate: ${rbg_status} — safe to merge PR #${pr_number}"
+		return 0
+		;;
+	*)
+		print_error "Review bot gate: ${rbg_status:-FAILED} — do NOT merge PR #${pr_number}"
+		printf '%s\n' "$rbg_result" | tail -5
+		return 1
+		;;
+	esac
+}
+
+# Merge wrapper (GH#17541) — enforces review-bot-gate then merges.
+# Single command that replaces the multi-step protocol (wait + merge).
+# Workers call this instead of bare `gh pr merge`.
+#
+# Usage: full-loop-helper.sh merge <PR_NUMBER> [REPO] [--squash|--merge|--rebase]
+# Exit codes: 0 = merged, 1 = gate failed or merge failed
+cmd_merge() {
+	local pr_number="${1:-}"
+	local repo="${2:-}"
+	local merge_method="--squash"
+
+	if [[ -z "$pr_number" ]]; then
+		print_error "Usage: full-loop-helper.sh merge <PR_NUMBER> [REPO] [--squash|--merge|--rebase]"
+		return 1
+	fi
+
+	# Parse optional repo and merge method
+	if [[ "${repo:-}" == --* ]]; then
+		merge_method="$repo"
+		repo=""
+	fi
+	if [[ -n "${3:-}" && "${3:-}" == --* ]]; then
+		merge_method="$3"
+	fi
+
+	# Auto-detect repo from git remote if not provided
+	if [[ -z "$repo" ]]; then
+		repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+		if [[ -z "$repo" ]]; then
+			print_error "Cannot detect repo. Pass REPO as second argument."
+			return 1
+		fi
+	fi
+
+	# Gate: enforce review-bot-gate before merge
+	cmd_pre_merge_gate "$pr_number" "$repo" || {
+		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
+		return 1
+	}
+
+	# Merge (no --delete-branch from inside worktree, per full-loop.md step 4.5)
+	print_info "Merging PR #${pr_number} in ${repo} (${merge_method})..."
+	if gh pr merge "$pr_number" --repo "$repo" "$merge_method" 2>&1; then
+		print_success "PR #${pr_number} merged successfully"
+		return 0
+	else
+		print_error "Merge failed for PR #${pr_number}"
+		return 1
+	fi
+}
+
 cmd_complete() {
 	load_state 2>/dev/null || true
 	printf "\n${BOLD}${GREEN}=== FULL DEVELOPMENT LOOP - COMPLETE ===${NC}\n"
@@ -373,7 +482,15 @@ show_help() {
 	cat <<'EOF'
 Full Development Loop Orchestrator
 Usage: full-loop-helper.sh <command> [options]
-Commands: start "<prompt>" | resume | status | cancel | logs [N] | help
+Commands:
+  start "<prompt>"              Start a new development loop
+  resume                        Resume from last phase
+  status                        Show current loop state
+  cancel                        Cancel active loop
+  logs [N]                      Show last N log lines (default: 50)
+  pre-merge-gate <PR> [REPO]    Check review bot gate before merge (GH#17541)
+  merge <PR> [REPO] [--squash]  Gate-enforced merge (runs pre-merge-gate first)
+  help                          Show this help
 Options: --max-task-iterations N (50) | --max-preflight-iterations N (5)
   --max-pr-iterations N (20) | --skip-preflight | --skip-postflight
   --skip-runtime-testing | --no-auto-pr | --no-auto-deploy
@@ -399,6 +516,8 @@ main() {
 	case "$command" in
 	start) cmd_start "$@" ;; resume) cmd_resume ;; status) cmd_status ;;
 	cancel) cmd_cancel ;; logs) cmd_logs "$@" ;; _run_foreground) _run_foreground "$@" ;;
+	pre-merge-gate) cmd_pre_merge_gate "$@" ;;
+	merge) cmd_merge "$@" ;;
 	help | --help | -h) show_help ;;
 	*)
 		print_error "Unknown command: $command"


### PR DESCRIPTION
## Summary

Workers dispatched via `/full-loop` bypassed the review-bot-gate by calling `gh pr merge` directly, merging PRs in <30s before any review bot could post. The gate was prompt-level only (~85% compliance rate). This moves enforcement from prompt to code.

## Changes

- **`full-loop-helper.sh merge`**: New gate-enforced merge wrapper that runs `review-bot-gate-helper.sh wait` (polls up to 600s) before executing `gh pr merge --squash`. Workers call this single command instead of the multi-step protocol.
- **`full-loop-helper.sh pre-merge-gate`**: Standalone gate check command for cases where you need to verify the gate without merging.
- **`full-loop.md` steps 4.4/4.5**: Updated to mandate the merge wrapper. Direct `gh pr merge` is now documented as a bug.
- **`reference/review-bot-gate.md`**: Documents both enforcement paths (pulse deterministic merge + worker merge) with a command reference table.

## Design

Models the existing pulse-wrapper.sh pattern (line 8243-8262) which already enforces the gate in code for the pulse merge path. The worker merge path now has equivalent enforcement.

The wrapper approach (Option 1+2 from the issue) was chosen because:
1. It reduces the prompt surface area from a multi-step protocol to a single command
2. It's deterministic — the gate runs regardless of LLM compliance
3. It degrades gracefully — if `review-bot-gate-helper.sh` is missing, it warns and proceeds

## Runtime Testing

- **Risk**: Low (agent prompts + shell script, no runtime state changes)
- **Verification**: `shellcheck` passes on `full-loop-helper.sh` (only pre-existing SC1091 info)
- **Pattern verification**: `grep review-bot-gate full-loop-helper.sh` shows the gate

Closes #17541

---
[aidevops.sh](https://aidevops.sh) v3.6.114 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added a new merge command that enforces gate validation before merging pull requests.
  - Introduced a pre-merge gate check command to validate reviews without merging.

* **Documentation**
  - Updated merge workflow documentation with explicit enforcement layers and clearer merge command guidance for proper gate enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->