### PR TITLE
GH#17806: fix(upgrade-planning): preserve ### subsection headers in Backlog

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -2265,7 +2265,9 @@ _upgrade_todo() {
 	print_info "Upgrading TODO.md..."
 	local existing_tasks=""
 	if [[ -f "$todo_file" ]]; then
-		existing_tasks=$(grep -E "^[[:space:]]*- \[([ x-])\]" "$todo_file" 2>/dev/null || echo "")
+		# Extract everything under ## Backlog (tasks AND ### subsection headers)
+		# until the next ## header or EOF — preserves semantic grouping
+		existing_tasks=$(awk '/^## Backlog/{found=1; next} found && /^## /{exit} found' "$todo_file" 2>/dev/null || echo "")
 		[[ "$backup" == "true" ]] && {
 			cp "$todo_file" "${todo_file}.bak"
 			print_success "Backup created: TODO.md.bak"


### PR DESCRIPTION
## Summary

- **Root cause**: `_upgrade_todo()` used `grep -E "^[[:space:]]*- \[([ x-])\]"` to extract tasks — this captured only task lines, discarding `### Subsection` headers that provide semantic grouping within `## Backlog`.
- **Fix**: Replaced with `awk '/^## Backlog/{found=1; next} found && /^## /{exit} found'` — extracts the entire `## Backlog` body (headers, tasks, blank lines) until the next `## ` section or EOF. This matches the pattern already used by `_upgrade_plans()` at `aidevops.sh:2313`.
- **Tested**: End-to-end with a fixture containing 4 subsections — all preserved in output with correct task ordering.

## Verification

```bash
# Create a fixture with subsections, run upgrade, check headers survive
cp fixture.md TODO.md
yes "y" | aidevops upgrade-planning
grep '^### ' TODO.md
# Expect: all original subsections present
```

Resolves #17806