### PR TITLE
t1923: document TODO-based routine definitions

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -109,6 +109,18 @@ Planning files go direct to main. Code changes need worktree + PR. Workers NEVER
 
 **Simplification state policy:** Keep all changes to `.agents/configs/simplification-state.json`. It is the shared hash registry used by the simplification routine to detect unchanged vs changed files and decide when recheck/re-processing is needed.
 
+### Routines
+
+Recurring operational jobs live in `TODO.md` under `## Routines`, not in a separate registry. Use `r`-prefixed IDs (`r001`, `r002`) to distinguish them from `t`-prefixed tasks.
+
+- `repeat:` defines the schedule with `daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, or `cron(expr)`
+- `run:` points to a deterministic script relative to `~/.aidevops/agents/`
+- `agent:` names the LLM agent to dispatch with `headless-runtime-helper.sh`
+- `[x]` means enabled; `[ ]` means disabled/paused and should be skipped
+- Dispatch rule: prefer `run:` when present; otherwise use `agent:`; if neither is set, default to `run:custom/scripts/{routine-name}.sh` when it exists, else `agent:Build+`
+
+Use `/routine` to design, dry-run, and schedule these definitions. Reference: `.agents/reference/routines.md`.
+
 ### Cross-Repo Task Management
 
 **Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture. Repos with `"local_only": true` have no GitHub remote — skip `gh` operations on them. Repo paths may be nested (e.g., `~/Git/cloudron/netbird-app`), not just `~/Git/<name>`.

--- a/.agents/reference/routines.md
+++ b/.agents/reference/routines.md
@@ -1,0 +1,62 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Routines Reference
+
+Recurring operational jobs live in `TODO.md` under a dedicated `## Routines` section. They are git-tracked, human-readable, and use `r`-prefixed IDs to distinguish them from one-off `t`-prefixed tasks.
+
+## Format
+
+```markdown
+## Routines
+
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [x] r002 Daily health check repeat:daily(@06:00) ~2m run:custom/scripts/health-check.sh
+- [ ] r003 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
+- [x] r004 Nightly repo triage repeat:cron(15 2 * * *) ~20m agent:Build+
+```
+
+## Fields
+
+- `[x]` — enabled routine; schedulers and pulse-style dispatchers may run it
+- `[ ]` — disabled or paused routine; skip it without deleting the definition
+- `r001` — stable routine ID; never reuse IDs
+- Description — human-readable name of the routine
+- `repeat:` — recurrence expression
+- `~30m` — expected runtime estimate
+- `run:` — path relative to `~/.aidevops/agents/` for deterministic script execution
+- `agent:` — agent name for LLM-backed execution through `headless-runtime-helper.sh`
+
+## `repeat:` syntax
+
+- `daily(@06:00)` — every day at 06:00 local time
+- `weekly(mon@09:00)` — every Monday at 09:00 local time
+- `monthly(1@09:00)` — on day 1 of each month at 09:00 local time
+- `cron(15 2 * * *)` — raw cron expression for schedules that do not fit the shorthand forms
+
+Use the shorthand forms when possible. Use `cron(...)` only when the schedule needs cron-level flexibility.
+
+## Dispatch rules
+
+1. `run:` present → execute the script directly with no LLM tokens
+2. `agent:` present → dispatch via `headless-runtime-helper.sh` to the named agent
+3. Both present → prefer `run:`; the routine is deterministic-first
+4. Neither present → default to `run:custom/scripts/{routine-name}.sh` if that script exists, otherwise `agent:Build+`
+
+## Execution model
+
+- Keep SOP, targets, and schedule independent; do not collapse them into one giant prompt
+- Use `run:` for deterministic scripts, exports, health checks, and monitor-style jobs
+- Use `agent:` when the routine needs judgment, summarisation, triage, or outbound drafting
+- Disabled routines stay in `TODO.md` for auditability; do not delete them just to pause execution
+
+## Relationship to `/routine`
+
+Use `/routine` to design, dry-run, and install scheduler entries for the routines defined in `TODO.md`. The command doc is the operator workflow; `TODO.md` is the canonical routine registry.
+
+## Anti-patterns
+
+- Creating a separate routine registry when `TODO.md` can hold the definition
+- Repeating one-off task entries for routine execution history
+- Running deterministic script routines through an LLM agent unnecessarily
+- Hiding schedule semantics outside version control

--- a/.agents/scripts/commands/routine.md
+++ b/.agents/scripts/commands/routine.md
@@ -11,6 +11,8 @@ Create recurring operational routines (reports, audits, monitoring, outreach) wi
 
 Arguments: $ARGUMENTS
 
+Canonical format: define recurring routines in `TODO.md` under `## Routines`. Field reference: `.agents/reference/routines.md`.
+
 ## Route by work type
 
 - Code changes or PR traceability needed → `/full-loop`
@@ -26,7 +28,26 @@ Keep these independent so one can change without rewriting the others:
 
 ## Workflow
 
-### Step 1: Define the SOP command
+### Step 1: Define the routine entry in `TODO.md`
+
+Add or update the routine in the canonical registry first:
+
+```markdown
+## Routines
+
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [ ] r002 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
+```
+
+Use:
+
+- `repeat:` for schedule (`daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, `cron(expr)`)
+- `run:` for deterministic scripts relative to `~/.aidevops/agents/`
+- `agent:` for LLM-backed routines dispatched with `headless-runtime-helper.sh`
+
+If both `run:` and `agent:` exist, prefer `run:`. If neither exists, default to `run:custom/scripts/{routine-name}.sh` when present, else `agent:Build+`.
+
+### Step 2: Define the SOP command
 
 Pick or create a command that runs once for one target. Prefer deterministic helpers/scripts over free-form prompts.
 
@@ -36,7 +57,7 @@ Pick or create a command that runs once for one target. Prefer deterministic hel
 /email-health-check --tenant client-a
 ```
 
-### Step 2: Validate quality and safety
+### Step 3: Validate quality and safety
 
 Run it ad hoc before scheduling:
 
@@ -52,11 +73,11 @@ Before rollout, verify:
 - Retry/timeout behavior acceptable
 - Human review exists for outbound communication
 
-### Step 3: Pilot rollout
+### Step 4: Pilot rollout
 
 Roll out in order: internal/self → single client → small cohort → full target set. Do not skip stages for outbound routines.
 
-### Step 4: Schedule
+### Step 5: Schedule
 
 Use `routine-helper.sh` for launchd/cron when possible:
 
@@ -78,7 +99,7 @@ opencode run --dir ~/Git/<repo> --agent SEO --title "Weekly rankings" \
   "/seo-export --account client-a --format summary"
 ```
 
-Queue-driven development goes through `/pulse`. Fixed-time routines go through scheduler entries.
+Queue-driven development goes through `/pulse`. Fixed-time routines go through scheduler entries. Keep `TODO.md` as the source of truth even when the installed scheduler expands the routine into launchd or cron.
 
 ## Example: GH Failure Miner routine
 
@@ -112,24 +133,22 @@ Schedule via `routine-helper.sh`:
 
 This is operational work (triage + issue filing), so do not use `/full-loop`.
 
-## Routine spec template
+## TODO-based routine template
 
-Store routine definitions in your repo, e.g. `routines/seo-weekly.yaml`:
+Store canonical routine definitions in `TODO.md`, not a separate YAML registry:
 
-```yaml
-name: weekly-seo-rankings
-agent: SEO
-repo_dir: ~/Git/aidev-ops-client-seo-reports
-schedule: "0 9 * * 1"
-targets_cmd: "wp-helper --list-category client --jsonl"
-run_template: "/seo-export --account {{target.account}} --format summary"
+```markdown
+## Routines
+
+- [x] r010 GH Failure Miner repeat:cron(15 */2 * * *) ~10m run:scripts/gh-failure-miner-helper.sh
+- [x] r011 Weekly rankings summary repeat:weekly(mon@09:00) ~30m agent:SEO
 ```
 
-`targets_cmd` emits one JSON object per line for target iteration. `routine-helper.sh` currently schedules a literal `--prompt`; it does not parse `targets_cmd` or `run_template`.
+Use `.agents/reference/routines.md` for the full field specification and dispatch defaults.
 
 ## Anti-patterns
 
-- Repeating TODO items for routine execution
+- Creating a second routine registry outside `TODO.md`
 - Running operational routines through `/full-loop`
 - Skipping pilot stages for outbound content
 - Mixing SOP logic, target selection, and schedule in one monolithic prompt

--- a/TODO.md
+++ b/TODO.md
@@ -20,11 +20,29 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 - [-] tZZZ Declined task
 ```
 
+**Recurring routines:**
+
+```markdown
+## Routines
+
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [x] r002 Daily health check repeat:daily(@06:00) ~2m run:custom/scripts/health-check.sh
+- [ ] r003 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
+- [x] r004 Nightly repo triage repeat:cron(15 2 * * *) ~20m agent:Build+
+```
+
 **Task ID format:**
 
 - `t001` - Top-level task
 - `t001.1` - Subtask of t001
 - `t001.1.1` - Sub-subtask of t001.1
+- IDs are stable and never reused
+
+**Routine ID format:**
+
+- `r001` - Top-level recurring routine definition
+- `r002` - Another recurring routine definition
+- `r`-prefix IDs distinguish routines from `t`-prefix tasks
 - IDs are stable and never reused
 
 **Dependency fields:**
@@ -40,6 +58,16 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 - `logged:` - When task was added
 - `started:` - When branch was created (work began)
 - `completed:` - When task was marked done
+
+**Routine fields:**
+
+- `[x]` - Routine enabled; pulse/schedulers may dispatch it
+- `[ ]` - Routine disabled or paused; pulse skips it
+- `repeat:` - Human-readable schedule: `daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, or `cron(expr)`
+- `run:` - Script path relative to `~/.aidevops/agents/` for pure-script routines that should run without LLM tokens
+- `agent:` - Agent name for LLM-backed routines dispatched via `headless-runtime-helper.sh`
+- Dispatch rule: `run:` wins over `agent:` when both are present
+- Default dispatch: if neither field is set, use `run:custom/scripts/{routine-name}.sh` when that script exists, otherwise `agent:Build+`
 
 **Assignment fields:**
 


### PR DESCRIPTION
## Summary
- document `repeat:`, `run:`, `agent:`, and `r`-prefixed routine IDs in `TODO.md`
- add `.agents/reference/routines.md` as the canonical format and dispatch reference for TODO-based routines
- update `/routine` and `.agents/AGENTS.md` to point operators at the shared TODO-based routine registry

## Testing
- `npx markdownlint-cli2 ".agents/reference/routines.md" ".agents/scripts/commands/routine.md" ".agents/AGENTS.md"`
- `rg -n "repeat:|run:|agent:|r-prefix|## Routines|Routines Reference|TODO-based" -- TODO.md .agents/reference/routines.md .agents/scripts/commands/routine.md .agents/AGENTS.md`
- `npx markdownlint-cli2 "TODO.md" ".agents/reference/routines.md" ".agents/scripts/commands/routine.md" ".agents/AGENTS.md"` *(fails on pre-existing TODO.md lint debt outside the edited section)*

## Runtime Testing
- Risk: low (docs/format only)
- Result: self-assessed; no runtime execution path changed

Resolves #17772

---
[aidevops.sh](https://aidevops.sh) v3.6.159 plugin for [OpenCode](https://opencode.ai) v1.3.17 with gpt-5.4 spent 3m and 78,915 tokens on this as a headless worker.