### PR TITLE
t1934: Unlock issue and PR after worker self-merge

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -555,6 +555,24 @@ cmd_merge() {
 	print_info "Merging PR #${pr_number} in ${repo} (${merge_method})..."
 	if gh pr merge "$pr_number" --repo "$repo" "$merge_method" 2>&1; then
 		print_success "PR #${pr_number} merged successfully"
+
+		# t1934: Unlock PR and linked issue after worker merge.
+		# Issues/PRs are locked at dispatch time to prevent prompt injection.
+		# The worker merge path must unlock them — otherwise they stay locked
+		# permanently (the pulse deterministic merge path has its own unlock,
+		# but workers that self-merge bypass it).
+		gh issue unlock "$pr_number" --repo "$repo" >/dev/null 2>&1 || true
+
+		# Find and unlock the linked issue (from PR body "Resolves #NNN")
+		local _linked_issue
+		_linked_issue=$(gh pr view "$pr_number" --repo "$repo" --json body \
+			--jq '.body' 2>/dev/null |
+			grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' |
+			grep -oE '[0-9]+' | head -1) || _linked_issue=""
+		if [[ -n "$_linked_issue" && "$_linked_issue" =~ ^[0-9]+$ ]]; then
+			gh issue unlock "$_linked_issue" --repo "$repo" >/dev/null 2>&1 || true
+		fi
+
 		return 0
 	else
 		print_error "Merge failed for PR #${pr_number}"


### PR DESCRIPTION
## Summary

Adds `gh issue unlock` for both the merged PR and its linked issue to `full-loop-helper.sh cmd_merge()`, closing the last gap in the t1934 dispatch lock system.

## Why

Workers that self-merge via `full-loop-helper.sh merge` bypass the pulse's deterministic merge path (which already has unlock). This left 5 of 11 recently-completed issues permanently locked. The pulse path only handles PRs that workers left open for the pulse to merge.

## Evidence

5 closed issues still locked after v3.6.195 — all closed by workers, not by the pulse:
```
#17942: closed_by=commit (GitHub auto-close from worker PR)
#17902: closed_by=via-api (worker gh issue close)
#17912, #17910, #17899: same pattern
```

## Runtime Testing

- **Risk**: Low (non-fatal unlock, `|| true`)
- **Testing**: ShellCheck clean

Resolves #17927


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.206 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 2h 51m and 41,089 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests are now automatically unlocked upon successful merge completion.
  * Linked issues referenced within merged pull requests are automatically unlocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->