### PR TITLE
GH#17699: fix remaining TZ=UTC-missing date calls across 3 scripts

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -207,8 +207,8 @@ _epoch_from_iso() {
 		local clean_date
 		clean_date="${iso_date%Z}"
 		clean_date="${clean_date%+00:00}"
-		# Try multiple formats
-		date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_date" "+%s" 2>/dev/null || echo "0"
+		# GH#17699: TZ=UTC required — macOS date interprets input as local time
+		TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_date" "+%s" 2>/dev/null || echo "0"
 	else
 		date -d "$iso_date" "+%s" 2>/dev/null || echo "0"
 	fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -795,7 +795,8 @@ _prefetch_needs_full_sweep() {
 
 	# Convert ISO timestamp to epoch (macOS date -j -f)
 	local last_epoch now_epoch
-	last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_full_sweep" "+%s" 2>/dev/null) || last_epoch=0
+	# GH#17699: TZ=UTC required — macOS date interprets input as local time
+	last_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_full_sweep" "+%s" 2>/dev/null) || last_epoch=0
 	now_epoch=$(date -u +%s)
 	local age=$((now_epoch - last_epoch))
 	if [[ "$age" -ge "$PULSE_PREFETCH_FULL_SWEEP_INTERVAL" ]]; then
@@ -10693,7 +10694,8 @@ close_stale_quality_debt_prs() {
 		local pr_num pr_updated_at pr_epoch
 		pr_num=$(printf '%s' "$pr_json" | jq -r ".[$i].number" 2>/dev/null) || continue
 		pr_updated_at=$(printf '%s' "$pr_json" | jq -r ".[$i].updatedAt" 2>/dev/null) || continue
-		pr_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$pr_updated_at" +%s 2>/dev/null ||
+		# GH#17699: TZ=UTC required — macOS date interprets input as local time
+		pr_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$pr_updated_at" +%s 2>/dev/null ||
 			date -d "$pr_updated_at" +%s 2>/dev/null || echo 0)
 
 		if [[ "$pr_epoch" -lt "$cutoff_epoch" ]]; then

--- a/.agents/scripts/tests/test-pulse-wrapper-delta-prefetch.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-delta-prefetch.sh
@@ -110,7 +110,8 @@ _prefetch_needs_full_sweep() {
 		return 0
 	fi
 	local last_epoch now_epoch
-	last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_full_sweep" "+%s" 2>/dev/null) || last_epoch=0
+	# GH#17699: TZ=UTC required — macOS date interprets input as local time
+	last_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_full_sweep" "+%s" 2>/dev/null) || last_epoch=0
 	now_epoch=$(date -u +%s)
 	local age=$((now_epoch - last_epoch))
 	if [[ "$age" -ge "$PULSE_PREFETCH_FULL_SWEEP_INTERVAL" ]]; then


### PR DESCRIPTION
## Summary

Follow-up to #17710. Audit of all `date -j -f` calls found 4 more sites parsing GitHub API UTC timestamps without `TZ=UTC`:

| File | Line | Context |
|---|---|---|
| `contribution-watch-helper.sh` | 211 | `_epoch_from_iso()` — exact same pattern as `_ts_to_epoch()` |
| `pulse-wrapper.sh` | 798 | Prefetch full-sweep interval check |
| `pulse-wrapper.sh` | 10696 | Stale PR cutoff comparison |
| `test-pulse-wrapper-delta-prefetch.sh` | 113 | Test mirror of pulse-wrapper:798 |

**Not affected** (already have `TZ=UTC` or parse local timestamps): dispatch-dedup-helper, dispatch-claim-helper, dispatch-ledger-helper, auto-update-helper, draft-response-helper, model-availability-helper, model-registry-helper, stats-functions, headless-runtime-helper, review-bot-gate-helper, conversation-helper, mcp-index-helper, local-model-helper, ai-judgment-helper, screen-time-helper, session-time-helper, gh-signature-helper, email-test-suite-helper, content-calendar-helper.

Closes #17699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp parsing behavior on macOS systems to enforce UTC timezone interpretation for ISO-8601 formatted timestamps, ensuring accurate and consistent timestamp-based calculations in automated system operations across different local timezone environments.

* **Tests**
  * Updated test cases to validate corrected macOS timestamp handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->