### PR TITLE
GH#18208: tighten aidevops-business.md agent doc

### DIFF
--- a/.agents/business.md
+++ b/.agents/business.md
@@ -36,6 +36,8 @@ subagents:
 
 ## Architecture
 
+Task arrives (issue/TODO/mailbox) → pulse dispatches to runner → worker executes → pulse observes outcomes → files improvement issues if patterns emerge.
+
 ```text
 Pulse supervisor (every 2 min, stateless)
 ├── Fetches GitHub state (issues, PRs)
@@ -51,22 +53,13 @@ Named Runners:
 └── support-triage       — Customer issue classification
 ```
 
-**Flow**: Task arrives (issue/TODO/mailbox) → pulse dispatches to runner → worker executes → pulse observes outcomes → files improvement issues if patterns emerge.
-
 ## Guardrails
 
-Inherited from `/full-loop` and worktree isolation:
-
-- **Scope**: Path/tool whitelists per runner via AGENTS.md
-- **Audit**: Git commits and PR history
-- **Rollback**: Worktree isolation — each runner works in its own worktree
-- **Judgment**: `/full-loop` decides stop/retry/escalate
-
-Finance and legal runners require dedicated worktrees + PR review gates.
+Inherited from `/full-loop` and worktree isolation: scope via path/tool whitelists per runner (AGENTS.md), audit via git commits and PR history, rollback via worktree isolation, judgment via `/full-loop` stop/retry/escalate. Finance and legal runners require dedicated worktrees + PR review gates.
 
 ## Setting Up Runners
 
-Create via `runner-helper.sh`. Each runner gets a personality file at `~/.aidevops/.agent-workspace/runners/<name>/AGENTS.md`. Full templates and bootstrap script: `business/company-runners.md`.
+Create via `runner-helper.sh`. Each runner gets a personality file at `~/.aidevops/.agent-workspace/runners/<name>/AGENTS.md`. Full templates: `business/company-runners.md`.
 
 ```bash
 runner-helper.sh create hiring-coordinator \
@@ -80,11 +73,9 @@ runner-helper.sh list                                          # Show all runner
 runner-helper.sh run hiring-coordinator "Review latest 3 applications"  # Manual dispatch
 ```
 
-Pulse handles dispatch automatically. For manual one-off tasks, use `/full-loop` directly.
-
 ## Cross-Function Workflows
 
-Multi-department tasks use chained GitHub issues. Pulse routes by label:
+Multi-department tasks use chained GitHub issues; pulse routes by label. Sequenced single-department work (e.g., monthly close) uses multiple issues with the same label — pulse processes in order.
 
 ```bash
 # New hire onboarding (3 departments)
@@ -92,8 +83,6 @@ gh issue create --repo <owner/repo> --title "Onboard: Confirm offer" --label "hi
 gh issue create --repo <owner/repo> --title "Onboard: Setup payroll" --label "finance"
 gh issue create --repo <owner/repo> --title "Onboard: Provision accounts" --label "ops"
 ```
-
-Sequenced single-department work (e.g., monthly close) uses multiple issues with the same label — pulse processes in order.
 
 ## Pre-flight Questions
 


### PR DESCRIPTION
## Summary

Tighten `.agents/commands/aidevops-business.md` (104 → 93 lines) per simplification-debt scan.

Note: `aidevops-business.md` is a symlink to `../business.md`, so this change updates `.agents/business.md` directly.

- Moved flow description before Architecture code block, removing redundant bold **Flow** line
- Collapsed Guardrails 4-bullet list into single prose paragraph (same information, less vertical space)
- Removed "and bootstrap script" redundancy from Setting Up Runners (templates ref kept)
- Merged Cross-Function Workflows two-sentence intro into one sentence, moved trailing sentence before code block
- Removed "Pulse handles dispatch automatically. For manual one-off tasks, use `/full-loop` directly." (redundant with Quick Reference)

## Content Preservation

All code blocks, task IDs (t109), command examples, subagent references, and URLs preserved. No knowledge removed.

## Runtime Testing

Risk: **Low** — agent doc only, no code changes. Self-assessed.

## Verification

- `wc -l .agents/business.md` → 93 (was 104)
- All code blocks, t109 reference, runner-helper.sh commands, and subagent names present

Resolves #18208

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 6,370 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced agent business documentation with restructured architecture section including explicit end-to-end task flow descriptions.
  * Consolidated guardrails information into concise guidance, removing redundancy.
  * Merged cross-function and single-department workflow descriptions for better clarity.
  * Removed outdated setup references and dispatch handling instructions to improve documentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->