### PR TITLE
fix: prevent set -e from aborting version-manager release

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -1354,8 +1354,10 @@ create_git_tag() {
 	fi
 
 	# Also check remote tags to catch tags pushed by a concurrent run
-	git ls-remote -q --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1
-	local remote_tag_exit=$?
+	# Note: --exit-code returns 2 when ref not found; capture exit code to
+	# prevent set -e from aborting the script on a "not found" result.
+	local remote_tag_exit=0
+	git ls-remote -q --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1 || remote_tag_exit=$?
 	if [ $remote_tag_exit -eq 0 ]; then
 		print_error "Tag $tag_name already exists on remote origin"
 		print_info "A concurrent release run may have pushed this tag. Diagnose with:"
@@ -1585,8 +1587,10 @@ _release_execute() {
 	# Guard: detect partial release state before making any changes.
 	# A tag without a matching GitHub release indicates a prior failed run.
 	# Abort early with clear diagnostics rather than creating a duplicate tag.
-	git ls-remote -q --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1
-	local preflight_remote_exit=$?
+	# Note: --exit-code returns 2 when ref not found; capture exit code to
+	# prevent set -e from aborting the script on a "not found" result.
+	local preflight_remote_exit=0
+	git ls-remote -q --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1 || preflight_remote_exit=$?
 	if git show-ref --tags "$tag_name" &>/dev/null || [ $preflight_remote_exit -eq 0 ]; then
 		print_error "PARTIAL RELEASE STATE DETECTED: tag $tag_name already exists"
 		print_info ""
@@ -1632,8 +1636,10 @@ _release_execute() {
 		if ! push_changes; then
 			# --atomic push failed: tag was NOT pushed to remote.
 			# Check whether a concurrent run already pushed the tag before rolling back.
-			git ls-remote -q --exit-code --tags origin "refs/tags/v$new_version" >/dev/null 2>&1
-			local push_fail_remote_exit=$?
+			# Note: --exit-code returns 2 when ref not found; capture exit code to
+			# prevent set -e from aborting the script on a "not found" result.
+			local push_fail_remote_exit=0
+			git ls-remote -q --exit-code --tags origin "refs/tags/v$new_version" >/dev/null 2>&1 || push_fail_remote_exit=$?
 			if [ $push_fail_remote_exit -eq 0 ]; then
 				print_warning "Push failed but tag v$new_version already exists on remote (concurrent release?)"
 				print_info "Deleting local tag to avoid divergence. Check remote state:"


### PR DESCRIPTION
## Summary

- Fixes silent release abort caused by `git ls-remote --exit-code` returning exit code 2 (ref not found) under `set -euo pipefail`
- All three call sites in `version-manager.sh` (lines 1359, 1592, 1641) use the same `set -e`-safe pattern: pre-initialize variable, capture exit code via `||`
- Root cause: `--exit-code` returns 0 (found), 1 (error), or 2 (not found) — `set -e` treats 2 as fatal

## Problem

Every `version-manager.sh release` call silently aborted at the partial-release-state guard. The script would bump VERSION in the working tree but never commit, tag, push, or create the GitHub release. This required manual release steps as a workaround.

## Runtime Testing

- **Risk**: Medium (release tooling, affects every release)
- **Verification**: ShellCheck clean. Pattern is deterministic — `|| var=$?` is the standard `set -e` exit-code capture idiom.


---
[aidevops.sh](https://aidevops.sh) v3.6.117 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 30m and 26,758 tokens on this with the user in an interactive session.