### PR TITLE
GH#18101: exclude on-hold and blocked issues from pulse dispatch

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1188,7 +1188,7 @@ _prefetch_repo_issues() {
 
 	# Remove issues with non-dispatchable labels (supervisor, tracking, review gates)
 	local filtered_json
-	filtered_json=$(echo "$issue_json" | jq '[.[] | select(.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review") or index("needs-maintainer-review") or index("routine-tracking")) | not)]')
+	filtered_json=$(echo "$issue_json" | jq '[.[] | select(.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review") or index("needs-maintainer-review") or index("routine-tracking") or index("on hold") or index("blocked")) | not)]')
 
 	# GH#10308: Split issues into dispatchable vs quality-sweep-tracked.
 	local dispatchable_json sweep_tracked_json
@@ -8092,7 +8092,7 @@ dispatch_with_dedup() {
 		return 1
 	fi
 
-	if echo "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review"))' >/dev/null 2>&1; then
+	if echo "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review") or index("on hold") or index("blocked"))' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
 		return 1
 	fi


### PR DESCRIPTION
## Summary

- Adds `on hold` and `blocked` to the jq label exclusion filter in `_prefetch_repo_issues` (line 1191) — the primary dispatch gate
- Adds the same labels to the `dispatch_with_dedup` guard (line 8095) — the secondary check
- Both filters now consistently block issues labeled `on hold` or `blocked` from being dispatched to workers

## Root Cause

`pulse-wrapper.sh` excluded `supervisor`, `contributor`, `persistent`, `quality-review`, `needs-maintainer-review`, and `routine-tracking` from dispatch, but omitted `on hold` and `blocked`. This caused 16 consecutive wasted dispatch cycles to an explicitly on-hold issue.

## Verification

```
grep -n 'on hold\|"blocked"' .agents/scripts/pulse-wrapper.sh
# Returns lines 1191 and 8095 — both updated

# jq filter smoke tests pass:
# - on hold issues → excluded
# - blocked issues → excluded
# - normal queued issues → allowed through
```

Resolves #18101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced issue management by expanding non-dispatchable label recognition. Issues labeled "on hold" or "blocked" are now consistently treated as management labels and excluded from automated dispatch workflows across all filtering stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->