### PR TITLE
GH#17707: fix _is_task_committed_to_main false positive on planning commits

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1748,9 +1748,9 @@
       "pr": 15933
     },
     ".agents/scripts/gh-signature-helper.sh": {
-      "hash": "af29c64d604abe4a0afaf132648261377e2c7bbe",
-      "at": "2026-04-06T00:41:47Z",
-      "passes": 3,
+      "hash": "467e8eb417926046eb18bf797ebb5a866f0d682d",
+      "at": "2026-04-07T15:08:27Z",
+      "passes": 4,
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
@@ -5213,9 +5213,9 @@
       "pr": 13318
     },
     ".agents/workflows/review-issue-pr.md": {
-      "hash": "675c78c98b90bdb7440b5a233c556dd953f98d86",
-      "at": "2026-04-07T13:39:49Z",
-      "passes": 4,
+      "hash": "34292ce63bbb8d49f12b10e3cfecbabe5f1fcd09",
+      "at": "2026-04-07T15:08:40Z",
+      "passes": 5,
       "pr": 12308
     },
     ".agents/workflows/session-manager.md": {
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "4506f607ecc1e58328ed74ff3437832f8fc37c44",
-      "at": "2026-04-07T14:32:04Z",
-      "passes": 64,
+      "hash": "f24cec99bfefcd39d555799220455d6f0dade4b4",
+      "at": "2026-04-07T15:08:41Z",
+      "passes": 65,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "ffe9872bd481ab4af09ade6b3b95a9bd36441ef0",
-      "at": "2026-04-07T14:32:04Z",
-      "passes": 63,
+      "hash": "28d2cf8ce62d1a6cc54a7d836aefcd645f6bf1df",
+      "at": "2026-04-07T15:08:41Z",
+      "passes": 64,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6690,11 +6690,15 @@ _is_task_committed_to_main() {
 
 	# Search recent commits on origin/main for any matching pattern.
 	# Use -E for extended regex (Closes/Fixes patterns).
+	# GH#17707: Filter out planning-only commits (claim, plan, docs prefixes)
+	# that mention task IDs but don't contain implementation work.
 	local pattern
 	for pattern in "${search_patterns[@]}"; do
 		local match_count
 		match_count=$(git -C "$repo_path" log origin/main --since="$created_at" \
-			--oneline -E --grep="$pattern" 2>/dev/null | wc -l) || match_count=0
+			--oneline -E --grep="$pattern" 2>/dev/null |
+			grep -vE '^[0-9a-f]+ (chore: claim|plan:|docs:)' |
+			wc -l) || match_count=0
 		match_count=$(printf '%s' "$match_count" | tr -d '[:space:]')
 		if [[ "$match_count" -gt 0 ]]; then
 			echo "[pulse-wrapper] _is_task_committed_to_main: found ${match_count} commit(s) matching '${pattern}' on origin/main since ${created_at} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

- **What**: Filter out planning-only commits (`chore: claim`, `plan:`, `docs:`) from the `_is_task_committed_to_main()` dedup check in `pulse-wrapper.sh`
- **Why**: The GH#17574 dedup layer was matching task IDs in planning commits on main and blocking dispatch for genuinely unimplemented issues, effectively halting all dispatch for the aidevops repo
- **How**: Added a `grep -vE` filter in the commit search loop to exclude commits with planning prefixes before counting matches

## Files Changed

- `.agents/scripts/pulse-wrapper.sh` — `_is_task_committed_to_main()` function (lines ~6691-6707)

## Runtime Testing

- **Risk level**: Medium (pulse dispatch logic, no data mutation)
- **Testing**: ShellCheck passed (only SC2126 style suggestion, consistent with existing code pattern). The fix is a simple pipeline filter addition — no new control flow or state changes.

Closes #17707

---
[aidevops.sh](https://aidevops.sh) v3.6.151 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 2m and 3,929 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal task tracking configuration and state management.
  * Enhanced task detection logic to more accurately identify implementation commits by filtering out planning-related, documentation-only, and claim-related activity, reducing false positives in task completion tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->