### PR TITLE
GH#17777: replace assignees on dispatch instead of co-assigning

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6882,7 +6882,7 @@ dispatch_with_dedup() {
 	# gate prevents dispatch when prompt fallback logic is too permissive.
 	local issue_meta_json
 	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json number,title,state,labels 2>/dev/null) || issue_meta_json=""
+		--json number,title,state,labels,assignees 2>/dev/null) || issue_meta_json=""
 	if [[ -z "$issue_meta_json" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to load issue metadata" >>"$LOGFILE"
 		return 1
@@ -6958,9 +6958,19 @@ dispatch_with_dedup() {
 		return 1
 	fi
 
-	# Assign issue and label as queued + origin:worker (dispatched by pulse)
+	# Replace existing assignees with dispatching runner (GH#17777).
+	# Previous behavior only added self (--add-assignee), leaving the original
+	# assignee (typically the issue creator) co-assigned. This created ambiguity
+	# about ownership and confused dedup layer 6 (is_assigned) when status:queued
+	# made passive owner assignments appear active.
+	local -a _edit_flags=(--add-assignee "$self_login" --add-label "status:queued" --add-label "origin:worker")
+	local _prev_login
+	while IFS= read -r _prev_login; do
+		[[ -n "$_prev_login" && "$_prev_login" != "$self_login" ]] && _edit_flags+=(--remove-assignee "$_prev_login")
+	done < <(printf '%s' "$issue_meta_json" | jq -r '.assignees[].login' 2>/dev/null)
+
 	gh issue edit "$issue_number" --repo "$repo_slug" \
-		--add-assignee "$self_login" --add-label "status:queued" --add-label "origin:worker" 2>/dev/null || true
+		"${_edit_flags[@]}" 2>/dev/null || true
 
 	# Detach worker stdio from the dispatcher (GH#14483).
 	# Without this, background workers inherit the candidate-loop stdin created by


### PR DESCRIPTION
## Summary

When `dispatch_with_dedup()` assigns an issue to the dispatching runner, it previously used `--add-assignee` without removing existing assignees. This created co-assignment (e.g., both `marcusquinn` and `alex-solovyev` assigned to #17777), making issue ownership ambiguous and confusing dedup layer 6 (`is_assigned`) when `status:queued` made passive owner assignments appear active.

## Changes

- **`pulse-wrapper.sh:6884`**: Added `assignees` to the `--json` query in `dispatch_with_dedup()` so existing assignees are available from the already-fetched metadata (no extra API call).
- **`pulse-wrapper.sh:6961-6973`**: Replaced the single `--add-assignee` call with a loop that builds `--remove-assignee` flags for all existing non-self assignees, then issues a single `gh issue edit` that atomically removes previous assignees and adds the dispatching runner.

## Before / After

| | Before | After |
|---|--------|-------|
| Claim comment posted | No assignment change | No assignment change |
| Worker dispatched | `--add-assignee self` (old assignees stay) | `--remove-assignee old --add-assignee self` (clean handoff) |
| Visible on GitHub | 2 assignees, unclear ownership | 1 assignee, the active runner |

## Testing

- ShellCheck clean on edited sections
- Risk: **low** — only changes assignment metadata on issues at dispatch time; the dedup guard (7 layers) and claim protocol are unchanged
- Self-assessed (no runtime environment for pulse integration test)

## Runtime Testing

- Risk level: low (metadata-only change to assignment flags)
- Verification: `self-assessed` — no dev environment for pulse wrapper integration testing

Resolves #17777

---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 9m and 11,476 tokens on this with the user in an interactive session.