### PR TITLE
GH#17930: verify mergedAt before closing issues against PRs

### DIFF
--- a/.agents/reference/planning-detail.md
+++ b/.agents/reference/planning-detail.md
@@ -145,7 +145,9 @@ If ANY source confirms a merged PR (with verified `mergedAt`), treat the task as
 - `no_pr` or `task_only` worker exits: task stays `[ ]` until human or supervisor verifies the deliverable
 - The `issue-sync` GitHub Action auto-closes issues when tasks are marked `[x]` — false completions cascade into closed issues
 - NEVER close GitHub issues manually with `gh issue close` — let issue-sync verify deliverables before closing. Manual closure bypasses the proof-log safety check
+- **Merge state verification (GH#17871)**: Before closing an issue based on a PR, verify `mergedAt` is non-null via `gh pr view <N> --json mergedAt`. An open PR means work is in progress, not complete. The dedup helper returns exit 0 for BOTH open and merged PRs — callers that close issues must independently verify merge state.
 - **Pre-commit enforcement**: warns on `[ ]` → `[x]` without `verified:` or merged PR evidence (warning only — commit proceeds)
+- **Framework function references**: NEVER reference framework functions, automation, or processes that don't exist in the codebase. Workers that invent non-existent processes (e.g., referencing `_dispatch_issue_consolidation()` when no such function exists) create false audit trails. If proposing a new process, clearly label it as a proposal — never present it as existing automation.
 
 ## Planning File Workflow
 

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -715,19 +715,22 @@ is_assigned() {
 #######################################
 # Check whether an issue already has merged PR evidence.
 #
-# Historical note: command name is `has-open-pr` to match pulse-wrapper
-# dispatch dedup call sites from review feedback, but the underlying behavior
-# checks merged PR evidence to avoid redispatching already-completed issues.
+# IMPORTANT: This function returns exit 0 for BOTH open and merged PRs
+# that reference the issue. This is correct for dispatch dedup (any PR
+# blocks re-dispatch), but callers that close issues MUST independently
+# verify mergedAt before acting — an open PR means work in progress,
+# not work complete. See GH#17871 for the bug this caused.
 #
 # Args:
 #   $1 = issue number
 #   $2 = repo slug (owner/repo)
 #   $3 = issue title (optional; used for task-id fallback)
 # Returns:
-#   exit 0 if merged PR evidence exists (do NOT dispatch)
-#   exit 1 if no merged PR evidence (safe to dispatch)
+#   exit 0 if PR evidence exists — open OR merged (do NOT dispatch)
+#   exit 1 if no PR evidence (safe to dispatch)
 # Outputs:
 #   single-line reason when evidence is found
+# CALLERS: For issue closing, verify mergedAt after this returns 0.
 #######################################
 has_open_pr() {
 	local issue_number="$1"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4082,11 +4082,26 @@ close_issues_with_merged_prs() {
 			# Ask dedup helper if a merged PR exists for this issue
 			local dedup_output=""
 			if dedup_output=$("$dedup_helper" has-open-pr "$issue_num" "$slug" "$issue_title" 2>/dev/null); then
-				# has-open-pr returns 0 when merged PR evidence found (confusing name but correct)
+				# has-open-pr returns 0 when PR evidence found (open OR merged).
+				# For closing, we MUST verify the PR is actually merged — an open
+				# PR means work is in progress, not complete. (GH#17871 fix)
 				local pr_ref
 				pr_ref=$(printf '%s' "$dedup_output" | grep -o '#[0-9]*' | head -1) || pr_ref=""
 				local pr_num
 				pr_num=$(printf '%s' "$pr_ref" | tr -d '#')
+
+				# GH#17871: Verify PR is actually merged before closing.
+				# The dedup helper's Check 1 matches OPEN PRs by title/commit.
+				# An open PR blocks dispatch (correct) but must NOT trigger
+				# issue closure — the work isn't done yet.
+				if [[ -n "$pr_num" ]]; then
+					local merged_at
+					merged_at=$(gh pr view "$pr_num" --repo "$slug" --json mergedAt -q '.mergedAt // empty' 2>/dev/null) || merged_at=""
+					if [[ -z "$merged_at" ]]; then
+						echo "[pulse-wrapper] Skipped auto-close #${issue_num} in ${slug} — PR #${pr_num} exists but is NOT merged (GH#17871 guard)" >>"$LOGFILE"
+						continue
+					fi
+				fi
 
 				# GH#17372: Verify PR diff actually touches files from the issue.
 				# A merged PR with "closes #NNN" may reference the issue without
@@ -4099,7 +4114,7 @@ close_issues_with_merged_prs() {
 				fi
 
 				gh issue close "$issue_num" --repo "$slug" \
-					--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup helper)"}. Issue was open but dedup guard was blocking re-dispatch." \
+					--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup helper)"} (merged at ${merged_at:-unknown}). Issue was open but dedup guard was blocking re-dispatch." \
 					>/dev/null 2>&1 || continue
 
 				# Reset fast-fail counter now that the issue is confirmed resolved (GH#17384)
@@ -4166,12 +4181,29 @@ reconcile_stale_done_issues() {
 			# Check if a merged PR exists for this issue
 			local dedup_output=""
 			if dedup_output=$("$dedup_helper" has-open-pr "$issue_num" "$slug" "$issue_title" 2>/dev/null); then
-				# Merged PR found — verify diff overlap before closing (GH#17372)
+				# Dedup helper returns 0 for open OR merged PRs.
+				# For closing, verify the PR is actually merged (GH#17871).
 				local pr_ref
 				pr_ref=$(printf '%s' "$dedup_output" | grep -o '#[0-9]*' | head -1) || pr_ref=""
 				local pr_num
 				pr_num=$(printf '%s' "$pr_ref" | tr -d '#')
 
+				# GH#17871: Verify PR is actually merged before closing.
+				local merged_at=""
+				if [[ -n "$pr_num" ]]; then
+					merged_at=$(gh pr view "$pr_num" --repo "$slug" --json mergedAt -q '.mergedAt // empty' 2>/dev/null) || merged_at=""
+					if [[ -z "$merged_at" ]]; then
+						echo "[pulse-wrapper] Reconcile done: skipped close #${issue_num} in ${slug} — PR #${pr_num} is NOT merged (GH#17871 guard)" >>"$LOGFILE"
+						# Reset to available — PR exists but isn't merged yet
+						gh issue edit "$issue_num" --repo "$slug" \
+							--remove-label "status:done" \
+							--add-label "status:available" >/dev/null 2>&1 || continue
+						total_reset=$((total_reset + 1))
+						continue
+					fi
+				fi
+
+				# GH#17372: Verify PR diff touches files from the issue
 				if [[ -n "$pr_num" ]] && [[ -x "$verify_helper" ]]; then
 					if ! "$verify_helper" check "$issue_num" "$pr_num" "$slug" >/dev/null 2>&1; then
 						echo "[pulse-wrapper] Reconcile done: skipped close #${issue_num} in ${slug} — PR #${pr_num} does not touch issue files (GH#17372 guard)" >>"$LOGFILE"
@@ -4185,7 +4217,7 @@ reconcile_stale_done_issues() {
 				fi
 
 				gh issue close "$issue_num" --repo "$slug" \
-					--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup)"}." \
+					--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup)"} (merged at ${merged_at:-unknown})." \
 					>/dev/null 2>&1 || continue
 
 				# Reset fast-fail counter now that the issue is confirmed resolved (GH#17384)


### PR DESCRIPTION
## Summary

- Adds `mergedAt` verification to `close_issues_with_merged_prs()` and `reconcile_stale_done_issues()` — prevents closing issues against open/unmerged PRs
- Updates `has_open_pr()` docstring to warn callers about dual open/merged semantics
- Adds merge-state verification rule and anti-hallucination rule to planning-detail reference

## Root Cause

`dispatch-dedup-helper.sh has-open-pr` returns exit 0 for both open and merged PRs (correct for dispatch blocking, wrong for issue closing). The pulse auto-close functions treated exit 0 as "merged PR evidence" without verifying `mergedAt`. This caused #17871 to be incorrectly closed against unmerged PR #17923.

## Changes

| File | Change |
|------|--------|
| `pulse-wrapper.sh` | Added `gh pr view --json mergedAt` guard before `gh issue close` in both auto-close functions |
| `dispatch-dedup-helper.sh` | Updated `has_open_pr()` docstring — clarifies dual semantics, warns callers |
| `reference/planning-detail.md` | Added merge verification rule + anti-hallucination rule |

Resolves #17930


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.188 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 10m and 19,354 tokens on this with the user in an interactive session.