### PR TITLE
t1918: fix silent gh auth failure in approval-helper.sh under sudo on Linux

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -166,7 +166,7 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Review Bot Gate (t1382):** Before merging: `review-bot-gate-helper.sh check <PR_NUMBER>`. Read bot reviews before merging. Full workflow: `reference/review-bot-gate.md`.
 
-**Cryptographic issue/PR approval (human-only gate):** `sudo aidevops approve issue <number>` — SSH-signed approval comment; workers cannot forge it (private key is root-only). Setup once with `sudo aidevops approve setup`. Verify: `aidevops approve verify <number>`. This is distinct from the `ai-approved` label (which is a simple collaborator gate, not cryptographic).
+**Cryptographic issue/PR approval (human-only gate):** `sudo aidevops approve issue <number> [owner/repo]` — SSH-signed approval comment; workers cannot forge it (private key is root-only). Setup once with `sudo aidevops approve setup`. Verify: `aidevops approve verify <number>`. This is distinct from the `ai-approved` label (which is a simple collaborator gate, not cryptographic).
 
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -78,6 +78,15 @@ _print_error() {
 	return 0
 }
 
+_require_gh_auth() {
+	if ! gh auth status >/dev/null 2>&1; then
+		_print_error "gh authentication failed (common under sudo on Linux — gnome-keyring is inaccessible)"
+		_print_info "Workaround: export GH_TOKEN before sudo, or run: sudo GH_TOKEN=\$(gh auth token) aidevops approve ..."
+		return 1
+	fi
+	return 0
+}
+
 _require_number_arg() {
 	local value="${1:-}"
 	local noun="$2"
@@ -276,6 +285,7 @@ _approve_target() {
 	local actual_key
 	actual_key=$(_approval_private_key_path)
 	_require_approval_key "$actual_key" || return 1
+	_require_gh_auth || return 1
 
 	slug=$(_resolve_slug_or_fail "$slug" "$slug_error") || return 1
 
@@ -297,9 +307,15 @@ _approve_target() {
 	rm -f "$sig_file"
 
 	if [[ "$target_type" == "issue" ]]; then
-		gh issue comment "$target_number" --repo "$slug" --body "$comment_body" >/dev/null 2>&1
+		if ! gh issue comment "$target_number" --repo "$slug" --body "$comment_body"; then
+			_print_error "Failed to post approval comment on issue #$target_number"
+			return 1
+		fi
 	else
-		gh pr comment "$target_number" --repo "$slug" --body "$comment_body" >/dev/null 2>&1
+		if ! gh pr comment "$target_number" --repo "$slug" --body "$comment_body"; then
+			_print_error "Failed to post approval comment on PR #$target_number"
+			return 1
+		fi
 	fi
 
 	_post_issue_approval_updates "$target_type" "$target_number" "$slug"


### PR DESCRIPTION
## Summary
- Add a gh auth pre-check in `approval-helper.sh` so `sudo aidevops approve` fails loudly when Linux sudo sessions cannot access stored gh credentials.
- Check `gh issue comment` and `gh pr comment` exit codes before reporting approval success, and document the optional `[owner/repo]` positional argument.

## Testing
- `shellcheck .agents/scripts/approval-helper.sh`
- `rg -n "_require_gh_auth|gh issue comment.*>/dev/null 2>&1|gh pr comment.*>/dev/null 2>&1|GH_TOKEN|owner/repo" .agents/scripts/approval-helper.sh .agents/AGENTS.md`

## Runtime Testing
- Risk: low
- Status: self-assessed
- Reason: shell script and documentation changes only; no runtime environment needed for safe verification.

## Context
- Implements #17754


---
[aidevops.sh](https://aidevops.sh) v3.6.158 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.4 spent 3m and 66,515 tokens on this as a headless worker.
