### PR TITLE
GH#17993: replace Bash 4+ case-modification syntax with Bash 3.2 compatible pattern

### DIFF
--- a/.agents/scripts/101domains-helper.sh
+++ b/.agents/scripts/101domains-helper.sh
@@ -398,7 +398,10 @@ toggle_domain_lock() {
     local data
     data=$(jq -n --arg domain "$domain" --arg lock "$lock_status" '{domain: $domain, lock: $lock}')
 
-    print_info "${action^}ing domain: $domain"
+    # Bash 3.2 compat: ${var^} requires Bash 4+
+    local action_cap
+    action_cap="$(printf '%s' "${action:0:1}" | tr '[:lower:]' '[:upper:]')${action:1}"
+    print_info "${action_cap}ing domain: $domain"
     local response
     if response=$(api_request "$account_name" "POST" "domain/lock" "$data"); then
         print_success "Domain ${action}ed successfully"
@@ -471,7 +474,10 @@ toggle_domain_privacy() {
     local data
     data=$(jq -n --arg domain "$domain" --arg privacy "$privacy_status" '{domain: $domain, privacy: $privacy}')
 
-    print_info "${action^}ing privacy for domain: $domain"
+    # Bash 3.2 compat: ${var^} requires Bash 4+
+    local action_cap
+    action_cap="$(printf '%s' "${action:0:1}" | tr '[:lower:]' '[:upper:]')${action:1}"
+    print_info "${action_cap}ing privacy for domain: $domain"
     local response
     if response=$(api_request "$account_name" "POST" "domain/privacy" "$data"); then
         print_success "Domain privacy ${action}d successfully"

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -364,7 +364,10 @@ _approve_target() {
 	fi
 
 	_post_issue_approval_updates "$target_type" "$target_number" "$slug"
-	_print_ok "${target_type^} #$target_number approved and signed"
+	# Bash 3.2 compat: ${var^} (uppercase first) requires Bash 4+. Use printf + tr.
+	local target_type_cap
+	target_type_cap="$(printf '%s' "${target_type:0:1}" | tr '[:lower:]' '[:upper:]')${target_type:1}"
+	_print_ok "$target_type_cap #$target_number approved and signed"
 	echo ""
 	return 0
 }

--- a/.agents/scripts/spaceship-helper.sh
+++ b/.agents/scripts/spaceship-helper.sh
@@ -503,7 +503,10 @@ toggle_domain_lock() {
     local data
     data=$(jq -n --arg locked "$locked" '{locked: ($locked | test("true"))}')
 
-    print_info "${action^}ing domain: $domain"
+    # Bash 3.2 compat: ${var^} requires Bash 4+
+    local action_cap
+    action_cap="$(printf '%s' "${action:0:1}" | tr '[:lower:]' '[:upper:]')${action:1}"
+    print_info "${action_cap}ing domain: $domain"
     local response
     if response=$(api_request "$account_name" "PUT" "domains/$domain/lock" "$data"); then
         print_success "Domain ${action}ed successfully"


### PR DESCRIPTION
## Summary

- replace the Bash 4+ first-letter case-modification syntax in `approval-helper.sh`, `101domains-helper.sh`, and `spaceship-helper.sh` with the existing Bash 3.2 compatible `printf + tr` pattern already used in `oauth-pool-helper.sh`
- fix the approval success path that currently throws `bad substitution` on macOS Bash 3.2 after successfully approving an issue
- remove the remaining runtime-only compatibility hazard from the two provider helpers that use the same pattern

## Verification

- `git ls-files '*.sh' | xargs grep -n '\${[a-zA-Z_]*\^}' 2>/dev/null | grep -v 'compat.*Bash'` returns no matches
- ShellCheck on the touched sections passes

Resolves #17993


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.218 plugin for [OpenCode](https://opencode.ai) v1.4.0 with gpt-5.4 spent 45m and 420,093 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved compatibility of internal helper scripts with Bash 3.2, ensuring consistent functionality across different shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->