### PR TITLE
GH#18148: tighten log-issue-aidevops.md workflow doc prose

### DIFF
--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -20,7 +20,7 @@ Log an issue with the aidevops framework to GitHub.
 
 **Arguments**: Optional title hint, e.g., `/log-issue-aidevops "Update check not working"`
 
-All issues from non-collaborators are gated behind `needs-maintainer-review` — a maintainer must approve before the pipeline picks them up. This command produces higher-quality reports than the web form because it gathers diagnostics, checks duplicates, and validates before submission.
+Non-collaborator issues are gated behind `needs-maintainer-review`. This command produces higher-quality reports than the web form — it gathers diagnostics, checks duplicates, and validates before submission.
 
 ## Workflow
 
@@ -34,10 +34,7 @@ Collects: aidevops version (local + latest), AI assistant, OS/shell, repo contex
 
 ### Step 2: Understand the Issue
 
-Ask the user:
-1. What happened?
-2. What did you expect?
-3. Steps to reproduce (if known)?
+Ask the user: (1) What happened? (2) What did you expect? (3) Steps to reproduce?
 
 Use any provided argument as the title starting point. Review session context for commands, errors, and intent.
 
@@ -53,37 +50,36 @@ If duplicates found, present them and ask: add comment to existing / create new 
 
 Before filing, check whether this is a customization need rather than a framework issue:
 
-| User says | Likely route |
-|-----------|-------------|
-| "My script edits get overwritten" | Customization — use `~/.aidevops/agents/custom/scripts/` |
-| "I want X to behave differently" | Customization — create a wrapper in `custom/` |
-| "I added an agent but it disappeared" | Customization — use `custom/` or `draft/` (root agents are overwritten) |
+| User says | Route |
+|-----------|-------|
+| "My script edits get overwritten" | Customization — use `custom/scripts/` |
+| "I want X to behave differently" | Customization — create wrapper in `custom/` |
+| "I added an agent but it disappeared" | Customization — use `custom/` or `draft/` |
 | "This script is broken for everyone" | Bug — file an issue |
-| "The framework should support X" | Enhancement — file an issue (maintainers assess fit) |
+| "The framework should support X" | Enhancement — file an issue |
 
-If the need is customization, explain the `custom/` directory and link to `reference/customization.md`. Do not file an issue.
+If customization, explain the `custom/` directory and link to `reference/customization.md`. Do not file an issue.
 
-### Step 3.6: Performance Issue Validation (MANDATORY for performance/optimization claims)
+### Step 3.6: Performance Issue Validation (MANDATORY)
 
-If the issue involves performance, optimization, O(n^2) claims, or "hot path" assertions:
+Applies when the issue involves performance, optimization, O(n^2) claims, or "hot path" assertions (GH#17832-17835):
 
-1. **Verify line references**: Read the cited file at the cited line number. If the code at that line does not match the claim, REJECT the issue. Do not file issues with hallucinated line numbers.
-2. **Require measurements**: "May cause O(n^2)" is not evidence. Require actual timing data (`time`, `hyperfine`, profiling output). No measurements = no issue.
-3. **Verify data scale**: Check how many items the loop actually processes and how often it runs. A loop over 5 items on a 60-second timer is not a performance problem regardless of algorithmic complexity.
-4. **Check for template-driven findings**: If the user or AI is filing multiple performance issues with identical structure ("nested loops", "O(n^2)", "hot path") across different files, this is likely a batch code scan without verification. Validate each independently.
+1. **Verify line references**: Read the cited file at the cited line. Code mismatch → REJECT.
+2. **Require measurements**: "May cause O(n^2)" is not evidence. Require timing data (`time`, `hyperfine`, profiling output).
+3. **Verify data scale**: A loop over 5 items on a 60-second timer is not a performance problem regardless of complexity.
+4. **Detect template-driven findings**: Multiple perf issues with identical structure across files → likely unverified batch scan. Validate each independently.
 
-If any check fails, explain why and do not file the issue. Direct the user to the "Performance Optimization" issue template which requires mandatory evidence fields.
+If any check fails, explain why and do not file. Direct to the "Performance Optimization" issue template (mandatory evidence fields).
 
 ### Step 3.7: Architectural Alignment (enhancements only)
 
-Skip for bugs with clear reproduction steps — bugs are observed failures and belong in the tracker.
+Skip for bugs with clear reproduction steps.
 
-For enhancements, feature requests, and architectural changes, evaluate against:
-
-- **Observed failure first**: Is this addressing an actual failure, or preemptive? Preemptive rules are prompt bloat.
-- **Intelligence over determinism**: Does this add a deterministic gate where model judgment would work better?
+For enhancements and architectural changes, evaluate:
+- **Observed failure first**: Addressing an actual failure, or preemptive? Preemptive rules are prompt bloat.
+- **Intelligence over determinism**: Adding a deterministic gate where model judgment would work better?
 - **Prompt cost**: Every instruction has a per-turn cost. Is the value worth it?
-- **External pattern adoption**: A "gap" vs another framework may be a deliberate omission in an intelligence-first design.
+- **External pattern adoption**: A "gap" vs another framework may be a deliberate omission.
 
 If the proposal doesn't survive these questions, discuss before filing — it may be better as a memory entry.
 
@@ -106,11 +102,9 @@ If the proposal doesn't survive these questions, discuss before filing — it ma
 {errors, session context}
 ```
 
-### Step 5: Confirm Before Submitting
+### Step 5: Confirm and Submit
 
 Show the user: title, body preview, label. Offer: create / edit title / edit description / cancel.
-
-### Step 6: Create the Issue
 
 ```bash
 gh issue create -R marcusquinn/aidevops \
@@ -122,9 +116,7 @@ EOF
   --label "LABEL"
 ```
 
-### Step 7: Confirm Success
-
-Output the issue URL. Note: user can add comments, subscribe to notifications, or reference with `Fixes #NNN`.
+Output the issue URL. Note: user can add comments, subscribe, or reference with `Fixes #NNN`.
 
 ## Label Selection
 
@@ -138,9 +130,9 @@ Output the issue URL. Note: user can add comments, subscribe to notifications, o
 
 ## Privacy
 
-Diagnostics do NOT include credentials or tokens. File paths are included (may reveal username). No file contents uploaded. User reviews everything before submission.
+Diagnostics do NOT include credentials or tokens. File paths included (may reveal username). No file contents uploaded. User reviews everything before submission.
 
 ## Error Handling
 
-- `gh` not authenticated: prompt `gh auth login`, then retry.
-- Network failure: prompt user to check connection and retry.
+- `gh` not authenticated → prompt `gh auth login`, retry.
+- Network failure → prompt user to check connection, retry.


### PR DESCRIPTION
## Summary

Tightened .agents/workflows/log-issue-aidevops.md from 146 to 138 lines. Merged Steps 5/6/7 into single Confirm and Submit step, compressed Step 2 to single line, tightened intro prose and table headers. All institutional knowledge preserved: task IDs, code blocks, URLs, command examples, validation gates.

## Files Changed

.agents/workflows/log-issue-aidevops.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 clean (0 errors), Qlty smells clean, all key content patterns verified present

Resolves #18148


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 2m and 3,913 tokens on this as a headless worker.