### PR TITLE
GH#18120: ratchet-down NESTING_DEPTH_THRESHOLD 253 → 249

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -37,7 +37,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Bumped to 253 (GH#18075): proximity guard firing at 246/247 (1 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
 # Ratcheted down to 248 (GH#18080): actual violations 246 + 2 buffer
 # Bumped to 253 (GH#18086): proximity guard firing at 246/248 (2 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
-NESTING_DEPTH_THRESHOLD=253
+# Ratcheted down to 249 (GH#18120): actual violations 247 + 2 buffer
+NESTING_DEPTH_THRESHOLD=249
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1528,9 +1528,9 @@
       "pr": 12959
     },
     ".agents/scripts/commands/neuronwriter.md": {
-      "hash": "886434db9ad929bf62b41590b900856a48a78fbf",
-      "at": "2026-03-29T07:02:53Z",
-      "passes": 1,
+      "hash": "6d9d9b9ff1e61097f415362a55ce4444a5cabd74",
+      "at": "2026-04-11T02:40:55Z",
+      "passes": 2,
       "pr": 12588
     },
     ".agents/scripts/commands/new-task.md": {
@@ -1742,9 +1742,9 @@
       "pr": 12145
     },
     ".agents/scripts/generate-runtime-config.sh": {
-      "hash": "560fc8924c7d2c2aef4d452a6d0ee20f6ab4fe81",
-      "at": "2026-04-09T07:32:02Z",
-      "passes": 3,
+      "hash": "43c5f5c366082146e335de449e71d4e63237e7cb",
+      "at": "2026-04-11T02:40:56Z",
+      "passes": 4,
       "pr": 15933
     },
     ".agents/scripts/gh-signature-helper.sh": {
@@ -1790,9 +1790,9 @@
       "pr": 15455
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "efbe58b551915a847c6d779af54cef9df4a74822",
-      "at": "2026-04-10T03:17:43Z",
-      "passes": 4,
+      "hash": "9200b0f74d88d721437e0a77a3454efdba5c2101",
+      "at": "2026-04-11T02:40:56Z",
+      "passes": 5,
       "pr": 15086
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -5261,21 +5261,21 @@
       "pr": 16415
     },
     "TODO.md": {
-      "hash": "1c62774f6be8eb337a3cabb81ac477aa8e77d19b",
-      "at": "2026-04-10T03:17:58Z",
-      "passes": 15,
+      "hash": "a79edcde22f8dcf9e1869d1611ddb714a02d8da7",
+      "at": "2026-04-11T02:41:10Z",
+      "passes": 16,
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "8808122d8d8c3ca9ab8373f0e3452e5b1219e00a",
-      "at": "2026-04-10T05:00:58Z",
-      "passes": 50,
+      "hash": "fa47fe85322942b8b65f8e0b493b24dd048340ad",
+      "at": "2026-04-11T02:41:10Z",
+      "passes": 51,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "3e18405f4d2a221cc84b997c7a310b6f5b9293d7",
-      "at": "2026-04-10T05:00:58Z",
-      "passes": 49,
+      "hash": "d92364ca3b2d046c6ce4dbb118fda1fb25414aca",
+      "at": "2026-04-11T02:41:10Z",
+      "passes": 50,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -5561,9 +5561,9 @@
       "pr": 16710
     },
     ".agents/scripts/commands/email-health-check.md": {
-      "hash": "594e57a10c82787f0d813a0ebbef39739ad6aa19",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
+      "hash": "e558738cbf896c8ecf3dc22b981a175b95f43521",
+      "at": "2026-04-11T02:40:55Z",
+      "passes": 2,
       "pr": 16709
     },
     ".agents/services/outreach/leadsforge.md": {
@@ -6773,10 +6773,10 @@
       "passes": 2
     },
     ".agents/configs/complexity-thresholds-history.md": {
-      "hash": "9314b78dc3d4c25dbe47de963fd40f576a0ca50e",
-      "at": "2026-04-10T04:09:15Z",
+      "hash": "a398398e6a74d5ff458737f0d27c3a5166199e6e",
+      "at": "2026-04-11T02:40:51Z",
       "pr": 17979,
-      "passes": 5
+      "passes": 6
     },
     ".agents/scripts/memory-pressure-monitor.sh": {
       "hash": "d71f3754e56b925114a9b13c4ae3809cfb0c199d",


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 253 to 249 (actual violations: 247 + 2 buffer). Ratchet-down comment added to audit trail.

## Files Changed

.agents/configs/complexity-thresholds.conf,.agents/configs/simplification-state.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** complexity-scan-helper.sh ratchet-check confirms actual=247 < threshold=249; no further ratchet available

Resolves #18120


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.238 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 1,941 tokens on this as a headless worker.