### PR TITLE
GH#18288: tighten venv-health.md — compress prose, preserve all content

### DIFF
--- a/.agents/workflows/venv-health.md
+++ b/.agents/workflows/venv-health.md
@@ -7,8 +7,6 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Run Python venv smoke tests across managed repos. Arguments: $ARGUMENTS
-
 ```bash
 ~/.aidevops/agents/scripts/venv-health-check-helper.sh scan $ARGUMENTS
 ```
@@ -30,7 +28,7 @@ Run Python venv smoke tests across managed repos. Arguments: $ARGUMENTS
 | Stale editable installs | `.pth` files pointing to deleted paths (e.g., pruned git worktrees) | Error |
 | Missing requirements file | Venvs with no `requirements.txt`, `pyproject.toml`, `setup.py`, `setup.cfg`, or `Pipfile` | Warning |
 
-Discovery: looks for `.venv/pyvenv.cfg` (PEP 405 marker) up to 3 levels deep in each registered repo, deduplicated by realpath.
+> Discovery: looks for `.venv/pyvenv.cfg` (PEP 405 marker) up to 3 levels deep in each registered repo, deduplicated by realpath.
 
 ## Automatic Checks
 


### PR DESCRIPTION
## Summary

Tightens `.agents/workflows/venv-health.md` per the simplification-debt issue. File classified as **instruction doc** (workflow command doc, not reference corpus).

**Changes:**
- Removed redundant opening sentence (`Run Python venv smoke tests across managed repos. Arguments: $ARGUMENTS`) — duplicated the frontmatter `description` field and was unnecessary since `$ARGUMENTS` appears in the bash invocation block directly below
- Formatted the inline "Discovery:" prose note as a blockquote (`>`) for visual consistency with surrounding table content

**Result:** 61 → 59 lines. All code blocks, tables, URLs, command examples, and institutional knowledge preserved.

## Verification

- Content preservation: all code blocks, URLs, references present ✓
- No broken internal links ✓
- Qlty smells for target file: 0 ✓
- Agent behaviour unchanged (doc tightening only, no logic removed) ✓

## Runtime Testing

Risk: **Low** (doc-only change, no code or scripts modified). Self-assessed.

Resolves #18288

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 4,098 tokens on this as a headless worker.