### PR TITLE
GH#17898: consolidate jq calls in normalize_active_issue_assignments into single pass

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "b347bcd4c143ff4e9eebe63fe750fcd48ef6be55",
+      "hash": "0b8733892d91916d3f92db72ea80263570d08a30",
       "at": "2026-04-09T07:32:02Z",
-      "passes": 30,
+      "passes": 0,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3970,8 +3970,8 @@ normalize_active_issue_assignments() {
 				IFS= read -r dispatch_pid
 				IFS= read -r dispatch_created_at
 			} < <(gh api "repos/${slug}/issues/${stale_num}/comments" \
-				--jq '[.[] | select(.body | startswith("Dispatching worker"))] | sort_by(.created_at) | last | if . then ((.body | capture("\\*\\*Worker PID\\*\\*: (?<pid>[0-9]+)") | .pid // ""), .created_at) else empty end' \
-				-r 2>/dev/null) || true
+				--jq '[.[] | select(.body | test("^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker"))] | sort_by(.created_at) | last | if . then ((.body | capture("\\*\\*Worker PID\\*\\*: (?<pid>[0-9]+)") | .pid // ""), .created_at) else empty end' \
+				2>/dev/null) || true
 
 			if [[ -n "$dispatch_created_at" ]]; then
 				local dispatch_epoch

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3960,22 +3960,25 @@ normalize_active_issue_assignments() {
 			# other machines.
 			local dispatch_pid=""
 			local dispatch_comment_age=0
-			local dispatch_comments_json
-			# Match dispatch comments with or without <!-- ops:start --> marker prefix (GH#17945)
-			dispatch_comments_json=$(gh api "repos/${slug}/issues/${stale_num}/comments" \
-				--jq '[.[] | select(.body | test("^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker"))] | sort_by(.created_at) | reverse | first // empty' \
-				2>/dev/null) || dispatch_comments_json=""
-			if [[ -n "$dispatch_comments_json" && "$dispatch_comments_json" != "null" ]]; then
-				dispatch_pid=$(printf '%s' "$dispatch_comments_json" | jq -r '
-					.body | capture("\\*\\*Worker PID\\*\\*: (?<pid>[0-9]+)") | .pid // ""
-				' 2>/dev/null) || dispatch_pid=""
-				local dispatch_created_at
-				dispatch_created_at=$(printf '%s' "$dispatch_comments_json" | jq -r '.created_at // ""' 2>/dev/null) || dispatch_created_at=""
-				if [[ -n "$dispatch_created_at" ]]; then
-					local dispatch_epoch
-					dispatch_epoch=$(date -u -d "$dispatch_created_at" '+%s' 2>/dev/null ||
-						TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$dispatch_created_at" '+%s' 2>/dev/null ||
-						echo "0")
+			local dispatch_created_at=""
+
+			# Read PID and creation date from the latest dispatch comment in one go.
+			# This avoids storing the full comment JSON and running multiple jq processes.
+			# The || true on the process substitution prevents set -e from exiting
+			# if gh api returns no comments.
+			{
+				IFS= read -r dispatch_pid
+				IFS= read -r dispatch_created_at
+			} < <(gh api "repos/${slug}/issues/${stale_num}/comments" \
+				--jq '[.[] | select(.body | startswith("Dispatching worker"))] | sort_by(.created_at) | last | if . then ((.body | capture("\\*\\*Worker PID\\*\\*: (?<pid>[0-9]+)") | .pid // ""), .created_at) else empty end' \
+				-r 2>/dev/null) || true
+
+			if [[ -n "$dispatch_created_at" ]]; then
+				local dispatch_epoch
+				dispatch_epoch=$(date -u -d "$dispatch_created_at" '+%s' 2>/dev/null ||
+					TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$dispatch_created_at" '+%s' 2>/dev/null ||
+					echo "0")
+				if [[ "$dispatch_epoch" -gt 0 ]]; then
 					dispatch_comment_age=$((now_epoch - dispatch_epoch))
 				fi
 			fi


### PR DESCRIPTION
## Summary

Consolidates multiple jq calls in `normalize_active_issue_assignments` (`.agents/scripts/pulse-wrapper.sh:3961`) into a single `gh api` + `jq` pass using process substitution.

**Before:** One `gh api` call stored the full comment JSON, then two separate `jq` invocations extracted the PID and `created_at` fields.

**After:** A single `gh api --jq` call outputs both values line-by-line; a `{ read; read; } < <(...)` block reads them into shell variables in one pass. A guard ensures `dispatch_comment_age` is only calculated when a valid `dispatch_epoch` > 0 is found.

## Changes

- EDIT: `.agents/scripts/pulse-wrapper.sh:3961-3984` — replace multi-jq pattern with process substitution single-pass

## Runtime Testing

Risk: **Low** — refactor of internal stale-issue detection logic; no change to observable behaviour or external API calls. Self-assessed.

## Verification

- `shellcheck -S error .agents/scripts/pulse-wrapper.sh` — passes (CI gate)
- Logic equivalence: same fields extracted, same guard conditions, fewer process forks

Resolves #17898

<!-- aidevods:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.219 plugin for [OpenCode](https://opencode.ai) v1.4.1 with claude-sonnet-4-6 spent 2m and 3,993 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refreshed system configuration metadata with updated timestamps and pass counters
  * Added new configuration, workflow and support entries

* **Refactor**
  * Streamlined assignment recovery and dispatch handling to avoid failures and reduce stale assignments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->