### PR TITLE
t1915: add qlty verification to simplification brief template and code-simplifier

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5431,6 +5431,7 @@ Tighten and restructure this agent doc. Follow \`tools/build-agent/build-agent.m
 - Content preservation: all code blocks, URLs, task ID references (\`tNNN\`, \`GH#NNN\`), and command examples must be present before and after
 - No broken internal links or references
 - Agent behaviour unchanged (test with a representative query if possible)
+- Qlty smells resolved for the target file: \`~/.qlty/bin/qlty smells --all 2>&1 | grep '${file_path}' | grep -c . | grep -q '^0$'\` (report \`SKIP\` if Qlty is unavailable, not \`FAIL\`)
 - For reference corpora: \`wc -l\` total of chapter files >= original line count minus index overhead
 
 ### Confidence: medium

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -119,6 +119,12 @@ that defines how to machine-check the criterion. See `.agents/scripts/verify-bri
   ```
 - [ ] Tests pass (`npm test` / `bun test` / project-specific)
 - [ ] Lint clean (`eslint` / `shellcheck` / project-specific)
+- [ ] Qlty smells resolved (for `#simplification` tasks): `~/.qlty/bin/qlty smells --all 2>&1 | grep '<target_file>' | grep -c . | grep -q '^0$'`
+  ```yaml
+  verify:
+    method: bash
+    run: "~/.qlty/bin/qlty smells --all 2>&1 | grep '<target_file>' | grep -c '.' | xargs test 0 -eq"
+  ```
 
 <!-- Verify block reference:
   Methods:

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -39,7 +39,7 @@ Per finding: `### [file:line_range] Category: Brief description` with sections *
 
 ### Prescriptive format for tier:simple dispatch (MANDATORY for issue creation)
 
-Format findings using `workflows/brief.md` prescriptive format. Research finding: Haiku achieves 100% success rate when issues provide verbatim oldString/newString. Simplification issues are inherently single-file, pattern-following, exact-code-known — the ideal `tier:simple` candidates. Every finding MUST include explicit Edit tool parameters:
+Format findings using `workflows/brief.md` prescriptive format. Research finding: Haiku achieves 100% success rate when issues provide verbatim oldString/newString. Simplification issues are inherently single-file, pattern-following, exact-code-known — the ideal `tier:simple` candidates. Every finding MUST include explicit Edit tool parameters, and verification MUST include a Qlty smells check for simplification targets rather than relying on shellcheck or grep alone:
 
 ```markdown
 ### [path/to/file.sh:45-52] Safe: Remove decorative emoji from log message
@@ -73,6 +73,7 @@ This format enables direct dispatch at `tier:simple` — Haiku copies the oldStr
 | Agent docs (`.md`) | All code blocks, URLs, task ID refs (`tNNN`, `GH#NNN`), command examples present before and after. **Executable templates** (code blocks containing commands workers must run — `gh`, helper scripts, verification commands) must remain as code blocks; compressing them to inline prose is a functional regression (GH#17503). |
 | TypeScript/JavaScript | `tsc --noEmit` + existing tests |
 | Configuration files | Schema validation or dry-run the consuming tool |
+| All `#simplification` targets | `~/.qlty/bin/qlty smells --all \| grep <file>` returns zero results — partial reduction is not completion |
 
 ## Classification
 


### PR DESCRIPTION
## Summary
- Add a Qlty smells verification criterion to the simplification brief template.
- Require Qlty verification in code-simplifier guidance and in pulse-wrapper-generated simplification issue bodies.

## Files changed
- EDIT: .agents/templates/brief-template.md
- EDIT: .agents/tools/code-review/code-simplifier.md
- EDIT: .agents/scripts/pulse-wrapper.sh

## Verification
- `grep -q "Qlty smells resolved" .agents/templates/brief-template.md`
- `grep -q "verification MUST include a Qlty smells check" .agents/tools/code-review/code-simplifier.md`
- `grep -q "Qlty smells resolved for the target file" .agents/scripts/pulse-wrapper.sh`
- `bash -n .agents/scripts/pulse-wrapper.sh`

## Closes
Closes #17704

---
[aidevops.sh](https://aidevops.sh) v3.6.154 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.4-mini spent 2m and 117,117 tokens on this as a headless worker.