### PR TITLE
GH#17725: include PID 1 in OpenCode runtime detection

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -146,7 +146,7 @@ _is_opencode_runtime() {
 	# Fallback: check parent process chain for "opencode"
 	local walk_pid="${PPID:-0}"
 	local walk_depth=0
-	while [[ "$walk_pid" -gt 1 ]] && [[ "$walk_depth" -lt 10 ]] 2>/dev/null; do
+	while [[ "$walk_pid" -ge 1 ]] && [[ "$walk_depth" -lt 10 ]] 2>/dev/null; do
 		local walk_comm walk_args walk_lower
 		walk_comm=$(ps -o comm= -p "$walk_pid" 2>/dev/null || echo "")
 		walk_args=$(ps -o args= -p "$walk_pid" 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- Fix `_is_opencode_runtime` to continue parent-process traversal when `walk_pid` is `1`.
- This ensures OpenCode detection does not return a false negative when the session process chain reaches PID 1.

## Testing
- `shellcheck -e SC1091 .agents/scripts/gh-signature-helper.sh`

## Runtime Testing
- Risk level: Low (single-condition shell logic fix)
- Verification method: self-assessed (static lint + targeted diff review)

Closes #17725

---
[aidevops.sh](https://aidevops.sh) v3.6.152 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.3-codex spent 3m and 26,982 tokens on this as a headless worker.