### PR TITLE
GH#18018: connect pulse_interval_seconds to Linux scheduler installation

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -199,7 +199,7 @@ _read_pulse_interval_seconds() {
 
 # Convert an interval in seconds to a cron schedule expression (e.g. "*/2 * * * *").
 # Minimum granularity is 1 minute. Intervals that don't divide evenly into minutes
-# are rounded to the nearest minute with a warning.
+# are rounded down to whole minutes with a warning.
 # Args: $1 = interval_seconds
 _seconds_to_cron_schedule() {
 	local _interval_sec="$1"
@@ -213,10 +213,16 @@ _seconds_to_cron_schedule() {
 
 	# Warn if interval doesn't divide evenly into minutes
 	if [[ "$_remainder" -ne 0 ]]; then
-		echo "[schedulers] Warning: pulse_interval_seconds=${_interval_sec} does not divide evenly into minutes; rounding to ${_minutes}min for cron schedule (systemd uses exact seconds)" >&2
+		echo "[schedulers] Warning: pulse_interval_seconds=${_interval_sec} does not divide evenly into minutes; rounding down to ${_minutes}min for cron schedule (systemd uses exact seconds)" >&2
 	fi
 
-	printf '*/%d * * * *' "$_minutes"
+	# cron step values must be 1-59; */60 is invalid. Use @hourly for exactly 60 min,
+	# clamp anything above 59 to 59 (the _read_pulse_interval_seconds cap is 3600s=60min).
+	if [[ "$_minutes" -ge 60 ]]; then
+		printf '@hourly'
+	else
+		printf '*/%d * * * *' "$_minutes"
+	fi
 	return 0
 }
 
@@ -239,7 +245,13 @@ _install_supervisor_pulse() {
 	_pulse_interval_sec=$(_read_pulse_interval_seconds)
 	local _pulse_cron_schedule
 	_pulse_cron_schedule=$(_seconds_to_cron_schedule "$_pulse_interval_sec")
-	local _pulse_interval_min=$((_pulse_interval_sec / 60))
+	# Build a human-readable interval label: show seconds when < 60s, minutes otherwise
+	local _pulse_interval_label
+	if [[ "$_pulse_interval_sec" -lt 60 ]]; then
+		_pulse_interval_label="${_pulse_interval_sec}s"
+	else
+		_pulse_interval_label="$((_pulse_interval_sec / 60))min"
+	fi
 
 	local _pulse_timeout_sec=$((PULSE_STALE_THRESHOLD_SECONDS + 60))
 	local _pulse_env=""
@@ -252,7 +264,7 @@ _install_supervisor_pulse() {
 		"${_pulse_interval_sec}" \
 		"$HOME/.aidevops/logs/pulse-wrapper.log" \
 		"$_pulse_env" \
-		"Supervisor pulse enabled (every ${_pulse_interval_min} min)" \
+		"Supervisor pulse enabled (every ${_pulse_interval_label})" \
 		"Failed to install supervisor pulse scheduler. See runners.md for manual setup." \
 		"true" \
 		"false" \

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -170,6 +170,56 @@ PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}"
 	return 0
 }
 
+# Read supervisor.pulse_interval_seconds from settings.json.
+# Falls back to 120 if the file is missing, the key is absent, or jq is unavailable.
+# Clamps to the validated range [30, 3600].
+# GH#18018: previously this was hardcoded as "120" in _install_supervisor_pulse.
+_read_pulse_interval_seconds() {
+	local _settings_file="$HOME/.config/aidevops/settings.json"
+	local _interval=120
+
+	if command -v jq >/dev/null 2>&1 && [[ -f "$_settings_file" ]]; then
+		local _raw
+		_raw=$(jq -r '.supervisor.pulse_interval_seconds // empty' "$_settings_file" 2>/dev/null) || _raw=""
+		if [[ -n "$_raw" ]] && [[ "$_raw" =~ ^[0-9]+$ ]]; then
+			_interval="$_raw"
+		fi
+	fi
+
+	# Clamp to validated range (mirrors settings-helper.sh validation: 30-3600)
+	if [[ "$_interval" -lt 30 ]]; then
+		_interval=30
+	elif [[ "$_interval" -gt 3600 ]]; then
+		_interval=3600
+	fi
+
+	printf '%d' "$_interval"
+	return 0
+}
+
+# Convert an interval in seconds to a cron schedule expression (e.g. "*/2 * * * *").
+# Minimum granularity is 1 minute. Intervals that don't divide evenly into minutes
+# are rounded to the nearest minute with a warning.
+# Args: $1 = interval_seconds
+_seconds_to_cron_schedule() {
+	local _interval_sec="$1"
+	local _minutes=$((_interval_sec / 60))
+	local _remainder=$((_interval_sec % 60))
+
+	# Clamp to at least 1 minute
+	if [[ "$_minutes" -lt 1 ]]; then
+		_minutes=1
+	fi
+
+	# Warn if interval doesn't divide evenly into minutes
+	if [[ "$_remainder" -ne 0 ]]; then
+		echo "[schedulers] Warning: pulse_interval_seconds=${_interval_sec} does not divide evenly into minutes; rounding to ${_minutes}min for cron schedule (systemd uses exact seconds)" >&2
+	fi
+
+	printf '*/%d * * * *' "$_minutes"
+	return 0
+}
+
 _install_supervisor_pulse() {
 	local _os="$1"
 	local pulse_label="$2"
@@ -184,18 +234,25 @@ _install_supervisor_pulse() {
 		return 0
 	fi
 
+	# GH#18018: read user-configured interval instead of hardcoding 120s / */2 cron
+	local _pulse_interval_sec
+	_pulse_interval_sec=$(_read_pulse_interval_seconds)
+	local _pulse_cron_schedule
+	_pulse_cron_schedule=$(_seconds_to_cron_schedule "$_pulse_interval_sec")
+	local _pulse_interval_min=$((_pulse_interval_sec / 60))
+
 	local _pulse_timeout_sec=$((PULSE_STALE_THRESHOLD_SECONDS + 60))
 	local _pulse_env=""
 	_pulse_env=$(_build_pulse_linux_env)
 	_install_scheduler_linux \
 		"aidevops-supervisor-pulse" \
 		"aidevops: supervisor-pulse" \
-		"*/2 * * * *" \
+		"${_pulse_cron_schedule}" \
 		"\"${wrapper_script}\"" \
-		"120" \
+		"${_pulse_interval_sec}" \
 		"$HOME/.aidevops/logs/pulse-wrapper.log" \
 		"$_pulse_env" \
-		"Supervisor pulse enabled (every 2 min)" \
+		"Supervisor pulse enabled (every ${_pulse_interval_min} min)" \
 		"Failed to install supervisor pulse scheduler. See runners.md for manual setup." \
 		"true" \
 		"false" \


### PR DESCRIPTION
## Summary

- Fixes the disconnected `supervisor.pulse_interval_seconds` setting: it existed, was validated, but was never read by the scheduler installer (dead config path).
- Adds `_read_pulse_interval_seconds()` to read from `~/.config/aidevops/settings.json` (jq, falls back to 120, clamps to [30, 3600]).
- Adds `_seconds_to_cron_schedule()` to derive a cron expression from seconds (1-min minimum, warns on non-even divisors since systemd handles seconds natively).
- `_install_supervisor_pulse()` now passes the user-configured interval to `_install_scheduler_linux()` for both cron schedule and systemd `OnUnitActiveSec`.
- The existing dual-backend dedup logic (systemd preferred, cron migrated on upgrade; GH#17695) is **unchanged** — this PR only fixes the hardcoded values.

## Files Changed

- `setup-modules/schedulers.sh` — two new helpers + updated `_install_supervisor_pulse()`

## Testing

- ShellCheck: zero violations
- Unit-tested `_seconds_to_cron_schedule` and `_read_pulse_interval_seconds` with temp home directory — all cases pass (120s→`*/2`, 300s→`*/5`, 90s→`*/1`+warning, settings override)
- Verification: after merge, `aidevops settings set supervisor.pulse_interval_seconds 300` + `aidevops update` should produce `*/5` cron or 300s systemd timer

## Runtime Testing

Risk: **Low** — no payment, auth, data deletion, crypto, or polling loops. Config read + string formatting only. `self-assessed`.

Resolves #18018

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.223 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-sonnet-4-6 spent 3m and 7,687 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supervisor pulse timing is now configurable via the user settings file (30 seconds–1 hour) with automatic validation and clamping for stability.
  * The system converts the chosen interval into the scheduled task format, uses an hourly shortcut when appropriate, and warns if the interval isn’t an exact whole-minute multiple.
  * Installation messages now report the configured interval (seconds if <60, otherwise minutes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->