### PR TITLE
GH#17707: fix _is_task_committed_to_main dedup false positive on planning commits

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6690,14 +6690,62 @@ _is_task_committed_to_main() {
 
 	# Search recent commits on origin/main for any matching pattern.
 	# Use -E for extended regex (Closes/Fixes patterns).
+	# GH#17707: Filter out planning-only commits that match task IDs but
+	# don't contain actual implementation (e.g., "chore: claim t1910..t1915"
+	# or commits that only modify TODO.md/todo/ files).
 	local pattern
 	for pattern in "${search_patterns[@]}"; do
-		local match_count
-		match_count=$(git -C "$repo_path" log origin/main --since="$created_at" \
-			--oneline -E --grep="$pattern" 2>/dev/null | wc -l) || match_count=0
-		match_count=$(printf '%s' "$match_count" | tr -d '[:space:]')
-		if [[ "$match_count" -gt 0 ]]; then
-			echo "[pulse-wrapper] _is_task_committed_to_main: found ${match_count} commit(s) matching '${pattern}' on origin/main since ${created_at} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+		local matching_shas
+		matching_shas=$(git -C "$repo_path" log origin/main --since="$created_at" \
+			--format='%H' -E --grep="$pattern" 2>/dev/null) || matching_shas=""
+
+		if [[ -z "$matching_shas" ]]; then
+			continue
+		fi
+
+		# Filter out planning-only commits
+		local impl_count=0
+		local sha
+		while IFS= read -r sha; do
+			[[ -z "$sha" ]] && continue
+
+			# Check 1: Subject-based exclusion for known planning prefixes
+			local subject
+			subject=$(git -C "$repo_path" log -1 --format='%s' "$sha" 2>/dev/null) || subject=""
+			if printf '%s' "$subject" | grep -qE '^(chore: claim|plan:)'; then
+				echo "[pulse-wrapper] _is_task_committed_to_main: skipping planning commit ${sha:0:10} ('${subject}') for #${issue_number}" >>"$LOGFILE"
+				continue
+			fi
+
+			# Check 2: Path-based detection — if the commit only modifies
+			# planning files (TODO.md, todo/*, AGENTS.md, .agents/AGENTS.md),
+			# it's a planning commit regardless of its subject prefix.
+			local changed_files
+			changed_files=$(git -C "$repo_path" diff-tree --no-commit-id --name-only -r "$sha" 2>/dev/null) || changed_files=""
+			if [[ -n "$changed_files" ]]; then
+				local has_impl_files=false
+				local file
+				while IFS= read -r file; do
+					[[ -z "$file" ]] && continue
+					case "$file" in
+					TODO.md | todo/* | AGENTS.md | .agents/AGENTS.md) ;;
+					*)
+						has_impl_files=true
+						break
+						;;
+					esac
+				done <<<"$changed_files"
+				if [[ "$has_impl_files" == "false" ]]; then
+					echo "[pulse-wrapper] _is_task_committed_to_main: skipping planning-files-only commit ${sha:0:10} ('${subject}') for #${issue_number}" >>"$LOGFILE"
+					continue
+				fi
+			fi
+
+			impl_count=$((impl_count + 1))
+		done <<<"$matching_shas"
+
+		if [[ "$impl_count" -gt 0 ]]; then
+			echo "[pulse-wrapper] _is_task_committed_to_main: found ${impl_count} implementation commit(s) matching '${pattern}' on origin/main since ${created_at} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 			return 0
 		fi
 	done


### PR DESCRIPTION
## Summary

Fixes the dedup layer (GH#17574) false positive where planning commits (e.g., `chore: claim t1910..t1915`) matched task IDs and blocked dispatch of genuinely unimplemented issues.

## Changes

- **File**: `.agents/scripts/pulse-wrapper.sh` — `_is_task_committed_to_main()` function (lines ~6691-6754)
- **Two-layer planning commit filter**:
  1. **Subject-based**: Skip commits with `chore: claim` or `plan:` prefixes (always planning)
  2. **Path-based**: Skip commits that only modify planning files (`TODO.md`, `todo/*`, `AGENTS.md`, `.agents/AGENTS.md`) regardless of subject prefix — this catches `docs:` commits that are actually planning edits without broadly excluding all `docs:` commits

## Why path-based instead of subject-based for docs

The previous PR #17711 used `grep -v` to exclude `docs:` commits by subject prefix. CodeRabbit correctly noted this is too broad — a `docs:` commit could contain real implementation changes. Path-based detection checks the actual files changed, which is more precise.

## Runtime Testing

- **Risk**: Low (agent prompt/dispatch logic, no user-facing runtime)
- **Verification**: `self-assessed` — ShellCheck clean on extracted function

Closes #17707

---
[aidevops.sh](https://aidevops.sh) v3.6.151 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 2m and 4,945 tokens on this as a headless worker.