### PR TITLE
t1929: Fix duplicate Contributor health issues caused by API failure in _get_runner_role

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -74,13 +74,16 @@ _validate_repo_slug() {
 #######################################
 # Determine runner role for a repo: supervisor or contributor
 #
-# Checks the runner's permission on the repo via the GitHub API.
-# Maintainers (admin, maintain, write) are "supervisor"; everyone
-# else (read, none, 404) is "contributor". API failures default to
-# "contributor" (fail closed — never grant elevated status on error).
+# Resolution order (first match wins):
+#   1. In-process env-var cache (per pulse cycle, no I/O)
+#   2. repos.json maintainer field (deterministic, no API)
+#   3. Persistent disk cache with 24h TTL (~/.aidevops/logs/)
+#   4. GitHub API permission check (fallback)
 #
-# Results are cached per runner+repo for the duration of the pulse
-# to avoid repeated API calls (one call per repo per pulse cycle).
+# Layers 1-3 prevent the bug where a transient API failure (rate
+# limit, network) defaulted to "contributor" and created duplicate
+# [Contributor:user] health issues alongside the correct [Supervisor]
+# ones. See t1929 for the full root-cause analysis.
 #
 # Arguments:
 #   $1 - runner GitHub login
@@ -97,7 +100,7 @@ _get_runner_role() {
 		return 0
 	fi
 
-	# Check cache (env var keyed by slug — avoids repeated API calls)
+	# Layer 1: in-process env-var cache (per pulse cycle)
 	local cache_key="__RUNNER_ROLE_${repo_slug//[^a-zA-Z0-9]/_}"
 	local cached_role="${!cache_key:-}"
 	if [[ -n "$cached_role" ]]; then
@@ -105,17 +108,70 @@ _get_runner_role() {
 		return 0
 	fi
 
-	local role="contributor"
+	# Layer 2: repos.json maintainer field (deterministic, no API needed).
+	# If the runner matches the registered maintainer, they are supervisor.
+	# This is the primary defense against API failure causing role misdetection.
+	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+	if [[ -f "$repos_json" ]]; then
+		local registered_maintainer
+		registered_maintainer=$(jq -r \
+			--arg slug "$repo_slug" \
+			'.initialized_repos[] | select(.slug == $slug) | .maintainer // empty' \
+			"$repos_json" 2>/dev/null | head -1)
+		if [[ -n "$registered_maintainer" && "$registered_maintainer" == "$runner_user" ]]; then
+			export "$cache_key=supervisor"
+			_persist_role_cache "$runner_user" "$repo_slug" "supervisor"
+			echo "supervisor"
+			return 0
+		fi
+	fi
+
+	# Layer 3: persistent disk cache with 24h TTL.
+	# Survives across pulse cycles; prevents API failure from flipping role.
+	local disk_cache_dir="${HOME}/.aidevops/logs"
+	local slug_safe="${repo_slug//\//-}"
+	local disk_cache_file="${disk_cache_dir}/runner-role-${runner_user}-${slug_safe}"
+	if [[ -f "$disk_cache_file" ]]; then
+		local disk_role disk_ts now_ts
+		IFS='|' read -r disk_role disk_ts <"$disk_cache_file" 2>/dev/null || disk_role=""
+		disk_ts="${disk_ts//[^0-9]/}"
+		disk_ts="${disk_ts:-0}"
+		now_ts=$(date +%s)
+		# 24h TTL (86400 seconds)
+		if [[ -n "$disk_role" && $((now_ts - disk_ts)) -lt 86400 ]]; then
+			export "$cache_key=$disk_role"
+			echo "$disk_role"
+			return 0
+		fi
+	fi
+
+	# Layer 4: GitHub API permission check (fallback).
+	# On failure, use expired disk cache if available rather than defaulting
+	# to "contributor" — this prevents role flip-flop on transient errors.
+	local role=""
 	local api_path="repos/${repo_slug}/collaborators/${runner_user}/permission"
 	local response
-	response=$(gh api "$api_path" --jq '.permission // empty') || response=""
+	response=$(gh api "$api_path" --jq '.permission // empty' 2>/dev/null) || response=""
 
 	case "$response" in
 	admin | maintain | write)
 		role="supervisor"
 		;;
-	read | none | "")
+	read | none)
 		role="contributor"
+		;;
+	"")
+		# API failure — use expired disk cache if available (stale > wrong)
+		if [[ -f "$disk_cache_file" ]]; then
+			local stale_role _stale_ts
+			IFS='|' read -r stale_role _stale_ts <"$disk_cache_file" 2>/dev/null || stale_role=""
+			if [[ -n "$stale_role" ]]; then
+				echo "[stats] _get_runner_role: API failed for ${repo_slug}, using stale cache: ${stale_role}" >>"${LOGFILE:-/dev/null}"
+				role="$stale_role"
+			fi
+		fi
+		# No cache at all — default to contributor (fail closed)
+		[[ -z "$role" ]] && role="contributor"
 		;;
 	*)
 		# Unknown permission value — fail closed
@@ -123,10 +179,109 @@ _get_runner_role() {
 		;;
 	esac
 
-	# Cache for this pulse cycle
+	# Persist to both caches
 	export "$cache_key=$role"
+	_persist_role_cache "$runner_user" "$repo_slug" "$role"
 
 	echo "$role"
+	return 0
+}
+
+# Write role to persistent disk cache.
+# Format: "role|epoch_timestamp" — simple, no JSON dependency.
+# Arguments:
+#   $1 - runner_user
+#   $2 - repo_slug
+#   $3 - role (supervisor|contributor)
+_persist_role_cache() {
+	local runner_user="$1"
+	local repo_slug="$2"
+	local role="$3"
+	local disk_cache_dir="${HOME}/.aidevops/logs"
+	local slug_safe="${repo_slug//\//-}"
+	local disk_cache_file="${disk_cache_dir}/runner-role-${runner_user}-${slug_safe}"
+	mkdir -p "$disk_cache_dir" 2>/dev/null || true
+	printf '%s|%s\n' "$role" "$(date +%s)" >"$disk_cache_file" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Clean up a stale health issue from the opposite role.
+#
+# When the runner is confirmed as "supervisor", any lingering
+# "contributor" health issue (and its cache file) is a duplicate
+# created by a past API failure. Close it and remove the cache.
+# Same logic applies in reverse (contributor → stale supervisor).
+#
+# Called once per repo per health-issue update cycle. Idempotent —
+# does nothing if no opposite-role issue exists.
+#
+# Arguments:
+#   $1 - runner_user
+#   $2 - runner_role (the CORRECT current role)
+#   $3 - repo_slug
+#   $4 - slug_safe (slug with / replaced by -)
+#   $5 - cache_dir
+#######################################
+_cleanup_opposite_role_health_issue() {
+	local runner_user="$1"
+	local runner_role="$2"
+	local repo_slug="$3"
+	local slug_safe="$4"
+	local cache_dir="$5"
+
+	local opposite_role
+	if [[ "$runner_role" == "supervisor" ]]; then
+		opposite_role="contributor"
+	else
+		opposite_role="supervisor"
+	fi
+
+	local opposite_cache="${cache_dir}/health-issue-${runner_user}-${opposite_role}-${slug_safe}"
+	# Also check legacy cache files (without role prefix, from older versions)
+	local legacy_cache="${cache_dir}/health-issue-${runner_user}-${slug_safe}"
+
+	local stale_num=""
+	if [[ -f "$opposite_cache" ]]; then
+		stale_num=$(cat "$opposite_cache" 2>/dev/null || echo "")
+	fi
+
+	if [[ -n "$stale_num" ]]; then
+		local stale_state
+		stale_state=$(gh issue view "$stale_num" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "")
+		if [[ "$stale_state" == "OPEN" ]]; then
+			# Unpin if it was pinned (supervisor issues get pinned)
+			if [[ "$opposite_role" == "supervisor" ]]; then
+				_unpin_health_issue "$stale_num" "$repo_slug"
+			fi
+			gh issue close "$stale_num" --repo "$repo_slug" \
+				--comment "Closing duplicate ${opposite_role} health issue. Runner role is ${runner_role} — the correct health issue is the [${runner_role^}:${runner_user}] issue. See t1929." 2>/dev/null || true
+			echo "[stats] Closed stale ${opposite_role} health issue #${stale_num} for ${repo_slug} (runner is ${runner_role})" >>"${LOGFILE:-/dev/null}"
+		fi
+		rm -f "$opposite_cache" 2>/dev/null || true
+	fi
+
+	# Clean up legacy cache file (no role prefix) if it exists and differs
+	# from the current role's cache file. These are from before role-aware naming.
+	if [[ -f "$legacy_cache" ]]; then
+		local legacy_num
+		legacy_num=$(cat "$legacy_cache" 2>/dev/null || echo "")
+		# Only remove if the legacy cache points to a different issue than current
+		local current_cache="${cache_dir}/health-issue-${runner_user}-${runner_role}-${slug_safe}"
+		local current_num=""
+		[[ -f "$current_cache" ]] && current_num=$(cat "$current_cache" 2>/dev/null || echo "")
+		if [[ -n "$legacy_num" && "$legacy_num" != "$current_num" ]]; then
+			local legacy_state
+			legacy_state=$(gh issue view "$legacy_num" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "")
+			if [[ "$legacy_state" == "OPEN" ]]; then
+				gh issue close "$legacy_num" --repo "$repo_slug" \
+					--comment "Closing legacy health issue (pre-role-naming). Superseded by role-specific health issue. See t1929." 2>/dev/null || true
+				echo "[stats] Closed legacy health issue #${legacy_num} for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
+			fi
+		fi
+		rm -f "$legacy_cache" 2>/dev/null || true
+	fi
+
 	return 0
 }
 
@@ -1054,6 +1209,13 @@ _update_health_issue_for_repo() {
 	local cache_dir="${HOME}/.aidevops/logs"
 	local health_issue_file="${cache_dir}/health-issue-${runner_user}-${role_label}-${slug_safe}"
 	mkdir -p "$cache_dir"
+
+	# t1929: Clean up stale opposite-role health issues.
+	# If the runner is "supervisor", close any lingering "contributor" health
+	# issue (and vice versa). These duplicates were caused by transient API
+	# failures in _get_runner_role() defaulting to "contributor".
+	_cleanup_opposite_role_health_issue \
+		"$runner_user" "$runner_role" "$repo_slug" "$slug_safe" "$cache_dir"
 
 	# Guard: skip health issue creation for repos with no activity (GH#15959).
 	# Only applies when no cached issue exists (i.e. this would CREATE a new one).


### PR DESCRIPTION
## Summary

Resolves the root cause of duplicate `[Contributor:user]` health dashboard issues appearing on all repos alongside the correct `[Supervisor:user]` issues.

## Root Cause

`_get_runner_role()` in `stats-functions.sh` calls `gh api repos/{slug}/collaborators/{user}/permission` to determine if the runner is "supervisor" or "contributor". When this API call fails (rate limiting, transient network error, auth timeout), the function **defaults to "contributor"** (line 108). This creates:

1. A separate cache file (`health-issue-{user}-contributor-{slug}`)
2. A separate `[Contributor:user]` health dashboard issue on GitHub

Next pulse cycle, the API works → detects "supervisor" → updates the correct `[Supervisor:user]` issue. But the stale `[Contributor:user]` issue remains open, duplicating content and causing confusion.

**Evidence:** Both `health-issue-marcusquinn-supervisor-*` and `health-issue-marcusquinn-contributor-*` cache files exist for the same repos. Confirmed open duplicate issues: `marcusquinn/aidevops.sh#69`, `<webapp>/<webapp>#2103`.

## Fix

Adds three defensive layers **before** the API call in `_get_runner_role()`:

| Layer | Source | Failure mode | Speed |
|-------|--------|-------------|-------|
| 1. In-process env-var cache | Memory | Process restart | Instant |
| 2. `repos.json` maintainer field | Disk (deterministic) | Field missing | Fast |
| 3. Persistent disk cache (24h TTL) | `~/.aidevops/logs/runner-role-*` | File missing + API fail | Fast |
| 4. GitHub API (existing) | Network | Rate limit, timeout | Slow |

On API failure, falls back to **expired disk cache** (stale > wrong) instead of defaulting to "contributor".

Also adds `_cleanup_opposite_role_health_issue()` which runs during each health-issue update cycle:
- Detects and closes any lingering health issue from the opposite role
- Cleans up legacy cache files (pre-role-naming format)
- Idempotent — no-op when no duplicate exists

## Testing

- `shellcheck` passes with zero violations
- Cache file cleanup targets only opposite-role and legacy files
- Closing comments reference t1929 for traceability

## Files Changed

- `EDIT: .agents/scripts/stats-functions.sh` — `_get_runner_role()` rewritten with 4-layer resolution, new `_persist_role_cache()` and `_cleanup_opposite_role_health_issue()` functions

## Runtime Testing

Self-assessed (low risk — agent prompt/stats infrastructure, no payment/auth/data paths).

Resolves t1929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented multi-layered role resolution strategy with persistent caching for improved reliability and reduced API calls.
  * Added automatic cleanup of duplicate health issues across different runner roles.

* **Bug Fixes**
  * Enhanced fallback behavior to preserve cached role data when API calls fail, preventing degradation to default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->