### PR TITLE
fix: filter claims by latest CLAIM_RELEASED timestamp

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -207,20 +207,24 @@ _fetch_claims() {
 		return 0
 	fi
 
-	# Check if the most recent relevant comment is a CLAIM_RELEASED — if so,
-	# all prior claims are invalidated and the issue is free for dispatch.
-	local latest_is_release
-	latest_is_release=$(printf '%s' "$comments_json" | jq -r '
-		sort_by(.created_at) | last | .body | test("CLAIM_RELEASED")
-	' 2>/dev/null) || latest_is_release="false"
-	if [[ "$latest_is_release" == "true" ]]; then
-		printf '[]'
-		return 0
-	fi
+	# Find the most recent CLAIM_RELEASED timestamp. Any DISPATCH_CLAIM older
+	# than this is invalidated (the worker died or completed). Only claims
+	# posted AFTER the latest release are considered active.
+	local latest_release_ts
+	latest_release_ts=$(printf '%s' "$comments_json" | jq -r '
+		[.[] | select(.body | test("CLAIM_RELEASED")) | .created_at] |
+		sort | last // ""
+	' 2>/dev/null) || latest_release_ts=""
 
-	# Filter to only DISPATCH_CLAIM comments (exclude CLAIM_RELEASED from parsing)
+	# Filter to DISPATCH_CLAIM comments posted after the latest release
 	local claims_only
-	claims_only=$(printf '%s' "$comments_json" | jq -c '[.[] | select(.body | test("'"${CLAIM_MARKER}"' nonce="))]' 2>/dev/null) || claims_only="[]"
+	if [[ -n "$latest_release_ts" ]]; then
+		claims_only=$(printf '%s' "$comments_json" | jq -c --arg release_ts "$latest_release_ts" '
+			[.[] | select((.body | test("'"${CLAIM_MARKER}"' nonce=")) and (.created_at > $release_ts))]
+		' 2>/dev/null) || claims_only="[]"
+	else
+		claims_only=$(printf '%s' "$comments_json" | jq -c '[.[] | select(.body | test("'"${CLAIM_MARKER}"' nonce="))]' 2>/dev/null) || claims_only="[]"
+	fi
 
 	if [[ "$claims_only" == "[]" ]]; then
 		printf '[]'


### PR DESCRIPTION
## Summary

Fix claim release filtering so CLAIM_RELEASED actually unblocks re-dispatch. The previous fix (v3.6.232) checked if the most recent comment was a CLAIM_RELEASED, but the claim protocol posts a new DISPATCH_CLAIM before checking — making the new claim the most recent and hiding the release.

Now finds the latest CLAIM_RELEASED timestamp and excludes any DISPATCH_CLAIM older than it. Only claims posted after the latest release are active.

## Runtime Testing
- shellcheck clean
- Tested: chronology CLAIM → RELEASE → CLAIM correctly filters out the pre-release claim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated claim selection logic to determine active claims based on release timestamps rather than comment content, improving accuracy of claim ordering in dispatch workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->