### PR TITLE
GH#17894: chore: ratchet-down NESTING_DEPTH_THRESHOLD 256→252

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -72,7 +72,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # test-multi-container-batch-dispatch.sh), replacing while-loop with sed/paste
 # pipeline to put 'done' on its own line (opencode-db-archive.sh), and converting
 # one-liner if statements to && || chains (run-tests.sh). 250 violations + 6 headroom = 256.
-NESTING_DEPTH_THRESHOLD=256
+# Ratcheted down to 252 (GH#17894): actual violations 250 + 2 buffer
+NESTING_DEPTH_THRESHOLD=252
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1742,9 +1742,9 @@
       "pr": 12145
     },
     ".agents/scripts/generate-runtime-config.sh": {
-      "hash": "c98636b5fd34430f229e5708bef4317bcdbe2a31",
-      "at": "2026-04-03T16:35:21Z",
-      "passes": 2,
+      "hash": "560fc8924c7d2c2aef4d452a6d0ee20f6ab4fe81",
+      "at": "2026-04-08T18:52:12Z",
+      "passes": 3,
       "pr": 15933
     },
     ".agents/scripts/gh-signature-helper.sh": {
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "684c0bb489800ca863d98b7ab6b1fbbc9f23b1ef",
-      "at": "2026-04-08T17:58:41Z",
-      "passes": 60,
+      "hash": "2b0ba8d50cfec227fa9180becd775fec4b8dac5d",
+      "at": "2026-04-08T18:52:12Z",
+      "passes": 61,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -5261,21 +5261,21 @@
       "pr": 16415
     },
     "TODO.md": {
-      "hash": "aceb6325264886b6abdf9738a8d658fa86ce2957",
-      "at": "2026-04-08T05:08:24Z",
-      "passes": 24,
+      "hash": "924ae4b001a3530714caea746a9b4e2a3167d0f4",
+      "at": "2026-04-08T18:52:25Z",
+      "passes": 25,
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "8494a4477031db3e6aa983c41caf60752f659351",
-      "at": "2026-04-08T17:58:58Z",
-      "passes": 87,
+      "hash": "7adaadc611bdae5fd32f0fd2d5b0cdd8cd5a03ef",
+      "at": "2026-04-08T18:52:25Z",
+      "passes": 88,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "81f88e552ced561281d052a36dc1e011ef510ba0",
-      "at": "2026-04-08T17:58:58Z",
-      "passes": 85,
+      "hash": "e75e239937af64fd255d6fa5d01ebf3ecc62eeb9",
+      "at": "2026-04-08T18:52:25Z",
+      "passes": 86,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6731,10 +6731,10 @@
       "passes": 1
     },
     ".agents/scripts/approval-helper.sh": {
-      "hash": "c58f45b4de8e534f75cf797106db9ae7d9d2d3ab",
-      "at": "2026-04-08T17:58:40Z",
+      "hash": "54ce9a33142a08dc3e1059cb3817d3c205ce75da",
+      "at": "2026-04-08T18:52:11Z",
       "pr": 17454,
-      "passes": 4
+      "passes": 5
     },
     ".agents/reference/customization.md": {
       "hash": "f0eacffbaf909a5f1849f7bf5668c92a81ba252d",
@@ -6791,10 +6791,10 @@
       "passes": 2
     },
     ".agents/scripts/opencode-db-archive.sh": {
-      "hash": "d70b8431719f9de873d119eb81b297d4da471f25",
-      "at": "2026-04-08T17:58:41Z",
+      "hash": "cb7ae69bdd2f56fb15c166422a119f06e8bafa0a",
+      "at": "2026-04-08T18:52:12Z",
       "pr": 17584,
-      "passes": 6
+      "passes": 7
     },
     ".agents/scripts/colormind-helper.sh": {
       "hash": "fca3090dfe5b07e572ecf605cd270baa54981bbf",


### PR DESCRIPTION
## Summary

Lower `NESTING_DEPTH_THRESHOLD` from 256 to 252 as part of the automated ratchet-down routine (t1913).

**Change:** `NESTING_DEPTH_THRESHOLD`: 256 → 252 (actual violations: 250, buffer: 2)

## Files Changed

- `EDIT: .agents/configs/complexity-thresholds.conf` — lowered threshold, added ratchet-down comment

## Runtime Testing

Risk: **Low** — config file change only, no code logic modified.

Verification:
```
[complexity-scan] INFO: Actual violations — func:29 nest:250 size:52 bash32:71
[complexity-scan] INFO: Current thresholds — func:31 nest:252 size:53 bash32:72
[complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 5
```

Threshold is 2 above actual violations (250), within the 2-buffer policy.

Resolves #17894

---
[aidevops.sh](https://aidevops.sh) v3.6.182 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 1m and 2,314 tokens on this as a headless worker.