### PR TITLE
t1992: fix daily quality sweep serialization corrupting multi-line sections

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -1719,6 +1719,7 @@ _sweep_shellcheck() {
 
 	local sc_errors=0
 	local sc_warnings=0
+	local sc_notes=0
 	local sc_details=""
 
 	# timeout_sec (from shared-constants.sh) handles macOS + Linux portably,
@@ -1750,12 +1751,21 @@ _sweep_shellcheck() {
 			timeout_sec 30 shellcheck --norc -f gcc "$shfile" 2>&1 || true
 		)
 		if [[ -n "$result" ]]; then
-			local file_errors
-			file_errors=$(grep -c ':.*: error:' <<<"$result") || file_errors=0
-			local file_warnings
-			file_warnings=$(grep -c ':.*: warning:' <<<"$result") || file_warnings=0
+			# t1992: shellcheck -f gcc emits three severities: error, warning,
+			# note. The previous patterns (':.*: error:' and ':.*: warning:')
+			# matched only error+warning, so SC1091 — the noisiest rule, which
+			# fires `note` for every sourced file when -x is disabled — was
+			# silently counted as zero, leaving the sweep summary to show
+			# "(N files scanned)" with no findings even when several existed.
+			# Pin the regex to the gcc location prefix `<file>:<line>:<col>:`
+			# so we don't accidentally match content inside a finding message.
+			local file_errors file_warnings file_notes
+			file_errors=$(grep -cE ':[0-9]+:[0-9]+: error:' <<<"$result") || file_errors=0
+			file_warnings=$(grep -cE ':[0-9]+:[0-9]+: warning:' <<<"$result") || file_warnings=0
+			file_notes=$(grep -cE ':[0-9]+:[0-9]+: note:' <<<"$result") || file_notes=0
 			sc_errors=$((sc_errors + file_errors))
 			sc_warnings=$((sc_warnings + file_warnings))
+			sc_notes=$((sc_notes + file_notes))
 
 			# Capture first 3 findings per file for the summary
 			local rel_path="${shfile#"$repo_path"/}"
@@ -1776,13 +1786,14 @@ _sweep_shellcheck() {
 
 - **Errors**: ${sc_errors}
 - **Warnings**: ${sc_warnings}
+- **Notes**: ${sc_notes}
 "
 	if [[ -n "$sc_details" ]]; then
 		shellcheck_section="${shellcheck_section}
 **Top findings:**
 ${sc_details}"
 	fi
-	if [[ "$sc_errors" -eq 0 && "$sc_warnings" -eq 0 ]]; then
+	if [[ "$sc_errors" -eq 0 && "$sc_warnings" -eq 0 && "$sc_notes" -eq 0 ]]; then
 		shellcheck_section="${shellcheck_section}
 _All clear — no issues found._
 "
@@ -2327,15 +2338,23 @@ COMMENT
 }
 
 #######################################
-# Run all quality sweep tools for a repo and return results.
+# Run all quality sweep tools for a repo and write results to a sections dir.
+#
+# t1992: Each section is written to its own temp file (one file per variable)
+# so multi-line markdown sections survive the writer/reader round trip.
+# The previous implementation used `printf '%s\n'` + `IFS= read -r` chains,
+# which silently truncated every section after the first line — fragmenting
+# the daily quality-sweep comment.
 #
 # Arguments:
 #   $1 - repo slug
 #   $2 - repo path
-# Output: pipe-delimited
-#   tool_count|shellcheck_section|qlty_section|qlty_smell_count|qlty_grade|
-#   sonar_section|sweep_gate_status|sweep_total_issues|sweep_high_critical|
-#   codacy_section|coderabbit_section|review_scan_section
+# Output (single line on stdout): the absolute path of the sections directory.
+# Files written inside the sections directory (one file per variable):
+#   - tool_count, shellcheck, qlty, qlty_smell_count, qlty_grade
+#   - sonar, sweep_gate_status, sweep_total_issues, sweep_high_critical
+#   - codacy, coderabbit, review_scan
+# The caller is responsible for `rm -rf`ing the directory after consumption.
 #######################################
 _run_sweep_tools() {
 	local repo_slug="$1"
@@ -2387,11 +2406,27 @@ _run_sweep_tools() {
 	review_scan_section=$(_sweep_review_scanner "$repo_slug")
 	[[ -n "$review_scan_section" ]] && tool_count=$((tool_count + 1))
 
-	printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-		"$tool_count" "$shellcheck_section" "$qlty_section" \
-		"$qlty_smell_count" "$qlty_grade" "$sonar_section" \
-		"$sweep_gate_status" "$sweep_total_issues" "$sweep_high_critical" \
-		"$codacy_section" "$coderabbit_section" "$review_scan_section"
+	# t1992: write each section to its own file. printf '%s' (no trailing
+	# newline) preserves byte-for-byte content; multi-line strings round-trip
+	# intact because each file owns exactly one variable.
+	local sections_dir
+	sections_dir=$(mktemp -d 2>/dev/null) || return 1
+	printf '%s' "$tool_count" >"${sections_dir}/tool_count"
+	printf '%s' "$shellcheck_section" >"${sections_dir}/shellcheck"
+	printf '%s' "$qlty_section" >"${sections_dir}/qlty"
+	printf '%s' "$qlty_smell_count" >"${sections_dir}/qlty_smell_count"
+	printf '%s' "$qlty_grade" >"${sections_dir}/qlty_grade"
+	printf '%s' "$sonar_section" >"${sections_dir}/sonar"
+	printf '%s' "$sweep_gate_status" >"${sections_dir}/sweep_gate_status"
+	printf '%s' "$sweep_total_issues" >"${sections_dir}/sweep_total_issues"
+	printf '%s' "$sweep_high_critical" >"${sections_dir}/sweep_high_critical"
+	printf '%s' "$codacy_section" >"${sections_dir}/codacy"
+	printf '%s' "$coderabbit_section" >"${sections_dir}/coderabbit"
+	printf '%s' "$review_scan_section" >"${sections_dir}/review_scan"
+
+	# Single-line handshake: just the directory path. The caller reads each
+	# section by `cat`ing one file at a time.
+	printf '%s\n' "$sections_dir"
 	return 0
 }
 
@@ -2405,29 +2440,33 @@ _quality_sweep_for_repo() {
 	local now_iso
 	now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-	# Run all tools and read results via temp file
-	local tools_tmp
-	tools_tmp=$(mktemp)
-	_run_sweep_tools "$repo_slug" "$repo_path" >"$tools_tmp"
+	# t1992: read each section back from its own file. The previous code
+	# used `IFS= read -r` chains which only handled single-line values and
+	# silently truncated every multi-line markdown section.
+	local sections_dir
+	sections_dir=$(_run_sweep_tools "$repo_slug" "$repo_path")
+	if [[ -z "$sections_dir" || ! -d "$sections_dir" ]]; then
+		echo "[stats] Quality sweep: _run_sweep_tools produced no sections dir for ${repo_slug}" >>"$LOGFILE"
+		[[ -n "$sections_dir" && -e "$sections_dir" ]] && rm -rf "$sections_dir"
+		return 0
+	fi
 
 	local tool_count shellcheck_section qlty_section qlty_smell_count qlty_grade
 	local sonar_section sweep_gate_status sweep_total_issues sweep_high_critical
 	local codacy_section coderabbit_section review_scan_section
-	{
-		IFS= read -r tool_count
-		IFS= read -r shellcheck_section
-		IFS= read -r qlty_section
-		IFS= read -r qlty_smell_count
-		IFS= read -r qlty_grade
-		IFS= read -r sonar_section
-		IFS= read -r sweep_gate_status
-		IFS= read -r sweep_total_issues
-		IFS= read -r sweep_high_critical
-		IFS= read -r codacy_section
-		IFS= read -r coderabbit_section
-		IFS= read -r review_scan_section
-	} <"$tools_tmp"
-	rm -f "$tools_tmp"
+	tool_count=$(cat "${sections_dir}/tool_count" 2>/dev/null || echo 0)
+	shellcheck_section=$(cat "${sections_dir}/shellcheck" 2>/dev/null || echo "")
+	qlty_section=$(cat "${sections_dir}/qlty" 2>/dev/null || echo "")
+	qlty_smell_count=$(cat "${sections_dir}/qlty_smell_count" 2>/dev/null || echo 0)
+	qlty_grade=$(cat "${sections_dir}/qlty_grade" 2>/dev/null || echo UNKNOWN)
+	sonar_section=$(cat "${sections_dir}/sonar" 2>/dev/null || echo "")
+	sweep_gate_status=$(cat "${sections_dir}/sweep_gate_status" 2>/dev/null || echo UNKNOWN)
+	sweep_total_issues=$(cat "${sections_dir}/sweep_total_issues" 2>/dev/null || echo 0)
+	sweep_high_critical=$(cat "${sections_dir}/sweep_high_critical" 2>/dev/null || echo 0)
+	codacy_section=$(cat "${sections_dir}/codacy" 2>/dev/null || echo "")
+	coderabbit_section=$(cat "${sections_dir}/coderabbit" 2>/dev/null || echo "")
+	review_scan_section=$(cat "${sections_dir}/review_scan" 2>/dev/null || echo "")
+	rm -rf "$sections_dir"
 
 	if [[ "${tool_count:-0}" -eq 0 ]]; then
 		echo "[stats] Quality sweep: no tools available for ${repo_slug}" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-quality-sweep-serialization.sh
+++ b/.agents/scripts/tests/test-quality-sweep-serialization.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t1992: Regression test for the daily quality sweep serialization.
+#
+# The original implementation of `_run_sweep_tools` / `_quality_sweep_for_repo`
+# wrote 12 fields with `printf '%s\n'` and read them back with `IFS= read -r`.
+# That pattern only worked for single-line values; every multi-line section
+# (ShellCheck, Qlty, SonarCloud, Codacy, CodeRabbit, review_scan) was
+# truncated to its first line, with the remainder leaking into the next
+# variable.
+#
+# This test stubs the per-tool `_sweep_*` functions to return known multi-line
+# fixtures and then asserts that each section round-trips byte-for-byte
+# through `_run_sweep_tools` (writer) into the caller (reader).
+#
+# Run:
+#   bash .agents/scripts/tests/test-quality-sweep-serialization.sh
+#
+# shellcheck disable=SC1090,SC1091
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+
+# Isolate from real state files
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export LOGFILE="${TMP_HOME}/test.log"
+export QUALITY_SWEEP_STATE_DIR="${TMP_HOME}/state"
+mkdir -p "$QUALITY_SWEEP_STATE_DIR"
+
+# Source dependencies. stats-functions.sh expects shared-constants and
+# worker-lifecycle-common to be sourced first.
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/stats-functions.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		echo "PASS $name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $name"
+		[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# --- Fixtures ---
+# Every section uses multi-line markdown with embedded newlines, which the
+# original `IFS= read -r` chain truncated to the first line.
+
+FIXTURE_SHELLCHECK="### ShellCheck (3 files scanned)
+
+- **Errors**: 1
+- **Warnings**: 2
+- **Notes**: 4
+
+**Top findings:**
+  - \`a.sh\`: SC1009 missing fi
+  - \`b.sh\`: SC2086 quote vars
+  - \`c.sh\`: SC1091 sourced file not specified"
+
+FIXTURE_QLTY="### Qlty Maintainability
+
+- **Total smells**: 42
+- **By rule**:
+  - file-complexity: 12
+  - function-complexity: 9
+  - duplicate-blocks: 7
+  - file-length: 5
+  - return-statements: 4
+  - identical-blocks: 2
+  - similar-blocks: 2
+  - parameter-count: 1
+- **Top files (highest smell density)**:
+  - \`scripts/big.sh\`: 18 smells
+  - \`scripts/medium.sh\`: 9 smells
+- **Qlty Cloud grade**: B
+"
+
+FIXTURE_SONAR="### SonarCloud
+
+- **Quality gate**: ERROR
+- **Total issues**: 224
+- **High/critical**: 12
+
+**Top rules:**
+  - shelldre:S1481: 161
+  - shelldre:S1066: 63"
+
+FIXTURE_CODACY="### Codacy
+
+- **Issues**: 17
+
+**By severity:**
+  - error: 2
+  - warning: 8
+  - info: 7"
+
+# Empty section — common case when CodeRabbit posts no findings.
+FIXTURE_CODERABBIT=""
+
+# Last field, no trailing newline. Tests that the final section is not
+# truncated by the reader.
+FIXTURE_REVIEW_SCAN="### Review Scanner
+
+- **Open suggestions**: 5
+  - \`pr#100\`: refactor X
+  - \`pr#101\`: handle null in Y
+  - \`pr#102\`: missing error path"
+
+# --- Stubs ---
+# Override the per-tool sweep functions after sourcing. Bash lets you
+# redefine a function by name; the new body wins at call time.
+
+_sweep_shellcheck() {
+	printf '%s' "$FIXTURE_SHELLCHECK"
+	return 0
+}
+
+_sweep_qlty() {
+	# Original signature: stdout = "section|smell_count|grade"
+	printf '%s|%s|%s' "$FIXTURE_QLTY" "42" "B"
+	return 0
+}
+
+_sweep_sonarcloud() {
+	# Original signature: stdout = "section|gate|total|high"
+	printf '%s|%s|%s|%s' "$FIXTURE_SONAR" "ERROR" "224" "12"
+	return 0
+}
+
+_sweep_codacy() {
+	printf '%s' "$FIXTURE_CODACY"
+	return 0
+}
+
+_sweep_coderabbit() {
+	printf '%s' "$FIXTURE_CODERABBIT"
+	return 0
+}
+
+_sweep_review_scanner() {
+	printf '%s' "$FIXTURE_REVIEW_SCAN"
+	return 0
+}
+
+# Stub side-effects so the test stays hermetic.
+_save_sweep_state() {
+	return 0
+}
+
+_create_simplification_issues() {
+	return 0
+}
+
+# --- Helpers ---
+
+assert_file_eq() {
+	local label="$1"
+	local file="$2"
+	local expected="$3"
+	if [[ ! -f "$file" ]]; then
+		print_result "$label" 1 "missing file: $file"
+		return 0
+	fi
+	# Use cmp against a temp file so trailing newlines are NOT stripped by
+	# command substitution (which would mask the very bug we are guarding
+	# against). `$(cat file)` would silently lose the trailing \n.
+	local expected_tmp
+	expected_tmp=$(mktemp)
+	printf '%s' "$expected" >"$expected_tmp"
+	if cmp -s "$file" "$expected_tmp"; then
+		print_result "$label" 0
+		rm -f "$expected_tmp"
+	else
+		local actual_dump
+		actual_dump=$(od -c "$file" | head -20)
+		print_result "$label" 1 "$(printf 'cmp diff: %s vs %s\n%s' "$file" "$expected_tmp" "$actual_dump")"
+		rm -f "$expected_tmp"
+	fi
+	return 0
+}
+
+# --- Run the writer ---
+
+SECTIONS_DIR=$(_run_sweep_tools "owner/repo" "/tmp/fake-repo")
+
+if [[ -z "$SECTIONS_DIR" || ! -d "$SECTIONS_DIR" ]]; then
+	print_result "_run_sweep_tools returns sections dir" 1 "got: $SECTIONS_DIR"
+	echo "Tests run: $TESTS_RUN passed: $TESTS_PASSED failed: $TESTS_FAILED"
+	exit 1
+fi
+print_result "_run_sweep_tools returns sections dir" 0
+
+# --- Assertions ---
+
+# 1. Multi-line shellcheck section round-trips byte-for-byte.
+assert_file_eq "shellcheck section round-trips multi-line content" \
+	"${SECTIONS_DIR}/shellcheck" "$FIXTURE_SHELLCHECK"
+
+# 2. Multi-line qlty section round-trips byte-for-byte.
+assert_file_eq "qlty section round-trips 13-line content" \
+	"${SECTIONS_DIR}/qlty" "$FIXTURE_QLTY"
+
+# 3. Multi-line sonar section round-trips and adjacent integer metadata
+#    is read independently from the right files.
+assert_file_eq "sonar section round-trips multi-line content" \
+	"${SECTIONS_DIR}/sonar" "$FIXTURE_SONAR"
+assert_file_eq "sweep_gate_status read independently of sonar_section" \
+	"${SECTIONS_DIR}/sweep_gate_status" "ERROR"
+assert_file_eq "sweep_total_issues read independently of sonar_section" \
+	"${SECTIONS_DIR}/sweep_total_issues" "224"
+assert_file_eq "sweep_high_critical read independently of sonar_section" \
+	"${SECTIONS_DIR}/sweep_high_critical" "12"
+
+# 4. Empty coderabbit section round-trips as empty string.
+assert_file_eq "coderabbit section survives empty payload" \
+	"${SECTIONS_DIR}/coderabbit" "$FIXTURE_CODERABBIT"
+
+# 5. Last field (review_scan) survives even when previous section has no
+#    trailing newline. This was the worst regression in the original
+#    `IFS= read -r` chain — the last field commonly came back empty or
+#    contained the tail of a previous section.
+assert_file_eq "review_scan section survives as last field" \
+	"${SECTIONS_DIR}/review_scan" "$FIXTURE_REVIEW_SCAN"
+
+# 6. tool_count and qlty metadata survive too (sanity check on numeric fields).
+assert_file_eq "tool_count is captured (5 tools succeeded + coderabbit always-on)" \
+	"${SECTIONS_DIR}/tool_count" "6"
+assert_file_eq "qlty_smell_count read independently of qlty_section" \
+	"${SECTIONS_DIR}/qlty_smell_count" "42"
+assert_file_eq "qlty_grade read independently of qlty_section" \
+	"${SECTIONS_DIR}/qlty_grade" "B"
+
+# 7. _quality_sweep_for_repo end-to-end smoke test: stub _ensure_quality_issue
+#    and gh so it doesn't hit the network, then verify the full pipeline reads
+#    every section back into a local variable. The gh wrapper writes the
+#    captured --body to a file because the real call site uses
+#    `comment_stderr=$(gh ... --body "$comment_body" ...)` which runs in a
+#    subshell — variable assignments inside it would not propagate back.
+export CAPTURED_COMMENT_FILE="${TMP_HOME}/captured-comment"
+: >"$CAPTURED_COMMENT_FILE"
+
+_ensure_quality_issue() {
+	echo "9999"
+	return 0
+}
+_update_quality_issue_body() {
+	return 0
+}
+gh() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--body)
+			printf '%s' "$2" >"$CAPTURED_COMMENT_FILE"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+	return 0
+}
+
+rm -rf "$SECTIONS_DIR"
+_quality_sweep_for_repo "owner/repo" "/tmp/fake-repo"
+CAPTURED_COMMENT=$(cat "$CAPTURED_COMMENT_FILE")
+
+if [[ "$CAPTURED_COMMENT" == *"$FIXTURE_SHELLCHECK"* ]]; then
+	print_result "end-to-end: posted comment contains full shellcheck section" 0
+else
+	print_result "end-to-end: posted comment contains full shellcheck section" 1 "comment was: $CAPTURED_COMMENT"
+fi
+
+if [[ "$CAPTURED_COMMENT" == *"$FIXTURE_QLTY"* ]]; then
+	print_result "end-to-end: posted comment contains full qlty section" 0
+else
+	print_result "end-to-end: posted comment contains full qlty section" 1
+fi
+
+if [[ "$CAPTURED_COMMENT" == *"$FIXTURE_SONAR"* ]]; then
+	print_result "end-to-end: posted comment contains full sonar section" 0
+else
+	print_result "end-to-end: posted comment contains full sonar section" 1
+fi
+
+if [[ "$CAPTURED_COMMENT" == *"$FIXTURE_CODACY"* ]]; then
+	print_result "end-to-end: posted comment contains full codacy section" 0
+else
+	print_result "end-to-end: posted comment contains full codacy section" 1
+fi
+
+if [[ "$CAPTURED_COMMENT" == *"$FIXTURE_REVIEW_SCAN"* ]]; then
+	print_result "end-to-end: posted comment contains full review_scan section" 0
+else
+	print_result "end-to-end: posted comment contains full review_scan section" 1
+fi
+
+# Cleanup
+rm -rf "$TMP_HOME"
+
+echo
+echo "Tests run: $TESTS_RUN passed: $TESTS_PASSED failed: $TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Switch _run_sweep_tools / _quality_sweep_for_repo from a printf+IFS=read pipeline to a one-temp-file-per-section handshake so multi-line markdown sections (ShellCheck, Qlty, SonarCloud, Codacy, CodeRabbit, review_scan) round-trip byte-for-byte. Also fix _sweep_shellcheck severity counters to count gcc-format 'note:' lines (SC1091 was the silent majority) and surface them in the rendered section. Adds .agents/scripts/tests/test-quality-sweep-serialization.sh with 17 assertions covering writer round-trip, integer fields adjacent to multi-line sections, empty payloads, and the last-field edge case.

## Files Changed

.agents/scripts/stats-functions.sh,.agents/scripts/tests/test-quality-sweep-serialization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on stats-functions.sh and the new test; bash test-quality-sweep-serialization.sh -> 17/17 pass; bash test-pulse-wrapper-characterization.sh -> 26/26 pass.

Resolves #18418


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 6m and 20,385 tokens on this as a headless worker.