### PR TITLE
fix(headless): pin OpenCode to 1.3.16 to dodge run regression

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -23,10 +23,12 @@ _SHARED_CONSTANTS_LOADED=1
 # Set to "latest" to resume tracking upstream. Grep for the variable name to
 # find all consumers that need updating when unpinning.
 
-# OpenCode unpinned: root cause was SQLite contention (shared DB, busy_timeout=0),
-# not version-specific. Fixed by DB isolation per worker (v3.6.130).
-# Upstream context: https://github.com/anomalyco/opencode/issues/21215
-readonly OPENCODE_PINNED_VERSION="latest"
+# OpenCode pinned to 1.3.16: 1.3.17 ships an `opencode run` regression that
+# fails immediately with "Error: Session not found" (exit 0, no API call made),
+# breaking the headless canary across all repos and blocking every pulse dispatch.
+# Reproduced with `--pure` and a fresh DB — not a plugin or data issue.
+# See: marcusquinn/aidevops#17792
+readonly OPENCODE_PINNED_VERSION="1.3.16"
 
 # =============================================================================
 # HTTP and API Constants


### PR DESCRIPTION
OpenCode 1.3.17 ships a regression where 'opencode run <prompt>' exits 0 immediately with 'Error: Session not found' before making any API call. This causes the headless canary to fail across every pulse-managed repo, blocking all autonomous dispatch.

Reproduced with --pure (no plugins) and a fresh opencode.db, ruling out plugin and data corruption causes. 1.3.16 works correctly.

Refs marcusquinn/aidevops#17792

<!-- SPDX-License-Identifier: MIT -->
<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->

## Summary

Brief description of changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Runtime Testing

**Testing level** (select one):

- [ ] `runtime-verified` — dev environment started, smoke/stability checks passed
- [ ] `self-assessed` — logic reviewed, no runtime available (docs, config, shell scripts)
- [ ] `untested` — not tested (explain why below)

**Test results** (fill in for runtime-verified; N/A for others):

| Check | Result | Notes |
|-------|--------|-------|
| Dev environment started | pass / fail / N/A | |
| Smoke pages loaded | pass / fail / N/A | |
| Stability check (no reload loops) | pass / fail / N/A | |
| Key user flow | pass / fail / N/A | |

**Escalation warnings** (check all that apply — these require runtime-verified level):

- [ ] Contains polling or reload logic
- [ ] Touches payment, auth, or session handling
- [ ] Modifies database schema or migrations
- [ ] Changes environment variables or secrets handling
- [ ] Affects production deploy or release pipeline

**Justification if untested or escalation warnings present:**

<!-- Explain why runtime verification was not possible, or describe manual verification steps taken for escalation-flagged patterns. -->

## Checklist

- [ ] I have followed the commit message conventions
- [ ] I have updated documentation if needed
- [ ] For architectural changes or new integrations, I have obtained maintainer approval (see [CONTRIBUTING.md](../CONTRIBUTING.md#scope-of-contributions))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned internal tool to a stable version to resolve a regression affecting command execution in the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->