### PR TITLE
fix: run worktree pre-creation from repo_path, not pulse cwd

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8236,11 +8236,13 @@ dispatch_with_dedup() {
 	# existing path. On failure, fall back to letting the worker create it.
 	local worker_worktree_path="" worker_worktree_branch=""
 	local _wt_helper="${SCRIPT_DIR}/worktree-helper.sh"
-	if [[ -x "$_wt_helper" ]]; then
+	if [[ -x "$_wt_helper" && -d "$repo_path" ]]; then
 		# Derive branch name from issue number (deterministic, collision-free)
 		worker_worktree_branch="feature/auto-$(date +%Y%m%d-%H%M%S)"
 		local _wt_output=""
-		_wt_output=$("$_wt_helper" add "$worker_worktree_branch" 2>&1) || true
+		# Run from repo_path — worktree-helper.sh uses git commands that need
+		# to be inside the repo. The pulse-wrapper's cwd is typically / (launchd).
+		_wt_output=$(cd "$repo_path" && "$_wt_helper" add "$worker_worktree_branch" 2>&1) || true
 		worker_worktree_path=$(printf '%s' "$_wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || worker_worktree_path=""
 		if [[ -n "$worker_worktree_path" && -d "$worker_worktree_path" ]]; then
 			echo "[dispatch_with_dedup] Pre-created worktree for #${issue_number}: ${worker_worktree_path} (branch: ${worker_worktree_branch})" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Fix worktree pre-creation in `dispatch_with_dedup()` — it was always failing because `worktree-helper.sh` was called from the pulse-wrapper's cwd (`/` under launchd) instead of from within the repo directory.

**Root cause:** `worktree-helper.sh add` calls `git worktree add` which requires being inside a git repo. The pulse-wrapper runs as a launchd service with cwd `/`. The fix wraps the call in `cd "$repo_path" && ...`.

**Evidence:** Pulse log showed `Warning: worktree pre-creation failed for #18056 — worker will create its own` on the first dispatch after v3.6.225 deployed.

## Runtime Testing

- **Risk level:** Low (one-line cwd fix in subshell)
- **Verification:** shellcheck clean

Resolves the worktree pre-creation failure from v3.6.225 (#18046).