### PR TITLE
fix(schedulers): add default values for optional params $12 and $13 in _install_scheduler_linux

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -595,8 +595,8 @@ _install_scheduler_linux() {
 	local fail_msg="$9"
 	local run_at_load="${10}"
 	local low_priority="${11}"
-	local on_calendar="${12}"
-	local timeout_sec="${13}"
+	local on_calendar="${12:-}"
+	local timeout_sec="${13:-}"
 
 	if _systemd_user_available; then
 		if _install_scheduler_systemd \


### PR DESCRIPTION
## Summary

`_install_scheduler_linux()` in `setup-modules/schedulers.sh` accessed `${12}` (on_calendar) and `${13}` (timeout_sec) without default values. Under `set -u`, any caller that passes fewer than 13 arguments triggers an unbound variable error, causing `aidevops update` to exit 1.

## Root cause

The function signature documents `$12` and `$13` as **optional** parameters, but the variable assignments used bare `${12}` and `${13}` without `:-` defaults. Multiple callers pass only 11 arguments (omitting both optional params):

- `setup_stats_wrapper` (line 781)
- `setup_process_guard` (line 988)
- `setup_memory_pressure_monitor` (line 1080)
- `_install_cw_linux` (line 1281)
- `_install_profile_readme_linux` (line 1448)
- `setup_token_refresh` (line 1660)

## Fix

```diff
-	local on_calendar="${12}"
-	local timeout_sec="${13}"
+	local on_calendar="${12:-}"
+	local timeout_sec="${13:-}"
```

The downstream `_install_scheduler_systemd()` already handles empty `timeout_sec` (falls back to `interval_sec`, then `3600`), so empty defaults are safe.

## Verification

- `bash -n setup-modules/schedulers.sh` — syntax check passes
- `shellcheck setup-modules/schedulers.sh` — zero violations
- The fix allows callers with 11 args to work without triggering `set -u` errors

## Runtime Testing

**Risk level:** Low — two-character change to variable defaults, no logic change.
**Self-assessed:** syntax check + shellcheck pass; downstream empty-value handling confirmed at lines 492-496.

Resolves #17807

---
[aidevops.sh](https://aidevops.sh) v3.6.171 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 2m and 4,087 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scheduler installation stability by improving how optional configuration parameters are processed, preventing failures in scenarios where these parameters are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->