### PR TITLE
GH#17794: fix: skip closing comment on locked issues in Sync Issue Hygiene workflow

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -385,8 +385,15 @@ jobs:
               if [[ -n "$TASK_ID" ]]; then
                 TASK_REF=" Task $TASK_ID"
               fi
-              gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main."
-              echo "Posted closing comment on #$ISSUE_NUM"
+              # Check if issue is locked before attempting to comment (locked issues reject comments with exit 1)
+              IS_LOCKED=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.locked' 2>/dev/null || echo "false")
+              if [[ "$IS_LOCKED" == "true" ]]; then
+                echo "Issue #$ISSUE_NUM is locked — skipping closing comment (labels will still be updated)"
+              else
+                gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main." \
+                  || echo "Warning: failed to post closing comment on #$ISSUE_NUM (issue may have been locked concurrently)"
+                echo "Posted closing comment on #$ISSUE_NUM"
+              fi
             else
               echo "Closing comment already exists on #$ISSUE_NUM"
             fi

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -373,6 +373,7 @@ jobs:
 
           echo "Processing issues: $ALL_ISSUES"
 
+          COMMENT_FAILED=0
           for ISSUE_NUM in $ALL_ISSUES; do
             echo "--- Issue #$ISSUE_NUM ---"
 
@@ -389,10 +390,11 @@ jobs:
               IS_LOCKED=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.locked' 2>/dev/null || echo "false")
               if [[ "$IS_LOCKED" == "true" ]]; then
                 echo "Issue #$ISSUE_NUM is locked — skipping closing comment (labels will still be updated)"
-              else
-                gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main." \
-                  || echo "Warning: failed to post closing comment on #$ISSUE_NUM (issue may have been locked concurrently)"
+              elif gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "Completed via [PR #${PR_NUMBER}](${PR_URL}).${TASK_REF} merged to main."; then
                 echo "Posted closing comment on #$ISSUE_NUM"
+              else
+                echo "Warning: failed to post closing comment on #$ISSUE_NUM (issue may have been locked concurrently)"
+                COMMENT_FAILED=1
               fi
             else
               echo "Closing comment already exists on #$ISSUE_NUM"
@@ -409,6 +411,10 @@ jobs:
 
             echo "Updated labels on #$ISSUE_NUM (added status:done, removed stale)"
           done
+
+          if [[ "$COMMENT_FAILED" -eq 1 ]]; then
+            echo "Warning: one or more closing comments could not be posted (see above). Label updates completed."
+          fi
 
       - name: Checkout repo for TODO.md update
         if: steps.extract.outputs.task_id != ''


### PR DESCRIPTION
## Summary

Fixes the systemic CI failure in the **Sync Issue Hygiene on PR Merge** workflow where `gh issue comment` exits with code 1 when the target issue is locked, causing the entire step to fail.

**Root cause:** `gh issue comment` returns exit code 1 with `GraphQL: Unable to create comment because issue is locked` when the issue is locked. Since the step runs under `bash -e`, this propagates as a step failure. This was observed in 4 separate PR merges (PRs #17767, #17770, #17771).

**Fix:** Before attempting to post a closing comment, check the issue's `locked` state via the REST API. If locked, log a message and skip the comment — label updates (`status:done`, stale label removal) still proceed since `gh issue edit` handles locked issues gracefully. A `|| echo` fallback guard is also added for the race condition where an issue is locked between the check and the comment attempt.

## Files Changed

- EDIT: `.github/workflows/issue-sync.yml` — `Apply closing hygiene to linked issues` step, lines 383-399

## Runtime Testing

**Risk level:** Low (workflow YAML change, no shell scripts modified)

Self-assessed — the change adds a locked-state check before `gh issue comment` and a `|| echo` fallback. The logic is straightforward: if locked, skip comment; otherwise, attempt comment with non-fatal error handling. Label operations are unaffected.

Resolves #17794

---
[aidevops.sh](https://aidevops.sh) v3.6.167 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 1m and 4,053 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue synchronization workflow to respect locked issues and gracefully handle concurrent locking failures during automated completion comment posting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->