### PR TITLE
GH#17551: fix logind parser hostname matching for screen time

### DIFF
--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -358,23 +358,40 @@ _linux_logind_hours() {
 	current_user=$(whoami)
 
 	# Extract timestamped session events for the current user
+	# Track sessions by ID to avoid matching username in hostname (GH#17551)
 	local events_file
 	events_file=$(mktemp)
+	local tracked_sessions_file
+	tracked_sessions_file=$(mktemp)
 
 	journalctl --since "$since_date" -u systemd-logind.service --no-pager -o short-iso 2>/dev/null |
 		grep -iE "(New session|Removed session|Session .* logged out|Lid closed|Lid opened)" |
-		grep -i "$current_user" |
 		while IFS= read -r line; do
 			local ts
-			local event_type
 			ts=$(echo "$line" | awk '{print $1}')
-			if echo "$line" | grep -qi "New session\|Lid opened"; then
-				event_type="ON"
-			else
-				event_type="OFF"
+			local sid=""
+
+			# Lid events apply globally — no session ID filtering needed
+			if echo "$line" | grep -qi "Lid opened"; then
+				echo "${ts} ON"
+			elif echo "$line" | grep -qi "Lid closed"; then
+				echo "${ts} OFF"
+			# Match "New session <ID> of user <current_user>" exactly
+			elif echo "$line" | grep -qiE "New session [a-z0-9]+ of user ${current_user}([^a-zA-Z0-9]|$)"; then
+				sid=$(echo "$line" | sed -nE 's/.*[Nn]ew session ([a-zA-Z0-9]+) of user .*/\1/p')
+				[[ -n "$sid" ]] && echo "$sid" >>"$tracked_sessions_file" && echo "${ts} ON"
+			# Match "Removed session <ID>" only if ID was tracked
+			elif echo "$line" | grep -qiE "Removed session [a-z0-9]+"; then
+				sid=$(echo "$line" | sed -nE 's/.*[Rr]emoved session ([a-zA-Z0-9]+).*/\1/p')
+				[[ -n "$sid" ]] && grep -qxF "$sid" "$tracked_sessions_file" 2>/dev/null && echo "${ts} OFF"
+			# Match "Session <ID> logged out" only if ID was tracked
+			elif echo "$line" | grep -qiE "Session [a-z0-9]+ logged out"; then
+				sid=$(echo "$line" | sed -nE 's/.*[Ss]ession ([a-zA-Z0-9]+) logged out.*/\1/p')
+				[[ -n "$sid" ]] && grep -qxF "$sid" "$tracked_sessions_file" 2>/dev/null && echo "${ts} OFF"
 			fi
-			echo "${ts} ${event_type}"
 		done >"$events_file" 2>/dev/null
+
+	rm -f "$tracked_sessions_file"
 
 	local total_seconds=0
 


### PR DESCRIPTION
## Summary

Fixes a bug where `_linux_logind_hours()` in `screen-time-helper.sh` matched the current username anywhere in the journalctl log line — including the hostname field. On systems where the hostname contains the username (e.g., `rob-VirtualBox`), this caused GDM display manager sessions (`c1`) to be counted as user sessions, producing ~20s/day instead of actual hours.

Closes #17551

## Changes

- **`.agents/scripts/screen-time-helper.sh:360-403`**: Rewrote the event extraction loop to track sessions by ID:
  - Parse `New session <ID> of user <username>` with word-boundary matching to extract and record session IDs
  - Match `Removed session <ID>` and `Session <ID> logged out` only for tracked user session IDs
  - Pass through Lid open/close events without session ID filtering (they apply globally)
  - Uses a temp file to track session IDs across the pipeline subshell

## Root Cause

The original code used `grep -i "$current_user"` as a second filter on the full log line. On a host named `rob-VirtualBox`, every line matched — including `New session c1 of user gdm`. The ON/OFF pairing then paired GDM's 20-second session instead of the user's multi-hour session.

## Runtime Testing

- **Risk level**: Medium (data reporting, no destructive operations)
- **Verification**: `self-assessed` — ShellCheck passes clean; regex edge cases tested (exact match, trailing period, substring rejection, hostname-in-line rejection)
- **No dev environment with systemd-logind available** for runtime verification

## Testing Evidence

- ShellCheck: zero violations
- Regex edge cases verified:
  - `"New session 2 of user rob"` → MATCH ✓
  - `"New session 2 of user rob."` → MATCH ✓ (trailing period)
  - `"New session c1 of user gdm"` → NO MATCH ✓
  - `"New session 2 of user robert"` → NO MATCH ✓ (substring)
  - `"rob-VirtualBox systemd-logind: New session c1 of user gdm."` → NO MATCH ✓ (hostname)

---
[aidevops.sh](https://aidevops.sh) v3.6.118 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen time tracking accuracy on Linux systems by enhancing how user sessions are detected and monitored. The system now more reliably tracks when sessions start and end, resulting in more precise screen time measurements. Additionally, system events like lid open and close are now better handled in the tracking process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->