### PR TITLE
GH#17724: fix systemctl availability check to avoid hangs in worker-watchdog.sh

### DIFF
--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -131,8 +131,9 @@ _get_scheduler_backend() {
 	Darwin) echo "launchd" ;;
 	*)
 		# Prefer systemd user services when available (GH#17369, GH#17691)
+		# Use show-environment instead of status to avoid hangs when systemd user manager is unresponsive (GH#17724)
 		if command -v systemctl >/dev/null 2>&1 &&
-			systemctl --user status >/dev/null 2>&1; then
+			systemctl --user show-environment >/dev/null 2>&1; then
 			echo "systemd"
 		else
 			echo "cron"


### PR DESCRIPTION
## Summary

- Replaces `systemctl --user status` with `systemctl --user show-environment` in `_get_scheduler_backend()` to avoid hangs when the systemd user manager is unresponsive or slow.
- The `show-environment` command is faster and more reliable for checking systemd availability, as recommended by the Gemini review bot on PR #17696.

## Changes

- **EDIT**: `.agents/scripts/worker-watchdog.sh:135` — replace `systemctl --user status` with `systemctl --user show-environment >/dev/null 2>&1`

## Testing

- `shellcheck .agents/scripts/worker-watchdog.sh` — zero violations
- Logic: `show-environment` exits 0 when systemd user manager is running, non-zero otherwise — same semantics as `status` but without the hang risk

## Runtime Testing

Risk: **Low** — single-line change to a scheduler detection helper, no runtime state affected. `self-assessed`.

Closes #17724

---
[aidevops.sh](https://aidevops.sh) v3.6.152 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 1,774 tokens on this as a headless worker.