### PR TITLE
GH#17883: fix PRAGMA incremental_vacuum no-op in opencode-db-archive.sh

### DIFF
--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -472,9 +472,15 @@ BATCH_SQL
 	# Marks done so the RETURN trap does not double-run.
 	_checkpoint_archive_db "$ARCHIVE_DB"
 
-	# Reclaim space
-	print_info "Running incremental vacuum on active DB..."
-	sqlite3 "$ACTIVE_DB" "PRAGMA incremental_vacuum;"
+	# Reclaim space — VACUUM works regardless of auto_vacuum setting.
+	# PRAGMA incremental_vacuum is a no-op when auto_vacuum=0 (the SQLite default
+	# used by OpenCode), so VACUUM is required here. VACUUM needs exclusive access;
+	# if another connection holds the DB (interactive session), skip gracefully and
+	# retry on the next archive cycle.
+	print_info "Running VACUUM on active DB..."
+	if ! sqlite3 "$ACTIVE_DB" "VACUUM;" 2>/dev/null; then
+		print_warning "VACUUM skipped — database is in use by another process. Will retry next cycle."
+	fi
 
 	local size_after
 	size_after=$(file_size_bytes "$ACTIVE_DB")


### PR DESCRIPTION
## Summary

Fixes the silent no-op vacuum in `opencode-db-archive.sh`. `PRAGMA incremental_vacuum` only reclaims pages when `auto_vacuum=INCREMENTAL` (mode 2). OpenCode creates its database with the SQLite default (`auto_vacuum=0`), so the pragma has never worked on any standard installation.

## Changes

- **EDIT: `.agents/scripts/opencode-db-archive.sh:475-483`** — replace `PRAGMA incremental_vacuum` with `VACUUM`
- Added SQLITE_BUSY handling: if another connection holds the DB, VACUUM fails cleanly with a warning instead of silently doing nothing. The archive runs every pulse cycle so a skipped VACUUM retries automatically.

## Root Cause

```bash
# Before (no-op when auto_vacuum=0):
sqlite3 "$ACTIVE_DB" "PRAGMA incremental_vacuum;"

# After (works regardless of auto_vacuum setting):
if ! sqlite3 "$ACTIVE_DB" "VACUUM;" 2>/dev/null; then
    print_warning "VACUUM skipped — database is in use by another process. Will retry next cycle."
fi
```

## Testing

- ShellCheck: zero violations
- Logic verified against SQLite documentation: `VACUUM` reclaims all free pages regardless of `auto_vacuum` mode
- SQLITE_BUSY path: `VACUUM` returns non-zero exit code when another connection holds the DB; the `if !` guard catches this cleanly

## Runtime Testing

Risk level: **Low** — shell script logic change, no runtime environment available. Self-assessed.

Resolves #17883

---
[aidevops.sh](https://aidevops.sh) v3.6.190 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 2m and 2,191 tokens on this as a headless worker.