### PR TITLE
GH#17719: fix blocking sleep and gh pr view exit code in merge pass

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8657,11 +8657,20 @@ _merge_ready_prs_for_repo() {
 
 		# Skip non-mergeable — retry UNKNOWN once (GitHub race: mergeability
 		# not yet computed for recently-pushed PRs, resolves in seconds).
+		# sleep removed: blocking sleep inside the loop stalls all subsequent
+		# PRs; a single immediate retry is sufficient for the GitHub race.
 		if [[ "$pr_mergeable" == "UNKNOWN" ]]; then
-			sleep 5
 			local _retry_mergeable
-			_retry_mergeable=$(gh pr view "$pr_number" --repo "$repo_slug" \
-				--json mergeable --jq '.mergeable' 2>/dev/null) || _retry_mergeable="UNKNOWN"
+			local _retry_output
+			# Separate local declaration from assignment to preserve exit code (SC2181).
+			_retry_output=$(gh pr view "$pr_number" --repo "$repo_slug" \
+				--json mergeable --jq '.mergeable' 2>/dev/null)
+			local _retry_exit=$?
+			if [[ $_retry_exit -eq 0 && -n "$_retry_output" ]]; then
+				_retry_mergeable="$_retry_output"
+			else
+				_retry_mergeable="UNKNOWN"
+			fi
 			if [[ "$_retry_mergeable" == "MERGEABLE" ]]; then
 				pr_mergeable="MERGEABLE"
 				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — mergeable resolved to MERGEABLE after retry" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

- Remove `sleep 5` from the UNKNOWN mergeability retry block in `_merge_ready_prs_for_repo`. A blocking sleep inside the PR loop stalls all subsequent PRs while waiting for one UNKNOWN PR to resolve — the GitHub race condition resolves fast enough that an immediate retry is sufficient.
- Separate `local` declaration from assignment for `_retry_output` to preserve the `gh pr view` exit code (ShellCheck SC2181 / reviewer finding).
- Add guard clause: check exit code and non-empty output before using the retry result; fall back to `UNKNOWN` on failure.

## Files Changed

- `EDIT: .agents/scripts/pulse-wrapper.sh:8658-8681` — UNKNOWN mergeability retry block

## Runtime Testing

`self-assessed` — shell logic change, no runtime environment required. ShellCheck passes on the modified section (full-file run OOM on 11K-line file; section-level check clean).

## Key Decisions

- Removed sleep entirely rather than replacing with a shorter sleep. The GitHub mergeability race resolves in milliseconds to seconds; the retry call itself provides sufficient delay. Adding any sleep multiplies latency across all UNKNOWN PRs in the batch.
- Used explicit `local _retry_exit=$?` pattern (capturing `$?` immediately after the command) rather than `|| fallback` to satisfy both the exit-code-in-variable requirement and the empty-guard requirement from the review feedback.

Closes #17719

---
[aidevops.sh](https://aidevops.sh) v3.6.154 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 3,129 tokens on this as a headless worker.