### PR TITLE
GH#18028: chore: ratchet-down NESTING_DEPTH_THRESHOLD 252→247

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -32,7 +32,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=36
 # Bumped to 252 (GH#18013): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
 # Ratcheted down to 247 (GH#18016): actual violations 245 + 2 buffer
 # Bumped to 252 (GH#18020): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
-NESTING_DEPTH_THRESHOLD=252
+# Ratcheted down to 247 (GH#18028): actual violations 245 + 2 buffer
+NESTING_DEPTH_THRESHOLD=247
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "97615cc9382c96d3ffcd2566af1318ce197b9bc9",
-      "at": "2026-04-09T22:13:22Z",
-      "passes": 1,
+      "hash": "caa7d5c519f2d3e5f189b8313cc2147b6bd5c3a7",
+      "at": "2026-04-09T23:08:56Z",
+      "passes": 2,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "5928586c8770ddc41599eb5fd851c011ddf27092",
-      "at": "2026-04-09T22:13:39Z",
-      "passes": 45,
+      "hash": "96c83b6f76e5fba7029fd1683c631fdfc685b12b",
+      "at": "2026-04-09T23:09:13Z",
+      "passes": 46,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "797d61ac5aa9a62ef17d462264d4eae93c28a3cd",
-      "at": "2026-04-09T22:13:39Z",
-      "passes": 44,
+      "hash": "08fa82bd778ebd6940b673f6fd04fe14d66d17a1",
+      "at": "2026-04-09T23:09:13Z",
+      "passes": 45,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6773,10 +6773,10 @@
       "passes": 2
     },
     ".agents/configs/complexity-thresholds-history.md": {
-      "hash": "d519704771418341f344b240857205005ed10058",
-      "at": "2026-04-09T22:13:15Z",
+      "hash": "04529bc634ad1a2267238a6f91f02c7d6963cef0",
+      "at": "2026-04-09T23:08:50Z",
       "pr": 17979,
-      "passes": 2
+      "passes": 3
     },
     ".agents/scripts/memory-pressure-monitor.sh": {
       "hash": "d71f3754e56b925114a9b13c4ae3809cfb0c199d",


### PR DESCRIPTION
## Summary

Lowers `NESTING_DEPTH_THRESHOLD` from 252 to 247 as part of the automated ratchet-down routine (t1913).

- Actual violations: 245
- New threshold: 245 + 2 buffer = 247
- Gap from previous threshold (252): 5 — within the allowed ratchet window

## Changes

- **EDIT: `.agents/configs/complexity-thresholds.conf`** — lowered `NESTING_DEPTH_THRESHOLD` from 252 to 247, added ratchet-down history comment

## Runtime Testing

Risk level: **Low** (config file only, no code logic changed)
Self-assessed: threshold values verified via `complexity-scan-helper.sh ratchet-check . 5`

Output:
```
[complexity-scan] INFO: Actual violations — func:36 nest:245 size:53 bash32:71
[complexity-scan] INFO: Current thresholds — func:36 nest:247 size:56 bash32:72
[complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 5
```

CI will pass: actual (245) < threshold (247).

Resolves #18028

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.223 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-sonnet-4-6 spent 1m and 1,977 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code complexity analysis configuration to maintain consistency across the codebase.
  * Refreshed state tracking data for development tooling and build automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->