### PR TITLE
GH#17914: simplify --days condition in seo-export-helper.sh

### DIFF
--- a/.agents/scripts/seo-export-helper.sh
+++ b/.agents/scripts/seo-export-helper.sh
@@ -287,10 +287,10 @@ main() {
 		case "$arg" in
 		--days)
 			next_arg="${2:-}"
-			{ [[ -n "$next_arg" ]] && [[ "$next_arg" != -* ]]; } || {
+			if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
 				print_error "--days requires a numeric value"
 				return 1
-			}
+			fi
 			days="$next_arg"
 			shift 2
 			;;


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #17847 (gemini-code-assist[bot]).

**Change:** Replace the complex compound condition on line 293 of `.agents/scripts/seo-export-helper.sh` with a simple `if` statement for improved readability and maintainability.

**Before:**
```bash
{ [[ -n "$next_arg" ]] && [[ "$next_arg" != -* ]]; } || {
    print_error "--days requires a numeric value"
    return 1
}
```

**After:**
```bash
if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
    print_error "--days requires a numeric value"
    return 1
fi
```

## Testing

- ShellCheck: zero violations (SC1091 info pre-existing, unrelated to this change)
- Logic is semantically equivalent — same error condition, same error message, same return code

## Runtime Testing

Risk level: **Low** (docs/config/agent prompt equivalent — shell script argument parsing logic, no runtime state change)
Verification: `self-assessed`

Resolves #17914

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.189 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 2m and 1,851 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for the `--days` parameter to better handle invalid input in the export helper script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->