### PR TITLE
GH#17810: fix(full-loop) pre-start maintainer gate check prevents CI failures

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -34,6 +34,7 @@ Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d
 
 **Implementation context (t1901 — read BEFORE exploring):** After resolving the issue, read its body. Look for a "Worker Guidance" or "How" section containing Files to Modify, Implementation Steps, and Verification commands. If present, these are your mentor's instructions — follow them directly. Read only the referenced files, not the entire codebase. If the issue body lacks file paths and implementation steps, exit BLOCKED with reason "missing implementation context" rather than exploring broadly.
 
+- **Maintainer gate pre-check (GH#17810 — MANDATORY):** Before starting work, verify the linked issue does not have `needs-maintainer-review` label and has an assignee. `full-loop-helper.sh start` enforces this automatically — if blocked, exit with reason "linked issue has needs-maintainer-review label" or "linked issue has no assignee". Do NOT create a PR for an issue that will fail the CI maintainer gate.
 - **Decomposition (t1408.2):** Skip if `--no-decompose` or has subtasks. `task-decompose-helper.sh classify "$TASK_DESC"`. Composite headless → auto-decompose, exit `DECOMPOSED: ...`. Max depth 3.
 - **Claim (t1017):** Add `assignee:<identity> started:<ISO>` to TODO.md. Push rejection = claimed → **STOP**.
 - **Issue labels (t1343/#2452):** Guard: state must be `OPEN`. Set `status:in-progress`, remove stale labels. Lifecycle: `available` → `queued` → `in-progress` → `in-review` → `done`. Idempotent (t1687).

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -157,6 +157,85 @@ emit_deploy_phase() {
 	echo "Run setup.sh per full-loop.md guidance."
 }
 
+# Pre-start maintainer gate check (GH#17810).
+# Extracts the first issue number from the prompt and verifies the linked
+# issue does not have needs-maintainer-review label or missing assignee.
+# Mirrors the logic in .github/workflows/maintainer-gate.yml check-pr job.
+#
+# Returns:
+#   0 — gate passes (safe to start)
+#   1 — gate blocked (do NOT start work)
+#
+# Skips gracefully when:
+#   - No issue number found in prompt (not all tasks have linked issues)
+#   - gh CLI unavailable or API call fails (fail-open to avoid blocking non-issue tasks)
+#   - Issue is closed (already reviewed)
+_check_linked_issue_gate() {
+	local prompt="$1"
+	local repo="${2:-}"
+
+	# Extract first issue number from prompt — look for #NNN or issue/NNN patterns
+	local issue_num
+	issue_num=$(echo "$prompt" | grep -oE '#[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+	if [[ -z "$issue_num" ]]; then
+		# No issue number in prompt — skip gate (not all tasks reference issues)
+		return 0
+	fi
+
+	# Resolve repo from git remote if not provided
+	if [[ -z "$repo" ]]; then
+		repo=$(git remote get-url origin 2>/dev/null | sed -E 's|.*github\.com[:/]||;s|\.git$||' || true)
+	fi
+	if [[ -z "$repo" ]]; then
+		# Cannot determine repo — skip gate (fail-open)
+		return 0
+	fi
+
+	# Fetch issue data — fail-open on API errors (don't block non-issue tasks)
+	local raw_issue
+	raw_issue=$(gh api "repos/${repo}/issues/${issue_num}" 2>/dev/null) || {
+		print_warning "Maintainer gate pre-check: could not fetch issue #${issue_num} — skipping gate"
+		return 0
+	}
+
+	local state labels assignees
+	state=$(echo "$raw_issue" | jq -r '.state' 2>/dev/null || echo "unknown")
+	labels=$(echo "$raw_issue" | jq -r '[.labels[]?.name] | .[]' 2>/dev/null || true)
+	assignees=$(echo "$raw_issue" | jq -r '[.assignees[]?.login] | .[]' 2>/dev/null || true)
+
+	# Skip closed issues — they've already been reviewed
+	if [[ "$state" == "closed" ]]; then
+		return 0
+	fi
+
+	local blocked=false reasons=""
+
+	# Check 1: needs-maintainer-review label
+	if echo "$labels" | grep -q 'needs-maintainer-review'; then
+		blocked=true
+		reasons="${reasons}Issue #${issue_num} has \`needs-maintainer-review\` label — a maintainer must approve before work begins.\n"
+	fi
+
+	# Check 2: no assignee (exempt quality-debt issues per GH#6623)
+	if [[ -z "$assignees" ]]; then
+		if echo "$labels" | grep -q 'quality-debt'; then
+			: # exempt
+		else
+			blocked=true
+			reasons="${reasons}Issue #${issue_num} has no assignee — assign the issue before starting work.\n"
+		fi
+	fi
+
+	if [[ "$blocked" == "true" ]]; then
+		print_error "Maintainer gate pre-check BLOCKED — cannot start work:"
+		printf '%b' "$reasons" >&2
+		printf "To unblock:\n  1. Run: sudo aidevops approve issue %s\n  2. Assign the issue to yourself\n" "$issue_num" >&2
+		return 1
+	fi
+
+	return 0
+}
+
 # Initialize option variables with defaults so set -u doesn't crash on
 # export when flags are not passed.
 _init_start_defaults() {
@@ -264,6 +343,12 @@ cmd_start() {
 		print_error "Must be on a feature branch"
 		return 1
 	}
+
+	# Pre-start maintainer gate check (GH#17810): block if linked issue has
+	# needs-maintainer-review label or no assignee. Mirrors the CI gate in
+	# .github/workflows/maintainer-gate.yml so workers fail fast locally
+	# instead of creating PRs that will always fail CI.
+	_check_linked_issue_gate "$prompt" || return 1
 
 	printf "\n${BOLD}${BLUE}=== FULL DEVELOPMENT LOOP - STARTING ===${NC}\n  Task: %s\n  Branch: %s | Headless: %s\n\n" \
 		"$prompt" "$(get_current_branch)" "$HEADLESS"


### PR DESCRIPTION
## Summary

Adds a pre-start maintainer gate check to `full-loop-helper.sh` that mirrors the CI `maintainer-gate.yml` check-pr job logic. Workers now fail fast locally before creating PRs that will always fail the CI gate.

## Root Cause

PR #17791 was created for issue #17790 (authored by a CONTRIBUTOR, `needs-maintainer-review` applied by the triage gate) before the issue was approved. The CI gate correctly blocked the PR. This pattern occurred twice (2 events), triggering the systemic failure detector.

The pulse already filters `needs-maintainer-review` issues from dispatch (pulse-wrapper.sh:1188), but interactive and headless worker sessions calling `full-loop-helper.sh start` had no equivalent guard.

## What

- **EDIT** `.agents/scripts/full-loop-helper.sh` — adds `_check_linked_issue_gate()` function called from `cmd_start` before work begins. Extracts issue number from prompt, checks `needs-maintainer-review` label and assignee, blocks with clear message if gate fails.
- **EDIT** `.agents/scripts/commands/full-loop.md` — documents the mandatory pre-start check.

## Safety properties

- **Fail-open on API errors** — if `gh` is unavailable or the API call fails, the gate skips (doesn't block non-issue tasks)
- **Skips closed issues** — already reviewed, no need to block
- **Skips when no issue number** — not all tasks reference issues
- **quality-debt exempt** — mirrors the CI gate's GH#6623 exemption
- **No side effects** — read-only check, no labels or comments written

## Verification

```bash
shellcheck .agents/scripts/full-loop-helper.sh
# Only SC1091 (info) about sourced file — pre-existing, not a new violation
```

## Runtime Testing

Risk: **Low** — read-only pre-check, no state changes, no network writes. Self-assessed.

Resolves #17810

---

---
[aidevops.sh](https://aidevops.sh) v3.6.165 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 5m and 12,687 tokens on this as a headless worker.