### PR TITLE
GH#17549: integrate opencode-db-archive into pulse pre-flight

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8990,6 +8990,14 @@ _run_preflight_stages() {
 	run_stage_with_timeout "cleanup_worktrees" "$PRE_RUN_STAGE_TIMEOUT" cleanup_worktrees || true
 	run_stage_with_timeout "cleanup_stashes" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stashes || true
 
+	# GH#17549: Archive old OpenCode sessions to keep the active DB small.
+	# Concurrent workers hit SQLITE_BUSY on a bloated DB (busy_timeout=0).
+	# Runs daily with a 30s budget — catches up over multiple pulse cycles.
+	local _archive_helper="${SCRIPT_DIR}/opencode-db-archive.sh"
+	if [[ -x "$_archive_helper" ]]; then
+		"$_archive_helper" archive --max-duration-seconds 30 >>"$LOGFILE" 2>&1 || true
+	fi
+
 	# t1751: Reap zombie workers whose PRs have been merged by the deterministic merge pass.
 	# Runs before worker counting so count_active_workers sees accurate slot availability.
 	run_stage_with_timeout "reap_zombie_workers" "$PRE_RUN_STAGE_TIMEOUT" reap_zombie_workers || true


### PR DESCRIPTION
## Summary

- Adds `opencode-db-archive.sh archive --max-duration-seconds 30` to the pulse pre-flight cleanup stages
- Runs after orphan/stale/stash cleanup, before worker counting
- 30s time budget ensures it doesn't block the pulse cycle — catches up over multiple runs

## Context

PR #17582 added the archive script but didn't integrate it into the automated pulse cycle. Without this, the DB would re-bloat as new sessions accumulate.

Closes #17549