### PR TITLE
t1903: Suppress per-file log_success in generate-skills.sh during normal mode

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "071be0e85dd65b26eccedf8fd79005a7f97b6d86",
-      "at": "2026-04-07T04:16:04Z",
-      "passes": 41,
+      "hash": "93660e785269100485c538df045f06fbfa9bd408",
+      "at": "2026-04-07T07:52:46Z",
+      "passes": 42,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {

--- a/.agents/scripts/generate-skills.sh
+++ b/.agents/scripts/generate-skills.sh
@@ -17,11 +17,12 @@
 #   wordpress/wp-dev.md → wordpress/wp-dev/SKILL.md (generated)
 #
 # Usage:
-#   ./generate-skills.sh [--dry-run] [--clean]
+#   ./generate-skills.sh [--dry-run] [--clean] [--verbose]
 #
 # Options:
 #   --dry-run  Show what would be generated without writing files
 #   --clean    Remove all generated SKILL.md files
+#   --verbose  Show per-file output (suppressed by default in normal mode)
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
@@ -33,6 +34,7 @@ set -euo pipefail
 AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-$HOME/.aidevops/agents}"
 DRY_RUN=false
 CLEAN=false
+VERBOSE=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -43,6 +45,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--clean)
 		CLEAN=true
+		shift
+		;;
+	--verbose | -v)
+		VERBOSE=true
 		shift
 		;;
 	*)
@@ -73,6 +79,14 @@ log_warning() {
 
 log_error() {
 	echo -e "${RED}✗${NC} $1"
+	return 0
+}
+
+# Log per-file success only in verbose or dry-run mode
+log_file_success() {
+	if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+		echo -e "${GREEN}✓${NC} $1"
+	fi
 	return 0
 }
 
@@ -215,7 +229,7 @@ if [[ "$CLEAN" == true ]]; then
 			log_warning "Would remove: $skill_file"
 		else
 			rm -f "$skill_file"
-			log_success "Removed: $skill_file"
+			log_file_success "Removed: $skill_file"
 		fi
 		((++count))
 	done < <(find "$AGENTS_DIR" -name "SKILL.md" -type f 2>/dev/null)
@@ -244,8 +258,10 @@ skipped=0
 
 # Pattern 1: Folders with matching parent .md files
 # e.g., wordpress.md + wordpress/ → wordpress/SKILL.md
-log_info ""
-log_info "Pattern 1: Folders with parent .md files"
+if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+	log_info ""
+	log_info "Pattern 1: Folders with parent .md files"
+fi
 
 while IFS= read -r folder; do
 	folder_name=$(basename "$folder")
@@ -259,11 +275,11 @@ while IFS= read -r folder; do
 
 	if [[ -f "$parent_md" ]]; then
 		if [[ "$DRY_RUN" == true ]]; then
-			log_success "Would generate: $skill_file (from $parent_md)"
+			log_file_success "Would generate: $skill_file (from $parent_md)"
 		else
 			mkdir -p "$folder"
 			generate_folder_skill "$folder" "$parent_md" >"$skill_file"
-			log_success "Generated: $skill_file"
+			log_file_success "Generated: $skill_file"
 		fi
 		((++generated))
 	fi
@@ -271,8 +287,10 @@ done < <(find "$AGENTS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 
 # Pattern 2: Nested folders without parent .md but with children
 # e.g., tools/browser/ with playwright.md, etc.
-log_info ""
-log_info "Pattern 2: Nested folders with child .md files"
+if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+	log_info ""
+	log_info "Pattern 2: Nested folders with child .md files"
+fi
 
 while IFS= read -r folder; do
 	folder_name=$(basename "$folder")
@@ -289,7 +307,7 @@ while IFS= read -r folder; do
 		local_name=$(to_skill_name "$folder_name")
 
 		if [[ "$DRY_RUN" == true ]]; then
-			log_success "Would generate: $skill_file (folder index)"
+			log_file_success "Would generate: $skill_file (folder index)"
 		else
 			# Pure pointer — no inlined subskill lists
 			title=$(capitalize "$folder_name")
@@ -303,7 +321,7 @@ while IFS= read -r folder; do
 				echo ""
 				echo "Browse the .md files in this directory for full instructions."
 			} >"$skill_file"
-			log_success "Generated: $skill_file"
+			log_file_success "Generated: $skill_file"
 		fi
 		((++generated))
 	fi
@@ -312,8 +330,10 @@ done < <(find "$AGENTS_DIR" -mindepth 2 -type d 2>/dev/null | sort)
 # Pattern 3: Standalone .md files in nested dirs without matching folders
 # e.g., services/hosting/local-hosting.md with no local-hosting/ folder
 # These were previously missed, causing discovery gaps.
-log_info ""
-log_info "Pattern 3: Standalone .md files without matching folders"
+if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+	log_info ""
+	log_info "Pattern 3: Standalone .md files without matching folders"
+fi
 
 while IFS= read -r md_file; do
 	filename=$(basename "$md_file" .md)
@@ -344,11 +364,11 @@ while IFS= read -r md_file; do
 	fi
 
 	if [[ "$DRY_RUN" == true ]]; then
-		log_success "Would generate: $skill_file (standalone)"
+		log_file_success "Would generate: $skill_file (standalone)"
 	else
 		mkdir -p "$target_dir"
 		generate_leaf_skill "$md_file" >"$skill_file"
-		log_success "Generated: $skill_file"
+		log_file_success "Generated: $skill_file"
 	fi
 	((++generated))
 done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -not -name "SKILL.md" -not -name "AGENTS.md" -not -name "README.md" -type f 2>/dev/null | sort)


### PR DESCRIPTION
## Summary

- Suppress per-file `log_success` output in `generate-skills.sh` during normal mode to reduce noise
- Add `--verbose` / `-v` flag to opt-in to per-file output when needed
- Pattern section headers (`Pattern 1:`, `Pattern 2:`, `Pattern 3:`) are also suppressed in normal mode since they're meaningless without per-file lines

## Changes

- **EDIT**: `.agents/scripts/generate-skills.sh`
  - Added `VERBOSE=false` config variable and `--verbose`/`-v` argument parsing
  - Added `log_file_success()` function that only prints when `VERBOSE=true` or `DRY_RUN=true`
  - Replaced all per-file `log_success` calls with `log_file_success`
  - Wrapped pattern section headers in verbose/dry-run guards
  - Updated usage comment to document `--verbose` flag

## Runtime Testing

- **Risk**: Low (agent prompt/script, no runtime behaviour change)
- **Verification**: `self-assessed`
  - `shellcheck .agents/scripts/generate-skills.sh` — clean (only SC1091 external source info)
  - Normal mode: only shows header + summary (no per-file lines)
  - `--dry-run`: shows per-file output (unchanged behaviour)
  - `--verbose --dry-run`: shows per-file output
  - `--verbose`: shows per-file output during generation

Closes #17682

---
[aidevops.sh](https://aidevops.sh) v3.6.148 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 2m and 5,520 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verbose` (`-v` flag) to script for detailed output control during execution.
  * Conditional logging now displays per-file success messages and pattern details when verbose mode or dry-run is enabled.

* **Chores**
  * Updated internal state tracking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->