### PR TITLE
GH#17549: pin opencode-ai to 1.3.15 to prevent auto-upgrade to broken 1.3.17

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -17,6 +17,17 @@
 _SHARED_CONSTANTS_LOADED=1
 
 # =============================================================================
+# Tool Version Pins
+# =============================================================================
+# Pin a tool to a specific version to prevent auto-upgrade to a broken release.
+# Set to "latest" to resume tracking upstream. Grep for the variable name to
+# find all consumers that need updating when unpinning.
+
+# OpenCode pinned to 1.3.15: v1.3.17 hangs on API calls in headless mode.
+# Upstream: https://github.com/anomalyco/opencode/issues/21215
+readonly OPENCODE_PINNED_VERSION="1.3.15"
+
+# =============================================================================
 # HTTP and API Constants
 # =============================================================================
 

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -66,13 +66,16 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
+# OPENCODE_PINNED_VERSION is set in shared-constants.sh (sourced above).
+# To unpin: change to "latest" in shared-constants.sh when the upstream fix ships.
+
 # Detect how OpenCode was installed — build the right upgrade command.
 # update_cmd is executed via `bash -c` so it must be a self-contained string.
 # Use `command -v` path directly: bun-installed binaries live under ~/.bun/bin/,
 # so the path itself contains "bun". This avoids `readlink -f` which is a GNU
 # extension not available on macOS by default.
 # shellcheck disable=SC2016  # Single quotes intentional: string is a bash -c payload, must not expand at assignment time
-_oc_upgrade_cmd='if r=$(command -v opencode 2>/dev/null); [[ "$r" == *bun* ]]; then bun install -g opencode-ai@latest; else npm install -g opencode-ai@latest; fi'
+_oc_upgrade_cmd='if r=$(command -v opencode 2>/dev/null); [[ "$r" == *bun* ]]; then bun install -g opencode-ai@'"${OPENCODE_PINNED_VERSION}"'; else npm install -g opencode-ai@'"${OPENCODE_PINNED_VERSION}"'; fi'
 
 # Platform-aware brew package upgrade command.
 # On macOS (or any system with brew), use brew upgrade.

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -277,8 +277,9 @@ cleanup_stale_bun_opencode() {
 	if [[ "$npm_opencode" -eq 0 ]]; then
 		# npm version not installed — install it first, then clean up bun
 		if command -v npm >/dev/null 2>&1; then
+			local pin_ver="${OPENCODE_PINNED_VERSION:-latest}"
 			print_info "Installing opencode via npm (replacing bun install)..."
-			npm_global_install "opencode-ai" >/dev/null 2>&1 || true
+			npm_global_install "opencode-ai@${pin_ver}" >/dev/null 2>&1 || true
 		else
 			# Can't install npm version — leave bun version in place
 			return 0

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1489,7 +1489,10 @@ setup_opencode_cli() {
 
 	# Need either bun or npm to install
 	local installer=""
-	local install_pkg="opencode-ai@latest"
+	# Respect OPENCODE_PINNED_VERSION from shared-constants.sh if sourced,
+	# otherwise fall back to latest.
+	local pin_ver="${OPENCODE_PINNED_VERSION:-latest}"
+	local install_pkg="opencode-ai@${pin_ver}"
 
 	if command -v bun >/dev/null 2>&1; then
 		installer="bun"


### PR DESCRIPTION
## Summary

- Pins `opencode-ai` to version 1.3.15 across all installation paths to prevent the auto-update helper from upgrading to 1.3.17, which hangs on API calls in headless mode and kills all workers
- `OPENCODE_PINNED_VERSION` defined once in `shared-constants.sh`, consumed by `tool-version-check.sh` (6-hourly auto-update), `tool-install.sh` (fresh installs), and `migrations.sh` (bun-to-npm migration)
- To unpin when upstream fix ships: change to `"latest"` in `shared-constants.sh`

## Files changed

- `EDIT: .agents/scripts/shared-constants.sh` — new `OPENCODE_PINNED_VERSION` constant
- `EDIT: .agents/scripts/tool-version-check.sh` — use constant instead of `@latest` in upgrade command
- `EDIT: setup-modules/tool-install.sh` — respect pin for fresh installs
- `EDIT: setup-modules/migrations.sh` — respect pin for bun-to-npm migration

## Context

The auto-update helper runs `tool-version-check.sh --update --quiet` every 6 hours. This was reinstalling `opencode-ai@latest` (1.3.17) even after manual downgrade to 1.3.15.

Related: #17549, anomalyco/opencode#21215

## Verification

```bash
# Confirm version string expands correctly in upgrade command
source .agents/scripts/shared-constants.sh && echo "$OPENCODE_PINNED_VERSION"
# Should output: 1.3.15

# Confirm shellcheck passes
shellcheck .agents/scripts/tool-version-check.sh
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* OpenCode CLI is now pinned to version 1.3.15 during installation and upgrades to prevent an upstream compatibility issue. This ensures consistent tool behavior and stability across all setup workflows and package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->