### PR TITLE
GH#18276: tighten models-pool-check.md — remove redundant separate-terminal annotations

### DIFF
--- a/.agents/workflows/models-pool-check.md
+++ b/.agents/workflows/models-pool-check.md
@@ -30,7 +30,7 @@ Run in parallel: `oauth-pool-helper.sh check` (pool state) and `claude auth stat
 
 If `claude auth status --json` shows `loggedIn: true` with `pro` or `max`, say: "You're already logged into Claude CLI with a **{subscriptionType}** account ({email}). Run in a separate terminal: `oauth-pool-helper.sh import claude-cli`"
 
-Otherwise, ask which provider they have and run the matching command in a separate terminal:
+Otherwise, ask which provider they have and run the matching command:
 
 | Provider | Subscription | Command |
 |----------|-------------|---------|
@@ -45,14 +45,14 @@ Anthropic/OpenAI/Google: browser opens → authorize → paste code → restart 
 
 Say: "Everything looks good. Your pool has N account(s) and will auto-rotate if one hits rate limits."
 
-- **One account:** suggest adding a second — `oauth-pool-helper.sh add <provider>` (separate terminal).
-- **CLI account not in pool:** suggest importing — `oauth-pool-helper.sh import claude-cli` (separate terminal).
+- **One account:** suggest adding a second — `oauth-pool-helper.sh add <provider>`.
+- **CLI account not in pool:** suggest importing — `oauth-pool-helper.sh import claude-cli`.
 
 #### Path C — accounts exist but have problems
 
 Give one fix at a time:
 
-- **EXPIRED / INVALID (401) / auth-error**: Re-add — `oauth-pool-helper.sh add <provider>` (separate terminal).
+- **EXPIRED / INVALID (401) / auth-error**: Re-add — `oauth-pool-helper.sh add <provider>`.
   - Cursor exception: expired tokens are normal (IDE re-reads them) — only flag Cursor if status is also `auth-error`.
 - **Missing refresh token**: Remove first (`oauth-pool-helper.sh remove <provider> <email>`), then re-add.
 - **All rate-limited**: Offer to reset: `model-accounts-pool` tool `{"action": "reset-cooldowns"}`.


### PR DESCRIPTION
## Summary

Tightens `.agents/workflows/models-pool-check.md` per GH#18276 simplification-debt scan.

**Classification**: Instruction doc (agent rules, workflow, decision trees) — not a reference corpus. Content compression approach applied.

**Changes made:**
- Path A table intro: removed "in a separate terminal" from agent-internal prose — core rule 3 already establishes this
- Path B bullets: removed `(separate terminal)` annotations from two bullets — redundant with core rule 3
- Path C EXPIRED bullet: removed `(separate terminal)` annotation — same reason

**Preserved unchanged:**
- All commands (`oauth-pool-helper.sh add/import/remove/list/check`, `opencode auth login`, `claude auth status --json`, `model-accounts-pool` tool calls)
- User-facing quote in Path A line 31: "Run in a separate terminal: ..." stays (this is text the agent says TO the user)
- Core rule 3: "Auth commands go in a separate terminal." stays (canonical definition)
- Cursor exception in Path C (important institutional knowledge)
- All other paths, tables, and workflow structure

**Verification:**
- `qlty smells --all | grep models-pool-check.md` → 0 results (PASS)
- All commands present before and after
- Agent behaviour unchanged — core rule 3 still enforces separate terminal guidance

## Runtime Testing

Risk level: **Low** — agent prompt doc only, no code execution. Self-assessed.

Resolves #18276

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.239 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 8,693 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified workflow instructions by removing terminal-specific guidance from command suggestions across multiple workflow paths, affecting account setup and authentication management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->