### PR TITLE
t1932: auto-set assignee on crypto approval

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -272,6 +272,20 @@ _post_issue_approval_updates() {
 		--add-label "auto-dispatch" >/dev/null 2>&1 || true
 	_print_info "Labels updated: removed needs-maintainer-review, added auto-dispatch"
 
+	# t1932: Auto-assign the approving maintainer so the CI maintainer gate
+	# passes without a separate manual command. The crypto approval is already
+	# the strongest signal of maintainer intent — requiring a second command
+	# to set assignee adds friction with zero additional security value.
+	local gh_user
+	gh_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
+	if [[ -n "$gh_user" ]]; then
+		gh issue edit "$target_number" --repo "$slug" \
+			--add-assignee "$gh_user" >/dev/null 2>&1 || true
+		_print_info "Assigned to $gh_user"
+	else
+		_print_warn "Could not detect GitHub username — set assignee manually"
+	fi
+
 	# t1931: Lock the issue immediately at approval time to close the
 	# prompt-injection window between crypto-approval and worker dispatch.
 	# Previously, the lock only happened at dispatch time (pulse-wrapper.sh


### PR DESCRIPTION
## Summary

- Crypto approval (`sudo aidevops approve issue`) now auto-sets the assignee to the authenticated GitHub user
- Eliminates a separate manual `gh issue edit --add-assignee` command that added friction with zero security value
- The maintainer gate CI check requires both label removal (already done) and assignee (now also done)

## Changes

- EDIT: `.agents/scripts/approval-helper.sh:270-286` -- added `gh api user` lookup and `--add-assignee` in `_post_issue_approval_updates()`

## Verification

```bash
shellcheck .agents/scripts/approval-helper.sh  # zero violations
```

Resolves #17887


---
[aidevops.sh](https://aidevops.sh) v3.6.181 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 9m and 5,020 tokens on this with the user in an interactive session.