### PR TITLE
GH#17829: Fix headless dispatch when opencode serve is running + triage failure visibility

### DIFF
--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -18,6 +18,9 @@
   "peerDependencies": {
     "opencode-ai": ">=1.3.0"
   },
+  "dependencies": {
+    "@bufbuild/protobuf": "^2.0.0"
+  },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.3.13"
   }

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1341,6 +1341,46 @@ EOF
 	return 0
 }
 
+# _detect_opencode_server: check if an opencode server is already listening.
+# GH#17829: When `opencode serve` is running, `opencode run` without --attach
+# fails with "Session not found". Detect the running server and return its URL.
+#
+# Detection strategy (does NOT rely on OPENCODE_PID — that's intentionally
+# excluded from worker envs per GH#6668):
+#   1. Check OPENCODE_SERVER_PASSWORD is set (indicates a server context)
+#   2. Verify a server is actually listening on the expected port
+#
+# Outputs two lines to stdout: URL then password (empty if no server found).
+# Returns: 0 if a server is detected, 1 otherwise.
+_detect_opencode_server() {
+	local password="${OPENCODE_SERVER_PASSWORD:-}"
+	if [[ -z "$password" ]]; then
+		return 1
+	fi
+
+	local port="${OPENCODE_PORT:-4096}"
+	local url="http://localhost:${port}"
+
+	# Verify the server is actually listening (timeout 2s, silent).
+	# Use /api/session/list as a lightweight endpoint — it returns 401 without
+	# auth but proves the server is up (vs connection refused).
+	if curl -sf --max-time 2 -o /dev/null "${url}/api/session/list" 2>/dev/null ||
+		curl -sf --max-time 2 -o /dev/null -w '%{http_code}' "${url}/api/session/list" 2>/dev/null | grep -q '401'; then
+		printf '%s\n%s\n' "$url" "$password"
+		return 0
+	fi
+
+	# Fallback: check if anything is listening on the port (no curl endpoint needed)
+	if command -v lsof >/dev/null 2>&1; then
+		if lsof -iTCP:"$port" -sTCP:LISTEN -P -n >/dev/null 2>&1; then
+			printf '%s\n%s\n' "$url" "$password"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
 # _build_run_cmd: build the opencode command array for a run attempt.
 # Args: selected_model work_dir prompt title agent_name persisted_session
 #       extra_args (remaining positional args)
@@ -1362,6 +1402,16 @@ _build_run_cmd() {
 	fi
 	if [[ -n "$persisted_session" ]]; then
 		printf '%s\0' --session "$persisted_session" --continue
+	fi
+	# GH#17829: Attach to running opencode server if one is detected.
+	# Without this, `opencode run` tries to start an embedded server that
+	# conflicts with the user's `opencode serve`, causing "Session not found".
+	local _server_info=""
+	if _server_info=$(_detect_opencode_server); then
+		local _server_url _server_pass
+		_server_url=$(echo "$_server_info" | head -1)
+		_server_pass=$(echo "$_server_info" | tail -1)
+		printf '%s\0' --attach "$_server_url" --password "$_server_pass"
 	fi
 	# Emit any extra args passed as positional parameters
 	while [[ $# -gt 0 ]]; do
@@ -2556,10 +2606,23 @@ _run_canary_test() {
 	fi
 	local canary_exit=0
 
+	# GH#17829: Detect running opencode server and build attach args.
+	# The canary must test the same mode workers will use — if a server is
+	# running, both canary and workers need --attach to avoid conflicts.
+	local canary_attach_args=()
+	local _canary_server_info=""
+	if _canary_server_info=$(_detect_opencode_server); then
+		local _canary_url _canary_pass
+		_canary_url=$(echo "$_canary_server_info" | head -1)
+		_canary_pass=$(echo "$_canary_server_info" | tail -1)
+		canary_attach_args=(--attach "$_canary_url" --password "$_canary_pass")
+	fi
+
 	# perl alarm is the most portable macOS timeout mechanism
 	perl -e "alarm $CANARY_TIMEOUT_SECONDS; exec @ARGV" -- \
 		"$OPENCODE_BIN_DEFAULT" run "Reply with exactly: CANARY_OK" \
 		-m "$canary_model" --dir "${HOME}" \
+		${canary_attach_args[@]+"${canary_attach_args[@]}"} \
 		>"$canary_output" 2>&1 || canary_exit=$?
 
 	if [[ "$canary_exit" -eq 0 ]] && grep -q "CANARY_OK" "$canary_output" 2>/dev/null; then

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -11845,6 +11845,8 @@ PREFETCH_EOF
 		review_text=$(cat "$review_output_file")
 		rm -f "$review_output_file"
 
+		local triage_posted="false"
+
 		if [[ -n "$review_text" && ${#review_text} -gt 50 ]]; then
 			# ── Safety filter: NEVER post raw sandbox/infrastructure output ──
 			# If the LLM failed (quota, timeout, garbled), the output contains
@@ -11867,6 +11869,7 @@ PREFETCH_EOF
 					gh issue comment "$issue_num" --repo "$repo_slug" \
 						--body "$clean_review" >/dev/null 2>&1 || true
 					echo "[pulse-wrapper] Posted sandboxed triage review for #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+					triage_posted="true"
 				fi
 			elif [[ "$has_infra_markers" == "true" ]]; then
 				# No ## Review: header AND infra markers present — raw sandbox output, discard entirely
@@ -11876,6 +11879,20 @@ PREFETCH_EOF
 			fi
 		else
 			echo "[pulse-wrapper] Triage review for #${issue_num} produced no usable output (${#review_text} chars)" >>"$LOGFILE"
+		fi
+
+		# GH#17829: Surface triage failures visibly. When the triage worker
+		# fails to produce a review, the only evidence is log entries — the
+		# issue timeline shows lock/unlock churn with no visible outcome.
+		# Add a label so maintainers can identify issues needing manual triage.
+		# The label is removed when a successful triage review is posted.
+		if [[ "$triage_posted" == "true" ]]; then
+			gh issue edit "$issue_num" --repo "$repo_slug" \
+				--remove-label "triage-failed" >/dev/null 2>&1 || true
+		else
+			gh issue edit "$issue_num" --repo "$repo_slug" \
+				--add-label "triage-failed" >/dev/null 2>&1 || true
+			echo "[pulse-wrapper] Added triage-failed label to #${issue_num} in ${repo_slug}" >>"$LOGFILE"
 		fi
 
 		# Unlock issue after triage

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -186,11 +186,23 @@ _deploy_agents_post_copy() {
 	script_count=$(find "$target_dir/scripts" -name "*.sh" -type f 2>/dev/null | wc -l | tr -d ' ')
 	print_info "Deployed $agent_count agent files and $script_count scripts"
 
-	# Symlink OpenCode's node_modules into the plugin directory (t1551)
+	# Install plugin dependencies (GH#17829: @bufbuild/protobuf was missing)
+	# First try symlinking OpenCode's node_modules (t1551), then verify the
+	# critical dependency exists. If the symlink is broken or the module is
+	# absent, fall back to npm install in the plugin directory.
 	local oc_node_modules="$HOME/.config/opencode/node_modules"
 	local plugin_dir="$target_dir/plugins/opencode-aidevops"
-	if [[ -d "$oc_node_modules" && -d "$plugin_dir" ]]; then
-		ln -sf "$oc_node_modules" "$plugin_dir/node_modules" 2>/dev/null || true
+	if [[ -d "$plugin_dir" ]]; then
+		if [[ -d "$oc_node_modules" ]]; then
+			ln -sf "$oc_node_modules" "$plugin_dir/node_modules" 2>/dev/null || true
+		fi
+		# Verify critical dependency is available; npm install if not
+		if [[ ! -d "$plugin_dir/node_modules/@bufbuild/protobuf" ]]; then
+			if command -v npm &>/dev/null; then
+				npm install --omit=dev --prefix "$plugin_dir" >/dev/null 2>&1 ||
+					print_warning "Failed to install plugin dependencies (non-blocking)"
+			fi
+		fi
 	fi
 
 	# Copy VERSION file from repo root to deployed agents


### PR DESCRIPTION
## Summary

Resolves #17829

Three fixes for headless worker dispatch and triage visibility:

1. **Bug 1 — Missing plugin dependency**: Added `@bufbuild/protobuf` to `opencode-aidevops` plugin `dependencies` in `package.json`. Updated `agent-deploy.sh` to verify the dependency exists after symlinking OpenCode's `node_modules`, and falls back to `npm install --omit=dev` when it's missing.

2. **Bug 2 — Headless dispatch conflict with running server**: Added `_detect_opencode_server()` helper that checks `OPENCODE_SERVER_PASSWORD` + port liveness (via curl health check then lsof fallback). Both `_build_run_cmd` and `_run_canary_test` now append `--attach <url> --password <password>` when a server is detected. Does NOT rely on `OPENCODE_PID` (intentionally excluded from worker envs per GH#6668).

3. **Workflow improvement — Triage failure visibility**: When the triage review output is suppressed by the safety filter (infra markers, missing `## Review:` header, or empty output), a `triage-failed` label is now added to the issue. This makes failed triage visible on the issue timeline instead of only appearing in pulse logs. The label is automatically removed when a successful triage review is posted.

## Files Changed

- `EDIT: .agents/plugins/opencode-aidevops/package.json` — added `dependencies.@bufbuild/protobuf`
- `EDIT: setup-modules/agent-deploy.sh` — verify critical dep after symlink, npm install fallback
- `EDIT: .agents/scripts/headless-runtime-helper.sh` — `_detect_opencode_server()`, patched `_build_run_cmd` and `_run_canary_test`
- `EDIT: .agents/scripts/pulse-wrapper.sh` — `triage-failed` label on suppressed triage output

## Runtime Testing

| Risk | Assessment |
|------|-----------|
| Level | High — headless dispatch infrastructure |
| Verification | `self-assessed` — no opencode serve environment available locally to runtime-test. ShellCheck clean. JSON valid. Logic verified against issue reproduction steps. |

## Key Decisions

- **Port detection strategy**: Check `OPENCODE_PORT` env (default 4096), verify via curl health check on `/api/session/list` (returns 401 without auth but proves server is up), fallback to `lsof` port check. More robust than hardcoding port 4096.
- **No OPENCODE_PID dependency**: The detection uses `OPENCODE_SERVER_PASSWORD` + port liveness, not `OPENCODE_PID`. This works for both the pulse's own context (where PID is set) and isolated worker envs (where PID is stripped per GH#6668).
- **triage-failed label vs comment**: Label is preferable — it's filterable, visible in issue lists, and doesn't add noise to the timeline. Removed automatically on successful triage.

---
[aidevops.sh](https://aidevops.sh) v3.6.174 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 34m and 19,836 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks now support attaching to existing running servers instead of creating new instances, improving resource efficiency and reducing redundancy.

* **Improvements**
  * GitHub issues with failed triage operations are now automatically labeled for improved visibility and error tracking.
  * Enhanced Node module dependency management during agent deployment ensures all required modules are properly installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->