### PR TITLE
GH#17590: pre-check for active claims before posting own claim

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1100,6 +1100,18 @@ main() {
 		fi
 		"$CLAIM_HELPER" claim "$1" "$2" "${3:-}"
 		;;
+	check-claim)
+		# GH#17590: Pre-check for active claims (read-only, no comment posted).
+		[[ $# -lt 2 ]] && {
+			echo "Error: check-claim requires <issue-number> <repo-slug>" >&2
+			return 1
+		}
+		if [[ ! -x "$CLAIM_HELPER" ]]; then
+			echo "Error: dispatch-claim-helper.sh not found at ${CLAIM_HELPER}" >&2
+			return 2
+		fi
+		"$CLAIM_HELPER" check "$1" "$2"
+		;;
 	list-running-keys)
 		list_running_keys
 		;;

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6396,6 +6396,20 @@ check_dispatch_dedup() {
 	# dynamic scoping — do NOT declare local here or the value is lost on return.
 	_claim_comment_id=""
 	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+		# GH#17590: Pre-check for existing claims BEFORE posting our own.
+		# Without this, two runners both post claims within seconds, then
+		# the consensus window resolves the race — but the losing claim
+		# comment is left on the issue, wasting a GitHub API call and
+		# cluttering the issue. The pre-check is cheap (read-only) and
+		# catches the common case where another runner already claimed.
+		local _precheck_output="" _precheck_exit=0
+		_precheck_output=$("$dedup_helper" check-claim "$issue_number" "$repo_slug" 2>>"$LOGFILE") || _precheck_exit=$?
+		if [[ "$_precheck_exit" -eq 0 ]]; then
+			# Active claim exists from another runner — skip claim entirely
+			echo "[pulse-wrapper] Dedup: pre-check found active claim on #${issue_number} in ${repo_slug} — skipping (${_precheck_output})" >>"$LOGFILE"
+			return 0
+		fi
+		# No active claim found (exit 1) or error (exit 2, fail-open) — proceed to claim
 		local claim_exit=0 claim_output=""
 		claim_output=$("$dedup_helper" claim "$issue_number" "$repo_slug" "$self_login" 2>>"$LOGFILE") || claim_exit=$?
 		echo "$claim_output" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

- Adds a read-only `check-claim` pre-check before Layer 7 posts a `DISPATCH_CLAIM`
- If another runner already has an active claim, backs off without posting — no comment clutter, no wasted API call

## Root Cause

On #17590, alex-solovyev claimed at 17:56:09 and marcusquinn at 17:56:12 (3s later). Both passed the dedup layers and went straight to posting claims. The consensus window resolved it correctly (alex won), but marcusquinn's losing claim comment was left on the issue — indistinguishable from the winning one.

## Fix

1. `pulse-wrapper.sh`: Before calling `claim`, calls `check-claim` (read-only). If an active claim exists → back off immediately, no comment posted.
2. `dispatch-dedup-helper.sh`: New `check-claim` subcommand delegating to `dispatch-claim-helper.sh check`.

The consensus window still handles the rare case where two runners both pass the pre-check within the same second.

## Verification

- `bash -n` passes for both files

Related: #17590