### PR TITLE
GH#17861: fix systemd cmd_enable/cmd_disable missing case in auto-update and repo-sync helpers

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -86,6 +86,8 @@ readonly DEFAULT_VENV_HEALTH_HOURS=24
 readonly LAUNCHD_LABEL="com.aidevops.aidevops-auto-update"
 readonly LAUNCHD_DIR="$HOME/Library/LaunchAgents"
 readonly LAUNCHD_PLIST="${LAUNCHD_DIR}/${LAUNCHD_LABEL}.plist"
+readonly SYSTEMD_SERVICE_DIR="$HOME/.config/systemd/user"
+readonly SYSTEMD_UNIT_NAME="aidevops-auto-update"
 
 #######################################
 # Logging
@@ -1501,6 +1503,114 @@ _cmd_enable_launchd() {
 }
 
 #######################################
+# Install auto-update as a Linux systemd user timer
+# Args: $1 = script_path, $2 = interval (minutes)
+# Returns: 0 on success, falls back to cron on failure
+# Modelled on worker-watchdog.sh:_install_systemd() (GH#17691)
+#######################################
+_cmd_enable_systemd() {
+	local script_path="$1"
+	local interval="$2"
+	local service_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.service"
+	local timer_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.timer"
+	local interval_sec
+	interval_sec=$((interval * 60))
+
+	mkdir -p "${SYSTEMD_SERVICE_DIR}"
+
+	printf '%s' "[Unit]
+Description=aidevops auto-update
+After=network.target
+
+[Service]
+Type=oneshot
+KillMode=process
+ExecStart=/bin/bash -lc '${script_path} check'
+TimeoutStartSec=120
+Nice=10
+IOSchedulingClass=idle
+StandardOutput=append:${LOG_FILE}
+StandardError=append:${LOG_FILE}
+" >"$service_file"
+
+	printf '%s' "[Unit]
+Description=aidevops auto-update Timer
+
+[Timer]
+OnBootSec=${interval_sec}
+OnUnitActiveSec=${interval_sec}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+" >"$timer_file"
+
+	systemctl --user daemon-reload 2>/dev/null || true
+	if ! systemctl --user enable --now "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null; then
+		print_error "Failed to enable systemd timer — falling back to cron" >&2
+		_cmd_enable_cron "$script_path" "$interval"
+		return $?
+	fi
+
+	update_state "enable" "$(get_local_version)" "enabled"
+
+	print_success "Auto-update enabled (every ${interval} minutes)"
+	echo ""
+	echo "  Scheduler: systemd user timer"
+	echo "  Unit:      ${SYSTEMD_UNIT_NAME}.timer"
+	echo "  Service:   ${service_file}"
+	echo "  Timer:     ${timer_file}"
+	echo "  Logs:      ${LOG_FILE}"
+	echo ""
+	echo "  Disable with: aidevops auto-update disable"
+	echo "  Check now:    aidevops auto-update check"
+	return 0
+}
+
+#######################################
+# Disable auto-update systemd user timer
+# Returns: 0 on success
+#######################################
+_cmd_disable_systemd() {
+	local had_entry=false
+
+	if systemctl --user is-enabled "${SYSTEMD_UNIT_NAME}.timer" >/dev/null 2>&1; then
+		had_entry=true
+		systemctl --user disable --now "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || true
+	fi
+
+	local service_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.service"
+	local timer_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.timer"
+	if [[ -f "$timer_file" ]]; then
+		had_entry=true
+		rm -f "$timer_file"
+	fi
+	if [[ -f "$service_file" ]]; then
+		rm -f "$service_file"
+	fi
+	systemctl --user daemon-reload 2>/dev/null || true
+
+	# Also remove any lingering cron entry
+	if crontab -l 2>/dev/null | grep -qF "$CRON_MARKER"; then
+		local temp_cron
+		temp_cron=$(mktemp)
+		crontab -l 2>/dev/null | grep -vF "$CRON_MARKER" >"$temp_cron" || true
+		crontab "$temp_cron"
+		rm -f "$temp_cron"
+		had_entry=true
+	fi
+
+	update_state "disable" "$(get_local_version)" "disabled"
+
+	if [[ "$had_entry" == "true" ]]; then
+		print_success "Auto-update disabled"
+	else
+		print_info "Auto-update was not enabled"
+	fi
+	return 0
+}
+
+#######################################
 # Install auto-update as a Linux cron entry
 # Args: $1 = script_path, $2 = interval (minutes)
 # Returns: 0 on success
@@ -1572,6 +1682,9 @@ cmd_enable() {
 	if [[ "$backend" == "launchd" ]]; then
 		_cmd_enable_launchd "$script_path" "$interval"
 		return $?
+	elif [[ "$backend" == "systemd" ]]; then
+		_cmd_enable_systemd "$script_path" "$interval"
+		return $?
 	fi
 
 	_cmd_enable_cron "$script_path" "$interval"
@@ -1581,7 +1694,7 @@ cmd_enable() {
 #######################################
 # Disable auto-update scheduler (platform-aware)
 # On macOS: unloads and removes LaunchAgent plist
-# On Linux: removes crontab entry
+# On Linux: removes crontab entry or systemd timer
 #######################################
 cmd_disable() {
 	local backend
@@ -1618,6 +1731,9 @@ cmd_disable() {
 			print_info "Auto-update was not enabled"
 		fi
 		return 0
+	elif [[ "$backend" == "systemd" ]]; then
+		_cmd_disable_systemd
+		return $?
 	fi
 
 	# Linux: cron backend

--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -57,6 +57,8 @@ readonly DEFAULT_INTERVAL=1440
 readonly LAUNCHD_LABEL="sh.aidevops.repo-sync"
 readonly LAUNCHD_DIR="$HOME/Library/LaunchAgents"
 readonly LAUNCHD_PLIST="${LAUNCHD_DIR}/${LAUNCHD_LABEL}.plist"
+readonly SYSTEMD_SERVICE_DIR="$HOME/.config/systemd/user"
+readonly SYSTEMD_UNIT_NAME="aidevops-repo-sync"
 readonly INSTALL_DIR="$HOME/Git/aidevops"
 readonly DEFAULT_PARENT_DIRS=("$HOME/Git")
 
@@ -624,6 +626,115 @@ _enable_launchd() {
 }
 
 #######################################
+# Enable repo-sync via systemd user timer (Linux with systemd)
+# Arguments:
+#   $1 - script_path
+#   $2 - interval (minutes)
+# Returns: 0 on success, falls back to cron on failure
+# Modelled on worker-watchdog.sh:_install_systemd() (GH#17691)
+#######################################
+_enable_systemd() {
+	local script_path="$1"
+	local interval="$2"
+	local service_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.service"
+	local timer_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.timer"
+	local interval_sec
+	interval_sec=$((interval * 60))
+
+	mkdir -p "${SYSTEMD_SERVICE_DIR}"
+
+	printf '%s' "[Unit]
+Description=aidevops repo-sync
+After=network.target
+
+[Service]
+Type=oneshot
+KillMode=process
+ExecStart=/bin/bash -lc '${script_path} check'
+TimeoutStartSec=300
+Nice=10
+IOSchedulingClass=idle
+StandardOutput=append:${LOG_FILE}
+StandardError=append:${LOG_FILE}
+" >"$service_file"
+
+	printf '%s' "[Unit]
+Description=aidevops repo-sync Timer
+
+[Timer]
+OnBootSec=${interval_sec}
+OnUnitActiveSec=${interval_sec}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+" >"$timer_file"
+
+	systemctl --user daemon-reload 2>/dev/null || true
+	if ! systemctl --user enable --now "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null; then
+		print_error "Failed to enable systemd timer — falling back to cron" >&2
+		_enable_cron "$script_path" "$interval"
+		return $?
+	fi
+
+	update_state_action "enable" "enabled"
+
+	print_success "Repo sync enabled (every ${interval} minutes)"
+	echo ""
+	echo "  Scheduler: systemd user timer"
+	echo "  Unit:      ${SYSTEMD_UNIT_NAME}.timer"
+	echo "  Service:   ${service_file}"
+	echo "  Timer:     ${timer_file}"
+	echo "  Logs:      ${LOG_FILE}"
+	echo ""
+	echo "  Disable with: aidevops repo-sync disable"
+	return 0
+}
+
+#######################################
+# Disable repo-sync systemd user timer
+# Returns: 0 on success
+#######################################
+_disable_systemd() {
+	local had_entry=false
+
+	if systemctl --user is-enabled "${SYSTEMD_UNIT_NAME}.timer" >/dev/null 2>&1; then
+		had_entry=true
+		systemctl --user disable --now "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || true
+	fi
+
+	local service_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.service"
+	local timer_file="${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.timer"
+	if [[ -f "$timer_file" ]]; then
+		had_entry=true
+		rm -f "$timer_file"
+	fi
+	if [[ -f "$service_file" ]]; then
+		rm -f "$service_file"
+	fi
+	systemctl --user daemon-reload 2>/dev/null || true
+
+	# Also remove any lingering cron entry
+	if crontab -l 2>/dev/null | grep -qF "$CRON_MARKER"; then
+		local temp_cron
+		temp_cron=$(mktemp)
+		crontab -l 2>/dev/null | grep -vF "$CRON_MARKER" >"$temp_cron" || true
+		crontab "$temp_cron"
+		rm -f "$temp_cron"
+		had_entry=true
+	fi
+
+	update_state_action "disable" "disabled"
+
+	if [[ "$had_entry" == "true" ]]; then
+		print_success "Repo sync disabled"
+	else
+		print_info "Repo sync was not enabled"
+	fi
+	return 0
+}
+
+#######################################
 # Enable repo-sync via cron (Linux)
 # Arguments:
 #   $1 - script_path
@@ -700,6 +811,9 @@ cmd_enable() {
 	if [[ "$backend" == "launchd" ]]; then
 		_enable_launchd "$script_path" "$interval"
 		return $?
+	elif [[ "$backend" == "systemd" ]]; then
+		_enable_systemd "$script_path" "$interval"
+		return $?
 	fi
 
 	_enable_cron "$script_path" "$interval"
@@ -758,6 +872,9 @@ cmd_disable() {
 			print_info "Repo sync was not enabled"
 		fi
 		return 0
+	elif [[ "$backend" == "systemd" ]]; then
+		_disable_systemd
+		return $?
 	fi
 
 	# Linux: cron backend

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -1433,9 +1433,10 @@ migrate_cron_to_systemd() {
 		return 0
 	fi
 
-	# One-time migration marker
+	# Versioned migration marker — bump version when new entries are added so
+	# existing systems re-run the migration (GH#17861: added auto-update + repo-sync).
 	local marker_dir="$HOME/.aidevops/cache/migrations"
-	local marker_file="$marker_dir/cron-to-systemd-done"
+	local marker_file="$marker_dir/cron-to-systemd-v2-done"
 	if [[ -f "$marker_file" ]]; then
 		return 0
 	fi
@@ -1449,7 +1450,9 @@ aidevops: memory-pressure-monitor
 aidevops: screen-time-snapshot
 aidevops: contribution-watch
 aidevops: profile-readme-update
-aidevops: token-refresh"
+aidevops: token-refresh
+aidevops-auto-update
+aidevops-repo-sync"
 
 	local systemd_timers="aidevops-stats-wrapper
 aidevops-gh-failure-miner
@@ -1458,7 +1461,9 @@ aidevops-memory-pressure-monitor
 aidevops-screen-time-snapshot
 aidevops-contribution-watch
 aidevops-profile-readme-update
-aidevops-token-refresh"
+aidevops-token-refresh
+aidevops-auto-update
+aidevops-repo-sync"
 
 	local current_cron
 	current_cron=$(crontab -l 2>/dev/null) || current_cron=""
@@ -1490,7 +1495,7 @@ aidevops-token-refresh"
 		print_success "Cron-to-systemd migration: $migrated scheduler(s) migrated"
 	fi
 
-	# Write marker regardless of whether anything was migrated
+	# Write versioned marker regardless of whether anything was migrated
 	mkdir -p "$marker_dir"
 	date -u +%Y-%m-%dT%H:%M:%SZ >"$marker_file"
 	return 0

--- a/setup-modules/post-setup.sh
+++ b/setup-modules/post-setup.sh
@@ -28,7 +28,8 @@ setup_auto_update() {
 		"aidevops-auto-update" \
 		"$auto_update_script" \
 		"enable" \
-		"aidevops auto-update enable"; then
+		"aidevops auto-update enable" \
+		"aidevops-auto-update"; then
 		_auto_update_installed=true
 	fi
 	if [[ "$_auto_update_installed" == "false" ]]; then

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -1685,7 +1685,12 @@ setup_repo_sync() {
 	local _repo_sync_installed=false
 	if _launchd_has_agent "com.aidevops.aidevops-repo-sync"; then
 		_repo_sync_installed=true
+	elif _launchd_has_agent "sh.aidevops.repo-sync"; then
+		_repo_sync_installed=true
 	elif crontab -l 2>/dev/null | grep -qF "aidevops-repo-sync"; then
+		_repo_sync_installed=true
+	elif command -v systemctl >/dev/null 2>&1 &&
+		systemctl --user is-enabled "aidevops-repo-sync.timer" >/dev/null 2>&1; then
 		_repo_sync_installed=true
 	fi
 	if [[ "$_repo_sync_installed" == "false" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1032,7 +1032,7 @@ _setup_post_setup_steps() {
 	# Exceptions: regenerate existing schedulers (GH#17381, GH#17695 Finding B)
 	# and allow first-time install when config consent is explicitly true (GH#17403).
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
-		# Auto-update handles non-interactive internally
+		# Auto-update handles non-interactive internally (systemd detection fixed in GH#17861)
 		setup_auto_update
 		if _should_setup_noninteractive_supervisor_pulse; then
 			setup_supervisor_pulse "$os"
@@ -1056,7 +1056,7 @@ _setup_post_setup_steps() {
 		if _should_setup_noninteractive_scheduler "Contribution watch" "sh.aidevops.contribution-watch" "aidevops: contribution-watch" "aidevops-contribution-watch"; then
 			setup_contribution_watch
 		fi
-		# Repo sync handles non-interactive mode internally
+		# Repo sync handles non-interactive mode internally (systemd detection fixed in GH#17861)
 		setup_repo_sync
 		if _should_setup_noninteractive_scheduler "Profile README" "sh.aidevops.profile-readme-update" "aidevops: profile-readme-update" "aidevops-profile-readme-update"; then
 			setup_profile_readme


### PR DESCRIPTION
## Summary

Fixes the cron re-creation loop on Linux with systemd described in GH#17861. The root cause was that `cmd_enable()` and `cmd_disable()` in both `auto-update-helper.sh` and `repo-sync-helper.sh` had no `\"systemd\"` case — execution always fell through to the cron path even when `_get_scheduler_backend()` returned `\"systemd\"`.

## Changes

### A. `auto-update-helper.sh`
- Added `SYSTEMD_SERVICE_DIR` and `SYSTEMD_UNIT_NAME` constants
- Added `_cmd_enable_systemd()` — creates `.service` + `.timer` unit files, enables via `systemctl --user`, falls back to cron on failure
- Added `_cmd_disable_systemd()` — disables and removes unit files, also cleans up any lingering cron entry
- Updated `cmd_enable()`: added `elif [[ \"$backend\" == \"systemd\" ]]` branch
- Updated `cmd_disable()`: added `elif [[ \"$backend\" == \"systemd\" ]]` branch

### B. `repo-sync-helper.sh`
- Same pattern: added constants, `_enable_systemd()`, `_disable_systemd()`, updated `cmd_enable()` and `cmd_disable()`

### C. `setup-modules/post-setup.sh`
- `setup_auto_update()`: added `\"aidevops-auto-update\"` as 8th argument to `_scheduler_detect_installed()` so systemd timers are detected as already installed (prevents re-enable on non-interactive runs)

### D. `setup-modules/schedulers.sh`
- `setup_repo_sync()`: added `systemctl --user is-enabled aidevops-repo-sync.timer` check alongside launchd and cron detection; also added `sh.aidevops.repo-sync` launchd label check

### E. `setup-modules/migrations.sh`
- Added `aidevops-auto-update` and `aidevops-repo-sync` to `migrate_cron_to_systemd()` parallel arrays
- Bumped migration marker from `cron-to-systemd-done` to `cron-to-systemd-v2-done` so existing systems re-run the migration and pick up the new entries

## Runtime Testing

Risk: **Low** — shell script changes with no runtime environment available. Logic follows the established pattern from `worker-watchdog.sh:_install_systemd()` (GH#17691, PR #17696) and `routine-helper.sh:cmd_install_systemd()` (GH#17692, PR #17739). ShellCheck passes with zero new violations.

## Verification

```bash
# On Linux with systemd:
aidevops auto-update disable && aidevops auto-update enable
# Expected: prints \"systemd user timer\", no cron entry

aidevops repo-sync disable && aidevops repo-sync enable
# Expected: same

bash ~/Git/aidevops/setup.sh --non-interactive
crontab -l | grep -E 'aidevops-(auto-update|repo-sync)'
# Expected: empty (no re-creation)
```

Resolves #17861

---
[aidevops.sh](https://aidevops.sh) v3.6.182 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 6m and 20,728 tokens on this as a headless worker.