### PR TITLE
GH#17559: fix safety-policy-check for extracted Python settings file

### DIFF
--- a/.agents/scripts/safety-policy-check.sh
+++ b/.agents/scripts/safety-policy-check.sh
@@ -69,13 +69,23 @@ require_pattern() {
 }
 
 check_generator_rules() {
+	# The deny/allow rules live in the Python settings updater.
+	# Check the extracted file first (GH#17559), fall back to the
+	# legacy inline heredoc in generate-claude-agents.sh.
+	local settings_py="${SCRIPT_DIR}/update-claude-settings.py"
 	local generator_file="${SCRIPT_DIR}/generate-claude-agents.sh"
-	if [[ ! -f "$generator_file" ]]; then
-		echo "FAIL: generator file missing: $generator_file" >&2
+	local target_file=""
+
+	if [[ -f "$settings_py" ]]; then
+		target_file="$settings_py"
+	elif [[ -f "$generator_file" ]]; then
+		target_file="$generator_file"
+	else
+		echo "FAIL: neither update-claude-settings.py nor generate-claude-agents.sh found" >&2
 		return 1
 	fi
 
-	python3 - "$generator_file" <<'PY'
+	python3 - "$target_file" <<'PY'
 import re
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary

Follow-up to PR #17620 (merged). The safety-policy-check.sh CI step reads `generate-claude-agents.sh` to verify deny/allow rules exist. After extracting the Python settings logic to `update-claude-settings.py`, the check needs to look in the new file location.

- Updates `check_generator_rules()` to check `update-claude-settings.py` first, falling back to `generate-claude-agents.sh` for backward compatibility
- Fixes the Framework Validation CI failure introduced by #17620

Closes #17559

## Runtime Testing

- **Risk**: Low (CI config)
- **Verification**: `self-assessed`
- ShellCheck: zero violations

## Files Changed

- `EDIT: .agents/scripts/safety-policy-check.sh:71-84` — update file path lookup in check_generator_rules()


---
[aidevops.sh](https://aidevops.sh) v3.6.121 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6