### PR TITLE
GH#18412: docs: add /build-agent slash command cross-reference

### DIFF
--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -18,6 +18,7 @@ mode: subagent
 - **MCP servers**: Disabled globally, enabled per-agent
 - **Code refs**: `rg "pattern"` search patterns, not `file:line` (line numbers drift)
 - **Subagents**: `agent-review.md` (review), `agent-testing.md` (testing)
+- **Slash command**: `/build-agent {name} {kind} [category]` → `scripts/commands/build-agent.md` (interactive harness for creating new agents)
 - **Related**: `@code-standards`, `.agents/aidevops/architecture.md`, `tools/browser/browser-automation.md`
 - **After creating/promoting**: `~/.aidevops/agents/scripts/subagent-index-helper.sh generate`
 - **Testing**: `agent-test-helper.sh run my-tests` or `claude -p "Test query"`


### PR DESCRIPTION
## Summary

Added Quick Reference bullet in .agents/tools/build-agent/build-agent.md pointing to the new /build-agent slash command (scripts/commands/build-agent.md) for interactive agent creation.

## Files Changed

.agents/tools/build-agent/build-agent.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: markdownlint-cli2 passes, file contains reference to scripts/commands/build-agent.md, line count increased by exactly 1 (201→202 lines)

Resolves #18412


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.2 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-haiku-4-5 spent 1m and 2,700 tokens on this as a headless worker.