### PR TITLE
GH#18173: tighten SEO main agent doc (.agents/seo.md)

### DIFF
--- a/.agents/seo.md
+++ b/.agents/seo.md
@@ -49,14 +49,13 @@ subagents:
 
 ## Quick Reference
 
-- **Tools**: Google Search Console, Ahrefs, Semrush, DataForSEO, Serper, PageSpeed Insights, Google Analytics, Context7
 - **MCP**: GSC, DataForSEO, Serper, Google Analytics, Context7
-- **Commands**: `/keyword-research`, `/autocomplete-research`, `/keyword-research-extended`, `/seo-export`, `/seo-analyze`, `/seo-opportunities`, `/seo-write`, `/seo-optimize`, `/seo-analyze-content`, `/seo-fanout`, `/seo-geo`, `/seo-sro`, `/seo-hallucination-defense`, `/seo-agent-discovery`, `/seo-ai-readiness`, `/seo-ai-baseline`
+- **Commands**: `/keyword-research` | `/autocomplete-research` | `/keyword-research-extended` | `/seo-export` | `/seo-analyze` | `/seo-opportunities` | `/seo-write` | `/seo-optimize` | `/seo-analyze-content` | `/seo-fanout` | `/seo-geo` | `/seo-sro` | `/seo-hallucination-defense` | `/seo-agent-discovery` | `/seo-ai-readiness` | `/seo-ai-baseline`
 
 **Subagents** (`seo/` and `services/analytics/`):
 
 - **Research**: `keyword-research` (SERP weakness, 17 types, KeywordScore 0-100) | `ranking-opportunities` (quick wins, striking distance, cannibalization) | `query-fanout-research` (thematic fan-out) | `keyword-mapper` (placement/density) | `domain-research`
-- **Data providers**: `google-search-console` (queries, performance, index) | `dataforseo` (SERP, keywords, backlinks, on-page REST API) | `serper` (Google Search API) | `ahrefs` (backlinks, DR, REST API v3) | `semrush` (domain analytics, competitor research)
+- **Data**: `google-search-console` (queries, performance, index) | `dataforseo` (SERP, keywords, backlinks, on-page REST API) | `serper` (Google Search API) | `ahrefs` (backlinks, DR, REST API v3) | `semrush` (domain analytics, competitor research)
 - **Analytics**: `google-analytics` (GA4 reporting) | `analytics-tracking` (GA4 setup, events, UTM, attribution)
 - **Technical**: `site-crawler` (links, meta, redirects) | `screaming-frog` (SEO Spider CLI) | `contentking` (real-time monitoring) | `pagespeed`
 - **Content**: `content-analyzer` (readability, keywords, quality) | `seo-optimizer` (on-page audit) | `eeat-score` (7 criteria, 1-10) | `programmatic-seo` (pages at scale)
@@ -72,9 +71,9 @@ subagents:
 
 **Keyword research**: `/keyword-research "seed"` | `/autocomplete-research "question"` | `/keyword-research-extended "top keywords"`. Domain/Competitor/Gap modes: `seo/keyword-research.md`. GSC MCP for query performance, CTR, position, index coverage: `seo/google-search-console.md`.
 
-**AI search (GEO/SRO)**: baseline → fanout → GEO → SRO → hallucination defense → agent discovery. Focus: deterministic retrieval signals (clarity, structure, consistency, discoverability). Scorecard: `seo/ai-search-readiness.md`.
+**AI search (GEO/SRO)**: baseline → fanout → GEO → SRO → hallucination defense → agent discovery. Deterministic retrieval signals: clarity, structure, consistency, discoverability. Scorecard: `seo/ai-search-readiness.md`.
 
-**SERP/backlinks/technical**: SERP via DataForSEO (comprehensive) or Serper (quick) | Backlinks via DataForSEO or Ahrefs | PageSpeed/CWV: `tools/browser/pagespeed.md` | On-page: DataForSEO | Crawling: `seo/site-crawler.md` | Real-time monitoring: `seo/contentking.md`.
+**SERP/backlinks/technical**: SERP via DataForSEO (comprehensive) or Serper (quick) | Backlinks via DataForSEO or Ahrefs | PageSpeed/CWV: `tools/browser/pagespeed.md` | On-page: DataForSEO | Crawling: `seo/site-crawler.md` | Monitoring: `seo/contentking.md`.
 
 **Site audit** (output: `~/Downloads/{domain}/{datestamp}/` CSV/XLSX):
 


### PR DESCRIPTION
## Summary

Tightens `.agents/seo.md` (SEO main agent doc) per simplification-debt scan (GH#18173).

**Changes:**
- Removed redundant `**Tools**` line — tools are already enumerated in MCP and subagents sections
- Renamed `**Data providers**` → `**Data**` (shorter label, same meaning)
- Commands list: changed comma-separated to pipe-separated for visual consistency with subagent lists
- AI search workflow: removed filler word "Focus:" before the retrieval signals list
- SERP/backlinks line: "Real-time monitoring" → "Monitoring" (saves 10 chars, no information loss)

**Classification:** Instruction doc (agent routing, workflow commands) — prose compression applied, not content reduction.

**Verification:** All code blocks, URLs, command examples, and subagent references preserved. Agent behaviour unchanged.

Resolves #18173

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 5,679 tokens on this as a headless worker.