### PR TITLE
bugfix: fix origin:interactive detection for OpenCode/Claude Code sessions

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -207,6 +207,14 @@ Reference code as `file_path:line_number` for easy navigation.
 # Git Workflow
 Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 
+**Origin labelling (MANDATORY):**
+- NEVER use raw `gh pr create` or `gh issue create` directly. Always use the wrappers:
+  `gh_create_pr` and `gh_create_issue` (defined in `shared-constants.sh`, sourced via PATH).
+  The wrappers automatically apply `origin:interactive` or `origin:worker` based on the
+  session context. Raw `gh` calls produce unlabelled PRs that the pulse may auto-close.
+- If `gh_create_pr` is unavailable (e.g. not sourced), pass `--label origin:interactive`
+  explicitly when creating PRs in an interactive session.
+
 **Traceability (MANDATORY):**
 - PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
 - **PR bodies MUST use `Resolves #NNN`** to link the PR to its issue. GitHub only

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -766,7 +766,24 @@ detect_session_origin() {
 		echo "worker"
 		return 0
 	fi
+	# OpenCode interactive session: sets OPENCODE=1 and OPENCODE_PID in the
+	# shell environment. TTY is not available in OpenCode tool execution context
+	# so the TTY check below would incorrectly classify these as workers.
+	# OPENCODE_HEADLESS (checked above) is set by headless-runtime-helper.sh
+	# for worker dispatch — its absence here means this is a user session.
+	if [[ "${OPENCODE:-}" == "1" ]] || [[ -n "${OPENCODE_PID:-}" ]]; then
+		echo "interactive"
+		return 0
+	fi
+	# Claude Code interactive session: sets CLAUDE_SESSION_ID or CLAUDE_CODE.
+	if [[ -n "${CLAUDE_SESSION_ID:-}" ]] || [[ "${CLAUDE_CODE:-}" == "1" ]]; then
+		echo "interactive"
+		return 0
+	fi
 	# No TTY = non-interactive (headless dispatch, cron, pipe)
+	# NOTE: This fallback is unreliable for AI coding tools (OpenCode, Claude Code)
+	# which run bash tools without a TTY even in interactive sessions.
+	# The runtime-specific checks above must cover all supported runtimes.
 	if [[ ! -t 0 ]] && [[ ! -t 1 ]]; then
 		echo "worker"
 		return 0


### PR DESCRIPTION
## Problem

`detect_session_origin()` in `shared-constants.sh` used TTY presence as the fallback for interactive detection:

```bash
if [[ ! -t 0 ]] && [[ ! -t 1 ]]; then
    echo "worker"
fi
```

OpenCode and Claude Code run bash tools **without a TTY** even in interactive user sessions. So every interactive session was misclassified as `worker`, causing:
- PRs created with `gh_create_pr` to get `origin:worker` instead of `origin:interactive`
- The pulse auto-close protection (PR #18334) and gate bypass (PR #18334) to never trigger
- The implied-approval mechanism to be effectively dead

Verified in a live OpenCode session: `stdin isatty: False`, `stdout isatty: False`, no headless env vars set.

## Fix

### `shared-constants.sh` — runtime-specific checks before TTY fallback

```bash
# OpenCode interactive session
if [[ "${OPENCODE:-}" == "1" ]] || [[ -n "${OPENCODE_PID:-}" ]]; then
    echo "interactive"; return 0
fi
# Claude Code interactive session  
if [[ -n "${CLAUDE_SESSION_ID:-}" ]] || [[ "${CLAUDE_CODE:-}" == "1" ]]; then
    echo "interactive"; return 0
fi
```

`OPENCODE=1` and `OPENCODE_PID` are set by OpenCode in all interactive sessions (confirmed via `env` in live session). `OPENCODE_HEADLESS=true` (checked earlier in the function) is set by `headless-runtime-helper.sh` for worker dispatch — its absence means user session.

### `build.txt` — mandatory wrapper rule

Adds an explicit rule: always use `gh_create_pr` / `gh_create_issue` wrappers, never raw `gh pr create`. The wrappers call `session_origin_label()` and append the correct label automatically.

## Verification

```bash
# In an OpenCode session (OPENCODE=1 set):
source ~/.aidevops/agents/scripts/shared-constants.sh
detect_session_origin  # should print: interactive
session_origin_label   # should print: origin:interactive
```

Resolves #18285

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.241 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 5h 51m and 9,936 tokens on this as a headless worker.