### PR TITLE
GH#17727: tighten conversation-end loop scan phrasing

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -69,7 +69,7 @@ Before non-trivial tasks, restate: (1) actual goal, (2) constraints that must ho
 - Prefer lightweight approaches. Simpler tools over heavy dependencies.
 - Crash-resilient: every process must recover from cold start by reading current state, not assuming prior steps completed. Check results (PR exists? issue closed?), not flags.
 - Finding-to-task completeness: every actionable finding in audit/review reports must become a tracked task before declaring completion.
-- Conversation-end loop scan: before declaring a task complete or moving to the next task, scan back over the full conversation for: (1) commitments made to the user that weren't fulfilled, (2) external parties affected but not notified, (3) requests displaced by troubleshooting or corrections. Internal task creation does not close external loops.
+- Conversation-end loop scan: before declaring completion or moving to the next task, scan back over the full conversation for: (1) unfulfilled user commitments, (2) unnotified external parties, and (3) requests displaced by troubleshooting or corrections. Internal task creation does not close external loops.
 
 # Claim discipline (turn-end gate)
 - Never present future intent as completed work.


### PR DESCRIPTION
## Summary
- tighten the conversation-end loop scan rule in `.agents/prompts/build.txt` to use more direct wording while preserving behavior
- align wording with the issue feedback to reduce prompt verbosity and improve parsing clarity

## Testing
- `git diff -- .agents/prompts/build.txt`

## Runtime Testing
- Risk: low (prompt text-only change)
- Verification: self-assessed (no runtime path affected)

Closes #17727

---
[aidevops.sh](https://aidevops.sh) v3.6.154 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.3-codex spent 3m and 59,249 tokens on this as a headless worker.