### PR TITLE
t1964: fix init-routines metric pollution on bare invocation

### DIFF
--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -746,7 +746,21 @@ _create_core_routine_issues() {
 		local human_schedule
 		human_schedule=$(_humanise_schedule "$schedule" "$tz_name")
 
-		print_info "Creating issue for ${rid}: ${short_title}..."
+		# Detect whether this routine already has a tracking state file. If it
+		# does, we must NOT fire the initial `update --status success` body-
+		# rebuild trigger, because that call appends a fake run entry, bumps
+		# streak counters, and drags avg_duration toward zero. The
+		# `create-issue` call itself is already idempotent (see t1964).
+		local state_file="${HOME}/.aidevops/.agent-workspace/cron/${rid}/routine-state.json"
+		local preexisting_state=false
+		[[ -f "$state_file" ]] && preexisting_state=true
+
+		if [[ "$preexisting_state" == true ]]; then
+			print_info "Tracking issue for ${rid}: ${short_title} already exists — refreshing description only"
+		else
+			print_info "Creating tracking issue for ${rid}: ${short_title}..."
+		fi
+
 		local issue_num
 		issue_num=$(bash "$log_helper" create-issue "$rid" \
 			--repo "$slug" \
@@ -759,8 +773,12 @@ _create_core_routine_issues() {
 			gh issue edit "$issue_num" --repo "$slug" --add-label "routine-tracking" 2>/dev/null || true
 			# Store description in state so _build_issue_body includes it
 			_store_routine_description "$rid" "$short_title" "$human_schedule" "$script" "$rtype"
-			# Trigger a body rebuild to include the description
-			bash "$log_helper" update "$rid" --status success --duration 0 2>/dev/null || true
+			# Only fire the initial body-rebuild on fresh init — otherwise we
+			# append a fake success/duration=0 entry to every core routine on
+			# every invocation, polluting streak and avg_duration metrics (t1964).
+			if [[ "$preexisting_state" != true ]]; then
+				bash "$log_helper" update "$rid" --status success --duration 0 2>/dev/null || true
+			fi
 		fi
 	done < <(get_core_routine_entries)
 


### PR DESCRIPTION
## Summary

- Skip the per-routine `routine-log-helper.sh update --status success --duration 0` trigger when the routine already has tracking state. The call was unconditional and appended fake success entries to every core routine on every `init-routines-helper.sh` invocation.
- Correct the output messages so they report \"Creating tracking issue\" (new) vs \"already exists — refreshing description only\" (existing), rather than always claiming to create.

## Why

Every invocation of `init-routines-helper.sh` (including `aidevops init-routines` and `setup.sh` re-runs) polluted r901–r912 metrics: incrementing `streak_count`, updating `last_run`/`last_status`/`last_duration`, dragging `avg_duration` toward zero. Observed: a single exploratory call bumped r906 `streak_count` to 4.

The `create-issue` call in `routine-log-helper.sh` was already idempotent (line 873: returns early when state exists). Only the `update` call was the source of pollution.

## Verification

```
BEFORE: streak=4 last_run=2026-04-12T15:51:32Z
AFTER:  streak=4 last_run=2026-04-12T15:51:32Z
PASS: state unchanged
```

All 12 core routines now correctly report \"already exists — refreshing description only\" on repeat runs.

- `shellcheck .agents/scripts/init-routines-helper.sh` — clean
- `setup.sh` path unaffected: it sources the helper and calls `detect_and_create_all` directly, so the fix applies to both the interactive CLI path and setup re-runs.

Resolves #18358

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 32m and 4,948 tokens on this with the user in an interactive session. Overall, 3m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated initialization script to detect and properly handle existing routine configurations, skipping redundant operations when refreshing existing routines. Enhanced status messages to clarify whether a tracking issue is being created or refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->