### PR TITLE
GH#18158: simplification: tighten agent doc .agents/content/youtube-research.md

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -7082,5 +7082,10 @@
     "lines": 80,
     "status": "simplified",
     "issue": "GH#17305"
+  },
+  ".agents/content/youtube-research.md": {
+    "hash": "327909e6eb1a119de6b973c4daa95d02318d71f94f28fd1fde85746fb3d874a4",
+    "status": "simplified",
+    "lines": 137
   }
 }

--- a/.agents/content/youtube-research.md
+++ b/.agents/content/youtube-research.md
@@ -69,10 +69,7 @@ Target: $ARGUMENTS
 
 1. Compare your videos vs competitors: topics covered/not covered, unique angles.
 2. **Keyword clustering:** extract common keywords from competitor titles, group into clusters, rank by frequency and avg views.
-3. **Opportunity scoring:**
-   - High views + low competition = high opportunity
-   - High views + high competition = proven topic, need unique angle
-   - Low views + low competition = risky, validate demand first
+3. **Opportunity scoring:** High views + low competition = high opportunity. High views + high competition = proven topic, need unique angle. Low views + low competition = risky, validate demand first.
 
 #### Mode D: Video Analysis (`video VIDEO_ID`)
 
@@ -91,23 +88,18 @@ Target: $ARGUMENTS
 ```text
 YouTube Research: {target}
 
-Summary:
-- {key insight 1-3}
+Summary: {key insight 1-3}
 
 Outlier Videos (3x+ avg views):
 1. {title} - {views} views ({ratio}x avg)
 
 Common Patterns:
-- Topics: {clusters} | Title style: {pattern}
-- Video length: {avg} | Upload frequency: {freq}
+- Topics: {clusters} | Title style: {pattern} | Length: {avg} | Freq: {freq}
 
 Content Opportunities:
 1. {opportunity} - {reasoning}
 
-Next Steps:
-1. /youtube script "{topic}"
-2. /youtube research @handle
-3. /youtube research video VIDEO_ID
+Next Steps: /youtube script "{topic}" | /youtube research @handle | /youtube research video VIDEO_ID
 ```
 
 Offer follow-up: generate script for top opportunity, research another competitor, set up monitoring (`pipeline.md`), or export findings.
@@ -115,7 +107,7 @@ Offer follow-up: generate script for top opportunity, research another competito
 ## Example: Competitor Analysis
 
 ```text
-User: /youtube research @fireship
+/youtube research @fireship
 
 Channel: Fireship | 3.2M subs | 245 videos | Avg: 1.8M views
 


### PR DESCRIPTION
## Summary

Tighten `.agents/content/youtube-research.md` per simplification-debt scan (GH#18158).

**Changes:**
- Collapsed Mode C opportunity scoring from bullet list to inline prose (−3 lines)
- Merged output template summary and common patterns fields (−2 lines)
- Collapsed next steps from numbered list to inline pipe-separated (−3 lines)
- Removed redundant `User:` prefix from example block (−1 line)
- Updated simplification state registry

**Result:** 145 → 137 lines (−8 lines, ~5.5% reduction). All code blocks, commands, URLs, and institutional knowledge preserved. Agent behaviour unchanged.

## Runtime Testing

Risk: **Low** — documentation/agent prompt only, no code changes.
Self-assessed: content preservation verified via diff review.

Resolves #18158

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 5m on this as a headless worker.