### PR TITLE
hotfix: Bash 3.2 heredoc-in-subshell parse error crashing pulse dispatch

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -5232,9 +5232,11 @@ This file has been through ${pass_count} simplification passes but ${remaining_s
 
 	local issue_title="simplification: re-queue ${file_path} (pass ${pass_count}, ${remaining_smells} smells remaining)"
 
+	# NOTE: Uses IFS read instead of $(cat <<HEREDOC) to avoid Bash 3.2 bug
+	# where literal ) inside a heredoc nested in $() is misinterpreted as
+	# closing the command substitution. macOS ships Bash 3.2 by default.
 	local issue_body
-	issue_body=$(
-		cat <<REQUEUE_BODY_EOF
+	IFS= read -r -d '' issue_body <<REQUEUE_BODY_EOF || true
 ## Post-merge smell verification (automated — t1912)
 
 **File:** \`${file_path}\`
@@ -5260,7 +5262,6 @@ Review issue #${prev_issue_num} for what the previous attempt accomplished and w
 - Content preservation: all task IDs, URLs, code blocks present before and after
 - ShellCheck clean (for .sh files)
 REQUEUE_BODY_EOF
-	)
 
 	# Append signature footer
 	local sig_footer="" _pulse_elapsed=""

--- a/.agents/scripts/routine-schedule-helper.sh
+++ b/.agents/scripts/routine-schedule-helper.sh
@@ -18,7 +18,9 @@ set -euo pipefail
 #######################################
 _day_to_number() {
 	local day="$1"
-	case "${day,,}" in
+	# Bash 3.2 compat: ${var,,} (lowercase) requires Bash 4+. Use tr instead.
+	day=$(printf '%s' "$day" | tr '[:upper:]' '[:lower:]')
+	case "$day" in
 	sun | sunday) printf '0' ;;
 	mon | monday) printf '1' ;;
 	tue | tuesday) printf '2' ;;


### PR DESCRIPTION
## Summary

- **Root cause**: `_create_requeue_issue()` used `$(cat <<HEREDOC ...)` which triggers a known Bash 3.2 bug — literal `)` inside a heredoc nested in `$()` is misinterpreted as closing the command substitution
- **Impact**: Every 2-minute pulse cycle crashed on parse at line 5754 before reaching dispatch — **zero workers dispatched** for open issues
- **Fix**: Replace `$(cat <<HEREDOC ... HEREDOC)` with `IFS= read -r -d '' var <<HEREDOC || true` to avoid the `$()` nesting entirely
- Also fixes `routine-schedule-helper.sh` `${day,,}` (Bash 4+ syntax) → `tr` for Bash 3.2 compat

### Reproduction

```bash
# This fails on macOS Bash 3.2:
/bin/bash -n <<'TEST'
f() {
  x=$(cat <<INNER
text with (parens) here
INNER
  )
}
TEST
# Error: unexpected EOF while looking for matching `)'
```

### Verification

```bash
/bin/bash -n .agents/scripts/pulse-wrapper.sh  # must exit 0
/bin/bash -n .agents/scripts/routine-schedule-helper.sh  # must exit 0
```

Already hot-deployed to `~/.aidevops/agents/scripts/` — next pulse cycle will dispatch normally.