### PR TITLE
GH#17882: harden _detect_opencode_server curl logic and plugin symlink cleanup

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1364,8 +1364,9 @@ _detect_opencode_server() {
 	# Verify the server is actually listening (timeout 2s, silent).
 	# Use /api/session/list as a lightweight endpoint — it returns 401 without
 	# auth but proves the server is up (vs connection refused).
-	if curl -sf --max-time 2 -o /dev/null "${url}/api/session/list" 2>/dev/null ||
-		curl -sf --max-time 2 -o /dev/null -w '%{http_code}' "${url}/api/session/list" 2>/dev/null | grep -q '401'; then
+	local http_code
+	http_code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' "${url}/api/session/list" 2>/dev/null)
+	if [[ "$http_code" == "200" || "$http_code" == "401" ]]; then
 		printf '%s\n%s\n' "$url" "$password"
 		return 0
 	fi

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -199,6 +199,8 @@ _deploy_agents_post_copy() {
 		# Verify critical dependency is available; npm install if not
 		if [[ ! -d "$plugin_dir/node_modules/@bufbuild/protobuf" ]]; then
 			if command -v npm &>/dev/null; then
+				# Remove symlink if present so npm creates a local node_modules
+				[[ -L "$plugin_dir/node_modules" ]] && rm "$plugin_dir/node_modules"
 				npm install --omit=dev --prefix "$plugin_dir" >/dev/null 2>&1 ||
 					print_warning "Failed to install plugin dependencies (non-blocking)"
 			fi


### PR DESCRIPTION
Resolves #17882

## Summary

Two robustness improvements to server detection and plugin dependency installation:

1. **Fix dual-curl bug in _detect_opencode_server**: Replace redundant dual-curl calls with single curl checking HTTP status code (200 or 401). The second curl with -sf flag was suppressing 401 responses, so the piped grep never saw output.

2. **Fix plugin npm install symlink issue**: Remove symlink before npm install in agent-deploy.sh to prevent writing into OpenCode's shared node_modules directory.

## Testing

- shellcheck passes on both modified files
- Changes are minimal and follow the verbatim code blocks from issue guidance


---
[aidevops.sh](https://aidevops.sh) v3.6.181 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-haiku-4-5 spent 1m and 2,292 tokens on this as a headless worker. Overall, 40m since this issue was created.