### PR TITLE
t2016: fix(pulse-triage): surface triage failures — escalation comment + label provisioning

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -21,6 +21,133 @@
 _PULSE_ANCILLARY_DISPATCH_LOADED=1
 
 #######################################
+# Ensure the triage-failed label exists in the target repo.
+#
+# Uses gh label create --force (idempotent — creates if missing,
+# refreshes colour/description if present). This fixes t2016 where
+# the label was never provisioned in any repo and every
+# `gh issue edit --add-label "triage-failed"` call failed silently.
+#
+# Arguments:
+#   $1 - repo_slug (owner/repo)
+#######################################
+_ensure_triage_failed_label() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 0
+	gh label create "triage-failed" \
+		--repo "$repo_slug" \
+		--color "E11D21" \
+		--description "Automated triage could not produce a review — needs manual attention" \
+		--force >/dev/null 2>&1 || true
+	return 0
+}
+
+#######################################
+# Post a maintainer-visible escalation comment when automated triage
+# has exhausted its retry budget.
+#
+# Idempotent via the `<!-- triage-escalation -->` HTML marker — if a
+# comment containing the marker already exists, this is a no-op.
+# This closes the observability gap identified in t2016 where the
+# content-hash cache was written after N failures, silently locking
+# the issue out of triage with no visible signal to maintainers.
+#
+# Arguments:
+#   $1 - issue_num
+#   $2 - repo_slug
+#   $3 - failure_reason (short machine-readable tag)
+#   $4 - attempts (integer count of retries used)
+#   $5 - last_output_chars (integer)
+#
+# Returns 0 on success or when the marker already exists; non-zero
+# is reserved for unexpected gh failures (best-effort — the caller
+# should not block on this).
+#######################################
+_post_triage_escalation_comment() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local failure_reason="${3:-unknown}"
+	local attempts="${4:-0}"
+	local last_output_chars="${5:-0}"
+
+	[[ -n "$issue_num" && -n "$repo_slug" ]] || return 0
+
+	# Idempotency guard — scan existing comments for our marker.
+	local existing=""
+	existing=$(gh api "repos/${repo_slug}/issues/${issue_num}/comments" \
+		--jq '[.[] | select(.body | contains("<!-- triage-escalation -->"))] | length' \
+		2>/dev/null) || existing=""
+	if [[ "$existing" =~ ^[0-9]+$ && "$existing" -gt 0 ]]; then
+		echo "[pulse-wrapper] triage escalation comment already present on #${issue_num} in ${repo_slug} — skipping (idempotent)" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Map failure_reason → human-readable explanation.
+	local reason_human="${failure_reason}"
+	case "$failure_reason" in
+	no-review-header)
+		reason_human="Worker produced output but it did not contain a \`## Review\` header (safety filter suppressed the post)."
+		;;
+	raw-sandbox-output)
+		reason_human="Worker output contained infrastructure/sandbox markers (log lines, exec metadata). Suppressed to prevent leaking internal paths."
+		;;
+	no-usable-output)
+		reason_human="Worker returned no usable output (empty or <50 chars)."
+		;;
+	infra-markers-after-extraction)
+		reason_human="Extracted review block still contained infrastructure markers — suppressed as a belt-and-suspenders safety check."
+		;;
+	esac
+
+	# Compose signature footer via the canonical helper.
+	local footer=""
+	if [[ -x "$HOME/.aidevops/agents/scripts/gh-signature-helper.sh" ]]; then
+		footer=$("$HOME/.aidevops/agents/scripts/gh-signature-helper.sh" footer \
+			--model "pulse-triage" \
+			--issue "${repo_slug}#${issue_num}" 2>/dev/null) || footer=""
+	fi
+
+	local body_file=""
+	body_file=$(mktemp)
+	cat >"$body_file" <<ESCALATION_EOF
+<!-- triage-escalation -->
+## Automated triage could not produce a review
+
+The pulse attempted to post an automated triage review on this issue **${attempts}** time(s) but every attempt was suppressed by the safety filter. The content-hash cache has now been written to stop the lock/unlock churn, which means **this issue will no longer appear in the automated triage queue** until its body or comments change.
+
+### What went wrong
+
+- **Reason:** ${reason_human}
+- **Last attempt output size:** ${last_output_chars} chars
+- **Failure tag:** \`${failure_reason}\`
+
+### What a maintainer should do
+
+1. **Review manually** — run \`/review-issue-pr ${issue_num}\` in an interactive session, or open the issue and evaluate it by hand.
+2. **Force a retry** (optional) — delete the cache entry to let the next pulse cycle re-attempt:
+
+    \`\`\`bash
+    rm -f ~/.aidevops/.agent-workspace/tmp/triage-cache/$(echo "$repo_slug" | tr '/' '_')-${issue_num}.hash
+    gh issue edit ${issue_num} --repo ${repo_slug} --remove-label triage-failed
+    \`\`\`
+
+3. **Fix the worker** (if this keeps happening) — huge headerless outputs usually mean the triage-review agent prompt needs tightening. See \`.agents/workflows/triage-review.md\`.
+
+*This escalation was posted automatically by \`_post_triage_escalation_comment\` in \`pulse-ancillary-dispatch.sh\` (t2016) because the retry budget was exhausted without a visible review.*${footer:+
+
+}${footer:-}
+ESCALATION_EOF
+
+	if gh issue comment "$issue_num" --repo "$repo_slug" --body-file "$body_file" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] Posted triage escalation comment on #${issue_num} in ${repo_slug} (reason: ${failure_reason}, attempts: ${attempts})" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] Failed to post triage escalation comment on #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+	fi
+	rm -f "$body_file"
+	return 0
+}
+
+#######################################
 # Build the prefetch prompt for a triage review
 #
 # Fetches issue metadata and comments, runs dedup-cache and
@@ -181,6 +308,10 @@ _dispatch_triage_review_worker() {
 	rm -f "$review_output_file"
 
 	local triage_posted="false"
+	# t2016: Track WHY the post was suppressed so the escalation comment
+	# can surface an actionable reason instead of a buried log line.
+	local failure_reason=""
+	local output_chars="${#review_text}"
 
 	if [[ -n "$review_text" && ${#review_text} -gt 50 ]]; then
 		# ── Safety filter: NEVER post raw sandbox/infrastructure output ──
@@ -203,6 +334,7 @@ _dispatch_triage_review_worker() {
 			# Re-check extracted review for infra leaks (belt-and-suspenders)
 			if echo "$clean_review" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper'; then
 				echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} contained infrastructure markers after extraction — suppressed" >>"$LOGFILE"
+				failure_reason="infra-markers-after-extraction"
 			else
 				gh issue comment "$issue_num" --repo "$repo_slug" \
 					--body "$clean_review" >/dev/null 2>&1 || true
@@ -212,22 +344,31 @@ _dispatch_triage_review_worker() {
 		elif [[ "$has_infra_markers" == "true" ]]; then
 			# No review header AND infra markers present — raw sandbox output, discard entirely
 			echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} was raw sandbox output — suppressed (${#review_text} chars)" >>"$LOGFILE"
+			failure_reason="raw-sandbox-output"
 		else
 			echo "[pulse-wrapper] Triage review for #${issue_num} had no review header (## *Review*) and no infra markers — suppressed to be safe (${#review_text} chars)" >>"$LOGFILE"
+			failure_reason="no-review-header"
 		fi
 	else
 		echo "[pulse-wrapper] Triage review for #${issue_num} produced no usable output (${#review_text} chars)" >>"$LOGFILE"
+		failure_reason="no-usable-output"
 	fi
 
 	# GH#17829: Surface triage failures visibly. Add label so maintainers
 	# can identify issues needing manual triage; remove on success.
+	# t2016: Ensure the label exists first (gh label create --force is
+	# idempotent) and only log "Added" when the add command succeeds.
 	if [[ "$triage_posted" == "true" ]]; then
 		gh issue edit "$issue_num" --repo "$repo_slug" \
 			--remove-label "triage-failed" >/dev/null 2>&1 || true
 	else
-		gh issue edit "$issue_num" --repo "$repo_slug" \
-			--add-label "triage-failed" >/dev/null 2>&1 || true
-		echo "[pulse-wrapper] Added triage-failed label to #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+		_ensure_triage_failed_label "$repo_slug"
+		if gh issue edit "$issue_num" --repo "$repo_slug" \
+			--add-label "triage-failed" >/dev/null 2>&1; then
+			echo "[pulse-wrapper] Added triage-failed label to #${issue_num} in ${repo_slug}" >>"$LOGFILE"
+		else
+			echo "[pulse-wrapper] FAILED to add triage-failed label to #${issue_num} in ${repo_slug} (gh issue edit returned non-zero)" >>"$LOGFILE"
+		fi
 	fi
 
 	# Unlock issue after triage
@@ -237,10 +378,17 @@ _dispatch_triage_review_worker() {
 	# GH#17827: If failures are persistent (>= TRIAGE_MAX_RETRIES on the
 	# same content hash), cache to break the infinite lock→agent→fail→unlock
 	# loop. The triage-failed label remains for maintainer visibility.
+	# t2016: When the retry cap is hit, post a structured escalation comment
+	# BEFORE writing the cache, so the maintainer has a visible signal
+	# instead of a silently-cached issue that disappears from triage forever.
 	if [[ "$triage_posted" == "true" ]]; then
 		_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
 	elif _triage_increment_failure "$issue_num" "$repo_slug" "$content_hash"; then
 		echo "[pulse-wrapper] Triage retry cap reached for #${issue_num} in ${repo_slug} — caching hash to stop lock/unlock loop (GH#17827)" >>"$LOGFILE"
+		local cap_attempts="${TRIAGE_MAX_RETRIES:-1}"
+		_post_triage_escalation_comment \
+			"$issue_num" "$repo_slug" \
+			"$failure_reason" "$cap_attempts" "$output_chars"
 		_triage_update_cache "$issue_num" "$repo_slug" "$content_hash"
 	else
 		echo "[pulse-wrapper] Skipping triage cache for #${issue_num} — review not posted, will retry on next cycle" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-triage-failure-escalation.sh
+++ b/.agents/scripts/tests/test-triage-failure-escalation.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Unit tests for t2016 triage failure escalation helpers in
+# pulse-ancillary-dispatch.sh:
+#   - _ensure_triage_failed_label (label provisioning)
+#   - _post_triage_escalation_comment (maintainer-visible escalation)
+#
+# Uses the same harness style as test-pulse-wrapper-ever-nmr-cache.sh:
+# mocked `gh`, isolated HOME, marker files to assert call behaviour.
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_HOME="${HOME}"
+GH_CALL_LOG=""
+LOGFILE=""
+# Mock behaviour knobs — tests set these before exercising helpers.
+MOCK_COMMENTS_MARKER_COUNT=0
+MOCK_COMMENT_EXIT=0
+MOCK_LABEL_CREATE_EXIT=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/agents/scripts"
+	LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
+	: >"$LOGFILE"
+	GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_CALL_LOG"
+	# Reset mock knobs.
+	MOCK_COMMENTS_MARKER_COUNT=0
+	MOCK_COMMENT_EXIT=0
+	MOCK_LABEL_CREATE_EXIT=0
+	return 0
+}
+
+teardown_test_env() {
+	export HOME="${ORIGINAL_HOME}"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Mock `gh` that records every call and serves canned responses
+# based on the MOCK_* knobs.
+gh() {
+	printf '%s\n' "$*" >>"$GH_CALL_LOG"
+	case "${1:-}" in
+	api)
+		# API call: comments listing. Return marker count as JSON int.
+		printf '%d\n' "$MOCK_COMMENTS_MARKER_COUNT"
+		return 0
+		;;
+	label)
+		# `gh label create ...` — honour MOCK_LABEL_CREATE_EXIT.
+		return "$MOCK_LABEL_CREATE_EXIT"
+		;;
+	issue)
+		if [[ "${2:-}" == "comment" ]]; then
+			return "$MOCK_COMMENT_EXIT"
+		fi
+		return 0
+		;;
+	esac
+	return 0
+}
+export -f gh
+
+# Load just the two helper functions under test from the production
+# file. We redefine the private helpers via `source` of a small wrapper
+# that extracts them using awk — this keeps the test focused on the
+# helpers without booting the whole pulse-wrapper runtime.
+load_helpers_under_test() {
+	local src="${AIDEVOPS_SOURCE:-$HOME/Git/aidevops-bugfix-t2016-triage-cache-gate/.agents/scripts/pulse-ancillary-dispatch.sh}"
+	if [[ ! -f "$src" ]]; then
+		# Fallback: derive from this test file's location.
+		local here
+		here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+		src="${here}/../pulse-ancillary-dispatch.sh"
+	fi
+	if [[ ! -f "$src" ]]; then
+		printf 'ERROR: cannot locate pulse-ancillary-dispatch.sh (tried %s)\n' "$src" >&2
+		exit 2
+	fi
+	# Extract the two helper functions (ensure + post) into a temp file
+	# and source it. We stop at `_build_triage_review_prompt` which
+	# immediately follows the helpers in source order.
+	local tmp
+	tmp=$(mktemp)
+	awk '/^_ensure_triage_failed_label\(\) \{/{flag=1} flag{print} /^_build_triage_review_prompt\(\) \{/{flag=0}' "$src" |
+		sed '/^_build_triage_review_prompt()/d' >"$tmp"
+	# shellcheck disable=SC1090
+	source "$tmp"
+	rm -f "$tmp"
+}
+
+# ------------------------------ Tests ------------------------------
+
+test_ensure_label_invokes_gh_label_create() {
+	setup_test_env
+	load_helpers_under_test
+	_ensure_triage_failed_label "owner/repo"
+	if grep -q 'label create triage-failed --repo owner/repo' "$GH_CALL_LOG"; then
+		print_result "_ensure_triage_failed_label calls gh label create" 0
+	else
+		print_result "_ensure_triage_failed_label calls gh label create" 1 \
+			"gh call log did not contain 'label create triage-failed'"
+	fi
+	teardown_test_env
+}
+
+test_ensure_label_uses_force_flag() {
+	setup_test_env
+	load_helpers_under_test
+	_ensure_triage_failed_label "owner/repo"
+	if grep -q -- '--force' "$GH_CALL_LOG"; then
+		print_result "_ensure_triage_failed_label passes --force" 0
+	else
+		print_result "_ensure_triage_failed_label passes --force" 1 \
+			"gh label create was called without --force"
+	fi
+	teardown_test_env
+}
+
+test_ensure_label_is_noop_on_empty_slug() {
+	setup_test_env
+	load_helpers_under_test
+	_ensure_triage_failed_label ""
+	if [[ ! -s "$GH_CALL_LOG" ]]; then
+		print_result "_ensure_triage_failed_label is a no-op on empty slug" 0
+	else
+		print_result "_ensure_triage_failed_label is a no-op on empty slug" 1 \
+			"gh was called when slug was empty"
+	fi
+	teardown_test_env
+}
+
+test_escalation_posts_comment_with_marker() {
+	setup_test_env
+	load_helpers_under_test
+	MOCK_COMMENTS_MARKER_COUNT=0
+	_post_triage_escalation_comment "18428" "owner/repo" "no-review-header" 1 72233
+	# The mock records the full gh args; posting happens via `gh issue comment`.
+	if grep -q '^issue comment 18428 --repo owner/repo --body-file' "$GH_CALL_LOG"; then
+		print_result "_post_triage_escalation_comment invokes gh issue comment" 0
+	else
+		print_result "_post_triage_escalation_comment invokes gh issue comment" 1 \
+			"gh call log did not contain expected 'issue comment' invocation"
+	fi
+	teardown_test_env
+}
+
+test_escalation_is_idempotent_when_marker_present() {
+	setup_test_env
+	load_helpers_under_test
+	MOCK_COMMENTS_MARKER_COUNT=1
+	_post_triage_escalation_comment "18428" "owner/repo" "no-review-header" 1 72233
+	# Should have checked via gh api, but NOT called gh issue comment.
+	if ! grep -q '^issue comment' "$GH_CALL_LOG"; then
+		print_result "_post_triage_escalation_comment skips when marker present" 0
+	else
+		print_result "_post_triage_escalation_comment skips when marker present" 1 \
+			"gh issue comment was called despite existing marker"
+	fi
+	# And the log should say "skipping (idempotent)".
+	if grep -q 'idempotent' "$LOGFILE"; then
+		print_result "_post_triage_escalation_comment logs idempotency skip" 0
+	else
+		print_result "_post_triage_escalation_comment logs idempotency skip" 1 \
+			"LOGFILE missing 'idempotent' marker"
+	fi
+	teardown_test_env
+}
+
+test_escalation_is_noop_on_empty_args() {
+	setup_test_env
+	load_helpers_under_test
+	_post_triage_escalation_comment "" "owner/repo" "no-review-header" 1 0
+	_post_triage_escalation_comment "18428" "" "no-review-header" 1 0
+	if [[ ! -s "$GH_CALL_LOG" ]]; then
+		print_result "_post_triage_escalation_comment is a no-op on empty args" 0
+	else
+		print_result "_post_triage_escalation_comment is a no-op on empty args" 1 \
+			"gh was called with empty issue/slug"
+	fi
+	teardown_test_env
+}
+
+test_escalation_body_contains_recovery_instructions() {
+	setup_test_env
+	load_helpers_under_test
+	MOCK_COMMENTS_MARKER_COUNT=0
+	# Capture the body-file path from the gh call and read its contents.
+	# The mock doesn't actually write to disk, but _post_triage_escalation_comment
+	# creates the temp file via mktemp and rm's it at the end. So we need to
+	# hook gh to copy the body-file BEFORE it's removed. Easiest: redefine
+	# gh for this one test to cp the body-file to a known location.
+	local captured="${TEST_ROOT}/captured-body.md"
+	gh() {
+		printf '%s\n' "$*" >>"$GH_CALL_LOG"
+		if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+			# Find --body-file <path> in the arg list.
+			local i=0
+			local args=("$@")
+			while [[ $i -lt ${#args[@]} ]]; do
+				if [[ "${args[$i]}" == "--body-file" ]]; then
+					cp "${args[$((i + 1))]}" "$captured" 2>/dev/null || true
+					break
+				fi
+				i=$((i + 1))
+			done
+			return "$MOCK_COMMENT_EXIT"
+		fi
+		case "${1:-}" in
+		api)
+			printf '%d\n' "$MOCK_COMMENTS_MARKER_COUNT"
+			return 0
+			;;
+		label) return "$MOCK_LABEL_CREATE_EXIT" ;;
+		esac
+		return 0
+	}
+	export -f gh
+	_post_triage_escalation_comment "18428" "owner/repo" "no-review-header" 1 72233
+	if [[ ! -f "$captured" ]]; then
+		print_result "escalation body is written to a temp file" 1 "no captured body"
+		teardown_test_env
+		return 0
+	fi
+	local ok=0
+	grep -q '<!-- triage-escalation -->' "$captured" || ok=1
+	grep -q 'no-review-header' "$captured" || ok=1
+	grep -q 'rm -f' "$captured" || ok=1
+	grep -q 'remove-label triage-failed' "$captured" || ok=1
+	grep -q '72233' "$captured" || ok=1
+	if [[ $ok -eq 0 ]]; then
+		print_result "escalation body contains marker, reason, and recovery steps" 0
+	else
+		print_result "escalation body contains marker, reason, and recovery steps" 1 \
+			"one of: marker, reason, recovery command, byte count was missing"
+	fi
+	teardown_test_env
+}
+
+main() {
+	test_ensure_label_invokes_gh_label_create
+	test_ensure_label_uses_force_flag
+	test_ensure_label_is_noop_on_empty_slug
+	test_escalation_posts_comment_with_marker
+	test_escalation_is_idempotent_when_marker_present
+	test_escalation_is_noop_on_empty_args
+	test_escalation_body_contains_recovery_instructions
+
+	echo ""
+	echo "Results: ${TESTS_RUN} tests, $((TESTS_RUN - TESTS_FAILED)) passed, ${TESTS_FAILED} failed"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/todo/tasks/t2016-brief.md
+++ b/todo/tasks/t2016-brief.md
@@ -1,0 +1,223 @@
+---
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t2016: fix(pulse-triage): surface triage failures to maintainer when retry cap is hit
+
+## Origin
+
+- **Created:** 2026-04-13
+- **Session:** opencode:interactive
+- **Created by:** marcusquinn (human, interactive session)
+- **Conversation context:** While manually reviewing issue #18428 we noticed the
+  automated triage worker never produced a `## Review` comment, yet the content-hash
+  cache was written and the issue was then silently skipped on every subsequent pulse
+  cycle. Log investigation (`~/.aidevops/logs/pulse-wrapper.log`) showed three
+  consecutive failures for #18428 (72KB/80KB/62KB output — "no review header" twice
+  and "raw sandbox output" once), followed by `Triage retry cap reached ... caching
+  hash to stop lock/unlock loop`. The maintainer had zero visible signal — no
+  `triage-failed` label, no escalation comment, only buried log lines.
+
+## What
+
+When `dispatch_triage_reviews` hits the `TRIAGE_MAX_RETRIES` cap and writes the cache
+to break the lock/unlock loop, post a structured, idempotent **maintainer escalation
+comment** on the issue so the failure is visible in the issue timeline. Also fix
+`gh_create_label`-style provisioning so the `triage-failed` label is actually created
+in the repo before being added (today the add silently fails on repos without the
+label, but the log unconditionally claims success).
+
+Out of scope: improving the triage-review worker prompt so it stops producing huge
+headerless outputs — that is a worker-quality fix tracked separately.
+
+## Why
+
+The whole point of triage dispatch (t1916) was to give the maintainer a head start on
+reviewing `needs-maintainer-review` issues. When triage silently fails, three things
+break:
+
+1. The maintainer has no signal that automation even tried — they must manually
+   re-discover the issue in the NMR queue.
+2. The content-hash cache is now permanent — the pulse will `triage dedup: skipping`
+   on every cycle forever (until a new comment changes the hash).
+3. The `triage-failed` label was the designed observability channel but was never
+   actually created in the repo, so the escalation path was a dead letter.
+
+Evidence of the impact: #18428 sat for ~2h with three failed triage attempts, no
+visible signal, and the only reason the maintainer intervened was because a human
+(`/review-issue-pr`) was run against it manually.
+
+## Tier
+
+`tier:standard`
+
+**Tier rationale:** Two-file touch (dispatch + test), clear cause chain, but the
+escalation comment design needs judgment about idempotency, content, and when to
+fire. Haiku would miss the idempotency marker and the "test with mocked gh" pattern.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/pulse-ancillary-dispatch.sh:145-250` — in
+  `_dispatch_triage_review_worker`:
+  - Capture the suppression reason (no-header / raw-sandbox / no-output) into a
+    local `failure_reason` variable so it can be surfaced in the escalation comment.
+  - Replace the unconditional `gh issue edit --add-label "triage-failed"` with a
+    wrapper that (a) calls `gh label create --force` to ensure the label exists,
+    (b) checks whether the add command succeeded, (c) only logs "Added" on success.
+  - When `_triage_increment_failure` signals "cap hit", call a new helper
+    `_post_triage_escalation_comment` before writing the cache.
+- `NEW: .agents/scripts/tests/test-triage-failure-escalation.sh` — unit tests using
+  the test-pulse-wrapper-ever-nmr-cache.sh style (mocked `gh`, temp $HOME, marker
+  files to assert call behaviour).
+
+### Reference patterns
+
+- `gh label create --force` idempotent pattern: `issue-sync-helper.sh:203-206`
+  (`gh_create_label`).
+- Test harness style: `.agents/scripts/tests/test-pulse-wrapper-ever-nmr-cache.sh`
+  (mocked `gh`, `setup_test_env`/`teardown_test_env`, `print_result` helper).
+- Idempotent comment marker pattern: `scripts/commands/pulse.md` dispatch comments
+  use `<!-- MERGE_SUMMARY -->`, `<!-- ops:start/end -->`. New marker:
+  `<!-- triage-escalation -->`.
+
+### Implementation Steps
+
+1. Add helper `_post_triage_escalation_comment issue_num repo_slug failure_reason
+   attempts output_chars`:
+   - First check if a comment with `<!-- triage-escalation -->` already exists on
+     the issue via `gh api repos/$slug/issues/$num/comments`. If found, return 0
+     without posting (idempotent).
+   - Build a structured markdown body containing: what failed, attempt count, last
+     failure reason, output size, how to recover (remove `triage-failed` label or
+     delete cache hash file). Include the `<!-- triage-escalation -->` marker at
+     the top.
+   - Append the standard signature footer via `gh-signature-helper.sh footer`
+     (passing `--issue $slug#$num`).
+   - Post with `gh issue comment`. Log success or failure.
+
+2. Add helper `_ensure_triage_failed_label repo_slug`:
+   - `gh label create "triage-failed" --repo "$repo_slug" --color "E11D21"
+     --description "Automated triage could not produce a review — needs manual
+     attention" --force 2>/dev/null || true`.
+
+3. Refactor the label-add block (lines 224-231) in `_dispatch_triage_review_worker`:
+   - Track `failure_reason` throughout the suppression branches (lines 202-220).
+   - On `triage_posted=false`, call `_ensure_triage_failed_label` first, then run
+     the add with explicit exit code capture.
+   - Only log "Added triage-failed label" when the add command exit code was 0.
+
+4. In the cache-update block (lines 236-247), in the `_triage_increment_failure`
+   branch, call `_post_triage_escalation_comment` before `_triage_update_cache`.
+
+5. Write `test-triage-failure-escalation.sh` with at least these assertions:
+   - `_post_triage_escalation_comment` writes the marker body via mocked `gh issue
+     comment`.
+   - Repeated calls are no-ops when the marker is already present (reads mock
+     comment list).
+   - `_ensure_triage_failed_label` invokes `gh label create --force`.
+   - Structured body contains the failure reason, attempt count, and recovery
+     instructions.
+
+### Verification
+
+```bash
+shellcheck .agents/scripts/pulse-ancillary-dispatch.sh
+.agents/scripts/tests/test-triage-failure-escalation.sh
+# Repeat runs of .agents/scripts/tests/test-pulse-wrapper-ever-nmr-cache.sh
+# to confirm we haven't regressed the adjacent cache code path.
+```
+
+## Acceptance Criteria
+
+- [ ] `_post_triage_escalation_comment` helper exists and is called when
+      `_triage_increment_failure` signals cap hit.
+  ```yaml
+  verify:
+    method: bash
+    run: "grep -q '_post_triage_escalation_comment' .agents/scripts/pulse-ancillary-dispatch.sh"
+  ```
+- [ ] The escalation comment uses an HTML marker for idempotency.
+  ```yaml
+  verify:
+    method: bash
+    run: "grep -q 'triage-escalation' .agents/scripts/pulse-ancillary-dispatch.sh"
+  ```
+- [ ] `_ensure_triage_failed_label` is called before every `--add-label
+      triage-failed` invocation.
+  ```yaml
+  verify:
+    method: bash
+    run: "awk '/_ensure_triage_failed_label/,/add-label \"triage-failed\"/' .agents/scripts/pulse-ancillary-dispatch.sh | grep -q 'add-label'"
+  ```
+- [ ] New test file passes.
+  ```yaml
+  verify:
+    method: bash
+    run: ".agents/scripts/tests/test-triage-failure-escalation.sh"
+  ```
+- [ ] Existing NMR cache test still passes (no regression).
+  ```yaml
+  verify:
+    method: bash
+    run: ".agents/scripts/tests/test-pulse-wrapper-ever-nmr-cache.sh"
+  ```
+- [ ] ShellCheck clean on the modified file.
+  ```yaml
+  verify:
+    method: bash
+    run: "shellcheck .agents/scripts/pulse-ancillary-dispatch.sh"
+  ```
+- [ ] The `triage-failed` label is provisioned in the `marcusquinn/aidevops` repo
+      after the first pulse cycle that runs the patched code (manual verification
+      post-merge).
+
+## Context & Decisions
+
+- **Why not fix worker output quality in the same PR?** The observability gap is
+  the blocker — without it, every future worker regression will silently fail. Worker
+  quality (prompt tuning, output validation pre-post) is a bigger, more judgment-heavy
+  change that deserves its own investigation and PR.
+- **Why post a comment instead of relying on the label?** Labels are quiet —
+  notifications happen on comment, not label. Also the label currently does not
+  exist in the repo at all, so it was never a working signal. A comment creates an
+  issue-timeline event the maintainer cannot miss.
+- **Idempotency via HTML marker, not label-presence:** cache may be cleared and
+  retries attempted; the label may be manually removed. The durable signal is the
+  comment body itself, scanned for a known marker.
+- **Why not block cache write entirely on failure?** t2014 just reduced
+  `TRIAGE_MAX_RETRIES` to 1 specifically to break the lock/unlock churn on persistent
+  failures. The cache IS the right answer — we just also need a loud signal when it
+  was written via the failure path.
+- **Structured escalation body content:** include failure reason, attempt count,
+  byte count, and recovery steps (remove label, delete hash file, or re-run
+  `/review-issue-pr` manually).
+
+## Relevant Files
+
+- `.agents/scripts/pulse-ancillary-dispatch.sh` — dispatch, label, cache logic
+- `.agents/scripts/issue-sync-helper.sh:203-206` — `gh_create_label` reference
+- `.agents/scripts/tests/test-pulse-wrapper-ever-nmr-cache.sh` — test harness style
+- `.agents/scripts/gh-signature-helper.sh` — signature footer helper
+- `~/.aidevops/logs/pulse-wrapper.log` — historical evidence of #18428 failures
+- `~/.aidevops/.agent-workspace/tmp/triage-cache/marcusquinn_aidevops-18428.hash` —
+  the stale cache file that locked #18428 out of triage
+
+## Dependencies
+
+- **Blocked by:** none
+- **Blocks:** future regressions of the triage pipeline from going unnoticed
+- **Related:** t1916 (triage dispatch), t2014 (retry cap reduction), t1934 (locking)
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research | 30m | Done in parent session (log analysis, code trace) |
+| Implementation | 45m | Two helpers, refactor label block, escalation comment |
+| Tests | 30m | New test file, mock `gh` interactions |
+| Verification | 15m | Shellcheck, run tests, manual repro check |
+| **Total** | **2h** | |


### PR DESCRIPTION
## Summary

- When `dispatch_triage_reviews()` exhausts `TRIAGE_MAX_RETRIES` and writes the content-hash cache (GH#17827 loop-break), it previously left **no visible signal** on the issue — maintainers had to dig through log files. Reproduced on #18428.
- Adds `_post_triage_escalation_comment()`: idempotent comment with `<!-- triage-escalation -->` marker posted **before** cache write, with failure reason, attempt count, output size, and manual recovery steps.
- Adds `_ensure_triage_failed_label()`: `gh label create --force` to provision the `triage-failed` label before every `--add-label` call. Previously the label was never created in any repo, making it a dead letter.
- Tracks `failure_reason` through all suppression branches so the escalation comment surfaces an actionable cause instead of a generic "triage failed" message.
- Fixes the `triage-failed` label log: only emits "Added" when `gh issue edit` exits 0.

## Tests

New: `.agents/scripts/tests/test-triage-failure-escalation.sh` — 8 assertions:

```
PASS _ensure_triage_failed_label calls gh label create
PASS _ensure_triage_failed_label passes --force
PASS _ensure_triage_failed_label is a no-op on empty slug
PASS _post_triage_escalation_comment invokes gh issue comment
PASS _post_triage_escalation_comment skips when marker present
PASS _post_triage_escalation_comment logs idempotency skip
PASS _post_triage_escalation_comment is a no-op on empty args
PASS escalation body contains marker, reason, and recovery steps
Results: 8 tests, 8 passed, 0 failed
```

Regression: `test-pulse-wrapper-ever-nmr-cache.sh` — 4 tests, 4 passed, 0 failed.
ShellCheck: zero violations on `.agents/scripts/pulse-ancillary-dispatch.sh`.

## Files Changed

- `EDIT: .agents/scripts/pulse-ancillary-dispatch.sh` — two new helpers, failure reason tracking, label provisioning, escalation comment
- `NEW: .agents/scripts/tests/test-triage-failure-escalation.sh` — 8 unit tests
- `NEW: todo/tasks/t2016-brief.md` — task brief

Resolves #18475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced triage failure tracking with automatic escalation comments for maintainers, including failure reasons and attempt details.
  * Improved label provisioning for failed triage issues with better error handling.

* **Tests**
  * Added comprehensive test suite for triage failure escalation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->