### PR TITLE
GH#18222: bump NESTING_DEPTH_THRESHOLD 249→254 (247 violations + 7 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -42,6 +42,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 254 | GH#18129 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
 | 249 | GH#18149 | ratcheted down — actual violations 247 + 2 buffer |
 | 254 | GH#18157 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
+| 249 | GH#18174 | ratcheted down — actual violations 247 + 2 buffer |
+| 254 | GH#18222 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -42,7 +42,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 249 (GH#18149): actual violations 247 + 2 buffer
 # Bumped to 254 (GH#18157): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
 # Ratcheted down to 249 (GH#18174): actual violations 247 + 2 buffer
-NESTING_DEPTH_THRESHOLD=249
+# Bumped to 254 (GH#18222): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=254-5=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
+NESTING_DEPTH_THRESHOLD=254
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Proximity guard fired at 247/249 (2 headroom). Bumped `NESTING_DEPTH_THRESHOLD` from 249 to 254 to restore adequate headroom.

- **Current violations**: 247 (verified with CI methodology via `lint-file-discovery.sh`)
- **New threshold**: 254 (247 violations + 7 headroom)
- **Proximity guard**: `warn_at = 254-5 = 249` fires when violations exceed 249 (i.e., at 250), preventing saturation

## Files changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` from 249 to 254
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#18174 ratchet-down and GH#18222 bump entries

## Pattern followed

Follows established pattern from GH#18129, GH#18157 (same scenario: 247 violations, 249 threshold, 2 headroom → bump to 254).

## Verification

```bash
grep NESTING_DEPTH_THRESHOLD .agents/configs/complexity-thresholds.conf
# → NESTING_DEPTH_THRESHOLD=254
```

Resolves #18222