### PR TITLE
GH#17754: fix PR↔issue linkage — require Resolves #NNN in PR bodies

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -196,14 +196,16 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 
 **Traceability (MANDATORY):**
 - PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
-- Closing keywords (`Closes #NNN`, `Fixes #NNN`) go in **code fix commit messages only**.
-  NEVER in planning-only commits (TODO entries, briefs, docs). Planning commits that
-  touch TODO.md or todo/* must use `For #NNN` or `Ref #NNN` — these reference the issue
-  without triggering GitHub's auto-close. Reserve `Closes`/`Fixes` for the commit that
-  contains the actual implementation code.
-  GitHub auto-closes issues from commit messages when merged to the default branch.
-  PR bodies should use `For #NNN` or `Implements #NNN` for context — never `Closes`.
-  The dedup system checks commit messages to determine if work is already in progress.
+- **PR bodies MUST use `Resolves #NNN`** to link the PR to its issue. GitHub only
+  creates the sidebar "Development" link (PR↔issue) when the PR body contains a closing
+  keyword (`Closes`, `Fixes`, `Resolves`). Without it, the audit trail is broken — you
+  can navigate from issue→commit but not issue↔PR. `Resolves` only triggers closure
+  when the PR *merges*, so there is no risk of premature closure.
+- **Planning-only commits** (TODO entries, briefs, docs) must use `For #NNN` or
+  `Ref #NNN` — these reference the issue without triggering GitHub's auto-close.
+  NEVER use `Closes`/`Fixes` in commits that only touch TODO.md or todo/*.
+- **Code fix commit messages** may use `Fixes #NNN` — auto-closes when merged to
+  the default branch. The dedup system checks commit messages to detect in-progress work.
 - Every dispatched task MUST have a GitHub issue. Issue number in TODO.md as `ref:GH#NNN`.
 
 # 9. Worker-Ready Implementation Context (t1900 — MANDATORY)

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -22,7 +22,7 @@ gh_issue=$(grep -E '^\s*- \[.\] <task-id> ' TODO.md 2>/dev/null | grep -oE 'ref:
 pr_body='WIP - incremental commits'
 [[ -n "$gh_issue" ]] && pr_body="${pr_body}
 
-Ref #${gh_issue}"
+Resolves #${gh_issue}"
 SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model "$ANTHROPIC_MODEL" 2>/dev/null || echo "")
 pr_body="${pr_body}${SIG_FOOTER}"
 gh pr create --draft --title '<task-id>: <description>' --body "$pr_body"

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -101,7 +101,7 @@ Changelog: `feat:` → Added, `fix:` → Fixed, `docs:`/`perf:`/`refactor:` → 
 
 **4.1 Preflight:** quality checks, auto-fixes.
 
-**4.2 PR Create:** rebase onto `origin/main`, push, create PR. Body MUST include `Closes #NNN`. Add `origin:worker` or `origin:interactive` label.
+**4.2 PR Create:** rebase onto `origin/main`, push, create PR. Body MUST include `Resolves #NNN` (creates GitHub sidebar link between PR and issue; only auto-closes issue when PR merges). Add `origin:worker` or `origin:interactive` label.
 
 **Signature footer (GH#12805 — MANDATORY):** append `gh-signature-helper.sh footer` output. Verify: `gh pr view --json body | jq -e '.body | (contains("aidevops.sh") and (contains("spent") or contains("Overall,")))'`.
 
@@ -136,7 +136,7 @@ If you need to check the gate without merging: `full-loop-helper.sh pre-merge-ga
 
 **4.6 Auto-Release (aidevops only):** `version-manager.sh bump patch`, tag, push, `gh release create`, `setup.sh --non-interactive`.
 
-**4.7 Closing Comments (MANDATORY):** post structured closing comment on **both** issue AND PR: What done, Testing Evidence, Key decisions, Files changed, Blockers, Follow-up, Released in. PR comment: `Closes #NNN`. Issue comment: `PR #NNN`. **Pre-close verification (GH#17372):** Only close an issue if your session created the fixing PR. Never close citing someone else's PR without running `verify-issue-close-helper.sh check`.
+**4.7 Closing Comments (MANDATORY):** post structured closing comment on **both** issue AND PR: What done, Testing Evidence, Key decisions, Files changed, Blockers, Follow-up, Released in. PR comment: `Resolves #NNN`. Issue comment: `PR #NNN`. **Pre-close verification (GH#17372):** Only close an issue if your session created the fixing PR. Never close citing someone else's PR without running `verify-issue-close-helper.sh check`.
 
 **4.8 Postflight + Deploy:** verify release health; `setup.sh --non-interactive`. Emit: `<promise>FULL_LOOP_COMPLETE</promise>`.
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6160,7 +6160,7 @@ reap_zombie_workers() {
 
 		# Check if a merged PR exists that closes this issue
 		local merged_pr
-		merged_pr=$(gh pr list --repo "$repo_slug" --state merged --search "closes #${issue_number} OR Closes #${issue_number}" \
+		merged_pr=$(gh pr list --repo "$repo_slug" --state merged --search "closes #${issue_number} OR Closes #${issue_number} OR Resolves #${issue_number} OR resolves #${issue_number}" \
 			--limit 1 --json number --jq '.[0].number' 2>/dev/null) || merged_pr=""
 
 		if [[ -n "$merged_pr" && "$merged_pr" != "null" ]]; then

--- a/.agents/tools/autoagent/autoagent.md
+++ b/.agents/tools/autoagent/autoagent.md
@@ -212,7 +212,7 @@ gh pr create \
   --title "autoagent({PROGRAM_NAME}): {improvement_pct:+.1f}% improvement in {METRIC_NAME}" \
   --body "$(generate_completion_summary)
 
-Closes #{issue_number_if_any}"
+Resolves #{issue_number_if_any}"
 ```
 
 **3.4 Store PR memory:**

--- a/.agents/tools/autoresearch/autoresearch/completion.md
+++ b/.agents/tools/autoresearch/autoresearch/completion.md
@@ -99,7 +99,7 @@ gh pr create \
   --title "experiment({PROGRAM_NAME}): {improvement_pct:+.1f}% improvement in {METRIC_NAME}" \
   --body "$(generate_completion_summary)
 
-Closes #{issue_number_if_any}"
+Resolves #{issue_number_if_any}"
 ```
 
 **3.6 Store PR memory:**

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -54,7 +54,7 @@ tools:
 # GitHub
 git push -u origin HEAD
 gh pr create --fill                                    # Auto-fill from commits
-gh pr create --title "feat: ..." --body "Closes #123"  # Custom title/body
+gh pr create --title "feat: ..." --body "Resolves #123"  # Custom title/body
 gh pr create --fill --draft                            # Draft PR
 gh pr create --fill --reviewer @username,@team         # With reviewers
 # GitLab: glab mr create --fill  |  Gitea: tea pulls create --title "feat: ..."


### PR DESCRIPTION
## Summary

- **Root cause**: `build.txt:205` told workers "PR bodies should use `For #NNN` — never `Closes`", which prevented GitHub from creating sidebar Development links between PRs and issues. The audit trail was broken — commits linked to issues but PRs did not.
- **Fix**: Rewrote the traceability policy to require `Resolves #NNN` in all PR bodies. Updated all 7 PR creation paths to be consistent.
- **Why `Resolves`**: PR body closing keywords only auto-close issues on *merge* (not on PR creation), so there was never a risk of premature closure. The original rule over-reached from a valid concern about planning commits.

## Files Changed

- EDIT: `.agents/prompts/build.txt` — rewrote traceability rules (the system prompt policy that caused the bug)
- EDIT: `.agents/prompts/worker-efficiency-protocol.md` — draft PR body `Ref #` → `Resolves #`
- EDIT: `.agents/scripts/commands/full-loop.md` — standardized on `Resolves #NNN`
- EDIT: `.agents/scripts/pulse-wrapper.sh` — merged-PR search now matches `Resolves #NNN`
- EDIT: `.agents/tools/autoagent/autoagent.md` — PR template `Closes #` → `Resolves #`
- EDIT: `.agents/tools/autoresearch/autoresearch/completion.md` — PR template `Closes #` → `Resolves #`
- EDIT: `.agents/workflows/pr.md` — example `Closes #123` → `Resolves #123`

## Runtime Testing

- Risk: medium (changes system prompt policy that governs all PR creation)
- Status: self-assessed — all changes are documentation/policy, the shell script change is a search string addition
- Verification: `rg "Resolves #" .agents/prompts/build.txt .agents/prompts/worker-efficiency-protocol.md .agents/scripts/commands/full-loop.md .agents/workflows/pr.md .agents/tools/autoagent/autoagent.md .agents/tools/autoresearch/autoresearch/completion.md` should return 7+ matches

Resolves #17754
Resolves #17755

---
[aidevops.sh](https://aidevops.sh) v3.6.158 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 31m on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub issue-linking conventions across PR templates, workflows, and automated tools to consistently use `Resolves #NNN` instead of `Closes #NNN` for issue resolution references.

* **Chores**
  * Updated internal workflow scripts and automation tools to recognize and generate standardized issue-resolution keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->