### PR TITLE
GH#17707: check open PRs in dedup Layer 4 — prevent duplicate dispatch

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -738,6 +738,33 @@ has_open_pr() {
 		return 1
 	fi
 
+	# ── Check 1: Open PRs targeting this issue ──
+	# If an open PR references "Closes #NNN" or has GH#NNN / #NNN in its
+	# title, a worker already produced output — don't dispatch another.
+	# This was the missing dedup layer: has_open_pr previously only checked
+	# --state merged, so open PRs were invisible and caused duplicate dispatch.
+	local open_pr_json open_pr_count
+	open_pr_json=$(gh pr list --repo "$repo_slug" --state open \
+		--json number,title,body --limit 10 2>/dev/null) || open_pr_json="[]"
+	open_pr_count=$(printf '%s' "$open_pr_json" | jq 'length' 2>/dev/null) || open_pr_count=0
+	[[ "$open_pr_count" =~ ^[0-9]+$ ]] || open_pr_count=0
+
+	if [[ "$open_pr_count" -gt 0 ]]; then
+		local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+		local title_pattern="(GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
+		local match_pr
+		match_pr=$(printf '%s' "$open_pr_json" | jq -r --arg cp "$close_pattern" --arg tp "$title_pattern" \
+			'[.[] | select(
+				(.body // "" | test($cp; "i")) or
+				(.title // "" | test($tp))
+			)] | .[0].number // empty' 2>/dev/null) || match_pr=""
+		if [[ -n "$match_pr" ]]; then
+			printf 'open PR #%s targets issue #%s — worker already produced output\n' "$match_pr" "$issue_number"
+			return 0
+		fi
+	fi
+
+	# ── Check 2: Merged PRs (existing logic) ──
 	local query pr_json pr_count pr_number
 	for keyword in close closes closed fix fixes fixed resolve resolves resolved; do
 		query="${keyword} #${issue_number} in:body"
@@ -753,8 +780,8 @@ has_open_pr() {
 				local pr_body
 				pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null) || pr_body=""
 				# Match: keyword + optional whitespace + #NNN or owner/repo#NNN followed by a non-word char or end
-				local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
-				if ! printf '%s' "$pr_body" | grep -iqE "$close_pattern"; then
+				local close_pattern_merged="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+				if ! printf '%s' "$pr_body" | grep -iqE "$close_pattern_merged"; then
 					continue
 				fi
 				printf 'merged PR #%s references issue #%s via "%s" keyword\n' "$pr_number" "$issue_number" "$keyword"
@@ -765,6 +792,7 @@ has_open_pr() {
 		fi
 	done
 
+	# ── Check 3: Task-ID title match (merged PRs) ──
 	local task_id
 	task_id=$(printf '%s' "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || true)
 	if [[ -z "$task_id" ]]; then

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6478,14 +6478,16 @@ check_dispatch_dedup() {
 		fi
 	fi
 
-	# Layer 4: merged PR evidence for this issue/task
+	# Layer 4: open or merged PR evidence for this issue/task — if a worker
+	# already produced a PR (open or merged), don't dispatch another worker.
+	# Previously only checked --state merged, missing open PRs entirely.
 	local dedup_helper_output=""
 	if [[ -x "$dedup_helper" ]]; then
 		if dedup_helper_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>>"$LOGFILE"); then
 			if [[ -n "$dedup_helper_output" ]]; then
 				echo "[pulse-wrapper] Dedup: ${dedup_helper_output}" >>"$LOGFILE"
 			else
-				echo "[pulse-wrapper] Dedup: merged PR evidence already exists for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+				echo "[pulse-wrapper] Dedup: PR evidence already exists for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 			fi
 			return 0
 		fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8116,16 +8116,25 @@ _fast_fail_record_locked() {
 		--argjson backoff_secs "$new_backoff" \
 		'.[$k] = {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs}' 2>/dev/null) || return 0
 
+	# Flag for enrichment on first non-rate-limit failure: a reasoning worker
+	# will analyze the issue and add implementation guidance before re-dispatch.
+	# Only set once — cleared after enrichment runs.
+	local is_rate_limit=false
+	case "$reason" in
+	rate_limit* | backoff) is_rate_limit=true ;;
+	esac
+	if [[ "$is_rate_limit" == "false" && "$new_count" -eq 1 ]]; then
+		updated_state=$(printf '%s' "$updated_state" | jq \
+			--arg k "$key" \
+			'.[$k].enrichment_needed = true' 2>/dev/null) || true
+	fi
+
 	_ff_save "$updated_state"
 	echo "[pulse-wrapper] fast_fail_record: #${issue_number} (${repo_slug}) ${log_action} reason=${reason}" >>"$LOGFILE"
 
 	# Trigger tier escalation on non-rate-limit failures only (GH#2076).
 	# Rate-limit paths (rate_limit*, backoff) don't escalate — the model isn't
 	# the problem, it's provider capacity. Escalating would waste a higher tier.
-	local is_rate_limit=false
-	case "$reason" in
-	rate_limit* | backoff) is_rate_limit=true ;;
-	esac
 	if [[ "$is_rate_limit" == "false" && "$new_count" -gt "$existing_count" ]]; then
 		escalate_issue_tier "$issue_number" "$repo_slug" "$new_count" "$reason" || true
 	fi
@@ -8450,6 +8459,18 @@ dispatch_deterministic_fill_floor() {
 		echo "[pulse-wrapper] Deterministic fill floor: dispatched ${triage_dispatched} triage review(s), ${triage_remaining} slots remaining for implementation" >>"$LOGFILE"
 	fi
 	available_slots="$triage_remaining"
+
+	# Enrichment pass: analyze failed issues with reasoning before re-dispatch.
+	# Runs after triage (responsiveness) but before implementation dispatch
+	# (so enriched issues get better context on the next dispatch attempt).
+	local enrichment_remaining
+	enrichment_remaining=$(dispatch_enrichment_workers "$available_slots" 2>>"$LOGFILE") || enrichment_remaining="$available_slots"
+	[[ "$enrichment_remaining" =~ ^[0-9]+$ ]] || enrichment_remaining="$available_slots"
+	local enrichment_dispatched=$((available_slots - enrichment_remaining))
+	if [[ "$enrichment_dispatched" -gt 0 ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: dispatched ${enrichment_dispatched} enrichment worker(s), ${enrichment_remaining} slots remaining for implementation" >>"$LOGFILE"
+	fi
+	available_slots="$enrichment_remaining"
 
 	local dispatched_count=0
 	while IFS= read -r candidate_json; do
@@ -10769,6 +10790,209 @@ close_stale_quality_debt_prs() {
 			fi
 		fi
 	done
+	return 0
+}
+
+#######################################
+# Enrich failed issues with reasoning-tier analysis before re-dispatch.
+#
+# When a worker fails (premature_exit, idle kill), the issue body often
+# lacks the implementation context needed for success. This function
+# spawns an inline reasoning worker to analyze the codebase and append
+# a "## Worker Guidance" section with concrete file paths, patterns,
+# and verification commands.
+#
+# Triggered by: fast_fail_record sets enrichment_needed=true on the
+# first non-rate-limit failure. Runs at most once per issue.
+#
+# Arguments:
+#   $1 - available worker slots
+# Outputs: updated available count to stdout
+# Exit code: always 0
+#######################################
+ENRICHMENT_MAX_PER_CYCLE="${ENRICHMENT_MAX_PER_CYCLE:-2}"
+
+dispatch_enrichment_workers() {
+	local available="$1"
+	local enrichment_count=0
+
+	[[ "$available" =~ ^[0-9]+$ ]] || available=0
+	[[ "$available" -gt 0 ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
+
+	# Read fast-fail state for issues needing enrichment
+	local state
+	state=$(_ff_load)
+	[[ -n "$state" && "$state" != "{}" && "$state" != "null" ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
+
+	# Resolve reasoning model
+	local resolved_model=""
+	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
+	if [[ -z "$resolved_model" ]]; then
+		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
+	fi
+	if [[ -z "$resolved_model" ]]; then
+		echo "[pulse-wrapper] dispatch_enrichment_workers: no reasoning model available — skipping" >>"$LOGFILE"
+		printf '%d\n' "$available"
+		return 0
+	fi
+
+	# Extract keys with enrichment_needed=true
+	local enrichment_keys
+	enrichment_keys=$(printf '%s' "$state" | jq -r 'to_entries[] | select(.value.enrichment_needed == true) | .key' 2>/dev/null) || enrichment_keys=""
+
+	[[ -n "$enrichment_keys" ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
+
+	local repos_json="${REPOS_JSON:-$HOME/.config/aidevops/repos.json}"
+	local enriched_total=0
+
+	while IFS= read -r ff_key; do
+		[[ -n "$ff_key" ]] || continue
+		[[ "$enrichment_count" -lt "$ENRICHMENT_MAX_PER_CYCLE" ]] || break
+		[[ "$available" -gt 0 ]] || break
+		[[ -f "$STOP_FLAG" ]] && break
+
+		# Parse key format: "issue_number:repo_slug"
+		local issue_number repo_slug
+		issue_number="${ff_key%%:*}"
+		repo_slug="${ff_key#*:}"
+		[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
+		[[ -n "$repo_slug" ]] || continue
+
+		# Resolve repo path
+		local repo_path
+		repo_path=$(jq -r --arg s "$repo_slug" \
+			'.initialized_repos[]? | select(.slug == $s) | .path' \
+			"$repos_json" 2>/dev/null || echo "")
+		repo_path="${repo_path/#\~/$HOME}"
+		[[ -n "$repo_path" && -d "$repo_path" ]] || continue
+
+		echo "[pulse-wrapper] Enrichment: analyzing #${issue_number} in ${repo_slug} after worker failure" >>"$LOGFILE"
+
+		# Pre-fetch issue data (deterministic, no LLM)
+		local issue_body issue_title issue_comments
+		issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" \
+			--json body --jq '.body // ""' 2>/dev/null) || issue_body=""
+		issue_title=$(gh issue view "$issue_number" --repo "$repo_slug" \
+			--json title --jq '.title // ""' 2>/dev/null) || issue_title=""
+
+		# Get kill/dispatch comments for failure context
+		issue_comments=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+			--jq '[.[] | select(.body | test("CLAIM|kill|premature|BLOCKED|worker_failed|Dispatching")) | {author: .user.login, body: .body, created: .created_at}] | last(3) // []' 2>/dev/null) || issue_comments="[]"
+
+		# Build enrichment prompt
+		local prompt_file
+		prompt_file=$(mktemp)
+		cat >"$prompt_file" <<ENRICHMENT_PROMPT_EOF
+You are a reasoning-tier analyst. A worker attempted to implement issue #${issue_number} but failed.
+Your job: analyze the issue and codebase, then edit the issue body to add concrete implementation guidance.
+
+## Issue Title
+${issue_title}
+
+## Current Issue Body
+${issue_body}
+
+## Recent Comments (failure context)
+${issue_comments}
+
+## Instructions
+
+1. Read the issue body to understand the task
+2. Search the codebase (use Bash with rg/git ls-files, Read, Grep) to identify:
+   - Exact file paths that need modification
+   - Reference patterns in similar existing code
+   - The verification command to confirm completion
+3. Edit the issue body on GitHub using: gh issue edit ${issue_number} --repo ${repo_slug} --body "\$NEW_BODY"
+   - Preserve the existing body content
+   - Append a new section:
+
+## Worker Guidance
+
+**Files to modify:**
+- EDIT: path/to/file.ext:LINE_RANGE — description
+- NEW: path/to/new-file.ext — model on path/to/reference.ext
+
+**Reference pattern:** Follow the pattern at path/to/similar.ext:LINES
+
+**What the previous worker likely struggled with:** (your analysis)
+
+**Verification:** command to verify completion
+
+4. Keep analysis focused — spend at most 5 minutes. If the task is genuinely ambiguous, say so in the guidance rather than guessing.
+5. Do NOT implement the solution. Only analyze and document guidance.
+ENRICHMENT_PROMPT_EOF
+
+		# Run inline reasoning worker
+		local enrichment_output
+		enrichment_output=$(mktemp)
+
+		# shellcheck disable=SC2086
+		"$HEADLESS_RUNTIME_HELPER" run \
+			--role worker \
+			--session-key "enrichment-${issue_number}" \
+			--dir "$repo_path" \
+			--model "$resolved_model" \
+			--title "Enrichment analysis: Issue #${issue_number}" \
+			--prompt-file "$prompt_file" </dev/null >"$enrichment_output" 2>&1
+
+		local enrichment_exit=$?
+		rm -f "$prompt_file"
+
+		# Check if enrichment succeeded (issue body was edited)
+		local post_body
+		post_body=$(gh issue view "$issue_number" --repo "$repo_slug" \
+			--json body --jq '.body // ""' 2>/dev/null) || post_body=""
+
+		if [[ "$post_body" == *"Worker Guidance"* ]]; then
+			echo "[pulse-wrapper] Enrichment: successfully added Worker Guidance to #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+			enriched_total=$((enriched_total + 1))
+		else
+			echo "[pulse-wrapper] Enrichment: worker ran (exit=${enrichment_exit}) but no Worker Guidance found in #${issue_number} body (${#post_body} chars)" >>"$LOGFILE"
+		fi
+
+		rm -f "$enrichment_output"
+
+		# Mark enrichment complete in fast-fail state (regardless of success —
+		# don't retry enrichment, let normal escalation handle persistent failures)
+		_ff_with_lock _ff_mark_enrichment_done "$issue_number" "$repo_slug" || true
+
+		enrichment_count=$((enrichment_count + 1))
+		available=$((available - 1))
+	done <<<"$enrichment_keys"
+
+	if [[ "$enrichment_count" -gt 0 ]]; then
+		echo "[pulse-wrapper] dispatch_enrichment_workers: processed ${enrichment_count} issues (${enriched_total} enriched), ${available} slots remaining" >>"$LOGFILE"
+	fi
+
+	printf '%d\n' "$available"
+	return 0
+}
+
+# Mark enrichment as done in the fast-fail state (called under lock).
+_ff_mark_enrichment_done() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local key state
+
+	key=$(_ff_key "$issue_number" "$repo_slug")
+	state=$(_ff_load)
+
+	local updated_state
+	updated_state=$(printf '%s' "$state" | jq \
+		--arg k "$key" \
+		'if .[$k] then .[$k].enrichment_needed = false | .[$k].enrichment_done = true else . end' \
+		2>/dev/null) || return 0
+
+	_ff_save "$updated_state"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

`has_open_pr()` only checked `--state merged` PRs. Open PRs were invisible to the entire 7-layer dedup system. When a worker created PRs and then its dispatch comment TTL expired (30 min), the pulse dispatched another worker for the same issue — wasting tokens on duplicate work.

**Evidence:** Issue #17707 — alex-solovyev's worker created PRs #17711 and #17714 (both open). 5 minutes later, marcusquinn's pulse dispatched a third worker that created PR #17715.

## Root cause

Layer 4 (`has_open_pr`) searched `gh pr list --state merged` exclusively. The function name says "open" but it only checked merged. No other layer compensated — Layer 5 (dispatch comment) had expired, Layer 6 (assignee) was cleared by claim release.

## Fix

Add open PR check as the first step in `has_open_pr()`:
- Fetches open PRs via `gh pr list --state open`
- Matches by `Closes/Fixes/Resolves #NNN` in body OR `GH#NNN`/`#NNN` in title
- Blocks dispatch if a matching open PR exists

Falls through to existing merged PR check if no open match found.

Closes #17707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced duplicate detection for pull requests to identify both open and merged PRs that reference target issues, reducing redundant processing.

* **New Features**
  * Added automatic enrichment system for failed issues. Uses reasoning-based analysis to enhance context and improve resolution quality with controlled processing limits per cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->