### PR TITLE
GH#17647: restructure brief.md into modular subfiles

### DIFF
--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -28,39 +28,6 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
-## When to Use This Agent
-
-Any agent writing structured content to GitHub — issues, PRs, comments, or local briefs:
-
-### Work item creation (dispatched to workers)
-
-| Creator | Content type | What this agent provides |
-|---------|-------------|------------------------|
-| `/define` | Task brief | Tier classification + prescriptive format |
-| `/new-task` | Task brief + issue body | Brief structure + issue body format |
-| `/save-todo` | Task brief | Brief structure from conversation |
-| `code-simplifier` | Simplification issue | Prescriptive oldString/newString findings |
-| `quality-feedback-helper.sh` | Review feedback issue | Exact code suggestions as edit blocks |
-| `pulse-wrapper.sh` | Complexity scan issue | Scan finding → structured issue body |
-| `framework-routing-helper.sh` | Framework issue | Finding → structured issue body |
-
-### Comments (context for workers and humans)
-
-| Creator | Content type | What this agent provides |
-|---------|-------------|------------------------|
-| `pulse-wrapper.sh` | Dispatch comment | Structured context: what to implement, where, why |
-| `worker-lifecycle-common.sh` | Kill/escalation comment | Structured escalation report with reason codes |
-| `triage-review.md` | Review comment | Tier assessment + actionable implementation guidance |
-| Workers (on completion) | PR description | Summary + linked issue + verification evidence |
-| Workers (on failure) | Escalation comment | What was tried, where it stuck, brief gaps |
-
-### PR descriptions
-
-| Creator | Content type | What this agent provides |
-|---------|-------------|------------------------|
-| `/full-loop` workers | PR body | Summary, linked issue (`Closes #NNN`), verification |
-| Interactive sessions | PR body | Summary, motivation, testing evidence |
-
 ## Core Rule
 
 **The brief IS the product.** A vague brief dispatched to Opus wastes more money than a prescriptive brief dispatched to Haiku. Invest the effort in the brief, not the worker.
@@ -80,220 +47,6 @@ Assess every work item against these empirical criteria (from 47-PR research):
 
 **Default to `tier:simple` and verify the brief meets it.** Only escalate when the brief genuinely cannot provide exact code.
 
-## Prescriptive Brief Format (tier:simple)
-
-Every finding/task that targets `tier:simple` MUST include this structure. Haiku copies this verbatim — it does not explore, interpret, or decide.
-
-```markdown
-### Edit 1: {description}
-
-**File:** `{exact/path/to/file.ext}`
-
-**oldString:**
-\`\`\`{language}
-{exact multi-line content to find — include 2-3 surrounding context lines for unique matching}
-\`\`\`
-
-**newString:**
-\`\`\`{language}
-{exact replacement content — same surrounding context, changed lines in the middle}
-\`\`\`
-
-**Verification:**
-\`\`\`bash
-{one-liner that prints PASS or FAIL}
-\`\`\`
-```
-
-### Rules for prescriptive content
-
-1. **Context for uniqueness**: oldString must include enough surrounding lines to match exactly once in the file. A single changed line without context may match multiple locations.
-2. **Preserve indentation**: Copy whitespace exactly. Tab/space mismatch causes Edit tool failures.
-3. **One edit per finding**: Don't bundle multiple changes into a single oldString/newString. If a task requires 3 edits to 3 locations, write 3 separate edit blocks.
-4. **New files**: Provide complete file content, not a skeleton. Include imports, function signatures, and all boilerplate.
-5. **Verification must be automated**: `grep`, `shellcheck`, `test -f`, `jq .`, etc. Never "verify visually" or "check manually".
-
-## Standard Brief Format (tier:standard)
-
-For tasks requiring judgment, provide skeletons rather than verbatim code:
-
-```markdown
-### Files to Modify
-
-- `EDIT: path/to/file.ts:45-60` — {what to change and why}
-- `NEW: path/to/new-file.ts` — {purpose, model on `path/to/reference.ts`}
-
-### Implementation Steps
-
-1. Read `path/to/reference.ts` for the existing pattern
-2. {Step with code skeleton:}
-
-\`\`\`typescript
-// Function signature and structure — worker fills in logic
-export function handleAuth(req: Request): Response {
-  // TODO: validate token using pattern from middleware/auth.ts:12
-  // TODO: check role using checkRole() at roles.ts:22
-}
-\`\`\`
-
-3. {Verification step}
-
-### Verification
-\`\`\`bash
-{commands to confirm implementation}
-\`\`\`
-```
-
-## Reasoning Brief Format (tier:reasoning)
-
-For tasks requiring deep reasoning, describe the problem space and constraints:
-
-```markdown
-### Problem
-
-{What needs to be solved, why the obvious approach may be wrong}
-
-### Constraints
-
-- {Hard constraint — must hold}
-- {Soft constraint — prefer but can trade off}
-
-### Prior Art
-
-- `path/to/similar.ts` — {how a similar problem was solved}
-- {External reference if applicable}
-
-### Acceptance Criteria
-
-- [ ] {Testable criterion}
-- [ ] {Testable criterion}
-```
-
-## Issue Body Template (for agents creating GitHub issues)
-
-When creating issues via `gh issue create`, format the body using the appropriate tier template above, wrapped in standard issue structure:
-
-```markdown
-## Description
-
-{1-2 sentence summary of what needs to change and why}
-
-## Implementation
-
-{Tier-appropriate content from templates above}
-
-## Acceptance Criteria
-
-- [ ] {criterion with verify block if possible}
-- [ ] Lint clean
-- [ ] No unrelated changes
-```
-
-Always include tier label: `--label "tier:simple"` / `--label "tier:standard"` / `--label "tier:reasoning"`.
-
-## Comment Templates
-
-### Dispatch comment (pulse → worker)
-
-Posted by the pulse when dispatching a worker. Gives the worker enough context to skip re-reading the issue body for orientation:
-
-```markdown
-## Dispatching: {issue_title}
-
-**Tier:** `tier:{tier}` | **Model:** {resolved_model} | **Agent:** {agent_name}
-**Issue:** #{issue_number} | **Repo:** {repo_slug}
-
-### Context for worker
-{1-2 sentence summary of what the issue asks for}
-
-### Key files
-- `{primary_file:line_range}` — {what to change}
-{additional files if multi-file}
-
-_Dispatched by pulse at {timestamp}_
-```
-
-### Kill/timeout comment (watchdog → issue)
-
-Posted when a worker is killed. Must mentor the next worker — not just state "timed out":
-
-```markdown
-## Worker killed: {reason}
-
-**Duration:** {time} | **Tokens:** {tokens} | **Previous tier:** `tier:{tier}`
-
-### What the worker spent time on
-- {What files it read}
-- {What approaches it tried, if visible from logs}
-
-### Why it likely failed
-- {Assessment: brief too vague? File changed? Multi-file coordination?}
-
-### Guidance for next attempt
-- {Specific advice: "Read the escalation report above" / "The brief lacks file paths — enrich before re-dispatch"}
-
-_Killed by watchdog at {timestamp}_
-```
-
-### Escalation comment (cascade dispatch)
-
-See `templates/escalation-report-template.md` for the full structured format. Must include:
-1. What was attempted (files read, code tried)
-2. Structured reason code (see template for taxonomy)
-3. Discoveries reusable by the next tier
-4. Brief gaps (what was missing or unclear)
-
-## PR Description Template
-
-Workers creating PRs use this structure. The description serves two audiences: the review bot (needs structured sections) and the human reviewer (needs motivation and evidence).
-
-```markdown
-## Summary
-
-{1-3 bullet points: what changed and why}
-
-## Changes
-
-{For each file changed:}
-- `{file_path}` — {what changed in this file}
-
-## Verification
-
-{Evidence that the change works:}
-- {Test output, lint results, or manual verification}
-
-## Linked Issue
-
-Closes #{issue_number}
-```
-
-**Rules** (from `prompts/build.txt` "Traceability"):
-- PR title: `{task-id}: {description}` — never bare descriptions
-- Exactly ONE `Closes #NNN` — for the issue the PR directly solves
-- Context references: use `Related: #NNN` or `See #NNN`, never `Closes`
-
-## Review Comment Template
-
-For triage reviews and code review feedback:
-
-```markdown
-## Review: {Approved / Needs Changes / Decline}
-
-### Assessment
-| Check | Status | Notes |
-|-------|--------|-------|
-| {criterion} | {pass/fail} | {detail} |
-
-### Tier Classification
-**Recommended:** `tier:{tier}`
-**Rationale:** {why — e.g., "single-file fix with exact code suggestion → tier:simple"}
-
-### Implementation Guidance
-{Actionable steps for the worker, not abstract advice}
-- File: `{path:line}`
-- Change: {exact description or code block}
-```
-
 ## The Mentorship Principle
 
 Every piece of GitHub-written content mentors the next reader. Apply these checks:
@@ -307,6 +60,15 @@ Every piece of GitHub-written content mentors the next reader. Apply these check
 | Could a cheaper model execute this? | Make it more prescriptive |
 
 A dispatch comment that says "implement issue #42" teaches nothing. One that says "edit `src/auth.ts:45` — replace `([^0-9]|$)` with `\b` — verify with `shellcheck src/auth.ts`" enables tier:simple dispatch.
+
+## How to Use This Agent
+
+- **Routing**: See `brief/routing.md` for when to use this agent (work item creation, comments, PR descriptions)
+- **Tier-specific formats**:
+  - `tier:simple` → `brief/tier-simple.md` (prescriptive, exact code blocks)
+  - `tier:standard` → `brief/tier-standard.md` (skeletons, judgment required)
+  - `tier:reasoning` → `brief/tier-reasoning.md` (problem space, constraints)
+- **Templates**: `brief/templates.md` (issue body, comments, PR description, review comment)
 
 ## Callers: How to Reference This Agent
 

--- a/.agents/workflows/brief/routing.md
+++ b/.agents/workflows/brief/routing.md
@@ -1,0 +1,35 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Brief Composition Agent — Routing
+
+When to use this agent for structured GitHub content.
+
+## Work item creation (dispatched to workers)
+
+| Creator | Content type | What this agent provides |
+|---------|-------------|------------------------|
+| `/define` | Task brief | Tier classification + prescriptive format |
+| `/new-task` | Task brief + issue body | Brief structure + issue body format |
+| `/save-todo` | Task brief | Brief structure from conversation |
+| `code-simplifier` | Simplification issue | Prescriptive oldString/newString findings |
+| `quality-feedback-helper.sh` | Review feedback issue | Exact code suggestions as edit blocks |
+| `pulse-wrapper.sh` | Complexity scan issue | Scan finding → structured issue body |
+| `framework-routing-helper.sh` | Framework issue | Finding → structured issue body |
+
+## Comments (context for workers and humans)
+
+| Creator | Content type | What this agent provides |
+|---------|-------------|------------------------|
+| `pulse-wrapper.sh` | Dispatch comment | Structured context: what to implement, where, why |
+| `worker-lifecycle-common.sh` | Kill/escalation comment | Structured escalation report with reason codes |
+| `triage-review.md` | Review comment | Tier assessment + actionable implementation guidance |
+| Workers (on completion) | PR description | Summary + linked issue + verification evidence |
+| Workers (on failure) | Escalation comment | What was tried, where it stuck, brief gaps |
+
+## PR descriptions
+
+| Creator | Content type | What this agent provides |
+|---------|-------------|------------------------|
+| `/full-loop` workers | PR body | Summary, linked issue (`Closes #NNN`), verification |
+| Interactive sessions | PR body | Summary, motivation, testing evidence |

--- a/.agents/workflows/brief/templates.md
+++ b/.agents/workflows/brief/templates.md
@@ -1,0 +1,131 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Brief Composition Templates
+
+Reference templates for GitHub-written content.
+
+## Issue Body Template
+
+When creating issues via `gh issue create`, format the body using the appropriate tier template, wrapped in standard issue structure:
+
+```markdown
+## Description
+
+{1-2 sentence summary of what needs to change and why}
+
+## Implementation
+
+{Tier-appropriate content from tier-simple.md, tier-standard.md, or tier-reasoning.md}
+
+## Acceptance Criteria
+
+- [ ] {criterion with verify block if possible}
+- [ ] Lint clean
+- [ ] No unrelated changes
+```
+
+Always include tier label: `--label "tier:simple"` / `--label "tier:standard"` / `--label "tier:reasoning"`.
+
+## Comment Templates
+
+### Dispatch comment (pulse → worker)
+
+Posted by the pulse when dispatching a worker. Gives the worker enough context to skip re-reading the issue body for orientation:
+
+```markdown
+## Dispatching: {issue_title}
+
+**Tier:** `tier:{tier}` | **Model:** {resolved_model} | **Agent:** {agent_name}
+**Issue:** #{issue_number} | **Repo:** {repo_slug}
+
+### Context for worker
+{1-2 sentence summary of what the issue asks for}
+
+### Key files
+- `{primary_file:line_range}` — {what to change}
+{additional files if multi-file}
+
+_Dispatched by pulse at {timestamp}_
+```
+
+### Kill/timeout comment (watchdog → issue)
+
+Posted when a worker is killed. Must mentor the next worker — not just state "timed out":
+
+```markdown
+## Worker killed: {reason}
+
+**Duration:** {time} | **Tokens:** {tokens} | **Previous tier:** `tier:{tier}`
+
+### What the worker spent time on
+- {What files it read}
+- {What approaches it tried, if visible from logs}
+
+### Why it likely failed
+- {Assessment: brief too vague? File changed? Multi-file coordination?}
+
+### Guidance for next attempt
+- {Specific advice: "Read the escalation report above" / "The brief lacks file paths — enrich before re-dispatch"}
+
+_Killed by watchdog at {timestamp}_
+```
+
+### Escalation comment (cascade dispatch)
+
+See `templates/escalation-report-template.md` for the full structured format. Must include:
+1. What was attempted (files read, code tried)
+2. Structured reason code (see template for taxonomy)
+3. Discoveries reusable by the next tier
+4. Brief gaps (what was missing or unclear)
+
+## PR Description Template
+
+Workers creating PRs use this structure. The description serves two audiences: the review bot (needs structured sections) and the human reviewer (needs motivation and evidence).
+
+```markdown
+## Summary
+
+{1-3 bullet points: what changed and why}
+
+## Changes
+
+{For each file changed:}
+- `{file_path}` — {what changed in this file}
+
+## Verification
+
+{Evidence that the change works:}
+- {Test output, lint results, or manual verification}
+
+## Linked Issue
+
+Closes #{issue_number}
+```
+
+**Rules** (from `prompts/build.txt` "Traceability"):
+- PR title: `{task-id}: {description}` — never bare descriptions
+- Exactly ONE `Closes #NNN` — for the issue the PR directly solves
+- Context references: use `Related: #NNN` or `See #NNN`, never `Closes`
+
+## Review Comment Template
+
+For triage reviews and code review feedback:
+
+```markdown
+## Review: {Approved / Needs Changes / Decline}
+
+### Assessment
+| Check | Status | Notes |
+|-------|--------|-------|
+| {criterion} | {pass/fail} | {detail} |
+
+### Tier Classification
+**Recommended:** `tier:{tier}`
+**Rationale:** {why — e.g., "single-file fix with exact code suggestion → tier:simple"}
+
+### Implementation Guidance
+{Actionable steps for the worker, not abstract advice}
+- File: `{path:line}`
+- Change: {exact description or code block}
+```

--- a/.agents/workflows/brief/tier-reasoning.md
+++ b/.agents/workflows/brief/tier-reasoning.md
@@ -1,0 +1,36 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Reasoning Brief Format (tier:reasoning)
+
+For tasks requiring deep reasoning. Describe the problem space and constraints.
+
+## Format
+
+```markdown
+### Problem
+
+{What needs to be solved, why the obvious approach may be wrong}
+
+### Constraints
+
+- {Hard constraint — must hold}
+- {Soft constraint — prefer but can trade off}
+
+### Prior Art
+
+- `path/to/similar.ts` — {how a similar problem was solved}
+- {External reference if applicable}
+
+### Acceptance Criteria
+
+- [ ] {Testable criterion}
+- [ ] {Testable criterion}
+```
+
+## Key principles
+
+- **Problem-first**: Describe the challenge, not the solution
+- **Constraints matter**: Hard constraints (must hold) vs soft constraints (prefer)
+- **Prior art**: Reference similar solutions in the codebase
+- **Testable criteria**: Each criterion must be verifiable, not subjective

--- a/.agents/workflows/brief/tier-simple.md
+++ b/.agents/workflows/brief/tier-simple.md
@@ -1,0 +1,39 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Prescriptive Brief Format (tier:simple)
+
+For single-file changes with exact code blocks. Haiku copies this verbatim — it does not explore, interpret, or decide.
+
+## Format
+
+Every finding/task that targets `tier:simple` MUST include this structure:
+
+```markdown
+### Edit 1: {description}
+
+**File:** `{exact/path/to/file.ext}`
+
+**oldString:**
+\`\`\`{language}
+{exact multi-line content to find — include 2-3 surrounding context lines for unique matching}
+\`\`\`
+
+**newString:**
+\`\`\`{language}
+{exact replacement content — same surrounding context, changed lines in the middle}
+\`\`\`
+
+**Verification:**
+\`\`\`bash
+{one-liner that prints PASS or FAIL}
+\`\`\`
+```
+
+## Rules for prescriptive content
+
+1. **Context for uniqueness**: oldString must include enough surrounding lines to match exactly once in the file. A single changed line without context may match multiple locations.
+2. **Preserve indentation**: Copy whitespace exactly. Tab/space mismatch causes Edit tool failures.
+3. **One edit per finding**: Don't bundle multiple changes into a single oldString/newString. If a task requires 3 edits to 3 locations, write 3 separate edit blocks.
+4. **New files**: Provide complete file content, not a skeleton. Include imports, function signatures, and all boilerplate.
+5. **Verification must be automated**: `grep`, `shellcheck`, `test -f`, `jq .`, etc. Never "verify visually" or "check manually".

--- a/.agents/workflows/brief/tier-standard.md
+++ b/.agents/workflows/brief/tier-standard.md
@@ -1,0 +1,42 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Standard Brief Format (tier:standard)
+
+For tasks requiring judgment. Provide skeletons rather than verbatim code.
+
+## Format
+
+```markdown
+### Files to Modify
+
+- `EDIT: path/to/file.ts:45-60` — {what to change and why}
+- `NEW: path/to/new-file.ts` — {purpose, model on `path/to/reference.ts`}
+
+### Implementation Steps
+
+1. Read `path/to/reference.ts` for the existing pattern
+2. {Step with code skeleton:}
+
+\`\`\`typescript
+// Function signature and structure — worker fills in logic
+export function handleAuth(req: Request): Response {
+  // TODO: validate token using pattern from middleware/auth.ts:12
+  // TODO: check role using checkRole() at roles.ts:22
+}
+\`\`\`
+
+3. {Verification step}
+
+### Verification
+\`\`\`bash
+{commands to confirm implementation}
+\`\`\`
+```
+
+## Key principles
+
+- **Skeletons, not verbatim**: Provide function signatures and structure; worker fills in logic
+- **Reference patterns**: Point to existing code that demonstrates the pattern
+- **Line ranges**: Use `file:line-line` format for clarity
+- **Judgment required**: Worker decides approach, error handling, edge cases


### PR DESCRIPTION
## Summary

Restructured 327-line instruction doc into focused, progressive-disclosure modules following `tools/build-agent/build-agent.md` guidance.

## Changes

- `.agents/workflows/brief.md` — Entry point (89 lines): core rule, tier classification, mentorship principle, routing to subfiles
- `.agents/workflows/brief/routing.md` — When to use this agent (work item creation, comments, PR descriptions)
- `.agents/workflows/brief/tier-simple.md` — Prescriptive format with exact code blocks (tier:simple)
- `.agents/workflows/brief/tier-standard.md` — Standard format with skeletons and judgment (tier:standard)
- `.agents/workflows/brief/tier-reasoning.md` — Reasoning format with problem space and constraints (tier:reasoning)
- `.agents/workflows/brief/templates.md` — All template examples (issue body, comments, PR description, review comment)

## Verification

- Content preservation: 327 → 372 lines (increase due to structure clarity, no content loss)
- All institutional knowledge preserved: tier definitions, mentorship principle, evidence citations (47-PR research), task IDs (GH#6432)
- Markdown linting: 0 errors
- No broken internal links or references
- Agent behaviour unchanged (progressive disclosure: pointers instead of inline content)

## Linked Issue

Closes #17647