### PR TITLE
GH#18171: tighten agent doc .agents/tools/testing-setup.md

### DIFF
--- a/.agents/tools/testing-setup.md
+++ b/.agents/tools/testing-setup.md
@@ -16,8 +16,6 @@ Configure testing infrastructure for the current project. Detects bundle, discov
 
 Arguments: $ARGUMENTS
 
-## Workflow
-
 ### Step 1: Detect Project Bundle
 
 ```bash
@@ -27,7 +25,7 @@ QUALITY_GATES=$(echo "$BUNDLE" | jq -r '.quality_gates[]')
 SKIP_GATES=$(echo "$BUNDLE" | jq -r '.skip_gates[]' 2>/dev/null)
 ```
 
-Display detected bundle and quality gates. No bundle → fall back to `cli-tool`. Offer override (web-app, cli-tool, library, infrastructure, content-site, agent).
+Display detected bundle and quality gates. No bundle → fall back to `cli-tool`. Offer override: web-app, cli-tool, library, infrastructure, content-site, agent.
 
 ### Step 2: Discover Existing Infrastructure
 
@@ -62,7 +60,7 @@ Group results: Ready, Needs attention, Missing (recommended), Skipped by bundle.
 
 For each gap, offer: (1) install and configure (recommended), (2) skip — handle manually, (3) use alternative already installed.
 
-**Categories:** missing test runner (install dep, create config, sample test, add `test` script), missing coverage (c8/istanbul, 80% threshold default), missing CI integration (add test step to workflow), pre-commit hooks (aidevops hooks or husky/lint-staged).
+**Categories:** missing test runner (install dep, create config, sample test, add `test` script) · missing coverage (c8/istanbul, 80% threshold default) · missing CI integration (add test step to workflow) · pre-commit hooks (aidevops hooks or husky/lint-staged).
 
 > Runner installation is agent-driven (requires judgment for alternatives, conflict handling). The helper provides `discover`, `gaps`, `status`, `verify` — the deterministic parts.
 
@@ -88,12 +86,7 @@ Create all configuration files from collected choices: test runner configs, cove
 testing-setup-helper.sh verify .
 ```
 
-Execute each configured runner — report `[pass]`/`[fail]`/`[skip]` per gate. Then display files created/modified and next steps:
-
-1. Write tests for existing code
-2. Run `testing-setup-helper.sh status` to check test health
-3. Push to trigger CI pipeline test step
-4. Consider `/testing-coverage` to identify untested code paths
+Execute each configured runner — report `[pass]`/`[fail]`/`[skip]` per gate. Display files created/modified and next steps: write tests for existing code, run `testing-setup-helper.sh status`, push to trigger CI, consider `/testing-coverage` for untested paths.
 
 ## Options
 


### PR DESCRIPTION
## Summary

Tightened `.agents/tools/testing-setup.md` from 125 to 118 lines (7 lines removed, ~6% reduction).

## Changes

- Removed redundant `## Workflow` heading — the numbered steps are self-evident structure
- Condensed Step 4 categories from comma-separated list to bullet-separated inline (same content, less visual noise)
- Collapsed Step 6 next-steps from 4-line numbered list to single inline sentence

## Content Preservation

All knowledge preserved:
- All code blocks intact (bundle detection bash, .aidevops-testing.json example, verify command)
- All URLs and command references present
- All table data (discovery scan, gap analysis, options, bundle-to-runner mapping) unchanged
- All related links preserved

## Classification

Instruction doc (agent workflow/decision tree) — tightened prose, not split into chapters. Reference corpus treatment not applicable.

## Testing

- Content preservation: verified all code blocks, commands, and reference links present before and after
- Qlty smells for target file: 0
- Agent behaviour unchanged: workflow steps, commands, and decision logic identical

Resolves #18171


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 4,270 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing setup documentation with improved formatting and clarity. Streamlined workflow instructions and reorganized step-by-step guidance for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->