### PR TITLE
GH#18443: fix(issue-sync): add auto-dispatch to _is_protected_label exact-match list

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -130,7 +130,7 @@ _is_protected_label() {
 	case "$lbl" in
 	persistent | needs-maintainer-review | not-planned | duplicate | wontfix | \
 		already-fixed | "good first issue" | "help wanted" | \
-		parent-task | meta)
+		parent-task | meta | auto-dispatch)
 		return 0
 		;;
 	esac


### PR DESCRIPTION
## Summary

Added auto-dispatch to the exact-match protected label list in _is_protected_label() to prevent reconciliation from stripping it when the TODO entry doesn't yet carry the #auto-dispatch tag.

## Files Changed

.agents/scripts/issue-sync-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified _is_protected_label returns 0 for auto-dispatch; shellcheck clean

Resolves #18443


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.2 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-haiku-4-5 spent 47s and 2,273 tokens on this as a headless worker.