### PR TITLE
GH#17605: use github.paginate for full comment dedup in nmr-hold-comment

### DIFF
--- a/.github/workflows/nmr-hold-comment.yml
+++ b/.github/workflows/nmr-hold-comment.yml
@@ -49,15 +49,16 @@ jobs:
             // Dedup: check for existing comments with the approve command.
             // Covers prior posts from issue-triage-gate, maintainer-gate
             // label protection, or a previous run of this workflow.
-            const comments = await github.rest.issues.listComments({
+            // Use paginate to fetch ALL comments — listComments caps at 100
+            // and would miss older comments on high-traffic issues.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: issueNumber,
-              per_page: 100
+              issue_number: issueNumber
             });
 
             const approvePattern = `sudo aidevops approve issue ${issueNumber}`;
-            const hasApproveComment = comments.data.some(c =>
+            const hasApproveComment = comments.some(c =>
               c.body.includes(approvePattern) ||
               c.body.includes('<!-- nmr-hold-guidance -->')
             );


### PR DESCRIPTION
## Summary

- Replace `github.rest.issues.listComments` (capped at 100 items) with `github.paginate` in `.github/workflows/nmr-hold-comment.yml` so all comments are fetched before the dedup check
- Update `comments.data.some()` → `comments.some()` since `github.paginate` returns a flat array, not a `{ data: [] }` wrapper
- Adds an explanatory comment noting why paginate is used

## Changes

- EDIT: `.github/workflows/nmr-hold-comment.yml` lines 52-63 — pagination fix

## Verification

The dedup check now correctly handles issues with >100 comments, preventing duplicate NMR hold guidance comments on high-traffic issues.

Closes #17605


---
[aidevops.sh](https://aidevops.sh) v3.6.121 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6