### PR TITLE
GH#17549: nohup worker launch to survive pulse-wrapper exit

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6621,7 +6621,12 @@ dispatch_with_dedup() {
 	if [[ -n "$selected_model" ]]; then
 		worker_cmd+=(--model "$selected_model")
 	fi
-	"${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 &
+	# GH#17549: Detach worker from the pulse-wrapper's SIGHUP.
+	# launchd runs pulse-wrapper with StartInterval=120s. When the wrapper
+	# exits after its dispatch cycle, bash sends SIGHUP to background jobs.
+	# nohup makes the worker immune to SIGHUP so it survives the parent's
+	# exit. The EXIT trap only releases the instance lock (no child killing).
+	nohup "${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 &
 	local worker_pid="$!"
 
 	# GH#17549: Stagger delay between worker launches to reduce SQLite


### PR DESCRIPTION
## Summary

- Wraps worker launch with `nohup` so workers survive the pulse-wrapper's exit
- One-line change: `"${worker_cmd[@]}"` → `nohup "${worker_cmd[@]}"`

## Root Cause

launchd runs pulse-wrapper with `StartInterval=120` and `KeepAlive=false`. Each cycle completes its dispatch/merge work and exits. When bash exits, it sends SIGHUP to all background jobs — including workers launched via `&`. Every worker dispatched today died at the exact same moment (when the pulse-wrapper exited), not at random times.

The earlier SQLITE_BUSY analysis (DB archival + stagger) addressed a real contention issue but was not the primary kill signal. Evidence: all workers in a batch died simultaneously at pulse-wrapper exit time, not at random points from DB lock contention.

## Why nohup

- `nohup` ignores SIGHUP — the signal bash sends on exit
- `$!` still captures the worker PID (unlike subshell + disown)
- The EXIT trap only calls `release_instance_lock` (removes lock dir) — no child process killing
- macOS lacks `setsid`; `nohup` is the portable equivalent for SIGHUP immunity

## Verification

- `bash -n .agents/scripts/pulse-wrapper.sh` — syntax OK
- PID tracking unchanged (`$!` works with nohup)
- Stagger delay and dispatch comment still work (they run after the launch line)

## Runtime Testing

- **Risk**: High (polling loop / process lifecycle)
- **Plan**: Deploy, wait for next pulse cycle, verify workers survive the wrapper exit
- **Status**: `pending-verification` (will verify post-merge)

Related: #17549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background worker process handling to prevent premature termination from session signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->