### PR TITLE
fix: setup.sh deploys slash commands to all installed runtimes (GH#18106)

### DIFF
--- a/setup-modules/config.sh
+++ b/setup-modules/config.sh
@@ -395,3 +395,84 @@ PYEOF
 	echo "  Done -- $mcp_count new MCP servers added to Cursor config"
 	return 0
 }
+
+# Deploy slash commands to every installed runtime that supports them.
+#
+# Background: update_opencode_config and update_claude_config already invoke
+# the unified generator (.agents/scripts/generate-runtime-config.sh) for
+# their runtimes. The other per-client update_*_config functions (Codex,
+# Cursor, Droid, etc.) were written before the unified generator existed
+# and only handle MCP registration. This function closes that gap by
+# invoking the generator for every other installed client.
+#
+# Gated on rt_feature_commands so users can disable command installation
+# per-runtime via AIDEVOPS_FEATURE_COMMANDS_<SUFFIX>=no. Clients with no
+# _RT_COMMAND_DIR (windsurf, amp, kilo, aider) are skipped automatically.
+#
+# Fixes GH#18106 / t15474.
+deploy_commands_to_all_runtimes() {
+	local registry_script="${INSTALL_DIR:-.}/.agents/scripts/runtime-registry.sh"
+	local generator_script="${INSTALL_DIR:-.}/.agents/scripts/generate-runtime-config.sh"
+
+	if [[ ! -f "$registry_script" ]]; then
+		print_info "Runtime registry not found — skipping unified command deployment"
+		return 0
+	fi
+	if [[ ! -x "$generator_script" ]]; then
+		print_info "Runtime config generator not executable — skipping unified command deployment"
+		return 0
+	fi
+
+	# Source registry if not already loaded
+	if [[ -z "${_RUNTIME_REGISTRY_LOADED:-}" ]]; then
+		# shellcheck source=/dev/null
+		source "$registry_script"
+	fi
+
+	local runtime_id cmd_dir feature_flag display_name
+	local deployed_count=0 skipped_count=0
+
+	while IFS= read -r runtime_id; do
+		# OpenCode and Claude Code are already handled by their dedicated
+		# update_*_config functions above — skip to avoid double-deploy
+		# and keep the log output clean.
+		case "$runtime_id" in
+		opencode | claude-code) continue ;;
+		esac
+
+		# Skip runtimes with no command directory in the registry (repo-only
+		# clients like Windsurf/Amp, and clients without native slash command
+		# support like Kilo/Aider).
+		cmd_dir=$(rt_command_dir "$runtime_id" 2>/dev/null || echo "")
+		[[ -z "$cmd_dir" ]] && continue
+
+		# Honour the rt_feature_commands flag.
+		feature_flag=$(rt_feature_commands "$runtime_id" 2>/dev/null || echo "yes")
+		if [[ "$feature_flag" != "yes" ]]; then
+			display_name=$(rt_display_name "$runtime_id" 2>/dev/null || echo "$runtime_id")
+			print_info "Commands installation disabled for $display_name (feature flag)"
+			skipped_count=$((skipped_count + 1))
+			continue
+		fi
+
+		# Invoke the unified generator — it prints its own success/failure.
+		# Redirect stdin from /dev/null so the generator cannot accidentally
+		# read from the `while read` loop's process-substitution pipe and
+		# steal the remaining runtime IDs — a classic bash pitfall.
+		if "$generator_script" commands --runtime "$runtime_id" </dev/null; then
+			deployed_count=$((deployed_count + 1))
+		else
+			display_name=$(rt_display_name "$runtime_id" 2>/dev/null || echo "$runtime_id")
+			print_warning "Failed to deploy commands for $display_name"
+		fi
+	done < <(rt_detect_installed 2>/dev/null)
+
+	if [[ $deployed_count -gt 0 ]]; then
+		print_success "Deployed slash commands to $deployed_count additional runtime(s)"
+	elif [[ $skipped_count -gt 0 ]]; then
+		print_info "All remaining runtimes had commands installation disabled via feature flags"
+	else
+		print_info "No additional runtimes needed command deployment"
+	fi
+	return 0
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1009,6 +1009,11 @@ _setup_run_interactive() {
 	# Run AFTER Claude Code config so Codex/Cursor get equivalent setup
 	confirm_step "Update Codex configuration (MCPs, instructions)" && update_codex_config
 	confirm_step "Update Cursor configuration (MCPs)" && update_cursor_config
+	# Deploy slash commands to the other installed runtimes (Codex, Cursor,
+	# Droid, Gemini CLI, Continue, Kiro, Kimi, Qwen) via the unified generator.
+	# OpenCode and Claude Code are already handled by their update_*_config
+	# functions above. Closes GH#18106 / t15474.
+	confirm_step "Deploy slash commands to remaining runtimes" && deploy_commands_to_all_runtimes
 	# Run AFTER all MCP setup functions to ensure disabled state persists
 	confirm_step "Disable on-demand MCPs globally" && disable_ondemand_mcps
 	return 0


### PR DESCRIPTION
Resolves #18106 (t15474). Follow-up to #18096.

## Summary

Before this change, `./setup.sh --non-interactive` only deployed the `aidevops-*` slash commands to OpenCode and Claude Code, because only their `update_*_config` functions had been migrated to the unified `generate-runtime-config.sh` path. Other installed clients (Codex, Cursor, Droid, Gemini CLI, Continue, Kiro, Qwen, Kimi) had their MCP servers registered but their command directories stayed empty — users had to run the generator manually for each client.

This PR adds a single post-MCP function that deploys slash commands to every remaining installed runtime in one pass.

## What changed

- **`setup-modules/config.sh`**: new function `deploy_commands_to_all_runtimes` that iterates `rt_detect_installed`, skips opencode/claude-code (already handled) and runtimes with empty `_RT_COMMAND_DIR` (Windsurf, Amp, Kilo, Aider), honours the `rt_feature_commands` flag, and invokes the unified generator for each remaining runtime. Prints a single summary at the end.
- **`setup.sh`**: wired via `confirm_step` between `update_cursor_config` and `disable_ondemand_mcps` so the step is controllable like every other setup stage.

Per-client format transforms are already implemented in `generate-runtime-config.sh` from #18096 — this PR just makes `setup.sh` invoke them: TOML for Gemini, `.prompt + invokable: true` for Continue, `inclusion: manual` for Kiro, frontmatter-stripped for Cursor, opencode-fields-stripped for Codex/Droid/Qwen/Kimi.

## Subtle bug caught during testing

The initial implementation invoked the generator inside a standard `while IFS= read ... done < <(rt_detect_installed)` loop without redirecting the generator's stdin. The generator (or one of its internal helpers) reads from stdin, which stole remaining runtime IDs from the process-substitution pipe and caused every generator call after the first to appear as a failure even though the underlying work completed successfully.

Fix: add `</dev/null` when invoking the generator inside the loop. Documented inline as a classic bash while-read pitfall. Without this, users would see misleading "Failed to deploy" warnings despite successful deployment.

## Testing

Self-assessed + interactive verification on a real machine with 9 installed AI clients:

- `bash -n setup.sh` — clean
- `bash -n setup-modules/config.sh` — clean
- `shellcheck -x setup-modules/config.sh` — clean
- Ran `deploy_commands_to_all_runtimes` in isolation against opencode, claude-code, codex, cursor, droid, gemini-cli, continue, kiro, qwen:

```
[SUCCESS] Codex CLI: 93 commands in ~/.codex/prompts
[SUCCESS] Cursor: 93 commands in ~/.cursor/commands
[SUCCESS] Droid: 93 commands in ~/.factory/commands
[SUCCESS] Gemini CLI: 93 commands in ~/.gemini/commands
[SUCCESS] Continue: 93 commands in ~/.continue/prompts
[SUCCESS] Kiro: 93 commands in ~/.kiro/steering
[SUCCESS] Qwen Code: 93 commands in ~/.qwen/commands
```

Every file on disk checked for the correct per-client format (inspected head of `aidevops-build-plus.{md,toml,prompt}` for each client) — all transforms applied correctly.

## Runtime Testing

Medium risk pattern (setup / CI config). Runtime-verified via the isolated function call against the real install on this machine; all 7 target clients received their expected command files.

## Related

- #18096 — introduced the unified generator and per-client format transforms
- #18104 — logged t15474 into TODO.md
- #18106 — tracks this fix
- #18107 — tiny TODO ref update (open)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.236 plugin for [Claude Code](https://claude.ai/code) v2.1.101