### PR TITLE
t1955: close audit trail gap — workers create PRs without DISPATCH_CLAIM after stale recovery

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -567,9 +567,15 @@ _recover_stale_assignment() {
 		--remove-label "status:queued" --remove-label "status:in-progress" \
 		--add-label "status:available" 2>/dev/null || true
 
-	# Post audit comment
+	# Post audit comment with WORKER_SUPERSEDED marker (t1955).
+	# The marker is a structured HTML comment that workers can detect before
+	# creating PRs. If a worker's runner login matches the superseded runner,
+	# it knows its assignment was revoked and should abort or re-claim.
+	local _now_ts
+	_now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	gh issue comment "$issue_number" --repo "$repo_slug" \
-		--body "**Stale assignment recovered** (GH#15060)
+		--body "<!-- WORKER_SUPERSEDED runners=${stale_assignees} ts=${_now_ts} -->
+**Stale assignment recovered** (GH#15060)
 
 Previously assigned to: ${stale_assignees}
 Reason: ${reason}

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -660,6 +660,81 @@ ${sig_footer}"
 	return 0
 }
 
+# t1955: Validate that this worker's dispatch claim is still active before
+# creating a PR. Prevents orphan PRs from workers whose assignment was
+# stale-recovered while they were still working.
+#
+# Checks:
+#   1. Issue comments for a WORKER_SUPERSEDED marker naming this runner
+#   2. Issue assignee — if reassigned to another runner, we've been replaced
+#
+# Only runs in headless mode (interactive sessions don't go through dispatch).
+# Non-fatal in interactive mode — always returns 0.
+# In headless mode: returns 0 if claim is valid, 1 if superseded.
+#
+# Arguments: $1 = issue_number, $2 = repo slug
+_validate_worker_claim() {
+	local issue_number="$1"
+	local repo="$2"
+
+	# Skip in interactive mode — no dispatch claim to validate
+	if [[ "${HEADLESS:-false}" != "true" && "${FULL_LOOP_HEADLESS:-}" != "true" ]]; then
+		return 0
+	fi
+
+	# Skip if no issue number (shouldn't happen, but defensive)
+	if [[ -z "$issue_number" || ! "$issue_number" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+
+	# Determine this runner's login
+	local self_login=""
+	self_login=$(gh api user --jq '.login' 2>/dev/null) || self_login=""
+	if [[ -z "$self_login" ]]; then
+		# Can't determine identity — proceed (fail-open)
+		print_warning "Cannot determine runner login for claim validation — proceeding"
+		return 0
+	fi
+
+	# Check for WORKER_SUPERSEDED marker in recent comments
+	local comments_json=""
+	comments_json=$(gh api "repos/${repo}/issues/${issue_number}/comments" \
+		--jq '[.[] | select(.body | test("WORKER_SUPERSEDED")) | {body: .body, created_at: .created_at}] | sort_by(.created_at) | reverse | first // empty' \
+		2>/dev/null) || comments_json=""
+
+	if [[ -n "$comments_json" ]]; then
+		local superseded_runners=""
+		superseded_runners=$(printf '%s' "$comments_json" | jq -r '.body' 2>/dev/null |
+			grep -oE 'WORKER_SUPERSEDED runners=[^ ]*' |
+			sed 's/WORKER_SUPERSEDED runners=//' || echo "")
+
+		if [[ -n "$superseded_runners" && ",$superseded_runners," == *",$self_login,"* ]]; then
+			# This runner was explicitly superseded — check if we've been re-assigned since
+			local current_assignees=""
+			current_assignees=$(gh issue view "$issue_number" --repo "$repo" \
+				--json assignees --jq '[.assignees[].login] | join(",")' 2>/dev/null) || current_assignees=""
+
+			if [[ ",$current_assignees," != *",$self_login,"* ]]; then
+				print_warning "Worker claim superseded: this runner (${self_login}) was stale-recovered on #${issue_number} and not re-assigned — aborting PR creation (t1955)"
+				return 1
+			fi
+			# Re-assigned back to us (e.g., re-dispatched) — proceed
+		fi
+	fi
+
+	# Check current assignee — if assigned to someone else, we've been replaced
+	local current_assignees=""
+	current_assignees=$(gh issue view "$issue_number" --repo "$repo" \
+		--json assignees --jq '[.assignees[].login] | join(",")' 2>/dev/null) || current_assignees=""
+
+	if [[ -n "$current_assignees" && ",$current_assignees," != *",$self_login,"* ]]; then
+		print_warning "Worker claim invalid: #${issue_number} is assigned to ${current_assignees}, not ${self_login} — aborting PR creation (t1955)"
+		return 1
+	fi
+
+	return 0
+}
+
 # Create the PR and print the PR number to stdout.
 # Arguments: repo, pr_title, pr_body, origin_label; extra_labels passed as remaining args.
 # Returns 1 on failure.
@@ -766,6 +841,13 @@ cmd_commit_and_pr() {
 
 	local pr_body=""
 	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "$sig_footer")
+
+	# t1955: Validate dispatch claim before creating PR. In headless mode,
+	# abort if this worker was stale-recovered and replaced by another runner.
+	_validate_worker_claim "$issue_number" "$repo" || {
+		print_error "Aborting: dispatch claim no longer valid for #${issue_number} (t1955)"
+		return 1
+	}
 
 	local pr_number=""
 	pr_number=$(_create_pr "$repo" "$pr_title" "$pr_body" "$origin_label" "${extra_labels[@]+"${extra_labels[@]}"}") || return 1

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -4881,10 +4881,12 @@ This is an automated stall-detection sweep. The LLM should review the actual iss
 		sweep_review_label="--label needs-maintainer-review"
 	fi
 	# shellcheck disable=SC2086
+	# t1955: Don't self-assign on issue creation — let dispatch_with_dedup handle
+	# assignment. Self-assigning creates a phantom claim that triggers stale recovery
+	# on other runners, producing audit trail gaps.
 	if gh_create_issue --repo "$aidevops_slug" \
 		--title "perf: simplification debt stalled — LLM sweep needed ($(date -u +%Y-%m-%d))" \
 		--label "simplification-debt" $sweep_review_label --label "tier:reasoning" \
-		--assignee "$maintainer" \
 		--body "$sweep_body" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Complexity LLM sweep: created stall-review issue" >>"$LOGFILE"
 	else
@@ -5823,19 +5825,19 @@ This file was previously simplified (PR #${prev_pr}) but has since been modified
 	fi
 
 	local create_ok=false
+	# t1955: Don't self-assign on issue creation — let dispatch_with_dedup handle
+	# assignment. Self-assigning creates a phantom claim that triggers stale recovery.
 	if [[ "$needs_recheck" == true ]]; then
 		# shellcheck disable=SC2086
 		gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
 			--label "simplification-debt" $review_label --label "tier:standard" --label "recheck-simplicity" \
-			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	else
 		# shellcheck disable=SC2086
 		gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
 			--label "simplification-debt" $review_label --label "tier:standard" \
-			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1 && create_ok=true
 	fi
 
@@ -6010,11 +6012,11 @@ This is an automated scan. The function lengths are factual, but the best decomp
 		if [[ "${_COMPLEXITY_SCAN_SKIP_REVIEW_GATE:-false}" != "true" ]]; then
 			review_label_sh="--label needs-maintainer-review"
 		fi
+		# t1955: Don't self-assign — let dispatch_with_dedup handle assignment.
 		# shellcheck disable=SC2086
 		if gh_create_issue --repo "$aidevops_slug" \
 			--title "$issue_title" \
 			--label "simplification-debt" $review_label_sh \
-			--assignee "$maintainer" \
 			--body "$issue_body" >/dev/null 2>&1; then
 			_complexity_scan_close_duplicate_issues_by_title "$aidevops_slug" "$issue_title"
 			issues_created=$((issues_created + 1))
@@ -6252,10 +6254,10 @@ done | sort -rn | head -20
 		--tokens 0 --time "$_pulse_elapsed" --session-type routine 2>/dev/null || true)
 	issue_body="${issue_body}${sig_footer}"
 
+	# t1955: Don't self-assign — let dispatch_with_dedup handle assignment.
 	gh_create_issue --repo "$aidevops_slug" \
 		--title "CI nesting threshold proximity: ${violations}/${threshold} violations (${headroom} headroom)" \
 		--label "bug" --label "auto-dispatch" --label "tier:standard" \
-		--assignee "$maintainer" \
 		--body "$issue_body" >/dev/null 2>&1 || true
 
 	echo "[pulse-wrapper] CI nesting threshold proximity: warning issue created (${violations}/${threshold})" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Closes the audit trail gap where workers create PRs without a DISPATCH_CLAIM after stale recovery. Observed on GH#18056 and GH#18058 — both showed a PR appearing 2-9 minutes after stale recovery with no dispatch claim, no "Dispatching worker" comment, and no assignment in between.

Three defense-in-depth fixes:

1. **Remove `--assignee` from routine issue creation** — pulse routines (nesting threshold, simplification, complexity scan) were self-assigning on issue creation without posting a DISPATCH_CLAIM. This created phantom claims that triggered unnecessary stale recovery. Issues now start unassigned with `auto-dispatch` label.

2. **Add `WORKER_SUPERSEDED` marker to stale recovery** — `_recover_stale_assignment()` now includes `<!-- WORKER_SUPERSEDED runners=<logins> ts=<timestamp> -->` in the audit comment. Workers can detect this before creating PRs.

3. **Add worker-side claim validation** — `_validate_worker_claim()` in `full-loop-helper.sh` checks for WORKER_SUPERSEDED markers and current assignee before PR creation. Headless workers abort if stale-recovered and not re-assigned. Fail-open in interactive mode and on API errors.

## Files Changed

.agents/scripts/pulse-wrapper.sh, .agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/full-loop-helper.sh

## Runtime Testing

- **Risk level:** Medium (dispatch state machine, multi-runner concurrency)
- **Verification:** `bash -n` passes on all 3 files. shellcheck clean on full-loop-helper.sh and dispatch-dedup-helper.sh. pulse-wrapper.sh too large for single-pass shellcheck but syntax-verified.

Resolves #18070

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.230 plugin for [Claude Code](https://claude.ai/code) with claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to prevent PR creation when worker assignment claims are invalid or superseded.

* **Improvements**
  * Updated stale assignment recovery audit tracking with structured timestamps and worker identifiers.
  * Modified automated issue creation to defer assignment handling to the dedicated claim dispatch path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->