### PR TITLE
GH#17854: document nesting threshold proximity resolution in complexity-thresholds.conf

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -55,6 +55,10 @@ FUNCTION_COMPLEXITY_THRESHOLD=420
 # (quality-fix.sh), and restructuring loops to use pipes instead of process
 # substitution so 'done' lines are recognized by the awk decrement pattern
 # (spdx-headers.sh). 256 violations + 6 headroom = 262.
+# Resolved GH#17854 (proximity warning at 279/279): violations reduced from
+# 279→256 across GH#17847, GH#17851, GH#17852; threshold ratcheted from
+# 279→285→268→262. Current state: 256 violations, 6 headroom. Proximity guard
+# (GH#17808) fires at 257 violations (within 5 of 262), preventing saturation.
 # NOTE: pulse-wrapper.sh now has a proximity guard (GH#17808) that warns when
 # violations are within 5 of this threshold. Bump this value AND document the
 # reason above when adding scripts that push the count over the current value.


### PR DESCRIPTION
## Summary

The CI nesting threshold proximity warning (GH#17854) was triggered when violations reached 279/279 (0 headroom). This PR documents the resolution in the config file's audit trail.

## What was done

Violations were reduced from 279→256 across three PRs:
- GH#17847: reduced 279→264 (early-return patterns, heredoc fixes)
- GH#17851: reduced 264→262 (additional elif chain conversions)
- GH#17852: reduced 262→256 (prose text in heredocs/echo statements, guard clauses, pipe restructuring)

Threshold was ratcheted from 279→285→268→262 to maintain 6 units of headroom.

## Current state

- **Violations**: 256
- **Threshold**: 262
- **Headroom**: 6
- **Proximity guard** (GH#17808): fires at 257 violations (within 5 of 262)

## Files changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — added resolution note to audit trail

## Runtime Testing

Risk: Low (docs/config only, no code changes)
Self-assessed: config comment update, no functional change.

Resolves #17854

---
[aidevops.sh](https://aidevops.sh) v3.6.172 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 3m and 7,570 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration documentation to reflect historical threshold adjustments and current system state. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->