### PR TITLE
GH#17642: stop auto-closing issues from main-commit check false positives

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6768,11 +6768,11 @@ dispatch_with_dedup() {
 	# the pulse dispatches redundant workers for already-completed work.
 	if _is_task_committed_to_main "$issue_number" "$repo_slug" "$target_title" "$repo_path"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: task already committed to main (GH#17574)" >>"$LOGFILE"
-		# Auto-close the issue since the work is done
-		gh issue close "$issue_number" --repo "$repo_slug" \
-			--comment "Closing — work for this issue has already been committed directly to main. Detected by pre-dispatch main-commit check (GH#17574).
-
-_Closed by pulse-wrapper.sh deterministic dispatch guard._" 2>/dev/null || true
+		# GH#17642: Do NOT auto-close the issue. The main-commit check has a
+		# high false-positive rate (casual mentions, multi-runner deployment
+		# gaps, stale patterns). A false skip is harmless (next cycle retries),
+		# a false close is destructive (needs manual reopen, re-dispatch, and
+		# loses worker context). Let the verified merge-pass or human close it.
 		return 1
 	fi
 
@@ -8866,21 +8866,12 @@ _close_conflicting_pr() {
 
 _Closed by deterministic merge pass (pulse-wrapper.sh, GH#17574)._" 2>/dev/null || true
 
-		# Also close the linked issue if it's still open
-		local linked_issue
-		linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug")
-		if [[ -n "$linked_issue" ]]; then
-			local issue_state
-			issue_state=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-				--json state -q '.state' 2>/dev/null) || issue_state=""
-			if [[ "$issue_state" == "OPEN" ]]; then
-				gh issue close "$linked_issue" --repo "$repo_slug" \
-					--comment "Closing — work has already been committed directly to main. Detected when closing conflicting PR #${pr_number} (GH#17574).
-
-_Closed by pulse-wrapper.sh deterministic merge pass._" 2>/dev/null || true
-				echo "[pulse-wrapper] Deterministic merge: closed linked issue #${linked_issue} — work already on main (GH#17574)" >>"$LOGFILE"
-			fi
-		fi
+		# GH#17642: Do NOT auto-close the linked issue. Closing a conflicting
+		# PR is safe (PRs are cheap), but closing the ISSUE based on a commit
+		# search has too many false positives. The issue stays open for
+		# re-dispatch with a fresh branch. Only the verified merge-pass
+		# (which checks for an actually-merged PR) should close issues.
+		echo "[pulse-wrapper] Deterministic merge: conflicting PR #${pr_number} closed, linked issue left open for re-dispatch (GH#17642)" >>"$LOGFILE"
 
 		echo "[pulse-wrapper] Deterministic merge: closed conflicting PR #${pr_number} in ${repo_slug}: ${pr_title} (work already on main)" >>"$LOGFILE"
 	else


### PR DESCRIPTION
## Summary

Remove `gh issue close` from both the dispatch guard (`_is_task_committed_to_main` at line 6772) and the conflicting-PR merge pass (`_close_conflicting_pr` at line 8877). The commit search has too many false positives to safely auto-close issues.

Closes #17642

## Evidence

Issues #17642 and #17643 were falsely closed **5+ times each** by both the `marcusquinn` and `alex-solovyev` runners despite no work being merged. The `robstiles` runner even posted a detailed analysis confirming the function `_nmr_applied_by_maintainer()` does not exist on main.

## Principle

- **False skip** (dispatch blocked but issue stays open): harmless, next cycle retries
- **False close** (issue closed with no work merged): destructive, needs manual reopen, loses dispatch context, wastes cycles

Only the verified merge-pass (which confirms an actually-merged PR with `Closes #NNN`) should close issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed premature auto-closure of issues in conflict resolution scenarios. Issues now remain open for proper handling through verified merge processes or manual action, improving workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->