### PR TITLE
GH#18056: GH#18056: bump NESTING_DEPTH_THRESHOLD to 252 (245 violations + 7 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -32,6 +32,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 252 | GH#18013 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
 | 247 | GH#18016 | ratcheted down — actual violations 245 + 2 buffer |
 | 252 | GH#18020 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
+| 247 | GH#18028 | ratcheted down — actual violations 245 + 2 buffer |
+| 252 | GH#18056 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -34,7 +34,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 247 (GH#18016): actual violations 245 + 2 buffer
 # Bumped to 252 (GH#18020): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
 # Ratcheted down to 247 (GH#18028): actual violations 245 + 2 buffer
-NESTING_DEPTH_THRESHOLD=247
+# Bumped to 252 (GH#18056): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
+NESTING_DEPTH_THRESHOLD=252
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 247 to 252 in complexity-thresholds.conf and documented the change in complexity-thresholds-history.md. The proximity guard was firing at 245/247 (2 headroom); 245 violations + 7 headroom = 252 restores adequate buffer.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** CI code-quality workflow will pass with NESTING_DEPTH_THRESHOLD=252 (245 violations < 252 threshold)

Resolves #18056


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.230 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-sonnet-4-6 spent 1m and 2,304 tokens on this as a headless worker.