### PR TITLE
t1938: Fix simplification gate race — skip already-dispatched issues

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -7597,6 +7597,25 @@ _issue_targets_large_files() {
 		return 1
 	fi
 
+	# GH#17958: Skip if issue is already dispatched (worker actively running).
+	# A second pulse cycle can re-evaluate the same issue and post a spurious
+	# simplification comment even though the worker is mid-implementation.
+	# The gate should only fire for issues that haven't been claimed yet.
+	if [[ ",$issue_labels," == *",status:queued,"* ]] ||
+		[[ ",$issue_labels," == *",status:in-progress,"* ]]; then
+		return 1
+	fi
+	# Also skip if assigned with origin:worker — worker was dispatched even if
+	# status label hasn't been applied yet (race window between assign and label).
+	if [[ ",$issue_labels," == *",origin:worker,"* ]]; then
+		local assignee_count
+		assignee_count=$(gh issue view "$issue_number" --repo "$repo_slug" \
+			--json assignees --jq '.assignees | length' 2>/dev/null) || assignee_count="0"
+		if [[ "$assignee_count" -gt 0 ]]; then
+			return 1
+		fi
+	fi
+
 	# Extract file paths from "EDIT:" and "Files to Modify" patterns in body.
 	# Patterns: "EDIT: path/to/file.sh:123-456", "- EDIT: path/to/file"
 	local file_paths


### PR DESCRIPTION
## Summary

- Fix race condition where `_issue_targets_large_files()` fires on issues that already have a worker running, posting spurious `needs-simplification` comments and labels
- Add early-return guards for `status:queued`, `status:in-progress`, and `origin:worker` + assignee

## Problem

Observed on GH#17955: worker was assigned at 22:44:38 and created PR at 22:48:18, but a second pulse cycle ran `_issue_targets_large_files()` at 22:48:22 — adding the `needs-simplification` label and comment to an issue that was already being successfully worked on.

The gate checked for the `needs-simplification` label (to avoid re-checking) but didn't check whether the issue was already dispatched/in-progress.

## Fix

Added three early-return guards in `_issue_targets_large_files()` after the existing label checks:

1. `status:queued` label present → return 1 (skip gate)
2. `status:in-progress` label present → return 1 (skip gate)
3. `origin:worker` label + assignee present → return 1 (skip gate, covers the race window between assign and status label)

The gate still fires normally for unassigned/new issues targeting large files.

## Runtime Testing

- **Risk**: Low — gate is a pre-dispatch check, not a data path
- **Verification**: `bash -n` syntax check passes; logic review confirms correct early-return semantics

Resolves #17958

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.202 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 5m and 6,848 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue processing workflow by preventing file simplification from being reapplied to issues that are already queued, in progress, or currently assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->