### PR TITLE
GH#18282: ratchet NESTING_DEPTH_THRESHOLD 254→249

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -43,7 +43,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Bumped to 254 (GH#18157): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
 # Ratcheted down to 249 (GH#18174): actual violations 247 + 2 buffer
 # Bumped to 254 (GH#18267): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
-NESTING_DEPTH_THRESHOLD=254
+# Ratcheted down to 249 (GH#18282): actual violations 247 + 2 buffer
+NESTING_DEPTH_THRESHOLD=249
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 254 to 249 in complexity-thresholds.conf. Actual violations are 247; new threshold = 247 + 2 buffer = 249.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** complexity-scan-helper.sh ratchet-check . 5 passes: actual nest=247, threshold=249

Resolves #18282


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 2,371 tokens on this as a headless worker.