### PR TITLE
fix: fast claim release — dead workers no longer block re-dispatch

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -191,10 +191,12 @@ _fetch_claims() {
 	local now_epoch
 	now_epoch=$(_now_epoch)
 
-	# Fetch last 30 comments (more than enough for claim window)
+	# Fetch last 30 comments — look for both DISPATCH_CLAIM and CLAIM_RELEASED.
+	# A CLAIM_RELEASED comment posted after the most recent DISPATCH_CLAIM
+	# invalidates all prior claims (the worker died or completed).
 	local comments_json
 	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq '[.[] | select(.body | test("'"${CLAIM_MARKER}"' nonce=")) | {id: .id, body: .body, created_at: .created_at}]' \
+		--jq '[.[] | select(.body | test("'"${CLAIM_MARKER}"' nonce=|CLAIM_RELEASED")) | {id: .id, body: .body, created_at: .created_at}]' \
 		2>/dev/null) || {
 		echo "Error: failed to fetch comments for #${issue_number} in ${repo_slug}" >&2
 		return 1
@@ -205,9 +207,29 @@ _fetch_claims() {
 		return 0
 	fi
 
+	# Check if the most recent relevant comment is a CLAIM_RELEASED — if so,
+	# all prior claims are invalidated and the issue is free for dispatch.
+	local latest_is_release
+	latest_is_release=$(printf '%s' "$comments_json" | jq -r '
+		sort_by(.created_at) | last | .body | test("CLAIM_RELEASED")
+	' 2>/dev/null) || latest_is_release="false"
+	if [[ "$latest_is_release" == "true" ]]; then
+		printf '[]'
+		return 0
+	fi
+
+	# Filter to only DISPATCH_CLAIM comments (exclude CLAIM_RELEASED from parsing)
+	local claims_only
+	claims_only=$(printf '%s' "$comments_json" | jq -c '[.[] | select(.body | test("'"${CLAIM_MARKER}"' nonce="))]' 2>/dev/null) || claims_only="[]"
+
+	if [[ "$claims_only" == "[]" ]]; then
+		printf '[]'
+		return 0
+	fi
+
 	# Parse claim fields from comment bodies and filter by max age
 	local parsed
-	parsed=$(printf '%s' "$comments_json" | jq -c --argjson now "$now_epoch" --argjson max_age "$DISPATCH_CLAIM_MAX_AGE" '
+	parsed=$(printf '%s' "$claims_only" | jq -c --argjson now "$now_epoch" --argjson max_age "$DISPATCH_CLAIM_MAX_AGE" '
 		[.[] |
 			(.body | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)")) as $fields |
 			{

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -2777,7 +2777,7 @@ _cmd_run_prepare() {
 		return 2
 	fi
 	# shellcheck disable=SC2064
-	trap "_release_session_lock '$session_key'; _update_dispatch_ledger '$session_key' 'fail'" EXIT
+	trap "_release_dispatch_claim '$session_key' 'process_exit'; _release_session_lock '$session_key'; _update_dispatch_ledger '$session_key' 'fail'" EXIT
 
 	# GH#6696: Register this dispatch in the in-flight ledger so the pulse
 	# can detect workers that haven't created PRs yet. The ledger bridges


### PR DESCRIPTION
## Summary

Dead workers left permanent dispatch claims that blocked re-dispatch for the full 30-minute TTL. This fix releases claims immediately when the process exits.

**Changes:**
- `dispatch-claim-helper.sh`: `_fetch_claims` now fetches both `DISPATCH_CLAIM` and `CLAIM_RELEASED` comments. If the most recent is a `CLAIM_RELEASED`, all prior claims are invalidated.
- `headless-runtime-helper.sh`: Added `_release_dispatch_claim` to the EXIT trap so claims are released even when the process tree dies (the known bug where post-execution code never runs). On normal completion, `_cmd_run_finish` clears the trap first.

**Evidence:** #18031 and #18039 were blocked from re-dispatch for 30+ minutes after workers died because stale claims persisted. Tested: posting `CLAIM_RELEASED` on #18039 immediately cleared the claim (exit 1 from `check-claim`).

## Runtime Testing

- **Risk level:** Low (additive — existing claim flow unchanged, release is a new signal)
- **Verification:** shellcheck clean, manual test confirmed claim release works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of dispatch claim release handling
  * Enhanced process termination cleanup for better resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->