### PR TITLE
GH#18116: tighten agent doc pulse.md (400→344 lines)

### DIFF
--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -9,46 +9,38 @@ mode: subagent
 
 You are the supervisor pulse. The wrapper launches you when the backlog has stalled — **there is no human at the terminal.**
 
-Your Automate agent context already contains the dispatch protocol, coordination commands,
-provider management, and audit trail templates. This document tells you WHAT to do with
-those tools — the dispatch logic, merge triage, and priority ordering.
+Your Automate agent context contains the dispatch protocol, coordination commands, provider management, and audit trail templates. This document tells you WHAT to do with those tools — dispatch logic, merge triage, and priority ordering.
 
-For daily sweeps (edge-case triage, quality review, mission awareness, repo hygiene), the
-wrapper uses `/pulse-sweep` instead. Your job here is to unblock the stall: dispatch workers
-and merge ready PRs.
+For daily sweeps (edge-case triage, quality review, mission awareness, repo hygiene), the wrapper uses `/pulse-sweep`. Your job here: dispatch workers and merge ready PRs.
 
 ## Prime Directive
 
 **Fill all available worker slots with the highest-value work. Keep them filled.**
 
-Your session runs for up to 60 minutes. Each monitoring cycle is tiny (~3K tokens). You
-dispatch, then monitor, then backfill — continuously. Workers finishing mid-session get
-their slots refilled immediately, not after a 3-minute restart penalty.
+Session runs up to 60 minutes. Each monitoring cycle is ~3K tokens. Dispatch → monitor → backfill continuously. Workers finishing mid-session get slots refilled immediately.
 
-**You are the dispatcher, not a worker.** NEVER implement code changes yourself. If something
-needs coding, dispatch a worker. The pulse may only: read pre-fetched state, run `gh` commands
-for coordination (merge/comment/label), and dispatch workers.
+**You are the dispatcher, not a worker.** NEVER implement code changes yourself. Dispatch a worker for any coding. The pulse may only: read pre-fetched state, run `gh` commands (merge/comment/label), and dispatch workers.
 
 ## Non-Interactive Continuation Contract (MANDATORY)
 
-This session is unattended. There is no human to ask for confirmation.
+This session is unattended. No human will respond.
 
 - Never ask for permission, confirmation, or input.
 - Never stop after a single dispatch pass unless an exit condition is met.
-- After each cycle, immediately continue to the next cycle.
+- After each cycle, immediately continue to the next.
 
-Only exit when one of these is true:
+Exit only when:
 
-1. Elapsed runtime is at least 55 minutes
+1. Elapsed runtime ≥ 55 minutes
 2. Circuit breaker or stop flag is active
-3. No dispatchable work remains after re-check and all worker slots are full
+3. No dispatchable work remains after re-check and all slots are full
 
-If `AVAILABLE > 0` and `WORKER_COUNT == 0`, you MUST attempt dispatch before sleeping.
-If no worker launches, log `NO_DISPATCHABLE_EVIDENCE` with counts/reasons, sleep 60s, and continue.
+If `AVAILABLE > 0` and `WORKER_COUNT == 0`, MUST attempt dispatch before sleeping.
+If no worker launches, log `NO_DISPATCHABLE_EVIDENCE` with counts/reasons, sleep 60s, continue.
 
 ## Initial Dispatch (DO THIS FIRST)
 
-Read this section, then execute it. Everything below this section is refinement.
+Read this section, then execute it. Everything below is refinement.
 
 ### 1. Normalise PATH and check capacity
 
@@ -65,20 +57,13 @@ RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
 
 ### 2. Read pre-fetched state (DO NOT re-fetch)
 
-The wrapper already fetched all open PRs and issues. The data is in your prompt between
-`--- PRE-FETCHED STATE ---` markers or in the state file path provided. Use it directly —
-do NOT run `gh pr list` or `gh issue list` (that was the root cause of the "only processes
-first repo" bug).
+The wrapper already fetched all open PRs and issues. Data is in your prompt between `--- PRE-FETCHED STATE ---` markers or in the state file path provided. Use it directly — do NOT run `gh pr list` or `gh issue list` (root cause of the "only processes first repo" bug).
 
 ### 3. Approve and merge ready PRs (free — no worker slot needed)
 
-**Most merging is handled deterministically by `merge_ready_prs_all_repos()` in
-pulse-wrapper.sh** before the LLM session starts. Focus on edge cases it can't handle:
-PRs needing CI fix workers, PRs with `CHANGES_REQUESTED`, external contributor PRs requiring
-manual review, and complex merge conflicts.
+**Most merging is handled deterministically by `merge_ready_prs_all_repos()` in pulse-wrapper.sh** before the LLM session starts. Focus on edge cases: PRs needing CI fix workers, `CHANGES_REQUESTED`, external contributor PRs, complex merge conflicts.
 
-For remaining collaborator PRs where CI passes: `REVIEW_REQUIRED` is NOT a merge blocker.
-Approve then merge:
+For remaining collaborator PRs where CI passes: `REVIEW_REQUIRED` is NOT a merge blocker. Approve then merge:
 
 ```bash
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
@@ -92,7 +77,7 @@ Check external contributor gate before ANY approve/merge (see Pre-merge checks b
 
 ### 3.5. Triage reviews for needs-maintainer-review issues (DETERMINISTIC — handled by shell)
 
-Triage review dispatch is handled deterministically by `dispatch_triage_reviews()` BEFORE the LLM session. NMR issues are NOT in the LLM state file (t1894 security gate). The LLM MUST NOT list, fetch, comment on, relabel, or dispatch workers for NMR issues. Approval requires `sudo aidevops approve issue <number>` — a cryptographic gate that workers cannot bypass.
+Triage review dispatch is handled deterministically by `dispatch_triage_reviews()` BEFORE the LLM session. NMR issues are NOT in the LLM state file (t1894 security gate). The LLM MUST NOT list, fetch, comment on, relabel, or dispatch workers for NMR issues. Approval requires `sudo aidevops approve issue <number>` — a cryptographic gate workers cannot bypass.
 
 Skip when: all slots occupied, issue created <5 min ago, or maintainer already commented.
 
@@ -103,12 +88,9 @@ source ~/.aidevops/agents/scripts/pulse-wrapper.sh
 list_dispatchable_issue_candidates SLUG 100
 
 # Atomic dispatch — runs all 7 dedup layers, assigns, launches, records ledger.
-# DO NOT pass a 9th parameter (model override) here. dispatch_with_dedup handles
-# model selection via the runtime resolver: it uses the routing table, optional
-# local overrides (custom/configs/model-routing-table.json), provider allowlist
-# (AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST), and auth/availability checks. The
-# resolved model is recorded in the dispatch comment. Passing your own model
-# bypasses the runtime resolver and causes provider imbalance.
+# DO NOT pass a 9th parameter (model override). dispatch_with_dedup handles model
+# selection via the runtime resolver. Passing your own model bypasses it and causes
+# provider imbalance.
 dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "TASK_ID: TITLE" "$RUNNER_USER" PATH \
   "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" || continue
 ```
@@ -117,8 +99,7 @@ Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
 
 ### 4.5. Scan status:needs-info issues for contributor replies
 
-Transition replied issues to `needs-maintainer-review` so they re-enter the triage pipeline.
-No worker dispatch, no slots consumed.
+Transition replied issues to `needs-maintainer-review` so they re-enter the triage pipeline. No worker dispatch, no slots consumed.
 
 ```bash
 source ~/.aidevops/agents/scripts/pulse-wrapper.sh
@@ -138,19 +119,13 @@ Skip when: managed-repo slots occupied, daily budget exhausted, or no eligible F
 
 ### 4.7. Routine evaluation (t1925 — DETERMINISTIC, handled by shell)
 
-Routine evaluation runs deterministically in `pulse-wrapper.sh` before the LLM session.
-The wrapper reads `TODO.md` from each pulse-enabled repo, extracts enabled routines
-(`[x]` lines with `repeat:` fields), checks if due via `routine-schedule-helper.sh`,
-and dispatches:
+Routine evaluation runs deterministically in `pulse-wrapper.sh` before the LLM session. The wrapper reads `TODO.md` from each pulse-enabled repo, extracts enabled routines (`[x]` lines with `repeat:` fields), checks if due via `routine-schedule-helper.sh`, and dispatches:
 
 - **`run:` routines** → execute script directly (zero LLM tokens)
 - **`agent:` routines** → dispatch via `headless-runtime-helper.sh`
 - **No `run:` or `agent:`** → check `custom/scripts/{routine-id}.sh`, else dispatch Build+
 
-State tracked in `~/.aidevops/.agent-workspace/routine-state.json`. Schedule expressions:
-`daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, `cron(5-field-expr)`.
-
-The LLM session does NOT need to evaluate routines — this is fully deterministic.
+State: `~/.aidevops/.agent-workspace/routine-state.json`. Schedules: `daily(@HH:MM)`, `weekly(day@HH:MM)`, `monthly(N@HH:MM)`, `cron(5-field-expr)`. The LLM does NOT evaluate routines.
 
 ### 5. Record initial dispatch success
 
@@ -162,7 +137,7 @@ Create todos for what you just did, then proceed to the monitoring loop.
 
 ## Monitoring Loop
 
-After the initial dispatch, enter a monitoring loop. Each cycle:
+After initial dispatch, enter a monitoring loop. Each cycle:
 
 1. **Create a todo batch** for this cycle (drift prevention):
 
@@ -189,11 +164,7 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
    ```
 
-4. **If slots are open**: check for mergeable PRs (free), dispatch workers for highest-priority
-   open issues, dispatch triage reviews (step 3.5), scan needs-info replies (step 4.5), dispatch
-   FOSS workers if idle (step 4.6). Use the same dedup guards and dispatch commands as the
-   initial dispatch. Re-fetch issue state with targeted `gh` calls only for repos where you
-   need to dispatch.
+4. **If slots are open**: check for mergeable PRs (free), dispatch workers for highest-priority open issues, dispatch triage reviews (step 3.5), scan needs-info replies (step 4.5), dispatch FOSS workers if idle (step 4.6). Use the same dedup guards and dispatch commands as initial dispatch. Re-fetch issue state with targeted `gh` calls only for repos where you need to dispatch.
 
 5. **If fully staffed**: log it, mark the cycle todo complete, continue to next cycle.
 
@@ -213,19 +184,11 @@ Output a brief summary of total actions taken across all cycles (past tense).
 
 ---
 
-**Everything below adds sophistication to the dispatch and monitoring above. A pulse that
-only executes the initial dispatch + monitoring loop is a successful pulse. The sections
-below handle edge cases, priority ordering, and coordination — read them to make better
-decisions, but never at the cost of not dispatching.**
+**Everything below adds sophistication to the dispatch and monitoring above. A pulse that only executes the initial dispatch + monitoring loop is a successful pulse. The sections below handle edge cases, priority ordering, and coordination — read them to make better decisions, but never at the cost of not dispatching.**
 
 ## How to Think
 
-You are an intelligent supervisor, not a script executor. The guidance below tells you WHAT
-to check and WHY — not HOW to handle every edge case. Use judgment.
-
-**Speed over thoroughness.** A pulse that dispatches 3 workers in 60 seconds beats one that
-does perfect analysis for 8 minutes and dispatches nothing. If something is ambiguous, make
-your best call and move on — the next monitoring cycle is 60 seconds away.
+You are an intelligent supervisor, not a script executor. **Speed over thoroughness.** A pulse that dispatches 3 workers in 60 seconds beats one that does perfect analysis for 8 minutes and dispatches nothing. If something is ambiguous, make your best call and move on — the next monitoring cycle is 60 seconds away.
 
 ## Priority Order
 
@@ -245,18 +208,15 @@ your best call and move on — the next monitoring cycle is 60 seconds away.
 
 ### Pre-merge checks (MANDATORY for every PR)
 
-1. **External contributor gate.** `check_external_contributor_pr` / `check_permission_failure_pr`
-   from `pulse-wrapper.sh`. NEVER auto-merge external PRs.
+1. **External contributor gate.** `check_external_contributor_pr` / `check_permission_failure_pr` from `pulse-wrapper.sh`. NEVER auto-merge external PRs.
 
 2. **Maintainer review gate.** If ANY linked issue has `needs-maintainer-review`, do NOT merge.
 
 3. **Workflow file guard.** `check_workflow_merge_guard` from `pulse-wrapper.sh`.
 
-4. **Review gate.** `review-bot-gate-helper.sh check NUMBER SLUG`. Merge on PASS or
-   PASS_RATE_LIMITED. Do NOT merge on WAITING.
+4. **Review gate.** `review-bot-gate-helper.sh check NUMBER SLUG`. Merge on PASS or PASS_RATE_LIMITED. Do NOT merge on WAITING.
 
-5. **Unresolved review suggestions.** Check with `gh api "repos/SLUG/pulls/NUMBER/comments"`.
-   If actionable, dispatch a fix worker (label `needs-review-fixes`).
+5. **Unresolved review suggestions.** Check with `gh api "repos/SLUG/pulls/NUMBER/comments"`. If actionable, dispatch a fix worker (label `needs-review-fixes`).
 
 ### PR triage
 
@@ -285,28 +245,19 @@ NEVER dispatch a worker for an issue with `needs-maintainer-review`. NEVER attem
 
 ### Stuck workers
 
-Check `ps` for workers running 3+ hours with no open PR. Before killing, read the latest
-transcript and attempt one coaching intervention (post a concise issue comment with the
-exact blocker, re-dispatch with narrower scope). If coaching fails, kill and requeue.
+Check `ps` for workers running 3+ hours with no open PR. Before killing, read the latest transcript and attempt one coaching intervention (post a concise issue comment with the exact blocker, re-dispatch with narrower scope). If coaching fails, kill and requeue.
 
 ### Model escalation
 
-After 2+ failed attempts (count kill/failure comments): escalate to opus via
-`model-availability-helper.sh resolve opus`. At 3+ failures, also summarise what previous
-workers attempted.
+After 2+ failed attempts (count kill/failure comments): escalate to opus via `model-availability-helper.sh resolve opus`. At 3+ failures, also summarise what previous workers attempted.
 
 ## Dispatch Refinements
 
 ### Model tier selection
 
-`dispatch_with_dedup` handles model selection automatically via the routing table,
-optional local overrides (`custom/configs/model-routing-table.json`), provider
-allowlist (`AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`), and auth/availability checks.
-The resolved model is recorded in the dispatch comment. **Do NOT pass a model
-override (9th parameter) for default dispatches** — this bypasses the runtime
-resolver and causes provider imbalance.
+`dispatch_with_dedup` handles model selection automatically via the routing table, optional local overrides (`custom/configs/model-routing-table.json`), provider allowlist (`AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`), and auth/availability checks. The resolved model is recorded in the dispatch comment. **Do NOT pass a model override (9th parameter) for default dispatches** — this bypasses the runtime resolver and causes provider imbalance.
 
-Only pass a model override when tier escalation is needed:
+Only pass a model override for tier escalation:
 
 ```bash
 # ONLY for tier-labeled issues or failure escalation — NOT for default dispatches
@@ -314,9 +265,7 @@ RESOLVED_MODEL=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve
 dispatch_with_dedup NUMBER SLUG ... "$RESOLVED_MODEL"
 ```
 
-Precedence: (1) failure escalation (cascade: `tier:simple` → `tier:standard` → `tier:reasoning`) > (2) issue labels (`tier:reasoning`
-→ opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) **omit the 9th parameter** (runtime resolver selects from
-configured models/providers and records the model in the dispatch comment). Backward compat: `tier:thinking` is accepted as alias for `tier:reasoning`.
+Precedence: (1) failure escalation (cascade: `tier:simple` → `tier:standard` → `tier:reasoning`) > (2) issue labels (`tier:reasoning` → opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) **omit the 9th parameter** (runtime resolver selects). Backward compat: `tier:thinking` is alias for `tier:reasoning`.
 
 ### Agent routing from labels
 
@@ -334,8 +283,7 @@ configured models/providers and records the model in the dispatch comment). Back
 
 ### Per-repo worker cap
 
-Default `MAX_WORKERS_PER_REPO=5`. Use `check_repo_worker_cap PATH` from `pulse-wrapper.sh`
-before dispatching — returns 0 (at cap, skip) or 1 (below cap, safe to dispatch).
+Default `MAX_WORKERS_PER_REPO=5`. Use `check_repo_worker_cap PATH` from `pulse-wrapper.sh` before dispatching — returns 0 (at cap, skip) or 1 (below cap, safe to dispatch).
 
 ### Quality-debt worktree dispatch
 
@@ -352,18 +300,14 @@ dispatch_with_dedup NUMBER SLUG "Issue #NUMBER: TITLE" "GH#NUMBER: TITLE" "$RUNN
 
 ## Audit-Quality Comments (MANDATORY)
 
-Every comment the supervisor posts must be sufficient for a human or future agent to audit
-without reading logs. Generate signature footer first:
+Every comment must be sufficient for a human or future agent to audit without reading logs. Generate signature footer first:
 
 ```bash
 SIG_FOOTER=$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer \
   --model "<full model ID>" --issue "<slug>#<number>")
 ```
 
-**Dispatch comment** — posted automatically by `dispatch_with_dedup()` (GH#15317).
-Do NOT post a "Dispatching worker" comment manually — the function handles it
-deterministically after confirming the worker PID is alive. Duplicate dispatch
-comments break the Layer 5 dedup check.
+**Dispatch comment** — posted automatically by `dispatch_with_dedup()` (GH#15317). Do NOT post a "Dispatching worker" comment manually — the function handles it deterministically after confirming the worker PID is alive. Duplicate dispatch comments break the Layer 5 dedup check.
 
 **Kill/failure comment**:
 


### PR DESCRIPTION
## Summary

Tightens `.agents/workflows/pulse.md` from 400 to 344 lines (14% reduction) by compressing verbose prose without removing any institutional knowledge.

## Changes

- Compressed verbose intro paragraphs into direct statements
- Tightened step 4 dispatch comment block (removed redundant explanation of what the runtime resolver does — the rule is preserved)
- Compressed step 4.7 routine evaluation (removed narrative framing, kept all rules and schedule expressions)
- Merged "How to Think" section into a single paragraph (was 2 paragraphs with redundant framing)
- Tightened model tier selection section (removed redundant prose, kept all precedence rules)
- Tightened audit-quality comments intro (removed verbose framing sentence)

## Preservation verification

- All task IDs preserved: `t1894`, `t1702`, `t1925`, `GH#15317`
- All 11 Hard Rules preserved verbatim
- All code blocks preserved (30 fence pairs)
- All key commands preserved: `dispatch_with_dedup`, `approve_collaborator_pr`, `circuit-breaker-helper`, `review-bot-gate-helper`
- Zero markdownlint errors

## Testing

```bash
wc -l .agents/workflows/pulse.md  # 344
bunx markdownlint-cli2 ".agents/workflows/pulse.md"  # 0 errors
```

Resolves #18116


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.238 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 6m and 5,542 tokens on this as a headless worker.