### PR TITLE
GH#18021: add ownership registry check to Pass 2 orphan worktree cleanup

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3266,6 +3266,18 @@ cleanup_worktrees() {
 					continue
 				fi
 
+				# Check ownership registry before removing (GH#18021).
+				# pgrep only detects processes that expose the worktree path
+				# in their argv. Interactive runtimes (e.g. OpenCode Web, Claude Code)
+				# dispatch MCP tool calls inside the agent runtime — the worktree
+				# path never appears in process arguments. The registry is the
+				# authoritative source for live ownership; skip removal if a live
+				# owner PID is registered.
+				if is_worktree_owned_by_others "$wt_path_age"; then
+					echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} ($wt_path_age) — registered owner alive in registry" >>"$LOGFILE"
+					continue
+				fi
+
 				local should_remove=false
 				local reason=""
 


### PR DESCRIPTION
## Summary

- **Root cause**: Pass 2 of `cleanup_worktrees()` (age-based orphan cleanup in `pulse-wrapper.sh`) only used `pgrep` to detect active processes. Interactive runtimes (OpenCode Web, Claude Code) run MCP tool calls inside the agent runtime without exposing the worktree path in process argv — so `pgrep` returns nothing and Pass 2 treats the worktree as abandoned.
- **Fix**: Add `is_worktree_owned_by_others "$wt_path_age"` check after the `pgrep` guard (line 3268), before any `should_remove=true` decision. If the registry has a live owner PID, skip the worktree.
- **Alignment**: Pass 1 (`worktree-helper.sh clean --auto --force-merged`) already calls `is_worktree_owned_by_others()` via `should_skip_cleanup()`. This PR brings Pass 2 to parity.

## Files Changed

- `EDIT: .agents/scripts/pulse-wrapper.sh` — 12 lines added at lines 3269–3279 (after the `pgrep` check, before `local should_remove=false`)

## Testing

- **ShellCheck**: zero violations on the changed section
- **Self-assessed**: the function `is_worktree_owned_by_others` is already available in `pulse-wrapper.sh` (shared-constants.sh sourced at line 100); no new dependencies introduced
- **Stale-entry safety**: `is_worktree_owned_by_others()` auto-prunes dead PIDs from the registry, so crashed workers without a live PID still get cleaned up

## Runtime Testing

Risk: **Low** — change is a guard clause (`continue`) inside an orphan-cleanup loop. No existing pass logic is altered; the only new behaviour is "skip worktrees with a live registry owner". Self-assessed.

Resolves #18021

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.222 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-sonnet-4-6 spent 2m and 4,616 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree cleanup safety by implementing registry-based ownership detection. The system now better preserves active worktrees that may not be discoverable through standard process monitoring, preventing potential accidental deletions in certain runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->