### PR TITLE
GH#17848: pull latest state before complexity scan to prevent stale proximity warnings

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1814,9 +1814,9 @@
       "pr": 16536
     },
     ".agents/scripts/session-checkpoint-helper.sh": {
-      "hash": "97853293fc74ebb62428051502cbf0962104a204",
-      "at": "2026-04-03T03:15:28Z",
-      "passes": 1,
+      "hash": "1feda3eaabb02f6475b7d89129c0fafb06605298",
+      "at": "2026-04-08T10:00:30Z",
+      "passes": 2,
       "pr": 15917
     },
     ".agents/scripts/settings-helper.sh": {
@@ -5925,10 +5925,10 @@
       "passes": 1
     },
     ".agents/scripts/design-preview-helper.sh": {
-      "hash": "5bced80b1577bec5acd54ab00c8757d684482897",
-      "at": "2026-04-03T22:57:37Z",
+      "hash": "6b9e3abc59fce088288993aa32023b9d5589558e",
+      "at": "2026-04-08T10:00:29Z",
       "pr": 16879,
-      "passes": 1
+      "passes": 2
     },
     ".agents/tools/design/library/styles/playful-vibrant/DESIGN.md": {
       "hash": "f42502be75dfeee3f716f54b3ea2d8e6697414a6",
@@ -6791,10 +6791,10 @@
       "passes": 2
     },
     ".agents/scripts/opencode-db-archive.sh": {
-      "hash": "a953f036c9b90db133b936a23562c884dcb1e435",
-      "at": "2026-04-07T19:50:54Z",
+      "hash": "6e0d4a91eb51f9d9a718f0dd92d62c85555a2dbf",
+      "at": "2026-04-08T10:00:29Z",
       "pr": 17584,
-      "passes": 4
+      "passes": 5
     },
     ".agents/scripts/colormind-helper.sh": {
       "hash": "fca3090dfe5b07e572ecf605cd270baa54981bbf",
@@ -6855,6 +6855,12 @@
       "hash": "6f759c36018684c1292c2eb47eef885c29cc19ea",
       "at": "2026-04-08T01:53:08Z",
       "pr": 17786,
+      "passes": 1
+    },
+    ".agents/scripts/commands/init-routines.md": {
+      "hash": "3bb3703f09649692c0be7473b2882097bb5083fc",
+      "at": "2026-04-08T10:00:43Z",
+      "pr": 17819,
       "passes": 1
     }
   },

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6045,10 +6045,14 @@ run_weekly_complexity_scan() {
 	# tree-change check both read working-tree files, so a stale checkout
 	# (e.g., local repo hasn't pulled a threshold-bump PR yet) produces
 	# incorrect violation counts and may create spurious warning issues.
+	# Fail-closed: if pull fails, skip this scan cycle rather than proceeding
+	# with stale data (which would reintroduce the exact problem we're fixing).
+	# Do NOT update COMPLEXITY_SCAN_LAST_RUN on skip — the next cycle retries.
 	if git -C "$aidevops_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-		git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 || {
-			echo "[pulse-wrapper] Complexity scan: git pull failed for ${aidevops_path} — proceeding with current checkout" >>"$LOGFILE"
-		}
+		if ! git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1; then
+			echo "[pulse-wrapper] Complexity scan: git pull failed for ${aidevops_path} — skipping this cycle to avoid stale-state warnings" >>"$LOGFILE"
+			return 0
+		fi
 	fi
 
 	# Deterministic skip: if no tracked files changed since last scan, skip all

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6048,8 +6048,11 @@ run_weekly_complexity_scan() {
 	# Fail-closed: if pull fails, skip this scan cycle rather than proceeding
 	# with stale data (which would reintroduce the exact problem we're fixing).
 	# Do NOT update COMPLEXITY_SCAN_LAST_RUN on skip — the next cycle retries.
+	# GIT_TERMINAL_PROMPT=0 prevents credential prompts from hanging the pulse.
+	# timeout 30 prevents network hangs from blocking the pulse cycle.
 	if git -C "$aidevops_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-		if ! git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1; then
+		if ! GIT_TERMINAL_PROMPT=0 timeout 30 \
+			git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1; then
 			echo "[pulse-wrapper] Complexity scan: git pull failed for ${aidevops_path} — skipping this cycle to avoid stale-state warnings" >>"$LOGFILE"
 			return 0
 		fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6040,6 +6040,17 @@ run_weekly_complexity_scan() {
 	local aidevops_path
 	aidevops_path=$(_complexity_scan_find_repo "$repos_json" "$aidevops_slug" "$now_epoch") || return 0
 
+	# GH#17848: Pull latest state before scanning to avoid false-positive
+	# proximity warnings from stale local checkouts. The proximity guard and
+	# tree-change check both read working-tree files, so a stale checkout
+	# (e.g., local repo hasn't pulled a threshold-bump PR yet) produces
+	# incorrect violation counts and may create spurious warning issues.
+	if git -C "$aidevops_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 || {
+			echo "[pulse-wrapper] Complexity scan: git pull failed for ${aidevops_path} — proceeding with current checkout" >>"$LOGFILE"
+		}
+	fi
+
 	# Deterministic skip: if no tracked files changed since last scan, skip all
 	# file iteration (O(1) tree hash check vs O(n) per-file awk/wc scan).
 	# GH#15285: this is the primary perf fix — most pulse cycles see no changes.


### PR DESCRIPTION
## Summary

The proximity guard in `run_weekly_complexity_scan` was reading working-tree files without first pulling the latest remote state. This caused false-positive warning issues when the local checkout was behind origin.

**Root cause:** Issue #17848 was created at 09:50 UTC on 2026-04-08, but PR #17841 (threshold bump to 285) had merged at 08:40 UTC and PR #17847 (violations reduced to 264) had merged at 09:45 UTC. The pulse was running with a stale local checkout that hadn't pulled these changes, so it saw 279 violations against a 279 threshold (0 headroom) instead of the actual 264/285 (21 headroom).

## Changes

**EDIT: `.agents/scripts/pulse-wrapper.sh`** — add `git pull --ff-only` at the start of `run_weekly_complexity_scan`, before the tree-change check and proximity guard. Mirrors the pattern already used in `dispatch_with_dedup` (line 7204) before launching workers.

## Runtime Testing

Risk: **Low** — adds a git pull before a read-only scan. No state mutations, no new logic paths. Syntax-checked with `bash -n`.

Verification: `bash -n .agents/scripts/pulse-wrapper.sh` exits 0.

## Resolves #17848

Resolves #17848

---
[aidevops.sh](https://aidevops.sh) v3.6.172 plugin for [Claude Code](https://claude.ai/code) with claude-sonnet-4-6 spent 4m and 9,320 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration entries and recorded state for several automation scripts; added an initial record for a new initialization routine.
  * Automation scans now attempt to refresh the repository before running; if the refresh fails, the scan is safely skipped to avoid using stale checkout data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->