### PR TITLE
GH#18272: tighten agent doc Research - Main Agent (.agents/research.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1426,10 +1426,10 @@
       "pr": 13637
     },
     ".agents/research.md": {
-      "hash": "e30f6a29668b78be4808c38b12913ffaa49e6562",
-      "at": "2026-04-01T20:59:28Z",
-      "passes": 1,
-      "pr": 14996
+      "hash": "129d8428437322236b63583a1d1f2d9ba18c12dba7e4f4f7fab4b5af2aa31442",
+      "at": "2026-04-11T14:47:37Z",
+      "passes": 2,
+      "pr": 18272
     },
     ".agents/scripts/anti-detect-helper.sh": {
       "hash": "730469e80477587a80574ef900b64911a8cd04f7",

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1426,7 +1426,7 @@
       "pr": 13637
     },
     ".agents/research.md": {
-      "hash": "129d8428437322236b63583a1d1f2d9ba18c12dba7e4f4f7fab4b5af2aa31442",
+      "hash": "347455006952967cdc5928a9c86caccbfd05809e",
       "at": "2026-04-11T14:47:37Z",
       "passes": 2,
       "pr": 18272

--- a/.agents/research.md
+++ b/.agents/research.md
@@ -26,17 +26,12 @@ subagents:
 
 ## Role
 
-You handle research and analysis: technical docs, competitor reviews, market research, best practices, tool evaluation, and trend analysis.
+Research and analysis: technical docs, competitor reviews, market research, best practices, tool evaluation, trend analysis.
 
-Stay in analyst mode. Answer with findings, evidence, and recommendations; do not switch into implementation or redirect work that belongs here.
+Stay in analyst mode — gather evidence, not implement changes. Answer with findings, evidence, and recommendations.
 
-## Quick Reference
-
-- **Purpose**: research and analysis
-- **Mode**: gather evidence, not implement changes
-- **Primary tools**: Context7 for official docs, Crawl4AI/browser tools for web content, webfetch for supplied URLs
-- **Common tasks**: technical documentation, competitor analysis, market research, best-practice discovery, tool evaluation
-- **Output**: structured findings, not code changes
+- **Tools**: Context7 for official docs; Crawl4AI/browser for web content; webfetch for supplied URLs
+- **Output**: structured findings (decision, options, evidence/citations, recommendation, next steps), not code changes
 
 <!-- AI-CONTEXT-END -->
 
@@ -62,13 +57,5 @@ Stay in analyst mode. Answer with findings, evidence, and recommendations; do no
 2. Check adoption and ecosystem fit
 3. Compare realistic alternatives
 4. Recommend one option with rationale
-
-### Output format
-
-- Decision
-- Options
-- Evidence/citations
-- Recommendation
-- Next steps
 
 Research informs implementation; it does not perform it.


### PR DESCRIPTION
## Summary

Tightens `.agents/research.md` (Research - Main Agent) per GH#18272 simplification scan.

**Changes:**
- Merged redundant `Role` + `Quick Reference` sections into a single compact `Role` section — both said the same things in two formats
- Inlined the `Output format` subsection into the `Role` bullet points — eliminates a separate section for 5 items already captured in the role description
- Result: 74 → 61 lines (-17.6%)

**Knowledge preserved:** tool list (Context7, Crawl4AI, webfetch), output format (decision/options/evidence/recommendation/next steps), all three workflow types (technical, competitor/market, tool evaluation), closing principle.

**Simplification state:** `.agents/configs/simplification-state.json` updated with new hash.

Resolves #18272

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 4,618 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal research subagent instructions for clarity and accuracy.

* **Chores**
  * Updated internal configuration and state tracking metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->