### PR TITLE
t17915: improve readability of exit code check in test-runtime-registry.sh

### DIFF
--- a/tests/test-runtime-registry.sh
+++ b/tests/test-runtime-registry.sh
@@ -347,5 +347,7 @@ echo ""
 echo "=== Results ==="
 printf "Total: %d  Passed: %d  Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
 
-[[ $FAIL_COUNT -eq 0 ]] || exit 1
+if [[ $FAIL_COUNT -gt 0 ]]; then
+	exit 1
+fi
 exit 0


### PR DESCRIPTION
## Summary

Applies review feedback from PR #17847 to improve code readability in `tests/test-runtime-registry.sh`.

## Changes

- **EDIT: tests/test-runtime-registry.sh:350** — Replace `[[ $FAIL_COUNT -eq 0 ]] || exit 1` with a standard `if` block for clearer intent in test suite exit handling.

## Before

```bash
[[ $FAIL_COUNT -eq 0 ]] || exit 1
exit 0
```

## After

```bash
if [[ $FAIL_COUNT -gt 0 ]]; then
	exit 1
fi
exit 0
```

## Verification

- ShellCheck: zero violations
- Logic is semantically equivalent — only readability improved

## Runtime Testing

Risk: **Low** (test file, no logic change, docs/comments equivalent)
Assessment: `self-assessed` — no runtime environment required for this change.

Resolves #17915


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.190 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 2m and 1,735 tokens on this as a headless worker.