### PR TITLE
GH#18086: restore nesting threshold headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -36,6 +36,7 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 252 | GH#18056 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
 | 247 | GH#18067 | ratcheted down — actual violations 245 + 2 buffer |
 | 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
+| 253 | GH#18086 | proximity guard firing at 246/248 (2 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -36,6 +36,7 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 252 | GH#18056 | proximity guard firing at 245/247 (2 headroom); bumped to 252 to restore adequate headroom — 245 violations + 7 headroom ensures the proximity guard fires at 247 violations before saturation |
 | 247 | GH#18067 | ratcheted down — actual violations 245 + 2 buffer |
 | 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
+| 248 | GH#18080 | ratcheted down — actual violations 246 + 2 buffer |
 | 253 | GH#18086 | proximity guard firing at 246/248 (2 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -36,7 +36,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 247 (GH#18067): actual violations 245 + 2 buffer
 # Bumped to 253 (GH#18075): proximity guard firing at 246/247 (1 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
 # Ratcheted down to 248 (GH#18080): actual violations 246 + 2 buffer
-NESTING_DEPTH_THRESHOLD=248
+# Bumped to 253 (GH#18086): proximity guard firing at 246/248 (2 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
+NESTING_DEPTH_THRESHOLD=253
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Raised NESTING_DEPTH_THRESHOLD from 248 to 253 to restore the standard 7-violation buffer above the current 246 nesting-depth violations, and recorded the rationale in the threshold audit history.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified the CI-equivalent nesting-depth count remains 246, the new threshold is 253, warn_at is 248, headroom is 7; git diff --check clean.

Resolves #18086


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.235 plugin for [OpenCode](https://opencode.ai) v1.4.3 with gpt-5.4 spent 3m and 109,334 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted code complexity thresholds used by CI quality gates for nesting-depth checks.
* **Documentation**
  * Updated audit/config documentation to reflect the revised complexity threshold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->