### PR TITLE
GH#18149: chore: ratchet-down NESTING_DEPTH_THRESHOLD 254→249 (GH#18149)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -39,7 +39,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Bumped to 253 (GH#18086): proximity guard firing at 246/248 (2 headroom); 246 violations + 7 headroom; warn_at=248, guard fires when violations exceed 248 (i.e., at 249)
 # Ratcheted down to 249 (GH#18120): actual violations 247 + 2 buffer
 # Bumped to 254 (GH#18129): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
-NESTING_DEPTH_THRESHOLD=254
+# Ratcheted down to 249 (GH#18149): actual violations 247 + 2 buffer
+NESTING_DEPTH_THRESHOLD=249
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 254 to 249. Actual violations at 247, new value is 247 + 2 buffer. Added ratchet-down comment to complexity-thresholds.conf.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** complexity-scan-helper.sh ratchet-check confirmed: actual nest=247 < threshold=249. CI will pass.

Resolves #18149


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.238 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 2,549 tokens on this as a headless worker.