### PR TITLE
GH#18285: add shopify-dev-mcp to plugin registry and AGENT_MCP_TOOLS

### DIFF
--- a/.agents/plugins/opencode-aidevops/agent-loader.mjs
+++ b/.agents/plugins/opencode-aidevops/agent-loader.mjs
@@ -39,6 +39,7 @@ const AGENT_MCP_TOOLS = {
   context7: ["context7_*"],
   sentry: ["sentry_*"],
   socket: ["socket_*"],
+  shopify: ["shopify-dev-mcp_*"],
 };
 
 /**

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -173,6 +173,15 @@ function getMcpRegistry() {
       globallyEnabled: false,
       description: "Dependency security scanning",
     },
+    {
+      name: "shopify-dev-mcp",
+      type: "local",
+      command: [...pkgRunnerParts, "@shopify/dev-mcp@latest"],
+      eager: false,
+      toolPattern: "shopify-dev-mcp_*",
+      globallyEnabled: false,
+      description: "Shopify schema-aware GraphQL, Liquid validation, Admin API",
+    },
   ];
 }
 

--- a/.agents/services/ecommerce/shopify.md
+++ b/.agents/services/ecommerce/shopify.md
@@ -37,12 +37,14 @@ mcp:
 
 ## Activation
 
-This agent is invoked with `@shopify`. The `shopify-dev-mcp` MCP server is disabled globally
-in `opencode.json` and enabled only for this agent via `tools: shopify-dev-mcp_*: true`.
+This agent is invoked with `@shopify`. The `shopify-dev-mcp` server is lazy-loaded on demand
+(`eager: false` in the plugin registry) — it starts on the first tool call, not at OpenCode
+launch. Tool calls are gated: `shopify-dev-mcp_*: false` globally, `true` only for this agent.
+No context bloat for sessions that don't use Shopify.
 
-**Headless workers**: The MCP must be registered in `opencode.json` before dispatch.
-If `shopify-dev-mcp` tools are absent from the session tool list, exit BLOCKED immediately:
-`BLOCKED: Required MCP shopify-dev-mcp not available in this session. Register it via setup-mcp-integrations.sh shopify-dev-mcp and restart.`
+**Headless workers**: The MCP is registered automatically by the plugin on every OpenCode
+startup. If `shopify-dev-mcp` tools are absent from the session tool list, exit BLOCKED:
+`BLOCKED: Required MCP shopify-dev-mcp not available. Ensure aidevops plugin is loaded and restart OpenCode.`
 
 ## Capabilities
 


### PR DESCRIPTION
## Summary

Fixes the actual root cause: the plugin (`mcp-registry.mjs` + `agent-loader.mjs`) is the authoritative source for MCP registration and per-agent tool gating — not `opencode.json` directly. The plugin runs on every OpenCode startup and overwrites `opencode.json` entries.

## Architecture (clarified)

The system is correctly designed — no context bloat, no idle processes:

| Component | Role |
|---|---|
| `mcp-registry.mjs` `eager: false` | Lazy-load: process starts on first tool call, not at launch |
| `mcp-registry.mjs` `globallyEnabled: false` | Sets `tools_*: false` globally — all agents blocked by default |
| `agent-loader.mjs` `AGENT_MCP_TOOLS` | Injects `tools_*: true` into specific agent configs at startup |
| `opencode.json` | Written by plugin at startup; secondary to plugin registry |

`enabled: false` in `opencode.json` is the plugin's output of `eager: false`. The process still starts on first tool call — opencode lazy-loads MCPs. This is the correct design.

## Changes

- `mcp-registry.mjs`: add `shopify-dev-mcp` entry (`eager: false`, `globallyEnabled: false`)
- `agent-loader.mjs`: add `shopify: ["shopify-dev-mcp_*"]` to `AGENT_MCP_TOOLS`
- `shopify.md`: correct Activation docs to describe lazy-load model accurately

## What was wrong

`shopify` was missing from `AGENT_MCP_TOOLS` — so the plugin never injected `shopify-dev-mcp_*: true` into the `@shopify` agent config. The `opencode.json` stub had the right `tools` entry from `generate-opencode-agents.sh`, but the plugin overwrites it at startup without the shopify entry in `AGENT_MCP_TOOLS`.

## Verification

After `aidevops update` + OpenCode restart, the plugin log should show:
```
[aidevops] Config hook: N agents, N MCPs, N agent tool perms
```
The `agent tool perms` count should increase by 1 (shopify added).

Resolves #18285

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.241 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 4h 30m and 9,936 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shopify integration now available with automatic tool loading on first use
  * Shopify service tools are pre-configured and ready to use

* **Documentation**
  * Updated activation instructions for simplified Shopify setup
  * Streamlined configuration process for headless environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->