### PR TITLE
feat: trash entire worktree directory before removal for recoverability

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -305,6 +305,10 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 - WIP commits are squashed/amended before PR — the commit message quality doesn't matter here, survival does.
 - Exception: generated/temp files explicitly gitignored (e.g. `.agents/loop-state/`, `.agents/tmp/`).
 
+**Worktree removal safety:**
+- `worktree-helper.sh remove` and `wt clean` move the worktree directory to system trash before deregistering from git. Accidental removal (e.g. by cleanup routines) is recoverable — restore from trash and `git worktree add` on the same branch.
+- If trash is unavailable, falls back to permanent `git worktree remove`.
+
 # Quality Standards
 - ShellCheck zero violations. `local var="$1"` pattern. Explicit returns.
 

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -734,7 +734,15 @@ _remove_cleanup_and_execute() {
 	removed_branch="$(git -C "$path_to_remove" branch --show-current 2>/dev/null || echo "")"
 
 	echo -e "${BLUE}Removing worktree: $path_to_remove${NC}"
-	git worktree remove "$path_to_remove"
+	# Move the worktree directory to trash BEFORE git deregisters it.
+	# This makes accidental removal recoverable — the directory survives in trash.
+	# git worktree prune then cleans up the now-missing entry from .git/worktrees/.
+	if ! trash_path "$path_to_remove"; then
+		# trash unavailable or failed — fall back to git worktree remove
+		git worktree remove "$path_to_remove" || return 1
+	else
+		git worktree prune 2>/dev/null || true
+	fi
 
 	# Unregister ownership (t189)
 	unregister_worktree "$path_to_remove"
@@ -1211,18 +1219,23 @@ _clean_remove_merged() {
 					rm -rf "$worktree_path/node_modules" 2>/dev/null || true
 					rm -rf "$worktree_path/.next" 2>/dev/null || true
 					rm -rf "$worktree_path/.turbo" 2>/dev/null || true
-					# Clean up aidevops runtime files (use trash for recoverability)
-					trash_path "$worktree_path/.agents/loop-state" || true
-					trash_path "$worktree_path/.agents/tmp" || true
-					rm -f "$worktree_path/.agents/.DS_Store" 2>/dev/null || true
-					rmdir "$worktree_path/.agent" 2>/dev/null || true
-
-					local remove_flag=""
-					if [[ "$use_force" == "true" ]]; then
-						remove_flag="--force"
+					# Move entire worktree to trash for recoverability, then prune git's registry.
+					# Falls back to git worktree remove if trash is unavailable.
+					local removed=false
+					if trash_path "$worktree_path"; then
+						git worktree prune 2>/dev/null || true
+						removed=true
+					else
+						local remove_flag=""
+						if [[ "$use_force" == "true" ]]; then
+							remove_flag="--force"
+						fi
+						# shellcheck disable=SC2086
+						if git worktree remove $remove_flag "$worktree_path" 2>/dev/null; then
+							removed=true
+						fi
 					fi
-					# shellcheck disable=SC2086
-					if ! git worktree remove $remove_flag "$worktree_path"; then
+					if [[ "$removed" != "true" ]]; then
 						echo -e "${RED}Failed to remove $worktree_branch - may have uncommitted changes${NC}"
 					else
 						# Unregister ownership (t189)


### PR DESCRIPTION
## Summary

Replaces `git worktree remove` with `trash_path` + `git worktree prune` in both removal paths. The entire worktree directory is moved to system trash before git deregisters it, making accidental removal (e.g. by cleanup routines incorrectly treating an active session's worktree as orphaned — see #18090) recoverable.

## How it works

**Before:** `git worktree remove $path` — directory permanently deleted, git deregisters it atomically.

**After:**
1. `trash_path "$path"` — moves directory to system trash (recoverable)
2. `git worktree prune` — cleans up the now-missing entry from `.git/worktrees/`

Falls back to `git worktree remove` if `trash` / `gio trash` are unavailable.

## Files changed

- EDIT: `.agents/scripts/worktree-helper.sh:722-742` — `_remove_cleanup_and_execute`: trash + prune instead of `git worktree remove`
- EDIT: `.agents/scripts/worktree-helper.sh:1208-1234` — `_clean_remove_merged`: same pattern, with `use_force` fallback preserved

## Verification

```bash
shellcheck .agents/scripts/worktree-helper.sh
# Create a test worktree, run wt remove, confirm directory appears in trash
```

## Related

- #18090 — interactive session worktrees removed by cleanup routines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved worktree cleanup process with enhanced error handling and fallback mechanisms for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->