### PR TITLE
GH#17632: fix nesting-only violations creating false-positive simplification issues

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5532,6 +5532,16 @@ _complexity_scan_create_issues() {
 		[[ -n "$file_path" ]] || continue
 		[[ "$issues_created" -ge "$max_issues_per_run" ]] && break
 
+		# Skip nesting-only violations (GH#17632): files flagged solely for max_nesting
+		# exceeding the threshold have violation_count=0 (no long functions). The current
+		# issue template is function-length-specific; creating a "0 functions >100 lines"
+		# issue is misleading and produces false-positive dispatch work.
+		if [[ "${violation_count:-0}" -eq 0 ]]; then
+			echo "[pulse-wrapper] Complexity scan: skipping ${file_path} — nesting-only violation (0 long functions)" >>"$LOGFILE"
+			issues_skipped=$((issues_skipped + 1))
+			continue
+		fi
+
 		# Dedup via server-side title search — accurate across all issues (GH#5630)
 		if _complexity_scan_has_existing_issue "$aidevops_slug" "$file_path"; then
 			echo "[pulse-wrapper] Complexity scan: skipping ${file_path} — existing open issue" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Fixes a false-positive in the complexity scan that created issues titled "0 functions >100 lines" — a misleading and unactionable result.

## Root Cause

`_scan_shell_files` in `complexity-scan-helper.sh` includes a file in scan output when **either**:
- `long_func_count >= COMPLEXITY_FILE_VIOLATION_THRESHOLD` (function length violation), OR
- `max_nesting > COMPLEXITY_NESTING_DEPTH_THRESHOLD` (nesting depth violation)

When only the nesting condition triggers, `long_func_count=0`. This value flows into `_complexity_scan_create_issues` as `violation_count`, which uses it verbatim in the issue title and body:

```
simplification: reduce function complexity in .agents/scripts/dispatch-dedup-helper.sh (0 functions >100 lines)
```

This is factually correct (0 violations) but creates a real issue that gets dispatched to workers who find nothing to fix.

**Verified on dispatch-dedup-helper.sh:**
- Long functions (>100 lines): **0**
- Max nesting depth: **9** (threshold: 8) ← this triggered the issue

## Fix

Added a guard in `_complexity_scan_create_issues` to skip entries where `violation_count=0`. These are nesting-only violations; the current issue template is function-length-specific and cannot meaningfully describe them.

```bash
if [[ "${violation_count:-0}" -eq 0 ]]; then
    echo "[pulse-wrapper] Complexity scan: skipping ${file_path} — nesting-only violation (0 long functions)" >>""
    issues_skipped=$((issues_skipped + 1))
    continue
fi
```

## Files Changed

- EDIT: `.agents/scripts/pulse-wrapper.sh` — added nesting-only skip guard in `_complexity_scan_create_issues`

## Testing

- `bash -n .agents/scripts/pulse-wrapper.sh` — syntax check passes
- ShellCheck on the modified block — no violations
- Logic verified: `dispatch-dedup-helper.sh` has 0 long functions and nesting=9, would now be skipped

## Runtime Testing

**Risk level: Low** — guard condition added to issue creation loop; no behavior change for files with actual function length violations.

Closes #17632


---
[aidevops.sh](https://aidevops.sh) v3.6.134 plugin for [Claude Code](https://claude.ai/code) spent 5m on this as a headless worker.