### PR TITLE
GH#18239: tighten agent doc .agents/workflows/skills.md

### DIFF
--- a/.agents/workflows/skills.md
+++ b/.agents/workflows/skills.md
@@ -15,6 +15,8 @@ Arguments: $ARGUMENTS
 
 ### Step 1: Determine Operation Mode
 
+All scripts at `~/.aidevops/agents/scripts/`.
+
 | Argument pattern | Action |
 |-----------------|--------|
 | empty / "help" | Show available commands and quick examples |
@@ -32,8 +34,6 @@ Arguments: $ARGUMENTS
 | "update" / "check" | `skill-update-helper.sh check` |
 | "remove" \<name\> | `add-skill-helper.sh remove <name>` |
 
-All scripts at `~/.aidevops/agents/scripts/`.
-
 ### Step 2: Present Results
 
 Format output conversationally:
@@ -48,27 +48,17 @@ Format output conversationally:
 
 ### Step 3: Offer Follow-up Actions
 
-```text
-Next steps:
-1. /skills describe <name>              — Get full details on a skill
-2. /skills browse <category>            — Explore a category
-3. /skills recommend "<task>"           — Get task-specific suggestions
-4. /skills search --registry "<query>"  — Search the public skills.sh registry
-5. /skills install <owner/repo@skill>   — Install from the public registry
-6. aidevops skill add <repo>            — Import a community skill
-```
+After presenting results, suggest relevant next steps from the command table above. Tailor suggestions to context — e.g., after a search, offer `describe` or `install`; after `list`, offer `browse` or `recommend`.
 
 ## Conversational Mode
 
-Interpret natural language and map to the appropriate command:
+Interpret natural language and map to the appropriate command. Examples:
 
-- "What skills do I have for browser automation?" → search "browser automation"
-- "Show me all SEO tools" → browse seo
-- "What does the playwright skill do?" → describe playwright
-- "I need to deploy a Next.js app" → recommend "deploy Next.js app"
-- "How many skills are installed?" → list, report count
-- "Are there any public skills for X?" → search --registry "X"
-- "Install the vercel browser skill" → install vercel-labs/agent-browser@agent-browser
+- "What skills do I have for browser automation?" → `search "browser automation"`
+- "What does the playwright skill do?" → `describe playwright`
+- "I need to deploy a Next.js app" → `recommend "deploy Next.js app"`
+- "Are there any public skills for X?" → `search --registry "X"`
+- "Install the vercel browser skill" → `install vercel-labs/agent-browser@agent-browser`
 
 ## Related
 


### PR DESCRIPTION
## Summary

Tightened skills.md from 80 to 70 lines. Replaced verbose Step 3 follow-up code block with a 2-line context-aware prose instruction. Condensed Conversational Mode examples from 7 to 5 (removed redundant entries obvious from the command table). Moved scripts path note to top of Step 1. All commands, script paths, and institutional knowledge preserved.

## Files Changed

.agents/workflows/skills.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Qlty smells: 0 findings. Content preservation: all command references, script paths, and task IDs intact. wc -l: 70 (was 80).

Resolves #18239


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 3,122 tokens on this as a headless worker.