### PR TITLE
GH#18052: t1954: enforce tier checklist consistency in issue-sync

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -513,6 +513,22 @@ _push_process_task() {
 	title=$(_build_title "$task_id" "$description")
 	local labels
 	labels=$(map_tags_to_labels "$tags")
+
+	# Extract and validate tier from brief file
+	local brief_path="$project_root/todo/tasks/${task_id}-brief.md"
+	local tier_label
+	tier_label=$(_extract_tier_from_brief "$brief_path")
+	if [[ -n "$tier_label" ]]; then
+		# Validate tier:simple against checklist
+		tier_label=$(_validate_tier_checklist "$brief_path" "$tier_label")
+		# Add tier label to labels list
+		if [[ -n "$labels" ]]; then
+			labels="${labels},${tier_label}"
+		else
+			labels="$tier_label"
+		fi
+	fi
+
 	local body
 	body=$(compose_issue_body "$task_id" "$project_root")
 
@@ -628,6 +644,22 @@ cmd_enrich() {
 		tags=$(echo "$parsed" | grep '^tags=' | cut -d= -f2-)
 		local labels
 		labels=$(map_tags_to_labels "$tags")
+
+		# Extract and validate tier from brief file
+		local brief_path="$project_root/todo/tasks/${task_id}-brief.md"
+		local tier_label
+		tier_label=$(_extract_tier_from_brief "$brief_path")
+		if [[ -n "$tier_label" ]]; then
+			# Validate tier:simple against checklist
+			tier_label=$(_validate_tier_checklist "$brief_path" "$tier_label")
+			# Add tier label to labels list
+			if [[ -n "$labels" ]]; then
+				labels="${labels},${tier_label}"
+			else
+				labels="$tier_label"
+			fi
+		fi
+
 		local title
 		title=$(_build_title "$task_id" "$desc")
 		local body

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -1295,6 +1295,62 @@ resolve_gh_node_id() {
 	return 0
 }
 
+# Extract the selected tier from a brief file.
+# Looks for "**Selected tier:** `tier:XXX`" in the brief.
+# Arguments:
+#   $1 - brief file path
+# Returns: tier label on stdout (e.g., "tier:simple"), or empty string if not found
+_extract_tier_from_brief() {
+	local brief_path="$1"
+
+	if [[ ! -f "$brief_path" ]]; then
+		return 0
+	fi
+
+	# Extract tier from "**Selected tier:** `tier:XXX`" line
+	grep -oE 'tier:(simple|standard|reasoning)' "$brief_path" | head -1 || true
+	return 0
+}
+
+# Validate tier:simple briefs have all checklist boxes checked.
+# If any box is unchecked, override to tier:standard and warn.
+# Arguments:
+#   $1 - brief file path
+#   $2 - selected tier label (e.g., "tier:simple")
+# Returns: the validated tier label on stdout
+# Exit: 0 always (validation is advisory, not blocking)
+_validate_tier_checklist() {
+	local brief_path="$1"
+	local selected_tier="$2"
+
+	# Only validate tier:simple — standard and reasoning don't have hard checklist gates
+	if [[ "$selected_tier" != "tier:simple" ]]; then
+		printf '%s' "$selected_tier"
+		return 0
+	fi
+
+	# Check if brief file exists
+	if [[ ! -f "$brief_path" ]]; then
+		printf '%s' "$selected_tier"
+		return 0
+	fi
+
+	# Count unchecked boxes in the tier checklist section
+	# Pattern: lines between "### Tier checklist" and "**Selected tier:**"
+	local unchecked_count
+	unchecked_count=$(sed -n '/^### Tier checklist/,/^\*\*Selected tier/p' "$brief_path" |
+		grep -c '^\- \[ \]' || true)
+
+	if [[ "$unchecked_count" -gt 0 ]]; then
+		echo "[WARN] tier:simple selected but $unchecked_count checklist box(es) unchecked in $brief_path — overriding to tier:standard" >&2
+		printf '%s' "tier:standard"
+		return 0
+	fi
+
+	printf '%s' "$selected_tier"
+	return 0
+}
+
 # Detect the parent task ID from a subtask ID.
 # t1873.2 → t1873, t1873.2.1 → t1873.2, t1873 → "" (no parent)
 # Arguments:


### PR DESCRIPTION
## Summary

Added _validate_tier_checklist() function to reject tier:simple when brief checklist has unchecked boxes, auto-correcting to tier:standard with warning. Integrated into issue creation and enrichment workflows.

## Files Changed

.agents/scripts/issue-sync-helper.sh,.agents/scripts/issue-sync-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Tested with t1948 (2 unchecked boxes → tier:standard), t1950 (1 unchecked box → tier:standard), t1954 (all checked → tier:simple). Shellcheck passes.

Resolves #18052


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.228 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-haiku-4-5 spent 2m and 4,186 tokens on this as a headless worker.