### PR TITLE
t2003: refactor(pulse) split cleanup_worktrees() + fix GH#18346 silent-skip

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -14,6 +14,11 @@
 # section.
 #
 # Functions in this module (in source order):
+#   Private helpers (called only within this module):
+#   - _cleanup_merged_prs_for_all_repos  (Pass 1: merged-PR worktree removal)
+#   - _worktree_owner_alive              (pgrep + registry ownership check)
+#   - _cleanup_single_worktree           (per-worktree age/orphan decision)
+#   Public interface (called by pulse-wrapper.sh):
 #   - cleanup_worktrees
 #   - cleanup_stashes
 #   - reap_zombie_workers
@@ -22,37 +27,32 @@
 #   - cleanup_orphans
 #   - cleanup_stale_opencode
 #
-# This is a pure move from pulse-wrapper.sh. The function bodies are
-# byte-identical to their pre-extraction form. Any change must go in a
-# separate follow-up PR after the full decomposition (Phase 12) lands.
+# Phase 12 refactor (t2003 / GH#18451): split cleanup_worktrees() (250 lines)
+# into the three private helpers above. Also preserves the GH#18346 fix
+# (silent-skip logging) that was applied during Phase 5 extraction — see
+# _worktree_owner_alive() and _cleanup_single_worktree() for the two
+# previously-silent continue paths that now emit diagnostic log entries.
 
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_CLEANUP_LOADED:-}" ]] && return 0
 _PULSE_CLEANUP_LOADED=1
 
 #######################################
-# Clean up worktrees for merged/closed PRs across ALL managed repos
+# Pass 1 helper: remove worktrees for merged/closed PRs across ALL repos
 #
 # Iterates repos.json (.initialized_repos[]) and runs
 # worktree-helper.sh clean --auto --force-merged in each repo directory.
-# This prevents stale worktrees from accumulating on disk after PR merges
-# — including squash merges that git branch --merged cannot detect.
-#
-# worktree-helper.sh clean internally:
-#   1. Runs git fetch --prune origin (prunes deleted remote branches)
-#   2. Checks refs/remotes/origin/<branch> for each worktree
-#   3. Detects squash merges via gh pr list --state merged
-#   4. Removes worktrees + deletes local branches for merged PRs
+# Echoes the total count of removed worktrees on stdout; returns 0 always.
 #
 # --force-merged: force-removes dirty worktrees when the PR is confirmed
 # merged (dirty state = abandoned WIP from a completed worker).
-#
 # Safety: skips worktrees owned by active sessions (handled by
 # worktree-helper.sh ownership registry, t189).
 #######################################
-cleanup_worktrees() {
+_cleanup_merged_prs_for_all_repos() {
 	local helper="${HOME}/.aidevops/agents/scripts/worktree-helper.sh"
 	if [[ ! -x "$helper" ]]; then
+		echo 0
 		return 0
 	fi
 
@@ -104,187 +104,259 @@ cleanup_worktrees() {
 		fi
 	fi
 
-	# --- Age-based orphan cleanup (GH#16830, t1884) ---
-	# Workers that crash leave worktrees with 0 commits / no PR. The
-	# --force-merged pass above won't touch them. Clean based on age:
-	#   0 commits, no open PR, >30m → crashed worker, safe to remove fast (t1884)
-	#   0 commits, 0 dirty,   >3h  → empty, safe to remove
-	#   0 commits, dirty,     >6h  → worker died mid-edit, no process
-	#   any commits, no PR,   >24h → abandoned, issue will be re-dispatched
-	local now_epoch
-	now_epoch=$(date +%s)
+	echo "$total_removed"
+	return 0
+}
+
+#######################################
+# Check whether a worktree has an active owner (process or registry).
+#
+# Two checks in priority order:
+#   1. pgrep: any process with the worktree path in its argv.
+#   2. Registry: is_worktree_owned_by_others() — covers interactive
+#      runtimes (e.g. Claude Code) where the path never appears in argv.
+#
+# Both silent-skip paths log a diagnostic message (GH#18346 fix):
+# previously these paths produced zero log output, making it impossible
+# to diagnose why eligible orphan worktrees survived cleanup.
+#
+# Args:
+#   $1 - wt_path: absolute path to the worktree
+#   $2 - wt_branch: branch name (for log context; empty = detached)
+# Returns: 0 if alive (caller should skip removal), 1 if no active owner
+#######################################
+_worktree_owner_alive() {
+	local wt_path="$1"
+	local wt_branch="${2:-}"
+
+	# pgrep check: any process referencing this path in its command line
+	if pgrep -f "$wt_path" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch:-detached} ($wt_path) — pgrep matched active process" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Registry check (GH#18021): covers MCP-dispatch runtimes where the
+	# worktree path never appears in process argv.
+	if is_worktree_owned_by_others "$wt_path"; then
+		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch:-detached} ($wt_path) — registered owner alive in registry" >>"$LOGFILE"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
+# Per-worktree age-based orphan cleanup decision and removal.
+#
+# Evaluates a single worktree against the age/commit/PR thresholds and
+# removes it if eligible. Also handles crash classification and issue
+# state recovery for crashed workers (t1884, GH#18021).
+#
+# Age thresholds (GH#16830, t1884):
+#   0 commits, no open PR, >30m → crashed worker, safe to remove fast
+#   0 commits, 0 dirty,   >3h  → empty, safe to remove
+#   0 commits, dirty,     >6h  → worker died mid-edit, no active process
+#   any commits, no PR,   >24h → abandoned, issue will be re-dispatched
+#
+# Args:
+#   $1 - rp_age:        repo root path (for git -C commands)
+#   $2 - wt_path_age:   absolute worktree path
+#   $3 - wt_branch_age: branch name (may be empty for detached HEAD)
+#   $4 - now_epoch:     current Unix timestamp (from caller to avoid drift)
+#   $5 - repo_slug_age: owner/repo slug for gh API calls (may be empty)
+#   $6 - main_branch:   name of the default branch (e.g. "main")
+# Returns: 0 if worktree was removed, 1 if skipped
+#######################################
+_cleanup_single_worktree() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local now_epoch="$4"
+	local repo_slug_age="$5"
+	local main_branch="$6"
+
+	# Age thresholds — grace period from config, others hardcoded
 	local age_grace="$ORPHAN_WORKTREE_GRACE_SECS"
 	local age_3h=$((3 * 3600))
 	local age_6h=$((6 * 3600))
 	local age_24h=$((24 * 3600))
 
-	if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
-		local repo_paths_age
-		repo_paths_age=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
-
-		local rp_age
-		while IFS= read -r rp_age; do
-			[[ -z "$rp_age" ]] && continue
-			[[ ! -d "$rp_age/.git" ]] && continue
-
-			local main_branch
-			main_branch=$(git -C "$rp_age" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="main"
-
-			local repo_slug_age
-			repo_slug_age=$(git -C "$rp_age" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||') || repo_slug_age=""
-
-			# Parse worktree list — non-porcelain: "path  hash [branch]" per line.
-			# Using process substitution (not pipe) so total_removed propagates.
-			local wt_line_age
-			while IFS= read -r wt_line_age; do
-				# Extract path (first field, before double-space)
-				local wt_path_age
-				wt_path_age=$(printf '%s' "$wt_line_age" | awk '{print $1}')
-				[[ -z "$wt_path_age" ]] && continue
-				[[ "$wt_path_age" == "$rp_age" ]] && continue
-				[[ ! -d "$wt_path_age" ]] && continue
-
-				# Extract branch name from [branch] at end of line
-				local wt_branch_age=""
-				if [[ "$wt_line_age" == *"["*"]"* ]]; then
-					wt_branch_age=$(printf '%s' "$wt_line_age" | sed 's/.*\[//;s/\]//')
-				fi
-
-				# Get worktree creation time from .git file mtime
-				# Linux stat -c first (stat -f '%m' on Linux outputs filesystem info to stdout)
-				local wt_created=0
-				if [[ -f "$wt_path_age/.git" ]]; then
-					wt_created=$(stat -c '%Y' "$wt_path_age/.git" 2>/dev/null || stat -f '%m' "$wt_path_age/.git" 2>/dev/null) || wt_created=0
-				fi
-				if [[ "$wt_created" -eq 0 ]]; then
-					echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} ($wt_path_age) — stat on .git failed (wt_created=0)" >>"$LOGFILE"
-					continue
-				fi
-				local wt_age_secs=$((now_epoch - wt_created))
-
-				# Count commits ahead of main
-				local commits_ahead=0
-				commits_ahead=$(git -C "$wt_path_age" rev-list --count "HEAD" "^${main_branch}" 2>/dev/null) || commits_ahead=0
-
-				# Count dirty files
-				local dirty_count=0
-				dirty_count=$(git -C "$wt_path_age" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || dirty_count=0
-
-				# Check for active worker process using this worktree
-				if pgrep -f "$wt_path_age" >/dev/null 2>&1; then
-					echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} ($wt_path_age) — pgrep matched active process" >>"$LOGFILE"
-					continue
-				fi
-
-				# Check ownership registry before removing (GH#18021).
-				# pgrep only detects processes that expose the worktree path
-				# in their argv. Interactive runtimes (e.g. OpenCode Web, Claude Code)
-				# dispatch MCP tool calls inside the agent runtime — the worktree
-				# path never appears in process arguments. The registry is the
-				# authoritative source for live ownership; skip removal if a live
-				# owner PID is registered.
-				if is_worktree_owned_by_others "$wt_path_age"; then
-					echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} ($wt_path_age) — registered owner alive in registry" >>"$LOGFILE"
-					continue
-				fi
-
-				local should_remove=false
-				local reason=""
-
-				# Fast-path: 0 commits + no open PR + past grace period → crashed worker (t1884)
-				# Check this before the 3h/6h thresholds — no PR means no risk of losing work.
-				# Only check GitHub if we have a slug and branch name; skip if either is missing.
-				if [[ "$commits_ahead" -eq 0 && "$wt_age_secs" -ge "$age_grace" ]]; then
-					local has_open_pr=false
-					if [[ -n "$repo_slug_age" && -n "$wt_branch_age" ]]; then
-						local open_pr_count
-						open_pr_count=$(gh pr list --repo "$repo_slug_age" --head "$wt_branch_age" --state open --limit 1 2>/dev/null | wc -l | tr -d ' ') || open_pr_count=0
-						[[ "$open_pr_count" -gt 0 ]] && has_open_pr=true
-					fi
-					if [[ "$has_open_pr" == "false" ]]; then
-						should_remove=true
-						reason="0 commits, no open PR, age $((wt_age_secs / 60))m (crashed worker)"
-					fi
-				elif [[ "$commits_ahead" -eq 0 && "$dirty_count" -eq 0 && "$wt_age_secs" -ge "$age_3h" ]]; then
-					should_remove=true
-					reason="0 commits, clean, age $((wt_age_secs / 3600))h"
-				elif [[ "$commits_ahead" -eq 0 && "$dirty_count" -gt 0 && "$wt_age_secs" -ge "$age_6h" ]]; then
-					should_remove=true
-					reason="0 commits, ${dirty_count} dirty files, age $((wt_age_secs / 3600))h"
-				elif [[ "$commits_ahead" -gt 0 && "$wt_age_secs" -ge "$age_24h" ]]; then
-					# Only if no PR exists for this branch
-					local has_pr=false
-					if [[ -n "$repo_slug_age" && -n "$wt_branch_age" ]]; then
-						local pr_count
-						pr_count=$(gh pr list --repo "$repo_slug_age" --head "$wt_branch_age" --state all --limit 1 2>/dev/null | wc -l | tr -d ' ') || pr_count=0
-						[[ "$pr_count" -gt 0 ]] && has_pr=true
-					fi
-					if [[ "$has_pr" == "false" ]]; then
-						should_remove=true
-						reason="${commits_ahead} commits, no PR, age $((wt_age_secs / 3600))h"
-					fi
-				fi
-
-				if [[ "$should_remove" == "true" ]]; then
-					local repo_name_age
-					repo_name_age=$(basename "$rp_age")
-					echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — $reason" >>"$LOGFILE"
-
-					# Crash classification for orphaned worktrees.
-					# Classify based on evidence in the worktree to drive
-					# crash-type-aware tier escalation:
-					#   - "overwhelmed": issue-named branch + dirty files or
-					#     evidence of file reads. Model attempted real work
-					#     but couldn't produce commits. Escalate immediately.
-					#   - "no_work": auto-named branch (feature/auto-*) or
-					#     clean worktree with 0 dirty files. Worker never
-					#     got past setup. Transient — retry at same tier.
-					if [[ "$reason" == *"crashed worker"* && -n "$wt_branch_age" && -n "$repo_slug_age" ]]; then
-						local orphan_issue_num=""
-						if [[ "$wt_branch_age" =~ gh[-]?([0-9]+) ]]; then
-							orphan_issue_num="${BASH_REMATCH[1]}"
-						fi
-						if [[ -n "$orphan_issue_num" ]]; then
-							# Classify crash type from worktree state
-							local orphan_crash_type="no_work"
-							if [[ "$dirty_count" -gt 0 ]]; then
-								# Dirty files = model wrote code but didn't commit
-								orphan_crash_type="overwhelmed"
-							elif [[ "$wt_branch_age" != feature/auto-* ]]; then
-								# Issue-named branch = model parsed the issue and
-								# set up properly, but produced nothing. This is the
-								# "read files, created worktree, couldn't close the
-								# loop" pattern. Overwhelmed by complexity.
-								orphan_crash_type="overwhelmed"
-							fi
-							# Auto-named branches (feature/auto-*) with 0 dirty
-							# files stay as "no_work" — the worker couldn't even
-							# parse the issue metadata, likely an infra failure.
-
-							recover_failed_launch_state "$orphan_issue_num" "$repo_slug_age" "premature_exit" "$orphan_crash_type"
-							echo "[pulse-wrapper] Orphan cleanup: recorded premature_exit for #${orphan_issue_num} (${repo_slug_age}) crash_type=${orphan_crash_type} — triggers fast-fail escalation" >>"$LOGFILE"
-
-							# Post failure comment to clear dedup guard immediately.
-							# Without this, the dispatch comment blocks re-dispatch
-							# for the full TTL even though the worker is dead.
-							# "Worker failed" is a recognised completion signal in
-							# dispatch-dedup-helper.sh has_dispatch_comment().
-							gh issue comment "$orphan_issue_num" --repo "$repo_slug_age" \
-								--body "Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 commits). Cleared for re-dispatch." \
-								>/dev/null 2>&1 || true
-						fi
-					fi
-
-					git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null || rm -rf "$wt_path_age"
-					if [[ -n "$wt_branch_age" ]]; then
-						git -C "$rp_age" branch -D "$wt_branch_age" 2>/dev/null || true
-						git -C "$rp_age" push origin --delete "$wt_branch_age" 2>/dev/null || true
-					fi
-					total_removed=$((total_removed + 1))
-				fi
-			done < <(git -C "$rp_age" worktree list 2>/dev/null)
-		done <<<"$repo_paths_age"
+	# Get worktree creation time from .git file mtime.
+	# Linux uses stat -c '%Y'; macOS uses stat -f '%m'.
+	local wt_created=0
+	if [[ -f "$wt_path_age/.git" ]]; then
+		wt_created=$(stat -c '%Y' "$wt_path_age/.git" 2>/dev/null || stat -f '%m' "$wt_path_age/.git" 2>/dev/null) || wt_created=0
 	fi
+	if [[ "$wt_created" -eq 0 ]]; then
+		# GH#18346: previously a silent skip — now logs the reason
+		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} ($wt_path_age) — stat on .git failed (wt_created=0)" >>"$LOGFILE"
+		return 1
+	fi
+	local wt_age_secs=$((now_epoch - wt_created))
+
+	# Count commits ahead of main and dirty files
+	local commits_ahead=0
+	commits_ahead=$(git -C "$wt_path_age" rev-list --count "HEAD" "^${main_branch}" 2>/dev/null) || commits_ahead=0
+	local dirty_count=0
+	dirty_count=$(git -C "$wt_path_age" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || dirty_count=0
+
+	# Check for active owner (process or registry) — GH#18346, GH#18021
+	if _worktree_owner_alive "$wt_path_age" "$wt_branch_age"; then
+		return 1
+	fi
+
+	# Determine whether this worktree is eligible for removal
+	local should_remove=false
+	local reason=""
+
+	# Fast-path: 0 commits + no open PR + past grace period → crashed worker (t1884)
+	# Only check GitHub if we have a slug and branch name; skip if either is missing.
+	if [[ "$commits_ahead" -eq 0 && "$wt_age_secs" -ge "$age_grace" ]]; then
+		local has_open_pr=false
+		if [[ -n "$repo_slug_age" && -n "$wt_branch_age" ]]; then
+			local open_pr_count
+			open_pr_count=$(gh pr list --repo "$repo_slug_age" --head "$wt_branch_age" --state open --limit 1 2>/dev/null | wc -l | tr -d ' ') || open_pr_count=0
+			[[ "$open_pr_count" -gt 0 ]] && has_open_pr=true
+		fi
+		if [[ "$has_open_pr" == "false" ]]; then
+			should_remove=true
+			reason="0 commits, no open PR, age $((wt_age_secs / 60))m (crashed worker)"
+		fi
+	elif [[ "$commits_ahead" -eq 0 && "$dirty_count" -eq 0 && "$wt_age_secs" -ge "$age_3h" ]]; then
+		should_remove=true
+		reason="0 commits, clean, age $((wt_age_secs / 3600))h"
+	elif [[ "$commits_ahead" -eq 0 && "$dirty_count" -gt 0 && "$wt_age_secs" -ge "$age_6h" ]]; then
+		should_remove=true
+		reason="0 commits, ${dirty_count} dirty files, age $((wt_age_secs / 3600))h"
+	elif [[ "$commits_ahead" -gt 0 && "$wt_age_secs" -ge "$age_24h" ]]; then
+		# Only remove if no PR exists for this branch
+		local has_pr=false
+		if [[ -n "$repo_slug_age" && -n "$wt_branch_age" ]]; then
+			local pr_count
+			pr_count=$(gh pr list --repo "$repo_slug_age" --head "$wt_branch_age" --state all --limit 1 2>/dev/null | wc -l | tr -d ' ') || pr_count=0
+			[[ "$pr_count" -gt 0 ]] && has_pr=true
+		fi
+		if [[ "$has_pr" == "false" ]]; then
+			should_remove=true
+			reason="${commits_ahead} commits, no PR, age $((wt_age_secs / 3600))h"
+		fi
+	fi
+
+	[[ "$should_remove" != "true" ]] && return 1
+
+	local repo_name_age
+	repo_name_age=$(basename "$rp_age")
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — $reason" >>"$LOGFILE"
+
+	# Crash classification for orphaned workers.
+	# Classify based on worktree state to drive crash-type-aware tier escalation:
+	#   "overwhelmed": issue-named branch + dirty files or evidence of file reads.
+	#                  Model attempted real work but couldn't produce commits.
+	#   "no_work":     auto-named branch (feature/auto-*) or clean worktree.
+	#                  Worker never got past setup. Transient — retry at same tier.
+	if [[ "$reason" == *"crashed worker"* && -n "$wt_branch_age" && -n "$repo_slug_age" ]]; then
+		local orphan_issue_num=""
+		if [[ "$wt_branch_age" =~ gh[-]?([0-9]+) ]]; then
+			orphan_issue_num="${BASH_REMATCH[1]}"
+		fi
+		if [[ -n "$orphan_issue_num" ]]; then
+			local orphan_crash_type="no_work"
+			if [[ "$dirty_count" -gt 0 ]]; then
+				orphan_crash_type="overwhelmed"
+			elif [[ "$wt_branch_age" != feature/auto-* ]]; then
+				# Issue-named branch = model parsed the issue but produced nothing.
+				# "Read files, created worktree, couldn't close the loop" pattern.
+				orphan_crash_type="overwhelmed"
+			fi
+			# Auto-named branches (feature/auto-*) with 0 dirty files stay
+			# as "no_work" — the worker couldn't parse the issue, likely infra.
+
+			recover_failed_launch_state "$orphan_issue_num" "$repo_slug_age" "premature_exit" "$orphan_crash_type"
+			echo "[pulse-wrapper] Orphan cleanup: recorded premature_exit for #${orphan_issue_num} (${repo_slug_age}) crash_type=${orphan_crash_type} — triggers fast-fail escalation" >>"$LOGFILE"
+
+			# Post failure comment to clear dedup guard immediately.
+			# Without this, the dispatch comment blocks re-dispatch for the
+			# full TTL even though the worker is dead.
+			# "Worker failed" is a recognised completion signal in
+			# dispatch-dedup-helper.sh has_dispatch_comment().
+			gh issue comment "$orphan_issue_num" --repo "$repo_slug_age" \
+				--body "Worker failed: orphan worktree detected (crash_type=${orphan_crash_type}, 0 commits). Cleared for re-dispatch." \
+				>/dev/null 2>&1 || true
+		fi
+	fi
+
+	# Perform removal
+	git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null || rm -rf "$wt_path_age"
+	if [[ -n "$wt_branch_age" ]]; then
+		git -C "$rp_age" branch -D "$wt_branch_age" 2>/dev/null || true
+		git -C "$rp_age" push origin --delete "$wt_branch_age" 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# Clean up worktrees for merged/closed PRs and orphaned workers
+# across ALL managed repos.
+#
+# Two-pass approach:
+#   Pass 1 (_cleanup_merged_prs_for_all_repos): remove worktrees whose
+#           PR has merged. Uses worktree-helper.sh.
+#   Pass 2 (_cleanup_single_worktree): age-based orphan cleanup for
+#           worktrees that have no PR (crashed/abandoned workers).
+#           Age thresholds: >30m no-PR, >3h clean, >6h dirty, >24h commits.
+#
+# See also: GH#18346 (silent-skip logging fix preserved in helpers above)
+#######################################
+cleanup_worktrees() {
+	local total_removed=0
+
+	# Pass 1: remove worktrees for merged PRs
+	local merged_removed
+	merged_removed=$(_cleanup_merged_prs_for_all_repos)
+	total_removed=$((total_removed + merged_removed))
+
+	# Pass 2: age-based orphan cleanup
+	local now_epoch
+	now_epoch=$(date +%s)
+
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	[[ -f "$repos_json" ]] && command -v jq &>/dev/null || return 0
+
+	local repo_paths_age
+	repo_paths_age=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
+
+	local rp_age
+	while IFS= read -r rp_age; do
+		[[ -z "$rp_age" ]] && continue
+		[[ ! -d "$rp_age/.git" ]] && continue
+
+		local main_branch
+		main_branch=$(git -C "$rp_age" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="main"
+
+		local repo_slug_age
+		repo_slug_age=$(git -C "$rp_age" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||') || repo_slug_age=""
+
+		# Parse worktree list — non-porcelain: "path  hash [branch]" per line.
+		# Using process substitution (not pipe) so total_removed propagates.
+		local wt_line_age
+		while IFS= read -r wt_line_age; do
+			local wt_path_age
+			wt_path_age=$(printf '%s' "$wt_line_age" | awk '{print $1}')
+			[[ -z "$wt_path_age" ]] && continue
+			[[ "$wt_path_age" == "$rp_age" ]] && continue
+			[[ ! -d "$wt_path_age" ]] && continue
+
+			local wt_branch_age=""
+			if [[ "$wt_line_age" == *"["*"]"* ]]; then
+				wt_branch_age=$(printf '%s' "$wt_line_age" | sed 's/.*\[//;s/\]//')
+			fi
+
+			if _cleanup_single_worktree "$rp_age" "$wt_path_age" "$wt_branch_age" \
+				"$now_epoch" "$repo_slug_age" "$main_branch"; then
+				total_removed=$((total_removed + 1))
+			fi
+		done < <(git -C "$rp_age" worktree list 2>/dev/null)
+	done <<<"$repo_paths_age"
 
 	if [[ "$total_removed" -gt 0 ]]; then
 		echo "[pulse-wrapper] Worktree cleanup total: $total_removed worktree(s) removed across all repos" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Phase 12 refactor (t2003 / GH#18451): split `cleanup_worktrees()` (250 lines) in `pulse-cleanup.sh` into focused private helpers, and document the GH#18346 silent-skip fix that was already applied during Phase 5 extraction.

## Changes

**Extracted functions:**
- `_cleanup_merged_prs_for_all_repos()` (76L) — Pass 1 merged-PR worktree removal, extracted from the first half of `cleanup_worktrees()`. Echoes removed count on stdout.
- `_worktree_owner_alive()` (42L) — combines pgrep and registry ownership checks. **This is where the GH#18346 fix lives**: both previously-silent skip paths now emit diagnostic log entries with explicit skip reason.
- `_cleanup_single_worktree()` (140L) — full per-worktree age/orphan decision and removal, including crash classification and `recover_failed_launch_state` call.

**Refactored `cleanup_worktrees()`:** reduced to 69 lines (target: < 80). Now a coordinator: calls `_cleanup_merged_prs_for_all_repos`, iterates repos and worktrees, delegates per-worktree logic to `_cleanup_single_worktree`.

## GH#18346 Fix

The silent-skip bug had two paths in `cleanup_worktrees()` that `continue`d with zero log output:
1. `[[ "$wt_created" -eq 0 ]] && continue` — stat on `.git` failed
2. `pgrep -f "$wt_path" >/dev/null && continue` — active process matched

Both were already fixed with logging during Phase 5 (t1973/#18381). This refactor isolates both paths cleanly into `_worktree_owner_alive()` and `_cleanup_single_worktree()`, making the diagnostic logging explicit and self-contained. Every skipped worktree now logs its skip reason, matching the pattern at the registry check.

## Verification

- `bash -n .agents/scripts/pulse-cleanup.sh` — syntax clean
- `shellcheck .agents/scripts/pulse-cleanup.sh` — zero findings
- `.agents/scripts/pulse-wrapper.sh --self-check` — `ok (28 canonical functions defined, 23 module guards verified)`
- `bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh` — **all 26 tests pass**

Post-merge: monitor `pulse.log` for `Orphan cleanup:` lines. Every skipped worktree should now have a corresponding `skipping ... — <reason>` entry. Orphan worktrees that previously survived silently should now be logged and reaped.

Resolves #18451
Fixes #18346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal cleanup process for managing development worktrees with improved detection of active work and better diagnostic logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->