### PR TITLE
GH#18240: docs: tighten init-routines.md (80→73 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -7082,5 +7082,13 @@
     "lines": 80,
     "status": "simplified",
     "issue": "GH#17305"
+  },
+  ".agents/workflows/init-routines.md": {
+    "hash": "273d21c57015d94c131b9b401dc92a2d334eba5e8c8626325b540462c46a2865",
+    "lines": 73,
+    "status": "tightened",
+    "at": "2026-04-11T12:03:20Z",
+    "passes": 1,
+    "pr": "GH#18240"
   }
 }

--- a/.agents/workflows/init-routines.md
+++ b/.agents/workflows/init-routines.md
@@ -7,7 +7,7 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Scaffold a private git repo for routine definitions. Always private — routine definitions may contain client names, schedules, and sensitive operational details.
+Always private — routine definitions may contain client names, schedules, and sensitive operational details.
 
 Arguments: $ARGUMENTS
 
@@ -18,8 +18,6 @@ aidevops init-routines                  # Personal: <username>/aidevops-routines
 aidevops init-routines --org <name>     # Org: <org>/aidevops-routines (private)
 aidevops init-routines --local          # Local-only, local_only: true in repos.json
 aidevops init-routines --dry-run        # Preview without changes
-
-# Or via the helper directly:
 ~/.aidevops/agents/scripts/init-routines-helper.sh [--org <name>] [--local] [--dry-run]
 ```
 
@@ -41,9 +39,7 @@ aidevops init-routines --dry-run        # Preview without changes
         └── routine.md   # Template for routine tracking issues
 ```
 
-For repos with a GitHub remote, a tracking issue is created for each core routine via `routine-log-helper.sh` (idempotent — skipped if already exists).
-
-Registered in `~/.config/aidevops/repos.json` with `pulse: true, priority: "tooling"`.
+Registered in `~/.config/aidevops/repos.json` with `pulse: true, priority: "tooling"`. For repos with a GitHub remote, a tracking issue is created for each core routine via `routine-log-helper.sh` (idempotent).
 
 ## Core routines seeded
 
@@ -62,19 +58,16 @@ Registered in `~/.config/aidevops/repos.json` with `pulse: true, priority: "tool
 | r911 | OAuth token refresh | Every 30 min |
 | r912 | Dashboard server | Persistent |
 
-Each routine has a description file in `routines/core/<id>.md` covering what it does, what to check, and how to verify it's working.
+Each routine has a description file in `routines/core/<id>.md` (what it does, what to check, how to verify).
 
-## Custom routine descriptions
+## Custom routines and next steps
 
-Create `routines/custom/<id>.md` for your own routines. Custom descriptions override core descriptions when both exist for the same ID. Use `~/.aidevops/agents/templates/routine-description-template.md` as a starting point.
+Create `routines/custom/<id>.md` for your own routines (IDs r001-r899; core uses r901+). Custom descriptions override core when both exist for the same ID. Use `~/.aidevops/agents/templates/routine-description-template.md` as a starting point.
 
-## After setup
-
-Add your own routines to `~/Git/aidevops-routines/TODO.md` under `## User Routines`. Use IDs r001-r899 (core routines use r901+). See `.agents/reference/routines.md` for field specification.
+Add your own routines to `~/Git/aidevops-routines/TODO.md` under `## User Routines`. See `.agents/reference/routines.md` for field specification.
 
 ## Related
 
 - `/routine` — design and schedule a recurring routine
 - `.agents/reference/routines.md` — routine field reference
-- `.agents/templates/routine-description-template.md` — description template
 - `~/.config/aidevops/repos.json` — repo registration


### PR DESCRIPTION
## Summary

Tighten `.agents/workflows/init-routines.md` from 80 to 73 lines per GH#18240.

**Changes:**
- Remove redundant intro sentence (repeated the frontmatter `description` field verbatim)
- Merge helper script line into Usage code block (remove the `# Or via the helper directly:` comment wrapper)
- Merge post-creation notes (repos.json registration, tracking issue creation) into the "What it creates" section
- Merge "Custom routine descriptions" and "After setup" into a single "Custom routines and next steps" section
- Remove duplicate `routine-description-template.md` reference from Related (already mentioned in the merged section)

**Preservation check:**
- All code blocks present ✓
- All file paths and URLs present ✓
- All routine IDs (r901-r912) and schedule data present ✓
- All command examples present ✓
- No broken internal links ✓

Resolves #18240