### PR TITLE
t1931: Lock issues at crypto-approval time to close prompt-injection window

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -252,6 +252,8 @@ ${signature}
 \`\`\`
 
 This approval was signed with a root-protected SSH key. It cannot be forged by automation.
+
+> **This issue is now locked.** To propose scope changes, open a new issue referencing this one.
 EOF
 	return 0
 }
@@ -269,6 +271,16 @@ _post_issue_approval_updates() {
 		--remove-label "needs-maintainer-review" \
 		--add-label "auto-dispatch" >/dev/null 2>&1 || true
 	_print_info "Labels updated: removed needs-maintainer-review, added auto-dispatch"
+
+	# t1931: Lock the issue immediately at approval time to close the
+	# prompt-injection window between crypto-approval and worker dispatch.
+	# Previously, the lock only happened at dispatch time (pulse-wrapper.sh
+	# lock_issue_for_worker), leaving a gap where non-collaborators could
+	# add comments that influence the worker. The pulse's dispatch-time lock
+	# becomes a reinforcing no-op (gh issue lock on an already-locked issue
+	# is idempotent). Unlock still happens after worker completion.
+	gh issue lock "$target_number" --repo "$slug" --reason "resolved" >/dev/null 2>&1 || true
+	_print_info "Issue #$target_number locked (scope finalized, unlocks after worker completion)"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Closes the prompt-injection window between maintainer crypto-approval and worker dispatch by locking the issue immediately at approval time
- The approval comment now includes a notice directing contributors to open new issues for scope changes

## What changed

**`approval-helper.sh`** — two additions:

1. `_build_signed_comment()`: Added blockquote notice to the approval comment: "This issue is now locked. To propose scope changes, open a new issue referencing this one."

2. `_post_issue_approval_updates()`: Added `gh issue lock` call immediately after label updates. The lock uses `--reason resolved` for consistency with the existing `lock_issue_for_worker` in `pulse-wrapper.sh`.

## Why

Issue #17870 demonstrated the gap: a non-collaborator posted a scope-changing comment 53 minutes after crypto-approval but before worker dispatch. The existing `lock_issue_for_worker` in `pulse-wrapper.sh` only locks at dispatch time, leaving the approval-to-dispatch window open. This is the exact vector t1894 was designed to prevent.

The pulse's dispatch-time lock becomes a reinforcing no-op (`gh issue lock` on an already-locked issue is idempotent). Unlock still happens after worker completion via `unlock_issue_after_worker`.

## Runtime Testing

- **Risk**: Low (security hardening, no behavioral change to existing lock/unlock lifecycle)
- **Verified**: ShellCheck zero violations, manual code review of lock/unlock flow

Resolves #17880

---
[aidevops.sh](https://aidevops.sh) v3.6.180 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 6m and 8,384 tokens on this with the user in an interactive session.