### PR TITLE
GH#17907: fix: use printf instead of echo for api_key output in model-availability-helper.sh

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -844,7 +844,7 @@ _probe_resolve_and_validate_key() {
 		return 100
 	fi
 
-	echo "$api_key"
+	printf '%s\n' "$api_key"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Replace `echo "$api_key"` with `printf '%s\n' "$api_key"` at line 847 of `.agents/scripts/model-availability-helper.sh` to safely handle API keys that might start with a hyphen, preventing them from being interpreted as command-line options.

## Changes

- **EDIT**: `.agents/scripts/model-availability-helper.sh:847` — `echo "$api_key"` → `printf '%s\n' "$api_key"`

## Testing

- ShellCheck passes (only pre-existing SC1091 info, unrelated to this change)
- Change is a 1-line substitution with no logic impact; output is identical for normal keys, safer for hyphen-prefixed keys

## Runtime Testing

Risk: **Low** — docs/agent prompt-level change to a shell utility function. No runtime environment required.

Resolves #17907

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.189 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 1m and 1,591 tokens on this as a headless worker.