### PR TITLE
t1916: remove approval gate from pulse triage dispatch

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -10800,17 +10800,11 @@ dispatch_triage_reviews() {
 		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
 		[[ "$available" -gt 0 && "$triage_count" -lt "$triage_max" ]] || break
 
-		# ── Cryptographic approval gate (GH#17490) ──
-		# Triage reviews are sandboxed but their OUTPUT is posted as a GitHub
-		# comment under the maintainer's account. Without this gate, any
-		# external non-contributor issue triggers automated actions (worker
-		# dispatch, comment posting, resource consumption). The same approval
-		# gate enforced by dispatch_with_dedup() must also apply here —
-		# no automated processing of unapproved external issues.
-		if ! issue_has_required_approval "$issue_num" "$repo_slug" "unknown"; then
-			echo "[pulse-wrapper] dispatch_triage_reviews: BLOCKED #${issue_num} in ${repo_slug} — requires cryptographic approval before triage" >>"$LOGFILE"
-			continue
-		fi
+		# ── t1916: Triage is exempt from the cryptographic approval gate ──
+		# Triage is read + comment — it helps the maintainer decide whether to
+		# approve the issue for implementation dispatch. The approval gate is
+		# enforced on implementation dispatch (dispatch_with_dedup), not here.
+		# Previously blocked by GH#17490 (t1894), restored in GH#17705 (t1916).
 
 		# ── t1894: Sandboxed triage — pre-fetch all GitHub data deterministically ──
 		local prefetch_file=""


### PR DESCRIPTION
## Summary

- Removes the cryptographic approval gate from `dispatch_triage_reviews()` in `pulse-wrapper.sh`
- Triage (read + comment) now runs on any `needs-maintainer-review` issue without prior approval
- The approval gate remains on implementation dispatch (`dispatch_with_dedup`) — no security reduction

## Why

The triage comment is what helps the maintainer decide whether to approve an issue. Blocking triage before approval forced manual review of every external issue, defeating the purpose of the triage pipeline. The gate was added in t1894 (GH#17490) and applied too broadly.

## Changes

- `EDIT: .agents/scripts/pulse-wrapper.sh:10803-10813` — removed `issue_has_required_approval` check and continue block
- Added explanatory comment noting triage exemption and cross-references (t1916, GH#17705, t1894)

## Verification

```
$ rg -n 'issue_has_required_approval' .agents/scripts/pulse-wrapper.sh
4295:issue_has_required_approval() {        # definition — unchanged
6792:   if ! issue_has_required_approval ... # dispatch_with_dedup — unchanged
```

Gate removed from triage, preserved in dispatch.

Closes #17705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Triage reviews are now dispatched without an initial approval requirement. Approval validation has been deferred to the implementation dispatch phase, streamlining the triage workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->