### PR TITLE
GH#17602: use DISPATCH_COMMENT_MAX_AGE as default for STALE_ASSIGNMENT_THRESHOLD_SECONDS

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -434,7 +434,7 @@ _get_repo_maintainer() {
 #   exit 0 = stale assignment recovered (safe to dispatch)
 #   exit 1 = assignment is NOT stale (genuine active claim, block dispatch)
 #######################################
-STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-1800}" # 30 min (GH#17549: aligned with DISPATCH_COMMENT_MAX_AGE to close dead zone)
+STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-1800}}" # 30 min (GH#17549: aligned with DISPATCH_COMMENT_MAX_AGE to close dead zone)
 
 _is_stale_assignment() {
 	local issue_number="$1"


### PR DESCRIPTION
## Summary

- Fixes configuration drift risk in `dispatch-dedup-helper.sh` where overriding `DISPATCH_COMMENT_MAX_AGE` via env would not propagate to `STALE_ASSIGNMENT_THRESHOLD_SECONDS`
- Uses nested parameter expansion `${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-1800}}` so the stale threshold inherits from the comment TTL when not explicitly set
- Prevents the dead zone from reappearing due to configuration drift (originally fixed in GH#17549)

## Change

```diff
-STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-1800}"
+STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-1800}}"
```

## Verification

- shellcheck passes with zero violations
- Nested default expansion: if `STALE_ASSIGNMENT_THRESHOLD_SECONDS` is unset, falls back to `DISPATCH_COMMENT_MAX_AGE`; if that is also unset, falls back to 1800

Closes #17602

---

---
[aidevops.sh](https://aidevops.sh) v3.6.121 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6