### PR TITLE
GH#18413: t1991: feat(claudecli): map OpenCode reasoning level to Claude CLI --effort flag

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -448,12 +448,20 @@ function buildClaudeArgs(body, systemPrompt, streaming) {
     "-p",
     "--model",
     body.model,
+  ];
+
+  // Add reasoning effort level if provided
+  if (body.effortLevel) {
+    args.push("--effort", body.effortLevel);
+  }
+
+  args.push(
     "--permission-mode",
     "default",
     "--no-session-persistence",
     "--add-dir",
     agentsDir,
-  ];
+  );
 
   // Agent-specific MCP config (lazy loading — only needed MCPs start)
   const mcpConfig = getMcpConfigForAgent(agentName);
@@ -902,12 +910,19 @@ async function handleChatCompletions(req, directory) {
     resolvedModel = MODEL_ALIASES[modelSuffix] || incoming.model;
   }
 
+  // Extract reasoning effort level from OpenAI-compatible request
+  const EFFORT_LEVELS = new Set(["low", "medium", "high", "max"]);
+  const effortLevel = typeof incoming.reasoning_effort === "string" && EFFORT_LEVELS.has(incoming.reasoning_effort)
+    ? incoming.reasoning_effort
+    : null;
+
   const body = {
     model: resolvedModel,
     agentName: agentName || "build-plus",
     systemPrompt: parsed.systemPrompt,
     prompt: parsed.prompt,
     stream: incoming.stream !== false,
+    effortLevel: effortLevel,
   };
 
   console.error(


### PR DESCRIPTION
## Summary

Extract reasoning_effort from OpenCode requests and pass as --effort flag to Claude CLI subprocess. Validates against allowed levels (low, medium, high, max) and omits flag if not provided.

## Files Changed

.agents/plugins/opencode-aidevops/claude-proxy.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified JavaScript syntax with node -c. Implementation follows existing --model pattern in buildClaudeArgs.

Resolves #18413


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.2 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-haiku-4-5 spent 1m and 1,314 tokens on this as a headless worker.