### PR TITLE
GH#18171: tighten testing-setup.md prose

### DIFF
--- a/.agents/tools/testing-setup.md
+++ b/.agents/tools/testing-setup.md
@@ -12,13 +12,13 @@ tools:
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Configure testing infrastructure for the current project. Detects bundle, discovers existing tooling, identifies gaps against bundle quality gates, generates configuration, and verifies end-to-end.
+Configure testing infrastructure for the current project. Detects bundle, discovers existing tooling, gaps against quality gates, generates config, and verifies end-to-end.
 
 Arguments: $ARGUMENTS
 
 ## Workflow
 
-### Step 1: Detect Project Bundle
+### Step 1: Detect Bundle
 
 ```bash
 BUNDLE=$(~/.aidevops/agents/scripts/bundle-helper.sh resolve .)
@@ -64,7 +64,7 @@ For each gap, offer: (1) install and configure (recommended), (2) skip — handl
 
 **Categories:** missing test runner (install dep, create config, sample test, add `test` script), missing coverage (c8/istanbul, 80% threshold default), missing CI integration (add test step to workflow), pre-commit hooks (aidevops hooks or husky/lint-staged).
 
-> Runner installation is agent-driven (requires judgment for alternatives, conflict handling). The helper provides `discover`, `gaps`, `status`, `verify` — the deterministic parts.
+Runner installation is agent-driven (judgment for alternatives, conflict handling). The helper provides `discover`, `gaps`, `status`, `verify` — the deterministic parts.
 
 ### Step 5: Generate Configuration
 
@@ -73,7 +73,6 @@ Create all configuration files from collected choices: test runner configs, cove
 ```json
 {
   "bundle": "web-app",
-  "configured_at": "2026-03-26T12:00:00Z",
   "test_runners": ["vitest"],
   "quality_gates": ["eslint", "prettier", "typescript-check", "vitest"],
   "coverage": { "enabled": true, "threshold": 80 },
@@ -88,12 +87,7 @@ Create all configuration files from collected choices: test runner configs, cove
 testing-setup-helper.sh verify .
 ```
 
-Execute each configured runner — report `[pass]`/`[fail]`/`[skip]` per gate. Then display files created/modified and next steps:
-
-1. Write tests for existing code
-2. Run `testing-setup-helper.sh status` to check test health
-3. Push to trigger CI pipeline test step
-4. Consider `/testing-coverage` to identify untested code paths
+Execute each configured runner — report `[pass]`/`[fail]`/`[skip]` per gate. Display files created/modified. Next: write tests, run `testing-setup-helper.sh status`, push to trigger CI, consider `/testing-coverage`.
 
 ## Options
 


### PR DESCRIPTION
## Summary

Tighten `.agents/tools/testing-setup.md` prose per simplification-debt scan (GH#18171).

**Classification:** Instruction doc (agent rules, workflow, operational procedures) — prose compression applied, not chapter split.

**Changes:**
- Compress intro sentence (redundant words removed)
- Shorten Step 1 heading ("Detect Project Bundle" → "Detect Bundle")
- Remove blockquote wrapper from Step 4 note (content preserved inline)
- Remove `configured_at` field from Step 5 JSON example (auto-generated, not instructional)
- Compress Step 6 next-steps from 4-item numbered list to single inline sentence

**Preserved:** All code blocks, tables, command examples, URLs, and references intact.

**Result:** 125 → 119 lines (−6 lines, −5%)

## Verification

- Qlty smells: `PASS` (0 smells on target file)
- Content preservation: all code blocks, tables, commands, and references present before and after
- No broken internal links

## Runtime Testing

Risk: **Low** (docs/agent prompts only — no code changes)
Assessment: `self-assessed`

Resolves #18171

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 4,901 tokens on this as a headless worker.