### PR TITLE
GH#18509: fix(deploy): copy restricted agents verbatim instead of permissive stub

### DIFF
--- a/.agents/scripts/audit-agent-deployment.sh
+++ b/.agents/scripts/audit-agent-deployment.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Audit Agent Deployment — frontmatter parity check (GH#18509)
+# =============================================================================
+# Compares deployed OpenCode agent frontmatter against source files for
+# security-sandboxed agents (those with bash: false in their source).
+#
+# Usage:
+#   audit-agent-deployment.sh [--fix] [--agent <name>]
+#
+# Options:
+#   --fix         Re-run generator to fix violations (requires setup.sh access)
+#   --agent <n>   Check only the named agent (e.g. triage-review)
+#
+# Exit codes:
+#   0  All checked agents are correctly deployed
+#   1  One or more violations found (deployed permissions exceed source)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
+
+AGENTS_DIR="${HOME}/.aidevops/agents"
+OPENCODE_AGENT_DIR="${HOME}/.config/opencode/agent"
+CLAUDE_AGENT_DIR="${HOME}/.claude/agents"
+VIOLATIONS=0
+FIX_MODE=0
+FILTER_AGENT=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--fix)
+		FIX_MODE=1
+		shift
+		;;
+	--agent)
+		FILTER_AGENT="$2"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+
+# _has_bash_false <file>
+# Returns 0 (true) if the file has bash: false in its YAML frontmatter.
+_has_bash_false() {
+	local f="$1"
+	local result
+	result=$(awk '
+		/^---$/ { fm_delim++; next }
+		fm_delim == 1 && /bash:[[:space:]]*false/ { print; exit }
+		fm_delim == 2 { exit }
+	' "$f" 2>/dev/null)
+	[[ -n "$result" ]]
+	return $?
+}
+
+# _check_deployed <src_file> <deployed_file> <agent_name>
+# Checks that deployed file does not grant permissions beyond source.
+_check_deployed() {
+	local src="$1"
+	local deployed="$2"
+	local agent_name="$3"
+	local violation=0
+
+	if [[ ! -f "$deployed" ]]; then
+		echo "[MISSING] $agent_name — deployed file not found: $deployed"
+		VIOLATIONS=$((VIOLATIONS + 1))
+		return 1
+	fi
+
+	# Check for banned keys in deployed file
+	if grep -q 'bash: true' "$deployed" 2>/dev/null; then
+		echo "[VIOLATION] $agent_name — deployed has bash:true, source has bash:false"
+		violation=1
+	fi
+
+	if grep -q 'external_directory: allow' "$deployed" 2>/dev/null; then
+		echo "[VIOLATION] $agent_name — deployed has external_directory:allow (not in source)"
+		violation=1
+	fi
+
+	# Check that deployed tool list does not exceed source
+	for tool_key in write edit webfetch task; do
+		local src_val deployed_val
+		src_val=$(awk '
+			/^---$/ { fm_delim++; next }
+			fm_delim == 1 && /'"${tool_key}"':/ { gsub(/.*:[[:space:]]*/, ""); print; exit }
+			fm_delim == 2 { exit }
+		' "$src" 2>/dev/null | tr -d '[:space:]')
+		deployed_val=$(awk '
+			/^---$/ { fm_delim++; next }
+			fm_delim == 1 && /'"${tool_key}"':/ { gsub(/.*:[[:space:]]*/, ""); print; exit }
+			fm_delim == 2 { exit }
+		' "$deployed" 2>/dev/null | tr -d '[:space:]')
+		# If source says false but deployed says true, that's a violation
+		if [[ "$src_val" == "false" && "$deployed_val" == "true" ]]; then
+			echo "[VIOLATION] $agent_name — deployed grants ${tool_key}:true, source has ${tool_key}:false"
+			violation=1
+		fi
+	done
+
+	if [[ "$violation" -eq 0 ]]; then
+		echo "[OK] $agent_name"
+		return 0
+	fi
+
+	VIOLATIONS=$((VIOLATIONS + violation))
+	return 1
+}
+
+echo "=== Agent Deployment Audit (GH#18509) ==="
+echo "Source:    $AGENTS_DIR"
+echo "Deployed:  $OPENCODE_AGENT_DIR"
+echo ""
+
+# Find all source agents with bash: false
+while IFS= read -r src_file; do
+	local_name=$(basename "$src_file" .md)
+
+	# Apply filter if set
+	if [[ -n "$FILTER_AGENT" && "$local_name" != "$FILTER_AGENT" ]]; then
+		continue
+	fi
+
+	deployed_file="${OPENCODE_AGENT_DIR}/${local_name}.md"
+	_check_deployed "$src_file" "$deployed_file" "$local_name" || true
+done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f -not -path "*/loop-state/*" -not -name "*-skill.md" | while IFS= read -r f; do
+	_has_bash_false "$f" && echo "$f"
+done | sort)
+
+echo ""
+if [[ "$VIOLATIONS" -eq 0 ]]; then
+	echo "All restricted agents are correctly deployed."
+	exit 0
+else
+	echo "Found $VIOLATIONS violation(s). Re-run setup.sh (or deploy with generate-runtime-config.sh) to fix."
+	if [[ "$FIX_MODE" -eq 1 ]]; then
+		echo "Running generator to fix violations..."
+		bash "${SCRIPT_DIR}/generate-runtime-config.sh" agents --runtime opencode
+		echo "Re-running audit to verify fix..."
+		VIOLATIONS=0
+		if [[ -n "$FILTER_AGENT" ]]; then
+			exec "$0" --agent "$FILTER_AGENT"
+		else
+			exec "$0"
+		fi
+	fi
+	exit 1
+fi

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -196,6 +196,25 @@ generate_subagent_stub() {
 	*) ;; # No extra tools for other agents
 	esac
 
+	# GH#18509: If source frontmatter explicitly sets bash: false, the agent is
+	# security-sandboxed or has its own tool restrictions. Copy source verbatim
+	# (with model-name normalisation) instead of writing a permissive stub.
+	local src_bash_false
+	src_bash_false=$(awk '
+		/^---$/ { fm_delim++; next }
+		fm_delim == 1 && /bash:[[:space:]]*false/ { print; exit }
+		fm_delim == 2 { exit }
+	' "$f" 2>/dev/null)
+	if [[ -n "$src_bash_false" ]]; then
+		sed \
+			-e 's/^model: opus$/model: anthropic\/claude-opus-4-6/' \
+			-e 's/^model: sonnet$/model: anthropic\/claude-sonnet-4-6/' \
+			-e 's/^model: haiku$/model: anthropic\/claude-haiku-4-5/' \
+			"$f" >"$OPENCODE_AGENT_DIR/$name.md"
+		echo 1
+		return 0
+	fi
+
 	# GH#3601: Use printf to write stub content — avoids unquoted heredoc expansion.
 	# src_desc and rel_path come from filesystem (frontmatter sed extraction / path
 	# stripping) and could contain shell metacharacters that would execute inside

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -256,6 +256,29 @@ _write_subagent_stub() {
 
 	local rel_path="${f#"$AGENTS_DIR"/}"
 
+	# GH#18509: If source frontmatter explicitly sets bash: false, the agent is
+	# security-sandboxed or has its own tool restrictions. Copy source verbatim
+	# (with model-name normalisation) instead of writing a permissive stub that
+	# grants bash:true and external_directory:allow — those would override the
+	# source's intent and become an attack surface for prompt-injected content.
+	local src_bash_false
+	src_bash_false=$(awk '
+		/^---$/ { fm_delim++; next }
+		fm_delim == 1 && /bash:[[:space:]]*false/ { print; exit }
+		fm_delim == 2 { exit }
+	' "$f" 2>/dev/null)
+	if [[ -n "$src_bash_false" ]]; then
+		# Deploy source verbatim, normalising short model aliases to full provider/model IDs
+		# (mirrors the mapping in opencode-agent-discovery.py)
+		sed \
+			-e 's/^model: opus$/model: anthropic\/claude-opus-4-6/' \
+			-e 's/^model: sonnet$/model: anthropic\/claude-sonnet-4-6/' \
+			-e 's/^model: haiku$/model: anthropic\/claude-haiku-4-5/' \
+			"$f" >"$agent_dir/$name.md"
+		echo 1
+		return 0
+	fi
+
 	# Extract description from source file frontmatter
 	local src_desc
 	src_desc=$(sed -n '/^---$/,/^---$/{ /^description:/{s/^description: *//p; q} }' "$f" 2>/dev/null)


### PR DESCRIPTION
## Summary

- Fixes a deployment bug where agent files with `bash: false` in their YAML frontmatter were being deployed as permissive pointer-stubs (`bash: true`, `external_directory: allow`), contradicting the source's security restrictions.
- Modifies `_write_subagent_stub` in `generate-runtime-config.sh` to detect `bash: false` in source frontmatter using awk and copy the source verbatim (with model-name normalisation) instead of generating a permissive stub.
- Same fix applied to the deprecated `generate-opencode-agents.sh` fallback.
- Adds `audit-agent-deployment.sh` to verify deployed agent frontmatter matches source restrictions.

## Verification

```bash
# Deployed triage-review.md now has bash:false and no external_directory:allow
grep -E 'bash:|external_directory' ~/.config/opencode/agent/triage-review.md
# Expected: "  bash: false", no external_directory line

# Audit script passes
~/.aidevops/agents/scripts/audit-agent-deployment.sh --agent triage-review
# Expected: [OK] triage-review

# t2019 tests still pass
bash .agents/scripts/tests/test-triage-output-shape.sh
bash .agents/scripts/tests/test-triage-failure-escalation.sh
```

## Files Changed

- `EDIT: .agents/scripts/generate-runtime-config.sh` — modified `_write_subagent_stub` to detect `bash: false` and deploy verbatim
- `EDIT: .agents/scripts/generate-opencode-agents.sh` — same fix for deprecated fallback
- `NEW: .agents/scripts/audit-agent-deployment.sh` — validation script

Resolves #18509