### PR TITLE
GH#17909: fix stdout pollution in spdx-headers.sh _check_ext_files

### DIFF
--- a/.agents/scripts/spdx-headers.sh
+++ b/.agents/scripts/spdx-headers.sh
@@ -256,7 +256,7 @@ _check_ext_files() {
 		total=$((total + 1))
 		_is_spdx_exempt "$file" && continue
 		_has_spdx "$file" && continue
-		echo "  missing: $file"
+		echo "  missing: $file" >&2
 		missing=$((missing + 1))
 	done < <(git ls-files "*.${ext}" 2>/dev/null)
 	echo "$missing $total"


### PR DESCRIPTION
## Summary

Fixes stdout pollution in `_check_ext_files()` in `.agents/scripts/spdx-headers.sh`.

## Problem

The progress message `echo "  missing: $file"` at line 259 was written to stdout. When `cmd_check` calls `_check_ext_files` and captures its output into `result` (line 271), the missing-file progress lines were included in `result`. This caused the count parsing at lines 272-273 to fail — `m` would be empty or incorrect when any files were missing, leading to arithmetic errors at line 274.

## Fix

Redirect the progress message to stderr:
```bash
echo "  missing: $file" >&2
```

This ensures only the final `"missing_count total_count"` line is captured for processing, while progress is still visible to the user on stderr.

## Testing

- shellcheck: zero violations
- Risk: **Low** — single-character change (`>&2`), no logic change, fixes a parsing bug

## Runtime Testing

`self-assessed` — Low risk: docs/scripts change, no runtime environment needed. The fix is a single stderr redirect that corrects a clear stdout-capture bug.

Resolves #17909

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.185 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 59s and 1,904 tokens on this as a headless worker.