### PR TITLE
t1913: automate ratchet-down of complexity thresholds

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "a8ac5d559fb543f3ab73013e877f1f4f49f9e724",
-      "at": "2026-04-08T12:43:12Z",
-      "passes": 84,
+      "hash": "5b9e8ca946c891264348cfd9ad845b2cb861b77b",
+      "at": "2026-04-08T14:27:37Z",
+      "passes": 85,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "06549ffb8ea8443249029e341f4ca2bec358a25a",
-      "at": "2026-04-08T12:43:12Z",
-      "passes": 82,
+      "hash": "a99c60131461354dcbd155f2385731d8c0dbf876",
+      "at": "2026-04-08T14:27:37Z",
+      "passes": 83,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -6876,9 +6876,9 @@
       "passes": 1
     },
     ".agents/reference/routines.md": {
-      "hash": "a652a5b05f55a805d982f0d6798b1ddab27ada41",
-      "at": "2026-04-08T14:00:00Z",
-      "passes": 1,
+      "hash": "9ab2dd18f0d71a8487892e22ba6c26f94bd2eb49",
+      "at": "2026-04-08T14:27:23Z",
+      "passes": 2,
       "pr": 0
     }
   },

--- a/.agents/scripts/complexity-scan-helper.sh
+++ b/.agents/scripts/complexity-scan-helper.sh
@@ -15,6 +15,7 @@
 #   complexity-scan-helper.sh scan <repo_path> [--state-file <path>] [--format json|pipe] [--type sh|md|py|js|all]
 #   complexity-scan-helper.sh sweep-check <repo_slug> [--stall-hours 6]
 #   complexity-scan-helper.sh metrics <file_path>
+#   complexity-scan-helper.sh ratchet-check [repo_path] [gap]
 #   complexity-scan-helper.sh help
 #
 # Exit codes: 0 = success, 1 = error, 2 = no changes detected
@@ -789,6 +790,188 @@ cmd_metrics() {
 }
 
 #######################################
+# Ratchet check — compare actual violation counts against thresholds.
+# When actual count is below threshold by more than gap, outputs proposed
+# new thresholds (actual + 2 buffer). Returns 0 if ratchet-down is possible.
+#
+# Arguments: $1 - repo_path (default: .)
+#            $2 - gap (default: 5)
+# Output: proposed threshold lines to stdout when ratchet-down is available
+# Exit: 0 = ratchet-down possible, 1 = thresholds already tight or error
+#######################################
+cmd_ratchet_check() {
+	local repo_path="${1:-.}"
+	local gap="${2:-5}"
+	local conf_file="${repo_path}/.agents/configs/complexity-thresholds.conf"
+
+	if [[ ! -f "$conf_file" ]]; then
+		_log "ERROR" "Config not found: $conf_file"
+		return 1
+	fi
+
+	# Read current thresholds from config
+	local func_threshold nest_threshold size_threshold bash32_threshold
+	func_threshold=$(grep '^FUNCTION_COMPLEXITY_THRESHOLD=' "$conf_file" | cut -d= -f2)
+	nest_threshold=$(grep '^NESTING_DEPTH_THRESHOLD=' "$conf_file" | cut -d= -f2)
+	size_threshold=$(grep '^FILE_SIZE_THRESHOLD=' "$conf_file" | cut -d= -f2)
+	bash32_threshold=$(grep '^BASH32_COMPAT_THRESHOLD=' "$conf_file" | cut -d= -f2)
+
+	# Validate thresholds are numeric
+	for val in "$func_threshold" "$nest_threshold" "$size_threshold" "$bash32_threshold"; do
+		if [[ ! "$val" =~ ^[0-9]+$ ]]; then
+			_log "ERROR" "Non-numeric threshold value: $val"
+			return 1
+		fi
+	done
+
+	# Discover shell files using same logic as CI (git ls-files)
+	local sh_files
+	sh_files=$(git -C "$repo_path" ls-files '*.sh' 2>/dev/null |
+		grep -Ev 'archived/|\.archive/|vendor/|node_modules/' || true)
+
+	if [[ -z "$sh_files" ]]; then
+		_log "ERROR" "No shell files found in $repo_path"
+		return 1
+	fi
+
+	# Count function complexity violations (>100 lines per function)
+	local actual_func=0
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
+		local full_path="${repo_path}/${file}"
+		[[ -f "$full_path" ]] || continue
+		local result
+		result=$(awk '
+			/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ { fname=$1; sub(/\(\)/, "", fname); start=NR; next }
+			fname && /^\}$/ { lines=NR-start; if(lines>100) print "BLOCK"; fname="" }
+		' "$full_path" 2>/dev/null) || result=""
+		if [[ -n "$result" ]]; then
+			local count
+			count=$(printf '%s\n' "$result" | grep -c '.' || echo "0")
+			actual_func=$((actual_func + count))
+		fi
+	done <<<"$sh_files"
+
+	# Count nesting depth violations (>8 levels per file)
+	local actual_nest=0
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
+		local full_path="${repo_path}/${file}"
+		[[ -f "$full_path" ]] || continue
+		local max_depth
+		max_depth=$(awk '
+			BEGIN { depth=0; max_depth=0 }
+			/^[[:space:]]*#/ { next }
+			/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
+			/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+			END { print max_depth }
+		' "$full_path" 2>/dev/null) || max_depth=0
+		if [[ "$max_depth" -gt 8 ]]; then
+			actual_nest=$((actual_nest + 1))
+		fi
+	done <<<"$sh_files"
+
+	# Count file size violations (>1500 lines)
+	local actual_size=0
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
+		local full_path="${repo_path}/${file}"
+		[[ -f "$full_path" ]] || continue
+		local lc
+		lc=$(wc -l <"$full_path" 2>/dev/null) || lc=0
+		if [[ "$lc" -gt 1500 ]]; then
+			actual_size=$((actual_size + 1))
+		fi
+	done <<<"$sh_files"
+
+	# Count Bash 3.2 compatibility violations
+	local actual_bash32=0
+	local self_skip="linters-local.sh"
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
+		local full_path="${repo_path}/${file}"
+		[[ -f "$full_path" ]] || continue
+		local basename_file
+		basename_file=$(basename "$file")
+		[[ "$basename_file" = "$self_skip" ]] && continue
+
+		# "\t" or "\n" in string assignments
+		local matches
+		matches=$(grep -nE '\+="\\[tn]|="\\[tn]' "$full_path" 2>/dev/null |
+			grep -vE '^[0-9]+:[[:space:]]*#' |
+			grep -vE 'awk|sed|printf|echo.*-e|python|f\.write|gsub|join|split|print |replace|coords|excerpt|delimiter|regex|pattern' ||
+			true)
+		if [[ -n "$matches" ]]; then
+			local cnt
+			cnt=$(printf '%s\n' "$matches" | grep -c '.' || echo "0")
+			actual_bash32=$((actual_bash32 + cnt))
+		fi
+
+		# Associative arrays (bash 4.0+)
+		local assoc
+		assoc=$(grep -nE '^[[:space:]]*(declare|local|typeset)[[:space:]]+-A[[:space:]]' "$full_path" 2>/dev/null |
+			grep -vE '^[0-9]+:[[:space:]]*#' || true)
+		if [[ -n "$assoc" ]]; then
+			local cnt2
+			cnt2=$(printf '%s\n' "$assoc" | grep -c '.' || echo "0")
+			actual_bash32=$((actual_bash32 + cnt2))
+		fi
+
+		# Namerefs (bash 4.3+)
+		local nameref
+		nameref=$(grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' "$full_path" 2>/dev/null |
+			grep -vE '^[0-9]+:[[:space:]]*#' || true)
+		if [[ -n "$nameref" ]]; then
+			local cnt3
+			cnt3=$(printf '%s\n' "$nameref" | grep -c '.' || echo "0")
+			actual_bash32=$((actual_bash32 + cnt3))
+		fi
+	done <<<"$sh_files"
+
+	_log "INFO" "Actual violations — func:${actual_func} nest:${actual_nest} size:${actual_size} bash32:${actual_bash32}"
+	_log "INFO" "Current thresholds — func:${func_threshold} nest:${nest_threshold} size:${size_threshold} bash32:${bash32_threshold}"
+
+	# Compare and output proposals (buffer of +2 above actual to prevent flapping)
+	local proposed=0
+
+	if [[ $((func_threshold - actual_func)) -ge "$gap" ]]; then
+		local new_func=$((actual_func + 2))
+		printf 'FUNCTION_COMPLEXITY_THRESHOLD: %d → %d (actual: %d, gap: %d)\n' \
+			"$func_threshold" "$new_func" "$actual_func" "$((func_threshold - actual_func))"
+		proposed=$((proposed + 1))
+	fi
+
+	if [[ $((nest_threshold - actual_nest)) -ge "$gap" ]]; then
+		local new_nest=$((actual_nest + 2))
+		printf 'NESTING_DEPTH_THRESHOLD: %d → %d (actual: %d, gap: %d)\n' \
+			"$nest_threshold" "$new_nest" "$actual_nest" "$((nest_threshold - actual_nest))"
+		proposed=$((proposed + 1))
+	fi
+
+	if [[ $((size_threshold - actual_size)) -ge "$gap" ]]; then
+		local new_size=$((actual_size + 2))
+		printf 'FILE_SIZE_THRESHOLD: %d → %d (actual: %d, gap: %d)\n' \
+			"$size_threshold" "$new_size" "$actual_size" "$((size_threshold - actual_size))"
+		proposed=$((proposed + 1))
+	fi
+
+	if [[ $((bash32_threshold - actual_bash32)) -ge "$gap" ]]; then
+		local new_bash32=$((actual_bash32 + 2))
+		printf 'BASH32_COMPAT_THRESHOLD: %d → %d (actual: %d, gap: %d)\n' \
+			"$bash32_threshold" "$new_bash32" "$actual_bash32" "$((bash32_threshold - actual_bash32))"
+		proposed=$((proposed + 1))
+	fi
+
+	if [[ "$proposed" -gt 0 ]]; then
+		_log "INFO" "Ratchet-down available: $proposed threshold(s) can be lowered"
+		return 0
+	fi
+
+	_log "INFO" "No ratchet-down available: all thresholds within gap of $gap"
+	return 1
+}
+
+#######################################
 # Help
 #######################################
 cmd_help() {
@@ -808,6 +991,13 @@ COMMANDS
   sweep-done                    Record that LLM sweep was performed
 
   metrics <file_path>           Compute metrics for a single file
+
+  ratchet-check [repo_path] [gap]
+                                Compare actual violation counts against thresholds.
+                                Outputs proposed new thresholds when gap >= minimum.
+                                repo_path: path to repo root (default: .)
+                                gap: minimum gap to trigger proposal (default: 5)
+                                Exit 0: ratchet-down available, Exit 1: thresholds tight
 
   help                          Show this help
 
@@ -839,6 +1029,7 @@ main() {
 	sweep-check) cmd_sweep_check "$@" ;;
 	sweep-done) cmd_sweep_done ;;
 	metrics) cmd_metrics "$@" ;;
+	ratchet-check) cmd_ratchet_check "$@" ;;
 	help | --help | -h) cmd_help ;;
 	*)
 		_log "ERROR" "Unknown command: $cmd"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -6214,6 +6214,57 @@ Review all open \`simplification-debt\` issues and the current \`simplification-
 				"$scan_helper" sweep-done 2>>"$LOGFILE" || true
 			fi
 		fi
+
+		# Phase 5: Ratchet-check — lower thresholds when simplification wins accumulate (t1913)
+		# Runs after backfill so closed issues are reflected in violation counts.
+		# Creates a chore/ratchet-down PR when gap >= 5 (default).
+		local ratchet_output
+		ratchet_output=$("$scan_helper" ratchet-check "$aidevops_path" 2>>"$LOGFILE") || true
+		if [[ -n "$ratchet_output" ]]; then
+			echo "[pulse-wrapper] ratchet-check: proposals available" >>"$LOGFILE"
+			echo "$ratchet_output" >>"$LOGFILE"
+			# Check if a ratchet-down PR already exists to avoid duplicates
+			local ratchet_pr_exists
+			ratchet_pr_exists=$(gh pr list --repo "$aidevops_slug" \
+				--state open \
+				--search "in:title \"chore: ratchet-down complexity thresholds\"" \
+				--json number --jq 'length' 2>/dev/null) || ratchet_pr_exists="0"
+			if [[ "${ratchet_pr_exists:-0}" -eq 0 ]]; then
+				echo "[pulse-wrapper] ratchet-check: creating ratchet-down issue (t1913)" >>"$LOGFILE"
+				gh_create_issue --repo "$aidevops_slug" \
+					--title "chore: ratchet-down complexity thresholds" \
+					--label "code-quality" --label "auto-dispatch" --label "tier:standard" \
+					--body "## Automated ratchet-down (t1913)
+
+Simplification wins have accumulated. The following thresholds can be lowered:
+
+\`\`\`
+${ratchet_output}
+\`\`\`
+
+### Worker Guidance
+
+**Files to Modify:**
+- \`EDIT: .agents/configs/complexity-thresholds.conf\` — lower the thresholds listed above
+
+**Implementation Steps:**
+1. For each proposed threshold, update the value in \`complexity-thresholds.conf\`
+2. Add a ratchet-down comment above the updated value documenting the change (e.g., \`# Ratcheted down to NNN (GH#NNNN): actual violations NNN + 2 buffer\`)
+3. Do NOT remove existing bump history comments — they are the audit trail
+
+**Verification:**
+\`\`\`bash
+# Confirm thresholds updated
+grep -E 'FUNCTION_COMPLEXITY_THRESHOLD|NESTING_DEPTH_THRESHOLD|FILE_SIZE_THRESHOLD|BASH32_COMPAT_THRESHOLD' .agents/configs/complexity-thresholds.conf
+# Confirm CI would pass with new values
+.agents/scripts/complexity-scan-helper.sh ratchet-check . 5
+\`\`\`" >/dev/null 2>&1 || true
+			else
+				echo "[pulse-wrapper] ratchet-check: ratchet-down PR already open, skipping issue creation" >>"$LOGFILE"
+			fi
+		else
+			echo "[pulse-wrapper] ratchet-check: no ratchet-down available (thresholds already tight)" >>"$LOGFILE"
+		fi
 	else
 		# Fallback to inline scan if helper not available
 		echo "[pulse-wrapper] complexity-scan-helper.sh not found, using inline scan" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Implements automated ratchet-down of complexity thresholds (t1913). Thresholds have only gone UP (11 bumps documented in comments) — this closes the loop so simplification wins translate into tighter CI gates.

## Changes

### `.agents/scripts/complexity-scan-helper.sh`

Added `cmd_ratchet_check()` command that:
- Reads current thresholds from `.agents/configs/complexity-thresholds.conf`
- Counts actual violations using the same awk/grep logic as CI
- Covers all four ratchetable thresholds: `FUNCTION_COMPLEXITY_THRESHOLD`, `NESTING_DEPTH_THRESHOLD`, `FILE_SIZE_THRESHOLD`, `BASH32_COMPAT_THRESHOLD`
- Outputs proposed new thresholds (actual + 2 buffer) when gap >= configured minimum (default 5)
- Returns exit 0 when ratchet-down is possible, exit 1 when thresholds are already tight
- Added to main dispatch case and help text

### `.agents/scripts/pulse-wrapper.sh`

Added Phase 5 after simplification backfill:
- Calls `complexity-scan-helper.sh ratchet-check` after backfill so closed issues are reflected
- When ratchet-down is available, creates a `chore: ratchet-down complexity thresholds` issue with worker guidance
- Deduplicates by checking for existing open ratchet-down PRs before creating a new issue

## Testing

```bash
# Command exists and runs
.agents/scripts/complexity-scan-helper.sh ratchet-check . 5
# Output:
# [complexity-scan] INFO: Actual violations — func:28 nest:256 size:52 bash32:71
# [complexity-scan] INFO: Current thresholds — func:420 nest:262 size:53 bash32:72
# FUNCTION_COMPLEXITY_THRESHOLD: 420 → 30 (actual: 28, gap: 392)
# NESTING_DEPTH_THRESHOLD: 262 → 258 (actual: 256, gap: 6)
# [complexity-scan] INFO: Ratchet-down available: 2 threshold(s) can be lowered

# Exit 1 when gap too small
.agents/scripts/complexity-scan-helper.sh ratchet-check . 500
# [complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 500

# ShellCheck clean
shellcheck .agents/scripts/complexity-scan-helper.sh
```

## Runtime Testing

Risk: **Low** — docs/config/agent prompts pattern. New command added to existing script; no changes to existing logic. Pulse integration is best-effort (|| true) and creates issues, not PRs directly.

## Key Decisions

- Buffer of +2 above actual count prevents flapping from concurrent PRs
- Gap threshold of 5 prevents noise — only propose when meaningful reduction accumulated
- Ratchet-check is idempotent — running twice with no changes produces same proposal
- Pulse integration creates an issue (not a PR directly) to keep the ratchet-down in the normal review flow
- ShellCheck OOM on pulse-wrapper.sh (12K lines) is a pre-existing limitation; the added section follows existing patterns

Resolves #17702

---
[aidevops.sh](https://aidevops.sh) v3.6.174 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 4m and 12,188 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated complexity threshold management integrated into weekly scans with intelligent ratcheting recommendations
  * Automatic issue creation for proposed threshold improvements based on current violation analysis

* **Chores**
  * Updated internal run metadata and tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->