### PR TITLE
GH#18146: tighten aidevops-content.md agent doc

### DIFF
--- a/.agents/content.md
+++ b/.agents/content.md
@@ -50,7 +50,7 @@ subagents:
 
 ## Role
 
-You are the Content agent. Domain: multi-media multi-channel content production (blog, video, social, newsletters, podcasts, short-form, AI video generation, video prompt engineering). Own it fully -- you are NOT a DevOps assistant in this role.
+Content agent. Domain: blog, video, social, newsletters, podcasts, short-form, AI video generation, video prompt engineering. Own it fully — NOT a DevOps assistant in this role.
 
 ## Quick Reference
 
@@ -113,12 +113,12 @@ All subagent paths relative to `content/`.
 
 | Subagent | Frameworks |
 |----------|-----------|
-| research.md | **11-Dimension Reddit Research** (sentiment, UX, competitors, pricing, use cases, support, performance, updates, power tips, red flags, decision summary), **30-Minute Expert Method** (Reddit -> NotebookLM -> insights), **Niche Viability** (Demand + Buying Intent + Low Competition) |
-| story.md | **7 Hook Formulas** (Bold Claim, Question, Story, Contrarian, Result, Problem-Agitate, Curiosity Gap; 6-12 words), **4-Part Script** (Hook / Storytelling / Soft Sell / Visual Cues) |
-| production-video.md | **Sora 2 Pro 6-Section Template** (header, shots, timestamps, dialogue, sound, specs), **Veo 3.1 Ingredients-to-Video** (upload face/product as ingredients, NOT frame-to-video), **Seed Bracketing** (test seeds 1000-1010, score, iterate; 15% -> 70%+ success) |
-| production-audio.md | **Voice Pipeline** -- CapCut cleanup FIRST, THEN ElevenLabs transformation (t204) |
-| production-characters.md | **Facial Engineering** -- exhaustive facial analysis for cross-output consistency |
-| optimization.md | **A/B Testing** (10 variants min, 250-sample rule, <2% kill, >3% scale), **Monetization** (affiliates -> info products $5-27 -> upsell ladder -> Q4 seasonality) |
+| research.md | **11-Dimension Reddit Research** + **30-Minute Expert Method** (Reddit → NotebookLM → insights); **Niche Viability** (Demand + Buying Intent + Low Competition) |
+| story.md | **7 Hook Formulas** (6-12 words) + **4-Part Script** (Hook / Storytelling / Soft Sell / Visual Cues) |
+| production-video.md | **Sora 2 Pro 6-Section Template**; **Veo 3.1 Ingredients-to-Video** (upload face/product, NOT frame-to-video); **Seed Bracketing** (seeds 1000-1010; 15% → 70%+ success) |
+| production-audio.md | **Voice Pipeline** — CapCut cleanup FIRST, THEN ElevenLabs transformation (t204) |
+| production-characters.md | **Facial Engineering** — exhaustive facial analysis for cross-output consistency |
+| optimization.md | **A/B Testing** (10 variants min, 250-sample rule, <2% kill, >3% scale); **Monetization** (affiliates → info products $5-27 → upsell ladder → Q4 seasonality) |
 
 **Note**: YouTube agents live in `.agents/content/distribution-youtube/` (migrated from `.agents/youtube/` in t199.8).
 
@@ -144,10 +144,9 @@ content-fanout-helper.sh run <plan-file>    # Execute (also: channels, status, e
 | Video | `content/video-higgsfield.md`, `tools/video/video-prompt-design.md`, t200 Veo Meta Framework |
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh` |
 | SEO/Blog | `seo/`, `content/seo-writer.md`, `content/editor.md`, `content/meta-creator.md`, `content/internal-linker.md` |
-| Email | `marketing-sales.md` (FluentCRM), Social: `content/social-bird.md` (X), `social-linkedin.md`, `social-reddit.md` |
+| Email/Social | `marketing-sales.md` (FluentCRM), `content/social-bird.md` (X), `social-linkedin.md`, `social-reddit.md` |
 | Analysis | `seo-content-analyzer.py analyze article.md --keyword "target keyword"` |
-
-**Legacy text tools** (for blog/article workflows): `guidelines.md`, `platform-personas.md`, `seo-writer.md`, `meta-creator.md`, `editor.md`, `internal-linker.md`, `context-templates.md`.
+| Legacy text | `guidelines.md`, `platform-personas.md`, `seo-writer.md`, `meta-creator.md`, `editor.md`, `internal-linker.md`, `context-templates.md` (blog/article workflows) |
 
 ## Related Tasks
 


### PR DESCRIPTION
## Summary

Tighten `.agents/content.md` (symlinked as `.agents/commands/aidevops-content.md`) per build-agent.md principles: progressive disclosure, order by importance, compress prose not knowledge.

**Changes:**
- **Role**: tighten prose (removed redundant preamble, same meaning)
- **Key Frameworks table**: trim verbose parenthetical dimension lists (11 Reddit dimensions, 7 hook formula names, 6-section template fields) that duplicate content already in individual subagent files; preserve all critical operational rules (CapCut→ElevenLabs order, NOT frame-to-video constraint, seed bracketing success rates, all t-refs)
- **Supporting Tools**: fold `Legacy text tools` standalone paragraph into the table as a row; rename `Email` row to `Email/Social`

**Preservation verification:**
- All task ID references intact: t199.8, t200–t209, t204, t206
- All command examples intact: content-fanout-helper.sh, seo-content-analyzer.py
- All operational rules intact: CapCut FIRST rule (t204), NOT frame-to-video, 15%→70%+ seed bracketing, voice pipeline order
- All tool/file paths intact

**Line count**: 154 → 153 (the value is readability, not line count — Key Frameworks table rows now fit readable widths)

Resolves #18146

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.238 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 5m and 9,699 tokens on this as a headless worker.