### PR TITLE
GH#18344: fix model definitions — image modality, names, attachments

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -76,10 +76,9 @@ function registerAnthropicModels(config) {
   if (!config.provider.anthropic.models) config.provider.anthropic.models = {};
   for (const [id, def] of Object.entries(ANTHROPIC_MODELS)) {
     const existing = config.provider.anthropic.models[id];
-    if (!existing || existing.name !== def.name) {
-      config.provider.anthropic.models[id] = { ...existing, ...def };
-      count++;
-    }
+    // Always merge — ensures stale fields (modalities, attachment) get updated
+    config.provider.anthropic.models[id] = { ...existing, ...def };
+    if (!existing) count++;
   }
 
   // claudecli provider — via Claude CLI proxy
@@ -89,14 +88,16 @@ function registerAnthropicModels(config) {
       npm: "@ai-sdk/openai-compatible",
       api: "http://127.0.0.1:32125/v1",
     };
+  } else if (config.provider.claudecli.name === "Claude CLI (coming soon)") {
+    // Migrate legacy provider name
+    config.provider.claudecli.name = "Claude CLI";
   }
   if (!config.provider.claudecli.models) config.provider.claudecli.models = {};
   for (const [id, def] of Object.entries(CLAUDECLI_MODELS)) {
     const existing = config.provider.claudecli.models[id];
-    if (!existing || existing.name !== def.name) {
-      config.provider.claudecli.models[id] = { ...existing, ...def };
-      count++;
-    }
+    // Always merge — ensures stale fields (modalities, attachment) get updated
+    config.provider.claudecli.models[id] = { ...existing, ...def };
+    if (!existing) count++;
   }
 
   return count;

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -19,11 +19,11 @@ import { checkOpenCodeVersionDrift } from "./version-tracking.mjs";
  */
 function claudeModelDef(overrides) {
   return {
-    attachment: false,
+    attachment: true,
     tool_call: false,
     temperature: true,
     reasoning: true,
-    modalities: { input: ["text"], output: ["text"] },
+    modalities: { input: ["text", "image"], output: ["text"] },
     cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
     ...overrides,
   };
@@ -34,36 +34,30 @@ const ANTHROPIC_MODELS = {
   "claude-haiku-4-5": claudeModelDef({
     name: "Claude Haiku 4.5 (via aidevops)",
     limit: { context: 200000, output: 32000 },
-    family: "claudecli",
   }),
   "claude-sonnet-4-6": claudeModelDef({
     name: "Claude Sonnet 4.6 (via aidevops)",
     limit: { context: 200000, output: 32000 },
-    family: "claudecli",
   }),
   "claude-opus-4-6": claudeModelDef({
     name: "Claude Opus 4.6 (via aidevops)",
     limit: { context: 200000, output: 64000 },
-    family: "claudecli",
   }),
 };
 
-/** Models registered under the claudecli provider (via Claude CLI binary — coming soon). */
+/** Models registered under the claudecli provider (via Claude CLI proxy). */
 const CLAUDECLI_MODELS = {
   "claude-haiku-4-5": claudeModelDef({
-    name: "Claude Haiku 4.5 (via Claude CLI — coming soon)",
+    name: "Claude Haiku 4.5 (via CLI)",
     limit: { context: 200000, output: 32000 },
-    family: "claudecli",
   }),
   "claude-sonnet-4-6": claudeModelDef({
-    name: "Claude Sonnet 4.6 (via Claude CLI — coming soon)",
+    name: "Claude Sonnet 4.6 (via CLI)",
     limit: { context: 200000, output: 32000 },
-    family: "claudecli",
   }),
   "claude-opus-4-6": claudeModelDef({
-    name: "Claude Opus 4.6 (via Claude CLI — coming soon)",
+    name: "Claude Opus 4.6 (via CLI)",
     limit: { context: 200000, output: 64000 },
-    family: "claudecli",
   }),
 };
 
@@ -88,10 +82,10 @@ function registerAnthropicModels(config) {
     }
   }
 
-  // claudecli provider — via Claude CLI binary (coming soon)
+  // claudecli provider — via Claude CLI proxy
   if (!config.provider.claudecli) {
     config.provider.claudecli = {
-      name: "Claude CLI (coming soon)",
+      name: "Claude CLI",
       npm: "@ai-sdk/openai-compatible",
       api: "http://127.0.0.1:32125/v1",
     };


### PR DESCRIPTION
## Summary

- Fixes image paste blocked in OpenCode by adding `"image"` to model input modalities
- Shortens verbose claudecli model names (`"via CLI"` instead of `"via Claude CLI — coming soon"`)
- Enables `attachment: true` for file/image paste support
- Removes stale "coming soon" labels

Resolves #18344

## Changes

Single file: `.agents/plugins/opencode-aidevops/config-hook.mjs`

| Field | Before | After |
|-------|--------|-------|
| `modalities.input` | `["text"]` | `["text", "image"]` |
| `attachment` | `false` | `true` |
| claudecli model names | `"Claude Opus 4.6 (via Claude CLI — coming soon)"` | `"Claude Opus 4.6 (via CLI)"` |
| Provider name | `"Claude CLI (coming soon)"` | `"Claude CLI"` |

## Follow-up

Map OpenCode reasoning level to Claude CLI `--effort` flag in `claude-proxy.mjs` (depends on PR #18343).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude models now support multimodal input, including images and attachments for richer interactions.

* **Updates**
  * Claude CLI provider updated from "coming soon" status to reflect current availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->