### PR TITLE
GH#17722: replace $(uname) with $OSTYPE in file_size_bytes

### DIFF
--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -144,7 +144,7 @@ file_size_bytes() {
 		echo "0"
 		return 0
 	fi
-	if [[ "$(uname)" == "Darwin" ]]; then
+	if [[ "$OSTYPE" == "darwin"* ]]; then
 		stat -f '%z' "$filepath" 2>/dev/null || echo "0"
 	else
 		stat -c '%s' "$filepath" 2>/dev/null || echo "0"


### PR DESCRIPTION
## Summary

Replace `$(uname)` with `$OSTYPE` in the `file_size_bytes()` function in `.agents/scripts/opencode-db-archive.sh`.

`$(uname)` spawns a subshell on every invocation. `$OSTYPE` is a Bash built-in that provides equivalent platform detection without the fork overhead. This is especially relevant since `file_size_bytes()` is called in loops during archiving.

## Changes

- **EDIT**: `.agents/scripts/opencode-db-archive.sh:147` — `[[ "$(uname)" == "Darwin" ]]` → `[[ "$OSTYPE" == "darwin"* ]]`

## Testing

- `shellcheck` passes with zero violations.
- Logic is equivalent: `$OSTYPE` is `darwin*` on macOS, non-darwin on Linux.

## Runtime Testing

Risk: **Low** — single-line shell condition change, no logic change, no runtime environment needed.
Assessment: `self-assessed`

Closes #17722

---
[aidevops.sh](https://aidevops.sh) v3.6.152 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 1,648 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection reliability for macOS systems in database archive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->