### PR TITLE
GH#17707: dedup checks commit messages — closing keywords go in commits not PR bodies

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -196,10 +196,12 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 
 **Traceability (MANDATORY):**
 - PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
-- PR body MUST include exactly ONE `Closes #NNN` for the issue the PR **directly solves**.
-  GitHub auto-closes issues when PRs with `Closes/Fixes/Resolves #NNN` merge.
-  NEVER use `Closes` for context references — use `Related: #NNN` or `See #NNN` instead.
-  Evidence: GH#17584 was auto-closed twice by PRs that referenced it for context, not as the target.
+- Closing keywords (`Closes #NNN`, `Fixes #NNN`) go in **commit messages**, not PR bodies.
+  Commits are the source of truth — they represent actual code changes. PR bodies are
+  written upfront and may mention issues for context without solving them.
+  GitHub auto-closes issues from commit messages when merged to the default branch.
+  PR bodies should use `For #NNN` or `Implements #NNN` for context — never `Closes`.
+  The dedup system checks commit messages to determine if work is already in progress.
 - Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref:GH#NNN`.
 
 # 9. Worker-Ready Implementation Context (t1900 — MANDATORY)

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -738,28 +738,34 @@ has_open_pr() {
 		return 1
 	fi
 
-	# ── Check 1: Open PRs targeting this issue ──
-	# If an open PR references "Closes #NNN" or has GH#NNN / #NNN in its
-	# title, a worker already produced output — don't dispatch another.
-	# This was the missing dedup layer: has_open_pr previously only checked
-	# --state merged, so open PRs were invisible and caused duplicate dispatch.
+	# ── Check 1: Open PRs with commits that reference this issue ──
+	# The source of truth for "this PR solves this issue" is the commit
+	# messages, not the PR body. PR bodies are written at creation time
+	# (often from templates) and may mention issues for context without
+	# solving them. Commit messages are attached to actual code changes.
+	#
+	# GitHub auto-close works from commit messages on merge to default
+	# branch, so moving closing keywords from PR body to commits changes
+	# nothing for auto-close but eliminates false-positive dedup blocks.
 	local open_pr_json open_pr_count
 	open_pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--json number,title,body --limit 10 2>/dev/null) || open_pr_json="[]"
+		--json number,title,commits --limit 10 2>/dev/null) || open_pr_json="[]"
 	open_pr_count=$(printf '%s' "$open_pr_json" | jq 'length' 2>/dev/null) || open_pr_count=0
 	[[ "$open_pr_count" =~ ^[0-9]+$ ]] || open_pr_count=0
 
 	if [[ "$open_pr_count" -gt 0 ]]; then
+		# Match: closing keyword + #NNN in commit messages, or GH#NNN/#NNN in PR title
 		local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
 		local title_pattern="(GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
+
 		local match_pr
 		match_pr=$(printf '%s' "$open_pr_json" | jq -r --arg cp "$close_pattern" --arg tp "$title_pattern" \
 			'[.[] | select(
-				(.body // "" | test($cp; "i")) or
-				(.title // "" | test($tp))
+				(.title // "" | test($tp)) or
+				((.commits // [])[] | .messageHeadline // "" | test($cp; "i"))
 			)] | .[0].number // empty' 2>/dev/null) || match_pr=""
 		if [[ -n "$match_pr" ]]; then
-			printf 'open PR #%s targets issue #%s — worker already produced output\n' "$match_pr" "$issue_number"
+			printf 'open PR #%s has commits targeting issue #%s\n' "$match_pr" "$issue_number"
 			return 0
 		fi
 	fi


### PR DESCRIPTION
## Summary

Shifts the closing keyword convention from PR bodies to commit messages and updates the dedup system to match. PR bodies describe intent; commits describe work done. The dedup system should check what was actually done.

## Problem

A PR body saying `Closes #123` doesn't mean the PR solves #123 — it might reference it for context, or the worker might have failed to implement it. This caused both false-positive dedup blocks (PR mentions issue but doesn't solve it) and false-negative blocks (PR #17749 fix checked PR bodies, which are unreliable).

## Changes

- **Convention (build.txt)**: Closing keywords (`Closes #NNN`) go in commit messages, not PR bodies. PR bodies use `For #NNN` or `Implements #NNN` for context.
- **Open PR dedup**: Scans `commits[].messageHeadline` for closing keywords instead of PR body text. Also matches `GH#NNN`/`#NNN` in PR titles.
- **Merged PR check**: Kept as-is for backward compatibility (existing merged PRs have keywords in bodies).
- **GitHub auto-close**: Works from commit messages on merge to default branch — no behavior change.

For #17707