### PR TITLE
GH#18290: tighten cross-review.md — remove redundant parse step, flatten usage block

### DIFF
--- a/.agents/workflows/cross-review.md
+++ b/.agents/workflows/cross-review.md
@@ -7,18 +7,16 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-## Instructions
+## Usage
 
-1. Parse `$ARGUMENTS` — extract `--prompt`, `--models`, `--score`, `--judge`, `--timeout`. Run:
+```bash
+~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
+  --prompt "your prompt here" \
+  --models "sonnet,opus" \
+  [--score] [--judge sonnet]
+```
 
-   ```bash
-   ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
-     --prompt "your prompt here" \
-     --models "sonnet,opus" \
-     [--score] [--judge sonnet]
-   ```
-
-2. Present: each model's response summary, diff (2-model comparisons), judge scores and winner if `--score` used, note failures. Scores recorded in model-comparisons SQLite DB, fed into pattern tracker (`/route`, `/patterns`).
+Present response summaries, diff (2-model), judge scores+winner if `--score` used, note failures. Scores → model-comparisons DB → `/route`, `/patterns`.
 
 ## Options
 


### PR DESCRIPTION
## Summary

- Remove redundant `1. Parse $ARGUMENTS` step from `## Instructions` — agents parse args by default; this was noise
- Rename `## Instructions` → `## Usage` — cleaner heading for command docs
- Unindent code block (was indented 3 spaces inside numbered list context)
- Condense output description from 2 verbose sentences to 1 tight line with arrow notation
- 60 lines → 58 lines; all content preserved

## Content Preservation Check

- Code blocks: ✓ (bash usage block, examples block)
- Command examples: ✓ (all 4 examples preserved verbatim)
- Options table: ✓ (all 6 options unchanged)
- Scoring criteria: ✓ (all 5 criteria preserved)
- Related links: ✓ (all 4 links unchanged)
- No task IDs or URLs existed in source to check

## Runtime Testing

Risk: **Low** — agent prompt/doc file. No code execution paths. `self-assessed`.

Qlty smells: 0 for target file.

Resolves #18290

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 10,477 tokens on this as a headless worker.