### PR TITLE
GH#18346: add logging to silent skip paths in cleanup_worktrees() Pass 2

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -156,7 +156,10 @@ cleanup_worktrees() {
 				if [[ -f "$wt_path_age/.git" ]]; then
 					wt_created=$(stat -c '%Y' "$wt_path_age/.git" 2>/dev/null || stat -f '%m' "$wt_path_age/.git" 2>/dev/null) || wt_created=0
 				fi
-				[[ "$wt_created" -eq 0 ]] && continue
+				if [[ "$wt_created" -eq 0 ]]; then
+					echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} ($wt_path_age) — stat on .git failed (wt_created=0)" >>"$LOGFILE"
+					continue
+				fi
 				local wt_age_secs=$((now_epoch - wt_created))
 
 				# Count commits ahead of main
@@ -169,6 +172,7 @@ cleanup_worktrees() {
 
 				# Check for active worker process using this worktree
 				if pgrep -f "$wt_path_age" >/dev/null 2>&1; then
+					echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} ($wt_path_age) — pgrep matched active process" >>"$LOGFILE"
 					continue
 				fi
 


### PR DESCRIPTION
## Summary

Fixes two silent `continue` paths in `cleanup_worktrees()` Pass 2 (`pulse-cleanup.sh`) that prevented diagnosis of why eligible orphan worktrees survived cleanup.

## Changes

EDIT: `.agents/scripts/pulse-cleanup.sh`

**Path 1 — stat failure** (line 159): Replaced one-liner `[[ "$wt_created" -eq 0 ]] && continue` with a logged block:
```bash
if [[ "$wt_created" -eq 0 ]]; then
    echo "[pulse-wrapper] Orphan cleanup: skipping ... — stat on .git failed (wt_created=0)" >>"$LOGFILE"
    continue
fi
```

**Path 2 — pgrep match** (line 171): Added log before `continue`:
```bash
if pgrep -f "$wt_path_age" >/dev/null 2>&1; then
    echo "[pulse-wrapper] Orphan cleanup: skipping ... — pgrep matched active process" >>"$LOGFILE"
    continue
fi
```

Both changes model the existing logged skip at the registry-check path (line 187, added in PR #18024).

## Verification

```bash
grep "Orphan cleanup: skipping" ~/.aidevops/logs/pulse.log | tail -10
# Every worktree that survived cleanup now has a logged skip reason.
```

ShellCheck: zero violations on modified file.

Resolves #18346