### PR TITLE
GH#18439: fix systemd env_lines newline stripping and thread OPENCODE_BIN on Linux pulse

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -142,8 +142,27 @@ _is_pulse_installed() {
 }
 
 _resolve_pulse_runtime_binary() {
+	# GH#18439 Bug 2: Persist the resolved binary path across setup.sh
+	# invocations. aidevops-auto-update.timer runs setup.sh under systemd's
+	# minimal PATH, so re-resolving from live `$PATH` alone yields the
+	# legacy macOS-biased `/opt/homebrew/bin/opencode` fallback on Linux.
+	# Reading from persistence first (populated during an interactive
+	# setup.sh run with a rich `$PATH`) prevents the auto-update cycle
+	# from silently degrading the service file.
+	local _persisted_file="$HOME/.config/aidevops/scheduler-runtime-bin"
 	local opencode_bin=""
 
+	# 1. Prefer persisted path if it still points at an executable file.
+	if [[ -f "$_persisted_file" ]]; then
+		local _persisted
+		_persisted=$(head -n1 "$_persisted_file" 2>/dev/null || true)
+		if [[ -n "$_persisted" ]] && [[ -x "$_persisted" ]]; then
+			printf '%s' "$_persisted"
+			return 0
+		fi
+	fi
+
+	# 2. Try runtime-registry lookup via live PATH.
 	if type rt_list_headless &>/dev/null; then
 		local _sched_rt_id=""
 		local _sched_bin=""
@@ -156,15 +175,64 @@ _resolve_pulse_runtime_binary() {
 		done < <(rt_list_headless)
 	fi
 
-	printf '%s' "${opencode_bin:-$(command -v opencode 2>/dev/null || printf '/opt/homebrew/bin/opencode')}"
+	# 3. Direct PATH lookup for the default runtime.
+	if [[ -z "$opencode_bin" ]]; then
+		opencode_bin=$(command -v opencode 2>/dev/null || true)
+	fi
+
+	# 4. OS-aware common-install-location sweep. Used when live `$PATH` is
+	# minimal (systemd-spawned setup.sh) and persistence hasn't been
+	# seeded yet. Covers Homebrew (macOS + Linuxbrew), /usr/local, npm
+	# global, Python/uv pipx-style `.local/bin`, and bun.
+	if [[ -z "$opencode_bin" ]]; then
+		local _candidate
+		for _candidate in \
+			/opt/homebrew/bin/opencode \
+			/usr/local/bin/opencode \
+			/home/linuxbrew/.linuxbrew/bin/opencode \
+			"$HOME/.npm-global/bin/opencode" \
+			"$HOME/.local/bin/opencode" \
+			"$HOME/.bun/bin/opencode" \
+			/opt/homebrew/bin/claude \
+			/usr/local/bin/claude \
+			"$HOME/.local/bin/claude"; do
+			if [[ -x "$_candidate" ]]; then
+				opencode_bin="$_candidate"
+				break
+			fi
+		done
+	fi
+
+	# 5. Last-resort legacy fallback (preserves pre-GH#18439 behaviour so
+	# setup.sh never exits the resolver empty-handed).
+	[[ -z "$opencode_bin" ]] && opencode_bin="/opt/homebrew/bin/opencode"
+
+	# Persist the resolved path for subsequent non-interactive invocations
+	# (auto-update timer, cron regeneration). Only write when we actually
+	# found a real executable — don't persist the legacy fallback.
+	if [[ -x "$opencode_bin" ]]; then
+		mkdir -p "$(dirname "$_persisted_file")" 2>/dev/null || true
+		printf '%s\n' "$opencode_bin" >"$_persisted_file" 2>/dev/null || true
+	fi
+
+	printf '%s' "$opencode_bin"
 	return 0
 }
 
 _build_pulse_linux_env() {
 	# GH#17546/GH#17769: Model config is derived from pool + routing table at
 	# runtime. No model env vars embedded in cron/systemd.
+	local opencode_bin="${1:-}"
 	local _pulse_env="PULSE_DIR=${HOME}/.aidevops/.agent-workspace
 PULSE_STALE_THRESHOLD=${PULSE_STALE_THRESHOLD_SECONDS}"
+
+	# GH#18439 Bug 2: embed resolved runtime binary path so pulse-wrapper.sh
+	# and headless-runtime-helper.sh find the correct binary under systemd's
+	# minimal PATH (e.g. when aidevops-auto-update.timer regenerates the
+	# service file). Mirrors the macOS launchd <OPENCODE_BIN> key.
+	if [[ -n "$opencode_bin" ]]; then
+		_pulse_env+=$'\n'"OPENCODE_BIN=${opencode_bin}"
+	fi
 
 	printf '%s' "$_pulse_env"
 	return 0
@@ -255,7 +323,10 @@ _install_supervisor_pulse() {
 
 	local _pulse_timeout_sec=$((PULSE_STALE_THRESHOLD_SECONDS + 60))
 	local _pulse_env=""
-	_pulse_env=$(_build_pulse_linux_env)
+	# GH#18439 Bug 2: thread resolved runtime binary path through to the
+	# Linux env builder so OPENCODE_BIN is embedded in the systemd service
+	# file (parity with the macOS launchd plist at line 415).
+	_pulse_env=$(_build_pulse_linux_env "$opencode_bin")
 	_install_scheduler_linux \
 		"aidevops-supervisor-pulse" \
 		"aidevops: supervisor-pulse" \
@@ -555,8 +626,17 @@ _install_scheduler_systemd() {
 
 	mkdir -p "$service_dir"
 
+	# GH#18439 Bug 1: command substitution strips trailing newlines, which
+	# would run the final Environment=PATH=... into the following
+	# StandardOutput=... directive on the same line. Use a sentinel ('x')
+	# to preserve the trailing newline that _scheduler_systemd_env_lines
+	# always emits.
 	local _env_lines
-	_env_lines=$(_scheduler_systemd_env_lines "$env_vars")
+	_env_lines=$(
+		_scheduler_systemd_env_lines "$env_vars"
+		printf 'x'
+	)
+	_env_lines="${_env_lines%x}"
 
 	if [[ -z "$timeout_sec" ]]; then
 		timeout_sec="$interval_sec"

--- a/tests/test-pulse-systemd-timeout.sh
+++ b/tests/test-pulse-systemd-timeout.sh
@@ -91,3 +91,47 @@ if ! grep -q '^Environment=PULSE_STALE_THRESHOLD="1800"$' "$SERVICE_FILE"; then
 fi
 
 printf 'PASS %s\n' "pulse systemd service timeout exceeds watchdog threshold"
+
+# GH#18439 Bug 1 regression: _scheduler_systemd_env_lines() emits a trailing
+# newline, but $() strips it. The caller MUST re-add the separator or
+# Environment=PATH=... will concatenate with StandardOutput=... on the same
+# line, breaking systemd parsing and producing opencode=unknown in canary.
+if grep -qE 'PATH=.*StandardOutput' "$SERVICE_FILE"; then
+	echo "GH#18439 Bug 1 regression: Environment=PATH concatenated with StandardOutput on same line" >&2
+	echo "--- service file ---" >&2
+	cat "$SERVICE_FILE" >&2
+	echo "--- end ---" >&2
+	exit 1
+fi
+
+if ! grep -qE '^Environment=PATH=' "$SERVICE_FILE"; then
+	echo "GH#18439 Bug 1 regression: Environment=PATH= not found as its own directive line" >&2
+	echo "--- service file ---" >&2
+	cat "$SERVICE_FILE" >&2
+	echo "--- end ---" >&2
+	exit 1
+fi
+
+if ! grep -qE '^StandardOutput=' "$SERVICE_FILE"; then
+	echo "GH#18439 Bug 1 regression: StandardOutput= not found as its own directive line" >&2
+	echo "--- service file ---" >&2
+	cat "$SERVICE_FILE" >&2
+	echo "--- end ---" >&2
+	exit 1
+fi
+
+printf 'PASS %s\n' "GH#18439 Bug 1 newline preserved between Environment= and StandardOutput="
+
+# GH#18439 Bug 2 regression: the Linux install path must embed OPENCODE_BIN
+# in the systemd service file (mirror of the macOS launchd plist) so
+# pulse-wrapper.sh can find the dispatch binary even under systemd's minimal
+# PATH after aidevops-auto-update.timer regenerates the unit.
+if ! grep -qE '^Environment=OPENCODE_BIN=' "$SERVICE_FILE"; then
+	echo "GH#18439 Bug 2 regression: Environment=OPENCODE_BIN= not found in Linux pulse service file" >&2
+	echo "--- service file ---" >&2
+	cat "$SERVICE_FILE" >&2
+	echo "--- end ---" >&2
+	exit 1
+fi
+
+printf 'PASS %s\n' "GH#18439 Bug 2 OPENCODE_BIN propagated to Linux systemd service"


### PR DESCRIPTION
## Summary

Fixes two bugs in the Linux `aidevops-supervisor-pulse.service` systemd unit that blocked Linux pulse workers from finding the dispatch runtime binary.

Resolves #18439

## Bug 1 — trailing newline stripped by `$()`

`_install_scheduler_systemd` at `setup-modules/schedulers.sh:559` captured `_scheduler_systemd_env_lines`'s output via command substitution:

```bash
_env_lines=$(_scheduler_systemd_env_lines "$env_vars")
```

Bash `$(...)` strips trailing newlines. The helper always emits a trailing `\n` after the final `Environment=PATH=…` line (line 505), but after capture it was gone. The template at line 583 then concatenated:

```
${_service_extra}${_env_lines}StandardOutput=$(_systemd_escape "append:${log_file}")
```

producing `Environment=PATH="/…"StandardOutput="append:/…"` on a single line. systemd's `PATH=` parser swallowed the `StandardOutput=` text, the canary ran with a broken PATH, and `opencode=unknown` was reported.

**Regression source correction:** the issue title attributes this to #17405. The actual regression was introduced by **PR #17499** (`f3573d153` — "fix: centralize Linux scheduler installs for parity") when it extracted the inline env-line building into `_scheduler_systemd_env_lines()`. PR #17450 kept the env building inline and is not affected.

**Fix:** sentinel trick at the consumer site preserves the trailing newline:

```bash
_env_lines=$(_scheduler_systemd_env_lines "$env_vars"; printf 'x')
_env_lines="${_env_lines%x}"
```

Localized to the one call site. The helper itself keeps its existing contract (always emit trailing `\n`).

## Bug 2 — Linux install path ignored `opencode_bin`

`_install_supervisor_pulse` at line 229 accepted `opencode_bin="$4"` but only used it on macOS (line 239). On Linux the binary path was dropped, and `_build_pulse_linux_env` emitted only `PULSE_DIR` and `PULSE_STALE_THRESHOLD` — no `OPENCODE_BIN`, no runtime binary path hint.

When `aidevops-auto-update.timer` regenerated the service file under systemd's minimal PATH, `command -v opencode` inside `_resolve_pulse_runtime_binary` returned empty, and the function's fallback was `/opt/homebrew/bin/opencode` — macOS-specific and wrong on Linux. Each auto-update cycle silently degraded the service file until Rob's `CANARY_OK` started failing with `opencode=unknown`.

**Fix (two-part):**

1. **Mirror the macOS launchd pattern on Linux.** `_build_pulse_linux_env` now accepts `opencode_bin` and emits `Environment=OPENCODE_BIN=<full_path>` into the systemd env. `_install_supervisor_pulse` passes the resolved path through. Parity with the plist at line 415.

2. **Persist the resolved path across invocations.** `_resolve_pulse_runtime_binary` now:
   - Reads `~/.config/aidevops/scheduler-runtime-bin` first and uses the persisted path if it still points at an executable.
   - Falls through to the runtime-registry probe → direct `command -v opencode` → OS-aware common-install-location sweep (Homebrew macOS + Linuxbrew, `/usr/local/bin`, `~/.npm-global/bin`, `~/.local/bin`, `~/.bun/bin`, plus `claude` variants) → legacy `/opt/homebrew/bin/opencode` default.
   - Writes the resolved path to the persistence file on success (only if the binary is executable — never persists the legacy fallback).

This means the first interactive `setup.sh` run (with a rich `$PATH`) seeds the file. Subsequent auto-update regenerations read from the file instead of re-resolving under minimal PATH. The service file stops degrading.

**Runtime parity:** the common-location sweep covers both `opencode` and `claude`, so Linux users on either runtime get the correct binary embedded.

## Files changed

- `setup-modules/schedulers.sh` — sentinel trick, `_build_pulse_linux_env` signature, `_resolve_pulse_runtime_binary` rewrite, Bug 2 threading in `_install_supervisor_pulse`
- `tests/test-pulse-systemd-timeout.sh` — four new regression assertions (see Testing below)

## Testing

Local runtime verification on macOS (the test uses a sandboxed systemd-stub environment that runs on both platforms):

```bash
bash tests/test-pulse-systemd-timeout.sh
# PASS pulse systemd service timeout exceeds watchdog threshold
# PASS GH#18439 Bug 1 newline preserved between Environment= and StandardOutput=
# PASS GH#18439 Bug 2 OPENCODE_BIN propagated to Linux systemd service
```

**Reproduction + fix confirmation:** I temporarily reverted just the sentinel-trick fix and reran the test — it failed with the exact bug Rob reported:

```
GH#18439 Bug 1 regression: Environment=PATH concatenated with StandardOutput on same line
…
Environment=PATH="/usr/bin:/bin"StandardOutput="append:/…/pulse-wrapper.log"
```

After restoring the fix the test passes again. The regression check is a real guard, not a tautology.

**Shellcheck:** clean on both modified files.

**Linter blocker count:** unchanged at 55 (main) → 55 (branch). `setup-modules/schedulers.sh` was already in the file-size advisory list at 1783 lines; the fix brings it to 1863 without adding a new blocker.

## Runtime Testing

- **Risk classification**: **High** — touches the pulse service-file generation code path that drives autonomous worker dispatch on Linux. A regression here would be invisible until the next canary fails.
- **Verification mode**: `runtime-verified` via the extended `tests/test-pulse-systemd-timeout.sh`, which generates an actual systemd service file (in a tmp `$HOME`) and greps directive structure. Bug 1 was reproduced on the reverted code and confirmed fixed on the patched code.
- **Linux end-to-end**: not covered here (test runs on macOS with systemd stubs). The patches are file-generation logic — the bug was textual concatenation, not a runtime-systemd interaction — so macOS-stub generation is a faithful proxy. Rob's Ubuntu 24.04 reproduction in the issue body gives us a real-world confirmation of the symptom our test guards against.

## Key decisions and trade-offs

1. **Sentinel trick vs. template newline.** I chose the sentinel trick over adding an explicit `\n` to the template because it's localized to the one call site that has the command-substitution bug, doesn't depend on the helper's output format staying stable, and is a canonical bash idiom (comment explains the non-obvious `%x` strip so future maintainers don't "optimize" it away).
2. **PATH persistence anchor vs. env-only fix.** A minimal fix would be "just add `OPENCODE_BIN` on Linux and call it done." But without the persistence file, the next `aidevops-auto-update.timer` cycle would still re-enter `_resolve_pulse_runtime_binary` under minimal PATH and resolve to the legacy fallback — the service file would degrade again on the next regeneration. The persistence file closes that loop.
3. **OS-aware common-path sweep as a fallback.** First-install on a Linux machine without persistence still needs a way to find `opencode`/`claude`. I enumerated the common install locations (Homebrew variants, npm global, bun, `.local/bin`) rather than adding arbitrary user-configurable paths — keeps the fix scoped and predictable.
4. **Keep `_systemd_escape` quoting.** The issue notes Rob's local workaround stripped quotes from `StandardOutput=`. I left quoting intact — it's valid systemd syntax and `_systemd_escape` is the right tool for handling paths with special characters.

## Follow-up

- `setup.sh --force-scheduler-refresh` (or `rm ~/.config/aidevops/scheduler-runtime-bin && aidevops init`) to recover from a stale persisted path after `npm uninstall -g opencode` + reinstall elsewhere. Worth documenting in runners.md as a troubleshooting step — will file a small docs task separately.
- `auto-update-helper.sh:1521-1534` (the auto-update service's own definition) has no `Environment=PATH=`. With this fix's persistence approach it doesn't need one — `_resolve_pulse_runtime_binary` handles the minimal-PATH case internally. Noted for future readers.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.2 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 49m and 7,856 tokens on this as a headless worker.
