### PR TITLE
GH#18115: tighten pulse-sweep.md prose

### DIFF
--- a/.agents/workflows/pulse-sweep.md
+++ b/.agents/workflows/pulse-sweep.md
@@ -7,13 +7,13 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-You are the supervisor pulse running a **daily sweep** — invoked every 24 hours (or `PULSE_FORCE_LLM=1`) to handle edge cases the deterministic merge pass cannot resolve. Your Automate agent context contains the dispatch protocol, coordination commands, provider management, and audit trail templates. This document covers triage logic, priority ordering, and edge-case handling.
+You are the supervisor pulse running a **daily sweep** — invoked every 24 hours (or `PULSE_FORCE_LLM=1`) to handle edge cases the deterministic merge pass cannot resolve. This document covers triage logic, priority ordering, and edge-case handling. The Automate agent context provides dispatch protocol, coordination commands, provider management, and audit trail templates.
 
 ## Prime Directive
 
 **Fill all available worker slots with the highest-value work. Keep them filled.**
 
-Session: 60 min max. Each cycle ~3K tokens. Dispatch → monitor → backfill continuously. Refill slots immediately when workers finish.
+Session: 60 min max. Each cycle ~3K tokens. Dispatch → monitor → backfill continuously.
 
 **You are the dispatcher, not a worker.** NEVER implement code changes. Pulse may only: read pre-fetched state, run `gh` commands (merge/comment/label), dispatch workers.
 


### PR DESCRIPTION
## Summary

Tightens prose in `.agents/workflows/pulse-sweep.md` per issue #18115 (automated simplification scan).

**File type:** Instruction doc (agent rules, workflows, decision trees) — prose compression, not content reduction.

**Changes:**
- Reorder opening sentence: key doc purpose (triage logic, priority, edge cases) stated first; Automate agent context reference moved to end of sentence
- Remove "Refill slots immediately when workers finish" — redundant with "Keep them filled" in the Prime Directive directly above it

**Preserved:** All institutional knowledge, task IDs (t1894, t1545, t1702, GH#10308, GH#15317, GH#5149), command examples, code blocks, URLs, and decision rationale.

**Verification:** Content audit — all code blocks, URLs, task ID references, and command examples present before and after. Agent behaviour unchanged.

Resolves #18115


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.238 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 8,773 tokens on this as a headless worker.