### PR TITLE
GH#17945: fix dispatch comment jq patterns for ops marker compatibility

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3960,8 +3960,9 @@ normalize_active_issue_assignments() {
 			local dispatch_pid=""
 			local dispatch_comment_age=0
 			local dispatch_comments_json
+			# Match dispatch comments with or without <!-- ops:start --> marker prefix (GH#17945)
 			dispatch_comments_json=$(gh api "repos/${slug}/issues/${stale_num}/comments" \
-				--jq '[.[] | select(.body | startswith("Dispatching worker"))] | sort_by(.created_at) | reverse | first // empty' \
+				--jq '[.[] | select(.body | test("^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker"))] | sort_by(.created_at) | reverse | first // empty' \
 				2>/dev/null) || dispatch_comments_json=""
 			if [[ -n "$dispatch_comments_json" && "$dispatch_comments_json" != "null" ]]; then
 				dispatch_pid=$(printf '%s' "$dispatch_comments_json" | jq -r '
@@ -7515,7 +7516,7 @@ _issue_needs_consolidation() {
 			and (.user.type != "Bot")
 			and (.body | test("^<!-- (nmr-hold|aidevops-signed)") | not)
 			and (.body | test("DISPATCH_CLAIM nonce=") | not)
-			and (.body | test("^Dispatching worker") | not)
+			and (.body | test("^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker") | not)
 		)] | length
 	' 2>/dev/null) || substantive_count=0
 


### PR DESCRIPTION
## Summary

The `<!-- ops:start -->` markers added in PR #17957 broke two jq patterns in pulse-wrapper.sh that detect dispatch comments. Without this fix, the pulse would fail to:
- Detect stale dispatches (line 3965) — could cause duplicate worker dispatches
- Filter dispatch comments from substantive comment counts (line 7519)

## Changes

- **pulse-wrapper.sh:3965**: `startswith("Dispatching worker")` → `test("^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker")`
- **pulse-wrapper.sh:7519**: same regex pattern update

Both patterns now match dispatch comments with or without the ops marker prefix.

## Runtime Testing
- Risk: High (dispatch dedup is a critical path)
- Self-assessed: regex matches both `"Dispatching worker..."` and `"<!-- ops:start...-->\\nDispatching worker..."` formats
- The unanchored `test("Dispatching worker")` on line 7515 was already compatible (contains match, no `^` anchor)

Resolves #17945
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.203 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 1h 37m and 69,437 tokens on this with the user in an interactive session.