### PR TITLE
t1983: P0 fix BSD awk dynamic-regex silently breaking add_gh_ref_to_todo on macOS

### DIFF
--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -1125,11 +1125,16 @@ fix_gh_ref_in_todo() {
 		return 0
 	fi
 
-	# Find line number outside code fences, then replace only that line
+	# Find line number outside code fences, then replace only that line.
+	# NOTE: regex escapes must be doubled in the dynamic `pat` string (t1983) —
+	# BSD awk (macOS default) interprets `\[` in `$0 ~ pat` as literal `\` + `[`
+	# rather than a single literal `[`, causing the match to silently miss. The
+	# `\\[` / `\\]` form is correct on both BSD awk and gawk: awk's dynamic regex
+	# compiler reads `\\` as `\` and `\[` as literal `[`.
 	local task_id_ere
 	task_id_ere=$(_escape_ere "$task_id")
 	local line_num
-	line_num=$(awk -v pat="^[[:space:]]*- \\[.\\] ${task_id_ere} .*ref:GH#${old_number}" \
+	line_num=$(awk -v pat="^[[:space:]]*- \\\\[.\\\\] ${task_id_ere} .*ref:GH#${old_number}" \
 		'/^[[:space:]]*```/{f=!f; next} !f && $0 ~ pat {print NR; exit}' "$todo_file")
 	[[ -z "$line_num" ]] && {
 		log_verbose "$task_id with ref:GH#$old_number not found outside code fences"
@@ -1166,8 +1171,11 @@ add_gh_ref_to_todo() {
 
 	# Find the line number of the task OUTSIDE code fences, then apply sed to that specific line.
 	# This prevents modifying format examples inside code-fenced blocks.
+	# NOTE: double-backslash escapes in the dynamic `pat` string — required for
+	# BSD awk dynamic-regex semantics (t1983). See _fix_gh_ref_in_todo for
+	# the detailed explanation.
 	local line_num
-	line_num=$(awk -v pat="^[[:space:]]*- \\[.\\] ${task_id_ere} " \
+	line_num=$(awk -v pat="^[[:space:]]*- \\\\[.\\\\] ${task_id_ere} " \
 		'/^[[:space:]]*```/{f=!f; next} !f && $0 ~ pat {print NR; exit}' "$todo_file")
 	[[ -z "$line_num" ]] && {
 		log_verbose "$task_id not found outside code fences"
@@ -1218,9 +1226,11 @@ add_pr_ref_to_todo() {
 		return 0
 	fi
 
-	# Find line number outside code fences, then modify only that line
+	# Find line number outside code fences, then modify only that line.
+	# NOTE: double-backslash escapes in the dynamic `pat` string — required for
+	# BSD awk dynamic-regex semantics (t1983).
 	local line_num
-	line_num=$(awk -v pat="^[[:space:]]*- \\[.\\] ${task_id_ere} " \
+	line_num=$(awk -v pat="^[[:space:]]*- \\\\[.\\\\] ${task_id_ere} " \
 		'/^[[:space:]]*```/{f=!f; next} !f && $0 ~ pat {print NR; exit}' "$todo_file")
 	[[ -z "$line_num" ]] && {
 		log_verbose "$task_id not found outside code fences for pr: ref"


### PR DESCRIPTION
## Summary

P0 fix for a latent BSD awk dynamic-regex bug that has been silently breaking `issue-sync-lib.sh` on every Mac for an unknown duration.

**Failure mode:** `awk -v pat='...\[.\]...'` in BSD awk's `$0 ~ pat` path silently miscompiles single-backslash escapes, returning no match even when the line exists. Every Mac running `issue-sync-helper.sh push` locally has been silently failing TODO.md ref writebacks. Linux CI (gawk) works correctly, which is why the bug has been shipping undetected.

**Fix:** double-backslash the bracket escapes at all three `awk -v pat=` sites in `issue-sync-lib.sh`:

- `_fix_gh_ref_in_todo` (line 1132) — ref update path
- `add_gh_ref_to_todo` (line 1170) — initial ref stamp path
- `add_pr_ref_to_todo` (line 1223) — PR ref stamp path

Inside a bash double-quoted string, `\\[` → `\[` which BSD awk's dynamic regex compiler reads as literal `[`. Fix is a no-op on gawk — Linux CI behaviour is unchanged.

## Verification

Isolated regression test (runs on macOS with BSD awk at `/usr/bin/awk`):

```
=== test 1: add ref to plain task ===
PASS

=== test 2: add ref to task with inline backticks ===
PASS

=== test 3: idempotent re-run ===
PASS (count=1)
```

Final TODO.md content after tests:

```
- [ ] t9001 plain task description tier:simple ref:GH#1001
- [ ] t9002 task with `inline code` in description tier:simple ref:GH#1002
```

Both plain and backtick-containing lines get the ref stamped. Re-run is a no-op (caught by the existing "ref already exists" early return). Shellcheck clean on the modified file (only pre-existing SC1091/SC2016 info-level noise unchanged).

## Evidence of the original failure

Earlier in today's session, I filed t1979-t1985 via `issue-sync-helper.sh push tNNNN`. The refs never stamped in TODO.md — `add_gh_ref_to_todo` silently returned 0 without writing. I had to manually backfill three ref:GH# markers. That led to the investigation that reproduced the bug in isolation (see the brief for the minimal repro).

## Follow-up

- t1985 (#18404, tier:standard, depends on this): extend the stub-harness pattern to `issue-sync-lib.sh` with an explicit regression test for t1983 so this class of bug is caught on every future CI run, on macOS matrix runners.

Resolves #18401

---
$SIG