### PR TITLE
t1957: fix dedup guard false positive on task ID collision

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -802,6 +802,11 @@ has_open_pr() {
 	done
 
 	# ── Check 3: Task-ID title match (merged PRs) ──
+	# GH#18041 (t1957): When a merged PR matches by task ID, verify it actually
+	# targets the same issue. A task ID collision (counter reset, fabricated ID)
+	# produces a merged PR for a *different* issue — blocking dispatch forever.
+	# Fix: fetch the merged PR body and check if it references our issue_number.
+	# If it references a different issue, it's a collision — warn but don't block.
 	local task_id
 	task_id=$(printf '%s' "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || true)
 	if [[ -z "$task_id" ]]; then
@@ -815,11 +820,29 @@ has_open_pr() {
 	if [[ "$pr_count" -gt 0 ]]; then
 		pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
 		if [[ -n "$pr_number" ]]; then
-			printf 'merged PR #%s found by task id %s in title\n' "$pr_number" "$task_id"
+			# Verify the merged PR actually targets our issue, not a different
+			# one that happened to reuse the same task ID (collision detection).
+			local merged_pr_body
+			merged_pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null) || merged_pr_body=""
+			local merged_pr_title
+			merged_pr_title=$(gh pr view "$pr_number" --repo "$repo_slug" --json title --jq '.title' 2>/dev/null) || merged_pr_title=""
+
+			# Check if the merged PR references our specific issue number
+			local our_issue_pattern="#${issue_number}([^[:alnum:]_]|$)"
+			if printf '%s\n%s' "$merged_pr_title" "$merged_pr_body" | grep -qE "$our_issue_pattern"; then
+				printf 'merged PR #%s found by task id %s in title\n' "$pr_number" "$task_id"
+				return 0
+			fi
+
+			# The merged PR has the same task ID but targets a different issue.
+			# This is a task ID collision — warn on stderr but don't block dispatch.
+			printf 'COLLISION: merged PR #%s has task id %s but targets a different issue (not #%s) — allowing dispatch\n' \
+				"$pr_number" "$task_id" "$issue_number" >&2
+			return 1
 		else
 			printf 'merged PR found by task id %s in title\n' "$task_id"
+			return 0
 		fi
-		return 0
 	fi
 	return 1
 }

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -532,6 +532,18 @@ _push_process_task() {
 	local body
 	body=$(compose_issue_body "$task_id" "$project_root")
 
+	# GH#18041 (t1957): Collision detection — warn if a merged PR already uses
+	# this task ID. This catches task ID reuse (counter reset, fabricated IDs)
+	# before the issue is created, preventing permanent dispatch blocks.
+	local collision_pr
+	collision_pr=$(gh_find_merged_pr "$repo" "$task_id")
+	if [[ -n "$collision_pr" ]]; then
+		local collision_num collision_url
+		collision_num="${collision_pr%%|*}"
+		collision_url="${collision_pr#*|}"
+		print_warning "TASK ID COLLISION: ${task_id} already used by merged PR #${collision_num} (${collision_url}). This issue will be blocked by the dedup guard. Re-ID the task with claim-task-id.sh."
+	fi
+
 	if [[ "$DRY_RUN" == "true" ]]; then
 		print_info "[DRY-RUN] Would create: $title"
 		echo "CREATED"


### PR DESCRIPTION
## Summary

- Fix dispatch-dedup-helper.sh Check 3 (task-ID title match) to verify merged PRs actually target the same issue before blocking dispatch — prevents permanent dispatch blocks from task ID collisions
- Add early-warning collision check in issue-sync-helper.sh that warns at issue creation time if a task ID already appears in a merged PR title

## Root Cause

A worker fabricated task ID `t1951` (bypassing `claim-task-id.sh`) when the counter was at ~t1750. PR #15481 was merged with that ID. When the counter naturally reached t1951 via a batch claim (`t1941..t1952`), the new issue #18041 was permanently blocked by the dedup guard finding the old merged PR.

## Changes

**dispatch-dedup-helper.sh** (`.agents/scripts/dispatch-dedup-helper.sh:804-848`):
- Check 3 now fetches the merged PR body/title and verifies it references the current issue number
- If the merged PR targets a different issue → collision detected → warn on stderr, allow dispatch (return 1)
- If the merged PR targets the same issue → legitimate completion → block dispatch (return 0, existing behaviour)

**issue-sync-helper.sh** (`.agents/scripts/issue-sync-helper.sh:535-547`):
- Before creating a new issue, checks if the task ID already appears in a merged PR title
- If collision detected, prints a warning with the conflicting PR number and advises re-IDing

## Verification

The fix would have prevented the permanent block on #18041. The collision is detected and dispatch proceeds. The issue-sync warning would have caught the collision at creation time.

Resolves #18041