### PR TITLE
GH#17669: replace codex fallbacks with general-purpose gpt-5.4 models

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -124,12 +124,15 @@ get_tier_models() {
 	local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 	haiku) echo "anthropic/claude-haiku-4-5|openai/gpt-5.4-mini" ;;
 	flash) echo "openai/gpt-5.4-mini|openai/gpt-4.1-mini" ;;
-	sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.3-codex" ;;
+	# GH#17669: codex models are code-completion, not agentic — zero tool calls
+	# observed when dispatched as headless workers. Use general-purpose gpt-5.4
+	# variants as fallbacks instead.
+	sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.4" ;;
 	pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
-	opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
+	opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4-pro" ;;
 	health) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.4-mini" ;;
 	eval) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.4-mini" ;;
-	coding) echo "anthropic/claude-opus-4-6|openai/gpt-5.4" ;;
+	coding) echo "anthropic/claude-opus-4-6|openai/gpt-5.4-pro" ;;
 	*) return 1 ;;
 	esac
 	return 0


### PR DESCRIPTION
## Summary

Replace non-functional codex model fallbacks with general-purpose gpt-5.4 variants that can actually work as agentic headless workers.

Related: #17669

## Evidence

`openai/gpt-5.3-codex` dispatched for #17669 produced **zero tool calls** — the worker started, the contract was injected, and the model generated nothing. Codex models are code-completion models, not agentic — they don't know how to use tools.

## Changes

| Tier | Before | After |
|------|--------|-------|
| sonnet | `anthropic/claude-sonnet-4-6 \| openai/gpt-5.3-codex` | `anthropic/claude-sonnet-4-6 \| openai/gpt-5.4` |
| opus | `anthropic/claude-opus-4-6 \| openai/gpt-5.4` | `anthropic/claude-opus-4-6 \| openai/gpt-5.4-pro` |
| coding | `anthropic/claude-opus-4-6 \| openai/gpt-5.4` | `anthropic/claude-opus-4-6 \| openai/gpt-5.4-pro` |

haiku, flash, health, eval unchanged — their fallbacks already use general-purpose models.