### PR TITLE
GH#17699: fix _ts_to_epoch() timezone bug causing premature stale recovery

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -527,7 +527,10 @@ _ts_to_epoch() {
 		# Strip trailing Z or timezone offset for macOS date parsing
 		local clean_ts="${ts%%Z*}"
 		clean_ts="${clean_ts%%+*}"
-		date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0"
+		# GH#17699: TZ=UTC is critical — without it, macOS date interprets
+		# the input as local time, making UTC timestamps appear TZ-offset
+		# seconds older than they are (e.g. BST/UTC+1 = 3600s too old).
+		TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0"
 	else
 		date -d "$ts" "+%s" 2>/dev/null || echo "0"
 	fi


### PR DESCRIPTION
## Summary

- `_ts_to_epoch()` on macOS stripped the `Z` suffix from UTC timestamps then passed them to `date -j -f`, which interprets input as **local time**. On any machine east of UTC this made every GitHub timestamp appear `TZ_OFFSET` seconds older than reality.
- On BST (UTC+1), a 20-second-old dispatch claim computed as 3620s — exceeding the 1800s threshold — causing stale recovery to immediately kill freshly dispatched workers.
- Fix: prefix `TZ=UTC` on the macOS `date` call. Linux branch (`date -d`) is unaffected.

## Evidence

GH#17699 comment timeline:
| Time | Event |
|---|---|
| 17:20:55Z | `DISPATCH_CLAIM` posted |
| 17:21:17Z | Worker dispatched (PID 3349956) |
| 17:21:20Z | Stale recovery fires — reports "3620s old" (3600s TZ offset + 20s actual age) |

## Verification

```bash
# Before fix (BST):
_ts_to_epoch "2026-04-07T17:20:55Z"  # Returns epoch of 17:20:55 BST = 16:20:55 UTC (wrong)

# After fix:
_ts_to_epoch "2026-04-07T17:20:55Z"  # Returns epoch of 17:20:55 UTC (correct)
```

ShellCheck clean.

Closes #17699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UTC timestamp conversion on macOS systems that were previously affected by local timezone settings, ensuring accurate timestamp computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->