### PR TITLE
GH#18383: fix session-miner copy logic to include all Python modules

### DIFF
--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -667,12 +667,21 @@ parse_args() {
 
 sync_scripts() {
 	mkdir -p "${MINER_DIR}"
-	if [[ -f "${EXTRACTOR_SRC}" ]] && [[ ! -f "${EXTRACTOR}" || "${EXTRACTOR_SRC}" -nt "${EXTRACTOR}" ]]; then
-		cp "${EXTRACTOR_SRC}" "${EXTRACTOR}"
-	fi
-	if [[ -f "${COMPRESSOR_SRC}" ]] && [[ ! -f "${COMPRESSOR}" || "${COMPRESSOR_SRC}" -nt "${COMPRESSOR}" ]]; then
-		cp "${COMPRESSOR_SRC}" "${COMPRESSOR}"
-	fi
+	# Copy all Python modules from source to workspace (not just extract.py + compress.py).
+	# Resilient to future refactoring: any new .py added to scripts/session-miner/ is
+	# automatically deployed. Fixes regression from t1944 which added 5 helper modules
+	# (extract_chunking.py, extract_errors.py, extract_git.py, extract_shared.py,
+	# extract_steerage.py) without updating this copy logic. Ref: GH#18383.
+	local _miner_src_dir="${SCRIPT_DIR}/session-miner"
+	local _py_src
+	local _py_dst
+	for _py_src in "${_miner_src_dir}"/*.py; do
+		[[ -f "${_py_src}" ]] || continue
+		_py_dst="${MINER_DIR}/$(basename "${_py_src}")"
+		if [[ ! -f "${_py_dst}" || "${_py_src}" -nt "${_py_dst}" ]]; then
+			cp "${_py_src}" "${_py_dst}"
+		fi
+	done
 	return 0
 }
 


### PR DESCRIPTION
## Summary

`sync_scripts()` in `session-miner-pulse.sh` only copied `extract.py` and `compress.py` to the workspace. When t1944 (GH#18034) refactored `extract.py` into 5 helper modules, the copy logic was not updated, leaving the session miner broken with:

```
ModuleNotFoundError: No module named 'extract_chunking'
```

## Changes

**EDIT: `.agents/scripts/session-miner-pulse.sh:668-686`**

Replace two individual `cp` calls with a glob loop over `*.py` in the session-miner source directory. All 7 modules (`extract.py`, `compress.py`, `extract_chunking.py`, `extract_errors.py`, `extract_git.py`, `extract_shared.py`, `extract_steerage.py`) are now copied with the same freshness check.

This approach is also resilient to future refactoring — any new `.py` module added to `scripts/session-miner/` is automatically deployed to the workspace.

## Testing

- `shellcheck` clean (zero violations)
- Manually verified the glob correctly expands to all 7 `.py` files in `scripts/session-miner/`
- Dry-run verification: `session-miner-pulse.sh --dry-run` produces no `ModuleNotFoundError`

## Runtime Testing

**Risk: Low** — file-copy sync logic; no runtime state, no credentials, no data deletion.
**Self-assessed** — shellcheck clean, logic verified against directory contents.

Resolves #18383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved module deployment process to dynamically sync all Python modules in the session-miner directory, using timestamp-based updates to deploy only when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->