### PR TITLE
GH#18075: bump NESTING_DEPTH_THRESHOLD to 253

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -34,6 +34,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 252 | GH#18020 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
 | 247 | GH#18028 | ratcheted down — actual violations 245 + 2 buffer |
 | 252 | GH#18056 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
+| 247 | GH#18067 | ratcheted down — actual violations 245 + 2 buffer |
+| 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom ensures the proximity guard fires at 248 violations before saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -35,7 +35,7 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 247 | GH#18028 | ratcheted down — actual violations 245 + 2 buffer |
 | 252 | GH#18056 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
 | 247 | GH#18067 | ratcheted down — actual violations 245 + 2 buffer |
-| 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations reach 248, preventing saturation |
+| 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -35,7 +35,7 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 247 | GH#18028 | ratcheted down — actual violations 245 + 2 buffer |
 | 252 | GH#18056 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
 | 247 | GH#18067 | ratcheted down — actual violations 245 + 2 buffer |
-| 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom ensures the proximity guard fires at 248 violations before saturation |
+| 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations reach 248, preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -22,11 +22,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # count over the current value.
 # Counting methodology: violations are counted using lint_shell_files() from
 # lint-file-discovery.sh (same file set as CI), not a raw find/glob. This
-# excludes vendor, node_modules, and non-shell files — yielding 245, not ~309.
+# excludes vendor, node_modules, and non-shell files — yielding 246, not ~309.
 #
 # Recent history (full log in complexity-thresholds-history.md):
-# Bumped to 256 (GH#17954): pre-existing regression on main — 254 violations vs threshold 253; 254 + 2 buffer
-# Bumped to 258 (GH#17969): threshold saturated at 256/256 (0 headroom); 256 violations + 2 buffer
 # Bumped to 263 (GH#17978): proximity guard firing at 256/258 (2 headroom); 256 violations + 7 headroom
 # Ratcheted down to 258 (GH#17992): actual violations 256 + 2 buffer
 # Ratcheted down to 247 (GH#18009): actual violations 245 + 2 buffer
@@ -36,7 +34,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 247 (GH#18028): actual violations 245 + 2 buffer
 # Bumped to 252 (GH#18056): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
 # Ratcheted down to 247 (GH#18067): actual violations 245 + 2 buffer
-NESTING_DEPTH_THRESHOLD=247
+# Bumped to 253 (GH#18075): proximity guard firing at 246/247 (1 headroom); 246 violations + 7 headroom
+NESTING_DEPTH_THRESHOLD=253
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -34,7 +34,7 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 247 (GH#18028): actual violations 245 + 2 buffer
 # Bumped to 252 (GH#18056): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
 # Ratcheted down to 247 (GH#18067): actual violations 245 + 2 buffer
-# Bumped to 253 (GH#18075): proximity guard firing at 246/247 (1 headroom); 246 violations + 7 headroom
+# Bumped to 253 (GH#18075): proximity guard firing at 246/247 (1 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
 NESTING_DEPTH_THRESHOLD=253
 
 # File size: files with >1500 lines

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1754,9 +1754,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "875a824701bfc3db90920e162057b5c84d76582b",
-      "at": "2026-04-10T01:33:01Z",
-      "passes": 13,
+      "hash": "5a87a3746bb97f2e3adbe69c631dff0e6c8c2256",
+      "at": "2026-04-10T03:17:43Z",
+      "passes": 14,
       "pr": 15086
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "73aa7effecc288bee57688ea40cda93e9c4ac181",
-      "at": "2026-04-10T01:33:02Z",
-      "passes": 3,
+      "hash": "efbe58b551915a847c6d779af54cef9df4a74822",
+      "at": "2026-04-10T03:17:43Z",
+      "passes": 4,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -5261,21 +5261,21 @@
       "pr": 16415
     },
     "TODO.md": {
-      "hash": "8bf25bb3319b105ff41da5914c18e282da687662",
-      "at": "2026-04-10T01:33:19Z",
-      "passes": 14,
+      "hash": "1c62774f6be8eb337a3cabb81ac477aa8e77d19b",
+      "at": "2026-04-10T03:17:58Z",
+      "passes": 15,
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "97c5dcaa3bd83de71b6cd715aa240c299754e4ee",
-      "at": "2026-04-10T01:33:19Z",
-      "passes": 47,
+      "hash": "65d13e4de4573e791c8bad7e2d9f130f9d243afe",
+      "at": "2026-04-10T03:17:58Z",
+      "passes": 48,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "47a208417e17997455c7a30e036df176d8924d3a",
-      "at": "2026-04-10T01:33:19Z",
-      "passes": 46,
+      "hash": "8481a0b457501c09499292b440bbbeb1c075ded2",
+      "at": "2026-04-10T03:17:58Z",
+      "passes": 47,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -5699,9 +5699,9 @@
       "pr": 16651
     },
     ".agents/scripts/dispatch-dedup-helper.sh": {
-      "hash": "e1062ec6cbea8ab0d957a21a48f3101c9653b607",
-      "at": "2026-04-09T07:32:01Z",
-      "passes": 5,
+      "hash": "e7c1df0e577b93b74a6a66f5e8fa31e161dc4be1",
+      "at": "2026-04-10T03:17:43Z",
+      "passes": 6,
       "pr": 16650
     },
     ".agents/tools/ocr/overview.md": {
@@ -6881,10 +6881,10 @@
       "passes": 1
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "hash": "1a6498aa870644760f533d57d117ac1f5bc868f2",
-      "at": "2026-04-10T01:33:20Z",
+      "hash": "52d287d7df7ecb61c95e21327b54562e0113f775",
+      "at": "2026-04-10T03:17:43Z",
       "pr": 18058,
-      "passes": 1
+      "passes": 2
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {


### PR DESCRIPTION
## Summary

Proximity guard fired at 246/247 (1 headroom remaining). Bumped `NESTING_DEPTH_THRESHOLD` from 247 to 253 to restore adequate headroom.

- **Current violations**: 246 (verified locally via `lint_shell_files()` + awk depth checker)
- **New threshold**: 253 (246 violations + 7 headroom)
- **Proximity guard fires at**: 248 violations (within 5 of 253), preventing saturation before the threshold is hit

## Files Modified

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` from 247 to 253, update counting methodology comment (245→246), add history entry
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#18067 ratchet-down entry (missing from history) and GH#18075 bump entry

## Runtime Testing

Risk: **Low** — config file change only, no code logic modified. CI will verify the new threshold passes the nesting depth check.

## Verification

After merge, the CI `Shell nesting depth` check should pass with 246 violations < 253 threshold (7 headroom).

Resolves #18075


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.231 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-sonnet-4-6 spent 2m and 5,521 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI complexity quality gate to refine violation detection and headroom handling.
  * Updated build/runtime metadata entries (hashes, timestamps and pass counts) for several internal scripts and docs.

* **Documentation**
  * Appended audit-trail/history notes explaining recent threshold tuning and guard behavior observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->