### PR TITLE
GH#17968: centralise known bots list for workflow and monitor

### DIFF
--- a/.agents/configs/known-bots.txt
+++ b/.agents/configs/known-bots.txt
@@ -1,0 +1,18 @@
+# Known bot accounts with token-efficiency skip rules (build.txt #8c)
+# One login per line. Lines starting with # are comments.
+# Shared by: unknown-bot-alert.yml, bot-noise-monitor-helper.sh
+# When adding a bot here, also add skip guidance to build.txt rule #8c.
+coderabbitai[bot]
+sonarqubecloud[bot]
+codacy-production[bot]
+github-actions[bot]
+gemini-code-assist[bot]
+codefactor-io[bot]
+socket-security[bot]
+qltybot[bot]
+dependabot[bot]
+renovate[bot]
+mergify[bot]
+allcontributors[bot]
+codecov[bot]
+stale[bot]

--- a/.agents/scripts/bot-noise-monitor-helper.sh
+++ b/.agents/scripts/bot-noise-monitor-helper.sh
@@ -15,24 +15,24 @@
 
 set -euo pipefail
 
-# Known bot accounts with existing skip rules (build.txt #8c)
-# Keep in sync with .github/workflows/unknown-bot-alert.yml KNOWN_BOTS
-KNOWN_BOTS=(
-	"coderabbitai[bot]"
-	"sonarqubecloud[bot]"
-	"codacy-production[bot]"
-	"github-actions[bot]"
-	"gemini-code-assist[bot]"
-	"codefactor-io[bot]"
-	"socket-security[bot]"
-	"qltybot[bot]"
-	"dependabot[bot]"
-	"renovate[bot]"
-	"mergify[bot]"
-	"allcontributors[bot]"
-	"codecov[bot]"
-	"stale[bot]"
-)
+# Load known bots from central config (single source of truth).
+# Falls back to inline list if config file not found.
+_KNOWN_BOTS_FILE="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}/configs/known-bots.txt"
+KNOWN_BOTS=()
+if [[ -f "$_KNOWN_BOTS_FILE" ]]; then
+	while IFS= read -r line; do
+		[[ -z "$line" || "$line" == \#* ]] && continue
+		KNOWN_BOTS+=("$line")
+	done <"$_KNOWN_BOTS_FILE"
+else
+	# Fallback if deployed config not available
+	KNOWN_BOTS=(
+		"coderabbitai[bot]" "sonarqubecloud[bot]" "codacy-production[bot]"
+		"github-actions[bot]" "gemini-code-assist[bot]" "codefactor-io[bot]"
+		"socket-security[bot]" "qltybot[bot]" "dependabot[bot]" "renovate[bot]"
+		"mergify[bot]" "allcontributors[bot]" "codecov[bot]" "stale[bot]"
+	)
+fi
 
 _is_known_bot() {
 	local login="$1"

--- a/.github/workflows/unknown-bot-alert.yml
+++ b/.github/workflows/unknown-bot-alert.yml
@@ -34,23 +34,19 @@ jobs:
           BOT_LOGIN: ${{ github.event.comment.user.login }}
           COMMENT_LEN: ${{ github.event.comment.body && '1' || '0' }}
         run: |
-          # Known bots with skip rules in build.txt #8c
-          KNOWN_BOTS=(
-            "coderabbitai[bot]"
-            "sonarqubecloud[bot]"
-            "codacy-production[bot]"
-            "github-actions[bot]"
-            "gemini-code-assist[bot]"
-            "codefactor-io[bot]"
-            "socket-security[bot]"
-            "qltybot[bot]"
-            "dependabot[bot]"
-            "renovate[bot]"
-            "mergify[bot]"
-            "allcontributors[bot]"
-            "codecov[bot]"
-            "stale[bot]"
-          )
+          # Fetch known bots list from aidevops repo (single source of truth).
+          # Falls back to a minimal hardcoded list if fetch fails.
+          KNOWN_BOTS=()
+          BOTS_URL="https://raw.githubusercontent.com/marcusquinn/aidevops/main/.agents/configs/known-bots.txt"
+          if BOTS_FILE=$(curl -fsSL "$BOTS_URL" 2>/dev/null); then
+            while IFS= read -r line; do
+              [[ -z "$line" || "$line" == \#* ]] && continue
+              KNOWN_BOTS+=("$line")
+            done <<< "$BOTS_FILE"
+          else
+            # Fallback: minimal list to avoid false alerts on common bots
+            KNOWN_BOTS=("github-actions[bot]" "dependabot[bot]" "renovate[bot]")
+          fi
 
           is_known=false
           for bot in "${KNOWN_BOTS[@]}"; do
@@ -123,9 +119,8 @@ jobs:
           - What percentage of its output is actionable vs noise?
 
           ### Files to update
-          - EDIT: .agents/prompts/build.txt — add to rule #8c known bot patterns
-          - EDIT: .agents/scripts/bot-noise-monitor-helper.sh — add to KNOWN_BOTS array
-          - EDIT: .github/workflows/unknown-bot-alert.yml — add to KNOWN_BOTS array'
+          - EDIT: .agents/configs/known-bots.txt — add bot login (single source of truth, auto-propagates to monitor script and workflow)
+          - EDIT: .agents/prompts/build.txt — add skip guidance to rule #8c if the bot has unique noise patterns'
              \`\`\`
           3. **Until skip rules are added**, workers will process this bot's full output on every issue/PR thread read
 


### PR DESCRIPTION
## Summary

The hardcoded KNOWN_BOTS arrays in the workflow and monitor script would go stale when new bots are added to the central config. This centralises the list so updates propagate automatically.

## Changes

- **NEW: `.agents/configs/known-bots.txt`** — single source of truth for known bot logins (one per line, comments supported)
- **`bot-noise-monitor-helper.sh`** — reads from deployed config (`~/.aidevops/agents/configs/known-bots.txt`), falls back to inline list
- **`unknown-bot-alert.yml`** — fetches from `raw.githubusercontent.com/marcusquinn/aidevops/main/.agents/configs/known-bots.txt` at runtime, falls back to minimal inline list

## How updates propagate

| Consumer | Update mechanism | Latency |
|---|---|---|
| Monitor script | `aidevops update` deploys new config | ~10 min (auto-update) |
| GitHub Action workflow | Fetches from GitHub on every trigger | Immediate |
| build.txt rule #8c | Manual (skip guidance is bot-specific) | PR required |

Adding a new known bot = one line in `known-bots.txt`. No workflow YAML changes needed.

## Runtime Testing
- Risk: Low (config file read, curl fallback)
- Self-assessed: YAML valid, ShellCheck passes, both fallback paths work

Resolves #17968
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.209 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 2h 15m and 81,968 tokens on this with the user in an interactive session.