### PR TITLE
GH#17596: tighten completion detection in JSON parsing block

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1532,16 +1532,31 @@ for line in raw.splitlines():
         obj = json.loads(line)
     except (json.JSONDecodeError, ValueError):
         continue
-    # OpenCode text events contain the model's own output
-    if obj.get("type") == "text":
+    # OpenCode text events contain the model's own output.
+    # GH#17596 (MEDIUM): consolidate extraction into a single pass checking
+    # multiple common paths for text and tool input fields.
+    event_type = obj.get("type", "")
+    if event_type == "text":
         part = obj.get("part", {})
-        model_text_parts.append(part.get("text", ""))
+        text = (
+            obj.get("text")
+            or part.get("text")
+            or ""
+        )
+        if text:
+            model_text_parts.append(text)
     # Also check tool calls where the MODEL invoked gh pr create/merge
     # (the input field shows what the model requested, not file contents)
-    elif obj.get("type") == "tool_use":
+    elif event_type == "tool_use":
         part = obj.get("part", {})
         state = part.get("state", {})
-        inp = state.get("input", {})
+        # GH#17596 (MEDIUM): check multiple common input paths
+        inp = (
+            obj.get("input")
+            or part.get("input")
+            or state.get("input")
+            or {}
+        )
         if isinstance(inp, dict):
             cmd = inp.get("command", "")
             if cmd:
@@ -1554,11 +1569,15 @@ if model_text.strip():
     for marker in ("FULL_LOOP_COMPLETE", "BLOCKED", "TASK_COMPLETE"):
         if marker in model_text:
             sys.exit(0)
-    if "gh pr create" in model_text:
+    # GH#17596 (HIGH): verify both model intent AND actual success signal in raw.
+    # Checking model_text alone may match commands the model merely mentioned
+    # or invoked but that failed. Requiring a success signal in raw (same as
+    # the fallback block) prevents false-positive completion classification.
+    if "gh pr create" in model_text and ("pull/" in raw or "created pull request" in raw.lower()):
         sys.exit(0)
-    if "gh pr merge" in model_text:
+    if "gh pr merge" in model_text and "merged" in raw.lower():
         sys.exit(0)
-    if "git push" in model_text:
+    if "git push" in model_text and ("-> " in raw or "branch " in raw):
         sys.exit(0)
     sys.exit(1)
 


### PR DESCRIPTION
## Summary

Addresses two review findings from PR #17595 on `.agents/scripts/headless-runtime-helper.sh`.

### HIGH (line 1562): False-positive completion detection

The JSON-path block previously exited 0 if `model_text` contained `gh pr create`, `gh pr merge`, or `git push` — regardless of whether those commands succeeded. This could match commands the model merely mentioned in its reasoning or invoked but that failed.

**Fix**: Mirror the fallback block's logic — require both model intent in `model_text` AND a success signal in `raw`:
- `gh pr create`: requires `pull/` or `created pull request` in raw
- `gh pr merge`: requires `merged` in raw (case-insensitive)
- `git push`: requires `-> ` or `branch ` in raw

### MEDIUM (line 1548): Single-pass field extraction

The extraction for `text` events only checked `part.text`. The extraction for `tool_use` events only checked `part.state.input.command`. OpenCode JSON events can have fields at multiple levels.

**Fix**: Check multiple common paths in a single pass:
- Text: `obj.text` → `part.text` (with short-circuit)
- Tool input: `obj.input` → `part.input` → `state.input` (with short-circuit)

## Verification

The fallback block (non-JSON path) is unchanged and continues to work as before. The JSON-path block now has equivalent strictness to the fallback block for command-success checks.

Closes #17596

---
[aidevops.sh](https://aidevops.sh) v3.6.121 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy for git and GitHub command completions with stricter validation requirements, reducing false positive detections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->