### PR TITLE
GH#18157: bump NESTING_DEPTH_THRESHOLD to 254 to restore headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -40,6 +40,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 253 | GH#18086 | proximity guard firing at 246/248 (2 headroom); bumped to 253 to restore adequate headroom — 246 violations + 7 headroom; proximity guard (warn_at = 253-5 = 248) fires when violations exceed 248 (i.e., at 249), preventing saturation |
 | 249 | GH#18120 | ratcheted down — actual violations 247 + 2 buffer |
 | 254 | GH#18129 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
+| 249 | GH#18149 | ratcheted down — actual violations 247 + 2 buffer |
+| 254 | GH#18157 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -40,7 +40,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 249 (GH#18120): actual violations 247 + 2 buffer
 # Bumped to 254 (GH#18129): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
 # Ratcheted down to 249 (GH#18149): actual violations 247 + 2 buffer
-NESTING_DEPTH_THRESHOLD=249
+# Bumped to 254 (GH#18157): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
+NESTING_DEPTH_THRESHOLD=254
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -139,9 +139,9 @@
       "pr": 15804
     },
     ".agents/build-plus.md": {
-      "hash": "0dac774fd81627ed224b8bd117944ba6ffaa2b14",
-      "at": "2026-04-11T04:09:25Z",
-      "passes": 2,
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "at": "2026-04-11T05:05:43Z",
+      "passes": 3,
       "pr": 13101
     },
     ".agents/business.md": {
@@ -1588,9 +1588,9 @@
       "pr": 14604
     },
     ".agents/scripts/commands/routine.md": {
-      "hash": "1bb7727bc0bf5187d94c97f53d348e1a1cdf3e10",
-      "at": "2026-04-09T07:32:01Z",
-      "passes": 3,
+      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
+      "at": "2026-04-11T05:05:49Z",
+      "passes": 4,
       "pr": 14509
     },
     ".agents/scripts/commands/runners-check.md": {
@@ -5225,9 +5225,9 @@
       "pr": 13443
     },
     ".agents/workflows/session-review.md": {
-      "hash": "a1e9708a230f0a852b23ac316aee99d9390e2a38",
-      "at": "2026-03-29T11:19:53Z",
-      "passes": 1,
+      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
+      "at": "2026-04-11T05:06:04Z",
+      "passes": 2,
       "pr": 12889
     },
     ".agents/workflows/sql-migrations.md": {
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "fa47fe85322942b8b65f8e0b493b24dd048340ad",
-      "at": "2026-04-11T02:41:10Z",
-      "passes": 51,
+      "hash": "608bfe89c318af487448ee6fb368b97130a8df02",
+      "at": "2026-04-11T05:06:04Z",
+      "passes": 52,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "d92364ca3b2d046c6ce4dbb118fda1fb25414aca",
-      "at": "2026-04-11T02:41:10Z",
-      "passes": 50,
+      "hash": "c419b2fee2197a3cf8fde9ccabd93fe9f838475f",
+      "at": "2026-04-11T05:06:04Z",
+      "passes": 51,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6917,10 +6917,10 @@
       "passes": 1
     },
     ".agents/commands/build-plus.md": {
-      "hash": "0dac774fd81627ed224b8bd117944ba6ffaa2b14",
-      "at": "2026-04-11T04:09:50Z",
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "at": "2026-04-11T05:05:43Z",
       "pr": 18133,
-      "passes": 1
+      "passes": 2
     },
     ".agents/commands/content.md": {
       "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
@@ -6944,6 +6944,30 @@
       "hash": "7f5d11baa5324a3da964a513d27e5790b0bdea27",
       "at": "2026-04-11T04:09:50Z",
       "pr": 18130,
+      "passes": 1
+    },
+    ".agents/scripts/commands/session-review.md": {
+      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18147,
+      "passes": 1
+    },
+    ".agents/commands/aidevops-content.md": {
+      "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18146,
+      "passes": 1
+    },
+    ".agents/workflows/routine.md": {
+      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18144,
+      "passes": 1
+    },
+    ".agents/commands/aidevops-build-plus.md": {
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18134,
       "passes": 1
     }
   },


### PR DESCRIPTION
## Summary

Proximity guard fired at 247/249 violations (2 headroom). Bumps `NESTING_DEPTH_THRESHOLD` from 249 to 254 to restore adequate headroom.

- **Current violations**: 247 (verified locally)
- **New threshold**: 254 (247 + 7 headroom)
- **Proximity guard fires at**: 249 violations (warn_at = 254-5 = 249), preventing CI saturation before threshold is reached

Also backfills the missing GH#18149 entry in `complexity-thresholds-history.md` (the ratchet-down from 254→249 was not recorded in the history file).

## Files Changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` from 249 to 254, add comment entry
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#18149 backfill entry and GH#18157 entry

## Runtime Testing

**Risk level**: Low — config file change only, no code logic modified.

Self-assessed: CI will verify the threshold value is read correctly by the `Shell nesting depth` check in `.github/workflows/code-quality.yml`.

Resolves #18157

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 4,344 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD complexity threshold configuration for improved build validation.
  * Advanced code simplification tracking metadata with updated status entries for multiple build and workflow components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->