### PR TITLE
t1961: extract _has_active_claim() from is_assigned() to fix complexity ratchet

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -591,6 +591,42 @@ _This recovery prevents the orphaned-assignment deadlock where offline runners p
 }
 
 #######################################
+# Return "true" if the issue metadata represents an active claim that
+# should override the owner/maintainer passive-assignee exemption in
+# is_assigned(). An issue is actively claimed when EITHER:
+#   - a lifecycle status label is set: status:queued, status:in-progress,
+#     status:in-review, or status:claimed, OR
+#   - the origin:interactive label is present (a live human session is
+#     driving the work regardless of status label state)
+#
+# Extracted from is_assigned() to keep that function under the 100-line
+# complexity cap after GH#18352 expanded the active-claim signal set
+# (see t1961). Adding new active-state labels is a one-line change here.
+#
+# Args:
+#   $1 = issue metadata JSON from `gh issue view --json labels` (at minimum
+#        must contain a .labels array of {name: ...} objects)
+# Stdout: "true" or "false"
+#######################################
+_has_active_claim() {
+	local issue_meta_json="$1"
+	local result
+	result=$(printf '%s' "$issue_meta_json" | jq -r '
+		[.labels[].name] as $labels |
+		(
+			($labels | index("status:queued") != null) or
+			($labels | index("status:in-progress") != null) or
+			($labels | index("status:in-review") != null) or
+			($labels | index("status:claimed") != null) or
+			($labels | index("origin:interactive") != null)
+		)
+	' 2>/dev/null) || result="false"
+	[[ "$result" == "true" || "$result" == "false" ]] || result="false"
+	printf '%s' "$result"
+	return 0
+}
+
+#######################################
 # Check if a GitHub issue is already assigned to another runner.
 #
 # This is the primary cross-machine dedup guard. Process-based checks
@@ -669,22 +705,14 @@ is_assigned() {
 		return 1
 	fi
 
-	local repo_owner repo_maintainer has_active_status has_origin_interactive
+	local repo_owner repo_maintainer active_claim
 	repo_owner=$(_get_repo_owner "$repo_slug")
 	repo_maintainer=$(_get_repo_maintainer "$repo_slug")
-	# GH#18352: recognise the full active lifecycle — status:claimed (set by
-	# claim-task-id.sh for interactive sessions) and status:in-review (set
-	# when a PR is opened) are active states just like queued/in-progress.
-	# Previously the check was limited to queued/in-progress, which let the
-	# pulse dispatch a worker against a status:claimed interactive task.
-	has_active_status=$(printf '%s' "$issue_meta_json" | jq -r '([.labels[].name] | (index("status:queued") != null or index("status:in-progress") != null or index("status:in-review") != null or index("status:claimed") != null))' 2>/dev/null)
-	[[ "$has_active_status" == "true" || "$has_active_status" == "false" ]] || has_active_status="false"
-	# GH#18352: origin:interactive is a strong "a human session owns this
-	# work" signal — treat any human assignee (owner included) as actively
-	# claimed regardless of status label state. Prevents the pulse from
-	# racing an in-flight interactive session.
-	has_origin_interactive=$(printf '%s' "$issue_meta_json" | jq -r '([.labels[].name] | index("origin:interactive") != null)' 2>/dev/null)
-	[[ "$has_origin_interactive" == "true" || "$has_origin_interactive" == "false" ]] || has_origin_interactive="false"
+	# GH#18352 / t1961: owner/maintainer assignees are passive unless
+	# _has_active_claim() reports an active lifecycle label (queued,
+	# in-progress, in-review, claimed) or origin:interactive is present.
+	# See _has_active_claim() above for the full rule set.
+	active_claim=$(_has_active_claim "$issue_meta_json")
 
 	local -a assignee_array=()
 	local saved_ifs="${IFS:-}"
@@ -699,10 +727,9 @@ is_assigned() {
 		fi
 
 		if [[ "$assignee" == "$repo_owner" || (-n "$repo_maintainer" && "$assignee" == "$repo_maintainer") ]]; then
-			# Owner/maintainer is passive UNLESS an active status label is
-			# present OR origin:interactive signals a live human session
-			# (GH#18352).
-			if [[ "$has_active_status" != "true" && "$has_origin_interactive" != "true" ]]; then
+			# Owner/maintainer is passive UNLESS _has_active_claim returned
+			# "true" (GH#18352 / t1961).
+			if [[ "$active_claim" != "true" ]]; then
 				continue
 			fi
 		fi


### PR DESCRIPTION
## Summary

Follow-up to #18353 — mechanical extract-method refactor to drop `is_assigned()` from 101 lines to 93 lines, restoring `func` violations from 41 to 40 (at threshold). Closes the CI-broken state left on `main` when #18353 was merged with the Complexity Analysis check failing.

## Root cause

#18353 shipped the GH#18352 fix that expanded the active-claim signal set inside `is_assigned()` — adding `status:claimed`, `status:in-review`, and `origin:interactive` alongside the existing `status:queued`/`status:in-progress` checks. Each signal added was a new inline `jq` block plus a `true`/`false` sanitisation line, and the owner/maintainer exemption had to check both locals in a compound condition. Result: 101 lines — one over the 100-line function size cap that feeds the `func` metric in `complexity-scan-helper.sh ratchet-check`. Pushing past the cap took `func` violations from 40 to 41 against a threshold of 40, breaking Complexity Analysis on every subsequent PR until resolved.

## Fix

Extract the five-label lookup into a new private helper `_has_active_claim()`:

```bash
_has_active_claim() {
    local issue_meta_json="$1"
    local result
    result=$(printf '%s' "$issue_meta_json" | jq -r '
        [.labels[].name] as $labels |
        (
            ($labels | index("status:queued") != null) or
            ($labels | index("status:in-progress") != null) or
            ($labels | index("status:in-review") != null) or
            ($labels | index("status:claimed") != null) or
            ($labels | index("origin:interactive") != null)
        )
    ' 2>/dev/null) || result="false"
    [[ "$result" == "true" || "$result" == "false" ]] || result="false"
    printf '%s' "$result"
    return 0
}
```

`is_assigned()` now calls it once and stores the result in a single `active_claim` variable. The owner/maintainer exemption check collapses from:

```bash
if [[ "$has_active_status" != "true" && "$has_origin_interactive" != "true" ]]; then
```

to:

```bash
if [[ "$active_claim" != "true" ]]; then
```

Adding new active-state labels in the future is now a one-line change inside `_has_active_claim()` instead of a new jq block + sanitisation + compound condition update.

## Behaviour change

None. The refactor is byte-for-byte equivalent to the previous inline logic:

- `status:queued`, `status:in-progress`, `status:in-review`, `status:claimed` all still trigger the owner/maintainer blocking path.
- `origin:interactive` still acts as an independent strong signal.
- Self-login, stale-assignment recovery, and the blocking-assignees fallback loop are untouched.

## Verification

Local run in the worktree:

```text
shellcheck .agents/scripts/dispatch-dedup-helper.sh
  (clean)

bash .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
  Ran 16 tests, 0 failed.

complexity-scan-helper.sh ratchet-check
  Actual violations — func:40 nest:247 size:54 bash32:71
  Current thresholds — func:40 nest:249 size:56 bash32:72
```

All 16 `is_assigned()` tests pass, including:
- GH#10521 regression guards (owner/maintainer alone does NOT block)
- GH#11141 regression guards (owner + `status:queued`/`in-progress` blocks)
- GH#18352 cases (owner + `status:claimed`/`in-review`/`origin:interactive` blocks)

## Measurements

| Metric | Before | After |
|--------|--------|-------|
| `is_assigned()` line count | 101 | 93 |
| `func` violations | 41 | 40 |
| CI Complexity Analysis | FAILURE | expected SUCCESS |

## Notes

- The `_has_active_claim()` helper is private (underscore-prefixed), consistent with the other `_get_repo_owner`, `_get_repo_maintainer`, `_is_stale_assignment`, `_recover_stale_assignment` helpers in the same file.
- No test harness changes needed — the existing 16-case harness already exercises all five active-claim labels plus the owner/maintainer negative case.

Resolves #18354
Ref #18352

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 58m and 6,931 tokens on this with the user in an interactive session. Overall, 2m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal issue assignment and dispatch logic by consolidating active claim detection into a dedicated helper function. Improved code maintainability and updated assignment validation rules to more accurately determine when assignees are considered actively engaged, ensuring consistent behavior across the issue management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->