### PR TITLE
GH#18161: tighten agent doc Marketing - Main Agent (.agents/commands/aidevops-marketing-sales.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -540,9 +540,9 @@
       "pr": 16526
     },
     ".agents/marketing-sales.md": {
-      "hash": "83f5bd4cfdac9d5d6082d7de8c38e23d140360b2",
-      "at": "2026-03-30T06:03:16Z",
-      "passes": 1,
+      "hash": "f8f0af6b6be25536b600c62fd5c6d73adf2162f7",
+      "at": "2026-04-11T10:00:00Z",
+      "passes": 2,
       "pr": 13839
     },
     ".agents/marketing-sales/ad-creative-ai-tools-reference.md": {

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2363,9 +2363,9 @@
       "pr": 12041
     },
     ".agents/services/email/email-design-test.md": {
-      "hash": "455d497e3e0a523019c98a74444a73f4e6e89cf0",
-      "at": "2026-03-29T22:09:19Z",
-      "passes": 1,
+      "hash": "2055f755f4558bb21f4ac9714e6f1011b2745ec4",
+      "at": "2026-04-11T07:23:11Z",
+      "passes": 2,
       "pr": 13324
     },
     ".agents/services/email/email-health-check.md": {
@@ -6968,6 +6968,12 @@
       "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
       "at": "2026-04-11T05:06:05Z",
       "pr": 18134,
+      "passes": 1
+    },
+    ".agents/scripts/commands/email-design-test.md": {
+      "hash": "2055f755f4558bb21f4ac9714e6f1011b2745ec4",
+      "at": "2026-04-11T07:23:25Z",
+      "pr": 18170,
       "passes": 1
     }
   },

--- a/.agents/marketing-sales.md
+++ b/.agents/marketing-sales.md
@@ -63,11 +63,8 @@ Marketing agent: strategy, campaigns, paid ads (Meta/Google), email, landing pag
 ## Email Campaigns
 
 **Workflow**: Plan → `fluentcrm_create_email_template` (title, subject, HTML) → `fluentcrm_create_campaign` (title, subject, template_id, list) → test → schedule → monitor.
-
 **Type routing**: Newsletter/Promotional → Email Campaign. Nurture/Transactional/Re-engagement → Automation.
-
 **Template rules**: Subject 40-60 chars (personalized, clear value). Preheader 40-100 chars. Single column, scannable, mobile-first. CTA above fold. Footer: unsubscribe, contact, social.
-
 **Personalization**: `{{contact.first_name}}`, `{{contact.last_name}}`, `{{contact.email}}`, `{{contact.full_name}}`, `{{contact.custom.field_name}}`
 
 ## Automation
@@ -95,11 +92,8 @@ Marketing agent: strategy, campaigns, paid ads (Meta/Google), email, landing pag
 ## Content & Lead Generation
 
 **Platform voice**: `content/platform-personas.md`.
-
 **Content → Campaign**: Create (`content.md`) → adapt platforms → SEO (`seo.md`) → email template → campaign (interest tags) → smart link → schedule → monitor.
-
 **Lead magnet**: Create → landing page + form → `fluentcrm_create_list` → delivery automation → nurture. Forms: Fluent Forms, WPForms, Gravity Forms, Contact Form 7, custom API.
-
 **Lead handoff**: Apply `lead-mql` tag → automation notifies sales → sales qualifies/accepts → apply `lead-sql` tag → remove from marketing sequences.
 
 ## Analytics & Testing
@@ -117,7 +111,6 @@ Marketing agent: strategy, campaigns, paid ads (Meta/Google), email, landing pag
 ## Deliverability & Compliance
 
 **Deliverability**: SPF/DKIM/DMARC auth. Warm new domains. Double opt-in. Remove hard bounces immediately. Re-engage or remove inactive (90+ days). Honor unsubscribes instantly.
-
 **Compliance**: GDPR (consent, erasure) | CAN-SPAM (unsubscribe, address) | CASL (consent, ID). Frequency: Newsletter weekly/bi-weekly. Promotional 2-4/month. Nurture 2-5 days apart.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Tighten `.agents/marketing-sales.md` (the target of symlink `.agents/commands/aidevops-marketing-sales.md`) from 132 to 125 lines (~5% reduction) by removing unnecessary blank lines between consecutive bold-prefixed paragraphs within sections.

## Changes

- **Email Campaigns**: merged 4 bold-prefixed paragraphs (Workflow, Type routing, Template rules, Personalization) — removed 3 blank lines
- **Content & Lead Generation**: merged 4 bold-prefixed paragraphs (Platform voice, Content→Campaign, Lead magnet, Lead handoff) — removed 3 blank lines
- **Deliverability & Compliance**: merged Deliverability and Compliance paragraphs — removed 1 blank line

Note: `.agents/commands/aidevops-marketing-sales.md` is a symlink to `../marketing-sales.md`. Changes to the symlink target apply to both paths.

## Verification

- All code blocks, URLs, command examples, and operational knowledge preserved
- No broken internal links or references
- Agent behaviour unchanged — only whitespace removed between related paragraphs within sections
- Qlty smells: SKIP (Qlty unavailable in this environment)

Resolves #18161

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 7m and 16,161 tokens on this as a headless worker.