### PR TITLE
hotfix: Bash 3.2 compat — replace ${var^} in oauth-pool-helper.sh

### DIFF
--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -678,7 +678,10 @@ cmd_add() {
 		"$token_endpoint" "$content_type" "$ua_header" || return 1
 
 	print_info "Restart OpenCode to use the new token."
-	print_info "Then switch to the '${provider^}' provider and select a model to start chatting."
+	# Bash 3.2 compat: ${var^} (uppercase first) requires Bash 4+. Use printf + tr.
+	local provider_cap
+	provider_cap="$(printf '%s' "${provider:0:1}" | tr '[:lower:]' '[:upper:]')${provider:1}"
+	print_info "Then switch to the '${provider_cap}' provider and select a model to start chatting."
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- `${provider^}` (uppercase first letter) is Bash 4+ syntax — causes `bad substitution` on macOS Bash 3.2
- Fix: `printf + tr` for the capitalize operation
- Cosmetic only — the token save succeeds before this line, so auth works fine