### PR TITLE
GH#17995: support opt-in OpenAI routing for headless dispatch

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -2,7 +2,7 @@
   "_comment": "Model routing table — SINGLE SOURCE OF TRUTH for tier-to-model mappings. All scripts, docs, and configs should reference this file rather than hardcoding model IDs. When a new model generation releases (e.g., gpt-5.5), update ONLY this file.",
   "_docs": "See .agents/tools/context/model-routing.md for routing rules, .agents/tools/ai-assistants/fallback-chains.md for integration.",
   "_agentic_note": "codex/code-completion models (gpt-5.3-codex, gpt-5.4-codex) are NOT agentic — zero tool calls observed (GH#17669). Never use them for headless worker dispatch. Only general-purpose models support agentic workflows.",
-  "_defaults": "Claude models are the default primary for all tiers. Non-Anthropic providers are opt-in fallbacks — edit this file to change the order or add providers. The first model in each tier's array is the primary; subsequent entries are tried in order when the primary is unavailable.",
+  "_defaults": "Claude models are the default primary for all tiers. Non-Anthropic providers are opt-in fallbacks — add them in custom/configs/model-routing-table.json to change the order or enable another provider locally. The first model in each tier's array is the primary; subsequent entries are tried in order when the primary is unavailable.",
 
   "tiers": {
     "local":  { "models": ["anthropic/claude-haiku-4-5"], "cost": 0 },

--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -24,14 +24,6 @@
       "probe_timeout_seconds": 3,
       "_comment": "llama.cpp or compatible OpenAI-API server. No API key needed. Use local-model-helper.sh status to check."
     },
-    "ollama": {
-      "endpoint": "http://localhost:11434/v1/chat/completions",
-      "key_env": null,
-      "probe_path": "/api/tags",
-      "probe_timeout_seconds": 3,
-      "min_context_length": 16384,
-      "_comment": "Ollama local model server. No API key needed. Probe /api/tags to check availability. OpenAI-compatible endpoint at /v1/."
-    },
     "anthropic": {
       "endpoint": "https://api.anthropic.com/v1/messages",
       "key_env": "ANTHROPIC_API_KEY",

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -103,11 +103,12 @@ source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 list_dispatchable_issue_candidates SLUG 100
 
 # Atomic dispatch — runs all 7 dedup layers, assigns, launches, records ledger.
-# DO NOT pass a 9th parameter (model override) here. dispatch_with_dedup owns
-# the round-robin: it calls headless-runtime-helper.sh select --role worker to
-# rotate between configured providers (e.g., anthropic ↔ openai) and records
-# the resolved model in the dispatch comment. Passing your own model bypasses
-# the round-robin and causes all workers to land on a single provider.
+# DO NOT pass a 9th parameter (model override) here. dispatch_with_dedup handles
+# model selection via the runtime resolver: it uses the routing table, optional
+# local overrides (custom/configs/model-routing-table.json), provider allowlist
+# (AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST), and auth/availability checks. The
+# resolved model is recorded in the dispatch comment. Passing your own model
+# bypasses the runtime resolver and causes provider imbalance.
 dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER_USER" PATH \
   "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" || continue
 ```

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -298,10 +298,12 @@ workers attempted.
 
 ### Model tier selection
 
-`dispatch_with_dedup` handles model selection automatically via round-robin across
-providers derived from the OAuth pool + routing table (GH#17769). The resolved model
-is recorded in the dispatch comment. **Do NOT pass a model override (9th parameter)
-for default dispatches** — this bypasses the round-robin and causes provider imbalance.
+`dispatch_with_dedup` handles model selection automatically via the routing table,
+optional local overrides (`custom/configs/model-routing-table.json`), provider
+allowlist (`AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`), and auth/availability checks.
+The resolved model is recorded in the dispatch comment. **Do NOT pass a model
+override (9th parameter) for default dispatches** — this bypasses the runtime
+resolver and causes provider imbalance.
 
 Only pass a model override when tier escalation is needed:
 
@@ -312,8 +314,8 @@ dispatch_with_dedup NUMBER SLUG ... "$RESOLVED_MODEL"
 ```
 
 Precedence: (1) failure escalation (cascade: `tier:simple` → `tier:standard` → `tier:reasoning`) > (2) issue labels (`tier:reasoning`
-→ opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) **omit the 9th parameter** (round-robin selects from
-configured providers and records the model in the dispatch comment). Backward compat: `tier:thinking` is accepted as alias for `tier:reasoning`.
+→ opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) **omit the 9th parameter** (runtime resolver selects from
+configured models/providers and records the model in the dispatch comment). Backward compat: `tier:thinking` is accepted as alias for `tier:reasoning`.
 
 ### Agent routing from labels
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -310,10 +310,11 @@ get_auth_signature() {
 	return 0
 }
 
-# Derive the headless model list from the OAuth pool + routing table (GH#17769).
-# Flow: pool → available providers → routing table sonnet tier → model list.
-# This eliminates AIDEVOPS_HEADLESS_MODELS as a user-configurable env var.
-# The pool is the authority on accounts; the routing table is the authority on models.
+# Derive the headless model list from the routing table (GH#17769).
+# Flow: routing table sonnet tier → optional provider allowlist → providers with
+# usable auth at dispatch time. This eliminates AIDEVOPS_HEADLESS_MODELS as a
+# user-configurable env var while allowing temporary provider pinning via
+# AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST.
 get_configured_models() {
 	local allowlist_raw="${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}"
 	local -a allowlist=()
@@ -343,28 +344,17 @@ get_configured_models() {
 		IFS=',' read -r -a allowlist <<<"$allowlist_raw"
 	fi
 
-	local routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
-	local pool_helper="${SCRIPT_DIR}/oauth-pool-helper.sh"
-
-	# Step 1: Query pool for available providers (cheap — reads JSON file, no API calls)
-	local -a pool_providers=()
-	if [[ -x "$pool_helper" ]]; then
-		local pool_output=""
-		pool_output=$("$pool_helper" list all 2>/dev/null) || pool_output=""
-		# Parse provider names from lines like "anthropic (2 accounts):"
-		while IFS= read -r line; do
-			local prov=""
-			prov=$(printf '%s' "$line" | sed -n 's/^\([a-z]*\) ([0-9]* account.*/\1/p')
-			if [[ -n "$prov" ]]; then
-				pool_providers+=("$prov")
-			fi
-		done <<<"$pool_output"
+	local routing_table="${SCRIPT_DIR}/../custom/configs/model-routing-table.json"
+	if [[ ! -f "$routing_table" ]]; then
+		routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
 	fi
 
-	# Step 2: For each pool provider, look up the sonnet-tier model from the routing table
-	if [[ ${#pool_providers[@]} -gt 0 ]] && [[ -f "$routing_table" ]] && command -v jq >/dev/null 2>&1; then
-		for provider in "${pool_providers[@]}"; do
-			# Apply allowlist filter if set
+	if [[ -f "$routing_table" ]] && command -v jq >/dev/null 2>&1; then
+		while IFS= read -r model; do
+			[[ -z "$model" ]] && continue
+			provider=$(extract_provider "$model" 2>/dev/null || printf '%s' "")
+			[[ -z "$provider" ]] && continue
+
 			if [[ ${#allowlist[@]} -gt 0 ]]; then
 				local allowed=false
 				local allowed_provider
@@ -378,18 +368,21 @@ get_configured_models() {
 				[[ "$allowed" == "true" ]] || continue
 			fi
 
-			model=$(jq -r --arg p "$provider" \
-				'.tiers.sonnet.models[] | select(startswith($p + "/"))' \
-				"$routing_table" 2>/dev/null | head -1) || model=""
-			if [[ -n "$model" ]]; then
-				models+=("$model")
+			if ! provider_auth_available "$provider"; then
+				continue
 			fi
-		done
+
+			models+=("$model")
+		done < <(jq -r '.tiers.sonnet.models[]? // empty' "$routing_table" 2>/dev/null)
 	fi
 
-	# Fallback: if pool/routing derivation yielded nothing, use hardcoded default
-	if [[ ${#models[@]} -eq 0 ]]; then
-		models+=("$DEFAULT_HEADLESS_MODELS")
+	# Fallback: if routing derivation yielded nothing and no allowlist is forcing a
+	# provider subset, use the historical default when auth is available.
+	if [[ ${#models[@]} -eq 0 ]] && [[ -z "$allowlist_raw" ]]; then
+		provider=$(extract_provider "$DEFAULT_HEADLESS_MODELS" 2>/dev/null || printf '%s' "")
+		if [[ -n "$provider" ]] && provider_auth_available "$provider"; then
+			models+=("$DEFAULT_HEADLESS_MODELS")
+		fi
 	fi
 
 	printf '%s\n' "${models[@]}"
@@ -1171,7 +1164,7 @@ cmd_session() {
 
 # _parse_run_args: parse cmd_run flags into caller-scoped variables.
 # Caller must declare: role session_key work_dir title prompt prompt_file
-#                      model_override agent_name extra_args
+#                      model_override tier_override variant_override agent_name extra_args
 # Returns 1 on unknown flag.
 _parse_run_args() {
 	while [[ $# -gt 0 ]]; do
@@ -1204,6 +1197,14 @@ _parse_run_args() {
 			model_override="${2:-}"
 			shift 2
 			;;
+		--tier)
+			tier_override="${2:-}"
+			shift 2
+			;;
+		--variant)
+			variant_override="${2:-}"
+			shift 2
+			;;
 		--agent)
 			agent_name="${2:-}"
 			shift 2
@@ -1227,6 +1228,54 @@ _parse_run_args() {
 			;;
 		esac
 	done
+	return 0
+}
+
+resolve_headless_variant() {
+	local role="$1"
+	local tier="${2:-}"
+	local variant="${AIDEVOPS_HEADLESS_VARIANT:-}"
+	local tier_upper=""
+
+	if [[ -n "$tier" ]]; then
+		tier_upper=$(printf '%s' "$tier" | tr '[:lower:]-' '[:upper:]_')
+		case "$tier_upper" in
+		HAIKU | FLASH | SONNET | PRO | OPUS | HEALTH | EVAL | CODING)
+			local tier_env_var="AIDEVOPS_HEADLESS_VARIANT_${tier_upper}"
+			local tier_variant="${!tier_env_var:-}"
+			if [[ -n "$tier_variant" ]]; then
+				variant="$tier_variant"
+			fi
+			;;
+		esac
+	fi
+
+	case "$role" in
+	pulse)
+		if [[ -n "${AIDEVOPS_HEADLESS_PULSE_VARIANT:-}" ]]; then
+			variant="${AIDEVOPS_HEADLESS_PULSE_VARIANT}"
+		fi
+		;;
+	worker)
+		if [[ -n "${AIDEVOPS_HEADLESS_WORKER_VARIANT:-}" ]]; then
+			variant="${AIDEVOPS_HEADLESS_WORKER_VARIANT}"
+		fi
+		;;
+	esac
+
+	if [[ -n "$tier" ]]; then
+		case "$tier_upper" in
+		HAIKU | FLASH | SONNET | PRO | OPUS | HEALTH | EVAL | CODING)
+			local tier_env_var="AIDEVOPS_HEADLESS_VARIANT_${tier_upper}"
+			local tier_variant="${!tier_env_var:-}"
+			if [[ -n "$tier_variant" ]]; then
+				variant="$tier_variant"
+			fi
+			;;
+		esac
+	fi
+
+	printf '%s' "$variant"
 	return 0
 }
 
@@ -1383,7 +1432,7 @@ _detect_opencode_server() {
 }
 
 # _build_run_cmd: build the opencode command array for a run attempt.
-# Args: selected_model work_dir prompt title agent_name persisted_session
+# Args: selected_model work_dir prompt title variant_override agent_name persisted_session
 #       extra_args (remaining positional args)
 # Outputs: space-separated command (caller must eval or use array assignment).
 # Returns: 0 always.
@@ -1392,9 +1441,10 @@ _build_run_cmd() {
 	local work_dir="$2"
 	local prompt="$3"
 	local title="$4"
-	local agent_name="$5"
-	local persisted_session="$6"
-	shift 6
+	local variant_override="$5"
+	local agent_name="$6"
+	local persisted_session="$7"
+	shift 7
 
 	# Emit base command args as null-delimited tokens (bash 3.2 compat: no local -a in subshell)
 	printf '%s\0' "$OPENCODE_BIN_DEFAULT" run "$prompt" --dir "$work_dir" -m "$selected_model" --title "$title" --format json
@@ -1403,6 +1453,9 @@ _build_run_cmd() {
 	fi
 	if [[ -n "$persisted_session" ]]; then
 		printf '%s\0' --session "$persisted_session" --continue
+	fi
+	if [[ -n "$variant_override" ]]; then
+		printf '%s\0' --variant "$variant_override"
 	fi
 	# GH#17829: Attach to running opencode server if one is detected.
 	# Without this, `opencode run` tries to start an embedded server that
@@ -2024,7 +2077,7 @@ _handle_run_result() {
 
 # _execute_run_attempt: run one headless invocation and handle the result.
 # Dispatches to OpenCode (default) or Claude CLI (when --runtime claude specified).
-# Args: role session_key work_dir title prompt selected_model agent_name model_override
+# Args: role session_key work_dir title prompt selected_model variant_override agent_name model_override
 #       extra_args (array passed as remaining positional args after the named ones)
 # Reads caller variable headless_runtime (set by _parse_run_args --runtime flag).
 # Prints the discovered session ID to stdout on success (may be empty).
@@ -2037,9 +2090,10 @@ _execute_run_attempt() {
 	local title="$4"
 	local prompt="$5"
 	local selected_model="$6"
-	local agent_name="$7"
-	local model_override="$8"
-	shift 8
+	local variant_override="$7"
+	local agent_name="$8"
+	local model_override="$9"
+	shift 9
 	local -a extra_args=("$@")
 
 	# Determine which runtime to use. Default is opencode unless explicitly overridden.
@@ -2073,7 +2127,7 @@ _execute_run_attempt() {
 		while IFS= read -r -d '' arg; do
 			cmd+=("$arg")
 		done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt" "$title" \
-			"$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
+			"$variant_override" "$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
 		;;
 	esac
 
@@ -2765,6 +2819,8 @@ cmd_run() {
 	local prompt=""
 	local prompt_file=""
 	local model_override=""
+	local tier_override=""
+	local variant_override=""
 	local agent_name=""
 	local headless_runtime=""
 	local detach=0
@@ -2812,6 +2868,10 @@ cmd_run() {
 		return "$choose_exit"
 	}
 
+	if [[ -z "$variant_override" ]]; then
+		variant_override=$(resolve_headless_variant "$role" "$tier_override")
+	fi
+
 	# GH#17436: Continuation retry configuration.
 	# When a worker exits prematurely (activity but no completion signal),
 	# resume the session with a "continue" prompt instead of starting fresh.
@@ -2844,7 +2904,7 @@ cmd_run() {
 		local attempt_exit=0
 		if _execute_run_attempt \
 			"$role" "$session_key" "$work_dir" "$title" "$prompt" \
-			"$selected_model" "$agent_name" "$model_override" \
+			"$selected_model" "$variant_override" "$agent_name" "$model_override" \
 			"${extra_args[@]+"${extra_args[@]}"}"; then
 			attempt_exit=0
 		else
@@ -2927,7 +2987,7 @@ headless-runtime-helper.sh - Model-aware headless runtime (OpenCode default, Cla
 
 Usage:
   headless-runtime-helper.sh select [--role pulse|worker] [--model provider/model]
-  headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG] [--detach]
+  headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--tier haiku|sonnet|opus|...] [--variant NAME] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG] [--detach]
   headless-runtime-helper.sh backoff [status|set MODEL-OR-PROVIDER REASON [SECONDS]|clear MODEL-OR-PROVIDER]
   headless-runtime-helper.sh session [status|clear PROVIDER SESSION_KEY]
   headless-runtime-helper.sh metrics [--role pulse|worker] [--hours N] [--model SUBSTRING] [--fast-threshold N]
@@ -2949,10 +3009,13 @@ Dedup guard (GH#6538):
   are cleaned up automatically. Lock files: $STATE_DIR/locks/<key>.pid
 
 Defaults:
-  Model list is derived from OAuth pool + routing table (GH#17769).
-  Fallback: anthropic/claude-sonnet-4-6 if pool/routing unavailable.
+  Model list is derived from routing table + auth availability (GH#17769).
+  Fallback: anthropic/claude-sonnet-4-6 if routing resolution fails.
   AIDEVOPS_HEADLESS_MODELS is deprecated — respected as override for one release cycle.
   AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST can restrict selection to providers like: openai
+  AIDEVOPS_HEADLESS_VARIANT_SONNET / AIDEVOPS_HEADLESS_VARIANT_OPUS can set tier defaults.
+  AIDEVOPS_HEADLESS_VARIANT sets an OpenCode model variant (for example: high, xhigh).
+  AIDEVOPS_HEADLESS_PULSE_VARIANT / AIDEVOPS_HEADLESS_WORKER_VARIANT override by role.
   AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 disables worker /full-loop contract injection
   NOTE: opencode/* gateway models are NOT used — per-token billing is too expensive.
 EOF

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -2659,6 +2659,7 @@ _enforce_opencode_version_pin() {
 }
 
 _run_canary_test() {
+	local requested_model="${1:-}"
 	local cache_file="${STATE_DIR}/canary-last-pass"
 
 	# Check cache — skip if last canary passed recently
@@ -2677,14 +2678,15 @@ _run_canary_test() {
 	canary_output=$(mktemp "${TMPDIR:-/tmp}/aidevops-canary.XXXXXX")
 
 	# Run WITH plugins (not --pure) so our oauth-pool auth is available.
-	# Use sonnet — verified working, and the trivial prompt costs ~100 tokens.
-	# Model ID resolved from model-routing-table.json (single source of truth).
-	local routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
-	local canary_model=""
-	if [[ -f "$routing_table" ]] && command -v jq >/dev/null 2>&1; then
-		canary_model=$(jq -r '.tiers.sonnet.models[0] // empty' "$routing_table" 2>/dev/null) || canary_model=""
+	# The canary must validate the same provider/model the upcoming run will use,
+	# otherwise OpenAI opt-in runs still fail behind an Anthropic-only gate.
+	local canary_model="$requested_model"
+	if [[ -z "$canary_model" ]]; then
+		while IFS= read -r canary_model; do
+			[[ -n "$canary_model" ]] && break
+		done < <(get_configured_models)
 	fi
-	# Fallback to the script-level default if routing table unavailable
+	# Fallback to the script-level default if routing resolution yielded nothing.
 	if [[ -z "$canary_model" ]]; then
 		canary_model="$DEFAULT_HEADLESS_MODELS"
 	fi
@@ -2834,6 +2836,13 @@ cmd_run() {
 		return 0
 	fi
 
+	local selected_model
+	selected_model=$(choose_model "$role" "$model_override") || {
+		local choose_exit=$?
+		_cmd_run_finish "$session_key" "fail"
+		return "$choose_exit"
+	}
+
 	# GH#17549: Version guard — runs on EVERY dispatch (not cached).
 	# Something keeps upgrading opencode to 1.3.17 between canary checks.
 	_enforce_opencode_version_pin
@@ -2843,7 +2852,7 @@ cmd_run() {
 	# _cmd_run_prepare so a canary failure never posts a dispatch claim or
 	# increments the fast-fail counter. Cached for CANARY_CACHE_TTL_SECONDS
 	# (default 30 min) so it runs at most once per pulse cycle.
-	if ! _run_canary_test; then
+	if ! _run_canary_test "$selected_model"; then
 		print_warning "Canary failed — aborting dispatch for session $session_key (no claim posted)"
 		return 1
 	fi
@@ -2860,13 +2869,6 @@ cmd_run() {
 	if [[ "$prepare_exit" -ne 0 ]]; then
 		return "$prepare_exit"
 	fi
-
-	local selected_model
-	selected_model=$(choose_model "$role" "$model_override") || {
-		local choose_exit=$?
-		_cmd_run_finish "$session_key" "fail"
-		return "$choose_exit"
-	}
 
 	if [[ -z "$variant_override" ]]; then
 		variant_override=$(resolve_headless_variant "$role" "$tier_override")

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1064,6 +1064,7 @@ choose_model() {
 cmd_select() {
 	local role="worker"
 	local model_override=""
+	local tier_override=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--role)
@@ -1074,12 +1075,28 @@ cmd_select() {
 			model_override="${2:-}"
 			shift 2
 			;;
+		--tier)
+			tier_override="${2:-}"
+			shift 2
+			;;
 		*)
 			print_error "Unknown option for select: $1"
 			return 1
 			;;
 		esac
 	done
+
+	# When a tier is specified, resolve the concrete model for that tier and
+	# use it as the explicit model override. This ensures the round-robin
+	# selects from the correct tier's model pool (e.g., haiku for tier:simple,
+	# opus for tier:reasoning) rather than always defaulting to sonnet.
+	if [[ -n "$tier_override" && -z "$model_override" ]]; then
+		local tier_model=""
+		tier_model=$(resolve_model_tier "$tier_override" 2>/dev/null) || tier_model=""
+		if [[ -n "$tier_model" ]]; then
+			model_override="$tier_model"
+		fi
+	fi
 
 	local selected
 	selected=$(choose_model "$role" "$model_override") || return $?
@@ -2077,7 +2094,7 @@ _handle_run_result() {
 
 # _execute_run_attempt: run one headless invocation and handle the result.
 # Dispatches to OpenCode (default) or Claude CLI (when --runtime claude specified).
-# Args: role session_key work_dir title prompt selected_model variant_override agent_name model_override
+# Args: role session_key work_dir title prompt selected_model variant_override agent_name
 #       extra_args (array passed as remaining positional args after the named ones)
 # Reads caller variable headless_runtime (set by _parse_run_args --runtime flag).
 # Prints the discovered session ID to stdout on success (may be empty).
@@ -2092,8 +2109,7 @@ _execute_run_attempt() {
 	local selected_model="$6"
 	local variant_override="$7"
 	local agent_name="$8"
-	local model_override="$9"
-	shift 9
+	shift 8
 	local -a extra_args=("$@")
 
 	# Determine which runtime to use. Default is opencode unless explicitly overridden.
@@ -2906,7 +2922,7 @@ cmd_run() {
 		local attempt_exit=0
 		if _execute_run_attempt \
 			"$role" "$session_key" "$work_dir" "$title" "$prompt" \
-			"$selected_model" "$variant_override" "$agent_name" "$model_override" \
+			"$selected_model" "$variant_override" "$agent_name" \
 			"${extra_args[@]+"${extra_args[@]}"}"; then
 			attempt_exit=0
 		else

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -119,6 +119,14 @@ is_known_provider() {
 # provider API keys or subscription accounts.
 get_tier_models() {
 	local tier="$1"
+	local allowlist_raw="${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}"
+	local -a allowlist=()
+	local -a filtered_models=()
+	local current_model current_provider
+
+	if [[ -n "$allowlist_raw" ]]; then
+		IFS=',' read -r -a allowlist <<<"$allowlist_raw"
+	fi
 
 	# User-local override checked first — survives aidevops update.
 	# Copy configs/model-routing-table.json to custom/configs/ and edit.
@@ -129,33 +137,87 @@ get_tier_models() {
 		routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
 	fi
 	if [[ -f "$routing_table" ]]; then
-		local models_json
-		models_json=$(jq -r --arg t "$tier" \
-			'.tiers[$t].models // empty | join("|")' \
-			"$routing_table" 2>/dev/null) || models_json=""
-		if [[ -n "$models_json" ]]; then
+		while IFS= read -r current_model; do
+			[[ -z "$current_model" ]] && continue
+			current_provider="${current_model%%/*}"
+			if [[ ${#allowlist[@]} -gt 0 ]]; then
+				local allowed=false
+				local allowed_provider
+				for allowed_provider in "${allowlist[@]}"; do
+					allowed_provider=$(printf '%s' "$allowed_provider" | sed 's/^ *//;s/ *$//')
+					if [[ "$allowed_provider" == "$current_provider" ]]; then
+						allowed=true
+						break
+					fi
+				done
+				[[ "$allowed" == "true" ]] || continue
+			fi
+			filtered_models+=("$current_model")
+		done < <(jq -r --arg t "$tier" '.tiers[$t].models[]? // empty' "$routing_table" 2>/dev/null)
+		if [[ ${#filtered_models[@]} -gt 0 ]]; then
+			local models_json=""
+			models_json=$(
+				IFS='|'
+				printf '%s' "${filtered_models[*]}"
+			)
 			echo "$models_json"
+			return 0
+		fi
+		if [[ ${#allowlist[@]} -gt 0 ]]; then
+			echo ""
 			return 0
 		fi
 	fi
 
 	# Hardcoded fallback — kept in sync with model-routing-table.json.
 	# If you're editing these, update the JSON file instead.
-	# Anthropic-only for all tiers. Other providers excluded — not
-	# producing results in headless workers. Re-add via the JSON
-	# config when provider-specific prompting is tuned.
+	# Claude remains primary. OpenAI is the direct-provider fallback for
+	# headless continuity when Anthropic is unavailable.
 	case "$tier" in
-	local) echo "anthropic/claude-haiku-4-5" ;;
-	haiku) echo "anthropic/claude-haiku-4-5" ;;
-	flash) echo "anthropic/claude-haiku-4-5" ;;
-	sonnet) echo "anthropic/claude-sonnet-4-6" ;;
-	pro) echo "anthropic/claude-sonnet-4-6" ;;
-	opus) echo "anthropic/claude-opus-4-6" ;;
-	health) echo "anthropic/claude-sonnet-4-6" ;;
-	eval) echo "anthropic/claude-sonnet-4-6" ;;
-	coding) echo "anthropic/claude-opus-4-6" ;;
+	local) current_model="anthropic/claude-haiku-4-5" ;;
+	haiku) current_model=$'anthropic/claude-haiku-4-5\nopenai/gpt-5.4' ;;
+	flash) current_model=$'anthropic/claude-haiku-4-5\nopenai/gpt-5.4' ;;
+	sonnet) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
+	pro) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
+	opus) current_model=$'anthropic/claude-opus-4-6\nopenai/gpt-5.4' ;;
+	health) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
+	eval) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
+	coding) current_model=$'anthropic/claude-opus-4-6\nopenai/gpt-5.4' ;;
 	*) return 1 ;;
 	esac
+
+	if [[ ${#allowlist[@]} -eq 0 ]]; then
+		echo "$(printf '%s\n' "$current_model" | paste -sd'|' -)"
+		return 0
+	fi
+
+	filtered_models=()
+	while IFS= read -r current_provider; do
+		[[ -z "$current_provider" ]] && continue
+		local provider_name="${current_provider%%/*}"
+		local allowed=false
+		local allowed_provider
+		for allowed_provider in "${allowlist[@]}"; do
+			allowed_provider=$(printf '%s' "$allowed_provider" | sed 's/^ *//;s/ *$//')
+			if [[ "$allowed_provider" == "$provider_name" ]]; then
+				allowed=true
+				break
+			fi
+		done
+		if [[ "$allowed" == "true" ]]; then
+			filtered_models+=("$current_provider")
+		fi
+	done <<<"$current_model"
+
+	if [[ ${#filtered_models[@]} -eq 0 ]]; then
+		echo ""
+		return 0
+	fi
+
+	echo "$(
+		IFS='|'
+		printf '%s' "${filtered_models[*]}"
+	)"
 	return 0
 }
 
@@ -1255,9 +1317,14 @@ resolve_tier() {
 	local quiet="${3:-false}"
 
 	local tier_spec
-	tier_spec=$(get_tier_models "$tier" 2>/dev/null) || true
-	if [[ -z "$tier_spec" ]]; then
+	tier_spec=$(get_tier_models "$tier" 2>/dev/null)
+	local tier_models_rc=$?
+	if [[ "$tier_models_rc" -ne 0 ]]; then
 		[[ "$quiet" != "true" ]] && print_error "Unknown tier: $tier"
+		return 1
+	fi
+	if [[ -z "$tier_spec" ]]; then
+		[[ "$quiet" != "true" ]] && print_error "No models configured for tier: $tier"
 		return 1
 	fi
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8188,7 +8188,7 @@ dispatch_with_dedup() {
 	if [[ -n "$model_override" ]]; then
 		selected_model="$model_override"
 	else
-		selected_model=$("$HEADLESS_RUNTIME_HELPER" select --role worker 2>/dev/null) || selected_model=""
+		selected_model=$("$HEADLESS_RUNTIME_HELPER" select --role worker --tier "$dispatch_model_tier" 2>/dev/null) || selected_model=""
 	fi
 
 	# t1894/t1934: Lock issue and linked PRs during worker execution

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -175,20 +175,21 @@ DAILY_PR_CAP="${DAILY_PR_CAP:-1000}"                                            
 PRODUCT_RESERVATION_PCT="${PRODUCT_RESERVATION_PCT:-60}"                                                # % of worker slots reserved for product repos (t1423)
 QUALITY_DEBT_CAP_PCT="${QUALITY_DEBT_CAP_PCT:-$(config_get "orchestration.quality_debt_cap_pct" "30")}" # % cap for quality-debt dispatch share
 # GH#17769: PULSE_MODEL and AIDEVOPS_HEADLESS_MODELS are deprecated.
-# Model routing is now derived from the OAuth pool + routing table at runtime.
+# Model routing is now derived from the routing table at runtime and resolved
+# through model-availability-helper.sh so pulse follows the same provider
+# fallback logic as workers.
 # Backward compat: if legacy env vars are still set, log deprecation warnings.
+MODEL_AVAILABILITY_HELPER="${MODEL_AVAILABILITY_HELPER:-${SCRIPT_DIR}/model-availability-helper.sh}"
 if [[ -n "${PULSE_MODEL:-}" ]]; then
-	echo "[pulse-wrapper] WARN: PULSE_MODEL env var is deprecated (v3.7+). Model routing is now automatic via pool + routing table. Remove this export from credentials.sh." >&2
+	echo "[pulse-wrapper] WARN: PULSE_MODEL env var is deprecated (v3.7+). Model routing is now automatic via routing table + availability checks. Remove this export from credentials.sh." >&2
 fi
 if [[ -n "${AIDEVOPS_HEADLESS_MODELS:-}" ]]; then
-	echo "[pulse-wrapper] WARN: AIDEVOPS_HEADLESS_MODELS env var is deprecated (v3.7+). Model routing is now automatic via pool + routing table. Remove this export from credentials.sh." >&2
+	echo "[pulse-wrapper] WARN: AIDEVOPS_HEADLESS_MODELS env var is deprecated (v3.7+). Model routing is now automatic via routing table + availability checks. Remove this export from credentials.sh." >&2
 fi
-# Derive pulse model from routing table — pulse always uses Anthropic sonnet
-ROUTING_TABLE="${SCRIPT_DIR}/../configs/model-routing-table.json"
-if [[ -z "${PULSE_MODEL:-}" ]] && [[ -f "$ROUTING_TABLE" ]] && command -v jq >/dev/null 2>&1; then
-	PULSE_MODEL=$(jq -r '.tiers.sonnet.models[] | select(startswith("anthropic/"))' "$ROUTING_TABLE" 2>/dev/null | head -1) || PULSE_MODEL=""
+if [[ -z "${PULSE_MODEL:-}" ]] && [[ -x "$MODEL_AVAILABILITY_HELPER" ]]; then
+	PULSE_MODEL=$("$MODEL_AVAILABILITY_HELPER" resolve sonnet --quiet 2>/dev/null || true)
 fi
-# Absolute fallback
+# Absolute fallback if routing resolution fails entirely.
 PULSE_MODEL="${PULSE_MODEL:-anthropic/claude-sonnet-4-6}"
 PULSE_BACKFILL_MAX_ATTEMPTS="${PULSE_BACKFILL_MAX_ATTEMPTS:-3}"                                            # Additional pulse passes when below utilization target (t1453)
 PULSE_LAUNCH_GRACE_SECONDS="${PULSE_LAUNCH_GRACE_SECONDS:-35}"                                             # Max grace window for worker process to appear after dispatch (t1453) — raised from 20s to 35s: sandbox-exec + opencode cold-start takes ~25-30s
@@ -3099,7 +3100,7 @@ gathered by pulse-wrapper.sh BEFORE this session started."
 	fi
 
 	# Run the provider-aware headless wrapper in background.
-	local -a pulse_cmd=("$HEADLESS_RUNTIME_HELPER" run --role pulse --session-key supervisor-pulse --dir "$PULSE_DIR" --title "Supervisor Pulse" --agent Automate --prompt "$prompt")
+	local -a pulse_cmd=("$HEADLESS_RUNTIME_HELPER" run --role pulse --session-key supervisor-pulse --dir "$PULSE_DIR" --title "Supervisor Pulse" --agent Automate --prompt "$prompt" --tier sonnet)
 	if [[ -n "$PULSE_MODEL" ]]; then
 		pulse_cmd+=(--model "$PULSE_MODEL")
 	fi
@@ -8146,9 +8147,10 @@ dispatch_with_dedup() {
 	# ROUND-ROBIN MODEL SELECTION (owned by this function, NOT the caller).
 	#
 	# When model_override (param 9) is EMPTY, this function calls
-	# headless-runtime-helper.sh select --role worker, which runs the
-	# round-robin across AIDEVOPS_HEADLESS_MODELS (respects backoff DB,
-	# auth availability, and provider rotation). The resolved model name
+	# headless-runtime-helper.sh select --role worker, which resolves the
+	# worker model from the routing table / local override (respecting
+	# backoff DB, auth availability, provider allowlists, and rotation).
+	# The resolved model name
 	# is shown in the dispatch comment so the audit trail records exactly
 	# which provider/model the worker used.
 	#
@@ -8163,6 +8165,25 @@ dispatch_with_dedup() {
 	# History: GH#17503 moved model resolution here (from the worker) so
 	# the dispatch comment shows the actual model. Prior to that fix, the
 	# comment showed "auto-select (round-robin)" which was unhelpful.
+	local dispatch_tier="standard"
+	local dispatch_model_tier="sonnet"
+	local issue_labels_csv
+	issue_labels_csv=$(echo "$issue_meta_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels_csv=""
+	case ",$issue_labels_csv," in
+	*,tier:reasoning,* | *,tier:thinking,*)
+		dispatch_tier="reasoning"
+		dispatch_model_tier="opus"
+		;;
+	*,tier:standard,*)
+		dispatch_tier="standard"
+		dispatch_model_tier="sonnet"
+		;;
+	*,tier:simple,*)
+		dispatch_tier="simple"
+		dispatch_model_tier="haiku"
+		;;
+	esac
+
 	local selected_model=""
 	if [[ -n "$model_override" ]]; then
 		selected_model="$model_override"
@@ -8184,12 +8205,13 @@ dispatch_with_dedup() {
 	fi
 
 	# Launch worker — headless-runtime-helper.sh handles model selection
-	# via round-robin when no --model is specified. Its choose_model() reads
-	# AIDEVOPS_HEADLESS_MODELS, checks backoff/auth, and rotates providers.
+	# when no --model is specified. Its choose_model() uses the routing
+	# table/local override, then checks backoff/auth and rotates providers.
 	local -a worker_cmd=("$HEADLESS_RUNTIME_HELPER" run
 		--role worker
 		--session-key "$session_key"
 		--dir "$repo_path"
+		--tier "$dispatch_model_tier"
 		--title "$dispatch_title"
 		--prompt "$prompt")
 	if [[ -n "$selected_model" ]]; then
@@ -8210,16 +8232,6 @@ dispatch_with_dedup() {
 	# time to complete its initial DB writes before the next one starts.
 	local stagger_delay="${PULSE_DISPATCH_STAGGER_SECONDS:-8}"
 	sleep "$stagger_delay"
-
-	# Determine dispatch tier from issue labels for telemetry
-	local dispatch_tier="standard"
-	local issue_labels_csv
-	issue_labels_csv=$(echo "$issue_meta_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels_csv=""
-	case ",$issue_labels_csv," in
-	*,tier:reasoning,* | *,tier:thinking,*) dispatch_tier="reasoning" ;;
-	*,tier:standard,*) dispatch_tier="standard" ;;
-	*,tier:simple,*) dispatch_tier="simple" ;;
-	esac
 
 	# Record in dispatch ledger (with tier telemetry)
 	local ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"

--- a/.agents/tools/ai-assistants/models-opus.md
+++ b/.agents/tools/ai-assistants/models-opus.md
@@ -3,10 +3,10 @@ description: Highest-capability model for architecture decisions, novel problems
 mode: subagent
 model: anthropic/claude-opus-4-6
 model-tier: opus
-model-fallback: openai/gpt-5.4-pro
+model-fallback: openai/gpt-5.4
 fallback-chain:
   - anthropic/claude-opus-4-6
-  - openai/gpt-5.4-pro
+  - openai/gpt-5.4
   - anthropic/claude-sonnet-4-6
   - openrouter/anthropic/claude-opus-4-6
 tools:

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -69,16 +69,59 @@ Supervisor resolves automatically. Interactive: `compare-models-helper.sh discov
 
 ## Headless Dispatch
 
-**Automatic model derivation (GH#17769):** The headless model list is derived at runtime — no env var configuration needed:
+**Automatic model derivation (GH#17769):** Headless routing is derived at runtime — no model-ID env var configuration needed:
 
-1. **OAuth pool** (`oauth-pool-helper.sh list all`) → available providers (cheap JSON read, no API calls)
-2. **Routing table** (`configs/model-routing-table.json`) → sonnet-tier model per provider
-3. **Result**: round-robin list of agentic models matching the user's active accounts
+1. **Routing table** (`configs/model-routing-table.json`, or local override at `custom/configs/model-routing-table.json`) → ordered models per tier
+2. **Provider filter** (`AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`) → optional local pinning such as `openai`
+3. **Auth + availability checks** (`headless-runtime-helper.sh`, `model-availability-helper.sh`) → providers/models that can actually run now
+4. **Result**: pulse resolves a sonnet-tier model; workers round-robin across the filtered sonnet-tier list
 
-- **Pulse**: Always Anthropic sonnet (derived from routing table). OpenAI models exit without activity (proven).
-- **Workers**: Round-robin across all pool providers' sonnet models. Tier escalation: `tier:reasoning` labels (cascade: `tier:simple` → `tier:standard` → `tier:reasoning`).
-- **Fallback**: If pool or routing table unavailable, falls back to `anthropic/claude-sonnet-4-6`.
+- **Shared default**: The framework routing table remains Anthropic-first. Other providers are opt-in through `custom/configs/model-routing-table.json`, so existing Anthropic users are unchanged after update.
+- **Pulse**: Resolves `sonnet` through `model-availability-helper.sh resolve sonnet`, so it follows routing-table order, health checks, local routing-table overrides, and `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`.
+- **Workers**: Round-robin across the routed `sonnet` models after allowlist filtering and auth checks. Tier escalation still uses `resolve` (`tier:simple` → `haiku`, `tier:standard` → `sonnet`, `tier:reasoning` → `opus`).
+- **Local switch**: Add OpenAI models to `custom/configs/model-routing-table.json`, then set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto OpenAI. If you want OpenAI primary but Anthropic fallback, reorder the custom routing table and omit the allowlist.
+- **Reasoning effort**: OpenCode exposes GPT reasoning variants separately (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`). Headless runs do not default to `xhigh`; if no variant is set, OpenCode sends no explicit effort override and the provider default applies.
+- **Tier-aware effort**: Headless dispatch can now apply variants by resolved tier. `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` and `AIDEVOPS_HEADLESS_VARIANT_OPUS=xhigh` make standard work run at `high` and reasoning-tier work run at `xhigh` even when both tiers use `openai/gpt-5.4`.
+- **Fallback**: If routed resolution fails entirely, pulse falls back to `anthropic/claude-sonnet-4-6`; workers fall back to `DEFAULT_HEADLESS_MODELS` when no allowlist is forcing a subset.
 - **Deprecated**: `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle with deprecation warnings. Remove from `credentials.sh`.
+
+### Per-user override that survives auto-update
+
+Auto-update overwrites `~/.aidevops/agents/configs/*.json` and `~/.aidevops/agents/scripts/*`, so user-specific routing must live outside those paths.
+
+- Put persistent model-order overrides in `~/.aidevops/agents/custom/configs/model-routing-table.json`
+- Put the provider pin in `~/.config/aidevops/credentials.sh`
+
+Example custom override for OpenAI-capable headless routing:
+
+```json
+{
+  "tiers": {
+    "sonnet": { "models": ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"] },
+    "opus": { "models": ["openai/gpt-5.4", "anthropic/claude-opus-4-6"] }
+  }
+}
+```
+
+Example hard pin:
+
+```bash
+export AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="openai"
+```
+
+Example reasoning effort override:
+
+```bash
+export AIDEVOPS_HEADLESS_VARIANT_SONNET="high"
+export AIDEVOPS_HEADLESS_VARIANT_OPUS="xhigh"
+```
+
+Role-specific overrides still exist when needed:
+
+```bash
+export AIDEVOPS_HEADLESS_PULSE_VARIANT="high"
+export AIDEVOPS_HEADLESS_WORKER_VARIANT="xhigh"
+```
 
 ## CLI Tools
 


### PR DESCRIPTION
## Summary
- add opt-in OpenAI routing for headless pulse/workers while keeping shared defaults Anthropic-first
- make the headless canary validate the routed provider/model so OpenAI clean-start runs are not blocked by an Anthropic-only gate
- support tier-aware OpenCode reasoning effort so sonnet uses high and opus uses xhigh with openai/gpt-5.4

## Verification
- `bash -n .agents/scripts/headless-runtime-helper.sh`
- `bash -n .agents/scripts/model-availability-helper.sh`
- `bash -n .agents/scripts/pulse-wrapper.sh`
- `shellcheck -S warning .agents/scripts/headless-runtime-helper.sh`
- `shellcheck -S warning .agents/scripts/model-availability-helper.sh`
- deployed locally with `./setup.sh --non-interactive`
- verified `model-availability-helper.sh resolve sonnet --quiet` and `resolve opus --quiet` both return `openai/gpt-5.4` under the local override
- live clean-start smoke tests passed:
  - sonnet: `opencode run ... -m openai/gpt-5.4 ... --variant high` -> `OK`
  - opus: `opencode run ... -m openai/gpt-5.4 ... --variant xhigh` -> `OK`

Resolves #17995


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.218 plugin for [OpenCode](https://opencode.ai) v1.4.0 with gpt-5.4 spent 1h 28m and 865,483 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local customization for model routing without modifying system files.
  * Introduced provider allowlist to restrict which AI providers are used.
  * Added `--tier` and `--variant` flags for model selection overrides.

* **Documentation**
  * Updated guidance on model routing, variant selection, and local configuration workflows.
  * Clarified headless model resolution pipeline and provider filtering behavior.

* **Chores**
  * Updated default fallback model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->