### PR TITLE
GH#17549: align stale assignment TTL with dispatch comment TTL

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -418,9 +418,13 @@ _get_repo_maintainer() {
 # the dedup guard permanently blocks all dispatch (0 workers, 100%
 # failure rate observed in production — 370 issues, 159 PRs stuck).
 #
-# The 1-hour threshold is conservative: any legitimate worker would
-# have produced at least one comment or commit within an hour. Workers
-# that crash or exit without cleanup leave the assignment orphaned.
+# The 30-minute threshold matches DISPATCH_COMMENT_MAX_AGE (Layer 5).
+# GH#17549: Previously 1 hour, creating a 30-minute dead zone (30-60 min)
+# where Layer 5 passed (dispatch comment expired) but Layer 6 blocked
+# (assignment still "active"). This forced the LLM to bypass
+# dispatch_with_dedup() to re-dispatch dead workers, skipping all
+# dedup guards including the claim protocol. Any legitimate worker
+# should produce at least one comment or commit within 30 minutes.
 #
 # Args:
 #   $1 = issue number
@@ -430,7 +434,7 @@ _get_repo_maintainer() {
 #   exit 0 = stale assignment recovered (safe to dispatch)
 #   exit 1 = assignment is NOT stale (genuine active claim, block dispatch)
 #######################################
-STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-3600}" # 1 hour
+STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-1800}" # 30 min (GH#17549: aligned with DISPATCH_COMMENT_MAX_AGE to close dead zone)
 
 _is_stale_assignment() {
 	local issue_number="$1"


### PR DESCRIPTION
## Summary

- Reduces `STALE_ASSIGNMENT_THRESHOLD_SECONDS` from 3600s (1 hour) to 1800s (30 min) to match `DISPATCH_COMMENT_MAX_AGE`
- Closes a 30-minute dead zone where Layer 5 allowed re-dispatch but Layer 6 blocked it, forcing pulse LLMs to bypass `dispatch_with_dedup()` entirely

## Root Cause Analysis

GH#17549 worker (PID 12644, claude-sonnet-4-6) crashed after 21.4 seconds while attempting to create a worktree. The DISPATCH_CLAIM and dispatch comment held the issue locked for 30 minutes with no worker running.

At 41 minutes, alex-solovyev's pulse detected the expired dispatch comment (Layer 5 passed) but `dispatch_with_dedup()` would have blocked at Layer 6 because the assignment threshold was still 1 hour. The LLM worked around this by bypassing the function — no DISPATCH_CLAIM was posted, and the dispatch comment was LLM-composed instead of deterministic.

## The Fix

Align both TTLs at 1800s. Once matched, `dispatch_with_dedup()` passes both layers consistently and the LLM has no reason to bypass it.

## Verification

- `bash -n .agents/scripts/dispatch-dedup-helper.sh` — syntax OK
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh` — zero violations
- The threshold is env-overridable (`STALE_ASSIGNMENT_THRESHOLD_SECONDS`) for any runner needing different behaviour

Closes #17549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved stale assignment recovery timing by reducing the detection threshold from 1 hour to 30 minutes, enabling faster system recovery from stale assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->