### PR TITLE
GH#17648: add Done When, recovery paths, and empty-result fallbacks to briefs

### DIFF
--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -56,10 +56,43 @@ Every piece of GitHub-written content mentors the next reader. Apply these check
 | Does this tell the reader WHERE to look? | Add file paths with line ranges |
 | Does this tell the reader WHAT to do? | Add exact code or clear steps |
 | Does this tell the reader HOW to verify? | Add verification commands |
+| Does this tell the reader WHEN they are done? | Add a concrete completion signal |
+| Does this tell the reader WHAT to do when stuck? | Add fallback/recovery steps |
 | Does this tell the reader WHAT was already tried? | Add prior attempt context (escalation, kill comments) |
 | Could a cheaper model execute this? | Make it more prescriptive |
 
 A dispatch comment that says "implement issue #42" teaches nothing. One that says "edit `src/auth.ts:45` — replace `([^0-9]|$)` with `\b` — verify with `shellcheck src/auth.ts`" enables tier:simple dispatch.
+
+## Headless Continuation Resilience
+
+Briefs consumed by headless workers must anticipate that the worker will encounter empty results, wrong paths, and ambiguous states. Every brief section should answer: "what does the worker do when this step produces nothing?"
+
+**Completion signal (mandatory for all tiers):** Every issue body must include a `### Done When` section with a concrete, machine-verifiable condition. Without this, workers explore indefinitely or stop prematurely.
+
+```markdown
+### Done When
+
+- `shellcheck .agents/scripts/{file}.sh` exits 0
+- `gh pr view --json state` shows MERGED
+- The issue is closed with a closing comment linking the PR
+```
+
+**Recovery paths (mandatory for tier:standard and above):** For each implementation step, include what to do if the expected file/function/pattern is not found:
+
+```markdown
+### Implementation Steps
+
+1. Read `.agents/scripts/pulse-wrapper.sh:4254` — the `auto_approve_maintainer_issues()` function
+   - **If not found at that line:** `grep -n 'auto_approve_maintainer_issues' .agents/scripts/pulse-wrapper.sh`
+   - **If function was renamed/removed:** check `git log --oneline -5 .agents/scripts/pulse-wrapper.sh` for recent changes
+```
+
+**Empty-result fallbacks:** When a brief references a file path, include a fallback search so the worker doesn't stop on first miss:
+
+```markdown
+- EDIT: `.agents/scripts/memory-pressure-monitor.sh:877-888`
+  - Fallback: `grep -n 'cmd_daemon' .agents/scripts/memory-pressure-monitor.sh`
+```
 
 ## How to Use This Agent
 

--- a/.agents/workflows/brief/templates.md
+++ b/.agents/workflows/brief/templates.md
@@ -23,9 +23,20 @@ When creating issues via `gh issue create`, wrap the appropriate tier content in
 - [ ] {criterion with verify block if possible}
 - [ ] Lint clean
 - [ ] No unrelated changes
+
+## Done When
+
+{Concrete, machine-verifiable completion signal — the worker does not stop until these are true}
+
+- `{lint/test command}` exits 0
+- PR exists with `Closes #{issue_number}` in body
+- MERGE_SUMMARY comment posted on PR
+- Issue closed with closing comment linking PR
 ```
 
 Always include a tier label: `tier:simple`, `tier:standard`, or `tier:reasoning`.
+
+**Why "Done When" matters:** Workers that lack a concrete completion signal exhibit two failure modes: (1) stop after setup/exploration without implementing anything (observed on #17642, #17643), or (2) stop after PR creation without merging or posting closing comments. "Done When" gives the model a checklist to drive toward instead of an open-ended goal.
 
 ## Comment Templates
 

--- a/.agents/workflows/brief/tier-simple.md
+++ b/.agents/workflows/brief/tier-simple.md
@@ -37,3 +37,4 @@ Every finding/task that targets `tier:simple` MUST include this structure:
 3. **One edit per finding**: Don't bundle multiple changes into a single oldString/newString. If a task requires 3 edits to 3 locations, write 3 separate edit blocks.
 4. **New files**: Provide complete file content, not a skeleton. Include imports, function signatures, and all boilerplate.
 5. **Verification must be automated**: `grep`, `shellcheck`, `test -f`, `jq .`, etc. Never "verify visually" or "check manually".
+6. **Done When is mandatory**: End every issue body with `### Done When` containing a concrete check (e.g., `shellcheck {file}` exits 0, PR merged, issue closed). Without this, even Haiku may stop after applying the edit without committing/pushing/creating a PR.

--- a/.agents/workflows/brief/tier-standard.md
+++ b/.agents/workflows/brief/tier-standard.md
@@ -40,3 +40,28 @@ export function handleAuth(req: Request): Response {
 - **Reference patterns**: Point to existing code that demonstrates the pattern
 - **Line ranges**: Use `file:line-line` format for clarity
 - **Judgment required**: Worker decides approach, error handling, edge cases
+- **Done When is mandatory**: Every brief must include a concrete completion signal (see below)
+- **Recovery paths**: For each step, include what to do if the expected file/pattern is not found
+
+## Done When (required section)
+
+Every tier:standard issue body must end with a machine-verifiable completion condition:
+
+```markdown
+### Done When
+
+- `{lint/test command}` exits 0
+- PR exists with `Closes #{issue_number}` and MERGE_SUMMARY comment posted
+- Issue closed with closing comment linking PR
+```
+
+Without this, workers explore indefinitely or stop after reading files without implementing anything.
+
+## Fallback patterns
+
+For each file reference, include a fallback search so the worker doesn't stop on first miss:
+
+```markdown
+- EDIT: `path/to/file.ts:45-60` -- {what to change}
+  - Fallback: `grep -n 'functionName' path/to/file.ts`
+```


### PR DESCRIPTION
## Summary

- Add mandatory `Done When` section to all brief tiers -- concrete, machine-verifiable completion signals so workers drive toward a checklist instead of stopping after exploration
- Add recovery paths for tier:standard+ -- fallback searches when expected files/patterns are not at the expected line numbers
- Add empty-result fallbacks -- grep fallbacks alongside file references so workers retry instead of stopping on first miss

Related: #17648

## Evidence

- #17642: gpt-5.4 did 12 tool calls of solid exploration then stopped at pre-edit-check exit 2 -- no completion signal to drive toward
- #17643: gpt-5.4 searched without `.agents/` prefix, got empty result, stopped after 1 tool call -- no fallback guidance
- Both had good issue bodies (file paths, line numbers) but no 'Done When' to anchor the session

## Changes

| File | Change |
|------|--------|
| `.agents/workflows/brief.md` | Add 'WHEN done?' and 'WHAT when stuck?' to mentorship table; add Headless Continuation Resilience section with Done When, recovery paths, fallback patterns |
| `.agents/workflows/brief/templates.md` | Add Done When section to issue body template |
| `.agents/workflows/brief/tier-standard.md` | Add Done When requirement + fallback patterns |
| `.agents/workflows/brief/tier-simple.md` | Add rule #6: Done When is mandatory |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Issue templates enhanced with new "Done When" sections containing concrete, machine-verifiable completion checks
  * Added fallback guidance and recovery paths for implementation edge cases and missing dependencies
  * Introduced resilient fallback search mechanisms to prevent workflow stalls when initial file references are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->