### PR TITLE
GH#18080: ratchet down NESTING_DEPTH_THRESHOLD to 248

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -35,7 +35,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Bumped to 252 (GH#18056): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
 # Ratcheted down to 247 (GH#18067): actual violations 245 + 2 buffer
 # Bumped to 253 (GH#18075): proximity guard firing at 246/247 (1 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
-NESTING_DEPTH_THRESHOLD=253
+# Ratcheted down to 248 (GH#18080): actual violations 246 + 2 buffer
+NESTING_DEPTH_THRESHOLD=248
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowers `NESTING_DEPTH_THRESHOLD` from 253 to 248 following simplification wins that reduced actual nesting violations from 256 to 246.

- Actual violations: 246
- New threshold: 246 + 2 buffer = 248
- Previous threshold (253) was bumped in GH#18075 to provide proximity guard headroom

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — lowered `NESTING_DEPTH_THRESHOLD` from 253 to 248; added ratchet-down audit comment

## Verification

```
[complexity-scan] INFO: Actual violations — func:37 nest:246 size:54 bash32:71
[complexity-scan] INFO: Current thresholds — func:40 nest:248 size:56 bash32:72
[complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 5
```

Resolves #18080

---

<!-- MERGE_SUMMARY -->
**What was done:** Ratcheted down `NESTING_DEPTH_THRESHOLD` from 253 → 248 in `.agents/configs/complexity-thresholds.conf`. Added audit comment documenting the change with actual violation count (246) and 2-buffer rationale.

**How verified:** Ran `complexity-scan-helper.sh ratchet-check . 5` — confirmed actual violations (246) are below new threshold (248) and no further ratchet-down is available within the 5-gap window.
<!-- /MERGE_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality standards configuration to enforce stricter nesting depth limits in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->