### PR TITLE
GH#18314: bump NESTING_DEPTH_THRESHOLD 249→254 to restore headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -44,6 +44,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 254 | GH#18157 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
 | 249 | GH#18174 | ratcheted down — actual violations 247 + 2 buffer |
 | 254 | GH#18267 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
+| 249 | GH#18293 | ratcheted down — actual violations 247 + 2 buffer |
+| 254 | GH#18314 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -44,7 +44,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=40
 # Ratcheted down to 249 (GH#18174): actual violations 247 + 2 buffer
 # Bumped to 254 (GH#18267): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
 # Ratcheted down to 249 (GH#18293): actual violations 247 + 2 buffer
-NESTING_DEPTH_THRESHOLD=249
+# Bumped to 254 (GH#18314): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
+NESTING_DEPTH_THRESHOLD=254
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Proximity guard firing at 247/249 nesting violations (2 headroom). Bumps `NESTING_DEPTH_THRESHOLD` from 249 → 254 to restore adequate headroom.

- 247 violations + 7 headroom = 254 threshold
- Proximity guard (`warn_at = 254-5 = 249`) fires when violations exceed 249, preventing saturation before CI fails

Also backfills the missing GH#18293 ratchet-down entry in `complexity-thresholds-history.md` (that PR updated the config but not the history file).

## Files Modified

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 249→254, add history comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#18293 ratchet entry (backfill) + GH#18314 bump entry

## Runtime Testing

`self-assessed` — config-only change; no shell logic affected. CI will verify the threshold value is read correctly via the `code-quality.yml` workflow.

Resolves #18314

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 6,380 tokens on this as a headless worker.