### PR TITLE
GH#17902: fix path quoting in systemd unit generation in repo-sync-helper.sh

### DIFF
--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -650,12 +650,12 @@ After=network.target
 [Service]
 Type=oneshot
 KillMode=process
-ExecStart=/bin/bash -lc '${script_path} check'
+ExecStart=/bin/bash -lc '\"${script_path}\" check'
 TimeoutStartSec=300
 Nice=10
 IOSchedulingClass=idle
-StandardOutput=append:${LOG_FILE}
-StandardError=append:${LOG_FILE}
+StandardOutput=\"append:${LOG_FILE}\"
+StandardError=\"append:${LOG_FILE}\"
 " >"$service_file"
 
 	printf '%s' "[Unit]


### PR DESCRIPTION
## Summary

Fixes two path-quoting issues in the systemd unit file generated by `_enable_systemd()` in `.agents/scripts/repo-sync-helper.sh`, as identified in PR #17892 review feedback.

## Changes

**File**: `.agents/scripts/repo-sync-helper.sh` (lines 653, 657-658)

- `ExecStart`: Escaped double-quotes around `${script_path}` so the systemd unit receives `"<path>" check`, correctly handling paths with spaces
- `StandardOutput`/`StandardError`: Escaped double-quotes around the `append:<path>` values so systemd correctly parses log file paths containing spaces

## Before / After

```diff
-ExecStart=/bin/bash -lc '${script_path} check'
+ExecStart=/bin/bash -lc '\"${script_path}\" check'
 TimeoutStartSec=300
 Nice=10
 IOSchedulingClass=idle
-StandardOutput=append:${LOG_FILE}
-StandardError=append:${LOG_FILE}
+StandardOutput=\"append:${LOG_FILE}\"
+StandardError=\"append:${LOG_FILE}\"
```

The escaped `\"` inside the outer double-quoted `printf` string produces literal `"` characters in the written systemd unit file.

## Runtime Testing

**Risk level**: Low — documentation/config generation change. No runtime environment needed; the fix is verified by shellcheck (SC1078/SC1079/SC2027/SC2086 warnings resolved) and manual inspection of the generated unit file content.

`self-assessed`

## Verification

```bash
shellcheck .agents/scripts/repo-sync-helper.sh
# Only SC1091 info-level (pre-existing sourced file warnings) — no warnings on modified lines
```

Resolves #17902

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.196 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 4m and 3,375 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved systemd service unit file generation to ensure proper handling of script execution and log file output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->