### PR TITLE
GH#18173: tighten aidevops-seo.md - abbreviate tool names, shorten category label

### DIFF
--- a/.agents/seo.md
+++ b/.agents/seo.md
@@ -49,14 +49,14 @@ subagents:
 
 ## Quick Reference
 
-- **Tools**: Google Search Console, Ahrefs, Semrush, DataForSEO, Serper, PageSpeed Insights, Google Analytics, Context7
+- **Tools**: GSC, Ahrefs, Semrush, DataForSEO, Serper, PageSpeed, GA4, Context7
 - **MCP**: GSC, DataForSEO, Serper, Google Analytics, Context7
 - **Commands**: `/keyword-research`, `/autocomplete-research`, `/keyword-research-extended`, `/seo-export`, `/seo-analyze`, `/seo-opportunities`, `/seo-write`, `/seo-optimize`, `/seo-analyze-content`, `/seo-fanout`, `/seo-geo`, `/seo-sro`, `/seo-hallucination-defense`, `/seo-agent-discovery`, `/seo-ai-readiness`, `/seo-ai-baseline`
 
 **Subagents** (`seo/` and `services/analytics/`):
 
 - **Research**: `keyword-research` (SERP weakness, 17 types, KeywordScore 0-100) | `ranking-opportunities` (quick wins, striking distance, cannibalization) | `query-fanout-research` (thematic fan-out) | `keyword-mapper` (placement/density) | `domain-research`
-- **Data providers**: `google-search-console` (queries, performance, index) | `dataforseo` (SERP, keywords, backlinks, on-page REST API) | `serper` (Google Search API) | `ahrefs` (backlinks, DR, REST API v3) | `semrush` (domain analytics, competitor research)
+- **Data**: `google-search-console` (queries, performance, index) | `dataforseo` (SERP, keywords, backlinks, on-page REST API) | `serper` (Google Search API) | `ahrefs` (backlinks, DR, REST API v3) | `semrush` (domain analytics, competitor research)
 - **Analytics**: `google-analytics` (GA4 reporting) | `analytics-tracking` (GA4 setup, events, UTM, attribution)
 - **Technical**: `site-crawler` (links, meta, redirects) | `screaming-frog` (SEO Spider CLI) | `contentking` (real-time monitoring) | `pagespeed`
 - **Content**: `content-analyzer` (readability, keywords, quality) | `seo-optimizer` (on-page audit) | `eeat-score` (7 criteria, 1-10) | `programmatic-seo` (pages at scale)


### PR DESCRIPTION
## Summary

Tightens `.agents/seo.md` (symlinked as `.agents/commands/aidevops-seo.md`) per simplification-debt scan GH#18173.

**Changes:**
- Abbreviated verbose tool names in Quick Reference: `Google Search Console` → `GSC`, `PageSpeed Insights` → `PageSpeed`, `Google Analytics` → `GA4`
- Shortened category label: `**Data providers**:` → `**Data**:`

**Preserved:**
- All code blocks, command examples, and bash scripts
- All URLs (SEO Machine GitHub link)
- All subagent descriptions and routing logic
- Tool comparison table (reference data for tool selection)
- E-E-A-T scoring criteria and workflow steps

**Classification:** Instruction doc (agent rules, workflows, decision trees) — tightened prose, no content removed.

**Verification:** Content preservation confirmed — all code blocks, URLs, and command examples present before and after. Line count unchanged at 122 (file was already well-structured; changes are minor abbreviations only).

Resolves #18173

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 6,081 tokens on this as a headless worker.