### PR TITLE
GH#17549: add worker diagnostics reference doc

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -84,6 +84,10 @@ Every agent session should improve the system, not just complete its task. Full 
 
 Not every task is code. Full routing table, rules, and dispatch examples: `reference/agent-routing.md`.
 
+## Worker Diagnostics
+
+When headless workers fail to complete tasks, stall mid-session, or get stuck in dispatch loops: `reference/worker-diagnostics.md`. Covers the worker lifecycle (version guard → canary → dispatch → DB isolation → watchdog → recovery), architecture decisions (why workers need isolated SQLite DBs, why the watchdog must be a standalone process), and a diagnostic quick reference for common failure modes.
+
 ---
 
 ## File Discovery

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -1,0 +1,128 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Worker Diagnostics and Architecture
+
+<!-- AI-CONTEXT-START -->
+
+Reference for diagnosing headless worker failures. Workers are OpenCode instances dispatched by the pulse to solve GitHub issues autonomously.
+
+**Scripts**: `headless-runtime-helper.sh` (worker lifecycle), `pulse-wrapper.sh` (dispatch), `dispatch-dedup-helper.sh` (dedup), `dispatch-claim-helper.sh` (claims).
+
+<!-- AI-CONTEXT-END -->
+
+## Worker Lifecycle
+
+```
+Pulse cycle (every 2 min)
+  → Version guard (enforce OPENCODE_PINNED_VERSION)
+  → Canary smoke test (cached 30 min)
+  → dispatch_with_dedup (claim + dedup check)
+  → nohup worker launch (survives pulse-wrapper exit)
+    → DB isolation (XDG_DATA_HOME per worker)
+    → Activity watchdog (standalone process, monitors output growth)
+    → OpenCode run (headless, direct to Anthropic API via OAuth)
+    → On completion: merge worker DB back to shared DB, cleanup
+    → On failure: CLAIM_RELEASED posted, issue available for re-dispatch
+```
+
+## Architecture Decisions
+
+### SQLite DB Isolation (v3.6.130)
+
+**Problem**: All headless workers shared `~/.local/share/opencode/opencode.db` with `busy_timeout=0`. Concurrent writes caused `SQLITE_BUSY` which silently broke OpenCode's streaming connection handler. Workers stalled at `step_start` with zero API errors logged.
+
+**Why it was hard to find**: Interactive sessions (single instance) never hit contention. Version bisecting was misleading — fewer workers = less contention = fewer failures, creating a false correlation with OpenCode versions.
+
+**Fix**: Each worker gets its own DB via `XDG_DATA_HOME=/tmp/aidevops-worker-auth.XXXXXX`. After completion, `_merge_worker_db()` copies session/message rows back to the shared DB using `ATTACH DATABASE` + `INSERT OR IGNORE` with a 5s timeout.
+
+**Diagnostic**: If workers stall at `step_start` with no API errors, check:
+```bash
+# Are isolated dirs being created?
+ls -d /tmp/aidevops-worker-auth.* 2>/dev/null || ls -d "$TMPDIR"/aidevops-worker-auth.* 2>/dev/null
+# Is OPENCODE_DB still set? (it should NOT be)
+grep 'OPENCODE_DB' ~/.aidevops/agents/scripts/headless-runtime-helper.sh
+```
+
+### Activity Watchdog (v3.6.126, fixed v3.6.140)
+
+**Problem**: The original watchdog was a bash function backgrounded with `&` inside the worker's subshell. When `nohup` launched the worker (to survive pulse-wrapper exit), the backgrounded function died with its parent context. Stalled workers sat indefinitely with no kill mechanism.
+
+**Fix**: Watchdog launched as a standalone process that outlives the worker subshell.
+
+**Diagnostic**: If workers stall past the 300s timeout:
+```bash
+# Are watchdog processes alive?
+ps aux | grep 'worker-activity-watchdog\|activity_watchdog' | grep -v grep
+# Check worker log for WATCHDOG_KILL marker
+grep WATCHDOG_KILL /tmp/pulse-*-<issue>.log
+# Check for CLAIM_RELEASED on the issue
+gh api repos/<slug>/issues/<num>/comments --jq '.[] | select(.body | test("CLAIM_RELEASED")) | .created_at'
+```
+
+### Canary Smoke Test (v3.6.123)
+
+**Rules**:
+1. Must use a **verified-working** model name (currently `anthropic/claude-sonnet-4-20250514`)
+2. Must run **before** any side effects (claims, locks, ledger updates) — a failed canary must not block re-dispatch
+3. Cached for 30 min (`~/.aidevops/.agent-workspace/headless-runtime/canary-last-pass`)
+4. Version guard runs on every dispatch (not cached)
+
+**Diagnostic**: If no workers dispatch at all:
+```bash
+# Check canary cache
+cat ~/.aidevops/.agent-workspace/headless-runtime/canary-last-pass
+# Clear cache to force re-test
+rm -f ~/.aidevops/.agent-workspace/headless-runtime/canary-last-pass
+# Test canary manually
+opencode run "Reply with exactly: CANARY_OK" -m anthropic/claude-sonnet-4-20250514 --dir "$HOME"
+```
+
+### Version Guard
+
+**Problem**: Something outside aidevops periodically upgrades OpenCode to latest. The version guard in `headless-runtime-helper.sh` runs on every dispatch and reinstalls `OPENCODE_PINNED_VERSION` from `shared-constants.sh` if drift is detected.
+
+**When to pin**: Set `OPENCODE_PINNED_VERSION` in `.agents/scripts/shared-constants.sh` to a specific version when a known-broken release exists. Set to `"latest"` when no pin is needed.
+
+## Diagnostic Quick Reference
+
+| Symptom | Check | Likely cause |
+|---------|-------|-------------|
+| Workers stall at `step_start`, no errors | Isolated DBs exist? Watchdog alive? | SQLite contention (if no isolation) or stream drop (if isolated) |
+| No workers dispatched | Canary cache, pulse log | Broken canary, dedup blocking, no dispatchable issues |
+| Workers rejected immediately | `grep "Claim guard" /tmp/pulse-*.log` | Claim format mismatch (removed in v3.6.138) |
+| Workers dispatch but produce 0 bytes | Version check, `opencode --version` | Wrong OpenCode version, auth failure |
+| PRs created but not merged | `review-bot-gate-helper.sh check <PR>` | Review bot rate-limited (passes immediately since v3.6.136) |
+| Claim/release loop | Comment history on issue | Stale claims, guard rejections — recreate issue with clean context |
+| Watchdog doesn't fire | `ps aux \| grep watchdog` | Watchdog process died with subshell |
+
+## Proving Workers Are Doing Real Work
+
+Don't trust process counts or log existence. Prove output growth:
+
+```bash
+# Measure actual output growth over 15 seconds
+for log in $(ls -t /tmp/pulse-*-*.log | head -3); do
+  issue=$(basename "$log" .log | sed 's/pulse-[^-]*-[^-]*-//')
+  s1=$(wc -c < "$log" | tr -d ' ')
+  sleep 15
+  s2=$(wc -c < "$log" | tr -d ' ')
+  echo "#$issue: +$((s2-s1))b in 15s"
+done
+
+# Check GitHub notifications for actual PRs
+gh api notifications --jq '.[0:5] | .[] | "\(.updated_at[0:16]) \(.subject.type): \(.subject.title)"'
+```
+
+## Recovery Checklist
+
+When workers are failing systemically:
+
+1. **Version**: `opencode --version` — matches pin in `shared-constants.sh`?
+2. **Canary**: `rm -f ~/.aidevops/.agent-workspace/headless-runtime/canary-last-pass` and check next cycle
+3. **Processes**: `ps aux | grep opencode` — stale processes? Kill with `pkill -f 'opencode.*run'`
+4. **Isolation**: `grep 'db_isolated' /tmp/pulse-*.log` — are workers getting isolated DBs?
+5. **Watchdog**: `ps aux | grep watchdog` — are watchdog processes surviving?
+6. **Pulse log**: `tail -30 ~/.aidevops/logs/pulse.log` — dedup blocked? backoff? claim errors?
+7. **Issue comments**: check for `CLAIM_RELEASED` / `DISPATCH_CLAIM` comment loops
+8. **Review gate**: `review-bot-gate-helper.sh check <PR>` — `WAITING` means bot is blocking merge

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -28,6 +28,7 @@ tools:
 
 **Use for**: parallel tasks, scheduled/cron AI work, CI/CD, chat-triggered dispatch (Matrix/Discord/Slack via OpenClaw), background tasks.
 **Don't use for**: interactive dev (use TUI), frequent human-in-the-loop, single quick questions.
+**Diagnostics**: When workers fail, stall, or loop: `reference/worker-diagnostics.md`.
 
 **Draft agents**: Share domain instructions across workers via `~/.aidevops/agents/draft/`. See `tools/build-agent/build-agent.md`.
 **Remote dispatch**: `tools/containers/remote-dispatch.md` (SSH/Tailscale with credential forwarding).


### PR DESCRIPTION
## Summary

- Adds `reference/worker-diagnostics.md` — comprehensive reference for diagnosing headless worker failures
- Covers the full worker lifecycle, architecture decisions (SQLite isolation, standalone watchdog, canary rules), diagnostic quick reference table, and recovery checklist
- Pointer added to AGENTS.md (Worker Diagnostics section) and headless-dispatch.md

## Context

Codifies all learnings from the 6-hour GH#17549 investigation session (v3.6.120→v3.6.140, 20 releases). Without this doc, the next person debugging worker failures would repeat the same investigation.

Closes #17549