### PR TITLE
t1984: sync-todo-to-issues workflow tags issues interactive and assigns human pusher

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -470,11 +470,20 @@ _push_create_issue() {
 	# to self-assign — CI fires on the created issue within seconds, and
 	# re-running the workflow after a manual assign is extra friction.
 	#
+	# t1984: In the `Sync TODO.md → GitHub Issues` workflow, `gh api user`
+	# resolves to `github-actions[bot]` (the GITHUB_TOKEN identity), not the
+	# human pusher. The workflow sets AIDEVOPS_SESSION_ORIGIN=interactive
+	# AND AIDEVOPS_SESSION_USER=<github.actor> to override both the origin
+	# detection and the assignee target. Falls back to `gh api user` when
+	# the env var is unset (normal local interactive usage).
+	#
 	# Worker-origin issues are NOT auto-assigned here — they follow the
 	# existing dispatch flow (`status:claimed` + pulse-managed assignment).
 	if [[ -n "$num" && -z "$assignee" && "$origin_label" == "origin:interactive" ]]; then
-		local current_user
-		current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
+		local current_user="${AIDEVOPS_SESSION_USER:-}"
+		if [[ -z "$current_user" ]]; then
+			current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
+		fi
 		if [[ -n "$current_user" ]]; then
 			if gh issue edit "$num" --repo "$repo" --add-assignee "$current_user" >/dev/null 2>&1; then
 				print_info "Auto-assigned #${num} to @${current_user} (origin:interactive)"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -754,6 +754,22 @@ files_include_workflow_changes() {
 #   # Returns: "origin:worker" or "origin:interactive"
 
 detect_session_origin() {
+	# t1984: Explicit override via AIDEVOPS_SESSION_ORIGIN takes precedence
+	# over the headless auto-detection. Used by the sync-todo-to-issues
+	# workflow to mark issues created from human-triggered TODO.md pushes
+	# as origin:interactive rather than origin:worker, so the t1970 auto-
+	# assign path fires and the Maintainer Gate doesn't block downstream PRs.
+	case "${AIDEVOPS_SESSION_ORIGIN:-}" in
+	interactive)
+		echo "interactive"
+		return 0
+		;;
+	worker)
+		echo "worker"
+		return 0
+		;;
+	esac
+
 	# Known headless signals — set by dispatch infrastructure only.
 	# If none of these are set, the session is interactive by default.
 	if [[ "${FULL_LOOP_HEADLESS:-}" == "true" ]]; then

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -86,6 +86,13 @@ jobs:
           bash .agents/scripts/issue-sync-helper.sh push --verbose || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # t1984: override origin detection and assignee target so issues
+          # created from human-triggered TODO.md pushes get origin:interactive
+          # and are assigned to the human pusher, not github-actions[bot].
+          # `check-author` upstream already filters out bot-authored commits,
+          # so by this step the push is guaranteed human (or a non-[bot] actor).
+          AIDEVOPS_SESSION_ORIGIN: ${{ endsWith(github.actor, '[bot]') && 'worker' || 'interactive' }}
+          AIDEVOPS_SESSION_USER: ${{ endsWith(github.actor, '[bot]') && '' || github.actor }}
 
       - name: Enrich plan-linked issues
         if: steps.check-author.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

t1970 fixed the **local** `issue-sync-helper.sh` auto-assign path but the **server-side** `Sync TODO.md → GitHub Issues` workflow still created issues with `origin:worker` and no assignee. Root cause: `detect_session_origin()` sees `GITHUB_ACTIONS=true` and returns `worker`, so the t1970 auto-assign block never fires. Secondary problem: even if it did, `gh api user` in a workflow returns `github-actions[bot]` — wrong assignee target.

This PR adds two env var overrides that let the workflow explicitly opt into the interactive treatment and name the human pusher.

## Changes

### `shared-constants.sh` — `detect_session_origin` override

Adds an explicit `AIDEVOPS_SESSION_ORIGIN` env var override that takes precedence over the headless auto-detection:

```bash
case "${AIDEVOPS_SESSION_ORIGIN:-}" in
interactive) echo interactive; return 0 ;;
worker)      echo worker; return 0 ;;
esac
# ... existing headless checks ...
```

Unrecognised values fall through.

### `issue-sync-helper.sh` — `AIDEVOPS_SESSION_USER` override in `_gh_create_issue`

t1970's auto-assign used `gh api user` which returns `github-actions[bot]` in CI. New env var `AIDEVOPS_SESSION_USER` specifies who to assign explicitly, with `gh api user` as the fallback for normal local interactive usage.

### `.github/workflows/issue-sync.yml` — wire both overrides

```yaml
env:
  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  AIDEVOPS_SESSION_ORIGIN: ${{ endsWith(github.actor, '[bot]') && 'worker' || 'interactive' }}
  AIDEVOPS_SESSION_USER: ${{ endsWith(github.actor, '[bot]') && '' || github.actor }}
```

The `check-author` upstream step already filters out `github-actions[bot]` commits. The `endsWith` check is a second line of defense for dependabot, renovate, and other bots that might edit TODO.md.

## Verification

Unit tests of `detect_session_origin`:

```
PASS: default → interactive
PASS: GITHUB_ACTIONS=true → worker
PASS: AIDEVOPS_SESSION_ORIGIN=interactive wins over GITHUB_ACTIONS=true
PASS: explicit AIDEVOPS_SESSION_ORIGIN=worker
PASS: unrecognised value falls through to default
```

Shellcheck clean on both modified files (only pre-existing SC1091/SC2016 info-level unchanged).

End-to-end verification happens on the next real human TODO.md push that fires this workflow. I'll check the resulting issue has `origin:interactive` + human pusher assignee after merge.

## Follow-up

- **None directly** — t1984 was the last of my filed follow-ups for this session's session-level findings (t1979, t1980 already done, t1981 still open as investigation, t1983 merged, t1985 tests pending review, t1995 merged).

Resolves #18403

---
$SIG