### PR TITLE
GH#17979: tighten complexity-thresholds-history.md

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -1,7 +1,6 @@
 # Complexity Thresholds — Historical Audit Trail
 
-This file archives the full change history for `.agents/configs/complexity-thresholds.conf`.
-The main config retains only the last few entries for readability.
+Archives the full change history for `.agents/configs/complexity-thresholds.conf` (main config retains only recent entries).
 
 ## NESTING_DEPTH_THRESHOLD History
 


### PR DESCRIPTION
## Summary

Tighten the intro prose in `.agents/configs/complexity-thresholds-history.md`.

**Classification**: Reference corpus (historical audit trail). Content is preserved verbatim — all GH# references, threshold values, and rationale unchanged.

**Change**: Compressed 2-line intro to 1 line (53→52 lines). No content loss.

## Verification

- All code blocks, URLs, task ID references (`GH#NNN`), and command examples present before and after ✓
- No broken internal links or references ✓
- Qlty smells: 0 for target file ✓
- `wc -l` after: 52 lines (original 53 minus 1 line of prose overhead) ✓

## Runtime Testing

Risk: **Low** — documentation-only change, no code or agent behaviour affected. Self-assessed.

Resolves #17979

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.214 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-sonnet-4-6 spent 2m and 3,561 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation text for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->