### PR TITLE
t1968: setup.sh auto-installs privacy guard in every initialized repo

### DIFF
--- a/.agents/scripts/setup/_privacy_guard.sh
+++ b/.agents/scripts/setup/_privacy_guard.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Setup module: install privacy-guard pre-push hook in every initialized repo.
+# Sourced by setup.sh — do not execute directly.
+#
+# Idempotent: re-installs managed hooks, skips unmanaged ones with a warning,
+# counts each outcome, and returns success regardless of per-repo conflicts
+# so setup.sh does not abort on a single non-cooperative repo.
+#
+# Opt out by exporting AIDEVOPS_PRIVACY_GUARD=false before running setup.
+
+#######################################
+# Resolve the path of install-privacy-guard.sh relative to this module.
+# Returns: path on stdout, 0 on success; nothing on stdout, 1 on miss.
+#######################################
+_load_privacy_guard_installer() {
+	local installer_path
+	installer_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../install-privacy-guard.sh"
+	if [[ ! -f "$installer_path" ]]; then
+		print_warning "install-privacy-guard.sh not found at: $installer_path"
+		return 1
+	fi
+	printf '%s' "$installer_path"
+	return 0
+}
+
+#######################################
+# Install or refresh the privacy-guard pre-push hook in every initialized
+# repo listed in repos.json. Called from setup.sh.
+#
+# Behaviour:
+#   - Iterates initialized_repos[].path, expanding leading ~
+#   - Skips entries without a local .git present
+#   - Calls install-privacy-guard.sh install inside each repo (idempotent)
+#   - Counts outcomes: ok, already-managed, conflict (unmanaged hook present),
+#     skip (no .git), err (other)
+#   - Reports a one-line summary via print_info
+#   - Tracks success via setup_track_configured
+#
+# Opt out: AIDEVOPS_PRIVACY_GUARD=false
+#######################################
+setup_privacy_guard() {
+	if [[ "${AIDEVOPS_PRIVACY_GUARD:-true}" == "false" ]]; then
+		print_info "Privacy guard install disabled via AIDEVOPS_PRIVACY_GUARD=false"
+		setup_track_skipped "Privacy guard" "opted out via AIDEVOPS_PRIVACY_GUARD=false"
+		return 0
+	fi
+
+	print_info "Installing privacy guard pre-push hook across initialized repos..."
+
+	local installer_path
+	if ! installer_path=$(_load_privacy_guard_installer); then
+		setup_track_skipped "Privacy guard" "installer not available"
+		return 0
+	fi
+
+	local repos_config="${HOME}/.config/aidevops/repos.json"
+	if [[ ! -f "$repos_config" ]]; then
+		print_warning "repos.json not found — skipping privacy guard rollout"
+		setup_track_skipped "Privacy guard" "repos.json not found"
+		return 0
+	fi
+
+	if ! command -v jq >/dev/null 2>&1; then
+		print_warning "jq not installed — skipping privacy guard rollout"
+		setup_track_skipped "Privacy guard" "jq not installed"
+		return 0
+	fi
+
+	local ok=0 already=0 conflict=0 skip=0 err=0
+	local rawpath path result
+
+	while IFS= read -r rawpath; do
+		[[ -z "$rawpath" ]] && continue
+		path="${rawpath/#\~/$HOME}"
+		if [[ ! -e "$path/.git" ]]; then
+			skip=$((skip + 1))
+			continue
+		fi
+		result=$(cd "$path" && bash "$installer_path" install 2>&1 </dev/null || true)
+		if [[ "$result" == *"installed privacy guard"* ]]; then
+			ok=$((ok + 1))
+		elif [[ "$result" == *"already installed"* ]]; then
+			already=$((already + 1))
+		elif [[ "$result" == *"Refusing to overwrite"* || "$result" == *"NOT managed"* ]]; then
+			conflict=$((conflict + 1))
+		else
+			err=$((err + 1))
+		fi
+	done < <(jq -r '.initialized_repos[]? | select(.path != null) | .path' "$repos_config")
+
+	print_info "Privacy guard: ok=$ok already=$already conflict=$conflict skip=$skip err=$err"
+	local total_covered=$((ok + already))
+	setup_track_configured "Privacy guard (${total_covered} repos)"
+	return 0
+}

--- a/setup.sh
+++ b/setup.sh
@@ -87,6 +87,8 @@ if [[ -d "$SETUP_MODULES_DIR" ]]; then
 	source "$SETUP_MODULES_DIR/_bootstrap.sh"
 	# shellcheck disable=SC1091
 	source "$SETUP_MODULES_DIR/_routines.sh"
+	# shellcheck disable=SC1091
+	source "$SETUP_MODULES_DIR/_privacy_guard.sh"
 fi
 
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
@@ -913,6 +915,10 @@ _setup_run_non_interactive() {
 	# Creates local git repo + private GitHub remote for personal repo only.
 	# Org repos require explicit: aidevops init-routines --org <name>
 	setup_routines
+	# Install/refresh the privacy-guard pre-push hook in every initialized
+	# repo so TODO/todo/README/ISSUE_TEMPLATE pushes to public GitHub repos
+	# are scanned for private slug leaks (t1968).
+	setup_privacy_guard
 	return 0
 }
 
@@ -977,6 +983,7 @@ _setup_run_interactive() {
 	confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && deploy_aidevops_agents
 	confirm_step "Sync agents from private repositories" && sync_agent_sources
 	confirm_step "Set up routines repo (private repo for recurring operational jobs)" && setup_routines
+	confirm_step "Install privacy guard pre-push hook across initialized repos (blocks private slug leaks on public push)" && setup_privacy_guard
 	is_feature_enabled safety_hooks 2>/dev/null && confirm_step "Install Claude Code safety hooks (block destructive commands)" && setup_safety_hooks
 	confirm_step "Initialize settings.json (canonical config file)" && init_settings_json
 	confirm_step "Setup multi-tenant credential storage" && setup_multi_tenant_credentials


### PR DESCRIPTION
## Summary

- New setup module `.agents/scripts/setup/_privacy_guard.sh` — iterates `initialized_repos[]` in `repos.json` and calls `install-privacy-guard.sh install` inside each repo that has a local `.git/` present.
- Wires `setup_privacy_guard` into `setup.sh`'s non-interactive flow (always runs) and interactive flow (behind `confirm_step`), right after `setup_routines`.
- Opt-out: `AIDEVOPS_PRIVACY_GUARD=false` before running setup skips the step.
- Conflict-safe: per-repo conflicts (pre-existing non-aidevops pre-push hook) are counted and skipped without aborting the outer setup flow.

## Why

Makes the privacy guard durable. Without this, the rollout from t1965 was point-in-time — new clones, new repos, and teammate machines gradually fall out of sync. Integrating into setup means every `aidevops update` cycle (every ~10 min via launchd) re-confirms the hook is present and pointing at the current deployed helper, and every `aidevops init` on a new repo installs the hook from day one.

## Verification

End-to-end on the dev host with two synthetic cases (wiped hook + polluted non-aidevops hook):

```
[INFO] Installing privacy guard pre-push hook across initialized repos...
[INFO] Privacy guard: ok=26 already=0 conflict=1 skip=3 err=0
[TRACK] configured: Privacy guard (26 repos)
<webapp> hook after setup: RE-INSTALLED
quickfile-mcp polluted hook: LEFT UNTOUCHED (conflict detected, skipped)
AIDEVOPS_PRIVACY_GUARD=false path: correctly skipped with track_skipped
```

All 4 acceptance criteria met (fresh install, conflict-safe, opt-out, shellcheck clean).

Resolves #18369

---
$SIG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Privacy-guard pre-push hook installation is now automatically integrated into the setup process, deploying hooks across all initialized repositories to ensure consistent configuration.
  * Optional configuration flag allows users to skip installation if they have existing pre-push workflows or specific hook management requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->