### PR TITLE
t1911: fix Qlty smells CI gate installer (use official GitHub Action)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -487,9 +487,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qlty CLI
-      run: |
-        curl -sSL https://qlty.sh/install | bash
-        echo "$HOME/.qlty/bin" >> "$GITHUB_PATH"
+      uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
 
     - name: Qlty smells check (diff mode)
       run: |


### PR DESCRIPTION
## Summary

Fix the broken `qlty-smells` CI job by replacing the non-existent `curl https://qlty.sh/install` installer URL with the official `qltysh/qlty-action/install` GitHub Action.

Fixes #17700

## Problem

The initial PR (#17864) used `curl -sSL https://qlty.sh/install | bash` which returns a 404 HTML page, causing the install step to fail with `bash: line 1: syntax error near unexpected token '<'`. The correct CLI install URL is `curl https://qlty.sh | bash` (no `/install` suffix), but the official GitHub Action is the better approach for CI.

## Fix

Replace the `run:` install step with:
```yaml
uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
```

This is the [official Qlty CI integration](https://github.com/qltysh/qlty-action), pinned by commit SHA. Benefits: proper caching, version management, and maintained by Qlty.

## Runtime Testing

- **Risk level**: Low (CI workflow config fix)
- **Verification**: `self-assessed`
  - YAML validation passed
  - The `qltysh/qlty-action/install` action is documented in Qlty's official README
  - CI on this PR will validate the fix

## Files Changed

- `.github/workflows/code-quality.yml` — replaced curl installer with `qltysh/qlty-action/install` action

---
[aidevops.sh](https://aidevops.sh) v3.6.175 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 24m on this interactively.