### PR TITLE
GH#18042: exempt simplification tasks from large-file gate deadlock

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -7842,10 +7842,26 @@ _issue_targets_large_files() {
 	[[ -n "$issue_body" ]] || return 1
 	[[ -d "$repo_path" ]] || return 1
 
-	# Skip if already labeled (avoid re-checking every cycle)
 	local issue_labels
 	issue_labels=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+
+	# GH#18042: Never gate simplification tasks behind the large-file gate.
+	# Issues tagged "simplification" or "simplification-debt" exist to reduce
+	# the file — blocking them creates a deadlock where the file can never be
+	# simplified because the simplification issue is held by the gate.
+	# If the label was already applied (e.g., before this fix), auto-clear it.
+	if [[ ",$issue_labels," == *",simplification,"* ]] ||
+		[[ ",$issue_labels," == *",simplification-debt,"* ]]; then
+		if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
+			gh issue edit "$issue_number" --repo "$repo_slug" \
+				--remove-label "needs-simplification" >/dev/null 2>&1 || true
+			echo "[pulse-wrapper] Simplification gate auto-cleared for #${issue_number} (${repo_slug}) — issue is itself a simplification task (GH#18042)" >>"$LOGFILE"
+		fi
+		return 1
+	fi
+
+	# Skip if already labeled (avoid re-checking every cycle)
 	if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
 		return 0
 	fi


### PR DESCRIPTION
## Summary

- Fix deadlock where `_issue_targets_large_files()` blocked simplification issues from dispatch when they referenced files >= 2000 lines — the exact files they exist to simplify
- Add early-return check for `simplification` / `simplification-debt` labels before the `needs-simplification` early-return, with auto-clear of any previously-applied gate label
- Also fixes the `_reevaluate_simplification_labels()` path which couldn't clear the label for these issues due to ordering

## Root Cause

Issue #18042 (`t1952: simplification: reduce remaining higgsfield complexity`) references `higgsfield-commands.mjs` (2024 lines, threshold is 2000). The gate scans `EDIT:` lines in the issue body, finds the file exceeds the threshold, adds `needs-simplification`, and blocks dispatch. The candidate filter (`list_dispatchable_issue_candidates_json` line 6769) excludes all `needs-*` labeled issues, so the issue becomes permanently undispatchable — a deadlock.

## Fix

Check for `simplification` or `simplification-debt` labels **before** the `needs-simplification` early-return. If the issue is itself simplification work, return 1 (don't gate) and auto-clear any existing `needs-simplification` label.

## Verification

- Removed `needs-simplification` from #18042 (immediate unblock)
- No other issues had the same deadlock (`--label needs-simplification --label simplification` returned empty)

Resolves #18042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue processing system to provide enhanced support for simplification-related tasks through automatic label management, gate exemptions, and streamlined workflow behavior. These improvements reduce manual overhead by automatically handling labels for simplification-focused items while exempting them from certain gating restrictions, resulting in more efficient task management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->