### PR TITLE
GH#18270: GH#18270: tighten add-skill.md workflow doc (74→70 lines)

### DIFF
--- a/.agents/workflows/add-skill.md
+++ b/.agents/workflows/add-skill.md
@@ -12,7 +12,7 @@ Import an external skill, convert to aidevops format, and register for update tr
 ## Quick Reference
 
 ```bash
-# GitHub shorthand (saved as *-skill.md)
+# GitHub shorthand — saved as *-skill.md (imported, upstream-tracked)
 /add-skill dmmulroy/cloudflare-skill        # → .agents/services/hosting/cloudflare-skill.md
 /add-skill anthropics/skills/pdf            # → .agents/tools/pdf-skill.md
 /add-skill vercel-labs/agent-skills --name vercel-deploy
@@ -21,8 +21,8 @@ Import an external skill, convert to aidevops format, and register for update tr
 /add-skill clawdhub:caldav-calendar         # → .agents/tools/productivity/caldav-calendar-skill.md
 /add-skill https://clawdhub.com/mSarheed/proxmox-full
 
-# Raw URL
-/add-skill https://convos.org/skill.md --name convos   # category auto-detected
+# Raw URL (category auto-detected)
+/add-skill https://convos.org/skill.md --name convos
 
 # Flags
 /add-skill dmmulroy/cloudflare-skill --force    # overwrite existing
@@ -34,9 +34,7 @@ Import an external skill, convert to aidevops format, and register for update tr
 /add-skill remove <name>
 ```
 
-## Naming Convention
-
-`-skill` suffix marks imported skills: `playwright-skill.md` (imported, upstream-tracked) vs `playwright.md` (native). No name clashes; `*-skill.md` glob finds all imports; `aidevops skill check` knows which to update.
+`-skill` suffix marks imported skills: `playwright-skill.md` (imported) vs `playwright.md` (native). `*-skill.md` glob finds all imports; `aidevops skill check` knows which to update.
 
 ## Workflow
 
@@ -46,24 +44,22 @@ Import an external skill, convert to aidevops format, and register for update tr
 4. **Security scan:** [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner) if installed — CRITICAL/HIGH blocks import. `--skip-security` bypasses; `--force` only controls file overwrite. Scan also runs on `aidevops skill update`.
 5. **Post-import:** Placed in `.agents/` per conventions → registered in `.agents/configs/skill-sources.json` → run `./setup.sh` to create symlinks.
 
-## Supported Sources & Formats
+## Sources & Formats
 
-| Source | Detection | Fetch Method |
-|--------|-----------|--------------|
+| Source | Detection | Fetch |
+|--------|-----------|-------|
 | GitHub | `owner/repo` or github.com URL | `git clone --depth 1` |
 | ClawdHub | `clawdhub:slug` or clawdhub.com URL | Playwright browser extraction |
-| Raw URL | Any `https://` (not GitHub/ClawdHub) | `curl` with SHA-256 content hash |
+| Raw URL | Any `https://` (not GitHub/ClawdHub) | `curl` + SHA-256 content hash |
 
 | Format | Detection | Conversion |
 |--------|-----------|------------|
 | SKILL.md | OpenSkills/Claude Code/ClawdHub | Frontmatter preserved, content adapted |
-| AGENTS.md | aidevops/Windsurf | Direct copy with mode: subagent |
+| AGENTS.md | aidevops/Windsurf | Direct copy with `mode: subagent` |
 | .cursorrules | Cursor | Wrapped in markdown with frontmatter |
 | README.md | Generic | Copied as-is |
 
-## Update Tracking
-
-Tracked in `.agents/configs/skill-sources.json`: `name`, `upstream_url`, `upstream_commit`/`upstream_hash`, `local_path`, `format_detected`, `imported_at`, `last_checked`, `merge_strategy`. URL sources use SHA-256 content hashing instead of git commit comparison. Run `/add-skill check-updates` periodically.
+Update tracking in `.agents/configs/skill-sources.json` — fields: `name`, `upstream_url`, `upstream_commit`/`upstream_hash`, `local_path`, `format_detected`, `imported_at`, `last_checked`, `merge_strategy`. URL sources use SHA-256 hashing. Run `/add-skill check-updates` periodically.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Tightened .agents/workflows/add-skill.md from 74 to 70 lines. Merged Naming Convention into Quick Reference, merged Update Tracking into Sources & Formats section, renamed section heading. All code blocks, URLs, and command examples preserved. No Qlty smells.

## Files Changed

.agents/workflows/add-skill.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l confirms 70 lines; qlty smells returns 0 matches; all content verified present

Resolves #18270


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 3,576 tokens on this as a headless worker.