### PR TITLE
GH#18189: tighten business.md (104 → 97 lines)

### DIFF
--- a/.agents/business.md
+++ b/.agents/business.md
@@ -55,18 +55,11 @@ Named Runners:
 
 ## Guardrails
 
-Inherited from `/full-loop` and worktree isolation:
-
-- **Scope**: Path/tool whitelists per runner via AGENTS.md
-- **Audit**: Git commits and PR history
-- **Rollback**: Worktree isolation — each runner works in its own worktree
-- **Judgment**: `/full-loop` decides stop/retry/escalate
-
-Finance and legal runners require dedicated worktrees + PR review gates.
+Inherited from `/full-loop` and worktree isolation: path/tool whitelists per runner (AGENTS.md), git audit trail, per-runner worktree rollback, `/full-loop` stop/retry/escalate judgment. Finance and legal runners require dedicated worktrees + PR review gates.
 
 ## Setting Up Runners
 
-Create via `runner-helper.sh`. Each runner gets a personality file at `~/.aidevops/.agent-workspace/runners/<name>/AGENTS.md`. Full templates and bootstrap script: `business/company-runners.md`.
+Create via `runner-helper.sh`. Each runner gets a personality file at `~/.aidevops/.agent-workspace/runners/<name>/AGENTS.md`. Full templates: `business/company-runners.md`.
 
 ```bash
 runner-helper.sh create hiring-coordinator \
@@ -84,7 +77,7 @@ Pulse handles dispatch automatically. For manual one-off tasks, use `/full-loop`
 
 ## Cross-Function Workflows
 
-Multi-department tasks use chained GitHub issues. Pulse routes by label:
+Multi-department tasks use chained GitHub issues routed by label:
 
 ```bash
 # New hire onboarding (3 departments)

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -145,10 +145,10 @@
       "pr": 13101
     },
     ".agents/business.md": {
-      "hash": "dae5291987de357f73ae79460b5e990b125cf143",
-      "at": "2026-03-29T16:34:54Z",
+      "hash": "b78adf9bf3285609dcf66c8797787e8b9e20afca",
+      "at": "2026-04-11T00:00:00Z",
       "passes": 1,
-      "pr": 13055
+      "pr": 18189
     },
     ".agents/business/accounts-receipt-ocr.md": {
       "hash": "85396dc720574178abc734adf590b980ff764355",
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -6999,6 +6999,12 @@
       "at": "2026-04-11T10:09:10Z",
       "pr": 18159,
       "passes": 1
+    },
+    ".agents/commands/business.md": {
+      "hash": "b78adf9bf3285609dcf66c8797787e8b9e20afca",
+      "at": "2026-04-11T00:00:00Z",
+      "passes": 1,
+      "pr": 18189
     }
   },
   ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {


### PR DESCRIPTION
## Summary

- Tightened `.agents/business.md` (symlinked as `.agents/commands/business.md`) from 104 to 97 lines
- Compressed Guardrails section from bullet list to single prose paragraph — all rules preserved
- Removed redundant "bootstrap script" phrase from Setting Up Runners (templates link covers it)
- Tightened Cross-Function Workflows intro sentence
- Updated simplification state registry with new hash for both paths

## Changes

- EDIT: `.agents/business.md` — prose compression, no content loss
- EDIT: `.agents/configs/simplification-state.json` — updated hash for both `business.md` paths

## Verification

- All code blocks, URLs, task ID references, and command examples preserved
- No broken internal links
- `wc -l .agents/business.md` → 97 (was 104)

Resolves #18189