### PR TITLE
GH#17584: git pull before worker launch to prevent stale-checkout closures

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6599,6 +6599,16 @@ dispatch_with_dedup() {
 	# t1894: Lock external contributor issues during worker execution
 	lock_issue_for_worker "$issue_number" "$repo_slug"
 
+	# GH#17584: Ensure the repo is on the latest remote commit before
+	# launching the worker. Without this, workers on stale checkouts
+	# close issues as "Invalid — file does not exist" when the target
+	# file was added in a recent commit they haven't pulled.
+	if git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		git -C "$repo_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 || {
+			echo "[dispatch_with_dedup] Warning: git pull failed for ${repo_path} — proceeding with current checkout" >>"$LOGFILE"
+		}
+	fi
+
 	# Launch worker — headless-runtime-helper.sh handles model selection
 	# via round-robin when no --model is specified. Its choose_model() reads
 	# AIDEVOPS_HEADLESS_MODELS, checks backoff/auth, and rotates providers.


### PR DESCRIPTION
## Summary

- Adds `git pull --ff-only` in `dispatch_with_dedup()` before launching the worker
- Prevents workers from operating on stale checkouts that are missing recently-added files

## Root Cause

alex-solovyev's worker closed #17584 as "Invalid — target file does not exist" because `opencode-db-archive.sh` hadn't been pulled to their clone yet — the file was merged minutes earlier in #17582.

## Fix

`git -C "$repo_path" pull --ff-only --no-rebase` runs after the claim/dedup checks pass but before the worker launches. Uses `--ff-only` to avoid merge commits on the canonical main branch. Failure is non-fatal — logs a warning and proceeds.

## Verification

- `bash -n .agents/scripts/pulse-wrapper.sh` — syntax OK
- Only one issue (#17584) was affected today — searched all comments from today for "does not exist" / "never existed" patterns

Closes #17584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic repository synchronization step before worker execution to advance local checkout to the latest remote state, with graceful error handling for synchronization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->