### PR TITLE
GH#17607: fix full-loop-helper.sh review feedback from PR #17547

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -402,7 +402,7 @@ cmd_pre_merge_gate() {
 	rbg_result=$(bash "$rbg_helper" wait "$pr_number" "$repo" 2>&1) || true
 
 	local rbg_status=""
-	rbg_status=$(printf '%s' "$rbg_result" | grep -oE '^(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | head -1)
+	rbg_status=$(printf '%s' "$rbg_result" | grep -oE '(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | tail -1)
 
 	case "$rbg_status" in
 	PASS | SKIP | PASS_RATE_LIMITED)
@@ -425,22 +425,31 @@ cmd_pre_merge_gate() {
 # Exit codes: 0 = merged, 1 = gate failed or merge failed
 cmd_merge() {
 	local pr_number="${1:-}"
-	local repo="${2:-}"
+	local repo=""
 	local merge_method="--squash"
 
 	if [[ -z "$pr_number" ]]; then
 		print_error "Usage: full-loop-helper.sh merge <PR_NUMBER> [REPO] [--squash|--merge|--rebase]"
 		return 1
 	fi
+	shift
 
-	# Parse optional repo and merge method
-	if [[ "${repo:-}" == --* ]]; then
-		merge_method="$repo"
-		repo=""
-	fi
-	if [[ -n "${3:-}" && "${3:-}" == --* ]]; then
-		merge_method="$3"
-	fi
+	# Parse optional repo and merge method from remaining arguments
+	for arg in "$@"; do
+		case "$arg" in
+		--squash | --merge | --rebase)
+			merge_method="$arg"
+			;;
+		*)
+			if [[ -z "$repo" ]]; then
+				repo="$arg"
+			else
+				print_error "Unknown argument: $arg"
+				return 1
+			fi
+			;;
+		esac
+	done
 
 	# Auto-detect repo from git remote if not provided
 	if [[ -z "$repo" ]]; then


### PR DESCRIPTION
## Summary

Addresses 2 medium-severity review findings from Gemini on PR #17547 in `.agents/scripts/full-loop-helper.sh`.

### Finding 1 — Line 405: Fragile grep status extraction

**Before:**
```shell
rbg_status=$(printf '%s' "$rbg_result" | grep -oE '^(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | head -1)
```

**After:**
```shell
rbg_status=$(printf '%s' "$rbg_result" | grep -oE '(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | tail -1)
```

- Removed `^` anchor so the status keyword is matched anywhere on the line (not just line-start), making it resilient to format changes.
- Changed `head -1` to `tail -1` per repository guidelines for extracting metadata fields.

### Finding 2 — Line 443: Fragile argument parsing in `cmd_merge`

Replaced positional `$2`/`$3` parsing with a `for arg in "$@"` loop using a `case` statement. The new logic:
- Uses `shift` after consuming `$1` (PR number), then iterates remaining args.
- Distinguishes `--squash|--merge|--rebase` flags from the optional repo argument.
- Emits a clear error on unknown arguments.
- Eliminates the brittle `if [[ "${repo:-}" == --* ]]` workaround.

Closes #17607

---
[aidevops.sh](https://aidevops.sh) v3.6.129 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal merge workflow script with refined argument handling and gate result evaluation logic for merge automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->