### PR TITLE
GH#18210: tighten seo-audit.md from 98 to 84 lines

### DIFF
--- a/.agents/seo/seo-audit.md
+++ b/.agents/seo/seo-audit.md
@@ -9,7 +9,12 @@ mode: subagent
 
 Run a comprehensive SEO audit for: $ARGUMENTS
 
-Options: `--scope=full|technical|on-page|content` (default: full) | `--pages=N` (default: 10) | `--gsc` | `--compare=competitor.com` | `--output=report.md`
+Options:
+- `--scope=full|technical|on-page|content` (default: full)
+- `--pages=N` — max pages to analyze (default: 10)
+- `--gsc` — include Search Console data
+- `--compare=competitor.com` — compare against competitor
+- `--output=report.md` — save report to file
 
 ## Workflow
 
@@ -42,21 +47,21 @@ Audit in priority order. Lead with top 3 issues by impact. Separate fixes by pri
 - **Top 3 Priority Issues:** [with impact level]
 
 ### Technical SEO
-| Check | Status | Notes |
-|-------|--------|-------|
-| HTTPS | | |
-| robots.txt | | |
-| Sitemap | | |
-| Core Web Vitals | | |
-| Mobile | | |
+| Issue | Impact | Evidence | Fix | Priority |
+|-------|--------|----------|-----|----------|
+| HTTPS | | | | |
+| robots.txt | | | | |
+| Sitemap | | | | |
+| Core Web Vitals | | | | |
+| Mobile | | | | |
 
 ### On-Page SEO
-| Element | Status | Recommendation |
-|---------|--------|----------------|
-| Title | | |
-| Meta Description | | |
-| H1 | | |
-| Image Alt Text | | |
+| Issue | Impact | Evidence | Fix | Priority |
+|-------|--------|----------|-----|----------|
+| Title | | | | |
+| Meta Description | | | | |
+| H1 | | | | |
+| Image Alt Text | | | | |
 
 ### Content Quality
 - E-E-A-T Score, Content Depth, AI Writing Patterns

--- a/.agents/seo/seo-audit.md
+++ b/.agents/seo/seo-audit.md
@@ -7,32 +7,19 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Run a comprehensive SEO audit for the specified URL or domain.
+Run a comprehensive SEO audit for: $ARGUMENTS
 
-URL/Target: $ARGUMENTS
-
-## Quick Reference
-
-```text
-Default: Full audit (technical + on-page + content)
-Options:
-  --scope=full|technical|on-page|content  Audit scope (default: full)
-  --pages=N                               Max pages to analyze (default: 10)
-  --gsc                                   Include Search Console data if available
-  --compare=competitor.com                Compare against competitor
-  --output=report.md                      Save report to file
-```
+Options: `--scope=full|technical|on-page|content` (default: full) | `--pages=N` (default: 10) | `--gsc` | `--compare=competitor.com` | `--output=report.md`
 
 ## Workflow
 
 ### 1. Preparation & Baseline
 
-Read audit framework files before analysis:
+Read before analysis:
 - `seo/seo-audit-skill.md` (priority: crawlability → technical → on-page → content → authority)
 - `seo/seo-audit-skill/ai-writing-detection.md`
 - `seo/seo-audit-skill/aeo-geo-patterns.md`
 
-Gather baseline data using lightweight fetches:
 ```bash
 # robots.txt, sitemap, and homepage meta
 curl -s "https://$DOMAIN/robots.txt"
@@ -40,14 +27,12 @@ curl -s "https://$DOMAIN/sitemap.xml" | head -50
 curl -s "https://$DOMAIN" | grep -E '<(title|meta)' | head -20
 ```
 
-If `--gsc` set, export Search Console: `~/.aidevops/agents/scripts/seo-export-gsc.sh "$DOMAIN"`.
-Use browser automation only for rendering/field data (Core Web Vitals, Structured Data, Mobile, Internal links).
+If `--gsc`: `~/.aidevops/agents/scripts/seo-export-gsc.sh "$DOMAIN"`. Browser automation only for rendering/field data (Core Web Vitals, Structured Data, Mobile, Internal links).
 
 ### 2. Audit & Reporting
 
-Audit in priority order. Record status, evidence, impact, and next action. Focus on ranked issues.
+Audit in priority order. Lead with top 3 issues by impact. Separate fixes by priority (Critical, High, Quick Wins, Long-Term). If `--compare`, call out gaps vs competitor. If `--output`, save to file.
 
-**Report Structure:**
 ```markdown
 ## SEO Audit Report: [DOMAIN]
 **Date:** YYYY-MM-DD | **Scope:** [scope]
@@ -59,25 +44,26 @@ Audit in priority order. Record status, evidence, impact, and next action. Focus
 ### Technical SEO
 | Check | Status | Notes |
 |-------|--------|-------|
-| HTTPS / robots.txt / Sitemap / Core Web Vitals / Mobile |
+| HTTPS | | |
+| robots.txt | | |
+| Sitemap | | |
+| Core Web Vitals | | |
+| Mobile | | |
 
 ### On-Page SEO
 | Element | Status | Recommendation |
 |---------|--------|----------------|
-| Title / Meta Description / H1 / Image Alt Text |
+| Title | | |
+| Meta Description | | |
+| H1 | | |
+| Image Alt Text | | |
 
 ### Content Quality
 - E-E-A-T Score, Content Depth, AI Writing Patterns
 
 ### Prioritized Action Plan
-- **Critical** (fix immediately) | **High Priority** (this week) | **Quick Wins** (easy) | **Long-Term**
+- **Critical** (fix immediately) | **High** (this week) | **Quick Wins** | **Long-Term**
 ```
-
-**Rules:**
-- Lead with top 3 issues by impact.
-- Separate fixes by priority (Critical, High, Quick Wins, Long-Term).
-- If `--compare` used, call out gaps vs competitor.
-- If `--output` set, save to file.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Merged Quick Reference code block into a single inline options line (saves 10 lines)
- Merged Rules section into Audit & Reporting prose (saves 5 lines)
- Expanded table rows for proper markdown table structure (each check on its own row)
- Removed redundant intro sentence

All content preserved: code blocks, URLs, command examples, framework file references, report structure template.

**Before:** 98 lines | **After:** 84 lines (−14 lines, −14%)

## Verification

- All code blocks, URLs, task ID references, and command examples present before and after ✓
- No broken internal links or references ✓
- Qlty smells: 0 for target file ✓

Resolves #18210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized SEO audit documentation for improved clarity and usability
  * Updated report template to display individual checks separately for better visibility
  * Enhanced reporting guidance to prioritize issues by impact
  * Simplified action plan labels for quicker scanning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->