### PR TITLE
t1923: add recurring routines system to harness docs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -172,6 +172,36 @@ Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 
 ---
 
+## Recurring Routines
+
+Routines are repeating TODOs — recurring operational jobs tracked as first-class items in a private `aidevops-routines` repo.
+
+**Setup**: `aidevops init-routines` scaffolds a private routines repo (always private, enforced). Supports `--org <name>` for per-org repos and `--local` for no-remote.
+
+**Definition format** (in the routines repo's `TODO.md`):
+
+```markdown
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [x] r002 Daily health check repeat:daily(@06:00) ~2m run:custom/scripts/health-check.sh
+- [ ] r003 Monthly content review repeat:monthly(1@09:00) ~15m agent:Content
+```
+
+- `[x]` = enabled, `[ ]` = disabled. Pulse skips disabled routines.
+- `repeat:` — schedule: `daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, `cron(expr)`
+- `run:` — script path (relative to `~/.aidevops/agents/`). Executes directly, zero LLM tokens.
+- `agent:` — agent name. Dispatched via `headless-runtime-helper.sh` (uses LLM tokens).
+- `r`-prefix IDs (`r001`) distinguish routines from tasks (`t001`).
+
+**Dispatch**: The pulse evaluates `repeat:` entries each cycle. `run:` routines execute as scripts (no LLM cost). `agent:` routines dispatch via the headless runtime. No separate crontab/launchd entries per routine.
+
+**Custom automation**: Scripts and agents for routines live in `~/.aidevops/agents/custom/scripts/` and `custom/agents/` — survives framework updates.
+
+**Tracking**: Each routine gets a GitHub issue in the routines repo. The issue description is a living summary (updated after each execution with metrics, streak, next-run). Comments are for user-LLM discussions about modifications. Detailed logs stay local at `~/.aidevops/.agent-workspace/cron/`.
+
+**Comment handling**: The pulse monitors routine issues for new comments (same infrastructure as contribution-watch). Modification requests create TODOs; questions get LLM responses; action requests for other repos create issues in the target repo.
+
+Full reference: `reference/routines.md`. Setup: `/init-routines`. Design routines: `/routine`.
+
 ## Operational Routines (Non-Code Work)
 
 Not every autonomous task should use `/full-loop`. Use this decision rule:

--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -21,7 +21,7 @@ subagents:
 
 You dispatch workers, merge PRs, coordinate scheduled tasks, and monitor background processes. You do NOT write application code — route that to Build+ or domain agents.
 
-**Scope:** pulse supervisor, worker-watchdog, scheduled routines, launchd/cron, dispatch troubleshooting, provider backoff.
+**Scope:** pulse supervisor, worker-watchdog, scheduled routines, recurring routine dispatch, launchd/systemd, dispatch troubleshooting, provider backoff.
 **Not scope:** features, bugs, refactors, tests, code review.
 
 ## Quick Reference
@@ -35,6 +35,8 @@ You dispatch workers, merge PRs, coordinate scheduled tasks, and monitor backgro
 - Workers: `pgrep -af "opencode run" | grep -v language-server`
 - Backoff: `headless-runtime-helper.sh backoff status|clear PROVIDER`
 - Circuit breaker: `circuit-breaker-helper.sh check|record-success|record-failure`
+- Routines: `routine-schedule-helper.sh is-due|next-run EXPR` / `routine-log-helper.sh update|notable|status`
+- Routine state: `~/.aidevops/.agent-workspace/routine-state.json`
 
 <!-- AI-CONTEXT-END -->
 
@@ -122,6 +124,30 @@ export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.4"
 
 **Backoff:** `headless-runtime-helper.sh backoff status` / `backoff clear PROVIDER`. Exit code 75 = all providers backed off.
 **Escalation:** After 2+ failed attempts, use `--model anthropic/claude-opus-4-6`. One opus dispatch (~3x cost) is cheaper than 5+ failed sonnet dispatches.
+
+## Recurring Routines
+
+The pulse evaluates `repeat:` fields in the routines repo's `TODO.md` each cycle. Two dispatch paths:
+
+- **`run:` (script-only)** — execute directly, zero LLM tokens. For health checks, backups, exports.
+- **`agent:` (LLM-requiring)** — dispatch via `headless-runtime-helper.sh`. For content review, analysis, responses.
+
+```bash
+# Check if a routine is due
+routine-schedule-helper.sh is-due "daily(@09:00)" "$LAST_RUN_EPOCH"
+
+# Update routine issue description with execution results
+routine-log-helper.sh update r001 --status success --duration 108
+
+# Post notable event as comment (streak break, budget threshold)
+routine-log-helper.sh notable r001 --event "first failure after 12 successes"
+```
+
+Custom automation logic lives in `~/.aidevops/agents/custom/scripts/` (scripts) and `custom/agents/` (LLM agents). These survive framework updates.
+
+Routine state tracked in `~/.aidevops/.agent-workspace/routine-state.json`. Detailed logs in `~/.aidevops/.agent-workspace/cron/<routine-id>/`. Issue descriptions in the routines repo are living summaries — updated after each execution. Comments are for user discussions.
+
+Full reference: `reference/routines.md`.
 
 ## Audit Trail
 

--- a/.agents/scripts/commands/automate.md
+++ b/.agents/scripts/commands/automate.md
@@ -11,4 +11,10 @@ Execute this request with the Automate primary agent.
 
 Request: $ARGUMENTS
 
-Focus on orchestration, scheduling, dispatch, monitoring, and automation workflows.
+Focus on orchestration, scheduling, dispatch, monitoring, recurring routines, and automation workflows.
+
+Capabilities include:
+- **Recurring routines**: Define in routines repo (`aidevops init-routines`), dispatch via pulse. `run:` for script-only (zero LLM tokens), `agent:` for LLM-requiring. See `reference/routines.md`.
+- **Worker dispatch**: `headless-runtime-helper.sh run` for task execution
+- **Scheduling**: launchd (macOS) / systemd (Linux) — not crontab
+- **Monitoring**: worker health, provider backoff, circuit breaker

--- a/.agents/scripts/commands/routine.md
+++ b/.agents/scripts/commands/routine.md
@@ -11,6 +11,26 @@ Create recurring operational routines (reports, audits, monitoring, outreach) wi
 
 Arguments: $ARGUMENTS
 
+## Routines repo (primary approach)
+
+Routines are repeating TODOs defined in a private `aidevops-routines` repo. Setup: `aidevops init-routines`.
+
+Define routines in the repo's `TODO.md`:
+
+```markdown
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [x] r002 Daily health check repeat:daily(@06:00) ~2m run:custom/scripts/health-check.sh
+- [ ] r003 Monthly content review repeat:monthly(1@09:00) ~15m agent:Content
+```
+
+- `[x]` = enabled, `[ ]` = disabled
+- `run:` = script-only (zero LLM tokens), `agent:` = LLM-requiring
+- Custom scripts in `~/.aidevops/agents/custom/scripts/`, custom agents in `custom/agents/`
+- Each routine gets a tracking issue — description is living summary, comments for discussion
+- The pulse dispatches due routines automatically
+
+Full reference: `reference/routines.md`.
+
 ## Route by work type
 
 - Code changes or PR traceability needed → `/full-loop`

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -1,6 +1,6 @@
 <!--TOON:agents[9]{name,file,purpose,model_tier}:
 Build+,build-plus.md,Enhanced Build with context tools,opus
-Automate,automate.md,Scheduling dispatch monitoring and background orchestration,sonnet
+Automate,automate.md,Scheduling dispatch monitoring recurring routines and background orchestration,sonnet
 Business,business.md,Company orchestration including financial ops invoicing receipts,sonnet
 Content,content.md,All media production and distribution including AI video generation and social media,opus
 Health,health.md,Health and wellness,opus
@@ -232,6 +232,9 @@ agent-test-helper.sh,Agent testing framework (run run-one compare baseline list 
 testing-setup-helper.sh,Per-repo testing infrastructure setup (discover gaps status verify) with bundle-aware defaults
 cron-helper.sh,Cron job management for scheduled AI agent dispatch
 cron-dispatch.sh,Execute cron jobs via OpenCode server API
+routine-schedule-helper.sh,Deterministic schedule parser for recurring routines (is-due next-run parse)
+routine-log-helper.sh,Routine execution tracking via GitHub issue descriptions (update notable create-issue status)
+init-routines-helper.sh,Scaffold private routines repo for recurring automation (personal org local)
 runner-helper.sh,Named headless AI agent instances (create run status list edit logs stop destroy)
 matrix-dispatch-helper.sh,Matrix bot for dispatching messages to AI runners (setup start stop map test)
 schema-validator-helper.sh,Schema.org structured data validation (validate validate-json status install)


### PR DESCRIPTION
## Summary

- Add "Recurring Routines" section to AGENTS.md documenting the full routines system
- Update Automate agent with routine dispatch commands and Quick Reference entries
- Update `/routine` and `/automate` command docs to reference the new system
- Add routine helper scripts to subagent-index.toon

This PR adds the harness documentation so aidevops knows about the routines system. The implementation tasks (t1923-t1926) will add the actual scripts and format changes.

Related: GH#17772, GH#17773, GH#17774, GH#17775
Supersedes: GH#17712

Closes #17772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Recurring Routines workflow for operational automation with two execution modes: script-based and LLM-assisted.
  * Added `aidevops init-routines` command to set up custom recurring automation tasks.
  * Documented routine tracking via GitHub issues and scheduling support for macOS (launchd) and Linux (systemd).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->