### PR TITLE
GH#17911: Fix typo and awk truncation in quality-fix.sh

### DIFF
--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -166,7 +166,7 @@ fix_positional_parameters() {
             }' "$file" >"$temp_file"
 
 			# Replace direct positional parameter usage in case statements
-			sed_inplace 's/\$_arg1/\${command}/g; s/\$2/\${account_name}/g; s/\$3/\${target}/g; s/\$4/\${options}/g' "$temp_file"
+			sed_inplace 's/\$1/\${command}/g; s/\$2/\${account_name}/g; s/\$3/\${target}/g; s/\$4/\${options}/g' "$temp_file"
 
 			if ! diff -q "$file" "$temp_file" >/dev/null; then
 				mv "$temp_file" "$file"
@@ -195,11 +195,14 @@ analyze_string_literals() {
 		# Find repeated strings (3+ occurrences)
 		(grep -o '"[^"]*"' "$file" || true) | sort | uniq -c | sort -nr | awk '
             $1 >= 3 {
-                gsub(/"/, "", $2); cn = toupper($2)
+                count = $1
+                # Strip leading whitespace and count to get the full string literal
+                str = $0; sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", str)
+                gsub(/"/, "", str); cn = toupper(str)
                 gsub(/[^A-Z0-9_]/, "_", cn); gsub(/_+/, "_", cn); gsub(/^_|_$/, "", cn)
             }
             $1 >= 3 && length(cn) > 0 {
-                printf "readonly %s=\"%s\"  # Used %d times\n", cn, $2, $1
+                printf "readonly %s=\"%s\"  # Used %d times\n", cn, str, count
             }' >>"$constants_file"
 
 		echo "" >>"$constants_file"


### PR DESCRIPTION
## Summary

Resolves #17911

Addresses two review findings from PR #17851 in `.agents/scripts/quality-fix.sh`:

1. **High — Line 169**: Fixed `$_arg1` typo → `$1` in the sed replacement pattern within `fix_positional_parameters()`. The original pattern would never match actual positional parameter usage because `$_arg1` is not a valid shell variable reference in this context.

2. **Medium — Lines 196-206**: Fixed awk `$2` truncation in `analyze_string_literals()`. When `uniq -c` output contains multi-word quoted strings (e.g., `"hello world"`), awk's default field splitting means `$2` only captures the first word. Replaced with `$0` + count stripping (`sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", str)`) to preserve the full string literal.

## Files Changed

- `.agents/scripts/quality-fix.sh` — both fixes in this single file

## Runtime Testing

- **Risk**: Low (quality tooling script, not production path)
- **Verification**: `shellcheck .agents/scripts/quality-fix.sh` — passes (only SC1091 info about sourced files)
- **Self-assessed**: Changes are straightforward pattern corrections with no control flow impact

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.211 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 2m and 2,548 tokens on this as a headless worker.