### PR TITLE
fix: avoid stat output pollution and WAL stdout leak

### DIFF
--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -144,7 +144,11 @@ file_size_bytes() {
 		echo "0"
 		return 0
 	fi
-	stat -f '%z' "$filepath" 2>/dev/null || stat -c '%s' "$filepath" 2>/dev/null || echo "0"
+	if [[ "$(uname)" == "Darwin" ]]; then
+		stat -f '%z' "$filepath" 2>/dev/null || echo "0"
+	else
+		stat -c '%s' "$filepath" 2>/dev/null || echo "0"
+	fi
 	return 0
 }
 
@@ -251,9 +255,8 @@ CREATE TABLE IF NOT EXISTS `session_share` (
 	CONSTRAINT `fk_session_share_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
 );
 
--- WAL mode for the archive too (better read concurrency)
-PRAGMA journal_mode=WAL;
 SCHEMA_SQL
+	sqlite3 "$archive_db" "PRAGMA journal_mode=WAL;" >/dev/null 2>&1 || true
 	return 0
 }
 


### PR DESCRIPTION
Fixes #17683

On Linux, the macOS stat path was writing errors to stdout before the fallback, which could break size arithmetic under strict shell settings. file_size_bytes() now picks the stat variant by platform.

Also moved PRAGMA journal_mode=WAL out of the schema heredoc and run it with stdout suppressed, so wal doesn't leak into command output.

Greetings, saschabuehrle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform compatibility for file size detection on macOS and Linux systems.
  * Enhanced database write-ahead logging initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->