### PR TITLE
GH#18185: tighten agent doc /optimize-tiers (121 → 100 lines)

### DIFF
--- a/.agents/workflows/optimize-tiers.md
+++ b/.agents/workflows/optimize-tiers.md
@@ -17,15 +17,11 @@ tools:
 
 # /optimize-tiers
 
-Manage the cascade tier optimisation pipeline: expand the test corpus, review telemetry, and iterate brief quality.
-
 Topic: $ARGUMENTS
 
 ## Subcommands
 
 ### `/optimize-tiers report`
-
-Show current tier dispatch telemetry from production data:
 
 ```bash
 ~/.aidevops/agents/scripts/dispatch-ledger-helper.sh tier-report
@@ -40,19 +36,15 @@ Expand the test corpus with recently merged worker PRs. Run weekly or on-demand.
 ```bash
 CORPUS="${HOME}/.aidevops/.agent-workspace/work/tier-corpus"
 mkdir -p "$CORPUS"
-
-# Extract new PRs from all pulse-enabled repos
 for slug in $(jq -r '.initialized_repos[] | select(.pulse == true) | .slug' ~/.config/aidevops/repos.json); do
   ~/.aidevops/agents/scripts/brief-tier-test-helper.sh extract \
     --repo "$slug" --label origin:worker --max-files 3 --limit 20 \
     --output "$CORPUS"
 done
-
-# Report corpus size
 echo "Corpus: $(jq 'length' "$CORPUS/index.json") cases"
 ```
 
-After extraction, generate enriched briefs for new cases:
+Then enrich new cases:
 
 ```bash
 ~/.aidevops/agents/scripts/brief-tier-test-helper.sh enrich \
@@ -61,42 +53,31 @@ After extraction, generate enriched briefs for new cases:
 
 ### `/optimize-tiers test`
 
-Run Haiku against the corpus and score results:
-
 ```bash
 CORPUS="${HOME}/.aidevops/.agent-workspace/work/tier-corpus"
 RESULTS="${HOME}/.aidevops/.agent-workspace/work/tier-results.tsv"
-
 ~/.aidevops/agents/scripts/brief-tier-test-helper.sh test \
   --corpus "$CORPUS" --model haiku --results "$RESULTS"
-
 ~/.aidevops/agents/scripts/brief-tier-test-helper.sh report --results "$RESULTS"
 ```
 
 ### `/optimize-tiers research`
 
-Launch the autoresearch optimisation loop. Iterates brief template changes and measures Haiku success rate improvement.
+Iterates brief template changes and measures Haiku success rate improvement. Read `todo/research/optimize-brief-tiers.md` for the full program definition, then:
 
-Read `todo/research/optimize-brief-tiers.md` for the full program definition, then:
-
-1. Review current telemetry (`tier-report`) to identify the dominant escalation reason
-2. Form a hypothesis about which brief template change would reduce that reason
+1. Run `tier-report` to identify the dominant escalation reason
+2. Form a hypothesis about which brief template change would reduce it
 3. Modify `templates/brief-template.md` or `workflows/brief.md`
-4. Re-enrich a subset of corpus cases with the modified template
-5. Re-test Haiku on the subset
-6. Score and compare against baseline
-7. Keep improvement or revert
+4. Re-enrich a corpus subset with the modified template
+5. Re-test Haiku on the subset; score vs baseline; keep or revert
 
 Budget: 30 iterations max, 3 trials per hypothesis (Haiku output has variance).
 
 ## Scheduling
 
-### Weekly corpus expansion (L2)
-
-Add to pulse routine (runs once per week):
+**Weekly corpus expansion** — add to pulse routine:
 
 ```bash
-# In pulse-wrapper.sh or as a launchd timer
 LAST_EXPAND="${HOME}/.aidevops/.agent-workspace/tmp/tier-corpus-last-expand"
 if [[ ! -f "$LAST_EXPAND" ]] || [[ $(( $(date +%s) - $(cat "$LAST_EXPAND") )) -gt 604800 ]]; then
   /optimize-tiers expand
@@ -104,16 +85,14 @@ if [[ ! -f "$LAST_EXPAND" ]] || [[ $(( $(date +%s) - $(cat "$LAST_EXPAND") )) -g
 fi
 ```
 
-### Production telemetry (L1, always on)
-
-Tier telemetry is recorded automatically by:
-- `dispatch-ledger-helper.sh register` — records tier + model at dispatch time
-- `dispatch-ledger-helper.sh record-outcome` — records outcome + escalation reason
+**Production telemetry** (always on) — recorded automatically:
+- `dispatch-ledger-helper.sh register` — tier + model at dispatch time
+- `dispatch-ledger-helper.sh record-outcome` — outcome + escalation reason
 - Append-only log: `~/.aidevops/.agent-workspace/tmp/tier-telemetry.jsonl`
 
 ## Related
 
-- `workflows/brief.md` — centralised brief formatting (the file being optimised)
+- `workflows/brief.md` — centralised brief formatting
 - `reference/task-taxonomy.md` — tier definitions and cascade model
 - `templates/brief-template.md` — task brief template (modified by autoresearch)
 - `templates/escalation-report-template.md` — escalation reason codes


### PR DESCRIPTION
## Summary

Tightens `.agents/workflows/optimize-tiers.md` from 121 to 100 lines (17% reduction) per GH#18185.

**Changes:**
- Removed redundant intro sentence (duplicated frontmatter description)
- Removed inline comments in code blocks that were self-evident
- Collapsed scheduling section from two H3 headers to bold inline headings
- Condensed research subcommand steps (7 → 5 by merging related steps)
- Removed "Show current tier dispatch telemetry from production data:" prose before report command (self-evident from command name)

**Preserved:**
- All code blocks and command examples (verbatim)
- All file references and related links
- All operational constraints (budget limits, scheduling logic)
- Agent behaviour unchanged

## Runtime Testing

Risk: **Low** — doc-only change, no code modified.
Verification: `self-assessed`

Resolves #18185


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 5,308 tokens on this as a headless worker.