### PR TITLE
GH#17831: fix(gh-failure-miner) exclude policy gate checks from systemic failure analysis

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1754,9 +1754,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "e296d8b5991af304b86dddc9088cee43b64b6848",
-      "at": "2026-04-08T02:39:29Z",
-      "passes": 26,
+      "hash": "9ad7ad779192ec16d43021b71ca1da104a0684fa",
+      "at": "2026-04-08T05:28:52Z",
+      "passes": 27,
       "pr": 15086
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "6acacb9eab7aa51d0d259ce5889bb133cb118ff4",
-      "at": "2026-04-08T04:51:04Z",
-      "passes": 56,
+      "hash": "1f97cd9546bc3887803876f60b43b60c3644840d",
+      "at": "2026-04-08T05:28:52Z",
+      "passes": 57,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -5267,9 +5267,9 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "b87d73e24891209a6993c57bd2938b2bc36e24e6",
-      "at": "2026-04-08T04:51:27Z",
-      "passes": 80,
+      "hash": "e2cc493eb82dcc50422d004716aa9e6c8a5be3c0",
+      "at": "2026-04-08T05:29:06Z",
+      "passes": 81,
       "pr": 15470
     },
     "setup.sh": {

--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -325,14 +325,25 @@ emit_event_json() {
 # 2. action_required — only from GitHub Actions runs. External apps (Codacy, SonarCloud)
 #    use action_required to mean "issues found for developer review", which is informational
 #    not a CI failure. Including these creates false systemic clusters (GH#4696).
+#
+# Policy gate checks are excluded (GH#17831): checks that enforce workflow policy
+# (e.g. maintainer review, assignee requirements) fail by design when policy is not met.
+# Treating these as systemic CI failures creates false noise — they are not tooling defects.
+# The exclusion list uses substring matching so minor name variations are still caught.
 filter_failed_check_runs() {
 	local checks_json="$1"
 	printf '%s\n' "$checks_json" | jq '[.check_runs[] | select(
-		((.conclusion // "" | ascii_downcase) as $c |
-			["failure","cancelled","timed_out","startup_failure"] | index($c))
-		or
-		((.conclusion // "" | ascii_downcase) == "action_required"
-			and (.app.slug // "" | ascii_downcase) == "github-actions")
+		(
+			((.conclusion // "" | ascii_downcase) as $c |
+				["failure","cancelled","timed_out","startup_failure"] | index($c))
+			or
+			((.conclusion // "" | ascii_downcase) == "action_required"
+				and (.app.slug // "" | ascii_downcase) == "github-actions")
+		)
+		and
+		# Exclude policy gate checks — these fail by design when policy is not met,
+		# not because of a tooling defect. (GH#17831)
+		((.name // "") | ascii_downcase | test("maintainer.*review|maintainer.*gate|assignee.*gate") | not)
 	)]'
 	return 0
 }


### PR DESCRIPTION
## Summary

The `gh-failure-miner` was treating "Maintainer Review & Assignee Gate" failures as systemic CI failures, creating noise issues like GH#17831. These failures are expected policy enforcement — the gate blocks PRs when linked issues lack an assignee or have the `needs-maintainer-review` label. This is by design, not a tooling defect.

## Root Cause

The `filter_failed_check_runs()` function in `gh-failure-miner-helper.sh` had no exclusion for policy gate checks. When the gate fired on two PRs within the notification window, the miner clustered them as a systemic failure and created a tracking issue.

## Fix

Added a policy gate exclusion to `filter_failed_check_runs()` that skips check names matching:
- `maintainer.*review` — catches "Maintainer Review & Assignee Gate"
- `maintainer.*gate` — catches "Maintainer Gate" (workflow name)
- `assignee.*gate` — catches any future assignee-specific gate variants

The regex uses substring matching (case-insensitive) so minor name variations are still caught.

## What Changed

- **EDIT** `.agents/scripts/gh-failure-miner-helper.sh` — added policy gate exclusion in `filter_failed_check_runs()` with explanatory comment referencing GH#17831

## Evidence

The two PRs cited in GH#17831:
- PR #17791: blocked because issue #17790 had `needs-maintainer-review` + no assignee (external contributor PR — correct behavior)
- PR #17818: blocked because issue #440 had no assignee (internal PR, gate passed on re-run after issue was updated — correct behavior)

Both are the gate working as designed. Neither is a tooling defect.

## Runtime Testing

- Risk: **Low** (pure filter logic change, no feature changes)
- Self-assessed: ShellCheck passes. jq filter logic verified with test input — correctly excludes all three gate check name patterns while keeping legitimate CI failures (ShellCheck, review-bot-gate, etc.)

## Verification

```bash
shellcheck .agents/scripts/gh-failure-miner-helper.sh
```

Resolves #17831

---
[aidevops.sh](https://aidevops.sh) v3.6.171 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 4m and 7,055 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering to exclude policy gate check runs from failure detection and reporting.

* **Chores**
  * Updated internal configuration state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->