### PR TITLE
GH#17920: fix pulse throughput — reduce dedup TTL, clear dedup on crash, dispatch-first ordering

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -418,13 +418,13 @@ _get_repo_maintainer() {
 # the dedup guard permanently blocks all dispatch (0 workers, 100%
 # failure rate observed in production — 370 issues, 159 PRs stuck).
 #
-# The 30-minute threshold matches DISPATCH_COMMENT_MAX_AGE (Layer 5).
-# GH#17549: Previously 1 hour, creating a 30-minute dead zone (30-60 min)
-# where Layer 5 passed (dispatch comment expired) but Layer 6 blocked
-# (assignment still "active"). This forced the LLM to bypass
-# dispatch_with_dedup() to re-dispatch dead workers, skipping all
-# dedup guards including the claim protocol. Any legitimate worker
-# should produce at least one comment or commit within 30 minutes.
+# The 10-minute threshold matches DISPATCH_COMMENT_MAX_AGE (Layer 5).
+# GH#17549: Previously 1 hour, creating a dead zone where Layer 5 passed
+# (dispatch comment expired) but Layer 6 blocked (assignment still "active").
+# Reduced from 30 min to 10 min: workers either succeed in ~10 min or crash
+# in ~2 min. The 30-min TTL wasted 28 min of dispatch capacity per crash
+# (880 dedup blocks vs 622 dispatches observed). Any legitimate worker
+# should produce at least one comment or commit within 10 minutes.
 #
 # Args:
 #   $1 = issue number
@@ -434,7 +434,7 @@ _get_repo_maintainer() {
 #   exit 0 = stale assignment recovered (safe to dispatch)
 #   exit 1 = assignment is NOT stale (genuine active claim, block dispatch)
 #######################################
-STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-1800}}" # 30 min (GH#17549: aligned with DISPATCH_COMMENT_MAX_AGE to close dead zone)
+STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-600}}" # 10 min (GH#17549: aligned with DISPATCH_COMMENT_MAX_AGE; reduced from 30 min — crash recovery was too slow)
 
 _is_stale_assignment() {
 	local issue_number="$1"
@@ -910,15 +910,16 @@ _is_dispatch_comment_active() {
 #
 # GH#17503: This is now the PRIMARY dedup guard. Dispatch comments are
 # never deleted (audit trail). A dispatch comment blocks re-dispatch for
-# DISPATCH_COMMENT_MAX_AGE seconds (default 1800 = 30 min). After that,
+# DISPATCH_COMMENT_MAX_AGE seconds (default 600 = 10 min). After that,
 # the comment stays for audit but no longer blocks — allowing a fresh
 # dispatch attempt.
 #
 # A completion or failure comment posted AFTER the dispatch comment
 # cancels the lock early — the worker is done, re-dispatch is safe.
 # Recognised completion signals: "TASK_COMPLETE", "FULL_LOOP_COMPLETE",
-# "Worker failed", "BLOCKED", "Stale assignment recovered",
-# "Kill signal sent", "gh pr merge", "Closes #".
+# "Worker failed", "Worker Watchdog Kill", "BLOCKED",
+# "Stale assignment recovered", "Kill signal sent", "gh pr merge",
+# "Closes #", "MERGE_SUMMARY", "CLAIM_RELEASED".
 #
 # No active-claim-state gate (removed GH#17503) — the dispatch comment
 # itself IS the claim. Labels and assignees are secondary signals.
@@ -947,7 +948,7 @@ has_dispatch_comment() {
 	# status:queued/in-progress. That gate allowed stale recovery to destroy the
 	# claim state and bypass this check entirely.
 
-	local max_age="${DISPATCH_COMMENT_MAX_AGE:-1800}" # 30 min (GH#17503, was 3600)
+	local max_age="${DISPATCH_COMMENT_MAX_AGE:-600}" # 10 min (was 30 min/1800s — reduced to match worker lifecycle; crash recovery was wasting 28 min per crash)
 	local now_epoch
 	now_epoch=$(date -u '+%s')
 
@@ -995,6 +996,7 @@ has_dispatch_comment() {
 				(.body_start | test("TASK_COMPLETE"; "i")) or
 				(.body_start | test("FULL_LOOP_COMPLETE"; "i")) or
 				(.body_start | test("Worker failed"; "i")) or
+				(.body_start | test("Worker Watchdog Kill"; "i")) or
 				(.body_start | test("BLOCKED"; "i")) or
 				(.body_start | test("Kill signal sent"; "i")) or
 				(.body_start | test("Closes #"; "i")) or

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -2512,7 +2512,7 @@ _cmd_run_finish() {
 
 	# Release the dispatch claim on failure so the issue is immediately
 	# available for re-dispatch (next 2-min pulse cycle) instead of
-	# waiting for the 30-min TTL to expire.
+	# waiting for the 10-min TTL to expire.
 	if [[ "$ledger_status" == "fail" ]]; then
 		_release_dispatch_claim "$session_key" "worker_failed"
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3337,6 +3337,15 @@ cleanup_worktrees() {
 
 							recover_failed_launch_state "$orphan_issue_num" "$repo_slug_age" "premature_exit" "$orphan_crash_type"
 							echo "[pulse-wrapper] Orphan cleanup: recorded premature_exit for #${orphan_issue_num} (${repo_slug_age}) crash_type=${orphan_crash_type} — triggers fast-fail escalation" >>"$LOGFILE"
+
+							# Post failure comment to clear dedup guard immediately.
+							# Without this, the dispatch comment blocks re-dispatch
+							# for the full TTL even though the worker is dead.
+							# "Worker failed" is a recognised completion signal in
+							# dispatch-dedup-helper.sh has_dispatch_comment().
+							gh issue comment "$orphan_issue_num" --repo "$repo_slug_age" \
+								--body "Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 commits). Cleared for re-dispatch." \
+								>/dev/null 2>&1 || true
 						fi
 					fi
 
@@ -10329,6 +10338,19 @@ _run_preflight_stages() {
 	_session_ct=$(check_session_count)
 	if [[ "${_session_ct:-0}" -gt "$SESSION_COUNT_WARN" ]]; then
 		echo "[pulse-wrapper] Session warning: $_session_ct interactive sessions open (threshold: $SESSION_COUNT_WARN). Each consumes 100-440MB + language servers. Consider closing unused tabs." >>"$LOGFILE"
+	fi
+
+	# Early dispatch pass: fill available worker slots BEFORE heavy housekeeping.
+	# Workers take 25-30s to cold-start (sandbox-exec + opencode), so dispatching
+	# here lets them boot in parallel with the remaining housekeeping stages
+	# (close_issues_with_merged_prs ~260s, prefetch_state ~130s, etc.).
+	# The main fill floor at the end of the cycle catches any slots freed by
+	# housekeeping. Without this, workers sit idle for ~7 minutes of cleanup.
+	if [[ -f "$STOP_FLAG" ]]; then
+		echo "[pulse-wrapper] Stop flag present — skipping early fill floor" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] Early fill floor: dispatching workers before housekeeping" >>"$LOGFILE"
+		apply_deterministic_fill_floor
 	fi
 
 	# Daily complexity scan (GH#5628): creates simplification-debt issues


### PR DESCRIPTION
## Summary

Fixes three bottlenecks causing 58% of pulse cycles to dispatch 0 workers despite 24 available slots and 40+ dispatchable issues.

**Observed metrics before fix:**
- 880 dedup blocks vs 622 dispatches (1.4:1 block ratio)
- 200 orphan cleanups (32% crash rate)
- 58% of cycles dispatch 0 workers
- `close_issues_with_merged_prs` stage takes ~262s per cycle
- `prefetch_state` takes ~128s per cycle
- Workers sit idle during ~7 min of housekeeping before dispatch

## Changes

### A. Reduce DISPATCH_COMMENT_MAX_AGE: 1800s → 600s
Workers either succeed in ~10 min or crash in ~2 min. The 30-min TTL wasted 28 min of dispatch capacity per crash. Aligned `STALE_ASSIGNMENT_THRESHOLD_SECONDS` to match.

### B. Clear dedup on crash detection
1. **Added "Worker Watchdog Kill" to completion signals** — watchdog kill comments were NOT clearing the dedup guard, leaving killed issues locked until TTL expiry.
2. **Post "Worker failed" comment from orphan cleanup** — when a 0-commit worktree is cleaned up, immediately post a completion signal so the issue is dispatchable on the next cycle instead of waiting for TTL.

### C. Dispatch-first cycle ordering
Added early `apply_deterministic_fill_floor` call right after `calculate_max_workers` in `_run_preflight_stages()`, before heavy housekeeping stages. Workers cold-start in 25-30s and boot in parallel with cleanup. The main fill floor at cycle end still catches slots freed by housekeeping.

## Files Changed
- `.agents/scripts/dispatch-dedup-helper.sh` — TTL reduction, completion signal list
- `.agents/scripts/pulse-wrapper.sh` — orphan crash comment, early fill floor
- `.agents/scripts/headless-runtime-helper.sh` — comment update (30-min → 10-min)

## Runtime Testing
- Risk: Medium (configuration + dispatch ordering, no new logic paths)
- Self-assessed: changes are to timing constants, signal matching, and stage ordering
- Verification: monitor `pulse.log` for `Early fill floor:` entries and check `pulse-health.json` shows higher `workers_active` counts

Resolves #17920