### PR TITLE
GH#17707: fix _is_task_committed_to_main false positive on planning commits

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6690,12 +6690,41 @@ _is_task_committed_to_main() {
 
 	# Search recent commits on origin/main for any matching pattern.
 	# Use -E for extended regex (Closes/Fixes patterns).
+	# GH#17707: Filter out planning-only commits that mention task IDs but
+	# don't contain implementation work. Two-stage filter:
+	#   1. Subject-line filter: drop obvious planning prefixes (chore: claim, plan:)
+	#   2. Path-based filter: for remaining commits, check if ALL touched paths
+	#      are planning-only files (TODO.md, todo/*, AGENTS.md). If so, exclude.
+	# This preserves real docs: commits while filtering true planning-only commits.
 	local pattern
 	for pattern in "${search_patterns[@]}"; do
-		local match_count
-		match_count=$(git -C "$repo_path" log origin/main --since="$created_at" \
-			--oneline -E --grep="$pattern" 2>/dev/null | wc -l) || match_count=0
-		match_count=$(printf '%s' "$match_count" | tr -d '[:space:]')
+		local match_count=0
+		local commit_hash
+		# Stage 1: get matching commits, exclude obvious planning subjects
+		while IFS= read -r commit_hash; do
+			[[ -z "$commit_hash" ]] && continue
+			# Stage 2: path-based planning detection — check if ALL touched
+			# paths are planning-only files. Real implementation commits touch
+			# code files beyond TODO.md/todo/*/AGENTS.md.
+			local is_planning_only=true
+			local touched_path
+			while IFS= read -r touched_path; do
+				[[ -z "$touched_path" ]] && continue
+				case "$touched_path" in
+				TODO.md | todo/* | AGENTS.md | .agents/AGENTS.md) ;;
+				*)
+					is_planning_only=false
+					break
+					;;
+				esac
+			done < <(git -C "$repo_path" diff-tree --no-commit-id --name-only -r "$commit_hash" 2>/dev/null)
+			if [[ "$is_planning_only" == "false" ]]; then
+				match_count=$((match_count + 1))
+			fi
+		done < <(git -C "$repo_path" log origin/main --since="$created_at" \
+			--oneline -E --grep="$pattern" |
+			grep -vE '^[0-9a-f]+ (chore: claim|plan:)' |
+			cut -d' ' -f1 || true)
 		if [[ "$match_count" -gt 0 ]]; then
 			echo "[pulse-wrapper] _is_task_committed_to_main: found ${match_count} commit(s) matching '${pattern}' on origin/main since ${created_at} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 			return 0

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6722,7 +6722,7 @@ _is_task_committed_to_main() {
 				match_count=$((match_count + 1))
 			fi
 		done < <(git -C "$repo_path" log origin/main --since="$created_at" \
-			--oneline -E --grep="$pattern" |
+			-E --grep="$pattern" --format='%H %s' |
 			grep -vE '^[0-9a-f]+ (chore: claim|plan:)' |
 			cut -d' ' -f1 || true)
 		if [[ "$match_count" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- **What**: Replace the overly broad `docs:` subject-line exclusion in `_is_task_committed_to_main()` with a precise two-stage planning commit filter
- **Why**: The GH#17574 dedup layer was matching task IDs in planning commits on main and blocking dispatch for genuinely unimplemented issues. The original fix (PR #17711) excluded all `docs:` commits, but CodeRabbit correctly identified this as too broad -- real docs commits are shipped work (version-manager.sh treats `docs:*` as real shipped work)
- **How**: Two-stage filter:
  1. **Subject filter**: Drop obvious planning prefixes (`chore: claim`, `plan:`) -- these are always planning-only
  2. **Path filter**: For remaining commits, use `git diff-tree --name-only` to check if ALL touched paths are planning-only files (`TODO.md`, `todo/*`, `AGENTS.md`, `.agents/AGENTS.md`). Only exclude when every touched path is a planning file -- real implementation commits touch code files beyond these

## Files Changed

- `.agents/scripts/pulse-wrapper.sh` -- `_is_task_committed_to_main()` function (lines ~6691-6732)

## Review Feedback Addressed (from PR #17711)

- **CodeRabbit (Major)**: Replaced broad `docs:` exclusion with per-commit path-based detection using `git diff-tree`
- **Google Code Review**: Removed `2>/dev/null` from `git log` to keep stderr visible for debugging
- **CodeFactor SC2126**: Replaced `grep|wc -l` pipeline with direct counting in the loop

## Runtime Testing

- **Risk level**: Medium (pulse dispatch logic, no data mutation)
- **Testing**: ShellCheck passed with zero warnings. The fix replaces a simple pipeline filter with a per-commit path check loop -- more precise, negligible overhead since matching commits are typically 0-3 per check.

Closes #17707


---
[aidevops.sh](https://aidevops.sh) v3.6.151 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 8m and 12,127 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task commitment detection to more accurately exclude planning-only commits. The system now distinguishes between commits that implement code changes versus those limited to documentation or planning files, ensuring more reliable task status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->