### PR TITLE
t2000: refactor(pulse): Phase 12 — split dispatch_triage_reviews() (291 lines)

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# pulse-ancillary-dispatch.sh — Ancillary worker dispatch — triage reviews (303 lines), needs-info relabel, routine comment responses, FOSS workers.
+# pulse-ancillary-dispatch.sh — Ancillary worker dispatch — triage reviews, needs-info relabel, routine comment responses, FOSS workers.
 #
 # Extracted from pulse-wrapper.sh in Phase 10 (FINAL) of the phased
 # decomposition (parent: GH#18356, plan: todo/plans/pulse-wrapper-decomposition.md §6).
 #
-# This is the final extraction. After Phase 10 merges, pulse-wrapper.sh
-# drops below the 2,000-line simplification gate.
+# Phase 12 (t2000, GH#18448): dispatch_triage_reviews() split into three
+# functions to reduce size from 291 to <80 lines and improve testability.
 #
 # Functions in this module (in source order):
-#   - dispatch_triage_reviews
+#   - _build_triage_review_prompt   (private: pure prompt construction)
+#   - _dispatch_triage_review_worker (private: side-effecting worker dispatch)
+#   - dispatch_triage_reviews       (public: thin orchestrator)
 #   - relabel_needs_info_replies
 #   - dispatch_routine_comment_responses
 #   - dispatch_foss_workers
@@ -19,160 +21,77 @@
 _PULSE_ANCILLARY_DISPATCH_LOADED=1
 
 #######################################
-# Dispatch triage review workers for needs-maintainer-review issues
+# Build the prefetch prompt for a triage review
 #
-# Reads the pre-fetched triage status from STATE_FILE and dispatches
-# opus-tier review workers for issues marked needs-review. Respects
-# the 2-per-cycle cap and available worker slots.
+# Fetches issue metadata and comments, runs dedup-cache and
+# contributor-reply guards, then writes the prompt to a temp file.
+# Pure in the sense of no lock/unlock or agent launch; cache writes
+# and LOGFILE writes are allowed as logging side effects.
 #
 # Arguments:
-#   $1 - available worker slots (AVAILABLE)
-#   $2 - repos JSON path (default: REPOS_JSON)
+#   $1 - issue_num
+#   $2 - repo_slug
+#   $3 - repo_path (may be empty for non-local repos)
 #
-# Outputs: updated available count to stdout (one integer)
-# Exit code: always 0
+# Outputs to stdout: "prompt_file_path|content_hash" (pipe-separated)
+# Returns 0 on success; 1 if the issue should be skipped (cached or
+#   awaiting contributor reply)
 #######################################
-dispatch_triage_reviews() {
-	local available="$1"
-	local repos_json="${2:-${REPOS_JSON:-~/.config/aidevops/repos.json}}"
-	local triage_count=0
-	local triage_max=2
+_build_triage_review_prompt() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local repo_path="$3"
 
-	[[ "$available" =~ ^[0-9]+$ ]] || available=0
-	[[ "$available" -gt 0 ]] || {
-		printf '%d\n' "$available"
-		return 0
-	}
+	# ── GH#17746: Fetch body+comments early — needed for dedup AND prompt ──
+	local issue_json=""
+	issue_json=$(gh issue view "$issue_num" --repo "$repo_slug" \
+		--json number,title,body,author,labels,createdAt,updatedAt 2>/dev/null) || issue_json="{}"
 
-	# Parse needs-review items from the dedicated triage state file (t1894).
-	# NMR data is written to a separate file, not the LLM's STATE_FILE.
-	local triage_file="${TRIAGE_STATE_FILE:-${STATE_FILE%.txt}-triage.txt}"
-	[[ -f "$triage_file" ]] || {
-		echo "[pulse-wrapper] dispatch_triage_reviews: no triage state file" >>"$LOGFILE"
-		printf '%d\n' "$available"
-		return 0
-	}
-	local state_file="$triage_file"
+	local issue_comments=""
+	issue_comments=$(gh api "repos/${repo_slug}/issues/${issue_num}/comments" \
+		--jq '[.[] | {author: .user.login, body: .body, created: .created_at}]' 2>/dev/null) || issue_comments="[]"
 
-	# Resolve model: prefer opus, fall back to sonnet, then omit --model
-	# (lets headless-runtime-helper pick its default, same as implementation workers)
-	local resolved_model=""
-	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
-	if [[ -z "$resolved_model" ]]; then
-		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
-	fi
-	if [[ -z "$resolved_model" ]]; then
-		echo "[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)" >>"$LOGFILE"
+	local issue_body=""
+	issue_body=$(echo "$issue_json" | jq -r '.body // "No body"' 2>/dev/null) || issue_body="No body"
+
+	# Compute content hash and check cache
+	local content_hash=""
+	content_hash=$(_triage_content_hash "$issue_num" "$repo_slug" "$issue_body" "$issue_comments")
+
+	if _triage_is_cached "$issue_num" "$repo_slug" "$content_hash"; then
+		echo "[pulse-wrapper] triage dedup: skipping #${issue_num} in ${repo_slug} — content unchanged since last triage" >>"$LOGFILE"
+		return 1
 	fi
 
-	# Parse markdown-format state entries:
-	#   ## owner/repo            ← repo slug header
-	#   - Issue #NNN: ... [status: **needs-review**] ...
-	# Build pipe-separated list: issue_num|repo_slug|repo_path
-	local current_slug="" current_path="" candidates=""
-	while IFS= read -r line; do
-		# Match repo slug headers: "## owner/repo"
-		if [[ "$line" =~ ^##[[:space:]]+([^[:space:]]+/[^[:space:]]+) ]]; then
-			current_slug="${BASH_REMATCH[1]}"
-			current_path=$(jq -r --arg s "$current_slug" '.initialized_repos[]? | select(.slug == $s) | .path' "$repos_json" 2>/dev/null || echo "")
-			# Expand ~ in path
-			current_path="${current_path/#\~/$HOME}"
-			continue
-		fi
-		# Match needs-review issue lines
-		if [[ "$line" == *"**needs-review**"* && "$line" =~ Issue\ #([0-9]+) ]]; then
-			local issue_num="${BASH_REMATCH[1]}"
-			if [[ -n "$current_slug" && -n "$current_path" ]]; then
-				candidates="${candidates}${issue_num}|${current_slug}|${current_path}"$'\n'
-			fi
-		fi
-	done <"$state_file"
-
-	local candidate_count=0
-	if [[ -n "$candidates" ]]; then
-		candidate_count=$(printf '%s' "$candidates" | grep -c '|' 2>/dev/null || echo 0)
+	# ── GH#17827: Skip if awaiting contributor reply ──
+	# A new contributor comment will change the hash and trigger re-evaluation.
+	if _triage_awaiting_contributor_reply "$issue_comments" "$repo_slug"; then
+		echo "[pulse-wrapper] triage skip: #${issue_num} in ${repo_slug} — awaiting contributor reply (GH#17827)" >>"$LOGFILE"
+		_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
+		return 1
 	fi
-	echo "[pulse-wrapper] dispatch_triage_reviews: parsed ${candidate_count} candidates from state file" >>"$LOGFILE"
 
-	[[ -n "$candidates" ]] || {
-		echo "[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file" >>"$LOGFILE"
-		printf '%d\n' "$available"
-		return 0
-	}
+	# ── Content is new or changed — proceed with full prefetch ──
+	local pr_diff="" pr_files="" is_pr=""
+	is_pr=$(gh pr view "$issue_num" --repo "$repo_slug" --json number --jq '.number' 2>/dev/null) || is_pr=""
+	if [[ -n "$is_pr" ]]; then
+		pr_diff=$(gh pr diff "$issue_num" --repo "$repo_slug" 2>/dev/null | head -500) || pr_diff=""
+		pr_files=$(gh pr view "$issue_num" --repo "$repo_slug" --json files --jq '[.files[].path]' 2>/dev/null) || pr_files="[]"
+	fi
 
-	while IFS='|' read -r issue_num repo_slug repo_path; do
-		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
-		[[ "$available" -gt 0 && "$triage_count" -lt "$triage_max" ]] || break
+	local recent_closed=""
+	recent_closed=$(gh issue list --repo "$repo_slug" --state closed \
+		--json number,title --limit 30 --jq '.[].title' 2>/dev/null) || recent_closed=""
 
-		# ── t1916: Triage is exempt from the cryptographic approval gate ──
-		# Triage is read + comment — it helps the maintainer decide whether to
-		# approve the issue for implementation dispatch. The approval gate is
-		# enforced on implementation dispatch (dispatch_with_dedup), not here.
-		# Previously blocked by GH#17490 (t1894), restored in GH#17705 (t1916).
+	local git_log_context=""
+	if [[ -n "$is_pr" && -n "$repo_path" && -d "$repo_path" ]]; then
+		git_log_context=$(git -C "$repo_path" log --oneline -10 2>/dev/null) || git_log_context=""
+	fi
 
-		# ── GH#17746: Content-hash dedup — fetch body+comments first ──
-		# Fetch issue metadata and comments early: needed for both the dedup
-		# check AND the prefetch prompt. If content is unchanged since the
-		# last triage attempt, skip entirely (saves agent launch, lock/unlock,
-		# and remaining API calls).
-		local issue_json=""
-		issue_json=$(gh issue view "$issue_num" --repo "$repo_slug" \
-			--json number,title,body,author,labels,createdAt,updatedAt 2>/dev/null) || issue_json="{}"
+	local prefetch_file=""
+	prefetch_file=$(mktemp)
 
-		local issue_comments=""
-		issue_comments=$(gh api "repos/${repo_slug}/issues/${issue_num}/comments" \
-			--jq '[.[] | {author: .user.login, body: .body, created: .created_at}]' 2>/dev/null) || issue_comments="[]"
-
-		local issue_body=""
-		issue_body=$(echo "$issue_json" | jq -r '.body // "No body"' 2>/dev/null) || issue_body="No body"
-
-		# Compute content hash and check cache
-		local content_hash=""
-		content_hash=$(_triage_content_hash "$issue_num" "$repo_slug" "$issue_body" "$issue_comments")
-
-		if _triage_is_cached "$issue_num" "$repo_slug" "$content_hash"; then
-			echo "[pulse-wrapper] triage dedup: skipping #${issue_num} in ${repo_slug} — content unchanged since last triage" >>"$LOGFILE"
-			continue
-		fi
-
-		# ── GH#17827: Skip triage if awaiting contributor reply ──
-		# When the last human comment is from a collaborator (maintainer asking
-		# for info), the contributor needs to respond — not another triage cycle.
-		# This eliminates the lock/unlock noise on NMR issues waiting for replies.
-		if _triage_awaiting_contributor_reply "$issue_comments" "$repo_slug"; then
-			echo "[pulse-wrapper] triage skip: #${issue_num} in ${repo_slug} — awaiting contributor reply (last comment from collaborator) (GH#17827)" >>"$LOGFILE"
-			# Cache the hash so we don't re-check every cycle. A new contributor
-			# comment will change the hash and trigger re-evaluation.
-			_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
-			continue
-		fi
-
-		# ── Content is new or changed — proceed with full prefetch ──
-
-		# Check if this is a PR
-		local pr_diff="" pr_files="" is_pr=""
-		is_pr=$(gh pr view "$issue_num" --repo "$repo_slug" --json number --jq '.number' 2>/dev/null) || is_pr=""
-		if [[ -n "$is_pr" ]]; then
-			pr_diff=$(gh pr diff "$issue_num" --repo "$repo_slug" 2>/dev/null | head -500) || pr_diff=""
-			pr_files=$(gh pr view "$issue_num" --repo "$repo_slug" --json files --jq '[.files[].path]' 2>/dev/null) || pr_files="[]"
-		fi
-
-		# Recent closed issues for duplicate detection
-		local recent_closed=""
-		recent_closed=$(gh issue list --repo "$repo_slug" --state closed \
-			--json number,title --limit 30 --jq '.[].title' 2>/dev/null) || recent_closed=""
-
-		# Git log for affected files (if PR)
-		local git_log_context=""
-		if [[ -n "$is_pr" && -n "$repo_path" && -d "$repo_path" ]]; then
-			git_log_context=$(git -C "$repo_path" log --oneline -10 2>/dev/null) || git_log_context=""
-		fi
-
-		# Build the prompt with all pre-fetched data
-		local prefetch_file=""
-		prefetch_file=$(mktemp)
-
-		cat >"$prefetch_file" <<PREFETCH_EOF
+	cat >"$prefetch_file" <<PREFETCH_EOF
 You are reviewing issue/PR #${issue_num} in ${repo_slug}.
 
 ## ISSUE_METADATA
@@ -201,125 +120,217 @@ ${git_log_context:-No git log available}
 Now read the triage-review.md agent instructions and produce your review.
 PREFETCH_EOF
 
-		# ── Launch sandboxed agent (no Bash, no gh, no network) ──
-		# NOTE: headless-runtime-helper.sh does not yet support --allowed-tools.
-		# Tool restriction is enforced by the triage-review.md agent file frontmatter
-		# in runtimes that respect YAML tool declarations (Claude Code, OpenCode).
-		local review_output_file=""
-		review_output_file=$(mktemp)
+	# Output file path and content hash (pipe-separated) for the caller
+	printf '%s|%s\n' "$prefetch_file" "$content_hash"
+	return 0
+}
 
-		local model_flag=""
-		if [[ -n "$resolved_model" ]]; then
-			model_flag="--model $resolved_model"
+#######################################
+# Dispatch a sandboxed triage review worker and post its output
+#
+# Locks the issue, runs the triage-review agent, posts the review
+# comment (with safety filtering), updates triage labels, updates the
+# content-hash cache, and unlocks the issue. All side effects live here.
+#
+# Arguments:
+#   $1 - issue_num
+#   $2 - repo_slug
+#   $3 - repo_path (passed to --dir of headless helper)
+#   $4 - prompt_file (path to prefetch temp file; consumed and removed)
+#   $5 - content_hash (for success/failure cache update)
+#   $6 - resolved_model (empty = let helper choose)
+#
+# Exit code: always 0
+#######################################
+_dispatch_triage_review_worker() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local repo_path="$3"
+	local prefetch_file="$4"
+	local content_hash="$5"
+	local resolved_model="${6:-}"
+
+	local model_flag=""
+	[[ -n "$resolved_model" ]] && model_flag="--model $resolved_model"
+
+	# ── Launch sandboxed agent (no Bash, no gh, no network) ──
+	# NOTE: headless-runtime-helper.sh does not yet support --allowed-tools.
+	# Tool restriction is enforced by the triage-review.md agent file frontmatter
+	# in runtimes that respect YAML tool declarations (Claude Code, OpenCode).
+	local review_output_file=""
+	review_output_file=$(mktemp)
+
+	# t1894/t1934: Lock issue and linked PRs during triage
+	lock_issue_for_worker "$issue_num" "$repo_slug"
+
+	# Run agent with triage-review prompt — agent file restricts to Read/Glob/Grep
+	# shellcheck disable=SC2086
+	"$HEADLESS_RUNTIME_HELPER" run \
+		--role worker \
+		--session-key "triage-review-${issue_num}" \
+		--dir "$repo_path" \
+		$model_flag \
+		--title "Sandboxed triage review: Issue #${issue_num}" \
+		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1
+
+	rm -f "$prefetch_file"
+
+	# ── Post-process: post the review comment (deterministic) ──
+	local review_text=""
+	review_text=$(cat "$review_output_file")
+	rm -f "$review_output_file"
+
+	local triage_posted="false"
+
+	if [[ -n "$review_text" && ${#review_text} -gt 50 ]]; then
+		# ── Safety filter: NEVER post raw sandbox/infrastructure output ──
+		# If the LLM failed (quota, timeout, garbled), the output contains
+		# sandbox startup logs, execution metadata, or internal paths.
+		# These MUST be discarded — posting them leaks sensitive infra data.
+		local has_infra_markers="false"
+		if echo "$review_text" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper|/opt/homebrew/|opencode run '; then
+			has_infra_markers="true"
 		fi
 
-		# t1894/t1934: Lock issue and linked PRs during triage
-		lock_issue_for_worker "$issue_num" "$repo_slug"
+		# Extract just the review portion (starts with ## Review variants).
+		# GH#17873: Workers sometimes produce slightly different headers
+		# (e.g., "## Review", "## Triage Review:", "## Review Summary:").
+		# Match any "## " line containing "Review" (case-insensitive).
+		local clean_review=""
+		clean_review=$(echo "$review_text" | sed -n '/^## .*[Rr]eview/,$ p')
 
-		# Run agent with triage-review prompt — agent file restricts to Read/Glob/Grep
-		# shellcheck disable=SC2086
-		"$HEADLESS_RUNTIME_HELPER" run \
-			--role worker \
-			--session-key "triage-review-${issue_num}" \
-			--dir "$repo_path" \
-			$model_flag \
-			--title "Sandboxed triage review: Issue #${issue_num}" \
-			--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1
-
-		rm -f "$prefetch_file"
-
-		# ── Post-process: post the review comment (deterministic) ──
-		local review_text=""
-		review_text=$(cat "$review_output_file")
-		rm -f "$review_output_file"
-
-		local triage_posted="false"
-
-		if [[ -n "$review_text" && ${#review_text} -gt 50 ]]; then
-			# ── Safety filter: NEVER post raw sandbox/infrastructure output ──
-			# If the LLM failed (quota, timeout, garbled), the output contains
-			# sandbox startup logs, execution metadata, or internal paths.
-			# These MUST be discarded — posting them leaks sensitive infra data.
-			local has_infra_markers="false"
-			if echo "$review_text" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper|/opt/homebrew/|opencode run '; then
-				has_infra_markers="true"
-			fi
-
-			# Extract just the review portion (starts with ## Review variants).
-			# GH#17873: Workers sometimes produce slightly different headers
-			# (e.g., "## Review", "## Triage Review:", "## Review Summary:").
-			# Match any "## " line containing "Review" (case-insensitive).
-			local clean_review=""
-			clean_review=$(echo "$review_text" | sed -n '/^## .*[Rr]eview/,$ p')
-
-			if [[ -n "$clean_review" ]]; then
-				# Re-check extracted review for infra leaks (belt-and-suspenders)
-				if echo "$clean_review" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper'; then
-					echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} contained infrastructure markers after extraction — suppressed" >>"$LOGFILE"
-				else
-					gh issue comment "$issue_num" --repo "$repo_slug" \
-						--body "$clean_review" >/dev/null 2>&1 || true
-					echo "[pulse-wrapper] Posted sandboxed triage review for #${issue_num} in ${repo_slug}" >>"$LOGFILE"
-					triage_posted="true"
-				fi
-			elif [[ "$has_infra_markers" == "true" ]]; then
-				# No review header AND infra markers present — raw sandbox output, discard entirely
-				echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} was raw sandbox output — suppressed (${#review_text} chars)" >>"$LOGFILE"
+		if [[ -n "$clean_review" ]]; then
+			# Re-check extracted review for infra leaks (belt-and-suspenders)
+			if echo "$clean_review" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper'; then
+				echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} contained infrastructure markers after extraction — suppressed" >>"$LOGFILE"
 			else
-				echo "[pulse-wrapper] Triage review for #${issue_num} had no review header (## *Review*) and no infra markers — suppressed to be safe (${#review_text} chars)" >>"$LOGFILE"
+				gh issue comment "$issue_num" --repo "$repo_slug" \
+					--body "$clean_review" >/dev/null 2>&1 || true
+				echo "[pulse-wrapper] Posted sandboxed triage review for #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+				triage_posted="true"
 			fi
+		elif [[ "$has_infra_markers" == "true" ]]; then
+			# No review header AND infra markers present — raw sandbox output, discard entirely
+			echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} was raw sandbox output — suppressed (${#review_text} chars)" >>"$LOGFILE"
 		else
-			echo "[pulse-wrapper] Triage review for #${issue_num} produced no usable output (${#review_text} chars)" >>"$LOGFILE"
+			echo "[pulse-wrapper] Triage review for #${issue_num} had no review header (## *Review*) and no infra markers — suppressed to be safe (${#review_text} chars)" >>"$LOGFILE"
 		fi
+	else
+		echo "[pulse-wrapper] Triage review for #${issue_num} produced no usable output (${#review_text} chars)" >>"$LOGFILE"
+	fi
 
-		# GH#17829: Surface triage failures visibly. When the triage worker
-		# fails to produce a review, the only evidence is log entries — the
-		# issue timeline shows lock/unlock churn with no visible outcome.
-		# Add a label so maintainers can identify issues needing manual triage.
-		# The label is removed when a successful triage review is posted.
-		if [[ "$triage_posted" == "true" ]]; then
-			gh issue edit "$issue_num" --repo "$repo_slug" \
-				--remove-label "triage-failed" >/dev/null 2>&1 || true
-		else
-			gh issue edit "$issue_num" --repo "$repo_slug" \
-				--add-label "triage-failed" >/dev/null 2>&1 || true
-			echo "[pulse-wrapper] Added triage-failed label to #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+	# GH#17829: Surface triage failures visibly. Add label so maintainers
+	# can identify issues needing manual triage; remove on success.
+	if [[ "$triage_posted" == "true" ]]; then
+		gh issue edit "$issue_num" --repo "$repo_slug" \
+			--remove-label "triage-failed" >/dev/null 2>&1 || true
+	else
+		gh issue edit "$issue_num" --repo "$repo_slug" \
+			--add-label "triage-failed" >/dev/null 2>&1 || true
+		echo "[pulse-wrapper] Added triage-failed label to #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+	fi
+
+	# Unlock issue after triage
+	unlock_issue_after_worker "$issue_num" "$repo_slug"
+
+	# GH#17873: Only cache content hash on successful post.
+	# GH#17827: If failures are persistent (>= TRIAGE_MAX_RETRIES on the
+	# same content hash), cache to break the infinite lock→agent→fail→unlock
+	# loop. The triage-failed label remains for maintainer visibility.
+	if [[ "$triage_posted" == "true" ]]; then
+		_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
+	elif _triage_increment_failure "$issue_num" "$repo_slug" "$content_hash"; then
+		echo "[pulse-wrapper] Triage retry cap reached for #${issue_num} in ${repo_slug} — caching hash to stop lock/unlock loop (GH#17827)" >>"$LOGFILE"
+		_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
+	else
+		echo "[pulse-wrapper] Skipping triage cache for #${issue_num} — review not posted, will retry on next cycle" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+#######################################
+# Dispatch triage review workers for needs-maintainer-review issues
+#
+# Reads the pre-fetched triage status from the triage state file and
+# dispatches opus-tier review workers for issues marked needs-review.
+# Respects the 2-per-cycle cap and available worker slots.
+#
+# Arguments:
+#   $1 - available worker slots (AVAILABLE)
+#   $2 - repos JSON path (default: REPOS_JSON)
+#
+# Outputs: updated available count to stdout (one integer)
+# Exit code: always 0
+#######################################
+dispatch_triage_reviews() {
+	local available="$1"
+	local repos_json="${2:-${REPOS_JSON:-~/.config/aidevops/repos.json}}"
+	local triage_count=0
+	local triage_max=2
+
+	[[ "$available" =~ ^[0-9]+$ ]] || available=0
+	[[ "$available" -gt 0 ]] || {
+		printf '%d\n' "$available"
+		return 0
+	}
+
+	# NMR data is in a dedicated triage state file, not the LLM's STATE_FILE (t1894).
+	local triage_file="${TRIAGE_STATE_FILE:-${STATE_FILE%.txt}-triage.txt}"
+	[[ -f "$triage_file" ]] || {
+		echo "[pulse-wrapper] dispatch_triage_reviews: no triage state file" >>"$LOGFILE"
+		printf '%d\n' "$available"
+		return 0
+	}
+
+	# Resolve model: prefer opus, fall back to sonnet, then omit --model
+	local resolved_model=""
+	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
+	[[ -n "$resolved_model" ]] || resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
+	[[ -n "$resolved_model" ]] || echo "[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)" >>"$LOGFILE"
+
+	# Parse "## owner/repo" headers and "- Issue #N: ... [status: **needs-review**]" lines.
+	local current_slug="" current_path="" candidates=""
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^##[[:space:]]+([^[:space:]]+/[^[:space:]]+) ]]; then
+			current_slug="${BASH_REMATCH[1]}"
+			current_path=$(jq -r --arg s "$current_slug" '.initialized_repos[]? | select(.slug == $s) | .path' "$repos_json" 2>/dev/null || echo "")
+			current_path="${current_path/#\~/$HOME}"
+			continue
 		fi
-
-		# Unlock issue after triage
-		unlock_issue_after_worker "$issue_num" "$repo_slug"
-
-		# GH#17873: Only cache content hash on successful post.
-		# Previously (GH#17746) the cache was written unconditionally,
-		# which created a dead-letter state: if the safety filter suppressed
-		# the review (e.g., missing ## Review: header), the content hash was
-		# still cached, and subsequent pulse cycles would skip the issue
-		# forever ("content unchanged since last triage") even though no
-		# review was ever posted. Now we only cache on success — failed
-		# attempts are retried on the next pulse cycle, allowing transient
-		# worker formatting issues to self-heal.
-		#
-		# GH#17827: BUT if failures are persistent (>= TRIAGE_MAX_RETRIES on
-		# the same content hash), cache anyway to break the infinite
-		# lock→agent→fail→unlock loop. The triage-failed label remains so
-		# maintainers can identify these issues for manual triage.
-		if [[ "$triage_posted" == "true" ]]; then
-			_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
-		elif _triage_increment_failure "$issue_num" "$repo_slug" "$content_hash"; then
-			echo "[pulse-wrapper] Triage retry cap reached for #${issue_num} in ${repo_slug} — caching hash to stop lock/unlock loop (GH#17827)" >>"$LOGFILE"
-			_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
-		else
-			echo "[pulse-wrapper] Skipping triage cache for #${issue_num} — review not posted, will retry on next cycle" >>"$LOGFILE"
+		if [[ "$line" == *"**needs-review**"* && "$line" =~ Issue\ #([0-9]+) ]]; then
+			local issue_num="${BASH_REMATCH[1]}"
+			[[ -n "$current_slug" && -n "$current_path" ]] && candidates="${candidates}${issue_num}|${current_slug}|${current_path}"$'\n'
 		fi
+	done <"$triage_file"
+
+	local candidate_count=0
+	[[ -n "$candidates" ]] && candidate_count=$(printf '%s' "$candidates" | grep -c '|' 2>/dev/null || echo 0)
+	echo "[pulse-wrapper] dispatch_triage_reviews: parsed ${candidate_count} candidates from state file" >>"$LOGFILE"
+
+	[[ -n "$candidates" ]] || {
+		echo "[pulse-wrapper] dispatch_triage_reviews: 0 candidates found in state file" >>"$LOGFILE"
+		printf '%d\n' "$available"
+		return 0
+	}
+
+	# t1916: Triage is exempt from the cryptographic approval gate.
+	while IFS='|' read -r issue_num repo_slug repo_path; do
+		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
+		[[ "$available" -gt 0 && "$triage_count" -lt "$triage_max" ]] || break
+
+		local prompt_result=""
+		prompt_result=$(_build_triage_review_prompt "$issue_num" "$repo_slug" "$repo_path") || continue
+		_dispatch_triage_review_worker \
+			"$issue_num" "$repo_slug" "$repo_path" \
+			"${prompt_result%%|*}" "${prompt_result#*|}" "$resolved_model"
 
 		sleep 2
 		triage_count=$((triage_count + 1))
 		available=$((available - 1))
 	done <<<"$candidates"
 
-	local slots_remaining="$available"
-	echo "[pulse-wrapper] dispatch_triage_reviews: dispatched ${triage_count} triage workers (${slots_remaining} slots remaining)" >>"$LOGFILE"
-
+	echo "[pulse-wrapper] dispatch_triage_reviews: dispatched ${triage_count} triage workers (${available} slots remaining)" >>"$LOGFILE"
 	printf '%d\n' "$available"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -468,6 +468,9 @@ _setup_dispatch_stub() {
 	printf 'printf "%%s\\n" "$session_key" >> "${DISPATCH_LOG_FILE}"\n' >>"${stub_dir}/headless-runtime-helper.sh"
 	chmod +x "${stub_dir}/headless-runtime-helper.sh"
 	export PATH="${stub_dir}:${PATH}"
+	# Override HEADLESS_RUNTIME_HELPER so dispatch_triage_reviews uses the stub
+	# instead of the absolute path set when pulse-wrapper.sh was sourced.
+	export HEADLESS_RUNTIME_HELPER="${stub_dir}/headless-runtime-helper.sh"
 	export DISPATCH_LOG_FILE="${TEST_ROOT}/dispatch.log"
 	: >"$DISPATCH_LOG_FILE"
 	return 0
@@ -508,6 +511,7 @@ test_dispatch_triage_reviews_decrements_slot_count() {
 ")
 
 	STATE_FILE="$state_file"
+	TRIAGE_STATE_FILE="$state_file"
 	# model-availability-helper.sh is not available in test env; resolved_model
 	# will be empty, which exercises the no-model branch (same as production
 	# when all models are rate-limited).
@@ -537,6 +541,7 @@ test_dispatch_triage_reviews_no_stderr_errors() {
 ")
 
 	STATE_FILE="$state_file"
+	TRIAGE_STATE_FILE="$state_file"
 	local stderr_file="${TEST_ROOT}/triage-stderr.txt"
 	dispatch_triage_reviews 3 "$repos_json" 2>"$stderr_file" >/dev/null
 
@@ -576,6 +581,7 @@ test_dispatch_triage_reviews_returns_available_when_no_candidates() {
 ")
 
 	STATE_FILE="$state_file"
+	TRIAGE_STATE_FILE="$state_file"
 	local remaining
 	remaining=$(dispatch_triage_reviews 4 "$repos_json" 2>/dev/null)
 
@@ -603,6 +609,7 @@ test_dispatch_triage_reviews_caps_at_triage_max() {
 ")
 
 	STATE_FILE="$state_file"
+	TRIAGE_STATE_FILE="$state_file"
 	local remaining
 	remaining=$(dispatch_triage_reviews 10 "$repos_json" 2>/dev/null)
 
@@ -629,6 +636,7 @@ test_dispatch_triage_reviews_returns_zero_when_no_slots() {
 ")
 
 	STATE_FILE="$state_file"
+	TRIAGE_STATE_FILE="$state_file"
 	local remaining
 	remaining=$(dispatch_triage_reviews 0 "$repos_json" 2>/dev/null)
 
@@ -659,6 +667,7 @@ test_dispatch_triage_reviews_resolves_repo_path_via_initialized_repos() {
 ")
 
 	STATE_FILE="$state_file"
+	TRIAGE_STATE_FILE="$state_file"
 	local remaining
 	remaining=$(dispatch_triage_reviews 3 "$repos_json_path" 2>/dev/null)
 
@@ -678,6 +687,8 @@ test_dispatch_triage_reviews_returns_available_when_no_state_file() {
 	local repos_json
 	repos_json=$(_make_repos_json "owner/repo" "/tmp/repo")
 
+	# Clear TRIAGE_STATE_FILE so the function falls back to deriving from STATE_FILE.
+	TRIAGE_STATE_FILE=""
 	STATE_FILE="/nonexistent/state-file-that-does-not-exist.txt"
 	local remaining
 	remaining=$(dispatch_triage_reviews 7 "$repos_json" 2>/dev/null)


### PR DESCRIPTION
## Summary

Resolves #18448

Split `dispatch_triage_reviews()` (291 lines, second-largest function in `pulse-ancillary-dispatch.sh`) into three focused functions as planned in §6 Phase 12 candidate #2:

- **`_build_triage_review_prompt()`** (87 lines) — pure prompt construction. Fetches issue/PR metadata, runs content-hash dedup and contributor-reply guards, builds the prefetch file. No lock/unlock or agent launch.
- **`_dispatch_triage_review_worker()`** (106 lines) — all side effects. Locks issue, runs sandboxed agent, posts review, updates labels, updates cache, unlocks.
- **`dispatch_triage_reviews()`** (71 lines) — thin orchestrator. Candidate selection + loop that calls the two helpers.

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| `dispatch_triage_reviews()` under 80 lines | ✅ 71 lines |
| `_build_triage_review_prompt()` under 180 lines | ✅ 87 lines |
| `_dispatch_triage_review_worker()` under 180 lines | ✅ 106 lines |
| External interface unchanged | ✅ |
| `--self-check` reports 28 canonical fns + 23 module guards | ✅ |
| `shellcheck` clean (no new findings) | ✅ |
| All existing pulse tests pass | ✅ 22/22 |

## Investigation: 3 pre-existing worker-count test failures

The 3 failures in `test-pulse-wrapper-worker-count.sh` were caused by a `STATE_FILE` vs `TRIAGE_STATE_FILE` mismatch in the tests, unrelated to the split itself.

**Root cause**: `dispatch_triage_reviews()` reads from `${TRIAGE_STATE_FILE:-${STATE_FILE%.txt}-triage.txt}`. Tests set `STATE_FILE=/tmp/.../pulse-state.txt`, so the function derived `/tmp/.../pulse-state-triage.txt` (which didn't exist) and returned early — never dispatching, never decrementing slot count.

**Fixes applied**:
1. Tests now set `TRIAGE_STATE_FILE="$state_file"` alongside `STATE_FILE`.
2. `_setup_dispatch_stub` exports `HEADLESS_RUNTIME_HELPER` to the stub path (previously only added to PATH, but the function uses the absolute path variable set at source time).
3. Test 7 (`returns_available_when_no_state_file`) clears `TRIAGE_STATE_FILE=""` before setting `STATE_FILE` to a non-existent path, to test the proper fallback.

The fixes are minimal test-infra corrections that don't change the production logic. All 22 tests now pass.

## Verification

```
bash -n .agents/scripts/pulse-ancillary-dispatch.sh          # syntax: PASS
SHELLCHECK_RSS_LIMIT_MB=4096 shellcheck pulse-ancillary-dispatch.sh  # PASS
.agents/scripts/pulse-wrapper.sh --self-check                # 28 canonical fns, 23 module guards
bash tests/test-pulse-wrapper-characterization.sh            # 26/26 PASS
bash tests/test-pulse-wrapper-worker-count.sh                # 22/22 PASS (was 19/22)
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.2 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 17m and 59,424 tokens on this as a headless worker.