### PR TITLE
t2030: add pulse-batch-prefetch-helper.sh (step 1/2)

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pulse-batch-prefetch-helper.sh — Org-level prefetch for pulse (t2030)
+#
+# Collapses per-repo `gh issue list` / `gh pr list` calls into a single
+# `gh search` per owner, dramatically reducing GitHub API consumption
+# during pulse prefetch.
+#
+# The pulse historically ran one `gh issue list --repo $slug` and one
+# `gh pr list --repo $slug` per pulse-enabled repo every cycle. With
+# 40+ repos that burns ~100 GraphQL calls per cycle before any actual
+# work, exhausting the 5000/hr budget.
+#
+# This helper groups repos by owner, runs ONE `gh search issues
+# --owner X` per owner, then splits the response into per-slug cache
+# files. Downstream consumers (pulse-wrapper.sh prefetch functions)
+# read the cache file if present and fall back to per-repo on miss.
+#
+# Usage:
+#   pulse-batch-prefetch-helper.sh refresh [--repos-json PATH]
+#     Read pulse-enabled repos from repos.json, group by owner, run
+#     one gh search per owner for issues AND prs, write per-slug cache.
+#
+#   pulse-batch-prefetch-helper.sh cache-path --kind issues|prs --slug owner/repo
+#     Print the cache file path for a given kind+slug. Empty output if
+#     not cached. Used by pulse-wrapper.sh to check for a cached result.
+#
+#   pulse-batch-prefetch-helper.sh clear
+#     Remove all cached batch prefetch files.
+#
+#   pulse-batch-prefetch-helper.sh status
+#     Show cache contents (owner counts, ages, file sizes).
+#
+# Cache format:
+#   ~/.aidevops/.agent-workspace/supervisor/batch-prefetch/
+#     issues-{owner}--{repo}.json  — array of issue objects (per-slug)
+#     prs-{owner}--{repo}.json     — array of pr objects (per-slug)
+#     .last-refresh-{owner}        — unix timestamp of last owner refresh
+#
+# Each cached file mirrors the shape that `gh issue list --repo slug
+# --json number,title,labels,updatedAt,assignees` returns, so pulse
+# consumers can use the data without transformation.
+#
+# Environment:
+#   PULSE_BATCH_PREFETCH_DIR    Override cache directory
+#   PULSE_BATCH_PREFETCH_TTL    Cache freshness in seconds (default: 240)
+#   PULSE_BATCH_PREFETCH_LIMIT  Max results per owner search (default: 1000)
+#   AIDEVOPS_REPOS_JSON         Override repos.json path
+
+set -uo pipefail
+
+# shellcheck disable=SC2034
+SCRIPT_VERSION="1.0.0"
+
+CACHE_DIR="${PULSE_BATCH_PREFETCH_DIR:-${HOME}/.aidevops/.agent-workspace/supervisor/batch-prefetch}"
+CACHE_TTL="${PULSE_BATCH_PREFETCH_TTL:-240}"
+SEARCH_LIMIT="${PULSE_BATCH_PREFETCH_LIMIT:-1000}"
+REPOS_JSON="${AIDEVOPS_REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+
+#######################################
+# Log a message to stderr with a helper prefix.
+# Globals: none
+# Arguments:
+#   $* - message text
+# Returns:
+#   0 always
+#######################################
+_log() {
+	local msg="$*"
+	echo "[pulse-batch-prefetch] ${msg}" >&2
+	return 0
+}
+
+#######################################
+# Sanitise a repo slug into a filesystem-safe filename component.
+# Example: "Ultimate-Multisite/ultimate-multisite" -> "Ultimate-Multisite--ultimate-multisite"
+# Arguments:
+#   $1 - repo slug (owner/repo)
+# Outputs:
+#   Sanitised name on stdout
+# Returns:
+#   0 on success, 1 if slug is empty
+#######################################
+_slug_to_filename() {
+	local slug="${1:-}"
+	if [[ -z "$slug" ]]; then
+		return 1
+	fi
+	# Replace / with -- (double dash distinguishes from single-dash in org names)
+	echo "${slug//\//--}"
+	return 0
+}
+
+#######################################
+# Read the list of pulse-enabled repo slugs from repos.json, grouped by owner.
+# Emits lines of form "owner\tslug" for each repo where pulse: true and
+# local_only is not true.
+# Globals:
+#   REPOS_JSON
+# Outputs:
+#   Tab-separated owner\tslug pairs on stdout, one per line
+# Returns:
+#   0 on success, 1 if repos.json is missing or invalid
+#######################################
+_list_pulse_repos_by_owner() {
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		_log "repos.json not found: $REPOS_JSON"
+		return 1
+	fi
+
+	if ! jq -e . "$REPOS_JSON" >/dev/null 2>&1; then
+		_log "repos.json is not valid JSON: $REPOS_JSON"
+		return 1
+	fi
+
+	jq -r '
+		.initialized_repos[]
+		| select(.pulse == true)
+		| select((.local_only // false) | not)
+		| .slug
+		| split("/") as $parts
+		| select($parts | length == 2)
+		| "\($parts[0])\t\(.)"
+	' "$REPOS_JSON" 2>/dev/null
+	return 0
+}
+
+#######################################
+# Fetch all open issues for a single owner via `gh search issues --owner X`.
+# Writes the raw JSON array to stdout. Logs failures but still exits 0
+# with an empty array, so callers can treat missing data as "no open issues".
+#
+# Arguments:
+#   $1 - owner (GitHub org or user)
+# Outputs:
+#   JSON array on stdout (empty array on any failure)
+# Returns:
+#   0 always (errors are logged, not propagated)
+#######################################
+_fetch_owner_issues() {
+	local owner="${1:-}"
+	if [[ -z "$owner" ]]; then
+		echo "[]"
+		return 0
+	fi
+
+	local err_file result
+	err_file=$(mktemp "${TMPDIR:-/tmp}/pulse-batch-issues.XXXXXX.err")
+	result=$(gh search issues \
+		--owner "$owner" \
+		--state open \
+		--limit "$SEARCH_LIMIT" \
+		--json number,title,labels,updatedAt,assignees,repository \
+		2>"$err_file") || result=""
+
+	if [[ -z "$result" || "$result" == "null" ]]; then
+		local err_msg
+		err_msg=$(head -c 500 "$err_file" 2>/dev/null || echo "unknown")
+		_log "gh search issues FAILED for owner=${owner}: ${err_msg}"
+		rm -f "$err_file"
+		echo "[]"
+		return 0
+	fi
+
+	rm -f "$err_file"
+	echo "$result"
+	return 0
+}
+
+#######################################
+# Fetch all open PRs for a single owner via `gh search prs --owner X`.
+# Note: gh search does NOT support reviewDecision or statusCheckRollup —
+# the pulse enriches those in a separate per-PR pass. This helper only
+# fetches the fields that match `gh pr list` basic output.
+#
+# Arguments:
+#   $1 - owner (GitHub org or user)
+# Outputs:
+#   JSON array on stdout (empty array on any failure)
+# Returns:
+#   0 always
+#######################################
+_fetch_owner_prs() {
+	local owner="${1:-}"
+	if [[ -z "$owner" ]]; then
+		echo "[]"
+		return 0
+	fi
+
+	local err_file result
+	err_file=$(mktemp "${TMPDIR:-/tmp}/pulse-batch-prs.XXXXXX.err")
+	result=$(gh search prs \
+		--owner "$owner" \
+		--state open \
+		--limit "$SEARCH_LIMIT" \
+		--json number,title,author,createdAt,updatedAt,repository \
+		2>"$err_file") || result=""
+
+	if [[ -z "$result" || "$result" == "null" ]]; then
+		local err_msg
+		err_msg=$(head -c 500 "$err_file" 2>/dev/null || echo "unknown")
+		_log "gh search prs FAILED for owner=${owner}: ${err_msg}"
+		rm -f "$err_file"
+		echo "[]"
+		return 0
+	fi
+
+	rm -f "$err_file"
+	echo "$result"
+	return 0
+}
+
+#######################################
+# Split a combined search result (many repos) into per-slug files under
+# $CACHE_DIR. Each output file contains a JSON array of just the entries
+# matching that slug, with the top-level `repository` field stripped to
+# match the shape of `gh issue list --repo X` / `gh pr list --repo X`.
+#
+# Arguments:
+#   $1 - kind ("issues" or "prs")
+#   $2 - list of slugs for this owner (space-separated)
+#   $3 - combined JSON result from _fetch_owner_*
+# Outputs:
+#   One line per slug written to stdout: "slug count"
+# Returns:
+#   0 on success, 1 on fatal jq error
+#######################################
+_split_by_slug() {
+	local kind="$1"
+	local slugs="$2"
+	local combined="$3"
+
+	mkdir -p "$CACHE_DIR" 2>/dev/null || {
+		_log "Failed to create cache dir: $CACHE_DIR"
+		return 1
+	}
+
+	local slug filename cache_file per_slug count
+	for slug in $slugs; do
+		filename=$(_slug_to_filename "$slug") || continue
+		cache_file="${CACHE_DIR}/${kind}-${filename}.json"
+
+		per_slug=$(echo "$combined" | jq --arg s "$slug" \
+			'[.[] | select(.repository.nameWithOwner == $s) | del(.repository)]' 2>/dev/null) || per_slug="[]"
+
+		if [[ -z "$per_slug" || "$per_slug" == "null" ]]; then
+			per_slug="[]"
+		fi
+
+		# Atomic write via temp + rename
+		local tmp_file
+		tmp_file=$(mktemp "${cache_file}.XXXXXX")
+		echo "$per_slug" >"$tmp_file"
+		mv -f "$tmp_file" "$cache_file"
+
+		count=$(echo "$per_slug" | jq 'length' 2>/dev/null) || count=0
+		echo "${slug} ${count}"
+	done
+	return 0
+}
+
+#######################################
+# Refresh the batch prefetch cache for all pulse-enabled repos.
+# Groups repos by owner, fetches issues + prs once per owner, splits
+# results into per-slug cache files. Writes a per-owner timestamp marker
+# so consumers can check freshness.
+#
+# Arguments: none (reads repos.json)
+# Outputs:
+#   Summary lines on stdout (one per slug per kind)
+# Returns:
+#   0 on success, 1 if repos.json is missing/invalid
+#######################################
+cmd_refresh() {
+	local pairs
+	pairs=$(_list_pulse_repos_by_owner) || return 1
+
+	if [[ -z "$pairs" ]]; then
+		_log "No pulse-enabled repos found in $REPOS_JSON"
+		return 0
+	fi
+
+	mkdir -p "$CACHE_DIR" 2>/dev/null || {
+		_log "Failed to create cache dir: $CACHE_DIR"
+		return 1
+	}
+
+	# Group slugs by owner using a temp file (bash 3.2 — no associative arrays)
+	local tmp_groups
+	tmp_groups=$(mktemp "${TMPDIR:-/tmp}/pulse-batch-groups.XXXXXX")
+	echo "$pairs" | sort -u >"$tmp_groups"
+
+	local owners
+	owners=$(awk -F'\t' '{print $1}' "$tmp_groups" | sort -u)
+
+	local owner owner_slugs issues_json prs_json ts
+	local total_issues=0 total_prs=0 owner_count=0
+
+	for owner in $owners; do
+		owner_count=$((owner_count + 1))
+		owner_slugs=$(awk -F'\t' -v o="$owner" '$1 == o {print $2}' "$tmp_groups" | tr '\n' ' ')
+
+		_log "Refreshing owner=${owner} slugs=$(echo "$owner_slugs" | wc -w | tr -d ' ')"
+
+		issues_json=$(_fetch_owner_issues "$owner")
+		prs_json=$(_fetch_owner_prs "$owner")
+
+		local issue_summary pr_summary
+		issue_summary=$(_split_by_slug issues "$owner_slugs" "$issues_json") || issue_summary=""
+		pr_summary=$(_split_by_slug prs "$owner_slugs" "$prs_json") || pr_summary=""
+
+		if [[ -n "$issue_summary" ]]; then
+			local issue_owner_count
+			issue_owner_count=$(echo "$issue_summary" | awk '{sum+=$2} END {print sum+0}')
+			total_issues=$((total_issues + issue_owner_count))
+			echo "$issue_summary" | while read -r line; do
+				echo "issues ${line}"
+			done
+		fi
+		if [[ -n "$pr_summary" ]]; then
+			local pr_owner_count
+			pr_owner_count=$(echo "$pr_summary" | awk '{sum+=$2} END {print sum+0}')
+			total_prs=$((total_prs + pr_owner_count))
+			echo "$pr_summary" | while read -r line; do
+				echo "prs ${line}"
+			done
+		fi
+
+		# Write freshness marker
+		ts=$(date +%s)
+		echo "$ts" >"${CACHE_DIR}/.last-refresh-${owner}"
+	done
+
+	rm -f "$tmp_groups"
+	_log "Refresh complete: owners=${owner_count} total_issues=${total_issues} total_prs=${total_prs}"
+	return 0
+}
+
+#######################################
+# Print the cache file path for a given kind+slug if it exists and is
+# fresh (within CACHE_TTL seconds). Empty output means cache miss or
+# stale — callers should fall back to per-repo fetch.
+#
+# Arguments:
+#   $1 - --kind
+#   $2 - issues|prs
+#   $3 - --slug
+#   $4 - owner/repo
+# Outputs:
+#   Absolute path to cache file (if fresh), empty otherwise
+# Returns:
+#   0 if cache hit + fresh, 1 if miss or stale
+#######################################
+cmd_cache_path() {
+	local kind="" slug=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--kind)
+			kind="$2"
+			shift 2
+			;;
+		--slug)
+			slug="$2"
+			shift 2
+			;;
+		*)
+			_log "cache-path: unknown arg: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$kind" || -z "$slug" ]]; then
+		_log "cache-path: --kind and --slug required"
+		return 1
+	fi
+
+	if [[ "$kind" != "issues" && "$kind" != "prs" ]]; then
+		_log "cache-path: --kind must be 'issues' or 'prs'"
+		return 1
+	fi
+
+	local filename cache_file owner
+	filename=$(_slug_to_filename "$slug") || return 1
+	cache_file="${CACHE_DIR}/${kind}-${filename}.json"
+
+	if [[ ! -f "$cache_file" ]]; then
+		return 1
+	fi
+
+	# Check freshness via owner marker
+	owner="${slug%%/*}"
+	local marker="${CACHE_DIR}/.last-refresh-${owner}"
+	if [[ ! -f "$marker" ]]; then
+		return 1
+	fi
+
+	local last_refresh now age
+	last_refresh=$(cat "$marker" 2>/dev/null || echo 0)
+	now=$(date +%s)
+	age=$((now - last_refresh))
+
+	if [[ "$age" -gt "$CACHE_TTL" ]]; then
+		return 1
+	fi
+
+	echo "$cache_file"
+	return 0
+}
+
+#######################################
+# Remove all cached batch prefetch files.
+# Arguments: none
+# Returns: 0 always
+#######################################
+cmd_clear() {
+	if [[ -d "$CACHE_DIR" ]]; then
+		rm -f "${CACHE_DIR}"/issues-*.json "${CACHE_DIR}"/prs-*.json "${CACHE_DIR}"/.last-refresh-*
+		_log "Cache cleared: $CACHE_DIR"
+	fi
+	return 0
+}
+
+#######################################
+# Print a human-readable status summary of the cache.
+# Arguments: none
+# Outputs:
+#   Markdown-formatted summary on stdout
+# Returns: 0 always
+#######################################
+cmd_status() {
+	echo "# pulse-batch-prefetch status"
+	echo "- cache_dir: ${CACHE_DIR}"
+	echo "- ttl: ${CACHE_TTL}s"
+	echo "- search_limit: ${SEARCH_LIMIT}"
+	echo ""
+
+	if [[ ! -d "$CACHE_DIR" ]]; then
+		echo "Cache directory does not exist."
+		return 0
+	fi
+
+	local now
+	now=$(date +%s)
+
+	echo "## Owner refresh markers"
+	local marker owner last_refresh age
+	for marker in "${CACHE_DIR}"/.last-refresh-*; do
+		[[ -f "$marker" ]] || continue
+		owner="${marker##*/.last-refresh-}"
+		last_refresh=$(cat "$marker" 2>/dev/null || echo 0)
+		age=$((now - last_refresh))
+		echo "- ${owner}: age=${age}s"
+	done
+	echo ""
+
+	echo "## Cached files"
+	local f count kind rest
+	for f in "${CACHE_DIR}"/issues-*.json "${CACHE_DIR}"/prs-*.json; do
+		[[ -f "$f" ]] || continue
+		count=$(jq 'length' "$f" 2>/dev/null || echo "?")
+		rest="${f##*/}"
+		kind="${rest%%-*}"
+		echo "- ${rest} (kind=${kind} count=${count})"
+	done
+
+	return 0
+}
+
+#######################################
+# Entry point.
+# Arguments:
+#   $1 - subcommand (refresh|cache-path|clear|status|help)
+# Returns:
+#   Subcommand exit code
+#######################################
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	refresh)
+		cmd_refresh "$@"
+		;;
+	cache-path)
+		cmd_cache_path "$@"
+		;;
+	clear)
+		cmd_clear "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	help | --help | -h)
+		sed -n '4,60p' "$0"
+		;;
+	*)
+		_log "Unknown command: $cmd"
+		sed -n '4,60p' "$0" >&2
+		return 1
+		;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/TODO.md
+++ b/TODO.md
@@ -230,6 +230,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 
 ## Backlog
 
+- [ ] t2030 refactor(pulse): replace per-repo prefetch gh calls with org-level `gh search issues` — exhausts GitHub API rate limit with 46+ UM repos. Target ~10x reduction in prefetch calls. Stopgap `pulse_hours:{3,5}` applied to UM repos. #performance #pulse #tooling #auto-dispatch ~4h logged:2026-04-07 tier:reasoning
 - [ ] GH#17804 fix(upgrade-planning): extracts template placeholders (tXXX/tYYY/tZZZ) from ## Format section as real tasks — discovered during awardsapp upgrade 2026-04-08, upgrade reverted. Fix: section-aware parser or numeric-ID filter. #bug #planning #tooling #regression #auto-dispatch ~1h ref:GH#17804 logged:2026-04-08 tier:simple
 - [ ] GH#17806 fix(upgrade-planning): loses ### subsection headers in Backlog — semantic data loss, flattens all groups into one pile. Fix: preserve ### headers verbatim OR make upgrade minimal (only add TOON header, skip body rewrite). #bug #planning #tooling #data-loss #auto-dispatch ~2h ref:GH#17806 logged:2026-04-08 tier:standard
 - [ ] GH#17807 fix(schedulers): `aidevops update` exits 1 due to unbound variable at schedulers.sh line 613 — update succeeds but exit code breaks CI/automation wrappers. Fix: add ${VAR:-default} or fix typo. #bug #tooling #shell #ci #auto-dispatch ~30m ref:GH#17807 logged:2026-04-08 tier:simple

--- a/todo/tasks/t2030-brief.md
+++ b/todo/tasks/t2030-brief.md
@@ -1,0 +1,68 @@
+# t2030: Refactor pulse prefetch to use org-level GitHub search
+
+## Session Origin
+Interactive session 2026-04-07. User reported pulse exhausting GitHub API rate limit ("API rate limit already exceeded" on `gh repo list`). 46 `Ultimate-Multisite/*` repos (plus others) each cause per-repo `gh issue list`/`gh pr list` calls every pulse cycle. Stopgap applied: `pulse_hours: {start:3, end:5}` on all UM repos to shrink the cycle window. This task is the proper fix.
+
+## What
+Replace per-repo prefetch/scan calls in `.agents/scripts/pulse-wrapper.sh` with one org-level (or global) `gh search issues` / `gh search prs` call per category, then group results by `repository.nameWithOwner` in jq and distribute to the existing per-slug cache structures. Target ~10–20x reduction in `gh` calls per cycle.
+
+## Why
+- 46+ pulse-enabled repos × multiple prefetch functions per cycle = hundreds of API calls per pulse run.
+- GitHub REST has a 5000 req/hr cap; we're exhausting it during normal operation.
+- `gh search issues --owner ORG --state open --json ...` returns all matching issues in one call — same data, fraction of the cost.
+- Per-issue/per-PR mutations (edit, comment, merge, labels) and `gh api .../timeline` calls must stay per-repo — they have no org-level equivalent. The win is purely in the scan/prefetch phase.
+
+## How
+
+### Files to modify
+- **EDIT**: `.agents/scripts/pulse-wrapper.sh` — functions to convert to org-level prefetch:
+  - `_prefetch_repo_prs` (~line 989)
+  - `_prefetch_repo_issues` (~line 1170)
+  - `_prefetch_repo_daily_cap` (~line 1038)
+  - `prefetch_triage_review_status` (~line 3630) — `needs-maintainer-review` label scan
+  - `prefetch_needs_info_replies` (~line 3737) — `status:needs-info` label scan
+  - `_fetch_queue_metrics` (~line 7321, 7336)
+  - `count_runnable_candidates` (~line 7735)
+  - `count_queued_without_worker` (~line 7776)
+  - Debt counters (~line 11084-11096) — `quality-debt`, `simplification-debt`
+- **KEEP UNCHANGED** (cannot use org search): all `gh issue edit/comment/close`, `gh pr edit/comment/merge/close`, `gh pr view --json files/comments`, `gh api .../timeline`, `gh api .../comments --paginate`.
+
+### Pattern to follow
+Group pulse-enabled repos by org owner (from `~/.config/aidevops/repos.json` `slug` field), then for each owner run:
+```
+gh search issues --owner "$owner" --state open --limit 1000 \
+  --json number,title,labels,assignees,repository,updatedAt,url
+```
+Cache result keyed by `${owner}:${category}`, then for each repo slug filter via jq:
+```
+jq --arg slug "$slug" '[.[] | select(.repository.nameWithOwner == $slug)]'
+```
+Write to the same per-slug cache files the existing prefetch functions populate, so downstream code is unchanged.
+
+For label-filtered scans, add `--label` flags to `gh search issues`. For global/cross-org scans (e.g., FOSS contribution watchers), use `gh search issues --involves @me` or similar.
+
+Handle single-repo case (non-org solo repos) by falling back to the existing per-repo `gh issue list` path — don't force org search when there's only one repo for an owner.
+
+### Verification
+1. Dry-run: `bash .agents/scripts/pulse-wrapper.sh --dry-run` (if supported) or run pulse manually and inspect `~/.aidevops/logs/pulse.log` for `gh issue list`/`gh pr list` call counts before and after.
+2. Count API calls per cycle: `grep -c "^\[pulse-wrapper\].*gh (issue|pr) list" $LOGFILE` should drop ~10x.
+3. Functional: confirm dispatched tasks, triage replies, and queue metrics still work across at least 3 repos on next pulse cycle.
+4. Rate limit check: `gh api rate_limit` after a full cycle — remaining budget should be markedly higher.
+
+### Rollout
+- Implement behind a feature flag `PULSE_ORG_SEARCH_ENABLED=1` initially.
+- Test on one org (e.g., Ultimate-Multisite) before enabling globally.
+- Once proven, remove flag and old per-repo code paths.
+
+## Acceptance Criteria
+- [ ] `gh issue list --repo` / `gh pr list --repo` calls per pulse cycle reduced by ≥10x
+- [ ] All existing prefetch cache files still populated correctly for every pulse-enabled repo
+- [ ] No regression in dispatch, triage, needs-info, queue metrics, or debt counters
+- [ ] Stopgap `pulse_hours: {3,5}` can be removed from UM repos afterward
+- [ ] `gh api rate_limit` shows significantly higher remaining budget post-cycle
+- [ ] Verification commands documented in PR description with before/after call counts
+
+## Context
+- Stopgap commit in `~/.config/aidevops/repos.json` (backup at `repos.json.bak-*`)
+- Rate limit hit observed 2026-04-07 on `gh repo list Ultimate-Multisite`
+- Related: pulse-wrapper.sh is ~11K lines; this refactor touches ~10 functions, not the mutation-heavy code paths


### PR DESCRIPTION
## Summary

Step 1 of the pulse prefetch refactor (t2030). Introduces a standalone helper that collapses per-repo `gh issue list` / `gh pr list` calls into one `gh search issues --owner X` / `gh search prs --owner X` per owner.

For the current pulse workload (42 pulse-enabled repos across 2 owners), this reduces the prefetch phase from ~84 `gh` calls per cycle to **4** — a ~20x reduction in GitHub API consumption, staying well within the 5000/hr GraphQL budget even at high pulse frequency.

## Why

Observed on 2026-04-07/08: GraphQL rate limit exhausted repeatedly during normal pulse operation, blocking worker dispatch. Stopgap: trimmed pulse-enabled repos from 42 to 6. This PR makes the structural fix so the 42 repos can be re-enabled.

## What this PR does

- Adds `.agents/scripts/pulse-batch-prefetch-helper.sh` (standalone, 507 lines, shellcheck clean)
- Commands: `refresh`, `cache-path --kind issues|prs --slug owner/repo`, `clear`, `status`
- Cache at `~/.aidevops/.agent-workspace/supervisor/batch-prefetch/` with per-owner TTL markers
- Per-slug output files mirror the shape of `gh issue list --json number,title,labels,updatedAt,assignees` after `repository` field is stripped during split

## What this PR does NOT do

- `pulse-wrapper.sh` is untouched. Step 2 (follow-up PR) wires it to call `refresh` at the top of `prefetch_state` and check `cache-path` before each per-repo `gh` call, with fallback to the existing per-repo path on cache miss.
- No feature flag yet — the helper is inert until step 2 integrates it.

## Verification

Ran against live pulse-enabled repos:

\`\`\`
./.agents/scripts/pulse-batch-prefetch-helper.sh refresh
[pulse-batch-prefetch] Refreshing owner=superdav42 slugs=1
[pulse-batch-prefetch] Refreshing owner=Ultimate-Multisite slugs=5
[pulse-batch-prefetch] Refresh complete: owners=2 total_issues=27 total_prs=1
\`\`\`

- 6 repos, 2 owners, **4 gh calls total** (2 owners × {issues, prs})
- Shape verified: labels, assignees, number, title, updatedAt match existing consumer expectations
- `cache-path` returns path + exit 0 on hit, empty + exit 1 on miss or stale
- `clear` wipes cache; `status` shows counts and ages
- Shellcheck: zero violations

## Limitations

- `gh search prs` does not return `reviewDecision` or `statusCheckRollup`. Step 2 will leave the existing per-PR enrichment pass in place for those fields — only the bulk list is batched.
- Default search limit 1000/owner (raise via `PULSE_BATCH_PREFETCH_LIMIT`). At current scale the largest owner has ~20 open issues, so headroom is ample.

## Follow-up

Step 2 PR will:
1. Add `PULSE_BATCH_PREFETCH_ENABLED` feature flag to `pulse-wrapper.sh`
2. Call `pulse-batch-prefetch-helper.sh refresh` at top of `prefetch_state` stage
3. Modify `_prefetch_repo_issues` and `_prefetch_repo_prs` to consult `cache-path` before their existing per-repo `gh` calls
4. Document the before/after `gh` call count in the PR description

Resolves #NNN (linked via ref:GH# once issue exists on upstream).

---

[aidevops.sh](https://aidevops.sh) v3.6.167 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-opus-4-6 spent 6m and 2,100 tokens on this with the user in an interactive session.

For #t2030