### PR TITLE
GH#17809: fallback to jobs API in extract_failure_signature when --log-failed is empty

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1754,9 +1754,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "e296d8b5991af304b86dddc9088cee43b64b6848",
-      "at": "2026-04-08T02:39:29Z",
-      "passes": 26,
+      "hash": "9ad7ad779192ec16d43021b71ca1da104a0684fa",
+      "at": "2026-04-08T05:28:52Z",
+      "passes": 27,
       "pr": 15086
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "6acacb9eab7aa51d0d259ce5889bb133cb118ff4",
-      "at": "2026-04-08T04:51:04Z",
-      "passes": 56,
+      "hash": "1f97cd9546bc3887803876f60b43b60c3644840d",
+      "at": "2026-04-08T05:28:52Z",
+      "passes": 57,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -5267,9 +5267,9 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "b87d73e24891209a6993c57bd2938b2bc36e24e6",
-      "at": "2026-04-08T04:51:27Z",
-      "passes": 80,
+      "hash": "e2cc493eb82dcc50422d004716aa9e6c8a5be3c0",
+      "at": "2026-04-08T05:29:06Z",
+      "passes": 81,
       "pr": 15470
     },
     "setup.sh": {

--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -167,6 +167,17 @@ extract_failure_signature() {
 	local logs
 	logs=$(gh run view "$run_id" --repo "$repo_slug" --log-failed 2>/dev/null || true)
 	if [[ -z "$logs" ]]; then
+		# Fallback: --log-failed returned empty (logs expired, rate-limited, or run still
+		# in progress). Try the jobs API to get the first failed job's logs directly.
+		# This avoids the "no_failed_log_output" signature which produces unhelpful clusters.
+		local failed_job_id
+		failed_job_id=$(gh api "repos/${repo_slug}/actions/runs/${run_id}/jobs" \
+			--jq '[.jobs[] | select(.conclusion == "failure")] | first | .id // empty' 2>/dev/null || true)
+		if [[ -n "$failed_job_id" ]]; then
+			logs=$(gh api "repos/${repo_slug}/actions/jobs/${failed_job_id}/logs" 2>/dev/null || true)
+		fi
+	fi
+	if [[ -z "$logs" ]]; then
 		printf '%s' "no_failed_log_output"
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Fixes the `no_failed_log_output` error signature in `gh-failure-miner-helper.sh` by adding a fallback to the GitHub jobs API when `gh run view --log-failed` returns empty output.

## Root Cause

`extract_failure_signature()` calls `gh run view --log-failed` to get the error text from a failed CI run. This returns empty when:
- Run logs have expired (GitHub retains logs for 90 days, but the miner may run after expiry)
- The run is still in progress when the miner fires
- API rate limiting

When empty, the function returned the literal string `no_failed_log_output` as the signature. This caused the failure miner to cluster all such events under a single vague signature, producing unhelpful systemic-failure issues (like #17809 itself) that don't identify the actual error.

## Fix

Added a two-step fallback inside `extract_failure_signature()`:
1. `GET /actions/runs/{run_id}/jobs` — find the first job with `conclusion=failure`
2. `GET /actions/jobs/{job_id}/logs` — get that job's log output directly

Both API calls are wrapped in `2>/dev/null || true` so failures are non-fatal. If the fallback also returns empty, the function still returns `no_failed_log_output` as before.

## Files Changed

- EDIT: `.agents/scripts/gh-failure-miner-helper.sh` — `extract_failure_signature()` function (lines 164-193)

## Runtime Testing

- Risk: **Low** — non-fatal fallback path, both API calls wrapped in `|| true`
- Testing: ShellCheck zero violations on modified file; logic verified against GitHub Actions API docs

Resolves #17809


---
[aidevops.sh](https://aidevops.sh) v3.6.171 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 5m and 9,965 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging recovery in CI processes with improved fallback mechanisms for retrieving failure information when standard queries are unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->