### PR TITLE
t1960: enable 1M context window for Claude models in opencode-aidevops plugin

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -299,28 +299,31 @@ function isClaudeCliAvailable() {
   }
 }
 
+// Model limits mirror config-hook.mjs CLAUDECLI_MODELS. 1M context requires
+// the `context-1m-2025-08-07` beta header (provider-auth.mjs REQUIRED_BETAS).
+// Sonnet/Opus support 64K output; Haiku caps at 32K.
 function getClaudeProxyModels() {
   return [
     {
       id: "claude-haiku-4-5",
       name: "Claude Haiku 4.5 (via Claude CLI)",
       reasoning: true,
-      contextWindow: 200000,
+      contextWindow: 1000000,
       maxTokens: 32000,
     },
     {
       id: "claude-sonnet-4-6",
       name: "Claude Sonnet 4.6 (via Claude CLI)",
       reasoning: true,
-      contextWindow: 200000,
+      contextWindow: 1000000,
       maxTokens: 64000,
     },
     {
       id: "claude-opus-4-6",
       name: "Claude Opus 4.6 (via Claude CLI)",
       reasoning: true,
-      contextWindow: 200000,
-      maxTokens: 32000,
+      contextWindow: 1000000,
+      maxTokens: 64000,
     },
   ];
 }

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -30,19 +30,27 @@ function claudeModelDef(overrides) {
   };
 }
 
+// Context window and output token limits. 1M context requires the
+// `context-1m-2025-08-07` beta header — injected automatically by
+// provider-auth.mjs REQUIRED_BETAS. Sonnet/Opus cap output at 64K;
+// Haiku caps output at 32K.
+const CONTEXT_1M = 1000000;
+const OUTPUT_64K = 64000;
+const OUTPUT_32K = 32000;
+
 /** Models registered under the built-in anthropic provider (via aidevops OAuth pool). */
 const ANTHROPIC_MODELS = {
   "claude-haiku-4-5": claudeModelDef({
     name: "Claude Haiku 4.5 (via aidevops)",
-    limit: { context: 200000, output: 32000 },
+    limit: { context: CONTEXT_1M, output: OUTPUT_32K },
   }),
   "claude-sonnet-4-6": claudeModelDef({
     name: "Claude Sonnet 4.6 (via aidevops)",
-    limit: { context: 200000, output: 32000 },
+    limit: { context: CONTEXT_1M, output: OUTPUT_64K },
   }),
   "claude-opus-4-6": claudeModelDef({
     name: "Claude Opus 4.6 (via aidevops)",
-    limit: { context: 200000, output: 64000 },
+    limit: { context: CONTEXT_1M, output: OUTPUT_64K },
   }),
 };
 
@@ -50,15 +58,15 @@ const ANTHROPIC_MODELS = {
 const CLAUDECLI_MODELS = {
   "claude-haiku-4-5": claudeModelDef({
     name: "Claude Haiku 4.5 (via CLI)",
-    limit: { context: 200000, output: 32000 },
+    limit: { context: CONTEXT_1M, output: OUTPUT_32K },
   }),
   "claude-sonnet-4-6": claudeModelDef({
     name: "Claude Sonnet 4.6 (via CLI)",
-    limit: { context: 200000, output: 32000 },
+    limit: { context: CONTEXT_1M, output: OUTPUT_64K },
   }),
   "claude-opus-4-6": claudeModelDef({
     name: "Claude Opus 4.6 (via CLI)",
-    limit: { context: 200000, output: 64000 },
+    limit: { context: CONTEXT_1M, output: OUTPUT_64K },
   }),
 };
 

--- a/.agents/plugins/opencode-aidevops/provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth.mjs
@@ -365,6 +365,12 @@ const REQUIRED_BETAS = [
   "oauth-2025-04-20",
   "interleaved-thinking-2025-05-14",
   "context-management-2025-06-27",
+  // context-1m-2025-08-07 unlocks the 1M token context window for Claude Haiku 4.5,
+  // Sonnet 4.6, and Opus 4.6. Paired with limit.context: 1000000 in config-hook.mjs
+  // so OpenCode's auto-compaction trigger moves from ~160K to ~800K (80% of window).
+  // Pricing above 200K tokens shifts to the higher 1M tier (~2x input, ~1.5x output)
+  // — absorbed by OAuth subscription accounts, real cost on pay-as-you-go API keys.
+  "context-1m-2025-08-07",
   "prompt-caching-scope-2026-01-05",
   "claude-code-20250219",
 ];


### PR DESCRIPTION
## Summary

Enable 1M context window for all three Claude models routed through the opencode-aidevops plugin. Adds the context-1m-2025-08-07 beta header, bumps limit.context to 1000000 in both provider definitions, and syncs the claude-proxy.mjs drift copy. Also fixes stale Sonnet/Opus output token caps.

## Files Changed

.agents/plugins/opencode-aidevops/claude-proxy.mjs,.agents/plugins/opencode-aidevops/config-hook.mjs,.agents/plugins/opencode-aidevops/provider-auth.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check on all three edited files (clean), node import of config-hook.mjs (loads clean), grep verification of acceptance criteria (all 4 pass), diff review (only intended changes), linters-local.sh (pre-existing violations in unrelated shell/python files only — no new violations in edited plugin files)

Resolves #18349


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.0 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 18m and 28,823 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Claude model configurations with larger context windows (up to 1M tokens) and increased output token limits for improved processing capacity and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->