### PR TITLE
GH#18285: register shopify-dev-mcp in generate-runtime-config.sh so setup/update installs it

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -993,6 +993,14 @@ _generate_mcp_for_runtime() {
 		'{"url":"https://mcp.cloudflare.com/mcp"}'
 	mcp_count=$((mcp_count + 1))
 
+	# Shopify Dev MCP (disabled by default; enabled per-agent via @shopify)
+	# Requires: Node 18+, Shopify CLI 3.93.0+ (npm install -g @shopify/cli@latest)
+	# TODO(permission-migration): when anomalyco/opencode#6892 is resolved, the
+	# per-agent tools: entry can be replaced with permission: shopify-dev-mcp: allow
+	register_mcp_for_runtime "$runtime_id" "shopify-dev-mcp" \
+		'{"command":"npx","args":["-y","@shopify/dev-mcp@latest"]}'
+	mcp_count=$((mcp_count + 1))
+
 	print_success "$display_name: $mcp_count MCP servers processed"
 	return 0
 }


### PR DESCRIPTION
## Summary

- Adds `register_mcp_for_runtime` call for `shopify-dev-mcp` in `generate-runtime-config.sh` alongside the other always-registered MCPs (context7, playwright, cloudflare-api, etc.)
- Registered as `enabled: false` by default — activated per-session via `@shopify` agent
- Fixes the gap where `setup.sh` / `aidevops update` deployed the `@shopify` agent stub but never registered the MCP server in `opencode.json`, leaving `shopify-dev-mcp_*` tools unavailable at runtime

## Root cause

`generate-runtime-config.sh` is the authoritative source for which MCPs get registered during setup/update. The previous PR (#18311) added the agent file, install instructions, and agent stub generation — but missed this file, which is where the actual `opencode.json` MCP entry is written.

## Verification

After `setup.sh --non-interactive` (or `aidevops update`):

```bash
python3 -c "
import json
with open('/Users/\$USER/.config/opencode/opencode.json') as f:
    d = json.load(f)
print('registered:', 'shopify-dev-mcp' in d.get('mcp', {}))
print('enabled:', d['mcp'].get('shopify-dev-mcp', {}).get('enabled'))
print('tools entry:', d.get('tools', {}).get('shopify-dev-mcp_*'))
"
# Expected: registered: True, enabled: False, tools entry: False
```

Resolves #18285

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.241 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1h 52m and 9,936 tokens on this as a headless worker.