### PR TITLE
GH#17850: reduce shell nesting depth violations and ratchet threshold

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -43,10 +43,14 @@ FUNCTION_COMPLEXITY_THRESHOLD=420
 # Adding 6 units of headroom (279+6=285) ensures the proximity guard (GH#17808)
 # fires at 280 violations before the threshold is saturated again, preventing
 # false-positive CI failures on PRs that don't introduce new nesting violations.
+# Ratcheted down to 268 (GH#17850): reduced violations from 264→262 by converting
+# elif chains to early-return patterns and extracting heredoc code into separate
+# files (platform-detect.sh, safety-policy-check.sh, quality-fix.sh, spdx-headers.sh,
+# dispatch-claim-helper.sh, ip-rep-blocklistde.sh). 262 violations + 6 headroom = 268.
 # NOTE: pulse-wrapper.sh now has a proximity guard (GH#17808) that warns when
 # violations are within 5 of this threshold. Bump this value AND document the
 # reason above when adding scripts that push the count over the current value.
-NESTING_DEPTH_THRESHOLD=285
+NESTING_DEPTH_THRESHOLD=268
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/scripts/check-generator-rules.py
+++ b/.agents/scripts/check-generator-rules.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# check-generator-rules.py — Validate deny/allow secret rules in settings updater
+# Called by safety-policy-check.sh check_generator_rules()
+# Usage: python3 check-generator-rules.py <target_file>
+
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8", errors="replace")
+
+
+def extract_block(name: str) -> str:
+    m = re.search(rf"{name}\s*=\s*\[(.*?)\]\n", text, re.S)
+    return m.group(1) if m else ""
+
+
+allow_block = extract_block("allow_rules")
+deny_block = extract_block("deny_rules")
+
+forbidden_in_allow = [
+    "Bash(gopass show *)",
+    "Bash(pass show *)",
+    "Bash(op read *)",
+    "Bash(cat ~/.config/aidevops/credentials.sh)",
+    "Read(~/.config/aidevops/credentials.sh)",
+]
+
+required_in_deny = [
+    "Bash(gopass show *)",
+    "Bash(pass show *)",
+    "Bash(op read *)",
+    "Bash(cat ~/.config/aidevops/credentials.sh)",
+    "Read(~/.config/aidevops/credentials.sh)",
+]
+
+errors = []
+for rule in forbidden_in_allow:
+    if rule in allow_block:
+        errors.append(f"forbidden rule in allow_rules: {rule}")
+
+for rule in required_in_deny:
+    if rule not in deny_block:
+        errors.append(f"required deny rule missing: {rule}")
+
+if errors:
+    for err in errors:
+        print(f"FAIL: {err}", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: generator deny/allow secret rules")

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -417,20 +417,12 @@ Protocol:
   5. Winner proceeds with dispatch; claim blocks re-dispatch for TTL duration
 
 Examples:
-  # Claim before dispatching (in pulse dedup guard)
-  RUNNER=$(gh api user --jq '.login')
-  if dispatch-claim-helper.sh claim 42 owner/repo "$RUNNER"; then
-    # Won the claim — dispatch worker
-    headless-runtime-helper.sh run --session-key "issue-42" ...
-  else
-    exit_code=$?
-    if [[ $exit_code -eq 1 ]]; then
-      echo "Lost claim — another runner is dispatching"
-    else
-      echo "Claim error — proceeding (fail-open)"
-      # dispatch anyway
-    fi
-  fi
+  # Claim before dispatching (in pulse dedup guard):
+  #   RUNNER=\$(gh api user --jq '.login')
+  #   dispatch-claim-helper.sh claim 42 owner/repo "\$RUNNER"
+  #   Exit 0 → won claim, proceed with dispatch
+  #   Exit 1 → lost claim, back off
+  #   Exit 2 → error, proceed (fail-open)
 HELP
 	return 0
 }

--- a/.agents/scripts/platform-detect.sh
+++ b/.agents/scripts/platform-detect.sh
@@ -44,63 +44,82 @@ _detect_linux_scheduler() {
 
 _detect_linux_clipboard() {
 	# Clipboard: prefer xclip, then xsel, then wl-copy (Wayland), then clip.exe (WSL2)
+	# Uses early-return pattern to avoid elif chains (reduces awk nesting depth count)
+	AIDEVOPS_CLIPBOARD_COPY=""
+	AIDEVOPS_CLIPBOARD_PASTE=""
 	if command -v xclip >/dev/null 2>&1; then
 		AIDEVOPS_CLIPBOARD_COPY="xclip -selection clipboard"
 		AIDEVOPS_CLIPBOARD_PASTE="xclip -selection clipboard -o"
-	elif command -v xsel >/dev/null 2>&1; then
+		return 0
+	fi
+	if command -v xsel >/dev/null 2>&1; then
 		AIDEVOPS_CLIPBOARD_COPY="xsel --clipboard --input"
 		AIDEVOPS_CLIPBOARD_PASTE="xsel --clipboard --output"
-	elif command -v wl-copy >/dev/null 2>&1; then
+		return 0
+	fi
+	if command -v wl-copy >/dev/null 2>&1; then
 		AIDEVOPS_CLIPBOARD_COPY="wl-copy"
 		AIDEVOPS_CLIPBOARD_PASTE="wl-paste"
-	elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v clip.exe >/dev/null 2>&1; then
+		return 0
+	fi
+	if [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v clip.exe >/dev/null 2>&1; then
 		AIDEVOPS_CLIPBOARD_COPY="clip.exe"
 		AIDEVOPS_CLIPBOARD_PASTE="powershell.exe -c Get-Clipboard"
-	else
-		AIDEVOPS_CLIPBOARD_COPY=""
-		AIDEVOPS_CLIPBOARD_PASTE=""
+		return 0
 	fi
 	return 0
 }
 
 _detect_linux_open_cmd() {
 	# Open URL/file: prefer xdg-open, then wslview (WSL2 bridge)
+	AIDEVOPS_OPEN_CMD=""
 	if command -v xdg-open >/dev/null 2>&1; then
 		AIDEVOPS_OPEN_CMD="xdg-open"
-	elif [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v wslview >/dev/null 2>&1; then
+		return 0
+	fi
+	if [[ "$AIDEVOPS_PLATFORM" == "wsl2" ]] && command -v wslview >/dev/null 2>&1; then
 		AIDEVOPS_OPEN_CMD="wslview"
-	else
-		AIDEVOPS_OPEN_CMD=""
+		return 0
 	fi
 	return 0
 }
 
 _detect_linux_file_search() {
 	# File search: prefer fd, then locate, then find
+	AIDEVOPS_FILE_SEARCH="find"
 	if command -v fd >/dev/null 2>&1; then
 		AIDEVOPS_FILE_SEARCH="fd"
-	elif command -v locate >/dev/null 2>&1; then
+		return 0
+	fi
+	if command -v locate >/dev/null 2>&1; then
 		AIDEVOPS_FILE_SEARCH="locate"
-	else
-		AIDEVOPS_FILE_SEARCH="find"
+		return 0
 	fi
 	return 0
 }
 
 _detect_linux_pkg_manager() {
-	# Package manager
+	# Package manager — early-return pattern to avoid elif chains
+	AIDEVOPS_PKG_INSTALL=""
 	if command -v apt-get >/dev/null 2>&1; then
 		AIDEVOPS_PKG_INSTALL="sudo apt-get install -y"
-	elif command -v brew >/dev/null 2>&1; then
+		return 0
+	fi
+	if command -v brew >/dev/null 2>&1; then
 		AIDEVOPS_PKG_INSTALL="brew install"
-	elif command -v dnf >/dev/null 2>&1; then
+		return 0
+	fi
+	if command -v dnf >/dev/null 2>&1; then
 		AIDEVOPS_PKG_INSTALL="sudo dnf install -y"
-	elif command -v pacman >/dev/null 2>&1; then
+		return 0
+	fi
+	if command -v pacman >/dev/null 2>&1; then
 		AIDEVOPS_PKG_INSTALL="sudo pacman -S --noconfirm"
-	elif command -v apk >/dev/null 2>&1; then
+		return 0
+	fi
+	if command -v apk >/dev/null 2>&1; then
 		AIDEVOPS_PKG_INSTALL="sudo apk add"
-	else
-		AIDEVOPS_PKG_INSTALL=""
+		return 0
 	fi
 	return 0
 }

--- a/.agents/scripts/providers/ip-rep-blocklistde.sh
+++ b/.agents/scripts/providers/ip-rep-blocklistde.sh
@@ -125,11 +125,9 @@ cmd_check() {
 		reports=$(echo "$normalized" | grep -oE 'reports:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' || echo "0")
 		attacks="${attacks:-0}"
 		reports="${reports:-0}"
-		if [[ "$attacks" -gt 0 || "$reports" -gt 0 ]]; then
-			is_listed=true
-		else
-			is_listed=false
-		fi
+		# Determine listing status based on attack/report counts
+		is_listed=false
+		[[ "$attacks" -gt 0 || "$reports" -gt 0 ]] && is_listed=true
 	else
 		# Unexpected response format — treat as error
 		error_json "$ip" "unexpected response format: ${response:0:100}"

--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -71,74 +71,71 @@ fix_return_statements() {
 	local files_fixed=0
 
 	while IFS= read -r -d '' file; do
-		if [[ -f "$file" ]]; then
-			# Find functions that don't end with return statement
-			local temp_file
-			temp_file=$(mktemp)
-			local file_mode=""
-			file_mode=$(stat -f "%Lp" "$file" 2>/dev/null || stat -c "%a" "$file" 2>/dev/null || true)
-			local in_function=false
-			local function_name=""
-			local brace_count=0
-			local fixed_functions=0
+		[[ -f "$file" ]] || continue
+		# Find functions that don't end with return statement
+		local temp_file
+		temp_file=$(mktemp)
+		local file_mode=""
+		file_mode=$(stat -f "%Lp" "$file" 2>/dev/null || stat -c "%a" "$file" 2>/dev/null || true)
+		local in_function=false
+		local function_name=""
+		local brace_count=0
+		local fixed_functions=0
 
-			while IFS= read -r line; do
-				echo "$line" >>"$temp_file"
+		while IFS= read -r line; do
+			echo "$line" >>"$temp_file"
 
-				# Detect function start
-				if [[ $line =~ ^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{ ]]; then
-					in_function=true
-					function_name=$(echo "$line" | sed 's/().*//')
-					brace_count=1
-				elif [[ $in_function == true ]]; then
-					# Count braces to track function scope
-					local open_braces
-					open_braces=$(echo "$line" | grep -o '{' | wc -l 2>/dev/null || echo "0")
-					local close_braces
-					close_braces=$(echo "$line" | grep -o '}' | wc -l 2>/dev/null || echo "0")
+			# Detect function start
+			if [[ $line =~ ^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{ ]]; then
+				in_function=true
+				function_name=$(echo "$line" | sed 's/().*//')
+				brace_count=1
+			elif [[ $in_function == true ]]; then
+				# Count braces to track function scope
+				local open_braces
+				open_braces=$(echo "$line" | grep -o '{' | wc -l 2>/dev/null || echo "0")
+				local close_braces
+				close_braces=$(echo "$line" | grep -o '}' | wc -l 2>/dev/null || echo "0")
 
-					# Ensure variables are numeric
-					open_braces=${open_braces//[^0-9]/}
-					close_braces=${close_braces//[^0-9]/}
-					open_braces=${open_braces:-0}
-					close_braces=${close_braces:-0}
+				# Ensure variables are numeric
+				open_braces=${open_braces//[^0-9]/}
+				close_braces=${close_braces//[^0-9]/}
+				open_braces=${open_braces:-0}
+				close_braces=${close_braces:-0}
 
-					# Fix arithmetic expansion
-					local diff
-					diff=$((open_braces - close_braces))
-					brace_count=$((brace_count + diff))
+				# Fix arithmetic expansion
+				local diff
+				diff=$((open_braces - close_braces))
+				brace_count=$((brace_count + diff))
 
-					# Check if function is ending
-					if [[ $brace_count -eq 0 && $line == "}" ]]; then
-						# Check if previous line has return statement
-						local last_line
-						last_line=$(tail -2 "$temp_file" | head -1)
+				# Check if function is ending
+				if [[ $brace_count -eq 0 && $line == "}" ]]; then
+					# Check if previous line has return statement
+					local last_line
+					last_line=$(tail -2 "$temp_file" | head -1)
 
-						if [[ ! $last_line =~ return[[:space:]]+[01] ]]; then
-							# Remove the closing brace and add return statement
-							sed_inplace '$ d' "$temp_file"
-							echo "    return 0" >>"$temp_file"
-							echo "}" >>"$temp_file"
-							((++fixed_functions))
-							print_info "Fixed function: $function_name"
-						fi
-
-						in_function=false
-						function_name=""
+					if [[ ! $last_line =~ return[[:space:]]+[01] ]]; then
+						# Remove the closing brace and add return statement
+						sed_inplace '$ d' "$temp_file"
+						echo "    return 0" >>"$temp_file"
+						echo "}" >>"$temp_file"
+						((++fixed_functions))
+						print_info "Fixed function: $function_name"
 					fi
-				fi
-			done <"$file"
 
-			if [[ $fixed_functions -gt 0 ]]; then
-				mv "$temp_file" "$file"
-				if [[ -n "$file_mode" ]]; then
-					chmod "$file_mode" "$file"
+					in_function=false
+					function_name=""
 				fi
-				((++files_fixed))
-				print_success "Fixed $fixed_functions functions in $file"
-			else
-				rm -f "$temp_file"
 			fi
+		done <"$file"
+
+		if [[ $fixed_functions -gt 0 ]]; then
+			mv "$temp_file" "$file"
+			[[ -n "$file_mode" ]] && chmod "$file_mode" "$file"
+			((++files_fixed))
+			print_success "Fixed $fixed_functions functions in $file"
+		else
+			rm -f "$temp_file"
 		fi
 	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null)
 
@@ -152,32 +149,31 @@ fix_positional_parameters() {
 	local files_fixed=0
 
 	while IFS= read -r -d '' file; do
-		if [[ -f "$file" ]]; then
-			local temp_file
-			temp_file=$(mktemp)
+		[[ -f "$file" ]] || continue
+		local temp_file
+		temp_file=$(mktemp)
 
-			# Process main() functions specifically
-			if grep -q "^main() {" "$file"; then
-				# Add local variable assignments to main function
-				sed '/^main() {/,/^}$/ {
-                    /^main() {/a\
+		# Process main() functions specifically
+		if grep -q "^main() {" "$file"; then
+			# Add local variable assignments to main function
+			sed '/^main() {/,/^}$/ {
+                /^main() {/a\
     # Assign positional parameters to local variables\
     local command="${1:-help}"\
     local account_name="$2"\
     local target="$3"\
     local options="$4"
-                }' "$file" >"$temp_file"
+            }' "$file" >"$temp_file"
 
-				# Replace direct positional parameter usage in case statements
-				sed_inplace 's/\$_arg1/\${command}/g; s/\$2/\${account_name}/g; s/\$3/\${target}/g; s/\$4/\${options}/g' "$temp_file"
+			# Replace direct positional parameter usage in case statements
+			sed_inplace 's/\$_arg1/\${command}/g; s/\$2/\${account_name}/g; s/\$3/\${target}/g; s/\$4/\${options}/g' "$temp_file"
 
-				if ! diff -q "$file" "$temp_file" >/dev/null; then
-					mv "$temp_file" "$file"
-					((++files_fixed))
-					print_success "Fixed positional parameters in main() function of $file"
-				else
-					rm -f "$temp_file"
-				fi
+			if ! diff -q "$file" "$temp_file" >/dev/null; then
+				mv "$temp_file" "$file"
+				((++files_fixed))
+				print_success "Fixed positional parameters in main() function of $file"
+			else
+				rm -f "$temp_file"
 			fi
 		fi
 	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null)
@@ -193,23 +189,20 @@ analyze_string_literals() {
 	constants_file=$(mktemp)
 
 	while IFS= read -r -d '' file; do
-		if [[ -f "$file" ]]; then
-			echo "=== $file ===" >>"$constants_file"
+		[[ -f "$file" ]] || continue
+		echo "=== $file ===" >>"$constants_file"
 
-			# Find repeated strings (3+ occurrences)
-			(grep -o '"[^"]*"' "$file" || true) | sort | uniq -c | sort -nr | awk '$_arg1 >= 3 {
-                gsub(/"/, "", $2)
-                constant_name = toupper($2)
-                gsub(/[^A-Z0-9_]/, "_", constant_name)
-                gsub(/_+/, "_", constant_name)
-                gsub(/^_|_$/, "", constant_name)
-                if (length(constant_name) > 0) {
-                    printf "readonly %s=\"%s\"  # Used %d times\n", constant_name, $2, $_arg1
-                }
+		# Find repeated strings (3+ occurrences)
+		(grep -o '"[^"]*"' "$file" || true) | sort | uniq -c | sort -nr | awk '
+            $1 >= 3 {
+                gsub(/"/, "", $2); cn = toupper($2)
+                gsub(/[^A-Z0-9_]/, "_", cn); gsub(/_+/, "_", cn); gsub(/^_|_$/, "", cn)
+            }
+            $1 >= 3 && length(cn) > 0 {
+                printf "readonly %s=\"%s\"  # Used %d times\n", cn, $2, $1
             }' >>"$constants_file"
 
-			echo "" >>"$constants_file"
-		fi
+		echo "" >>"$constants_file"
 	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null)
 
 	if [[ -s "$constants_file" ]]; then
@@ -230,10 +223,10 @@ validate_fixes() {
 	local validation_errors=0
 
 	while IFS= read -r -d '' file; do
-		if [[ -f "$file" ]] && ! shellcheck "$file" >/dev/null 2>&1; then
-			((++validation_errors))
-			print_warning "ShellCheck issues remain in $file"
-		fi
+		[[ -f "$file" ]] || continue
+		shellcheck "$file" >/dev/null 2>&1 && continue
+		((++validation_errors))
+		print_warning "ShellCheck issues remain in $file"
 	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null)
 
 	if [[ $validation_errors -eq 0 ]]; then

--- a/.agents/scripts/safety-policy-check.sh
+++ b/.agents/scripts/safety-policy-check.sh
@@ -85,54 +85,7 @@ check_generator_rules() {
 		return 1
 	fi
 
-	python3 - "$target_file" <<'PY'
-import re
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-text = path.read_text(encoding="utf-8", errors="replace")
-
-def extract_block(name: str) -> str:
-    m = re.search(rf"{name}\s*=\s*\[(.*?)\]\n", text, re.S)
-    return m.group(1) if m else ""
-
-allow_block = extract_block("allow_rules")
-deny_block = extract_block("deny_rules")
-
-forbidden_in_allow = [
-    "Bash(gopass show *)",
-    "Bash(pass show *)",
-    "Bash(op read *)",
-    "Bash(cat ~/.config/aidevops/credentials.sh)",
-    "Read(~/.config/aidevops/credentials.sh)",
-]
-
-required_in_deny = [
-    "Bash(gopass show *)",
-    "Bash(pass show *)",
-    "Bash(op read *)",
-    "Bash(cat ~/.config/aidevops/credentials.sh)",
-    "Read(~/.config/aidevops/credentials.sh)",
-]
-
-errors = []
-for rule in forbidden_in_allow:
-    if rule in allow_block:
-        errors.append(f"forbidden rule in allow_rules: {rule}")
-
-for rule in required_in_deny:
-    if rule not in deny_block:
-        errors.append(f"required deny rule missing: {rule}")
-
-if errors:
-    for err in errors:
-        print(f"FAIL: {err}", file=sys.stderr)
-    sys.exit(1)
-
-print("PASS: generator deny/allow secret rules")
-PY
-
+	python3 "${SCRIPT_DIR}/check-generator-rules.py" "$target_file"
 	return $?
 }
 
@@ -167,23 +120,24 @@ check_policy_markers() {
 
 	# Detailed secret handling rules must exist (either inline in build.txt
 	# or in the extracted reference file)
+	local secret_check_target="$build_prompt"
 	if [[ -f "$secret_handling_ref" ]]; then
-		if [[ ! -r "$secret_handling_ref" ]]; then
+		[[ ! -r "$secret_handling_ref" ]] && {
 			echo "FAIL: secret-handling reference not readable: $secret_handling_ref" >&2
 			return 1
-		fi
-		if ! require_pattern "Never paste secret values into AI chat" "$secret_handling_ref" \
-			"mandatory warning guidance missing from secret-handling reference"; then
-			return 1
-		fi
+		}
+		secret_check_target="$secret_handling_ref"
+	fi
+
+	if ! require_pattern "Never paste secret values into AI chat" "$secret_check_target" \
+		"mandatory warning guidance missing from ${secret_check_target##*/}"; then
+		return 1
+	fi
+
+	# Transcript exposure section only required in the dedicated reference file
+	if [[ -f "$secret_handling_ref" ]]; then
 		if ! require_pattern "Session Transcript Exposure" "$secret_handling_ref" \
 			"transcript exposure section missing from secret-handling reference"; then
-			return 1
-		fi
-	else
-		# Fallback: if reference file doesn't exist, check build.txt directly
-		if ! require_pattern "Never paste secret values into AI chat" "$build_prompt" \
-			"mandatory warning guidance missing from build prompt"; then
 			return 1
 		fi
 	fi

--- a/.agents/scripts/spdx-headers.sh
+++ b/.agents/scripts/spdx-headers.sh
@@ -236,21 +236,28 @@ cmd_add() {
 	return 0
 }
 
+_is_spdx_exempt() {
+	local file="$1"
+	local bn
+	bn=$(basename "$file")
+	# Exempt: VERSION, log files, csv files, json.txt files
+	[[ "$bn" == "VERSION" || "$bn" == *.log || "$bn" == *.csv ]] && return 0
+	[[ "$file" == *.json.txt ]] && return 0
+	return 1
+}
+
 cmd_check() {
 	echo "Checking SPDX header coverage..."
 	local missing=0 total=0
+	local ext
 	for ext in sh md py txt; do
 		while IFS= read -r file; do
 			[[ -z "$file" ]] && continue
 			total=$((total + 1))
-			local bn
-			bn=$(basename "$file")
-			case "$bn" in VERSION | *.log | *.csv) continue ;; esac
-			case "$file" in *.json.txt) continue ;; esac
-			if ! _has_spdx "$file"; then
-				echo "  missing: $file"
-				missing=$((missing + 1))
-			fi
+			_is_spdx_exempt "$file" && continue
+			_has_spdx "$file" && continue
+			echo "  missing: $file"
+			missing=$((missing + 1))
 		done < <(git ls-files "*.${ext}" 2>/dev/null)
 	done
 	echo ""
@@ -274,13 +281,19 @@ cmd_help() {
 	return 0
 }
 
+_parse_options() {
+	local arg
+	for arg in "$@"; do
+		[[ "$arg" == "--dry-run" ]] && DRY_RUN=true
+		[[ "$arg" == "--verbose" ]] && VERBOSE=true
+	done
+	return 0
+}
+
 main() {
 	local command="${1:-help}"
 	shift 2>/dev/null || true
-	local arg
-	for arg in "$@"; do
-		case "$arg" in --dry-run) DRY_RUN=true ;; --verbose) VERBOSE=true ;; esac
-	done
+	_parse_options "$@"
 	case "$command" in
 	add) cmd_add ;;
 	check) cmd_check ;;


### PR DESCRIPTION
## Summary

Resolves #17850

Reduce shell nesting depth violations from 264→262 and ratchet the CI threshold from 285→268 (262 + 6 headroom).

## What changed

The awk-based nesting depth checker in CI counts `if/for/while/until/case` keywords across entire files without function-boundary resets. This means:
- `elif` is counted as an `if` increment (substring match)
- Python/awk code inside heredocs inflates the count
- Large files with many functions accumulate depth across all functions

### Refactoring patterns applied

| File | Before | After | Technique |
|------|--------|-------|-----------|
| platform-detect.sh | 10 | 1 | elif chains → early-return if/return 0 |
| safety-policy-check.sh | 10 | 3 | Python heredoc → check-generator-rules.py |
| quality-fix.sh | 10 | 8 | Guard clauses (`|| continue`), awk restructure |
| spdx-headers.sh | 10 | 9 | Extract `_is_spdx_exempt` helper, `_parse_options` |
| dispatch-claim-helper.sh | 10 | 9 | Heredoc example → comment format |
| ip-rep-blocklistde.sh | 10 | 9 | Nested if → inline conditional |

### Threshold ratchet

- **Before**: 285 (set in GH#17830 to add headroom after saturation)
- **After**: 268 (262 violations + 6 headroom)
- This ratchets down the threshold so future regressions are caught earlier

## Runtime Testing

- Risk: **Low** (refactoring shell scripts, no runtime behaviour change)
- Verification: `self-assessed` — shellcheck clean on all modified files, nesting count verified via CI's exact awk pattern

## Files changed

- `.agents/configs/complexity-thresholds.conf` — threshold 285→268
- `.agents/scripts/platform-detect.sh` — elif → early-return
- `.agents/scripts/safety-policy-check.sh` — extract Python to separate file
- `.agents/scripts/check-generator-rules.py` — NEW: extracted from heredoc
- `.agents/scripts/quality-fix.sh` — guard clauses, awk fix
- `.agents/scripts/spdx-headers.sh` — extract helpers
- `.agents/scripts/dispatch-claim-helper.sh` — simplify heredoc example
- `.agents/scripts/providers/ip-rep-blocklistde.sh` — inline conditional


---
[aidevops.sh](https://aidevops.sh) v3.6.172 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 12m and 31,793 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation script for configuration rule checking.

* **Chores**
  * Updated configuration threshold values.
  * Refactored internal scripts for improved control flow and logic clarity.
  * Updated documentation and help text for commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->