### PR TITLE
t1937: Fix stub issue bodies and improve pulse stub detection

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -9,7 +9,8 @@
 #
 # Options:
 #   --title "Task title"       Task title for GitHub/GitLab issue (required unless --batch)
-#   --description "Details"    Task description (optional)
+#   --description "Details"    Task description (required for issue creation unless
+#                              a brief file exists at todo/tasks/{task_id}-brief.md)
 #   --labels "label1,label2"   Comma-separated labels (optional)
 #   --count N                  Allocate N consecutive IDs (default: 1)
 #                              Creates one GitHub/GitLab issue per ID using
@@ -743,13 +744,16 @@ _compose_issue_body() {
 			body="## Task"
 			body="$body"$'\n\n'"$brief_what"
 		else
-			log_warn "No --description provided and no brief file found — issue body will lack detail. Pass --description for rich issue content."
-			local desc_part
-			desc_part=$(printf '%s' "$title" | sed 's/^t[0-9]*: *//')
-			body="## Task"
-			body="$body"$'\n\n'"$desc_part"
-			body="$body"$'\n\n'"---"
-			body="$body"$'\n'"*Created by claim-task-id.sh (no description provided — enrich before dispatch)*"
+			# t1937: No description and no brief file — refuse to create a stub issue.
+			# The task ID is already secured; the issue should be created later when
+			# the brief is written (via issue-sync-helper.sh push or manually).
+			# Returning empty body signals create_github_issue() to skip creation.
+			log_error "No --description provided and no brief file found at todo/tasks/${task_id}-brief.md"
+			log_error "Issue creation skipped — create the issue after writing the brief:"
+			log_error "  issue-sync-helper.sh push ${task_id}"
+			log_error "  OR: gh issue create --title \"${title}\" --body \"<description>\""
+			echo ""
+			return 1
 		fi
 	fi
 
@@ -794,8 +798,15 @@ create_github_issue() {
 	# Fallback: bare issue creation with structured body
 	local gh_args=(issue create --title "$title")
 
-	local body
-	body=$(_compose_issue_body "$title" "$description")
+	local body=""
+	local compose_rc=0
+	body=$(_compose_issue_body "$title" "$description") || compose_rc=$?
+	# t1937: If body composition failed (no description + no brief), skip issue creation.
+	# The task ID is already secured — issue can be created later with proper content.
+	if [[ $compose_rc -ne 0 || -z "$body" ]]; then
+		log_warn "Skipping issue creation — no description available. Task ID is secured."
+		return 1
+	fi
 	gh_args+=(--body "$body")
 
 	# Append session origin label (origin:worker or origin:interactive)

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -9843,13 +9843,21 @@ dispatch_deterministic_fill_floor() {
 			continue
 		fi
 
-		# t1899: Skip issues with placeholder/empty bodies — dispatching a
+		# t1899/t1937: Skip issues with placeholder/empty bodies — dispatching a
 		# worker to an undescribed issue wastes a session. The body check is
 		# a single API call cached for the candidate loop iteration.
+		# Detects both the legacy GitLab stub and the current claim-task-id.sh
+		# stub marker ("no description provided — enrich before dispatch").
 		local issue_body
 		issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body -q '.body' 2>/dev/null || echo "")
 		if [[ -z "$issue_body" || "$issue_body" == "Task created via claim-task-id.sh" || "$issue_body" == "null" ]]; then
 			echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — placeholder/empty issue body, needs enrichment before dispatch" >>"$LOGFILE"
+			continue
+		fi
+		# t1937: Detect the current claim-task-id.sh stub marker embedded in
+		# structured bodies (## Task\n\n<title>\n\n---\n*Created by claim-task-id.sh ...*)
+		if [[ "$issue_body" == *"no description provided — enrich before dispatch"* ]]; then
+			echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — claim-task-id.sh stub body, needs enrichment before dispatch" >>"$LOGFILE"
 			continue
 		fi
 


### PR DESCRIPTION
## Summary

- **claim-task-id.sh**: Refuse to create GitHub issues when no `--description` is provided and no brief file exists at `todo/tasks/{task_id}-brief.md`. The task ID is still secured via CAS; the issue can be created later with proper content via `issue-sync-helper.sh push` or `gh issue create`.
- **pulse-wrapper.sh**: Add detection for the current stub marker text (`"no description provided — enrich before dispatch"`) alongside the legacy stub check. Prevents dispatching workers to undescribed issues that waste tokens.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/claim-task-id.sh` | `_compose_issue_body()`: return error when no description source available; `create_github_issue()`: handle compose failure by skipping issue creation |
| `.agents/scripts/pulse-wrapper.sh` | Add second stub body check for current marker text |

## Testing

- `shellcheck .agents/scripts/claim-task-id.sh` — clean (SC1091 info only)
- Searched all open issues for stub bodies — only #17955 (this task's own issue, now backfilled)
- 8 closed issues historically had stub bodies — confirms the pattern was real

## Runtime Testing

**Risk: Low** — changes to issue creation flow and dispatch filtering. No payment, auth, or data deletion paths.
**Verification: self-assessed** — shellcheck clean, logic review of both paths.

Resolves #17955


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.200 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 18m and 10,247 tokens on this with the user in an interactive session.