### PR TITLE
t2037: refactor(maintainer-gate): delete Job 3 inline gate logic, delegate to Job 1

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -309,8 +309,10 @@ jobs:
           # Post commit status so branch protection sees the result (GH#14277)
           # The check-run (job name) is separate from the commit status context.
           # Branch protection may require the "maintainer-gate" commit status,
-          # which was previously only posted by the retrigger-pr-checks job on
-          # issue label changes — not on PR open/sync events.
+          # which Job 1 now posts directly on all pull_request_target events.
+          # Job 3 (retrigger-pr-checks) triggers a Job 1 rerun on issue changes
+          # rather than posting its own status — t2037 delegates all evaluation
+          # to Job 1 as the single source of truth.
           # Fail-closed: if status post fails after retry, fail the job (GH#14277)
           if [[ "$BLOCKED" == "true" ]]; then
             DESCRIPTION=$(head -c 140 /tmp/gate-reasons.txt | tr '\n' ' ')
@@ -455,7 +457,8 @@ jobs:
 
   # =========================================================================
   # Job 3: Re-evaluate PR gate when a linked issue's labels or assignees change
-  #         (evaluates conditions and posts final success/failure status)
+  #         Pure plumbing: finds linked PRs, posts pending, triggers Job 1 rerun.
+  #         Gate evaluation logic lives exclusively in Job 1 (t2037).
   # =========================================================================
   retrigger-pr-checks:
     name: Re-evaluate PR Gate on Issue Change
@@ -472,12 +475,11 @@ jobs:
       actions: write  # t2018: refresh required CheckRun by re-running Job 1
 
     steps:
-      - name: Find linked PRs and re-evaluate gate
+      - name: Find linked PRs and trigger Job 1 rerun
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAINTAINER_GATE_DEBUG: ${{ vars.MAINTAINER_GATE_DEBUG || 'false' }}
         run: |
           echo "Issue #$ISSUE_NUMBER updated (labels/assignee) — checking for linked PRs"
 
@@ -515,10 +517,7 @@ jobs:
           echo "Found PRs referencing issue #$ISSUE_NUMBER: $OPEN_PRS"
 
           for PR_NUM in $OPEN_PRS; do
-            echo "=== Evaluating gate for PR #$PR_NUM ==="
-
-            # Reset per-PR state so failures don't leak across iterations (GH#14413)
-            TITLE_LOOKUP_FAILED=false
+            echo "=== Triggering Job 1 rerun for PR #$PR_NUM ==="
 
             HEAD_SHA=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
             if [[ -z "$HEAD_SHA" ]]; then
@@ -526,195 +525,29 @@ jobs:
               continue
             fi
 
-            # Post pending status while we evaluate
+            # Post pending status while Job 1 re-evaluates
+            # t2037: Job 3 is pure plumbing — gate evaluation is Job 1's sole responsibility
             gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
               --method POST \
               -f state=pending \
               -f context="maintainer-gate" \
-              -f description="Re-evaluating after issue #${ISSUE_NUMBER} update" \
+              -f description="Refreshing via Job 1 rerun..." \
               2>/dev/null || true
 
-            # Get PR body and labels to find ALL linked issues (not just the triggering one)
-            PR_BODY=$(gh pr view "$PR_NUM" --repo "$REPO" --json body --jq '.body' 2>/dev/null || true)
-            RETRIGGER_PR_LABELS=$(gh pr view "$PR_NUM" --repo "$REPO" --json labels --jq '.labels[].name' 2>/dev/null || true)
-            PR_TITLE=$(gh pr view "$PR_NUM" --repo "$REPO" --json title --jq '.title' 2>/dev/null || true)
-
-            LINKED_ISSUES=""
-            if [[ -n "$PR_BODY" ]]; then
-              LINKED_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes?|fixes?|resolves?)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
-            fi
-
-            # Also check PR title for task ID and find matching issue
-            TASK_ID=$(echo "$PR_TITLE" | grep -oE '^t[0-9]+(\.[0-9]+)*' || true)
-            if [[ -n "$TASK_ID" && -z "$LINKED_ISSUES" ]]; then
-              ISSUE_SEARCH_OUTPUT=$(gh issue list --repo "$REPO" --state all --search "${TASK_ID}:" --json number,title --limit 5 2>&1) || {
-                echo "::warning::Title-based issue lookup failed for task ID '$TASK_ID': $ISSUE_SEARCH_OUTPUT"
-                ISSUE_SEARCH_OUTPUT=""
-                TITLE_LOOKUP_FAILED=true
-              }
-              if [[ -n "$ISSUE_SEARCH_OUTPUT" ]]; then
-                FOUND=$(echo "$ISSUE_SEARCH_OUTPUT" \
-                  | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>&1) || {
-                  echo "::error::jq parsing failed during title-based issue lookup for task ID '$TASK_ID': $FOUND"
-                  FOUND=""
-                  TITLE_LOOKUP_FAILED=true
-                }
-                if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
-                  LINKED_ISSUES="$FOUND"
-                fi
-              fi
-            fi
-
-            # If title-based lookup was attempted but failed, block — don't pass the gate on API errors
-            if [[ -z "$LINKED_ISSUES" && "$TITLE_LOOKUP_FAILED" == "true" ]]; then
-              echo "::error::Title-based issue lookup failed for PR #$PR_NUM — blocking to be safe"
-              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                --method POST \
-                -f state=failure \
-                -f context="maintainer-gate" \
-                -f description="Title-based issue lookup failed — cannot verify linked issues" \
-                2>/dev/null || echo "::warning::Could not post failure status on PR #$PR_NUM"
-              continue
-            fi
-
-            if [[ -z "$LINKED_ISSUES" ]]; then
-              # External-contributor PRs must link an issue (same rule as Job 1)
-              if echo "$RETRIGGER_PR_LABELS" | grep -q 'external-contributor'; then
-                echo "BLOCKED: external-contributor PR #$PR_NUM has no linked issue"
-                gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                  --method POST \
-                  -f state=failure \
-                  -f context="maintainer-gate" \
-                  -f description="External PR has no linked issue — requires Closes #NNN in body" \
-                  2>/dev/null || echo "::warning::Could not post failure status on PR #$PR_NUM"
-                continue
-              fi
-
-              echo "No linked issues found for PR #$PR_NUM — gate passes"
-              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                --method POST \
-                -f state=success \
-                -f context="maintainer-gate" \
-                -f description="No linked issues to check" \
-                2>/dev/null || echo "::warning::Could not post status on PR #$PR_NUM"
-              continue
-            fi
-
-            echo "Checking linked issues for PR #$PR_NUM: $LINKED_ISSUES"
-
-            # Evaluate gate conditions on all linked issues
-            BLOCKED=false
-            DESCRIPTION="All linked issues pass gate checks"
-
-            for ISSUE_NUM in $LINKED_ISSUES; do
-              echo "--- Checking issue #$ISSUE_NUM ---"
-
-              # Fetch raw issue JSON first, then parse — never silence API errors (GH#11063)
-              RAW_ISSUE_DATA=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" 2>&1) || {
-                echo "::error::gh api failed for issue #$ISSUE_NUM: $RAW_ISSUE_DATA"
-                BLOCKED=true
-                DESCRIPTION="Issue #${ISSUE_NUM}: API call failed"
-                continue
-              }
-
-              # Debug: log raw assignees and labels arrays for troubleshooting (opt-in)
-              if [[ "${MAINTAINER_GATE_DEBUG:-false}" == "true" ]]; then
-                echo "DEBUG: Raw assignees for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.assignees[]?.login]')"
-                echo "DEBUG: Raw labels for issue #$ISSUE_NUM: $(echo "$RAW_ISSUE_DATA" | jq -c '[.labels[]?.name]')"
-              fi
-
-              # Parse fields from raw JSON
-              ISSUE_DATA=$(echo "$RAW_ISSUE_DATA" | jq '{labels: [.labels[]?.name], assignees: [.assignees[]?.login], state: .state, user_login: .user.login}') || {
-                echo "::error::jq parsing failed for issue #$ISSUE_NUM"
-                echo "DEBUG: First 500 chars of raw response: ${RAW_ISSUE_DATA:0:500}"
-                BLOCKED=true
-                DESCRIPTION="Issue #${ISSUE_NUM}: Failed to parse API response"
-                continue
-              }
-
-              LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[]' 2>/dev/null || true)
-              ASSIGNEES=$(echo "$ISSUE_DATA" | jq -r '.assignees[]' 2>/dev/null || true)
-              STATE=$(echo "$ISSUE_DATA" | jq -r '.state' 2>/dev/null || echo "unknown")
-              ISSUE_AUTHOR=$(echo "$ISSUE_DATA" | jq -r '.user_login' 2>/dev/null || echo "unknown")
-
-              if [[ "${MAINTAINER_GATE_DEBUG:-false}" == "true" ]]; then
-                echo "DEBUG: Parsed LABELS='$LABELS' ASSIGNEES='$ASSIGNEES' STATE='$STATE' ISSUE_AUTHOR='$ISSUE_AUTHOR'"
-              fi
-
-              # Skip closed issues — they've already been reviewed
-              if [[ "$STATE" == "closed" ]]; then
-                echo "Issue #$ISSUE_NUM is closed — skipping"
-                continue
-              fi
-
-              # Check 1: needs-maintainer-review label
-              if echo "$LABELS" | grep -q 'needs-maintainer-review'; then
-                BLOCKED=true
-                DESCRIPTION="Issue #${ISSUE_NUM} has needs-maintainer-review label"
-                echo "BLOCKED: Issue #$ISSUE_NUM has needs-maintainer-review"
-              fi
-
-              # Check 2: no assignee
-              # Exempt only when BOTH conditions hold (GH#6623, GH#18197):
-              #   a) Issue was created by github-actions[bot]
-              #   b) PR author is OWNER or MEMBER (maintainer-tier only, not COLLABORATOR)
-              if [[ -z "$ASSIGNEES" ]]; then
-                PR_AUTHOR_ASSOC=$(gh pr view "$PR_NUM" --repo "$REPO" \
-                  --json authorAssociation --jq '.authorAssociation' 2>/dev/null || echo "NONE")
-                PR_AUTHOR_IS_MAINTAINER=false
-                if [[ "$PR_AUTHOR_ASSOC" == "OWNER" ]] || \
-                   [[ "$PR_AUTHOR_ASSOC" == "MEMBER" ]]; then
-                  PR_AUTHOR_IS_MAINTAINER=true
-                fi
-
-                if [[ "$ISSUE_AUTHOR" == "github-actions[bot]" ]] && [[ "$PR_AUTHOR_IS_MAINTAINER" == "true" ]]; then
-                  echo "EXEMPT: Issue #$ISSUE_NUM created by github-actions[bot] and PR author is maintainer (OWNER/MEMBER) — assignee check skipped"
-                else
-                  BLOCKED=true
-                  DESCRIPTION="Issue #${ISSUE_NUM} has no assignee"
-                  echo "BLOCKED: Issue #$ISSUE_NUM has no assignee (issue_author=$ISSUE_AUTHOR, pr_author_assoc=$PR_AUTHOR_ASSOC)"
-                fi
-              fi
-          done
-
-            # Post final status
-            if [[ "$BLOCKED" == "true" ]]; then
-              echo "Gate BLOCKED for PR #$PR_NUM: $DESCRIPTION"
-              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                --method POST \
-                -f state=failure \
-                -f context="maintainer-gate" \
-                -f description="$DESCRIPTION" \
-                2>/dev/null || echo "::warning::Could not post failure status on PR #$PR_NUM"
-            else
-              echo "Gate PASSED for PR #$PR_NUM"
-              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                --method POST \
-                -f state=success \
-                -f context="maintainer-gate" \
-                -f description="$DESCRIPTION" \
-                2>/dev/null || echo "::warning::Could not post success status on PR #$PR_NUM"
-            fi
-
             # -----------------------------------------------------------------
-            # t2018: refresh the REQUIRED CheckRun by re-running Job 1.
+            # t2018 + t2037: Trigger Job 1 rerun so it re-evaluates gate
+            # conditions against current issue state. Use full /rerun endpoint
+            # (not /rerun-failed-jobs) to handle both directions:
+            # - Issue loses NMR label / gains assignee: previous run may have
+            #   been SUCCESS — must rerun to produce updated result
+            # - Issue gains NMR label / loses assignee: previous run may have
+            #   been SUCCESS — same requirement
+            # /rerun-failed-jobs would skip re-running a previously-successful
+            # run, leaving stale SUCCESS status when conditions changed.
             #
-            # The `maintainer-gate` status context posted above is NOT the
-            # required check — branch protection requires the CheckRun
-            # "Maintainer Review & Assignee Gate" produced by Job 1's job
-            # name. Job 1 only runs on `pull_request_target` events, so when
-            # an approval happens AFTER the PR is opened the required
-            # CheckRun stays stuck on its stale PR-creation-time failure
-            # until someone manually re-runs the workflow.
-            #
-            # Fix: find the latest completed `check-pr` workflow run for
-            # this PR's HEAD SHA and re-run its failed jobs if its conclusion
-            # was not `success`. The re-run creates a new CheckRun with the
-            # same required name, and branch protection uses the latest one.
-            #
-            # Job 1 is idempotent — it reads issue state via gh api at
-            # runtime rather than caching — so re-running reflects the
-            # post-approval state automatically.
+            # Security: the rerun executes the same pull_request_target event.
+            # Jobs 2-5 are gated on `github.event_name == 'issues'` and are
+            # skipped, so only Job 1 runs in the rerun. No infinite loop risk.
             # -----------------------------------------------------------------
             RUN_LOOKUP=$(gh api \
               "repos/${REPO}/actions/workflows/maintainer-gate.yml/runs?head_sha=${HEAD_SHA}&event=pull_request_target&per_page=1" \
@@ -722,21 +555,19 @@ jobs:
               2>/dev/null || true)
 
             if [[ -z "$RUN_LOOKUP" ]]; then
-              echo "No prior maintainer-gate run found for PR #$PR_NUM at $HEAD_SHA — skipping CheckRun refresh"
+              echo "No prior maintainer-gate run found for PR #$PR_NUM at $HEAD_SHA — pending status posted; will resolve on next PR push"
             else
               RUN_ID=$(printf '%s' "$RUN_LOOKUP" | cut -f1)
-              RUN_CONCLUSION=$(printf '%s' "$RUN_LOOKUP" | cut -f2)
               if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
-                echo "::warning::Could not parse run id from Job 1 lookup for PR #$PR_NUM"
-              elif [[ "$RUN_CONCLUSION" == "success" ]]; then
-                echo "Latest Job 1 run $RUN_ID already succeeded — no refresh needed for PR #$PR_NUM"
+                echo "::warning::Could not parse run id for PR #$PR_NUM — pending status posted"
               else
-                echo "Refreshing required CheckRun: re-running Job 1 (run_id=$RUN_ID, prior=$RUN_CONCLUSION) for PR #$PR_NUM"
+                RUN_CONCLUSION=$(printf '%s' "$RUN_LOOKUP" | cut -f2)
+                echo "Triggering Job 1 rerun (run_id=$RUN_ID, prior=$RUN_CONCLUSION) for PR #$PR_NUM"
                 gh api \
-                  "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs" \
+                  "repos/${REPO}/actions/runs/${RUN_ID}/rerun" \
                   --method POST \
                   2>/dev/null \
-                  || echo "::warning::Failed to re-run Job 1 for PR #$PR_NUM — required CheckRun may remain stale until the next pull_request_target event"
+                  || echo "::warning::Failed to re-run Job 1 for PR #$PR_NUM — pending status remains until next PR push"
               fi
             fi
           done


### PR DESCRIPTION
## Summary

Closes the gate-evaluation duplication between Job 1 and Job 3 in `.github/workflows/maintainer-gate.yml`.

**Problem:** CodeRabbit flagged on PR #18512 that when t2030 added the `origin:interactive` exemption to Job 1, Job 3 was not updated in parallel. Job 3 had ~90 lines of duplicated gate logic that was drifting from Job 1's rules, causing inconsistent gate state when an issue label/assignee change triggered Job 3 vs when a PR open/sync triggered Job 1.

**Fix:** Delete all inline gate evaluation from Job 3. Job 3 becomes pure plumbing:
1. Find linked PRs (unchanged)
2. Post `pending` `maintainer-gate` status `Refreshing via Job 1 rerun...`
3. Trigger Job 1 rerun via `/rerun` endpoint

**Rerun endpoint upgrade:** Changed from `/rerun-failed-jobs` to `/rerun`. The old endpoint skipped re-running when the prior conclusion was `success`, leaving stale SUCCESS status when conditions changed adversely (e.g. issue assignee removed after PR was opened and gate had already passed). The new `/rerun` endpoint always re-runs Job 1 regardless of prior conclusion, handling both directions correctly.

**Security:** The rerun executes the same `pull_request_target` event. Jobs 2–5 are gated on `github.event_name == 'issues'` so only Job 1 runs in the rerun — no infinite loop risk.

## Changes

- `.github/workflows/maintainer-gate.yml`: 198 lines deleted, 29 lines added (net -169 lines)
  - Job 3 header comment updated to document the new pure-plumbing role
  - Job 3 step renamed from `Find linked PRs and re-evaluate gate` to `Find linked PRs and trigger Job 1 rerun`
  - Removed `MAINTAINER_GATE_DEBUG` env var (no longer needed in Job 3)
  - Removed: PR body/labels extraction, `LINKED_ISSUES` resolution, inline gate checks (NMR label, assignee exemption logic), `BLOCKED`/`DESCRIPTION` state, final success/failure status posting
  - Kept: PR discovery (body closing keywords + task-ID reverse lookup), HEAD SHA fetch, pending status post, Job 1 rerun trigger
  - Rerun endpoint: `/rerun-failed-jobs` → `/rerun`
  - Job 1 comment updated to reflect it is now the exclusive source for gate evaluation

## Verification

Future gate-rule changes (new exemptions, new checks) apply in one place (Job 1) only. Confirmed by code diff: zero instances of `BLOCKED`, `LINKED_ISSUES`, `for ISSUE_NUM`, or `ISSUE_DATA` remain in Job 3.

Resolves #18521


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 5m and 18,073 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified maintainer gate workflow to streamline status checks and reruns. Gate status is now determined by the initial check job, with rerun logic triggered only on issue label or assignee changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->