### PR TITLE
GH#17843: decompose _collect_monitored_processes() into focused helpers

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "e637946e7f3a27ae5bcbca853d2c44b00e9c35dd",
-      "at": "2026-04-08T09:22:57Z",
-      "passes": 83,
+      "hash": "a8ac5d559fb543f3ab73013e877f1f4f49f9e724",
+      "at": "2026-04-08T12:43:12Z",
+      "passes": 84,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "eb510873d7a45058109e5161db46f1dd7f6f91aa",
-      "at": "2026-04-08T08:10:57Z",
-      "passes": 81,
+      "hash": "06549ffb8ea8443249029e341f4ca2bec358a25a",
+      "at": "2026-04-08T12:43:12Z",
+      "passes": 82,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6861,6 +6861,12 @@
       "hash": "3bb3703f09649692c0be7473b2882097bb5083fc",
       "at": "2026-04-08T10:00:43Z",
       "pr": 17819,
+      "passes": 1
+    },
+    ".agents/scripts/model-availability-helper.sh": {
+      "hash": "f6c317d405d9e0132c0f8027910d39fdf62b20a3",
+      "at": "2026-04-08T12:43:13Z",
+      "pr": 17797,
       "passes": 1
     }
   },

--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -442,6 +442,92 @@ _batch_get_process_ages() {
 	return 0
 }
 
+# Check if a process command matches a monitoring pattern.
+# Simple patterns match against the command basename only (case-insensitive).
+# Regex patterns (containing ".*") match against the full command line.
+# Arguments: $1=pattern, $2=cmd_name (basename), $3=full_cmd
+# Returns: 0 if match, 1 if no match
+_matches_monitor_pattern() {
+	local pattern="$1"
+	local cmd_name="$2"
+	local full_cmd="$3"
+
+	if [[ "$pattern" == *".*"* ]]; then
+		# Regex pattern — match against full command line
+		if echo "$full_cmd" | grep -iqE "$pattern"; then
+			return 0
+		fi
+	else
+		# Simple pattern — match against basename only
+		# Use bash 4+ ${var,,} lowercasing to avoid tr subprocess forks
+		local cmd_lower="${cmd_name,,}"
+		local pattern_lower="${pattern,,}"
+		if [[ "$cmd_lower" == *"$pattern_lower"* ]]; then
+			return 0
+		fi
+	fi
+	return 1
+}
+
+# Check if a process should be excluded from monitoring results.
+# Excludes grep processes, this script itself, and already-seen PIDs.
+# Arguments: $1=pid, $2=cmd_name, $3=full_cmd
+# Uses caller-scope: seen_pids[] (read-only check)
+# Returns: 0 if should be skipped, 1 if should be included
+_should_skip_process() {
+	local pid="$1"
+	local cmd_name="$2"
+	local full_cmd="$3"
+
+	# Skip grep and this script
+	if [[ "$cmd_name" == "grep" ]] || [[ "$full_cmd" == *"${SCRIPT_NAME}"* ]]; then
+		return 0
+	fi
+
+	# Skip already-seen PIDs (dedup across overlapping patterns)
+	local seen_pid
+	for seen_pid in "${seen_pids[@]+"${seen_pids[@]}"}"; do
+		if [[ "$seen_pid" == "$pid" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Batch-fetch process ages and emit final pipe-delimited rows sorted by RSS.
+# Arguments: matched_rows[] and seen_pids[] from caller scope
+# Output: PID|RSS_MB|RUNTIME_SECS|COMMAND_NAME|FULL_COMMAND (sorted by RSS desc)
+_resolve_ages_and_emit() {
+	# No matches — nothing to emit
+	if [[ "${#matched_rows[@]}" -eq 0 ]]; then
+		return 0
+	fi
+
+	# Batch-fetch process ages for all matched PIDs in a single ps call
+	local -A age_map
+	local age_line age_pid age_secs
+	while IFS= read -r age_line; do
+		[[ -z "$age_line" ]] && continue
+		read -r age_pid age_secs <<<"$age_line"
+		[[ "$age_pid" =~ ^[0-9]+$ ]] || continue
+		age_map["$age_pid"]="${age_secs:-0}"
+	done < <(_batch_get_process_ages "${seen_pids[@]}")
+
+	# Emit final rows with ages, then sort by RSS descending
+	local row
+	for row in "${matched_rows[@]}"; do
+		local r_pid="${row%%:*}"
+		local rest="${row#*:}"
+		local r_rss="${rest%%:*}"
+		rest="${rest#*:}"
+		local r_cmd_name="${rest%%:*}"
+		local r_cmd="${rest#*:}"
+		local r_age="${age_map[$r_pid]:-0}"
+		printf '%s|%s|%s|%s|%s\n' "$r_pid" "$r_rss" "$r_age" "$r_cmd_name" "$r_cmd"
+	done | sort -t'|' -k2 -rn
+	return 0
+}
+
 # Collect all monitored processes with their RSS and runtime
 # Output: one line per process: PID|RSS_MB|RUNTIME_SECS|COMMAND_NAME|FULL_COMMAND
 #
@@ -478,44 +564,13 @@ _collect_monitored_processes() {
 			local cmd_name="${cmd_path##*/}"
 			[[ -z "$cmd_name" ]] && cmd_name="unknown"
 
-			# Match pattern against the command basename, NOT the full command line.
-			# This prevents false positives like `zsh -l -c "opencode"` matching
-			# the "opencode" pattern — zsh is not an opencode process.
-			# Exception: patterns containing ".*" (regex) are matched against full
-			# command for cases like "node.*language-server".
-			local match=false
-			if [[ "$pattern" == *".*"* ]]; then
-				# Regex pattern — match against full command line
-				if echo "$cmd" | grep -iqE "$pattern"; then
-					match=true
-				fi
-			else
-				# Simple pattern — match against basename only
-				# Use bash 4+ ${var,,} lowercasing to avoid tr subprocess forks
-				local cmd_lower="${cmd_name,,}"
-				local pattern_lower="${pattern,,}"
-				if [[ "$cmd_lower" == *"$pattern_lower"* ]]; then
-					match=true
-				fi
-			fi
-
-			if [[ "$match" != "true" ]]; then
+			# Check pattern match
+			if ! _matches_monitor_pattern "$pattern" "$cmd_name" "$cmd"; then
 				continue
 			fi
 
-			# Skip grep, this script, and already-seen PIDs
-			if [[ "$cmd_name" == "grep" ]] || [[ "$cmd" == *"${SCRIPT_NAME}"* ]]; then
-				continue
-			fi
-			local seen_pid
-			local is_dup=false
-			for seen_pid in "${seen_pids[@]+"${seen_pids[@]}"}"; do
-				if [[ "$seen_pid" == "$pid" ]]; then
-					is_dup=true
-					break
-				fi
-			done
-			if [[ "$is_dup" == "true" ]]; then
+			# Check exclusions and dedup
+			if _should_skip_process "$pid" "$cmd_name" "$cmd"; then
 				continue
 			fi
 			seen_pids+=("$pid")
@@ -526,33 +581,8 @@ _collect_monitored_processes() {
 		done <<<"$ps_output"
 	done
 
-	# No matches — nothing to emit
-	if [[ "${#matched_rows[@]}" -eq 0 ]]; then
-		return 0
-	fi
-
-	# Batch-fetch process ages for all matched PIDs in a single ps call
-	local -A age_map
-	local age_line age_pid age_secs
-	while IFS= read -r age_line; do
-		[[ -z "$age_line" ]] && continue
-		read -r age_pid age_secs <<<"$age_line"
-		[[ "$age_pid" =~ ^[0-9]+$ ]] || continue
-		age_map["$age_pid"]="${age_secs:-0}"
-	done < <(_batch_get_process_ages "${seen_pids[@]}")
-
-	# Emit final rows with ages, then sort by RSS descending
-	local row
-	for row in "${matched_rows[@]}"; do
-		local r_pid="${row%%:*}"
-		local rest="${row#*:}"
-		local r_rss="${rest%%:*}"
-		rest="${rest#*:}"
-		local r_cmd_name="${rest%%:*}"
-		local r_cmd="${rest#*:}"
-		local r_age="${age_map[$r_pid]:-0}"
-		printf '%s|%s|%s|%s|%s\n' "$r_pid" "$r_rss" "$r_age" "$r_cmd_name" "$r_cmd"
-	done | sort -t'|' -k2 -rn
+	# Resolve ages and emit sorted output
+	_resolve_ages_and_emit
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Resolves #17843

Break down the 106-line `_collect_monitored_processes()` function in `.agents/scripts/memory-pressure-monitor.sh` into three smaller, focused helper functions:

| Function | Lines | Responsibility |
|----------|-------|----------------|
| `_matches_monitor_pattern()` | 21 | Pattern matching — simple basename match vs regex full-command match |
| `_should_skip_process()` | 19 | Dedup and exclusion checks (grep, self, already-seen PIDs) |
| `_resolve_ages_and_emit()` | 30 | Batch age resolution via `_batch_get_process_ages` and pipe-delimited output |
| `_collect_monitored_processes()` | 51 | Orchestration — ps snapshot, pattern loop, delegate to helpers |

## Runtime Testing

- **Risk**: Low (refactor, no behaviour change)
- **Verification**: `bash -n` syntax check passed, `shellcheck` zero violations
- **Self-assessed**: Pure structural refactor — no logic changes, no new code paths

## Key Decisions

- Extracted helpers access `seen_pids[]` and `matched_rows[]` from caller scope (bash convention for array-heavy functions) rather than serializing/deserializing through arguments
- Each helper has full doc comments explaining arguments, return codes, and side effects

---
[aidevops.sh](https://aidevops.sh) v3.6.173 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 2m and 6,146 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration tracking metadata and timestamps.
  * Refactored process monitoring system for improved code maintainability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->