### PR TITLE
fix: use SHA-keyed concurrency group on main to prevent badge cancellation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,10 +12,13 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Only cancel in-progress runs on PR branches, not main.
-  # Cancelled runs show as "failing" on the badge — rapid main pushes
-  # (e.g. pulse auto-merges) would keep the badge red indefinitely.
+  # Each main push gets a unique group (by SHA) so rapid pushes never cancel
+  # each other's queued runs. GitHub's concurrency queue holds only ONE pending
+  # run per group — cancel-in-progress:false protects in-progress runs but a
+  # third push still replaces the queued second, producing a "cancelled"
+  # conclusion that the badge renders as "failing". Using SHA on main prevents
+  # this entirely. PR pushes share a group per branch (desirable cancellation).
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
## Summary

The Code Quality Analysis badge intermittently shows "failing" despite all checks passing. Root cause: rapid pushes to `main` (from pulse auto-merges) cause queued workflow runs to be cancelled, and GitHub badges treat "cancelled" as "failing".

## Root Cause

GitHub's concurrency queue holds only **one pending run per group**. `cancel-in-progress: false` protects in-progress runs, but when a third push arrives while a second is queued, the queued run is **always replaced** — regardless of `cancel-in-progress`. The replaced run completes with `conclusion: cancelled`, which the badge renders as failing.

Evidence from last 20 main-branch runs: 4 cancellations, all following rapid successive pushes within 10-20 seconds (pulse auto-merges). Cancelled runs had zero jobs — never ran, just evicted from the queue.

## Fix

Key each main push by SHA so they never share a concurrency group:

```yaml
# Before
group: ${{ github.workflow }}-${{ github.ref }}

# After
group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
```

- **Main pushes**: group = `Code Quality Analysis-<sha>` — independent, no cancellations
- **PR pushes**: group = `Code Quality Analysis-refs/heads/<branch>` — new push cancels stale run (unchanged, desirable)

## Trade-off

Slightly more CI minutes on main (parallel runs instead of queued). Given the pulse merges rapidly, each merge should validate independently anyway.

## Runtime Testing

- **Risk**: Low (CI config only, no application code)
- **Verification**: self-assessed — the fix is a well-documented GitHub Actions concurrency pattern

---
[aidevops.sh](https://aidevops.sh) v3.6.140 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 11m and 8,601 tokens on this with the user in an interactive session.