### PR TITLE
t1953: optimize model tier resolution for performance and Bash 3.2

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -158,70 +158,61 @@ _resolve_model_tiers_in_frontmatter() {
 		return 0
 	fi
 
-	# Validate routing table has tiers (Bash 3.2 compatible — no associative arrays)
-	local tier_count
-	tier_count=$(jq -r '.tiers | keys | length' "$routing_table" 2>/dev/null) || tier_count=0
-	if [[ "$tier_count" -eq 0 ]]; then
+	# Build a sed script file from the routing table in ONE jq call.
+	# Each line is a separate sed command for cross-platform compatibility
+	# (macOS sed doesn't support ; as command separator inside {}).
+	# Generates replacements for both plain and commented forms:
+	#   model: sonnet        → model: anthropic/claude-sonnet-4-6
+	#   model: sonnet  # ... → model: anthropic/claude-sonnet-4-6  # ...
+	local sed_file
+	sed_file=$(mktemp "${TMPDIR:-/tmp}/model-resolve-XXXXXX.sed")
+	jq -r '
+		.tiers | to_entries[] |
+		"s|^model: \(.key)$|model: \(.value.models[0])|",
+		"s|^model: \(.key)  #|model: \(.value.models[0])  #|"
+	' "$routing_table" >"$sed_file" 2>/dev/null
+
+	if [[ ! -s "$sed_file" ]]; then
+		rm -f "$sed_file"
 		print_warning "No tiers found in routing table — skipping frontmatter model resolution"
 		return 0
 	fi
 
-	local resolved_count=0
+	# Build a grep pattern to find only files with bare tier names.
+	# This avoids scanning all 3000+ .md files — only ~60 need changes.
+	local tier_names
+	tier_names=$(jq -r '.tiers | keys[]' "$routing_table" 2>/dev/null | paste -sd'|' -)
+	if [[ -z "$tier_names" ]]; then
+		rm -f "$sed_file"
+		return 0
+	fi
+
+	# Find candidate files: have a model: line with a bare tier name (no /)
+	# grep -rl is fast — scans content without loading full files
+	# The || true prevents set -e from exiting when grep finds no matches
 	local md_file
-	# Use a simple while-read loop with find for Bash 3.2 compat (no -print0 + read -d '')
-	find "$target_dir" -name "*.md" -type f | while IFS= read -r md_file; do
-		# Quick check: first line must be --- (YAML frontmatter)
+	{ grep -rlE "^model: ($tier_names)(\$|  #)" "$target_dir" --include='*.md' 2>/dev/null || true; } | while IFS= read -r md_file; do
+		[[ -n "$md_file" ]] || continue
+		# Verify the match is in YAML frontmatter (first line is ---)
 		local first_line
 		first_line=$(head -1 "$md_file" 2>/dev/null) || continue
 		[[ "$first_line" == "---" ]] || continue
 
-		# Scan frontmatter (lines 2..closing ---) for a bare model: line
-		local line_num=0 in_frontmatter=true frontmatter_end=0
-		local model_value="" model_line_num=0 comment_suffix=""
-		while IFS= read -r line; do
-			line_num=$((line_num + 1))
-			[[ "$line_num" -eq 1 ]] && continue # skip opening ---
-			if [[ "$line" == "---" ]]; then
-				frontmatter_end=$line_num
-				break
-			fi
-			# Match: model: <bare-tier>  [# optional comment]
-			# Skip if value contains / (already a FQID)
-			if echo "$line" | grep -qE '^model:[[:space:]]+[^/[:space:]#]+'; then
-				# Extract the tier name (word after "model: ", before whitespace/# )
-				model_value=$(echo "$line" | sed -E 's/^model:[[:space:]]+([^[:space:]#]+).*/\1/')
-				# Extract optional comment suffix
-				if echo "$line" | grep -qF '#'; then
-					comment_suffix=$(echo "$line" | sed -E 's/^[^#]+(#.*)/  \1/')
-				else
-					comment_suffix=""
-				fi
-				model_line_num=$line_num
-			fi
-		done < <(head -20 "$md_file")
-
-		# Skip if no bare model found or frontmatter didn't close
-		[[ -n "$model_value" && "$frontmatter_end" -gt 0 ]] || continue
-
-		# Look up the FQID from routing table
-		local fqid
-		fqid=$(jq -r --arg tier "$model_value" '.tiers[$tier].models[0] // empty' "$routing_table" 2>/dev/null)
-		[[ -n "$fqid" ]] || continue
-
-		# Replace the model line in-place (macOS sed -i '' vs GNU sed -i)
-		if sed -i '' "${model_line_num}s|^model:.*|model: ${fqid}${comment_suffix}|" "$md_file" 2>/dev/null ||
-			sed -i "${model_line_num}s|^model:.*|model: ${fqid}${comment_suffix}|" "$md_file" 2>/dev/null; then
-			resolved_count=$((resolved_count + 1))
-		fi
+		# Apply sed replacements from the script file (macOS sed -i '' vs GNU sed -i)
+		sed -i '' -f "$sed_file" "$md_file" 2>/dev/null ||
+			sed -i -f "$sed_file" "$md_file" 2>/dev/null || true
 	done
 
-	# The while loop runs in a subshell (piped from find), so resolved_count
-	# won't propagate. Re-count by checking deployed files for FQIDs.
-	local actual_count
-	actual_count=$(grep -rl '^model: [a-z]*/[a-z]' "$target_dir" --include='*.md' 2>/dev/null | wc -l | tr -d ' ')
-	if [[ "$actual_count" -gt 0 ]]; then
+	# Count remaining unresolved files
+	local remaining
+	remaining=$({ grep -rlE "^model: ($tier_names)(\$|  #)" "$target_dir" --include='*.md' 2>/dev/null || true; } | wc -l | tr -d ' ')
+	if [[ "$remaining" -eq 0 ]]; then
 		print_success "Resolved model tiers to FQIDs in deployed agent files (via model-routing-table.json)"
+	else
+		print_warning "Some model tiers could not be resolved ($remaining files remaining)"
 	fi
+
+	rm -f "$sed_file"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #18051 — the initial implementation scanned all 3,328 `.md` files with per-file `jq` calls, causing timeouts on large deployments.

- Single `jq` call builds a sed script file from `model-routing-table.json`
- `grep -rl` finds only ~60 candidate files with bare tier names
- `sed -f` applies all replacements in one pass per file
- Fixes `set -e`/ERR trap interactions with grep exit codes (grep returns 1 when no matches)
- Runs in 0.05s vs previous timeout

## Testing

All 5 test cases pass:
1. `model: sonnet` → `model: anthropic/claude-sonnet-4-6` ✓
2. `model: haiku` → `model: anthropic/claude-haiku-4-5` ✓
3. `model: opus  # comment` → preserved comment ✓
4. Already-FQID → unchanged ✓
5. No frontmatter → unchanged ✓

## Runtime Testing

- **Risk**: Low — deploy-time processing of agent prompt files
- **Verification**: `self-assessed` — timed execution (0.05s), shellcheck clean

Resolves #18043


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.227 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-opus-4-6 spent 27m and 35,716 tokens on this with the user in an interactive session.