### PR TITLE
GH#17601: fail fast when domain command generation fails

### DIFF
--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -788,13 +788,13 @@ Review the current session for: $ARGUMENTS
 generate_hardcoded_commands() {
 	echo -e "${BLUE}Phase 2: Generating additional commands for Claude Code parity...${NC}"
 
-	_generate_workflow_commands
-	_generate_quality_commands
-	_generate_branch_commands
-	_generate_utility_commands
-	_generate_planning_commands
-	_generate_seo_commands
-	_generate_system_commands
+	_generate_workflow_commands || return 1
+	_generate_quality_commands || return 1
+	_generate_branch_commands || return 1
+	_generate_utility_commands || return 1
+	_generate_planning_commands || return 1
+	_generate_seo_commands || return 1
+	_generate_system_commands || return 1
 
 	return 0
 }


### PR DESCRIPTION
## Summary
- Make `generate_hardcoded_commands` stop immediately when any domain-specific generator fails.
- Propagate non-zero exit codes with explicit `|| return 1` checks for each helper call to avoid masked orchestration failures.

## Verification
- `shellcheck -x .agents/scripts/generate-claude-commands.sh` (existing SC1091 informational warning unchanged)
- `bash .agents/scripts/generate-claude-commands.sh --dry-run`

## Runtime Testing
- self-assessed (low-risk shell orchestration change)

Closes #17601

---
[aidevops.sh](https://aidevops.sh) v3.6.121 plugin for [OpenCode](https://opencode.ai) v1.3.15 with gpt-5.3-codex