### PR TITLE
t1926: feat: routine-log-helper.sh for execution tracking via issue descriptions

### DIFF
--- a/.agents/scripts/routine-log-helper.sh
+++ b/.agents/scripts/routine-log-helper.sh
@@ -1,0 +1,909 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# routine-log-helper.sh — Update routine tracking issue descriptions with
+# living summary metrics after execution. Notable events as comments.
+# Script-only shows $0 cost. Detailed logs stay local. (t1926)
+#
+# Usage:
+#   routine-log-helper.sh update <routine-id> --status success|failure --duration SECONDS [--tokens N] [--cost AMOUNT]
+#   routine-log-helper.sh notable <routine-id> --event "description"
+#   routine-log-helper.sh create-issue <routine-id> --repo SLUG --title "rNNN: Title" [--schedule EXPR] [--type TYPE]
+#   routine-log-helper.sh status
+#   routine-log-helper.sh help
+#
+# State file: ~/.aidevops/.agent-workspace/cron/<routine-id>/routine-state.json
+# Local logs: ~/.aidevops/.agent-workspace/cron/<routine-id>/
+
+set -euo pipefail
+
+# PATH normalisation for launchd/MCP environments
+export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
+
+# Fallback colours if shared-constants.sh not loaded
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${BLUE+x}" ]] && BLUE='\033[0;34m'
+[[ -z "${CYAN+x}" ]] && CYAN='\033[0;36m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+CRON_BASE="${HOME}/.aidevops/.agent-workspace/cron"
+REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+PERIOD_DAYS=7
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+_log_info() {
+	local msg="$1"
+	echo -e "${BLUE}[INFO]${NC} ${msg}" >&2
+	return 0
+}
+
+_log_warn() {
+	local msg="$1"
+	echo -e "${YELLOW}[WARN]${NC} ${msg}" >&2
+	return 0
+}
+
+_log_error() {
+	local msg="$1"
+	echo -e "${RED}[ERROR]${NC} ${msg}" >&2
+	return 0
+}
+
+_log_success() {
+	local msg="$1"
+	echo -e "${GREEN}[OK]${NC} ${msg}" >&2
+	return 0
+}
+
+# =============================================================================
+# Prerequisites
+# =============================================================================
+
+_check_prerequisites() {
+	if ! command -v gh &>/dev/null; then
+		_log_error "gh CLI not found. Install from https://cli.github.com/"
+		return 1
+	fi
+	if ! command -v jq &>/dev/null; then
+		_log_error "jq not found. Install with: brew install jq / apt install jq"
+		return 1
+	fi
+	return 0
+}
+
+# =============================================================================
+# State management
+# =============================================================================
+
+_state_dir() {
+	local routine_id="$1"
+	echo "${CRON_BASE}/${routine_id}"
+}
+
+_state_file() {
+	local routine_id="$1"
+	echo "$(_state_dir "$routine_id")/routine-state.json"
+}
+
+_ensure_state_dir() {
+	local routine_id="$1"
+	local dir
+	dir="$(_state_dir "$routine_id")"
+	mkdir -p "$dir"
+	return 0
+}
+
+_read_state() {
+	local routine_id="$1"
+	local state_file
+	state_file="$(_state_file "$routine_id")"
+	if [[ -f "$state_file" ]]; then
+		cat "$state_file"
+	else
+		echo '{}'
+	fi
+	return 0
+}
+
+_write_state() {
+	local routine_id="$1"
+	local state_json="$2"
+	local state_file
+	state_file="$(_state_file "$routine_id")"
+	_ensure_state_dir "$routine_id"
+	echo "$state_json" >"$state_file"
+	return 0
+}
+
+_get_state_field() {
+	local routine_id="$1"
+	local field="$2"
+	local default="${3:-}"
+	local value
+	value=$(_read_state "$routine_id" | jq -r ".${field} // empty")
+	if [[ -z "$value" ]]; then
+		echo "$default"
+	else
+		echo "$value"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Local log management
+# =============================================================================
+
+_append_local_log() {
+	local routine_id="$1"
+	local status="$2"
+	local duration="$3"
+	local tokens="${4:-0}"
+	local cost="${5:-0.00}"
+	local log_dir
+	log_dir="$(_state_dir "$routine_id")/logs"
+	mkdir -p "$log_dir"
+
+	local timestamp
+	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	local log_entry
+	log_entry=$(jq -n \
+		--arg ts "$timestamp" \
+		--arg st "$status" \
+		--argjson dur "$duration" \
+		--argjson tok "$tokens" \
+		--arg cost "$cost" \
+		'{timestamp: $ts, status: $st, duration: $dur, tokens: $tok, cost: $cost}')
+
+	echo "$log_entry" >>"${log_dir}/executions.jsonl"
+	return 0
+}
+
+_compute_period_summary() {
+	local routine_id="$1"
+	local log_file
+	log_file="$(_state_dir "$routine_id")/logs/executions.jsonl"
+
+	if [[ ! -f "$log_file" ]]; then
+		echo '{"total":0,"successes":0,"failures":0,"total_cost":"0.00","avg_duration":0,"period_start":"","period_end":""}'
+		return 0
+	fi
+
+	local cutoff_ts
+	cutoff_ts=$(date -u -d "${PERIOD_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+		date -u -v-${PERIOD_DAYS}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+		echo "1970-01-01T00:00:00Z")
+
+	local period_start
+	period_start=$(date -u -d "${PERIOD_DAYS} days ago" +%Y-%m-%d 2>/dev/null ||
+		date -u -v-${PERIOD_DAYS}d +%Y-%m-%d 2>/dev/null ||
+		echo "unknown")
+	local period_end
+	period_end=$(date -u +%Y-%m-%d)
+
+	# Filter entries within period and compute aggregates
+	local result
+	result=$(jq -s --arg cutoff "$cutoff_ts" '
+        [.[] | select(.timestamp >= $cutoff)] |
+        {
+            total: length,
+            successes: [.[] | select(.status == "success")] | length,
+            failures: [.[] | select(.status == "failure")] | length,
+            total_cost: ([.[] | .cost | tonumber] | add // 0 | . * 100 | round / 100 | tostring),
+            avg_duration: (if length > 0 then ([.[] | .duration] | add / length | round) else 0 end)
+        }
+    ' "$log_file" 2>/dev/null || echo '{"total":0,"successes":0,"failures":0,"total_cost":"0.00","avg_duration":0}')
+
+	# Add period dates
+	result=$(echo "$result" | jq --arg ps "$period_start" --arg pe "$period_end" \
+		'. + {period_start: $ps, period_end: $pe}')
+
+	echo "$result"
+	return 0
+}
+
+# =============================================================================
+# Duration formatting
+# =============================================================================
+
+_format_duration() {
+	local seconds="$1"
+	local mins=$((seconds / 60))
+	local secs=$((seconds % 60))
+	if [[ "$mins" -gt 0 ]]; then
+		echo "${mins}m ${secs}s"
+	else
+		echo "${secs}s"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Streak tracking
+# =============================================================================
+
+_update_streak() {
+	local routine_id="$1"
+	local new_status="$2"
+	local current_streak_count
+	current_streak_count=$(_get_state_field "$routine_id" "streak_count" "0")
+	local current_streak_type
+	current_streak_type=$(_get_state_field "$routine_id" "streak_type" "")
+
+	local streak_broke="false"
+
+	if [[ "$current_streak_type" == "$new_status" ]]; then
+		current_streak_count=$((current_streak_count + 1))
+	else
+		if [[ -n "$current_streak_type" ]] && [[ "$current_streak_count" -ge 3 ]]; then
+			streak_broke="true"
+		fi
+		current_streak_count=1
+		current_streak_type="$new_status"
+	fi
+
+	# Update state
+	local state
+	state=$(_read_state "$routine_id")
+	state=$(echo "$state" | jq \
+		--argjson count "$current_streak_count" \
+		--arg type "$current_streak_type" \
+		'.streak_count = $count | .streak_type = $type')
+	_write_state "$routine_id" "$state"
+
+	echo "$streak_broke"
+	return 0
+}
+
+# =============================================================================
+# Next run computation
+# =============================================================================
+
+_compute_next_run() {
+	local schedule="$1"
+	local now_ts
+	now_ts=$(date -u +%s)
+
+	# Parse schedule expressions
+	case "$schedule" in
+	daily\(@*\))
+		local time_part
+		time_part=$(echo "$schedule" | sed -E 's/daily\(@([0-9:]+)\)/\1/')
+		local hour minute
+		hour=$(echo "$time_part" | cut -d: -f1)
+		minute=$(echo "$time_part" | cut -d: -f2)
+		# Next occurrence: tomorrow at that time
+		local tomorrow
+		tomorrow=$(date -u -d "tomorrow ${hour}:${minute}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+			date -u -v+1d -v"${hour}"H -v"${minute}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+			echo "unknown")
+		echo "$tomorrow"
+		;;
+	weekly\(*\))
+		echo "~7 days"
+		;;
+	monthly\(*\))
+		echo "~30 days"
+		;;
+	cron\(*\))
+		echo "per cron schedule"
+		;;
+	*)
+		echo "unknown"
+		;;
+	esac
+	return 0
+}
+
+# =============================================================================
+# Issue body template
+# =============================================================================
+
+_build_issue_body() {
+	local routine_id="$1"
+	local title="$2"
+	local schedule="$3"
+	local routine_type="$4"
+	local status_label="$5"
+	local last_run="$6"
+	local last_result="$7"
+	local last_duration="$8"
+	local next_run="$9"
+	local streak_count="${10}"
+	local streak_type="${11}"
+	local total_cost="${12}"
+	local period_summary="${13}"
+
+	local formatted_duration
+	formatted_duration=$(_format_duration "$last_duration")
+
+	local streak_label
+	if [[ "$streak_count" -gt 0 ]] && [[ -n "$streak_type" ]]; then
+		local plural="successes"
+		[[ "$streak_type" == "failure" ]] && plural="failures"
+		streak_label="${streak_count} consecutive ${plural}"
+	else
+		streak_label="—"
+	fi
+
+	# Parse period summary
+	local p_total p_successes p_cost p_avg_dur p_start p_end
+	p_total=$(echo "$period_summary" | jq -r '.total')
+	p_successes=$(echo "$period_summary" | jq -r '.successes')
+	p_cost=$(echo "$period_summary" | jq -r '.total_cost')
+	p_avg_dur=$(echo "$period_summary" | jq -r '.avg_duration')
+	p_start=$(echo "$period_summary" | jq -r '.period_start')
+	p_end=$(echo "$period_summary" | jq -r '.period_end')
+
+	local p_avg_formatted
+	p_avg_formatted=$(_format_duration "$p_avg_dur")
+
+	local last_result_display
+	if [[ "$last_result" == "none" ]] || [[ -z "$last_result" ]]; then
+		last_result_display="—"
+	else
+		last_result_display="${last_result} (${formatted_duration})"
+	fi
+
+	local last_run_display
+	if [[ "$last_run" == "never" ]] || [[ -z "$last_run" ]]; then
+		last_run_display="—"
+	else
+		last_run_display="$last_run"
+	fi
+
+	cat <<EOF
+## ${routine_id}: ${title}
+
+| Field | Value |
+|-------|-------|
+| Schedule | ${schedule} |
+| Type | ${routine_type} |
+| Status | ${status_label} |
+| Last run | ${last_run_display} |
+| Last result | ${last_result_display} |
+| Next run | ${next_run} |
+| Streak | ${streak_label} |
+| Total cost | \$${total_cost} |
+
+### Latest Period (${p_start} — ${p_end})
+${p_successes}/${p_total} runs succeeded. Total cost: \$${p_cost}. Avg duration: ${p_avg_formatted}.
+
+**Detailed logs**: \`~/.aidevops/.agent-workspace/cron/${routine_id}/\`
+EOF
+	return 0
+}
+
+# =============================================================================
+# Subcommand: update
+# =============================================================================
+
+cmd_update() {
+	local routine_id=""
+	local status=""
+	local duration=""
+	local tokens="0"
+	local cost="0.00"
+
+	# Parse args
+	if [[ $# -lt 1 ]]; then
+		_log_error "Usage: routine-log-helper.sh update <routine-id> --status success|failure --duration SECONDS [--tokens N] [--cost AMOUNT]"
+		return 1
+	fi
+	routine_id="$1"
+	shift
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--status)
+			status="$2"
+			shift 2
+			;;
+		--duration)
+			duration="$2"
+			shift 2
+			;;
+		--tokens)
+			tokens="$2"
+			shift 2
+			;;
+		--cost)
+			cost="$2"
+			shift 2
+			;;
+		*)
+			_log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$status" ]] || [[ -z "$duration" ]]; then
+		_log_error "Both --status and --duration are required"
+		return 1
+	fi
+
+	if [[ "$status" != "success" ]] && [[ "$status" != "failure" ]]; then
+		_log_error "Status must be 'success' or 'failure'"
+		return 1
+	fi
+
+	_check_prerequisites || return 1
+	_ensure_state_dir "$routine_id"
+
+	# Read current state
+	local state
+	state=$(_read_state "$routine_id")
+	local issue_number
+	issue_number=$(echo "$state" | jq -r '.issue_number // empty')
+	local repo_slug
+	repo_slug=$(echo "$state" | jq -r '.repo_slug // empty')
+
+	if [[ -z "$issue_number" ]] || [[ -z "$repo_slug" ]]; then
+		_log_error "No tracking issue found for ${routine_id}. Run 'create-issue' first."
+		return 1
+	fi
+
+	local title
+	title=$(echo "$state" | jq -r '.title // "Untitled Routine"')
+	local schedule
+	schedule=$(echo "$state" | jq -r '.schedule // "unknown"')
+	local routine_type
+	routine_type=$(echo "$state" | jq -r '.routine_type // "unknown"')
+	local status_label
+	status_label=$(echo "$state" | jq -r '.status_label // "active"')
+
+	# Determine cost: run: routines always show $0.00
+	if [[ "$routine_type" == script* ]]; then
+		cost="0.00"
+		tokens="0"
+	fi
+
+	# Append to local log
+	_append_local_log "$routine_id" "$status" "$duration" "$tokens" "$cost"
+
+	# Update streak
+	local streak_broke
+	streak_broke=$(_update_streak "$routine_id" "$status")
+
+	# Re-read state after streak update
+	state=$(_read_state "$routine_id")
+	local streak_count
+	streak_count=$(echo "$state" | jq -r '.streak_count // 0')
+	local streak_type
+	streak_type=$(echo "$state" | jq -r '.streak_type // ""')
+
+	# Update last run info in state
+	local now_ts
+	now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+	# Accumulate total cost
+	local prev_total_cost
+	prev_total_cost=$(echo "$state" | jq -r '.total_cost // "0.00"')
+	local new_total_cost
+	new_total_cost=$(echo "$prev_total_cost $cost" | awk '{printf "%.2f", $1 + $2}')
+
+	# Compute next run
+	local next_run
+	next_run=$(_compute_next_run "$schedule")
+
+	# Save updated state
+	state=$(echo "$state" | jq \
+		--arg lr "$now_ts" \
+		--arg ls "$status" \
+		--argjson ld "$duration" \
+		--arg nr "$next_run" \
+		--arg tc "$new_total_cost" \
+		'.last_run = $lr | .last_status = $ls | .last_duration = $ld | .next_run = $nr | .total_cost = $tc')
+	_write_state "$routine_id" "$state"
+
+	# Compute period summary
+	local period_summary
+	period_summary=$(_compute_period_summary "$routine_id")
+
+	# Build new issue body
+	local new_body
+	new_body=$(_build_issue_body \
+		"$routine_id" \
+		"$title" \
+		"$schedule" \
+		"$routine_type" \
+		"$status_label" \
+		"$now_ts" \
+		"$status" \
+		"$duration" \
+		"$next_run" \
+		"$streak_count" \
+		"$streak_type" \
+		"$new_total_cost" \
+		"$period_summary")
+
+	# Update issue description
+	if gh issue edit "$issue_number" --repo "$repo_slug" --body "$new_body" &>/dev/null; then
+		_log_success "Updated issue #${issue_number} for ${routine_id} (${status}, ${duration}s)"
+	else
+		_log_error "Failed to update issue #${issue_number} for ${routine_id}"
+		return 1
+	fi
+
+	# Post notable event if streak broke
+	if [[ "$streak_broke" == "true" ]]; then
+		cmd_notable "$routine_id" --event "Streak broken: was ${streak_count} consecutive, now ${status}"
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Subcommand: notable
+# =============================================================================
+
+cmd_notable() {
+	local routine_id=""
+	local event=""
+
+	if [[ $# -lt 1 ]]; then
+		_log_error "Usage: routine-log-helper.sh notable <routine-id> --event \"description\""
+		return 1
+	fi
+	routine_id="$1"
+	shift
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--event)
+			event="$2"
+			shift 2
+			;;
+		*)
+			_log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$event" ]]; then
+		_log_error "--event is required"
+		return 1
+	fi
+
+	_check_prerequisites || return 1
+
+	local state
+	state=$(_read_state "$routine_id")
+	local issue_number
+	issue_number=$(echo "$state" | jq -r '.issue_number // empty')
+	local repo_slug
+	repo_slug=$(echo "$state" | jq -r '.repo_slug // empty')
+
+	if [[ -z "$issue_number" ]] || [[ -z "$repo_slug" ]]; then
+		_log_error "No tracking issue found for ${routine_id}. Run 'create-issue' first."
+		return 1
+	fi
+
+	local timestamp
+	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+	# Build comment body
+	local comment_body
+	comment_body="### Notable Event
+
+**Routine:** ${routine_id}
+**Time:** ${timestamp}
+**Event:** ${event}"
+
+	# Append signature footer if available
+	local footer=""
+	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
+		footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer 2>/dev/null || true)
+	fi
+	if [[ -n "$footer" ]]; then
+		comment_body="${comment_body}
+
+${footer}"
+	fi
+
+	if gh issue comment "$issue_number" --repo "$repo_slug" --body "$comment_body" &>/dev/null; then
+		_log_success "Posted notable event on issue #${issue_number}: ${event}"
+	else
+		_log_error "Failed to post notable event on issue #${issue_number}"
+		return 1
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Subcommand: create-issue
+# =============================================================================
+
+cmd_create_issue() {
+	local routine_id=""
+	local repo_slug=""
+	local title=""
+	local schedule=""
+	local routine_type=""
+
+	if [[ $# -lt 1 ]]; then
+		_log_error "Usage: routine-log-helper.sh create-issue <routine-id> --repo SLUG --title \"rNNN: Title\" [--schedule EXPR] [--type TYPE]"
+		return 1
+	fi
+	routine_id="$1"
+	shift
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo)
+			repo_slug="$2"
+			shift 2
+			;;
+		--title)
+			title="$2"
+			shift 2
+			;;
+		--schedule)
+			schedule="$2"
+			shift 2
+			;;
+		--type)
+			routine_type="$2"
+			shift 2
+			;;
+		*)
+			_log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$repo_slug" ]] || [[ -z "$title" ]]; then
+		_log_error "--repo and --title are required"
+		return 1
+	fi
+
+	_check_prerequisites || return 1
+	_ensure_state_dir "$routine_id"
+
+	# Check if issue already exists
+	local existing_issue
+	existing_issue=$(_get_state_field "$routine_id" "issue_number" "")
+	if [[ -n "$existing_issue" ]]; then
+		_log_warn "Issue #${existing_issue} already exists for ${routine_id}"
+		echo "$existing_issue"
+		return 0
+	fi
+
+	# Set defaults
+	[[ -z "$schedule" ]] && schedule="unknown"
+	[[ -z "$routine_type" ]] && routine_type="unknown"
+
+	# Build initial issue body
+	local initial_body
+	initial_body=$(_build_issue_body \
+		"$routine_id" \
+		"$title" \
+		"$schedule" \
+		"$routine_type" \
+		"active" \
+		"never" \
+		"none" \
+		"0" \
+		"pending first run" \
+		"0" \
+		"" \
+		'{"total":0,"successes":0,"failures":0,"total_cost":"0.00","avg_duration":0,"period_start":"—","period_end":"—"}' \
+		"$routine_id")
+
+	# Create the issue
+	local issue_url
+	if ! issue_url=$(gh issue create --repo "$repo_slug" --title "$title" --body "$initial_body" --label "routines" 2>&1); then
+		_log_error "Failed to create issue: ${issue_url}"
+		return 1
+	fi
+
+	# Extract issue number from URL
+	local issue_number
+	issue_number=$(echo "$issue_url" | grep -oE '[0-9]+$')
+
+	if [[ -z "$issue_number" ]]; then
+		_log_error "Could not extract issue number from: ${issue_url}"
+		return 1
+	fi
+
+	# Save state
+	local state
+	state=$(_read_state "$routine_id")
+	state=$(echo "$state" | jq \
+		--arg in "$issue_number" \
+		--arg rs "$repo_slug" \
+		--arg t "$title" \
+		--arg s "$schedule" \
+		--arg rt "$routine_type" \
+		--arg sl "active" \
+		--arg tc "0.00" \
+		'.issue_number = $in | .repo_slug = $rs | .title = $t | .schedule = $s | .routine_type = $rt | .status_label = $sl | .total_cost = $tc')
+	_write_state "$routine_id" "$state"
+
+	_log_success "Created issue #${issue_number} for ${routine_id} in ${repo_slug}"
+	echo "$issue_number"
+	return 0
+}
+
+# =============================================================================
+# Subcommand: status
+# =============================================================================
+
+cmd_status() {
+	_check_prerequisites || return 1
+
+	# Find all routine state files
+	local found=0
+
+	printf "%-10s %-8s %-20s %-10s %-8s %-12s %s\n" \
+		"ROUTINE" "ISSUE" "LAST RUN" "RESULT" "STREAK" "COST" "REPO"
+	printf "%-10s %-8s %-20s %-10s %-8s %-12s %s\n" \
+		"-------" "-----" "--------" "------" "------" "----" "----"
+
+	if [[ -d "$CRON_BASE" ]]; then
+		local dir
+		for dir in "${CRON_BASE}"/*/; do
+			[[ -d "$dir" ]] || continue
+			local rid
+			rid=$(basename "$dir")
+			local state_file="${dir}routine-state.json"
+			[[ -f "$state_file" ]] || continue
+
+			local state
+			state=$(cat "$state_file")
+			local issue_number
+			issue_number=$(echo "$state" | jq -r '.issue_number // "—"')
+			local last_run
+			last_run=$(echo "$state" | jq -r '.last_run // "never"')
+			local last_status
+			last_status=$(echo "$state" | jq -r '.last_status // "—"')
+			local streak_count
+			streak_count=$(echo "$state" | jq -r '.streak_count // 0')
+			local streak_type
+			streak_type=$(echo "$state" | jq -r '.streak_type // ""')
+			local total_cost
+			total_cost=$(echo "$state" | jq -r '.total_cost // "0.00"')
+			local repo_slug
+			repo_slug=$(echo "$state" | jq -r '.repo_slug // "—"')
+
+			# Format last_run to short form
+			local last_run_short
+			if [[ "$last_run" == "never" ]]; then
+				last_run_short="never"
+			else
+				last_run_short=$(echo "$last_run" | cut -c1-16 | tr 'T' ' ')
+			fi
+
+			local streak_display="${streak_count}${streak_type:0:1}"
+
+			printf "%-10s %-8s %-20s %-10s %-8s %-12s %s\n" \
+				"$rid" "#${issue_number}" "$last_run_short" "$last_status" "$streak_display" "\$${total_cost}" "$repo_slug"
+
+			found=$((found + 1))
+		done
+	fi
+
+	if [[ "$found" -eq 0 ]]; then
+		echo "(no routines tracked yet)"
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Help
+# =============================================================================
+
+cmd_help() {
+	cat <<'HELP'
+routine-log-helper.sh — Routine execution tracking via GitHub issue descriptions
+
+Usage:
+  routine-log-helper.sh update <routine-id> --status success|failure --duration SECONDS [--tokens N] [--cost AMOUNT]
+    Update the tracking issue description with latest execution metrics.
+    Appends to local execution log. Updates streak counter.
+    Script-only routines (run:) always show $0.00 cost.
+
+  routine-log-helper.sh notable <routine-id> --event "description"
+    Post a comment on the tracking issue for notable events only.
+    Examples: streak breaks, budget thresholds, configuration changes.
+
+  routine-log-helper.sh create-issue <routine-id> --repo SLUG --title "rNNN: Title" [--schedule EXPR] [--type TYPE]
+    Create the initial tracking issue with template description.
+    Returns the issue number. Stores mapping in routine-state.json.
+
+  routine-log-helper.sh status
+    Print summary table of all tracked routines.
+
+  routine-log-helper.sh help
+    Show this help message.
+
+Options:
+  --status success|failure    Execution result (required for update)
+  --duration SECONDS          Execution duration in seconds (required for update)
+  --tokens N                  Token count (optional, default 0)
+  --cost AMOUNT               Cost in dollars (optional, default 0.00)
+  --event "description"       Notable event description (required for notable)
+  --repo SLUG                 GitHub repo slug owner/repo (required for create-issue)
+  --title "rNNN: Title"       Issue title (required for create-issue)
+  --schedule EXPR             Schedule expression e.g. daily(@06:00) (optional)
+  --type TYPE                 Routine type e.g. script or agent (optional)
+
+Examples:
+  # After a successful script execution
+  routine-log-helper.sh update r001 --status success --duration 108
+
+  # After an agent execution with cost
+  routine-log-helper.sh update r002 --status success --duration 300 --tokens 5000 --cost 0.15
+
+  # Post a notable event
+  routine-log-helper.sh notable r001 --event "5 consecutive failures — check cron config"
+
+  # Create tracking issue for a new routine
+  routine-log-helper.sh create-issue r001 --repo owner/repo --title "r001: Daily Pulse" --schedule "daily(@06:00)" --type "script (scripts/pulse-wrapper.sh)"
+
+  # View all routine statuses
+  routine-log-helper.sh status
+
+State:
+  Local logs:  ~/.aidevops/.agent-workspace/cron/<routine-id>/logs/executions.jsonl
+  State file:  ~/.aidevops/.agent-workspace/cron/<routine-id>/routine-state.json
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main dispatch
+# =============================================================================
+
+main() {
+	if [[ $# -lt 1 ]]; then
+		cmd_help
+		return 0
+	fi
+
+	local command="$1"
+	shift
+
+	case "$command" in
+	update)
+		cmd_update "$@"
+		;;
+	notable)
+		cmd_notable "$@"
+		;;
+	create-issue)
+		cmd_create_issue "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		_log_error "Unknown command: ${command}"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements `routine-log-helper.sh` — a new helper script that updates routine tracking issue descriptions with living summary metrics after each execution. Notable events posted as comments. Script-only routines show $0 cost. Detailed logs stay local.

Resolves #17775

## Changes

- **NEW**: `.agents/scripts/routine-log-helper.sh` — 4 subcommands:
  - `update <routine-id>` — rewrites issue description with metrics table (last run, result, streak, cost, period summary)
  - `notable <routine-id>` — posts comment for notable events (streak breaks, budget thresholds)
  - `create-issue <routine-id>` — creates initial tracking issue with template description
  - `status` — prints summary table of all tracked routines

## Design Decisions

- Issue description = living summary (rewritten after each execution), not comments
- Comments reserved for user-LLM discussions and notable events only
- `run:` routines always show $0.00 cost (script execution is free)
- Period summary aggregates last 7 days from local JSONL logs
- Streak tracking with automatic notable event on streak breaks (>=3 consecutive)
- State stored in `~/.aidevops/.agent-workspace/cron/<routine-id>/routine-state.json`
- Local logs in `~/.aidevops/.agent-workspace/cron/<routine-id>/logs/executions.jsonl`

## Runtime Testing

- **Risk level**: Low (new helper script, no existing code modified)
- **Verification**: `self-assessed`
  - ShellCheck: clean (only SC1091 info for external source, same as all helpers)
  - `--help` output verified
  - `status` subcommand verified (empty state)
  - Argument parsing and error handling verified

## Files Changed

- `.agents/scripts/routine-log-helper.sh` (new, 909 lines)

---
[aidevops.sh](https://aidevops.sh) v3.6.161 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 4m and 12,718 tokens on this as a headless worker.