### PR TITLE
GH#17913: fix(design-preview-helper): use if blocks for format conversion clarity

### DIFF
--- a/.agents/scripts/design-preview-helper.sh
+++ b/.agents/scripts/design-preview-helper.sh
@@ -326,10 +326,12 @@ _screenshot_convert_formats() {
 	local png base
 	for png in "${all_pngs[@]}"; do
 		base="${png%.png}"
-		[[ "$_ss_format" != "webp" && "$_ss_format" != "all" ]] ||
+		if [[ "$_ss_format" == "webp" || "$_ss_format" == "all" ]]; then
 			convert_to_webp "$png" "${base}.webp" && print_success "WebP: ${base}.webp" || true
-		[[ "$_ss_format" != "avif" && "$_ss_format" != "all" ]] ||
+		fi
+		if [[ "$_ss_format" == "avif" || "$_ss_format" == "all" ]]; then
 			convert_to_avif "$png" "${base}.avif" && print_success "AVIF: ${base}.avif" || true
+		fi
 	done
 
 	return 0


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #17847 on `.agents/scripts/design-preview-helper.sh`.

Replaces operator-chained `||` conditions with explicit `if` blocks for webp and avif format conversion in `_screenshot_convert_formats()`. The previous pattern was valid but harder to read — the `||` chaining made it non-obvious that the condition was a guard rather than part of the conversion pipeline.

## Changes

- **EDIT**: `.agents/scripts/design-preview-helper.sh:329-334` — replace `[[ ... ]] || convert_...` pattern with `if [[ ... ]]; then convert_...; fi` blocks

## Verification

- `shellcheck .agents/scripts/design-preview-helper.sh` — passes with zero violations
- Behaviour unchanged: webp/avif conversion only runs when `_ss_format` matches

## Runtime Testing

**Risk**: Low — docs/script logic refactor, no functional change.
**Assessment**: self-assessed — operator precedence verified, shellcheck clean.

Resolves #17913

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.189 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 1m and 1,806 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code structure and readability in screenshot format conversion handling without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->