### PR TITLE
GH#17642: respect manually-applied NMR on maintainer-authored issues

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1754,9 +1754,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "274aa6efd4b42744eedbbc6b7905a6f1cd745ddd",
-      "at": "2026-04-07T01:33:01Z",
-      "passes": 22,
+      "hash": "09acca8dbd127ff833346557e398272159dd9f07",
+      "at": "2026-04-07T02:44:50Z",
+      "passes": 23,
       "pr": 15086
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "a92c8a21d484ee9a3d06e381a24ebe98b891fdcb",
-      "at": "2026-04-07T02:17:25Z",
-      "passes": 59,
+      "hash": "e24a4a6d20c246485f600904b29c2b2783023f0d",
+      "at": "2026-04-07T02:45:04Z",
+      "passes": 60,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "f5464db5ec33d425b9faf70099d469179b4d1451",
-      "at": "2026-04-07T02:17:25Z",
-      "passes": 58,
+      "hash": "ae8d37be37d20a8a35156c9c119c99a878686960",
+      "at": "2026-04-07T02:45:04Z",
+      "passes": 59,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6825,6 +6825,12 @@
       "hash": "8bd4181e68050e7109e6c69d66c06fd0ef7936f2",
       "at": "2026-04-07T02:17:26Z",
       "pr": 17659,
+      "passes": 1
+    },
+    ".agents/scripts/commands/optimize-tiers.md": {
+      "hash": "066bd6b47e328dbd06fdda6e003d447d060aa816",
+      "at": "2026-04-07T02:45:05Z",
+      "pr": 17660,
       "passes": 1
     }
   },

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4325,11 +4325,45 @@ issue_has_required_approval() {
 # issue <number>`. This ensures only a human with the system password
 # (and root access to the approval signing key) can approve issues.
 #
-# Fallback: maintainer-authored issues are still auto-approved (the
-# maintainer wouldn't gate their own issues). Comment-based approval
-# is removed — workers share the same GitHub account so any comment
-# from the account is indistinguishable from a human comment.
+# Fallback: maintainer-authored issues are auto-approved unless the
+# maintainer themselves applied NMR as a manual hold (GH#17642).
+# Comment-based approval is removed — workers share the same GitHub
+# account so any comment from the account is indistinguishable from
+# a human comment.
 #######################################
+#######################################
+# Check if the most recent NMR label on an issue was applied by the
+# maintainer themselves (GH#17642). Uses the immutable timeline API to
+# find the actor of the most recent "labeled" event for NMR.
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug (owner/repo)
+#   $3 - maintainer login
+# Returns: 0 if the maintainer manually applied NMR, 1 otherwise
+#######################################
+_nmr_applied_by_maintainer() {
+	local issue_num="$1"
+	local slug="$2"
+	local maintainer="$3"
+
+	[[ -n "$issue_num" && -n "$slug" && -n "$maintainer" ]] || return 1
+
+	# Query the timeline for all NMR label events and get the actor of the
+	# most recent one. The timeline is immutable and append-only, so the
+	# last "labeled" event for NMR reflects who most recently applied it.
+	local nmr_actor
+	nmr_actor=$(gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate \
+		--jq '[.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")] | last | .actor.login // empty' \
+		2>/dev/null) || nmr_actor=""
+
+	if [[ "$nmr_actor" == "$maintainer" ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
 auto_approve_maintainer_issues() {
 	local repos_json="$REPOS_JSON"
 	[[ -f "$repos_json" ]] || return 0
@@ -4361,10 +4395,17 @@ auto_approve_maintainer_issues() {
 			local should_approve=false
 			local approval_reason=""
 
-			# Case 1: maintainer created the issue — auto-approve
+			# Case 1: maintainer created the issue — auto-approve UNLESS
+			# the maintainer themselves applied NMR (manual hold, GH#17642).
+			# Only auto-approve NMR labels applied by automation (triage gate,
+			# relabel_needs_info_replies, etc.).
 			if [[ "$issue_author" == "$maintainer" ]]; then
-				should_approve=true
-				approval_reason="maintainer is author"
+				if _nmr_applied_by_maintainer "$issue_num" "$slug" "$maintainer"; then
+					echo "[pulse-wrapper] Skipping auto-approve for #${issue_num} in ${slug} — NMR manually applied by maintainer (GH#17642)" >>"$LOGFILE"
+				else
+					should_approve=true
+					approval_reason="maintainer is author, NMR applied by automation"
+				fi
 			fi
 
 			# Case 2: cryptographic approval signature found


### PR DESCRIPTION
## Summary

- `auto_approve_maintainer_issues()` now checks the timeline API to determine who applied the `needs-maintainer-review` label before auto-approving
- If the maintainer themselves applied NMR (manual hold), the label is preserved across pulse cycles
- Only automation-applied NMR labels (triage gate, `relabel_needs_info_replies`, etc.) are auto-approved for maintainer-authored issues

## Changes

- **NEW**: `_nmr_applied_by_maintainer()` helper function — queries the immutable timeline API for the actor of the most recent NMR `labeled` event, modelling on the existing `issue_was_ever_nmr()` pattern at `:4243`
- **EDIT**: `auto_approve_maintainer_issues()` Case 1 — wraps the maintainer-is-author auto-approve in a timeline actor check; logs skip reason when NMR was manually applied
- **EDIT**: docblock for the auto-approve section — updated to reflect the new manual-hold behavior

## Verification

- `shellcheck` passes on the modified functions (full file OOM on this machine; extracted function checked cleanly)
- Logic: timeline API `last` selector gets the most recent NMR label event actor; if actor == maintainer, return 0 (manual hold detected), else return 1 (automation-applied, safe to auto-approve)

Closes #17642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-approval behavior for maintainer-authored issues. The system now correctly identifies when a maintainer manually applies the `needs-maintainer-review` label and skips auto-approval in these cases. This ensures maintainers have proper control over issue handling and review workflows (GH#17642).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->