### PR TITLE
t1920: fix planning filter false positive

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6791,7 +6791,7 @@ _is_task_committed_to_main() {
 			while IFS= read -r touched_path; do
 				[[ -z "$touched_path" ]] && continue
 				case "$touched_path" in
-				TODO.md | todo/* | AGENTS.md | .agents/AGENTS.md) ;;
+				TODO.md | todo/* | AGENTS.md | .agents/AGENTS.md | */docs/* | docs/*) ;;
 				*)
 					is_planning_only=false
 					break
@@ -6803,7 +6803,7 @@ _is_task_committed_to_main() {
 			fi
 		done < <(git -C "$repo_path" log origin/main --since="$created_at" \
 			-E --grep="$pattern" --format='%H %s' |
-			grep -vE '^[0-9a-f]+ (chore: claim|plan:)' |
+			grep -vE '^[0-9a-f]+ (chore: claim|plan:|p[0-9]+:)' |
 			cut -d' ' -f1 || true)
 		if [[ "$match_count" -gt 0 ]]; then
 			echo "[pulse-wrapper] _is_task_committed_to_main: found ${match_count} commit(s) matching '${pattern}' on origin/main since ${created_at} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"


### PR DESCRIPTION
## Summary
- Treat `p[0-9]+:` planning commits as planning-only in the main-commit filter.
- Treat `docs/` paths as planning-only alongside TODO and AGENTS files.

## Verification
- `shellcheck -s bash -` on the changed snippet
- `printf '%s\n' 'ed66537 p002: add Phase 10 plan' | grep -vE '^[0-9a-f]+ (chore: claim|plan:|p[0-9]+:)'` returns no output
- `case "shared/deep-research/docs/design-cross-topic-knowledge-compounding.md" in TODO.md|todo/*|AGENTS.md|.agents/AGENTS.md|*/docs/*|docs/*) echo planning;; *) echo impl;; esac` returns `planning`

Closes #17761

---
[aidevops.sh](https://aidevops.sh) v3.6.158 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.4-mini spent 1m and 46,604 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Refined commit filtering logic to exclude documentation-only changes from evidence of committed work to main.
* Broadened planning-only commit subject filtering with additional pattern matching criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->