### PR TITLE
GH#17550: fix profile-readme session hours hardcoded to ~/Git/aidevops

### DIFF
--- a/.agents/scripts/contributor-activity-helper.sh
+++ b/.agents/scripts/contributor-activity-helper.sh
@@ -26,7 +26,7 @@
 #   contributor-activity-helper.sh table <repo-path> [--format markdown|json]
 #   contributor-activity-helper.sh user <repo-path> <github-login>
 #   contributor-activity-helper.sh cross-repo-summary <repo-path1> [<repo-path2> ...] [--period month]
-#   contributor-activity-helper.sh session-time <repo-path> [--period month]
+#   contributor-activity-helper.sh session-time <repo-path> [--period month] [--all-dirs]
 #   contributor-activity-helper.sh cross-repo-session-time <path1> [path2 ...] [--period month]
 #   contributor-activity-helper.sh person-stats <repo-path> [--period month] [--logins a,b]
 #   contributor-activity-helper.sh cross-repo-person-stats <path1> [path2 ...] [--period month]
@@ -623,17 +623,31 @@ _session_time_all_periods() {
 	local format="$2"
 	local db_path="$3"
 
+	# Detect --all-dirs passthrough: when repo_path is literally "--all-dirs",
+	# pass the flag through to session_time instead of a repo path.
+	local all_dirs_flag=""
+	if [[ "$repo_path" == "--all-dirs" ]]; then
+		all_dirs_flag="--all-dirs"
+		repo_path=""
+	fi
+
 	local all_periods=("day" "week" "month" "quarter" "year")
 	local combined_json="["
 	local first_period=true
 	local p
 	for p in "${all_periods[@]}"; do
 		local p_json
-		local -a db_args=()
-		if [[ -n "$db_path" ]]; then
-			db_args+=(--db-path "$db_path")
+		local -a session_args=()
+		if [[ -n "$all_dirs_flag" ]]; then
+			session_args+=("--all-dirs")
+		elif [[ -n "$repo_path" ]]; then
+			session_args+=("$repo_path")
 		fi
-		p_json=$(session_time "$repo_path" --period "$p" --format json "${db_args[@]}") || p_json="{}"
+		session_args+=(--period "$p" --format json)
+		if [[ -n "$db_path" ]]; then
+			session_args+=(--db-path "$db_path")
+		fi
+		p_json=$(session_time "${session_args[@]}") || p_json="{}"
 		if [[ "$first_period" == "true" ]]; then
 			first_period=false
 		else
@@ -679,7 +693,7 @@ else:
 #
 # Arguments:
 #   $1 - db path
-#   $2 - abs repo path (for SQL filtering)
+#   $2 - abs repo path (for SQL filtering; empty string = all directories)
 #   $3 - since_ms (milliseconds threshold)
 # Output: JSON array of session rows to stdout
 #######################################
@@ -688,13 +702,22 @@ _session_time_query_db() {
 	local abs_repo_path="$2"
 	local since_ms="$3"
 
-	# Escape path for safe SQL embedding:
-	# - Single quotes doubled per SQL standard (prevents injection)
-	# - % and _ escaped for LIKE patterns (prevents wildcard matching)
-	# since_ms is always numeric (computed by Python above), no injection risk.
-	local safe_path="${abs_repo_path//\'/\'\'}"
-	local like_path="${safe_path//%/\\%}"
-	like_path="${like_path//_/\\_}"
+	# Build directory filter clause.
+	# When abs_repo_path is empty (--all-dirs), skip directory filtering
+	# to aggregate sessions across all repos (profile-level stats).
+	local dir_clause=""
+	if [[ -n "$abs_repo_path" ]]; then
+		# Escape path for safe SQL embedding:
+		# - Single quotes doubled per SQL standard (prevents injection)
+		# - % and _ escaped for LIKE patterns (prevents wildcard matching)
+		# since_ms is always numeric (computed by Python above), no injection risk.
+		local safe_path="${abs_repo_path//\'/\'\'}"
+		local like_path="${safe_path//%/\\%}"
+		like_path="${like_path//_/\\_}"
+		dir_clause="AND (s.directory = '${safe_path}'
+			       OR s.directory LIKE '${like_path}.%' ESCAPE '\\'
+			       OR s.directory LIKE '${like_path}-%' ESCAPE '\\')"
+	fi
 
 	# Query per-session human vs machine time using window functions.
 	# LAG() compares each message with the previous one in the same session:
@@ -719,9 +742,7 @@ _session_time_query_db() {
 			JOIN message m ON m.session_id = s.id
 			WHERE s.parent_id IS NULL
 			  AND m.time_created > ${since_ms}
-			  AND (s.directory = '${safe_path}'
-			       OR s.directory LIKE '${like_path}.%' ESCAPE '\\'
-			       OR s.directory LIKE '${like_path}-%' ESCAPE '\\')
+			  ${dir_clause}
 		)
 		SELECT
 			session_id,
@@ -920,6 +941,7 @@ _session_time_process() {
 #   --period day|week|month|quarter|year|all (optional, default: month)
 #   --format markdown|json (optional, default: markdown)
 #   --db-path <path> (optional, default: auto-detect)
+#   --all-dirs (optional, skip directory filter — aggregate all sessions)
 # Output: markdown table or JSON. "all" shows every period in one table.
 #######################################
 session_time() {
@@ -927,6 +949,7 @@ session_time() {
 	local period="month"
 	local format="markdown"
 	local db_path=""
+	local all_dirs="false"
 
 	# Parse arguments
 	while [[ $# -gt 0 ]]; do
@@ -943,6 +966,10 @@ session_time() {
 			db_path="${2:-}"
 			shift 2
 			;;
+		--all-dirs)
+			all_dirs="true"
+			shift
+			;;
 		*)
 			if [[ -z "$repo_path" ]]; then
 				repo_path="$1"
@@ -952,7 +979,9 @@ session_time() {
 		esac
 	done
 
-	repo_path="${repo_path:-.}"
+	if [[ "$all_dirs" != "true" ]]; then
+		repo_path="${repo_path:-.}"
+	fi
 
 	# Auto-detect database path
 	if [[ -z "$db_path" ]]; then
@@ -979,7 +1008,11 @@ session_time() {
 
 	# Handle --period all: collect JSON for each period and output combined table
 	if [[ "$period" == "all" ]]; then
-		_session_time_all_periods "$repo_path" "$format" "$db_path"
+		local -a all_args=("$repo_path" "$format" "$db_path")
+		if [[ "$all_dirs" == "true" ]]; then
+			all_args=("--all-dirs" "$format" "$db_path")
+		fi
+		_session_time_all_periods "${all_args[@]}"
 		return 0
 	fi
 
@@ -997,8 +1030,11 @@ session_time() {
 	since_ms=$(python3 -c "import time; print(int((time.time() - ${seconds}) * 1000))")
 
 	# Resolve repo_path to absolute for matching against session.directory
-	local abs_repo_path
-	abs_repo_path=$(cd "$repo_path" 2>/dev/null && pwd) || abs_repo_path="$repo_path"
+	# When --all-dirs is set, pass empty string to skip directory filtering
+	local abs_repo_path=""
+	if [[ "$all_dirs" != "true" ]]; then
+		abs_repo_path=$(cd "$repo_path" 2>/dev/null && pwd) || abs_repo_path="$repo_path"
+	fi
 
 	local query_result
 	query_result=$(_session_time_query_db "$db_path" "$abs_repo_path" "$since_ms")
@@ -1793,7 +1829,7 @@ main() {
 		echo "  table   <repo-path> [--period day|week|month|year] [--format markdown|json]"
 		echo "  user    <repo-path> <github-login>"
 		echo "  cross-repo-summary <path1> [path2 ...] [--period month] [--format markdown]"
-		echo "  session-time <repo-path> [--period day|week|month|quarter|year|all] [--format markdown|json]"
+		echo "  session-time <repo-path> [--period day|week|month|quarter|year|all] [--format markdown|json] [--all-dirs]"
 		echo "  cross-repo-session-time <path1> [path2 ...] [--period month|all] [--format markdown|json]"
 		echo "  person-stats <repo-path> [--period day|week|month|quarter|year] [--format markdown|json] [--logins a,b]"
 		echo "  cross-repo-person-stats <path1> [path2 ...] [--period month] [--format markdown|json] [--logins a,b]"

--- a/.agents/scripts/contributor-activity-helper.sh
+++ b/.agents/scripts/contributor-activity-helper.sh
@@ -623,13 +623,10 @@ _session_time_all_periods() {
 	local format="$2"
 	local db_path="$3"
 
-	# Detect --all-dirs passthrough: when repo_path is literally "--all-dirs",
-	# pass the flag through to session_time instead of a repo path.
-	local all_dirs_flag=""
-	if [[ "$repo_path" == "--all-dirs" ]]; then
-		all_dirs_flag="--all-dirs"
-		repo_path=""
-	fi
+	# Build base args before the loop. repo_path may be "--all-dirs" (flag),
+	# a real path, or empty. session_time() handles all three cases.
+	local -a base_args=("$repo_path")
+	[[ -n "$db_path" ]] && base_args+=(--db-path "$db_path")
 
 	local all_periods=("day" "week" "month" "quarter" "year")
 	local combined_json="["
@@ -637,17 +634,7 @@ _session_time_all_periods() {
 	local p
 	for p in "${all_periods[@]}"; do
 		local p_json
-		local -a session_args=()
-		if [[ -n "$all_dirs_flag" ]]; then
-			session_args+=("--all-dirs")
-		elif [[ -n "$repo_path" ]]; then
-			session_args+=("$repo_path")
-		fi
-		session_args+=(--period "$p" --format json)
-		if [[ -n "$db_path" ]]; then
-			session_args+=(--db-path "$db_path")
-		fi
-		p_json=$(session_time "${session_args[@]}") || p_json="{}"
+		p_json=$(session_time "${base_args[@]}" --period "$p" --format json) || p_json="{}"
 		if [[ "$first_period" == "true" ]]; then
 			first_period=false
 		else
@@ -703,21 +690,19 @@ _session_time_query_db() {
 	local since_ms="$3"
 
 	# Build directory filter clause.
-	# When abs_repo_path is empty (--all-dirs), skip directory filtering
+	# When abs_repo_path is empty (--all-dirs), dir_clause stays empty
 	# to aggregate sessions across all repos (profile-level stats).
+	# Uses parameter expansion to avoid an if/fi block (nesting budget).
 	local dir_clause=""
-	if [[ -n "$abs_repo_path" ]]; then
-		# Escape path for safe SQL embedding:
-		# - Single quotes doubled per SQL standard (prevents injection)
-		# - % and _ escaped for LIKE patterns (prevents wildcard matching)
-		# since_ms is always numeric (computed by Python above), no injection risk.
-		local safe_path="${abs_repo_path//\'/\'\'}"
-		local like_path="${safe_path//%/\\%}"
-		like_path="${like_path//_/\\_}"
-		dir_clause="AND (s.directory = '${safe_path}'
-			       OR s.directory LIKE '${like_path}.%' ESCAPE '\\'
-			       OR s.directory LIKE '${like_path}-%' ESCAPE '\\')"
-	fi
+	local safe_path="${abs_repo_path//\'/\'\'}"
+	local like_path="${safe_path//%/\\%}"
+	like_path="${like_path//_/\\_}"
+	# Only set dir_clause when a path was provided; empty abs_repo_path
+	# produces empty safe_path, so the :+ expansion yields nothing.
+	# shellcheck disable=SC2016,SC1003 # Single quotes are SQL delimiters, not bash
+	dir_clause="${safe_path:+AND (s.directory = '${safe_path}'
+			       OR s.directory LIKE '${like_path}.%' ESCAPE '\\\\'
+			       OR s.directory LIKE '${like_path}-%' ESCAPE '\\\\')}"
 
 	# Query per-session human vs machine time using window functions.
 	# LAG() compares each message with the previous one in the same session:
@@ -1008,11 +993,11 @@ session_time() {
 
 	# Handle --period all: collect JSON for each period and output combined table
 	if [[ "$period" == "all" ]]; then
-		local -a all_args=("$repo_path" "$format" "$db_path")
-		if [[ "$all_dirs" == "true" ]]; then
-			all_args=("--all-dirs" "$format" "$db_path")
-		fi
-		_session_time_all_periods "${all_args[@]}"
+		# Pass "--all-dirs" as repo_path when aggregating all directories;
+		# _session_time_all_periods passes it through to session_time().
+		local all_repo_arg="$repo_path"
+		[[ "$all_dirs" == "true" ]] && all_repo_arg="--all-dirs"
+		_session_time_all_periods "$all_repo_arg" "$format" "$db_path"
 		return 0
 	fi
 

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -169,9 +169,11 @@ _get_screen_time() {
 _get_session_time() {
 	local period="$1"
 	local session_json
-	# Use a single repo path (aidevops) as the DB is global, not per-repo
+	# GH#17550: Use --all-dirs to aggregate sessions across all repos/directories.
+	# The profile README is a user-level summary — not per-repo.
+	# The DB is global; filtering by a single repo path missed 99%+ of sessions.
 	session_json=$("${SCRIPT_DIR}/contributor-activity-helper.sh" session-time \
-		"${HOME}/Git/aidevops" --period "$period" --format json 2>/dev/null) || session_json="{}"
+		--all-dirs --period "$period" --format json 2>/dev/null) || session_json="{}"
 	echo "$session_json"
 	return 0
 }


### PR DESCRIPTION
## Summary

`profile-readme-helper.sh` `_get_session_time()` hardcoded `~/Git/aidevops` as the directory filter for session-time queries. For users whose work spans multiple repos, this missed 99%+ of sessions, showing 0.0h in the profile README despite active usage.

## Changes

- **`contributor-activity-helper.sh`**: Added `--all-dirs` flag to `session_time()` that passes an empty path to `_session_time_query_db()`, which now conditionally skips the directory WHERE clause when the path is empty. Updated `_session_time_all_periods()` to pass `--all-dirs` through to recursive calls. Updated help text and docstrings.
- **`profile-readme-helper.sh`**: Changed `_get_session_time()` to use `--all-dirs` instead of the hardcoded `${HOME}/Git/aidevops` path, aggregating sessions across all directories for the user-level profile summary.

## Design Decision

Option 1 from the issue was chosen: add a flag that skips the directory filter, rather than iterating repos.json. This is cleaner because:
- The session DB is global, not per-repo
- Iterating repos.json would still miss `$HOME` and `/tmp` sessions
- The per-repo directory filter remains correct for health issues (unchanged)

## Runtime Testing

- **Risk**: Low (shell script, no state mutation, query-only change)
- **Verification**: `shellcheck` passes clean on both files
- **Self-assessed**: The `--all-dirs` flag is additive; existing per-repo queries are unchanged

Closes #17550

---
[aidevops.sh](https://aidevops.sh) v3.6.118 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6