### PR TITLE
GH#18158: tighten youtube-research.md (145 → 137 lines)

### DIFF
--- a/.agents/content/youtube-research.md
+++ b/.agents/content/youtube-research.md
@@ -24,27 +24,21 @@ Target: $ARGUMENTS
 | `--all` | Full research cycle (all competitors) |
 | No args | Interactive (ask user) |
 
-### Step 2: Load Configuration
+Load config: `~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "channel"`
 
-```bash
-~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "channel"
-```
-
-### Step 3: Execute Research
+### Step 2: Execute Research
 
 #### Mode A: Competitor Analysis (`@competitor`)
-
-1. Get channel overview and recent videos:
 
 ```bash
 ~/.aidevops/agents/scripts/youtube-helper.sh channel @competitor
 ~/.aidevops/agents/scripts/youtube-helper.sh videos @competitor 50
 ```
 
-2. **Identify outliers** — videos with 3x+ channel average views.
-3. Get transcripts of top 3 outliers: `youtube-helper.sh transcript VIDEO_ID`
-4. **Analyze patterns:** topics, title style (length, keywords, hooks), video length, upload frequency.
-5. Store findings:
+1. **Identify outliers** — videos with 3x+ channel average views.
+2. Get transcripts of top 3 outliers: `youtube-helper.sh transcript VIDEO_ID`
+3. **Analyze patterns:** topics, title style (length, keywords, hooks), video length, upload frequency.
+4. Store findings:
 
 ```bash
 ~/.aidevops/agents/scripts/memory-helper.sh store \
@@ -54,7 +48,7 @@ Target: $ARGUMENTS
 
 #### Mode B: Trending Topics (`trending`)
 
-1. Search trending videos: `youtube-helper.sh trending "niche topic" 20`
+1. Search: `youtube-helper.sh trending "niche topic" 20`
 2. **Cluster by topic:** group by keywords/themes, identify rising topics, note view counts.
 3. **Cross-reference with competitors:** which trending topics haven't they covered? Which are oversaturated?
 4. Store opportunities:
@@ -76,17 +70,15 @@ Target: $ARGUMENTS
 
 #### Mode D: Video Analysis (`video VIDEO_ID`)
 
-1. Get details and transcript:
-
 ```bash
 ~/.aidevops/agents/scripts/youtube-helper.sh video VIDEO_ID
 ~/.aidevops/agents/scripts/youtube-helper.sh transcript VIDEO_ID
 ```
 
-2. **Analyze structure:** hook (first 30s), intro (problem setup), body (solution/content), CTA.
-3. **Extract reusable patterns:** title formula, hook formula, content structure, pacing (words/minute).
+1. **Analyze structure:** hook (first 30s), intro (problem setup), body (solution/content), CTA.
+2. **Extract reusable patterns:** title formula, hook formula, content structure, pacing (words/minute).
 
-### Step 4: Present Findings
+### Step 3: Present Findings
 
 ```text
 YouTube Research: {target}


### PR DESCRIPTION
## Summary

Simplify `.agents/content/youtube-research.md` per issue #18158 (simplification-debt scan).

**Changes:**
- Collapse "Step 2: Load Configuration" (3-line code block) into a single inline command
- Remove redundant intro lines before code blocks ("1. Get channel overview and recent videos:", "1. Get details and transcript:")
- Renumber steps from 4 to 3 (Step 3 → Step 2, Step 4 → Step 3)
- Tighten "Search trending videos:" to "Search:"
- Renumber Mode A list items (5 → 4, removing the intro item)

**Result:** 145 → 137 lines (−8 lines, 5.5% reduction)

## Content Preservation

All code blocks, commands, URLs, and institutional knowledge preserved. Verified via diff.

## Runtime Testing

Risk: **Low** (docs/agent prompt only — no code changes). Self-assessed.

## Verification

- `wc -l .agents/content/youtube-research.md` → 137 (reduced from 145)
- qlty smells: 0 findings on target file
- All code blocks, commands, and task references present before and after

Resolves #18158

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 4,170 tokens on this as a headless worker.