### PR TITLE
GH#18080: ratchet down NESTING_DEPTH_THRESHOLD from 253 to 248

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -35,7 +35,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Bumped to 252 (GH#18056): proximity guard firing at 245/247 (2 headroom); 245 violations + 7 headroom
 # Ratcheted down to 247 (GH#18067): actual violations 245 + 2 buffer
 # Bumped to 253 (GH#18075): proximity guard firing at 246/247 (1 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
-NESTING_DEPTH_THRESHOLD=253
+# Ratcheted down to 248 (GH#18080): actual violations 246 + 2 buffer
+NESTING_DEPTH_THRESHOLD=248
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1754,9 +1754,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "5a87a3746bb97f2e3adbe69c631dff0e6c8c2256",
-      "at": "2026-04-10T03:17:43Z",
-      "passes": 14,
+      "hash": "a2d2647022c4934ffbf0df258a20b038792e20e5",
+      "at": "2026-04-10T04:09:22Z",
+      "passes": 15,
       "pr": 15086
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "65d13e4de4573e791c8bad7e2d9f130f9d243afe",
-      "at": "2026-04-10T03:17:58Z",
-      "passes": 48,
+      "hash": "637b2042eb0634549e0bc9b716ae9f168d646575",
+      "at": "2026-04-10T04:09:38Z",
+      "passes": 49,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "8481a0b457501c09499292b440bbbeb1c075ded2",
-      "at": "2026-04-10T03:17:58Z",
-      "passes": 47,
+      "hash": "e3d4daf0aaf680b742df5ce7075bb05210d0f040",
+      "at": "2026-04-10T04:09:38Z",
+      "passes": 48,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6773,10 +6773,10 @@
       "passes": 2
     },
     ".agents/configs/complexity-thresholds-history.md": {
-      "hash": "f4cf241751c295f31646d9164e8b27a2a213c2fe",
-      "at": "2026-04-10T01:32:56Z",
+      "hash": "9314b78dc3d4c25dbe47de963fd40f576a0ca50e",
+      "at": "2026-04-10T04:09:15Z",
       "pr": 17979,
-      "passes": 4
+      "passes": 5
     },
     ".agents/scripts/memory-pressure-monitor.sh": {
       "hash": "d71f3754e56b925114a9b13c4ae3809cfb0c199d",


### PR DESCRIPTION
## Summary

- Lower `NESTING_DEPTH_THRESHOLD` from 253 to 248 in `.agents/configs/complexity-thresholds.conf`
- Actual violations: 246, new threshold: 248 (246 + 2 buffer)
- Adds ratchet-down audit comment preserving bump history

## Verification

```
grep NESTING_DEPTH_THRESHOLD .agents/configs/complexity-thresholds.conf
# NESTING_DEPTH_THRESHOLD=248

.agents/scripts/complexity-scan-helper.sh ratchet-check . 5
# [complexity-scan] INFO: Actual violations — func:37 nest:246 size:54 bash32:71
# [complexity-scan] INFO: Current thresholds — func:40 nest:248 size:56 bash32:72
# [complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 5
```

Resolves #18080


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.234 plugin for [OpenCode](https://opencode.ai) v1.4.2 with claude-opus-4-6 spent 1m and 1,850 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality standards and configuration metadata to reflect recent improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->