### PR TITLE
t1921: Add objective tier assignment validation to prevent mis-tagging

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -84,10 +84,11 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 **Model tiers**: Use GitHub labels to set the model tier. The pulse reads these labels for tier routing, not `model:` in `TODO.md`. See `reference/task-taxonomy.md`. **Brief quality determines which model tier can execute** — never assign a tier without verifying the brief meets that tier's prerequisites:
 
-- `tier:simple`: Haiku — requires a brief with verbatim code blocks, explicit file paths, and copy-pasteable implementation. Single-file edits, config tweaks. **Never assign without verifying code blocks exist in the brief.**
-- `tier:standard`: Sonnet — standard implementation, bug fixes, refactors. Narrative briefs with file references are sufficient. Use when uncertain.
-- `tier:reasoning`: Opus — architecture, novel design, deep reasoning, security audits.
+- `tier:simple`: Haiku — requires a brief with verbatim code blocks, explicit file paths, and copy-pasteable implementation. **Hard disqualifiers:** >2 files, skeleton code blocks, error/fallback logic to design, estimate >1h, >4 acceptance criteria, judgment keywords (see `reference/task-taxonomy.md` "Tier Assignment Validation"). Never assign without checking the disqualifier list.
+- `tier:standard`: Sonnet — standard implementation, bug fixes, refactors. Narrative briefs with file references are sufficient. Use when uncertain. This is the default tier.
+- `tier:reasoning`: Opus — architecture, novel design with no existing pattern to follow, deep reasoning, security audits.
 - **Cascade dispatch**: The pulse may start at `tier:simple` and escalate through tiers if the worker fails, accumulating context at each level. See `reference/task-taxonomy.md` "Cascade Dispatch Model".
+- **Tier checklist**: The brief template (`templates/brief-template.md`) includes a mandatory tier checklist. Complete it before assigning a tier — it catches obvious mis-classifications that waste dispatch cycles.
 
 **Dispatchability gate**: Before recommending a tier (in reviews, triage, task creation), verify: (1) brief exists, (2) brief quality matches the tier's prerequisites, (3) TODO entry exists with `ref:GH#NNN`, (4) task ID claimed via `claim-task-id.sh`. A task missing any of these is not dispatchable — flag what's missing rather than assigning a tier the task can't satisfy.
 

--- a/.agents/reference/task-taxonomy.md
+++ b/.agents/reference/task-taxonomy.md
@@ -44,6 +44,47 @@ Tiers route tasks to models with appropriate capability. The pulse resolves labe
 - **Cascade dispatch:** The pulse may start at `tier:simple` and escalate through `tier:standard` → `tier:reasoning` if the worker fails. Each tier's attempt produces a structured escalation report (see `templates/escalation-report-template.md`) that gives the next tier pre-digested context.
 - **Backward compatibility:** `tier:thinking` is accepted as an alias for `tier:reasoning` during transition. Scripts match both labels.
 
+## Tier Assignment Validation
+
+The cascade model tolerates initial mis-classification, but obvious mis-tiers waste compute on guaranteed failures. A 6-file task tagged `tier:simple` will fail at every simple-tier attempt before escalating — burning dispatches for no value. Apply these hard rules at task creation time.
+
+### tier:simple Disqualifiers
+
+If **any** of the following are true, the task is **not** `tier:simple`. Use `tier:standard` or higher.
+
+| # | Disqualifier | Rationale |
+|---|-------------|-----------|
+| 1 | >2 files to modify | Simple-tier models cannot coordinate multi-file changes reliably |
+| 2 | Code blocks are skeletons, not complete | `tier:simple` requires exact oldString/newString or full file content; if the worker must invent logic, it needs judgment |
+| 3 | Conditional logic or branching to design | "if enabled, do X; if gateway fails, fall back to Y" requires reasoning about states |
+| 4 | Error handling, retry, or fallback logic | Designing resilience patterns is not copy-paste work |
+| 5 | Estimate >1h | Simple tasks are mechanical; longer estimates signal reasoning work |
+| 6 | >4 acceptance criteria | Many criteria = many things to coordinate and verify |
+| 7 | Keywords in brief: "graceful degradation", "fallback", "retry", "conditional", "coordinate", "design" | These signal judgment, not transcription |
+| 8 | Cross-package changes (multiple `packages/` dirs, multiple apps) | Cross-boundary reasoning exceeds simple-tier capability |
+
+### tier:standard vs tier:reasoning Signals
+
+| Signal | tier:standard | tier:reasoning |
+|--------|--------------|----------------|
+| Files | 2-8, within one package/module | Many, cross-cutting, or unknown at brief time |
+| Pattern | Follow existing patterns with adaptation | No existing pattern; must design from scratch |
+| Decisions | Implementation choices (which API, which pattern) | Architectural choices (what abstraction, what trade-offs) |
+| Error modes | Known error modes with documented recovery | Novel failure modes requiring analysis |
+| Brief detail | Code skeletons with function signatures | Approach description with constraints |
+
+### Quick-Check at Creation Time
+
+Before assigning a tier, verify these in order. Stop at the first failure:
+
+1. **Count files in "Files to Modify"** — >2 files disqualifies `tier:simple`
+2. **Check code blocks** — skeletons or pseudocode disqualifies `tier:simple`; must be exact, copy-pasteable edits
+3. **Scan for judgment keywords** — fallback, retry, graceful, conditional, coordinate, design in the brief disqualifies `tier:simple`
+4. **Check estimate** — >1h disqualifies `tier:simple`
+5. **When uncertain** — `tier:standard` (the default exists for this reason)
+
+See `templates/brief-template.md` "Tier checklist" for the structured version used during task creation.
+
 ## Cascade Dispatch Model
 
 Instead of classifying tasks to the "correct" tier upfront, the cascade model starts cheap and escalates with knowledge:

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -25,12 +25,28 @@ mode: subagent
 ## Tier
 
 <!-- Recommended model tier. Determines cascade dispatch starting point.
-     See reference/task-taxonomy.md for criteria and cascade model. -->
+     See reference/task-taxonomy.md for full criteria, disqualifiers, and cascade model.
+     The checklist below is MANDATORY — it prevents mis-tagging that wastes
+     compute on guaranteed-to-fail dispatches (see t1921). -->
 
-`tier:simple` | `tier:standard` | `tier:reasoning`
+### Tier checklist (verify before assigning)
 
-**Tier rationale:** {Why this tier — e.g., "Single-file edit with exact code block provided → tier:simple"
-or "Multi-file refactor requiring judgment about which pattern to follow → tier:standard"}
+Answer each question for `tier:simple`. If **any** answer is "no", use `tier:standard` or higher.
+
+- [ ] **2 or fewer files to modify?** (count the Files to Modify section below)
+- [ ] **Complete code blocks for every edit?** (exact oldString/newString, not skeletons)
+- [ ] **No judgment or design decisions?** (no "choose between", "design", "coordinate")
+- [ ] **No error handling or fallback logic to design?** (no "graceful", "retry", "fallback")
+- [ ] **Estimate 1h or less?**
+- [ ] **4 or fewer acceptance criteria?**
+
+All checked = `tier:simple`. Any unchecked = `tier:standard` (default) or `tier:reasoning` (no existing pattern to follow).
+
+**Selected tier:** `tier:simple` | `tier:standard` | `tier:reasoning`
+
+**Tier rationale:** {1-2 sentences justifying the tier choice, referencing which checklist items
+drove the decision. e.g., "6 files across 3 packages, fallback retry logic needed -> tier:standard"
+or "Single-file config edit with exact code block provided -> tier:simple"}
 
 ## How (Approach)
 


### PR DESCRIPTION
## Summary

- Adds a "Tier Assignment Validation" section to `reference/task-taxonomy.md` with hard, machine-checkable disqualifiers for `tier:simple` (>2 files, skeleton code blocks, error/fallback logic, estimate >1h, >4 acceptance criteria, judgment keywords)
- Restructures the Tier section in `templates/brief-template.md` with a mandatory checklist that must be verified before assigning `tier:simple`
- Updates `AGENTS.md` tier guidance to reference the disqualifier list

## Motivation

Observed in `<webapp>/<webapp>#2112`: a 6-file Cloudflare AI Gateway integration task was tagged `tier:simple` and burned through 6 failed dispatch attempts (2x Opus, 4x GPT-5.4-mini) before the cascade system escalated to `tier:standard`. Every simple-tier attempt was guaranteed to fail because the task required multi-file coordination, error handling design, and conditional logic — none of which are simple-tier work.

The root cause: tier criteria were qualitative ("single-file edits following existing patterns") with no hard gates. The brief template had a free-text rationale field that the creator skipped entirely.

## What Changed

| File | Change |
|------|--------|
| `.agents/reference/task-taxonomy.md` | New "Tier Assignment Validation" section: 8 hard disqualifiers for `tier:simple`, `tier:standard` vs `tier:reasoning` signal table, quick-check procedure |
| `.agents/templates/brief-template.md` | Tier section restructured: mandatory checklist (6 yes/no questions), structured rationale requiring checklist references |
| `.agents/AGENTS.md` | Updated tier descriptions to reference disqualifier list, added tier checklist mention |

## Runtime Testing

- **Risk:** Low (docs/guidance only, no code paths affected)
- **Verification:** `self-assessed` — markdown lint clean (0 new violations), content review confirms checklist items match disqualifier table

For #17764


---
[aidevops.sh](https://aidevops.sh) v3.6.157 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 9m and 10,381 tokens on this with the user in an interactive session.