### PR TITLE
GH#17728: extract verbose output helper in generate-skills

### DIFF
--- a/.agents/scripts/generate-skills.sh
+++ b/.agents/scripts/generate-skills.sh
@@ -82,9 +82,17 @@ log_error() {
 	return 0
 }
 
+is_verbose_output() {
+	if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
 # Log per-file success only in verbose or dry-run mode
 log_file_success() {
-	if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+	if is_verbose_output; then
 		echo -e "${GREEN}✓${NC} $1"
 	fi
 	return 0
@@ -258,7 +266,7 @@ skipped=0
 
 # Pattern 1: Folders with matching parent .md files
 # e.g., wordpress.md + wordpress/ → wordpress/SKILL.md
-if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+if is_verbose_output; then
 	log_info ""
 	log_info "Pattern 1: Folders with parent .md files"
 fi
@@ -287,7 +295,7 @@ done < <(find "$AGENTS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 
 # Pattern 2: Nested folders without parent .md but with children
 # e.g., tools/browser/ with playwright.md, etc.
-if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+if is_verbose_output; then
 	log_info ""
 	log_info "Pattern 2: Nested folders with child .md files"
 fi
@@ -330,7 +338,7 @@ done < <(find "$AGENTS_DIR" -mindepth 2 -type d 2>/dev/null | sort)
 # Pattern 3: Standalone .md files in nested dirs without matching folders
 # e.g., services/hosting/local-hosting.md with no local-hosting/ folder
 # These were previously missed, causing discovery gaps.
-if [[ "$VERBOSE" == true || "$DRY_RUN" == true ]]; then
+if is_verbose_output; then
 	log_info ""
 	log_info "Pattern 3: Standalone .md files without matching folders"
 fi


### PR DESCRIPTION
## Summary
- Extracted the repeated `[[ \"$VERBOSE\" == true || \"$DRY_RUN\" == true ]]` check into a new `is_verbose_output()` helper in `.agents/scripts/generate-skills.sh`.
- Switched all verbose section guards and per-file logging guard to call the helper, reducing duplicated condition logic.
- Preserved behavior while improving maintainability and readability.

## Testing
- `shellcheck -e SC1091 .agents/scripts/generate-skills.sh`
- `bash .agents/scripts/generate-skills.sh --dry-run`

## Runtime Testing
- Risk level: low (shell script refactor only)
- Verification: self-assessed via static lint + dry-run execution

Closes #17728

---
[aidevops.sh](https://aidevops.sh) v3.6.154 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.3-codex spent 4m and 67,623 tokens on this as a headless worker.