### PR TITLE
fix: skip closing comment on locked issues in sync-on-pr-merge

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -376,19 +376,27 @@ jobs:
           for ISSUE_NUM in $ALL_ISSUES; do
             echo "--- Issue #$ISSUE_NUM ---"
 
-            # Post closing comment if none exists from this PR
-            EXISTING_COMMENT=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
-              --jq "[.[] | select(.body | test(\"Completed via.*PR #${PR_NUMBER}\"))] | length" 2>/dev/null || echo "0")
+            # Check if issue is locked — locked issues reject addComment via GraphQL
+            IS_LOCKED=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.locked' 2>/dev/null || echo "false")
 
-            if [[ "$EXISTING_COMMENT" == "0" ]]; then
-              TASK_REF=""
-              if [[ -n "$TASK_ID" ]]; then
-                TASK_REF=" Task $TASK_ID"
-              fi
-              gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main."
-              echo "Posted closing comment on #$ISSUE_NUM"
+            # Post closing comment if none exists from this PR (skip if locked)
+            if [[ "$IS_LOCKED" == "true" ]]; then
+              echo "Issue #$ISSUE_NUM is locked — skipping closing comment"
             else
-              echo "Closing comment already exists on #$ISSUE_NUM"
+              EXISTING_COMMENT=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
+                --jq "[.[] | select(.body | test(\"Completed via.*PR #${PR_NUMBER}\"))] | length" 2>/dev/null || echo "0")
+
+              if [[ "$EXISTING_COMMENT" == "0" ]]; then
+                TASK_REF=""
+                if [[ -n "$TASK_ID" ]]; then
+                  TASK_REF=" Task $TASK_ID"
+                fi
+                gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main." \
+                  || echo "::warning::Could not post closing comment on #$ISSUE_NUM (issue may have been locked after check)"
+                echo "Posted closing comment on #$ISSUE_NUM"
+              else
+                echo "Closing comment already exists on #$ISSUE_NUM"
+              fi
             fi
 
             # Apply status:done label (create if needed)


### PR DESCRIPTION
## Summary

The `Sync Issue Hygiene on PR Merge` CI job was failing with exit code 1 on 4 observed events (systemic threshold exceeded). Root cause: the `Apply closing hygiene to linked issues` step calls `gh issue comment` on linked issues, but GitHub's GraphQL API rejects `addComment` on locked issues with:

```
GraphQL: Unable to create comment because issue is locked (addComment)
```

Since the step had no error handling for this case, the entire job failed.

## Fix

- Check the issue's `locked` state via REST API (`gh api repos/.../issues/NNN --jq '.locked'`) before attempting to post the closing comment
- If locked: log a skip message and continue — label hygiene (`gh issue edit`) still runs since it uses a different API path that succeeds on locked issues
- Added `|| echo "::warning::..."` fallback on the comment call to handle the race condition where an issue is locked between the check and the comment attempt

## Files Changed

- EDIT: `.github/workflows/issue-sync.yml` — `Apply closing hygiene to linked issues` step in `sync-on-pr-merge` job (lines 376-412)

## Runtime Testing

**Risk level:** Low — CI workflow YAML change only. No shell scripts modified.

Self-assessed: the fix adds a pre-check API call and wraps the comment call with a graceful fallback. The label hygiene path is unchanged. Verified by reading the CI failure logs from all 4 affected runs — all show the same `locked` error on the comment step.

Resolves #17794

---
[aidevops.sh](https://aidevops.sh) v3.6.166 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 7m and 2,945 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue synchronization workflow to safely handle locked issues by checking their state before adding comments, preventing errors and unnecessary interactions with locked issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->