### PR TITLE
GH#17870: fix stat order to Linux-first across 6 scripts

### DIFF
--- a/.agents/scripts/mail-helper.sh
+++ b/.agents/scripts/mail-helper.sh
@@ -677,7 +677,8 @@ cmd_transport_status() {
 	echo "    Database:  $MAIL_DB"
 	if [[ -f "$MAIL_DB" ]]; then
 		local db_size
-		db_size=$(stat -f%z "$MAIL_DB" 2>/dev/null || stat -c%s "$MAIL_DB" 2>/dev/null || echo "0")
+		# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
+		db_size=$(stat -c%s "$MAIL_DB" 2>/dev/null || stat -f%z "$MAIL_DB" 2>/dev/null || echo "0")
 		echo "    Size:      $((db_size / 1024))KB"
 	else
 		echo "    Size:      (not initialized)"
@@ -1276,7 +1277,8 @@ prune_execute() {
 	db "$MAIL_DB" "VACUUM;"
 
 	local new_size_bytes
-	new_size_bytes=$(stat -f%z "$MAIL_DB" 2>/dev/null || stat -c%s "$MAIL_DB" 2>/dev/null || echo "0")
+	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
+	new_size_bytes=$(stat -c%s "$MAIL_DB" 2>/dev/null || stat -f%z "$MAIL_DB" 2>/dev/null || echo "0")
 	local new_size_kb=$((new_size_bytes / 1024))
 	local saved_kb=$((db_size_kb - new_size_kb))
 
@@ -1326,7 +1328,8 @@ cmd_prune() {
 	ensure_db
 
 	local db_size_bytes
-	db_size_bytes=$(stat -f%z "$MAIL_DB" 2>/dev/null || stat -c%s "$MAIL_DB" 2>/dev/null || echo "0")
+	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
+	db_size_bytes=$(stat -c%s "$MAIL_DB" 2>/dev/null || stat -f%z "$MAIL_DB" 2>/dev/null || echo "0")
 	local db_size_kb=$((db_size_bytes / 1024))
 
 	local report_output prunable archivable

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -1011,7 +1011,8 @@ _sessions_stats_entity_aware() {
 	active_sessions=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM matrix_room_sessions WHERE session_id != '';" 2>/dev/null || echo "0")
 	matrix_interactions=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM interactions WHERE channel = 'matrix';" 2>/dev/null || echo "0")
 	entity_count=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM entity_channels WHERE channel = 'matrix';" 2>/dev/null || echo "0")
-	db_size=$(stat -f%z "$db_path" 2>/dev/null || stat -c%s "$db_path" 2>/dev/null || echo "0")
+	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
+	db_size=$(stat -c%s "$db_path" 2>/dev/null || stat -f%z "$db_path" 2>/dev/null || echo "0")
 
 	echo "Total sessions:       ${total_sessions:-0}"
 	echo "Active sessions:      ${active_sessions:-0}"
@@ -1032,7 +1033,8 @@ _sessions_stats_legacy() {
 	active_sessions=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM sessions WHERE session_id != '';" 2>/dev/null || echo "0")
 	total_messages=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM message_log;" 2>/dev/null || echo "0")
 	context_bytes=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COALESCE(SUM(length(compacted_context)), 0) FROM sessions;" 2>/dev/null || echo "0")
-	db_size=$(stat -f%z "$db_path" 2>/dev/null || stat -c%s "$db_path" 2>/dev/null || echo "0")
+	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
+	db_size=$(stat -c%s "$db_path" 2>/dev/null || stat -f%z "$db_path" 2>/dev/null || echo "0")
 
 	echo "Total sessions:    ${total_sessions:-0} (legacy store)"
 	echo "Active sessions:   ${active_sessions:-0}"

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -103,8 +103,8 @@ get_active_worker_sessions() {
 	for logfile in /tmp/pulse-*.log; do
 		[[ -f "$logfile" ]] || continue
 		local file_mtime
-		# macOS stat syntax
-		file_mtime=$(stat -f '%m' "$logfile" 2>/dev/null || stat -c '%Y' "$logfile" 2>/dev/null || echo "0")
+		# Linux stat -c first (stat -f '%m' on Linux outputs filesystem info to stdout)
+		file_mtime=$(stat -c '%Y' "$logfile" 2>/dev/null || stat -f '%m' "$logfile" 2>/dev/null || echo "0")
 		if ((file_mtime > one_hour_ago)); then
 			# Extract session IDs from log content (UUIDs)
 			local found
@@ -144,7 +144,8 @@ file_size_bytes() {
 		echo "0"
 		return 0
 	fi
-	stat -f '%z' "$filepath" 2>/dev/null || stat -c '%s' "$filepath" 2>/dev/null || echo "0"
+	# Linux stat -c first (stat -f '%z' on Linux outputs filesystem info to stdout, not file size)
+	stat -c '%s' "$filepath" 2>/dev/null || stat -f '%z' "$filepath" 2>/dev/null || echo "0"
 	return 0
 }
 

--- a/.agents/scripts/opencode-sandbox-helper.sh
+++ b/.agents/scripts/opencode-sandbox-helper.sh
@@ -88,7 +88,8 @@ _latest_sandbox() {
 			local ver
 			ver=$(basename "$dir")
 			local mtime
-			mtime=$(stat -f '%m' "$dir" 2>/dev/null || stat -c '%Y' "$dir" 2>/dev/null || echo "0")
+			# Linux stat -c first (stat -f '%m' on Linux outputs filesystem info to stdout)
+			mtime=$(stat -c '%Y' "$dir" 2>/dev/null || stat -f '%m' "$dir" 2>/dev/null || echo "0")
 			if [[ "$mtime" -gt "$latest_time" ]]; then
 				latest_time="$mtime"
 				latest="$ver"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3242,9 +3242,10 @@ cleanup_worktrees() {
 				fi
 
 				# Get worktree creation time from .git file mtime
+				# Linux stat -c first (stat -f '%m' on Linux outputs filesystem info to stdout)
 				local wt_created=0
 				if [[ -f "$wt_path_age/.git" ]]; then
-					wt_created=$(stat -f '%m' "$wt_path_age/.git" 2>/dev/null) || wt_created=0
+					wt_created=$(stat -c '%Y' "$wt_path_age/.git" 2>/dev/null || stat -f '%m' "$wt_path_age/.git" 2>/dev/null) || wt_created=0
 				fi
 				[[ "$wt_created" -eq 0 ]] && continue
 				local wt_age_secs=$((now_epoch - wt_created))
@@ -4009,7 +4010,8 @@ normalize_active_issue_assignments() {
 			local worker_log="/tmp/pulse-${safe_slug_check}-${stale_num}.log"
 			if [[ -f "$worker_log" ]]; then
 				local log_mtime
-				log_mtime=$(stat -f '%m' "$worker_log" 2>/dev/null) || log_mtime=0
+				# Linux stat -c first (stat -f '%m' on Linux outputs filesystem info to stdout)
+				log_mtime=$(stat -c '%Y' "$worker_log" 2>/dev/null || stat -f '%m' "$worker_log" 2>/dev/null) || log_mtime=0
 				if [[ $((now_epoch - log_mtime)) -lt 600 ]]; then
 					continue
 				fi

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -247,7 +247,8 @@ _smwm_download_images() {
 
 		if curl -sS -L --max-time 10 -o "${page_images_dir}/${img_filename}" "$img_src" 2>/dev/null; then
 			local file_size
-			file_size=$(stat -f%z "${page_images_dir}/${img_filename}" 2>/dev/null || echo "0")
+			# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
+			file_size=$(stat -c%s "${page_images_dir}/${img_filename}" 2>/dev/null || stat -f%z "${page_images_dir}/${img_filename}" 2>/dev/null || echo "0")
 			if [[ $file_size -gt 1024 ]]; then
 				printf '%s\n' "${img_filename}|${img_src}|${img_alt}" >>"${_out_images}"
 			else


### PR DESCRIPTION
## Summary

On Linux, `stat -f` means filesystem status (not format string). So `stat -f '%z'` and `stat -f '%m'` output multi-line filesystem info to **stdout** before failing with exit code 1. When captured in `$()`, this corrupts variables used in arithmetic, causing hard exits under `set -Eeuo pipefail`.

The fix is to swap the fallback chain: `stat -c` (GNU/Linux) first, `stat -f` (BSD/macOS) second. On macOS, `stat -c` is an illegal option → stderr only (suppressed by `2>/dev/null`), no stdout pollution → falls through to `stat -f` cleanly.

This matches the existing correct pattern already used in `headless-runtime-helper.sh:262`.

## Files Changed

- `opencode-db-archive.sh`: `file_size_bytes()` and `get_active_worker_sessions()` — the primary bug causing DB archiving to never complete on Linux
- `opencode-sandbox-helper.sh`: `_latest_sandbox()` mtime check
- `pulse-wrapper.sh`: worktree `.git` mtime and worker log mtime (also added missing fallback)
- `mail-helper.sh`: 3× db size checks
- `matrix-dispatch-helper.sh`: 2× db size checks
- `site-crawler-helper.sh`: downloaded image size check (also added missing fallback)

## Testing

- ShellCheck: zero violations on all 6 modified files
- Pattern verified against `headless-runtime-helper.sh:262` (existing correct implementation)
- macOS: `stat -c` fails silently (stderr only), `stat -f` succeeds — correct result
- Linux: `stat -c` succeeds immediately — correct result, no stdout pollution

## Runtime Testing

Risk: **Low** — shell utility functions, no auth/payment/data-deletion paths. Self-assessed.

Resolves #17870


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.193 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 9m and 14,517 tokens on this as a headless worker.