### PR TITLE
GH#17904: fix coderabbit labels filter — remove external-contributor positive label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -45,12 +45,15 @@ reviews:
       - "dependabot[bot]"
       - "renovate[bot]"
     # GH#17671 post-mortem: external-contributor PRs must always be reviewed,
-    # even when rate-limited. The positive "external-contributor" label ensures
-    # CodeRabbit prioritises these PRs. The "!no-review" excludes internal PRs
-    # that are explicitly opted out.
+    # even when rate-limited. The "!no-review" exclusion filter skips PRs that
+    # are explicitly opted out. Positive labels (without "!") act as inclusion
+    # filters — they restrict reviews to only PRs with those labels, which would
+    # disable reviews for all internal PRs. Do NOT add "external-contributor"
+    # here; use path_filters or path_instructions to apply stricter review rules
+    # to external-contributor PRs instead. GH#17904: removed "external-contributor"
+    # positive label that was inadvertently disabling internal PR reviews.
     labels:
       - "!no-review"
-      - "external-contributor"
 
   # Request changes for critical issues — this is the setting that controls
   # whether CodeRabbit submits formal APPROVED/CHANGES_REQUESTED reviews.


### PR DESCRIPTION
## Summary

Removes `external-contributor` from the `labels` list in `.coderabbit.yaml`'s `auto_review` section.

## Problem

CodeRabbit's `labels` field acts as an **inclusion filter** when any positive labels (without `!` prefix) are present. Adding `"external-contributor"` as a positive label meant CodeRabbit would **only** review PRs carrying that label — effectively disabling automatic reviews for all internal PRs. This contradicted the comment on lines 49-50 which implied internal PRs were still covered unless they had the `no-review` label.

This was flagged by gemini-code-assist in PR #17868 review.

## Fix

- Remove `"external-contributor"` from the `labels` list
- Keep only `"!no-review"` (exclusion filter — correctly skips opted-out PRs)
- Update the comment to document inclusion vs exclusion filter semantics to prevent recurrence

## Files Changed

- EDIT: `.coderabbit.yaml:51-56` — remove positive label, update comment

## Runtime Testing

**Risk level**: Low — YAML config change, no code execution.
**Verification**: CodeRabbit will now review all PRs that don't have the `no-review` label, restoring the intended behavior.

## Resolves

Resolves #17904

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.189 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 1m and 2,419 tokens on this as a headless worker.