### PR TITLE
GH#17978: bump nesting depth threshold to 263 to restore headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -28,6 +28,7 @@ The main config retains only the last few entries for readability.
 | 253 | GH#17951 | pre-existing regression on main — 253 violations vs threshold 252; not introduced by this PR (run-tests.sh change reduces nesting, not increases it) |
 | 256 | GH#17954 | pre-existing regression on main — 254 violations vs threshold 253 (proximity guard fired at -1 headroom); 254 violations + 2 buffer = 256 |
 | 258 | GH#17969 | threshold saturated at 256/256 (0 headroom); proximity guard may warn at threshold-5 but cannot prevent saturation when already at 0 headroom; 256 violations + 2 buffer = 258 |
+| 263 | GH#17978 | proximity guard firing at 256/258 (2 headroom); bumped to 263 to restore adequate headroom — 256 violations + 7 headroom ensures proximity guard fires at 258 violations before saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -21,10 +21,10 @@ FUNCTION_COMPLEXITY_THRESHOLD=36
 # count over the current value.
 #
 # Recent history (full log in complexity-thresholds-history.md):
-# Bumped to 253 (GH#17951): pre-existing regression on main — 253 violations vs threshold 252
 # Bumped to 256 (GH#17954): pre-existing regression on main — 254 violations vs threshold 253; 254 + 2 buffer
 # Bumped to 258 (GH#17969): threshold saturated at 256/256 (0 headroom); 256 violations + 2 buffer
-NESTING_DEPTH_THRESHOLD=258
+# Bumped to 263 (GH#17978): proximity guard firing at 256/258 (2 headroom); 256 violations + 7 headroom
+NESTING_DEPTH_THRESHOLD=263
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Resolves #17978

The CI nesting depth proximity guard was firing at 256/258 violations (2 headroom remaining). This PR bumps `NESTING_DEPTH_THRESHOLD` from 258 to 263 to restore adequate headroom.

## Changes

- **EDIT: `.agents/configs/complexity-thresholds.conf`** — bumped `NESTING_DEPTH_THRESHOLD` from 258 to 263
- **EDIT: `.agents/configs/complexity-thresholds-history.md`** — added entry for GH#17978 per convention

## Rationale

- Current violations: 256
- Previous threshold: 258 (2 headroom — proximity guard firing)
- New threshold: 263 (7 headroom)
- Proximity guard fires when violations are within 5 of threshold, so at 258 violations it will warn before saturation at 263

This follows the established pattern documented in `complexity-thresholds-history.md` (GH#17808, GH#17830, GH#17969, etc.).

## Runtime Testing

Risk: **Low** — config file change only, no code logic modified.
Self-assessed: CI will verify the threshold value is read correctly.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.214 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 2m and 4,961 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code complexity analysis configuration thresholds to refine detection sensitivity.

* **Documentation**
  * Updated threshold history log with the latest configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->