### PR TITLE
fix: correct arg order in routine-log-helper create-issue body builder

### DIFF
--- a/.agents/scripts/routine-log-helper.sh
+++ b/.agents/scripts/routine-log-helper.sh
@@ -858,8 +858,8 @@ cmd_create_issue() {
 		"pending first run" \
 		"0" \
 		"" \
-		'{"total":0,"successes":0,"failures":0,"total_cost":"0.00","avg_duration":0,"period_start":"—","period_end":"—"}' \
-		"$routine_id")
+		"0.00" \
+		'{"total":0,"successes":0,"failures":0,"total_cost":"0.00","avg_duration":0,"period_start":"—","period_end":"—"}')
 
 	# Create the issue on GitHub
 	local issue_number


### PR DESCRIPTION
## Summary

Fixes a bug in `routine-log-helper.sh` where `cmd_create_issue` passed arguments in the wrong order to `_build_issue_body`, causing the issue body to render the raw JSON period_summary object in the **Total cost** field instead of `$0.00`.

## Root Cause

`_build_issue_body` expects:
- Arg 12: `total_cost` (string, e.g. `"0.00"`)
- Arg 13: `period_summary` (JSON object)

`cmd_create_issue` was passing:
- Arg 12: the full JSON object `'{"total":0,...}'` → rendered as `${"total":0,...}` in the issue body
- Arg 13: `"$routine_id"` → used as period_summary, causing jq parse failures

## Fix

- Arg 12: `"0.00"` (correct initial total_cost)
- Arg 13: the JSON object (correct period_summary)
- Removed spurious extra arg (routine_id was arg 14, ignored by the function)

## Verification

```bash
shellcheck .agents/scripts/routine-log-helper.sh
# Only pre-existing SC1091 info — no new violations
```

The rendering bug was visible in marcusquinn/aidevops-routines#2 where the Total cost field showed the raw JSON object. The issue body has been corrected directly; this fix prevents recurrence when new routine tracking issues are created.

## Runtime Testing

**Risk: Low** — argument order fix in a shell function. No runtime environment needed; the fix is verified by code inspection and shellcheck.

`self-assessed`

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.210 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 8m and 14,410 tokens on this as a headless worker.