### PR TITLE
GH#17556: rewrite nesting depth checker — fix 88% false positive rate (278->34)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -12,27 +12,13 @@
 FUNCTION_COMPLEXITY_THRESHOLD=420
 
 # Shell nesting depth: files with >8 levels of nesting
-# Current baseline: 262 (as of 2026-04-01, +1 for complexity-scan-helper.sh GH#15285)
-# Bumped to 263 (GH#15316): orchestration-efficiency-collector.sh adds 1 violation
-# due to awk heredocs with if/for patterns counted by the depth checker
-# Bumped to 266 (GH#15391/t1748): platform-detect.sh adds 1 violation (elif-counting
-# quirk in awk checker inflates depth); 2 additional violations from pre-existing
-# scripts included in CI merge ref after threshold was set
-# Bumped to 267 (GH#16096/t1864): notes-helper.sh adds 1 violation (osascript
-# AppleScript blocks inside bash functions — same pattern as calendar/contacts helpers)
-# Bumped to 268 (GH#16685/t1867): autoagent-metric-helper.sh adds 1 violation
-# (CI awk checker counts if/case across all functions without resetting at boundaries)
-# Bumped to 269 (GH#16866): pre-existing regression on main from ollama-helper.sh
-# (GH#16862) — awk checker counts if/case patterns inside heredocs
-# Bumped to 271 (GH#16880): pre-existing regression on main (2 new violations from
-# scripts merged after threshold was set — not introduced by this PR)
-# Bumped to 275 (GH#17068): pre-existing regression from t1880/t1881 attribution
-# protection work — aidevops.sh grew by ~35 lines adding signing verification and
-# status checks; awk depth checker counts all if/case/for across the entire file
-# without function-boundary resets, inflating the count for large scripts
-# Bumped to 276 (GH#17086): pre-existing regression on main (1 new violation from
-# scripts merged after threshold was set — not introduced by this PR)
-NESTING_DEPTH_THRESHOLD=276
+# Checker rewritten (refactor/nesting-checker) to fix systemic false positives:
+#   - Resets depth at function boundaries (was accumulating across all functions)
+#   - Skips heredoc content (was counting keywords in awk/AppleScript/etc.)
+#   - Uses word-level matching (was matching "if" inside "elif", strings, etc.)
+# Previous threshold was 276 with the broken checker (278 violations at failure).
+# Accurate checker baseline: 34 violations (as of 2026-04-06).
+NESTING_DEPTH_THRESHOLD=34
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -364,11 +364,48 @@ jobs:
         violations=0
         while IFS= read -r file; do
           [ -n "$file" ] || continue
+          # Improved depth checker (refactor/nesting-checker):
+          #   - Resets depth at function boundaries (prevents cross-function accumulation)
+          #   - Skips heredoc content (prevents counting keywords in embedded languages)
+          #   - Uses word-level matching (prevents matching "if" inside "elif", strings, etc.)
           max_depth=$(awk '
-            BEGIN { depth=0; max_depth=0 }
+            BEGIN { depth=0; max_depth=0; in_heredoc=0; heredoc_end="" }
+            in_heredoc {
+              if ($0 ~ ("^[[:space:]]*" heredoc_end "[[:space:]]*$")) { in_heredoc=0 }
+              next
+            }
             /^[[:space:]]*#/ { next }
-            /[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
-            /[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+            /<<[^<]/ || /<<$/ {
+              line = $0
+              idx = index(line, "<<")
+              if (idx > 0) {
+                rest = substr(line, idx + 2)
+                sub(/^-/, "", rest)
+                sub(/^[[:space:]]*\\?/, "", rest)
+                sub(/^['"'"'\"]+/, "", rest)
+                if (match(rest, /^[A-Za-z_][A-Za-z0-9_]*/)) {
+                  heredoc_end = substr(rest, RSTART, RLENGTH)
+                  in_heredoc = 1
+                }
+              }
+            }
+            /^[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\(\)/ || /^function[[:space:]]+[a-zA-Z_]/ {
+              depth = 0
+            }
+            !in_heredoc {
+              n = split($0, words)
+              for (i = 1; i <= n; i++) {
+                w = words[i]
+                gsub(/[;,(){}|&>]/, "", w)
+                if (w == "if" || w == "for" || w == "while" || w == "until" || w == "case") {
+                  depth++
+                  if (depth > max_depth) max_depth = depth
+                }
+                if (w == "fi" || w == "done" || w == "esac") {
+                  if (depth > 0) depth--
+                }
+              }
+            }
             END { print max_depth }
           ' "$file")
           if [ "$max_depth" -gt 8 ]; then


### PR DESCRIPTION
## Summary

- Rewrites the CI awk nesting depth checker to fix three systemic bugs that caused 88% of violations to be false positives (278 → 34 real violations)
- Drops threshold from 276 to 34 — the ratchet can now actually ratchet downward
- Filed 10 simplification issues (GH#17556–GH#17565) for files with genuine deep nesting

### Checker bugs fixed

| Bug | Impact | Example |
|-----|--------|---------|
| No function-boundary resets | Depth accumulated across ALL functions in a file | `pulse-wrapper.sh`: 238 reported → 19 actual |
| Counted heredoc content | Keywords in awk/AppleScript/embedded langs inflated depth | `document-creation-helper.sh`: 95 → 6 |
| Regex substring matching | Matched `if` inside `elif`, inside strings, etc. | `platform-detect.sh`: 10 → 1 |

### Real top 10 violations (to be simplified via filed issues)

| Depth | File | Issue |
|-------|------|-------|
| 35 | `generate-claude-commands.sh` | GH#17556 |
| 28 | `oauth-pool-helper.sh` | GH#17557 |
| 22 | `generate-opencode-commands.sh` | GH#17558 |
| 21 | `generate-claude-agents.sh` | GH#17559 |
| 19 | `pulse-wrapper.sh` | GH#17560 |
| 16 | `worker-lifecycle-common.sh` | GH#17561 |
| 16 | `colormind-helper.sh` | GH#17562 |
| 15 | `cch-traffic-monitor.sh` | GH#17563 |
| 14 | `pre-edit-check.sh` | GH#17564 |
| 14 | `servers-helper.sh` | GH#17565 |

Closes #17556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced nesting depth quality checks for improved accuracy in the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->