### PR TITLE
fix: add --print-logs to headless opencode for Go-level error tracing

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1593,6 +1593,24 @@ _invoke_opencode() {
 	# way to separate tee output from the exit code in a single $()).
 	(
 		set +e
+		# Inject --print-logs for headless workers so opencode's internal Go logs
+		# (API errors, model resolution, DB writes) appear in the worker log.
+		# This is critical for diagnosing silent exits — the JSON event stream
+		# shows step_start then nothing, but the Go logs show the actual error.
+		local -a _oc_cmd=("${cmd[@]}")
+		if [[ "${HEADLESS:-}" == "1" ]]; then
+			# Insert --print-logs after the 'run' subcommand
+			local -a _new_cmd=()
+			local _inserted=0
+			for _arg in "${_oc_cmd[@]}"; do
+				_new_cmd+=("$_arg")
+				if [[ "$_arg" == "run" && "$_inserted" -eq 0 ]]; then
+					_new_cmd+=("--print-logs" "--log-level" "WARN")
+					_inserted=1
+				fi
+			done
+			_oc_cmd=("${_new_cmd[@]}")
+		fi
 		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
 			local passthrough_csv
 			passthrough_csv="$(build_sandbox_passthrough_csv)"
@@ -1602,13 +1620,13 @@ _invoke_opencode() {
 			# a temp file and replays it after exit — the watchdog sees nothing
 			# and kills every sandboxed worker at ~93s.
 			if [[ -n "$passthrough_csv" ]]; then
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --passthrough "$passthrough_csv" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			else
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		else
-			timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${cmd[@]}" 2>&1 | tee "$output_file"
+			timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		fi
 	) &

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -607,11 +607,13 @@ _sandbox_exec_with_pgkill() {
 	fi
 
 	# Emit captured stderr to our stderr so callers (headless-runtime-helper)
-	# can see crash errors from the child process. Only emit on non-zero exit
-	# to avoid noise on success. Truncate to 4KB to avoid flooding logs.
-	if [[ "$t_exit_code" -ne 0 && -s "$t_stderr_file" ]]; then
-		log_sandbox "WARN" "Child exited $t_exit_code — captured stderr ($(wc -c <"$t_stderr_file" | tr -d ' ')B):"
-		head -c 4096 "$t_stderr_file" >&2
+	# can see errors from the child process. Always emit for headless workers
+	# (opencode exits 0 even on silent failures). Truncate to 8KB.
+	if [[ -s "$t_stderr_file" ]]; then
+		local _stderr_size
+		_stderr_size=$(wc -c <"$t_stderr_file" | tr -d ' ')
+		log_sandbox "INFO" "Child exited $t_exit_code — captured stderr (${_stderr_size}B):"
+		head -c 8192 "$t_stderr_file" >&2
 		echo >&2
 	fi
 


### PR DESCRIPTION
## Summary
Add --print-logs --log-level WARN to headless opencode sessions so Go-level logs appear in worker logs. Also emit sandbox stderr on all exits (opencode exits 0 on silent failures). This gives complete observability for diagnosing gpt-5.4 worker deaths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message visibility in sandboxed operations with improved logging output.
  * Better logging information for background worker operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->