### PR TITLE
GH#18352: skip pulse dispatch for interactive-session issues

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -104,6 +104,8 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 **`origin:interactive` implies maintainer approval**: PRs tagged `origin:interactive` pass the maintainer gate automatically when the PR author is `OWNER` or `MEMBER` — the maintainer was present and directing the work. No separate `sudo aidevops approve` is needed. Contributors (`COLLABORATOR`) with `origin:interactive` still go through the normal gate — the label alone is not sufficient. The pulse also never auto-closes `origin:interactive` PRs via the deterministic merge pass, even if the task ID appears in recent commits (incremental work on the same issue is legitimate).
 
+**`origin:interactive` also skips pulse dispatch (GH#18352)**: When an issue carries `origin:interactive` AND has any human assignee, the pulse's deterministic dedup guard (`dispatch-dedup-helper.sh is-assigned`) treats the assignee as blocking — even if that assignee is the repo owner or maintainer, and regardless of the current `status:*` label. This closes the race where an interactive session claimed a task via `claim-task-id.sh` (applying `status:claimed` + owner assignment) and the pulse dispatched a duplicate worker before the session could open its PR. The full active lifecycle is now recognised: `status:queued`, `status:in-progress`, `status:in-review`, and `status:claimed` all keep owner/maintainer assignees in the blocking set.
+
 Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`. Every completed task must link to its verification evidence — work without an audit trail is unverifiable and may be reverted.
 
 Planning files go direct to main. Code changes need worktree + PR. Workers NEVER edit TODO.md.

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -610,15 +610,23 @@ _This recovery prevents the orphaned-assignment deadlock where offline runners p
 #
 # Systemic rule:
 # - self_login never blocks
-# - owner/maintainer assignees are passive unless the issue has an active
-#   claim status label (status:queued or status:in-progress)
+# - owner/maintainer assignees are passive unless EITHER:
+#     (a) the issue has an active claim status label — status:queued,
+#         status:in-progress, status:in-review, or status:claimed
+#         (full active lifecycle, not just the worker-set states), OR
+#     (b) the issue has the origin:interactive label — a human session
+#         is actively driving the work regardless of status label state
+#         (GH#18352 — closes the race where an interactive claim used
+#         status:claimed, which was not recognised as an active state,
+#         so the pulse dispatched a duplicate worker mid-flight)
 # - any other assignee blocks dispatch — UNLESS the assignment is stale
 #   (no active worker, dispatch claim >1h old, no recent progress).
 #   Stale assignments are auto-recovered (GH#15060).
 #
 # This preserves GH#10521 (maintainer assignment alone must not starve the
 # queue) while still protecting GH#11141 (owner-assigned queued work must
-# block other runners once a real claim is active).
+# block other runners once a real claim is active) and GH#18352 (interactive
+# sessions working on owner-assigned issues must not be raced by the pulse).
 #
 # Args:
 #   $1 = issue number
@@ -661,11 +669,22 @@ is_assigned() {
 		return 1
 	fi
 
-	local repo_owner repo_maintainer has_active_status
+	local repo_owner repo_maintainer has_active_status has_origin_interactive
 	repo_owner=$(_get_repo_owner "$repo_slug")
 	repo_maintainer=$(_get_repo_maintainer "$repo_slug")
-	has_active_status=$(printf '%s' "$issue_meta_json" | jq -r '([.labels[].name] | (index("status:queued") != null or index("status:in-progress") != null))' 2>/dev/null)
+	# GH#18352: recognise the full active lifecycle — status:claimed (set by
+	# claim-task-id.sh for interactive sessions) and status:in-review (set
+	# when a PR is opened) are active states just like queued/in-progress.
+	# Previously the check was limited to queued/in-progress, which let the
+	# pulse dispatch a worker against a status:claimed interactive task.
+	has_active_status=$(printf '%s' "$issue_meta_json" | jq -r '([.labels[].name] | (index("status:queued") != null or index("status:in-progress") != null or index("status:in-review") != null or index("status:claimed") != null))' 2>/dev/null)
 	[[ "$has_active_status" == "true" || "$has_active_status" == "false" ]] || has_active_status="false"
+	# GH#18352: origin:interactive is a strong "a human session owns this
+	# work" signal — treat any human assignee (owner included) as actively
+	# claimed regardless of status label state. Prevents the pulse from
+	# racing an in-flight interactive session.
+	has_origin_interactive=$(printf '%s' "$issue_meta_json" | jq -r '([.labels[].name] | index("origin:interactive") != null)' 2>/dev/null)
+	[[ "$has_origin_interactive" == "true" || "$has_origin_interactive" == "false" ]] || has_origin_interactive="false"
 
 	local -a assignee_array=()
 	local saved_ifs="${IFS:-}"
@@ -680,7 +699,10 @@ is_assigned() {
 		fi
 
 		if [[ "$assignee" == "$repo_owner" || (-n "$repo_maintainer" && "$assignee" == "$repo_maintainer") ]]; then
-			if [[ "$has_active_status" != "true" ]]; then
+			# Owner/maintainer is passive UNLESS an active status label is
+			# present OR origin:interactive signals a live human session
+			# (GH#18352).
+			if [[ "$has_active_status" != "true" && "$has_origin_interactive" != "true" ]]; then
 				continue
 			fi
 		fi

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
@@ -81,11 +81,19 @@ teardown_test_env() {
 }
 
 # Create a gh stub that returns specific issue metadata for a given issue.
+#
+# The stub also serves a recent-activity comment for `gh api .../comments`
+# so that _is_stale_assignment() in dispatch-dedup-helper.sh returns
+# "not stale" (exit 1). Without this, the stale recovery path fires in
+# the test environment (empty comments → no activity → treated as stale
+# → block → recover → allow dispatch), causing all "blocks dispatch"
+# assertions to flip. The recent-activity timestamp is generated fresh
+# at stub creation time to guarantee it's under the 10-minute threshold.
 create_gh_stub() {
 	local assignees_csv="$1"
 	local labels_csv="${2:-}"
 	local state="${3:-OPEN}"
-	local assignees_json labels_json
+	local assignees_json labels_json recent_ts
 
 	assignees_json=$(
 		ASSIGNEES_CSV="$assignees_csv" python3 - <<'PY'
@@ -104,6 +112,10 @@ print(json.dumps([{"name": item} for item in items]))
 PY
 	)
 
+	# Fresh UTC timestamp so the synthetic comment is always "recent"
+	# regardless of when the test runs.
+	recent_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
 	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
 #!/usr/bin/env bash
 set -euo pipefail
@@ -113,7 +125,24 @@ if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
 	exit 0
 fi
 
-printf 'unsupported gh invocation in test stub\n' >&2
+# Stale-assignment recovery calls: gh api repos/<slug>/issues/<num>/comments --jq '...'
+# Return a single recent "Dispatching worker" comment so the helper's
+# _is_stale_assignment() sees active work and does NOT recover the
+# assignment. The --jq filter is applied by the real gh client, but the
+# helper's own subsequent jq calls work on this array directly.
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -q '/comments'; then
+	printf '%s\n' '[{"created_at":"${recent_ts}","author":"runner1","body_start":"Dispatching worker (PID 12345)"}]'
+	exit 0
+fi
+
+# gh issue edit / gh issue comment — used by _recover_stale_assignment in
+# the unlikely event a test trips it. Succeed silently so the recovery is
+# idempotent and doesn't break the test run.
+if [[ "\${1:-}" == "issue" && ("\${2:-}" == "edit" || "\${2:-}" == "comment") ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation in test stub: %s\n' "\$*" >&2
 exit 1
 GHEOF
 
@@ -294,6 +323,114 @@ test_maintainer_assigned_with_active_status_blocks() {
 	return 0
 }
 
+# GH#18352: owner + status:claimed blocks dispatch.
+# Regression guard for the exact race that produced #18352: an interactive
+# session claimed a task via claim-task-id.sh, which applied status:claimed
+# + owner assignment. The old code only treated queued/in-progress as active,
+# so the owner-passive exemption fired and the pulse raced the interactive
+# session with a duplicate worker.
+test_owner_assigned_with_status_claimed_blocks() {
+	create_gh_stub "marcusquinn" "status:claimed"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'marcusquinn'*)
+			print_result "owner + status:claimed blocks dispatch (GH#18352)" 0
+			return 0
+			;;
+		esac
+		print_result "owner + status:claimed blocks dispatch (GH#18352)" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "owner + status:claimed blocks dispatch (GH#18352)" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+# GH#18352: owner + status:in-review blocks dispatch.
+# Once an interactive session opens a PR, the issue transitions to in-review.
+# The pulse must not dispatch a duplicate worker against an in-review issue
+# owned by the maintainer.
+test_owner_assigned_with_status_in_review_blocks() {
+	create_gh_stub "marcusquinn" "status:in-review"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'marcusquinn'*)
+			print_result "owner + status:in-review blocks dispatch (GH#18352)" 0
+			return 0
+			;;
+		esac
+		print_result "owner + status:in-review blocks dispatch (GH#18352)" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "owner + status:in-review blocks dispatch (GH#18352)" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+# GH#18352: owner + origin:interactive blocks dispatch even without a status
+# label. origin:interactive is a strong "human session owns this" signal —
+# the pulse must never race an in-flight interactive session regardless of
+# whether the status label has caught up yet.
+test_owner_assigned_with_origin_interactive_blocks() {
+	create_gh_stub "marcusquinn" "origin:interactive,bug"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'marcusquinn'*)
+			print_result "owner + origin:interactive blocks dispatch (GH#18352)" 0
+			return 0
+			;;
+		esac
+		print_result "owner + origin:interactive blocks dispatch (GH#18352)" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "owner + origin:interactive blocks dispatch (GH#18352)" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+# GH#18352: maintainer + origin:interactive blocks dispatch.
+# Same rule as owner — origin:interactive overrides the passive exemption.
+test_maintainer_assigned_with_origin_interactive_blocks() {
+	create_gh_stub "marcusquinn-bot" "origin:interactive"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'marcusquinn-bot'*)
+			print_result "maintainer + origin:interactive blocks dispatch (GH#18352)" 0
+			return 0
+			;;
+		esac
+		print_result "maintainer + origin:interactive blocks dispatch (GH#18352)" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "maintainer + origin:interactive blocks dispatch (GH#18352)" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
+# Regression: the original owner-passive exemption must still work when
+# neither an active status label nor origin:interactive is present.
+# A bare owner-assignment from auto-triage workflows must not block dispatch
+# (this preserves the GH#10521 queue-starvation fix).
+test_owner_assigned_no_status_no_origin_allows_dispatch() {
+	create_gh_stub "marcusquinn" "bug"
+
+	if "$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 >/dev/null 2>&1; then
+		print_result "owner + no active status + no origin:interactive allows dispatch (GH#10521 regression)" 1 "Expected exit 1 (safe) but got exit 0 (blocked)"
+		return 0
+	fi
+
+	print_result "owner + no active status + no origin:interactive allows dispatch (GH#10521 regression)" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -309,6 +446,11 @@ main() {
 	test_no_self_login_owner_assigned
 	test_owner_assigned_with_active_status_blocks
 	test_maintainer_assigned_with_active_status_blocks
+	test_owner_assigned_with_status_claimed_blocks
+	test_owner_assigned_with_status_in_review_blocks
+	test_owner_assigned_with_origin_interactive_blocks
+	test_maintainer_assigned_with_origin_interactive_blocks
+	test_owner_assigned_no_status_no_origin_allows_dispatch
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -234,12 +234,15 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **`persistent` label** → NEVER close. CI guard auto-reopens accidental closures.
 - **Has merged PR** → comment linking PR, then close.
 - **`status:blocked` but blockers resolved** → remove label, add `status:available`, comment.
-- **`status:queued`/`status:in-progress`** → if updated within 3h, skip. If 3+ hours with no PR/worker, relabel `status:available`, unassign, comment recovery.
+- **`status:queued`/`status:in-progress`/`status:in-review`/`status:claimed`** → if updated within 3h, skip. If 3+ hours with no PR/worker, relabel `status:available`, unassign, comment recovery.
+- **`origin:interactive` + human assignee** → NEVER dispatch. An active interactive session owns this work; dispatching would race the user's in-flight PR. Skip silently regardless of status label state (GH#18352).
 - **`needs-maintainer-review`** → dispatch triage review worker (step 3.5), NOT implementation worker.
 - **`status:needs-info`** → check pre-fetched reply status (step 4.5).
 - **`status:available` or no status** → dispatch implementation worker.
 
 NEVER dispatch a worker for an issue with `needs-maintainer-review`. NEVER attempt to remove this label, comment on these issues, or bypass the gate. Approval is cryptographic (t1894) — only `sudo aidevops approve issue <number>` can unlock it. NMR issues are excluded from the LLM state file; if you encounter one, skip it.
+
+**Interactive-session protection (GH#18352):** `dispatch-dedup-helper.sh is-assigned` treats any human assignee as blocking when EITHER (a) the issue carries an active lifecycle label — `status:queued`, `status:in-progress`, `status:in-review`, or `status:claimed` — OR (b) the `origin:interactive` label is present. This is enforced in Layer 6 of `check_dispatch_dedup` and applies to owner/maintainer assignees too. Previously the owner-passive exemption only recognised `status:queued`/`status:in-progress`, so an interactive session using `claim-task-id.sh` (which applies `status:claimed`) could be raced by the pulse. Regression tested in `tests/test-dispatch-dedup-helper-is-assigned.sh`.
 
 ## Worker Management
 


### PR DESCRIPTION
## Summary

Closes the race observed on issue #18349 earlier today: the interactive session claimed the task via `claim-task-id.sh`, opened PR #18350, and the pulse dispatched a duplicate worker that merged PR #18351 mid-flight — invalidating the interactive work.

Root cause: `dispatch-dedup-helper.sh::is_assigned()` exempted owner/maintainer assignees as "passive" unless the issue had `status:queued` or `status:in-progress`. But `claim-task-id.sh` sets `status:claimed`, and `issue-sync-helper.sh` transitions to `status:in-review` when a PR opens — neither of which the exemption recognised.

## Changes

### `dispatch-dedup-helper.sh::is_assigned()`

1. **Expand `has_active_status` to the full active lifecycle** — recognise `status:queued`, `status:in-progress`, `status:in-review`, and `status:claimed` as active states. Previously limited to `queued`/`in-progress`.
2. **Add `has_origin_interactive` override** — when `origin:interactive` is present, any human assignee blocks dispatch regardless of status label. Belt-and-braces protection against label drift.

Preserves GH#10521 (bare owner assignment without active state still allows dispatch) and GH#11141 (owner + active state blocks dispatch).

### Test coverage — `test-dispatch-dedup-helper-is-assigned.sh`

- 5 new GH#18352 cases: `status:claimed`, `status:in-review`, `origin:interactive` for owner AND maintainer, and a regression guard for bare owner assignment.
- **Fixed a pre-existing test harness defect**: the `gh` stub didn't implement `gh api .../comments`, so `_is_stale_assignment()` saw empty output and recovered every blocking assignment — silently breaking the four existing "blocks dispatch" tests on main. Extended the stub to serve a fresh recent comment and stub out `gh issue edit`/`comment` idempotently.
- **All 16 tests now pass** (previously 7/11 on main; the 4 existing blocks-dispatch tests were silently green in CI only because the stale-recovery path was never exercised elsewhere, or the tests may have been running green in a different environment — either way, the harness now reflects reality).

### Docs

- `.agents/AGENTS.md` — new paragraph under "origin:interactive implies maintainer approval" documenting the dispatch-skip semantics.
- `.agents/workflows/pulse.md` — new bullet under "Issues — Dispatch or Skip" and an explanatory paragraph tying the protection back to Layer 6 of `check_dispatch_dedup`.

## Reproduction / Verification

The exact race from #18349:

1. Interactive: `claim-task-id.sh --title "..."` → creates issue with labels `bug`, `status:claimed`, `origin:interactive` and assigns `marcusquinn`.
2. Pulse cycle runs, calls `check_dispatch_dedup` → `is_assigned 18349 marcusquinn/aidevops <runner>`.
3. **Before this PR:** `has_active_status=false` (only `status:claimed` present), `marcusquinn == repo_owner`, → `continue` → `blocking_assignees` empty → return 1 (safe) → **duplicate dispatched**.
4. **After this PR:** `has_active_status=true` (status:claimed now counts) OR `has_origin_interactive=true` → owner NOT treated as passive → blocking_assignees=marcusquinn → return 0 (blocked) → **dispatch skipped**.

Covered by the new test cases — shellcheck clean, all 16 tests green.

Resolves #18352

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 45m and 92,042 tokens on this with the user in an interactive session.
