### PR TITLE
GH#17720: extract _parse_iso_macos_utc helper in contribution-watch-helper.sh

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -199,16 +199,21 @@ _now_iso() {
 	return 0
 }
 
+# Parse an ISO 8601 UTC timestamp to epoch seconds on macOS.
+# TZ=UTC is required: macOS date -j -f interprets the input as local time without it (GH#17699).
+_parse_iso_macos_utc() {
+	local iso_date="$1"
+	local clean_date
+	clean_date="${iso_date%Z}"
+	clean_date="${clean_date%+00:00}"
+	TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_date" "+%s" 2>/dev/null || echo "0"
+	return 0
+}
+
 _epoch_from_iso() {
 	local iso_date="$1"
-	# macOS date -j -f for parsing ISO 8601
 	if [[ "$(uname)" == "Darwin" ]]; then
-		# Handle both Z and +00:00 suffixes
-		local clean_date
-		clean_date="${iso_date%Z}"
-		clean_date="${clean_date%+00:00}"
-		# GH#17699: TZ=UTC required — macOS date interprets input as local time
-		TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_date" "+%s" 2>/dev/null || echo "0"
+		_parse_iso_macos_utc "$iso_date"
 	else
 		date -d "$iso_date" "+%s" 2>/dev/null || echo "0"
 	fi


### PR DESCRIPTION
## Summary

Extract the macOS-specific `TZ=UTC date -j -f` logic from `_epoch_from_iso()` into a dedicated `_parse_iso_macos_utc()` helper function in `contribution-watch-helper.sh`.

## What

- Added `_parse_iso_macos_utc()` helper that encapsulates: ISO suffix stripping (`%Z`, `%+00:00`) and the `TZ=UTC date -j -f` call with a single clear comment explaining why `TZ=UTC` is required (GH#17699).
- Simplified `_epoch_from_iso()` to delegate to `_parse_iso_macos_utc()` on Darwin, removing the two-comment pattern the reviewer flagged as "multiple, potentially conflicting rationales".

## Why

Addresses gemini review feedback on PR #17716 (issue #17720):
- Extract repeated `TZ=UTC date` logic into an internal helper function for maintainability.
- Ensure comments provide a single, clear justification for a design choice.

## Files Changed

- EDIT: `.agents/scripts/contribution-watch-helper.sh:202-221` — added `_parse_iso_macos_utc()`, simplified `_epoch_from_iso()`

## Runtime Testing

- Risk: **Low** (shell refactor, no logic change — same code path, same output)
- Verified: `shellcheck` passes (only pre-existing SC1091 info on source path)
- Self-assessed: function extraction with identical behaviour

Closes #17720

---
[aidevops.sh](https://aidevops.sh) v3.6.152 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 3m and 3,741 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal script organization for better maintainability and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->