### PR TITLE
GH#18159: tighten agent doc Marketing - Main Agent (.agents/commands/marketing-sales.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -139,9 +139,9 @@
       "pr": 15804
     },
     ".agents/build-plus.md": {
-      "hash": "0dac774fd81627ed224b8bd117944ba6ffaa2b14",
-      "at": "2026-04-11T04:09:25Z",
-      "passes": 2,
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "at": "2026-04-11T05:05:43Z",
+      "passes": 3,
       "pr": 13101
     },
     ".agents/business.md": {
@@ -1588,9 +1588,9 @@
       "pr": 14604
     },
     ".agents/scripts/commands/routine.md": {
-      "hash": "1bb7727bc0bf5187d94c97f53d348e1a1cdf3e10",
-      "at": "2026-04-09T07:32:01Z",
-      "passes": 3,
+      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
+      "at": "2026-04-11T05:05:49Z",
+      "passes": 4,
       "pr": 14509
     },
     ".agents/scripts/commands/runners-check.md": {
@@ -5225,9 +5225,9 @@
       "pr": 13443
     },
     ".agents/workflows/session-review.md": {
-      "hash": "a1e9708a230f0a852b23ac316aee99d9390e2a38",
-      "at": "2026-03-29T11:19:53Z",
-      "passes": 1,
+      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
+      "at": "2026-04-11T05:06:04Z",
+      "passes": 2,
       "pr": 12889
     },
     ".agents/workflows/sql-migrations.md": {
@@ -5267,15 +5267,15 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "hash": "fa47fe85322942b8b65f8e0b493b24dd048340ad",
-      "at": "2026-04-11T02:41:10Z",
-      "passes": 51,
+      "hash": "608bfe89c318af487448ee6fb368b97130a8df02",
+      "at": "2026-04-11T05:06:04Z",
+      "passes": 52,
       "pr": 15470
     },
     "setup.sh": {
-      "hash": "d92364ca3b2d046c6ce4dbb118fda1fb25414aca",
-      "at": "2026-04-11T02:41:10Z",
-      "passes": 50,
+      "hash": "c419b2fee2197a3cf8fde9ccabd93fe9f838475f",
+      "at": "2026-04-11T05:06:04Z",
+      "passes": 51,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {
@@ -6917,10 +6917,10 @@
       "passes": 1
     },
     ".agents/commands/build-plus.md": {
-      "hash": "0dac774fd81627ed224b8bd117944ba6ffaa2b14",
-      "at": "2026-04-11T04:09:50Z",
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "at": "2026-04-11T05:05:43Z",
       "pr": 18133,
-      "passes": 1
+      "passes": 2
     },
     ".agents/commands/content.md": {
       "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
@@ -6944,6 +6944,30 @@
       "hash": "7f5d11baa5324a3da964a513d27e5790b0bdea27",
       "at": "2026-04-11T04:09:50Z",
       "pr": 18130,
+      "passes": 1
+    },
+    ".agents/scripts/commands/session-review.md": {
+      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18147,
+      "passes": 1
+    },
+    ".agents/commands/aidevops-content.md": {
+      "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18146,
+      "passes": 1
+    },
+    ".agents/workflows/routine.md": {
+      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18144,
+      "passes": 1
+    },
+    ".agents/commands/aidevops-build-plus.md": {
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "at": "2026-04-11T05:06:05Z",
+      "pr": 18134,
       "passes": 1
     }
   },

--- a/.agents/marketing-sales.md
+++ b/.agents/marketing-sales.md
@@ -63,11 +63,8 @@ Marketing agent: strategy, campaigns, paid ads (Meta/Google), email, landing pag
 ## Email Campaigns
 
 **Workflow**: Plan → `fluentcrm_create_email_template` (title, subject, HTML) → `fluentcrm_create_campaign` (title, subject, template_id, list) → test → schedule → monitor.
-
 **Type routing**: Newsletter/Promotional → Email Campaign. Nurture/Transactional/Re-engagement → Automation.
-
 **Template rules**: Subject 40-60 chars (personalized, clear value). Preheader 40-100 chars. Single column, scannable, mobile-first. CTA above fold. Footer: unsubscribe, contact, social.
-
 **Personalization**: `{{contact.first_name}}`, `{{contact.last_name}}`, `{{contact.email}}`, `{{contact.full_name}}`, `{{contact.custom.field_name}}`
 
 ## Automation
@@ -95,11 +92,8 @@ Marketing agent: strategy, campaigns, paid ads (Meta/Google), email, landing pag
 ## Content & Lead Generation
 
 **Platform voice**: `content/platform-personas.md`.
-
 **Content → Campaign**: Create (`content.md`) → adapt platforms → SEO (`seo.md`) → email template → campaign (interest tags) → smart link → schedule → monitor.
-
 **Lead magnet**: Create → landing page + form → `fluentcrm_create_list` → delivery automation → nurture. Forms: Fluent Forms, WPForms, Gravity Forms, Contact Form 7, custom API.
-
 **Lead handoff**: Apply `lead-mql` tag → automation notifies sales → sales qualifies/accepts lead → apply `lead-sql` tag → remove from marketing sequences.
 
 ## Analytics & Testing
@@ -113,13 +107,11 @@ Marketing agent: strategy, campaigns, paid ads (Meta/Google), email, landing pag
 | List Growth | 5-10%/mo | Lead magnets, promo |
 
 **Workflow**: `fluentcrm_dashboard_stats` → review rates by segment → identify top content → document learnings.
-
 **A/B testing**: Variations (subject, send time, from name, CTA, length) → 10-20% test split → 24-48h → send winner to remainder.
 
 ## Deliverability & Compliance
 
 **Deliverability**: SPF/DKIM/DMARC auth. Warm new domains. Double opt-in. Remove hard bounces immediately. Re-engage or remove inactive (90+ days). Honor unsubscribes instantly.
-
 **Compliance**: GDPR (consent, erasure) | CAN-SPAM (unsubscribe, address) | CASL (consent, ID). Frequency: Newsletter weekly/bi-weekly. Promotional 2-4/month. Nurture 2-5 days apart.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Tighten `.agents/commands/marketing-sales.md` from 134 to 126 lines (~6% reduction) by removing unnecessary blank lines between consecutive bold-prefixed paragraphs within sections.

## Changes

- **Email Campaigns**: merged 4 bold-prefixed paragraphs (Workflow, Type routing, Template rules, Personalization) — removed 3 blank lines
- **Content & Lead Generation**: merged 4 bold-prefixed paragraphs (Platform voice, Content→Campaign, Lead magnet, Lead handoff) — removed 3 blank lines
- **Analytics & Testing**: merged Workflow and A/B testing paragraphs — removed 1 blank line
- **Deliverability & Compliance**: merged Deliverability and Compliance paragraphs — removed 1 blank line

## Verification

- All code blocks, URLs, command examples, and operational knowledge preserved
- No broken internal links or references
- Agent behaviour unchanged — only whitespace removed between related paragraphs within sections

Resolves #18159

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 4,715 tokens on this as a headless worker.