### PR TITLE
GH#17983: exclude audit-trail/history files from simplification scanner

### DIFF
--- a/.agents/scripts/complexity-scan-helper.sh
+++ b/.agents/scripts/complexity-scan-helper.sh
@@ -383,7 +383,7 @@ _is_frontmatter_stub() {
 
 # Exclusion patterns shared by scan phases
 _EXCLUDED_DIRS='_archive/|/templates/|/todo/'
-_EXCLUDED_FILES='/README\.md$'
+_EXCLUDED_FILES='/README\.md$|-history\.md$|/configs/.*\.md$|CHANGELOG\.md$'
 _PROTECTED_PATTERN='prompts/build\.txt|^\.agents/AGENTS\.md|^AGENTS\.md|scripts/commands/pulse\.md'
 
 #######################################

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -93,6 +93,10 @@ Verbose code that could be shorter without losing readability, abstractions addi
 
 Split into chapter files with slim index (~100-200 lines). Verify: `wc -l` total of chapters >= original minus index overhead. Issue title: "restructure" not "tighten".
 
+### Audit trails and history files — never simplify (GH#17983)
+
+Files whose primary content is historical records (threshold change logs, changelogs, decision audit trails). Each row is a traceable record — PR/issue number, value, rationale. Compressing or removing rows destroys the audit trail. The scanner excludes these automatically: `*-history.md`, `configs/*.md`, `CHANGELOG.md`.
+
 ### Almost never simplify
 
 Comments with task IDs/incident numbers/error data (`t1345`, `GH#2928`, `46.8% failure rate`), `DISABLED:` blocks with bug/PR references, agent prompt rules encoding observed failure patterns, shell quality standards (`local var="$1"`, explicit `return 0`), intentional repetition across docs serving different audiences, error-prevention rules with supporting data, executable template code blocks in agent docs — code blocks that workers copy-paste to run commands (e.g., `gh pr comment`, verification one-liners). Prose surrounding the block can be tightened; the block itself must survive verbatim (GH#17503).


### PR DESCRIPTION
## Summary

- Add `*-history.md`, `configs/*.md`, and `CHANGELOG.md` to the simplification scanner's `_EXCLUDED_FILES` pattern in `complexity-scan-helper.sh`
- Document the "audit trails and history files" category in `code-simplifier.md` under classification

**Why:** PR #17983 demonstrated the problem — a worker spent a dispatch cycle "tightening" `complexity-thresholds-history.md` by merging two intro sentences into one. The file is a historical audit trail where every row is a traceable PR/issue reference. Simplifying it produces zero value and wastes CI, review bot, and human attention.

**Files changed:**
- `EDIT: .agents/scripts/complexity-scan-helper.sh:386` — expanded `_EXCLUDED_FILES` regex
- `EDIT: .agents/tools/code-review/code-simplifier.md:96` — added "Audit trails and history files" classification section

**Verification:**
- Regex tested against repo-relative paths — correctly excludes `complexity-thresholds-history.md`, `CHANGELOG.md`, `configs/SKILL-SCAN-RESULTS.md` while including normal agent docs
- ShellCheck passes with zero violations

Ref #17983


---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.215 plugin for [OpenCode](https://opencode.ai) v1.4.0 with claude-opus-4-6 spent 6m and 6,194 tokens on this with the user in an interactive session.