### PR TITLE
GH#17629: fix url-allowlist-check grep -c double-output corrupts GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/url-allowlist-check.yml
+++ b/.github/workflows/url-allowlist-check.yml
@@ -103,7 +103,7 @@ jobs:
           }
           rm -f "$TMPFILE"
 
-          UNKNOWN_COUNT=$(echo "$UNKNOWN_HOSTS" | grep -c '^[^[:space:]]' || echo "0")
+          UNKNOWN_COUNT=$(echo "$UNKNOWN_HOSTS" | grep -c '^[^[:space:]]' || true)
           echo "unknown_count=${UNKNOWN_COUNT}" >> "$GITHUB_OUTPUT"
 
           if [[ "$UNKNOWN_COUNT" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- Fix `grep -c` + `|| echo "0"` double-output bug in URL Allowlist Check workflow that corrupts `GITHUB_OUTPUT` on every PR with no unknown URLs (the happy path)
- One-character change: `|| echo "0"` → `|| true` on line 106

## Root Cause

When `grep -c` finds no matches, it outputs `0` to stdout AND exits with code 1. The `|| echo "0"` fallback fires inside the command substitution, appending a second `0`. Result: `UNKNOWN_COUNT="0\n0"` — a two-line string instead of an integer.

This breaks:
1. `[[ "$UNKNOWN_COUNT" -eq 0 ]]` — bash can't compare multiline string as integer
2. `echo "unknown_count=${UNKNOWN_COUNT}"` writes a bare `0` line to `$GITHUB_OUTPUT` (invalid format)
3. Status description becomes garbled: `"Maintainer PR: 0\n0 new URL(s)"`

## Evidence

Failed run: https://github.com/marcusquinn/aidevops/actions/runs/24052917718/job/70152584892?pr=17627

## Runtime Testing

- **Risk level**: Low (CI workflow config, no runtime code)
- **Verification**: `self-assessed` — the fix is a well-understood bash pattern; verification will be the next PR that triggers this workflow

Closes #17629


---
[aidevops.sh](https://aidevops.sh) v3.6.132 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 3m and 7,614 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve how empty result scenarios are handled during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->