### PR TITLE
GH#17875: chore: ratchet-down complexity thresholds

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -9,7 +9,8 @@
 
 # Shell function complexity: functions with >100 lines
 # Current baseline: 404 (as of 2026-03-24)
-FUNCTION_COMPLEXITY_THRESHOLD=420
+# Ratcheted down to 31 (GH#17875): actual violations 29 + 2 buffer
+FUNCTION_COMPLEXITY_THRESHOLD=31
 
 # Shell nesting depth: files with >8 levels of nesting
 # Current baseline: 262 (as of 2026-04-01, +1 for complexity-scan-helper.sh GH#15285)
@@ -62,7 +63,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=420
 # NOTE: pulse-wrapper.sh now has a proximity guard (GH#17808) that warns when
 # violations are within 5 of this threshold. Bump this value AND document the
 # reason above when adding scripts that push the count over the current value.
-NESTING_DEPTH_THRESHOLD=262
+# Ratcheted down to 258 (GH#17875): actual violations 256 + 2 buffer
+NESTING_DEPTH_THRESHOLD=258
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1754,9 +1754,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "9ad7ad779192ec16d43021b71ca1da104a0684fa",
-      "at": "2026-04-08T05:28:52Z",
-      "passes": 27,
+      "hash": "9296ae8d055c9758c6c9daef842f2bad2740ce0c",
+      "at": "2026-04-08T15:33:00Z",
+      "passes": 28,
       "pr": 15086
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "5301744e65611db1f5d92c7828e3fe8b8675e8ca",
-      "at": "2026-04-08T11:24:42Z",
-      "passes": 58,
+      "hash": "cf03fb5ef1f06ba69440a7d0c0db36ee0d1ed7bd",
+      "at": "2026-04-08T15:33:00Z",
+      "passes": 59,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "5b9e8ca946c891264348cfd9ad845b2cb861b77b",
-      "at": "2026-04-08T14:27:37Z",
-      "passes": 85,
+      "hash": "99263a6681e05b218d87b86ccbae2e1a1d565694",
+      "at": "2026-04-08T15:33:13Z",
+      "passes": 86,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "a99c60131461354dcbd155f2385731d8c0dbf876",
-      "at": "2026-04-08T14:27:37Z",
-      "passes": 83,
+      "hash": "63bd30a3e87905a9bd0b68b591e029ad9298de34",
+      "at": "2026-04-08T15:33:13Z",
+      "passes": 84,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6840,10 +6840,10 @@
       "passes": 1
     },
     ".agents/scripts/complexity-scan-helper.sh": {
-      "hash": "161d9fd3affccad89c81b2aecd2269dfbd1a634d",
-      "at": "2026-04-07T21:08:13Z",
+      "hash": "af1f152dc9b7b414ad6550262ef5d9421237f0e8",
+      "at": "2026-04-08T15:33:00Z",
       "pr": 17713,
-      "passes": 1
+      "passes": 2
     },
     ".agents/tools/context/pageindex.md": {
       "hash": "0e5ba2c8f16ab6362aa6de09ab2e704d534eaf27",


### PR DESCRIPTION
## Summary

Automated ratchet-down of complexity thresholds following simplification wins (t1913).

## Changes

- `FUNCTION_COMPLEXITY_THRESHOLD`: 420 → 31 (actual violations: 29, buffer: 2)
- `NESTING_DEPTH_THRESHOLD`: 262 → 258 (actual violations: 256, buffer: 2)

## Verification

```
[complexity-scan] INFO: Actual violations — func:29 nest:256 size:52 bash32:71
[complexity-scan] INFO: Current thresholds — func:31 nest:258 size:53 bash32:72
[complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 5
```

## Runtime Testing

Risk: **Low** — config file only, no code changes. Self-assessed.

Resolves #17875

---
[aidevops.sh](https://aidevops.sh) v3.6.175 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 1m and 2,403 tokens on this as a headless worker.