### PR TITLE
GH#440: fix setup.sh blocking on generate-skills.sh (56s → 0.2s)

### DIFF
--- a/.agents/scripts/generate-skills.sh
+++ b/.agents/scripts/generate-skills.sh
@@ -251,6 +251,35 @@ if [[ "$CLEAN" == true ]]; then
 fi
 
 # =============================================================================
+# Cache check — skip generation if source .md files haven't changed
+# =============================================================================
+
+CACHE_HASH_FILE="${AGENTS_DIR}/.skills-source-hash"
+
+compute_source_hash() {
+	# Hash the listing of all source .md files with their sizes and mtimes.
+	# This is fast (~10ms for 1600 files) vs regenerating (~56s).
+	find "$AGENTS_DIR" -name "*.md" -not -name "SKILL.md" -not -name "AGENTS.md" \
+		-not -name "README.md" -type f -exec stat -f '%N %z %m' {} + 2>/dev/null |
+		LC_ALL=C sort | shasum -a 256 | cut -d' ' -f1
+	return 0
+}
+
+if [[ "$DRY_RUN" == false && "$CLEAN" == false ]]; then
+	current_hash=$(compute_source_hash)
+	if [[ -f "$CACHE_HASH_FILE" ]]; then
+		stored_hash=$(cat "$CACHE_HASH_FILE" 2>/dev/null || echo "")
+		if [[ "$current_hash" == "$stored_hash" ]]; then
+			# Verify at least one SKILL.md exists (handles first run after cache file created manually)
+			if find "$AGENTS_DIR" -name "SKILL.md" -type f -print -quit 2>/dev/null | grep -q .; then
+				log_info "Agent Skills SKILL.md files up to date (source unchanged) — skipping generation"
+				exit 0
+			fi
+		fi
+	fi
+fi
+
+# =============================================================================
 # Generate Mode
 # =============================================================================
 
@@ -393,6 +422,10 @@ log_info "  Skipped: $skipped (already exist or excluded)"
 if [[ "$DRY_RUN" == true ]]; then
 	log_warning ""
 	log_warning "This was a dry run. Run without --dry-run to generate files."
+else
+	# Write cache hash so next run skips if nothing changed
+	new_hash=$(compute_source_hash)
+	echo "$new_hash" >"$CACHE_HASH_FILE"
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

- `setup.sh` was blocking for **56 seconds** on every run because `generate-skills.sh` unconditionally regenerated all 957 SKILL.md files from 1650 source `.md` files
- Root cause: ~3000 subprocess spawns (`awk`, `grep`, `mkdir`, file writes) with no caching
- Fix: shasum-based content cache — hash source `.md` listing with sizes+mtimes, skip when unchanged
- Result: **56s → 0.18s** on subsequent runs (130x faster). First run after update still regenerates.

## How it works

1. Before generation, compute `shasum -a 256` of `find ... -exec stat -f '%N %z %m'` (fast — ~10ms for 1600 files)
2. Compare to stored hash in `~/.aidevops/agents/.skills-source-hash`
3. Match + SKILL.md files exist → exit immediately
4. Mismatch → regenerate all, write new hash

Cache invalidates automatically when any source `.md` file is added, removed, resized, or modified.

## Testing

```
First run (cold):  24.1s (generates 957 files)
Second run (warm): 0.18s (cache hit, exits)
```

## Runtime Testing

- Risk: **Low** — existing generation logic unchanged, only added early-exit gate
- Self-assessed: Verified cold/warm cache behavior, shellcheck clean

Resolves #440