### PR TITLE
GH#18317: GH#18317: tighten agent doc /security-review (52 → 50 lines)

### DIFF
--- a/.agents/tools/security/security-review.md
+++ b/.agents/tools/security/security-review.md
@@ -3,11 +3,9 @@
 
 # /security-review
 
-Review quarantined security items and apply learn actions to update the security config. Run after headless worker batches or when `quarantine-helper.sh stats` shows pending items.
+Triage quarantined security items. Run after worker batches or when `quarantine-helper.sh stats` shows pending items.
 
-## Sources
-
-Ambiguous items flagged but not auto-blocked:
+## Sources — ambiguous items not auto-blocked
 
 - **prompt-guard-helper.sh** — WARN-level prompt injection detections
 - **network-tier-helper.sh** — Tier 4 unknown domains allowed but flagged


### PR DESCRIPTION
## Summary

Tightened .agents/tools/security/security-review.md from 52 to 50 lines: merged Sources section intro into header, simplified opening description by removing redundant phrase.

## Files Changed

.agents/tools/security/security-review.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Content preservation: all Sources, Learn actions table, Usage code block, and Related pointers present. Line count reduced by 2.

Resolves #18317


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.240 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 5,028 tokens on this as a headless worker.