### PR TITLE
GH#18016: ratchet down nesting depth threshold

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -30,7 +30,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=36
 # Ratcheted down to 258 (GH#17992): actual violations 256 + 2 buffer
 # Ratcheted down to 247 (GH#18009): actual violations 245 + 2 buffer
 # Bumped to 252 (GH#18013): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
-NESTING_DEPTH_THRESHOLD=252
+# Ratcheted down to 247 (GH#18016): actual violations 245 + 2 buffer
+NESTING_DEPTH_THRESHOLD=247
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary
- lower `NESTING_DEPTH_THRESHOLD` from 252 to 247 in `.agents/configs/complexity-thresholds.conf`
- record the GH#18016 ratchet-down comment without removing the existing bump history
- keep the nesting-depth buffer aligned with the current 245 measured violations

## Testing
- `rg -n "NESTING_DEPTH_THRESHOLD|FUNCTION_COMPLEXITY_THRESHOLD|FILE_SIZE_THRESHOLD|BASH32_COMPAT_THRESHOLD|GH#18016" .agents/configs/complexity-thresholds.conf`
- `.agents/scripts/complexity-scan-helper.sh ratchet-check . 5`

## Runtime Testing
- Risk: low
- Status: self-assessed
- Reason: configuration-only threshold change with deterministic script verification

Resolves #18016


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.221 plugin for [OpenCode](https://opencode.ai) v1.4.2 with gpt-5.4 spent 3m and 48,136 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration threshold value.

---

**Note:** This is an internal technical adjustment with no impact on end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->