### PR TITLE
t2025: fix sandboxed triage JSONL parsing (resolves #18473)

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -290,6 +290,15 @@ _dispatch_triage_review_worker() {
 	# t1894/t1934: Lock issue and linked PRs during triage
 	lock_issue_for_worker "$issue_num" "$repo_slug"
 
+	# t2025: Capture stderr to a separate file so sandbox INFO lines
+	# (written to stderr by sandbox-exec-helper.sh's log_sandbox) don't
+	# contaminate the stdout review capture. Previously, "2>&1" merged
+	# '[INFO] Executing (timeout=..., network_blocked=...)' lines into
+	# the capture file, which caused the safety filter to classify
+	# legitimate output as "raw sandbox output" and suppress it.
+	local review_stderr_file=""
+	review_stderr_file="${review_output_file}.stderr"
+
 	# Run agent with triage-review prompt — agent file restricts to Read/Glob/Grep
 	# shellcheck disable=SC2086
 	"$HEADLESS_RUNTIME_HELPER" run \
@@ -298,14 +307,54 @@ _dispatch_triage_review_worker() {
 		--dir "$repo_path" \
 		$model_flag \
 		--title "Sandboxed triage review: Issue #${issue_num}" \
-		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1
+		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>"$review_stderr_file"
 
 	rm -f "$prefetch_file"
 
-	# ── Post-process: post the review comment (deterministic) ──
+	# t2025: opencode run is invoked with --format json by
+	# headless-runtime-helper.sh (see _build_opencode_cmd_args:1477), which
+	# means the capture file contains a JSONL transcript of the full
+	# session: user prompt + tool_use events + tool_result events +
+	# assistant messages. The final assistant message holds the review
+	# text. Parse it with jq before running the plain-text safety filter,
+	# otherwise the "## Review:" header is buried inside an escaped JSON
+	# string and the "^## .*[Rr]eview" regex never matches.
+	#
+	# Defensive fallback: if the file isn't valid JSONL (e.g., opencode
+	# crashed before emitting anything structured, or the format changes
+	# in a future release), fall through to reading the raw file as plain
+	# text — same behaviour as before this fix.
 	local review_text=""
-	review_text=$(cat "$review_output_file")
-	rm -f "$review_output_file"
+	local jsonl_parsed=""
+	if [[ -s "$review_output_file" ]]; then
+		jsonl_parsed=$(jq -rs '
+			[.[] | select(.type == "assistant")] as $assistants
+			| if ($assistants | length) > 0 then
+				$assistants
+				| last
+				| (.message.content // .content // "")
+				| if type == "array" then
+					[.[] | select(.type == "text") | .text] | join("\n")
+				  elif type == "string" then
+					.
+				  else
+					""
+				  end
+			  else
+				""
+			  end
+		' "$review_output_file" 2>/dev/null) || jsonl_parsed=""
+	fi
+	if [[ -n "$jsonl_parsed" ]]; then
+		review_text="$jsonl_parsed"
+	else
+		# Fallback: raw file (non-JSONL or parser failure)
+		review_text=$(cat "$review_output_file" 2>/dev/null || echo "")
+	fi
+
+	# t2025: On any failure path below, save the raw capture for debugging.
+	# Keep a reference to the raw file until we know whether to preserve it.
+	local _triage_raw_capture="$review_output_file"
 
 	local triage_posted="false"
 	# t2016: Track WHY the post was suppressed so the escalation comment
@@ -370,6 +419,39 @@ _dispatch_triage_review_worker() {
 			echo "[pulse-wrapper] FAILED to add triage-failed label to #${issue_num} in ${repo_slug} (gh issue edit returned non-zero)" >>"$LOGFILE"
 		fi
 	fi
+
+	# t2025: On any failure, save the raw JSONL capture for future debugging
+	# so we don't have to re-trigger the bug. Capped at 100 files to prevent
+	# runaway accumulation.
+	if [[ "$triage_posted" != "true" && -s "$_triage_raw_capture" ]]; then
+		local _triage_debug_dir="${TRIAGE_DEBUG_DIR:-${HOME}/.aidevops/.agent-workspace/tmp/triage-debug}"
+		if mkdir -p "$_triage_debug_dir" 2>/dev/null; then
+			local _triage_debug_count
+			_triage_debug_count=$(find "$_triage_debug_dir" -type f -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')
+			if [[ "$_triage_debug_count" -ge 100 ]]; then
+				# Drop the oldest to make room
+				local _oldest
+				_oldest=$(find "$_triage_debug_dir" -type f -name '*.jsonl' -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | tail -1)
+				[[ -n "$_oldest" ]] && rm -f "$_oldest" "${_oldest%.jsonl}.meta"
+			fi
+			local _slug_safe_dbg="${repo_slug//\//_}"
+			local _ts_dbg
+			_ts_dbg=$(date +%s)
+			local _dest_dbg="${_triage_debug_dir}/${_slug_safe_dbg}-${issue_num}-${_ts_dbg}.jsonl"
+			if cp "$_triage_raw_capture" "$_dest_dbg" 2>/dev/null; then
+				printf 'reason=%s\ntime=%s\nslug=%s\nissue=%s\nchars=%s\nstderr=%s\n' \
+					"$failure_reason" \
+					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+					"$repo_slug" \
+					"$issue_num" \
+					"$output_chars" \
+					"$([[ -s "$review_stderr_file" ]] && echo "present" || echo "empty")" \
+					>"${_dest_dbg%.jsonl}.meta" 2>/dev/null || true
+				echo "[pulse-wrapper] Triage debug capture saved to ${_dest_dbg} (reason: ${failure_reason})" >>"$LOGFILE"
+			fi
+		fi
+	fi
+	rm -f "$review_output_file" "$review_stderr_file"
 
 	# Unlock issue after triage
 	unlock_issue_after_worker "$issue_num" "$repo_slug"

--- a/todo/tasks/t2025-brief.md
+++ b/todo/tasks/t2025-brief.md
@@ -1,0 +1,250 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2025: fix sandboxed triage JSONL parsing — opencode --format json output parsed as plain text
+
+## Origin
+
+- **Created:** 2026-04-13
+- **Session:** claude-code (interactive)
+- **Created by:** ai-interactive (implementation of #18473 root cause)
+- **Parent task:** none (resolves #18473)
+- **Conversation context:** The session that produced #18471 (`TRIAGE_MAX_RETRIES` 3→1) and the investigation that produced #18473 identified that sandboxed triage reviews have been 100% broken since opencode adopted `--format json` as the default invocation mode. The last successful triage review in the pulse log was #17490, ~106K log lines ago. Every triage attempt since then has been suppressed by the safety filter, either as "raw sandbox output" or "no review header", because the dispatch code parses a JSONL transcript as plain text and fails to find the `## Review:` header at column 0.
+
+## What
+
+Fix `_dispatch_triage_review_worker()` in `pulse-ancillary-dispatch.sh` so that sandboxed triage reviews actually post instead of being silently suppressed:
+
+1. **Separate stderr from stdout** when capturing the opencode output. Replace `>"$review_output_file" 2>&1` with `>"$review_output_file" 2>"${review_output_file}.stderr"`. This eliminates the "raw sandbox output" class of failures — sandbox INFO lines (`[INFO] Executing (timeout=…, network_blocked=…)` from `sandbox-exec-helper.sh:1013`) no longer contaminate the review capture.
+
+2. **Parse the JSONL transcript via jq** before running the plain-text safety filter. `opencode run … --format json` emits a JSONL stream where each line is a JSON object (`user`, `tool_use`, `tool_result`, `assistant` types). The review text lives in the last `assistant` message's `.message.content` field, which may be either a string or an array of content blocks. Extract it before passing to the existing `^## .*[Rr]eview` extractor.
+
+3. **Preserve backwards compatibility** — if the file isn't valid JSONL (e.g., opencode crashed before emitting anything structured, or the output format changes in a future release), fall through to reading the raw file as plain text — same behaviour as before this fix. No regression for non-JSONL captures.
+
+4. **Save failed captures to a debug directory** for future regression debugging. When triage fails, copy the raw JSONL + a metadata sidecar to `~/.aidevops/.agent-workspace/tmp/triage-debug/`. Capped at 100 files (drop oldest to make room) so it can't run away. This prevents the next regression from being as invisible as this one.
+
+## Why
+
+### Evidence
+
+From `~/.aidevops/logs/pulse.log` — every triage attempt in recent memory has failed:
+
+```text
+127509: SECURITY: triage review for #18383 was raw sandbox output — suppressed (51480 chars)
+129401: SECURITY: triage review for #18429 was raw sandbox output — suppressed (57540 chars)
+129407: Triage review for #18428 had no review header — suppressed (72233 chars)
+129467: SECURITY: triage review for #18429 was raw sandbox output — suppressed (51900 chars)
+129473: Triage review for #18428 had no review header — suppressed (80568 chars)
+129595: Triage review for #18439 had no review header — suppressed (123252 chars)
+129601: Triage review for #18429 had no review header — suppressed (78381 chars)
+129675: Triage review for #18439 had no review header — suppressed  (97887 chars)
+129681: SECURITY: triage review for #18428 was raw sandbox output — suppressed (62198 chars)
+129792: Triage review for #18439 had no review header — suppressed (157690 chars)
+```
+
+Last successful triage: `22991: Posted sandboxed triage review for #17490` — approximately 106,000 log lines ago.
+
+### Root cause (two collaborating bugs in one dispatch path)
+
+1. **`headless-runtime-helper.sh:1477`** invokes `opencode run … --format json`. Every caller now gets JSONL back: one JSON object per line covering the user prompt, every tool_use event, every tool_result (which for Read tools serializes the full file contents), and assistant messages. For a triage agent with `read/glob/grep` access to the repo, a single run produces 50–160 KB of JSONL.
+
+2. **`pulse-ancillary-dispatch.sh:221-253`** captures that output with `>"$review_output_file" 2>&1` and then runs `sed -n '/^## .*[Rr]eview/,$ p'` against it as if it were plain text. Two failure modes:
+
+   - **"raw sandbox output"** — the `2>&1` merges sandbox stderr lines (`[INFO] Executing (timeout=…, network_blocked=…)` from `sandbox-exec-helper.sh:1013`) into the capture. These match the infrastructure-marker regex and trigger the SECURITY suppression branch.
+   - **"no review header"** — even when no infra markers are present, the `## Review:` header lives inside an escaped JSON string (`{"type":"assistant","message":{"content":[{"type":"text","text":"## Review: Approved\\n..."}]}}`) and never starts a line. `^##` can't match, and `sed` returns empty.
+
+Both failure classes in the log come from the same root cause, just different branches of the safety filter.
+
+### Why this wasn't noticed earlier
+
+`TRIAGE_MAX_RETRIES=3` (now cut to 1 in #18471) capped the observable symptom after 3 failures per content version, and the `triage-failed` label is easy to miss unless you're watching logs. The cap and the label together hid the complete breakage behind "retry timeout" dressing.
+
+### Effect
+
+- Restores sandboxed triage reviews from "100% broken" to "working"
+- Eliminates the per-failing-issue waste of running opus agents that always get suppressed
+- Unblocks the genuine review-gating workflow for external contributor issues
+- Combined with #18471 (cuts retries 3→1) and t2024 (scope-aware gate), closes the loop on the session's original "wasted cycles on gated issues" investigation
+
+## Tier
+
+### Tier checklist (verify before assigning)
+
+- [x] **2 or fewer files to modify?** Yes — 1 file (`pulse-ancillary-dispatch.sh`)
+- [x] **Complete code blocks for every edit?** Yes — verbatim specified below
+- [x] **No judgment or design decisions?** Borderline — the JSONL schema discovery and the debug-dir design are judgement calls. Documented in Context & Decisions.
+- [x] **No error handling or fallback logic to design?** Borderline — explicit fallback path for non-JSONL captures and the debug-dir cap. Both are simple, but they exist.
+- [x] **Estimate 1h or less?** Yes — ~30 minutes
+- [x] **4 or fewer acceptance criteria?** Yes — 4
+
+**Selected tier:** `tier:standard` (Sonnet). Not `tier:simple` because:
+- The jq expression needs to handle both `content` as array-of-blocks and `content` as string, plus fall-through to raw-file read when jq returns empty.
+- The debug-dir capping logic needs careful ordering (check count → drop oldest → save new).
+- The stderr separation has a subtle interaction with the existing infra-markers check (we still check for them on the parsed `review_text`, but the common case — sandbox log leakage — is now prevented at source).
+
+## How (Approach)
+
+### Files to modify
+
+- `EDIT: .agents/scripts/pulse-ancillary-dispatch.sh:290-400` — update `_dispatch_triage_review_worker()` with three insertions (stderr separation, JSONL parsing, debug-capture on failure).
+
+### Implementation — three changes inside `_dispatch_triage_review_worker()`
+
+**Change 1: Separate stderr from stdout capture.**
+
+Replace:
+
+```bash
+	"$HEADLESS_RUNTIME_HELPER" run \
+		--role worker \
+		...
+		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>&1
+```
+
+With:
+
+```bash
+	# t2025: Capture stderr to a separate file so sandbox INFO lines
+	# (written to stderr by sandbox-exec-helper.sh's log_sandbox) don't
+	# contaminate the stdout review capture.
+	local review_stderr_file=""
+	review_stderr_file="${review_output_file}.stderr"
+	...
+	"$HEADLESS_RUNTIME_HELPER" run \
+		--role worker \
+		...
+		--prompt-file "$prefetch_file" </dev/null >"$review_output_file" 2>"$review_stderr_file"
+```
+
+**Change 2: Parse JSONL via jq before the safety filter.**
+
+Replace:
+
+```bash
+	rm -f "$prefetch_file"
+
+	# ── Post-process: post the review comment (deterministic) ──
+	local review_text=""
+	review_text=$(cat "$review_output_file")
+	rm -f "$review_output_file"
+```
+
+With a jq-based parser (full text in the commit) that:
+
+1. Reads the JSONL via `jq -rs` (slurp mode)
+2. Filters to `.type == "assistant"` entries
+3. Takes the last one
+4. Extracts `.message.content` (or falls back to `.content`)
+5. If the content is an array, joins the `type == "text"` block texts
+6. If the content is a string, uses it directly
+7. Falls back to raw `cat` if jq returns empty (non-JSONL edge case)
+8. Keeps `$review_output_file` around (no `rm`) so the debug-capture below can copy it
+
+**Change 3: Save raw capture on failure (new block before `unlock_issue_after_worker`).**
+
+Add a block that:
+
+1. Fires only when `triage_posted != "true"` and the raw file is non-empty
+2. Creates `$TRIAGE_DEBUG_DIR` (default `~/.aidevops/.agent-workspace/tmp/triage-debug`)
+3. Counts existing `.jsonl` files; if ≥ 100, drops the oldest to make room
+4. Copies `$_triage_raw_capture` to `${slug}-${issue}-${epoch}.jsonl`
+5. Writes a sidecar `.meta` file with reason, timestamp, slug, issue number, char count, stderr presence
+6. Logs the save location
+7. Follows with `rm -f "$review_output_file" "$review_stderr_file"` to clean up the live files
+
+### Verification
+
+```bash
+# 1. Shellcheck clean
+shellcheck .agents/scripts/pulse-ancillary-dispatch.sh
+# → exit 0
+
+# 2. Characterization test passes
+bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh
+# → All 26 tests passed
+
+# 3. jq extractor sanity test — four shapes
+# Shape 1 (array content): jq returns "## Review: Approved\n..."
+# Shape 2 (string content): jq returns the string directly
+# Shape 3 (multiple assistant messages): jq returns the LAST
+# Shape 4 (non-JSONL garbage): jq fails, fallback fires
+# Verified in session transcript
+
+# 4. No functional test possible without a live triage dispatch;
+# the real smoke test is the next pulse cycle after this lands, watching
+# for "Posted sandboxed triage review" log lines on an NMR issue.
+```
+
+## Acceptance Criteria
+
+- [ ] `_dispatch_triage_review_worker()` captures stderr to a separate file, not merged into stdout
+  ```yaml
+  verify:
+    method: codebase
+    pattern: '2>"\$review_stderr_file"'
+    path: ".agents/scripts/pulse-ancillary-dispatch.sh"
+  ```
+- [ ] JSONL parsing via jq precedes the plain-text `## Review:` extractor
+  ```yaml
+  verify:
+    method: codebase
+    pattern: 'jq -rs'
+    path: ".agents/scripts/pulse-ancillary-dispatch.sh"
+  ```
+- [ ] Failed triage captures are saved to `TRIAGE_DEBUG_DIR` with a `.meta` sidecar, capped at 100 files
+  ```yaml
+  verify:
+    method: codebase
+    pattern: 'Triage debug capture saved'
+    path: ".agents/scripts/pulse-ancillary-dispatch.sh"
+  ```
+- [ ] `shellcheck` exits 0, characterization test passes 26/26
+  ```yaml
+  verify:
+    method: bash
+    run: "shellcheck .agents/scripts/pulse-ancillary-dispatch.sh && bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh"
+  ```
+
+## Context & Decisions
+
+- **Why not change `--format json` in `headless-runtime-helper.sh`?** Because `--format json` is load-bearing for other callers:
+  - Session DB merge (`_merge_worker_db`) relies on structured output for SQLite schema mapping
+  - `observability-helper.sh:126` parses the JSONL transcript for usage/cost/timing telemetry
+  - The session-miner pulse reads JSONL for cross-session analytics
+  
+  Changing the flag would break all of these. The fix has to live in the triage dispatch path only — that's where the plain-text assumption came from, not from the helper.
+
+- **Why `jq -rs` (slurp) and not line-by-line?** JSONL with streaming assistant messages means the final review text can span multiple `content` blocks or appear in any position. Slurp-then-filter is simpler and correctness-dominant for a file that's always ≤200 KB. Performance isn't a concern; the agent invocation is >100× slower than the parse.
+
+- **Why treat `.content` as a fallback from `.message.content`?** Different opencode versions have varied between `{type, message: {content: ...}}` and `{type, content: ...}`. The `//` coalesce handles both without pinning the schema.
+
+- **Why cap the debug directory at 100 files?** A typical failing cycle produces one debug capture per issue per content version. At 100 files the directory is ~2 MB (median 20 KB per capture). Drop-oldest semantics keep the most recent failures for debugging without unbounded growth. A separate pulse-cleanup task can be added later if we want time-based pruning instead of count-based.
+
+- **Why keep the existing safety filter?** Belt-and-suspenders: even if the JSONL parser extracts the assistant text, a malformed or malicious `.message.content` string could still contain infra markers. The re-check at `line 384` catches this case. It also means the fallback path (raw `cat` on non-JSONL files) still benefits from the existing defence.
+
+- **Non-goals:** Rewriting the triage agent's output contract, changing opencode invocation flags, deleting the old safety filter, implementing time-based debug-dir cleanup, or handling the `--format json` change at the headless-runtime-helper level. All out of scope.
+
+## Relevant Files
+
+- `.agents/scripts/pulse-ancillary-dispatch.sh:290-400` — `_dispatch_triage_review_worker()` (site of all three edits)
+- `.agents/scripts/headless-runtime-helper.sh:1477` — `_build_opencode_cmd_args()` (reference: origin of `--format json`)
+- `.agents/scripts/sandbox-exec-helper.sh:1013` — `log_sandbox()` (reference: origin of the stderr INFO lines)
+- `.agents/scripts/observability-helper.sh:126` — existing JSONL parser reference pattern (reuses the same `.type == "assistant"` filter shape)
+- `~/.aidevops/.agent-workspace/tmp/triage-debug/` — new debug directory (created on first failure)
+
+## Dependencies
+
+- **Blocked by:** none (t2024 scope-aware gate fix also unblocks this issue from the pulse dispatch path, but the fix itself is independent)
+- **Blocks:** nothing
+- **External:** `jq` (already a hard dependency across aidevops)
+- **Resolves:** #18473
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Design + jq expression | 10m | Schema discovery + shape experimentation |
+| Implementation | 10m | Three targeted Edit calls |
+| Verification | 5m | Shellcheck + characterization test + jq sanity tests |
+| Commit + PR | 5m | Conventional commit, PR body with evidence |
+| **Total** | **~30m** | |


### PR DESCRIPTION
## Summary

- Separate stderr from stdout capture when invoking the triage agent (eliminates "raw sandbox output" failure class)
- Parse the JSONL transcript via `jq` to extract the assistant's final text, instead of searching for `## Review:` in the escaped-JSON raw capture (eliminates "no review header" failure class)
- Save failed captures to a debug directory (capped at 100) so the next regression isn't as invisible as this one

## Why

Sandboxed triage reviews have been 100% broken for ~106,000 log lines. Last successful triage: #17490. Every attempt since has been suppressed as either "raw sandbox output" or "no review header". Both failure classes come from the same root cause, just different branches of the safety filter.

**Two collaborating bugs**:

1. `>"$review_output_file" 2>&1` merged sandbox stderr (`[INFO] Executing ...` from `sandbox-exec-helper.sh:1013`) into the review capture.
2. `headless-runtime-helper.sh:1477` invokes `opencode run … --format json`, so the capture is JSONL, but the dispatch code parsed it as plain text. The `## Review:` header lives inside an escaped JSON string at `.message.content[].text` and never starts a line — `^## .*[Rr]eview` can't match.

## Verification

```text
$ shellcheck .agents/scripts/pulse-ancillary-dispatch.sh
→ exit 0

$ bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh
All 26 tests passed

$ # jq extractor sanity test (four shapes, all correct):
Shape 1 (content as array of text blocks)  → returns "## Review: Approved\n..."
Shape 2 (content as string)                 → returns string directly
Shape 3 (multiple assistant messages)       → returns the LAST one
Shape 4 (non-JSONL garbage)                 → jq fails, raw-file fallback fires
```

## Why not change `--format json` in `headless-runtime-helper.sh`?

It's load-bearing for:

- `_merge_worker_db` (session DB merge)
- `observability-helper.sh:126` (usage/cost/timing telemetry)
- session-miner analytics

Changing the flag would break all of these. The fix stays localised to the triage dispatch path where the plain-text assumption originated.

## Smoke-test plan (post-merge)

Once this deploys, the next pulse cycle should produce `Posted sandboxed triage review for #N` entries on any `needs-maintainer-review` issue. Stale `triage-failed` labels can be cleared with:

```bash
gh issue list --repo marcusquinn/aidevops --label triage-failed --state open --json number --jq '.[].number' | while read n; do
  gh issue edit "$n" --repo marcusquinn/aidevops --remove-label triage-failed
  rm -f ~/.aidevops/.agent-workspace/tmp/triage-cache/marcusquinn_aidevops-"$n".{hash,failures}
done
```

## Companion PR

The systemic gate fix (t2024) that unblocks the pulse from dispatching this kind of targeted fix is submitted separately. Both can land independently — this PR was implemented interactively in parallel rather than waiting for t2024 to enable pulse dispatch.

Resolves #18473
Resolves #18496


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.3 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 3h 27m and 4,693 tokens on this as a headless worker.