### PR TITLE
GH#17584: tighten Closes keyword rule to prevent accidental issue auto-close

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -195,7 +195,10 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 
 **Traceability (MANDATORY):**
 - PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
-- PR body MUST include `Closes #NNN` — only mechanism creating GitHub PR-issue link.
+- PR body MUST include exactly ONE `Closes #NNN` for the issue the PR **directly solves**.
+  GitHub auto-closes issues when PRs with `Closes/Fixes/Resolves #NNN` merge.
+  NEVER use `Closes` for context references — use `Related: #NNN` or `See #NNN` instead.
+  Evidence: GH#17584 was auto-closed twice by PRs that referenced it for context, not as the target.
 - Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref:GH#NNN`.
 
 # 9. Worker-Ready Implementation Context (t1900 — MANDATORY)


### PR DESCRIPTION
## Summary

- Changes the traceability rule in `build.txt` from "PR body MUST include `Closes #NNN`" to "exactly ONE `Closes #NNN` for the issue the PR directly solves"
- Adds explicit guidance: context references use `Related: #NNN` or `See #NNN`, NEVER `Closes`

## Root Cause

Line 198 of `build.txt` told every agent to always include `Closes #NNN`. When a PR mentioned an issue for context (e.g., PR #17587 explaining *why* the git-pull fix was needed referenced #17584), `Closes #17584` auto-closed the simplification issue on merge — even though the PR didn't do the simplification work.

#17584 was auto-closed twice:
1. By alex-solovyev's worker (stale checkout, closed as "Invalid")
2. By PR #17587 (git-pull fix that referenced #17584 for context with `Closes`)

## What changed

```diff
- PR body MUST include `Closes #NNN` — only mechanism creating GitHub PR-issue link.
+ PR body MUST include exactly ONE `Closes #NNN` for the issue the PR **directly solves**.
+   GitHub auto-closes issues when PRs with `Closes/Fixes/Resolves #NNN` merge.
+   NEVER use `Closes` for context references — use `Related: #NNN` or `See #NNN` instead.
```

Related: #17584