### PR TITLE
t1924: feat: aidevops init-routines

### DIFF
--- a/.agents/scripts/commands/init-routines.md
+++ b/.agents/scripts/commands/init-routines.md
@@ -1,0 +1,73 @@
+---
+description: Scaffold a private routines repo with TODO.md, routines/ dir, and issue template
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Scaffold a private git repo for routine definitions. Supports personal repos, per-org repos, and local-only (no remote).
+
+Arguments: $ARGUMENTS
+
+## Usage
+
+```bash
+aidevops init-routines                  # Personal: <username>/aidevops-routines
+aidevops init-routines --org <name>     # Org: <org>/aidevops-routines
+aidevops init-routines --local          # Local-only (no remote)
+aidevops init-routines --dry-run        # Preview without changes
+```
+
+Or via the helper directly:
+
+```bash
+~/.aidevops/agents/scripts/init-routines-helper.sh [--org <name>] [--local] [--dry-run]
+```
+
+## What it creates
+
+```
+~/Git/aidevops-routines/
+├── TODO.md              # Routine definitions with repeat: fields
+├── routines/            # YAML specs for complex routines
+│   └── .gitkeep
+├── .gitignore
+└── .github/
+    └── ISSUE_TEMPLATE/
+        └── routine.md   # Template for routine tracking issues
+```
+
+The repo is registered in `~/.config/aidevops/repos.json` with `pulse: true, priority: "tooling"`.
+
+## Privacy
+
+Always private — no flag to make public. Routine definitions may contain client names, internal schedules, and sensitive operational details.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--org <name>` | Create `<org>/aidevops-routines` (private) |
+| `--local` | Local-only repo, `local_only: true` in repos.json |
+| `--dry-run` | Preview without making changes |
+
+## After setup
+
+Add routines to `~/Git/aidevops-routines/TODO.md` under `## Routines`:
+
+```markdown
+## Routines
+
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [ ] r002 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
+```
+
+See `.agents/reference/routines.md` for the full field specification.
+
+## Related
+
+- `/routine` — design and schedule a recurring routine
+- `.agents/reference/routines.md` — routine field reference
+- `~/.config/aidevops/repos.json` — repo registration

--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -1,0 +1,548 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# init-routines-helper.sh — scaffold a private routines repo and register it
+#
+# Usage:
+#   init-routines-helper.sh [--org <name>] [--local] [--dry-run] [--help]
+#
+# Options:
+#   --org <name>   Create per-org variant: <org>/aidevops-routines
+#   --local        Create local-only repo (no remote, local_only: true)
+#   --dry-run      Print what would be done without making changes
+#   --help         Show this help message
+#
+# Without flags: creates personal <username>/aidevops-routines (always private)
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+GIT_PARENT="${HOME}/Git"
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# scaffold_repo <path>
+# Creates the standard routines repo structure at the given path.
+# ---------------------------------------------------------------------------
+scaffold_repo() {
+	local repo_path="$1"
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[dry-run] Would scaffold repo at: $repo_path"
+		return 0
+	fi
+
+	mkdir -p "${repo_path}/routines"
+	mkdir -p "${repo_path}/.github/ISSUE_TEMPLATE"
+
+	# TODO.md with Routines section header and format reference
+	cat >"${repo_path}/TODO.md" <<'TODOEOF'
+# Routines
+
+Recurring operational jobs. Format reference: `.agents/reference/routines.md`
+
+- `repeat:` — schedule: `daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, `cron(expr)`
+- `run:` — deterministic script relative to `~/.aidevops/agents/`
+- `agent:` — LLM agent dispatched with `headless-runtime-helper.sh`
+- `[x]` enabled, `[ ]` disabled/paused
+
+## Routines
+
+<!-- Add your routines below. Example:
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [ ] r002 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
+-->
+
+## Tasks
+
+<!-- Non-recurring tasks go here -->
+TODOEOF
+
+	# routines/.gitkeep
+	touch "${repo_path}/routines/.gitkeep"
+
+	# .gitignore
+	cat >"${repo_path}/.gitignore" <<'GITIGNOREEOF'
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Runtime
+*.log
+tmp/
+GITIGNOREEOF
+
+	# .github/ISSUE_TEMPLATE/routine.md
+	cat >"${repo_path}/.github/ISSUE_TEMPLATE/routine.md" <<'TEMPLATEEOF'
+---
+name: Routine tracking
+about: Track a recurring operational routine
+title: "r000: <routine name>"
+labels: routine
+assignees: ''
+---
+
+## Routine
+
+**ID:** `r000`
+**Schedule:** `repeat:weekly(mon@09:00)`
+**Script/Agent:** `run:custom/scripts/example.sh` or `agent:Build+`
+
+## Description
+
+What this routine does and why it exists.
+
+## SOP
+
+Step-by-step procedure for the routine.
+
+## Targets
+
+Who or what this routine applies to.
+
+## Verification
+
+How to confirm the routine ran successfully.
+TEMPLATEEOF
+
+	print_success "Scaffolded repo at: $repo_path"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# register_repo <path> <slug> [local_only]
+# Appends the repo to repos.json initialized_repos array.
+# ---------------------------------------------------------------------------
+register_repo() {
+	local repo_path="$1"
+	local slug="$2"
+	local local_only="${3:-false}"
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[dry-run] Would register in repos.json: path=$repo_path slug=$slug local_only=$local_only"
+		return 0
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		print_warning "jq not found — skipping repos.json registration. Add manually:"
+		echo "  path: $repo_path"
+		echo "  slug: $slug"
+		return 0
+	fi
+
+	# Ensure repos.json exists with correct structure
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		mkdir -p "$(dirname "$REPOS_JSON")"
+		echo '{"initialized_repos": [], "git_parent_dirs": ["~/Git"]}' >"$REPOS_JSON"
+	fi
+
+	# Check if already registered
+	if jq -e --arg path "$repo_path" '.initialized_repos[] | select(.path == $path)' "$REPOS_JSON" &>/dev/null; then
+		print_info "Already registered in repos.json: $repo_path"
+		return 0
+	fi
+
+	local tmp_json
+	tmp_json=$(mktemp)
+
+	local maintainer=""
+	if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+		maintainer=$(gh api user --jq '.login' 2>/dev/null || echo "")
+	fi
+
+	if [[ "$local_only" == "true" ]]; then
+		jq --arg path "$repo_path" \
+			--arg slug "$slug" \
+			--arg maintainer "$maintainer" \
+			'.initialized_repos += [{
+		     "path": $path,
+		     "slug": $slug,
+		     "pulse": true,
+		     "priority": "tooling",
+		     "local_only": true,
+		     "maintainer": $maintainer,
+		     "initialized": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+		   }]' "$REPOS_JSON" >"$tmp_json"
+	else
+		jq --arg path "$repo_path" \
+			--arg slug "$slug" \
+			--arg maintainer "$maintainer" \
+			'.initialized_repos += [{
+		     "path": $path,
+		     "slug": $slug,
+		     "pulse": true,
+		     "priority": "tooling",
+		     "maintainer": $maintainer,
+		     "initialized": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+		   }]' "$REPOS_JSON" >"$tmp_json"
+	fi
+
+	if jq empty "$tmp_json" 2>/dev/null; then
+		mv "$tmp_json" "$REPOS_JSON"
+		print_success "Registered in repos.json: $slug"
+	else
+		print_error "repos.json write produced invalid JSON — aborting (GH#16746)"
+		rm -f "$tmp_json"
+		return 1
+	fi
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# init_personal
+# Creates <username>/aidevops-routines on GitHub (private), clones, scaffolds.
+# ---------------------------------------------------------------------------
+init_personal() {
+	if ! command -v gh &>/dev/null; then
+		print_error "gh CLI not found. Install from https://cli.github.com/"
+		return 1
+	fi
+
+	if ! gh auth status &>/dev/null 2>&1; then
+		print_error "Not authenticated with gh. Run: gh auth login"
+		return 1
+	fi
+
+	local username
+	username=$(gh api user --jq '.login' 2>/dev/null)
+	if [[ -z "$username" ]]; then
+		print_error "Could not detect GitHub username"
+		return 1
+	fi
+
+	local slug="${username}/aidevops-routines"
+	local repo_path="${GIT_PARENT}/aidevops-routines"
+
+	print_info "Creating personal routines repo: $slug"
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[dry-run] Would create: gh repo create $slug --private"
+		print_info "[dry-run] Would clone to: $repo_path"
+		scaffold_repo "$repo_path"
+		register_repo "$repo_path" "$slug"
+		return 0
+	fi
+
+	# Check if repo already exists on GitHub
+	if gh repo view "$slug" &>/dev/null 2>&1; then
+		print_info "Repo already exists on GitHub: $slug"
+	else
+		gh repo create "$slug" --private --description "Private routines for aidevops" 2>&1
+		print_success "Created GitHub repo: $slug"
+	fi
+
+	# Clone if not already present
+	if [[ -d "$repo_path/.git" ]]; then
+		print_info "Repo already cloned at: $repo_path"
+	else
+		mkdir -p "$GIT_PARENT"
+		gh repo clone "$slug" "$repo_path" 2>&1
+		print_success "Cloned to: $repo_path"
+	fi
+
+	scaffold_repo "$repo_path"
+	register_repo "$repo_path" "$slug"
+
+	# Commit and push scaffold
+	if [[ -d "$repo_path/.git" ]]; then
+		(
+			cd "$repo_path"
+			git add -A
+			if ! git diff --cached --quiet; then
+				git commit -m "chore: scaffold aidevops-routines repo"
+				git push origin HEAD 2>&1 || print_warning "Push failed — commit exists locally"
+			fi
+		)
+	fi
+
+	print_success "Personal routines repo ready: $repo_path"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# init_org <org_name>
+# Creates <org>/aidevops-routines on GitHub (private), clones, scaffolds.
+# ---------------------------------------------------------------------------
+init_org() {
+	local org_name="$1"
+
+	if ! command -v gh &>/dev/null; then
+		print_error "gh CLI not found. Install from https://cli.github.com/"
+		return 1
+	fi
+
+	if ! gh auth status &>/dev/null 2>&1; then
+		print_error "Not authenticated with gh. Run: gh auth login"
+		return 1
+	fi
+
+	local slug="${org_name}/aidevops-routines"
+	local repo_path="${GIT_PARENT}/${org_name}-aidevops-routines"
+
+	print_info "Creating org routines repo: $slug"
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[dry-run] Would create: gh repo create $slug --private"
+		print_info "[dry-run] Would clone to: $repo_path"
+		scaffold_repo "$repo_path"
+		register_repo "$repo_path" "$slug"
+		return 0
+	fi
+
+	# Check if repo already exists on GitHub
+	if gh repo view "$slug" &>/dev/null 2>&1; then
+		print_info "Repo already exists on GitHub: $slug"
+	else
+		gh repo create "$slug" --private --description "Private routines for aidevops (${org_name})" 2>&1
+		print_success "Created GitHub repo: $slug"
+	fi
+
+	# Clone if not already present
+	if [[ -d "$repo_path/.git" ]]; then
+		print_info "Repo already cloned at: $repo_path"
+	else
+		mkdir -p "$GIT_PARENT"
+		gh repo clone "$slug" "$repo_path" 2>&1
+		print_success "Cloned to: $repo_path"
+	fi
+
+	scaffold_repo "$repo_path"
+	register_repo "$repo_path" "$slug"
+
+	# Commit and push scaffold
+	if [[ -d "$repo_path/.git" ]]; then
+		(
+			cd "$repo_path"
+			git add -A
+			if ! git diff --cached --quiet; then
+				git commit -m "chore: scaffold aidevops-routines repo"
+				git push origin HEAD 2>&1 || print_warning "Push failed — commit exists locally"
+			fi
+		)
+	fi
+
+	print_success "Org routines repo ready: $repo_path"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# init_local
+# Creates a local-only git repo (no remote), scaffolds, registers with local_only: true.
+# ---------------------------------------------------------------------------
+init_local() {
+	local repo_path="${GIT_PARENT}/aidevops-routines"
+	local slug="local/aidevops-routines"
+
+	print_info "Creating local-only routines repo at: $repo_path"
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[dry-run] Would git init at: $repo_path"
+		scaffold_repo "$repo_path"
+		register_repo "$repo_path" "$slug" "true"
+		return 0
+	fi
+
+	if [[ -d "$repo_path/.git" ]]; then
+		print_info "Repo already exists at: $repo_path"
+	else
+		mkdir -p "$repo_path"
+		git -C "$repo_path" init
+		print_success "Initialized local git repo at: $repo_path"
+	fi
+
+	scaffold_repo "$repo_path"
+	register_repo "$repo_path" "$slug" "true"
+
+	# Initial commit
+	(
+		cd "$repo_path"
+		git add -A
+		if ! git diff --cached --quiet; then
+			git commit -m "chore: scaffold aidevops-routines repo"
+		fi
+	)
+
+	print_success "Local routines repo ready: $repo_path"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# detect_and_create_all
+# For setup integration: detect username + admin orgs, create all routines repos.
+# In non-interactive mode: only creates personal repo.
+# ---------------------------------------------------------------------------
+detect_and_create_all() {
+	local non_interactive="${1:-false}"
+
+	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
+		print_warning "gh CLI not available or not authenticated — skipping routines repo creation"
+		return 0
+	fi
+
+	local username
+	username=$(gh api user --jq '.login' 2>/dev/null || echo "")
+	if [[ -z "$username" ]]; then
+		print_warning "Could not detect GitHub username — skipping routines repo creation"
+		return 0
+	fi
+
+	# Always create personal repo
+	init_personal
+
+	# Org repos require interactive confirmation
+	if [[ "$non_interactive" == "true" ]]; then
+		print_info "Non-interactive mode: skipping org routines repos (run 'aidevops init-routines --org <name>' for each org)"
+		return 0
+	fi
+
+	# Detect admin orgs
+	local admin_orgs
+	admin_orgs=$(gh api user/memberships/orgs --jq '.[] | select(.role == "admin") | .organization.login' 2>/dev/null || echo "")
+
+	if [[ -z "$admin_orgs" ]]; then
+		return 0
+	fi
+
+	while IFS= read -r org; do
+		[[ -z "$org" ]] && continue
+		local org_slug="${org}/aidevops-routines"
+		# Check if already registered
+		if command -v jq &>/dev/null && [[ -f "$REPOS_JSON" ]]; then
+			if jq -e --arg slug "$org_slug" '.initialized_repos[] | select(.slug == $slug)' "$REPOS_JSON" &>/dev/null; then
+				print_info "Org routines repo already registered: $org_slug"
+				continue
+			fi
+		fi
+		print_info "Create routines repo for org: $org? [y/N] "
+		local response
+		read -r response || response="n"
+		case "$response" in
+		[yY] | [yY][eE][sS])
+			init_org "$org"
+			;;
+		*)
+			print_info "Skipping org: $org"
+			;;
+		esac
+	done <<<"$admin_orgs"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# show_help
+# ---------------------------------------------------------------------------
+show_help() {
+	cat <<'HELPEOF'
+init-routines-helper.sh — scaffold a private routines repo
+
+Usage:
+  init-routines-helper.sh [options]
+
+Options:
+  --org <name>   Create per-org variant: <org>/aidevops-routines (always private)
+  --local        Create local-only repo (no remote, local_only: true in repos.json)
+  --dry-run      Print what would be done without making changes
+  --help         Show this help message
+
+Without flags: creates personal <username>/aidevops-routines (always private).
+
+Scaffolded structure:
+  ~/Git/aidevops-routines/
+  ├── TODO.md              # Routine definitions with repeat: fields
+  ├── routines/            # YAML specs for complex routines
+  │   └── .gitkeep
+  ├── .gitignore
+  └── .github/
+      └── ISSUE_TEMPLATE/
+          └── routine.md   # Template for routine tracking issues
+
+The repo is registered in ~/.config/aidevops/repos.json with:
+  pulse: true, priority: "tooling"
+
+Privacy: always private — no flag to make public.
+
+Examples:
+  init-routines-helper.sh                  # Personal repo
+  init-routines-helper.sh --org mycompany  # Org repo
+  init-routines-helper.sh --local          # Local-only (no remote)
+  init-routines-helper.sh --dry-run        # Preview without changes
+HELPEOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	local mode="personal"
+	local org_name=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--org)
+			mode="org"
+			org_name="${2:-}"
+			if [[ -z "$org_name" ]]; then
+				print_error "--org requires an organization name"
+				exit 1
+			fi
+			shift 2
+			;;
+		--local)
+			mode="local"
+			shift
+			;;
+		--dry-run)
+			DRY_RUN=true
+			shift
+			;;
+		--help | -h)
+			show_help
+			exit 0
+			;;
+		*)
+			print_error "Unknown option: $1"
+			echo "Run with --help for usage."
+			exit 1
+			;;
+		esac
+	done
+
+	case "$mode" in
+	personal)
+		init_personal
+		;;
+	org)
+		init_org "$org_name"
+		;;
+	local)
+		init_local
+		;;
+	esac
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -35,6 +35,77 @@ GIT_PARENT="${HOME}/Git"
 DRY_RUN=false
 
 # ---------------------------------------------------------------------------
+# _write_todo_md <path>
+# Creates TODO.md with Routines section header and format reference.
+# ---------------------------------------------------------------------------
+_write_todo_md() {
+	local repo_path="$1"
+	cat >"${repo_path}/TODO.md" <<'TODOEOF'
+# Routines
+
+Recurring operational jobs. Format reference: .agents/reference/routines.md
+
+Fields:
+  repeat: -- schedule: daily(@HH:MM), weekly(day@HH:MM), monthly(N@HH:MM), cron(expr)
+  run:    -- deterministic script relative to ~/.aidevops/agents/
+  agent:  -- LLM agent dispatched via headless-runtime-helper.sh
+  [x] enabled, [ ] disabled/paused
+
+## Routines
+
+<!-- Add your routines below. Example:
+- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
+- [ ] r002 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
+-->
+
+## Tasks
+
+<!-- Non-recurring tasks go here -->
+TODOEOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _write_issue_template <path>
+# Creates .github/ISSUE_TEMPLATE/routine.md
+# ---------------------------------------------------------------------------
+_write_issue_template() {
+	local repo_path="$1"
+	cat >"${repo_path}/.github/ISSUE_TEMPLATE/routine.md" <<'TEMPLATEEOF'
+---
+name: Routine tracking
+about: Track a recurring operational routine
+title: "r000: <routine name>"
+labels: routine
+assignees: ''
+---
+
+## Routine
+
+**ID:** r000
+**Schedule:** repeat:weekly(mon@09:00)
+**Script/Agent:** run:custom/scripts/example.sh or agent:Build+
+
+## Description
+
+What this routine does and why it exists.
+
+## SOP
+
+Step-by-step procedure.
+
+## Targets
+
+Who or what this routine applies to.
+
+## Verification
+
+How to confirm the routine ran successfully.
+TEMPLATEEOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # scaffold_repo <path>
 # Creates the standard routines repo structure at the given path.
 # ---------------------------------------------------------------------------
@@ -49,28 +120,7 @@ scaffold_repo() {
 	mkdir -p "${repo_path}/routines"
 	mkdir -p "${repo_path}/.github/ISSUE_TEMPLATE"
 
-	# TODO.md with Routines section header and format reference
-	cat >"${repo_path}/TODO.md" <<'TODOEOF'
-# Routines
-
-Recurring operational jobs. Format reference: `.agents/reference/routines.md`
-
-- `repeat:` — schedule: `daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, `cron(expr)`
-- `run:` — deterministic script relative to `~/.aidevops/agents/`
-- `agent:` — LLM agent dispatched with `headless-runtime-helper.sh`
-- `[x]` enabled, `[ ]` disabled/paused
-
-## Routines
-
-<!-- Add your routines below. Example:
-- [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
-- [ ] r002 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
--->
-
-## Tasks
-
-<!-- Non-recurring tasks go here -->
-TODOEOF
+	_write_todo_md "$repo_path"
 
 	# routines/.gitkeep
 	touch "${repo_path}/routines/.gitkeep"
@@ -92,38 +142,7 @@ Thumbs.db
 tmp/
 GITIGNOREEOF
 
-	# .github/ISSUE_TEMPLATE/routine.md
-	cat >"${repo_path}/.github/ISSUE_TEMPLATE/routine.md" <<'TEMPLATEEOF'
----
-name: Routine tracking
-about: Track a recurring operational routine
-title: "r000: <routine name>"
-labels: routine
-assignees: ''
----
-
-## Routine
-
-**ID:** `r000`
-**Schedule:** `repeat:weekly(mon@09:00)`
-**Script/Agent:** `run:custom/scripts/example.sh` or `agent:Build+`
-
-## Description
-
-What this routine does and why it exists.
-
-## SOP
-
-Step-by-step procedure for the routine.
-
-## Targets
-
-Who or what this routine applies to.
-
-## Verification
-
-How to confirm the routine ran successfully.
-TEMPLATEEOF
+	_write_issue_template "$repo_path"
 
 	print_success "Scaffolded repo at: $repo_path"
 	return 0
@@ -170,32 +189,33 @@ register_repo() {
 		maintainer=$(gh api user --jq '.login' 2>/dev/null || echo "")
 	fi
 
+	local jq_filter
+	# shellcheck disable=SC2016  # jq uses $path/$slug/$maintainer as jq vars, not shell vars
 	if [[ "$local_only" == "true" ]]; then
-		jq --arg path "$repo_path" \
-			--arg slug "$slug" \
-			--arg maintainer "$maintainer" \
-			'.initialized_repos += [{
-		     "path": $path,
-		     "slug": $slug,
-		     "pulse": true,
-		     "priority": "tooling",
-		     "local_only": true,
-		     "maintainer": $maintainer,
-		     "initialized": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
-		   }]' "$REPOS_JSON" >"$tmp_json"
+		jq_filter='.initialized_repos += [{
+		  "path": $path,
+		  "slug": $slug,
+		  "pulse": true,
+		  "priority": "tooling",
+		  "local_only": true,
+		  "maintainer": $maintainer,
+		  "initialized": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+		}]'
 	else
-		jq --arg path "$repo_path" \
-			--arg slug "$slug" \
-			--arg maintainer "$maintainer" \
-			'.initialized_repos += [{
-		     "path": $path,
-		     "slug": $slug,
-		     "pulse": true,
-		     "priority": "tooling",
-		     "maintainer": $maintainer,
-		     "initialized": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
-		   }]' "$REPOS_JSON" >"$tmp_json"
+		jq_filter='.initialized_repos += [{
+		  "path": $path,
+		  "slug": $slug,
+		  "pulse": true,
+		  "priority": "tooling",
+		  "maintainer": $maintainer,
+		  "initialized": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+		}]'
 	fi
+
+	jq --arg path "$repo_path" \
+		--arg slug "$slug" \
+		--arg maintainer "$maintainer" \
+		"$jq_filter" "$REPOS_JSON" >"$tmp_json"
 
 	if jq empty "$tmp_json" 2>/dev/null; then
 		mv "$tmp_json" "$REPOS_JSON"
@@ -210,19 +230,77 @@ register_repo() {
 }
 
 # ---------------------------------------------------------------------------
-# init_personal
-# Creates <username>/aidevops-routines on GitHub (private), clones, scaffolds.
+# _commit_and_push <path>
+# Commits scaffolded files and pushes to remote.
 # ---------------------------------------------------------------------------
-init_personal() {
+_commit_and_push() {
+	local repo_path="$1"
+	(
+		cd "$repo_path"
+		git add -A
+		if ! git diff --cached --quiet; then
+			git commit -m "chore: scaffold aidevops-routines repo"
+			git push origin HEAD 2>&1 || print_warning "Push failed — commit exists locally"
+		fi
+	)
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _check_gh_auth
+# Returns 0 if gh CLI is available and authenticated, 1 otherwise.
+# ---------------------------------------------------------------------------
+_check_gh_auth() {
 	if ! command -v gh &>/dev/null; then
 		print_error "gh CLI not found. Install from https://cli.github.com/"
 		return 1
 	fi
-
 	if ! gh auth status &>/dev/null 2>&1; then
 		print_error "Not authenticated with gh. Run: gh auth login"
 		return 1
 	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _ensure_gh_repo <slug> <description>
+# Creates the GitHub repo if it doesn't exist. Always private.
+# ---------------------------------------------------------------------------
+_ensure_gh_repo() {
+	local slug="$1"
+	local description="$2"
+	if gh repo view "$slug" &>/dev/null 2>&1; then
+		print_info "Repo already exists on GitHub: $slug"
+		return 0
+	fi
+	gh repo create "$slug" --private --description "$description" 2>&1
+	print_success "Created GitHub repo: $slug"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _ensure_cloned <slug> <path>
+# Clones the repo if not already present locally.
+# ---------------------------------------------------------------------------
+_ensure_cloned() {
+	local slug="$1"
+	local repo_path="$2"
+	if [[ -d "$repo_path/.git" ]]; then
+		print_info "Repo already cloned at: $repo_path"
+		return 0
+	fi
+	mkdir -p "$GIT_PARENT"
+	gh repo clone "$slug" "$repo_path" 2>&1
+	print_success "Cloned to: $repo_path"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# init_personal
+# Creates <username>/aidevops-routines on GitHub (private), clones, scaffolds.
+# ---------------------------------------------------------------------------
+init_personal() {
+	_check_gh_auth || return 1
 
 	local username
 	username=$(gh api user --jq '.login' 2>/dev/null)
@@ -244,37 +322,11 @@ init_personal() {
 		return 0
 	fi
 
-	# Check if repo already exists on GitHub
-	if gh repo view "$slug" &>/dev/null 2>&1; then
-		print_info "Repo already exists on GitHub: $slug"
-	else
-		gh repo create "$slug" --private --description "Private routines for aidevops" 2>&1
-		print_success "Created GitHub repo: $slug"
-	fi
-
-	# Clone if not already present
-	if [[ -d "$repo_path/.git" ]]; then
-		print_info "Repo already cloned at: $repo_path"
-	else
-		mkdir -p "$GIT_PARENT"
-		gh repo clone "$slug" "$repo_path" 2>&1
-		print_success "Cloned to: $repo_path"
-	fi
-
+	_ensure_gh_repo "$slug" "Private routines"
+	_ensure_cloned "$slug" "$repo_path"
 	scaffold_repo "$repo_path"
 	register_repo "$repo_path" "$slug"
-
-	# Commit and push scaffold
-	if [[ -d "$repo_path/.git" ]]; then
-		(
-			cd "$repo_path"
-			git add -A
-			if ! git diff --cached --quiet; then
-				git commit -m "chore: scaffold aidevops-routines repo"
-				git push origin HEAD 2>&1 || print_warning "Push failed — commit exists locally"
-			fi
-		)
-	fi
+	_commit_and_push "$repo_path"
 
 	print_success "Personal routines repo ready: $repo_path"
 	return 0
@@ -287,15 +339,7 @@ init_personal() {
 init_org() {
 	local org_name="$1"
 
-	if ! command -v gh &>/dev/null; then
-		print_error "gh CLI not found. Install from https://cli.github.com/"
-		return 1
-	fi
-
-	if ! gh auth status &>/dev/null 2>&1; then
-		print_error "Not authenticated with gh. Run: gh auth login"
-		return 1
-	fi
+	_check_gh_auth || return 1
 
 	local slug="${org_name}/aidevops-routines"
 	local repo_path="${GIT_PARENT}/${org_name}-aidevops-routines"
@@ -310,37 +354,11 @@ init_org() {
 		return 0
 	fi
 
-	# Check if repo already exists on GitHub
-	if gh repo view "$slug" &>/dev/null 2>&1; then
-		print_info "Repo already exists on GitHub: $slug"
-	else
-		gh repo create "$slug" --private --description "Private routines for aidevops (${org_name})" 2>&1
-		print_success "Created GitHub repo: $slug"
-	fi
-
-	# Clone if not already present
-	if [[ -d "$repo_path/.git" ]]; then
-		print_info "Repo already cloned at: $repo_path"
-	else
-		mkdir -p "$GIT_PARENT"
-		gh repo clone "$slug" "$repo_path" 2>&1
-		print_success "Cloned to: $repo_path"
-	fi
-
+	_ensure_gh_repo "$slug" "Private routines (${org_name})"
+	_ensure_cloned "$slug" "$repo_path"
 	scaffold_repo "$repo_path"
 	register_repo "$repo_path" "$slug"
-
-	# Commit and push scaffold
-	if [[ -d "$repo_path/.git" ]]; then
-		(
-			cd "$repo_path"
-			git add -A
-			if ! git diff --cached --quiet; then
-				git commit -m "chore: scaffold aidevops-routines repo"
-				git push origin HEAD 2>&1 || print_warning "Push failed — commit exists locally"
-			fi
-		)
-	fi
+	_commit_and_push "$repo_path"
 
 	print_success "Org routines repo ready: $repo_path"
 	return 0
@@ -363,12 +381,12 @@ init_local() {
 		return 0
 	fi
 
-	if [[ -d "$repo_path/.git" ]]; then
-		print_info "Repo already exists at: $repo_path"
-	else
+	if [[ ! -d "$repo_path/.git" ]]; then
 		mkdir -p "$repo_path"
 		git -C "$repo_path" init
 		print_success "Initialized local git repo at: $repo_path"
+	else
+		print_info "Repo already exists at: $repo_path"
 	fi
 
 	scaffold_repo "$repo_path"
@@ -388,8 +406,38 @@ init_local() {
 }
 
 # ---------------------------------------------------------------------------
+# _prompt_org <org>
+# Prompts user to create org routines repo. Returns 0 to create, 1 to skip.
+# ---------------------------------------------------------------------------
+_prompt_org() {
+	local org="$1"
+	local org_slug="${org}/aidevops-routines"
+
+	# Check if already registered
+	if command -v jq &>/dev/null && [[ -f "$REPOS_JSON" ]]; then
+		if jq -e --arg slug "$org_slug" '.initialized_repos[] | select(.slug == $slug)' "$REPOS_JSON" &>/dev/null; then
+			print_info "Org routines repo already registered: $org_slug"
+			return 1
+		fi
+	fi
+
+	print_info "Create routines repo for org: $org? [y/N] "
+	local response
+	read -r response || response="n"
+	case "$response" in
+	[yY] | [yY][eE][sS])
+		return 0
+		;;
+	*)
+		print_info "Skipping org: $org"
+		return 1
+		;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
 # detect_and_create_all
-# For setup integration: detect username + admin orgs, create all routines repos.
+# Setup integration: detect username + admin orgs, create all routines repos.
 # In non-interactive mode: only creates personal repo.
 # ---------------------------------------------------------------------------
 detect_and_create_all() {
@@ -410,9 +458,8 @@ detect_and_create_all() {
 	# Always create personal repo
 	init_personal
 
-	# Org repos require interactive confirmation
 	if [[ "$non_interactive" == "true" ]]; then
-		print_info "Non-interactive mode: skipping org routines repos (run 'aidevops init-routines --org <name>' for each org)"
+		print_info "Non-interactive mode: skipping org repos (run 'aidevops init-routines --org <name>')"
 		return 0
 	fi
 
@@ -420,31 +467,13 @@ detect_and_create_all() {
 	local admin_orgs
 	admin_orgs=$(gh api user/memberships/orgs --jq '.[] | select(.role == "admin") | .organization.login' 2>/dev/null || echo "")
 
-	if [[ -z "$admin_orgs" ]]; then
-		return 0
-	fi
+	[[ -z "$admin_orgs" ]] && return 0
 
 	while IFS= read -r org; do
 		[[ -z "$org" ]] && continue
-		local org_slug="${org}/aidevops-routines"
-		# Check if already registered
-		if command -v jq &>/dev/null && [[ -f "$REPOS_JSON" ]]; then
-			if jq -e --arg slug "$org_slug" '.initialized_repos[] | select(.slug == $slug)' "$REPOS_JSON" &>/dev/null; then
-				print_info "Org routines repo already registered: $org_slug"
-				continue
-			fi
-		fi
-		print_info "Create routines repo for org: $org? [y/N] "
-		local response
-		read -r response || response="n"
-		case "$response" in
-		[yY] | [yY][eE][sS])
+		if _prompt_org "$org"; then
 			init_org "$org"
-			;;
-		*)
-			print_info "Skipping org: $org"
-			;;
-		esac
+		fi
 	done <<<"$admin_orgs"
 
 	return 0
@@ -455,7 +484,7 @@ detect_and_create_all() {
 # ---------------------------------------------------------------------------
 show_help() {
 	cat <<'HELPEOF'
-init-routines-helper.sh — scaffold a private routines repo
+init-routines-helper.sh -- scaffold a private routines repo
 
 Usage:
   init-routines-helper.sh [options]
@@ -470,18 +499,18 @@ Without flags: creates personal <username>/aidevops-routines (always private).
 
 Scaffolded structure:
   ~/Git/aidevops-routines/
-  ├── TODO.md              # Routine definitions with repeat: fields
-  ├── routines/            # YAML specs for complex routines
-  │   └── .gitkeep
-  ├── .gitignore
-  └── .github/
-      └── ISSUE_TEMPLATE/
-          └── routine.md   # Template for routine tracking issues
+  |- TODO.md              # Routine definitions with repeat: fields
+  |- routines/            # YAML specs
+  |  `- .gitkeep
+  |- .gitignore
+  `- .github/
+     `- ISSUE_TEMPLATE/
+        `- routine.md
 
 The repo is registered in ~/.config/aidevops/repos.json with:
   pulse: true, priority: "tooling"
 
-Privacy: always private — no flag to make public.
+Privacy: always private -- no flag to make public.
 
 Examples:
   init-routines-helper.sh                  # Personal repo
@@ -493,25 +522,26 @@ HELPEOF
 }
 
 # ---------------------------------------------------------------------------
-# main
+# _parse_args <args...>
+# Parse command-line arguments. Sets MODE and ORG_NAME globals.
 # ---------------------------------------------------------------------------
-main() {
-	local mode="personal"
-	local org_name=""
+MODE="personal"
+ORG_NAME=""
 
+_parse_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--org)
-			mode="org"
-			org_name="${2:-}"
-			if [[ -z "$org_name" ]]; then
+			MODE="org"
+			ORG_NAME="${2:-}"
+			if [[ -z "$ORG_NAME" ]]; then
 				print_error "--org requires an organization name"
 				exit 1
 			fi
 			shift 2
 			;;
 		--local)
-			mode="local"
+			MODE="local"
 			shift
 			;;
 		--dry-run)
@@ -529,13 +559,21 @@ main() {
 			;;
 		esac
 	done
+	return 0
+}
 
-	case "$mode" in
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	_parse_args "$@"
+
+	case "$MODE" in
 	personal)
 		init_personal
 		;;
 	org)
-		init_org "$org_name"
+		init_org "$ORG_NAME"
 		;;
 	local)
 		init_local

--- a/.agents/scripts/setup/_routines.sh
+++ b/.agents/scripts/setup/_routines.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Setup module: routines repo scaffolding
+# Sourced by setup.sh — do not execute directly.
+
+# Source the helper if not already loaded
+_load_init_routines_helper() {
+	local helper_path
+	helper_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../init-routines-helper.sh"
+	if [[ -f "$helper_path" ]]; then
+		# shellcheck disable=SC1090  # dynamic path, exists at runtime
+		source "$helper_path"
+	else
+		print_warning "init-routines-helper.sh not found at: $helper_path"
+		return 1
+	fi
+	return 0
+}
+
+# setup_routines — called from setup.sh interactive flow
+# In interactive mode: creates personal repo + prompts for org repos
+# In non-interactive mode: creates personal repo only
+setup_routines() {
+	print_info "Setting up routines repo..."
+
+	if ! _load_init_routines_helper; then
+		print_warning "Skipping routines setup — helper not available"
+		setup_track_skipped "Routines repo" "init-routines-helper.sh not found"
+		return 0
+	fi
+
+	local non_interactive="${NON_INTERACTIVE:-false}"
+
+	# detect_and_create_all handles: personal repo + org repos (interactive only)
+	if detect_and_create_all "$non_interactive"; then
+		setup_track_configured "Routines repo"
+	else
+		setup_track_skipped "Routines repo" "gh CLI unavailable or not authenticated"
+	fi
+
+	return 0
+}

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3387,6 +3387,7 @@ cmd_skills() {
 _help_commands() {
 	echo "Commands:"
 	echo "  init [features]    Initialize aidevops in current project"
+	echo "  init-routines      Scaffold private routines repo (--org <name> | --local)"
 	echo "  upgrade-planning   Upgrade TODO.md/PLANS.md to latest templates"
 	echo "  features           List available features for init"
 	echo "  skill <cmd>        Manage agent skills (add/list/check/update/remove)"
@@ -3755,6 +3756,7 @@ main() {
 	signing) _dispatch_helper "signing-setup.sh" "signing-setup.sh" "$@" ;;
 	stats | observability) _dispatch_helper "observability-helper.sh" "observability-helper.sh" "$@" ;;
 	tabby) _dispatch_helper "tabby-helper.sh" "tabby-helper.sh" "$@" ;;
+	init-routines) _dispatch_helper "init-routines-helper.sh" "init-routines-helper.sh" "$@" ;;
 	config | configure) _dispatch_config "$@" ;;
 	uninstall | remove) cmd_uninstall ;;
 	version | v | -v | --version) cmd_version ;;

--- a/setup.sh
+++ b/setup.sh
@@ -85,6 +85,8 @@ if [[ -d "$SETUP_MODULES_DIR" ]]; then
 	source "$SETUP_MODULES_DIR/_services.sh"
 	# shellcheck disable=SC1091
 	source "$SETUP_MODULES_DIR/_bootstrap.sh"
+	# shellcheck disable=SC1091
+	source "$SETUP_MODULES_DIR/_routines.sh"
 fi
 
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
@@ -964,6 +966,7 @@ _setup_run_interactive() {
 	confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift
 	confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && deploy_aidevops_agents
 	confirm_step "Sync agents from private repositories" && sync_agent_sources
+	confirm_step "Set up routines repo (private repo for recurring operational jobs)" && setup_routines
 	is_feature_enabled safety_hooks 2>/dev/null && confirm_step "Install Claude Code safety hooks (block destructive commands)" && setup_safety_hooks
 	confirm_step "Initialize settings.json (canonical config file)" && init_settings_json
 	confirm_step "Setup multi-tenant credential storage" && setup_multi_tenant_credentials


### PR DESCRIPTION
## Summary

New CLI command `aidevops init-routines` and helper script that scaffolds a private git repo for routine definitions. Supports personal repos, per-org repos, and local-only (no remote).

Resolves #17773

## Changes

### New files

- `.agents/scripts/init-routines-helper.sh` — main helper with:
  - `init_personal()`: creates `<username>/aidevops-routines` (always private)
  - `init_org(org)`: creates `<org>/aidevops-routines` (always private)
  - `init_local()`: local-only git repo (`local_only: true` in repos.json)
  - `scaffold_repo(path)`: TODO.md with Routines section, `routines/.gitkeep`, `.github/ISSUE_TEMPLATE/routine.md`, `.gitignore`
  - `register_repo(path, slug)`: appends to repos.json with `pulse: true, priority: "tooling"`
  - `detect_and_create_all()`: for setup integration (personal + org repos)
  - `--dry-run` flag for safe preview
- `.agents/scripts/commands/init-routines.md` — slash command doc
- `.agents/scripts/setup/_routines.sh` — setup module (`setup_routines()`)

### Modified files

- `aidevops.sh`: add `init-routines` subcommand routing + help entry
- `setup.sh`: source `_routines.sh`, add `confirm_step` for routines in interactive flow

## Scaffolded structure

```
~/Git/aidevops-routines/
├── TODO.md              # Routine definitions with repeat: fields
├── routines/            # YAML specs for complex routines
│   └── .gitkeep
├── .gitignore
└── .github/
    └── ISSUE_TEMPLATE/
        └── routine.md   # Template for routine tracking issues
```

## Runtime Testing

**Risk level:** Low — new scripts, no existing functionality modified beyond routing wires.

- shellcheck: zero violations on all new scripts
- bash -n: syntax check passes on setup.sh and aidevops.sh
- `--help` flag: verified output
- `--dry-run` flag: verified personal and local modes
- All 9 acceptance criteria verified via bash assertions


---
[aidevops.sh](https://aidevops.sh) v3.6.165 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 6m and 19,919 tokens on this as a headless worker.