### PR TITLE
GH#17908: refactor complexity-thresholds.conf audit trail for readability

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -1,0 +1,41 @@
+# Complexity Thresholds — Historical Audit Trail
+
+This file archives the full change history for `.agents/configs/complexity-thresholds.conf`.
+The main config retains only the last few entries for readability.
+
+## NESTING_DEPTH_THRESHOLD History
+
+| Value | PR/Issue | Reason |
+|-------|----------|--------|
+| 262 | baseline (2026-04-01) | +1 for complexity-scan-helper.sh GH#15285 |
+| 263 | GH#15316 | orchestration-efficiency-collector.sh adds 1 violation — awk heredocs with if/for patterns counted by depth checker |
+| 266 | GH#15391/t1748 | platform-detect.sh adds 1 violation (elif-counting quirk in awk checker inflates depth); 2 additional violations from pre-existing scripts included in CI merge ref after threshold was set |
+| 267 | GH#16096/t1864 | notes-helper.sh adds 1 violation (osascript AppleScript blocks inside bash functions — same pattern as calendar/contacts helpers) |
+| 268 | GH#16685/t1867 | autoagent-metric-helper.sh adds 1 violation (CI awk checker counts if/case across all functions without resetting at boundaries) |
+| 269 | GH#16866 | pre-existing regression on main from ollama-helper.sh (GH#16862) — awk checker counts if/case patterns inside heredocs |
+| 271 | GH#16880 | pre-existing regression on main (2 new violations from scripts merged after threshold was set — not introduced by this PR) |
+| 275 | GH#17068 | pre-existing regression from t1880/t1881 attribution protection work — aidevops.sh grew by ~35 lines adding signing verification and status checks; awk depth checker counts all if/case/for across the entire file without function-boundary resets, inflating the count for large scripts |
+| 276 | GH#17086 | pre-existing regression on main (1 new violation from scripts merged after threshold was set — not introduced by this PR) |
+| 278 | GH#17560 | pre-existing regression on main (2 new violations from scripts merged after threshold was set — not introduced by this PR) |
+| 279 | GH#17799/t2028, GH#17779 | two violations merged simultaneously — cch-extract.sh (cleanup_tmpfiles() with if-block) and pulse-wrapper.sh (_count_impl_commits() with nested while/case/if blocks); awk depth checker counts if/case across entire file without function-boundary resets |
+| 285 | GH#17830 | threshold was saturated at 279 = zero headroom; adding 6 units of headroom (279+6=285) ensures the proximity guard (GH#17808) fires at 280 violations before the threshold is saturated again, preventing false-positive CI failures on PRs that don't introduce new nesting violations |
+| 268 | GH#17850 | ratcheted down — reduced violations from 264→262 by converting elif chains to early-return patterns and extracting heredoc code into separate files (platform-detect.sh, safety-policy-check.sh, quality-fix.sh, spdx-headers.sh, dispatch-claim-helper.sh, ip-rep-blocklistde.sh). 262 violations + 6 headroom = 268 |
+| 262 | GH#17852 | ratcheted down — reduced violations from 262→256 by fixing prose text in heredocs/echo statements containing 'if/for' keywords that were incorrectly counted by the awk depth checker (terminal-title-helper.sh, quality-cli-manager.sh, dispatch-claim-helper.sh), converting elif chains to early-return patterns (ip-rep-blocklistde.sh), using guard clauses (quality-fix.sh), and restructuring loops to use pipes instead of process substitution so 'done' lines are recognized by the awk decrement pattern (spdx-headers.sh). 256 violations + 6 headroom = 262 |
+| 262 | GH#17854 | resolved proximity warning at 279/279 — violations reduced from 279→256 across GH#17847, GH#17851, GH#17852; threshold ratcheted from 279→285→268→262. Current state: 256 violations, 6 headroom. Proximity guard (GH#17808) fires at 257 violations (within 5 of 262), preventing saturation |
+| 258 | GH#17875 | ratcheted down — actual violations 256 + 2 buffer |
+| 256 | GH#17886 | ratcheted down — reduced violations from 257→250 by extracting Python heredocs into separate .py files (generate-runtime-config.sh, generate-opencode-agents.sh), rewording prose text containing 'if/for' keywords that were falsely counted by the awk depth checker (test-memory-mail.sh, test-tier-downgrade.sh, test-dual-cli-e2e.sh, test-ai-actions.sh, test-multi-container-batch-dispatch.sh), replacing while-loop with sed/paste pipeline to put 'done' on its own line (opencode-db-archive.sh), and converting one-liner if statements to && \|\| chains (run-tests.sh). 250 violations + 6 headroom = 256 |
+| 252 | GH#17894 | ratcheted down — actual violations 250 + 2 buffer |
+
+## FUNCTION_COMPLEXITY_THRESHOLD History
+
+| Value | PR/Issue | Reason |
+|-------|----------|--------|
+| 404 | baseline (2026-03-24) | initial baseline |
+| 31 | GH#17875 | ratcheted down — actual violations 29 + 2 buffer |
+
+## BASH32_COMPAT_THRESHOLD History
+
+| Value | PR/Issue | Reason |
+|-------|----------|--------|
+| 69 | baseline (2026-04-04) | mostly namerefs in helper scripts |
+| 72 | GH#17830 | pre-existing regression on main — 71 violations vs threshold 69; email-delivery-test-helper.sh and memory-pressure-monitor.sh added namerefs/associative arrays after threshold was set. Adding 1 unit of headroom to unblock PRs; proper fix is to refactor those scripts |

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -6,73 +6,22 @@
 #
 # Format: KEY=VALUE (no spaces around =, no quotes needed)
 # Lines starting with # are comments.
+#
+# Full change history: complexity-thresholds-history.md
 
 # Shell function complexity: functions with >100 lines
-# Current baseline: 404 (as of 2026-03-24)
-# Ratcheted down to 31 (GH#17875): actual violations 29 + 2 buffer
+# Baseline: 404 (2026-03-24) → ratcheted to 31 (GH#17875): 29 violations + 2 buffer
 FUNCTION_COMPLEXITY_THRESHOLD=31
 
 # Shell nesting depth: files with >8 levels of nesting
-# Current baseline: 262 (as of 2026-04-01, +1 for complexity-scan-helper.sh GH#15285)
-# Bumped to 263 (GH#15316): orchestration-efficiency-collector.sh adds 1 violation
-# due to awk heredocs with if/for patterns counted by the depth checker
-# Bumped to 266 (GH#15391/t1748): platform-detect.sh adds 1 violation (elif-counting
-# quirk in awk checker inflates depth); 2 additional violations from pre-existing
-# scripts included in CI merge ref after threshold was set
-# Bumped to 267 (GH#16096/t1864): notes-helper.sh adds 1 violation (osascript
-# AppleScript blocks inside bash functions — same pattern as calendar/contacts helpers)
-# Bumped to 268 (GH#16685/t1867): autoagent-metric-helper.sh adds 1 violation
-# (CI awk checker counts if/case across all functions without resetting at boundaries)
-# Bumped to 269 (GH#16866): pre-existing regression on main from ollama-helper.sh
-# (GH#16862) — awk checker counts if/case patterns inside heredocs
-# Bumped to 271 (GH#16880): pre-existing regression on main (2 new violations from
-# scripts merged after threshold was set — not introduced by this PR)
-# Bumped to 275 (GH#17068): pre-existing regression from t1880/t1881 attribution
-# protection work — aidevops.sh grew by ~35 lines adding signing verification and
-# status checks; awk depth checker counts all if/case/for across the entire file
-# without function-boundary resets, inflating the count for large scripts
-# Bumped to 276 (GH#17086): pre-existing regression on main (1 new violation from
-# scripts merged after threshold was set — not introduced by this PR)
-# Bumped to 278 (GH#17560): pre-existing regression on main (2 new violations from
-# scripts merged after threshold was set — not introduced by this PR)
-# Bumped to 279 (GH#17799/t2028, GH#17779): two violations merged simultaneously —
-# cch-extract.sh (cleanup_tmpfiles() with if-block) and pulse-wrapper.sh
-# (_count_impl_commits() with nested while/case/if blocks); awk depth checker
-# counts if/case across entire file without function-boundary resets
-# Bumped to 285 (GH#17830): threshold was saturated at 279 = zero headroom; any PR
-# opened against main with 279 violations fails CI if it adds even 1 more violation.
-# Adding 6 units of headroom (279+6=285) ensures the proximity guard (GH#17808)
-# fires at 280 violations before the threshold is saturated again, preventing
-# false-positive CI failures on PRs that don't introduce new nesting violations.
-# Ratcheted down to 268 (GH#17850): reduced violations from 264→262 by converting
-# elif chains to early-return patterns and extracting heredoc code into separate
-# files (platform-detect.sh, safety-policy-check.sh, quality-fix.sh, spdx-headers.sh,
-# dispatch-claim-helper.sh, ip-rep-blocklistde.sh). 262 violations + 6 headroom = 268.
-# Ratcheted down to 262 (GH#17852): reduced violations from 262→256 by fixing
-# prose text in heredocs/echo statements containing 'if/for' keywords that were
-# incorrectly counted by the awk depth checker (terminal-title-helper.sh,
-# quality-cli-manager.sh, dispatch-claim-helper.sh), converting elif chains to
-# early-return patterns (ip-rep-blocklistde.sh), using guard clauses
-# (quality-fix.sh), and restructuring loops to use pipes instead of process
-# substitution so 'done' lines are recognized by the awk decrement pattern
-# (spdx-headers.sh). 256 violations + 6 headroom = 262.
-# Resolved GH#17854 (proximity warning at 279/279): violations reduced from
-# 279→256 across GH#17847, GH#17851, GH#17852; threshold ratcheted from
-# 279→285→268→262. Current state: 256 violations, 6 headroom. Proximity guard
-# (GH#17808) fires at 257 violations (within 5 of 262), preventing saturation.
-# NOTE: pulse-wrapper.sh now has a proximity guard (GH#17808) that warns when
+# NOTE: pulse-wrapper.sh has a proximity guard (GH#17808) that warns when
 # violations are within 5 of this threshold. Bump this value AND document the
-# reason above when adding scripts that push the count over the current value.
-# Ratcheted down to 258 (GH#17875): actual violations 256 + 2 buffer
-# Ratcheted down to 256 (GH#17886): reduced violations from 257→250 by
-# extracting Python heredocs into separate .py files (generate-runtime-config.sh,
-# generate-opencode-agents.sh), rewording prose text containing 'if/for' keywords
-# that were falsely counted by the awk depth checker (test-memory-mail.sh,
-# test-tier-downgrade.sh, test-dual-cli-e2e.sh, test-ai-actions.sh,
-# test-multi-container-batch-dispatch.sh), replacing while-loop with sed/paste
-# pipeline to put 'done' on its own line (opencode-db-archive.sh), and converting
-# one-liner if statements to && || chains (run-tests.sh). 250 violations + 6 headroom = 256.
-# Ratcheted down to 252 (GH#17894): actual violations 250 + 2 buffer
+# reason in complexity-thresholds-history.md when adding scripts that push the
+# count over the current value.
+#
+# Recent history (full log in complexity-thresholds-history.md):
+# Ratcheted down to 256 (GH#17886): 250 violations + 6 headroom = 256
+# Ratcheted down to 252 (GH#17894): 250 violations + 2 buffer
 NESTING_DEPTH_THRESHOLD=252
 
 # File size: files with >1500 lines
@@ -81,9 +30,7 @@ FILE_SIZE_THRESHOLD=53
 
 # Bash 3.2 compatibility: "\n"/"\t" in double-quoted strings, associative
 # arrays (bash 4.0+), and namerefs (bash 4.3+). GH#17371.
-# Current baseline: 69 (as of 2026-04-04, mostly namerefs in helper scripts)
-# Bumped to 72 (GH#17830): pre-existing regression on main — 71 violations vs
-# threshold 69; email-delivery-test-helper.sh and memory-pressure-monitor.sh
-# added namerefs/associative arrays after threshold was set. Adding 1 unit of
-# headroom to unblock PRs; proper fix is to refactor those scripts.
+# Baseline: 69 (2026-04-04) → bumped to 72 (GH#17830): pre-existing regression;
+# email-delivery-test-helper.sh and memory-pressure-monitor.sh added
+# namerefs/associative arrays. Proper fix is to refactor those scripts.
 BASH32_COMPAT_THRESHOLD=72


### PR DESCRIPTION
## Summary

Addresses Gemini review feedback from PR #17856: the audit trail comment in `.agents/configs/complexity-thresholds.conf` was too long and dense (89 lines, 60+ lines of inline history).

## What was done

- Moved the full historical change log to a new archive file: `.agents/configs/complexity-thresholds-history.md`
- Kept only the current state and last 2 entries in the main config
- Added a pointer comment in the main config directing readers to the history file
- Updated the NOTE comment to reference the history file for new entries
- Config reduced from 89 lines to 36 lines (59% reduction)

## Files changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — trimmed inline history, added pointer to history file
- NEW: `.agents/configs/complexity-thresholds-history.md` — full historical audit trail in table format

## Runtime Testing

Risk: Low (docs/config only, no functional change — values unchanged)
Self-assessed: config comment restructure, no code or threshold value changes.

Resolves #17908

---
[aidevops.sh](https://aidevops.sh) v3.6.182 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 3m and 4,342 tokens on this as a headless worker.