### PR TITLE
GH#17723: tighten task brief guidance wording

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -78,7 +78,7 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 ### Briefs, Tiers, and Dispatchability
 
-**Task briefs are MANDATORY.** Every task must have `todo/tasks/{task_id}-brief.md` capturing: session origin, what, why, how, acceptance criteria, and conversation context. Use `/define` for interactive brief generation with latent criteria probing, or `/new-task` for quick creation from `templates/brief-template.md`. A task without a brief is undevelopable — the brief captures conversation context that would otherwise be lost between sessions. See `workflows/plans.md` and `scripts/commands/new-task.md`.
+- **Task briefs:** Every task must have `todo/tasks/{task_id}-brief.md` (via `/define` or `/new-task`). A task without a brief is undevelopable because it loses the implementation context needed for autonomous execution. See `workflows/plans.md` and `scripts/commands/new-task.md`.
 
 **Brief composition**: All GitHub-written content (issue bodies, PR descriptions, comments, escalation reports) follows `workflows/brief.md` — the centralised formatting workflow.
 


### PR DESCRIPTION
## Summary
- Tighten the mandatory task-brief guidance in `.agents/AGENTS.md` to keep the core file concise.
- Convert the requirement into a bullet-point operational rule for improved scannability.
- Explicitly state the technical reason: without a brief, autonomous execution loses implementation context.

## Runtime Testing
- Risk level: low (docs-only wording/format change).
- Verification: manual diff review and `git status --short --branch` clean after commit.
- Note: `markdownlint-cli2` is not available in this environment (`command not found`).

Closes #17723

---
[aidevops.sh](https://aidevops.sh) v3.6.152 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.3-codex spent 4m and 42,480 tokens on this as a headless worker.