### PR TITLE
GH#17961: fix consolidation self-referential loop — exclude gate comments from filter

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -7558,7 +7558,7 @@ _issue_needs_consolidation() {
 			and (.body | test("CLAIM_RELEASED reason=") | not)
 			and (.body | test("^(Worker failed:|## Worker Watchdog Kill)") | not)
 			and (.body | test("^(\\*\\*)?Stale assignment recovered") | not)
-			and (.body | test("^## (Triage Review|Completion Summary)") | not)
+			and (.body | test("^## (Triage Review|Completion Summary|Large File Simplification Gate|Issue Consolidation Needed)") | not)
 			and (.body | test("<!-- MERGE_SUMMARY -->") | not)
 			and (.body | test("^Closing:") | not)
 			and (.body | test("^Worker failed: orphan worktree") | not)


### PR DESCRIPTION
## Summary

The consolidation gate's own comment (`## Issue Consolidation Needed`) and the simplification gate's comment (`## Large File Simplification Gate`) were passing the >500-char substantive comment filter, causing the gate to re-trigger on its own output. This created a circular dependency that permanently locked 8 issues.

Added both patterns to the exclusion list in the jq filter.

## Files Changed
- `.agents/scripts/pulse-wrapper.sh` — one-line filter addition

## Runtime Testing
- Self-assessed: filter-only change, removes false positives

Resolves #17961