### PR TITLE
GH#17905: fix routines.md review feedback — restore anti-pattern detail and fix AGENTS.md fallback

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -117,7 +117,7 @@ Recurring operational jobs live in `TODO.md` under `## Routines`, not in a separ
 - `run:` points to a deterministic script relative to `~/.aidevops/agents/`
 - `agent:` names the LLM agent to dispatch with `headless-runtime-helper.sh`
 - `[x]` means enabled; `[ ]` means disabled/paused and should be skipped
-- Dispatch rule: prefer `run:` when present; otherwise use `agent:`; if neither is set, default to `run:custom/scripts/{routine-name}.sh` when it exists, else `agent:Build+`
+- Dispatch rule: prefer `run:` when present; otherwise use `agent:`; if neither is set, default to `run:custom/scripts/{routine_id}.sh` (e.g. `r001.sh`) when it exists, else `agent:Build+`
 
 Use `/routine` to design, dry-run, and schedule these definitions. Reference: `.agents/reference/routines.md`.
 

--- a/.agents/reference/routines.md
+++ b/.agents/reference/routines.md
@@ -51,3 +51,4 @@ Use `run:` for scripts, exports, health checks. Use `agent:` when judgment or su
 - One-off task entries for routine execution history
 - Running deterministic scripts through an LLM agent
 - Schedule semantics outside version control
+- Collapsing SOP, targets, and schedule into a single prompt — keep them independent


### PR DESCRIPTION
## Summary

Addresses two unactioned review findings from PR #17859 on `.agents/reference/routines.md`.

### Changes

- **routines.md**: Restore the missing anti-pattern bullet: "Collapsing SOP, targets, and schedule into a single prompt — keep them independent" (gemini MEDIUM finding)
- **AGENTS.md**: Fix routine fallback path from `{routine-name}.sh` to `{routine_id}.sh` to match the actual runtime behavior in `pulse-wrapper.sh` (coderabbit HIGH finding — was fixed in routines.md via commit d9ec06d but AGENTS.md still had the old text)

### Verification

- Both files updated consistently with pulse-wrapper.sh runtime behavior
- No code paths changed — docs-only fix
- `grep -n 'routine_id' .agents/AGENTS.md` returns the corrected line
- `grep -n 'Collapsing SOP' .agents/reference/routines.md` returns the new anti-pattern

## Runtime Testing

**Risk level:** Low (docs-only change)
**Testing:** self-assessed — no code paths changed, only documentation updated

Resolves #17905

---

---
[aidevops.sh](https://aidevops.sh) v3.6.183 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 5m and 4,032 tokens on this as a headless worker.