### PR TITLE
GH#18271: tighten agent doc Research - Main Agent (.agents/research.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6773,10 +6773,10 @@
       "passes": 2
     },
     ".agents/configs/complexity-thresholds-history.md": {
-      "hash": "01fd2efc270f8119715f5547bcd2fdb74f969dd7",
-      "at": "2026-04-11T05:55:30Z",
+      "hash": "d249a24d6d59d5aa62cc2c0f7dc5e2fa7d8828d8",
+      "at": "2026-04-11T14:31:32Z",
       "pr": 17979,
-      "passes": 8
+      "passes": 9
     },
     ".agents/scripts/memory-pressure-monitor.sh": {
       "hash": "d71f3754e56b925114a9b13c4ae3809cfb0c199d",

--- a/.agents/research.md
+++ b/.agents/research.md
@@ -26,19 +26,11 @@ subagents:
 
 ## Role
 
-You handle research and analysis: technical docs, competitor reviews, market research, best practices, tool evaluation, and trend analysis.
+Analyst mode only. Gather evidence, produce findings, do not implement changes.
 
-Stay in analyst mode. Answer with findings, evidence, and recommendations; do not switch into implementation or redirect work that belongs here.
-
-## Quick Reference
-
-- **Purpose**: research and analysis
-- **Mode**: gather evidence, not implement changes
-- **Primary tools**: Context7 for official docs, Crawl4AI/browser tools for web content, webfetch for supplied URLs
-- **Common tasks**: technical documentation, competitor analysis, market research, best-practice discovery, tool evaluation
-- **Output**: structured findings, not code changes
-
-<!-- AI-CONTEXT-END -->
+- **Tools**: Context7 for official docs, Crawl4AI/browser for web content, webfetch for supplied URLs
+- **Tasks**: technical docs, competitor analysis, market research, best-practice discovery, tool evaluation
+- **Output**: structured findings with citations, not code changes
 
 ## Research Workflow
 
@@ -72,3 +64,5 @@ Stay in analyst mode. Answer with findings, evidence, and recommendations; do no
 - Next steps
 
 Research informs implementation; it does not perform it.
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

Tightens `.agents/research.md` (the Research - Main Agent instruction doc) per GH#18271.

**Changes:**
- Merged redundant "Role" + "Quick Reference" sections into a single concise "Role" section — both described the same thing with different wording
- Moved `<!-- AI-CONTEXT-END -->` to end of file so the Research Workflow section is now included within AI context markers (previously it was outside, meaning the workflow was invisible to context extraction)
- Preserved all workflow content, output format, and closing principle verbatim
- 74 → 68 lines

**Verification:**
- All code blocks, URLs, and command examples present before and after: N/A (none in this file)
- No broken internal links or references: confirmed (symlink `.agents/commands/research.md → ../research.md` unchanged)
- Agent behaviour unchanged: analyst-mode-only constraint, tool list, workflow steps, and output format all preserved

Resolves #18271

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 4,817 tokens on this as a headless worker.