### PR TITLE
GH#17597: remove redundant 2>>"$LOGFILE" from check-claim pre-check

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6403,7 +6403,7 @@ check_dispatch_dedup() {
 		# cluttering the issue. The pre-check is cheap (read-only) and
 		# catches the common case where another runner already claimed.
 		local _precheck_output="" _precheck_exit=0
-		_precheck_output=$("$dedup_helper" check-claim "$issue_number" "$repo_slug" 2>>"$LOGFILE") || _precheck_exit=$?
+		_precheck_output=$("$dedup_helper" check-claim "$issue_number" "$repo_slug") || _precheck_exit=$?
 		if [[ "$_precheck_exit" -eq 0 ]]; then
 			# Active claim exists from another runner — skip claim entirely
 			echo "[pulse-wrapper] Dedup: pre-check found active claim on #${issue_number} in ${repo_slug} — skipping (${_precheck_output})" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

- Removes the redundant `2>>"$LOGFILE"` stderr redirect from the `check-claim` pre-check call in `pulse-wrapper.sh`
- `check-claim` is a read-only operation; its stdout is already captured in `_precheck_output` and exit code in `_precheck_exit`
- Logging stderr of a read-only pre-check on every pulse cycle bloats the log unnecessarily
- The `claim` command (non-read-only, line 6414) retains its `2>>"$LOGFILE"` redirect — that one is appropriate

## Change

**EDIT: `.agents/scripts/pulse-wrapper.sh:6406`**

Before:
```bash
_precheck_output=$("$dedup_helper" check-claim "$issue_number" "$repo_slug" 2>>"$LOGFILE") || _precheck_exit=$?
```

After:
```bash
_precheck_output=$("$dedup_helper" check-claim "$issue_number" "$repo_slug") || _precheck_exit=$?
```

## Verification

- `bash -n .agents/scripts/pulse-wrapper.sh` passes (syntax OK)

Closes #17597

---
[aidevops.sh](https://aidevops.sh) v3.6.130 plugin for [OpenCode](https://opencode.ai) v1.3.15 with claude-sonnet-4-6 spent 1m and 2,906 tokens on this as a headless worker.