### PR TITLE
GH#18129: bump nesting depth threshold to 254 to restore headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -38,6 +38,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 253 | GH#18075 | proximity guard firing at 246/247 (1 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
 | 248 | GH#18080 | ratcheted down — actual violations 246 + 2 buffer |
 | 253 | GH#18086 | proximity guard firing at 246/248 (2 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
+| 249 | GH#18120 | ratcheted down — actual violations 247 + 2 buffer |
+| 254 | GH#18129 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -22,7 +22,7 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # count over the current value.
 # Counting methodology: violations are counted using lint_shell_files() from
 # lint-file-discovery.sh (same file set as CI), not a raw find/glob. This
-# excludes vendor, node_modules, and non-shell files — yielding 246, not ~309.
+# excludes vendor, node_modules, and non-shell files — yielding 247, not ~309.
 #
 # Recent history (full log in complexity-thresholds-history.md):
 # Bumped to 263 (GH#17978): proximity guard firing at 256/258 (2 headroom); 256 violations + 7 headroom

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -38,7 +38,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 248 (GH#18080): actual violations 246 + 2 buffer
 # Bumped to 253 (GH#18086): proximity guard firing at 246/248 (2 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
 # Ratcheted down to 249 (GH#18120): actual violations 247 + 2 buffer
-NESTING_DEPTH_THRESHOLD=249
+# Bumped to 254 (GH#18129): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
+NESTING_DEPTH_THRESHOLD=254
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1558,15 +1558,15 @@
       "pr": 15682
     },
     ".agents/scripts/commands/pulse-sweep.md": {
-      "hash": "47015dbeca2b4f5fa6165119f41370c90eae2917",
-      "at": "2026-04-09T07:32:01Z",
-      "passes": 3,
+      "hash": "dcd38ac9f6aaeb0c23d5b7a4435c250ebf66e25b",
+      "at": "2026-04-11T03:27:10Z",
+      "passes": 4,
       "pr": 16472
     },
     ".agents/scripts/commands/pulse.md": {
-      "hash": "7d15b7a3f7d56177b46e96284887d62aa6e7f090",
-      "at": "2026-04-09T07:32:01Z",
-      "passes": 6,
+      "hash": "6420beeeed4b764c123b623f430c6df8ab62c192",
+      "at": "2026-04-11T03:27:10Z",
+      "passes": 7,
       "pr": 13117
     },
     ".agents/scripts/commands/recall.md": {
@@ -2357,9 +2357,9 @@
       "pr": 13837
     },
     ".agents/services/email/email-delivery-test.md": {
-      "hash": "7dc66ba9aac63dc55d8a6344d12fa68d27dd8458",
-      "at": "2026-03-28T16:40:17Z",
-      "passes": 1,
+      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
+      "at": "2026-04-11T03:27:14Z",
+      "passes": 2,
       "pr": 12041
     },
     ".agents/services/email/email-design-test.md": {
@@ -5417,9 +5417,9 @@
       "pr": 16570
     },
     ".agents/scripts/commands/autoresearch.md": {
-      "hash": "4836ead87c0b4c2cea8f7a87dcfbcddeef40e77c",
-      "at": "2026-04-03T21:12:00Z",
-      "passes": 2,
+      "hash": "f6c9df3d4d0f41acbccf1714eaa890ea59bcb0b3",
+      "at": "2026-04-11T03:27:09Z",
+      "passes": 3,
       "pr": 16569
     },
     ".agents/tools/productivity/contacts.md": {
@@ -6885,6 +6885,36 @@
       "at": "2026-04-10T03:17:43Z",
       "pr": 18058,
       "passes": 2
+    },
+    ".agents/workflows/autoresearch.md": {
+      "hash": "f6c9df3d4d0f41acbccf1714eaa890ea59bcb0b3",
+      "at": "2026-04-11T03:27:26Z",
+      "pr": 18119,
+      "passes": 1
+    },
+    ".agents/scripts/commands/email-delivery-test.md": {
+      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
+      "at": "2026-04-11T03:27:26Z",
+      "pr": 18118,
+      "passes": 1
+    },
+    ".agents/commands/AGENTS.md": {
+      "hash": "b52aab4466b045375bc8b6a8af238997061aa688",
+      "at": "2026-04-11T03:27:26Z",
+      "pr": 18117,
+      "passes": 1
+    },
+    ".agents/workflows/pulse.md": {
+      "hash": "6420beeeed4b764c123b623f430c6df8ab62c192",
+      "at": "2026-04-11T03:27:26Z",
+      "pr": 18116,
+      "passes": 1
+    },
+    ".agents/workflows/pulse-sweep.md": {
+      "hash": "dcd38ac9f6aaeb0c23d5b7a4435c250ebf66e25b",
+      "at": "2026-04-11T03:27:26Z",
+      "pr": 18115,
+      "passes": 1
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1558,15 +1558,15 @@
       "pr": 15682
     },
     ".agents/scripts/commands/pulse-sweep.md": {
-      "hash": "dcd38ac9f6aaeb0c23d5b7a4435c250ebf66e25b",
-      "at": "2026-04-11T03:27:10Z",
-      "passes": 4,
+      "hash": "47015dbeca2b4f5fa6165119f41370c90eae2917",
+      "at": "2026-04-09T07:32:01Z",
+      "passes": 3,
       "pr": 16472
     },
     ".agents/scripts/commands/pulse.md": {
-      "hash": "6420beeeed4b764c123b623f430c6df8ab62c192",
-      "at": "2026-04-11T03:27:10Z",
-      "passes": 7,
+      "hash": "7d15b7a3f7d56177b46e96284887d62aa6e7f090",
+      "at": "2026-04-09T07:32:01Z",
+      "passes": 6,
       "pr": 13117
     },
     ".agents/scripts/commands/recall.md": {
@@ -2357,9 +2357,9 @@
       "pr": 13837
     },
     ".agents/services/email/email-delivery-test.md": {
-      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
-      "at": "2026-04-11T03:27:14Z",
-      "passes": 2,
+      "hash": "7dc66ba9aac63dc55d8a6344d12fa68d27dd8458",
+      "at": "2026-03-28T16:40:17Z",
+      "passes": 1,
       "pr": 12041
     },
     ".agents/services/email/email-design-test.md": {
@@ -5417,9 +5417,9 @@
       "pr": 16570
     },
     ".agents/scripts/commands/autoresearch.md": {
-      "hash": "f6c9df3d4d0f41acbccf1714eaa890ea59bcb0b3",
-      "at": "2026-04-11T03:27:09Z",
-      "passes": 3,
+      "hash": "4836ead87c0b4c2cea8f7a87dcfbcddeef40e77c",
+      "at": "2026-04-03T21:12:00Z",
+      "passes": 2,
       "pr": 16569
     },
     ".agents/tools/productivity/contacts.md": {
@@ -6885,36 +6885,6 @@
       "at": "2026-04-10T03:17:43Z",
       "pr": 18058,
       "passes": 2
-    },
-    ".agents/workflows/autoresearch.md": {
-      "hash": "f6c9df3d4d0f41acbccf1714eaa890ea59bcb0b3",
-      "at": "2026-04-11T03:27:26Z",
-      "pr": 18119,
-      "passes": 1
-    },
-    ".agents/scripts/commands/email-delivery-test.md": {
-      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
-      "at": "2026-04-11T03:27:26Z",
-      "pr": 18118,
-      "passes": 1
-    },
-    ".agents/commands/AGENTS.md": {
-      "hash": "b52aab4466b045375bc8b6a8af238997061aa688",
-      "at": "2026-04-11T03:27:26Z",
-      "pr": 18117,
-      "passes": 1
-    },
-    ".agents/workflows/pulse.md": {
-      "hash": "6420beeeed4b764c123b623f430c6df8ab62c192",
-      "at": "2026-04-11T03:27:26Z",
-      "pr": 18116,
-      "passes": 1
-    },
-    ".agents/workflows/pulse-sweep.md": {
-      "hash": "dcd38ac9f6aaeb0c23d5b7a4435c250ebf66e25b",
-      "at": "2026-04-11T03:27:26Z",
-      "pr": 18115,
-      "passes": 1
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {


### PR DESCRIPTION
## Summary

Proximity guard was firing at 247/249 violations (2 headroom). Bumped `NESTING_DEPTH_THRESHOLD` from 249 to 254 to restore adequate headroom and prevent CI failures on PRs that don't introduce new nesting violations.

## Changes

- **EDIT: `.agents/configs/complexity-thresholds.conf`** — bumped `NESTING_DEPTH_THRESHOLD` from 249 to 254
- **EDIT: `.agents/configs/complexity-thresholds-history.md`** — added missing GH#18120 entry and new GH#18129 entry

## Rationale

Following the established pattern (see history file):
- Current violations: 247
- New threshold: 254 (247 + 7 headroom)
- Proximity guard `warn_at = 254 - 5 = 249` fires when violations exceed 249 (i.e., at 250), preventing saturation before the CI threshold is hit

This is the same approach used in GH#18086, GH#18075, GH#18056, GH#18020, GH#18013, GH#17978.

## Runtime Testing

`self-assessed` — config file change only; no shell logic modified. The CI `Shell nesting depth` check will validate the threshold is correct.

Resolves #18129

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.238 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 5,180 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code complexity threshold configuration and related audit records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->