### PR TITLE
GH#18293: ratchet-down NESTING_DEPTH_THRESHOLD 254 → 249

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -43,7 +43,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Bumped to 254 (GH#18157): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
 # Ratcheted down to 249 (GH#18174): actual violations 247 + 2 buffer
 # Bumped to 254 (GH#18267): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
-NESTING_DEPTH_THRESHOLD=254
+# Ratcheted down to 249 (GH#18293): actual violations 247 + 2 buffer
+NESTING_DEPTH_THRESHOLD=249
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

- Lowers `NESTING_DEPTH_THRESHOLD` from 254 to 249 in `.agents/configs/complexity-thresholds.conf`
- Actual violations: 247; new threshold: 249 (247 + 2 buffer)
- Adds audit-trail comment following the ratchet-down history pattern

## Verification

```
[complexity-scan] INFO: Actual violations — func:37 nest:247 size:54 bash32:71
[complexity-scan] INFO: Current thresholds — func:40 nest:249 size:56 bash32:72
```

Violations (247) are below the new threshold (249) — CI will pass.

Resolves #18293