### PR TITLE
t1911: add Qlty smells CI gate to prevent maintainability regression

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -474,6 +474,36 @@ jobs:
           echo "No Pyflakes issues"
         fi
 
+  qlty-smells:
+    name: Qlty Maintainability Smells
+    runs-on: ubuntu-latest
+    # Only run on PRs — diff mode needs a comparison base
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0
+
+    - name: Install Qlty CLI
+      run: |
+        curl -sSL https://qlty.sh/install | bash
+        echo "$HOME/.qlty/bin" >> "$GITHUB_PATH"
+
+    - name: Qlty smells check (diff mode)
+      run: |
+        echo "Checking for new code smells vs origin/main..."
+        if qlty smells 2>&1 | tee /tmp/qlty-smells-output.txt | grep -q '^[^ ]'; then
+          smell_count=$(grep -c '^[^ ]' /tmp/qlty-smells-output.txt || echo "0")
+          echo ""
+          echo "::error::This PR introduces ${smell_count} new code smell(s). Fix before merging."
+          echo "Run 'qlty smells' locally to see details."
+          exit 1
+        else
+          echo "No new code smells introduced"
+        fi
+
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add a new `qlty-smells` job to `.github/workflows/code-quality.yml` that runs `qlty smells` in diff mode on PRs. Fails if the PR introduces new code smells, preventing maintainability grade regression.

Resolves #17700

## Changes

- **NEW job**: `qlty-smells` in `code-quality.yml`, positioned after `complexity-check` and before `sonarcloud`
- PR-only gate (`if: github.event_name == 'pull_request'`) — diff mode needs a comparison base
- Installs Qlty CLI via `https://qlty.sh/install`
- Runs `qlty smells` in diff mode (default: compares against `origin/main`)
- Fails with `::error::` annotation when new smells are detected

## Design Decisions

- **Diff mode, not `--all`**: Only blocks new smells. The existing 224+ smells would fail every PR if we used `--all`.
- **PR-only**: Main-branch pushes don't need this gate — they're already merged.
- **Hard gate** (`continue-on-error: false` default): This is a blocking check, not advisory.
- **Inherits `.qlty/qlty.toml` config**: Exclude patterns, test patterns, and plugins are already configured.

## Runtime Testing

- **Risk level**: Low (CI workflow config, agent prompt)
- **Verification**: `self-assessed`
  - YAML validation: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/code-quality.yml'))"` — passed
  - Job structure verified: correct position, correct `if:` condition, 3 steps (checkout, install, check)
  - Will be fully validated by GitHub Actions when this PR's CI runs

## Files Changed

- `.github/workflows/code-quality.yml` — added `qlty-smells` job (30 lines)

---
[aidevops.sh](https://aidevops.sh) v3.6.174 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 1m on this interactively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code smell detection to the pull request review process. CI checks will now fail if new code smells are introduced in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->