### PR TITLE
GH#18162: tighten agent doc Automate - Scheduling & Orchestration Agent (.agents/commands/aidevops-automate.md, 134 → 129 lines)

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -113,14 +113,9 @@ launchctl bootout gui/$(id -u)/sh.aidevops.<name> && \
 
 ## Provider Management
 
-**Automatic model routing (v3.7+, GH#17769):** The headless model list is derived at runtime from two sources — no env var configuration needed:
+**Automatic model routing (v3.7+, GH#17769):** Model list derived at runtime from OAuth pool (`oauth-pool-helper.sh list all`) + routing table (`configs/model-routing-table.json`). Round-robin = sonnet-tier model per provider. Pulse always uses Anthropic sonnet. No env var config needed.
 
-1. **OAuth pool** (`oauth-pool-helper.sh list all`) — which providers the user has accounts for
-2. **Routing table** (`configs/model-routing-table.json`) — which models map to which tiers per provider
-
-The round-robin model list = "for each provider in the pool, get the sonnet-tier model from the routing table." Pulse always uses the Anthropic sonnet model (derived from the routing table). Workers round-robin across all pool providers.
-
-**No manual model configuration required.** The deprecated `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle, with deprecation warnings logged. Remove them from `credentials.sh` — they will be ignored in a future release.
+**Deprecated:** `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` respected one release cycle with warnings. Remove from `credentials.sh`.
 
 **Backoff:** `headless-runtime-helper.sh backoff status` / `backoff clear PROVIDER`. Exit code 75 = all providers backed off.
 **Escalation:** After 2+ failed attempts, use `--model anthropic/claude-opus-4-6`. One opus dispatch (~3x cost) is cheaper than 5+ failed sonnet dispatches.


### PR DESCRIPTION
## Summary

Tightens `.agents/commands/aidevops-automate.md` (symlink to `.agents/automate.md`) from 134 to 129 lines by compressing verbose prose in the Provider Management section.

## Changes

- **Provider Management section**: Collapsed 9 lines of verbose prose into 4 lines. Combined the two-source description into a single sentence, condensed the round-robin explanation, and tightened the deprecation notice.
- All institutional knowledge preserved: GH#17769 reference, both source commands (`oauth-pool-helper.sh`, `configs/model-routing-table.json`), round-robin behavior, Pulse model behavior, deprecated env var names and removal instruction.

## Runtime Testing

**Risk level:** Low — documentation/agent prompt only, no code changes.
**Verification:** `self-assessed` — content preservation verified via diff review.

## Verification

- All code blocks, URLs, task ID references (GH#17769, GH#15317), and command examples present before and after ✓
- No broken internal links or references ✓
- Agent behaviour unchanged ✓
- Qlty: `SKIP` (unavailable in this environment)

Resolves #18162

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 7,308 tokens on this as a headless worker.