### PR TITLE
GH#18009: ratchet down nesting depth threshold

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -25,7 +25,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=36
 # Bumped to 258 (GH#17969): threshold saturated at 256/256 (0 headroom); 256 violations + 2 buffer
 # Bumped to 263 (GH#17978): proximity guard firing at 256/258 (2 headroom); 256 violations + 7 headroom
 # Ratcheted down to 258 (GH#17992): actual violations 256 + 2 buffer
-NESTING_DEPTH_THRESHOLD=258
+# Ratcheted down to 247 (GH#18009): actual violations 245 + 2 buffer
+NESTING_DEPTH_THRESHOLD=247
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary
- Ratchet `NESTING_DEPTH_THRESHOLD` down from 258 to 247 after the current nesting-depth violation count dropped to 245.
- Preserve the audit trail in `.agents/configs/complexity-thresholds.conf` by recording the GH#18009 ratchet-down comment above the updated threshold.

## Runtime Testing
- Risk: low (configuration-only quality gate update)
- Verification: self-assessed via threshold inspection and ratchet-check helper output

## Testing
- `grep -E 'FUNCTION_COMPLEXITY_THRESHOLD|NESTING_DEPTH_THRESHOLD|FILE_SIZE_THRESHOLD|BASH32_COMPAT_THRESHOLD' .agents/configs/complexity-thresholds.conf`
- `.agents/scripts/complexity-scan-helper.sh ratchet-check . 5`

Resolves #18009


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.219 plugin for [OpenCode](https://opencode.ai) v1.4.1 with gpt-5.4 spent 4m and 51,565 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated quality gate thresholds to enforce stricter code complexity standards during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->