### PR TITLE
GH#17799: bump nesting depth threshold to 279 (t2028 follow-up)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -34,7 +34,10 @@ FUNCTION_COMPLEXITY_THRESHOLD=420
 # scripts merged after threshold was set — not introduced by this PR)
 # Bumped to 278 (GH#17560): pre-existing regression on main (2 new violations from
 # scripts merged after threshold was set — not introduced by this PR)
-NESTING_DEPTH_THRESHOLD=278
+# Bumped to 279 (GH#17799/t2028): cch-extract.sh adds 1 violation — awk depth
+# checker counts if/case across entire file without function-boundary resets;
+# new cleanup_tmpfiles() function with if-block pushes global depth counter over 278
+NESTING_DEPTH_THRESHOLD=279
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Follow-up to #17799 (t2028: cch-extract.sh Bun binary support). The PR was merged before this threshold bump could be included, leaving the CI nesting depth check at 278 while the codebase now has 279 violations.

## Change

- Bumps `NESTING_DEPTH_THRESHOLD` from 278 to 279 in `.agents/configs/complexity-thresholds.conf`
- Follows the documented pattern for threshold bumps (GH#5628)

## Why

The new `cleanup_tmpfiles()` function in `cch-extract.sh` contains an `if` block. The CI awk depth checker counts `if/case/for` across the entire file without function-boundary resets, so this pushes the global depth counter from 278 to 279.


---
[aidevops.sh](https://aidevops.sh) v3.6.165 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 9m and 18,885 tokens on this as a headless worker.