### PR TITLE
GH#18132: tighten agent doc .agents/workflows/mission.md

### DIFF
--- a/.agents/workflows/mission.md
+++ b/.agents/workflows/mission.md
@@ -33,7 +33,18 @@ fi
 
 If `$MISSION_DESC` empty and not headless: ask "What's the mission? Describe the end goal in one sentence."
 
-**Headless defaults** (`--headless` or ` -- ` in args): auto-classify; Full mode unless "poc"/"prototype"/"spike"/"research" in desc; Time 1 week; Cost moderate; Infra existing/local; Deps none. Run decomposition with opus. Output: `MISSION_ID={id} MISSION_DIR={path} MISSION_MODE={poc|full} MISSION_MILESTONES={n} MISSION_FEATURES={n} MISSION_STATUS=planning`
+**Headless defaults** (`--headless` or ` -- ` in args):
+
+| Setting | Default |
+|---------|---------|
+| Classification | auto-detect |
+| Mode | Full (unless "poc"/"prototype"/"spike"/"research" in desc) |
+| Time | 1 week |
+| Cost | moderate |
+| Infra | existing/local |
+| Deps | none |
+
+Run decomposition with opus. Output: `MISSION_ID={id} MISSION_DIR={path} MISSION_MODE={poc|full} MISSION_MILESTONES={n} MISSION_FEATURES={n} MISSION_STATUS=planning`
 
 ## Step 1: Mission Classification
 
@@ -55,8 +66,6 @@ If ambiguous, present numbered options and ask.
 | **Full** | Worktree + PR workflow, task briefs per feature, parallel worker dispatch, preflight/postflight (recommended for greenfield/enhancement) |
 
 ## Step 3: Budget and Constraints Interview
-
-Ask sequentially, one recommended option each:
 
 | Q | Options |
 |---|---------|


### PR DESCRIPTION
## Summary

Convert headless defaults run-on sentence (line 36) to a readable table; remove redundant 'Ask sequentially' prose before budget table in Step 3. All code blocks, task ID refs (t1357.1, t1357.7), and command examples preserved. markdownlint: 0 errors, qlty smells: 0.

## Files Changed

.agents/workflows/mission.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2: 0 errors; qlty smells: 0 matches; content preservation verified (code blocks, t1357.1, t1357.7 refs present)

Resolves #18132


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.238 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 9,898 tokens on this as a headless worker.