### PR TITLE
t1935: feat(pulse): deterministic blocked-by resolution via cached dependency graph

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -365,6 +365,8 @@ COMPLEXITY_MD_MIN_LINES="${COMPLEXITY_MD_MIN_LINES:-50}"                        
 WORKER_WATCHDOG_HELPER="${SCRIPT_DIR}/worker-watchdog.sh"
 PULSE_HEALTH_FILE="${HOME}/.aidevops/logs/pulse-health.json"
 FAST_FAIL_STATE_FILE="${HOME}/.aidevops/.agent-workspace/supervisor/fast-fail-counter.json"
+DEP_GRAPH_CACHE_FILE="${DEP_GRAPH_CACHE_FILE:-${HOME}/.aidevops/.agent-workspace/supervisor/dep-graph-cache.json}" # Dependency graph cache (t1935)
+DEP_GRAPH_CACHE_TTL_SECS="${DEP_GRAPH_CACHE_TTL_SECS:-300}"                                                        # Rebuild graph if older than 5 min (t1935)
 
 # Log sharding: hot/cold split + append-only cycle index (t1886)
 #
@@ -9241,11 +9243,256 @@ _fast_fail_prune_expired_locked() {
 # issues getting labeled "stuck".
 
 #######################################
-# Blocked-by enforcement (t1927)
+# Dependency graph cache (t1935)
+#
+# Builds a JSON cache of all blocked-by relationships across pulse repos.
+# The cache is rebuilt once per cycle (or when stale) so that
+# is_blocked_by_unresolved() can answer without any live API calls.
+#
+# Cache format (DEP_GRAPH_CACHE_FILE):
+# {
+#   "built_at": "<ISO timestamp>",
+#   "repos": {
+#     "owner/repo": {
+#       "open_issues": [<number>, ...],
+#       "task_to_issue": { "tNNN": <number>, ... },
+#       "blocked_by": {
+#         "<issue_number>": {
+#           "task_ids": ["NNN", ...],
+#           "issue_nums": ["NNN", ...]
+#         }
+#       }
+#     }
+#   }
+# }
+#
+# Returns: 0 always (non-fatal — cache miss falls back to live API)
+#######################################
+build_dependency_graph_cache() {
+	local cache_file="$DEP_GRAPH_CACHE_FILE"
+	local ttl_secs="$DEP_GRAPH_CACHE_TTL_SECS"
+
+	# Skip rebuild if cache is fresh
+	if [[ -f "$cache_file" ]]; then
+		local cache_age
+		cache_age=$(($(date +%s) - $(date -r "$cache_file" +%s 2>/dev/null || echo 0)))
+		if [[ "$cache_age" -lt "$ttl_secs" ]]; then
+			echo "[pulse-wrapper] dep-graph-cache: cache fresh (${cache_age}s < ${ttl_secs}s TTL), skipping rebuild" >>"$LOGFILE"
+			return 0
+		fi
+	fi
+
+	echo "[pulse-wrapper] dep-graph-cache: building dependency graph cache (t1935)" >>"$LOGFILE"
+	local build_start
+	build_start=$(date +%s)
+
+	local repos_json
+	repos_json=$(jq -c '.initialized_repos[] | select(.pulse == true and (.local_only != true))' \
+		"${HOME}/.config/aidevops/repos.json" 2>/dev/null) || repos_json=""
+	if [[ -z "$repos_json" ]]; then
+		echo "[pulse-wrapper] dep-graph-cache: no pulse repos found, skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Build the graph JSON incrementally
+	local graph_json
+	graph_json=$(printf '{"built_at":"%s","repos":{}}' "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+
+	while IFS= read -r repo_entry; do
+		[[ -n "$repo_entry" ]] || continue
+		local slug
+		slug=$(printf '%s' "$repo_entry" | jq -r '.slug // empty' 2>/dev/null)
+		[[ -n "$slug" ]] || continue
+
+		# Fetch all open issues with their bodies in one API call
+		local issues_json
+		issues_json=$(gh issue list --repo "$slug" --state open --limit 200 \
+			--json number,title,body,labels 2>/dev/null) || issues_json='[]'
+
+		local open_nums task_to_issue blocked_by_map
+		open_nums='[]'
+		task_to_issue='{}'
+		blocked_by_map='{}'
+
+		# Parse each issue: extract open issue numbers, task→issue mapping, and blocked-by refs
+		while IFS= read -r issue_json; do
+			[[ -n "$issue_json" ]] || continue
+			local num title body
+			num=$(printf '%s' "$issue_json" | jq -r '.number // empty' 2>/dev/null)
+			title=$(printf '%s' "$issue_json" | jq -r '.title // ""' 2>/dev/null)
+			body=$(printf '%s' "$issue_json" | jq -r '.body // ""' 2>/dev/null)
+			[[ "$num" =~ ^[0-9]+$ ]] || continue
+
+			# Accumulate open issue numbers
+			local _new_open_nums
+			_new_open_nums=$(printf '%s' "$open_nums" | jq --argjson n "$num" '. + [$n]' 2>/dev/null) || _new_open_nums=""
+			[[ -n "$_new_open_nums" ]] && open_nums="$_new_open_nums"
+
+			# Extract task ID from title (e.g. "t1935: ..." → "1935")
+			local task_id_in_title
+			task_id_in_title=$(printf '%s' "$title" | grep -oE '^t([0-9]+):' | grep -oE '[0-9]+' || true)
+			if [[ -n "$task_id_in_title" ]]; then
+				task_to_issue=$(printf '%s' "$task_to_issue" |
+					jq --arg tid "$task_id_in_title" --argjson n "$num" '.[$tid] = $n' 2>/dev/null) || true
+			fi
+
+			# Extract blocked-by task IDs and issue numbers from body
+			local blocker_tids blocker_nums
+			blocker_tids=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ]by[: ]*t([0-9]+)' | grep -oE '[0-9]+' || true)
+			blocker_nums=$(printf '%s' "$body" | grep -ioE '[Bb]locked[- ]by[: ]*#([0-9]+)' | grep -oE '[0-9]+' || true)
+
+			if [[ -n "$blocker_tids" || -n "$blocker_nums" ]]; then
+				local tid_arr num_arr
+				tid_arr=$(printf '%s' "$blocker_tids" | jq -Rs 'split("\n") | map(select(length > 0))' 2>/dev/null) || tid_arr='[]'
+				num_arr=$(printf '%s' "$blocker_nums" | jq -Rs 'split("\n") | map(select(length > 0))' 2>/dev/null) || num_arr='[]'
+				blocked_by_map=$(printf '%s' "$blocked_by_map" |
+					jq --arg n "$num" --argjson tids "$tid_arr" --argjson nums "$num_arr" \
+						'.[$n] = {"task_ids": $tids, "issue_nums": $nums}' 2>/dev/null) || true
+			fi
+		done < <(printf '%s' "$issues_json" | jq -c '.[]' 2>/dev/null)
+
+		# Merge repo data into graph
+		graph_json=$(printf '%s' "$graph_json" |
+			jq --arg slug "$slug" \
+				--argjson open "$open_nums" \
+				--argjson t2i "$task_to_issue" \
+				--argjson bb "$blocked_by_map" \
+				'.repos[$slug] = {"open_issues": $open, "task_to_issue": $t2i, "blocked_by": $bb}' \
+				2>/dev/null) || true
+
+	done <<<"$repos_json"
+
+	# Atomically write cache (write to tmp then mv)
+	local tmp_file
+	tmp_file="${cache_file}.tmp.$$"
+	mkdir -p "$(dirname "$cache_file")" 2>/dev/null || true
+	if printf '%s\n' "$graph_json" >"$tmp_file"; then
+		mv "$tmp_file" "$cache_file" || rm -f "$tmp_file"
+	else
+		rm -f "$tmp_file"
+	fi
+
+	local build_end build_dur
+	build_end=$(date +%s)
+	build_dur=$((build_end - build_start))
+	echo "[pulse-wrapper] dep-graph-cache: built in ${build_dur}s → ${cache_file}" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Refresh blocked status from dependency graph (t1935)
+#
+# Reads the cached dependency graph and relabels issues from
+# status:blocked → status:available when all their blockers are closed.
+# Runs once per cycle with zero API calls for the resolution check
+# (the graph already contains open issue numbers).
+#
+# Returns: 0 always (non-fatal)
+#######################################
+refresh_blocked_status_from_graph() {
+	local cache_file="$DEP_GRAPH_CACHE_FILE"
+
+	if [[ ! -f "$cache_file" ]]; then
+		echo "[pulse-wrapper] dep-graph-cache: no cache file, skipping blocked-status refresh" >>"$LOGFILE"
+		return 0
+	fi
+
+	local graph_json
+	graph_json=$(cat "$cache_file" 2>/dev/null) || return 0
+	[[ -n "$graph_json" ]] || return 0
+
+	local unblocked_count=0
+
+	# Iterate repos in the graph
+	local slugs
+	slugs=$(printf '%s' "$graph_json" | jq -r '.repos | keys[]' 2>/dev/null) || slugs=""
+	[[ -n "$slugs" ]] || return 0
+
+	while IFS= read -r slug; do
+		[[ -n "$slug" ]] || continue
+
+		local repo_data open_issues_json task_to_issue_json blocked_by_json
+		repo_data=$(printf '%s' "$graph_json" | jq -c --arg s "$slug" '.repos[$s]' 2>/dev/null) || continue
+		open_issues_json=$(printf '%s' "$repo_data" | jq -c '.open_issues // []' 2>/dev/null) || open_issues_json='[]'
+		task_to_issue_json=$(printf '%s' "$repo_data" | jq -c '.task_to_issue // {}' 2>/dev/null) || task_to_issue_json='{}'
+		blocked_by_json=$(printf '%s' "$repo_data" | jq -c '.blocked_by // {}' 2>/dev/null) || blocked_by_json='{}'
+
+		# For each issue that has blocked-by entries, check if all blockers are resolved
+		local blocked_issue_nums
+		blocked_issue_nums=$(printf '%s' "$blocked_by_json" | jq -r 'keys[]' 2>/dev/null) || blocked_issue_nums=""
+		[[ -n "$blocked_issue_nums" ]] || continue
+
+		while IFS= read -r issue_num; do
+			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
+
+			local entry_json
+			entry_json=$(printf '%s' "$blocked_by_json" | jq -c --arg n "$issue_num" '.[$n]' 2>/dev/null) || continue
+
+			local all_resolved=true
+
+			# Check task ID blockers against task_to_issue map + open_issues
+			local blocker_tids
+			blocker_tids=$(printf '%s' "$entry_json" | jq -r '.task_ids[]' 2>/dev/null) || blocker_tids=""
+			while IFS= read -r tid; do
+				[[ -n "$tid" ]] || continue
+				local blocker_issue_num
+				blocker_issue_num=$(printf '%s' "$task_to_issue_json" | jq -r --arg t "$tid" '.[$t] // empty' 2>/dev/null)
+				if [[ -n "$blocker_issue_num" ]]; then
+					# Check if blocker issue is in open_issues list
+					local is_open
+					is_open=$(printf '%s' "$open_issues_json" | jq --argjson n "$blocker_issue_num" 'index($n) != null' 2>/dev/null) || is_open="false"
+					if [[ "$is_open" == "true" ]]; then
+						all_resolved=false
+						break
+					fi
+				fi
+				# If task not in map, assume resolved (issue may have been closed and pruned)
+			done <<<"$blocker_tids"
+
+			# Check issue number blockers against open_issues
+			if [[ "$all_resolved" == "true" ]]; then
+				local blocker_nums
+				blocker_nums=$(printf '%s' "$entry_json" | jq -r '.issue_nums[]' 2>/dev/null) || blocker_nums=""
+				while IFS= read -r bnum; do
+					[[ "$bnum" =~ ^[0-9]+$ ]] || continue
+					local is_open
+					is_open=$(printf '%s' "$open_issues_json" | jq --argjson n "$bnum" 'index($n) != null' 2>/dev/null) || is_open="false"
+					if [[ "$is_open" == "true" ]]; then
+						all_resolved=false
+						break
+					fi
+				done <<<"$blocker_nums"
+			fi
+
+			# If all blockers resolved, relabel status:blocked → status:available
+			if [[ "$all_resolved" == "true" ]]; then
+				# Verify the issue actually has status:blocked before making API call
+				local current_labels
+				current_labels=$(gh issue view "$issue_num" --repo "$slug" \
+					--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || current_labels=""
+				if [[ ",${current_labels}," == *",status:blocked,"* ]]; then
+					gh issue edit "$issue_num" --repo "$slug" \
+						--remove-label "status:blocked" --add-label "status:available" 2>/dev/null || true
+					echo "[pulse-wrapper] dep-graph-cache: unblocked #${issue_num} in ${slug} — all blockers resolved (t1935)" >>"$LOGFILE"
+					unblocked_count=$((unblocked_count + 1))
+				fi
+			fi
+		done <<<"$blocked_issue_nums"
+	done <<<"$slugs"
+
+	if [[ "$unblocked_count" -gt 0 ]]; then
+		echo "[pulse-wrapper] dep-graph-cache: refresh complete — unblocked ${unblocked_count} issue(s) (t1935)" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+#######################################
+# Blocked-by enforcement (t1927, enhanced t1935)
 #
 # Parses the issue body for blocked-by dependencies and checks whether
-# the blocking task/issue is still open. If the blocker is unresolved,
-# dispatch is skipped.
+# the blocking task/issue is still open. Uses the cached dependency graph
+# (built once per cycle) for zero-API-call resolution. Falls back to live
+# API calls only when the cache is absent or the blocker is not found in it.
 #
 # Patterns matched:
 #   - "blocked-by:tNNN" or "blocked-by: tNNN" (TODO.md format)
@@ -9275,17 +9522,64 @@ is_blocked_by_unresolved() {
 	blocker_task_ids=$(printf '%s' "$issue_body" | grep -ioE '[Bb]locked[- ]by[: ]*t([0-9]+)' | grep -oE '[0-9]+' || true)
 	blocker_issue_nums=$(printf '%s' "$issue_body" | grep -ioE '[Bb]locked[- ]by[: ]*#([0-9]+)' | grep -oE '[0-9]+' || true)
 
-	# Check task ID blockers — resolve tNNN to GitHub issue via TODO.md search
-	# or grep recent issues. For simplicity, search issue titles.
+	# No blocked-by references → not blocked
+	if [[ -z "$blocker_task_ids" && -z "$blocker_issue_nums" ]]; then
+		return 1
+	fi
+
+	# Attempt cache-based resolution (t1935): read the dependency graph cache
+	# built once per cycle. If the cache is present and fresh, use it to
+	# resolve blocker state without any API calls.
+	local cache_file="$DEP_GRAPH_CACHE_FILE"
+	local use_cache=false
+	local graph_json="" open_issues_json="" task_to_issue_json=""
+
+	if [[ -f "$cache_file" ]]; then
+		local cache_age
+		cache_age=$(($(date +%s) - $(date -r "$cache_file" +%s 2>/dev/null || echo 0)))
+		# Accept cache up to 2× TTL to tolerate slow rebuild cycles
+		if [[ "$cache_age" -lt $((DEP_GRAPH_CACHE_TTL_SECS * 2)) ]]; then
+			graph_json=$(cat "$cache_file" 2>/dev/null) || graph_json=""
+			if [[ -n "$graph_json" ]]; then
+				open_issues_json=$(printf '%s' "$graph_json" |
+					jq -c --arg s "$repo_slug" '.repos[$s].open_issues // []' 2>/dev/null) || open_issues_json='[]'
+				task_to_issue_json=$(printf '%s' "$graph_json" |
+					jq -c --arg s "$repo_slug" '.repos[$s].task_to_issue // {}' 2>/dev/null) || task_to_issue_json='{}'
+				use_cache=true
+			fi
+		fi
+	fi
+
+	# Check task ID blockers
 	if [[ -n "$blocker_task_ids" ]]; then
 		while IFS= read -r task_id; do
 			[[ -n "$task_id" ]] || continue
-			# Search for an open issue with this task ID in the title
+
+			if [[ "$use_cache" == "true" ]]; then
+				# Cache path: look up task→issue mapping, then check open_issues
+				local blocker_issue_num
+				blocker_issue_num=$(printf '%s' "$task_to_issue_json" |
+					jq -r --arg t "$task_id" '.[$t] // empty' 2>/dev/null)
+				if [[ -n "$blocker_issue_num" ]]; then
+					local is_open
+					is_open=$(printf '%s' "$open_issues_json" |
+						jq --argjson n "$blocker_issue_num" 'index($n) != null' 2>/dev/null) || is_open="false"
+					if [[ "$is_open" == "true" ]]; then
+						echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id}=#${blocker_issue_num} (cache: open) — skipping dispatch (t1935)" >>"$LOGFILE"
+						return 0
+					fi
+					# Blocker issue found in map but not in open list → resolved
+					continue
+				fi
+				# Task not in map → fall through to live API (may be a new issue)
+			fi
+
+			# Live API fallback: search for an open issue with this task ID in the title
 			local blocker_state
 			blocker_state=$(gh issue list --repo "$repo_slug" --state open \
 				--search "t${task_id} in:title" --json number,state --jq '.[0].state // ""' 2>/dev/null) || blocker_state=""
 			if [[ "$blocker_state" == "OPEN" ]]; then
-				echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id} (still open) — skipping dispatch (t1927)" >>"$LOGFILE"
+				echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by t${task_id} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
 				return 0
 			fi
 		done <<<"$blocker_task_ids"
@@ -9295,11 +9589,26 @@ is_blocked_by_unresolved() {
 	if [[ -n "$blocker_issue_nums" ]]; then
 		while IFS= read -r blocker_num; do
 			[[ -n "$blocker_num" ]] || continue
+
+			if [[ "$use_cache" == "true" ]]; then
+				# Cache path: check if blocker_num is in open_issues list
+				local is_open
+				is_open=$(printf '%s' "$open_issues_json" |
+					jq --argjson n "$blocker_num" 'index($n) != null' 2>/dev/null) || is_open="false"
+				if [[ "$is_open" == "true" ]]; then
+					echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (cache: open) — skipping dispatch (t1935)" >>"$LOGFILE"
+					return 0
+				fi
+				# Not in open list → resolved (closed or never existed)
+				continue
+			fi
+
+			# Live API fallback
 			local blocker_state
 			blocker_state=$(gh issue view "$blocker_num" --repo "$repo_slug" \
 				--json state --jq '.state // ""' 2>/dev/null) || blocker_state=""
 			if [[ "$blocker_state" == "OPEN" ]]; then
-				echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (still open) — skipping dispatch (t1927)" >>"$LOGFILE"
+				echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} blocked by #${blocker_num} (live: open) — skipping dispatch (t1927)" >>"$LOGFILE"
 				return 0
 			fi
 		done <<<"$blocker_issue_nums"
@@ -11167,6 +11476,26 @@ main() {
 	# LLM failed to execute merge steps or the prefetch showed 0 PRs.
 	run_stage_with_timeout "deterministic_merge_pass" "$PRE_RUN_STAGE_TIMEOUT" \
 		merge_ready_prs_all_repos || true
+
+	# Dependency graph cache (t1935): build once per cycle so that
+	# is_blocked_by_unresolved() can resolve blocker state without API calls.
+	# Runs before the fill floor so the cache is warm when dispatch checks run.
+	if [[ -f "$STOP_FLAG" ]]; then
+		echo "[pulse-wrapper] Stop flag appeared — skipping dependency graph cache build" >>"$LOGFILE"
+	else
+		run_stage_with_timeout "build_dependency_graph_cache" "$PRE_RUN_STAGE_TIMEOUT" \
+			build_dependency_graph_cache || true
+	fi
+
+	# Blocked-status refresh (t1935): relabel status:blocked → status:available
+	# for issues whose blockers are now closed. Uses the freshly built cache —
+	# zero API calls for the resolution check, one API call per unblocked issue.
+	if [[ -f "$STOP_FLAG" ]]; then
+		echo "[pulse-wrapper] Stop flag appeared — skipping blocked-status refresh" >>"$LOGFILE"
+	else
+		run_stage_with_timeout "refresh_blocked_status_from_graph" "$PRE_RUN_STAGE_TIMEOUT" \
+			refresh_blocked_status_from_graph || true
+	fi
 
 	# Deterministic fill floor runs EVERY cycle — before the LLM session,
 	# not after. This ensures workers are dispatched every 2-min cycle


### PR DESCRIPTION
## Summary

Implements a cached dependency graph for blocked-by resolution in the pulse, eliminating per-dispatch API calls and enabling automatic `status:blocked→status:available` relabeling every 2-min cycle.

## What

- **`build_dependency_graph_cache()`**: Builds a JSON cache of all blocked-by relationships across pulse repos once per cycle (5-min TTL). One bulk `gh issue list` per repo replaces N per-dispatch API calls.
- **`refresh_blocked_status_from_graph()`**: Reads the cache and relabels `status:blocked→status:available` for issues whose blockers are now closed. Zero API calls for resolution check; one API call per unblocked issue.
- **Enhanced `is_blocked_by_unresolved()`**: Reads from cache first (zero API calls), falls back to live API only when cache is absent or task not found in the task→issue map.
- **Main cycle hooks**: merge → build graph → refresh blocked → fill floor.
- **Constants**: `DEP_GRAPH_CACHE_FILE` and `DEP_GRAPH_CACHE_TTL_SECS` (default 300s).

## Why

Previously, `is_blocked_by_unresolved()` made 1-2 live `gh` API calls per dispatch candidate per cycle. With 50+ issues in the backlog, this adds significant latency and rate-limit pressure. More critically, `status:blocked` issues were only unblocked when the LLM supervisor ran (~1h delay), not every 2-min cycle.

## Files Changed

- EDIT: `.agents/scripts/pulse-wrapper.sh` — added 337 lines (2 new functions, enhanced existing function, 2 cycle hooks, 2 constants)

## Runtime Testing

- **Risk level**: Medium (polling loop, state machine labels)
- **Verification**: self-assessed — logic is additive (cache miss falls back to existing live API path), no existing behavior removed
- **ShellCheck**: zero violations on new code (full-file check hits RSS limit on 13K-line file; new functions checked in isolation)

Resolves #17942


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.196 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 9m and 17,598 tokens on this as a headless worker.