### PR TITLE
t1965: add git pre-push privacy guard for private slug leaks

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -260,6 +260,8 @@ Advisories delivered via `aidevops update`; shown in session greeting until dism
 
 **Cross-repo privacy:** NEVER include private repo names in TODO.md task descriptions, issue titles, or comments on public repos. Use generic references like "a managed private repo" or "cross-repo project". The issue-sync-helper.sh has automated sanitization, but prevention at the source is the primary defense.
 
+**Client-side privacy guard (t1965):** A git `pre-push` hook at `.agents/hooks/privacy-guard-pre-push.sh` blocks pushes to public GitHub repos that contain private repo slugs (from `repos.json`) in `TODO.md`, `todo/**`, `README.md`, or `.github/ISSUE_TEMPLATE/**`. Install per-repo with `.agents/scripts/install-privacy-guard.sh install`. Status/uninstall: same script, `status`/`uninstall`. Private slugs are enumerated from `initialized_repos[]` entries with `mirror_upstream` or `local_only: true`, plus optional extras in `~/.aidevops/configs/privacy-guard-extra-slugs.txt` (one per line). Bypass for legitimate cases: `PRIVACY_GUARD_DISABLE=1 git push ...` or `git push --no-verify`. Fail-open on offline/unauthenticated `gh` (the rule still holds, it's just not enforced client-side in that case — server-side `issue-sync-helper.sh` sanitisation is the second line). Test harness: `.agents/scripts/test-privacy-guard.sh`.
+
 ## Working Directories
 
 Tree: `prompts/build.txt`. Agent tiers:

--- a/.agents/hooks/privacy-guard-pre-push.sh
+++ b/.agents/hooks/privacy-guard-pre-push.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# privacy-guard-pre-push.sh — git pre-push hook.
+#
+# Blocks a push to a public GitHub repo if the push diff introduces any
+# private repo slug (from ~/.config/aidevops/repos.json) into TODO.md,
+# todo/**, README.md, or .github/ISSUE_TEMPLATE/** content.
+#
+# Install: see .agents/scripts/install-privacy-guard.sh
+#
+# Git pre-push protocol:
+#   $1 = remote name
+#   $2 = remote URL
+#   stdin: one line per ref being pushed:
+#     <local_ref> <local_sha> <remote_ref> <remote_sha>
+#
+# Exit 0 = allow push. Exit 1 = block push.
+#
+# Environment:
+#   PRIVACY_GUARD_DISABLE=1  — bypass for this invocation (equivalent to --no-verify)
+#   PRIVACY_GUARD_DEBUG=1    — verbose stderr trace
+#
+# Fail-open cases (exit 0 with warning):
+#   - gh CLI unavailable or unauthenticated
+#   - remote URL not parseable as github.com
+#   - repos.json missing or malformed
+
+set -u
+
+if [[ "${PRIVACY_GUARD_DISABLE:-0}" == "1" ]]; then
+	printf '[privacy-guard][INFO] PRIVACY_GUARD_DISABLE=1 — bypassing\n' >&2
+	exit 0
+fi
+
+# Locate the helper library. Resolve relative to the hook's real path so it
+# works whether installed as a symlink in .git/hooks or copied in place.
+_resolve_self() {
+	local src="${BASH_SOURCE[0]}"
+	while [[ -L "$src" ]]; do
+		local dir
+		dir=$(cd -P "$(dirname "$src")" && pwd)
+		src=$(readlink "$src")
+		[[ "$src" != /* ]] && src="$dir/$src"
+	done
+	cd -P "$(dirname "$src")" && pwd
+}
+
+HOOK_DIR=$(_resolve_self)
+HELPER_REPO="${HOOK_DIR}/../scripts/privacy-guard-helper.sh"
+HELPER_DEPLOYED="${HOME}/.aidevops/agents/scripts/privacy-guard-helper.sh"
+
+if [[ -f "$HELPER_REPO" ]]; then
+	# shellcheck source=/dev/null
+	source "$HELPER_REPO"
+elif [[ -f "$HELPER_DEPLOYED" ]]; then
+	# shellcheck source=/dev/null
+	source "$HELPER_DEPLOYED"
+else
+	printf '[privacy-guard][WARN] helper library not found — fail-open\n' >&2
+	exit 0
+fi
+
+remote_name="${1:-}"
+remote_url="${2:-}"
+
+if [[ -z "$remote_url" ]]; then
+	privacy_log WARN "pre-push called with no remote URL — fail-open"
+	exit 0
+fi
+
+# Fast path: target is private → nothing to guard
+if ! privacy_is_target_public "$remote_url"; then
+	# exit 1 = private, exit 2 = unknown — both allow the push
+	[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "target private or unknown ($remote_url) — allowing push"
+	exit 0
+fi
+
+[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "target public ($remote_url) — scanning diff"
+
+# Enumerate private slugs once for the whole push
+slugs_file=$(mktemp 2>/dev/null) || {
+	privacy_log WARN "mktemp failed — fail-open"
+	exit 0
+}
+trap 'rm -f "$slugs_file"' EXIT
+
+if ! privacy_enumerate_private_slugs "$slugs_file"; then
+	privacy_log WARN "could not enumerate private slugs — fail-open"
+	exit 0
+fi
+
+if [[ ! -s "$slugs_file" ]]; then
+	[[ "${PRIVACY_GUARD_DEBUG:-0}" == "1" ]] && privacy_log INFO "no private slugs to guard against"
+	exit 0
+fi
+
+# Walk each ref in the push
+exit_code=0
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+	[[ -z "$local_sha" ]] && continue
+	# Branch deletion (local_sha is zeros) — nothing to scan
+	if [[ "$local_sha" =~ ^0+$ ]]; then
+		continue
+	fi
+
+	hits_output=$(privacy_scan_diff "$remote_sha" "$local_sha" "$slugs_file")
+	scan_rc=$?
+	if [[ "$scan_rc" -ne 0 ]]; then
+		printf '\n[privacy-guard][BLOCK] Push to %s contains private repo slugs in planning/docs content:\n\n' "$remote_name" >&2
+		printf '%s\n\n' "$hits_output" >&2
+		printf '  Remove the private slug from the committed content and amend/rewrite the commit before pushing.\n' >&2
+		printf '  To bypass (audit trail preserves the override): PRIVACY_GUARD_DISABLE=1 git push ... or git push --no-verify\n' >&2
+		printf '  Private slug sources scanned: repos.json initialized_repos[] with mirror_upstream or local_only, plus ~/.aidevops/configs/privacy-guard-extra-slugs.txt\n\n' >&2
+		exit_code=1
+	fi
+done
+
+exit "$exit_code"

--- a/.agents/scripts/install-privacy-guard.sh
+++ b/.agents/scripts/install-privacy-guard.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# install-privacy-guard.sh — Install the privacy guard git pre-push hook
+# into the current repository.
+#
+# Usage:
+#   install-privacy-guard.sh install      Install (or chain) into .git/hooks/pre-push
+#   install-privacy-guard.sh uninstall    Remove just the privacy guard entry
+#   install-privacy-guard.sh status       Report current state
+#   install-privacy-guard.sh test         Run the shared test harness
+#
+# The installer points .git/hooks/pre-push at a small dispatcher that invokes
+# the deployed hook at ~/.aidevops/agents/hooks/privacy-guard-pre-push.sh
+# (survives aidevops updates). If a pre-existing pre-push hook is found that
+# is NOT ours, we refuse to overwrite and print remediation instructions.
+#
+# The installer targets the git COMMON dir (`git rev-parse --git-common-dir`)
+# so worktrees share the hook with the parent repo — which is what users
+# expect from a repo-wide privacy guard.
+
+set -euo pipefail
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+BLUE=$'\033[0;34m'
+NC=$'\033[0m'
+
+print_info() { printf '%s[INFO]%s %s\n' "$BLUE" "$NC" "$1"; }
+print_success() { printf '%s[OK]%s %s\n' "$GREEN" "$NC" "$1"; }
+print_warning() { printf '%s[WARN]%s %s\n' "$YELLOW" "$NC" "$1" >&2; }
+print_error() { printf '%s[ERROR]%s %s\n' "$RED" "$NC" "$1" >&2; }
+
+HOOK_MARKER="# aidevops-privacy-guard"
+DEPLOYED_HOOK="$HOME/.aidevops/agents/hooks/privacy-guard-pre-push.sh"
+
+#######################################
+# Locate the repo-local copy of the hook (for use before `aidevops update`
+# has deployed it) or fall back to the deployed location.
+#######################################
+_find_source_hook() {
+	local script_dir
+	script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+	local repo_hook="$script_dir/../hooks/privacy-guard-pre-push.sh"
+	if [[ -f "$repo_hook" ]]; then
+		echo "$repo_hook"
+		return 0
+	fi
+	if [[ -f "$DEPLOYED_HOOK" ]]; then
+		echo "$DEPLOYED_HOOK"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Resolve the git common dir (shared between worktrees).
+#######################################
+_git_common_dir() {
+	git rev-parse --git-common-dir 2>/dev/null || {
+		print_error "not a git repository"
+		return 1
+	}
+	return 0
+}
+
+#######################################
+# Install the hook. If an existing pre-push hook is found that is not ours,
+# abort with a clear message. Otherwise write a small dispatcher script.
+#######################################
+cmd_install() {
+	local common_dir
+	common_dir=$(_git_common_dir) || return 1
+
+	local hook_path="${common_dir}/hooks/pre-push"
+	mkdir -p "$(dirname "$hook_path")"
+
+	local source_hook
+	if ! source_hook=$(_find_source_hook); then
+		print_error "privacy-guard-pre-push.sh not found in repo or deployed location"
+		print_error "  checked: \$REPO/.agents/hooks/privacy-guard-pre-push.sh"
+		print_error "  checked: $DEPLOYED_HOOK"
+		return 1
+	fi
+
+	if [[ -f "$hook_path" ]]; then
+		if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
+			print_info "privacy-guard already installed at $hook_path — updating"
+		else
+			print_error "existing pre-push hook at $hook_path is NOT managed by aidevops"
+			print_error "Refusing to overwrite. To chain, manually add this line to your hook:"
+			print_error "  ${source_hook} \"\$@\" < /dev/stdin || exit \$?"
+			return 1
+		fi
+	fi
+
+	cat >"$hook_path" <<HOOKEOF
+#!/usr/bin/env bash
+$HOOK_MARKER
+# Managed by .agents/scripts/install-privacy-guard.sh — do not edit.
+# Dispatcher that calls the aidevops privacy guard. Bypass with --no-verify
+# or PRIVACY_GUARD_DISABLE=1.
+
+set -u
+
+# Prefer the repo-local hook when available, fall back to deployed.
+_repo_hook=""
+if git_dir=\$(git rev-parse --show-toplevel 2>/dev/null); then
+	_repo_hook="\${git_dir}/.agents/hooks/privacy-guard-pre-push.sh"
+fi
+_deployed_hook="$DEPLOYED_HOOK"
+
+if [[ -n "\$_repo_hook" && -f "\$_repo_hook" ]]; then
+	exec "\$_repo_hook" "\$@"
+elif [[ -f "\$_deployed_hook" ]]; then
+	exec "\$_deployed_hook" "\$@"
+else
+	printf '[privacy-guard][WARN] hook not installed — allowing push\n' >&2
+	exit 0
+fi
+HOOKEOF
+	chmod +x "$hook_path"
+	print_success "installed privacy guard at $hook_path"
+	print_info "source hook: $source_hook"
+	print_info "bypass: PRIVACY_GUARD_DISABLE=1 git push ...  (or git push --no-verify)"
+	return 0
+}
+
+#######################################
+# Remove the hook if (and only if) it is managed by us.
+#######################################
+cmd_uninstall() {
+	local common_dir
+	common_dir=$(_git_common_dir) || return 1
+	local hook_path="${common_dir}/hooks/pre-push"
+
+	if [[ ! -f "$hook_path" ]]; then
+		print_info "no pre-push hook installed"
+		return 0
+	fi
+
+	if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
+		rm -f "$hook_path"
+		print_success "removed privacy guard pre-push hook"
+		return 0
+	fi
+
+	print_warning "pre-push hook at $hook_path is NOT managed by aidevops — leaving it alone"
+	return 1
+}
+
+#######################################
+# Report current state.
+#######################################
+cmd_status() {
+	local common_dir
+	common_dir=$(_git_common_dir) || return 1
+	local hook_path="${common_dir}/hooks/pre-push"
+
+	if [[ ! -f "$hook_path" ]]; then
+		printf 'pre-push hook: NOT INSTALLED\n'
+		return 0
+	fi
+	if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
+		printf 'pre-push hook: installed (aidevops privacy guard)\n'
+		printf '  path: %s\n' "$hook_path"
+	else
+		printf 'pre-push hook: installed (unknown manager)\n'
+		printf '  path: %s\n' "$hook_path"
+	fi
+	return 0
+}
+
+#######################################
+# Run the test harness (delegates to test-privacy-guard.sh).
+#######################################
+cmd_test() {
+	local script_dir
+	script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+	local test_script="${script_dir}/test-privacy-guard.sh"
+	if [[ ! -f "$test_script" ]]; then
+		print_error "test harness not found: $test_script"
+		return 1
+	fi
+	bash "$test_script" "$@"
+	return $?
+}
+
+main() {
+	local cmd="${1:-install}"
+	shift || true
+	case "$cmd" in
+	install) cmd_install "$@" ;;
+	uninstall) cmd_uninstall "$@" ;;
+	status) cmd_status "$@" ;;
+	test) cmd_test "$@" ;;
+	help | --help | -h)
+		sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+		;;
+	*)
+		print_error "unknown command: $cmd"
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# privacy-guard-helper.sh — Shared library for the git pre-push privacy guard.
+#
+# Enumerates private repo slugs from ~/.config/aidevops/repos.json and scans
+# a git diff range for TODO.md / todo/** content that would leak a private
+# slug into a public target.
+#
+# This file is sourced by:
+#   - .agents/hooks/privacy-guard-pre-push.sh (the actual git pre-push hook)
+#   - .agents/scripts/test-privacy-guard.sh   (the test harness)
+#
+# It is NOT intended to be executed directly — it is a library. Functions
+# exit the caller via `return`, never `exit`, to preserve the hook's control
+# flow.
+#
+# Functions exported:
+#   privacy_is_target_public <remote_url>        exit 0 public, 1 private, 2 unknown
+#   privacy_enumerate_private_slugs [out_file]   writes one slug per line
+#   privacy_scan_diff <base_sha> <head_sha>      writes "file:line: slug" to stdout
+#   privacy_scan_paths                           list of path globs scanned
+#   privacy_log <level> <msg>                    tagged stderr log
+#
+# Cache: ~/.aidevops/cache/repo-privacy.json (TTL 10m)
+# Repos: ~/.config/aidevops/repos.json
+
+set -u
+# Do NOT set -e here — callers may source this file and we don't want our
+# early returns to abort their scripts unexpectedly.
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+PRIVACY_REPOS_CONFIG="${PRIVACY_REPOS_CONFIG:-$HOME/.config/aidevops/repos.json}"
+PRIVACY_CACHE_FILE="${PRIVACY_CACHE_FILE:-$HOME/.aidevops/cache/repo-privacy.json}"
+PRIVACY_CACHE_TTL="${PRIVACY_CACHE_TTL:-600}" # 10 minutes
+# Paths whose diffs we scan. Shell globs, matched against every changed file
+# in the diff range. Keep tight — this is the set of "planning-only" paths
+# that bypass the worktree-PR flow and go direct to main.
+PRIVACY_SCAN_GLOBS=(
+	"TODO.md"
+	"todo/"
+	".github/ISSUE_TEMPLATE/"
+	"README.md"
+)
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+#######################################
+# Emit a tagged log line to stderr.
+# Arguments:
+#   $1 - level (INFO/WARN/ERROR/BLOCK)
+#   $@ - message
+#######################################
+privacy_log() {
+	local level="$1"
+	shift
+	printf '[privacy-guard][%s] %s\n' "$level" "$*" >&2
+	return 0
+}
+
+# =============================================================================
+# Target-privacy lookup
+# =============================================================================
+
+#######################################
+# Given a git remote URL, parse owner/repo and ask gh whether it is public.
+# Caches positive + negative results to ~/.aidevops/cache/repo-privacy.json
+# with a 10-minute TTL to keep hook latency under 500ms on warm cache.
+# Arguments:
+#   $1 - remote URL (https://github.com/owner/repo.git or git@github.com:owner/repo.git)
+# Returns:
+#   0 if public, 1 if private, 2 if unknown (fail-open: hook allows push).
+#######################################
+privacy_is_target_public() {
+	local url="$1"
+	local slug=""
+
+	# Extract owner/repo from either SSH or HTTPS form, strip optional .git
+	if [[ "$url" =~ github\.com[:/]([^/]+/[^/]+) ]]; then
+		slug="${BASH_REMATCH[1]%.git}"
+	else
+		privacy_log WARN "Non-GitHub remote ($url) — fail-open, allowing push"
+		return 2
+	fi
+
+	# Cache hit?
+	mkdir -p "$(dirname "$PRIVACY_CACHE_FILE")" 2>/dev/null || true
+	if [[ -f "$PRIVACY_CACHE_FILE" ]]; then
+		local cached_ts cached_private now
+		cached_ts=$(jq -r --arg slug "$slug" '.[$slug].checked_at // ""' "$PRIVACY_CACHE_FILE" 2>/dev/null)
+		cached_private=$(jq -r --arg slug "$slug" '.[$slug].private // ""' "$PRIVACY_CACHE_FILE" 2>/dev/null)
+		now=$(date +%s)
+		if [[ -n "$cached_ts" && -n "$cached_private" ]]; then
+			local age=$((now - cached_ts))
+			if [[ "$age" -lt "$PRIVACY_CACHE_TTL" ]]; then
+				if [[ "$cached_private" == "false" ]]; then
+					return 0
+				else
+					return 1
+				fi
+			fi
+		fi
+	fi
+
+	# Cold probe via gh
+	if ! command -v gh >/dev/null 2>&1; then
+		privacy_log WARN "gh CLI not installed — fail-open, allowing push to $slug"
+		return 2
+	fi
+	if ! gh auth status >/dev/null 2>&1; then
+		privacy_log WARN "gh not authenticated — fail-open, allowing push to $slug"
+		return 2
+	fi
+
+	# Use `.private | tostring` — NOT `.private // "unknown"`. The `//` operator
+	# treats `false` as null-ish, so `.private // "unknown"` returns "unknown"
+	# for every public repo. `tostring` returns "true", "false", or "null".
+	local is_private
+	is_private=$(gh api "repos/${slug}" --jq '.private | tostring' 2>/dev/null) || {
+		privacy_log WARN "gh api repos/${slug} failed — fail-open"
+		return 2
+	}
+
+	case "$is_private" in
+	true)
+		_privacy_cache_write "$slug" "true"
+		return 1
+		;;
+	false)
+		_privacy_cache_write "$slug" "false"
+		return 0
+		;;
+	*)
+		privacy_log WARN "gh returned unexpected privacy value ($is_private) for $slug — fail-open"
+		return 2
+		;;
+	esac
+}
+
+#######################################
+# Write a slug -> {private, checked_at} entry to the privacy cache.
+# Arguments:
+#   $1 - slug
+#   $2 - privacy string (true|false)
+#######################################
+_privacy_cache_write() {
+	local slug="$1"
+	local private="$2"
+	local now
+	now=$(date +%s)
+
+	mkdir -p "$(dirname "$PRIVACY_CACHE_FILE")" 2>/dev/null || true
+	if [[ ! -f "$PRIVACY_CACHE_FILE" ]]; then
+		printf '{}\n' >"$PRIVACY_CACHE_FILE"
+	fi
+
+	local tmp
+	tmp=$(mktemp "${PRIVACY_CACHE_FILE}.XXXXXX")
+	jq --arg slug "$slug" --arg private "$private" --argjson now "$now" \
+		'.[$slug] = {private: ($private == "true"), checked_at: $now}' \
+		"$PRIVACY_CACHE_FILE" >"$tmp" 2>/dev/null && mv "$tmp" "$PRIVACY_CACHE_FILE" || rm -f "$tmp"
+	return 0
+}
+
+# =============================================================================
+# Private-slug enumeration
+# =============================================================================
+
+#######################################
+# Enumerate private repo slugs from repos.json. A slug is considered private
+# if ANY of these conditions hold:
+#   - mirror_upstream is set (mirrors are private by design)
+#   - local_only: true (no remote, definitionally not public)
+#   - the slug's owner is the current gh user AND the repo is private on GH
+#
+# For speed, we use structural markers only (mirror_upstream, local_only).
+# We do NOT probe every slug with gh api — that would cost N network calls
+# on every push. Users who want additional slugs covered can add them to
+# ~/.aidevops/configs/privacy-guard-extra-slugs.txt (one per line).
+#
+# Arguments:
+#   $1 - (optional) output file path. If omitted, writes to stdout.
+#######################################
+privacy_enumerate_private_slugs() {
+	local out_file="${1:-}"
+
+	if [[ ! -f "$PRIVACY_REPOS_CONFIG" ]]; then
+		privacy_log WARN "repos.json not found at $PRIVACY_REPOS_CONFIG"
+		return 1
+	fi
+
+	local slugs
+	slugs=$(jq -r '
+		.initialized_repos[]?
+		| select(
+			(.mirror_upstream // null) != null and (.mirror_upstream // "") != ""
+			or (.local_only // false) == true
+		)
+		| .slug // empty
+	' "$PRIVACY_REPOS_CONFIG" 2>/dev/null)
+
+	# Also include extra user-configured slugs
+	local extra_file="$HOME/.aidevops/configs/privacy-guard-extra-slugs.txt"
+	if [[ -f "$extra_file" ]]; then
+		local extras
+		extras=$(grep -vE '^\s*(#|$)' "$extra_file" 2>/dev/null || true)
+		if [[ -n "$extras" ]]; then
+			slugs=$(printf '%s\n%s\n' "$slugs" "$extras")
+		fi
+	fi
+
+	# De-dupe while preserving order via awk
+	slugs=$(printf '%s\n' "$slugs" | awk 'NF && !seen[$0]++')
+
+	if [[ -n "$out_file" ]]; then
+		printf '%s\n' "$slugs" >"$out_file"
+	else
+		printf '%s\n' "$slugs"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Diff scanning
+# =============================================================================
+
+#######################################
+# Build a `git diff` path filter from PRIVACY_SCAN_GLOBS suitable for
+# `git diff -- <pathspecs>`. Outputs pathspec args one per line.
+#######################################
+_privacy_pathspec_args() {
+	local glob
+	for glob in "${PRIVACY_SCAN_GLOBS[@]}"; do
+		# Glob ending with / → match everything under that directory
+		if [[ "$glob" == */ ]]; then
+			printf '%s**\n' "$glob"
+		else
+			printf '%s\n' "$glob"
+		fi
+	done
+	return 0
+}
+
+#######################################
+# Scan the diff between two SHAs for added lines matching any private slug.
+# Only lines added (prefix '+') in paths matching PRIVACY_SCAN_GLOBS are
+# considered — we don't flag pre-existing content that has already been
+# pushed. Output format: "file:NNN: slug" for each hit.
+# Arguments:
+#   $1 - base SHA (remote tip); may be 40 zeros for a new branch push
+#   $2 - head SHA (local tip)
+#   $3 - file containing newline-separated private slugs
+# Writes: "file:line: slug" lines to stdout for each hit
+# Returns: 0 if no hits, 1 if at least one hit
+#######################################
+privacy_scan_diff() {
+	local base_sha="$1"
+	local head_sha="$2"
+	local slugs_file="$3"
+
+	if [[ ! -s "$slugs_file" ]]; then
+		# No private slugs to match → nothing to block
+		return 0
+	fi
+
+	# Build path filter args for git diff
+	local -a pathspecs=()
+	while IFS= read -r p; do
+		pathspecs+=("$p")
+	done < <(_privacy_pathspec_args)
+
+	# If base is all zeros, this is a new branch push — diff against the merge
+	# base with the default branch instead (or fall back to empty tree).
+	local diff_base="$base_sha"
+	if [[ "$base_sha" =~ ^0+$ ]]; then
+		local default_branch
+		default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||') || default_branch=""
+		if [[ -z "$default_branch" ]]; then
+			default_branch="main"
+		fi
+		diff_base=$(git merge-base "$head_sha" "origin/${default_branch}" 2>/dev/null) || diff_base=""
+		if [[ -z "$diff_base" ]]; then
+			# Fall back to the git empty tree
+			diff_base=$(git hash-object -t tree /dev/null)
+		fi
+	fi
+
+	# Produce a unified diff of ADDED lines in the path filter
+	local diff_output
+	diff_output=$(git diff --unified=0 --no-color "$diff_base" "$head_sha" -- "${pathspecs[@]}" 2>/dev/null) || return 0
+
+	if [[ -z "$diff_output" ]]; then
+		return 0
+	fi
+
+	# Walk the diff, tracking current file and hunk line counter. Match added
+	# lines (those starting with "+" but not "+++") against each slug.
+	local hits=0
+	local current_file=""
+	local line_num=0
+	while IFS= read -r line; do
+		case "$line" in
+		"+++ b/"*)
+			current_file="${line#+++ b/}"
+			line_num=0
+			;;
+		"--- "*) ;;
+		"@@ "*)
+			# @@ -old,oldc +new,newc @@ — extract new start
+			local rest="${line#@@ -*+}"
+			local new_start="${rest%% *}"
+			new_start="${new_start%,*}"
+			line_num="$new_start"
+			;;
+		"+"*)
+			# Skip the "+++ b/..." which we already handled
+			[[ "$line" == "+++ "* ]] && continue
+			local added="${line:1}"
+			local slug
+			while IFS= read -r slug; do
+				[[ -z "$slug" ]] && continue
+				# Match as a literal substring. Slugs look like owner/repo and
+				# contain no regex metacharacters by convention.
+				if [[ "$added" == *"$slug"* ]]; then
+					printf '%s:%s: %s\n' "$current_file" "$line_num" "$slug"
+					hits=$((hits + 1))
+				fi
+			done <"$slugs_file"
+			line_num=$((line_num + 1))
+			;;
+		" "*)
+			line_num=$((line_num + 1))
+			;;
+		esac
+	done <<<"$diff_output"
+
+	if [[ "$hits" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}

--- a/.agents/scripts/test-privacy-guard.sh
+++ b/.agents/scripts/test-privacy-guard.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-privacy-guard.sh — Smoke tests for the privacy guard pre-push hook.
+#
+# These tests DO NOT call gh or hit the network. They stub the privacy
+# library's "is public" function by overriding PRIVACY_REPOS_CONFIG and
+# sourcing the library directly, bypassing the gh probe.
+#
+# Tests:
+#   1. Match blocks: TODO.md diff introducing a private slug → scanner returns 1
+#   2. Sanitised passes: TODO.md diff without private slug → scanner returns 0
+#   3. No scan paths: diff only in src/ → scanner returns 0
+#   4. Extra-slug file: privacy-guard-extra-slugs.txt entries are picked up
+#   5. Enumerate: repos.json with mirror_upstream / local_only → enumerated correctly
+#
+# Usage:
+#   .agents/scripts/test-privacy-guard.sh
+# Exit code 0 = all tests pass, 1 = at least one failure.
+
+set -u
+
+# Colours
+if [[ -t 1 ]]; then
+	GREEN=$'\033[0;32m'
+	RED=$'\033[0;31m'
+	BLUE=$'\033[0;34m'
+	NC=$'\033[0m'
+else
+	GREEN="" RED="" BLUE="" NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$GREEN" "$NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$RED" "$NC" "$1"
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/privacy-guard-helper.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	printf 'test harness cannot find helper at %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+# Set up a temp scratch area with a fake repos.json and a fake git repo
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+export PRIVACY_REPOS_CONFIG="${TMP}/repos.json"
+export PRIVACY_CACHE_FILE="${TMP}/cache.json"
+
+cat >"$PRIVACY_REPOS_CONFIG" <<'EOF'
+{
+  "initialized_repos": [
+    {
+      "slug": "marcusquinn/aidevops",
+      "path": "/tmp/aidevops",
+      "pulse": true
+    },
+    {
+      "slug": "marcusquinn/turbostarter-ai",
+      "path": "/tmp/turbostarter/ai",
+      "pulse": false,
+      "mirror_upstream": "turbostarter/ai"
+    },
+    {
+      "slug": "marcusquinn/wpallstars.com",
+      "path": "/tmp/wpallstars.com",
+      "local_only": true
+    }
+  ]
+}
+EOF
+
+# shellcheck source=privacy-guard-helper.sh
+source "$HELPER"
+
+printf '%sRunning privacy-guard tests%s\n' "$BLUE" "$NC"
+
+# -----------------------------------------------------------------------------
+# Test 5: enumerate
+# -----------------------------------------------------------------------------
+slugs=$(privacy_enumerate_private_slugs 2>/dev/null)
+if printf '%s\n' "$slugs" | grep -q '^marcusquinn/turbostarter-ai$' &&
+	printf '%s\n' "$slugs" | grep -q '^marcusquinn/wpallstars.com$'; then
+	pass "enumerate picks up mirror_upstream and local_only entries"
+else
+	fail "enumerate missed expected slugs. Output:"
+	printf '%s\n' "$slugs" | sed 's/^/     /'
+fi
+
+if printf '%s\n' "$slugs" | grep -q '^marcusquinn/aidevops$'; then
+	fail "enumerate incorrectly included public aidevops slug"
+else
+	pass "enumerate excludes non-private aidevops slug"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 4: extra slug file
+# -----------------------------------------------------------------------------
+EXTRA_DIR="${TMP}/configs"
+mkdir -p "$EXTRA_DIR"
+EXTRA_FILE="${EXTRA_DIR}/privacy-guard-extra-slugs.txt"
+cat >"$EXTRA_FILE" <<'EOF'
+# extra private slugs
+marcusquinn/extra-secret
+EOF
+
+# Override HOME temporarily so the helper reads our test extra-slugs file
+ORIG_HOME="$HOME"
+export HOME="$TMP"
+mkdir -p "$HOME/.aidevops/configs"
+cp "$EXTRA_FILE" "$HOME/.aidevops/configs/privacy-guard-extra-slugs.txt"
+slugs_with_extra=$(privacy_enumerate_private_slugs 2>/dev/null)
+export HOME="$ORIG_HOME"
+
+if printf '%s\n' "$slugs_with_extra" | grep -q '^marcusquinn/extra-secret$'; then
+	pass "enumerate includes entries from privacy-guard-extra-slugs.txt"
+else
+	fail "enumerate missed extra slug from config file. Output:"
+	printf '%s\n' "$slugs_with_extra" | sed 's/^/     /'
+fi
+
+# -----------------------------------------------------------------------------
+# Prepare a real git repo for diff scanning tests
+# -----------------------------------------------------------------------------
+REPO="${TMP}/fake-repo"
+mkdir -p "$REPO"
+(
+	cd "$REPO" || exit 1
+	git init --quiet
+	git config user.email 'test@example.com'
+	git config user.name 'Test'
+	# Initial empty commit
+	git commit --allow-empty -m 'init' --quiet
+) || {
+	printf 'failed to create fake repo\n' >&2
+	exit 1
+}
+
+SLUGS_FILE="${TMP}/private-slugs.txt"
+cat >"$SLUGS_FILE" <<'EOF'
+marcusquinn/turbostarter-ai
+marcusquinn/wpallstars.com
+EOF
+
+# -----------------------------------------------------------------------------
+# Test 1: TODO.md diff with private slug → blocks
+# -----------------------------------------------------------------------------
+(
+	cd "$REPO" || exit 1
+	cat >TODO.md <<'EOF'
+- [x] r005 Sync mirror marcusquinn/turbostarter-ai run:custom/scripts/mirror-sync.sh
+EOF
+	git add TODO.md
+	git commit -m 'add TODO with private slug' --quiet
+) || fail "could not seed test 1 repo state"
+
+# Scan the newly added commit against the initial empty commit
+base=$(git -C "$REPO" rev-list --max-parents=0 HEAD)
+head=$(git -C "$REPO" rev-parse HEAD)
+
+pushd "$REPO" >/dev/null || exit 1
+hits=$(privacy_scan_diff "$base" "$head" "$SLUGS_FILE")
+rc=$?
+popd >/dev/null || exit 1
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -q 'marcusquinn/turbostarter-ai'; then
+	pass "diff with private slug in TODO.md is flagged"
+else
+	fail "diff with private slug not flagged (rc=$rc hits=$hits)"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 2: sanitised TODO.md → does not block
+# -----------------------------------------------------------------------------
+(
+	cd "$REPO" || exit 1
+	cat >TODO.md <<'EOF'
+- [x] r005 Sync private mirror repos (see local routine config) run:custom/scripts/mirror-sync.sh
+EOF
+	git add TODO.md
+	git commit -m 'sanitise TODO' --quiet
+) || fail "could not seed test 2 repo state"
+
+base=$(git -C "$REPO" rev-parse HEAD~1)
+head=$(git -C "$REPO" rev-parse HEAD)
+
+pushd "$REPO" >/dev/null || exit 1
+hits=$(privacy_scan_diff "$base" "$head" "$SLUGS_FILE")
+rc=$?
+popd >/dev/null || exit 1
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "sanitised TODO.md diff is not flagged"
+else
+	fail "sanitised diff incorrectly flagged (rc=$rc hits=$hits)"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 3: diff only in src/ (outside scan globs) → does not block
+# -----------------------------------------------------------------------------
+(
+	cd "$REPO" || exit 1
+	mkdir -p src
+	cat >src/code.ts <<'EOF'
+// reference to marcusquinn/turbostarter-ai in source code (private handling)
+const MIRROR = "marcusquinn/turbostarter-ai";
+EOF
+	git add src/code.ts
+	git commit -m 'add source reference' --quiet
+) || fail "could not seed test 3 repo state"
+
+base=$(git -C "$REPO" rev-parse HEAD~1)
+head=$(git -C "$REPO" rev-parse HEAD)
+
+pushd "$REPO" >/dev/null || exit 1
+hits=$(privacy_scan_diff "$base" "$head" "$SLUGS_FILE")
+rc=$?
+popd >/dev/null || exit 1
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "src/ diff outside scan globs is not flagged"
+else
+	fail "src/ diff incorrectly flagged (rc=$rc hits=$hits)"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+printf '\n'
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d test(s) passed%s\n' "$GREEN" "$TESTS_RUN" "$NC"
+	exit 0
+fi
+printf '%s%d of %d test(s) failed%s\n' "$RED" "$TESTS_FAILED" "$TESTS_RUN" "$NC"
+exit 1


### PR DESCRIPTION
## Summary

- Git `pre-push` hook that blocks pushes to **public** GitHub repos when the diff introduces private repo slugs (from `repos.json`) into planning/docs content (`TODO.md`, `todo/**`, `README.md`, `.github/ISSUE_TEMPLATE/**`).
- Reusable helper library (`privacy-guard-helper.sh`) with 10-minute cached target-privacy lookup and slug enumeration from `initialized_repos[].mirror_upstream` / `local_only: true`, plus optional extras in `~/.aidevops/configs/privacy-guard-extra-slugs.txt`.
- Per-repo installer (`install-privacy-guard.sh`) that writes a dispatcher into the git **common dir** (`git rev-parse --git-common-dir`) so worktrees share the hook with the parent repo.
- Unit test harness (`test-privacy-guard.sh`) — 6 tests, no network, no `gh` dependency.
- Documentation update in `.agents/AGENTS.md` under "Cross-repo privacy".

## Why

The cross-repo privacy rule is currently defended by prompt-level discipline plus `issue-sync-helper.sh` post-push sanitisation. Planning edits to `TODO.md` and `todo/**` go directly to main, bypassing the sanitiser entirely. In this session I almost leaked `marcusquinn/turbostarter-ai` into the public aidevops TODO.md. The hook catches this at the earliest possible point: after commit, before network push, so the private slug never leaves the machine.

## Design notes

- **Fail-open** when `gh` is offline/unauthenticated, `repos.json` is missing, or the remote isn't `github.com`. The rule still holds — the hook is defence-in-depth, not a single point of failure. Hard-fail would break legitimate offline work and train users to alias `--no-verify`.
- **Scans only added lines** in the diff range. Historical content is never flagged.
- **Bypass:** `PRIVACY_GUARD_DISABLE=1 git push ...` or `git push --no-verify`. Audit trail preserves the override.
- **Worktree-aware:** installer targets `$(git rev-parse --git-common-dir)/hooks/` so every worktree shares the guard — which is what users expect from a repo-wide privacy setting.
- **Refuses to overwrite** a pre-existing, non-aidevops pre-push hook. Prints chaining instructions instead.

## Verification

### Unit tests (6/6)

```
Running privacy-guard tests
  PASS enumerate picks up mirror_upstream and local_only entries
  PASS enumerate excludes non-private aidevops slug
  PASS enumerate includes entries from privacy-guard-extra-slugs.txt
  PASS diff with private slug in TODO.md is flagged
  PASS sanitised TODO.md diff is not flagged
  PASS src/ diff outside scan globs is not flagged

All 6 test(s) passed
```

### End-to-end: blocks a real leak

```
[privacy-guard][BLOCK] Push to origin contains private repo slugs in planning/docs content:

TODO.md:1: marcusquinn/turbostarter-ai

  Remove the private slug from the committed content and amend/rewrite the commit before pushing.
  To bypass (audit trail preserves the override): PRIVACY_GUARD_DISABLE=1 git push ... or git push --no-verify
EXIT=1
```

### End-to-end: allows on private target, bypass, and framework work

- `git@github.com:marcusquinn/turbostarter-plus.git` (private) → EXIT=0 (fast path)
- `PRIVACY_GUARD_DISABLE=1` → EXIT=0 (bypass audited)
- **This PR's own push** → allowed by the installed hook, no false positive (framework code without private slugs in scan paths)

### Shellcheck

Clean: `.agents/hooks/privacy-guard-pre-push.sh`, `.agents/scripts/privacy-guard-helper.sh`, `.agents/scripts/install-privacy-guard.sh`, `.agents/scripts/test-privacy-guard.sh` (only SC1091 informational on dynamic source).

## Follow-ups (not in this PR)

- Add a test case that stubs `privacy_is_target_public` so we can unit-test the full hook dispatch offline. Currently only the scan path is unit-tested; the target-privacy lookup was verified end-to-end with live `gh`.
- Consider extending the scan globs to cover other docs surfaces (`docs/**`, `*.md` at root) if leaks are observed there.
- Optional: a `sudo`-installable system-level installer that hooks every new repo via `git init.templateDir`.

Resolves #18359

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 41m and 37,246 tokens on this with the user in an interactive session. Overall, 11m since this issue was created.