### PR TITLE
t1905: add conversation-end loop scan rule to build.txt

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -69,6 +69,7 @@ Before non-trivial tasks, restate: (1) actual goal, (2) constraints that must ho
 - Prefer lightweight approaches. Simpler tools over heavy dependencies.
 - Crash-resilient: every process must recover from cold start by reading current state, not assuming prior steps completed. Check results (PR exists? issue closed?), not flags.
 - Finding-to-task completeness: every actionable finding in audit/review reports must become a tracked task before declaring completion.
+- Conversation-end loop scan: before declaring a task complete or moving to the next task, scan back over the full conversation for: (1) commitments made to the user that weren't fulfilled, (2) external parties affected but not notified, (3) requests displaced by troubleshooting or corrections. Internal task creation does not close external loops.
 
 # Claim discipline (turn-end gate)
 - Never present future intent as completed work.


### PR DESCRIPTION
## Summary

- Adds a single bullet to "Completion and quality discipline" in `build.txt` requiring a conversation-end scan for open threads before declaring tasks complete
- Covers three failure modes observed in a single session: unfulfilled user commitments, unnotified external parties, and requests displaced by troubleshooting
- Generic rule — applies to all session types, not just external issue workflows

Closes #17686

---
[aidevops.sh](https://aidevops.sh) v3.6.148 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 13m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced task completion verification to ensure all user commitments are fulfilled, affected parties are notified, and no requests are overlooked during transitions between tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->