### PR TITLE
feat: run routines repo setup in non-interactive mode (aidevops update)

### DIFF
--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -438,24 +438,30 @@ _prompt_org() {
 # ---------------------------------------------------------------------------
 # detect_and_create_all
 # Setup integration: detect username + admin orgs, create all routines repos.
-# In non-interactive mode: only creates personal repo.
+# Non-interactive mode: scaffolds local repo + creates personal GH remote only.
+# Interactive mode: personal repo + prompts for each admin org.
+# Falls back to local-only if gh CLI is unavailable.
 # ---------------------------------------------------------------------------
 detect_and_create_all() {
 	local non_interactive="${1:-false}"
 
+	# If gh is unavailable, fall back to local-only scaffolding so the repo
+	# structure exists even without a GitHub remote.
 	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
-		print_warning "gh CLI not available or not authenticated — skipping routines repo creation"
+		print_warning "gh CLI not available or not authenticated — creating local-only routines repo"
+		init_local
 		return 0
 	fi
 
 	local username
 	username=$(gh api user --jq '.login' 2>/dev/null || echo "")
 	if [[ -z "$username" ]]; then
-		print_warning "Could not detect GitHub username — skipping routines repo creation"
+		print_warning "Could not detect GitHub username — creating local-only routines repo"
+		init_local
 		return 0
 	fi
 
-	# Always create personal repo
+	# Always create personal repo (private GH remote + local clone)
 	init_personal
 
 	if [[ "$non_interactive" == "true" ]]; then

--- a/.agents/scripts/setup/_routines.sh
+++ b/.agents/scripts/setup/_routines.sh
@@ -18,9 +18,10 @@ _load_init_routines_helper() {
 	return 0
 }
 
-# setup_routines — called from setup.sh interactive flow
-# In interactive mode: creates personal repo + prompts for org repos
-# In non-interactive mode: creates personal repo only
+# setup_routines — called from setup.sh in both interactive and non-interactive flows
+# Non-interactive (update): scaffolds local repo + creates personal GH remote only
+# Interactive: creates personal repo + prompts for org repos
+# Falls back to local-only if gh CLI is unavailable (idempotent)
 setup_routines() {
 	print_info "Setting up routines repo..."
 

--- a/setup.sh
+++ b/setup.sh
@@ -905,6 +905,10 @@ _setup_run_non_interactive() {
 	update_codex_config
 	update_cursor_config
 	disable_ondemand_mcps
+	# Scaffold personal routines repo if not already present (idempotent).
+	# Creates local git repo + private GitHub remote for personal repo only.
+	# Org repos require explicit: aidevops init-routines --org <name>
+	setup_routines
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Wires `setup_routines` into `_setup_run_non_interactive()` so `aidevops update` automatically scaffolds the personal routines repo (`~/Git/aidevops-routines`) with a private GitHub remote
- Falls back to local-only scaffolding (`git init`, no remote) when `gh` CLI is unavailable or unauthenticated
- Org routines repos remain on-request only via `aidevops init-routines --org <name>`

## Changes

| File | Change |
|------|--------|
| `setup.sh:908` | Added `setup_routines` call to `_setup_run_non_interactive()` |
| `.agents/scripts/init-routines-helper.sh:443` | `detect_and_create_all` now falls back to `init_local` instead of skipping entirely when gh is unavailable |
| `.agents/scripts/setup/_routines.sh:21` | Updated comment to reflect both-mode usage |

All operations are idempotent — safe to run on every update cycle. ShellCheck clean on all three files.