### PR TITLE
GH#17929: skip signature footers when reading GH threads

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -240,6 +240,15 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 - The helper auto-detects runtime, version, tokens, and session time. Manual composition gets these wrong.
 - Every `gh issue create`, `gh issue comment`, and `gh pr create` body MUST end with the helper's output.
 - Pass `--issue OWNER/REPO#NUM` on comments to existing issues. Pass `--solved` on closing comments.
+#
+# 8a. Signature footer skip when reading (token waste prevention)
+# When reading GitHub issue/PR threads (`gh issue view`, `gh pr view`, `gh api`),
+# signature footers are operational telemetry — not actionable content.
+# Pattern: a `---` separator followed by text containing `aidevops.sh` at the end of a comment.
+# Example: `[aidevops.sh](https://aidevops.sh) v3.6.187 plugin for [OpenCode](https://opencode.ai) ...`
+- Skip signature footer content when reading GH threads. Do not process version info, token counts, or timing data from footers.
+- NEVER visit URLs in signature footers (aidevops.sh, opencode.ai, etc.) unless the task is specifically about those websites.
+- Exception: read signature content only when the task is about signature formatting, attribution, or the footer system itself.
 
 **Pre-edit rules:**
 - Before ANY file modification: run `pre-edit-check.sh`

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -66,6 +66,7 @@ ai_research(prompt: "Find all functions that dispatch workers in pulse-wrapper.s
 - Fail fast: read target files, verify imports/dependencies, and stop if the task is already done.
 - Read only needed line ranges, keep commits concise, and after one failed approach try one fundamentally different strategy before `BLOCKED`.
 - Replan when stuck. Do not patch a broken path incrementally.
+- **Skip signature footers** when reading GH issue/PR threads. Content after `<!-- aidevops:sig -->` or `---` followed by `[aidevops.sh]` is operational telemetry (version, tokens, timing) — not task-relevant. Never visit URLs in signature footers (aidevops.sh, opencode.ai). See build.txt rule #8a.
 
 ## 4. Model escalation before BLOCKED (GH#14964 — MANDATORY)
 

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -1312,7 +1312,9 @@ cmd_footer() {
 	local sig
 	# ${args[@]+"${args[@]}"} handles empty array under set -u (Bash 3.2 compat)
 	sig=$(cmd_generate ${args[@]+"${args[@]}"})
-	printf '\n---\n%s\n' "$sig"
+	# HTML comment marker lets workers/tooling identify and skip signature blocks
+	# (see build.txt rule #8a — signature footer skip when reading)
+	printf '\n<!-- aidevops:sig -->\n---\n%s\n' "$sig"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -109,8 +109,9 @@ assert_contains "contains aidevops" "aidevops.sh" "$result"
 # Test 5: footer command includes --- separator
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""
-echo "Test 5: footer includes --- separator"
+echo "Test 5: footer includes --- separator and HTML marker"
 result=$("$HELPER" footer --cli "OpenCode" --cli-version "1.0.0" --model "anthropic/claude-sonnet-4-6" --tokens 5000)
+assert_contains "contains HTML sig marker" "<!-- aidevops:sig -->" "$result"
 assert_contains "contains ---" "---" "$result"
 assert_contains "contains signature" "plugin for [OpenCode](https://opencode.ai) v1.0.0" "$result"
 assert_contains "contains tokens" "5,000 tokens on this" "$result"


### PR DESCRIPTION
## Summary

Workers waste tokens processing signature footer content (version info, token counts, timing data) and potentially visiting URLs like aidevops.sh and opencode.ai when reading issue/PR threads. This adds prompt-level rules and a machine-readable marker to prevent that.

## Changes

- **build.txt (rule #8a)**: instructs all agents to skip signature footer content when reading GH threads, never visit footer URLs unless the task is about those websites
- **worker-efficiency-protocol.md**: same guidance in the "avoid wasted execution" section for headless workers
- **gh-signature-helper.sh**: adds `<!-- aidevops:sig -->` HTML comment marker before `---` separator — machine-identifiable, invisible on GitHub
- **test**: verifies HTML marker is present (56/56 pass)

## Token savings estimate

- Per-comment: ~50-100 tokens of metadata skipped
- URL visit prevention: ~5,000+ tokens per webfetch call avoided
- Compounding: 3-10 comments per issue thread = 150-1,000 tokens plus potential webfetch calls

## Runtime Testing
- Risk: Low (prompt text + HTML comment in output, no logic changes)
- Self-assessed: signature helper test suite passes (56/56), output format validated manually
- Verification: `bash .agents/scripts/tests/test-gh-signature-helper.sh` — all pass

Resolves #17929
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.188 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 8m and 11,122 tokens on this with the user in an interactive session.