### PR TITLE
GH#17906: fix memory-pressure-monitor.sh review feedback (delimiter safety + here-string)

### DIFF
--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -454,7 +454,8 @@ _matches_monitor_pattern() {
 
 	if [[ "$pattern" == *".*"* ]]; then
 		# Regex pattern — match against full command line
-		if echo "$full_cmd" | grep -iqE "$pattern"; then
+		# Use here-string to avoid issues with values starting with '-' or containing backslashes
+		if grep -iqE "$pattern" <<<"$full_cmd"; then
 			return 0
 		fi
 	else
@@ -514,14 +515,14 @@ _resolve_ages_and_emit() {
 	done < <(_batch_get_process_ages "${seen_pids[@]}")
 
 	# Emit final rows with ages, then sort by RSS descending
+	# Rows use SOH (\x01) as delimiter — safe against colons in command names/args
 	local row
 	for row in "${matched_rows[@]}"; do
-		local r_pid="${row%%:*}"
-		local rest="${row#*:}"
-		local r_rss="${rest%%:*}"
-		rest="${rest#*:}"
-		local r_cmd_name="${rest%%:*}"
-		local r_cmd="${rest#*:}"
+		local r_pid r_rss r_cmd_name r_cmd
+		IFS=$'\1' read -r r_pid r_rss r_cmd_name r_cmd <<<"$row"
+		# Validate numeric fields after parsing — defense-in-depth against delimiter shifting
+		[[ "$r_pid" =~ ^[0-9]+$ ]] || continue
+		[[ "$r_rss" =~ ^[0-9]+$ ]] || continue
 		local r_age="${age_map[$r_pid]:-0}"
 		printf '%s|%s|%s|%s|%s\n' "$r_pid" "$r_rss" "$r_age" "$r_cmd_name" "$r_cmd"
 	done | sort -t'|' -k2 -rn
@@ -543,7 +544,7 @@ _collect_monitored_processes() {
 	local -a seen_pids=()
 
 	# Accumulate matched process data before fetching ages (avoids per-PID ps forks)
-	# Format: PID:RSS_MB:CMD_NAME:FULL_CMD
+	# Format: PID<SOH>RSS_MB<SOH>CMD_NAME<SOH>FULL_CMD (SOH=\x01, safe delimiter — never appears in cmd)
 	local -a matched_rows=()
 
 	local pattern
@@ -577,7 +578,8 @@ _collect_monitored_processes() {
 
 			local rss_mb=$((rss_kb / 1024))
 			# Accumulate row — age fetched in batch below
-			matched_rows+=("${pid}:${rss_mb}:${cmd_name}:${cmd}")
+			# Use SOH (\x01) as delimiter — safe because it never appears in process names or args
+			matched_rows+=("${pid}"$'\1'"${rss_mb}"$'\1'"${cmd_name}"$'\1'"${cmd}")
 		done <<<"$ps_output"
 	done
 


### PR DESCRIPTION
## Summary

Addresses two code review findings from PR #17858 on `.agents/scripts/memory-pressure-monitor.sh`.

### Fix 1: Here-string in `_matches_monitor_pattern` (line 457)

**Before:**
```bash
if echo "$full_cmd" | grep -iqE "$pattern"; then
```

**After:**
```bash
if grep -iqE "$pattern" <<<"$full_cmd"; then
```

Using `echo` to pipe variables to `grep` is problematic when the variable content starts with a hyphen (interpreted as a flag) or contains backslashes. The here-string form is safer and avoids spawning an extra subshell.

### Fix 2: SOH delimiter in `matched_rows` array (lines 546-582)

**Before:** `matched_rows+=("${pid}:${rss_mb}:${cmd_name}:${cmd}")` with `%%:*` / `#*:` parsing.

**After:** `matched_rows+=("${pid}"$'\1'"${rss_mb}"$'\1'"${cmd_name}"$'\1'"${cmd}")` with `IFS=$'\1' read -r r_pid r_rss r_cmd_name r_cmd <<<"$row"`.

Colon (`:`) is an unsafe delimiter because command names and arguments can contain colons (e.g., paths like `/usr/local/bin:something`, URLs, Python module paths). SOH (`\x01`) is a non-printable ASCII control character that never appears in process names or arguments.

### Fix 3: Numeric validation after parsing (lines 524-525)

Added `[[ "$r_pid" =~ ^[0-9]+$ ]] || continue` and `[[ "$r_rss" =~ ^[0-9]+$ ]] || continue` after parsing each row. This provides defense-in-depth against injection attacks that could result from delimiter shifting caused by malicious data.

## Runtime Testing

**Risk level:** Low — monitoring script, no payment/auth/data-deletion paths.
**Verification:** `shellcheck .agents/scripts/memory-pressure-monitor.sh` — zero violations.

## Files Changed

- EDIT: `.agents/scripts/memory-pressure-monitor.sh` — three targeted fixes at lines 457, 522-525, 547, 582

Resolves #17906

---
[aidevops.sh](https://aidevops.sh) v3.6.185 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 4m and 4,711 tokens on this as a headless worker.