### PR TITLE
t1922: derive headless model list from pool + routing table

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -113,14 +113,14 @@ launchctl bootout gui/$(id -u)/sh.aidevops.<name> && \
 
 ## Provider Management
 
-**Round-robin:** Helper alternates providers in `AIDEVOPS_HEADLESS_MODELS`. Pulse requires Anthropic (sonnet) — OpenAI models exit immediately without activity, wasting every other cycle. Pin pulse with `PULSE_MODEL`; workers can use any provider.
+**Automatic model routing (v3.7+, GH#17769):** The headless model list is derived at runtime from two sources — no env var configuration needed:
 
-**CRITICAL:** Only use agentic-capable models in the round-robin. Codex/code-completion models (gpt-5.3-codex, gpt-5.4-codex) cannot make tool calls and will fail silently as headless workers (GH#17669). Model tiers are defined in `configs/model-routing-table.json` — the single source of truth.
+1. **OAuth pool** (`oauth-pool-helper.sh list all`) — which providers the user has accounts for
+2. **Routing table** (`configs/model-routing-table.json`) — which models map to which tiers per provider
 
-```bash
-export PULSE_MODEL="anthropic/claude-sonnet-4-6"
-export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.4"
-```
+The round-robin model list = "for each provider in the pool, get the sonnet-tier model from the routing table." Pulse always uses the Anthropic sonnet model (derived from the routing table). Workers round-robin across all pool providers.
+
+**No manual model configuration required.** The deprecated `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle, with deprecation warnings logged. Remove them from `credentials.sh` — they will be ignored in a future release.
 
 **Backoff:** `headless-runtime-helper.sh backoff status` / `backoff clear PROVIDER`. Exit code 75 = all providers backed off.
 **Escalation:** After 2+ failed attempts, use `--model anthropic/claude-opus-4-6`. One opus dispatch (~3x cost) is cheaper than 5+ failed sonnet dispatches.

--- a/.agents/configs/aidevops-config.schema.json
+++ b/.agents/configs/aidevops-config.schema.json
@@ -127,12 +127,14 @@
         "pulse_model": {
           "type": "string",
           "default": "",
-          "description": "Optional explicit pulse model override. Empty string keeps shared defaults. Env: PULSE_MODEL"
+          "deprecated": true,
+          "description": "DEPRECATED (v3.7+, GH#17769): Model routing is now derived from pool + routing table. This field is ignored. Remove from config."
         },
         "headless_models": {
           "type": "string",
           "default": "",
-          "description": "Optional comma-separated headless worker model override. Empty string keeps shared defaults. Env: AIDEVOPS_HEADLESS_MODELS"
+          "deprecated": true,
+          "description": "DEPRECATED (v3.7+, GH#17769): Model routing is now derived from pool + routing table. This field is ignored. Remove from config."
         },
         "peak_hours_enabled": {
           "type": "boolean",

--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -124,16 +124,9 @@
     // Env override: AIDEVOPS_QUALITY_DEBT_CAP_PCT
     "quality_debt_cap_pct": 30,
 
-    // Optional explicit pulse model override.
-    // Empty string keeps the shared default selection behavior.
-    // Example local opt-in: "openai/gpt-5.4"
-    // Env override: PULSE_MODEL
+    // DEPRECATED (v3.7+, GH#17769): Model routing is now derived from
+    // pool + routing table at runtime. These fields are ignored.
     "pulse_model": "",
-
-    // Optional explicit headless worker model list override (comma-separated).
-    // Empty string keeps the shared round-robin/default behavior.
-    // Example local opt-in: "openai/gpt-5.4"
-    // Env override: AIDEVOPS_HEADLESS_MODELS
     "headless_models": "",
 
     // Seconds of unchanged backlog before triggering an LLM supervisor session.

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -299,9 +299,9 @@ workers attempted.
 ### Model tier selection
 
 `dispatch_with_dedup` handles model selection automatically via round-robin across
-configured providers (AIDEVOPS_HEADLESS_MODELS). The resolved model is recorded in
-the dispatch comment. **Do NOT pass a model override (9th parameter) for default
-dispatches** — this bypasses the round-robin and causes provider imbalance.
+providers derived from the OAuth pool + routing table (GH#17769). The resolved model
+is recorded in the dispatch comment. **Do NOT pass a model override (9th parameter)
+for default dispatches** — this bypasses the round-robin and causes provider imbalance.
 
 Only pass a model override when tier escalation is needed:
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -27,6 +27,7 @@ if [[ -f "$HOME/.ssh/agent.env" ]]; then
 	. "$HOME/.ssh/agent.env" >/dev/null 2>&1 || true
 fi
 
+# Absolute fallback when both pool and routing table are unavailable (GH#17769)
 readonly DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6"
 readonly STATE_DIR="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 readonly STATE_DB="${STATE_DIR}/state.db"
@@ -309,107 +310,89 @@ get_auth_signature() {
 	return 0
 }
 
+# Derive the headless model list from the OAuth pool + routing table (GH#17769).
+# Flow: pool → available providers → routing table sonnet tier → model list.
+# This eliminates AIDEVOPS_HEADLESS_MODELS as a user-configurable env var.
+# The pool is the authority on accounts; the routing table is the authority on models.
 get_configured_models() {
-	local configured="${AIDEVOPS_HEADLESS_MODELS:-}"
 	local allowlist_raw="${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}"
 	local -a allowlist=()
-	local -a raw_models=()
 	local -a models=()
-	local item provider
+	local provider model
 
-	if [[ -z "$configured" ]] && type config_get >/dev/null 2>&1; then
-		configured=$(config_get "orchestration.headless_models" "")
-		if [[ "$configured" == "null" ]]; then
-			configured=""
+	# Backward compatibility: if legacy env var is still set, log deprecation
+	# warning but respect it as an override for one release cycle.
+	if [[ -n "${AIDEVOPS_HEADLESS_MODELS:-}" ]]; then
+		print_warning "AIDEVOPS_HEADLESS_MODELS is deprecated (v3.7+). Model routing is now automatic via pool + routing table. Remove this export from credentials.sh. Respecting override for this release cycle."
+		local -a raw_models=()
+		IFS=',' read -r -a raw_models <<<"$AIDEVOPS_HEADLESS_MODELS"
+		for item in "${raw_models[@]}"; do
+			item=$(trim_spaces "$item")
+			[[ -z "$item" ]] && continue
+			provider=$(extract_provider "$item" 2>/dev/null || printf '%s' "")
+			[[ -z "$provider" ]] && continue
+			models+=("$item")
+		done
+		if [[ ${#models[@]} -gt 0 ]]; then
+			printf '%s\n' "${models[@]}"
+			return 0
 		fi
-	fi
-	if [[ -z "$configured" ]]; then
-		configured="$DEFAULT_HEADLESS_MODELS"
 	fi
 
 	if [[ -n "$allowlist_raw" ]]; then
 		IFS=',' read -r -a allowlist <<<"$allowlist_raw"
 	fi
 
-	IFS=',' read -r -a raw_models <<<"$configured"
-	for item in "${raw_models[@]}"; do
-		item=$(trim_spaces "$item")
-		[[ -z "$item" ]] && continue
-		provider=$(extract_provider "$item" 2>/dev/null || printf '%s' "")
-		[[ -z "$provider" ]] && continue
+	local routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
+	local pool_helper="${SCRIPT_DIR}/oauth-pool-helper.sh"
 
-		# GH#17669: Filter out non-agentic models. Codex/code-completion
-		# models can't make tool calls and die silently as headless workers.
-		# This self-heals stale AIDEVOPS_HEADLESS_MODELS configs without
-		# requiring manual credentials.sh edits.
-		if _is_non_agentic_model "$item"; then
-			local replacement=""
-			replacement=$(_get_agentic_replacement "$item")
-			if [[ -n "$replacement" ]]; then
-				item="$replacement"
-				provider=$(extract_provider "$item" 2>/dev/null || printf '%s' "")
-			else
-				continue
+	# Step 1: Query pool for available providers (cheap — reads JSON file, no API calls)
+	local -a pool_providers=()
+	if [[ -x "$pool_helper" ]]; then
+		local pool_output=""
+		pool_output=$("$pool_helper" list all 2>/dev/null) || pool_output=""
+		# Parse provider names from lines like "anthropic (2 accounts):"
+		while IFS= read -r line; do
+			local prov=""
+			prov=$(printf '%s' "$line" | sed -n 's/^\([a-z]*\) ([0-9]* account.*/\1/p')
+			if [[ -n "$prov" ]]; then
+				pool_providers+=("$prov")
 			fi
-		fi
+		done <<<"$pool_output"
+	fi
 
-		if [[ ${#allowlist[@]} -gt 0 ]]; then
-			local allowed=false
-			local allowed_provider
-			for allowed_provider in "${allowlist[@]}"; do
-				allowed_provider=$(trim_spaces "$allowed_provider")
-				if [[ "$allowed_provider" == "$provider" ]]; then
-					allowed=true
-					break
-				fi
-			done
-			[[ "$allowed" == "true" ]] || continue
-		fi
-		models+=("$item")
-	done
+	# Step 2: For each pool provider, look up the sonnet-tier model from the routing table
+	if [[ ${#pool_providers[@]} -gt 0 ]] && [[ -f "$routing_table" ]] && command -v jq >/dev/null 2>&1; then
+		for provider in "${pool_providers[@]}"; do
+			# Apply allowlist filter if set
+			if [[ ${#allowlist[@]} -gt 0 ]]; then
+				local allowed=false
+				local allowed_provider
+				for allowed_provider in "${allowlist[@]}"; do
+					allowed_provider=$(trim_spaces "$allowed_provider")
+					if [[ "$allowed_provider" == "$provider" ]]; then
+						allowed=true
+						break
+					fi
+				done
+				[[ "$allowed" == "true" ]] || continue
+			fi
 
+			model=$(jq -r --arg p "$provider" \
+				'.tiers.sonnet.models[] | select(startswith($p + "/"))' \
+				"$routing_table" 2>/dev/null | head -1) || model=""
+			if [[ -n "$model" ]]; then
+				models+=("$model")
+			fi
+		done
+	fi
+
+	# Fallback: if pool/routing derivation yielded nothing, use hardcoded default
 	if [[ ${#models[@]} -eq 0 ]]; then
-		return 1
+		models+=("$DEFAULT_HEADLESS_MODELS")
 	fi
 
 	printf '%s\n' "${models[@]}"
-	return 0
-}
-
-# Check if a model ID is non-agentic (code-completion only, no tool calls).
-# These models silently fail as headless workers — zero tool calls observed.
-_is_non_agentic_model() {
-	local model="$1"
-	case "$model" in
-	*codex* | *code-completion*) return 0 ;;
-	*) return 1 ;;
-	esac
-}
-
-# Get the agentic replacement for a non-agentic model.
-# Reads from model-routing-table.json sonnet tier for the same provider.
-_get_agentic_replacement() {
-	local model="$1"
-	local provider=""
-	provider=$(extract_provider "$model" 2>/dev/null || printf '%s' "")
-
-	local routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
-	if [[ -f "$routing_table" ]]; then
-		local replacement=""
-		replacement=$(jq -r --arg p "$provider" \
-			'.tiers.sonnet.models[] | select(startswith($p + "/"))' \
-			"$routing_table" 2>/dev/null | head -1) || replacement=""
-		if [[ -n "$replacement" ]]; then
-			printf '%s' "$replacement"
-			return 0
-		fi
-	fi
-
-	# Hardcoded fallback for known non-agentic → agentic mappings
-	case "$model" in
-	openai/gpt-5.3-codex | openai/gpt-5.4-codex) printf 'openai/gpt-5.4' ;;
-	*) return 1 ;;
-	esac
 	return 0
 }
 
@@ -2864,7 +2847,9 @@ Dedup guard (GH#6538):
   are cleaned up automatically. Lock files: $STATE_DIR/locks/<key>.pid
 
 Defaults:
-  AIDEVOPS_HEADLESS_MODELS defaults to anthropic/claude-sonnet-4-6,openai/gpt-4o
+  Model list is derived from OAuth pool + routing table (GH#17769).
+  Fallback: anthropic/claude-sonnet-4-6 if pool/routing unavailable.
+  AIDEVOPS_HEADLESS_MODELS is deprecated — respected as override for one release cycle.
   AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST can restrict selection to providers like: openai
   AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 disables worker /full-loop contract injection
   NOTE: opencode/* gateway models are NOT used — per-token billing is too expensive.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -113,11 +113,12 @@ if [[ -f "$HOME/.ssh/agent.env" ]]; then
 fi
 
 #######################################
-# Source credentials.sh for model config and API keys (GH#17546)
+# Source credentials.sh for API keys (GH#17546)
 # Launchd plists bake env vars at setup time — they go stale when
 # credentials.sh is later updated. Sourcing at runtime ensures the
-# pulse always uses the current AIDEVOPS_HEADLESS_MODELS, PULSE_MODEL,
-# and provider API keys, regardless of what the plist embedded.
+# pulse always uses the current provider API keys, regardless of what
+# the plist embedded. Model config is now derived from the pool +
+# routing table (GH#17769), not env vars.
 #######################################
 if [[ -f "${HOME}/.config/aidevops/credentials.sh" ]]; then
 	# shellcheck source=/dev/null
@@ -173,21 +174,22 @@ MAX_WORKERS_CAP="${MAX_WORKERS_CAP:-$(config_get "orchestration.max_workers_cap"
 DAILY_PR_CAP="${DAILY_PR_CAP:-1000}"                                                                    # Max PRs created per repo per day (GH#3821)
 PRODUCT_RESERVATION_PCT="${PRODUCT_RESERVATION_PCT:-60}"                                                # % of worker slots reserved for product repos (t1423)
 QUALITY_DEBT_CAP_PCT="${QUALITY_DEBT_CAP_PCT:-$(config_get "orchestration.quality_debt_cap_pct" "30")}" # % cap for quality-debt dispatch share
-if [[ -z "${PULSE_MODEL:-}" ]]; then
-	PULSE_MODEL=$(config_get "orchestration.pulse_model" "")
-	if [[ "$PULSE_MODEL" == "null" ]]; then
-		PULSE_MODEL=""
-	fi
+# GH#17769: PULSE_MODEL and AIDEVOPS_HEADLESS_MODELS are deprecated.
+# Model routing is now derived from the OAuth pool + routing table at runtime.
+# Backward compat: if legacy env vars are still set, log deprecation warnings.
+if [[ -n "${PULSE_MODEL:-}" ]]; then
+	echo "[pulse-wrapper] WARN: PULSE_MODEL env var is deprecated (v3.7+). Model routing is now automatic via pool + routing table. Remove this export from credentials.sh." >&2
 fi
-if [[ -z "${AIDEVOPS_HEADLESS_MODELS:-}" ]]; then
-	AIDEVOPS_HEADLESS_MODELS=$(config_get "orchestration.headless_models" "")
-	if [[ "$AIDEVOPS_HEADLESS_MODELS" == "null" ]]; then
-		AIDEVOPS_HEADLESS_MODELS=""
-	fi
-	if [[ -n "$AIDEVOPS_HEADLESS_MODELS" ]]; then
-		export AIDEVOPS_HEADLESS_MODELS
-	fi
+if [[ -n "${AIDEVOPS_HEADLESS_MODELS:-}" ]]; then
+	echo "[pulse-wrapper] WARN: AIDEVOPS_HEADLESS_MODELS env var is deprecated (v3.7+). Model routing is now automatic via pool + routing table. Remove this export from credentials.sh." >&2
 fi
+# Derive pulse model from routing table — pulse always uses Anthropic sonnet
+ROUTING_TABLE="${SCRIPT_DIR}/../configs/model-routing-table.json"
+if [[ -z "${PULSE_MODEL:-}" ]] && [[ -f "$ROUTING_TABLE" ]] && command -v jq >/dev/null 2>&1; then
+	PULSE_MODEL=$(jq -r '.tiers.sonnet.models[] | select(startswith("anthropic/"))' "$ROUTING_TABLE" 2>/dev/null | head -1) || PULSE_MODEL=""
+fi
+# Absolute fallback
+PULSE_MODEL="${PULSE_MODEL:-anthropic/claude-sonnet-4-6}"
 PULSE_BACKFILL_MAX_ATTEMPTS="${PULSE_BACKFILL_MAX_ATTEMPTS:-3}"                                            # Additional pulse passes when below utilization target (t1453)
 PULSE_LAUNCH_GRACE_SECONDS="${PULSE_LAUNCH_GRACE_SECONDS:-35}"                                             # Max grace window for worker process to appear after dispatch (t1453) — raised from 20s to 35s: sandbox-exec + opencode cold-start takes ~25-30s
 PULSE_LAUNCH_SETTLE_BATCH_MAX="${PULSE_LAUNCH_SETTLE_BATCH_MAX:-5}"                                        # Dispatch count at which the full PULSE_LAUNCH_GRACE_SECONDS wait applies (t1887)
@@ -338,7 +340,7 @@ OPENCODE_BIN="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "opencod
 # to accumulate under that project even when it had pulse:false (GH#5136).
 # Override via env var if a specific directory is needed.
 PULSE_DIR="${PULSE_DIR:-${HOME}/.aidevops/.agent-workspace}"
-PULSE_MODEL="${PULSE_MODEL:-}"
+# PULSE_MODEL is derived from routing table above (GH#17769) — no longer user-configurable
 HEADLESS_RUNTIME_HELPER="${HEADLESS_RUNTIME_HELPER:-${SCRIPT_DIR}/headless-runtime-helper.sh}"
 MODEL_AVAILABILITY_HELPER="${MODEL_AVAILABILITY_HELPER:-${SCRIPT_DIR}/model-availability-helper.sh}"
 REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -329,7 +329,8 @@ extract_provider_from_cmd() {
 		model="${BASH_REMATCH[1]}"
 	fi
 
-	# Fall back to AIDEVOPS_HEADLESS_MODELS env var embedded in command
+	# Legacy fallback: AIDEVOPS_HEADLESS_MODELS env var embedded in command
+	# (deprecated GH#17769 — kept for backward compat with in-flight workers)
 	if [[ -z "$model" && "$cmd" =~ AIDEVOPS_HEADLESS_MODELS=([^[:space:]]+) ]]; then
 		model="${BASH_REMATCH[1]}"
 		# Take first model if comma-separated list

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -69,8 +69,16 @@ Supervisor resolves automatically. Interactive: `compare-models-helper.sh discov
 
 ## Headless Dispatch
 
-- **Pulse**: Anthropic sonnet only — OpenAI models exit without activity (proven). `PULSE_MODEL=anthropic/claude-sonnet-4-6`.
-- **Workers**: Any provider. `AIDEVOPS_HEADLESS_MODELS` is rotation with backoff, not escalation. Tier escalation: `tier:reasoning` labels (cascade: `tier:simple` → `tier:standard` → `tier:reasoning`).
+**Automatic model derivation (GH#17769):** The headless model list is derived at runtime — no env var configuration needed:
+
+1. **OAuth pool** (`oauth-pool-helper.sh list all`) → available providers (cheap JSON read, no API calls)
+2. **Routing table** (`configs/model-routing-table.json`) → sonnet-tier model per provider
+3. **Result**: round-robin list of agentic models matching the user's active accounts
+
+- **Pulse**: Always Anthropic sonnet (derived from routing table). OpenAI models exit without activity (proven).
+- **Workers**: Round-robin across all pool providers' sonnet models. Tier escalation: `tier:reasoning` labels (cascade: `tier:simple` → `tier:standard` → `tier:reasoning`).
+- **Fallback**: If pool or routing table unavailable, falls back to `anthropic/claude-sonnet-4-6`.
+- **Deprecated**: `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle with deprecation warnings. Remove from `credentials.sh`.
 
 ## CLI Tools
 

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -110,27 +110,16 @@ _determine_pulse_install() {
 	return 0
 }
 
+# GH#17769: These functions are deprecated — model routing is now derived
+# from the OAuth pool + routing table at runtime. Kept as no-ops for one
+# release cycle in case external scripts call them.
 _resolve_headless_models_override() {
-	local configured="${AIDEVOPS_HEADLESS_MODELS:-}"
-	if [[ -z "$configured" ]] && type config_get &>/dev/null; then
-		configured=$(config_get "orchestration.headless_models" "")
-		if [[ "$configured" == "null" ]]; then
-			configured=""
-		fi
-	fi
-	printf '%s' "$configured"
+	printf '%s' ""
 	return 0
 }
 
 _resolve_pulse_model_override() {
-	local configured="${PULSE_MODEL:-}"
-	if [[ -z "$configured" ]] && type config_get &>/dev/null; then
-		configured=$(config_get "orchestration.pulse_model" "")
-		if [[ "$configured" == "null" ]]; then
-			configured=""
-		fi
-	fi
-	printf '%s' "$configured"
+	printf '%s' ""
 	return 0
 }
 
@@ -172,9 +161,8 @@ _resolve_pulse_runtime_binary() {
 }
 
 _build_pulse_linux_env() {
-	# GH#17546: Model config (AIDEVOPS_HEADLESS_MODELS, PULSE_MODEL,
-	# AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST) no longer embedded in cron/systemd env.
-	# pulse-wrapper.sh sources credentials.sh at runtime for current values.
+	# GH#17546/GH#17769: Model config is derived from pool + routing table at
+	# runtime. No model env vars embedded in cron/systemd.
 	local _pulse_env="PULSE_DIR=${HOME}/.aidevops/.agent-workspace
 PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}"
 
@@ -300,12 +288,9 @@ _cleanup_old_pulse_plists() {
 }
 
 # Build XML environment variable fragment for headless model overrides.
-# GH#17546: Model config (AIDEVOPS_HEADLESS_MODELS, PULSE_MODEL,
-# AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST) is NO LONGER embedded in the plist.
-# Baking these at setup time caused drift: credentials.sh gets updated but
-# the loaded launchd agent keeps using whatever was baked at last setup.
-# The pulse-wrapper now sources credentials.sh at startup, which is the
-# single source of truth for model routing config.
+# GH#17546: Model config was removed from plist embedding.
+# GH#17769: Model routing is now derived from pool + routing table at runtime.
+# No env vars needed — pulse-wrapper.sh reads the routing table directly.
 _build_pulse_headless_env_xml() {
 	# Intentionally empty — model config read from credentials.sh at runtime.
 	printf '%s' ""

--- a/setup.sh
+++ b/setup.sh
@@ -813,39 +813,36 @@ _setup_print_header() {
 	return 0
 }
 
+# GH#17769: Comment out deprecated model env vars in a single credentials file.
+_comment_out_deprecated_model_vars() {
+	local file="$1"
+	local deprecated_vars="AIDEVOPS_HEADLESS_MODELS|PULSE_MODEL"
+	local deprecation_note="# DEPRECATED by aidevops v3.7+ — model routing is now automatic (GH#17769)"
+	[[ -f "$file" ]] || return 0
+	# Only process lines that are active exports (not already commented)
+	if grep -qE "^[[:space:]]*export[[:space:]]+(${deprecated_vars})=" "$file" 2>/dev/null; then
+		sed -i.bak -E "s/^([[:space:]]*)(export[[:space:]]+(${deprecated_vars})=.*)$/\1${deprecation_note}\n\1# \2/" "$file"
+		rm -f "${file}.bak"
+		print_info "Commented out deprecated model env vars in $(basename "$file")"
+	fi
+	return 0
+}
+
 # GH#17769: Comment out deprecated model env vars from credentials.sh.
 # Runs on every `aidevops update`. Uses sed to comment out (not delete) lines
 # so the user's file history is preserved.
 _cleanup_legacy_model_config() {
 	local creds_file="${HOME}/.config/aidevops/credentials.sh"
-	local deprecated_vars="AIDEVOPS_HEADLESS_MODELS|PULSE_MODEL"
-	local deprecation_note="# DEPRECATED by aidevops v3.7+ — model routing is now automatic (GH#17769)"
-
-	_comment_out_deprecated_in_file() {
-		local file="$1"
-		[[ -f "$file" ]] || return 0
-		# Only process lines that are active exports (not already commented)
-		if grep -qE "^[[:space:]]*export[[:space:]]+(${deprecated_vars})=" "$file" 2>/dev/null; then
-			# Add deprecation note and comment out the export line
-			sed -i.bak -E "s/^([[:space:]]*)(export[[:space:]]+(${deprecated_vars})=.*)$/\1${deprecation_note}\n\1# \2/" "$file"
-			rm -f "${file}.bak"
-			print_info "Commented out deprecated model env vars in $(basename "$file")"
-		fi
-		return 0
-	}
-
-	# Clean up main credentials.sh
-	_comment_out_deprecated_in_file "$creds_file"
+	_comment_out_deprecated_model_vars "$creds_file"
 
 	# Clean up tenant credentials files
 	local tenant_dir="${HOME}/.config/aidevops/tenants"
 	if [[ -d "$tenant_dir" ]]; then
 		local tenant_creds=""
 		while IFS= read -r -d '' tenant_creds; do
-			_comment_out_deprecated_in_file "$tenant_creds"
+			_comment_out_deprecated_model_vars "$tenant_creds"
 		done < <(find "$tenant_dir" -name "credentials.sh" -print0 2>/dev/null)
 	fi
-
 	return 0
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -813,6 +813,42 @@ _setup_print_header() {
 	return 0
 }
 
+# GH#17769: Comment out deprecated model env vars from credentials.sh.
+# Runs on every `aidevops update`. Uses sed to comment out (not delete) lines
+# so the user's file history is preserved.
+_cleanup_legacy_model_config() {
+	local creds_file="${HOME}/.config/aidevops/credentials.sh"
+	local deprecated_vars="AIDEVOPS_HEADLESS_MODELS|PULSE_MODEL"
+	local deprecation_note="# DEPRECATED by aidevops v3.7+ — model routing is now automatic (GH#17769)"
+
+	_comment_out_deprecated_in_file() {
+		local file="$1"
+		[[ -f "$file" ]] || return 0
+		# Only process lines that are active exports (not already commented)
+		if grep -qE "^[[:space:]]*export[[:space:]]+(${deprecated_vars})=" "$file" 2>/dev/null; then
+			# Add deprecation note and comment out the export line
+			sed -i.bak -E "s/^([[:space:]]*)(export[[:space:]]+(${deprecated_vars})=.*)$/\1${deprecation_note}\n\1# \2/" "$file"
+			rm -f "${file}.bak"
+			print_info "Commented out deprecated model env vars in $(basename "$file")"
+		fi
+		return 0
+	}
+
+	# Clean up main credentials.sh
+	_comment_out_deprecated_in_file "$creds_file"
+
+	# Clean up tenant credentials files
+	local tenant_dir="${HOME}/.config/aidevops/tenants"
+	if [[ -d "$tenant_dir" ]]; then
+		local tenant_creds=""
+		while IFS= read -r -d '' tenant_creds; do
+			_comment_out_deprecated_in_file "$tenant_creds"
+		done < <(find "$tenant_dir" -name "credentials.sh" -print0 2>/dev/null)
+	fi
+
+	return 0
+}
+
 # Non-interactive path: deploy agents and run safe migrations only (no prompts).
 _setup_run_non_interactive() {
 	print_info "Non-interactive mode: deploying agents and running safe migrations only"
@@ -832,6 +868,7 @@ _setup_run_non_interactive() {
 	backfill_issue_relationships
 	cleanup_deprecated_mcps
 	cleanup_stale_bun_opencode
+	_cleanup_legacy_model_config
 	validate_opencode_config
 	deploy_aidevops_agents
 	sync_agent_sources
@@ -924,6 +961,7 @@ _setup_run_interactive() {
 	confirm_step "Backfill GitHub issue relationships (blocked-by, sub-issues)" && backfill_issue_relationships
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
+	_cleanup_legacy_model_config
 	confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 	confirm_step "Extract OpenCode prompts" && extract_opencode_prompts
 	confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -46,7 +46,9 @@ export AIDEVOPS_HEADLESS_RUNTIME_DIR="$TEST_TMP_DIR/runtime"
 export STUB_LOG_FILE="$TEST_TMP_DIR/opencode-args.log"
 # Set a known model list so tests are self-contained and don't depend on
 # the user's environment. Includes two providers for rotation/fallback tests.
-export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex"
+# GH#17769: AIDEVOPS_HEADLESS_MODELS is deprecated but respected as override
+# for backward compat. Using agentic models only (codex models removed).
+export AIDEVOPS_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.4"
 unset AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST
 # Disable sandbox for tests — the sandbox strips env vars (STUB_*) needed
 # by the opencode stub, causing test failures.
@@ -481,26 +483,18 @@ else
 	pass "sourcing sandbox-exec-helper.sh with watchdog args does not print help text (GH#6617)"
 fi
 
-section "JSONC Config Overrides"
-CONFIG_USER_FILE="$TEST_TMP_DIR/headless-config.jsonc"
-cat >"$CONFIG_USER_FILE" <<'JSONC'
-{
-  "orchestration": {
-    "headless_models": "openai/gpt-5.4"
-  }
-}
-JSONC
+section "Deprecated Env Var Override (GH#17769)"
+# GH#17769: AIDEVOPS_HEADLESS_MODELS is deprecated but respected as override
+# for one release cycle. When set, it should be used directly.
 config_selected=$(
-	AIDEVOPS_HEADLESS_MODELS="" \
-		JSONC_DEFAULTS="$REPO_DIR/.agents/configs/aidevops.defaults.jsonc" \
-		JSONC_USER="$CONFIG_USER_FILE" \
+	AIDEVOPS_HEADLESS_MODELS="openai/gpt-5.4" \
 		OPENAI_API_KEY="test-key-for-provider-auth-check" \
 		bash "$HELPER" select --role worker 2>/dev/null || true
 )
 if [[ "$config_selected" == "openai/gpt-5.4" ]]; then
-	pass "JSONC orchestration.headless_models overrides default selection"
+	pass "Deprecated AIDEVOPS_HEADLESS_MODELS env var override is respected"
 else
-	fail "JSONC orchestration.headless_models overrides default selection" "got: $config_selected"
+	fail "Deprecated AIDEVOPS_HEADLESS_MODELS env var override is respected" "got: $config_selected"
 fi
 
 section "Metrics Review Signals"


### PR DESCRIPTION
## Summary

Resolves #17769

Replace `AIDEVOPS_HEADLESS_MODELS` and `PULSE_MODEL` env vars with automatic derivation from the OAuth pool and model routing table at runtime.

**Flow**: pool (available providers) → routing table (sonnet-tier models) → round-robin list.

## Changes

- **headless-runtime-helper.sh**: Rewrite `get_configured_models()` to query pool for available providers, then look up each provider's sonnet-tier model from the routing table. Remove `_is_non_agentic_model`/`_get_agentic_replacement` (no longer needed — routing table is source of truth).
- **pulse-wrapper.sh**: Derive `PULSE_MODEL` from routing table instead of env var. Always uses Anthropic sonnet.
- **setup.sh**: Add `_cleanup_legacy_model_config()` to comment out deprecated exports from `credentials.sh` on every `aidevops update`.
- **setup-modules/schedulers.sh**: Deprecate `_resolve_headless_models_override` and `_resolve_pulse_model_override`.
- **automate.md, model-routing.md, pulse.md**: Update docs for new derivation flow.
- **configs**: Mark `pulse_model` and `headless_models` as deprecated in schema/defaults.
- **tests**: Update `test-headless-runtime-helper.sh` for new behavior.

## Backward Compatibility

Legacy env vars (`AIDEVOPS_HEADLESS_MODELS`, `PULSE_MODEL`) are respected as overrides for one release cycle with deprecation warnings logged. The `_cleanup_legacy_model_config()` function in setup.sh comments out (not deletes) deprecated lines with a note.

## Runtime Testing

- **Risk**: Medium (env var config, model selection, scheduler config)
- **Verification**: `self-assessed` — tested model selection with and without env vars:
  - `unset AIDEVOPS_HEADLESS_MODELS && bash headless-runtime-helper.sh select --role worker` → `anthropic/claude-sonnet-4-6` (derived from pool)
  - With legacy env var set → deprecation warning logged, override respected
  - No codex models appear in output
- ShellCheck clean on all modified `.sh` files

---
[aidevops.sh](https://aidevops.sh) v3.6.162 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 13m and 25,271 tokens on this as a headless worker.