### PR TITLE
GH#18291: tighten worktree-cleanup.md

### DIFF
--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -3,11 +3,13 @@
 
 # Worktree Cleanup After Merge
 
-After a PR is merged, clean up the linked worktree and return the canonical repo to a clean state.
+After a PR merges, clean up the linked worktree and return the canonical repo to a clean state.
+
+**Key constraint:** Never pass `--delete-branch` to `gh pr merge` from inside a worktree — the branch is checked out there, not in the canonical repo.
 
 ## Automated Cleanup (workers — GH#6740)
 
-Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (Step 4.9). The pulse `cleanup_worktrees()` stage acts as a safety net, but workers must not rely on it — self-cleanup prevents accumulation during batch dispatch.
+Workers dispatched via `/full-loop` MUST self-cleanup after successful merge (Step 4.9). The pulse `cleanup_worktrees()` stage is a safety net — workers must not rely on it; self-cleanup prevents accumulation during batch dispatch.
 
 ```bash
 # After gh pr merge --squash succeeds:
@@ -46,11 +48,7 @@ git pull origin main
 wt prune
 ```
 
-## Key Rules
-
-- **Do not use `--delete-branch`** with `gh pr merge` from inside a worktree — the branch is checked out there, not in the canonical repo.
-- `wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run from the canonical repo (on `main`).
-- If `wt prune` is unavailable, use `git worktree prune` then manually delete the worktree directory.
+`wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run from the canonical repo (on `main`). If unavailable: `git worktree prune` then delete the worktree directory manually.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Simplified worktree-cleanup.md (59→57 lines): moved --delete-branch constraint to top-level callout (applies to both sections), eliminated Key Rules heading by merging content inline where used, tightened automated section intro

## Files Changed

.agents/workflows/worktree-cleanup.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Content preservation verified via diff; all code blocks, GH#6740 ref, and See Also links intact; Qlty smells: 0 matches; wc -l: 57

Resolves #18291


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 8,277 tokens on this as a headless worker.