### PR TITLE
GH#18285: add @shopify agent, fix MCP audit gaps, add permission-migration TODOs

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -170,6 +170,29 @@ generate_subagent_stub() {
 			extra_tools=$'  ios-simulator_*: true'
 		fi
 		;;
+	shopify)
+		extra_tools=$'  shopify-dev-mcp_*: true'
+		# TODO(permission-migration): Replace with permission: shopify-dev-mcp: allow
+		# once anomalyco/opencode#6892 is resolved.
+		;;
+	sentry)
+		extra_tools=$'  sentry_*: true'
+		;;
+	socket)
+		extra_tools=$'  socket_*: true'
+		;;
+	context7 | context7-cli)
+		extra_tools=$'  context7_*: true'
+		;;
+	chrome-devtools)
+		extra_tools=$'  chrome-devtools_*: true'
+		;;
+	cloudflare-mcp)
+		extra_tools=$'  cloudflare-api_*: true'
+		;;
+	playwright)
+		extra_tools=$'  playwright_*: true'
+		;;
 	*) ;; # No extra tools for other agents
 	esac
 

--- a/.agents/scripts/setup-mcp-integrations.sh
+++ b/.agents/scripts/setup-mcp-integrations.sh
@@ -41,6 +41,7 @@ get_mcp_command() {
 	# serper - REMOVED: Uses curl subagent (.agents/seo/serper.md), no MCP needed
 	"unstract") echo "docker:unstract/mcp-server" ;;
 	"context7") echo "npx -y @upstash/context7-mcp@latest" ;;
+	"shopify-dev-mcp") echo "npx -y @shopify/dev-mcp@latest" ;;
 	*) echo "" ;;
 	esac
 	return 0
@@ -64,6 +65,7 @@ MCP_LIST=(
 	"dataforseo"
 	"unstract"
 	"context7"
+	"shopify-dev-mcp"
 )
 
 is_known_mcp() {
@@ -390,6 +392,36 @@ _install_context7() {
 	return 0
 }
 
+_install_shopify_dev_mcp() {
+	print_info "Setting up Shopify Dev MCP for schema-aware GraphQL, Liquid validation, and Admin API..."
+	print_warning "Prerequisites: Node 18+, Shopify CLI 3.93.0+"
+	print_info "Install Shopify CLI: npm install -g @shopify/cli@latest"
+	print_info "Verify: shopify version"
+	echo ""
+	print_info "Auth: shopify store auth (browser-based OAuth, no stored tokens)"
+	echo ""
+	print_info "The MCP is registered as disabled globally in opencode.json."
+	print_info "Enable it per-session by invoking the @shopify agent."
+	echo ""
+	print_info "OpenCode config (added to ~/.config/opencode/opencode.json):"
+	print_info '  "shopify-dev-mcp": {'
+	print_info '    "type": "local",'
+	print_info '    "command": ["npx", "-y", "@shopify/dev-mcp@latest"],'
+	print_info '    "enabled": false'
+	print_info '  }'
+	echo ""
+	print_info "Global tools entry (added to opencode.json tools section):"
+	print_info '  "shopify-dev-mcp_*": false'
+	echo ""
+	print_info "Per-repo skills (install at repo level, not framework level):"
+	print_info "  npx @shopify/shopify-ai-toolkit@latest add shopify-admin"
+	print_info "  npx @shopify/shopify-ai-toolkit@latest add shopify-liquid"
+	echo ""
+	print_info "Docs: ~/.aidevops/agents/services/ecommerce/shopify.md"
+	print_info "Config template: ~/.aidevops/agents/configs/mcp-templates/shopify-dev-mcp-config.json.txt"
+	return 0
+}
+
 # Install specific MCP integration — thin dispatcher to per-integration helpers
 install_mcp() {
 	local mcp_name="$1"
@@ -422,6 +454,7 @@ install_mcp() {
 	# serper - REMOVED: Uses curl subagent (.agents/seo/serper.md), no MCP needed
 	"unstract") _install_unstract ;;
 	"context7") _install_context7 ;;
+	"shopify-dev-mcp") _install_shopify_dev_mcp ;;
 	*)
 		print_error "Unknown MCP integration: $mcp_name"
 		print_info "Available integrations: ${MCP_LIST[*]}"

--- a/.agents/services/ecommerce/shopify.md
+++ b/.agents/services/ecommerce/shopify.md
@@ -1,0 +1,91 @@
+---
+description: Shopify store management — schema-aware GraphQL, Liquid template validation, Admin API, content management via MCP
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  shopify-dev-mcp_*: true
+  # TODO(permission-migration): When anomalyco/opencode#6892 is resolved and
+  # permission: supports MCP wildcard gating, migrate to:
+  #   permission:
+  #     shopify-dev-mcp: allow
+  # and remove the tools: shopify-dev-mcp_* entry above.
+mcp:
+  - shopify-dev-mcp
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Shopify Agent
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **MCP**: `shopify-dev-mcp` — schema-aware GraphQL, Liquid validation, Admin API execution
+- **Tool prefix**: `shopify-dev-mcp_*`
+- **Prerequisites**: Node 18+, Shopify CLI 3.93.0+ (`npm install -g @shopify/cli@latest`)
+- **Auth**: Browser OAuth via `shopify store auth` — no stored tokens
+- **Config template**: `configs/mcp-templates/shopify-dev-mcp-config.json.txt`
+- **Setup**: `setup-mcp-integrations.sh shopify-dev-mcp`
+
+## Activation
+
+This agent is invoked with `@shopify`. The `shopify-dev-mcp` MCP server is disabled globally
+in `opencode.json` and enabled only for this agent via `tools: shopify-dev-mcp_*: true`.
+
+**Headless workers**: The MCP must be registered in `opencode.json` before dispatch.
+If `shopify-dev-mcp` tools are absent from the session tool list, exit BLOCKED immediately:
+`BLOCKED: Required MCP shopify-dev-mcp not available in this session. Register it via setup-mcp-integrations.sh shopify-dev-mcp and restart.`
+
+## Capabilities
+
+| Task | Approach |
+|------|----------|
+| Validate Liquid templates | MCP schema validation before push |
+| Search Admin GraphQL schema | Schema-aware field/mutation lookup |
+| Execute Admin GraphQL | `shopify store execute` via MCP |
+| Blog/article management | Full content CRUD via Admin API |
+| Pages, redirects, navigation | Content management surface |
+| Metafields, SEO metadata | Structured data management |
+
+## Why MCP over CLI
+
+`shopify store execute` (CLI) is raw GraphQL — no schema awareness, no field validation.
+The MCP guides correct queries and catches schema errors before hitting the API.
+CLI is only appropriate for theme file operations (`themeFilesUpsert`) and simple
+product/order reads where the schema is stable and well-known.
+
+## Repo-Level Skills
+
+Install per-repo from the Shopify AI Toolkit (not framework-level):
+
+```bash
+npx @shopify/shopify-ai-toolkit@latest add shopify-admin
+npx @shopify/shopify-ai-toolkit@latest add shopify-liquid
+npx @shopify/shopify-ai-toolkit@latest add shopify-polaris
+```
+
+Available: `shopify-admin`, `shopify-admin-execution`, `shopify-liquid`, `shopify-polaris`, `shopify-app-bridge`
+
+## repos.json Integration
+
+Tag Shopify repos with `"platform": "shopify"` to document intent (auto-enable is not yet
+implemented at the dispatch layer — invoke `@shopify` explicitly):
+
+```json
+{
+  "slug": "owner/my-shopify-store",
+  "path": "~/Git/my-shopify-store",
+  "platform": "shopify",
+  "pulse": true
+}
+```
+
+<!-- AI-CONTEXT-END -->

--- a/.agents/services/monitoring/sentry.md
+++ b/.agents/services/monitoring/sentry.md
@@ -10,6 +10,9 @@ tools:
   grep: false
   webfetch: true
   task: false
+  sentry_*: true
+  # TODO(permission-migration): Replace with permission: sentry: allow
+  # once anomalyco/opencode#6892 is resolved.
 mcp:
   - sentry
 ---

--- a/.agents/services/monitoring/socket.md
+++ b/.agents/services/monitoring/socket.md
@@ -10,6 +10,9 @@ tools:
   grep: false
   webfetch: true
   task: false
+  socket_*: true
+  # TODO(permission-migration): Replace with permission: socket: allow
+  # once anomalyco/opencode#6892 is resolved.
 mcp:
   - socket
 ---

--- a/.agents/tools/ai-assistants/claude-code.md
+++ b/.agents/tools/ai-assistants/claude-code.md
@@ -5,6 +5,10 @@ tools:
   read: true
   bash: true
   claude-code-mcp_*: true
+  # TODO(permission-migration): Replace with permission: claude-code-mcp: allow
+  # once anomalyco/opencode#6892 is resolved.
+mcp:
+  - claude-code-mcp
 ---
 
 <!-- SPDX-License-Identifier: MIT -->

--- a/.agents/tools/api/cloudflare-mcp.md
+++ b/.agents/tools/api/cloudflare-mcp.md
@@ -10,6 +10,10 @@ tools:
   grep: true
   webfetch: true
   cloudflare-api_*: true
+  # TODO(permission-migration): Replace with permission: cloudflare-api: allow
+  # once anomalyco/opencode#6892 is resolved.
+mcp:
+  - cloudflare-api
 ---
 
 <!-- SPDX-License-Identifier: MIT -->

--- a/.agents/tools/browser/chrome-devtools.md
+++ b/.agents/tools/browser/chrome-devtools.md
@@ -10,6 +10,11 @@ tools:
   grep: true
   webfetch: true
   task: true
+  chrome-devtools_*: true
+  # TODO(permission-migration): Replace with permission: chrome-devtools: allow
+  # once anomalyco/opencode#6892 is resolved.
+mcp:
+  - chrome-devtools
 ---
 
 <!-- SPDX-License-Identifier: MIT -->

--- a/.agents/tools/browser/playwright.md
+++ b/.agents/tools/browser/playwright.md
@@ -11,6 +11,8 @@ tools:
   webfetch: true
   task: true
   playwright_*: true
+  # TODO(permission-migration): Replace with permission: playwright: allow
+  # once anomalyco/opencode#6892 is resolved.
 mcp:
   - playwright
 ---

--- a/.agents/tools/context/context7.md
+++ b/.agents/tools/context/context7.md
@@ -11,6 +11,8 @@ tools:
   webfetch: true
   task: true
   context7_*: true
+  # TODO(permission-migration): Replace with permission: context7: allow
+  # once anomalyco/opencode#6892 is resolved.
 mcp:
   - context7
 ---

--- a/.agents/tools/ui/shadcn.md
+++ b/.agents/tools/ui/shadcn.md
@@ -11,6 +11,8 @@ tools:
   webfetch: true
   task: true
   shadcn_*: true
+  # TODO(permission-migration): Replace with permission: shadcn: allow
+  # once anomalyco/opencode#6892 is resolved.
 mcp:
   - shadcn
 ---

--- a/.agents/tools/wordpress/localwp.md
+++ b/.agents/tools/wordpress/localwp.md
@@ -6,7 +6,11 @@ tools:
   bash: true
   read: true
   localwp_*: true
+  # TODO(permission-migration): Replace with permission: localwp: allow
+  # once anomalyco/opencode#6892 is resolved.
   task: true
+mcp:
+  - localwp
 ---
 
 <!-- SPDX-License-Identifier: MIT -->

--- a/configs/mcp-templates/shopify-dev-mcp-config.json.txt
+++ b/configs/mcp-templates/shopify-dev-mcp-config.json.txt
@@ -3,7 +3,7 @@
   "description": "Shopify Dev MCP server — schema-aware GraphQL generation, Liquid template validation, and Admin API execution for Shopify-platform repos",
   "documentation": "https://shopify.dev/docs/apps/build/ai-toolkit",
   "toolkit_repo": "https://github.com/Shopify/Shopify-AI-Toolkit",
-  "activation": "Auto-enabled for repos with \"platform\": \"shopify\" in repos.json",
+  "activation": "Invoke @shopify agent — MCP is disabled globally, enabled per-agent via tools: shopify-dev-mcp_*: true. Tag repos with platform:shopify in repos.json to document intent (dispatch-layer auto-enable is not yet implemented).",
   "prerequisites": {
     "node_version": "18+",
     "shopify_cli": "3.93.0+ (required for shopify store execute)",
@@ -31,7 +31,7 @@
           "enabled": false
         }
       },
-      "notes": "Disabled globally; auto-enabled for repos with platform:shopify in repos.json"
+      "notes": "Disabled globally; enabled per-agent via tools: shopify-dev-mcp_*: true in the @shopify agent. Invoke @shopify to activate. TODO(permission-migration): migrate to permission: shopify-dev-mcp: allow once anomalyco/opencode#6892 is resolved."
     },
     "cursor": {
       "config_location": "~/.cursor/mcp.json",
@@ -76,7 +76,7 @@
     "Generate schema-validated GraphQL queries that catch errors before hitting the API"
   ],
   "repos_json_integration": {
-    "description": "Add platform field to repos.json entry to auto-enable this MCP server",
+    "description": "Add platform field to repos.json entry to document that this repo uses Shopify. Invoke @shopify agent to activate the MCP — dispatch-layer auto-enable is not yet implemented.",
     "example": {
       "slug": "owner/my-shopify-store",
       "path": "~/Git/my-shopify-store",


### PR DESCRIPTION
## Summary

- Adds `@shopify` agent (`services/ecommerce/shopify.md`) with `shopify-dev-mcp_*: true` — the missing piece that caused GH#18285
- Registers `shopify-dev-mcp` in `setup-mcp-integrations.sh` (MCP_LIST, get_mcp_command, install function) so it is installed as `enabled: false` during setup/update
- Fixes `generate-opencode-agents.sh` to emit `shopify-dev-mcp_*: true` for the shopify agent case, plus adds missing cases for sentry, socket, context7, chrome-devtools, cloudflare-mcp, playwright
- Removes the false "auto-enabled for platform:shopify repos" claim from the template — documents the actual mechanism (invoke `@shopify`)
- Adds `mcp:` declarations to agent files that were missing them (claude-code, cloudflare-mcp, chrome-devtools, playwright, localwp, sentry, socket)
- Adds `TODO(permission-migration)` comments to every `_*: true` entry pointing to anomalyco/opencode#6892 — when that bug is fixed, each entry has a clear migration path to `permission: <mcp>: allow`

## Audit findings fixed

| MCP | Was | Now |
|---|---|---|
| shopify-dev-mcp | Not registered anywhere | Agent + setup + generate + template fixed |
| sentry | Agent had `mcp:` but no `sentry_*: true` | Added `sentry_*: true` + generate case |
| socket | Same as sentry | Added `socket_*: true` + generate case |
| chrome-devtools | No `mcp:` declaration, no generate case | Added both |
| playwright | Had `playwright_*: true` but no generate case | Added generate case |
| cloudflare-api | Had `cloudflare-api_*: true` but no `mcp:` | Added `mcp:` declaration |
| context7 | Correct, added future-compat comment | — |

## Orphaned global tools entries (not fixed — separate cleanup)

`dataforseo_*`, `serper_*`, `shadcn_*`, `websearch_*`, `grep_app_*` exist in `opencode.json` global tools but have no corresponding MCP registration. These are either removed MCPs or MCPs registered elsewhere. Left for a separate cleanup pass.

Resolves #18285

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 27m and 9,936 tokens on this as a headless worker.