### PR TITLE
t2008: feat(pulse): dispatch hardening — stale-recovery escalation

### DIFF
--- a/.agents/configs/dispatch-stale-recovery.conf
+++ b/.agents/configs/dispatch-stale-recovery.conf
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# dispatch-stale-recovery.conf — Stale-recovery escalation config (t2008)
+#
+# Controls how many consecutive stale-recovery cycles are allowed before
+# an issue is escalated to `needs-maintainer-review` instead of being
+# reset to `status:available` for re-dispatch.
+#
+# Background (GH#18356 root-cause analysis, Phase 3):
+#   GH#18356 stale-recovered twice in succession without producing a PR.
+#   Each cycle wasted compute: dispatch → claim → fail → stale-recover → repeat.
+#   t1986 stops parent tasks; t2007 adds a cost cap; t2008 stops persistent
+#   no-progress loops by escalating to human review after N cycles.
+#
+# Format: KEY=VALUE (no spaces around =, no quotes needed)
+# Lines starting with # are comments.
+
+# Number of consecutive stale-recovery cycles (without a PR) that triggers
+# escalation. After this many recoveries the issue receives
+# `needs-maintainer-review` and automated dispatch is suspended.
+#
+# The 3rd attempt = threshold 2: workers 1 and 2 each stale-recovered
+# (ticks 1 and 2); the 3rd cycle detects prior_ticks >= 2 and escalates.
+# Same model, same brief, same infrastructure → third attempt is wasted
+# compute. A human needs to inspect and fix the root cause first.
+#
+# Raise this value to allow more retries before escalation (useful if
+# transient failures are common in your environment). Lower it to escalate
+# sooner (useful for expensive models where every dispatch cycle costs money).
+STALE_RECOVERY_THRESHOLD=2

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -551,6 +551,82 @@ _recover_stale_assignment() {
 	local stale_assignees="$3"
 	local reason="$4"
 
+	# ── Stale-recovery escalation check (t2008) ──────────────────────────
+	# After STALE_RECOVERY_THRESHOLD consecutive recoveries without a PR, stop
+	# resetting to status:available and apply needs-maintainer-review instead.
+	# Counter is stored as structured comment markers for cross-runner correctness.
+	# Config: .agents/configs/dispatch-stale-recovery.conf
+
+	# Load threshold from config (default 2 consecutive recoveries)
+	local _stale_conf="${SCRIPT_DIR}/../configs/dispatch-stale-recovery.conf"
+	if [[ -f "$_stale_conf" ]]; then
+		# shellcheck source=/dev/null
+		source "$_stale_conf"
+	fi
+	local _threshold="${STALE_RECOVERY_THRESHOLD:-2}"
+
+	# Count prior non-reset stale-recovery-tick comments (cross-runner counter)
+	local _prior_ticks
+	_prior_ticks=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--jq '[.[] | select(.body | (test("<!-- stale-recovery-tick:[1-9]") and (test("reset") | not)))] | length' \
+		2>/dev/null) || _prior_ticks=0
+	[[ "$_prior_ticks" =~ ^[0-9]+$ ]] || _prior_ticks=0
+
+	# Check for any open PR referencing this issue (resets the counter)
+	# A PR means progress is being made — don't escalate yet.
+	local _open_pr
+	_open_pr=$(gh pr list --repo "$repo_slug" --state open \
+		--search "#${issue_number} in:body" --limit 1 \
+		--json number --jq '.[0].number // empty' 2>/dev/null) || _open_pr=""
+
+	if [[ -n "$_open_pr" ]]; then
+		# Open PR exists — counter resets; post a reset marker and allow normal recovery
+		gh issue comment "$issue_number" --repo "$repo_slug" \
+			--body "<!-- stale-recovery-tick:0 (reset: open PR #${_open_pr} detected) -->" \
+			2>/dev/null || true
+	elif [[ "$_prior_ticks" -ge "$_threshold" ]]; then
+		# Threshold reached — escalate to needs-maintainer-review (t2008)
+		# Unassign stale workers (still needed to clean up the assignment)
+		local _esc_ifs="${IFS:-}"
+		local -a _esc_assignee_arr=()
+		IFS=',' read -ra _esc_assignee_arr <<<"$stale_assignees"
+		IFS="$_esc_ifs"
+		for _esc_assignee in "${_esc_assignee_arr[@]}"; do
+			gh issue edit "$issue_number" --repo "$repo_slug" \
+				--remove-assignee "$_esc_assignee" 2>/dev/null || true
+		done
+		# Remove stale status labels; apply needs-maintainer-review (NOT status:available)
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--remove-label "status:queued" --remove-label "status:in-progress" \
+			--remove-label "status:available" \
+			--add-label "needs-maintainer-review" 2>/dev/null || true
+		# Post escalation comment explaining the suspension
+		gh issue comment "$issue_number" --repo "$repo_slug" \
+			--body "<!-- stale-recovery-tick:escalated (threshold=${_threshold}) -->
+**Stale recovery threshold reached** (t2008)
+
+This issue has been stale-recovered **${_prior_ticks}** consecutive time(s) without producing a PR. Further automated dispatch is suspended until a human reviews the root cause.
+
+Previously assigned to: ${stale_assignees}
+Reason for latest stale: ${reason}
+Recovery count: ${_prior_ticks} (threshold: ${_threshold})
+
+Marked \`needs-maintainer-review\`. Remove this label after investigating why workers keep failing (wrong brief, unimplementable scope, missing dependency, etc.) to re-enable dispatch.
+
+_This escalation is the \"no-progress fail-safe\" from t2008 (paired with t1986 parent-task guard and t2007 cost circuit breaker)._" \
+			2>/dev/null || true
+		printf 'STALE_ESCALATED: issue #%s in %s — unassigned %s, applied needs-maintainer-review (threshold %s reached after %s ticks)\n' \
+			"$issue_number" "$repo_slug" "$stale_assignees" "$_threshold" "$_prior_ticks"
+		return 0
+	else
+		# Under threshold — increment tick counter, continue normal recovery
+		local _next_tick=$((_prior_ticks + 1))
+		gh issue comment "$issue_number" --repo "$repo_slug" \
+			--body "<!-- stale-recovery-tick:${_next_tick} -->" \
+			2>/dev/null || true
+	fi
+	# ── End stale-recovery escalation check ──────────────────────────────
+
 	# Unassign all stale users
 	local saved_ifs="${IFS:-}"
 	local -a assignee_arr=()
@@ -1288,6 +1364,16 @@ main() {
 			return 1
 		}
 		normalize_title "$1"
+		;;
+	test-recover)
+		# Test shim for t2008: expose _recover_stale_assignment for test harness.
+		# Usage: dispatch-dedup-helper.sh test-recover <issue> <repo> <assignees> <reason>
+		# Not for production use — test files only.
+		[[ $# -lt 4 ]] && {
+			echo "Error: test-recover requires <issue> <repo> <assignees> <reason>" >&2
+			return 1
+		}
+		_recover_stale_assignment "$1" "$2" "$3" "$4"
 		;;
 	help | --help | -h)
 		show_help

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-stale-recovery-escalation.sh — t2008 regression guard.
+#
+# Asserts the stale-recovery escalation logic works end-to-end:
+#
+#   1. First recovery (0 prior ticks) → tick:1 posted, status:available added
+#   2. Second recovery (1 prior tick) → tick:2 posted, status:available added
+#   3. Third recovery (2 prior ticks = threshold) → STALE_ESCALATED emitted,
+#      needs-maintainer-review applied, status:available NOT added
+#   4. Reset path: when an open PR is detected, tick reset comment posted,
+#      normal recovery proceeds (no escalation)
+#   5. Above-threshold (3 prior ticks >= threshold=2) also escalates
+#
+# Tests use the `test-recover` subcommand added to dispatch-dedup-helper.sh
+# (t2008) to expose _recover_stale_assignment without sourcing complications.
+#
+# Stubs use environment variables to control output, not heredoc jq calls.
+#
+# Failure history motivating this test: GH#18356 (t1962 Phase 3, observed
+# stale-recovery looping twice without a PR and requiring manual intervention).
+#
+# NOTE: not using `set -e` — negative assertions rely on capturing non-zero
+# exits. NOTE: SCRIPT_DIR NOT readonly to avoid readonly-collision pattern
+# (same as test-parent-task-guard.sh).
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+}
+
+# Sandbox HOME so sourcing is side-effect-free
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+
+STUB_DIR="${TEST_ROOT}/bin"
+mkdir -p "$STUB_DIR"
+GH_CALLS_FILE="${TEST_ROOT}/gh_calls.log"
+
+#######################################
+# write_stub_gh: write a minimal gh stub that:
+#   - Appends all calls to GH_CALLS_FILE
+#   - Returns STUB_TICK_COUNT for 'gh api *comments --jq ...'
+#     (simulates the count of stale-recovery-tick comments)
+#   - Returns STUB_OPEN_PR for 'gh pr list --state open ...'
+#     (simulates finding an open PR by number, or empty for none)
+#   - Silently succeeds for all write calls (issue edit, issue comment)
+#
+# Called with env vars STUB_TICK_COUNT and STUB_OPEN_PR set.
+#######################################
+write_stub_gh() {
+	local tick_count="${1:-0}"
+	local open_pr="${2:-}"
+	: >"$GH_CALLS_FILE"
+
+	cat >"${STUB_DIR}/gh" <<STUBEOF
+#!/usr/bin/env bash
+# Stub gh for test-stale-recovery-escalation.sh
+printf '%s\n' "\$*" >> "${GH_CALLS_FILE}"
+
+# gh api .../comments --jq '... | length'
+# Returns the pre-computed tick count directly (t2008 test shim)
+if [[ "\$1" == "api" && "\$2" == *"/comments" ]]; then
+	printf '%s\n' "${tick_count}"
+	exit 0
+fi
+
+# gh pr list --state open ...
+# Returns open PR number if configured, empty if not
+if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
+	printf '%s\n' "${open_pr}"
+	exit 0
+fi
+
+# gh issue edit, gh issue comment — silent success (write operations)
+if [[ "\$1" == "issue" ]]; then
+	exit 0
+fi
+
+exit 0
+STUBEOF
+	chmod +x "${STUB_DIR}/gh"
+	return 0
+}
+
+OLD_PATH="$PATH"
+export PATH="${STUB_DIR}:${OLD_PATH}"
+
+#######################################
+# run_recover: invoke dispatch-dedup-helper.sh test-recover with given
+# tick count and open PR state. Captures output and exit code in globals
+# $output and $rc.
+#######################################
+output=""
+rc=0
+
+run_recover() {
+	local tick_count="${1:-0}"
+	local open_pr="${2:-}"
+	write_stub_gh "$tick_count" "$open_pr"
+	set +e
+	output=$(
+		STALE_ASSIGNMENT_THRESHOLD_SECONDS=0
+		STALE_RECOVERY_THRESHOLD=2
+		export STALE_ASSIGNMENT_THRESHOLD_SECONDS STALE_RECOVERY_THRESHOLD
+		"${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" test-recover \
+			"99999" "owner/repo" "stale-runner" "test reason" 2>/dev/null
+	)
+	rc=$?
+	set -e
+	return 0
+}
+
+# =============================================================================
+# Test 1 — First recovery (0 prior ticks → tick:1 comment, STALE_RECOVERED)
+# =============================================================================
+
+run_recover 0 ""
+
+if echo "$output" | grep -q "STALE_RECOVERED"; then
+	print_result "Tick 1 (0 prior ticks): STALE_RECOVERED emitted, not escalated" 0
+else
+	print_result "Tick 1 (0 prior ticks): STALE_RECOVERED emitted, not escalated" 1 "(got: '$output')"
+fi
+
+# gh issue comment should have been called (tick:1 posted)
+if grep -q "^issue comment" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "Tick 1: tick comment call posted" 0
+else
+	print_result "Tick 1: tick comment call posted" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null | head -5))"
+fi
+
+# =============================================================================
+# Test 2 — Second recovery (1 prior tick → tick:2 comment, STALE_RECOVERED)
+# =============================================================================
+
+run_recover 1 ""
+
+if echo "$output" | grep -q "STALE_RECOVERED"; then
+	print_result "Tick 2 (1 prior tick): STALE_RECOVERED emitted, not escalated" 0
+else
+	print_result "Tick 2 (1 prior tick): STALE_RECOVERED emitted, not escalated" 1 "(got: '$output')"
+fi
+
+# =============================================================================
+# Test 3 — Third recovery (2 prior ticks = threshold → STALE_ESCALATED)
+# =============================================================================
+
+run_recover 2 ""
+
+if echo "$output" | grep -q "STALE_ESCALATED"; then
+	print_result "Escalation (2 prior ticks >= threshold 2): STALE_ESCALATED emitted" 0
+else
+	print_result "Escalation (2 prior ticks >= threshold 2): STALE_ESCALATED emitted" 1 "(got: '$output')"
+fi
+
+# STALE_RECOVERED must NOT be emitted in escalation path (no re-dispatch)
+if ! echo "$output" | grep -q "STALE_RECOVERED"; then
+	print_result "Escalation: STALE_RECOVERED NOT emitted (no re-dispatch loop)" 0
+else
+	print_result "Escalation: STALE_RECOVERED NOT emitted (no re-dispatch loop)" 1 "(got: '$output')"
+fi
+
+# needs-maintainer-review must be applied (check gh issue edit call in log)
+if grep -q "needs-maintainer-review" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "Escalation: needs-maintainer-review label applied" 0
+else
+	print_result "Escalation: needs-maintainer-review label applied" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null | head -10))"
+fi
+
+# status:available must NOT be --add-label'd in escalation path
+# (it's OK to appear as --remove-label; we just must not reset to available)
+if ! grep -q "add-label status:available" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "Escalation: status:available NOT added (correct; only removed if present)" 0
+else
+	print_result "Escalation: status:available NOT added (correct; only removed if present)" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null))"
+fi
+
+# =============================================================================
+# Test 4 — Reset path: open PR detected → counter reset, STALE_RECOVERED
+# =============================================================================
+
+# 2 prior ticks (above threshold), but open PR #42 detected → should NOT escalate
+run_recover 2 "42"
+
+if echo "$output" | grep -q "STALE_RECOVERED"; then
+	print_result "Reset path (PR #42 detected, 2 ticks): STALE_RECOVERED emitted (no escalation)" 0
+else
+	print_result "Reset path (PR #42 detected, 2 ticks): STALE_RECOVERED emitted (no escalation)" 1 "(got: '$output')"
+fi
+
+if ! echo "$output" | grep -q "STALE_ESCALATED"; then
+	print_result "Reset path: STALE_ESCALATED NOT emitted" 0
+else
+	print_result "Reset path: STALE_ESCALATED NOT emitted" 1 "(got: '$output')"
+fi
+
+# A reset tick comment should have been posted
+if grep -q "^issue comment" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "Reset path: reset comment call made" 0
+else
+	print_result "Reset path: reset comment call made" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null | head -5))"
+fi
+
+# =============================================================================
+# Test 5 — Above-threshold (3 prior ticks >= threshold=2 → STALE_ESCALATED)
+# =============================================================================
+
+run_recover 3 ""
+
+if echo "$output" | grep -q "STALE_ESCALATED"; then
+	print_result "Above-threshold (3 prior ticks >= threshold 2): STALE_ESCALATED emitted" 0
+else
+	print_result "Above-threshold (3 prior ticks >= threshold 2): STALE_ESCALATED emitted" 1 "(got: '$output')"
+fi
+
+export PATH="$OLD_PATH"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+	exit 0
+else
+	printf '%s%d / %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Add stale-recovery counter to _recover_stale_assignment in dispatch-dedup-helper.sh. After STALE_RECOVERY_THRESHOLD (default 2) consecutive recoveries without a PR, apply needs-maintainer-review instead of resetting to status:available. Counter stored as structured HTML comment markers for cross-runner correctness. Counter resets when open PR detected.

## Files Changed

.agents/configs/dispatch-stale-recovery.conf,.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-stale-recovery-escalation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on dispatch-dedup-helper.sh and test file. 11/11 new tests pass (test-stale-recovery-escalation.sh). 20/20 parent-task-guard regression tests pass. 7/7 dispatch-dedup-multi-operator regression tests pass.

Resolves #18456


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.2 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 11m and 36,299 tokens on this as a headless worker.