### PR TITLE
GH#17669: consolidate model tier mappings to single source of truth

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -113,9 +113,11 @@ launchctl bootout gui/$(id -u)/sh.aidevops.<name> && \
 
 **Round-robin:** Helper alternates providers in `AIDEVOPS_HEADLESS_MODELS`. Pulse requires Anthropic (sonnet) — OpenAI models exit immediately without activity, wasting every other cycle. Pin pulse with `PULSE_MODEL`; workers can use any provider.
 
+**CRITICAL:** Only use agentic-capable models in the round-robin. Codex/code-completion models (gpt-5.3-codex, gpt-5.4-codex) cannot make tool calls and will fail silently as headless workers (GH#17669). Model tiers are defined in `configs/model-routing-table.json` — the single source of truth.
+
 ```bash
 export PULSE_MODEL="anthropic/claude-sonnet-4-6"
-export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex"
+export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.4"
 ```
 
 **Backoff:** `headless-runtime-helper.sh backoff status` / `backoff clear PROVIDER`. Exit code 75 = all providers backed off.

--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -1,17 +1,18 @@
 {
-  "_comment": "Model routing table — AI reads this directly to decide fallback order. Per Intelligence Over Scripts principle, the AI decides routing; bash only checks availability.",
+  "_comment": "Model routing table — SINGLE SOURCE OF TRUTH for tier-to-model mappings. All scripts, docs, and configs should reference this file rather than hardcoding model IDs. When a new model generation releases (e.g., gpt-5.5), update ONLY this file.",
   "_docs": "See .agents/tools/context/model-routing.md for routing rules, .agents/tools/ai-assistants/fallback-chains.md for integration.",
+  "_agentic_note": "codex/code-completion models (gpt-5.3-codex, gpt-5.4-codex) are NOT agentic — zero tool calls observed (GH#17669). Never use them for headless worker dispatch. Only general-purpose models support agentic workflows.",
 
   "tiers": {
     "local":  { "models": ["local/llama.cpp"], "fallback": "haiku", "cost": 0 },
-    "haiku":  { "models": ["anthropic/claude-haiku-4-5-20251001", "google/gemini-2.5-flash-preview-05-20", "openrouter/anthropic/claude-haiku-4-5"] },
-    "flash":  { "models": ["anthropic/claude-haiku-4-5"] },
-    "sonnet": { "models": ["anthropic/claude-sonnet-4-6"] },
-    "pro":    { "models": ["anthropic/claude-sonnet-4-6"] },
-    "opus":   { "models": ["anthropic/claude-opus-4-6"] },
-    "coding": { "models": ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6"] },
-    "eval":   { "models": ["anthropic/claude-sonnet-4-6"] },
-    "health": { "models": ["anthropic/claude-sonnet-4-6"] }
+    "haiku":  { "models": ["anthropic/claude-haiku-4-5", "openai/gpt-5.4-mini"] },
+    "flash":  { "models": ["openai/gpt-5.4-mini", "openai/gpt-4.1-mini"] },
+    "sonnet": { "models": ["anthropic/claude-sonnet-4-6", "openai/gpt-5.4"] },
+    "pro":    { "models": ["google/gemini-2.5-pro", "anthropic/claude-sonnet-4-6"] },
+    "opus":   { "models": ["anthropic/claude-opus-4-6", "openai/gpt-5.4-pro"] },
+    "coding": { "models": ["anthropic/claude-opus-4-6", "openai/gpt-5.4-pro"] },
+    "eval":   { "models": ["anthropic/claude-sonnet-4-6", "openai/gpt-5.4-mini"] },
+    "health": { "models": ["anthropic/claude-sonnet-4-6", "openai/gpt-5.4-mini"] }
   },
 
   "providers": {

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -120,13 +120,26 @@ is_known_provider() {
 get_tier_models() {
 	local tier="$1"
 
+	# Read from model-routing-table.json (single source of truth).
+	# Falls back to hardcoded defaults only if the JSON file is missing.
+	local routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
+	if [[ -f "$routing_table" ]]; then
+		local models_json
+		models_json=$(jq -r --arg t "$tier" \
+			'.tiers[$t].models // empty | join("|")' \
+			"$routing_table" 2>/dev/null) || models_json=""
+		if [[ -n "$models_json" ]]; then
+			echo "$models_json"
+			return 0
+		fi
+	fi
+
+	# Hardcoded fallback — kept in sync with model-routing-table.json.
+	# If you're editing these, update the JSON file instead.
 	case "$tier" in
 	local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 	haiku) echo "anthropic/claude-haiku-4-5|openai/gpt-5.4-mini" ;;
 	flash) echo "openai/gpt-5.4-mini|openai/gpt-4.1-mini" ;;
-	# GH#17669: codex models are code-completion, not agentic — zero tool calls
-	# observed when dispatched as headless workers. Use general-purpose gpt-5.4
-	# variants as fallbacks instead.
 	sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-5.4" ;;
 	pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
 	opus) echo "anthropic/claude-opus-4-6|openai/gpt-5.4-pro" ;;

--- a/.agents/tools/ai-assistants/models-README.md
+++ b/.agents/tools/ai-assistants/models-README.md
@@ -35,10 +35,12 @@ Tiers define fallback chains for provider failures (API error, timeout, rate lim
 ```yaml
 fallback-chain:
   - anthropic/claude-sonnet-4-6
-  - openai/gpt-5.3-codex
+  - openai/gpt-5.4
   - google/gemini-2.5-pro
   - openrouter/anthropic/claude-sonnet-4-6
 ```
+
+> **Note:** codex/code-completion models (gpt-5.3-codex, gpt-5.4-codex) are NOT agentic and must never appear in fallback chains. See `configs/model-routing-table.json` for the canonical tier→model mappings.
 
 - **Per-tier override:** Add `fallback-chain:` to model subagent frontmatter.
 - **Global defaults:** `configs/fallback-chain-config.json`.

--- a/.agents/tools/ai-assistants/models-opus.md
+++ b/.agents/tools/ai-assistants/models-opus.md
@@ -3,10 +3,10 @@ description: Highest-capability model for architecture decisions, novel problems
 mode: subagent
 model: anthropic/claude-opus-4-6
 model-tier: opus
-model-fallback: openai/gpt-5.4
+model-fallback: openai/gpt-5.4-pro
 fallback-chain:
   - anthropic/claude-opus-4-6
-  - openai/gpt-5.4
+  - openai/gpt-5.4-pro
   - anthropic/claude-sonnet-4-6
   - openrouter/anthropic/claude-opus-4-6
 tools:

--- a/.agents/tools/ai-assistants/models-sonnet.md
+++ b/.agents/tools/ai-assistants/models-sonnet.md
@@ -3,10 +3,10 @@ description: Balanced model for code implementation, review, and most developmen
 mode: subagent
 model: anthropic/claude-sonnet-4-6
 model-tier: sonnet
-model-fallback: openai/gpt-5.3-codex
+model-fallback: openai/gpt-5.4
 fallback-chain:
   - anthropic/claude-sonnet-4-6
-  - openai/gpt-5.3-codex
+  - openai/gpt-5.4
   - google/gemini-2.5-pro
   - openrouter/anthropic/claude-sonnet-4-6
 tools:


### PR DESCRIPTION
## Summary

Model-to-tier mappings were scattered across 7 locations. When gpt-5.3-codex was identified as non-agentic (GH#17669), only some locations were updated — the round-robin config and several docs still referenced it, causing half of all worker dispatches to fail silently.

## Root cause

`AIDEVOPS_HEADLESS_MODELS` in credentials.sh had `gpt-5.3-codex` as the OpenAI fallback. Codex models are code-completion only — zero tool calls in agentic sessions. Every other dispatch attempt got this model via round-robin and died immediately.

## Changes

- **`model-routing-table.json`** is now the single source of truth with OpenAI fallbacks for every tier
- **`get_tier_models()`** reads from the JSON file first, hardcoded fallback only if file missing
- **Replaced gpt-5.3-codex** with correct agentic models everywhere:
  - `automate.md`: gpt-5.3-codex → gpt-5.4
  - `models-sonnet.md`: gpt-5.3-codex → gpt-5.4
  - `models-opus.md`: gpt-5.4 → gpt-5.4-pro (correct tier match)
  - `models-README.md`: gpt-5.3-codex → gpt-5.4 + warning about codex
- **Added agentic note** to routing table header warning against codex models

## Manual step required

The runtime config needs updating in a terminal (not committed to git):
```bash
sed -i '' 's/gpt-5.3-codex/gpt-5.4/g' ~/.config/aidevops/credentials.sh
sed -i '' 's/gpt-5.3-codex/gpt-5.4/g' ~/.config/aidevops/tenants/default/credentials.sh
```

For #17669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which AI model variants are incompatible with headless worker dispatch.
  * Updated model tier documentation with revised fallback selections.

* **Chores**
  * Updated AI model routing configuration across multiple tiers.
  * Centralized model routing as a single source of truth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->