### PR TITLE
t2039: skip main/master in session-rename sync-branch (GH#18523)

### DIFF
--- a/.agents/scripts/session-rename-helper.sh
+++ b/.agents/scripts/session-rename-helper.sh
@@ -172,10 +172,55 @@ cmd_rename() {
 	return 0
 }
 
+# Check whether a branch name is a meaningful session title.
+# Default branches (main/master/HEAD) are NOT meaningful — they represent the
+# absence of a feature branch and should never clobber a session title. This
+# matters because pre-edit-check.sh triggers sync-branch on every edit, and
+# interactive sessions in canonical repo directories stay on main (t1990).
+# Without this guard, planning-only sessions end up titled "main" forever.
+# Arguments:
+#   $1 - branch name
+# Returns: 0 if branch is meaningful (rename allowed), 1 otherwise
+_is_meaningful_branch_title() {
+	local branch="$1"
+	case "$branch" in
+	"" | HEAD | main | master) return 1 ;;
+	*) return 0 ;;
+	esac
+}
+
+# Check whether the current session title is safe to overwrite.
+# A title is overwritable when it is empty, the default "New Session", or
+# itself one of the default branch names (main/master/HEAD). A meaningful
+# custom title — anything else, including feature branch names or
+# LLM-generated summaries — is preserved.
+# Arguments:
+#   $1 - sqlite database path
+#   $2 - session ID
+# Returns: 0 if safe to overwrite, 1 if a meaningful title already exists
+_is_title_overwritable() {
+	local db_path="$1"
+	local session_id="$2"
+
+	local escaped_session_id
+	escaped_session_id="$(_sql_escape "$session_id")"
+
+	local current_title
+	current_title="$(sqlite3 "$db_path" \
+		"SELECT COALESCE(title, '') FROM session WHERE id = '${escaped_session_id}';" 2>/dev/null || echo "")"
+
+	case "$current_title" in
+	"" | "New Session" | HEAD | main | master) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
 # Rename the most relevant (or specified) session to match the current git branch.
+# Skips default branch names (main/master/HEAD) and preserves meaningful
+# existing titles to avoid the "session title stuck as main" bug (t2039).
 # Arguments:
 #   $1 - session ID (optional; defaults to current-directory session)
-# Returns: 0 on success, 1 on failure
+# Returns: 0 on success or skip, 1 on failure
 cmd_sync_branch() {
 	local session_id="${1:-}"
 
@@ -197,6 +242,21 @@ cmd_sync_branch() {
 	if [[ -z "$branch" || "$branch" == "HEAD" ]]; then
 		print_error "No branch checked out (detached HEAD state)"
 		return 1
+	fi
+
+	# Guard 1: never write default branch names as session titles.
+	# Returns 0 (success) so pre-edit-check.sh's best-effort trigger stays quiet.
+	if ! _is_meaningful_branch_title "$branch"; then
+		print_info "Skipping session rename: '${branch}' is not a meaningful title"
+		return 0
+	fi
+
+	# Guard 2: do not clobber a meaningful existing title.
+	# A user-set title or a feature-branch title should survive later syncs
+	# that happen from the canonical main directory.
+	if ! _is_title_overwritable "$db_path" "$session_id"; then
+		print_info "Skipping session rename: session already has a meaningful title"
+		return 0
 	fi
 
 	cmd_rename "$session_id" "$branch"

--- a/.agents/scripts/tests/test-session-rename-helper.sh
+++ b/.agents/scripts/tests/test-session-rename-helper.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Tests for session-rename-helper.sh
+#
+# Covers the t2039 guards that prevent session titles from being clobbered
+# with default branch names (main/master/HEAD) or overwritten when a
+# meaningful title already exists.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../session-rename-helper.sh"
+
+PASS=0
+FAIL=0
+
+# -----------------------------------------------------------------------------
+# Assertions
+# -----------------------------------------------------------------------------
+
+assert_eq() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected: $expected"
+		echo "    actual:   $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_exit() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $test_name (exit=$actual)"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected exit: $expected"
+		echo "    actual exit:   $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test fixture helpers
+# -----------------------------------------------------------------------------
+
+TMPDIR_ROOT=""
+REPO_DIR=""
+DB_PATH=""
+SESSION_ID="ses_test_t2039"
+
+setup_fixture() {
+	TMPDIR_ROOT="$(mktemp -d)"
+	REPO_DIR="${TMPDIR_ROOT}/fake-repo"
+	DB_PATH="${TMPDIR_ROOT}/opencode.db"
+
+	# Create a minimal git repo so `git rev-parse --abbrev-ref HEAD` works.
+	mkdir -p "$REPO_DIR"
+	git -C "$REPO_DIR" init -q -b main
+	git -C "$REPO_DIR" config user.email "test@aidevops.sh"
+	git -C "$REPO_DIR" config user.name "Test"
+	git -C "$REPO_DIR" commit --allow-empty -q -m "init"
+
+	# Create a session table matching the OpenCode schema subset the helper touches.
+	sqlite3 "$DB_PATH" <<-'SQL'
+		CREATE TABLE session (
+		  id TEXT PRIMARY KEY,
+		  title TEXT,
+		  directory TEXT,
+		  time_created INTEGER,
+		  time_updated INTEGER
+		);
+	SQL
+	return 0
+}
+
+teardown_fixture() {
+	if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+		rm -rf "$TMPDIR_ROOT"
+	fi
+	return 0
+}
+
+# Seed the session row with a title and directory.
+# Args: $1 = title, $2 = directory (default: REPO_DIR)
+seed_session() {
+	local title="$1"
+	local directory="${2:-$REPO_DIR}"
+	sqlite3 "$DB_PATH" \
+		"DELETE FROM session WHERE id = '${SESSION_ID}'; \
+		 INSERT INTO session (id, title, directory, time_created, time_updated) \
+		 VALUES ('${SESSION_ID}', '${title}', '${directory}', 1000, 1000);"
+	return 0
+}
+
+get_title() {
+	sqlite3 "$DB_PATH" "SELECT title FROM session WHERE id = '${SESSION_ID}';"
+	return 0
+}
+
+# Run sync-branch in a subshell with OPENCODE_DB + PWD = fake repo.
+# Arg: $1 = branch name to check out before running
+run_sync_on_branch() {
+	local branch="$1"
+	(
+		cd "$REPO_DIR"
+		git checkout -q -B "$branch"
+		OPENCODE_DB="$DB_PATH" "$HELPER" sync-branch "$SESSION_ID" >/dev/null 2>&1
+	)
+	return $?
+}
+
+# -----------------------------------------------------------------------------
+# Tests
+# -----------------------------------------------------------------------------
+
+echo "=== session-rename-helper.sh tests ==="
+echo ""
+
+trap teardown_fixture EXIT
+setup_fixture
+
+# Test 1: sync to main must NOT rename
+echo "Test 1: sync on 'main' branch skips rename (no clobber)"
+seed_session "New Session"
+run_sync_on_branch "main"
+rc=$?
+assert_exit "exit 0 on main skip" "0" "$rc"
+assert_eq "title untouched on main" "New Session" "$(get_title)"
+
+# Test 2: sync to master must NOT rename
+echo ""
+echo "Test 2: sync on 'master' branch skips rename"
+seed_session "New Session"
+run_sync_on_branch "master"
+rc=$?
+assert_exit "exit 0 on master skip" "0" "$rc"
+assert_eq "title untouched on master" "New Session" "$(get_title)"
+
+# Test 3: sync to feature/* renames as before
+echo ""
+echo "Test 3: sync on 'feature/x' renames session"
+seed_session "New Session"
+run_sync_on_branch "feature/cool-thing"
+rc=$?
+assert_exit "exit 0 on feature branch" "0" "$rc"
+assert_eq "title renamed to feature branch" "feature/cool-thing" "$(get_title)"
+
+# Test 4: do not clobber a meaningful existing title with a feature branch sync
+echo ""
+echo "Test 4: sync preserves existing meaningful title"
+seed_session "investigating the session rename bug"
+run_sync_on_branch "feature/auto-20260413-025423"
+rc=$?
+assert_exit "exit 0 preserve branch" "0" "$rc"
+assert_eq "meaningful title preserved" "investigating the session rename bug" "$(get_title)"
+
+# Test 5: empty title gets renamed (initial sync still works)
+echo ""
+echo "Test 5: empty title is overwritten on feature branch sync"
+seed_session ""
+run_sync_on_branch "feature/empty-title"
+rc=$?
+assert_exit "exit 0 on empty title sync" "0" "$rc"
+assert_eq "empty title filled in" "feature/empty-title" "$(get_title)"
+
+# Test 6: existing 'main' title is overwritten on feature branch sync
+# (recovery path: sessions that already got stuck as 'main' by the old code
+# should heal on the first sync from a real feature branch)
+echo ""
+echo "Test 6: stuck-on-main title heals when syncing from feature branch"
+seed_session "main"
+run_sync_on_branch "feature/heal-me"
+rc=$?
+assert_exit "exit 0 heal" "0" "$rc"
+assert_eq "main title healed to feature" "feature/heal-me" "$(get_title)"
+
+# Test 7: existing 'master' title is overwritten too
+echo ""
+echo "Test 7: stuck-on-master title heals when syncing from feature branch"
+seed_session "master"
+run_sync_on_branch "feature/heal-master"
+rc=$?
+assert_exit "exit 0 heal master" "0" "$rc"
+assert_eq "master title healed" "feature/heal-master" "$(get_title)"
+
+# Test 8: explicit rename still works for main (direct rename command is unguarded)
+# The guards apply only to sync-branch (automatic, driven by cwd branch).
+# Direct `rename` is a manual user action and should remain unrestricted.
+echo ""
+echo "Test 8: explicit 'rename' command ignores guards (manual override)"
+seed_session "New Session"
+OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "main" >/dev/null 2>&1
+rc=$?
+assert_exit "exit 0 explicit rename" "0" "$rc"
+assert_eq "explicit rename to main allowed" "main" "$(get_title)"
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add two guards to `session-rename-helper.sh cmd_sync_branch`:

1. Never write `main`, `master`, or `HEAD` as a session title — they are the absence of a feature branch, not meaningful titles.
2. Never clobber an existing meaningful title (feature branch name or user/LLM-generated summary) when syncing from the canonical directory.

Both guards return 0 on skip so `pre-edit-check.sh`'s best-effort `|| true` trigger keeps working. The manual `rename` subcommand stays unrestricted for explicit user control.

Root cause: `pre-edit-check.sh:759` fires `sync-branch` on every edit. Interactive sessions keep the canonical repo on main per t1990, so planning-only or diagnostic sessions that never create a worktree were getting their title rewritten to the literal string 'main' on the first edit.

## Files Changed

.agents/scripts/session-rename-helper.sh,.agents/scripts/tests/test-session-rename-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - shellcheck clean on session-rename-helper.sh, test harness, pre-edit-check.sh
- New `test-session-rename-helper.sh` — 16/16 assertions pass across 8 scenarios (main skip, master skip, feature/* rename, meaningful-title preservation, empty-title fill, stuck-on-main heal, stuck-on-master heal, explicit rename bypass)
- Live verification: ran `sync-branch` from worktree against real OpenCode DB — correctly preserved the existing meaningful title instead of overwriting with the feature branch name

Resolves #18523


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.7 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 7m and 14,115 tokens on this with the user in an interactive session.