### PR TITLE
GH#18285: fix shopify-dev-mcp enabled:true so server starts on OpenCode load

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -993,12 +993,13 @@ _generate_mcp_for_runtime() {
 		'{"url":"https://mcp.cloudflare.com/mcp"}'
 	mcp_count=$((mcp_count + 1))
 
-	# Shopify Dev MCP (disabled by default; enabled per-agent via @shopify)
+	# Shopify Dev MCP — server starts on load (enabled:true); tool calls gated per-agent
+	# via tools: shopify-dev-mcp_*: true in the @shopify agent stub (false globally).
 	# Requires: Node 18+, Shopify CLI 3.93.0+ (npm install -g @shopify/cli@latest)
 	# TODO(permission-migration): when anomalyco/opencode#6892 is resolved, the
 	# per-agent tools: entry can be replaced with permission: shopify-dev-mcp: allow
 	register_mcp_for_runtime "$runtime_id" "shopify-dev-mcp" \
-		'{"command":"npx","args":["-y","@shopify/dev-mcp@latest"]}'
+		'{"command":"npx","args":["-y","@shopify/dev-mcp@latest"],"enabled":true}'
 	mcp_count=$((mcp_count + 1))
 
 	print_success "$display_name: $mcp_count MCP servers processed"

--- a/.agents/services/ecommerce/shopify.md
+++ b/.agents/services/ecommerce/shopify.md
@@ -37,12 +37,13 @@ mcp:
 
 ## Activation
 
-This agent is invoked with `@shopify`. The `shopify-dev-mcp` MCP server is disabled globally
-in `opencode.json` and enabled only for this agent via `tools: shopify-dev-mcp_*: true`.
+This agent is invoked with `@shopify`. The `shopify-dev-mcp` server starts on OpenCode load
+(`enabled: true`). Tool calls are gated: `shopify-dev-mcp_*: false` globally, `true` only for
+this agent — so the tools are available here but not to other agents.
 
 **Headless workers**: The MCP must be registered in `opencode.json` before dispatch.
 If `shopify-dev-mcp` tools are absent from the session tool list, exit BLOCKED immediately:
-`BLOCKED: Required MCP shopify-dev-mcp not available in this session. Register it via setup-mcp-integrations.sh shopify-dev-mcp and restart.`
+`BLOCKED: Required MCP shopify-dev-mcp not available in this session. Run setup-mcp-integrations.sh shopify-dev-mcp and restart OpenCode.`
 
 ## Capabilities
 

--- a/configs/mcp-templates/shopify-dev-mcp-config.json.txt
+++ b/configs/mcp-templates/shopify-dev-mcp-config.json.txt
@@ -28,10 +28,10 @@
         "shopify-dev-mcp": {
           "command": "npx",
           "args": ["-y", "@shopify/dev-mcp@latest"],
-          "enabled": false
+          "enabled": true
         }
       },
-      "notes": "Disabled globally; enabled per-agent via tools: shopify-dev-mcp_*: true in the @shopify agent. Invoke @shopify to activate. TODO(permission-migration): migrate to permission: shopify-dev-mcp: allow once anomalyco/opencode#6892 is resolved."
+      "notes": "Server starts on load (enabled: true). Tool calls gated: shopify-dev-mcp_*: false globally, true only in the @shopify agent stub. Invoke @shopify to use the tools. TODO(permission-migration): migrate to permission: shopify-dev-mcp: allow once anomalyco/opencode#6892 is resolved."
     },
     "cursor": {
       "config_location": "~/.cursor/mcp.json",


### PR DESCRIPTION
## Summary

Fixes the root cause of the user-reported failure: `@shopify` agent had `shopify-dev-mcp_*: true` in its tools but the MCP server was `enabled: false`, so the process never started and all tool calls would fail.

## The two-layer model (clarified)

| Layer | Field | Value | Effect |
|---|---|---|---|
| Process startup | `mcp.shopify-dev-mcp.enabled` | `true` | Server process starts when OpenCode loads |
| Global call gate | `tools.shopify-dev-mcp_*` | `false` | No agent can call the tools by default |
| Per-agent call gate | `agent.shopify.tools.shopify-dev-mcp_*` | `true` | Only `@shopify` agent can call the tools |

`enabled: false` means the process never starts — `tools_*: true` in an agent stub only gates call permission, not process startup. Both layers are needed.

## Changes

- `generate-runtime-config.sh`: pass `"enabled":true` in shopify-dev-mcp registration JSON
- `shopify.md`: correct Activation section — "server starts on load, tool calls gated per-agent"
- `shopify-dev-mcp-config.json.txt`: correct `enabled: false` → `true` in opencode config example, update notes

## Verification

After `aidevops update` + OpenCode restart:
```bash
# Server should be enabled:true
python3 -c "import json; d=json.load(open('/Users/\$USER/.config/opencode/opencode.json')); print(d['mcp']['shopify-dev-mcp']['enabled'])"
# Expected: True

# Global tools gate should still be false
python3 -c "import json; d=json.load(open('/Users/\$USER/.config/opencode/opencode.json')); print(d['tools']['shopify-dev-mcp_*'])"
# Expected: False
```

Resolves #18285

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.241 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 4h 25m and 9,936 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Shopify MCP server now automatically starts on system load with explicit enablement flag.
  * Tool access remains controlled at the agent level.

* **Documentation**
  * Updated Shopify agent documentation with revised setup instructions and clarified tool access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->