### PR TITLE
GH#17658: default simplification issues to tier:standard

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5519,14 +5519,14 @@ This file was previously simplified (PR #${prev_pr}) but has since been modified
 		# shellcheck disable=SC2086
 		gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
-			--label "simplification-debt" $review_label --label "tier:simple" --label "recheck-simplicity" \
+			--label "simplification-debt" $review_label --label "tier:standard" --label "recheck-simplicity" \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	else
 		# shellcheck disable=SC2086
 		gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
-			--label "simplification-debt" $review_label --label "tier:simple" \
+			--label "simplification-debt" $review_label --label "tier:standard" \
 			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	fi
@@ -5545,9 +5545,11 @@ This file was previously simplified (PR #${prev_pr}) but has since been modified
 }
 
 # Create GitHub issues for agent docs flagged for simplification review.
-# Default these to tier:simple so short doc-tightening work routes to a
-# cheaper worker by default; maintainers can raise to tier:standard or tier:reasoning when the
-# issue requires architectural reasoning, security trade-offs, or novel design.
+# Default to tier:standard — simplification requires reading the file, understanding
+# its structure, deciding what to extract vs compress, and preserving institutional
+# knowledge. Haiku-tier models lack the judgment for this; they over-compress,
+# lose task IDs, or restructure without understanding the reasoning behind the
+# original layout. Maintainers can raise to tier:reasoning for architectural docs.
 # Arguments: $1 - scan_results (pipe-delimited: file_path|line_count), $2 - repos_json, $3 - aidevops_slug
 _complexity_scan_create_md_issues() {
 	local scan_results="$1"
@@ -5730,7 +5732,7 @@ This is an automated scan. The function lengths are factual, but the best decomp
 # - .md files: all agent docs (no size gate — classification determines action, t1679)
 #
 # Protected files (build.txt, AGENTS.md, pulse.md, pulse-sweep.md) are excluded.
-# Results processed longest-first. .md issues get tier:simple by default.
+# Results processed longest-first. .md issues get tier:standard by default.
 #
 # Daily LLM sweep (GH#15285): if simplification debt hasn't decreased in 6h,
 # creates a tier:reasoning issue for LLM-powered deep review of stalled debt.


### PR DESCRIPTION
## Summary

- Change simplification issue creation from `tier:simple` (Haiku) to `tier:standard` (Sonnet)
- Simplification requires reading files, understanding structure, deciding what to extract vs compress, and preserving institutional knowledge — that's standard-tier judgment, not prescriptive Haiku work

Closes #17658

## Audit of existing merged work

Reviewed all April simplification PRs to assess whether cheap-model work needs redoing:

| PR | Model | Assessment |
|----|-------|-----------|
| #17652 (brief.md restructure) | gpt-5.4-mini | Acceptable — 327 to 370 lines, zero content loss, clean split into 5 subfiles. Issue body was highly prescriptive. |
| #17661 (templates tightening) | gpt-5.4-mini | Acceptable — +8/-10 lines, minimal change. |
| #16605, #15565, #17302, #15980 | claude-sonnet | Already standard-tier (cascade dispatch escalated past the label). |
| #15600 (tunnel gotchas) | gemini-3-flash | +37/-34, single file — low risk. |

**Conclusion**: No existing merged work needs to be redone. Cascade dispatch was already escalating most simplification tasks past Haiku. The label fix prevents wasting the initial Haiku attempt.

## Changes

- `.agents/scripts/pulse-wrapper.sh`: `tier:simple` to `tier:standard` in both issue creation calls
- Updated code comments explaining why standard is the correct default
- Relabeled open issues #17659 and #17660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal issue labeling and documentation for agent-doc simplification workflows.

---

**Note:** This release contains internal tooling improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->