### PR TITLE
GH#18264: fix FD 9 inheritance — replace ineffective python3 fcntl with bash 9>&-

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -531,6 +531,10 @@ acquire_instance_lock() {
 # Safe to call multiple times (idempotent).
 #######################################
 release_instance_lock() {
+	# GH#18264: explicitly release the flock before removing the lock directory.
+	# exec 9>&- closes FD 9 in the current (parent) bash process, releasing the
+	# flock so the next pulse cycle can acquire it immediately.
+	exec 9>&- 2>/dev/null || true
 	rm -rf "$LOCKDIR" 2>/dev/null || true
 	return 0
 } # nice — idempotent cleanup
@@ -1619,7 +1623,7 @@ prefetch_state() {
 	while IFS='|' read -r slug path; do
 		(
 			_prefetch_single_repo "$slug" "$path" "${tmpdir}/${idx}.txt"
-		) &
+		) 9>&- &
 		pids+=($!)
 		idx=$((idx + 1))
 	done <<<"$repo_entries"
@@ -2724,7 +2728,7 @@ run_cmd_with_timeout() {
 	shift
 	[[ "$timeout_secs" =~ ^[0-9]+$ ]] || timeout_secs=60
 
-	"$@" &
+	"$@" 9>&- &
 	local cmd_pid=$!
 
 	local elapsed=0
@@ -2777,7 +2781,7 @@ run_stage_with_timeout() {
 	stage_start=$(date +%s)
 	echo "[pulse-wrapper] Stage start: ${stage_name} (timeout ${timeout_seconds}s)" >>"$LOGFILE"
 
-	"$@" &
+	"$@" 9>&- &
 	local stage_pid=$!
 
 	while kill -0 "$stage_pid" 2>/dev/null; do
@@ -3104,7 +3108,7 @@ gathered by pulse-wrapper.sh BEFORE this session started."
 	if [[ -n "$PULSE_MODEL" ]]; then
 		pulse_cmd+=(--model "$PULSE_MODEL")
 	fi
-	"${pulse_cmd[@]}" >>"$LOGFILE" 2>&1 &
+	"${pulse_cmd[@]}" >>"$LOGFILE" 2>&1 9>&- &
 
 	local opencode_pid=$!
 	echo "$opencode_pid" >"$PIDFILE"
@@ -6319,7 +6323,7 @@ run_weekly_complexity_scan() {
 	# timeout 30 prevents network hangs from blocking the pulse cycle.
 	if git -C "$aidevops_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 		if ! GIT_TERMINAL_PROMPT=0 timeout 30 \
-			git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1; then
+			git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 9>&-; then
 			echo "[pulse-wrapper] Complexity scan: git pull failed for ${aidevops_path} — skipping this cycle to avoid stale-state warnings" >>"$LOGFILE"
 			return 0
 		fi
@@ -7442,7 +7446,7 @@ _is_task_committed_to_main() {
 	# Ensure we have the latest remote refs (the dispatch loop already
 	# does git pull, but fetch is cheaper and sufficient for log queries)
 	if [[ -d "$repo_path/.git" ]] || git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
-		git -C "$repo_path" fetch origin main --quiet 2>/dev/null || true
+		git -C "$repo_path" fetch origin main --quiet 2>/dev/null 9>&- || true
 	else
 		return 1
 	fi
@@ -8248,7 +8252,7 @@ dispatch_with_dedup() {
 	# close issues as "Invalid — file does not exist" when the target
 	# file was added in a recent commit they haven't pulled.
 	if git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-		git -C "$repo_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 || {
+		git -C "$repo_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 9>&- || {
 			echo "[dispatch_with_dedup] Warning: git pull failed for ${repo_path} — proceeding with current checkout" >>"$LOGFILE"
 		}
 	fi
@@ -8313,7 +8317,7 @@ dispatch_with_dedup() {
 	# exits after its dispatch cycle, bash sends SIGHUP to background jobs.
 	# nohup makes the worker immune to SIGHUP so it survives the parent's
 	# exit. The EXIT trap only releases the instance lock (no child killing).
-	nohup "${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 &
+	nohup "${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 9>&- &
 	local worker_pid="$!"
 
 	# GH#17549: Stagger delay between worker launches to reduce SQLite
@@ -11783,7 +11787,7 @@ _routine_execute() {
 			--dir "$dispatch_dir" \
 			--agent "$agent_name" \
 			--title "Routine ${routine_id}: ${description}" \
-			--prompt "Execute routine ${routine_id}: ${description}" &
+			--prompt "Execute routine ${routine_id}: ${description}" 9>&- &
 		# Don't wait — let it run in background like a worker
 	else
 		# Fallback: check for custom script
@@ -11803,7 +11807,7 @@ _routine_execute() {
 				--session-key "routine-${routine_id}" \
 				--dir "${repo_path:-$PULSE_DIR}" \
 				--title "Routine ${routine_id}: ${description}" \
-				--prompt "Execute routine ${routine_id}: ${description}" &
+				--prompt "Execute routine ${routine_id}: ${description}" 9>&- &
 		fi
 	fi
 
@@ -11917,13 +11921,14 @@ main() {
 
 	# Open FD 9 for flock supplementary layer (no-op if flock unavailable)
 	exec 9>"$LOCKFILE"
-	# GH#18094: Set O_CLOEXEC on FD 9 so child processes (e.g. bd daemon spawned
-	# by the beads git merge driver) do not inherit the flock across exec().
-	# Without CLOEXEC, any long-lived child holds the flock indefinitely after
-	# the pulse exits, deadlocking every subsequent pulse cycle.
-	# python3 is a hard dependency of the pulse; the || true makes this a no-op
-	# on systems where python3 is unexpectedly absent.
-	python3 -c "import fcntl; fcntl.fcntl(9, fcntl.F_SETFD, fcntl.FD_CLOEXEC)" 2>/dev/null || true
+	# GH#18264: FD 9 inheritance is prevented by appending 9>&- to every child-
+	# spawning command below (backgrounded workers, git calls, subshells). This
+	# tells bash to close FD 9 in the child before exec — the parent's FD 9 and
+	# flock are unaffected. The previous python3 fcntl(F_SETFD) approach (GH#18094)
+	# was ineffective: fcntl() operates on the calling process's FD table, so
+	# running it in a child python3 process only set CLOEXEC on python's copy of
+	# FD 9, which was discarded when python exited. The parent bash FD 9 was never
+	# modified. Bash has no built-in for fcntl().
 	if ! acquire_instance_lock; then
 		return 0
 	fi
@@ -13549,7 +13554,7 @@ dispatch_foss_workers() {
 			--dir "$foss_path" \
 			--title "FOSS: ${foss_slug} #${foss_issue_num}: ${foss_issue_title}" \
 			--prompt "/full-loop Implement issue #${foss_issue_num} (https://github.com/${foss_slug}/issues/${foss_issue_num}) -- ${foss_issue_title}. This is a FOSS contribution.${disclosure_flag} After completion, run: foss-contribution-helper.sh record ${foss_slug} <tokens_used>" \
-			</dev/null >>"/tmp/pulse-foss-${foss_issue_num}.log" 2>&1 &
+			</dev/null >>"/tmp/pulse-foss-${foss_issue_num}.log" 2>&1 9>&- &
 		sleep 2
 
 		foss_count=$((foss_count + 1))

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -329,6 +329,10 @@ EVER_NMR_NEGATIVE_CACHE_TTL_SECS=$(_validate_int EVER_NMR_NEGATIVE_CACHE_TTL_SEC
 PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
 LOCKFILE="${HOME}/.aidevops/logs/pulse-wrapper.lock"
 LOCKDIR="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
+# GH#18264: tracks whether this process successfully acquired the instance lock.
+# release_instance_lock() checks this flag so it only closes FD 9 and removes
+# LOCKDIR when this process actually owns the lock.
+_LOCK_OWNED=false
 LOGFILE="${HOME}/.aidevops/logs/pulse.log"
 WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
 SESSION_FLAG="${HOME}/.aidevops/logs/pulse-session.flag"
@@ -518,6 +522,9 @@ acquire_instance_lock() {
 		echo "[pulse-wrapper] Instance lock acquired via mkdir (PID $$, flock not available on this platform)" >>"$WRAPPER_LOGFILE"
 	fi
 
+	# GH#18264: mark that this process owns the lock so release_instance_lock()
+	# only cleans up when we actually hold it.
+	_LOCK_OWNED=true
 	return 0
 }
 
@@ -531,7 +538,11 @@ acquire_instance_lock() {
 # Safe to call multiple times (idempotent).
 #######################################
 release_instance_lock() {
-	# GH#18264: explicitly release the flock before removing the lock directory.
+	# GH#18264: only release the lock when this process actually acquired it.
+	# _LOCK_OWNED is set to true by acquire_instance_lock() on success.
+	# This prevents the EXIT trap from removing LOCKDIR when the lock was
+	# never acquired (e.g., another instance was already running).
+	[[ "$_LOCK_OWNED" == "true" ]] || return 0
 	# exec 9>&- closes FD 9 in the current (parent) bash process, releasing the
 	# flock so the next pulse cycle can acquire it immediately.
 	exec 9>&- 2>/dev/null || true


### PR DESCRIPTION
## Summary

Replaces the ineffective `python3 fcntl(F_SETFD, FD_CLOEXEC)` approach from GH#18094 (PR #18105) with the correct bash-native `9>&-` redirection on every child-spawning command.

**Root cause of the previous fix's failure**: `fcntl(F_SETFD)` operates on the calling process's FD table. Running it in a child `python3` process sets CLOEXEC on python's copy of FD 9, which is discarded when python exits. The parent bash process's FD 9 was never modified. Bash has no built-in for `fcntl()`.

**This fix**: Appending `9>&-` to a command tells bash to close FD 9 in the child before `exec()` — the parent's FD 9 and flock are completely unaffected.

## Changes (12 sites in `.agents/scripts/pulse-wrapper.sh`)

**`release_instance_lock()`**: Added `exec 9>&- 2>/dev/null || true` before `rm -rf "$LOCKDIR"` to explicitly release the flock on parent exit.

**8 backgrounded commands** — added `9>&-` before `&`:
1. Worker dispatch nohup (~8320)
2. FOSS worker dispatch (~13557)
3. Routine dispatch (agent path, ~11784)
4. Routine dispatch (Build+ fallback, ~11805)
5. Supervisor pulse (~3107)
6. `run_cmd_with_timeout` generic wrapper (~2727)
7. `run_stage_with_timeout` generic wrapper (~2780)
8. Prefetch subshell (~1622)

**3 inline git commands** — added `9>&-` to prevent merge driver inheritance:
9. Complexity scan `git pull` (~6325)
10. `_is_task_committed_to_main` `git fetch` (~7448)
11. `dispatch_with_dedup` `git pull` (~8254)

**Removed**: The broken `python3 -c "import fcntl..."` block, replaced with an explanatory comment documenting why the previous approach failed.

## Runtime Testing

**Test script** (from issue body, run locally):

```
WITHOUT 9>&-:
FAIL: child inherited FD 9   ← confirms the bug exists without fix

WITH 9>&-:
PASS: child did not inherit FD 9   ← fix works

Parent FD 9 still open:
PASS: parent FD 9 intact   ← parent flock unaffected
```

All 3 test scenarios pass. Bash syntax check: `bash -n pulse-wrapper.sh` → clean.

## Key Decisions

- `9>&-` is bash-native, zero dependencies, works on all POSIX shells. No python3, no external tools.
- Applied to ALL child-spawning sites (not just the beads merge driver path) — any long-lived child can hold the flock, not just `bd daemon`.
- `exec 9>&-` in `release_instance_lock()` ensures the flock is released even if the EXIT trap fires before the lock directory is removed.

Resolves #18264

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 5m and 12,408 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock file cleanup and resource management to prevent potential deadlock situations in background operations.
  * Enhanced file descriptor handling during instance termination to ensure proper resource release and prevent lock conflicts.

* **Chores**
  * Updated background process management to prevent resource inheritance issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->