### PR TITLE
GH#18011: remove BSD grep noise from headless runtime diagnostics

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -826,11 +826,10 @@ for line in Path(sys.argv[1]).read_text(errors="ignore").splitlines():
         continue
     if obj.get("sessionID"):
         session_id = obj["sessionID"]
-        break
+        continue
     part = obj.get("part") or {}
     if part.get("sessionID"):
         session_id = part["sessionID"]
-        break
 print(session_id)
 PY
 	return 0
@@ -2230,7 +2229,7 @@ _execute_run_attempt() {
 	# Extract session ID BEFORE the append block to avoid SC2094 (read+write same file).
 	local _diag_session_id="" _diag_incomplete_msgs="0"
 	if [[ "$exit_code" -eq 0 && -f "$output_file" ]]; then
-		_diag_session_id=$(grep -oP '"sessionID":"[^"]*"' "$output_file" 2>/dev/null | tail -1 | grep -oP '"[^"]*"$' | tr -d '"' || true)
+		_diag_session_id=$(extract_session_id_from_output "$output_file" 2>/dev/null || true)
 		if [[ -n "$_diag_session_id" ]]; then
 			_diag_incomplete_msgs=$(sqlite3 ~/.local/share/opencode/opencode.db \
 				"SELECT count(*) FROM message WHERE session_id='${_diag_session_id}' AND json_extract(data, '$.role')='assistant' AND json_extract(data, '$.time.completed') IS NULL" 2>/dev/null || echo "0")

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -60,10 +60,10 @@ test_appends_escalation_contract() {
 	local output
 	output=$(append_worker_headless_contract "$prompt")
 
-	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V1'* ]] &&
-		[[ "$output" == *'Treat review-policy metadata alone as non-blocking'* ]] &&
-		[[ "$output" == *'Before exiting BLOCKED or handing work to a human, try at least one stronger-model or alternate-provider path'* ]] &&
-		[[ "$output" == *'Use BLOCKED only for real blockers with evidence after retries/escalation are exhausted'* ]]; then
+	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V5'* ]] &&
+		[[ "$output" == *'Read the issue body FIRST. Look for a "Worker Guidance" or "How" section'* ]] &&
+		[[ "$output" == *'Never ask for user confirmation, approval, or next steps. No user will respond.'* ]] &&
+		[[ "$output" == *'The only valid exit states are FULL_LOOP_COMPLETE or BLOCKED with evidence.'* ]]; then
 		print_result "appends escalation-before-blocked contract to full-loop prompts" 0
 		return 0
 	fi
@@ -89,7 +89,7 @@ test_non_full_loop_prompt_unchanged() {
 test_does_not_double_append() {
 	local prompt='/full-loop Continue issue #14964
 
-[HEADLESS_CONTINUATION_CONTRACT_V1]
+[HEADLESS_CONTINUATION_CONTRACT_V5]
 This worker run is unattended.'
 	local output
 	output=$(append_worker_headless_contract "$prompt")
@@ -103,11 +103,32 @@ This worker run is unattended.'
 	return 0
 }
 
+test_extract_session_id_from_output_returns_latest_session_id() {
+	local output_file="${TEST_ROOT}/opencode-output.jsonl"
+	cat >"$output_file" <<'EOF'
+not-json
+{"type":"message","sessionID":"ses_early"}
+{"type":"tool_use","part":{"sessionID":"ses_latest"}}
+EOF
+
+	local session_id
+	session_id=$(extract_session_id_from_output "$output_file")
+
+	if [[ "$session_id" == "ses_latest" ]]; then
+		print_result "extract_session_id_from_output returns latest session id" 0
+		return 0
+	fi
+
+	print_result "extract_session_id_from_output returns latest session id" 1 "Expected ses_latest, got ${session_id:-<empty>}"
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_appends_escalation_contract
 	test_non_full_loop_prompt_unchanged
 	test_does_not_double_append
+	test_extract_session_id_from_output_returns_latest_session_id
 	teardown_test_env
 
 	printf '\nTests run: %d\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary
- replace the successful-run `sessionID` parsing path in `headless-runtime-helper.sh` with the existing JSONL parser so macOS no longer hits BSD-incompatible `grep -P`
- preserve the latest observed `sessionID` behavior and add regression coverage for that parser
- update the headless runtime contract test to match the current `HEADLESS_CONTINUATION_CONTRACT_V5` content

## Verification
- `shellcheck -x .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/headless-runtime-helper.sh run --role worker --session-key "smoke-grep-p-noise-$(date +%s)" --dir "/Users/marcusquinn/Git/aidevops-hotfix-grep-p-noise" --title "smoke grep noise" --prompt "Reply exactly OK and stop." --model "openai/gpt-5.4" --variant high`
- `bash ~/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key "smoke-deployed-grep-p-noise-$(date +%s)" --dir "/Users/marcusquinn/Git/aidevops-hotfix-grep-p-noise" --title "deployed smoke grep noise" --prompt "Reply exactly OK and stop." --model "openai/gpt-5.4" --variant high`

Resolves #18011

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.219 plugin for [OpenCode](https://opencode.ai) v1.4.1 with gpt-5.4 spent 10h 34m and 1,476,759 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal session identification logic to ensure more reliable discovery of session data.

* **Tests**
  * Updated headless continuation contract test assertions to align with latest specifications.
  * Added test coverage for session identification to verify correct behavior with multiple occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->