### PR TITLE
GH#17648: auto-create worktree, provide file paths, log empty-result gaps

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -834,6 +834,74 @@ PY
 	return 0
 }
 
+#######################################
+# _log_empty_result_gaps: scan worker output for empty tool results that
+# preceded the model stopping. Each is a gap (wrong path, missing prefix)
+# that can be closed with better hints or fallback patterns.
+# Logs to ~/.aidevops/logs/worker-empty-results.log for pattern analysis.
+# Args: $1=output_file $2=model $3=session_key
+#######################################
+_log_empty_result_gaps() {
+	local output_file="$1"
+	local model="$2"
+	local session_key="$3"
+
+	[[ -f "$output_file" ]] || return 0
+
+	local diag_log="${HOME}/.aidevops/logs/worker-empty-results.log"
+	mkdir -p "$(dirname "$diag_log")" 2>/dev/null || true
+
+	local _py_script
+	_py_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-empty-gaps.XXXXXX.py") || return 0
+	cat >"$_py_script" <<'EMPTYPY'
+import json, sys, os, datetime
+from pathlib import Path
+of = os.environ.get("ER_OUTPUT_FILE", "")
+md = os.environ.get("ER_MODEL", "")
+sk = os.environ.get("ER_SESSION_KEY", "")
+dl = os.environ.get("ER_DIAG_LOG", "")
+if not of or not dl:
+    sys.exit(0)
+lines = Path(of).read_text(errors="ignore").splitlines()
+gaps, tc = [], 0
+for ln in lines:
+    ln = ln.strip()
+    if not ln.startswith("{"):
+        continue
+    try:
+        o = json.loads(ln)
+    except Exception:
+        continue
+    if o.get("type") == "tool_use":
+        tc += 1
+        st = o.get("part", {}).get("state", {})
+        ip = st.get("input", {})
+        out = (st.get("output", "") or "").strip()
+        empty = (out == "" or out == "0" or out == "\n"
+                 or ("grep" == o["part"].get("tool", "") and "Found 0 matches" in out))
+        if empty:
+            det = ((ip.get("command", "") or "")[:120]
+                   or (ip.get("pattern", "") or "")[:80]
+                   or (ip.get("filePath", "") or "")[:120]
+                   or (ip.get("description", "") or "")[:80])
+            gaps.append({"t": o["part"].get("tool", ""), "d": det, "i": tc})
+if not gaps:
+    sys.exit(0)
+ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+with open(dl, "a") as f:
+    f.write("\n[%s] model=%s session=%s tools=%d empty=%d\n" % (ts, md, sk, tc, len(gaps)))
+    for g in gaps:
+        f.write("  #%d/%d %s -> EMPTY: %s\n" % (g["i"], tc, g["t"], g["d"]))
+print("[empty-result-gaps] %d empty in %d tool calls:" % (len(gaps), tc))
+for g in gaps:
+    print("  [%d/%d] %s -> EMPTY: %s" % (g["i"], tc, g["t"], g["d"][:100]))
+EMPTYPY
+	ER_OUTPUT_FILE="$output_file" ER_MODEL="$model" ER_SESSION_KEY="$session_key" ER_DIAG_LOG="$diag_log" \
+		python3 "$_py_script" 2>/dev/null || true
+	rm -f "$_py_script" 2>/dev/null || true
+	return 0
+}
+
 # _choose_model_explicit: validate and return an explicitly-requested model.
 # Returns 0 on success (prints model), 1 on bad format, 75 if backed off.
 _choose_model_explicit() {
@@ -1192,10 +1260,20 @@ append_worker_headless_contract() {
 This is a HEADLESS worker session. No user is present. No user input is available.
 You must drive autonomously to completion or an evidence-backed BLOCKED outcome.
 
+Key file paths (use these directly, do NOT search for them):
+- Full-loop workflow: .agents/scripts/commands/full-loop.md
+- Pre-edit check: .agents/scripts/pre-edit-check.sh
+- Worktree helper: .agents/scripts/worktree-helper.sh
+- Agents config: .agents/AGENTS.md
+- All agent scripts live under .agents/scripts/ (not scripts/ at root)
+
 Implementation approach:
 1. Read the issue body FIRST. Look for a "Worker Guidance" or "How" section — it contains the files to modify, reference patterns, and verification commands. Follow these directly instead of exploring the codebase broadly.
 2. Budget discipline: spend at most 25% of your effort on reading/exploring. After reading the issue body + 2-3 reference files mentioned in it, start writing code. Do not read entire helper scripts — read only the sections you will modify.
 3. If the issue body lacks file paths and implementation steps, exit BLOCKED with reason "missing implementation context" so the dispatcher can enrich the body. Do NOT explore broadly to compensate for a vague issue.
+
+Empty tool results:
+If a tool call returns empty output, it usually means the path or pattern was wrong, not that the resource is missing. Common causes: missing .agents/ prefix on paths, wrong glob pattern, file moved/renamed. Retry with corrected paths before giving up. If retries also fail, log what you tried and continue with the next step. Do NOT stop the session over one empty result.
 
 Mandatory behavior:
 4. Never ask for user confirmation, approval, or next steps. No user will respond.
@@ -1787,6 +1865,10 @@ _handle_run_result() {
 		# or triage sessions which don't produce PR completion signals.
 		if [[ "$role" == "worker" && "$session_key" == issue-* ]]; then
 			if ! output_has_completion_signal "$output_file"; then
+				# Diagnose empty tool results that may have caused the model to stop.
+				# Each is a closeable gap (wrong path, missing prefix, moved file).
+				_log_empty_result_gaps "$output_file" "$selected_model" "$session_key"
+
 				_run_result_label="premature_exit"
 				rm -f "$output_file"
 				print_warning "$selected_model worker exited with activity but no completion signal (premature exit — will attempt continuation)"

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -438,14 +438,71 @@ _handle_loop_mode_on_protected() {
 		exit 0
 	fi
 
-	# Auto-create worktree for non-allowlisted paths / code changes
+	# Auto-create worktree for non-allowlisted paths / code changes.
+	# Previously this just signalled "worktree required" (exit 2) and left
+	# creation to the LLM. Many models (gpt-5.4, haiku) didn't know how to
+	# interpret exit 2 and stopped dead. Now we create the worktree
+	# deterministically and return the path so the model can continue.
 	if [[ -n "$TARGET_FILE" ]]; then
 		echo -e "${YELLOW}LOOP-AUTO${NC}: Non-allowlisted path '$TARGET_FILE', worktree required"
 	else
 		echo -e "${YELLOW}LOOP-AUTO${NC}: Code task detected, worktree required"
 	fi
-	echo "LOOP_DECISION=worktree"
-	exit 2 # Special exit code for "create worktree"
+
+	# Derive branch name from --task description or fall back to generic
+	local _wt_branch_name=""
+	local _wt_task_desc="${TASK_DESCRIPTION:-}"
+	if [[ -n "$_wt_task_desc" ]]; then
+		# Extract issue number if present (e.g., "Implement issue #17642")
+		local _wt_issue_num=""
+		_wt_issue_num=$(printf '%s' "$_wt_task_desc" | grep -oE '#[0-9]+|issue[/ ]*([0-9]+)' | grep -oE '[0-9]+' | head -1) || _wt_issue_num=""
+		if [[ -n "$_wt_issue_num" ]]; then
+			# Slugify the task title for the branch name
+			local _wt_slug=""
+			_wt_slug=$(printf '%s' "$_wt_task_desc" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-40) || _wt_slug="task"
+			_wt_branch_name="bugfix/gh${_wt_issue_num}-${_wt_slug}"
+		fi
+	fi
+	# Fallback: timestamp-based branch name
+	if [[ -z "$_wt_branch_name" ]]; then
+		_wt_branch_name="feature/auto-$(date +%Y%m%d-%H%M%S)"
+	fi
+
+	# Try to create the worktree using the helper
+	local _wt_helper="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/worktree-helper.sh"
+	local _wt_path=""
+	if [[ -x "$_wt_helper" ]]; then
+		local _wt_output=""
+		_wt_output=$("$_wt_helper" add "$_wt_branch_name" 2>&1) || true
+		# Extract the worktree path from helper output
+		_wt_path=$(printf '%s' "$_wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || _wt_path=""
+		if [[ -z "$_wt_path" ]]; then
+			# Fallback: construct expected path from repo name + branch
+			local _wt_repo_name=""
+			_wt_repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+			local _wt_safe_branch=""
+			_wt_safe_branch=$(printf '%s' "$_wt_branch_name" | tr '/' '-')
+			_wt_path="$(dirname "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")/${_wt_repo_name}-${_wt_safe_branch}"
+		fi
+	fi
+
+	if [[ -n "$_wt_path" && -d "$_wt_path" ]]; then
+		echo "LOOP_DECISION=worktree_created"
+		echo "WORKTREE_PATH=$_wt_path"
+		echo "WORKTREE_BRANCH=$_wt_branch_name"
+		echo -e "${GREEN}LOOP-AUTO${NC}: Worktree created at $_wt_path"
+		echo ""
+		echo "NEXT_STEP: cd to the worktree path and continue implementation there."
+		echo "All file reads and edits must use the worktree path, not the main repo."
+		exit 0
+	else
+		# Worktree creation failed — fall back to signalling exit 2
+		echo -e "${RED}LOOP-AUTO${NC}: Failed to auto-create worktree '$_wt_branch_name'"
+		echo "LOOP_DECISION=worktree"
+		echo "WORKTREE_BRANCH=$_wt_branch_name"
+		echo "NEXT_STEP: Run worktree-helper.sh add '$_wt_branch_name' manually, then cd to the new path."
+		exit 2 # Special exit code for "create worktree"
+	fi
 }
 
 # Show interactive warning when on a protected branch (main/master).


### PR DESCRIPTION
## Summary

Three improvements to worker resilience based on analysis of gpt-5.4 failure sessions on #17642 and #17643:

1. **Auto-create worktree on pre-edit-check exit 2** -- previously just signalled `LOOP_DECISION=worktree` and left creation to the LLM. gpt-5.4 stopped dead at this point on #17642 (12 tool calls, solid exploration, then nothing). Now creates the worktree deterministically, returns `WORKTREE_PATH` and exit 0.

2. **Key file paths in headless contract** -- gpt-5.4 searched for `full-loop.md` without the `.agents/` prefix on #17643, got empty output, and stopped after 1 tool call. The contract now includes resolved paths for the 5 most-needed files + guidance to retry with corrected paths on empty results.

3. **Empty-result gap logging** -- on premature_exit, scans worker output for empty tool results and logs to `~/.aidevops/logs/worker-empty-results.log`. Each entry is a closeable gap. Pattern analysis across workers surfaces systemic path/prefix issues.

Related: #17648

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/pre-edit-check.sh` | `_handle_loop_mode_on_protected()`: auto-create worktree via worktree-helper, return path + exit 0 |
| `.agents/scripts/headless-runtime-helper.sh` | Contract: add key paths + empty result guidance. Add `_log_empty_result_gaps()`. Call from premature_exit path. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced automatic worktree creation with intelligent branch naming from task descriptions.

* **Bug Fixes**
  * Improved diagnostic logging for tool execution failures to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->