### PR TITLE
GH#17869: docs: document S1192 suppression review decision — decline PR #3846 change

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -79,7 +79,10 @@ sonar.issue.ignore.multicriteria.e4.ruleKey=shelldre:S7679
 sonar.issue.ignore.multicriteria.e4.resourceKey=**/*.sh
 
 # S1192: String literals - Many repeated strings are intentional (color codes, log prefixes)
-# Extracting these to constants would reduce readability in shell scripts
+# Extracting these to constants would reduce readability in shell scripts.
+# Reviewed and confirmed in GH#17869: 118 of 463 scripts use ANSI color codes (\033[0;3Xm)
+# as repeated literals. Extracting to per-script constants adds boilerplate with no safety benefit.
+# The suppression is intentional and correct for this codebase.
 sonar.issue.ignore.multicriteria.e5.ruleKey=shelldre:S1192
 sonar.issue.ignore.multicriteria.e5.resourceKey=**/*.sh
 


### PR DESCRIPTION
## Summary

Resolves #17869

Reviews the reverted PR #3846 (OnlyTerp) which removed the S1192 string literals suppression from `sonar-project.properties`. **Decision: decline the change.**

## Review Analysis

**What PR #3846 did:** Removed `e5` from `sonar.issue.ignore.multicriteria` and deleted the S1192 rule definition, re-enabling SonarCloud's S1192 rule which flags repeated string literals.

**Why the suppression is correct:**
- 118 of 463 shell scripts (~25%) use ANSI color codes (`\033[0;3Xm`) as repeated string literals
- These are intentional UX patterns — colored terminal output for status messages
- Extracting to per-script constants (`RED='\033[0;31m'`) adds boilerplate with no safety benefit
- S1192 is a code smell rule, not a security rule — the risk of keeping the suppression is zero
- The original rationale in the comment is accurate and well-reasoned

**Contributor profile concerns (from issue body):**
- Generic PR template text not specific to the actual change
- Referenced "PR #77 review feedback" but PR #77 added the S1192 suppression — removing it contradicts the referenced PR's intent
- Account created 2023, 6 public repos, bio suggests automated activity

## Changes

- `sonar-project.properties`: Enhanced S1192 comment with explicit review reference (GH#17869) and quantified rationale (118/463 scripts). Makes the decision traceable and prevents future re-removal without context.

## Testing

- Self-assessed (docs/config change only, no code logic)
- Verified current file state has `e5` in the multicriteria list (restored by revert commit 70837c38a)
- Verified 118 scripts use ANSI color codes via `rg --count '\033\[' .agents/scripts/`

## Runtime Testing

Risk: **Low** — documentation/comment change in config file only. No code execution paths affected.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.192 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 5m and 4,372 tokens on this as a headless worker.