### PR TITLE
GH#17910: fix check-generator-rules.py argument validation and regex robustness

### DIFF
--- a/.agents/scripts/check-generator-rules.py
+++ b/.agents/scripts/check-generator-rules.py
@@ -9,12 +9,15 @@ import re
 import sys
 from pathlib import Path
 
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} <target_file>", file=sys.stderr)
+    sys.exit(1)
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8", errors="replace")
 
 
 def extract_block(name: str) -> str:
-    m = re.search(rf"{name}\s*=\s*\[(.*?)\]\n", text, re.S)
+    m = re.search(rf"{name}\s*=\s*\[(.*?)\]", text, re.S)
     return m.group(1) if m else ""
 
 


### PR DESCRIPTION
## Summary

Addresses two medium-severity review findings from PR #17851 on `.agents/scripts/check-generator-rules.py`.

### Changes

**1. Argument validation (line 12)**
Added `sys.argv` length check before accessing `sys.argv[1]`. Without this, calling the script with no arguments raises an `IndexError`. Now prints usage to stderr and exits 1.

**2. Regex robustness (line 20)**
Removed the mandatory `\n` after the closing bracket in the `extract_block` regex. The original pattern `\]\n` fails when the file has trailing whitespace or comments on the same line as the closing bracket. The updated pattern `\]` matches correctly in all cases.

### Testing

- No-args: prints `Usage: ... <target_file>` to stderr, exits 1 ✓
- Valid file arg: processes correctly, regex extracts blocks as expected ✓
- Self-assessed (low risk: script logic fix, no runtime dependencies)

## Runtime Testing

**Risk level**: Low — script logic fix, no external dependencies, no state changes.
**Verification**: Manual execution of both code paths confirmed correct behaviour.

Resolves #17910

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.196 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 2m and 2,142 tokens on this as a headless worker.