### PR TITLE
GH#17594: broaden signature gate regex to match all footer variable patterns

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -790,9 +790,11 @@ async function toolExecuteBefore(input, output) {
       // Direct footer text or helper invocation in the command
       const hasDirectFooter =
         cmd.includes("aidevops.sh") || cmd.includes("gh-signature-helper");
-      // Footer stored in a shell variable from a prior command (unexpanded at hook time)
+      // Footer stored in a shell variable from a prior command (unexpanded at hook time).
+      // Match any variable containing "footer" or "signature" as a substring to cover
+      // all naming conventions: sig_footer, SIG_FOOTER, _merge_sig_footer, sig_footer2, etc.
       const hasFooterVar =
-        /\$\{?(?:SIG_FOOTER|FOOTER|footer|sig_footer|SIGNATURE|signature)\}?/.test(cmd);
+        /\$\{?\w*(?:footer|FOOTER|signature|SIGNATURE)\w*\}?/i.test(cmd);
 
       if (!isMachineProtocol && !hasDirectFooter && !hasFooterVar) {
         console.error(


### PR DESCRIPTION
## Summary

- Replaces the explicit variable name enumeration in the signature gate regex with substring matching — any shell variable containing `footer` or `signature` (case-insensitive) now passes the gate
- Fixes false positives for variables like `_merge_sig_footer` that use prefixed naming conventions

### Before (explicit list, misses prefixed variants)
```javascript
/\$\{?(?:SIG_FOOTER|FOOTER|footer|sig_footer|SIGNATURE|signature)\}?/
```

### After (substring match, covers all conventions)
```javascript
/\$\{?\w*(?:footer|FOOTER|signature|SIGNATURE)\w*\}?/i
```

### Verified against all known patterns
```
$sig_footer, ${sig_footer}, $SIG_FOOTER, ${SIG_FOOTER},
$_merge_sig_footer, ${_merge_sig_footer}, $sig_footer2,
$footer, $FOOTER, $signature, $SIGNATURE, $closing_footer
— all pass. Plain text without variable reference correctly fails.
```

Closes #17594

---
[aidevops.sh](https://aidevops.sh) v3.6.121 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-opus-4-6 spent 36m and 33,137 tokens on this as a headless worker. Overall, 1h 11m since this issue was created.