### PR TITLE
GH#17562: register colormind-helper.sh in simplification state (depth already ≤8)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -6795,6 +6795,13 @@
       "at": "2026-04-06T19:20:31Z",
       "pr": 17584,
       "passes": 2
+    },
+    ".agents/scripts/colormind-helper.sh": {
+      "hash": "fca3090dfe5b07e572ecf605cd270baa54981bbf",
+      "at": "2026-04-07T00:00:00Z",
+      "passes": 1,
+      "pr": 16888,
+      "note": "depth reduced from 16 to 4 in PR #16888; issue #17562 created after fix was already merged"
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {


### PR DESCRIPTION
## Summary

Closes #17562

The nesting depth in `colormind-helper.sh` was already reduced from 16 to 4 in PR #16888 (merged 2026-04-03). Issue #17562 was created on 2026-04-06 based on stale simplification state data — the fix was already in main before the issue was filed.

## What Changed

- EDIT: `.agents/configs/simplification-state.json` — added entry for `colormind-helper.sh` with current hash, referencing PR #16888 as the fixing PR, to prevent re-dispatch of this already-resolved task.

## Acceptance Criteria Verification

- [x] Max nesting depth ≤8: **depth is 4** (verified via `complexity-scan-helper.sh metrics`)
- [x] No functional changes: file is identical to main
- [x] CI passes: `shellcheck` zero violations

## Runtime Testing

**Risk level:** Low — config file update only, no code changes.

Verified:
- `shellcheck .agents/scripts/colormind-helper.sh`: PASS (zero violations)
- `complexity-scan-helper.sh metrics .agents/scripts/colormind-helper.sh`: Max nesting depth: 4
- `bash -n .agents/scripts/colormind-helper.sh`: PASS

**self-assessed** (config-only change, no runtime behaviour affected)

---
[aidevops.sh](https://aidevops.sh) v3.6.134 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 3m and 8,018 tokens on this as a headless worker.