### PR TITLE
t1929: Move health issue cleanup from per-cycle to setup migration

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -206,86 +206,6 @@ _persist_role_cache() {
 }
 
 #######################################
-# Clean up a stale health issue from the opposite role.
-#
-# When the runner is confirmed as "supervisor", any lingering
-# "contributor" health issue (and its cache file) is a duplicate
-# created by a past API failure. Close it and remove the cache.
-# Same logic applies in reverse (contributor → stale supervisor).
-#
-# Called once per repo per health-issue update cycle. Idempotent —
-# does nothing if no opposite-role issue exists.
-#
-# Arguments:
-#   $1 - runner_user
-#   $2 - runner_role (the CORRECT current role)
-#   $3 - repo_slug
-#   $4 - slug_safe (slug with / replaced by -)
-#   $5 - cache_dir
-#######################################
-_cleanup_opposite_role_health_issue() {
-	local runner_user="$1"
-	local runner_role="$2"
-	local repo_slug="$3"
-	local slug_safe="$4"
-	local cache_dir="$5"
-
-	local opposite_role
-	if [[ "$runner_role" == "supervisor" ]]; then
-		opposite_role="contributor"
-	else
-		opposite_role="supervisor"
-	fi
-
-	local opposite_cache="${cache_dir}/health-issue-${runner_user}-${opposite_role}-${slug_safe}"
-	# Also check legacy cache files (without role prefix, from older versions)
-	local legacy_cache="${cache_dir}/health-issue-${runner_user}-${slug_safe}"
-
-	local stale_num=""
-	if [[ -f "$opposite_cache" ]]; then
-		stale_num=$(cat "$opposite_cache" 2>/dev/null || echo "")
-	fi
-
-	if [[ -n "$stale_num" ]]; then
-		local stale_state
-		stale_state=$(gh issue view "$stale_num" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "")
-		if [[ "$stale_state" == "OPEN" ]]; then
-			# Unpin if it was pinned (supervisor issues get pinned)
-			if [[ "$opposite_role" == "supervisor" ]]; then
-				_unpin_health_issue "$stale_num" "$repo_slug"
-			fi
-			gh issue close "$stale_num" --repo "$repo_slug" \
-				--comment "Closing duplicate ${opposite_role} health issue. Runner role is ${runner_role} — the correct health issue is the [${runner_role^}:${runner_user}] issue. See t1929." 2>/dev/null || true
-			echo "[stats] Closed stale ${opposite_role} health issue #${stale_num} for ${repo_slug} (runner is ${runner_role})" >>"${LOGFILE:-/dev/null}"
-		fi
-		rm -f "$opposite_cache" 2>/dev/null || true
-	fi
-
-	# Clean up legacy cache file (no role prefix) if it exists and differs
-	# from the current role's cache file. These are from before role-aware naming.
-	if [[ -f "$legacy_cache" ]]; then
-		local legacy_num
-		legacy_num=$(cat "$legacy_cache" 2>/dev/null || echo "")
-		# Only remove if the legacy cache points to a different issue than current
-		local current_cache="${cache_dir}/health-issue-${runner_user}-${runner_role}-${slug_safe}"
-		local current_num=""
-		[[ -f "$current_cache" ]] && current_num=$(cat "$current_cache" 2>/dev/null || echo "")
-		if [[ -n "$legacy_num" && "$legacy_num" != "$current_num" ]]; then
-			local legacy_state
-			legacy_state=$(gh issue view "$legacy_num" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "")
-			if [[ "$legacy_state" == "OPEN" ]]; then
-				gh issue close "$legacy_num" --repo "$repo_slug" \
-					--comment "Closing legacy health issue (pre-role-naming). Superseded by role-specific health issue. See t1929." 2>/dev/null || true
-				echo "[stats] Closed legacy health issue #${legacy_num} for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
-			fi
-		fi
-		rm -f "$legacy_cache" 2>/dev/null || true
-	fi
-
-	return 0
-}
-
-#######################################
 # Find an existing health issue by cache, labels, or title search.
 #
 # Arguments:
@@ -1209,13 +1129,6 @@ _update_health_issue_for_repo() {
 	local cache_dir="${HOME}/.aidevops/logs"
 	local health_issue_file="${cache_dir}/health-issue-${runner_user}-${role_label}-${slug_safe}"
 	mkdir -p "$cache_dir"
-
-	# t1929: Clean up stale opposite-role health issues.
-	# If the runner is "supervisor", close any lingering "contributor" health
-	# issue (and vice versa). These duplicates were caused by transient API
-	# failures in _get_runner_role() defaulting to "contributor".
-	_cleanup_opposite_role_health_issue \
-		"$runner_user" "$runner_role" "$repo_slug" "$slug_safe" "$cache_dir"
 
 	# Guard: skip health issue creation for repos with no activity (GH#15959).
 	# Only applies when no cached issue exists (i.e. this would CREATE a new one).

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -302,6 +302,70 @@ cleanup_stale_bun_opencode() {
 	return 0
 }
 
+# t1929: Remove stale contributor/legacy health issue cache files and close
+# the corresponding GitHub issues. One-time migration — the root cause
+# (API failure in _get_runner_role defaulting to "contributor") is fixed
+# by the 4-layer role resolution in stats-functions.sh.
+#
+# Gated by a flag file so it runs exactly once per install.
+cleanup_stale_health_issue_caches() {
+	local flag_file="${HOME}/.aidevops/logs/.migrated-health-issue-caches-t1929"
+	[[ -f "$flag_file" ]] && return 0
+
+	local cache_dir="${HOME}/.aidevops/logs"
+	[[ -d "$cache_dir" ]] || return 0
+
+	local cleaned=0
+
+	# 1. Remove contributor cache files (the duplicates).
+	#    The correct files are health-issue-{user}-supervisor-{slug}.
+	local contributor_cache
+	for contributor_cache in "${cache_dir}"/health-issue-*-contributor-*; do
+		[[ -f "$contributor_cache" ]] || continue
+		local stale_num
+		stale_num=$(cat "$contributor_cache" 2>/dev/null || echo "")
+		# Extract slug from filename: health-issue-{user}-contributor-{slug}
+		# Best-effort close via gh if available and authenticated
+		if [[ -n "$stale_num" ]] && command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+			# Derive repo slug from filename: strip prefix up to "-contributor-", rest is slug-safe
+			local fname
+			fname=$(basename "$contributor_cache")
+			local slug_safe="${fname##*-contributor-}"
+			# Find the matching supervisor cache to get the repo slug
+			local supervisor_cache="${cache_dir}/health-issue-${fname%-contributor-*}-supervisor-${slug_safe}"
+			# Only close if there IS a supervisor counterpart (confirms it's a duplicate)
+			if [[ -f "$supervisor_cache" ]]; then
+				gh issue close "$stale_num" --repo "$(echo "$slug_safe" | sed 's/-/\//' | head -1)" \
+					--comment "Closing duplicate contributor health issue (t1929 migration)." 2>/dev/null || true
+			fi
+		fi
+		rm -f "$contributor_cache"
+		cleaned=$((cleaned + 1))
+	done
+
+	# 2. Remove legacy cache files (no role prefix, pre-role-naming).
+	#    Pattern: health-issue-{user}-{slug} where {slug} has no "supervisor" or "contributor".
+	local legacy_cache
+	for legacy_cache in "${cache_dir}"/health-issue-*; do
+		[[ -f "$legacy_cache" ]] || continue
+		local fname
+		fname=$(basename "$legacy_cache")
+		# Skip files that already have a role prefix (they're the correct format)
+		[[ "$fname" == *-supervisor-* || "$fname" == *-contributor-* ]] && continue
+		rm -f "$legacy_cache"
+		cleaned=$((cleaned + 1))
+	done
+
+	# Write flag file
+	mkdir -p "$(dirname "$flag_file")"
+	date -u +"%Y-%m-%dT%H:%M:%SZ" >"$flag_file"
+
+	if [[ "$cleaned" -gt 0 ]]; then
+		print_info "Cleaned up $cleaned stale health issue cache file(s) (t1929)"
+	fi
+	return 0
+}
+
 # Migrate legacy .agent symlink/directory to .agents in a single repo.
 # Args: $1 = repo_path
 # Prints: info messages for each migration action

--- a/setup.sh
+++ b/setup.sh
@@ -865,6 +865,7 @@ _setup_run_non_interactive() {
 	backfill_issue_relationships
 	cleanup_deprecated_mcps
 	cleanup_stale_bun_opencode
+	cleanup_stale_health_issue_caches
 	_cleanup_legacy_model_config
 	validate_opencode_config
 	deploy_aidevops_agents
@@ -958,6 +959,7 @@ _setup_run_interactive() {
 	confirm_step "Backfill GitHub issue relationships (blocked-by, sub-issues)" && backfill_issue_relationships
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
+	cleanup_stale_health_issue_caches
 	_cleanup_legacy_model_config
 	confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 	confirm_step "Extract OpenCode prompts" && extract_opencode_prompts


### PR DESCRIPTION
## Summary

Follow-up to PR #17813. Moves the stale health issue cleanup from the per-pulse-cycle hot path to a one-time setup migration, where it belongs.

## Changes

- **Remove** `_cleanup_opposite_role_health_issue()` and its per-cycle call from `stats-functions.sh` (-87 lines)
- **Add** `cleanup_stale_health_issue_caches()` to `setup-modules/migrations.sh` — runs once, gated by flag file
- **Wire** into both `_setup_run_non_interactive()` and `_setup_run_interactive()` paths in `setup.sh`

The migration:
1. Finds `health-issue-*-contributor-*` cache files, closes the GitHub issues if a supervisor counterpart exists (confirms duplicate)
2. Removes legacy cache files (no role prefix, pre-role-naming format)
3. Writes `~/.aidevops/logs/.migrated-health-issue-caches-t1929` flag — never runs again

## Rationale

The systemic cause (API failure → wrong role) is fixed by the 4-layer resolution in `_get_runner_role()`. Running cleanup every pulse cycle was unnecessary overhead (even if negligible) and masked whether the fix actually holds. Cleanup belongs in setup/update scripts.

## Files Changed

- `EDIT: .agents/scripts/stats-functions.sh` — remove function + call
- `EDIT: setup-modules/migrations.sh` — add `cleanup_stale_health_issue_caches()`
- `EDIT: setup.sh` — wire migration into both paths

Resolves t1929